### PR TITLE
cavs: platform: clear memory windows

### DIFF
--- a/src/platform/apollolake/platform.c
+++ b/src/platform/apollolake/platform.c
@@ -167,21 +167,31 @@ static void platform_memory_windows_init(void)
 	io_reg_write(DMWLO(0), HP_SRAM_WIN0_SIZE | 0x7);
 	io_reg_write(DMWBA(0), HP_SRAM_WIN0_BASE
 		| DMWBA_READONLY | DMWBA_ENABLE);
+	bzero((void *)(HP_SRAM_WIN0_BASE + SRAM_REG_FW_END),
+	      HP_SRAM_WIN0_SIZE - SRAM_REG_FW_END);
+	dcache_writeback_region((void *)(HP_SRAM_WIN0_BASE + SRAM_REG_FW_END),
+				HP_SRAM_WIN0_SIZE - SRAM_REG_FW_END);
 
 	/* window1, for inbox/downlink mbox */
 	io_reg_write(DMWLO(1), HP_SRAM_WIN1_SIZE | 0x7);
 	io_reg_write(DMWBA(1), HP_SRAM_WIN1_BASE
 		| DMWBA_ENABLE);
+	bzero((void *)HP_SRAM_WIN1_BASE, HP_SRAM_WIN1_SIZE);
+	dcache_writeback_region((void *)HP_SRAM_WIN1_BASE, HP_SRAM_WIN1_SIZE);
 
 	/* window2, for debug */
 	io_reg_write(DMWLO(2), HP_SRAM_WIN2_SIZE | 0x7);
 	io_reg_write(DMWBA(2), HP_SRAM_WIN2_BASE
 		| DMWBA_READONLY | DMWBA_ENABLE);
+	bzero((void *)HP_SRAM_WIN2_BASE, HP_SRAM_WIN2_SIZE);
+	dcache_writeback_region((void *)HP_SRAM_WIN2_BASE, HP_SRAM_WIN2_SIZE);
 
 	/* window3, for trace */
 	io_reg_write(DMWLO(3), HP_SRAM_WIN3_SIZE | 0x7);
 	io_reg_write(DMWBA(3), HP_SRAM_WIN3_BASE
 		| DMWBA_READONLY | DMWBA_ENABLE);
+	bzero((void *)HP_SRAM_WIN3_BASE, HP_SRAM_WIN3_SIZE);
+	dcache_writeback_region((void *)HP_SRAM_WIN3_BASE, HP_SRAM_WIN3_SIZE);
 }
 
 int platform_init(struct sof *sof)

--- a/src/platform/cannonlake/platform.c
+++ b/src/platform/cannonlake/platform.c
@@ -166,21 +166,31 @@ static void platform_memory_windows_init(void)
 	io_reg_write(DMWLO(0), HP_SRAM_WIN0_SIZE | 0x7);
 	io_reg_write(DMWBA(0), HP_SRAM_WIN0_BASE
 		| DMWBA_READONLY | DMWBA_ENABLE);
+	bzero((void *)(HP_SRAM_WIN0_BASE + SRAM_REG_FW_END),
+	      HP_SRAM_WIN0_SIZE - SRAM_REG_FW_END);
+	dcache_writeback_region((void *)(HP_SRAM_WIN0_BASE + SRAM_REG_FW_END),
+				HP_SRAM_WIN0_SIZE - SRAM_REG_FW_END);
 
 	/* window1, for inbox/downlink mbox */
 	io_reg_write(DMWLO(1), HP_SRAM_WIN1_SIZE | 0x7);
 	io_reg_write(DMWBA(1), HP_SRAM_WIN1_BASE
 		| DMWBA_ENABLE);
+	bzero((void *)HP_SRAM_WIN1_BASE, HP_SRAM_WIN1_SIZE);
+	dcache_writeback_region((void *)HP_SRAM_WIN1_BASE, HP_SRAM_WIN1_SIZE);
 
 	/* window2, for debug */
 	io_reg_write(DMWLO(2), HP_SRAM_WIN2_SIZE | 0x7);
 	io_reg_write(DMWBA(2), HP_SRAM_WIN2_BASE
 		| DMWBA_READONLY | DMWBA_ENABLE);
+	bzero((void *)HP_SRAM_WIN2_BASE, HP_SRAM_WIN2_SIZE);
+	dcache_writeback_region((void *)HP_SRAM_WIN2_BASE, HP_SRAM_WIN2_SIZE);
 
 	/* window3, for trace */
 	io_reg_write(DMWLO(3), HP_SRAM_WIN3_SIZE | 0x7);
 	io_reg_write(DMWBA(3), HP_SRAM_WIN3_BASE
 		| DMWBA_READONLY | DMWBA_ENABLE);
+	bzero((void *)HP_SRAM_WIN3_BASE, HP_SRAM_WIN3_SIZE);
+	dcache_writeback_region((void *)HP_SRAM_WIN3_BASE, HP_SRAM_WIN3_SIZE);
 }
 
 /* init HW  */


### PR DESCRIPTION
Clear memory windows after initialization on APL and CNL.
They were recently moved to the beginning of HPSRAM and since
that area is also used by ROM, there was some unneeded data left.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>