### PR TITLE
cavs: pm_runtime: scale down host dma l1 exit times

### DIFF
--- a/src/platform/apollolake/include/platform/platform.h
+++ b/src/platform/apollolake/include/platform/platform.h
@@ -119,7 +119,7 @@ struct sof;
 #define PLATFORM_DEFAULT_DELAY	12
 
 /* minimal L1 exit time in cycles */
-#define PLATFORM_FORCE_L1_EXIT_TIME	12288
+#define PLATFORM_FORCE_L1_EXIT_TIME	585
 
 /* Platform defined panic code */
 static inline void platform_panic(uint32_t p)

--- a/src/platform/cannonlake/include/platform/platform.h
+++ b/src/platform/cannonlake/include/platform/platform.h
@@ -116,7 +116,7 @@ struct sof;
 #define PLATFORM_DEFAULT_DELAY	12
 
 /* minimal L1 exit time in cycles */
-#define PLATFORM_FORCE_L1_EXIT_TIME	8192
+#define PLATFORM_FORCE_L1_EXIT_TIME	482
 
 /* Platform defined trace code */
 static inline void platform_panic(uint32_t p)


### PR DESCRIPTION
Scales down host dma l1 exit times, since they were defined
for Fast RING clock, but implementation uses XTAL based timer.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>