### PR TITLE
core: fix wrong inclusion of core-isa.h

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,7 +1,7 @@
 export COMMON_INCDIR = \
+	$(PLATFORM_INCDIR) \
 	$(SOF_INCDIR) \
-	$(ARCH_INCDIR) \
-	$(PLATFORM_INCDIR)
+	$(ARCH_INCDIR)
 
 if BUILD_LIB
 SUBDIRS = ipc math audio arch include library host

--- a/src/arch/xtensa/Makefile.am
+++ b/src/arch/xtensa/Makefile.am
@@ -50,8 +50,8 @@ endif
 sof_CFLAGS = \
 	$(ARCH_INCDIR) \
 	$(ARCH_CFLAGS) \
-	$(SOF_INCDIR) \
-	$(PLATFORM_INCDIR)
+	$(PLATFORM_INCDIR) \
+	$(SOF_INCDIR)
 
 sof_CCASFLAGS = \
 	$(ARCH_INCDIR) \
@@ -111,8 +111,8 @@ boot_ldr_SOURCES = \
 boot_ldr_CFLAGS = \
 	$(ARCH_INCDIR) \
 	$(ARCH_CFLAGS) \
-	$(SOF_INCDIR) \
-	$(PLATFORM_INCDIR)
+	$(PLATFORM_INCDIR) \
+	$(SOF_INCDIR)
 
 boot_ldr_CCASFLAGS = \
 	$(ARCH_INCDIR) \

--- a/src/drivers/Makefile.am
+++ b/src/drivers/Makefile.am
@@ -39,6 +39,6 @@ endif
 
 libdrivers_a_CFLAGS = \
 	$(ARCH_CFLAGS) \
+	$(PLATFORM_INCDIR) \
 	$(SOF_INCDIR) \
-	$(ARCH_INCDIR) \
-	$(PLATFORM_INCDIR)
+	$(ARCH_INCDIR)

--- a/src/init/Makefile.am
+++ b/src/init/Makefile.am
@@ -6,5 +6,5 @@ libinit_a_SOURCES = \
 libinit_a_CFLAGS = \
 	$(ARCH_CFLAGS) \
 	$(ARCH_INCDIR) \
-	$(SOF_INCDIR) \
-	$(PLATFORM_INCDIR)
+	$(PLATFORM_INCDIR) \
+	$(SOF_INCDIR)

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -15,8 +15,8 @@ libcore_a_SOURCES = \
 libcore_a_CFLAGS = \
 	$(ARCH_CFLAGS) \
 	$(ARCH_INCDIR) \
-	$(SOF_INCDIR) \
-	$(PLATFORM_INCDIR)
+	$(PLATFORM_INCDIR) \
+	$(SOF_INCDIR)
 
 libdma_a_SOURCES = \
 	dma.c
@@ -24,5 +24,5 @@ libdma_a_SOURCES = \
 libdma_a_CFLAGS = \
 	$(ARCH_CFLAGS) \
 	$(ARCH_INCDIR) \
-	$(SOF_INCDIR) \
-	$(PLATFORM_INCDIR)
+	$(PLATFORM_INCDIR) \
+	$(SOF_INCDIR)

--- a/src/platform/apollolake/Makefile.am
+++ b/src/platform/apollolake/Makefile.am
@@ -19,8 +19,8 @@ libplatform_a_SOURCES = \
 libplatform_a_CFLAGS = \
 	$(ARCH_CFLAGS) \
 	$(ARCH_INCDIR) \
-	$(SOF_INCDIR) \
-	$(PLATFORM_INCDIR)
+	$(PLATFORM_INCDIR) \
+	$(SOF_INCDIR)
 
 noinst_PROGRAMS = module boot_module
 
@@ -29,13 +29,13 @@ module_SOURCES = \
 
 module_CFLAGS = \
 	$(ARCH_INCDIR) \
-	$(SOF_INCDIR) \
-	$(PLATFORM_INCDIR)
+	$(PLATFORM_INCDIR) \
+	$(SOF_INCDIR)
 
 boot_module_SOURCES = \
 	boot_module.c
 
 boot_module_CFLAGS = \
 	$(ARCH_INCDIR) \
-	$(SOF_INCDIR) \
-	$(PLATFORM_INCDIR)
+	$(PLATFORM_INCDIR) \
+	$(SOF_INCDIR)

--- a/src/platform/baytrail/Makefile.am
+++ b/src/platform/baytrail/Makefile.am
@@ -15,5 +15,5 @@ libplatform_a_SOURCES = \
 libplatform_a_CFLAGS = \
 	$(ARCH_CFLAGS) \
 	$(ARCH_INCDIR) \
-	$(SOF_INCDIR) \
-	$(PLATFORM_INCDIR)
+	$(PLATFORM_INCDIR) \
+	$(SOF_INCDIR)

--- a/src/platform/cannonlake/Makefile.am
+++ b/src/platform/cannonlake/Makefile.am
@@ -19,8 +19,8 @@ libplatform_a_SOURCES = \
 libplatform_a_CFLAGS = \
 	$(ARCH_CFLAGS) \
 	$(ARCH_INCDIR) \
-	$(SOF_INCDIR) \
-	$(PLATFORM_INCDIR)
+	$(PLATFORM_INCDIR) \
+	$(SOF_INCDIR)
 
 noinst_PROGRAMS = module boot_module
 
@@ -29,13 +29,13 @@ module_SOURCES = \
 
 module_CFLAGS = \
 	$(ARCH_INCDIR) \
-	$(SOF_INCDIR) \
-	$(PLATFORM_INCDIR)
+	$(PLATFORM_INCDIR) \
+	$(SOF_INCDIR)
 
 boot_module_SOURCES = \
 	boot_module.c
 
 boot_module_CFLAGS = \
 	$(ARCH_INCDIR) \
-	$(SOF_INCDIR) \
-	$(PLATFORM_INCDIR)
+	$(PLATFORM_INCDIR) \
+	$(SOF_INCDIR)

--- a/src/platform/haswell/Makefile.am
+++ b/src/platform/haswell/Makefile.am
@@ -15,5 +15,5 @@ libplatform_a_SOURCES = \
 libplatform_a_CFLAGS = \
 	$(ARCH_CFLAGS) \
 	$(ARCH_INCDIR) \
-	$(SOF_INCDIR) \
-	$(PLATFORM_INCDIR)
+	$(PLATFORM_INCDIR) \
+	$(SOF_INCDIR)

--- a/src/tasks/Makefile.am
+++ b/src/tasks/Makefile.am
@@ -6,5 +6,5 @@ libtasks_a_SOURCES = \
 libtasks_a_CFLAGS = \
 	$(ARCH_CFLAGS) \
 	$(ARCH_INCDIR) \
-	$(SOF_INCDIR) \
-	$(PLATFORM_INCDIR)
+	$(PLATFORM_INCDIR) \
+	$(SOF_INCDIR)


### PR DESCRIPTION
Moves inclusion of PLATFORM_INCDIR before SOF_INCDIR.
This temporarily fixes wrong inclusion of core-isa.h from
xtensa-root directory during build with gcc. It's the best
solution for now, because that unwanted header comes from
Xtensa Newlib C library, which will take much more time to change.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>