### PR TITLE
RFC fix for the APL noise regression

### DIFF
--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -124,7 +124,7 @@ static void dai_dma_cb(void *data, uint32_t type, struct dma_sg_elem *next)
 		comp_update_buffer_consume(dma_buffer, copied_size);
 
 		/* writeback buffer contents from cache */
-		dcache_writeback_region(dma_buffer->r_ptr, copied_size);
+		//dcache_writeback_region(dma_buffer->r_ptr, copied_size);
 
 		/* update host position(in bytes offset) for drivers */
 		dev->position += copied_size;

--- a/src/audio/volume.c
+++ b/src/audio/volume.c
@@ -448,7 +448,9 @@ static int volume_copy(struct comp_dev *dev)
 	cd->scale_vol(dev, sink, source);
 
 	/* calc new free and available */
+	dcache_writeback_region(sink->w_ptr, cd->sink_period_bytes);
 	comp_update_buffer_produce(sink, cd->sink_period_bytes);
+
 	comp_update_buffer_consume(source, cd->source_period_bytes);
 
 	return dev->frames;


### PR DESCRIPTION
Find a noise regression only with the  volume pipeline topology: test-ssp5-I2S-volume-s16le-s16le-48k-24576k-nocodec.tplg
But with pass-through topology: test-ssp5-I2S-passthrough-s16le-s16le-48k-24576k-nocodec.tplg the noise is gone. Bisect the regressiong happen to 80f3d47215c6

The bug is may be related to the L2 cache disable and may have different cache behavior.

This RFC WORKAROUND move dcache into the volume comp where the data is crated and need write to
memory. The DAI callback function did a predicate dchace that may cause problem.


