### PR TITLE
DMA-Trace: fix dma-trace overflow issue

### DIFF
--- a/src/include/sof/pm_runtime.h
+++ b/src/include/sof/pm_runtime.h
@@ -41,10 +41,11 @@
 #include <sof/trace.h>
 
 /** \brief Power management trace function. */
-#define trace_pm(__e)	trace_event_atomic(TRACE_CLASS_POWER, __e)
+#define trace_pm(__e)	trace_event(TRACE_CLASS_POWER, __e)
+#define tracev_pm(__e)	tracev_event(TRACE_CLASS_POWER, __e)
 
 /** \brief Power management trace value function. */
-#define trace_pm_value(__e)	trace_value_atomic(__e)
+#define tracev_pm_value(__e)	tracev_value(__e)
 
 /** \brief Runtime power management context */
 enum pm_runtime_context {

--- a/src/lib/pm_runtime.c
+++ b/src/lib/pm_runtime.c
@@ -53,7 +53,7 @@ void pm_runtime_init(void)
 
 void pm_runtime_get(enum pm_runtime_context context)
 {
-	trace_pm("get");
+	tracev_pm("get");
 
 	switch (context) {
 	default:
@@ -64,7 +64,7 @@ void pm_runtime_get(enum pm_runtime_context context)
 
 void pm_runtime_put(enum pm_runtime_context context)
 {
-	trace_pm("put");
+	tracev_pm("put");
 
 	switch (context) {
 	default:


### PR DESCRIPTION
Refine dtrace_event_atomic according to dtrace_event

Signed-off-by: Rander Wang <rander.wang@linux.intel.com>