### PR TITLE
interrupt: use core id from interrupt value

### DIFF
--- a/src/platform/apollolake/interrupt.c
+++ b/src/platform/apollolake/interrupt.c
@@ -137,7 +137,7 @@ static struct irq_desc dsp_irq[PLATFORM_CORE_COUNT][4] = {
 
 struct irq_desc *platform_irq_get_parent(uint32_t irq)
 {
-	int core = cpu_get_id();
+	int core = SOF_IRQ_CPU(irq);
 
 	switch (SOF_IRQ_NUMBER(irq)) {
 	case IRQ_NUM_EXT_LEVEL2:
@@ -160,7 +160,7 @@ uint32_t platform_interrupt_get_enabled(void)
 
 void platform_interrupt_mask(uint32_t irq, uint32_t mask)
 {
-	int core = cpu_get_id();
+	int core = SOF_IRQ_CPU(irq);
 
 	/* mask external interrupt bit */
 	switch (SOF_IRQ_NUMBER(irq)) {
@@ -184,7 +184,7 @@ void platform_interrupt_mask(uint32_t irq, uint32_t mask)
 
 void platform_interrupt_unmask(uint32_t irq, uint32_t mask)
 {
-	int core = cpu_get_id();
+	int core = SOF_IRQ_CPU(irq);
 
 	/* unmask external interrupt bit */
 	switch (SOF_IRQ_NUMBER(irq)) {

--- a/src/platform/cannonlake/interrupt.c
+++ b/src/platform/cannonlake/interrupt.c
@@ -147,7 +147,7 @@ static struct irq_desc dsp_irq[PLATFORM_CORE_COUNT][4] = {
 
 struct irq_desc *platform_irq_get_parent(uint32_t irq)
 {
-	int core = cpu_get_id();
+	int core = SOF_IRQ_CPU(irq);
 
 	switch (SOF_IRQ_NUMBER(irq)) {
 	case IRQ_NUM_EXT_LEVEL2:
@@ -170,7 +170,7 @@ uint32_t platform_interrupt_get_enabled(void)
 
 void platform_interrupt_mask(uint32_t irq, uint32_t mask)
 {
-	int core = cpu_get_id();
+	int core = SOF_IRQ_CPU(irq);
 
 	/* mask external interrupt bit */
 	switch (SOF_IRQ_NUMBER(irq)) {
@@ -194,7 +194,7 @@ void platform_interrupt_mask(uint32_t irq, uint32_t mask)
 
 void platform_interrupt_unmask(uint32_t irq, uint32_t mask)
 {
-	int core = cpu_get_id();
+	int core = SOF_IRQ_CPU(irq);
 
 	/* unmask external interrupt bit */
 	switch (SOF_IRQ_NUMBER(irq)) {


### PR DESCRIPTION
Use core id from interrupt value instead of own core id.
This allows to enable interrupts for slave cores.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>