### PR TITLE
apl must support 8-channel, if not, the capture can not work on this platform.

### DIFF
--- a/src/platform/apollolake/include/platform/platform.h
+++ b/src/platform/apollolake/include/platform/platform.h
@@ -64,7 +64,7 @@ struct sof;
 #define PLATFORM_HOST_DMA_MASK	0x00000000
 
 /* Platform stream capabilities */
-#define PLATFORM_MAX_CHANNELS	4
+#define PLATFORM_MAX_CHANNELS	8
 #define PLATFORM_MAX_STREAMS	16
 
 /* clock source used by scheduler for deadline calculations */


### PR DESCRIPTION
the gpmrb must support 8-channel,
if not, the capture feature can not work.

Signed-off-by: Wu Zhigang <zhigang.wu@linux.intel.com>