### PR TITLE
rimage: adding an include for all gcc version build

### DIFF
--- a/rimage/pkcs1_5.c
+++ b/rimage/pkcs1_5.c
@@ -24,6 +24,7 @@
 #include <openssl/bn.h>
 #include <stdio.h>
 #include <errno.h>
+#include <string.h>
 
 #include "config.h"
 #include "rimage.h"


### PR DESCRIPTION
To fix build error on some gcc version.