### PR TITLE
boot_loader: remove function for secondary core

### DIFF
--- a/src/arch/xtensa/boot_entry.S
+++ b/src/arch/xtensa/boot_entry.S
@@ -41,8 +41,7 @@
 #include <xtensa/corebits.h>
 #include <xtensa/config/core-isa.h>
 
-	.type   boot_pri_core, @function
-	.type   boot_sec_core, @function
+	.type   boot_master_core, @function
 
 	.begin	literal_prefix	.boot_entry
 	.section .boot_entry.text, "ax"
@@ -145,16 +144,16 @@ boot_init:
 #endif
 
 	/* determine core we are running on */
-	rsr a2, PRID
-	beqz a2, 1f
+	rsr.prid	a2
+	movi		a3, PLATFORM_MASTER_CORE_ID
+	beq			a2, a3, 1f
 
-	/* we are seconadry core, so boot it */
-	call8 boot_sec_core
+	/* no core should get here */
 	j dead
 
 1:
 	/* we are primary core so boot it */
-	call8 boot_pri_core
+	call8 boot_master_core
 
 dead:
 	/* should never get here - we are dead */

--- a/src/arch/xtensa/boot_loader.c
+++ b/src/arch/xtensa/boot_loader.c
@@ -39,8 +39,7 @@
 /* entry point to main firmware */
 extern void _ResetVector(void);
 
-void boot_pri_core(void);
-void boot_sec_core(void);
+void boot_master_core(void);
 
 #if defined(CONFIG_BOOT_LOADER)
 
@@ -171,18 +170,8 @@ static uint32_t hp_sram_init(void)
 }
 #endif
 
-/* boot secondary core - i.e core ID > 0 */
-void boot_sec_core(void)
-{
-	/* TODO: prepare C stack for this core */
-	while (1);
-
-	/* now call SOF entry */
-	_ResetVector();
-}
-
-/* boot primary core - i.e. core ID == 0 */
-void boot_pri_core(void)
+/* boot master core */
+void boot_master_core(void)
 {
 	int32_t result;
 


### PR DESCRIPTION
Removes boot_sec_core function.
It's not needed here, because slave cores will directly
go to main.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>