### PR TITLE
idc: refactor arch_idc_send_msg method

### DIFF
--- a/src/arch/xtensa/smp/include/arch/idc.h
+++ b/src/arch/xtensa/smp/include/arch/idc.h
@@ -74,7 +74,6 @@ struct idc {
 	uint32_t done_bit_mask;		/**< done interrupt mask */
 	uint32_t msg_pending;		/**< is message pending */
 	struct idc_msg received_msg;	/**< received message */
-	struct idc_msg msg_to_send;	/**< message to be sent */
 };
 
 /**
@@ -142,12 +141,11 @@ static void idc_irq_handler(void *arg)
 
 /**
  * \brief Sends IDC message.
+ * \param[in,out] msg Pointer to IDC message.
  */
-static inline void arch_idc_send_msg(void)
+static inline void arch_idc_send_msg(struct idc_msg *msg)
 {
 	struct idc *idc = *idc_get();
-
-	struct idc_msg msg = idc->msg_to_send;
 	int core = cpu_get_id();
 	uint32_t flags;
 
@@ -155,8 +153,8 @@ static inline void arch_idc_send_msg(void)
 
 	spin_lock_irq(&idc->lock, flags);
 
-	idc_write(IPC_IDCIETC(msg.core), core, msg.extension);
-	idc_write(IPC_IDCITC(msg.core), core, msg.header | IPC_IDCITC_BUSY);
+	idc_write(IPC_IDCIETC(msg->core), core, msg->extension);
+	idc_write(IPC_IDCITC(msg->core), core, msg->header | IPC_IDCITC_BUSY);
 
 	spin_unlock_irq(&idc->lock, flags);
 }

--- a/src/arch/xtensa/up/include/arch/idc.h
+++ b/src/arch/xtensa/up/include/arch/idc.h
@@ -37,10 +37,12 @@
 #ifndef __ARCH_IDC_H__
 #define __ARCH_IDC_H__
 
+struct idc_msg;
+
 /**
  * \brief Sends IDC message.
  */
-static inline void arch_idc_send_msg(void) { }
+static inline void arch_idc_send_msg(struct idc_msg *msg) { }
 
 /**
  * \brief Checks for pending IDC messages.

--- a/src/platform/apollolake/include/platform/idc.h
+++ b/src/platform/apollolake/include/platform/idc.h
@@ -33,9 +33,9 @@
 
 #include <arch/idc.h>
 
-static inline void idc_send_msg(void)
+static inline void idc_send_msg(struct idc_msg *msg)
 {
-	arch_idc_send_msg();
+	arch_idc_send_msg(msg);
 }
 
 static inline void idc_process_msg_queue(void)

--- a/src/platform/baytrail/include/platform/idc.h
+++ b/src/platform/baytrail/include/platform/idc.h
@@ -31,7 +31,9 @@
 #ifndef __INCLUDE_PLATFORM_IDC_H__
 #define __INCLUDE_PLATFORM_IDC_H__
 
-static inline void idc_send_msg(void) { }
+struct idc_msg;
+
+static inline void idc_send_msg(struct idc_msg *msg) { }
 
 static inline void idc_process_msg_queue(void) { }
 

--- a/src/platform/cannonlake/include/platform/idc.h
+++ b/src/platform/cannonlake/include/platform/idc.h
@@ -33,9 +33,9 @@
 
 #include <arch/idc.h>
 
-static inline void idc_send_msg(void)
+static inline void idc_send_msg(struct idc_msg *msg)
 {
-	arch_idc_send_msg();
+	arch_idc_send_msg(msg);
 }
 
 static inline void idc_process_msg_queue(void)

--- a/src/platform/haswell/include/platform/idc.h
+++ b/src/platform/haswell/include/platform/idc.h
@@ -31,7 +31,9 @@
 #ifndef __INCLUDE_PLATFORM_IDC_H__
 #define __INCLUDE_PLATFORM_IDC_H__
 
-static inline void idc_send_msg(void) { }
+struct idc_msg;
+
+static inline void idc_send_msg(struct idc_msg *msg) { }
 
 static inline void idc_process_msg_queue(void) { }
 


### PR DESCRIPTION
Changes arch_idc_send_msg method to accept idc_msg instead of idc.
This way it's more flexible for external components to send messages
without even knowing about internal idc implementation.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>