### PR TITLE
klocwork: fix initialization of HiFi3 variables

### DIFF
--- a/src/audio/src_hifi3.c
+++ b/src/audio/src_hifi3.c
@@ -199,10 +199,10 @@ static inline void fir_filter(ae_f32 *rp, const void *cp, ae_f32 *wp0,
 	 */
 	ae_f64 a0;
 	ae_f64 a1;
-	ae_f24x2 data2;
-	ae_f24x2 coef2;
-	ae_f24x2 d0;
-	ae_f24x2 d1;
+	ae_f24x2 data2 = AE_ZERO24();
+	ae_f24x2 coef2 = AE_ZERO24();
+	ae_f24x2 d0 = AE_ZERO24();
+	ae_f24x2 d1 = AE_ZERO24();
 	ae_f24x2 *coefp;
 	ae_f24x2 *dp;
 	ae_f24 *dp1;
@@ -332,7 +332,7 @@ void src_polyphase_stage_cir(struct src_stage_prm *s)
 	 * 16x integers
 	 *  7x address pointers,
 	 */
-	ae_int32x2 q;
+	ae_int32x2 q = AE_ZERO32();
 	ae_f32 *rp;
 	ae_f32 *wp;
 	int i;
@@ -448,7 +448,7 @@ void src_polyphase_stage_cir_s24(struct src_stage_prm *s)
 	 * 16x integers
 	 *  7x address pointers,
 	 */
-	ae_int32x2 q;
+	ae_int32x2 q = AE_ZERO32();
 	ae_f32 *rp;
 	ae_f32 *wp;
 	int i;

--- a/src/audio/volume_hifi3.c
+++ b/src/audio/volume_hifi3.c
@@ -57,7 +57,7 @@ static void vol_s16_to_s16(struct comp_dev *dev, struct comp_buffer *sink,
 	ae_f32x2 volume;
 	ae_f32x2 mult;
 	ae_f32x2 out_sample;
-	ae_f16x4 in_sample;
+	ae_f16x4 in_sample = AE_ZERO16();
 	size_t channel;
 	int i;
 	int limit = source->size / (dev->params.channels << 1);
@@ -105,7 +105,7 @@ static void vol_s16_to_sX(struct comp_dev *dev, struct comp_buffer *sink,
 	ae_f32x2 volume;
 	ae_f32x2 mult;
 	ae_f32x2 out_sample;
-	ae_f16x4 in_sample;
+	ae_f16x4 in_sample = AE_ZERO16();
 	size_t channel;
 	uint8_t shift_left = 0;
 	int i;
@@ -161,7 +161,7 @@ static void vol_sX_to_s16(struct comp_dev *dev, struct comp_buffer *sink,
 	uint32_t vol_scaled[SOF_IPC_MAX_CHANNELS];
 	ae_f32x2 volume;
 	ae_f32x2 mult;
-	ae_f32x2 in_sample;
+	ae_f32x2 in_sample = AE_ZERO32();
 	ae_f16x4 out_sample;
 	size_t channel;
 	uint8_t shift_left = 0;
@@ -216,7 +216,7 @@ static void vol_s24_to_s24_s32(struct comp_dev *dev, struct comp_buffer *sink,
 	struct comp_data *cd = comp_get_drvdata(dev);
 	uint32_t vol_scaled[SOF_IPC_MAX_CHANNELS];
 	ae_f32x2 volume;
-	ae_f32x2 in_sample;
+	ae_f32x2 in_sample = AE_ZERO32();
 	ae_f32x2 out_sample;
 	ae_f32x2 mult;
 	size_t channel;
@@ -271,7 +271,7 @@ static void vol_s32_to_s24_s32(struct comp_dev *dev, struct comp_buffer *sink,
 	struct comp_data *cd = comp_get_drvdata(dev);
 	uint32_t vol_scaled[SOF_IPC_MAX_CHANNELS];
 	ae_f32x2 volume;
-	ae_f32x2 in_sample;
+	ae_f32x2 in_sample = AE_ZERO32();
 	ae_f32x2 out_sample;
 	ae_f32x2 mult;
 	size_t channel;


### PR DESCRIPTION
Initializes HiFi3 variables to 0.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>