### PR TITLE
cache: change in cache functions definition

### DIFF
--- a/src/arch/xtensa/include/arch/cache.h
+++ b/src/arch/xtensa/include/arch/cache.h
@@ -33,37 +33,36 @@
 
 #include <stdint.h>
 #include <stddef.h>
+#include <xtensa/config/core.h>
 #include <xtensa/hal.h>
-
-#if defined CONFIG_BAYTRAIL || defined CONFIG_CHERRYTRAIL ||\
-	defined CONFIG_HASWELL || defined CONFIG_BROADWELL
-
-static inline void dcache_writeback_region(void *addr, size_t size) {}
-static inline void dcache_invalidate_region(void *addr, size_t size) {}
-static inline void icache_invalidate_region(void *addr, size_t size) {}
-static inline void dcache_writeback_invalidate_region(void *addr, size_t size) {}
-#else
 
 static inline void dcache_writeback_region(void *addr, size_t size)
 {
+#if XCHAL_DCACHE_SIZE > 0
 	xthal_dcache_region_writeback(addr, size);
+#endif
 }
 
 static inline void dcache_invalidate_region(void *addr, size_t size)
 {
+#if XCHAL_DCACHE_SIZE > 0
 	xthal_dcache_region_invalidate(addr, size);
+#endif
 }
 
 static inline void icache_invalidate_region(void *addr, size_t size)
 {
+#if XCHAL_ICACHE_SIZE > 0
 	xthal_icache_region_invalidate(addr, size);
+#endif
 }
 
 static inline void dcache_writeback_invalidate_region(void *addr, size_t size)
 {
+#if XCHAL_DCACHE_SIZE > 0
 	xthal_dcache_region_writeback_inv(addr, size);
+#endif
 }
 
-#endif
 #endif
 

--- a/src/platform/baytrail/include/arch/xtensa/config/core-isa-byt.h
+++ b/src/platform/baytrail/include/arch/xtensa/config/core-isa-byt.h
@@ -213,16 +213,16 @@
 #define XCHAL_ICACHE_LINEWIDTH		7	/* log2(I line size in bytes) */
 #define XCHAL_DCACHE_LINEWIDTH		7	/* log2(D line size in bytes) */
 
-#define XCHAL_ICACHE_SIZE		49152	/* I-cache size in bytes or 0 */
-#define XCHAL_DCACHE_SIZE		98304	/* D-cache size in bytes or 0 */
+#define XCHAL_ICACHE_SIZE		0	/* I-cache size in bytes or 0 */
+#define XCHAL_DCACHE_SIZE		0	/* D-cache size in bytes or 0 */
 
-#define XCHAL_DCACHE_IS_WRITEBACK	1	/* writeback feature */
+#define XCHAL_DCACHE_IS_WRITEBACK	0	/* writeback feature */
 #define XCHAL_DCACHE_IS_COHERENT	0	/* MP coherence feature */
 
-#define XCHAL_HAVE_PREFETCH		1	/* PREFCTL register */
+#define XCHAL_HAVE_PREFETCH		0	/* PREFCTL register */
 #define XCHAL_HAVE_PREFETCH_L1		0	/* prefetch to L1 dcache */
-#define XCHAL_PREFETCH_CASTOUT_LINES	1	/* dcache pref. castout bufsz */
-#define XCHAL_PREFETCH_ENTRIES		8	/* cache prefetch entries */
+#define XCHAL_PREFETCH_CASTOUT_LINES	0	/* dcache pref. castout bufsz */
+#define XCHAL_PREFETCH_ENTRIES		0	/* cache prefetch entries */
 #define XCHAL_PREFETCH_BLOCK_ENTRIES	0	/* prefetch block streams */
 #define XCHAL_HAVE_CACHE_BLOCKOPS	0	/* block prefetch for caches */
 #define XCHAL_HAVE_ICACHE_TEST		0	/* Icache test instructions */

--- a/src/platform/baytrail/include/arch/xtensa/config/core-isa-cht.h
+++ b/src/platform/baytrail/include/arch/xtensa/config/core-isa-cht.h
@@ -213,16 +213,16 @@
 #define XCHAL_ICACHE_LINEWIDTH		7	/* log2(I line size in bytes) */
 #define XCHAL_DCACHE_LINEWIDTH		7	/* log2(D line size in bytes) */
 
-#define XCHAL_ICACHE_SIZE		49152	/* I-cache size in bytes or 0 */
-#define XCHAL_DCACHE_SIZE		98304	/* D-cache size in bytes or 0 */
+#define XCHAL_ICACHE_SIZE		0	/* I-cache size in bytes or 0 */
+#define XCHAL_DCACHE_SIZE		0	/* D-cache size in bytes or 0 */
 
-#define XCHAL_DCACHE_IS_WRITEBACK	1	/* writeback feature */
+#define XCHAL_DCACHE_IS_WRITEBACK	0	/* writeback feature */
 #define XCHAL_DCACHE_IS_COHERENT	0	/* MP coherence feature */
 
-#define XCHAL_HAVE_PREFETCH		1	/* PREFCTL register */
+#define XCHAL_HAVE_PREFETCH		0	/* PREFCTL register */
 #define XCHAL_HAVE_PREFETCH_L1		0	/* prefetch to L1 dcache */
-#define XCHAL_PREFETCH_CASTOUT_LINES	1	/* dcache pref. castout bufsz */
-#define XCHAL_PREFETCH_ENTRIES		8	/* cache prefetch entries */
+#define XCHAL_PREFETCH_CASTOUT_LINES	0	/* dcache pref. castout bufsz */
+#define XCHAL_PREFETCH_ENTRIES		0	/* cache prefetch entries */
 #define XCHAL_PREFETCH_BLOCK_ENTRIES	0	/* prefetch block streams */
 #define XCHAL_HAVE_CACHE_BLOCKOPS	0	/* block prefetch for caches */
 #define XCHAL_HAVE_ICACHE_TEST		0	/* Icache test instructions */


### PR DESCRIPTION
Makes cache functions available based on XCHAL_DCACHE_SIZE
and XCHAL_ICACHE_SIZE rather than specific platform.
Also fixes those definitions for BYT and CHT.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>