### PR TITLE
cache: add operations on whole memory

### DIFF
--- a/src/arch/xtensa/include/arch/cache.h
+++ b/src/arch/xtensa/include/arch/cache.h
@@ -49,9 +49,23 @@ static inline void dcache_writeback_region(void *addr, size_t size)
 	xthal_dcache_region_writeback(addr, size);
 }
 
+static inline void dcache_writeback_all()
+{
+#if XCHAL_DCACHE_SIZE > 0
+	xthal_dcache_all_writeback();
+#endif
+}
+
 static inline void dcache_invalidate_region(void *addr, size_t size)
 {
 	xthal_dcache_region_invalidate(addr, size);
+}
+
+static inline void dcache_invalidate_all()
+{
+#if XCHAL_DCACHE_SIZE > 0
+	xthal_dcache_all_invalidate();
+#endif
 }
 
 static inline void icache_invalidate_region(void *addr, size_t size)
@@ -59,9 +73,23 @@ static inline void icache_invalidate_region(void *addr, size_t size)
 	xthal_icache_region_invalidate(addr, size);
 }
 
+static inline void icache_invalidate_all()
+{
+#if XCHAL_ICACHE_SIZE > 0
+	xthal_icache_all_invalidate();
+#endif
+}
+
 static inline void dcache_writeback_invalidate_region(void *addr, size_t size)
 {
 	xthal_dcache_region_writeback_inv(addr, size);
+}
+
+static inline void dcache_writeback_invalidate_all()
+{
+#if XCHAL_DCACHE_SIZE > 0
+	xthal_dcache_all_writeback_inv();
+#endif
 }
 
 #endif


### PR DESCRIPTION
Adds cache operations, which execute on whole memory.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>