### PR TITLE
arch: free core specific structs

### DIFF
--- a/src/include/sof/schedule.h
+++ b/src/include/sof/schedule.h
@@ -110,4 +110,6 @@ static inline void schedule_task_config(struct task *task, uint16_t priority,
 
 int scheduler_init(struct sof *sof);
 
+void scheduler_free(void);
+
 #endif


### PR DESCRIPTION
Implements free methods for idc, irq_task and schedule_data,
so the slave cores can free memory on shutdown.
Saves system heap, which cannot be deallotaced.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>