### PR TITLE
autotools: replace user variables with automake variables

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -86,17 +86,13 @@ case "$with_arch" in
     xtensa*)
 
 	ARCH_CFLAGS="-mtext-section-literals"
-	AC_SUBST(ARCH_CFLAGS)
 
 	ARCH_LDFLAGS="-nostdlib -Wl,--no-check-sections -u call_user_start -Wl,-static"
-	AC_SUBST(XTENSA_LDFLAGS)
 
-	# extra CFLAGS defined here otherwise configure working gcc tests fails.
-	CFLAGS="${CFLAGS:+$CFLAGS }-fno-inline-functions -nostdlib -mlongcalls"
-	LDFLAGS="${LDFLAGS:+$LDFLAGS }-nostdlib"
-
-	#ARCH_ASFLAGS=""
-	AC_SUBST(ARCH_ASFLAGS)
+	# automake FLAGS defined here
+	AM_CFLAGS="-fno-inline-functions -nostdlib -mlongcalls"
+	AM_LDFLAGS="-nostdlib"
+	AM_CCASFLAGS="-fno-inline-functions -nostdlib -mlongcalls"
 
 	ARCH="xtensa"
 	AC_SUBST(ARCH)
@@ -109,11 +105,11 @@ case "$with_arch" in
     host*)
 
 	ARCH_CFLAGS="-g"
-	AC_SUBST(ARCH_CFLAGS)
 
-	# extra CFLAGS defined here otherwise configure working gcc tests fails.
-	CFLAGS="${CFLAGS:+$CFLAGS } -O3"
-	LDFLAGS="${LDFLAGS:+$LDFLAGS }-lpthread"
+	# automake FLAGS defined here
+	AM_CFLAGS="-O3"
+	AM_LDFLAGS="-lpthread"
+	AM_CCASFLAGS="-O3"
 
 	ARCH="host"
 	AC_SUBST(ARCH)
@@ -124,6 +120,13 @@ case "$with_arch" in
 	fi
     ;;
 esac
+
+AC_SUBST(ARCH_CFLAGS)
+AC_SUBST(ARCH_LDFLAGS)
+
+AC_SUBST(AM_CFLAGS)
+AC_SUBST(AM_LDFLAGS)
+AC_SUBST(AM_CCASFLAGS)
 
 AM_CONDITIONAL(BUILD_XTENSA, test "$ARCH" = "xtensa")
 AM_CONDITIONAL(BUILD_HOST, test "$ARCH" = "host")
@@ -494,5 +497,8 @@ CFLAGS:                        ${CFLAGS}
 LDFLAGS:                       ${LDFLAGS}
 ARCH_CFLAGS:                   ${ARCH_CFLAGS}
 ARCH_LDFLAGS:                  ${ARCH_LDFLAGS}
+A@&t@M_CFLAGS:                     ${AM_CFLAGS}
+A@&t@M_LDFLAGS:                    ${AM_LDFLAGS}
+A@&t@M_CCASFLAGS:                  ${AM_CCASFLAGS}
 "
 

--- a/src/arch/xtensa/Makefile.am
+++ b/src/arch/xtensa/Makefile.am
@@ -31,7 +31,7 @@ libreset_a_SOURCES = \
 libreset_a_CCASFLAGS = \
 	$(ARCH_INCDIR) \
 	$(ASFLAGS) \
-	$(ARCH_ASFLAGS) \
+	$(AM_CCASFLAGS) \
 	$(PLATFORM_INCDIR) \
 	-mtext-section-literals
 
@@ -49,6 +49,7 @@ endif
 
 sof_CFLAGS = \
 	$(ARCH_INCDIR) \
+	$(AM_CFLAGS) \
 	$(ARCH_CFLAGS) \
 	$(PLATFORM_INCDIR) \
 	$(SOF_INCDIR)
@@ -56,7 +57,7 @@ sof_CFLAGS = \
 sof_CCASFLAGS = \
 	$(ARCH_INCDIR) \
 	$(ASFLAGS) \
-	$(ARCH_ASFLAGS) \
+	$(AM_CCASFLAGS) \
 	$(PLATFORM_INCDIR)
 
 sof_LDADD = \
@@ -83,6 +84,7 @@ sof_LDADD += \
 endif
 
 sof_LDFLAGS = \
+	$(AM_LDFLAGS) \
 	$(ARCH_LDFLAGS) -Wl,-Map=sof-$(FW_NAME).map \
 	-T ../../platform/$(PLATFORM)/$(PLATFORM_LDSCRIPT)
 
@@ -110,6 +112,7 @@ boot_ldr_SOURCES = \
 
 boot_ldr_CFLAGS = \
 	$(ARCH_INCDIR) \
+	$(AM_CFLAGS) \
 	$(ARCH_CFLAGS) \
 	$(PLATFORM_INCDIR) \
 	$(SOF_INCDIR)
@@ -117,7 +120,7 @@ boot_ldr_CFLAGS = \
 boot_ldr_CCASFLAGS = \
 	$(ARCH_INCDIR) \
 	$(ASFLAGS) \
-	$(ARCH_ASFLAGS) \
+	$(AM_CCASFLAGS) \
 	$(PLATFORM_INCDIR)
 
 boot_ldr_LDADD = \
@@ -126,6 +129,7 @@ boot_ldr_LDADD = \
 	-lgcc
 
 boot_ldr_LDFLAGS = \
+	$(AM_LDFLAGS) \
 	$(ARCH_LDFLAGS) \
 	-T ../../platform/$(PLATFORM)/$(PLATFORM_BOOT_LDR_LDSCRIPT)
 

--- a/src/arch/xtensa/hal/Makefile.am
+++ b/src/arch/xtensa/hal/Makefile.am
@@ -223,12 +223,13 @@ libhal_a_SOURCES = \
 
 libhal_a_CFLAGS = \
 	$(ARCH_INCDIR) \
+	$(AM_CFLAGS) \
 	$(ARCH_CFLAGS) \
 	$(PLATFORM_INCDIR) \
 	$(PLATFORM_DEFS)
 
 libhal_a_CCASFLAGS = \
 	$(ARCH_INCDIR) \
-	$(ARCH_ASFLAGS) \
+	$(AM_CCASFLAGS) \
 	$(PLATFORM_INCDIR) \
 	$(PLATFORM_DEFS)

--- a/src/arch/xtensa/xtos/Makefile.am
+++ b/src/arch/xtensa/xtos/Makefile.am
@@ -62,7 +62,7 @@ libxlevel2_a_SOURCES = \
 
 libxlevel2_a_CCASFLAGS = \
 	$(ARCH_INCDIR) \
-	$(ARCH_ASFLAGS) \
+	$(AM_CCASFLAGS) \
 	$(PLATFORM_INCDIR) \
 	$(PLATFORM_DEFS) \
 	-D_INTERRUPT_LEVEL=2
@@ -72,7 +72,7 @@ libxlevel3_a_SOURCES = \
 
 libxlevel3_a_CCASFLAGS = \
 	$(ARCH_INCDIR) \
-	$(ARCH_ASFLAGS) \
+	$(AM_CCASFLAGS) \
 	$(PLATFORM_INCDIR) \
 	$(PLATFORM_DEFS) \
 	-D_INTERRUPT_LEVEL=3
@@ -82,7 +82,7 @@ libxlevel4_a_SOURCES = \
 
 libxlevel4_a_CCASFLAGS = \
 	$(ARCH_INCDIR) \
-	$(ARCH_ASFLAGS) \
+	$(AM_CCASFLAGS) \
 	$(PLATFORM_INCDIR) \
 	$(PLATFORM_DEFS) \
 	-D_INTERRUPT_LEVEL=4
@@ -92,7 +92,7 @@ libxlevel5_a_SOURCES = \
 
 libxlevel5_a_CCASFLAGS = \
 	$(ARCH_INCDIR) \
-	$(ARCH_ASFLAGS) \
+	$(AM_CCASFLAGS) \
 	$(PLATFORM_INCDIR) \
 	$(PLATFORM_DEFS) \
 	-D_INTERRUPT_LEVEL=5
@@ -103,7 +103,7 @@ libxlevel6_a_SOURCES = \
 
 libxlevel6_a_CCASFLAGS = \
 	$(ARCH_INCDIR) \
-	$(ARCH_ASFLAGS) \
+	$(AM_CCASFLAGS) \
 	$(PLATFORM_INCDIR) \
 	$(PLATFORM_DEFS) \
 	-D_INTERRUPT_LEVEL=6
@@ -142,12 +142,13 @@ libxtos_a_SOURCES = \
 
 libxtos_a_CFLAGS = \
 	$(ARCH_INCDIR) \
+	$(AM_CFLAGS) \
 	$(ARCH_CFLAGS) \
 	$(PLATFORM_INCDIR) \
 	$(PLATFORM_DEFS)
 
 libxtos_a_CCASFLAGS = \
 	$(ARCH_INCDIR) \
-	$(ARCH_ASFLAGS) \
+	$(AM_CCASFLAGS) \
 	$(PLATFORM_INCDIR) \
 	$(PLATFORM_DEFS)

--- a/src/audio/Makefile.am
+++ b/src/audio/Makefile.am
@@ -51,10 +51,22 @@ VOLUME_SRC = \
 	volume.c \
 	volume_generic.c
 
+# common compiler flags for libs
+lib_cflags = \
+	$(AM_CFLAGS) \
+	$(ARCH_CFLAGS)
+
 if BUILD_LIB
 
 # only host builds shared libraries, the rest are static
 if BUILD_HOST
+
+# common linker flags for host libs
+host_lib_ldflags = \
+	$(AM_LDFLAGS) \
+	-version-info `echo $(VERSION) | cut -d '.' -f 1` \
+	-no-undefined \
+	-export-dynamic
 
 # libsof
 lib_LTLIBRARIES  = libsof.la
@@ -62,13 +74,10 @@ lib_LTLIBRARIES  = libsof.la
 libsof_la_SOURCES = $(SOF_SRC)
 
 libsof_la_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(COMMON_INCDIR)
 
-libsof_la_LDFLAGS = \
-	-version-info `echo $(VERSION) | cut -d '.' -f 1` \
-	-no-undefined \
-	-export-dynamic
+libsof_la_LDFLAGS = $(host_lib_ldflags)
 
 # libsof_src
 lib_LTLIBRARIES  += libsof_src.la
@@ -76,13 +85,10 @@ lib_LTLIBRARIES  += libsof_src.la
 libsof_src_la_SOURCES = $(SRC_SRC)
 
 libsof_src_la_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(COMMON_INCDIR)
 
-libsof_src_la_LDFLAGS = \
-	-version-info `echo $(VERSION) | cut -d '.' -f 1` \
-	-no-undefined \
-	-export-dynamic
+libsof_src_la_LDFLAGS = $(host_lib_ldflags)
 
 # libsof_eq_fir
 lib_LTLIBRARIES  += libsof_eq_fir.la
@@ -90,13 +96,10 @@ lib_LTLIBRARIES  += libsof_eq_fir.la
 libsof_eq_fir_la_SOURCES = $(EQ_FIR_SRC)
 
 libsof_eq_fir_la_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(COMMON_INCDIR)
 
-libsof_eq_fir_la_LDFLAGS = \
-	-version-info `echo $(VERSION) | cut -d '.' -f 1` \
-	-no-undefined \
-	-export-dynamic
+libsof_eq_fir_la_LDFLAGS = $(host_lib_ldflags)
 
 # libsof_eq_iir
 lib_LTLIBRARIES  += libsof_eq_iir.la
@@ -104,13 +107,10 @@ lib_LTLIBRARIES  += libsof_eq_iir.la
 libsof_eq_iir_la_SOURCES = $(EQ_IIR_SRC)
 
 libsof_eq_iir_la_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(COMMON_INCDIR)
 
-libsof_eq_iir_la_LDFLAGS = \
-	-version-info `echo $(VERSION) | cut -d '.' -f 1` \
-	-no-undefined \
-	-export-dynamic
+libsof_eq_iir_la_LDFLAGS = $(host_lib_ldflags)
 
 # libsof_volume
 lib_LTLIBRARIES  += libsof_volume.la
@@ -118,13 +118,10 @@ lib_LTLIBRARIES  += libsof_volume.la
 libsof_volume_la_SOURCES = $(VOLUME_SRC)
 
 libsof_volume_la_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(COMMON_INCDIR)
 
-libsof_volume_la_LDFLAGS = \
-	-version-info `echo $(VERSION) | cut -d '.' -f 1` \
-	-no-undefined \
-	-export-dynamic
+libsof_volume_la_LDFLAGS = $(host_lib_ldflags)
 
 # libsof_mux
 lib_LTLIBRARIES  += libsof_mux.la
@@ -132,13 +129,10 @@ lib_LTLIBRARIES  += libsof_mux.la
 libsof_mux_la_SOURCES = mux.c
 
 libsof_mux_la_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(COMMON_INCDIR)
 
-libsof_mux_la_LDFLAGS = \
-	-version-info `echo $(VERSION) | cut -d '.' -f 1` \
-	-no-undefined \
-	-export-dynamic
+libsof_mux_la_LDFLAGS = $(host_lib_ldflags)
 
 # libsof_switch
 lib_LTLIBRARIES  += libsof_switch.la
@@ -146,13 +140,10 @@ lib_LTLIBRARIES  += libsof_switch.la
 libsof_switch_la_SOURCES = switch.c
 
 libsof_switch_la_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(COMMON_INCDIR)
 
-libsof_switch_la_LDFLAGS = \
-	-version-info `echo $(VERSION) | cut -d '.' -f 1` \
-	-no-undefined \
-	-export-dynamic
+libsof_switch_la_LDFLAGS = $(host_lib_ldflags)
 
 # libsof_mixer
 lib_LTLIBRARIES  += libsof_mixer.la
@@ -160,13 +151,10 @@ lib_LTLIBRARIES  += libsof_mixer.la
 libsof_mixer_la_SOURCES = mixer.c
 
 libsof_mixer_la_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(COMMON_INCDIR)
 
-libsof_mixer_la_LDFLAGS = \
-	-version-info `echo $(VERSION) | cut -d '.' -f 1` \
-	-no-undefined \
-	-export-dynamic
+libsof_mixer_la_LDFLAGS = $(host_lib_ldflags)
 
 # libsof_tone
 lib_LTLIBRARIES  += libsof_tone.la
@@ -174,13 +162,10 @@ lib_LTLIBRARIES  += libsof_tone.la
 libsof_tone_la_SOURCES = tone.c
 
 libsof_tone_la_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(COMMON_INCDIR)
 
-libsof_tone_la_LDFLAGS = \
-	-version-info `echo $(VERSION) | cut -d '.' -f 1` \
-	-no-undefined \
-	-export-dynamic
+libsof_tone_la_LDFLAGS = $(host_lib_ldflags)
 
 if HAVE_SSE42
 # libsof
@@ -189,14 +174,11 @@ lib_LTLIBRARIES  += libsof_sse42.la
 libsof_sse42_la_SOURCES = $(SOF_SRC)
 
 libsof_sse42_la_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(SSE42_CFLAGS) \
 	$(COMMON_INCDIR)
 
-libsof_sse42_la_LDFLAGS = \
-	-version-info `echo $(VERSION) | cut -d '.' -f 1` \
-	-no-undefined \
-	-export-dynamic
+libsof_sse42_la_LDFLAGS = $(host_lib_ldflags)
 
 # libsof_src
 lib_LTLIBRARIES  += libsof_src_sse42.la
@@ -204,14 +186,11 @@ lib_LTLIBRARIES  += libsof_src_sse42.la
 libsof_src_sse42_la_SOURCES = $(SRC_SRC)
 
 libsof_src_sse42_la_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(SSE42_CFLAGS) \
 	$(COMMON_INCDIR)
 
-libsof_src_sse42_la_LDFLAGS = \
-	-version-info `echo $(VERSION) | cut -d '.' -f 1` \
-	-no-undefined \
-	-export-dynamic
+libsof_src_sse42_la_LDFLAGS = $(host_lib_ldflags)
 
 # libsof_eq_fir
 lib_LTLIBRARIES  += libsof_eq_fir_sse42.la
@@ -219,14 +198,11 @@ lib_LTLIBRARIES  += libsof_eq_fir_sse42.la
 libsof_eq_fir_sse42_la_SOURCES = $(EQ_FIR_SRC)
 
 libsof_eq_fir_sse42_la_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(SSE42_CFLAGS) \
 	$(COMMON_INCDIR)
 
-libsof_eq_fir_sse42_la_LDFLAGS = \
-	-version-info `echo $(VERSION) | cut -d '.' -f 1` \
-	-no-undefined \
-	-export-dynamic
+libsof_eq_fir_sse42_la_LDFLAGS = $(host_lib_ldflags)
 
 # libsof_eq_iir
 lib_LTLIBRARIES  += libsof_eq_iir_sse42.la
@@ -234,14 +210,11 @@ lib_LTLIBRARIES  += libsof_eq_iir_sse42.la
 libsof_eq_iir_sse42_la_SOURCES = $(EQ_IIR_SRC)
 
 libsof_eq_iir_sse42_la_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(SSE42_CFLAGS) \
 	$(COMMON_INCDIR)
 
-libsof_eq_iir_sse42_la_LDFLAGS = \
-	-version-info `echo $(VERSION) | cut -d '.' -f 1` \
-	-no-undefined \
-	-export-dynamic
+libsof_eq_iir_sse42_la_LDFLAGS = $(host_lib_ldflags)
 
 # libsof_volume
 lib_LTLIBRARIES  += libsof_volume_sse42.la
@@ -249,14 +222,11 @@ lib_LTLIBRARIES  += libsof_volume_sse42.la
 libsof_volume_sse42_la_SOURCES = $(VOLUME_SRC)
 
 libsof_volume_sse42_la_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(SSE42_CFLAGS) \
 	$(COMMON_INCDIR)
 
-libsof_volume_sse42_la_LDFLAGS = \
-	-version-info `echo $(VERSION) | cut -d '.' -f 1` \
-	-no-undefined \
-	-export-dynamic
+libsof_volume_sse42_la_LDFLAGS = $(host_lib_ldflags)
 
 # libsof_mux
 lib_LTLIBRARIES  += libsof_mux_sse42.la
@@ -264,14 +234,11 @@ lib_LTLIBRARIES  += libsof_mux_sse42.la
 libsof_mux_sse42_la_SOURCES = mux.c
 
 libsof_mux_sse42_la_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(SSE42_CFLAGS) \
 	$(COMMON_INCDIR)
 
-libsof_mux_sse42_la_LDFLAGS = \
-	-version-info `echo $(VERSION) | cut -d '.' -f 1` \
-	-no-undefined \
-	-export-dynamic
+libsof_mux_sse42_la_LDFLAGS = $(host_lib_ldflags)
 
 # libsof_switch
 lib_LTLIBRARIES  += libsof_switch_sse42.la
@@ -279,14 +246,11 @@ lib_LTLIBRARIES  += libsof_switch_sse42.la
 libsof_switch_sse42_la_SOURCES = switch.c
 
 libsof_switch_sse42_la_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(SSE42_CFLAGS) \
 	$(COMMON_INCDIR)
 
-libsof_switch_sse42_la_LDFLAGS = \
-	-version-info `echo $(VERSION) | cut -d '.' -f 1` \
-	-no-undefined \
-	-export-dynamic
+libsof_switch_sse42_la_LDFLAGS = $(host_lib_ldflags)
 
 # libsof_mixer
 lib_LTLIBRARIES  += libsof_mixer_sse42.la
@@ -294,14 +258,11 @@ lib_LTLIBRARIES  += libsof_mixer_sse42.la
 libsof_mixer_sse42_la_SOURCES = mixer.c
 
 libsof_mixer_sse42_la_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(SSE42_CFLAGS) \
 	$(COMMON_INCDIR)
 
-libsof_mixer_sse42_la_LDFLAGS = \
-	-version-info `echo $(VERSION) | cut -d '.' -f 1` \
-	-no-undefined \
-	-export-dynamic
+libsof_mixer_sse42_la_LDFLAGS = $(host_lib_ldflags)
 
 # libsof_tone
 lib_LTLIBRARIES  += libsof_tone_sse42.la
@@ -309,14 +270,11 @@ lib_LTLIBRARIES  += libsof_tone_sse42.la
 libsof_tone_sse42_la_SOURCES = tone.c
 
 libsof_tone_sse42_la_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(SSE42_CFLAGS) \
 	$(COMMON_INCDIR)
 
-libsof_tone_sse42_la_LDFLAGS = \
-	-version-info `echo $(VERSION) | cut -d '.' -f 1` \
-	-no-undefined \
-	-export-dynamic
+libsof_tone_sse42_la_LDFLAGS = $(host_lib_ldflags)
 endif
 
 if HAVE_AVX
@@ -326,14 +284,11 @@ lib_LTLIBRARIES  += libsof_avx.la
 libsof_avx_la_SOURCES = $(SOF_SRC)
 
 libsof_avx_la_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(AVX_CFLAGS) \
 	$(COMMON_INCDIR)
 
-libsof_avx_la_LDFLAGS = \
-	-version-info `echo $(VERSION) | cut -d '.' -f 1` \
-	-no-undefined \
-	-export-dynamic
+libsof_avx_la_LDFLAGS = $(host_lib_ldflags)
 
 # libsof_src
 lib_LTLIBRARIES  += libsof_src_avx.la
@@ -341,14 +296,11 @@ lib_LTLIBRARIES  += libsof_src_avx.la
 libsof_src_avx_la_SOURCES = $(SRC_SRC)
 
 libsof_src_avx_la_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(AVX_CFLAGS) \
 	$(COMMON_INCDIR)
 
-libsof_src_avx_la_LDFLAGS = \
-	-version-info `echo $(VERSION) | cut -d '.' -f 1` \
-	-no-undefined \
-	-export-dynamic
+libsof_src_avx_la_LDFLAGS = $(host_lib_ldflags)
 
 # libsof_eq_fir
 lib_LTLIBRARIES  += libsof_eq_fir_avx.la
@@ -356,14 +308,11 @@ lib_LTLIBRARIES  += libsof_eq_fir_avx.la
 libsof_eq_fir_avx_la_SOURCES = $(EQ_FIR_SRC)
 
 libsof_eq_fir_avx_la_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(AVX_CFLAGS) \
 	$(COMMON_INCDIR)
 
-libsof_eq_fir_avx_la_LDFLAGS = \
-	-version-info `echo $(VERSION) | cut -d '.' -f 1` \
-	-no-undefined \
-	-export-dynamic
+libsof_eq_fir_avx_la_LDFLAGS = $(host_lib_ldflags)
 
 # libsof_eq_iir
 lib_LTLIBRARIES  += libsof_eq_iir_avx.la
@@ -371,14 +320,11 @@ lib_LTLIBRARIES  += libsof_eq_iir_avx.la
 libsof_eq_iir_avx_la_SOURCES = $(EQ_IIR_SRC)
 
 libsof_eq_iir_avx_la_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(AVX_CFLAGS) \
 	$(COMMON_INCDIR)
 
-libsof_eq_iir_avx_la_LDFLAGS = \
-	-version-info `echo $(VERSION) | cut -d '.' -f 1` \
-	-no-undefined \
-	-export-dynamic
+libsof_eq_iir_avx_la_LDFLAGS = $(host_lib_ldflags)
 
 # libsof_volume
 lib_LTLIBRARIES  += libsof_volume_avx.la
@@ -386,14 +332,11 @@ lib_LTLIBRARIES  += libsof_volume_avx.la
 libsof_volume_avx_la_SOURCES = $(VOLUME_SRC)
 
 libsof_volume_avx_la_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(AVX_CFLAGS) \
 	$(COMMON_INCDIR)
 
-libsof_volume_avx_la_LDFLAGS = \
-	-version-info `echo $(VERSION) | cut -d '.' -f 1` \
-	-no-undefined \
-	-export-dynamic
+libsof_volume_avx_la_LDFLAGS = $(host_lib_ldflags)
 
 # libsof_mux
 lib_LTLIBRARIES  += libsof_mux_avx.la
@@ -401,14 +344,11 @@ lib_LTLIBRARIES  += libsof_mux_avx.la
 libsof_mux_avx_la_SOURCES = mux.c
 
 libsof_mux_avx_la_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(AVX_CFLAGS) \
 	$(COMMON_INCDIR)
 
-libsof_mux_avx_la_LDFLAGS = \
-	-version-info `echo $(VERSION) | cut -d '.' -f 1` \
-	-no-undefined \
-	-export-dynamic
+libsof_mux_avx_la_LDFLAGS = $(host_lib_ldflags)
 
 # libsof_switch
 lib_LTLIBRARIES  += libsof_switch_avx.la
@@ -416,14 +356,11 @@ lib_LTLIBRARIES  += libsof_switch_avx.la
 libsof_switch_avx_la_SOURCES = switch.c
 
 libsof_switch_avx_la_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(AVX_CFLAGS) \
 	$(COMMON_INCDIR)
 
-libsof_switch_avx_la_LDFLAGS = \
-	-version-info `echo $(VERSION) | cut -d '.' -f 1` \
-	-no-undefined \
-	-export-dynamic
+libsof_switch_avx_la_LDFLAGS = $(host_lib_ldflags)
 
 # libsof_mixer
 lib_LTLIBRARIES  += libsof_mixer_avx.la
@@ -431,14 +368,11 @@ lib_LTLIBRARIES  += libsof_mixer_avx.la
 libsof_mixer_avx_la_SOURCES = mixer.c
 
 libsof_mixer_avx_la_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(AVX_CFLAGS) \
 	$(COMMON_INCDIR)
 
-libsof_mixer_avx_la_LDFLAGS = \
-	-version-info `echo $(VERSION) | cut -d '.' -f 1` \
-	-no-undefined \
-	-export-dynamic
+libsof_mixer_avx_la_LDFLAGS = $(host_lib_ldflags)
 
 # libsof_tone
 lib_LTLIBRARIES  += libsof_tone_avx.la
@@ -446,14 +380,11 @@ lib_LTLIBRARIES  += libsof_tone_avx.la
 libsof_tone_avx_la_SOURCES = tone.c
 
 libsof_tone_avx_la_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(AVX_CFLAGS) \
 	$(COMMON_INCDIR)
 
-libsof_tone_avx_la_LDFLAGS = \
-	-version-info `echo $(VERSION) | cut -d '.' -f 1` \
-	-no-undefined \
-	-export-dynamic
+libsof_tone_avx_la_LDFLAGS = $(host_lib_ldflags)
 endif
 
 if HAVE_AVX2
@@ -463,14 +394,11 @@ lib_LTLIBRARIES  += libsof_avx2.la
 libsof_avx2_la_SOURCES = $(SOF_SRC)
 
 libsof_avx2_la_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(AVX2_CFLAGS) \
 	$(COMMON_INCDIR)
 
-libsof_avx2_la_LDFLAGS = \
-	-version-info `echo $(VERSION) | cut -d '.' -f 1` \
-	-no-undefined \
-	-export-dynamic
+libsof_avx2_la_LDFLAGS = $(host_lib_ldflags)
 
 # libsof_src
 lib_LTLIBRARIES  += libsof_src_avx2.la
@@ -478,14 +406,11 @@ lib_LTLIBRARIES  += libsof_src_avx2.la
 libsof_src_avx2_la_SOURCES = $(SRC_SRC)
 
 libsof_src_avx2_la_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(AVX2_CFLAGS) \
 	$(COMMON_INCDIR)
 
-libsof_src_avx2_la_LDFLAGS = \
-	-version-info `echo $(VERSION) | cut -d '.' -f 1` \
-	-no-undefined \
-	-export-dynamic
+libsof_src_avx2_la_LDFLAGS = $(host_lib_ldflags)
 
 # libsof_eq_fir
 lib_LTLIBRARIES  += libsof_eq_fir_avx2.la
@@ -493,14 +418,11 @@ lib_LTLIBRARIES  += libsof_eq_fir_avx2.la
 libsof_eq_fir_avx2_la_SOURCES = $(EQ_FIR_SRC)
 
 libsof_eq_fir_avx2_la_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(AVX2_CFLAGS) \
 	$(COMMON_INCDIR)
 
-libsof_eq_fir_avx2_la_LDFLAGS = \
-	-version-info `echo $(VERSION) | cut -d '.' -f 1` \
-	-no-undefined \
-	-export-dynamic
+libsof_eq_fir_avx2_la_LDFLAGS = $(host_lib_ldflags)
 
 # libsof_eq_iir
 lib_LTLIBRARIES  += libsof_eq_iir_avx2.la
@@ -508,14 +430,11 @@ lib_LTLIBRARIES  += libsof_eq_iir_avx2.la
 libsof_eq_iir_avx2_la_SOURCES = $(EQ_IIR_SRC)
 
 libsof_eq_iir_avx2_la_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(AVX2_CFLAGS) \
 	$(COMMON_INCDIR)
 
-libsof_eq_iir_avx2_la_LDFLAGS = \
-	-version-info `echo $(VERSION) | cut -d '.' -f 1` \
-	-no-undefined \
-	-export-dynamic
+libsof_eq_iir_avx2_la_LDFLAGS = $(host_lib_ldflags)
 
 # libsof_volume
 lib_LTLIBRARIES  += libsof_volume_avx2.la
@@ -523,14 +442,11 @@ lib_LTLIBRARIES  += libsof_volume_avx2.la
 libsof_volume_avx2_la_SOURCES = $(VOLUME_SRC)
 
 libsof_volume_avx2_la_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(AVX2_CFLAGS) \
 	$(COMMON_INCDIR)
 
-libsof_volume_avx2_la_LDFLAGS = \
-	-version-info `echo $(VERSION) | cut -d '.' -f 1` \
-	-no-undefined \
-	-export-dynamic
+libsof_volume_avx2_la_LDFLAGS = $(host_lib_ldflags)
 
 # libsof_mux
 lib_LTLIBRARIES  += libsof_mux_avx2.la
@@ -538,14 +454,11 @@ lib_LTLIBRARIES  += libsof_mux_avx2.la
 libsof_mux_avx2_la_SOURCES = mux.c
 
 libsof_mux_avx2_la_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(AVX2_CFLAGS) \
 	$(COMMON_INCDIR)
 
-libsof_mux_avx2_la_LDFLAGS = \
-	-version-info `echo $(VERSION) | cut -d '.' -f 1` \
-	-no-undefined \
-	-export-dynamic
+libsof_mux_avx2_la_LDFLAGS = $(host_lib_ldflags)
 
 # libsof_switch
 lib_LTLIBRARIES  += libsof_switch_avx2.la
@@ -553,14 +466,11 @@ lib_LTLIBRARIES  += libsof_switch_avx2.la
 libsof_switch_avx2_la_SOURCES = switch.c
 
 libsof_switch_avx2_la_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(AVX2_CFLAGS) \
 	$(COMMON_INCDIR)
 
-libsof_switch_avx2_la_LDFLAGS = \
-	-version-info `echo $(VERSION) | cut -d '.' -f 1` \
-	-no-undefined \
-	-export-dynamic
+libsof_switch_avx2_la_LDFLAGS = $(host_lib_ldflags)
 
 # libsof_mixer
 lib_LTLIBRARIES  += libsof_mixer_avx2.la
@@ -568,14 +478,11 @@ lib_LTLIBRARIES  += libsof_mixer_avx2.la
 libsof_mixer_avx2_la_SOURCES = mixer.c
 
 libsof_mixer_avx2_la_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(AVX2_CFLAGS) \
 	$(COMMON_INCDIR)
 
-libsof_mixer_avx2_la_LDFLAGS = \
-	-version-info `echo $(VERSION) | cut -d '.' -f 1` \
-	-no-undefined \
-	-export-dynamic
+libsof_mixer_avx2_la_LDFLAGS = $(host_lib_ldflags)
 
 # libsof_tone
 lib_LTLIBRARIES  += libsof_tone_avx2.la
@@ -583,14 +490,11 @@ lib_LTLIBRARIES  += libsof_tone_avx2.la
 libsof_tone_avx2_la_SOURCES = tone.c
 
 libsof_tone_avx2_la_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(AVX2_CFLAGS) \
 	$(COMMON_INCDIR)
 
-libsof_tone_avx2_la_LDFLAGS = \
-	-version-info `echo $(VERSION) | cut -d '.' -f 1` \
-	-no-undefined \
-	-export-dynamic
+libsof_tone_avx2_la_LDFLAGS = $(host_lib_ldflags)
 
 endif
 
@@ -601,14 +505,11 @@ lib_LTLIBRARIES  += libsof_fma.la
 libsof_fma_la_SOURCES = $(SOF_SRC)
 
 libsof_fma_la_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(FMA_CFLAGS) \
 	$(COMMON_INCDIR)
 
-libsof_fma_la_LDFLAGS = \
-	-version-info `echo $(VERSION) | cut -d '.' -f 1` \
-	-no-undefined \
-	-export-dynamic
+libsof_fma_la_LDFLAGS = $(host_lib_ldflags)
 
 # libsof_src
 lib_LTLIBRARIES  += libsof_src_fma.la
@@ -616,14 +517,11 @@ lib_LTLIBRARIES  += libsof_src_fma.la
 libsof_src_fma_la_SOURCES = $(SRC_SRC)
 
 libsof_src_fma_la_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(FMA_CFLAGS) \
 	$(COMMON_INCDIR)
 
-libsof_src_fma_la_LDFLAGS = \
-	-version-info `echo $(VERSION) | cut -d '.' -f 1` \
-	-no-undefined \
-	-export-dynamic
+libsof_src_fma_la_LDFLAGS = $(host_lib_ldflags)
 
 # libsof_eq_fir
 lib_LTLIBRARIES  += libsof_eq_fir_fma.la
@@ -631,14 +529,11 @@ lib_LTLIBRARIES  += libsof_eq_fir_fma.la
 libsof_eq_fir_fma_la_SOURCES = $(EQ_FIR_SRC)
 
 libsof_eq_fir_fma_la_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(FMA_CFLAGS) \
 	$(COMMON_INCDIR)
 
-libsof_eq_fir_fma_la_LDFLAGS = \
-	-version-info `echo $(VERSION) | cut -d '.' -f 1` \
-	-no-undefined \
-	-export-dynamic
+libsof_eq_fir_fma_la_LDFLAGS = $(host_lib_ldflags)
 
 # libsof_eq_iir
 lib_LTLIBRARIES  += libsof_eq_iir_fma.la
@@ -646,14 +541,11 @@ lib_LTLIBRARIES  += libsof_eq_iir_fma.la
 libsof_eq_iir_fma_la_SOURCES = $(EQ_IIR_SRC)
 
 libsof_eq_iir_fma_la_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(FMA_CFLAGS) \
 	$(COMMON_INCDIR)
 
-libsof_eq_iir_fma_la_LDFLAGS = \
-	-version-info `echo $(VERSION) | cut -d '.' -f 1` \
-	-no-undefined \
-	-export-dynamic
+libsof_eq_iir_fma_la_LDFLAGS = $(host_lib_ldflags)
 
 # libsof_volume
 lib_LTLIBRARIES  += libsof_volume_fma.la
@@ -661,14 +553,11 @@ lib_LTLIBRARIES  += libsof_volume_fma.la
 libsof_volume_fma_la_SOURCES = $(VOLUME_SRC)
 
 libsof_volume_fma_la_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(FMA_CFLAGS) \
 	$(COMMON_INCDIR)
 
-libsof_volume_fma_la_LDFLAGS = \
-	-version-info `echo $(VERSION) | cut -d '.' -f 1` \
-	-no-undefined \
-	-export-dynamic
+libsof_volume_fma_la_LDFLAGS = $(host_lib_ldflags)
 
 # libsof_mux
 lib_LTLIBRARIES  += libsof_mux_fma.la
@@ -676,14 +565,11 @@ lib_LTLIBRARIES  += libsof_mux_fma.la
 libsof_mux_fma_la_SOURCES = mux.c
 
 libsof_mux_fma_la_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(FMA_CFLAGS) \
 	$(COMMON_INCDIR)
 
-libsof_mux_fma_la_LDFLAGS = \
-	-version-info `echo $(VERSION) | cut -d '.' -f 1` \
-	-no-undefined \
-	-export-dynamic
+libsof_mux_fma_la_LDFLAGS = $(host_lib_ldflags)
 
 # libsof_switch
 lib_LTLIBRARIES  += libsof_switch_fma.la
@@ -691,14 +577,11 @@ lib_LTLIBRARIES  += libsof_switch_fma.la
 libsof_switch_fma_la_SOURCES = switch.c
 
 libsof_switch_fma_la_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(FMA_CFLAGS) \
 	$(COMMON_INCDIR)
 
-libsof_switch_fma_la_LDFLAGS = \
-	-version-info `echo $(VERSION) | cut -d '.' -f 1` \
-	-no-undefined \
-	-export-dynamic
+libsof_switch_fma_la_LDFLAGS = $(host_lib_ldflags)
 
 # libsof_mixer
 lib_LTLIBRARIES  += libsof_mixer_fma.la
@@ -706,14 +589,11 @@ lib_LTLIBRARIES  += libsof_mixer_fma.la
 libsof_mixer_fma_la_SOURCES = mixer.c
 
 libsof_mixer_fma_la_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(FMA_CFLAGS) \
 	$(COMMON_INCDIR)
 
-libsof_mixer_fma_la_LDFLAGS = \
-	-version-info `echo $(VERSION) | cut -d '.' -f 1` \
-	-no-undefined \
-	-export-dynamic
+libsof_mixer_fma_la_LDFLAGS = $(host_lib_ldflags)
 
 # libsof_tone
 lib_LTLIBRARIES  += libsof_tone_fma.la
@@ -721,14 +601,11 @@ lib_LTLIBRARIES  += libsof_tone_fma.la
 libsof_tone_fma_la_SOURCES = tone.c
 
 libsof_tone_fma_la_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(FMA_CFLAGS) \
 	$(COMMON_INCDIR)
 
-libsof_tone_fma_la_LDFLAGS = \
-	-version-info `echo $(VERSION) | cut -d '.' -f 1` \
-	-no-undefined \
-	-export-dynamic
+libsof_tone_fma_la_LDFLAGS = $(host_lib_ldflags)
 endif
 
 else
@@ -741,7 +618,7 @@ lib_LIBRARIES  = libsof.a
 libsof_a_SOURCES = $(SOF_SRC)
 
 libsof_a_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(COMMON_INCDIR)
 
 # libsof_src
@@ -750,7 +627,7 @@ lib_LIBRARIES  += libsof_src.a
 libsof_src_a_SOURCES = $(SRC_SRC)
 
 libsof_src_a_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(COMMON_INCDIR)
 
 # libsof_eq_fir
@@ -759,7 +636,7 @@ lib_LIBRARIES  += libsof_eq_fir.a
 libsof_eq_fir_a_SOURCES = $(EQ_FIR_SRC)
 
 libsof_eq_fir_a_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(COMMON_INCDIR)
 
 # libsof_eq_iir
@@ -768,7 +645,7 @@ lib_LIBRARIES  += libsof_eq_iir.a
 libsof_eq_iir_a_SOURCES = $(EQ_IIR_SRC)
 
 libsof_eq_iir_a_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(COMMON_INCDIR)
 
 # libsof_volume
@@ -777,7 +654,7 @@ lib_LIBRARIES  += libsof_volume.a
 libsof_volume_a_SOURCES = $(VOLUME_SRC)
 
 libsof_volume_a_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(COMMON_INCDIR)
 
 # libsof_mux
@@ -786,7 +663,7 @@ lib_LIBRARIES  += libsof_mux.a
 libsof_mux_a_SOURCES = mux.c
 
 libsof_mux_a_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(COMMON_INCDIR)
 
 # libsof_switch
@@ -795,7 +672,7 @@ lib_LIBRARIES  += libsof_switch.a
 libsof_switch_a_SOURCES = switch.c
 
 libsof_switch_a_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(COMMON_INCDIR)
 
 # libsof_mixer
@@ -804,7 +681,7 @@ lib_LIBRARIES  += libsof_mixer.a
 libsof_mixer_a_SOURCES = mixer.c
 
 libsof_mixer_a_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(COMMON_INCDIR)
 
 # libsof_tone
@@ -813,7 +690,7 @@ lib_LIBRARIES  += libsof_tone.a
 libsof_tone_a_SOURCES = tone.c
 
 libsof_tone_a_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(COMMON_INCDIR)
 
 
@@ -824,7 +701,7 @@ lib_LIBRARIES  += libsof_hifi2ep.a
 libsof_hifi2ep_a_SOURCES = $(SOF_SRC)
 
 libsof_hifi2ep_a_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(SSE42_CFLAGS) \
 	$(COMMON_INCDIR)
 
@@ -834,7 +711,7 @@ lib_LIBRARIES  += libsof_src_hifi2ep.a
 libsof_src_hifi2ep_a_SOURCES = $(SRC_SRC)
 
 libsof_src_hifi2ep_a_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(SSE42_CFLAGS) \
 	$(COMMON_INCDIR)
 
@@ -844,7 +721,7 @@ lib_LIBRARIES  += libsof_eq_fir_hifi2ep.a
 libsof_eq_fir_hifi2ep_a_SOURCES = $(EQ_FIR_SRC)
 
 libsof_eq_fir_hifi2ep_a_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(SSE42_CFLAGS) \
 	$(COMMON_INCDIR)
 
@@ -854,7 +731,7 @@ lib_LIBRARIES  += libsof_eq_iir_hifi2ep.a
 libsof_eq_iir_hifi2ep_a_SOURCES = $(EQ_IIR_SRC)
 
 libsof_eq_iir_hifi2ep_a_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(SSE42_CFLAGS) \
 	$(COMMON_INCDIR)
 
@@ -864,7 +741,7 @@ lib_LIBRARIES  += libsof_volume_hifi2ep.a
 libsof_volume_hifi2ep_a_SOURCES = $(VOLUME_SRC)
 
 libsof_volume_hifi2ep_a_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(SSE42_CFLAGS) \
 	$(COMMON_INCDIR)
 
@@ -874,7 +751,7 @@ lib_LIBRARIES  += libsof_mux_hifi2ep.a
 libsof_mux_hifi2ep_a_SOURCES = mux.c
 
 libsof_mux_hifi2ep_a_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(SSE42_CFLAGS) \
 	$(COMMON_INCDIR)
 
@@ -884,7 +761,7 @@ lib_LIBRARIES  += libsof_switch_hifi2ep.a
 libsof_switch_hifi2ep_a_SOURCES = switch.c
 
 libsof_switch_hifi2ep_a_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(SSE42_CFLAGS) \
 	$(COMMON_INCDIR)
 
@@ -894,7 +771,7 @@ lib_LIBRARIES  += libsof_mixer_hifi2ep.a
 libsof_mixer_hifi2ep_a_SOURCES = mixer.c
 
 libsof_mixer_hifi2ep_a_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(SSE42_CFLAGS) \
 	$(COMMON_INCDIR)
 
@@ -904,7 +781,7 @@ lib_LIBRARIES  += libsof_tone_hifi2ep.a
 libsof_tone_hifi2ep_a_SOURCES = tone.c
 
 libsof_tone_hifi2ep_a_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(SSE42_CFLAGS) \
 	$(COMMON_INCDIR)
 endif
@@ -916,7 +793,7 @@ lib_LIBRARIES  += libsof_hifi3.a
 libsof_hifi3_a_SOURCES = $(COMP_SRC)
 
 libsof_hifi3_a_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(SSE42_CFLAGS) \
 	$(COMMON_INCDIR)
 
@@ -926,7 +803,7 @@ lib_LIBRARIES  += libsof_src_hifi3.a
 libsof_src_hifi3_a_SOURCES = $(SRC_SRC)
 
 libsof_src_hifi3_a_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(SSE42_CFLAGS) \
 	$(COMMON_INCDIR)
 
@@ -936,7 +813,7 @@ lib_LIBRARIES  += libsof_eq_fir_hifi3.a
 libsof_eq_fir_hifi3_a_SOURCES = $(EQ_FIR_SRC)
 
 libsof_eq_fir_hifi3_a_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(SSE42_CFLAGS) \
 	$(COMMON_INCDIR)
 
@@ -946,7 +823,7 @@ lib_LIBRARIES  += libsof_eq_iir_hifi3.a
 libsof_eq_iir_hifi3_a_SOURCES = $(EQ_IIR_SRC)
 
 libsof_eq_iir_hifi3_a_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(SSE42_CFLAGS) \
 	$(COMMON_INCDIR)
 
@@ -956,7 +833,7 @@ lib_LIBRARIES  += libsof_volume_hifi3.a
 libsof_volume_hifi3_a_SOURCES = $(VOLUME_SRC)
 
 libsof_volume_hifi3_a_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(SSE42_CFLAGS) \
 	$(COMMON_INCDIR)
 
@@ -966,7 +843,7 @@ lib_LIBRARIES  += libsof_mux_hifi3.a
 libsof_mux_hifi3_a_SOURCES = mux.c
 
 libsof_mux_hifi3_a_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(SSE42_CFLAGS) \
 	$(COMMON_INCDIR)
 
@@ -976,7 +853,7 @@ lib_LIBRARIES  += libsof_switch_hifi3.a
 libsof_switch_hifi3_a_SOURCES = switch.c
 
 libsof_switch_hifi3_a_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(SSE42_CFLAGS) \
 	$(COMMON_INCDIR)
 
@@ -986,7 +863,7 @@ lib_LIBRARIES  += libsof_mixer_hifi3.a
 libsof_mixer_hifi3_a_SOURCES = mixer.c
 
 libsof_mixer_hifi3_a_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(SSE42_CFLAGS) \
 	$(COMMON_INCDIR)
 
@@ -996,7 +873,7 @@ lib_LIBRARIES  += libsof_tone_hifi3.a
 libsof_tone_hifi3_a_SOURCES = tone.c
 
 libsof_tone_hifi3_a_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(SSE42_CFLAGS) \
 	$(COMMON_INCDIR)
 endif
@@ -1033,7 +910,7 @@ libaudio_a_SOURCES = \
 	buffer.c
 
 libaudio_a_CFLAGS = \
-	$(ARCH_CFLAGS) \
+	$(lib_cflags) \
 	$(COMMON_INCDIR)
 
 endif

--- a/src/drivers/Makefile.am
+++ b/src/drivers/Makefile.am
@@ -38,6 +38,7 @@ libdrivers_a_SOURCES += \
 endif
 
 libdrivers_a_CFLAGS = \
+	$(AM_CFLAGS) \
 	$(ARCH_CFLAGS) \
 	$(PLATFORM_INCDIR) \
 	$(SOF_INCDIR) \

--- a/src/host/Makefile.am
+++ b/src/host/Makefile.am
@@ -4,8 +4,8 @@ SOF_INC = $(prefix)/include/sof
 DEFINE = -DSOF_INC=\"$(SOF_INC)\"
 
 AM_CPPFLAGS = -I $(SOF_INC) $(COMMON_INCDIR) $(DEFINE)
-AM_CFLAGS = -g -Wall
-AM_LDFLAGS = -L../ipc -L../audio/.libs
+AM_CFLAGS += -g -Wall
+AM_LDFLAGS += -L../ipc -L../audio/.libs
 
 bin_PROGRAMS = testbench
 

--- a/src/init/Makefile.am
+++ b/src/init/Makefile.am
@@ -4,6 +4,7 @@ libinit_a_SOURCES = \
 	init.c
 
 libinit_a_CFLAGS = \
+	$(AM_CFLAGS) \
 	$(ARCH_CFLAGS) \
 	$(ARCH_INCDIR) \
 	$(PLATFORM_INCDIR) \

--- a/src/ipc/Makefile.am
+++ b/src/ipc/Makefile.am
@@ -5,11 +5,13 @@ libsof_ipc_la_SOURCES = \
 	ipc.c
 
 libsof_ipc_la_LDFLAGS = \
+	$(AM_LDFLAGS) \
 	-version-info `echo $(VERSION) | cut -d '.' -f 1` \
 	-no-undefined \
 	-export-dynamic
 
 libsof_ipc_la_CFLAGS = \
+	$(AM_CFLAGS) \
 	$(ARCH_CFLAGS) \
 	$(COMMON_INCDIR)
 else
@@ -67,6 +69,7 @@ libsof_ipc_a_SOURCES = \
 endif
 
 libsof_ipc_a_CFLAGS = \
+	$(AM_CFLAGS) \
 	$(ARCH_CFLAGS) \
 	$(COMMON_INCDIR)
 endif

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -13,6 +13,7 @@ libcore_a_SOURCES = \
 	pm_runtime.c
 
 libcore_a_CFLAGS = \
+	$(AM_CFLAGS) \
 	$(ARCH_CFLAGS) \
 	$(ARCH_INCDIR) \
 	$(PLATFORM_INCDIR) \
@@ -22,6 +23,7 @@ libdma_a_SOURCES = \
 	dma.c
 
 libdma_a_CFLAGS = \
+	$(AM_CFLAGS) \
 	$(ARCH_CFLAGS) \
 	$(ARCH_INCDIR) \
 	$(PLATFORM_INCDIR) \

--- a/src/math/Makefile.am
+++ b/src/math/Makefile.am
@@ -6,6 +6,7 @@ libsof_math_la_SOURCES = \
 	numbers.c
 
 libsof_math_la_CFLAGS = \
+	$(AM_CFLAGS) \
 	$(ARCH_CFLAGS) \
 	$(COMMON_INCDIR)
 else
@@ -16,6 +17,7 @@ libsof_math_a_SOURCES = \
 	numbers.c
 
 libsof_math_a_CFLAGS = \
+	$(AM_CFLAGS) \
 	$(ARCH_CFLAGS) \
 	$(COMMON_INCDIR)
 endif

--- a/src/platform/apollolake/Makefile.am
+++ b/src/platform/apollolake/Makefile.am
@@ -17,6 +17,7 @@ libplatform_a_SOURCES = \
 	pm_runtime.c
 
 libplatform_a_CFLAGS = \
+	$(AM_CFLAGS) \
 	$(ARCH_CFLAGS) \
 	$(ARCH_INCDIR) \
 	$(PLATFORM_INCDIR) \
@@ -28,6 +29,7 @@ module_SOURCES = \
 	base_module.c
 
 module_CFLAGS = \
+	$(AM_CFLAGS) \
 	$(ARCH_INCDIR) \
 	$(PLATFORM_INCDIR) \
 	$(SOF_INCDIR)
@@ -36,6 +38,7 @@ boot_module_SOURCES = \
 	boot_module.c
 
 boot_module_CFLAGS = \
+	$(AM_CFLAGS) \
 	$(ARCH_INCDIR) \
 	$(PLATFORM_INCDIR) \
 	$(SOF_INCDIR)

--- a/src/platform/baytrail/Makefile.am
+++ b/src/platform/baytrail/Makefile.am
@@ -13,6 +13,7 @@ libplatform_a_SOURCES = \
 	memory.c
 
 libplatform_a_CFLAGS = \
+	$(AM_CFLAGS) \
 	$(ARCH_CFLAGS) \
 	$(ARCH_INCDIR) \
 	$(PLATFORM_INCDIR) \

--- a/src/platform/cannonlake/Makefile.am
+++ b/src/platform/cannonlake/Makefile.am
@@ -17,6 +17,7 @@ libplatform_a_SOURCES = \
 	pm_runtime.c
 
 libplatform_a_CFLAGS = \
+	$(AM_CFLAGS) \
 	$(ARCH_CFLAGS) \
 	$(ARCH_INCDIR) \
 	$(PLATFORM_INCDIR) \
@@ -28,6 +29,7 @@ module_SOURCES = \
 	base_module.c
 
 module_CFLAGS = \
+	$(AM_CFLAGS) \
 	$(ARCH_INCDIR) \
 	$(PLATFORM_INCDIR) \
 	$(SOF_INCDIR)
@@ -36,6 +38,7 @@ boot_module_SOURCES = \
 	boot_module.c
 
 boot_module_CFLAGS = \
+	$(AM_CFLAGS) \
 	$(ARCH_INCDIR) \
 	$(PLATFORM_INCDIR) \
 	$(SOF_INCDIR)

--- a/src/platform/haswell/Makefile.am
+++ b/src/platform/haswell/Makefile.am
@@ -13,6 +13,7 @@ libplatform_a_SOURCES = \
 	memory.c
 
 libplatform_a_CFLAGS = \
+	$(AM_CFLAGS) \
 	$(ARCH_CFLAGS) \
 	$(ARCH_INCDIR) \
 	$(PLATFORM_INCDIR) \

--- a/src/tasks/Makefile.am
+++ b/src/tasks/Makefile.am
@@ -4,6 +4,7 @@ libtasks_a_SOURCES = \
 	audio.c
 
 libtasks_a_CFLAGS = \
+	$(AM_CFLAGS) \
 	$(ARCH_CFLAGS) \
 	$(ARCH_INCDIR) \
 	$(PLATFORM_INCDIR) \


### PR DESCRIPTION
Our autotools configs shouldn't use user variables such as CFLAGS and LDFLAGS, so I moved their contents to AM_CFLAGS and AM_LDFLAGS and updated all affected makefiles.

Also I had to add AM_CCASFLAGS which is used for .S files, previously CFLAGS were added while compiling these files what can be misleading and we may want to not have the same CFLAGS for c and .S sources. So now we have to set AM_CFLAGS for c files and AM_CCASFLAGS for as files.

AM_CCASFLAGS are intially set to the same value as AM_CFLAGS for backward compatibility, but it would be good to check if we really need all these flags for our .S files.

Order of the flags passed to tools changed, because AM/target flags are added before user CFLAGS but binaries look to be the same, checked with:
```
xt-objdump -dz src/arch/xtensa/sof | sha1sum
xt-objdump -dz src/arch/xtensa/boot_ldr | sha1sum
```

Signed-off-by: Janusz Jankowski <janusz.jankowski@linux.intel.com>