### PR TITLE
ipc: add SOF_IPC_PM_CORE_ENABLE message

### DIFF
--- a/src/include/uapi/ipc.h
+++ b/src/include/uapi/ipc.h
@@ -101,6 +101,7 @@
 #define SOF_IPC_PM_CLK_SET			SOF_CMD_TYPE(0x004)
 #define SOF_IPC_PM_CLK_GET			SOF_CMD_TYPE(0x005)
 #define SOF_IPC_PM_CLK_REQ			SOF_CMD_TYPE(0x006)
+#define SOF_IPC_PM_CORE_ENABLE			SOF_CMD_TYPE(0x007)
 
 /* component runtime config - multiple different types */
 #define SOF_IPC_COMP_SET_VALUE			SOF_CMD_TYPE(0x001)
@@ -815,6 +816,12 @@ struct sof_ipc_pm_ctx {
 	uint32_t num_elems;
 	uint32_t size;
 	struct sof_ipc_pm_ctx_elem elems[];
+};
+
+/* enable or disable cores - SOF_IPC_PM_CORE_ENABLE */
+struct sof_ipc_pm_core_config {
+	struct sof_ipc_hdr hdr;
+	uint32_t enable_mask;
 };
 
 /*

--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -58,6 +58,7 @@
 #include <uapi/ipc.h>
 #include <sof/intel-ipc.h>
 #include <sof/dma-trace.h>
+#include <sof/cpu.h>
 #include <config.h>
 
 #define iGS(x) ((x >> SOF_GLB_TYPE_SHIFT) & 0xf)
@@ -588,6 +589,25 @@ static int ipc_pm_context_restore(uint32_t header)
 	return 0;
 }
 
+static int ipc_pm_core_enable(uint32_t header)
+{
+	struct sof_ipc_pm_core_config *pm_core_config = _ipc->comp_data;
+	int i = 0;
+
+	trace_ipc("PMc");
+
+	for (i = 0; i < PLATFORM_CORE_COUNT; i++) {
+		if (i != PLATFORM_MASTER_CORE_ID) {
+			if (pm_core_config->enable_mask & (1 << i))
+				cpu_enable_core(i);
+			else
+				cpu_disable_core(i);
+		}
+	}
+
+	return 0;
+}
+
 static int ipc_glb_pm_message(uint32_t header)
 {
 	uint32_t cmd = (header & SOF_CMD_TYPE_MASK) >> SOF_CMD_TYPE_SHIFT;
@@ -599,6 +619,8 @@ static int ipc_glb_pm_message(uint32_t header)
 		return ipc_pm_context_restore(header);
 	case iCS(SOF_IPC_PM_CTX_SIZE):
 		return ipc_pm_context_size(header);
+	case iCS(SOF_IPC_PM_CORE_ENABLE):
+		return ipc_pm_core_enable(header);
 	case iCS(SOF_IPC_PM_CLK_SET):
 	case iCS(SOF_IPC_PM_CLK_GET):
 	case iCS(SOF_IPC_PM_CLK_REQ):


### PR DESCRIPTION
Adds definition and implementation of new IPC
message, which allows to enable and disable cores
based on passed enable_mask.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>