### PR TITLE
trace: Refine trace function in irq function

### DIFF
--- a/src/ipc/apl-ipc.c
+++ b/src/ipc/apl-ipc.c
@@ -68,7 +68,7 @@ static void irq_handler(void *arg)
 
 	/* new message from host */
 	if (dipct & IPC_DIPCT_BUSY) {
-		trace_ipc("Nms");
+		tracev_ipc("Nms");
 
 		/* mask Busy interrupt */
 		ipc_write(IPC_DIPCCTL, ipc_read(IPC_DIPCCTL) & ~IPC_DIPCCTL_IPCTBIE);

--- a/src/ipc/cnl-ipc.c
+++ b/src/ipc/cnl-ipc.c
@@ -69,7 +69,7 @@ static void irq_handler(void *arg)
 
 	/* new message from host */
 	if (dipctdr & IPC_DIPCTDR_BUSY) {
-		trace_ipc("Nms");
+		tracev_ipc("Nms");
 
 		/* mask Busy interrupt */
 		ipc_write(IPC_DIPCCTL, ipc_read(IPC_DIPCCTL) & ~IPC_DIPCCTL_IPCTBIE);


### PR DESCRIPTION
Change trace_ipc to tracev_ipc because it is too many
in irq function

Signed-off-by: Rander Wang <rander.wang@linux.intel.com>