### PR TITLE
hda-dma: wait for buffer full after starting render

### DIFF
--- a/src/drivers/hda-dma.c
+++ b/src/drivers/hda-dma.c
@@ -212,6 +212,14 @@ static int hda_dma_start(struct dma *dma, int channel)
 
 	/* full buffer is copied at startup */
 	p->chan[channel].desc_avail = p->chan[channel].desc_count;
+
+	/* for render let's wait for buffer full */
+	if (p->chan[channel].direction == DMA_DIR_HMEM_TO_LMEM) {
+		do {
+			idelay(PLATFORM_DEFAULT_DELAY);
+			dgcs = host_dma_reg_read(dma, channel, DGCS);
+		} while (!(dgcs & DGCS_BF));
+	}
 out:
 	spin_unlock_irq(&dma->lock, flags);
 	return ret;


### PR DESCRIPTION
Host DMA should wait for buffer full after starting render
to avoid empty samples at the beginning. Temporary solution
until DMA unified flow will be implemented.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>