### PR TITLE
test: fix CFLAGS and LDFLAGS warnings

### DIFF
--- a/test/cmocka/Makefile.am
+++ b/test/cmocka/Makefile.am
@@ -6,10 +6,12 @@ if BUILD_XTENSA
 LOG_COMPILER = xt-run
 endif
 
-AM_CFLAGS = \
+override AM_CFLAGS := \
+	$(filter-out -nostdlib,$(AM_CFLAGS)) \
 	$(SOF_INCDIR)
 
-AM_LDFLAGS =
+override AM_LDFLAGS := \
+	$(filter-out -nostdlib,$(AM_LDFLAGS))
 
 if HAVE_CMOCKA_PREFIX
 AM_CFLAGS += -I$(CMOCKA_PREFIX)/include
@@ -25,9 +27,6 @@ endif
 if BUILD_HOST
 AM_CFLAGS += -I../../src/arch/host/include
 endif
-
-CFLAGS := $(filter-out -nostdlib,$(CFLAGS))
-LDFLAGS := $(filter-out -nostdlib,$(LDFLAGS))
 
 LDADD = -lcmocka
 

--- a/test/cmocka/src/lib/alloc/mock.c
+++ b/test/cmocka/src/lib/alloc/mock.c
@@ -26,6 +26,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *
  * Author: Slawomir Blauciak <slawomir.blauciak@linux.intel.com>
+ *         Janusz Jankowski <janusz.jankowski@linux.intel.com>
  */
 
 #include <stdint.h>
@@ -38,11 +39,13 @@ struct dma_sg_config;
 int dma_copy_from_host(struct dma_copy *dc, struct dma_sg_config *host_sg,
 		       int32_t host_offset, void *local_ptr, int32_t size)
 {
+	return 0;
 }
 
 int dma_copy_to_host(struct dma_copy *dc, struct dma_sg_config *host_sg,
 		     int32_t host_offset, void *local_ptr, int32_t size)
 {
+	return 0;
 }
 
 void _trace_event_mbox_atomic(uint32_t e)


### PR DESCRIPTION
Fixes warnings related to CFLAGS and LDFLAGS in cmocka makefiles.
Also had to do minor fix in mock.c, because now when flags are fixed it wouldn't compile because of warnings.

Signed-off-by: Janusz Jankowski <janusz.jankowski@linux.intel.com>