### PR TITLE
trace: fix IPC timeout issue on APL

### DIFF
--- a/src/lib/dma-trace.c
+++ b/src/lib/dma-trace.c
@@ -87,13 +87,13 @@ static uint64_t trace_work(void *data, uint64_t delay)
 
 	/* update host pointer and check for wrap */
 	d->host_offset += size;
-	if (d->host_offset == d->host_size)
-		d->host_offset = 0;
+	if (d->host_offset >= d->host_size)
+		d->host_offset -= d->host_size;
 
 	/* update local pointer and check for wrap */
 	buffer->r_ptr += size;
-	if (buffer->r_ptr == buffer->end_addr)
-		buffer->r_ptr = buffer->addr;
+	if (buffer->r_ptr >= buffer->end_addr)
+		buffer->r_ptr -= DMA_TRACE_LOCAL_SIZE;
 
 out:
 	spin_lock_irq(&d->lock, flags);


### PR DESCRIPTION
Refine read pointer, it should rewind to head when it is at tail

Test on APL & BDW

Signed-off-by: Rander Wang <rander.wang@linux.intel.com>
Signed-off-by: Pan Xiuli <xiuli.pan@linux.intel.com>