### PR TITLE
volume: fix condition in volume_ctrl_set_cmd

### DIFF
--- a/src/audio/volume.c
+++ b/src/audio/volume.c
@@ -286,7 +286,7 @@ static int volume_ctrl_set_cmd(struct comp_dev *dev,
 	int j;
 
 	/* validate */
-	if (cdata->num_elems == 0 || cdata->num_elems >= SOF_IPC_MAX_CHANNELS) {
+	if (cdata->num_elems == 0 || cdata->num_elems > SOF_IPC_MAX_CHANNELS) {
 		trace_volume_error("gs0");
 		return -EINVAL;
 	}


### PR DESCRIPTION
volume_ctrl_set_cmd should accept 8 channels.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>