### PR TITLE
hda-dma: wait for L1 exit instead of buffer full

### DIFF
--- a/src/drivers/hda-dma.c
+++ b/src/drivers/hda-dma.c
@@ -213,13 +213,7 @@ static int hda_dma_start(struct dma *dma, int channel)
 	/* full buffer is copied at startup */
 	p->chan[channel].desc_avail = p->chan[channel].desc_count;
 
-	/* for render let's wait for buffer full */
-	if (p->chan[channel].direction == DMA_DIR_HMEM_TO_LMEM) {
-		do {
-			idelay(PLATFORM_DEFAULT_DELAY);
-			dgcs = host_dma_reg_read(dma, channel, DGCS);
-		} while (!(dgcs & DGCS_BF));
-	}
+	pm_runtime_put(PM_RUNTIME_HOST_DMA_L1);
 out:
 	spin_unlock_irq(&dma->lock, flags);
 	return ret;


### PR DESCRIPTION
Changes waiting condition for Host Output DMA start.
Let's wait for L1 exit instead of buffer full.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>