### PR TITLE
configure: fix flags for unit tests

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -89,13 +89,13 @@ case "$with_arch" in
 
 	# automake FLAGS defined here
 	AM_CFLAGS="-fno-inline-functions -nostdlib -mlongcalls"
-	AM_LDFLAGS="-nostdlib"
-	AM_CCASFLAGS="-fno-inline-functions -nostdlib -mlongcalls"
+	AM_LDFLAGS=""
+	AM_CCASFLAGS=""
 
 	# GCC needs these additional flags on top of any user flags.
 	CFLAGS="${CFLAGS:+$CFLAGS } -O2 -g -Wall -Werror -Wl,-EL -Wmissing-prototypes"
-	LDFLAGS="${LDFLAGS:+$LDFLAGS } ${AM_LDFLAGS}"
-	CCASFLAGS="${CCASFLAGS:+$CCASFLAGS } ${AM_CCASFLAGS}"
+	LDFLAGS="${LDFLAGS:+$LDFLAGS } -nostdlib"
+	CCASFLAGS="${CCASFLAGS:+$CCASFLAGS } -fno-inline-functions -nostdlib -mlongcalls"
 
 	ARCH="xtensa"
 	AC_SUBST(ARCH)

--- a/test/cmocka/Makefile.am
+++ b/test/cmocka/Makefile.am
@@ -6,6 +6,9 @@ if BUILD_XTENSA
 LOG_COMPILER = xt-run
 endif
 
+# cmocka needs stdlib
+override LDFLAGS := $(filter-out -nostdlib,$(LDFLAGS))
+
 override AM_CFLAGS := \
 	$(filter-out -nostdlib,$(AM_CFLAGS)) \
 	$(SOF_INCDIR)


### PR DESCRIPTION
-nostdlib breaks UT because cmoka need stdlib
At all "-nostdlib" was only flag that was required to not break gcc builds, because for some reason gcc needs it, however I'm not gonna mess with it more atm.
I also removed flags that was already forced.

Requires volume tests fix: https://github.com/thesofproject/sof/pull/112

Signed-off-by: Janusz Jankowski <janusz.jankowski@linux.intel.com>