### PR TITLE
volume: Set max volume value from IPC for volume module

### DIFF
--- a/src/audio/volume.h
+++ b/src/audio/volume.h
@@ -78,6 +78,9 @@
 /** \brief Volume maximum value. */
 #define VOL_MAX		(1 << 16)
 
+/** \brief Volume 0dB value. */
+#define VOL_ZERO_DB	(1 << 16)
+
 /** \brief Volume minimum value. */
 #define VOL_MIN		0
 
@@ -94,6 +97,8 @@ struct comp_data {
 	uint32_t volume[SOF_IPC_MAX_CHANNELS];	/**< current volume */
 	uint32_t tvolume[SOF_IPC_MAX_CHANNELS];	/**< target volume */
 	uint32_t mvolume[SOF_IPC_MAX_CHANNELS];	/**< mute volume */
+	uint32_t min_volume;			/**< minimum volume level */
+	uint32_t max_volume;			/**< maximum volume level */
 	void (*scale_vol)(struct comp_dev *dev, struct comp_buffer *sink,
 		struct comp_buffer *source);	/**< volume processing function */
 	struct work volwork;			/**< volume scheduled work function */

--- a/src/include/uapi/ipc.h
+++ b/src/include/uapi/ipc.h
@@ -689,8 +689,8 @@ struct sof_ipc_comp_volume {
 	struct sof_ipc_comp comp;
 	struct sof_ipc_comp_config config;
 	uint32_t channels;
-	int32_t min_value;
-	int32_t max_value;
+	uint32_t min_value;
+	uint32_t max_value;
 	enum sof_volume_ramp ramp;
 	uint32_t initial_ramp;	/* ramp space in ms */
 }  __attribute__((packed));


### PR DESCRIPTION
volume: Set max volume value from sof_ipc_comp_volume IPC for volume module

Signed-off-by: Kamil Kulesza <kamil.kulesza@linux.intel.com>