### PR TITLE
[RFC]host:remove the useless state set.

### DIFF
--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -727,7 +727,6 @@ static int host_pointer_reset(struct comp_dev *dev)
 	hd->local_pos = 0;
 	hd->report_pos = 0;
 	dev->position = 0;
-	comp_set_state(dev, COMP_TRIGGER_RESET);
 
 	return 0;
 }
@@ -740,7 +739,6 @@ static int host_stop(struct comp_dev *dev)
 	/* reset elements, to let next start from original one */
 	host_elements_reset(dev);
 
-	dev->state = COMP_STATE_PAUSED;
 	return 0;
 }
 


### PR DESCRIPTION
1. when the stop command comes, the host's state
is set in host_trigger() function with PREPARE.
it should not be set with PAUSED in host_stop().
2. when the host_pointer_reset() called, it does
not need to set host state to READY state.the caller
will do this job.

Signed-off-by: Wu Zhigang <zhigang.wu@linux.intel.com>