### PR TITLE
 Volume: refine condition in volume_ctrl_get_cmd 

### DIFF
--- a/src/audio/volume.c
+++ b/src/audio/volume.c
@@ -350,7 +350,7 @@ static int volume_ctrl_get_cmd(struct comp_dev *dev,
 	int j;
 
 	/* validate */
-	if (cdata->num_elems == 0 || cdata->num_elems >= SOF_IPC_MAX_CHANNELS) {
+	if (cdata->num_elems == 0 || cdata->num_elems > SOF_IPC_MAX_CHANNELS) {
 		trace_volume_error("gc0");
 		tracev_value(cdata->num_elems);
 		return -EINVAL;


### PR DESCRIPTION
Fix the check for maximum number of channels to be in the correct range.

Signed-off-by: Rander Wang <rander.wang@linux.intel.com>