### PR TITLE
ipc: Refine some IPC data structures to make its size 4bytes aligned

### DIFF
--- a/src/include/uapi/ipc.h
+++ b/src/include/uapi/ipc.h
@@ -298,6 +298,7 @@ struct sof_ipc_dai_dmic_pdm_ctrl {
 	uint16_t polarity_mic_b; /* Optionally invert mic B signal (0 or 1) */
 	uint16_t clk_edge; /* Optionally swap data clock edge (0 or 1) */
 	uint16_t skew; /* Adjust PDM data sampling vs. clock (0..15) */
+	uint16_t pad; /* Make sure the total size is 4 bytes aligned */
 } __attribute__((packed));
 
 /* This struct contains the global settings for all 2ch PDM controllers. The
@@ -832,6 +833,7 @@ struct sof_ipc_fw_version {
 	uint8_t date[12];
 	uint8_t time[10];
 	uint8_t tag[6];
+	uint8_t pad[2]; /* Make sure the total size is 4 bytes aligned */
 } __attribute__((packed));
 
 /* FW ready Message - sent by firmware when boot has completed */


### PR DESCRIPTION
Host communicates with dsp by sending or receiving data in memory
windows which are in PCI MMIO space. Some platforms like ICL require
the transaction size is 4bytes aligned. So it is better to make the
data size 4bytes aligned to make it work on all platforms.

I test on BDW and ICL, pass

Please make sure it is merged with :https://github.com/thesofproject/linux/pull/48,
or you would get kernel panic

Signed-off-by: Rander Wang <rander.wang@linux.intel.com>