### PR TITLE
dai index alignment

### DIFF
--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -191,7 +191,7 @@ static struct comp_dev *dai_new(struct sof_ipc_comp *comp)
 
 	comp_set_drvdata(dev, dd);
 
-	dd->dai = dai_get(dai->type, dai->index);
+	dd->dai = dai_get(dai->type, dai->dai_index);
 	if (dd->dai == NULL) {
 		trace_dai_error("eDg");
 		goto error;

--- a/src/audio/pipeline_static.c
+++ b/src/audio/pipeline_static.c
@@ -89,7 +89,7 @@
 	{.comp = scomp, .no_irq = hno_irq, \
 	 .dmac_config = hconfig}
 #define SPIPE_DAI(scomp, ddai_type, ddai_idx, ddmac, dchan, dconfig) \
-	{.comp = scomp, .type = ddai_type, .index = ddai_idx, \
+	{.comp = scomp, .type = ddai_type, .dai_index = ddai_idx, \
 	 .dmac_config = dconfig}
 #define SPIPE_VOL(scomp, vmin, vmax) \
 	{.comp = scomp, .min_value = vmin, .max_value = vmax}

--- a/src/drivers/apl-ssp.c
+++ b/src/drivers/apl-ssp.c
@@ -619,8 +619,8 @@ static inline int ssp_set_config(struct dai *dai,
 	/* TODO: move this into M/N driver */
 	mn_reg_write(0x0, mdivc);
 	mn_reg_write(0x80 + config->ssp.mclk_id * 0x4, mdivr);
-	mn_reg_write(0x100 + config->id * 0x8 + 0x0, i2s_m);
-	mn_reg_write(0x100 + config->id * 0x8 + 0x4, i2s_n);
+	mn_reg_write(0x100 + config->dai_index * 0x8 + 0x0, i2s_m);
+	mn_reg_write(0x100 + config->dai_index * 0x8 + 0x4, i2s_n);
 
 	ssp->state[DAI_DIR_PLAYBACK] = COMP_STATE_PREPARE;
 	ssp->state[DAI_DIR_CAPTURE] = COMP_STATE_PREPARE;

--- a/src/include/uapi/ipc.h
+++ b/src/include/uapi/ipc.h
@@ -340,7 +340,7 @@ struct sof_ipc_dai_dmic_params {
 struct sof_ipc_dai_config {
 	struct sof_ipc_hdr hdr;
 	enum sof_ipc_dai_type type;
-	uint32_t id;	/* physical number if more than 1 of this type */
+	uint32_t dai_index; /* index of this type dai */
 
 	/* physical protocol and clocking */
 	uint16_t format;	/* SOF_DAI_FMT_ */
@@ -665,7 +665,7 @@ struct sof_ipc_comp_dai {
 	struct sof_ipc_comp comp;
 	struct sof_ipc_comp_config config;
 	enum sof_ipc_stream_direction direction;
-	uint32_t index;
+	uint32_t dai_index; /* index of this type dai */
 	enum sof_ipc_dai_type type;
 	uint32_t dmac_config; /* DMA engine specific */
 }  __attribute__((packed));

--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -489,11 +489,11 @@ static int ipc_dai_config(uint32_t header)
 	trace_ipc("DsF");
 
 	/* get DAI */
-	dai = dai_get(config->type, config->id);
+	dai = dai_get(config->type, config->dai_index);
 	if (dai == NULL) {
 		trace_ipc_error("eDi");
 		trace_error_value(config->type);
-		trace_error_value(config->id);
+		trace_error_value(config->dai_index);
 		return -ENODEV;
 	}
 


### PR DESCRIPTION
dai_get function only need type and index, make index filed unified to
dai_index to avoid misleading in sof_ipc_dai_config and sof_ipc_dai_config.

Structure name change only, will have no depend on related patch sets:
https://github.com/thesofproject/soft/pull/40
https://github.com/thesofproject/linux/pull/42