### PR TITLE
exception: fix ipc timeout issue on bdw

### DIFF
--- a/src/arch/xtensa/init.c
+++ b/src/arch/xtensa/init.c
@@ -65,8 +65,6 @@ static void register_exceptions(void)
 	_xtos_set_exception_handler(
 		EXCCAUSE_LOAD_STORE_ERROR, (void *)&exception);
 	_xtos_set_exception_handler(
-		EXCCAUSE_LEVEL1_INTERRUPT, (void *)&exception);
-	_xtos_set_exception_handler(
 		EXCCAUSE_ALLOCA, (void *)&exception);
 	_xtos_set_exception_handler(
 		EXCCAUSE_DIVIDE_BY_ZERO, (void *)&exception);


### PR DESCRIPTION
It is a regression issue. L1 interrupt is used by SSP on bdw,
so don't register it as a exception.

Signed-off-by: Rander Wang <rander.wang@linux.intel.com>