### PR TITLE
apl-ssp: setting additional bits in ssp registers

### DIFF
--- a/src/include/sof/ssp.h
+++ b/src/include/sof/ssp.h
@@ -134,9 +134,13 @@ extern const struct dai_ops ssp_ops;
 #elif defined CONFIG_APOLLOLAKE || defined CONFIG_CANNONLAKE \
 		|| defined CONFIG_HASWELL || defined CONFIG_BROADWELL
 #define SSCR2_TURM1		BIT(1)
+#define SSCR2_PSPSRWFDFD	BIT(3)
+#define SSCR2_PSPSTWFDFD	BIT(4)
 #define SSCR2_SDFD		BIT(14)
 #define SSCR2_SDPM		BIT(16)
 #define SSCR2_LJDFD		BIT(17)
+#define SSCR2_MMRATF		BIT(18)
+#define SSCR2_SMTATF		BIT(19)
 #endif
 
 

--- a/src/include/uapi/ipc.h
+++ b/src/include/uapi/ipc.h
@@ -226,6 +226,23 @@ struct sof_ipc_compound_hdr {
 #define SOF_DAI_FMT_INV_MASK		0x0f00
 #define SOF_DAI_FMT_MASTER_MASK		0xf000
 
+ /* ssc1: TINTE */
+#define SOF_DAI_INTEL_SSP_QUIRK_TINTE		(1 << 0)
+ /* ssc1: PINTE */
+#define SOF_DAI_INTEL_SSP_QUIRK_PINTE		(1 << 1)
+ /* ssc2: SMTATF */
+#define SOF_DAI_INTEL_SSP_QUIRK_SMTATF		(1 << 2)
+ /* ssc2: MMRATF */
+#define SOF_DAI_INTEL_SSP_QUIRK_MMRATF		(1 << 3)
+ /* ssc2: PSPSTWFDFD */
+#define SOF_DAI_INTEL_SSP_QUIRK_PSPSTWFDFD	(1 << 4)
+ /* ssc2: PSPSRWFDFD */
+#define SOF_DAI_INTEL_SSP_QUIRK_PSPSRWFDFD	(1 << 5)
+ /* here is the possibility to define others aux macros */
+
+
+#define SOF_DAI_INTEL_SSP_FRAME_PULSE_WIDTH_MAX		38
+
 /** \brief Types of DAI */
 enum sof_ipc_dai_type {
 	SOF_DAI_INTEL_NONE = 0,	/**< None */
@@ -259,8 +276,10 @@ struct sof_ipc_dai_ssp_params {
 	uint32_t bclk_keep_active;
 	uint32_t fs_keep_active;
 
-	//uint32_t quirks; // FIXME: is 32 bits enough ?
+	uint16_t frame_pulse_width;
+	uint32_t quirks; // FIXME: is 32 bits enough ?
 
+	uint16_t padding;
 	/* private data, e.g. for quirks */
 	//uint32_t pdata[10]; // FIXME: would really need ~16 u32
 } __attribute__((packed));


### PR DESCRIPTION
I've added possibility to set some additional bits in ssp registers.
In reference to this there was a need to add quirk field in
sof_ipc_dai_ssp_params struct.

Signed-off-by: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>