### PR TITLE
DMIC: Fix mistake in comment and add check for supported word lengths

### DIFF
--- a/src/drivers/dmic.c
+++ b/src/drivers/dmic.c
@@ -1150,6 +1150,18 @@ static int dmic_set_config(struct dai *dai, struct sof_ipc_dai_config *config)
 		goto finish;
 	}
 
+	if (prm->fifo_bits_a != 16 && prm->fifo_bits_a != 32) {
+		trace_dmic_error("fba");
+		ret = -EINVAL;
+		goto finish;
+	}
+
+	if (prm->fifo_bits_b != 16 && prm->fifo_bits_b != 32) {
+		trace_dmic_error("fbb");
+		ret = -EINVAL;
+		goto finish;
+	}
+
 	/* Match and select optimal decimators configuration for FIFOs A and B
 	 * paths. This setup phase is still abstract. Successful completion
 	 * points struct cfg to FIR coefficients and contains the scale value

--- a/src/include/uapi/ipc.h
+++ b/src/include/uapi/ipc.h
@@ -329,8 +329,8 @@ struct sof_ipc_dai_dmic_params {
 	uint32_t fifo_fs_a;  /* FIFO A sample rate in Hz (8000..96000) */
 	uint32_t fifo_fs_b;  /* FIFO B sample rate in Hz (8000..96000) */
 	/* TODO: FIFO word lengths can be retrieved from SOF_DAI_FMT */
-	uint16_t fifo_bits_a; /* FIFO A word length (16 or 24) */
-	uint16_t fifo_bits_b; /* FIFO B word length (16 or 24) */
+	uint16_t fifo_bits_a; /* FIFO A word length (16 or 32) */
+	uint16_t fifo_bits_b; /* FIFO B word length (16 or 32) */
 	uint16_t duty_min;    /* Min. mic clock duty cycle in % (20..80) */
 	uint16_t duty_max;    /* Max. mic clock duty cycle in % (min..80) */
 	uint32_t num_pdm_active; /* Number of active controllers */


### PR DESCRIPTION
This patch fixes the mistake in uapi/ipc.h text comments that falsely
claims that 24 bit data is supported. The supported PCM formats are
16 and 32 bits only. A check is added to DMIC set config function
to return error if anything else is requested.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>