### PR TITLE
drivers: apl-ssp: change clock idle state

### DIFF
--- a/src/include/uapi/ipc.h
+++ b/src/include/uapi/ipc.h
@@ -40,6 +40,7 @@
 #define __INCLUDE_UAPI_IPC_H__
 
 #include <uapi/abi.h>
+#include <sof/io.h>
 
 /** \addtogroup sof_uapi uAPI
  *  SOF uAPI specification.
@@ -249,6 +250,24 @@ struct sof_ipc_compound_hdr {
 #define SOF_DAI_INTEL_SSP_FRAME_PULSE_WIDTH_MAX		38
 #define SOF_DAI_INTEL_SSP_SLOT_PADDING_MAX		31
 
+/* SSP clocks control settings
+ *
+ * Macros for clks_control field in sof_ipc_dai_ssp_params struct.
+ */
+
+/* mclk 0 disable */
+#define SOF_DAI_INTEL_SSP_MCLK_0_DISABLE		BIT(0)
+/* mclk 1 disable */
+#define SOF_DAI_INTEL_SSP_MCLK_1_DISABLE		BIT(1)
+/* mclk keep active */
+#define SOF_DAI_INTEL_SSP_CLKCTRL_MCLK_KA		BIT(2)
+/* bclk keep active */
+#define SOF_DAI_INTEL_SSP_CLKCTRL_BCLK_KA		BIT(3)
+/* fs keep active */
+#define SOF_DAI_INTEL_SSP_CLKCTRL_FS_KA			BIT(4)
+/* bclk idle */
+#define SOF_DAI_INTEL_SSP_CLKCTRL_BCLK_IDLE_HIGH	BIT(5)
+
 /** \brief Types of DAI */
 enum sof_ipc_dai_type {
 	SOF_DAI_INTEL_NONE = 0,	/**< None */
@@ -278,14 +297,11 @@ struct sof_ipc_dai_ssp_params {
 
 	/* MCLK */
 	uint32_t mclk_direction;
-	uint32_t mclk_keep_active;
-	uint32_t bclk_keep_active;
-	uint32_t fs_keep_active;
 
 	uint16_t frame_pulse_width;
-	uint32_t quirks; // FIXME: is 32 bits enough ?
-
 	uint16_t tdm_per_slot_padding_flag;
+	uint32_t clks_control;
+	uint32_t quirks; // FIXME: is 32 bits enough ?
 	/* private data, e.g. for quirks */
 	//uint32_t pdata[10]; // FIXME: would really need ~16 u32
 } __attribute__((packed));


### PR DESCRIPTION
I've change clock idle state to low. Old:
- SCMODE(2) - data driven (rising), data sampled (falling),
  idle state(high)
New:
- SCMODE(1) - data driven (rising), data sampled (falling),
  idle state(low)

Signed-off-by: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>