### PR TITLE
[PATCH] DMIC: Fix 16 bit capture by using always 32 bits wide DMA

### DIFF
--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -332,10 +332,20 @@ static int dai_capture_params(struct comp_dev *dev)
 
 	/* set up DMA configuration */
 	config->direction = DMA_DIR_DEV_TO_MEM;
-	config->src_width = comp_sample_bytes(dev);
-	config->dest_width = comp_sample_bytes(dev);
 	config->cyclic = 1;
 	config->src_dev = dd->dai->plat_data.fifo[1].handshake;
+
+	switch (config->dai_type) {
+	case SOF_DAI_INTEL_DMIC:
+		config->burst_elems = 8;
+		config->src_width = 4;
+		config->dest_width = 4;
+		break;
+	default:
+		config->src_width = comp_sample_bytes(dev);
+		config->dest_width = comp_sample_bytes(dev);
+		break;
+	}
 
 	/* set up local and host DMA elems to reset values */
 	dma_buffer = list_first_item(&dev->bsink_list,
@@ -647,6 +657,7 @@ static int dai_config(struct comp_dev *dev, struct sof_ipc_dai_config *config)
 {
 	struct dai_data *dd = comp_get_drvdata(dev);
 
+	dd->config.dai_type = config->type;
 	switch (config->type) {
 	case SOF_DAI_INTEL_SSP:
 		/* set dma burst elems to slot number */
@@ -669,9 +680,6 @@ static int dai_config(struct comp_dev *dev, struct sof_ipc_dai_config *config)
 		 * this DMIC driver version.
 		 */
 		trace_dai("did");
-
-		/* We can use always the largest burst length. */
-		dd->config.burst_elems = 8;
 
 		/* Set frame size in bytes to match the configuration. */
 		if (config->dmic.num_pdm_active > 1) {

--- a/src/include/sof/dma.h
+++ b/src/include/sof/dma.h
@@ -89,6 +89,7 @@ struct dma_sg_config {
 	uint32_t src_dev;
 	uint32_t dest_dev;
 	uint32_t cyclic;		/* circular buffer */
+	enum sof_ipc_dai_type dai_type;
 	struct list_item elem_list;	/* list of dma_sg elems */
 };
 


### PR DESCRIPTION
Fixes: #152 "DMIC: 16bits FIFOs record at double rate"

This patch adds check for DAI type in dai_capture_params() function. For
DMIC the DMA burst and widths can use always these fixed values due
to 32 bit FIFO packer. DMA settings similar to SSP resulted to omitting
every second 16 bit sample from DMIC FIFO.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>