### PR TITLE
Refactor of schedule.c

### DIFF
--- a/src/host/schedule.c
+++ b/src/host/schedule.c
@@ -77,6 +77,29 @@ int scheduler_init(struct sof *sof)
 	return 0;
 }
 
+void schedule_task_init(struct task *task, void(*func)(void *),
+	void *data)
+{
+	task->core = 0;
+	task->state = TASK_STATE_INIT;
+	task->func = func;
+	task->data = data;
+}
+
+void schedule_task_free(struct task *task)
+{
+	task->state = TASK_STATE_FREE;
+	task->func = NULL;
+	task->data = NULL;
+}
+
+void schedule_task_config(struct task *task, uint16_t priority,
+	uint16_t core)
+{
+	task->priority = priority;
+	task->core = core;
+}
+
 /* The following definitions are to satisfy libsof linker errors */
 
 void schedule(void)

--- a/src/include/sof/schedule.h
+++ b/src/include/sof/schedule.h
@@ -82,28 +82,13 @@ void schedule_task_idle(struct task *task, uint64_t deadline);
 
 void schedule_task_complete(struct task *task);
 
-static inline void schedule_task_init(struct task *task, void (*func)(void *),
-	void *data)
-{
-	task->core = 0;
-	task->state = TASK_STATE_INIT;
-	task->func = func;
-	task->data = data;
-}
+void schedule_task_init(struct task *task, void(*func)(void *),
+	void *data);
 
-static inline void schedule_task_free(struct task *task)
-{
-	task->state = TASK_STATE_FREE;
-	task->func = NULL;
-	task->data = NULL;
-}
+void schedule_task_free(struct task *task);
 
-static inline void schedule_task_config(struct task *task, uint16_t priority,
-	uint16_t core)
-{
-	task->priority = priority;
-	task->core = core;
-}
+void schedule_task_config(struct task *task, uint16_t priority,
+	uint16_t core);
 
 int scheduler_init(struct sof *sof);
 

--- a/src/lib/schedule.c
+++ b/src/lib/schedule.c
@@ -204,6 +204,30 @@ static struct task *schedule_edf(void)
 	return future_task;
 }
 
+void schedule_task_init(struct task *task, void(*func)(void *),
+	void *data)
+{
+	task->core = 0;
+	task->state = TASK_STATE_INIT;
+	task->func = func;
+	task->data = data;
+}
+
+void schedule_task_free(struct task *task)
+{
+	task->state = TASK_STATE_FREE;
+	task->func = NULL;
+	task->data = NULL;
+}
+
+void schedule_task_config(struct task *task, uint16_t priority,
+	uint16_t core)
+{
+	task->priority = priority;
+	task->core = core;
+}
+
+
 #if 0 /* FIXME: is this needed ? */
 /* delete task from scheduler */
 static int schedule_task_del(struct task *task)


### PR DESCRIPTION
Due to xt-xcc not beeing able to wrap (--wrap option).
Which is needed to create a proper test for pipeline.c , definitions of some functions were moved to .c files which allows mocking those functions in unit tests.