### PR TITLE
host: remove reset in stop to keep status

### DIFF
--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -745,12 +745,6 @@ static int host_pointer_reset(struct comp_dev *dev)
 
 static int host_stop(struct comp_dev *dev)
 {
-	/* reset host side buffer pointers */
-	host_pointer_reset(dev);
-
-	/* reset elements, to let next start from original one */
-	host_elements_reset(dev);
-
 	return 0;
 }
 


### PR DESCRIPTION
Need to keep status of host comp at when we stop.

Check ALSA handler for these XRUN patterns to make sure no more bugs happen

depend on #169 to fix #161