### PR TITLE
Revert "dai: ignore data on capture stop"

### DIFF
--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -94,10 +94,6 @@ static void dai_dma_cb(void *data, uint32_t type, struct dma_sg_elem *next)
 
 		/* inform waiters */
 		wait_completed(&dd->complete);
-
-		/* for capture do nothing to avoid buffer ptr inconsistency */
-		if (dev->params.direction == SOF_IPC_STREAM_CAPTURE)
-			return;
 	}
 
 	/* is our pipeline handling an XRUN ? */


### PR DESCRIPTION
This reverts commit 58bc284905ee8203c17e7d62e4e57bb0bf4dd2b4.

which will cause the pointer mis-match between the DAI-DMA's
hardware pointer and the buffer pointer.
when you do the pause/release for the capture, the firmware
will be panic.

Signed-off-by: Wu Zhigang <zhigang.wu@linux.intel.com>