### PR TITLE
cnl: pm_runtime: increase L1 exit time

### DIFF
--- a/src/platform/cannonlake/include/platform/platform.h
+++ b/src/platform/cannonlake/include/platform/platform.h
@@ -116,7 +116,7 @@ struct sof;
 #define PLATFORM_DEFAULT_DELAY	12
 
 /* minimal L1 exit time in cycles */
-#define PLATFORM_FORCE_L1_EXIT_TIME	482
+#define PLATFORM_FORCE_L1_EXIT_TIME	985
 
 /* the SSP port fifo depth */
 #define SSP_FIFO_DEPTH		16


### PR DESCRIPTION
Increases L1 exit time for CNL platform to make sure,
that Host DMA transferred needed data.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>