### PR TITLE
dai: dma_release is no longer needed

### DIFF
--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -586,10 +586,6 @@ static int dai_comp_trigger(struct comp_dev *dev, int cmd)
 
 		/* only start the DAI if we are not XRUN handling */
 		if (dd->xrun == 0) {
-			/* recover the dma status */
-			ret = dma_release(dd->dma, dd->chan);
-			if (ret < 0)
-				return ret;
 			/* start the DAI */
 			ret = dma_start(dd->dma, dd->chan);
 			if (ret < 0)


### PR DESCRIPTION
Calling dma_release function is no longer needed
as we are currently tracking ll_current for all
platforms and starting GPDMA from the right item.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>