### PR TITLE
apl-ssp: do not override common MDIVCTRL register

### DIFF
--- a/src/drivers/apl-ssp.c
+++ b/src/drivers/apl-ssp.c
@@ -252,7 +252,9 @@ static inline int ssp_set_config(struct dai *dai,
 
 	sscr0 |= SSCR0_MOD | SSCR0_ACS;
 
-	mdivc = 0x1;
+	mdivc = mn_reg_read(0x0);
+	mdivc |= 0x1;
+
 #ifdef CONFIG_CANNONLAKE
 	if (!config->ssp.mclk_rate || config->ssp.mclk_rate > F_24000_kHz) {
 		trace_ssp_error("eci");


### PR DESCRIPTION
When we use different clock sources for different SSPs, we need to
make sure the mdivc register is not overwritten by IPC
configuration. Move to read-modify-write mode (assuming a zero-value
on reset)

Tested on GeminiLake with SSP2 derived from 19.2MHz XTAL and SSP1
derived from 24.576 MHz PLL.

Note that the topology needs to ensure compatibility between the
different settings, in the future we'll need a true clock driver which
will check for incompatibilities.

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>