### PR TITLE
interrupt: arch_interrupt_get_level

### DIFF
--- a/src/arch/host/include/arch/interrupt.h
+++ b/src/arch/host/include/arch/interrupt.h
@@ -45,6 +45,7 @@ static inline int arch_interrupt_register(int irq,
 static inline void arch_interrupt_unregister(int irq) {}
 static inline uint32_t arch_interrupt_enable_mask(uint32_t mask) {return 0; }
 static inline uint32_t arch_interrupt_disable_mask(uint32_t mask) {return 0; }
+static inline uint32_t arch_interrupt_get_level(void) { return 0; }
 static inline void arch_interrupt_set(int irq) {}
 static inline void arch_interrupt_clear(int irq) {}
 static inline uint32_t arch_interrupt_get_enabled(void) {return 0; }

--- a/src/arch/xtensa/include/arch/interrupt.h
+++ b/src/arch/xtensa/include/arch/interrupt.h
@@ -61,6 +61,18 @@ static inline void arch_interrupt_unregister(int irq)
 #define arch_interrupt_disable_mask(mask) \
 	_xtos_ints_off(mask)
 
+static inline uint32_t arch_interrupt_get_level(void)
+{
+	uint32_t level;
+
+	__asm__ __volatile__(
+		"       rsr.ps %0\n"
+		"       extui  %0, %0, 0, 4\n"
+		: "=&a" (level) :: "memory");
+
+	return level;
+}
+
 static inline void arch_interrupt_set(int irq)
 {
 	irq = SOF_IRQ_NUMBER(irq);


### PR DESCRIPTION
Adds possibility to retrieve current irq level.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>