### PR TITLE
hda-dma fix: align DGMBS value to 32 bytes

### DIFF
--- a/src/drivers/hda-dma.c
+++ b/src/drivers/hda-dma.c
@@ -44,7 +44,9 @@
 #include <sof/ipc.h>
 #include <sof/pm_runtime.h>
 #include <sof/wait.h>
+#include <sof/audio/format.h>
 #include <platform/dma.h>
+#include <platform/platform.h>
 #include <arch/cache.h>
 #include <uapi/ipc.h>
 
@@ -367,7 +369,8 @@ static int hda_dma_set_config(struct dma *dma, int channel,
 	host_dma_reg_write(dma, channel, DGBS,  buffer_bytes);
 	host_dma_reg_write(dma, channel, DGBFPI,  0);
 	host_dma_reg_write(dma, channel, DGBSP,  period_bytes);
-	host_dma_reg_write(dma, channel, DGMBS,  period_bytes);
+	host_dma_reg_write(dma, channel, DGMBS,
+			ALIGN_UP(period_bytes, PLATFORM_HDA_BUFFER_ALIGNMENT));
 	host_dma_reg_write(dma, channel, DGLLPI,  0);
 	host_dma_reg_write(dma, channel, DGLPIBI,  0);
 

--- a/src/platform/apollolake/include/platform/platform.h
+++ b/src/platform/apollolake/include/platform/platform.h
@@ -41,6 +41,9 @@
 
 struct sof;
 
+/* DGMBS align value */
+#define PLATFORM_HDA_BUFFER_ALIGNMENT	0x20
+
 /* Host page size */
 #define HOST_PAGE_SIZE		4096
 #define PLATFORM_PAGE_TABLE_SIZE	256

--- a/src/platform/cannonlake/include/platform/platform.h
+++ b/src/platform/cannonlake/include/platform/platform.h
@@ -47,6 +47,9 @@ struct sof;
 #define PLATFORM_SSP_COUNT 3
 #define MAX_GPDMA_COUNT 2
 
+/* DGMBS align value */
+#define PLATFORM_HDA_BUFFER_ALIGNMENT	0x20
+
 /* Host page size */
 #define HOST_PAGE_SIZE		4096
 #define PLATFORM_PAGE_TABLE_SIZE	256


### PR DESCRIPTION
APL/CNL:
If DSP Gateway Minimum Buffer Size (DGMBS) is not aligned to 32 bytes they occur
glitches in output signal (the buffer will be overwritten during work). It can
be observed during playback in following configuration:
- 8Khz 16bits 1 channel
- 24kHz 16bits 1 channel

Signed-off-by: Kamil Kulesza <kamil.kulesza@linux.intel.com>