### PR TITLE
trace: refine dma trace algorithm for apl

### DIFF
--- a/src/platform/apollolake/include/platform/platform.h
+++ b/src/platform/apollolake/include/platform/platform.h
@@ -104,7 +104,7 @@ struct sof;
  * the interval of reschedule DMA trace copying in special case like half
  * fullness of local DMA trace buffer
  */
-#define DMA_TRACE_RESCHEDULE_TIME	5000
+#define DMA_TRACE_RESCHEDULE_TIME	5
 
 /* DSP should be idle in this time frame */
 #define PLATFORM_IDLE_TIME	750000

--- a/src/platform/baytrail/include/platform/platform.h
+++ b/src/platform/baytrail/include/platform/platform.h
@@ -94,7 +94,7 @@ struct sof;
  * the interval of reschedule DMA trace copying in special case like half
  * fullness of local DMA trace buffer
  */
-#define DMA_TRACE_RESCHEDULE_TIME	5000
+#define DMA_TRACE_RESCHEDULE_TIME	5
 
 /* DSP should be idle in this time frame */
 #define PLATFORM_IDLE_TIME	750000

--- a/src/platform/cannonlake/include/platform/platform.h
+++ b/src/platform/cannonlake/include/platform/platform.h
@@ -110,7 +110,7 @@ struct sof;
  * the interval of reschedule DMA trace copying in special case like half
  * fullness of local DMA trace buffer
  */
-#define DMA_TRACE_RESCHEDULE_TIME	5000
+#define DMA_TRACE_RESCHEDULE_TIME	5
 
 /* DSP should be idle in this time frame */
 #define PLATFORM_IDLE_TIME	750000

--- a/src/platform/haswell/include/platform/platform.h
+++ b/src/platform/haswell/include/platform/platform.h
@@ -93,7 +93,7 @@ struct sof;
  * the interval of reschedule DMA trace copying in special case like half
  * fullness of local DMA trace buffer
  */
-#define DMA_TRACE_RESCHEDULE_TIME	5000
+#define DMA_TRACE_RESCHEDULE_TIME	5
 
 /* DSP should be idle in this time frame */
 #define PLATFORM_IDLE_TIME	750000


### PR DESCRIPTION
For apl, host pointer is updated to host in next trace_work.
So although the available trace data is null, we need to check
whether host pointer needs to be updated.

And another reason is trace buffer overflows.

this is for issue: https://github.com/thesofproject/sof/issues/157

Signed-off-by: Rander Wang <rander.wang@linux.intel.com>