### PR TITLE
ci: travis: update to use docker hub image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ services:
   - docker
 
 before_install:
-  - touch apt.conf
-  - docker build --build-arg UID=$(id -u) -f ./scripts/docker_build/Dockerfile -t sof .
+  - docker pull xiulipan/sof
 
 script:
-  - docker run -it -v `pwd`:/home/sof/work/sof.git -v `pwd`/../soft.git:/home/sof/work/soft.git --user `id -u` sof ./scripts/xtensa-build-all.sh -l
+  - docker run -it -v `pwd`:/home/sof/work/sof.git -v `pwd`/../soft.git:/home/sof/work/soft.git --user `id -u` xiulipan/sof ./scripts/xtensa-build-all.sh -l


### PR DESCRIPTION
No travis CI can work with the Docker hub image.
But we have some issues with .version file generate.

I create a issue to track that before we can enable travis CI.
#206
After I had PR fix for it the travis ci should be able to work.