### PR TITLE
EQ FIR: Improve robustness with configuration blobs

### DIFF
--- a/src/audio/eq_fir.c
+++ b/src/audio/eq_fir.c
@@ -175,7 +175,17 @@ static int eq_fir_setup(struct fir_state_32x16 fir[],
 	/* Initialize 1st phase */
 	trace_eq("asr");
 	for (i = 0; i < nch; i++) {
-		resp = assign_response[i];
+		/* If the configuration blob contains less channels for
+		 * response assign to channels than the current channels count
+		 * use the first channel response to remaining channels. E.g.
+		 * a blob that contains just a mono EQ can be used for stereo
+		 * stream by using the same response for all channels.
+		 */
+		if (i < config->channels_in_config)
+			resp = assign_response[i];
+		else
+			resp = assign_response[0];
+
 		trace_value(resp);
 		if (resp >= config->number_of_responses || resp < 0) {
 			trace_eq_error("eas");


### PR DESCRIPTION
This patch prevents an error if the EQ responses to channels mapping
table in the configuration blob contains less channels than current
number of channels in firmware. Without this check the lookup from blob
can go past the table. Reporting an error depended on successive blob
content to detect corrupt blob and was not guaranteed.

The situation is not changed to stop to error but instead extrapolate
the table by applying 1st channel EQ for additional channels. It e.g.
helps to duplicate mono effect EQ to all channels without need to make
blobs with mapping to match max. channels count of SOF. The used response
index for each channel can be seen from trace.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>