### PR TITLE
drivers: apl-ssp: handle tdm mode in ssp

### DIFF
--- a/src/drivers/apl-ssp.c
+++ b/src/drivers/apl-ssp.c
@@ -137,7 +137,7 @@ static inline int ssp_set_config(struct dai *dai,
 	uint32_t i2s_m;
 	uint32_t i2s_n;
 	uint32_t data_size;
-	uint32_t start_delay;
+	uint32_t start_delay = 0;
 	uint32_t frame_end_padding;
 	uint32_t slot_end_padding;
 	uint32_t frame_len = 0;
@@ -536,45 +536,14 @@ static inline int ssp_set_config(struct dai *dai,
 		break;
 	case SOF_DAI_FMT_DSP_A:
 
-		start_delay = 0;
-
-		sscr0 |= SSCR0_MOD | SSCR0_FRDC(config->ssp.tdm_slots);
-
-		/* set asserted frame length */
-		frame_len = 1; /* default */
-
-		if (cfs && ssp->params.frame_pulse_width > 0 &&
-			ssp->params.frame_pulse_width <=
-			SOF_DAI_INTEL_SSP_FRAME_PULSE_WIDTH_MAX) {
-			frame_len = ssp->params.frame_pulse_width;
-		}
-
-		/* frame_pulse_width must less or equal 38 */
-		if (ssp->params.frame_pulse_width >
-			SOF_DAI_INTEL_SSP_FRAME_PULSE_WIDTH_MAX) {
-			trace_ssp_error("efa");
-			ret = -EINVAL;
-			goto out;
-		}
-
-		/*
-		 * handle frame polarity, DSP_A default is rising/active high,
-		 * non-inverted(inverted_frame=0) -- active high(SFRMP=1),
-		 * inverted(inverted_frame=1) -- falling/active low(SFRMP=0),
-		 * so, we should set SFRMP to !inverted_frame.
-		 */
-		sspsp |= SSPSP_SFRMP(!inverted_frame);
+		start_delay = 1;
 		sspsp |= SSPSP_FSRT;
 
-		active_tx_slots = hweight_32(config->ssp.tx_slots);
-		active_rx_slots = hweight_32(config->ssp.rx_slots);
+		/* fallthrough */
 
-		sspsp2 |= (frame_end_padding & SSPSP2_FEP_MASK);
-
-		break;
 	case SOF_DAI_FMT_DSP_B:
 
-		start_delay = 0;
+		/* default start_delay value is set to 0 */
 
 		sscr0 |= SSCR0_MOD | SSCR0_FRDC(config->ssp.tdm_slots);
 

--- a/src/include/uapi/ipc.h
+++ b/src/include/uapi/ipc.h
@@ -241,6 +241,7 @@ struct sof_ipc_compound_hdr {
  /* here is the possibility to define others aux macros */
 
 #define SOF_DAI_INTEL_SSP_FRAME_PULSE_WIDTH_MAX		38
+#define SOF_DAI_INTEL_SSP_SLOT_PADDING_MAX		31
 
 /** \brief Types of DAI */
 enum sof_ipc_dai_type {
@@ -278,7 +279,7 @@ struct sof_ipc_dai_ssp_params {
 	uint16_t frame_pulse_width;
 	uint32_t quirks; // FIXME: is 32 bits enough ?
 
-	uint16_t padding;
+	uint16_t tdm_per_slot_padding_flag;
 	/* private data, e.g. for quirks */
 	//uint32_t pdata[10]; // FIXME: would really need ~16 u32
 } __attribute__((packed));


### PR DESCRIPTION
I've added tdm mode support in ssp. Tdm mode
has padding at the and of each slot. Tdm mode
is enabled by tdm_per_slot_padding_flag in
sof_ipc_dai_ssp_params struct.

Signed-off-by: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>