### PR TITLE
cpu: implement cpu_is_core_enabled function

### DIFF
--- a/src/arch/xtensa/include/arch/cpu.h
+++ b/src/arch/xtensa/include/arch/cpu.h
@@ -39,6 +39,8 @@ void arch_cpu_enable_core(int id);
 
 void arch_cpu_disable_core(int id);
 
+int arch_cpu_is_core_enabled(int id);
+
 static inline int arch_cpu_get_id(void)
 {
 	int prid;

--- a/src/arch/xtensa/smp/cpu.c
+++ b/src/arch/xtensa/smp/cpu.c
@@ -86,6 +86,11 @@ void arch_cpu_disable_core(int id)
 	spin_unlock_irq(&lock, flags);
 }
 
+int arch_cpu_is_core_enabled(int id)
+{
+	return active_cores_mask & (1 << id);
+}
+
 void cpu_power_down_core(void)
 {
 	arch_interrupt_global_disable();

--- a/src/arch/xtensa/up/cpu.c
+++ b/src/arch/xtensa/up/cpu.c
@@ -40,3 +40,5 @@
 void arch_cpu_enable_core(int id) { }
 
 void arch_cpu_disable_core(int id) { }
+
+int arch_cpu_is_core_enabled(int id) { return 1; }

--- a/src/include/sof/cpu.h
+++ b/src/include/sof/cpu.h
@@ -54,4 +54,9 @@ static inline void cpu_disable_core(int id)
 	arch_cpu_disable_core(id);
 }
 
+static inline int cpu_is_core_enabled(int id)
+{
+	return arch_cpu_is_core_enabled(id);
+}
+
 #endif


### PR DESCRIPTION
Adds cpu_is_core_enabled function to check for active cores.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>