### PR TITLE
idc: allow to send blocking messages to cores

### DIFF
--- a/src/arch/xtensa/smp/cpu.c
+++ b/src/arch/xtensa/smp/cpu.c
@@ -62,7 +62,7 @@ void arch_cpu_enable_core(int id)
 		idc_enable_interrupts(id, arch_cpu_get_id());
 
 		/* send IDC power up message */
-		arch_idc_send_msg(&power_up);
+		arch_idc_send_msg(&power_up, IDC_NON_BLOCKING);
 
 		active_cores_mask |= (1 << id);
 	}
@@ -78,7 +78,7 @@ void arch_cpu_disable_core(int id)
 	spin_lock_irq(&lock, flags);
 
 	if (active_cores_mask & (1 << id)) {
-		arch_idc_send_msg(&power_down);
+		arch_idc_send_msg(&power_down, IDC_NON_BLOCKING);
 
 		active_cores_mask ^= (1 << id);
 	}

--- a/src/arch/xtensa/up/include/arch/idc.h
+++ b/src/arch/xtensa/up/include/arch/idc.h
@@ -41,8 +41,12 @@ struct idc_msg;
 
 /**
  * \brief Sends IDC message.
+ * \param[in,out] msg Pointer to IDC message.
+ * \param[in] mode Is message blocking or not.
+ * \return Error code.
  */
-static inline void arch_idc_send_msg(struct idc_msg *msg) { }
+static inline int arch_idc_send_msg(struct idc_msg *msg,
+				    uint32_t mode) { return 0; }
 
 /**
  * \brief Checks for pending IDC messages.

--- a/src/platform/apollolake/include/platform/idc.h
+++ b/src/platform/apollolake/include/platform/idc.h
@@ -33,9 +33,9 @@
 
 #include <arch/idc.h>
 
-static inline void idc_send_msg(struct idc_msg *msg)
+static inline int idc_send_msg(struct idc_msg *msg, uint32_t mode)
 {
-	arch_idc_send_msg(msg);
+	return arch_idc_send_msg(msg, mode);
 }
 
 static inline void idc_process_msg_queue(void)

--- a/src/platform/baytrail/include/platform/idc.h
+++ b/src/platform/baytrail/include/platform/idc.h
@@ -33,7 +33,8 @@
 
 struct idc_msg;
 
-static inline void idc_send_msg(struct idc_msg *msg) { }
+static inline int idc_send_msg(struct idc_msg *msg,
+			       uint32_t mode) { return 0; }
 
 static inline void idc_process_msg_queue(void) { }
 

--- a/src/platform/cannonlake/include/platform/idc.h
+++ b/src/platform/cannonlake/include/platform/idc.h
@@ -33,9 +33,9 @@
 
 #include <arch/idc.h>
 
-static inline void idc_send_msg(struct idc_msg *msg)
+static inline int idc_send_msg(struct idc_msg *msg, uint32_t mode)
 {
-	arch_idc_send_msg(msg);
+	return arch_idc_send_msg(msg, mode);
 }
 
 static inline void idc_process_msg_queue(void)

--- a/src/platform/haswell/include/platform/idc.h
+++ b/src/platform/haswell/include/platform/idc.h
@@ -33,7 +33,8 @@
 
 struct idc_msg;
 
-static inline void idc_send_msg(struct idc_msg *msg) { }
+static inline int idc_send_msg(struct idc_msg *msg,
+			       uint32_t mode) { return 0; }
 
 static inline void idc_process_msg_queue(void) { }
 


### PR DESCRIPTION
Adds functionality of sending blocking IDC messages
to other cores.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>