### PR TITLE
memory: add cache_to_uncache and uncache_to_cache macros

### DIFF
--- a/src/platform/apollolake/include/platform/memory.h
+++ b/src/platform/apollolake/include/platform/memory.h
@@ -359,4 +359,10 @@
 /** \brief Manifest size (seems unused). */
 #define IMR_BOOT_LDR_MANIFEST_SIZE	0x6000
 
+#define SRAM_ALIAS_OFFSET	0x20000000
+#define uncache_to_cache(address) \
+	((__typeof__((address)))((uint32_t)((address)) + SRAM_ALIAS_OFFSET))
+#define cache_to_uncache(address) \
+	((__typeof__((address)))((uint32_t)((address)) - SRAM_ALIAS_OFFSET))
+
 #endif

--- a/src/platform/baytrail/include/platform/memory.h
+++ b/src/platform/baytrail/include/platform/memory.h
@@ -148,4 +148,7 @@
 
 #define SOF_MEM_RO_SIZE			0x8
 
+#define uncache_to_cache(address)	address
+#define cache_to_uncache(address)	address
+
 #endif

--- a/src/platform/cannonlake/include/platform/memory.h
+++ b/src/platform/cannonlake/include/platform/memory.h
@@ -357,4 +357,10 @@
 #define IMR_BOOT_LDR_BSS_BASE		0xB0100000
 #define IMR_BOOT_LDR_BSS_SIZE		0x10000
 
+#define SRAM_ALIAS_OFFSET	0x20000000
+#define uncache_to_cache(address) \
+	((__typeof__((address)))((uint32_t)((address)) + SRAM_ALIAS_OFFSET))
+#define cache_to_uncache(address) \
+	((__typeof__((address)))((uint32_t)((address)) - SRAM_ALIAS_OFFSET))
+
 #endif

--- a/src/platform/haswell/include/platform/memory.h
+++ b/src/platform/haswell/include/platform/memory.h
@@ -145,4 +145,7 @@
 
 #define SOF_MEM_RO_SIZE		0x8
 
+#define uncache_to_cache(address)	address
+#define cache_to_uncache(address)	address
+
 #endif


### PR DESCRIPTION
Adds macros, which allows to retrieve cached/uncached version
of memory pointer.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>