### PR TITLE
alloc: align memmap to cache line size

### DIFF
--- a/src/arch/xtensa/include/arch/cache.h
+++ b/src/arch/xtensa/include/arch/cache.h
@@ -36,6 +36,8 @@
 #include <xtensa/config/core.h>
 #include <xtensa/hal.h>
 
+#define DCACHE_LINE_SIZE	XCHAL_DCACHE_LINESIZE
+
 static inline void dcache_writeback_region(void *addr, size_t size)
 {
 #if XCHAL_DCACHE_SIZE > 0

--- a/src/include/sof/alloc.h
+++ b/src/include/sof/alloc.h
@@ -74,7 +74,7 @@ struct block_map {
 	uint16_t first_free;	/* index of first free block */
 	struct block_hdr *block;	/* base block header */
 	uint32_t base;		/* base address of space */
-} __attribute__ ((packed));
+} __attribute__ ((__aligned__(PLATFORM_DCACHE_ALIGN)));
 
 #define BLOCK_DEF(sz, cnt, hdr) \
 	{.block_size = sz, .count = cnt, .free_count = cnt, .block = hdr}
@@ -86,7 +86,7 @@ struct mm_heap {
 	uint32_t size;
 	uint32_t caps;
 	struct mm_info info;
-};
+} __attribute__ ((__aligned__(PLATFORM_DCACHE_ALIGN)));
 
 /* heap block memory map */
 struct mm {
@@ -99,7 +99,7 @@ struct mm {
 
 	struct mm_info total;
 	spinlock_t lock;	/* all allocs and frees are atomic */
-};
+} __attribute__ ((__aligned__(PLATFORM_DCACHE_ALIGN)));
 
 /* heap allocation and free */
 void *rmalloc(int zone, uint32_t caps, size_t bytes);

--- a/src/include/sof/platform.h
+++ b/src/include/sof/platform.h
@@ -44,6 +44,13 @@
  *  @{
  */
 
+/* data cache line alignment */
+#if DCACHE_LINE_SIZE > 0
+#define PLATFORM_DCACHE_ALIGN	DCACHE_LINE_SIZE
+#else
+#define PLATFORM_DCACHE_ALIGN	sizeof(uint32_t)
+#endif
+
 /*
  * APIs declared here are defined for every platform.
  */

--- a/src/platform/baytrail/include/arch/xtensa/config/core-isa-byt.h
+++ b/src/platform/baytrail/include/arch/xtensa/config/core-isa-byt.h
@@ -208,10 +208,10 @@
 				CACHE
   ----------------------------------------------------------------------*/
 
-#define XCHAL_ICACHE_LINESIZE		128	/* I-cache line size in bytes */
-#define XCHAL_DCACHE_LINESIZE		128	/* D-cache line size in bytes */
-#define XCHAL_ICACHE_LINEWIDTH		7	/* log2(I line size in bytes) */
-#define XCHAL_DCACHE_LINEWIDTH		7	/* log2(D line size in bytes) */
+#define XCHAL_ICACHE_LINESIZE		0	/* I-cache line size in bytes */
+#define XCHAL_DCACHE_LINESIZE		0	/* D-cache line size in bytes */
+#define XCHAL_ICACHE_LINEWIDTH		0	/* log2(I line size in bytes) */
+#define XCHAL_DCACHE_LINEWIDTH		0	/* log2(D line size in bytes) */
 
 #define XCHAL_ICACHE_SIZE		0	/* I-cache size in bytes or 0 */
 #define XCHAL_DCACHE_SIZE		0	/* D-cache size in bytes or 0 */

--- a/src/platform/baytrail/include/arch/xtensa/config/core-isa-cht.h
+++ b/src/platform/baytrail/include/arch/xtensa/config/core-isa-cht.h
@@ -208,10 +208,10 @@
 				CACHE
   ----------------------------------------------------------------------*/
 
-#define XCHAL_ICACHE_LINESIZE		128	/* I-cache line size in bytes */
-#define XCHAL_DCACHE_LINESIZE		128	/* D-cache line size in bytes */
-#define XCHAL_ICACHE_LINEWIDTH		7	/* log2(I line size in bytes) */
-#define XCHAL_DCACHE_LINEWIDTH		7	/* log2(D line size in bytes) */
+#define XCHAL_ICACHE_LINESIZE		0	/* I-cache line size in bytes */
+#define XCHAL_DCACHE_LINESIZE		0	/* D-cache line size in bytes */
+#define XCHAL_ICACHE_LINEWIDTH		0	/* log2(I line size in bytes) */
+#define XCHAL_DCACHE_LINEWIDTH		0	/* log2(D line size in bytes) */
 
 #define XCHAL_ICACHE_SIZE		0	/* I-cache size in bytes or 0 */
 #define XCHAL_DCACHE_SIZE		0	/* D-cache size in bytes or 0 */

--- a/src/platform/haswell/include/arch/xtensa/config/core-isa-bdw.h
+++ b/src/platform/haswell/include/arch/xtensa/config/core-isa-bdw.h
@@ -208,10 +208,10 @@
 				CACHE
   ----------------------------------------------------------------------*/
 
-#define XCHAL_ICACHE_LINESIZE		128	/* I-cache line size in bytes */
-#define XCHAL_DCACHE_LINESIZE		128	/* D-cache line size in bytes */
-#define XCHAL_ICACHE_LINEWIDTH		7	/* log2(I line size in bytes) */
-#define XCHAL_DCACHE_LINEWIDTH		7	/* log2(D line size in bytes) */
+#define XCHAL_ICACHE_LINESIZE		0	/* I-cache line size in bytes */
+#define XCHAL_DCACHE_LINESIZE		0	/* D-cache line size in bytes */
+#define XCHAL_ICACHE_LINEWIDTH		0	/* log2(I line size in bytes) */
+#define XCHAL_DCACHE_LINEWIDTH		0	/* log2(D line size in bytes) */
 
 #define XCHAL_ICACHE_SIZE		0	/* I-cache size in bytes or 0 */
 #define XCHAL_DCACHE_SIZE		0	/* D-cache size in bytes or 0 */

--- a/src/platform/haswell/include/arch/xtensa/config/core-isa-hsw.h
+++ b/src/platform/haswell/include/arch/xtensa/config/core-isa-hsw.h
@@ -208,10 +208,10 @@
 				CACHE
   ----------------------------------------------------------------------*/
 
-#define XCHAL_ICACHE_LINESIZE		128	/* I-cache line size in bytes */
-#define XCHAL_DCACHE_LINESIZE		128	/* D-cache line size in bytes */
-#define XCHAL_ICACHE_LINEWIDTH		7	/* log2(I line size in bytes) */
-#define XCHAL_DCACHE_LINEWIDTH		7	/* log2(D line size in bytes) */
+#define XCHAL_ICACHE_LINESIZE		0	/* I-cache line size in bytes */
+#define XCHAL_DCACHE_LINESIZE		0	/* D-cache line size in bytes */
+#define XCHAL_ICACHE_LINEWIDTH		0	/* log2(I line size in bytes) */
+#define XCHAL_DCACHE_LINEWIDTH		0	/* log2(D line size in bytes) */
 
 #define XCHAL_ICACHE_SIZE		0	/* I-cache size in bytes or 0 */
 #define XCHAL_DCACHE_SIZE		0	/* D-cache size in bytes or 0 */


### PR DESCRIPTION
Aligns memmap related structs to cache line size.
This is getting us closer to have memory allocator
fully shared between cores.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>