### PR TITLE
dw-dma: refactor interrupt registration and unregistration

### DIFF
--- a/src/drivers/dw-dma.c
+++ b/src/drivers/dw-dma.c
@@ -58,6 +58,7 @@
 #include <sof/trace.h>
 #include <sof/wait.h>
 #include <sof/audio/component.h>
+#include <sof/cpu.h>
 #include <platform/dma.h>
 #include <platform/platform.h>
 #include <platform/interrupt.h>
@@ -247,6 +248,11 @@
 /* number of tries to wait for reset */
 #define DW_DMA_CFG_TRIES	10000
 
+struct dma_id {
+	struct dma *dma;
+	uint32_t channel;
+};
+
 /* data for each DMA channel */
 struct dma_chan_data {
 	uint32_t status;
@@ -256,8 +262,7 @@ struct dma_chan_data {
 	uint32_t desc_count;
 	uint32_t cfg_lo;
 	uint32_t cfg_hi;
-	struct dma *dma;
-	int32_t channel;
+	struct dma_id id;
 
 	void (*cb)(void *data, uint32_t type, struct dma_sg_elem *next);	/* client callback function */
 	void *cb_data;		/* client callback data */
@@ -273,6 +278,8 @@ struct dma_pdata {
 static inline void dw_dma_chan_reload_lli(struct dma *dma, int channel);
 static inline void dw_dma_chan_reload_next(struct dma *dma, int channel,
 		struct dma_sg_elem *next);
+static inline void dw_dma_interrupt_register(struct dma *dma, int channel);
+static inline void dw_dma_interrupt_unregister(struct dma *dma, int channel);
 
 static inline void dw_write(struct dma *dma, uint32_t reg, uint32_t value)
 {
@@ -401,7 +408,7 @@ static int dw_dma_start(struct dma *dma, int channel)
 	dw_write(dma, DW_CLEAR_ERR, 0x1 << channel);
 
 	/* clear platform interrupt */
-	platform_interrupt_clear(dma_irq(dma), 1 << channel);
+	platform_interrupt_clear(dma_irq(dma, cpu_get_id()), 1 << channel);
 
 #if DW_USE_HW_LLI
 	/* TODO: Revisit: are we using LLP mode or single transfer ? */
@@ -421,6 +428,10 @@ static int dw_dma_start(struct dma *dma, int channel)
 	/* write channel config */
 	dw_write(dma, DW_CFG_LOW(channel), p->chan[channel].cfg_lo);
 	dw_write(dma, DW_CFG_HIGH(channel), p->chan[channel].cfg_hi);
+
+	/* enable interrupt only for the first start */
+	if (p->chan[channel].status == COMP_STATE_PREPARE)
+		dw_dma_interrupt_register(dma, channel);
 
 	/* enable the channel */
 	p->chan[channel].status = COMP_STATE_ACTIVE;
@@ -491,6 +502,9 @@ static int dw_dma_stop(struct dma *dma, int channel)
 		trace_dma_error("ea0");
 		trace_error_value(channel);
 	}
+
+	/* disable interrupt */
+	dw_dma_interrupt_unregister(dma, channel);
 
 	p->chan[channel].status = COMP_STATE_PREPARE;
 
@@ -910,13 +924,13 @@ found:
 /* external layer 2 interrupt for dmac */
 static void dw_dma_irq_handler(void *data)
 {
-	struct dma_int *dma_int = (struct dma_int *)data;
-	struct dma *dma = dma_int->dma;
+	struct dma_id *dma_id = (struct dma_id *)data;
+	struct dma *dma = dma_id->dma;
 	struct dma_pdata *p = dma_get_drvdata(dma);
 	struct dma_sg_elem next;
 	uint32_t status_tfr = 0, status_block = 0, status_err = 0, status_intr;
 	uint32_t mask;
-	int i = dma_int->channel;
+	int i = dma_id->channel;
 
 	status_intr = dw_read(dma, DW_INTR_STATUS);
 	if (!status_intr) {
@@ -1005,7 +1019,6 @@ static void dw_dma_irq_handler(void *data)
 
 static int dw_dma_probe(struct dma *dma)
 {
-	struct dma_int *dma_int[DW_MAX_CHAN];
 	struct dma_pdata *dw_pdata;
 	int i;
 
@@ -1019,29 +1032,34 @@ static int dw_dma_probe(struct dma *dma)
 
 	/* init work */
 	for (i = 0; i < dma->plat_data.channels; i++) {
-		dw_pdata->chan[i].dma = dma;
-		dw_pdata->chan[i].channel = i;
+		dw_pdata->chan[i].id.dma = dma;
+		dw_pdata->chan[i].id.channel = i;
 		dw_pdata->chan[i].status = COMP_STATE_INIT;
-
-		dma_int[i] = rzalloc(RZONE_SYS, SOF_MEM_CAPS_RAM,
-				     sizeof(struct dma_int));
-
-		dma_int[i]->dma = dma;
-		dma_int[i]->channel = i;
-		dma_int[i]->irq = dma->plat_data.irq +
-				(i << SOF_IRQ_BIT_SHIFT);
-
-		/* register our IRQ handler */
-		interrupt_register(dma_int[i]->irq,
-				   dw_dma_irq_handler,
-				   dma_int[i]);
-		interrupt_enable(dma_int[i]->irq);
 	}
 
 	/* init number of channels draining */
 	atomic_init(&dma->num_channels_busy, 0);
 
 	return 0;
+}
+
+static inline void dw_dma_interrupt_register(struct dma *dma, int channel)
+{
+	struct dma_pdata *p = dma_get_drvdata(dma);
+	uint32_t irq = dma_irq(dma, cpu_get_id()) +
+		(channel << SOF_IRQ_BIT_SHIFT);
+
+	interrupt_register(irq, dw_dma_irq_handler, &p->chan[channel].id);
+	interrupt_enable(irq);
+}
+
+static inline void dw_dma_interrupt_unregister(struct dma *dma, int channel)
+{
+	uint32_t irq = dma_irq(dma, cpu_get_id()) +
+		(channel << SOF_IRQ_BIT_SHIFT);
+
+	interrupt_disable(irq);
+	interrupt_unregister(irq);
 }
 
 #else
@@ -1085,7 +1103,7 @@ static void dw_dma_irq_handler(void *data)
 
 	/* clear platform and DSP interrupt */
 	pmask = status_block | status_tfr | status_err;
-	platform_interrupt_clear(dma_irq(dma), pmask);
+	platform_interrupt_clear(dma_irq(dma, cpu_get_id()), pmask);
 
 	/* confirm IRQ cleared */
 	status_block_new = dw_read(dma, DW_STATUS_BLOCK);
@@ -1169,19 +1187,31 @@ static int dw_dma_probe(struct dma *dma)
 
 	/* init work */
 	for (i = 0; i < DW_MAX_CHAN; i++) {
-		dw_pdata->chan[i].dma = dma;
-		dw_pdata->chan[i].channel = i;
+		dw_pdata->chan[i].id.dma = dma;
+		dw_pdata->chan[i].id.channel = i;
 		dw_pdata->chan[i].status = COMP_STATE_INIT;
 	}
-
-	/* register our IRQ handler */
-	interrupt_register(dma_irq(dma), dw_dma_irq_handler, dma);
-	interrupt_enable(dma_irq(dma));
 
 	/* init number of channels draining */
 	atomic_init(&dma->num_channels_busy, 0);
 
 	return 0;
+}
+
+static inline void dw_dma_interrupt_register(struct dma *dma, int channel)
+{
+	uint32_t irq = dma_irq(dma, cpu_get_id());
+
+	interrupt_register(irq, dw_dma_irq_handler, dma);
+	interrupt_enable(irq);
+}
+
+static inline void dw_dma_interrupt_unregister(struct dma *dma, int channel)
+{
+	uint32_t irq = dma_irq(dma, cpu_get_id());
+
+	interrupt_disable(irq);
+	interrupt_unregister(irq);
 }
 #endif
 

--- a/src/include/sof/dma.h
+++ b/src/include/sof/dma.h
@@ -164,12 +164,6 @@ struct dma {
 	void *private;
 };
 
-struct dma_int {
-	struct dma *dma;
-	uint32_t channel;
-	uint32_t irq;
-};
-
 struct dma *dma_get(uint32_t dir, uint32_t caps, uint32_t dev, uint32_t flags);
 
 /* initialize all platform DMAC's */
@@ -181,8 +175,8 @@ int dmac_init(void);
 	dma->private;
 #define dma_base(dma) \
 	dma->plat_data.base
-#define dma_irq(dma) \
-	dma->plat_data.irq
+#define dma_irq(dma, cpu) \
+	(dma->plat_data.irq + (cpu << SOF_IRQ_CPU_SHIFT))
 #define dma_chan_size(dma) \
 	dma->plat_data.chan_size
 #define dma_chan_base(dma, chan) \


### PR DESCRIPTION
Changes flow of dw-dma interrupt registration and unregistration:
Now it is possible for slave cores to register for dw-dma handler.
Also registration happens before start and not on FW load
during probing. This way we are not wasting runtime heap memory
and also it will allow us to dynamically change execution core
for certain pipelines.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>