### PR TITLE
SRC: Use 16 bit coefficients when FW is built with gcc

### DIFF
--- a/src/audio/src_config.h
+++ b/src/audio/src_config.h
@@ -34,36 +34,19 @@
 
 #include <config.h>
 
-/* If next defines are set to 1 the SRC is configured automatically. Setting
+/* If next define is set to 1 the SRC is configured automatically. Setting
  * to zero temporarily is useful is for testing needs.
- * Setting SRC_AUTODSP to 0 allows to manually set the code variant.
- * Setting SRC_AUTOCOEF to 0 allows to select the coefficient type.
  */
 #define SRC_AUTOARCH    1
-#define SRC_AUTOCOEF    1
 
 /* Force manually some code variant when SRC_AUTODSP is set to zero. These
  * are useful in code debugging.
  */
 #if SRC_AUTOARCH == 0
+#define SRC_SHORT	0
 #define SRC_GENERIC	1
 #define SRC_HIFIEP	0
 #define SRC_HIFI3	0
-#endif
-#if SRC_AUTOCOEF == 0
-#define SRC_SHORT	0
-#endif
-
-/* Select 16 bit coefficients for specific platforms.
- * Otherwise 32 bits is the default.
- */
-#if SRC_AUTOCOEF == 1
-#if defined CONFIG_BAYTRAIL || defined CONFIG_CHERRYTRAIL \
-	|| defined CONFIG_BROADWELL || defined CONFIG_HASWELL
-#define SRC_SHORT	1     /* Use int16_t filter coefficients */
-#else
-#define SRC_SHORT	0     /* Use int32_t filter coefficients */
-#endif
 #endif
 
 /* Select optimized code variant when xt-xcc compiler is used */
@@ -72,15 +55,18 @@
 #include <xtensa/config/core-isa.h>
 #define SRC_GENERIC	0
 #if XCHAL_HAVE_HIFI2EP == 1
+#define SRC_SHORT	1  /* Select 16 bit coefficients to save RAM */
 #define SRC_HIFIEP	1
 #define SRC_HIFI3	0
 #endif
 #if XCHAL_HAVE_HIFI3 == 1
+#define SRC_SHORT	0  /* Select 32 bit default quality coefficients */
 #define SRC_HIFI3	1
 #define SRC_HIFIEP	0
 #endif
 #else
 /* GCC */
+#define SRC_SHORT	1  /* Use 16 bit filter coefficients for speed */
 #define SRC_GENERIC	1
 #define SRC_HIFIEP	0
 #define SRC_HIFI3	0


### PR DESCRIPTION
This patch changes the 16/32 bits coefficients selection macros to
always use 16 bit coefficient set when compiled with other than xt-xcc.
It was found out that gcc compiled SRC can't maintain real-time speed
in HiFi3 platform.

With xt-xcc compilation HiFiEP platforms will use 16 bit for RAM saving
(speed isn't an issue with 32 bit) and HiFi3 platforms will continue
using 32 bit coefficients. Only the 32 bit set provides the larger
conversions set and default quality.

With this change the APL and similar HiFi3 platforms can play via SRC
pipeline 8/16/32/48 kHz rate audio.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>