### PR TITLE
component: add cache ops

### DIFF
--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -691,6 +691,58 @@ static int dai_config(struct comp_dev *dev, struct sof_ipc_dai_config *config)
 	return 0;
 }
 
+static void dai_cache(struct comp_dev *dev, int cmd)
+{
+	struct dai_data *dd;
+	struct list_item *item;
+	struct dma_sg_elem *e;
+
+	switch (cmd) {
+	case COMP_CACHE_WRITEBACK_INV:
+		trace_dai("wtb");
+
+		dd = comp_get_drvdata(dev);
+
+		list_for_item(item, &dd->config.elem_list) {
+			e = container_of(item, struct dma_sg_elem, list);
+			dcache_writeback_invalidate_region(e, sizeof(*e));
+			dcache_writeback_invalidate_region(item,
+							   sizeof(*item));
+		}
+
+		dcache_writeback_invalidate_region(dd->dai, sizeof(*dd->dai));
+		dcache_writeback_invalidate_region(dd->dai->private,
+						   dd->dai->private_size);
+		dcache_writeback_invalidate_region(dd->dma, sizeof(*dd->dma));
+		dcache_writeback_invalidate_region(dd->dma->private,
+						   dd->dma->private_size);
+		dcache_writeback_invalidate_region(dd, sizeof(*dd));
+		dcache_writeback_invalidate_region(dev, sizeof(*dev));
+		break;
+
+	case COMP_CACHE_INVALIDATE:
+		trace_dai("inv");
+
+		dcache_invalidate_region(dev, sizeof(*dev));
+
+		dd = comp_get_drvdata(dev);
+		dcache_invalidate_region(dd, sizeof(*dd));
+		dcache_invalidate_region(dd->dma, sizeof(*dd->dma));
+		dcache_invalidate_region(dd->dma->private,
+					 dd->dma->private_size);
+		dcache_invalidate_region(dd->dai, sizeof(*dd->dai));
+		dcache_invalidate_region(dd->dai->private,
+					 dd->dai->private_size);
+
+		list_for_item(item, &dd->config.elem_list) {
+			dcache_invalidate_region(item, sizeof(*item));
+			e = container_of(item, struct dma_sg_elem, list);
+			dcache_invalidate_region(e, sizeof(*e));
+		}
+		break;
+	}
+}
+
 static struct comp_driver comp_dai = {
 	.type	= SOF_COMP_DAI,
 	.ops	= {
@@ -703,6 +755,7 @@ static struct comp_driver comp_dai = {
 		.reset		= dai_reset,
 		.dai_config	= dai_config,
 		.position	= dai_position,
+		.cache		= dai_cache,
 	},
 };
 

--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -884,6 +884,65 @@ out:
 	return ret;
 }
 
+static void host_cache(struct comp_dev *dev, int cmd)
+{
+	struct host_data *hd;
+	struct list_item *item;
+	struct dma_sg_elem *e;
+
+	switch (cmd) {
+	case COMP_CACHE_WRITEBACK_INV:
+		trace_host("wtb");
+
+		hd = comp_get_drvdata(dev);
+
+		list_for_item(item, &hd->config.elem_list) {
+			e = container_of(item, struct dma_sg_elem, list);
+			dcache_writeback_invalidate_region(e, sizeof(*e));
+			dcache_writeback_invalidate_region(item,
+							   sizeof(*item));
+		}
+
+		list_for_item(item, &hd->local.elem_list) {
+			e = container_of(item, struct dma_sg_elem, list);
+			dcache_writeback_invalidate_region(e, sizeof(*e));
+			dcache_writeback_invalidate_region(item,
+							   sizeof(*item));
+		}
+
+		dcache_writeback_invalidate_region(hd->dma, sizeof(*hd->dma));
+		dcache_writeback_invalidate_region(hd->dma->private,
+						   hd->dma->private_size);
+		dcache_writeback_invalidate_region(hd, sizeof(*hd));
+		dcache_writeback_invalidate_region(dev, sizeof(*dev));
+		break;
+
+	case COMP_CACHE_INVALIDATE:
+		trace_host("inv");
+
+		dcache_invalidate_region(dev, sizeof(*dev));
+
+		hd = comp_get_drvdata(dev);
+		dcache_invalidate_region(hd, sizeof(*hd));
+		dcache_invalidate_region(hd->dma, sizeof(*hd->dma));
+		dcache_invalidate_region(hd->dma->private,
+					 hd->dma->private_size);
+
+		list_for_item(item, &hd->local.elem_list) {
+			dcache_invalidate_region(item, sizeof(*item));
+			e = container_of(item, struct dma_sg_elem, list);
+			dcache_invalidate_region(e, sizeof(*e));
+		}
+
+		list_for_item(item, &hd->config.elem_list) {
+			dcache_invalidate_region(item, sizeof(*item));
+			e = container_of(item, struct dma_sg_elem, list);
+			dcache_invalidate_region(e, sizeof(*e));
+		}
+		break;
+	}
+}
+
 struct comp_driver comp_host = {
 	.type	= SOF_COMP_HOST,
 	.ops	= {
@@ -896,6 +955,7 @@ struct comp_driver comp_host = {
 		.prepare	= host_prepare,
 		.host_buffer	= host_buffer,
 		.position	= host_position,
+		.cache		= host_cache,
 	},
 };
 

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -338,6 +338,31 @@ static int mixer_prepare(struct comp_dev *dev)
 	return downstream;
 }
 
+static void mixer_cache(struct comp_dev *dev, int cmd)
+{
+	struct mixer_data *md;
+
+	switch (cmd) {
+	case COMP_CACHE_WRITEBACK_INV:
+		trace_mixer("wtb");
+
+		md = comp_get_drvdata(dev);
+
+		dcache_writeback_invalidate_region(md, sizeof(*md));
+		dcache_writeback_invalidate_region(dev, sizeof(*dev));
+		break;
+
+	case COMP_CACHE_INVALIDATE:
+		trace_mixer("inv");
+
+		dcache_invalidate_region(dev, sizeof(*dev));
+
+		md = comp_get_drvdata(dev);
+		dcache_invalidate_region(md, sizeof(*md));
+		break;
+	}
+}
+
 struct comp_driver comp_mixer = {
 	.type	= SOF_COMP_MIXER,
 	.ops	= {
@@ -348,6 +373,7 @@ struct comp_driver comp_mixer = {
 		.trigger	= mixer_trigger,
 		.copy		= mixer_copy,
 		.reset		= mixer_reset,
+		.cache		= mixer_cache,
 	},
 };
 

--- a/src/audio/tone.c
+++ b/src/audio/tone.c
@@ -699,6 +699,31 @@ static int tone_reset(struct comp_dev * dev)
 	return 0;
 }
 
+static void tone_cache(struct comp_dev *dev, int cmd)
+{
+	struct comp_data *cd;
+
+	switch (cmd) {
+	case COMP_CACHE_WRITEBACK_INV:
+		trace_tone("wtb");
+
+		cd = comp_get_drvdata(dev);
+
+		dcache_writeback_invalidate_region(cd, sizeof(*cd));
+		dcache_writeback_invalidate_region(dev, sizeof(*dev));
+		break;
+
+	case COMP_CACHE_INVALIDATE:
+		trace_tone("inv");
+
+		dcache_invalidate_region(dev, sizeof(*dev));
+
+		cd = comp_get_drvdata(dev);
+		dcache_invalidate_region(cd, sizeof(*cd));
+		break;
+	}
+}
+
 struct comp_driver comp_tone = {
 	.type = SOF_COMP_TONE,
 	.ops = {
@@ -710,6 +735,7 @@ struct comp_driver comp_tone = {
 		.copy = tone_copy,
 		.prepare = tone_prepare,
 		.reset = tone_reset,
+		.cache = tone_cache,
 	},
 };
 

--- a/src/audio/volume.c
+++ b/src/audio/volume.c
@@ -585,6 +585,36 @@ static int volume_reset(struct comp_dev *dev)
 	return 0;
 }
 
+/**
+ * \brief Executes cache operation on volume component.
+ * \param[in,out] dev Volume base component device.
+ * \param[in] cmd Cache command.
+ */
+static void volume_cache(struct comp_dev *dev, int cmd)
+{
+	struct comp_data *cd;
+
+	switch (cmd) {
+	case COMP_CACHE_WRITEBACK_INV:
+		trace_volume("wtb");
+
+		cd = comp_get_drvdata(dev);
+
+		dcache_writeback_invalidate_region(cd, sizeof(*cd));
+		dcache_writeback_invalidate_region(dev, sizeof(*dev));
+		break;
+
+	case COMP_CACHE_INVALIDATE:
+		trace_volume("inv");
+
+		dcache_invalidate_region(dev, sizeof(*dev));
+
+		cd = comp_get_drvdata(dev);
+		dcache_invalidate_region(cd, sizeof(*cd));
+		break;
+	}
+}
+
 /** \brief Volume component definition. */
 struct comp_driver comp_volume = {
 	.type	= SOF_COMP_VOLUME,
@@ -597,6 +627,7 @@ struct comp_driver comp_volume = {
 		.copy		= volume_copy,
 		.prepare	= volume_prepare,
 		.reset		= volume_reset,
+		.cache		= volume_cache,
 	},
 };
 

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -99,6 +99,13 @@
 
 #define COMP_CMD_IPC_MMAP_VOL(chan)	(216 + chan)	/* Volume */
 
+/* component cache operations */
+
+/* writeback and invalidate component data */
+#define COMP_CACHE_WRITEBACK_INV	0
+/* invalidate component data */
+#define COMP_CACHE_INVALIDATE		1
+
 /* component operations */
 #define COMP_OPS_PARAMS		0
 #define COMP_OPS_TRIGGER	1
@@ -156,6 +163,9 @@ struct comp_ops {
 	/* position */
 	int (*position)(struct comp_dev *dev,
 		struct sof_ipc_stream_posn *posn);
+
+	/* cache operation on component data */
+	void (*cache)(struct comp_dev *dev, int cmd);
 };
 
 
@@ -212,6 +222,8 @@ struct comp_dev {
 	c->private = data
 #define comp_get_drvdata(c) \
 	c->private;
+
+typedef void (*cache_command)(void *, size_t);
 
 void sys_comp_init(void);
 
@@ -303,6 +315,13 @@ static inline int comp_position(struct comp_dev *dev,
 	if (dev->drv->ops.position)
 		return dev->drv->ops.position(dev, posn);
 	return 0;
+}
+
+/* component cache command */
+static inline void comp_cache(struct comp_dev *dev, int cmd)
+{
+	if (dev->drv->ops.cache)
+		dev->drv->ops.cache(dev, cmd);
 }
 
 /* default base component initialisations */

--- a/src/include/sof/dai.h
+++ b/src/include/sof/dai.h
@@ -122,12 +122,14 @@ struct dai {
 	struct dai_plat_data plat_data;
 	const struct dai_ops *ops;
 	void *private;
+	uint32_t private_size;
 };
 
 struct dai *dai_get(uint32_t type, uint32_t index);
 
 #define dai_set_drvdata(dai, data) \
-	dai->private = data
+	dai->private = data; \
+	dai->private_size = sizeof(*data)
 #define dai_get_drvdata(dai) \
 	dai->private;
 #define dai_base(dai) \

--- a/src/include/sof/dma.h
+++ b/src/include/sof/dma.h
@@ -162,6 +162,7 @@ struct dma {
 	const struct dma_ops *ops;
 	atomic_t num_channels_busy; /* number of busy channels */
 	void *private;
+	uint32_t private_size;
 };
 
 struct dma *dma_get(uint32_t dir, uint32_t caps, uint32_t dev, uint32_t flags);
@@ -170,7 +171,8 @@ struct dma *dma_get(uint32_t dir, uint32_t caps, uint32_t dev, uint32_t flags);
 int dmac_init(void);
 
 #define dma_set_drvdata(dma, data) \
-	dma->private = data
+	dma->private = data; \
+	dma->private_size = sizeof(*data)
 #define dma_get_drvdata(dma) \
 	dma->private;
 #define dma_base(dma) \


### PR DESCRIPTION
Adds cache operation for every component.
This method allows performing cache operation on
current execution core based on selected cache command.
It's required in order to allow pipeline task switching to
slave cores. Master core will handle IPC to create and
configure pipeline, but later the whole pipeline with
components needs to be flushed to SRAM for other cores
to properly read it.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>