### PR TITLE
work: init work queue for slave cores

### DIFF
--- a/src/include/sof/init.h
+++ b/src/include/sof/init.h
@@ -31,7 +31,13 @@
 #ifndef __INCLUDE_INIT_H__
 #define __INCLUDE_INIT_H__
 
+#include <platform/platcfg.h>
+#include <sof/work.h>
+
 struct sof;
+
+extern struct work_queue_timesource
+	platform_generic_queue[PLATFORM_CORE_COUNT];
 
 /* main firmware entry point - argc and argv not currently used */
 int main(int argc, char *argv[]);

--- a/src/init/init.c
+++ b/src/init/init.c
@@ -103,6 +103,9 @@ int slave_core_init(struct sof *sof)
 
 	platform_interrupt_init();
 
+	trace_point(TRACE_BOOT_SYS_WORK);
+	init_system_workq(&platform_generic_queue[cpu_get_id()]);
+
 	/* initialize IDC mechanism */
 	trace_point(TRACE_BOOT_PLATFORM_IDC);
 	idc_init();


### PR DESCRIPTION
Initializes system work queue for slave cores.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>