### PR TITLE
alloc: align system objects to dcache line size

### DIFF
--- a/src/lib/alloc.c
+++ b/src/lib/alloc.c
@@ -113,6 +113,11 @@ static void *rmalloc_sys(size_t bytes)
 		return NULL;
 	}
 
+	/* align address to dcache line size */
+	if (memmap.system.heap % PLATFORM_DCACHE_ALIGN)
+		memmap.system.heap += PLATFORM_DCACHE_ALIGN -
+			(memmap.system.heap % PLATFORM_DCACHE_ALIGN);
+
 	ptr = (void *)memmap.system.heap;
 
 	/* always succeeds or panics */


### PR DESCRIPTION
Aligns objects allocated on system heap to dcache line size.
One of the reason why it's required is because DMA and DAI
private data is allocated on system heap.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>