### PR TITLE
ipc: alloc page_table based on CONFIG_HOST_PTABLE

### DIFF
--- a/src/ipc/apl-ipc.c
+++ b/src/ipc/apl-ipc.c
@@ -194,11 +194,13 @@ int platform_ipc_init(struct ipc *ipc)
 	for (i = 0; i < MSG_QUEUE_SIZE; i++)
 		list_item_prepend(&ipc->message[i].list, &ipc->empty_list);
 
+#ifdef CONFIG_HOST_PTABLE
 	/* allocate page table buffer */
 	iipc->page_table = rballoc(RZONE_SYS, SOF_MEM_CAPS_RAM,
 			HOST_PAGE_SIZE);
 	if (iipc->page_table)
 		bzero(iipc->page_table, HOST_PAGE_SIZE);
+#endif
 
 	/* request HDA DMA with shared access privilege */
 	caps = 0;

--- a/src/ipc/byt-ipc.c
+++ b/src/ipc/byt-ipc.c
@@ -219,11 +219,13 @@ int platform_ipc_init(struct ipc *ipc)
 	for (i = 0; i < MSG_QUEUE_SIZE; i++)
 		list_item_prepend(&ipc->message[i].list, &ipc->empty_list);
 
+#ifdef CONFIG_HOST_PTABLE
 	/* allocate page table buffer */
 	iipc->page_table = rzalloc(RZONE_SYS, SOF_MEM_CAPS_RAM,
 		PLATFORM_PAGE_TABLE_SIZE);
 	if (iipc->page_table)
 		bzero(iipc->page_table, PLATFORM_PAGE_TABLE_SIZE);
+#endif
 
 	/* request HDA DMA with shared access privilege */
 	caps = 0;

--- a/src/ipc/cnl-ipc.c
+++ b/src/ipc/cnl-ipc.c
@@ -193,11 +193,13 @@ int platform_ipc_init(struct ipc *ipc)
 	for (i = 0; i < MSG_QUEUE_SIZE; i++)
 		list_item_prepend(&ipc->message[i].list, &ipc->empty_list);
 
+#ifdef CONFIG_HOST_PTABLE
 	/* allocate page table buffer */
 	iipc->page_table = rballoc(RZONE_SYS, SOF_MEM_CAPS_RAM,
 			HOST_PAGE_SIZE);
 	if (iipc->page_table)
 		bzero(iipc->page_table, HOST_PAGE_SIZE);
+#endif
 
 	/* request HDA DMA with shared access privilege */
 	caps = 0;

--- a/src/ipc/hsw-ipc.c
+++ b/src/ipc/hsw-ipc.c
@@ -215,11 +215,13 @@ int platform_ipc_init(struct ipc *ipc)
 	for (i = 0; i < MSG_QUEUE_SIZE; i++)
 		list_item_prepend(&ipc->message[i].list, &ipc->empty_list);
 
+#ifdef CONFIG_HOST_PTABLE
 	/* allocate page table buffer */
 	iipc->page_table = rzalloc(RZONE_SYS, SOF_MEM_CAPS_RAM,
 		PLATFORM_PAGE_TABLE_SIZE);
 	if (iipc->page_table)
 		bzero(iipc->page_table, PLATFORM_PAGE_TABLE_SIZE);
+#endif
 
 	/* request GP DMA with shared access privilege */
 	caps = 0;


### PR DESCRIPTION
Allocates page_table only if CONFIG_HOST_PTABLE is defined.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>