### PR TITLE
ipc: fix position notifications

### DIFF
--- a/src/include/sof/ipc.h
+++ b/src/include/sof/ipc.h
@@ -126,10 +126,8 @@ int ipc_stream_send_position(struct comp_dev *cdev,
 int ipc_stream_send_xrun(struct comp_dev *cdev,
 	struct sof_ipc_stream_posn *posn);
 
-int ipc_queue_host_message(struct ipc *ipc, uint32_t header,
-	void *tx_data, size_t tx_bytes, void *rx_data,
-	size_t rx_bytes, void (*cb)(void*, void*), void *cb_data, uint32_t replace);
-int ipc_send_short_msg(uint32_t msg);
+int ipc_queue_host_message(struct ipc *ipc, uint32_t header, void *tx_data,
+			   size_t tx_bytes, uint32_t replace);
 
 void ipc_platform_do_cmd(struct ipc *ipc);
 void ipc_platform_send_msg(struct ipc *ipc);


### PR DESCRIPTION
Fixes notification data for position and xrun notifications.
Data sent to host was invalid.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>