### PR TITLE
pipeline: trigger ppl on different core

### DIFF
--- a/src/arch/xtensa/smp/cpu.c
+++ b/src/arch/xtensa/smp/cpu.c
@@ -43,6 +43,11 @@
 #include <sof/lock.h>
 #include <sof/schedule.h>
 
+/* cpu tracing */
+#define trace_cpu(__e) trace_event(TRACE_CLASS_CPU, __e)
+#define trace_cpu_error(__e) trace_error(TRACE_CLASS_CPU, __e)
+#define tracev_cpu(__e) tracev_event(TRACE_CLASS_CPU, __e)
+
 static uint32_t active_cores_mask = 0x1;
 static spinlock_t lock = { 0 };
 

--- a/src/include/sof/trace.h
+++ b/src/include/sof/trace.h
@@ -103,6 +103,7 @@
 #define TRACE_CLASS_DMIC	(22 << 24)
 #define TRACE_CLASS_POWER	(23 << 24)
 #define TRACE_CLASS_IDC		(24 << 24)
+#define TRACE_CLASS_CPU		(25 << 24)
 
 /* move to config.h */
 #define TRACE	1


### PR DESCRIPTION
Implements function, which allows to trigger pipeline
on different core than master. Core id is chosen
via pipeline IPC message.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>