### PR TITLE
ipc: add ipc_shared_context

### DIFF
--- a/src/include/sof/ipc.h
+++ b/src/include/sof/ipc.h
@@ -82,29 +82,34 @@ struct ipc_msg {
 	void *cb_data;
 };
 
-struct ipc {
-	/* messaging */
-	uint32_t host_msg;		/* current message from host */
-	struct ipc_msg *dsp_msg;		/* current message to host */
-	uint32_t host_pending;
+struct ipc_shared_context {
+	struct ipc_msg *dsp_msg;	/* current message to host */
 	uint32_t dsp_pending;
 	struct list_item msg_list;
 	struct list_item empty_list;
-	spinlock_t lock;
 	struct ipc_msg message[MSG_QUEUE_SIZE];
+
+	struct list_item comp_list;	/* list of component devices */
+};
+
+struct ipc {
+	/* messaging */
+	uint32_t host_msg;		/* current message from host */
+	uint32_t host_pending;
+	spinlock_t lock;
 	void *comp_data;
 
 	/* RX call back */
 	int (*cb)(struct ipc_msg *msg);
-
-	/* pipelines, components and buffers */
-	struct list_item comp_list;		/* list of component devices */
 
 	/* DMA for Trace*/
 	struct dma_trace_data *dmat;
 
 	/* mmap for posn_offset */
 	struct pipeline *posn_map[PLATFORM_MAX_STREAMS];
+
+	/* context shared between cores */
+	struct ipc_shared_context *shared_ctx;
 
 	void *private;
 };

--- a/src/ipc/apl-ipc.c
+++ b/src/ipc/apl-ipc.c
@@ -153,23 +153,24 @@ void ipc_platform_send_msg(struct ipc *ipc)
 	spin_lock_irq(&ipc->lock, flags);
 
 	/* any messages to send ? */
-	if (list_is_empty(&ipc->msg_list)) {
-		ipc->dsp_pending = 0;
+	if (list_is_empty(&ipc->shared_ctx->msg_list)) {
+		ipc->shared_ctx->dsp_pending = 0;
 		goto out;
 	}
 
 	/* now send the message */
-	msg = list_first_item(&ipc->msg_list, struct ipc_msg, list);
+	msg = list_first_item(&ipc->shared_ctx->msg_list, struct ipc_msg,
+			      list);
 	mailbox_dspbox_write(0, msg->tx_data, msg->tx_size);
 	list_item_del(&msg->list);
-	ipc->dsp_msg = msg;
+	ipc->shared_ctx->dsp_msg = msg;
 	tracev_ipc("Msg");
 
 	/* now interrupt host to tell it we have message sent */
 	ipc_write(IPC_DIPCIE, 0);
 	ipc_write(IPC_DIPCI, 0x80000000 | msg->header);
 
-	list_item_append(&msg->list, &ipc->empty_list);
+	list_item_append(&msg->list, &ipc->shared_ctx->empty_list);
 
 out:
 	spin_unlock_irq(&ipc->lock, flags);
@@ -179,7 +180,6 @@ int platform_ipc_init(struct ipc *ipc)
 {
 	struct intel_ipc_data *iipc;
 	uint32_t dir, caps, dev;
-	int i;
 
 	_ipc = ipc;
 
@@ -187,12 +187,6 @@ int platform_ipc_init(struct ipc *ipc)
 	iipc = rzalloc(RZONE_SYS, SOF_MEM_CAPS_RAM,
 		sizeof(struct intel_ipc_data));
 	ipc_set_drvdata(_ipc, iipc);
-	_ipc->dsp_msg = NULL;
-	list_init(&ipc->empty_list);
-	list_init(&ipc->msg_list);
-	spinlock_init(&ipc->lock);
-	for (i = 0; i < MSG_QUEUE_SIZE; i++)
-		list_item_prepend(&ipc->message[i].list, &ipc->empty_list);
 
 #ifdef CONFIG_HOST_PTABLE
 	/* allocate page table buffer */

--- a/src/ipc/byt-ipc.c
+++ b/src/ipc/byt-ipc.c
@@ -62,7 +62,7 @@ static void do_notify(void)
 	tracev_ipc("Not");
 
 	spin_lock_irq(&_ipc->lock, flags);
-	msg = _ipc->dsp_msg;
+	msg = _ipc->shared_ctx->dsp_msg;
 	if (msg == NULL)
 		goto out;
 
@@ -74,7 +74,7 @@ static void do_notify(void)
 	if (msg->cb)
 		msg->cb(msg->cb_data, msg->rx_data);
 
-	list_item_append(&msg->list, &_ipc->empty_list);
+	list_item_append(&msg->list, &_ipc->shared_ctx->empty_list);
 
 out:
 	spin_unlock_irq(&_ipc->lock, flags);
@@ -173,8 +173,8 @@ void ipc_platform_send_msg(struct ipc *ipc)
 	spin_lock_irq(&ipc->lock, flags);
 
 	/* any messages to send ? */
-	if (list_is_empty(&ipc->msg_list)) {
-		ipc->dsp_pending = 0;
+	if (list_is_empty(&ipc->shared_ctx->msg_list)) {
+		ipc->shared_ctx->dsp_pending = 0;
 		goto out;
 	}
 
@@ -183,17 +183,18 @@ void ipc_platform_send_msg(struct ipc *ipc)
 		goto out;
 
 	/* now send the message */
-	msg = list_first_item(&ipc->msg_list, struct ipc_msg, list);
+	msg = list_first_item(&ipc->shared_ctx->msg_list, struct ipc_msg,
+			      list);
 	mailbox_dspbox_write(0, msg->tx_data, msg->tx_size);
 	list_item_del(&msg->list);
-	ipc->dsp_msg = msg;
+	ipc->shared_ctx->dsp_msg = msg;
 	tracev_ipc("Msg");
 
 	/* now interrupt host to tell it we have message sent */
 	shim_write(SHIM_IPCDL, msg->header);
 	shim_write(SHIM_IPCDH, SHIM_IPCDH_BUSY);
 
-	list_item_append(&msg->list, &ipc->empty_list);
+	list_item_append(&msg->list, &ipc->shared_ctx->empty_list);
 
 out:
 	spin_unlock_irq(&ipc->lock, flags);
@@ -203,7 +204,6 @@ int platform_ipc_init(struct ipc *ipc)
 {
 	struct intel_ipc_data *iipc;
 	uint32_t imrd, dir, caps, dev;
-	int i;
 
 	_ipc = ipc;
 
@@ -211,13 +211,6 @@ int platform_ipc_init(struct ipc *ipc)
 	iipc = rzalloc(RZONE_SYS, SOF_MEM_CAPS_RAM,
 		sizeof(struct intel_ipc_data));
 	ipc_set_drvdata(_ipc, iipc);
-	_ipc->dsp_msg = NULL;
-	list_init(&ipc->empty_list);
-	list_init(&ipc->msg_list);
-	spinlock_init(&ipc->lock);
-
-	for (i = 0; i < MSG_QUEUE_SIZE; i++)
-		list_item_prepend(&ipc->message[i].list, &ipc->empty_list);
 
 #ifdef CONFIG_HOST_PTABLE
 	/* allocate page table buffer */

--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -991,8 +991,9 @@ static inline struct ipc_msg *msg_get_empty(struct ipc *ipc)
 {
 	struct ipc_msg *msg = NULL;
 
-	if (!list_is_empty(&ipc->empty_list)) {
-		msg = list_first_item(&ipc->empty_list, struct ipc_msg, list);
+	if (!list_is_empty(&ipc->shared_ctx->empty_list)) {
+		msg = list_first_item(&ipc->shared_ctx->empty_list,
+				      struct ipc_msg, list);
 		list_item_del(&msg->list);
 	}
 
@@ -1015,7 +1016,7 @@ static inline struct ipc_msg *ipc_glb_stream_message_find(struct ipc *ipc,
 	case iCS(SOF_IPC_STREAM_POSITION):
 
 		/* iterate host message list for searching */
-		list_for_item(plist, &ipc->msg_list) {
+		list_for_item(plist, &ipc->shared_ctx->msg_list) {
 			msg = container_of(plist, struct ipc_msg, list);
 			if (msg->header == posn->rhdr.hdr.cmd) {
 				old_posn = (struct sof_ipc_stream_posn *)msg->tx_data;
@@ -1045,7 +1046,7 @@ static inline struct ipc_msg *ipc_glb_trace_message_find(struct ipc *ipc,
 	switch (cmd) {
 	case iCS(SOF_IPC_TRACE_DMA_POSITION):
 		/* iterate host message list for searching */
-		list_for_item(plist, &ipc->msg_list) {
+		list_for_item(plist, &ipc->shared_ctx->msg_list) {
 			msg = container_of(plist, struct ipc_msg, list);
 			if (msg->header == posn->rhdr.hdr.cmd)
 				return msg;
@@ -1115,8 +1116,8 @@ int ipc_queue_host_message(struct ipc *ipc, uint32_t header, void *tx_data,
 
 	if (!found) {
 		/* now queue the message */
-		ipc->dsp_pending = 1;
-		list_item_append(&msg->list, &ipc->msg_list);
+		ipc->shared_ctx->dsp_pending = 1;
+		list_item_append(&msg->list, &ipc->shared_ctx->msg_list);
 	}
 
 out:
@@ -1129,7 +1130,7 @@ int ipc_process_msg_queue(void)
 {
 	if (_ipc->host_pending)
 		ipc_platform_do_cmd(_ipc);
-	if (_ipc->dsp_pending)
+	if (_ipc->shared_ctx->dsp_pending)
 		ipc_platform_send_msg(_ipc);
 	return 0;
 }

--- a/src/ipc/hsw-ipc.c
+++ b/src/ipc/hsw-ipc.c
@@ -62,7 +62,7 @@ static void do_notify(void)
 	tracev_ipc("Not");
 
 	spin_lock_irq(&_ipc->lock, flags);
-	msg = _ipc->dsp_msg;
+	msg = _ipc->shared_ctx->dsp_msg;
 	if (msg == NULL)
 		goto out;
 
@@ -74,7 +74,7 @@ static void do_notify(void)
 	if (msg->cb)
 		msg->cb(msg->cb_data, msg->rx_data);
 
-	list_item_append(&msg->list, &_ipc->empty_list);
+	list_item_append(&msg->list, &_ipc->shared_ctx->empty_list);
 
 out:
 	spin_unlock_irq(&_ipc->lock, flags);
@@ -170,8 +170,8 @@ void ipc_platform_send_msg(struct ipc *ipc)
 	spin_lock_irq(&ipc->lock, flags);
 
 	/* any messages to send ? */
-	if (list_is_empty(&ipc->msg_list)) {
-		ipc->dsp_pending = 0;
+	if (list_is_empty(&ipc->shared_ctx->msg_list)) {
+		ipc->shared_ctx->dsp_pending = 0;
 		goto out;
 	}
 
@@ -180,16 +180,17 @@ void ipc_platform_send_msg(struct ipc *ipc)
 		goto out;
 
 	/* now send the message */
-	msg = list_first_item(&ipc->msg_list, struct ipc_msg, list);
+	msg = list_first_item(&ipc->shared_ctx->msg_list, struct ipc_msg,
+			      list);
 	mailbox_dspbox_write(0, msg->tx_data, msg->tx_size);
 	list_item_del(&msg->list);
-	ipc->dsp_msg = msg;
+	ipc->shared_ctx->dsp_msg = msg;
 	tracev_ipc("Msg");
 
 	/* now interrupt host to tell it we have message sent */
 	shim_write(SHIM_IPCD, SHIM_IPCD_BUSY);
 
-	list_item_append(&msg->list, &ipc->empty_list);
+	list_item_append(&msg->list, &ipc->shared_ctx->empty_list);
 
 out:
 	spin_unlock_irq(&ipc->lock, flags);
@@ -199,7 +200,6 @@ int platform_ipc_init(struct ipc *ipc)
 {
 	struct intel_ipc_data *iipc;
 	uint32_t imrd, dir, caps, dev;
-	int i;
 
 	_ipc = ipc;
 
@@ -207,13 +207,6 @@ int platform_ipc_init(struct ipc *ipc)
 	iipc = rzalloc(RZONE_SYS, SOF_MEM_CAPS_RAM,
 		sizeof(struct intel_ipc_data));
 	ipc_set_drvdata(_ipc, iipc);
-	_ipc->dsp_msg = NULL;
-	list_init(&ipc->empty_list);
-	list_init(&ipc->msg_list);
-	spinlock_init(&ipc->lock);
-
-	for (i = 0; i < MSG_QUEUE_SIZE; i++)
-		list_item_prepend(&ipc->message[i].list, &ipc->empty_list);
 
 #ifdef CONFIG_HOST_PTABLE
 	/* allocate page table buffer */

--- a/src/ipc/ipc.c
+++ b/src/ipc/ipc.c
@@ -55,7 +55,7 @@ struct ipc_comp_dev *ipc_get_comp(struct ipc *ipc, uint32_t id)
 	struct ipc_comp_dev *icd;
 	struct list_item *clist;
 
-	list_for_item(clist, cache_to_uncache(&ipc->comp_list)) {
+	list_for_item(clist, &ipc->shared_ctx->comp_list) {
 		icd = container_of(clist, struct ipc_comp_dev, list);
 		switch (icd->type) {
 		case COMP_TYPE_COMPONENT:
@@ -132,7 +132,7 @@ int ipc_comp_new(struct ipc *ipc, struct sof_ipc_comp *comp)
 	icd->type = COMP_TYPE_COMPONENT;
 
 	/* add new component to the list */
-	list_item_append(&icd->list, cache_to_uncache(&ipc->comp_list));
+	list_item_append(&icd->list, &ipc->shared_ctx->comp_list);
 	return ret;
 }
 
@@ -185,7 +185,7 @@ int ipc_buffer_new(struct ipc *ipc, struct sof_ipc_buffer *desc)
 	ibd->type = COMP_TYPE_BUFFER;
 
 	/* add new buffer to the list */
-	list_item_append(&ibd->list, cache_to_uncache(&ipc->comp_list));
+	list_item_append(&ibd->list, &ipc->shared_ctx->comp_list);
 	return ret;
 }
 
@@ -291,7 +291,7 @@ int ipc_pipeline_new(struct ipc *ipc,
 	ipc_pipe->type = COMP_TYPE_PIPELINE;
 
 	/* add new pipeline to the list */
-	list_item_append(&ipc_pipe->list, cache_to_uncache(&ipc->comp_list));
+	list_item_append(&ipc_pipe->list, &ipc->shared_ctx->comp_list);
 	return 0;
 }
 
@@ -338,7 +338,7 @@ int ipc_comp_dai_config(struct ipc *ipc, struct sof_ipc_dai_config *config)
 	int ret = 0;
 
 	/* for each component */
-	list_for_item(clist, cache_to_uncache(&ipc->comp_list)) {
+	list_for_item(clist, &ipc->shared_ctx->comp_list) {
 		icd = container_of(clist, struct ipc_comp_dev, list);
 		switch (icd->type) {
 		case COMP_TYPE_COMPONENT:
@@ -513,10 +513,22 @@ int ipc_init(struct sof *sof)
 	for (i = 0; i < PLATFORM_MAX_STREAMS; i++)
 		sof->ipc->posn_map[i] = NULL;
 
-	dcache_writeback_invalidate_region(sof->ipc, sizeof(*sof->ipc));
+	spinlock_init(&sof->ipc->lock);
 
-	/* component list shared between cores */
-	list_init(cache_to_uncache(&sof->ipc->comp_list));
+	sof->ipc->shared_ctx = rzalloc(RZONE_SYS | RZONE_FLAG_UNCACHED,
+				       SOF_MEM_CAPS_RAM,
+				       sizeof(*sof->ipc->shared_ctx));
+
+	dcache_writeback_region(sof->ipc, sizeof(*sof->ipc));
+
+	sof->ipc->shared_ctx->dsp_msg = NULL;
+	list_init(&sof->ipc->shared_ctx->empty_list);
+	list_init(&sof->ipc->shared_ctx->msg_list);
+	list_init(&sof->ipc->shared_ctx->comp_list);
+
+	for (i = 0; i < MSG_QUEUE_SIZE; i++)
+		list_item_prepend(&sof->ipc->shared_ctx->message[i].list,
+				  &sof->ipc->shared_ctx->empty_list);
 
 	return platform_ipc_init(sof->ipc);
 }


### PR DESCRIPTION
Implements ipc_shared_context struct, which allocates
notification related fields in uncached memory. This
way slave cores can add to queue stream notifications.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>