### PR TITLE
ipc: use scheduler task for IPC process

### DIFF
--- a/src/include/sof/ipc.h
+++ b/src/include/sof/ipc.h
@@ -106,6 +106,9 @@ struct ipc {
 	/* mmap for posn_offset */
 	struct pipeline *posn_map[PLATFORM_MAX_STREAMS];
 
+	/* processing task */
+	struct task ipc_task;
+
 	void *private;
 };
 
@@ -120,6 +123,8 @@ int platform_ipc_init(struct ipc *ipc);
 void ipc_free(struct ipc *ipc);
 
 int ipc_process_msg_queue(void);
+void ipc_process_task(void *data);
+void ipc_schedule_process(struct ipc *ipc);
 
 int ipc_stream_send_position(struct comp_dev *cdev,
 		struct sof_ipc_stream_posn *posn);

--- a/src/ipc/apl-ipc.c
+++ b/src/ipc/apl-ipc.c
@@ -77,11 +77,13 @@ static void irq_handler(void *arg)
 
 		/* TODO: place message in Q and process later */
 		/* It's not Q ATM, may overwrite */
-		if (_ipc->host_pending)
+		if (_ipc->host_pending) {
 			trace_ipc_error("Pen");
-		_ipc->host_msg = msg;
-		_ipc->host_pending = 1;
-
+		} else {
+			_ipc->host_msg = msg;
+			_ipc->host_pending = 1;
+			ipc_schedule_process(_ipc);
+		}
 	}
 
 	/* reply message(done) from host */
@@ -195,6 +197,10 @@ int platform_ipc_init(struct ipc *ipc)
 	spinlock_init(&ipc->lock);
 	for (i = 0; i < MSG_QUEUE_SIZE; i++)
 		list_item_prepend(&ipc->message[i].list, &ipc->empty_list);
+
+	/* schedule */
+	schedule_task_init(&_ipc->ipc_task, ipc_process_task, _ipc);
+	schedule_task_config(&_ipc->ipc_task, 0, 0);
 
 	/* allocate page table buffer */
 	iipc->page_table = rballoc(RZONE_SYS, SOF_MEM_CAPS_RAM,

--- a/src/ipc/byt-ipc.c
+++ b/src/ipc/byt-ipc.c
@@ -111,10 +111,13 @@ static void irq_handler(void *arg)
 
 		/* TODO: place message in Q and process later */
 		/* It's not Q ATM, may overwrite */
-		if (_ipc->host_pending)
+		if (_ipc->host_pending) {
 			trace_ipc_error("Pen");
-		_ipc->host_msg = shim_read(SHIM_IPCXL);
-		_ipc->host_pending = 1;
+		} else {
+			_ipc->host_msg = shim_read(SHIM_IPCXL);
+			_ipc->host_pending = 1;
+			ipc_schedule_process(_ipc);
+		}
 	}
 }
 
@@ -218,6 +221,10 @@ int platform_ipc_init(struct ipc *ipc)
 
 	for (i = 0; i < MSG_QUEUE_SIZE; i++)
 		list_item_prepend(&ipc->message[i].list, &ipc->empty_list);
+
+	/* schedule */
+	schedule_task_init(&_ipc->ipc_task, ipc_process_task, _ipc);
+	schedule_task_config(&_ipc->ipc_task, 0, 0);
 
 	/* allocate page table buffer */
 	iipc->page_table = rzalloc(RZONE_SYS, SOF_MEM_CAPS_RAM,

--- a/src/ipc/cnl-ipc.c
+++ b/src/ipc/cnl-ipc.c
@@ -78,10 +78,13 @@ static void irq_handler(void *arg)
 
 		/* TODO: place message in Q and process later */
 		/* It's not Q ATM, may overwrite */
-		if (_ipc->host_pending)
+		if (_ipc->host_pending) {
 			trace_ipc_error("Pen");
-		_ipc->host_msg = msg;
-		_ipc->host_pending = 1;
+		} else {
+			_ipc->host_msg = msg;
+			_ipc->host_pending = 1;
+			ipc_schedule_process(_ipc);
+		}
 	}
 
 	/* reply message(done) from host */
@@ -196,6 +199,10 @@ int platform_ipc_init(struct ipc *ipc)
 	spinlock_init(&ipc->lock);
 	for (i = 0; i < MSG_QUEUE_SIZE; i++)
 		list_item_prepend(&ipc->message[i].list, &ipc->empty_list);
+
+	/* schedule */
+	schedule_task_init(&_ipc->ipc_task, ipc_process_task, _ipc);
+	schedule_task_config(&_ipc->ipc_task, 0, 0);
 
 	/* allocate page table buffer */
 	iipc->page_table = rballoc(RZONE_SYS, SOF_MEM_CAPS_RAM,

--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -1122,9 +1122,18 @@ out:
 /* process current message */
 int ipc_process_msg_queue(void)
 {
-	if (_ipc->host_pending)
-		ipc_platform_do_cmd(_ipc);
 	if (_ipc->dsp_pending)
 		ipc_platform_send_msg(_ipc);
 	return 0;
+}
+
+void ipc_process_task(void *data)
+{
+	if (_ipc->host_pending)
+		ipc_platform_do_cmd(_ipc);
+}
+
+void ipc_schedule_process(struct ipc *ipc)
+{
+	schedule_task(&ipc->ipc_task, 0, 100);
 }


### PR DESCRIPTION
IPC process is handled after wait_for_interrupt, but there may some IPC
is handled outside this WFI function. Use scheduler to avoid wait for
IRQ caused IPC timeout.

fix #238