### PR TITLE
dma: hda: 2nd playback with existing topology fixed

### DIFF
--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -495,6 +495,8 @@ static int dai_reset(struct comp_dev *dev)
 
 	trace_dai("res");
 
+	dma_channel_put(dd->dma, dd->chan);
+
 	list_for_item_safe(elist, tlist, &config->elem_list) {
 		elem = container_of(elist, struct dma_sg_elem, list);
 		list_item_del(&elem->list);

--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -674,14 +674,16 @@ static int host_reset(struct comp_dev *dev)
 			    struct dma_sg_elem, list);
 	/*
 	 * here free dma_sg_elem those allocated in create_local_elems(),
-	 * we should keep header and the first local elem after reset
+	 * we should keep header and the first local elem after reset (but only
+	 * for dw-dma since hda-dma allocates the full list again)
 	 */
 	list_for_item_safe(elist, tlist, &e->list) {
 		e = container_of(elist, struct dma_sg_elem, list);
-
+#if !defined CONFIG_DMA_GW
 		/* should not free the header, finished */
 		if (elist == &hd->config.elem_list)
 			break;
+#endif
 		list_item_del(&e->list);
 		rfree(e);
 	}


### PR DESCRIPTION
Host comp must delete sgl completely on reset since
it is fully re-created on params.

Dai comp must free the dma channel on reset since it
is acquired again on params (stream tag may change).

Signed-off-by: Marcin Maka <marcin.maka@linux.intel.com>