### PR TITLE
Host platform library: Fix compilation after git merge from next branch

### DIFF
--- a/src/arch/host/include/arch/cpu.h
+++ b/src/arch/host/include/arch/cpu.h
@@ -25,49 +25,38 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
- *         Liam Girdwood <liam.r.girdwood@linux.intel.com>
- *         Keyon Jie <yang.jie@linux.intel.com>
- *	   Ranjani Sridharan <ranjani.sridharan@linux.intel.com>
+ * Author: Rander Wang <rander.wang@linux.intel.com>
+ *
  */
 
-#include <sof/ipc.h>
-#include <sof/intel-ipc.h>
+#ifndef __INCLUDE_ARCH_CPU__
+#define __INCLUDE_ARCH_CPU__
 
-/* testbench ipc */
-struct ipc *_ipc;
-
-int platform_ipc_init(struct ipc *ipc)
+static inline void arch_cpu_enable_core(int id)
 {
-	struct intel_ipc_data *iipc;
-
-	_ipc = ipc;
-
-	/* init ipc data */
-	iipc = malloc(sizeof(struct intel_ipc_data));
-	ipc_set_drvdata(_ipc, iipc);
-
-	/* allocate page table buffer */
-	iipc->page_table = malloc(HOST_PAGE_SIZE);
-	if (iipc->page_table)
-		bzero(iipc->page_table, HOST_PAGE_SIZE);
-
-	/* PM */
-	iipc->pm_prepare_D3 = 0;
-
-	return 0;
 }
 
-/* The following definitions are to satisfy libsof linker errors */
+static inline void arch_cpu_disable_core(int id)
+{
+}
 
-int ipc_stream_send_position(struct comp_dev *cdev,
-			     struct sof_ipc_stream_posn *posn)
+static inline int arch_cpu_is_core_enabled(int id)
 {
 	return 0;
 }
 
-int ipc_stream_send_xrun(struct comp_dev *cdev,
-			 struct sof_ipc_stream_posn *posn)
+static inline int arch_cpu_get_id(void)
 {
 	return 0;
 }
+
+static inline void cpu_write_threadptr(int threadptr)
+{
+}
+
+static inline int cpu_read_threadptr(void)
+{
+	return 0;
+}
+
+#endif

--- a/src/arch/host/include/arch/sof.h
+++ b/src/arch/host/include/arch/sof.h
@@ -42,6 +42,9 @@
 /* architecture specific stack frames to dump */
 #define ARCH_STACK_DUMP_FRAMES		32
 
+/* data cache line alignment */
+#define PLATFORM_DCACHE_ALIGN	sizeof(uint32_t)
+
 static inline void *arch_get_stack_ptr(void)
 {
 	void *frames[ARCH_STACK_DUMP_FRAMES];

--- a/src/arch/host/include/arch/task.h
+++ b/src/arch/host/include/arch/task.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Intel Corporation
+ * Copyright (c) 2017, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,49 +25,35 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
- *         Liam Girdwood <liam.r.girdwood@linux.intel.com>
- *         Keyon Jie <yang.jie@linux.intel.com>
- *	   Ranjani Sridharan <ranjani.sridharan@linux.intel.com>
+ * Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
+ *
  */
 
-#include <sof/ipc.h>
-#include <sof/intel-ipc.h>
+/**
+ * \file arch/xtensa/include/arch/task.h
+ * \brief Arch task header file
+ * \authors Liam Girdwood <liam.r.girdwood@linux.intel.com>
+ */
 
-/* testbench ipc */
-struct ipc *_ipc;
+#ifndef __ARCH_TASK_H_
+#define __ARCH_TASK_H_
 
-int platform_ipc_init(struct ipc *ipc)
-{
-	struct intel_ipc_data *iipc;
+#include <sof/schedule.h>
 
-	_ipc = ipc;
-
-	/* init ipc data */
-	iipc = malloc(sizeof(struct intel_ipc_data));
-	ipc_set_drvdata(_ipc, iipc);
-
-	/* allocate page table buffer */
-	iipc->page_table = malloc(HOST_PAGE_SIZE);
-	if (iipc->page_table)
-		bzero(iipc->page_table, HOST_PAGE_SIZE);
-
-	/* PM */
-	iipc->pm_prepare_D3 = 0;
-
-	return 0;
-}
-
-/* The following definitions are to satisfy libsof linker errors */
-
-int ipc_stream_send_position(struct comp_dev *cdev,
-			     struct sof_ipc_stream_posn *posn)
+/**
+ * \brief Allocates IRQ tasks.
+ */
+static inline int arch_allocate_tasks(void)
 {
 	return 0;
 }
 
-int ipc_stream_send_xrun(struct comp_dev *cdev,
-			 struct sof_ipc_stream_posn *posn)
+/**
+ * \brief Runs task.
+ * \param[in,out] task Task data.
+ */
+static inline void arch_run_task(struct task *task)
 {
-	return 0;
 }
+
+#endif

--- a/src/audio/eq_fir.c
+++ b/src/audio/eq_fir.c
@@ -124,7 +124,6 @@ static void eq_fir_free_delaylines(struct fir_state_32x16 fir[])
 
 	if (data) {
 		trace_eq("fr1");
-		trace_value((uint32_t)data);
 
 		rfree(data);
 
@@ -222,7 +221,6 @@ static int eq_fir_setup(struct fir_state_32x16 fir[],
 	for (i = 0; i < nch; i++) {
 		resp = assign_response[i];
 		if (resp >= 0) {
-			trace_value((uint32_t)fir_data);
 			trace_value(fir->length);
 			fir_init_delay(&fir[i], &fir_data);
 		}

--- a/src/host/common_test.c
+++ b/src/host/common_test.c
@@ -38,6 +38,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
+#include <arch/sof.h>
 #include <sof/task.h>
 #include <sof/alloc.h>
 #include <sof/ipc.h>

--- a/src/host/testbench.c
+++ b/src/host/testbench.c
@@ -129,7 +129,7 @@ static void free_comps(void)
 	struct list_item *temp;
 	struct ipc_comp_dev *icd = NULL;
 
-	list_for_item_safe(clist, temp, &sof.ipc->comp_list) {
+	list_for_item_safe(clist, temp, &sof.ipc->shared_ctx->comp_list) {
 		icd = container_of(clist, struct ipc_comp_dev, list);
 		switch (icd->type) {
 		case COMP_TYPE_COMPONENT:

--- a/src/library/include/platform/idc.h
+++ b/src/library/include/platform/idc.h
@@ -25,49 +25,23 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
- *         Liam Girdwood <liam.r.girdwood@linux.intel.com>
- *         Keyon Jie <yang.jie@linux.intel.com>
- *	   Ranjani Sridharan <ranjani.sridharan@linux.intel.com>
+ * Author: Tomasz Lauda <tomasz.lauda@linux.intel.com>
  */
 
-#include <sof/ipc.h>
-#include <sof/intel-ipc.h>
+#ifndef __INCLUDE_PLATFORM_IDC_H__
+#define __INCLUDE_PLATFORM_IDC_H__
 
-/* testbench ipc */
-struct ipc *_ipc;
-
-int platform_ipc_init(struct ipc *ipc)
-{
-	struct intel_ipc_data *iipc;
-
-	_ipc = ipc;
-
-	/* init ipc data */
-	iipc = malloc(sizeof(struct intel_ipc_data));
-	ipc_set_drvdata(_ipc, iipc);
-
-	/* allocate page table buffer */
-	iipc->page_table = malloc(HOST_PAGE_SIZE);
-	if (iipc->page_table)
-		bzero(iipc->page_table, HOST_PAGE_SIZE);
-
-	/* PM */
-	iipc->pm_prepare_D3 = 0;
-
-	return 0;
-}
-
-/* The following definitions are to satisfy libsof linker errors */
-
-int ipc_stream_send_position(struct comp_dev *cdev,
-			     struct sof_ipc_stream_posn *posn)
+static inline int idc_send_msg(struct idc_msg *msg, uint32_t mode)
 {
 	return 0;
 }
 
-int ipc_stream_send_xrun(struct comp_dev *cdev,
-			 struct sof_ipc_stream_posn *posn)
+static inline void idc_process_msg_queue(void)
 {
-	return 0;
 }
+
+static inline void idc_init(void)
+{
+}
+
+#endif


### PR DESCRIPTION
Most of the errors are due to missing macros and header files. This
patch adds a number of minimal new header files into
src/arch/host/include/arch and src/library/include/platform.

The testbench ipc init is updated with previous changes of removed ipc
struct fields.

The testbench memory freeing code is updated with ipc struct change to
access comp_list.

The FIR EQ allocated pointer address tracing is removed since it is not
critical to trace. The pointer casting caused a compilation error for
host.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>