### PR TITLE
host: fix for uninitialized pointers

### DIFF
--- a/src/host/testbench.c
+++ b/src/host/testbench.c
@@ -67,7 +67,8 @@ int debug;
  */
 static void parse_libraries(char *libs)
 {
-	char *lib_token, *comp_token;
+	char *lib_token = NULL;
+	char *comp_token = NULL;
 	char *token = strtok_r(libs, ",", &lib_token);
 	char message[DEBUG_MSG_LEN];
 	int index;


### PR DESCRIPTION
For #282 
To make it work for some versions of gcc (5.4.0 for example).

Signed-off-by: Janusz Jankowski <janusz.jankowski@linux.intel.com>