### PR TITLE
EQ: Add check for configuration IPC and handle possible null pointers

### DIFF
--- a/src/audio/eq_fir.c
+++ b/src/audio/eq_fir.c
@@ -343,22 +343,15 @@ static int fir_cmd_get_data(struct comp_dev *dev,
 	case SOF_CTRL_CMD_BINARY:
 		trace_eq("gbi");
 
-		struct sof_eq_fir_config *cfg =
-			(struct sof_eq_fir_config *)cdata->data->data;
-
 		/* Copy back to user space */
-		bs = cfg->size;
-		if (bs > SOF_EQ_FIR_MAX_SIZE || bs < 1)
-			return -EINVAL;
-		if (!cd->config) {
-			cd->config = rzalloc(RZONE_RUNTIME,
-					     SOF_MEM_CAPS_RAM,
-					     bs);
-
-			if (!cd->config)
-				return -ENOMEM;
-
+		if (cd->config) {
+			bs = cd->config->size;
+			if (bs > SOF_EQ_FIR_MAX_SIZE || bs == 0)
+				return -EINVAL;
 			memcpy(cdata->data->data, cd->config, bs);
+		} else {
+			trace_eq_error("ecn");
+			ret = -EINVAL;
 		}
 		break;
 	default:

--- a/src/audio/eq_iir.c
+++ b/src/audio/eq_iir.c
@@ -160,7 +160,8 @@ static int eq_iir_setup(struct iir_state_df2t iir[],
 
 	/* Sanity checks */
 	if (nch > PLATFORM_MAX_CHANNELS ||
-	    config->channels_in_config > PLATFORM_MAX_CHANNELS) {
+	    config->channels_in_config > PLATFORM_MAX_CHANNELS ||
+	    !config->channels_in_config) {
 		trace_eq_error("ech");
 		return -EINVAL;
 	}
@@ -352,10 +353,10 @@ static int iir_cmd_get_data(struct comp_dev *dev,
 		trace_eq("gbi");
 
 		/* Copy back to user space */
-		bs = cd->config->size;
-		if (bs > SOF_EQ_IIR_MAX_SIZE || bs == 0)
-			return -EINVAL;
-		if (!cd->config) {
+		if (cd->config) {
+			bs = cd->config->size;
+			if (bs > SOF_EQ_IIR_MAX_SIZE || bs == 0)
+				return -EINVAL;
 			memcpy(cdata->data->data, cd->config, bs);
 		} else {
 			trace_eq_error("ecn");


### PR DESCRIPTION
This patch set adds to IIR and FIR EQs code to handle properly previously missing exceptions in IPC. Also the FIR get binary data command handling was quite totally wrong.