### PR TITLE
dma-trace: workaround reschedule work fail

### DIFF
--- a/src/platform/apollolake/include/platform/platform.h
+++ b/src/platform/apollolake/include/platform/platform.h
@@ -104,7 +104,7 @@ struct sof;
  * the interval of reschedule DMA trace copying in special case like half
  * fullness of local DMA trace buffer
  */
-#define DMA_TRACE_RESCHEDULE_TIME	5
+#define DMA_TRACE_RESCHEDULE_TIME	500
 
 /* DSP should be idle in this time frame */
 #define PLATFORM_IDLE_TIME	750000

--- a/src/platform/baytrail/include/platform/platform.h
+++ b/src/platform/baytrail/include/platform/platform.h
@@ -94,7 +94,7 @@ struct sof;
  * the interval of reschedule DMA trace copying in special case like half
  * fullness of local DMA trace buffer
  */
-#define DMA_TRACE_RESCHEDULE_TIME	5
+#define DMA_TRACE_RESCHEDULE_TIME	500
 
 /* DSP should be idle in this time frame */
 #define PLATFORM_IDLE_TIME	750000

--- a/src/platform/cannonlake/include/platform/platform.h
+++ b/src/platform/cannonlake/include/platform/platform.h
@@ -110,7 +110,7 @@ struct sof;
  * the interval of reschedule DMA trace copying in special case like half
  * fullness of local DMA trace buffer
  */
-#define DMA_TRACE_RESCHEDULE_TIME	5
+#define DMA_TRACE_RESCHEDULE_TIME	500
 
 /* DSP should be idle in this time frame */
 #define PLATFORM_IDLE_TIME	750000

--- a/src/platform/haswell/include/platform/platform.h
+++ b/src/platform/haswell/include/platform/platform.h
@@ -93,7 +93,7 @@ struct sof;
  * the interval of reschedule DMA trace copying in special case like half
  * fullness of local DMA trace buffer
  */
-#define DMA_TRACE_RESCHEDULE_TIME	5
+#define DMA_TRACE_RESCHEDULE_TIME	500
 
 /* DSP should be idle in this time frame */
 #define PLATFORM_IDLE_TIME	750000


### PR DESCRIPTION
If reschedule work timeout is too small. The reschedule will fail.
Workaround this issue by increace the reschedule timeout.

workaround #286 to fix dma-trace random stop issue.