### PR TITLE
list: refine list_item_del to avoid make list corruption

### DIFF
--- a/src/include/sof/list.h
+++ b/src/include/sof/list.h
@@ -77,6 +77,7 @@ static inline void list_item_del(struct list_item *item)
 {
 	item->next->prev = item->prev;
 	item->prev->next = item->next;
+	list_init(item);
 }
 
 /* is list item the last item in list ? */


### PR DESCRIPTION
There are possible that we call list_item_del to same list item twice. This
will cause the list be into chaos. Reset the next and prev pointer to 0
to avoid risk.

Signed-off-by: Pan Xiuli <xiuli.pan@linux.intel.com>