### PR TITLE
ssp: cavs: make sure that SSP FIFO is empty

### DIFF
--- a/src/include/sof/ssp.h
+++ b/src/include/sof/ssp.h
@@ -146,12 +146,13 @@ extern const struct dai_ops ssp_ops;
 
 
 /* SSR bits */
-#define SSSR_TNF	(1 << 2)
-#define SSSR_RNE	(1 << 3)
-#define SSSR_BSY	(1 << 4)
-#define SSSR_TFS	(1 << 5)
-#define SSSR_RFS	(1 << 6)
-#define SSSR_ROR	(1 << 7)
+#define SSSR_TNF	BIT(2)
+#define SSSR_RNE	BIT(3)
+#define SSSR_BSY	BIT(4)
+#define SSSR_TFS	BIT(5)
+#define SSSR_RFS	BIT(6)
+#define SSSR_ROR	BIT(7)
+#define SSSR_TUR	BIT(21)
 
 /* SSPSP bits */
 #define SSPSP_SCMODE(x)		((x) << 0)

--- a/src/platform/apollolake/include/platform/platform.h
+++ b/src/platform/apollolake/include/platform/platform.h
@@ -133,6 +133,9 @@ struct sof;
 /* the watermark for the SSP fifo depth setting */
 #define SSP_FIFO_WATERMARK	8
 
+/* minimal SSP port stop delay in cycles */
+#define PLATFORM_SSP_STOP_DELAY	2400
+
 /* Platform defined panic code */
 static inline void platform_panic(uint32_t p)
 {

--- a/src/platform/cannonlake/include/platform/platform.h
+++ b/src/platform/cannonlake/include/platform/platform.h
@@ -130,6 +130,9 @@ struct sof;
 /* the watermark for the SSP fifo depth setting */
 #define SSP_FIFO_WATERMARK	8
 
+/* minimal SSP port stop delay in cycles */
+#define PLATFORM_SSP_STOP_DELAY	3000
+
 /* Platform defined trace code */
 static inline void platform_panic(uint32_t p)
 {

--- a/src/platform/icelake/include/platform/platform.h
+++ b/src/platform/icelake/include/platform/platform.h
@@ -130,6 +130,9 @@ struct sof;
 /* the watermark for the SSP fifo depth setting */
 #define SSP_FIFO_WATERMARK	8
 
+/* minimal SSP port stop delay in cycles */
+#define PLATFORM_SSP_STOP_DELAY	4800
+
 /* Platform defined trace code */
 static inline void platform_panic(uint32_t p)
 {


### PR DESCRIPTION
This patch implements delay before SSP stop
to make sure, that for transmitting the FIFO is empty
and for receiving the FIFO provides the real status.
Also it clears transmit underrun.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>