### PR TITLE
list: added list_item_del_init

### DIFF
--- a/src/include/sof/list.h
+++ b/src/include/sof/list.h
@@ -72,11 +72,22 @@ static inline void list_item_append(struct list_item *item,
 	list->prev = item;
 }
 
-/* delete item from the list */
+/* delete item from the list leaves deleted list item
+ *in undefined state list_is_empty won't return true
+ */
 static inline void list_item_del(struct list_item *item)
 {
 	item->next->prev = item->prev;
 	item->prev->next = item->next;
+}
+
+/* delete item from the list list iteam will be reinitialised
+ * and list_is_empty will return true
+ */
+static inline void list_item_del_init(struct list_item *item)
+{
+	list_item_del(item);
+	list_init(item);
 }
 
 /* is list item the last item in list ? */


### PR DESCRIPTION
Added function that will delete and reinitialize list.

Reinitialized lists show up as empty unlike deleted with
list_item_del.

Signed-off-by: Jakub Dabek <jakub.dabek@linux.intel.com>