### PR TITLE
pipeline: list delete on comp disconnect

### DIFF
--- a/src/audio/pipeline.c
+++ b/src/audio/pipeline.c
@@ -162,7 +162,7 @@ static void disconnect_upstream(struct pipeline *p, struct comp_dev *start,
 
 	/* disconnect source from buffer */
 	spin_lock(&current->lock);
-	list_item_del(&current->bsource_list);
+	list_item_del_init(&current->bsource_list);
 	spin_unlock(&current->lock);
 }
 
@@ -191,7 +191,7 @@ static void disconnect_downstream(struct pipeline *p, struct comp_dev *start,
 
 	/* disconnect source from buffer */
 	spin_lock(&current->lock);
-	list_item_del(&current->bsink_list);
+	list_item_del_init(&current->bsink_list);
 	spin_unlock(&current->lock);
 }
 


### PR DESCRIPTION
Changed list delete function used after comp disconection
so list item will return true on list_is_empty call.

Signed-off-by: Jakub Dabek <jakub.dabek@linux.intel.com>