### PR TITLE
pipe: remove waiti when task is cancelled

### DIFF
--- a/src/audio/pipeline.c
+++ b/src/audio/pipeline.c
@@ -1134,7 +1134,7 @@ void pipeline_schedule_cancel(struct pipeline *p)
 	int err;
 
 	/* cancel and wait for pipeline to complete */
-	err = schedule_task_cancel(&p->pipe_task, 1);
+	err = schedule_task_cancel(&p->pipe_task);
 	if (err < 0)
 		trace_pipe_error("pC0");
 }

--- a/src/include/sof/schedule.h
+++ b/src/include/sof/schedule.h
@@ -84,7 +84,7 @@ void schedule_task(struct task *task, uint64_t start, uint64_t deadline);
 
 void schedule_task_idle(struct task *task, uint64_t deadline);
 
-int schedule_task_cancel(struct task *task, int wait);
+int schedule_task_cancel(struct task *task);
 
 void schedule_task_complete(struct task *task);
 

--- a/src/lib/schedule.c
+++ b/src/lib/schedule.c
@@ -214,7 +214,7 @@ static struct task *schedule_edf(void)
 }
 
 /* cancel and delete task from scheduler - won't stop it if already running */
-int schedule_task_cancel(struct task *task, int wait)
+int schedule_task_cancel(struct task *task)
 {
 	uint32_t flags;
 	int ret = 0;
@@ -223,31 +223,17 @@ int schedule_task_cancel(struct task *task, int wait)
 
 	spin_lock_irq(&sch->lock, flags);
 
-	/* check current task state */
-	switch (task->state) {
-	case TASK_STATE_QUEUED:
+	/* check current task state, delete it if it is queued
+	 * if it is already running, nothing we can do about it atm
+	 */
+	if (task->state == TASK_STATE_QUEUED) {
 		/* delete task */
 		task->state = TASK_STATE_CANCEL;
 		list_item_del(&task->list);
-		break;
-	case TASK_STATE_RUNNING:
-		/* already running, nothing we can do about it atm */
-		if (wait) {
-			task->complete.timeout = SCHEDULE_TASK_MAX_TIME_SLICE;
-			spin_unlock_irq(&sch->lock, flags);
-			ret = wait_for_completion_timeout(&task->complete);
-			goto out;
-		} else {
-			ret = -EBUSY;
-		}
-		break;
-	default:
-		break;
 	}
 
 	spin_unlock_irq(&sch->lock, flags);
 
-out:
 	return ret;
 }
 


### PR DESCRIPTION
Two reasons: (1)waiti would cause FW panic if it is called in irq level
higher than passive level (2)no need to wait cancelled task to be complete.

Signed-off-by: Pan Xiuli <xiuli.pan@linux.intel.com>
Signed-off-by: Rander Wang <rander.wang@linux.intel.com>