### PR TITLE
dma-trace: tune the dma trace reschedule time

### DIFF
--- a/src/platform/apollolake/include/platform/platform.h
+++ b/src/platform/apollolake/include/platform/platform.h
@@ -104,7 +104,7 @@ struct sof;
  * the interval of reschedule DMA trace copying in special case like half
  * fullness of local DMA trace buffer
  */
-#define DMA_TRACE_RESCHEDULE_TIME	500
+#define DMA_TRACE_RESCHEDULE_TIME	100
 
 /* DSP should be idle in this time frame */
 #define PLATFORM_IDLE_TIME	750000

--- a/src/platform/baytrail/include/platform/platform.h
+++ b/src/platform/baytrail/include/platform/platform.h
@@ -94,7 +94,7 @@ struct sof;
  * the interval of reschedule DMA trace copying in special case like half
  * fullness of local DMA trace buffer
  */
-#define DMA_TRACE_RESCHEDULE_TIME	500
+#define DMA_TRACE_RESCHEDULE_TIME	100
 
 /* DSP should be idle in this time frame */
 #define PLATFORM_IDLE_TIME	750000

--- a/src/platform/cannonlake/include/platform/platform.h
+++ b/src/platform/cannonlake/include/platform/platform.h
@@ -110,7 +110,7 @@ struct sof;
  * the interval of reschedule DMA trace copying in special case like half
  * fullness of local DMA trace buffer
  */
-#define DMA_TRACE_RESCHEDULE_TIME	500
+#define DMA_TRACE_RESCHEDULE_TIME	100
 
 /* DSP should be idle in this time frame */
 #define PLATFORM_IDLE_TIME	750000

--- a/src/platform/haswell/include/platform/platform.h
+++ b/src/platform/haswell/include/platform/platform.h
@@ -93,7 +93,7 @@ struct sof;
  * the interval of reschedule DMA trace copying in special case like half
  * fullness of local DMA trace buffer
  */
-#define DMA_TRACE_RESCHEDULE_TIME	500
+#define DMA_TRACE_RESCHEDULE_TIME	100
 
 /* DSP should be idle in this time frame */
 #define PLATFORM_IDLE_TIME	750000


### PR DESCRIPTION
500us woulld cause dma trace buffer overflow at the boot up time.
Now refine it to 100us to make both scheduler and dma trace happy

Signed-off-by: Rander Wang <rander.wang@linux.intel.com>