### PR TITLE
dai: remove wait on stop

### DIFF
--- a/src/drivers/dw-dma.c
+++ b/src/drivers/dw-dma.c
@@ -440,22 +440,15 @@ out:
 static int dw_dma_release(struct dma *dma, int channel)
 {
 	struct dma_pdata *p = dma_get_drvdata(dma);
-	struct dw_lli2 *lli;
 	uint32_t flags;
 
 	spin_lock_irq(&dma->lock, flags);
 
 	trace_dma("Dpr");
 
-	/* get current lli */
-#if DW_USE_HW_LLI
-	lli = (struct dw_lli2 *)dw_read(dma, DW_LLP(channel));
-#else
-	lli = p->chan[channel].lli_current;
-#endif
-	/* get next lli and recover the lli to head for restart */
-	lli = (struct dw_lli2 *)lli->llp;
-	p->chan[channel].lli = lli;
+	/* get next lli for proper release */
+	p->chan[channel].lli_current =
+		(struct dw_lli2 *)p->chan[channel].lli_current->llp;
 
 	spin_unlock_irq(&dma->lock, flags);
 	return 0;


### PR DESCRIPTION
Removes wait on stop, as it's not needed.
Also this change fixes problems with sending IPC as
wait function lowers interrupt level, while IPCs are
now executed on irq task level.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>