### PR TITLE
dai: fix dai pointer for START

### DIFF
--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -543,8 +543,18 @@ static int dai_comp_trigger(struct comp_dev *dev, int cmd)
 	switch (cmd) {
 	case COMP_TRIGGER_START:
 		trace_dai("tsa");
-		if (!dd->pointer_init)
+		if (!dd->pointer_init) {
 			dai_pointer_init(dev);
+		} else {
+			/* recover state for ALSA XRUN */
+			if (dd->xrun == 0) {
+				/* set valid buffer pointer */
+				dai_buffer_process(dev);
+
+				/* recover valid start position */
+				ret = dma_release(dd->dma, dd->chan);
+			}
+		}
 		/* only start the DAI if we are not XRUN handling */
 		if (dd->xrun == 0) {
 			/* start the DAI */


### PR DESCRIPTION
After remove wait in dai trigger stop/puase we need also to
restore pointer for start just like release. 
Now same behavior for stop/start and pause/release.
Fix noise issue caused by ALSA XRUN

> 0xc30 [275.624383]      delta [1.475974]        volume xro //caused by did no update pointer at trigger start.
> 0xc40 [275.624393]      delta [0.000009]        pipe ePU
> 0xc50 [275.624394]      delta [0.000001]        value 0x0000000000000004
> 0xc60 [275.624395]      delta [0.000001]        pipe pxr
> 0xc70 [275.991686]      delta [0.367291]        volume xro
> 0xc80 [275.991695]      delta [0.000009]        pipe ePU
> 0xc90 [275.991696]      delta [0.000001]        value 0x0000000000000004
> 0xca0 [275.991698]      delta [0.000001]        pipe pxr

Addition fix for #320  #284 
May need to merge to master later.