### PR TITLE
byt: remove waiti on byt

### DIFF
--- a/src/ipc/pmc-ipc.c
+++ b/src/ipc/pmc-ipc.c
@@ -126,7 +126,7 @@ static void irq_handler(void *arg)
 int ipc_pmc_send_msg(uint32_t message)
 {
 	uint32_t ipclpesch;
-	uint32_t irq_mask;
+	int try = 0;
 
 	trace_ipc("SMs");
 
@@ -138,21 +138,22 @@ int ipc_pmc_send_msg(uint32_t message)
 		return -EAGAIN;
 	}
 
-	/* disable all interrupts except for SCU */
-	irq_mask = arch_interrupt_disable_mask(~(1 << IRQ_NUM_EXT_PMC));
-
 	/* send the new message */
 	shim_write(SHIM_IPCLPESCL, 0);
 	shim_write(SHIM_IPCLPESCH, SHIM_IPCLPESCH_BUSY | message);
 
-	/* now wait for clock change */
-	wait_for_interrupt(0);
-
-	/* enable other IRQs */
-	arch_interrupt_enable_mask(irq_mask);
-
 	/* check status */
 	ipclpesch = shim_read(SHIM_IPCLPESCH);
+
+	while (ipclpesch & SHIM_IPCLPESCH_BUSY) {
+		/* now wait for clock change */
+		idelay(PLATFORM_LPE_DELAY);
+		ipclpesch = shim_read(SHIM_IPCLPESCH);
+
+		try++;
+		if (try > 10)
+			break;
+	}
 
 	/* did command succeed */
 	if (ipclpesch & SHIM_IPCLPESCH_BUSY) {

--- a/src/platform/baytrail/include/platform/platform.h
+++ b/src/platform/baytrail/include/platform/platform.h
@@ -102,6 +102,9 @@ struct sof;
 /* DSP default delay in cycles */
 #define PLATFORM_DEFAULT_DELAY	12
 
+/* DSP LPE delay in cycles */
+#define PLATFORM_LPE_DELAY 2000
+
 /* Platform defined panic code */
 static inline void platform_panic(uint32_t p)
 {


### PR DESCRIPTION
waiti would cause FW panic if it is called in irq level
higher than passive level.

Test it on byt

Signed-off-by: Rander Wang <rander.wang@linux.intel.com>