### PR TITLE
Enforce implicit falltrough check for rimage and host builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -65,7 +65,7 @@ AM_CONDITIONAL(BUILD_LIB, test "$have_library" = "yes")
 AC_ARG_ENABLE(rimage, [AS_HELP_STRING([--enable-rimage],[build rimage tool])], have_rimage=$enableval, have_rimage=no)
 if test "$have_rimage" = "yes"; then
 	AC_DEFINE([CONFIG_RIMAGE], [1], [Configure to build rimage])
-	AM_CFLAGS="-O2 -g -Wall -Werror -Wl,-EL -Wmissing-prototypes"
+	AM_CFLAGS="-O2 -g -Wall -Werror -Wl,-EL -Wmissing-prototypes -Wimplicit-fallthrough=3"
 fi
 AM_CONDITIONAL(BUILD_RIMAGE, test "$have_rimage" = "yes")
 
@@ -117,9 +117,9 @@ case "$with_arch" in
 	ARCH_CFLAGS="-g"
 
 	# automake FLAGS defined here
-	AM_CFLAGS="-O3 -Wall -Werror -Wl,-EL -Wmissing-prototypes"
+	AM_CFLAGS="-O3 -Wall -Werror -Wl,-EL -Wmissing-prototypes -Wimplicit-fallthrough=3"
 	AM_LDFLAGS="-lpthread"
-	AM_CCASFLAGS="-O3 -Wall -Werror -Wl,-EL -Wmissing-prototypes"
+	AM_CCASFLAGS="-O3 -Wall -Werror -Wl,-EL -Wmissing-prototypes -Wimplicit-fallthrough=3"
 
 	ARCH="host"
 	AC_SUBST(ARCH)
@@ -403,7 +403,7 @@ fi
 AM_CONDITIONAL(HAVE_HIFI3, test "$have_hifi3" = "yes")
 AC_SUBST(HIFI3_CFLAGS)
 
-# Test after CFLAGS set othewise test of cross compiler fails. 
+# Test after CFLAGS set othewise test of cross compiler fails.
 AM_PROG_AS
 AM_PROG_AR
 AC_PROG_CC
@@ -554,4 +554,3 @@ A@&t@M_CFLAGS:                     ${AM_CFLAGS}
 A@&t@M_LDFLAGS:                    ${AM_LDFLAGS}
 A@&t@M_CCASFLAGS:                  ${AM_CCASFLAGS}
 "
-

--- a/rimage/manifest.c
+++ b/rimage/manifest.c
@@ -143,6 +143,7 @@ static int man_copy_sram(struct image *image, Elf32_Shdr *section,
 		break;
 	case SHT_NOBITS:
 		seg_type = SOF_MAN_SEGMENT_BSS;
+		/* FALLTHRU */
 	default:
 		return 0;
 	}


### PR DESCRIPTION
This patch adds the -Wimplicit-fallthrough=3 option into Makefiles to
check the switch case statements for possibly missed break statements.
Hence the build for those targets will need at least GCC7.

The only fix needed is for rimage target where a comment for falltrough
is added to mark it as intentional. Note that increase of check level
to 4 would intercept also such comments so it is not yet done. Other
modules like dai use already the commenting for intended falltrough.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>