### PR TITLE
trace: implement multicore traces

### DIFF
--- a/src/include/sof/trace.h
+++ b/src/include/sof/trace.h
@@ -105,6 +105,9 @@
 #define TRACE_CLASS_IDC		(24 << 24)
 #define TRACE_CLASS_CPU		(25 << 24)
 
+/* trace core id */
+#define TRACE_CORE_ID(x)	((uint64_t)(x) << 32)
+
 /* move to config.h */
 #define TRACE	1
 #define TRACEV	0


### PR DESCRIPTION
Implements multicore traces for both DMA and memory window mode.
Also adds core id to the logs.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>