### PR TITLE
dma: hda: playback preload phase synced with logical buffer state

### DIFF
--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -741,7 +741,7 @@ static int host_copy_int(struct comp_dev *dev, bool preload_run)
 #if defined CONFIG_DMA_GW
 	/* tell gateway to copy another period */
 	ret = dma_copy(hd->dma, hd->chan, hd->period_bytes,
-		       preload_run ? DMA_COPY_NO_COMMIT : 0);
+		       preload_run ? DMA_COPY_PRELOAD : 0);
 	if (ret < 0)
 		goto out;
 

--- a/src/include/sof/dma.h
+++ b/src/include/sof/dma.h
@@ -81,7 +81,7 @@
 #define DMA_IRQ_TYPE_LLIST	BIT(1)
 
 /* DMA copy flags */
-#define DMA_COPY_NO_COMMIT	BIT(0)
+#define DMA_COPY_PRELOAD	BIT(0)
 
 /* We will use this macro in cb handler to inform dma that
  * we need to stop the reload for special purpose


### PR DESCRIPTION
Removed dma/dsp race condition that happened within preload phase.

Min buffer size set to entire buffer to avoid dma and dsp
pointers misalignmen in case the period size is not multiple
of the hda dma burst size.

Signed-off-by: Marcin Maka <marcin.maka@linux.intel.com>