### PR TITLE
ipc: add missing schedule_task_init/config

### DIFF
--- a/src/ipc/byt-ipc.c
+++ b/src/ipc/byt-ipc.c
@@ -215,6 +215,10 @@ int platform_ipc_init(struct ipc *ipc)
 		sizeof(struct intel_ipc_data));
 	ipc_set_drvdata(_ipc, iipc);
 
+	/* schedule */
+	schedule_task_init(&_ipc->ipc_task, ipc_process_task, _ipc);
+	schedule_task_config(&_ipc->ipc_task, 0, 0);
+
 #ifdef CONFIG_HOST_PTABLE
 	/* allocate page table buffer */
 	iipc->page_table = rzalloc(RZONE_SYS, SOF_MEM_CAPS_RAM,


### PR DESCRIPTION
schedule_task_init and schedule_task_config was removed on the
"Merge remote-tracking branch 'gh/next' into next-master2" commit.
Which is necessary for scheduler task.

Signed-off-by: Bard liao <yung-chuan.liao@intel.com>