### PR TITLE
dma-trace: kill a infinite loop when visiting list

### DIFF
--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -166,7 +166,8 @@ static int ipc_stream_pcm_params(uint32_t stream)
 	struct sof_ipc_comp_host *host = NULL;
 	struct list_item elem_list;
 	struct dma_sg_elem *elem;
-	struct list_item *plist;
+	struct list_item *clist;
+	struct list_item *tlist;
 	uint32_t ring_size;
 #endif
 	struct sof_ipc_pcm_params *pcm_params = _ipc->comp_data;
@@ -232,8 +233,8 @@ static int ipc_stream_pcm_params(uint32_t stream)
 		goto error;
 	}
 
-	list_for_item(plist, &elem_list) {
-		elem = container_of(plist, struct dma_sg_elem, list);
+	list_for_item_safe(clist, tlist, &elem_list) {
+		elem = container_of(clist, struct dma_sg_elem, list);
 
 		err = comp_host_buffer(cd, elem, ring_size);
 		if (err < 0) {
@@ -278,8 +279,8 @@ pipe_params:
 
 error:
 #ifdef CONFIG_HOST_PTABLE
-	list_for_item(plist, &elem_list) {
-		elem = container_of(plist, struct dma_sg_elem, list);
+	list_for_item_safe(clist, tlist, &elem_list) {
+		elem = container_of(clist, struct dma_sg_elem, list);
 		list_item_del(&elem->list);
 		rfree(elem);
 	}

--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -613,14 +613,14 @@ static int ipc_glb_pm_message(uint32_t header)
 /*
  * Debug IPC Operations.
  */
-
 static int ipc_dma_trace_config(uint32_t header)
 {
 #ifdef CONFIG_HOST_PTABLE
 	struct intel_ipc_data *iipc = ipc_get_drvdata(_ipc);
 	struct list_item elem_list;
 	struct dma_sg_elem *elem;
-	struct list_item *plist;
+	struct list_item *clist;
+	struct list_item *tlist;
 	uint32_t ring_size;
 #endif
 	struct sof_ipc_dma_trace_params *params = _ipc->comp_data;
@@ -659,8 +659,8 @@ static int ipc_dma_trace_config(uint32_t header)
 		goto error;
 	}
 
-	list_for_item(plist, &elem_list) {
-		elem = container_of(plist, struct dma_sg_elem, list);
+	list_for_item_safe(clist, tlist, &elem_list) {
+		elem = container_of(clist, struct dma_sg_elem, list);
 
 		err = dma_trace_host_buffer(_ipc->dmat, elem, ring_size);
 		if (err < 0) {
@@ -693,8 +693,8 @@ static int ipc_dma_trace_config(uint32_t header)
 
 error:
 #ifdef CONFIG_HOST_PTABLE
-	list_for_item(plist, &elem_list) {
-		elem = container_of(plist, struct dma_sg_elem, list);
+	list_for_item_safe(clist, tlist, &elem_list) {
+		elem = container_of(clist, struct dma_sg_elem, list);
 		list_item_del(&elem->list);
 		rfree(elem);
 	}


### PR DESCRIPTION
Don't delete item with list_for_item. with list_for_item, a item
is deleted from list but the next of this item is used to visit
the list.

Signed-off-by: Rander Wang <rander.wang@linux.intel.com>