### PR TITLE
dai: fix a regression issue in dai

### DIFF
--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -611,8 +611,6 @@ static int dai_comp_trigger(struct comp_dev *dev, int cmd)
 	case COMP_TRIGGER_PAUSE:
 	case COMP_TRIGGER_STOP:
 		trace_dai("tsp");
-		ret = dma_stop(dd->dma, dd->chan);
-		dai_trigger(dd->dai, COMP_TRIGGER_STOP, dev->params.direction);
 		break;
 	default:
 		break;


### PR DESCRIPTION
It is caused by the change of removing dai waiting after stop.
dma & dai should not be stopped in dai_trigger stop. At this
time, dma can't be stopped sometimes. In the original code,
they are stopped only in failed case

Signed-off-by: Pan Xiuli <xiuli.pan@linux.intel.com>
Signed-off-by: Rander Wang <rander.wang@linux.intel.com>