### PR TITLE
ipc: remove waiti running in IRQ level higher than passive level

### DIFF
--- a/src/ipc/ipc.c
+++ b/src/ipc/ipc.c
@@ -501,8 +501,9 @@ int ipc_get_page_descriptors(struct dma *dmac, uint8_t *page_table,
 	}
 
 	/* wait for DMA to complete */
-	complete.timeout = PLATFORM_HOST_DMA_TIMEOUT;
-	ret = wait_for_completion_timeout(&complete);
+	ret = poll_for_completion_delay(&complete, PLATFORM_DMA_TIMEOUT);
+	if (ret < 0)
+		trace_ipc_error("eDt");
 
 	/* compressed page tables now in buffer at _ipc->page_table */
 out:


### PR DESCRIPTION
waiti would cause FW panic if it is called in irq level
higher than passive level

Signed-off-by: Rander Wang <rander.wang@linux.intel.com>