### PR TITLE
dma: hda: playback preload phase synced with logical buffer state

### DIFF
--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -48,6 +48,9 @@
 #define DAI_PLAYBACK_STREAM	0
 #define DAI_CAPTURE_STREAM	1
 
+#define DAI_PTR_INIT_DAI	1	/* buffer ptr initialized by dai */
+#define DAI_PTR_INIT_HOST	2	/* buffer ptr initialized by host */
+
 /* tracing */
 #define trace_dai(__e) trace_event(TRACE_CLASS_DAI, __e)
 #define trace_dai_error(__e)   trace_error(TRACE_CLASS_DAI, __e)
@@ -523,6 +526,8 @@ static void dai_pointer_init(struct comp_dev *dev)
 	struct comp_buffer *dma_buffer;
 	struct dai_data *dd = comp_get_drvdata(dev);
 
+	dd->pointer_init = DAI_PTR_INIT_DAI;
+
 	/* not required for capture streams */
 	if (dev->params.direction == SOF_IPC_STREAM_PLAYBACK) {
 		dma_buffer = list_first_item(&dev->bsource_list,
@@ -532,6 +537,7 @@ static void dai_pointer_init(struct comp_dev *dev)
 		case SOF_COMP_HOST:
 		case SOF_COMP_SG_HOST:
 			/* buffer is preloaded and advanced by host DMA engine */
+			dd->pointer_init = DAI_PTR_INIT_HOST;
 			break;
 		default:
 			/* advance source pipeline w_ptr by one period
@@ -540,8 +546,6 @@ static void dai_pointer_init(struct comp_dev *dev)
 			break;
 		}
 	}
-
-	dd->pointer_init = 1;
 }
 
 /* used to pass standard and bespoke command (with data) to component */
@@ -563,8 +567,12 @@ static int dai_comp_trigger(struct comp_dev *dev, int cmd)
 		trace_dai("tsa");
 		if (!dd->pointer_init)
 			dai_pointer_init(dev);
-		/* only start the DAI if we are not XRUN handling */
-		if (dd->xrun == 0) {
+		/* only start the DAI if we are not XRUN handling
+		 * and the ptr is not initialized by the host as in this
+		 * case start is deferred to the first copy call as the buffer
+		 * is populated by the host only then
+		 */
+		if (dd->xrun == 0 && dd->pointer_init != DAI_PTR_INIT_HOST) {
 			/* start the DAI */
 			ret = dma_start(dd->dma, dd->chan);
 			if (ret < 0)
@@ -632,6 +640,18 @@ static int dai_comp_trigger(struct comp_dev *dev, int cmd)
 /* copy and process stream data from source to sink buffers */
 static int dai_copy(struct comp_dev *dev)
 {
+	struct dai_data *dd = comp_get_drvdata(dev);
+	int ret;
+
+	if (dd->pointer_init == DAI_PTR_INIT_HOST) {
+		/* start the DAI */
+		ret = dma_start(dd->dma, dd->chan);
+		if (ret < 0)
+			return ret;
+		dai_trigger(dd->dai, COMP_TRIGGER_START, dev->params.direction);
+		dd->pointer_init = DAI_PTR_INIT_DAI; /* next copy just quits */
+		platform_dai_wallclock(dev, &dd->wallclock);
+	}
 	return 0;
 }
 

--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -741,7 +741,7 @@ static int host_copy_int(struct comp_dev *dev, bool preload_run)
 #if defined CONFIG_DMA_GW
 	/* tell gateway to copy another period */
 	ret = dma_copy(hd->dma, hd->chan, hd->period_bytes,
-		       preload_run ? DMA_COPY_NO_COMMIT : 0);
+		       preload_run ? DMA_COPY_PRELOAD : 0);
 	if (ret < 0)
 		goto out;
 

--- a/src/include/sof/dma.h
+++ b/src/include/sof/dma.h
@@ -81,7 +81,7 @@
 #define DMA_IRQ_TYPE_LLIST	BIT(1)
 
 /* DMA copy flags */
-#define DMA_COPY_NO_COMMIT	BIT(0)
+#define DMA_COPY_PRELOAD	BIT(0)
 
 /* We will use this macro in cb handler to inform dma that
  * we need to stop the reload for special purpose


### PR DESCRIPTION
Removed dma/dsp race condition that happened within preload phase.

Min buffer size set to entire buffer to avoid dma and dsp
pointers misalignmen in case the period size is not multiple
of the hda dma burst size.

Signed-off-by: Marcin Maka <marcin.maka@linux.intel.com>