### PR TITLE
memory: cavs: cache fixes

### DIFF
--- a/src/arch/xtensa/smp/include/arch/alloc.h
+++ b/src/arch/xtensa/smp/include/arch/alloc.h
@@ -72,6 +72,9 @@ static inline void alloc_core_context(int core)
 	core_ctx_ptr[core] = core_ctx;
 	dcache_writeback_invalidate_region(core_ctx_ptr,
 					   sizeof(core_ctx_ptr));
+
+	/* writeback bss region to share static pointers */
+	dcache_writeback_region((void *)SOF_BSS_DATA_START, SOF_BSS_DATA_SIZE);
 }
 
 /**

--- a/src/drivers/intel/cavs/clk.c
+++ b/src/drivers/intel/cavs/clk.c
@@ -252,4 +252,6 @@ void init_platform_clocks(void)
 			ssp_freq[SSP_DEFAULT_IDX].ticks_per_usec;
 	clk_pdata->clk[CLK_SSP].ticks_per_msec =
 			ssp_freq[SSP_DEFAULT_IDX].ticks_per_msec;
+
+	dcache_writeback_region(clk_pdata, sizeof(*clk_pdata));
 }

--- a/src/platform/apollolake/apollolake.x.in
+++ b/src/platform/apollolake/apollolake.x.in
@@ -81,10 +81,10 @@ MEMORY
 	org = SOF_TEXT_BASE,
         len = SOF_TEXT_SIZE,
   sof_data :
-	org = SOF_TEXT_BASE + SOF_TEXT_SIZE,
+	org = SOF_DATA_START,
         len = SOF_DATA_SIZE
   sof_bss_data :
-	org = SOF_TEXT_BASE + SOF_TEXT_SIZE + SOF_DATA_SIZE,
+	org = SOF_BSS_DATA_START,
         len = SOF_BSS_DATA_SIZE
   system_heap :
         org = HEAP_SYSTEM_BASE,

--- a/src/platform/apollolake/include/platform/memory.h
+++ b/src/platform/apollolake/include/platform/memory.h
@@ -143,7 +143,7 @@
 #define HEAP_SYSTEM_BASE \
 	(SOF_TEXT_BASE + SOF_TEXT_SIZE +\
 	SOF_DATA_SIZE + SOF_BSS_DATA_SIZE)
-#define HEAP_SYSTEM_SIZE		0x8000
+#define HEAP_SYSTEM_SIZE		0x9000
 
 #define HEAP_RUNTIME_BASE		(HEAP_SYSTEM_BASE + HEAP_SYSTEM_SIZE)
 #define HEAP_RUNTIME_SIZE \
@@ -243,6 +243,7 @@
 #define SOF_TEXT_SIZE		(0x19000 - 0x400)
 
 /* initialized data */
+#define SOF_DATA_START		(SOF_TEXT_BASE + SOF_TEXT_SIZE)
 #if defined CONFIG_DMIC
 #define SOF_DATA_SIZE		0x1b000
 #else
@@ -250,6 +251,7 @@
 #endif
 
 /* bss data */
+#define SOF_BSS_DATA_START	(SOF_TEXT_BASE + SOF_TEXT_SIZE + SOF_DATA_SIZE)
 #define SOF_BSS_DATA_SIZE	0x8700
 
 /* Stack configuration */

--- a/src/platform/cannonlake/cannonlake.x.in
+++ b/src/platform/cannonlake/cannonlake.x.in
@@ -81,10 +81,10 @@ MEMORY
         org = SOF_TEXT_BASE,
         len = SOF_TEXT_SIZE,
   sof_data :
-        org = SOF_TEXT_BASE + SOF_TEXT_SIZE,
+        org = SOF_DATA_START,
         len = SOF_DATA_SIZE
   sof_bss_data :
-        org = SOF_TEXT_BASE + SOF_TEXT_SIZE + SOF_DATA_SIZE,
+        org = SOF_BSS_DATA_START,
         len = SOF_BSS_DATA_SIZE
   system_heap :
         org = HEAP_SYSTEM_BASE,

--- a/src/platform/cannonlake/include/platform/memory.h
+++ b/src/platform/cannonlake/include/platform/memory.h
@@ -230,6 +230,7 @@
 #define SOF_TEXT_SIZE		(0x18000 - 0x400)
 
 /* initialized data */
+#define SOF_DATA_START		(SOF_TEXT_BASE + SOF_TEXT_SIZE)
 #if defined CONFIG_DMIC
 #define SOF_DATA_SIZE		0x1b000
 #else
@@ -237,7 +238,8 @@
 #endif
 
 /* bss data */
-#define SOF_BSS_DATA_SIZE		0x10900
+#define SOF_BSS_DATA_START	(SOF_TEXT_BASE + SOF_TEXT_SIZE + SOF_DATA_SIZE)
+#define SOF_BSS_DATA_SIZE	0x10900
 
 /* Heap configuration */
 #define HEAP_SYSTEM_BASE		(SOF_TEXT_BASE + SOF_TEXT_SIZE + \

--- a/src/platform/icelake/icelake.x.in
+++ b/src/platform/icelake/icelake.x.in
@@ -81,10 +81,10 @@ MEMORY
         org = SOF_TEXT_BASE,
         len = SOF_TEXT_SIZE,
   sof_data :
-        org = SOF_TEXT_BASE + SOF_TEXT_SIZE,
+        org = SOF_DATA_START,
         len = SOF_DATA_SIZE
   sof_bss_data :
-        org = SOF_TEXT_BASE + SOF_TEXT_SIZE + SOF_DATA_SIZE,
+        org = SOF_BSS_DATA_START,
         len = SOF_BSS_DATA_SIZE
   system_heap :
         org = HEAP_SYSTEM_BASE,

--- a/src/platform/icelake/include/platform/memory.h
+++ b/src/platform/icelake/include/platform/memory.h
@@ -230,6 +230,7 @@
 #define SOF_TEXT_SIZE		(0x18000 - 0x400)
 
 /* initialized data */
+#define SOF_DATA_START		(SOF_TEXT_BASE + SOF_TEXT_SIZE)
 #if defined CONFIG_DMIC
 #define SOF_DATA_SIZE		0x1b000
 #else
@@ -237,7 +238,8 @@
 #endif
 
 /* bss data */
-#define SOF_BSS_DATA_SIZE		0x10900
+#define SOF_BSS_DATA_START	(SOF_TEXT_BASE + SOF_TEXT_SIZE + SOF_DATA_SIZE)
+#define SOF_BSS_DATA_SIZE	0x10900
 
 /* Heap configuration */
 #define HEAP_SYSTEM_BASE		(SOF_TEXT_BASE + SOF_TEXT_SIZE + \


### PR DESCRIPTION
We need to writeback clock data, because it's used
in work queue. Also we need to writeback bss in order
to share static pointers with slave cores.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>