### PR TITLE
apl: memory: expand number of 256 Bytes block to be 128

### DIFF
--- a/src/platform/apollolake/include/platform/memory.h
+++ b/src/platform/apollolake/include/platform/memory.h
@@ -134,8 +134,9 @@
 /* Heap section sizes for module pool */
 #define HEAP_RT_COUNT64			256
 #define HEAP_RT_COUNT128		32
-#define HEAP_RT_COUNT256		64
-#define HEAP_RT_COUNT512		32
+#define HEAP_RT_COUNT256		128
+#define HEAP_RT_COUNT512		8
+#define HEAP_RT_COUNT1024		4
 
 #define L2_VECTOR_SIZE			0x1000
 


### PR DESCRIPTION
Still lack of this size HP buffer when enable all 6 ssps on APL.

Signed-off-by: Pan Xiuli <xiuli.pan@linux.intel.com>