### PR TITLE
EQ: Update IPC to deliver parameters in component creation

### DIFF
--- a/src/include/uapi/ipc.h
+++ b/src/include/uapi/ipc.h
@@ -773,13 +773,24 @@ struct sof_ipc_comp_tone {
 struct sof_ipc_comp_eq_fir {
 	struct sof_ipc_comp comp;
 	struct sof_ipc_comp_config config;
+	uint32_t size;
+	unsigned char data[0];
 } __attribute__((packed));
 
 /* IIR equalizer component */
 struct sof_ipc_comp_eq_iir {
 	struct sof_ipc_comp comp;
 	struct sof_ipc_comp_config config;
+	uint32_t size;
+	unsigned char data[0];
 } __attribute__((packed));
+
+/** \brief Types of EFFECT */
+enum sof_ipc_effect_type {
+	SOF_EFFECT_NONE = 0,		/**< None */
+	SOF_EFFECT_INTEL_EQFIR,		/**< Intel FIR */
+	SOF_EFFECT_INTEL_EQIIR,		/**< Intel IIR */
+};
 
 /* frees components, buffers and pipelines
  * SOF_IPC_TPLG_COMP_FREE, SOF_IPC_TPLG_PIPE_FREE, SOF_IPC_TPLG_BUFFER_FREE


### PR DESCRIPTION
Update iir and fir to get parameters at the creation time from ipc
message. Parameters are originally sent from user space as part
of the topology.

Also update ipc.h with data members for iir and fir struct.

Signed-off-by: Jaska Uimonen <jaska.uimonen@intel.com>