### PR TITLE
Fix for scheduler bugs

### DIFF
--- a/src/arch/xtensa/task.c
+++ b/src/arch/xtensa/task.c
@@ -116,6 +116,7 @@ static void _irq_task(void *arg)
 	uint32_t flags;
 
 	spin_lock_irq(&irq_task->lock, flags);
+	interrupt_clear(irq_task->irq);
 	list_for_item_safe(clist, tlist, &irq_task->list) {
 
 		task = container_of(clist, struct task, irq_list);
@@ -130,7 +131,6 @@ static void _irq_task(void *arg)
 		spin_lock_irq(&irq_task->lock, flags);
 	}
 
-	interrupt_clear(irq_task->irq);
 
 	spin_unlock_irq(&irq_task->lock, flags);
 }

--- a/src/include/sof/schedule.h
+++ b/src/include/sof/schedule.h
@@ -56,7 +56,7 @@ struct sof;
 #define TASK_PRI_MED	0
 #define TASK_PRI_HIGH	-20
 
-#define TASK_PRI_IPC	1
+#define TASK_PRI_IPC	6
 
 /* maximun task time slice in microseconds */
 #define SCHEDULE_TASK_MAX_TIME_SLICE	5000


### PR DESCRIPTION
Now both ipc process task and pipeline copy task are using scheduler. Need to care about the run order of the task. Fix some bugs in scheduler that will cause the wrong order of task.
1. use different IRQ to let Ppl copy run in higher IRQ level.
2. clear scheduler IRQ earlier to let DAI IRQ schedule can run in time.
3. clear arch task IRQ earlier to make sure all task IRQ goes on time.