### PR TITLE
apl: memory: revert the runtime heap map

### DIFF
--- a/src/platform/apollolake/include/platform/memory.h
+++ b/src/platform/apollolake/include/platform/memory.h
@@ -134,9 +134,8 @@
 /* Heap section sizes for module pool */
 #define HEAP_RT_COUNT64			256
 #define HEAP_RT_COUNT128		32
-#define HEAP_RT_COUNT256		128
-#define HEAP_RT_COUNT512		8
-#define HEAP_RT_COUNT1024		4
+#define HEAP_RT_COUNT256		64
+#define HEAP_RT_COUNT512		32
 
 #define L2_VECTOR_SIZE			0x1000
 


### PR DESCRIPTION
The new map breaks allocation sequnce on startup.
Changes for up^2 to be deferred for glk branch and applied
together with initial allocation adjustments.

Signed-off-by: Marcin Maka <marcin.maka@linux.intel.com>