### PR TITLE
ipc: add time shift for trace log

### DIFF
--- a/src/arch/xtensa/include/arch/timer.h
+++ b/src/arch/xtensa/include/arch/timer.h
@@ -43,6 +43,7 @@ struct timer {
 	uint32_t hitime;	/* high end of 64bit timer */
 	uint32_t hitimeout;
 	uint32_t lowtimeout;
+	uint64_t shift;
 };
 
 /* internal API calls */

--- a/src/include/uapi/ipc.h
+++ b/src/include/uapi/ipc.h
@@ -131,6 +131,7 @@
 /* trace and debug */
 #define SOF_IPC_TRACE_DMA_PARAMS		SOF_CMD_TYPE(0x001)
 #define SOF_IPC_TRACE_DMA_POSITION		SOF_CMD_TYPE(0x002)
+#define SOF_IPC_TRACE_TIME_SHIFT		SOF_CMD_TYPE(0x003)
 
 /* Get message component id */
 #define SOF_IPC_MESSAGE_ID(x)			((x) & 0xffff)
@@ -960,6 +961,11 @@ struct sof_ipc_dma_trace_posn {
 	uint32_t host_offset;	/* Offset of DMA host buffer */
 	uint32_t overflow;	/* overflow bytes if any */
 	uint32_t messages;	/* total trace messages */
+}  __attribute__((packed));
+
+struct sof_ipc_dma_trace_ts {
+	struct sof_ipc_hdr hdr;
+	uint64_t ts;
 }  __attribute__((packed));
 
 /*

--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -743,6 +743,22 @@ int ipc_dma_trace_send_position(void)
 		sizeof(posn), NULL, 0, NULL, NULL, 1);
 }
 
+static int ipc_dma_trace_ts(uint32_t header)
+{
+	struct sof_ipc_dma_trace_ts *ts = _ipc->comp_data;
+	struct sof_ipc_reply reply;
+
+	/* set time shift */
+	platform_timer->shift = ts->ts;
+
+	/* write component values to the outbox */
+	reply.hdr.size = sizeof(reply);
+	reply.hdr.cmd = header;
+	reply.error = 0;
+	mailbox_hostbox_write(0, &reply, sizeof(reply));
+	return 0;
+}
+
 static int ipc_glb_debug_message(uint32_t header)
 {
 	uint32_t cmd = (header & SOF_CMD_TYPE_MASK) >> SOF_CMD_TYPE_SHIFT;
@@ -752,6 +768,8 @@ static int ipc_glb_debug_message(uint32_t header)
 	switch (cmd) {
 	case iCS(SOF_IPC_TRACE_DMA_PARAMS):
 		return ipc_dma_trace_config(header);
+	case iCS(SOF_IPC_TRACE_TIME_SHIFT):
+		return ipc_dma_trace_ts(header);
 	default:
 		trace_ipc_error("eDc");
 		trace_error_value(header);

--- a/src/lib/trace.c
+++ b/src/lib/trace.c
@@ -54,7 +54,7 @@ void _trace_event(uint32_t event)
 	if (!trace->enable)
 		return;
 
-	dt[0] = platform_timer_get(platform_timer);
+	dt[0] = platform_timer_get(platform_timer) + platform_timer->shift;
 	dt[1] = event | TRACE_CORE_ID(cpu_get_id());
 	dtrace_event((const char *)dt, sizeof(uint64_t) * 2);
 }
@@ -66,7 +66,7 @@ void _trace_event_atomic(uint32_t event)
 	if (!trace->enable)
 		return;
 
-	dt[0] = platform_timer_get(platform_timer);
+	dt[0] = platform_timer_get(platform_timer) + platform_timer->shift;
 	dt[1] = event | TRACE_CORE_ID(cpu_get_id());
 	dtrace_event_atomic((const char *)dt, sizeof(uint64_t) * 2);
 }
@@ -83,7 +83,7 @@ void _trace_event_mbox(uint32_t event)
 	if (!trace->enable)
 		return;
 
-	time = platform_timer_get(platform_timer);
+	time = platform_timer_get(platform_timer) + platform_timer->shift;
 
 	dt[0] = time;
 	dt[1] = event | TRACE_CORE_ID(cpu_get_id());
@@ -117,7 +117,7 @@ void _trace_event_mbox_atomic(uint32_t event)
 	if (!trace->enable)
 		return;
 
-	time = platform_timer_get(platform_timer);
+	time = platform_timer_get(platform_timer) + platform_timer->shift;
 
 	dt[0] = time;
 	dt[1] = event | TRACE_CORE_ID(cpu_get_id());


### PR DESCRIPTION
Getting a time shift value and adding to the timestamp of trace log.
So the trace log's timestamp will not be reset after DSP is reset.

Signed-off-by: Bard liao <yung-chuan.liao@intel.com>