### PR TITLE
Merge stable 1.2 (part 3) scheduler and BYT part into master

### DIFF
--- a/src/arch/xtensa/include/arch/task.h
+++ b/src/arch/xtensa/include/arch/task.h
@@ -138,6 +138,9 @@ static void _irq_task(void *arg)
 	uint32_t flags;
 
 	spin_lock_irq(&irq_task->lock, flags);
+
+	interrupt_clear(irq_task->irq);
+
 	list_for_item_safe(clist, tlist, &irq_task->list) {
 
 		task = container_of(clist, struct task, irq_list);
@@ -151,8 +154,6 @@ static void _irq_task(void *arg)
 		schedule_task_complete(task);
 		spin_lock_irq(&irq_task->lock, flags);
 	}
-
-	interrupt_clear(irq_task->irq);
 
 	spin_unlock_irq(&irq_task->lock, flags);
 }

--- a/src/drivers/intel/dw-dma.c
+++ b/src/drivers/intel/dw-dma.c
@@ -120,6 +120,7 @@
 #define INT_UNMASK_ALL			0xFFFF
 #define CHAN_ENABLE(chan)		(0x101 << chan)
 #define CHAN_DISABLE(chan)		(0x100 << chan)
+#define CHAN_MASK(chan)		(0x1 << chan)
 
 #define DW_CFG_CH_SUSPEND		0x100
 #define DW_CFG_CH_FIFO_EMPTY		0x200
@@ -491,6 +492,31 @@ out:
 	return 0;
 }
 
+#if defined CONFIG_BAYTRAIL || defined CONFIG_CHERRYTRAIL
+static int dw_dma_stop(struct dma *dma, int channel)
+{
+	struct dma_pdata *p = dma_get_drvdata(dma);
+	int ret = 0;
+	uint32_t flags;
+	uint32_t val = 0;
+
+	spin_lock_irq(&dma->lock, flags);
+
+	trace_dma("DDi");
+
+	ret = poll_for_register_delay(dma_base(dma) + DW_DMA_CHAN_EN,
+				      CHAN_MASK(channel), val,
+				      PLATFORM_DMA_TIMEOUT);
+	if (ret < 0)
+		trace_dma_error("esp");
+
+	dw_write(dma, DW_CLEAR_BLOCK, 0x1 << channel);
+	p->chan[channel].status = COMP_STATE_PREPARE;
+
+	spin_unlock_irq(&dma->lock, flags);
+	return ret;
+}
+#else
 static int dw_dma_stop(struct dma *dma, int channel)
 {
 	struct dma_pdata *p = dma_get_drvdata(dma);
@@ -528,6 +554,7 @@ static int dw_dma_stop(struct dma *dma, int channel)
 	spin_unlock_irq(&dma->lock, flags);
 	return ret;
 }
+#endif
 
 /* fill in "status" with current DMA channel state and position */
 static int dw_dma_status(struct dma *dma, int channel,

--- a/src/include/sof/wait.h
+++ b/src/include/sof/wait.h
@@ -42,8 +42,11 @@
 #include <sof/interrupt.h>
 #include <sof/trace.h>
 #include <sof/lock.h>
+#include <sof/clock.h>
+#include <platform/clk.h>
 #include <platform/interrupt.h>
 #include <sof/drivers/timer.h>
+#include <platform/platform.h>
 
 #if DEBUG_LOCKS
 #define wait_atomic_check	\
@@ -53,6 +56,8 @@
 #else
 #define wait_atomic_check
 #endif
+
+#define DEFAULT_TRY_TIMES 8
 
 typedef struct {
 	uint32_t complete;
@@ -156,6 +161,29 @@ static inline void wait_delay(uint64_t number_of_clks)
 
 	while ((platform_timer_get(platform_timer) - current) < number_of_clks)
 		idelay(PLATFORM_DEFAULT_DELAY);
+}
+
+static inline int poll_for_completion_delay(completion_t *comp, uint64_t us)
+{
+	uint64_t tick = clock_us_to_ticks(CLK_CPU, us);
+	uint32_t tries = DEFAULT_TRY_TIMES;
+	uint64_t delta = tick / tries;
+
+	if (!delta) {
+		delta = us;
+		tries = 1;
+	}
+
+	while (!wait_is_completed(comp)) {
+		if (!tries--) {
+			trace_error(TRACE_CLASS_WAIT, "ewt");
+			return -EIO;
+		}
+
+		wait_delay(delta);
+	}
+
+	return 0;
 }
 
 #endif

--- a/src/include/sof/wait.h
+++ b/src/include/sof/wait.h
@@ -36,6 +36,7 @@
 #include <stdint.h>
 #include <errno.h>
 #include <arch/wait.h>
+#include <sof/io.h>
 #include <sof/debug.h>
 #include <sof/work.h>
 #include <sof/timer.h>
@@ -183,6 +184,29 @@ static inline int poll_for_completion_delay(completion_t *comp, uint64_t us)
 		wait_delay(delta);
 	}
 
+	return 0;
+}
+
+static inline int poll_for_register_delay(uint32_t reg,
+					  uint32_t mask,
+					  uint32_t val, uint64_t us)
+{
+	uint64_t tick = clock_us_to_ticks(CLK_CPU, us);
+	uint32_t tries = DEFAULT_TRY_TIMES;
+	uint64_t delta = tick / tries;
+
+	if (!delta) {
+		delta = us;
+		tries = 1;
+	}
+
+	while ((io_reg_read(reg) & mask) != val) {
+		if (!tries--) {
+			trace_error(TRACE_CLASS_WAIT, "ewt");
+			return -EIO;
+		}
+		wait_delay(delta);
+	}
 	return 0;
 }
 

--- a/src/ipc/ipc.c
+++ b/src/ipc/ipc.c
@@ -501,8 +501,9 @@ int ipc_get_page_descriptors(struct dma *dmac, uint8_t *page_table,
 	}
 
 	/* wait for DMA to complete */
-	complete.timeout = PLATFORM_HOST_DMA_TIMEOUT;
-	ret = wait_for_completion_timeout(&complete);
+	ret = poll_for_completion_delay(&complete, PLATFORM_DMA_TIMEOUT);
+	if (ret < 0)
+		trace_ipc_error("eDt");
 
 	/* compressed page tables now in buffer at _ipc->page_table */
 out:

--- a/src/lib/schedule.c
+++ b/src/lib/schedule.c
@@ -102,13 +102,9 @@ static inline struct task *edf_get_next(uint64_t current,
 	uint64_t delta;
 	uint64_t deadline;
 	int reschedule = 0;
-	uint32_t flags;
  
-	spin_lock_irq(&sch->lock, flags);
-
 	/* any tasks in the scheduler ? */
 	if (list_is_empty(&sch->list)) {
-		spin_unlock_irq(&sch->lock, flags);
 		return NULL;
 	}
 
@@ -159,7 +155,6 @@ static inline struct task *edf_get_next(uint64_t current,
 		}
 	}
 
-	spin_unlock_irq(&sch->lock, flags);
 	return next_task;
 }
 
@@ -187,35 +182,40 @@ static struct task *schedule_edf(void)
 
 	tracev_pipe("edf");
 
-	/* get the current time */
-	current = platform_timer_get(platform_timer);
-
-	/* get next task to be scheduled */
-	task = edf_get_next(current, NULL);
-
 	interrupt_clear(PLATFORM_SCHEDULE_IRQ);
 
-	/* any tasks ? */
-	if (task == NULL)
-		return NULL;
-
-	/* can task be started now ? */
-	if (task->start > current) {
-		/* no, then schedule wake up */
-		future_task = task;
-	} else {
-		/* yes, run current task */
-		task->start = current;
-
-		/* init task for running */
-		wait_init(&task->complete);
+	while (!list_is_empty(&sch->list)) {
 		spin_lock_irq(&sch->lock, flags);
-		task->state = TASK_STATE_RUNNING;
-		list_item_del(&task->list);
+
+		/* get the current time */
+		current = platform_timer_get(platform_timer);
+
+		/* get next task to be scheduled */
+		task = edf_get_next(current, NULL);
 		spin_unlock_irq(&sch->lock, flags);
 
-		/* now run task at correct run level */
-		run_task(task);
+		/* any tasks ? */
+		if (!task)
+			return NULL;
+
+		/* can task be started now ? */
+		if (task->start <= current) {
+			/* yes, run current task */
+			task->start = current;
+
+			/* init task for running */
+			spin_lock_irq(&sch->lock, flags);
+			task->state = TASK_STATE_RUNNING;
+			list_item_del(&task->list);
+			spin_unlock_irq(&sch->lock, flags);
+
+			/* now run task at correct run level */
+			run_task(task);
+		} else {
+			/* no, then schedule wake up */
+			future_task = task;
+			break;
+		}
 	}
 
 	/* tell caller about future task */


### PR DESCRIPTION
Fixes for BYT:
ipc: remove waiti running in IRQ level higher than passive level
wait: add a function to wait for a register ready by pulling method
dma: fix dma issue on BYT

Fixes for scheduler corner cases:
task: clear interrupt earlier
scheduler: refine schedule_edf function to handle multiple task

This PR is rebase patches from #335 #342 #360
