### PR TITLE
ipc: set flag to disable memory banks before entering D3

### DIFF
--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -547,6 +547,7 @@ static int ipc_pm_context_size(uint32_t header)
 static int ipc_pm_context_save(uint32_t header)
 {
 	struct sof_ipc_pm_ctx *pm_ctx = _ipc->comp_data;
+	struct intel_ipc_data *iipc = ipc_get_drvdata(_ipc);
 
 	trace_ipc("PMs");
 
@@ -575,7 +576,7 @@ static int ipc_pm_context_save(uint32_t header)
 	/* write the context to the host driver */
 	mailbox_hostbox_write(0, pm_ctx, sizeof(*pm_ctx));
 
-	//iipc->pm_prepare_D3 = 1;
+	iipc->pm_prepare_D3 = 1;
 
 	return 1;
 }


### PR DESCRIPTION
This could potentially lead to power savings when the system
is suspended.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>