### PR TITLE
eq: iir: don't destroy eq config in reset

### DIFF
--- a/src/audio/eq_iir.c
+++ b/src/audio/eq_iir.c
@@ -552,7 +552,6 @@ static int eq_iir_reset(struct comp_dev *dev)
 	trace_eq("res");
 
 	eq_iir_free_delaylines(cd);
-	eq_iir_free_parameters(&cd->config);
 
 	cd->eq_iir_func = eq_iir_s32_default;
 	for (i = 0; i < PLATFORM_MAX_CHANNELS; i++)


### PR DESCRIPTION
Remove freeing of config data in reset. If pm is
not enabled, stopping the stream causes component
reset in firmware. When you start a new stream the
eq parameters are gone and defaults will be used.
When pm is enabled this is not a problem because
component is recreated from swidget in kernel side.

Signed-off-by: Jaska Uimonen <jaska.uimonen@intel.com>