### PR TITLE
idc: simplify idc_pipeline_trigger

### DIFF
--- a/src/audio/pipeline.c
+++ b/src/audio/pipeline.c
@@ -735,10 +735,8 @@ void pipeline_cache(struct pipeline *p, struct comp_dev *dev, int cmd)
 static int pipeline_trigger_on_core(struct pipeline *p, struct comp_dev *host,
 				    int cmd)
 {
-	struct idc_msg pipeline_trigger = {
-		IDC_MSG_PPL_TRIGGER,
-		IDC_MSG_PPL_TRIGGER_EXT(host->comp.id, cmd),
-		p->ipc_pipe.core };
+	struct idc_msg pipeline_trigger = { IDC_MSG_PPL_TRIGGER,
+		IDC_MSG_PPL_TRIGGER_EXT(cmd), p->ipc_pipe.core };
 	int ret;
 
 	/* check if requested core is enabled */

--- a/src/include/sof/idc.h
+++ b/src/include/sof/idc.h
@@ -83,23 +83,11 @@
 #define IDC_MSG_POWER_DOWN_EXT	IDC_EXTENSION(0x0)
 
 /** \brief IDC trigger pipeline message. */
-#define IDC_MSG_PPL_COMP_SHIFT		4
-#define IDC_MSG_PPL_COMP(x)		((x) << IDC_MSG_PPL_COMP_SHIFT)
-#define IDC_MSG_PPL_CMD_MASK		0xf
-#define IDC_MSG_PPL_CMD(x)		((x) & IDC_MSG_PPL_CMD_MASK)
 #define IDC_MSG_PPL_TRIGGER		IDC_TYPE(0x3)
-#define IDC_MSG_PPL_TRIGGER_EXT(x, y)	IDC_EXTENSION( \
-						IDC_MSG_PPL_COMP(x) | \
-						IDC_MSG_PPL_CMD(y))
+#define IDC_MSG_PPL_TRIGGER_EXT(x)	IDC_EXTENSION(x)
 
 /** \brief Decodes IDC message type. */
 #define iTS(x)	(((x) >> IDC_TYPE_SHIFT) & IDC_TYPE_MASK)
-
-/** \brief Decodes component id from IDC trigger pipeline message. */
-#define iPTComp(x)	((x) >> IDC_MSG_PPL_COMP_SHIFT)
-
-/** \brief Decodes command from IDC trigger pipeline message. */
-#define iPTCommand(x)	((x) & IDC_MSG_PPL_CMD_MASK)
 
 /** \brief IDC message. */
 struct idc_msg {

--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -85,6 +85,9 @@ static inline struct sof_ipc_hdr *mailbox_validate(void)
 
 	/* read rest of component data */
 	mailbox_hostbox_read(hdr + 1, sizeof(*hdr), hdr->size - sizeof(*hdr));
+
+	dcache_writeback_region(hdr, hdr->size);
+
 	return hdr;
 }
 


### PR DESCRIPTION
Simplifies idc_pipeline_trigger function by reading
component data directly from IPC buffer. This way
we don't need to send unneeded data through IDC.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>