### PR TITLE
timer: different handling of TIMER3 for cAVS

### DIFF
--- a/src/arch/xtensa/timer.c
+++ b/src/arch/xtensa/timer.c
@@ -214,18 +214,3 @@ int arch_timer_set(struct timer *timer, uint64_t ticks)
 	return 0;
 }
 
-void timer_unregister(struct timer *timer)
-{
-	interrupt_unregister(timer->irq);
-}
-
-void timer_enable(struct timer *timer)
-{
-	interrupt_enable(timer->irq);
-}
-
-void timer_disable(struct timer *timer)
-{
-	interrupt_disable(timer->irq);
-}
-

--- a/src/drivers/intel/baytrail/timer.c
+++ b/src/drivers/intel/baytrail/timer.c
@@ -232,3 +232,18 @@ int timer_register(struct timer *timer, void(*handler)(void *arg), void *arg)
 		return -EINVAL;
 	}
 }
+
+void timer_unregister(struct timer *timer)
+{
+	interrupt_unregister(timer->irq);
+}
+
+void timer_enable(struct timer *timer)
+{
+	interrupt_enable(timer->irq);
+}
+
+void timer_disable(struct timer *timer)
+{
+	interrupt_disable(timer->irq);
+}

--- a/src/drivers/intel/haswell/timer.c
+++ b/src/drivers/intel/haswell/timer.c
@@ -107,3 +107,18 @@ int timer_register(struct timer *timer, void(*handler)(void *arg), void *arg)
 		return -EINVAL;
 	}
 }
+
+void timer_unregister(struct timer *timer)
+{
+	interrupt_unregister(timer->irq);
+}
+
+void timer_enable(struct timer *timer)
+{
+	interrupt_enable(timer->irq);
+}
+
+void timer_disable(struct timer *timer)
+{
+	interrupt_disable(timer->irq);
+}


### PR DESCRIPTION
Different handling of TIMER3 for cAVS platforms.
Now we are operating on irq masks on core level,
not on the timer level. It gives us opportunity
to implement multicore work queue.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>