### PR TITLE
clk: remove clock microseconds handling

### DIFF
--- a/src/include/sof/clock.h
+++ b/src/include/sof/clock.h
@@ -39,22 +39,14 @@
 
 struct clock_notify_data {
 	uint32_t old_freq;
-	uint32_t old_ticks_per_usec;
+	uint32_t old_ticks_per_msec;
 	uint32_t freq;
-	uint32_t ticks_per_usec;
+	uint32_t ticks_per_msec;
 };
-
-void clock_enable(int clock);
-void clock_disable(int clock);
 
 uint32_t clock_set_freq(int clock, unsigned int hz);
 
-uint32_t clock_get_freq(int clock);
-
-uint64_t clock_us_to_ticks(int clock, uint64_t us);
 uint64_t clock_ms_to_ticks(int clock, uint64_t ms);
-
-uint64_t clock_time_elapsed(int clock, uint64_t previous, uint64_t *current);
 
 void clock_register_notifier(int clock, struct notifier *notifier);
 

--- a/src/include/sof/wait.h
+++ b/src/include/sof/wait.h
@@ -166,7 +166,7 @@ static inline void wait_delay(uint64_t number_of_clks)
 
 static inline int poll_for_completion_delay(completion_t *comp, uint64_t us)
 {
-	uint64_t tick = clock_us_to_ticks(CLK_CPU, us);
+	uint64_t tick = clock_ms_to_ticks(CLK_CPU, 1) * us / 1000;
 	uint32_t tries = DEFAULT_TRY_TIMES;
 	uint64_t delta = tick / tries;
 
@@ -191,7 +191,7 @@ static inline int poll_for_register_delay(uint32_t reg,
 					  uint32_t mask,
 					  uint32_t val, uint64_t us)
 {
-	uint64_t tick = clock_us_to_ticks(CLK_CPU, us);
+	uint64_t tick = clock_ms_to_ticks(CLK_CPU, 1) * us / 1000;
 	uint32_t tries = DEFAULT_TRY_TIMES;
 	uint64_t delta = tick / tries;
 

--- a/src/include/sof/work.h
+++ b/src/include/sof/work.h
@@ -45,7 +45,8 @@ struct work_queue;
 #define WORK_SYNC	(1 << 0)	/* work is scheduled synchronously */
 
 struct work {
-	uint64_t (*cb)(void*, uint64_t udelay);	/* returns reschedule timeout in msecs */
+	/* returns reschedule timeout in usecs */
+	uint64_t (*cb)(void *data, uint64_t udelay);
 	void *cb_data;
 	struct list_item list;
 	uint64_t timeout;

--- a/src/lib/schedule.c
+++ b/src/lib/schedule.c
@@ -252,6 +252,7 @@ static int _schedule_task(struct task *task, uint64_t start, uint64_t deadline)
 	struct schedule_data *sch = *arch_schedule_get();
 	uint32_t flags;
 	uint64_t current;
+	uint64_t ticks_per_ms;
 
 	tracev_pipe("ad!");
 
@@ -274,15 +275,17 @@ static int _schedule_task(struct task *task, uint64_t start, uint64_t deadline)
 	/* get the current time */
 	current = platform_timer_get(platform_timer);
 
+	ticks_per_ms = clock_ms_to_ticks(sch->clock, 1);
+
 	/* calculate start time - TODO: include MIPS */
 	if (start == 0)
 		task->start = current;
 	else
-		task->start = task->start + clock_us_to_ticks(sch->clock, start) -
+		task->start = task->start + ticks_per_ms * start / 1000 -
 			PLATFORM_SCHEDULE_COST;
 
 	/* calculate deadline - TODO: include MIPS */
-	task->deadline = task->start + clock_us_to_ticks(sch->clock, deadline);
+	task->deadline = task->start + ticks_per_ms * deadline / 1000;
 
 	/* add task to list */
 	list_item_append(&task->list, &sch->list);


### PR DESCRIPTION
Removes clock microseconds handling for scheduling
and work queue. In case of some clocks it is causing
too much of a drift in cycles. We still pass every
delay in microseconds, but handle it as milliseconds.
Microseconds are needed to get delays less then 1 ms.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>