### PR TITLE
dma: SG elem lists replaced with arrays

### DIFF
--- a/src/arch/host/include/arch/sof.h
+++ b/src/arch/host/include/arch/sof.h
@@ -45,6 +45,10 @@
 /* data cache line alignment */
 #define PLATFORM_DCACHE_ALIGN	sizeof(uint32_t)
 
+#define PLATFORM_HEAP_SYSTEM	1
+#define PLATFORM_HEAP_RUNTIME	1
+#define PLATFORM_HEAP_BUFFER	3
+
 static inline void *arch_get_stack_ptr(void)
 {
 	void *frames[ARCH_STACK_DUMP_FRAMES];

--- a/src/arch/xtensa/up/include/arch/idc.h
+++ b/src/arch/xtensa/up/include/arch/idc.h
@@ -49,11 +49,6 @@ static inline int arch_idc_send_msg(struct idc_msg *msg,
 				    uint32_t mode) { return 0; }
 
 /**
- * \brief Checks for pending IDC messages.
- */
-static inline void arch_idc_process_msg_queue(void) { }
-
-/**
  * \brief Initializes IDC data and registers for interrupt.
  */
 static inline void arch_idc_init(void) { }

--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -217,7 +217,7 @@ static struct comp_dev *dai_new(struct sof_ipc_comp *comp)
 		goto error;
 	}
 
-	list_init(&dd->config.elem_list);
+	dma_sg_init(&dd->config.elem_array);
 	dd->dai_pos = NULL;
 	dd->dai_pos_blks = 0;
 	dd->xrun = 0;
@@ -248,11 +248,7 @@ static int dai_playback_params(struct comp_dev *dev)
 	struct dai_data *dd = comp_get_drvdata(dev);
 	struct dma_sg_config *config = &dd->config;
 	struct sof_ipc_comp_config *source_config;
-	struct dma_sg_elem *elem;
 	struct comp_buffer *dma_buffer;
-	struct list_item *elist;
-	struct list_item *tlist;
-	int i;
 	int err;
 	uint32_t buffer_size;
 
@@ -280,35 +276,19 @@ static int dai_playback_params(struct comp_dev *dev)
 		return err;
 	}
 
-	if (list_is_empty(&config->elem_list)) {
-		/* set up cyclic list of DMA elems */
-		for (i = 0; i < source_config->periods_sink; i++) {
-
-			elem = rzalloc(RZONE_RUNTIME, SOF_MEM_CAPS_RAM,
-				sizeof(*elem));
-			if (elem == NULL)
-				goto err_unwind;
-
-			elem->size = dd->period_bytes;
-			elem->src = (uintptr_t)(dma_buffer->r_ptr) +
-				i * dd->period_bytes;
-
-			elem->dest = dai_fifo(dd->dai, SOF_IPC_STREAM_PLAYBACK);
-
-			list_item_append(&elem->list, &config->elem_list);
+	if (!config->elem_array.elems) {
+		err = dma_sg_alloc(&config->elem_array, config->direction,
+				   source_config->periods_sink,
+				   dd->period_bytes,
+				   (uintptr_t)(dma_buffer->r_ptr),
+				   dai_fifo(dd->dai, SOF_IPC_STREAM_PLAYBACK));
+		if (err < 0) {
+			trace_dai_error("ep3");
+			return err;
 		}
 	}
 
 	return 0;
-
-err_unwind:
-	trace_dai_error("ep3");
-	list_for_item_safe(elist, tlist, &config->elem_list) {
-		elem = container_of(elist, struct dma_sg_elem, list);
-		list_item_del(&elem->list);
-		rfree(elem);
-	}
-	return -ENOMEM;
 }
 
 static int dai_capture_params(struct comp_dev *dev)
@@ -316,11 +296,7 @@ static int dai_capture_params(struct comp_dev *dev)
 	struct dai_data *dd = comp_get_drvdata(dev);
 	struct dma_sg_config *config = &dd->config;
 	struct sof_ipc_comp_config *sink_config;
-	struct dma_sg_elem *elem;
 	struct comp_buffer *dma_buffer;
-	struct list_item *elist;
-	struct list_item *tlist;
-	int i;
 	int err;
 	uint32_t buffer_size;
 
@@ -348,33 +324,19 @@ static int dai_capture_params(struct comp_dev *dev)
 		return err;
 	}
 
-	if (list_is_empty(&config->elem_list)) {
-		/* set up cyclic list of DMA elems */
-		for (i = 0; i < sink_config->periods_source; i++) {
-
-			elem = rzalloc(RZONE_RUNTIME, SOF_MEM_CAPS_RAM,
-				sizeof(*elem));
-			if (elem == NULL)
-				goto err_unwind;
-
-			elem->size = dd->period_bytes;
-			elem->dest = (uintptr_t)(dma_buffer->w_ptr) +
-				i * dd->period_bytes;
-			elem->src = dai_fifo(dd->dai, SOF_IPC_STREAM_CAPTURE);
-			list_item_append(&elem->list, &config->elem_list);
+	if (!config->elem_array.elems) {
+		err = dma_sg_alloc(&config->elem_array, config->direction,
+				   sink_config->periods_source,
+				   dd->period_bytes,
+				   (uintptr_t)(dma_buffer->w_ptr),
+				   dai_fifo(dd->dai, SOF_IPC_STREAM_CAPTURE));
+		if (err < 0) {
+			trace_dai_error("ec3");
+			return err;
 		}
 	}
 
 	return 0;
-
-err_unwind:
-	trace_dai_error("ec3");
-	list_for_item_safe(elist, tlist, &config->elem_list) {
-		elem = container_of(elist, struct dma_sg_elem, list);
-		list_item_del(&elem->list);
-		rfree(elem);
-	}
-	return -ENOMEM;
 }
 
 static int dai_params(struct comp_dev *dev)
@@ -448,7 +410,7 @@ static int dai_prepare(struct comp_dev *dev)
 
 	dev->position = 0;
 
-	if (list_is_empty(&dd->config.elem_list)) {
+	if (!dd->config.elem_array.elems) {
 		trace_dai_error("wdm");
 		comp_set_state(dev, COMP_TRIGGER_RESET);
 		return -EINVAL;
@@ -487,19 +449,12 @@ static int dai_reset(struct comp_dev *dev)
 {
 	struct dai_data *dd = comp_get_drvdata(dev);
 	struct dma_sg_config *config = &dd->config;
-	struct list_item *elist;
-	struct list_item *tlist;
-	struct dma_sg_elem *elem;
 
 	trace_dai("res");
 
 	dma_channel_put(dd->dma, dd->chan);
 
-	list_for_item_safe(elist, tlist, &config->elem_list) {
-		elem = container_of(elist, struct dma_sg_elem, list);
-		list_item_del(&elem->list);
-		rfree(elem);
-	}
+	dma_sg_free(&config->elem_array);
 
 	dd->dai_pos_blks = 0;
 	if (dd->dai_pos)
@@ -748,8 +703,6 @@ static int dai_config(struct comp_dev *dev, struct sof_ipc_dai_config *config)
 static void dai_cache(struct comp_dev *dev, int cmd)
 {
 	struct dai_data *dd;
-	struct list_item *item;
-	struct dma_sg_elem *e;
 
 	switch (cmd) {
 	case COMP_CACHE_WRITEBACK_INV:
@@ -757,12 +710,7 @@ static void dai_cache(struct comp_dev *dev, int cmd)
 
 		dd = comp_get_drvdata(dev);
 
-		list_for_item(item, &dd->config.elem_list) {
-			e = container_of(item, struct dma_sg_elem, list);
-			dcache_writeback_invalidate_region(e, sizeof(*e));
-			dcache_writeback_invalidate_region(item,
-							   sizeof(*item));
-		}
+		dma_sg_cache_wb_inv(&dd->config.elem_array);
 
 		dcache_writeback_invalidate_region(dd->dai, sizeof(*dd->dai));
 		dcache_writeback_invalidate_region(dd->dai->private,
@@ -788,11 +736,7 @@ static void dai_cache(struct comp_dev *dev, int cmd)
 		dcache_invalidate_region(dd->dai->private,
 					 dd->dai->private_size);
 
-		list_for_item(item, &dd->config.elem_list) {
-			dcache_invalidate_region(item, sizeof(*item));
-			e = container_of(item, struct dma_sg_elem, list);
-			dcache_invalidate_region(e, sizeof(*e));
-		}
+		dma_sg_cache_inv(&dd->config.elem_array);
 		break;
 	}
 }

--- a/src/drivers/intel/cavs/hda-dma.c
+++ b/src/drivers/intel/cavs/hda-dma.c
@@ -470,26 +470,21 @@ static int hda_dma_set_config(struct dma *dma, int channel,
 	struct dma_sg_config *config)
 {
 	struct dma_pdata *p = dma_get_drvdata(dma);
-	struct list_item *plist;
 	struct dma_sg_elem *sg_elem;
 	uint32_t buffer_addr = 0;
 	uint32_t period_bytes = 0;
 	uint32_t buffer_bytes = 0;
-	uint32_t desc_count = 0;
 	uint32_t flags;
 	uint32_t addr;
 	uint32_t dgcs;
+	int i;
 	int ret = 0;
 
 	spin_lock_irq(&dma->lock, flags);
 
 	trace_host("Dsc");
 
-	/* get number of SG elems */
-	list_for_item(plist, &config->elem_list)
-		desc_count++;
-
-	if (desc_count == 0) {
+	if (!config->elem_array.count) {
 		trace_host_error("eD1");
 		ret = -EINVAL;
 		goto out;
@@ -497,11 +492,11 @@ static int hda_dma_set_config(struct dma *dma, int channel,
 
 	/* default channel config */
 	p->chan[channel].direction = config->direction;
-	p->chan[channel].desc_count = desc_count;
+	p->chan[channel].desc_count = config->elem_array.count;
 
 	/* validate - HDA only supports continuous elems of same size  */
-	list_for_item(plist, &config->elem_list) {
-		sg_elem = container_of(plist, struct dma_sg_elem, list);
+	for (i = 0; i < config->elem_array.count; i++) {
+		sg_elem = config->elem_array.elems + i;
 
 		if (config->direction == DMA_DIR_HMEM_TO_LMEM ||
 		    config->direction == DMA_DIR_DEV_TO_MEM)

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -173,8 +173,9 @@ struct comp_ops {
 	int (*copy)(struct comp_dev *dev);
 
 	/* host buffer config */
-	int (*host_buffer)(struct comp_dev *dev, struct dma_sg_elem *elem,
-			uint32_t host_size);
+	int (*host_buffer)(struct comp_dev *dev,
+			   struct dma_sg_elem_array *elem_array,
+			   uint32_t host_size);
 
 	/* position */
 	int (*position)(struct comp_dev *dev,
@@ -267,10 +268,10 @@ static inline int comp_params(struct comp_dev *dev)
  * mandatory for host components, optional for the others.
  */
 static inline int comp_host_buffer(struct comp_dev *dev,
-	struct dma_sg_elem *elem, uint32_t host_size)
+		struct dma_sg_elem_array *elem_array, uint32_t host_size)
 {
 	if (dev->drv->ops.host_buffer)
-		return dev->drv->ops.host_buffer(dev, elem, host_size);
+		return dev->drv->ops.host_buffer(dev, elem_array, host_size);
 	return 0;
 }
 

--- a/src/include/sof/dma-trace.h
+++ b/src/include/sof/dma-trace.h
@@ -70,8 +70,9 @@ struct dma_trace_data {
 
 int dma_trace_init_early(struct sof *sof);
 int dma_trace_init_complete(struct dma_trace_data *d);
-int dma_trace_host_buffer(struct dma_trace_data *d, struct dma_sg_elem *elem,
-	uint32_t host_size);
+int dma_trace_host_buffer(struct dma_trace_data *d,
+			  struct dma_sg_elem_array *elem_array,
+			  uint32_t host_size);
 int dma_trace_enable(struct dma_trace_data *d);
 void dma_trace_flush(void *t);
 

--- a/src/include/sof/dma.h
+++ b/src/include/sof/dma.h
@@ -91,23 +91,33 @@
 
 struct dma;
 
+/**
+ *  \brief Element of SG list (as array item).
+ */
 struct dma_sg_elem {
-	uint32_t src;
-	uint32_t dest;
-	uint32_t size;
-	struct list_item list;
+	uint32_t src;	/**< source address */
+	uint32_t dest;	/**< destination address */
+	uint32_t size;	/**< size (in bytes) */
+};
+
+/**
+ * \brief SG elem array.
+ */
+struct dma_sg_elem_array {
+	uint32_t count;			/**< number of elements in elems */
+	struct dma_sg_elem *elems;	/**< elements */
 };
 
 /* DMA physical SG params */
 struct dma_sg_config {
-	uint32_t src_width;	/* in bytes */
-	uint32_t dest_width;	/* in bytes */
+	uint32_t src_width;			/* in bytes */
+	uint32_t dest_width;			/* in bytes */
 	uint32_t burst_elems;
 	uint32_t direction;
 	uint32_t src_dev;
 	uint32_t dest_dev;
-	uint32_t cyclic;		/* circular buffer */
-	struct list_item elem_list;	/* list of dma_sg elems */
+	uint32_t cyclic;			/* circular buffer */
+	struct dma_sg_elem_array elem_array;	/* array of dma_sg elems */
 };
 
 struct dma_chan_status {
@@ -267,18 +277,44 @@ static inline int dma_probe(struct dma *dma)
 	return dma->ops->probe(dma);
 }
 
-/* get the size of SG buffer */
-static inline uint32_t dma_sg_get_size(struct dma_sg_config *sg)
+static inline void dma_sg_init(struct dma_sg_elem_array *ea)
 {
-	struct dma_sg_elem *sg_elem;
-	struct list_item *plist;
+	ea->count = 0;
+	ea->elems = NULL;
+}
+
+int dma_sg_alloc(struct dma_sg_elem_array *ea, uint32_t direction,
+		 uint32_t buffer_count, uint32_t buffer_bytes,
+		 uintptr_t dma_buffer_addr, uintptr_t external_addr);
+
+void dma_sg_free(struct dma_sg_elem_array *ea);
+
+static inline void dma_sg_cache_wb_inv(struct dma_sg_elem_array *ea)
+{
+	dcache_writeback_invalidate_region(ea->elems,
+					   ea->count *
+					   sizeof(struct dma_sg_elem));
+}
+
+static inline void dma_sg_cache_inv(struct dma_sg_elem_array *ea)
+{
+	dcache_invalidate_region(ea->elems,
+				 ea->count * sizeof(struct dma_sg_elem));
+}
+
+/**
+ * \brief Get the total size of SG buffer
+ *
+ * \param ea Array of SG elements.
+ * \return Size of the buffer.
+ */
+static inline uint32_t dma_sg_get_size(struct dma_sg_elem_array *ea)
+{
+	int i;
 	uint32_t size = 0;
 
-	list_for_item(plist, &sg->elem_list) {
-
-		sg_elem = container_of(plist, struct dma_sg_elem, list);
-		size += sg_elem->size;
-	}
+	for (i = 0 ; i < ea->count; i++)
+		size += ea->elems[i].size;
 
 	return size;
 }

--- a/src/include/sof/idc.h
+++ b/src/include/sof/idc.h
@@ -37,6 +37,7 @@
 #ifndef __INCLUDE_IDC_H__
 #define __INCLUDE_IDC_H__
 
+#include <sof/schedule.h>
 #include <sof/trace.h>
 
 /** \brief IDC trace function. */
@@ -56,6 +57,9 @@
 
 /** \brief IDC send timeout in cycles. */
 #define IDC_TIMEOUT	800000
+
+/** \brief IDC task deadline. */
+#define IDC_DEADLINE	100
 
 /** \brief ROM wake version parsed by ROM during core wake up. */
 #define IDC_ROM_WAKE_VERSION	0x2
@@ -101,8 +105,8 @@ struct idc {
 	spinlock_t lock;		/**< lock mechanism */
 	uint32_t busy_bit_mask;		/**< busy interrupt mask */
 	uint32_t done_bit_mask;		/**< done interrupt mask */
-	uint32_t msg_pending;		/**< is message pending */
 	struct idc_msg received_msg;	/**< received message */
+	struct task idc_task;		/**< IDC processing task */
 };
 
 #endif

--- a/src/include/sof/ipc.h
+++ b/src/include/sof/ipc.h
@@ -147,7 +147,7 @@ void ipc_platform_send_msg(struct ipc *ipc);
 /* create a SG page table eme list from a compressed page table */
 int ipc_parse_page_descriptors(uint8_t *page_table,
 			       struct sof_ipc_host_buffer *ring,
-			       struct list_item *elem_list,
+			       struct dma_sg_elem_array *elem_array,
 			       uint32_t direction);
 int ipc_get_page_descriptors(struct dma *dmac, uint8_t *page_table,
 			     struct sof_ipc_host_buffer *ring);

--- a/src/include/sof/schedule.h
+++ b/src/include/sof/schedule.h
@@ -58,6 +58,7 @@ struct sof;
 #define TASK_PRI_HIGH	-20
 
 #define TASK_PRI_IPC	1
+#define TASK_PRI_IDC	1
 
 /* maximun task time slice in microseconds */
 #define SCHEDULE_TASK_MAX_TIME_SLICE	5000

--- a/src/include/sof/trace.h
+++ b/src/include/sof/trace.h
@@ -192,7 +192,7 @@ typedef void(*log_func)();
 #define __log_message(func_name, lvl, comp_id, format, ...)		\
 {									\
 	_DECLARE_LOG_ENTRY(lvl, format, comp_id, PP_NARG(__VA_ARGS__));	\
-	BASE_LOG(func_name, (uint32_t)&log_entry, ##__VA_ARGS__)	\
+	BASE_LOG(func_name, &log_entry, ##__VA_ARGS__)	\
 }
 
 #define _log_message(mbox, atomic, level, comp_id, format, ...)	\

--- a/src/ipc/dma-copy.c
+++ b/src/ipc/dma-copy.c
@@ -44,17 +44,18 @@
 #define trace_dma_error(__e)	trace_error(TRACE_CLASS_DMA, __e)
 #define tracev_dma(__e)	tracev_event(TRACE_CLASS_DMA, __e)
 
+#if !defined CONFIG_DMA_GW
 static struct dma_sg_elem *sg_get_elem_at(struct dma_sg_config *host_sg,
 	int32_t *offset)
 {
 	struct dma_sg_elem *host_sg_elem;
-	struct list_item *plist;
+	int i;
 	int32_t _offset = *offset;
  
 	/* find host element with host_offset */
-	list_for_item(plist, &host_sg->elem_list) {
+	for (i = 0; i < host_sg->elem_array.count; i++) {
 
-		host_sg_elem = container_of(plist, struct dma_sg_elem, list);
+		host_sg_elem = host_sg->elem_array.elems + i;
 
 		/* is offset in this elem ? */
 		if (_offset >= 0 && _offset < host_sg_elem->size) {
@@ -69,6 +70,7 @@ static struct dma_sg_elem *sg_get_elem_at(struct dma_sg_config *host_sg,
 	trace_dma_error("ex0");
 	return NULL;
 }
+#endif
 
 #if !defined CONFIG_DMA_GW
 
@@ -130,7 +132,7 @@ int dma_copy_to_host_nowait(struct dma_copy *dc, struct dma_sg_config *host_sg,
 	config.src_width = sizeof(uint32_t);
 	config.dest_width = sizeof(uint32_t);
 	config.cyclic = 0;
-	list_init(&config.elem_list);
+	dma_sg_init(&config.elem_array);
 
 	/* configure local DMA elem */
 	local_sg_elem.dest = host_sg_elem->dest + offset;
@@ -140,7 +142,8 @@ int dma_copy_to_host_nowait(struct dma_copy *dc, struct dma_sg_config *host_sg,
 	else
 		local_sg_elem.size = size;
 
-	list_item_prepend(&local_sg_elem.list, &config.elem_list);
+	config.elem_array.elems = &local_sg_elem;
+	config.elem_array.count = 1;
 
 	/* start the DMA */
 	err = dma_set_config(dc->dmac, dc->chan, &config);
@@ -156,138 +159,6 @@ int dma_copy_to_host_nowait(struct dma_copy *dc, struct dma_sg_config *host_sg,
 }
 
 #endif
-
-/* Copy host memory to DSP memory.
- * Copies host memory to host in PAGE_SIZE or smaller blocks and waits/sleeps
- * between blocks. Cant be used in IRQ context.
- */
-int dma_copy_from_host(struct dma_copy *dc, struct dma_sg_config *host_sg,
-	int32_t host_offset, void *local_ptr, int32_t size)
-{
-	struct dma_sg_config config;
-	struct dma_sg_elem *host_sg_elem;
-	struct dma_sg_elem local_sg_elem;
-	int32_t err;
-	int32_t offset = host_offset;
-	int32_t bytes_copied = 0;
-
-	if (size <= 0)
-		return 0;
-
-	/* find host element with host_offset */
-	host_sg_elem = sg_get_elem_at(host_sg, &offset);
-	if (host_sg_elem == NULL)
-		return -EINVAL;
-
-	/* set up DMA configuration */
-	config.direction = DMA_DIR_HMEM_TO_LMEM;
-	config.src_width = sizeof(uint32_t);
-	config.dest_width = sizeof(uint32_t);
-	config.cyclic = 0;
-	list_init(&config.elem_list);
-
-	/* configure local DMA elem */
-	local_sg_elem.dest = (uint32_t)local_ptr;
-	local_sg_elem.src = host_sg_elem->src + offset;
-	if (size >= HOST_PAGE_SIZE - offset)
-		local_sg_elem.size = HOST_PAGE_SIZE - offset;
-	else
-		local_sg_elem.size = size;
-	list_item_prepend(&local_sg_elem.list, &config.elem_list);
-
-	/* transfer max PAGE size at a time to SG buffer */
-	while (size > 0) {
-
-		/* start the DMA */
-		wait_init(&dc->complete);
-		err = dma_set_config(dc->dmac, dc->chan, &config);
-		if (err < 0)
-			return err;
-
-		err = dma_start(dc->dmac, dc->chan);
-		if (err < 0)
-			return err;
-
-		/* wait for DMA to complete */
-		err = wait_for_completion_timeout(&dc->complete);
-		if (err < 0) {
-			trace_dma_error("ex2");
-			return -EIO;
-		}
-
-		/* update offset and bytes remaining */
-		size -= local_sg_elem.size;
-		host_offset += local_sg_elem.size;
-
-		/* next dest host address is in next host elem */
-		host_sg_elem = list_next_item(host_sg_elem, list);
-		local_sg_elem.src = host_sg_elem->src;
-
-		/* local address is continuous */
-		local_sg_elem.dest = (uint32_t)local_ptr + local_sg_elem.size;
-
-		bytes_copied += local_sg_elem.size;
-
-		/* do we have less than 1 PAGE to copy ? */
-		if (size >= HOST_PAGE_SIZE)
-			local_sg_elem.size = HOST_PAGE_SIZE;
-		else
-			local_sg_elem.size = size;
-	}
-
-	/* bytes copied */
-	return bytes_copied;
-}
-
-/* Copy host memory to DSP memory.
- * Copies host memory to DSP in a single PAGE_SIZE or smaller block. Does not
- * waits/sleeps and can be used in IRQ context.
- */
-int dma_copy_from_host_nowait(struct dma_copy *dc, struct dma_sg_config *host_sg,
-	int32_t host_offset, void *local_ptr, int32_t size)
-{
-	struct dma_sg_config config;
-	struct dma_sg_elem *host_sg_elem;
-	struct dma_sg_elem local_sg_elem;
-	int32_t err;
-	int32_t offset = host_offset;
-
-	if (size <= 0)
-		return 0;
-
-	/* find host element with host_offset */
-	host_sg_elem = sg_get_elem_at(host_sg, &offset);
-	if (host_sg_elem == NULL)
-		return -EINVAL;
-
-	/* set up DMA configuration */
-	config.direction = DMA_DIR_HMEM_TO_LMEM;
-	config.src_width = sizeof(uint32_t);
-	config.dest_width = sizeof(uint32_t);
-	config.cyclic = 0;
-	list_init(&config.elem_list);
-
-	/* configure local DMA elem */
-	local_sg_elem.dest = (uint32_t)local_ptr;
-	local_sg_elem.src = host_sg_elem->src + offset;
-	if (size >= HOST_PAGE_SIZE - offset)
-		local_sg_elem.size = HOST_PAGE_SIZE - offset;
-	else
-		local_sg_elem.size = size;
-	list_item_prepend(&local_sg_elem.list, &config.elem_list);
-
-	/* start the DMA */
-	err = dma_set_config(dc->dmac, dc->chan, &config);
-	if (err < 0)
-		return err;
-
-	err = dma_start(dc->dmac, dc->chan);
-	if (err < 0)
-		return err;
-
-	/* bytes copied */
-	return local_sg_elem.size;
-}
 
 int dma_copy_new(struct dma_copy *dc)
 {

--- a/src/platform/apollolake/include/platform/idc.h
+++ b/src/platform/apollolake/include/platform/idc.h
@@ -38,11 +38,6 @@ static inline int idc_send_msg(struct idc_msg *msg, uint32_t mode)
 	return arch_idc_send_msg(msg, mode);
 }
 
-static inline void idc_process_msg_queue(void)
-{
-	arch_idc_process_msg_queue();
-}
-
 static inline void idc_init(void)
 {
 	arch_idc_init();

--- a/src/platform/baytrail/include/platform/idc.h
+++ b/src/platform/baytrail/include/platform/idc.h
@@ -36,8 +36,6 @@ struct idc_msg;
 static inline int idc_send_msg(struct idc_msg *msg,
 			       uint32_t mode) { return 0; }
 
-static inline void idc_process_msg_queue(void) { }
-
 static inline void idc_init(void) { }
 
 #endif

--- a/src/platform/cannonlake/include/platform/idc.h
+++ b/src/platform/cannonlake/include/platform/idc.h
@@ -38,11 +38,6 @@ static inline int idc_send_msg(struct idc_msg *msg, uint32_t mode)
 	return arch_idc_send_msg(msg, mode);
 }
 
-static inline void idc_process_msg_queue(void)
-{
-	arch_idc_process_msg_queue();
-}
-
 static inline void idc_init(void)
 {
 	arch_idc_init();

--- a/src/platform/haswell/include/platform/idc.h
+++ b/src/platform/haswell/include/platform/idc.h
@@ -36,8 +36,6 @@ struct idc_msg;
 static inline int idc_send_msg(struct idc_msg *msg,
 			       uint32_t mode) { return 0; }
 
-static inline void idc_process_msg_queue(void) { }
-
 static inline void idc_init(void) { }
 
 #endif

--- a/src/platform/icelake/include/platform/idc.h
+++ b/src/platform/icelake/include/platform/idc.h
@@ -38,11 +38,6 @@ static inline int idc_send_msg(struct idc_msg *msg, uint32_t mode)
 	return arch_idc_send_msg(msg, mode);
 }
 
-static inline void idc_process_msg_queue(void)
-{
-	arch_idc_process_msg_queue();
-}
-
 static inline void idc_init(void)
 {
 	arch_idc_init();

--- a/src/tasks/audio.c
+++ b/src/tasks/audio.c
@@ -103,9 +103,6 @@ int do_task_slave_core(struct sof *sof)
 		/* sleep until next IDC */
 		wait_for_interrupt(0);
 
-		/* now process any IDC messages from master core */
-		idc_process_msg_queue();
-
 		/* schedule any idle tasks */
 		schedule();
 	}

--- a/test/cmocka/Makefile.am
+++ b/test/cmocka/Makefile.am
@@ -39,6 +39,16 @@ endif
 
 LDADD = -lcmocka
 
+# generate linker script
+LINK_SCRIPT = memory_mock.x
+
+BUILT_SOURCES = $(LINK_SCRIPT)
+CLEANFILES = $(LINK_SCRIPT)
+$(LINK_SCRIPT): Makefile $(LINK_SCRIPT).in
+	cat $(LINK_SCRIPT).in | $(CPP) -P $(PLATFORM_INCDIR) $(SOF_INCDIR) - >$@
+
+AM_LDFLAGS += -T $(LINK_SCRIPT)
+
 # mixer tests
 check_PROGRAMS += mixer
 mixer_SOURCES = src/audio/mixer/mixer_test.c \

--- a/test/cmocka/memory_mock.x.in
+++ b/test/cmocka/memory_mock.x.in
@@ -1,0 +1,10 @@
+SECTIONS
+{
+
+    .static_log_entries (COPY) : ALIGN(1024)
+    {
+      *(*.static_log*)
+    }
+
+}
+INSERT AFTER .text;

--- a/test/cmocka/src/audio/buffer/mock.c
+++ b/test/cmocka/src/audio/buffer/mock.c
@@ -33,14 +33,15 @@
 
 #include <sof/alloc.h>
 
-void _trace_event(uint32_t e)
+void _trace_event0(uint32_t log_entry)
 {
-	(void)e;
+	(void)log_entry;
 }
 
-void _trace_event_mbox_atomic(uint32_t e)
+void _trace_event1(uint32_t log_entry, uint32_t param)
 {
-	(void)e;
+	(void)log_entry;
+	(void)param;
 }
 
 void *rzalloc(int zone, uint32_t caps, size_t bytes)

--- a/test/cmocka/src/audio/component/mock.c
+++ b/test/cmocka/src/audio/component/mock.c
@@ -34,9 +34,15 @@
 #include <sof/alloc.h>
 #include <sof/trace.h>
 
-void _trace_event_mbox_atomic(uint32_t e)
+void _trace_event0(uint32_t log_entry)
 {
-	(void)e;
+	(void)log_entry;
+}
+
+void _trace_event1(uint32_t log_entry, uint32_t param)
+{
+	(void)log_entry;
+	(void)param;
 }
 
 void *rzalloc(int zone, uint32_t caps, size_t bytes)

--- a/test/cmocka/src/audio/mixer/mock.c
+++ b/test/cmocka/src/audio/mixer/mock.c
@@ -38,14 +38,15 @@
 
 #include "comp_mock.h"
 
-void _trace_event(uint32_t e)
+void _trace_event0(uint32_t log_entry)
 {
-	(void)e;
+	(void)log_entry;
 }
 
-void _trace_event_mbox_atomic(uint32_t e)
+void _trace_event1(uint32_t log_entry, uint32_t param)
 {
-	(void)e;
+	(void)log_entry;
+	(void)param;
 }
 
 void *rballoc(int zone, uint32_t caps, size_t bytes)

--- a/test/cmocka/src/audio/pipeline/pipeline_mocks.c
+++ b/test/cmocka/src/audio/pipeline/pipeline_mocks.c
@@ -79,12 +79,13 @@ int ipc_stream_send_xrun(struct comp_dev *cdev,
 	return 0;
 }
 
-void _trace_event(uint32_t event)
+void _trace_event0(uint32_t log_entry)
 {
-	(void)event;
+	(void)log_entry;
 }
 
-void _trace_event_mbox_atomic(uint32_t event)
+void _trace_event1(uint32_t log_entry, uint32_t param)
 {
-	(void)event;
+	(void)log_entry;
+	(void)param;
 }

--- a/test/cmocka/src/lib/alloc/mock.c
+++ b/test/cmocka/src/lib/alloc/mock.c
@@ -48,8 +48,15 @@ int dma_copy_to_host(struct dma_copy *dc, struct dma_sg_config *host_sg,
 	return 0;
 }
 
-void _trace_event_mbox_atomic(uint32_t e)
+void _trace_event0(uint32_t log_entry)
 {
+	(void)log_entry;
+}
+
+void _trace_event1(uint32_t log_entry, uint32_t param)
+{
+	(void)log_entry;
+	(void)param;
 }
 
 void trace_flush(void)


### PR DESCRIPTION
Multiple alloctions of SG elements linked as a list
replaced with single allocations of arrays.

- the code flows (esp. cleanup-on-error) are simplified,

- number of 64bytes chunk allocations reduced from 18 to 12 for
  example very basic topology, no increase in other areas
  (2-period sgls still fit),

- more efficient allocation for host page tables on legacy platforms;
  instead of going from a desc array to the list that is copied to
  another list, there is just a single allocation of array moved
  to the destination component.

Signed-off-by: Marcin Maka <marcin.maka@linux.intel.com>