### PR TITLE
host: fix build errors

### DIFF
--- a/src/arch/host/include/arch/sof.h
+++ b/src/arch/host/include/arch/sof.h
@@ -45,6 +45,10 @@
 /* data cache line alignment */
 #define PLATFORM_DCACHE_ALIGN	sizeof(uint32_t)
 
+#define PLATFORM_HEAP_SYSTEM	1
+#define PLATFORM_HEAP_RUNTIME	1
+#define PLATFORM_HEAP_BUFFER	3
+
 static inline void *arch_get_stack_ptr(void)
 {
 	void *frames[ARCH_STACK_DUMP_FRAMES];

--- a/src/include/sof/trace.h
+++ b/src/include/sof/trace.h
@@ -192,7 +192,7 @@ typedef void(*log_func)();
 #define __log_message(func_name, lvl, comp_id, format, ...)		\
 {									\
 	_DECLARE_LOG_ENTRY(lvl, format, comp_id, PP_NARG(__VA_ARGS__));	\
-	BASE_LOG(func_name, (uint32_t)&log_entry, ##__VA_ARGS__)	\
+	BASE_LOG(func_name, &log_entry, ##__VA_ARGS__)	\
 }
 
 #define _log_message(mbox, atomic, level, comp_id, format, ...)	\


### PR DESCRIPTION
Fixes building errors for arch host.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>