### PR TITLE
debugability: rimage: extract .static_log_entries from elf

### DIFF
--- a/rimage/elf.c
+++ b/rimage/elf.c
@@ -87,6 +87,12 @@ static int elf_read_sections(struct image *image, struct module *module)
 	fprintf(stdout, " BSS module metadata section at index %d\n",
 		man_section_idx);
 
+	/* find log entries section */
+	module->logs_index  = elf_find_section(image, module,
+		".static_log_entries");
+	fprintf(stdout, " static log entries section at index %d\n",
+		module->logs_index);
+
 	/* parse each section */
 	for (i = 0; i < hdr->e_shnum; i++) {
 
@@ -281,6 +287,9 @@ static void elf_module_size(struct image *image, struct module *module,
 			fprintf(stdout, "\tHEAP\t");
 		}
 		break;
+	case SHT_NOTE:
+		fprintf(stdout, "\tNOTE\t");
+		break;
 	default:
 		break;
 	}
@@ -343,7 +352,7 @@ static void elf_module_limits(struct image *image, struct module *module)
 		section = &module->section[i];
 
 		/* module bss can sometimes be missed */
-		if (i != module->bss_index) {
+		if (i != module->bss_index && i != module->logs_index) {
 
 			/* only check valid sections */
 			if (!(section->sh_flags & valid))

--- a/rimage/file_format.h
+++ b/rimage/file_format.h
@@ -67,6 +67,9 @@
 #define SND_SOF_FW_ABI		1
 #define SND_SOF_FW_SIG		"Reef"
 
+#define SND_SOF_LOGS_SIG_SIZE	4
+#define SND_SOF_LOGS_SIG	"Logs"
+
 /*
  * Firmware module is made up of 1 . N blocks of different types. The
  * Block header is used to determine where and how block is to be copied in the
@@ -114,4 +117,13 @@ struct snd_sof_fw_header {
 	uint32_t abi;		/* version of header format */
 } __attribute__((packed));
 
+/*
+ * Logs dictionary file header.
+ */
+struct snd_sof_logs_header {
+	unsigned char sig[SND_SOF_LOGS_SIG_SIZE]; /* "Logs" */
+	uint32_t base_address;	/* address of log entries section */
+	uint32_t data_length;	/* amount of bytes following this header */
+	uint32_t data_offset;	/* offset to first entry in this file */
+};
 #endif

--- a/rimage/rimage.c
+++ b/rimage/rimage.c
@@ -41,6 +41,7 @@ static void usage(char *name)
 	fprintf(stdout, "\t -v enable verbose output\n");
 	fprintf(stdout, "\t -r enable relocatable ELF files\n");
 	fprintf(stdout, "\t -s MEU signing offset\n");
+	fprintf(stdout, "\t -p log dictionary outfile\n");
 	exit(0);
 }
 
@@ -52,10 +53,13 @@ int main(int argc, char *argv[])
 
 	memset(&image, 0, sizeof(image));
 
-	while ((opt = getopt(argc, argv, "ho:m:vba:s:k:l:r")) != -1) {
+	while ((opt = getopt(argc, argv, "ho:p:m:vba:s:k:l:r")) != -1) {
 		switch (opt) {
 		case 'o':
 			image.out_file = optarg;
+			break;
+		case 'p':
+			image.ldc_out_file = optarg;
 			break;
 		case 'm':
 			mach = optarg;
@@ -89,6 +93,8 @@ int main(int argc, char *argv[])
 	if (image.out_file == NULL || mach == NULL)
 		usage(argv[0]);
 
+	if (image.ldc_out_file == NULL)
+		image.ldc_out_file = "out.ldc";
 
 	/* find machine */
 	for (i = 0; i < ARRAY_SIZE(machine); i++) {
@@ -136,11 +142,23 @@ found:
 		ret = image.adsp->write_firmware_meu(&image);
 	else
 		ret = image.adsp->write_firmware(&image);
+
+	unlink(image.ldc_out_file);
+	image.ldc_out_fd = fopen(image.ldc_out_file, "w");
+	if (image.ldc_out_fd == NULL) {
+		fprintf(stderr, "error: unable to open %s for writing %d\n",
+			image.ldc_out_file, errno);
+		ret = -EINVAL;
+		goto out;
+	}
+	ret = write_logs_dictionary(&image);
 out:
 	/* close files */
 	if (image.out_fd)
 		fclose(image.out_fd);
 
+	if (image.ldc_out_fd)
+		fclose(image.ldc_out_fd);
 
 	return ret;
 }

--- a/rimage/rimage.h
+++ b/rimage/rimage.h
@@ -68,6 +68,7 @@ struct module {
 	int num_bss;
 	int fw_size;
 	int bss_index;
+	int logs_index;
 
 	/* sizes do not include any gaps */
 	int bss_size;
@@ -90,7 +91,9 @@ struct module {
 struct image {
 
 	const char *out_file;
+	const char *ldc_out_file;
 	FILE *out_fd;
+	FILE *ldc_out_fd;
 	void *pos;
 
 	const struct adsp *adsp;
@@ -144,6 +147,8 @@ struct adsp {
 	int (*write_firmware_meu)(struct image *image);
 	struct fw_image_manifest *man;
 };
+
+int write_logs_dictionary(struct image *image);
 
 void module_sha256_create(struct image *image);
 void module_sha256_update(struct image *image, uint8_t *data, size_t bytes);

--- a/src/arch/xtensa/Makefile.am
+++ b/src/arch/xtensa/Makefile.am
@@ -209,11 +209,11 @@ MODULE_INSERT=
 endif
 
 if USE_MEU
-RIMAGE=rimage -o sof-$(FW_NAME).ri -m $(FW_NAME) $(RIMAGE_BOOT_FLAGS) $(RIMAGE_FLAGS) -s $(MEU_OFFSET)
+RIMAGE=rimage -o sof-$(FW_NAME).ri -p sof-$(FW_NAME).ldc -m $(FW_NAME) $(RIMAGE_BOOT_FLAGS) $(RIMAGE_FLAGS) -s $(MEU_OFFSET)
 MEU=$(MEU_PATH)/meu -w ./ -s sof-$(FW_NAME) -key $(PRIVATE_KEY) -stp /usr/bin/openssl -f $(MEU_PATH)/generic_meu_conf.xml \
 	-mnver 0.0.0.0 -o sof-$(FW_NAME).ri
 else
-RIMAGE=rimage -o sof-$(FW_NAME).ri -m $(FW_NAME) $(RIMAGE_BOOT_FLAGS) $(RIMAGE_FLAGS)
+RIMAGE=rimage -o sof-$(FW_NAME).ri -p sof-$(FW_NAME).ldc -m $(FW_NAME) $(RIMAGE_BOOT_FLAGS) $(RIMAGE_FLAGS)
 MEU=
 endif
 


### PR DESCRIPTION
.static_log_entries section is extracted to logs dictionary
to remove xtensa toolchain dependency from logs parser.

Signed-off-by: ArturX Kloniecki <arturx.kloniecki@linux.intel.com>