### PR TITLE
memory: apl: increased SOF_TEXT_SIZE

### DIFF
--- a/src/platform/apollolake/include/platform/memory.h
+++ b/src/platform/apollolake/include/platform/memory.h
@@ -247,7 +247,7 @@
 
 #define SOF_TEXT_START		(HP_SRAM_VECBASE_RESET + 0x400)
 #define SOF_TEXT_BASE		(SOF_TEXT_START)
-#define SOF_TEXT_SIZE		(0x19000 - 0x400)
+#define SOF_TEXT_SIZE		(0x1a000 - 0x400)
 
 /* initialized data */
 #define SOF_DATA_START		(SOF_TEXT_BASE + SOF_TEXT_SIZE)


### PR DESCRIPTION
Fixes xcc building errors by increasing SOF_TEXT_SIZE.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>