### PR TITLE
work: shared work queue implementation

### DIFF
--- a/src/drivers/intel/cavs/timer.c
+++ b/src/drivers/intel/cavs/timer.c
@@ -62,8 +62,7 @@ int platform_timer_set(struct timer *timer, uint64_t ticks)
 
 	/* set new value and run */
 	shim_write64(SHIM_DSPWCT0C, ticks);
-	shim_write(SHIM_DSPWCTCS,
-		   shim_read(SHIM_DSPWCTCS) | SHIM_DSPWCTCS_T0A);
+	shim_write(SHIM_DSPWCTCS, SHIM_DSPWCTCS_T0A);
 
 	return 0;
 }
@@ -71,8 +70,7 @@ int platform_timer_set(struct timer *timer, uint64_t ticks)
 void platform_timer_clear(struct timer *timer)
 {
 	/* write 1 to clear the timer interrupt */
-	shim_write(SHIM_DSPWCTCS,
-		   shim_read(SHIM_DSPWCTCS) | SHIM_DSPWCTCS_T0T);
+	shim_write(SHIM_DSPWCTCS, SHIM_DSPWCTCS_T0T);
 }
 
 uint64_t platform_timer_get(struct timer *timer)

--- a/src/lib/agent.c
+++ b/src/lib/agent.c
@@ -86,9 +86,9 @@ void sa_init(struct sof *sof)
 	sa = rzalloc(RZONE_SYS, SOF_MEM_CAPS_RAM, sizeof(*sa));
 	sof->sa = sa;
 
-	/* set default tick timout */
-	sa->ticks = clock_ms_to_ticks(PLATFORM_WORKQ_CLOCK,
-				      PLATFORM_IDLE_TIME / 1000);
+	/* set default tick timeout */
+	sa->ticks = clock_ms_to_ticks(PLATFORM_WORKQ_CLOCK, 1) *
+		PLATFORM_IDLE_TIME / 1000;
 	trace_sa_value(sa->ticks);
 
 	/* set lst idle time to now to give time for boot completion */

--- a/src/platform/apollolake/include/platform/platform.h
+++ b/src/platform/apollolake/include/platform/platform.h
@@ -88,6 +88,9 @@ struct sof;
 /* platform WorkQ clock */
 #define PLATFORM_WORKQ_CLOCK	CLK_SSP
 
+/* work queue default timeout in microseconds */
+#define PLATFORM_WORKQ_DEFAULT_TIMEOUT	1000
+
 /* Host finish work schedule delay in microseconds */
 #define PLATFORM_HOST_FINISH_DELAY	100
 


### PR DESCRIPTION
Implements shared work queue across multiple cores:
- Work queue with 1 ms tick (will be configurable via IPC).
- Work queue shared across cores based on the same timer.
- Work queue enablement based on the number of active tasks.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>