### PR TITLE
host: arch: define PLATFORM_DEFAULT_CLOCK

### DIFF
--- a/src/library/include/platform/platform.h
+++ b/src/library/include/platform/platform.h
@@ -53,6 +53,9 @@
 /* DSP default delay in cycles */
 #define PLATFORM_DEFAULT_DELAY	12
 
+/* default platform clock */
+#define PLATFORM_DEFAULT_CLOCK	CLK_SSP
+
 static inline void platform_panic(uint32_t p) {}
 
 extern struct timer *platform_timer;


### PR DESCRIPTION
Fixes building for host arch by defining
PLATFORM_DEFAULT_CLOCK.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>