### PR TITLE
ut: include missing headers

### DIFF
--- a/test/cmocka/src/audio/buffer/mock.c
+++ b/test/cmocka/src/audio/buffer/mock.c
@@ -32,6 +32,7 @@
 #include <stdlib.h>
 
 #include <sof/alloc.h>
+#include <sof/trace.h>
 
 void _trace_event0(uint32_t log_entry)
 {

--- a/test/cmocka/src/lib/lib/strcheck.c
+++ b/test/cmocka/src/lib/lib/strcheck.c
@@ -27,6 +27,7 @@
  * Author: Michal Jerzy Wierzbicki <michalx.wierzbicki@linux.intel.com>
  */
 #include <sof/alloc.h>
+#include <sof/dma.h>
 
 #include <stdarg.h>
 #include <setjmp.h>


### PR DESCRIPTION
Includes missing headers.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>