### PR TITLE
EQ FIR: Updates for component initialization and cache functions

### DIFF
--- a/src/audio/fir_config.h
+++ b/src/audio/fir_config.h
@@ -58,10 +58,11 @@
 #if XCHAL_HAVE_HIFI2EP == 1
 #define FIR_HIFIEP	1
 #define FIR_HIFI3	0
-#endif
-#if XCHAL_HAVE_HIFI3 == 1
+#elif XCHAL_HAVE_HIFI3 == 1
 #define FIR_HIFI3	1
 #define FIR_HIFIEP	0
+#else
+#error "No HIFIEP or HIFI3 found. Cannot build FIR module."
 #endif
 #else
 /* GCC */

--- a/src/audio/fir_hifi2ep.c
+++ b/src/audio/fir_hifi2ep.c
@@ -48,34 +48,28 @@
 
 void fir_reset(struct fir_state_32x16 *fir)
 {
-	fir->mute = 1;
+	fir->taps = 0;
 	fir->length = 0;
 	fir->out_shift = 0;
-	fir->rwp = NULL;
-	fir->delay = NULL;
-	fir->delay_end = NULL;
 	fir->coef = NULL;
 	/* There may need to know the beginning of dynamic allocation after
 	 * reset so omitting setting also fir->delay to NULL.
 	 */
 }
 
-int fir_init_coef(struct fir_state_32x16 *fir, int16_t config[])
+size_t fir_init_coef(struct fir_state_32x16 *fir,
+		     struct sof_eq_fir_coef_data *config)
 {
-	struct sof_eq_fir_coef_data *setup;
-
 	/* The length is taps plus two since the filter computes two
 	 * samples per call. Length plus one would be minimum but the add
 	 * must be even. The even length is needed for 64 bit loads from delay
 	 * lines with 32 bit samples.
 	 */
-	setup = (struct sof_eq_fir_coef_data *)config;
-	fir->mute = 0;
 	fir->rwp = NULL;
-	fir->taps = (int)setup->length;
+	fir->taps = (int)config->length;
 	fir->length = fir->taps + 2;
-	fir->out_shift = (int)setup->out_shift;
-	fir->coef = (ae_p16x2s *)&setup->coef[0];
+	fir->out_shift = (int)config->out_shift;
+	fir->coef = (ae_p16x2s *)&config->coef[0];
 	fir->delay = NULL;
 	fir->delay_end = NULL;
 
@@ -86,7 +80,7 @@ int fir_init_coef(struct fir_state_32x16 *fir, int16_t config[])
 	if (fir->taps & 3)
 		return -EINVAL;
 
-	return fir->length;
+	return fir->length * sizeof(int32_t);
 }
 
 void fir_init_delay(struct fir_state_32x16 *fir, int32_t **data)
@@ -100,13 +94,8 @@ void fir_init_delay(struct fir_state_32x16 *fir, int32_t **data)
 void fir_get_lrshifts(struct fir_state_32x16 *fir, int *lshift,
 		      int *rshift)
 {
-	if (fir->mute) {
-		*lshift = 0;
-		*rshift = 31;
-	} else {
-		*lshift = (fir->out_shift < 0) ? -fir->out_shift : 0;
-		*rshift = (fir->out_shift > 0) ? fir->out_shift : 0;
-	}
+	*lshift = (fir->out_shift < 0) ? -fir->out_shift : 0;
+	*rshift = (fir->out_shift > 0) ? fir->out_shift : 0;
 }
 
 /* For even frame lengths use FIR filter that processes two sequential

--- a/src/include/uapi/eq.h
+++ b/src/include/uapi/eq.h
@@ -44,6 +44,8 @@
 
 #define SOF_EQ_FIR_MAX_LENGTH 192 /* Max length for individual filter */
 
+#define SOF_EQ_FIR_MAX_RESPONSES 8 /* A blob can define max 8 FIR EQs */
+
 /*
  * eq_fir_configuration data structure contains this information
  *     uint32_t size


### PR DESCRIPTION
This patch delays FIR initialization until prepare() to avoid unnecessary
initialization for not final channels amount when in idle. It avoids
a number of malloc and free operations. The FIR delaylines allocation
is brought easier visible via addition for FIR delay address and size
pointers to component data. There's no more need to look it up from inside
of FIR channel instances.

The FIR channel bypass feature is now supported with assign of response
number -1 into channel similarly as in IIR. The same change is done
for generic C and optimized FIR cores.

The cache invalidate functions are cleaned up to perform the operation
into single allocated buffer instead of multiple.

FIR reconfigure during playback is prevented due to still incomplete
implementation for runtime changes.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>