### PR TITLE
dma: simple i/f to control flow between platform and lib

### DIFF
--- a/src/include/sof/dma.h
+++ b/src/include/sof/dma.h
@@ -167,10 +167,25 @@ struct dma {
 	uint32_t private_size;
 };
 
-struct dma *dma_get(uint32_t dir, uint32_t caps, uint32_t dev, uint32_t flags);
+/**
+ *  \brief Plugs platform specific DMA array once initialized into the lib.
+ *
+ *  Lib serves the DMAs to other FW elements by dma_get()
+ *
+ *  \param[in] dma_array Array of DMAs.
+ *  \param[in] num_dmas Number of elements in dma_array.
+ */
+void dma_install(struct dma *dma_array, size_t num_dmas);
 
-/* initialize all platform DMAC's */
-int dmac_init(void);
+/**
+ * \brief API to request a platform DMAC.
+ *
+ * Users can request DMAC based on dev type, copy direction, capabilities
+ * and access privilege.
+ * For exclusive access, ret DMAC with no channels draining.
+ * For shared access, ret DMAC with the least number of channels draining.
+ */
+struct dma *dma_get(uint32_t dir, uint32_t caps, uint32_t dev, uint32_t flags);
 
 #define dma_set_drvdata(dma, data) \
 	dma->private = data; \

--- a/src/platform/apollolake/include/platform/dma.h
+++ b/src/platform/apollolake/include/platform/dma.h
@@ -37,8 +37,6 @@
 #include <arch/cache.h>
 #include <sof/dma.h>
 
-#define PLATFORM_NUM_DMACS	6
-
 /* available DMACs */
 #define DMA_GP_LP_DMAC0		0
 #define DMA_GP_LP_DMAC1		1
@@ -75,6 +73,6 @@
 #define DMA_HANDSHAKE_SSP5_TX	12
 #define DMA_HANDSHAKE_SSP5_RX	13
 
-extern struct dma dma[PLATFORM_NUM_DMACS];
+int dmac_init(void);
 
 #endif

--- a/src/platform/baytrail/dma.c
+++ b/src/platform/baytrail/dma.c
@@ -206,5 +206,8 @@ int dmac_init(void)
 		}
 	}
 
+	/* tell the lib DMAs are ready to use */
+	dma_install(dma, ARRAY_SIZE(dma));
+
 	return 0;
 }

--- a/src/platform/baytrail/include/platform/dma.h
+++ b/src/platform/baytrail/include/platform/dma.h
@@ -60,6 +60,6 @@
 #define DMA_HANDSHAKE_SSP6_RX	12
 #define DMA_HANDSHAKE_SSP6_TX	13
 
-extern struct dma dma[PLATFORM_NUM_DMACS];
+int dmac_init(void);
 
 #endif

--- a/src/platform/cannonlake/include/platform/dma.h
+++ b/src/platform/cannonlake/include/platform/dma.h
@@ -35,8 +35,6 @@
 
 #include <sof/dma.h>
 
-#define PLATFORM_NUM_DMACS	6
-
 /* available DMACs */
 #define DMA_GP_LP_DMAC0		0
 #define DMA_GP_LP_DMAC1		1
@@ -73,6 +71,6 @@
 #define DMA_HANDSHAKE_SSP5_TX	12
 #define DMA_HANDSHAKE_SSP5_RX	13
 
-extern struct dma dma[PLATFORM_NUM_DMACS];
+int dmac_init(void);
 
 #endif

--- a/src/platform/haswell/dma.c
+++ b/src/platform/haswell/dma.c
@@ -155,5 +155,8 @@ int dmac_init(void)
 	io_reg_update_bits(SHIM_BASE + SHIM_IMRD,
 			   SHIM_IMRD_DMAC1, 0);
 
+	/* tell the lib DMAs are ready to use */
+	dma_install(dma, ARRAY_SIZE(dma));
+
 	return 0;
 }

--- a/src/platform/haswell/include/platform/dma.h
+++ b/src/platform/haswell/include/platform/dma.h
@@ -34,7 +34,7 @@
 #include <stdint.h>
 #include <sof/dma.h>
 
-#define PLATFORM_NUM_DMACS	2
+#define PLATFORM_NUM_DMACS		2
 
 #define DMA_ID_DMAC0			0
 #define DMA_ID_DMAC1			1
@@ -56,6 +56,6 @@
 #define DMA_HANDSHAKE_OBFF_10		14
 #define DMA_HANDSHAKE_OBFF_11		15
 
-extern struct dma dma[PLATFORM_NUM_DMACS];
+int dmac_init(void);
 
 #endif

--- a/src/platform/icelake/include/platform/dma.h
+++ b/src/platform/icelake/include/platform/dma.h
@@ -35,8 +35,6 @@
 
 #include <sof/dma.h>
 
-#define PLATFORM_NUM_DMACS	6
-
 /* available DMACs */
 #define DMA_GP_LP_DMAC0		0
 #define DMA_GP_LP_DMAC1		1
@@ -73,6 +71,6 @@
 #define DMA_HANDSHAKE_SSP5_TX	12
 #define DMA_HANDSHAKE_SSP5_RX	13
 
-extern struct dma dma[PLATFORM_NUM_DMACS];
+int dmac_init(void);
 
 #endif

--- a/src/platform/intel/cavs/dma.c
+++ b/src/platform/intel/cavs/dma.c
@@ -40,6 +40,8 @@
 #include <stdint.h>
 #include <string.h>
 
+#define CAVS_PLATFORM_NUM_DMACS		6
+
 #if defined(CONFIG_APOLLOLAKE)
 #define DMAC0_CLASS 1
 #define DMAC1_CLASS 2
@@ -124,7 +126,7 @@ static struct dw_drv_plat_data dmac1 = {
 	},
 };
 
-struct dma dma[PLATFORM_NUM_DMACS] = {
+static struct dma dma[CAVS_PLATFORM_NUM_DMACS] = {
 {	/* Low Power GP DMAC 0 */
 	.plat_data = {
 		.id		= DMA_GP_LP_DMAC0,
@@ -221,6 +223,9 @@ int dmac_init(void)
 			return ret;
 		}
 	}
+
+	/* tell the lib DMAs are ready to use */
+	dma_install(dma, ARRAY_SIZE(dma));
 
 	return 0;
 }


### PR DESCRIPTION
Less globals.
Path to dynamic dma discovery enabled on platforms that support it.
Avoid linker issues as platform lib still keeps refs to dma
array once probing is deferred (patch is coming).

Signed-off-by: Marcin Maka <marcin.maka@linux.intel.com>