### PR TITLE
dai: simple i/f to control flow between platform and lib

### DIFF
--- a/src/arch/xtensa/Makefile.am
+++ b/src/arch/xtensa/Makefile.am
@@ -93,6 +93,7 @@ sof_LDADD = \
 	../../platform/$(PLATFORM)/libplatform.la \
 	../../ipc/libsof_ipc.a \
 	../../lib/libdma.a \
+	../../lib/libdai.a \
 	../../audio/libaudio.a \
 	../../drivers/libdrivers.la \
 	../../math/libsof_math.a \

--- a/src/include/sof/dai.h
+++ b/src/include/sof/dai.h
@@ -125,6 +125,31 @@ struct dai {
 	uint32_t private_size;
 };
 
+/**
+ * \brief Array of DAIs grouped by type.
+ */
+struct dai_type_info {
+	uint32_t type;		/**< Type */
+	struct dai *dai_array;	/**< Array of DAIs */
+	size_t num_dais;	/**< Number of elements in dai_array */
+};
+
+/**
+ * \brief Plugs platform specific DAI array once initialized into the lib.
+ *
+ * Lib serves the DAIs to other FW elements with dai_get()
+ *
+ * \param[in] dai_type_array Array of DAI arrays grouped by type.
+ * \param[in] num_dai_types Number of elements in the dai_type_array.
+ */
+void dai_install(struct dai_type_info *dai_type_array, size_t num_dai_types);
+
+/**
+ * \brief API to request a platform DAI.
+ *
+ * \param[in] type Type of requested DAI.
+ * \param[in] index Index of requested DAI.
+ */
 struct dai *dai_get(uint32_t type, uint32_t index);
 
 #define dai_set_drvdata(dai, data) \

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -1,4 +1,4 @@
-noinst_LIBRARIES = libcore.a libdma.a
+noinst_LIBRARIES = libcore.a libdma.a libdai.a
 
 libcore_a_SOURCES = \
 	lib.c \
@@ -23,6 +23,16 @@ libdma_a_SOURCES = \
 	dma.c
 
 libdma_a_CFLAGS = \
+	$(AM_CFLAGS) \
+	$(ARCH_CFLAGS) \
+	$(ARCH_INCDIR) \
+	$(PLATFORM_INCDIR) \
+	$(SOF_INCDIR)
+
+libdai_a_SOURCES = \
+	dai.c
+
+libdai_a_CFLAGS = \
 	$(AM_CFLAGS) \
 	$(ARCH_CFLAGS) \
 	$(ARCH_INCDIR) \

--- a/src/platform/apollolake/include/platform/dai.h
+++ b/src/platform/apollolake/include/platform/dai.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Intel Corporation
+ * Copyright (c) 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,68 +25,26 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
+ * Author: Marcin Maka <marcin.maka@linux.intel.com>
  */
 
-#include <sof/sof.h>
-#include <sof/dai.h>
-#include <sof/ssp.h>
-#include <sof/stream.h>
-#include <sof/audio/component.h>
-#include <platform/memory.h>
-#include <platform/interrupt.h>
-#include <platform/dma.h>
-#include <platform/dai.h>
-#include <stdint.h>
-#include <string.h>
-#include <config.h>
+#ifndef __PLATFORM_DAI_H__
+#define __PLATFORM_DAI_H__
 
-static struct dai ssp[2] = {
-{
-	.type = SOF_DAI_INTEL_SSP,
-	.index = 0,
-	.plat_data = {
-		.base		= SSP0_BASE,
-		.irq		= IRQ_NUM_EXT_SSP0,
-		.fifo[SOF_IPC_STREAM_PLAYBACK] = {
-			.offset		= SSP0_BASE + SSDR,
-			.handshake	= DMA_HANDSHAKE_SSP0_TX,
-		},
-		.fifo[SOF_IPC_STREAM_CAPTURE] = {
-			.offset		= SSP0_BASE + SSDR,
-			.handshake	= DMA_HANDSHAKE_SSP0_RX,
-		}
-	},
-	.ops		= &ssp_ops,
-},
-{
-	.type = SOF_DAI_INTEL_SSP,
-	.index = 1,
-	.plat_data = {
-		.base		= SSP1_BASE,
-		.irq		= IRQ_NUM_EXT_SSP1,
-		.fifo[SOF_IPC_STREAM_PLAYBACK] = {
-			.offset		= SSP1_BASE + SSDR,
-			.handshake	= DMA_HANDSHAKE_SSP1_TX,
-		},
-		.fifo[SOF_IPC_STREAM_CAPTURE] = {
-			.offset		= SSP1_BASE + SSDR,
-			.handshake	= DMA_HANDSHAKE_SSP1_RX,
-		}
-	},
-	.ops		= &ssp_ops,
-}};
+/* SSP */
 
-static struct dai_type_info dti[] = {
-	{
-		.type = SOF_DAI_INTEL_SSP,
-		.dai_array = ssp,
-		.num_dais = ARRAY_SIZE(ssp)
-	}
-};
+/*
+ * Number of base and extended SSP ports must be defined separately
+ * since some HW registers are in two groups, one for base and one
+ * for extended.
+ */
 
-int dai_init(void)
-{
-	dai_install(dti, ARRAY_SIZE(dti));
-	return 0;
-}
+/** \brief Number of 'base' SSP ports available */
+#define DAI_NUM_SSP_BASE	4
+
+/** \brief Number of 'extended' SSP ports available */
+#define DAI_NUM_SSP_EXT		2
+
+int dai_init(void);
+
+#endif

--- a/src/platform/apollolake/include/platform/dai.h
+++ b/src/platform/apollolake/include/platform/dai.h
@@ -31,6 +31,8 @@
 #ifndef __PLATFORM_DAI_H__
 #define __PLATFORM_DAI_H__
 
+/* APOLLOLAKE */
+
 /* SSP */
 
 /*
@@ -44,6 +46,14 @@
 
 /** \brief Number of 'extended' SSP ports available */
 #define DAI_NUM_SSP_EXT		2
+
+/* HD/A */
+
+/** \brief Number of HD/A Link Outputs */
+#define DAI_NUM_HDA_OUT		6
+
+/** \brief Number of HD/A Link Inputs */
+#define DAI_NUM_HDA_IN		7
 
 int dai_init(void);
 

--- a/src/platform/apollolake/include/platform/platform.h
+++ b/src/platform/apollolake/include/platform/platform.h
@@ -130,9 +130,6 @@ struct sof;
 /* platform has low power memory type */
 #define PLATFORM_MEM_HAS_LP_RAM
 
-/* number of SSP ports in platform */
-#define PLATFORM_NUM_SSP	6
-
 /* DSP default delay in cycles */
 #define PLATFORM_DEFAULT_DELAY	12
 

--- a/src/platform/baytrail/dai.c
+++ b/src/platform/baytrail/dai.c
@@ -36,6 +36,7 @@
 #include <platform/memory.h>
 #include <platform/interrupt.h>
 #include <platform/dma.h>
+#include <platform/dai.h>
 #include <uapi/ipc.h>
 #include <stdint.h>
 #include <string.h>
@@ -148,14 +149,16 @@ static struct dai ssp[] = {
 #endif
 };
 
-struct dai *dai_get(enum sof_ipc_dai_type type, uint32_t index)
-{
-	int i;
-
-	for (i = 0; i < ARRAY_SIZE(ssp); i++) {
-		if (ssp[i].type == type && ssp[i].index == index)
-			return &ssp[i];
+static struct dai_type_info dti[] = {
+	{
+		.type = SOF_DAI_INTEL_SSP,
+		.dai_array = ssp,
+		.num_dais = ARRAY_SIZE(ssp)
 	}
+};
 
-	return NULL;
+int dai_init(void)
+{
+	dai_install(dti, ARRAY_SIZE(dti));
+	return 0;
 }

--- a/src/platform/baytrail/include/platform/dai.h
+++ b/src/platform/baytrail/include/platform/dai.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Intel Corporation
+ * Copyright (c) 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,68 +25,12 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
+ * Author: Marcin Maka <marcin.maka@linux.intel.com>
  */
 
-#include <sof/sof.h>
-#include <sof/dai.h>
-#include <sof/ssp.h>
-#include <sof/stream.h>
-#include <sof/audio/component.h>
-#include <platform/memory.h>
-#include <platform/interrupt.h>
-#include <platform/dma.h>
-#include <platform/dai.h>
-#include <stdint.h>
-#include <string.h>
-#include <config.h>
+#ifndef __PLATFORM_DAI_H__
+#define __PLATFORM_DAI_H__
 
-static struct dai ssp[2] = {
-{
-	.type = SOF_DAI_INTEL_SSP,
-	.index = 0,
-	.plat_data = {
-		.base		= SSP0_BASE,
-		.irq		= IRQ_NUM_EXT_SSP0,
-		.fifo[SOF_IPC_STREAM_PLAYBACK] = {
-			.offset		= SSP0_BASE + SSDR,
-			.handshake	= DMA_HANDSHAKE_SSP0_TX,
-		},
-		.fifo[SOF_IPC_STREAM_CAPTURE] = {
-			.offset		= SSP0_BASE + SSDR,
-			.handshake	= DMA_HANDSHAKE_SSP0_RX,
-		}
-	},
-	.ops		= &ssp_ops,
-},
-{
-	.type = SOF_DAI_INTEL_SSP,
-	.index = 1,
-	.plat_data = {
-		.base		= SSP1_BASE,
-		.irq		= IRQ_NUM_EXT_SSP1,
-		.fifo[SOF_IPC_STREAM_PLAYBACK] = {
-			.offset		= SSP1_BASE + SSDR,
-			.handshake	= DMA_HANDSHAKE_SSP1_TX,
-		},
-		.fifo[SOF_IPC_STREAM_CAPTURE] = {
-			.offset		= SSP1_BASE + SSDR,
-			.handshake	= DMA_HANDSHAKE_SSP1_RX,
-		}
-	},
-	.ops		= &ssp_ops,
-}};
+int dai_init(void);
 
-static struct dai_type_info dti[] = {
-	{
-		.type = SOF_DAI_INTEL_SSP,
-		.dai_array = ssp,
-		.num_dais = ARRAY_SIZE(ssp)
-	}
-};
-
-int dai_init(void)
-{
-	dai_install(dti, ARRAY_SIZE(dti));
-	return 0;
-}
+#endif

--- a/src/platform/baytrail/platform.c
+++ b/src/platform/baytrail/platform.c
@@ -33,6 +33,7 @@
 #include <platform/mailbox.h>
 #include <platform/shim.h>
 #include <platform/dma.h>
+#include <platform/dai.h>
 #include <platform/clk.h>
 #include <platform/timer.h>
 #include <platform/pmc.h>
@@ -231,6 +232,10 @@ int platform_init(struct sof *sof)
 	/* init DMACs */
 	trace_point(TRACE_BOOT_PLATFORM_DMA);
 	ret = dmac_init();
+	if (ret < 0)
+		return -ENODEV;
+
+	ret = dai_init();
 	if (ret < 0)
 		return -ENODEV;
 

--- a/src/platform/cannonlake/include/platform/dai.h
+++ b/src/platform/cannonlake/include/platform/dai.h
@@ -31,6 +31,8 @@
 #ifndef __PLATFORM_DAI_H__
 #define __PLATFORM_DAI_H__
 
+/* CANNONLAKE */
+
 /* SSP */
 
 /*
@@ -44,6 +46,14 @@
 
 /** \brief Number of 'extended' SSP ports available */
 #define DAI_NUM_SSP_EXT		0
+
+/* HD/A */
+
+/** \brief Number of HD/A Link Outputs */
+#define DAI_NUM_HDA_OUT		9
+
+/** \brief Number of HD/A Link Inputs */
+#define DAI_NUM_HDA_IN		7
 
 int dai_init(void);
 

--- a/src/platform/cannonlake/include/platform/dai.h
+++ b/src/platform/cannonlake/include/platform/dai.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Intel Corporation
+ * Copyright (c) 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,68 +25,26 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
+ * Author: Marcin Maka <marcin.maka@linux.intel.com>
  */
 
-#include <sof/sof.h>
-#include <sof/dai.h>
-#include <sof/ssp.h>
-#include <sof/stream.h>
-#include <sof/audio/component.h>
-#include <platform/memory.h>
-#include <platform/interrupt.h>
-#include <platform/dma.h>
-#include <platform/dai.h>
-#include <stdint.h>
-#include <string.h>
-#include <config.h>
+#ifndef __PLATFORM_DAI_H__
+#define __PLATFORM_DAI_H__
 
-static struct dai ssp[2] = {
-{
-	.type = SOF_DAI_INTEL_SSP,
-	.index = 0,
-	.plat_data = {
-		.base		= SSP0_BASE,
-		.irq		= IRQ_NUM_EXT_SSP0,
-		.fifo[SOF_IPC_STREAM_PLAYBACK] = {
-			.offset		= SSP0_BASE + SSDR,
-			.handshake	= DMA_HANDSHAKE_SSP0_TX,
-		},
-		.fifo[SOF_IPC_STREAM_CAPTURE] = {
-			.offset		= SSP0_BASE + SSDR,
-			.handshake	= DMA_HANDSHAKE_SSP0_RX,
-		}
-	},
-	.ops		= &ssp_ops,
-},
-{
-	.type = SOF_DAI_INTEL_SSP,
-	.index = 1,
-	.plat_data = {
-		.base		= SSP1_BASE,
-		.irq		= IRQ_NUM_EXT_SSP1,
-		.fifo[SOF_IPC_STREAM_PLAYBACK] = {
-			.offset		= SSP1_BASE + SSDR,
-			.handshake	= DMA_HANDSHAKE_SSP1_TX,
-		},
-		.fifo[SOF_IPC_STREAM_CAPTURE] = {
-			.offset		= SSP1_BASE + SSDR,
-			.handshake	= DMA_HANDSHAKE_SSP1_RX,
-		}
-	},
-	.ops		= &ssp_ops,
-}};
+/* SSP */
 
-static struct dai_type_info dti[] = {
-	{
-		.type = SOF_DAI_INTEL_SSP,
-		.dai_array = ssp,
-		.num_dais = ARRAY_SIZE(ssp)
-	}
-};
+/*
+ * Number of base and extended SSP ports must be defined separately
+ * since some HW registers are in two groups, one for base and one
+ * for extended.
+ */
 
-int dai_init(void)
-{
-	dai_install(dti, ARRAY_SIZE(dti));
-	return 0;
-}
+/** \brief Number of 'base' SSP ports available */
+#define DAI_NUM_SSP_BASE	3
+
+/** \brief Number of 'extended' SSP ports available */
+#define DAI_NUM_SSP_EXT		0
+
+int dai_init(void);
+
+#endif

--- a/src/platform/cannonlake/include/platform/platform.h
+++ b/src/platform/cannonlake/include/platform/platform.h
@@ -58,7 +58,6 @@ struct sof;
 
 #define PLATFORM_WAITI_DELAY	1
 
-#define PLATFORM_SSP_COUNT 3
 #define MAX_GPDMA_COUNT 2
 
 /* DGMBS align value */

--- a/src/platform/haswell/include/platform/dai.h
+++ b/src/platform/haswell/include/platform/dai.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Intel Corporation
+ * Copyright (c) 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,68 +25,12 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
+ * Author: Marcin Maka <marcin.maka@linux.intel.com>
  */
 
-#include <sof/sof.h>
-#include <sof/dai.h>
-#include <sof/ssp.h>
-#include <sof/stream.h>
-#include <sof/audio/component.h>
-#include <platform/memory.h>
-#include <platform/interrupt.h>
-#include <platform/dma.h>
-#include <platform/dai.h>
-#include <stdint.h>
-#include <string.h>
-#include <config.h>
+#ifndef __PLATFORM_DAI_H__
+#define __PLATFORM_DAI_H__
 
-static struct dai ssp[2] = {
-{
-	.type = SOF_DAI_INTEL_SSP,
-	.index = 0,
-	.plat_data = {
-		.base		= SSP0_BASE,
-		.irq		= IRQ_NUM_EXT_SSP0,
-		.fifo[SOF_IPC_STREAM_PLAYBACK] = {
-			.offset		= SSP0_BASE + SSDR,
-			.handshake	= DMA_HANDSHAKE_SSP0_TX,
-		},
-		.fifo[SOF_IPC_STREAM_CAPTURE] = {
-			.offset		= SSP0_BASE + SSDR,
-			.handshake	= DMA_HANDSHAKE_SSP0_RX,
-		}
-	},
-	.ops		= &ssp_ops,
-},
-{
-	.type = SOF_DAI_INTEL_SSP,
-	.index = 1,
-	.plat_data = {
-		.base		= SSP1_BASE,
-		.irq		= IRQ_NUM_EXT_SSP1,
-		.fifo[SOF_IPC_STREAM_PLAYBACK] = {
-			.offset		= SSP1_BASE + SSDR,
-			.handshake	= DMA_HANDSHAKE_SSP1_TX,
-		},
-		.fifo[SOF_IPC_STREAM_CAPTURE] = {
-			.offset		= SSP1_BASE + SSDR,
-			.handshake	= DMA_HANDSHAKE_SSP1_RX,
-		}
-	},
-	.ops		= &ssp_ops,
-}};
+int dai_init(void);
 
-static struct dai_type_info dti[] = {
-	{
-		.type = SOF_DAI_INTEL_SSP,
-		.dai_array = ssp,
-		.num_dais = ARRAY_SIZE(ssp)
-	}
-};
-
-int dai_init(void)
-{
-	dai_install(dti, ARRAY_SIZE(dti));
-	return 0;
-}
+#endif

--- a/src/platform/haswell/platform.c
+++ b/src/platform/haswell/platform.c
@@ -32,6 +32,7 @@
 #include <platform/mailbox.h>
 #include <platform/shim.h>
 #include <platform/dma.h>
+#include <platform/dai.h>
 #include <platform/clk.h>
 #include <platform/timer.h>
 #include <platform/platcfg.h>
@@ -219,6 +220,10 @@ int platform_init(struct sof *sof)
 	/* init DMACs */
 	trace_point(TRACE_BOOT_PLATFORM_DMA);
 	ret = dmac_init();
+	if (ret < 0)
+		return -ENODEV;
+
+	ret = dai_init();
 	if (ret < 0)
 		return -ENODEV;
 

--- a/src/platform/icelake/include/platform/dai.h
+++ b/src/platform/icelake/include/platform/dai.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Intel Corporation
+ * Copyright (c) 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,68 +25,26 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
+ * Author: Marcin Maka <marcin.maka@linux.intel.com>
  */
 
-#include <sof/sof.h>
-#include <sof/dai.h>
-#include <sof/ssp.h>
-#include <sof/stream.h>
-#include <sof/audio/component.h>
-#include <platform/memory.h>
-#include <platform/interrupt.h>
-#include <platform/dma.h>
-#include <platform/dai.h>
-#include <stdint.h>
-#include <string.h>
-#include <config.h>
+#ifndef __PLATFORM_DAI_H__
+#define __PLATFORM_DAI_H__
 
-static struct dai ssp[2] = {
-{
-	.type = SOF_DAI_INTEL_SSP,
-	.index = 0,
-	.plat_data = {
-		.base		= SSP0_BASE,
-		.irq		= IRQ_NUM_EXT_SSP0,
-		.fifo[SOF_IPC_STREAM_PLAYBACK] = {
-			.offset		= SSP0_BASE + SSDR,
-			.handshake	= DMA_HANDSHAKE_SSP0_TX,
-		},
-		.fifo[SOF_IPC_STREAM_CAPTURE] = {
-			.offset		= SSP0_BASE + SSDR,
-			.handshake	= DMA_HANDSHAKE_SSP0_RX,
-		}
-	},
-	.ops		= &ssp_ops,
-},
-{
-	.type = SOF_DAI_INTEL_SSP,
-	.index = 1,
-	.plat_data = {
-		.base		= SSP1_BASE,
-		.irq		= IRQ_NUM_EXT_SSP1,
-		.fifo[SOF_IPC_STREAM_PLAYBACK] = {
-			.offset		= SSP1_BASE + SSDR,
-			.handshake	= DMA_HANDSHAKE_SSP1_TX,
-		},
-		.fifo[SOF_IPC_STREAM_CAPTURE] = {
-			.offset		= SSP1_BASE + SSDR,
-			.handshake	= DMA_HANDSHAKE_SSP1_RX,
-		}
-	},
-	.ops		= &ssp_ops,
-}};
+/* SSP */
 
-static struct dai_type_info dti[] = {
-	{
-		.type = SOF_DAI_INTEL_SSP,
-		.dai_array = ssp,
-		.num_dais = ARRAY_SIZE(ssp)
-	}
-};
+/*
+ * Number of base and extended SSP ports must be defined separately
+ * since some HW registers are in two groups, one for base and one
+ * for extended.
+ */
 
-int dai_init(void)
-{
-	dai_install(dti, ARRAY_SIZE(dti));
-	return 0;
-}
+/** \brief Number of 'base' SSP ports available */
+#define DAI_NUM_SSP_BASE	6
+
+/** \brief Number of 'extended' SSP ports available */
+#define DAI_NUM_SSP_EXT		0
+
+int dai_init(void);
+
+#endif

--- a/src/platform/icelake/include/platform/dai.h
+++ b/src/platform/icelake/include/platform/dai.h
@@ -31,6 +31,8 @@
 #ifndef __PLATFORM_DAI_H__
 #define __PLATFORM_DAI_H__
 
+/* ICELAKE */
+
 /* SSP */
 
 /*
@@ -44,6 +46,14 @@
 
 /** \brief Number of 'extended' SSP ports available */
 #define DAI_NUM_SSP_EXT		0
+
+/* HD/A */
+
+/** \brief Number of HD/A Link Outputs */
+#define DAI_NUM_HDA_OUT		9
+
+/** \brief Number of HD/A Link Inputs */
+#define DAI_NUM_HDA_IN		7
 
 int dai_init(void);
 

--- a/src/platform/icelake/include/platform/platform.h
+++ b/src/platform/icelake/include/platform/platform.h
@@ -58,7 +58,6 @@ struct sof;
 
 #define PLATFORM_WAITI_DELAY	1
 
-#define PLATFORM_SSP_COUNT 3
 #define MAX_GPDMA_COUNT 2
 
 /* DGMBS align value */

--- a/src/platform/intel/cavs/dai.c
+++ b/src/platform/intel/cavs/dai.c
@@ -205,74 +205,7 @@ static struct dai dmic[2] = {
 
 #endif
 
-/* TODO: numbers to be defined and shared with HD/A dmas */
-static struct dai hda[(6 + 7)] = {
-	{
-		.type = SOF_DAI_INTEL_HDA,
-		.index = 0,
-		.ops = &hda_ops
-	},
-	{
-		.type = SOF_DAI_INTEL_HDA,
-		.index = 1,
-		.ops = &hda_ops
-	},
-	{
-		.type = SOF_DAI_INTEL_HDA,
-		.index = 2,
-		.ops = &hda_ops
-	},
-	{
-		.type = SOF_DAI_INTEL_HDA,
-		.index = 3,
-		.ops = &hda_ops
-	},
-	{
-		.type = SOF_DAI_INTEL_HDA,
-		.index = 4,
-		.ops = &hda_ops
-	},
-	{
-		.type = SOF_DAI_INTEL_HDA,
-		.index = 5,
-		.ops = &hda_ops
-	},
-	{
-		.type = SOF_DAI_INTEL_HDA,
-		.index = 6,
-		.ops = &hda_ops
-	},
-	{
-		.type = SOF_DAI_INTEL_HDA,
-		.index = 7,
-		.ops = &hda_ops
-	},
-	{
-		.type = SOF_DAI_INTEL_HDA,
-		.index = 8,
-		.ops = &hda_ops
-	},
-	{
-		.type = SOF_DAI_INTEL_HDA,
-		.index = 9,
-		.ops = &hda_ops
-	},
-	{
-		.type = SOF_DAI_INTEL_HDA,
-		.index = 10,
-		.ops = &hda_ops
-	},
-	{
-		.type = SOF_DAI_INTEL_HDA,
-		.index = 11,
-		.ops = &hda_ops
-	},
-	{
-		.type = SOF_DAI_INTEL_HDA,
-		.index = 12,
-		.ops = &hda_ops
-	}
-};
+static struct dai hda[(DAI_NUM_HDA_OUT + DAI_NUM_HDA_IN)];
 
 static struct dai_type_info dti[] = {
 	{
@@ -297,6 +230,13 @@ static struct dai_type_info dti[] = {
 int dai_init(void)
 {
 	int i;
+
+	/* init hd/a, note that size depends on the platform caps */
+	for (i = 0; i < ARRAY_SIZE(hda); i++) {
+		hda[i].type = SOF_DAI_INTEL_HDA;
+		hda[i].index = i;
+		hda[i].ops = &hda_ops;
+	}
 
 	/* init SSP ports */
 	trace_point(TRACE_BOOT_PLATFORM_SSP);

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -35,6 +35,7 @@
 #include <platform/mailbox.h>
 #include <platform/shim.h>
 #include <platform/dma.h>
+#include <platform/dai.h>
 #include <platform/clk.h>
 #include <platform/timer.h>
 #include <platform/interrupt.h>
@@ -57,13 +58,10 @@
 #include <version.h>
 
 #if defined(CONFIG_APOLLOLAKE)
-#define SSP_COUNT PLATFORM_NUM_SSP
 #define SSP_CLOCK_FREQUENCY 19200000
 #elif defined(CONFIG_CANNONLAKE) || defined(CONFIG_SUECREEK)
-#define SSP_COUNT PLATFORM_SSP_COUNT
 #define SSP_CLOCK_FREQUENCY 24000000
 #elif defined(CONFIG_ICELAKE)
-#define SSP_COUNT PLATFORM_SSP_COUNT
 #define SSP_CLOCK_FREQUENCY 38400000
 #endif
 
@@ -292,9 +290,7 @@ static void platform_init_hw(void)
 
 int platform_init(struct sof *sof)
 {
-	struct dai *ssp;
-	struct dai *dmic0;
-	int i, ret;
+	int ret;
 
 #if defined(CONFIG_CANNONLAKE) || defined(CONFIG_ICELAKE) \
 	|| defined(CONFIG_SUECREEK)
@@ -377,24 +373,9 @@ int platform_init(struct sof *sof)
 	if (ret < 0)
 		return -ENODEV;
 
-	/* init SSP ports */
-	trace_point(TRACE_BOOT_PLATFORM_SSP);
-	for (i = 0; i < SSP_COUNT; i++) {
-		ssp = dai_get(SOF_DAI_INTEL_SSP, i);
-		if (ssp == NULL)
-			return -ENODEV;
-		dai_probe(ssp);
-	}
-
-	/* Init DMIC. Note that the two PDM controllers and four microphones
-	 * supported max. those are available in platform are handled by dmic0.
-	 */
-	trace_point(TRACE_BOOT_PLATFORM_DMIC);
-	dmic0 = dai_get(SOF_DAI_INTEL_DMIC, 0);
-	if (!dmic0)
+	ret = dai_init();
+	if (ret < 0)
 		return -ENODEV;
-
-	dai_probe(dmic0);
 
 	/* initialize IDC mechanism */
 	trace_point(TRACE_BOOT_PLATFORM_IDC);

--- a/src/platform/suecreek/include/platform/dai.h
+++ b/src/platform/suecreek/include/platform/dai.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Intel Corporation
+ * Copyright (c) 2018, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,68 +25,26 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
+ * Author: Marcin Maka <marcin.maka@linux.intel.com>
  */
 
-#include <sof/sof.h>
-#include <sof/dai.h>
-#include <sof/ssp.h>
-#include <sof/stream.h>
-#include <sof/audio/component.h>
-#include <platform/memory.h>
-#include <platform/interrupt.h>
-#include <platform/dma.h>
-#include <platform/dai.h>
-#include <stdint.h>
-#include <string.h>
-#include <config.h>
+#ifndef __PLATFORM_DAI_H__
+#define __PLATFORM_DAI_H__
 
-static struct dai ssp[2] = {
-{
-	.type = SOF_DAI_INTEL_SSP,
-	.index = 0,
-	.plat_data = {
-		.base		= SSP0_BASE,
-		.irq		= IRQ_NUM_EXT_SSP0,
-		.fifo[SOF_IPC_STREAM_PLAYBACK] = {
-			.offset		= SSP0_BASE + SSDR,
-			.handshake	= DMA_HANDSHAKE_SSP0_TX,
-		},
-		.fifo[SOF_IPC_STREAM_CAPTURE] = {
-			.offset		= SSP0_BASE + SSDR,
-			.handshake	= DMA_HANDSHAKE_SSP0_RX,
-		}
-	},
-	.ops		= &ssp_ops,
-},
-{
-	.type = SOF_DAI_INTEL_SSP,
-	.index = 1,
-	.plat_data = {
-		.base		= SSP1_BASE,
-		.irq		= IRQ_NUM_EXT_SSP1,
-		.fifo[SOF_IPC_STREAM_PLAYBACK] = {
-			.offset		= SSP1_BASE + SSDR,
-			.handshake	= DMA_HANDSHAKE_SSP1_TX,
-		},
-		.fifo[SOF_IPC_STREAM_CAPTURE] = {
-			.offset		= SSP1_BASE + SSDR,
-			.handshake	= DMA_HANDSHAKE_SSP1_RX,
-		}
-	},
-	.ops		= &ssp_ops,
-}};
+/* SSP */
 
-static struct dai_type_info dti[] = {
-	{
-		.type = SOF_DAI_INTEL_SSP,
-		.dai_array = ssp,
-		.num_dais = ARRAY_SIZE(ssp)
-	}
-};
+/*
+ * Number of base and extended SSP ports must be defined separately
+ * since some HW registers are in two groups, one for base and one
+ * for extended.
+ */
 
-int dai_init(void)
-{
-	dai_install(dti, ARRAY_SIZE(dti));
-	return 0;
-}
+/** \brief Number of 'base' SSP ports available */
+#define DAI_NUM_SSP_BASE	3
+
+/** \brief Number of 'extended' SSP ports available */
+#define DAI_NUM_SSP_EXT		0
+
+int dai_init(void);
+
+#endif

--- a/src/platform/suecreek/include/platform/dai.h
+++ b/src/platform/suecreek/include/platform/dai.h
@@ -31,6 +31,8 @@
 #ifndef __PLATFORM_DAI_H__
 #define __PLATFORM_DAI_H__
 
+/* SUECREEK */
+
 /* SSP */
 
 /*
@@ -44,6 +46,12 @@
 
 /** \brief Number of 'extended' SSP ports available */
 #define DAI_NUM_SSP_EXT		0
+
+/** \brief Number of HD/A Link Outputs */
+#define DAI_NUM_HDA_OUT		9
+
+/** \brief Number of HD/A Link Inputs */
+#define DAI_NUM_HDA_IN		7
 
 int dai_init(void);
 

--- a/src/platform/suecreek/include/platform/platform.h
+++ b/src/platform/suecreek/include/platform/platform.h
@@ -58,7 +58,6 @@ struct sof;
 
 #define PLATFORM_WAITI_DELAY	1
 
-#define PLATFORM_SSP_COUNT 3
 #define MAX_GPDMA_COUNT 2
 
 /* DGMBS align value */


### PR DESCRIPTION
A mechanism similar to the one used for dma applied.
Dai initialization moved to separate unit from the main platform
code for cavs.
Optional dynamic discovery and initialization possible before
making available to other fw units via the lib hub.
SSP count cleaned up for cavs (important pre-work
for clock gating).

Signed-off-by: Marcin Maka <marcin.maka@linux.intel.com>