### PR TITLE
arch: fix smp build on CNL and ICL

### DIFF
--- a/src/platform/cannonlake/include/platform/memory.h
+++ b/src/platform/cannonlake/include/platform/memory.h
@@ -230,7 +230,7 @@
 /* text and data share the same HP L2 SRAM on Cannonlake */
 #define SOF_TEXT_START		0xBE040400
 #define SOF_TEXT_BASE		(SOF_TEXT_START)
-#define SOF_TEXT_SIZE		(0x18000 - 0x400)
+#define SOF_TEXT_SIZE		(0x1a000 - 0x400)
 
 /* initialized data */
 #define SOF_DATA_START		(SOF_TEXT_BASE + SOF_TEXT_SIZE)

--- a/src/platform/icelake/include/platform/memory.h
+++ b/src/platform/icelake/include/platform/memory.h
@@ -230,7 +230,7 @@
 /* text and data share the same HP L2 SRAM on Icelake */
 #define SOF_TEXT_START		0xBE040400
 #define SOF_TEXT_BASE		(SOF_TEXT_START)
-#define SOF_TEXT_SIZE		(0x18000 - 0x400)
+#define SOF_TEXT_SIZE		(0x1a000 - 0x400)
 
 /* initialized data */
 #define SOF_DATA_START		(SOF_TEXT_BASE + SOF_TEXT_SIZE)


### PR DESCRIPTION
Fixes building of xtensa-smp architecture on CNL and ICL.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>