### PR TITLE
pipeline: cache fixes for multicore processing

### DIFF
--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -765,11 +765,7 @@ static void dai_cache(struct comp_dev *dev, int cmd)
 		}
 
 		dcache_writeback_invalidate_region(dd->dai, sizeof(*dd->dai));
-		dcache_writeback_invalidate_region(dd->dai->private,
-						   dd->dai->private_size);
 		dcache_writeback_invalidate_region(dd->dma, sizeof(*dd->dma));
-		dcache_writeback_invalidate_region(dd->dma->private,
-						   dd->dma->private_size);
 		dcache_writeback_invalidate_region(dd, sizeof(*dd));
 		dcache_writeback_invalidate_region(dev, sizeof(*dev));
 		break;
@@ -782,11 +778,7 @@ static void dai_cache(struct comp_dev *dev, int cmd)
 		dd = comp_get_drvdata(dev);
 		dcache_invalidate_region(dd, sizeof(*dd));
 		dcache_invalidate_region(dd->dma, sizeof(*dd->dma));
-		dcache_invalidate_region(dd->dma->private,
-					 dd->dma->private_size);
 		dcache_invalidate_region(dd->dai, sizeof(*dd->dai));
-		dcache_invalidate_region(dd->dai->private,
-					 dd->dai->private_size);
 
 		list_for_item(item, &dd->config.elem_list) {
 			dcache_invalidate_region(item, sizeof(*item));

--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -786,8 +786,6 @@ static void host_cache(struct comp_dev *dev, int cmd)
 #endif
 
 		dcache_writeback_invalidate_region(hd->dma, sizeof(*hd->dma));
-		dcache_writeback_invalidate_region(hd->dma->private,
-						   hd->dma->private_size);
 		dcache_writeback_invalidate_region(hd, sizeof(*hd));
 		dcache_writeback_invalidate_region(dev, sizeof(*dev));
 		break;
@@ -800,8 +798,6 @@ static void host_cache(struct comp_dev *dev, int cmd)
 		hd = comp_get_drvdata(dev);
 		dcache_invalidate_region(hd, sizeof(*hd));
 		dcache_invalidate_region(hd->dma, sizeof(*hd->dma));
-		dcache_invalidate_region(hd->dma->private,
-					 hd->dma->private_size);
 
 #if !defined CONFIG_DMA_GW
 		list_for_item(item, &hd->local.elem_list) {

--- a/src/drivers/intel/baytrail/ssp.c
+++ b/src/drivers/intel/baytrail/ssp.c
@@ -603,7 +603,8 @@ static int ssp_probe(struct dai *dai)
 	struct ssp_pdata *ssp;
 
 	/* allocate private data */
-	ssp = rzalloc(RZONE_SYS, SOF_MEM_CAPS_RAM, sizeof(*ssp));
+	ssp = rzalloc(RZONE_SYS | RZONE_FLAG_UNCACHED, SOF_MEM_CAPS_RAM,
+		      sizeof(*ssp));
 	dai_set_drvdata(dai, ssp);
 
 	spinlock_init(&ssp->lock);

--- a/src/drivers/intel/cavs/dmic.c
+++ b/src/drivers/intel/cavs/dmic.c
@@ -1447,7 +1447,8 @@ static int dmic_probe(struct dai *dai)
 	trace_dmic("pro");
 
 	/* allocate private data */
-	dmic = rzalloc(RZONE_SYS, SOF_MEM_CAPS_RAM, sizeof(*dmic));
+	dmic = rzalloc(RZONE_SYS | RZONE_FLAG_UNCACHED, SOF_MEM_CAPS_RAM,
+		       sizeof(*dmic));
 	if (!dmic) {
 		trace_dmic_error("eap");
 		return -ENOMEM;

--- a/src/drivers/intel/cavs/hda-dma.c
+++ b/src/drivers/intel/cavs/hda-dma.c
@@ -613,7 +613,8 @@ static int hda_dma_probe(struct dma *dma)
 	struct hda_chan_data *chan;
 
 	/* allocate private data */
-	hda_pdata = rzalloc(RZONE_SYS, SOF_MEM_CAPS_RAM, sizeof(*hda_pdata));
+	hda_pdata = rzalloc(RZONE_SYS | RZONE_FLAG_UNCACHED, SOF_MEM_CAPS_RAM,
+			    sizeof(*hda_pdata));
 	dma_set_drvdata(dma, hda_pdata);
 
 	spinlock_init(&dma->lock);

--- a/src/drivers/intel/cavs/ssp.c
+++ b/src/drivers/intel/cavs/ssp.c
@@ -872,7 +872,8 @@ static int ssp_probe(struct dai *dai)
 	struct ssp_pdata *ssp;
 
 	/* allocate private data */
-	ssp = rzalloc(RZONE_SYS, SOF_MEM_CAPS_RAM, sizeof(*ssp));
+	ssp = rzalloc(RZONE_SYS | RZONE_FLAG_UNCACHED, SOF_MEM_CAPS_RAM,
+		      sizeof(*ssp));
 	dai_set_drvdata(dai, ssp);
 
 	spinlock_init(&ssp->lock);

--- a/src/drivers/intel/dw-dma.c
+++ b/src/drivers/intel/dw-dma.c
@@ -1113,7 +1113,8 @@ static int dw_dma_probe(struct dma *dma)
 	int i;
 
 	/* allocate private data */
-	dw_pdata = rzalloc(RZONE_SYS, SOF_MEM_CAPS_RAM, sizeof(*dw_pdata));
+	dw_pdata = rzalloc(RZONE_SYS | RZONE_FLAG_UNCACHED, SOF_MEM_CAPS_RAM,
+			   sizeof(*dw_pdata));
 	dma_set_drvdata(dma, dw_pdata);
 
 	spinlock_init(&dma->lock);

--- a/src/drivers/intel/haswell/ssp.c
+++ b/src/drivers/intel/haswell/ssp.c
@@ -500,7 +500,8 @@ static int ssp_probe(struct dai *dai)
 	struct ssp_pdata *ssp;
 
 	/* allocate private data */
-	ssp = rzalloc(RZONE_SYS, SOF_MEM_CAPS_RAM, sizeof(*ssp));
+	ssp = rzalloc(RZONE_SYS | RZONE_FLAG_UNCACHED, SOF_MEM_CAPS_RAM,
+		      sizeof(*ssp));
 	dai_set_drvdata(dai, ssp);
 
 	spinlock_init(&ssp->lock);

--- a/src/include/sof/dai.h
+++ b/src/include/sof/dai.h
@@ -122,7 +122,6 @@ struct dai {
 	struct dai_plat_data plat_data;
 	const struct dai_ops *ops;
 	void *private;
-	uint32_t private_size;
 };
 
 /**
@@ -153,8 +152,7 @@ void dai_install(struct dai_type_info *dai_type_array, size_t num_dai_types);
 struct dai *dai_get(uint32_t type, uint32_t index);
 
 #define dai_set_drvdata(dai, data) \
-	dai->private = data; \
-	dai->private_size = sizeof(*data)
+	dai->private = data;
 #define dai_get_drvdata(dai) \
 	dai->private;
 #define dai_base(dai) \

--- a/src/include/sof/dma.h
+++ b/src/include/sof/dma.h
@@ -164,7 +164,6 @@ struct dma {
 	const struct dma_ops *ops;
 	atomic_t num_channels_busy; /* number of busy channels */
 	void *private;
-	uint32_t private_size;
 };
 
 /**
@@ -188,8 +187,7 @@ void dma_install(struct dma *dma_array, size_t num_dmas);
 struct dma *dma_get(uint32_t dir, uint32_t caps, uint32_t dev, uint32_t flags);
 
 #define dma_set_drvdata(dma, data) \
-	dma->private = data; \
-	dma->private_size = sizeof(*data)
+	dma->private = data;
 #define dma_get_drvdata(dma) \
 	dma->private;
 #define dma_base(dma) \


### PR DESCRIPTION
Fixes cache issues with multicore processing of multiple pipelines:
- Changes pipeline_cache method as previous implementation
  could not work, especially for invalidation.
- Allocates dma and dai private data in uncached memory,
  because those resources are shared between different
  pipelines, so potentially also between different cores.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>