### PR TITLE
cpu: fix panic at core power down

### DIFF
--- a/src/arch/xtensa/smp/cpu.c
+++ b/src/arch/xtensa/smp/cpu.c
@@ -114,6 +114,10 @@ void cpu_power_down_core(void)
 	/* free entire sys heap, an instance dedicated for this core */
 	free_heap(RZONE_SYS);
 
+	/* arch_wait_for_interrupt() not used, because it will cause panic.
+	 * This code is executed on irq lvl > 0, which is expected.
+	 * Core will be put into reset by host anyway.
+	 */
 	while (1)
-		arch_wait_for_interrupt(0);
+		asm volatile("waiti 0");
 }


### PR DESCRIPTION
Fixes panic at core power down. Panic happened due to
the waiti check, where we expect waiti to be executed
on irq level 0 and cpu power down happens on idc task
irq level. This is OK, because core is going to be
reset anyway.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>