### PR TITLE
EQ FIR: Add support for 16 and 24 bit data

### DIFF
--- a/src/audio/eq_fir.c
+++ b/src/audio/eq_fir.c
@@ -63,26 +63,156 @@ struct comp_data {
 	uint32_t period_bytes;
 	int32_t *fir_delay;
 	size_t fir_delay_size;
+	void (*eq_fir_func_even)(struct fir_state_32x16 fir[],
+				 struct comp_buffer *source,
+				 struct comp_buffer *sink,
+				 int frames, int nch);
 	void (*eq_fir_func)(struct fir_state_32x16 fir[],
 			    struct comp_buffer *source,
 			    struct comp_buffer *sink,
 			    int frames, int nch);
-	void (*eq_fir_func_odd)(struct fir_state_32x16 fir[],
-				struct comp_buffer *source,
-				struct comp_buffer *sink,
-				int frames, int nch);
 };
 
-static void eq_fir_passthrough(struct fir_state_32x16 fir[],
-			       struct comp_buffer *source,
-			       struct comp_buffer *sink,
-			       int frames, int nch)
+/* The optimized FIR functions variants need to be updated into function
+ * set_fir_func. The cd->eq_fir_func is a function that can process any
+ * number of samples. The cd->eq_fir_func_even is for optimized version
+ * that is guaranteed to be called with even samples number.
+ */
+
+#if FIR_HIFI3
+static inline void set_s16_fir(struct comp_data *cd)
+{
+	cd->eq_fir_func_even = eq_fir_2x_s16_hifi3;
+	cd->eq_fir_func = eq_fir_s16_hifi3;
+}
+
+static inline void set_s24_fir(struct comp_data *cd)
+{
+	cd->eq_fir_func_even = eq_fir_2x_s24_hifi3;
+	cd->eq_fir_func = eq_fir_s24_hifi3;
+}
+
+static inline void set_s32_fir(struct comp_data *cd)
+{
+	cd->eq_fir_func_even = eq_fir_2x_s32_hifi3;
+	cd->eq_fir_func = eq_fir_s32_hifi3;
+}
+#elif FIR_HIFIEP
+static inline void set_s16_fir(struct comp_data *cd)
+{
+	cd->eq_fir_func_even = eq_fir_2x_s16_hifiep;
+	cd->eq_fir_func = eq_fir_s16_hifiep;
+}
+
+static inline void set_s24_fir(struct comp_data *cd)
+{
+	cd->eq_fir_func_even = eq_fir_2x_s24_hifiep;
+	cd->eq_fir_func = eq_fir_s24_hifiep;
+}
+
+static inline void set_s32_fir(struct comp_data *cd)
+{
+	cd->eq_fir_func_even = eq_fir_2x_s32_hifiep;
+	cd->eq_fir_func = eq_fir_s32_hifiep;
+}
+#else
+/* FIR_GENERIC */
+static inline void set_s16_fir(struct comp_data *cd)
+{
+	cd->eq_fir_func_even = eq_fir_s16;
+	cd->eq_fir_func = eq_fir_s16;
+}
+
+static inline void set_s24_fir(struct comp_data *cd)
+{
+	cd->eq_fir_func_even = eq_fir_s24;
+	cd->eq_fir_func = eq_fir_s24;
+}
+
+static inline void set_s32_fir(struct comp_data *cd)
+{
+	cd->eq_fir_func_even = eq_fir_s32;
+	cd->eq_fir_func = eq_fir_s32;
+}
+#endif
+
+static inline int set_fir_func(struct comp_dev *dev)
+{
+	struct comp_data *cd = comp_get_drvdata(dev);
+	struct sof_ipc_comp_config *config = COMP_GET_CONFIG(dev);
+
+	switch (config->frame_fmt) {
+	case SOF_IPC_FRAME_S16_LE:
+		trace_eq("f16");
+		set_s16_fir(cd);
+		break;
+	case SOF_IPC_FRAME_S24_4LE:
+		trace_eq("f24");
+		set_s24_fir(cd);
+		break;
+	case SOF_IPC_FRAME_S32_LE:
+		trace_eq("f32");
+		set_s32_fir(cd);
+		break;
+	default:
+		trace_eq_error("eef");
+		return -EINVAL;
+	}
+	return 0;
+}
+
+/* Pass-trough functions to replace FIR core while not configured for
+ * response.
+ */
+
+static void eq_fir_s16_passthrough(struct fir_state_32x16 fir[],
+				   struct comp_buffer *source,
+				   struct comp_buffer *sink,
+				   int frames, int nch)
+{
+	int16_t *src = (int16_t *)source->r_ptr;
+	int16_t *dest = (int16_t *)sink->w_ptr;
+	int n = frames * nch;
+
+	memcpy(dest, src, n * sizeof(int16_t));
+}
+
+static void eq_fir_s32_passthrough(struct fir_state_32x16 fir[],
+				   struct comp_buffer *source,
+				   struct comp_buffer *sink,
+				   int frames, int nch)
 {
 	int32_t *src = (int32_t *)source->r_ptr;
 	int32_t *dest = (int32_t *)sink->w_ptr;
 	int n = frames * nch;
 
 	memcpy(dest, src, n * sizeof(int32_t));
+}
+
+/* Function to select pass-trough depending on PCM format */
+
+static inline int set_pass_func(struct comp_dev *dev)
+{
+	struct comp_data *cd = comp_get_drvdata(dev);
+	struct sof_ipc_comp_config *config = COMP_GET_CONFIG(dev);
+
+	switch (config->frame_fmt) {
+	case SOF_IPC_FRAME_S16_LE:
+		trace_eq("p16");
+		cd->eq_fir_func_even = eq_fir_s16_passthrough;
+		cd->eq_fir_func = eq_fir_s16_passthrough;
+		break;
+	case SOF_IPC_FRAME_S24_4LE:
+	case SOF_IPC_FRAME_S32_LE:
+		trace_eq("p32");
+		cd->eq_fir_func_even = eq_fir_s32_passthrough;
+		cd->eq_fir_func = eq_fir_s32_passthrough;
+		break;
+	default:
+		trace_eq_error("epf");
+		return -EINVAL;
+	}
+	return 0;
 }
 
 /*
@@ -276,8 +406,8 @@ static struct comp_dev *eq_fir_new(struct sof_ipc_comp *comp)
 
 	comp_set_drvdata(dev, cd);
 
-	cd->eq_fir_func = eq_fir_passthrough;
-	cd->eq_fir_func_odd = eq_fir_passthrough;
+	cd->eq_fir_func_even = eq_fir_s32_passthrough;
+	cd->eq_fir_func = eq_fir_s32_passthrough;
 	cd->config = NULL;
 
 	/* Allocate and make a copy of the coefficients blob and reset FIR. If
@@ -339,10 +469,6 @@ static int eq_fir_params(struct comp_dev *dev)
 		trace_eq_error("eSz");
 		return err;
 	}
-
-	/* EQ supports only S32_LE PCM format */
-	if (config->frame_fmt != SOF_IPC_FRAME_S32_LE)
-		return -EINVAL;
 
 	return 0;
 }
@@ -531,9 +657,9 @@ static int eq_fir_copy(struct comp_dev *dev)
 	}
 
 	if (dev->frames & 1)
-		sd->eq_fir_func_odd(fir, source, sink, dev->frames, nch);
-	else
 		sd->eq_fir_func(fir, source, sink, dev->frames, nch);
+	else
+		sd->eq_fir_func_even(fir, source, sink, dev->frames, nch);
 
 	/* calc new free and available */
 	comp_update_buffer_consume(source, sd->period_bytes);
@@ -554,31 +680,19 @@ static int eq_fir_prepare(struct comp_dev *dev)
 		return ret;
 
 	/* Initialize EQ */
-	cd->eq_fir_func = eq_fir_passthrough;
 	if (cd->config) {
 		ret = eq_fir_setup(cd, dev->params.channels);
 		if (ret < 0) {
 			comp_set_state(dev, COMP_TRIGGER_RESET);
 			return ret;
 		}
-#if FIR_GENERIC
-		cd->eq_fir_func = eq_fir_s32;
-		cd->eq_fir_func_odd = eq_fir_s32;
-#endif
-#if FIR_HIFIEP
-		cd->eq_fir_func = eq_fir_2x_s32_hifiep;
-		cd->eq_fir_func_odd = eq_fir_s32_hifiep;
-#endif
-#if FIR_HIFI3
-		cd->eq_fir_func = eq_fir_2x_s32_hifi3;
-		cd->eq_fir_func_odd = eq_fir_s32_hifi3;
-#endif
-	}
-	trace_eq("len");
-	trace_value(cd->fir[0].length);
-	trace_value(cd->fir[1].length);
 
-	return 0;
+		ret = set_fir_func(dev);
+		return ret;
+	}
+
+	ret = set_pass_func(dev);
+	return ret;
 }
 
 static int eq_fir_reset(struct comp_dev *dev)
@@ -590,8 +704,8 @@ static int eq_fir_reset(struct comp_dev *dev)
 
 	eq_fir_free_delaylines(cd);
 
-	cd->eq_fir_func = eq_fir_passthrough;
-	cd->eq_fir_func_odd = eq_fir_passthrough;
+	cd->eq_fir_func_even = eq_fir_s32_passthrough;
+	cd->eq_fir_func = eq_fir_s32_passthrough;
 	for (i = 0; i < PLATFORM_MAX_CHANNELS; i++)
 		fir_reset(&cd->fir[i]);
 

--- a/src/audio/fir.c
+++ b/src/audio/fir.c
@@ -81,6 +81,56 @@ void fir_init_delay(struct fir_state_32x16 *fir, int32_t **data)
 	*data += fir->length; /* Point to next delay line start */
 }
 
+void eq_fir_s16(struct fir_state_32x16 fir[], struct comp_buffer *source,
+		struct comp_buffer *sink, int frames, int nch)
+{
+	struct fir_state_32x16 *filter;
+	int16_t *src = (int16_t *)source->r_ptr;
+	int16_t *snk = (int16_t *)sink->w_ptr;
+	int16_t *x;
+	int16_t *y;
+	int32_t z;
+	int ch;
+	int i;
+
+	for (ch = 0; ch < nch; ch++) {
+		filter = &fir[ch];
+		x = src++;
+		y = snk++;
+		for (i = 0; i < frames; i++) {
+			z = fir_32x16(filter, *x << 16);
+			*y = sat_int16(Q_SHIFT_RND(z, 31, 15));
+			x += nch;
+			y += nch;
+		}
+	}
+}
+
+void eq_fir_s24(struct fir_state_32x16 fir[], struct comp_buffer *source,
+		struct comp_buffer *sink, int frames, int nch)
+{
+	struct fir_state_32x16 *filter;
+	int32_t *src = (int32_t *)source->r_ptr;
+	int32_t *snk = (int32_t *)sink->w_ptr;
+	int32_t *x;
+	int32_t *y;
+	int32_t z;
+	int ch;
+	int i;
+
+	for (ch = 0; ch < nch; ch++) {
+		filter = &fir[ch];
+		x = src++;
+		y = snk++;
+		for (i = 0; i < frames; i++) {
+			z = fir_32x16(filter, *x << 8);
+			*y = sat_int24(Q_SHIFT_RND(z, 31, 23));
+			x += nch;
+			y += nch;
+		}
+	}
+}
+
 void eq_fir_s32(struct fir_state_32x16 fir[], struct comp_buffer *source,
 		struct comp_buffer *sink, int frames, int nch)
 {

--- a/src/audio/fir.h
+++ b/src/audio/fir.h
@@ -54,7 +54,13 @@ size_t fir_init_coef(struct fir_state_32x16 *fir,
 
 void fir_init_delay(struct fir_state_32x16 *fir, int32_t **data);
 
-void eq_fir_s32(struct fir_state_32x16 fir[], struct comp_buffer *source,
+void eq_fir_s16(struct fir_state_32x16 *fir, struct comp_buffer *source,
+		struct comp_buffer *sink, int frames, int nch);
+
+void eq_fir_s24(struct fir_state_32x16 *fir, struct comp_buffer *source,
+		struct comp_buffer *sink, int frames, int nch);
+
+void eq_fir_s32(struct fir_state_32x16 *fir, struct comp_buffer *source,
 		struct comp_buffer *sink, int frames, int nch);
 
 /* The next functions are inlined to optmize execution speed */

--- a/src/audio/fir_hifi2ep.c
+++ b/src/audio/fir_hifi2ep.c
@@ -134,7 +134,98 @@ void eq_fir_2x_s32_hifiep(struct fir_state_32x16 fir[],
 		for (i = 0; i < (frames >> 1); i++) {
 			x1 = x0 + nch;
 			y1 = y0 + nch;
-			fir_32x16_2x_hifiep(f, x0, x1, y0, y1, lshift, rshift);
+			fir_32x16_2x_hifiep(f, *x0, *x1, y0, y1,
+					    lshift, rshift);
+			x0 += inc;
+			y0 += inc;
+		}
+	}
+}
+
+void eq_fir_2x_s24_hifiep(struct fir_state_32x16 fir[],
+			  struct comp_buffer *source,
+			  struct comp_buffer *sink,
+			  int frames, int nch)
+{
+	struct fir_state_32x16 *f;
+	int32_t *src = (int32_t *)source->r_ptr;
+	int32_t *snk = (int32_t *)sink->w_ptr;
+	int32_t *x0;
+	int32_t *y0;
+	int32_t *x1;
+	int32_t *y1;
+	int32_t z0;
+	int32_t z1;
+	int ch;
+	int i;
+	int rshift;
+	int lshift;
+	int inc = nch << 1;
+
+	for (ch = 0; ch < nch; ch++) {
+		/* Get FIR instance and get shifts to e.g. apply mute
+		 * without overhead.
+		 */
+		f = &fir[ch];
+		fir_get_lrshifts(f, &lshift, &rshift);
+
+		/* Setup circular buffer for FIR input data delay */
+		fir_hifiep_setup_circular(f);
+
+		x0 = src++;
+		y0 = snk++;
+		for (i = 0; i < (frames >> 1); i++) {
+			x1 = x0 + nch;
+			y1 = y0 + nch;
+			fir_32x16_2x_hifiep(f, *x0 << 8, *x1 << 8, &z0, &z1,
+					    lshift, rshift);
+			*y0 = sat_int24(Q_SHIFT_RND(z0, 31, 23));
+			*y1 = sat_int24(Q_SHIFT_RND(z1, 31, 23));
+			x0 += inc;
+			y0 += inc;
+		}
+	}
+}
+
+void eq_fir_2x_s16_hifiep(struct fir_state_32x16 fir[],
+			  struct comp_buffer *source,
+			  struct comp_buffer *sink,
+			  int frames, int nch)
+{
+	struct fir_state_32x16 *f;
+	int16_t *src = (int16_t *)source->r_ptr;
+	int16_t *snk = (int16_t *)sink->w_ptr;
+	int16_t *x0;
+	int16_t *y0;
+	int16_t *x1;
+	int16_t *y1;
+	int32_t z0;
+	int32_t z1;
+	int ch;
+	int i;
+	int rshift;
+	int lshift;
+	int inc = nch << 1;
+
+	for (ch = 0; ch < nch; ch++) {
+		/* Get FIR instance and get shifts to e.g. apply mute
+		 * without overhead.
+		 */
+		f = &fir[ch];
+		fir_get_lrshifts(f, &lshift, &rshift);
+
+		/* Setup circular buffer for FIR input data delay */
+		fir_hifiep_setup_circular(f);
+
+		x0 = src++;
+		y0 = snk++;
+		for (i = 0; i < (frames >> 1); i++) {
+			x1 = x0 + nch;
+			y1 = y0 + nch;
+			fir_32x16_2x_hifiep(f, *x0 << 16, *x1 << 16, &z0, &z1,
+					    lshift, rshift);
+			*y0 = sat_int16(Q_SHIFT_RND(z0, 31, 15));
+			*y1 = sat_int16(Q_SHIFT_RND(z1, 31, 15));
 			x0 += inc;
 			y0 += inc;
 		}
@@ -168,7 +259,79 @@ void eq_fir_s32_hifiep(struct fir_state_32x16 fir[], struct comp_buffer *source,
 		x = src++;
 		y = snk++;
 		for (i = 0; i < frames; i++) {
-			fir_32x16_hifiep(f, x, y, lshift, rshift);
+			fir_32x16_hifiep(f, *x, y, lshift, rshift);
+			x += nch;
+			y += nch;
+		}
+	}
+}
+
+/* FIR for any number of frames */
+void eq_fir_s24_hifiep(struct fir_state_32x16 fir[], struct comp_buffer *source,
+		       struct comp_buffer *sink, int frames, int nch)
+{
+	struct fir_state_32x16 *f;
+	int32_t *src = (int32_t *)source->r_ptr;
+	int32_t *snk = (int32_t *)sink->w_ptr;
+	int32_t *x;
+	int32_t *y;
+	int32_t z;
+	int ch;
+	int i;
+	int rshift;
+	int lshift;
+
+	for (ch = 0; ch < nch; ch++) {
+		/* Get FIR instance and get shifts to e.g. apply mute
+		 * without overhead.
+		 */
+		f = &fir[ch];
+		fir_get_lrshifts(f, &lshift, &rshift);
+
+		/* Setup circular buffer for FIR input data delay */
+		fir_hifiep_setup_circular(f);
+
+		x = src++;
+		y = snk++;
+		for (i = 0; i < frames; i++) {
+			fir_32x16_hifiep(f, *x << 8, &z, lshift, rshift);
+			*y = sat_int24(Q_SHIFT_RND(z, 31, 23));
+			x += nch;
+			y += nch;
+		}
+	}
+}
+
+/* FIR for any number of frames */
+void eq_fir_s16_hifiep(struct fir_state_32x16 fir[], struct comp_buffer *source,
+		       struct comp_buffer *sink, int frames, int nch)
+{
+	struct fir_state_32x16 *f;
+	int16_t *src = (int16_t *)source->r_ptr;
+	int16_t *snk = (int16_t *)sink->w_ptr;
+	int16_t *x;
+	int16_t *y;
+	int32_t z;
+	int ch;
+	int i;
+	int rshift;
+	int lshift;
+
+	for (ch = 0; ch < nch; ch++) {
+		/* Get FIR instance and get shifts to e.g. apply mute
+		 * without overhead.
+		 */
+		f = &fir[ch];
+		fir_get_lrshifts(f, &lshift, &rshift);
+
+		/* Setup circular buffer for FIR input data delay */
+		fir_hifiep_setup_circular(f);
+
+		x = src++;
+		y = snk++;
+		for (i = 0; i < frames; i++) {
+			fir_32x16_hifiep(f, *x << 16, &z, lshift, rshift);
+			*y = sat_int16(Q_SHIFT_RND(z, 31, 15));
 			x += nch;
 			y += nch;
 		}

--- a/src/audio/fir_hifi2ep.h
+++ b/src/audio/fir_hifi2ep.h
@@ -57,13 +57,29 @@ size_t fir_init_coef(struct fir_state_32x16 *fir,
 
 void fir_init_delay(struct fir_state_32x16 *fir, int32_t **data);
 
-void eq_fir_2x_s32_hifiep(struct fir_state_32x16 fir[],
+void eq_fir_s16_hifiep(struct fir_state_32x16 fir[], struct comp_buffer *source,
+		       struct comp_buffer *sink, int frames, int nch);
+
+void eq_fir_s24_hifiep(struct fir_state_32x16 fir[], struct comp_buffer *source,
+		       struct comp_buffer *sink, int frames, int nch);
+
+void eq_fir_s32_hifiep(struct fir_state_32x16 fir[], struct comp_buffer *source,
+		       struct comp_buffer *sink, int frames, int nch);
+
+void eq_fir_2x_s16_hifiep(struct fir_state_32x16 fir[],
 			  struct comp_buffer *source,
 			  struct comp_buffer *sink,
 			  int frames, int nch);
 
-void eq_fir_s32_hifiep(struct fir_state_32x16 fir[], struct comp_buffer *source,
-		       struct comp_buffer *sink, int frames, int nch);
+void eq_fir_2x_s24_hifiep(struct fir_state_32x16 fir[],
+			  struct comp_buffer *source,
+			  struct comp_buffer *sink,
+			  int frames, int nch);
+
+void eq_fir_2x_s32_hifiep(struct fir_state_32x16 fir[],
+			  struct comp_buffer *source,
+			  struct comp_buffer *sink,
+			  int frames, int nch);
 
 /* Setup circular buffer for FIR input data delay */
 static inline void fir_hifiep_setup_circular(struct fir_state_32x16 *fir)
@@ -82,7 +98,7 @@ void fir_get_lrshifts(struct fir_state_32x16 *fir, int *lshift,
  * 8x 48 bit registers in register file P
  */
 
-static inline void fir_32x16_hifiep(struct fir_state_32x16 *fir, int32_t *x,
+static inline void fir_32x16_hifiep(struct fir_state_32x16 *fir, int32_t x,
 				    int32_t *y, int lshift, int rshift)
 {
 	/* This function uses
@@ -104,12 +120,12 @@ static inline void fir_32x16_hifiep(struct fir_state_32x16 *fir, int32_t *x,
 
 	/* Bypass samples if taps count is zero. */
 	if (!taps_div_4) {
-		*y = *x;
+		*y = x;
 		return;
 	}
 
 	/* Write sample to delay */
-	a = AE_LQ32F_I((ae_q32s *)x, 0);
+	a = AE_CVTQ48A32S(x);
 	AE_SQ32F_C(a, (ae_q32s *)fir->rwp, -sizeof(int32_t));
 
 	/* Note: If the next function is converted to handle two samples
@@ -156,8 +172,8 @@ static inline void fir_32x16_hifiep(struct fir_state_32x16 *fir, int32_t *x,
  * 8x 48 bit registers in register file P
  */
 
-static inline void fir_32x16_2x_hifiep(struct fir_state_32x16 *fir, int32_t *x0,
-				       int32_t *x1, int32_t *y0, int32_t *y1,
+static inline void fir_32x16_2x_hifiep(struct fir_state_32x16 *fir, int32_t x0,
+				       int32_t x1, int32_t *y0, int32_t *y1,
 				       int lshift, int rshift)
 {
 	/* This function uses
@@ -180,15 +196,15 @@ static inline void fir_32x16_2x_hifiep(struct fir_state_32x16 *fir, int32_t *x0,
 
 	/* Bypass samples if taps count is zero. */
 	if (!taps_div_4) {
-		*y0 = *x0;
-		*y1 = *x1;
+		*y0 = x0;
+		*y1 = x1;
 		return;
 	}
 
 	/* Write samples to delay */
-	a = AE_LQ32F_I((ae_q32s *)x0, 0);
+	a = AE_CVTQ48A32S(x0);
 	AE_SQ32F_C(a, (ae_q32s *)fir->rwp, -sizeof(int32_t));
-	a = AE_LQ32F_I((ae_q32s *)x1, 0);
+	a = AE_CVTQ48A32S(x1);
 	dp = fir->rwp;
 	AE_SQ32F_C(a, (ae_q32s *)fir->rwp, -sizeof(int32_t));
 


### PR DESCRIPTION
This patch adds to equalizer capability to process 16 and 24 bit
pipelines in addition to 32 bit similarly as IIR. The generic C,
HiFiEP, and HiFi3 versions are updated with the capability.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>