### PR TITLE
schedule: implement timer driven scheduling

### DIFF
--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -261,6 +261,7 @@ static int dai_playback_params(struct comp_dev *dev)
 	config->src_width = comp_sample_bytes(dev);
 	config->dest_width = comp_sample_bytes(dev);
 	config->cyclic = 1;
+	config->timer_delay = dev->pipeline->ipc_pipe.timer_delay;
 	config->dest_dev = dd->dai->plat_data.fifo[0].handshake;
 
 	/* set up local and host DMA elems to reset values */
@@ -329,6 +330,7 @@ static int dai_capture_params(struct comp_dev *dev)
 	config->src_width = comp_sample_bytes(dev);
 	config->dest_width = comp_sample_bytes(dev);
 	config->cyclic = 1;
+	config->timer_delay = dev->pipeline->ipc_pipe.timer_delay;
 	config->src_dev = dd->dai->plat_data.fifo[1].handshake;
 
 	/* set up local and host DMA elems to reset values */

--- a/src/audio/pipeline.c
+++ b/src/audio/pipeline.c
@@ -219,15 +219,8 @@ static void pipeline_trigger_sched_comp(struct pipeline *p,
 		 */
 		if (comp->params.direction == SOF_IPC_STREAM_PLAYBACK ||
 		    p->status == COMP_STATE_PAUSED) {
-
-			/* pipelines are either scheduled by timers or DAI/DMA interrupts */
-			if (p->ipc_pipe.timer) {
-				/* timer - schedule initial copy */
-				pipeline_schedule_copy(p, 0);
-			} else {
-				/* DAI - schedule initial pipeline fill when next idle */
-				pipeline_schedule_copy_idle(p);
-			}
+			/* schedule initial pipeline fill when next idle */
+			pipeline_schedule_copy_idle(p);
 		}
 		p->status = COMP_STATE_ACTIVE;
 		break;
@@ -1290,11 +1283,6 @@ static void pipeline_task(void *arg)
 
 sched:
 	tracev_pipe("PWe");
-
-	/* now reschedule the task */
-	/* TODO: add in scheduling cost and any timer drift */
-	if (p->ipc_pipe.timer)
-		pipeline_schedule_copy(p, p->ipc_pipe.deadline);
 }
 
 /* init pipeline */

--- a/src/include/host/topology.h
+++ b/src/include/host/topology.h
@@ -134,7 +134,7 @@ static const struct sof_topology_token sched_tokens[] = {
 		offsetof(struct sof_ipc_pipe_new, frames_per_sched), 0},
 	{SOF_TKN_SCHED_TIMER, SND_SOC_TPLG_TUPLE_TYPE_WORD,
 		get_token_uint32_t,
-		offsetof(struct sof_ipc_pipe_new, timer), 0},
+		offsetof(struct sof_ipc_pipe_new, timer_delay), 0},
 };
 
 /* volume */

--- a/src/include/sof/dma.h
+++ b/src/include/sof/dma.h
@@ -106,7 +106,8 @@ struct dma_sg_config {
 	uint32_t direction;
 	uint32_t src_dev;
 	uint32_t dest_dev;
-	uint32_t cyclic;		/* circular buffer */
+	uint32_t cyclic;	/* circular buffer */
+	uint32_t timer_delay;	/* non zero if timer scheduled */
 	struct list_item elem_list;	/* list of dma_sg elems */
 };
 

--- a/src/include/sof/work.h
+++ b/src/include/sof/work.h
@@ -65,9 +65,11 @@ struct work_queue_timesource {
 
 /* initialise our work */
 #define work_init(w, x, xd, xflags) \
-	(w)->cb = x; \
-	(w)->cb_data = xd; \
-	(w)->flags = xflags;
+	do { \
+		(w)->cb = x; \
+		(w)->cb_data = xd; \
+		(w)->flags = xflags; \
+	} while (0)
 
 struct work_queue **arch_work_queue_get(void);
 

--- a/src/include/uapi/ipc.h
+++ b/src/include/uapi/ipc.h
@@ -822,7 +822,9 @@ struct sof_ipc_pipe_new {
 	uint32_t mips;		/* worst case instruction count per period */
 	uint32_t frames_per_sched;/* output frames of pipeline, 0 is variable */
 	uint32_t xrun_limit_usecs; /* report xruns greater than limit */
-	uint32_t timer;/* non zero if timer scheduled otherwise DAI scheduled */
+
+	/* non zero if timer scheduled, otherwise DAI DMA irq scheduled */
+	uint32_t timer_delay;
 }  __attribute__((packed));
 
 /* pipeline construction complete - SOF_IPC_TPLG_PIPE_COMPLETE */


### PR DESCRIPTION
Implements timer driven scheduling by processing
DW DMA data in tasks added to work queue instead
of registering for DW DMA interrupt. Data processing
by default will happen every 1 ms.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>