### PR TITLE
configure: check for ASoC headers as part of host build.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -137,6 +137,8 @@ case "$with_arch" in
 
 	ARCH="host"
 	AC_SUBST(ARCH)
+
+	AC_CHECK_HEADERS([sound/asoc.h])
     ;;
     *)
 	if test "$have_rimage" = "no" && test "$have_doc" = "no" ; then


### PR DESCRIPTION
Check that the ASoC UAPI headers are installed as part of host build

Signed-off-by: Liam Girdwood <liam.r.girdwood@linux.intel.com>