### PR TITLE
ci: soft build script: install logging header

### DIFF
--- a/scripts/build-soft.sh
+++ b/scripts/build-soft.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+sudo mkdir -p /usr/local/include/sof/uapi
+sudo cp src/include/uapi/logging.h /usr/local/include/sof/uapi/logging.h
 cd ../soft.git
 ./autogen.sh
 ./configure


### PR DESCRIPTION
Install logging.h inside container before building
soft.

This is pretty dirty way to do it, but for me it works. I don't know how the sof headers should be installed the right way for _soft_ build. They are build separately and all sof building artifacts are totally cleaned before building soft (it is a new container).

As said, tested locally, don't know what CI thinks of this.