### PR TITLE
notifier: add notifier to core_context

### DIFF
--- a/src/arch/xtensa/Makefile.am
+++ b/src/arch/xtensa/Makefile.am
@@ -54,6 +54,7 @@ sof_SOURCES += \
 	smp/xtos/_vectors.S \
 	smp/cpu.c \
 	smp/init.c \
+	smp/notifier.c \
 	smp/schedule.c \
 	smp/task.c \
 	smp/work.c
@@ -63,6 +64,7 @@ sof_SOURCES += \
 	up/xtos/_vectors.S \
 	up/cpu.c \
 	up/init.c \
+	up/notifier.c \
 	up/schedule.c \
 	up/task.c \
 	up/work.c

--- a/src/arch/xtensa/smp/cpu.c
+++ b/src/arch/xtensa/smp/cpu.c
@@ -107,6 +107,8 @@ void cpu_power_down_core(void)
 
 	free_system_workq();
 
+	free_system_notify();
+
 	/* free entire sys heap, an instance dedicated for this core */
 	free_heap(RZONE_SYS);
 

--- a/src/arch/xtensa/smp/notifier.c
+++ b/src/arch/xtensa/smp/notifier.c
@@ -26,44 +26,22 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *
  * Author: Tomasz Lauda <tomasz.lauda@linux.intel.com>
+ *
  */
 
-#include "xtos-internal.h"
+/**
+ * \file arch/xtensa/smp/notifier.c
+ * \brief Xtensa SMP notifier implementation file
+ * \authors Tomasz Lauda <tomasz.lauda@linux.intel.com>
+ */
 
-#ifndef __XTOS_STRUCTS_H__
-#define __XTOS_STRUCTS_H__
+#include <xtos-structs.h>
+#include <arch/cpu.h>
+#include <sof/notifier.h>
 
-struct idc;
-struct irq_task;
-struct notify;
-struct schedule_data;
-struct work_queue;
+struct notify **arch_notify_get(void)
+{
+	struct core_context *ctx = (struct core_context *)cpu_read_threadptr();
 
-struct thread_data {
-	xtos_structures_pointers xtos_ptrs;
-};
-
-struct xtos_core_data {
-	struct XtosInterruptStructure xtos_int_data;
-	int xtos_stack_for_interrupt_2[XTOS_INT_STACK_SIZE / 4];
-	int xtos_stack_for_interrupt_3[XTOS_INT_STACK_SIZE / 4];
-	int xtos_stack_for_interrupt_4[XTOS_INT_STACK_SIZE / 4];
-	int xtos_stack_for_interrupt_5[XTOS_INT_STACK_SIZE / 4];
-
-	struct thread_data *thread_data_ptr;
-};
-
-struct core_context {
-	struct thread_data td;
-	struct irq_task *irq_low_task;
-	struct irq_task *irq_med_task;
-	struct irq_task *irq_high_task;
-	struct schedule_data *sch;
-	struct work_queue *queue;
-	struct notify *notify;
-	struct idc *idc;
-};
-
-void _xtos_initialize_pointers_per_core(void);
-
-#endif /* __XTOS_STRUCTS_H__ */
+	return &ctx->notify;
+}

--- a/src/arch/xtensa/up/notifier.c
+++ b/src/arch/xtensa/up/notifier.c
@@ -26,44 +26,21 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *
  * Author: Tomasz Lauda <tomasz.lauda@linux.intel.com>
+ *
  */
 
-#include "xtos-internal.h"
+/**
+ * \file arch/xtensa/up/notifier.c
+ * \brief Xtensa UP notifier implementation file
+ * \authors Tomasz Lauda <tomasz.lauda@linux.intel.com>
+ */
 
-#ifndef __XTOS_STRUCTS_H__
-#define __XTOS_STRUCTS_H__
+#include <sof/notifier.h>
 
-struct idc;
-struct irq_task;
-struct notify;
-struct schedule_data;
-struct work_queue;
+/** \brief Notify data pointer. */
+static struct notify *notify;
 
-struct thread_data {
-	xtos_structures_pointers xtos_ptrs;
-};
-
-struct xtos_core_data {
-	struct XtosInterruptStructure xtos_int_data;
-	int xtos_stack_for_interrupt_2[XTOS_INT_STACK_SIZE / 4];
-	int xtos_stack_for_interrupt_3[XTOS_INT_STACK_SIZE / 4];
-	int xtos_stack_for_interrupt_4[XTOS_INT_STACK_SIZE / 4];
-	int xtos_stack_for_interrupt_5[XTOS_INT_STACK_SIZE / 4];
-
-	struct thread_data *thread_data_ptr;
-};
-
-struct core_context {
-	struct thread_data td;
-	struct irq_task *irq_low_task;
-	struct irq_task *irq_med_task;
-	struct irq_task *irq_high_task;
-	struct schedule_data *sch;
-	struct work_queue *queue;
-	struct notify *notify;
-	struct idc *idc;
-};
-
-void _xtos_initialize_pointers_per_core(void);
-
-#endif /* __XTOS_STRUCTS_H__ */
+struct notify **arch_notify_get(void)
+{
+	return &notify;
+}

--- a/src/include/sof/notifier.h
+++ b/src/include/sof/notifier.h
@@ -33,12 +33,18 @@
 
 #include <stdint.h>
 #include <sof/list.h>
+#include <sof/lock.h>
 
 struct sof;
 
 /* notifier general IDs */
 #define NOTIFIER_ID_CPU_FREQ	0
 #define NOTIFIER_ID_SSP_FREQ	1
+
+struct notify {
+	spinlock_t lock;	/* notifier lock */
+	struct list_item list;	/* list of notifiers */
+};
 
 struct notifier {
 	uint32_t id;
@@ -47,11 +53,15 @@ struct notifier {
 	void (*cb)(int message, void *cb_data, void *event_data);
 };
 
+struct notify **arch_notify_get(void);
+
 void notifier_register(struct notifier *notifier);
 void notifier_unregister(struct notifier *notifier);
 
 void notifier_event(int id, int message, void *event_data);
 
 void init_system_notify(struct sof *sof);
+
+void free_system_notify(void);
 
 #endif

--- a/src/init/init.c
+++ b/src/init/init.c
@@ -100,6 +100,9 @@ int slave_core_init(struct sof *sof)
 	if (err < 0)
 		panic(SOF_IPC_PANIC_ARCH);
 
+	trace_point(TRACE_BOOT_SYS_NOTE);
+	init_system_notify(sof);
+
 	trace_point(TRACE_BOOT_SYS_SCHED);
 	scheduler_init(sof);
 

--- a/src/lib/work.c
+++ b/src/lib/work.c
@@ -501,13 +501,11 @@ struct work_queue *work_new_queue(struct work_queue_timesource *ts)
 	/* TODO: configurable through IPC */
 	queue->timeout = PLATFORM_WORKQ_DEFAULT_TIMEOUT;
 
-	if (cpu_get_id() == PLATFORM_MASTER_CORE_ID) {
-		/* notification of clk changes */
-		queue->notifier.cb = work_notify;
-		queue->notifier.cb_data = queue;
-		queue->notifier.id = ts->notifier;
-		notifier_register(&queue->notifier);
-	}
+	/* notification of clk changes */
+	queue->notifier.cb = work_notify;
+	queue->notifier.cb_data = queue;
+	queue->notifier.id = ts->notifier;
+	notifier_register(&queue->notifier);
 
 	/* register system timer */
 	timer_register(&queue->ts->timer, queue_run, queue);
@@ -539,8 +537,7 @@ void free_system_workq(void)
 
 	timer_unregister(&(*queue)->ts->timer);
 
-	if (cpu_get_id() == PLATFORM_MASTER_CORE_ID)
-		notifier_unregister(&(*queue)->notifier);
+	notifier_unregister(&(*queue)->notifier);
 
 	list_item_del(&(*queue)->work);
 


### PR DESCRIPTION
Adds notifier to core_context, which is the first step
of multicore notifier implementation.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>