### PR TITLE
IPC: EQ: Use C99 syntax for flexible array member in structs

### DIFF
--- a/src/include/uapi/ipc.h
+++ b/src/include/uapi/ipc.h
@@ -774,7 +774,7 @@ struct sof_ipc_comp_eq_fir {
 	struct sof_ipc_comp comp;
 	struct sof_ipc_comp_config config;
 	uint32_t size;
-	unsigned char data[0];
+	unsigned char data[];
 } __attribute__((packed));
 
 /* IIR equalizer component */
@@ -782,7 +782,7 @@ struct sof_ipc_comp_eq_iir {
 	struct sof_ipc_comp comp;
 	struct sof_ipc_comp_config config;
 	uint32_t size;
-	unsigned char data[0];
+	unsigned char data[];
 } __attribute__((packed));
 
 /** \brief Types of EFFECT */


### PR DESCRIPTION
There is risk that all compilers do not handle correctly the zero size
array. Current GCC documentation also recommends C99 style for the
purpose.

https://gcc.gnu.org/onlinedocs/gcc/Zero-Length.html

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>