### PR TITLE
IPC: DMIC: Use C99 syntax for flexible array member in struct

### DIFF
--- a/src/include/uapi/abi.h
+++ b/src/include/uapi/abi.h
@@ -53,7 +53,7 @@
 /** \brief SOF ABI version major, minor and patch numbers */
 #define SOF_ABI_MAJOR 2
 #define SOF_ABI_MINOR 0
-#define SOF_ABI_PATCH 0
+#define SOF_ABI_PATCH 1
 
 /** \brief SOF ABI version number. Format within 32bit word is MMmmmppp */
 #define SOF_ABI_MAJOR_SHIFT	24

--- a/src/include/uapi/ipc/dai-intel.h
+++ b/src/include/uapi/ipc/dai-intel.h
@@ -185,7 +185,7 @@ struct sof_ipc_dai_dmic_params {
 	uint32_t reserved[8];
 
 	/**< variable number of pdm controller config */
-	struct sof_ipc_dai_dmic_pdm_ctrl pdm[0];
+	struct sof_ipc_dai_dmic_pdm_ctrl pdm[];
 } __attribute__((packed));
 
 #endif


### PR DESCRIPTION
There is risk that all compilers do not handle correctly the zero size
array. Current GCC documentation also recommends C99 style for the
purpose.

https://gcc.gnu.org/onlinedocs/gcc/Zero-Length.html

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>