### PR TITLE
abi: Redefine SOF_ABI_VERSION to allow for backward compatibility

### DIFF
--- a/src/include/uapi/abi.h
+++ b/src/include/uapi/abi.h
@@ -38,7 +38,21 @@
 #define __INCLUDE_UAPI_ABI_H__
 
 /** \brief SOF ABI version number. */
-#define SOF_ABI_VERSION		1
+#define SOF_ABI_VER(major, minor, micro) \
+	(((major)<<8)|((minor)<<4)|(micro))
+#define SOF_ABI_VERSION_MAJOR(version)	(((version)>>8) & 0xff)
+#define SOF_ABI_VERSION_MINOR(version)	(((version)>>4) & 0xf)
+#define SOF_ABI_VERSION_MICRO(version)	((version) & 0xf)
+#define SOF_ABI_VERSION_INCOMPATIBLE(sof_ver, client_ver) \
+	(SOF_ABI_VERSION_MAJOR(sof_ver) != SOF_ABI_VERSION_MAJOR(client_ver) ||\
+	(SOF_ABI_VERSION_MAJOR(sof_ver) == SOF_ABI_VERSION_MAJOR(client_ver) &&\
+	SOF_ABI_VERSION_MINOR(sof_ver) != SOF_ABI_VERSION_MINOR(client_ver)))
+
+#define SOF_ABI_MAJOR 1
+#define SOF_ABI_MINOR 0
+#define SOF_ABI_MICRO 0
+
+#define SOF_ABI_VERSION SOF_ABI_VER(SOF_ABI_MAJOR, SOF_ABI_MINOR, SOF_ABI_MICRO)
 
 /** \brief SOF ABI magic number "SOF\0". */
 #define SOF_ABI_MAGIC		0x00464F53


### PR DESCRIPTION
SOF_ABI_VERSION macro now performs bitshift and addition to compose
final version number out of SOF_ABI_MAJOR, SOF_ABI_MINOR and SOF_ABI_MICRO
components.
Also added SOF_ABI_VERSION_INCOMPATIBLE macro to allow for easier comparison
between FW ABI version and client applications.

Signed-off-by: ArturX Kloniecki <arturx.kloniecki@linux.intel.com>