### PR TITLE
dma-trace: remove specific reply

### DIFF
--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -626,7 +626,6 @@ static int ipc_dma_trace_config(uint32_t header)
 	uint32_t ring_size;
 #endif
 	struct sof_ipc_dma_trace_params *params = _ipc->comp_data;
-	struct sof_ipc_reply reply;
 	int err;
 
 	trace_ipc("DA1");
@@ -680,11 +679,6 @@ static int ipc_dma_trace_config(uint32_t header)
 	if (err < 0)
 		goto error;
 
-	/* write component values to the outbox */
-	reply.hdr.size = sizeof(reply);
-	reply.hdr.cmd = header;
-	reply.error = 0;
-	mailbox_hostbox_write(0, &reply, sizeof(reply));
 	return 0;
 
 error:


### PR DESCRIPTION
ipc_platform_do_cmd will send a standard reply when ipc_cmd() return 0.
So, we don't need to send a specific reply in ipc_dma_trace_config().