### PR TITLE
Eq 16/24/32-bit support

### DIFF
--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -187,6 +187,31 @@ int comp_set_state(struct comp_dev *dev, int cmd)
 	return ret;
 }
 
+/* set period bytes based on source/sink format */
+void comp_set_period_bytes(struct comp_dev *dev, uint32_t frames,
+			   enum sof_ipc_frame *format, uint32_t *period_bytes)
+{
+	struct sof_ipc_comp_config *sconfig;
+
+	/* get data format */
+	switch (dev->comp.type) {
+	case SOF_COMP_DAI:
+	case SOF_COMP_SG_DAI:
+		/* format comes from DAI/comp config */
+		sconfig = COMP_GET_CONFIG(dev);
+		*format = sconfig->frame_fmt;
+		break;
+	case SOF_COMP_HOST:
+	case SOF_COMP_SG_HOST:
+	default:
+		/* format comes from IPC params */
+		*format = dev->params.frame_fmt;
+		break;
+	}
+
+	*period_bytes = frames * comp_frame_bytes(dev);
+}
+
 void sys_comp_init(void)
 {
 	cd = rzalloc(RZONE_SYS, SOF_MEM_CAPS_RAM, sizeof(*cd));

--- a/src/audio/eq_fir.c
+++ b/src/audio/eq_fir.c
@@ -515,7 +515,7 @@ static int fir_cmd_set_data(struct comp_dev *dev,
 	int ret = 0;
 
 	/* Check version from ABI header */
-	if (cdata->data->comp_abi != SOF_EQ_FIR_ABI_VERSION) {
+	if (cdata->data->comp_abi != SOF_ABI_VERSION) {
 		trace_eq_error("eab");
 		return -EINVAL;
 	}

--- a/src/audio/eq_iir.c
+++ b/src/audio/eq_iir.c
@@ -480,7 +480,7 @@ static int iir_cmd_set_data(struct comp_dev *dev,
 	int ret = 0;
 
 	/* Check version from ABI header */
-	if (cdata->data->comp_abi != SOF_EQ_IIR_ABI_VERSION) {
+	if (cdata->data->comp_abi != SOF_ABI_VERSION) {
 		trace_eq_error("eab");
 		return -EINVAL;
 	}

--- a/src/audio/volume.c
+++ b/src/audio/volume.c
@@ -488,7 +488,6 @@ static int volume_prepare(struct comp_dev *dev)
 	struct comp_data *cd = comp_get_drvdata(dev);
 	struct comp_buffer *sinkb;
 	struct comp_buffer *sourceb;
-	struct sof_ipc_comp_config *sconfig;
 	struct sof_ipc_comp_config *config = COMP_GET_CONFIG(dev);
 	int i;
 	int ret;
@@ -506,44 +505,13 @@ static int volume_prepare(struct comp_dev *dev)
 				struct comp_buffer, source_list);
 
 	/* get source data format */
-	switch (sourceb->source->comp.type) {
-	case SOF_COMP_HOST:
-	case SOF_COMP_SG_HOST:
-		/* source format comes from IPC params */
-		cd->source_format = sourceb->source->params.frame_fmt;
-		cd->source_period_bytes = dev->frames *
-			comp_frame_bytes(sourceb->source);
-		break;
-	case SOF_COMP_DAI:
-	case SOF_COMP_SG_DAI:
-	default:
-		/* source format comes from DAI/comp config */
-		sconfig = COMP_GET_CONFIG(sourceb->source);
-		cd->source_format = sconfig->frame_fmt;
-		cd->source_period_bytes = dev->frames *
-			comp_frame_bytes(sourceb->source);
-		break;
-	}
+	comp_set_period_bytes(sourceb->source, dev->frames, &cd->source_format,
+			      &cd->source_period_bytes);
 
 	/* get sink data format */
-	switch (sinkb->sink->comp.type) {
-	case SOF_COMP_HOST:
-	case SOF_COMP_SG_HOST:
-		/* sink format come from IPC params */
-		cd->sink_format = sinkb->sink->params.frame_fmt;
-		cd->sink_period_bytes = dev->frames *
-			comp_frame_bytes(sinkb->sink);
-		break;
-	case SOF_COMP_DAI:
-	case SOF_COMP_SG_DAI:
-	default:
-		/* sink format comes from DAI/comp config */
-		sconfig = COMP_GET_CONFIG(sinkb->sink);
-		cd->sink_format = sconfig->frame_fmt;
-		cd->sink_period_bytes = dev->frames *
-			comp_frame_bytes(sinkb->sink);
-		break;
-	}
+	comp_set_period_bytes(sinkb->sink, dev->frames, &cd->sink_format,
+			      &cd->sink_period_bytes);
+
 	/* rewrite params format for all downstream */
 	dev->params.frame_fmt = cd->sink_format;
 

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -258,6 +258,10 @@ static inline void comp_free(struct comp_dev *dev)
 /* component state set */
 int comp_set_state(struct comp_dev *dev, int cmd);
 
+/* component set period bytes */
+void comp_set_period_bytes(struct comp_dev *dev, uint32_t frames,
+			   enum sof_ipc_frame *format, uint32_t *period_bytes);
+
 /* component parameter init - mandatory */
 static inline int comp_params(struct comp_dev *dev)
 {

--- a/src/include/uapi/eq.h
+++ b/src/include/uapi/eq.h
@@ -33,11 +33,6 @@
 
 /* FIR EQ type */
 
-/* Component will reject non-matching configuration. The version number need
- * to be incremented with any ABI changes in function fir_cmd().
- */
-#define SOF_EQ_FIR_ABI_VERSION  1
-
 #define SOF_EQ_FIR_IDX_SWITCH	0
 
 #define SOF_EQ_FIR_MAX_SIZE 4096 /* Max size allowed for coef data in bytes */
@@ -96,11 +91,6 @@ struct sof_eq_fir_coef_data {
 #define SOF_EQ_FIR_COEF_NHEADER 2
 
 /* IIR EQ type */
-
-/* Component will reject non-matching configuration. The version number need
- * to be incremented with any ABI changes in function fir_cmd().
- */
-#define SOF_EQ_IIR_ABI_VERSION  1
 
 #define SOF_EQ_IIR_IDX_SWITCH   0
 


### PR DESCRIPTION
Update the period bytes and dev frame fmt based on the source frame fmt. This allows support for 16-bit/24-bit/32-bit formats in the eq pipeline.