### PR TITLE
debugability: Restore error traces always using mbox.

### DIFF
--- a/src/include/sof/trace.h
+++ b/src/include/sof/trace.h
@@ -180,10 +180,10 @@ void trace_init(struct sof *sof);
 
 /* error tracing */
 #if TRACEE
-#define trace_error(__c, __e, ...) \
-	_log_message(,, LOG_LEVEL_CRITICAL, __c, __e, ##__VA_ARGS__)
+#define trace_error(__c, __e, ...) _log_message(_mbox, _atomic, \
+	LOG_LEVEL_CRITICAL, __c, __e, ##__VA_ARGS__)
 #define trace_error_atomic(__c, __e, ...) \
-	_log_message(, _atomic, LOG_LEVEL_CRITICAL, __c, __e, ##__VA_ARGS__)
+	trace_error(__c, __e, ##__VA_ARGS__)
 /* write back error value to mbox */
 #define trace_error_value(x) \
 	trace_error(0, "value %u", x)

--- a/test/cmocka/src/audio/buffer/mock.c
+++ b/test/cmocka/src/audio/buffer/mock.c
@@ -45,6 +45,17 @@ void _trace_event1(uint32_t log_entry, uint32_t param)
 	(void)param;
 }
 
+void _trace_event_mbox_atomic0(uint32_t log_entry)
+{
+	(void)log_entry;
+}
+
+void _trace_event_mbox_atomic1(uint32_t log_entry, uint32_t param)
+{
+	(void)log_entry;
+	(void)param;
+}
+
 void *rzalloc(int zone, uint32_t caps, size_t bytes)
 {
 	(void)zone;

--- a/test/cmocka/src/audio/component/mock.c
+++ b/test/cmocka/src/audio/component/mock.c
@@ -45,6 +45,17 @@ void _trace_event1(uint32_t log_entry, uint32_t param)
 	(void)param;
 }
 
+void _trace_event_mbox_atomic0(uint32_t log_entry)
+{
+	(void)log_entry;
+}
+
+void _trace_event_mbox_atomic1(uint32_t log_entry, uint32_t param)
+{
+	(void)log_entry;
+	(void)param;
+}
+
 void *rzalloc(int zone, uint32_t caps, size_t bytes)
 {
 	(void)zone;

--- a/test/cmocka/src/audio/mixer/mock.c
+++ b/test/cmocka/src/audio/mixer/mock.c
@@ -49,6 +49,17 @@ void _trace_event1(uint32_t log_entry, uint32_t param)
 	(void)param;
 }
 
+void _trace_event_mbox_atomic0(uint32_t log_entry)
+{
+	(void)log_entry;
+}
+
+void _trace_event_mbox_atomic1(uint32_t log_entry, uint32_t param)
+{
+	(void)log_entry;
+	(void)param;
+}
+
 void *rballoc(int zone, uint32_t caps, size_t bytes)
 {
 	(void)zone;

--- a/test/cmocka/src/audio/pipeline/pipeline_mocks.c
+++ b/test/cmocka/src/audio/pipeline/pipeline_mocks.c
@@ -92,6 +92,17 @@ void _trace_event1(uint32_t log_entry, uint32_t param)
 	(void)param;
 }
 
+void _trace_event_mbox_atomic0(uint32_t log_entry)
+{
+	(void)log_entry;
+}
+
+void _trace_event_mbox_atomic1(uint32_t log_entry, uint32_t param)
+{
+	(void)log_entry;
+	(void)param;
+}
+
 int arch_cpu_is_core_enabled(int id)
 {
 	return 1;

--- a/test/cmocka/src/lib/alloc/mock.c
+++ b/test/cmocka/src/lib/alloc/mock.c
@@ -55,6 +55,17 @@ void _trace_event1(uint32_t log_entry, uint32_t param)
 	(void)param;
 }
 
+void _trace_event_mbox_atomic0(uint32_t log_entry)
+{
+	(void)log_entry;
+}
+
+void _trace_event_mbox_atomic1(uint32_t log_entry, uint32_t param)
+{
+	(void)log_entry;
+	(void)param;
+}
+
 void trace_flush(void)
 {
 }


### PR DESCRIPTION
Signed-off-by: ArturX Kloniecki <arturx.kloniecki@linux.intel.com>