### PR TITLE
platform: fix dma_get() of ipc fail issue for byt/hsw/cavs

### DIFF
--- a/src/platform/baytrail/platform.c
+++ b/src/platform/baytrail/platform.c
@@ -227,15 +227,15 @@ int platform_init(struct sof *sof)
 	/* set SSP clock to 19.2M */
 	clock_set_freq(CLK_SSP, 19200000);
 
-	/* initialise the host IPC mechanisms */
-	trace_point(TRACE_BOOT_PLATFORM_IPC);
-	ipc_init(sof);
-
 	/* init DMACs */
 	trace_point(TRACE_BOOT_PLATFORM_DMA);
 	ret = dmac_init();
 	if (ret < 0)
 		return -ENODEV;
+
+	/* initialise the host IPC mechanisms */
+	trace_point(TRACE_BOOT_PLATFORM_IPC);
+	ipc_init(sof);
 
 	ret = dai_init();
 	if (ret < 0)

--- a/src/platform/haswell/platform.c
+++ b/src/platform/haswell/platform.c
@@ -215,15 +215,15 @@ int platform_init(struct sof *sof)
 	trace_point(TRACE_BOOT_PLATFORM_SSP_FREQ);
 	clock_set_freq(CLK_SSP, 25000000);
 
-	/* initialise the host IPC mechanisms */
-	trace_point(TRACE_BOOT_PLATFORM_IPC);
-	ipc_init(sof);
-
 	/* init DMACs */
 	trace_point(TRACE_BOOT_PLATFORM_DMA);
 	ret = dmac_init();
 	if (ret < 0)
 		return -ENODEV;
+
+	/* initialise the host IPC mechanisms */
+	trace_point(TRACE_BOOT_PLATFORM_IPC);
+	ipc_init(sof);
 
 	ret = dai_init();
 	if (ret < 0)

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -348,15 +348,15 @@ int platform_init(struct sof *sof)
 	shim_write16(SHIM_PWRCTL, SHIM_PWRCTL_TCPDSP0PG);
 #endif
 
-	/* initialize the host IPC mechanisms */
-	trace_point(TRACE_BOOT_PLATFORM_IPC);
-	ipc_init(sof);
-
 	/* init DMACs */
 	trace_point(TRACE_BOOT_PLATFORM_DMA);
 	ret = dmac_init();
 	if (ret < 0)
 		return -ENODEV;
+
+	/* initialize the host IPC mechanisms */
+	trace_point(TRACE_BOOT_PLATFORM_IPC);
+	ipc_init(sof);
 
 	/* init DAIs */
 	ret = dai_init();


### PR DESCRIPTION
We need to call ipc_init() after dmac_init(), otherwise will faild
at getting dmac for ipc page table tranferring and error happends
as below:

CORE LEVEL COMP_ID TIMESTAMP DELTA FILE_NAME CONTENT
0 1 DMA 85943.645833 85943.648438 dma.c:59 No DMAs installed

Here correct and fix it.

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>