### PR TITLE
alloc: fixed memory leaks in dw-dma

### DIFF
--- a/src/drivers/intel/cavs/dmic.c
+++ b/src/drivers/intel/cavs/dmic.c
@@ -1454,7 +1454,7 @@ static int dmic_probe(struct dai *dai)
 	pm_runtime_get_sync(DMIC_CLK, dai->index);
 
 	/* allocate private data */
-	dmic = rzalloc(RZONE_SYS | RZONE_FLAG_UNCACHED, SOF_MEM_CAPS_RAM,
+	dmic = rzalloc(RZONE_RUNTIME | RZONE_FLAG_UNCACHED, SOF_MEM_CAPS_RAM,
 		       sizeof(*dmic));
 	if (!dmic) {
 		trace_dmic_error("eap");

--- a/src/drivers/intel/cavs/hda-dma.c
+++ b/src/drivers/intel/cavs/hda-dma.c
@@ -614,8 +614,12 @@ static int hda_dma_probe(struct dma *dma)
 		return -EEXIST; /* already created */
 
 	/* allocate private data */
-	hda_pdata = rzalloc(RZONE_SYS | RZONE_FLAG_UNCACHED, SOF_MEM_CAPS_RAM,
-			    sizeof(*hda_pdata));
+	hda_pdata = rzalloc(RZONE_RUNTIME | RZONE_FLAG_UNCACHED,
+			    SOF_MEM_CAPS_RAM, sizeof(*hda_pdata));
+	if (!hda_pdata) {
+		trace_error(TRACE_CLASS_DMA, "alloc failed");
+		return -ENOMEM;
+	}
 	dma_set_drvdata(dma, hda_pdata);
 
 	/* init channel status */

--- a/src/drivers/intel/cavs/ssp.c
+++ b/src/drivers/intel/cavs/ssp.c
@@ -875,8 +875,12 @@ static int ssp_probe(struct dai *dai)
 	pm_runtime_get_sync(SSP_CLK, dai->index);
 
 	/* allocate private data */
-	ssp = rzalloc(RZONE_SYS | RZONE_FLAG_UNCACHED, SOF_MEM_CAPS_RAM,
+	ssp = rzalloc(RZONE_RUNTIME | RZONE_FLAG_UNCACHED, SOF_MEM_CAPS_RAM,
 		      sizeof(*ssp));
+	if (!ssp) {
+		trace_error(TRACE_CLASS_DAI, "alloc failed");
+		return -ENOMEM;
+	}
 	dai_set_drvdata(dai, ssp);
 
 	ssp->state[DAI_DIR_PLAYBACK] = COMP_STATE_READY;

--- a/src/lib/alloc.c
+++ b/src/lib/alloc.c
@@ -127,7 +127,9 @@ static void *rmalloc_sys(int zone, int core, size_t bytes)
 
 	/* always succeeds or panics */
 	if (alignment + bytes > cpu_heap->info.free) {
-		trace_mem_error("eM1");
+		trace_error(TRACE_CLASS_MEM,
+			    "rmalloc-sys eM1 zone %x core %d bytes %d",
+			    zone, core, bytes);
 		panic(SOF_IPC_PANIC_MEM);
 	}
 	cpu_heap->info.used += alignment;
@@ -419,9 +421,9 @@ find:
 	return ptr;
 
 error:
-	trace_mem_error("eMm");
-	trace_error_value(bytes);
-	trace_error_value(caps);
+	trace_error(TRACE_CLASS_MEM,
+		    "rmalloc-runtime eMm zone %d caps %x bytes %d",
+		    zone, caps, bytes);
 	return NULL;
 }
 

--- a/src/lib/interrupt.c
+++ b/src/lib/interrupt.c
@@ -55,8 +55,10 @@ static int irq_register_child(struct irq_desc *parent, int irq, int unmask,
 
 	spin_lock(&parent->lock);
 
-	/* init child */
-	child = rzalloc(RZONE_SYS, SOF_MEM_CAPS_RAM,
+	/* init child from run-time, may be registered and unregistered
+	 * many times at run-time
+	 */
+	child = rzalloc(RZONE_RUNTIME, SOF_MEM_CAPS_RAM,
 			sizeof(struct irq_desc));
 	if (!child) {
 		ret = -ENOMEM;
@@ -102,6 +104,7 @@ static void irq_unregister_child(struct irq_desc *parent, int irq)
 		if (SOF_IRQ_ID(irq) == child->id) {
 			list_item_del(&child->irq_list);
 			parent->num_children--;
+			rfree(child);
 		}
 	}
 


### PR DESCRIPTION
Existing memory leaks in dw-dma in pause/resume scenarios fixed.
Potential leaks in probe/remove scenarios fixed too.

Signed-off-by: Marcin Maka <marcin.maka@linux.intel.com>