### PR TITLE
dma-trace: handling dma trace buffer overflow

### DIFF
--- a/src/include/sof/dma-trace.h
+++ b/src/include/sof/dma-trace.h
@@ -79,4 +79,9 @@ void dma_trace_flush(void *t);
 void dtrace_event(const char *e, uint32_t size);
 void dtrace_event_atomic(const char *e, uint32_t length);
 
+static inline uint32_t dtrace_calc_buf_margin(struct dma_trace_buf *buffer)
+{
+	return buffer->end_addr - buffer->w_ptr;
+}
+
 #endif


### PR DESCRIPTION
In dtrace_add_event function I've added handling
dma trace buffer overflow. If there is not enough
memory, log will be dropped. Amount of dropped entries
is counted and it will be logged.

Signed-off-by: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>