### PR TITLE
SRC: Use 32 bit filter coefficients in host testbench

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -137,6 +137,7 @@ case "$with_arch" in
 
 	ARCH="host"
 	AC_SUBST(ARCH)
+	AC_DEFINE([CONFIG_HOST], [1], [Configure for Host])
     ;;
     *)
 	if test "$have_rimage" = "no" && test "$have_doc" = "no" ; then

--- a/src/audio/src_config.h
+++ b/src/audio/src_config.h
@@ -66,7 +66,11 @@
 #endif
 #else
 /* GCC */
+#if defined(CONFIG_HOST)
+#define SRC_SHORT	0  /* Use high quality 32 bit filter coefficients */
+#else
 #define SRC_SHORT	1  /* Use 16 bit filter coefficients for speed */
+#endif
 #define SRC_GENERIC	1
 #define SRC_HIFIEP	0
 #define SRC_HIFI3	0


### PR DESCRIPTION
This patch adds check for automatically set macro for x86 64bit
architecture and selects the better quality and full conversions set
for testbench. The problem with default for gcc was that the conversions
set for non-optimized xtensa gcc is very limited and the quality has
been lowered to save resources. Hence the testbench creates huge amount
of fails without this change. With this patch the SRC test tracks the
quality of coefficients for optimized HiFiEP/HiFi3 version code.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>