### PR TITLE
platform: increase max streams count

### DIFF
--- a/src/platform/cannonlake/include/platform/platform.h
+++ b/src/platform/cannonlake/include/platform/platform.h
@@ -89,8 +89,8 @@ struct sof;
 #define PLATFORM_HOST_DMA_MASK	0x00000000
 
 /* Platform stream capabilities */
-#define PLATFORM_MAX_CHANNELS	4
-#define PLATFORM_MAX_STREAMS	5
+#define PLATFORM_MAX_CHANNELS	8
+#define PLATFORM_MAX_STREAMS	16
 
 /* clock source used by scheduler for deadline calculations */
 #define PLATFORM_SCHED_CLOCK	PLATFORM_DEFAULT_CLOCK

--- a/src/platform/icelake/include/platform/platform.h
+++ b/src/platform/icelake/include/platform/platform.h
@@ -89,8 +89,8 @@ struct sof;
 #define PLATFORM_HOST_DMA_MASK	0x00000000
 
 /* Platform stream capabilities */
-#define PLATFORM_MAX_CHANNELS	4
-#define PLATFORM_MAX_STREAMS	5
+#define PLATFORM_MAX_CHANNELS	8
+#define PLATFORM_MAX_STREAMS	16
 
 /* clock source used by scheduler for deadline calculations */
 #define PLATFORM_SCHED_CLOCK	PLATFORM_DEFAULT_CLOCK


### PR DESCRIPTION
Make platform streams and channels count for CNL&ICL be the same as for APL (it was like for BYT&HSW previously). I don't know if we should make it also for suecreek. This patch fixes mixer at least for CNL/ICL.
Also because mixer is fixed, all UTs now pass for apl/cnl/icl so we can add UTs for all these platforms to CI.
Signed-off-by: Janusz Jankowski <janusz.jankowski@linux.intel.com>