### PR TITLE
Revert "hda: set correct link dma channel"

### DIFF
--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -360,8 +360,8 @@ static int dai_params(struct comp_dev *dev)
 		return -EINVAL;
 	}
 
-	/* get DMA channel, once the backend dma channel is known */
-	dd->chan = dma_channel_get(dd->dma, dev->params.be_dma_ch);
+	/* get DMA channel, once the stream_tag is known */
+	dd->chan = dma_channel_get(dd->dma, dev->params.stream_tag);
 	if (dd->chan < 0) {
 		trace_dai_error("eDc");
 		return -EINVAL;

--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -515,10 +515,11 @@ static int host_params(struct comp_dev *dev)
 	host_elements_reset(dev);
 #endif
 
+	dev->params.stream_tag -= 1;
 	/* get DMA channel from DMAC
-	 * note: host_dma_ch is ignored by dw-dma
+	 * note: stream_tag is ignored by dw-dma
 	 */
-	hd->chan = dma_channel_get(hd->dma, dev->params.host_dma_ch);
+	hd->chan = dma_channel_get(hd->dma, dev->params.stream_tag);
 	if (hd->chan < 0) {
 		trace_host_error("eDC");
 		return -ENODEV;

--- a/src/include/uapi/ipc.h
+++ b/src/include/uapi/ipc.h
@@ -500,8 +500,7 @@ struct sof_ipc_stream_params {
 	enum sof_ipc_stream_direction direction;
 	enum sof_ipc_frame frame_fmt;
 	enum sof_ipc_buffer_format buffer_fmt;
-	uint32_t host_dma_ch;
-	uint32_t be_dma_ch;
+	uint32_t stream_tag;
 	uint32_t rate;
 	uint32_t channels;
 	uint32_t sample_valid_bytes;


### PR DESCRIPTION
Reverts thesofproject/sof#505. Please send matching kernel update.