### PR TITLE
[RFC] hda: fix capture issue with link dma

### DIFF
--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -361,7 +361,7 @@ static int dai_params(struct comp_dev *dev)
 	}
 
 	/* get DMA channel, once the stream_tag is known */
-	dd->chan = dma_channel_get(dd->dma, dev->params.stream_tag);
+	dd->chan = dma_channel_get(dd->dma, dev->params.stream_tag, dev);
 	if (dd->chan < 0) {
 		trace_dai_error("eDc");
 		return -EINVAL;

--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -519,7 +519,7 @@ static int host_params(struct comp_dev *dev)
 	/* get DMA channel from DMAC
 	 * note: stream_tag is ignored by dw-dma
 	 */
-	hd->chan = dma_channel_get(hd->dma, dev->params.stream_tag);
+	hd->chan = dma_channel_get(hd->dma, dev->params.stream_tag, NULL);
 	if (hd->chan < 0) {
 		trace_host_error("eDC");
 		return -ENODEV;

--- a/src/drivers/intel/dw-dma.c
+++ b/src/drivers/intel/dw-dma.c
@@ -311,7 +311,8 @@ static inline void dw_update_bits(struct dma *dma, uint32_t reg, uint32_t mask,
 }
 
 /* allocate next free DMA channel */
-static int dw_dma_channel_get(struct dma *dma, int req_chan)
+static int dw_dma_channel_get(struct dma *dma, int req_chan,
+			      struct comp_dev *dev)
 {
 	struct dma_pdata *p = dma_get_drvdata(dma);
 	uint32_t flags;

--- a/src/include/sof/dma.h
+++ b/src/include/sof/dma.h
@@ -132,7 +132,8 @@ struct dma_chan_status {
 /* DMA operations */
 struct dma_ops {
 
-	int (*channel_get)(struct dma *dma, int req_channel);
+	int (*channel_get)(struct dma *dma, int req_channel,
+			   struct comp_dev *dev);
 	void (*channel_put)(struct dma *dma, int channel);
 
 	int (*start)(struct dma *dma, int channel);
@@ -231,9 +232,10 @@ void dma_put(struct dma *dma);
  * 6) dma_channel_put()
  */
 
-static inline int dma_channel_get(struct dma *dma, int req_channel)
+static inline int dma_channel_get(struct dma *dma, int req_channel,
+				  struct comp_dev *dev)
 {
-	return dma->ops->channel_get(dma, req_channel);
+	return dma->ops->channel_get(dma, req_channel, dev);
 }
 
 static inline void dma_channel_put(struct dma *dma, int channel)

--- a/src/include/uapi/ipc.h
+++ b/src/include/uapi/ipc.h
@@ -169,6 +169,12 @@
 #define SOF_MEM_CAPS_EXEC			(1 << 7) /* executable */
 
 /*
+ * Stream configuration.
+ */
+
+#define SOF_IPC_MAX_CHANNELS			8
+
+/*
  * Command Header - Header for all IPC. Identifies IPC message.
  * The size can be greater than the structure size and that means there is
  * extended bespoke data beyond the end of the structure including variable
@@ -310,7 +316,9 @@ struct sof_ipc_dai_ssp_params {
 /* HDA Configuration Request - SOF_IPC_DAI_HDA_CONFIG */
 struct sof_ipc_dai_hda_params {
 	struct sof_ipc_hdr hdr;
-	/* TODO */
+	uint32_t hda_count;
+	uint32_t hda_comp_id[SOF_IPC_MAX_CHANNELS];
+	uint32_t hda_dma_ch[SOF_IPC_MAX_CHANNELS];
 } __attribute__((packed));
 
 /* DMIC Configuration Request - SOF_IPC_DAI_DMIC_CONFIG */
@@ -396,12 +404,6 @@ struct sof_ipc_dai_config {
 		struct sof_ipc_dai_dmic_params dmic;
 	};
 };
-
-/*
- * Stream configuration.
- */
-
-#define SOF_IPC_MAX_CHANNELS			8
 
 /* channel positions - uses same values as ALSA */
 enum sof_ipc_chmap {
@@ -508,6 +510,10 @@ struct sof_ipc_stream_params {
 	/* for notifying host period has completed - 0 means no period IRQ */
 	uint32_t host_period_bytes;
 	enum sof_ipc_chmap chmap[SOF_IPC_MAX_CHANNELS];	/* channel map */
+	union {
+		uint32_t private_data[64];
+		struct sof_ipc_dai_hda_params hda;
+	};
 } __attribute__((packed));
 
 /* PCM params info - SOF_IPC_STREAM_PCM_PARAMS */

--- a/src/ipc/dma-copy.c
+++ b/src/ipc/dma-copy.c
@@ -176,7 +176,7 @@ int dma_copy_new(struct dma_copy *dc)
 
 #if !defined CONFIG_DMA_GW
 	/* get DMA channel from DMAC0 */
-	dc->chan = dma_channel_get(dc->dmac, 0);
+	dc->chan = dma_channel_get(dc->dmac, 0, NULL);
 	if (dc->chan < 0) {
 		trace_dma_error("ec1");
 		return dc->chan;
@@ -195,7 +195,7 @@ int dma_copy_new(struct dma_copy *dc)
 int dma_copy_set_stream_tag(struct dma_copy *dc, uint32_t stream_tag)
 {
 	/* get DMA channel from DMAC */
-	dc->chan = dma_channel_get(dc->dmac, stream_tag - 1);
+	dc->chan = dma_channel_get(dc->dmac, stream_tag - 1, NULL);
 	if (dc->chan < 0) {
 		trace_dma_error("ec1");
 		return -EINVAL;

--- a/src/ipc/ipc.c
+++ b/src/ipc/ipc.c
@@ -461,7 +461,7 @@ int ipc_get_page_descriptors(struct dma *dmac, uint8_t *page_table,
 	int ret = 0;
 
 	/* get DMA channel from DMAC */
-	chan = dma_channel_get(dmac, 0);
+	chan = dma_channel_get(dmac, 0, NULL);
 	if (chan < 0) {
 		trace_ipc_error("ePC");
 		return chan;


### PR DESCRIPTION
host dma and link dma work in decouple mode for SOF + HDA codec.
Now allocate host dma and link dma channel in host and set them
in FW individually. For GP dma, the channel is allocated in FW,
so no such issue.

This patch supports for multiple dai backends. In SOF, each component
has a unique id which is useful to my patch. Now host stores all the
dma setting of each BE and its id, then sends them to FW to set each BE.
In FW, each BE could get dma setting by its id

Signed-off-by: Rander Wang <rander.wang@linux.intel.com>