### PR TITLE
dmic: fix mem alloc for dmic params

### DIFF
--- a/src/drivers/intel/cavs/dmic.c
+++ b/src/drivers/intel/cavs/dmic.c
@@ -1118,7 +1118,7 @@ static int dmic_set_config(struct dai *dai, struct sof_ipc_dai_config *config)
 	 */
 	size = sizeof(*prm) + DMIC_HW_CONTROLLERS
 		* sizeof(struct sof_ipc_dai_dmic_pdm_ctrl);
-	prm = rzalloc(RZONE_SYS, SOF_MEM_CAPS_RAM, size);
+	prm = rzalloc(RZONE_RUNTIME, SOF_MEM_CAPS_RAM, size);
 	if (!prm) {
 		trace_dmic_error("eac");
 		return -ENOMEM;


### PR DESCRIPTION
The dmic params struct should be allocated in RZONE_RUNTIME
instead of RZONE_SYS so that it can be freed. This
fixes the DSP panic caused while it is freed after setting
the DMIC config.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>