### PR TITLE
memory: Use cached memory for frequently used objects

### DIFF
--- a/src/drivers/intel/baytrail/ssp.c
+++ b/src/drivers/intel/baytrail/ssp.c
@@ -600,8 +600,7 @@ static int ssp_probe(struct dai *dai)
 	struct ssp_pdata *ssp;
 
 	/* allocate private data */
-	ssp = rzalloc(RZONE_SYS | RZONE_FLAG_UNCACHED, SOF_MEM_CAPS_RAM,
-		      sizeof(*ssp));
+	ssp = rzalloc(RZONE_SYS, SOF_MEM_CAPS_RAM, sizeof(*ssp));
 	dai_set_drvdata(dai, ssp);
 
 	spinlock_init(&dai->lock);

--- a/src/drivers/intel/cavs/dmic.c
+++ b/src/drivers/intel/cavs/dmic.c
@@ -1454,8 +1454,7 @@ static int dmic_probe(struct dai *dai)
 	pm_runtime_get_sync(DMIC_CLK, dai->index);
 
 	/* allocate private data */
-	dmic = rzalloc(RZONE_RUNTIME | RZONE_FLAG_UNCACHED, SOF_MEM_CAPS_RAM,
-		       sizeof(*dmic));
+	dmic = rzalloc(RZONE_RUNTIME, SOF_MEM_CAPS_RAM, sizeof(*dmic));
 	if (!dmic) {
 		trace_dmic_error("eap");
 		return -ENOMEM;

--- a/src/drivers/intel/cavs/hda-dma.c
+++ b/src/drivers/intel/cavs/hda-dma.c
@@ -645,8 +645,8 @@ static int hda_dma_probe(struct dma *dma)
 		return -EEXIST; /* already created */
 
 	/* allocate private data */
-	hda_pdata = rzalloc(RZONE_RUNTIME | RZONE_FLAG_UNCACHED,
-			    SOF_MEM_CAPS_RAM, sizeof(*hda_pdata));
+	hda_pdata = rzalloc(RZONE_RUNTIME, SOF_MEM_CAPS_RAM,
+			    sizeof(*hda_pdata));
 	if (!hda_pdata) {
 		trace_error(TRACE_CLASS_DMA, "alloc failed");
 		return -ENOMEM;

--- a/src/drivers/intel/cavs/ssp.c
+++ b/src/drivers/intel/cavs/ssp.c
@@ -875,8 +875,7 @@ static int ssp_probe(struct dai *dai)
 	pm_runtime_get_sync(SSP_CLK, dai->index);
 
 	/* allocate private data */
-	ssp = rzalloc(RZONE_RUNTIME | RZONE_FLAG_UNCACHED, SOF_MEM_CAPS_RAM,
-		      sizeof(*ssp));
+	ssp = rzalloc(RZONE_RUNTIME, SOF_MEM_CAPS_RAM, sizeof(*ssp));
 	if (!ssp) {
 		trace_error(TRACE_CLASS_DAI, "alloc failed");
 		return -ENOMEM;

--- a/src/drivers/intel/dw-dma.c
+++ b/src/drivers/intel/dw-dma.c
@@ -1280,8 +1280,7 @@ static int dw_dma_probe(struct dma *dma)
 	pm_runtime_get_sync(DW_DMAC_CLK, dma->plat_data.id);
 
 	/* allocate private data */
-	dw_pdata = rzalloc(RZONE_RUNTIME | RZONE_FLAG_UNCACHED,
-			   SOF_MEM_CAPS_RAM, sizeof(*dw_pdata));
+	dw_pdata = rzalloc(RZONE_RUNTIME, SOF_MEM_CAPS_RAM, sizeof(*dw_pdata));
 	if (!dw_pdata) {
 		trace_error(TRACE_CLASS_DMA, "alloc failed");
 		return -ENOMEM;

--- a/src/drivers/intel/haswell/ssp.c
+++ b/src/drivers/intel/haswell/ssp.c
@@ -498,8 +498,7 @@ static int ssp_probe(struct dai *dai)
 	struct ssp_pdata *ssp;
 
 	/* allocate private data */
-	ssp = rzalloc(RZONE_SYS | RZONE_FLAG_UNCACHED, SOF_MEM_CAPS_RAM,
-		      sizeof(*ssp));
+	ssp = rzalloc(RZONE_SYS, SOF_MEM_CAPS_RAM, sizeof(*ssp));
 	dai_set_drvdata(dai, ssp);
 
 	spinlock_init(&dai->lock);

--- a/src/ipc/ipc.c
+++ b/src/ipc/ipc.c
@@ -121,7 +121,7 @@ int ipc_comp_new(struct ipc *ipc, struct sof_ipc_comp *comp)
 	}
 
 	/* allocate the IPC component container */
-	icd = rzalloc(RZONE_RUNTIME | RZONE_FLAG_UNCACHED, SOF_MEM_CAPS_RAM,
+	icd = rzalloc(RZONE_RUNTIME, SOF_MEM_CAPS_RAM,
 		      sizeof(struct ipc_comp_dev));
 	if (icd == NULL) {
 		trace_ipc_error("eCm");
@@ -175,7 +175,7 @@ int ipc_buffer_new(struct ipc *ipc, struct sof_ipc_buffer *desc)
 		return -ENOMEM;
 	}
 
-	ibd = rzalloc(RZONE_RUNTIME | RZONE_FLAG_UNCACHED, SOF_MEM_CAPS_RAM,
+	ibd = rzalloc(RZONE_RUNTIME, SOF_MEM_CAPS_RAM,
 		      sizeof(struct ipc_comp_dev));
 	if (ibd == NULL) {
 		rfree(buffer);
@@ -280,13 +280,12 @@ int ipc_pipeline_new(struct ipc *ipc,
 	}
 
 	/* allocate the IPC pipeline container */
-	ipc_pipe = rzalloc(RZONE_RUNTIME | RZONE_FLAG_UNCACHED,
+	ipc_pipe = rzalloc(RZONE_RUNTIME,
 			   SOF_MEM_CAPS_RAM, sizeof(struct ipc_comp_dev));
 	if (ipc_pipe == NULL) {
 		pipeline_free(pipe);
 		return -ENOMEM;
 	}
-
 	ipc_pipe->pipeline = pipe;
 	ipc_pipe->type = COMP_TYPE_PIPELINE;
 
@@ -530,8 +529,7 @@ int ipc_init(struct sof *sof)
 
 	spinlock_init(&sof->ipc->lock);
 
-	sof->ipc->shared_ctx = rzalloc(RZONE_SYS | RZONE_FLAG_UNCACHED,
-				       SOF_MEM_CAPS_RAM,
+	sof->ipc->shared_ctx = rzalloc(RZONE_SYS, SOF_MEM_CAPS_RAM,
 				       sizeof(*sof->ipc->shared_ctx));
 
 	dcache_writeback_region(sof->ipc, sizeof(*sof->ipc));

--- a/src/lib/clk.c
+++ b/src/lib/clk.c
@@ -148,8 +148,7 @@ void clock_init(void)
 {
 	int i = 0;
 
-	clk_pdata = rmalloc(RZONE_SYS | RZONE_FLAG_UNCACHED, SOF_MEM_CAPS_RAM,
-			    sizeof(*clk_pdata));
+	clk_pdata = rmalloc(RZONE_SYS, SOF_MEM_CAPS_RAM, sizeof(*clk_pdata));
 
 	/* set defaults */
 	for (i = 0; i < PLATFORM_CORE_COUNT; i++) {

--- a/src/lib/work.c
+++ b/src/lib/work.c
@@ -520,8 +520,7 @@ void init_system_workq(struct work_queue_timesource *ts)
 	*queue = work_new_queue(ts);
 
 	if (cpu_get_id() == PLATFORM_MASTER_CORE_ID) {
-		work_shared_ctx = rzalloc(RZONE_SYS | RZONE_FLAG_UNCACHED,
-					  SOF_MEM_CAPS_RAM,
+		work_shared_ctx = rzalloc(RZONE_SYS, SOF_MEM_CAPS_RAM,
 					  sizeof(*work_shared_ctx));
 		atomic_init(&work_shared_ctx->total_num_work, 0);
 		atomic_init(&work_shared_ctx->timer_clients, 0);


### PR DESCRIPTION
This patch allocates the frequently used normal objects with cached
memory.

Signed-off-by: Libin Yang <libin.yang@intel.com>