### PR TITLE
Volume: Fix overflow in s16 and s24 output conversions

### DIFF
--- a/src/include/sof/audio/format.h
+++ b/src/include/sof/audio/format.h
@@ -126,21 +126,12 @@ static inline int16_t q_multsr_16x16(int16_t x, int32_t y, const int shift_bits)
 
 static inline int32_t sat_int32(int64_t x)
 {
-#if 1
-	/* TODO: Is this faster */
 	if (x > INT32_MAX)
 		return INT32_MAX;
 	else if (x < INT32_MIN)
 		return INT32_MIN;
 	else
 		return (int32_t)x;
-#else
-	/* Or this */
-	int64_t y;
-	y = SATP_INT32(x);
-	return (int32_t)SATM_INT32(y);
-
-#endif
 }
 
 static inline int32_t sat_int24(int32_t x)
@@ -165,13 +156,25 @@ static inline int16_t sat_int16(int32_t x)
 
 /* Fractional multiplication with shift and saturation */
 static inline int32_t q_multsr_sat_32x32(int32_t x, int32_t y,
-	const int shift_bits)
+					 const int shift_bits)
 {
 	return sat_int32(((((int64_t)x * y) >> (shift_bits - 1)) + 1) >> 1);
 }
 
+static inline int32_t q_multsr_sat_32x32_24(int32_t x, int32_t y,
+					    const int shift_bits)
+{
+	return sat_int24(((((int64_t)x * y) >> (shift_bits - 1)) + 1) >> 1);
+}
+
+static inline int32_t q_multsr_sat_32x32_16(int32_t x, int32_t y,
+					    const int shift_bits)
+{
+	return sat_int16(((((int64_t)x * y) >> (shift_bits - 1)) + 1) >> 1);
+}
+
 static inline int16_t q_multsr_sat_16x16(int16_t x, int32_t y,
-	const int shift_bits)
+					 const int shift_bits)
 {
 	return sat_int16(((((int32_t)x * y) >> (shift_bits - 1)) + 1) >> 1);
 }


### PR DESCRIPTION
The problem could be heard with extremely loud music content. The
32x32 saturating multiply function works for 32 bit output but
the result will overflow when less number of bits are used from output.

This patch adds to format.h rounded 32x32 multiply inline functions for
saturated s24 and s16 formats. The generic volume function is updated
to utilize them and the code structure is cleaned for easier maintenance
and simpler look.

The format.h file is cleaned up with function parameter indents and
remove of redundant code in saturate function.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>