### PR TITLE
preproc: varargscount: bugfix for tokens starting with '(' not being counted

### DIFF
--- a/src/include/sof/preproc-private.h
+++ b/src/include/sof/preproc-private.h
@@ -65,7 +65,7 @@
  * META_COUNT_VARAGS_BEFORE_COMPILE(A,B,C,D) evaluates to 4
  */
 #define _META_PP_NARG_BEFORE_COMPILE_(...) \
-		_META_PP_ARG_N(__VA_ARGS__)
+	_META_PP_ARG_N(__VA_ARGS__)
 #define _META_PP_ARG_N(\
 	_1,   _2,  _3,  _4,  _5,  _6,  _7,  _8,  _9, _10, \
 	_11, _12, _13, _14, _15, _16, _17, _18, _19, _20, \
@@ -224,7 +224,7 @@
 /* used by macro MAP, don't use on its own */
 #define _META_MAP_BODY(arg_count, m, ...)\
 	META_IF_ELSE(META_COUNT_VARAGS_BEFORE_COMPILE(__VA_ARGS__))(\
-		META_DEFER(2, _META_MAP)()\
+		_META_DEFER_2(_META_MAP)()\
 			(arg_count, m, __VA_ARGS__)\
 	)()
 
@@ -246,7 +246,7 @@
 /* used by macro MAP_AGGREGATE, don't use on its own */
 #define _META_MAP_AGGREGATE_BODY(arg_count, m, aggr, ...)\
 	META_IF_ELSE(META_COUNT_VARAGS_BEFORE_COMPILE(__VA_ARGS__))(\
-		META_DEFER(2, _META_MAP_AGGREGATE)()\
+		_META_DEFER_2(_META_MAP_AGGREGATE)()\
 			(arg_count, m, aggr, __VA_ARGS__)\
 	)(aggr)
 

--- a/src/include/sof/preproc.h
+++ b/src/include/sof/preproc.h
@@ -46,11 +46,10 @@
  * META_COUNT_VARAGS_BEFORE_COMPILE(A,B,C,D) evaluates to 4
  */
 #define META_COUNT_VARAGS_BEFORE_COMPILE(...)\
-	META_IF_ELSE(META_HAS_ARGS(__VA_ARGS__)) (\
-		_META_PP_NARG_BEFORE_COMPILE_(__VA_ARGS__, _META_PP_RSEQ_N())\
-	)\
-	(\
-		0\
+	META_DEC(\
+		_META_PP_NARG_BEFORE_COMPILE_(\
+			_, ##__VA_ARGS__, _META_PP_RSEQ_N()\
+		)\
 	)
 
 /* treat x as string while forcing x expansion beforehand */

--- a/test/cmocka/src/lib/preproc/varargs_count.c
+++ b/test/cmocka/src/lib/preproc/varargs_count.c
@@ -51,29 +51,42 @@ static void META_CONCAT_SEQ_DELIM_(prefix, test_func, postfix)(void **state)\
 #define A 1
 #define B 2
 #define C 3
+#define PARENTHESIS_PRE()  (1+3)/2
+#define PARENTHESIS_POST() 4/(3-1)
 
 #define META_NAME META_COUNT_VARAGS_BEFORE_COMPILE
-TEST_HERE_DECLARE(META_NAME, 0, 0,        )
-TEST_HERE_DECLARE(META_NAME, 1, 1, A      )
-TEST_HERE_DECLARE(META_NAME, 3, 3, A, B, C)
-TEST_HERE_DECLARE(PP_NARG  , 0, 0,        )
-TEST_HERE_DECLARE(PP_NARG  , 1, 1, A      )
-TEST_HERE_DECLARE(PP_NARG  , 3, 3, A, B, C)
+#define TEST_HERE_DECLARE_GROUP(func_name)\
+	TEST_HERE_DECLARE(func_name, 0, 0,        )\
+	TEST_HERE_DECLARE(func_name, 1, 1, A      )\
+	TEST_HERE_DECLARE(func_name, 3, 3, A, B, C)\
+	TEST_HERE_DECLARE(func_name, with_parenthesis_pre,  1,\
+		PARENTHESIS_PRE())\
+	TEST_HERE_DECLARE(func_name, with_parenthesis_post, 1,\
+		PARENTHESIS_POST())
 
+TEST_HERE_DECLARE_GROUP(META_NAME)
+TEST_HERE_DECLARE_GROUP(PP_NARG)
+
+#undef TEST_HERE_DECLARE_GROUP
+#undef PARENTHESIS_POST
+#undef PARENTHESIS_PRE
 #undef C
 #undef B
 #undef A
 #undef TEST_FUNC
 
+#define TEST_HERE_USE_GROUP(func_name)\
+	TEST_HERE_USE(func_name, 0),\
+	TEST_HERE_USE(func_name, 1),\
+	TEST_HERE_USE(func_name, 3),\
+	TEST_HERE_USE(func_name, with_parenthesis_pre),\
+	TEST_HERE_USE(func_name, with_parenthesis_post),
+
 int main(void)
 {
 	const struct CMUnitTest tests[] = {
-		TEST_HERE_USE(META_NAME, 0),
-		TEST_HERE_USE(META_NAME, 1),
-		TEST_HERE_USE(META_NAME, 3),
-		TEST_HERE_USE(PP_NARG  , 0),
-		TEST_HERE_USE(PP_NARG  , 1),
-		TEST_HERE_USE(PP_NARG  , 3),
+		TEST_HERE_USE_GROUP(META_NAME)
+		TEST_HERE_USE_GROUP(PP_NARG)
 	};
 
 	cmocka_set_message_output(CM_OUTPUT_TAP);
@@ -81,5 +94,6 @@ int main(void)
 	return cmocka_run_group_tests(tests, NULL, NULL);
 }
 
+#undef TEST_HERE_USE_GROUP
 #undef META_NAME 
 #undef TEST_PREFIX


### PR DESCRIPTION
; also introduced unit tests to check the issue

Signed-off-by: Michal Jerzy Wierzbicki <michalx.wierzbicki@linux.intel.com>

varargscount is macro META_COUNT_VARARGS_BEFORE_COMPILE

Fix for issue https://github.com/thesofproject/sof/issues/542