### PR TITLE
memory: apl: increase HEAP_RT_COUNT256 size

### DIFF
--- a/src/platform/apollolake/include/platform/memory.h
+++ b/src/platform/apollolake/include/platform/memory.h
@@ -135,7 +135,7 @@
 /* Heap section sizes for module pool */
 #define HEAP_RT_COUNT64			256
 #define HEAP_RT_COUNT128		32
-#define HEAP_RT_COUNT256		64
+#define HEAP_RT_COUNT256		80
 #define HEAP_RT_COUNT512		32
 #define HEAP_RT_COUNT1024		4
 


### PR DESCRIPTION
This patch fixes the memory allocation error by increasing HEAP_RT_COUNT256 size, for driver to run in nocodec mode.
It can fix these issues:
https://github.com/thesofproject/linux/issues/253


Signed-off-by: Libin Yang <libin.yang@intel.com>