### PR TITLE
Volume: Bug fix for vol_mult_s24_to_s16() function

### DIFF
--- a/src/audio/volume_generic.c
+++ b/src/audio/volume_generic.c
@@ -50,7 +50,7 @@
  *
  * Volume multiply for 24 bit input and 16 bit bit output.
  */
-static inline int16_t vol_mult_s24_to_s16(int16_t x, int32_t vol)
+static inline int16_t vol_mult_s24_to_s16(int32_t x, int32_t vol)
 {
 	return (int16_t)q_multsr_sat_32x32_16(sign_extend_s24(x), vol,
 					      Q_SHIFT_BITS_64(23, 16, 15));


### PR DESCRIPTION
The previous commit introduced a bug in this volume function. The input
parameter for s24 PCM samples must be int32_t. The bug causes for s24 to
s16 converted audio very low signal level and noise due to overflows.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>