### PR TITLE
Lower size of .text section

### DIFF
--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -702,11 +702,11 @@ static int dai_config(struct comp_dev *dev, struct sof_ipc_dai_config *config)
 		trace_dai("dai_config(), config->dmic.fifo_bits_a = %u; "
 			  "config->dmic.num_pdm_active = %u; "
 			  "config->dmic.pdm[0].enable_mic_a = %u; "
-			  "config->dmic.pdm[0].enable_mic_b = %u; "
-			  "dev->frame_bytes = %u", config->dmic.fifo_bits_a,
-			  config->dmic.num_pdm_active,
+			  "config->dmic.pdm[0].enable_mic_b = %u;",
+			  config->dmic.fifo_bits_a, config->dmic.num_pdm_active,
 			  config->dmic.pdm[0].enable_mic_a,
-			  config->dmic.pdm[0].enable_mic_b,
+			  config->dmic.pdm[0].enable_mic_b);
+		trace_dai("dai_config(), dev->frame_bytes = %u",
 			  dev->frame_bytes);
 		break;
 	case SOF_DAI_INTEL_HDA:

--- a/src/include/sof/panic.h
+++ b/src/include/sof/panic.h
@@ -86,7 +86,7 @@ static inline void panic_rewind(uint32_t p, uint32_t stack_rewind_frames,
 /* panic dump filename and linenumber of the call */
 #define panic(x) __panic((x), (__FILE__), (__LINE__))
 
-static inline void __panic(uint32_t p, char *filename, uint32_t linenum)
+static void __panic(uint32_t p, char *filename, uint32_t linenum)
 {
 	struct sof_ipc_panic_info panicinfo;
 	int strlen;

--- a/src/include/sof/trace.h
+++ b/src/include/sof/trace.h
@@ -200,19 +200,9 @@ _TRACE_EVENT_NTH_DECLARE_GROUP(3)
  */
 _TRACE_EVENT_NTH_DECLARE_GROUP(4)
 
-/* Declaration of
- * void _trace_event5            (uint32_t log_entry, uint32_t ids...,
- *                                uint32_t params...);
- * void _trace_event_mbox5       (uint32_t log_entry, uint32_t ids...,
- *                                uint32_t params...);
- * void _trace_event_atomic5     (uint32_t log_entry, uint32_t ids...,
- *                                uint32_t params...);
- * void _trace_event_mbox_atomic5(uint32_t log_entry, uint32_t ids...,
- *                                uint32_t params...);
- */
-_TRACE_EVENT_NTH_DECLARE_GROUP(5)
 #endif
-#define _TRACE_EVENT_MAX_ARGUMENT_COUNT 5
+
+#define _TRACE_EVENT_MAX_ARGUMENT_COUNT 4
 
 void trace_flush(void);
 void trace_off(void);

--- a/src/lib/trace.c
+++ b/src/lib/trace.c
@@ -223,18 +223,6 @@ _TRACE_EVENT_NTH_IMPL_GROUP(3)
  */
 _TRACE_EVENT_NTH_IMPL_GROUP(4)
 
-/* Implementation of
- * void _trace_event5(            uintptr_t log_entry, uint32_t ids...,
- *                                uint32_t params...) {...}
- * void _trace_event_mbox5(       uintptr_t log_entry, uint32_t ids...,
- *                                uint32_t params...) {...}
- * void _trace_event_atomic5(     uintptr_t log_entry, uint32_t ids...,
- *                                uint32_t params...) {...}
- * void _trace_event_mbox_atomic5(uintptr_t log_entry, uint32_t ids...,
- *                                uint32_t params...) {...}
- */
-_TRACE_EVENT_NTH_IMPL_GROUP(5)
-
 void trace_flush(void)
 {
 	volatile uint64_t *t;


### PR DESCRIPTION
Removed 5 parameter trace_event macro implementation.
Removed inline
specifier from __panic function definition.
I've observed, that recent growth of .text section size was caused
by 2 major factors: 2 instances of inlined __panic function
yielding 1.7kB and recent addition of 5 param trace_event
yeilding 0.5kB of used .text. section space.

Signed-off-by: ArturX Kloniecki <arturx.kloniecki@linux.intel.com>