### PR TITLE
memory: increase HEAP_RT_COUNT256 size

### DIFF
--- a/src/platform/cannonlake/include/platform/memory.h
+++ b/src/platform/cannonlake/include/platform/memory.h
@@ -180,7 +180,7 @@
 /* Heap section sizes for module pool */
 #define HEAP_RT_COUNT64			256
 #define HEAP_RT_COUNT128		32
-#define HEAP_RT_COUNT256		64
+#define HEAP_RT_COUNT256		80
 #define HEAP_RT_COUNT512		32
 #define HEAP_RT_COUNT1024		4
 

--- a/src/platform/icelake/include/platform/memory.h
+++ b/src/platform/icelake/include/platform/memory.h
@@ -180,7 +180,7 @@
 /* Heap section sizes for module pool */
 #define HEAP_RT_COUNT64			256
 #define HEAP_RT_COUNT128		32
-#define HEAP_RT_COUNT256		64
+#define HEAP_RT_COUNT256		80
 #define HEAP_RT_COUNT512		32
 #define HEAP_RT_COUNT1024		4
 

--- a/src/platform/suecreek/include/platform/memory.h
+++ b/src/platform/suecreek/include/platform/memory.h
@@ -168,7 +168,7 @@
 /* Heap section sizes for module pool */
 #define HEAP_RT_COUNT64			256
 #define HEAP_RT_COUNT128		32
-#define HEAP_RT_COUNT256		64
+#define HEAP_RT_COUNT256		80
 #define HEAP_RT_COUNT512		32
 #define HEAP_RT_COUNT1024		4
 


### PR DESCRIPTION
This patch increases HEAP_RT_COUNT256 size from 64 to 80 on
cannonlake, icelake and suecreek.

Signed-off-by: Libin Yang <libin.yang@intel.com>
---
Increase HEAP_RT_COUNT256 on cnl, icl and sue based on Liam's suggestion.
The patch doesn't touch hsw and byt as it seems they are very different from others.