### PR TITLE
I2S: Not enough padding for 24/32b, 48kHz

### DIFF
--- a/src/drivers/intel/cavs/ssp.c
+++ b/src/drivers/intel/cavs/ssp.c
@@ -526,8 +526,8 @@ static inline int ssp_set_config(struct dai *dai,
 
 		slot_end_padding = frame_end_padding / 2;
 
-		if (slot_end_padding > 15) {
-			/* can't handle padding over 15 bits */
+		if (slot_end_padding > SOF_DAI_INTEL_SSP_SLOT_PADDING_MAX) {
+			/* too big padding */
 			trace_ssp_error("ecf");
 			ret = -EINVAL;
 			goto out;


### PR DESCRIPTION
This PR fixes a problem with I2S two channels 24b/32b, 48kHz which is currently not supported due to 
15 bits maximum padding limit.

Signed-off-by: Marcin Rajwa <marcin.rajwa@linux.intel.com>