### PR TITLE
dw-dma: fix dw_dma_work reschedule issue

### DIFF
--- a/src/drivers/intel/dw-dma.c
+++ b/src/drivers/intel/dw-dma.c
@@ -1069,15 +1069,14 @@ static uint64_t dw_dma_work(void *data, uint64_t delay)
 
 	tracev_dma("wrk");
 
-	/* skip if channel is not running */
 	if (p->chan[i].status != COMP_STATE_ACTIVE) {
 		trace_dma_error("eDs");
-		goto out;
+		/* skip if channel is not running */
+		return 0;
 	}
 
 	dw_dma_process_block(&p->chan[i], &next);
 
-out:
 	return next.size == DMA_RELOAD_END ? 0 : p->chan[i].timer_delay;
 }
 


### PR DESCRIPTION
If the channel is not running, we should remove the task of dma work.

This patch fixes the coverity issue below:
static uint64_t dw_dma_work(void *data, uint64_t delay)
1063{
1064 struct dma_id *dma_id = (struct dma_id *)data;
1065 struct dma *dma = dma_id->dma;
1066 struct dma_pdata p = dma_get_drvdata(dma);
1. var_decl: Declaring variable next without initializer.
1067 struct dma_sg_elem next;
1068 int i = dma_id->channel;
1069
1070 tracev_dma("wrk");
1071
1072 / skip if channel is not running */
2. Condition p->chan[i].status != 5, taking true branch.
1073 if (p->chan[i].status != COMP_STATE_ACTIVE) {
1074 trace_dma_error("eDs");
3. Jumping to label out.
1075 goto out;
1076 }
1077
1078 dw_dma_process_block(&p->chan[i], &next);
1079
1080out:

CID 324979 (#1 of 1): Uninitialized scalar variable (UNINIT)
4. uninit_use: Using uninitialized value next.size.
1081 return next.size == DMA_RELOAD_END ? 0 : p->chan[i].timer_delay;

Signed-off-by: Libin Yang <libin.yang@intel.com>