### PR TITLE
host: fix coverity check issue of error handling

### DIFF
--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -283,6 +283,9 @@ static int host_trigger(struct comp_dev *dev, int cmd)
 	switch (cmd) {
 	case COMP_TRIGGER_STOP:
 		ret = host_stop(dev);
+		/* host stop fails, let's return the errno */
+		if (ret)
+			goto out;
 		/* fall through */
 	case COMP_TRIGGER_XRUN:
 /* TODO: add attribute to dma interface and do run-time if() here */


### PR DESCRIPTION
When host stop fails, it should return the errno.

This patch fixes the coverity the below coverity check issue:

static int host_trigger(struct comp_dev *dev, int cmd)
273{
274 struct host_data *hd = comp_get_drvdata(dev);
275 int ret = 0;
276
277 trace_host("trg");
278
279 ret = comp_set_state(dev, cmd);
280 if (ret < 0)
281 goto out;
282
283 switch (cmd) {
284 case COMP_TRIGGER_STOP:

CID 324978 (#1 of 1): Unused value (UNUSED_VALUE)
returned_value: Assigning value from host_stop(dev) to ret here,
but that stored value is overwritten before it can be used.
285 ret = host_stop(dev);
286 /* fall through /
287 case COMP_TRIGGER_XRUN:
288/ TODO: add attribute to dma interface and do run-time if() here */
289#if defined CONFIG_DMA_GW
value_overwrite: Overwriting previous write to ret with value from
dma_stop(hd->dma, hd->chan).
290 ret = dma_stop(hd->dma, hd->chan);
291#endif

Signed-off-by: Libin Yang <libin.yang@intel.com>