### PR TITLE
dma: make sure the HDA DMA pointers are aligned after release

### DIFF
--- a/src/drivers/intel/cavs/hda-dma.c
+++ b/src/drivers/intel/cavs/hda-dma.c
@@ -90,6 +90,7 @@ trace_event(TRACE_CLASS_HOST, __e, ##__VA_ARGS__)
 #define HDA_STATE_PRELOAD	BIT(0)
 #define HDA_STATE_BF_WAIT	BIT(1)
 #define HDA_STATE_INIT		BIT(2)
+#define HDA_STATE_RELEASE	BIT(3)
 
 struct hda_chan_data {
 	struct dma *dma;
@@ -252,7 +253,7 @@ static int hda_dma_copy_ch(struct dma *dma, struct hda_chan_data *chan,
 		hda_dma_inc_fp(dma, chan->index, bytes);
 
 	spin_lock_irq(&dma->lock, flags);
-	if (chan->cb) {
+	if (chan->cb && !(chan->state & HDA_STATE_RELEASE)) {
 		next.src = DMA_RELOAD_LLI;
 		next.dest = DMA_RELOAD_LLI;
 		next.size = DMA_RELOAD_LLI;
@@ -286,14 +287,15 @@ static void hda_dma_init(struct dma *dma, int channel)
 	/* full buffer is copied at startup */
 	p->chan[channel].desc_avail = p->chan[channel].desc_count;
 
-	p->chan[channel].state &= ~HDA_STATE_INIT;
-
 	pm_runtime_put(PM_RUNTIME_HOST_DMA_L1, 0);
 
 	/* start link output transfer now */
-	if (p->chan[channel].direction == DMA_DIR_MEM_TO_DEV)
+	if (p->chan[channel].direction == DMA_DIR_MEM_TO_DEV &&
+	    !(p->chan[channel].state & HDA_STATE_RELEASE))
 		hda_dma_inc_link_fp(dma, channel,
 				    p->chan[channel].buffer_bytes);
+
+	p->chan[channel].state &= ~(HDA_STATE_INIT | HDA_STATE_RELEASE);
 
 	spin_unlock_irq(&dma->lock, flags);
 }
@@ -301,6 +303,12 @@ static void hda_dma_init(struct dma *dma, int channel)
 static uint64_t hda_dma_work(void *data, uint64_t delay)
 {
 	struct hda_chan_data *chan = (struct hda_chan_data *)data;
+
+	/* align pointers on release */
+	if (chan->state & HDA_STATE_RELEASE) {
+		hda_dma_inc_link_fp(chan->dma, chan->index,
+				    chan->period_bytes);
+	}
 
 	if (chan->state & HDA_STATE_INIT)
 		hda_dma_init(chan->dma, chan->index);
@@ -428,15 +436,20 @@ out:
 
 static int hda_dma_release(struct dma *dma, int channel)
 {
-	/* Implementation left for future alignment
-	 *of dma pointers (if needed)
-	 */
+	struct dma_pdata *p = dma_get_drvdata(dma);
+
 	uint32_t flags;
 
 	spin_lock_irq(&dma->lock, flags);
 
 	trace_host("hda-dma-release dma-ptr: %p channel-number: %u",
 			  (uint32_t)dma, channel);
+
+	/*
+	 * Prepare for the handling of release condition on the first work cb.
+	 * This flag will be unset afterwards.
+	 */
+	p->chan[channel].state |= HDA_STATE_RELEASE;
 
 	spin_unlock_irq(&dma->lock, flags);
 	return 0;
@@ -477,6 +490,7 @@ static int hda_dma_stop(struct dma *dma, int channel)
 	/* disable the channel */
 	hda_update_bits(dma, channel, DGCS, DGCS_GEN | DGCS_FIFORDY, 0);
 	p->chan[channel].status = COMP_STATE_PREPARE;
+	p->chan[channel].state = 0;
 
 	spin_unlock_irq(&dma->lock, flags);
 	return 0;


### PR DESCRIPTION
After release the DMA pointers are prone to getting misaligned with the DAI software pointers due to additional buffer operations that happen on release trigger. This is a temporary measure to circumvent that.

Signed-off-by: Slawomir Blauciak <slawomir.blauciak@linux.intel.com>