### PR TITLE
EQ: Remove redundant binary configuration data check code

### DIFF
--- a/src/audio/eq_fir.c
+++ b/src/audio/eq_fir.c
@@ -579,12 +579,6 @@ static int fir_cmd_set_data(struct comp_dev *dev,
 		eq_fir_free_parameters(&cd->config);
 
 		/* Copy new config, find size from header */
-		if (!cdata->data->data) {
-			trace_eq_error("fir_cmd_set_data() error: "
-				       "invalid cdata->data->data");
-			return -EINVAL;
-		}
-
 		cfg = (struct sof_eq_fir_config *)cdata->data->data;
 		bs = cfg->size;
 		trace_eq("fir_cmd_set_data(): blob size: %u", bs);

--- a/src/audio/eq_iir.c
+++ b/src/audio/eq_iir.c
@@ -665,12 +665,6 @@ static int iir_cmd_set_data(struct comp_dev *dev,
 		eq_iir_free_parameters(&cd->config);
 
 		/* Copy new config, find size from header */
-		if (!cdata->data->data) {
-			trace_eq_error("iir_cmd_set_data() error: "
-				       "invalid cdata->data->data");
-			return -EINVAL;
-		}
-
 		cfg = (struct sof_eq_iir_config *)cdata->data->data;
 		bs = cfg->size;
 		trace_eq("iir_cmd_set_data(), blob size = %u", bs);


### PR DESCRIPTION
This patch removes from FIR and IIR EQs the check if array data pointer
is null. Since it is an array the test evaluates as true and the check is
unnecessary.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>