### PR TITLE
IPC: DMIC: Add clock start and clock change time delay parameters

### DIFF
--- a/src/include/uapi/ipc/dai-intel.h
+++ b/src/include/uapi/ipc/dai-intel.h
@@ -164,6 +164,14 @@ struct sof_ipc_dai_dmic_pdm_ctrl {
  * The microphone clock needs to be usually about 50-80 times the used audio
  * sample rate. With highest sample rates above 48 kHz this can relaxed
  * somewhat.
+ *
+ * The parameter wake_up_time describes how long time the microphone needs
+ * for the data line to produce valid output from mic clock start. The driver
+ * will mute the captured audio for the given time. The min_clock_on_time
+ * parameter is used to prevent too short clock bursts to happen. The driver
+ * will keep the clock active after capture stop if this time is not yet
+ * met. The unit for both is microseconds (us). Exceed of 100 ms will be
+ * treated as an error.
  */
 struct sof_ipc_dai_dmic_params {
 	uint32_t driver_ipc_version;	/**< Version (1..N) */
@@ -181,8 +189,11 @@ struct sof_ipc_dai_dmic_params {
 
 	uint32_t num_pdm_active; /**< Number of active pdm controllers */
 
+	uint32_t wake_up_time;      /**< Time from clock start to data (us) */
+	uint32_t min_clock_on_time; /**< Min. time that clk is kept on (us) */
+
 	/* reserved for future use */
-	uint32_t reserved[8];
+	uint32_t reserved[6];
 
 	/**< variable number of pdm controller config */
 	struct sof_ipc_dai_dmic_pdm_ctrl pdm[0];


### PR DESCRIPTION
This patch adds as a reservation to DMIC configuration IPC times in
microseconds for expected settle to valid data from clock start and
from clock rate change. That start sequence muting can utilize these
instead of hard coded values. These values can be also used to prevent
the driver to clock the microphone for a too short time.

The reserved[] vector is reduced by the amount of added words.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>