### PR TITLE
clk: trace error on wrong clock type

### DIFF
--- a/src/include/sof/clk.h
+++ b/src/include/sof/clk.h
@@ -49,7 +49,7 @@ struct freq_table {
 	uint32_t enc;
 };
 
-uint32_t clock_set_freq(int clock, uint32_t hz);
+void clock_set_freq(int clock, uint32_t hz);
 
 uint64_t clock_ms_to_ticks(int clock, uint64_t ms);
 

--- a/src/include/sof/trace.h
+++ b/src/include/sof/trace.h
@@ -107,6 +107,7 @@
 #define TRACE_CLASS_POWER	(23 << 24)
 #define TRACE_CLASS_IDC		(24 << 24)
 #define TRACE_CLASS_CPU		(25 << 24)
+#define TRACE_CLASS_CLK		(26 << 24)
 
 /* move to config.h */
 #define TRACE	1


### PR DESCRIPTION
Avoids null dereference in clock_set_freq in case
of wrong clock type.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>