### PR TITLE
Sue Creek: enable booting by loading over SPI

### DIFF
--- a/src/arch/xtensa/Makefile.am
+++ b/src/arch/xtensa/Makefile.am
@@ -175,6 +175,11 @@ boot_ldr_LDADD = \
 	libreset.a \
 	-lgcc
 
+if BUILD_SUECREEK
+boot_ldr_LDADD += \
+	../../drivers/libdrivers.la
+endif
+
 if BUILD_XTENSA_SMP
 boot_ldr_LDADD += \
 	smp/hal/libhal.a
@@ -198,7 +203,9 @@ boot_ldr-local:
 	$(OBJDUMP) -S boot_ldr > boot_ldr-$(FW_NAME).lst
 	$(OBJDUMP) -D boot_ldr > boot_ldr-$(FW_NAME).dis
 
+if !BUILD_SUECREEK
 RIMAGE_BOOT_FLAGS += boot_ldr-$(FW_NAME)
+endif
 BIN_FLAGS +=boot_ldr-local
 endif
 

--- a/src/arch/xtensa/boot_loader.c
+++ b/src/arch/xtensa/boot_loader.c
@@ -107,6 +107,13 @@ static void parse_module(struct sof_man_fw_header *hdr,
 	}
 }
 
+/* On Sue Creek the boot loader is attached separately, no need to skip it */
+#ifdef CONFIG_SUECREEK
+#define MAN_SKIP_ENTRIES 0
+#else
+#define MAN_SKIP_ENTRIES 1
+#endif
+
 /* parse FW manifest and copy modules */
 static void parse_manifest(void)
 {
@@ -117,7 +124,7 @@ static void parse_manifest(void)
 	int i;
 
 	/* copy module to SRAM  - skip bootloader module */
-	for (i = 1; i < hdr->num_module_entries; i++) {
+	for (i = MAN_SKIP_ENTRIES; i < hdr->num_module_entries; i++) {
 
 		platform_trace_point(TRACE_BOOT_LDR_PARSE_MODULE + i);
 		mod = sof_man_get_module(desc, i);

--- a/src/arch/xtensa/up/xtos/reset-vector.S
+++ b/src/arch/xtensa/up/xtos/reset-vector.S
@@ -581,7 +581,7 @@ unpackdone:
 
 #if CONFIG_BOOT_LOADER
 		/*ToDo refine the _start*/
-		movi a0, SOF_TEXT_START
+		movi a0, SOF_TEXT_BASE
 		callx0 a0
 #else
 		call0	_start		// jump to _start (in crt1-*.S)

--- a/src/platform/suecreek/include/platform/memory.h
+++ b/src/platform/suecreek/include/platform/memory.h
@@ -162,6 +162,9 @@
 #define HP_SRAM_BASE		0xBE000000
 #define HP_SRAM_SIZE		0x002F0000 /* Should be 48 * 64 - 0x300000 ?? */
 
+#define REEF_LOAD_OFFSET	0x00100000
+#define REEF_LOAD_BASE		(HP_SRAM_BASE + REEF_LOAD_OFFSET)
+
 /* HP SRAM Base */
 #define HP_SRAM_VECBASE_RESET	(HP_SRAM_BASE + 0x40000)
 
@@ -331,19 +334,28 @@
 #define SOF_MEM_RO_SIZE			0x8
 
 /* code loader */
-#define BOOT_LDR_TEXT_ENTRY_BASE	0xBE000000
+#define BOOT_LDR_TEXT_ENTRY_BASE	REEF_LOAD_BASE
 #define BOOT_LDR_TEXT_ENTRY_SIZE	0x400
 #define BOOT_LDR_LIT_BASE		(BOOT_LDR_TEXT_ENTRY_BASE + BOOT_LDR_TEXT_ENTRY_SIZE)
 #define BOOT_LDR_LIT_SIZE		0x400
 #define BOOT_LDR_TEXT_BASE		(BOOT_LDR_LIT_BASE + BOOT_LDR_LIT_SIZE)
-#define BOOT_LDR_TEXT_SIZE		0x800
+#define BOOT_LDR_TEXT_SIZE		0x1800
 #define BOOT_LDR_DATA_BASE		(BOOT_LDR_TEXT_BASE + BOOT_LDR_TEXT_SIZE)
 #define BOOT_LDR_DATA_SIZE		0x1000
 #define BOOT_LDR_BSS_BASE		(BOOT_LDR_DATA_BASE + BOOT_LDR_DATA_SIZE)
 #define BOOT_LDR_BSS_SIZE		0x100
 
 /* TODO: set this value */
-#define BOOT_LDR_MANIFEST_BASE		0x55aa55aa
+#define MAN_DESC_OFFSET			0x2000	/* from rimage/manifest.h */
+/*
+ * This is a temporary hack until rimage is updated to handle Sue Creek:
+ * currently the resuult of "xtensa-...-objdump -O binary sof-sue" is about
+ * 8250 bytes, reserve 9K for it and create a firmware image with something like
+ * dd if=/dev/zero bs=1 count=$(expr 9216 - $(stat --print=%s boot_ldr-sue.bin)) >> boot_ldr-sue.bin
+ * cat boot_ldr-sue.bin sof-sue.ri > /tmp/sue.img
+ */
+#define BOOT_LDR_MAX_SIZE		(1024 * 9)
+#define BOOT_LDR_MANIFEST_BASE		(REEF_LOAD_BASE + BOOT_LDR_MAX_SIZE + MAN_DESC_OFFSET)
 
 /* code lodar entry point for base fw */
 #define SRAM_VECBASE_RESET	(BOOT_LDR_BSS_BASE + BOOT_LDR_BSS_SIZE)


### PR DESCRIPTION
Tested: boots. To create an image something like this can be used:

```
dd if=/dev/zero bs=1 count=$(expr 9216 - $(stat --print=%s src/arch/xtensa/boot_ldr-sue.bin)) | \
cat src/arch/xtensa/boot_ldr-sue.bin - > /tmp/boot_ldr-sue.bin
cat /tmp/boot_ldr-sue.bin src/arch/xtensa/sof-sue.ri > /tmp/sue.ri
```