### PR TITLE
Build simple ROMs for CI testing of APL etc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -413,6 +413,8 @@ AM_CONDITIONAL(BUILD_BOOTLOADER,  test "$FW_NAME" = "apl" -o "$FW_NAME" = "cnl" 
 AM_CONDITIONAL(BUILD_CAVS,  test "$FW_NAME" = "apl" -o "$FW_NAME" = "cnl" -o "$FW_NAME" = "icl" -o "$FW_NAME" = "sue" -o "$FW_NAME" = "skl" -o "$FW_NAME" = "kbl")
 AM_CONDITIONAL(BUILD_MODULE,  test "$FW_NAME" = "apl" -o "$FW_NAME" = "cnl" -o "$FW_NAME" = "icl" -o "$FW_NAME" = "sue" -o "$FW_NAME" = "skl" -o "$FW_NAME" = "kbl")
 AM_CONDITIONAL(BUILD_APL_SSP,  test "$FW_NAME" = "apl" -o "$FW_NAME" = "cnl" -o "$FW_NAME" = "icl" -o "$FW_NAME" = "sue" -o "$FW_NAME" = "skl" -o "$FW_NAME" = "kbl")
+AM_CONDITIONAL(BUILD_VM_ROM,  test "$FW_NAME" = "apl" -o "$FW_NAME" = "cnl" -o "$FW_NAME" = "icl" -o "$FW_NAME" = "sue" -o "$FW_NAME" = "skl" -o "$FW_NAME" = "kbl")
+
 
 # DSP core support (Optional)
 AC_ARG_WITH([dsp-core],
@@ -426,6 +428,9 @@ case "$with_dsp_core" in
     ;;
 
 esac
+
+PLATFORM_ROM_LDSCRIPT="rom.x"
+AC_SUBST(PLATFORM_ROM_LDSCRIPT)
 
 PLATFORM_BOOT_LDR_LDSCRIPT="boot_ldr.x"
 AC_SUBST(PLATFORM_BOOT_LDR_LDSCRIPT)

--- a/src/arch/xtensa/Makefile.am
+++ b/src/arch/xtensa/Makefile.am
@@ -202,6 +202,66 @@ RIMAGE_BOOT_FLAGS += boot_ldr-$(FW_NAME)
 BIN_FLAGS +=boot_ldr-local
 endif
 
+if BUILD_VM_ROM
+
+# ROM
+noinst_PROGRAMS += \
+	rom
+
+LINK_ROM_SCRIPT = ../../platform/$(PLATFORM)/$(PLATFORM_ROM_LDSCRIPT)
+BUILT_SOURCES += $(LINK_ROM_SCRIPT)
+CLEANFILES += $(LINK_ROM_SCRIPT)
+
+nodist_rom_SOURCES = $(LINK_ROM_SCRIPT).in
+$(LINK_ROM_SCRIPT): Makefile $(LINK_ROM_SCRIPT).in $(LINK_DEPS)
+	cat $(LINK_ROM_SCRIPT).in | $(CPP) -P $(PLATFORM_INCDIR) $(SOF_INCDIR) $(ARCH_INCDIR) - >$@
+
+rom_LDADD = \
+	-lgcc
+
+# SMP ROM uses UP CRT1
+if BUILD_XTENSA_SMP
+rom_SOURCES = \
+	smp/xtos/memctl_default.S \
+	smp/xtos/reset-vector.S \
+	up/xtos/crt1-boards.S
+else
+rom_SOURCES = \
+	up/xtos/reset-vector.S \
+	up/xtos/crt1-boards.S
+endif
+
+rom_CFLAGS = \
+	$(ARCH_INCDIR) \
+	$(AM_CFLAGS) \
+	$(ARCH_CFLAGS) \
+	$(PLATFORM_INCDIR) \
+	$(SOF_INCDIR) \
+	-DCONFIG_VM_ROM
+
+rom_CCASFLAGS = \
+	$(ARCH_INCDIR) \
+	$(ASFLAGS) \
+	$(AM_CCASFLAGS) \
+	$(PLATFORM_INCDIR) \
+	-DCONFIG_VM_ROM
+
+rom_LDFLAGS = \
+	$(AM_LDFLAGS) \
+	$(ARCH_LDFLAGS) \
+	-T ../../platform/$(PLATFORM)/$(PLATFORM_ROM_LDSCRIPT)
+
+rom-local:
+	cp rom rom-$(FW_NAME)
+	$(OBJCOPY) -O binary rom rom-$(FW_NAME).bin
+	$(OBJDUMP) -h -D rom > rom-$(FW_NAME).map
+	$(OBJDUMP) -S rom > rom-$(FW_NAME).lst
+	$(OBJDUMP) -D rom > rom-$(FW_NAME).dis
+
+BIN_FLAGS += rom-local
+
+endif
+
 if BUILD_MODULE
 MODULE_COPY=$(OBJCOPY) -O binary ../../platform/$(PLATFORM)/module mod-$(FW_NAME).bin
 MODULE_INSERT=$(OBJCOPY) --add-section .module=mod-$(FW_NAME).bin \

--- a/src/arch/xtensa/Makefile.am
+++ b/src/arch/xtensa/Makefile.am
@@ -234,6 +234,5 @@ vminstall-local:
 
 clean-local:
 	rm -fr mod-*
-	rm -fr *.bin
 	rm -fr *.map
 	rm -fr *.dis

--- a/src/arch/xtensa/smp/xtos/reset-vector.S
+++ b/src/arch/xtensa/smp/xtos/reset-vector.S
@@ -564,7 +564,7 @@ unpackdone:
 	 */
 #if HAVE_XSR && (XCHAL_HAVE_XEA1 || XCHAL_HAVE_XEA2)
 
-#if !CONFIG_BOOT_LOADER
+#if !defined(CONFIG_BOOT_LOADER)  || defined(CONFIG_VM_ROM)
 # ifndef XCHAL_DEBUGLEVEL		/* debug option not selected? */
 #  define XCHAL_DEBUGLEVEL	99	/* bogus value outside 2..6 */
 # endif
@@ -615,7 +615,7 @@ unpackdone:
 	 *  Note:  This needs to be call0 regardless of the selected ABI.
 	 */
 
-#if CONFIG_BOOT_LOADER
+#if defined(CONFIG_BOOT_LOADER) && !defined(CONFIG_VM_ROM)
 	movi	a0, SOF_TEXT_START
 	callx0	a0
 #else

--- a/src/arch/xtensa/up/xtos/crt1-boards.S
+++ b/src/arch/xtensa/up/xtos/crt1-boards.S
@@ -29,6 +29,7 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include <xtensa/coreasm.h>
+#include <platform/memory.h>
 #include <config.h>
 // DF #include "xtos-internal.h"
 //#include <xtensa/../../src/xtos/xtos-internal.h>
@@ -93,6 +94,20 @@ _ResetVector:
 	.text
 	.align 4
 	.literal_position
+
+// VM ROM jumps to boot loader in IMR/SRAM
+#if defined(CONFIG_VM_ROM)
+
+#if defined(CONFIG_SUECREEK)
+_boot_ldr_entry:
+	.word BOOT_LDR_TEXT_ENTRY_BASE
+#else
+_boot_ldr_entry:
+	.word IMR_BOOT_LDR_TEXT_ENTRY_BASE
+#endif
+	.align 4
+#endif /* VM_ROM */
+
 _start:
 	//  _start is typically NOT at the beginning of the text segment --
 	//  it is always called from either the reset vector or other code
@@ -195,7 +210,7 @@ _start:
 1:
 
 /* boot loader takes care of zeroing BSS */
-#if !defined(CONFIG_BOOT_LOADER)
+#if !defined(CONFIG_BOOT_LOADER) && !defined(CONFIG_VM_ROM)
 	/*
 	 *  Clear the BSS (uninitialized data) segments.
 	 *  This code supports multiple zeroed sections (*.bss).
@@ -272,6 +287,20 @@ _start:
 	 */
 
 	//  Pass an empty argv array, with an empty string as the program name.
+
+	// VM ROM jumps to bootloader here.
+#if defined(CONFIG_VM_ROM)
+	l32r	a0, _boot_ldr_entry	// load SRAM reset handler address
+#if defined(CONFIG_SUECREEK)
+	callx8	a0		// jump to the handler
+#else
+	callx12	a0
+#endif
+dead:	nop
+	j dead
+
+#endif /* VM ROM */
+
 #if 0
 	movi	ARG1, _start_argc	// argc address
 	movi	ARG2, _start_argv	// argv = ["", 0]
@@ -281,6 +310,8 @@ _start:
 	l32i	ARG1, ARG1, 0		// argc = 1
 	CALL	__clibrary_init
 #endif
+
+#if !defined(CONFIG_VM_ROM)
 	//  Call:   int main(int argc, char ** argv, char ** environ);
 	movi	ARG1, _start_argc	// argc address
 	movi	ARG2, _start_argv	// argv = ["", 0]
@@ -291,6 +322,7 @@ _start:
 	//  as the first outgoing argument.
 //	CALL	exit			// exit with main's return value
 	// Does not return here.
+#endif
 
 	.data
 	//  Mark argc/argv/envp parameters as weak so that an external

--- a/src/arch/xtensa/up/xtos/reset-vector.S
+++ b/src/arch/xtensa/up/xtos/reset-vector.S
@@ -525,7 +525,7 @@ unpackdone:
 	 */
 #if HAVE_XSR
 
-#if !defined(CONFIG_BOOT_LOADER)
+#if !defined(CONFIG_BOOT_LOADER) || defined(CONFIG_VM_ROM)
 /*  For asm macros; works for positive a,b smaller than 1000:  */
 # define GREATERTHAN(a,b)	(((b)-(a)) & ~0xFFF)
 
@@ -579,7 +579,7 @@ unpackdone:
 	 *  Note:  This needs to be call0 regardless of the selected ABI.
 	 */
 
-#if CONFIG_BOOT_LOADER
+#if defined(CONFIG_BOOT_LOADER) && !defined(CONFIG_VM_ROM)
 		/*ToDo refine the _start*/
 		movi a0, SOF_TEXT_START
 		callx0 a0

--- a/src/platform/apollolake/rom.x.in
+++ b/src/platform/apollolake/rom.x.in
@@ -1,0 +1,353 @@
+/*
+ * Linker Script for Apollolake Bootloader.
+ *
+ * This script is run through the GNU C preprocessor to align the memory
+ * offsets with headers.
+ *
+ * Use spaces for formatting as cpp ignore tab sizes.
+ */
+
+#include <platform/memory.h>
+#include <xtensa/config/core-isa.h>
+
+OUTPUT_ARCH(xtensa)
+
+MEMORY
+{
+  vector_reset_text :
+        org = ROM_BASE,
+        len = 0x400
+  vector_reset_lit :
+        org = ROM_BASE + 0x400,
+        len = 0x100
+  vector_base_text :
+	org = ROM_BASE + 0x800,
+        len = SOF_MEM_VECBASE_LIT_SIZE
+  vector_int2_lit :
+        org = ROM_BASE + XCHAL_INTLEVEL2_VECOFS - SOF_MEM_VECT_LIT_SIZE,
+        len = SOF_MEM_VECT_LIT_SIZE
+  vector_int2_text :
+        org = ROM_BASE + XCHAL_INTLEVEL2_VECOFS,
+        len = SOF_MEM_VECT_TEXT_SIZE
+  vector_int3_lit :
+        org = ROM_BASE + XCHAL_INTLEVEL3_VECOFS - SOF_MEM_VECT_LIT_SIZE,
+        len = SOF_MEM_VECT_LIT_SIZE
+  vector_int3_text :
+        org = ROM_BASE + XCHAL_INTLEVEL3_VECOFS,
+        len = SOF_MEM_VECT_TEXT_SIZE
+  vector_int4_lit :
+        org = ROM_BASE + XCHAL_INTLEVEL4_VECOFS - SOF_MEM_VECT_LIT_SIZE,
+        len = SOF_MEM_VECT_LIT_SIZE
+  vector_int4_text :
+        org = ROM_BASE + XCHAL_INTLEVEL4_VECOFS,
+        len = SOF_MEM_VECT_TEXT_SIZE
+  vector_int5_lit :
+        org = ROM_BASE + XCHAL_INTLEVEL5_VECOFS - SOF_MEM_VECT_LIT_SIZE,
+        len = SOF_MEM_VECT_LIT_SIZE
+  vector_int5_text :
+        org = ROM_BASE + XCHAL_INTLEVEL5_VECOFS,
+        len = SOF_MEM_VECT_TEXT_SIZE
+  vector_int6_lit :
+        org = ROM_BASE + XCHAL_INTLEVEL6_VECOFS - SOF_MEM_VECT_LIT_SIZE,
+        len = SOF_MEM_VECT_LIT_SIZE
+  vector_int6_text :
+        org = ROM_BASE + XCHAL_INTLEVEL6_VECOFS,
+        len = SOF_MEM_VECT_TEXT_SIZE
+  vector_int7_lit :
+        org = ROM_BASE + XCHAL_INTLEVEL7_VECOFS - SOF_MEM_VECT_LIT_SIZE,
+        len = SOF_MEM_VECT_LIT_SIZE
+  vector_int7_text :
+        org = ROM_BASE + XCHAL_INTLEVEL7_VECOFS,
+        len = SOF_MEM_VECT_TEXT_SIZE
+  vector_kernel_lit :
+        org = ROM_BASE + XCHAL_KERNEL_VECOFS - SOF_MEM_VECT_LIT_SIZE,
+        len = SOF_MEM_VECT_LIT_SIZE
+  vector_kernel_text :
+        org = ROM_BASE + XCHAL_KERNEL_VECOFS,
+        len = SOF_MEM_VECT_TEXT_SIZE
+  vector_user_lit :
+        org = ROM_BASE + XCHAL_USER_VECOFS - SOF_MEM_VECT_LIT_SIZE,
+        len = SOF_MEM_VECT_LIT_SIZE
+  vector_user_text :
+        org = ROM_BASE + XCHAL_USER_VECOFS,
+        len = SOF_MEM_VECT_TEXT_SIZE
+  vector_double_lit :
+        org = ROM_BASE + XCHAL_DOUBLEEXC_VECOFS - SOF_MEM_VECT_LIT_SIZE,
+        len = SOF_MEM_VECT_LIT_SIZE
+  vector_double_text :
+        org = ROM_BASE + XCHAL_DOUBLEEXC_VECOFS,
+        len = SOF_MEM_VECT_TEXT_SIZE
+  sof_text :
+	org = ROM_BASE + 0x800,
+        len = ROM_SIZE,
+  sof_bss_data :
+	org = SOF_BSS_DATA_START,
+        len = SOF_BSS_DATA_SIZE
+  sof_stack :
+        org = SOF_STACK_END,
+        len = SOF_STACK_BASE - SOF_STACK_END
+}
+
+PHDRS
+{
+  vector_reset_text_phdr PT_LOAD;
+  vector_reset_lit_phdr PT_LOAD;
+  vector_base_text_phdr PT_LOAD;
+  vector_int2_lit_phdr PT_LOAD;
+  vector_int2_text_phdr PT_LOAD;
+  vector_int3_lit_phdr PT_LOAD;
+  vector_int3_text_phdr PT_LOAD;
+  vector_int4_lit_phdr PT_LOAD;
+  vector_int4_text_phdr PT_LOAD;
+  vector_int5_lit_phdr PT_LOAD;
+  vector_int5_text_phdr PT_LOAD;
+  vector_int6_lit_phdr PT_LOAD;
+  vector_int6_text_phdr PT_LOAD;
+  vector_int7_lit_phdr PT_LOAD;
+  vector_int7_text_phdr PT_LOAD;
+  vector_kernel_lit_phdr PT_LOAD;
+  vector_kernel_text_phdr PT_LOAD;
+  vector_user_lit_phdr PT_LOAD;
+  vector_user_text_phdr PT_LOAD;
+  vector_double_lit_phdr PT_LOAD;
+  vector_double_text_phdr PT_LOAD;
+  sof_text_phdr PT_LOAD;
+  sof_stack_phdr PT_LOAD;
+
+  static_log_entries_phdr PT_NOTE;
+}
+
+/*  Default entry point:  */
+ENTRY(_MainEntry)
+_rom_store_table = 0;
+
+/* ABI0 does not use Window base */
+PROVIDE(_memmap_vecbase_reset = ROM_BASE);
+
+/* Various memory-map dependent cache attribute settings: */
+_memmap_cacheattr_wbna_trapnull = 0xFF42FFF2;
+PROVIDE(_memmap_cacheattr_reset = _memmap_cacheattr_wbna_trapnull);
+
+SECTIONS
+{
+ .ResetVector.text : ALIGN(4)
+  {
+    _ResetVector_text_start = ABSOLUTE(.);
+    KEEP (*(.ResetVector.text))
+    _ResetVector_text_end = ABSOLUTE(.);
+  } >vector_reset_text :vector_reset_text_phdr
+
+  .ResetVector.literal : ALIGN(4)
+  {
+    _ResetVector_literal_start = ABSOLUTE(.);
+    *(.ResetVector.literal)
+    _ResetVector_literal_end = ABSOLUTE(.);
+  } >vector_reset_lit :vector_reset_lit_phdr
+
+  .WindowVectors.text : ALIGN(4)
+  {
+    _WindowVectors_text_start = ABSOLUTE(.);
+    KEEP (*(.WindowVectors.text))
+    _WindowVectors_text_end = ABSOLUTE(.);
+  } >vector_base_text :vector_base_text_phdr
+
+  .Level2InterruptVector.literal : ALIGN(4)
+  {
+    _Level2InterruptVector_literal_start = ABSOLUTE(.);
+    *(.Level2InterruptVector.literal)
+    _Level2InterruptVector_literal_end = ABSOLUTE(.);
+  } >vector_int2_lit :vector_int2_lit_phdr
+
+  .Level2InterruptVector.text : ALIGN(4)
+  {
+    _Level2InterruptVector_text_start = ABSOLUTE(.);
+    KEEP (*(.Level2InterruptVector.text))
+    _Level2InterruptVector_text_end = ABSOLUTE(.);
+  } >vector_int2_text :vector_int2_text_phdr
+
+  .Level3InterruptVector.literal : ALIGN(4)
+  {
+    _Level3InterruptVector_literal_start = ABSOLUTE(.);
+    *(.Level3InterruptVector.literal)
+    _Level3InterruptVector_literal_end = ABSOLUTE(.);
+  } >vector_int3_lit :vector_int3_lit_phdr
+
+  .Level3InterruptVector.text : ALIGN(4)
+  {
+    _Level3InterruptVector_text_start = ABSOLUTE(.);
+    KEEP (*(.Level3InterruptVector.text))
+    _Level3InterruptVector_text_end = ABSOLUTE(.);
+  } >vector_int3_text :vector_int3_text_phdr
+
+  .Level4InterruptVector.literal : ALIGN(4)
+  {
+    _Level4InterruptVector_literal_start = ABSOLUTE(.);
+    *(.Level4InterruptVector.literal)
+    _Level4InterruptVector_literal_end = ABSOLUTE(.);
+  } >vector_int4_lit :vector_int4_lit_phdr
+
+  .Level4InterruptVector.text : ALIGN(4)
+  {
+    _Level4InterruptVector_text_start = ABSOLUTE(.);
+    KEEP (*(.Level4InterruptVector.text))
+    _Level4InterruptVector_text_end = ABSOLUTE(.);
+  } >vector_int4_text :vector_int4_text_phdr
+
+  .Level5InterruptVector.literal : ALIGN(4)
+  {
+    _Level5InterruptVector_literal_start = ABSOLUTE(.);
+    *(.Level5InterruptVector.literal)
+    _Level5InterruptVector_literal_end = ABSOLUTE(.);
+  } >vector_int5_lit :vector_int5_lit_phdr
+
+  .Level5InterruptVector.text : ALIGN(4)
+  {
+    _Level5InterruptVector_text_start = ABSOLUTE(.);
+    KEEP (*(.Level5InterruptVector.text))
+    _Level5InterruptVector_text_end = ABSOLUTE(.);
+  } >vector_int5_text :vector_int5_text_phdr
+
+  .DebugExceptionVector.literal : ALIGN(4)
+  {
+    _DebugExceptionVector_literal_start = ABSOLUTE(.);
+    *(.DebugExceptionVector.literal)
+    _DebugExceptionVector_literal_end = ABSOLUTE(.);
+  } >vector_int6_lit :vector_int6_lit_phdr
+
+  .DebugExceptionVector.text : ALIGN(4)
+  {
+    _DebugExceptionVector_text_start = ABSOLUTE(.);
+    KEEP (*(.DebugExceptionVector.text))
+    _DebugExceptionVector_text_end = ABSOLUTE(.);
+  } >vector_int6_text :vector_int6_text_phdr
+
+  .NMIExceptionVector.literal : ALIGN(4)
+  {
+    _NMIExceptionVector_literal_start = ABSOLUTE(.);
+    *(.NMIExceptionVector.literal)
+    _NMIExceptionVector_literal_end = ABSOLUTE(.);
+  } >vector_int7_lit :vector_int7_lit_phdr
+
+  .NMIExceptionVector.text : ALIGN(4)
+  {
+    _NMIExceptionVector_text_start = ABSOLUTE(.);
+    KEEP (*(.NMIExceptionVector.text))
+    _NMIExceptionVector_text_end = ABSOLUTE(.);
+  } >vector_int7_text :vector_int7_text_phdr
+
+  .KernelExceptionVector.literal : ALIGN(4)
+  {
+    _KernelExceptionVector_literal_start = ABSOLUTE(.);
+    *(.KernelExceptionVector.literal)
+    _KernelExceptionVector_literal_end = ABSOLUTE(.);
+  } >vector_kernel_lit :vector_kernel_lit_phdr
+
+  .KernelExceptionVector.text : ALIGN(4)
+  {
+    _KernelExceptionVector_text_start = ABSOLUTE(.);
+    KEEP (*(.KernelExceptionVector.text))
+    _KernelExceptionVector_text_end = ABSOLUTE(.);
+  } >vector_kernel_text :vector_kernel_text_phdr
+
+  .UserExceptionVector.literal : ALIGN(4)
+  {
+    _UserExceptionVector_literal_start = ABSOLUTE(.);
+    *(.UserExceptionVector.literal)
+    _UserExceptionVector_literal_end = ABSOLUTE(.);
+  } >vector_user_lit :vector_user_lit_phdr
+
+  .UserExceptionVector.text : ALIGN(4)
+  {
+    _UserExceptionVector_text_start = ABSOLUTE(.);
+    KEEP (*(.UserExceptionVector.text))
+    _UserExceptionVector_text_end = ABSOLUTE(.);
+  } >vector_user_text :vector_user_text_phdr
+
+  .DoubleExceptionVector.literal : ALIGN(4)
+  {
+    _DoubleExceptionVector_literal_start = ABSOLUTE(.);
+    *(.DoubleExceptionVector.literal)
+    _DoubleExceptionVector_literal_end = ABSOLUTE(.);
+  } >vector_double_lit :vector_double_lit_phdr
+
+  .DoubleExceptionVector.text : ALIGN(4)
+  {
+    _DoubleExceptionVector_text_start = ABSOLUTE(.);
+    KEEP (*(.DoubleExceptionVector.text))
+    _DoubleExceptionVector_text_end = ABSOLUTE(.);
+  } >vector_double_text :vector_double_text_phdr
+
+  .text : ALIGN(4)
+  {
+    _stext = .;
+    _text_start = ABSOLUTE(.);
+    KEEP (*(.MainEntry.text))
+    *(.entry.text)
+    *(.init.literal)
+    KEEP(*(.init))
+    *(.literal .text .literal.* .text.* .stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.*)
+    *(.fini.literal)
+    KEEP(*(.fini))
+    *(.gnu.version)
+    _text_end = ABSOLUTE(.);
+    _etext = .;
+  } >sof_text :sof_text_phdr
+
+  /* stack */
+  _end = SOF_STACK_END;
+  PROVIDE(end = SOF_STACK_END);
+  _stack_sentry = SOF_STACK_END;
+  __stack = SOF_STACK_BASE;
+
+  .debug  0 :  { *(.debug) }
+  .line  0 :  { *(.line) }
+  .debug_srcinfo  0 :  { *(.debug_srcinfo) }
+  .debug_sfnames  0 :  { *(.debug_sfnames) }
+  .debug_aranges  0 :  { *(.debug_aranges) }
+  .debug_pubnames  0 :  { *(.debug_pubnames) }
+  .debug_info  0 :  { *(.debug_info) }
+  .debug_abbrev  0 :  { *(.debug_abbrev) }
+  .debug_line  0 :  { *(.debug_line) }
+  .debug_frame  0 :  { *(.debug_frame) }
+  .debug_str  0 :  { *(.debug_str) }
+  .debug_loc  0 :  { *(.debug_loc) }
+  .debug_macinfo  0 :  { *(.debug_macinfo) }
+  .debug_weaknames  0 :  { *(.debug_weaknames) }
+  .debug_funcnames  0 :  { *(.debug_funcnames) }
+  .debug_typenames  0 :  { *(.debug_typenames) }
+  .debug_varnames  0 :  { *(.debug_varnames) }
+
+  .xt.insn 0 :
+  {
+    KEEP (*(.xt.insn))
+    KEEP (*(.gnu.linkonce.x.*))
+  }
+  .xt.prop 0 :
+  {
+    KEEP (*(.xt.prop))
+    KEEP (*(.xt.prop.*))
+    KEEP (*(.gnu.linkonce.prop.*))
+  }
+  .xt.lit 0 :
+  {
+    KEEP (*(.xt.lit))
+    KEEP (*(.xt.lit.*))
+    KEEP (*(.gnu.linkonce.p.*))
+  }
+  .xt.profile_range 0 :
+  {
+    KEEP (*(.xt.profile_range))
+    KEEP (*(.gnu.linkonce.profile_range.*))
+  }
+  .xt.profile_ranges 0 :
+  {
+    KEEP (*(.xt.profile_ranges))
+    KEEP (*(.gnu.linkonce.xt.profile_ranges.*))
+  }
+  .xt.profile_files 0 :
+  {
+    KEEP (*(.xt.profile_files))
+    KEEP (*(.gnu.linkonce.xt.profile_files.*))
+  }
+}
+

--- a/src/platform/cannonlake/rom.x.in
+++ b/src/platform/cannonlake/rom.x.in
@@ -1,0 +1,350 @@
+/*
+ * Linker Script for Apollolake Bootloader.
+ *
+ * This script is run through the GNU C preprocessor to align the memory
+ * offsets with headers.
+ *
+ * Use spaces for formatting as cpp ignore tab sizes.
+ */
+
+#include <platform/memory.h>
+#include <xtensa/config/core-isa.h>
+
+OUTPUT_ARCH(xtensa)
+
+MEMORY
+{
+  vector_reset_text :
+        org = ROM_BASE,
+        len = 0x400
+  vector_reset_lit :
+        org = ROM_BASE + 0x400,
+        len = 0x100
+  vector_base_text :
+	org = ROM_BASE + 0x800,
+        len = SOF_MEM_VECBASE_LIT_SIZE
+  vector_int2_lit :
+        org = ROM_BASE + XCHAL_INTLEVEL2_VECOFS - SOF_MEM_VECT_LIT_SIZE,
+        len = SOF_MEM_VECT_LIT_SIZE
+  vector_int2_text :
+        org = ROM_BASE + XCHAL_INTLEVEL2_VECOFS,
+        len = SOF_MEM_VECT_TEXT_SIZE
+  vector_int3_lit :
+        org = ROM_BASE + XCHAL_INTLEVEL3_VECOFS - SOF_MEM_VECT_LIT_SIZE,
+        len = SOF_MEM_VECT_LIT_SIZE
+  vector_int3_text :
+        org = ROM_BASE + XCHAL_INTLEVEL3_VECOFS,
+        len = SOF_MEM_VECT_TEXT_SIZE
+  vector_int4_lit :
+        org = ROM_BASE + XCHAL_INTLEVEL4_VECOFS - SOF_MEM_VECT_LIT_SIZE,
+        len = SOF_MEM_VECT_LIT_SIZE
+  vector_int4_text :
+        org = ROM_BASE + XCHAL_INTLEVEL4_VECOFS,
+        len = SOF_MEM_VECT_TEXT_SIZE
+  vector_int5_lit :
+        org = ROM_BASE + XCHAL_INTLEVEL5_VECOFS - SOF_MEM_VECT_LIT_SIZE,
+        len = SOF_MEM_VECT_LIT_SIZE
+  vector_int5_text :
+        org = ROM_BASE + XCHAL_INTLEVEL5_VECOFS,
+        len = SOF_MEM_VECT_TEXT_SIZE
+  vector_int6_lit :
+        org = ROM_BASE + XCHAL_INTLEVEL6_VECOFS - SOF_MEM_VECT_LIT_SIZE,
+        len = SOF_MEM_VECT_LIT_SIZE
+  vector_int6_text :
+        org = ROM_BASE + XCHAL_INTLEVEL6_VECOFS,
+        len = SOF_MEM_VECT_TEXT_SIZE
+  vector_int7_lit :
+        org = ROM_BASE + XCHAL_INTLEVEL7_VECOFS - SOF_MEM_VECT_LIT_SIZE,
+        len = SOF_MEM_VECT_LIT_SIZE
+  vector_int7_text :
+        org = ROM_BASE + XCHAL_INTLEVEL7_VECOFS,
+        len = SOF_MEM_VECT_TEXT_SIZE
+  vector_kernel_lit :
+        org = ROM_BASE + XCHAL_KERNEL_VECOFS - SOF_MEM_VECT_LIT_SIZE,
+        len = SOF_MEM_VECT_LIT_SIZE
+  vector_kernel_text :
+        org = ROM_BASE + XCHAL_KERNEL_VECOFS,
+        len = SOF_MEM_VECT_TEXT_SIZE
+  vector_user_lit :
+        org = ROM_BASE + XCHAL_USER_VECOFS - SOF_MEM_VECT_LIT_SIZE,
+        len = SOF_MEM_VECT_LIT_SIZE
+  vector_user_text :
+        org = ROM_BASE + XCHAL_USER_VECOFS,
+        len = SOF_MEM_VECT_TEXT_SIZE
+  vector_double_lit :
+        org = ROM_BASE + XCHAL_DOUBLEEXC_VECOFS - SOF_MEM_VECT_LIT_SIZE,
+        len = SOF_MEM_VECT_LIT_SIZE
+  vector_double_text :
+        org = ROM_BASE + XCHAL_DOUBLEEXC_VECOFS,
+        len = SOF_MEM_VECT_TEXT_SIZE
+  sof_text :
+	org = ROM_BASE + 0x800,
+        len = ROM_SIZE,
+  sof_stack :
+        org = SOF_STACK_END,
+        len = SOF_STACK_BASE - SOF_STACK_END
+}
+
+PHDRS
+{
+  vector_reset_text_phdr PT_LOAD;
+  vector_reset_lit_phdr PT_LOAD;
+  vector_base_text_phdr PT_LOAD;
+  vector_int2_lit_phdr PT_LOAD;
+  vector_int2_text_phdr PT_LOAD;
+  vector_int3_lit_phdr PT_LOAD;
+  vector_int3_text_phdr PT_LOAD;
+  vector_int4_lit_phdr PT_LOAD;
+  vector_int4_text_phdr PT_LOAD;
+  vector_int5_lit_phdr PT_LOAD;
+  vector_int5_text_phdr PT_LOAD;
+  vector_int6_lit_phdr PT_LOAD;
+  vector_int6_text_phdr PT_LOAD;
+  vector_int7_lit_phdr PT_LOAD;
+  vector_int7_text_phdr PT_LOAD;
+  vector_kernel_lit_phdr PT_LOAD;
+  vector_kernel_text_phdr PT_LOAD;
+  vector_user_lit_phdr PT_LOAD;
+  vector_user_text_phdr PT_LOAD;
+  vector_double_lit_phdr PT_LOAD;
+  vector_double_text_phdr PT_LOAD;
+  sof_text_phdr PT_LOAD;
+  sof_stack_phdr PT_LOAD;
+
+  static_log_entries_phdr PT_NOTE;
+}
+
+/*  Default entry point:  */
+ENTRY(_MainEntry)
+_rom_store_table = 0;
+
+/* ABI0 does not use Window base */
+PROVIDE(_memmap_vecbase_reset = ROM_BASE);
+
+/* Various memory-map dependent cache attribute settings: */
+_memmap_cacheattr_wbna_trapnull = 0xFF42FFF2;
+PROVIDE(_memmap_cacheattr_reset = _memmap_cacheattr_wbna_trapnull);
+
+SECTIONS
+{
+ .ResetVector.text : ALIGN(4)
+  {
+    _ResetVector_text_start = ABSOLUTE(.);
+    KEEP (*(.ResetVector.text))
+    _ResetVector_text_end = ABSOLUTE(.);
+  } >vector_reset_text :vector_reset_text_phdr
+
+  .ResetVector.literal : ALIGN(4)
+  {
+    _ResetVector_literal_start = ABSOLUTE(.);
+    *(.ResetVector.literal)
+    _ResetVector_literal_end = ABSOLUTE(.);
+  } >vector_reset_lit :vector_reset_lit_phdr
+
+  .WindowVectors.text : ALIGN(4)
+  {
+    _WindowVectors_text_start = ABSOLUTE(.);
+    KEEP (*(.WindowVectors.text))
+    _WindowVectors_text_end = ABSOLUTE(.);
+  } >vector_base_text :vector_base_text_phdr
+
+  .Level2InterruptVector.literal : ALIGN(4)
+  {
+    _Level2InterruptVector_literal_start = ABSOLUTE(.);
+    *(.Level2InterruptVector.literal)
+    _Level2InterruptVector_literal_end = ABSOLUTE(.);
+  } >vector_int2_lit :vector_int2_lit_phdr
+
+  .Level2InterruptVector.text : ALIGN(4)
+  {
+    _Level2InterruptVector_text_start = ABSOLUTE(.);
+    KEEP (*(.Level2InterruptVector.text))
+    _Level2InterruptVector_text_end = ABSOLUTE(.);
+  } >vector_int2_text :vector_int2_text_phdr
+
+  .Level3InterruptVector.literal : ALIGN(4)
+  {
+    _Level3InterruptVector_literal_start = ABSOLUTE(.);
+    *(.Level3InterruptVector.literal)
+    _Level3InterruptVector_literal_end = ABSOLUTE(.);
+  } >vector_int3_lit :vector_int3_lit_phdr
+
+  .Level3InterruptVector.text : ALIGN(4)
+  {
+    _Level3InterruptVector_text_start = ABSOLUTE(.);
+    KEEP (*(.Level3InterruptVector.text))
+    _Level3InterruptVector_text_end = ABSOLUTE(.);
+  } >vector_int3_text :vector_int3_text_phdr
+
+  .Level4InterruptVector.literal : ALIGN(4)
+  {
+    _Level4InterruptVector_literal_start = ABSOLUTE(.);
+    *(.Level4InterruptVector.literal)
+    _Level4InterruptVector_literal_end = ABSOLUTE(.);
+  } >vector_int4_lit :vector_int4_lit_phdr
+
+  .Level4InterruptVector.text : ALIGN(4)
+  {
+    _Level4InterruptVector_text_start = ABSOLUTE(.);
+    KEEP (*(.Level4InterruptVector.text))
+    _Level4InterruptVector_text_end = ABSOLUTE(.);
+  } >vector_int4_text :vector_int4_text_phdr
+
+  .Level5InterruptVector.literal : ALIGN(4)
+  {
+    _Level5InterruptVector_literal_start = ABSOLUTE(.);
+    *(.Level5InterruptVector.literal)
+    _Level5InterruptVector_literal_end = ABSOLUTE(.);
+  } >vector_int5_lit :vector_int5_lit_phdr
+
+  .Level5InterruptVector.text : ALIGN(4)
+  {
+    _Level5InterruptVector_text_start = ABSOLUTE(.);
+    KEEP (*(.Level5InterruptVector.text))
+    _Level5InterruptVector_text_end = ABSOLUTE(.);
+  } >vector_int5_text :vector_int5_text_phdr
+
+  .DebugExceptionVector.literal : ALIGN(4)
+  {
+    _DebugExceptionVector_literal_start = ABSOLUTE(.);
+    *(.DebugExceptionVector.literal)
+    _DebugExceptionVector_literal_end = ABSOLUTE(.);
+  } >vector_int6_lit :vector_int6_lit_phdr
+
+  .DebugExceptionVector.text : ALIGN(4)
+  {
+    _DebugExceptionVector_text_start = ABSOLUTE(.);
+    KEEP (*(.DebugExceptionVector.text))
+    _DebugExceptionVector_text_end = ABSOLUTE(.);
+  } >vector_int6_text :vector_int6_text_phdr
+
+  .NMIExceptionVector.literal : ALIGN(4)
+  {
+    _NMIExceptionVector_literal_start = ABSOLUTE(.);
+    *(.NMIExceptionVector.literal)
+    _NMIExceptionVector_literal_end = ABSOLUTE(.);
+  } >vector_int7_lit :vector_int7_lit_phdr
+
+  .NMIExceptionVector.text : ALIGN(4)
+  {
+    _NMIExceptionVector_text_start = ABSOLUTE(.);
+    KEEP (*(.NMIExceptionVector.text))
+    _NMIExceptionVector_text_end = ABSOLUTE(.);
+  } >vector_int7_text :vector_int7_text_phdr
+
+  .KernelExceptionVector.literal : ALIGN(4)
+  {
+    _KernelExceptionVector_literal_start = ABSOLUTE(.);
+    *(.KernelExceptionVector.literal)
+    _KernelExceptionVector_literal_end = ABSOLUTE(.);
+  } >vector_kernel_lit :vector_kernel_lit_phdr
+
+  .KernelExceptionVector.text : ALIGN(4)
+  {
+    _KernelExceptionVector_text_start = ABSOLUTE(.);
+    KEEP (*(.KernelExceptionVector.text))
+    _KernelExceptionVector_text_end = ABSOLUTE(.);
+  } >vector_kernel_text :vector_kernel_text_phdr
+
+  .UserExceptionVector.literal : ALIGN(4)
+  {
+    _UserExceptionVector_literal_start = ABSOLUTE(.);
+    *(.UserExceptionVector.literal)
+    _UserExceptionVector_literal_end = ABSOLUTE(.);
+  } >vector_user_lit :vector_user_lit_phdr
+
+  .UserExceptionVector.text : ALIGN(4)
+  {
+    _UserExceptionVector_text_start = ABSOLUTE(.);
+    KEEP (*(.UserExceptionVector.text))
+    _UserExceptionVector_text_end = ABSOLUTE(.);
+  } >vector_user_text :vector_user_text_phdr
+
+  .DoubleExceptionVector.literal : ALIGN(4)
+  {
+    _DoubleExceptionVector_literal_start = ABSOLUTE(.);
+    *(.DoubleExceptionVector.literal)
+    _DoubleExceptionVector_literal_end = ABSOLUTE(.);
+  } >vector_double_lit :vector_double_lit_phdr
+
+  .DoubleExceptionVector.text : ALIGN(4)
+  {
+    _DoubleExceptionVector_text_start = ABSOLUTE(.);
+    KEEP (*(.DoubleExceptionVector.text))
+    _DoubleExceptionVector_text_end = ABSOLUTE(.);
+  } >vector_double_text :vector_double_text_phdr
+
+  .text : ALIGN(4)
+  {
+    _stext = .;
+    _text_start = ABSOLUTE(.);
+    KEEP (*(.MainEntry.text))
+    *(.entry.text)
+    *(.init.literal)
+    KEEP(*(.init))
+    *(.literal .text .literal.* .text.* .stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.*)
+    *(.fini.literal)
+    KEEP(*(.fini))
+    *(.gnu.version)
+    _text_end = ABSOLUTE(.);
+    _etext = .;
+  } >sof_text :sof_text_phdr
+
+  /* stack */
+  _end = SOF_STACK_END;
+  PROVIDE(end = SOF_STACK_END);
+  _stack_sentry = SOF_STACK_END;
+  __stack = SOF_STACK_BASE;
+
+  .debug  0 :  { *(.debug) }
+  .line  0 :  { *(.line) }
+  .debug_srcinfo  0 :  { *(.debug_srcinfo) }
+  .debug_sfnames  0 :  { *(.debug_sfnames) }
+  .debug_aranges  0 :  { *(.debug_aranges) }
+  .debug_pubnames  0 :  { *(.debug_pubnames) }
+  .debug_info  0 :  { *(.debug_info) }
+  .debug_abbrev  0 :  { *(.debug_abbrev) }
+  .debug_line  0 :  { *(.debug_line) }
+  .debug_frame  0 :  { *(.debug_frame) }
+  .debug_str  0 :  { *(.debug_str) }
+  .debug_loc  0 :  { *(.debug_loc) }
+  .debug_macinfo  0 :  { *(.debug_macinfo) }
+  .debug_weaknames  0 :  { *(.debug_weaknames) }
+  .debug_funcnames  0 :  { *(.debug_funcnames) }
+  .debug_typenames  0 :  { *(.debug_typenames) }
+  .debug_varnames  0 :  { *(.debug_varnames) }
+
+  .xt.insn 0 :
+  {
+    KEEP (*(.xt.insn))
+    KEEP (*(.gnu.linkonce.x.*))
+  }
+  .xt.prop 0 :
+  {
+    KEEP (*(.xt.prop))
+    KEEP (*(.xt.prop.*))
+    KEEP (*(.gnu.linkonce.prop.*))
+  }
+  .xt.lit 0 :
+  {
+    KEEP (*(.xt.lit))
+    KEEP (*(.xt.lit.*))
+    KEEP (*(.gnu.linkonce.p.*))
+  }
+  .xt.profile_range 0 :
+  {
+    KEEP (*(.xt.profile_range))
+    KEEP (*(.gnu.linkonce.profile_range.*))
+  }
+  .xt.profile_ranges 0 :
+  {
+    KEEP (*(.xt.profile_ranges))
+    KEEP (*(.gnu.linkonce.xt.profile_ranges.*))
+  }
+  .xt.profile_files 0 :
+  {
+    KEEP (*(.xt.profile_files))
+    KEEP (*(.gnu.linkonce.xt.profile_files.*))
+  }
+}
+

--- a/src/platform/icelake/rom.x.in
+++ b/src/platform/icelake/rom.x.in
@@ -1,0 +1,353 @@
+/*
+ * Linker Script for Apollolake Bootloader.
+ *
+ * This script is run through the GNU C preprocessor to align the memory
+ * offsets with headers.
+ *
+ * Use spaces for formatting as cpp ignore tab sizes.
+ */
+
+#include <platform/memory.h>
+#include <xtensa/config/core-isa.h>
+
+OUTPUT_ARCH(xtensa)
+
+MEMORY
+{
+  vector_reset_text :
+        org = ROM_BASE,
+        len = 0x400
+  vector_reset_lit :
+        org = ROM_BASE + 0x400,
+        len = 0x100
+  vector_base_text :
+	org = ROM_BASE + 0x800,
+        len = SOF_MEM_VECBASE_LIT_SIZE
+  vector_int2_lit :
+        org = ROM_BASE + XCHAL_INTLEVEL2_VECOFS - SOF_MEM_VECT_LIT_SIZE,
+        len = SOF_MEM_VECT_LIT_SIZE
+  vector_int2_text :
+        org = ROM_BASE + XCHAL_INTLEVEL2_VECOFS,
+        len = SOF_MEM_VECT_TEXT_SIZE
+  vector_int3_lit :
+        org = ROM_BASE + XCHAL_INTLEVEL3_VECOFS - SOF_MEM_VECT_LIT_SIZE,
+        len = SOF_MEM_VECT_LIT_SIZE
+  vector_int3_text :
+        org = ROM_BASE + XCHAL_INTLEVEL3_VECOFS,
+        len = SOF_MEM_VECT_TEXT_SIZE
+  vector_int4_lit :
+        org = ROM_BASE + XCHAL_INTLEVEL4_VECOFS - SOF_MEM_VECT_LIT_SIZE,
+        len = SOF_MEM_VECT_LIT_SIZE
+  vector_int4_text :
+        org = ROM_BASE + XCHAL_INTLEVEL4_VECOFS,
+        len = SOF_MEM_VECT_TEXT_SIZE
+  vector_int5_lit :
+        org = ROM_BASE + XCHAL_INTLEVEL5_VECOFS - SOF_MEM_VECT_LIT_SIZE,
+        len = SOF_MEM_VECT_LIT_SIZE
+  vector_int5_text :
+        org = ROM_BASE + XCHAL_INTLEVEL5_VECOFS,
+        len = SOF_MEM_VECT_TEXT_SIZE
+  vector_int6_lit :
+        org = ROM_BASE + XCHAL_INTLEVEL6_VECOFS - SOF_MEM_VECT_LIT_SIZE,
+        len = SOF_MEM_VECT_LIT_SIZE
+  vector_int6_text :
+        org = ROM_BASE + XCHAL_INTLEVEL6_VECOFS,
+        len = SOF_MEM_VECT_TEXT_SIZE
+  vector_int7_lit :
+        org = ROM_BASE + XCHAL_INTLEVEL7_VECOFS - SOF_MEM_VECT_LIT_SIZE,
+        len = SOF_MEM_VECT_LIT_SIZE
+  vector_int7_text :
+        org = ROM_BASE + XCHAL_INTLEVEL7_VECOFS,
+        len = SOF_MEM_VECT_TEXT_SIZE
+  vector_kernel_lit :
+        org = ROM_BASE + XCHAL_KERNEL_VECOFS - SOF_MEM_VECT_LIT_SIZE,
+        len = SOF_MEM_VECT_LIT_SIZE
+  vector_kernel_text :
+        org = ROM_BASE + XCHAL_KERNEL_VECOFS,
+        len = SOF_MEM_VECT_TEXT_SIZE
+  vector_user_lit :
+        org = ROM_BASE + XCHAL_USER_VECOFS - SOF_MEM_VECT_LIT_SIZE,
+        len = SOF_MEM_VECT_LIT_SIZE
+  vector_user_text :
+        org = ROM_BASE + XCHAL_USER_VECOFS,
+        len = SOF_MEM_VECT_TEXT_SIZE
+  vector_double_lit :
+        org = ROM_BASE + XCHAL_DOUBLEEXC_VECOFS - SOF_MEM_VECT_LIT_SIZE,
+        len = SOF_MEM_VECT_LIT_SIZE
+  vector_double_text :
+        org = ROM_BASE + XCHAL_DOUBLEEXC_VECOFS,
+        len = SOF_MEM_VECT_TEXT_SIZE
+  sof_text :
+	org = ROM_BASE + 0x800,
+        len = ROM_SIZE,
+  sof_bss_data :
+	org = SOF_BSS_DATA_START,
+        len = SOF_BSS_DATA_SIZE
+  sof_stack :
+        org = SOF_STACK_END,
+        len = SOF_STACK_BASE - SOF_STACK_END
+}
+
+PHDRS
+{
+  vector_reset_text_phdr PT_LOAD;
+  vector_reset_lit_phdr PT_LOAD;
+  vector_base_text_phdr PT_LOAD;
+  vector_int2_lit_phdr PT_LOAD;
+  vector_int2_text_phdr PT_LOAD;
+  vector_int3_lit_phdr PT_LOAD;
+  vector_int3_text_phdr PT_LOAD;
+  vector_int4_lit_phdr PT_LOAD;
+  vector_int4_text_phdr PT_LOAD;
+  vector_int5_lit_phdr PT_LOAD;
+  vector_int5_text_phdr PT_LOAD;
+  vector_int6_lit_phdr PT_LOAD;
+  vector_int6_text_phdr PT_LOAD;
+  vector_int7_lit_phdr PT_LOAD;
+  vector_int7_text_phdr PT_LOAD;
+  vector_kernel_lit_phdr PT_LOAD;
+  vector_kernel_text_phdr PT_LOAD;
+  vector_user_lit_phdr PT_LOAD;
+  vector_user_text_phdr PT_LOAD;
+  vector_double_lit_phdr PT_LOAD;
+  vector_double_text_phdr PT_LOAD;
+  sof_text_phdr PT_LOAD;
+  sof_stack_phdr PT_LOAD;
+
+  static_log_entries_phdr PT_NOTE;
+}
+
+/*  Default entry point:  */
+ENTRY(_MainEntry)
+_rom_store_table = 0;
+
+/* ABI0 does not use Window base */
+PROVIDE(_memmap_vecbase_reset = ROM_BASE);
+
+/* Various memory-map dependent cache attribute settings: */
+_memmap_cacheattr_wbna_trapnull = 0xFF42FFF2;
+PROVIDE(_memmap_cacheattr_reset = _memmap_cacheattr_wbna_trapnull);
+
+SECTIONS
+{
+ .ResetVector.text : ALIGN(4)
+  {
+    _ResetVector_text_start = ABSOLUTE(.);
+    KEEP (*(.ResetVector.text))
+    _ResetVector_text_end = ABSOLUTE(.);
+  } >vector_reset_text :vector_reset_text_phdr
+
+  .ResetVector.literal : ALIGN(4)
+  {
+    _ResetVector_literal_start = ABSOLUTE(.);
+    *(.ResetVector.literal)
+    _ResetVector_literal_end = ABSOLUTE(.);
+  } >vector_reset_lit :vector_reset_lit_phdr
+
+  .WindowVectors.text : ALIGN(4)
+  {
+    _WindowVectors_text_start = ABSOLUTE(.);
+    KEEP (*(.WindowVectors.text))
+    _WindowVectors_text_end = ABSOLUTE(.);
+  } >vector_base_text :vector_base_text_phdr
+
+  .Level2InterruptVector.literal : ALIGN(4)
+  {
+    _Level2InterruptVector_literal_start = ABSOLUTE(.);
+    *(.Level2InterruptVector.literal)
+    _Level2InterruptVector_literal_end = ABSOLUTE(.);
+  } >vector_int2_lit :vector_int2_lit_phdr
+
+  .Level2InterruptVector.text : ALIGN(4)
+  {
+    _Level2InterruptVector_text_start = ABSOLUTE(.);
+    KEEP (*(.Level2InterruptVector.text))
+    _Level2InterruptVector_text_end = ABSOLUTE(.);
+  } >vector_int2_text :vector_int2_text_phdr
+
+  .Level3InterruptVector.literal : ALIGN(4)
+  {
+    _Level3InterruptVector_literal_start = ABSOLUTE(.);
+    *(.Level3InterruptVector.literal)
+    _Level3InterruptVector_literal_end = ABSOLUTE(.);
+  } >vector_int3_lit :vector_int3_lit_phdr
+
+  .Level3InterruptVector.text : ALIGN(4)
+  {
+    _Level3InterruptVector_text_start = ABSOLUTE(.);
+    KEEP (*(.Level3InterruptVector.text))
+    _Level3InterruptVector_text_end = ABSOLUTE(.);
+  } >vector_int3_text :vector_int3_text_phdr
+
+  .Level4InterruptVector.literal : ALIGN(4)
+  {
+    _Level4InterruptVector_literal_start = ABSOLUTE(.);
+    *(.Level4InterruptVector.literal)
+    _Level4InterruptVector_literal_end = ABSOLUTE(.);
+  } >vector_int4_lit :vector_int4_lit_phdr
+
+  .Level4InterruptVector.text : ALIGN(4)
+  {
+    _Level4InterruptVector_text_start = ABSOLUTE(.);
+    KEEP (*(.Level4InterruptVector.text))
+    _Level4InterruptVector_text_end = ABSOLUTE(.);
+  } >vector_int4_text :vector_int4_text_phdr
+
+  .Level5InterruptVector.literal : ALIGN(4)
+  {
+    _Level5InterruptVector_literal_start = ABSOLUTE(.);
+    *(.Level5InterruptVector.literal)
+    _Level5InterruptVector_literal_end = ABSOLUTE(.);
+  } >vector_int5_lit :vector_int5_lit_phdr
+
+  .Level5InterruptVector.text : ALIGN(4)
+  {
+    _Level5InterruptVector_text_start = ABSOLUTE(.);
+    KEEP (*(.Level5InterruptVector.text))
+    _Level5InterruptVector_text_end = ABSOLUTE(.);
+  } >vector_int5_text :vector_int5_text_phdr
+
+  .DebugExceptionVector.literal : ALIGN(4)
+  {
+    _DebugExceptionVector_literal_start = ABSOLUTE(.);
+    *(.DebugExceptionVector.literal)
+    _DebugExceptionVector_literal_end = ABSOLUTE(.);
+  } >vector_int6_lit :vector_int6_lit_phdr
+
+  .DebugExceptionVector.text : ALIGN(4)
+  {
+    _DebugExceptionVector_text_start = ABSOLUTE(.);
+    KEEP (*(.DebugExceptionVector.text))
+    _DebugExceptionVector_text_end = ABSOLUTE(.);
+  } >vector_int6_text :vector_int6_text_phdr
+
+  .NMIExceptionVector.literal : ALIGN(4)
+  {
+    _NMIExceptionVector_literal_start = ABSOLUTE(.);
+    *(.NMIExceptionVector.literal)
+    _NMIExceptionVector_literal_end = ABSOLUTE(.);
+  } >vector_int7_lit :vector_int7_lit_phdr
+
+  .NMIExceptionVector.text : ALIGN(4)
+  {
+    _NMIExceptionVector_text_start = ABSOLUTE(.);
+    KEEP (*(.NMIExceptionVector.text))
+    _NMIExceptionVector_text_end = ABSOLUTE(.);
+  } >vector_int7_text :vector_int7_text_phdr
+
+  .KernelExceptionVector.literal : ALIGN(4)
+  {
+    _KernelExceptionVector_literal_start = ABSOLUTE(.);
+    *(.KernelExceptionVector.literal)
+    _KernelExceptionVector_literal_end = ABSOLUTE(.);
+  } >vector_kernel_lit :vector_kernel_lit_phdr
+
+  .KernelExceptionVector.text : ALIGN(4)
+  {
+    _KernelExceptionVector_text_start = ABSOLUTE(.);
+    KEEP (*(.KernelExceptionVector.text))
+    _KernelExceptionVector_text_end = ABSOLUTE(.);
+  } >vector_kernel_text :vector_kernel_text_phdr
+
+  .UserExceptionVector.literal : ALIGN(4)
+  {
+    _UserExceptionVector_literal_start = ABSOLUTE(.);
+    *(.UserExceptionVector.literal)
+    _UserExceptionVector_literal_end = ABSOLUTE(.);
+  } >vector_user_lit :vector_user_lit_phdr
+
+  .UserExceptionVector.text : ALIGN(4)
+  {
+    _UserExceptionVector_text_start = ABSOLUTE(.);
+    KEEP (*(.UserExceptionVector.text))
+    _UserExceptionVector_text_end = ABSOLUTE(.);
+  } >vector_user_text :vector_user_text_phdr
+
+  .DoubleExceptionVector.literal : ALIGN(4)
+  {
+    _DoubleExceptionVector_literal_start = ABSOLUTE(.);
+    *(.DoubleExceptionVector.literal)
+    _DoubleExceptionVector_literal_end = ABSOLUTE(.);
+  } >vector_double_lit :vector_double_lit_phdr
+
+  .DoubleExceptionVector.text : ALIGN(4)
+  {
+    _DoubleExceptionVector_text_start = ABSOLUTE(.);
+    KEEP (*(.DoubleExceptionVector.text))
+    _DoubleExceptionVector_text_end = ABSOLUTE(.);
+  } >vector_double_text :vector_double_text_phdr
+
+  .text : ALIGN(4)
+  {
+    _stext = .;
+    _text_start = ABSOLUTE(.);
+    KEEP (*(.MainEntry.text))
+    *(.entry.text)
+    *(.init.literal)
+    KEEP(*(.init))
+    *(.literal .text .literal.* .text.* .stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.*)
+    *(.fini.literal)
+    KEEP(*(.fini))
+    *(.gnu.version)
+    _text_end = ABSOLUTE(.);
+    _etext = .;
+  } >sof_text :sof_text_phdr
+
+  /* stack */
+  _end = SOF_STACK_END;
+  PROVIDE(end = SOF_STACK_END);
+  _stack_sentry = SOF_STACK_END;
+  __stack = SOF_STACK_BASE;
+
+  .debug  0 :  { *(.debug) }
+  .line  0 :  { *(.line) }
+  .debug_srcinfo  0 :  { *(.debug_srcinfo) }
+  .debug_sfnames  0 :  { *(.debug_sfnames) }
+  .debug_aranges  0 :  { *(.debug_aranges) }
+  .debug_pubnames  0 :  { *(.debug_pubnames) }
+  .debug_info  0 :  { *(.debug_info) }
+  .debug_abbrev  0 :  { *(.debug_abbrev) }
+  .debug_line  0 :  { *(.debug_line) }
+  .debug_frame  0 :  { *(.debug_frame) }
+  .debug_str  0 :  { *(.debug_str) }
+  .debug_loc  0 :  { *(.debug_loc) }
+  .debug_macinfo  0 :  { *(.debug_macinfo) }
+  .debug_weaknames  0 :  { *(.debug_weaknames) }
+  .debug_funcnames  0 :  { *(.debug_funcnames) }
+  .debug_typenames  0 :  { *(.debug_typenames) }
+  .debug_varnames  0 :  { *(.debug_varnames) }
+
+  .xt.insn 0 :
+  {
+    KEEP (*(.xt.insn))
+    KEEP (*(.gnu.linkonce.x.*))
+  }
+  .xt.prop 0 :
+  {
+    KEEP (*(.xt.prop))
+    KEEP (*(.xt.prop.*))
+    KEEP (*(.gnu.linkonce.prop.*))
+  }
+  .xt.lit 0 :
+  {
+    KEEP (*(.xt.lit))
+    KEEP (*(.xt.lit.*))
+    KEEP (*(.gnu.linkonce.p.*))
+  }
+  .xt.profile_range 0 :
+  {
+    KEEP (*(.xt.profile_range))
+    KEEP (*(.gnu.linkonce.profile_range.*))
+  }
+  .xt.profile_ranges 0 :
+  {
+    KEEP (*(.xt.profile_ranges))
+    KEEP (*(.gnu.linkonce.xt.profile_ranges.*))
+  }
+  .xt.profile_files 0 :
+  {
+    KEEP (*(.xt.profile_files))
+    KEEP (*(.gnu.linkonce.xt.profile_files.*))
+  }
+}
+

--- a/src/platform/suecreek/rom.x.in
+++ b/src/platform/suecreek/rom.x.in
@@ -1,0 +1,350 @@
+/*
+ * Linker Script for Apollolake Bootloader.
+ *
+ * This script is run through the GNU C preprocessor to align the memory
+ * offsets with headers.
+ *
+ * Use spaces for formatting as cpp ignore tab sizes.
+ */
+
+#include <platform/memory.h>
+#include <xtensa/config/core-isa.h>
+
+OUTPUT_ARCH(xtensa)
+
+MEMORY
+{
+  vector_reset_text :
+        org = ROM_BASE,
+        len = 0x400
+  vector_reset_lit :
+        org = ROM_BASE + 0x400,
+        len = 0x100
+  vector_base_text :
+	org = ROM_BASE + 0x800,
+        len = SOF_MEM_VECBASE_LIT_SIZE
+  vector_int2_lit :
+        org = ROM_BASE + XCHAL_INTLEVEL2_VECOFS - SOF_MEM_VECT_LIT_SIZE,
+        len = SOF_MEM_VECT_LIT_SIZE
+  vector_int2_text :
+        org = ROM_BASE + XCHAL_INTLEVEL2_VECOFS,
+        len = SOF_MEM_VECT_TEXT_SIZE
+  vector_int3_lit :
+        org = ROM_BASE + XCHAL_INTLEVEL3_VECOFS - SOF_MEM_VECT_LIT_SIZE,
+        len = SOF_MEM_VECT_LIT_SIZE
+  vector_int3_text :
+        org = ROM_BASE + XCHAL_INTLEVEL3_VECOFS,
+        len = SOF_MEM_VECT_TEXT_SIZE
+  vector_int4_lit :
+        org = ROM_BASE + XCHAL_INTLEVEL4_VECOFS - SOF_MEM_VECT_LIT_SIZE,
+        len = SOF_MEM_VECT_LIT_SIZE
+  vector_int4_text :
+        org = ROM_BASE + XCHAL_INTLEVEL4_VECOFS,
+        len = SOF_MEM_VECT_TEXT_SIZE
+  vector_int5_lit :
+        org = ROM_BASE + XCHAL_INTLEVEL5_VECOFS - SOF_MEM_VECT_LIT_SIZE,
+        len = SOF_MEM_VECT_LIT_SIZE
+  vector_int5_text :
+        org = ROM_BASE + XCHAL_INTLEVEL5_VECOFS,
+        len = SOF_MEM_VECT_TEXT_SIZE
+  vector_int6_lit :
+        org = ROM_BASE + XCHAL_INTLEVEL6_VECOFS - SOF_MEM_VECT_LIT_SIZE,
+        len = SOF_MEM_VECT_LIT_SIZE
+  vector_int6_text :
+        org = ROM_BASE + XCHAL_INTLEVEL6_VECOFS,
+        len = SOF_MEM_VECT_TEXT_SIZE
+  vector_int7_lit :
+        org = ROM_BASE + XCHAL_INTLEVEL7_VECOFS - SOF_MEM_VECT_LIT_SIZE,
+        len = SOF_MEM_VECT_LIT_SIZE
+  vector_int7_text :
+        org = ROM_BASE + XCHAL_INTLEVEL7_VECOFS,
+        len = SOF_MEM_VECT_TEXT_SIZE
+  vector_kernel_lit :
+        org = ROM_BASE + XCHAL_KERNEL_VECOFS - SOF_MEM_VECT_LIT_SIZE,
+        len = SOF_MEM_VECT_LIT_SIZE
+  vector_kernel_text :
+        org = ROM_BASE + XCHAL_KERNEL_VECOFS,
+        len = SOF_MEM_VECT_TEXT_SIZE
+  vector_user_lit :
+        org = ROM_BASE + XCHAL_USER_VECOFS - SOF_MEM_VECT_LIT_SIZE,
+        len = SOF_MEM_VECT_LIT_SIZE
+  vector_user_text :
+        org = ROM_BASE + XCHAL_USER_VECOFS,
+        len = SOF_MEM_VECT_TEXT_SIZE
+  vector_double_lit :
+        org = ROM_BASE + XCHAL_DOUBLEEXC_VECOFS - SOF_MEM_VECT_LIT_SIZE,
+        len = SOF_MEM_VECT_LIT_SIZE
+  vector_double_text :
+        org = ROM_BASE + XCHAL_DOUBLEEXC_VECOFS,
+        len = SOF_MEM_VECT_TEXT_SIZE
+  sof_text :
+	org = ROM_BASE + 0x800,
+        len = ROM_SIZE,
+  sof_stack :
+        org = SOF_STACK_END,
+        len = SOF_STACK_BASE - SOF_STACK_END
+}
+
+PHDRS
+{
+  vector_reset_text_phdr PT_LOAD;
+  vector_reset_lit_phdr PT_LOAD;
+  vector_base_text_phdr PT_LOAD;
+  vector_int2_lit_phdr PT_LOAD;
+  vector_int2_text_phdr PT_LOAD;
+  vector_int3_lit_phdr PT_LOAD;
+  vector_int3_text_phdr PT_LOAD;
+  vector_int4_lit_phdr PT_LOAD;
+  vector_int4_text_phdr PT_LOAD;
+  vector_int5_lit_phdr PT_LOAD;
+  vector_int5_text_phdr PT_LOAD;
+  vector_int6_lit_phdr PT_LOAD;
+  vector_int6_text_phdr PT_LOAD;
+  vector_int7_lit_phdr PT_LOAD;
+  vector_int7_text_phdr PT_LOAD;
+  vector_kernel_lit_phdr PT_LOAD;
+  vector_kernel_text_phdr PT_LOAD;
+  vector_user_lit_phdr PT_LOAD;
+  vector_user_text_phdr PT_LOAD;
+  vector_double_lit_phdr PT_LOAD;
+  vector_double_text_phdr PT_LOAD;
+  sof_text_phdr PT_LOAD;
+  sof_stack_phdr PT_LOAD;
+
+  static_log_entries_phdr PT_NOTE;
+}
+
+/*  Default entry point:  */
+ENTRY(_MainEntry)
+_rom_store_table = 0;
+
+/* ABI0 does not use Window base */
+PROVIDE(_memmap_vecbase_reset = ROM_BASE);
+
+/* Various memory-map dependent cache attribute settings: */
+_memmap_cacheattr_wbna_trapnull = 0xFF42FFF2;
+PROVIDE(_memmap_cacheattr_reset = _memmap_cacheattr_wbna_trapnull);
+
+SECTIONS
+{
+ .ResetVector.text : ALIGN(4)
+  {
+    _ResetVector_text_start = ABSOLUTE(.);
+    KEEP (*(.ResetVector.text))
+    _ResetVector_text_end = ABSOLUTE(.);
+  } >vector_reset_text :vector_reset_text_phdr
+
+  .ResetVector.literal : ALIGN(4)
+  {
+    _ResetVector_literal_start = ABSOLUTE(.);
+    *(.ResetVector.literal)
+    _ResetVector_literal_end = ABSOLUTE(.);
+  } >vector_reset_lit :vector_reset_lit_phdr
+
+  .WindowVectors.text : ALIGN(4)
+  {
+    _WindowVectors_text_start = ABSOLUTE(.);
+    KEEP (*(.WindowVectors.text))
+    _WindowVectors_text_end = ABSOLUTE(.);
+  } >vector_base_text :vector_base_text_phdr
+
+  .Level2InterruptVector.literal : ALIGN(4)
+  {
+    _Level2InterruptVector_literal_start = ABSOLUTE(.);
+    *(.Level2InterruptVector.literal)
+    _Level2InterruptVector_literal_end = ABSOLUTE(.);
+  } >vector_int2_lit :vector_int2_lit_phdr
+
+  .Level2InterruptVector.text : ALIGN(4)
+  {
+    _Level2InterruptVector_text_start = ABSOLUTE(.);
+    KEEP (*(.Level2InterruptVector.text))
+    _Level2InterruptVector_text_end = ABSOLUTE(.);
+  } >vector_int2_text :vector_int2_text_phdr
+
+  .Level3InterruptVector.literal : ALIGN(4)
+  {
+    _Level3InterruptVector_literal_start = ABSOLUTE(.);
+    *(.Level3InterruptVector.literal)
+    _Level3InterruptVector_literal_end = ABSOLUTE(.);
+  } >vector_int3_lit :vector_int3_lit_phdr
+
+  .Level3InterruptVector.text : ALIGN(4)
+  {
+    _Level3InterruptVector_text_start = ABSOLUTE(.);
+    KEEP (*(.Level3InterruptVector.text))
+    _Level3InterruptVector_text_end = ABSOLUTE(.);
+  } >vector_int3_text :vector_int3_text_phdr
+
+  .Level4InterruptVector.literal : ALIGN(4)
+  {
+    _Level4InterruptVector_literal_start = ABSOLUTE(.);
+    *(.Level4InterruptVector.literal)
+    _Level4InterruptVector_literal_end = ABSOLUTE(.);
+  } >vector_int4_lit :vector_int4_lit_phdr
+
+  .Level4InterruptVector.text : ALIGN(4)
+  {
+    _Level4InterruptVector_text_start = ABSOLUTE(.);
+    KEEP (*(.Level4InterruptVector.text))
+    _Level4InterruptVector_text_end = ABSOLUTE(.);
+  } >vector_int4_text :vector_int4_text_phdr
+
+  .Level5InterruptVector.literal : ALIGN(4)
+  {
+    _Level5InterruptVector_literal_start = ABSOLUTE(.);
+    *(.Level5InterruptVector.literal)
+    _Level5InterruptVector_literal_end = ABSOLUTE(.);
+  } >vector_int5_lit :vector_int5_lit_phdr
+
+  .Level5InterruptVector.text : ALIGN(4)
+  {
+    _Level5InterruptVector_text_start = ABSOLUTE(.);
+    KEEP (*(.Level5InterruptVector.text))
+    _Level5InterruptVector_text_end = ABSOLUTE(.);
+  } >vector_int5_text :vector_int5_text_phdr
+
+  .DebugExceptionVector.literal : ALIGN(4)
+  {
+    _DebugExceptionVector_literal_start = ABSOLUTE(.);
+    *(.DebugExceptionVector.literal)
+    _DebugExceptionVector_literal_end = ABSOLUTE(.);
+  } >vector_int6_lit :vector_int6_lit_phdr
+
+  .DebugExceptionVector.text : ALIGN(4)
+  {
+    _DebugExceptionVector_text_start = ABSOLUTE(.);
+    KEEP (*(.DebugExceptionVector.text))
+    _DebugExceptionVector_text_end = ABSOLUTE(.);
+  } >vector_int6_text :vector_int6_text_phdr
+
+  .NMIExceptionVector.literal : ALIGN(4)
+  {
+    _NMIExceptionVector_literal_start = ABSOLUTE(.);
+    *(.NMIExceptionVector.literal)
+    _NMIExceptionVector_literal_end = ABSOLUTE(.);
+  } >vector_int7_lit :vector_int7_lit_phdr
+
+  .NMIExceptionVector.text : ALIGN(4)
+  {
+    _NMIExceptionVector_text_start = ABSOLUTE(.);
+    KEEP (*(.NMIExceptionVector.text))
+    _NMIExceptionVector_text_end = ABSOLUTE(.);
+  } >vector_int7_text :vector_int7_text_phdr
+
+  .KernelExceptionVector.literal : ALIGN(4)
+  {
+    _KernelExceptionVector_literal_start = ABSOLUTE(.);
+    *(.KernelExceptionVector.literal)
+    _KernelExceptionVector_literal_end = ABSOLUTE(.);
+  } >vector_kernel_lit :vector_kernel_lit_phdr
+
+  .KernelExceptionVector.text : ALIGN(4)
+  {
+    _KernelExceptionVector_text_start = ABSOLUTE(.);
+    KEEP (*(.KernelExceptionVector.text))
+    _KernelExceptionVector_text_end = ABSOLUTE(.);
+  } >vector_kernel_text :vector_kernel_text_phdr
+
+  .UserExceptionVector.literal : ALIGN(4)
+  {
+    _UserExceptionVector_literal_start = ABSOLUTE(.);
+    *(.UserExceptionVector.literal)
+    _UserExceptionVector_literal_end = ABSOLUTE(.);
+  } >vector_user_lit :vector_user_lit_phdr
+
+  .UserExceptionVector.text : ALIGN(4)
+  {
+    _UserExceptionVector_text_start = ABSOLUTE(.);
+    KEEP (*(.UserExceptionVector.text))
+    _UserExceptionVector_text_end = ABSOLUTE(.);
+  } >vector_user_text :vector_user_text_phdr
+
+  .DoubleExceptionVector.literal : ALIGN(4)
+  {
+    _DoubleExceptionVector_literal_start = ABSOLUTE(.);
+    *(.DoubleExceptionVector.literal)
+    _DoubleExceptionVector_literal_end = ABSOLUTE(.);
+  } >vector_double_lit :vector_double_lit_phdr
+
+  .DoubleExceptionVector.text : ALIGN(4)
+  {
+    _DoubleExceptionVector_text_start = ABSOLUTE(.);
+    KEEP (*(.DoubleExceptionVector.text))
+    _DoubleExceptionVector_text_end = ABSOLUTE(.);
+  } >vector_double_text :vector_double_text_phdr
+
+  .text : ALIGN(4)
+  {
+    _stext = .;
+    _text_start = ABSOLUTE(.);
+    KEEP (*(.MainEntry.text))
+    *(.entry.text)
+    *(.init.literal)
+    KEEP(*(.init))
+    *(.literal .text .literal.* .text.* .stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.*)
+    *(.fini.literal)
+    KEEP(*(.fini))
+    *(.gnu.version)
+    _text_end = ABSOLUTE(.);
+    _etext = .;
+  } >sof_text :sof_text_phdr
+
+  /* stack */
+  _end = SOF_STACK_END;
+  PROVIDE(end = SOF_STACK_END);
+  _stack_sentry = SOF_STACK_END;
+  __stack = SOF_STACK_BASE;
+
+  .debug  0 :  { *(.debug) }
+  .line  0 :  { *(.line) }
+  .debug_srcinfo  0 :  { *(.debug_srcinfo) }
+  .debug_sfnames  0 :  { *(.debug_sfnames) }
+  .debug_aranges  0 :  { *(.debug_aranges) }
+  .debug_pubnames  0 :  { *(.debug_pubnames) }
+  .debug_info  0 :  { *(.debug_info) }
+  .debug_abbrev  0 :  { *(.debug_abbrev) }
+  .debug_line  0 :  { *(.debug_line) }
+  .debug_frame  0 :  { *(.debug_frame) }
+  .debug_str  0 :  { *(.debug_str) }
+  .debug_loc  0 :  { *(.debug_loc) }
+  .debug_macinfo  0 :  { *(.debug_macinfo) }
+  .debug_weaknames  0 :  { *(.debug_weaknames) }
+  .debug_funcnames  0 :  { *(.debug_funcnames) }
+  .debug_typenames  0 :  { *(.debug_typenames) }
+  .debug_varnames  0 :  { *(.debug_varnames) }
+
+  .xt.insn 0 :
+  {
+    KEEP (*(.xt.insn))
+    KEEP (*(.gnu.linkonce.x.*))
+  }
+  .xt.prop 0 :
+  {
+    KEEP (*(.xt.prop))
+    KEEP (*(.xt.prop.*))
+    KEEP (*(.gnu.linkonce.prop.*))
+  }
+  .xt.lit 0 :
+  {
+    KEEP (*(.xt.lit))
+    KEEP (*(.xt.lit.*))
+    KEEP (*(.gnu.linkonce.p.*))
+  }
+  .xt.profile_range 0 :
+  {
+    KEEP (*(.xt.profile_range))
+    KEEP (*(.gnu.linkonce.profile_range.*))
+  }
+  .xt.profile_ranges 0 :
+  {
+    KEEP (*(.xt.profile_ranges))
+    KEEP (*(.gnu.linkonce.xt.profile_ranges.*))
+  }
+  .xt.profile_files 0 :
+  {
+    KEEP (*(.xt.profile_files))
+    KEEP (*(.gnu.linkonce.xt.profile_files.*))
+  }
+}
+


### PR DESCRIPTION
This series builds a simple boot ROM for platforms like APL, CNL and ICL that use a ROM to load the manifest and jump to the boot loader. 

The ROM is only intended for CI testing purposes so that qemu can boot and validate ROM based platforms including manifest and bootloader. This needs latest qemu HEAD from today.

Next steps would be to add simple driver on top of this to load  topology and execute some smoke tests for every PR.