### PR TITLE
trace: increase trace pos for each event

### DIFF
--- a/src/lib/trace.c
+++ b/src/lib/trace.c
@@ -90,6 +90,7 @@ static void mtrace_event(const char *data, uint32_t length)
 		t[trace->pos + i] = data[i];
 
 	dcache_writeback_region((void *)&t[trace->pos], i);
+	trace->pos += length;
 
 	/* if there was more data than space available, wrap back */
 	if (length > available) {


### PR DESCRIPTION
position for trace->pos is not updated, make error trace only show the
newest one. Now update the pos to make all error trace can be seen.

Signed-off-by: Pan Xiuli <xiuli.pan@linux.intel.com>