### PR TITLE
Fixes for macros used for bit masks creation.

### DIFF
--- a/src/include/sof/bit.h
+++ b/src/include/sof/bit.h
@@ -32,9 +32,10 @@
 #define __INCLUDE_BIT__
 
 #define BIT(b)			(1 << (b))
-#define MASK(b_hi, b_lo)	((1 << ((b_hi) - (b_lo) + 1)) - 1)
+#define MASK(b_hi, b_lo)	\
+	(((1ULL << ((b_hi) - (b_lo) + 1ULL)) - 1ULL) << (b_lo))
 #define SET_BIT(b, x)		(((x) & 1) << (b))
 #define SET_BITS(b_hi, b_lo, x)	\
-	(((x) & ((1 << ((b_hi) - (b_lo) + 1)) - 1)) << (b_lo))
+	(((x) & ((1ULL << ((b_hi) - (b_lo) + 1ULL)) - 1ULL)) << (b_lo))
 
 #endif


### PR DESCRIPTION
Bit mask setting macros for for specific parameters were expanded
in a way that was causing unexpected compiler behaviour. Specifically:
literal 1 was treated as 32bit integer ((1 << ((b_hi)-(b_lo) + 1)) -1)
was expanded to shift the 32bit integer by 32. ((1 << (31 - 0 + 1)) -1)
Macro MASK() was was missing left shift.

Signed-off-by: Lech Betlej <lech.betlej@linux.intel.com>