### PR TITLE
Fix BYT issues

### DIFF
--- a/src/ipc/ipc.c
+++ b/src/ipc/ipc.c
@@ -470,6 +470,7 @@ int ipc_get_page_descriptors(struct dma *dmac, uint8_t *page_table,
 	config.src_width = sizeof(uint32_t);
 	config.dest_width = sizeof(uint32_t);
 	config.cyclic = 0;
+	config.timer_delay = 0;
 	dma_sg_init(&config.elem_array);
 
 	/* set up DMA descriptor */

--- a/src/platform/baytrail/dma.c
+++ b/src/platform/baytrail/dma.c
@@ -153,6 +153,7 @@ struct dma dma[PLATFORM_NUM_DMACS] = {
 		.caps		= DMA_CAP_GP_HP,
 		.devs		= DMA_DEV_SSP | DMA_DEV_DMIC | DMA_DEV_HOST,
 		.base		= DMA0_BASE,
+		.channels	= 8,
 		.irq		= IRQ_NUM_EXT_DMAC0,
 		.drv_plat_data	= &dmac0,
 	},
@@ -167,6 +168,7 @@ struct dma dma[PLATFORM_NUM_DMACS] = {
 		.caps		= DMA_CAP_GP_HP,
 		.devs		= DMA_DEV_SSP | DMA_DEV_DMIC | DMA_DEV_HOST,
 		.base		= DMA1_BASE,
+		.channels	= 8,
 		.irq		= IRQ_NUM_EXT_DMAC1,
 		.drv_plat_data	= &dmac1,
 	},
@@ -182,6 +184,7 @@ struct dma dma[PLATFORM_NUM_DMACS] = {
 		.caps		= DMA_CAP_GP_HP,
 		.devs		= DMA_DEV_SSP | DMA_DEV_DMIC | DMA_DEV_HOST,
 		.base		= DMA2_BASE,
+		.channels	= 8,
 		.irq		= IRQ_NUM_EXT_DMAC2,
 		.drv_plat_data	= &dmac2,
 	},
@@ -193,18 +196,14 @@ struct dma dma[PLATFORM_NUM_DMACS] = {
 /* Initialize all platform DMAC's */
 int dmac_init(void)
 {
-	int i, ret;
+	int i;
+	/* no probing before first use */
 
-	for (i = 0; i < ARRAY_SIZE(dma); i++) {
-		ret = dma_probe(&dma[i]);
-		if (ret < 0) {
+	/* TODO: dynamic init based on platform settings */
 
-			/* trace failed DMAC ID */
-			trace_error(TRACE_CLASS_DMA, "edi");
-			trace_error_value(dma[i].plat_data.id);
-			return ret;
-		}
-	}
+	/* early lock initialization for ref counting */
+	for (i = 0; i < ARRAY_SIZE(dma); i++)
+		spinlock_init(&dma[i].lock);
 
 	/* tell the lib DMAs are ready to use */
 	dma_install(dma, ARRAY_SIZE(dma));

--- a/src/platform/haswell/dma.c
+++ b/src/platform/haswell/dma.c
@@ -115,6 +115,7 @@ struct dma dma[PLATFORM_NUM_DMACS] = {
 		.devs		= DMA_DEV_SSP | DMA_DEV_DMIC | DMA_DEV_HOST,
 		.irq		= IRQ_NUM_EXT_DMAC0,
 		.drv_plat_data	= &dmac0,
+		.channels	= 8,
 	},
 	.ops		= &dw_dma_ops,
 },
@@ -128,6 +129,7 @@ struct dma dma[PLATFORM_NUM_DMACS] = {
 		.devs		= DMA_DEV_SSP | DMA_DEV_DMIC | DMA_DEV_HOST,
 		.irq		= IRQ_NUM_EXT_DMAC1,
 		.drv_plat_data	= &dmac1,
+		.channels	= 8,
 	},
 	.ops		= &dw_dma_ops,
 },};
@@ -135,18 +137,14 @@ struct dma dma[PLATFORM_NUM_DMACS] = {
 /* Initialize all platform DMAC's */
 int dmac_init(void)
 {
-	int i, ret;
+	int i;
+	/* no probing before first use */
 
-	for (i = 0; i < ARRAY_SIZE(dma); i++) {
-		ret = dma_probe(&dma[i]);
-		if (ret < 0) {
+	/* TODO: dynamic init based on platform settings */
 
-			/* trace failed DMAC ID */
-			trace_error(TRACE_CLASS_DMA, "edi");
-			trace_error_value(dma[i].plat_data.id);
-			return ret;
-		}
-	}
+	/* early lock initialization for ref counting */
+	for (i = 0; i < ARRAY_SIZE(dma); i++)
+		spinlock_init(&dma[i].lock);
 
 	/* clear the masks for dsp of the dmacs */
 	io_reg_update_bits(SHIM_BASE + SHIM_IMRD,


### PR DESCRIPTION
Clean up for BYT platform issues, now can have simple aplay and arecord.
Fix boot panic with DMAC clean up. Fix #443
Fix dma trace init failed by init value in ipc_get_page_description. 
Fix get channel bug with wrong use of stream tag.

Now BYT is in basic stable state, please run stress test and recheck old issues. 