### PR TITLE
IPC: Xrun: fix Xrun stream id error issue

### DIFF
--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -391,7 +391,9 @@ int ipc_stream_send_position(struct comp_dev *cdev,
 int ipc_stream_send_xrun(struct comp_dev *cdev,
 	struct sof_ipc_stream_posn *posn)
 {
-	posn->rhdr.hdr.cmd = SOF_IPC_GLB_STREAM_MSG | SOF_IPC_STREAM_TRIG_XRUN;
+	posn->rhdr.hdr.cmd = SOF_IPC_GLB_STREAM_MSG |
+			     SOF_IPC_STREAM_TRIG_XRUN |
+			     cdev->comp.id;
 	posn->rhdr.hdr.size = sizeof(*posn);
 	posn->comp_id = cdev->comp.id;
 


### PR DESCRIPTION
As API required, we need transfer stream host comp.id inside hdr cmd,
otherwise, host side can't get information about which stream has Xrun
happened, and reported error as "XRUN for unknown stream, msg_id 0".

This is similar to Position IPC, add comp.id into cmd to fix it.

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>