### PR TITLE
Power up only subset of HP SRAM banks on FW init (CannonLake)

### DIFF
--- a/src/platform/cannonlake/include/platform/memory.h
+++ b/src/platform/cannonlake/include/platform/memory.h
@@ -163,9 +163,9 @@
  * +---------------------+----------------+-----------------------------------+
  * | HEAP_BUFFER_BASE    | Module Buffers |  HEAP_BUFFER_SIZE                 |
  * +---------------------+----------------+-----------------------------------+
- * | SOF_STACK_END      | Stack          |  SOF_STACK_SIZE                  |
+ * | SOF_STACK_END       | Stack          |  SOF_STACK_SIZE                   |
  * +---------------------+----------------+-----------------------------------+
- * | SOF_STACK_BASE     |                |                                   |
+ * | SOF_STACK_BASE      |                |                                   |
  * +---------------------+----------------+-----------------------------------+
  */
 
@@ -279,8 +279,11 @@
 /* Stack configuration */
 #define SOF_STACK_SIZE		ARCH_STACK_SIZE
 #define SOF_STACK_TOTAL_SIZE	ARCH_STACK_TOTAL_SIZE
-#define SOF_STACK_BASE		(HP_SRAM_BASE + HP_SRAM_SIZE)
-#define SOF_STACK_END		(SOF_STACK_BASE - SOF_STACK_TOTAL_SIZE)
+/* SOF_STACK_OFFSET defines how much memory can be power gated */
+#define SOF_STACK_OFFSET	0x150000
+/* SOF_STACK_BASE is moved from end of physical memory by offset */
+#define SOF_STACK_BASE	(HP_SRAM_BASE + HP_SRAM_SIZE - SOF_STACK_OFFSET)
+#define SOF_STACK_END	(SOF_STACK_BASE - SOF_STACK_TOTAL_SIZE)
 
 #define HEAP_BUFFER_BASE		(HEAP_RUNTIME_BASE + HEAP_RUNTIME_SIZE)
 #define HEAP_BUFFER_SIZE	\
@@ -288,25 +291,26 @@
 #define HEAP_BUFFER_BLOCK_SIZE		0x180
 #define HEAP_BUFFER_COUNT	(HEAP_BUFFER_SIZE / HEAP_BUFFER_BLOCK_SIZE)
 
+#define SOF_MEMORY_SIZE (SOF_STACK_BASE - HP_SRAM_BASE)
 /*
  * The LP SRAM Heap and Stack on Cannonlake are organised like this :-
  *
  * +--------------------------------------------------------------------------+
  * | Offset              | Region         |  Size                             |
  * +---------------------+----------------+-----------------------------------+
- * | LP_SRAM_BASE        | RO Data        |  SOF_LP_DATA_SIZE                |
+ * | LP_SRAM_BASE        | RO Data        |  SOF_LP_DATA_SIZE                 |
  * |                     | Data           |                                   |
  * |                     | BSS            |                                   |
  * +---------------------+----------------+-----------------------------------+
- * | HEAP_LP_SYSTEM_BASE | System Heap    |  HEAP_LP_SYSTEM_SIZE                 |
+ * | HEAP_LP_SYSTEM_BASE | System Heap    |  HEAP_LP_SYSTEM_SIZE              |
  * +---------------------+----------------+-----------------------------------+
- * | HEAP_LP_RUNTIME_BASE| Runtime Heap   |  HEAP_LP_RUNTIME_SIZE                |
+ * | HEAP_LP_RUNTIME_BASE| Runtime Heap   |  HEAP_LP_RUNTIME_SIZE             |
  * +---------------------+----------------+-----------------------------------+
- * | HEAP_LP_BUFFER_BASE | Module Buffers |  HEAP_LP_BUFFER_SIZE                 |
+ * | HEAP_LP_BUFFER_BASE | Module Buffers |  HEAP_LP_BUFFER_SIZE              |
  * +---------------------+----------------+-----------------------------------+
- * | SOF_LP_STACK_END   | Stack          |  SOF_LP_STACK_SIZE                  |
+ * | SOF_LP_STACK_END    | Stack          |  SOF_LP_STACK_SIZE                |
  * +---------------------+----------------+-----------------------------------+
- * | SOF_STACK_BASE     |                |                                   |
+ * | SOF_STACK_BASE      |                |                                   |
  * +---------------------+----------------+-----------------------------------+
  */
 
@@ -366,8 +370,6 @@
 #define SOF_MEM_RESET_TEXT_SIZE	0x268
 #define SOF_MEM_RESET_LIT_SIZE		0x8
 #define SOF_MEM_VECBASE_LIT_SIZE	0x178
-
-#define SOF_MEM_RO_SIZE			0x8
 
 /* boot loader in IMR */
 #define IMR_BOOT_LDR_MANIFEST_BASE	0xB0032000

--- a/src/platform/cannonlake/include/platform/platcfg.h
+++ b/src/platform/cannonlake/include/platform/platcfg.h
@@ -43,4 +43,9 @@
 
 #define PLATFORM_MASTER_CORE_ID		0
 
+//TODO: move cAVS memory specific definitions to cavs/memory driver
+#define SRAM_BANK_SIZE	0x10000
+
+#define EBB_SEGMENT_SIZE	32
+
 #endif


### PR DESCRIPTION
In order to reduce power consumption in runtime only subset of HP SRAM
banks have to be powered. The PR covers 2 aspects:
1. Changed memory map to move stack up by 21 memory banks. Buffer heap
size reduced from ~2.3MB to ~0.9MB.
2. Changed HP SRAM initialization to power up only needed banks and
properly check HW response.

Signed-off-by: Lech Betlej <lech.betlej@linux.intel.com>