### PR TITLE
link dma: allocate link dma channel at dai_config

### DIFF
--- a/src/include/uapi/ipc/dai-intel.h
+++ b/src/include/uapi/ipc/dai-intel.h
@@ -106,8 +106,7 @@ struct sof_ipc_dai_ssp_params {
 
 /* HDA Configuration Request - SOF_IPC_DAI_HDA_CONFIG */
 struct sof_ipc_dai_hda_params {
-	struct sof_ipc_hdr hdr;
-	/* TODO */
+	uint32_t link_dma_ch;
 } __attribute__((packed));
 
 /* DMIC Configuration Request - SOF_IPC_DAI_DMIC_CONFIG */


### PR DESCRIPTION
Fix capture issue with hda codecs. Now the data captured by
hda codecs is full of zero. It is caused by mismatch of link
dma channel between host and FW.

Now host allocates link dma channel at dai config loading stage,
and sends it to FW to allocate link dma channel at dai_config
function

it for bug:https://github.com/thesofproject/sof/issues/433#issuecomment-441370152
kernel patch: https://github.com/thesofproject/linux/pull/291

Signed-off-by: Rander Wang <rander.wang@linux.intel.com>