### PR TITLE
logger: include file_format.h directly from rimage

### DIFF
--- a/tools/logger/Makefile.am
+++ b/tools/logger/Makefile.am
@@ -6,5 +6,6 @@ sof_logger_SOURCES = \
 
 sof_logger_CFLAGS = \
 	-I ../../src/include \
+	-I ../../ \
 	-Wall \
 	-Werror

--- a/tools/logger/convert.c
+++ b/tools/logger/convert.c
@@ -29,21 +29,6 @@
 #define TRACE_MAX_IDS_STR		10
 #define TRACE_IDS_MASK			((1 << TRACE_ID_LENGTH) - 1)
 
-/* logs file signature */
-#define SND_SOF_LOGS_SIG_SIZE	4
-#define SND_SOF_LOGS_SIG	"Logs"
-
-/*
-* Logs dictionary file header.
-*/
-struct snd_sof_logs_header {
-	unsigned char sig[SND_SOF_LOGS_SIG_SIZE]; /* "Logs" */
-	uint32_t base_address;  /* address of log entries section */
-	uint32_t data_length;   /* amount of bytes following this header */
-	uint32_t data_offset;   /* offset to first entry in this file */
-	struct sof_ipc_fw_version version;
-};
-
 struct ldc_entry_header {
 	uint32_t level;
 	uint32_t component_class;

--- a/tools/logger/convert.h
+++ b/tools/logger/convert.h
@@ -15,6 +15,7 @@
 #include <stdio.h>
 #include <uapi/user/trace.h>
 #include <uapi/ipc/info.h>
+#include <rimage/file_format.h>
 
 #define KNRM  "\x1B[0m"
 #define KRED  "\x1B[31m"


### PR DESCRIPTION
snd_sof_logs_header struct was directly in convert.c file in logger. I change it to be included from rimage.

Signed-off-by: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>