### PR TITLE
rimage: fix possible buffer overflow

### DIFF
--- a/rimage/pkcs1_5.c
+++ b/rimage/pkcs1_5.c
@@ -97,7 +97,7 @@ int pkcs_v1_5_sign_man_v1_5(struct image *image,
 	if (!image->key_name)
 		sprintf(path, "%s/otc_private_key.pem", PEM_KEY_PREFIX);
 	else
-		strcpy(path, image->key_name);
+		strncpy(path, image->key_name, 256);
 
 	fprintf(stdout, " pkcs: signing with key %s\n", path);
 	fp = fopen(path, "r");


### PR DESCRIPTION
Fixes possible buffer overflow with strcpy.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>