### PR TITLE
topology: fix kcontrol name by topology

### DIFF
--- a/tools/topology/m4/mixercontrol.m4
+++ b/tools/topology/m4/mixercontrol.m4
@@ -30,7 +30,7 @@ define(`CONTROLMIXER_OPS',
 
 dnl C_CONTROLMIXER(name, index, ops, max, invert, tlv, KCONTROL_CHANNELS)
 define(`C_CONTROLMIXER',
-`SectionControlMixer."$1 PIPELINE_ID" {'
+`SectionControlMixer."$2 $1" {'
 `'
 `	# control belongs to this index group'
 `	index STR($2)'

--- a/tools/topology/sof/pipe-eq-fir-volume-playback.m4
+++ b/tools/topology/sof/pipe-eq-fir-volume-playback.m4
@@ -52,7 +52,7 @@ C_CONTROLBYTES(EQFIR, PIPELINE_ID,
 W_PCM_PLAYBACK(PCM_ID, Passthrough Playback, 2, 0, 2)
 
 # "Volume" has 2 source and 2 sink periods
-W_PGA(0, PIPELINE_FORMAT, 2, 2, 2, LIST(`		', "Master Playback Volume PIPELINE_ID"))
+W_PGA(0, PIPELINE_FORMAT, 2, 2, 2, LIST(`		', "PIPELINE_ID Master Playback Volume"))
 
 # "EQ 0" has 2 sink period and 2 source periods
 W_EQ_FIR(0, PIPELINE_FORMAT, 2, 2, 2, LIST(`		', "EQFIR"))

--- a/tools/topology/sof/pipe-eq-iir-volume-playback.m4
+++ b/tools/topology/sof/pipe-eq-iir-volume-playback.m4
@@ -56,7 +56,7 @@ C_CONTROLBYTES(EQIIR, PIPELINE_ID,
 W_PCM_PLAYBACK(PCM_ID, Passthrough Playback, 2, 0, 2)
 
 # "Volume" has 2 source and 2 sink periods
-W_PGA(0, PIPELINE_FORMAT, 2, 2, 2, LIST(`		', "Master Playback Volume PIPELINE_ID"))
+W_PGA(0, PIPELINE_FORMAT, 2, 2, 2, LIST(`		', "PIPELINE_ID Master Playback Volume"))
 
 # "EQ 0" has 2 sink period and 2 source periods
 W_EQ_IIR(0, PIPELINE_FORMAT, 2, 2, 2, LIST(`		', "EQIIR"))

--- a/tools/topology/sof/pipe-eq-volume-playback.m4
+++ b/tools/topology/sof/pipe-eq-volume-playback.m4
@@ -62,7 +62,7 @@ C_CONTROLBYTES(EQFIR, PIPELINE_ID,
 W_PCM_PLAYBACK(PCM_ID, Passthrough Playback, 2, 0, 2)
 
 # "Volume" has 2 source and 2 sink periods
-W_PGA(0, PIPELINE_FORMAT, 2, 2, 2, LIST(`		', "Master Playback Volume PIPELINE_ID"))
+W_PGA(0, PIPELINE_FORMAT, 2, 2, 2, LIST(`		', "PIPELINE_ID Master Playback Volume"))
 
 # "EQ 0" has 2 sink period and 2 source periods
 W_EQ_IIR(0, PIPELINE_FORMAT, 2, 2, 2, LIST(`		', "EQIIR"))

--- a/tools/topology/sof/pipe-low-latency-capture.m4
+++ b/tools/topology/sof/pipe-low-latency-capture.m4
@@ -32,7 +32,7 @@ C_CONTROLMIXER(PCM PCM_ID Capture Volume, PIPELINE_ID,
 W_PCM_CAPTURE(PCM_ID, Low Latency Capture, 0, 2, 0)
 
 # "Capture Volume" has 2 sink and source periods for host and DAI ping-pong
-W_PGA(0, PIPELINE_FORMAT, 2, 2, 0, LIST(`		', "PCM PCM_ID Capture Volume PIPELINE_ID"))
+W_PGA(0, PIPELINE_FORMAT, 2, 2, 0, LIST(`		', "PIPELINE_ID PCM PCM_ID Capture Volume"))
 
 # Capture Buffers
 W_BUFFER(0, COMP_BUFFER_SIZE(2,

--- a/tools/topology/sof/pipe-low-latency-playback.m4
+++ b/tools/topology/sof/pipe-low-latency-playback.m4
@@ -57,10 +57,10 @@ C_CONTROLMIXER(Master Playback Volume, PIPELINE_ID,
 W_PCM_PLAYBACK(PCM_ID, Low Latency Playback, 2, 0, 2)
 
 # "Playback Volume" has 1 sink period and 2 source periods for host ping-pong
-W_PGA(0, PIPELINE_FORMAT, 1, 2, 1, LIST(`		', "PCM PCM_ID Playback Volume PIPELINE_ID"))
+W_PGA(0, PIPELINE_FORMAT, 1, 2, 1, LIST(`		', "PIPELINE_ID PCM PCM_ID Playback Volume"))
 
 # "Master Playback Volume" has 1 source and 2 sink periods for DAI ping-pong
-W_PGA(1, PIPELINE_FORMAT, 2, 1, 1, LIST(`		', "Master Playback Volume PIPELINE_ID"))
+W_PGA(1, PIPELINE_FORMAT, 2, 1, 1, LIST(`		', "PIPELINE_ID Master Playback Volume"))
 
 # Mixer 0 has 1 sink and source periods.
 W_MIXER(0, PIPELINE_FORMAT, 1, 1, 1)

--- a/tools/topology/sof/pipe-pcm-media.m4
+++ b/tools/topology/sof/pipe-pcm-media.m4
@@ -45,7 +45,7 @@ W_DATA(media_src_conf, media_src_tokens)
 W_PCM_PLAYBACK(PCM_ID, Media Playback, 2, 0, 2)
 
 # "Playback Volume" has 2 sink period and 2 source periods for host ping-pong
-W_PGA(0, PIPELINE_FORMAT, 2, 2, 2, LIST(`		', "PCM PCM_ID Playback Volume PIPELINE_ID"))
+W_PGA(0, PIPELINE_FORMAT, 2, 2, 2, LIST(`		', "PIPELINE_ID PCM PCM_ID Playback Volume"))
 
 # "SRC 0" has 2 sink and source periods.
 W_SRC(0, PIPELINE_FORMAT, 2, 2, media_src_conf, 2)

--- a/tools/topology/sof/pipe-src-playback.m4
+++ b/tools/topology/sof/pipe-src-playback.m4
@@ -46,7 +46,7 @@ W_DATA(media_src_conf, media_src_tokens)
 W_SRC(0, PIPELINE_FORMAT, 3, 3, media_src_conf, 2)
 
 # "Volume" has 2 source and 2 sink periods
-W_PGA(0, PIPELINE_FORMAT, 2, 2, 2, LIST(`		', "Master Playback Volume PIPELINE_ID"))
+W_PGA(0, PIPELINE_FORMAT, 2, 2, 2, LIST(`		', "PIPELINE_ID Master Playback Volume"))
 
 # Playback Buffers
 W_BUFFER(0, COMP_BUFFER_SIZE(3,

--- a/tools/topology/sof/pipe-tone.m4
+++ b/tools/topology/sof/pipe-tone.m4
@@ -42,10 +42,10 @@ C_CONTROLMIXER(Tone Switch, PIPELINE_ID,
 #
 
 # "Tone 0" has 2 sink period and 0 source periods
-W_TONE(0, PIPELINE_FORMAT, 2, 0, 0, LIST(`		', "Tone Switch PIPELINE_ID"))
+W_TONE(0, PIPELINE_FORMAT, 2, 0, 0, LIST(`		', "PIPELINE_ID Tone Switch"))
 
 # "Tone Volume" has 2 sink period and 2 source periods
-W_PGA(0, PIPELINE_FORMAT, 2, 2, 0, LIST(`		', "Tone Volume PIPELINE_ID"))
+W_PGA(0, PIPELINE_FORMAT, 2, 2, 0, LIST(`		', "PIPELINE_ID Tone Volume"))
 
 # Low Latency Buffers
 W_BUFFER(0,COMP_BUFFER_SIZE(2,

--- a/tools/topology/sof/pipe-volume-capture.m4
+++ b/tools/topology/sof/pipe-volume-capture.m4
@@ -34,7 +34,7 @@ C_CONTROLMIXER(Master Capture Volume, PIPELINE_ID,
 W_PCM_CAPTURE(PCM_ID, Passthrough Capture, 0, 2, 2)
 
 # "Volume" has 2 source and 2 sink periods
-W_PGA(0, PIPELINE_FORMAT, 2, 2, 2, LIST(`		', "Master Capture Volume PIPELINE_ID"))
+W_PGA(0, PIPELINE_FORMAT, 2, 2, 2, LIST(`		', "PIPELINE_ID Master Capture Volume"))
 
 # Capture Buffers
 W_BUFFER(0, COMP_BUFFER_SIZE(2,

--- a/tools/topology/sof/pipe-volume-playback.m4
+++ b/tools/topology/sof/pipe-volume-playback.m4
@@ -34,7 +34,7 @@ C_CONTROLMIXER(Master Playback Volume, PIPELINE_ID,
 W_PCM_PLAYBACK(PCM_ID, Passthrough Playback, 2, 0, 2)
 
 # "Volume" has 2 source and 2 sink periods
-W_PGA(0, PIPELINE_FORMAT, 2, 2, 2, LIST(`		', "Master Playback Volume PIPELINE_ID"))
+W_PGA(0, PIPELINE_FORMAT, 2, 2, 2, LIST(`		', "PIPELINE_ID Master Playback Volume"))
 
 # Playback Buffers
 W_BUFFER(0, COMP_BUFFER_SIZE(2,


### PR DESCRIPTION
the kcontrol item name doesn't follow the SOURCE:DIRECTION:FUNCTION, and
can't seperate playback and capture when display in alsamixer.
This fix is to move the pipeline id from the end of the name to the
head, this will make alsamixer to serperate playback and capture when
press F3 F4. The UCM still need to change the name for the SOURCE name
are changed.

Signed-off-by: Zhu Yingjiang <yingjiang.zhu@linux.intel.com>