### PR TITLE
IPC fixes for byt and apl

### DIFF
--- a/src/ipc/apl-ipc.c
+++ b/src/ipc/apl-ipc.c
@@ -91,7 +91,7 @@ static void irq_handler(void *arg)
 	}
 
 	/* reply message(done) from host */
-	if (dipcie & IPC_DIPCIE_DONE) {
+	if (dipcie & IPC_DIPCIE_DONE && dipcctl & IPC_DIPCCTL_IPCIDIE) {
 
 		/* mask Done interrupt */
 		ipc_write(IPC_DIPCCTL, ipc_read(IPC_DIPCCTL) & ~IPC_DIPCCTL_IPCIDIE);

--- a/src/ipc/byt-ipc.c
+++ b/src/ipc/byt-ipc.c
@@ -88,14 +88,18 @@ out:
 static void irq_handler(void *arg)
 {
 	uint32_t isr;
+	uint32_t imrd;
 	uint32_t msg = 0;
 
 	/* Interrupt arrived, check src */
 	isr = shim_read(SHIM_ISRD);
+	imrd = shim_read(SHIM_IMRD);
 
 	tracev_ipc("ipc: irq isr 0x%x", isr);
 
-	if (isr & SHIM_ISRD_DONE) {
+	/* reply message(done) from host */
+	if (isr & SHIM_ISRD_DONE &&
+	    !(imrd & SHIM_IMRD_DONE)) {
 
 		/* Mask Done interrupt before return */
 		shim_write(SHIM_IMRD, shim_read(SHIM_IMRD) | SHIM_IMRD_DONE);
@@ -103,7 +107,9 @@ static void irq_handler(void *arg)
 		do_notify();
 	}
 
-	if (isr & SHIM_ISRD_BUSY) {
+	/* new message from host */
+	if (isr & SHIM_ISRD_BUSY &&
+	    !(imrd & SHIM_IMRD_BUSY)) {
 
 		/* Mask Busy interrupt before return */
 		shim_write(SHIM_IMRD, shim_read(SHIM_IMRD) | SHIM_IMRD_BUSY);


### PR DESCRIPTION
add mask check to make sure ipc handle correctly

We are missing interrupt mask check, which will lead to error handling
IPC message type(e.g. treat an reply message as an new one), Here add
mask check to fix that.

This is only tested on APL ATM yet, will append byt test result later.