### PR TITLE
GDB: Added IPC trigger for GDB debug.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -14,6 +14,7 @@ src/include/sof/dmic.h			@singalsu
 src/include/host/*			@ranj063
 src/include/uapi/*			@bardliao
 src/include/uapi/ipc/*			@xiulipan @bardliao
+src/include/gdb/*			@mrajwa
 
 # audio component
 src/audio/src*				@singalsu
@@ -36,6 +37,7 @@ src/host/*				@ranj063
 src/math/*				@singalsu
 src/ipc/*				@xiulipan @bardliao
 src/lib/*				@libinyang
+src/gdb/*				@mrajwa
 
 # other helpers
 test/*					@jajanusz

--- a/src/include/sof/ipc.h
+++ b/src/include/sof/ipc.h
@@ -123,7 +123,7 @@ struct ipc {
 #define ipc_set_drvdata(ipc, data) \
 	(ipc)->private = data
 #define ipc_get_drvdata(ipc) \
-	(ipc)->private;
+	(ipc)->private
 
 
 int ipc_init(struct sof *sof);

--- a/src/include/uapi/ipc/header.h
+++ b/src/include/uapi/ipc/header.h
@@ -78,6 +78,7 @@
 #define SOF_IPC_FW_READY			SOF_GLB_TYPE(0x7U)
 #define SOF_IPC_GLB_DAI_MSG			SOF_GLB_TYPE(0x8U)
 #define SOF_IPC_GLB_TRACE_MSG			SOF_GLB_TYPE(0x9U)
+#define SOF_IPC_GLB_GDB_DEBUG                   SOF_GLB_TYPE(0xAU)
 
 /*
  * DSP Command Message Types

--- a/src/include/uapi/ipc/info.h
+++ b/src/include/uapi/ipc/info.h
@@ -86,6 +86,8 @@ struct sof_ipc_fw_ready {
 		uint64_t locks_verbose:1;
 	} debug;
 
+	uint32_t gdb_enabled;
+
 	/* reserved for future use */
 	uint32_t reserved[4];
 } __attribute__((packed));

--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -651,7 +651,6 @@ static int ipc_dma_trace_config(uint32_t header)
 	struct sof_ipc_dma_trace_params *params = _ipc->comp_data;
 	int err;
 
-
 	/* sanity check size */
 	if (IPC_INVALID_SIZE(params)) {
 		trace_ipc_error("ipc:_invalid IPC size 0x%x got 0x%x",
@@ -741,6 +740,21 @@ static int ipc_glb_debug_message(uint32_t header)
 		trace_ipc_error("ipc: unknown debug cmd %u", cmd);
 		return -EINVAL;
 	}
+}
+
+static int ipc_glb_gdb_debug(uint32_t header)
+{
+	/* no furher information needs to be extracted form header */
+	(void) header;
+
+#ifdef CONFIG_GDB_DEBUG
+	/* trigger debug exception */
+	asm volatile("_break 0, 0");
+	return 0;
+#else
+	return -EINVAL;
+#endif
+
 }
 
 /*
@@ -1018,6 +1032,8 @@ int ipc_cmd(void)
 		return ipc_glb_dai_message(hdr->cmd);
 	case iGS(SOF_IPC_GLB_TRACE_MSG):
 		return ipc_glb_debug_message(hdr->cmd);
+	case iGS(SOF_IPC_GLB_GDB_DEBUG):
+		return ipc_glb_gdb_debug(hdr->cmd);
 	default:
 		trace_ipc_error("ipc: unknown command type %u", type);
 		return -EINVAL;

--- a/src/platform/baytrail/platform.c
+++ b/src/platform/baytrail/platform.c
@@ -77,7 +77,7 @@ static const struct sof_ipc_fw_ready ready
 		.tag = SOF_TAG,
 		.abi_version = SOF_ABI_VERSION,
 	},
-	.debug = DEBUG_SET_FW_READY_FLAGS,
+	.debug = DEBUG_SET_FW_READY_FLAGS
 };
 
 #define NUM_BYT_WINDOWS		6

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -78,6 +78,11 @@ static const struct sof_ipc_fw_ready ready
 		.abi_version = SOF_ABI_VERSION,
 	},
 	.debug = DEBUG_SET_FW_READY_FLAGS,
+
+#ifdef CONFIG_GDB_DEBUG
+	.gdb_enabled = CONFIG_GDB_DEBUG
+#endif
+
 };
 
 #if defined(CONFIG_MEM_WND)


### PR DESCRIPTION
Signed-off-by: Marcin Rajwa <marcin.rajwa@linux.intel.com>

This change allows to send an IPC request for FW to start GDB session.
NOTE: In order to provide IPC response which includes new feature update of ABI will be required.