### PR TITLE
tools: logger: turn off colors if the output file is not a tty.

### DIFF
--- a/tools/logger/convert.c
+++ b/tools/logger/convert.c
@@ -101,7 +101,8 @@ static const char * get_component_name(uint32_t component_id) {
 }
 
 static void print_entry_params(FILE *out_fd, struct log_entry_header dma_log,
-	struct ldc_entry entry, uint64_t last_timestamp, double clock)
+	struct ldc_entry entry, uint64_t last_timestamp, double clock,
+	int use_colors)
 {	
 	char ids[TRACE_MAX_IDS_STR];
 	float dt = to_usecs(dma_log.timestamp - last_timestamp, clock);
@@ -114,7 +115,8 @@ static void print_entry_params(FILE *out_fd, struct log_entry_header dma_log,
 		        (dma_log.id_1 & TRACE_IDS_MASK));
 
 	fprintf(out_fd, "%s%5u %6u %12s %-7s %16.6f %16.6f %20s:%-4u\t",
-		entry.header.level == LOG_LEVEL_CRITICAL ? KRED : KNRM,
+		entry.header.level == use_colors ?
+			(LOG_LEVEL_CRITICAL ? KRED : KNRM) : "",
 		dma_log.core_id,
 		entry.header.level,
 		get_component_name(entry.header.component_class),
@@ -143,7 +145,7 @@ static void print_entry_params(FILE *out_fd, struct log_entry_header dma_log,
 			entry.params[2], entry.params[3]);
 		break;
 	}
-	fprintf(out_fd, "%s\n", KNRM);
+	fprintf(out_fd, "%s\n", use_colors ? KNRM : "");
 	fflush(out_fd);
 }
 
@@ -235,7 +237,7 @@ static int fetch_entry(struct convert_config *config, uint32_t base_address,
 
 	/* printing entry content */
 	print_entry_params(config->out_fd, dma_log, entry, *last_timestamp,
-		config->clock);
+			   config->clock, config->use_colors);
 	*last_timestamp = dma_log.timestamp;
 
 	/* set f_ldc file position to the beginning */

--- a/tools/logger/convert.h
+++ b/tools/logger/convert.h
@@ -17,8 +17,8 @@
 #include <uapi/ipc/info.h>
 #include <rimage/file_format.h>
 
-#define KNRM  "\x1B[0m"
-#define KRED  "\x1B[31m"
+#define KNRM	"\x1B[0m"
+#define KRED	"\x1B[31m"
 
 struct convert_config {
 	const char *out_file;
@@ -33,6 +33,7 @@ struct convert_config {
 	int version_fw;
 	char *version_file;
 	FILE *version_fd;
+	int use_colors;
 };
 
 int convert(struct convert_config *config);

--- a/tools/logger/logger.c
+++ b/tools/logger/logger.c
@@ -120,6 +120,7 @@ int main(int argc, char *argv[])
 	config.version_file = NULL;
 	config.version_fd = NULL;
 	config.version_fw = 0;
+	config.use_colors = 1;
 
 	while ((opt = getopt(argc, argv, "ho:i:l:ps:m:c:tev:")) != -1) {
 		switch (opt) {
@@ -215,6 +216,8 @@ int main(int argc, char *argv[])
 			goto out;
 		}
 	}
+	if (isatty(fileno(config.out_fd)) != 1)
+		config.use_colors = 0;
 
 	convert(&config);
 


### PR DESCRIPTION
Signed-off-by: Marcin Maka <marcin.maka@linux.intel.com>