### PR TITLE
init: compile out slave_core_init on UP arch

### DIFF
--- a/src/arch/xtensa/up/init.c
+++ b/src/arch/xtensa/up/init.c
@@ -64,3 +64,5 @@ int arch_init(struct sof *sof)
 	return 0;
 }
 
+int slave_core_init(struct sof *sof) { return 0; }
+

--- a/src/init/init.c
+++ b/src/init/init.c
@@ -88,41 +88,6 @@ int master_core_init(struct sof *sof)
 	return err;
 }
 
-/* TODO: should be compiled only on master/slave arch platforms */
-/* TODO: rename core -> cpu ? */
-int slave_core_init(struct sof *sof)
-{
-	int err;
-
-	/* init architecture */
-	trace_point(TRACE_BOOT_ARCH);
-	err = arch_init(sof);
-	if (err < 0)
-		panic(SOF_IPC_PANIC_ARCH);
-
-	trace_point(TRACE_BOOT_SYS_NOTE);
-	init_system_notify(sof);
-
-	trace_point(TRACE_BOOT_SYS_SCHED);
-	scheduler_init(sof);
-
-	platform_interrupt_init();
-
-	trace_point(TRACE_BOOT_SYS_WORK);
-	init_system_workq(&platform_generic_queue[cpu_get_id()]);
-
-	/* initialize IDC mechanism */
-	trace_point(TRACE_BOOT_PLATFORM_IDC);
-	idc_init();
-
-	trace_point(TRACE_BOOT_PLATFORM);
-
-	/* should not return */
-	err = do_task_slave_core(sof);
-
-	return err;
-}
-
 int main(int argc, char *argv[])
 {
 	int err;


### PR DESCRIPTION
Compiles out slave_core_init on UP architecure.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>