### PR TITLE
ipc: apply ipc change on BDW & HSW

### DIFF
--- a/src/ipc/hsw-ipc.c
+++ b/src/ipc/hsw-ipc.c
@@ -87,11 +87,12 @@ out:
 
 static void irq_handler(void *arg)
 {
-	uint32_t isr;
+	uint32_t isr, imrd;
 	uint32_t msg = 0;
 
 	/* Interrupt arrived, check src */
 	isr = shim_read(SHIM_ISRD);
+	imrd = shim_read(SHIM_IMRD);
 
 	tracev_ipc("ipc: irq isr 0x%x", isr);
 
@@ -103,7 +104,7 @@ static void irq_handler(void *arg)
 		do_notify();
 	}
 
-	if (isr & SHIM_ISRD_BUSY) {
+	if (isr & SHIM_ISRD_BUSY && !(imrd & SHIM_IMRD_BUSY)) {
 
 		/* Mask Busy interrupt before return */
 		shim_write(SHIM_IMRD, shim_read(SHIM_IMRD) | SHIM_IMRD_BUSY);


### PR DESCRIPTION
this patch follows:

ipc: Fix false positive IPC dropped messages.

On receiving an IPC IRQ the handler currently does not check the
IRQ mask. This means notification received ACKs (i.e. for trace updates)
from the host may be reported as duplicate host command IPCs.

Fix this by checking IPC IRQ mask.

Signed-off-by: Liam Girdwood <liam.r.girdwood@linux.intel.com>
Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>
Signed-off-by: Rander Wang <rander.wang@linux.intel.com>