### PR TITLE
topology: apl: nocodec config out of host GW DMAC channels

### DIFF
--- a/tools/topology/sof-apl-nocodec.m4
+++ b/tools/topology/sof-apl-nocodec.m4
@@ -1,6 +1,10 @@
 #
 # Topology for generic Apollolake board with no codec and digital mic array.
 #
+# APL Host GW DMAC support max 6 playback and max 6 capture channels so some
+# pipelines/PCMs/DAIs are commented out to keep within HW bounds. If these
+# are needed then they can be used provided other PCMs/pipelines/SSPs are
+# commented out in their place.
 
 # Include topology builder
 include(`utils.m4')
@@ -60,15 +64,15 @@ PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 
 # Low Latency playback pipeline 5 on PCM 2 using max 2 channels of s16le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
-	5, 2, 2, s16le,
-	48, 1000, 0, 0)
+#PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+#	5, 2, 2, s16le,
+#	48, 1000, 0, 0)
 
 # Low Latency capture pipeline 6 on PCM 2 using max 2 channels of s16le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
-	6, 2, 2, s16le,
-	48, 1000, 0, 0)
+#PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
+#	6, 2, 2, s16le,
+#	48, 1000, 0, 0)
 
 # Low Latency playback pipeline 7 on PCM 3 using max 2 channels of s16le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
@@ -84,15 +88,15 @@ PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 
 # Low Latency playback pipeline 9 on PCM 4 using max 2 channels of s16le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
-	9, 4, 2, s16le,
-	48, 1000, 0, 0)
+#PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+#	9, 4, 2, s16le,
+#	48, 1000, 0, 0)
 
 # Low Latency capture pipeline 10 on PCM 4 using max 2 channels of s16le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
-	10, 4, 2, s16le,
-	48, 1000, 0, 0)
+#PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
+#	10, 4, 2, s16le,
+#	48, 1000, 0, 0)
 
 # Low Latency playback pipeline 11 on PCM 5 using max 2 channels of s16le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
@@ -151,17 +155,17 @@ DAI_ADD(sof/pipe-dai-capture.m4,
 
 # playback DAI is SSP2 using 2 periods
 # Buffers use s16le format, with 48 frame per 1000us on core 0 with priority 0
-DAI_ADD(sof/pipe-dai-playback.m4,
-	5, SSP, 2, NoCodec-2,
-	PIPELINE_SOURCE_5, 2, s16le,
-	48, 1000, 0, 0)
+#DAI_ADD(sof/pipe-dai-playback.m4,
+#	5, SSP, 2, NoCodec-2,
+#	PIPELINE_SOURCE_5, 2, s16le,
+#	48, 1000, 0, 0)
 
 # capture DAI is SSP2 using 2 periods
 # Buffers use s16le format, with 48 frame per 1000us on core 0 with priority 0
-DAI_ADD(sof/pipe-dai-capture.m4,
-	6, SSP, 2, NoCodec-2,
-	PIPELINE_SINK_6, 2, s16le,
-	48, 1000, 0, 0)
+#DAI_ADD(sof/pipe-dai-capture.m4,
+#	6, SSP, 2, NoCodec-2,
+#	PIPELINE_SINK_6, 2, s16le,
+#	48, 1000, 0, 0)
 
 # playback DAI is SSP3 using 2 periods
 # Buffers use s16le format, with 48 frame per 1000us on core 0 with priority 0
@@ -179,17 +183,17 @@ DAI_ADD(sof/pipe-dai-capture.m4,
 
 # playback DAI is SSP4 using 2 periods
 # Buffers use s16le format, with 48 frame per 1000us on core 0 with priority 0
-DAI_ADD(sof/pipe-dai-playback.m4,
-	9, SSP, 4, NoCodec-4,
-	PIPELINE_SOURCE_9, 2, s16le,
-	48, 1000, 0, 0)
+#DAI_ADD(sof/pipe-dai-playback.m4,
+#	9, SSP, 4, NoCodec-4,
+#	PIPELINE_SOURCE_9, 2, s16le,
+#	48, 1000, 0, 0)
 
 # capture DAI is SSP4 using 2 periods
 # Buffers use s16le format, with 48 frame per 1000us on core 0 with priority 0
-DAI_ADD(sof/pipe-dai-capture.m4,
-	10, SSP, 4, NoCodec-4,
-	PIPELINE_SINK_10, 2, s16le,
-	48, 1000, 0, 0)
+#DAI_ADD(sof/pipe-dai-capture.m4,
+#	10, SSP, 4, NoCodec-4,
+#	PIPELINE_SINK_10, 2, s16le,
+#	48, 1000, 0, 0)
 
 # playback DAI is SSP5 using 2 periods
 # Buffers use s16le format, with 48 frame per 1000us on core 0 with priority 0
@@ -215,9 +219,9 @@ DAI_ADD(sof/pipe-dai-capture.m4,
 dnl PCM_DUPLEX_ADD(name, pcm_id, playback, capture)
 PCM_DUPLEX_ADD(Port0, 0, PIPELINE_PCM_1, PIPELINE_PCM_2)
 PCM_DUPLEX_ADD(Port1, 1, PIPELINE_PCM_3, PIPELINE_PCM_4)
-PCM_DUPLEX_ADD(Port2, 2, PIPELINE_PCM_5, PIPELINE_PCM_6)
+#PCM_DUPLEX_ADD(Port2, 2, PIPELINE_PCM_5, PIPELINE_PCM_6)
 PCM_DUPLEX_ADD(Port3, 3, PIPELINE_PCM_7, PIPELINE_PCM_8)
-PCM_DUPLEX_ADD(Port4, 4, PIPELINE_PCM_9, PIPELINE_PCM_10)
+#PCM_DUPLEX_ADD(Port4, 4, PIPELINE_PCM_9, PIPELINE_PCM_10)
 PCM_DUPLEX_ADD(Port5, 5, PIPELINE_PCM_11, PIPELINE_PCM_12)
 dnl PCM_CAPTURE_ADD(name, pipeline, capture)
 PCM_CAPTURE_ADD(DMIC01, 6, PIPELINE_PCM_13)
@@ -243,12 +247,12 @@ DAI_CONFIG(SSP, 1, 1, NoCodec-1,
 		      SSP_TDM(2, 16, 3, 3),
 		      SSP_CONFIG_DATA(SSP, 1, 16)))
 
-DAI_CONFIG(SSP, 2, 2, NoCodec-2,
-	   SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24576000, codec_mclk_in),
-		      SSP_CLOCK(bclk, 1536000, codec_slave),
-		      SSP_CLOCK(fsync, 48000, codec_slave),
-		      SSP_TDM(2, 16, 3, 3),
-		      SSP_CONFIG_DATA(SSP, 2, 16)))
+#DAI_CONFIG(SSP, 2, 2, NoCodec-2,
+#	   SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24576000, codec_mclk_in),
+#		      SSP_CLOCK(bclk, 1536000, codec_slave),
+#		      SSP_CLOCK(fsync, 48000, codec_slave),
+#		      SSP_TDM(2, 16, 3, 3),
+#		      SSP_CONFIG_DATA(SSP, 2, 16)))
 
 DAI_CONFIG(SSP, 3, 3, NoCodec-3,
 	   SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24576000, codec_mclk_in),
@@ -257,12 +261,12 @@ DAI_CONFIG(SSP, 3, 3, NoCodec-3,
 		      SSP_TDM(2, 16, 3, 3),
 		      SSP_CONFIG_DATA(SSP, 3, 16)))
 
-DAI_CONFIG(SSP, 4, 4, NoCodec-4,
-	   SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24576000, codec_mclk_in),
-		      SSP_CLOCK(bclk, 1536000, codec_slave),
-		      SSP_CLOCK(fsync, 48000, codec_slave),
-		      SSP_TDM(2, 16, 3, 3),
-		      SSP_CONFIG_DATA(SSP, 4, 16)))
+#DAI_CONFIG(SSP, 4, 4, NoCodec-4,
+#	   SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24576000, codec_mclk_in),
+#		      SSP_CLOCK(bclk, 1536000, codec_slave),
+#		      SSP_CLOCK(fsync, 48000, codec_slave),
+#		      SSP_TDM(2, 16, 3, 3),
+#		      SSP_CONFIG_DATA(SSP, 4, 16)))
 
 DAI_CONFIG(SSP, 5, 5, NoCodec-5,
 	   SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24576000, codec_mclk_in),


### PR DESCRIPTION
By default topology is using too many capture and playback PCMs, DAIs and
pipelines for available host GW DMAC channels. Comment out some so that
DMAC channels stay within bounds. This also gives users options to
re-enable for their given test HW.

Signed-off-by: Liam Girdwood <liam.r.girdwood@linux.intel.com>