### PR TITLE
ipc: prevent duplicate interrupt masking and msg overwrite

### DIFF
--- a/src/ipc/apl-ipc.c
+++ b/src/ipc/apl-ipc.c
@@ -72,11 +72,6 @@ static void irq_handler(void *arg)
 	/* new message from host */
 	if (dipct & IPC_DIPCT_BUSY && dipcctl & IPC_DIPCCTL_IPCTBIE) {
 
-		/* mask Busy interrupt */
-		ipc_write(IPC_DIPCCTL, dipcctl & ~IPC_DIPCCTL_IPCTBIE);
-
-		msg = dipct & IPC_DIPCT_MSG_MASK;
-
 		/* TODO: place message in Q and process later */
 		/* It's not Q ATM, may overwrite */
 		if (_ipc->host_pending) {
@@ -84,6 +79,12 @@ static void irq_handler(void *arg)
 			trace_ipc_error(" dipct 0x%x dipcie 0x%x dipcctl 0x%x",
 					dipct, dipcie, ipc_read(IPC_DIPCCTL));
 		} else {
+
+			/* mask Busy interrupt */
+			ipc_write(IPC_DIPCCTL, dipcctl & ~IPC_DIPCCTL_IPCTBIE);
+
+			msg = dipct & IPC_DIPCT_MSG_MASK;
+
 			_ipc->host_msg = msg;
 			_ipc->host_pending = 1;
 			ipc_schedule_process(_ipc);

--- a/src/ipc/byt-ipc.c
+++ b/src/ipc/byt-ipc.c
@@ -111,12 +111,6 @@ static void irq_handler(void *arg)
 	if (isr & SHIM_ISRD_BUSY &&
 	    !(imrd & SHIM_IMRD_BUSY)) {
 
-		/* Mask Busy interrupt before return */
-		shim_write(SHIM_IMRD, shim_read(SHIM_IMRD) | SHIM_IMRD_BUSY);
-		interrupt_clear(PLATFORM_IPC_INTERRUPT);
-
-		msg = shim_read(SHIM_IPCXL);
-
 		/* TODO: place message in Q and process later */
 		/* It's not Q ATM, may overwrite */
 		if (_ipc->host_pending) {
@@ -125,6 +119,14 @@ static void irq_handler(void *arg)
 					isr, shim_read(SHIM_IMRD),
 					shim_read(SHIM_IPCXH));
 		} else {
+
+			/* Mask Busy interrupt before return */
+			shim_write(SHIM_IMRD,
+				   shim_read(SHIM_IMRD) | SHIM_IMRD_BUSY);
+			interrupt_clear(PLATFORM_IPC_INTERRUPT);
+
+			msg = shim_read(SHIM_IPCXL);
+
 			_ipc->host_msg = msg;
 			_ipc->host_pending = 1;
 			ipc_schedule_process(_ipc);

--- a/src/ipc/cnl-ipc.c
+++ b/src/ipc/cnl-ipc.c
@@ -73,11 +73,6 @@ static void irq_handler(void *arg)
 	/* new message from host */
 	if (dipctdr & IPC_DIPCTDR_BUSY && dipcctl & IPC_DIPCCTL_IPCTBIE) {
 
-		/* mask Busy interrupt */
-		ipc_write(IPC_DIPCCTL, dipcctl & ~IPC_DIPCCTL_IPCTBIE);
-
-		msg = dipctdr & IPC_DIPCTDR_MSG_MASK;
-
 		/* TODO: place message in Q and process later */
 		/* It's not Q ATM, may overwrite */
 		if (_ipc->host_pending) {
@@ -86,6 +81,12 @@ static void irq_handler(void *arg)
 					dipctdr, dipcida,
 					ipc_read(IPC_DIPCCTL));
 		} else {
+
+			/* mask Busy interrupt */
+			ipc_write(IPC_DIPCCTL, dipcctl & ~IPC_DIPCCTL_IPCTBIE);
+
+			msg = dipctdr & IPC_DIPCTDR_MSG_MASK;
+
 			_ipc->host_msg = msg;
 			_ipc->host_pending = 1;
 			ipc_schedule_process(_ipc);

--- a/src/ipc/hsw-ipc.c
+++ b/src/ipc/hsw-ipc.c
@@ -106,12 +106,6 @@ static void irq_handler(void *arg)
 
 	if (isr & SHIM_ISRD_BUSY && !(imrd & SHIM_IMRD_BUSY)) {
 
-		/* Mask Busy interrupt before return */
-		shim_write(SHIM_IMRD, shim_read(SHIM_IMRD) | SHIM_IMRD_BUSY);
-		interrupt_clear(PLATFORM_IPC_INTERRUPT);
-
-		msg = shim_read(SHIM_IPCX);
-
 		/* TODO: place message in Q and process later */
 		/* It's not Q ATM, may overwrite */
 		if (_ipc->host_pending) {
@@ -120,6 +114,14 @@ static void irq_handler(void *arg)
 					isr, shim_read(SHIM_IMRD),
 					shim_read(SHIM_IPCX));
 		} else {
+
+			/* Mask Busy interrupt before return */
+			shim_write(SHIM_IMRD,
+				   shim_read(SHIM_IMRD) | SHIM_IMRD_BUSY);
+			interrupt_clear(PLATFORM_IPC_INTERRUPT);
+
+			msg = shim_read(SHIM_IPCX);
+
 			_ipc->host_msg = msg;
 			_ipc->host_pending = 1;
 			ipc_schedule_process(_ipc);


### PR DESCRIPTION
if host_pending is true and the dsp receives another doorbell,
it is likely to be a reply message from the host. So move
the check for host_pending before masking the BUSY interrupt
again or modifying the msg.

This fixes the ipc timeouts seen during suspend stress tests.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>