### PR TITLE
refine ipc msg structure

### DIFF
--- a/src/include/uapi/ipc/header.h
+++ b/src/include/uapi/ipc/header.h
@@ -59,13 +59,13 @@
  */
 
 /* Global Message - Generic */
-#define SOF_GLB_TYPE_SHIFT			28
+#define SOF_GLB_TYPE_SHIFT			24
 #define SOF_GLB_TYPE_MASK			(0xf << SOF_GLB_TYPE_SHIFT)
 #define SOF_GLB_TYPE(x)				((x) << SOF_GLB_TYPE_SHIFT)
 
 /* Command Message - Generic */
 #define SOF_CMD_TYPE_SHIFT			16
-#define SOF_CMD_TYPE_MASK			(0xfff << SOF_CMD_TYPE_SHIFT)
+#define SOF_CMD_TYPE_MASK			(0xff << SOF_CMD_TYPE_SHIFT)
 #define SOF_CMD_TYPE(x)				((x) << SOF_CMD_TYPE_SHIFT)
 
 /* Global Message Types */


### PR DESCRIPTION
Reserve LSB 32th ~ 29th bits for HW to trigger ipc msgs. Now
    our global type may overwrite some bits which are used to trigger
    ipc msgs. This case would make ipc out of order.
    
    On BDW, both LSB of 32th bit and 31th bit are used by ipc,
    #define  SHIM_IPCD_DONE          BIT(30)
    #define  SHIM_IPCD_BUSY          BIT(31)
    
    and on APL or CNL, only LSB 32th bit are used.
    #define HDA_DSP_REG_HIPCI_BUSY           BIT(31)
    
    Signed-off-by: Rander Wang <rander.wang@linux.intel.com>


please merge it with: https://github.com/thesofproject/linux/pull/398