### PR TITLE
IPC: fix component new fail issue.

### DIFF
--- a/src/include/sof/ipc.h
+++ b/src/include/sof/ipc.h
@@ -96,7 +96,7 @@ struct dai_config;
 			trace_ipc("ipc: hdr 0x%x rx (%d) > tx (%d)",	\
 				  rx->cmd, rx_size, tx->size);		\
 		} else if (tx->size > rx_size) {			\
-			memcpy(rx, tx, tx->size);			\
+			memcpy(rx, tx, rx_size);			\
 			trace_ipc("ipc: hdr 0x%x tx (%d) > rx (%d)",	\
 				  rx->cmd, tx->size, rx_size);		\
 		} else							\

--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -846,7 +846,7 @@ static int ipc_glb_tplg_comp_new(uint32_t header)
 		  comp.id, comp.type);
 
 	/* register component */
-	ret = ipc_comp_new(_ipc, &comp);
+	ret = ipc_comp_new(_ipc, (struct sof_ipc_comp *)_ipc->comp_data);
 	if (ret < 0) {
 		trace_ipc_error("ipc: pipe %d comp %d creation failed %d",
 				comp.pipeline_id, comp.id, ret);


### PR DESCRIPTION
We need to new component with the whole ipc struction passed in
ipc_comp_new(), e.g. struct sof_ipc_comp_dai, but not only the struct
sof_ipc_comp, otherwise, we will fail to new components and see errors
in log such as:
dai.c:208 	dai_new() error: dai_get() failed to create DAI. type:0,
index:-1106776464

Here change to pass in the whole _ipc->comp_data to fix this kind of
issues.

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>