### PR TITLE
task: move task_complete ahead task function run

### DIFF
--- a/src/arch/xtensa/include/arch/task.h
+++ b/src/arch/xtensa/include/arch/task.h
@@ -161,10 +161,17 @@ static void _irq_task(void *arg)
 
 		spin_unlock_irq(&irq_task->lock, flags);
 
-		if (task->func && task->state == TASK_STATE_RUNNING)
+		if (task->func && task->state == TASK_STATE_RUNNING) {
+			/* forehead state set to avoid state conflict
+			 * NOTICE: we did not have any wait_completed
+			 * user now, so this should work. But if any
+			 * task use wait completed, we need some refine
+			 * for the scheduler and task
+			 */
+			schedule_task_complete(task);
 			task->func(task->data);
+		}
 
-		schedule_task_complete(task);
 		spin_lock_irq(&irq_task->lock, flags);
 	}
 


### PR DESCRIPTION
With IPC task, the function will free lock on IPC and allow new IPC
comes from HOST. But the state of ipc_task may be not udpated at this
moment, and the new comer IPC will be droped by task scheduler add.
Move the complete ahead to avoid this situation. May need more
attention when new user for task.

Signed-off-by: Pan Xiuli <xiuli.pan@linux.intel.com>