### PR TITLE
gdb: fix ABI delta with kernel and make sure GDB flag is fully exported

### DIFF
--- a/src/include/sof/debug.h
+++ b/src/include/sof/debug.h
@@ -42,6 +42,12 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#if defined CONFIG_GDB_DEBUG
+#define DEBUG_GDB	1
+#else
+#define DEBUG_GDB	0
+#endif
+
 #ifdef DEBUG_BUILD
 
 #define DEBUG_SET_FW_READY_FLAGS	\
@@ -50,6 +56,7 @@
 		.build = 1,		\
 		.locks = DEBUG_LOCKS,	\
 		.locks_verbose = DEBUG_LOCKS_VERBOSE,	\
+		.gdb = DEBUG_GDB,	\
 	},				\
 }
 
@@ -133,6 +140,7 @@
 		.build = 0,		\
 		.locks = DEBUG_LOCKS,	\
 		.locks_verbose = DEBUG_LOCKS_VERBOSE,	\
+		.gdb = DEBUG_GDB,	\
 	},				\
 }
 

--- a/src/include/uapi/ipc/info.h
+++ b/src/include/uapi/ipc/info.h
@@ -90,8 +90,6 @@ struct sof_ipc_fw_ready {
 		} bits;
 	} debug;
 
-	uint32_t gdb_enabled;
-
 	/* reserved for future use */
 	uint32_t reserved[4];
 } __attribute__((packed));

--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -743,7 +743,8 @@ static int ipc_glb_gdb_debug(uint32_t header)
 	(void) header;
 
 #ifdef CONFIG_GDB_DEBUG
-	/* trigger debug exception */
+	/* TODO: this asm should be in arch/include/debug.h with a generic */
+	/* name and trigger debug exception */
 	asm volatile("_break 0, 0");
 	return 0;
 #else

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -79,11 +79,6 @@ static const struct sof_ipc_fw_ready ready
 		.abi_version = SOF_ABI_VERSION,
 	},
 	.debug = DEBUG_SET_FW_READY_FLAGS,
-
-#ifdef CONFIG_GDB_DEBUG
-	.gdb_enabled = CONFIG_GDB_DEBUG
-#endif
-
 };
 
 #if defined(CONFIG_MEM_WND)


### PR DESCRIPTION
Align ABI with kernel and make sure GDB enabled flag is fully exported
to all platforms.

Signed-off-by: Liam Girdwood <liam.r.girdwood@linux.intel.com>