### PR TITLE
pipeline: remove unnecessary pipeline_init and pipeline_data

### DIFF
--- a/src/audio/pipeline.c
+++ b/src/audio/pipeline.c
@@ -48,10 +48,6 @@
 #include <sof/idc.h>
 #include <platform/idc.h>
 
-struct pipeline_data {
-	spinlock_t lock;
-};
-
 /* generic operation data used by op graph walk */
 struct op_data {
 	int op;
@@ -61,7 +57,6 @@ struct op_data {
 	void *cmd_data;
 };
 
-static struct pipeline_data *pipe_data;
 static void pipeline_task(void *arg);
 
 /* call op on all upstream components - locks held by caller */
@@ -1316,21 +1311,4 @@ static void pipeline_task(void *arg)
 
 sched:
 	tracev_pipe("pipeline_task() sched");
-}
-
-/* init pipeline */
-int pipeline_init(void)
-{
-	trace_pipe("pipeline_init()");
-
-	pipe_data = rzalloc(RZONE_RUNTIME, SOF_MEM_CAPS_RAM,
-		sizeof(*pipe_data));
-	spinlock_init(&pipe_data->lock);
-
-	if (!pipe_data) {
-		trace_pipe_error("failed to init pipeline");
-		return -ENOMEM;
-	}
-
-	return 0;
 }

--- a/src/audio/pipeline_static.c
+++ b/src/audio/pipeline_static.c
@@ -363,11 +363,6 @@ int init_static_pipeline(struct ipc *ipc)
 	int k;
 	int ret;
 
-	/* init system pipeline core */
-	ret = pipeline_init();
-	if (ret < 0)
-		return ret;
-
 	/* create the pipelines */
 	for (i = 0; i < ARRAY_SIZE(pipeline); i++) {
 

--- a/src/include/sof/audio/pipeline.h
+++ b/src/include/sof/audio/pipeline.h
@@ -129,9 +129,6 @@ void pipeline_cache(struct pipeline *p, struct comp_dev *dev, int cmd);
 /* trigger pipeline - atomic */
 int pipeline_trigger(struct pipeline *p, struct comp_dev *host_cd, int cmd);
 
-/* initialise pipeline subsys */
-int pipeline_init(void);
-
 /* static pipeline creation */
 int init_static_pipeline(struct ipc *ipc);
 


### PR DESCRIPTION
Removes unnecessary pipeline_init function and pipeline_data
structure.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>