### PR TITLE
mixer: remove redundant prepare set state

### DIFF
--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -327,7 +327,6 @@ static int mixer_prepare(struct comp_dev *dev)
 
 		/* currently inactive so setup mixer */
 		md->mix_func = mix_n;
-		dev->state = COMP_STATE_PREPARE;
 
 		ret = comp_set_state(dev, COMP_TRIGGER_PREPARE);
 		if (ret < 0)


### PR DESCRIPTION
Removes redundant prepare set state in mixer.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>