### PR TITLE
Revert "ipc: get the ipc size from the header on copy"

### DIFF
--- a/src/include/sof/ipc.h
+++ b/src/include/sof/ipc.h
@@ -107,7 +107,7 @@ struct dai_config;
 #define IPC_COPY_CMD(rx, tx) \
 	_IPC_COPY_CMD(((struct sof_ipc_cmd_hdr *)&rx),			\
 			((struct sof_ipc_cmd_hdr *)tx),			\
-			((struct sof_ipc_cmd_hdr *)tx)->size)
+			sizeof(rx))
 
 /* validates internal non tail structures within IPC command structure */
 #define IPC_IS_SIZE_INVALID(object)					\


### PR DESCRIPTION
This reverts commit 7c620abcd0edcce62704a871b3789b6cc44ea4b6.