### PR TITLE
ipc: abi: Make sure we pass all IPC data to client APIs.

### DIFF
--- a/src/arch/xtensa/smp/include/arch/idc.h
+++ b/src/arch/xtensa/smp/include/arch/idc.h
@@ -231,7 +231,7 @@ static inline int idc_component_command(uint32_t cmd)
 		return -EINVAL;
 
 	/* execute component command */
-	ret = comp_cmd(comp_dev->cd, cmd, data);
+	ret = comp_cmd(comp_dev->cd, cmd, data, data->rhdr.hdr.size);
 
 	/* writeback control data */
 	dcache_writeback_region(data, data->rhdr.hdr.size);

--- a/src/audio/eq_fir.c
+++ b/src/audio/eq_fir.c
@@ -481,7 +481,7 @@ static int eq_fir_params(struct comp_dev *dev)
 }
 
 static int fir_cmd_get_data(struct comp_dev *dev,
-			    struct sof_ipc_ctrl_data *cdata)
+			    struct sof_ipc_ctrl_data *cdata, int max_size)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 
@@ -495,7 +495,8 @@ static int fir_cmd_get_data(struct comp_dev *dev,
 		/* Copy back to user space */
 		if (cd->config) {
 			bs = cd->config->size;
-			if (bs > SOF_EQ_FIR_MAX_SIZE || bs == 0)
+			if (bs > SOF_EQ_FIR_MAX_SIZE || bs == 0 ||
+			    bs > max_size)
 				return -EINVAL;
 			memcpy(cdata->data->data, cd->config, bs);
 			cdata->data->abi = SOF_ABI_VERSION;
@@ -613,7 +614,8 @@ static int fir_cmd_set_data(struct comp_dev *dev,
 }
 
 /* used to pass standard and bespoke commands (with data) to component */
-static int eq_fir_cmd(struct comp_dev *dev, int cmd, void *data)
+static int eq_fir_cmd(struct comp_dev *dev, int cmd, void *data,
+		      int max_data_size)
 {
 	struct sof_ipc_ctrl_data *cdata = data;
 	int ret = 0;
@@ -625,7 +627,7 @@ static int eq_fir_cmd(struct comp_dev *dev, int cmd, void *data)
 		ret = fir_cmd_set_data(dev, cdata);
 		break;
 	case COMP_CMD_GET_DATA:
-		ret = fir_cmd_get_data(dev, cdata);
+		ret = fir_cmd_get_data(dev, cdata, max_data_size);
 		break;
 	case COMP_CMD_SET_VALUE:
 		trace_eq("eq_fir_cmd(), COMP_CMD_SET_VALUE");

--- a/src/audio/eq_iir.c
+++ b/src/audio/eq_iir.c
@@ -451,7 +451,7 @@ static int eq_iir_params(struct comp_dev *dev)
 }
 
 static int iir_cmd_get_data(struct comp_dev *dev,
-			    struct sof_ipc_ctrl_data *cdata)
+			    struct sof_ipc_ctrl_data *cdata, int max_size)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 
@@ -466,7 +466,8 @@ static int iir_cmd_get_data(struct comp_dev *dev,
 		if (cd->config) {
 			bs = cd->config->size;
 			trace_value(bs);
-			if (bs > SOF_EQ_IIR_MAX_SIZE || bs == 0)
+			if (bs > SOF_EQ_IIR_MAX_SIZE || bs == 0 ||
+			    bs > max_size)
 				return -EINVAL;
 			memcpy(cdata->data->data, cd->config, bs);
 			cdata->data->abi = SOF_ABI_VERSION;
@@ -587,7 +588,8 @@ static int iir_cmd_set_data(struct comp_dev *dev,
 }
 
 /* used to pass standard and bespoke commands (with data) to component */
-static int eq_iir_cmd(struct comp_dev *dev, int cmd, void *data)
+static int eq_iir_cmd(struct comp_dev *dev, int cmd, void *data,
+		      int max_data_size)
 {
 	struct sof_ipc_ctrl_data *cdata = data;
 	int ret = 0;
@@ -599,7 +601,7 @@ static int eq_iir_cmd(struct comp_dev *dev, int cmd, void *data)
 		ret = iir_cmd_set_data(dev, cdata);
 		break;
 	case COMP_CMD_GET_DATA:
-		ret = iir_cmd_get_data(dev, cdata);
+		ret = iir_cmd_get_data(dev, cdata, max_data_size);
 		break;
 	case COMP_CMD_SET_VALUE:
 		trace_eq("eq_iir_cmd(), COMP_CMD_SET_VALUE");

--- a/src/audio/mux.c
+++ b/src/audio/mux.c
@@ -60,7 +60,8 @@ static int mux_params(struct comp_dev *dev)
 }
 
 /* used to pass standard and bespoke commands (with data) to component */
-static int mux_cmd(struct comp_dev *dev, int cmd, void *data)
+static int mux_cmd(struct comp_dev *dev, int cmd, void *data,
+		   int max_data_size)
 {
 	/* mux will use buffer "connected" status */
 	return 0;

--- a/src/audio/src.c
+++ b/src/audio/src.c
@@ -767,7 +767,8 @@ static int src_ctrl_cmd(struct comp_dev *dev, struct sof_ipc_ctrl_data *cdata)
 }
 
 /* used to pass standard and bespoke commands (with data) to component */
-static int src_cmd(struct comp_dev *dev, int cmd, void *data)
+static int src_cmd(struct comp_dev *dev, int cmd, void *data,
+		   int max_data_size)
 {
 	struct sof_ipc_ctrl_data *cdata = data;
 	int ret = 0;

--- a/src/audio/switch.c
+++ b/src/audio/switch.c
@@ -60,7 +60,8 @@ static int switch_params(struct comp_dev *dev)
 }
 
 /* used to pass standard and bespoke commands (with data) to component */
-static int switch_cmd(struct comp_dev *dev, int cmd, void *data)
+static int switch_cmd(struct comp_dev *dev, int cmd, void *data,
+		      int max_data_size)
 {
 	/* switch will use buffer "connected" status */
 	return 0;

--- a/src/audio/tone.c
+++ b/src/audio/tone.c
@@ -471,7 +471,7 @@ static int tone_params(struct comp_dev *dev)
 }
 
 static int tone_cmd_get_value(struct comp_dev *dev,
-			      struct sof_ipc_ctrl_data *cdata)
+			      struct sof_ipc_ctrl_data *cdata, int max_size)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 	int j;
@@ -490,7 +490,8 @@ static int tone_cmd_get_value(struct comp_dev *dev,
 	return 0;
 }
 
-static int tone_cmd_set_value(struct comp_dev *dev, struct sof_ipc_ctrl_data *cdata)
+static int tone_cmd_set_value(struct comp_dev *dev,
+			      struct sof_ipc_ctrl_data *cdata)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 	int j;
@@ -611,7 +612,8 @@ static int tone_cmd_set_data(struct comp_dev *dev,
 }
 
 /* used to pass standard and bespoke commands (with data) to component */
-static int tone_cmd(struct comp_dev *dev, int cmd, void *data)
+static int tone_cmd(struct comp_dev *dev, int cmd, void *data,
+		    int max_data_size)
 {
 	struct sof_ipc_ctrl_data *cdata = data;
 	int ret = 0;
@@ -626,7 +628,7 @@ static int tone_cmd(struct comp_dev *dev, int cmd, void *data)
 		ret = tone_cmd_set_value(dev, cdata);
 		break;
 	case COMP_CMD_GET_VALUE:
-		ret = tone_cmd_get_value(dev, cdata);
+		ret = tone_cmd_get_value(dev, cdata, max_data_size);
 		break;
 	}
 

--- a/src/audio/volume.c
+++ b/src/audio/volume.c
@@ -383,7 +383,7 @@ static int volume_ctrl_set_cmd(struct comp_dev *dev,
  * \return Error code.
  */
 static int volume_ctrl_get_cmd(struct comp_dev *dev,
-			       struct sof_ipc_ctrl_data *cdata)
+			       struct sof_ipc_ctrl_data *cdata, int size)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 	int j;
@@ -425,7 +425,8 @@ static int volume_ctrl_get_cmd(struct comp_dev *dev,
  * \param[in,out] data Control command data.
  * \return Error code.
  */
-static int volume_cmd(struct comp_dev *dev, int cmd, void *data)
+static int volume_cmd(struct comp_dev *dev, int cmd, void *data,
+		      int max_data_size)
 {
 	struct sof_ipc_ctrl_data *cdata = data;
 
@@ -435,7 +436,7 @@ static int volume_cmd(struct comp_dev *dev, int cmd, void *data)
 	case COMP_CMD_SET_VALUE:
 		return volume_ctrl_set_cmd(dev, cdata);
 	case COMP_CMD_GET_VALUE:
-		return volume_ctrl_get_cmd(dev, cdata);
+		return volume_ctrl_get_cmd(dev, cdata, max_data_size);
 	default:
 		return -EINVAL;
 	}

--- a/src/host/file.c
+++ b/src/host/file.c
@@ -551,7 +551,8 @@ static int file_trigger(struct comp_dev *dev, int cmd)
 }
 
 /* used to pass standard and bespoke commands (with data) to component */
-static int file_cmd(struct comp_dev *dev, int cmd, void *data)
+static int file_cmd(struct comp_dev *dev, int cmd, void *data,
+		    int max_data_size)
 {
 	struct sof_ipc_ctrl_data *cdata = data;
 	int ret = 0;

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -161,7 +161,8 @@ struct comp_ops {
 		struct sof_ipc_dai_config *dai_config);
 
 	/* used to pass standard and bespoke commands (with optional data) */
-	int (*cmd)(struct comp_dev *dev, int cmd, void *data);
+	int (*cmd)(struct comp_dev *dev, int cmd, void *data,
+		   int max_data_size);
 
 	/* atomic - used to start/stop/pause stream operations */
 	int (*trigger)(struct comp_dev *dev, int cmd);
@@ -283,7 +284,8 @@ static inline int comp_host_buffer(struct comp_dev *dev,
 }
 
 /* send component command - mandatory */
-static inline int comp_cmd(struct comp_dev *dev, int cmd, void *data)
+static inline int comp_cmd(struct comp_dev *dev, int cmd, void *data,
+			   int max_data_size)
 {
 	struct sof_ipc_ctrl_data *cdata = data;
 
@@ -296,7 +298,7 @@ static inline int comp_cmd(struct comp_dev *dev, int cmd, void *data)
 		return -EINVAL;
 	}
 
-	return dev->drv->ops.cmd(dev, cmd, data);
+	return dev->drv->ops.cmd(dev, cmd, data, max_data_size);
 }
 
 /* trigger component - mandatory and atomic */


### PR DESCRIPTION
Make sure we pass the entirety of IPC data between FW and host by
using the raw buffer for client APIs and the local copy for local
ABI safe instrospection & validation.

Make sure this works both ways and add a max_data_size argument to
comp_cmd() API in order for client API's to to overflow the return buffer.

Signed-off-by: Liam Girdwood <liam.r.girdwood@linux.intel.com>