### PR TITLE
DO NOT MERGE - pipeline: disable xrun recovery

### DIFF
--- a/src/include/sof/audio/pipeline.h
+++ b/src/include/sof/audio/pipeline.h
@@ -44,10 +44,15 @@
 
 /*
  * This flag disables firmware-side xrun recovery.
- * It should remain enabled in the situation when the
+ * It should remain set in the situation when the
  * recovery is delegated to the outside of firmware.
  */
-#define NO_XRUN_RECOVERY 0
+#define NO_XRUN_RECOVERY 1
+
+#define PIPELINE_SET_FW_READY_FLAGS \
+( \
+	(NO_XRUN_RECOVERY ? SOF_IPC_INFO_EXTERN_XRUN_RECOV : 0) \
+)
 
 /* pipeline tracing */
 #define trace_pipe(format, ...) \

--- a/src/include/uapi/abi.h
+++ b/src/include/uapi/abi.h
@@ -52,7 +52,7 @@
 
 /** \brief SOF ABI version major, minor and patch numbers */
 #define SOF_ABI_MAJOR 3
-#define SOF_ABI_MINOR 7
+#define SOF_ABI_MINOR 8
 #define SOF_ABI_PATCH 0
 
 /** \brief SOF ABI version number. Format within 32bit word is MMmmmppp */

--- a/src/include/uapi/ipc/info.h
+++ b/src/include/uapi/ipc/info.h
@@ -55,6 +55,7 @@
 #define SOF_IPC_INFO_LOCKS		BIT(1)
 #define SOF_IPC_INFO_LOCKSV		BIT(2)
 #define SOF_IPC_INFO_GDB		BIT(3)
+#define SOF_IPC_INFO_EXTERN_XRUN_RECOV	BIT(4)
 
 /* extended data types that can be appended onto end of sof_ipc_fw_ready */
 enum sof_ipc_ext_data {

--- a/src/platform/baytrail/platform.c
+++ b/src/platform/baytrail/platform.c
@@ -78,7 +78,7 @@ static const struct sof_ipc_fw_ready ready
 		.tag = SOF_TAG,
 		.abi_version = SOF_ABI_VERSION,
 	},
-	.flags = DEBUG_SET_FW_READY_FLAGS
+	.flags = DEBUG_SET_FW_READY_FLAGS | PIPELINE_SET_FW_READY_FLAGS,
 };
 
 #define NUM_BYT_WINDOWS		6

--- a/src/platform/haswell/platform.c
+++ b/src/platform/haswell/platform.c
@@ -77,7 +77,7 @@ static const struct sof_ipc_fw_ready ready
 		.tag = SOF_TAG,
 		.abi_version = SOF_ABI_VERSION,
 	},
-	.flags = DEBUG_SET_FW_READY_FLAGS,
+	.flags = DEBUG_SET_FW_READY_FLAGS | PIPELINE_SET_FW_READY_FLAGS,
 };
 
 #define NUM_HSW_WINDOWS		6

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -80,7 +80,7 @@ static const struct sof_ipc_fw_ready ready
 		.tag = SOF_TAG,
 		.abi_version = SOF_ABI_VERSION,
 	},
-	.flags = DEBUG_SET_FW_READY_FLAGS,
+	.flags = DEBUG_SET_FW_READY_FLAGS | PIPELINE_SET_FW_READY_FLAGS,
 };
 
 #if defined(CONFIG_MEM_WND)


### PR DESCRIPTION
This is in order to delegate the xrun recovery to the driver/ALSA.
Shouldn't be merged until the driver is ready.

Signed-off-by: Slawomir Blauciak <slawomir.blauciak@linux.intel.com>