### PR TITLE
test: fix _zalloc ut

### DIFF
--- a/test/cmocka/src/audio/pipeline/pipeline_mocks.c
+++ b/test/cmocka/src/audio/pipeline/pipeline_mocks.c
@@ -101,3 +101,8 @@ struct ipc_comp_dev *ipc_get_comp(struct ipc *ipc, uint32_t id)
 
 	return NULL;
 }
+
+void heap_trace_all(int force)
+{
+	(void)force;
+}

--- a/test/cmocka/src/audio/pipeline/pipeline_new_allocation.c
+++ b/test/cmocka/src/audio/pipeline/pipeline_new_allocation.c
@@ -52,9 +52,9 @@ static void test_audio_pipeline_pipeline_new_memory_allocation(
 	 *in future so expect errors here if any change to pipeline memory
 	 *capabilities or memmory space was made
 	 */
-	expect_value(rzalloc, zone, RZONE_RUNTIME);
-	expect_value(rzalloc, caps, SOF_MEM_CAPS_RAM);
-	expect_value(rzalloc, bytes, sizeof(struct pipeline));
+	expect_value(_zalloc, zone, RZONE_RUNTIME);
+	expect_value(_zalloc, caps, SOF_MEM_CAPS_RAM);
+	expect_value(_zalloc, bytes, sizeof(struct pipeline));
 
 	/*Testing component*/
 	result = pipeline_new(&pipe_desc, cd);

--- a/test/cmocka/src/audio/pipeline/pipeline_new_allocation_mocks.c
+++ b/test/cmocka/src/audio/pipeline/pipeline_new_allocation_mocks.c
@@ -37,7 +37,7 @@
 #include <stdint.h>
 #include <cmocka.h>
 
-void *rzalloc(int zone, uint32_t caps, size_t bytes)
+void *_zalloc(int zone, uint32_t caps, size_t bytes)
 {
 	check_expected(zone);
 	check_expected(caps);


### PR DESCRIPTION
Fixes changes caused by changing rzalloc into macro wrapper for _zalloc

Signed-off-by: Janusz Jankowski <janusz.jankowski@linux.intel.com>