### PR TITLE
xtensa: xtos:  Fix typo in reset-vector.S

### DIFF
--- a/src/arch/xtensa/up/xtos/reset-vector.S
+++ b/src/arch/xtensa/up/xtos/reset-vector.S
@@ -99,7 +99,7 @@ _reset_sram:
 	.word _ResetHandler
 	.align 4
 .sram_jump:
-	l32r	a0, _reset_sram	// load SRAM reset hanler address
+	l32r	a0, _reset_sram	// load SRAM reset handler address
 	jx	a0		// jump to the hanlder
 #endif
 	.size	_ResetVector, . - _ResetVector


### PR DESCRIPTION
Signed-off-by: Liam Girdwood <liam.r.girdwood@linux.intel.com>