### PR TITLE
Fix ut host

### DIFF
--- a/src/library/include/platform/platform.h
+++ b/src/library/include/platform/platform.h
@@ -55,8 +55,8 @@
 #define HOST_PAGE_SIZE		4096
 
 /* Platform stream capabilities */
-#define PLATFORM_MAX_CHANNELS	4
-#define PLATFORM_MAX_STREAMS	5
+#define PLATFORM_MAX_CHANNELS	8
+#define PLATFORM_MAX_STREAMS	16
 
 /* DMA channel drain timeout in microseconds */
 #define PLATFORM_DMA_TIMEOUT	1333

--- a/test/cmocka/Makefile.am
+++ b/test/cmocka/Makefile.am
@@ -116,8 +116,10 @@ preproc_get_arg_SOURCES =\
 
 # debugability tests
 
+if BUILD_XTENSA
 check_PROGRAMS += debugability_macros
 debugability_macros_SOURCES = src/debugability/macros.c
+endif
 
 # lib/lib tests
 
@@ -150,6 +152,9 @@ endif
 
 # volume tests
 
+if BUILD_XTENSA
+# these tests should be able to run on host after some tuning
+
 check_PROGRAMS += volume_process
 volume_process_SOURCES = src/audio/volume/volume_process.c
 volume_process_CFLAGS = -I../../src/audio $(AM_CFLAGS)
@@ -165,7 +170,12 @@ else
 volume_process_LDADD =  ../../src/audio/libaudio.a $(LDADD)
 endif
 
+endif
+
 # buffer tests
+
+if BUILD_XTENSA
+# these tests should be able to run on host after some tuning
 
 check_PROGRAMS += buffer_new
 buffer_new_SOURCES = src/audio/buffer/buffer_new.c src/audio/buffer/mock.c
@@ -213,6 +223,8 @@ buffer_copy_SOURCES += 	../../src/audio/component.c \
 buffer_copy_LDADD =  ../../src/host/libtb_common.a $(LDADD) -ldl
 else
 buffer_copy_LDADD =  ../../src/audio/libaudio.a $(LDADD)
+endif
+
 endif
 
 # component tests


### PR DESCRIPTION
I'm not sure, but I think you may need this to really close #735 issue for now

Fixes ut for host:
Mixer - fixed by increasing platform streams count

Disables ut for host:
Debugability - not designed to be run on host at all
Volume - needs some tuning to not fail
Buffer - needs some fixes to not have segfault
