### PR TITLE
xtos: prefctl: Set correctly for skl and kbl.

### DIFF
--- a/src/arch/xtensa/up/xtos/reset-vector.S
+++ b/src/arch/xtensa/up/xtos/reset-vector.S
@@ -356,9 +356,15 @@ _ResetHandler:
 #if XCHAL_HAVE_PREFETCH
 	/* Enable cache prefetch if present.  */
 #if defined(CONFIG_APOLLOLAKE)
-	movi.n	a2, 34
+
+#if defined(CONFIG_SKYLAKE) || defined(CONFIG_KABYLAKE)
+	movi.n	a2, 0	/* skylake and kabylake */
 #else
-	movi.n	a2, 68
+	movi.n	a2, 34  /* apollolake */
+#endif
+
+#else
+	movi.n	a2, 68  /* eveything else */
 #endif
 	wsr	a2, PREFCTL
 #endif


### PR DESCRIPTION
Update PREFCTL setting to correct values. Needs checked and updated for SMP too.

Signed-off-by: Liam Girdwood <liam.r.girdwood@linux.intel.com>