### PR TITLE
Testbench: Bug fix for s16 file read

### DIFF
--- a/src/host/file.c
+++ b/src/host/file.c
@@ -165,8 +165,6 @@ static int read_samples_16(struct comp_dev *dev, struct comp_buffer *sink,
 
 			/* copy sample per channel */
 			for (i = 0; i < nch; i++) {
-				/* read sample from file */
-				ret = fscanf(cd->fs.rfh, "%hd", dest);
 				switch (cd->fs.f_format) {
 				/* text input file */
 				case FILE_TEXT:


### PR DESCRIPTION
This patch removes some obsolete code that caused file
pointer to get out of sync and corrupt all data read.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>