### PR TITLE
PM D3 entry fixes for APL

### DIFF
--- a/src/ipc/apl-ipc.c
+++ b/src/ipc/apl-ipc.c
@@ -133,18 +133,17 @@ void ipc_platform_do_cmd(struct ipc *ipc)
 done:
 	ipc->host_pending = 0;
 
+	/* are we about to enter D3 ? */
+	if (iipc->pm_prepare_D3) {
+		/* no return - memory will be powered off and IPC sent */
+		platform_pm_runtime_power_off();
+	}
+
 	/* write 1 to clear busy, and trigger interrupt to host*/
-	ipc_write(IPC_DIPCT, ipc_read(IPC_DIPCT) |IPC_DIPCT_BUSY );
+	ipc_write(IPC_DIPCT, ipc_read(IPC_DIPCT) | IPC_DIPCT_BUSY);
 
 	/* unmask Busy interrupt */
 	ipc_write(IPC_DIPCCTL, ipc_read(IPC_DIPCCTL) | IPC_DIPCCTL_IPCTBIE);
-
-	// TODO: signal audio work to enter D3 in normal context
-	/* are we about to enter D3 ? */
-	if (iipc->pm_prepare_D3) {
-		/* no return - memory will be powered off */
-		platform_pm_runtime_power_off();
-	}
 }
 
 void ipc_platform_send_msg(struct ipc *ipc)

--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -611,7 +611,7 @@ static int ipc_pm_context_save(uint32_t header)
 	//mm_pm_context_save(struct dma_sg_config *sg);
 
 	/* mask all DSP interrupts */
-	arch_interrupt_disable_mask(0xffff);
+	arch_interrupt_disable_mask(0xffffffff);
 
 	/* TODO: mask ALL platform interrupts inc DMA */
 

--- a/src/platform/apollolake/power_down.S
+++ b/src/platform/apollolake/power_down.S
@@ -146,6 +146,15 @@ _PD_RELEASE_VNN:
 
 	//TODO: add sending IPC reply from L1$ locked code
 
+_PD_SEND_IPC:
+	// Send IPC to host informing of PD completion - Clear BUSY bit by
+	// writting IPC_DIPCT_BUSY to IPC_DIPCT
+	movi temp_reg0, IPC_HOST_BASE
+	l32i temp_reg1, temp_reg0, IPC_DIPCT
+	movi temp_reg2, IPC_DIPCT_BUSY
+	or temp_reg1, temp_reg1, temp_reg2
+	s32i temp_reg1, temp_reg0, IPC_DIPCT
+
 _PD_SLEEP:
     // effecfively executes:
     // xmp_spin()


### PR DESCRIPTION
Fixes to make sure PM entry is completed prior to IPC.

@Jocelyn-Li this also needs done for CNL, ICL. IPC signalling is different. Perhaps someone can do this in PRC over the holidays.
@michalgrodzicki someone from your team should review and cherry pick into release branch.
@ranj063 fyi, cleaned up version. I will merge into master once CI passes.