### PR TITLE
prefctl: sml: make sure prefctl settings match UP settings.

### DIFF
--- a/src/arch/xtensa/smp/xtos/reset-vector.S
+++ b/src/arch/xtensa/smp/xtos/reset-vector.S
@@ -335,8 +335,18 @@ _ResetHandler:
 
 #if XCHAL_HAVE_PREFETCH
 	/* Enable cache prefetch if present.  */
-	movi	a2, XCHAL_CACHE_PREFCTL_DEFAULT
-	wsr.prefctl	a2
+#if defined(CONFIG_APOLLOLAKE)
+
+#if defined(CONFIG_SKYLAKE) || defined(CONFIG_KABYLAKE)
+	movi.n	a2, 0	/* skylake and kabylake */
+#else
+	movi.n	a2, 34  /* apollolake */
+#endif
+
+#else
+	movi.n	a2, 68  /* eveything else */
+#endif
+	wsr	a2, PREFCTL
 #endif
 
 	/*


### PR DESCRIPTION
SMP prefctl setting should be the same as UP prefctl settings. Fix this.

Signed-off-by: Liam Girdwood <liam.r.girdwood@linux.intel.com>