### PR TITLE
scheduler: add pending_cnt for task to make pending scheduling possible

### DIFF
--- a/src/arch/xtensa/include/arch/task.h
+++ b/src/arch/xtensa/include/arch/task.h
@@ -160,7 +160,7 @@ static void _irq_task(void *arg)
 		task = container_of(clist, struct task, irq_list);
 		list_item_del(clist);
 
-		if (task->func && task->state == TASK_STATE_PENDING) {
+		if (task->func) {
 			schedule_task_running(task);
 			run_task = 1;
 		} else {

--- a/src/audio/pipeline.c
+++ b/src/audio/pipeline.c
@@ -1271,7 +1271,8 @@ void pipeline_schedule_copy(struct pipeline *p, uint64_t start)
  * buffers prior to trigger start. */
 void pipeline_schedule_copy_idle(struct pipeline *p)
 {
-	schedule_task_idle(&p->pipe_task, p->ipc_pipe.deadline);
+//	schedule_task_idle(&p->pipe_task, p->ipc_pipe.deadline);
+	schedule_task(&p->pipe_task, 0, p->ipc_pipe.deadline);
 }
 
 void pipeline_schedule_cancel(struct pipeline *p)

--- a/src/include/sof/schedule.h
+++ b/src/include/sof/schedule.h
@@ -91,6 +91,8 @@ struct task {
 	/* runtime duration in scheduling clock base */
 	uint64_t max_rtime;		/* max time taken to run */
 	completion_t complete;
+
+	uint32_t pending_cnt;
 };
 
 struct schedule_data **arch_schedule_get(void);
@@ -111,6 +113,7 @@ static inline void schedule_task_init(struct task *task, void (*func)(void *),
 	void *data)
 {
 	task->core = 0;
+	task->pending_cnt = 0;
 	task->state = TASK_STATE_INIT;
 	task->func = func;
 	task->data = data;
@@ -119,6 +122,7 @@ static inline void schedule_task_init(struct task *task, void (*func)(void *),
 static inline void schedule_task_free(struct task *task)
 {
 	task->state = TASK_STATE_FREE;
+	task->pending_cnt = 0;
 	task->func = NULL;
 	task->data = NULL;
 }


### PR DESCRIPTION
This series is [4/5] of fixes of #800.

When one instance of a task is queued(queued, pending, running, or
preempted), it is possible that another instance of this same task
scheduling require will come before the previous one is completed. In
today's design, this second instance may be dropped(e.g. for
pipeline_copy() task) and unexpected error will happen.

Here, we add a pending_cnt for the task, accumulate it when needed, and
schedule it when the previous one is finished.

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>