### PR TITLE
hda: dma preload timeout

### DIFF
--- a/src/drivers/intel/cavs/hda-dma.c
+++ b/src/drivers/intel/cavs/hda-dma.c
@@ -328,12 +328,19 @@ static int hda_dma_host_preload(struct dma *dma, struct hda_chan_data *chan)
 	int i;
 	int period_cnt;
 
+	uint64_t deadline = platform_timer_get(platform_timer) +
+			    clock_ms_to_ticks(PLATFORM_DEFAULT_CLOCK, 1) *
+					      PLATFORM_HOST_DMA_TIMEOUT / 1000;
+
 	/* waiting for buffer full after start
 	 * first try is unblocking, then blocking
 	 */
 	while (!(host_dma_reg_read(dma, chan->index, DGCS) & DGCS_BF) &&
-	       (chan->state & HDA_STATE_BF_WAIT))
-		; /* TODO: this should timeout and not wait forever */
+	       (chan->state & HDA_STATE_BF_WAIT)) {
+		if (deadline < platform_timer_get(platform_timer)) {
+			return -ETIME;
+		}
+	}
 
 	if (host_dma_reg_read(dma, chan->index, DGCS) & DGCS_BF) {
 		chan->state &= ~(HDA_STATE_HOST_PRELOAD | HDA_STATE_BF_WAIT);


### PR DESCRIPTION
Implementation for #723 

I used `PLATFORM_HOST_DMA_TIMEOUT` that looks to be defined for all platforms, but is unused - name looks good for this purpose, so I guess someone could even declare it for that use.
It's 50 microseconds for all platforms for now.

Signed-off-by: Janusz Jankowski <janusz.jankowski@linux.intel.com>