### PR TITLE
dma channel management fixes

### DIFF
--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -236,6 +236,7 @@ static struct comp_dev *dai_new(struct sof_ipc_comp *comp)
 	dd->dai_pos_blks = 0;
 	dd->xrun = 0;
 	dd->pointer_init = 0;
+	dd->chan = DMA_CHAN_INVALID;
 
 	dev->state = COMP_STATE_READY;
 	return dev;
@@ -747,8 +748,10 @@ static int dai_config(struct comp_dev *dev, struct sof_ipc_dai_config *config)
 		return -EINVAL;
 	}
 
-	/* channel is ignored by GP dma get function */
-	dd->chan = dma_channel_get(dd->dma, channel);
+	if (dd->chan == DMA_CHAN_INVALID)
+		/* get dma channel at first config only */
+		dd->chan = dma_channel_get(dd->dma, channel);
+
 	if (dd->chan < 0) {
 		trace_dai_error("dai_config() error: dma_channel_get() failed");
 		return -EIO;

--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -389,6 +389,8 @@ static struct comp_dev *host_new(struct sof_ipc_comp *comp)
 		goto error;
 #endif
 
+	hd->chan = DMA_CHAN_INVALID;
+
 	/* init posn data. TODO: other fields */
 	hd->posn.comp_id = comp->id;
 	hd->pointer_init = 0;
@@ -643,6 +645,9 @@ static int host_reset(struct comp_dev *dev)
 	/* free array for hda-dma only, do not free single one for dw-dma */
 	dma_sg_free(&hd->config.elem_array);
 #endif
+
+	/* reset dma channel as we have put it */
+	hd->chan = DMA_CHAN_INVALID;
 
 	host_pointer_reset(dev);
 	hd->pointer_init = 0;

--- a/src/include/sof/dma.h
+++ b/src/include/sof/dma.h
@@ -89,6 +89,8 @@
 #define DMA_RELOAD_END	0
 #define DMA_RELOAD_LLI	0xFFFFFFFF
 
+#define DMA_CHAN_INVALID	0xFFFFFFFF
+
 struct dma;
 
 /**


### PR DESCRIPTION
This series is only minor changes to fix a dma channel exhausted issue that happens at suspend/resume.
We get dma channels at dai_config() for dai component, but this might be called several times and the previous got channels are leak at that case.