### PR TITLE
SRC add S16_LE PCM format support

### DIFF
--- a/src/audio/src.h
+++ b/src/audio/src.h
@@ -84,48 +84,59 @@ struct polyphase_src {
 struct src_stage_prm {
 	int nch;
 	int times;
-	int32_t *x_rptr;
-	int32_t *x_end_addr;
+	void *x_rptr;
+	void *x_end_addr;
 	size_t x_size;
-	int32_t *y_wptr;
-	int32_t *y_addr;
-	int32_t *y_end_addr;
+	void *y_wptr;
+	void *y_addr;
+	void *y_end_addr;
 	size_t y_size;
+	int shift;
 	struct src_state *state;
 	struct src_stage *stage;
 };
 
-static inline void src_circ_inc_wrap(int32_t **ptr, int32_t *end, size_t size)
+static inline void src_inc_wrap(int32_t **ptr, int32_t *end, size_t size)
 {
 	if (*ptr >= end)
 		*ptr = (int32_t *)((size_t)*ptr - size);
 }
 
-static inline void src_circ_dec_wrap(int32_t **ptr, int32_t *addr, size_t size)
+static inline void src_dec_wrap(int32_t **ptr, int32_t *addr, size_t size)
 {
 	if (*ptr < addr)
 		*ptr = (int32_t *)((size_t)*ptr + size);
 }
 
+static inline void src_inc_wrap_s16(int16_t **ptr, int16_t *end, size_t size)
+{
+	if (*ptr >= end)
+		*ptr = (int16_t *)((size_t)*ptr - size);
+}
+
+static inline void src_dec_wrap_s16(int16_t **ptr, int16_t *addr, size_t size)
+{
+	if (*ptr < addr)
+		*ptr = (int16_t *)((size_t)*ptr + size);
+}
+
 void src_polyphase_reset(struct polyphase_src *src);
 
 int src_polyphase_init(struct polyphase_src *src, struct src_param *p,
-	int32_t *delay_lines_start);
+		       int32_t *delay_lines_start);
 
 int src_polyphase(struct polyphase_src *src, int32_t x[], int32_t y[],
-	int n_in);
+		  int n_in);
 
 void src_polyphase_stage_cir(struct src_stage_prm *s);
 
-void src_polyphase_stage_cir_s24(struct src_stage_prm *s);
+void src_polyphase_stage_cir_s16(struct src_stage_prm *s);
 
 int src_buffer_lengths(struct src_param *p, int fs_in, int fs_out, int nch,
-	int frames, int frames_is_for_source);
+		       int frames, int frames_is_for_source);
 
 int32_t src_input_rates(void);
 
 int32_t src_output_rates(void);
-
-int src_ceil_divide(int a, int b);
 
 #endif

--- a/src/audio/src_hifi3.c
+++ b/src/audio/src_hifi3.c
@@ -458,7 +458,7 @@ void src_polyphase_stage_cir_s16(struct src_stage_prm *s)
 	 * 11x address pointers,
 	 */
 	ae_int32x2 q = AE_ZERO32();
-	ae_int16x4 d;
+	ae_int16x4 d = AE_ZERO16();
 	ae_f32 *rp;
 	ae_f32 *wp;
 	int i;
@@ -508,8 +508,9 @@ void src_polyphase_stage_cir_s16(struct src_stage_prm *s)
 			n_min = (m < n_wrap_buf) ? m : n_wrap_buf;
 			m -= n_min;
 			for (i = 0; i < n_min; i++) {
-				/* Load a 16 bits sample and left shift by 16,
-				 * advance read and write pointers.
+				/* Load a 16 bits sample into d and left shift
+				 * by 16 into q, advance read and write
+				 * pointers.
 				 */
 				AE_L16_XP(d, (ae_int16 *)x_rptr,
 					  sizeof(ae_int16));

--- a/tools/test/audio/src_test_top.m
+++ b/tools/test/audio/src_test_top.m
@@ -28,6 +28,11 @@
 % Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
 %
 
+[n_fail, n_pass] = src_test(16, 16);
+if n_fail > 0 || n_pass < 1
+	fprintf('Error: SRC test with 16 bits data failed.\n');
+        quit(1)
+end
 [n_fail, n_pass] = src_test(24, 24);
 if n_fail > 0 || n_pass < 1
 	fprintf('Error: SRC test with 24 bits data failed.\n');
@@ -39,4 +44,4 @@ if n_fail > 0 || n_pass < 1
         quit(1)
 end
 
-fprintf('Success: SRC test with 24 and 32 bits data passed.\n');
+fprintf('Success: SRC test with 16, 24 and 32 bits data passed.\n');

--- a/tools/topology/sof/pipe-src-playback.m4
+++ b/tools/topology/sof/pipe-src-playback.m4
@@ -9,8 +9,22 @@ include(`utils.m4')
 include(`src.m4')
 include(`buffer.m4')
 include(`pcm.m4')
+include(`pga.m4')
 include(`dai.m4')
+include(`mixercontrol.m4')
 include(`pipeline.m4')
+
+#
+# Controls
+#
+# Volume Mixer control with max value of 32
+C_CONTROLMIXER(Master Playback Volume, PIPELINE_ID,
+	CONTROLMIXER_OPS(volsw, 256 binds the mixer control to volume get/put handlers, 256, 256),
+	CONTROLMIXER_MAX(, 32),
+	false,
+	CONTROLMIXER_TLV(TLV 32 steps from -90dB to +6dB for 3dB, vtlv_m90s3),
+	Channel register and shift for Front Left/Right,
+	LIST(`	', KCONTROL_CHANNEL(FL, 1, 0), KCONTROL_CHANNEL(FR, 1, 1)))
 
 #
 # Components and Buffers
@@ -31,35 +45,43 @@ W_DATA(media_src_conf, media_src_tokens)
 # "SRC" has 3 source and 3 sink periods
 W_SRC(0, PIPELINE_FORMAT, 3, 3, media_src_conf, 2)
 
+# "Volume" has 2 source and 2 sink periods
+W_PGA(0, PIPELINE_FORMAT, 2, 2, 2, LIST(`		', "Master Playback Volume PIPELINE_ID"))
+
 # Playback Buffers
 W_BUFFER(0, COMP_BUFFER_SIZE(3,
 	COMP_SAMPLE_SIZE(PIPELINE_FORMAT), PIPELINE_CHANNELS, SCHEDULE_FRAMES),
 	PLATFORM_HOST_MEM_CAP)
 W_BUFFER(1, COMP_BUFFER_SIZE(3,
 	COMP_SAMPLE_SIZE(PIPELINE_FORMAT), PIPELINE_CHANNELS, SCHEDULE_FRAMES),
+	PLATFORM_HOST_MEM_CAP)
+W_BUFFER(2, COMP_BUFFER_SIZE(2,
+	COMP_SAMPLE_SIZE(PIPELINE_FORMAT), PIPELINE_CHANNELS, SCHEDULE_FRAMES),
 	PLATFORM_DAI_MEM_CAP)
 
 #
 # Pipeline Graph
 #
-#  host PCM_P --> B0 --> SRC 0 --> B1 --> sink DAI0
+#  host PCM_P --> B0 --> SRC 0 --> B1 Volume 0 --> B2 --> sink DAI0
 
 P_GRAPH(pipe-pass-src-playback-PIPELINE_ID, PIPELINE_ID,
 	LIST(`		',
 	`dapm(N_PCMP(PCM_ID), SRC Playback PCM_ID)',
 	`dapm(N_BUFFER(0), N_PCMP(PCM_ID))',
 	`dapm(N_SRC(0), N_BUFFER(0))',
-	`dapm(N_BUFFER(1), N_SRC(0))'))
+	`dapm(N_BUFFER(1), N_SRC(0))',
+	`dapm(N_PGA(0), N_BUFFER(1))',
+	`dapm(N_BUFFER(2), N_PGA(0))'))
 
 #
 # Pipeline Source and Sinks
 #
-indir(`define', concat(`PIPELINE_SOURCE_', PIPELINE_ID), N_BUFFER(1))
+indir(`define', concat(`PIPELINE_SOURCE_', PIPELINE_ID), N_BUFFER(2))
 indir(`define', concat(`PIPELINE_PCM_', PIPELINE_ID), SRC Playback PCM_ID)
 
 #
 # PCM Configuration
 #
 
-PCM_CAPABILITIES(SRC Playback PCM_ID, `S24_LE', 8000, 192000, 2, PIPELINE_CHANNELS, 2, 16, 192, 16384, 65536, 65536)
+PCM_CAPABILITIES(SRC Playback PCM_ID, `S32_LE,S24_LE,S16_LE', 8000, 192000, 2, PIPELINE_CHANNELS, 2, 16, 192, 16384, 65536, 65536)
 


### PR DESCRIPTION
With this patch the S16_LE format becomes supported in addition
to S24_4LE and S32_LE. The generic C, HiFiEP, and HiFi3 versions
are updated. The patch changes the s24 polyphase algorithm for
s16 data and changes the s32 algorithm for both s24/s32 support
with a shift by 0 or 8 parameter.

As done for other components too the PCM format handling is moved
from params() to prepare() function since the actual pipeline
format didn't appear correctly in params().

The patch removes the own ceil_divide() function since it's
provided by math library. Also some code indents are fixed.

The s16 format is included to test bench test for SRC.

Finally, a volume component is added in topology after SRC to be able to convert
the variable pipeline s16/s24/s32 PCM format into PCM format used
by DAI. The PCM capabilities are changed to allow all the formats.