### PR TITLE
bootloader: change the start address to match the linker script

### DIFF
--- a/src/arch/xtensa/smp/xtos/reset-vector.S
+++ b/src/arch/xtensa/smp/xtos/reset-vector.S
@@ -616,7 +616,7 @@ unpackdone:
 	 */
 
 #if defined(CONFIG_BOOT_LOADER) && !defined(CONFIG_VM_ROM)
-	movi	a0, SOF_TEXT_START
+	movi	a0, SOF_TEXT_BASE
 	callx0	a0
 #else
 	call0	_start		// jump to _start (in crt1-*.S)

--- a/src/arch/xtensa/up/xtos/reset-vector.S
+++ b/src/arch/xtensa/up/xtos/reset-vector.S
@@ -587,7 +587,7 @@ unpackdone:
 
 #if defined(CONFIG_BOOT_LOADER) && !defined(CONFIG_VM_ROM)
 		/*ToDo refine the _start*/
-		movi a0, SOF_TEXT_START
+		movi a0, SOF_TEXT_BASE
 		callx0 a0
 #else
 		call0	_start		// jump to _start (in crt1-*.S)


### PR DESCRIPTION
Use SOF_TEXT_BASE instead of SOF_TEXT_START in asm