### PR TITLE
list: removing unnecessary list_item_del_init func

### DIFF
--- a/src/audio/pipeline.c
+++ b/src/audio/pipeline.c
@@ -160,7 +160,7 @@ static void disconnect_upstream(struct pipeline *p, struct comp_dev *start,
 
 	/* disconnect source from buffer */
 	spin_lock(&current->lock);
-	list_item_del_init(&current->bsource_list);
+	list_item_del(&current->bsource_list);
 	spin_unlock(&current->lock);
 }
 
@@ -190,7 +190,7 @@ static void disconnect_downstream(struct pipeline *p, struct comp_dev *start,
 
 	/* disconnect source from buffer */
 	spin_lock(&current->lock);
-	list_item_del_init(&current->bsink_list);
+	list_item_del(&current->bsink_list);
 	spin_unlock(&current->lock);
 }
 

--- a/src/include/sof/list.h
+++ b/src/include/sof/list.h
@@ -73,21 +73,12 @@ static inline void list_item_append(struct list_item *item,
 }
 
 /* delete item from the list leaves deleted list item
- *in undefined state list_is_empty won't return true
+ *in undefined state list_is_empty will return true
  */
 static inline void list_item_del(struct list_item *item)
 {
 	item->next->prev = item->prev;
 	item->prev->next = item->next;
-	list_init(item);
-}
-
-/* delete item from the list list iteam will be reinitialised
- * and list_is_empty will return true
- */
-static inline void list_item_del_init(struct list_item *item)
-{
-	list_item_del(item);
 	list_init(item);
 }
 


### PR DESCRIPTION
list_item_del_init function  had exactly the same
effect as list_item_del function

Signed-off-by: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>