### PR TITLE
gp-dma: Fix link position counter register block sizes

### DIFF
--- a/src/platform/apollolake/include/platform/memory.h
+++ b/src/platform/apollolake/include/platform/memory.h
@@ -75,11 +75,11 @@
 #define MN_SIZE			0x00000200
 
 /* low power DMA position */
-#define LP_GP_DMA_LINK_SIZE	0x00000080
+#define LP_GP_DMA_LINK_SIZE	0x00000010
 #define LP_GP_DMA_LINK_BASE(x) (0x00001C00 + x * LP_GP_DMA_LINK_SIZE)
 
 /* high performance DMA position */
-#define HP_GP_DMA_LINK_SIZE	0x00000800
+#define HP_GP_DMA_LINK_SIZE	0x00000010
 #define HP_GP_DMA_LINK_BASE(x)	(0x00001D00 + x * HP_GP_DMA_LINK_SIZE)
 
 /* link DMAC stream */

--- a/src/platform/cannonlake/include/platform/memory.h
+++ b/src/platform/cannonlake/include/platform/memory.h
@@ -80,11 +80,11 @@
 #define MN_SIZE			0x00000200
 
 /* low power DMA position */
-#define LP_GP_DMA_LINK_SIZE	0x00000080
+#define LP_GP_DMA_LINK_SIZE	0x00000010
 #define LP_GP_DMA_LINK_BASE(x) (0x00001C00 + x * LP_GP_DMA_LINK_SIZE)
 
 /* high performance DMA position */
-#define HP_GP_DMA_LINK_SIZE	0x00000800
+#define HP_GP_DMA_LINK_SIZE	0x00000010
 #define HP_GP_DMA_LINK_BASE(x)	(0x00001D00 + x * HP_GP_DMA_LINK_SIZE)
 
 /* link DMAC stream */

--- a/src/platform/icelake/include/platform/memory.h
+++ b/src/platform/icelake/include/platform/memory.h
@@ -80,11 +80,11 @@
 #define MN_SIZE			0x00000200
 
 /* low power DMA position */
-#define LP_GP_DMA_LINK_SIZE	0x00000080
+#define LP_GP_DMA_LINK_SIZE	0x00000010
 #define LP_GP_DMA_LINK_BASE(x) (0x00001C00 + x * LP_GP_DMA_LINK_SIZE)
 
 /* high performance DMA position */
-#define HP_GP_DMA_LINK_SIZE	0x00000800
+#define HP_GP_DMA_LINK_SIZE	0x00000010
 #define HP_GP_DMA_LINK_BASE(x)	(0x00001D00 + x * HP_GP_DMA_LINK_SIZE)
 
 /* link DMAC stream */

--- a/src/platform/suecreek/include/platform/memory.h
+++ b/src/platform/suecreek/include/platform/memory.h
@@ -80,11 +80,11 @@
 #define MN_SIZE			0x00000200
 
 /* low power DMA position */
-#define LP_GP_DMA_LINK_SIZE	0x00000080
+#define LP_GP_DMA_LINK_SIZE	0x00000010
 #define LP_GP_DMA_LINK_BASE(x) (0x00001C00 + x * LP_GP_DMA_LINK_SIZE)
 
 /* high performance DMA position */
-#define HP_GP_DMA_LINK_SIZE	0x00000800
+#define HP_GP_DMA_LINK_SIZE	0x00000010
 #define HP_GP_DMA_LINK_BASE(x)	(0x00001D00 + x * HP_GP_DMA_LINK_SIZE)
 
 /* link DMAC stream */


### PR DESCRIPTION
Register block size is 0x10

Signed-off-by: Liam Girdwood <liam.r.girdwood@linux.intel.com>