### PR TITLE
sue: fix platform name

### DIFF
--- a/src/platform/suecreek/boot_ldr.x.in
+++ b/src/platform/suecreek/boot_ldr.x.in
@@ -1,5 +1,5 @@
 /*
- * Linker Script for Cannonlake Bootloader.
+ * Linker Script for Sue Creek
  *
  * This script is run through the GNU C preprocessor to align the memory
  * offsets with headers.


### PR DESCRIPTION
Fix a copy-paste name in the Sue Creek boot-loader linker script.
