### PR TITLE
pipeline: add a flag for FW xrun recovery disabling

### DIFF
--- a/src/include/sof/audio/pipeline.h
+++ b/src/include/sof/audio/pipeline.h
@@ -42,6 +42,13 @@
 #include <sof/schedule.h>
 #include <uapi/ipc/topology.h>
 
+/*
+ * This flag disables firmware-side xrun recovery.
+ * It should remain enabled in the situation when the
+ * recovery is delegated to the outside of firmware.
+ */
+#define NO_XRUN_RECOVERY 0
+
 /* pipeline tracing */
 #define trace_pipe(format, ...) \
 	trace_event(TRACE_CLASS_PIPE, format, ##__VA_ARGS__)


### PR DESCRIPTION
This is PR [1/2] of Xrun recovery fixes and [1/5] of fixes of #800.

Add a flag NO_XRUN_RECOVERY to disable the FW internal xrun recovery,
make it to false by default.

Signed-off-by: Slawomir Blauciak <slawomir.blauciak@linux.intel.com>
Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>