### PR TITLE
add topology file for CometLake

### DIFF
--- a/tools/topology/Makefile.am
+++ b/tools/topology/Makefile.am
@@ -44,7 +44,8 @@ MACHINES = \
 	sof-apl-dmic-2ch.tplg \
 	sof-apl-dmic-4ch.tplg \
 	sof-icl-dmic-4ch.tplg \
-	sof-apl-src-pcm512x.tplg
+	sof-apl-src-pcm512x.tplg \
+	sof-cml-rt5682.tplg
 
 # Uncomment the following line if you want to debug conf files
 .PRECIOUS: %.conf
@@ -89,4 +90,5 @@ EXTRA_DIST = \
 	sof-apl-eq-dmic.m4 \
 	sof-apl-dmic-4ch.m4 \
 	sof-apl-dmic-2ch.m4 \
-	sof-apl-src-pcm512x.m4
+	sof-apl-src-pcm512x.m4 \
+	sof-cml-rt5682.m4

--- a/tools/topology/sof-cml-rt5682.m4
+++ b/tools/topology/sof-cml-rt5682.m4
@@ -1,0 +1,158 @@
+#
+# Topology for Cometlake with rt5682 codec.
+#
+
+# Include topology builder
+include(`utils.m4')
+include(`dai.m4')
+include(`pipeline.m4')
+include(`ssp.m4')
+include(`hda.m4')
+
+# Include TLV library
+include(`common/tlv.m4')
+
+# Include Token library
+include(`sof/tokens.m4')
+
+# Include Cannonlake DSP configuration
+include(`platform/intel/cnl.m4')
+include(`platform/intel/dmic.m4')
+
+DEBUG_START
+
+#
+# Define the pipelines
+#
+# PCM0 <---> volume <----> SSP1
+# PCM1 ----> volume -----> DMIC01 (dmic0 capture)
+# PCM2 ----> volume -----> iDisp1
+# PCM3 ----> volume -----> iDisp2
+# PCM4 ----> volume -----> iDisp3
+#
+
+dnl PIPELINE_PCM_ADD(pipeline,
+dnl     pipe id, pcm, max channels, format,
+dnl     frames, deadline, priority, core)
+
+# Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s24le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	1, 0, 2, s24le,
+	48, 1000, 0, 0)
+
+# Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s24le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
+	2, 0, 2, s24le,
+	48, 1000, 0, 0)
+
+# Passthrough capture pipeline 3 on PCM 1 using max 4 channels.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
+	3, 1, 4, s32le,
+	48, 1000, 0, 0)
+
+# Low Latency playback pipeline 4 on PCM 2 using max 2 channels of s32le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	4, 2, 2, s32le,
+	48, 1000, 0, 0)
+
+# Low Latency playback pipeline 5 on PCM 3 using max 2 channels of s32le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	5, 3, 2, s32le,
+	48, 1000, 0, 0)
+
+# Low Latency playback pipeline 6 on PCM 4 using max 2 channels of s32le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	6, 4, 2, s32le,
+	48, 1000, 0, 0)
+
+#
+# DAIs configuration
+#
+
+dnl DAI_ADD(pipeline,
+dnl     pipe id, dai type, dai_index, dai_be,
+dnl     buffer, periods, format,
+dnl     frames, deadline, priority, core)
+
+# playback DAI is SSP1 using 2 periods
+# Buffers use s24le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+	1, SSP, 1, SSP1-Codec,
+	PIPELINE_SOURCE_1, 2, s24le,
+	48, 1000, 0, 0)
+
+# capture DAI is SSP1 using 2 periods
+# Buffers use s24le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-capture.m4,
+	2, SSP, 1, SSP1-Codec,
+	PIPELINE_SINK_2, 2, s24le,
+	48, 1000, 0, 0)
+
+# capture DAI is DMIC01 using 2 periods
+# Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-capture.m4,
+	3, DMIC, 0, dmic01,
+	PIPELINE_SINK_3, 2, s32le,
+	48, 1000, 0, 0)
+
+# playback DAI is iDisp1 using 2 periods
+# Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+	4, HDA, 0, iDisp1,
+	PIPELINE_SOURCE_4, 2, s32le,
+	48, 1000, 0, 0)
+
+# playback DAI is iDisp2 using 2 periods
+# Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+	5, HDA, 1, iDisp2,
+	PIPELINE_SOURCE_5, 2, s32le,
+	48, 1000, 0, 0)
+
+# playback DAI is iDisp3 using 2 periods
+# Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+	6, HDA, 2, iDisp3,
+	PIPELINE_SOURCE_6, 2, s32le,
+	48, 1000, 0, 0)
+
+# PCM Low Latency, id 0
+dnl PCM_PLAYBACK_ADD(name, pcm_id, playback)
+PCM_DUPLEX_ADD(Port1, 0, PIPELINE_PCM_1, PIPELINE_PCM_2)
+PCM_CAPTURE_ADD(DMIC01, 1, PIPELINE_PCM_3)
+PCM_PLAYBACK_ADD(HDMI1, 2, PIPELINE_PCM_4)
+PCM_PLAYBACK_ADD(HDMI2, 3, PIPELINE_PCM_5)
+PCM_PLAYBACK_ADD(HDMI3, 4, PIPELINE_PCM_6)
+
+#
+# BE configurations - overrides config in ACPI if present
+#
+
+#SSP 1 (ID: 0)
+DAI_CONFIG(SSP, 1, 0, SSP1-Codec,
+	SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24000000, codec_mclk_in),
+		      SSP_CLOCK(bclk, 2400000, codec_slave),
+		      SSP_CLOCK(fsync, 48000, codec_slave),
+		      SSP_TDM(2, 25, 3, 3),
+		      SSP_CONFIG_DATA(SSP, 1, 24)))
+
+# dmic01 (ID: 1)
+DAI_CONFIG(DMIC, 0, 1, dmic01,
+	   DMIC_CONFIG(1, 500000, 4800000, 40, 60, 48000,
+		DMIC_WORD_LENGTH(s32le), DMIC, 0,
+		PDM_CONFIG(DMIC, 0, FOUR_CH_PDM0_PDM1)))
+
+# 3 HDMI/DP outputs (ID: 2,3,4)
+dnl HDA_DAI_CONFIG(dai_index, link_id, name)
+HDA_DAI_CONFIG(0, 2, iDisp1)
+HDA_DAI_CONFIG(0, 3, iDisp2)
+HDA_DAI_CONFIG(0, 4, iDisp3)
+
+
+DEBUG_END


### PR DESCRIPTION
 add the topology file for Cannonlake with codec rt5682, as CommetLake(CML)
 and Whiskeylake(WHL) are CannonLake, so WHL and CML can use this topology
 with rt5682 as well.


Signed-off-by: Zhu Yingjiang <yingjiang.zhu@linux.intel.com>