### PR TITLE
cavs: ipc: platform_ipc_init refinement

### DIFF
--- a/src/drivers/intel/cavs/ipc.c
+++ b/src/drivers/intel/cavs/ipc.c
@@ -56,7 +56,7 @@
 extern struct ipc *_ipc;
 
 /* test code to check working IRQ */
-static void irq_handler(void *arg)
+static void ipc_irq_handler(void *arg)
 {
 	uint32_t dipcctl;
 	uint32_t msg = 0;
@@ -245,7 +245,6 @@ out:
 int platform_ipc_init(struct ipc *ipc)
 {
 	struct ipc_data *iipc;
-	uint32_t dir, caps, dev;
 
 	_ipc = ipc;
 
@@ -258,26 +257,12 @@ int platform_ipc_init(struct ipc *ipc)
 	schedule_task_init(&_ipc->ipc_task, ipc_process_task, _ipc);
 	schedule_task_config(&_ipc->ipc_task, TASK_PRI_IPC, 0);
 
-#ifdef CONFIG_HOST_PTABLE
-	/* allocate page table buffer */
-	iipc->page_table = rballoc(RZONE_SYS, SOF_MEM_CAPS_RAM,
-				   HOST_PAGE_SIZE);
-	if (iipc->page_table)
-		bzero(iipc->page_table, HOST_PAGE_SIZE);
-#endif
-
-	/* request HDA DMA with shared access privilege */
-	caps = 0;
-	dir = DMA_DIR_HMEM_TO_LMEM;
-	dev = DMA_DEV_HOST;
-	iipc->dmac = dma_get(dir, caps, dev, DMA_ACCESS_SHARED);
-
 	/* PM */
 	iipc->pm_prepare_D3 = 0;
 
 	/* configure interrupt */
 	interrupt_register(PLATFORM_IPC_INTERRUPT, IRQ_AUTO_UNMASK,
-			   irq_handler, NULL);
+			   ipc_irq_handler, NULL);
 	interrupt_enable(PLATFORM_IPC_INTERRUPT);
 
 	/* enable IPC interrupts from host */

--- a/src/drivers/intel/cavs/sue-ipc.c
+++ b/src/drivers/intel/cavs/sue-ipc.c
@@ -127,7 +127,6 @@ out:
 int platform_ipc_init(struct ipc *ipc)
 {
 	struct ipc_data *iipc;
-	uint32_t dir, caps, dev;
 
 	_ipc = ipc;
 
@@ -139,20 +138,6 @@ int platform_ipc_init(struct ipc *ipc)
 	/* schedule */
 	schedule_task_init(&_ipc->ipc_task, ipc_process_task, _ipc);
 	schedule_task_config(&_ipc->ipc_task, 0, 0);
-
-#ifdef CONFIG_HOST_PTABLE
-	/* allocate page table buffer */
-	iipc->page_table = rballoc(RZONE_SYS, SOF_MEM_CAPS_RAM,
-				   HOST_PAGE_SIZE);
-	if (iipc->page_table)
-		bzero(iipc->page_table, HOST_PAGE_SIZE);
-#endif
-
-	/* request HDA DMA with shared access privilege */
-	caps = 0;
-	dir = DMA_DIR_HMEM_TO_LMEM;
-	dev = DMA_DEV_HOST;
-	iipc->dmac = dma_get(dir, caps, dev, DMA_ACCESS_SHARED);
 
 	/* PM */
 	iipc->pm_prepare_D3 = 0;


### PR DESCRIPTION
Removing the allocation of page table buffer for cavs platforms.

Signed-off-by: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>