### PR TITLE
arch: smp: fix exception handlers for SMP arch

### DIFF
--- a/src/arch/xtensa/smp/xtos/user-vector.S
+++ b/src/arch/xtensa/smp/xtos/user-vector.S
@@ -92,7 +92,7 @@ _UserExceptionFromVector:
 	 *  (registered at run-time) point to xtos_c_wrapper_handler;
 	 *  entries that have no handler point to xtos_unhandled_exception.
 	 */
-	.section	.rodata, "a"
+	.data
 	.global	xtos_exc_handler_table_r
 	.align 4
 xtos_exc_handler_table_r:


### PR DESCRIPTION
Fixes exception handlers for SMP architecture.
Root cause was the wrong section for exc_handler_table.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>