### PR TITLE
CHECKPATCH: Allowing comparison with constant on left.

### DIFF
--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -4583,7 +4583,7 @@ sub process {
 			my $to = $4;
 			my $newcomp = $comp;
 			if ($lead !~ /(?:$Operators|\.)\s*$/ &&
-			    $to !~ /^(?:Constant|[A-Z_][A-Z0-9_]*)$/ &&
+			    $to !~ /^(?:Constant|[A-Z_][A-Z0-9_]*)$/ && $comp !~ /==/ &&
 			    WARN("CONSTANT_COMPARISON",
 				 "Comparisons should place the constant on the right side of the test\n" . $herecurr) &&
 			    $fix) {


### PR DESCRIPTION
This change allows writing C comparisons with a constant on left. This is a technique to avoid common mistakes like `if (someVariable = NULL)` - if it was written as `if (NULL = someVariable)` compiler would warn about assigning to non-lvalue. 