### PR TITLE
checkpatch fixes

### DIFF
--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -5213,55 +5213,10 @@ sub process {
 			     "Use of volatile is usually wrong: see Documentation/process/volatile-considered-harmful.rst\n" . $herecurr);
 		}
 
-# Check for user-visible strings broken across lines, which breaks the ability
-# to grep for the string.  Make exceptions when the previous string ends in a
-# newline (multiple lines in one string constant) or '\t', '\r', ';', or '{'
-# (common in inline assembly) or is a octal \123 or hexadecimal \xaf value
-		if ($line =~ /^\+\s*$String/ &&
-		    $prevline =~ /"\s*$/ &&
-		    $prevrawline !~ /(?:\\(?:[ntr]|[0-7]{1,3}|x[0-9a-fA-F]{1,2})|;\s*|\{\s*)"\s*$/) {
-			if (WARN("SPLIT_STRING",
-				 "quoted string split across lines\n" . $hereprev) &&
-				     $fix &&
-				     $prevrawline =~ /^\+.*"\s*$/ &&
-				     $last_coalesced_string_linenr != $linenr - 1) {
-				my $extracted_string = get_quoted_string($line, $rawline);
-				my $comma_close = "";
-				if ($rawline =~ /\Q$extracted_string\E(\s*\)\s*;\s*$|\s*,\s*)/) {
-					$comma_close = $1;
-				}
-
-				fix_delete_line($fixlinenr - 1, $prevrawline);
-				fix_delete_line($fixlinenr, $rawline);
-				my $fixedline = $prevrawline;
-				$fixedline =~ s/"\s*$//;
-				$fixedline .= substr($extracted_string, 1) . trim($comma_close);
-				fix_insert_line($fixlinenr - 1, $fixedline);
-				$fixedline = $rawline;
-				$fixedline =~ s/\Q$extracted_string\E\Q$comma_close\E//;
-				if ($fixedline !~ /\+\s*$/) {
-					fix_insert_line($fixlinenr, $fixedline);
-				}
-				$last_coalesced_string_linenr = $linenr;
-			}
-		}
-
 # check for missing a space in a string concatenation
 		if ($prevrawline =~ /[^\\]\w"$/ && $rawline =~ /^\+[\t ]+"\w/) {
 			WARN('MISSING_SPACE',
 			     "break quoted strings at a space character\n" . $hereprev);
-		}
-
-# check for an embedded function name in a string when the function is known
-# This does not work very well for -f --file checking as it depends on patch
-# context providing the function name or a single line form for in-file
-# function declarations
-		if ($line =~ /^\+.*$String/ &&
-		    defined($context_function) &&
-		    get_quoted_string($line, $rawline) =~ /\b$context_function\b/ &&
-		    length(get_quoted_string($line, $rawline)) != (length($context_function) + 2)) {
-			WARN("EMBEDDED_FUNCTION_NAME",
-			     "Prefer using '\"%s...\", __func__' to using '$context_function', this function's name, in a string\n" . $herecurr);
 		}
 
 # check for spaces before a quoted newline

--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -77,7 +77,7 @@ struct comp_dev *comp_new(struct sof_ipc_comp *comp)
 
 	/* find the driver for our new component */
 	drv = get_drv(comp->type);
-	if (drv == NULL) {
+	if (!drv) {
 		trace_comp_error("comp_new() error: driver not found, "
 				 "comp->type = %u", comp->type);
 		return NULL;
@@ -85,7 +85,7 @@ struct comp_dev *comp_new(struct sof_ipc_comp *comp)
 
 	/* create the new component */
 	cdev = drv->ops.new(comp);
-	if (cdev == NULL) {
+	if (!cdev) {
 		trace_comp_error("comp_new() error: "
 				 "unable to create the new component");
 		return NULL;
@@ -156,9 +156,9 @@ int comp_set_state(struct comp_dev *dev, int cmd)
 		break;
 	case COMP_TRIGGER_PAUSE:
 		/* only support pausing for running */
-		if (dev->state == COMP_STATE_ACTIVE)
+		if (dev->state == COMP_STATE_ACTIVE) {
 			dev->state = COMP_STATE_PAUSED;
-		else {
+		} else {
 			trace_comp_error("comp_set_state() error: "
 					 "wrong state = %u, "
 					 "COMP_TRIGGER_PAUSE", dev->state);
@@ -168,7 +168,7 @@ int comp_set_state(struct comp_dev *dev, int cmd)
 	case COMP_TRIGGER_RESET:
 		/* reset always succeeds */
 		if (dev->state == COMP_STATE_ACTIVE ||
-			dev->state == COMP_STATE_PAUSED) {
+		    dev->state == COMP_STATE_PAUSED) {
 			trace_comp_error("comp_set_state() error: "
 					 "wrong state = %u, "
 					 "COMP_TRIGGER_RESET", dev->state);
@@ -178,7 +178,7 @@ int comp_set_state(struct comp_dev *dev, int cmd)
 		break;
 	case COMP_TRIGGER_PREPARE:
 		if (dev->state == COMP_STATE_PREPARE ||
-			dev->state == COMP_STATE_READY) {
+		    dev->state == COMP_STATE_READY) {
 			dev->state = COMP_STATE_PREPARE;
 		} else {
 			trace_comp_error("comp_set_state() error: "

--- a/src/audio/fir.h
+++ b/src/audio/fir.h
@@ -66,7 +66,7 @@ void eq_fir_s32(struct fir_state_32x16 *fir, struct comp_buffer *source,
 /* The next functions are inlined to optmize execution speed */
 
 static inline void fir_part_32x16(int64_t *y, int taps, const int16_t c[],
-	int *ic, int32_t d[], int *id)
+				  int *ic, int32_t d[], int *id)
 {
 	int n;
 
@@ -107,7 +107,7 @@ static inline int32_t fir_32x16(struct fir_state_32x16 *fir, int32_t x)
 		 * is >= 0 after FIR computation.
 		 */
 		fir_part_32x16(&y, fir->length, fir->coef, &i, fir->delay,
-			&tmp_ri);
+			       &tmp_ri);
 	} else {
 		n2 = fir->length - n1;
 		/* Part 1, loop n1 times, fir_ri becomes -1 */

--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -226,8 +226,9 @@ static void host_dma_cb(void *data, uint32_t type, struct dma_sg_elem *next)
 		next->dest = local_elem->dest;
 		next->size = local_elem->size;
 		return;
-	} else
-		next->size = DMA_RELOAD_END;
+	}
+
+	next->size = DMA_RELOAD_END;
 
 	/* let any waiters know we have completed */
 	wait_completed(&hd->complete);
@@ -348,14 +349,14 @@ static struct comp_dev *host_new(struct sof_ipc_comp *comp)
 
 	dev = rzalloc(RZONE_RUNTIME, SOF_MEM_CAPS_RAM,
 		COMP_SIZE(struct sof_ipc_comp_host));
-	if (dev == NULL)
+	if (!dev)
 		return NULL;
 
 	host = (struct sof_ipc_comp_host *)&dev->comp;
 	memcpy(host, ipc_host, sizeof(struct sof_ipc_comp_host));
 
 	hd = rzalloc(RZONE_RUNTIME, SOF_MEM_CAPS_RAM, sizeof(*hd));
-	if (hd == NULL) {
+	if (!hd) {
 		rfree(dev);
 		return NULL;
 	}
@@ -371,7 +372,8 @@ static struct comp_dev *host_new(struct sof_ipc_comp *comp)
 	caps = 0;
 	dma_dev = DMA_DEV_HOST;
 	hd->dma = dma_get(dir, caps, dma_dev, DMA_ACCESS_SHARED);
-	if (hd->dma == NULL) {
+
+	if (!hd->dma) {
 		trace_host_error("host_new() error: dma_get() returned NULL");
 		goto error;
 	}
@@ -600,7 +602,7 @@ static int host_stop(struct comp_dev *dev)
 }
 
 static int host_position(struct comp_dev *dev,
-	struct sof_ipc_stream_posn *posn)
+			 struct sof_ipc_stream_posn *posn)
 {
 	struct host_data *hd = comp_get_drvdata(dev);
 
@@ -687,7 +689,6 @@ static int host_copy_int(struct comp_dev *dev, bool preload_run)
 			return 0;
 		}
 	} else {
-
 		if (hd->dma_buffer->avail < local_elem->size) {
 			/* buffer is enough empty, just return. */
 			tracev_host("host_copy_int(), buffer is enough empty");

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -95,14 +95,14 @@ static struct comp_dev *mixer_new(struct sof_ipc_comp *comp)
 
 	dev = rzalloc(RZONE_RUNTIME, SOF_MEM_CAPS_RAM,
 		COMP_SIZE(struct sof_ipc_comp_mixer));
-	if (dev == NULL)
+	if (!dev)
 		return NULL;
 
 	mixer = (struct sof_ipc_comp_mixer *)&dev->comp;
 	memcpy(mixer, ipc_mixer, sizeof(struct sof_ipc_comp_mixer));
 
 	md = rzalloc(RZONE_RUNTIME, SOF_MEM_CAPS_RAM, sizeof(*md));
-	if (md == NULL) {
+	if (!md) {
 		rfree(dev);
 		return NULL;
 	}
@@ -162,7 +162,7 @@ static int mixer_params(struct comp_dev *dev)
 static int mixer_source_status_count(struct comp_dev *mixer, uint32_t status)
 {
 	struct comp_buffer *source;
-	struct list_item * blist;
+	struct list_item *blist;
 	int count = 0;
 
 	/* count source with state == status */
@@ -180,7 +180,7 @@ static inline int mixer_sink_status(struct comp_dev *mixer)
 	struct comp_buffer *sink;
 
 	sink = list_first_item(&mixer->bsink_list, struct comp_buffer,
-		source_list);
+			       source_list);
 	return sink->sink->state;
 }
 
@@ -195,7 +195,7 @@ static int mixer_trigger(struct comp_dev *dev, int cmd)
 	if (ret < 0)
 		return ret;
 
-	switch(cmd) {
+	switch (cmd) {
 	case COMP_TRIGGER_START:
 	case COMP_TRIGGER_RELEASE:
 		if (mixer_sink_status(dev) == COMP_STATE_ACTIVE)
@@ -255,20 +255,21 @@ static int mixer_copy(struct comp_dev *dev)
 
 		/* make sure source component buffer has enough data available
 		 * and that the sink component buffer has enough free bytes
-		 * for copy. Also check for XRUNs */
+		 * for copy. Also check for XRUNs
+		 */
 		res = comp_buffer_can_copy_bytes(sources[i], sink, md->period_bytes);
 		if (res < 0) {
 			trace_mixer_error("mixer_copy() error: "
 					  "source component buffer "
 					  "has not enough data available");
 			comp_underrun(dev, sources[i], sources[i]->avail,
-				md->period_bytes);
+				      md->period_bytes);
 		} else if (res > 0) {
 			trace_mixer_error("mixer_copy() error: "
 					  "sink component buffer has not "
 					  "enough free bytes for copy");
 			comp_overrun(dev, sources[i], sink->free,
-				md->period_bytes);
+				     md->period_bytes);
 		}
 	}
 
@@ -288,7 +289,7 @@ static int mixer_copy(struct comp_dev *dev)
 
 static int mixer_reset(struct comp_dev *dev)
 {
-	struct list_item * blist;
+	struct list_item *blist;
 	struct comp_buffer *source;
 
 	trace_mixer("mixer_reset()");
@@ -315,7 +316,7 @@ static int mixer_reset(struct comp_dev *dev)
 static int mixer_prepare(struct comp_dev *dev)
 {
 	struct mixer_data *md = comp_get_drvdata(dev);
-	struct list_item * blist;
+	struct list_item *blist;
 	struct comp_buffer *source;
 	int downstream = 0;
 	int ret;
@@ -339,7 +340,7 @@ static int mixer_prepare(struct comp_dev *dev)
 
 		/* only prepare downstream if we have no active sources */
 		if (source->source->state == COMP_STATE_PAUSED ||
-				source->source->state == COMP_STATE_ACTIVE) {
+		    source->source->state == COMP_STATE_ACTIVE) {
 			downstream = 1;
 		}
 	}

--- a/src/audio/pipeline_static.c
+++ b/src/audio/pipeline_static.c
@@ -44,7 +44,6 @@
 #include <sof/audio/component.h>
 #include <sof/audio/pipeline.h>
 
-
 /* 2 * 32 bit*/
 #define PLATFORM_INT_FRAME_SIZE		8
 /* 2 * 16 bit*/
@@ -115,8 +114,7 @@ struct scomps {
 };
 
 #define SCOMP(ccomps) \
-	{.comps = (struct sof_ipc_comp *)ccomps, .num_comps = ARRAY_SIZE(ccomps)}
-
+	{.comps = (struct sof_ipc_comp *)(ccomps), .num_comps = ARRAY_SIZE(ccomps)}
 
 struct spipe {
 	struct scomps *scomps;
@@ -386,7 +384,7 @@ int init_static_pipeline(struct ipc *ipc)
 					goto error;
 
 				/* next component - sizes not constant */
-				c = (void*)c + c->hdr.size;
+				c = (void *)c + c->hdr.size;
 			}
 		}
 
@@ -418,7 +416,7 @@ int init_static_pipeline(struct ipc *ipc)
 
 error:
 	trace_pipe_error("init_static_pipeline() error");
-	
+
 	for (i = 0; i < ARRAY_SIZE(pipeline); i++) {
 
 		/* free pipeline */

--- a/src/audio/volume.c
+++ b/src/audio/volume.c
@@ -58,12 +58,12 @@
  */
 static void vol_sync_host(struct comp_data *cd, uint32_t chan)
 {
-	if (cd->hvol == NULL)
+	if (!cd->hvol)
 		return;
 
-	if (chan < SOF_IPC_MAX_CHANNELS)
+	if (chan < SOF_IPC_MAX_CHANNELS) {
 		cd->hvol[chan].value = cd->volume[chan];
-	else {
+	} else {
 		trace_volume_error("vol_sync_host() error: "
 				   "chan = %u < SOF_IPC_MAX_CHANNELS", chan);
 	}
@@ -108,9 +108,9 @@ static uint64_t vol_work(void *data, uint64_t delay)
 			vol += VOL_RAMP_STEP;
 
 			/* ramp completed ? */
-			if (vol >= cd->tvolume[i] || vol >= cd->max_volume)
+			if (vol >= cd->tvolume[i] || vol >= cd->max_volume) {
 				vol_update(cd, i);
-			else {
+			} else {
 				cd->volume[i] = vol;
 				again = 1;
 			}
@@ -123,7 +123,7 @@ static uint64_t vol_work(void *data, uint64_t delay)
 			} else {
 				/* ramp completed ? */
 				if (new_vol <= cd->tvolume[i] ||
-					new_vol <= cd->min_volume) {
+				    new_vol <= cd->min_volume) {
 					vol_update(cd, i);
 				} else {
 					cd->volume[i] = new_vol;
@@ -184,14 +184,14 @@ static struct comp_dev *volume_new(struct sof_ipc_comp *comp)
 
 	dev = rzalloc(RZONE_RUNTIME, SOF_MEM_CAPS_RAM,
 		COMP_SIZE(struct sof_ipc_comp_volume));
-	if (dev == NULL)
+	if (!dev)
 		return NULL;
 
 	vol = (struct sof_ipc_comp_volume *)&dev->comp;
 	memcpy(vol, ipc_vol, sizeof(struct sof_ipc_comp_volume));
 
 	cd = rzalloc(RZONE_RUNTIME, SOF_MEM_CAPS_RAM, sizeof(*cd));
-	if (cd == NULL) {
+	if (!cd) {
 		rfree(dev);
 		return NULL;
 	}
@@ -205,7 +205,7 @@ static struct comp_dev *volume_new(struct sof_ipc_comp *comp)
 	/* set the default volumes */
 	for (i = 0; i < PLATFORM_MAX_CHANNELS; i++) {
 		cd->volume[i]  =  MAX(MIN(cd->max_volume,
-						  VOL_ZERO_DB), cd->min_volume);
+					  VOL_ZERO_DB), cd->min_volume);
 		cd->tvolume[i] =  cd->volume[i];
 	}
 
@@ -330,9 +330,9 @@ static int volume_ctrl_set_cmd(struct comp_dev *dev,
 				     "channel = %u, value = %u",
 				     cdata->chanv[j].channel, cdata->chanv[j].value);
 			i = cdata->chanv[j].channel;
-			if ((i >= 0) && (i < SOF_IPC_MAX_CHANNELS))
+			if ((i >= 0) && (i < SOF_IPC_MAX_CHANNELS)) {
 				volume_set_chan(dev, i, cdata->chanv[j].value);
-			else {
+			} else {
 				trace_volume_error("volume_ctrl_set_cmd() "
 						   "error: "
 						   "SOF_CTRL_CMD_VOLUME, "

--- a/src/drivers/dw-dma.c
+++ b/src/drivers/dw-dma.c
@@ -200,8 +200,8 @@
 #define DW_CFG_LOW_DEF			0x00000003
 #define DW_CFG_HIGH_DEF		0x0
 
-#elif defined(CONFIG_APOLLOLAKE) || defined(CONFIG_CANNONLAKE) \
-	|| defined(CONFIG_ICELAKE) || defined CONFIG_SUECREEK
+#elif defined(CONFIG_APOLLOLAKE) || defined(CONFIG_CANNONLAKE) || \
+	defined(CONFIG_ICELAKE) || defined CONFIG_SUECREEK
 
 /* CTL_LO */
 #define DW_CTLL_S_GATH_EN		(1 << 17)
@@ -248,8 +248,8 @@
 	trace_error(TRACE_CLASS_DMA, __e, ##__VA_ARGS__)
 
 /* HW Linked list support, only enabled for APL/CNL at the moment */
-#if defined CONFIG_APOLLOLAKE || defined CONFIG_CANNONLAKE \
-	|| defined CONFIG_ICELAKE || defined CONFIG_SUECREEK
+#if defined CONFIG_APOLLOLAKE || defined CONFIG_CANNONLAKE || \
+	defined CONFIG_ICELAKE || defined CONFIG_SUECREEK
 #define DW_USE_HW_LLI	1
 #else
 #define DW_USE_HW_LLI	0
@@ -292,7 +292,7 @@ struct dma_pdata {
 
 static inline void dw_dma_chan_reload_lli(struct dma *dma, int channel);
 static inline void dw_dma_chan_reload_next(struct dma *dma, int channel,
-		struct dma_sg_elem *next);
+					   struct dma_sg_elem *next);
 static inline int dw_dma_interrupt_register(struct dma *dma, int channel);
 static inline void dw_dma_interrupt_unregister(struct dma *dma, int channel);
 static uint64_t dw_dma_work(void *data, uint64_t delay);
@@ -308,7 +308,7 @@ static inline uint32_t dw_read(struct dma *dma, uint32_t reg)
 }
 
 static inline void dw_update_bits(struct dma *dma, uint32_t reg, uint32_t mask,
-	uint32_t value)
+				  uint32_t value)
 {
 	io_reg_update_bits(dma_base(dma) + reg, mask, value);
 }
@@ -411,7 +411,7 @@ static int dw_dma_start(struct dma *dma, int channel)
 
 	/* is channel idle, disabled and ready ? */
 	if (p->chan[channel].status != COMP_STATE_PREPARE ||
-		(dw_read(dma, DW_DMA_CHAN_EN) & (0x1 << channel))) {
+	    (dw_read(dma, DW_DMA_CHAN_EN) & (0x1 << channel))) {
 		ret = -EBUSY;
 		trace_dwdma_error("dw-dma: %d channel %d not ready",
 				  dma->plat_data.id, channel);
@@ -624,7 +624,8 @@ static int dw_dma_stop(struct dma *dma, int channel)
 
 /* fill in "status" with current DMA channel state and position */
 static int dw_dma_status(struct dma *dma, int channel,
-	struct dma_chan_status *status, uint8_t direction)
+			 struct dma_chan_status *status,
+			 uint8_t direction)
 {
 	struct dma_pdata *p = dma_get_drvdata(dma);
 
@@ -651,7 +652,7 @@ static const uint32_t burst_elems[] = {1, 2, 4, 8};
 
 /* set the DMA channel configuration, source/target address, buffer sizes */
 static int dw_dma_set_config(struct dma *dma, int channel,
-	struct dma_sg_config *config)
+			     struct dma_sg_config *config)
 {
 	struct dma_pdata *p = dma_get_drvdata(dma);
 	struct dma_sg_elem *sg_elem;
@@ -710,7 +711,8 @@ static int dw_dma_set_config(struct dma *dma, int channel,
 	/* initialise descriptors */
 	bzero(p->chan[channel].lli, sizeof(struct dw_lli2) *
 	      p->chan[channel].desc_count);
-	lli_desc = lli_desc_head = p->chan[channel].lli;
+	lli_desc = p->chan[channel].lli;
+	lli_desc_head = p->chan[channel].lli;
 	lli_desc_tail = p->chan[channel].lli + p->chan[channel].desc_count - 1;
 
 	/* configure msize if burst_elems is set */
@@ -896,9 +898,9 @@ static int dw_dma_set_config(struct dma *dma, int channel,
 		}
 
 		/* set transfer size of element */
-#if defined CONFIG_BAYTRAIL || defined CONFIG_CHERRYTRAIL \
-	|| defined CONFIG_APOLLOLAKE || defined CONFIG_CANNONLAKE \
-	|| defined CONFIG_ICELAKE || defined CONFIG_SUECREEK
+#if defined CONFIG_BAYTRAIL || defined CONFIG_CHERRYTRAIL || \
+	defined CONFIG_APOLLOLAKE || defined CONFIG_CANNONLAKE ||	\
+	defined CONFIG_ICELAKE || defined CONFIG_SUECREEK
 		lli_desc->ctrl_hi = DW_CTLH_CLASS(p->class) |
 			(sg_elem->size & DW_CTLH_BLOCK_TS_MASK);
 #elif defined CONFIG_BROADWELL || defined CONFIG_HASWELL
@@ -1010,7 +1012,7 @@ static inline void dw_dma_chan_reload_lli(struct dma *dma, int channel)
 
 /* reload using callback data */
 static inline void dw_dma_chan_reload_next(struct dma *dma, int channel,
-		struct dma_sg_elem *next)
+					   struct dma_sg_elem *next)
 {
 	struct dma_pdata *p = dma_get_drvdata(dma);
 	struct dw_lli2 *lli = p->chan[channel].lli_current;
@@ -1091,9 +1093,9 @@ found:
 
 	/* set channel priorities */
 	for (i = 0; i <  DW_MAX_CHAN; i++) {
-#if defined CONFIG_BAYTRAIL || defined CONFIG_CHERRYTRAIL \
-	|| defined CONFIG_APOLLOLAKE || defined CONFIG_CANNONLAKE \
-	|| defined CONFIG_ICELAKE || defined CONFIG_SUECREEK
+#if defined CONFIG_BAYTRAIL || defined CONFIG_CHERRYTRAIL || \
+	defined CONFIG_APOLLOLAKE || defined CONFIG_CANNONLAKE || \
+	defined CONFIG_ICELAKE || defined CONFIG_SUECREEK
 		dw_write(dma, DW_CTRL_HIGH(i),
 			 DW_CTLH_CLASS(dp->chan[i].class));
 #elif defined CONFIG_BROADWELL || defined CONFIG_HASWELL
@@ -1116,7 +1118,7 @@ static void dw_dma_process_block(struct dma_chan_data *chan,
 
 	if (next->size == DMA_RELOAD_END) {
 		tracev_dwdma("dw-dma: %d channel %d block end",
-			    chan->id.dma->plat_data.id, chan->id.channel);
+			     chan->id.dma->plat_data.id, chan->id.channel);
 
 		/* disable channel, finished */
 		dw_write(chan->id.dma, DW_DMA_CHAN_EN,

--- a/src/drivers/intel/baytrail/ipc.c
+++ b/src/drivers/intel/baytrail/ipc.c
@@ -60,7 +60,7 @@ static void do_notify(void)
 
 	spin_lock_irq(&_ipc->lock, flags);
 	msg = _ipc->shared_ctx->dsp_msg;
-	if (msg == NULL)
+	if (!msg)
 		goto out;
 
 	tracev_ipc("ipc: not rx -> 0x%x", msg->header);
@@ -220,7 +220,7 @@ int platform_ipc_init(struct ipc *ipc)
 
 	/* init ipc data */
 	iipc = rzalloc(RZONE_SYS, SOF_MEM_CAPS_RAM,
-		sizeof(struct ipc_data));
+		       sizeof(struct ipc_data));
 	ipc_set_drvdata(_ipc, iipc);
 
 	/* schedule */
@@ -230,7 +230,7 @@ int platform_ipc_init(struct ipc *ipc)
 #ifdef CONFIG_HOST_PTABLE
 	/* allocate page table buffer */
 	iipc->page_table = rzalloc(RZONE_SYS, SOF_MEM_CAPS_RAM,
-		PLATFORM_PAGE_TABLE_SIZE);
+				   PLATFORM_PAGE_TABLE_SIZE);
 	if (iipc->page_table)
 		bzero(iipc->page_table, PLATFORM_PAGE_TABLE_SIZE);
 #endif

--- a/src/drivers/intel/baytrail/ssp.c
+++ b/src/drivers/intel/baytrail/ssp.c
@@ -48,7 +48,7 @@ static int hweight_32(uint32_t mask)
 	int count = 0;
 
 	for (i = 0; i < 32; i++) {
-		count += mask&1;
+		count += mask & 1;
 		mask >>= 1;
 	}
 	return count;
@@ -108,7 +108,7 @@ static int ssp_context_restore(struct dai *dai)
 
 /* Digital Audio interface formatting */
 static inline int ssp_set_config(struct dai *dai,
-	struct sof_ipc_dai_config *config)
+				 struct sof_ipc_dai_config *config)
 {
 	struct ssp_pdata *ssp = dai_get_drvdata(dai);
 	uint32_t sscr0;
@@ -135,7 +135,7 @@ static inline int ssp_set_config(struct dai *dai,
 
 	/* is playback/capture already running */
 	if (ssp->state[DAI_DIR_PLAYBACK] == COMP_STATE_ACTIVE ||
-		ssp->state[DAI_DIR_CAPTURE] == COMP_STATE_ACTIVE) {
+	    ssp->state[DAI_DIR_CAPTURE] == COMP_STATE_ACTIVE) {
 		trace_ssp_error("ssp_set_config(): "
 				"playback/capture already running");
 		ret = -EINVAL;
@@ -172,7 +172,6 @@ static inline int ssp_set_config(struct dai *dai,
 #ifdef ENABLE_SSCR2_FIXES /* FIXME: is this needed ? */
 	sscr2 |= SSCR2_UNDRN_FIX_EN | SSCR2_FIFO_EMPTY_FIX_EN;
 #endif
-
 
 	/*
 	 * sscr3 dynamic settings are FRM_MS_EN, I2S_MODE_EN, I2S_FRM_POL,
@@ -458,8 +457,8 @@ static inline int ssp_set_config(struct dai *dai,
 	/* FIXME:
 	 * watermarks - (RFT + 1) should equal DMA SRC_MSIZE
 	 */
-	sfifott = (SFIFOTT_TX(2*active_tx_slots) |
-		   SFIFOTT_RX(2*active_rx_slots));
+	sfifott = (SFIFOTT_TX(2 * active_tx_slots) |
+		   SFIFOTT_RX(2 * active_rx_slots));
 
 	ssp_write(dai, SSCR0, sscr0);
 	ssp_write(dai, SSCR1, sscr1);
@@ -544,7 +543,7 @@ static void ssp_stop(struct dai *dai, int direction)
 
 	/* disable SSP port if no users */
 	if (ssp->state[SOF_IPC_STREAM_CAPTURE] != COMP_STATE_ACTIVE &&
-		ssp->state[SOF_IPC_STREAM_PLAYBACK] != COMP_STATE_ACTIVE) {
+	    ssp->state[SOF_IPC_STREAM_PLAYBACK] != COMP_STATE_ACTIVE) {
 		ssp_update_bits(dai, SSCR0, SSCR0_SSE, 0);
 		ssp->state[SOF_IPC_STREAM_CAPTURE] = COMP_STATE_PREPARE;
 		ssp->state[SOF_IPC_STREAM_PLAYBACK] = COMP_STATE_PREPARE;
@@ -563,12 +562,12 @@ static int ssp_trigger(struct dai *dai, int cmd, int direction)
 	switch (cmd) {
 	case COMP_TRIGGER_START:
 		if (ssp->state[direction] == COMP_STATE_PREPARE ||
-			ssp->state[direction] == COMP_STATE_PAUSED)
+		    ssp->state[direction] == COMP_STATE_PAUSED)
 			ssp_start(dai, direction);
 		break;
 	case COMP_TRIGGER_RELEASE:
 		if (ssp->state[direction] == COMP_STATE_PAUSED ||
-			ssp->state[direction] == COMP_STATE_PREPARE)
+		    ssp->state[direction] == COMP_STATE_PREPARE)
 			ssp_start(dai, direction);
 		break;
 	case COMP_TRIGGER_STOP:

--- a/src/drivers/intel/baytrail/timer.c
+++ b/src/drivers/intel/baytrail/timer.c
@@ -110,7 +110,7 @@ int platform_timer_set(struct timer *timer, uint64_t ticks)
 
 	/* same hi 64 bit context as ticks ? */
 	if (hitimeout < timer->hitime) {
-		/* cant be in the past */
+		/* can't be in the past */
 		arch_interrupt_global_enable(flags);
 		return -EINVAL;
 	}

--- a/src/drivers/intel/cavs/dmic.c
+++ b/src/drivers/intel/cavs/dmic.c
@@ -170,7 +170,7 @@ static uint32_t dmic_read(struct dai *dai, uint32_t reg)
 }
 
 static void dmic_update_bits(struct dai *dai, uint32_t reg, uint32_t mask,
-	uint32_t value)
+			     uint32_t value)
 {
 	uint32_t new_value;
 	uint32_t old_value = dmic_io[reg >> 2];
@@ -192,7 +192,7 @@ static uint32_t dmic_read(struct dai *dai, uint32_t reg)
 }
 
 static void dmic_update_bits(struct dai *dai, uint32_t reg, uint32_t mask,
-	uint32_t value)
+			     uint32_t value)
 {
 	io_reg_update_bits(dai_base(dai) + reg, mask, value);
 }
@@ -306,13 +306,13 @@ static void find_modes(struct decim_modes *modes,
 
 	/* Check for sane pdm clock, min 100 kHz, max ioclk/2 */
 	if (prm->pdmclk_max < DMIC_HW_PDM_CLK_MIN ||
-		prm->pdmclk_max > DMIC_HW_IOCLK / 2) {
+	    prm->pdmclk_max > DMIC_HW_IOCLK / 2) {
 		trace_dmic_error("find_modes() error: "
 				 "pdm clock max not in range");
 		return;
 	}
 	if (prm->pdmclk_min < DMIC_HW_PDM_CLK_MIN ||
-		prm->pdmclk_min > prm->pdmclk_max) {
+	    prm->pdmclk_min > prm->pdmclk_max) {
 		trace_dmic_error("find_modes() error: "
 				 "pdm clock min not in range");
 		return;
@@ -325,13 +325,13 @@ static void find_modes(struct decim_modes *modes,
 		return;
 	}
 	if (prm->duty_min < DMIC_HW_DUTY_MIN ||
-		prm->duty_min > DMIC_HW_DUTY_MAX) {
+	    prm->duty_min > DMIC_HW_DUTY_MAX) {
 		trace_dmic_error("find_modes() error: "
 				 "pdm clock min not in range");
 		return;
 	}
 	if (prm->duty_max < DMIC_HW_DUTY_MIN ||
-		prm->duty_max > DMIC_HW_DUTY_MAX) {
+	    prm->duty_max > DMIC_HW_DUTY_MAX) {
 		trace_dmic_error("find_modes() error: "
 				 "pdm clock max not in range");
 		return;
@@ -364,7 +364,7 @@ static void find_modes(struct decim_modes *modes,
 		 * next clkdiv.
 		 */
 		if (osr < osr_min || du_min < prm->duty_min ||
-			du_max > prm->duty_max)
+		    du_max > prm->duty_max)
 			continue;
 
 		/* Loop FIR decimation factors candidates. If the
@@ -380,9 +380,9 @@ static void find_modes(struct decim_modes *modes,
 			ioclk_test = fs * mfir * mcic * clkdiv;
 
 			if (ioclk_test == DMIC_HW_IOCLK &&
-				mcic >= DMIC_HW_CIC_DECIM_MIN &&
-				mcic <= DMIC_HW_CIC_DECIM_MAX &&
-				i < DMIC_MAX_MODES) {
+			    mcic >= DMIC_HW_CIC_DECIM_MIN &&
+			    mcic <= DMIC_HW_CIC_DECIM_MAX &&
+			    i < DMIC_MAX_MODES) {
 				modes->clkdiv[i] = clkdiv;
 				modes->mcic[i] = mcic;
 				modes->mfir[i] = mfir;
@@ -401,7 +401,7 @@ static void find_modes(struct decim_modes *modes,
  * list of compatible settings.
  */
 static void match_modes(struct matched_modes *c, struct decim_modes *a,
-	struct decim_modes *b)
+			struct decim_modes *b)
 {
 	int16_t idx[DMIC_MAX_MODES];
 	int idx_length;
@@ -418,7 +418,7 @@ static void match_modes(struct matched_modes *c, struct decim_modes *a,
 
 	/* Ensure that num_of_modes is sane. */
 	if (a->num_of_modes > DMIC_MAX_MODES ||
-		b->num_of_modes > DMIC_MAX_MODES)
+	    b->num_of_modes > DMIC_MAX_MODES)
 		return;
 
 	/* Check for request only for FIFO A or B. In such case pass list for
@@ -451,7 +451,7 @@ static void match_modes(struct matched_modes *c, struct decim_modes *a,
 	for (n = 0; n < a->num_of_modes; n++) {
 		/* Find all indices of values a->clkdiv[n] in b->clkdiv[] */
 		idx_length = find_equal_int16(idx, b->clkdiv, a->clkdiv[n],
-			b->num_of_modes, 0);
+					      b->num_of_modes, 0);
 		for (m = 0; m < idx_length; m++) {
 			if (b->mcic[idx[m]] == a->mcic[n]) {
 				c->clkdiv[i] = a->clkdiv[n];
@@ -488,7 +488,7 @@ static struct pdm_decim *get_fir(struct dmic_configuration *cfg, int mfir)
 
 	for (i = 0; i < DMIC_FIR_LIST_LENGTH; i++) {
 		if (fir_list[i]->decim_factor == mfir &&
-			fir_list[i]->length <= fir_max_length) {
+		    fir_list[i]->length <= fir_max_length) {
 			/* Store pointer, break from loop to avoid a
 			 * Possible other mode with lower FIR length.
 			 */
@@ -504,7 +504,7 @@ static struct pdm_decim *get_fir(struct dmic_configuration *cfg, int mfir)
  * before write to HW coef RAM. Shift will be programmed to HW register.
  */
 static int fir_coef_scale(int32_t *fir_scale, int *fir_shift, int add_shift,
-	const int32_t coef[], int coef_length, int32_t gain)
+			  const int32_t coef[], int coef_length, int32_t gain)
 {
 	int32_t amax;
 	int32_t new_amax;
@@ -520,7 +520,7 @@ static int fir_coef_scale(int32_t *fir_scale, int *fir_shift, int add_shift,
 
 	/* Scale max. tap value with FIR gain. */
 	new_amax = Q_MULTSR_32X32((int64_t)amax, fir_gain, 31,
-		DMIC_FIR_SCALE_Q, DMIC_FIR_SCALE_Q);
+				  DMIC_FIR_SCALE_Q, DMIC_FIR_SCALE_Q);
 	if (new_amax <= 0)
 		return -EINVAL;
 
@@ -537,7 +537,7 @@ static int fir_coef_scale(int32_t *fir_scale, int *fir_shift, int add_shift,
 	 */
 	*fir_shift = -shift + add_shift;
 	if (*fir_shift < DMIC_HW_FIR_SHIFT_MIN ||
-		*fir_shift > DMIC_HW_FIR_SHIFT_MAX)
+	    *fir_shift > DMIC_HW_FIR_SHIFT_MAX)
 		return -EINVAL;
 
 	/* Compensate shift into FIR coef scaler and store as Q4.20. */
@@ -578,7 +578,7 @@ static int fir_coef_scale(int32_t *fir_scale, int *fir_shift, int add_shift,
  * needs compromizes into specifications and is not desirable.
  */
 static int select_mode(struct dmic_configuration *cfg,
-	struct matched_modes *modes)
+		       struct matched_modes *modes)
 {
 	int32_t g_cic;
 	int32_t fir_in_max;
@@ -722,7 +722,7 @@ static int select_mode(struct dmic_configuration *cfg,
  */
 
 static inline void ipm_helper1(int *ipm, int stereo[], int swap[],
-	struct sof_ipc_dai_dmic_params *dmic)
+			       struct sof_ipc_dai_dmic_params *dmic)
 {
 	int pdm[DMIC_HW_CONTROLLERS] = {0};
 	int cnt;
@@ -766,7 +766,7 @@ static inline void ipm_helper1(int *ipm, int stereo[], int swap[],
 #if DMIC_HW_VERSION == 2
 
 static inline void ipm_helper2(int source[], int *ipm, int stereo[],
-	int swap[], struct sof_ipc_dai_dmic_params *dmic)
+			       int swap[], struct sof_ipc_dai_dmic_params *dmic)
 {
 	int pdm[DMIC_HW_CONTROLLERS];
 	int i;
@@ -781,7 +781,7 @@ static inline void ipm_helper2(int source[], int *ipm, int stereo[],
 	 */
 	for (i = 0; i < dmic->num_pdm_active; i++) {
 		if (dmic->pdm[i].enable_mic_a > 0 ||
-			dmic->pdm[i].enable_mic_b > 0) {
+		    dmic->pdm[i].enable_mic_b > 0) {
 			pdm[i] = 1;
 			source[n] = i;
 			n++;
@@ -791,7 +791,7 @@ static inline void ipm_helper2(int source[], int *ipm, int stereo[],
 		}
 
 		if (dmic->pdm[i].enable_mic_a > 0 &&
-			dmic->pdm[i].enable_mic_b > 0) {
+		    dmic->pdm[i].enable_mic_b > 0) {
 			stereo[i] = 1;
 			swap[i] = 0;
 		} else {
@@ -811,7 +811,7 @@ static inline void ipm_helper2(int source[], int *ipm, int stereo[],
 #endif
 
 static int configure_registers(struct dai *dai, struct dmic_configuration *cfg,
-	struct sof_ipc_dai_dmic_params *dmic)
+			       struct sof_ipc_dai_dmic_params *dmic)
 {
 	int stereo[DMIC_HW_CONTROLLERS];
 	int swap[DMIC_HW_CONTROLLERS];
@@ -1334,6 +1334,7 @@ static void dmic_start(struct dai *dai)
 
 	trace_dmic("dmic_start(), done");
 }
+
 /* stop the DMIC for capture */
 static void dmic_stop(struct dai *dai)
 {
@@ -1414,7 +1415,7 @@ static int dmic_trigger(struct dai *dai, int cmd, int direction)
 	case COMP_TRIGGER_RELEASE:
 	case COMP_TRIGGER_START:
 		if (dmic->state == COMP_STATE_PREPARE ||
-			dmic->state == COMP_STATE_PAUSED) {
+		    dmic->state == COMP_STATE_PAUSED) {
 			dmic_start(dai);
 		} else {
 			trace_dmic_error("dmic_trigger() error: "
@@ -1486,7 +1487,7 @@ static int dmic_probe(struct dai *dai)
 
 	/* register our IRQ handler */
 	ret = interrupt_register(dmic_irq(dai), IRQ_AUTO_UNMASK,
-				dmic_irq_handler, dai);
+				 dmic_irq_handler, dai);
 	if (ret < 0) {
 		trace_dmic_error("dmic failed to allocate IRQ");
 		rfree(dmic);

--- a/src/drivers/intel/cavs/hda-dma.c
+++ b/src/drivers/intel/cavs/hda-dma.c
@@ -179,19 +179,19 @@ struct dma_pdata {
 static int hda_dma_stop(struct dma *dma, int channel);
 
 static inline uint32_t host_dma_reg_read(struct dma *dma, uint32_t chan,
-	uint32_t reg)
+					 uint32_t reg)
 {
 	return io_reg_read(dma_chan_base(dma, chan) + reg);
 }
 
 static inline void host_dma_reg_write(struct dma *dma, uint32_t chan,
-	uint32_t reg, uint32_t value)
+				      uint32_t reg, uint32_t value)
 {
 	io_reg_write(dma_chan_base(dma, chan) + reg, value);
 }
 
 static inline void hda_update_bits(struct dma *dma, uint32_t chan,
-	uint32_t reg, uint32_t mask, uint32_t value)
+				   uint32_t reg, uint32_t mask, uint32_t value)
 {
 	io_reg_update_bits(dma_chan_base(dma, chan) + reg,  mask, value);
 }
@@ -226,8 +226,9 @@ static void hda_dma_get_dbg_vals(struct hda_chan_data *chan,
 				 enum hda_dbg_src src)
 {
 	struct hda_dbg_data *dbg_data = &chan->dbg_data;
+
 	if ((HDA_DBG_SRC == HDA_DBG_BOTH) || (src == HDA_DBG_BOTH) ||
-		(src == HDA_DBG_SRC)) {
+	    (src == HDA_DBG_SRC)) {
 		dbg_data->last_wp[sample] =
 			host_dma_reg_read(chan->dma, chan->index, DGBWP);
 		dbg_data->last_rp[sample] =
@@ -758,7 +759,7 @@ static int hda_dma_stop(struct dma *dma, int channel)
 
 /* fill in "status" with current DMA channel state and position */
 static int hda_dma_status(struct dma *dma, int channel,
-	struct dma_chan_status *status, uint8_t direction)
+			  struct dma_chan_status *status, uint8_t direction)
 {
 	struct dma_pdata *p = dma_get_drvdata(dma);
 
@@ -778,7 +779,7 @@ static int hda_dma_status(struct dma *dma, int channel,
 
 /* set the DMA channel configuration, source/target address, buffer sizes */
 static int hda_dma_set_config(struct dma *dma, int channel,
-	struct dma_sg_config *config)
+			      struct dma_sg_config *config)
 {
 	struct dma_pdata *p = dma_get_drvdata(dma);
 	struct dma_sg_elem *sg_elem;
@@ -836,8 +837,8 @@ static int hda_dma_set_config(struct dma *dma, int channel,
 		/* make sure period_bytes are constant */
 		if (period_bytes && period_bytes != sg_elem->size) {
 			trace_hddma_error("hda-dmac: %d chan %d - period size not constant %d",
-					 dma->plat_data.id, channel,
-					 period_bytes);
+					  dma->plat_data.id, channel,
+					  period_bytes);
 			ret = -EINVAL;
 			goto out;
 		}

--- a/src/drivers/intel/cavs/ipc.c
+++ b/src/drivers/intel/cavs/ipc.c
@@ -70,7 +70,7 @@ static void irq_handler(void *arg)
 	dipcctl = ipc_read(IPC_DIPCCTL);
 
 	tracev_ipc("ipc: irq dipct 0x%x dipcie 0x%x dipcctl 0x%x", dipct,
-		dipcie, dipcctl);
+		   dipcie, dipcctl);
 #else
 	uint32_t dipctdr;
 	uint32_t dipcida;
@@ -80,7 +80,7 @@ static void irq_handler(void *arg)
 	dipcctl = ipc_read(IPC_DIPCCTL);
 
 	tracev_ipc("ipc: irq dipctdr 0x%x dipcida 0x%x dipcctl 0x%x", dipctdr,
-		dipcida, dipcctl);
+		   dipcida, dipcctl);
 #endif
 
 	/* new message from host */

--- a/src/drivers/intel/cavs/ssp.c
+++ b/src/drivers/intel/cavs/ssp.c
@@ -133,7 +133,7 @@ static int ssp_context_restore(struct dai *dai)
 
 /* Digital Audio interface formatting */
 static inline int ssp_set_config(struct dai *dai,
-	struct sof_ipc_dai_config *config)
+				 struct sof_ipc_dai_config *config)
 {
 	struct ssp_pdata *ssp = dai_get_drvdata(dai);
 	uint32_t sscr0;
@@ -174,7 +174,7 @@ static inline int ssp_set_config(struct dai *dai,
 
 	/* is playback/capture already running */
 	if (ssp->state[DAI_DIR_PLAYBACK] == COMP_STATE_ACTIVE ||
-		ssp->state[DAI_DIR_CAPTURE] == COMP_STATE_ACTIVE) {
+	    ssp->state[DAI_DIR_CAPTURE] == COMP_STATE_ACTIVE) {
 		trace_ssp_error("ssp_set_config() error: "
 				"playback/capture already running");
 		ret = -EINVAL;
@@ -646,8 +646,8 @@ static inline int ssp_set_config(struct dai *dai,
 		frame_len = 1; /* default */
 
 		if (cfs && ssp->params.frame_pulse_width > 0 &&
-			ssp->params.frame_pulse_width <=
-			SOF_DAI_INTEL_SSP_FRAME_PULSE_WIDTH_MAX) {
+		    ssp->params.frame_pulse_width <=
+		    SOF_DAI_INTEL_SSP_FRAME_PULSE_WIDTH_MAX) {
 			frame_len = ssp->params.frame_pulse_width;
 		}
 
@@ -850,7 +850,7 @@ static void ssp_stop(struct dai *dai, int direction)
 
 	/* disable SSP port if no users */
 	if (ssp->state[SOF_IPC_STREAM_CAPTURE] != COMP_STATE_ACTIVE &&
-		ssp->state[SOF_IPC_STREAM_PLAYBACK] != COMP_STATE_ACTIVE) {
+	    ssp->state[SOF_IPC_STREAM_PLAYBACK] != COMP_STATE_ACTIVE) {
 		ssp_update_bits(dai, SSCR0, SSCR0_SSE, 0);
 		ssp->state[SOF_IPC_STREAM_CAPTURE] = COMP_STATE_PREPARE;
 		ssp->state[SOF_IPC_STREAM_PLAYBACK] = COMP_STATE_PREPARE;
@@ -869,12 +869,12 @@ static int ssp_trigger(struct dai *dai, int cmd, int direction)
 	switch (cmd) {
 	case COMP_TRIGGER_START:
 		if (ssp->state[direction] == COMP_STATE_PREPARE ||
-			ssp->state[direction] == COMP_STATE_PAUSED)
+		    ssp->state[direction] == COMP_STATE_PAUSED)
 			ssp_start(dai, direction);
 		break;
 	case COMP_TRIGGER_RELEASE:
 		if (ssp->state[direction] == COMP_STATE_PAUSED ||
-			ssp->state[direction] == COMP_STATE_PREPARE)
+		    ssp->state[direction] == COMP_STATE_PREPARE)
 			ssp_start(dai, direction);
 		break;
 	case COMP_TRIGGER_STOP:

--- a/src/drivers/intel/cavs/sue-ipc.c
+++ b/src/drivers/intel/cavs/sue-ipc.c
@@ -133,7 +133,7 @@ int platform_ipc_init(struct ipc *ipc)
 
 	/* init ipc data */
 	iipc = rzalloc(RZONE_SYS, SOF_MEM_CAPS_RAM,
-		sizeof(struct ipc_data));
+		       sizeof(struct ipc_data));
 	ipc_set_drvdata(_ipc, iipc);
 
 	/* schedule */
@@ -143,7 +143,7 @@ int platform_ipc_init(struct ipc *ipc)
 #ifdef CONFIG_HOST_PTABLE
 	/* allocate page table buffer */
 	iipc->page_table = rballoc(RZONE_SYS, SOF_MEM_CAPS_RAM,
-			HOST_PAGE_SIZE);
+				   HOST_PAGE_SIZE);
 	if (iipc->page_table)
 		bzero(iipc->page_table, HOST_PAGE_SIZE);
 #endif

--- a/src/drivers/intel/cavs/timer.c
+++ b/src/drivers/intel/cavs/timer.c
@@ -85,7 +85,7 @@ void platform_host_timestamp(struct comp_dev *host,
 {
 	int err;
 
-	/* get host postion */
+	/* get host position */
 	err = comp_position(host, posn);
 	if (err == 0)
 		posn->flags |= SOF_TIME_HOST_VALID;
@@ -97,7 +97,7 @@ void platform_dai_timestamp(struct comp_dev *dai,
 {
 	int err;
 
-	/* get DAI postion */
+	/* get DAI position */
 	err = comp_position(dai, posn);
 	if (err == 0)
 		posn->flags |= SOF_TIME_DAI_VALID;

--- a/src/drivers/intel/haswell/ipc.c
+++ b/src/drivers/intel/haswell/ipc.c
@@ -60,7 +60,7 @@ static void do_notify(void)
 
 	spin_lock_irq(&_ipc->lock, flags);
 	msg = _ipc->shared_ctx->dsp_msg;
-	if (msg == NULL)
+	if (!msg)
 		goto out;
 
 	tracev_ipc("ipc: not rx -> 0x%x", msg->header);
@@ -210,7 +210,7 @@ int platform_ipc_init(struct ipc *ipc)
 
 	/* init ipc data */
 	iipc = rzalloc(RZONE_SYS, SOF_MEM_CAPS_RAM,
-		sizeof(struct ipc_data));
+		       sizeof(struct ipc_data));
 	ipc_set_drvdata(_ipc, iipc);
 
 	/* schedule */
@@ -220,7 +220,7 @@ int platform_ipc_init(struct ipc *ipc)
 #ifdef CONFIG_HOST_PTABLE
 	/* allocate page table buffer */
 	iipc->page_table = rzalloc(RZONE_SYS, SOF_MEM_CAPS_RAM,
-		PLATFORM_PAGE_TABLE_SIZE);
+				   PLATFORM_PAGE_TABLE_SIZE);
 	if (iipc->page_table)
 		bzero(iipc->page_table, PLATFORM_PAGE_TABLE_SIZE);
 #endif

--- a/src/drivers/intel/haswell/ssp.c
+++ b/src/drivers/intel/haswell/ssp.c
@@ -70,7 +70,7 @@ static int ssp_context_restore(struct dai *dai)
 
 /* Digital Audio interface formatting */
 static inline int ssp_set_config(struct dai *dai,
-	struct sof_ipc_dai_config *config)
+				 struct sof_ipc_dai_config *config)
 {
 	struct ssp_pdata *ssp = dai_get_drvdata(dai);
 	uint32_t sscr0;
@@ -94,7 +94,7 @@ static inline int ssp_set_config(struct dai *dai,
 
 	/* is playback/capture already running */
 	if (ssp->state[DAI_DIR_PLAYBACK] == COMP_STATE_ACTIVE ||
-		ssp->state[DAI_DIR_CAPTURE] == COMP_STATE_ACTIVE) {
+	    ssp->state[DAI_DIR_CAPTURE] == COMP_STATE_ACTIVE) {
 		trace_ssp_error("ssp_set_config() error: "
 				"playback/capture already running");
 		ret = -EINVAL;
@@ -416,7 +416,6 @@ static void ssp_start(struct dai *dai, int direction)
 	/* enable port */
 	ssp->state[direction] = COMP_STATE_ACTIVE;
 
-
 	spin_unlock(&dai->lock);
 }
 
@@ -447,7 +446,7 @@ static void ssp_stop(struct dai *dai, int direction)
 
 	/* disable SSP port if no users */
 	if (ssp->state[SOF_IPC_STREAM_CAPTURE] != COMP_STATE_ACTIVE &&
-		ssp->state[SOF_IPC_STREAM_PLAYBACK] != COMP_STATE_ACTIVE) {
+	    ssp->state[SOF_IPC_STREAM_PLAYBACK] != COMP_STATE_ACTIVE) {
 		ssp_update_bits(dai, SSCR0, SSCR0_SSE, 0);
 		ssp->state[SOF_IPC_STREAM_CAPTURE] = COMP_STATE_PREPARE;
 		ssp->state[SOF_IPC_STREAM_PLAYBACK] = COMP_STATE_PREPARE;
@@ -466,12 +465,12 @@ static int ssp_trigger(struct dai *dai, int cmd, int direction)
 	switch (cmd) {
 	case COMP_TRIGGER_START:
 		if (ssp->state[direction] == COMP_STATE_PREPARE ||
-			ssp->state[direction] == COMP_STATE_PAUSED)
+		    ssp->state[direction] == COMP_STATE_PAUSED)
 			ssp_start(dai, direction);
 		break;
 	case COMP_TRIGGER_RELEASE:
 		if (ssp->state[direction] == COMP_STATE_PAUSED ||
-			ssp->state[direction] == COMP_STATE_PREPARE)
+		    ssp->state[direction] == COMP_STATE_PREPARE)
 			ssp_start(dai, direction);
 		break;
 	case COMP_TRIGGER_STOP:
@@ -517,7 +516,6 @@ static int ssp_probe(struct dai *dai)
 
 	ssp->state[DAI_DIR_PLAYBACK] = COMP_STATE_READY;
 	ssp->state[DAI_DIR_CAPTURE] = COMP_STATE_READY;
-
 
 	/* register our IRQ handler */
 	ret = interrupt_register(ssp_irq(dai), IRQ_AUTO_UNMASK, ssp_irq_handler,

--- a/src/drivers/intel/haswell/timer.c
+++ b/src/drivers/intel/haswell/timer.c
@@ -67,7 +67,7 @@ void platform_host_timestamp(struct comp_dev *host,
 {
 	int err;
 
-	/* get host postion */
+	/* get host position */
 	err = comp_position(host, posn);
 	if (err == 0)
 		posn->flags |= SOF_TIME_HOST_VALID | SOF_TIME_HOST_64;
@@ -79,7 +79,7 @@ void platform_dai_timestamp(struct comp_dev *dai,
 {
 	int err;
 
-	/* get DAI postion */
+	/* get DAI position */
 	err = comp_position(dai, posn);
 	if (err == 0)
 		posn->flags |= SOF_TIME_DAI_VALID;

--- a/src/drivers/intel/pmc-ipc.c
+++ b/src/drivers/intel/pmc-ipc.c
@@ -105,7 +105,6 @@ static void irq_handler(void *arg)
 	}
 
 	if (isrlpesc & SHIM_ISRLPESC_BUSY) {
-		
 		/* Mask Busy interrupt before return */
 		shim_write(SHIM_IMRLPESC, shim_read(SHIM_IMRLPESC) | SHIM_IMRLPESC_BUSY);
 		interrupt_clear(IRQ_NUM_EXT_PMC);
@@ -156,7 +155,7 @@ int platform_ipc_pmc_init(void)
 
 	/* init ipc data */
 	_pmc = rmalloc(RZONE_SYS, SOF_MEM_CAPS_RAM,
-		sizeof(struct intel_ipc_pmc_data));
+		       sizeof(struct intel_ipc_pmc_data));
 
 	/* configure interrupt */
 	interrupt_register(IRQ_NUM_EXT_PMC, IRQ_AUTO_UNMASK, irq_handler,

--- a/src/host/schedule.c
+++ b/src/host/schedule.c
@@ -39,7 +39,7 @@
 /* scheduler testbench definition */
 
 struct schedule_data {
-	spinlock_t lock;
+	spinlock_t lock; /* schedule lock */
 	struct list_item list; /* list of tasks in priority queue */
 	uint32_t clock;
 };

--- a/src/host/testbench.c
+++ b/src/host/testbench.c
@@ -266,7 +266,7 @@ int main(int argc, char **argv)
 
 	/* parse topology file and create pipeline */
 	if (parse_topology(tplg_file, &sof, &fr_id, &fw_id, &sched_id, bits_in,
-	    input_file, output_file, lib_table, pipeline) < 0) {
+			   input_file, output_file, lib_table, pipeline) < 0) {
 		fprintf(stderr, "error: parsing topology\n");
 		exit(EXIT_FAILURE);
 	}

--- a/src/host/topology.c
+++ b/src/host/topology.c
@@ -458,7 +458,7 @@ static int load_pipeline(struct sof *sof, struct sof_ipc_pipe_new *pipeline,
 }
 
 /* load dapm widget kcontrols
- * we dont use controls in the testbench atm.
+ * we don't use controls in the testbench atm.
  * so just skip to the next dapm widget
  */
 static int load_controls(struct sof *sof, int num_kcontrols)
@@ -775,9 +775,9 @@ static int load_widget(struct sof *sof, int *fr_id, int *fw_id,
 
 /* parse topology file and set up pipeline */
 int parse_topology(char *filename, struct sof *sof, int *fr_id, int *fw_id,
-		    int *sched_id, char *bits_in, char *in_file,
-		    char *out_file, struct shared_lib_table *library_table,
-		    char *pipeline_msg)
+		   int *sched_id, char *bits_in, char *in_file,
+		   char *out_file, struct shared_lib_table *library_table,
+		   char *pipeline_msg)
 {
 	struct snd_soc_tplg_hdr *hdr;
 

--- a/src/include/host/topology.h
+++ b/src/include/host/topology.h
@@ -195,8 +195,8 @@ void sof_parse_word_tokens(void *object,
 			   struct snd_soc_tplg_vendor_array *array);
 
 int parse_topology(char *filename, struct sof *sof, int *fr_id, int *fw_id,
-		    int *sched_id, char *bits_in, char *in_file,
-		    char *out_file, struct shared_lib_table *library_table,
-		    char *pipeline_msg);
+		   int *sched_id, char *bits_in, char *in_file,
+		   char *out_file, struct shared_lib_table *library_table,
+		   char *pipeline_msg);
 
 #endif

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -72,7 +72,7 @@ struct comp_buffer {
 	struct list_item source_list;	/* list in comp buffers */
 	struct list_item sink_list;	/* list in comp buffers */
 
-	spinlock_t lock;
+	spinlock_t lock; /* component buffer spinlock */
 };
 
 /* pipeline buffer creation and destruction */
@@ -96,7 +96,8 @@ static inline void buffer_zero(struct comp_buffer *buffer)
 
 /* get the max number of bytes that can be copied between sink and source */
 static inline int comp_buffer_can_copy_bytes(struct comp_buffer *source,
-	struct comp_buffer *sink, uint32_t bytes)
+					     struct comp_buffer *sink,
+					     uint32_t bytes)
 {
 	/* check for underrun */
 	if (source->avail < bytes)
@@ -111,7 +112,7 @@ static inline int comp_buffer_can_copy_bytes(struct comp_buffer *source,
 }
 
 static inline uint32_t comp_buffer_get_copy_bytes(struct comp_buffer *source,
-	struct comp_buffer *sink)
+						  struct comp_buffer *sink)
 {
 	if (source->avail > sink->free)
 		return sink->free;
@@ -122,12 +123,13 @@ static inline uint32_t comp_buffer_get_copy_bytes(struct comp_buffer *source,
 static inline void buffer_reset_pos(struct comp_buffer *buffer)
 {
 	/* reset read and write pointer to buffer bas */
-	buffer->w_ptr = buffer->r_ptr = buffer->addr;
+	buffer->w_ptr = buffer->addr;
+	buffer->r_ptr = buffer->addr;
 
 	/* free space is buffer size */
 	buffer->free = buffer->size;
 
-	/* ther are no avail samples at reset */
+	/* there are no avail samples at reset */
 	buffer->avail = 0;
 
 	/* clear buffer contents */

--- a/src/include/sof/audio/format.h
+++ b/src/include/sof/audio/format.h
@@ -81,22 +81,22 @@
 #define Q_CONVERT_QTOF(x, ny) ((float)(x) / ((int64_t)1 << (ny)))
 
 /* A more clever macro for Q-shifts */
-#define Q_SHIFT(x, src_q, dst_q) ((x)>>((src_q)-(dst_q)))
-#define Q_SHIFT_RND(x, src_q, dst_q) ((((x) >> ((src_q)-(dst_q) -1)) +1) >> 1)
+#define Q_SHIFT(x, src_q, dst_q) ((x) >> ((src_q) - (dst_q)))
+#define Q_SHIFT_RND(x, src_q, dst_q) ((((x) >> ((src_q) - (dst_q) - 1)) + 1) >> 1)
 
 /* Alternative version since compiler does not allow (x >> -1) */
-#define Q_SHIFT_LEFT(x, src_q, dst_q) ((x)<<((dst_q)-(src_q)))
+#define Q_SHIFT_LEFT(x, src_q, dst_q) ((x) << ((dst_q) - (src_q)))
 
 /* Fractional multiplication with shift
  * Note that the parameters px and py must be cast to (int64_t) if other type.
  */
-#define Q_MULTS_32X32(px, py, qx, qy, qp) ((px) * (py) >> (((qx)+(qy)-(qp))))
+#define Q_MULTS_32X32(px, py, qx, qy, qp) ((px) * (py) >> (((qx) + (qy) - (qp))))
 
 /* Fractional multiplication with shift and round
  * Note that the parameters px and py must be cast to (int64_t) if other type.
  */
 #define Q_MULTSR_32X32(px, py, qx, qy, qp) \
-	((((px) * (py) >> ((qx)+(qy)-(qp)-1)) + 1) >> 1)
+	((((px) * (py) >> ((qx) + (qy) - (qp) - 1)) + 1) >> 1)
 
 /* Saturation */
 #define SATP_INT32(x) (((x) > INT32_MAX) ? INT32_MAX : (x))

--- a/src/include/sof/audio/pipeline.h
+++ b/src/include/sof/audio/pipeline.h
@@ -74,7 +74,7 @@ struct ipc;
  * Audio pipeline.
  */
 struct pipeline {
-	spinlock_t lock;
+	spinlock_t lock; /* pipeline lock */
 	struct sof_ipc_pipe_new ipc_pipe;
 
 	/* runtime status */
@@ -115,7 +115,7 @@ int pipeline_complete(struct pipeline *p);
 
 /* pipeline parameters */
 int pipeline_params(struct pipeline *p, struct comp_dev *cd,
-	struct sof_ipc_pcm_params *params);
+		    struct sof_ipc_pcm_params *params);
 
 /* prepare the pipeline for usage */
 int pipeline_prepare(struct pipeline *p, struct comp_dev *cd);
@@ -142,7 +142,7 @@ void pipeline_schedule_cancel(struct pipeline *p);
 
 /* get time pipeline timestamps from host to dai */
 void pipeline_get_timestamp(struct pipeline *p, struct comp_dev *host_dev,
-	struct sof_ipc_stream_posn *posn);
+			    struct sof_ipc_stream_posn *posn);
 
 void pipeline_schedule(void *arg);
 

--- a/src/include/sof/dai.h
+++ b/src/include/sof/dai.h
@@ -159,7 +159,7 @@ struct dai *dai_get(uint32_t type, uint32_t index, uint32_t flags);
 void dai_put(struct dai *dai);
 
 #define dai_set_drvdata(dai, data) \
-	dai->private = data;
+	dai->private = data
 #define dai_get_drvdata(dai) \
 	dai->private
 #define dai_base(dai) \
@@ -173,7 +173,7 @@ void dai_put(struct dai *dai);
  * \brief Digital Audio interface formatting
  */
 static inline int dai_set_config(struct dai *dai,
-	struct sof_ipc_dai_config *config)
+				 struct sof_ipc_dai_config *config)
 {
 	return dai->ops->set_config(dai, config);
 }

--- a/src/include/sof/debug.h
+++ b/src/include/sof/debug.h
@@ -63,74 +63,80 @@
 /* dump file and line to start of mailbox or shared memory */
 #define dbg() \
 	do { \
-		volatile uint32_t *__m = (uint32_t*)mailbox_get_debug_base(); \
+		volatile uint32_t *__m = (uint32_t *)mailbox_get_debug_base(); \
 		*(__m++) = (__FILE__[0] << 24) + (__FILE__[1] << 16) +\
 			 (__FILE__[2] << 8) + (__FILE__[3]); \
 		*(__m++) = (__func__[0] << 24) + (__func__[1] << 16) + \
 			(__func__[2] << 8) + (__func__[3]); \
 		*__m = __LINE__; \
-	} while (0);
+	} while (0)
 
 /* dump file and line to offset in mailbox or shared memory */
 #define dbg_at(__x) \
 	do { \
-		volatile uint32_t *__m = (uint32_t*)mailbox_get_debug_base() + __x; \
+		volatile uint32_t *__m = (uint32_t *)mailbox_get_debug_base() + __x; \
 		*(__m++) = (__FILE__[0] << 24) + (__FILE__[1] << 16) +\
 			 (__FILE__[2] << 8) + (__FILE__[3]); \
 		*(__m++) = (__func__[0] << 24) + (__func__[1] << 16) + \
 			(__func__[2] << 8) + (__func__[3]); \
 		*__m = __LINE__; \
-	} while (0);
+	} while (0)
 
 /* dump value to start of mailbox or shared memory */
 #define dbg_val(__v) \
 	do { \
 		volatile uint32_t *__m = \
-			(volatile uint32_t*)mailbox_get_debug_base(); \
+			(volatile uint32_t *)mailbox_get_debug_base(); \
 		*__m = __v; \
-	} while (0);
+	} while (0)
 
 /* dump value to offset in mailbox or shared memory */
 #define dbg_val_at(__v, __x) \
 	do { \
 		volatile uint32_t *__m = \
-			(volatile uint32_t*)mailbox_get_debug_base() + __x; \
+			(volatile uint32_t *)mailbox_get_debug_base() + __x; \
 		*__m = __v; \
-	} while (0);
+	} while (0)
 
 /* dump data area at addr and size count to start of mailbox or shared memory */
 #define dump(addr, count) \
 	do { \
-		volatile uint32_t *__m = (uint32_t*)mailbox_get_debug_base(); \
-		volatile uint32_t *__a = (uint32_t*)addr; \
+		volatile uint32_t *__m = (uint32_t *)mailbox_get_debug_base(); \
+		volatile uint32_t *__a = (uint32_t *)addr; \
 		volatile int __c = count; \
 		while (__c--) \
 			*(__m++) = *(__a++); \
-	} while (0);
+	} while (0)
 
 /* dump data area at addr and size count at mailbox offset or shared memory */
 #define dump_at(addr, count, offset) \
 	do { \
-		volatile uint32_t *__m = (uint32_t*)mailbox_get_debug_base() + offset; \
-		volatile uint32_t *__a = (uint32_t*)addr; \
+		volatile uint32_t *__m = (uint32_t *)mailbox_get_debug_base() + offset; \
+		volatile uint32_t *__a = (uint32_t *)addr; \
 		volatile int __c = count; \
 		while (__c--) \
 			*(__m++) = *(__a++); \
-	} while (0);
+	} while (0)
 
 /* dump object to start of mailbox */
 #define dump_object(__o) \
-	dbg(); \
-	dump(&__o, sizeof(__o) >> 2);
+	do {						\
+		dbg();					\
+		dump(&__o, sizeof(__o) >> 2);		\
+	} while (0)
 
 /* dump object from pointer at start of mailbox */
 #define dump_object_ptr(__o) \
-	dbg(); \
-	dump(__o, sizeof(*(__o)) >> 2);
+	do {						\
+		dbg();					\
+		dump(__o, sizeof(*(__o)) >> 2);		\
+	} while (0)
 
 #define dump_object_ptr_at(__o, __at) \
-	dbg(); \
-	dump_at(__o, sizeof(*(__o)) >> 2, __at);
+	do {						\
+		dbg();					\
+		dump_at(__o, sizeof(*(__o)) >> 2, __at);\
+	} while (0)
 
 #else
 
@@ -155,7 +161,7 @@
 
 /* dump stack as part of panic */
 static inline uint32_t dump_stack(uint32_t p, void *addr, size_t offset,
-	size_t limit)
+				  size_t limit)
 {
 	extern void *_stack_sentry;
 	void *stack_limit = (void *)&_stack_sentry +

--- a/src/include/sof/dma-trace.h
+++ b/src/include/sof/dma-trace.h
@@ -65,7 +65,7 @@ struct dma_trace_data {
 	uint32_t enabled;
 	uint32_t copy_in_progress;
 	uint32_t stream_tag;
-	spinlock_t lock;
+	spinlock_t lock; /* dma trace lock */
 };
 
 int dma_trace_init_early(struct sof *sof);


### PR DESCRIPTION
It seems that everyone has dropped the ball on following coding guidelines, or no one cares about cleaning things up.

Before adding silly new rules to checkpatch, maybe we should first enforce its use and make sure the existing code is consistent. Here's a first batch I did during long debug sessions on the Linux side, there's more to come. I started from the master branch, did a reset to the origin and re-added all the files in separate patches, so checkpatch looked at all the history, not just the last contributions.

What I really looked for is:
- misaligned parameters and conditions
- multiple assignments
- macros
- spaces between casts/operands
- balanced brackets
- !pointer instead of pointer == NULL
- block comments with ending at end of line instead of newline
- logical statements on previous line rather than newline
- spelling. dont/cant/postion/her, etc.

Disclaimer: no tests were run, this is just based on checkpatch hints and checks are needed.