### PR TITLE
Make building xtensa(UP) on SMP platforms possible

### DIFF
--- a/scripts/xtensa-build-all.sh
+++ b/scripts/xtensa-build-all.sh
@@ -3,6 +3,7 @@
 SUPPORTED_PLATFORMS=(byt cht bdw hsw apl cnl sue icl skl kbl)
 BUILD_ROM=no
 BUILD_DEBUG=no
+BUILD_FORCE_UP=no
 BUILD_JOBS=1
 BUILD_JOBS_NEXT=0
 
@@ -15,6 +16,7 @@ then
 	echo "usage: xtensa-build.sh [options] platform(s)"
 	echo "       [-r] Build rom (gcc only)"
 	echo "       [-a] Build all platforms"
+	echo "       [-u] Force UP ARCH"
 	echo "       [-d] Enable debug build"
 	echo "       [-j [n]] Set number of make build jobs. Infinite jobs with no arg."
 	echo "       Supported platforms ${SUPPORTED_PLATFORMS[@]}"
@@ -25,6 +27,10 @@ else
 		if [[ "$args" == "-r" ]]
 			then
 			BUILD_ROM=yes
+
+		elif [[ "$args" == "-u" ]]
+			then
+			BUILD_FORCE_UP=yes
 
 		elif [[ "$args" == "-d" ]]
 			then
@@ -235,12 +241,22 @@ do
 	if [[ "x$BUILD_DEBUG" == "xyes" ]]
 	then
 		echo "CONFIG_DEBUG=y" >> override.config
-		make overrideconfig
 	fi
 
 	if [[ "x$BUILD_ROM" == "xyes" ]]
 	then
 		echo "CONFIG_BUILD_VM_ROM=y" >> override.config
+	fi
+
+	# override default ARCH if BUILD_FORCE_UP is set
+	if [ "x$BUILD_FORCE_UP" == "xyes" ]
+	then
+		echo "Force building UP(xtensa)..."
+		echo "CONFIG_SMP=n" >> override.config
+	fi
+
+	if [ -e override.config ]
+	then
 		make overrideconfig
 	fi
 


### PR DESCRIPTION
Add -u option to allow force building xtensa(up) ARCH on platforms which usually building xtensa-smp by default, this is helpful to debug SMP specific issues.
