### PR TITLE
scripts: pre update sof docker for cmake covert

### DIFF
--- a/scripts/docker_build/sof_builder/Dockerfile
+++ b/scripts/docker_build/sof_builder/Dockerfile
@@ -45,7 +45,9 @@ RUN apt-get -y update && \
 		texinfo \
 		udev \
 		wget \
-		unzip
+		unzip \
+		cmake \
+		python3
 
 
 # Use ToT alsa utils for the latest topology patches.


### PR DESCRIPTION
Update the sof docker to support cmake to pre test cmake build system
change.

Signed-off-by: Pan Xiuli <xiuli.pan@linux.intel.com>

pre test for https://github.com/thesofproject/sof/pull/845