### PR TITLE
topology: cml: update macros for HDA DAI's

### DIFF
--- a/tools/topology/sof-cml-rt5682.m4
+++ b/tools/topology/sof-cml-rt5682.m4
@@ -7,7 +7,6 @@ include(`utils.m4')
 include(`dai.m4')
 include(`pipeline.m4')
 include(`ssp.m4')
-include(`hda.m4')
 
 # Include TLV library
 include(`common/tlv.m4')
@@ -149,10 +148,9 @@ DAI_CONFIG(DMIC, 0, 1, dmic01,
 		PDM_CONFIG(DMIC, 0, FOUR_CH_PDM0_PDM1)))
 
 # 3 HDMI/DP outputs (ID: 2,3,4)
-dnl HDA_DAI_CONFIG(dai_index, link_id, name)
-HDA_DAI_CONFIG(0, 2, iDisp1)
-HDA_DAI_CONFIG(0, 3, iDisp2)
-HDA_DAI_CONFIG(0, 4, iDisp3)
+DAI_CONFIG(HDA, 0, 2, iDisp1)
+DAI_CONFIG(HDA, 0, 3, iDisp2)
+DAI_CONFIG(HDA, 0, 4, iDisp3)
 
 
 DEBUG_END


### PR DESCRIPTION
HDA_DAI_CONFIG has been replaced to re-use DAI_CONFIG.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>