### PR TITLE
scripts: disable pulseaudio before sof bootloop

### DIFF
--- a/tools/kmod_scripts/sof_bootloop.sh
+++ b/tools/kmod_scripts/sof_bootloop.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+enable_pulseaudio="; autospawn = yes"
+disable_pulseaudio="  autospawn = no"
+
+sed -i "s/$enable_pulseaudio/$disable_pulseaudio/" /etc/pulse/client.conf
+killall pulseaudio
+
 set -e
 
 MAXLOOPS=100
@@ -11,3 +17,5 @@ while [ $COUNTER -lt $MAXLOOPS ]; do
     dmesg > boot_$COUNTER.bootlog
     let COUNTER+=1
 done
+
+sed -i "s/$disable_pulseaudio/$enable_pulseaudio/" /etc/pulse/client.conf


### PR DESCRIPTION
the pulseaudio trigger a stream at the start, and it interfered
with the timing of sof_remove, this fix https://github.com/thesofproject/linux/issues/534

Signed-off-by: Zhu Yingjiang <yingjiang.zhu@linux.intel.com>