### PR TITLE
dw-dma: add delay for timer driven capture streams

### DIFF
--- a/src/platform/apollolake/include/platform/platform.h
+++ b/src/platform/apollolake/include/platform/platform.h
@@ -150,6 +150,9 @@ struct sof;
 /* minimal SSP port stop delay in cycles */
 #define PLATFORM_SSP_STOP_DELAY	2400
 
+/* timer driven scheduling start offset in microseconds */
+#define PLATFORM_TIMER_START_OFFSET	100
+
 /* Platform defined panic code */
 static inline void platform_panic(uint32_t p)
 {

--- a/src/platform/baytrail/include/platform/platform.h
+++ b/src/platform/baytrail/include/platform/platform.h
@@ -124,6 +124,9 @@ struct sof;
 /* DSP LPE delay in cycles */
 #define PLATFORM_LPE_DELAY 2000
 
+/* timer driven scheduling start offset in microseconds */
+#define PLATFORM_TIMER_START_OFFSET	100
+
 /* Platform defined panic code */
 static inline void platform_panic(uint32_t p)
 {

--- a/src/platform/cannonlake/include/platform/platform.h
+++ b/src/platform/cannonlake/include/platform/platform.h
@@ -151,6 +151,9 @@ struct sof;
 /* minimal SSP port stop delay in cycles */
 #define PLATFORM_SSP_STOP_DELAY	3000
 
+/* timer driven scheduling start offset in microseconds */
+#define PLATFORM_TIMER_START_OFFSET	100
+
 /* Platform defined trace code */
 static inline void platform_panic(uint32_t p)
 {

--- a/src/platform/haswell/include/platform/platform.h
+++ b/src/platform/haswell/include/platform/platform.h
@@ -120,6 +120,9 @@ struct sof;
 /* DSP default delay in cycles */
 #define PLATFORM_DEFAULT_DELAY	12
 
+/* timer driven scheduling start offset in microseconds */
+#define PLATFORM_TIMER_START_OFFSET	100
+
 /* Platform defined panic code */
 static inline void platform_panic(uint32_t p)
 {

--- a/src/platform/icelake/include/platform/platform.h
+++ b/src/platform/icelake/include/platform/platform.h
@@ -151,6 +151,9 @@ struct sof;
 /* minimal SSP port stop delay in cycles */
 #define PLATFORM_SSP_STOP_DELAY	4800
 
+/* timer driven scheduling start offset in microseconds */
+#define PLATFORM_TIMER_START_OFFSET	100
+
 /* Platform defined trace code */
 static inline void platform_panic(uint32_t p)
 {

--- a/src/platform/suecreek/include/platform/platform.h
+++ b/src/platform/suecreek/include/platform/platform.h
@@ -154,6 +154,9 @@ struct sof;
 /* minimal SSP port stop delay in cycles */
 #define PLATFORM_SSP_STOP_DELAY	3000
 
+/* timer driven scheduling start offset in microseconds */
+#define PLATFORM_TIMER_START_OFFSET	100
+
 // TODO: need UART versions
 #if 0
 /* Platform defined trace code */


### PR DESCRIPTION
Adds delay for timer driven capture streams.
External interface is enabled after DMA, so we need to compensate it.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>