### PR TITLE
GPDMA: Fix per-channel IRQ handling of GPDMA for non-APL platforms.

### DIFF
--- a/src/drivers/dw-dma.c
+++ b/src/drivers/dw-dma.c
@@ -1342,13 +1342,19 @@ static inline int dw_dma_interrupt_register(struct dma *dma, int channel)
 	uint32_t irq = dma_irq(dma, cpu_get_id());
 	int ret;
 
-	ret = interrupt_register(irq, IRQ_AUTO_UNMASK, dw_dma_irq_handler, dma);
-	if (ret < 0) {
-		trace_dwdma_error("DWDMA failed to allocate IRQ");
-		return ret;
+	if (!dma->mask_irq_channels) {
+		ret = interrupt_register(irq, IRQ_AUTO_UNMASK,
+					 dw_dma_irq_handler, dma);
+		if (ret < 0) {
+			trace_dwdma_error("DWDMA failed to allocate IRQ");
+			return ret;
+		}
+
+		interrupt_enable(irq);
 	}
 
-	interrupt_enable(irq);
+	dma->mask_irq_channels = dma->mask_irq_channels | BIT(channel);
+
 	return 0;
 }
 
@@ -1356,8 +1362,12 @@ static inline void dw_dma_interrupt_unregister(struct dma *dma, int channel)
 {
 	uint32_t irq = dma_irq(dma, cpu_get_id());
 
-	interrupt_disable(irq);
-	interrupt_unregister(irq);
+	dma->mask_irq_channels = dma->mask_irq_channels & ~BIT(channel);
+
+	if (!dma->mask_irq_channels) {
+		interrupt_disable(irq);
+		interrupt_unregister(irq);
+	}
 }
 #endif
 
@@ -1401,6 +1411,7 @@ static int dw_dma_probe(struct dma *dma)
 
 static int dw_dma_remove(struct dma *dma)
 {
+	tracev_dwdma("dw_dma_remove() id = %u", dma->plat_data.id);
 	pm_runtime_put_sync(DW_DMAC_CLK, dma->plat_data.id);
 	rfree(dma_get_drvdata(dma));
 	dma_set_drvdata(dma, NULL);

--- a/src/include/sof/dma.h
+++ b/src/include/sof/dma.h
@@ -178,6 +178,11 @@ struct dma {
 	int sref;		/**< simple ref counter, guarded by lock */
 	const struct dma_ops *ops;
 	atomic_t num_channels_busy; /* number of busy channels */
+#ifndef CONFIG_APOLLOLAKE
+	uint32_t mask_irq_channels; /* bitmask of channels with registered IRQs
+				     * on APL each channel has own IRQ handler
+				     */
+#endif
 	void *private;
 };
 


### PR DESCRIPTION
Fixed non-APL specific handling of per-channel IRQs from GPDMA.
APL has per-channel IRQs handled by xtos, so similar functionality
was implemented for other platforms. Bitmask for tracking usage of
IRQs was added to dma structure, for non-APL only.

Signed-off-by: ArturX Kloniecki <arturx.kloniecki@linux.intel.com>