### PR TITLE
dw-dma: remove superfluous check

### DIFF
--- a/src/drivers/dw-dma.c
+++ b/src/drivers/dw-dma.c
@@ -447,11 +447,8 @@ static int dw_dma_start(struct dma *dma, int channel)
 
 #if DW_USE_HW_LLI
 	/* TODO: Revisit: are we using LLP mode or single transfer ? */
-	if (p->chan[channel].lli_current) {
-		/* LLP mode - write LLP pointer */
-		dw_write(dma, DW_LLP(channel),
-			 (uint32_t)p->chan[channel].lli_current);
-	}
+	/* LLP mode - write LLP pointer */
+	dw_write(dma, DW_LLP(channel), (uint32_t)p->chan[channel].lli_current);
 #endif
 	/* channel needs started from scratch, so write SARn, DARn */
 	dw_write(dma, DW_SAR(channel), p->chan[channel].lli_current->sar);


### PR DESCRIPTION
In dw_dma_start() .lli_current cannot be NULL. If it were NULL, lines
following the check, would cause a NULL-pointer dereference. Remove
the superfluous check.

This fixes a KW issue, that triggers when dw-dma.c is moved to dw/dma.c