### PR TITLE
kmod_scripts: fix dependencies and add delays

### DIFF
--- a/tools/kmod_scripts/sof_bootloop.sh
+++ b/tools/kmod_scripts/sof_bootloop.sh
@@ -10,4 +10,5 @@ while [ $COUNTER -lt $MAXLOOPS ]; do
     ./sof_bootone.sh
     dmesg > boot_$COUNTER.bootlog
     let COUNTER+=1
+    sleep 6
 done

--- a/tools/kmod_scripts/sof_remove.sh
+++ b/tools/kmod_scripts/sof_remove.sh
@@ -14,12 +14,12 @@ remove_module() {
 
 remove_module sof_pci_dev
 remove_module sof_acpi_dev
-remove_module snd_soc_acpi_intel_match
 remove_module snd_sof_intel_byt
 remove_module snd_sof_intel_hsw
 remove_module snd_sof_intel_bdw
 remove_module snd_sof_intel_hda_common
 remove_module snd_sof_xtensa_dsp
+remove_module snd_soc_acpi_intel_match
 
 remove_module snd_soc_sst_bytcr_rt5640
 remove_module snd_soc_sst_bytcr_rt5651
@@ -29,8 +29,8 @@ remove_module snd_soc_sst_byt_cht_da7213
 remove_module snd_soc_sst_bxt_pcm512x
 remove_module snd_soc_sst_bxt_tdf8532
 remove_module snd_soc_cnl_rt274
-remove_module snd_sof_nocodec
 remove_module snd_sof
+remove_module snd_sof_nocodec
 
 remove_module snd_soc_rt5670
 remove_module snd_soc_rt5645


### PR DESCRIPTION
dependencies are incorrect due to kernel changes. this is needed for anyone testing with a recent kernel. This was tested with the latest topic/sof-dev kernel branch (e4fb585e96de3)

also add 6s delay after insert to let userspace complete its tasks and
go back to idle

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>