### PR TITLE
IPC: port PM D3 entry fixes to CNL, WHL & CML

### DIFF
--- a/src/platform/cannonlake/power_down.S
+++ b/src/platform/cannonlake/power_down.S
@@ -29,7 +29,7 @@
  */
 
 /**
- * \file platform/apollolake/power_down.S
+ * \file platform/cannonlake/power_down.S
  * \brief Power gating memory banks - implementation specific for Apollolake
  * \author Lech Betlej <lech.betlej@linux.intel.com>
  */
@@ -144,6 +144,21 @@ beqz pu32_hpsram_mask, _PD_SLEEP
 	m_cavs_set_hpldo_state temp_reg0, temp_reg1, temp_reg2
 
 //TODO: add sending IPC reply from L1$ locked code
+_PD_SEND_IPC:
+/* Send IPC to host informing of PD completion - Clear BUSY
+ * bit by writing IPC_DIPCTDR_BUSY to IPC_DIPCTDR
+ * and writing IPC_DIPCTDA_BUSY to IPC_DIPCTDA
+ */
+	movi temp_reg0, IPC_HOST_BASE
+	l32i temp_reg1, temp_reg0, IPC_DIPCTDR
+	movi temp_reg2, IPC_DIPCTDR_BUSY
+	or temp_reg1, temp_reg1, temp_reg2
+	s32i temp_reg1, temp_reg0, IPC_DIPCTDR
+
+	l32i temp_reg1, temp_reg0, IPC_DIPCTDA
+	movi temp_reg2, IPC_DIPCTDA_BUSY
+	or temp_reg1, temp_reg1, temp_reg2
+	s32i temp_reg1, temp_reg0, IPC_DIPCTDA
 
 _PD_SLEEP:
 /* effecfively executes:


### PR DESCRIPTION
The fix on APL is at: https://github.com/thesofproject/sof/pull/772/files
On CNL, we need to set two registers: IPC_DIPCTDR and IPC_DIPCTDA

This fixes https://github.com/thesofproject/sof/issues/773
