### PR TITLE
alloc: try all buffer heaps

### DIFF
--- a/src/audio/buffer.c
+++ b/src/audio/buffer.c
@@ -67,7 +67,7 @@ struct comp_buffer *buffer_new(struct sof_ipc_buffer *desc)
 		return NULL;
 	}
 
-	buffer->addr = rballoc(RZONE_RUNTIME, desc->caps, desc->size);
+	buffer->addr = rballoc(RZONE_BUFFER, desc->caps, desc->size);
 	if (!buffer->addr) {
 		rfree(buffer);
 		trace_buffer_error("buffer_new() error: "

--- a/src/audio/src.c
+++ b/src/audio/src.c
@@ -675,7 +675,7 @@ static int src_params(struct comp_dev *dev)
 	if (!cd->delay_lines)
 		rfree(cd->delay_lines);
 
-	cd->delay_lines = rballoc(RZONE_RUNTIME, SOF_MEM_CAPS_RAM,
+	cd->delay_lines = rballoc(RZONE_BUFFER, SOF_MEM_CAPS_RAM,
 				  delay_lines_size);
 	if (!cd->delay_lines) {
 		trace_src_error("src_params() error: "

--- a/src/lib/dma-trace.c
+++ b/src/lib/dma-trace.c
@@ -169,7 +169,7 @@ static int dma_trace_buffer_init(struct dma_trace_data *d)
 	struct dma_trace_buf *buffer = &d->dmatb;
 
 	/* allocate new buffer */
-	buffer->addr = rballoc(RZONE_RUNTIME,
+	buffer->addr = rballoc(RZONE_BUFFER,
 			       SOF_MEM_CAPS_RAM | SOF_MEM_CAPS_DMA,
 			       DMA_TRACE_LOCAL_SIZE);
 	if (!buffer->addr) {


### PR DESCRIPTION
this is untested. I expect CI to try various typical buffer allocations, but I think, that an allocation, that would actually test this patch, wouldn't be attempted, because if we had such a test it would be failing with the current _balloc() code. Can we add such a test to CI? The test should first allocate all or almost all buffer memory from the first heap, and then issue a second rballoc(..., SOF_MEM_CAPS_RAM, ...) for a smaller amount of memory, but too large to be satisfied from the remaining free size in the first buffer heap. Such a test should fail with the current code base but succeed with these patches.