### PR TITLE
cmake: fix ld script dependency

### DIFF
--- a/src/arch/xtensa/CMakeLists.txt
+++ b/src/arch/xtensa/CMakeLists.txt
@@ -117,6 +117,7 @@ function(sof_add_ld_script binary_name script_name)
 
 	add_custom_target("ld_script_${script_name}" DEPENDS ${lds_out})
 	add_dependencies(${binary_name} "ld_script_${script_name}")
+	set_target_properties(${binary_name} PROPERTIES LINK_DEPENDS ${lds_in})
 endfunction()
 
 sof_add_ld_script(sof ${platform_ld_script})


### PR DESCRIPTION
Fixed bug when changing *.x.in files didn't cause rebuild of sof binary.

Signed-off-by: Janusz Jankowski <janusz.jankowski@linux.intel.com>