### PR TITLE
cmake: doc: specify no languages

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-project(SOF_DOC)
+project(SOF_DOC NONE)
 
 set(SOF_ROOT_SOURCE_DIRECTORY "${PROJECT_SOURCE_DIR}/..")
 


### PR DESCRIPTION
Docs need no compilers, so skip checking them.

Signed-off-by: Janusz Jankowski <janusz.jankowski@linux.intel.com>