### PR TITLE
pipeline: pipeline_comp_copy: return once errors happened

### DIFF
--- a/src/audio/pipeline.c
+++ b/src/audio/pipeline.c
@@ -575,11 +575,16 @@ static int pipeline_comp_copy(struct comp_dev *current, void *data, int dir)
 	}
 
 	/* copy to downstream immediately */
-	if (current != ppl_data->start && dir == PPL_DIR_DOWNSTREAM)
+	if (current != ppl_data->start && dir == PPL_DIR_DOWNSTREAM) {
 		err = comp_copy(current);
+		if (err < 0)
+			return err;
+	}
 
-	pipeline_for_each_comp(current, &pipeline_comp_copy, data, NULL,
-			       dir);
+	err = pipeline_for_each_comp(current, &pipeline_comp_copy,
+				     data, NULL, dir);
+	if (err < 0)
+		return err;
 
 	if (dir == PPL_DIR_UPSTREAM)
 		err = comp_copy(current);


### PR DESCRIPTION
We should stop the pipeline copying once errors happened on any
component copying, here fix it.

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>