### PR TITLE
dma: check for invalid channel in dma stop

### DIFF
--- a/src/drivers/dw-dma.c
+++ b/src/drivers/dw-dma.c
@@ -546,7 +546,7 @@ static int dw_dma_stop(struct dma *dma, int channel)
 	int ret;
 	uint32_t flags;
 
-	if (channel >= dma->plat_data.channels) {
+	if (channel >= dma->plat_data.channels || channel == DMA_CHAN_INVALID) {
 		trace_dwdma_error("dw-dma: %d invalid channel %d",
 				  dma->plat_data.id, channel);
 		return -EINVAL;
@@ -585,7 +585,7 @@ static int dw_dma_stop(struct dma *dma, int channel)
 	struct dw_lli2 *lli;
 #endif
 
-	if (channel >= dma->plat_data.channels) {
+	if (channel >= dma->plat_data.channels || channel == DMA_CHAN_INVALID) {
 		trace_dwdma_error("dw-dma: %d invalid channel %d",
 				  dma->plat_data.id, channel);
 		return -EINVAL;

--- a/src/drivers/intel/cavs/hda-dma.c
+++ b/src/drivers/intel/cavs/hda-dma.c
@@ -752,7 +752,7 @@ static int hda_dma_stop(struct dma *dma, int channel)
 	struct dma_pdata *p = dma_get_drvdata(dma);
 	uint32_t flags;
 
-	if (channel >= HDA_DMA_MAX_CHANS) {
+	if (channel >= HDA_DMA_MAX_CHANS || channel == DMA_CHAN_INVALID) {
 		trace_hddma_error("hda-dmac: %d invalid channel %d",
 				  dma->plat_data.id, channel);
 		return -EINVAL;


### PR DESCRIPTION
if host params fails before dma channels are allocated
dma stop is called with invalid channel number and causes
eventually dsp oops.

Signed-off-by: Jaska Uimonen <jaska.uimonen@intel.com>