### PR TITLE
fw.h cleanups

### DIFF
--- a/rimage/file_format.h
+++ b/rimage/file_format.h
@@ -60,8 +60,8 @@
  * Firmware file format .
  */
 
-#ifndef __INCLUDE_UAPI_SOF_FW_H__
-#define __INCLUDE_UAPI_SOF_FW_H__
+#ifndef __INCLUDE_FILE_FORMAT_H__
+#define __INCLUDE_FILE_FORMAT_H__
 
 #include <uapi/ipc/info.h>
 #include <uapi/user/fw.h>

--- a/rimage/file_format.h
+++ b/rimage/file_format.h
@@ -64,60 +64,10 @@
 #define __INCLUDE_UAPI_SOF_FW_H__
 
 #include <uapi/ipc/info.h>
-
-#define SND_SOF_FW_SIG_SIZE	4
-#define SND_SOF_FW_ABI		1
-#define SND_SOF_FW_SIG		"Reef"
+#include <uapi/user/fw.h>
 
 #define SND_SOF_LOGS_SIG_SIZE	4
 #define SND_SOF_LOGS_SIG	"Logs"
-
-/*
- * Firmware module is made up of 1 . N blocks of different types. The
- * Block header is used to determine where and how block is to be copied in the
- * DSP/host memory space.
- */
-enum snd_sof_fw_blk_type {
-	SOF_BLK_IMAGE	= 0,	/* whole image - parsed by ROMs */
-	SOF_BLK_TEXT	= 1,
-	SOF_BLK_DATA	= 2,
-	SOF_BLK_CACHE	= 3,
-	SOF_BLK_REGS	= 4,
-	SOF_BLK_SIG	= 5,
-	SOF_BLK_ROM	= 6,
-	/* add new block types here */
-};
-
-struct snd_sof_blk_hdr {
-	enum snd_sof_fw_blk_type type;
-	uint32_t size;		/* bytes minus this header */
-	uint32_t offset;	/* offset from base */
-} __attribute__((packed));
-
-/*
- * Firmware file is made up of 1 .. N different modules types. The module
- * type is used to determine how to load and parse the module.
- */
-enum snd_sof_fw_mod_type {
-	SOF_FW_BASE	= 0,	/* base firmware image */
-	SOF_FW_MODULE	= 1,	/* firmware module */
-};
-
-struct snd_sof_mod_hdr {
-	enum snd_sof_fw_mod_type type;
-	uint32_t size;		/* bytes minus this header */
-	uint32_t num_blocks;	/* number of blocks */
-} __attribute__((packed));
-
-/*
- * Firmware file header.
- */
-struct snd_sof_fw_header {
-	unsigned char sig[SND_SOF_FW_SIG_SIZE]; /* "Reef" */
-	uint32_t file_size;	/* size of file minus this header */
-	uint32_t num_modules;	/* number of modules */
-	uint32_t abi;		/* version of header format */
-} __attribute__((packed));
 
 /*
  * Logs dictionary file header.

--- a/src/include/uapi/user/fw.h
+++ b/src/include/uapi/user/fw.h
@@ -45,7 +45,7 @@
  * Block header is used to determine where and how block is to be copied in the
  * DSP/host memory space.
  */
-enum sof_fw_blk_type {
+enum snd_sof_fw_blk_type {
 	SOF_BLK_IMAGE	= 0,	/* whole image - parsed by ROMs */
 	SOF_BLK_TEXT	= 1,
 	SOF_BLK_DATA	= 2,
@@ -56,7 +56,7 @@ enum sof_fw_blk_type {
 	/* add new block types here */
 };
 
-struct sof_blk_hdr {
+struct snd_sof_blk_hdr {
 	enum snd_sof_fw_blk_type type;
 	uint32_t size;		/* bytes minus this header */
 	uint32_t offset;	/* offset from base */
@@ -66,12 +66,12 @@ struct sof_blk_hdr {
  * Firmware file is made up of 1 .. N different modules types. The module
  * type is used to determine how to load and parse the module.
  */
-enum sof_fw_mod_type {
+enum snd_sof_fw_mod_type {
 	SOF_FW_BASE	= 0,	/* base firmware image */
 	SOF_FW_MODULE	= 1,	/* firmware module */
 };
 
-struct sof_mod_hdr {
+struct snd_sof_mod_hdr {
 	enum snd_sof_fw_mod_type type;
 	uint32_t size;		/* bytes minus this header */
 	uint32_t num_blocks;	/* number of blocks */
@@ -80,7 +80,7 @@ struct sof_mod_hdr {
 /*
  * Firmware file header.
  */
-struct sof_fw_header {
+struct snd_sof_fw_header {
 	unsigned char sig[SND_SOF_FW_SIG_SIZE]; /* "Reef" */
 	uint32_t file_size;	/* size of file minus this header */
 	uint32_t num_modules;	/* number of modules */


### PR DESCRIPTION
This patches series does the following:

* synchronizes src/include/uapi/user/fw.h with the file used by Linux (except the use of __packed
  which seems to be a Linux define).
* cleans up file_format.h to avoid code duplication. Common structures defining the blocks transferred are now defined only in fw.h and included from file_format.h

This patch series is in preparation for supporting loading section to different memory areas.