### PR TITLE
cmake: make CI builds verbose

### DIFF
--- a/scripts/host-build-all.sh
+++ b/scripts/host-build-all.sh
@@ -5,6 +5,11 @@ set -e
 
 mkdir build_host
 cd build_host
-cmake -DBUILD_HOST=ON -DCMAKE_INSTALL_PREFIX=install ..
+
+cmake -DBUILD_HOST=ON \
+	-DCMAKE_INSTALL_PREFIX=install \
+	-DCMAKE_VERBOSE_MAKEFILE=ON \
+	..
+
 make -j4
 make install

--- a/scripts/xtensa-build-all.sh
+++ b/scripts/xtensa-build-all.sh
@@ -243,7 +243,11 @@ do
 	mkdir $BUILD_DIR
 	cd $BUILD_DIR
 
-	cmake -DTOOLCHAIN=$TOOLCHAIN -DROOT_DIR=$ROOT ..
+	cmake -DTOOLCHAIN=$TOOLCHAIN \
+		-DROOT_DIR=$ROOT \
+		-DCMAKE_VERBOSE_MAKEFILE=ON \
+		..
+
 	make ${PLATFORM}_defconfig
 
 	rm -fr override.config


### PR DESCRIPTION
Usually that's spam that we may ignore in local builds, but is valuable for CI logs.

@xiulipan 
We have it in QB. Can you do it for travis?

Signed-off-by: Janusz Jankowski <janusz.jankowski@linux.intel.com>