### PR TITLE
rimage: Allow blocks to be loaded into specific memory areas

### DIFF
--- a/rimage/elf.c
+++ b/rimage/elf.c
@@ -243,15 +243,17 @@ static int elf_read_hdr(struct image *image, struct module *module)
 int elf_is_rom(struct image *image, Elf32_Shdr *section)
 {
 	uint32_t start, end;
+	uint32_t base, size;
 
 	start = section->vaddr;
 	end = section->vaddr + section->size;
 
-	if (start < image->adsp->rom_base ||
-		start > image->adsp->rom_base + image->adsp->rom_size)
+	base = image->adsp->mem_zones[SOF_FW_BLK_TYPE_ROM].base;
+	size = image->adsp->mem_zones[SOF_FW_BLK_TYPE_ROM].size;
+
+	if (start < base || start > base + size)
 		return 0;
-	if (end < image->adsp->rom_base ||
-		end > image->adsp->rom_base + image->adsp->rom_size)
+	if (end < base || end > base + size)
 		return 0;
 	return 1;
 }

--- a/rimage/file_simple.c
+++ b/rimage/file_simple.c
@@ -44,38 +44,27 @@
 #define BDW_DRAM_HOST_OFFSET	0x00000000
 #define BDW_DRAM_SIZE		(640 * 1024)
 
-static int is_iram(struct image *image, Elf32_Shdr *section)
-{
+static int get_mem_zone_type(struct image *image, Elf32_Shdr *section) {
 	const struct adsp *adsp = image->adsp;
-	uint32_t start, end;
+	uint32_t start, end, base, size;
+	int i;
 
 	start = section->vaddr;
 	end = section->vaddr + section->size;
 
-	if (start < adsp->iram_base)
-		return 0;
-	if (start >= adsp->iram_base + adsp->iram_size)
-		return 0;
-	if (end > adsp->iram_base + adsp->iram_size)
-		return 0;
-	return 1;
-}
+	for (i = SOF_FW_BLK_TYPE_START; i < SOF_FW_BLK_TYPE_NUM; i++) {
+		base =  adsp->mem_zones[i].base;
+		size =  adsp->mem_zones[i].size;
 
-static int is_dram(struct image *image, Elf32_Shdr *section)
-{
-	const struct adsp *adsp = image->adsp;
-	uint32_t start, end;
-
-	start = section->vaddr;
-	end = section->vaddr + section->size;
-
-	if (start < adsp->dram_base)
-		return 0;
-	if (start >= adsp->dram_base + adsp->dram_size)
-		return 0;
-	if (end > adsp->dram_base + adsp->dram_size)
-		return 0;
-	return 1;
+		if (start < base)
+			continue;
+		if (start >= base + size)
+			continue;
+		if (end > base + size)
+			continue;
+		return i;
+	}
+	return SOF_FW_BLK_TYPE_INVALID;
 }
 
 static int block_idx;
@@ -97,14 +86,11 @@ static int write_block(struct image *image, struct module *module,
 		block.size += padding;
 	}
 
-	if (is_iram(image, section)) {
-		block.type = SOF_FW_BLK_TYPE_IRAM;
-		block.offset = section->vaddr - adsp->iram_base
-			+ adsp->host_iram_offset;
-	} else if (is_dram(image, section)) {
-		block.type = SOF_FW_BLK_TYPE_DRAM;
-		block.offset = section->vaddr - adsp->dram_base
-			+ adsp->host_dram_offset;
+	ret = get_mem_zone_type(image, section);
+	if (ret != SOF_FW_BLK_TYPE_INVALID) {
+		block.type = ret;
+		block.offset = section->vaddr - adsp->mem_zones[ret].base
+			+ adsp->mem_zones[ret].host_offset;
 	} else {
 		fprintf(stderr, "error: invalid block address/size 0x%x/0x%x\n",
 			section->vaddr, section->size);
@@ -472,60 +458,90 @@ out:
 
 const struct adsp machine_byt = {
 	.name = "byt",
-	.iram_base = BYT_IRAM_BASE,
-	.iram_size = BYT_IRAM_SIZE,
-	.host_iram_offset = BYT_IRAM_HOST_OFFSET,
-	.dram_base = BYT_DRAM_BASE,
-	.dram_size = BYT_DRAM_SIZE,
-	.host_dram_offset = BYT_DRAM_HOST_OFFSET,
+	.mem_zones = {
+		[SOF_FW_BLK_TYPE_IRAM] = {
+			.base = BYT_IRAM_BASE,
+			.size = BYT_IRAM_SIZE,
+			.host_offset = BYT_IRAM_HOST_OFFSET,
+		},
+		[SOF_FW_BLK_TYPE_DRAM] = {
+			.base = BYT_DRAM_BASE,
+			.size = BYT_DRAM_SIZE,
+			.host_offset = BYT_DRAM_HOST_OFFSET,
+		},
+	},
 	.machine_id = MACHINE_BAYTRAIL,
 	.write_firmware = simple_write_firmware,
 };
 
 const struct adsp machine_cht = {
 	.name = "cht",
-	.iram_base = BYT_IRAM_BASE,
-	.iram_size = BYT_IRAM_SIZE,
-	.host_iram_offset = BYT_IRAM_HOST_OFFSET,
-	.dram_base = BYT_DRAM_BASE,
-	.dram_size = BYT_DRAM_SIZE,
-	.host_dram_offset = BYT_DRAM_HOST_OFFSET,
+	.mem_zones = {
+		[SOF_FW_BLK_TYPE_IRAM] = {
+			.base = BYT_IRAM_BASE,
+			.size = BYT_IRAM_SIZE,
+			.host_offset = BYT_IRAM_HOST_OFFSET,
+		},
+		[SOF_FW_BLK_TYPE_DRAM] = {
+			.base = BYT_DRAM_BASE,
+			.size = BYT_DRAM_SIZE,
+			.host_offset = BYT_DRAM_HOST_OFFSET,
+		},
+	},
 	.machine_id = MACHINE_CHERRYTRAIL,
 	.write_firmware = simple_write_firmware,
 };
 
 const struct adsp machine_bsw = {
 	.name = "bsw",
-	.iram_base = BYT_IRAM_BASE,
-	.iram_size = BYT_IRAM_SIZE,
-	.host_iram_offset = BYT_IRAM_HOST_OFFSET,
-	.dram_base = BYT_DRAM_BASE,
-	.dram_size = BYT_DRAM_SIZE,
-	.host_dram_offset = BYT_DRAM_HOST_OFFSET,
+	.mem_zones = {
+		[SOF_FW_BLK_TYPE_IRAM] = {
+			.base = BYT_IRAM_BASE,
+			.size = BYT_IRAM_SIZE,
+			.host_offset = BYT_IRAM_HOST_OFFSET,
+		},
+		[SOF_FW_BLK_TYPE_DRAM] = {
+			.base = BYT_DRAM_BASE,
+			.size = BYT_DRAM_SIZE,
+			.host_offset = BYT_DRAM_HOST_OFFSET,
+		},
+	},
 	.machine_id = MACHINE_BRASWELL,
 	.write_firmware = simple_write_firmware,
 };
 
 const struct adsp machine_hsw = {
 	.name = "hsw",
-	.iram_base = HSW_IRAM_BASE,
-	.iram_size = HSW_IRAM_SIZE,
-	.host_iram_offset = HSW_IRAM_HOST_OFFSET,
-	.dram_base = HSW_DRAM_BASE,
-	.dram_size = HSW_DRAM_SIZE,
-	.host_dram_offset = HSW_DRAM_HOST_OFFSET,
+	.mem_zones = {
+		[SOF_FW_BLK_TYPE_IRAM] = {
+			.base = HSW_IRAM_BASE,
+			.size = HSW_IRAM_SIZE,
+			.host_offset = HSW_IRAM_HOST_OFFSET,
+		},
+		[SOF_FW_BLK_TYPE_DRAM] = {
+			.base = HSW_DRAM_BASE,
+			.size = HSW_DRAM_SIZE,
+			.host_offset = HSW_DRAM_HOST_OFFSET,
+		},
+	},
 	.machine_id = MACHINE_HASWELL,
 	.write_firmware = simple_write_firmware,
 };
 
 const struct adsp machine_bdw = {
 	.name = "bdw",
-	.iram_base = BDW_IRAM_BASE,
-	.iram_size = BDW_IRAM_SIZE,
-	.host_iram_offset = BDW_IRAM_HOST_OFFSET,
-	.dram_base = BDW_DRAM_BASE,
-	.dram_size = BDW_DRAM_SIZE,
-	.host_dram_offset = BDW_DRAM_HOST_OFFSET,
+	.mem_zones = {
+		[SOF_FW_BLK_TYPE_IRAM] = {
+			.base = BDW_IRAM_BASE,
+			.size = BDW_IRAM_SIZE,
+			.host_offset = BDW_IRAM_HOST_OFFSET,
+		},
+		[SOF_FW_BLK_TYPE_DRAM] = {
+			.base = BDW_DRAM_BASE,
+			.size = BDW_DRAM_SIZE,
+			.host_offset = BDW_DRAM_HOST_OFFSET,
+		},
+	},
 	.machine_id = MACHINE_BROADWELL,
 	.write_firmware = simple_write_firmware,
 };

--- a/rimage/file_simple.c
+++ b/rimage/file_simple.c
@@ -98,11 +98,11 @@ static int write_block(struct image *image, struct module *module,
 	}
 
 	if (is_iram(image, section)) {
-		block.type = SOF_BLK_TEXT;
+		block.type = SOF_FW_BLK_TYPE_IRAM;
 		block.offset = section->vaddr - adsp->iram_base
 			+ adsp->host_iram_offset;
 	} else if (is_dram(image, section)) {
-		block.type = SOF_BLK_DATA;
+		block.type = SOF_FW_BLK_TYPE_DRAM;
 		block.offset = section->vaddr - adsp->dram_base
 			+ adsp->host_dram_offset;
 	} else {
@@ -146,7 +146,7 @@ static int write_block(struct image *image, struct module *module,
 
 	fprintf(stdout, "\t%d\t0x%8.8x\t0x%8.8x\t0x%8.8lx\t%s\n", block_idx++,
 		section->vaddr, section->size, ftell(image->out_fd),
-		block.type == SOF_BLK_TEXT ? "TEXT" : "DATA");
+		block.type == SOF_FW_BLK_TYPE_IRAM ? "TEXT" : "DATA");
 
 out:
 	free(buffer);
@@ -241,7 +241,7 @@ static int write_block_reloc(struct image *image, struct module *module)
 	int ret;
 
 	block.size = module->file_size;
-	block.type = SOF_BLK_DATA;
+	block.type = SOF_FW_BLK_TYPE_DRAM;
 	block.offset = 0;
 
 	/* write header */
@@ -277,7 +277,7 @@ static int write_block_reloc(struct image *image, struct module *module)
 
 	fprintf(stdout, "\t%d\t0x%8.8x\t0x%8.8x\t0x%8.8lx\t%s\n", block_idx++,
 		0, module->file_size, ftell(image->out_fd),
-		block.type == SOF_BLK_TEXT ? "TEXT" : "DATA");
+		block.type == SOF_FW_BLK_TYPE_IRAM ? "TEXT" : "DATA");
 
 out:
 	free(buffer);

--- a/rimage/manifest.c
+++ b/rimage/manifest.c
@@ -35,11 +35,15 @@
 
 static int man_open_rom_file(struct image *image)
 {
+	uint32_t size;
+
 	sprintf(image->out_rom_file, "%s.rom", image->out_file);
 	unlink(image->out_rom_file);
 
+	size = image->adsp->mem_zones[SOF_FW_BLK_TYPE_ROM].size;
+
 	/* allocate ROM image  */
-	image->rom_image = calloc(image->adsp->rom_size, 1);
+	image->rom_image = calloc(size, 1);
 	if (image->rom_image == NULL)
 		return -ENOMEM;
 
@@ -1099,10 +1103,16 @@ err:
 /* list of supported adsp */
 const struct adsp machine_apl = {
 	.name = "apl",
-	.rom_base = ADSP_APL_DSP_ROM_BASE,
-	.rom_size = ADSP_APL_DSP_ROM_SIZE,
-	.sram_base = APL_DSP_BASE_ENTRY,
-	.sram_size = 0x100000,
+	.mem_zones = {
+		[SOF_FW_BLK_TYPE_ROM] = {
+			.base = ADSP_APL_DSP_ROM_BASE,
+			.size = ADSP_APL_DSP_ROM_SIZE,
+		},
+		[SOF_FW_BLK_TYPE_SRAM] = {
+			.base = APL_DSP_BASE_ENTRY,
+			.size = 0x100000,
+		},
+	},
 	.image_size = 0x100000,
 	.dram_offset = 0,
 	.machine_id = MACHINE_APOLLOLAKE,
@@ -1113,10 +1123,16 @@ const struct adsp machine_apl = {
 
 const struct adsp machine_kbl = {
 	.name = "kbl",
-	.rom_base = ADSP_KBL_DSP_ROM_BASE,
-	.rom_size = ADSP_KBL_DSP_ROM_SIZE,
-	.sram_base = KBL_DSP_BASE_ENTRY,
-	.sram_size = 0x100000,
+	.mem_zones = {
+		[SOF_FW_BLK_TYPE_ROM] = {
+			.base = ADSP_KBL_DSP_ROM_BASE,
+			.size = ADSP_KBL_DSP_ROM_SIZE,
+		},
+		[SOF_FW_BLK_TYPE_SRAM] = {
+			.base = KBL_DSP_BASE_ENTRY,
+			.size = 0x100000,
+		},
+	},
 	.image_size = 0x100000,
 	.dram_offset = 0,
 	.machine_id = MACHINE_KABYLAKE,
@@ -1127,10 +1143,16 @@ const struct adsp machine_kbl = {
 
 const struct adsp machine_skl = {
 	.name = "skl",
-	.rom_base = ADSP_SKL_DSP_ROM_BASE,
-	.rom_size = ADSP_SKL_DSP_ROM_SIZE,
-	.sram_base = SKL_DSP_BASE_ENTRY,
-	.sram_size = 0x100000,
+	.mem_zones = {
+		[SOF_FW_BLK_TYPE_ROM] = {
+			.base = ADSP_SKL_DSP_ROM_BASE,
+			.size = ADSP_SKL_DSP_ROM_SIZE,
+		},
+		[SOF_FW_BLK_TYPE_SRAM] = {
+			.base = SKL_DSP_BASE_ENTRY,
+			.size = 0x100000,
+		},
+	},
 	.image_size = 0x100000,
 	.dram_offset = 0,
 	.machine_id = MACHINE_SKYLAKE,
@@ -1141,12 +1163,20 @@ const struct adsp machine_skl = {
 
 const struct adsp machine_cnl = {
 	.name = "cnl",
-	.rom_base = ADSP_CNL_DSP_ROM_BASE,
-	.rom_size = ADSP_CNL_DSP_ROM_SIZE,
-	.imr_base = CNL_DSP_IMR_BASE_ENTRY,
-	.imr_size = 0x100000,
-	.sram_base = CNL_DSP_HP_BASE_ENTRY,
-	.sram_size = 0x100000,
+	.mem_zones = {
+		[SOF_FW_BLK_TYPE_ROM] = {
+			.base = ADSP_CNL_DSP_ROM_BASE,
+			.size = ADSP_CNL_DSP_ROM_SIZE,
+		},
+		[SOF_FW_BLK_TYPE_IMR] = {
+			.base = CNL_DSP_IMR_BASE_ENTRY,
+			.size = 0x100000,
+		},
+		[SOF_FW_BLK_TYPE_SRAM] = {
+			.base = CNL_DSP_HP_BASE_ENTRY,
+			.size = 0x100000,
+		},
+	},
 	.image_size = 0x100000,
 	.dram_offset = 0,
 	.machine_id = MACHINE_CANNONLAKE,
@@ -1157,12 +1187,20 @@ const struct adsp machine_cnl = {
 
 const struct adsp machine_icl = {
 	.name = "icl",
-	.rom_base = ADSP_ICL_DSP_ROM_BASE,
-	.rom_size = ADSP_ICL_DSP_ROM_SIZE,
-	.imr_base = ICL_DSP_IMR_BASE_ENTRY,
-	.imr_size = 0x100000,
-	.sram_base = ICL_DSP_HP_BASE_ENTRY,
-	.sram_size = 0x100000,
+	.mem_zones = {
+		[SOF_FW_BLK_TYPE_ROM] = {
+			.base = ADSP_ICL_DSP_ROM_BASE,
+			.size = ADSP_ICL_DSP_ROM_SIZE,
+		},
+		[SOF_FW_BLK_TYPE_IMR] = {
+			.base = ICL_DSP_IMR_BASE_ENTRY,
+			.size = 0x100000,
+		},
+		[SOF_FW_BLK_TYPE_SRAM] = {
+			.base = ICL_DSP_HP_BASE_ENTRY,
+			.size = 0x100000,
+		},
+	},
 	.image_size = 0x100000,
 	.dram_offset = 0,
 	.machine_id = MACHINE_ICELAKE,
@@ -1173,12 +1211,20 @@ const struct adsp machine_icl = {
 
 const struct adsp machine_sue = {
 	.name = "sue",
-	.rom_base = ADSP_SUE_DSP_ROM_BASE,
-	.rom_size = ADSP_SUE_DSP_ROM_SIZE,
-	.imr_base = SUE_DSP_IMR_BASE_ENTRY,
-	.imr_size = 0x100000,
-	.sram_base = SUE_DSP_HP_BASE_ENTRY,
-	.sram_size = 0x100000,
+	.mem_zones = {
+		[SOF_FW_BLK_TYPE_ROM] = {
+			.base = ADSP_SUE_DSP_ROM_BASE,
+			.size = ADSP_SUE_DSP_ROM_SIZE,
+		},
+		[SOF_FW_BLK_TYPE_IMR] = {
+			.base = SUE_DSP_IMR_BASE_ENTRY,
+			.size = 0x100000,
+		},
+		[SOF_FW_BLK_TYPE_SRAM] = {
+			.base = SUE_DSP_HP_BASE_ENTRY,
+			.size = 0x100000,
+		},
+	},
 	.image_size = 0x100000,
 	.dram_offset = 0,
 	.machine_id = MACHINE_SUECREEK,

--- a/rimage/rimage.h
+++ b/rimage/rimage.h
@@ -24,6 +24,7 @@
 #include <openssl/conf.h>
 #include <openssl/evp.h>
 #include <openssl/err.h>
+#include <uapi/user/fw.h>
 
 #define ARRAY_SIZE(x) (sizeof(x) / sizeof(x[0]))
 #define MAX_MODULES		32
@@ -129,23 +130,18 @@ struct image {
 	char out_unsigned_file[256];
 };
 
+struct mem_zone {
+	uint32_t base;
+	uint32_t size;
+	uint32_t host_offset;
+};
+
 /*
  * Audio DSP descriptor and operations.
  */
 struct adsp {
 	const char *name;
-	uint32_t iram_base;
-	uint32_t iram_size;
-	uint32_t dram_base;
-	uint32_t dram_size;
-	uint32_t sram_base;
-	uint32_t sram_size;
-	uint32_t host_iram_offset;
-	uint32_t host_dram_offset;
-	uint32_t rom_base;
-	uint32_t rom_size;
-	uint32_t imr_base;
-	uint32_t imr_size;
+	struct mem_zone mem_zones[SOF_FW_BLK_TYPE_NUM];
 
 	uint32_t image_size;
 	uint32_t dram_offset;

--- a/src/include/uapi/user/fw.h
+++ b/src/include/uapi/user/fw.h
@@ -46,14 +46,25 @@
  * DSP/host memory space.
  */
 enum snd_sof_fw_blk_type {
-	SOF_BLK_IMAGE	= 0,	/* whole image - parsed by ROMs */
-	SOF_BLK_TEXT	= 1,
-	SOF_BLK_DATA	= 2,
-	SOF_BLK_CACHE	= 3,
-	SOF_BLK_REGS	= 4,
-	SOF_BLK_SIG	= 5,
-	SOF_BLK_ROM	= 6,
-	/* add new block types here */
+	SOF_FW_BLK_TYPE_INVALID	= -1,
+	SOF_FW_BLK_TYPE_START	= 0,
+	SOF_FW_BLK_TYPE_RSRVD0	= SOF_FW_BLK_TYPE_START,
+	SOF_FW_BLK_TYPE_IRAM	= 1,	/* local instruction RAM */
+	SOF_FW_BLK_TYPE_DRAM	= 2,	/* local data RAM */
+	SOF_FW_BLK_TYPE_SRAM	= 3,	/* system RAM */
+	SOF_FW_BLK_TYPE_ROM	= 4,
+	SOF_FW_BLK_TYPE_IMR	= 5,
+	SOF_FW_BLK_TYPE_RSRVD6	= 6,
+	SOF_FW_BLK_TYPE_RSRVD7	= 7,
+	SOF_FW_BLK_TYPE_RSRVD8	= 8,
+	SOF_FW_BLK_TYPE_RSRVD9	= 9,
+	SOF_FW_BLK_TYPE_RSRVD10	= 10,
+	SOF_FW_BLK_TYPE_RSRVD11	= 11,
+	SOF_FW_BLK_TYPE_RSRVD12	= 12,
+	SOF_FW_BLK_TYPE_RSRVD13	= 13,
+	SOF_FW_BLK_TYPE_RSRVD14	= 14,
+	/* use SOF_FW_BLK_TYPE_RSVRDX for new block types */
+	SOF_FW_BLK_TYPE_NUM
 };
 
 struct snd_sof_blk_hdr {


### PR DESCRIPTION
This will allow firmware binaries to have sections that are
loaded in different bars.

Memory areas are "manually" specified inside struct adsp. We
change that with an array of memory zones indexed by BAR type.

The indexes are specified via snd_sof_fw_blk_type which now
encodes the BAR type. To keep backward compatibility we map:
	-> SOF_BLK_TEXT to SOF_BAR_TYPE_IRAM
	-> SOF_BLK_DATA to SOF_BAR_TYPE_DRAM.

We get rid of SOF_BLK_{CACHE|REGS|SIGS} because they are not
used in SOF firmware (and ignored on Linux).

A minor drawback of this patch is that each machine description
will have memory allocated for all existing BARs even if less
are used. This can be refined in the future, by dynamically
allocating the memory zones.

Suggested-by: Liam Girdwood <liam.r.girdwood@linux.intel.com>
Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>