### PR TITLE
[skip ci] github: fix codeowners glob for @jajanusz

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -40,7 +40,7 @@ src/lib/*				@libinyang
 src/gdb/*				@mrajwa
 
 # other helpers
-test/*					@jajanusz
+test/**					@jajanusz
 scripts/*				@xiulipan
 rimage/*				@xiulipan
 
@@ -53,10 +53,10 @@ tools/eqctl/*				@singalsu
 tools/tune/*				@singalsu
 
 # build system
-*/CMakeLists.txt			@jajanusz
-*/Kconfig				@jajanusz
-scripts/cmake/*				@jajanusz
-scripts/kconfig/*			@jajanusz
+**/CMakeLists.txt			@jajanusz
+**/Kconfig				@jajanusz
+scripts/cmake/**			@jajanusz
+scripts/kconfig/**			@jajanusz
 
 # related fileds
 *.sh					@jajanusz


### PR DESCRIPTION
From: https://help.github.com/articles/about-code-owners/
```
# The `docs/*` pattern will match files like
# `docs/getting-started.md` but not further nested files like
# `docs/build-app/troubleshooting.md`.
docs/*  docs@example.com
```

What means that in most cases, we want globs like ** instead of *, when someone takes care of whole subtree.
If this fixes issue for me, I'll spam others to update codeowners.

Signed-off-by: Janusz Jankowski <janusz.jankowski@linux.intel.com>