### PR TITLE
hda-dma: Fixed flow in parameter set and stop

### DIFF
--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -301,6 +301,13 @@ static int host_trigger(struct comp_dev *dev, int cmd)
 		break;
 	case COMP_TRIGGER_START:
 #if defined CONFIG_DMA_GW
+		if (hd->chan < 0) {
+			ret = -EINVAL;
+			trace_host_error("host_trigger() error:"
+							 "no dma channel configured");
+			goto out;
+		}
+
 		ret = dma_start(hd->dma, hd->chan);
 		if (ret < 0) {
 			trace_host_error("host_trigger() error: "
@@ -542,6 +549,7 @@ static int host_params(struct comp_dev *dev)
 		trace_host_error("host_params() error: "
 				 "dma_set_config() failed");
 		dma_channel_put(hd->dma, hd->chan);
+		hd->chan = DMA_CHAN_INVALID;
 		return err;
 	}
 #else

--- a/src/drivers/intel/cavs/hda-dma.c
+++ b/src/drivers/intel/cavs/hda-dma.c
@@ -752,7 +752,7 @@ static int hda_dma_stop(struct dma *dma, int channel)
 	struct dma_pdata *p = dma_get_drvdata(dma);
 	uint32_t flags;
 
-	if (channel >= HDA_DMA_MAX_CHANS || channel == DMA_CHAN_INVALID) {
+	if (channel >= HDA_DMA_MAX_CHANS || channel < 0) {
 		trace_hddma_error("hda-dmac: %d invalid channel %d",
 				  dma->plat_data.id, channel);
 		return -EINVAL;


### PR DESCRIPTION
Fixed flow issue in which channels would be invalid number
and beeing later used to stop dma. When freeing
stream that have not even started FW tried to stop dma
which should not be the case since it was not started.

Signed-off-by: Jakub Dabek <jakub.dabek@linux.intel.com>