### PR TITLE
cmake: add dmic sources only if CONFIG_DMIC enabled

### DIFF
--- a/src/drivers/intel/cavs/CMakeLists.txt
+++ b/src/drivers/intel/cavs/CMakeLists.txt
@@ -1,5 +1,4 @@
 add_local_sources(sof
-	dmic.c
 	hda-dma.c
 	hda.c
 	interrupt.c
@@ -11,4 +10,8 @@ if(CONFIG_SUECREEK)
 	add_local_sources(sof sue-ipc.c)
 else()
 	add_local_sources(sof ipc.c)
+endif()
+
+if(CONFIG_DMIC)
+	add_local_sources(sof dmic.c)
 endif()


### PR DESCRIPTION
add dmic sources only if CONFIG_DMIC enabled

Signed-off-by: Adrian Bonislawski <adrian.bonislawski@linux.intel.com>