### PR TITLE
scripst: copy more tools and scripts to target.

### DIFF
--- a/scripts/sof-target-intsall.sh
+++ b/scripts/sof-target-intsall.sh
@@ -4,5 +4,10 @@
 for host in $@
 do
 	scp build_*_*/sof-*.ri tools/topology/*.tplg root@${host}:/lib/firmware/intel/
-	scp tools/logger/sof-logger build_*_*/src/arch/xtensa/sof-*.ldc root@${host}:~/
+	scp tools/logger/sof-logger \
+		build_*_*/src/arch/xtensa/sof-*.ldc \
+		tools/coredumper/* \
+		tools/eqctl/sof-eqctl \
+		tools/kmod_scripts/* \
+		root@${host}:~/
 done


### PR DESCRIPTION
Some tools and tests not added until their name prefix is fixed to sof-

Signed-off-by: Liam Girdwood <liam.r.girdwood@linux.intel.com>