### PR TITLE
build: add automatically generated files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,13 @@ m4/libtool.m4
 libtool
 src/include/version.h
 doc/doxygen
+CMakeFiles
+generated
+rimage_ep
+CMakeCache.txt
+__pycache__
 *.doxygen
+*.cmake
 
 autom4te*
 config.*


### PR DESCRIPTION
With the transition to Kconfig more automatically generated files and
directories have to be added to .gitignore.
