### PR TITLE
cmake: fix rimage options order

### DIFF
--- a/src/arch/xtensa/CMakeLists.txt
+++ b/src/arch/xtensa/CMakeLists.txt
@@ -297,10 +297,10 @@ if(MEU_PATH)
 			-o sof-${fw_name}.ri
 			-p sof-${fw_name}.ldc
 			-m ${fw_name}
-			${bootloader_binary_path}
-			sof-${fw_name}
 			-s ${MEU_OFFSET}
 			-k ${otc_private_key}
+			${bootloader_binary_path}
+			sof-${fw_name}
 		DEPENDS sof_dump
 		VERBATIM
 		USES_TERMINAL


### PR DESCRIPTION
It's mainly for non-compilant getopt implementation in mingw. Getopt should place all no-opt arguments at the end by default (source: http://man7.org/linux/man-pages/man3/getopt.3.html), however mingw implementation doesn't do it.

This PR changes order, so getopt in rimage will work both with default implementation and `POSIXLY_CORRECT` set to true.

Signed-off-by: Janusz Jankowski <janusz.jankowski@linux.intel.com>