### PR TITLE
dw-dma: align lli to 32 bytes

### DIFF
--- a/src/include/sof/dw-dma.h
+++ b/src/include/sof/dw-dma.h
@@ -64,6 +64,11 @@ struct dw_lli2 {
 	uint32_t ctrl_hi;
 	uint32_t sstat;
 	uint32_t dstat;
+
+	/* align to 32 bytes to not cross cache line
+	 * in case of more than two items
+	 */
+	uint32_t reserved;
 } __attribute__ ((packed));
 
 extern const struct dma_ops dw_dma_ops;


### PR DESCRIPTION
Aligns linked list items to 32 bytes to not cross
cache line in case of having more than two items.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>