### PR TITLE
hd-dma: missing COMP_STATE_ACTIVE on start

### DIFF
--- a/src/drivers/intel/cavs/hda-dma.c
+++ b/src/drivers/intel/cavs/hda-dma.c
@@ -689,6 +689,8 @@ static int hda_dma_start(struct dma *dma, int channel)
 	else
 		hda_dma_enable_unlock(dma, channel);
 
+	p->chan[channel].status = COMP_STATE_ACTIVE;
+
 out:
 	spin_unlock_irq(&dma->lock, flags);
 	return ret;


### PR DESCRIPTION
Adds missing status COMP_STATE_ACTIVE on start.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>