### PR TITLE
[RFC] ipc: pm_state_set/get commands added

### DIFF
--- a/src/drivers/intel/baytrail/ipc.c
+++ b/src/drivers/intel/baytrail/ipc.c
@@ -162,7 +162,7 @@ done:
 
 	// TODO: signal audio work to enter D3 in normal context
 	/* are we about to enter D3 ? */
-	if (iipc->pm_prepare_D3) {
+	if (iipc->pm_target_state == SOF_PM_STATE_D3) {
 		while (1) {
 			wait_for_interrupt(0);
 		}
@@ -235,7 +235,7 @@ int platform_ipc_init(struct ipc *ipc)
 	iipc->dmac = dma_get(dir, caps, dev, DMA_ACCESS_SHARED);
 
 	/* PM */
-	iipc->pm_prepare_D3 = 0;
+	iipc->pm_target_state = SOF_PM_STATE_D0;	/* initial value */
 
 	/* configure interrupt */
 	interrupt_register(PLATFORM_IPC_INTERRUPT, IRQ_AUTO_UNMASK,

--- a/src/drivers/intel/cavs/ipc.c
+++ b/src/drivers/intel/cavs/ipc.c
@@ -160,7 +160,7 @@ void ipc_platform_do_cmd(struct ipc *ipc)
 
 	/* are we about to enter D3 ? */
 #if CAVS_VERSION < CAVS_VERSION_2_0
-	if (iipc->pm_prepare_D3) {
+	if (iipc->pm_target_state == SOF_PM_STATE_D3) {
 		/* no return - memory will be powered off and IPC sent */
 		platform_pm_runtime_power_off();
 	}
@@ -178,7 +178,7 @@ void ipc_platform_do_cmd(struct ipc *ipc)
 	ipc_write(IPC_DIPCCTL, ipc_read(IPC_DIPCCTL) | IPC_DIPCCTL_IPCTBIE);
 
 #if CAVS_VERSION == CAVS_VERSION_2_0
-	if (iipc->pm_prepare_D3) {
+	if (iipc->pm_target_state == SOF_PM_STATE_D3) {
 		//TODO: add support for Icelake
 		while (1)
 			wait_for_interrupt(5);
@@ -246,7 +246,7 @@ int platform_ipc_init(struct ipc *ipc)
 			   ipc_process_task, _ipc, 0, 0);
 
 	/* PM */
-	iipc->pm_prepare_D3 = 0;
+	iipc->pm_target_state = SOF_PM_STATE_D0;	/* initial value */
 
 	/* configure interrupt */
 	interrupt_register(PLATFORM_IPC_INTERRUPT, IRQ_AUTO_UNMASK,

--- a/src/drivers/intel/cavs/sue-ipc.c
+++ b/src/drivers/intel/cavs/sue-ipc.c
@@ -86,7 +86,7 @@ done:
 
 	// TODO: signal audio work to enter D3 in normal context
 	/* are we about to enter D3 ? */
-	if (iipc->pm_prepare_D3) {
+	if (iipc->pm_target_state == SOF_PM_STATE_D3) {
 		while (1)
 			wait_for_interrupt(0);
 	}
@@ -137,7 +137,7 @@ int platform_ipc_init(struct ipc *ipc)
 			   ipc_process_task, _ipc, 0, 0);
 
 	/* PM */
-	iipc->pm_prepare_D3 = 0;
+	iipc->pm_target_state = SOF_PM_STATE_D0;	/* initial value */
 
 	return 0;
 }

--- a/src/drivers/intel/haswell/ipc.c
+++ b/src/drivers/intel/haswell/ipc.c
@@ -153,7 +153,7 @@ done:
 
 	// TODO: signal audio work to enter D3 in normal context
 	/* are we about to enter D3 ? */
-	if (iipc->pm_prepare_D3) {
+	if (iipc->pm_target_state == SOF_PM_STATE_D3) {
 		while (1) {
 			wait_for_interrupt(0);
 		}
@@ -225,7 +225,7 @@ int platform_ipc_init(struct ipc *ipc)
 	iipc->dmac = dma_get(dir, caps, dev, DMA_ACCESS_SHARED);
 
 	/* PM */
-	iipc->pm_prepare_D3 = 0;
+	iipc->pm_target_state = SOF_PM_STATE_D0;	/* initial value */
 
 	/* configure interrupt */
 	interrupt_register(PLATFORM_IPC_INTERRUPT, IRQ_AUTO_UNMASK,

--- a/src/host/ipc.c
+++ b/src/host/ipc.c
@@ -52,7 +52,7 @@ int platform_ipc_init(struct ipc *ipc)
 		bzero(iipc->page_table, HOST_PAGE_SIZE);
 
 	/* PM */
-	iipc->pm_prepare_D3 = 0;
+	iipc->pm_target_state = SOF_PM_STATE_D0;	/* initial value */
 
 	return 0;
 }

--- a/src/include/sof/ipc.h
+++ b/src/include/sof/ipc.h
@@ -42,6 +42,7 @@
 #include <sof/audio/component.h>
 #include <sof/dma-trace.h>
 #include <sof/preproc.h>
+#include <uapi/ipc/pm.h>
 
 struct sof;
 struct dai_config;
@@ -211,7 +212,7 @@ struct ipc_data {
 	uint8_t *page_table;
 
 	/* PM */
-	int pm_prepare_D3;	/* do we need to prepare for D3 */
+	uint32_t pm_target_state;	/* SOF_PM_STATE_D.. */
 };
 
 int ipc_cmd(void);

--- a/src/include/uapi/abi.h
+++ b/src/include/uapi/abi.h
@@ -52,7 +52,7 @@
 
 /** \brief SOF ABI version major, minor and patch numbers */
 #define SOF_ABI_MAJOR 3
-#define SOF_ABI_MINOR 6
+#define SOF_ABI_MINOR 7
 #define SOF_ABI_PATCH 0
 
 /** \brief SOF ABI version number. Format within 32bit word is MMmmmppp */

--- a/src/include/uapi/ipc/header.h
+++ b/src/include/uapi/ipc/header.h
@@ -124,6 +124,8 @@
 #define SOF_IPC_PM_CLK_GET			SOF_CMD_TYPE(0x005)
 #define SOF_IPC_PM_CLK_REQ			SOF_CMD_TYPE(0x006)
 #define SOF_IPC_PM_CORE_ENABLE			SOF_CMD_TYPE(0x007)
+#define SOF_IPC_PM_STATE_SET			SOF_CMD_TYPE(0x008)
+#define SOF_IPC_PM_STATE_GET			SOF_CMD_TYPE(0x009)
 
 /** \name DSP Command: Component runtime config - multiple different types
  *  @{

--- a/src/include/uapi/ipc/pm.h
+++ b/src/include/uapi/ipc/pm.h
@@ -75,4 +75,49 @@ struct sof_ipc_pm_core_config {
 	uint32_t enable_mask;
 } __attribute__((packed));
 
+/* DSP subsystem power states */
+enum sof_pm_state {
+	SOF_PM_STATE_D0 = 0,	/* D0 only, also initial state */
+	SOF_PM_STATE_D3,	/* D3 DSP subsystem is power gated*/
+	/* internal FW transitions across D0ix substates incl. D0 are allowed */
+	SOF_PM_STATE_D0ix,
+};
+
+/* Flags to allow FW for applying internally clock gating policies */
+enum sof_pm_cg {
+	SOF_PM_CG_ON = 0,	/* Clock gating enabled, */
+	SOF_PM_CG_OFF,		/* Clock gating disabled */
+};
+
+/* Flags to allow FW for applying power gating policies */
+enum sof_pm_pg {
+	SOF_PM_PG_ON = 0,	/* Power gating enabled, */
+	SOF_PM_PG_OFF,		/* Power gating disabled */
+};
+
+/* PM state - SOF_IPC_PM_STATE_SET */
+struct sof_ipc_pm_state {
+	struct sof_ipc_cmd_hdr hdr;
+
+	uint32_t pm_state;	/**< power state SOF_PM_STATE_D.. */
+	/**< flag to disable FW logic for autonomous D0ix<->D0 transitions */
+	uint32_t prevent_power_gating;
+	/**< flag to disable FW logic for autonomous clock gating */
+	uint32_t prevent_clock_gating;
+	/**< reserved for future use */
+	uint32_t reserved[8];
+} __attribute__((packed));
+
+/* PM params info reply - SOF_IPC_PM_STATE_GET */
+struct sof_ipc_pm_state_reply {
+	struct sof_ipc_reply rhdr;
+	uint32_t pm_state;	/**< power state SOF_PM_STATE_D.. */
+	/**< flag to disable FW logic for autonomous D0ix<->D0 transitions */
+	uint32_t prevent_power_gating;
+	/**< flag to disable FW logic for autonomous clock gating */
+	uint32_t prevent_clock_gating;
+	/**< reserved for future use */
+	uint32_t reserved[8];
+} __attribute__((packed));
+
 #endif


### PR DESCRIPTION
The commit extends IPC interface between a driver and FW to support
new power flows to be used with keyword detection feature. A new
command is added to set request for power state transition request
explicitly & definition of D0ix in addtion to D0 , D3 states is added.

Change to use registers instead of shared memory for cavs specific power 
flow will be covered by a separate PR.  CHT specific linking issue is tracked as #1330 

Signed-off-by: Lech Betlej <lech.betlej@linux.intel.com>