### PR TITLE
topology: cht: fix link id for nocodec DAI

### DIFF
--- a/tools/topology/sof-cht-nocodec.m4
+++ b/tools/topology/sof-cht-nocodec.m4
@@ -81,7 +81,7 @@ PCM_DUPLEX_ADD(Low Latency, 0, PIPELINE_PCM_1, PIPELINE_PCM_2)
 #
 # BE configurations - overrides config in ACPI if present
 #
-DAI_CONFIG(SSP, 2, 0, NoCodec-2,
+DAI_CONFIG(SSP, 2, 2, NoCodec-2,
 	   SSP_CONFIG(I2S, SSP_CLOCK(mclk, 19200000, codec_mclk_in),
 		      SSP_CLOCK(bclk, 2400000, codec_slave),
 		      SSP_CLOCK(fsync, 48000, codec_slave),


### PR DESCRIPTION
Nocodec machine driver add all the BE dai links with
ID's linearly incrementing from 0. So the link ID
should match with the SSP dai index.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>