### PR TITLE
scheduler: use timer driven scheduling based on config

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -26,6 +26,10 @@ config MEM_WND
 	bool
 	default n
 
+config TIMER_SCHEDULING
+	bool
+	default n
+
 source "src/Kconfig"
 
 menu "Debug"

--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -295,7 +295,6 @@ static int dai_playback_params(struct comp_dev *dev)
 	config->src_width = comp_sample_bytes(dev);
 	config->dest_width = comp_sample_bytes(dev);
 	config->cyclic = 1;
-	config->timer_delay = dev->pipeline->ipc_pipe.timer_delay;
 	config->dest_dev = dd->dai->plat_data.fifo[0].handshake;
 
 	/* set up local and host DMA elems to reset values */
@@ -349,7 +348,6 @@ static int dai_capture_params(struct comp_dev *dev)
 	/* set up DMA configuration */
 	config->direction = DMA_DIR_DEV_TO_MEM;
 	config->cyclic = 1;
-	config->timer_delay = dev->pipeline->ipc_pipe.timer_delay;
 	config->src_dev = dd->dai->plat_data.fifo[1].handshake;
 
 	/* TODO: Make this code platform-specific or move it driver callback */

--- a/src/audio/pipeline.c
+++ b/src/audio/pipeline.c
@@ -750,15 +750,13 @@ static int pipeline_xrun_recover(struct pipeline *p)
 /* notify pipeline that this component requires buffers emptied/filled */
 void pipeline_schedule_copy(struct pipeline *p, uint64_t start)
 {
-	if (p->sched_comp->state == COMP_STATE_ACTIVE) {
+	if (p->sched_comp->state == COMP_STATE_ACTIVE)
+#ifdef CONFIG_TIMER_SCHEDULING
 		/* timer driven pipeline should execute task synchronously */
-		if (p->ipc_pipe.timer_delay)
-			pipeline_copy(p->sched_comp);
-		else
-			schedule_task(&p->pipe_task, start,
-				      p->ipc_pipe.deadline);
-	}
-
+		pipeline_copy(p->sched_comp);
+#else
+		schedule_task(&p->pipe_task, start, p->ipc_pipe.deadline);
+#endif
 }
 
 /* notify pipeline that this component requires buffers emptied/filled

--- a/src/include/sof/dma.h
+++ b/src/include/sof/dma.h
@@ -121,7 +121,6 @@ struct dma_sg_config {
 	uint32_t src_dev;
 	uint32_t dest_dev;
 	uint32_t cyclic;			/* circular buffer */
-	uint32_t timer_delay;	/* non zero if timer scheduled */
 	struct dma_sg_elem_array elem_array;	/* array of dma_sg elems */
 	bool scatter;
 };

--- a/src/ipc/ipc.c
+++ b/src/ipc/ipc.c
@@ -296,6 +296,15 @@ int ipc_pipeline_new(struct ipc *ipc,
 		return -EINVAL;
 	}
 
+#ifdef CONFIG_TIMER_SCHEDULING
+	/* check whether timer value is correct */
+	if (!pipe_desc->timer_delay) {
+		trace_ipc_error("ipc_pipeline_new() error: timer_delay "
+				"value is invalid, pipe_desc->timer_delay"
+				" = %u", pipe_desc->timer_delay);
+		return -EINVAL;
+	}
+#else
 	/* find the scheduling component */
 	icd = ipc_get_comp(ipc, pipe_desc->sched_id);
 	if (icd == NULL) {
@@ -309,6 +318,7 @@ int ipc_pipeline_new(struct ipc *ipc,
 				"icd->type != COMP_TYPE_COMPONENT");
 		return -EINVAL;
 	}
+#endif
 
 	/* create the pipeline */
 	pipe = pipeline_new(pipe_desc, icd->cd);
@@ -522,7 +532,6 @@ int ipc_get_page_descriptors(struct dma *dmac, uint8_t *page_table,
 	config.src_width = sizeof(uint32_t);
 	config.dest_width = sizeof(uint32_t);
 	config.cyclic = 0;
-	config.timer_delay = 0;
 	dma_sg_init(&config.elem_array);
 
 	/* set up DMA descriptor */


### PR DESCRIPTION
Changes usage of timer driven scheduler to be config based
instead of runtime based. Coming changes to scheduling are
too big and too spread to be handled based on runtime parameters.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>