### PR TITLE
tools: kmod_scripts: remove modprobe error log and cleanups

### DIFF
--- a/tools/kmod_scripts/sof_insert.sh
+++ b/tools/kmod_scripts/sof_insert.sh
@@ -1,15 +1,27 @@
 #!/bin/bash
 
-modprobe snd_soc_rt5670
-modprobe snd_soc_rt5645
-modprobe snd_soc_rt5651
-modprobe snd_soc_rt5640
-modprobe snd_soc_da7213
-modprobe snd_soc_pcm512x_i2c
-modprobe snd_soc_tdf8532
-modprobe snd_soc_rt274
+insert_module() {
 
-modprobe sof_acpi_dev
-modprobe sof_pci_dev
+    MODULE="$1"
+
+    if modinfo "$MODULE" &> /dev/null ; then
+	modprobe $MODULE
+    else
+	echo "skipping $MODULE, not in tree"
+    fi
+}
+
+insert_module snd_soc_rt5640
+insert_module snd_soc_rt5645
+insert_module snd_soc_rt5651
+insert_module snd_soc_rt5670
+insert_module snd_soc_rt5682
+insert_module snd_soc_rt274
+insert_module snd_soc_da7213
+insert_module snd_soc_pcm512x_i2c
+insert_module snd_soc_wm8804_i2c
+
+insert_module sof_acpi_dev
+insert_module sof_pci_dev
 
 

--- a/tools/kmod_scripts/sof_remove.sh
+++ b/tools/kmod_scripts/sof_remove.sh
@@ -22,24 +22,28 @@ remove_module snd_sof_xtensa_dsp
 remove_module snd_soc_acpi_intel_match
 
 remove_module snd_soc_sst_bytcr_rt5640
-remove_module snd_soc_sst_bytcr_rt5651
 remove_module snd_soc_sst_cht_bsw_rt5645
+remove_module snd_soc_sst_bytcr_rt5651
 remove_module snd_soc_sst_cht_bsw_rt5670
+remove_module snd_soc_sof_rt5682
+remove_module snd_soc_cnl_rt274
 remove_module snd_soc_sst_byt_cht_da7213
 remove_module snd_soc_sst_bxt_pcm512x
-remove_module snd_soc_sst_bxt_tdf8532
-remove_module snd_soc_cnl_rt274
+remove_module snd_soc_sst_bxt_wm8804
+
 remove_module snd_sof
 remove_module snd_sof_nocodec
 
-remove_module snd_soc_rt5670
+remove_module snd_soc_rt5640
 remove_module snd_soc_rt5645
 remove_module snd_soc_rt5651
-remove_module snd_soc_rt5640
+remove_module snd_soc_rt5670
+remove_module snd_soc_rt5682
 remove_module snd_soc_rl6231
+remove_module snd_soc_rt274
 remove_module snd_soc_da7213
 remove_module snd_soc_pcm512x_i2c
+remove_module snd_soc_wm8804_i2c
 remove_module snd_soc_pcm512x
-remove_module snd_soc_tdf8532
-remove_module snd_soc_rt274
+
 remove_module snd_soc_acpi


### PR DESCRIPTION
filter out modprobe log if module is not in tree
also add missing codecs (rt5682 and wm8804) and reorder codec list

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>