### PR TITLE
kconfig: add CAVS_VER define for CAVS platforms

### DIFF
--- a/src/drivers/Kconfig
+++ b/src/drivers/Kconfig
@@ -8,3 +8,22 @@ config DMIC
 	  Select for DMIC driver
 
 endmenu
+
+config CAVS_VERSION_1_5
+	depends on CAVS
+	bool
+	help
+	  Select for CAVS version 1.5
+
+config CAVS_VERSION_1_8
+	depends on CAVS && !CAVS_VERSION_1_5
+	bool
+	help
+	  Select for CAVS version 1.8
+
+config CAVS_VERSION_2_0
+	depends on CAVS && !CAVS_VERSION_1_5 && !CAVS_VERSION_1_8
+	bool
+	help
+	  Select for CAVS version 2.0
+

--- a/src/drivers/intel/cavs/interrupt.c
+++ b/src/drivers/intel/cavs/interrupt.c
@@ -36,6 +36,7 @@
 #include <sof/interrupt.h>
 #include <sof/interrupt-map.h>
 #include <sof/cpu.h>
+#include <sof/cavs-version.h>
 #include <arch/interrupt.h>
 #include <platform/interrupt.h>
 #include <platform/platcfg.h>
@@ -123,7 +124,7 @@ static void irq_lvl2_level5_handler(void *data)
 
 /* DSP internal interrupts */
 static struct irq_desc dsp_irq[PLATFORM_CORE_COUNT][4] = {
-	#if defined(CONFIG_CANNONLAKE) || defined(CONFIG_ICELAKE)
+#if CAVS_VERSION >= CAVS_VERSION_1_8
 	{{IRQ_NUM_EXT_LEVEL2, irq_lvl2_level2_handler, },
 	{IRQ_NUM_EXT_LEVEL3, irq_lvl2_level3_handler, },
 	{IRQ_NUM_EXT_LEVEL4, irq_lvl2_level4_handler, },
@@ -133,7 +134,7 @@ static struct irq_desc dsp_irq[PLATFORM_CORE_COUNT][4] = {
 	{IRQ_NUM_EXT_LEVEL3, irq_lvl2_level3_handler, },
 	{IRQ_NUM_EXT_LEVEL4, irq_lvl2_level4_handler, },
 	{IRQ_NUM_EXT_LEVEL5, irq_lvl2_level5_handler, } },
-	#endif
+#endif
 
 	{{IRQ_NUM_EXT_LEVEL2, irq_lvl2_level2_handler, },
 	{IRQ_NUM_EXT_LEVEL3, irq_lvl2_level3_handler, },

--- a/src/include/sof/cavs-version.h
+++ b/src/include/sof/cavs-version.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2018, Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of the Intel Corporation nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>
+ */
+
+#ifndef __INCLUDE_CAVS_VERSION_H__
+#define __INCLUDE_CAVS_VERSION_H__
+
+#define CAVS_VERSION_1_5 0x10500
+#define CAVS_VERSION_1_8 0x10800
+#define CAVS_VERSION_2_0 0x20000
+
+/* CAVS version defined by CONFIG_CAVS_VER_*/
+#if defined(CONFIG_CAVS_VERSION_1_5)
+#define CAVS_VERSION CAVS_VERSION_1_5
+#elif defined(CONFIG_CAVS_VERSION_1_8)
+#define CAVS_VERSION CAVS_VERSION_1_8
+#elif defined(CONFIG_CAVS_VERSION_2_0)
+#define CAVS_VERSION CAVS_VERSION_2_0
+#endif
+
+#endif

--- a/src/platform/Kconfig
+++ b/src/platform/Kconfig
@@ -38,6 +38,7 @@ config APOLLOLAKE
 	select MEM_WND
 	select TASK_HAVE_PRIORITY_MEDIUM
 	select CAVS
+	select CAVS_VERSION_1_5
 	help
 	  Select if your target platform is Apollolake-compatible
 
@@ -49,6 +50,7 @@ config CANNONLAKE
 	select MEM_WND
 	select TASK_HAVE_PRIORITY_MEDIUM
 	select CAVS
+	select CAVS_VERSION_1_8
 	help
 	  Select if your target platform is Cannonlake-compatible
 
@@ -58,6 +60,7 @@ config SUECREEK
 	select IRQ_MAP
 	select TASK_HAVE_PRIORITY_MEDIUM
 	select CAVS
+	select CAVS_VERSION_2_0
 	help
 	  Select if your target platform is Suecreek-compatible
 
@@ -69,6 +72,7 @@ config ICELAKE
 	select MEM_WND
 	select TASK_HAVE_PRIORITY_MEDIUM
 	select CAVS
+	select CAVS_VERSION_2_0
 	help
 	  Select if your target platform is Icelake-compatible
 


### PR DESCRIPTION
I've added CAVS_VERSION choice in kconfig and CAVS_VER define for CAVS platforms. I've refactored drivers/cavs with CAVS_VER instead of CONFIG_* defines.