### PR TITLE
[RFC][WIP] large messages v2

### DIFF
--- a/src/include/uapi/abi.h
+++ b/src/include/uapi/abi.h
@@ -52,7 +52,7 @@
 
 /** \brief SOF ABI version major, minor and patch numbers */
 #define SOF_ABI_MAJOR 3
-#define SOF_ABI_MINOR 2
+#define SOF_ABI_MINOR 3
 #define SOF_ABI_PATCH 0
 
 /** \brief SOF ABI version number. Format within 32bit word is MMmmmppp */

--- a/src/include/uapi/ipc/control.h
+++ b/src/include/uapi/ipc/control.h
@@ -150,9 +150,13 @@ struct sof_ipc_ctrl_data {
 	/* control data - can either be appended or DMAed from host */
 	struct sof_ipc_host_buffer buffer;
 	uint32_t num_elems;	/**< in array elems or bytes for data type */
+	uint32_t total_elems;	/**< total size if message is sent in parts */
+
+	/* for large messages sent in parts */
+	uint32_t msg_id;
 
 	/* reserved for future use */
-	uint32_t reserved[8];
+	uint32_t reserved[6];
 
 	/* control data - add new types if needed */
 	union {


### PR DESCRIPTION
v2 of large messages. The component receiving data (in this case fir as an example) is reserving the large memory blob by itself and parts are copied directly there from ipc buffer. Mechanism uses new member in sof_ipc_ctrl_data called msg_id.