### PR TITLE
cmake: refactor and new targets: olddefconfig alldefconfig savedefconfig

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,17 +52,6 @@ if(BUILD_HOST)
 	return()
 endif()
 
-if(${CMAKE_VERSION} VERSION_LESS "3.12.0")
-	# FindPythonInterp is bugged and may sometimes be unable to find
-	# Python 3 when both Python 2 & 3 are in PATH,
-	# so it's always better to use CMake 3.12+
-	find_package(PythonInterp 3.0)
-	set(PYTHON3 "${PYTHON_EXECUTABLE}")
-else()
-	find_package(Python3 COMPONENTS Interpreter)
-	set(PYTHON3 "${Python3_EXECUTABLE}")
-endif()
-
 # get compiler name and version
 execute_process(
 	COMMAND ${CMAKE_C_COMPILER} --version
@@ -89,8 +78,6 @@ sof_add_version_h_rule(${PROJECT_SOURCE_DIR}/scripts/cmake/version.cmake)
 
 include(scripts/cmake/dist.cmake)
 
-include(scripts/cmake/defconfigs.cmake)
-
 # cmake itself cannot depend on files that don't exist
 # so to make it regenerate when .config file is created,
 # we make it depend on containing directory
@@ -103,49 +90,18 @@ if(EXISTS ${DOT_CONFIG_PATH})
 	read_kconfig_config(${DOT_CONFIG_PATH})
 endif()
 
-add_custom_target(
-	menuconfig
-	COMMAND ${CMAKE_COMMAND} -E env
-		srctree=${PROJECT_SOURCE_DIR}
-		CC_VERSION_TEXT=${CC_VERSION_TEXT}
-		ARCH=${ARCH}
-		${PYTHON3} ${PROJECT_SOURCE_DIR}/scripts/kconfig/menuconfig.py
-		${PROJECT_SOURCE_DIR}/Kconfig
-	WORKING_DIRECTORY ${GENERATED_DIRECTORY}
-	VERBATIM
-	USES_TERMINAL
-)
+if(${CMAKE_VERSION} VERSION_LESS "3.12.0")
+	# FindPythonInterp is bugged and may sometimes be unable to find
+	# Python 3 when both Python 2 & 3 are in PATH,
+	# so it's always better to use CMake 3.12+
+	find_package(PythonInterp 3.0)
+	set(PYTHON3 "${PYTHON_EXECUTABLE}")
+else()
+	find_package(Python3 COMPONENTS Interpreter)
+	set(PYTHON3 "${Python3_EXECUTABLE}")
+endif()
 
-add_custom_target(
-	overrideconfig
-	COMMAND ${CMAKE_COMMAND} -E env
-		srctree=${PROJECT_SOURCE_DIR}
-		CC_VERSION_TEXT=${CC_VERSION_TEXT}
-		ARCH=${ARCH}
-		${PYTHON3} ${PROJECT_SOURCE_DIR}/scripts/kconfig/overrideconfig.py
-		${PROJECT_SOURCE_DIR}/Kconfig
-		${PROJECT_BINARY_DIR}/override.config
-	WORKING_DIRECTORY ${GENERATED_DIRECTORY}
-	VERBATIM
-	USES_TERMINAL
-)
-
-add_custom_command(OUTPUT ${CONFIG_H_PATH}
-	COMMAND ${CMAKE_COMMAND} -E env
-		srctree=${PROJECT_SOURCE_DIR}
-		CC_VERSION_TEXT=${CC_VERSION_TEXT}
-		ARCH=${ARCH}
-		${PYTHON3} ${PROJECT_SOURCE_DIR}/scripts/kconfig/genconfig.py
-		--header-path ${CONFIG_H_PATH}
-		${PROJECT_SOURCE_DIR}/Kconfig
-	DEPENDS ${DOT_CONFIG_PATH}
-	WORKING_DIRECTORY ${GENERATED_DIRECTORY}
-	COMMENT "Generating ${CONFIG_H_PATH}"
-	VERBATIM
-	USES_TERMINAL
-)
-
-add_custom_target(genconfig DEPENDS ${CONFIG_H_PATH})
+include(scripts/cmake/kconfig.cmake)
 
 add_dependencies(sof_options genconfig)
 target_include_directories(sof_options INTERFACE ${GENERATED_DIRECTORY}/include)

--- a/scripts/cmake/kconfig.cmake
+++ b/scripts/cmake/kconfig.cmake
@@ -46,3 +46,16 @@ add_custom_command(
 )
 
 add_custom_target(genconfig DEPENDS ${CONFIG_H_PATH})
+
+add_custom_target(
+	olddefconfig
+	COMMAND ${CMAKE_COMMAND} -E env
+		srctree=${PROJECT_SOURCE_DIR}
+		CC_VERSION_TEXT=${CC_VERSION_TEXT}
+		ARCH=${ARCH}
+		${PYTHON3} ${PROJECT_SOURCE_DIR}/scripts/kconfig/olddefconfig.py
+		${PROJECT_SOURCE_DIR}/Kconfig
+	WORKING_DIRECTORY ${GENERATED_DIRECTORY}
+	VERBATIM
+	USES_TERMINAL
+)

--- a/scripts/cmake/kconfig.cmake
+++ b/scripts/cmake/kconfig.cmake
@@ -1,0 +1,48 @@
+# Kconfig targets
+
+include(${CMAKE_CURRENT_LIST_DIR}/defconfigs.cmake)
+
+add_custom_target(
+	menuconfig
+	COMMAND ${CMAKE_COMMAND} -E env
+		srctree=${PROJECT_SOURCE_DIR}
+		CC_VERSION_TEXT=${CC_VERSION_TEXT}
+		ARCH=${ARCH}
+		${PYTHON3} ${PROJECT_SOURCE_DIR}/scripts/kconfig/menuconfig.py
+		${PROJECT_SOURCE_DIR}/Kconfig
+	WORKING_DIRECTORY ${GENERATED_DIRECTORY}
+	VERBATIM
+	USES_TERMINAL
+)
+
+add_custom_target(
+	overrideconfig
+	COMMAND ${CMAKE_COMMAND} -E env
+		srctree=${PROJECT_SOURCE_DIR}
+		CC_VERSION_TEXT=${CC_VERSION_TEXT}
+		ARCH=${ARCH}
+		${PYTHON3} ${PROJECT_SOURCE_DIR}/scripts/kconfig/overrideconfig.py
+		${PROJECT_SOURCE_DIR}/Kconfig
+		${PROJECT_BINARY_DIR}/override.config
+	WORKING_DIRECTORY ${GENERATED_DIRECTORY}
+	VERBATIM
+	USES_TERMINAL
+)
+
+add_custom_command(
+	OUTPUT ${CONFIG_H_PATH}
+	COMMAND ${CMAKE_COMMAND} -E env
+		srctree=${PROJECT_SOURCE_DIR}
+		CC_VERSION_TEXT=${CC_VERSION_TEXT}
+		ARCH=${ARCH}
+		${PYTHON3} ${PROJECT_SOURCE_DIR}/scripts/kconfig/genconfig.py
+		--header-path ${CONFIG_H_PATH}
+		${PROJECT_SOURCE_DIR}/Kconfig
+	DEPENDS ${DOT_CONFIG_PATH}
+	WORKING_DIRECTORY ${GENERATED_DIRECTORY}
+	COMMENT "Generating ${CONFIG_H_PATH}"
+	VERBATIM
+	USES_TERMINAL
+)
+
+add_custom_target(genconfig DEPENDS ${CONFIG_H_PATH})

--- a/scripts/cmake/kconfig.cmake
+++ b/scripts/cmake/kconfig.cmake
@@ -72,3 +72,18 @@ add_custom_target(
 	VERBATIM
 	USES_TERMINAL
 )
+
+add_custom_target(
+	savedefconfig
+	COMMAND ${CMAKE_COMMAND} -E env
+		srctree=${PROJECT_SOURCE_DIR}
+		CC_VERSION_TEXT=${CC_VERSION_TEXT}
+		ARCH=${ARCH}
+		${PYTHON3} ${PROJECT_SOURCE_DIR}/scripts/kconfig/savedefconfig.py
+		${PROJECT_SOURCE_DIR}/Kconfig
+		${PROJECT_BINARY_DIR}/defconfig
+	WORKING_DIRECTORY ${GENERATED_DIRECTORY}
+	COMMENT "Saving minimal configuration to: ${PROJECT_BINARY_DIR}/defconfig"
+	VERBATIM
+	USES_TERMINAL
+)

--- a/scripts/cmake/kconfig.cmake
+++ b/scripts/cmake/kconfig.cmake
@@ -59,3 +59,16 @@ add_custom_target(
 	VERBATIM
 	USES_TERMINAL
 )
+
+add_custom_target(
+	alldefconfig
+	COMMAND ${CMAKE_COMMAND} -E env
+		srctree=${PROJECT_SOURCE_DIR}
+		CC_VERSION_TEXT=${CC_VERSION_TEXT}
+		ARCH=${ARCH}
+		${PYTHON3} ${PROJECT_SOURCE_DIR}/scripts/kconfig/alldefconfig.py
+		${PROJECT_SOURCE_DIR}/Kconfig
+	WORKING_DIRECTORY ${GENERATED_DIRECTORY}
+	VERBATIM
+	USES_TERMINAL
+)

--- a/scripts/kconfig/savedefconfig.py
+++ b/scripts/kconfig/savedefconfig.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2019, Intel Corporation
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#   * Neither the name of the Intel Corporation nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# Author: Janusz Jankowski <janusz.jankowski@linux.intel.com>
+#
+
+# Loads current config file and saves minimal configuration to
+# the given file.
+#
+# Usage:
+#   savedefconfig.py KCONFIG_FILENAME DEFCONFIG_OUTPUT_FILE
+
+import os
+import sys
+
+import kconfiglib
+
+
+def main():
+    if len(sys.argv) < 3:
+        sys.exit("usage: {} KCONFIG_FILENAME DEFCONFIG_OUTPUT_FILE"
+            .format(sys.argv[0]))
+
+    kconf = kconfiglib.Kconfig(sys.argv[1])
+    kconf.load_config()
+    kconf.write_min_config(sys.argv[2])
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Moves Kconfig targets to separate file to not bloat root CMakeLists. Adds these targets: olddefconfig, alldefconfig, savedefconfig