### PR TITLE
kmod_scripts: improve list of devices

### DIFF
--- a/tools/kmod_scripts/sof_insert.sh
+++ b/tools/kmod_scripts/sof_insert.sh
@@ -5,6 +5,7 @@ insert_module() {
     MODULE="$1"
 
     if modinfo "$MODULE" &> /dev/null ; then
+	echo "Inserting $MODULE"
 	modprobe $MODULE
     else
 	echo "skipping $MODULE, not in tree"

--- a/tools/kmod_scripts/sof_remove.sh
+++ b/tools/kmod_scripts/sof_remove.sh
@@ -18,6 +18,7 @@ remove_module snd_sof_intel_byt
 remove_module snd_sof_intel_hsw
 remove_module snd_sof_intel_bdw
 remove_module snd_sof_intel_hda_common
+remove_module snd_sof_intel_hda
 remove_module snd_sof_xtensa_dsp
 remove_module snd_soc_acpi_intel_match
 
@@ -30,6 +31,7 @@ remove_module snd_soc_cnl_rt274
 remove_module snd_soc_sst_byt_cht_da7213
 remove_module snd_soc_sst_bxt_pcm512x
 remove_module snd_soc_sst_bxt_wm8804
+remove_module snd_soc_skl_hda_dsp
 
 remove_module snd_sof
 remove_module snd_sof_nocodec
@@ -43,7 +45,18 @@ remove_module snd_soc_rl6231
 remove_module snd_soc_rt274
 remove_module snd_soc_da7213
 remove_module snd_soc_pcm512x_i2c
-remove_module snd_soc_wm8804_i2c
 remove_module snd_soc_pcm512x
+remove_module snd_soc_wm8804_i2c
+remove_module snd_soc_wm8804
+remove_module snd_soc_hdac_hda
+remove_module snd_soc_hdac_hdmi
+remove_module snd_soc_dmic
 
 remove_module snd_soc_acpi
+remove_module snd_hda_ext_core
+
+remove_module snd_soc_core
+remove_module snd_hda_codec
+remove_module snd_hda_core
+remove_module snd_hwdep
+remove_module snd_pcm


### PR DESCRIPTION
HDaudio support was missing, along with a slew of codecs
Also add a log on module insertion

Tested on Up2 with HDMI&PCM512x, and CHT w/ rt5645

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>