### PR TITLE
volume: refactor volume to support variable processing sizes

### DIFF
--- a/src/audio/volume.c
+++ b/src/audio/volume.c
@@ -494,7 +494,7 @@ static int volume_copy(struct comp_dev *dev)
 	}
 
 	/* copy and scale volume */
-	cd->scale_vol(dev, sink, source);
+	cd->scale_vol(dev, sink, source, dev->frames);
 
 	/* calc new free and available */
 	comp_update_buffer_produce(sink, cd->sink_period_bytes);

--- a/src/audio/volume_generic.c
+++ b/src/audio/volume_generic.c
@@ -111,801 +111,320 @@ static inline int32_t vol_mult_s32_to_s24(int32_t x, int32_t vol)
 }
 
 /**
- * \brief Volume processing from 16 bit to 32 bit in 2 channels.
+ * \brief Volume processing from 16 bit to 32 bit.
  * \param[in,out] dev Volume base component device.
  * \param[in,out] sink Destination buffer.
  * \param[in,out] source Source buffer.
+ * \param[in] frames Number of frames to process.
  *
  * Copy and scale volume from 16 bit source buffer
- * to 32 bit destination buffer for 2 channels.
+ * to 32 bit destination buffer.
  */
-static void vol_s16_to_s32_2ch(struct comp_dev *dev, struct comp_buffer *sink,
-			       struct comp_buffer *source)
+static void vol_s16_to_s32(struct comp_dev *dev, struct comp_buffer *sink,
+			   struct comp_buffer *source, uint32_t frames)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
-	int16_t *src = (int16_t *)source->r_ptr;
-	int32_t *dest = (int32_t *)sink->w_ptr;
+	int16_t *src;
+	int32_t *dest;
 	int32_t i;
+	uint32_t channel;
+	uint32_t buff_frag = 0;
 
-	/* buffer sizes are always divisible by period frames */
 	/* Samples are Q1.15 --> Q1.31 and volume is Q1.16 */
-	for (i = 0; i < dev->frames * 2; i += 2) {
-		dest[i] = (int32_t)src[i] * cd->volume[0];
-		dest[i + 1] = (int32_t)src[i + 1] * cd->volume[1];
+	for (i = 0; i < frames; i++) {
+		for (channel = 0; channel < dev->params.channels; channel++) {
+			src = buffer_read_frag_s16(source, buff_frag);
+			dest = buffer_write_frag_s32(sink, buff_frag);
+
+			*dest = (int32_t)*src * cd->volume[channel];
+
+			buff_frag++;
+		}
 	}
 }
 
 /**
- * \brief Volume processing from 32 bit to 16 bit in 2 channels.
+ * \brief Volume processing from 32 bit to 16 bit.
  * \param[in,out] dev Volume base component device.
  * \param[in,out] sink Destination buffer.
  * \param[in,out] source Source buffer.
+ * \param[in] frames Number of frames to process.
  *
  * Copy and scale volume from 32 bit source buffer
- * to 16 bit destination buffer for 2 channels.
+ * to 16 bit destination buffer.
  */
-static void vol_s32_to_s16_2ch(struct comp_dev *dev, struct comp_buffer *sink,
-			       struct comp_buffer *source)
+static void vol_s32_to_s16(struct comp_dev *dev, struct comp_buffer *sink,
+			   struct comp_buffer *source, uint32_t frames)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
-	int32_t *src = (int32_t *)source->r_ptr;
-	int16_t *dest = (int16_t *)sink->w_ptr;
+	int32_t *src;
+	int16_t *dest;
 	int32_t i;
+	uint32_t channel;
+	uint32_t buff_frag = 0;
 
-	/* buffer sizes are always divisible by period frames */
 	/* Samples are Q1.31 --> Q1.15 and volume is Q1.16 */
-	for (i = 0; i < dev->frames * 2; i += 2) {
-		dest[i] = vol_mult_s32_to_s16(src[i], cd->volume[0]);
-		dest[i + 1] = vol_mult_s32_to_s16(src[i + 1], cd->volume[1]);
+	for (i = 0; i < frames; i++) {
+		for (channel = 0; channel < dev->params.channels; channel++) {
+			src = buffer_read_frag_s32(source, buff_frag);
+			dest = buffer_write_frag_s16(sink, buff_frag);
+
+			*dest = vol_mult_s32_to_s16(*src, cd->volume[channel]);
+
+			buff_frag++;
+		}
 	}
 }
 
 /**
- * \brief Volume processing from 32 bit to 32 bit in 2 channels.
+ * \brief Volume processing from 32 bit to 32 bit.
  * \param[in,out] dev Volume base component device.
  * \param[in,out] sink Destination buffer.
  * \param[in,out] source Source buffer.
+ * \param[in] frames Number of frames to process.
  *
  * Copy and scale volume from 32 bit source buffer
- * to 32 bit destination buffer for 2 channels.
+ * to 32 bit destination buffer.
  */
-static void vol_s32_to_s32_2ch(struct comp_dev *dev, struct comp_buffer *sink,
-			       struct comp_buffer *source)
+static void vol_s32_to_s32(struct comp_dev *dev, struct comp_buffer *sink,
+			   struct comp_buffer *source, uint32_t frames)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
-	int32_t *src = (int32_t *)source->r_ptr;
-	int32_t *dest = (int32_t *)sink->w_ptr;
+	int32_t *src;
+	int32_t *dest;
 	int32_t i;
+	uint32_t channel;
+	uint32_t buff_frag = 0;
 
-	/* buffer sizes are always divisible by period frames */
 	/* Samples are Q1.31 --> Q1.31 and volume is Q1.16 */
-	for (i = 0; i < dev->frames * 2; i += 2) {
-		dest[i] = q_multsr_sat_32x32(
-			src[i], cd->volume[0], Q_SHIFT_BITS_64(31, 16, 31));
-		dest[i + 1] = q_multsr_sat_32x32(
-			src[i + 1], cd->volume[1], Q_SHIFT_BITS_64(31, 16, 31));
+	for (i = 0; i < frames; i++) {
+		for (channel = 0; channel < dev->params.channels; channel++) {
+			src = buffer_read_frag_s32(source, buff_frag);
+			dest = buffer_write_frag_s32(sink, buff_frag);
+
+			*dest = q_multsr_sat_32x32
+				(*src, cd->volume[channel],
+				 Q_SHIFT_BITS_64(31, 16, 31));
+
+			buff_frag++;
+		}
 	}
 }
 
 /**
- * \brief Volume processing from 16 bit to 16 bit in 2 channels.
+ * \brief Volume processing from 16 bit to 16 bit.
  * \param[in,out] dev Volume base component device.
  * \param[in,out] sink Destination buffer.
  * \param[in,out] source Source buffer.
+ * \param[in] frames Number of frames to process.
  *
  * Copy and scale volume from 16 bit source buffer
- * to 16 bit destination buffer for 2 channels.
+ * to 16 bit destination buffer.
  */
-static void vol_s16_to_s16_2ch(struct comp_dev *dev, struct comp_buffer *sink,
-			       struct comp_buffer *source)
+static void vol_s16_to_s16(struct comp_dev *dev, struct comp_buffer *sink,
+			   struct comp_buffer *source, uint32_t frames)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
-	int16_t *src = (int16_t *)source->r_ptr;
-	int16_t *dest = (int16_t *)sink->w_ptr;
+	int16_t *src;
+	int16_t *dest;
 	int32_t i;
+	uint32_t channel;
+	uint32_t buff_frag = 0;
 
-	/* buffer sizes are always divisible by period frames */
 	/* Samples are Q1.15 --> Q1.15 and volume is Q1.16 */
-	for (i = 0; i < dev->frames * 2; i += 2) {
-		dest[i] = q_multsr_sat_16x16(
-			src[i], cd->volume[0], Q_SHIFT_BITS_32(15, 16, 15));
-		dest[i + 1] = q_multsr_sat_16x16(
-			src[i + 1], cd->volume[1], Q_SHIFT_BITS_32(15, 16, 15));
+	for (i = 0; i < frames; i++) {
+		for (channel = 0; channel < dev->params.channels; channel++) {
+			src = buffer_read_frag_s16(source, buff_frag);
+			dest = buffer_write_frag_s16(sink, buff_frag);
+
+			*dest = q_multsr_sat_16x16
+				(*src, cd->volume[channel],
+				 Q_SHIFT_BITS_32(15, 16, 15));
+
+			buff_frag++;
+		}
 	}
 }
 
 /**
- * \brief Volume processing from 16 bit to 24/32 bit in 2 channels.
+ * \brief Volume processing from 16 bit to 24/32 bit.
  * \param[in,out] dev Volume base component device.
  * \param[in,out] sink Destination buffer.
  * \param[in,out] source Source buffer.
+ * \param[in] frames Number of frames to process.
  *
  * Copy and scale volume from 16 bit source buffer
- * to 24/32 bit destination buffer for 2 channels.
+ * to 24/32 bit destination buffer.
  */
-static void vol_s16_to_s24_2ch(struct comp_dev *dev, struct comp_buffer *sink,
-			       struct comp_buffer *source)
+static void vol_s16_to_s24(struct comp_dev *dev, struct comp_buffer *sink,
+			   struct comp_buffer *source, uint32_t frames)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
-	int16_t *src = (int16_t *)source->r_ptr;
-	int32_t *dest = (int32_t *)sink->w_ptr;
+	int16_t *src;
+	int32_t *dest;
 	int32_t i;
+	uint32_t channel;
+	uint32_t buff_frag = 0;
 
-	/* buffer sizes are always divisible by period frames */
 	/* Samples are Q1.15 and volume is Q1.16 */
-	for (i = 0; i < dev->frames * 2; i += 2) {
-		dest[i] = vol_mult_s16_to_s24(src[i], cd->volume[0]);
-		dest[i + 1] = vol_mult_s16_to_s24(src[i + 1], cd->volume[1]);
+	for (i = 0; i < frames; i++) {
+		for (channel = 0; channel < dev->params.channels; channel++) {
+			src = buffer_read_frag_s16(source, buff_frag);
+			dest = buffer_write_frag_s32(sink, buff_frag);
+
+			*dest = vol_mult_s16_to_s24(*src, cd->volume[channel]);
+
+			buff_frag++;
+		}
 	}
 }
 
 /**
- * \brief Volume processing from 24/32 bit to 16 bit in 2 channels.
+ * \brief Volume processing from 24/32 bit to 16 bit.
  * \param[in,out] dev Volume base component device.
  * \param[in,out] sink Destination buffer.
  * \param[in,out] source Source buffer.
+ * \param[in] frames Number of frames to process.
  *
  * Copy and scale volume from 24/32 bit source buffer
- * to 16 bit destination buffer for 2 channels.
+ * to 16 bit destination buffer.
  */
-static void vol_s24_to_s16_2ch(struct comp_dev *dev, struct comp_buffer *sink,
-			       struct comp_buffer *source)
+static void vol_s24_to_s16(struct comp_dev *dev, struct comp_buffer *sink,
+			   struct comp_buffer *source, uint32_t frames)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
-	int32_t *src = (int32_t *)source->r_ptr;
-	int16_t *dest = (int16_t *)sink->w_ptr;
+	int32_t *src;
+	int16_t *dest;
 	int32_t i;
+	uint32_t channel;
+	uint32_t buff_frag = 0;
 
-	/* buffer sizes are always divisible by period frames */
 	/* Samples are Q1.23 --> Q1.15 and volume is Q1.16 */
-	for (i = 0; i < dev->frames * 2; i += 2) {
-		dest[i] = vol_mult_s24_to_s16(src[i], cd->volume[0]);
-		dest[i + 1] = vol_mult_s24_to_s16(src[i + 1], cd->volume[1]);
+	for (i = 0; i < frames; i++) {
+		for (channel = 0; channel < dev->params.channels; channel++) {
+			src = buffer_read_frag_s32(source, buff_frag);
+			dest = buffer_write_frag_s16(sink, buff_frag);
+
+			*dest = vol_mult_s24_to_s16(*src, cd->volume[channel]);
+
+			buff_frag++;
+		}
 	}
 }
 
 /**
- * \brief Volume processing from 32 bit to 24/32 bit in 2 channels.
+ * \brief Volume processing from 32 bit to 24/32 bit.
  * \param[in,out] dev Volume base component device.
  * \param[in,out] sink Destination buffer.
  * \param[in,out] source Source buffer.
+ * \param[in] frames Number of frames to process.
  *
  * Copy and scale volume from 32 bit source buffer
- * to 24/32 bit destination buffer for 2 channels.
+ * to 24/32 bit destination buffer.
  */
-static void vol_s32_to_s24_2ch(struct comp_dev *dev, struct comp_buffer *sink,
-			       struct comp_buffer *source)
+static void vol_s32_to_s24(struct comp_dev *dev, struct comp_buffer *sink,
+			   struct comp_buffer *source, uint32_t frames)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
-	int32_t *src = (int32_t *)source->r_ptr;
-	int32_t *dest = (int32_t *)sink->w_ptr;
+	int32_t *src;
+	int32_t *dest;
 	int32_t i;
+	uint32_t channel;
+	uint32_t buff_frag = 0;
 
-	/* buffer sizes are always divisible by period frames */
 	/* Samples are Q1.31 --> Q1.23 and volume is Q1.16 */
-	for (i = 0; i < dev->frames * 2; i += 2) {
-		dest[i] = vol_mult_s32_to_s24(src[i], cd->volume[0]);
-		dest[i + 1] = vol_mult_s32_to_s24(src[i + 1], cd->volume[1]);
+	for (i = 0; i < frames; i++) {
+		for (channel = 0; channel < dev->params.channels; channel++) {
+			src = buffer_read_frag_s32(source, buff_frag);
+			dest = buffer_write_frag_s32(sink, buff_frag);
+
+			*dest = vol_mult_s32_to_s24(*src, cd->volume[channel]);
+
+			buff_frag++;
+		}
 	}
 }
 
 /**
- * \brief Volume processing from 24/32 bit to 32 bit in 2 channels.
+ * \brief Volume processing from 24/32 bit to 32 bit.
  * \param[in,out] dev Volume base component device.
  * \param[in,out] sink Destination buffer.
  * \param[in,out] source Source buffer.
+ * \param[in] frames Number of frames to process.
  *
  * Copy and scale volume from 24/32 bit source buffer
- * to 32 bit destination buffer for 2 channels.
+ * to 32 bit destination buffer.
  */
-static void vol_s24_to_s32_2ch(struct comp_dev *dev, struct comp_buffer *sink,
-			       struct comp_buffer *source)
+static void vol_s24_to_s32(struct comp_dev *dev, struct comp_buffer *sink,
+			   struct comp_buffer *source, uint32_t frames)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
-	int32_t *src = (int32_t *)source->r_ptr;
-	int32_t *dest = (int32_t *)sink->w_ptr;
+	int32_t *src;
+	int32_t *dest;
 	int32_t i;
+	uint32_t channel;
+	uint32_t buff_frag = 0;
 
-	/* buffer sizes are always divisible by period frames */
 	/* Samples are Q1.23 --> Q1.31 and volume is Q1.16 */
-	for (i = 0; i < dev->frames * 2; i += 2) {
-		dest[i] = q_multsr_sat_32x32(
-			sign_extend_s24(src[i]), cd->volume[0],
-			Q_SHIFT_BITS_64(23, 16, 31));
-		dest[i + 1] = q_multsr_sat_32x32(
-			sign_extend_s24(src[i + 1]), cd->volume[1],
-			Q_SHIFT_BITS_64(23, 16, 31));
+	for (i = 0; i < frames; i++) {
+		for (channel = 0; channel < dev->params.channels; channel++) {
+			src = buffer_read_frag_s32(source, buff_frag);
+			dest = buffer_write_frag_s32(sink, buff_frag);
+
+			*dest = q_multsr_sat_32x32
+				(sign_extend_s24(*src), cd->volume[channel],
+				 Q_SHIFT_BITS_64(23, 16, 31));
+
+			buff_frag++;
+		}
 	}
 }
 
 /**
- * \brief Volume processing from 24/32 bit to 24/32 bit in 2 channels.
+ * \brief Volume processing from 24/32 bit to 24/32 bit.
  * \param[in,out] dev Volume base component device.
  * \param[in,out] sink Destination buffer.
  * \param[in,out] source Source buffer.
+ * \param[in] frames Number of frames to process.
  *
  * Copy and scale volume from 24/32 bit source buffer
- * to 24/32 bit destination buffer for 2 channels.
+ * to 24/32 bit destination buffer.
  */
-static void vol_s24_to_s24_2ch(struct comp_dev *dev, struct comp_buffer *sink,
-			       struct comp_buffer *source)
+static void vol_s24_to_s24(struct comp_dev *dev, struct comp_buffer *sink,
+			   struct comp_buffer *source, uint32_t frames)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
-	int32_t i, *src = (int32_t *)source->r_ptr;
-	int32_t *dest = (int32_t *)sink->w_ptr;
+	int32_t *src;
+	int32_t *dest;
+	int32_t i;
+	uint32_t channel;
+	uint32_t buff_frag = 0;
 
-	/* buffer sizes are always divisible by period frames */
 	/* Samples are Q1.23 --> Q1.23 and volume is Q1.16 */
-	for (i = 0; i < dev->frames * 2; i += 2) {
-		dest[i] = vol_mult_s24_to_s24(src[i], cd->volume[0]);
-		dest[i + 1] = vol_mult_s24_to_s24(src[i + 1], cd->volume[1]);
+	for (i = 0; i < frames; i++) {
+		for (channel = 0; channel < dev->params.channels; channel++) {
+			src = buffer_read_frag_s32(source, buff_frag);
+			dest = buffer_write_frag_s32(sink, buff_frag);
+
+			*dest = vol_mult_s24_to_s24(*src, cd->volume[channel]);
+
+			buff_frag++;
+		}
 	}
 }
-
-#if PLATFORM_MAX_CHANNELS >= 4
-/**
- * \brief Volume processing from 16 bit to 32 bit in 4 channels.
- * \param[in,out] dev Volume base component device.
- * \param[in,out] sink Destination buffer.
- * \param[in,out] source Source buffer.
- *
- * Copy and scale volume from 16 bit source buffer
- * to 32 bit destination buffer for 4 channels.
- */
-static void vol_s16_to_s32_4ch(struct comp_dev *dev, struct comp_buffer *sink,
-			       struct comp_buffer *source)
-{
-	struct comp_data *cd = comp_get_drvdata(dev);
-	int16_t *src = (int16_t *)source->r_ptr;
-	int32_t *dest = (int32_t *)sink->w_ptr;
-	int32_t i;
-
-	/* buffer sizes are always divisible by period frames */
-	/* Samples are Q1.15 --> Q1.31 and volume is Q1.16 */
-	for (i = 0; i < dev->frames * 4; i += 4) {
-		dest[i] = (int32_t)src[i] * cd->volume[0];
-		dest[i + 1] = (int32_t)src[i + 1] * cd->volume[1];
-		dest[i + 2] = (int32_t)src[i + 2] * cd->volume[2];
-		dest[i + 3] = (int32_t)src[i + 3] * cd->volume[3];
-	}
-}
-
-/**
- * \brief Volume processing from 32 bit to 16 bit in 4 channels.
- * \param[in,out] dev Volume base component device.
- * \param[in,out] sink Destination buffer.
- * \param[in,out] source Source buffer.
- *
- * Copy and scale volume from 32 bit source buffer
- * to 16 bit destination buffer for 4 channels.
- */
-static void vol_s32_to_s16_4ch(struct comp_dev *dev, struct comp_buffer *sink,
-			       struct comp_buffer *source)
-{
-	struct comp_data *cd = comp_get_drvdata(dev);
-	int32_t *src = (int32_t *)source->r_ptr;
-	int16_t *dest = (int16_t *)sink->w_ptr;
-	int32_t i;
-
-	/* buffer sizes are always divisible by period frames */
-	/* Samples are Q1.31 --> Q1.15 and volume is Q1.16 */
-	for (i = 0; i < dev->frames * 4; i += 4) {
-		dest[i] = vol_mult_s32_to_s16(src[i], cd->volume[0]);
-		dest[i + 1] = vol_mult_s32_to_s16(src[i + 1], cd->volume[1]);
-		dest[i + 2] = vol_mult_s32_to_s16(src[i + 2], cd->volume[2]);
-		dest[i + 3] = vol_mult_s32_to_s16(src[i + 3], cd->volume[3]);
-	}
-}
-
-/**
- * \brief Volume processing from 32 bit to 32 bit in 4 channels.
- * \param[in,out] dev Volume base component device.
- * \param[in,out] sink Destination buffer.
- * \param[in,out] source Source buffer.
- *
- * Copy and scale volume from 32 bit source buffer
- * to 32 bit destination buffer for 4 channels.
- */
-static void vol_s32_to_s32_4ch(struct comp_dev *dev, struct comp_buffer *sink,
-			       struct comp_buffer *source)
-{
-	struct comp_data *cd = comp_get_drvdata(dev);
-	int32_t *src = (int32_t *)source->r_ptr;
-	int32_t *dest = (int32_t *)sink->w_ptr;
-	int32_t i;
-
-	/* buffer sizes are always divisible by period frames */
-	/* Samples are Q1.31 --> Q1.31 and volume is Q1.16 */
-	for (i = 0; i < dev->frames * 4; i += 4) {
-		dest[i] = q_multsr_sat_32x32(src[i], cd->volume[0],
-					     Q_SHIFT_BITS_64(31, 16, 31));
-		dest[i + 1] = q_multsr_sat_32x32(src[i + 1], cd->volume[1],
-						 Q_SHIFT_BITS_64(31, 16, 31));
-		dest[i + 2] = q_multsr_sat_32x32(src[i + 2], cd->volume[2],
-						 Q_SHIFT_BITS_64(31, 16, 31));
-		dest[i + 3] = q_multsr_sat_32x32(src[i + 3], cd->volume[3],
-						 Q_SHIFT_BITS_64(31, 16, 31));
-	}
-}
-
-/**
- * \brief Volume processing from 16 bit to 16 bit in 4 channels.
- * \param[in,out] dev Volume base component device.
- * \param[in,out] sink Destination buffer.
- * \param[in,out] source Source buffer.
- *
- * Copy and scale volume from 16 bit source buffer
- * to 16 bit destination buffer for 4 channels.
- */
-static void vol_s16_to_s16_4ch(struct comp_dev *dev, struct comp_buffer *sink,
-			       struct comp_buffer *source)
-{
-	struct comp_data *cd = comp_get_drvdata(dev);
-	int16_t *src = (int16_t *)source->r_ptr;
-	int16_t *dest = (int16_t *)sink->w_ptr;
-	int32_t i;
-
-	/* buffer sizes are always divisible by period frames */
-	/* Samples are Q1.15 --> Q1.15 and volume is Q1.16 */
-	for (i = 0; i < dev->frames * 4; i += 4) {
-		dest[i] = q_multsr_sat_16x16(src[i], cd->volume[0],
-					     Q_SHIFT_BITS_32(15, 16, 15));
-		dest[i + 1] = q_multsr_sat_16x16(src[i + 1], cd->volume[1],
-						 Q_SHIFT_BITS_32(15, 16, 15));
-		dest[i + 2] = q_multsr_sat_16x16(src[i + 2], cd->volume[2],
-						 Q_SHIFT_BITS_32(15, 16, 15));
-		dest[i + 3] = q_multsr_sat_16x16(src[i + 3], cd->volume[3],
-						 Q_SHIFT_BITS_32(15, 16, 15));
-	}
-}
-
-/**
- * \brief Volume processing from 16 bit to 24/32 bit in 4 channels.
- * \param[in,out] dev Volume base component device.
- * \param[in,out] sink Destination buffer.
- * \param[in,out] source Source buffer.
- *
- * Copy and scale volume from 16 bit source buffer
- * to 24/32 bit destination buffer for 4 channels.
- */
-static void vol_s16_to_s24_4ch(struct comp_dev *dev, struct comp_buffer *sink,
-			       struct comp_buffer *source)
-{
-	struct comp_data *cd = comp_get_drvdata(dev);
-	int16_t *src = (int16_t *)source->r_ptr;
-	int32_t *dest = (int32_t *)sink->w_ptr;
-	int32_t i;
-
-	/* buffer sizes are always divisible by period frames */
-	/* Samples are Q1.15 and volume is Q1.16 */
-	for (i = 0; i < dev->frames * 4; i += 4) {
-		dest[i] = vol_mult_s16_to_s24(src[i], cd->volume[0]);
-		dest[i + 1] = vol_mult_s16_to_s24(src[i + 1], cd->volume[1]);
-		dest[i + 2] = vol_mult_s16_to_s24(src[i + 2], cd->volume[2]);
-		dest[i + 3] = vol_mult_s16_to_s24(src[i + 3], cd->volume[3]);
-	}
-}
-
-/**
- * \brief Volume processing from 24/32 bit to 16 bit in 4 channels.
- * \param[in,out] dev Volume base component device.
- * \param[in,out] sink Destination buffer.
- * \param[in,out] source Source buffer.
- *
- * Copy and scale volume from 24/32 bit source buffer
- * to 16 bit destination buffer for 4 channels.
- */
-static void vol_s24_to_s16_4ch(struct comp_dev *dev, struct comp_buffer *sink,
-			       struct comp_buffer *source)
-{
-	struct comp_data *cd = comp_get_drvdata(dev);
-	int32_t *src = (int32_t *)source->r_ptr;
-	int16_t *dest = (int16_t *)sink->w_ptr;
-	int32_t i;
-
-	/* buffer sizes are always divisible by period frames */
-	/* Samples are Q1.23 --> Q1.15 and volume is Q1.16 */
-	for (i = 0; i < dev->frames * 4; i += 4) {
-		dest[i] = vol_mult_s24_to_s16(src[i], cd->volume[0]);
-		dest[i + 1] = vol_mult_s24_to_s16(src[i + 1], cd->volume[1]);
-		dest[i + 2] = vol_mult_s24_to_s16(src[i + 2], cd->volume[2]);
-		dest[i + 3] = vol_mult_s24_to_s16(src[i + 3], cd->volume[3]);
-	}
-}
-
-/**
- * \brief Volume processing from 32 bit to 24/32 bit in 4 channels.
- * \param[in,out] dev Volume base component device.
- * \param[in,out] sink Destination buffer.
- * \param[in,out] source Source buffer.
- *
- * Copy and scale volume from 32 bit source buffer
- * to 24/32 bit destination buffer for 4 channels.
- */
-static void vol_s32_to_s24_4ch(struct comp_dev *dev, struct comp_buffer *sink,
-			       struct comp_buffer *source)
-{
-	struct comp_data *cd = comp_get_drvdata(dev);
-	int32_t *src = (int32_t *)source->r_ptr;
-	int32_t *dest = (int32_t *)sink->w_ptr;
-	int32_t i;
-
-	/* buffer sizes are always divisible by period frames */
-	/* Samples are Q1.31 --> Q1.23 and volume is Q1.16 */
-	for (i = 0; i < dev->frames * 4; i += 4) {
-		dest[i] = vol_mult_s32_to_s24(src[i], cd->volume[0]);
-		dest[i + 1] = vol_mult_s32_to_s24(src[i + 1], cd->volume[1]);
-		dest[i + 2] = vol_mult_s32_to_s24(src[i + 2], cd->volume[2]);
-		dest[i + 3] = vol_mult_s32_to_s24(src[i + 3], cd->volume[3]);
-	}
-}
-
-/**
- * \brief Volume processing from 24/32 bit to 32 bit in 4 channels.
- * \param[in,out] dev Volume base component device.
- * \param[in,out] sink Destination buffer.
- * \param[in,out] source Source buffer.
- *
- * Copy and scale volume from 24/32 bit source buffer
- * to 32 bit destination buffer for 4 channels.
- */
-static void vol_s24_to_s32_4ch(struct comp_dev *dev, struct comp_buffer *sink,
-			       struct comp_buffer *source)
-{
-	struct comp_data *cd = comp_get_drvdata(dev);
-	int32_t *src = (int32_t *)source->r_ptr;
-	int32_t *dest = (int32_t *)sink->w_ptr;
-	int32_t i;
-
-	/* buffer sizes are always divisible by period frames */
-	/* Samples are Q1.23 --> Q1.31 and volume is Q1.16 */
-	for (i = 0; i < dev->frames * 4; i += 4) {
-		dest[i] = q_multsr_sat_32x32(sign_extend_s24(src[i]),
-					     cd->volume[0],
-					     Q_SHIFT_BITS_64(23, 16, 31));
-		dest[i + 1] = q_multsr_sat_32x32(sign_extend_s24(src[i + 1]),
-						 cd->volume[1],
-						 Q_SHIFT_BITS_64(23, 16, 31));
-		dest[i + 2] = q_multsr_sat_32x32(sign_extend_s24(src[i + 2]),
-						 cd->volume[2],
-						 Q_SHIFT_BITS_64(23, 16, 31));
-		dest[i + 3] = q_multsr_sat_32x32(sign_extend_s24(src[i + 3]),
-						 cd->volume[3],
-						 Q_SHIFT_BITS_64(23, 16, 31));
-	}
-}
-
-/**
- * \brief Volume processing from 24/32 bit to 24/32 bit in 4 channels.
- * \param[in,out] dev Volume base component device.
- * \param[in,out] sink Destination buffer.
- * \param[in,out] source Source buffer.
- *
- * Copy and scale volume from 24/32 bit source buffer
- * to 24/32 bit destination buffer for 4 channels.
- */
-static void vol_s24_to_s24_4ch(struct comp_dev *dev, struct comp_buffer *sink,
-			       struct comp_buffer *source)
-{
-	struct comp_data *cd = comp_get_drvdata(dev);
-	int32_t i, *src = (int32_t *)source->r_ptr;
-	int32_t *dest = (int32_t *)sink->w_ptr;
-
-	/* buffer sizes are always divisible by period frames */
-	/* Samples are Q1.23 --> Q1.23 and volume is Q1.16 */
-	for (i = 0; i < dev->frames * 4; i += 4) {
-		dest[i] = vol_mult_s24_to_s24(src[i], cd->volume[0]);
-		dest[i + 1] = vol_mult_s24_to_s24(src[i + 1], cd->volume[1]);
-		dest[i + 2] = vol_mult_s24_to_s24(src[i + 2], cd->volume[2]);
-		dest[i + 3] = vol_mult_s24_to_s24(src[i + 3], cd->volume[3]);
-	}
-}
-#endif
-
-#if PLATFORM_MAX_CHANNELS >= 8
-/* volume scaling functions for 8-channel input */
-
-/* copy and scale volume from 16 bit source buffer to 32 bit dest buffer */
-static void vol_s16_to_s32_8ch(struct comp_dev *dev, struct comp_buffer *sink,
-			       struct comp_buffer *source)
-{
-	struct comp_data *cd = comp_get_drvdata(dev);
-	int16_t *src = (int16_t *)source->r_ptr;
-	int32_t *dest = (int32_t *)sink->w_ptr;
-	int32_t i;
-
-	/* buffer sizes are always divisible by period frames */
-	/* Samples are Q1.15 --> Q1.31 and volume is Q1.16 */
-	for (i = 0; i < dev->frames * 8; i += 8) {
-		dest[i] = (int32_t)src[i] * cd->volume[0];
-		dest[i + 1] = (int32_t)src[i + 1] * cd->volume[1];
-		dest[i + 2] = (int32_t)src[i + 2] * cd->volume[2];
-		dest[i + 3] = (int32_t)src[i + 3] * cd->volume[3];
-		dest[i + 4] = (int32_t)src[i + 4] * cd->volume[4];
-		dest[i + 5] = (int32_t)src[i + 5] * cd->volume[5];
-		dest[i + 6] = (int32_t)src[i + 6] * cd->volume[6];
-		dest[i + 7] = (int32_t)src[i + 7] * cd->volume[7];
-	}
-}
-
-/* copy and scale volume from 32 bit source buffer to 16 bit dest buffer */
-static void vol_s32_to_s16_8ch(struct comp_dev *dev, struct comp_buffer *sink,
-			       struct comp_buffer *source)
-{
-	struct comp_data *cd = comp_get_drvdata(dev);
-	int32_t *src = (int32_t *)source->r_ptr;
-	int16_t *dest = (int16_t *)sink->w_ptr;
-	int32_t i;
-
-	/* buffer sizes are always divisible by period frames */
-	/* Samples are Q1.31 --> Q1.15 and volume is Q1.16 */
-	for (i = 0; i < dev->frames * 8; i += 8) {
-		dest[i] = vol_mult_s32_to_s16(src[i], cd->volume[0]);
-		dest[i + 1] = vol_mult_s32_to_s16(src[i + 1], cd->volume[1]);
-		dest[i + 2] = vol_mult_s32_to_s16(src[i + 2], cd->volume[2]);
-		dest[i + 3] = vol_mult_s32_to_s16(src[i + 3], cd->volume[3]);
-		dest[i + 4] = vol_mult_s32_to_s16(src[i + 4], cd->volume[4]);
-		dest[i + 5] = vol_mult_s32_to_s16(src[i + 5], cd->volume[5]);
-		dest[i + 6] = vol_mult_s32_to_s16(src[i + 6], cd->volume[6]);
-		dest[i + 7] = vol_mult_s32_to_s16(src[i + 7], cd->volume[7]);
-	}
-}
-
-/* copy and scale volume from 32 bit source buffer to 32 bit dest buffer */
-static void vol_s32_to_s32_8ch(struct comp_dev *dev, struct comp_buffer *sink,
-			       struct comp_buffer *source)
-{
-	struct comp_data *cd = comp_get_drvdata(dev);
-	int32_t *src = (int32_t *)source->r_ptr;
-	int32_t *dest = (int32_t *)sink->w_ptr;
-	int32_t i;
-
-	/* buffer sizes are always divisible by period frames */
-	/* Samples are Q1.31 --> Q1.31 and volume is Q1.16 */
-	for (i = 0; i < dev->frames * 8; i += 8) {
-		dest[i] = q_multsr_sat_32x32(src[i], cd->volume[0],
-					     Q_SHIFT_BITS_64(31, 16, 31));
-		dest[i + 1] = q_multsr_sat_32x32(src[i + 1], cd->volume[1],
-						 Q_SHIFT_BITS_64(31, 16, 31));
-		dest[i + 2] = q_multsr_sat_32x32(src[i + 2], cd->volume[2],
-						 Q_SHIFT_BITS_64(31, 16, 31));
-		dest[i + 3] = q_multsr_sat_32x32(src[i + 3], cd->volume[3],
-						 Q_SHIFT_BITS_64(31, 16, 31));
-		dest[i + 4] = q_multsr_sat_32x32(src[i + 4], cd->volume[4],
-						 Q_SHIFT_BITS_64(31, 16, 31));
-		dest[i + 5] = q_multsr_sat_32x32(src[i + 5], cd->volume[5],
-						 Q_SHIFT_BITS_64(31, 16, 31));
-		dest[i + 6] = q_multsr_sat_32x32(src[i + 6], cd->volume[6],
-						 Q_SHIFT_BITS_64(31, 16, 31));
-		dest[i + 7] = q_multsr_sat_32x32(src[i + 7], cd->volume[7],
-						 Q_SHIFT_BITS_64(31, 16, 31));
-	}
-}
-
-/* copy and scale volume from 16 bit source buffer to 16 bit dest buffer */
-static void vol_s16_to_s16_8ch(struct comp_dev *dev, struct comp_buffer *sink,
-			       struct comp_buffer *source)
-{
-	struct comp_data *cd = comp_get_drvdata(dev);
-	int16_t *src = (int16_t *)source->r_ptr;
-	int16_t *dest = (int16_t *)sink->w_ptr;
-	int32_t i;
-
-	/* buffer sizes are always divisible by period frames */
-	/* Samples are Q1.15 --> Q1.15 and volume is Q1.16 */
-	for (i = 0; i < dev->frames * 8; i += 8) {
-		dest[i] = q_multsr_sat_16x16(src[i], cd->volume[0],
-					     Q_SHIFT_BITS_32(15, 16, 15));
-		dest[i + 1] = q_multsr_sat_16x16(src[i + 1], cd->volume[1],
-						 Q_SHIFT_BITS_32(15, 16, 15));
-		dest[i + 2] = q_multsr_sat_16x16(src[i + 2], cd->volume[2],
-						 Q_SHIFT_BITS_32(15, 16, 15));
-		dest[i + 3] = q_multsr_sat_16x16(src[i + 3], cd->volume[3],
-						 Q_SHIFT_BITS_32(15, 16, 15));
-		dest[i + 4] = q_multsr_sat_16x16(src[i + 4], cd->volume[4],
-						 Q_SHIFT_BITS_32(15, 16, 15));
-		dest[i + 5] = q_multsr_sat_16x16(src[i + 5], cd->volume[5],
-						 Q_SHIFT_BITS_32(15, 16, 15));
-		dest[i + 6] = q_multsr_sat_16x16(src[i + 6], cd->volume[6],
-						 Q_SHIFT_BITS_32(15, 16, 15));
-		dest[i + 7] = q_multsr_sat_16x16(src[i + 7], cd->volume[7],
-						 Q_SHIFT_BITS_32(15, 16, 15));
-	}
-}
-
-/* copy and scale volume from 16 bit source buffer to 24 bit
- * on 32 bit boundary buffer
- */
-static void vol_s16_to_s24_8ch(struct comp_dev *dev, struct comp_buffer *sink,
-			       struct comp_buffer *source)
-{
-	struct comp_data *cd = comp_get_drvdata(dev);
-	int16_t *src = (int16_t *)source->r_ptr;
-	int32_t *dest = (int32_t *)sink->w_ptr;
-	int32_t i;
-
-	/* buffer sizes are always divisible by period frames */
-	/* Samples are Q1.15 and volume is Q1.16 */
-	for (i = 0; i < dev->frames * 8; i += 8) {
-		dest[i] = vol_mult_s16_to_s24(src[i], cd->volume[0]);
-		dest[i + 1] = vol_mult_s16_to_s24(src[i + 1], cd->volume[1]);
-		dest[i + 2] = vol_mult_s16_to_s24(src[i + 2], cd->volume[2]);
-		dest[i + 3] = vol_mult_s16_to_s24(src[i + 3], cd->volume[3]);
-		dest[i + 4] = vol_mult_s16_to_s24(src[i + 4], cd->volume[4]);
-		dest[i + 5] = vol_mult_s16_to_s24(src[i + 5], cd->volume[5]);
-		dest[i + 6] = vol_mult_s16_to_s24(src[i + 6], cd->volume[6]);
-		dest[i + 7] = vol_mult_s16_to_s24(src[i + 7], cd->volume[7]);
-	}
-}
-
-/* copy and scale volume from 16 bit source buffer to 24 bit
- * on 32 bit boundary dest buffer
- */
-static void vol_s24_to_s16_8ch(struct comp_dev *dev, struct comp_buffer *sink,
-			       struct comp_buffer *source)
-{
-	struct comp_data *cd = comp_get_drvdata(dev);
-	int32_t *src = (int32_t *)source->r_ptr;
-	int16_t *dest = (int16_t *)sink->w_ptr;
-	int32_t i;
-
-	/* buffer sizes are always divisible by period frames */
-	/* Samples are Q1.23 --> Q1.15 and volume is Q1.16 */
-	for (i = 0; i < dev->frames * 8; i += 8) {
-		dest[i] = vol_mult_s24_to_s16(src[i], cd->volume[0]);
-		dest[i + 1] = vol_mult_s24_to_s16(src[i + 1], cd->volume[1]);
-		dest[i + 2] = vol_mult_s24_to_s16(src[i + 2], cd->volume[2]);
-		dest[i + 3] = vol_mult_s24_to_s16(src[i + 3], cd->volume[3]);
-		dest[i + 4] = vol_mult_s24_to_s16(src[i + 4], cd->volume[4]);
-		dest[i + 5] = vol_mult_s24_to_s16(src[i + 5], cd->volume[5]);
-		dest[i + 6] = vol_mult_s24_to_s16(src[i + 6], cd->volume[6]);
-		dest[i + 7] = vol_mult_s24_to_s16(src[i + 7], cd->volume[7]);
-	}
-}
-
-/* copy and scale volume from 32 bit source buffer to 24 bit
- * on 32 bit boundary dest buffer
- */
-static void vol_s32_to_s24_8ch(struct comp_dev *dev, struct comp_buffer *sink,
-			       struct comp_buffer *source)
-{
-	struct comp_data *cd = comp_get_drvdata(dev);
-	int32_t *src = (int32_t *)source->r_ptr;
-	int32_t *dest = (int32_t *)sink->w_ptr;
-	int32_t i;
-
-	/* buffer sizes are always divisible by period frames */
-	/* Samples are Q1.31 --> Q1.23 and volume is Q1.16 */
-	for (i = 0; i < dev->frames * 8; i += 8) {
-		dest[i] = vol_mult_s32_to_s24(src[i], cd->volume[0]);
-		dest[i + 1] = vol_mult_s32_to_s24(src[i + 1], cd->volume[1]);
-		dest[i + 2] = vol_mult_s32_to_s24(src[i + 2], cd->volume[2]);
-		dest[i + 3] = vol_mult_s32_to_s24(src[i + 3], cd->volume[3]);
-		dest[i + 4] = vol_mult_s32_to_s24(src[i + 4], cd->volume[4]);
-		dest[i + 5] = vol_mult_s32_to_s24(src[i + 5], cd->volume[5]);
-		dest[i + 6] = vol_mult_s32_to_s24(src[i + 6], cd->volume[6]);
-		dest[i + 7] = vol_mult_s32_to_s24(src[i + 7], cd->volume[7]);
-	}
-}
-
-/* copy and scale volume from 16 bit source buffer to 24 bit
- * on 32 bit boundary dest buffer
- */
-static void vol_s24_to_s32_8ch(struct comp_dev *dev, struct comp_buffer *sink,
-			       struct comp_buffer *source)
-{
-	struct comp_data *cd = comp_get_drvdata(dev);
-	int32_t *src = (int32_t *)source->r_ptr;
-	int32_t *dest = (int32_t *)sink->w_ptr;
-	int32_t i;
-
-	/* buffer sizes are always divisible by period frames */
-	/* Samples are Q1.23 --> Q1.31 and volume is Q1.16 */
-	for (i = 0; i < dev->frames * 8; i += 8) {
-		dest[i] = q_multsr_sat_32x32(sign_extend_s24(src[i]),
-					     cd->volume[0],
-					     Q_SHIFT_BITS_64(23, 16, 31));
-		dest[i + 1] = q_multsr_sat_32x32(sign_extend_s24(src[i + 1]),
-						 cd->volume[1],
-						 Q_SHIFT_BITS_64(23, 16, 31));
-		dest[i + 2] = q_multsr_sat_32x32(sign_extend_s24(src[i + 2]),
-						 cd->volume[2],
-						 Q_SHIFT_BITS_64(23, 16, 31));
-		dest[i + 3] = q_multsr_sat_32x32(sign_extend_s24(src[i + 3]),
-						 cd->volume[3],
-						 Q_SHIFT_BITS_64(23, 16, 31));
-		dest[i + 4] = q_multsr_sat_32x32(sign_extend_s24(src[i + 4]),
-						 cd->volume[4],
-						 Q_SHIFT_BITS_64(23, 16, 31));
-		dest[i + 5] = q_multsr_sat_32x32(sign_extend_s24(src[i + 5]),
-						 cd->volume[5],
-						 Q_SHIFT_BITS_64(23, 16, 31));
-		dest[i + 6] = q_multsr_sat_32x32(sign_extend_s24(src[i + 6]),
-						 cd->volume[6],
-						 Q_SHIFT_BITS_64(23, 16, 31));
-		dest[i + 7] = q_multsr_sat_32x32(sign_extend_s24(src[i + 7]),
-						 cd->volume[7],
-						 Q_SHIFT_BITS_64(23, 16, 31));
-	}
-}
-
-/* Copy and scale volume from 24 bit source buffer to 24 bit on 32 bit boundary
- * dest buffer.
- */
-static void vol_s24_to_s24_8ch(struct comp_dev *dev, struct comp_buffer *sink,
-			       struct comp_buffer *source)
-{
-	struct comp_data *cd = comp_get_drvdata(dev);
-	int32_t i, *src = (int32_t *)source->r_ptr;
-	int32_t *dest = (int32_t *)sink->w_ptr;
-
-	/* buffer sizes are always divisible by period frames */
-	/* Samples are Q1.23 --> Q1.23 and volume is Q1.16 */
-	for (i = 0; i < dev->frames * 8; i += 8) {
-		dest[i] = vol_mult_s24_to_s24(src[i], cd->volume[0]);
-		dest[i + 1] = vol_mult_s24_to_s24(src[i + 1], cd->volume[1]);
-		dest[i + 2] = vol_mult_s24_to_s24(src[i + 2], cd->volume[2]);
-		dest[i + 3] = vol_mult_s24_to_s24(src[i + 3], cd->volume[3]);
-		dest[i + 4] = vol_mult_s24_to_s24(src[i + 4], cd->volume[4]);
-		dest[i + 5] = vol_mult_s24_to_s24(src[i + 5], cd->volume[5]);
-		dest[i + 6] = vol_mult_s24_to_s24(src[i + 6], cd->volume[6]);
-		dest[i + 7] = vol_mult_s24_to_s24(src[i + 7], cd->volume[7]);
-	}
-}
-#endif
 
 const struct comp_func_map func_map[] = {
-	{SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S16_LE, 2, vol_s16_to_s16_2ch},
-	{SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S32_LE, 2, vol_s16_to_s32_2ch},
-	{SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE, 2, vol_s32_to_s16_2ch},
-	{SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, 2, vol_s32_to_s32_2ch},
-	{SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S24_4LE, 2, vol_s16_to_s24_2ch},
-	{SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S16_LE, 2, vol_s24_to_s16_2ch},
-	{SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, 2, vol_s32_to_s24_2ch},
-	{SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S32_LE, 2, vol_s24_to_s32_2ch},
-	{SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S24_4LE, 2, vol_s24_to_s24_2ch},
-#if PLATFORM_MAX_CHANNELS >= 4
-	{SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S16_LE, 4, vol_s16_to_s16_4ch},
-	{SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S32_LE, 4, vol_s16_to_s32_4ch},
-	{SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE, 4, vol_s32_to_s16_4ch},
-	{SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, 4, vol_s32_to_s32_4ch},
-	{SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S24_4LE, 4, vol_s16_to_s24_4ch},
-	{SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S16_LE, 4, vol_s24_to_s16_4ch},
-	{SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, 4, vol_s32_to_s24_4ch},
-	{SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S32_LE, 4, vol_s24_to_s32_4ch},
-	{SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S24_4LE, 4, vol_s24_to_s24_4ch},
-#endif
-#if PLATFORM_MAX_CHANNELS >= 8
-	{SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S16_LE, 8, vol_s16_to_s16_8ch},
-	{SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S32_LE, 8, vol_s16_to_s32_8ch},
-	{SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE, 8, vol_s32_to_s16_8ch},
-	{SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, 8, vol_s32_to_s32_8ch},
-	{SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S24_4LE, 8, vol_s16_to_s24_8ch},
-	{SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S16_LE, 8, vol_s24_to_s16_8ch},
-	{SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, 8, vol_s32_to_s24_8ch},
-	{SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S32_LE, 8, vol_s24_to_s32_8ch},
-	{SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S24_4LE, 8, vol_s24_to_s24_8ch},
-#endif
+	{SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S16_LE, vol_s16_to_s16},
+	{SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S32_LE, vol_s16_to_s32},
+	{SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE, vol_s32_to_s16},
+	{SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, vol_s32_to_s32},
+	{SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S24_4LE, vol_s16_to_s24},
+	{SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S16_LE, vol_s24_to_s16},
+	{SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, vol_s32_to_s24},
+	{SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S32_LE, vol_s24_to_s32},
+	{SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S24_4LE, vol_s24_to_s24},
 };
 
-scale_vol vol_get_processing_function(struct comp_dev *dev)
-{
-	struct comp_data *cd = comp_get_drvdata(dev);
-	int i;
-
-	/* map the volume function for source and sink buffers */
-	for (i = 0; i < ARRAY_SIZE(func_map); i++) {
-		if (cd->source_format != func_map[i].source)
-			continue;
-		if (cd->sink_format != func_map[i].sink)
-			continue;
-		if (dev->params.channels != func_map[i].channels)
-			continue;
-
-		return func_map[i].func;
-	}
-
-	return NULL;
-}
+const size_t func_count = ARRAY_SIZE(func_map);
 
 #endif

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -96,6 +96,24 @@ struct comp_buffer {
 			buffer->sink = comp;		\
 	} while (0)					\
 
+#define buffer_read_frag(buffer, idx, size) \
+	buffer_get_frag(buffer, buffer->r_ptr, idx, size)
+
+#define buffer_read_frag_s16(buffer, idx) \
+	buffer_get_frag(buffer, buffer->r_ptr, idx, sizeof(int16_t))
+
+#define buffer_read_frag_s32(buffer, idx) \
+	buffer_get_frag(buffer, buffer->r_ptr, idx, sizeof(int32_t))
+
+#define buffer_write_frag(buffer, idx, size) \
+	buffer_get_frag(buffer, buffer->w_ptr, idx, size)
+
+#define buffer_write_frag_s16(buffer, idx) \
+	buffer_get_frag(buffer, buffer->w_ptr, idx, sizeof(int16_t))
+
+#define buffer_write_frag_s32(buffer, idx) \
+	buffer_get_frag(buffer, buffer->w_ptr, idx, sizeof(int32_t))
+
 typedef void (*cache_buff_op)(struct comp_buffer *);
 
 /* pipeline buffer creation and destruction */
@@ -195,6 +213,18 @@ static inline int buffer_set_size(struct comp_buffer *buffer, uint32_t size)
 	buffer->end_addr = buffer->addr + size;
 	buffer->size = size;
 	return 0;
+}
+
+static inline void *buffer_get_frag(struct comp_buffer *buffer, void *ptr,
+				    uint32_t idx, uint32_t size)
+{
+	void *current = ptr + (idx * size);
+
+	/* check for pointer wrap */
+	if (current >= buffer->end_addr)
+		current = buffer->addr + (current - buffer->end_addr);
+
+	return current;
 }
 
 #endif

--- a/test/cmocka/src/audio/volume/volume_process.c
+++ b/test/cmocka/src/audio/volume/volume_process.c
@@ -296,7 +296,8 @@ static void test_audio_vol(void **state)
 		break;
 	}
 
-	cd->scale_vol(vol_state->dev, vol_state->sink, vol_state->source);
+	cd->scale_vol(vol_state->dev, vol_state->sink, vol_state->source,
+		      vol_state->dev->frames);
 
 	vol_state->verify(vol_state->dev, vol_state->sink, vol_state->source);
 }


### PR DESCRIPTION
Refactors generic and HiFi3 volume processing implementations
to support variable processing sizes. The volume_copy method
will also be refactored in the near future to take advantage
of this feature.