### PR TITLE
cmake: build version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,10 @@ include(scripts/cmake/misc.cmake)
 
 project(SOF C ASM)
 
+# intended to be used where PROJECT_SOURCE_DIR is not set
+# for example in standalone scripts like version.cmake
+set(SOF_ROOT_SOURCE_DIRECTORY "${PROJECT_SOURCE_DIR}")
+
 # most of other options are set on per-arch and per-target basis
 set(CMAKE_ASM_FLAGS -DASSEMBLY)
 
@@ -74,7 +78,6 @@ set(CONFIG_H_PATH ${GENERATED_DIRECTORY}/include/config.h)
 set(VERSION_H_PATH ${GENERATED_DIRECTORY}/include/version.h)
 
 include(scripts/cmake/version.cmake)
-sof_add_version_h_rule(${PROJECT_SOURCE_DIR}/scripts/cmake/version.cmake)
 
 include(scripts/cmake/dist.cmake)
 
@@ -103,7 +106,7 @@ endif()
 
 include(scripts/cmake/kconfig.cmake)
 
-add_dependencies(sof_options genconfig)
+add_dependencies(sof_options genconfig check_version_h)
 target_include_directories(sof_options INTERFACE ${GENERATED_DIRECTORY}/include)
 
 if(BUILD_UNIT_TESTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,9 +37,10 @@ include(scripts/cmake/misc.cmake)
 
 project(SOF C ASM)
 
-# intended to be used where PROJECT_SOURCE_DIR is not set
+# intended to be used where PROJECT_* variables are not set
 # for example in standalone scripts like version.cmake
 set(SOF_ROOT_SOURCE_DIRECTORY "${PROJECT_SOURCE_DIR}")
+set(SOF_ROOT_BINARY_DIRECTORY "${PROJECT_BINARY_DIR}")
 
 # most of other options are set on per-arch and per-target basis
 set(CMAKE_ASM_FLAGS -DASSEMBLY)
@@ -125,6 +126,8 @@ add_executable(sof "")
 target_link_libraries(sof sof_options)
 target_link_libraries(sof sof_ld_scripts)
 target_link_libraries(sof sof_ld_flags)
+
+sof_add_build_counter_rule()
 
 add_subdirectory(src)
 

--- a/scripts/cmake/version-build-counter.cmake
+++ b/scripts/cmake/version-build-counter.cmake
@@ -1,0 +1,37 @@
+# Implements build counter and adds it as post-build action for sof
+
+cmake_minimum_required(VERSION 3.10)
+
+set(VERSION_BUILD_COUNTER_CMAKE_PATH ${CMAKE_CURRENT_LIST_DIR}/version-build-counter.cmake)
+
+set(BUILD_COUNTER_PATH "${SOF_ROOT_BINARY_DIRECTORY}/.build")
+
+if(NOT EXISTS "${BUILD_COUNTER_PATH}")
+	file(WRITE "${BUILD_COUNTER_PATH}" "1")
+endif()
+
+file(READ "${BUILD_COUNTER_PATH}" SOF_BUILD)
+
+if(NOT SOF_BUILD MATCHES "^[0-9]+$")
+	message(WARNING "Invalid SOF_BUILD - setting to 1")
+	set(SOF_BUILD 1)
+endif()
+
+function(sof_add_build_counter_rule)
+	add_custom_command(
+		TARGET sof
+		POST_BUILD
+		COMMAND ${CMAKE_COMMAND}
+			-DSOF_ROOT_BINARY_DIRECTORY=${SOF_ROOT_BINARY_DIRECTORY}
+			-DBUILD_COUNTER_INCREMENT=ON
+			-P ${VERSION_BUILD_COUNTER_CMAKE_PATH}
+		COMMENT "Incrementing build number in ${BUILD_COUNTER_PATH}"
+		VERBATIM
+		USES_TERMINAL
+	)
+endfunction()
+
+if(BUILD_COUNTER_INCREMENT)
+	MATH(EXPR NEXT_SOF_BUILD "(${SOF_BUILD} + 1) % 65536")
+	file(WRITE "${BUILD_COUNTER_PATH}" ${NEXT_SOF_BUILD})
+endif()

--- a/scripts/cmake/version.cmake
+++ b/scripts/cmake/version.cmake
@@ -50,8 +50,8 @@ if(NOT SOF_TAG)
 	set(SOF_TAG 0)
 endif()
 
-# TODO
-set(SOF_BUILD 0)
+# for SOF_BUILD
+include(${CMAKE_CURRENT_LIST_DIR}/version-build-counter.cmake)
 
 function(sof_check_version_h)
 	string(CONCAT header_content
@@ -82,6 +82,7 @@ if("${CMAKE_SCRIPT_MODE_FILE}" STREQUAL "")
 		COMMAND ${CMAKE_COMMAND}
 			-DVERSION_H_PATH=${VERSION_H_PATH}
 			-DSOF_ROOT_SOURCE_DIRECTORY=${SOF_ROOT_SOURCE_DIRECTORY}
+			-DSOF_ROOT_BINARY_DIRECTORY=${SOF_ROOT_BINARY_DIRECTORY}
 			-P ${VERSION_CMAKE_PATH}
 		COMMENT "Checking ${VERSION_H_PATH}"
 		VERBATIM

--- a/src/arch/xtensa/CMakeLists.txt
+++ b/src/arch/xtensa/CMakeLists.txt
@@ -201,6 +201,7 @@ target_link_libraries(sof_ld_flags INTERFACE "-T${PROJECT_BINARY_DIR}/${platform
 include(ExternalProject)
 
 ExternalProject_Add(rimage_ep
+	DEPENDS check_version_h
 	DOWNLOAD_COMMAND ""
 	SOURCE_DIR "${PROJECT_SOURCE_DIR}/rimage"
 	PREFIX "${PROJECT_BINARY_DIR}/rimage_ep"


### PR DESCRIPTION
It adds build counter that is needed for `#define SOF_BUILD`, it's incremented as post-build action of target sof

This was kinda in old buildsystem but didn't work (was starting at 3x value instead of 1, didnt update).
If we still need this feature then we can merge this pull request.