### PR TITLE
scheduler: reimplementation of timer scheduling

### DIFF
--- a/src/audio/buffer.c
+++ b/src/audio/buffer.c
@@ -112,6 +112,10 @@ void comp_update_buffer_produce(struct comp_buffer *buffer, uint32_t bytes)
 	uint32_t head = bytes;
 	uint32_t tail = 0;
 
+	/* do nothing in case of no bytes */
+	if (!bytes)
+		return;
+
 	spin_lock_irq(&buffer->lock, flags);
 
 	/* calculate head and tail size for dcache circular wrap ops */
@@ -174,6 +178,10 @@ void comp_update_buffer_produce(struct comp_buffer *buffer, uint32_t bytes)
 void comp_update_buffer_consume(struct comp_buffer *buffer, uint32_t bytes)
 {
 	uint32_t flags;
+
+	/* do nothing in case of no bytes */
+	if (!bytes)
+		return;
 
 	spin_lock_irq(&buffer->lock, flags);
 

--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -281,7 +281,7 @@ static int dai_playback_params(struct comp_dev *dev)
 	config->src_width = comp_sample_bytes(dev);
 	config->dest_width = comp_sample_bytes(dev);
 	config->cyclic = 1;
-	config->timer_delay = dev->pipeline->ipc_pipe.timer_delay;
+	config->timer = pipeline_is_timer_driven(dev->pipeline);
 	config->dest_dev = dd->dai->plat_data.fifo[0].handshake;
 
 	/* set up local and host DMA elems to reset values */
@@ -332,7 +332,7 @@ static int dai_capture_params(struct comp_dev *dev)
 	/* set up DMA configuration */
 	config->direction = DMA_DIR_DEV_TO_MEM;
 	config->cyclic = 1;
-	config->timer_delay = dev->pipeline->ipc_pipe.timer_delay;
+	config->timer = pipeline_is_timer_driven(dev->pipeline);
 	config->src_dev = dd->dai->plat_data.fifo[1].handshake;
 
 	/* TODO: Make this code platform-specific or move it driver callback */

--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -533,6 +533,7 @@ static int host_params(struct comp_dev *dev)
 	config->src_width = comp_sample_bytes(dev);
 	config->dest_width = comp_sample_bytes(dev);
 	config->cyclic = 0;
+	config->timer = pipeline_is_timer_driven(dev->pipeline);
 
 #if defined CONFIG_DMA_GW
 	dev->params.stream_tag -= 1;

--- a/src/audio/pipeline.c
+++ b/src/audio/pipeline.c
@@ -82,6 +82,8 @@ struct pipeline *pipeline_new(struct sof_ipc_pipe_new *pipe_desc,
 			     pipe_desc->core);
 	spinlock_init(&p->lock);
 	memcpy(&p->ipc_pipe, pipe_desc, sizeof(*pipe_desc));
+	p->scheduling_mode = pipe_desc->timer_delay ?
+		PPL_SCHED_TIMER_IRQ : PPL_SCHED_DMA_IRQ;
 
 	return p;
 }

--- a/src/drivers/intel/cavs/hda-dma.c
+++ b/src/drivers/intel/cavs/hda-dma.c
@@ -1005,6 +1005,83 @@ static int hda_dma_remove(struct dma *dma)
 	return 0;
 }
 
+static int hda_dma_in_data_size(struct hda_chan_data *chan)
+{
+	int32_t read_ptr;
+	int32_t write_ptr;
+	int size;
+
+	if (!(host_dma_reg_read(chan->dma, chan->index, DGCS) & DGCS_BNE))
+		return 0;
+
+	read_ptr = host_dma_reg_read(chan->dma, chan->index, DGBRP);
+	write_ptr = host_dma_reg_read(chan->dma, chan->index, DGBWP);
+
+	size = write_ptr - read_ptr;
+	if (size <= 0)
+		size += chan->buffer_bytes;
+
+	return size;
+}
+
+static int hda_dma_out_data_size(struct hda_chan_data *chan)
+{
+	uint32_t status;
+	int32_t read_ptr;
+	int32_t write_ptr;
+	int size;
+
+	status = host_dma_reg_read(chan->dma, chan->index, DGCS);
+
+	if (status & DGCS_BF)
+		return 0;
+
+	if (!(status & DGCS_BNE))
+		return chan->buffer_bytes;
+
+	read_ptr = host_dma_reg_read(chan->dma, chan->index, DGBRP);
+	write_ptr = host_dma_reg_read(chan->dma, chan->index, DGBWP);
+
+	size = read_ptr - write_ptr;
+	if (size <= 0)
+		size += chan->buffer_bytes;
+
+	return size;
+}
+
+static int hda_dma_data_size(struct dma *dma, int channel)
+{
+	struct dma_pdata *p = dma_get_drvdata(dma);
+	struct hda_chan_data *chan = &p->chan[channel];
+	int data_size = 0;
+	uint32_t flags;
+
+	if (channel >= HDA_DMA_MAX_CHANS) {
+		trace_hddma_error("hda-dmac: %d invalid channel %d",
+				  dma->plat_data.id, channel);
+		return 0;
+	}
+
+	tracev_hddma("hda-dmac: %d channel %d -> get_data_size",
+		     dma->plat_data.id, channel);
+
+	spin_lock_irq(&dma->lock, flags);
+
+	if (chan->status != COMP_STATE_ACTIVE)
+		goto out;
+
+	if (chan->direction == DMA_DIR_HMEM_TO_LMEM ||
+	    chan->direction == DMA_DIR_DEV_TO_MEM)
+		data_size = hda_dma_in_data_size(chan);
+	else
+		data_size = hda_dma_out_data_size(chan);
+
+out:
+	spin_unlock_irq(&dma->lock, flags);
+
+	return data_size;
+}
+
 const struct dma_ops hda_host_dma_ops = {
 	.channel_get	= hda_dma_channel_get,
 	.channel_put	= hda_dma_channel_put,
@@ -1020,6 +1097,7 @@ const struct dma_ops hda_host_dma_ops = {
 	.pm_context_store		= hda_dma_pm_context_store,
 	.probe		= hda_dma_probe,
 	.remove		= hda_dma_remove,
+	.get_data_size	= hda_dma_data_size,
 };
 
 const struct dma_ops hda_link_dma_ops = {
@@ -1037,5 +1115,6 @@ const struct dma_ops hda_link_dma_ops = {
 	.pm_context_store		= hda_dma_pm_context_store,
 	.probe		= hda_dma_probe,
 	.remove		= hda_dma_remove,
+	.get_data_size	= hda_dma_data_size,
 };
 

--- a/src/drivers/intel/cavs/hda-dma.c
+++ b/src/drivers/intel/cavs/hda-dma.c
@@ -155,6 +155,7 @@ struct hda_chan_data {
 	uint32_t desc_count;
 	uint32_t desc_avail;
 	uint32_t direction;
+	bool timer;
 
 	uint32_t period_bytes;
 	uint32_t buffer_bytes;
@@ -841,6 +842,7 @@ static int hda_dma_set_config(struct dma *dma, int channel,
 
 	/* default channel config */
 	p->chan[channel].direction = config->direction;
+	p->chan[channel].timer = config->timer;
 	p->chan[channel].desc_count = config->elem_array.count;
 
 	/* validate - HDA only supports continuous elems of same size  */

--- a/src/include/sof/audio/pipeline.h
+++ b/src/include/sof/audio/pipeline.h
@@ -105,6 +105,7 @@ struct pipeline {
 	/* scheduling */
 	enum ppl_sched_mode scheduling_mode;	/* pipeline scheduling mode */
 	struct task pipe_task;		/* pipeline processing task */
+	struct work pipe_work;		/* pipeline processing work */
 	struct comp_dev *sched_comp;	/* component that drives scheduling in this pipe */
 	struct comp_dev *source_comp;	/* source component for this pipe */
 

--- a/src/include/sof/audio/pipeline.h
+++ b/src/include/sof/audio/pipeline.h
@@ -85,6 +85,12 @@ struct ipc;
 #define PPL_DIR_DOWNSTREAM	0
 #define PPL_DIR_UPSTREAM	1
 
+/* pipeline scheduling modes */
+enum ppl_sched_mode {
+	PPL_SCHED_DMA_IRQ = 0,
+	PPL_SCHED_TIMER_IRQ,
+};
+
 /*
  * Audio pipeline.
  */
@@ -97,6 +103,7 @@ struct pipeline {
 	uint32_t status;		/* pipeline status */
 
 	/* scheduling */
+	enum ppl_sched_mode scheduling_mode;	/* pipeline scheduling mode */
 	struct task pipe_task;		/* pipeline processing task */
 	struct comp_dev *sched_comp;	/* component that drives scheduling in this pipe */
 	struct comp_dev *source_comp;	/* source component for this pipe */
@@ -107,6 +114,12 @@ struct pipeline {
 
 /* static pipeline */
 extern struct pipeline *pipeline_static;
+
+/* checks if pipeline is scheduled with timer */
+static inline bool pipeline_is_timer_driven(struct pipeline *p)
+{
+	return p->scheduling_mode == PPL_SCHED_TIMER_IRQ;
+}
 
 /* pipeline creation and destruction */
 struct pipeline *pipeline_new(struct sof_ipc_pipe_new *pipe_desc,

--- a/src/include/sof/dma.h
+++ b/src/include/sof/dma.h
@@ -121,7 +121,7 @@ struct dma_sg_config {
 	uint32_t src_dev;
 	uint32_t dest_dev;
 	uint32_t cyclic;			/* circular buffer */
-	uint32_t timer_delay;	/* non zero if timer scheduled */
+	bool timer;				/* timer scheduling */
 	struct dma_sg_elem_array elem_array;	/* array of dma_sg elems */
 	bool scatter;
 };

--- a/src/include/sof/dma.h
+++ b/src/include/sof/dma.h
@@ -85,10 +85,13 @@
 /* DMA copy flags */
 #define DMA_COPY_PRELOAD	BIT(0)
 
+/* DMA preload threshold */
+#define DMA_PRELOAD_THRESHOLD(x)	((x) * 2)
+
 /* We will use this macro in cb handler to inform dma that
  * we need to stop the reload for special purpose
  */
-#define DMA_RELOAD_END	0
+#define DMA_RELOAD_END	0xFFFFFFFE
 #define DMA_RELOAD_LLI	0xFFFFFFFF
 
 #define DMA_CHAN_INVALID	0xFFFFFFFF

--- a/src/include/sof/dma.h
+++ b/src/include/sof/dma.h
@@ -160,6 +160,8 @@ struct dma_ops {
 
 	int (*probe)(struct dma *dma);
 	int (*remove)(struct dma *dma);
+
+	int (*get_data_size)(struct dma *dma, int channel);
 };
 
 /* DMA platform data */
@@ -313,6 +315,11 @@ static inline int dma_probe(struct dma *dma)
 static inline int dma_remove(struct dma *dma)
 {
 	return dma->ops->remove(dma);
+}
+
+static inline int dma_get_data_size(struct dma *dma, int channel)
+{
+	return dma->ops->get_data_size(dma, channel);
 }
 
 static inline void dma_sg_init(struct dma_sg_elem_array *ea)

--- a/src/platform/apollolake/include/platform/platform.h
+++ b/src/platform/apollolake/include/platform/platform.h
@@ -150,9 +150,6 @@ struct sof;
 /* minimal SSP port stop delay in cycles */
 #define PLATFORM_SSP_STOP_DELAY	2400
 
-/* timer driven scheduling start offset in microseconds */
-#define PLATFORM_TIMER_START_OFFSET	100
-
 /* Platform defined panic code */
 static inline void platform_panic(uint32_t p)
 {

--- a/src/platform/baytrail/include/platform/platform.h
+++ b/src/platform/baytrail/include/platform/platform.h
@@ -124,9 +124,6 @@ struct sof;
 /* DSP LPE delay in cycles */
 #define PLATFORM_LPE_DELAY 2000
 
-/* timer driven scheduling start offset in microseconds */
-#define PLATFORM_TIMER_START_OFFSET	100
-
 /* Platform defined panic code */
 static inline void platform_panic(uint32_t p)
 {

--- a/src/platform/cannonlake/include/platform/memory.h
+++ b/src/platform/cannonlake/include/platform/memory.h
@@ -266,7 +266,7 @@
 /* text and data share the same HP L2 SRAM on Cannonlake */
 #define SOF_TEXT_START		0xBE040400
 #define SOF_TEXT_BASE		(SOF_TEXT_START)
-#define SOF_TEXT_MIN_SIZE	(0x17000 - 0x400 + 0x2000)
+#define SOF_TEXT_MIN_SIZE	(0x17000 - 0x400 + 0x3000)
 #define SOF_TEXT_SIZE		(SOF_TEXT_MIN_SIZE + SOF_TEXT_DMIC_SIZE \
 				+ SOF_TEXT_VOLUME_SIZE + SOF_TEXT_SRC_SIZE)
 

--- a/src/platform/cannonlake/include/platform/platform.h
+++ b/src/platform/cannonlake/include/platform/platform.h
@@ -151,9 +151,6 @@ struct sof;
 /* minimal SSP port stop delay in cycles */
 #define PLATFORM_SSP_STOP_DELAY	3000
 
-/* timer driven scheduling start offset in microseconds */
-#define PLATFORM_TIMER_START_OFFSET	100
-
 /* Platform defined trace code */
 static inline void platform_panic(uint32_t p)
 {

--- a/src/platform/haswell/include/platform/platform.h
+++ b/src/platform/haswell/include/platform/platform.h
@@ -120,9 +120,6 @@ struct sof;
 /* DSP default delay in cycles */
 #define PLATFORM_DEFAULT_DELAY	12
 
-/* timer driven scheduling start offset in microseconds */
-#define PLATFORM_TIMER_START_OFFSET	100
-
 /* Platform defined panic code */
 static inline void platform_panic(uint32_t p)
 {

--- a/src/platform/icelake/include/platform/platform.h
+++ b/src/platform/icelake/include/platform/platform.h
@@ -151,9 +151,6 @@ struct sof;
 /* minimal SSP port stop delay in cycles */
 #define PLATFORM_SSP_STOP_DELAY	4800
 
-/* timer driven scheduling start offset in microseconds */
-#define PLATFORM_TIMER_START_OFFSET	100
-
 /* Platform defined trace code */
 static inline void platform_panic(uint32_t p)
 {

--- a/src/platform/suecreek/include/platform/platform.h
+++ b/src/platform/suecreek/include/platform/platform.h
@@ -154,9 +154,6 @@ struct sof;
 /* minimal SSP port stop delay in cycles */
 #define PLATFORM_SSP_STOP_DELAY	3000
 
-/* timer driven scheduling start offset in microseconds */
-#define PLATFORM_TIMER_START_OFFSET	100
-
 /* SSI / SPI GPIO bindings */
 #define PLATFORM_SPI_GPIO_ID	0
 #define PLATFORM_SPI_GPIO_IRQ	14

--- a/test/cmocka/src/audio/pipeline/pipeline_mocks.c
+++ b/test/cmocka/src/audio/pipeline/pipeline_mocks.c
@@ -67,6 +67,17 @@ int schedule_task_cancel(struct task *task)
 	return 0;
 }
 
+void work_schedule_default(struct work *w, uint64_t timeout)
+{
+	(void)w;
+	(void)timeout;
+}
+
+void work_cancel_default(struct work *w)
+{
+	(void)w;
+}
+
 void rfree(void *ptr)
 {
 	(void)ptr;


### PR DESCRIPTION
Refactors implementation of timer scheduling in order to get it work correctly:
- Adds scheduling mode to pipeline.
- Moves timer work from dw-dma to pipeline.
- Adds new operation avail_data_size to dw-dma and hd-dma.
- Reimplements dai and host copy methods.
- Reimplements dw-dma and hd-dma copy methods.