### PR TITLE
topology: add topology for cht with Realtek codecs

### DIFF
--- a/tools/topology/CMakeLists.txt
+++ b/tools/topology/CMakeLists.txt
@@ -9,6 +9,7 @@ file(GLOB TPLG_DEPS
 set(MACHINES
 	sof-cht-nocodec
 	sof-cht-max98090
+	sof-cht-rt5682
 	sof-hda-intel-common
 	sof-apl-nocodec
 	sof-byt-nocodec

--- a/tools/topology/sof-cht-rt5682.m4
+++ b/tools/topology/sof-cht-rt5682.m4
@@ -1,0 +1,69 @@
+#
+# Topology for generic CHT board with Realtek codecs
+#
+
+# Include topology builder
+include(`utils.m4')
+include(`dai.m4')
+include(`pipeline.m4')
+include(`ssp.m4')
+
+# Include TLV library
+include(`common/tlv.m4')
+
+# Include Token library
+include(`sof/tokens.m4')
+
+# Include Cherrytrail DSP configuration
+include(`platform/intel/cht.m4')
+
+#
+# Define the pipelines
+#
+# PCM0 <----> Volume <----> SSP2
+#
+
+# Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s24le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	1, 0, 2, s24le,
+	48, 1000, 0, 0)
+
+# Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s24le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
+	2, 0, 2, s24le,
+	48, 1000, 0, 0)
+
+#
+# DAI configuration
+#
+# SSP port 2 is our only pipeline DAI
+#
+
+# playback DAI is SSP2 using 2 periods
+# Buffers use s24le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+	1, SSP, 2, SSP2-Codec,
+	PIPELINE_SOURCE_1, 2, s24le,
+	48, 1000, 0, 0)
+
+# capture DAI is SSP2 using 2 periods
+# Buffers use s24le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-capture.m4,
+	2, SSP, 2, SSP2-Codec,
+	PIPELINE_SINK_2, 2, s24le,
+	48, 1000, 0, 0)
+
+# PCM Low Latency
+PCM_DUPLEX_ADD(SSP2, 0, PIPELINE_PCM_1, PIPELINE_PCM_2)
+
+#
+# BE configurations - overrides config in ACPI if present
+#
+DAI_CONFIG(SSP, 2, 0, SSP2-Codec,
+	   SSP_CONFIG(I2S, SSP_CLOCK(mclk, 19200000, codec_mclk_in),
+		      SSP_CLOCK(bclk, 2400000, codec_slave),
+		      SSP_CLOCK(fsync, 48000, codec_slave),
+		      SSP_TDM(2, 25, 3, 3),
+		      SSP_CONFIG_DATA(SSP, 2, 24)))


### PR DESCRIPTION
This topology is tested on Up board with Realtek rt5682 codec.

Signed-off-by: Bard liao <yung-chuan.liao@linux.intel.com>