### PR TITLE
cmake: meu: add option for openssl path

### DIFF
--- a/src/arch/xtensa/CMakeLists.txt
+++ b/src/arch/xtensa/CMakeLists.txt
@@ -308,11 +308,15 @@ if(MEU_PATH)
 		USES_TERMINAL
 	)
 
+	if(NOT DEFINED MEU_OPENSSL)
+		set(MEU_OPENSSL "/usr/bin/openssl")
+	endif()
+
 	add_custom_target(
 		run_meu
 		COMMAND ${MEU_PATH}/meu -w ./ -s sof-${fw_name}
 			-key ${MEU_PRIVATE_KEY}
-			-stp /usr/bin/openssl
+			-stp ${MEU_OPENSSL}
 			-f ${MEU_PATH}/generic_meu_conf.xml
 			-mnver 0.0.0.0 -o sof-${fw_name}.ri
 		DEPENDS run_rimage


### PR DESCRIPTION
It was previously hardcoded as /usr/bin/openssl. First of all it shouldn't be done like this but I don't want to make chaos with expecting everyone to have proper meu_config.xml files or set some defines, so by default it stays like it was but this PR gives a possibility to overwrite it.

Usage:
Just add something like `-DMEU_OPENSSL=C:/some/path/to/openssl.exe` while running `cmake`

Signed-off-by: Janusz Jankowski <janusz.jankowski@linux.intel.com>