### PR TITLE
Keyword Detection topology updates

### DIFF
--- a/tools/topology/CMakeLists.txt
+++ b/tools/topology/CMakeLists.txt
@@ -11,6 +11,7 @@ set(MACHINES
 	sof-cht-max98090
 	sof-hda-intel-common
 	sof-apl-nocodec
+	sof-apl-keyword-detect
 	sof-byt-nocodec
 	sof-bdw-rt286
 	sof-bdw-rt5640

--- a/tools/topology/m4/detect.m4
+++ b/tools/topology/m4/detect.m4
@@ -1,0 +1,67 @@
+divert(-1)
+
+dnl Define macro for generic detection widget
+
+dnl Detect name)
+define(`N_DETECT', `DETECT'PIPELINE_ID`.'$1)
+
+dnl W_DETECT(name, format, periods_sink, periods_source, detect_type, mixer_list, enum_list)
+define(`W_DETECT',
+`SectionVendorTuples."'N_DETECT($1)`_tuples_w" {'
+`	tokens "sof_comp_tokens"'
+`	tuples."word" {'
+`		SOF_TKN_COMP_PERIOD_SINK_COUNT'		STR($3)
+`		SOF_TKN_COMP_PERIOD_SOURCE_COUNT'	STR($4)
+`	}'
+`}'
+`SectionVendorTuples."'N_DETECT($1)`_detect_tuples_w" {'
+`	tokens "sof_detect_tokens"'
+`	tuples."word" {'
+`		SOF_TKN_DETECT_ITEM1'	STR($4)
+`	}'
+`}'
+`SectionVendorTuples."'N_DETECT($1)`_detect_effect_tuples_str" {'
+`	tokens "sof_effect_tokens"'
+`	tuples."string" {'
+`		SOF_TKN_EFFECT_TYPE'	STR(concat($5, _DETECT))
+`	}'
+`}'
+`SectionVendorTuples."'N_DETECT($1)`_detect_pm_tuples_w" {'
+`	tokens "sof_pm_tokens"'
+`	tuples."word" {'
+`		SOF_TKN_PM_COMP_WAKE_SOURCE	"1"'
+`		SOF_TKN_PM_COMP_ACTIVE_IN_PD	"1"'
+`	}'
+`}'
+`SectionData."'N_DETECT($1)`_data_w" {'
+`	tuples "'N_DETECT($1)`_tuples_w"'
+`	tuples "'N_DETECT($1)`_detect_tuples_w"'
+`	tuples "'N_DETECT($1)`_detect_pm_tuples_w"'
+`}'
+`SectionVendorTuples."'N_DETECT($1)`_tuples_str" {'
+`	tokens "sof_comp_tokens"'
+`	tuples."string" {'
+`		SOF_TKN_COMP_FORMAT'	STR($2)
+`	}'
+`}'
+`SectionData."'N_DETECT($1)`_data_str" {'
+`	tuples "'N_DETECT($1)`_tuples_str"'
+`	tuples "'N_DETECT($1)`_detect_effect_tuples_str"'
+`}'
+`SectionWidget."'N_DETECT($1)`" {'
+`	index "'PIPELINE_ID`"'
+`	type "effect"'
+`	no_pm "true"'
+`	data ['
+`		"'N_DETECT($1)`_data_w"'
+`		"'N_DETECT($1)`_data_str"'
+`	]'
+`	mixer ['
+		$6
+`	]'
+`	enum ['
+`		$7'
+`	]'
+`}')
+
+divert(0)dnl

--- a/tools/topology/m4/enumcontrol.m4
+++ b/tools/topology/m4/enumcontrol.m4
@@ -1,0 +1,46 @@
+divert(-1)
+
+dnl Define macro for mux control
+
+dnl KCONTROL_ENUM_CHANNEL(name, reg, shift)
+define(`KCONTROL_ENUM_CHANNEL',
+`channel.STR($1) {'
+`		reg STR($2)'
+`		shift STR($3)'
+`	}')
+
+dnl C_CONTROLENUM_TEXT(name, list of values)
+define(`C_CONTROLENUM_TEXT',
+`SectionText."$1" {'
+`	values ['
+`		$2'
+`	]'
+`}')
+
+
+dnl CONTROLENUM_OPS(info, comment, get, put)
+define(`CONTROLENUM_OPS',
+`ops."ctl" {'
+`		info STR($1)'
+`		#$2'
+`		get STR($3)'
+`		put STR($4)'
+`	}')
+
+dnl C_CONTROLENUM(name, index, ops, list of KCONTROL_ENUM_CHANNEL, enum text section name)
+define(`C_CONTROLENUM',
+`SectionControlEnum."$1 PIPELINE_ID" {'
+`'
+`	# control belongs to this index group'
+`	index STR($2)'
+`'
+`	$4'
+`	# control uses bespoke driver get/put/info ID'
+`	$3'
+`'
+`	text ['
+`	 STR($5)'
+`	]'
+`}')
+
+divert(0)dnl

--- a/tools/topology/m4/mux.m4
+++ b/tools/topology/m4/mux.m4
@@ -1,0 +1,53 @@
+divert(-1)
+
+dnl Define macro for Mux widget
+
+dnl Mux Name)
+define(`N_MUX', `MUX'$2`.'$1)
+
+dnl Pipe Buffer name in pipeline (pipeline, buffer)
+define(`NPIPELINE_MUX', `MUX'$1`.'$2)
+
+dnl W_MUX(name, format, periods_sink, periods_source, flavour, enum_list, pipeline_id)
+define(`W_MUX',
+`SectionVendorTuples."'N_MUX($1, $7)`_tuples_w" {'
+`	tokens "sof_comp_tokens"'
+`	tuples."word" {'
+`		SOF_TKN_COMP_PERIOD_SINK_COUNT'		STR($3)
+`		SOF_TKN_COMP_PERIOD_SOURCE_COUNT'	STR($4)
+`	}'
+`	tuples."short" {'
+`		SOF_TKN_COMP_FLAVOUR'			STR($5)
+`	}'
+`}'
+`SectionData."'N_MUX($1, $7)`_data_w" {'
+`	tuples "'N_MUX($1, $7)`_tuples_w"'
+`}'
+`SectionVendorTuples."'N_MUX($1, $7)`_tuples_str" {'
+`	tokens "sof_comp_tokens"'
+`	tuples."string" {'
+`		SOF_TKN_COMP_FORMAT'	STR($2)
+`	}'
+`}'
+`SectionData."'N_MUX($1, $7)`_data_str" {'
+`	tuples "'N_MUX($1, $7)`_tuples_str"'
+`}'
+`SectionWidget."'N_MUX($1, $7)`" {'
+`	index STR($7)'
+`	type "mux"'
+`	no_pm "true"'
+`	data ['
+`		"'N_MUX($1, $7)`_data_w"'
+`		"'N_MUX($1, $7)`_data_str"'
+`	]'
+`	enum ['
+`		$6'
+`	]'
+`}')
+
+#flavours of mux
+define(SOF_COMP_MUX_GENERIC, `0')
+define(SOF_COMP_MUX_CH_SEL, `1')
+define(SOF_COMP_MUX_KPB, `2')
+
+divert(0)dnl

--- a/tools/topology/sof-apl-keyword-detect.m4
+++ b/tools/topology/sof-apl-keyword-detect.m4
@@ -1,0 +1,95 @@
+#
+# Topology for ApolloLake with direct attach digital microphones array for
+# keyword detection and triggering use case.
+#
+
+# Include topology builder
+include(`utils.m4')
+include(`dai.m4')
+include(`pipeline.m4')
+
+# Include TLV library
+include(`common/tlv.m4')
+
+# Include Token library
+include(`sof/tokens.m4')
+
+# Include Apollolake DSP configuration
+include(`platform/intel/bxt.m4')
+include(`platform/intel/dmic.m4')
+
+DEBUG_START
+
+#
+# Define the pipelines
+#
+# PCM 0 <-------+- Mux 0 <-- B0 <-- DMIC6 (DMIC01)
+#               |
+# Keyword <-----+
+
+dnl PIPELINE_PCM_ADD(pipeline,
+dnl     pipe id, pcm, max channels, format,
+dnl     frames, deadline, priority, core)
+
+
+# Passthrough capture pipeline 1 on PCM 0 using max 2 channels.
+# Schedule 16 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-mux-capture.m4,
+	1, 0, 2, s32le,
+	16, 1000, 0, 0)
+
+
+# keyword detector pipe
+dnl PIPELINE_ADD(pipeline,
+dnl     pipe id, max channels, format,
+dnl     frames, deadline, priority, core)
+PIPELINE_ADD(sof/pipe-detect.m4, 2, 2, s16le, 16, 1000, 0, 0)
+
+# Connect pipelines together
+SectionGraph."pipe-sof-apl-keyword-detect" {
+        index "0"
+
+        lines [
+		# keyword detect
+                dapm(PIPELINE_SINK_2, PIPELINE_SOURCE_1)
+        ]
+}
+
+#
+# DAIs configuration
+#
+
+dnl DAI_ADD(pipeline,
+dnl     pipe id, dai type, dai_index, dai_be,
+dnl     buffer, periods, format,
+dnl     frames, deadline, priority, core)
+
+
+# capture DAI is DMIC 0 using 1000 periods (64kB buffer for 2 secs of audio)
+# Buffers use s16le format, with 16 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-capture.m4,
+	1, DMIC, 0, NoCodec-6,
+	PIPELINE_SINK_1, 1000, s16le,
+	16, 1000, 0, 0)
+
+dnl PCM_CAPTURE_ADD(name, pipeline, capture)
+PCM_CAPTURE_ADD(DMIC01, 1, PIPELINE_PCM_1)
+
+#
+# BE configurations - overrides config in ACPI if present
+#
+
+#TODO: Change to DMIC 1
+dnl DAI_CONFIG(type, dai_index, link_id, name, ssp_config/dmic_config)
+DAI_CONFIG(DMIC, 0, 6, NoCodec-6,
+           dnl DMIC_CONFIG(driver_version, clk_min, clk_mac, duty_min, duty_max,
+           dnl             sample_rate,
+           dnl             fifo word length, type, dai_index, pdm controller config)
+           DMIC_CONFIG(1, 500000, 4800000, 40, 60, 16000,
+                dnl DMIC_WORD_LENGTH(frame_format)
+                DMIC_WORD_LENGTH(s16le), DMIC, 0,
+                dnl PDM_CONFIG(type, dai_index, num pdm active, pdm tuples list)
+                dnl STEREO_PDM0 is a pre-defined pdm config for stereo capture
+                PDM_CONFIG(DMIC, 0, STEREO_PDM0)))
+
+DEBUG_END

--- a/tools/topology/sof/pipe-detect.m4
+++ b/tools/topology/sof/pipe-detect.m4
@@ -1,0 +1,76 @@
+# Sound Detector
+#
+#  Generic sound detector.
+#
+# Pipeline Endpoints for connection are :-
+#
+#  (Sound Detector <-- Detect Switch) <-- Channel Mux <--- Source Pipeline
+#
+
+# Include topology builder
+include(`utils.m4')
+include(`buffer.m4')
+include(`pga.m4')
+include(`detect.m4')
+include(`mixercontrol.m4')
+include(`enumcontrol.m4')
+include(`pipeline.m4')
+
+#
+# Controls
+#
+
+# Switch type Mixer Control with max value of 1 (Internal to Detector)
+C_CONTROLENUM_TEXT(CHANNELS, LIST(`	        ', "Left", "Right"))
+C_CONTROLMIXER(Detect Switch, PIPELINE_ID,
+	CONTROLMIXER_OPS(volsw, 259 binds the mixer control to switch get/put handlers, 259, 259),
+	CONTROLMIXER_MAX(max 1 indicates switch type control, 1),
+	false,
+	,
+	Channel register and shift for Front Left/Right,
+	LIST(`	', KCONTROL_CHANNEL(FL, 2, 0), KCONTROL_CHANNEL(FR, 2, 1)))
+
+# Channel Selector Mux control with max value of 32 (Internal to Detector)
+# TODO pass in enum options
+C_CONTROLENUM(Channel Mux, PIPELINE_ID,
+	CONTROLENUM_OPS(enum, 257 binds the mixer control to enum get/put handlers, 257, 257),
+	LIST(`	', KCONTROL_ENUM_CHANNEL(FL, 0, 0), KCONTROL_ENUM_CHANNEL(FR, 0, 1)),
+	CHANNELS)
+
+#
+# Components and Buffers
+#
+
+# "Detect 0" has 2 sink period and 0 source periods
+W_DETECT(0, PIPELINE_FORMAT, 2, 0, KEYWORD,
+	LIST(`		', "Detect Switch PIPELINE_ID"))
+
+W_MUX(0, PIPELINE_FORMAT, 2, 2, SOF_COMP_MUX_CH_SEL, LIST(`		', "Channel Mux PIPELINE_ID"), PIPELINE_ID)
+
+# Capture Buffers
+W_BUFFER(0, COMP_BUFFER_SIZE(2,
+	 COMP_SAMPLE_SIZE(PIPELINE_FORMAT), PIPELINE_CHANNELS, SCHEDULE_FRAMES),
+	 PLATFORM_HOST_MEM_CAP)
+# Capture Buffers
+W_BUFFER(1, COMP_BUFFER_SIZE(2,
+	 COMP_SAMPLE_SIZE(PIPELINE_FORMAT), PIPELINE_CHANNELS, SCHEDULE_FRAMES),
+	 PLATFORM_HOST_MEM_CAP)
+
+#FIXME: platform data in pipeline
+W_PIPELINE(N_MUX(0, PIPELINE_ID), SCHEDULE_DEADLINE, SCHEDULE_PRIORITY, SCHEDULE_FRAMES, SCHEDULE_CORE, 0, pipe_media_schedule_plat)
+
+#
+# Pipeline Graph
+#
+# Detect <-- B0 <-- Mux <-- B1
+
+P_GRAPH(pipe-detect-PIPELINE_ID, PIPELINE_ID,
+	LIST(`		',
+	`dapm(N_DETECT(0), N_BUFFER(0))',
+	`dapm(N_BUFFER(0), N_MUX(0, PIPELINE_ID))',
+	`dapm(N_MUX(0, PIPELINE_ID), N_BUFFER(1))'))
+
+#
+# Pipeline Source and Sinks
+#
+indir(`define', concat(`PIPELINE_SINK_', PIPELINE_ID), N_BUFFER(1))

--- a/tools/topology/sof/pipe-mux-capture.m4
+++ b/tools/topology/sof/pipe-mux-capture.m4
@@ -1,0 +1,76 @@
+# Passthrough Capture Pipeline with MUX and PCM
+#
+# Pipeline Endpoints for connection are :-
+#
+#  host PCM_C <-+- Mux 0 <-- B0 <-- source DAI0
+#               |
+#  Others    <--+
+
+# Include topology builder
+include(`utils.m4')
+include(`buffer.m4')
+include(`pcm.m4')
+include(`dai.m4')
+include(`mux.m4')
+include(`enumcontrol.m4')
+include(`pipeline.m4')
+
+#
+# Controls
+#
+# Volume Mixer control with max value of 32
+# TODO pass in enum options
+C_CONTROLENUM_TEXT(OUTPUTS, LIST(`		', STR(N_PCMC(PCM_ID)), STR(Other)))
+C_CONTROLENUM(Capture Mux, PIPELINE_ID,
+	CONTROLENUM_OPS(enum, 257 binds the mixer control to enum get/put handlers, 257, 257),
+	LIST(`	', KCONTROL_ENUM_CHANNEL(FL, 0, 0), KCONTROL_ENUM_CHANNEL(FR, 0, 1)),
+	OUTPUTS)
+
+#
+# Components and Buffers
+#
+
+# Host "Passthrough Capture" PCM
+# with 0 sink and 2 source periods
+W_PCM_CAPTURE(PCM_ID, Mux Capture, 0, 2, 2)
+
+# "Mux" has 2 source and 2 sink periods
+W_MUX(0, PIPELINE_FORMAT, 2, 2, SOF_COMP_MUX_GENERIC, LIST(`		', "Capture Mux PIPELINE_ID"), PIPELINE_ID)
+
+# Capture Buffers
+W_BUFFER(0, COMP_BUFFER_SIZE(2,
+	COMP_SAMPLE_SIZE(PIPELINE_FORMAT), PIPELINE_CHANNELS, SCHEDULE_FRAMES),
+	PLATFORM_HOST_MEM_CAP)
+# Capture Buffers
+W_BUFFER(1, COMP_BUFFER_SIZE(2,
+	COMP_SAMPLE_SIZE(PIPELINE_FORMAT), PIPELINE_CHANNELS, SCHEDULE_FRAMES),
+	PLATFORM_HOST_MEM_CAP)
+
+#
+# Pipeline Graph
+#
+#  host PCM_C <-- B1 <--+- Mux 0 <-- B0 <-- source DAI0
+#                	|
+#            Others  <--
+
+P_GRAPH(pipe-mux-capture-PIPELINE_ID, PIPELINE_ID,
+	LIST(`		',
+	`dapm(Mux Capture PCM_ID, N_PCMC(PCM_ID))',
+	`dapm(N_PCMC(PCM_ID), N_BUFFER(1))',
+	`dapm(N_BUFFER(1), N_MUX(0, PIPELINE_ID))',
+	`dapm(N_MUX(0, PIPELINE_ID), N_BUFFER(0))'))
+
+#
+# Pipeline Source and Sinks
+# TODO add others for MUX (list ??)
+#
+indir(`define', concat(`PIPELINE_SINK_', PIPELINE_ID), N_BUFFER(0))
+indir(`define', concat(`PIPELINE_SOURCE_', PIPELINE_ID), N_MUX(0, PIPELINE_ID))
+indir(`define', concat(`PIPELINE_PCM_', PIPELINE_ID), Mux Capture PCM_ID)
+
+#
+# PCM Configuration
+#
+
+PCM_CAPABILITIES(Mux Capture PCM_ID, `S32_LE,S24_LE,S16_LE', 16000, 16000, 2, PIPELINE_CHANNELS, 2, 16, 192, 16384, 65536, 65536)
+

--- a/tools/topology/sof/tokens.m4
+++ b/tools/topology/sof/tokens.m4
@@ -49,6 +49,7 @@ SectionVendorTokens."sof_comp_tokens" {
 	SOF_TKN_COMP_PERIOD_SOURCE_COUNT	"401"
 	SOF_TKN_COMP_FORMAT			"402"
 	SOF_TKN_COMP_PRELOAD_COUNT		"403"
+	SOF_TKN_COMP_FLAVOUR		"404"
 }
 
 SectionVendorTokens."sof_ssp_tokens" {

--- a/tools/topology/sof/tokens.m4
+++ b/tools/topology/sof/tokens.m4
@@ -89,3 +89,8 @@ SectionVendorTokens."sof_tone_tokens" {
 SectionVendorTokens."sof_effect_tokens" {
 	SOF_TKN_EFFECT_TYPE			"900"
 }
+
+SectionVendorTokens."sof_pm_tokens" {
+	SOF_TKN_PM_COMP_WAKE_SOURCE		"1100"
+	SOF_TKN_PM_COMP_ACTIVE_IN_PD		"1101"
+}


### PR DESCRIPTION
This PR adds the following:

1. Topology support mux and detect components needed for wov topology
2. enum controls supprt
3. keyword detect topology for apl 
4. The mux1.0 component also copies the buffer in the current implementation. This can be optimized in the future to avoid the copy and directly use the component upstream to perform the copy ie we can get rid of BUF1.1 and BUF2.1 possibly.
5. The proposed test tplg is shown in the diagram below
![tplg](https://user-images.githubusercontent.com/7766921/52684382-eb8b7e00-2efa-11e9-800c-d6bf34b29e67.png)
