### PR TITLE
ipc: tplg: de-duplicate effect/process component loading

### DIFF
--- a/src/audio/eq_fir.c
+++ b/src/audio/eq_fir.c
@@ -376,8 +376,8 @@ static struct comp_dev *eq_fir_new(struct sof_ipc_comp *comp)
 {
 	struct comp_dev *dev;
 	struct comp_data *cd;
-	struct sof_ipc_comp_eq_fir *ipc_fir
-		= (struct sof_ipc_comp_eq_fir *)comp;
+	struct sof_ipc_comp_process *ipc_fir
+		= (struct sof_ipc_comp_process *)comp;
 	size_t bs = ipc_fir->size;
 	int i;
 
@@ -398,11 +398,11 @@ static struct comp_dev *eq_fir_new(struct sof_ipc_comp *comp)
 	}
 
 	dev = rzalloc(RZONE_RUNTIME, SOF_MEM_CAPS_RAM,
-		      COMP_SIZE(struct sof_ipc_comp_eq_fir));
+		      COMP_SIZE(struct sof_ipc_comp_process));
 	if (!dev)
 		return NULL;
 
-	memcpy(&dev->comp, comp, sizeof(struct sof_ipc_comp_eq_fir));
+	memcpy(&dev->comp, comp, sizeof(struct sof_ipc_comp_process));
 
 	cd = rzalloc(RZONE_RUNTIME, SOF_MEM_CAPS_RAM, sizeof(*cd));
 	if (!cd) {

--- a/src/audio/eq_iir.c
+++ b/src/audio/eq_iir.c
@@ -481,8 +481,8 @@ static struct comp_dev *eq_iir_new(struct sof_ipc_comp *comp)
 {
 	struct comp_dev *dev;
 	struct comp_data *cd;
-	struct sof_ipc_comp_eq_iir *ipc_iir =
-		(struct sof_ipc_comp_eq_iir *)comp;
+	struct sof_ipc_comp_process *ipc_iir =
+		(struct sof_ipc_comp_process *)comp;
 	size_t bs = ipc_iir->size;
 	int i;
 
@@ -503,11 +503,11 @@ static struct comp_dev *eq_iir_new(struct sof_ipc_comp *comp)
 	}
 
 	dev = rzalloc(RZONE_RUNTIME, SOF_MEM_CAPS_RAM,
-		      COMP_SIZE(struct sof_ipc_comp_eq_iir));
+		      COMP_SIZE(struct sof_ipc_comp_process));
 	if (!dev)
 		return NULL;
 
-	memcpy(&dev->comp, comp, sizeof(struct sof_ipc_comp_eq_iir));
+	memcpy(&dev->comp, comp, sizeof(struct sof_ipc_comp_process));
 
 	cd = rzalloc(RZONE_RUNTIME, SOF_MEM_CAPS_RAM, sizeof(*cd));
 	if (!cd) {

--- a/src/include/uapi/abi.h
+++ b/src/include/uapi/abi.h
@@ -52,7 +52,7 @@
 
 /** \brief SOF ABI version major, minor and patch numbers */
 #define SOF_ABI_MAJOR 3
-#define SOF_ABI_MINOR 1
+#define SOF_ABI_MINOR 2
 #define SOF_ABI_PATCH 0
 
 /** \brief SOF ABI version number. Format within 32bit word is MMmmmppp */

--- a/src/include/uapi/ipc/topology.h
+++ b/src/include/uapi/ipc/topology.h
@@ -210,39 +210,22 @@ struct sof_ipc_comp_tone {
 	int32_t ramp_step;
 } __attribute__((packed));
 
-/** \brief Types of EFFECT */
-enum sof_ipc_effect_type {
-	SOF_EFFECT_NONE = 0,		/**< None */
-	SOF_EFFECT_INTEL_EQFIR,		/**< Intel FIR */
-	SOF_EFFECT_INTEL_EQIIR,		/**< Intel IIR */
+/** \brief Types of processing components */
+enum sof_ipc_process_type {
+	SOF_PROCESS_NONE = 0,		/**< None */
+	SOF_PROCESS_EQFIR,		/**< Intel FIR */
+	SOF_PROCESS_EQIIR,		/**< Intel IIR */
 };
 
-/* general purpose EFFECT configuration */
-struct sof_ipc_comp_effect {
-	struct sof_ipc_hdr hdr;
-	uint32_t type;			/** sof_ipc_effect_type */
-} __attribute__((packed));
-
-/* FIR equalizer component */
-struct sof_ipc_comp_eq_fir {
+/* generic "effect", "codec" or proprietary processing component */
+struct sof_ipc_comp_process {
 	struct sof_ipc_comp comp;
 	struct sof_ipc_comp_config config;
-	uint32_t size;
+	uint32_t size;	/**< size of bespoke data section in bytes */
+	uint32_t type;	/**< sof_ipc_effect_type */
 
 	/* reserved for future use */
-	uint32_t reserved[8];
-
-	unsigned char data[0];
-} __attribute__((packed));
-
-/* IIR equalizer component */
-struct sof_ipc_comp_eq_iir {
-	struct sof_ipc_comp comp;
-	struct sof_ipc_comp_config config;
-	uint32_t size;
-
-	/* reserved for future use */
-	uint32_t reserved[8];
+	uint32_t reserved[7];
 
 	unsigned char data[0];
 } __attribute__((packed));


### PR DESCRIPTION
Merge sof_ipc_comp_eq_fir and sof_comp_eq_iir into sof_ipc_comp_process,
the former two eq structs were the same fields with differentiation
done in the bespoke data section. Same applies to the new generic
sof_ipc_comp_process structure.

Signed-off-by: Liam Girdwood <liam.r.girdwood@linux.intel.com>
Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>