### PR TITLE
ipc: add flavour member to sof_ipc_comp_config

### DIFF
--- a/src/include/uapi/abi.h
+++ b/src/include/uapi/abi.h
@@ -52,7 +52,7 @@
 
 /** \brief SOF ABI version major, minor and patch numbers */
 #define SOF_ABI_MAJOR 3
-#define SOF_ABI_MINOR 1
+#define SOF_ABI_MINOR 2 
 #define SOF_ABI_PATCH 0
 
 /** \brief SOF ABI version number. Format within 32bit word is MMmmmppp */

--- a/src/include/uapi/ipc/topology.h
+++ b/src/include/uapi/ipc/topology.h
@@ -113,9 +113,11 @@ struct sof_ipc_comp_config {
 	uint32_t preload_count;	/**< how many periods to preload */
 	uint32_t frame_fmt;		/**< SOF_IPC_FRAME_ */
 	uint32_t xrun_action;
+	uint16_t flavour;
 
 	/* reserved for future use */
-	uint32_t reserved[2];
+	uint16_t reserved16;
+	uint32_t reserved32;
 } __attribute__((packed));
 
 /* generic host component */


### PR DESCRIPTION
components can come in different flavours. ex: a mux
can be a regular mux or just be a channel selector.
Add a member in struct sof_ipc_comp_config{} to specify
the flavour.

Also update the ABI to indicate the change.

Signed-off-by: Liam Girdwoord <liam.r.girdwood@linux.intel.com>
Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>