### PR TITLE
pipeline: enable copy of connected pipelines

### DIFF
--- a/src/include/sof/audio/pipeline.h
+++ b/src/include/sof/audio/pipeline.h
@@ -108,6 +108,13 @@ struct pipeline {
 /* static pipeline */
 extern struct pipeline *pipeline_static;
 
+/* checks if two pipelines have the same scheduling component */
+static inline bool pipeline_is_same_sched_comp(struct pipeline *current,
+					       struct pipeline *previous)
+{
+	return current->sched_comp == previous->sched_comp;
+}
+
 /* pipeline creation and destruction */
 struct pipeline *pipeline_new(struct sof_ipc_pipe_new *pipe_desc,
 	struct comp_dev *cd);


### PR DESCRIPTION
Enables copy of connected pipelines if the pipelines
were set to have the same scheduling component.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>