### PR TITLE
ABI: Fix version check for COMP_CMD_SET_DATA

### DIFF
--- a/src/audio/eq_fir.c
+++ b/src/audio/eq_fir.c
@@ -525,12 +525,6 @@ static int fir_cmd_set_data(struct comp_dev *dev,
 	int i;
 	int ret = 0;
 
-	/* Check version from ABI header */
-	if (SOF_ABI_VERSION_INCOMPATIBLE(SOF_ABI_VERSION, cdata->data->abi)) {
-		trace_eq_error("fir_cmd_set_data() error: invalid version");
-		return -EINVAL;
-	}
-
 	switch (cdata->cmd) {
 	case SOF_CTRL_CMD_ENUM:
 		trace_eq("fir_cmd_set_data(), SOF_CTRL_CMD_ENUM");

--- a/src/audio/eq_iir.c
+++ b/src/audio/eq_iir.c
@@ -611,12 +611,6 @@ static int iir_cmd_set_data(struct comp_dev *dev,
 	int i;
 	int ret = 0;
 
-	/* Check version from ABI header */
-	if (SOF_ABI_VERSION_INCOMPATIBLE(SOF_ABI_VERSION, cdata->data->abi)) {
-		trace_eq_error("iir_cmd_set_data() error: invalid version");
-		return -EINVAL;
-	}
-
 	switch (cdata->cmd) {
 	case SOF_CTRL_CMD_ENUM:
 		trace_eq("iir_cmd_set_data(), SOF_CTRL_CMD_ENUM");

--- a/src/audio/tone.c
+++ b/src/audio/tone.c
@@ -538,12 +538,6 @@ static int tone_cmd_set_data(struct comp_dev *dev,
 
 	trace_tone("tone_cmd_set_data()");
 
-	/* Check version from ABI header */
-	if (SOF_ABI_VERSION_INCOMPATIBLE(SOF_ABI_VERSION, cdata->data->abi)) {
-		trace_tone_error("tone_cmd_set_data() error: invalid version");
-		return -EINVAL;
-	}
-
 	switch (cdata->cmd) {
 	case SOF_CTRL_CMD_ENUM:
 		trace_tone("tone_cmd_set_data(), "

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -213,7 +213,7 @@ struct comp_driver {
 	struct comp_ops ops;	/**< component operations */
 
 	struct list_item list;	/**< list of component drivers */
-};	
+};
 
 /**
  * Audio component base device "class"
@@ -389,9 +389,9 @@ static inline int comp_cmd(struct comp_dev *dev, int cmd, void *data,
 {
 	struct sof_ipc_ctrl_data *cdata = data;
 
-	if ((cmd == COMP_CMD_SET_DATA)
-		&& ((cdata->data->magic != SOF_ABI_MAGIC)
-		|| (cdata->data->abi != SOF_ABI_VERSION))) {
+	if (cmd == COMP_CMD_SET_DATA &&
+	    (cdata->data->magic != SOF_ABI_MAGIC ||
+	     SOF_ABI_VERSION_INCOMPATIBLE(SOF_ABI_VERSION, cdata->data->abi))) {
 		trace_comp_error("comp_cmd() error: invalid version, "
 				 "data->magic = %u, data->abi = %u",
 				 cdata->data->magic, cdata->data->abi);


### PR DESCRIPTION
An earlier update for ABI major, minor, patch versioning has missed
to update this header that caused the EQ settings to fail with any
version bump.

The ABI version check in components is not needed since it is
done in the comp_cmd() inline function that calls the the component
command handlers.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>