### PR TITLE
arch: move xtos_exc_handler_table to bss

### DIFF
--- a/src/arch/xtensa/smp/xtos/user-vector.S
+++ b/src/arch/xtensa/smp/xtos/user-vector.S
@@ -143,7 +143,7 @@ xtos_exc_handler_table_r:
 	.rept	XCHAL_EXCCAUSE_NUM-40
 	.word	xtos_unhandled_exception	//40-63 (reserved for TIE)
 	.endr
-	.data
+	.section .bss
 	.global	xtos_exc_handler_table
 	.align 4
 xtos_exc_handler_table:


### PR DESCRIPTION
Moves xtos_exc_handler_table to bss for SMP arch.
It's modified at runtime, so shouldn't be kept
in data, which is supposed to be read-only.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>