### PR TITLE
Memory cleanup

### DIFF
--- a/src/arch/xtensa/smp/include/arch/alloc.h
+++ b/src/arch/xtensa/smp/include/arch/alloc.h
@@ -42,6 +42,7 @@
 
 extern struct core_context *core_ctx_ptr[PLATFORM_CORE_COUNT];
 extern struct xtos_core_data *core_data_ptr[PLATFORM_CORE_COUNT];
+extern unsigned int _bss_start, _bss_end;
 
 /**
  * \brief Allocates memory for core specific data.
@@ -68,7 +69,8 @@ static inline void alloc_core_context(int core)
 					   sizeof(core_ctx_ptr));
 
 	/* writeback bss region to share static pointers */
-	dcache_writeback_region((void *)SOF_BSS_DATA_START, SOF_BSS_DATA_SIZE);
+	dcache_writeback_region((void *)&_bss_start, \
+		(unsigned int)&_bss_end - (unsigned int)&_bss_start);
 }
 
 #endif

--- a/src/platform/apollolake/apollolake.x.in
+++ b/src/platform/apollolake/apollolake.x.in
@@ -86,15 +86,9 @@ MEMORY
   vector_double_text :
         org = SOF_MEM_VECBASE + XCHAL_DOUBLEEXC_VECOFS,
         len = SOF_MEM_VECT_TEXT_SIZE
-  sof_text :
-	org = SOF_TEXT_BASE,
-        len = SOF_TEXT_SIZE,
-  sof_data :
-	org = SOF_DATA_START,
-        len = SOF_DATA_SIZE
-  sof_bss_data :
-	org = SOF_BSS_DATA_START,
-        len = SOF_BSS_DATA_SIZE
+  sof_fw :
+        org = SOF_FW_BASE,
+        len = SOF_FW_MAX_SIZE
   system_heap :
         org = HEAP_SYSTEM_0_BASE,
         len = HEAP_SYSTEM_T_SIZE
@@ -156,9 +150,7 @@ PHDRS
   vector_user_text_phdr PT_LOAD;
   vector_double_lit_phdr PT_LOAD;
   vector_double_text_phdr PT_LOAD;
-  sof_text_phdr PT_LOAD;
-  sof_data_phdr PT_LOAD;
-  sof_bss_data_phdr PT_LOAD;
+  sof_fw_phdr PT_LOAD;
   system_heap_phdr PT_LOAD;
   system_runtime_heap_phdr PT_LOAD;
   runtime_heap_phdr PT_LOAD;
@@ -406,9 +398,9 @@ SECTIONS
     *(.gnu.version)
     _text_end = ABSOLUTE(.);
     _etext = .;
-  } >sof_text :sof_text_phdr
+  } >sof_fw :sof_fw_phdr
 
-  .rodata : ALIGN(4)
+  .rodata : ALIGN(4096)
   {
     _rodata_start = ABSOLUTE(.);
     *(.rodata)
@@ -444,7 +436,7 @@ SECTIONS
     LONG(_bss_end)
     _bss_table_end = ABSOLUTE(.);
     _rodata_end = ABSOLUTE(.);
-  } >sof_data :sof_data_phdr
+  } >sof_fw :sof_fw_phdr
 
   .data : ALIGN(4)
   {
@@ -462,7 +454,7 @@ SECTIONS
     *(.gnu.linkonce.s2.*)
     KEEP(*(.jcr))
     _data_end = ABSOLUTE(.);
-  } >sof_data :sof_data_phdr
+  } >sof_fw :sof_fw_phdr
 
   .lit4 : ALIGN(4)
   {
@@ -471,9 +463,14 @@ SECTIONS
     *(.lit4.*)
     *(.gnu.linkonce.lit4.*)
     _lit4_end = ABSOLUTE(.);
-  } >sof_data :sof_data_phdr
+  } >sof_fw :sof_fw_phdr
 
-  .bss (NOLOAD) : ALIGN(8)
+  .fw_ready : ALIGN(4)
+  {
+    KEEP (*(.fw_ready))
+  } >sof_fw :sof_fw_phdr
+
+  .bss (NOLOAD) : ALIGN(4096)
   {
     . = ALIGN (8);
     _bss_start = ABSOLUTE(.);
@@ -492,7 +489,7 @@ SECTIONS
     *(COMMON)
     . = ALIGN (8);
     _bss_end = ABSOLUTE(.);
-  } >sof_bss_data :sof_bss_data_phdr
+  } >sof_fw :sof_fw_phdr
 
   /* stack */
   _end = SOF_STACK_END;
@@ -608,9 +605,4 @@ SECTIONS
   {
     *(*.static_log*)
   } > static_log_entries_seg :static_log_entries_phdr
-
-  .fw_ready : ALIGN(4)
-  {
-    KEEP (*(.fw_ready))
-  } >sof_data :sof_data_phdr
 }

--- a/src/platform/apollolake/base_module.c
+++ b/src/platform/apollolake/base_module.c
@@ -48,7 +48,6 @@ struct sof_man_module_manifest apl_manifest = {
 		},
 		.affinity_mask = 3,
 	},
-	.text_size = SOF_TEXT_SIZE + L2_VECTOR_SIZE,
 };
 
 /* not used, but stops linker complaining */

--- a/src/platform/apollolake/include/platform/memory.h
+++ b/src/platform/apollolake/include/platform/memory.h
@@ -152,9 +152,7 @@
 #define L2_VECTOR_SIZE			0x1000
 
 /* Heap configuration */
-#define HEAP_SYSTEM_0_BASE \
-	(SOF_TEXT_BASE + SOF_TEXT_SIZE +\
-	SOF_DATA_SIZE + SOF_BSS_DATA_SIZE)
+#define HEAP_SYSTEM_0_BASE	(SOF_FW_BASE + SOF_FW_MAX_SIZE)
 #define HEAP_SYSTEM_0_SIZE		0x8000
 
 #define HEAP_SYSTEM_1_BASE	(HEAP_SYSTEM_0_BASE + HEAP_SYSTEM_0_SIZE)
@@ -270,24 +268,6 @@
 #define HP_SRAM_WIN3_BASE	SRAM_TRACE_BASE
 #define HP_SRAM_WIN3_SIZE	SRAM_TRACE_SIZE
 
-#if defined(CONFIG_CAVS_DMIC)
-#define SOF_TEXT_DMIC_SIZE 0x2000
-#else
-#define SOF_TEXT_DMIC_SIZE 0
-#endif
-
-#if defined(CONFIG_COMP_VOLUME)
-#define SOF_TEXT_VOLUME_SIZE 0x1000
-#else
-#define SOF_TEXT_VOLUME_SIZE 0
-#endif
-
-#if defined(CONFIG_COMP_SRC)
-#define SOF_TEXT_SRC_SIZE 0x1000
-#else
-#define SOF_TEXT_SRC_SIZE 0
-#endif
-
 /* Apollolake HP-SRAM config */
 #if defined(CONFIG_APOLLOLAKE) \
 	&& !(defined(CONFIG_KABYLAKE) || defined(CONFIG_SKYLAKE))
@@ -301,11 +281,11 @@
 #define HP_SRAM_VECBASE_RESET	(HP_SRAM_WIN0_BASE + HP_SRAM_WIN0_SIZE)
 #define HP_SRAM_VECBASE_OFFSET	0x0
 
-#define SOF_TEXT_START		(HP_SRAM_VECBASE_RESET + 0x400)
-#define SOF_TEXT_BASE		(SOF_TEXT_START)
-#define SOF_TEXT_MIN_SIZE	(0x19000 - 0x400)
-#define SOF_TEXT_SIZE		(SOF_TEXT_MIN_SIZE + SOF_TEXT_DMIC_SIZE \
-				+ SOF_TEXT_VOLUME_SIZE + SOF_TEXT_SRC_SIZE)
+#define SOF_FW_START		(HP_SRAM_VECBASE_RESET + 0x400)
+#define SOF_FW_BASE		(SOF_FW_START)
+
+/* max size for all var-size sections (text/rodata/bss) */
+#define SOF_FW_MAX_SIZE		(0x41000 - 0x400)
 
 /* Skylake or kabylake HP-SRAM config */
 #elif defined(CONFIG_KABYLAKE) || defined(CONFIG_SKYLAKE)
@@ -321,27 +301,18 @@
 #define HP_SRAM_RESET_TEXT_SIZE	0x400
 #define HP_SRAM_RESET_LIT_SIZE	0x100
 
-#define SOF_TEXT_START		HP_SRAM_VECBASE_RESET
-#define SOF_TEXT_BASE		(SOF_TEXT_START + 0x1000)
-#define SOF_TEXT_MIN_SIZE	0x18000
-#define SOF_TEXT_SIZE		(SOF_TEXT_MIN_SIZE + SOF_TEXT_DMIC_SIZE \
-				+ SOF_TEXT_VOLUME_SIZE + SOF_TEXT_SRC_SIZE)
+#define SOF_FW_START		HP_SRAM_VECBASE_RESET
+#define SOF_FW_BASE		(SOF_FW_START + 0x1000)
+
+/* max size for all var-size sections (text/rodata/bss) */
+#define SOF_FW_MAX_SIZE		0x40000
 
 #else
 #error Platform not specified
 #endif
 
-/* initialized data */
-#define SOF_DATA_START		(SOF_TEXT_BASE + SOF_TEXT_SIZE)
-#if defined CONFIG_CAVS_DMIC
-#define SOF_DATA_SIZE		0x1b000
-#else
-#define SOF_DATA_SIZE		0x19000
-#endif
-
-/* bss data */
-#define SOF_BSS_DATA_START	(SOF_TEXT_BASE + SOF_TEXT_SIZE + SOF_DATA_SIZE)
-#define SOF_BSS_DATA_SIZE	0x9000
+#define SOF_TEXT_START		(SOF_FW_START)
+#define SOF_TEXT_BASE		(SOF_FW_START)
 
 /* Stack configuration */
 #define SOF_STACK_SIZE		ARCH_STACK_SIZE

--- a/src/platform/apollolake/rom.x.in
+++ b/src/platform/apollolake/rom.x.in
@@ -80,9 +80,6 @@ MEMORY
   sof_text :
 	org = ROM_BASE + 0x800,
         len = ROM_SIZE,
-  sof_bss_data :
-	org = SOF_BSS_DATA_START,
-        len = SOF_BSS_DATA_SIZE
   sof_stack :
         org = SOF_STACK_END,
         len = SOF_STACK_BASE - SOF_STACK_END

--- a/src/platform/cannonlake/cannonlake.x.in
+++ b/src/platform/cannonlake/cannonlake.x.in
@@ -77,15 +77,9 @@ MEMORY
   vector_double_text :
         org = SOF_MEM_VECBASE + XCHAL_DOUBLEEXC_VECOFS,
         len = SOF_MEM_VECT_TEXT_SIZE
-  sof_text :
-        org = SOF_TEXT_BASE,
-        len = SOF_TEXT_SIZE,
-  sof_data :
-        org = SOF_DATA_START,
-        len = SOF_DATA_SIZE
-  sof_bss_data :
-        org = SOF_BSS_DATA_START,
-        len = SOF_BSS_DATA_SIZE
+  sof_fw :
+        org = SOF_FW_BASE,
+        len = SOF_FW_MAX_SIZE
   system_heap :
         org = HEAP_SYSTEM_0_BASE,
         len = HEAP_SYSTEM_T_SIZE
@@ -144,9 +138,7 @@ PHDRS
   vector_user_text_phdr PT_LOAD;
   vector_double_lit_phdr PT_LOAD;
   vector_double_text_phdr PT_LOAD;
-  sof_text_phdr PT_LOAD;
-  sof_data_phdr PT_LOAD;
-  sof_bss_data_phdr PT_LOAD;
+  sof_fw_phdr PT_LOAD;
   system_heap_phdr PT_LOAD;
   system_runtime_heap_phdr PT_LOAD;
   runtime_heap_phdr PT_LOAD;
@@ -368,9 +360,9 @@ SECTIONS
     KEEP (*(.ResetHandler.text))
     _text_end = ABSOLUTE(.);
     _etext = .;
-  } >sof_text :sof_text_phdr
+  } >sof_fw :sof_fw_phdr
 
-  .rodata : ALIGN(4)
+  .rodata : ALIGN(4096)
   {
     _rodata_start = ABSOLUTE(.);
     *(.rodata)
@@ -406,7 +398,7 @@ SECTIONS
     LONG(_bss_end)
     _bss_table_end = ABSOLUTE(.);
     _rodata_end = ABSOLUTE(.);
-  } >sof_data :sof_data_phdr
+  } >sof_fw :sof_fw_phdr
 
   .data : ALIGN(4)
   {
@@ -424,7 +416,7 @@ SECTIONS
     *(.gnu.linkonce.s2.*)
     KEEP(*(.jcr))
     _data_end = ABSOLUTE(.);
-  } >sof_data :sof_data_phdr
+  } >sof_fw :sof_fw_phdr
 
   .lit4 : ALIGN(4)
   {
@@ -433,9 +425,14 @@ SECTIONS
     *(.lit4.*)
     *(.gnu.linkonce.lit4.*)
     _lit4_end = ABSOLUTE(.);
-  } >sof_data :sof_data_phdr
+  } >sof_fw :sof_fw_phdr
 
-  .bss (NOLOAD) : ALIGN(8)
+  .fw_ready : ALIGN(4)
+  {
+    KEEP (*(.fw_ready))
+  } >sof_fw :sof_fw_phdr
+
+  .bss (NOLOAD) : ALIGN(4096)
   {
     . = ALIGN (8);
     _bss_start = ABSOLUTE(.);
@@ -454,7 +451,7 @@ SECTIONS
     *(COMMON)
     . = ALIGN (8);
     _bss_end = ABSOLUTE(.);
-  } >sof_bss_data :sof_bss_data_phdr
+  } >sof_fw :sof_fw_phdr
 
   /* stack */
   _end = SOF_STACK_END;
@@ -571,9 +568,4 @@ SECTIONS
   {
     *(*.static_log*)
   } > static_log_entries_seg :static_log_entries_phdr
-
-  .fw_ready : ALIGN(4)
-  {
-    KEEP (*(.fw_ready))
-  } >sof_data :sof_data_phdr
 }

--- a/src/platform/cannonlake/include/platform/memory.h
+++ b/src/platform/cannonlake/include/platform/memory.h
@@ -245,48 +245,20 @@
 #define HEAP_HP_BUFFER_COUNT \
 			(HEAP_HP_BUFFER_SIZE / HEAP_HP_BUFFER_BLOCK_SIZE)
 
-#if defined(CONFIG_CAVS_DMIC)
-#define SOF_TEXT_DMIC_SIZE 0x2000
-#else
-#define SOF_TEXT_DMIC_SIZE 0
-#endif
-
-#if defined(CONFIG_COMP_VOLUME)
-#define SOF_TEXT_VOLUME_SIZE 0x1000
-#else
-#define SOF_TEXT_VOLUME_SIZE 0
-#endif
-
-#if defined(CONFIG_COMP_SRC)
-#define SOF_TEXT_SRC_SIZE 0x1000
-#else
-#define SOF_TEXT_SRC_SIZE 0
-#endif
-
 /* text and data share the same HP L2 SRAM on Cannonlake */
-#define SOF_TEXT_START		0xBE040400
-#define SOF_TEXT_BASE		(SOF_TEXT_START)
-#define SOF_TEXT_MIN_SIZE	(0x17000 - 0x400 + 0x2000)
-#define SOF_TEXT_SIZE		(SOF_TEXT_MIN_SIZE + SOF_TEXT_DMIC_SIZE \
-				+ SOF_TEXT_VOLUME_SIZE + SOF_TEXT_SRC_SIZE)
+#define SOF_FW_START		0xBE040400
+#define SOF_FW_BASE		(SOF_FW_START)
 
-/* initialized data */
-#define SOF_DATA_START		(SOF_TEXT_BASE + SOF_TEXT_SIZE)
-#if defined CONFIG_CAVS_DMIC
-#define SOF_DATA_SIZE		0x1d000
-#else
-#define SOF_DATA_SIZE		0x19000
-#endif
+/* max size for all var-size sections (text/rodata/bss) */
+#define SOF_FW_MAX_SIZE		(0x4A900 - 0x400)
 
-/* bss data */
-#define SOF_BSS_DATA_START	(SOF_TEXT_BASE + SOF_TEXT_SIZE + SOF_DATA_SIZE)
-#define SOF_BSS_DATA_SIZE	0x10900
+#define SOF_TEXT_START		(SOF_FW_START)
+#define SOF_TEXT_BASE		(SOF_FW_START)
 
 /* Heap configuration */
-#define HEAP_SYSTEM_0_BASE		(SOF_TEXT_BASE + SOF_TEXT_SIZE + \
-					SOF_DATA_SIZE + SOF_BSS_DATA_SIZE)
+#define HEAP_SYSTEM_0_BASE	(SOF_FW_BASE + SOF_FW_MAX_SIZE)
 
-#define HEAP_SYSTEM_0_SIZE		0x8000
+#define HEAP_SYSTEM_0_SIZE	0x8000
 
 #define HEAP_SYSTEM_1_BASE	(HEAP_SYSTEM_0_BASE + HEAP_SYSTEM_0_SIZE)
 #define HEAP_SYSTEM_1_SIZE	0x5000

--- a/src/platform/icelake/icelake.x.in
+++ b/src/platform/icelake/icelake.x.in
@@ -77,15 +77,9 @@ MEMORY
   vector_double_text :
         org = SOF_MEM_VECBASE + XCHAL_DOUBLEEXC_VECOFS,
         len = SOF_MEM_VECT_TEXT_SIZE
-  sof_text :
-        org = SOF_TEXT_BASE,
-        len = SOF_TEXT_SIZE,
-  sof_data :
-        org = SOF_DATA_START,
-        len = SOF_DATA_SIZE
-  sof_bss_data :
-        org = SOF_BSS_DATA_START,
-        len = SOF_BSS_DATA_SIZE
+  sof_fw :
+        org = SOF_FW_BASE,
+        len = SOF_FW_MAX_SIZE
   system_heap :
         org = HEAP_SYSTEM_0_BASE,
         len = HEAP_SYSTEM_T_SIZE
@@ -147,9 +141,7 @@ PHDRS
   vector_user_text_phdr PT_LOAD;
   vector_double_lit_phdr PT_LOAD;
   vector_double_text_phdr PT_LOAD;
-  sof_text_phdr PT_LOAD;
-  sof_data_phdr PT_LOAD;
-  sof_bss_data_phdr PT_LOAD;
+  sof_fw_phdr PT_LOAD;
   system_heap_phdr PT_LOAD;
   system_runtime_heap_phdr PT_LOAD;
   runtime_heap_phdr PT_LOAD;
@@ -372,9 +364,9 @@ SECTIONS
     KEEP (*(.ResetHandler.text))
     _text_end = ABSOLUTE(.);
     _etext = .;
-  } >sof_text :sof_text_phdr
+  } >sof_fw :sof_fw_phdr
 
-  .rodata : ALIGN(4)
+  .rodata : ALIGN(4096)
   {
     _rodata_start = ABSOLUTE(.);
     *(.rodata)
@@ -410,7 +402,7 @@ SECTIONS
     LONG(_bss_end)
     _bss_table_end = ABSOLUTE(.);
     _rodata_end = ABSOLUTE(.);
-  } >sof_data :sof_data_phdr
+  } >sof_fw :sof_fw_phdr
 
   .data : ALIGN(4)
   {
@@ -428,7 +420,7 @@ SECTIONS
     *(.gnu.linkonce.s2.*)
     KEEP(*(.jcr))
     _data_end = ABSOLUTE(.);
-  } >sof_data :sof_data_phdr
+  } >sof_fw :sof_fw_phdr
 
   .lit4 : ALIGN(4)
   {
@@ -437,9 +429,14 @@ SECTIONS
     *(.lit4.*)
     *(.gnu.linkonce.lit4.*)
     _lit4_end = ABSOLUTE(.);
-  } >sof_data :sof_data_phdr
+  } >sof_fw :sof_fw_phdr
 
-  .bss (NOLOAD) : ALIGN(8)
+  .fw_ready : ALIGN(4)
+  {
+    KEEP (*(.fw_ready))
+  } >sof_fw :sof_fw_phdr
+
+  .bss (NOLOAD) : ALIGN(4096)
   {
     . = ALIGN (8);
     _bss_start = ABSOLUTE(.);
@@ -458,7 +455,7 @@ SECTIONS
     *(COMMON)
     . = ALIGN (8);
     _bss_end = ABSOLUTE(.);
-  } >sof_bss_data :sof_bss_data_phdr
+  } >sof_fw :sof_fw_phdr
 
   /* stack */
   _end = SOF_STACK_END;
@@ -574,11 +571,6 @@ SECTIONS
   {
     *(*.static_log*)
   } > static_log_entries_seg :static_log_entries_phdr
-
-  .fw_ready : ALIGN(4)
-  {
-    KEEP (*(.fw_ready))
-  } >sof_data :sof_data_phdr
 
   .lpsram(NOLOAD) : ALIGN(8)
   {

--- a/src/platform/icelake/include/platform/memory.h
+++ b/src/platform/icelake/include/platform/memory.h
@@ -244,48 +244,20 @@
 #define HEAP_HP_BUFFER_COUNT \
 			(HEAP_HP_BUFFER_SIZE / HEAP_HP_BUFFER_BLOCK_SIZE)
 
-#if defined(CONFIG_CAVS_DMIC)
-#define SOF_TEXT_DMIC_SIZE 0x2000
-#else
-#define SOF_TEXT_DMIC_SIZE 0
-#endif
-
-#if defined(CONFIG_COMP_VOLUME)
-#define SOF_TEXT_VOLUME_SIZE 0x1000
-#else
-#define SOF_TEXT_VOLUME_SIZE 0
-#endif
-
-#if defined(CONFIG_COMP_SRC)
-#define SOF_TEXT_SRC_SIZE 0x1000
-#else
-#define SOF_TEXT_SRC_SIZE 0
-#endif
-
 /* text and data share the same HP L2 SRAM on Icelake */
-#define SOF_TEXT_START		0xBE040400
-#define SOF_TEXT_BASE		(SOF_TEXT_START)
-#define SOF_TEXT_MIN_SIZE	(0x1B000 - 0x400)
-#define SOF_TEXT_SIZE		(SOF_TEXT_MIN_SIZE + SOF_TEXT_DMIC_SIZE \
-				+ SOF_TEXT_VOLUME_SIZE + SOF_TEXT_SRC_SIZE)
+#define SOF_FW_START		0xBE040400
+#define SOF_FW_BASE		(SOF_FW_START)
 
-/* initialized data */
-#define SOF_DATA_START		(SOF_TEXT_BASE + SOF_TEXT_SIZE)
-#if defined CONFIG_CAVS_DMIC
-#define SOF_DATA_SIZE		0x1b000
-#else
-#define SOF_DATA_SIZE		0x19000
-#endif
+/* max size for all var-size sections (text/rodata/bss) */
+#define SOF_FW_MAX_SIZE		(0x4A900 - 0x400)
 
-/* bss data */
-#define SOF_BSS_DATA_START	(SOF_TEXT_BASE + SOF_TEXT_SIZE + SOF_DATA_SIZE)
-#define SOF_BSS_DATA_SIZE	0x10900
+#define SOF_TEXT_START		(SOF_FW_START)
+#define SOF_TEXT_BASE		(SOF_FW_START)
 
 /* Heap configuration */
-#define HEAP_SYSTEM_0_BASE		(SOF_TEXT_BASE + SOF_TEXT_SIZE + \
-					SOF_DATA_SIZE + SOF_BSS_DATA_SIZE)
+#define HEAP_SYSTEM_0_BASE	(SOF_FW_BASE + SOF_FW_MAX_SIZE)
 
-#define HEAP_SYSTEM_0_SIZE		0x8000
+#define HEAP_SYSTEM_0_SIZE	0x8000
 
 #define HEAP_SYSTEM_1_BASE	(HEAP_SYSTEM_0_BASE + HEAP_SYSTEM_0_SIZE)
 #define HEAP_SYSTEM_1_SIZE	0x5000

--- a/src/platform/icelake/rom.x.in
+++ b/src/platform/icelake/rom.x.in
@@ -80,9 +80,6 @@ MEMORY
   sof_text :
 	org = ROM_BASE + 0x800,
         len = ROM_SIZE,
-  sof_bss_data :
-	org = SOF_BSS_DATA_START,
-        len = SOF_BSS_DATA_SIZE
   sof_stack :
         org = SOF_STACK_END,
         len = SOF_STACK_BASE - SOF_STACK_END


### PR DESCRIPTION
Memory cleanup.
One shared memory block SOF_FW for SOF_TEXT, SOF_DATA and SOF_BSS sections.
Moved fw_ready near to .rodata and .data
Used linker symbols to obtain real BSS size in alloc.h
Removed setting of .text_size for APL manifes