### PR TITLE
timer: BDW: fix DMA trace issue on BDW

### DIFF
--- a/src/drivers/intel/haswell/timer.c
+++ b/src/drivers/intel/haswell/timer.c
@@ -38,7 +38,7 @@
 
 void platform_timer_start(struct timer *timer)
 {
-	arch_timer_enable(timer);
+	//nothing to do on BDW & HSW for cpu timer
 }
 
 void platform_timer_stop(struct timer *timer)


### PR DESCRIPTION
On BDW, DMA trace doesn't update trace log to host.
platform_timer_start function would set up some registers
for HW and make timer ready. On BDW, cpu timer is used to
driver work queue while on other platforms, external timer
is used. we don't need to enable timer interrupt now or it
will trigger unexpect interrupt which would make scheduler
in unknown status. timer_enable function would enable it

It fixes https://github.com/thesofproject/sof/issues/1012