### PR TITLE
KW issues reduced, some base ones like malloc(SYS,...) get_cpu_id() fixed by KW analysis tuning

### DIFF
--- a/scripts/sof_fw.kb
+++ b/scripts/sof_fw.kb
@@ -1,0 +1,10 @@
+# KW configuration file
+
+__panic - NORET
+
+# malloc succeeds for zone = RZONE_SYS (1) or RZONE_SYS|UNCACHED (17)
+_malloc - RET $1 EQ(1) : NE(0)
+_malloc - RET $1 EQ(17) : NE(0)
+
+# core id is used to index arrays, so tell KW the max value
+arch_cpu_get_id - RET 1 : [0,3]

--- a/src/include/sof/debug.h
+++ b/src/include/sof/debug.h
@@ -164,10 +164,10 @@ static inline uint32_t dump_stack(uint32_t p, void *addr, size_t offset,
 				  size_t limit)
 {
 	extern void *_stack_sentry;
-	void *stack_limit = (void *)&_stack_sentry +
+	uintptr_t stack_limit = (uintptr_t)&_stack_sentry +
 		(cpu_get_id() * SOF_STACK_SIZE);
-	void *stack_bottom = stack_limit + SOF_STACK_SIZE - sizeof(void *);
-	void *stack_top = arch_get_stack_ptr() + offset;
+	uintptr_t stack_bottom = stack_limit + SOF_STACK_SIZE - sizeof(void *);
+	uintptr_t stack_top = (uintptr_t)arch_get_stack_ptr() + offset;
 	size_t size = stack_bottom - stack_top;
 
 	/* is stack smashed ? */
@@ -182,7 +182,7 @@ static inline uint32_t dump_stack(uint32_t p, void *addr, size_t offset,
 		size = limit;
 
 	/* copy stack contents and writeback */
-	rmemcpy(addr, stack_top, size - sizeof(void *));
+	rmemcpy(addr, (void*)stack_top, size - sizeof(void *));
 	dcache_writeback_region(addr, size - sizeof(void *));
 	return p;
 }

--- a/src/lib/alloc.c
+++ b/src/lib/alloc.c
@@ -599,6 +599,7 @@ void *_malloc(int zone, uint32_t caps, size_t bytes)
 		break;
 	default:
 		trace_mem_error("rmalloc() error: invalid zone");
+		panic(SOF_IPC_PANIC_MEM); /* logic non recoverable problem */
 		break;
 	}
 


### PR DESCRIPTION
Seems to be a logic, non recoverable error that should fail immediately.

Signed-off-by: Marcin Maka <marcin.maka@linux.intel.com>