### PR TITLE
dma: add get_data_size ops

### DIFF
--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -267,9 +267,21 @@
 /* number of tries to wait for reset */
 #define DW_DMA_CFG_TRIES	10000
 
+/* linked list item address */
+#define DW_DMA_LLI_ADDRESS(lli, dir) \
+	(((dir) == DMA_DIR_MEM_TO_DEV) ? ((lli)->sar) : ((lli)->dar))
+
 struct dma_id {
 	struct dma *dma;
 	uint32_t channel;
+};
+
+/* pointer data for dma buffer */
+struct dma_ptr_data {
+	uint32_t current_ptr;
+	uint32_t start_ptr;
+	uint32_t end_ptr;
+	uint32_t buffer_bytes;
 };
 
 /* data for each DMA channel */
@@ -284,6 +296,9 @@ struct dma_chan_data {
 	struct dma_id id;
 	uint32_t timer_delay;
 	struct work dma_ch_work;
+
+	/* pointer data */
+	struct dma_ptr_data ptr_data;
 
 	/* client callback function */
 	void (*cb)(void *data, uint32_t type, struct dma_sg_elem *next);
@@ -385,6 +400,10 @@ static void dw_dma_channel_put_unlocked(struct dma *dma, int channel)
 	chan->status = COMP_STATE_INIT;
 	chan->cb = NULL;
 	chan->desc_count = 0;
+	chan->ptr_data.current_ptr = 0;
+	chan->ptr_data.start_ptr = 0;
+	chan->ptr_data.end_ptr = 0;
+	chan->ptr_data.buffer_bytes = 0;
 
 	if (chan->timer_delay)
 		work_init(&chan->dma_ch_work, NULL, NULL, 0, 0);
@@ -790,6 +809,8 @@ static int dw_dma_set_config(struct dma *dma, int channel,
 		dw_write(dma, DW_MASK_ERR, INT_UNMASK(channel));
 	}
 
+	chan->ptr_data.buffer_bytes = 0;
+
 	/* fill in lli for the elem in the list */
 	for (i = 0; i < config->elem_array.count; i++) {
 
@@ -951,6 +972,8 @@ static int dw_dma_set_config(struct dma *dma, int channel,
 			& DW_CTLH_BLOCK_TS_MASK;
 #endif
 
+		chan->ptr_data.buffer_bytes += sg_elem->size;
+
 		/* set next descriptor in list */
 		lli_desc->llp = (uint32_t)(lli_desc + 1);
 
@@ -983,6 +1006,14 @@ static int dw_dma_set_config(struct dma *dma, int channel,
 	if (chan->timer_delay)
 		work_init(&chan->dma_ch_work, dw_dma_work,
 			  &chan->id, WORK_HIGH_PRI, WORK_SYNC);
+
+	/* initialize pointers */
+	chan->ptr_data.start_ptr = DW_DMA_LLI_ADDRESS(chan->lli,
+						      chan->direction);
+	chan->ptr_data.end_ptr = chan->ptr_data.start_ptr +
+		chan->ptr_data.buffer_bytes;
+	chan->ptr_data.current_ptr = chan->ptr_data.start_ptr;
+
 out:
 	spin_unlock_irq(&dma->lock, flags);
 	return ret;
@@ -1473,6 +1504,55 @@ static int dw_dma_remove(struct dma *dma)
 	return 0;
 }
 
+static int dw_dma_avail_data_size(struct dma_chan_data *chan)
+{
+	int32_t read_ptr = chan->ptr_data.current_ptr;
+	int32_t write_ptr = dw_read(chan->id.dma, DW_DAR(chan->id.channel));
+	int size;
+
+	size = write_ptr - read_ptr;
+	if (size < 0)
+		size += chan->ptr_data.buffer_bytes;
+
+	return size;
+}
+
+static int dw_dma_free_data_size(struct dma_chan_data *chan)
+{
+	int32_t read_ptr = dw_read(chan->id.dma, DW_SAR(chan->id.channel));
+	int32_t write_ptr = chan->ptr_data.current_ptr;
+	int size;
+
+	size = read_ptr - write_ptr;
+	if (size < 0)
+		size += chan->ptr_data.buffer_bytes;
+
+	return size;
+}
+
+static int dw_dma_get_data_size(struct dma *dma, int channel, uint32_t *avail,
+				uint32_t *free)
+{
+	struct dma_pdata *p = dma_get_drvdata(dma);
+	struct dma_chan_data *chan = &p->chan[channel];
+	uint32_t flags;
+
+	tracev_dwdma("dw-dma: %d channel %d get_data_size",
+		     dma->plat_data.id, channel);
+
+	spin_lock_irq(&dma->lock, flags);
+
+	if (chan->direction == DMA_DIR_HMEM_TO_LMEM ||
+	    chan->direction == DMA_DIR_DEV_TO_MEM)
+		*avail = dw_dma_avail_data_size(chan);
+	else
+		*free = dw_dma_free_data_size(chan);
+
+	spin_unlock_irq(&dma->lock, flags);
+
+	return 0;
+}
+
 const struct dma_ops dw_dma_ops = {
 	.channel_get	= dw_dma_channel_get,
 	.channel_put	= dw_dma_channel_put,
@@ -1487,4 +1567,5 @@ const struct dma_ops dw_dma_ops = {
 	.pm_context_store		= dw_dma_pm_context_store,
 	.probe		= dw_dma_probe,
 	.remove		= dw_dma_remove,
+	.get_data_size	= dw_dma_get_data_size,
 };

--- a/src/include/sof/dma.h
+++ b/src/include/sof/dma.h
@@ -160,6 +160,9 @@ struct dma_ops {
 
 	int (*probe)(struct dma *dma);
 	int (*remove)(struct dma *dma);
+
+	int (*get_data_size)(struct dma *dma, int channel, uint32_t *avail,
+			     uint32_t *free);
 };
 
 /* DMA platform data */
@@ -313,6 +316,12 @@ static inline int dma_probe(struct dma *dma)
 static inline int dma_remove(struct dma *dma)
 {
 	return dma->ops->remove(dma);
+}
+
+static inline int dma_get_data_size(struct dma *dma, int channel,
+				    uint32_t *avail, uint32_t *free)
+{
+	return dma->ops->get_data_size(dma, channel, avail, free);
 }
 
 static inline void dma_sg_init(struct dma_sg_elem_array *ea)


### PR DESCRIPTION
Adds get_data_size operation to DMA.
This operation allows components to retrieve
currently available data from input and output
DMAs.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>