### PR TITLE
cmake: lds headers dependency

### DIFF
--- a/src/arch/xtensa/CMakeLists.txt
+++ b/src/arch/xtensa/CMakeLists.txt
@@ -102,13 +102,17 @@ function(sof_add_ld_script binary_name script_name)
 	get_target_property(incdirs sof_options INTERFACE_INCLUDE_DIRECTORIES)
 
 	set(iflags "")
+	set(glob_predicates "")
 	foreach(d ${incdirs})
 		list(APPEND iflags "-I${d}")
+		list(APPEND glob_predicates "${d}/*.h")
 	endforeach()
+
+	file(GLOB lds_headers ${glob_predicates})
 
 	add_custom_command(OUTPUT ${lds_out}
 		COMMAND ${CMAKE_C_COMPILER} -E -P ${iflags} -o ${lds_out} -x c ${lds_in}
-		DEPENDS ${lds_in} ${LINK_DEPS} genconfig ${CONFIG_H_PATH}
+		DEPENDS ${lds_in} ${LINK_DEPS} genconfig ${CONFIG_H_PATH} ${lds_headers}
 		WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
 		COMMENT "Generating linker script: ${lds_out}"
 		VERBATIM


### PR DESCRIPTION
Linker scripts weren't rebuilt when project .h files changed. This PR fixes that.

Signed-off-by: Janusz Jankowski <janusz.jankowski@linux.intel.com>