### PR TITLE
tools: readme fix for cmake 3.10

### DIFF
--- a/tools/README
+++ b/tools/README
@@ -7,8 +7,9 @@ DSP firmwares for ALSA.
 Building and Installing
 =======================
 
-cmake -Bbuild .
-cd build
+mkdir build_tools
+cd build_tools
+cmake ..
 make
 make install
 


### PR DESCRIPTION
Argument `-B<builddir>` is not supported in minimum version of CMake
required by our project (3.10).

Signed-off-by: Janusz Jankowski <janusz.jankowski@linux.intel.com>