### PR TITLE
Added memcpy_s and memset_s functions

### DIFF
--- a/src/arch/host/include/arch/string.h
+++ b/src/arch/host/include/arch/string.h
@@ -32,7 +32,53 @@
 #ifndef __INCLUDE_ARCH_STRING_SOF__
 #define __INCLUDE_ARCH_STRING_SOF__
 
+#include <errno.h>
+
 #define arch_memcpy(dest, src, size) \
 	memcpy(dest, src, size)
+
+#define arch_bzero(ptr, size) \
+	memset(ptr, 0, size)
+
+
+void *memcpy(void *dest, const void *src, size_t length);
+void *memset(void *dest, int data, size_t count);
+int memset_s(void *dest, size_t dest_size,
+	     int data, size_t count);
+int memcpy_s(void *dest, size_t dest_size,
+	     const void *src, size_t src_size);
+
+static inline int arch_memcpy_s(void *dest, size_t dest_size,
+				const void *src, size_t src_size)
+{
+	if (!dest || !src)
+		return -EINVAL;
+
+	if ((dest + dest_size >= src && dest + dest_size <= src + src_size) ||
+		(src + src_size >= dest && src + src_size <= dest + dest_size))
+		return -EINVAL;
+
+	if (src_size > dest_size)
+		return -EINVAL;
+
+	memcpy(dest, src, src_size);
+
+	return 0;
+}
+
+static inline int arch_memset_s(void *dest, size_t dest_size,
+				int data, size_t count)
+{
+	if (!dest)
+		return -EINVAL;
+
+	if (count > dest_size)
+		return -EINVAL;
+
+	if (!memset(dest, data, count))
+		return -ENOMEM;
+
+	return 0;
+}
 
 #endif

--- a/src/arch/xtensa/include/arch/string.h
+++ b/src/arch/xtensa/include/arch/string.h
@@ -32,9 +32,66 @@
 #ifndef __INCLUDE_ARCH_STRING_SOF__
 #define __INCLUDE_ARCH_STRING_SOF__
 
-void *xthal_memcpy(void *dst, const void *src, size_t len);
+#include <errno.h>
 
 #define arch_memcpy(dest, src, size) \
 	xthal_memcpy(dest, src, size)
+
+#if __XCC__ && !defined(CHECK)
+#define arch_bzero(ptr, size)	\
+	memset_s(ptr, size, 0, size)
+#else
+#define arch_bzero(ptr, size)	\
+	memset(ptr, 0, size)
+#endif
+
+void *memcpy(void *dest, const void *src, size_t length);
+void *memset(void *dest, int data, size_t count);
+void *xthal_memcpy(void *dst, const void *src, size_t len);
+
+int memset_s(void *dest, size_t dest_size,
+	     int data, size_t count);
+int memcpy_s(void *dest, size_t dest_size,
+	     const void *src, size_t src_size);
+void *__vec_memcpy(void *dst, const void *src, size_t len);
+void *__vec_memset(void *dest, int data, size_t src_size);
+
+static inline int arch_memcpy_s(void *dest, size_t dest_size,
+				const void *src, size_t src_size)
+{
+	if (!dest || !src)
+		return -EINVAL;
+
+	if ((dest + dest_size >= src && dest + dest_size <= src + src_size) ||
+		(src + src_size >= dest && src + src_size <= dest + dest_size))
+		return -EINVAL;
+
+	if (src_size > dest_size)
+		return -EINVAL;
+#if __XCC__ && !CONFIG_HOST
+	__vec_memcpy(dest, src, src_size);
+#else
+	memcpy(dest, src, src_size);
+#endif
+	return 0;
+}
+
+static inline int arch_memset_s(void *dest, size_t dest_size,
+				int data, size_t count)
+{
+	if (!dest)
+		return -EINVAL;
+
+	if (count > dest_size)
+		return -EINVAL;
+
+#if __XCC__ && !CONFIG_HOST
+	if (!__vec_memset(dest, data, count))
+		return -ENOMEM;
+#else
+	memset(dest, data, count);
+#endif
+	return 0;
+}
 
 #endif

--- a/src/include/sof/alloc.h
+++ b/src/include/sof/alloc.h
@@ -39,7 +39,6 @@
 #include <platform/memory.h>
 #include <arch/spinlock.h>
 #include <uapi/ipc/topology.h>
-
 struct sof;
 
 /* Heap Memory Zones
@@ -184,8 +183,9 @@ void alloc_trace_buffer_heap(int zone, uint32_t caps, size_t bytes);
 void *rzalloc_core_sys(int core, size_t bytes);
 
 /* utility */
-void bzero(void *s, size_t n);
-void *memset(void *s, int c, size_t n);
+#define bzero(ptr, size) \
+	arch_bzero(ptr, size)
+
 int rstrlen(const char *s);
 int rstrcmp(const char *s1, const char *s2);
 

--- a/src/lib/lib.c
+++ b/src/lib/lib.c
@@ -67,26 +67,7 @@ void *memcpy(void *dest, const void *src, size_t n)
 	return dest;
 }
 
-/* generic bzero - TODO: can be optimsed for ARCH ? */
-void bzero(void *s, size_t n)
-{
-	uint32_t *d32 = s;
-	uint8_t *d8;
-	int i;
-	int d = n >> 2;
-	int r = n % 4;
-
-	/* zero word at a time */
-	for (i = 0; i <	d; i++)
-		d32[i] = 0;
-
-	/* zero remaining bytes */
-	d8 = (uint8_t*) &d32[i];
-	for (i = 0; i <	r; i++)
-		d8[i] = 0;
-}
-
-/* generic memset - TODO: can be optimsed for ARCH ? */
+/* generic memset */
 void *memset(void *s, int c, size_t n)
 {
 	uint8_t *d8 = s;
@@ -99,6 +80,17 @@ void *memset(void *s, int c, size_t n)
 	return s;
 }
 #endif
+
+int memcpy_s(void *dest, size_t dest_size,
+	     const void *src, size_t src_size)
+{
+	return arch_memcpy_s(dest, dest_size, src, src_size);
+}
+
+int memset_s(void *dest, size_t dest_size, int data, size_t count)
+{
+	return arch_memset_s(dest, dest_size, data, count);
+}
 
 /* generic strlen - TODO: can be optimsed for ARCH ? */
 int rstrlen(const char *s)
@@ -130,4 +122,3 @@ int rstrcmp(const char *s1, const char *s2)
 	/* match */
 	return 0;
 }
-


### PR DESCRIPTION
Added mecpy_s which performs checks similar to standard lib and
uses architectural copy mechanic or fallsback to memcopy.
Added memset_s which performs checks similar to standard lib and
uses architectural set mechanic.
Chaged bzero to memset since memset has optimizations for zeroing.

Signed-off-by: Jakub Dabek <jakub.dabek@linux.intel.com>