### PR TITLE
Key phrase detected: async notifications

### DIFF
--- a/src/audio/CMakeLists.txt
+++ b/src/audio/CMakeLists.txt
@@ -16,6 +16,8 @@ if(NOT BUILD_HOST)
 		pipeline_static.c
 		component.c
 		buffer.c
+		kpb.c
+		kp_detector.c
 	)
 	if(CONFIG_COMP_VOLUME)
 		add_local_sources(sof

--- a/src/audio/kp_detector.c
+++ b/src/audio/kp_detector.c
@@ -1,0 +1,28 @@
+#include <sof/audio/kp_detector.h>
+#include <sof/audio/component.h>
+
+void kp_dummy_func(void);
+struct comp_data dummy_cd;
+
+/* copy and process stream data from source to sink buffers */
+static int kp_detector_copy(struct comp_dev *dev)
+{
+	struct comp_data *cd = &dummy_cd;
+
+	/*...*/
+	/* key phrase detected */
+	cd->notify_data.id = NOTIFIER_ID_KEY_PHRASE_DETECTED;
+	cd->notify_data.data_size = sizeof(struct kp_data);
+	cd->notify_data.data = &cd->data;
+	/*...*/
+	/* triger async notification */
+	notifier_event(&cd->notify_data);
+
+	return 0;
+}
+
+void kp_dummy_func(void)
+{
+	kp_detector_copy(NULL);
+}
+

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -1,0 +1,43 @@
+#include <sof/audio/kpb.h>
+#include <sof/audio/component.h>
+
+static struct comp_dev *kpb_new(struct sof_ipc_comp *comp);
+static void kpb_set_draining_params(int message, void *cb_data,
+				    void *event_data);
+void kpb_dummy_func(void);
+struct comp_data dummy_cd;
+struct comp_dev dummy_dev;
+
+static struct comp_dev *kpb_new(struct sof_ipc_comp *comp)
+{
+	struct comp_dev *dev = &dummy_dev;
+	struct comp_data *cd = &dummy_cd;
+
+	/* prepare async notifier for key phrase detection */
+	cd->kpb_notifier.id = NOTIFIER_ID_KEY_PHRASE_DETECTED;
+	cd->kpb_notifier.cb_data = cd;
+	cd->kpb_notifier.cb = kpb_set_draining_params;
+
+	/* register KPB for async notification */
+	notifier_register(&cd->kpb_notifier);
+
+	return dev;
+}
+
+static void kpb_set_draining_params(int message, void *cb_data,
+				    void *event_data)
+{
+	(void)message; /* not used */
+	struct comp_data *cd = (struct comp_data *)cb_data;
+	struct kp_data *data = (struct kp_data *)event_data;
+
+	/* update sink data */
+	cd->data.kp_begin = data->kp_begin;
+	cd->data.kp_end = data->kp_end;
+}
+
+void kpb_dummy_func(void)
+{
+	kpb_new(NULL);
+	kpb_set_draining_params(0, NULL, NULL);
+}

--- a/src/include/sof/audio/kp_common.h
+++ b/src/include/sof/audio/kp_common.h
@@ -1,0 +1,6 @@
+#include <stdint.h>
+
+struct kp_data {
+	uint32_t kp_begin; /**< start sample of key word */
+	uint32_t kp_end;  /**< end sample of key word */
+};

--- a/src/include/sof/audio/kp_detector.h
+++ b/src/include/sof/audio/kp_detector.h
@@ -1,0 +1,8 @@
+#include <sof/audio/kp_common.h>
+#include <sof/notifier.h>
+
+/*! Key word detector  runtime data */
+struct comp_data {
+	struct notify_data notify_data; /**< async notification data */
+	struct kp_data data; /**< start,end sample of key word */
+};

--- a/src/include/sof/audio/kpb.h
+++ b/src/include/sof/audio/kpb.h
@@ -1,0 +1,8 @@
+#include <sof/notifier.h>
+#include <sof/audio/kp_common.h>
+
+/*! Key phrase buffer runtime data */
+struct comp_data {
+	struct notifier kpb_notifier; /**< async notification data */
+	struct kp_data data; /**< start,end sample of key phrase */
+};

--- a/src/include/sof/notifier.h
+++ b/src/include/sof/notifier.h
@@ -37,13 +37,15 @@
 
 struct sof;
 
-/* notifier general IDs */
-#define NOTIFIER_ID_CPU_FREQ	0
-#define NOTIFIER_ID_SSP_FREQ	1
-
 /* notifier target core masks */
 #define NOTIFIER_TARGET_CORE_MASK(x)	(1 << x)
 #define NOTIFIER_TARGET_CORE_ALL_MASK	0xFFFFFFFF
+
+enum notify_id {
+	NOTIFIER_ID_CPU_FREQ = 0,
+	NOTIFIER_ID_SSP_FREQ,
+	NOTIFIER_ID_KEY_PHRASE_DETECTED,
+};
 
 struct notify {
 	spinlock_t lock;	/* notifier lock */
@@ -51,7 +53,7 @@ struct notify {
 };
 
 struct notify_data {
-	uint32_t id;
+	enum notify_id id;
 	uint32_t message;
 	uint32_t target_core_mask;
 	uint32_t data_size;
@@ -59,7 +61,7 @@ struct notify_data {
 };
 
 struct notifier {
-	uint32_t id;
+	enum notify_id id;
 	struct list_item list;
 	void *cb_data;
 	void (*cb)(int message, void *cb_data, void *event_data);


### PR DESCRIPTION
DO NOT MERGE! This is just a proposal of how we can handle async notification between key phrase detector component and KPB.

Key phrase detector component sends async notification to KPB
component using notifier module. KPB registers to specific event
dedicated to key phrase detection. Once such event takes place
detection component calls notifier_event handler which in turn
calls KPB call-back function.

Signed-off-by: Marcin Rajwa <marcin.rajwa@linux.intel.com>