### PR TITLE
topology: remove dapm route from PCM dev to host comp

### DIFF
--- a/tools/topology/sof/pipe-eq-capture.m4
+++ b/tools/topology/sof/pipe-eq-capture.m4
@@ -56,7 +56,6 @@ W_BUFFER(1, COMP_BUFFER_SIZE(2,
 
 P_GRAPH(pipe-pass-capture-PIPELINE_ID, PIPELINE_ID,
 	LIST(`		',
-	`dapm(Highpass Capture PCM_ID, N_PCMC(PCM_ID))',
 	`dapm(N_PCMC(PCM_ID), N_BUFFER(1))',
 	`dapm(N_BUFFER(1), N_EQ_IIR(0))',
         `dapm(N_EQ_IIR(0), N_BUFFER(0))'))

--- a/tools/topology/sof/pipe-eq-fir-volume-playback.m4
+++ b/tools/topology/sof/pipe-eq-fir-volume-playback.m4
@@ -75,7 +75,6 @@ W_BUFFER(2, COMP_BUFFER_SIZE(2,
 
 P_GRAPH(pipe-pass-vol-playback-PIPELINE_ID, PIPELINE_ID,
 	LIST(`		',
-	`dapm(N_PCMP(PCM_ID), Passthrough Playback PCM_ID)',
 	`dapm(N_BUFFER(0), N_PCMP(PCM_ID))',
 	`dapm(N_EQ_FIR(0), N_BUFFER(0))',
 	`dapm(N_BUFFER(1), N_EQ_FIR(0))',

--- a/tools/topology/sof/pipe-eq-iir-volume-playback.m4
+++ b/tools/topology/sof/pipe-eq-iir-volume-playback.m4
@@ -79,7 +79,6 @@ W_BUFFER(2, COMP_BUFFER_SIZE(2,
 
 P_GRAPH(pipe-pass-vol-playback-PIPELINE_ID, PIPELINE_ID,
 	LIST(`		',
-	`dapm(N_PCMP(PCM_ID), Passthrough Playback PCM_ID)',
 	`dapm(N_BUFFER(0), N_PCMP(PCM_ID))',
 	`dapm(N_EQ_IIR(0), N_BUFFER(0))',
 	`dapm(N_BUFFER(1), N_EQ_IIR(0))',

--- a/tools/topology/sof/pipe-eq-volume-playback.m4
+++ b/tools/topology/sof/pipe-eq-volume-playback.m4
@@ -91,7 +91,6 @@ W_BUFFER(3, COMP_BUFFER_SIZE(2,
 
 P_GRAPH(pipe-pass-vol-playback-PIPELINE_ID, PIPELINE_ID,
 	LIST(`		',
-	`dapm(N_PCMP(PCM_ID), Passthrough Playback PCM_ID)',
 	`dapm(N_BUFFER(0), N_PCMP(PCM_ID))',
 	`dapm(N_EQ_IIR(0), N_BUFFER(0))',
 	`dapm(N_BUFFER(1), N_EQ_IIR(0))',

--- a/tools/topology/sof/pipe-low-latency-capture.m4
+++ b/tools/topology/sof/pipe-low-latency-capture.m4
@@ -49,7 +49,6 @@ W_BUFFER(1, COMP_BUFFER_SIZE(2,
 
 P_GRAPH(pipe-ll-capture-PIPELINE_ID, PIPELINE_ID,
 	LIST(`		',
-	`dapm(Low Latency Capture PCM_ID, N_PCMC(PCM_ID))',
 	`dapm(N_PCMC(PCM_ID), N_BUFFER(1))',
 	`dapm(N_BUFFER(1), N_PGA(0))',
 	`dapm(N_PGA(0), N_BUFFER(0))'))

--- a/tools/topology/sof/pipe-low-latency-playback.m4
+++ b/tools/topology/sof/pipe-low-latency-playback.m4
@@ -93,7 +93,6 @@ W_BUFFER(3, COMP_BUFFER_SIZE(2,
 
 P_GRAPH(pipe-ll-playback-PIPELINE_ID, PIPELINE_ID,
 	LIST(`		',
-	`dapm(N_PCMP(PCM_ID), Low Latency Playback PCM_ID)',
 	`dapm(N_BUFFER(0), N_PCMP(PCM_ID))',
 	`dapm(N_PGA(0), N_BUFFER(0))',
 	`dapm(N_BUFFER(1), N_PGA(0))',

--- a/tools/topology/sof/pipe-passthrough-capture.m4
+++ b/tools/topology/sof/pipe-passthrough-capture.m4
@@ -31,7 +31,6 @@ W_BUFFER(0, COMP_BUFFER_SIZE(2,
 
 P_GRAPH(pipe-pass-capture-PIPELINE_ID, PIPELINE_ID,
 	LIST(`		',
-	`dapm(Passthrough Capture PCM_ID, N_PCMC(PCM_ID))',
 	`dapm(N_PCMC(PCM_ID), N_BUFFER(0))'))
 
 #

--- a/tools/topology/sof/pipe-passthrough-playback.m4
+++ b/tools/topology/sof/pipe-passthrough-playback.m4
@@ -31,7 +31,6 @@ W_BUFFER(0, COMP_BUFFER_SIZE(2,
 
 P_GRAPH(pipe-pass-playback-PIPELINE_ID, PIPELINE_ID,
 	LIST(`		',
-	`dapm(N_PCMP(PCM_ID), Passthrough Playback PCM_ID)',
 	`dapm(N_BUFFER(0), N_PCMP(PCM_ID))'))
 
 #

--- a/tools/topology/sof/pipe-pcm-media.m4
+++ b/tools/topology/sof/pipe-pcm-media.m4
@@ -71,7 +71,6 @@ W_BUFFER(2, COMP_BUFFER_SIZE(3,
 
 P_GRAPH(pipe-media-PIPELINE_ID, PIPELINE_ID,
 	LIST(`		',
-	`dapm(N_PCMP(PCM_ID), Media Playback PCM_ID)',
 	`dapm(N_BUFFER(0), N_PCMP(PCM_ID))',
 	`dapm(N_PGA(0), N_BUFFER(0))',
 	`dapm(N_BUFFER(1), N_PGA(0))',

--- a/tools/topology/sof/pipe-src-capture.m4
+++ b/tools/topology/sof/pipe-src-capture.m4
@@ -46,7 +46,6 @@ W_BUFFER(1, COMP_BUFFER_SIZE(4,
 
 P_GRAPH(pipe-pass-src-capture-PIPELINE_ID, PIPELINE_ID,
 	LIST(`		',
-	`dapm(Passthrough Capture PCM_ID, N_PCMC(PCM_ID))',
 	`dapm(N_PCMC(PCM_ID), N_BUFFER(0))',
 	`dapm(N_BUFFER(0), N_SRC(0))',
 	`dapm(N_SRC(0), N_BUFFER(1))'))

--- a/tools/topology/sof/pipe-src-playback.m4
+++ b/tools/topology/sof/pipe-src-playback.m4
@@ -66,7 +66,6 @@ W_BUFFER(2, COMP_BUFFER_SIZE(2,
 
 P_GRAPH(pipe-pass-src-playback-PIPELINE_ID, PIPELINE_ID,
 	LIST(`		',
-	`dapm(N_PCMP(PCM_ID), SRC Playback PCM_ID)',
 	`dapm(N_BUFFER(0), N_PCMP(PCM_ID))',
 	`dapm(N_SRC(0), N_BUFFER(0))',
 	`dapm(N_BUFFER(1), N_SRC(0))',

--- a/tools/topology/sof/pipe-volume-capture.m4
+++ b/tools/topology/sof/pipe-volume-capture.m4
@@ -51,7 +51,6 @@ W_BUFFER(1, COMP_BUFFER_SIZE(2,
 
 P_GRAPH(pipe-pass-vol-capture-PIPELINE_ID, PIPELINE_ID,
 	LIST(`		',
-	`dapm(Passthrough Capture PCM_ID, N_PCMC(PCM_ID))',
 	`dapm(N_PCMC(PCM_ID), N_BUFFER(0))',
 	`dapm(N_BUFFER(0), N_PGA(0))',
 	`dapm(N_PGA(0), N_BUFFER(1))'))

--- a/tools/topology/sof/pipe-volume-playback.m4
+++ b/tools/topology/sof/pipe-volume-playback.m4
@@ -51,7 +51,6 @@ W_BUFFER(1, COMP_BUFFER_SIZE(2,
 
 P_GRAPH(pipe-pass-vol-playback-PIPELINE_ID, PIPELINE_ID,
 	LIST(`		',
-	`dapm(N_PCMP(PCM_ID), Passthrough Playback PCM_ID)',
 	`dapm(N_BUFFER(0), N_PCMP(PCM_ID))',
 	`dapm(N_PGA(0), N_BUFFER(0))',
 	`dapm(N_BUFFER(1), N_PGA(0))'))


### PR DESCRIPTION
This route is automatically created when the host comp is created
during topology loading. So remove it to avoid duplicating
the connection in the dapm graph.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>