### PR TITLE
topology: ssp: add polarity inversion option in SSP_CLOCK

### DIFF
--- a/tools/topology/platform/common/ssp.m4
+++ b/tools/topology/platform/common/ssp.m4
@@ -2,11 +2,12 @@ divert(-1)
 
 dnl SSP related macros
 
-dnl SSP_CLOCK(clock, freq, codec_master)
+dnl SSP_CLOCK(clock, freq, codec_master, polarity)
+dnl polarity is optional
 define(`SSP_CLOCK',
 	$1		STR($3)
-	$1_freq	STR($2))
-
+	$1_freq	STR($2)
+	`ifelse($4, `inverted', `$1_invert	"true"',`')')
 
 dnl SSP_TDM(slots, width, tx_mask, rx_mask)
 define(`SSP_TDM',


### PR DESCRIPTION
alsatplg allows setting inverted bclk and fsync polarities
by setting either bclk_invert or fsync_invert to "true".
This patch adds a default parameter in the SSP_CLOCK m4
macro which allows setting inverted bclk and fsync polarities.

Signed-off-by: Dragos Tarcatu <dragos_tarcatu@mentor.com>