### PR TITLE
sof: Fix compilation error when TRACEE = 0

### DIFF
--- a/src/include/sof/trace.h
+++ b/src/include/sof/trace.h
@@ -385,8 +385,12 @@ _thrown_from_macro_BASE_LOG_in_trace_h
 
 #define	trace_event(...)
 #define	trace_event_atomic(...)
+#define trace_event_with_ids(...)
+#define trace_event_atomic_with_ids(...)
 
 #define trace_error_with_ids(...)
+#define trace_error(...)
+#define trace_error_atomic(...)
 #define trace_error_atomic_with_ids(...)
 
 #define trace_error_value(x)

--- a/src/include/sof/trace.h
+++ b/src/include/sof/trace.h
@@ -294,8 +294,11 @@ void trace_init(struct sof *sof);
 #define trace_error_value(x)		trace_error(0, "value %u", x)
 #define trace_error_value_atomic(...)	trace_error_value(__VA_ARGS__)
 #else
+#define _trace_error_with_ids(...)
 #define trace_error(...)
+#define trace_error_with_ids(...)
 #define trace_error_atomic(...)
+#define trace_error_atomic_with_ids(...)
 #define trace_error_value(x)
 #define trace_error_value_atomic(x)
 #endif

--- a/src/lib/alloc.c
+++ b/src/lib/alloc.c
@@ -797,6 +797,7 @@ void free_heap(int zone)
 	dcache_writeback_region(cpu_heap, sizeof(*cpu_heap));
 }
 
+#if TRACE
 void heap_trace(struct mm_heap *heap, int size)
 {
 	struct block_map *current_map;
@@ -838,6 +839,10 @@ void heap_trace_all(int force)
 	}
 	memmap.heap_trace_updated = 0;
 }
+#else
+void heap_trace_all(int force) { }
+void heap_trace(struct mm_heap *heap, int size) { }
+#endif
 
 /* initialise map */
 void init_heap(struct sof *sof)

--- a/src/lib/dma-trace.c
+++ b/src/lib/dma-trace.c
@@ -409,8 +409,9 @@ static void dtrace_add_event(const char *e, uint32_t length)
 			 * if any dropped entries have appeared and there
 			 * is not any overflow, their amount will be logged
 			 */
+#if TRACEE
 			uint32_t tmp_dropped_entries = dropped_entries;
-
+#endif
 			dropped_entries = 0;
 			/*
 			 * this trace_error invocation causes recursion,

--- a/src/lib/dma-trace.c
+++ b/src/lib/dma-trace.c
@@ -409,7 +409,7 @@ static void dtrace_add_event(const char *e, uint32_t length)
 			 * if any dropped entries have appeared and there
 			 * is not any overflow, their amount will be logged
 			 */
-#if TRACEE
+#if TRACEE && TRACE
 			uint32_t tmp_dropped_entries = dropped_entries;
 #endif
 			dropped_entries = 0;


### PR DESCRIPTION
Add missing macro definitions to fix compilation error.

Reported-by: Daniel Baluta <daniel.baluta@nxp.com>
Signed-off-by: Diana Ungureanu <diana-gabriela.ungureanu@nxp.com>

This fixes https://github.com/thesofproject/sof/issues/1046