### PR TITLE
platform: make IOMUX, SPI, DW_GPIO a Kconfig option

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -30,6 +30,18 @@ config MEM_WND
 	bool
 	default n
 
+config DW_SPI
+	bool
+	default n
+
+config INTEL_IOMUX
+	bool
+	default n
+
+config DW_GPIO
+	bool
+	default n
+
 source "src/Kconfig"
 
 menu "Debug"

--- a/src/drivers/intel/cavs/CMakeLists.txt
+++ b/src/drivers/intel/cavs/CMakeLists.txt
@@ -6,8 +6,12 @@ add_local_sources(sof
 	timer.c
 )
 
+if(CONFIG_INTEL_IOMUX)
+	add_local_sources(sof sue-iomux.c)
+endif()
+
 if(CONFIG_SUECREEK)
-	add_local_sources(sof sue-iomux.c sue-ipc.c)
+	add_local_sources(sof sue-ipc.c)
 else()
 	add_local_sources(sof ipc.c)
 endif()

--- a/src/platform/Kconfig
+++ b/src/platform/Kconfig
@@ -66,6 +66,9 @@ config SUECREEK
 	select IRQ_MAP
 	select TASK_HAVE_PRIORITY_LOW
 	select TASK_HAVE_PRIORITY_MEDIUM
+	select DW_SPI
+	select INTEL_IOMUX
+	select DW_GPIO
 	select CAVS
 	select CAVS_VERSION_2_0
 	help

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -59,6 +59,7 @@
 #include <config.h>
 #include <string.h>
 #include <version.h>
+#include <sof/cavs-version.h>
 
 static const struct sof_ipc_fw_ready ready
 	__attribute__((section(".fw_ready"))) = {
@@ -173,8 +174,7 @@ struct work_queue_timesource platform_generic_queue[] = {
 	.timer_clear	= platform_timer_clear,
 	.timer_get	= platform_timer_get,
 },
-#if defined(CONFIG_CANNONLAKE) || defined(CONFIG_ICELAKE) \
-	|| defined(CONFIG_SUECREEK)
+#if CAVS_VERSION >= CAVS_VERSION_1_8
 {
 	.timer	 = {
 		.id = TIMER3, /* external timer */
@@ -329,14 +329,14 @@ int platform_boot_complete(uint32_t boot_message)
 		sram_window.ext_hdr.hdr.size);
 #endif // defined(CONFIG_MEM_WND)
 
-#if defined(CONFIG_APOLLOLAKE)
+#if CAVS_VERSION == CAVS_VERSION_1_5
 	/* boot now complete so we can relax the CPU */
 	clock_set_freq(CLK_CPU(cpu_get_id()), CLK_DEFAULT_CPU_HZ);
 
 	/* tell host we are ready */
 	ipc_write(IPC_DIPCIE, SRAM_WINDOW_HOST_OFFSET(0) >> 12);
 	ipc_write(IPC_DIPCI, 0x80000000 | SOF_IPC_FW_READY);
-#elif defined(CONFIG_CANNONLAKE) || defined(CONFIG_ICELAKE)
+#else
 	/* tell host we are ready */
 	ipc_write(IPC_DIPCIDD, SRAM_WINDOW_HOST_OFFSET(0) >> 12);
 	ipc_write(IPC_DIPCIDR, 0x80000000 | SOF_IPC_FW_READY);
@@ -380,8 +380,7 @@ static void platform_memory_windows_init(void)
 }
 #endif
 
-#if defined(CONFIG_CANNONLAKE) || defined(CONFIG_ICELAKE) \
-|| defined(CONFIG_SUECREEK)
+#if CAVS_VERSION >= CAVS_VERSION_1_8
 /* init HW  */
 static void platform_init_hw(void)
 {


### PR DESCRIPTION
This commit:
1. Makes IOMUX, SPI and DW_GPIO as a configurable
   Kconfig options.
2. Replace CONFIG_{PLATFORM} defines by CONFIG_CAVS_VERSION
   in cavs/platform.c source file.

Signed-off-by: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>