### PR TITLE
topology: remove unused properties in tokens

### DIFF
--- a/src/audio/pipeline_static.c
+++ b/src/audio/pipeline_static.c
@@ -84,11 +84,9 @@
 #define SPIPE_COMP(cid, ctype, csize) \
 	{.id = cid, .type = ctype, .hdr.size = sizeof(struct csize)}
 #define SPIPE_HOST(scomp, hno_irq, hdmac, hchan, hconfig) \
-	{.comp = scomp, .no_irq = hno_irq, \
-	 .dmac_config = hconfig}
+	{.comp = scomp, .no_irq = hno_irq}
 #define SPIPE_DAI(scomp, ddai_type, ddai_idx, ddmac, dchan, dconfig) \
-	{.comp = scomp, .type = ddai_type, .dai_index = ddai_idx, \
-	 .dmac_config = dconfig}
+	{.comp = scomp, .type = ddai_type, .dai_index = ddai_idx}
 #define SPIPE_VOL(scomp, vmin, vmax) \
 	{.comp = scomp, .min_value = vmin, .max_value = vmax}
 #define SPIPE_MIX(scomp) {.comp = scomp}

--- a/src/include/host/topology.h
+++ b/src/include/host/topology.h
@@ -63,7 +63,9 @@
 #define SOF_TKN_COMP_PERIOD_SINK_COUNT          400
 #define SOF_TKN_COMP_PERIOD_SOURCE_COUNT        401
 #define SOF_TKN_COMP_FORMAT                     402
-#define SOF_TKN_COMP_PRELOAD_COUNT              403
+/* Token retired with ABI 3.2, do not use for new capabilities
+ * #define SOF_TKN_COMP_PRELOAD_COUNT              403
+ */
 
 struct comp_info {
 	char *name;
@@ -172,9 +174,6 @@ static const struct sof_topology_token comp_tokens[] = {
 	{SOF_TKN_COMP_FORMAT,
 		SND_SOC_TPLG_TUPLE_TYPE_STRING, get_token_comp_format,
 		offsetof(struct sof_ipc_comp_config, frame_fmt), 0},
-	{SOF_TKN_COMP_PRELOAD_COUNT,
-		SND_SOC_TPLG_TUPLE_TYPE_WORD, get_token_uint32_t,
-		offsetof(struct sof_ipc_comp_config, preload_count), 0},
 };
 
 int sof_parse_tokens(void *object,

--- a/src/include/uapi/ipc/topology.h
+++ b/src/include/uapi/ipc/topology.h
@@ -111,9 +111,9 @@ struct sof_ipc_buffer {
 struct sof_ipc_comp_config {
 	struct sof_ipc_cmd_hdr hdr;
 	uint32_t periods_sink;	/**< 0 means variable */
-	uint32_t periods_source;	/**< 0 means variable */
-	uint32_t preload_count;	/**< how many periods to preload */
-	uint32_t frame_fmt;		/**< SOF_IPC_FRAME_ */
+	uint32_t periods_source;/**< 0 means variable */
+	uint32_t reserved1;	/**< reserved */
+	uint32_t frame_fmt;	/**< SOF_IPC_FRAME_ */
 	uint32_t xrun_action;
 
 	/* reserved for future use */
@@ -134,9 +134,9 @@ struct sof_ipc_comp_dai {
 	struct sof_ipc_comp comp;
 	struct sof_ipc_comp_config config;
 	uint32_t direction;	/**< SOF_IPC_STREAM_ */
-	uint32_t dai_index; /**< index of this type dai */
+	uint32_t dai_index;	/**< index of this type dai */
 	uint32_t type;		/**< DAI type - SOF_DAI_ */
-	uint32_t dmac_config; /**< DMA engine specific */
+	uint32_t reserved;	/**< reserved */
 } __attribute__((packed));
 
 /* generic mixer component */

--- a/src/include/uapi/user/tokens.h
+++ b/src/include/uapi/user/tokens.h
@@ -54,7 +54,9 @@
 #define SOF_TKN_BUF_CAPS			101
 
 /* DAI */
-#define	SOF_TKN_DAI_DMAC_CONFIG			153
+/* Token retired with ABI 3.2, do not use for new capabilities
+ * #define	SOF_TKN_DAI_DMAC_CONFIG			153
+ */
 #define SOF_TKN_DAI_TYPE			154
 #define SOF_TKN_DAI_INDEX			155
 #define SOF_TKN_DAI_DIRECTION			156
@@ -82,7 +84,9 @@
 #define SOF_TKN_COMP_PERIOD_SINK_COUNT		400
 #define SOF_TKN_COMP_PERIOD_SOURCE_COUNT	401
 #define SOF_TKN_COMP_FORMAT			402
-#define SOF_TKN_COMP_PRELOAD_COUNT		403
+/* Token retired with ABI 3.2, do not use for new capabilities
+ * #define SOF_TKN_COMP_PRELOAD_COUNT		403
+ */
 
 /* SSP */
 #define SOF_TKN_INTEL_SSP_CLKS_CONTROL		500

--- a/tools/topology/m4/dai.m4
+++ b/tools/topology/m4/dai.m4
@@ -9,14 +9,13 @@ define(`N_DAI', DAI_NAME)
 define(`N_DAI_OUT', DAI_NAME`.OUT')
 define(`N_DAI_IN', DAI_NAME`.IN')
 
-dnl W_DAI_OUT(type, index, dai_link, format, periods_sink, periods_source, preload)
+dnl W_DAI_OUT(type, index, dai_link, format, periods_sink, periods_source)
 define(`W_DAI_OUT',
 `SectionVendorTuples."'N_DAI_OUT($2)`_tuples_w_comp" {'
 `	tokens "sof_comp_tokens"'
 `	tuples."word" {'
 `		SOF_TKN_COMP_PERIOD_SINK_COUNT'		STR($5)
 `		SOF_TKN_COMP_PERIOD_SOURCE_COUNT'	STR($6)
-`		SOF_TKN_COMP_PRELOAD_COUNT'		STR($7)
 `	}'
 `}'
 `SectionData."'N_DAI_OUT($2)`_data_w_comp" {'
@@ -63,14 +62,13 @@ define(`W_DAI_OUT',
 `	]'
 `}')
 
-dnl W_DAI_IN(type, index, dai_link, format, periods_sink, periods_source, preload)
+dnl W_DAI_IN(type, index, dai_link, format, periods_sink, periods_source)
 define(`W_DAI_IN',
 `SectionVendorTuples."'N_DAI_IN($2)`_tuples_w_comp" {'
 `	tokens "sof_comp_tokens"'
 `	tuples."word" {'
 `		SOF_TKN_COMP_PERIOD_SINK_COUNT'		STR($5)
 `		SOF_TKN_COMP_PERIOD_SOURCE_COUNT'	STR($6)
-`		SOF_TKN_COMP_PRELOAD_COUNT'		STR($7)
 `	}'
 `}'
 `SectionData."'N_DAI_IN($2)`_data_w_comp" {'

--- a/tools/topology/m4/eq_fir.m4
+++ b/tools/topology/m4/eq_fir.m4
@@ -5,14 +5,13 @@ dnl Define macro for Eq effect widget
 dnl EQ name)
 define(`N_EQ_FIR', `EQFIR'PIPELINE_ID`.'$1)
 
-dnl W_EQ(name, format, periods_sink, periods_source, preload, kcontrols_list)
+dnl W_EQ(name, format, periods_sink, periods_source, kcontrols_list)
 define(`W_EQ_FIR',
 `SectionVendorTuples."'N_EQ_FIR($1)`_tuples_w" {'
 `	tokens "sof_comp_tokens"'
 `	tuples."word" {'
 `		SOF_TKN_COMP_PERIOD_SINK_COUNT'		STR($3)
 `		SOF_TKN_COMP_PERIOD_SOURCE_COUNT'	STR($4)
-`		SOF_TKN_COMP_PRELOAD_COUNT'		STR($5)
 `	}'
 `}'
 `SectionData."'N_EQ_FIR($1)`_data_w" {'
@@ -46,7 +45,7 @@ define(`W_EQ_FIR',
 `		"'N_EQ_FIR($1)`_data_str_type"'
 `	]'
 `	bytes ['
-		$6
+		$5
 `	]'
 `}')
 

--- a/tools/topology/m4/eq_iir.m4
+++ b/tools/topology/m4/eq_iir.m4
@@ -5,14 +5,13 @@ dnl Define macro for Eq effect widget
 dnl EQ name)
 define(`N_EQ_IIR', `EQIIR'PIPELINE_ID`.'$1)
 
-dnl W_EQ(name, format, periods_sink, periods_source, preload, kcontrols_list)
+dnl W_EQ(name, format, periods_sink, periods_source, kcontrols_list)
 define(`W_EQ_IIR',
 `SectionVendorTuples."'N_EQ_IIR($1)`_tuples_w" {'
 `	tokens "sof_comp_tokens"'
 `	tuples."word" {'
 `		SOF_TKN_COMP_PERIOD_SINK_COUNT'		STR($3)
 `		SOF_TKN_COMP_PERIOD_SOURCE_COUNT'	STR($4)
-`		SOF_TKN_COMP_PRELOAD_COUNT'		STR($5)
 `	}'
 `}'
 `SectionData."'N_EQ_IIR($1)`_data_w" {'
@@ -46,7 +45,7 @@ define(`W_EQ_IIR',
 `		"'N_EQ_IIR($1)`_data_str_type"'
 `	]'
 `	bytes ['
-		$6
+		$5
 `	]'
 `}')
 

--- a/tools/topology/m4/mixer.m4
+++ b/tools/topology/m4/mixer.m4
@@ -8,14 +8,13 @@ define(`N_MIXER', `MIXER'PIPELINE_ID`.'$1)
 dnl Pipe Buffer name in pipeline (pipeline, buffer)
 define(`NPIPELINE_MIXER', `MIXER'$1`.'$2)
 
-dnl W_MIXER(name, format, periods_sink, periods_source, preload)
+dnl W_MIXER(name, format, periods_sink, periods_source)
 define(`W_MIXER',
 `SectionVendorTuples."'N_MIXER($1)`_tuples_w" {'
 `	tokens "sof_comp_tokens"'
 `	tuples."word" {'
 `		SOF_TKN_COMP_PERIOD_SINK_COUNT'		STR($3)
 `		SOF_TKN_COMP_PERIOD_SOURCE_COUNT'	STR($4)
-`		SOF_TKN_COMP_PRELOAD_COUNT'		STR($5)
 `	}'
 `}'
 `SectionData."'N_MIXER($1)`_data_w" {'

--- a/tools/topology/m4/pcm.m4
+++ b/tools/topology/m4/pcm.m4
@@ -6,7 +6,7 @@ dnl PCM name)
 define(`N_PCMP', `PCM'$1`P')
 define(`N_PCMC', `PCM'$1`C')
 
-dnl W_PCM_PLAYBACK(pcm, stream, periods_sink, periods_source, preload)
+dnl W_PCM_PLAYBACK(pcm, stream, periods_sink, periods_source)
 dnl  PCM platform configuration
 define(`W_PCM_PLAYBACK',
 `SectionVendorTuples."'N_PCMP($1)`_tuples_w_comp" {'
@@ -14,7 +14,6 @@ define(`W_PCM_PLAYBACK',
 `	tuples."word" {'
 `		SOF_TKN_COMP_PERIOD_SINK_COUNT'		STR($3)
 `		SOF_TKN_COMP_PERIOD_SOURCE_COUNT'	STR($4)
-`		SOF_TKN_COMP_PRELOAD_COUNT'		STR($5)
 `	}'
 `}'
 `SectionData."'N_PCMP($1)`_data_w_comp" {'
@@ -31,14 +30,13 @@ define(`W_PCM_PLAYBACK',
 `}')
 
 
-dnl W_PCM_CAPTURE(pcm, stream, periods_sink, periods_source, preload)
+dnl W_PCM_CAPTURE(pcm, stream, periods_sink, periods_source)
 define(`W_PCM_CAPTURE',
 `SectionVendorTuples."'N_PCMC($1)`_tuples_w_comp" {'
 `	tokens "sof_comp_tokens"'
 `	tuples."word" {'
 `		SOF_TKN_COMP_PERIOD_SINK_COUNT'		STR($3)
 `		SOF_TKN_COMP_PERIOD_SOURCE_COUNT'	STR($4)
-`		SOF_TKN_COMP_PRELOAD_COUNT'		STR($5)
 `	}'
 `}'
 `SectionData."'N_PCMC($1)`_data_w_comp" {'

--- a/tools/topology/m4/pga.m4
+++ b/tools/topology/m4/pga.m4
@@ -5,14 +5,13 @@ dnl Define macro for PGA widget
 dnl PGA name)
 define(`N_PGA', `PGA'PIPELINE_ID`.'$1)
 
-dnl W_PGA(name, format, periods_sink, periods_source, preload, kcontrol0. kcontrol1...etc)
+dnl W_PGA(name, format, periods_sink, periods_source, kcontrol0. kcontrol1...etc)
 define(`W_PGA',
 `SectionVendorTuples."'N_PGA($1)`_tuples_w" {'
 `	tokens "sof_comp_tokens"'
 `	tuples."word" {'
 `		SOF_TKN_COMP_PERIOD_SINK_COUNT'		STR($3)
 `		SOF_TKN_COMP_PERIOD_SOURCE_COUNT'	STR($4)
-`		SOF_TKN_COMP_PRELOAD_COUNT'		STR($5)
 `	}'
 `}'
 `SectionData."'N_PGA($1)`_data_w" {'
@@ -36,7 +35,7 @@ define(`W_PGA',
 `		"'N_PGA($1)`_data_str"'
 `	]'
 `	mixer ['
-		$6
+		$5
 `	]'
 
 `}')

--- a/tools/topology/m4/src.m4
+++ b/tools/topology/m4/src.m4
@@ -5,14 +5,13 @@ dnl Defines the macro for SRC widget
 dnl SRC name)
 define(`N_SRC', `SRC'PIPELINE_ID`.'$1)
 
-dnl W_SRC(name, format, periods_sink, periods_source, data, preload)
+dnl W_SRC(name, format, periods_sink, periods_source, data)
 define(`W_SRC',
 `SectionVendorTuples."'N_SRC($1)`_tuples_w" {'
 `	tokens "sof_comp_tokens"'
 `	tuples."word" {'
 `		SOF_TKN_COMP_PERIOD_SINK_COUNT'		STR($3)
 `		SOF_TKN_COMP_PERIOD_SOURCE_COUNT'	STR($4)
-`		SOF_TKN_COMP_PRELOAD_COUNT'		STR($6)
 `	}'
 `}'
 `SectionData."'N_SRC($1)`_data_w" {'

--- a/tools/topology/m4/tone.m4
+++ b/tools/topology/m4/tone.m4
@@ -5,14 +5,13 @@ dnl Define macro for siggen widget
 dnl Tone name)
 define(`N_TONE', `TONE'PIPELINE_ID`.'$1)
 
-dnl W_TONE(name, format, periods_sink, periods_source, preload, kcontrols_list)
+dnl W_TONE(name, format, periods_sink, periods_source, kcontrols_list)
 define(`W_TONE',
 `SectionVendorTuples."'N_TONE($1)`_tuples_w" {'
 `	tokens "sof_comp_tokens"'
 `	tuples."word" {'
 `		SOF_TKN_COMP_PERIOD_SINK_COUNT'		STR($3)
 `		SOF_TKN_COMP_PERIOD_SOURCE_COUNT'	STR($4)
-`		SOF_TKN_COMP_PRELOAD_COUNT'		STR($5)
 `	}'
 `}'
 `SectionVendorTuples."'N_TONE($1)`_tone_tuples_w" {'
@@ -43,7 +42,7 @@ define(`W_TONE',
 `		"'N_TONE($1)`_data_str"'
 `	]'
 `	mixer ['
-		$6
+		$5
 `	]'
 `}')
 

--- a/tools/topology/sof/pipe-eq-capture.m4
+++ b/tools/topology/sof/pipe-eq-capture.m4
@@ -35,10 +35,10 @@ C_CONTROLBYTES(EQIIR, PIPELINE_ID,
 
 # Host "Highpass Capture" PCM
 # with 0 sink and 2 source periods
-W_PCM_CAPTURE(PCM_ID, Highpass Capture, 0, 2, 2)
+W_PCM_CAPTURE(PCM_ID, Highpass Capture, 0, 2)
 
 # "EQ 0" has 2 sink period and 2 source periods
-W_EQ_IIR(0, PIPELINE_FORMAT, 2, 2, 2, LIST(`		', "EQIIR"))
+W_EQ_IIR(0, PIPELINE_FORMAT, 2, 2, LIST(`		', "EQIIR"))
 
 # Capture Buffers
 W_BUFFER(0, COMP_BUFFER_SIZE(2,

--- a/tools/topology/sof/pipe-eq-fir-volume-playback.m4
+++ b/tools/topology/sof/pipe-eq-fir-volume-playback.m4
@@ -49,13 +49,13 @@ C_CONTROLBYTES(EQFIR, PIPELINE_ID,
 
 # Host "Passthrough Playback" PCM
 # with 2 sink and 0 source periods
-W_PCM_PLAYBACK(PCM_ID, Passthrough Playback, 2, 0, 2)
+W_PCM_PLAYBACK(PCM_ID, Passthrough Playback, 2, 0)
 
 # "Volume" has 2 source and 2 sink periods
-W_PGA(0, PIPELINE_FORMAT, 2, 2, 2, LIST(`		', "PIPELINE_ID Master Playback Volume"))
+W_PGA(0, PIPELINE_FORMAT, 2, 2, LIST(`		', "PIPELINE_ID Master Playback Volume"))
 
 # "EQ 0" has 2 sink period and 2 source periods
-W_EQ_FIR(0, PIPELINE_FORMAT, 2, 2, 2, LIST(`		', "EQFIR"))
+W_EQ_FIR(0, PIPELINE_FORMAT, 2, 2, LIST(`		', "EQFIR"))
 
 # Playback Buffers
 W_BUFFER(0, COMP_BUFFER_SIZE(2,

--- a/tools/topology/sof/pipe-eq-iir-volume-playback.m4
+++ b/tools/topology/sof/pipe-eq-iir-volume-playback.m4
@@ -53,13 +53,13 @@ C_CONTROLBYTES(EQIIR, PIPELINE_ID,
 
 # Host "Passthrough Playback" PCM
 # with 2 sink and 0 source periods
-W_PCM_PLAYBACK(PCM_ID, Passthrough Playback, 2, 0, 2)
+W_PCM_PLAYBACK(PCM_ID, Passthrough Playback, 2, 0)
 
 # "Volume" has 2 source and 2 sink periods
-W_PGA(0, PIPELINE_FORMAT, 2, 2, 2, LIST(`		', "PIPELINE_ID Master Playback Volume"))
+W_PGA(0, PIPELINE_FORMAT, 2, 2, LIST(`		', "PIPELINE_ID Master Playback Volume"))
 
 # "EQ 0" has 2 sink period and 2 source periods
-W_EQ_IIR(0, PIPELINE_FORMAT, 2, 2, 2, LIST(`		', "EQIIR"))
+W_EQ_IIR(0, PIPELINE_FORMAT, 2, 2, LIST(`		', "EQIIR"))
 
 # Playback Buffers
 W_BUFFER(0, COMP_BUFFER_SIZE(2,

--- a/tools/topology/sof/pipe-eq-volume-playback.m4
+++ b/tools/topology/sof/pipe-eq-volume-playback.m4
@@ -59,16 +59,16 @@ C_CONTROLBYTES(EQFIR, PIPELINE_ID,
 
 # Host "Passthrough Playback" PCM
 # with 2 sink and 0 source periods
-W_PCM_PLAYBACK(PCM_ID, Passthrough Playback, 2, 0, 2)
+W_PCM_PLAYBACK(PCM_ID, Passthrough Playback, 2, 0)
 
 # "Volume" has 2 source and 2 sink periods
-W_PGA(0, PIPELINE_FORMAT, 2, 2, 2, LIST(`		', "PIPELINE_ID Master Playback Volume"))
+W_PGA(0, PIPELINE_FORMAT, 2, 2, LIST(`		', "PIPELINE_ID Master Playback Volume"))
 
 # "EQ 0" has 2 sink period and 2 source periods
-W_EQ_IIR(0, PIPELINE_FORMAT, 2, 2, 2, LIST(`		', "EQIIR"))
+W_EQ_IIR(0, PIPELINE_FORMAT, 2, 2, LIST(`		', "EQIIR"))
 
 # "EQ 0" has 2 sink period and 2 source periods
-W_EQ_FIR(0, PIPELINE_FORMAT, 2, 2, 2, LIST(`		', "EQFIR"))
+W_EQ_FIR(0, PIPELINE_FORMAT, 2, 2, LIST(`		', "EQFIR"))
 
 # Playback Buffers
 W_BUFFER(0, COMP_BUFFER_SIZE(2,

--- a/tools/topology/sof/pipe-low-latency-capture.m4
+++ b/tools/topology/sof/pipe-low-latency-capture.m4
@@ -29,10 +29,10 @@ C_CONTROLMIXER(PCM PCM_ID Capture Volume, PIPELINE_ID,
 
 # Host "Low Latency Capture" PCM
 # with 0 sink and 2 source periods
-W_PCM_CAPTURE(PCM_ID, Low Latency Capture, 0, 2, 0)
+W_PCM_CAPTURE(PCM_ID, Low Latency Capture, 0, 2)
 
 # "Capture Volume" has 2 sink and source periods for host and DAI ping-pong
-W_PGA(0, PIPELINE_FORMAT, 2, 2, 0, LIST(`		', "PIPELINE_ID PCM PCM_ID Capture Volume"))
+W_PGA(0, PIPELINE_FORMAT, 2, 2, LIST(`		', "PIPELINE_ID PCM PCM_ID Capture Volume"))
 
 # Capture Buffers
 W_BUFFER(0, COMP_BUFFER_SIZE(2,

--- a/tools/topology/sof/pipe-low-latency-playback.m4
+++ b/tools/topology/sof/pipe-low-latency-playback.m4
@@ -54,16 +54,16 @@ C_CONTROLMIXER(Master Playback Volume, PIPELINE_ID,
 
 # Host "Low latency Playback" PCM
 # with 2 sink and 0 source periods
-W_PCM_PLAYBACK(PCM_ID, Low Latency Playback, 2, 0, 2)
+W_PCM_PLAYBACK(PCM_ID, Low Latency Playback, 2, 0)
 
 # "Playback Volume" has 1 sink period and 2 source periods for host ping-pong
-W_PGA(0, PIPELINE_FORMAT, 1, 2, 1, LIST(`		', "PIPELINE_ID PCM PCM_ID Playback Volume"))
+W_PGA(0, PIPELINE_FORMAT, 1, 2, LIST(`		', "PIPELINE_ID PCM PCM_ID Playback Volume"))
 
 # "Master Playback Volume" has 1 source and 2 sink periods for DAI ping-pong
-W_PGA(1, PIPELINE_FORMAT, 2, 1, 1, LIST(`		', "PIPELINE_ID Master Playback Volume"))
+W_PGA(1, PIPELINE_FORMAT, 2, 1, LIST(`		', "PIPELINE_ID Master Playback Volume"))
 
 # Mixer 0 has 1 sink and source periods.
-W_MIXER(0, PIPELINE_FORMAT, 1, 1, 1)
+W_MIXER(0, PIPELINE_FORMAT, 1, 1)
 
 # Low Latency Buffers
 W_BUFFER(0, COMP_BUFFER_SIZE(2,

--- a/tools/topology/sof/pipe-passthrough-capture.m4
+++ b/tools/topology/sof/pipe-passthrough-capture.m4
@@ -17,7 +17,7 @@ include(`pipeline.m4')
 
 # Host "Passthrough Capture" PCM
 # with 0 sink and 2 source periods
-W_PCM_CAPTURE(PCM_ID, Passthrough Capture, 0, 2, 2)
+W_PCM_CAPTURE(PCM_ID, Passthrough Capture, 0, 2)
 
 # Capture Buffers
 W_BUFFER(0, COMP_BUFFER_SIZE(2,

--- a/tools/topology/sof/pipe-passthrough-playback.m4
+++ b/tools/topology/sof/pipe-passthrough-playback.m4
@@ -17,7 +17,7 @@ include(`pipeline.m4')
 
 # Host "Passthrough Playback" PCM
 # with 2 sink and 0 source periods
-W_PCM_PLAYBACK(PCM_ID, Passthrough Playback, 2, 0, 2)
+W_PCM_PLAYBACK(PCM_ID, Passthrough Playback, 2, 0)
 
 # Playback Buffers
 W_BUFFER(0, COMP_BUFFER_SIZE(2,

--- a/tools/topology/sof/pipe-pcm-media.m4
+++ b/tools/topology/sof/pipe-pcm-media.m4
@@ -42,13 +42,13 @@ W_DATA(media_src_conf, media_src_tokens)
 
 # Host "Low latency Playback" PCM
 # with 2 sink and 0 source periods
-W_PCM_PLAYBACK(PCM_ID, Media Playback, 2, 0, 2)
+W_PCM_PLAYBACK(PCM_ID, Media Playback, 2, 0)
 
 # "Playback Volume" has 2 sink period and 2 source periods for host ping-pong
-W_PGA(0, PIPELINE_FORMAT, 2, 2, 2, LIST(`		', "PIPELINE_ID PCM PCM_ID Playback Volume"))
+W_PGA(0, PIPELINE_FORMAT, 2, 2, LIST(`		', "PIPELINE_ID PCM PCM_ID Playback Volume"))
 
 # "SRC 0" has 2 sink and source periods.
-W_SRC(0, PIPELINE_FORMAT, 2, 2, media_src_conf, 2)
+W_SRC(0, PIPELINE_FORMAT, 2, 2, media_src_conf)
 
 # Media Source Buffers to SRC, make them big enough to deal with 2 * rate.
 W_BUFFER(0, COMP_BUFFER_SIZE(4,

--- a/tools/topology/sof/pipe-src-capture.m4
+++ b/tools/topology/sof/pipe-src-capture.m4
@@ -18,7 +18,7 @@ include(`pipeline.m4')
 
 # Host "Passthrough Capture" PCM
 # with 4 sink and 0 source periods
-W_PCM_CAPTURE(PCM_ID, Passthrough Capture, 4, 0, 2)
+W_PCM_CAPTURE(PCM_ID, Passthrough Capture, 4, 0)
 
 #
 # SRC Configuration
@@ -29,7 +29,7 @@ W_VENDORTUPLES(media_src_tokens, sof_src_tokens, LIST(`		', `SOF_TKN_SRC_RATE_OU
 W_DATA(media_src_conf, media_src_tokens)
 
 # "SRC" has 4 source and 4 sink periods
-W_SRC(0, PIPELINE_FORMAT, 4, 4, media_src_conf, 2)
+W_SRC(0, PIPELINE_FORMAT, 4, 4, media_src_conf)
 
 # Capture Buffers
 W_BUFFER(0, COMP_BUFFER_SIZE(4,

--- a/tools/topology/sof/pipe-src-playback.m4
+++ b/tools/topology/sof/pipe-src-playback.m4
@@ -32,7 +32,7 @@ C_CONTROLMIXER(Master Playback Volume, PIPELINE_ID,
 
 # Host "SRC Playback" PCM
 # with 3 sink and 0 source periods
-W_PCM_PLAYBACK(PCM_ID, SRC Playback, 3, 0, 2)
+W_PCM_PLAYBACK(PCM_ID, SRC Playback, 3, 0)
 
 #
 # SRC Configuration
@@ -43,10 +43,10 @@ W_VENDORTUPLES(media_src_tokens, sof_src_tokens, LIST(`		', `SOF_TKN_SRC_RATE_OU
 W_DATA(media_src_conf, media_src_tokens)
 
 # "SRC" has 3 source and 3 sink periods
-W_SRC(0, PIPELINE_FORMAT, 3, 3, media_src_conf, 2)
+W_SRC(0, PIPELINE_FORMAT, 3, 3, media_src_conf)
 
 # "Volume" has 2 source and 2 sink periods
-W_PGA(0, PIPELINE_FORMAT, 2, 2, 2, LIST(`		', "PIPELINE_ID Master Playback Volume"))
+W_PGA(0, PIPELINE_FORMAT, 2, 2, LIST(`		', "PIPELINE_ID Master Playback Volume"))
 
 # Playback Buffers
 W_BUFFER(0, COMP_BUFFER_SIZE(3,

--- a/tools/topology/sof/pipe-tone.m4
+++ b/tools/topology/sof/pipe-tone.m4
@@ -42,10 +42,10 @@ C_CONTROLMIXER(Tone Switch, PIPELINE_ID,
 #
 
 # "Tone 0" has 2 sink period and 0 source periods
-W_TONE(0, PIPELINE_FORMAT, 2, 0, 0, LIST(`		', "PIPELINE_ID Tone Switch"))
+W_TONE(0, PIPELINE_FORMAT, 2, 0, LIST(`		', "PIPELINE_ID Tone Switch"))
 
 # "Tone Volume" has 2 sink period and 2 source periods
-W_PGA(0, PIPELINE_FORMAT, 2, 2, 0, LIST(`		', "PIPELINE_ID Tone Volume"))
+W_PGA(0, PIPELINE_FORMAT, 2, 2, LIST(`		', "PIPELINE_ID Tone Volume"))
 
 # Low Latency Buffers
 W_BUFFER(0,COMP_BUFFER_SIZE(2,

--- a/tools/topology/sof/pipe-volume-capture.m4
+++ b/tools/topology/sof/pipe-volume-capture.m4
@@ -31,10 +31,10 @@ C_CONTROLMIXER(Master Capture Volume, PIPELINE_ID,
 
 # Host "Passthrough Capture" PCM
 # with 0 sink and 2 source periods
-W_PCM_CAPTURE(PCM_ID, Passthrough Capture, 0, 2, 2)
+W_PCM_CAPTURE(PCM_ID, Passthrough Capture, 0, 2)
 
 # "Volume" has 2 source and 2 sink periods
-W_PGA(0, PIPELINE_FORMAT, 2, 2, 2, LIST(`		', "PIPELINE_ID Master Capture Volume"))
+W_PGA(0, PIPELINE_FORMAT, 2, 2, LIST(`		', "PIPELINE_ID Master Capture Volume"))
 
 # Capture Buffers
 W_BUFFER(0, COMP_BUFFER_SIZE(2,

--- a/tools/topology/sof/pipe-volume-playback.m4
+++ b/tools/topology/sof/pipe-volume-playback.m4
@@ -31,10 +31,10 @@ C_CONTROLMIXER(Master Playback Volume, PIPELINE_ID,
 
 # Host "Passthrough Playback" PCM
 # with 2 sink and 0 source periods
-W_PCM_PLAYBACK(PCM_ID, Passthrough Playback, 2, 0, 2)
+W_PCM_PLAYBACK(PCM_ID, Passthrough Playback, 2, 0)
 
 # "Volume" has 2 source and 2 sink periods
-W_PGA(0, PIPELINE_FORMAT, 2, 2, 2, LIST(`		', "PIPELINE_ID Master Playback Volume"))
+W_PGA(0, PIPELINE_FORMAT, 2, 2, LIST(`		', "PIPELINE_ID Master Playback Volume"))
 
 # Playback Buffers
 W_BUFFER(0, COMP_BUFFER_SIZE(2,

--- a/tools/topology/sof/tokens.m4
+++ b/tools/topology/sof/tokens.m4
@@ -15,7 +15,8 @@ SectionVendorTokens."sof_buffer_tokens" {
 }
 
 SectionVendorTokens."sof_dai_tokens" {
-	SOF_TKN_DAI_DMAC_CONFIG			"153"
+# Token retired with ABI 3.2, do not use for new capabilities
+#	SOF_TKN_DAI_DMAC_CONFIG			"153"
 	SOF_TKN_DAI_TYPE			"154"
 	SOF_TKN_DAI_INDEX			"155"
 	SOF_TKN_DAI_DIRECTION			"156"
@@ -48,7 +49,8 @@ SectionVendorTokens."sof_comp_tokens" {
 	SOF_TKN_COMP_PERIOD_SINK_COUNT		"400"
 	SOF_TKN_COMP_PERIOD_SOURCE_COUNT	"401"
 	SOF_TKN_COMP_FORMAT			"402"
-	SOF_TKN_COMP_PRELOAD_COUNT		"403"
+# Token retired with ABI 3.2, do not use for new capabilities
+#	SOF_TKN_COMP_PRELOAD_COUNT		"403"
 }
 
 SectionVendorTokens."sof_ssp_tokens" {


### PR DESCRIPTION
Some properties are populated from the topologies and not being used by
DSP either. Need to clean up token data structures. these are identified
as unused.

comp_tokens: preload_count
dai_tokens: dmac_config
ssp_tokens: clks_control, frame_pulse_width, quirks,
            tdm_per_slot_padding_flag

Signed-off-by: Fred Oh <fred.oh@linux.intel.com>