### PR TITLE
schedule: remove timer scheduling

### DIFF
--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -283,7 +283,6 @@ static int dai_playback_params(struct comp_dev *dev)
 	config->src_width = comp_sample_bytes(dev);
 	config->dest_width = comp_sample_bytes(dev);
 	config->cyclic = 1;
-	config->timer_delay = dev->pipeline->ipc_pipe.timer_delay;
 	config->dest_dev = dd->dai->plat_data.fifo[0].handshake;
 
 	/* set up local and host DMA elems to reset values */
@@ -334,7 +333,6 @@ static int dai_capture_params(struct comp_dev *dev)
 	/* set up DMA configuration */
 	config->direction = DMA_DIR_DEV_TO_MEM;
 	config->cyclic = 1;
-	config->timer_delay = dev->pipeline->ipc_pipe.timer_delay;
 	config->src_dev = dd->dai->plat_data.fifo[1].handshake;
 
 	/* TODO: Make this code platform-specific or move it driver callback */

--- a/src/audio/pipeline.c
+++ b/src/audio/pipeline.c
@@ -766,14 +766,8 @@ static int pipeline_xrun_recover(struct pipeline *p)
 /* notify pipeline that this component requires buffers emptied/filled */
 void pipeline_schedule_copy(struct pipeline *p, uint64_t start)
 {
-	if (p->sched_comp->state == COMP_STATE_ACTIVE) {
-		/* timer driven pipeline should execute task synchronously */
-		if (p->ipc_pipe.timer_delay)
-			pipeline_copy(p->sched_comp);
-		else
-			schedule_task(&p->pipe_task, start,
-				      p->ipc_pipe.deadline);
-	}
+	if (p->sched_comp->state == COMP_STATE_ACTIVE)
+		schedule_task(&p->pipe_task, start, p->ipc_pipe.deadline);
 
 }
 

--- a/src/include/sof/dma.h
+++ b/src/include/sof/dma.h
@@ -121,7 +121,6 @@ struct dma_sg_config {
 	uint32_t src_dev;
 	uint32_t dest_dev;
 	uint32_t cyclic;			/* circular buffer */
-	uint32_t timer_delay;	/* non zero if timer scheduled */
 	struct dma_sg_elem_array elem_array;	/* array of dma_sg elems */
 	bool scatter;
 };

--- a/src/ipc/ipc.c
+++ b/src/ipc/ipc.c
@@ -524,7 +524,6 @@ int ipc_get_page_descriptors(struct dma *dmac, uint8_t *page_table,
 	config.src_width = sizeof(uint32_t);
 	config.dest_width = sizeof(uint32_t);
 	config.cyclic = 0;
-	config.timer_delay = 0;
 	dma_sg_init(&config.elem_array);
 
 	/* set up DMA descriptor */


### PR DESCRIPTION
Removes timer scheduling as of right now.
It doesn't work correctly and pollutes the
dw-dma code. More generic implementation will
be added in the near future.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>