### PR TITLE
mixer: add support for variable data copy

### DIFF
--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -39,9 +39,12 @@
 #include <sof/audio/component.h>
 #include <sof/audio/format.h>
 
-#define trace_mixer(__e)	trace_event(TRACE_CLASS_MIXER, __e)
-#define tracev_mixer(__e)	tracev_event(TRACE_CLASS_MIXER, __e)
-#define trace_mixer_error(__e)	trace_error(TRACE_CLASS_MIXER, __e)
+#define trace_mixer(__e, ...) \
+	trace_event(TRACE_CLASS_MIXER, __e, ##__VA_ARGS__)
+#define tracev_mixer(__e, ...) \
+	tracev_event(TRACE_CLASS_MIXER, __e, ##__VA_ARGS__)
+#define trace_mixer_error(__e, ...) \
+	trace_error(TRACE_CLASS_MIXER, __e, ##__VA_ARGS__)
 
 /* mixer component private data */
 struct mixer_data {


### PR DESCRIPTION
Adds support to mixer component for variable
data size copy.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>