### PR TITLE
pipeline: restrict pipeline params and prepare to the current pipeline

### DIFF
--- a/src/audio/pipeline.c
+++ b/src/audio/pipeline.c
@@ -265,6 +265,13 @@ static int pipeline_comp_params(struct comp_dev *current, void *data, int dir)
 	tracev_pipe("pipeline_comp_params(), current->comp.id = %u, dir = %u",
 		    current->comp.id, dir);
 
+	/* dont do params if comp is from a different pipeline */
+	if (!comp_is_single_pipeline(current, ppl_data->start)) {
+		tracev_pipe_with_ids(current->pipeline, "pipeline_comp_params"
+				     "(), current is from another pipeline");
+		return 0;
+	}
+
 	/* don't do any params if current is running */
 	if (current->state == COMP_STATE_ACTIVE)
 		return 0;
@@ -305,6 +312,7 @@ int pipeline_params(struct pipeline *p, struct comp_dev *host,
 	trace_pipe_with_ids(p, "pipeline_params()");
 
 	data.params = params;
+	data.start = host;
 
 	spin_lock_irq(&p->lock, flags);
 
@@ -321,10 +329,18 @@ int pipeline_params(struct pipeline *p, struct comp_dev *host,
 
 static int pipeline_comp_prepare(struct comp_dev *current, void *data, int dir)
 {
+	struct pipeline_data *ppl_data = data;
 	int err = 0;
 
 	tracev_pipe("pipeline_comp_prepare(), current->comp.id = %u, dir = %u",
 		    current->comp.id, dir);
+
+	/* dont do prepare if comp is from a different pipeline */
+	if (!comp_is_single_pipeline(current, ppl_data->start)) {
+		tracev_pipe_with_ids(current->pipeline, "pipeline_comp_prepare"
+				     "(), current is from another pipeline");
+		return 0;
+	}
 
 	err = comp_prepare(current);
 	if (err < 0 || err > 0)
@@ -337,14 +353,17 @@ static int pipeline_comp_prepare(struct comp_dev *current, void *data, int dir)
 /* prepare the pipeline for usage - preload host buffers here */
 int pipeline_prepare(struct pipeline *p, struct comp_dev *dev)
 {
+	struct pipeline_data ppl_data;
 	int ret = 0;
 	uint32_t flags;
 
 	trace_pipe_with_ids(p, "pipeline_prepare()");
 
+	ppl_data.start = dev;
+
 	spin_lock_irq(&p->lock, flags);
 
-	ret = pipeline_comp_prepare(dev, NULL, dev->params.direction);
+	ret = pipeline_comp_prepare(dev, &ppl_data, dev->params.direction);
 	if (ret < 0) {
 		trace_pipe_error("pipeline_prepare() error: ret = %d,"
 				 "dev->comp.id = %u", ret, dev->comp.id);


### PR DESCRIPTION
Pipeline params and prepare should not be allowed to
propagate beyond the pipeline that the starting comp
belongs to.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>