### PR TITLE
component: remove double semicolon

### DIFF
--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -277,7 +277,7 @@ struct comp_dev {
 
 /** \brief Retrieves the driver private data. */
 #define comp_get_drvdata(c) \
-	c->private;
+	c->private
 
 /** \brief Retrieves the component device buffer list. */
 #define comp_buffer_list(comp, dir) \


### PR DESCRIPTION
Removes double semicolon when using comp_get_drvdata
macro.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>