### PR TITLE
dmic: fix a pointer arithmetic bug

### DIFF
--- a/src/drivers/intel/cavs/dmic.c
+++ b/src/drivers/intel/cavs/dmic.c
@@ -1150,7 +1150,8 @@ static int dmic_set_config(struct dai *dai, struct sof_ipc_dai_config *config)
 			return -ENOMEM;
 		}
 		for (i = 1; i < DMIC_HW_FIFOS; i++)
-			dmic_prm[i] = dmic_prm[i - 1] + size;
+			dmic_prm[i] = (struct sof_ipc_dai_dmic_params *)
+				((uint8_t *)dmic_prm[i - 1] + size);
 	}
 
 	if (di >= DMIC_HW_FIFOS) {


### PR DESCRIPTION
Adding N to a pointer is like jumping N array elements forward, not
like adding N bytes to the pointer.