### PR TITLE
[RFC] uapi: stream: reclaim unused offset field in host buffer

### DIFF
--- a/src/include/uapi/ipc/stream.h
+++ b/src/include/uapi/ipc/stream.h
@@ -98,8 +98,7 @@ struct sof_ipc_host_buffer {
 	uint32_t phy_addr;
 	uint32_t pages;
 	uint32_t size;
-	uint32_t offset;
-	uint32_t reserved[2];
+	uint32_t reserved[3];
 } __attribute__((packed));
 
 struct sof_ipc_stream_params {


### PR DESCRIPTION
This field doesn't seem to be used by anyone, reclaim as reserved.

Don't merge for now, this meant to trigger CI tests since it's compile-tested only, and we may want to reuse the field to describe the compressed page table endianness, the code assumes a little endian representation.

The matching Linux PR is https://github.com/thesofproject/linux/pull/693