### PR TITLE
scheduler: generic scheduler and work api

### DIFF
--- a/src/arch/xtensa/CMakeLists.txt
+++ b/src/arch/xtensa/CMakeLists.txt
@@ -161,7 +161,6 @@ if(CONFIG_SMP)
 		smp/notifier.c
 		smp/schedule.c
 		smp/task.c
-		smp/work.c
 	)
 else()
 	add_subdirectory(up)
@@ -173,7 +172,6 @@ else()
 		up/notifier.c
 		up/schedule.c
 		up/task.c
-		up/work.c
 	)
 endif()
 

--- a/src/arch/xtensa/smp/cpu.c
+++ b/src/arch/xtensa/smp/cpu.c
@@ -105,9 +105,7 @@ void cpu_power_down_core(void)
 
 	idc_free();
 
-	scheduler_free();
-
-	free_system_workq();
+	schedule_free();
 
 	free_system_notify();
 

--- a/src/arch/xtensa/smp/init.c
+++ b/src/arch/xtensa/smp/init.c
@@ -123,12 +123,9 @@ int slave_core_init(struct sof *sof)
 	init_system_notify(sof);
 
 	trace_point(TRACE_BOOT_SYS_SCHED);
-	scheduler_init(sof);
+	scheduler_init();
 
 	platform_interrupt_init();
-
-	trace_point(TRACE_BOOT_SYS_WORK);
-	init_system_workq(&platform_generic_queue[cpu_get_id()]);
 
 	/* initialize IDC mechanism */
 	trace_point(TRACE_BOOT_PLATFORM_IDC);

--- a/src/arch/xtensa/smp/schedule.c
+++ b/src/arch/xtensa/smp/schedule.c
@@ -39,9 +39,9 @@
 #include <arch/cpu.h>
 #include <sof/schedule.h>
 
-struct schedule_data **arch_schedule_get(void)
+struct schedule_data **arch_schedule_get_data(void)
 {
 	struct core_context *ctx = (struct core_context *)cpu_read_threadptr();
 
-	return &ctx->sch;
+	return &ctx->sch_data;
 }

--- a/src/arch/xtensa/smp/xtos/xtos-structs.h
+++ b/src/arch/xtensa/smp/xtos/xtos-structs.h
@@ -37,7 +37,6 @@ struct idc;
 struct irq_task;
 struct notify;
 struct schedule_data;
-struct work_queue;
 
 struct thread_data {
 	xtos_structures_pointers xtos_ptrs;
@@ -58,8 +57,7 @@ struct core_context {
 	struct irq_task *irq_low_task;
 	struct irq_task *irq_med_task;
 	struct irq_task *irq_high_task;
-	struct schedule_data *sch;
-	struct work_queue *queue;
+	struct schedule_data *sch_data;
 	struct notify *notify;
 	struct idc *idc;
 };

--- a/src/arch/xtensa/up/schedule.c
+++ b/src/arch/xtensa/up/schedule.c
@@ -37,10 +37,10 @@
 
 #include <sof/schedule.h>
 
-/** \brief Schedule data pointer. */
+/** \brief Schedule data pointer */
 static struct schedule_data *sch;
 
-struct schedule_data **arch_schedule_get(void)
+struct schedule_data **arch_schedule_get_data(void)
 {
 	return &sch;
 }

--- a/src/audio/eq_iir.c
+++ b/src/audio/eq_iir.c
@@ -39,7 +39,7 @@
 #include <sof/list.h>
 #include <sof/stream.h>
 #include <sof/alloc.h>
-#include <sof/work.h>
+#include <sof/schedule.h>
 #include <sof/clk.h>
 #include <sof/ipc.h>
 #include <sof/audio/component.h>

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -47,7 +47,7 @@
 static void kpb_event_handler(int message, void *cb_data, void *event_data);
 static int kpb_register_client(struct comp_data *kpb, struct kpb_client *cli);
 static void kpb_init_draining(struct comp_data *kpb, struct kpb_client *cli);
-static void kpb_draining_task(void *arg);
+static uint64_t kpb_draining_task(void *arg);
 static void kpb_buffer_data(struct comp_data *kpb, struct comp_buffer *source);
 
 /**
@@ -225,7 +225,8 @@ static int kpb_prepare(struct comp_dev *dev)
 	notifier_register(&cd->kpb_events);
 
 	/* initialie draining task */
-	schedule_task_init(&cd->draining_task, kpb_draining_task, cd);
+	schedule_task_init(&cd->draining_task, SOF_SCHEDULE_EDF, 0,
+			   kpb_draining_task, cd, 0, 0);
 
 	/* search for the channel selector sink.
 	 * NOTE! We assume here that channel selector component device
@@ -517,15 +518,16 @@ static void kpb_init_draining(struct comp_data *kpb, struct kpb_client *cli)
 				"sink not ready for draining");
 	} else {
 		/* add one-time draining task into the scheduler */
-		schedule_task(&kpb->draining_task, 0, 0);
+		schedule_task(&kpb->draining_task, 0, 0, 0);
 	}
 }
 
-static void kpb_draining_task(void *arg)
+static uint64_t kpb_draining_task(void *arg)
 {
 	/* TODO: while loop drainning history buffer accoriding to
 	 * clients request
 	 */
+	return 0;
 }
 
 struct comp_driver comp_kpb = {

--- a/src/audio/pipeline_static.c
+++ b/src/audio/pipeline_static.c
@@ -345,9 +345,9 @@ static struct spipe spipe[] = {
 
 /* pipelines */
 struct sof_ipc_pipe_new pipeline[] = {
-	SPIPE_PIPE(0, 0, 1000, TASK_PRI_HIGH),	/* high pri - 1ms deadline */
-//	SPIPE_PIPE(1, 0, 4000, TASK_PRI_MED),	/* med pri - 4ms deadline */
-//	SPIPE_PIPE(2, 0, 5000, TASK_PRI_LOW),	/* low pri - 5ms deadline */
+	SPIPE_PIPE(0, 0, 1000, SOF_TASK_PRI_HIGH),/* high pri - 1ms deadline */
+//	SPIPE_PIPE(1, 0, 4000, SOF_TASK_PRI_MED),/* med pri - 4ms deadline */
+//	SPIPE_PIPE(2, 0, 5000, SOF_TASK_PRI_LOW),/* low pri - 5ms deadline */
 };
 
 int init_static_pipeline(struct ipc *ipc)

--- a/src/audio/selector.c
+++ b/src/audio/selector.c
@@ -44,7 +44,6 @@
 #include <sof/list.h>
 #include <sof/stream.h>
 #include <sof/alloc.h>
-#include <sof/work.h>
 #include <sof/clk.h>
 #include <sof/ipc.h>
 #include "selector.h"

--- a/src/audio/src.c
+++ b/src/audio/src.c
@@ -38,7 +38,7 @@
 #include <sof/list.h>
 #include <sof/stream.h>
 #include <sof/alloc.h>
-#include <sof/work.h>
+#include <sof/schedule.h>
 #include <sof/clk.h>
 #include <sof/ipc.h>
 #include <sof/audio/component.h>

--- a/src/audio/tone.c
+++ b/src/audio/tone.c
@@ -39,7 +39,7 @@
 #include <sof/list.h>
 #include <sof/stream.h>
 #include <sof/alloc.h>
-#include <sof/work.h>
+#include <sof/schedule.h>
 #include <sof/clk.h>
 #include <sof/ipc.h>
 #include <sof/audio/component.h>

--- a/src/audio/volume.h
+++ b/src/audio/volume.h
@@ -115,7 +115,7 @@ struct comp_data {
 	/**< volume processing function */
 	void (*scale_vol)(struct comp_dev *dev, struct comp_buffer *sink,
 		struct comp_buffer *source, uint32_t frames);
-	struct work volwork;			/**< volume scheduled work function */
+	struct task volwork;	/**< volume scheduled work function */
 	struct sof_ipc_ctrl_value_chan *hvol;	/**< host volume readback */
 };
 

--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -53,7 +53,7 @@
 #include <sof/timer.h>
 #include <sof/alloc.h>
 #include <sof/interrupt.h>
-#include <sof/work.h>
+#include <sof/schedule.h>
 #include <sof/lock.h>
 #include <sof/trace.h>
 #include <sof/wait.h>
@@ -459,7 +459,6 @@ static void dw_dma_channel_put_unlocked(struct dma *dma, int channel)
 	chan->ptr_data.start_ptr = 0;
 	chan->ptr_data.end_ptr = 0;
 	chan->ptr_data.buffer_bytes = 0;
-
 	atomic_sub(&dma->num_channels_busy, 1);
 }
 

--- a/src/drivers/intel/baytrail/ipc.c
+++ b/src/drivers/intel/baytrail/ipc.c
@@ -218,8 +218,8 @@ int platform_ipc_init(struct ipc *ipc)
 	ipc_set_drvdata(_ipc, iipc);
 
 	/* schedule */
-	schedule_task_init(&_ipc->ipc_task, ipc_process_task, _ipc);
-	schedule_task_config(&_ipc->ipc_task, TASK_PRI_IPC, 0);
+	schedule_task_init(&_ipc->ipc_task, SOF_SCHEDULE_EDF, SOF_TASK_PRI_IPC,
+			   ipc_process_task, _ipc, 0, 0);
 
 #ifdef CONFIG_HOST_PTABLE
 	/* allocate page table buffer */

--- a/src/drivers/intel/cavs/hda-dma.c
+++ b/src/drivers/intel/cavs/hda-dma.c
@@ -53,6 +53,7 @@
 #include <arch/cache.h>
 #include <arch/wait.h>
 #include <uapi/ipc/topology.h>
+#include <sof/schedule.h>
 
 #define trace_hddma(__e, ...) \
 	trace_event(TRACE_CLASS_DMA, __e, ##__VA_ARGS__)
@@ -565,7 +566,6 @@ static int hda_dma_start(struct dma *dma, int channel)
 	hda_dma_enable_unlock(dma, channel);
 
 	p->chan[channel].status = COMP_STATE_ACTIVE;
-
 out:
 	spin_unlock_irq(&dma->lock, flags);
 	return ret;

--- a/src/drivers/intel/cavs/ipc.c
+++ b/src/drivers/intel/cavs/ipc.c
@@ -242,8 +242,8 @@ int platform_ipc_init(struct ipc *ipc)
 	ipc_set_drvdata(_ipc, iipc);
 
 	/* schedule */
-	schedule_task_init(&_ipc->ipc_task, ipc_process_task, _ipc);
-	schedule_task_config(&_ipc->ipc_task, TASK_PRI_IPC, 0);
+	schedule_task_init(&_ipc->ipc_task, SOF_SCHEDULE_EDF, SOF_TASK_PRI_IPC,
+			   ipc_process_task, _ipc, 0, 0);
 
 	/* PM */
 	iipc->pm_prepare_D3 = 0;

--- a/src/drivers/intel/cavs/sue-ipc.c
+++ b/src/drivers/intel/cavs/sue-ipc.c
@@ -132,8 +132,8 @@ int platform_ipc_init(struct ipc *ipc)
 	ipc_set_drvdata(_ipc, iipc);
 
 	/* schedule */
-	schedule_task_init(&_ipc->ipc_task, ipc_process_task, _ipc);
-	schedule_task_config(&_ipc->ipc_task, TASK_PRI_MED, 0);
+	schedule_task_init(&_ipc->ipc_task, SOF_SCHEDULE_EDF, SOF_TASK_PRI_MED,
+			   ipc_process_task, _ipc, 0, 0);
 
 	/* PM */
 	iipc->pm_prepare_D3 = 0;

--- a/src/drivers/intel/haswell/ipc.c
+++ b/src/drivers/intel/haswell/ipc.c
@@ -208,8 +208,8 @@ int platform_ipc_init(struct ipc *ipc)
 	ipc_set_drvdata(_ipc, iipc);
 
 	/* schedule */
-	schedule_task_init(&_ipc->ipc_task, ipc_process_task, _ipc);
-	schedule_task_config(&_ipc->ipc_task, TASK_PRI_IPC, 0);
+	schedule_task_init(&_ipc->ipc_task, SOF_SCHEDULE_EDF, SOF_TASK_PRI_IPC,
+			   ipc_process_task, _ipc, 0, 0);
 
 #ifdef CONFIG_HOST_PTABLE
 	/* allocate page table buffer */

--- a/src/host/CMakeLists.txt
+++ b/src/host/CMakeLists.txt
@@ -16,6 +16,8 @@ add_local_sources(tb_common
 	file.c
 	ipc.c
 	schedule.c
+	edf_schedule.c
+	ll_schedule.c
 	topology.c
 	trace.c
 )

--- a/src/host/common_test.c
+++ b/src/host/common_test.c
@@ -44,7 +44,7 @@
 #include <sof/ipc.h>
 #include <sof/dai.h>
 #include <sof/dma.h>
-#include <sof/work.h>
+#include <sof/schedule.h>
 #include <sof/wait.h>
 #include <sof/ipc.h>
 #include <sof/audio/pipeline.h>
@@ -65,7 +65,7 @@ int tb_pipeline_setup(struct sof *sof)
 	}
 
 	/* init scheduler */
-	if (scheduler_init(sof) < 0) {
+	if (scheduler_init() < 0) {
 		fprintf(stderr, "error: scheduler init\n");
 		return -EINVAL;
 	}

--- a/src/host/edf_schedule.c
+++ b/src/host/edf_schedule.c
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2019, Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of the Intel Corporation nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>
+ */
+
+#include <sof/audio/component.h>
+#include <sof/task.h>
+#include <stdint.h>
+#include <sof/edf_schedule.h>
+#include <sof/wait.h>
+
+ /* scheduler testbench definition */
+
+struct edf_schedule_data {
+	spinlock_t lock; /* schedule lock */
+	struct list_item list; /* list of tasks in priority queue */
+	uint32_t clock;
+};
+
+static struct edf_schedule_data *sch;
+
+static void schedule_edf_task_complete(struct task *task);
+static void schedule_edf_task(struct task *task, uint64_t start,
+			      uint64_t deadline, uint32_t flags);
+static int schedule_edf_task_init(struct task *task, uint32_t xflags);
+static int edf_scheduler_init(void);
+static void edf_scheduler_free(void);
+static void schedule_edf(void);
+static int schedule_edf_task_cancel(struct task *task);
+static void schedule_edf_task_free(struct task *task);
+
+static void schedule_edf_task_complete(struct task *task)
+{
+	list_item_del(&task->list);
+	task->state = SOF_TASK_STATE_COMPLETED;
+}
+
+/* schedule task */
+static void schedule_edf_task(struct task *task, uint64_t start,
+			      uint64_t deadline, uint32_t flags)
+{
+	(void)deadline;
+	list_item_prepend(&task->list, &sch->list);
+	task->state = SOF_TASK_STATE_QUEUED;
+
+	if (task->func)
+		task->func(task->data);
+
+	schedule_edf_task_complete(task);
+}
+
+static int schedule_edf_task_init(struct task *task, uint32_t xflags)
+{
+	struct edf_task_pdata *edf_pdata;
+	(void)xflags;
+
+	edf_pdata = malloc(sizeof(*edf_pdata));
+	edf_sch_set_pdata(task, edf_pdata);
+
+	return 0;
+}
+
+/* initialize scheduler */
+static int edf_scheduler_init(void)
+{
+	trace_edf_sch("edf_scheduler_init()");
+	sch = malloc(sizeof(*sch));
+	list_init(&sch->list);
+	spinlock_init(&sch->lock);
+
+	return 0;
+}
+
+static void edf_scheduler_free(void)
+{
+	free(sch);
+}
+
+/* The following definitions are to satisfy libsof linker errors */
+static void schedule_edf(void)
+{
+}
+
+static int schedule_edf_task_cancel(struct task *task)
+{
+	if (task->state == SOF_TASK_STATE_QUEUED) {
+		/* delete task */
+		task->state = SOF_TASK_STATE_CANCEL;
+		list_item_del(&task->list);
+	}
+
+	return 0;
+}
+
+static void schedule_edf_task_free(struct task *task)
+{
+	task->state = SOF_TASK_STATE_FREE;
+	task->func = NULL;
+	task->data = NULL;
+
+	free(edf_sch_get_pdata(task));
+	edf_sch_set_pdata(task, NULL);
+}
+
+struct scheduler_ops schedule_edf_ops = {
+	.schedule_task		= schedule_edf_task,
+	.schedule_task_init	= schedule_edf_task_init,
+	.schedule_task_running	= NULL,
+	.schedule_task_complete = NULL,
+	.reschedule_task	= NULL,
+	.schedule_task_cancel	= schedule_edf_task_cancel,
+	.schedule_task_free	= schedule_edf_task_free,
+	.scheduler_init		= edf_scheduler_init,
+	.scheduler_free		= edf_scheduler_free,
+	.scheduler_run		= schedule_edf
+};

--- a/src/host/file.c
+++ b/src/host/file.c
@@ -40,7 +40,6 @@
 #include <sof/lock.h>
 #include <sof/list.h>
 #include <sof/stream.h>
-#include <sof/work.h>
 #include <sof/clk.h>
 #include <sof/audio/component.h>
 #include <sof/audio/format.h>

--- a/src/host/ll_schedule.c
+++ b/src/host/ll_schedule.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Intel Corporation
+ * Copyright (c) 2019, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,23 +25,25 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * Author: Tomasz Lauda <tomasz.lauda@linux.intel.com>
- *
+ * Author: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>
  */
 
-/**
- * \file arch/xtensa/smp/work.c
- * \brief Xtensa SMP work queue implementation file
- * \authors Tomasz Lauda <tomasz.lauda@linux.intel.com>
- */
+#include <sof/audio/component.h>
+#include <sof/task.h>
+#include <stdint.h>
+#include <sof/wait.h>
 
-#include <xtos-structs.h>
-#include <arch/cpu.h>
-#include <sof/work.h>
+/* TODO: Make host ll ops implementation */
+struct scheduler_ops schedule_ll_ops = {
+	.schedule_task = NULL,
+	.schedule_task_init = NULL,
+	.schedule_task_running = NULL,
+	.schedule_task_complete = NULL,
+	.reschedule_task = NULL,
+	.schedule_task_cancel = NULL,
+	.schedule_task_free = NULL,
+	.scheduler_init = NULL,
+	.scheduler_free = NULL,
+	.scheduler_run = NULL
+};
 
-struct work_queue **arch_work_queue_get(void)
-{
-	struct core_context *ctx = (struct core_context *)cpu_read_threadptr();
-
-	return &ctx->queue;
-}

--- a/src/include/host/common_test.h
+++ b/src/include/host/common_test.h
@@ -73,7 +73,7 @@ struct shared_lib_table {
 
 extern int debug;
 
-int scheduler_init(struct sof *sof);
+int edf_scheduler_init(void);
 
 void sys_comp_file_init(void);
 

--- a/src/include/host/edf_schedule.h
+++ b/src/include/host/edf_schedule.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Intel Corporation
+ * Copyright (c) 2019, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,53 +25,12 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * Author: Slawomir Blauciak <slawomir.blauciak@linux.intel.com>
+ * Author: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>
  */
 
-#include <stdarg.h>
-#include <stddef.h>
-#include <setjmp.h>
-#include <cmocka.h>
+#ifndef _INCLUDE_HOST_EDF_SCHEDULE_H_
+#define _INCLUDE_HOST_EDF_SCHEDULE_H_
 
-#include <sof/alloc.h>
-#include <sof/audio/component.h>
+extern struct scheduler_ops schedule_edf_ops;
 
-#include "comp_mock.h"
-
-#include <mock_trace.h>
-
-TRACE_IMPL()
-
-void *rballoc(int zone, uint32_t caps, size_t bytes)
-{
-	(void)zone;
-	(void)caps;
-
-	return malloc(bytes);
-}
-
-void *rzalloc(int zone, uint32_t caps, size_t bytes)
-{
-	(void)zone;
-	(void)caps;
-
-	return calloc(bytes, 1);
-}
-
-void rfree(void *ptr)
-{
-	free(ptr);
-}
-
-void pipeline_xrun(struct pipeline *p, struct comp_dev *dev, int32_t bytes)
-{
-}
-
-int comp_set_state(struct comp_dev *dev, int cmd)
-{
-	return 0;
-}
-
-void ll_schedule_default(struct task *w, uint64_t timeout)
-{
-}
+#endif /* _INCLUDE_HOST_EDF_SCHEDULE_H_ */

--- a/src/include/host/ll_schedule.h
+++ b/src/include/host/ll_schedule.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Intel Corporation
+ * Copyright (c) 2019, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,22 +25,12 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * Author: Tomasz Lauda <tomasz.lauda@linux.intel.com>
- *
+ * Author: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>
  */
 
-/**
- * \file arch/xtensa/up/work.c
- * \brief Xtensa UP work queue implementation file
- * \authors Tomasz Lauda <tomasz.lauda@linux.intel.com>
- */
+#ifndef _INCLUDE_HOST_LL_SCHEDULE_H_
+#define _INCLUDE_HOST_LL_SCHEDULE_H_
 
-#include <sof/work.h>
+extern struct scheduler_ops schedule_ll_ops;
 
-/** \brief Generic system work queue. */
-static struct work_queue *queue;
-
-struct work_queue **arch_work_queue_get(void)
-{
-	return &queue;
-}
+#endif /* _INCLUDE_HOST_LL_SCHEDULE_H_ */

--- a/src/include/sof/agent.h
+++ b/src/include/sof/agent.h
@@ -33,7 +33,7 @@
 
 #include <stdint.h>
 #include <stddef.h>
-#include <sof/work.h>
+#include <sof/schedule.h>
 
 struct sof;
 
@@ -41,7 +41,7 @@ struct sof;
 struct sa {
 	uint64_t last_idle;	/* time of last idle */
 	uint64_t ticks;
-	struct work work;
+	struct task work;
 };
 
 void sa_enter_idle(struct sof *sof);

--- a/src/include/sof/dma-trace.h
+++ b/src/include/sof/dma-trace.h
@@ -39,7 +39,7 @@
 #include <sof/debug.h>
 #include <sof/timer.h>
 #include <sof/dma.h>
-#include <sof/work.h>
+#include <sof/schedule.h>
 #include <platform/platform.h>
 #include <platform/timer.h>
 
@@ -61,7 +61,7 @@ struct dma_trace_data {
 	uint32_t overflow;
 	uint32_t messages;
 	uint32_t host_size;
-	struct work dmat_work;
+	struct task dmat_work;
 	uint32_t enabled;
 	uint32_t copy_in_progress;
 	uint32_t stream_tag;

--- a/src/include/sof/dmic.h
+++ b/src/include/sof/dmic.h
@@ -330,7 +330,7 @@ struct dmic_pdata {
 	uint16_t enable[DMIC_HW_CONTROLLERS];
 	uint32_t state;
 	completion_t drain_complete;
-	struct work dmicwork;
+	struct task dmicwork;
 	int32_t startcount;
 	int32_t gain;
 };

--- a/src/include/sof/edf_schedule.h
+++ b/src/include/sof/edf_schedule.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Intel Corporation
+ * Copyright (c) 2017, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,82 +26,45 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *
  * Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
- *
- * Generic DSP initialisation. This calls architecture and platform specific
- * initialisation functions.
  */
 
+#ifndef __INCLUDE_SOF_EDF_SCHEDULE_H__
+#define __INCLUDE_SOF_EDF_SCHEDULE_H__
+
+#include <stdint.h>
 #include <stddef.h>
-#include <sof/init.h>
-#include <sof/task.h>
-#include <sof/debug.h>
-#include <sof/panic.h>
-#include <sof/alloc.h>
-#include <sof/notifier.h>
+#include <errno.h>
+#include <sof/sof.h>
+#include <sof/lock.h>
+#include <sof/list.h>
+#include <sof/wait.h>
 #include <sof/schedule.h>
-#include <sof/trace.h>
-#include <sof/dma-trace.h>
-#include <sof/pm_runtime.h>
-#include <sof/cpu.h>
-#include <platform/idc.h>
-#include <platform/platform.h>
-#include <platform/memory.h>
+#include <sof/alloc.h>
 
-/* main firmware context */
-static struct sof sof;
+/* schedule tracing */
+#define trace_edf_sch(format, ...) \
+	trace_event(TRACE_CLASS_EDF, format, ##__VA_ARGS__)
 
-int master_core_init(struct sof *sof)
-{
-	int err;
+#define trace_edf_sch_error(format, ...) \
+	trace_error(TRACE_CLASS_EDF, format, ##__VA_ARGS__)
 
-	/* init architecture */
-	trace_point(TRACE_BOOT_ARCH);
-	err = arch_init(sof);
-	if (err < 0)
-		panic(SOF_IPC_PANIC_ARCH);
+#define tracev_edf_sch(format, ...) \
+	tracev_event(TRACE_CLASS_EDF, format, ##__VA_ARGS__)
 
-	/* initialise system services */
-	trace_point(TRACE_BOOT_SYS_HEAP);
-	platform_init_memmap();
-	init_heap(sof);
+struct sof;
 
-	trace_init(sof);
+/* maximun task time slice in microseconds */
+#define SCHEDULE_TASK_MAX_TIME_SLICE	5000
 
-	trace_point(TRACE_BOOT_SYS_NOTE);
-	init_system_notify(sof);
+#define edf_sch_set_pdata(task, data) \
+	task->private = data
 
-	trace_point(TRACE_BOOT_SYS_POWER);
-	pm_runtime_init();
+#define edf_sch_get_pdata(task) task->private
 
-	/* init the platform */
-	err = platform_init(sof);
-	if (err < 0)
-		panic(SOF_IPC_PANIC_PLATFORM);
+struct edf_task_pdata {
+	uint64_t deadline;
+};
 
-	trace_point(TRACE_BOOT_PLATFORM);
+extern struct scheduler_ops schedule_edf_ops;
 
-	/* should not return */
-	err = do_task_master_core(sof);
-
-	return err;
-}
-
-int main(int argc, char *argv[])
-{
-	int err;
-
-	trace_point(TRACE_BOOT_START);
-
-	/* setup context */
-	sof.argc = argc;
-	sof.argv = argv;
-
-	if (cpu_get_id() == PLATFORM_MASTER_CORE_ID)
-		err = master_core_init(&sof);
-	else
-		err = slave_core_init(&sof);
-
-	/* should never get here */
-	panic(SOF_IPC_PANIC_TASK);
-	return err;
-}
+#endif /* __INCLUDE_SOF_EDF_SCHEDULE_H__ */

--- a/src/include/sof/init.h
+++ b/src/include/sof/init.h
@@ -32,12 +32,8 @@
 #define __INCLUDE_INIT_H__
 
 #include <platform/platcfg.h>
-#include <sof/work.h>
 
 struct sof;
-
-extern struct work_queue_timesource
-	platform_generic_queue[PLATFORM_CORE_COUNT];
 
 /* main firmware entry point - argc and argv not currently used */
 int main(int argc, char *argv[]);

--- a/src/include/sof/ipc.h
+++ b/src/include/sof/ipc.h
@@ -139,7 +139,7 @@ int platform_ipc_init(struct ipc *ipc);
 void ipc_free(struct ipc *ipc);
 
 int ipc_process_msg_queue(void);
-void ipc_process_task(void *data);
+uint64_t ipc_process_task(void *data);
 void ipc_schedule_process(struct ipc *ipc);
 
 int ipc_stream_send_position(struct comp_dev *cdev,

--- a/src/include/sof/ssp.h
+++ b/src/include/sof/ssp.h
@@ -34,7 +34,7 @@
 #include <sof/dai.h>
 #include <sof/io.h>
 #include <sof/lock.h>
-#include <sof/work.h>
+#include <sof/schedule.h>
 #include <sof/trace.h>
 #include <sof/wait.h>
 

--- a/src/include/sof/task.h
+++ b/src/include/sof/task.h
@@ -34,7 +34,7 @@
 #include <arch/task.h>
 
 struct sof;
-struct task;
+struct edf_task;
 
 int do_task_master_core(struct sof *sof);
 

--- a/src/include/sof/timer.h
+++ b/src/include/sof/timer.h
@@ -34,6 +34,15 @@
 #include <arch/timer.h>
 #include <stdint.h>
 
+struct timesource_data {
+	struct timer timer;
+	int clk;
+	int notifier;
+	int (*timer_set)(struct timer *t, uint64_t ticks);
+	void (*timer_clear)(struct timer *t);
+	uint64_t (*timer_get)(struct timer *t);
+};
+
 int timer_register(struct timer *timer,
 	void(*handler)(void *arg), void *arg);
 void timer_unregister(struct timer *timer);

--- a/src/include/sof/trace.h
+++ b/src/include/sof/trace.h
@@ -61,7 +61,6 @@
 #define TRACE_BOOT_PLATFORM		0x4000
 
 /* system specific codes */
-#define TRACE_BOOT_SYS_WORK		(TRACE_BOOT_SYS + 0x100)
 #define TRACE_BOOT_SYS_CPU_FREQ		(TRACE_BOOT_SYS + 0x200)
 #define TRACE_BOOT_SYS_HEAP		(TRACE_BOOT_SYS + 0x300)
 #define TRACE_BOOT_SYS_NOTE		(TRACE_BOOT_SYS + 0x400)
@@ -109,9 +108,10 @@
 #define TRACE_CLASS_IDC		(24 << 24)
 #define TRACE_CLASS_CPU		(25 << 24)
 #define TRACE_CLASS_CLK		(26 << 24)
-#define TRACE_CLASS_SCHEDULE	(27 << 24)
+#define TRACE_CLASS_EDF		(27 << 24)
 #define TRACE_CLASS_KPB		(28 << 24)
 #define TRACE_CLASS_SELECTOR	(29 << 24)
+#define TRACE_CLASS_SCHEDULE	(30 << 24)
 
 /* move to config.h */
 #define TRACE	1

--- a/src/include/uapi/user/trace.h
+++ b/src/include/uapi/user/trace.h
@@ -75,9 +75,10 @@ struct system_time {
 #define TRACE_CLASS_POWER	(23 << 24)
 #define TRACE_CLASS_IDC		(24 << 24)
 #define TRACE_CLASS_CPU		(25 << 24)
-#define TRACE_CLASS_SCHEDULE	(27 << 24)
+#define TRACE_CLASS_EDF		(27 << 24)
 #define TRACE_CLASS_KPB		(28 << 24)
 #define TRACE_CLASS_SELECTOR	(29 << 24)
+#define TRACE_CLASS_SCHEDULE	(30 << 24)
 
 #define LOG_ENABLE		1  /* Enable logging */
 #define LOG_DISABLE		0  /* Disable logging */

--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -1259,13 +1259,14 @@ int ipc_process_msg_queue(void)
 	return 0;
 }
 
-void ipc_process_task(void *data)
+uint64_t ipc_process_task(void *data)
 {
 	if (_ipc->host_pending)
 		ipc_platform_do_cmd(_ipc);
+	return 0;
 }
 
 void ipc_schedule_process(struct ipc *ipc)
 {
-	schedule_task(&ipc->ipc_task, 0, 100);
+	schedule_task(&ipc->ipc_task, 0, 100, 0);
 }

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -6,9 +6,10 @@ endif()
 add_local_sources(sof
 	lib.c
 	alloc.c
-	work.c
+	ll_schedule.c
 	notifier.c
 	trace.c
+	edf_schedule.c
 	schedule.c
 	agent.c
 	interrupt.c

--- a/src/lib/agent.c
+++ b/src/lib/agent.c
@@ -59,7 +59,7 @@ void sa_enter_idle(struct sof *sof)
 	sa->last_idle = platform_timer_get(platform_timer);
 }
 
-static uint64_t validate(void *data, uint64_t delay)
+static uint64_t validate(void *data)
 {
 	struct sa *sa = data;
 	uint64_t current;
@@ -94,6 +94,9 @@ void sa_init(struct sof *sof)
 
 	/* set lst idle time to now to give time for boot completion */
 	sa->last_idle = platform_timer_get(platform_timer) + sa->ticks;
-	work_init(&sa->work, validate, sa, WORK_MED_PRI, WORK_ASYNC);
-	work_schedule_default(&sa->work, PLATFORM_IDLE_TIME);
+
+	schedule_task_init(&sa->work, SOF_SCHEDULE_LL, SOF_TASK_PRI_MED,
+			   validate, sa, 0, 0);
+
+	schedule_task(&sa->work, PLATFORM_IDLE_TIME, 0, 0);
 }

--- a/src/lib/edf_schedule.c
+++ b/src/lib/edf_schedule.c
@@ -1,0 +1,549 @@
+/*
+ * Copyright (c) 2017, Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of the Intel Corporation nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
+ */
+
+#include <stdint.h>
+#include <stddef.h>
+#include <errno.h>
+#include <sof/sof.h>
+#include <sof/lock.h>
+#include <sof/list.h>
+#include <sof/stream.h>
+#include <sof/alloc.h>
+#include <sof/debug.h>
+#include <sof/clk.h>
+#include <sof/edf_schedule.h>
+#include <sof/ll_schedule.h>
+#include <platform/timer.h>
+#include <platform/clk.h>
+#include <sof/audio/component.h>
+#include <sof/drivers/timer.h>
+#include <sof/task.h>
+
+struct edf_schedule_data {
+	spinlock_t lock;
+	struct list_item list;	/* list of tasks in priority queue */
+	uint32_t clock;
+};
+
+#define SLOT_ALIGN_TRIES	10
+
+static void schedule_edf(void);
+static void schedule_edf_task(struct task *task, uint64_t start,
+			      uint64_t deadline, uint32_t flags);
+static int schedule_edf_task_cancel(struct task *task);
+static void schedule_edf_task_complete(struct task *task);
+static void schedule_edf_task_running(struct task *task);
+static int schedule_edf_task_init(struct task *task, uint32_t xflags);
+static void schedule_edf_task_free(struct task *task);
+static int edf_scheduler_init(void);
+static void edf_scheduler_free(void);
+
+/*
+ * Simple rescheduler to calculate tasks new start time and deadline if
+ * prevoius deadline was missed. Tries to align at first with current task
+ * timing, but will just add onto current if too far behind current.
+ * XRUNs will be propagated upto the host if we have to reschedule.
+ */
+static inline void edf_reschedule(struct task *task, uint64_t current)
+{
+	int i;
+	struct edf_task_pdata *edf_pdata;
+	uint64_t delta;
+
+	edf_pdata = edf_sch_get_pdata(task);
+	delta = (edf_pdata->deadline - task->start) << 1;
+
+	/* try and align task with current scheduling slots */
+	for (i = 0; i < SLOT_ALIGN_TRIES; i++) {
+		task->start += delta;
+
+		if (task->start > current + delta) {
+			edf_pdata->deadline = task->start + delta;
+			return;
+		}
+	}
+
+	/* task has slipped a lot, so just add delay to current */
+	task->start = current + delta;
+	edf_pdata->deadline = task->start + delta;
+}
+
+/*
+ * Find the first non running task with the earliest deadline.
+ * TODO: Reduce cache invalidations by checking if the currently
+ * running task AND the earliest queued task will both complete before their
+ * deadlines. If so, then schedule the earlier queued task after the currently
+ * running task has completed.
+ */
+static inline struct task *edf_get_next(uint64_t current, struct task *ignore)
+{
+	struct edf_schedule_data *sch =
+		(*arch_schedule_get_data())->edf_sch_data;
+	struct list_item *clist;
+	struct list_item *tlist;
+	uint64_t next_delta = UINT64_MAX;
+	int next_priority = SOF_TASK_PRI_LOW;
+	uint64_t delta;
+	uint64_t deadline;
+	int reschedule = 0;
+	struct task *edf_task_next = NULL;
+	struct task *edf_task;
+	struct edf_task_pdata *edf_pdata;
+
+	/* any tasks in the scheduler ? */
+	if (list_is_empty(&sch->list)) {
+		return NULL;
+	}
+
+	/* check every queued or running task in list */
+	list_for_item_safe(clist, tlist, &sch->list) {
+		edf_task = container_of(clist, struct task, list);
+
+		/* only check queued tasks */
+		if (edf_task->state != SOF_TASK_STATE_QUEUED)
+			continue;
+
+		/* ignore the ignored tasks */
+		if (edf_task == ignore)
+			continue;
+
+		edf_pdata = edf_sch_get_pdata(edf_task);
+
+		deadline = edf_pdata->deadline;
+
+		if (current < deadline) {
+			delta = deadline - current;
+
+			/* get highest priority */
+			if (edf_task->priority > next_priority) {
+				next_priority = edf_task->priority;
+				next_delta = delta;
+				edf_task_next = edf_task;
+			} else if (edf_task->priority == next_priority) {
+				/* get earliest deadline */
+				if (delta < next_delta) {
+					next_delta = delta;
+					edf_task_next = edf_task;
+				}
+			}
+		} else {
+			/* missed scheduling - will be rescheduled */
+			trace_edf_sch("edf_get_next(), "
+				   "missed scheduling - will be rescheduled");
+
+			/* have we already tried to rescheule ? */
+			if (!reschedule) {
+				reschedule++;
+				trace_edf_sch("edf_get_next(), "
+					       "didn't try to reschedule yet");
+				edf_reschedule(edf_task, current);
+			} else {
+				/* reschedule failed */
+				list_item_del(&edf_task->list);
+				edf_task->state = SOF_TASK_STATE_CANCEL;
+			}
+		}
+	}
+
+	return edf_task_next;
+}
+
+/*
+ * EDF Scheduler - Earliest Deadline First Scheduler.
+ *
+ * Schedule task with the earliest deadline from task list.
+ * Can run in IRQ context.
+ */
+static struct task *sch_edf(void)
+{
+	struct edf_schedule_data *sch =
+		(*arch_schedule_get_data())->edf_sch_data;
+	uint64_t current;
+	uint32_t flags;
+
+	struct task *task;
+	struct task *future_task = NULL;
+
+	tracev_edf_sch("sch_edf()");
+
+	interrupt_clear(PLATFORM_SCHEDULE_IRQ);
+
+	while (!list_is_empty(&sch->list)) {
+		spin_lock_irq(&sch->lock, flags);
+
+		/* get the current time */
+		current = platform_timer_get(platform_timer);
+
+		/* get next task to be scheduled */
+		task = edf_get_next(current, NULL);
+		spin_unlock_irq(&sch->lock, flags);
+
+		/* any tasks ? */
+		if (!task)
+			return NULL;
+
+		/* can task be started now ? */
+		if (task->start <= current) {
+			/* yes, run current task */
+			task->start = current;
+
+			/* init task for running */
+			spin_lock_irq(&sch->lock, flags);
+			task->state = SOF_TASK_STATE_PENDING;
+			list_item_del(&task->list);
+			spin_unlock_irq(&sch->lock, flags);
+
+			/* now run task at correct run level */
+			if (run_task(task) < 0) {
+				trace_error(TRACE_CLASS_EDF,
+					    "sch_edf() error");
+				break;
+			}
+		} else {
+			/* no, then schedule wake up */
+			future_task = task;
+			break;
+		}
+	}
+
+	/* tell caller about future task */
+	return future_task;
+}
+
+/* cancel and delete task from scheduler - won't stop it if already running */
+static int schedule_edf_task_cancel(struct task *task)
+{
+	struct edf_schedule_data *sch =
+		(*arch_schedule_get_data())->edf_sch_data;
+	uint32_t flags;
+	int ret = 0;
+
+	tracev_edf_sch("schedule_edf_task_cancel()");
+
+	spin_lock_irq(&sch->lock, flags);
+
+	/* check current task state, delete it if it is queued
+	 * if it is already running, nothing we can do about it atm
+	 */
+	if (task->state == SOF_TASK_STATE_QUEUED) {
+		/* delete task */
+		task->state = SOF_TASK_STATE_CANCEL;
+		list_item_del(&task->list);
+	}
+
+	spin_unlock_irq(&sch->lock, flags);
+
+	return ret;
+}
+
+static int _sch_edf_task(struct task *task, uint64_t start,
+			 uint64_t deadline)
+{
+	struct edf_schedule_data *sch =
+		(*arch_schedule_get_data())->edf_sch_data;
+	uint32_t flags;
+	uint64_t current;
+	uint64_t ticks_per_ms;
+	struct edf_task_pdata *edf_pdata;
+
+	edf_pdata = edf_sch_get_pdata(task);
+
+	tracev_edf_sch("_schedule_edf_task()");
+
+	spin_lock_irq(&sch->lock, flags);
+
+	/* is task already pending ? - not enough MIPS to complete ? */
+	if (task->state == SOF_TASK_STATE_PENDING) {
+		trace_edf_sch("_schedule_edf_task(), task already pending");
+		spin_unlock_irq(&sch->lock, flags);
+		return 0;
+	}
+
+	/* is task already queued ? - not enough MIPS to complete ? */
+	if (task->state == SOF_TASK_STATE_QUEUED) {
+		trace_edf_sch("_schedule_edf_task(), task already queued");
+		spin_unlock_irq(&sch->lock, flags);
+		return 0;
+	}
+
+	/* get the current time */
+	current = platform_timer_get(platform_timer);
+
+	ticks_per_ms = clock_ms_to_ticks(sch->clock, 1);
+
+	/* calculate start time - TODO: include MIPS */
+	if (start == 0)
+		task->start = current;
+	else
+		task->start = task->start + ticks_per_ms * start / 1000 -
+			PLATFORM_SCHEDULE_COST;
+
+	/* calculate deadline - TODO: include MIPS */
+	edf_pdata->deadline = task->start + ticks_per_ms * deadline / 1000;
+
+	/* add task to list */
+	list_item_append(&task->list, &sch->list);
+	task->state = SOF_TASK_STATE_QUEUED;
+	spin_unlock_irq(&sch->lock, flags);
+
+	return 1;
+}
+
+/*
+ * Add a new task to the scheduler to be run and define a scheduling
+ * deadline in time for the task to be ran. Do not invoke the scheduler
+ * immediately to run task, but wait intil schedule is next called.
+ *
+ * deadline is in microseconds relative to start.
+ */
+static void schedule_edf_task_idle(struct task *task, uint64_t deadline)
+{
+	_sch_edf_task(task, 0, deadline);
+}
+
+/*
+ * Add a new task to the scheduler to be run and define a scheduling
+ * window in time for the task to be ran. i.e. task will run between start and
+ * deadline times.
+ *
+ * start is in microseconds relative to last task start time.
+ * deadline is in microseconds relative to start.
+ */
+static void schedule_edf_task_normal(struct task *task, uint64_t start,
+				     uint64_t deadline)
+{
+	int need_sched;
+
+	need_sched = _sch_edf_task(task, start, deadline);
+
+	/* need to run scheduler if task not already running */
+	if (need_sched) {
+		/* rerun scheduler */
+		schedule();
+	}
+}
+
+static void schedule_edf_task(struct task *task, uint64_t start,
+			      uint64_t deadline, uint32_t flags)
+{
+	if (flags & SOF_SCHEDULE_FLAG_IDLE)
+		schedule_edf_task_idle(task, deadline);
+	else
+		schedule_edf_task_normal(task, start, deadline);
+}
+
+/* Remove a task from the scheduler when complete */
+static void schedule_edf_task_complete(struct task *task)
+{
+	struct edf_schedule_data *sch =
+		(*arch_schedule_get_data())->edf_sch_data;
+	uint32_t flags;
+
+	tracev_edf_sch("schedule_edf_task_complete()");
+
+	spin_lock_irq(&sch->lock, flags);
+
+	/* Some high priority HW based IRQ handlers can reschedule tasks
+	 * immediately. i.e. before the task context can change task state
+	 * back to COMPLETED. Check here to make sure we dont clobber
+	 * task->state for regular non IRQ users.
+	 */
+	switch (task->state) {
+	case SOF_TASK_STATE_RUNNING:
+		task->state = SOF_TASK_STATE_COMPLETED;
+		break;
+	case SOF_TASK_STATE_QUEUED:
+	case SOF_TASK_STATE_PENDING:
+		/* nothing to do here, high priority IRQ has scheduled us */
+		break;
+	default:
+		trace_error(TRACE_CLASS_EDF, "unexpected task state %d "
+			"at edf_task completion",
+			task->state);
+		task->state = SOF_TASK_STATE_COMPLETED;
+		break;
+	}
+	spin_unlock_irq(&sch->lock, flags);
+}
+
+/* Update task state to running */
+static void schedule_edf_task_running(struct task *task)
+{
+	struct edf_schedule_data *sch =
+		(*arch_schedule_get_data())->edf_sch_data;
+	uint32_t flags;
+
+	tracev_edf_sch("schedule_edf_task_running()");
+
+	spin_lock_irq(&sch->lock, flags);
+	task->state = SOF_TASK_STATE_RUNNING;
+	spin_unlock_irq(&sch->lock, flags);
+}
+
+static void edf_scheduler_run(void *unused)
+{
+	tracev_edf_sch("edf_scheduler_run()");
+
+	sch_edf();
+}
+
+/* run the scheduler */
+static void schedule_edf(void)
+{
+	struct edf_schedule_data *sch =
+		(*arch_schedule_get_data())->edf_sch_data;
+	struct list_item *tlist;
+	struct task *edf_task;
+
+	uint32_t flags;
+
+	tracev_edf_sch("schedule_edf()");
+
+	spin_lock_irq(&sch->lock, flags);
+
+	/* make sure we have a queued task in the list first before we
+	   start scheduling as contexts switches are not free. */
+	list_for_item(tlist, &sch->list) {
+		edf_task = container_of(tlist, struct task, list);
+
+		/* schedule if we find any queued tasks */
+		if (edf_task->state == SOF_TASK_STATE_QUEUED) {
+			spin_unlock_irq(&sch->lock, flags);
+			goto schedule;
+		}
+	}
+
+	/* no task to schedule */
+	spin_unlock_irq(&sch->lock, flags);
+	return;
+
+schedule:
+	/* TODO: detect current IRQ context and call edf_scheduler_run if both
+	 * current context matches scheduler context. saves a DSP context
+	 * switch.
+	 */
+
+	/* the scheduler is run in IRQ context */
+	interrupt_set(PLATFORM_SCHEDULE_IRQ);
+}
+
+/* Initialise the scheduler */
+static int edf_scheduler_init(void)
+{
+	trace_edf_sch("edf_scheduler_init()");
+
+	struct schedule_data *sch_data = *arch_schedule_get_data();
+	struct edf_schedule_data *sch;
+
+	sch_data->edf_sch_data = rzalloc(RZONE_SYS, SOF_MEM_CAPS_RAM,
+					 sizeof(*sch_data->edf_sch_data));
+
+	sch = sch_data->edf_sch_data;
+
+	list_init(&sch->list);
+	spinlock_init(&sch->lock);
+	sch->clock = PLATFORM_SCHED_CLOCK;
+
+	/* configure scheduler interrupt */
+	interrupt_register(PLATFORM_SCHEDULE_IRQ, IRQ_AUTO_UNMASK,
+			   edf_scheduler_run, NULL);
+	interrupt_enable(PLATFORM_SCHEDULE_IRQ);
+
+	/* allocate arch tasks */
+	int tasks_result = allocate_tasks();
+
+	return tasks_result;
+}
+
+/* Frees scheduler */
+static void edf_scheduler_free(void)
+{
+	struct edf_schedule_data *sch =
+		(*arch_schedule_get_data())->edf_sch_data;
+	uint32_t flags;
+
+	spin_lock_irq(&sch->lock, flags);
+
+	/* disable and unregister scheduler interrupt */
+	interrupt_disable(PLATFORM_SCHEDULE_IRQ);
+	interrupt_unregister(PLATFORM_SCHEDULE_IRQ);
+
+	/* free arch tasks */
+	arch_free_tasks();
+
+	list_item_del(&sch->list);
+
+	spin_unlock_irq(&sch->lock, flags);
+}
+
+static int schedule_edf_task_init(struct task *task, uint32_t xflags)
+{
+	struct edf_task_pdata *edf_pdata;
+	(void)xflags;
+
+	if (edf_sch_get_pdata(task))
+		return -EEXIST;
+
+	edf_pdata = rzalloc(RZONE_SYS_RUNTIME | RZONE_FLAG_UNCACHED,
+			    SOF_MEM_CAPS_RAM, sizeof(*edf_pdata));
+
+	if (!edf_pdata) {
+		trace_edf_sch_error("schedule_edf_task_init() error:"
+				    "alloc failed");
+		return -ENOMEM;
+	}
+
+	edf_sch_set_pdata(task, edf_pdata);
+
+	return 0;
+}
+
+static void schedule_edf_task_free(struct task *task)
+{
+	task->state = SOF_TASK_STATE_FREE;
+	task->func = NULL;
+	task->data = NULL;
+
+	rfree(edf_sch_get_pdata(task));
+	edf_sch_set_pdata(task, NULL);
+}
+
+struct scheduler_ops schedule_edf_ops = {
+	.schedule_task		= schedule_edf_task,
+	.schedule_task_init	= schedule_edf_task_init,
+	.schedule_task_running	= schedule_edf_task_running,
+	.schedule_task_complete = schedule_edf_task_complete,
+	.reschedule_task	= NULL,
+	.schedule_task_cancel	= schedule_edf_task_cancel,
+	.schedule_task_free	= schedule_edf_task_free,
+	.scheduler_init		= edf_scheduler_init,
+	.scheduler_free		= edf_scheduler_free,
+	.scheduler_run		= schedule_edf
+};

--- a/src/lib/schedule.c
+++ b/src/lib/schedule.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Intel Corporation
+ * Copyright (c) 2019, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,459 +25,120 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
+ * Author: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>
  */
 
-#include <stdint.h>
-#include <stddef.h>
-#include <errno.h>
-#include <sof/sof.h>
-#include <sof/lock.h>
-#include <sof/list.h>
-#include <sof/stream.h>
-#include <sof/alloc.h>
-#include <sof/debug.h>
-#include <sof/clk.h>
+/* Generic scheduler */
 #include <sof/schedule.h>
-#include <sof/work.h>
-#include <platform/timer.h>
-#include <platform/clk.h>
-#include <sof/audio/component.h>
-#include <sof/drivers/timer.h>
-#include <sof/task.h>
+#include <sof/edf_schedule.h>
+#include <sof/ll_schedule.h>
 
-struct schedule_data {
-	spinlock_t lock;
-	struct list_item list;	/* list of tasks in priority queue */
-	uint32_t clock;
-	struct work work;
+static const struct scheduler_ops *schedulers[SOF_SCHEDULE_COUNT] = {
+	&schedule_edf_ops,              /* SOF_SCHEDULE_EDF */
+	&schedule_ll_ops		/* SOF_SCHEDULE_LL */
 };
 
-#define SLOT_ALIGN_TRIES	10
-
-/*
- * Simple rescheduler to calculate tasks new start time and deadline if
- * prevoius deadline was missed. Tries to align at first with current task
- * timing, but will just add onto current if too far behind current.
- * XRUNs will be propagated upto the host if we have to reschedule.
- */
-static inline void edf_reschedule(struct task *task, uint64_t current)
+int schedule_task_init(struct task *task, uint16_t type, uint16_t priority,
+		       uint64_t (*func)(void *data), void *data, uint16_t core,
+		       uint32_t xflags)
 {
-	uint64_t delta = (task->deadline - task->start) << 1;
-	int i;
-
-	/* try and align task with current scheduling slots */
-	for (i = 0; i < SLOT_ALIGN_TRIES; i++) {
-
-		task->start += delta;
-
-		if (task->start > current + delta) {
-			task->deadline = task->start + delta;
-			return;
-		}
-	}
-
-	/* task has slipped a lot, so just add delay to current */
-	task->start = current + delta;
-	task->deadline = task->start + delta;
-}
-
-/*
- * Find the first non running task with the earliest deadline.
- * TODO: Reduce cache invalidations by checking if the currently
- * running task AND the earliest queued task will both complete before their
- * deadlines. If so, then schedule the earlier queued task after the currently
- * running task has completed.
- */
-static inline struct task *edf_get_next(uint64_t current,
-	struct task *ignore)
-{
-	struct schedule_data *sch = *arch_schedule_get();
-	struct task *task;
-	struct task *next_task = NULL;
-	struct list_item *clist;
-	struct list_item *tlist;
-	uint64_t next_delta = UINT64_MAX;
-	int next_priority = TASK_PRI_LOW;
-	uint64_t delta;
-	uint64_t deadline;
-	int reschedule = 0;
- 
-	/* any tasks in the scheduler ? */
-	if (list_is_empty(&sch->list)) {
-		return NULL;
-	}
-
-	/* check every queued or running task in list */
-	list_for_item_safe(clist, tlist, &sch->list) {
-		task = container_of(clist, struct task, list);
-
-		/* only check queued tasks */
-		if (task->state != TASK_STATE_QUEUED)
-			continue;
-
-		/* ignore the ignored tasks */
-		if (task == ignore)
-			continue;
-
-		/* include the length of task in deadline calc */
-		deadline = task->deadline - task->max_rtime;
-
-		if (current < deadline) {
-			delta = deadline - current;
-
-			/* get highest priority */
-			if (task->priority < next_priority) {
-				next_priority = task->priority;
-				next_delta = delta;
-				next_task = task;
-			} else if (task->priority == next_priority) {
-				/* get earliest deadline */
-				if (delta < next_delta) {
-					next_delta = delta;
-					next_task = task;
-				}
-			}
-		} else {
-			/* missed scheduling - will be rescheduled */
-			trace_schedule("edf_get_next(), "
-				   "missed scheduling - will be rescheduled");
-
-			/* have we already tried to rescheule ? */
-			if (!reschedule) {
-				reschedule++;
-				trace_schedule("edf_get_next(), "
-					       "didn't try to reschedule yet");
-				edf_reschedule(task, current);
-			} else {
-				/* reschedule failed */
-				list_item_del(&task->list);
-				task->state = TASK_STATE_CANCEL;
-			}
-		}
-	}
-
-	return next_task;
-}
-
-/* work set in the future when next task can be scheduled */
-static uint64_t sch_work(void *data, uint64_t delay)
-{
-	tracev_schedule("sch_work()");
-	schedule();
-	return 0;
-}
-
-/*
- * EDF Scheduler - Earliest Deadline First Scheduler.
- *
- * Schedule task with the earliest deadline from task list.
- * Can run in IRQ context.
- */
-static struct task *schedule_edf(void)
-{
-	struct schedule_data *sch = *arch_schedule_get();
-	struct task *task;
-	struct task *future_task = NULL;
-	uint64_t current;
-	uint32_t flags;
-
-	tracev_schedule("schedule_edf()");
-
-	interrupt_clear(PLATFORM_SCHEDULE_IRQ);
-
-	while (!list_is_empty(&sch->list)) {
-		spin_lock_irq(&sch->lock, flags);
-
-		/* get the current time */
-		current = platform_timer_get(platform_timer);
-
-		/* get next task to be scheduled */
-		task = edf_get_next(current, NULL);
-		spin_unlock_irq(&sch->lock, flags);
-
-		/* any tasks ? */
-		if (!task)
-			return NULL;
-
-		/* can task be started now ? */
-		if (task->start <= current) {
-			/* yes, run current task */
-			task->start = current;
-
-			/* init task for running */
-			spin_lock_irq(&sch->lock, flags);
-			task->state = TASK_STATE_PENDING;
-			list_item_del(&task->list);
-			spin_unlock_irq(&sch->lock, flags);
-
-			/* now run task at correct run level */
-			if (run_task(task) < 0) {
-				trace_error(TRACE_CLASS_SCHEDULE,
-					    "schedule_edf() error");
-				break;
-			}
-		} else {
-			/* no, then schedule wake up */
-			future_task = task;
-			break;
-		}
-	}
-
-	/* tell caller about future task */
-	return future_task;
-}
-
-/* cancel and delete task from scheduler - won't stop it if already running */
-int schedule_task_cancel(struct task *task)
-{
-	struct schedule_data *sch = *arch_schedule_get();
-	uint32_t flags;
 	int ret = 0;
 
-	tracev_schedule("schedule_task_cancel()");
-
-	spin_lock_irq(&sch->lock, flags);
-
-	/* check current task state, delete it if it is queued
-	 * if it is already running, nothing we can do about it atm
-	 */
-	if (task->state == TASK_STATE_QUEUED) {
-		/* delete task */
-		task->state = TASK_STATE_CANCEL;
-		list_item_del(&task->list);
+	if (type >= SOF_SCHEDULE_COUNT) {
+		trace_schedule_error("schedule_task_init() error: "
+				     "invalid task type");
+		ret = -EINVAL;
+		goto out;
 	}
 
-	spin_unlock_irq(&sch->lock, flags);
+	task->type = type;
+	task->priority = priority;
+	task->core = core;
+	task->state = SOF_TASK_STATE_INIT;
+	task->func = func;
+	task->data = data;
+	task->ops = schedulers[task->type];
 
+	if (task->ops->schedule_task_init)
+		ret = task->ops->schedule_task_init(task, xflags);
+out:
 	return ret;
 }
 
-static int _schedule_task(struct task *task, uint64_t start, uint64_t deadline)
+void schedule_task_free(struct task *task)
 {
-	struct schedule_data *sch = *arch_schedule_get();
-	uint32_t flags;
-	uint64_t current;
-	uint64_t ticks_per_ms;
-
-	tracev_schedule("_schedule_task()");
-
-	spin_lock_irq(&sch->lock, flags);
-
-	/* is task already pending ? - not enough MIPS to complete ? */
-	if (task->state == TASK_STATE_PENDING) {
-		trace_schedule("_schedule_task(), task already pending");
-		spin_unlock_irq(&sch->lock, flags);
-		return 0;
-	}
-
-	/* is task already queued ? - not enough MIPS to complete ? */
-	if (task->state == TASK_STATE_QUEUED) {
-		trace_schedule("_schedule_task(), task already queued");
-		spin_unlock_irq(&sch->lock, flags);
-		return 0;
-	}
-
-	/* get the current time */
-	current = platform_timer_get(platform_timer);
-
-	ticks_per_ms = clock_ms_to_ticks(sch->clock, 1);
-
-	/* calculate start time - TODO: include MIPS */
-	if (start == 0)
-		task->start = current;
-	else
-		task->start = task->start + ticks_per_ms * start / 1000 -
-			PLATFORM_SCHEDULE_COST;
-
-	/* calculate deadline - TODO: include MIPS */
-	task->deadline = task->start + ticks_per_ms * deadline / 1000;
-
-	/* add task to list */
-	list_item_append(&task->list, &sch->list);
-	task->state = TASK_STATE_QUEUED;
-	spin_unlock_irq(&sch->lock, flags);
-
-	return 1;
+	if (task->ops->schedule_task_free)
+		task->ops->schedule_task_free(task);
 }
 
-/*
- * Add a new task to the scheduler to be run and define a scheduling
- * deadline in time for the task to be ran. Do not invoke the scheduler
- * immediately to run task, but wait intil schedule is next called.
- *
- * deadline is in microseconds relative to start.
- */
-void schedule_task_idle(struct task *task, uint64_t deadline)
+void schedule_task(struct task *task, uint64_t start, uint64_t deadline,
+		   uint32_t flags)
 {
-	_schedule_task(task, 0, deadline);
+	if (task->ops->schedule_task)
+		task->ops->schedule_task(task, start, deadline, flags);
 }
 
-/*
- * Add a new task to the scheduler to be run and define a scheduling
- * window in time for the task to be ran. i.e. task will run between start and
- * deadline times.
- *
- * start is in microseconds relative to last task start time.
- * deadline is in microseconds relative to start.
- */
-void schedule_task(struct task *task, uint64_t start, uint64_t deadline)
+void reschedule_task(struct task *task, uint64_t start)
 {
-	int need_sched;
-
-	need_sched = _schedule_task(task, start, deadline);
-
-	/* need to run scheduler if task not already running */
-	if (need_sched) {
-		/* rerun scheduler */
-		schedule();
-	}
+	if (task->ops->reschedule_task)
+		task->ops->reschedule_task(task, start);
 }
 
-/* Remove a task from the scheduler when complete */
-void schedule_task_complete(struct task *task)
+int schedule_task_cancel(struct task *task)
 {
-	struct schedule_data *sch = *arch_schedule_get();
-	uint32_t flags;
-
-	tracev_schedule("schedule_task_complete()");
-
-	spin_lock_irq(&sch->lock, flags);
-
-	/* Some high priority HW based IRQ handlers can reschedule tasks
-	 * immediately. i.e. before the task context can change task state
-	 * back to COMPLETED. Check here to make sure we dont clobber
-	 * task->state for regular non IRQ users.
-	 */
-	switch (task->state) {
-	case TASK_STATE_RUNNING:
-		task->state = TASK_STATE_COMPLETED;
-		break;
-	case TASK_STATE_QUEUED:
-	case TASK_STATE_PENDING:
-		/* nothing to do here, high priority IRQ has scheduled us */
-		break;
-	default:
-		trace_error(TRACE_CLASS_SCHEDULE, "unexpected task state %d "
-			"at task completion",
-			task->state);
-		task->state = TASK_STATE_COMPLETED;
-		break;
-	}
-	spin_unlock_irq(&sch->lock, flags);
-
-	/* tell any waiter that task has completed */
-	wait_completed(&task->complete);
+	if (task->ops->schedule_task_cancel)
+		return task->ops->schedule_task_cancel(task);
+	return 0;
 }
 
-/* Update task state to running */
 void schedule_task_running(struct task *task)
 {
-	struct schedule_data *sch = *arch_schedule_get();
-	uint32_t flags;
-
-	tracev_schedule("schedule_task_running()");
-
-	spin_lock_irq(&sch->lock, flags);
-	task->state = TASK_STATE_RUNNING;
-	spin_unlock_irq(&sch->lock, flags);
+	if (task->ops->schedule_task_running)
+		task->ops->schedule_task_running(task);
 }
 
-static void scheduler_run(void *unused)
+void schedule_task_complete(struct task *task)
 {
-	struct task *future_task;
-
-	tracev_schedule("scheduler_run()");
-
-	/* EDF is only scheduler supported atm */
-	future_task = schedule_edf();
-	if (future_task)
-		work_reschedule_default_at(&((*arch_schedule_get())->work),
-					   future_task->start);
+	if (task->ops->schedule_task_complete)
+		task->ops->schedule_task_complete(task);
 }
 
-/* run the scheduler */
-void schedule(void)
+int scheduler_init(void)
 {
-	struct schedule_data *sch = *arch_schedule_get();
-	struct list_item *tlist;
-	struct task *task;
-	uint32_t flags;
+	struct schedule_data **sch = arch_schedule_get_data();
+	int i = 0;
+	int ret = 0;
 
-	tracev_schedule("schedule()");
-
-	spin_lock_irq(&sch->lock, flags);
-
-	/* make sure we have a queued task in the list first before we
-	   start scheduling as contexts switches are not free. */
-	list_for_item(tlist, &sch->list) {
-		task = container_of(tlist, struct task, list);
-
-		/* schedule if we find any queued tasks */
-		if (task->state == TASK_STATE_QUEUED) {
-			spin_unlock_irq(&sch->lock, flags);
-			goto schedule;
-		}
-	}
-
-	/* no task to schedule */
-	spin_unlock_irq(&sch->lock, flags);
-	return;
-
-schedule:
-	/* TODO: detect current IRQ context and call scheduler_run if both
-	 * current context matches scheduler context. saves a DSP context
-	 * switch.
-	 */
-
-	/* the scheduler is run in IRQ context */
-	interrupt_set(PLATFORM_SCHEDULE_IRQ);
-}
-
-/* Initialise the scheduler */
-int scheduler_init(struct sof *sof)
-{
-	trace_schedule("scheduler_init()");
-
-	struct schedule_data **sch = arch_schedule_get();
+	/* init scheduler_data */
 	*sch = rzalloc(RZONE_SYS, SOF_MEM_CAPS_RAM, sizeof(**sch));
 
-	if (!*sch)
-		return -ENOMEM;
-
-	list_init(&((*sch)->list));
-	spinlock_init(&((*sch)->lock));
-	(*sch)->clock = PLATFORM_SCHED_CLOCK;
-	work_init(&((*sch)->work), sch_work, *sch, WORK_MED_PRI, WORK_ASYNC);
-
-	/* configure scheduler interrupt */
-	interrupt_register(PLATFORM_SCHEDULE_IRQ, IRQ_AUTO_UNMASK,
-			   scheduler_run, NULL);
-	interrupt_enable(PLATFORM_SCHEDULE_IRQ);
-
-	/* allocate arch tasks */
-	int tasks_result = allocate_tasks();
-
-	return tasks_result;
+	for (i = 0; i < SOF_SCHEDULE_COUNT; i++) {
+		if (schedulers[i]->scheduler_init) {
+			ret = schedulers[i]->scheduler_init();
+			if (ret < 0)
+				goto out;
+		}
+	}
+out:
+	return ret;
 }
 
-/* Frees scheduler */
-void scheduler_free(void)
+void schedule_free(void)
 {
-	struct schedule_data **sch = arch_schedule_get();
-	uint32_t flags;
+	int i;
 
-	spin_lock_irq(&(*sch)->lock, flags);
+	for (i = 0; i < SOF_SCHEDULE_COUNT; i++) {
+		if (schedulers[i]->scheduler_free)
+			schedulers[i]->scheduler_free();
+	}
+}
 
-	/* disable and unregister scheduler interrupt */
-	interrupt_disable(PLATFORM_SCHEDULE_IRQ);
-	interrupt_unregister(PLATFORM_SCHEDULE_IRQ);
+void schedule(void)
+{
+	int i = 0;
 
-	/* free arch tasks */
-	arch_free_tasks();
-
-	work_cancel_default(&(*sch)->work);
-	list_item_del(&(*sch)->list);
-
-	spin_unlock_irq(&(*sch)->lock, flags);
+	for (i = 0; i < SOF_SCHEDULE_COUNT; i++) {
+		if (schedulers[i]->scheduler_run)
+			schedulers[i]->scheduler_run();
+	}
 }

--- a/src/lib/wait.c
+++ b/src/lib/wait.c
@@ -36,7 +36,7 @@
 #include <sof/io.h>
 #include <sof/debug.h>
 #include <sof/wait.h>
-#include <sof/work.h>
+#include <sof/schedule.h>
 #include <sof/timer.h>
 #include <sof/interrupt.h>
 #include <sof/trace.h>
@@ -54,7 +54,7 @@ int wait_for_completion_timeout(completion_t *comp)
 {
 	volatile completion_t *c = (volatile completion_t *)comp;
 
-	work_schedule_default(&comp->work, comp->timeout);
+	schedule_task(&comp->work, comp->timeout, 0, 0);
 	comp->timeout = 0;
 
 	/* check for completion after every wake from IRQ */
@@ -64,7 +64,7 @@ int wait_for_completion_timeout(completion_t *comp)
 	/* did we complete */
 	if (c->complete) {
 		/* no timeout so cancel work and return 0 */
-		work_cancel_default(&comp->work);
+		schedule_task_cancel(&comp->work);
 
 		return 0;
 	}

--- a/src/platform/baytrail/platform.c
+++ b/src/platform/baytrail/platform.c
@@ -44,7 +44,6 @@
 #include <sof/dma.h>
 #include <sof/interrupt.h>
 #include <sof/sof.h>
-#include <sof/work.h>
 #include <sof/clk.h>
 #include <sof/ipc.h>
 #include <sof/trace.h>
@@ -137,7 +136,7 @@ static const struct sof_ipc_window sram_window = {
 	},
 };
 
-struct work_queue_timesource platform_generic_queue[] = {
+struct timesource_data platform_generic_queue[] = {
 {
 	.timer	 = {
 		.id = TIMER3,	/* external timer */
@@ -215,9 +214,9 @@ int platform_init(struct sof *sof)
 	trace_point(TRACE_BOOT_PLATFORM_CLOCK);
 	clock_init();
 
-	/* init work queues and clocks */
-	trace_point(TRACE_BOOT_SYS_WORK);
-	init_system_workq(&platform_generic_queue[PLATFORM_MASTER_CORE_ID]);
+	/* init scheduler and clocks */
+	trace_point(TRACE_BOOT_SYS_SCHED);
+	scheduler_init();
 
 	trace_point(TRACE_BOOT_PLATFORM_TIMER);
 	platform_timer_start(platform_timer);

--- a/src/platform/haswell/platform.c
+++ b/src/platform/haswell/platform.c
@@ -42,7 +42,6 @@
 #include <sof/dma.h>
 #include <sof/interrupt.h>
 #include <sof/sof.h>
-#include <sof/work.h>
 #include <sof/clk.h>
 #include <sof/ipc.h>
 #include <sof/trace.h>
@@ -136,7 +135,7 @@ static const struct sof_ipc_window sram_window = {
 	},
 };
 
-struct work_queue_timesource platform_generic_queue[] = {
+struct timesource_data platform_generic_queue[] = {
 {
 	.timer	 = {
 		.id = TIMER1,	/* internal timer */
@@ -204,9 +203,9 @@ int platform_init(struct sof *sof)
 	trace_point(TRACE_BOOT_PLATFORM_CLOCK);
 	clock_init();
 
-	/* init work queues and clocks */
-	trace_point(TRACE_BOOT_SYS_WORK);
-	init_system_workq(&platform_generic_queue[PLATFORM_MASTER_CORE_ID]);
+	/* init scheduler and clocks */
+	trace_point(TRACE_BOOT_SYS_SCHED);
+	scheduler_init();
 
 	trace_point(TRACE_BOOT_PLATFORM_TIMER);
 	platform_timer_start(platform_timer);

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -46,7 +46,6 @@
 #include <sof/dma.h>
 #include <sof/sof.h>
 #include <sof/agent.h>
-#include <sof/work.h>
 #include <sof/clk.h>
 #include <sof/ipc.h>
 #include <sof/io.h>
@@ -151,7 +150,7 @@ static const struct sof_ipc_window sram_window = {
 };
 #endif
 
-struct work_queue_timesource platform_generic_queue[] = {
+struct timesource_data platform_generic_queue[] = {
 {
 	.timer	 = {
 		.id = TIMER3, /* external timer */
@@ -429,8 +428,8 @@ int platform_init(struct sof *sof)
 	trace_point(TRACE_BOOT_PLATFORM_CLOCK);
 	clock_init();
 
-	trace_point(TRACE_BOOT_SYS_WORK);
-	init_system_workq(&platform_generic_queue[PLATFORM_MASTER_CORE_ID]);
+	trace_point(TRACE_BOOT_SYS_SCHED);
+	scheduler_init();
 
 	/* init the system agent */
 	sa_init(sof);

--- a/src/tasks/audio.c
+++ b/src/tasks/audio.c
@@ -41,7 +41,7 @@
 #include <platform/interrupt.h>
 #include <platform/shim.h>
 #include <sof/audio/pipeline.h>
-#include <sof/work.h>
+#include <sof/schedule.h>
 #include <sof/debug.h>
 #include <sof/trace.h>
 #include <stdint.h>

--- a/test/cmocka/src/audio/kpb/kpb_mock.c
+++ b/test/cmocka/src/audio/kpb/kpb_mock.c
@@ -39,14 +39,18 @@ int comp_set_state(struct comp_dev *dev, int cmd)
 	return 0;
 }
 
-void work_schedule_default(struct work *w, uint64_t timeout)
-{
-}
-
 void notifier_register(struct notifier *notifier)
 {
 }
 
-void schedule_task(struct task *task, uint64_t start, uint64_t deadline)
+int schedule_task_init(struct task *task, uint16_t type, uint16_t priority,
+		       uint64_t (*func)(void *data), void *data, uint16_t core,
+		       uint32_t xflags)
+{
+	return 0;
+}
+
+void schedule_task(struct task *task, uint64_t start, uint64_t deadline,
+		   uint32_t flags)
 {
 }

--- a/test/cmocka/src/audio/pipeline/pipeline_connect_upstream.c
+++ b/test/cmocka/src/audio/pipeline/pipeline_connect_upstream.c
@@ -31,7 +31,7 @@
 #include <stdint.h>
 #include <sof/audio/component.h>
 #include <sof/audio/pipeline.h>
-#include <sof/schedule.h>
+#include <sof/edf_schedule.h>
 #include "pipeline_mocks.h"
 #include "pipeline_connection_mocks.h"
 #include <stdarg.h>

--- a/test/cmocka/src/audio/pipeline/pipeline_connection_mocks.h
+++ b/test/cmocka/src/audio/pipeline/pipeline_connection_mocks.h
@@ -30,7 +30,7 @@
 
 #include <sof/audio/component.h>
 #include <sof/audio/pipeline.h>
-#include <sof/schedule.h>
+#include <sof/edf_schedule.h>
 #include <stdarg.h>
 #include <stddef.h>
 #include <setjmp.h>

--- a/test/cmocka/src/audio/pipeline/pipeline_free.c
+++ b/test/cmocka/src/audio/pipeline/pipeline_free.c
@@ -31,7 +31,7 @@
 #include <stdint.h>
 #include <sof/audio/component.h>
 #include <sof/audio/pipeline.h>
-#include <sof/schedule.h>
+#include <sof/edf_schedule.h>
 #include "pipeline_mocks.h"
 #include "pipeline_connection_mocks.h"
 #include <stdarg.h>
@@ -95,7 +95,7 @@ static void test_audio_pipeline_free_sheduler_task_free(void **state)
 	/*Testing component*/
 	pipeline_free(&result);
 
-	assert_int_equal(result.pipe_task.state, TASK_STATE_FREE);
+	assert_int_equal(result.pipe_task.state, SOF_TASK_STATE_FREE);
 	assert_ptr_equal(NULL, result.pipe_task.data);
 	assert_ptr_equal(NULL, result.pipe_task.func);
 }

--- a/test/cmocka/src/audio/pipeline/pipeline_mocks.c
+++ b/test/cmocka/src/audio/pipeline/pipeline_mocks.c
@@ -43,22 +43,42 @@ void platform_dai_timestamp(struct comp_dev *dai,
 	(void)posn;
 }
 
-void schedule_task(struct task *task, uint64_t start, uint64_t deadline)
+void schedule_task_free(struct task *task)
+{
+	(void)task;
+	task->state = SOF_TASK_STATE_FREE;
+	task->func = NULL;
+	task->data = NULL;
+}
+
+void schedule_edf_task_idle(struct task *task, uint64_t deadline)
 {
 	(void)deadline;
+	(void)task;
+}
+
+void schedule_task(struct task *task, uint64_t start, uint64_t deadline,
+		   uint32_t flags)
+{
+	(void)task;
 	(void)start;
-	(void)task;
-}
-
-void schedule_task_complete(struct task *task)
-{
-	(void)task;
-}
-
-void schedule_task_idle(struct task *task, uint64_t deadline)
-{
 	(void)deadline;
+	(void)flags;
+}
+
+int schedule_task_init(struct task *task, uint16_t type, uint16_t priority,
+		       uint64_t (*func)(void *data), void *data, uint16_t core,
+		       uint32_t xflags)
+{
 	(void)task;
+	(void)type;
+	(void)priority;
+	(void)func;
+	(void)data;
+	(void)core;
+	(void)xflags;
+
+	return 0;
 }
 
 int schedule_task_cancel(struct task *task)

--- a/test/cmocka/src/audio/pipeline/pipeline_mocks.h
+++ b/test/cmocka/src/audio/pipeline/pipeline_mocks.h
@@ -30,7 +30,7 @@
 
 #include <sof/audio/component.h>
 #include <sof/audio/pipeline.h>
-#include <sof/schedule.h>
+#include <sof/edf_schedule.h>
 #include <stdarg.h>
 #include <stddef.h>
 #include <setjmp.h>

--- a/test/cmocka/src/audio/pipeline/pipeline_mocks_rzalloc.c
+++ b/test/cmocka/src/audio/pipeline/pipeline_mocks_rzalloc.c
@@ -30,7 +30,7 @@
 
 #include <sof/audio/component.h>
 #include <sof/audio/pipeline.h>
-#include <sof/schedule.h>
+#include <sof/edf_schedule.h>
 #include <stdarg.h>
 #include <stddef.h>
 #include <setjmp.h>

--- a/test/cmocka/src/audio/pipeline/pipeline_new.c
+++ b/test/cmocka/src/audio/pipeline/pipeline_new.c
@@ -72,35 +72,6 @@ static void test_audio_pipeline_pipeline_new_creation(void **state)
 	assert_non_null(result);
 }
 
-static void test_audio_pipeline_new_sheduler_init(void **state)
-{
-	struct pipeline_new_setup_data *test_data = *state;
-
-	/*Testing component*/
-	struct pipeline *result = pipeline_new(&test_data->ipc_data,
-	test_data->comp_data);
-
-	/*Check if all parameters are passed to sheduler
-	 *(initialization)
-	 */
-	assert_int_equal(result->pipe_task.state, TASK_STATE_INIT);
-	assert_int_equal(result->pipe_task.core, test_data->ipc_data.core);
-}
-
-static void test_audio_pipeline_new_sheduler_config(void **state)
-{
-	struct pipeline_new_setup_data *test_data = *state;
-
-	/*Testing component*/
-	struct pipeline *result = pipeline_new(&test_data->ipc_data,
-	test_data->comp_data);
-
-	/*Pipeline should end in pre init state untli sheduler runs
-	 *task that initializes it
-	 */
-	assert_int_equal(COMP_STATE_INIT, result->status);
-}
-
 static void test_audio_pipeline_new_ipc_data_coppy(void **state)
 {
 	struct pipeline_new_setup_data *test_data = *state;
@@ -115,11 +86,8 @@ static void test_audio_pipeline_new_ipc_data_coppy(void **state)
 
 int main(void)
 {
-
 	const struct CMUnitTest tests[] = {
 		cmocka_unit_test(test_audio_pipeline_pipeline_new_creation),
-		cmocka_unit_test(test_audio_pipeline_new_sheduler_init),
-		cmocka_unit_test(test_audio_pipeline_new_sheduler_config),
 		cmocka_unit_test(test_audio_pipeline_new_ipc_data_coppy),
 	};
 

--- a/test/cmocka/src/audio/pipeline/pipeline_new_allocation.c
+++ b/test/cmocka/src/audio/pipeline/pipeline_new_allocation.c
@@ -31,7 +31,7 @@
 #include <stdint.h>
 #include <sof/audio/component.h>
 #include <sof/audio/pipeline.h>
-#include <sof/schedule.h>
+#include <sof/edf_schedule.h>
 #include "pipeline_mocks.h"
 #include <stdarg.h>
 #include <stddef.h>

--- a/test/cmocka/src/audio/pipeline/pipeline_new_allocation_mocks.c
+++ b/test/cmocka/src/audio/pipeline/pipeline_new_allocation_mocks.c
@@ -30,7 +30,7 @@
 
 #include <sof/audio/component.h>
 #include <sof/audio/pipeline.h>
-#include <sof/schedule.h>
+#include <sof/edf_schedule.h>
 #include <stdarg.h>
 #include <stddef.h>
 #include <setjmp.h>

--- a/tools/logger/convert.c
+++ b/tools/logger/convert.c
@@ -96,9 +96,10 @@ static const char * get_component_name(uint32_t component_id) {
 		CASE(SA);
 		CASE(DMIC);
 		CASE(POWER);
-		CASE(SCHEDULE);
+		CASE(EDF);
 		CASE(KPB);
 		CASE(SELECTOR);
+		CASE(SCHEDULE);
 	default: return "unknown";
 	}
 }


### PR DESCRIPTION
This PR provides generic scheduler API. Source API code is placed in schedule (.c/.h) sources.
Specific existing schedulers were renamed:
1. schedule (.c/.h) -> edf_schedule (.c/.h)
2. work (.c/.h) -> ll_schedule (.c/.h)

Each scheduler export structure with pointers to its own, specific functions. API using task type, selects proper scheduler specific function and calls it. 