### PR TITLE
KPB: search for real time sink

### DIFF
--- a/src/include/sof/audio/kpb.h
+++ b/src/include/sof/audio/kpb.h
@@ -128,7 +128,7 @@ struct comp_data {
 	struct task draining_task;
 	uint32_t source_period_bytes; /**< source number of period bytes */
 	uint32_t sink_period_bytes; /**< sink number of period bytes */
-
+	struct comp_buffer *rt_sink; /**< real time sink (channel selector ) */
 };
 
 #endif

--- a/test/cmocka/src/audio/kpb/kpb_buffer.c
+++ b/test/cmocka/src/audio/kpb/kpb_buffer.c
@@ -116,6 +116,7 @@ static int buffering_test_setup(void **state)
 	sink->w_ptr = sink_data;
 	kpb_dev_mock->bsource_list.next = &source->sink_list;
 	kpb_dev_mock->bsink_list.next = &sink->source_list;
+	((struct comp_data *)kpb_dev_mock->private)->rt_sink = sink;
 
 	return 0;
 }


### PR DESCRIPTION
This change allows host to keep real time
sink at any position - not forced to be the
very first sink. Pointer to the sink itself
has been added to component private data
therefore .copy takes slightly less resources.

Signed-off-by: Marcin Rajwa <marcin.rajwa@linux.intel.com>