### PR TITLE
Memory: self registering ability for audio components

### DIFF
--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -227,7 +227,15 @@ void comp_set_period_bytes(struct comp_dev *dev, uint32_t frames,
 
 void sys_comp_init(void)
 {
+	extern intptr_t _comp_init_start, _comp_init_end;
+
 	cd = rzalloc(RZONE_SYS, SOF_MEM_CAPS_RAM, sizeof(*cd));
 	list_init(&cd->list);
 	spinlock_init(&cd->lock);
+
+	intptr_t *comp_init = (intptr_t *)(&_comp_init_start);
+
+	for (; comp_init < (intptr_t *)&_comp_init_end; ++comp_init) {
+		((void(*)(void))(*comp_init))();
+	}
 }

--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -799,7 +799,11 @@ static struct comp_driver comp_dai = {
 	},
 };
 
+void sys_comp_dai_init(void);
+
 void sys_comp_dai_init(void)
 {
 	comp_register(&comp_dai);
 }
+
+DECLARE_COMPONENT(sys_comp_dai_init);

--- a/src/audio/eq_fir.c
+++ b/src/audio/eq_fir.c
@@ -804,7 +804,11 @@ struct comp_driver comp_eq_fir = {
 	},
 };
 
+void sys_comp_eq_fir_init(void);
+
 void sys_comp_eq_fir_init(void)
 {
 	comp_register(&comp_eq_fir);
 }
+
+DECLARE_COMPONENT(sys_comp_eq_fir_init);

--- a/src/audio/eq_iir.c
+++ b/src/audio/eq_iir.c
@@ -923,7 +923,11 @@ struct comp_driver comp_eq_iir = {
 	},
 };
 
+void sys_comp_eq_iir_init(void);
+
 void sys_comp_eq_iir_init(void)
 {
 	comp_register(&comp_eq_iir);
 }
+
+DECLARE_COMPONENT(sys_comp_eq_iir_init);

--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -803,7 +803,11 @@ struct comp_driver comp_host = {
 	},
 };
 
+void sys_comp_host_init(void);
+
 void sys_comp_host_init(void)
 {
 	comp_register(&comp_host);
 }
+
+DECLARE_COMPONENT(sys_comp_host_init);

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -524,7 +524,11 @@ struct comp_driver comp_kpb = {
 	},
 };
 
+void sys_comp_kpb_init(void);
+
 void sys_comp_kpb_init(void)
 {
 	comp_register(&comp_kpb);
 }
+
+DECLARE_COMPONENT(sys_comp_kpb_init);

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -405,7 +405,11 @@ struct comp_driver comp_mixer = {
 	},
 };
 
+void sys_comp_mixer_init(void);
+
 void sys_comp_mixer_init(void)
 {
 	comp_register(&comp_mixer);
 }
+
+DECLARE_COMPONENT(sys_comp_mixer_init);

--- a/src/audio/mux.c
+++ b/src/audio/mux.c
@@ -97,7 +97,11 @@ struct comp_driver comp_mux = {
 	},
 };
 
+void sys_comp_mux_init(void);
+
 void sys_comp_mux_init(void)
 {
 	comp_register(&comp_mux);
 }
+
+DECLARE_COMPONENT(sys_comp_mux_init);

--- a/src/audio/selector.c
+++ b/src/audio/selector.c
@@ -50,7 +50,6 @@
 #include "selector.h"
 #include <sof/math/numbers.h>
 
-
 /**
  * \brief Validates channel count and index and sets channel count.
  * \details If input data is not supported trace error is displayed and
@@ -467,8 +466,12 @@ struct comp_driver comp_selector = {
 	},
 };
 
+void sys_comp_selector_init(void);
+
 /** \brief Initializes selector component. */
 void sys_comp_selector_init(void)
 {
 	comp_register(&comp_selector);
 }
+
+DECLARE_COMPONENT(sys_comp_selector_init);

--- a/src/audio/src.c
+++ b/src/audio/src.c
@@ -971,7 +971,11 @@ struct comp_driver comp_src = {
 	},
 };
 
+void sys_comp_src_init(void);
+
 void sys_comp_src_init(void)
 {
 	comp_register(&comp_src);
 }
+
+DECLARE_COMPONENT(sys_comp_src_init);

--- a/src/audio/switch.c
+++ b/src/audio/switch.c
@@ -97,7 +97,11 @@ struct comp_driver comp_switch = {
 	},
 };
 
+void sys_comp_switch_init(void);
+
 void sys_comp_switch_init(void)
 {
 	comp_register(&comp_switch);
 }
+
+DECLARE_COMPONENT(sys_comp_switch_init);

--- a/src/audio/tone.c
+++ b/src/audio/tone.c
@@ -756,7 +756,11 @@ struct comp_driver comp_tone = {
 	},
 };
 
+void sys_comp_tone_init(void);
+
 void sys_comp_tone_init(void)
 {
 	comp_register(&comp_tone);
 }
+
+DECLARE_COMPONENT(sys_comp_tone_init);

--- a/src/audio/volume.c
+++ b/src/audio/volume.c
@@ -663,6 +663,8 @@ struct comp_driver comp_volume = {
 	},
 };
 
+void sys_comp_volume_init(void);
+
 /**
  * \brief Initializes volume component.
  */
@@ -670,3 +672,5 @@ void sys_comp_volume_init(void)
 {
 	comp_register(&comp_volume);
 }
+
+DECLARE_COMPONENT(sys_comp_volume_init);

--- a/src/host/testbench.c
+++ b/src/host/testbench.c
@@ -54,6 +54,9 @@ static int fr_id; /* comp id for fileread */
 static int fw_id; /* comp id for filewrite */
 static int sched_id; /* comp id for scheduling comp */
 
+/* compatible variables, not used */
+intptr_t _comp_init_start, _comp_init_end;
+
 /*
  * Parse shared library from user input
  * Currently only handles volume and src comp

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -140,6 +140,17 @@
 #define COMP_CMD_IPC_MMAP_VOL(chan)	(216 + chan)	/**< Volume */
 /** @}*/
 
+/** \name Declare component macro
+ *  \brief Usage at the end of comp file: DECLARE_COMPONENT(sys_comp_*_init);
+ *  @{
+ */
+#ifdef CHECK
+#define DECLARE_COMPONENT(init)
+#else
+#define DECLARE_COMPONENT(init) __attribute__((__used__)) \
+	__attribute__((section(".comp_init"))) static void(*f)(void) = init
+#endif
+
 /** \name Trace macros
  *  @{
  */
@@ -493,64 +504,6 @@ static inline void comp_cache(struct comp_dev *dev, int cmd)
  * To be called once at boot time.
  */
 void sys_comp_init(void);
-
-/* default base component initialisations */
-#ifdef CONFIG_COMP_DAI
-void sys_comp_dai_init(void);
-#else
-static inline void sys_comp_dai_init(void) {}
-#endif
-void sys_comp_host_init(void);
-#ifdef CONFIG_COMP_MIXER
-void sys_comp_mixer_init(void);
-#else
-static inline void sys_comp_mixer_init(void) {}
-#endif
-#ifdef CONFIG_COMP_MUX
-void sys_comp_mux_init(void);
-#else
-static inline void sys_comp_mux_init(void) {}
-#endif
-#ifdef CONFIG_COMP_SWITCH
-void sys_comp_switch_init(void);
-#else
-static inline void sys_comp_switch_init(void) {}
-#endif
-#ifdef CONFIG_COMP_VOLUME
-void sys_comp_volume_init(void);
-#else
-static inline void sys_comp_volume_init(void) {}
-#endif
-#ifdef CONFIG_COMP_SRC
-void sys_comp_src_init(void);
-#else
-static inline void sys_comp_src_init(void) {}
-#endif
-#ifdef CONFIG_COMP_TONE
-void sys_comp_tone_init(void);
-#else
-static inline void sys_comp_tone_init(void) {}
-#endif
-#ifdef CONFIG_COMP_IIR
-void sys_comp_eq_iir_init(void);
-#else
-static inline void sys_comp_eq_iir_init(void) {}
-#endif
-#ifdef CONFIG_COMP_FIR
-void sys_comp_eq_fir_init(void);
-#else
-static inline void sys_comp_eq_fir_init(void) {}
-#endif
-#ifdef CONFIG_COMP_KPB
-void sys_comp_kpb_init(void);
-#else
-static inline void sys_comp_kpb_init(void) {}
-#endif
-#ifdef CONFIG_COMP_SEL
-void sys_comp_selector_init(void);
-#else
-static inline void sys_comp_selector_init(void) {}
-#endif
 
 /** @}*/
 

--- a/src/platform/apollolake/apollolake.x.in
+++ b/src/platform/apollolake/apollolake.x.in
@@ -438,6 +438,13 @@ SECTIONS
     _rodata_end = ABSOLUTE(.);
   } >sof_fw :sof_fw_phdr
 
+  .comp_init : ALIGN(4)
+  {
+    _comp_init_start = ABSOLUTE(.);
+    *(*.comp_init)
+    _comp_init_end = ABSOLUTE(.);
+  } >sof_fw :sof_fw_phdr
+
   .data : ALIGN(4)
   {
     _data_start = ABSOLUTE(.);

--- a/src/platform/baytrail/baytrail.x.in
+++ b/src/platform/baytrail/baytrail.x.in
@@ -376,6 +376,13 @@ SECTIONS
     _rodata_end = ABSOLUTE(.);
   } >sof_data :sof_data_phdr
 
+  .comp_init : ALIGN(4)
+  {
+    _comp_init_start = ABSOLUTE(.);
+    *(*.comp_init)
+    _comp_init_end = ABSOLUTE(.);
+  } >sof_data :sof_data_phdr
+
   .data : ALIGN(4)
   {
     _data_start = ABSOLUTE(.);

--- a/src/platform/cannonlake/cannonlake.x.in
+++ b/src/platform/cannonlake/cannonlake.x.in
@@ -400,6 +400,13 @@ SECTIONS
     _rodata_end = ABSOLUTE(.);
   } >sof_fw :sof_fw_phdr
 
+  .comp_init : ALIGN(4)
+  {
+    _comp_init_start = ABSOLUTE(.);
+    *(*.comp_init)
+    _comp_init_end = ABSOLUTE(.);
+  } >sof_fw :sof_fw_phdr
+
   .data : ALIGN(4)
   {
     _data_start = ABSOLUTE(.);

--- a/src/platform/haswell/haswell.x.in
+++ b/src/platform/haswell/haswell.x.in
@@ -376,6 +376,13 @@ SECTIONS
     _rodata_end = ABSOLUTE(.);
   } >sof_data :sof_data_phdr
 
+  .comp_init : ALIGN(4)
+  {
+    _comp_init_start = ABSOLUTE(.);
+    *(*.comp_init)
+    _comp_init_end = ABSOLUTE(.);
+  } >sof_data :sof_data_phdr
+
   .data : ALIGN(4)
   {
     _data_start = ABSOLUTE(.);

--- a/src/platform/icelake/icelake.x.in
+++ b/src/platform/icelake/icelake.x.in
@@ -404,6 +404,13 @@ SECTIONS
     _rodata_end = ABSOLUTE(.);
   } >sof_fw :sof_fw_phdr
 
+  .comp_init : ALIGN(4)
+  {
+    _comp_init_start = ABSOLUTE(.);
+    *(*.comp_init)
+    _comp_init_end = ABSOLUTE(.);
+  } >sof_fw :sof_fw_phdr
+
   .data : ALIGN(4)
   {
     _data_start = ABSOLUTE(.);

--- a/src/platform/suecreek/suecreek.x.in
+++ b/src/platform/suecreek/suecreek.x.in
@@ -407,6 +407,13 @@ SECTIONS
     _rodata_end = ABSOLUTE(.);
   } >sof_data :sof_data_phdr
 
+  .comp_init : ALIGN(4)
+  {
+    _comp_init_start = ABSOLUTE(.);
+    *(*.comp_init)
+    _comp_init_end = ABSOLUTE(.);
+  } >sof_data :sof_data_phdr
+
   .data : ALIGN(4)
   {
     _data_start = ABSOLUTE(.);

--- a/src/tasks/audio.c
+++ b/src/tasks/audio.c
@@ -54,18 +54,6 @@ int do_task_master_core(struct sof *sof)
 
 	/* init default audio components */
 	sys_comp_init();
-	sys_comp_dai_init();
-	sys_comp_host_init();
-	sys_comp_mixer_init();
-	sys_comp_mux_init();
-	sys_comp_switch_init();
-	sys_comp_volume_init();
-	sys_comp_src_init();
-	sys_comp_tone_init();
-	sys_comp_eq_iir_init();
-	sys_comp_eq_fir_init();
-	sys_comp_selector_init();
-	sys_comp_kpb_init();
 
 #if STATIC_PIPE
 	/* init static pipeline */

--- a/test/cmocka/memory_mock.x.in
+++ b/test/cmocka/memory_mock.x.in
@@ -6,5 +6,7 @@ SECTIONS
       *(*.static_log*)
     }
 
+    _comp_init_start = .;
+    _comp_init_end = .;
 }
 INSERT AFTER .text;


### PR DESCRIPTION
No more need to update global component.h and audio.c component init list

New macro DECLARE_COMPONENT
The component can "register itself" in the appropriate linker section
sys_comp_init() will iterate over all registered components

Example of usage:
DECLARE_COMPONENT(sys_comp_dai_init);

Signed-off-by: Adrian Bonislawski <adrian.bonislawski@linux.intel.com>