### PR TITLE
memory: fix extensive, continuous memory blocks allocation

### DIFF
--- a/src/include/sof/alloc.h
+++ b/src/include/sof/alloc.h
@@ -94,7 +94,8 @@ struct block_map {
 } __attribute__ ((__aligned__(PLATFORM_DCACHE_ALIGN)));
 
 #define BLOCK_DEF(sz, cnt, hdr) \
-	{.block_size = sz, .count = cnt, .free_count = cnt, .block = hdr}
+	{.block_size = sz, .count = cnt, .free_count = cnt, .block = hdr, \
+	 .first_free = 0}
 
 struct mm_heap {
 	uint32_t blocks;


### PR DESCRIPTION
This commit fixes a problem with memory allocation of big
areas of memory dedicated i.e for buffers. The calculation of
remainnig blocks of memory was incorect and disallowed usage
of available blocks.

Signed-off-by: Marcin Rajwa <marcin.rajwa@linux.intel.com>