### PR TITLE
comp: selector: add support for binary configuration data

### DIFF
--- a/src/audio/selector.c
+++ b/src/audio/selector.c
@@ -93,9 +93,9 @@ static int sel_set_channel_values(struct comp_data *cd, uint32_t in_channels,
 		return -EINVAL;
 	}
 
-	cd->in_channels_count = in_channels;
-	cd->out_channels_count = out_channels;
-	cd->sel_channel = ch_idx;
+	cd->config.in_channels_count = in_channels;
+	cd->config.out_channels_count = out_channels;
+	cd->config.sel_channel = ch_idx;
 
 	return 0;
 }
@@ -180,9 +180,9 @@ static int selector_params(struct comp_dev *dev)
 
 	/* rewrite channels number for other components */
 	if (dev->params.direction == SOF_IPC_STREAM_PLAYBACK)
-		dev->params.channels = cd->out_channels_count;
+		dev->params.channels = cd->config.out_channels_count;
 	else
-		dev->params.channels = cd->in_channels_count;
+		dev->params.channels = cd->config.in_channels_count;
 
 	return 0;
 }
@@ -194,13 +194,30 @@ static int selector_params(struct comp_dev *dev)
  * \param[in,out] cdata Control command data.
  * \return Error code.
  */
-static int selector_ctrl_set_cmd(struct comp_dev *dev,
-				 struct sof_ipc_ctrl_data *cdata)
+static int selector_ctrl_set_data(struct comp_dev *dev,
+				  struct sof_ipc_ctrl_data *cdata)
 {
-	/* TODO add implementation aligned with SW assumptions */
-	trace_selector("selector_ctrl_set_cmd(), cdata->cmd = %u", cdata->cmd);
+	struct comp_data *cd = comp_get_drvdata(dev);
+	struct sof_sel_config *cfg;
+	int ret = 0;
 
-	return 0;
+	switch (cdata->cmd) {
+		case SOF_CTRL_CMD_BINARY:
+		trace_selector("selector_ctrl_set_data(), SOF_CTRL_CMD_BINARY");
+
+		cfg = (struct sof_sel_config *)cdata->data->data;
+		/* Just copy the configuration & verify input params.*/
+		ret = sel_set_channel_values(cd, cfg->in_channels_count,
+				  cfg->out_channels_count, cfg->sel_channel);
+		break;
+	default:
+		trace_selector_error("selector_ctrl_set_cmd() error: "
+				     "invalid cdata->cmd = %u", cdata->cmd);
+		ret = -EINVAL;
+		break;
+	}
+
+	return ret;
 }
 
 /**
@@ -210,15 +227,36 @@ static int selector_ctrl_set_cmd(struct comp_dev *dev,
  * \param[in] size Command data size.
  * \return Error code.
  */
-static int selector_ctrl_get_cmd(struct comp_dev *dev,
-				 struct sof_ipc_ctrl_data *cdata, int size)
+static int selector_ctrl_get_data(struct comp_dev *dev,
+				  struct sof_ipc_ctrl_data *cdata, int size)
 {
-	/* TODO add implementation aligned with SW assumptions */
-	cdata->cmd = SOF_CTRL_CMD_ENUM;
-	trace_selector("selector_ctrl_get_cmd(), cdata->cmd = %u",
-		       cdata->index);
+	struct comp_data *cd = comp_get_drvdata(dev);
 
-	return 0;
+	int ret = 0;
+
+	switch (cdata->cmd) {
+	case SOF_CTRL_CMD_BINARY:
+		trace_selector("selector_ctrl_get_data(), SOF_CTRL_CMD_BINARY");
+
+		/* Copy back to user space */
+		ret = memcpy_s(cdata->data->data, ((struct sof_abi_hdr *)
+			      (cdata->data))->size, &(cd->config),
+			      sizeof(cd->config));
+		if (ret < 0)
+			return ret;
+
+		cdata->data->abi = SOF_ABI_VERSION;
+		cdata->data->size = sizeof(cd->config);
+		break;
+
+	default:
+		trace_selector_error("selector_ctrl_get_data() error:"
+				     "invalid cdata->cmd");
+		ret = -EINVAL;
+		break;
+	}
+
+	return ret;
 }
 
 /**
@@ -233,17 +271,29 @@ static int selector_cmd(struct comp_dev *dev, int cmd, void *data,
 			int max_data_size)
 {
 	struct sof_ipc_ctrl_data *cdata = data;
+	int ret = 0;
 
 	trace_selector("selector_cmd()");
 
 	switch (cmd) {
+	case COMP_CMD_SET_DATA:
+		ret = selector_ctrl_set_data(dev, cdata);
+		break;
+	case COMP_CMD_GET_DATA:
+		ret = selector_ctrl_get_data(dev, cdata, max_data_size);
+		break;
 	case COMP_CMD_SET_VALUE:
-		return selector_ctrl_set_cmd(dev, cdata);
+		trace_selector("selector_cmd(), COMP_CMD_SET_VALUE");
+		break;
 	case COMP_CMD_GET_VALUE:
-		return selector_ctrl_get_cmd(dev, cdata, max_data_size);
+		trace_selector("selector_cmd(), COMP_CMD_GET_VALUE");
+		break;
 	default:
-		return -EINVAL;
+		trace_selector_error("selector_cmd() error: invalid command");
+		ret = -EINVAL;
 	}
+
+	return ret;
 }
 
 /**
@@ -397,7 +447,7 @@ static int selector_prepare(struct comp_dev *dev)
 				     "cd->sink_format = %u, "
 				     "cd->out_channels_count = %u",
 				     cd->source_format, cd->sink_format,
-				     cd->out_channels_count);
+				     cd->config.out_channels_count);
 		ret = -EINVAL;
 		goto err;
 	}

--- a/src/audio/selector.h
+++ b/src/audio/selector.h
@@ -63,22 +63,25 @@
 #define SEL_SINK_2CH 2
 #define SEL_SINK_4CH 4
 
+/** \brief Selector component configuration data. */
+struct sof_sel_config {
+	/* selector supports 1 input and 1 output */
+	uint32_t in_channels_count;	/**< accepted values 2 or 4 */
+	uint32_t out_channels_count;	/**< accepted values 1 or 2 or 4 */
+	/* note: if 2 or 4 output channels selected the component works in
+	 * a passthrough mode
+	 */
+	uint32_t sel_channel;	/**< 0..3 */
+};
+
+
 /** \brief Selector component private data. */
 struct comp_data {
 	uint32_t source_period_bytes;	/**< source number of period bytes */
 	uint32_t sink_period_bytes;	/**< sink number of period bytes */
 	enum sof_ipc_frame source_format;	/**< source frame format */
 	enum sof_ipc_frame sink_format;		/**< sink frame format */
-
-	/* selector supports 1 input and 1 output */
-	uint32_t in_channels_count;	/**< accepted values 2 or 4 */
-	uint32_t out_channels_count;	/**< accepted values 1 or 2 or 4 */
-
-	/* note: if 2 or 4 output channels selected the component works in
-	 * a passthrough mode
-	 */
-	uint32_t sel_channel;	/**< 0..3 */
-
+	struct sof_sel_config config;	/**< component configuration data */
 	/**< channel selector processing function */
 	void (*sel_func)(struct comp_dev *dev, struct comp_buffer *sink,
 		struct comp_buffer *source, uint32_t frames);

--- a/src/audio/selector_generic.c
+++ b/src/audio/selector_generic.c
@@ -51,9 +51,9 @@ static void sel_s16le_1ch(struct comp_dev *dev, struct comp_buffer *sink,
 	int16_t *dest;
 	uint32_t i;
 	uint32_t j = 0;
-	uint32_t nch = cd->in_channels_count;
+	uint32_t nch = cd->config.in_channels_count;
 
-	for (i = cd->sel_channel; i < frames * nch; i += nch) {
+	for (i = cd->config.sel_channel; i < frames * nch; i += nch) {
 		src = buffer_read_frag_s16(source, i);
 		dest = buffer_write_frag_s16(sink, j++);
 		*dest = *src;
@@ -75,9 +75,9 @@ static void sel_s32le_1ch(struct comp_dev *dev, struct comp_buffer *sink,
 	int32_t *dest;
 	uint32_t i;
 	uint32_t j = 0;
-	uint32_t nch = cd->in_channels_count;
+	uint32_t nch = cd->config.in_channels_count;
 
-	for (i = cd->sel_channel; i < frames * nch; i += nch) {
+	for (i = cd->config.sel_channel; i < frames * nch; i += nch) {
 		src = buffer_read_frag_s32(source, i);
 		dest = buffer_write_frag_s32(sink, j++);
 		*dest = *src;
@@ -102,7 +102,7 @@ static void sel_s16le_nch(struct comp_dev *dev, struct comp_buffer *sink,
 	uint32_t channel;
 
 	for (i = 0; i < frames; i++) {
-		for (channel = 0; channel < cd->in_channels_count; channel++) {
+		for (channel = 0; channel < cd->config.in_channels_count; channel++) {
 			src = buffer_read_frag_s16(source, j);
 			dest = buffer_write_frag_s16(sink, j);
 			*dest = *src;
@@ -129,7 +129,7 @@ static void sel_s32le_nch(struct comp_dev *dev, struct comp_buffer *sink,
 	uint32_t channel;
 
 	for (i = 0; i < frames; i++) {
-		for (channel = 0; channel < cd->in_channels_count; channel++) {
+		for (channel = 0; channel < cd->config.in_channels_count; channel++) {
 			src = buffer_read_frag_s32(source, j);
 			dest = buffer_write_frag_s32(sink, j);
 			*dest = *src;
@@ -159,7 +159,7 @@ sel_func sel_get_processing_function(struct comp_dev *dev)
 	for (i = 0; i < ARRAY_SIZE(func_table); i++) {
 		if (cd->source_format != func_table[i].source)
 			continue;
-		if (cd->out_channels_count != func_table[i].out_channels)
+		if (cd->config.out_channels_count != func_table[i].out_channels)
 			continue;
 
 		/* TODO: add additional criteria as needed */

--- a/test/cmocka/src/audio/selector/selector_test.c
+++ b/test/cmocka/src/audio/selector/selector_test.c
@@ -78,9 +78,9 @@ static int setup(void **state)
 	cd->sink_format = parameters->sink_format;
 	
 	/* prepare paramters that will be used by sel_get_processing_function */
-	cd->in_channels_count = parameters->in_channels;
-	cd->out_channels_count = parameters->out_channels;
-	cd->sel_channel = parameters->sel_channel;
+	cd->config.in_channels_count = parameters->in_channels;
+	cd->config.out_channels_count = parameters->out_channels;
+	cd->config.sel_channel = parameters->sel_channel;
 
 	cd->sel_func = sel_get_processing_function(sel_state->dev);
 
@@ -88,7 +88,7 @@ static int setup(void **state)
 	sel_state->sink = test_malloc(sizeof(*sel_state->sink));
 	sel_state->dev->params.frame_fmt = parameters->sink_format;
 	size = parameters->frames * comp_frame_bytes(sel_state->dev);
-	if(cd->out_channels_count == SEL_SINK_1CH){
+	if (cd->config.out_channels_count == SEL_SINK_1CH){
 		size = size / sel_state->dev->params.channels;
 	}
 	sel_state->sink->w_ptr = test_calloc(parameters->buffer_size_ms,
@@ -154,7 +154,7 @@ static void verify_s16le_Xch_to_1ch(struct comp_dev *dev, struct comp_buffer *si
 	struct comp_data *cd = comp_get_drvdata(dev);
 	const uint16_t *src = (uint16_t *)source->r_ptr;
 	const uint16_t *dst = (uint16_t *)sink->w_ptr;
-	uint32_t in_channels = cd->in_channels_count;
+	uint32_t in_channels = cd->config.in_channels_count;
 	uint32_t channel;
 	uint32_t i;
 	uint32_t j = 0;
@@ -163,8 +163,8 @@ static void verify_s16le_Xch_to_1ch(struct comp_dev *dev, struct comp_buffer *si
 
 	for (i = 0; i < source->size / sizeof(uint16_t); i += in_channels) {
 		for (channel = 0; channel < in_channels; channel++) {
-			if (channel == cd->sel_channel) {
-				source_in = src[i + cd->sel_channel];
+			if (channel == cd->config.sel_channel) {
+				source_in = src[i + cd->config.sel_channel];
 				destination = dst[j++];
 				assert_int_equal(source_in, destination);
 			}
@@ -178,7 +178,7 @@ static void verify_s32le_Xch_to_1ch(struct comp_dev *dev, struct comp_buffer *si
 	struct comp_data *cd = comp_get_drvdata(dev);
 	const uint32_t *src = (uint32_t *)source->r_ptr;
 	const uint32_t *dst = (uint32_t *)sink->w_ptr;
-	uint32_t in_channels = cd->in_channels_count;
+	uint32_t in_channels = cd->config.in_channels_count;
 	uint32_t channel;
 	uint32_t i;
 	uint32_t j = 0;
@@ -187,8 +187,8 @@ static void verify_s32le_Xch_to_1ch(struct comp_dev *dev, struct comp_buffer *si
 
 	for (i = 0; i < source->size / sizeof(uint32_t); i += in_channels) {
 		for (channel = 0; channel < in_channels; channel++) {
-			if (channel == cd->sel_channel) {
-				source_in = src[i + cd->sel_channel];
+			if (channel == cd->config.sel_channel) {
+				source_in = src[i + cd->config.sel_channel];
 				destination = dst[j++];
 				assert_int_equal(source_in, destination);
 			}


### PR DESCRIPTION
Channel selector component extended with support for configuration get/set using
COMP_CMD_GET_DATA & COMP_CMD_SET_DATA commands of SOF_CTRL_CMD_BINARY type.