### PR TITLE
logger: add channel selector component name

### DIFF
--- a/src/include/uapi/user/trace.h
+++ b/src/include/uapi/user/trace.h
@@ -76,6 +76,7 @@ struct system_time {
 #define TRACE_CLASS_IDC		(24 << 24)
 #define TRACE_CLASS_CPU		(25 << 24)
 #define TRACE_CLASS_SCHEDULE	(27 << 24)
+#define TRACE_CLASS_SELECTOR	(29 << 24)
 
 #define LOG_ENABLE		1  /* Enable logging */
 #define LOG_DISABLE		0  /* Disable logging */

--- a/tools/logger/convert.c
+++ b/tools/logger/convert.c
@@ -97,6 +97,7 @@ static const char * get_component_name(uint32_t component_id) {
 		CASE(DMIC);
 		CASE(POWER);
 		CASE(SCHEDULE);
+		CASE(SELECTOR);
 	default: return "unknown";
 	}
 }


### PR DESCRIPTION
Logger will display a proper component name for traces
from channel selector component.

Signed-off-by: Lech Betlej <lech.betlej@linux.intel.com>