### PR TITLE
topology:sof-byt-rt5651: add virtual widgets for machine driver compa…

### DIFF
--- a/tools/topology/sof-byt-rt5651.m4
+++ b/tools/topology/sof-byt-rt5651.m4
@@ -87,3 +87,6 @@ DAI_CONFIG(SSP, 2, 0, SSP2-Codec,
 		      SSP_CLOCK(fsync, 48000, codec_slave),
 		      SSP_TDM(2, 25, 3, 3),
 		      SSP_CONFIG_DATA(SSP, 2, 24)))
+
+VIRTUAL_WIDGET(ssp2 Rx, out_drv, 1)
+VIRTUAL_WIDGET(ssp2 Tx, out_drv, 2)


### PR DESCRIPTION
…tibitlity

Add virtual widgets for ssp2 RX/TX for compatibility with the
bytcr_rt5651 machine driver. This is needed now because a recent
change in the driver removed these from the dai definitions
which results in card registration failure.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>