### PR TITLE
Tone: Remove not used version macro from ABI header

### DIFF
--- a/src/include/uapi/user/tone.h
+++ b/src/include/uapi/user/tone.h
@@ -31,11 +31,6 @@
 #ifndef __INCLUDE_UAPI_USER_TONE_H__
 #define __INCLUDE_UAPI_USER_TONE_H__
 
-/* Component will reject non-matching configuration. The version number need
- * to be incremented with any ABI changes in function fir_cmd().
- */
-#define SOF_TONE_ABI_VERSION		1
-
 #define SOF_TONE_IDX_FREQUENCY		0
 #define SOF_TONE_IDX_AMPLITUDE		1
 #define SOF_TONE_IDX_FREQ_MULT		2


### PR DESCRIPTION
The SOF_TONE_ABI_VERSION macro is no more used. This change is
also needed to match with kernel side header.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>