### PR TITLE
 dw-dma: enable interrupts based on the scheduling mode

### DIFF
--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -293,6 +293,7 @@ static int dai_playback_params(struct comp_dev *dev)
 	config->src_width = comp_sample_bytes(dev);
 	config->dest_width = comp_sample_bytes(dev);
 	config->cyclic = 1;
+	config->irq_disabled = pipeline_is_timer_driven(dev->pipeline);
 	config->dest_dev = dd->dai->plat_data.fifo[0].handshake;
 
 	/* set up local and host DMA elems to reset values */
@@ -343,6 +344,7 @@ static int dai_capture_params(struct comp_dev *dev)
 	/* set up DMA configuration */
 	config->direction = DMA_DIR_DEV_TO_MEM;
 	config->cyclic = 1;
+	config->irq_disabled = pipeline_is_timer_driven(dev->pipeline);
 	config->src_dev = dd->dai->plat_data.fifo[1].handshake;
 
 	/* TODO: Make this code platform-specific or move it driver callback */

--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -572,6 +572,7 @@ static int host_params(struct comp_dev *dev)
 	config->src_width = comp_sample_bytes(dev);
 	config->dest_width = comp_sample_bytes(dev);
 	config->cyclic = 0;
+	config->irq_disabled = pipeline_is_timer_driven(dev->pipeline);
 
 #if CONFIG_DMA_GW
 	dev->params.stream_tag -= 1;

--- a/src/include/sof/audio/pipeline.h
+++ b/src/include/sof/audio/pipeline.h
@@ -123,6 +123,12 @@ static inline bool pipeline_is_preload(struct pipeline *p)
 	return p->preload;
 }
 
+/* checks if pipeline is scheduled with timer */
+static inline bool pipeline_is_timer_driven(struct pipeline *p)
+{
+	return p->ipc_pipe.timer_delay;
+}
+
 /* pipeline creation and destruction */
 struct pipeline *pipeline_new(struct sof_ipc_pipe_new *pipe_desc,
 	struct comp_dev *cd);

--- a/src/include/sof/dma.h
+++ b/src/include/sof/dma.h
@@ -127,6 +127,7 @@ struct dma_sg_config {
 	uint32_t cyclic;			/* circular buffer */
 	struct dma_sg_elem_array elem_array;	/* array of dma_sg elems */
 	bool scatter;
+	bool irq_disabled;
 };
 
 struct dma_chan_status {

--- a/src/ipc/ipc.c
+++ b/src/ipc/ipc.c
@@ -541,6 +541,7 @@ int ipc_get_page_descriptors(struct dma *dmac, uint8_t *page_table,
 	config.src_width = sizeof(uint32_t);
 	config.dest_width = sizeof(uint32_t);
 	config.cyclic = 0;
+	config.irq_disabled = false;
 	dma_sg_init(&config.elem_array);
 
 	/* set up DMA descriptor */


### PR DESCRIPTION
Adds new functionality to DW-DMA driver to enable/disable
interrupts based on the pipeline scheduling mode. If
we are scheduling on timer there is no need to touch
any irq related registers.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>