### PR TITLE
memory: prework for memcpy calls change

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,6 +4,7 @@ if(BUILD_HOST)
 	add_subdirectory(ipc)
 	add_subdirectory(audio)
 	add_subdirectory(host)
+	add_subdirectory(lib)
 	return()
 endif()
 

--- a/src/arch/host/include/arch/string.h
+++ b/src/arch/host/include/arch/string.h
@@ -33,6 +33,8 @@
 #define __INCLUDE_ARCH_STRING_SOF__
 
 #include <errno.h>
+#include <string.h>
+#include <stdlib.h>
 
 #define arch_memcpy(dest, src, size) \
 	memcpy(dest, src, size)

--- a/src/arch/xtensa/include/arch/string.h
+++ b/src/arch/xtensa/include/arch/string.h
@@ -33,6 +33,8 @@
 #define __INCLUDE_ARCH_STRING_SOF__
 
 #include <errno.h>
+#include <stdlib.h>
+#include <string.h>
 
 #define arch_memcpy(dest, src, size) \
 	xthal_memcpy(dest, src, size)

--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -65,7 +65,7 @@
 #include <platform/interrupt.h>
 #include <errno.h>
 #include <stdint.h>
-#include <string.h>
+#include <sof/string.h>
 #include <config.h>
 
 /* channel registers */

--- a/src/gdb/gdb.c
+++ b/src/gdb/gdb.c
@@ -35,7 +35,7 @@
 #include <sof/gdb/gdb.h>
 #include <sof/gdb/ringbuffer.h>
 #include <arch/gdb/xtensa-defs.h>
-#include <string.h>
+#include <sof/string.h>
 #include <signal.h>
 #include <stdint.h>
 #include <xtensa/xtruntime.h>

--- a/src/host/CMakeLists.txt
+++ b/src/host/CMakeLists.txt
@@ -4,10 +4,11 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 add_executable(testbench "")
 add_local_sources(testbench testbench.c)
 
-target_link_libraries(testbench PRIVATE -ldl -lm)
-target_link_libraries(testbench PRIVATE sof_ipc tb_common sof_audio_core)
-
 add_library(tb_common STATIC "")
+target_link_libraries(testbench PRIVATE -ldl -lm)
+target_link_libraries(testbench PRIVATE sof_ipc sof_audio_core tb_common)
+
+
 target_link_libraries(tb_common sof_options)
 add_local_sources(tb_common
 	alloc.c

--- a/src/host/common_test.c
+++ b/src/host/common_test.c
@@ -36,7 +36,7 @@
 #include <time.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
+#include <sof/string.h>
 #include <math.h>
 #include <arch/sof.h>
 #include <sof/task.h>

--- a/src/host/topology.c
+++ b/src/host/topology.c
@@ -36,7 +36,7 @@
 
 #include <sof/ipc.h>
 #include <stdio.h>
-#include <string.h>
+#include <sof/string.h>
 #include <dlfcn.h>
 #include <sof/audio/component.h>
 #include "host/topology.h"

--- a/src/include/sof/alloc.h
+++ b/src/include/sof/alloc.h
@@ -32,7 +32,8 @@
 #ifndef __INCLUDE_ALLOC__
 #define __INCLUDE_ALLOC__
 
-#include <string.h>
+#include <stdlib.h>
+#include <sof/string.h>
 #include <stdint.h>
 #include <sof/bit.h>
 #include <sof/platform.h>

--- a/src/include/sof/string.h
+++ b/src/include/sof/string.h
@@ -35,6 +35,8 @@
 
 /* C memcpy for arch that don't have arch_memcpy() */
 void cmemcpy(void *dest, void *src, size_t size);
+int rstrlen(const char *s);
+int rstrcmp(const char *s1, const char *s2);
 
 #if defined(arch_memcpy)
 #define rmemcpy(dest, src, size) \

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -1,3 +1,8 @@
+if(BUILD_HOST)
+	add_local_sources(tb_common lib.c )
+	return()
+endif()
+
 add_local_sources(sof
 	lib.c
 	alloc.c

--- a/src/platform/baytrail/dai.c
+++ b/src/platform/baytrail/dai.c
@@ -38,7 +38,7 @@
 #include <platform/dma.h>
 #include <platform/dai.h>
 #include <stdint.h>
-#include <string.h>
+#include <sof/string.h>
 #include <config.h>
 
 static struct dai ssp[] = {

--- a/src/platform/baytrail/dma.c
+++ b/src/platform/baytrail/dma.c
@@ -34,7 +34,7 @@
 #include <platform/interrupt.h>
 #include <platform/dma.h>
 #include <stdint.h>
-#include <string.h>
+#include <sof/string.h>
 
 static struct dw_drv_plat_data dmac0 = {
 	.chan[0] = {

--- a/src/platform/baytrail/include/platform/interrupt.h
+++ b/src/platform/baytrail/include/platform/interrupt.h
@@ -32,7 +32,7 @@
 #define __INCLUDE_PLATFORM_INTERRUPT__
 
 #include <stdint.h>
-#include <string.h>
+#include <sof/string.h>
 #include <sof/interrupt-map.h>
 
 /* IRQ numbers */

--- a/src/platform/baytrail/platform.c
+++ b/src/platform/baytrail/platform.c
@@ -55,7 +55,7 @@
 #include <sof/cpu.h>
 #include <sof/notifier.h>
 #include <config.h>
-#include <string.h>
+#include <sof/string.h>
 #include <version.h>
 
 static const struct sof_ipc_fw_ready ready

--- a/src/platform/haswell/dai.c
+++ b/src/platform/haswell/dai.c
@@ -38,7 +38,7 @@
 #include <platform/dma.h>
 #include <platform/dai.h>
 #include <stdint.h>
-#include <string.h>
+#include <sof/string.h>
 #include <config.h>
 
 static struct dai ssp[2] = {

--- a/src/platform/haswell/dma.c
+++ b/src/platform/haswell/dma.c
@@ -34,7 +34,7 @@
 #include <platform/interrupt.h>
 #include <platform/dma.h>
 #include <stdint.h>
-#include <string.h>
+#include <sof/string.h>
 
 static struct dw_drv_plat_data dmac0 = {
 	.chan[0] = {

--- a/src/platform/haswell/platform.c
+++ b/src/platform/haswell/platform.c
@@ -54,7 +54,7 @@
 #include <sof/cpu.h>
 #include <sof/notifier.h>
 #include <config.h>
-#include <string.h>
+#include <sof/string.h>
 #include <version.h>
 
 static const struct sof_ipc_fw_ready ready

--- a/src/platform/intel/cavs/dai.c
+++ b/src/platform/intel/cavs/dai.c
@@ -44,7 +44,7 @@
 #include <platform/dma.h>
 #include <platform/dai.h>
 #include <stdint.h>
-#include <string.h>
+#include <sof/string.h>
 #include <config.h>
 
 #if CONFIG_CAVS_SSP

--- a/src/platform/intel/cavs/dma.c
+++ b/src/platform/intel/cavs/dma.c
@@ -38,7 +38,7 @@
 #include <platform/interrupt.h>
 #include <platform/dma.h>
 #include <stdint.h>
-#include <string.h>
+#include <sof/string.h>
 
 #if defined(CONFIG_APOLLOLAKE)
 #define DMAC0_CLASS 1

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -57,7 +57,7 @@
 #include <sof/notifier.h>
 #include <sof/spi.h>
 #include <config.h>
-#include <string.h>
+#include <sof/string.h>
 #include <version.h>
 #include <sof/cavs-version.h>
 

--- a/test/cmocka/CMakeLists.txt
+++ b/test/cmocka/CMakeLists.txt
@@ -51,6 +51,10 @@ add_custom_command(OUTPUT ${memory_mock_lds_out}
 )
 
 add_custom_target(ld_script_memory_mock DEPENDS ${memory_mock_lds_out})
+SET(arch_src ${PROJECT_SOURCE_DIR}/src/arch/xtensa/smp/idc.c)
+add_library(universal_mock STATIC ${PROJECT_SOURCE_DIR}/test/cmocka/src/universal_mocks.c)
+target_link_libraries(universal_mock PRIVATE sof_options)
+link_libraries(universal_mock)
 
 # creates exectuable for new test and adds it as test for ctest
 function(cmocka_test test_name)

--- a/test/cmocka/src/universal_mocks.c
+++ b/test/cmocka/src/universal_mocks.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Intel Corporation
+ * Copyright (c) 2019, Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,54 +25,26 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
- *
+ * Author: Jakub Dabek <jakub.dabek@linux.intel.com>
  */
 
-#ifndef __INCLUDE_ARCH_SOF__
-#define __INCLUDE_ARCH_SOF__
+#include <errno.h>
+#include <sof/alloc.h>
 
-#include <stdint.h>
-#include <stdlib.h>
-#include <stddef.h>
-#include <sof/string.h>
-#include <stdio.h>
-#include <execinfo.h>
-
-/* architecture specific stack frames to dump */
-#define ARCH_STACK_DUMP_FRAMES		32
-
-/* data cache line alignment */
-#define PLATFORM_DCACHE_ALIGN	sizeof(uint32_t)
-
-#define PLATFORM_HEAP_SYSTEM		1
-#define PLATFORM_HEAP_SYSTEM_RUNTIME	1
-#define PLATFORM_HEAP_RUNTIME		1
-#define PLATFORM_HEAP_BUFFER		3
-
-static inline void *arch_get_stack_ptr(void)
+int memcpy_s(void *dest, size_t dest_size,
+	     const void *src, size_t src_size)
 {
-	void *frames[ARCH_STACK_DUMP_FRAMES];
-	size_t frame_count;
-	size_t i;
-	char **symbols;
+	if (!dest || !src)
+		return -EINVAL;
 
-	frame_count = backtrace(frames, ARCH_STACK_DUMP_FRAMES);
-	symbols = backtrace_symbols(frames, frame_count);
+	if ((dest + dest_size >= src && dest + dest_size <= src + src_size) ||
+		(src + src_size >= dest && src + src_size <= dest + dest_size))
+		return -EINVAL;
 
-	fprintf(stderr, "Dumping %zd stack frames.\n", frame_count);
+	if (src_size > dest_size)
+		return -EINVAL;
 
-	for (i = 0; i < frame_count; i++)
-		fprintf(stderr, "\t%s\n", symbols[i]);
+	memcpy(dest, src, src_size);
 
-	free(symbols);
-
-	return NULL;
+	return 0;
 }
-
-static inline void *arch_dump_regs(void)
-{
-	return NULL;
-}
-
-#endif


### PR DESCRIPTION
Prepared host build and whole solution to use new memcpy_s
Fixed string.h dependencies

Signed-off-by: Jakub Dabek <jakub.dabek@linux.intel.com>