### PR TITLE
dw-dma: fix the failure of dmic dai initialization on HDA platform

### DIFF
--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -286,8 +286,8 @@ struct dma_ptr_data {
 
 /* data for each DMA channel */
 struct dma_chan_data {
-	uint32_t status;
-	uint32_t direction;
+	uint16_t status;
+	uint16_t direction;
 	struct dw_lli2 *lli;
 	struct dw_lli2 *lli_current;
 	uint32_t desc_count;


### PR DESCRIPTION
Dmic is failed to initialize dw-dma when working with HDA dais
because there is no suitable block in system_runtime heap. There
are three types of block size in system_runtime heap: 64, 512 and
1024 bytes. The size of dma_pdata is 516 bytes, so it could only be allocated
from the 1024 sized block but there is no such free block.

The value of Status in dma_pdata is only range from COMP_STATE_INIT
to COMP_STATE_ACTIVE(0 - 5), and direction is only range fromm BIT(0)
to BIT(5), so uint_16 is enough for them. Now refine them in 8 channels to reduce
the dma_pdata size to under 512 bytes to save memory.

Tested on ICL.

Signed-off-by: Rander Wang <rander.wang@linux.intel.com>