### PR TITLE
kpb: temporary fix for the component new fails

### DIFF
--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -60,10 +60,20 @@ static struct comp_dev *kpb_new(struct sof_ipc_comp *comp)
 {
 	struct comp_dev *dev;
 	struct sof_ipc_comp_kpb *kpb;
-	struct sof_ipc_comp_kpb *ipc_kpb = (struct sof_ipc_comp_kpb *)comp;
+//	struct sof_ipc_comp_kpb *ipc_kpb = (struct sof_ipc_comp_kpb *)comp;
+	struct sof_ipc_comp_kpb kpb_ipc, *ipc_kpb;
 	struct comp_data *cd;
 
 	trace_kpb("kpb_new()");
+
+	/* We don't have configs from ipc yet, initialize them locally atm. */
+	ipc_kpb = &kpb_ipc;
+
+	ipc_kpb->config.hdr.size = sizeof(struct sof_ipc_comp_config);
+	ipc_kpb->no_channels = KPB_MAX_SUPPORTED_CHANNELS;
+	ipc_kpb->history_depth = KPB_MAX_BUFFER_SIZE;
+	ipc_kpb->sampling_freq = KPB_SAMPLNG_FREQUENCY;
+	ipc_kpb->sampling_width = KPB_SAMPLING_WIDTH;
 
 	/* Validate input parameters */
 	if (IPC_IS_SIZE_INVALID(ipc_kpb->config)) {

--- a/src/include/uapi/abi.h
+++ b/src/include/uapi/abi.h
@@ -52,7 +52,7 @@
 
 /** \brief SOF ABI version major, minor and patch numbers */
 #define SOF_ABI_MAJOR 3
-#define SOF_ABI_MINOR 2
+#define SOF_ABI_MINOR 4
 #define SOF_ABI_PATCH 0
 
 /** \brief SOF ABI version number. Format within 32bit word is MMmmmppp */

--- a/src/include/uapi/ipc/topology.h
+++ b/src/include/uapi/ipc/topology.h
@@ -62,10 +62,12 @@ enum sof_comp_type {
 	SOF_COMP_BUFFER,
 	SOF_COMP_EQ_IIR,
 	SOF_COMP_EQ_FIR,
-	SOF_COMP_FILEREAD,	/**< host test based file IO */
-	SOF_COMP_FILEWRITE,	/**< host test based file IO */
-	SOF_COMP_KPB, /* A key phrase buffer component */
-	SOF_COMP_SELECTOR,
+	SOF_COMP_KEYWORD_DETECT,
+	SOF_COMP_KPB,			/* A key phrase buffer component */
+	SOF_COMP_SELECTOR,		/**< channel selector component */
+	/* keep FILEREAD/FILEWRITE as the last ones */
+	SOF_COMP_FILEREAD = 10000,	/**< host test based file IO */
+	SOF_COMP_FILEWRITE = 10001,	/**< host test based file IO */
 };
 
 /* XRUN action for component */
@@ -215,6 +217,9 @@ enum sof_ipc_process_type {
 	SOF_PROCESS_NONE = 0,		/**< None */
 	SOF_PROCESS_EQFIR,		/**< Intel FIR */
 	SOF_PROCESS_EQIIR,		/**< Intel IIR */
+	SOF_PROCESS_KEYWORD_DETECT,	/**< Keyword Detection */
+	SOF_PROCESS_KPB,		/**< KeyPhrase Buffer Manager */
+	SOF_PROCESS_CHAN_SELECTOR,	/**< Channel Selector */
 };
 
 /* generic "effect", "codec" or proprietary processing component */
@@ -222,7 +227,7 @@ struct sof_ipc_comp_process {
 	struct sof_ipc_comp comp;
 	struct sof_ipc_comp_config config;
 	uint32_t size;	/**< size of bespoke data section in bytes */
-	uint32_t type;	/**< sof_ipc_effect_type */
+	uint32_t type;	/**< sof_ipc_process_type */
 
 	/* reserved for future use */
 	uint32_t reserved[7];


### PR DESCRIPTION
kpb: a temporary fix for the component new fails

We don't have configuration from IPC for kpb yet, this is only temporary
fix for the fails at component new.