### PR TITLE
scheduler: add support for unprioritized tasks

### DIFF
--- a/src/include/sof/interrupt-map.h
+++ b/src/include/sof/interrupt-map.h
@@ -33,6 +33,7 @@
 
 #include <config.h>
 
+#define SOF_IRQ_PASSIVE_LEVEL	0
 #define SOF_IRQ_ID_SHIFT	29
 #define SOF_IRQ_BIT_SHIFT	24
 #define SOF_IRQ_LEVEL_SHIFT	16


### PR DESCRIPTION
The aim of this PR is the possibility to schedule idle/unprioritized
tasks which shouldn't block these higer priority ones.
Theoretically, we could schedule idle task with lowest
possibly priority, however some very important tasks like IPC
handler are already scheduled with lowest priority.

PS: The main customer of this feature will be a draining tasks for keyword detection.

Signed-off-by: Marcin Rajwa <marcin.rajwa@linux.intel.com>