### PR TITLE
cmake: copy ldc to build root

### DIFF
--- a/src/arch/xtensa/CMakeLists.txt
+++ b/src/arch/xtensa/CMakeLists.txt
@@ -347,6 +347,7 @@ endif()
 add_custom_target(
 	bin
 	COMMAND ${CMAKE_COMMAND} -E copy sof-${fw_name}.ri ${PROJECT_BINARY_DIR}/sof-${fw_name}.ri
+	COMMAND ${CMAKE_COMMAND} -E copy sof-${fw_name}.ldc ${PROJECT_BINARY_DIR}/sof-${fw_name}.ldc
 	DEPENDS run_meu
 	VERBATIM
 	USES_TERMINAL


### PR DESCRIPTION
We copy .ri already so .ldc should be also there

Signed-off-by: Janusz Jankowski <janusz.jankowski@linux.intel.com>