### PR TITLE
Trace: treat trace errors as normal logs if TRACEE disabled + tracev fix

### DIFF
--- a/src/include/sof/trace.h
+++ b/src/include/sof/trace.h
@@ -267,7 +267,7 @@ void trace_init(struct sof *sof);
 #define tracev_event(...) trace_event(__VA_ARGS__)
 #define tracev_event_with_ids(...) trace_event_with_ids(__VA_ARGS__)
 #define tracev_event_atomic(...) trace_event_atomic(__VA_ARGS__)
-#define tracev_event_atomic_with_ids(...) trace_event_with_ids(__VA_ARGS__)
+#define tracev_event_atomic_with_ids(...) trace_event_atomic_with_ids(__VA_ARGS__)
 
 #define tracev_value(x)	trace_value(x)
 #define tracev_value_atomic(x)	trace_value_atomic(x)

--- a/src/include/sof/trace.h
+++ b/src/include/sof/trace.h
@@ -296,13 +296,12 @@ void trace_init(struct sof *sof);
 #define trace_error_value(x)		trace_error(0, "value %u", x)
 #define trace_error_value_atomic(...)	trace_error_value(__VA_ARGS__)
 #else
-#define _trace_error_with_ids(...)
-#define trace_error(...)
-#define trace_error_with_ids(...)
-#define trace_error_atomic(...)
-#define trace_error_atomic_with_ids(...)
-#define trace_error_value(x)
-#define trace_error_value_atomic(x)
+#define trace_error(...) trace_event(__VA_ARGS__)
+#define trace_error_with_ids(...) trace_event_with_ids(__VA_ARGS__)
+#define trace_error_atomic(...) trace_event_atomic(__VA_ARGS__)
+#define trace_error_atomic_with_ids(...) trace_event_atomic_with_ids(__VA_ARGS__)
+#define trace_error_value(x) trace_value(x)
+#define trace_error_value_atomic(x) trace_value_atomic(x)
 #endif
 
 #ifndef CONFIG_HOST

--- a/src/lib/dma-trace.c
+++ b/src/lib/dma-trace.c
@@ -409,7 +409,7 @@ static void dtrace_add_event(const char *e, uint32_t length)
 			 * if any dropped entries have appeared and there
 			 * is not any overflow, their amount will be logged
 			 */
-#if TRACEE && TRACE
+#if TRACE
 			uint32_t tmp_dropped_entries = dropped_entries;
 #endif
 			dropped_entries = 0;


### PR DESCRIPTION
Treat trace errors as normal logs if TRACEE disabled (to not lost them)
and change trace_event to the correct one for tracev_event_atomic_with_ids

Signed-off-by: Adrian Bonislawski <adrian.bonislawski@linux.intel.com>