### PR TITLE
hda-dma: utilize generic scheduling support for Link DMA

### DIFF
--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -606,9 +606,9 @@ static int host_params(struct comp_dev *dev)
 	}
 #endif
 	/* set up callback */
-	dma_set_cb(hd->dma, hd->chan, DMA_CB_TYPE_LLIST,
-		   host_dma_cb,
-		   dev);
+	dma_set_cb(hd->dma, hd->chan, DMA_CB_TYPE_LLIST | DMA_CB_TYPE_PROCESS,
+		   host_dma_cb, dev);
+
 	return 0;
 }
 


### PR DESCRIPTION
Changes implementation of HDA Link DMA to fully utilize
generic scheduling support. HDA Link DMA cannot work
with IRQ scheduling, so timer scheduling was hidden
inside of the hda-dma driver. Now it fully utilizes
timer scheduling support by default.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>