### PR TITLE
Volume: Improve PCM format handling in params and prepare

### DIFF
--- a/src/audio/volume.c
+++ b/src/audio/volume.c
@@ -236,12 +236,7 @@ static void volume_free(struct comp_dev *dev)
  */
 static int volume_params(struct comp_dev *dev)
 {
-	struct comp_data *cd = comp_get_drvdata(dev);
-
 	trace_volume("volume_params()");
-
-	/* rewrite params format for all downstream */
-	dev->params.frame_fmt = cd->sink_format;
 
 	return 0;
 }
@@ -551,8 +546,11 @@ static int volume_prepare(struct comp_dev *dev)
 	comp_set_period_bytes(sinkb->sink, dev->frames, &cd->sink_format,
 			      &sink_period_bytes);
 
-	/* rewrite params format for all downstream */
-	dev->params.frame_fmt = cd->sink_format;
+	/* Rewrite params format for this component to match the host side. */
+	if (dev->params.direction == SOF_IPC_STREAM_PLAYBACK)
+		dev->params.frame_fmt = cd->source_format;
+	else
+		dev->params.frame_fmt = cd->sink_format;
 
 	/* set downstream buffer size */
 	ret = buffer_set_size(sinkb, sink_period_bytes * config->periods_sink);


### PR DESCRIPTION
This patch removes from params function the setting of component's
own stored frame_fmt since the variable cd->sink_format was not set.

In prepare function the stored frame_fmt is stored based on stream
direction. In playback it's set from source and in capture from sink.
This way the format matches the host component.

These changes help other components in the pipeline to operate with
correct PCM format.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>