### PR TITLE
EQ: Add to FIR and IIR support for timer based scheduling

### DIFF
--- a/src/audio/fir.c
+++ b/src/audio/fir.c
@@ -85,23 +85,22 @@ void eq_fir_s16(struct fir_state_32x16 fir[], struct comp_buffer *source,
 		struct comp_buffer *sink, int frames, int nch)
 {
 	struct fir_state_32x16 *filter;
-	int16_t *src = (int16_t *)source->r_ptr;
-	int16_t *snk = (int16_t *)sink->w_ptr;
 	int16_t *x;
 	int16_t *y;
 	int32_t z;
+	int idx;
 	int ch;
 	int i;
 
 	for (ch = 0; ch < nch; ch++) {
 		filter = &fir[ch];
-		x = src++;
-		y = snk++;
+		idx = ch;
 		for (i = 0; i < frames; i++) {
+			x = buffer_read_frag_s16(source, idx);
+			y = buffer_write_frag_s16(sink, idx);
 			z = fir_32x16(filter, *x << 16);
 			*y = sat_int16(Q_SHIFT_RND(z, 31, 15));
-			x += nch;
-			y += nch;
+			idx += nch;
 		}
 	}
 }
@@ -110,23 +109,22 @@ void eq_fir_s24(struct fir_state_32x16 fir[], struct comp_buffer *source,
 		struct comp_buffer *sink, int frames, int nch)
 {
 	struct fir_state_32x16 *filter;
-	int32_t *src = (int32_t *)source->r_ptr;
-	int32_t *snk = (int32_t *)sink->w_ptr;
 	int32_t *x;
 	int32_t *y;
 	int32_t z;
+	int idx;
 	int ch;
 	int i;
 
 	for (ch = 0; ch < nch; ch++) {
 		filter = &fir[ch];
-		x = src++;
-		y = snk++;
+		idx = ch;
 		for (i = 0; i < frames; i++) {
+			x = buffer_read_frag_s32(source, idx);
+			y = buffer_write_frag_s32(sink, idx);
 			z = fir_32x16(filter, *x << 8);
 			*y = sat_int24(Q_SHIFT_RND(z, 31, 23));
-			x += nch;
-			y += nch;
+			idx += nch;
 		}
 	}
 }
@@ -135,21 +133,20 @@ void eq_fir_s32(struct fir_state_32x16 fir[], struct comp_buffer *source,
 		struct comp_buffer *sink, int frames, int nch)
 {
 	struct fir_state_32x16 *filter;
-	int32_t *src = (int32_t *)source->r_ptr;
-	int32_t *snk = (int32_t *)sink->w_ptr;
 	int32_t *x;
 	int32_t *y;
+	int idx;
 	int ch;
 	int i;
 
 	for (ch = 0; ch < nch; ch++) {
 		filter = &fir[ch];
-		x = src++;
-		y = snk++;
+		idx = ch;
 		for (i = 0; i < frames; i++) {
+			x = buffer_read_frag_s32(source, idx);
+			y = buffer_write_frag_s32(sink, idx);
 			*y = fir_32x16(filter, *x);
-			x += nch;
-			y += nch;
+			idx += nch;
 		}
 	}
 }

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -272,6 +272,15 @@ struct comp_dev {
  *  @{
  */
 
+/** \brief Struct for use with comp_get_copy_limits() function. */
+struct comp_copy_limits {
+	struct comp_buffer *sink;
+	struct comp_buffer *source;
+	int frames;
+	int source_bytes;
+	int sink_bytes;
+};
+
 /** \brief Computes size of the component device including ipc config. */
 #define COMP_SIZE(x) \
 	(sizeof(struct comp_dev) - sizeof(struct sof_ipc_comp) + sizeof(x))
@@ -682,6 +691,13 @@ static inline void comp_overrun(struct comp_dev *dev, struct comp_buffer *sink,
 
 	pipeline_xrun(dev->pipeline, dev, (int32_t)copy_bytes - sink->free);
 }
+
+/**
+ * Called by component in copy.
+ * @param dev Component device.
+ * @param cl Struct of parameters for use in copy function.
+ */
+int comp_get_copy_limits(struct comp_dev *dev, struct comp_copy_limits *cl);
 
 /** @}*/
 

--- a/test/cmocka/src/audio/component/mock.c
+++ b/test/cmocka/src/audio/component/mock.c
@@ -48,4 +48,8 @@ void *rzalloc(int zone, uint32_t caps, size_t bytes)
 	return calloc(bytes, 1);
 }
 
+void pipeline_xrun(struct pipeline *p, struct comp_dev *dev, int32_t bytes)
+{
+}
+
 #endif


### PR DESCRIPTION
This patch updates the component buffers access for FIR and IIR
equalizer components. Timer based scheduling requires true circular
buffers capability. The copy functions are simplified with a new
utility function comp_copy_helper() that is added to component.c.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>