### PR TITLE
topology: add ABI information

### DIFF
--- a/tools/topology/CMakeLists.txt
+++ b/tools/topology/CMakeLists.txt
@@ -6,6 +6,14 @@ file(GLOB TPLG_DEPS
 	sof/*.m4
 )
 
+add_custom_target(abi
+	COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/get_abi.sh
+	DEPENDS ${TPLG_DEPS}
+	WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+	VERBATIM
+	USES_TERMINAL
+)
+
 set(TPLGS
 	"sof-cht-nocodec\;sof-cht-nocodec\;-DPLATFORM=cht"
 	"sof-cht-nocodec\;sof-byt-nocodec\;-DPLATFORM=byt"
@@ -66,9 +74,11 @@ foreach(tplg ${TPLGS})
 			-I ${CMAKE_CURRENT_SOURCE_DIR}/common
 			-I ${CMAKE_CURRENT_SOURCE_DIR}/platform/common
 			-I ${CMAKE_CURRENT_SOURCE_DIR}
+			-I ${CMAKE_CURRENT_BINARY_DIR}
+			${CMAKE_CURRENT_SOURCE_DIR}/common/abi.m4
 			${CMAKE_CURRENT_SOURCE_DIR}/${input}.m4
 			> ${output}.conf
-		DEPENDS ${TPLG_DEPS}
+		DEPENDS abi
 		VERBATIM
 		USES_TERMINAL
 	)

--- a/tools/topology/common/abi.m4
+++ b/tools/topology/common/abi.m4
@@ -1,0 +1,14 @@
+include(`abi.h')
+
+dnl ABI_INFO(name, major, minor, patch)
+define(`ABI_INFO',
+`SectionData."SOF_ABI" {'
+`	bytes "$2,$3,$4"'
+`}'
+`SectionManifest.STR($1) {'
+`	data ['
+`		SOF_ABI'
+`	]'
+`}')
+
+ABI_INFO(sof_manifest, SOF_ABI_MAJOR, SOF_ABI_MINOR, SOF_ABI_PATCH)

--- a/tools/topology/get_abi.sh
+++ b/tools/topology/get_abi.sh
@@ -1,0 +1,6 @@
+MAJOR=`grep '#define SOF_ABI_MAJOR ' ../../../src/include/uapi/abi.h | grep -E ".[[:digit:]]$" -o`
+MINOR=`grep '#define SOF_ABI_MINOR ' ../../../src/include/uapi/abi.h | grep -E ".[[:digit:]]$" -o`
+PATCH=`grep '#define SOF_ABI_PATCH ' ../../../src/include/uapi/abi.h | grep -E ".[[:digit:]]$" -o`
+printf "define(\`SOF_ABI_MAJOR', \`0x%02x')\n" $MAJOR > abi.h
+printf "define(\`SOF_ABI_MINOR', \`0x%02x')\n" $MINOR >> abi.h
+printf "define(\`SOF_ABI_PATCH', \`0x%02x')\n" $PATCH >> abi.h


### PR DESCRIPTION
We can add ABI information to the Manifest section. So kernel can check if the topology is compatible with the kernel.
The 0x03, 0x02, and 0x00 map to SOF_ABI_MAJOR, SOF_ABI_MINOR, and SOF_ABI_PATCH , respectively.
I don't know if it is a good idea to add ABI_INFO in tokens.m4. My point is tokens.m4 is included in every m4 files and all of them should have the same ABI number. 