### PR TITLE
schedule: ll: refinement low latency queue

### DIFF
--- a/src/include/sof/ll_schedule.h
+++ b/src/include/sof/ll_schedule.h
@@ -43,9 +43,6 @@
 
 struct work_queue;
 
-/* range of priorities (0 - SOF_TASK_PRI_COUNT) */
-#define LL_PRIORITIES	SOF_TASK_PRI_COUNT
-
 #define ll_sch_set_pdata(task, data) \
 	task->private = data
 


### PR DESCRIPTION
I've removed queue per priority in low latency scheduler. Now there is only one queue for all priorities. Scheduler adds tasks to queue in descending order based on their priority.
