### PR TITLE
topology: enable LBM for nocodec topology

### DIFF
--- a/tools/topology/platform/common/ssp.m4
+++ b/tools/topology/platform/common/ssp.m4
@@ -27,13 +27,17 @@ define(`SSP_CONFIG',
 $6
 )
 
-dnl SSP_CONFIG_DATA(type, idx, valid bits, mclk_id)
+dnl SSP_QUIRK_LBM 64 = (1 << 6)
+define(`SSP_QUIRK_LBM', 64)
+
+dnl SSP_CONFIG_DATA(type, idx, valid bits, mclk_id, quirks)
 dnl mclk_id is optional
 define(`SSP_CONFIG_DATA',
 `SectionVendorTuples."'N_DAI_CONFIG($1$2)`_tuples" {'
 `	tokens "sof_ssp_tokens"'
 `	tuples."word" {'
 `		SOF_TKN_INTEL_SSP_SAMPLE_BITS'	STR($3)
+`		SOF_TKN_INTEL_SSP_QUIRKS'	ifelse($5, `', "0", STR($5))
 `	}'
 `	tuples."short" {'
 `		SOF_TKN_INTEL_SSP_MCLK_ID'	ifelse($4, `', "0", STR($4))

--- a/tools/topology/sof-apl-nocodec.m4
+++ b/tools/topology/sof-apl-nocodec.m4
@@ -237,43 +237,43 @@ DAI_CONFIG(SSP, 0, 0, NoCodec-0,
 		      SSP_CLOCK(bclk, 1536000, codec_slave),
 		      SSP_CLOCK(fsync, 48000, codec_slave),
 		      SSP_TDM(2, 16, 3, 3),
-		      dnl SSP_CONFIG_DATA(type, dai_index, valid bits, mclk_id)
-		      SSP_CONFIG_DATA(SSP, 0, 16)))
+		      dnl SSP_CONFIG_DATA(type, dai_index, valid bits, mclk_id, quirks)
+		      SSP_CONFIG_DATA(SSP, 0, 16, 0, SSP_QUIRK_LBM)))
 
 DAI_CONFIG(SSP, 1, 1, NoCodec-1,
 	   SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24576000, codec_mclk_in),
 		      SSP_CLOCK(bclk, 1536000, codec_slave),
 		      SSP_CLOCK(fsync, 48000, codec_slave),
 		      SSP_TDM(2, 16, 3, 3),
-		      SSP_CONFIG_DATA(SSP, 1, 16)))
+		      SSP_CONFIG_DATA(SSP, 1, 16, 0, SSP_QUIRK_LBM)))
 
 #DAI_CONFIG(SSP, 2, 2, NoCodec-2,
 #	   SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24576000, codec_mclk_in),
 #		      SSP_CLOCK(bclk, 1536000, codec_slave),
 #		      SSP_CLOCK(fsync, 48000, codec_slave),
 #		      SSP_TDM(2, 16, 3, 3),
-#		      SSP_CONFIG_DATA(SSP, 2, 16)))
+#		      SSP_CONFIG_DATA(SSP, 2, 16, 0, SSP_QUIRK_LBM)))
 
 DAI_CONFIG(SSP, 3, 3, NoCodec-3,
 	   SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24576000, codec_mclk_in),
 		      SSP_CLOCK(bclk, 1536000, codec_slave),
 		      SSP_CLOCK(fsync, 48000, codec_slave),
 		      SSP_TDM(2, 16, 3, 3),
-		      SSP_CONFIG_DATA(SSP, 3, 16)))
+		      SSP_CONFIG_DATA(SSP, 3, 16, 0, SSP_QUIRK_LBM)))
 
 #DAI_CONFIG(SSP, 4, 4, NoCodec-4,
 #	   SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24576000, codec_mclk_in),
 #		      SSP_CLOCK(bclk, 1536000, codec_slave),
 #		      SSP_CLOCK(fsync, 48000, codec_slave),
 #		      SSP_TDM(2, 16, 3, 3),
-#		      SSP_CONFIG_DATA(SSP, 4, 16)))
+#		      SSP_CONFIG_DATA(SSP, 4, 16, 0, SSP_QUIRK_LBM)))
 
 DAI_CONFIG(SSP, 5, 5, NoCodec-5,
 	   SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24576000, codec_mclk_in),
 		      SSP_CLOCK(bclk, 1536000, codec_slave),
 		      SSP_CLOCK(fsync, 48000, codec_slave),
 		      SSP_TDM(2, 16, 3, 3),
-		      SSP_CONFIG_DATA(SSP, 5, 16)))
+		      SSP_CONFIG_DATA(SSP, 5, 16, 0, SSP_QUIRK_LBM)))
 
 DAI_CONFIG(DMIC, 0, 6, NoCodec-6,
 	   dnl DMIC_CONFIG(driver_version, clk_min, clk_mac, duty_min, duty_max,

--- a/tools/topology/sof-cht-nocodec.m4
+++ b/tools/topology/sof-cht-nocodec.m4
@@ -90,4 +90,4 @@ DAI_CONFIG(SSP, 2, 2, NoCodec-2,
 		      SSP_CLOCK(bclk, 2400000, codec_slave),
 		      SSP_CLOCK(fsync, 48000, codec_slave),
 		      SSP_TDM(2, 25, 3, 3),
-		      SSP_CONFIG_DATA(SSP, 2, 24)))
+		      SSP_CONFIG_DATA(SSP, 2, 24, 0, SSP_QUIRK_LBM)))

--- a/tools/topology/sof-cnl-nocodec.m4
+++ b/tools/topology/sof-cnl-nocodec.m4
@@ -149,22 +149,22 @@ DAI_CONFIG(SSP, 0, 0, NoCodec-0,
 		      SSP_CLOCK(bclk, 4800000, codec_slave),
 		      SSP_CLOCK(fsync, 48000, codec_slave),
 		      SSP_TDM(2, 25, 3, 3),
-		      dnl SSP_CONFIG_DATA(type, dai_index, valid bits, mclk_id)
-		      SSP_CONFIG_DATA(SSP, 0, 24)))
+		      dnl SSP_CONFIG_DATA(type, dai_index, valid bits, mclk_id, quirks)
+		      SSP_CONFIG_DATA(SSP, 0, 24, 0, SSP_QUIRK_LBM)))
 
 DAI_CONFIG(SSP, 1, 1, NoCodec-1,
 	   SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24000000, codec_mclk_in),
 		      SSP_CLOCK(bclk, 4800000, codec_slave),
 		      SSP_CLOCK(fsync, 48000, codec_slave),
 		      SSP_TDM(2, 25, 3, 3),
-		      SSP_CONFIG_DATA(SSP, 1, 24)))
+		      SSP_CONFIG_DATA(SSP, 1, 24, 0, SSP_QUIRK_LBM)))
 
 DAI_CONFIG(SSP, 2, 2, NoCodec-2,
 	   SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24000000, codec_mclk_in),
 		      SSP_CLOCK(bclk, 4800000, codec_slave),
 		      SSP_CLOCK(fsync, 48000, codec_slave),
 		      SSP_TDM(2, 25, 3, 3),
-		      SSP_CONFIG_DATA(SSP, 2, 24)))
+		      SSP_CONFIG_DATA(SSP, 2, 24, 0, SSP_QUIRK_LBM)))
 
 DAI_CONFIG(DMIC, 0, 3, NoCodec-3,
 	   DMIC_CONFIG(1, 500000, 4800000, 40, 60, 48000,

--- a/tools/topology/sof-icl-nocodec.m4
+++ b/tools/topology/sof-icl-nocodec.m4
@@ -66,4 +66,4 @@ DAI_CONFIG(SSP, 0, 0, NoCodec-0,
 		      SSP_CLOCK(bclk, 2400000, codec_slave),
 		      SSP_CLOCK(fsync, 48000, codec_slave),
 		      SSP_TDM(2, 25, 3, 3),
-		      SSP_CONFIG_DATA(SSP, 0, 24)))
+		      SSP_CONFIG_DATA(SSP, 0, 24, 0, SSP_QUIRK_LBM)))


### PR DESCRIPTION
Add quirks parameter in SSP_CONFIG_DATA(). Enable LBM in dupulex pipelines
by setting quirks as SOF_DAI_INTEL_SSP_QUIRK_LBM 64(1<<6). SSPx.IN port get
PCM data from SSPx.OUT.

Signed-off-by: Fred Oh <fred.oh@linux.intel.com>