### PR TITLE
cmake: add git hooks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,9 @@ project(SOF C ASM)
 set(SOF_ROOT_SOURCE_DIRECTORY "${PROJECT_SOURCE_DIR}")
 set(SOF_ROOT_BINARY_DIRECTORY "${PROJECT_BINARY_DIR}")
 
+# check git hooks
+include(scripts/cmake/git-hooks.cmake)
+
 # most of other options are set on per-arch and per-target basis
 set(CMAKE_ASM_FLAGS -DASSEMBLY)
 

--- a/scripts/cmake/git-hooks.cmake
+++ b/scripts/cmake/git-hooks.cmake
@@ -1,0 +1,22 @@
+# Links git hooks, if there are no other hooks already
+
+if(NOT EXISTS "${SOF_ROOT_SOURCE_DIRECTORY}/.git")
+	return()
+endif()
+
+if(NOT CMAKE_HOST_UNIX)
+	return()
+endif()
+
+set(pre_commit_hook "${SOF_ROOT_SOURCE_DIRECTORY}/.git/hooks/pre-commit")
+set(post_commit_hook "${SOF_ROOT_SOURCE_DIRECTORY}/.git/hooks/post-commit")
+
+if(NOT EXISTS ${pre_commit_hook})
+	message(STATUS "Linking git pre-commit hook")
+	execute_process(COMMAND ln -s -f -T ../../scripts/sof-pre-commit-hook.sh ${pre_commit_hook})
+endif()
+
+if(NOT EXISTS ${post_commit_hook})
+	message(STATUS "Linking git post-commit hook")
+	execute_process(COMMAND ln -s -f -T ../../scripts/sof-post-commit-hook.sh ${post_commit_hook})
+endif()


### PR DESCRIPTION
It was missing feature from autotools-based buildsystem 

Signed-off-by: Janusz Jankowski <janusz.jankowski@linux.intel.com>