### PR TITLE
trace: fix DMA setting for traces

### DIFF
--- a/src/ipc/dma-copy.c
+++ b/src/ipc/dma-copy.c
@@ -133,6 +133,7 @@ int dma_copy_to_host_nowait(struct dma_copy *dc, struct dma_sg_config *host_sg,
 	config.src_width = sizeof(uint32_t);
 	config.dest_width = sizeof(uint32_t);
 	config.cyclic = 0;
+	config.irq_disabled = false;
 	dma_sg_init(&config.elem_array);
 
 	/* configure local DMA elem */


### PR DESCRIPTION
Fixes DMA setting for traces transferred using
DW-DMA. They are currently using IRQ mode.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>