### PR TITLE
edf: using specific schedule_edf() instead of schedule()

### DIFF
--- a/src/lib/edf_schedule.c
+++ b/src/lib/edf_schedule.c
@@ -346,7 +346,7 @@ static void schedule_edf_task_normal(struct task *task, uint64_t start,
 	/* need to run scheduler if task not already running */
 	if (need_sched) {
 		/* rerun scheduler */
-		schedule();
+		schedule_edf();
 	}
 }
 


### PR DESCRIPTION
I've changed scheduler invocation in ```schedule_edf_task_normal()```
from generic ```schedule()``` to ```specific schedule_edf()``` for optimization
(there is no need to use generic functions in specific scheduler
implementation).
