### PR TITLE
Fix checkpatch errors

### DIFF
--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -837,9 +837,7 @@ static struct comp_driver comp_dai = {
 	},
 };
 
-void sys_comp_dai_init(void);
-
-void sys_comp_dai_init(void)
+static void sys_comp_dai_init(void)
 {
 	comp_register(&comp_dai);
 }

--- a/src/audio/eq_fir.c
+++ b/src/audio/eq_fir.c
@@ -816,9 +816,7 @@ struct comp_driver comp_eq_fir = {
 	},
 };
 
-void sys_comp_eq_fir_init(void);
-
-void sys_comp_eq_fir_init(void)
+static void sys_comp_eq_fir_init(void)
 {
 	comp_register(&comp_eq_fir);
 }

--- a/src/audio/eq_iir.c
+++ b/src/audio/eq_iir.c
@@ -936,9 +936,8 @@ struct comp_driver comp_eq_iir = {
 	},
 };
 
-void sys_comp_eq_iir_init(void);
 
-void sys_comp_eq_iir_init(void)
+static void sys_comp_eq_iir_init(void)
 {
 	comp_register(&comp_eq_iir);
 }

--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -855,9 +855,7 @@ struct comp_driver comp_host = {
 	},
 };
 
-void sys_comp_host_init(void);
-
-void sys_comp_host_init(void)
+static void sys_comp_host_init(void)
 {
 	comp_register(&comp_host);
 }

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -43,6 +43,7 @@
 #include <sof/audio/kpb.h>
 #include <sof/list.h>
 #include <sof/audio/buffer.h>
+#include <sof/ut.h>
 
 static void kpb_event_handler(int message, void *cb_data, void *event_data);
 static int kpb_register_client(struct comp_data *kpb, struct kpb_client *cli);
@@ -545,7 +546,7 @@ struct comp_driver comp_kpb = {
 	},
 };
 
-static void sys_comp_kpb_init(void)
+UT_STATIC void sys_comp_kpb_init(void)
 {
 	comp_register(&comp_kpb);
 }

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -545,9 +545,7 @@ struct comp_driver comp_kpb = {
 	},
 };
 
-void sys_comp_kpb_init(void);
-
-void sys_comp_kpb_init(void)
+static void sys_comp_kpb_init(void)
 {
 	comp_register(&comp_kpb);
 }

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -38,6 +38,7 @@
 #include <sof/ipc.h>
 #include <sof/audio/component.h>
 #include <sof/audio/format.h>
+#include <sof/ut.h>
 
 #define trace_mixer(__e, ...) \
 	trace_event(TRACE_CLASS_MIXER, __e, ##__VA_ARGS__)
@@ -445,7 +446,7 @@ struct comp_driver comp_mixer = {
 	},
 };
 
-static void sys_comp_mixer_init(void)
+UT_STATIC void sys_comp_mixer_init(void)
 {
 	comp_register(&comp_mixer);
 }

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -445,9 +445,7 @@ struct comp_driver comp_mixer = {
 	},
 };
 
-void sys_comp_mixer_init(void);
-
-void sys_comp_mixer_init(void)
+static void sys_comp_mixer_init(void)
 {
 	comp_register(&comp_mixer);
 }

--- a/src/audio/mux.c
+++ b/src/audio/mux.c
@@ -97,9 +97,7 @@ struct comp_driver comp_mux = {
 	},
 };
 
-void sys_comp_mux_init(void);
-
-void sys_comp_mux_init(void)
+static void sys_comp_mux_init(void)
 {
 	comp_register(&comp_mux);
 }

--- a/src/audio/selector.c
+++ b/src/audio/selector.c
@@ -516,10 +516,8 @@ struct comp_driver comp_selector = {
 	},
 };
 
-void sys_comp_selector_init(void);
-
 /** \brief Initializes selector component. */
-void sys_comp_selector_init(void)
+static void sys_comp_selector_init(void)
 {
 	comp_register(&comp_selector);
 }

--- a/src/audio/src.c
+++ b/src/audio/src.c
@@ -980,9 +980,7 @@ struct comp_driver comp_src = {
 	},
 };
 
-void sys_comp_src_init(void);
-
-void sys_comp_src_init(void)
+static void sys_comp_src_init(void)
 {
 	comp_register(&comp_src);
 }

--- a/src/audio/switch.c
+++ b/src/audio/switch.c
@@ -97,9 +97,7 @@ struct comp_driver comp_switch = {
 	},
 };
 
-void sys_comp_switch_init(void);
-
-void sys_comp_switch_init(void)
+static void sys_comp_switch_init(void)
 {
 	comp_register(&comp_switch);
 }

--- a/src/audio/tone.c
+++ b/src/audio/tone.c
@@ -762,9 +762,7 @@ struct comp_driver comp_tone = {
 	},
 };
 
-void sys_comp_tone_init(void);
-
-void sys_comp_tone_init(void)
+static void sys_comp_tone_init(void)
 {
 	comp_register(&comp_tone);
 }

--- a/src/audio/volume.c
+++ b/src/audio/volume.c
@@ -667,12 +667,10 @@ struct comp_driver comp_volume = {
 	},
 };
 
-void sys_comp_volume_init(void);
-
 /**
  * \brief Initializes volume component.
  */
-void sys_comp_volume_init(void)
+static void sys_comp_volume_init(void)
 {
 	comp_register(&comp_volume);
 }

--- a/src/include/sof/ut.h
+++ b/src/include/sof/ut.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2019, Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of the Intel Corporation nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: Janusz Jankowski <janusz.jankowski@linux.intel.com>
+ */
+
+#ifndef __INCLUDE_SOF_UT__
+#define __INCLUDE_SOF_UT__
+
+/* UT_STATIC makes function unit-testable (non-static) when built for unit tests
+ */
+#ifdef CHECK
+#define UT_STATIC
+#else
+#define UT_STATIC static
+#endif
+
+#endif


### PR DESCRIPTION
The init functions are declared in a way that upsets checkpatch, this fixes those errors.

Fixes #1166 