### PR TITLE
[DO NOT MERGE] trace: deduplication of TRACE_CLASS defines

### DIFF
--- a/src/include/sof/trace.h
+++ b/src/include/sof/trace.h
@@ -81,38 +81,6 @@
 #define TRACE_BOOT_PLATFORM_DMIC	(TRACE_BOOT_PLATFORM + 0x1a0)
 #define TRACE_BOOT_PLATFORM_IDC		(TRACE_BOOT_PLATFORM + 0x1b0)
 
-/* trace event classes - high 8 bits*/
-#define TRACE_CLASS_IRQ		(1 << 24)
-#define TRACE_CLASS_IPC		(2 << 24)
-#define TRACE_CLASS_PIPE	(3 << 24)
-#define TRACE_CLASS_HOST	(4 << 24)
-#define TRACE_CLASS_DAI		(5 << 24)
-#define TRACE_CLASS_DMA		(6 << 24)
-#define TRACE_CLASS_SSP		(7 << 24)
-#define TRACE_CLASS_COMP	(8 << 24)
-#define TRACE_CLASS_WAIT	(9 << 24)
-#define TRACE_CLASS_LOCK	(10 << 24)
-#define TRACE_CLASS_MEM		(11 << 24)
-#define TRACE_CLASS_MIXER	(12 << 24)
-#define TRACE_CLASS_BUFFER	(13 << 24)
-#define TRACE_CLASS_VOLUME	(14 << 24)
-#define TRACE_CLASS_SWITCH	(15 << 24)
-#define TRACE_CLASS_MUX		(16 << 24)
-#define TRACE_CLASS_SRC         (17 << 24)
-#define TRACE_CLASS_TONE        (18 << 24)
-#define TRACE_CLASS_EQ_FIR      (19 << 24)
-#define TRACE_CLASS_EQ_IIR      (20 << 24)
-#define TRACE_CLASS_SA		(21 << 24)
-#define TRACE_CLASS_DMIC	(22 << 24)
-#define TRACE_CLASS_POWER	(23 << 24)
-#define TRACE_CLASS_IDC		(24 << 24)
-#define TRACE_CLASS_CPU		(25 << 24)
-#define TRACE_CLASS_CLK		(26 << 24)
-#define TRACE_CLASS_EDF		(27 << 24)
-#define TRACE_CLASS_KPB		(28 << 24)
-#define TRACE_CLASS_SELECTOR	(29 << 24)
-#define TRACE_CLASS_SCHEDULE	(30 << 24)
-
 #ifdef CONFIG_HOST
 extern int test_bench_trace;
 char *get_trace_class(uint32_t trace_class);

--- a/src/include/uapi/abi.h
+++ b/src/include/uapi/abi.h
@@ -51,7 +51,7 @@
 #define __INCLUDE_UAPI_ABI_H__
 
 /** \brief SOF ABI version major, minor and patch numbers */
-#define SOF_ABI_MAJOR 3
+#define SOF_ABI_MAJOR 4
 #define SOF_ABI_MINOR 2
 #define SOF_ABI_PATCH 0
 

--- a/src/include/uapi/user/trace.h
+++ b/src/include/uapi/user/trace.h
@@ -50,35 +50,36 @@ struct system_time {
 } __attribute__((packed));
 
 /* trace event classes - high 8 bits*/
-#define TRACE_CLASS_IRQ		(1 << 24)
-#define TRACE_CLASS_IPC		(2 << 24)
-#define TRACE_CLASS_PIPE	(3 << 24)
-#define TRACE_CLASS_HOST	(4 << 24)
-#define TRACE_CLASS_DAI		(5 << 24)
-#define TRACE_CLASS_DMA		(6 << 24)
-#define TRACE_CLASS_SSP		(7 << 24)
-#define TRACE_CLASS_COMP	(8 << 24)
-#define TRACE_CLASS_WAIT	(9 << 24)
-#define TRACE_CLASS_LOCK	(10 << 24)
-#define TRACE_CLASS_MEM		(11 << 24)
-#define TRACE_CLASS_MIXER	(12 << 24)
-#define TRACE_CLASS_BUFFER	(13 << 24)
-#define TRACE_CLASS_VOLUME	(14 << 24)
-#define TRACE_CLASS_SWITCH	(15 << 24)
-#define TRACE_CLASS_MUX		(16 << 24)
-#define TRACE_CLASS_SRC         (17 << 24)
-#define TRACE_CLASS_TONE        (18 << 24)
-#define TRACE_CLASS_EQ_FIR      (19 << 24)
-#define TRACE_CLASS_EQ_IIR      (20 << 24)
-#define TRACE_CLASS_SA		(21 << 24)
-#define TRACE_CLASS_DMIC	(22 << 24)
-#define TRACE_CLASS_POWER	(23 << 24)
-#define TRACE_CLASS_IDC		(24 << 24)
-#define TRACE_CLASS_CPU		(25 << 24)
-#define TRACE_CLASS_EDF		(27 << 24)
-#define TRACE_CLASS_KPB		(28 << 24)
-#define TRACE_CLASS_SELECTOR	(29 << 24)
-#define TRACE_CLASS_SCHEDULE	(30 << 24)
+#define TRACE_CLASS_IRQ		1
+#define TRACE_CLASS_IPC		2
+#define TRACE_CLASS_PIPE	3
+#define TRACE_CLASS_HOST	4
+#define TRACE_CLASS_DAI		5
+#define TRACE_CLASS_DMA		6
+#define TRACE_CLASS_SSP		7
+#define TRACE_CLASS_COMP	8
+#define TRACE_CLASS_WAIT	9
+#define TRACE_CLASS_LOCK	10
+#define TRACE_CLASS_MEM		11
+#define TRACE_CLASS_MIXER	12
+#define TRACE_CLASS_BUFFER	13
+#define TRACE_CLASS_VOLUME	14
+#define TRACE_CLASS_SWITCH	15
+#define TRACE_CLASS_MUX		16
+#define TRACE_CLASS_SRC         17
+#define TRACE_CLASS_TONE        18
+#define TRACE_CLASS_EQ_FIR      19
+#define TRACE_CLASS_EQ_IIR      20
+#define TRACE_CLASS_SA		21
+#define TRACE_CLASS_DMIC	22
+#define TRACE_CLASS_POWER	23
+#define TRACE_CLASS_IDC		24
+#define TRACE_CLASS_CPU		25
+#define TRACE_CLASS_CLK		26
+#define TRACE_CLASS_EDF		27
+#define TRACE_CLASS_KPB		28
+#define TRACE_CLASS_SELECTOR	29
+#define TRACE_CLASS_SCHEDULE	30
 
 #define LOG_ENABLE		1  /* Enable logging */
 #define LOG_DISABLE		0  /* Disable logging */

--- a/test/cmocka/src/debugability/macros.c
+++ b/test/cmocka/src/debugability/macros.c
@@ -68,7 +68,7 @@ static void test_debugability_macros_declare_log_entry(void **state)
 			"const char text[sizeof(\"Message\")]; "
 		"} log_entry = { "
 			"1"
-			"(6 << 24)"
+			"6"
 			"1"
 			"1"
 			"54"


### PR DESCRIPTION
[DO NOT MERGE] Waiting for general abi changes

I've left TRACE_CLASS defines only in uapi/user/trace.h
header. I've changed also TRACE_CLASS_* values since
bitshifting is not required anymore.

Signed-off-by: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>