### PR TITLE
test: rename CHECK to UNIT_TEST

### DIFF
--- a/src/arch/xtensa/include/arch/string.h
+++ b/src/arch/xtensa/include/arch/string.h
@@ -39,7 +39,7 @@
 #define arch_memcpy(dest, src, size) \
 	xthal_memcpy(dest, src, size)
 
-#if __XCC__ && !defined(CHECK)
+#if __XCC__ && !defined(UNIT_TEST)
 #define arch_bzero(ptr, size)	\
 	memset_s(ptr, size, 0, size)
 #else

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -144,7 +144,7 @@
  *  \brief Usage at the end of comp file: DECLARE_COMPONENT(sys_comp_*_init);
  *  @{
  */
-#ifdef CHECK
+#ifdef UNIT_TEST
 #define DECLARE_COMPONENT(init)
 #else
 #define DECLARE_COMPONENT(init) __attribute__((__used__)) \

--- a/src/include/sof/ut.h
+++ b/src/include/sof/ut.h
@@ -33,7 +33,7 @@
 
 /* UT_STATIC makes function unit-testable (non-static) when built for unit tests
  */
-#ifdef CHECK
+#ifdef UNIT_TEST
 #define UT_STATIC
 #else
 #define UT_STATIC static

--- a/test/cmocka/CMakeLists.txt
+++ b/test/cmocka/CMakeLists.txt
@@ -66,7 +66,7 @@ function(cmocka_test test_name)
 	target_link_libraries(${test_name} PRIVATE "-T${memory_mock_lds_out}")
 	target_link_libraries(${test_name} PRIVATE cmocka)
 	target_link_libraries(${test_name} PRIVATE sof_options)
-	target_compile_definitions(${test_name} PRIVATE -DCHECK)
+	target_compile_definitions(${test_name} PRIVATE -DUNIT_TEST)
 
 	# Cmocka requires this define for stdint.h that defines uintptr
 	target_compile_definitions(${test_name} PRIVATE -D_UINTPTR_T_DEFINED)


### PR DESCRIPTION
We no longer use check framework (the one that was in autotools), so `CHECK` define is a bit misleading. Also renaming it to `CTEST`/`CMOCKA` is unnecessary when we do generic things that would be needed by any ut frameworks, so it's better to just name it `UNIT_TEST`.

Signed-off-by: Janusz Jankowski <janusz.jankowski@linux.intel.com>