### PR TITLE
detector: bin blob rework

### DIFF
--- a/src/include/sof/math/numbers.h
+++ b/src/include/sof/math/numbers.h
@@ -85,6 +85,8 @@ int32_t find_max_abs_int32(int32_t vec[], int vec_length);
  */
 int norm_int32(int32_t val);
 
+uint32_t crc32(const void *data, uint32_t size);
+
 /* merges two 16-bit values into a single 32-bit value */
 #define merge_16b16b(high, low) (((uint32_t)(high) << 16) | \
 				 ((low) & 0xFFFF))

--- a/src/include/uapi/abi.h
+++ b/src/include/uapi/abi.h
@@ -52,7 +52,7 @@
 
 /** \brief SOF ABI version major, minor and patch numbers */
 #define SOF_ABI_MAJOR 3
-#define SOF_ABI_MINOR 5
+#define SOF_ABI_MINOR 6
 #define SOF_ABI_PATCH 0
 
 /** \brief SOF ABI version number. Format within 32bit word is MMmmmppp */

--- a/src/include/uapi/ipc/control.h
+++ b/src/include/uapi/ipc/control.h
@@ -150,10 +150,9 @@ struct sof_ipc_ctrl_data {
 	/* control data - can either be appended or DMAed from host */
 	struct sof_ipc_host_buffer buffer;
 	uint32_t num_elems;	/**< in array elems or bytes for data type */
-	uint32_t total_elems;	/**< total size if message is sent in parts */
+	uint32_t elems_remaining;	/**< elems remaining if sent in parts */
 
-	/* for large messages sent in parts */
-	uint32_t msg_id;
+	uint32_t msg_index;	/**< index for large messages sent in parts */
 
 	/* reserved for future use */
 	uint32_t reserved[6];
@@ -189,7 +188,7 @@ struct sof_ipc_comp_event {
 
 	/* reserved for future use */
 	uint32_t reserved[8];
-	
+
 	/* control data - add new types if needed */
 	union {
 		/* data can be used by binary controls */

--- a/src/include/uapi/user/detect_test.h
+++ b/src/include/uapi/user/detect_test.h
@@ -31,6 +31,11 @@
 #ifndef __INCLUDE_DETECT_TEST_USER_EQ_H__
 #define __INCLUDE_DETECT_TEST_USER_EQ_H__
 
+enum sof_detect_test_data_type {
+	SOF_DETECT_TEST_CONFIG = 0,
+	SOF_DETECT_TEST_MODEL
+};
+
 struct sof_detect_test_config {
 	uint32_t size;
 
@@ -38,8 +43,11 @@ struct sof_detect_test_config {
 	uint32_t load_mips;
 	uint32_t load_memory_size;
 
+	/* length of the keyphrase in milliseconds */
+	uint32_t keyphrase_length;
+
 	/* reserved for future use */
-	uint32_t reserved[5];
+	uint32_t reserved[4];
 } __attribute__((packed));
 
 /* used for binary blob size sanity checks */

--- a/src/math/numbers.c
+++ b/src/math/numbers.c
@@ -129,3 +129,21 @@ int norm_int32(int32_t val)
 	}
 	return s;
 }
+
+uint32_t crc32(const void *data, uint32_t size)
+{
+	uint32_t crc = 0xFFFFFFFF;
+	uint32_t mask;
+	int i, j;
+
+	for (i = 0; i < size; ++i) {
+		crc = crc ^ ((const uint8_t *)data)[i];
+
+		for (j = 7; j >= 0; --j) {
+			mask = -(crc & 1);
+			crc = (crc >> 1) ^ (0xEDB88320 & mask);
+		}
+	}
+
+	return ~crc;
+}


### PR DESCRIPTION
This change introduces load memory filling via large IPC messages and its verification.
It also adds a way to configure the length of the preamble with a run-time parameter inside the binary blob.

Syncs up with the large messages' IPC changes.