### PR TITLE
topology: add mandatory param checks to pcm macros

### DIFF
--- a/tools/topology/m4/pcm.m4
+++ b/tools/topology/m4/pcm.m4
@@ -71,6 +71,7 @@ define(`PCM_CAPABILITIES',
 
 dnl PCM_PLAYBACK_ADD(name, pcm_id, playback)
 define(`PCM_PLAYBACK_ADD',
+`ifelse(`$#', `3',
 `SectionPCM.STR($1) {'
 `'
 `	# used for binding to the PCM'
@@ -84,10 +85,12 @@ define(`PCM_PLAYBACK_ADD',
 `'
 `		capabilities STR($3)'
 `	}'
-`}')
+`}', `fatal_error(`Invalid parameters ($#) to PCM_PLAYBACK_ADD')')'
+)
 
 dnl PCM_CAPTURE_ADD(name, pcm_id, capture)
 define(`PCM_CAPTURE_ADD',
+`ifelse(`$#', `3',
 `SectionPCM.STR($1) {'
 `'
 `	# used for binding to the PCM'
@@ -101,10 +104,12 @@ define(`PCM_CAPTURE_ADD',
 `'
 `		capabilities STR($3)'
 `	}'
-`}')
+`}', `fatal_error(`Invalid parameters ($#) to PCM_CAPTURE_ADD')')'
+)
 
 dnl PCM_DUPLEX_ADD(name, pcm_id, playback, capture)
 define(`PCM_DUPLEX_ADD',
+`ifelse(`$#', `4',
 `SectionPCM.STR($1) {'
 `'
 `	# used for binding to the PCM'
@@ -123,6 +128,7 @@ define(`PCM_DUPLEX_ADD',
 `'
 `		capabilities STR($3)'
 `	}'
-`}')
+`}', `fatal_error(`Invalid parameters ($#) to PCM_DUPLEX_ADD')')'
+)
 
 divert(0)dnl

--- a/tools/topology/m4/utils.m4
+++ b/tools/topology/m4/utils.m4
@@ -10,6 +10,9 @@ dnl Argument iterator.
 define(`argn', `ifelse(`$1', 1, ``$2'',
        `argn(decr(`$1'), shift(shift($@)))')')
 
+define(`fatal_error', `errprint(`m4: '__file__: __line__`: fatal error: $*
+')m4exit(1)')
+
 dnl Defines a list of items from a variable number of params.
 dnl Use as last argument in a macro.
 dnl The first argument specifies the number of tabs to be added for formatting


### PR DESCRIPTION
@ranj063 Ranjani (and others) would this be close to what you had in mind? If the general approach is ok, I can extend to other APIs. For others, we had a chat about this with Ranjani and thought this could be a good general enhancement to the topology macros.

Add check on correct number of parameters to PCM macros.
This should help to catch invalid usage.

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>