### PR TITLE
ssi-spi: fix a regression, caused by a scheduler-update

### DIFF
--- a/src/drivers/dw/ssi-spi.c
+++ b/src/drivers/dw/ssi-spi.c
@@ -428,10 +428,9 @@ static int spi_slave_init(struct spi *spi)
 	config->dir = SPI_DIR_TX;
 	config->src_buf = spi->tx_buffer;
 
-	schedule_task_init(&spi->completion, SOF_SCHEDULE_EDF, SOF_TASK_PRI_MED,
-			   spi_completion_work, spi, 0, 0);
-
-	return 0;
+	spi->completion.private = NULL;
+	return schedule_task_init(&spi->completion, SOF_SCHEDULE_EDF,
+			SOF_TASK_PRI_MED, spi_completion_work, spi, 0, 0);
 }
 
 int spi_probe(struct spi *spi)


### PR DESCRIPTION
After a recent scheduler update the API has changed: now it requires
task's private pointer to be NULL before calling schedule_task_init()