### PR TITLE
EQ: Fix IPC data copy size in new() method in IIR and FIR

### DIFF
--- a/src/audio/eq_fir.c
+++ b/src/audio/eq_fir.c
@@ -376,6 +376,7 @@ static struct comp_dev *eq_fir_new(struct sof_ipc_comp *comp)
 {
 	struct comp_dev *dev;
 	struct comp_data *cd;
+	struct sof_ipc_comp_process *fir;
 	struct sof_ipc_comp_process *ipc_fir
 		= (struct sof_ipc_comp_process *)comp;
 	size_t bs = ipc_fir->size;
@@ -402,8 +403,9 @@ static struct comp_dev *eq_fir_new(struct sof_ipc_comp *comp)
 	if (!dev)
 		return NULL;
 
-	err = memcpy_s(&dev->comp, sizeof(dev->comp), comp,
-		       sizeof(struct sof_ipc_comp_process));
+	fir = (struct sof_ipc_comp_process *)&dev->comp;
+	err = memcpy_s(fir, sizeof(*fir),
+		       ipc_fir, sizeof(struct sof_ipc_comp_process));
 
 	cd = rzalloc(RZONE_RUNTIME, SOF_MEM_CAPS_RAM, sizeof(*cd));
 	if (!cd) {

--- a/src/audio/eq_iir.c
+++ b/src/audio/eq_iir.c
@@ -481,6 +481,7 @@ static struct comp_dev *eq_iir_new(struct sof_ipc_comp *comp)
 {
 	struct comp_dev *dev;
 	struct comp_data *cd;
+	struct sof_ipc_comp_process *iir;
 	struct sof_ipc_comp_process *ipc_iir =
 		(struct sof_ipc_comp_process *)comp;
 	size_t bs = ipc_iir->size;
@@ -507,8 +508,9 @@ static struct comp_dev *eq_iir_new(struct sof_ipc_comp *comp)
 	if (!dev)
 		return NULL;
 
-	err = memcpy_s(&dev->comp, sizeof(dev->comp),
-		       comp, sizeof(struct sof_ipc_comp_process));
+	iir = (struct sof_ipc_comp_process *)&dev->comp;
+	err = memcpy_s(iir, sizeof(*iir),
+		       ipc_iir, sizeof(struct sof_ipc_comp_process));
 
 	cd = rzalloc(RZONE_RUNTIME, SOF_MEM_CAPS_RAM, sizeof(*cd));
 	if (!cd) {


### PR DESCRIPTION
The used memcpy_s() has wrong size for destination. It causes the
prepare() method to fail later in component life cycle into sink buffer
resize due to zero config->periods_sink value. This patch fixes the
fail of pipeline instantantion with IIR and FIR EQ components.

this fixes #1190 

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>