### PR TITLE
cavs: ssp: generic ssp mclk configuration for cavs

### DIFF
--- a/src/include/sof/clk.h
+++ b/src/include/sof/clk.h
@@ -36,6 +36,10 @@
 #define CLOCK_NOTIFY_PRE	0
 #define CLOCK_NOTIFY_POST	1
 
+#define CLOCK_SSP_XTAL_OSCILLATOR		0x0
+#define CLOCK_SSP_AUDIO_CARDINAL		0x1
+#define CLOCK_SSP_PLL_FIXED			0x2
+
 struct clock_notify_data {
 	uint32_t old_freq;
 	uint32_t old_ticks_per_msec;

--- a/src/include/sof/ssp.h
+++ b/src/include/sof/ssp.h
@@ -37,6 +37,7 @@
 #include <sof/schedule.h>
 #include <sof/trace.h>
 #include <sof/wait.h>
+#include <platform/clk-map.h>
 
 #define SSP_CLK_AUDIO	0
 #define SSP_CLK_NET_PLL	1
@@ -223,6 +224,11 @@ extern const struct dai_ops ssp_ops;
 #if CONFIG_CAVS
 #define MNDSS(x)	((x) << 20)
 #define MCDSS(x)	((x) << 16)
+#endif
+
+#if CONFIG_CAVS
+/* max possible index in ssp_freq array */
+#define MAX_SSP_FREQ_INDEX (ARRAY_SIZE(ssp_freq) - 1)
 #endif
 
 /* tracing */

--- a/src/include/sof/ssp.h
+++ b/src/include/sof/ssp.h
@@ -128,8 +128,7 @@ extern const struct dai_ops ssp_ops;
 #define SSCR2_ASRC_CNTR_CLR		BIT(9)
 #define SSCR2_ASRC_FRM_CNRT_EN		BIT(10)
 #define SSCR2_ASRC_INTR_MASK		BIT(11)
-#elif CONFIG_APOLLOLAKE || CONFIG_CANNONLAKE || CONFIG_ICELAKE || \
-	CONFIG_SUECREEK || CONFIG_HASWELL || CONFIG_BROADWELL
+#elif CONFIG_CAVS || CONFIG_HASWELL || CONFIG_BROADWELL
 #define SSCR2_TURM1		BIT(1)
 #define SSCR2_PSPSRWFDFD	BIT(3)
 #define SSCR2_PSPSTWFDFD	BIT(4)
@@ -168,7 +167,7 @@ extern const struct dai_ops ssp_ops;
 #define SSPSP2			0x44
 #define SSPSP2_FEP_MASK		0xff
 
-#if CONFIG_APOLLOLAKE || CONFIG_CANNONLAKE || CONFIG_ICELAKE || CONFIG_SUECREEK
+#if CONFIG_CAVS
 #define SSCR3		0x48
 #define SSIOC		0x4C
 
@@ -205,8 +204,7 @@ extern const struct dai_ops ssp_ops;
 #define SFIFOL_TFL(x)		((x) & 0xFFFF)
 #define SFIFOL_RFL(x)		((x) >> 16)
 
-#if CONFIG_APOLLOLAKE || CONFIG_CANNONLAKE || CONFIG_SUECREEK \
-	|| CONFIG_ICELAKE || CONFIG_HASWELL || CONFIG_BROADWELL
+#if CONFIG_CAVS || CONFIG_HASWELL || CONFIG_BROADWELL
 #define SSTSA_TSEN			BIT(8)
 #define SSRSA_RSEN			BIT(8)
 
@@ -222,7 +220,7 @@ extern const struct dai_ops ssp_ops;
 #define SSIOC_SCOE	BIT(5)
 #endif
 
-#if CONFIG_APOLLOLAKE || CONFIG_CANNONLAKE || CONFIG_ICELAKE || CONFIG_SUECREEK
+#if CONFIG_CAVS
 #define MNDSS(x)	((x) << 20)
 #define MCDSS(x)	((x) << 16)
 #endif

--- a/src/platform/apollolake/include/platform/clk-map.h
+++ b/src/platform/apollolake/include/platform/clk-map.h
@@ -31,15 +31,21 @@
 #ifndef __INCLUDE_CLOCK_MAP__
 #define __INCLUDE_CLOCK_MAP__
 
+#include <sof/clk.h>
+
 static const struct freq_table cpu_freq[] = {
 	{100000000, 100000, 0x3},
 	{200000000, 200000, 0x1},
 	{400000000, 400000, 0x0}, /* default */
 };
 
+/* IMPORTANT: array should be filled in increasing order
+ * (regarding to .freq field)
+ */
 static const struct freq_table ssp_freq[] = {
-	{19200000, 19200, }, /* default */
-	{24576000, 24576, },
+	{ 19200000, 19200, CLOCK_SSP_XTAL_OSCILLATOR },
+	{ 24576000, 24576, CLOCK_SSP_AUDIO_CARDINAL },
+	{ 96000000, 96000, CLOCK_SSP_PLL_FIXED },
 };
 
 #endif

--- a/src/platform/baytrail/include/platform/clk-map.h
+++ b/src/platform/baytrail/include/platform/clk-map.h
@@ -31,6 +31,8 @@
 #ifndef __INCLUDE_CLOCK_MAP__
 #define __INCLUDE_CLOCK_MAP__
 
+#include <sof/clk.h>
+
 #if defined CONFIG_BAYTRAIL
 static const struct freq_table cpu_freq[] = {
 	{25000000, 25000, 0x0},

--- a/src/platform/cannonlake/include/platform/clk-map.h
+++ b/src/platform/cannonlake/include/platform/clk-map.h
@@ -31,14 +31,19 @@
 #ifndef __INCLUDE_CLOCK_MAP__
 #define __INCLUDE_CLOCK_MAP__
 
+#include <sof/clk.h>
+
 static const struct freq_table cpu_freq[] = {
 	{120000000, 120000, 0x0},
 	{400000000, 400000, 0x4}, /* default */
 };
 
+/* IMPORTANT: array should be filled in increasing order
+ * (regarding to .freq field)
+ */
 static const struct freq_table ssp_freq[] = {
-	{19200000, 19200, }, /* default */
-	{24000000, 24000, },
+	{ 24000000, 24000, CLOCK_SSP_XTAL_OSCILLATOR },
+	{ 96000000, 96000, CLOCK_SSP_PLL_FIXED },
 };
 
 #endif

--- a/src/platform/haswell/include/platform/clk-map.h
+++ b/src/platform/haswell/include/platform/clk-map.h
@@ -31,6 +31,8 @@
 #ifndef __INCLUDE_CLOCK_MAP__
 #define __INCLUDE_CLOCK_MAP__
 
+#include <sof/clk.h>
+
 static const struct freq_table cpu_freq[] = {
 	{32000000, 32000, 0x6},
 	{80000000, 80000, 0x2},

--- a/src/platform/icelake/include/platform/clk-map.h
+++ b/src/platform/icelake/include/platform/clk-map.h
@@ -31,14 +31,20 @@
 #ifndef __INCLUDE_CLOCK_MAP__
 #define __INCLUDE_CLOCK_MAP__
 
+#include <sof/clk.h>
+
 static const struct freq_table cpu_freq[] = {
 	{120000000, 120000, 0x0},
 	{400000000, 400000, 0x4}, /* default */
 };
 
+/* IMPORTANT: array should be filled in increasing order
+ * (regarding to .freq field)
+ */
 static const struct freq_table ssp_freq[] = {
-	{19200000, 19200, }, /* default */
-	{38400000, 38400, },
+	{ 24576000, 24576, CLOCK_SSP_AUDIO_CARDINAL },
+	{ 38400000, 38400, CLOCK_SSP_XTAL_OSCILLATOR },
+	{ 96000000, 96000, CLOCK_SSP_PLL_FIXED },
 };
 
 #endif

--- a/src/platform/suecreek/include/platform/clk-map.h
+++ b/src/platform/suecreek/include/platform/clk-map.h
@@ -31,14 +31,19 @@
 #ifndef __INCLUDE_CLOCK_MAP__
 #define __INCLUDE_CLOCK_MAP__
 
+#include <sof/clk.h>
+
 static const struct freq_table cpu_freq[] = {
 	{120000000, 120000, 0x0},
 	{400000000, 400000, 0x4}, /* default */
 };
 
+/* IMPORTANT: array should be filled in increasing order
+ * (regarding to .freq field)
+ */
 static const struct freq_table ssp_freq[] = {
-	{19200000, 19200, }, /* default */
-	{24000000, 24000, },
+	{ 38400000, 38400, CLOCK_SSP_XTAL_OSCILLATOR },
+	{ 96000000, 96000, CLOCK_SSP_PLL_FIXED },
 };
 
 #endif


### PR DESCRIPTION
Unification in setting mclk and bclk in ssp_config() for cavs platform.
Now ssp clk information are placed in include/platform/clk-map.h. I've
added also possibility to select PLL Fixed clock as a mclk and bclk
source for cavs platforms.

issue: #560