### PR TITLE
cmake: generate map (section header list) file for sof elf

### DIFF
--- a/src/arch/xtensa/CMakeLists.txt
+++ b/src/arch/xtensa/CMakeLists.txt
@@ -272,6 +272,7 @@ endif()
 add_custom_target(
 	sof_dump
 	COMMAND ${CMAKE_OBJDUMP} -S sof-${fw_name} > sof-${fw_name}.lst
+	COMMAND ${CMAKE_OBJDUMP} -h sof-${fw_name} > sof-${fw_name}.map
 	COMMAND ${CMAKE_OBJDUMP} -D sof-${fw_name} > sof-${fw_name}.dis
 	DEPENDS process_base_module
 	VERBATIM


### PR DESCRIPTION
This file is useful to visualize memory map of the fw image
with much more details than using just the aggregated data
available from the .ri file manifest.

Signed-off-by: Marcin Maka <marcin.maka@linux.intel.com>