### PR TITLE
tools: logger: added less formatted output mode

### DIFF
--- a/tools/logger/convert.h
+++ b/tools/logger/convert.h
@@ -35,6 +35,7 @@ struct convert_config {
 	FILE *version_fd;
 	int use_colors;
 	int serial_fd;
+	int raw_output;
 };
 
 int convert(const struct convert_config *config);

--- a/tools/logger/logger.c
+++ b/tools/logger/logger.c
@@ -46,6 +46,7 @@ static void usage(void)
 	fprintf(stdout, "%s:\t -s\t\t\tTake a snapshot of state\n", APP_NAME);
 	fprintf(stdout, "%s:\t -t\t\t\tDisplay trace data\n", APP_NAME);
 	fprintf(stdout, "%s:\t -u baud\t\tInput data from a UART\n", APP_NAME);
+	fprintf(stdout, "%s:\t -r less formatted output for chained log processors\n", APP_NAME);
 	exit(0);
 }
 
@@ -149,8 +150,9 @@ int main(int argc, char *argv[])
 	config.version_fw = 0;
 	config.use_colors = 1;
 	config.serial_fd = -EINVAL;
+	config.raw_output = 0;
 
-	while ((opt = getopt(argc, argv, "ho:i:l:ps:c:u:tev:")) != -1) {
+	while ((opt = getopt(argc, argv, "ho:i:l:ps:c:u:tev:r")) != -1) {
 		switch (opt) {
 		case 'o':
 			config.out_file = optarg;
@@ -182,6 +184,9 @@ int main(int argc, char *argv[])
 			break;
 		case 'u':
 			baud = atoi(optarg);
+			break;
+		case 'r':
+			config.raw_output = 1;
 			break;
 		case 'v':
 			/* enabling checking fw version with ver_file file */


### PR DESCRIPTION
Activated by '-r' option. Useful for intermediate log
processing when the output is used as an input for another
tool. No headers, tokens separated by single spaces,
component ids concatenated with component name to
still produce a single token if present.

Signed-off-by: Marcin Maka <marcin.maka@linux.intel.com>