### PR TITLE
scripts: build-tools: exit immediately when return an error value

### DIFF
--- a/scripts/build-tools.sh
+++ b/scripts/build-tools.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# fail immediately on any errors
+set -e
+
 cd tools
 
 rm -rf build_tools


### PR DESCRIPTION
fix build-tools script to exit immediately when error occurs.

Signed-off-by: Xun Zhang <xun2.zhang@intel.com>