### PR TITLE
topology: update HDA index

### DIFF
--- a/tools/topology/sof-cml-rt5682.m4
+++ b/tools/topology/sof-cml-rt5682.m4
@@ -156,8 +156,8 @@ DAI_CONFIG(DMIC, 0, 1, dmic01,
 
 # 3 HDMI/DP outputs (ID: 2,3,4)
 DAI_CONFIG(HDA, 0, 2, iDisp1)
-DAI_CONFIG(HDA, 0, 3, iDisp2)
-DAI_CONFIG(HDA, 0, 4, iDisp3)
+DAI_CONFIG(HDA, 1, 3, iDisp2)
+DAI_CONFIG(HDA, 2, 4, iDisp3)
 
 
 DEBUG_END

--- a/tools/topology/sof-cml-src-rt5682.m4
+++ b/tools/topology/sof-cml-src-rt5682.m4
@@ -150,8 +150,8 @@ DAI_CONFIG(DMIC, 0, 1, dmic01,
 
 # 3 HDMI/DP outputs (ID: 2,3,4)
 DAI_CONFIG(HDA, 0, 2, iDisp1)
-DAI_CONFIG(HDA, 0, 3, iDisp2)
-DAI_CONFIG(HDA, 0, 4, iDisp3)
+DAI_CONFIG(HDA, 1, 3, iDisp2)
+DAI_CONFIG(HDA, 2, 4, iDisp3)
 
 
 DEBUG_END


### PR DESCRIPTION
The index should be 0,1,2 instead of all 0.

Signed-off-by: Bard liao <yung-chuan.liao@linux.intel.com>