### PR TITLE
HDA-DMA: postpone update of free bytes, add blocking mode

### DIFF
--- a/src/platform/apollolake/include/platform/platform.h
+++ b/src/platform/apollolake/include/platform/platform.h
@@ -109,7 +109,7 @@ struct sof;
 #define PLATFORM_DMA_TIMEOUT	1333
 
 /* DMA host transfer timeouts in microseconds */
-#define PLATFORM_HOST_DMA_TIMEOUT	200
+#define PLATFORM_HOST_DMA_TIMEOUT	400
 
 /* DMA link transfer timeouts in microseconds
  * TODO: timeout should be reduced


### PR DESCRIPTION
This change adds blocking mode into hda-dma.
    It is necessary because we should not update
    post-copy data without being sure dma copy has been
    finished.

Signed-off-by: Marcin Rajwa <marcin.rajwa@linux.intel.com>