### PR TITLE
SRC: Add support for timer based scheduling

### DIFF
--- a/src/audio/src.h
+++ b/src/audio/src.h
@@ -44,8 +44,6 @@ struct src_param {
 	int blk_out;
 	int stage1_times;
 	int stage2_times;
-	int stage1_times_max;
-	int stage2_times_max;
 	int idx_in;
 	int idx_out;
 	int nch;
@@ -133,7 +131,7 @@ void src_polyphase_stage_cir(struct src_stage_prm *s);
 void src_polyphase_stage_cir_s16(struct src_stage_prm *s);
 
 int src_buffer_lengths(struct src_param *p, int fs_in, int fs_out, int nch,
-		       int frames, int frames_is_for_source);
+		       int source_frames);
 
 int32_t src_input_rates(void);
 


### PR DESCRIPTION
This patch adds to SRC for timer based scheduling capability to
determine in copy() the number of frames to process. Due to
potentially high computational load the max amount to process is
limited to just exceed the nominal number of frames per
scheduling rate. It prevents SRC to be preempted due to too long
processing time and cause pipeline xruns in the start of playback
when the buffers contain a large number of frames.

The pre-fill of samples in first copy() is removed since the just
above period length of data processing target avoids the sink
buffer to get too small number of frames for the downstream
pipeline.

The currently happening bad metallic sound with SRC in pipeline
is fixed by this patch.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>