### PR TITLE
tools: logger: ignore end-of-file in trace mode

### DIFF
--- a/tools/logger/convert.c
+++ b/tools/logger/convert.c
@@ -371,10 +371,13 @@ static int logger_read(const struct convert_config *config,
 				return ret;
 		}
 
-	while (!feof(config->in_fd)) {
+	while (!ferror(config->in_fd)) {
 		/* getting entry parameters from dma dump */
 		ret = fread(&dma_log, sizeof(dma_log), 1, config->in_fd);
 		if (!ret) {
+			if (config->trace)
+				continue;
+
 			return -ferror(config->in_fd);
 		}
 


### PR DESCRIPTION
Change logger behaviour such that in trace (-t) mode logger
only stops if an error is detected. If no error, logger
continues to try and read data from the debugfs node.

Closes thesofproject/linux#486

Note: this works standalone but you get a more consistant trace out together with following kernel change in RFC:
https://github.com/thesofproject/linux/pull/781

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>