### PR TITLE
heap-debug: use the correct functions for heap trace

### DIFF
--- a/src/lib/alloc.c
+++ b/src/lib/alloc.c
@@ -472,7 +472,8 @@ void alloc_trace_runtime_heap(int zone, uint32_t caps, size_t bytes)
 	/* check runtime heap for capabilities */
 	trace_mem_error("heap: using runtime");
 	do {
-		heap = get_runtime_heap_from_caps(caps, current);
+		heap = get_heap_from_caps(memmap.runtime, PLATFORM_HEAP_RUNTIME,
+					  caps);
 		if (heap) {
 			trace_heap_blocks(heap);
 			count++;
@@ -494,7 +495,8 @@ void alloc_trace_buffer_heap(int zone, uint32_t caps, size_t bytes)
 	/* check buffer heap for capabilities */
 	trace_mem_error("heap: using buffer");
 	do {
-		heap = get_buffer_heap_from_caps(caps, current);
+		heap = get_heap_from_caps(memmap.buffer, PLATFORM_HEAP_BUFFER,
+					  caps);
 		if (heap) {
 			trace_heap_blocks(heap);
 			count++;


### PR DESCRIPTION
For for this issue: https://github.com/thesofproject/sof/issues/1222

This fix will just use the correct functions in trace heap, previous functions simply does not exist

Signed-off-by: Adrian Bonislawski <adrian.bonislawski@linux.intel.com>