### PR TITLE
hd-dma: add host blocking copy implementation

### DIFF
--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -789,7 +789,7 @@ static int host_copy(struct comp_dev *dev)
 	 */
 	if (pipeline_is_preload(dev->pipeline)) {
 		ret = dma_copy(hd->dma, hd->chan, hd->dma_buffer->size,
-			       DMA_COPY_PRELOAD);
+			       DMA_COPY_PRELOAD | DMA_COPY_BLOCKING);
 		if (ret < 0) {
 			trace_host_error("host_copy() error: dma_copy() "
 					 "failed, ret = %u", ret);

--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -626,8 +626,8 @@ static int host_params(struct comp_dev *dev)
 	}
 #endif
 	/* set up callback */
-	dma_set_cb(hd->dma, hd->chan, DMA_CB_TYPE_LLIST | DMA_CB_TYPE_PROCESS,
-		   host_dma_cb, dev);
+	dma_set_cb(hd->dma, hd->chan, DMA_CB_TYPE_LLI_TRANSFER |
+		   DMA_CB_TYPE_PROCESS, host_dma_cb, dev);
 
 	return 0;
 }

--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -788,7 +788,7 @@ static int host_copy(struct comp_dev *dev)
 	 * in host_buffer_cb()
 	 */
 	if (pipeline_is_preload(dev->pipeline)) {
-		ret = dma_copy(hd->dma, hd->chan, hd->period_bytes,
+		ret = dma_copy(hd->dma, hd->chan, hd->dma_buffer->size,
 			       DMA_COPY_PRELOAD);
 		if (ret < 0) {
 			trace_host_error("host_copy() error: dma_copy() "

--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -589,7 +589,7 @@ static int dw_dma_release(struct dma *dma, int channel)
 			(chan->ptr_data.end_ptr - chan->ptr_data.current_ptr) +
 			(next_ptr - chan->ptr_data.start_ptr);
 
-	dw_dma_copy(dma, channel, bytes_left, DMA_COPY_BLOCK);
+	dw_dma_copy(dma, channel, bytes_left, DMA_COPY_LLI_BLOCK);
 
 	spin_unlock_irq(&dma->lock, flags);
 	return 0;
@@ -1297,12 +1297,12 @@ static int dw_dma_copy(struct dma *dma, int channel, int bytes, uint32_t flags)
 		     channel);
 
 #if DW_USE_HW_LLI
-	if (flags & DMA_COPY_BLOCK)
+	if (flags & DMA_COPY_LLI_BLOCK)
 		dw_dma_irq_callback(chan, &next, DMA_CB_TYPE_PROCESS,
 				    &dw_dma_verify_block);
 #endif
 
-	if (flags & DMA_COPY_LLIST)
+	if (flags & DMA_COPY_LLI_TRANSFER)
 		dw_dma_irq_callback(chan, &next, DMA_CB_TYPE_PROCESS,
 				    &dw_dma_verify_transfer);
 
@@ -1368,8 +1368,8 @@ static void dw_dma_irq_handler(void *data)
 #if DW_USE_HW_LLI
 	/* end of a LLI block */
 	if (status_block & mask &&
-	    p->chan[i].cb_type & DMA_CB_TYPE_BLOCK)
-		dw_dma_irq_callback(&p->chan[i], &next, DMA_CB_TYPE_BLOCK,
+	    p->chan[i].cb_type & DMA_CB_TYPE_LLI_BLOCK)
+		dw_dma_irq_callback(&p->chan[i], &next, DMA_CB_TYPE_LLI_BLOCK,
 				    &dw_dma_verify_block);
 #endif
 }
@@ -1481,16 +1481,16 @@ static void dw_dma_irq_handler(void *data)
 #if DW_USE_HW_LLI
 		/* end of a LLI block */
 		if (status_block & mask &&
-		    p->chan[i].cb_type & DMA_CB_TYPE_BLOCK)
+		    p->chan[i].cb_type & DMA_CB_TYPE_LLI_BLOCK)
 			dw_dma_irq_callback(&p->chan[i], &next,
-					    DMA_CB_TYPE_BLOCK,
+					    DMA_CB_TYPE_LLI_BLOCK,
 					    &dw_dma_verify_block);
 #endif
 		/* end of a transfer */
 		if (status_tfr & mask &&
-		    p->chan[i].cb_type & DMA_CB_TYPE_LLIST)
+		    p->chan[i].cb_type & DMA_CB_TYPE_LLI_TRANSFER)
 			dw_dma_irq_callback(&p->chan[i], &next,
-					    DMA_CB_TYPE_LLIST,
+					    DMA_CB_TYPE_LLI_TRANSFER,
 					    &dw_dma_verify_transfer);
 	}
 }

--- a/src/drivers/dw/ssi-spi.c
+++ b/src/drivers/dw/ssi-spi.c
@@ -484,9 +484,9 @@ int spi_probe(struct spi *spi)
 	spi->ipc_status = IPC_READ;
 
 	dma_set_cb(spi->dma[SPI_DIR_RX], spi->chan[SPI_DIR_RX],
-		   DMA_CB_TYPE_BLOCK, spi_dma_complete, spi);
+		   DMA_CB_TYPE_LLI_BLOCK, spi_dma_complete, spi);
 	dma_set_cb(spi->dma[SPI_DIR_TX], spi->chan[SPI_DIR_TX],
-		   DMA_CB_TYPE_BLOCK, spi_dma_complete, spi);
+		   DMA_CB_TYPE_LLI_BLOCK, spi_dma_complete, spi);
 
 	return spi_slave_init(spi);
 }

--- a/src/drivers/intel/cavs/hda-dma.c
+++ b/src/drivers/intel/cavs/hda-dma.c
@@ -299,7 +299,8 @@ static int hda_dma_host_preload(struct dma *dma, struct hda_chan_data *chan)
 		period_cnt = chan->buffer_bytes / chan->period_bytes;
 		for (i = 0; i < period_cnt; i++) {
 			next.size = chan->period_bytes;
-			chan->cb(chan->cb_data, DMA_CB_TYPE_LLIST, &next);
+			chan->cb(chan->cb_data, DMA_CB_TYPE_LLI_TRANSFER,
+				 &next);
 		}
 		/* do not need to test out next in this path */
 	}

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -146,6 +146,12 @@
 #define COMP_STATUS_STATE_ALREADY_SET	1	/**< Comp set state status */
 /** @}*/
 
+/** \name Component attribute types
+ *  @{
+ */
+#define COMP_ATTR_COPY_BLOCKING	0	/**< Comp blocking copy attribute */
+/** @}*/
+
 /** \name Declare component macro
  *  \brief Usage at the end of comp file: DECLARE_COMPONENT(sys_comp_*_init);
  *  @{
@@ -217,6 +223,10 @@ struct comp_ops {
 
 	/** cache operation on component data */
 	void (*cache)(struct comp_dev *dev, int cmd);
+
+	/** set attribute in component */
+	int (*set_attribute)(struct comp_dev *dev, uint32_t type,
+			     uint32_t value);
 };
 
 
@@ -520,6 +530,21 @@ static inline void comp_cache(struct comp_dev *dev, int cmd)
 {
 	if (dev->drv->ops.cache)
 		dev->drv->ops.cache(dev, cmd);
+}
+
+/**
+ * Sets component attribute.
+ * @param dev Component device.
+ * @param type Attribute type.
+ * @param type Attribute value.
+ * @return 0 if succeeded, error code otherwise.
+ */
+static inline int comp_set_attribute(struct comp_dev *dev, uint32_t type,
+				     uint32_t value)
+{
+	if (dev->drv->ops.set_attribute)
+		return dev->drv->ops.set_attribute(dev, type, value);
+	return 0;
 }
 
 /** @}*/

--- a/src/include/sof/dma.h
+++ b/src/include/sof/dma.h
@@ -79,14 +79,14 @@
 #define DMA_ACCESS_SHARED	0
 
 /* DMA callback types */
-#define DMA_CB_TYPE_BLOCK	BIT(0)
-#define DMA_CB_TYPE_LLIST	BIT(1)
-#define DMA_CB_TYPE_PROCESS	BIT(2)
+#define DMA_CB_TYPE_LLI_BLOCK		BIT(0)
+#define DMA_CB_TYPE_LLI_TRANSFER	BIT(1)
+#define DMA_CB_TYPE_PROCESS		BIT(2)
 
 /* DMA copy flags */
 #define DMA_COPY_PRELOAD	BIT(0)
-#define DMA_COPY_BLOCK		BIT(1)
-#define DMA_COPY_LLIST		BIT(2)
+#define DMA_COPY_LLI_BLOCK	BIT(1)
+#define DMA_COPY_LLI_TRANSFER	BIT(2)
 
 /* We will use this macro in cb handler to inform dma that
  * we need to stop the reload for special purpose

--- a/src/include/sof/dma.h
+++ b/src/include/sof/dma.h
@@ -85,8 +85,9 @@
 
 /* DMA copy flags */
 #define DMA_COPY_PRELOAD	BIT(0)
-#define DMA_COPY_LLI_BLOCK	BIT(1)
-#define DMA_COPY_LLI_TRANSFER	BIT(2)
+#define DMA_COPY_BLOCKING	BIT(1)
+#define DMA_COPY_LLI_BLOCK	BIT(2)
+#define DMA_COPY_LLI_TRANSFER	BIT(3)
 
 /* We will use this macro in cb handler to inform dma that
  * we need to stop the reload for special purpose

--- a/src/ipc/dma-copy.c
+++ b/src/ipc/dma-copy.c
@@ -79,7 +79,7 @@ static void dma_complete(void *data, uint32_t type, struct dma_sg_elem *next)
 {
 	completion_t *comp = (completion_t *)data;
 
-	if (type == DMA_CB_TYPE_LLIST)
+	if (type == DMA_CB_TYPE_LLI_TRANSFER)
 		wait_completed(comp);
 
 	ipc_dma_trace_send_position();
@@ -185,8 +185,8 @@ int dma_copy_new(struct dma_copy *dc)
 	}
 
 	dc->complete.timeout = 100;	/* wait 100 usecs for DMA to finish */
-	dma_set_cb(dc->dmac, dc->chan, DMA_CB_TYPE_LLIST, dma_complete,
-		&dc->complete);
+	dma_set_cb(dc->dmac, dc->chan, DMA_CB_TYPE_LLI_TRANSFER, dma_complete,
+		   &dc->complete);
 #endif
 
 	return 0;

--- a/src/ipc/ipc.c
+++ b/src/ipc/ipc.c
@@ -513,7 +513,7 @@ static void dma_complete(void *data, uint32_t type, struct dma_sg_elem *next)
 {
 	completion_t *complete = data;
 
-	if (type == DMA_CB_TYPE_LLIST)
+	if (type == DMA_CB_TYPE_LLI_TRANSFER)
 		wait_completed(complete);
 }
 
@@ -562,7 +562,8 @@ int ipc_get_page_descriptors(struct dma *dmac, uint8_t *page_table,
 	}
 
 	/* set up callback */
-	dma_set_cb(dmac, chan, DMA_CB_TYPE_LLIST, dma_complete, &complete);
+	dma_set_cb(dmac, chan, DMA_CB_TYPE_LLI_TRANSFER, dma_complete,
+		   &complete);
 
 	wait_init(&complete);
 


### PR DESCRIPTION
Adds implementation of blocking copy mode for Host DMA.
In blocking mode we are waiting for data to be copied
after incrementing DMA pointer.