### PR TITLE
rimage: enable key to be override by ENV

### DIFF
--- a/rimage/rimage.c
+++ b/rimage/rimage.c
@@ -52,6 +52,7 @@ int main(int argc, char *argv[])
 {
 	struct image image;
 	const char *mach = NULL;
+	const char *env_key = NULL;
 	int opt, ret, i, elf_argc = 0;
 
 	memset(&image, 0, sizeof(image));
@@ -88,6 +89,12 @@ int main(int argc, char *argv[])
 		default:
 			break;
 		}
+	}
+
+	env_key = getenv("SOF_RIMAGE_KEY");
+	if (env_key) {
+		fprintf(stdout, "using ENV key %s\n", env_key);
+		image.key_name = env_key;
 	}
 
 	elf_argc = optind;


### PR DESCRIPTION
To use the key from ENV instead of args.

Signed-off-by: Pan Xiuli <xiuli.pan@linux.intel.com>

some enhancement to https://github.com/thesofproject/sof/pull/1239
usage:
```
export SOF_RIMAGE_KEY=path/to/you/key
make bin

...
using ENV key path/to/you/key
...
Firmware file size 0x2d000 page count 39
 pkcs: signing with key path/to/you/key
...
```
Fix #1238 