### PR TITLE
panic: panicinfo filename OOB fix

### DIFF
--- a/src/include/uapi/ipc/trace.h
+++ b/src/include/uapi/ipc/trace.h
@@ -86,7 +86,9 @@ struct sof_ipc_dma_trace_posn {
 #define SOF_IPC_PANIC_WFI			(SOF_IPC_PANIC_MAGIC | 0xa)
 #define SOF_IPC_PANIC_ASSERT			(SOF_IPC_PANIC_MAGIC | 0xb)
 
-/* panic info include filename and line number */
+/* panic info include filename and line number
+ * filename array will not include null terminator if fully filled
+ */
 struct sof_ipc_panic_info {
 	struct sof_ipc_hdr hdr;
 	uint32_t code;			/* SOF_IPC_PANIC_ */

--- a/src/lib/panic.c
+++ b/src/lib/panic.c
@@ -99,8 +99,14 @@ void __panic(uint32_t p, char *filename, uint32_t linenum)
 	int strlen;
 
 	strlen = rstrlen(filename);
+	if (strlen >= SOF_TRACE_FILENAME_SIZE) {
+		rmemcpy(panicinfo.filename, filename + strlen -
+			SOF_TRACE_FILENAME_SIZE, SOF_TRACE_FILENAME_SIZE);
+		rmemcpy(panicinfo.filename, "...", 3);
+	} else {
+		rmemcpy(panicinfo.filename, filename, strlen + 1);
+	}
 	panicinfo.linenum = linenum;
-	rmemcpy(panicinfo.filename, filename, strlen + 1);
 
 	panic_rewind(p, 0, &panicinfo);
 }


### PR DESCRIPTION
For this issue: https://github.com/thesofproject/sof/issues/1242

Now in the coredump-reader linenum will be displayed correctly along with a truncated location, example:

Location: .../TEST22/sof/src/ipc/handler.c:1089

Signed-off-by: Adrian Bonislawski <adrian.bonislawski@linux.intel.com>