### PR TITLE
schedule: switch IPC and IDC tasks to low priority

### DIFF
--- a/src/include/sof/schedule.h
+++ b/src/include/sof/schedule.h
@@ -59,8 +59,8 @@ enum {
 
 #define SOF_TASK_PRI_COUNT	10	/* range of priorities (0-9) */
 
-#define SOF_TASK_PRI_IPC	5
-#define SOF_TASK_PRI_IDC	5
+#define SOF_TASK_PRI_IPC	SOF_TASK_PRI_LOW
+#define SOF_TASK_PRI_IDC	SOF_TASK_PRI_LOW
 
 /* task states */
 #define SOF_TASK_STATE_INIT		0


### PR DESCRIPTION
Switches priority of IPC and IDC tasks back to low.
They were accidentally switched to higher priority
during schedule refactor.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>