### PR TITLE
dmic: fix dmic initial ramp regression

### DIFF
--- a/src/platform/cannonlake/include/platform/clk.h
+++ b/src/platform/cannonlake/include/platform/clk.h
@@ -41,7 +41,7 @@
 #define CLK_SSP		4
 
 #define CPU_DEFAULT_IDX		1
-#define SSP_DEFAULT_IDX		1
+#define SSP_DEFAULT_IDX		0
 
 #define CLK_DEFAULT_CPU_HZ	120000000
 #define CLK_MAX_CPU_HZ		400000000

--- a/src/platform/suecreek/include/platform/clk.h
+++ b/src/platform/suecreek/include/platform/clk.h
@@ -41,7 +41,7 @@
 #define CLK_SSP		4
 
 #define CPU_DEFAULT_IDX		1
-#define SSP_DEFAULT_IDX		1
+#define SSP_DEFAULT_IDX		0
 
 #define CLK_DEFAULT_CPU_HZ	120000000
 #define CLK_MAX_CPU_HZ		400000000


### PR DESCRIPTION
Set XTAL_OSCILLATOR clock as a default clock on CNL.
Setting PLL_FIXED clock as a default clock causes very long DMIC initial ramp.

![dmic-regression](https://user-images.githubusercontent.com/41052777/55811370-4ef3ef80-5ae9-11e9-8244-f10693f692a3.PNG)

Also fixes #1251 

Signed-off-by: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>