### PR TITLE
CMake/rimage: add option to use out-of-tree private key

### DIFF
--- a/scripts/xtensa-build-all.sh
+++ b/scripts/xtensa-build-all.sh
@@ -19,6 +19,7 @@ then
 	echo "       [-u] Force UP ARCH"
 	echo "       [-d] Enable debug build"
 	echo "       [-c] Configure defconfig"
+	echo "       [-k] Use private key"
 	echo "       [-j [n]] Set number of make build jobs." \
 		"Jobs=#cores when no flag. Inifinte when no arg."
 	echo "       Supported platforms ${SUPPORTED_PLATFORMS[@]}"
@@ -46,6 +47,10 @@ else
 		elif [[ "$args" == "-c" ]]
 			then
 			MAKE_MENUCONFIG=yes
+
+		elif [[ "$args" == "-k" ]]
+			then
+			USE_PRIVATE_KEY=yes
 
 		# Build all platforms
 		elif [[ "$args" == "-a" ]]
@@ -77,6 +82,16 @@ if [ ${#PLATFORMS[@]} -eq 0 ];
 then
 	echo "Error: No platforms specified. Supported are: ${SUPPORTED_PLATFORMS[@]}"
 	exit 1
+fi
+
+if [ "x$USE_PRIVATE_KEY" == "xyes" ]
+then
+	if [ -z ${RIMAGE_PRIVATE_KEY+x} ]
+	then
+		echo "Error: No variable specified for RIMAGE_PRIVATE_KEY"
+		exit 1
+	fi
+	PRIVATE_KEY_OPTION="-DRIMAGE_PRIVATE_KEY=${RIMAGE_PRIVATE_KEY}"
 fi
 
 # fail on any errors
@@ -252,6 +267,7 @@ do
 	cmake -DTOOLCHAIN=$TOOLCHAIN \
 		-DROOT_DIR=$ROOT \
 		-DCMAKE_VERBOSE_MAKEFILE=ON \
+		${PRIVATE_KEY_OPTION} \
 		..
 
 	make ${PLATFORM}_defconfig

--- a/src/arch/xtensa/CMakeLists.txt
+++ b/src/arch/xtensa/CMakeLists.txt
@@ -285,6 +285,10 @@ add_custom_target(
 	USES_TERMINAL
 )
 
+if(NOT DEFINED RIMAGE_PRIVATE_KEY)
+	set(RIMAGE_PRIVATE_KEY ${PROJECT_SOURCE_DIR}/rimage/keys/otc_private_key.pem)
+endif()
+
 if(MEU_PATH)
 	execute_process(
 		COMMAND ${MEU_PATH}/meu -ver
@@ -301,8 +305,6 @@ if(MEU_PATH)
 		set(MEU_OFFSET 1088)
 	endif()
 
-	set(otc_private_key ${PROJECT_SOURCE_DIR}/rimage/keys/otc_private_key.pem)
-
 	add_custom_target(
 		run_rimage
 		COMMAND ${PROJECT_BINARY_DIR}/rimage_ep/build/rimage
@@ -310,7 +312,7 @@ if(MEU_PATH)
 			-p sof-${fw_name}.ldc
 			-m ${fw_name}
 			-s ${MEU_OFFSET}
-			-k ${otc_private_key}
+			-k ${RIMAGE_PRIVATE_KEY}
 			${bootloader_binary_path}
 			sof-${fw_name}
 		DEPENDS sof_dump
@@ -340,6 +342,7 @@ else()
 			-o sof-${fw_name}.ri
 			-p sof-${fw_name}.ldc
 			-m ${fw_name}
+			-k ${RIMAGE_PRIVATE_KEY}
 			${bootloader_binary_path}
 			sof-${fw_name}
 		DEPENDS sof_dump


### PR DESCRIPTION
On specific Intel platforms, we have to use a private key which is not
shared with the rest of the world.

Extended xtensa-build-all.sh with an option, and pass the key path
explicitly to cmake.

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>