### PR TITLE
memory: fix wrong calculation of remaining free blocks

### DIFF
--- a/src/lib/alloc.c
+++ b/src/lib/alloc.c
@@ -258,8 +258,7 @@ static void *alloc_cont_blocks(struct mm_heap *heap, int level,
 	/* check if we have enough consecutive blocks for requested
 	 * allocation size.
 	 */
-	for (current = map->first_free; current < map->count ||
-	     count > remaining; current++) {
+	for (current = map->first_free; current < map->count; current++) {
 		hdr = &map->block[current];
 
 		if (!hdr->used)


### PR DESCRIPTION
This patch corrects the calculation of free blocks.
Now, once we allocate all free space, the allocator
will go beyond available space.

Signed-off-by: Marcin Rajwa <marcin.rajwa@linux.intel.com>
