### PR TITLE
coredump-reader: grep gdb output to print only interesting parts

### DIFF
--- a/tools/coredumper/sof-coredump-to-gdb.sh
+++ b/tools/coredumper/sof-coredump-to-gdb.sh
@@ -9,14 +9,15 @@ dump="${2}"
 
 reader_name="sof-coredump-reader.py" # in case it is changed
 reader_output="$(${THIS_SCRIPT_DIR}/${reader_name} -vc -i ${dump} -l 4 \
-		-o coredump-reader-output.txt)"
+		-o reader-output.txt)"
 reader_result="$?" # if $reader_name script fails, running xt-gdb is pointless
 if [[ ${reader_result} -ne 0 ]] ; then
 	echo "${reader_name} failed!"
 	exit ${reader_result}
 else
 	(echo "${reader_output}")
-	echo "quit" >> coredump-reader-output.txt
-	xt-gdb -q "${elf}" --command=coredump-reader-output.txt
-	rm -rf coredump-reader-output.txt
+	echo "quit" >> reader-output.txt
+	xt-gdb -q "${elf}" --command=reader-output.txt |& tee gdb_log.txt \
+		| grep -E '^[0-9]|#|\$'
+	rm -rf reader-output.txt
 fi


### PR DESCRIPTION
This will hide default starting gdb prints and show only the backtrace.
Also it can work with PR #1259 and print exception details

Signed-off-by: Adrian Bonislawski <adrian.bonislawski@linux.intel.com>