### PR TITLE
tools: logger: fix parsing of -s argument

### DIFF
--- a/tools/logger/logger.c
+++ b/tools/logger/logger.c
@@ -132,7 +132,7 @@ int main(int argc, char *argv[])
 {
 	struct convert_config config;
 	unsigned int baud = 0;
-	bool do_snapshot = false;
+	const char *snapshot_file = 0;
 	int opt, ret = 0;
 
 	config.trace = 0;
@@ -167,7 +167,7 @@ int main(int argc, char *argv[])
 			config.clock = atof(optarg);
 			break;
 		case 's':
-			do_snapshot = true;
+			snapshot_file = optarg;
 			break;
 		case 'l':
 			config.ldc_file = optarg;
@@ -199,9 +199,9 @@ int main(int argc, char *argv[])
 		}
 	}
 
-	if (do_snapshot)
-		return baud ? EINVAL : -snapshot(optarg);
-	
+	if (snapshot_file)
+		return baud ? EINVAL : -snapshot(snapshot_file);
+
 	if (!config.ldc_file) {
 		fprintf(stderr, "error: Missing ldc file\n");
 		usage();


### PR DESCRIPTION
Fix logic for saving the snapshot file argument. getopt()
is called at least once after snapshot option is parsed and
getopt() will erase the optarg value when exiting the while
loop. Without this patch, argument is always NULL and snapshot
cannot be taken.

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>