### PR TITLE
dw-dma: unify irq handling for all platforms

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -55,6 +55,18 @@ config HW_LLI
 	  Any platforms with hardware linked list support
 	  should set this.
 
+config DMA_AGGREGATED_IRQ
+	bool
+	default n
+	help
+	  Some platforms cannot register interrupt per DMA channel
+	  and have the possibility only to register interrupts per
+	  DMA controller, which require manual handling of aggregated
+	  irq.
+
+	  Any platforms with DMA aggregated interrupts support
+	  should set this.
+
 source "src/Kconfig"
 
 menu "Debug"

--- a/Kconfig
+++ b/Kconfig
@@ -42,6 +42,19 @@ config DW_GPIO
 	bool
 	default n
 
+config HW_LLI
+	bool
+	default n
+	help
+	  Hardware linked list is the DW-DMA feature, which allows
+	  to automatically reload the next programmed linked list
+	  item from memory without stopping the transfer. Without
+	  it the transfer stops after every lli read and FW needs
+	  to manually setup the next transfer.
+
+	  Any platforms with hardware linked list support
+	  should set this.
+
 source "src/Kconfig"
 
 menu "Debug"

--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -634,8 +634,8 @@ static int host_params(struct comp_dev *dev)
 	}
 #endif
 	/* set up callback */
-	dma_set_cb(hd->dma, hd->chan, DMA_CB_TYPE_LLI_TRANSFER |
-		   DMA_CB_TYPE_PROCESS, host_dma_cb, dev);
+	dma_set_cb(hd->dma, hd->chan, DMA_CB_TYPE_IRQ |
+		   DMA_CB_TYPE_COPY, host_dma_cb, dev);
 
 	return 0;
 }

--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -1500,7 +1500,9 @@ static inline int dw_dma_interrupt_register(struct dma *dma, int channel)
 		return 0;
 	}
 
+#if CONFIG_DMA_AGGREGATED_IRQ
 	if (!dma->mask_irq_channels) {
+#endif
 		ret = interrupt_register(irq, IRQ_AUTO_UNMASK,
 					 dw_dma_irq_handler, dma);
 		if (ret < 0) {
@@ -1509,9 +1511,11 @@ static inline int dw_dma_interrupt_register(struct dma *dma, int channel)
 		}
 
 		interrupt_enable(irq);
+#if CONFIG_DMA_AGGREGATED_IRQ
 	}
 
 	dma->mask_irq_channels = dma->mask_irq_channels | BIT(channel);
+#endif
 
 	return 0;
 }
@@ -1528,12 +1532,16 @@ static inline void dw_dma_interrupt_unregister(struct dma *dma, int channel)
 		return;
 	}
 
+#if CONFIG_DMA_AGGREGATED_IRQ
 	dma->mask_irq_channels = dma->mask_irq_channels & ~BIT(channel);
 
 	if (!dma->mask_irq_channels) {
+#endif
 		interrupt_disable(irq);
 		interrupt_unregister(irq);
+#if CONFIG_DMA_AGGREGATED_IRQ
 	}
+#endif
 }
 #endif
 

--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -266,11 +266,6 @@
 #define DW_DMA_LLI_ADDRESS(lli, dir) \
 	(((dir) == DMA_DIR_MEM_TO_DEV) ? ((lli)->sar) : ((lli)->dar))
 
-struct dma_id {
-	struct dma *dma;
-	uint32_t channel;
-};
-
 /* pointer data for dma buffer */
 struct dma_ptr_data {
 	uint32_t current_ptr;
@@ -288,7 +283,6 @@ struct dma_chan_data {
 	uint32_t desc_count;
 	uint32_t cfg_lo;
 	uint32_t cfg_hi;
-	struct dma_id id;
 	bool irq_disabled;
 
 	/* pointer data */
@@ -361,8 +355,11 @@ static void dw_dma_interrupt_unmask(struct dma *dma, int channel)
 	}
 
 	/* unmask block, transfer and error interrupts for channel */
-	dw_write(dma, DW_MASK_TFR, INT_UNMASK(channel));
+#if CONFIG_HW_LLI
 	dw_write(dma, DW_MASK_BLOCK, INT_UNMASK(channel));
+#else
+	dw_write(dma, DW_MASK_TFR, INT_UNMASK(channel));
+#endif
 	dw_write(dma, DW_MASK_ERR, INT_UNMASK(channel));
 }
 
@@ -581,7 +578,7 @@ static int dw_dma_release(struct dma *dma, int channel)
 			(chan->ptr_data.end_ptr - chan->ptr_data.current_ptr) +
 			(next_ptr - chan->ptr_data.start_ptr);
 
-	dw_dma_copy(dma, channel, bytes_left, DMA_COPY_LLI_BLOCK);
+	dw_dma_copy(dma, channel, bytes_left, 0);
 
 	spin_unlock_irq(&dma->lock, flags);
 	return 0;
@@ -680,10 +677,6 @@ static int dw_dma_stop(struct dma *dma, int channel)
 	dcache_writeback_region(chan->lli,
 			sizeof(struct dw_lli2) * chan->desc_count);
 #endif
-
-	if (!chan->irq_disabled)
-		dw_write(dma, DW_CLEAR_BLOCK, 0x1 << channel);
-
 	/* disable interrupt */
 	dw_dma_interrupt_unregister(dma, channel);
 
@@ -1215,17 +1208,18 @@ static int dw_dma_setup(struct dma *dma)
 	return 0;
 }
 
-#if CONFIG_HW_LLI
-static void dw_dma_verify_block(struct dma_chan_data *chan,
-				struct dma_sg_elem *next)
+static void dw_dma_verify_transfer(struct dma *dma, int channel,
+				   struct dma_sg_elem *next)
 {
+	struct dma_pdata *p = dma_get_drvdata(dma);
+	struct dma_chan_data *chan = p->chan + channel;
+#if CONFIG_HW_LLI
 	struct dw_lli2 *ll_uncached = cache_to_uncache(chan->lli_current);
 
 	switch (next->size) {
 	case DMA_RELOAD_END:
 		chan->status = COMP_STATE_PREPARE;
-		dw_write(chan->id.dma, DW_DMA_CHAN_EN,
-			 CHAN_DISABLE(chan->id.channel));
+		dw_write(dma, DW_DMA_CHAN_EN, CHAN_DISABLE(channel));
 		/* fallthrough */
 	default:
 		if (ll_uncached->ctrl_hi & DW_CTLH_DONE(1)) {
@@ -1235,12 +1229,7 @@ static void dw_dma_verify_block(struct dma_chan_data *chan,
 		}
 		break;
 	}
-}
-#endif
-
-static void dw_dma_verify_transfer(struct dma_chan_data *chan,
-				   struct dma_sg_elem *next)
-{
+#else
 	/* check for reload channel:
 	 * next.size is DMA_RELOAD_END, stop this dma copy;
 	 * next.size > 0 but not DMA_RELOAD_LLI, use next
@@ -1254,25 +1243,32 @@ static void dw_dma_verify_transfer(struct dma_chan_data *chan,
 		chan->lli_current = (struct dw_lli2 *)chan->lli_current->llp;
 		break;
 	case DMA_RELOAD_LLI:
-		dw_dma_chan_reload_lli(chan->id.dma, chan->id.channel);
+		dw_dma_chan_reload_lli(dma, channel);
 		break;
 	default:
-		dw_dma_chan_reload_next(chan->id.dma, chan->id.channel, next,
-					chan->direction);
+		dw_dma_chan_reload_next(dma, channel, next, chan->direction);
 		break;
 	}
+#endif
 }
 
-static void dw_dma_irq_callback(struct dma_chan_data *chan,
-				struct dma_sg_elem *next, uint32_t type,
-				void (*verify)(struct dma_chan_data *,
-					       struct dma_sg_elem *))
+static void dw_dma_irq_callback(struct dma *dma, int channel,
+				struct dma_sg_elem *next, uint32_t type)
 {
-	if (chan->cb)
+	struct dma_pdata *p = dma_get_drvdata(dma);
+	struct dma_chan_data *chan = p->chan + channel;
+
+	if (channel >= dma->plat_data.channels) {
+		trace_dwdma_error("dw-dma: %d invalid channel %d",
+				  dma->plat_data.id, channel);
+		return;
+	}
+
+	if (chan->cb && chan->cb_type & type)
 		chan->cb(chan->cb_data, type, next);
 
-	if (verify && next->size != DMA_RELOAD_IGNORE)
-		verify(chan, next);
+	if (next->size != DMA_RELOAD_IGNORE)
+		dw_dma_verify_transfer(dma, channel, next);
 }
 
 static int dw_dma_copy(struct dma *dma, int channel, int bytes, uint32_t flags)
@@ -1288,15 +1284,7 @@ static int dw_dma_copy(struct dma *dma, int channel, int bytes, uint32_t flags)
 	tracev_dwdma("dw-dma: %d channel %d copy", dma->plat_data.id,
 		     channel);
 
-#if CONFIG_HW_LLI
-	if (flags & DMA_COPY_LLI_BLOCK)
-		dw_dma_irq_callback(chan, &next, DMA_CB_TYPE_PROCESS,
-				    &dw_dma_verify_block);
-#endif
-
-	if (flags & DMA_COPY_LLI_TRANSFER)
-		dw_dma_irq_callback(chan, &next, DMA_CB_TYPE_PROCESS,
-				    &dw_dma_verify_transfer);
+	dw_dma_irq_callback(dma, channel, &next, DMA_CB_TYPE_COPY);
 
 	/* change current pointer */
 	chan->ptr_data.current_ptr += bytes;
@@ -1307,121 +1295,15 @@ static int dw_dma_copy(struct dma *dma, int channel, int bytes, uint32_t flags)
 	return 0;
 }
 
-#if CONFIG_APOLLOLAKE
-/* interrupt handler for DW DMA */
-static void dw_dma_irq_handler(void *data)
-{
-	struct dma_id *dma_id = data;
-	struct dma *dma = dma_id->dma;
-	struct dma_pdata *p = dma_get_drvdata(dma);
-	uint32_t status_tfr, status_block, status_err, status_intr;
-	uint32_t mask;
-	int i = dma_id->channel;
-	struct dma_sg_elem next = {
-		.src = DMA_RELOAD_LLI,
-		.dest = DMA_RELOAD_LLI,
-		.size = DMA_RELOAD_LLI
-	};
-
-	status_intr = dw_read(dma, DW_INTR_STATUS);
-	if (!status_intr) {
-		trace_dwdma_error("dw-dma: %d IRQ with no status",
-				  dma->plat_data.id);
-	}
-
-	tracev_dwdma("dw-dma: %d IRQ status 0x%x", dma->plat_data.id,
-		     status_intr);
-
-	/* get the source of our IRQ. */
-	status_block = dw_read(dma, DW_STATUS_BLOCK);
-	status_tfr = dw_read(dma, DW_STATUS_TFR);
-
-	/* TODO: handle errors, just clear them atm */
-	status_err = dw_read(dma, DW_STATUS_ERR);
-	if (status_err) {
-		trace_dwdma("dw-dma: %d IRQ error 0x%", dma->plat_data.id,
-			    status_err);
-		dw_write(dma, DW_CLEAR_ERR, status_err & i);
-	}
-
-	mask = 0x1 << i;
-
-	/* clear interrupts for channel*/
-	dw_write(dma, DW_CLEAR_BLOCK, status_block & mask);
-	dw_write(dma, DW_CLEAR_TFR, status_tfr & mask);
-
-	/* skip if channel is not running */
-	if (p->chan[i].status != COMP_STATE_ACTIVE) {
-		trace_dwdma_error("dw-dma: %d channel %d not running",
-				  dma->plat_data.id, dma_id->channel);
-		return;
-	}
-
-#if CONFIG_HW_LLI
-	/* end of a LLI block */
-	if (status_block & mask &&
-	    p->chan[i].cb_type & DMA_CB_TYPE_LLI_BLOCK)
-		dw_dma_irq_callback(&p->chan[i], &next, DMA_CB_TYPE_LLI_BLOCK,
-				    &dw_dma_verify_block);
-#endif
-}
-
-static inline int dw_dma_interrupt_register(struct dma *dma, int channel)
-{
-	struct dma_pdata *p = dma_get_drvdata(dma);
-	uint32_t irq = dma_irq(dma, cpu_get_id()) +
-		(channel << SOF_IRQ_BIT_SHIFT);
-	int ret;
-
-	trace_event(TRACE_CLASS_DMA, "dw_dma_interrupt_register()");
-
-	if (p->chan[channel].irq_disabled) {
-		tracev_event(TRACE_CLASS_DMA, "dw_dma_interrupt_register(): "
-			     "dma %d channel %d not working in irq mode",
-			     dma->plat_data.id, channel);
-		return 0;
-	}
-
-	ret = interrupt_register(irq, IRQ_AUTO_UNMASK, dw_dma_irq_handler,
-				 &p->chan[channel].id);
-	if (ret < 0) {
-		trace_dwdma_error("DWDMA failed to allocate IRQ");
-		return ret;
-	}
-
-	interrupt_enable(irq);
-	return 0;
-}
-
-static inline void dw_dma_interrupt_unregister(struct dma *dma, int channel)
-{
-	struct dma_pdata *p = dma_get_drvdata(dma);
-	uint32_t irq = dma_irq(dma, cpu_get_id()) +
-		(channel << SOF_IRQ_BIT_SHIFT);
-
-	if (p->chan[channel].irq_disabled) {
-		tracev_event(TRACE_CLASS_DMA, "dw_dma_interrupt_unregister(): "
-			     "dma %d channel %d not working in irq mode",
-			     dma->plat_data.id, channel);
-		return;
-	}
-
-	interrupt_disable(irq);
-	interrupt_unregister(irq);
-}
-#else
 /* interrupt handler for DMA */
 static void dw_dma_irq_handler(void *data)
 {
 	struct dma *dma = data;
 	struct dma_pdata *p = dma_get_drvdata(dma);
-	uint32_t status_tfr;
-	uint32_t status_block;
-	uint32_t status_block_new;
-	uint32_t status_err;
 	uint32_t status_intr;
+	uint32_t status_err;
+	uint32_t status_src;
 	uint32_t mask;
-	uint32_t pmask;
 	int i;
 	struct dma_sg_elem next = {
 		.src = DMA_RELOAD_LLI,
@@ -1433,70 +1315,52 @@ static void dw_dma_irq_handler(void *data)
 	if (!status_intr)
 		return;
 
-	tracev_dwdma("dw-dma: %d IRQ status 0x%x", dma->plat_data.id,
-		     status_intr);
+	tracev_dwdma("dw_dma_irq_handler(): dma %d IRQ status 0x%x",
+		     dma->plat_data.id, status_intr);
 
-	/* get the source of our IRQ. */
-	status_block = dw_read(dma, DW_STATUS_BLOCK);
-	status_tfr = dw_read(dma, DW_STATUS_TFR);
-
-	/* clear interrupts */
-	dw_write(dma, DW_CLEAR_BLOCK, status_block);
-	dw_write(dma, DW_CLEAR_TFR, status_tfr);
+	/* get the source of our IRQ and clear it */
+#if CONFIG_HW_LLI
+	status_src = dw_read(dma, DW_STATUS_BLOCK);
+	dw_write(dma, DW_CLEAR_BLOCK, status_src);
+#else
+	status_src = dw_read(dma, DW_STATUS_TFR);
+	dw_write(dma, DW_CLEAR_TFR, status_src);
+#endif
 
 	/* TODO: handle errors, just clear them atm */
 	status_err = dw_read(dma, DW_STATUS_ERR);
-	dw_write(dma, DW_CLEAR_ERR, status_err);
-	if (status_err)
-		trace_dwdma_error("dw-dma: %d error 0x%x", dma->plat_data.id,
-				  status_err);
-
-	/* clear platform and DSP interrupt */
-	pmask = status_block | status_tfr | status_err;
-	platform_interrupt_clear(dma_irq(dma, cpu_get_id()), pmask);
-
-	/* confirm IRQ cleared */
-	status_block_new = dw_read(dma, DW_STATUS_BLOCK);
-	if (status_block_new) {
-		trace_dwdma_error("dw-dma: %d status block 0x%x not cleared",
-				  dma->plat_data.id, status_block_new);
+	if (status_err) {
+		trace_dwdma_error("dw_dma_irq_handler() error: dma %d status "
+				  "error 0x%x", dma->plat_data.id, status_err);
+		dw_write(dma, DW_CLEAR_ERR, status_err);
 	}
 
-	for (i = 0; i < dma->plat_data.channels; i++) {
+	/* clear platform and DSP interrupt */
+	platform_interrupt_clear(dma_irq(dma, cpu_get_id()),
+				 status_src | status_err);
 
+	for (i = 0; i < dma->plat_data.channels; i++) {
 		/* skip if channel is not running */
 		if (p->chan[i].status != COMP_STATE_ACTIVE)
 			continue;
 
 		mask = 0x1 << i;
 
-#if CONFIG_HW_LLI
-		/* end of a LLI block */
-		if (status_block & mask &&
-		    p->chan[i].cb_type & DMA_CB_TYPE_LLI_BLOCK)
-			dw_dma_irq_callback(&p->chan[i], &next,
-					    DMA_CB_TYPE_LLI_BLOCK,
-					    &dw_dma_verify_block);
-#endif
-		/* end of a transfer */
-		if (status_tfr & mask &&
-		    p->chan[i].cb_type & DMA_CB_TYPE_LLI_TRANSFER)
-			dw_dma_irq_callback(&p->chan[i], &next,
-					    DMA_CB_TYPE_LLI_TRANSFER,
-					    &dw_dma_verify_transfer);
+		if (status_src & mask)
+			dw_dma_irq_callback(dma, i, &next, DMA_CB_TYPE_IRQ);
 	}
 }
 
 static inline int dw_dma_interrupt_register(struct dma *dma, int channel)
 {
 	struct dma_pdata *p = dma_get_drvdata(dma);
-	uint32_t irq = dma_irq(dma, cpu_get_id());
+	uint32_t irq = dma_chan_irq(dma, cpu_get_id(), channel);
 	int ret;
 
 	if (p->chan[channel].irq_disabled) {
-		tracev_event(TRACE_CLASS_DMA, "dw_dma_interrupt_register(): "
-			     "dma %d channel %d not working in irq mode",
-			     dma->plat_data.id, channel);
+		tracev_dwdma("dw_dma_interrupt_register(): dma %d channel %d "
+			     "not working in irq mode", dma->plat_data.id,
+			     channel);
 		return 0;
 	}
 
@@ -1506,7 +1370,10 @@ static inline int dw_dma_interrupt_register(struct dma *dma, int channel)
 		ret = interrupt_register(irq, IRQ_AUTO_UNMASK,
 					 dw_dma_irq_handler, dma);
 		if (ret < 0) {
-			trace_dwdma_error("DWDMA failed to allocate IRQ");
+			trace_dwdma_error("dw_dma_interrupt_register() error: "
+					  "dma %d channel %d failed to "
+					  "allocate IRQ", dma->plat_data.id,
+					  channel);
 			return ret;
 		}
 
@@ -1514,7 +1381,7 @@ static inline int dw_dma_interrupt_register(struct dma *dma, int channel)
 #if CONFIG_DMA_AGGREGATED_IRQ
 	}
 
-	dma->mask_irq_channels = dma->mask_irq_channels | BIT(channel);
+	dma->mask_irq_channels |= BIT(channel);
 #endif
 
 	return 0;
@@ -1523,17 +1390,17 @@ static inline int dw_dma_interrupt_register(struct dma *dma, int channel)
 static inline void dw_dma_interrupt_unregister(struct dma *dma, int channel)
 {
 	struct dma_pdata *p = dma_get_drvdata(dma);
-	uint32_t irq = dma_irq(dma, cpu_get_id());
+	uint32_t irq = dma_chan_irq(dma, cpu_get_id(), channel);
 
 	if (p->chan[channel].irq_disabled) {
-		tracev_event(TRACE_CLASS_DMA, "dw_dma_interrupt_unregister(): "
-			     "dma %d channel %d not working in irq mode",
-			     dma->plat_data.id, channel);
+		tracev_dwdma("dw_dma_interrupt_unregister(): dma %d channel %d"
+			     " not working in irq mode", dma->plat_data.id,
+			     channel);
 		return;
 	}
 
 #if CONFIG_DMA_AGGREGATED_IRQ
-	dma->mask_irq_channels = dma->mask_irq_channels & ~BIT(channel);
+	dma->mask_irq_channels &= ~BIT(channel);
 
 	if (!dma->mask_irq_channels) {
 #endif
@@ -1543,12 +1410,12 @@ static inline void dw_dma_interrupt_unregister(struct dma *dma, int channel)
 	}
 #endif
 }
-#endif
 
 static int dw_dma_probe(struct dma *dma)
 {
 	struct dma_pdata *dw_pdata;
-	int i, ret;
+	int ret;
+	int i;
 
 	if (dma_get_drvdata(dma))
 		return -EEXIST; /* already created */
@@ -1573,11 +1440,8 @@ static int dw_dma_probe(struct dma *dma)
 		return ret;
 
 	/* init work */
-	for (i = 0; i < dma->plat_data.channels; i++) {
-		dw_pdata->chan[i].id.dma = dma;
-		dw_pdata->chan[i].id.channel = i;
+	for (i = 0; i < dma->plat_data.channels; i++)
 		dw_pdata->chan[i].status = COMP_STATE_INIT;
-	}
 
 	/* init number of channels draining */
 	atomic_init(&dma->num_channels_busy, 0);
@@ -1594,10 +1458,12 @@ static int dw_dma_remove(struct dma *dma)
 	return 0;
 }
 
-static int dw_dma_avail_data_size(struct dma_chan_data *chan)
+static int dw_dma_avail_data_size(struct dma *dma, int channel)
 {
+	struct dma_pdata *p = dma_get_drvdata(dma);
+	struct dma_chan_data *chan = &p->chan[channel];
 	int32_t read_ptr = chan->ptr_data.current_ptr;
-	int32_t write_ptr = dw_read(chan->id.dma, DW_DAR(chan->id.channel));
+	int32_t write_ptr = dw_read(dma, DW_DAR(channel));
 	int size;
 
 	size = write_ptr - read_ptr;
@@ -1607,9 +1473,11 @@ static int dw_dma_avail_data_size(struct dma_chan_data *chan)
 	return size;
 }
 
-static int dw_dma_free_data_size(struct dma_chan_data *chan)
+static int dw_dma_free_data_size(struct dma *dma, int channel)
 {
-	int32_t read_ptr = dw_read(chan->id.dma, DW_SAR(chan->id.channel));
+	struct dma_pdata *p = dma_get_drvdata(dma);
+	struct dma_chan_data *chan = &p->chan[channel];
+	int32_t read_ptr = dw_read(dma, DW_SAR(channel));
 	int32_t write_ptr = chan->ptr_data.current_ptr;
 	int size;
 
@@ -1634,9 +1502,9 @@ static int dw_dma_get_data_size(struct dma *dma, int channel, uint32_t *avail,
 
 	if (chan->direction == DMA_DIR_HMEM_TO_LMEM ||
 	    chan->direction == DMA_DIR_DEV_TO_MEM)
-		*avail = dw_dma_avail_data_size(chan);
+		*avail = dw_dma_avail_data_size(dma, channel);
 	else
-		*free = dw_dma_free_data_size(chan);
+		*free = dw_dma_free_data_size(dma, channel);
 
 	spin_unlock_irq(&dma->lock, flags);
 

--- a/src/drivers/dw/ssi-spi.c
+++ b/src/drivers/dw/ssi-spi.c
@@ -484,9 +484,9 @@ int spi_probe(struct spi *spi)
 	spi->ipc_status = IPC_READ;
 
 	dma_set_cb(spi->dma[SPI_DIR_RX], spi->chan[SPI_DIR_RX],
-		   DMA_CB_TYPE_LLI_BLOCK, spi_dma_complete, spi);
+		   DMA_CB_TYPE_IRQ, spi_dma_complete, spi);
 	dma_set_cb(spi->dma[SPI_DIR_TX], spi->chan[SPI_DIR_TX],
-		   DMA_CB_TYPE_LLI_BLOCK, spi_dma_complete, spi);
+		   DMA_CB_TYPE_IRQ, spi_dma_complete, spi);
 
 	return spi_slave_init(spi);
 }

--- a/src/drivers/intel/cavs/hda-dma.c
+++ b/src/drivers/intel/cavs/hda-dma.c
@@ -312,7 +312,7 @@ static void hda_dma_post_copy(struct dma *dma, struct hda_chan_data *chan,
 	};
 
 	if (chan->cb) {
-		chan->cb(chan->cb_data, DMA_CB_TYPE_PROCESS, &next);
+		chan->cb(chan->cb_data, DMA_CB_TYPE_COPY, &next);
 		if (next.size == DMA_RELOAD_END)
 			/* disable channel, finished */
 			hda_dma_stop(dma, chan->index);

--- a/src/include/sof/dma.h
+++ b/src/include/sof/dma.h
@@ -190,10 +190,9 @@ struct dma {
 	int sref;		/**< simple ref counter, guarded by lock */
 	const struct dma_ops *ops;
 	atomic_t num_channels_busy; /* number of busy channels */
-#ifndef CONFIG_APOLLOLAKE
-	uint32_t mask_irq_channels; /* bitmask of channels with registered IRQs
-				     * on APL each channel has own IRQ handler
-				     */
+#if CONFIG_DMA_AGGREGATED_IRQ
+	/**< bitmask of channels with registered IRQs */
+	uint32_t mask_irq_channels;
 #endif
 	void *private;
 };

--- a/src/include/sof/dma.h
+++ b/src/include/sof/dma.h
@@ -80,15 +80,12 @@
 #define DMA_ACCESS_SHARED	0
 
 /* DMA callback types */
-#define DMA_CB_TYPE_LLI_BLOCK		BIT(0)
-#define DMA_CB_TYPE_LLI_TRANSFER	BIT(1)
-#define DMA_CB_TYPE_PROCESS		BIT(2)
+#define DMA_CB_TYPE_IRQ		BIT(0)
+#define DMA_CB_TYPE_COPY	BIT(1)
 
 /* DMA copy flags */
 #define DMA_COPY_PRELOAD	BIT(0)
 #define DMA_COPY_BLOCKING	BIT(1)
-#define DMA_COPY_LLI_BLOCK	BIT(2)
-#define DMA_COPY_LLI_TRANSFER	BIT(3)
 
 /* We will use this macro in cb handler to inform dma that
  * we need to stop the reload for special purpose

--- a/src/ipc/dma-copy.c
+++ b/src/ipc/dma-copy.c
@@ -79,7 +79,7 @@ static void dma_complete(void *data, uint32_t type, struct dma_sg_elem *next)
 {
 	completion_t *comp = (completion_t *)data;
 
-	if (type == DMA_CB_TYPE_LLI_TRANSFER)
+	if (type == DMA_CB_TYPE_IRQ)
 		wait_completed(comp);
 
 	ipc_dma_trace_send_position();
@@ -185,7 +185,7 @@ int dma_copy_new(struct dma_copy *dc)
 	}
 
 	dc->complete.timeout = 100;	/* wait 100 usecs for DMA to finish */
-	dma_set_cb(dc->dmac, dc->chan, DMA_CB_TYPE_LLI_TRANSFER, dma_complete,
+	dma_set_cb(dc->dmac, dc->chan, DMA_CB_TYPE_IRQ, dma_complete,
 		   &dc->complete);
 #endif
 

--- a/src/ipc/ipc.c
+++ b/src/ipc/ipc.c
@@ -513,7 +513,7 @@ static void dma_complete(void *data, uint32_t type, struct dma_sg_elem *next)
 {
 	completion_t *complete = data;
 
-	if (type == DMA_CB_TYPE_LLI_TRANSFER)
+	if (type == DMA_CB_TYPE_IRQ)
 		wait_completed(complete);
 }
 
@@ -562,8 +562,7 @@ int ipc_get_page_descriptors(struct dma *dmac, uint8_t *page_table,
 	}
 
 	/* set up callback */
-	dma_set_cb(dmac, chan, DMA_CB_TYPE_LLI_TRANSFER, dma_complete,
-		   &complete);
+	dma_set_cb(dmac, chan, DMA_CB_TYPE_IRQ, dma_complete, &complete);
 
 	wait_init(&complete);
 

--- a/src/platform/Kconfig
+++ b/src/platform/Kconfig
@@ -42,6 +42,7 @@ config APOLLOLAKE
 	select MEM_WND
 	select TASK_HAVE_PRIORITY_LOW
 	select TASK_HAVE_PRIORITY_MEDIUM
+	select HW_LLI
 	select CAVS
 	select CAVS_VERSION_1_5
 	help
@@ -55,6 +56,7 @@ config CANNONLAKE
 	select MEM_WND
 	select TASK_HAVE_PRIORITY_LOW
 	select TASK_HAVE_PRIORITY_MEDIUM
+	select HW_LLI
 	select CAVS
 	select CAVS_VERSION_1_8
 	help
@@ -69,6 +71,7 @@ config SUECREEK
 	select DW_SPI
 	select INTEL_IOMUX
 	select DW_GPIO
+	select HW_LLI
 	select CAVS
 	select CAVS_VERSION_2_0
 	help
@@ -82,6 +85,7 @@ config ICELAKE
 	select MEM_WND
 	select TASK_HAVE_PRIORITY_LOW
 	select TASK_HAVE_PRIORITY_MEDIUM
+	select HW_LLI
 	select CAVS
 	select CAVS_VERSION_2_0
 	help

--- a/src/platform/Kconfig
+++ b/src/platform/Kconfig
@@ -9,6 +9,7 @@ config BAYTRAIL
 	select HOST_PTABLE
 	select TASK_HAVE_PRIORITY_LOW
 	select TASK_HAVE_PRIORITY_MEDIUM
+	select DMA_AGGREGATED_IRQ
 	help
 	  Select if your target platform is Baytrail-compatible
 
@@ -17,6 +18,7 @@ config CHERRYTRAIL
 	select HOST_PTABLE
 	select TASK_HAVE_PRIORITY_LOW
 	select TASK_HAVE_PRIORITY_MEDIUM
+	select DMA_AGGREGATED_IRQ
 	help
 	  Select if your target platform is Cherrytrail-compatible
 
@@ -24,6 +26,7 @@ config HASWELL
 	bool "Build for Haswell"
 	select HOST_PTABLE
 	select TASK_HAVE_PRIORITY_LOW
+	select DMA_AGGREGATED_IRQ
 	help
 	  Select if your target platform is Haswell-compatible
 
@@ -31,6 +34,7 @@ config BROADWELL
 	bool "Build for Broadwell"
 	select HOST_PTABLE
 	select TASK_HAVE_PRIORITY_LOW
+	select DMA_AGGREGATED_IRQ
 	help
 	  Select if your target platform is Broadwell-compatible
 
@@ -57,6 +61,7 @@ config CANNONLAKE
 	select TASK_HAVE_PRIORITY_LOW
 	select TASK_HAVE_PRIORITY_MEDIUM
 	select HW_LLI
+	select DMA_AGGREGATED_IRQ
 	select CAVS
 	select CAVS_VERSION_1_8
 	help
@@ -72,6 +77,7 @@ config SUECREEK
 	select INTEL_IOMUX
 	select DW_GPIO
 	select HW_LLI
+	select DMA_AGGREGATED_IRQ
 	select CAVS
 	select CAVS_VERSION_2_0
 	help
@@ -86,6 +92,7 @@ config ICELAKE
 	select TASK_HAVE_PRIORITY_LOW
 	select TASK_HAVE_PRIORITY_MEDIUM
 	select HW_LLI
+	select DMA_AGGREGATED_IRQ
 	select CAVS
 	select CAVS_VERSION_2_0
 	help

--- a/src/platform/apollolake/include/platform/dma.h
+++ b/src/platform/apollolake/include/platform/dma.h
@@ -73,6 +73,9 @@
 #define DMA_HANDSHAKE_SSP5_TX	12
 #define DMA_HANDSHAKE_SSP5_RX	13
 
+#define dma_chan_irq(dma, cpu, chan) \
+	(dma_irq(dma, cpu) + (channel << SOF_IRQ_BIT_SHIFT))
+
 int dmac_init(void);
 
 #endif

--- a/src/platform/baytrail/include/platform/dma.h
+++ b/src/platform/baytrail/include/platform/dma.h
@@ -60,6 +60,8 @@
 #define DMA_HANDSHAKE_SSP6_RX	12
 #define DMA_HANDSHAKE_SSP6_TX	13
 
+#define dma_chan_irq(dma, cpu, chan) dma_irq(dma, cpu)
+
 int dmac_init(void);
 
 #endif

--- a/src/platform/cannonlake/include/platform/dma.h
+++ b/src/platform/cannonlake/include/platform/dma.h
@@ -71,6 +71,8 @@
 #define DMA_HANDSHAKE_SSP5_TX	12
 #define DMA_HANDSHAKE_SSP5_RX	13
 
+#define dma_chan_irq(dma, cpu, chan) dma_irq(dma, cpu)
+
 int dmac_init(void);
 
 #endif

--- a/src/platform/haswell/include/platform/dma.h
+++ b/src/platform/haswell/include/platform/dma.h
@@ -56,6 +56,8 @@
 #define DMA_HANDSHAKE_OBFF_10		14
 #define DMA_HANDSHAKE_OBFF_11		15
 
+#define dma_chan_irq(dma, cpu, chan) dma_irq(dma, cpu)
+
 int dmac_init(void);
 
 #endif

--- a/src/platform/icelake/include/platform/dma.h
+++ b/src/platform/icelake/include/platform/dma.h
@@ -71,6 +71,8 @@
 #define DMA_HANDSHAKE_SSP5_TX	12
 #define DMA_HANDSHAKE_SSP5_RX	13
 
+#define dma_chan_irq(dma, cpu, chan) dma_irq(dma, cpu)
+
 int dmac_init(void);
 
 #endif

--- a/src/platform/suecreek/include/platform/dma.h
+++ b/src/platform/suecreek/include/platform/dma.h
@@ -60,6 +60,8 @@
 #define DMA_HANDSHAKE_SSI_TX	26
 #define DMA_HANDSHAKE_SSI_RX	27
 
+#define dma_chan_irq(dma, cpu, chan) dma_irq(dma, cpu)
+
 int dmac_init(void);
 
 #endif


### PR DESCRIPTION
Unifies code responsible for interrupt handling
for all platforms. This way we can eliminate #if
based on platform type and rather use feature ones.
Support for hardware linked list defines what kind
of interrupt we expect - block or transfer. There
is no point of supporting both of them simultaneously.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>