### PR TITLE
TPLG: Fix mistake in 2ch configuration related DMIC macro

### DIFF
--- a/tools/topology/sof-apl-dmic.m4
+++ b/tools/topology/sof-apl-dmic.m4
@@ -18,7 +18,7 @@ include(`platform/intel/bxt.m4')
 include(`platform/intel/dmic.m4')
 
 define(DMIC_PDM_CONFIG, ifelse(CHANNELS, `4', ``FOUR_CH_PDM0_PDM1'',
-	ifelse(CHANNELS, `2', ``STEREO_PDM0'', `')))
+	`ifelse(CHANNELS, `2', ``STEREO_PDM0'', `')'))
 
 #
 # Define the pipelines


### PR DESCRIPTION
This patch fixes 2ch dmic capture topology. It appeared as topology
completion fail in SOF boot. The missing quote characters in m4
caused the STEREO_PDM0 macro triggered lines to no not be included
into conf file.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>