### PR TITLE
schedule: task priority levels reversal

### DIFF
--- a/src/arch/xtensa/task.c
+++ b/src/arch/xtensa/task.c
@@ -51,10 +51,10 @@ static uint32_t task_get_irq(struct task *task)
 	uint32_t irq;
 
 	switch (task->priority) {
-	case SOF_TASK_PRI_LOW ... SOF_TASK_PRI_MED - 1:
+	case SOF_TASK_PRI_MED + 1 ... SOF_TASK_PRI_LOW:
 		irq = PLATFORM_IRQ_TASK_LOW;
 		break;
-	case SOF_TASK_PRI_MED + 1 ... SOF_TASK_PRI_HIGH:
+	case SOF_TASK_PRI_HIGH ... SOF_TASK_PRI_MED - 1:
 		irq = PLATFORM_IRQ_TASK_HIGH;
 		break;
 	case SOF_TASK_PRI_MED:
@@ -78,24 +78,24 @@ static int task_set_data(struct task *task)
 
 	switch (task->priority) {
 #ifdef CONFIG_TASK_HAVE_PRIORITY_MEDIUM
-	case SOF_TASK_PRI_LOW ... SOF_TASK_PRI_MED - 1:
+	case SOF_TASK_PRI_MED + 1 ... SOF_TASK_PRI_LOW:
 		irq_task = *task_irq_low_get();
 		break;
-	case SOF_TASK_PRI_MED + 1 ... SOF_TASK_PRI_HIGH:
+	case SOF_TASK_PRI_HIGH ... SOF_TASK_PRI_MED - 1:
 		irq_task = *task_irq_high_get();
 		break;
 	case SOF_TASK_PRI_MED:
 		irq_task = *task_irq_med_get();
 		break;
 #elif CONFIG_TASK_HAVE_PRIORITY_LOW
-	case  SOF_TASK_PRI_LOW ... SOF_TASK_PRI_MED:
+	case  SOF_TASK_PRI_MED ... SOF_TASK_PRI_LOW:
 		irq_task = *task_irq_low_get();
 		break;
-	case SOF_TASK_PRI_MED + 1 ... SOF_TASK_PRI_HIGH:
+	case SOF_TASK_PRI_HIGH ... SOF_TASK_PRI_MED - 1:
 		irq_task = *task_irq_high_get();
 		break;
 #else
-	case SOF_TASK_PRI_LOW ... SOF_TASK_PRI_HIGH:
+	case SOF_TASK_PRI_HIGH ... SOF_TASK_PRI_LOW:
 		irq_task = *task_irq_high_get();
 		break;
 #endif

--- a/src/include/sof/schedule.h
+++ b/src/include/sof/schedule.h
@@ -53,9 +53,9 @@ enum {
 	SOF_SCHEDULE_COUNT
 };
 
-#define SOF_TASK_PRI_LOW	0	/* priority level 0 - low */
+#define SOF_TASK_PRI_HIGH	0	/* priority level 0 - high */
 #define SOF_TASK_PRI_MED	4	/* priority level 4 - medium */
-#define SOF_TASK_PRI_HIGH	9	/* priority level 9 - high */
+#define SOF_TASK_PRI_LOW	9	/* priority level 9 - low */
 
 #define SOF_TASK_PRI_COUNT	10	/* range of priorities (0-9) */
 

--- a/src/lib/edf_schedule.c
+++ b/src/lib/edf_schedule.c
@@ -142,7 +142,7 @@ static inline struct task *edf_get_next(uint64_t current, struct task *ignore)
 			delta = deadline - current;
 
 			/* get highest priority */
-			if (edf_task->priority > next_priority) {
+			if (edf_task->priority < next_priority) {
 				next_priority = edf_task->priority;
 				next_delta = delta;
 				edf_task_next = edf_task;

--- a/src/lib/ll_schedule.c
+++ b/src/lib/ll_schedule.c
@@ -371,7 +371,7 @@ static inline void insert_task_to_queue(struct task *w,
 	/* works are adding to queue in order */
 	list_for_item(wlist, q_list) {
 		ll_task = container_of(wlist, struct task, list);
-		if (w->priority >= ll_task->priority) {
+		if (w->priority <= ll_task->priority) {
 			list_item_append(&w->list, &ll_task->list);
 			return;
 		}


### PR DESCRIPTION
I've reverted level of priority tasks. Now tasks
levels are as follows:
- level 0 - highest priority;
- level 9 - lowest priority.

Signed-off-by: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>