### PR TITLE
topology: sof: add pipe-passthrough-capture_16k.m4

### DIFF
--- a/tools/topology/sof/pipe-passthrough-capture_16k.m4
+++ b/tools/topology/sof/pipe-passthrough-capture_16k.m4
@@ -1,0 +1,50 @@
+# Capture Passthrough Pipeline and PCM for 16KHz
+# This is a temporary solution. After FW supports the
+# refinement of sample rate, this file will be removed
+# and the default Passthrough will support all kinds
+# of sample rates.
+#
+# Pipeline Endpoints for connection are :-
+#
+#  host PCM_C <-- B0 <-- sink DAI0
+
+# Include topology builder
+include(`utils.m4')
+include(`buffer.m4')
+include(`pcm.m4')
+include(`dai.m4')
+include(`pipeline.m4')
+
+#
+# Components and Buffers
+#
+
+# Host "Passthrough Capture" PCM
+# with 0 sink and 2 source periods
+W_PCM_CAPTURE(PCM_ID, Passthrough Capture, 0, 2)
+
+# Capture Buffers
+W_BUFFER(0, COMP_BUFFER_SIZE(2,
+	COMP_SAMPLE_SIZE(PIPELINE_FORMAT), PIPELINE_CHANNELS, SCHEDULE_FRAMES),
+	PLATFORM_PASS_MEM_CAP)
+
+#
+# Pipeline Graph
+#
+#  host PCM_C <-- B0 <-- sink DAI0
+
+P_GRAPH(pipe-pass-capture-PIPELINE_ID, PIPELINE_ID,
+	LIST(`		',
+	`dapm(N_PCMC(PCM_ID), N_BUFFER(0))'))
+
+#
+# Pipeline Source and Sinks
+#
+indir(`define', concat(`PIPELINE_SINK_', PIPELINE_ID), N_BUFFER(0))
+indir(`define', concat(`PIPELINE_PCM_', PIPELINE_ID), Passthrough Capture PCM_ID)
+
+#
+# PCM Configuration
+#
+
+PCM_CAPABILITIES(Passthrough Capture PCM_ID, COMP_FORMAT_NAME(PIPELINE_FORMAT), 16000, 16000,  PIPELINE_CHANNELS, PIPELINE_CHANNELS, 2, 16, 192, 16384, 65536, 65536)


### PR DESCRIPTION
DMIC16k only supports 16000Hz sample rate. pipe-passthough-capture.m4
only supports 48000Hz. Add pipe-passthrough-capture_16k.m4 to support 16KHz
record.

Signed-off-by: Libin Yang <libin.yang@intel.com>