### PR TITLE
Volume component scale update and sample topology for test

### DIFF
--- a/src/audio/volume.h
+++ b/src/audio/volume.h
@@ -65,7 +65,7 @@
 #define trace_volume_error(__e, ...)	trace_error(TRACE_CLASS_VOLUME, __e, ##__VA_ARGS__)
 
 //** \brief Volume gain Qx.y integer x number of bits including sign bit. */
-#define VOL_QXY_X 2
+#define VOL_QXY_X 8
 
 //** \brief Volume gain Qx.y fractional y number of bits. */
 #define VOL_QXY_Y 16
@@ -91,10 +91,10 @@
  * TODO: This should be 1 << (VOL_QX_BITS + VOL_QY_BITS - 1) - 1 but
  * the current volume code cannot handle the full Q1.16 range correctly.
  */
-#define VOL_MAX		(1 << VOL_QXY_Y)
+#define VOL_MAX		((1 << (VOL_QXY_X + VOL_QXY_Y - 1)) - 1)
 
 /** \brief Volume 0dB value. */
-#define VOL_ZERO_DB	(1 << 16)
+#define VOL_ZERO_DB	(1 << VOL_QXY_Y)
 
 /** \brief Volume minimum value. */
 #define VOL_MIN		0
@@ -107,11 +107,9 @@
 struct comp_data {
 	enum sof_ipc_frame source_format;	/**< source frame format */
 	enum sof_ipc_frame sink_format;		/**< sink frame format */
-	uint32_t volume[SOF_IPC_MAX_CHANNELS];	/**< current volume */
-	uint32_t tvolume[SOF_IPC_MAX_CHANNELS];	/**< target volume */
-	uint32_t mvolume[SOF_IPC_MAX_CHANNELS];	/**< mute volume */
-	uint32_t min_volume;			/**< minimum volume level */
-	uint32_t max_volume;			/**< maximum volume level */
+	int32_t volume[SOF_IPC_MAX_CHANNELS];	/**< current volume */
+	int32_t tvolume[SOF_IPC_MAX_CHANNELS];	/**< target volume */
+	int32_t mvolume[SOF_IPC_MAX_CHANNELS];	/**< mute volume */
 	/**< volume processing function */
 	void (*scale_vol)(struct comp_dev *dev, struct comp_buffer *sink,
 		struct comp_buffer *source, uint32_t frames);

--- a/src/audio/volume_generic.c
+++ b/src/audio/volume_generic.c
@@ -130,13 +130,15 @@ static void vol_s16_to_s32(struct comp_dev *dev, struct comp_buffer *sink,
 	uint32_t channel;
 	uint32_t buff_frag = 0;
 
-	/* Samples are Q1.15 --> Q1.31 and volume is Q1.16 */
+	/* Samples are Q1.15 --> Q1.31 and volume is Q8.16 */
 	for (i = 0; i < frames; i++) {
 		for (channel = 0; channel < dev->params.channels; channel++) {
 			src = buffer_read_frag_s16(source, buff_frag);
 			dest = buffer_write_frag_s32(sink, buff_frag);
+			*dest = q_multsr_sat_32x32
+				(*src << 8, cd->volume[channel],
+				 Q_SHIFT_BITS_64(23, 16, 31));
 
-			*dest = (int32_t)*src * cd->volume[channel];
 
 			buff_frag++;
 		}
@@ -163,7 +165,7 @@ static void vol_s32_to_s16(struct comp_dev *dev, struct comp_buffer *sink,
 	uint32_t channel;
 	uint32_t buff_frag = 0;
 
-	/* Samples are Q1.31 --> Q1.15 and volume is Q1.16 */
+	/* Samples are Q1.31 --> Q1.15 and volume is Q8.16 */
 	for (i = 0; i < frames; i++) {
 		for (channel = 0; channel < dev->params.channels; channel++) {
 			src = buffer_read_frag_s32(source, buff_frag);
@@ -196,7 +198,7 @@ static void vol_s32_to_s32(struct comp_dev *dev, struct comp_buffer *sink,
 	uint32_t channel;
 	uint32_t buff_frag = 0;
 
-	/* Samples are Q1.31 --> Q1.31 and volume is Q1.16 */
+	/* Samples are Q1.31 --> Q1.31 and volume is Q8.16 */
 	for (i = 0; i < frames; i++) {
 		for (channel = 0; channel < dev->params.channels; channel++) {
 			src = buffer_read_frag_s32(source, buff_frag);
@@ -231,13 +233,13 @@ static void vol_s16_to_s16(struct comp_dev *dev, struct comp_buffer *sink,
 	uint32_t channel;
 	uint32_t buff_frag = 0;
 
-	/* Samples are Q1.15 --> Q1.15 and volume is Q1.16 */
+	/* Samples are Q1.15 --> Q1.15 and volume is Q8.16 */
 	for (i = 0; i < frames; i++) {
 		for (channel = 0; channel < dev->params.channels; channel++) {
 			src = buffer_read_frag_s16(source, buff_frag);
 			dest = buffer_write_frag_s16(sink, buff_frag);
 
-			*dest = q_multsr_sat_16x16
+			*dest = q_multsr_sat_32x32_16
 				(*src, cd->volume[channel],
 				 Q_SHIFT_BITS_32(15, 16, 15));
 
@@ -266,7 +268,7 @@ static void vol_s16_to_s24(struct comp_dev *dev, struct comp_buffer *sink,
 	uint32_t channel;
 	uint32_t buff_frag = 0;
 
-	/* Samples are Q1.15 and volume is Q1.16 */
+	/* Samples are Q1.15 and volume is Q8.16 */
 	for (i = 0; i < frames; i++) {
 		for (channel = 0; channel < dev->params.channels; channel++) {
 			src = buffer_read_frag_s16(source, buff_frag);
@@ -299,7 +301,7 @@ static void vol_s24_to_s16(struct comp_dev *dev, struct comp_buffer *sink,
 	uint32_t channel;
 	uint32_t buff_frag = 0;
 
-	/* Samples are Q1.23 --> Q1.15 and volume is Q1.16 */
+	/* Samples are Q1.23 --> Q1.15 and volume is Q8.16 */
 	for (i = 0; i < frames; i++) {
 		for (channel = 0; channel < dev->params.channels; channel++) {
 			src = buffer_read_frag_s32(source, buff_frag);
@@ -332,7 +334,7 @@ static void vol_s32_to_s24(struct comp_dev *dev, struct comp_buffer *sink,
 	uint32_t channel;
 	uint32_t buff_frag = 0;
 
-	/* Samples are Q1.31 --> Q1.23 and volume is Q1.16 */
+	/* Samples are Q1.31 --> Q1.23 and volume is Q8.16 */
 	for (i = 0; i < frames; i++) {
 		for (channel = 0; channel < dev->params.channels; channel++) {
 			src = buffer_read_frag_s32(source, buff_frag);
@@ -365,7 +367,7 @@ static void vol_s24_to_s32(struct comp_dev *dev, struct comp_buffer *sink,
 	uint32_t channel;
 	uint32_t buff_frag = 0;
 
-	/* Samples are Q1.23 --> Q1.31 and volume is Q1.16 */
+	/* Samples are Q1.23 --> Q1.31 and volume is Q8.16 */
 	for (i = 0; i < frames; i++) {
 		for (channel = 0; channel < dev->params.channels; channel++) {
 			src = buffer_read_frag_s32(source, buff_frag);
@@ -400,7 +402,7 @@ static void vol_s24_to_s24(struct comp_dev *dev, struct comp_buffer *sink,
 	uint32_t channel;
 	uint32_t buff_frag = 0;
 
-	/* Samples are Q1.23 --> Q1.23 and volume is Q1.16 */
+	/* Samples are Q1.23 --> Q1.23 and volume is Q8.16 */
 	for (i = 0; i < frames; i++) {
 		for (channel = 0; channel < dev->params.channels; channel++) {
 			src = buffer_read_frag_s32(source, buff_frag);

--- a/tools/topology/common/tlv.m4
+++ b/tools/topology/common/tlv.m4
@@ -3,7 +3,7 @@
 # Common TLV control ranges
 #
 
-SectionTLV."vtlv_m90s3" {
+SectionTLV."vtlv_m64s2" {
 	Comment "-64dB step 2dB"
 
 	scale {

--- a/tools/topology/common/tlv.m4
+++ b/tools/topology/common/tlv.m4
@@ -12,3 +12,13 @@ SectionTLV."vtlv_m90s3" {
 		mute "1"
 	}
 }
+
+SectionTLV."vtlv_m50s1" {
+	Comment "-50dB step 1dB"
+
+	scale {
+		min "-5000"
+		step "100"
+		mute "1"
+	}
+}

--- a/tools/topology/sof-apl-dmic.m4
+++ b/tools/topology/sof-apl-dmic.m4
@@ -33,14 +33,14 @@ dnl     frames, deadline, priority, core)
 
 # Passthrough capture pipeline 6 on PCM 6 using max channels defined by CHANNELS.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	6, 6, CHANNELS, s32le,
 	48, 1000, 0, 0)
 
 # Passthrough capture pipeline 7 on PCM 7 using max channels defined by CHANNELS.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
-	7, 7, CHANNELS, s16le,
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
+	7, 7, CHANNELS, s32le,
 	48, 1000, 0, 0)
 
 #

--- a/tools/topology/sof/pipe-eq-fir-volume-playback.m4
+++ b/tools/topology/sof/pipe-eq-fir-volume-playback.m4
@@ -23,7 +23,7 @@ C_CONTROLMIXER(Master Playback Volume, PIPELINE_ID,
 	CONTROLMIXER_OPS(volsw, 256 binds the mixer control to volume get/put handlers, 256, 256),
 	CONTROLMIXER_MAX(, 32),
 	false,
-	CONTROLMIXER_TLV(TLV 32 steps from -90dB to +6dB for 3dB, vtlv_m90s3),
+	CONTROLMIXER_TLV(TLV 32 steps from -64dB to 0dB for 2dB, vtlv_m64s2),
 	Channel register and shift for Front Left/Right,
 	LIST(`	', KCONTROL_CHANNEL(FL, 1, 0), KCONTROL_CHANNEL(FR, 1, 1)))
 

--- a/tools/topology/sof/pipe-eq-iir-volume-playback.m4
+++ b/tools/topology/sof/pipe-eq-iir-volume-playback.m4
@@ -23,7 +23,7 @@ C_CONTROLMIXER(Master Playback Volume, PIPELINE_ID,
 	CONTROLMIXER_OPS(volsw, 256 binds the mixer control to volume get/put handlers, 256, 256),
 	CONTROLMIXER_MAX(, 32),
 	false,
-	CONTROLMIXER_TLV(TLV 32 steps from -90dB to +6dB for 3dB, vtlv_m90s3),
+	CONTROLMIXER_TLV(TLV 32 steps from -64dB to 0dB for 2dB, vtlv_m64s2),
 	Channel register and shift for Front Left/Right,
 	LIST(`	', KCONTROL_CHANNEL(FL, 1, 0), KCONTROL_CHANNEL(FR, 1, 1)))
 

--- a/tools/topology/sof/pipe-eq-volume-playback.m4
+++ b/tools/topology/sof/pipe-eq-volume-playback.m4
@@ -24,7 +24,7 @@ C_CONTROLMIXER(Master Playback Volume, PIPELINE_ID,
 	CONTROLMIXER_OPS(volsw, 256 binds the mixer control to volume get/put handlers, 256, 256),
 	CONTROLMIXER_MAX(, 32),
 	false,
-	CONTROLMIXER_TLV(TLV 32 steps from -90dB to +6dB for 3dB, vtlv_m90s3),
+	CONTROLMIXER_TLV(TLV 32 steps from -64dB to 0dB for 2dB, vtlv_m64s2),
 	Channel register and shift for Front Left/Right,
 	LIST(`	', KCONTROL_CHANNEL(FL, 1, 0), KCONTROL_CHANNEL(FR, 1, 1)))
 

--- a/tools/topology/sof/pipe-low-latency-capture.m4
+++ b/tools/topology/sof/pipe-low-latency-capture.m4
@@ -19,7 +19,7 @@ C_CONTROLMIXER(PCM PCM_ID Capture Volume, PIPELINE_ID,
 	CONTROLMIXER_OPS(volsw, 256 binds the mixer control to volume get/put handlers, 256, 256),
 	CONTROLMIXER_MAX(, 40),
 	false,
-	CONTROLMIXER_TLV(TLV 32 steps from -90dB to +6dB for 3dB, vtlv_m90s3),
+	CONTROLMIXER_TLV(TLV 32 steps from -64dB to 0dB for 2dB, vtlv_m64s2),
 	Channel register and shift for Front Left/Right,
 	LIST(`	', KCONTROL_CHANNEL(FL, 0, 0), KCONTROL_CHANNEL(FR, 0, 1)))
 

--- a/tools/topology/sof/pipe-low-latency-playback.m4
+++ b/tools/topology/sof/pipe-low-latency-playback.m4
@@ -35,7 +35,7 @@ C_CONTROLMIXER(PCM PCM_ID Playback Volume, PIPELINE_ID,
 	CONTROLMIXER_OPS(volsw, 256 binds the mixer control to volume get/put handlers, 256, 256),
 	CONTROLMIXER_MAX(, 32),
 	false,
-	CONTROLMIXER_TLV(TLV 32 steps from -90dB to +6dB for 3dB, vtlv_m90s3),
+	CONTROLMIXER_TLV(TLV 32 steps from -64dB to 0dB for 2dB, vtlv_m64s2),
 	Channel register and shift for Front Left/Right,
 	LIST(KCONTROL_CHANNEL(FL, 0, 0), KCONTROL_CHANNEL(FR, 0, 1)))
 
@@ -44,7 +44,7 @@ C_CONTROLMIXER(Master Playback Volume, PIPELINE_ID,
 	CONTROLMIXER_OPS(volsw, 256 binds the mixer control to volume get/put handlers, 256, 256),
 	CONTROLMIXER_MAX(, 32),
 	false,
-	CONTROLMIXER_TLV(TLV 32 steps from -90dB to +6dB for 3dB, vtlv_m90s3),
+	CONTROLMIXER_TLV(TLV 32 steps from -64dB to 0dB for 2dB, vtlv_m64s2),
 	Channel register and shift for Front Left/Right,
 	LIST(`	', KCONTROL_CHANNEL(FL, 1, 0), KCONTROL_CHANNEL(FR, 1, 1)))
 

--- a/tools/topology/sof/pipe-pcm-media.m4
+++ b/tools/topology/sof/pipe-pcm-media.m4
@@ -24,7 +24,7 @@ C_CONTROLMIXER(PCM PCM_ID Playback Volume, PIPELINE_ID,
 	CONTROLMIXER_OPS(volsw, 256 binds the mixer control to volume get/put handlers, 256, 256),
 	CONTROLMIXER_MAX(, 32),
 	false,
-	CONTROLMIXER_TLV(TLV 32 steps from -90dB to +6dB for 3dB, vtlv_m90s3),
+	CONTROLMIXER_TLV(TLV 32 steps from -64dB to 0dB for 2dB, vtlv_m64s2),
 	Channel register and shift for Front Left/Right,
 	LIST(`	', KCONTROL_CHANNEL(FL, 1, 0), KCONTROL_CHANNEL(FR, 1, 1)))
 

--- a/tools/topology/sof/pipe-src-playback.m4
+++ b/tools/topology/sof/pipe-src-playback.m4
@@ -22,7 +22,7 @@ C_CONTROLMIXER(Master Playback Volume, PIPELINE_ID,
 	CONTROLMIXER_OPS(volsw, 256 binds the mixer control to volume get/put handlers, 256, 256),
 	CONTROLMIXER_MAX(, 32),
 	false,
-	CONTROLMIXER_TLV(TLV 32 steps from -90dB to +6dB for 3dB, vtlv_m90s3),
+	CONTROLMIXER_TLV(TLV 32 steps from -64dB to 0dB for 2dB, vtlv_m64s2),
 	Channel register and shift for Front Left/Right,
 	LIST(`	', KCONTROL_CHANNEL(FL, 1, 0), KCONTROL_CHANNEL(FR, 1, 1)))
 

--- a/tools/topology/sof/pipe-tone.m4
+++ b/tools/topology/sof/pipe-tone.m4
@@ -24,7 +24,7 @@ C_CONTROLMIXER(Tone Volume, PIPELINE_ID,
 	CONTROLMIXER_OPS(volsw, 256 binds the mixer control to volume get/put handlers, 256, 256),
 	CONTROLMIXER_MAX(, 32),
 	false,
-	CONTROLMIXER_TLV(TLV 32 steps from -90dB to +6dB for 3dB, vtlv_m90s3),
+	CONTROLMIXER_TLV(TLV 32 steps from -64dB to 0dB for 2dB, vtlv_m64s2),
 	Channel register and shift for Front Left/Right,
 	LIST(`	', KCONTROL_CHANNEL(FL, 1, 0), KCONTROL_CHANNEL(FR, 1, 1)))
 

--- a/tools/topology/sof/pipe-volume-capture.m4
+++ b/tools/topology/sof/pipe-volume-capture.m4
@@ -19,9 +19,9 @@ include(`pipeline.m4')
 # Volume Mixer control with max value of 32
 C_CONTROLMIXER(Master Capture Volume, PIPELINE_ID,
 	CONTROLMIXER_OPS(volsw, 256 binds the mixer control to volume get/put handlers, 256, 256),
-	CONTROLMIXER_MAX(, 32),
+	CONTROLMIXER_MAX(, 80),
 	false,
-	CONTROLMIXER_TLV(TLV 32 steps from -90dB to +6dB for 3dB, vtlv_m90s3),
+	CONTROLMIXER_TLV(TLV 80 steps from -50dB to +30dB for 1dB, vtlv_m50s1),
 	Channel register and shift for Front Left/Right,
 	LIST(`	', KCONTROL_CHANNEL(FL, 1, 0), KCONTROL_CHANNEL(FR, 1, 1)))
 

--- a/tools/topology/sof/pipe-volume-playback.m4
+++ b/tools/topology/sof/pipe-volume-playback.m4
@@ -21,7 +21,7 @@ C_CONTROLMIXER(Master Playback Volume, PIPELINE_ID,
 	CONTROLMIXER_OPS(volsw, 256 binds the mixer control to volume get/put handlers, 256, 256),
 	CONTROLMIXER_MAX(, 32),
 	false,
-	CONTROLMIXER_TLV(TLV 32 steps from -90dB to +6dB for 3dB, vtlv_m90s3),
+	CONTROLMIXER_TLV(TLV 32 steps from -64dB to 0dB for 2dB, vtlv_m64s2),
 	Channel register and shift for Front Left/Right,
 	LIST(`	', KCONTROL_CHANNEL(FL, 1, 0), KCONTROL_CHANNEL(FR, 1, 1)))
 


### PR DESCRIPTION
This patch set enhances the volume component to support up to 42 dB gain with Q8.16 format gain that is needed for microphone capture applications (at least -50 to +20 dB range).

The patch set addressed volume component, dmic capture topology and generally volume capture pipe, and rename of existing tvl volume macro.

The previous version of this PR passed the CI unit tests those contain tests for all modes. I've also locally tested in unit test also the generic version that passed too (with modification to volume.h to have VOLUME_GENERIC defined). So according to my best knowledge this code is technically possible to merge. Now a normal PR code review is needed!

Please inspect the CI unit test reference volume code. Since there was an issue with hard coded max to 0 dB I had to rewrite fair amount of that code. The added saturation to reference code added a bit complexity there (the rounding & saturation combination). Now it tests the component with gains of +42 dB, 0 dB, and -80 dB.