### PR TITLE
host: remove check for host buffer alignment

### DIFF
--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -580,17 +580,6 @@ static int host_params(struct comp_dev *dev)
 		return err;
 	}
 
-#if !CONFIG_DMA_GW
-	/* component buffer size must be divisor of host buffer size */
-	if (hd->host_size % hd->period_bytes) {
-		trace_comp_error("host_params() error: component buffer size "
-				"is not a divisor of host buffer size, "
-				"host_size = %u, period_bytes = %u",
-				hd->host_size, hd->period_bytes);
-		return -EINVAL;
-	}
-#endif
-
 	/* create SG DMA elems for local DMA buffer */
 	err = create_local_elems(dev, buffer_count, buffer_single_size);
 	if (err < 0)


### PR DESCRIPTION
Removes check for host buffer alignment to period size.
This check is deprecated as we are correctly handling
split transfers.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>