### PR TITLE
Re-purpose component self-register functionality for general use

### DIFF
--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -236,17 +236,9 @@ void comp_set_period_bytes(struct comp_dev *dev, uint32_t frames,
 
 void sys_comp_init(void)
 {
-	extern intptr_t _comp_init_start, _comp_init_end;
-
 	cd = rzalloc(RZONE_SYS, SOF_MEM_CAPS_RAM, sizeof(*cd));
 	list_init(&cd->list);
 	spinlock_init(&cd->lock);
-
-	intptr_t *comp_init = (intptr_t *)(&_comp_init_start);
-
-	for (; comp_init < (intptr_t *)&_comp_init_end; ++comp_init) {
-		((void(*)(void))(*comp_init))();
-	}
 }
 
 int comp_get_copy_limits(struct comp_dev *dev, struct comp_copy_limits *cl)

--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -825,4 +825,4 @@ static void sys_comp_dai_init(void)
 	comp_register(&comp_dai);
 }
 
-DECLARE_COMPONENT(sys_comp_dai_init);
+DECLARE_MODULE(sys_comp_dai_init);

--- a/src/audio/detect_test.c
+++ b/src/audio/detect_test.c
@@ -661,4 +661,4 @@ static void sys_comp_keyword_init(void)
 	comp_register(&comp_keyword);
 }
 
-DECLARE_COMPONENT(sys_comp_keyword_init);
+DECLARE_MODULE(sys_comp_keyword_init);

--- a/src/audio/eq_fir.c
+++ b/src/audio/eq_fir.c
@@ -849,4 +849,4 @@ static void sys_comp_eq_fir_init(void)
 	comp_register(&comp_eq_fir);
 }
 
-DECLARE_COMPONENT(sys_comp_eq_fir_init);
+DECLARE_MODULE(sys_comp_eq_fir_init);

--- a/src/audio/eq_iir.c
+++ b/src/audio/eq_iir.c
@@ -936,4 +936,4 @@ static void sys_comp_eq_iir_init(void)
 	comp_register(&comp_eq_iir);
 }
 
-DECLARE_COMPONENT(sys_comp_eq_iir_init);
+DECLARE_MODULE(sys_comp_eq_iir_init);

--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -882,4 +882,4 @@ static void sys_comp_host_init(void)
 	comp_register(&comp_host);
 }
 
-DECLARE_COMPONENT(sys_comp_host_init);
+DECLARE_MODULE(sys_comp_host_init);

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -559,4 +559,4 @@ UT_STATIC void sys_comp_kpb_init(void)
 	comp_register(&comp_kpb);
 }
 
-DECLARE_COMPONENT(sys_comp_kpb_init);
+DECLARE_MODULE(sys_comp_kpb_init);

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -458,4 +458,4 @@ UT_STATIC void sys_comp_mixer_init(void)
 	comp_register(&comp_mixer);
 }
 
-DECLARE_COMPONENT(sys_comp_mixer_init);
+DECLARE_MODULE(sys_comp_mixer_init);

--- a/src/audio/mux.c
+++ b/src/audio/mux.c
@@ -102,4 +102,4 @@ static void sys_comp_mux_init(void)
 	comp_register(&comp_mux);
 }
 
-DECLARE_COMPONENT(sys_comp_mux_init);
+DECLARE_MODULE(sys_comp_mux_init);

--- a/src/audio/selector.c
+++ b/src/audio/selector.c
@@ -525,4 +525,4 @@ static void sys_comp_selector_init(void)
 	comp_register(&comp_selector);
 }
 
-DECLARE_COMPONENT(sys_comp_selector_init);
+DECLARE_MODULE(sys_comp_selector_init);

--- a/src/audio/src.c
+++ b/src/audio/src.c
@@ -986,4 +986,4 @@ static void sys_comp_src_init(void)
 	comp_register(&comp_src);
 }
 
-DECLARE_COMPONENT(sys_comp_src_init);
+DECLARE_MODULE(sys_comp_src_init);

--- a/src/audio/switch.c
+++ b/src/audio/switch.c
@@ -102,4 +102,4 @@ static void sys_comp_switch_init(void)
 	comp_register(&comp_switch);
 }
 
-DECLARE_COMPONENT(sys_comp_switch_init);
+DECLARE_MODULE(sys_comp_switch_init);

--- a/src/audio/tone.c
+++ b/src/audio/tone.c
@@ -770,4 +770,4 @@ static void sys_comp_tone_init(void)
 	comp_register(&comp_tone);
 }
 
-DECLARE_COMPONENT(sys_comp_tone_init);
+DECLARE_MODULE(sys_comp_tone_init);

--- a/src/audio/volume.c
+++ b/src/audio/volume.c
@@ -658,4 +658,4 @@ static void sys_comp_volume_init(void)
 	comp_register(&comp_volume);
 }
 
-DECLARE_COMPONENT(sys_comp_volume_init);
+DECLARE_MODULE(sys_comp_volume_init);

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -152,21 +152,6 @@
 #define COMP_ATTR_COPY_BLOCKING	0	/**< Comp blocking copy attribute */
 /** @}*/
 
-/** \name Declare component macro
- *  \brief Usage at the end of comp file: DECLARE_COMPONENT(sys_comp_*_init);
- *  @{
- */
-#ifdef UNIT_TEST
-#define DECLARE_COMPONENT(init)
-#elif CONFIG_HOST
-/* In case of shared libs components are initialised in dlopen */
-#define DECLARE_COMPONENT(init) __attribute__((constructor)) \
-	static void _comp_init(void) { init(); }
-#else
-#define DECLARE_COMPONENT(init) __attribute__((__used__)) \
-	__attribute__((section(".comp_init"))) static void(*f)(void) = init
-#endif
-
 /** \name Trace macros
  *  @{
  */

--- a/src/include/sof/sof.h
+++ b/src/include/sof/sof.h
@@ -57,6 +57,22 @@ struct sa;
 	__attribute__((unused))		\
 	typedef char META_CONCAT(assertion_failed_, MESSAGE)[(COND) ? 1 : -1]
 
+/** \name Declare module macro
+ *  \brief Usage at the end of an independent module file:
+ *         DECLARE_MODULE(sys_*_init);
+ *  @{
+ */
+#ifdef UNIT_TEST
+#define DECLARE_MODULE(init)
+#elif CONFIG_HOST
+/* In case of shared libs components are initialised in dlopen */
+#define DECLARE_MODULE(init) __attribute__((constructor)) \
+	static void _module_init(void) { init(); }
+#else
+#define DECLARE_MODULE(init) __attribute__((__used__)) \
+	__attribute__((section(".module_init"))) static void(*f)(void) = init
+#endif
+
 /* general firmware context */
 struct sof {
 	/* init data */

--- a/src/platform/apollolake/apollolake.x.in
+++ b/src/platform/apollolake/apollolake.x.in
@@ -439,11 +439,11 @@ SECTIONS
     _rodata_end = ABSOLUTE(.);
   } >sof_fw :sof_fw_phdr
 
-  .comp_init : ALIGN(4)
+  .module_init : ALIGN(4)
   {
-    _comp_init_start = ABSOLUTE(.);
-    *(*.comp_init)
-    _comp_init_end = ABSOLUTE(.);
+    _module_init_start = ABSOLUTE(.);
+    *(*.module_init)
+    _module_init_end = ABSOLUTE(.);
   } >sof_fw :sof_fw_phdr
 
   .data : ALIGN(4)

--- a/src/platform/baytrail/baytrail.x.in
+++ b/src/platform/baytrail/baytrail.x.in
@@ -376,11 +376,11 @@ SECTIONS
     _rodata_end = ABSOLUTE(.);
   } >sof_data :sof_data_phdr
 
-  .comp_init : ALIGN(4)
+  .module_init : ALIGN(4)
   {
-    _comp_init_start = ABSOLUTE(.);
-    *(*.comp_init)
-    _comp_init_end = ABSOLUTE(.);
+    _module_init_start = ABSOLUTE(.);
+    *(*.module_init)
+    _module_init_end = ABSOLUTE(.);
   } >sof_data :sof_data_phdr
 
   .data : ALIGN(4)

--- a/src/platform/cannonlake/cannonlake.x.in
+++ b/src/platform/cannonlake/cannonlake.x.in
@@ -401,11 +401,11 @@ SECTIONS
     _rodata_end = ABSOLUTE(.);
   } >sof_fw :sof_fw_phdr
 
-  .comp_init : ALIGN(4)
+  .module_init : ALIGN(4)
   {
-    _comp_init_start = ABSOLUTE(.);
-    *(*.comp_init)
-    _comp_init_end = ABSOLUTE(.);
+    _module_init_start = ABSOLUTE(.);
+    *(*.module_init)
+    _module_init_end = ABSOLUTE(.);
   } >sof_fw :sof_fw_phdr
 
   .data : ALIGN(4)

--- a/src/platform/haswell/haswell.x.in
+++ b/src/platform/haswell/haswell.x.in
@@ -376,13 +376,12 @@ SECTIONS
     _rodata_end = ABSOLUTE(.);
   } >sof_data :sof_data_phdr
 
-  .comp_init : ALIGN(4)
+  .module_init : ALIGN(4)
   {
-    _comp_init_start = ABSOLUTE(.);
-    *(*.comp_init)
-    _comp_init_end = ABSOLUTE(.);
+    _module_init_start = ABSOLUTE(.);
+    *(*.module_init)
+    _module_init_end = ABSOLUTE(.);
   } >sof_data :sof_data_phdr
-
   .data : ALIGN(4)
   {
     _data_start = ABSOLUTE(.);

--- a/src/platform/icelake/icelake.x.in
+++ b/src/platform/icelake/icelake.x.in
@@ -405,11 +405,11 @@ SECTIONS
     _rodata_end = ABSOLUTE(.);
   } >sof_fw :sof_fw_phdr
 
-  .comp_init : ALIGN(4)
+  .module_init : ALIGN(4)
   {
-    _comp_init_start = ABSOLUTE(.);
-    *(*.comp_init)
-    _comp_init_end = ABSOLUTE(.);
+    _module_init_start = ABSOLUTE(.);
+    *(*.module_init)
+    _module_init_end = ABSOLUTE(.);
   } >sof_fw :sof_fw_phdr
 
   .data : ALIGN(4)

--- a/src/platform/suecreek/suecreek.x.in
+++ b/src/platform/suecreek/suecreek.x.in
@@ -408,11 +408,11 @@ SECTIONS
     _rodata_end = ABSOLUTE(.);
   } >sof_data :sof_data_phdr
 
-  .comp_init : ALIGN(4)
+  .module_init : ALIGN(4)
   {
-    _comp_init_start = ABSOLUTE(.);
-    *(*.comp_init)
-    _comp_init_end = ABSOLUTE(.);
+    _module_init_start = ABSOLUTE(.);
+    *(*.module_init)
+    _module_init_end = ABSOLUTE(.);
   } >sof_data :sof_data_phdr
 
   .data : ALIGN(4)

--- a/src/tasks/audio.c
+++ b/src/tasks/audio.c
@@ -48,12 +48,24 @@
 #include <stdlib.h>
 #include <errno.h>
 
+static void sys_module_init(void)
+{
+	extern intptr_t _module_init_start, _module_init_end;
+	intptr_t *module_init = (intptr_t *)(&_module_init_start);
+
+	for (; module_init < (intptr_t *)&_module_init_end; ++module_init)
+		((void(*)(void))(*module_init))();
+}
+
 int do_task_master_core(struct sof *sof)
 {
 	int ret;
 
 	/* init default audio components */
 	sys_comp_init();
+
+	/* init self-registered modules */
+	sys_module_init();
 
 #if STATIC_PIPE
 	/* init static pipeline */


### PR DESCRIPTION
From now on, modules (including components) that wish to be self-registered
and initialized on boot up shall use the DECLARE_MODULE macro.

Signed-off-by: Slawomir Blauciak <slawomir.blauciak@linux.intel.com>