### PR TITLE
ipc: irq: IPC IRQ is a LEVEL type and is cleared via HW

### DIFF
--- a/src/drivers/intel/baytrail/ipc.c
+++ b/src/drivers/intel/baytrail/ipc.c
@@ -103,7 +103,6 @@ static void irq_handler(void *arg)
 
 		/* Mask Done interrupt before return */
 		shim_write(SHIM_IMRD, shim_read(SHIM_IMRD) | SHIM_IMRD_DONE);
-		interrupt_clear(PLATFORM_IPC_INTERRUPT);
 		do_notify();
 	}
 
@@ -113,7 +112,6 @@ static void irq_handler(void *arg)
 
 		/* Mask Busy interrupt before return */
 		shim_write(SHIM_IMRD, shim_read(SHIM_IMRD) | SHIM_IMRD_BUSY);
-		interrupt_clear(PLATFORM_IPC_INTERRUPT);
 
 		/* TODO: place message in Q and process later */
 		/* It's not Q ATM, may overwrite */

--- a/src/drivers/intel/haswell/ipc.c
+++ b/src/drivers/intel/haswell/ipc.c
@@ -100,7 +100,6 @@ static void irq_handler(void *arg)
 
 		/* Mask Done interrupt before return */
 		shim_write(SHIM_IMRD, shim_read(SHIM_IMRD) | SHIM_IMRD_DONE);
-		interrupt_clear(PLATFORM_IPC_INTERRUPT);
 		do_notify();
 	}
 
@@ -108,7 +107,6 @@ static void irq_handler(void *arg)
 
 		/* Mask Busy interrupt before return */
 		shim_write(SHIM_IMRD, shim_read(SHIM_IMRD) | SHIM_IMRD_BUSY);
-		interrupt_clear(PLATFORM_IPC_INTERRUPT);
 
 		/* TODO: place message in Q and process later */
 		/* It's not Q ATM, may overwrite */


### PR DESCRIPTION
IPC IRQ is a LEVEL interrupt and hence does not need INTCLEAR set as
this is cleared by SHIM HW.

Signed-off-by: Liam Girdwood <liam.r.girdwood@linux.intel.com>