### PR TITLE
[IRQ] cavs: make sure all level2 IRQs are serviced fairly

### DIFF
--- a/src/include/sof/interrupt.h
+++ b/src/include/sof/interrupt.h
@@ -41,7 +41,8 @@
 #include <sof/list.h>
 
 #define trace_irq(__e)	trace_event(TRACE_CLASS_IRQ, __e)
-#define trace_irq_error(__e)	trace_error(TRACE_CLASS_IRQ,  __e)
+#define trace_irq_error(__e, ...) \
+	trace_error(TRACE_CLASS_IRQ,  __e, ##__VA_ARGS__)
 
 #define IRQ_MANUAL_UNMASK	0
 #define IRQ_AUTO_UNMASK		1


### PR DESCRIPTION
This series fixes some issues with the CAVS core level2 IRQ logic.
1) Now continually check the IRQ status.
2) Don't mask IRQ's
3) Dont clear level 2 controller IRQ (it's a LEVEL based IRQ)
4) Tell the user if we cant clear a device after a number of tries.

@mengdonglin this will need stress testing on CML