### PR TITLE
test: ipc: Add FW testing IPC foundations.

### DIFF
--- a/src/include/uapi/abi.h
+++ b/src/include/uapi/abi.h
@@ -52,7 +52,7 @@
 
 /** \brief SOF ABI version major, minor and patch numbers */
 #define SOF_ABI_MAJOR 3
-#define SOF_ABI_MINOR 6
+#define SOF_ABI_MINOR 7
 #define SOF_ABI_PATCH 0
 
 /** \brief SOF ABI version number. Format within 32bit word is MMmmmppp */

--- a/src/include/uapi/ipc/header.h
+++ b/src/include/uapi/ipc/header.h
@@ -93,6 +93,7 @@
 #define SOF_IPC_GLB_DAI_MSG			SOF_GLB_TYPE(0x8U)
 #define SOF_IPC_GLB_TRACE_MSG			SOF_GLB_TYPE(0x9U)
 #define SOF_IPC_GLB_GDB_DEBUG                   SOF_GLB_TYPE(0xAU)
+#define SOF_IPC_GLB_TEST			SOF_GLB_TYPE(0xBU)
 
 /** @} */
 
@@ -169,6 +170,14 @@
 
 #define SOF_IPC_TRACE_DMA_PARAMS		SOF_CMD_TYPE(0x001)
 #define SOF_IPC_TRACE_DMA_POSITION		SOF_CMD_TYPE(0x002)
+
+/** @} */
+
+/** \name DSP Command: Test - Debug build only
+ *  @{
+ */
+
+#define SOF_IPC_TEST_IPC_FLOOD			SOF_CMD_TYPE(0x001)
 
 /** @} */
 

--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -1094,6 +1094,21 @@ static int ipc_glb_tplg_message(uint32_t header)
 	}
 }
 
+#ifdef CONFIG_DEBUG
+static int ipc_glb_test_message(uint32_t header)
+{
+	uint32_t cmd = iCS(header);
+
+	switch (cmd) {
+	case SOF_IPC_TEST_IPC_FLOOD:
+		return 0; /* just return so next IPC can be sent */
+	default:
+		trace_ipc_error("ipc: unknown test header 0x%x", header);
+		return -EINVAL;
+	}
+}
+#endif
+
 /*
  * Global IPC Operations.
  */
@@ -1130,6 +1145,10 @@ int ipc_cmd(void)
 		return ipc_glb_debug_message(hdr->cmd);
 	case SOF_IPC_GLB_GDB_DEBUG:
 		return ipc_glb_gdb_debug(hdr->cmd);
+#ifdef CONFIG_DEBUG
+	case SOF_IPC_GLB_TEST:
+		return ipc_glb_test_message(hdr->cmd);
+#endif
 	default:
 		trace_ipc_error("ipc: unknown command type %u", type);
 		return -EINVAL;


### PR DESCRIPTION
Add a new IPC global class for FW testing alongside the first "test" IPC
command for flooding the DSP with IPCs.

Needs to have CONFIG_DEBUG enabled.

Signed-off-by: Liam Girdwood <liam.r.girdwood@linux.intel.com>

@ranj063 I would expect the kernel to export a debugFS file where the user could 
```
echo 1000 > /debugFS/sof/ipc_flood
```
to execute a test of a 1000 IPCs. Then
```
cat /debugFS/sof/ipc_flood
```
Would indicate number of tests until failure, where 1000 would be a pass.