### PR TITLE
ssp: remove not needed irq handler

### DIFF
--- a/src/drivers/intel/haswell/ssp.c
+++ b/src/drivers/intel/haswell/ssp.c
@@ -479,22 +479,9 @@ static int ssp_trigger(struct dai *dai, int cmd, int direction)
 	return 0;
 }
 
-/* clear IRQ sources atm */
-static void ssp_irq_handler(void *data)
-{
-	struct dai *dai = data;
-
-	trace_ssp("ssp_irq_handler(), IRQ = %u", ssp_read(dai, SSSR));
-
-	/* clear IRQ */
-	ssp_write(dai, SSSR, ssp_read(dai, SSSR));
-	platform_interrupt_clear(ssp_irq(dai), 1);
-}
-
 static int ssp_probe(struct dai *dai)
 {
 	struct ssp_pdata *ssp;
-	int ret;
 
 	/* allocate private data */
 	ssp = rzalloc(RZONE_SYS | RZONE_FLAG_UNCACHED, SOF_MEM_CAPS_RAM,
@@ -505,18 +492,6 @@ static int ssp_probe(struct dai *dai)
 
 	ssp->state[DAI_DIR_PLAYBACK] = COMP_STATE_READY;
 	ssp->state[DAI_DIR_CAPTURE] = COMP_STATE_READY;
-
-	/* register our IRQ handler */
-	ret = interrupt_register(ssp_irq(dai), IRQ_AUTO_UNMASK, ssp_irq_handler,
-				 dai);
-	if (ret < 0) {
-		trace_ssp_error("SSP failed to allocate IRQ");
-		rfree(ssp);
-		return ret;
-	}
-
-	platform_interrupt_unmask(ssp_irq(dai), 1);
-	interrupt_enable(ssp_irq(dai));
 
 	return 0;
 }


### PR DESCRIPTION
Removes SSP interrupt handler as it's not used.
Let's not waste any memory for interrupt registration
and do not pollute the code.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>