### PR TITLE
codeowners: make sure TSC is notified for every ABI change.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,8 +11,7 @@
 # include files
 src/include/sof/dmic.h			@singalsu
 src/include/host/*			@ranj063
-src/include/uapi/**			@bardliao @wwittbrx @zrombel @dbaluta
-src/include/uapi/ipc/*			@xiulipan @bardliao @wwittbrx @zrombel @dbaluta
+src/include/uapi/**			@thesofproject/steering-committee
 src/include/gdb/*			@mrajwa
 src/include/audio/kpb.h			@mrajwa
 


### PR DESCRIPTION
TSC can then classify the ABI change as PATCH, MINOR or MAJOR in ABI
classifier and connect to corresponding kernel PR.

https://github.com/orgs/thesofproject/projects/2

Signed-off-by: Liam Girdwood <liam.r.girdwood@linux.intel.com>