### PR TITLE
[RFC][Do not merge] TPLG: Pipeline with non-standard rate DAI

### DIFF
--- a/tools/topology/CMakeLists.txt
+++ b/tools/topology/CMakeLists.txt
@@ -48,6 +48,7 @@ set(TPLGS
 	"sof-apl-dmic\;sof-apl-dmic-2ch\;-DCHANNELS=2"
 	"sof-icl-dmic-4ch\;sof-icl-dmic-4ch"
 	"sof-apl-src-pcm512x\;sof-apl-src-pcm512x"
+	"sof-apl-src-50k-pcm512x\;sof-apl-src-50k-pcm512x"
 	"sof-cml-rt5682\;sof-cml-rt5682\;-DPLATFORM=cml"
 	"sof-cml-rt5682\;sof-whl-rt5682\;-DPLATFORM=whl"
 	"sof-cml-src-rt5682\;sof-cml-src-rt5682"

--- a/tools/topology/sof-apl-src-50k-pcm512x.m4
+++ b/tools/topology/sof-apl-src-50k-pcm512x.m4
@@ -1,0 +1,72 @@
+#
+# Topology for Apollolake UP^2 with pcm512x codec with sample rate
+# conversion (SRC component).
+#
+
+# Include topology builder
+include(`utils.m4')
+include(`dai.m4')
+include(`pipeline.m4')
+include(`ssp.m4')
+
+# Include TLV library
+include(`common/tlv.m4')
+
+# Include Token library
+include(`sof/tokens.m4')
+
+# Include Apollolake DSP configuration
+include(`platform/intel/bxt.m4')
+
+DEBUG_START
+
+#
+# Define the pipelines
+#
+# PCM0 ----> src -----> SSP5 (pcm512x)
+#
+
+dnl PIPELINE_PCM_ADD(pipeline,
+dnl     pipe id, pcm, max channels, format,
+dnl     frames, deadline, priority, core)
+
+# Playback pipeline 1 on PCM 0 using max 2 channels of s24le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-src-50k-playback.m4,
+	1, 0, 2, s24le,
+	48, 1000, 0, 0)
+
+#
+# DAIs configuration
+#
+
+dnl DAI_ADD(pipeline,
+dnl     pipe id, dai type, dai_index, dai_be,
+dnl     buffer, periods, format,
+dnl     frames, deadline, priority, core)
+
+# playback DAI is SSP5 using 2 periods
+# Buffers use s24le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+	1, SSP, 5, SSP5-Codec,
+	PIPELINE_SOURCE_1, 2, s24le,
+	48, 1000, 0, 0)
+
+# PCM, id 0
+dnl PCM_PLAYBACK_ADD(name, pcm_id, playback)
+PCM_PLAYBACK_ADD(Port5, 0, PIPELINE_PCM_1)
+
+#
+# BE configurations - overrides config in ACPI if present
+#
+
+#SSP 5 (ID: 0)
+DAI_CONFIG(SSP, 5, 0, SSP5-Codec,
+	SSP_CONFIG(I2S, SSP_CLOCK(mclk, 19200000, codec_mclk_in),
+		SSP_CLOCK(bclk, 3200000, codec_slave),
+		SSP_CLOCK(fsync, 50000, codec_slave),
+		SSP_TDM(2, 32, 3, 3),
+		SSP_CONFIG_DATA(SSP, 5, 24)))
+
+DEBUG_END
+

--- a/tools/topology/sof/pipe-src-50k-playback.m4
+++ b/tools/topology/sof/pipe-src-50k-playback.m4
@@ -1,0 +1,86 @@
+# Low Latency Passthrough with volume Pipeline and PCM
+#
+# Pipeline Endpoints for connection are :-
+#
+#  host PCM_P --> SRC --> sink DAI0
+
+# Include topology builder
+include(`utils.m4')
+include(`src.m4')
+include(`buffer.m4')
+include(`pcm.m4')
+include(`pga.m4')
+include(`dai.m4')
+include(`mixercontrol.m4')
+include(`pipeline.m4')
+
+#
+# Controls
+#
+# Volume Mixer control with max value of 32
+C_CONTROLMIXER(Master Playback Volume, PIPELINE_ID,
+	CONTROLMIXER_OPS(volsw, 256 binds the mixer control to volume get/put handlers, 256, 256),
+	CONTROLMIXER_MAX(, 32),
+	false,
+	CONTROLMIXER_TLV(TLV 32 steps from -64dB to 0dB for 2dB, vtlv_m64s2),
+	Channel register and shift for Front Left/Right,
+	LIST(`	', KCONTROL_CHANNEL(FL, 1, 0), KCONTROL_CHANNEL(FR, 1, 1)))
+
+#
+# Components and Buffers
+#
+
+# Host "SRC Playback" PCM
+# with 3 sink and 0 source periods
+W_PCM_PLAYBACK(PCM_ID, SRC Playback, 3, 0)
+
+#
+# SRC Configuration
+#
+
+W_VENDORTUPLES(media_src_tokens, sof_src_tokens, LIST(`		', `SOF_TKN_SRC_RATE_OUT	"50000"'))
+
+W_DATA(media_src_conf, media_src_tokens)
+
+# "SRC" has 3 source and 3 sink periods
+W_SRC(0, PIPELINE_FORMAT, 3, 3, media_src_conf)
+
+# "Volume" has 2 source and 2 sink periods
+W_PGA(0, PIPELINE_FORMAT, 2, 2, LIST(`		', "PIPELINE_ID Master Playback Volume"))
+
+# Playback Buffers
+W_BUFFER(0, COMP_BUFFER_SIZE(3,
+	COMP_SAMPLE_SIZE(PIPELINE_FORMAT), PIPELINE_CHANNELS, SCHEDULE_FRAMES),
+	PLATFORM_HOST_MEM_CAP)
+W_BUFFER(1, COMP_BUFFER_SIZE(3,
+	COMP_SAMPLE_SIZE(PIPELINE_FORMAT), PIPELINE_CHANNELS, SCHEDULE_FRAMES),
+	PLATFORM_HOST_MEM_CAP)
+W_BUFFER(2, COMP_BUFFER_SIZE(2,
+	COMP_SAMPLE_SIZE(PIPELINE_FORMAT), PIPELINE_CHANNELS, SCHEDULE_FRAMES),
+	PLATFORM_DAI_MEM_CAP)
+
+#
+# Pipeline Graph
+#
+#  host PCM_P --> B0 --> SRC 0 --> B1 Volume 0 --> B2 --> sink DAI0
+
+P_GRAPH(pipe-pass-src-playback-PIPELINE_ID, PIPELINE_ID,
+	LIST(`		',
+	`dapm(N_BUFFER(0), N_PCMP(PCM_ID))',
+	`dapm(N_SRC(0), N_BUFFER(0))',
+	`dapm(N_BUFFER(1), N_SRC(0))',
+	`dapm(N_PGA(0), N_BUFFER(1))',
+	`dapm(N_BUFFER(2), N_PGA(0))'))
+
+#
+# Pipeline Source and Sinks
+#
+indir(`define', concat(`PIPELINE_SOURCE_', PIPELINE_ID), N_BUFFER(2))
+indir(`define', concat(`PIPELINE_PCM_', PIPELINE_ID), SRC Playback PCM_ID)
+
+#
+# PCM Configuration
+#
+
+PCM_CAPABILITIES(SRC Playback PCM_ID, `S32_LE,S24_LE,S16_LE', 8000, 192000, 2, PIPELINE_CHANNELS, 2, 16, 192, 16384, 65536, 65536)
+


### PR DESCRIPTION
This patch demonstrates topology to operate DAI with 50 kHz
rate. Such non-standard rate can be used if otherwise
compatible I2S format is not achievable due to master clock
divide and I2S word length constraints. The SRC component
converts in this pipeline 48 kHz playback to used 50 kHz DAI
rate.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>