### PR TITLE
module: fix include needed for DECLARE_MODULE

### DIFF
--- a/src/include/sof/sof.h
+++ b/src/include/sof/sof.h
@@ -36,6 +36,7 @@
 #include <arch/sof.h>
 #include <sof/panic.h>
 #include <sof/preproc.h>
+#include <config.h>
 
 struct ipc;
 struct sa;


### PR DESCRIPTION
DECLARE_MODULE from #1284 didn't work for host build because it was using CONFIG_* variable and didn't include config.h. This PR adds this include.

Signed-off-by: Janusz Jankowski <janusz.jankowski@linux.intel.com>