### PR TITLE
sof: logger: reopen trace file upon EOF

### DIFF
--- a/tools/logger/convert.c
+++ b/tools/logger/convert.c
@@ -375,8 +375,10 @@ static int logger_read(const struct convert_config *config,
 		/* getting entry parameters from dma dump */
 		ret = fread(&dma_log, sizeof(dma_log), 1, config->in_fd);
 		if (!ret) {
-			if (config->trace)
+			if (config->trace && !ferror(config->in_fd)) {
+				freopen(NULL, "r", config->in_fd);
 				continue;
+			}
 
 			return -ferror(config->in_fd);
 		}


### PR DESCRIPTION
If logger reads an end-of-file from trace node, reopen the file
to ensure trace read position is in sync between host and DSP.

This allows to avoid duplicate/misordered traces at suspend/resume cycles when used together with PR781 https://github.com/thesofproject/linux/pull/781

This patch can be merged independently of PR781, there is no hard dependency.


