### PR TITLE
smp: fix slave cores initialization

### DIFF
--- a/src/arch/xtensa/smp/init.c
+++ b/src/arch/xtensa/smp/init.c
@@ -118,10 +118,11 @@ int slave_core_init(struct sof *sof)
 	trace_point(TRACE_BOOT_SYS_NOTE);
 	init_system_notify(sof);
 
+	/* interrupts need to be initialized before any usage */
+	platform_interrupt_init();
+
 	trace_point(TRACE_BOOT_SYS_SCHED);
 	scheduler_init();
-
-	platform_interrupt_init();
 
 	/* initialize IDC mechanism */
 	trace_point(TRACE_BOOT_PLATFORM_IDC);


### PR DESCRIPTION
Fixes slave cores initialization by moving interrupt
init before any interrupt registration.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>