### PR TITLE
headers: remove unused header from IPC handler and audio core.

### DIFF
--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -50,7 +50,6 @@
 #include <sof/math/numbers.h>
 #include <platform/interrupt.h>
 #include <platform/mailbox.h>
-#include <platform/shim.h>
 #include <platform/dma.h>
 #include <platform/timer.h>
 #include <platform/idc.h>

--- a/src/tasks/audio.c
+++ b/src/tasks/audio.c
@@ -39,7 +39,6 @@
 #include <sof/agent.h>
 #include <platform/idc.h>
 #include <platform/interrupt.h>
-#include <platform/shim.h>
 #include <sof/audio/pipeline.h>
 #include <sof/schedule.h>
 #include <sof/debug.h>


### PR DESCRIPTION
The Intel shim header is specific to Intel hardware and not used by IPC
handler or audio core.

Signed-off-by: John Gunn <jgunn0262@gmail.com>