### PR TITLE
clk: i2s: Make clock API generic and not Intel specific

### DIFF
--- a/src/include/sof/notifier.h
+++ b/src/include/sof/notifier.h
@@ -43,7 +43,7 @@ struct sof;
 
 enum notify_id {
 	NOTIFIER_ID_CPU_FREQ = 0,
-	NOTIFIER_ID_SSP_FREQ,
+	NOTIFIER_ID_I2S_FREQ,
 	NOTIFIER_ID_KPB_CLIENT_EVT,
 };
 

--- a/src/lib/clk.c
+++ b/src/lib/clk.c
@@ -112,11 +112,11 @@ void clock_set_freq(int clock, uint32_t hz)
 		notify_data.target_core_mask =
 			NOTIFIER_TARGET_CORE_MASK(cpu_get_id());
 		break;
-	case CLK_SSP:
-		set_freq = &clock_platform_set_ssp_freq;
-		freq_table = ssp_freq;
-		freq_table_size = ARRAY_SIZE(ssp_freq);
-		notify_data.id = NOTIFIER_ID_SSP_FREQ;
+	case CLK_I2S:
+		set_freq = &clock_platform_set_i2s_freq;
+		freq_table = i2s_freq;
+		freq_table_size = ARRAY_SIZE(i2s_freq);
+		notify_data.id = NOTIFIER_ID_I2S_FREQ;
 		notify_data.target_core_mask = NOTIFIER_TARGET_CORE_ALL_MASK;
 		break;
 	default:
@@ -167,8 +167,8 @@ void clock_init(void)
 		spinlock_init(&clk_pdata->clk[i].lock);
 	}
 
-	clk_pdata->clk[CLK_SSP].freq = ssp_freq[SSP_DEFAULT_IDX].freq;
-	clk_pdata->clk[CLK_SSP].ticks_per_msec =
-			ssp_freq[SSP_DEFAULT_IDX].ticks_per_msec;
-	spinlock_init(&clk_pdata->clk[CLK_SSP].lock);
+	clk_pdata->clk[CLK_I2S].freq = i2s_freq[I2S_DEFAULT_IDX].freq;
+	clk_pdata->clk[CLK_I2S].ticks_per_msec =
+			i2s_freq[I2S_DEFAULT_IDX].ticks_per_msec;
+	spinlock_init(&clk_pdata->clk[CLK_I2S].lock);
 }

--- a/src/library/include/platform/clk.h
+++ b/src/library/include/platform/clk.h
@@ -32,7 +32,7 @@
 #define __INCLUDE_LIB_PLATFORM_HOST_CLOCK__
 
 #define CLK_CPU(x)	x
-#define CLK_SSP		1
+#define CLK_I2S		1
 
 #define CLK_DEFAULT_CPU_HZ	50000000
 #define CLK_MAX_CPU_HZ		343000000

--- a/src/platform/apollolake/include/platform/clk-map.h
+++ b/src/platform/apollolake/include/platform/clk-map.h
@@ -42,7 +42,7 @@ static const struct freq_table cpu_freq[] = {
 /* IMPORTANT: array should be filled in increasing order
  * (regarding to .freq field)
  */
-static const struct freq_table ssp_freq[] = {
+static const struct freq_table i2s_freq[] = {
 	{ 19200000, 19200, CLOCK_SSP_XTAL_OSCILLATOR },
 	{ 24576000, 24576, CLOCK_SSP_AUDIO_CARDINAL },
 	{ 96000000, 96000, CLOCK_SSP_PLL_FIXED },

--- a/src/platform/apollolake/include/platform/clk.h
+++ b/src/platform/apollolake/include/platform/clk.h
@@ -37,10 +37,10 @@
 #include <platform/shim.h>
 
 #define CLK_CPU(x)	(x)
-#define CLK_SSP		2
+#define CLK_I2S		2
 
 #define CPU_DEFAULT_IDX		2
-#define SSP_DEFAULT_IDX		0
+#define I2S_DEFAULT_IDX		0
 
 #define CLK_DEFAULT_CPU_HZ	400000000
 #define CLK_MAX_CPU_HZ		400000000
@@ -58,7 +58,7 @@ static inline int clock_platform_set_cpu_freq(uint32_t cpu_freq_enc)
 	return 0;
 }
 
-static inline int clock_platform_set_ssp_freq(uint32_t ssp_freq_enc)
+static inline int clock_platform_set_i2s_freq(uint32_t ssp_freq_enc)
 {
 	return 0;
 }

--- a/src/platform/apollolake/include/platform/platform.h
+++ b/src/platform/apollolake/include/platform/platform.h
@@ -63,7 +63,7 @@ struct sof;
  *  xtensa core, and ssp clock which is provided by external HW IP.
  *  The choice depends on HW features on different platform
  */
-#define PLATFORM_DEFAULT_CLOCK CLK_SSP
+#define PLATFORM_DEFAULT_CLOCK CLK_I2S
 
 /* DGMBS align value */
 #define PLATFORM_HDA_BUFFER_ALIGNMENT	0x20

--- a/src/platform/baytrail/include/platform/clk-map.h
+++ b/src/platform/baytrail/include/platform/clk-map.h
@@ -57,7 +57,7 @@ static const struct freq_table cpu_freq[] = {
 };
 #endif
 
-static const struct freq_table ssp_freq[] = {
+static const struct freq_table i2s_freq[] = {
 	{19200000, 19200, PMC_SET_SSP_19M2}, /* default */
 	{25000000, 25000, PMC_SET_SSP_25M},
 };

--- a/src/platform/baytrail/include/platform/clk.h
+++ b/src/platform/baytrail/include/platform/clk.h
@@ -36,14 +36,14 @@
 #include <platform/shim.h>
 
 #define CLK_CPU(x)	(x)
-#define CLK_SSP		1
+#define CLK_I2S		1
 
 #define CPU_DEFAULT_IDX		3
 
 #if defined CONFIG_BAYTRAIL
-#define SSP_DEFAULT_IDX		1
+#define I2S_DEFAULT_IDX		1
 #elif defined CONFIG_CHERRYTRAIL
-#define SSP_DEFAULT_IDX		0
+#define I2S_DEFAULT_IDX		0
 #endif
 
 #define CLK_DEFAULT_CPU_HZ	50000000
@@ -61,7 +61,7 @@ static inline int clock_platform_set_cpu_freq(uint32_t cpu_freq_enc)
 	return ipc_pmc_send_msg(PMC_SET_LPECLK);
 }
 
-static inline int clock_platform_set_ssp_freq(uint32_t ssp_freq_enc)
+static inline int clock_platform_set_i2s_freq(uint32_t ssp_freq_enc)
 {
 	/* send SSP freq request to SC */
 	return ipc_pmc_send_msg(ssp_freq_enc);

--- a/src/platform/baytrail/include/platform/platform.h
+++ b/src/platform/baytrail/include/platform/platform.h
@@ -59,7 +59,7 @@ struct sof;
  *  xtensa core, and ssp clock which is provided by external HW IP.
  *  The choice depends on HW features on different platform
  */
-#define PLATFORM_DEFAULT_CLOCK CLK_SSP
+#define PLATFORM_DEFAULT_CLOCK CLK_I2S
 
 /*! \def PLATFORM_WORKQ_DEFAULT_TIMEOUT
  *  \brief work queue default timeout in microseconds

--- a/src/platform/baytrail/platform.c
+++ b/src/platform/baytrail/platform.c
@@ -143,7 +143,7 @@ struct timesource_data platform_generic_queue[] = {
 		.irq = IRQ_NUM_EXT_TIMER,
 	},
 	.clk		= PLATFORM_WORKQ_CLOCK,
-	.notifier	= NOTIFIER_ID_SSP_FREQ,
+	.notifier	= NOTIFIER_ID_I2S_FREQ,
 	.timer_set	= platform_timer_set,
 	.timer_clear	= platform_timer_clear,
 	.timer_get	= platform_timer_get,
@@ -231,7 +231,7 @@ int platform_init(struct sof *sof)
 	trace_point(TRACE_BOOT_PLATFORM_SSP_FREQ);
 
 	/* set SSP clock to 19.2M */
-	clock_set_freq(CLK_SSP, 19200000);
+	clock_set_freq(CLK_I2S, 19200000);
 
 	/* init DMACs */
 	trace_point(TRACE_BOOT_PLATFORM_DMA);

--- a/src/platform/cannonlake/include/platform/clk-map.h
+++ b/src/platform/cannonlake/include/platform/clk-map.h
@@ -41,7 +41,7 @@ static const struct freq_table cpu_freq[] = {
 /* IMPORTANT: array should be filled in increasing order
  * (regarding to .freq field)
  */
-static const struct freq_table ssp_freq[] = {
+static const struct freq_table i2s_freq[] = {
 	{ 24000000, 24000, CLOCK_SSP_XTAL_OSCILLATOR },
 	{ 96000000, 96000, CLOCK_SSP_PLL_FIXED },
 };

--- a/src/platform/cannonlake/include/platform/clk.h
+++ b/src/platform/cannonlake/include/platform/clk.h
@@ -38,10 +38,10 @@
 #include <platform/shim.h>
 
 #define CLK_CPU(x)	(x)
-#define CLK_SSP		4
+#define CLK_I2S		4
 
 #define CPU_DEFAULT_IDX		1
-#define SSP_DEFAULT_IDX		0
+#define I2S_DEFAULT_IDX		0
 
 #define CLK_DEFAULT_CPU_HZ	120000000
 #define CLK_MAX_CPU_HZ		400000000
@@ -58,7 +58,7 @@ static inline int clock_platform_set_cpu_freq(uint32_t cpu_freq_enc)
 	return 0;
 }
 
-static inline int clock_platform_set_ssp_freq(uint32_t ssp_freq_enc)
+static inline int clock_platform_set_i2s_freq(uint32_t ssp_freq_enc)
 {
 	return 0;
 }

--- a/src/platform/cannonlake/include/platform/platform.h
+++ b/src/platform/cannonlake/include/platform/platform.h
@@ -64,7 +64,7 @@ struct sof;
  *  xtensa core, and ssp clock which is provided by external HW IP.
  *  The choice depends on HW features on different platform
  */
-#define PLATFORM_DEFAULT_CLOCK CLK_SSP
+#define PLATFORM_DEFAULT_CLOCK CLK_I2S
 
 /*! \def PLATFORM_WORKQ_DEFAULT_TIMEOUT
  *  \brief work queue default timeout in microseconds

--- a/src/platform/haswell/include/platform/clk-map.h
+++ b/src/platform/haswell/include/platform/clk-map.h
@@ -42,7 +42,7 @@ static const struct freq_table cpu_freq[] = {
 	{160000000, 160000, 0x5},
 };
 
-static const struct freq_table ssp_freq[] = {
+static const struct freq_table i2s_freq[] = {
 	{24000000, 24000, 0}, /* default */
 };
 

--- a/src/platform/haswell/include/platform/clk.h
+++ b/src/platform/haswell/include/platform/clk.h
@@ -35,10 +35,10 @@
 #include <platform/shim.h>
 
 #define CLK_CPU(x)	(x)
-#define CLK_SSP		1
+#define CLK_I2S		1
 
 #define CPU_DEFAULT_IDX		3
-#define SSP_DEFAULT_IDX		0
+#define I2S_DEFAULT_IDX		0
 
 #define CLK_DEFAULT_CPU_HZ	320000000
 #define CLK_MAX_CPU_HZ		320000000
@@ -54,7 +54,7 @@ static inline int clock_platform_set_cpu_freq(uint32_t cpu_freq_enc)
 	return 0;
 }
 
-static inline int clock_platform_set_ssp_freq(uint32_t ssp_freq_enc)
+static inline int clock_platform_set_i2s_freq(uint32_t ssp_freq_enc)
 {
 	return 0;
 }

--- a/src/platform/haswell/platform.c
+++ b/src/platform/haswell/platform.c
@@ -219,7 +219,7 @@ int platform_init(struct sof *sof)
 
 	/* set SSP clock to 25M */
 	trace_point(TRACE_BOOT_PLATFORM_SSP_FREQ);
-	clock_set_freq(CLK_SSP, 25000000);
+	clock_set_freq(CLK_I2S, 25000000);
 
 	/* init DMACs */
 	trace_point(TRACE_BOOT_PLATFORM_DMA);

--- a/src/platform/icelake/include/platform/clk-map.h
+++ b/src/platform/icelake/include/platform/clk-map.h
@@ -41,7 +41,7 @@ static const struct freq_table cpu_freq[] = {
 /* IMPORTANT: array should be filled in increasing order
  * (regarding to .freq field)
  */
-static const struct freq_table ssp_freq[] = {
+static const struct freq_table i2s_freq[] = {
 	{ 24576000, 24576, CLOCK_SSP_AUDIO_CARDINAL },
 	{ 38400000, 38400, CLOCK_SSP_XTAL_OSCILLATOR },
 	{ 96000000, 96000, CLOCK_SSP_PLL_FIXED },

--- a/src/platform/icelake/include/platform/clk.h
+++ b/src/platform/icelake/include/platform/clk.h
@@ -38,10 +38,10 @@
 #include <platform/shim.h>
 
 #define CLK_CPU(x)	(x)
-#define CLK_SSP		4
+#define CLK_I2S		4
 
 #define CPU_DEFAULT_IDX		1
-#define SSP_DEFAULT_IDX		1
+#define I2S_DEFAULT_IDX		1
 
 #define CLK_DEFAULT_CPU_HZ	120000000
 #define CLK_MAX_CPU_HZ		400000000
@@ -58,7 +58,7 @@ static inline int clock_platform_set_cpu_freq(uint32_t cpu_freq_enc)
 	return 0;
 }
 
-static inline int clock_platform_set_ssp_freq(uint32_t ssp_freq_enc)
+static inline int clock_platform_set_i2s_freq(uint32_t ssp_freq_enc)
 {
 	return 0;
 }

--- a/src/platform/icelake/include/platform/platform.h
+++ b/src/platform/icelake/include/platform/platform.h
@@ -64,7 +64,7 @@ struct sof;
  *  xtensa core, and ssp clock which is provided by external HW IP.
  *  The choice depends on HW features on different platform
  */
-#define PLATFORM_DEFAULT_CLOCK CLK_SSP
+#define PLATFORM_DEFAULT_CLOCK CLK_I2S
 
 /*! \def PLATFORM_WORKQ_DEFAULT_TIMEOUT
  *  \brief work queue default timeout in microseconds

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -156,8 +156,8 @@ struct timesource_data platform_generic_queue[] = {
 		.id = TIMER3, /* external timer */
 		.irq = IRQ_EXT_TSTAMP0_LVL2(0),
 	},
-	.clk		= CLK_SSP,
-	.notifier	= NOTIFIER_ID_SSP_FREQ,
+	.clk		= CLK_I2S,
+	.notifier	= NOTIFIER_ID_I2S_FREQ,
 	.timer_set	= platform_timer_set,
 	.timer_clear	= platform_timer_clear,
 	.timer_get	= platform_timer_get,
@@ -167,8 +167,8 @@ struct timesource_data platform_generic_queue[] = {
 		.id = TIMER3, /* external timer */
 		.irq = IRQ_EXT_TSTAMP0_LVL2(1),
 	},
-	.clk		= CLK_SSP,
-	.notifier	= NOTIFIER_ID_SSP_FREQ,
+	.clk		= CLK_I2S,
+	.notifier	= NOTIFIER_ID_I2S_FREQ,
 	.timer_set	= platform_timer_set,
 	.timer_clear	= platform_timer_clear,
 	.timer_get	= platform_timer_get,
@@ -179,8 +179,8 @@ struct timesource_data platform_generic_queue[] = {
 		.id = TIMER3, /* external timer */
 		.irq = IRQ_EXT_TSTAMP0_LVL2(2),
 	},
-	.clk		= CLK_SSP,
-	.notifier	= NOTIFIER_ID_SSP_FREQ,
+	.clk		= CLK_I2S,
+	.notifier	= NOTIFIER_ID_I2S_FREQ,
 	.timer_set	= platform_timer_set,
 	.timer_clear	= platform_timer_clear,
 	.timer_get	= platform_timer_get,
@@ -190,8 +190,8 @@ struct timesource_data platform_generic_queue[] = {
 		.id = TIMER3, /* external timer */
 		.irq = IRQ_EXT_TSTAMP0_LVL2(3),
 	},
-	.clk		= CLK_SSP,
-	.notifier	= NOTIFIER_ID_SSP_FREQ,
+	.clk		= CLK_I2S,
+	.notifier	= NOTIFIER_ID_I2S_FREQ,
 	.timer_set	= platform_timer_set,
 	.timer_clear	= platform_timer_clear,
 	.timer_get	= platform_timer_get,

--- a/src/platform/suecreek/include/platform/clk-map.h
+++ b/src/platform/suecreek/include/platform/clk-map.h
@@ -41,7 +41,7 @@ static const struct freq_table cpu_freq[] = {
 /* IMPORTANT: array should be filled in increasing order
  * (regarding to .freq field)
  */
-static const struct freq_table ssp_freq[] = {
+static const struct freq_table i2s_freq[] = {
 	{ 38400000, 38400, CLOCK_SSP_XTAL_OSCILLATOR },
 	{ 96000000, 96000, CLOCK_SSP_PLL_FIXED },
 };

--- a/src/platform/suecreek/include/platform/clk.h
+++ b/src/platform/suecreek/include/platform/clk.h
@@ -38,10 +38,10 @@
 #include <platform/shim.h>
 
 #define CLK_CPU(x)	(x)
-#define CLK_SSP		4
+#define CLK_I2S		4
 
 #define CPU_DEFAULT_IDX		1
-#define SSP_DEFAULT_IDX		0
+#define I2S_DEFAULT_IDX		0
 
 #define CLK_DEFAULT_CPU_HZ	120000000
 #define CLK_MAX_CPU_HZ		400000000
@@ -58,7 +58,7 @@ static inline int clock_platform_set_cpu_freq(uint32_t cpu_freq_enc)
 	return 0;
 }
 
-static inline int clock_platform_set_ssp_freq(uint32_t ssp_freq_enc)
+static inline int clock_platform_set_i2s_freq(uint32_t ssp_freq_enc)
 {
 	return 0;
 }

--- a/src/platform/suecreek/include/platform/platform.h
+++ b/src/platform/suecreek/include/platform/platform.h
@@ -64,7 +64,7 @@ struct sof;
  *  xtensa core, and ssp clock which is provided by external HW IP.
  *  The choice depends on HW features on different platform
  */
-#define PLATFORM_DEFAULT_CLOCK CLK_SSP
+#define PLATFORM_DEFAULT_CLOCK CLK_I2S
 
 /*! \def PLATFORM_WORKQ_DEFAULT_TIMEOUT
  *  \brief work queue default timeout in microseconds


### PR DESCRIPTION
The CLK API core defines an Intel specific "SSP" clock to represent a
clock from an I2S port. Rename this clock to I2S to make it generic and
applicable to other non Intel hardware.

Signed-off-by: John Gunn <jgunn0262@gmail.com>