### PR TITLE
ipc: fix dst size of read in mailbox_validate()

### DIFF
--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -141,7 +141,7 @@ static inline struct sof_ipc_cmd_hdr *mailbox_validate(void)
 	}
 
 	/* read rest of component data */
-	mailbox_hostbox_read(hdr + 1, SOF_IPC_MSG_MAX_SIZE,
+	mailbox_hostbox_read(hdr + 1, SOF_IPC_MSG_MAX_SIZE - sizeof(*hdr),
 			     sizeof(*hdr), hdr->size - sizeof(*hdr));
 
 	dcache_writeback_region(hdr, hdr->size);


### PR DESCRIPTION
Fixes destination size of mailbox_hostbox_read() call
in mailbox_validate(). We're starting from some non-zero
offset, so the size is smaller than SOF_IPC_MSG_MAX_SIZE.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>