### PR TITLE
arch: memcpy: using memcpy instead of __vec_memcpy

### DIFF
--- a/src/arch/xtensa/include/arch/string.h
+++ b/src/arch/xtensa/include/arch/string.h
@@ -70,11 +70,15 @@ static inline int arch_memcpy_s(void *dest, size_t dest_size,
 
 	if (src_size > dest_size)
 		return -EINVAL;
-#if __XCC__ && !CONFIG_HOST
-	__vec_memcpy(dest, src, src_size);
-#else
+
+	/* can't be use until full context switch will be supported */
+/* #if __XCC__ && !CONFIG_HOST
+ *	__vec_memcpy(dest, src, src_size);
+ * #else
+ */
 	memcpy(dest, src, src_size);
-#endif
+/* #endif */
+
 	return 0;
 }
 


### PR DESCRIPTION
Using simple memcpy function in arch_memcpy_s() since
preemption of __vec_memcpy() causes wrong memory reading.

Signed-off-by: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>