### PR TITLE
agent: agent should run at high priority

### DIFF
--- a/src/lib/agent.c
+++ b/src/lib/agent.c
@@ -95,7 +95,7 @@ void sa_init(struct sof *sof)
 	/* set lst idle time to now to give time for boot completion */
 	sa->last_idle = platform_timer_get(platform_timer) + sa->ticks;
 
-	schedule_task_init(&sa->work, SOF_SCHEDULE_LL, SOF_TASK_PRI_MED,
+	schedule_task_init(&sa->work, SOF_SCHEDULE_LL, SOF_TASK_PRI_HIGH,
 			   validate, sa, 0, 0);
 
 	schedule_task(&sa->work, PLATFORM_IDLE_TIME, 0, 0);


### PR DESCRIPTION
The system agent should always run at high priority to ensure other lower
priority tasks run as expected. SA work must be as short as possible
since we dont want to impact other high priority work.

Signed-off-by: Liam Girdwood <liam.r.girdwood@linux.intel.com>