### PR TITLE
buffer: remove redundant assignment after creating new buffer

### DIFF
--- a/src/audio/buffer.c
+++ b/src/audio/buffer.c
@@ -90,7 +90,6 @@ struct comp_buffer *buffer_new(struct sof_ipc_buffer *desc)
 
 	buffer->size = desc->size;
 	buffer->alloc_size = desc->size;
-	buffer->ipc_buffer = *desc;
 	buffer->w_ptr = buffer->addr;
 	buffer->r_ptr = buffer->addr;
 	buffer->end_addr = buffer->addr + buffer->ipc_buffer.size;


### PR DESCRIPTION
ipc_buffer member in the new buffer is already populated
when the contents of the "desc" argument are copied
into it. So remove the redundant assignment to ipc_buffer
after the memcpy.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>