### PR TITLE
topology: keyword-detect: change to use DMIC FIFO B

### DIFF
--- a/tools/topology/sof-apl-keyword-detect.m4
+++ b/tools/topology/sof-apl-keyword-detect.m4
@@ -53,7 +53,7 @@ dnl     frames, deadline, priority, core)
 # capture DAI is DMIC 0 using 2 periods
 # Buffers use s16le format, with 320 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
-	1, DMIC, 0, NoCodec-6,
+	1, DMIC, 1, NoCodec-6,
 	PIPELINE_SINK_1, 2, s16le,
 	KWD_PERIOD_FRAMES,
 	KWD_PIPE_SCH_DEADLINE_US,
@@ -84,14 +84,14 @@ SectionGraph."pipe-sof-apl-keyword-detect" {
 #
 
 dnl DAI_CONFIG(type, dai_index, link_id, name, ssp_config/dmic_config)
-DAI_CONFIG(DMIC, 0, 6, NoCodec-6,
+DAI_CONFIG(DMIC, 1, 6, NoCodec-6,
            dnl DMIC_CONFIG(driver_version, clk_min, clk_mac, duty_min, duty_max,
            dnl             sample_rate,
            dnl             fifo word length, type, dai_index, pdm controller config)
            DMIC_CONFIG(1, 500000, 4800000, 40, 60, 16000,
                 dnl DMIC_WORD_LENGTH(frame_format)
-                DMIC_WORD_LENGTH(s16le), DMIC, 0,
+                DMIC_WORD_LENGTH(s16le), DMIC, 1,
                 dnl PDM_CONFIG(type, dai_index, num pdm active, pdm tuples list)
                 dnl STEREO_PDM0 is a pre-defined pdm config for stereo capture
-                PDM_CONFIG(DMIC, 0, STEREO_PDM0)))
+                PDM_CONFIG(DMIC, 1, STEREO_PDM0)))
 


### PR DESCRIPTION
We need use FIFO B for keyword detect DMIC, here change it.

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>