### PR TITLE
include: user: move selector and kpb structures

### DIFF
--- a/src/include/sof/audio/kpb.h
+++ b/src/include/sof/audio/kpb.h
@@ -12,6 +12,7 @@
 #include <sof/notifier.h>
 #include <sof/trace.h>
 #include <sof/schedule.h>
+#include <user/kpb.h>
 
 /* KPB tracing */
 #define trace_kpb(__e, ...) trace_event(TRACE_CLASS_KPB, __e, ##__VA_ARGS__)
@@ -95,16 +96,6 @@ struct dd {
 	size_t history_depth;
 	uint8_t is_draining_active;
 	enum kpb_state *state;
-};
-
-/** \brief kpb component configuration data. */
-struct sof_kpb_config {
-	uint32_t size; /**< kpb size in bytes */
-	uint32_t caps; /**< SOF_MEM_CAPS_ */
-	uint32_t no_channels; /**< no of channels */
-	uint32_t history_depth; /**< time of buffering in milliseconds */
-	uint32_t sampling_freq; /**< frequency in hertz */
-	uint32_t sampling_width; /**< number of bits */
 };
 
 #ifdef UNIT_TEST

--- a/src/include/sof/audio/selector.h
+++ b/src/include/sof/audio/selector.h
@@ -18,6 +18,7 @@
 #include <sof/audio/component.h>
 #include <sof/audio/pipeline.h>
 #include <sof/audio/format.h>
+#include <user/selector.h>
 
 /** \brief Selector trace function. */
 #define trace_selector(__e, ...) \
@@ -39,17 +40,6 @@
 #define SEL_SINK_1CH 1
 #define SEL_SINK_2CH 2
 #define SEL_SINK_4CH 4
-
-/** \brief Selector component configuration data. */
-struct sof_sel_config {
-	/* selector supports 1 input and 1 output */
-	uint32_t in_channels_count;	/**< accepted values 2 or 4 */
-	uint32_t out_channels_count;	/**< accepted values 1 or 2 or 4 */
-	/* note: if 2 or 4 output channels selected the component works in
-	 * a passthrough mode
-	 */
-	uint32_t sel_channel;	/**< 0..3 */
-};
 
 /** \brief Selector component private data. */
 struct comp_data {

--- a/src/include/user/kpb.h
+++ b/src/include/user/kpb.h
@@ -1,0 +1,21 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2019 Intel Corporation. All rights reserved.
+ *
+ * Author: Marcin Rajwa <marcin.rajwa@linux.intel.com>
+ */
+
+#ifndef __INCLUDE_USER_KPB_H__
+#define __INCLUDE_USER_KPB_H__
+
+/** \brief kpb component configuration data. */
+struct sof_kpb_config {
+	uint32_t size; /**< kpb size in bytes */
+	uint32_t caps; /**< SOF_MEM_CAPS_ */
+	uint32_t no_channels; /**< no of channels */
+	uint32_t history_depth; /**< time of buffering in milliseconds */
+	uint32_t sampling_freq; /**< frequency in hertz */
+	uint32_t sampling_width; /**< number of bits */
+};
+
+#endif

--- a/src/include/user/selector.h
+++ b/src/include/user/selector.h
@@ -1,0 +1,22 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2019 Intel Corporation. All rights reserved.
+ *
+ * Author: Lech Betlej <lech.betlej@linux.intel.com>
+ */
+
+#ifndef __INCLUDE_USER_SELECTOR_H__
+#define __INCLUDE_USER_SELECTOR_H__
+
+/** \brief Selector component configuration data. */
+struct sof_sel_config {
+	/* selector supports 1 input and 1 output */
+	uint32_t in_channels_count;	/**< accepted values 2 or 4 */
+	uint32_t out_channels_count;	/**< accepted values 1 or 2 or 4 */
+	/* note: if 2 or 4 output channels selected the component works in
+	 * a passthrough mode
+	 */
+	uint32_t sel_channel;	/**< 0..3 */
+};
+
+#endif


### PR DESCRIPTION
Move selector and kpb configuration structures to /sof/src/include/uapi/user to match eq and detect dummy structures configuration;

Signed-off-by: Wojciech Wittbrodt <wojciechx.wittbrodt@linux.intel.com>