### PR TITLE
dai: supply caps and other info from within drivers

### DIFF
--- a/scripts/const_structs.checkpatch
+++ b/scripts/const_structs.checkpatch
@@ -1,4 +1,4 @@
 comp_func_map
 dma_ops
-dai_ops
+dai_driver
 freq_table

--- a/src/drivers/intel/baytrail/ssp.c
+++ b/src/drivers/intel/baytrail/ssp.c
@@ -592,10 +592,15 @@ static int ssp_probe(struct dai *dai)
 	return 0;
 }
 
-const struct dai_ops ssp_ops = {
-	.trigger		= ssp_trigger,
-	.set_config		= ssp_set_config,
-	.pm_context_store	= ssp_context_store,
-	.pm_context_restore	= ssp_context_restore,
-	.probe			= ssp_probe,
+const struct dai_driver ssp_driver = {
+	.type = SOF_DAI_INTEL_SSP,
+	.dma_caps = DMA_CAP_GP_LP | DMA_CAP_GP_HP,
+	.dma_dev = DMA_DEV_SSP,
+	.ops = {
+		.trigger		= ssp_trigger,
+		.set_config		= ssp_set_config,
+		.pm_context_store	= ssp_context_store,
+		.pm_context_restore	= ssp_context_restore,
+		.probe			= ssp_probe,
+	},
 };

--- a/src/drivers/intel/cavs/dmic.c
+++ b/src/drivers/intel/cavs/dmic.c
@@ -1579,13 +1579,18 @@ static int dmic_remove(struct dai *dai)
 	return 0;
 }
 
-const struct dai_ops dmic_ops = {
-	.trigger		= dmic_trigger,
-	.set_config		= dmic_set_config,
-	.pm_context_store	= dmic_context_store,
-	.pm_context_restore	= dmic_context_restore,
-	.probe			= dmic_probe,
-	.remove			= dmic_remove,
+const struct dai_driver dmic_driver = {
+	.type = SOF_DAI_INTEL_DMIC,
+	.dma_caps = DMA_CAP_GP_LP | DMA_CAP_GP_HP,
+	.dma_dev = DMA_DEV_DMIC,
+	.ops = {
+		.trigger		= dmic_trigger,
+		.set_config		= dmic_set_config,
+		.pm_context_store	= dmic_context_store,
+		.pm_context_restore	= dmic_context_restore,
+		.probe			= dmic_probe,
+		.remove			= dmic_remove,
+	},
 };
 
 #endif

--- a/src/drivers/intel/cavs/hda.c
+++ b/src/drivers/intel/cavs/hda.c
@@ -47,11 +47,16 @@ static int hda_dummy(struct dai *dai)
 	return 0;
 }
 
-const struct dai_ops hda_ops = {
-	.trigger		= hda_trigger,
-	.set_config		= hda_set_config,
-	.pm_context_store	= hda_dummy,
-	.pm_context_restore	= hda_dummy,
-	.probe			= hda_dummy,
-	.remove			= hda_dummy,
+const struct dai_driver hda_driver = {
+	.type = SOF_DAI_INTEL_HDA,
+	.dma_caps = DMA_CAP_HDA,
+	.dma_dev = DMA_DEV_HDA,
+	.ops = {
+		.trigger		= hda_trigger,
+		.set_config		= hda_set_config,
+		.pm_context_store	= hda_dummy,
+		.pm_context_restore	= hda_dummy,
+		.probe			= hda_dummy,
+		.remove			= hda_dummy,
+	},
 };

--- a/src/drivers/intel/cavs/soundwire.c
+++ b/src/drivers/intel/cavs/soundwire.c
@@ -89,11 +89,16 @@ static int soundwire_remove(struct dai *dai)
 	return 0;
 }
 
-const struct dai_ops soundwire_ops = {
-	.trigger		= soundwire_trigger,
-	.set_config		= soundwire_set_config,
-	.pm_context_store	= soundwire_context_store,
-	.pm_context_restore	= soundwire_context_restore,
-	.probe			= soundwire_probe,
-	.remove			= soundwire_remove,
+const struct dai_driver soundwire_driver = {
+	.type = SOF_DAI_INTEL_SOUNDWIRE,
+	.dma_caps = DMA_CAP_GP_LP | DMA_CAP_GP_HP,
+	.dma_dev = DMA_DEV_SOUNDWIRE,
+	.ops = {
+		.trigger		= soundwire_trigger,
+		.set_config		= soundwire_set_config,
+		.pm_context_store	= soundwire_context_store,
+		.pm_context_restore	= soundwire_context_restore,
+		.probe			= soundwire_probe,
+		.remove			= soundwire_remove,
+	},
 };

--- a/src/drivers/intel/cavs/ssp.c
+++ b/src/drivers/intel/cavs/ssp.c
@@ -877,11 +877,16 @@ static int ssp_remove(struct dai *dai)
 	return 0;
 }
 
-const struct dai_ops ssp_ops = {
-	.trigger		= ssp_trigger,
-	.set_config		= ssp_set_config,
-	.pm_context_store	= ssp_context_store,
-	.pm_context_restore	= ssp_context_restore,
-	.probe			= ssp_probe,
-	.remove			= ssp_remove,
+const struct dai_driver ssp_driver = {
+	.type = SOF_DAI_INTEL_SSP,
+	.dma_caps = DMA_CAP_GP_LP | DMA_CAP_GP_HP,
+	.dma_dev = DMA_DEV_SSP,
+	.ops = {
+		.trigger		= ssp_trigger,
+		.set_config		= ssp_set_config,
+		.pm_context_store	= ssp_context_store,
+		.pm_context_restore	= ssp_context_restore,
+		.probe			= ssp_probe,
+		.remove			= ssp_remove,
+	},
 };

--- a/src/drivers/intel/haswell/ssp.c
+++ b/src/drivers/intel/haswell/ssp.c
@@ -496,10 +496,15 @@ static int ssp_probe(struct dai *dai)
 	return 0;
 }
 
-const struct dai_ops ssp_ops = {
-	.trigger		= ssp_trigger,
-	.set_config		= ssp_set_config,
-	.pm_context_store	= ssp_context_store,
-	.pm_context_restore	= ssp_context_restore,
-	.probe			= ssp_probe,
+const struct dai_driver ssp_driver = {
+	.type = SOF_DAI_INTEL_SSP,
+	.dma_caps = DMA_CAP_GP_LP | DMA_CAP_GP_HP,
+	.dma_dev = DMA_DEV_SSP,
+	.ops = {
+		.trigger		= ssp_trigger,
+		.set_config		= ssp_set_config,
+		.pm_context_store	= ssp_context_store,
+		.pm_context_restore	= ssp_context_restore,
+		.probe			= ssp_probe,
+	},
 };

--- a/src/include/sof/dmic.h
+++ b/src/include/sof/dmic.h
@@ -335,7 +335,7 @@ struct dmic_pdata {
 	int32_t gain;
 };
 
-extern const struct dai_ops dmic_ops;
+extern const struct dai_driver dmic_driver;
 
 #endif /* DMIC_HW_VERSION  */
 #endif /* __INCLUDE_DMIC__ */

--- a/src/include/sof/hda.h
+++ b/src/include/sof/hda.h
@@ -33,7 +33,7 @@
 
 #include <sof/dai.h>
 
-extern const struct dai_ops hda_ops;
+extern const struct dai_driver hda_driver;
 
 #endif /* __INCLUDE_HDA__ */
 

--- a/src/include/sof/ssp.h
+++ b/src/include/sof/ssp.h
@@ -66,7 +66,7 @@
 #define SSCR5		0x78
 #endif
 
-extern const struct dai_ops ssp_ops;
+extern const struct dai_driver ssp_driver;
 
 /* SSCR0 bits */
 #define SSCR0_DSS_MASK	(0x0000000f)

--- a/src/platform/baytrail/dai.c
+++ b/src/platform/baytrail/dai.c
@@ -43,7 +43,6 @@
 
 static struct dai ssp[] = {
 {
-	.type = SOF_DAI_INTEL_SSP,
 	.index = 0,
 	.plat_data = {
 		.base		= SSP0_BASE,
@@ -57,10 +56,9 @@ static struct dai ssp[] = {
 			.handshake	= DMA_HANDSHAKE_SSP0_RX,
 		}
 	},
-	.ops		= &ssp_ops,
+	.drv		= &ssp_driver,
 },
 {
-	.type = SOF_DAI_INTEL_SSP,
 	.index = 1,
 	.plat_data = {
 		.base		= SSP1_BASE,
@@ -74,10 +72,9 @@ static struct dai ssp[] = {
 			.handshake	= DMA_HANDSHAKE_SSP1_RX,
 		}
 	},
-	.ops		= &ssp_ops,
+	.drv		= &ssp_driver,
 },
 {
-	.type = SOF_DAI_INTEL_SSP,
 	.index = 2,
 	.plat_data = {
 		.base		= SSP2_BASE,
@@ -91,11 +88,10 @@ static struct dai ssp[] = {
 			.handshake	= DMA_HANDSHAKE_SSP2_RX,
 		}
 	},
-	.ops		= &ssp_ops,
+	.drv		= &ssp_driver,
 },
 #if defined CONFIG_CHERRYTRAIL
 {
-	.type = SOF_DAI_INTEL_SSP,
 	.index = 3,
 	.plat_data = {
 		.base		= SSP3_BASE,
@@ -109,10 +105,9 @@ static struct dai ssp[] = {
 			.handshake	= DMA_HANDSHAKE_SSP3_RX,
 		}
 	},
-	.ops		= &ssp_ops,
+	.drv		= &ssp_driver,
 },
 {
-	.type = SOF_DAI_INTEL_SSP,
 	.index = 4,
 	.plat_data = {
 		.base		= SSP4_BASE,
@@ -126,10 +121,9 @@ static struct dai ssp[] = {
 			.handshake	= DMA_HANDSHAKE_SSP4_RX,
 		}
 	},
-	.ops		= &ssp_ops,
+	.drv		= &ssp_driver,
 },
 {
-	.type = SOF_DAI_INTEL_SSP,
 	.index = 5,
 	.plat_data = {
 		.base		= SSP5_BASE,
@@ -143,7 +137,7 @@ static struct dai ssp[] = {
 			.handshake	= DMA_HANDSHAKE_SSP5_RX,
 		}
 	},
-	.ops		= &ssp_ops,
+	.drv		= &ssp_driver,
 },
 #endif
 };

--- a/src/platform/haswell/dai.c
+++ b/src/platform/haswell/dai.c
@@ -43,7 +43,6 @@
 
 static struct dai ssp[2] = {
 {
-	.type = SOF_DAI_INTEL_SSP,
 	.index = 0,
 	.plat_data = {
 		.base		= SSP0_BASE,
@@ -57,10 +56,9 @@ static struct dai ssp[2] = {
 			.handshake	= DMA_HANDSHAKE_SSP0_RX,
 		}
 	},
-	.ops		= &ssp_ops,
+	.drv		= &ssp_driver,
 },
 {
-	.type = SOF_DAI_INTEL_SSP,
 	.index = 1,
 	.plat_data = {
 		.base		= SSP1_BASE,
@@ -74,7 +72,7 @@ static struct dai ssp[2] = {
 			.handshake	= DMA_HANDSHAKE_SSP1_RX,
 		}
 	},
-	.ops		= &ssp_ops,
+	.drv		= &ssp_driver,
 }};
 
 static struct dai_type_info dti[] = {

--- a/src/platform/intel/cavs/dai.c
+++ b/src/platform/intel/cavs/dai.c
@@ -62,7 +62,6 @@ static struct dai dmic[2] = {
 
 	/* Primary FIFO A */
 	{
-		.type = SOF_DAI_INTEL_DMIC,
 		.index = 0,
 		.plat_data = {
 			.base = DMIC_BASE,
@@ -76,11 +75,10 @@ static struct dai dmic[2] = {
 				.handshake = DMA_HANDSHAKE_DMIC_CH0,
 			}
 		},
-		.ops = &dmic_ops,
+		.drv = &dmic_driver,
 	},
 	/* Secondary FIFO B */
 	{
-		.type = SOF_DAI_INTEL_DMIC,
 		.index = 1,
 		.plat_data = {
 			.base = DMIC_BASE,
@@ -94,7 +92,7 @@ static struct dai dmic[2] = {
 				.handshake = DMA_HANDSHAKE_DMIC_CH1,
 			}
 		},
-		.ops = &dmic_ops,
+		.drv = &dmic_driver,
 	}
 };
 
@@ -130,9 +128,8 @@ int dai_init(void)
 #if CONFIG_CAVS_SSP
 	/* init ssp */
 	for (i = 0; i < ARRAY_SIZE(ssp); i++) {
-		ssp[i].type = SOF_DAI_INTEL_SSP;
 		ssp[i].index = i;
-		ssp[i].ops = &ssp_ops;
+		ssp[i].drv = &ssp_driver;
 		ssp[i].plat_data.base = SSP_BASE(i);
 		ssp[i].plat_data.irq = IRQ_EXT_SSPx_LVL5(i, 0);
 		ssp[i].plat_data.fifo[SOF_IPC_STREAM_PLAYBACK].offset =
@@ -149,9 +146,8 @@ int dai_init(void)
 #endif
 	/* init hd/a, note that size depends on the platform caps */
 	for (i = 0; i < ARRAY_SIZE(hda); i++) {
-		hda[i].type = SOF_DAI_INTEL_HDA;
 		hda[i].index = i;
-		hda[i].ops = &hda_ops;
+		hda[i].drv = &hda_driver;
 		spinlock_init(&hda[i].lock);
 	}
 


### PR DESCRIPTION
This change gathers some of the information inside of the DAI drivers,
which was previously inferred using external logic.

Signed-off-by: Slawomir Blauciak <slawomir.blauciak@linux.intel.com>