### PR TITLE
trace: convert trace time stamp to ticks

### DIFF
--- a/src/include/sof/clk.h
+++ b/src/include/sof/clk.h
@@ -32,6 +32,7 @@
 #define __INCLUDE_CLOCK__
 
 #include <stdint.h>
+#include <arch/timer.h>
 
 #define CLOCK_NOTIFY_PRE	0
 #define CLOCK_NOTIFY_POST	1
@@ -56,6 +57,8 @@ struct freq_table {
 void clock_set_freq(int clock, uint32_t hz);
 
 uint64_t clock_ms_to_ticks(int clock, uint64_t ms);
+
+void platform_timer_set_delta(struct timer *timer, uint64_t ns);
 
 void clock_init(void);
 

--- a/src/include/uapi/ipc/trace.h
+++ b/src/include/uapi/ipc/trace.h
@@ -61,7 +61,7 @@ struct sof_ipc_dma_trace_params_ext {
 	struct sof_ipc_cmd_hdr hdr;
 	struct sof_ipc_host_buffer buffer;
 	uint32_t stream_tag;
-	uint64_t timestamp;
+	uint64_t timestamp_ns; /* in nanosecnd */
 	uint32_t reserved[8];
 } __attribute__((packed));
 

--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -47,6 +47,7 @@
 #include <sof/alloc.h>
 #include <sof/wait.h>
 #include <sof/trace.h>
+#include <sof/clk.h>
 #include <sof/math/numbers.h>
 #include <platform/interrupt.h>
 #include <platform/mailbox.h>
@@ -726,8 +727,7 @@ static int ipc_dma_trace_config(uint32_t header)
 	IPC_COPY_CMD(params, _ipc->comp_data);
 
 	if (iCS(header) == SOF_IPC_TRACE_DMA_PARAMS_EXT)
-		platform_timer->delta = params.timestamp -
-					platform_timer_get(platform_timer);
+		platform_timer_set_delta(platform_timer, params.timestamp_ns);
 	else
 		platform_timer->delta = 0;
 

--- a/src/lib/clk.c
+++ b/src/lib/clk.c
@@ -40,6 +40,7 @@
 #include <platform/clk.h>
 #include <platform/clk-map.h>
 #include <platform/platform.h>
+#include <sof/drivers/timer.h>
 #include <config.h>
 #include <stdint.h>
 #include <limits.h>
@@ -150,6 +151,15 @@ out:
 uint64_t clock_ms_to_ticks(int clock, uint64_t ms)
 {
 	return clk_pdata->clk[clock].ticks_per_msec * ms;
+}
+
+void platform_timer_set_delta(struct timer *timer, uint64_t ns)
+{
+	uint64_t ticks;
+
+	ticks = clk_pdata->clk[PLATFORM_DEFAULT_CLOCK].ticks_per_msec /
+		1000 * ns / 1000;
+	timer->delta = ticks - platform_timer_get(timer);
 }
 
 void clock_init(void)


### PR DESCRIPTION
The unit of trace header timestamp is ticks but it is nanosecond
in trace params. So we have to convert it to ticks.

Signed-off-by: Bard Liao <yung-chuan.liao@linux.intel.com>