### PR TITLE
detect_test: fix get_drvdata() before set_drvdata() issue

### DIFF
--- a/src/audio/detect_test.c
+++ b/src/audio/detect_test.c
@@ -234,9 +234,10 @@ static struct comp_dev *test_keyword_new(struct sof_ipc_comp *comp)
 	/* using default processing function */
 	cd->detect_func = default_detect_test;
 
+	comp_set_drvdata(dev, cd);
+
 	test_keyword_set_default_config(dev);
 
-	comp_set_drvdata(dev, cd);
 	dev->state = COMP_STATE_READY;
 	return dev;
 }


### PR DESCRIPTION
We are calling comp_get_drvdata() in test_keyword_set_default_config(),
so we should move comp_set_drvdata() before that in test_keyword_new(),
to avoid getting wrong private pointer for the component.

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>