### PR TITLE
kpb: fix kpb reset issue to make the consequent iteration work

### DIFF
--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -431,11 +431,16 @@ static int kpb_reset(struct comp_dev *dev)
 
 	trace_kpb("kpb_reset()");
 
+	/* Reset state to be buffering */
+	kpb->state = KPB_STATE_BUFFERING;
 	/* Reset history buffer */
 	kpb->is_internal_buffer_full = false;
 	kpb_clear_history_buffer(kpb->history_buffer);
 	/* Reset amount of buffered data */
 	kpb->buffered_data = 0;
+
+	/* Unregister KPB for async notification */
+	notifier_unregister(&kpb->kpb_events);
 
 	return comp_set_state(dev, COMP_TRIGGER_RESET);
 }

--- a/test/cmocka/src/audio/kpb/kpb_mock.c
+++ b/test/cmocka/src/audio/kpb/kpb_mock.c
@@ -45,6 +45,10 @@ void notifier_register(struct notifier *notifier)
 {
 }
 
+void notifier_unregister(struct notifier *notifier)
+{
+}
+
 int schedule_task_init(struct task *task, uint16_t type, uint16_t priority,
 		       uint64_t (*func)(void *data), void *data, uint16_t core,
 		       uint32_t xflags)


### PR DESCRIPTION
We need reset kpb->state to KPB_STATE_BUFFERING, and unregister notifier
in .reset() as we will register it again at next .prepare(), otherwise,
the consequent record won't work.

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>