### PR TITLE
ssp: icl: enable registers for all 6 SSPs

### DIFF
--- a/src/platform/icelake/include/platform/shim.h
+++ b/src/platform/icelake/include/platform/shim.h
@@ -219,7 +219,7 @@
 
 #define DSP_INIT_IOPO	0x71A68
 #define IOPO_DMIC_FLAG		(1 << 0)
-#define IOPO_I2S_FLAG		(7 << 8)
+#define IOPO_I2S_FLAG		MASK(DAI_NUM_SSP_BASE + DAI_NUM_SSP_EXT + 7, 8)
 
 #define DSP_INIT_GENO	0x71A6C
 #define GENO_MDIVOSEL		(1 << 1)


### PR DESCRIPTION
On Icelake we have 6 SSP ports, but we only enable
registers for 3 of them. Let's enable all.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>