### PR TITLE
Volume: Use ramp tokens and define the ramp tokens in all topologies

### DIFF
--- a/src/audio/volume.h
+++ b/src/audio/volume.h
@@ -74,17 +74,17 @@
  * \brief Volume ramp update rate in microseconds.
  * Update volume gain value every 1 ms.
  */
-#define VOL_RAMP_US 1000
+#define VOL_RAMP_UPDATE_US 1000
 
 /**
- * \brief Volume linear ramp length in milliseconds.
- * Use linear ramp length of 250 ms from mute to unity gain. The linear ramp
- * step in Q1.16 to use in vol_work function  is computed from the length.
+ * \brief Macro for volume linear gain ramp step computation
+ * Volume gain ramp step as Q1.16 is computed with equation
+ * step = VOL_RAMP_STEP_CONST/ SOF_TKN_VOLUME_RAMP_STEP_MS. This
+ * macro defines as Q1.16 value the constant term
+ * (1000 / VOL_RAMP_UPDATE) for step calculation.
  */
-#define VOL_RAMP_LENGTH_MS 250
-#define VOL_RAMP_STEP Q_CONVERT_FLOAT(1.0 / 1000 * \
-				      VOL_RAMP_US / VOL_RAMP_LENGTH_MS, \
-				      VOL_QXY_Y)
+#define VOL_RAMP_STEP_CONST \
+	Q_CONVERT_FLOAT(1000.0 / VOL_RAMP_UPDATE_US, VOL_QXY_Y)
 
 /**
  * \brief Volume maximum value.
@@ -115,6 +115,7 @@ struct comp_data {
 		struct comp_buffer *source, uint32_t frames);
 	struct task volwork;	/**< volume scheduled work function */
 	struct sof_ipc_ctrl_value_chan *hvol;	/**< host volume readback */
+	int32_t ramp_increment[SOF_IPC_MAX_CHANNELS];	/**< for linear ramp */
 };
 
 /** \brief Volume processing functions map. */

--- a/src/include/sof/math/numbers.h
+++ b/src/include/sof/math/numbers.h
@@ -45,6 +45,10 @@
 	typeof(b) __b = (b);	\
 	__a < __b ? __b : __a;	\
 })
+#define ABS(a) ({		\
+	typeof(a) __a = (a);	\
+	__a < 0 ? -__a : __a;	\
+})
 
 int gcd(int a, int b); /* Calculate greatest common divisor for a and b */
 

--- a/tools/topology/m4/pga.m4
+++ b/tools/topology/m4/pga.m4
@@ -33,9 +33,10 @@ define(`W_PGA',
 `	data ['
 `		"'N_PGA($1)`_data_w"'
 `		"'N_PGA($1)`_data_str"'
+`		"'$5`"'
 `	]'
 `	mixer ['
-		$5
+		$6
 `	]'
 
 `}')

--- a/tools/topology/sof/pipe-eq-volume-playback.m4
+++ b/tools/topology/sof/pipe-eq-volume-playback.m4
@@ -29,6 +29,16 @@ C_CONTROLMIXER(Master Playback Volume, PIPELINE_ID,
 	LIST(`	', KCONTROL_CHANNEL(FL, 1, 0), KCONTROL_CHANNEL(FR, 1, 1)))
 
 
+#
+# Volume configuration
+#
+
+W_VENDORTUPLES(playback_pga_tokens, sof_volume_tokens,
+LIST(`		', `SOF_TKN_VOLUME_RAMP_STEP_TYPE	"0"'
+     `		', `SOF_TKN_VOLUME_RAMP_STEP_MS		"250"'))
+
+W_DATA(playback_pga_conf, playback_pga_tokens)
+
 # Use coefficients for flat frequency response
 include(`eq_iir_coef_flat.m4')
 
@@ -62,7 +72,7 @@ C_CONTROLBYTES(EQFIR, PIPELINE_ID,
 W_PCM_PLAYBACK(PCM_ID, Passthrough Playback, 2, 0)
 
 # "Volume" has 2 source and 2 sink periods
-W_PGA(0, PIPELINE_FORMAT, 2, 2, LIST(`		', "PIPELINE_ID Master Playback Volume"))
+W_PGA(0, PIPELINE_FORMAT, 2, 2, playback_pga_conf, LIST(`		', "PIPELINE_ID Master Playback Volume"))
 
 # "EQ 0" has 2 sink period and 2 source periods
 W_EQ_IIR(0, PIPELINE_FORMAT, 2, 2, LIST(`		', "EQIIR"))

--- a/tools/topology/sof/pipe-low-latency-capture.m4
+++ b/tools/topology/sof/pipe-low-latency-capture.m4
@@ -24,6 +24,16 @@ C_CONTROLMIXER(PCM PCM_ID Capture Volume, PIPELINE_ID,
 	LIST(`	', KCONTROL_CHANNEL(FL, 0, 0), KCONTROL_CHANNEL(FR, 0, 1)))
 
 #
+# Volume configuration
+#
+
+W_VENDORTUPLES(capture_pga_tokens, sof_volume_tokens,
+LIST(`		', `SOF_TKN_VOLUME_RAMP_STEP_TYPE	"0"'
+     `		', `SOF_TKN_VOLUME_RAMP_STEP_MS		"250"'))
+
+W_DATA(capture_pga_conf, capture_pga_tokens)
+
+#
 # Components and Buffers
 #
 
@@ -32,7 +42,7 @@ C_CONTROLMIXER(PCM PCM_ID Capture Volume, PIPELINE_ID,
 W_PCM_CAPTURE(PCM_ID, Low Latency Capture, 0, 2)
 
 # "Capture Volume" has 2 sink and source periods for host and DAI ping-pong
-W_PGA(0, PIPELINE_FORMAT, 2, 2, LIST(`		', "PIPELINE_ID PCM PCM_ID Capture Volume"))
+W_PGA(0, PIPELINE_FORMAT, 2, 2, capture_pga_conf, LIST(`		', "PIPELINE_ID PCM PCM_ID Capture Volume"))
 
 # Capture Buffers
 W_BUFFER(0, COMP_BUFFER_SIZE(2,

--- a/tools/topology/sof/pipe-low-latency-playback.m4
+++ b/tools/topology/sof/pipe-low-latency-playback.m4
@@ -49,6 +49,16 @@ C_CONTROLMIXER(Master Playback Volume, PIPELINE_ID,
 	LIST(`	', KCONTROL_CHANNEL(FL, 1, 0), KCONTROL_CHANNEL(FR, 1, 1)))
 
 #
+# Volume configuration
+#
+
+W_VENDORTUPLES(playback_pga_tokens, sof_volume_tokens,
+LIST(`		', `SOF_TKN_VOLUME_RAMP_STEP_TYPE	"0"'
+     `		', `SOF_TKN_VOLUME_RAMP_STEP_MS		"250"'))
+
+W_DATA(playback_pga_conf, playback_pga_tokens)
+
+#
 # Components and Buffers
 #
 
@@ -57,10 +67,10 @@ C_CONTROLMIXER(Master Playback Volume, PIPELINE_ID,
 W_PCM_PLAYBACK(PCM_ID, Low Latency Playback, 2, 0)
 
 # "Playback Volume" has 2 sink periods and 2 source periods for host ping-pong
-W_PGA(0, PIPELINE_FORMAT, 2, 2, LIST(`		', "PIPELINE_ID PCM PCM_ID Playback Volume"))
+W_PGA(0, PIPELINE_FORMAT, 2, 2, playback_pga_conf, LIST(`		', "PIPELINE_ID PCM PCM_ID Playback Volume"))
 
 # "Master Playback Volume" has 2 source and 2 sink periods for DAI ping-pong
-W_PGA(1, PIPELINE_FORMAT, 2, 2, LIST(`		', "PIPELINE_ID Master Playback Volume"))
+W_PGA(1, PIPELINE_FORMAT, 2, 2, playback_pga_conf, LIST(`		', "PIPELINE_ID Master Playback Volume"))
 
 # Mixer 0 has 2 sink and source periods.
 W_MIXER(0, PIPELINE_FORMAT, 2, 2)

--- a/tools/topology/sof/pipe-pcm-media.m4
+++ b/tools/topology/sof/pipe-pcm-media.m4
@@ -37,6 +37,16 @@ W_VENDORTUPLES(media_src_tokens, sof_src_tokens, LIST(`		', `SOF_TKN_SRC_RATE_OU
 W_DATA(media_src_conf, media_src_tokens)
 
 #
+# Volume Configuration
+#
+
+W_VENDORTUPLES(playback_pga_tokens, sof_volume_tokens,
+LIST(`		', `SOF_TKN_VOLUME_RAMP_STEP_TYPE	"0"'
+     `		', `SOF_TKN_VOLUME_RAMP_STEP_MS		"250"'))
+
+W_DATA(playback_pga_conf, playback_pga_tokens)
+
+#
 # Components and Buffers
 #
 
@@ -45,7 +55,7 @@ W_DATA(media_src_conf, media_src_tokens)
 W_PCM_PLAYBACK(PCM_ID, Media Playback, 2, 0)
 
 # "Playback Volume" has 2 sink period and 2 source periods for host ping-pong
-W_PGA(0, PIPELINE_FORMAT, 2, 2, LIST(`		', "PIPELINE_ID PCM PCM_ID Playback Volume"))
+W_PGA(0, PIPELINE_FORMAT, 2, 2, playback_pga_conf, LIST(`		', "PIPELINE_ID PCM PCM_ID Playback Volume"))
 
 # "SRC 0" has 2 sink and source periods.
 W_SRC(0, PIPELINE_FORMAT, 2, 2, media_src_conf)

--- a/tools/topology/sof/pipe-src-playback.m4
+++ b/tools/topology/sof/pipe-src-playback.m4
@@ -45,8 +45,19 @@ W_DATA(media_src_conf, media_src_tokens)
 # "SRC" has 3 source and 3 sink periods
 W_SRC(0, PIPELINE_FORMAT, 3, 3, media_src_conf)
 
+#
+# Volume Configuration
+#
+
+W_VENDORTUPLES(playback_pga_tokens, sof_volume_tokens,
+LIST(`		', `SOF_TKN_VOLUME_RAMP_STEP_TYPE	"0"'
+     `		', `SOF_TKN_VOLUME_RAMP_STEP_MS		"250"'))
+
+
+W_DATA(playback_pga_conf, playback_pga_tokens)
+
 # "Volume" has 2 source and 2 sink periods
-W_PGA(0, PIPELINE_FORMAT, 2, 2, LIST(`		', "PIPELINE_ID Master Playback Volume"))
+W_PGA(0, PIPELINE_FORMAT, 2, 2, playback_pga_conf, LIST(`		', "PIPELINE_ID Master Playback Volume"))
 
 # Playback Buffers
 W_BUFFER(0, COMP_BUFFER_SIZE(3,

--- a/tools/topology/sof/pipe-tone.m4
+++ b/tools/topology/sof/pipe-tone.m4
@@ -38,6 +38,16 @@ C_CONTROLMIXER(Tone Switch, PIPELINE_ID,
 	LIST(`	', KCONTROL_CHANNEL(FL, 2, 0), KCONTROL_CHANNEL(FR, 2, 1)))
 
 #
+# Volume configuration
+#
+
+W_VENDORTUPLES(playback_pga_tokens, sof_volume_tokens,
+LIST(`		', `SOF_TKN_VOLUME_RAMP_STEP_TYPE	"0"'
+     `		', `SOF_TKN_VOLUME_RAMP_STEP_MS		"250"'))
+
+W_DATA(playback_pga_conf, playback_pga_tokens)
+
+#
 # Components and Buffers
 #
 
@@ -45,7 +55,7 @@ C_CONTROLMIXER(Tone Switch, PIPELINE_ID,
 W_TONE(0, PIPELINE_FORMAT, 2, 0, LIST(`		', "PIPELINE_ID Tone Switch"))
 
 # "Tone Volume" has 2 sink period and 2 source periods
-W_PGA(0, PIPELINE_FORMAT, 2, 2, LIST(`		', "PIPELINE_ID Tone Volume"))
+W_PGA(0, PIPELINE_FORMAT, 2, 2, playback_pga_conf, LIST(`		', "PIPELINE_ID Tone Volume"))
 
 # Low Latency Buffers
 W_BUFFER(0,COMP_BUFFER_SIZE(2,

--- a/tools/topology/sof/pipe-volume-capture-16khz.m4
+++ b/tools/topology/sof/pipe-volume-capture-16khz.m4
@@ -29,6 +29,16 @@ C_CONTROLMIXER(Master Capture Volume, PIPELINE_ID,
 	LIST(`	', KCONTROL_CHANNEL(FL, 1, 0), KCONTROL_CHANNEL(FR, 1, 1)))
 
 #
+# Volume configuration
+#
+
+W_VENDORTUPLES(playback_pga_tokens, sof_volume_tokens,
+LIST(`		', `SOF_TKN_VOLUME_RAMP_STEP_TYPE	"0"'
+     `		', `SOF_TKN_VOLUME_RAMP_STEP_MS		"250"'))
+
+W_DATA(playback_pga_conf, playback_pga_tokens)
+
+#
 # Components and Buffers
 #
 
@@ -37,7 +47,7 @@ C_CONTROLMIXER(Master Capture Volume, PIPELINE_ID,
 W_PCM_CAPTURE(PCM_ID, Passthrough Capture, 0, 2)
 
 # "Volume" has 2 source and 2 sink periods
-W_PGA(0, PIPELINE_FORMAT, 2, 2, LIST(`		', "PIPELINE_ID Master Capture Volume"))
+W_PGA(0, PIPELINE_FORMAT, 2, 2, playback_pga_conf, LIST(`		', "PIPELINE_ID Master Capture Volume"))
 
 # Capture Buffers
 W_BUFFER(0, COMP_BUFFER_SIZE(2,

--- a/tools/topology/sof/pipe-volume-capture.m4
+++ b/tools/topology/sof/pipe-volume-capture.m4
@@ -26,6 +26,16 @@ C_CONTROLMIXER(Master Capture Volume, PIPELINE_ID,
 	LIST(`	', KCONTROL_CHANNEL(FL, 1, 0), KCONTROL_CHANNEL(FR, 1, 1)))
 
 #
+# Volume Configuration
+#
+
+W_VENDORTUPLES(capture_pga_tokens, sof_volume_tokens,
+LIST(`		', `SOF_TKN_VOLUME_RAMP_STEP_TYPE	"0"'
+     `		', `SOF_TKN_VOLUME_RAMP_STEP_MS		"250"'))
+
+W_DATA(capture_pga_conf, capture_pga_tokens)
+
+#
 # Components and Buffers
 #
 
@@ -34,7 +44,7 @@ C_CONTROLMIXER(Master Capture Volume, PIPELINE_ID,
 W_PCM_CAPTURE(PCM_ID, Passthrough Capture, 0, 2)
 
 # "Volume" has 2 source and 2 sink periods
-W_PGA(0, PIPELINE_FORMAT, 2, 2, LIST(`		', "PIPELINE_ID Master Capture Volume"))
+W_PGA(0, PIPELINE_FORMAT, 2, 2, capture_pga_conf, LIST(`		', "PIPELINE_ID Master Capture Volume"))
 
 # Capture Buffers
 W_BUFFER(0, COMP_BUFFER_SIZE(2,

--- a/tools/topology/sof/pipe-volume-playback.m4
+++ b/tools/topology/sof/pipe-volume-playback.m4
@@ -26,6 +26,16 @@ C_CONTROLMIXER(Master Playback Volume, PIPELINE_ID,
 	LIST(`	', KCONTROL_CHANNEL(FL, 1, 0), KCONTROL_CHANNEL(FR, 1, 1)))
 
 #
+# Volume configuration
+#
+
+W_VENDORTUPLES(playback_pga_tokens, sof_volume_tokens,
+LIST(`		', `SOF_TKN_VOLUME_RAMP_STEP_TYPE	"0"'
+     `		', `SOF_TKN_VOLUME_RAMP_STEP_MS		"250"'))
+
+W_DATA(playback_pga_conf, playback_pga_tokens)
+
+#
 # Components and Buffers
 #
 
@@ -33,8 +43,9 @@ C_CONTROLMIXER(Master Playback Volume, PIPELINE_ID,
 # with 2 sink and 0 source periods
 W_PCM_PLAYBACK(PCM_ID, Passthrough Playback, 2, 0)
 
+
 # "Volume" has 2 source and 2 sink periods
-W_PGA(0, PIPELINE_FORMAT, 2, 2, LIST(`		', "PIPELINE_ID Master Playback Volume"))
+W_PGA(0, PIPELINE_FORMAT, 2, 2, playback_pga_conf, LIST(`		', "PIPELINE_ID Master Playback Volume"))
 
 # Playback Buffers
 W_BUFFER(0, COMP_BUFFER_SIZE(2,


### PR DESCRIPTION
This PR consists of two commits. The first contains the changes for volume component. The second updates all topologies to define the volume ramp tokens. This approach does not need kernel update.

I removed the [RFC][Do not merge] labels since the code now seems to pass the CI tests.