### PR TITLE
pipeline: Limit propagation of pipeline params, prepare and reset.

### DIFF
--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -164,6 +164,13 @@
 #define tracev_comp(__e, ...)	tracev_event(TRACE_CLASS_COMP, __e, ##__VA_ARGS__)
 /** @}*/
 
+/* \brief Type of endpoint this component is connected to in a pipeline */
+enum comp_endpoint_type {
+	COMP_ENDPOINT_HOST,
+	COMP_ENDPOINT_DAI,
+	COMP_ENDPOINT_NODE
+};
+
 struct comp_dev;
 struct comp_buffer;
 struct dai_config;
@@ -682,6 +689,19 @@ static inline int comp_get_requested_state(int cmd)
 	}
 
 	return state;
+}
+
+/* \brief Returns comp_endpoint_type of given component */
+static inline int comp_get_endpoint_type(struct comp_dev *dev)
+{
+	switch (dev->comp.type) {
+	case SOF_COMP_HOST:
+		return COMP_ENDPOINT_HOST;
+	case SOF_COMP_DAI:
+		return COMP_ENDPOINT_DAI;
+	default:
+		return COMP_ENDPOINT_NODE;
+	}
 }
 
 /** @}*/


### PR DESCRIPTION
In order to handle complex topologies, we need more precise control
over connected pipelines behaviour and propagation of events.
Better control is accomplished by limiting propagation of events in
case of mismatch between starting and desination pipelines that are
connected, for example when propagating from playback pipeline to branch
which endpoint is Host component, or reversely, when propagating from
capture pipeline to one with Dai endpoint.

Signed-off-by: ArturX Kloniecki <arturx.kloniecki@linux.intel.com>

This PR was extracted from https://github.com/thesofproject/sof/pull/1275