### PR TITLE
meu: support for custom flags

### DIFF
--- a/src/arch/xtensa/CMakeLists.txt
+++ b/src/arch/xtensa/CMakeLists.txt
@@ -337,13 +337,20 @@ if(MEU_PATH)
 		set(MEU_OPENSSL "/usr/bin/openssl")
 	endif()
 
+	if(NOT DEFINED MEU_FLAGS)
+		set(MEU_FLAGS
+			-f ${MEU_PATH}/generic_meu_conf.xml
+			-mnver 0.0.0.0
+			-key ${MEU_PRIVATE_KEY}
+			-stp ${MEU_OPENSSL}
+		)
+	endif()
+
 	add_custom_target(
 		run_meu
 		COMMAND ${MEU_PATH}/meu -w ./ -s sof-${fw_name}
-			-key ${MEU_PRIVATE_KEY}
-			-stp ${MEU_OPENSSL}
-			-f ${MEU_PATH}/generic_meu_conf.xml
-			-mnver 0.0.0.0 -o sof-${fw_name}.ri
+			${MEU_FLAGS}
+			-o sof-${fw_name}.ri
 		DEPENDS run_rimage
 		VERBATIM
 		USES_TERMINAL

--- a/src/arch/xtensa/CMakeLists.txt
+++ b/src/arch/xtensa/CMakeLists.txt
@@ -343,6 +343,7 @@ if(MEU_PATH)
 			-mnver 0.0.0.0
 			-key ${MEU_PRIVATE_KEY}
 			-stp ${MEU_OPENSSL}
+			${MEU_EXTRA_FLAGS}
 		)
 	endif()
 


### PR DESCRIPTION
For #1310 
~Adds `bin_post_pv` target.~

~It's going to be used for signing post-pv firmware on some platforms.
Usage: build as usual, but use `make bin_post_pv` instead of `make bin`~

Adds support for 2 cmake variables.
`MEU_FLAGS` - overrides meu flags
`MEU_EXTRA_FLAGS` - adds additional flags after default meu flags

Sample usage:
```
# Build as usual ...
# If you want to add meu flag just:
cmake -DMEU_EXTRA_FLAGS=-mnpv\ true
make bin
```
