### PR TITLE
ipc: fill wallclock frequency and timestamp resolution in sof_ipc_stream_posn

### DIFF
--- a/src/audio/pipeline.c
+++ b/src/audio/pipeline.c
@@ -780,6 +780,9 @@ void pipeline_get_timestamp(struct pipeline *p, struct comp_dev *host,
 	data.posn = posn;
 
 	pipeline_comp_timestamp(host, &data, host->params.direction);
+
+	/* set timestamp resolution */
+	posn->timestamp_ns = p->ipc_pipe.period * 1000;
 }
 
 static int pipeline_comp_xrun(struct comp_dev *current, void *data, int dir)

--- a/src/drivers/intel/baytrail/timer.c
+++ b/src/drivers/intel/baytrail/timer.c
@@ -35,6 +35,7 @@
 #include <platform/interrupt.h>
 #include <sof/debug.h>
 #include <sof/audio/component.h>
+#include <sof/clk.h>
 #include <sof/drivers/timer.h>
 #include <stdint.h>
 
@@ -189,6 +190,7 @@ void platform_dai_timestamp(struct comp_dev *dai,
 
 	/* get SSP wallclock - DAI sets this to stream start value */
 	posn->wallclock = platform_timer_get(platform_timer) - posn->wallclock;
+	posn->wallclock_hz = clock_get_freq(PLATFORM_DEFAULT_CLOCK);
 	posn->flags |= SOF_TIME_WALL_VALID | SOF_TIME_WALL_64;
 }
 

--- a/src/drivers/intel/cavs/timer.c
+++ b/src/drivers/intel/cavs/timer.c
@@ -35,6 +35,7 @@
 #include <platform/shim.h>
 #include <sof/debug.h>
 #include <sof/audio/component.h>
+#include <sof/clk.h>
 #include <sof/drivers/timer.h>
 #include <stdint.h>
 
@@ -104,6 +105,7 @@ void platform_dai_timestamp(struct comp_dev *dai,
 
 	/* get SSP wallclock - DAI sets this to stream start value */
 	posn->wallclock = shim_read64(SHIM_DSPWC) - posn->wallclock;
+	posn->wallclock_hz = clock_get_freq(PLATFORM_DEFAULT_CLOCK);
 	posn->flags |= SOF_TIME_WALL_VALID;
 }
 

--- a/src/drivers/intel/haswell/timer.c
+++ b/src/drivers/intel/haswell/timer.c
@@ -33,6 +33,7 @@
 #include <platform/interrupt.h>
 #include <sof/debug.h>
 #include <sof/audio/component.h>
+#include <sof/clk.h>
 #include <sof/drivers/timer.h>
 #include <stdint.h>
 
@@ -86,6 +87,7 @@ void platform_dai_timestamp(struct comp_dev *dai,
 
 	/* get SSP wallclock - DAI sets this to stream start value */
 	posn->wallclock = timer_get_system(platform_timer) - posn->wallclock;
+	posn->wallclock_hz = clock_get_freq(PLATFORM_DEFAULT_CLOCK);
 	posn->flags |= SOF_TIME_WALL_VALID | SOF_TIME_WALL_64;
 }
 

--- a/src/include/sof/clk.h
+++ b/src/include/sof/clk.h
@@ -53,6 +53,8 @@ struct freq_table {
 	uint32_t enc;
 };
 
+uint32_t clock_get_freq(int clock);
+
 void clock_set_freq(int clock, uint32_t hz);
 
 uint64_t clock_ms_to_ticks(int clock, uint64_t ms);

--- a/src/lib/clk.c
+++ b/src/lib/clk.c
@@ -68,14 +68,14 @@ struct clk_pdata {
 
 static struct clk_pdata *clk_pdata;
 
-static inline uint32_t clock_get_freq(const struct freq_table *table,
-				      uint32_t size, uint32_t hz)
+static inline uint32_t clock_get_nearest_freq_idx(const struct freq_table *tab,
+						  uint32_t size, uint32_t hz)
 {
 	uint32_t i;
 
 	/* find lowest available frequency that is >= requested hz */
 	for (i = 0; i < size; i++) {
-		if (hz <= table[i].freq)
+		if (hz <= tab[i].freq)
 			return i;
 	}
 
@@ -125,7 +125,7 @@ void clock_set_freq(int clock, uint32_t hz)
 	}
 
 	/* get nearest frequency that is >= requested Hz */
-	idx = clock_get_freq(freq_table, freq_table_size, hz);
+	idx = clock_get_nearest_freq_idx(freq_table, freq_table_size, hz);
 	clk_notify_data.freq = freq_table[idx].freq;
 
 	/* tell anyone interested we are about to change freq */

--- a/src/lib/clk.c
+++ b/src/lib/clk.c
@@ -83,6 +83,11 @@ static inline uint32_t clock_get_nearest_freq_idx(const struct freq_table *tab,
 	return size - 1;
 }
 
+uint32_t clock_get_freq(int clock)
+{
+	return clk_pdata->clk[clock].freq;
+}
+
 void clock_set_freq(int clock, uint32_t hz)
 {
 	struct notify_data notify_data;


### PR DESCRIPTION
This set of patches adds missing values in sof_ipc_stream_posn notification.
These values are probably not used, but since they are already in the structure and since ABI changes are expensive, let use them properly.