### PR TITLE
[RFC] [proposal] alloc: treat memory caps separately

### DIFF
--- a/src/lib/alloc.c
+++ b/src/lib/alloc.c
@@ -324,13 +324,11 @@ static struct mm_heap *get_heap_from_ptr(void *ptr)
 static struct mm_heap *get_heap_from_caps(struct mm_heap *heap, int count,
 					  uint32_t caps)
 {
-	uint32_t mask;
 	int i;
 
 	/* find first heap that support type */
 	for (i = 0; i < count; i++) {
-		mask = heap[i].caps & caps;
-		if (mask == caps)
+		if (heap[i].caps & caps)
 			return &heap[i];
 	}
 

--- a/src/lib/alloc.c
+++ b/src/lib/alloc.c
@@ -645,8 +645,8 @@ static void *alloc_heap_buffer(struct mm_heap *heap, int zone, uint32_t caps,
 		for (i = heap->blocks - 1; i >= 0; i--) {
 			map = &heap->map[i];
 
-			/* allocate if block size is smaller than request */
-			if (heap->size >= bytes && map->block_size < bytes) {
+			/* does whole heap have enough space? */
+			if (heap->size >= bytes) {
 				ptr = alloc_cont_blocks(heap, i, caps, bytes);
 				if (ptr)
 					break;


### PR DESCRIPTION
Current implementation accept allocation for specific
memory region only if all CAPS supported by that region
match requested CAPS. This is wrong we should accept
request if at least one CAP match request.
    
Signed-off-by: Marcin Rajwa <marcin.rajwa@linux.intel.com>