### PR TITLE
[DO NOT MERGE][WIP] hda-dma: increase PLATFORM_HOST_DMA_TIMEOUT

### DIFF
--- a/src/platform/apollolake/include/platform/platform.h
+++ b/src/platform/apollolake/include/platform/platform.h
@@ -104,7 +104,7 @@ struct sof;
 #define PLATFORM_DMA_TIMEOUT	1333
 
 /* DMA host transfer timeouts in microseconds */
-#define PLATFORM_HOST_DMA_TIMEOUT	200
+#define PLATFORM_HOST_DMA_TIMEOUT	250
 
 /* DMA link transfer timeouts in microseconds
  * TODO: timeout should be reduced

--- a/src/platform/baytrail/include/platform/platform.h
+++ b/src/platform/baytrail/include/platform/platform.h
@@ -99,7 +99,7 @@ struct sof;
 #define PLATFORM_DMA_TIMEOUT	1333
 
 /* DMA host transfer timeouts in microseconds */
-#define PLATFORM_HOST_DMA_TIMEOUT	200
+#define PLATFORM_HOST_DMA_TIMEOUT	250
 
 /* DMA link transfer timeouts in microseconds
  * TODO: timeout should be reduced

--- a/src/platform/cannonlake/include/platform/platform.h
+++ b/src/platform/cannonlake/include/platform/platform.h
@@ -114,7 +114,7 @@ struct sof;
 #define PLATFORM_DMA_TIMEOUT	1333
 
 /* DMA host transfer timeouts in microseconds */
-#define PLATFORM_HOST_DMA_TIMEOUT	200
+#define PLATFORM_HOST_DMA_TIMEOUT	250
 
 /* DMA link transfer timeouts in microseconds
  * TODO: timeout should be reduced

--- a/src/platform/haswell/include/platform/platform.h
+++ b/src/platform/haswell/include/platform/platform.h
@@ -97,7 +97,7 @@ struct sof;
 #define PLATFORM_DMA_TIMEOUT	1333
 
 /* DMA host transfer timeouts in microseconds */
-#define PLATFORM_HOST_DMA_TIMEOUT	200
+#define PLATFORM_HOST_DMA_TIMEOUT	250
 
 /* DMA link transfer timeouts in microseconds
  * TODO: timeout should be reduced

--- a/src/platform/icelake/include/platform/platform.h
+++ b/src/platform/icelake/include/platform/platform.h
@@ -114,7 +114,7 @@ struct sof;
 #define PLATFORM_DMA_TIMEOUT	1333
 
 /* DMA host transfer timeouts in microseconds */
-#define PLATFORM_HOST_DMA_TIMEOUT	200
+#define PLATFORM_HOST_DMA_TIMEOUT	250
 
 /* DMA link transfer timeouts in microseconds
  * TODO: timeout should be reduced

--- a/src/platform/suecreek/include/platform/platform.h
+++ b/src/platform/suecreek/include/platform/platform.h
@@ -114,7 +114,7 @@ struct sof;
 #define PLATFORM_DMA_TIMEOUT	1333
 
 /* DMA host transfer timeouts in microseconds */
-#define PLATFORM_HOST_DMA_TIMEOUT	200
+#define PLATFORM_HOST_DMA_TIMEOUT	250
 
 /* DMA link transfer timeouts in microseconds
  * TODO: timeout should be reduced


### PR DESCRIPTION
Increasing PLATFORM_HOST_DMA_TIMEOUT define is required,
because on some boards preload process slightly exceeding
previous value.

Signed-off-by: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>