### PR TITLE
xtensa: add support for coprocessors store and restore

### DIFF
--- a/src/arch/xtensa/include/arch/string.h
+++ b/src/arch/xtensa/include/arch/string.h
@@ -55,8 +55,11 @@ int memset_s(void *dest, size_t dest_size,
 	     int data, size_t count);
 int memcpy_s(void *dest, size_t dest_size,
 	     const void *src, size_t src_size);
+
+#if __XCC__ && !CONFIG_LIBRARY
 void *__vec_memcpy(void *dst, const void *src, size_t len);
 void *__vec_memset(void *dest, int data, size_t src_size);
+#endif
 
 static inline int arch_memcpy_s(void *dest, size_t dest_size,
 				const void *src, size_t src_size)
@@ -71,13 +74,11 @@ static inline int arch_memcpy_s(void *dest, size_t dest_size,
 	if (src_size > dest_size)
 		return -EINVAL;
 
-	/* can't be use until full context switch will be supported */
-/* #if __XCC__ && !CONFIG_LIBRARY
- *	__vec_memcpy(dest, src, src_size);
- * #else
- */
+#if __XCC__ && !CONFIG_LIBRARY
+	__vec_memcpy(dest, src, src_size);
+#else
 	memcpy(dest, src, src_size);
-/* #endif */
+#endif
 
 	return 0;
 }

--- a/src/arch/xtensa/include/xtensa/xtruntime-frames.h
+++ b/src/arch/xtensa/include/xtensa/xtruntime-frames.h
@@ -44,6 +44,11 @@
 #define STRUCT_END(sname)	} sname;
 #endif /*_ASMLANGUAGE||__ASSEMBLER__*/
 
+/* Coprocessors masks.
+ * NOTE: currently only 2 supported.
+ */
+#define CP0_MASK	(1 << 0)
+#define CP1_MASK	(1 << 1)
 
 /*
  *  Kernel vector mode exception stack frame.
@@ -99,8 +104,8 @@ STRUCT_FIELD (long,4,UEXC_,a11)
 STRUCT_FIELD (long,4,UEXC_,a12)
 STRUCT_FIELD (long,4,UEXC_,a13)
 STRUCT_FIELD (long,4,UEXC_,a14)
-STRUCT_FIELD (long,4,UEXC_,a15)
 #endif
+STRUCT_FIELD (long,4,UEXC_,a15)
 STRUCT_FIELD (long,4,UEXC_,exccause)	/* NOTE: can probably rid of this one (pass direct) */
 #if XCHAL_HAVE_LOOPS
 STRUCT_FIELD (long,4,UEXC_,lcount)
@@ -112,13 +117,25 @@ STRUCT_FIELD (long,4,UEXC_,acclo)
 STRUCT_FIELD (long,4,UEXC_,acchi)
 STRUCT_AFIELD(long,4,UEXC_,mr, 4)
 #endif
+#if (XCHAL_CP_MASK & CP0_MASK)
+#define HAVE_CP0	1
+STRUCT_AFIELD_A(long,4,XCHAL_CP0_SA_ALIGN,UEXC_,cp0, XCHAL_CP0_SA_SIZE / 4)
+#else
+#define HAVE_CP0	0
+#endif
+#if (XCHAL_CP_MASK & CP1_MASK)
+#define HAVE_CP1	1
+STRUCT_AFIELD_A(long,4,XCHAL_CP1_SA_ALIGN,UEXC_,cp1, XCHAL_CP1_SA_SIZE / 4)
+#else
+#define HAVE_CP1	0
+#endif
 /* ALIGNPAD is the 16-byte alignment padding. */
 #ifdef __XTENSA_CALL0_ABI__
 # define CALL0_ABI	1
 #else
 # define CALL0_ABI	0
 #endif
-#define ALIGNPAD  ((3 + XCHAL_HAVE_LOOPS*1 + XCHAL_HAVE_MAC16*2 + CALL0_ABI*1) & 3)
+#define ALIGNPAD  ((2 + XCHAL_HAVE_LOOPS*1 + XCHAL_HAVE_MAC16*2 + HAVE_CP0*2 + HAVE_CP1*1 + CALL0_ABI*2) & 3)
 #if ALIGNPAD
 STRUCT_AFIELD(long,4,UEXC_,pad, ALIGNPAD)	/* 16-byte alignment padding */
 #endif

--- a/src/arch/xtensa/smp/xtos/int-medpri-dispatcher.S
+++ b/src/arch/xtensa/smp/xtos/int-medpri-dispatcher.S
@@ -73,6 +73,8 @@ LABEL(_Level,FromVector):
 	movi	a2, PS_WOECALL4_ABI|PS_UM|PS_INTLEVEL(XCHAL_EXCM_LEVEL)
 	s32i	a4, a1, UEXC_a4
 	s32i	a5, a1, UEXC_a5
+/* Save also a15 (becomes a11 after _entry) to store coprocessors. */
+	s32i	a15, a1, UEXC_a15
 	wsr.ps	a2
 	rsync
 
@@ -88,7 +90,6 @@ LABEL(_Level,FromVector):
 	s32i	a12, a1, UEXC_a12
 	s32i	a13, a1, UEXC_a13
 	s32i	a14, a1, UEXC_a14
-	s32i	a15, a1, UEXC_a15
 	movi	a0, 0			/* terminate stack frames */
 #  if XTOS_DEBUG_PC
 	// TODO: setup return PC for call traceback through interrupt dispatch
@@ -117,8 +118,21 @@ LABEL(_Level,FromVector):
 
 #if SINGLE_INTERRUPT  /* if only one interrupt at this priority level... */
 
-/* Preserve the SAR, loop, and MAC16 regs.  Also, clear the interrupt. */
+/* Preserve the SAR, loop, MAC16 regs and coprocessors.  Also, clear the interrupt. */
 
+/* TODO: remove this constraint after GCC toolchain update */
+#if __XCC__
+#if (XCHAL_CP_MASK & CP0_MASK)
+	mov	a11, a1
+	addi	a11, a11, UEXC_cp0
+	xchal_cp0_store	a11, a12, a13, a14, a15
+#endif
+#if (XCHAL_CP_MASK & CP1_MASK)
+	mov	a11, a1
+	addi	a11, a11, UEXC_cp1
+	xchal_cp1_store a11, a12, a13, a14, a15
+#endif
+#endif
 	rsr.sar	a14
 	movi	a12, INTERRUPT_MASK
 	s32i	a14, a1, UEXC_sar
@@ -147,8 +161,21 @@ LABEL(_Level,FromVector):
  * If bit list is empty, interrupt is spurious (can happen if a
  * genuine interrupt brings control this direction, but the interrupt
  * goes away before we read the INTERRUPT register).  Also save off
- * sar, loops, and mac16 registers. */
+ * sar, loops, mac16 registers and coprocessors. */
 
+ /* TODO: remove this constraint after GCC toolchain update */
+#if __XCC__
+#if (XCHAL_CP_MASK & CP0_MASK)
+	mov	a11, a1
+	addi	a11, a11, UEXC_cp0
+	xchal_cp0_store	a11, a12, a13, a14, a15
+#endif
+#if (XCHAL_CP_MASK & CP1_MASK)
+	mov	a11, a1
+	addi	a11, a11, UEXC_cp1
+	xchal_cp1_store a11, a12, a13, a14, a15
+#endif
+#endif
 	rsr.interrupt	a15
 	rsr.intenable	a12
 	movi	a13, INTERRUPT_MASK
@@ -190,6 +217,19 @@ LABEL(.L1,_loop0):
 
 /* Restore everything, and return. */
 
+/* TODO: remove this constraint after GCC toolchain update */
+#if __XCC__
+#if (XCHAL_CP_MASK & CP0_MASK)
+	mov	a11, a1
+	addi	a11, a11, UEXC_cp0
+	xchal_cp0_load	a11, a12, a13, a14, a15
+#endif
+#if (XCHAL_CP_MASK & CP1_MASK)
+	mov	a11, a1
+	addi	a11, a11, UEXC_cp1
+	xchal_cp1_load	a11, a12, a13, a14, a15
+#endif
+#endif
 	restore_loops_mac16	a1, a13, a14, a15
 	l32i	a14, a1, UEXC_sar
 LABEL(spurious,int):
@@ -241,6 +281,7 @@ LABEL(return,from_exc):
 # endif
 	l32i	a2, a5, UEXC_a2
 	l32i	a4, a5, UEXC_a4
+	l32i	a15, a5, UEXC_a15
 	l32i	a5, a5, UEXC_a5
 	rfi	_INTERRUPT_LEVEL
 #endif /* windowed ABI */

--- a/src/arch/xtensa/up/xtos/int-medpri-dispatcher.S
+++ b/src/arch/xtensa/up/xtos/int-medpri-dispatcher.S
@@ -77,6 +77,8 @@ LABEL(_Level,FromVector):
 #endif
 	s32i	a4, a1, UEXC_a4
 	s32i	a5, a1, UEXC_a5
+/* Save also a15 (becomes a11 after _entry) to store coprocessors. */
+	s32i	a15, a1, UEXC_a15
 	wsr	a2, PS
 	rsync
 
@@ -92,7 +94,6 @@ LABEL(_Level,FromVector):
 	s32i	a12, a1, UEXC_a12
 	s32i	a13, a1, UEXC_a13
 	s32i	a14, a1, UEXC_a14
-	s32i	a15, a1, UEXC_a15
 	movi	a0, 0			/* terminate stack frames */
 #  if XTOS_DEBUG_PC
 	// TODO: setup return PC for call traceback through interrupt dispatch
@@ -121,8 +122,21 @@ LABEL(_Level,FromVector):
 
 #if SINGLE_INTERRUPT  /* if only one interrupt at this priority level... */
 
-/* Preserve the SAR, loop, and MAC16 regs.  Also, clear the interrupt. */
+/* Preserve the SAR, loop, MAC16 regs and coprocessors.  Also, clear the interrupt. */
 
+/* TODO: remove this constraint after GCC toolchain update */
+#if __XCC__
+#if (XCHAL_CP_MASK & CP0_MASK)
+	mov	a11, a1
+	addi	a11, a11, UEXC_cp0
+	xchal_cp0_store	a11, a12, a13, a14, a15
+#endif
+#if (XCHAL_CP_MASK & CP1_MASK)
+	mov	a11, a1
+	addi	a11, a11, UEXC_cp1
+	xchal_cp1_store a11, a12, a13, a14, a15
+#endif
+#endif
 	rsr	a14, SAR
 	movi	a12, INTERRUPT_MASK
 	s32i	a14, a1, UEXC_sar
@@ -151,8 +165,21 @@ LABEL(_Level,FromVector):
  * If bit list is empty, interrupt is spurious (can happen if a
  * genuine interrupt brings control this direction, but the interrupt
  * goes away before we read the INTERRUPT register).  Also save off
- * sar, loops, and mac16 registers. */
+ * sar, loops, mac16 registers and coprocessors. */
 
+ /* TODO: remove this constraint after GCC toolchain update */
+#if __XCC__
+#if (XCHAL_CP_MASK & CP0_MASK)
+	mov	a11, a1
+	addi	a11, a11, UEXC_cp0
+	xchal_cp0_store	a11, a12, a13, a14, a15
+#endif
+#if (XCHAL_CP_MASK & CP1_MASK)
+	mov	a11, a1
+	addi	a11, a11, UEXC_cp1
+	xchal_cp1_store a11, a12, a13, a14, a15
+#endif
+#endif
 	rsr	a15, INTERRUPT
 	rsr	a12, INTENABLE
 	movi	a13, INTERRUPT_MASK
@@ -194,6 +221,19 @@ LABEL(.L1,_loop0):
 
 /* Restore everything, and return. */
 
+/* TODO: remove this constraint after GCC toolchain update */
+#if __XCC__
+#if (XCHAL_CP_MASK & CP0_MASK)
+	mov	a11, a1
+	addi	a11, a11, UEXC_cp0
+	xchal_cp0_load	a11, a12, a13, a14, a15
+#endif
+#if (XCHAL_CP_MASK & CP1_MASK)
+	mov	a11, a1
+	addi	a11, a11, UEXC_cp1
+	xchal_cp1_load	a11, a12, a13, a14, a15
+#endif
+#endif
 	restore_loops_mac16	a1, a13, a14, a15
 	l32i	a14, a1, UEXC_sar
 LABEL(spurious,int):
@@ -239,6 +279,7 @@ LABEL(return,from_exc):
 # endif
 	l32i	a2, a5, UEXC_a2
 	l32i	a4, a5, UEXC_a4
+	l32i	a15, a5, UEXC_a15
 	l32i	a5, a5, UEXC_a5
 	rfi	_INTERRUPT_LEVEL
 #endif /* windowed ABI */


### PR DESCRIPTION
Adds support for coprocessors store and restore on context
switch during interrupt handling. This way we can support
preemption of methods, which use coprocessors. Currently
implementation is limited to 2 coprocessors.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>