### PR TITLE
uapi: topology: align with kernel SOF_PROCESS_TYPE definitions

### DIFF
--- a/src/include/uapi/ipc/topology.h
+++ b/src/include/uapi/ipc/topology.h
@@ -197,6 +197,16 @@ struct sof_ipc_comp_tone {
 	int32_t ramp_step;
 } __attribute__((packed));
 
+/** \brief Types of processing components */
+enum sof_ipc_process_type {
+	SOF_PROCESS_NONE = 0,		/**< None */
+	SOF_PROCESS_EQFIR,		/**< Intel FIR */
+	SOF_PROCESS_EQIIR,		/**< Intel IIR */
+	SOF_PROCESS_KEYWORD_DETECT,	/**< Keyword Detection */
+	SOF_PROCESS_KPB,		/**< KeyPhrase Buffer Manager */
+	SOF_PROCESS_CHAN_SELECTOR,	/**< Channel Selector */
+};
+
 /* generic "effect", "codec" or proprietary processing component */
 struct sof_ipc_comp_process {
 	struct sof_ipc_comp comp;


### PR DESCRIPTION
Firmware is missing totally the SOF_PROCESS_TYPE definitions. Firmware
is not using these for anything, but they should be aligned at least
for reminding that you need to check kernel parsing when adding new
types in topology.

Signed-off-by: Jaska Uimonen <jaska.uimonen@intel.com>