### PR TITLE
uapi: replace sof_man_get_module with SOF_MAN_MODULE_OFFSET

### DIFF
--- a/rimage/manifest.c
+++ b/rimage/manifest.c
@@ -641,7 +641,7 @@ static int man_create_modules(struct image *image, struct sof_man_fw_desc *desc,
 
 	/* if first module is executable then write before manifest */
 	if (image->adsp->exec_boot_ldr) {
-		man_module = sof_man_get_module(desc, 0);
+		man_module = (void *)desc + SOF_MAN_MODULE_OFFSET(0);
 		module = &image->module[0];
 
 		fprintf(stdout, "Module: %s used as executable header\n",
@@ -661,7 +661,7 @@ static int man_create_modules(struct image *image, struct sof_man_fw_desc *desc,
 	}
 
 	for (; i < image->num_modules; i++) {
-		man_module = sof_man_get_module(desc, i - offset);
+		man_module = (void *)desc + SOF_MAN_MODULE_OFFSET(i - offset);
 		module = &image->module[i];
 
 		if (i == 0)
@@ -688,7 +688,7 @@ static int man_hash_modules(struct image *image, struct sof_man_fw_desc *desc)
 	int i;
 
 	for (i = 0; i < image->num_modules; i++) {
-		man_module = sof_man_get_module(desc, i);
+		man_module = (void *)desc + SOF_MAN_MODULE_OFFSET(i);
 
 		if (image->adsp->exec_boot_ldr && i == 0) {
 			fprintf(stdout, " module: no need to hash %s\n as its exec header\n",

--- a/src/arch/xtensa/boot_loader.c
+++ b/src/arch/xtensa/boot_loader.c
@@ -127,7 +127,7 @@ static void parse_manifest(void)
 	for (i = MAN_SKIP_ENTRIES; i < hdr->num_module_entries; i++) {
 
 		platform_trace_point(TRACE_BOOT_LDR_PARSE_MODULE + i);
-		mod = sof_man_get_module(desc, i);
+		mod = (void *)desc + SOF_MAN_MODULE_OFFSET(i);
 		parse_module(hdr, mod);
 	}
 }

--- a/src/include/uapi/user/manifest.h
+++ b/src/include/uapi/user/manifest.h
@@ -215,19 +215,11 @@ struct sof_man_module_manifest {
 	uint32_t text_size;
 };
 
-/**
- * \brief Utility to get module pointer from position.
- * \param [in,out] desc FW descriptor in manifest.
- * \param [in] index Index of the module.
- * \return Pointer to module descriptor.
- *
- * Note that index is not verified against OOB.
+/*
+ * Module offset in manifest.
  */
-static inline struct sof_man_module *sof_man_get_module(
-	struct sof_man_fw_desc *desc, int index)
-{
-	return (void *)desc + sizeof(struct sof_man_fw_header) +
-			index * sizeof(struct sof_man_module);
-}
+#define SOF_MAN_MODULE_OFFSET(index) \
+	(sizeof(struct sof_man_fw_header) + \
+		(index) * sizeof(struct sof_man_module))
 
 #endif


### PR DESCRIPTION
Fix #1377 

There should be no logic in uapi headers.
Also there is no good place for headers shared only by rimage and FW,
so it has to be duplicated for now.

Signed-off-by: Janusz Jankowski <janusz.jankowski@linux.intel.com>