### PR TITLE
SRC testbench updates

### DIFF
--- a/src/include/sof/trace.h
+++ b/src/include/sof/trace.h
@@ -126,6 +126,7 @@ do {									\
 		char *msg = "%s " format;				\
 		fprintf(stderr, msg, get_trace_class(comp_class),	\
 			##__VA_ARGS__);					\
+		fprintf(stderr, "\n");					\
 	}								\
 } while (0)
 #endif

--- a/tools/test/audio/src_run.sh
+++ b/tools/test/audio/src_run.sh
@@ -10,7 +10,7 @@ FN_IN=$5
 FN_OUT=$6
 
 # The HOST_ROOT path need to be retrived from SOFT .configure command
-HOST_ROOT=../../../build_host/install/
+HOST_ROOT=../../../tools/testbench/build_testbench/install
 HOST_EXE=$HOST_ROOT/bin/testbench
 HOST_LIB=$HOST_ROOT/lib
 
@@ -18,13 +18,14 @@ HOST_LIB=$HOST_ROOT/lib
 INFMT=s${BITS_IN}le
 OUTFMT=s${BITS_IN}le
 MCLK=24576k
-tplg1=../../build_tools/test/topology/test-playback-ssp2-mclk-0-I2S-
+tplg1=../../test/topology/test-playback-ssp2-mclk-0-I2S-
 tplg2=${COMP}-${INFMT}-${OUTFMT}-48k-${MCLK}-nocodec.tplg
 TPLG=${tplg1}${tplg2}
 
 # Alternatively use platform specific topologies
-# though currently test fails with this.
-#TPLG=../../topology/sof-apl-src-pcm512x.tplg
+# though currently test works only with s24 data due
+# to not fully set volume component in the pipeline.
+#TPLG=../../build_tools/topology/sof-apl-src-pcm512x.tplg
 
 # If binary test vectors
 if [ ${FN_IN: -4} == ".raw" ]; then

--- a/tools/test/audio/test_utils/chirp_test_analyze.m
+++ b/tools/test/audio/test_utils/chirp_test_analyze.m
@@ -53,7 +53,7 @@ tz = sz(1)/test.fs;
 et = abs(test.cl-tz)/test.cl;
 rms_db = 10*log10(mean(z.^2)) + 20*log10(sqrt(2));
 offs_db = 20*log10(abs(mean(z)));
-sum_max_db = 20*log10(max(abs(s)));
+sum_rms_db = 10*log10(mean(s.^2))
 % Check for proper ratio of out/in samples, minimum level, maximum offset
 % and maximum of sum of channels. The input is such that the channels should
 % sum to zero. A phase difference in channels would cause non-zero output
@@ -68,7 +68,7 @@ else if (min(rms_db) < -3) && (test.fs2 + 1 > test.fs1)
      else if max(offs_db) > -40
 		  fail = 1;
 		  fprintf('Failed output chirp DC offset.\n');
-	  else if (sum_max_db > -100) && (mod(test.nch, 2) == 0)
+	  else if (sum_rms_db > -80) && (mod(test.nch, 2) == 0)
 		       fail = 1;
 		       fprintf('Failed output chirp channels phase.\n');
 	       else

--- a/tools/testbench/file.c
+++ b/tools/testbench/file.c
@@ -586,6 +586,8 @@ static int file_copy(struct comp_dev *dev)
 	struct comp_buffer *buffer;
 	struct file_comp_data *cd = comp_get_drvdata(dev);
 	int ret = 0, bytes;
+	int snk_frames;
+	int src_frames;
 
 	switch (cd->fs.mode) {
 	case FILE_READ:
@@ -594,9 +596,10 @@ static int file_copy(struct comp_dev *dev)
 					 source_list);
 
 		/* test sink has enough free frames */
-		if (buffer->free >= cd->period_bytes && !cd->fs.reached_eof) {
+		snk_frames = buffer->free / comp_frame_bytes(buffer->sink);
+		if (snk_frames > 0 && !cd->fs.reached_eof) {
 			/* read PCM samples from file */
-			ret = cd->file_func(dev, buffer, NULL, dev->frames);
+			ret = cd->file_func(dev, buffer, NULL, snk_frames);
 
 			/* update sink buffer pointers */
 			bytes = dev->params.sample_container_bytes;
@@ -611,9 +614,10 @@ static int file_copy(struct comp_dev *dev)
 					 struct comp_buffer, sink_list);
 
 		/* test source has enough free frames */
-		if (buffer->avail >= cd->period_bytes) {
+		src_frames = buffer->avail / comp_frame_bytes(buffer->source);
+		if (src_frames > 0) {
 			/* write PCM samples into file */
-			ret = cd->file_func(dev, NULL, buffer, dev->frames);
+			ret = cd->file_func(dev, NULL, buffer, src_frames);
 
 			/* update source buffer pointers */
 			bytes = dev->params.sample_container_bytes;

--- a/tools/topology/sof-apl-src-pcm512x.m4
+++ b/tools/topology/sof-apl-src-pcm512x.m4
@@ -32,7 +32,7 @@ dnl     frames, deadline, priority, core)
 
 # Playback pipeline 1 on PCM 0 using max 2 channels of s24le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_ADD(sof/pipe-src-playback.m4,
+PIPELINE_PCM_ADD(sof/pipe-src-volume-playback.m4,
 	1, 0, 2, s24le,
 	48, 1000, 0, 0)
 

--- a/tools/topology/sof-cml-rt5682-max98357a.m4
+++ b/tools/topology/sof-cml-rt5682-max98357a.m4
@@ -21,7 +21,7 @@ dnl     frames, deadline, priority, core)
 
 # Low Latency playback pipeline 7 on PCM 5 using max 2 channels of s32le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_ADD(sof/pipe-src-playback.m4,
+PIPELINE_PCM_ADD(sof/pipe-src-volume-playback.m4,
 	7, 5, 2, s32le,
 	48, 1000, 0, 0)
 

--- a/tools/topology/sof-cml-src-rt5682.m4
+++ b/tools/topology/sof-cml-src-rt5682.m4
@@ -37,7 +37,7 @@ dnl     frames, deadline, priority, core)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s24le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_ADD(sof/pipe-src-playback.m4,
+PIPELINE_PCM_ADD(sof/pipe-src-volume-playback.m4,
 	1, 0, 2, s24le,
 	48, 1000, 0, 0)
 

--- a/tools/topology/sof/pipe-src-playback.m4
+++ b/tools/topology/sof/pipe-src-playback.m4
@@ -2,29 +2,19 @@
 #
 # Pipeline Endpoints for connection are :-
 #
-#  host PCM_P --> SRC --> sink DAI0
+#  host PCM_P --> B0 --> SRC --> B1 --> sink DAI0
 
 # Include topology builder
 include(`utils.m4')
-include(`src.m4')
 include(`buffer.m4')
 include(`pcm.m4')
-include(`pga.m4')
+include(`src.m4')
 include(`dai.m4')
-include(`mixercontrol.m4')
 include(`pipeline.m4')
 
 #
 # Controls
 #
-# Volume Mixer control with max value of 32
-C_CONTROLMIXER(Master Playback Volume, PIPELINE_ID,
-	CONTROLMIXER_OPS(volsw, 256 binds the mixer control to volume get/put handlers, 256, 256),
-	CONTROLMIXER_MAX(, 32),
-	false,
-	CONTROLMIXER_TLV(TLV 32 steps from -64dB to 0dB for 2dB, vtlv_m64s2),
-	Channel register and shift for Front Left/Right,
-	LIST(`	', KCONTROL_CHANNEL(FL, 1, 0), KCONTROL_CHANNEL(FR, 1, 1)))
 
 #
 # Components and Buffers
@@ -45,48 +35,29 @@ W_DATA(media_src_conf, media_src_tokens)
 # "SRC" has 3 source and 3 sink periods
 W_SRC(0, PIPELINE_FORMAT, 3, 3, media_src_conf)
 
-#
-# Volume Configuration
-#
-
-W_VENDORTUPLES(playback_pga_tokens, sof_volume_tokens,
-LIST(`		', `SOF_TKN_VOLUME_RAMP_STEP_TYPE	"0"'
-     `		', `SOF_TKN_VOLUME_RAMP_STEP_MS		"250"'))
-
-
-W_DATA(playback_pga_conf, playback_pga_tokens)
-
-# "Volume" has 2 source and 2 sink periods
-W_PGA(0, PIPELINE_FORMAT, 2, 2, playback_pga_conf, LIST(`		', "PIPELINE_ID Master Playback Volume"))
-
 # Playback Buffers
 W_BUFFER(0, COMP_BUFFER_SIZE(3,
 	COMP_SAMPLE_SIZE(PIPELINE_FORMAT), PIPELINE_CHANNELS, SCHEDULE_FRAMES),
 	PLATFORM_HOST_MEM_CAP)
 W_BUFFER(1, COMP_BUFFER_SIZE(3,
-	COMP_SAMPLE_SIZE(PIPELINE_FORMAT), PIPELINE_CHANNELS, SCHEDULE_FRAMES),
-	PLATFORM_HOST_MEM_CAP)
-W_BUFFER(2, COMP_BUFFER_SIZE(2,
-	COMP_SAMPLE_SIZE(PIPELINE_FORMAT), PIPELINE_CHANNELS, SCHEDULE_FRAMES),
+	COMP_SAMPLE_SIZE(DAI_FORMAT), PIPELINE_CHANNELS, SCHEDULE_FRAMES),
 	PLATFORM_DAI_MEM_CAP)
 
 #
 # Pipeline Graph
 #
-#  host PCM_P --> B0 --> SRC 0 --> B1 Volume 0 --> B2 --> sink DAI0
+#  host PCM_P --> B0 --> SRC 0 --> B1 --> sink DAI0
 
 P_GRAPH(pipe-pass-src-playback-PIPELINE_ID, PIPELINE_ID,
 	LIST(`		',
 	`dapm(N_BUFFER(0), N_PCMP(PCM_ID))',
 	`dapm(N_SRC(0), N_BUFFER(0))',
-	`dapm(N_BUFFER(1), N_SRC(0))',
-	`dapm(N_PGA(0), N_BUFFER(1))',
-	`dapm(N_BUFFER(2), N_PGA(0))'))
+	`dapm(N_BUFFER(1), N_SRC(0))'))
 
 #
 # Pipeline Source and Sinks
 #
-indir(`define', concat(`PIPELINE_SOURCE_', PIPELINE_ID), N_BUFFER(2))
+indir(`define', concat(`PIPELINE_SOURCE_', PIPELINE_ID), N_BUFFER(1))
 indir(`define', concat(`PIPELINE_PCM_', PIPELINE_ID), SRC Playback PCM_ID)
 
 #

--- a/tools/topology/sof/pipe-src-volume-playback.m4
+++ b/tools/topology/sof/pipe-src-volume-playback.m4
@@ -1,0 +1,97 @@
+# Low Latency Passthrough with volume Pipeline and PCM
+#
+# Pipeline Endpoints for connection are :-
+#
+#  host PCM_P --> SRC --> sink DAI0
+
+# Include topology builder
+include(`utils.m4')
+include(`src.m4')
+include(`buffer.m4')
+include(`pcm.m4')
+include(`pga.m4')
+include(`dai.m4')
+include(`mixercontrol.m4')
+include(`pipeline.m4')
+
+#
+# Controls
+#
+# Volume Mixer control with max value of 32
+C_CONTROLMIXER(Master Playback Volume, PIPELINE_ID,
+	CONTROLMIXER_OPS(volsw, 256 binds the mixer control to volume get/put handlers, 256, 256),
+	CONTROLMIXER_MAX(, 32),
+	false,
+	CONTROLMIXER_TLV(TLV 32 steps from -64dB to 0dB for 2dB, vtlv_m64s2),
+	Channel register and shift for Front Left/Right,
+	LIST(`	', KCONTROL_CHANNEL(FL, 1, 0), KCONTROL_CHANNEL(FR, 1, 1)))
+
+#
+# Components and Buffers
+#
+
+# Host "SRC Playback" PCM
+# with 3 sink and 0 source periods
+W_PCM_PLAYBACK(PCM_ID, SRC Playback, 3, 0)
+
+#
+# SRC Configuration
+#
+
+W_VENDORTUPLES(media_src_tokens, sof_src_tokens, LIST(`		', `SOF_TKN_SRC_RATE_OUT	"48000"'))
+
+W_DATA(media_src_conf, media_src_tokens)
+
+# "SRC" has 3 source and 3 sink periods
+W_SRC(0, PIPELINE_FORMAT, 3, 3, media_src_conf)
+
+#
+# Volume Configuration
+#
+
+W_VENDORTUPLES(playback_pga_tokens, sof_volume_tokens,
+LIST(`		', `SOF_TKN_VOLUME_RAMP_STEP_TYPE	"0"'
+     `		', `SOF_TKN_VOLUME_RAMP_STEP_MS		"250"'))
+
+
+W_DATA(playback_pga_conf, playback_pga_tokens)
+
+# "Volume" has 2 source and 2 sink periods
+W_PGA(0, PIPELINE_FORMAT, 2, 2, playback_pga_conf, LIST(`		', "PIPELINE_ID Master Playback Volume"))
+
+# Playback Buffers
+W_BUFFER(0, COMP_BUFFER_SIZE(3,
+	COMP_SAMPLE_SIZE(PIPELINE_FORMAT), PIPELINE_CHANNELS, SCHEDULE_FRAMES),
+	PLATFORM_HOST_MEM_CAP)
+W_BUFFER(1, COMP_BUFFER_SIZE(3,
+	COMP_SAMPLE_SIZE(PIPELINE_FORMAT), PIPELINE_CHANNELS, SCHEDULE_FRAMES),
+	PLATFORM_HOST_MEM_CAP)
+W_BUFFER(2, COMP_BUFFER_SIZE(2,
+	COMP_SAMPLE_SIZE(PIPELINE_FORMAT), PIPELINE_CHANNELS, SCHEDULE_FRAMES),
+	PLATFORM_DAI_MEM_CAP)
+
+#
+# Pipeline Graph
+#
+#  host PCM_P --> B0 --> SRC 0 --> B1 Volume 0 --> B2 --> sink DAI0
+
+P_GRAPH(pipe-pass-src-playback-PIPELINE_ID, PIPELINE_ID,
+	LIST(`		',
+	`dapm(N_BUFFER(0), N_PCMP(PCM_ID))',
+	`dapm(N_SRC(0), N_BUFFER(0))',
+	`dapm(N_BUFFER(1), N_SRC(0))',
+	`dapm(N_PGA(0), N_BUFFER(1))',
+	`dapm(N_BUFFER(2), N_PGA(0))'))
+
+#
+# Pipeline Source and Sinks
+#
+indir(`define', concat(`PIPELINE_SOURCE_', PIPELINE_ID), N_BUFFER(2))
+indir(`define', concat(`PIPELINE_PCM_', PIPELINE_ID), SRC Playback PCM_ID)
+
+#
+# PCM Configuration
+#
+
+PCM_CAPABILITIES(SRC Playback PCM_ID, `S32_LE,S24_LE,S16_LE', 8000, 192000, 2, PIPELINE_CHANNELS, 2, 16, 192, 16384, 65536, 65536)
+


### PR DESCRIPTION
This pull request consists of five commits

- The testbench file component is fixed to work with timer based scheduling aware components

- The testbench traces are made readable by adding line feeds to ends

- The SRC testbench run script is updated for new testbench and test topologies locations

- SRC tests pass criteria is lowered for 16 bit mode tests

- To have consistent topology processing component naming the pipe-src-playback.m4 macro is renamed tp pipe-src-volume-playback.m4. A new pure SRC pipeline is created called pipe-src-playback.m4. The test topologies build is simpler with consistent pipe names.