### PR TITLE
cmake: add install target for fw

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,6 +146,12 @@ if(BUILD_UNIT_TESTS)
 	return()
 endif()
 
+# for FW just install uapi folder
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/src/include/uapi
+	DESTINATION include
+	PATTERN "*.h"
+)
+
 add_library(sof_ld_flags INTERFACE)
 add_library(sof_ld_scripts INTERFACE)
 

--- a/src/arch/xtensa/CMakeLists.txt
+++ b/src/arch/xtensa/CMakeLists.txt
@@ -367,12 +367,18 @@ else()
 endif()
 
 add_custom_target(
-	bin
+	bin ALL
 	COMMAND ${CMAKE_COMMAND} -E copy sof-${fw_name}.ri ${PROJECT_BINARY_DIR}/sof-${fw_name}.ri
 	COMMAND ${CMAKE_COMMAND} -E copy sof-${fw_name}.ldc ${PROJECT_BINARY_DIR}/sof-${fw_name}.ldc
 	DEPENDS run_meu
 	VERBATIM
 	USES_TERMINAL
+)
+
+install(
+	FILES ${PROJECT_BINARY_DIR}/sof-${fw_name}.ri
+		${PROJECT_BINARY_DIR}/sof-${fw_name}.ldc
+	DESTINATION bin
 )
 
 if(CONFIG_BUILD_VM_ROM)


### PR DESCRIPTION
Adds `make install` support for FW build.
For commands like:
```
cmake -DTOOLCHAIN=xt -DROOT_DIR=$CONFIG_PATH/xtensa-elf -DMEU_PATH=$MEU_PATH -DMEU_PRIVATE_KEY=$PRIVATE_KEY_PATH -DCMAKE_INSTALL_PREFIX=install ..
make apollolake_defconfig
make install -j6
# install depends on all that has bin in it so you can do build&install with just install target
```

It creates install dir like:
```
install
├── bin
│   ├── sof-apl.ldc
│   └── sof-apl.ri
└── include
    └── uapi
        ├── abi.h
        ├── ipc
        │   ├── control.h
        │   ├── dai.h
        │   ├── dai-intel.h
        │   ├── header.h
        │   ├── info.h
        │   ├── pm.h
        │   ├── stream.h
        │   ├── topology.h
        │   ├── trace.h
        │   └── xtensa.h
        └── user
            ├── detect_test.h
            ├── eq.h
            ├── fw.h
            ├── header.h
            ├── manifest.h
            ├── tokens.h
            ├── tone.h
            └── trace.h

```

Resolves #1309 

Signed-off-by: Janusz Jankowski <janusz.jankowski@linux.intel.com>