### PR TITLE
ipc: replace fw ready bitfield with explicit bit ordering

### DIFF
--- a/src/include/sof/debug.h
+++ b/src/include/sof/debug.h
@@ -50,15 +50,13 @@
 
 #ifdef CONFIG_DEBUG
 
-#define DEBUG_SET_FW_READY_FLAGS	\
-{					\
-	.bits = {			\
-		.build = 1,		\
-		.locks = DEBUG_LOCKS,	\
-		.locks_verbose = DEBUG_LOCKS_VERBOSE,	\
-		.gdb = DEBUG_GDB,	\
-	},				\
-}
+#define DEBUG_SET_FW_READY_FLAGS				\
+(								\
+	SOF_IPC_INFO_BUILD |					\
+	(DEBUG_LOCKS ? SOF_IPC_INFO_LOCKS : 0) |		\
+	(DEBUG_LOCKS_VERBOSE ? SOF_IPC_INFO_LOCKSV : 0) |	\
+	(DEBUG_GDB ? SOF_IPC_INFO_GDB : 0)			\
+)
 
 /* dump file and line to start of mailbox or shared memory */
 #define dbg() \
@@ -140,15 +138,12 @@
 
 #else
 
-#define DEBUG_SET_FW_READY_FLAGS	\
-{					\
-	.bits = {			\
-		.build = 0,		\
-		.locks = DEBUG_LOCKS,	\
-		.locks_verbose = DEBUG_LOCKS_VERBOSE,	\
-		.gdb = DEBUG_GDB,	\
-	},				\
-}
+#define DEBUG_SET_FW_READY_FLAGS				\
+(								\
+	(DEBUG_LOCKS ? SOF_IPC_INFO_LOCKS : 0) |		\
+	(DEBUG_LOCKS_VERBOSE ? SOF_IPC_INFO_LOCKSV : 0) |	\
+	(DEBUG_GDB ? SOF_IPC_INFO_GDB : 0)			\
+)
 
 #define dbg()
 #define dbg_at(__x)

--- a/src/include/uapi/ipc/info.h
+++ b/src/include/uapi/ipc/info.h
@@ -48,6 +48,14 @@
 
 #define SOF_IPC_MAX_ELEMS	16
 
+/*
+ * Firmware boot info flag bits (64-bit)
+ */
+#define SOF_IPC_INFO_BUILD		BIT(0)
+#define SOF_IPC_INFO_LOCKS		BIT(1)
+#define SOF_IPC_INFO_LOCKSV		BIT(2)
+#define SOF_IPC_INFO_GDB		BIT(3)
+
 /* extended data types that can be appended onto end of sof_ipc_fw_ready */
 enum sof_ipc_ext_data {
 	SOF_IPC_EXT_DMA_BUFFER = 0,
@@ -79,16 +87,8 @@ struct sof_ipc_fw_ready {
 	uint32_t hostbox_size;
 	struct sof_ipc_fw_version version;
 
-	/* Miscellaneous debug flags showing build/debug features enabled */
-	union {
-		uint64_t reserved;
-		struct {
-			uint64_t build:1;
-			uint64_t locks:1;
-			uint64_t locks_verbose:1;
-			uint64_t gdb:1;
-		} bits;
-	} debug;
+	/* Miscellaneous flags */
+	uint64_t flags;
 
 	/* reserved for future use */
 	uint32_t reserved[4];

--- a/src/platform/baytrail/platform.c
+++ b/src/platform/baytrail/platform.c
@@ -78,7 +78,7 @@ static const struct sof_ipc_fw_ready ready
 		.tag = SOF_TAG,
 		.abi_version = SOF_ABI_VERSION,
 	},
-	.debug = DEBUG_SET_FW_READY_FLAGS
+	.flags = DEBUG_SET_FW_READY_FLAGS
 };
 
 #define NUM_BYT_WINDOWS		6

--- a/src/platform/haswell/platform.c
+++ b/src/platform/haswell/platform.c
@@ -77,7 +77,7 @@ static const struct sof_ipc_fw_ready ready
 		.tag = SOF_TAG,
 		.abi_version = SOF_ABI_VERSION,
 	},
-	.debug = DEBUG_SET_FW_READY_FLAGS,
+	.flags = DEBUG_SET_FW_READY_FLAGS,
 };
 
 #define NUM_HSW_WINDOWS		6

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -80,7 +80,7 @@ static const struct sof_ipc_fw_ready ready
 		.tag = SOF_TAG,
 		.abi_version = SOF_ABI_VERSION,
 	},
-	.debug = DEBUG_SET_FW_READY_FLAGS,
+	.flags = DEBUG_SET_FW_READY_FLAGS,
 };
 
 #if defined(CONFIG_MEM_WND)


### PR DESCRIPTION
Previously the structure used bitfields,
which do not guarantee bit ordering.

This change makes sure the order is clearly defined.
It also renames and repurposes the field for general use,
which helps avoid the need to introduce new flag fields.

Signed-off-by: Slawomir Blauciak <slawomir.blauciak@linux.intel.com>

SW side: https://github.com/thesofproject/linux/pull/937