### PR TITLE
ipc: cavs: send notification as soon as possible

### DIFF
--- a/src/drivers/intel/cavs/ipc.c
+++ b/src/drivers/intel/cavs/ipc.c
@@ -134,6 +134,9 @@ static void ipc_irq_handler(void *arg)
 		/* unmask Done interrupt */
 		ipc_write(IPC_DIPCCTL,
 			  ipc_read(IPC_DIPCCTL) | IPC_DIPCCTL_IPCIDIE);
+
+		/* send next message to host */
+		ipc_process_msg_queue();
 	}
 }
 


### PR DESCRIPTION
Right now we are sending ipc notifications only on
passive level. With many pipelines running there
are simply too many messages to be send with not
much time to do so. This patch adds additional
message sending as soon as host reports readiness
to receive it. With this change likelihood of
getting out of empty messages is very small.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>