### PR TITLE
uapi: fix xtensa oops

### DIFF
--- a/src/arch/xtensa/include/arch/sof.h
+++ b/src/arch/xtensa/include/arch/sof.h
@@ -69,7 +69,8 @@ static inline void fill_core_dump(struct sof_ipc_dsp_oops_xtensa *oops,
 	oops->plat_hdr.configidlo = 0;
 #endif
 	oops->plat_hdr.numaregs = XCHAL_NUM_AREGS;
-	oops->plat_hdr.stackoffset = ((void *)&oops->stack) - (void *)oops;
+	oops->plat_hdr.stackoffset = oops->arch_hdr.totalsize
+				     + sizeof(struct sof_ipc_panic_info);
 	oops->plat_hdr.stackptr = stack_ptr;
 
 	oops->epc1 = *epc1;

--- a/src/arch/xtensa/include/arch/sof.h
+++ b/src/arch/xtensa/include/arch/sof.h
@@ -26,6 +26,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *
  * Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
+ *         Janusz Jankowski <janusz.jankowski@linux.intel.com>
  *
  */
 
@@ -40,6 +41,10 @@
 
 /* architecture specific stack frames to dump */
 #define ARCH_STACK_DUMP_FRAMES		32
+
+/* xtensa core specific oops size */
+#define ARCH_OOPS_SIZE (sizeof(struct sof_ipc_dsp_oops_xtensa) \
+			+ (XCHAL_NUM_AREGS * sizeof(uint32_t)))
 
 void arch_dump_regs_a(void *dump_buf, uint32_t ps);
 
@@ -60,7 +65,7 @@ static inline void fill_core_dump(struct sof_ipc_dsp_oops_xtensa *oops,
 				  uintptr_t *epc1)
 {
 	oops->arch_hdr.arch = ARCHITECTURE_ID;
-	oops->arch_hdr.totalsize = sizeof(*oops);
+	oops->arch_hdr.totalsize = ARCH_OOPS_SIZE;
 #if XCHAL_HW_CONFIGID_RELIABLE
 	oops->plat_hdr.configidhi = XCHAL_HW_CONFIGID0;
 	oops->plat_hdr.configidlo = XCHAL_HW_CONFIGID1;
@@ -85,7 +90,7 @@ static inline void arch_dump_regs(uint32_t ps, uintptr_t stack_ptr,
 
 	fill_core_dump(buf, ps, stack_ptr, epc1);
 
-	dcache_writeback_region(buf, sizeof(struct sof_ipc_dsp_oops_xtensa));
+	dcache_writeback_region(buf, ARCH_OOPS_SIZE);
 }
 
 #endif

--- a/src/include/uapi/ipc/header.h
+++ b/src/include/uapi/ipc/header.h
@@ -246,7 +246,7 @@ struct sof_ipc_dsp_oops_plat_hdr {
 	uint32_t stackoffset;	/* Offset to stack pointer from beginning of
 				 * oops message
 				 */
-	uintptr_t stackptr;	/* Stack ptr */
+	uint32_t stackptr;	/* Stack ptr */
 } __attribute__((packed));
 
 /** @}*/

--- a/src/include/uapi/ipc/header.h
+++ b/src/include/uapi/ipc/header.h
@@ -228,11 +228,17 @@ struct sof_ipc_compound_hdr {
 	uint32_t count;		/**< count of 0 means end of compound sequence */
 } __attribute__((packed));
 
+/**
+ * OOPS header architecture specific data.
+ */
 struct sof_ipc_dsp_oops_arch_hdr {
 	uint32_t arch;		/* Identifier of architecture */
 	uint32_t totalsize;	/* Total size of oops message */
 } __attribute__((packed));
 
+/**
+ * OOPS header platform specific data.
+ */
 struct sof_ipc_dsp_oops_plat_hdr {
 	uint32_t configidhi;	/* ConfigID hi 32bits */
 	uint32_t configidlo;	/* ConfigID lo 32bits */

--- a/src/include/uapi/ipc/xtensa.h
+++ b/src/include/uapi/ipc/xtensa.h
@@ -77,7 +77,6 @@ struct sof_ipc_dsp_oops_xtensa {
 	uint32_t windowstart;
 	uint32_t excsave1;
 	uint32_t ar[XCHAL_NUM_AREGS];
-	uint32_t stack;
 } __attribute__((packed));
 
 #endif

--- a/src/include/uapi/ipc/xtensa.h
+++ b/src/include/uapi/ipc/xtensa.h
@@ -76,7 +76,7 @@ struct sof_ipc_dsp_oops_xtensa {
 	uint32_t widnowbase;
 	uint32_t windowstart;
 	uint32_t excsave1;
-	uint32_t ar[XCHAL_NUM_AREGS];
+	uint32_t ar[];
 } __attribute__((packed));
 
 #endif

--- a/src/include/uapi/ipc/xtensa.h
+++ b/src/include/uapi/ipc/xtensa.h
@@ -73,7 +73,7 @@ struct sof_ipc_dsp_oops_xtensa {
 	uint32_t interrupt;
 	uint32_t sar;
 	uint32_t debugcause;
-	uint32_t widnowbase;
+	uint32_t windowbase;
 	uint32_t windowstart;
 	uint32_t excsave1;
 	uint32_t ar[];

--- a/src/lib/panic.c
+++ b/src/lib/panic.c
@@ -62,8 +62,7 @@ void panic_rewind(uint32_t p, uint32_t stack_rewind_frames,
 	/* disable all IRQs */
 	oldps = interrupt_global_disable();
 
-	ext_offset = (void *)mailbox_get_exception_base() +
-			sizeof(struct sof_ipc_dsp_oops_xtensa);
+	ext_offset = (void *)mailbox_get_exception_base() + ARCH_OOPS_SIZE;
 
 	/* dump panic info, filename ane linenum */
 	dump_panicinfo(ext_offset, panic_info);

--- a/tools/coredumper/sof-coredump-reader.py
+++ b/tools/coredumper/sof-coredump-reader.py
@@ -493,8 +493,6 @@ def CoreDumpFactory(dsp_arch):
 				]
 			] + [
 				("a", dsp_arch.bitness * c_uint32)
-			] + [
-				("stack", c_uint32)
 			]
 
 		def __init__(self, columncount):


### PR DESCRIPTION
For #1374 

`stack` wasn't used as field at all, it was just end marker, so I replaced it with just using size of struct. Data of stack itself needs no cache invalidation because it's done in other place (so oops size wasn't really full panic info anyway).

I changed `ar` field to vararray, because we shouldn't use arch defines in uapi headers, so it should be *dynamic* and user can get it from `totalsize` field of `arch_hdr`.
