### PR TITLE
platform: apl: increase l1 exit time

### DIFF
--- a/src/platform/apollolake/include/platform/platform.h
+++ b/src/platform/apollolake/include/platform/platform.h
@@ -155,7 +155,7 @@ struct sof;
 #define PLATFORM_DEFAULT_DELAY	12
 
 /* minimal L1 exit time in cycles */
-#define PLATFORM_FORCE_L1_EXIT_TIME	585
+#define PLATFORM_FORCE_L1_EXIT_TIME	800
 
 /* the SSP port fifo depth */
 #define SSP_FIFO_DEPTH		16


### PR DESCRIPTION
Increasing PLATFORM_FORCE_L1_EXIT_TIME on apollolake platform. I do not observe hda dma buffer full timeout after that change (buffer full timeouts are reproducible on apl's). Value is experimental. Please do not merge it yet.

Signed-off-by: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>