### PR TITLE
topology: fix sof-glk-da7219-kwd topology

### DIFF
--- a/tools/topology/sof-glk-da7219-kwd.m4
+++ b/tools/topology/sof-glk-da7219-kwd.m4
@@ -77,14 +77,6 @@ PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
         7, 7, 2, s32le,
         48, 1000, 0, 0)
 
-# Passthrough capture pipeline 8 on PCM 8 using max 2 channels.
-# Schedule 320 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_ADD(sof/pipe-kfbm-capture.m4,
-	8, 8, 2, s16le,
-	KWD_PERIOD_FRAMES,
-	KWD_PIPE_SCH_DEADLINE_US,
-	0, 0)
-
 #
 # DAIs configuration
 #
@@ -122,24 +114,36 @@ DAI_ADD(sof/pipe-dai-capture.m4,
 DAI_ADD(sof/pipe-dai-playback.m4,
         5, HDA, 3, iDisp1,
         PIPELINE_SOURCE_5, 2, s32le,
-        48, 1000, 0, 0)
+        48, 1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp2 using 2 periods
 # Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
         6, HDA, 4, iDisp2,
         PIPELINE_SOURCE_6, 2, s32le,
-        48, 1000, 0, 0)
+        48, 1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp3 using 2 periods
 # Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
         7, HDA, 5, iDisp3,
         PIPELINE_SOURCE_7, 2, s32le,
-        48, 1000, 0, 0)
+        48, 1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+
+#
+# KWD configuration
+#
+
+# Passthrough capture pipeline 8 on PCM 8 using max 2 channels.
+# Schedule 320 frames per 20000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-kfbm-capture.m4,
+	8, 8, 2, s16le,
+	KWD_PERIOD_FRAMES,
+	KWD_PIPE_SCH_DEADLINE_US,
+	0, 0)
 
 # capture DAI is DMIC 1 using 2 periods
-# Buffers use s16le format, with 320 frame per 1000us on core 0 with priority 0
+# Buffers use s16le format, with 320 frame per 20000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	8, DMIC, 1, dmic16k,
 	PIPELINE_SINK_8, 2, s16le,


### PR DESCRIPTION
This patch fixes two things:
- Configures HDA pipelines to be timer driven.
- Moves definition of pipe-kfbm-capture to avoid overwrite
of deadline and frames for other pipelines.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>