### PR TITLE
Cavs clk defs - deduplication and cleanup

### DIFF
--- a/src/platform/apollolake/include/platform/clk-map.h
+++ b/src/platform/apollolake/include/platform/clk-map.h
@@ -33,19 +33,25 @@
 
 #include <sof/clk.h>
 
+#define CLK_MAX_CPU_HZ		400000000
+
 static const struct freq_table cpu_freq[] = {
 	{100000000, 100000, 0x3},
 	{200000000, 200000, 0x1},
-	{400000000, 400000, 0x0}, /* default */
+	{CLK_MAX_CPU_HZ, 400000, 0x0}, /* the default one */
 };
+
+#define CPU_DEFAULT_IDX	2
 
 /* IMPORTANT: array should be filled in increasing order
  * (regarding to .freq field)
  */
 static const struct freq_table ssp_freq[] = {
-	{ 19200000, 19200, CLOCK_SSP_XTAL_OSCILLATOR },
+	{ 19200000, 19200, CLOCK_SSP_XTAL_OSCILLATOR }, /* the default one */
 	{ 24576000, 24576, CLOCK_SSP_AUDIO_CARDINAL },
 	{ 96000000, 96000, CLOCK_SSP_PLL_FIXED },
 };
+
+#define SSP_DEFAULT_IDX	0
 
 #endif

--- a/src/platform/apollolake/include/platform/clk.h
+++ b/src/platform/apollolake/include/platform/clk.h
@@ -32,35 +32,6 @@
 #ifndef __PLATFORM_CLOCK__
 #define __PLATFORM_CLOCK__
 
-#include <sof/cpu.h>
-#include <sof/io.h>
-#include <platform/shim.h>
-
-#define CLK_CPU(x)	(x)
-#define CLK_SSP		2
-
-#define CPU_DEFAULT_IDX		2
-#define SSP_DEFAULT_IDX		0
-
-#define CLK_DEFAULT_CPU_HZ	400000000
-#define CLK_MAX_CPU_HZ		400000000
-
-#define NUM_CLOCKS	3
-
-static inline int clock_platform_set_cpu_freq(uint32_t cpu_freq_enc)
-{
-	/* set CPU frequency request for CCU */
-	io_reg_update_bits(SHIM_BASE + SHIM_CLKCTL, SHIM_CLKCTL_HDCS, 0);
-	io_reg_update_bits(SHIM_BASE + SHIM_CLKCTL,
-			   SHIM_CLKCTL_DPCS_MASK(cpu_get_id()),
-			   cpu_freq_enc);
-
-	return 0;
-}
-
-static inline int clock_platform_set_ssp_freq(uint32_t ssp_freq_enc)
-{
-	return 0;
-}
+#include <cavs/clk.h>
 
 #endif

--- a/src/platform/cannonlake/include/platform/clk-map.h
+++ b/src/platform/cannonlake/include/platform/clk-map.h
@@ -33,17 +33,23 @@
 
 #include <sof/clk.h>
 
+#define CLK_MAX_CPU_HZ		400000000
+
 static const struct freq_table cpu_freq[] = {
 	{120000000, 120000, 0x0},
-	{400000000, 400000, 0x4}, /* default */
+	{CLK_MAX_CPU_HZ, 400000, 0x4}, /* default */
 };
+
+#define CPU_DEFAULT_IDX		1
 
 /* IMPORTANT: array should be filled in increasing order
  * (regarding to .freq field)
  */
 static const struct freq_table ssp_freq[] = {
-	{ 24000000, 24000, CLOCK_SSP_XTAL_OSCILLATOR },
+	{ 24000000, 24000, CLOCK_SSP_XTAL_OSCILLATOR }, /* default */
 	{ 96000000, 96000, CLOCK_SSP_PLL_FIXED },
 };
+
+#define SSP_DEFAULT_IDX		0
 
 #endif

--- a/src/platform/cannonlake/include/platform/clk.h
+++ b/src/platform/cannonlake/include/platform/clk.h
@@ -33,34 +33,6 @@
 #ifndef __PLATFORM_CLOCK__
 #define __PLATFORM_CLOCK__
 
-#include <sof/cpu.h>
-#include <sof/io.h>
-#include <platform/shim.h>
-
-#define CLK_CPU(x)	(x)
-#define CLK_SSP		4
-
-#define CPU_DEFAULT_IDX		1
-#define SSP_DEFAULT_IDX		0
-
-#define CLK_DEFAULT_CPU_HZ	120000000
-#define CLK_MAX_CPU_HZ		400000000
-
-#define NUM_CLOCKS	5
-
-static inline int clock_platform_set_cpu_freq(uint32_t cpu_freq_enc)
-{
-	/* set CPU frequency request for CCU */
-	io_reg_update_bits(SHIM_BASE + SHIM_CLKCTL,
-			   SHIM_CLKCTL_DPCS_MASK(cpu_get_id()),
-			   cpu_freq_enc);
-
-	return 0;
-}
-
-static inline int clock_platform_set_ssp_freq(uint32_t ssp_freq_enc)
-{
-	return 0;
-}
+#include <cavs/clk.h>
 
 #endif

--- a/src/platform/icelake/include/platform/clk-map.h
+++ b/src/platform/icelake/include/platform/clk-map.h
@@ -33,18 +33,24 @@
 
 #include <sof/clk.h>
 
+#define CLK_MAX_CPU_HZ		400000000
+
 static const struct freq_table cpu_freq[] = {
 	{120000000, 120000, 0x0},
-	{400000000, 400000, 0x4}, /* default */
+	{CLK_MAX_CPU_HZ, 400000, 0x4}, /* default */
 };
+
+#define CPU_DEFAULT_IDX		1
 
 /* IMPORTANT: array should be filled in increasing order
  * (regarding to .freq field)
  */
 static const struct freq_table ssp_freq[] = {
 	{ 24576000, 24576, CLOCK_SSP_AUDIO_CARDINAL },
-	{ 38400000, 38400, CLOCK_SSP_XTAL_OSCILLATOR },
+	{ 38400000, 38400, CLOCK_SSP_XTAL_OSCILLATOR }, /* default */
 	{ 96000000, 96000, CLOCK_SSP_PLL_FIXED },
 };
+
+#define SSP_DEFAULT_IDX		1
 
 #endif

--- a/src/platform/icelake/include/platform/clk.h
+++ b/src/platform/icelake/include/platform/clk.h
@@ -33,34 +33,6 @@
 #ifndef __PLATFORM_CLOCK__
 #define __PLATFORM_CLOCK__
 
-#include <sof/cpu.h>
-#include <sof/io.h>
-#include <platform/shim.h>
-
-#define CLK_CPU(x)	(x)
-#define CLK_SSP		4
-
-#define CPU_DEFAULT_IDX		1
-#define SSP_DEFAULT_IDX		1
-
-#define CLK_DEFAULT_CPU_HZ	120000000
-#define CLK_MAX_CPU_HZ		400000000
-
-#define NUM_CLOCKS	5
-
-static inline int clock_platform_set_cpu_freq(uint32_t cpu_freq_enc)
-{
-	/* set CPU frequency request for CCU */
-	io_reg_update_bits(SHIM_BASE + SHIM_CLKCTL,
-			   SHIM_CLKCTL_DPCS_MASK(cpu_get_id()),
-			   cpu_freq_enc);
-
-	return 0;
-}
-
-static inline int clock_platform_set_ssp_freq(uint32_t ssp_freq_enc)
-{
-	return 0;
-}
+#include <cavs/clk.h>
 
 #endif

--- a/src/platform/intel/cavs/include/cavs/cpu.h
+++ b/src/platform/intel/cavs/include/cavs/cpu.h
@@ -28,40 +28,15 @@
  * Author: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>
  */
 
-#ifndef __INCLUDE_CAVS_MEM_MAP__
-#define __INCLUDE_CAVS_MEM_MAP__
+/**
+ * \file cavs/cpu.h
+ * \brief DSP parameters, common for cAVS platforms.
+ */
 
-#include <config.h>
-#include <cavs/cpu.h>
+#ifndef __INCLUDE_CAVS_CPU__
+#define __INCLUDE_CAVS_CPU__
 
-#define SRAM_BANK_SIZE			(64 * 1024)
-
-#define EBB_BANKS_IN_SEGMENT		32
-
-#define EBB_SEGMENT_SIZE		EBB_BANKS_IN_SEGMENT
-
-#define PLATFORM_LPSRAM_EBB_COUNT	CONFIG_LP_MEMORY_BANKS
-
-#define PLATFORM_HPSRAM_EBB_COUNT	CONFIG_HP_MEMORY_BANKS
-
-#define MAX_MEMORY_SEGMENTS		PLATFORM_HPSRAM_SEGMENTS
-
-#define LP_SRAM_SIZE			(CONFIG_LP_MEMORY_BANKS * SRAM_BANK_SIZE)
-
-#define HP_SRAM_SIZE			(CONFIG_HP_MEMORY_BANKS * SRAM_BANK_SIZE)
-
-#define PLATFORM_HPSRAM_SEGMENTS	((PLATFORM_HPSRAM_EBB_COUNT \
-	+ EBB_BANKS_IN_SEGMENT - 1) / EBB_BANKS_IN_SEGMENT)
-
-#define LPSRAM_MASK(ignored)	((1 << PLATFORM_LPSRAM_EBB_COUNT) - 1)
-
-#define HPSRAM_MASK(seg_idx)	((1 << (PLATFORM_HPSRAM_EBB_COUNT \
-	- EBB_BANKS_IN_SEGMENT * seg_idx)) - 1)
-
-#define LPSRAM_SIZE (PLATFORM_LPSRAM_EBB_COUNT * SRAM_BANK_SIZE)
-
-#if !defined(__ASSEMBLER__) && !defined(LINKER)
-void platform_init_memmap(void);
-#endif
+/** \brief Number of available DSP cores (conf. by kconfig) */
+#define PLATFORM_CORE_COUNT	CONFIG_CORE_COUNT
 
 #endif

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -37,6 +37,9 @@
 #include <platform/dma.h>
 #include <platform/dai.h>
 #include <platform/clk.h>
+#if defined(CONFIG_ICELAKE) || defined(CONFIG_SUECREEK)
+#include <platform/clk-map.h>
+#endif
 #include <platform/timer.h>
 #include <platform/interrupt.h>
 #include <platform/idc.h>

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -328,15 +328,11 @@ int platform_boot_complete(uint32_t boot_message)
 		sram_window.ext_hdr.hdr.size);
 #endif // defined(CONFIG_MEM_WND)
 
-#if CAVS_VERSION == CAVS_VERSION_1_5
-	/* boot now complete so we can relax the CPU */
-	clock_set_freq(CLK_CPU(cpu_get_id()), CLK_DEFAULT_CPU_HZ);
-
 	/* tell host we are ready */
+#if CAVS_VERSION == CAVS_VERSION_1_5
 	ipc_write(IPC_DIPCIE, SRAM_WINDOW_HOST_OFFSET(0) >> 12);
 	ipc_write(IPC_DIPCI, 0x80000000 | SOF_IPC_FW_READY);
 #else
-	/* tell host we are ready */
 	ipc_write(IPC_DIPCIDD, SRAM_WINDOW_HOST_OFFSET(0) >> 12);
 	ipc_write(IPC_DIPCIDR, 0x80000000 | SOF_IPC_FW_READY);
 #endif


### PR DESCRIPTION
Cleanup of clock defs for cavs platforms, defs related to run-time data separated from platform capabilities to improve code readability. Common defs deduplicated for cAVS platforms.