### PR TITLE
kpb: stop pipeline copy at draining

### DIFF
--- a/src/include/sof/audio/kpb.h
+++ b/src/include/sof/audio/kpb.h
@@ -60,6 +60,7 @@
 enum kpb_state {
 	KPB_STATE_BUFFERING = 0,
 	KPB_STATE_DRAINING_ON_DEMAND,
+	KPB_STATE_REALTIME,
 };
 
 enum kpb_event {


### PR DESCRIPTION
Add a state KPB_STATE_REALTIME for the realtime copy, and stop propagate
copying while at draining.

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>