### PR TITLE
pipeline: disable xrun recovery

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -114,6 +114,16 @@ config DMA_FIFO_PARTITION
 
 source "src/Kconfig"
 
+menu "Pipeline"
+
+config EXTERN_XRUN_RECOVERY
+	bool "External xrun recovery"
+	default y
+	help
+	  Select to delegate xrun recovery to outside of the firmware.
+
+endmenu
+
 menu "Debug"
 
 config GDB_DEBUG

--- a/src/audio/pipeline.c
+++ b/src/audio/pipeline.c
@@ -827,7 +827,7 @@ void pipeline_xrun(struct pipeline *p, struct comp_dev *dev,
 	pipeline_comp_xrun(dev, &data, dev->params.direction);
 }
 
-#if NO_XRUN_RECOVERY
+#if EXTERN_XRUN_RECOVERY
 /* recover the pipeline from a XRUN condition */
 static int pipeline_xrun_recover(struct pipeline *p)
 {

--- a/src/include/sof/audio/pipeline.h
+++ b/src/include/sof/audio/pipeline.h
@@ -40,14 +40,19 @@
 #include <sof/audio/component.h>
 #include <sof/trace.h>
 #include <sof/schedule.h>
+#include <uapi/ipc/info.h>
 #include <uapi/ipc/topology.h>
 
-/*
- * This flag disables firmware-side xrun recovery.
- * It should remain enabled in the situation when the
- * recovery is delegated to the outside of firmware.
- */
-#define NO_XRUN_RECOVERY 0
+#if CONFIG_EXTERN_XRUN_RECOVERY
+#define EXTERN_XRUN_RECOVERY	1
+#else
+#define EXTERN_XRUN_RECOVERY	0
+#endif
+
+#define PIPELINE_SET_FW_READY_FLAGS \
+( \
+	(EXTERN_XRUN_RECOVERY ? SOF_IPC_INFO_EXTERN_XRUN_RECOVERY : 0) \
+)
 
 /* pipeline tracing */
 #define trace_pipe(format, ...) \

--- a/src/include/uapi/abi.h
+++ b/src/include/uapi/abi.h
@@ -52,7 +52,7 @@
 
 /** \brief SOF ABI version major, minor and patch numbers */
 #define SOF_ABI_MAJOR 3
-#define SOF_ABI_MINOR 7
+#define SOF_ABI_MINOR 8
 #define SOF_ABI_PATCH 0
 
 /** \brief SOF ABI version number. Format within 32bit word is MMmmmppp */

--- a/src/include/uapi/ipc/info.h
+++ b/src/include/uapi/ipc/info.h
@@ -51,10 +51,11 @@
 /*
  * Firmware boot info flag bits (64-bit)
  */
-#define SOF_IPC_INFO_BUILD		BIT(0)
-#define SOF_IPC_INFO_LOCKS		BIT(1)
-#define SOF_IPC_INFO_LOCKSV		BIT(2)
-#define SOF_IPC_INFO_GDB		BIT(3)
+#define SOF_IPC_INFO_BUILD			BIT(0)
+#define SOF_IPC_INFO_LOCKS			BIT(1)
+#define SOF_IPC_INFO_LOCKSV			BIT(2)
+#define SOF_IPC_INFO_GDB			BIT(3)
+#define SOF_IPC_INFO_EXTERN_XRUN_RECOVERY	BIT(4)
 
 /* extended data types that can be appended onto end of sof_ipc_fw_ready */
 enum sof_ipc_ext_data {

--- a/src/platform/baytrail/platform.c
+++ b/src/platform/baytrail/platform.c
@@ -78,7 +78,7 @@ static const struct sof_ipc_fw_ready ready
 		.tag = SOF_TAG,
 		.abi_version = SOF_ABI_VERSION,
 	},
-	.flags = DEBUG_SET_FW_READY_FLAGS
+	.flags = DEBUG_SET_FW_READY_FLAGS | PIPELINE_SET_FW_READY_FLAGS,
 };
 
 #define NUM_BYT_WINDOWS		6

--- a/src/platform/haswell/platform.c
+++ b/src/platform/haswell/platform.c
@@ -77,7 +77,7 @@ static const struct sof_ipc_fw_ready ready
 		.tag = SOF_TAG,
 		.abi_version = SOF_ABI_VERSION,
 	},
-	.flags = DEBUG_SET_FW_READY_FLAGS,
+	.flags = DEBUG_SET_FW_READY_FLAGS | PIPELINE_SET_FW_READY_FLAGS,
 };
 
 #define NUM_HSW_WINDOWS		6

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -80,7 +80,7 @@ static const struct sof_ipc_fw_ready ready
 		.tag = SOF_TAG,
 		.abi_version = SOF_ABI_VERSION,
 	},
-	.flags = DEBUG_SET_FW_READY_FLAGS,
+	.flags = DEBUG_SET_FW_READY_FLAGS | PIPELINE_SET_FW_READY_FLAGS,
 };
 
 #if defined(CONFIG_MEM_WND)


### PR DESCRIPTION
added a flag to FW ready message to inform
whether the internal xrun recovery is enabled or not

Signed-off-by: Slawomir Blauciak <slawomir.blauciak@linux.intel.com>