### PR TITLE
detector: fix bug of incorrect amount of samples in detecting function

### DIFF
--- a/src/audio/detect_test.c
+++ b/src/audio/detect_test.c
@@ -613,7 +613,7 @@ static int test_keyword_copy(struct comp_dev *dev)
 
 	/* copy and perform detection */
 	cd->detect_func(dev, source,
-			source->avail / comp_frame_bytes(source->source));
+			source->avail / comp_frame_bytes(dev));
 
 	/* calc new available */
 	comp_update_buffer_consume(source, source->avail);


### PR DESCRIPTION
This patch solves the issue with wrong number of bytes
being passed to detecting function therefore causing a loss
of recorded data.

Signed-off-by: Marcin Rajwa <marcin.rajwa@linux.intel.com>