### PR TITLE
DMIC: Support capture from different microphones for DAI 0 and 1

### DIFF
--- a/src/include/sof/dmic.h
+++ b/src/include/sof/dmic.h
@@ -208,6 +208,9 @@
 #define OUTCONTROL1_IPM_SOURCE_3(x)		SET_BITS(10, 9, x)
 #define OUTCONTROL1_IPM_SOURCE_4(x)		SET_BITS(8, 7, x)
 #define OUTCONTROL1_TH(x)			SET_BITS(5, 0, x)
+
+#define OUTCONTROLX_IPM_NUMSOURCES		4
+
 #endif
 
 /* OUTSTAT0 bits */


### PR DESCRIPTION
This patch allows to configure the two DMIC DAIs for different
used microphones, e.g. DAI 0 for 4ch and DAI 1 for 2ch capture.

The common decimator core is programmed for combined max. request
and the FIFOs are configured to match the desired microphones. In
case of not a possible configuration an error is returned.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>