### PR TITLE
Tools: sof-eqctl: Print return code for fails.

### DIFF
--- a/tools/eqctl/eqctl.c
+++ b/tools/eqctl/eqctl.c
@@ -229,7 +229,7 @@ int main(int argc, char *argv[])
 		user_data[1] = n * sizeof(unsigned int);
 		ret = snd_ctl_elem_tlv_write(ctl, id, user_data);
 		if (ret) {
-			fprintf(stderr, "Error: failed TLV write.\n");
+			fprintf(stderr, "Error: failed TLV write (%d).\n", ret);
 			free(user_data);
 			exit(ret);
 		}


### PR DESCRIPTION
This patch adds printing of return code in decimal for failed
user control attempt. It helps the user to understand why a fail
happened.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>