### PR TITLE
topology: fix pipeline indexes in cml demux topology

### DIFF
--- a/tools/topology/sof-cml-demux-rt5682.m4
+++ b/tools/topology/sof-cml-demux-rt5682.m4
@@ -130,7 +130,7 @@ SectionGraph."PIPE_CAP_VIRT" {
 # capture DAI is DMIC01 using 2 periods
 # Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
-	7, DMIC, 0, dmic01,
+	3, DMIC, 0, dmic01,
 	PIPELINE_SINK_3, 2, s32le,
 	48, 1000, 0, 0)
 
@@ -144,7 +144,7 @@ DAI_ADD(sof/pipe-dai-playback.m4,
 # playback DAI is iDisp2 using 2 periods
 # Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
-	5, HDA, 1, iDisp2,
+	7, HDA, 1, iDisp2,
 	PIPELINE_SOURCE_7, 2, s32le,
 	48, 1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 


### PR DESCRIPTION
Dmic and hdmi1 have wrong pipeline id's in demux topology
so fix them.

Signed-off-by: Jaska Uimonen <jaska.uimonen@intel.com>