### PR TITLE
Add initial support for i.MX8 platform

### DIFF
--- a/rimage/file_simple.c
+++ b/rimage/file_simple.c
@@ -43,6 +43,14 @@
 #define BDW_DRAM_HOST_OFFSET	0x00000000
 #define BDW_DRAM_SIZE		(640 * 1024)
 
+#define IMX8_IRAM_BASE		0x596f8000
+#define IMX8_IRAM_HOST_OFFSET	0x10000
+#define IMX8_IRAM_SIZE		0x800
+#define IMX8_DRAM_BASE		0x596e8000
+#define IMX8_DRAM_SIZE		0x8000
+#define IMX8_SRAM_BASE		0x92400000
+#define IMX8_SRAM_SIZE		0x800000
+
 static int get_mem_zone_type(struct image *image, Elf32_Shdr *section)
 {
 	const struct adsp *adsp = image->adsp;
@@ -546,5 +554,28 @@ const struct adsp machine_bdw = {
 		},
 	},
 	.machine_id = MACHINE_BROADWELL,
+	.write_firmware = simple_write_firmware,
+};
+
+const struct adsp machine_imx8 = {
+	.name = "imx8",
+	.mem_zones = {
+		[SOF_FW_BLK_TYPE_IRAM] = {
+			.base = IMX8_IRAM_BASE,
+			.size = IMX8_IRAM_SIZE,
+			.host_offset = IMX8_IRAM_HOST_OFFSET,
+		},
+		[SOF_FW_BLK_TYPE_DRAM] = {
+			.base = IMX8_DRAM_BASE,
+			.size = IMX8_DRAM_SIZE,
+			.host_offset = 0,
+		},
+		[SOF_FW_BLK_TYPE_SRAM] = {
+			.base = IMX8_SRAM_BASE,
+			.size = IMX8_SRAM_SIZE,
+			.host_offset = 0,
+		},
+	},
+	.machine_id = MACHINE_IMX8,
 	.write_firmware = simple_write_firmware,
 };

--- a/rimage/rimage.c
+++ b/rimage/rimage.c
@@ -35,6 +35,7 @@ static const struct adsp *machine[] = {
 	&machine_sue,
 	&machine_kbl,
 	&machine_skl,
+	&machine_imx8,
 };
 
 static void usage(char *name)

--- a/rimage/rimage.h
+++ b/rimage/rimage.h
@@ -46,6 +46,7 @@ enum machine_id {
 	MACHINE_CANNONLAKE,
 	MACHINE_ICELAKE,
 	MACHINE_SUECREEK,
+	MACHINE_IMX8,
 	MACHINE_MAX
 };
 
@@ -193,6 +194,7 @@ extern const struct adsp machine_icl;
 extern const struct adsp machine_sue;
 extern const struct adsp machine_skl;
 extern const struct adsp machine_kbl;
+extern const struct adsp machine_imx8;
 
 
 #endif

--- a/src/arch/xtensa/CMakeLists.txt
+++ b/src/arch/xtensa/CMakeLists.txt
@@ -16,6 +16,8 @@ elseif(CONFIG_SUECREEK)
 	set(platform_folder suecreek)
 elseif(CONFIG_ICELAKE)
 	set(platform_folder icelake)
+elseif(CONFIG_IMX8)
+	set(platform_folder imx8)
 endif()
 
 set(fw_name ${CONFIG_FIRMWARE_SHORT_NAME})

--- a/src/arch/xtensa/configs/imx8_defconfig
+++ b/src/arch/xtensa/configs/imx8_defconfig
@@ -1,0 +1,1 @@
+CONFIG_IMX8=y

--- a/src/arch/xtensa/exc-dump.S
+++ b/src/arch/xtensa/exc-dump.S
@@ -125,8 +125,10 @@ dump_special_registers:
 	s32i a6, a2, REG_OFFSET_EPC4
 	rsr  a6, EPC5
 	s32i a6, a2, REG_OFFSET_EPC5
+#if XCHAL_INTLEVEL6_MASK
 	rsr  a6, EPC6
 	s32i a6, a2, REG_OFFSET_EPC6
+#endif
 #if XCHAL_INTLEVEL7_MASK
 	rsr  a6, EPC7
 	s32i a6, a2, REG_OFFSET_EPC7
@@ -139,8 +141,10 @@ dump_special_registers:
 	s32i a6, a2, REG_OFFSET_EPS4
 	rsr a6, EPS5
 	s32i a6, a2, REG_OFFSET_EPS5
+#if XCHAL_INTLEVEL6_MASK
 	rsr a6, EPS6
 	s32i a6, a2, REG_OFFSET_EPS6
+#endif
 #if XCHAL_INTLEVEL7_MASK
 	rsr a6, EPS7
 	s32i a6, a2, REG_OFFSET_EPS7

--- a/src/arch/xtensa/up/xtos/reset-vector.S
+++ b/src/arch/xtensa/up/xtos/reset-vector.S
@@ -86,7 +86,8 @@ _ResetVector:
 /* Apollolake+ have reset vector in ROM */
 #if defined(CONFIG_BAYTRAIL) || defined(CONFIG_CHERRYTRAIL) \
 	|| defined (CONFIG_HASWELL) || defined(CONFIG_BROADWELL) \
-	|| defined(CONFIG_SKYLAKE) || defined(CONFIG_KABYLAKE)
+	|| defined(CONFIG_SKYLAKE) || defined(CONFIG_KABYLAKE) \
+	|| defined(CONFIG_IMX8)
 	j	_ResetHandler
 #else
 

--- a/src/drivers/CMakeLists.txt
+++ b/src/drivers/CMakeLists.txt
@@ -1,2 +1,6 @@
+if(CONFIG_IMX8)
+add_subdirectory(imx)
+else()
 add_subdirectory(intel)
 add_subdirectory(dw)
+endif()

--- a/src/drivers/imx/CMakeLists.txt
+++ b/src/drivers/imx/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_local_sources(sof
+	dummy-dma.c
+	edma.c
+	esai.c
+	interrupt.c
+	ipc.c
+	timer.c
+)

--- a/src/drivers/imx/dummy-dma.c
+++ b/src/drivers/imx/dummy-dma.c
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright 2019 NXP
+//
+// Author: Daniel Baluta <daniel.baluta@nxp.com>
+
+#include <sof/dma.h>
+#include <errno.h>
+#include <stdint.h>
+#include <sof/string.h>
+#include <config.h>
+
+/* allocate next free DMA channel */
+static int dummy_dma_channel_get(struct dma *dma, int req_chan)
+{
+	return 0;
+}
+
+/* channel must not be running when this is called */
+static void dummy_dma_channel_put(struct dma *dma, int channel)
+{
+}
+
+static int dummy_dma_start(struct dma *dma, int channel)
+{
+	return 0;
+}
+
+
+static int dummy_dma_release(struct dma *dma, int channel)
+{
+	return 0;
+}
+
+static int dummy_dma_pause(struct dma *dma, int channel)
+{
+	return 0;
+}
+
+static int dummy_dma_stop(struct dma *dma, int channel)
+{
+	return 0;
+}
+
+/* fill in "status" with current DMA channel state and position */
+static int dummy_dma_status(struct dma *dma, int channel,
+			 struct dma_chan_status *status,
+			 uint8_t direction)
+{
+	return 0;
+}
+
+/* set the DMA channel configuration, source/target address, buffer sizes */
+static int dummy_dma_set_config(struct dma *dma, int channel,
+			     struct dma_sg_config *config)
+{
+	return 0;
+}
+
+/* restore DMA context after leaving D3 */
+static int dummy_dma_pm_context_restore(struct dma *dma)
+{
+	return 0;
+}
+
+/* store DMA context after leaving D3 */
+static int dummy_dma_pm_context_store(struct dma *dma)
+{
+	return 0;
+}
+
+static int dummy_dma_set_cb(struct dma *dma, int channel, int type,
+		void (*cb)(void *data, uint32_t type, struct dma_sg_elem *next),
+		void *data)
+{
+	return 0;
+}
+
+static int dummy_dma_copy(struct dma *dma, int channel, int bytes,
+			  uint32_t flags)
+{
+	return 0;
+}
+
+static int dummy_dma_probe(struct dma *dma)
+{
+	return 0;
+}
+
+static int dummy_dma_remove(struct dma *dma)
+{
+	return 0;
+}
+
+static int dummy_dma_get_data_size(struct dma *dma, int channel,
+				   uint32_t *avail, uint32_t *free)
+{
+	return 0;
+}
+
+const struct dma_ops dummy_dma_ops = {
+	.channel_get	= dummy_dma_channel_get,
+	.channel_put	= dummy_dma_channel_put,
+	.start		= dummy_dma_start,
+	.stop		= dummy_dma_stop,
+	.pause		= dummy_dma_pause,
+	.release	= dummy_dma_release,
+	.copy		= dummy_dma_copy,
+	.status		= dummy_dma_status,
+	.set_config	= dummy_dma_set_config,
+	.set_cb		= dummy_dma_set_cb,
+	.pm_context_restore		= dummy_dma_pm_context_restore,
+	.pm_context_store		= dummy_dma_pm_context_store,
+	.probe		= dummy_dma_probe,
+	.remove		= dummy_dma_remove,
+	.get_data_size	= dummy_dma_get_data_size,
+};

--- a/src/drivers/imx/edma.c
+++ b/src/drivers/imx/edma.c
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright 2019 NXP
+//
+// Author: Daniel Baluta <daniel.baluta@nxp.com>
+
+#include <sof/dma.h>
+#include <sof/io.h>
+#include <platform/dma.h>
+#include <errno.h>
+#include <stdint.h>
+#include <string.h>
+#include <config.h>
+
+static inline void edma_write(struct dma *dma, uint32_t reg, uint32_t value)
+{
+	io_reg_write(dma_base(dma) + reg, value);
+}
+
+static inline uint32_t edma_read(struct dma *dma, uint32_t reg)
+{
+	return io_reg_read(dma_base(dma) + reg);
+}
+
+static inline void edma_write16(struct dma *dma, uint32_t reg, uint16_t value)
+{
+	io_reg_write16(dma_base(dma) + reg, value);
+}
+
+static inline uint16_t edma_read16(struct dma *dma, uint32_t reg)
+{
+	return io_reg_read16(dma_base(dma) + reg);
+}
+
+static inline void edma_update_bits(struct dma *dma, uint32_t reg,
+				    uint32_t mask, uint32_t value)
+{
+	io_reg_update_bits(dma_base(dma) + reg, mask, value);
+}
+
+/* acquire the specific DMA channel */
+static int edma_channel_get(struct dma *dma, int req_chan)
+{
+	return 0;
+}
+
+/* channel must not be running when this is called */
+static void edma_channel_put(struct dma *dma, int channel)
+{
+}
+
+static int edma_start(struct dma *dma, int channel)
+{
+	return 0;
+}
+
+static int edma_release(struct dma *dma, int channel)
+{
+	return 0;
+}
+
+static int edma_pause(struct dma *dma, int channel)
+{
+	return 0;
+}
+
+static int edma_stop(struct dma *dma, int channel)
+{
+	return 0;
+}
+
+static int edma_status(struct dma *dma, int channel,
+		       struct dma_chan_status *status, uint8_t direction)
+{
+	return 0;
+}
+
+/* set the DMA channel configuration, source/target address, buffer sizes */
+static int edma_set_config(struct dma *dma, int channel,
+			     struct dma_sg_config *config)
+{
+	return 0;
+}
+
+/* restore DMA context after leaving D3 */
+static int edma_pm_context_restore(struct dma *dma)
+{
+	return 0;
+}
+
+/* store DMA context after leaving D3 */
+static int edma_pm_context_store(struct dma *dma)
+{
+	/* disable the DMA controller */
+	return 0;
+}
+
+static int edma_set_cb(struct dma *dma, int channel, int type,
+		void (*cb)(void *data, uint32_t type, struct dma_sg_elem *next),
+		void *data)
+{
+	return 0;
+}
+
+static int edma_probe(struct dma *dma)
+{
+	return 0;
+}
+
+static int edma_remove(struct dma *dma)
+{
+	return 0;
+}
+
+const struct dma_ops edma_ops = {
+	.channel_get	= edma_channel_get,
+	.channel_put	= edma_channel_put,
+	.start		= edma_start,
+	.stop		= edma_stop,
+	.pause		= edma_pause,
+	.release	= edma_release,
+	.status		= edma_status,
+	.set_config	= edma_set_config,
+	.set_cb		= edma_set_cb,
+	.pm_context_restore	= edma_pm_context_restore,
+	.pm_context_store	= edma_pm_context_store,
+	.probe		= edma_probe,
+	.remove		= edma_remove,
+};

--- a/src/drivers/imx/esai.c
+++ b/src/drivers/imx/esai.c
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright 2019 NXP
+//
+// Author: Daniel Baluta <daniel.baluta@nxp.com>
+
+#include <errno.h>
+#include <stdbool.h>
+#include <sof/esai.h>
+
+static int esai_context_store(struct dai *dai)
+{
+	return 0;
+}
+
+static int esai_context_restore(struct dai *dai)
+{
+	return 0;
+}
+
+static inline int esai_set_config(struct dai *dai,
+				 struct sof_ipc_dai_config *config)
+{
+	return 0;
+}
+
+static int esai_trigger(struct dai *dai, int cmd, int direction)
+{
+	return 0;
+}
+
+static int esai_probe(struct dai *dai)
+{
+	return 0;
+}
+
+const struct dai_driver esai_driver = {
+	.type = SOF_DAI_IMX_ESAI,
+	.dma_dev = DMA_DEV_ESAI,
+	.ops = {
+		.trigger		= esai_trigger,
+		.set_config		= esai_set_config,
+		.pm_context_store	= esai_context_store,
+		.pm_context_restore	= esai_context_restore,
+		.probe			= esai_probe,
+	},
+};

--- a/src/drivers/imx/interrupt.c
+++ b/src/drivers/imx/interrupt.c
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright 2019 NXP
+//
+// Author: Daniel Baluta <daniel.baluta@nxp.com>
+
+#include <sof/sof.h>
+#include <sof/interrupt.h>
+
+void platform_interrupt_init(void) {}
+
+struct irq_desc *platform_irq_get_parent(uint32_t irq)
+{
+	return NULL;
+}
+
+void platform_interrupt_set(int irq)
+{
+	arch_interrupt_set(irq);
+}
+
+void platform_interrupt_clear(uint32_t irq, uint32_t mask)
+{
+	arch_interrupt_clear(irq);
+}
+
+uint32_t platform_interrupt_get_enabled(void)
+{
+	return 0;
+}
+
+void platform_interrupt_mask(uint32_t irq, uint32_t mask) {}
+void platform_interrupt_unmask(uint32_t irq, uint32_t mask) {}

--- a/src/drivers/imx/ipc.c
+++ b/src/drivers/imx/ipc.c
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright 2019 NXP
+//
+// Author: Daniel Baluta <daniel.baluta@nxp.com>
+
+#include <sof/debug.h>
+#include <sof/timer.h>
+#include <sof/interrupt.h>
+#include <sof/ipc.h>
+#include <sof/mailbox.h>
+#include <sof/sof.h>
+#include <sof/stream.h>
+#include <sof/dai.h>
+#include <sof/dma.h>
+#include <sof/alloc.h>
+#include <sof/wait.h>
+#include <sof/trace.h>
+
+#include <platform/interrupt.h>
+#include <platform/mailbox.h>
+#include <platform/dma.h>
+#include <platform/platform.h>
+#include <platform/mu.h>
+#include <sof/audio/component.h>
+#include <sof/audio/pipeline.h>
+#include <uapi/ipc/header.h>
+
+extern struct ipc *_ipc;
+
+static void do_notify(void)
+{
+	uint32_t flags;
+	struct ipc_msg *msg;
+
+	spin_lock_irq(&_ipc->lock, flags);
+	msg = _ipc->shared_ctx->dsp_msg;
+	if (msg == NULL)
+		goto out;
+
+	tracev_ipc("ipc: not rx -> 0x%x", msg->header);
+
+	/* copy the data returned from DSP */
+	if (msg->rx_size && msg->rx_size < SOF_IPC_MSG_MAX_SIZE)
+		mailbox_dspbox_read(msg->rx_data, SOF_IPC_MSG_MAX_SIZE,
+				    0, msg->rx_size);
+
+	/* any callback ? */
+	if (msg->cb)
+		msg->cb(msg->cb_data, msg->rx_data);
+
+	list_item_append(&msg->list, &_ipc->shared_ctx->empty_list);
+
+out:
+	spin_unlock_irq(&_ipc->lock, flags);
+
+	/* unmask GP interrupt #1 */
+	imx_mu_xcr_rmw(IMX_MU_xCR_GIEn(1), 0);
+}
+
+static void irq_handler(void *arg)
+{
+	uint32_t ctrl;
+	uint32_t status;
+	uint32_t msg = 0;
+
+	/* Interrupt arrived, check src */
+	ctrl = imx_mu_read(IMX_MU_xCR);
+	status = imx_mu_read(IMX_MU_xSR);
+
+	tracev_ipc("ipc: irq isr 0x%x", status);
+
+	/* reply message(done) from host */
+	if (status & IMX_MU_xSR_GIPn(1)) {
+		/* Disable GP interrupt #1 */
+		imx_mu_xcr_rmw(0, IMX_MU_xCR_GIEn(1));
+
+		/* Clear GP pending interrupt #1 */
+		imx_mu_xsr_rmw(IMX_MU_xSR_GIPn(1), 0);
+
+		interrupt_clear(PLATFORM_IPC_INTERRUPT);
+		do_notify();
+	}
+
+	/* new message from host */
+	if (status & IMX_MU_xSR_GIPn(0)) {
+
+		/* Disable GP interrupt #0 */
+		imx_mu_xcr_rmw(0, IMX_MU_xCR_GIEn(0));
+
+		/* Clear GP pending interrupt #0 */
+		imx_mu_xsr_rmw(IMX_MU_xSR_GIPn(0), 0);
+
+		interrupt_clear(PLATFORM_IPC_INTERRUPT);
+		/* TODO: place message in Q and process later */
+		/* It's not Q ATM, may overwrite */
+		if (_ipc->host_pending) {
+			trace_ipc_error("ipc: dropping msg 0x%x", msg);
+			trace_ipc_error(" isr 0x%x ctrl 0x%x ipcxh 0x%x",
+					status, ctrl);
+		} else {
+			_ipc->host_pending = 1;
+			ipc_schedule_process(_ipc);
+		}
+	}
+}
+
+void ipc_platform_do_cmd(struct ipc *ipc)
+{
+	struct ipc_data *iipc = ipc_get_drvdata(ipc);
+	struct sof_ipc_reply reply;
+	int32_t err;
+
+	/* perform command and return any error */
+	err = ipc_cmd();
+	if (err > 0) {
+		goto done; /* reply created and copied by cmd() */
+	} else {
+		/* send std error reply */
+		reply.error = err;
+	}
+
+	/* send std error/ok reply */
+	reply.hdr.cmd = SOF_IPC_GLB_REPLY;
+	reply.hdr.size = sizeof(reply);
+	mailbox_hostbox_write(0, &reply, sizeof(reply));
+
+done:
+	ipc->host_pending = 0;
+
+	/* enable GP interrupt #0 - accept new messages */
+	imx_mu_xcr_rmw(IMX_MU_xCR_GIEn(0), 0);
+
+	/* request GP interrupt #0 - notify host that reply is ready */
+	imx_mu_xcr_rmw(IMX_MU_xCR_GIRn(0), 0);
+
+	// TODO: signal audio work to enter D3 in normal context
+	/* are we about to enter D3 ? */
+	if (iipc->pm_prepare_D3) {
+		while (1)
+			wait_for_interrupt(0);
+	}
+}
+
+void ipc_platform_send_msg(struct ipc *ipc)
+{
+	struct ipc_msg *msg;
+	uint32_t flags;
+
+	spin_lock_irq(&ipc->lock, flags);
+
+	/* any messages to send ? */
+	if (list_is_empty(&ipc->shared_ctx->msg_list)) {
+		ipc->shared_ctx->dsp_pending = 0;
+		goto out;
+	}
+
+	/* can't send notification when one is in progress */
+	if (imx_mu_read(IMX_MU_xCR) & IMX_MU_xCR_GIRn(1))
+		goto out;
+
+	/* now send the message */
+	msg = list_first_item(&ipc->shared_ctx->msg_list, struct ipc_msg,
+			      list);
+	mailbox_dspbox_write(0, msg->tx_data, msg->tx_size);
+	list_item_del(&msg->list);
+	ipc->shared_ctx->dsp_msg = msg;
+	tracev_ipc("ipc: msg tx -> 0x%x", msg->header);
+
+	/* now interrupt host to tell it we have sent a message */
+	imx_mu_xcr_rmw(IMX_MU_xCR_GIRn(1), 0);
+
+	list_item_append(&msg->list, &ipc->shared_ctx->empty_list);
+
+out:
+	spin_unlock_irq(&ipc->lock, flags);
+}
+
+int platform_ipc_init(struct ipc *ipc)
+{
+	struct ipc_data *iipc;
+
+	_ipc = ipc;
+
+	/* init ipc data */
+	iipc = rzalloc(RZONE_SYS, SOF_MEM_CAPS_RAM, sizeof(struct ipc_data));
+	ipc_set_drvdata(_ipc, iipc);
+
+	/* schedule */
+	schedule_task_init(&_ipc->ipc_task, SOF_SCHEDULE_EDF, SOF_TASK_PRI_IPC,
+			   ipc_process_task, _ipc, 0, 0);
+
+#ifdef CONFIG_HOST_PTABLE
+	/* allocate page table buffer */
+	iipc->page_table = rzalloc(RZONE_SYS, SOF_MEM_CAPS_RAM,
+		PLATFORM_PAGE_TABLE_SIZE);
+	if (iipc->page_table)
+		bzero(iipc->page_table, PLATFORM_PAGE_TABLE_SIZE);
+#endif
+
+	/* PM */
+	iipc->pm_prepare_D3 = 0;
+
+	/* configure interrupt */
+	interrupt_register(PLATFORM_IPC_INTERRUPT, IRQ_AUTO_UNMASK,
+			   irq_handler, NULL);
+	interrupt_enable(PLATFORM_IPC_INTERRUPT);
+
+	/* enable GP #0 for Host -> DSP message notification
+	 * enable GP #1 for DSP -> Host message notification
+	 */
+	imx_mu_xcr_rmw(IMX_MU_xCR_GIEn(0) | IMX_MU_xCR_GIEn(1), 0);
+
+	return 0;
+}
+

--- a/src/drivers/imx/timer.c
+++ b/src/drivers/imx/timer.c
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright 2019 NXP
+//
+// Author: Daniel Baluta <daniel.baluta@nxp.com>
+
+#include <platform/timer.h>
+#include <platform/interrupt.h>
+#include <sof/debug.h>
+#include <sof/audio/component.h>
+#include <sof/drivers/timer.h>
+#include <stdint.h>
+
+void platform_timer_start(struct timer *timer)
+{
+	arch_timer_enable(timer);
+}
+
+void platform_timer_stop(struct timer *timer)
+{
+	arch_timer_disable(timer);
+}
+
+int platform_timer_set(struct timer *timer, uint64_t ticks)
+{
+	return arch_timer_set(timer, ticks);
+}
+
+void platform_timer_clear(struct timer *timer)
+{
+	arch_timer_clear(timer);
+}
+
+uint64_t platform_timer_get(struct timer *timer)
+{
+	return arch_timer_get_system(timer);
+}
+
+/* get timestamp for host stream DMA position */
+void platform_host_timestamp(struct comp_dev *host,
+			     struct sof_ipc_stream_posn *posn)
+{
+	int err;
+
+	/* get host position */
+	err = comp_position(host, posn);
+	if (err == 0)
+		posn->flags |= SOF_TIME_HOST_VALID | SOF_TIME_HOST_64;
+}
+
+/* get timestamp for DAI stream DMA position */
+void platform_dai_timestamp(struct comp_dev *dai,
+			    struct sof_ipc_stream_posn *posn)
+{
+	int err;
+
+	/* get DAI position */
+	err = comp_position(dai, posn);
+	if (err == 0)
+		posn->flags |= SOF_TIME_DAI_VALID;
+
+	/* get SSP wallclock - DAI sets this to stream start value */
+	posn->wallclock = timer_get_system(platform_timer) - posn->wallclock;
+	posn->flags |= SOF_TIME_WALL_VALID | SOF_TIME_WALL_64;
+}
+
+/* get current wallclock for componnent */
+void platform_dai_wallclock(struct comp_dev *dai, uint64_t *wallclock)
+{
+	/* only 1 wallclock on imx8 */
+	*wallclock = timer_get_system(platform_timer);
+}
+
+int timer_register(struct timer *timer, void(*handler)(void *arg), void *arg)
+{
+	switch (timer->id) {
+	case TIMER0:
+	case TIMER1:
+		return arch_timer_register(timer, handler, arg);
+	default:
+		return -EINVAL;
+	}
+}
+
+void timer_unregister(struct timer *timer)
+{
+	interrupt_unregister(timer->irq);
+}
+
+void timer_enable(struct timer *timer)
+{
+	interrupt_enable(timer->irq);
+}
+
+void timer_disable(struct timer *timer)
+{
+	interrupt_disable(timer->irq);
+}

--- a/src/include/sof/dma.h
+++ b/src/include/sof/dma.h
@@ -74,6 +74,8 @@
 #define DMA_DEV_DMIC		BIT(3) /**< connectable to DMIC fifo */
 #define DMA_DEV_SSI		BIT(4) /**< connectable to SSI / SPI fifo */
 #define DMA_DEV_SOUNDWIRE	BIT(5) /**< connectable to SoundWire link */
+#define DMA_DEV_SAI		BIT(6) /**< connectable to SAI fifo */
+#define DMA_DEV_ESAI		BIT(7) /**< connectable to ESAI fifo */
 
 /* DMA access privilege flag */
 #define DMA_ACCESS_EXCLUSIVE	1

--- a/src/include/sof/edma.h
+++ b/src/include/sof/edma.h
@@ -1,0 +1,34 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright 2019 NXP
+ *
+ * Author: Daniel Baluta <daniel.baluta@nxp.com>
+ */
+
+#ifndef _EDMA_H
+#define _EDMA_H
+
+#include <stdint.h>
+
+#define EDMA_CH_CSR                     0x00
+#define EDMA_CH_ES                      0x04
+#define EDMA_CH_INT                     0x08
+#define EDMA_CH_SBR                     0x0C
+#define EDMA_CH_PRI                     0x10
+#define EDMA_TCD_SADDR                  0x20
+#define EDMA_TCD_SOFF                   0x24
+#define EDMA_TCD_ATTR                   0x26
+#define EDMA_TCD_NBYTES                 0x28
+#define EDMA_TCD_SLAST                  0x2C
+#define EDMA_TCD_DADDR                  0x30
+#define EDMA_TCD_DOFF                   0x34
+#define EDMA_TCD_CITER_ELINK            0x36
+#define EDMA_TCD_CITER                  0x36
+#define EDMA_TCD_DLAST_SGA              0x38
+#define EDMA_TCD_CSR                    0x3C
+#define EDMA_TCD_BITER_ELINK            0x3E
+#define EDMA_TCD_BITER                  0x3E
+
+int edma_init(void);
+
+#endif

--- a/src/include/sof/esai.h
+++ b/src/include/sof/esai.h
@@ -1,0 +1,54 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright 2019 NXP
+ *
+ * Author: Daniel Baluta <daniel.baluta@nxp.com>
+ */
+
+#ifndef _ESAI_H
+#define _ESAI_H
+
+#include <sof/dai.h>
+#include <sof/io.h>
+
+/* ESAI Register Map */
+#define REG_ESAI_ETDR           0x00
+#define REG_ESAI_ERDR           0x04
+#define REG_ESAI_ECR            0x08
+#define REG_ESAI_ESR            0x0C
+#define REG_ESAI_TFCR           0x10
+#define REG_ESAI_TFSR           0x14
+#define REG_ESAI_RFCR           0x18
+#define REG_ESAI_RFSR           0x1C
+#define REG_ESAI_xFCR(tx)       (tx ? REG_ESAI_TFCR : REG_ESAI_RFCR)
+#define REG_ESAI_xFSR(tx)       (tx ? REG_ESAI_TFSR : REG_ESAI_RFSR)
+#define REG_ESAI_TX0            0x80
+#define REG_ESAI_TX1            0x84
+#define REG_ESAI_TX2            0x88
+#define REG_ESAI_TX3            0x8C
+#define REG_ESAI_TX4            0x90
+#define REG_ESAI_TX5            0x94
+#define REG_ESAI_TSR            0x98
+#define REG_ESAI_RX0            0xA0
+#define REG_ESAI_RX1            0xA4
+#define REG_ESAI_RX2            0xA8
+#define REG_ESAI_RX3            0xAC
+#define REG_ESAI_SAISR          0xCC
+#define REG_ESAI_SAICR          0xD0
+#define REG_ESAI_TCR            0xD4
+#define REG_ESAI_TCCR           0xD8
+#define REG_ESAI_RCR            0xDC
+#define REG_ESAI_RCCR           0xE0
+#define REG_ESAI_xCR(tx)        (tx ? REG_ESAI_TCR : REG_ESAI_RCR)
+#define REG_ESAI_xCCR(tx)       (tx ? REG_ESAI_TCCR : REG_ESAI_RCCR)
+#define REG_ESAI_TSMA           0xE4
+#define REG_ESAI_TSMB           0xE8
+#define REG_ESAI_RSMA           0xEC
+#define REG_ESAI_RSMB           0xF0
+#define REG_ESAI_xSMA(tx)       (tx ? REG_ESAI_TSMA : REG_ESAI_RSMA)
+#define REG_ESAI_xSMB(tx)       (tx ? REG_ESAI_TSMB : REG_ESAI_RSMB)
+#define REG_ESAI_PRRC           0xF8
+#define REG_ESAI_PCRC           0xFC
+
+extern const struct dai_driver esai_driver;
+#endif

--- a/src/include/uapi/ipc/dai.h
+++ b/src/include/uapi/ipc/dai.h
@@ -80,6 +80,8 @@ enum sof_ipc_dai_type {
 	SOF_DAI_INTEL_DMIC,		/**< Intel DMIC */
 	SOF_DAI_INTEL_HDA,		/**< Intel HD/A */
 	SOF_DAI_INTEL_SOUNDWIRE,	/**< Intel SoundWire */
+	SOF_DAI_IMX_SAI,                /**< i.MX SAI */
+	SOF_DAI_IMX_ESAI,               /**< i.MX ESAI */
 };
 
 /* general purpose DAI configuration */

--- a/src/platform/CMakeLists.txt
+++ b/src/platform/CMakeLists.txt
@@ -10,6 +10,8 @@ elseif(CONFIG_SUECREEK)
 	add_subdirectory(suecreek)
 elseif(CONFIG_ICELAKE)
 	add_subdirectory(icelake)
+elseif(CONFIG_IMX8)
+	add_subdirectory(imx8)
 endif()
 
 if(CONFIG_CAVS)

--- a/src/platform/Kconfig
+++ b/src/platform/Kconfig
@@ -122,6 +122,11 @@ config LIBRARY
 	  Library builds are not intended to be run on DSP, but to be used by
 	  user-space applications.
 
+config IMX8
+	bool "Build for NXP i.MX8"
+	help
+	  Select if your target platform is imx8-compatible
+
 endchoice
 
 config CAVS
@@ -139,6 +144,7 @@ config FIRMWARE_SHORT_NAME
 	default "cnl" if CANNONLAKE
 	default "sue" if SUECREEK
 	default "icl" if ICELAKE
+	default "imx8" if IMX8
 	default ""
 	help
 	  3-characters long firmware identifer

--- a/src/platform/imx8/CMakeLists.txt
+++ b/src/platform/imx8/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_local_sources(sof
+	dai.c
+	dma.c
+	memory.c
+	platform.c
+)

--- a/src/platform/imx8/dai.c
+++ b/src/platform/imx8/dai.c
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright 2019 NXP
+//
+// Author: Daniel Baluta <daniel.baluta@nxp.com>
+
+#include <sof/sof.h>
+#include <sof/dai.h>
+#include <sof/esai.h>
+#include <platform/dai.h>
+
+static struct dai esai[] = {
+{
+	.index = 0,
+	.plat_data = {
+		.base = ESAI_BASE,
+	},
+	.drv = &esai_driver,
+},
+};
+
+static struct dai_type_info dti[] = {
+	{
+		.type = SOF_DAI_IMX_ESAI,
+		.dai_array = esai,
+		.num_dais = ARRAY_SIZE(esai)
+	},
+};
+
+int dai_init(void)
+{
+	dai_install(dti, ARRAY_SIZE(dti));
+	return 0;
+}

--- a/src/platform/imx8/dma.c
+++ b/src/platform/imx8/dma.c
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright 2019 NXP
+//
+// Author: Daniel Baluta <daniel.baluta@nxp.com>
+
+#include <sof/dma.h>
+#include <sof/edma.h>
+
+#include <platform/memory.h>
+#include <platform/interrupt.h>
+#include <platform/dma.h>
+
+extern struct dma_ops dummy_dma_ops;
+extern struct dma_ops edma_ops;
+
+struct dma dma[PLATFORM_NUM_DMACS] = {
+{
+	.plat_data = {
+		.id		= DMA_ID_EDMA0,
+		.dir		= DMA_DIR_MEM_TO_DEV | DMA_DIR_DEV_TO_MEM,
+		.devs		= DMA_DEV_ESAI,
+		.base		= EDMA0_BASE,
+		.channels	= 32,
+		.irq		= IRQ_NUM_IRQSTR_DSP6,
+	},
+	.ops	= &edma_ops,
+},
+{
+	.plat_data = {
+		.id		= DMA_ID_HOST,
+		.dir		= DMA_DIR_MEM_TO_MEM,
+		.devs		= DMA_DEV_HOST,
+		.channels	= 32,
+	},
+	.ops	= &dummy_dma_ops,
+},
+};
+
+int edma_init(void)
+{
+	int i;
+
+	/* early lock initialization for ref counting */
+	for (i = 0; i < ARRAY_SIZE(dma); i++)
+		spinlock_init(&dma[i].lock);
+
+	/* tell the lib DMAs are ready to use */
+	dma_install(dma, ARRAY_SIZE(dma));
+
+	return 0;
+}

--- a/src/platform/imx8/imx8.x.in
+++ b/src/platform/imx8/imx8.x.in
@@ -1,0 +1,503 @@
+/*
+ * Linker Script for i.MX8 QXP
+ *
+ * This script is run through the GNU C preprocessor to align the memory
+ * offsets with headers.
+ *
+ * Use spaces for formatting as cpp ignore tab sizes.
+ */
+
+#include <platform/memory.h>
+#include <xtensa/config/core-isa.h>
+
+OUTPUT_ARCH(xtensa)
+
+MEMORY
+{
+  vector_reset_text :
+        org = XCHAL_RESET_VECTOR0_PADDR,
+        len = SOF_MEM_RESET_TEXT_SIZE
+  vector_reset_lit :
+        org = XCHAL_RESET_VECTOR0_PADDR + SOF_MEM_RESET_TEXT_SIZE,
+        len = SOF_MEM_RESET_LIT_SIZE
+  vector_base_text :
+        org = XCHAL_VECBASE_RESET_PADDR,
+        len = SOF_MEM_VECBASE_LIT_SIZE
+  vector_int2_lit :
+        org = XCHAL_INTLEVEL2_VECTOR_PADDR - SOF_MEM_VECT_LIT_SIZE,
+        len = SOF_MEM_VECT_LIT_SIZE
+  vector_int2_text :
+        org = XCHAL_INTLEVEL2_VECTOR_PADDR,
+        len = SOF_MEM_VECT_TEXT_SIZE
+  vector_int3_lit :
+        org = XCHAL_INTLEVEL3_VECTOR_PADDR - SOF_MEM_VECT_LIT_SIZE,
+        len = SOF_MEM_VECT_LIT_SIZE
+  vector_int3_text :
+        org = XCHAL_INTLEVEL3_VECTOR_PADDR,
+        len = SOF_MEM_VECT_TEXT_SIZE
+  vector_int4_lit :
+        org = XCHAL_INTLEVEL4_VECTOR_PADDR - SOF_MEM_VECT_LIT_SIZE,
+        len = SOF_MEM_VECT_LIT_SIZE
+  vector_int4_text :
+        org = XCHAL_INTLEVEL4_VECTOR_PADDR,
+        len = SOF_MEM_VECT_TEXT_SIZE
+  vector_int5_lit :
+        org = XCHAL_INTLEVEL5_VECTOR_PADDR - SOF_MEM_VECT_LIT_SIZE,
+        len = SOF_MEM_VECT_LIT_SIZE
+  vector_int5_text :
+        org = XCHAL_INTLEVEL5_VECTOR_PADDR,
+        len = SOF_MEM_VECT_TEXT_SIZE
+  vector_kernel_lit :
+        org = XCHAL_KERNEL_VECTOR_PADDR - SOF_MEM_VECT_LIT_SIZE,
+        len = SOF_MEM_VECT_LIT_SIZE
+  vector_kernel_text :
+        org = XCHAL_KERNEL_VECTOR_PADDR,
+        len = SOF_MEM_VECT_TEXT_SIZE
+  vector_user_lit :
+        org = XCHAL_USER_VECTOR_PADDR - SOF_MEM_VECT_LIT_SIZE,
+        len = SOF_MEM_VECT_LIT_SIZE
+  vector_user_text :
+        org = XCHAL_USER_VECTOR_PADDR,
+        len = SOF_MEM_VECT_TEXT_SIZE
+  vector_double_lit :
+        org = XCHAL_DOUBLEEXC_VECTOR_PADDR - SOF_MEM_VECT_LIT_SIZE,
+        len = SOF_MEM_VECT_LIT_SIZE
+  vector_double_text :
+        org = XCHAL_DOUBLEEXC_VECTOR_PADDR,
+        len = SOF_MEM_VECT_TEXT_SIZE
+  sof_iram_text_start :
+        org = XCHAL_DOUBLEEXC_VECTOR_PADDR + SOF_MEM_VECT_TEXT_SIZE,
+        len = (IRAM_BASE + IRAM_SIZE) - (XCHAL_DOUBLEEXC_VECTOR_PADDR + SOF_MEM_VECT_TEXT_SIZE)
+  sof_sdram0 :
+        org = SDRAM0_BASE,
+        len = SDRAM0_SIZE
+  system_heap :
+        org = HEAP_SYSTEM_BASE,
+        len = HEAP_SYSTEM_SIZE
+  system_runtime_heap :
+        org = HEAP_SYS_RUNTIME_BASE,
+        len = HEAP_SYS_RUNTIME_SIZE
+  runtime_heap :
+        org = HEAP_RUNTIME_BASE,
+        len = HEAP_RUNTIME_SIZE
+  buffer_heap :
+        org = HEAP_BUFFER_BASE,
+        len = HEAP_BUFFER_SIZE
+  sof_stack :
+        org = SOF_STACK_END,
+        len = SOF_STACK_BASE - SOF_STACK_END
+  sof_sdram1 :
+        org = SDRAM1_BASE,
+        len = SDRAM1_SIZE
+  static_log_entries_seg (!ari) :
+        org = LOG_ENTRY_ELF_BASE,
+        len = LOG_ENTRY_ELF_SIZE
+}
+
+PHDRS
+{
+  vector_reset_text_phdr PT_LOAD;
+  vector_reset_lit_phdr PT_LOAD;
+  vector_base_text_phdr PT_LOAD;
+  vector_base_lit_phdr PT_LOAD;
+  vector_int2_text_phdr PT_LOAD;
+  vector_int2_lit_phdr PT_LOAD;
+  vector_int3_text_phdr PT_LOAD;
+  vector_int3_lit_phdr PT_LOAD;
+  vector_int4_text_phdr PT_LOAD;
+  vector_int4_lit_phdr PT_LOAD;
+  vector_int5_text_phdr PT_LOAD;
+  vector_int5_lit_phdr PT_LOAD;
+  vector_kernel_text_phdr PT_LOAD;
+  vector_kernel_lit_phdr PT_LOAD;
+  vector_user_text_phdr PT_LOAD;
+  vector_user_lit_phdr PT_LOAD;
+  vector_double_text_phdr PT_LOAD;
+  vector_double_lit_phdr PT_LOAD;
+  sof_iram_text_start_phdr PT_LOAD;
+  sof_sdram0_phdr PT_LOAD;
+  system_heap_phdr PT_LOAD;
+  system_runtime_heap_phdr PT_LOAD;
+  runtime_heap_phdr PT_LOAD;
+  buffer_heap_phdr PT_LOAD;
+  sof_stack_phdr PT_LOAD;
+  static_log_entries_phdr PT_NOTE;
+}
+
+/*  Default entry point:  */
+ENTRY(_ResetVector)
+_rom_store_table = 0;
+
+/* ABI0 does not use Window base */
+PROVIDE(_memmap_vecbase_reset = XCHAL_VECBASE_RESET_PADDR);
+
+/* Various memory-map dependent cache attribute settings: */
+_memmap_cacheattr_wb_base = 0x44024000;
+_memmap_cacheattr_wt_base = 0x11021000;
+_memmap_cacheattr_bp_base = 0x22022000;
+_memmap_cacheattr_unused_mask = 0x00F00FFF;
+_memmap_cacheattr_wb_trapnull = 0x4422422F;
+_memmap_cacheattr_wba_trapnull = 0x4422422F;
+_memmap_cacheattr_wbna_trapnull = 0x25222222;
+_memmap_cacheattr_wt_trapnull = 0x1122122F;
+_memmap_cacheattr_bp_trapnull = 0x2222222F;
+_memmap_cacheattr_wb_strict = 0x44F24FFF;
+_memmap_cacheattr_wt_strict = 0x11F21FFF;
+_memmap_cacheattr_bp_strict = 0x22F22FFF;
+_memmap_cacheattr_wb_allvalid = 0x44224222;
+_memmap_cacheattr_wt_allvalid = 0x11221222;
+_memmap_cacheattr_bp_allvalid = 0x22222222;
+PROVIDE(_memmap_cacheattr_reset = _memmap_cacheattr_wbna_trapnull);
+
+SECTIONS
+{
+  .ResetVector.text : ALIGN(4)
+  {
+    _ResetVector_text_start = ABSOLUTE(.);
+    KEEP (*(.ResetVector.text))
+    _ResetVector_text_end = ABSOLUTE(.);
+  } >vector_reset_text :vector_reset_text_phdr
+
+  .ResetVector.literal : ALIGN(4)
+  {
+    _ResetVector_literal_start = ABSOLUTE(.);
+    *(.ResetVector.literal)
+    _ResetVector_literal_end = ABSOLUTE(.);
+  } >vector_reset_lit :vector_reset_lit_phdr
+
+  .WindowVectors.text : ALIGN(4)
+  {
+    _WindowVectors_text_start = ABSOLUTE(.);
+    KEEP (*(.WindowVectors.text))
+    _WindowVectors_text_end = ABSOLUTE(.);
+  } >vector_base_text :vector_base_text_phdr
+
+  .Level2InterruptVector.literal : ALIGN(4)
+  {
+    _Level2InterruptVector_literal_start = ABSOLUTE(.);
+    *(.Level2InterruptVector.literal)
+    _Level2InterruptVector_literal_end = ABSOLUTE(.);
+  } >vector_int2_lit :vector_int2_lit_phdr
+
+  .Level2InterruptVector.text : ALIGN(4)
+  {
+    _Level2InterruptVector_text_start = ABSOLUTE(.);
+    KEEP (*(.Level2InterruptVector.text))
+    _Level2InterruptVector_text_end = ABSOLUTE(.);
+  } >vector_int2_text :vector_int2_text_phdr
+
+  .Level3InterruptVector.literal : ALIGN(4)
+  {
+    _Level3InterruptVector_literal_start = ABSOLUTE(.);
+    *(.Level3InterruptVector.literal)
+    _Level3InterruptVector_literal_end = ABSOLUTE(.);
+  } >vector_int3_lit :vector_int3_lit_phdr
+
+  .Level3InterruptVector.text : ALIGN(4)
+  {
+    _Level3InterruptVector_text_start = ABSOLUTE(.);
+    KEEP (*(.Level3InterruptVector.text))
+    _Level3InterruptVector_text_end = ABSOLUTE(.);
+  } >vector_int3_text :vector_int3_text_phdr
+
+  .DebugExceptionVector.literal : ALIGN(4)
+  {
+    _DebugExceptionVector_literal_start = ABSOLUTE(.);
+    *(.DebugExceptionVector.literal)
+    _DebugExceptionVector_literal_end = ABSOLUTE(.);
+  } >vector_int4_lit :vector_int4_lit_phdr
+
+  .DebugExceptionVector.text : ALIGN(4)
+  {
+    _DebugExceptionVector_text_start = ABSOLUTE(.);
+    KEEP (*(.DebugExceptionVector.text))
+    _DebugExceptionVector_text_end = ABSOLUTE(.);
+  } >vector_int4_text :vector_int4_text_phdr
+
+  .NMIExceptionVector.literal : ALIGN(4)
+  {
+    _NMIExceptionVector_literal_start = ABSOLUTE(.);
+    *(.NMIExceptionVector.literal)
+    _NMIExceptionVector_literal_end = ABSOLUTE(.);
+  } >vector_int5_lit :vector_int5_lit_phdr
+
+  .NMIExceptionVector.text : ALIGN(4)
+  {
+    _NMIExceptionVector_text_start = ABSOLUTE(.);
+    KEEP (*(.NMIExceptionVector.text))
+    _NMIExceptionVector_text_end = ABSOLUTE(.);
+  } >vector_int5_text :vector_int5_text_phdr
+
+  .KernelExceptionVector.literal : ALIGN(4)
+  {
+    _KernelExceptionVector_literal_start = ABSOLUTE(.);
+    *(.KernelExceptionVector.literal)
+    _KernelExceptionVector_literal_end = ABSOLUTE(.);
+  } >vector_kernel_lit :vector_kernel_lit_phdr
+
+  .KernelExceptionVector.text : ALIGN(4)
+  {
+    _KernelExceptionVector_text_start = ABSOLUTE(.);
+    KEEP (*(.KernelExceptionVector.text))
+    _KernelExceptionVector_text_end = ABSOLUTE(.);
+  } >vector_kernel_text :vector_kernel_text_phdr
+
+  .UserExceptionVector.literal : ALIGN(4)
+  {
+    _UserExceptionVector_literal_start = ABSOLUTE(.);
+    *(.UserExceptionVector.literal)
+    _UserExceptionVector_literal_end = ABSOLUTE(.);
+  } >vector_user_lit :vector_user_lit_phdr
+
+  .UserExceptionVector.text : ALIGN(4)
+  {
+    _UserExceptionVector_text_start = ABSOLUTE(.);
+    KEEP (*(.UserExceptionVector.text))
+    _UserExceptionVector_text_end = ABSOLUTE(.);
+  } >vector_user_text :vector_user_text_phdr
+
+  .DoubleExceptionVector.literal : ALIGN(4)
+  {
+    _DoubleExceptionVector_literal_start = ABSOLUTE(.);
+    *(.DoubleExceptionVector.literal)
+    _DoubleExceptionVector_literal_end = ABSOLUTE(.);
+  } >vector_double_lit :vector_double_lit_phdr
+
+  .DoubleExceptionVector.text : ALIGN(4)
+  {
+    _DoubleExceptionVector_text_start = ABSOLUTE(.);
+    KEEP (*(.DoubleExceptionVector.text))
+    _DoubleExceptionVector_text_end = ABSOLUTE(.);
+  } >vector_double_text :vector_double_text_phdr
+
+  .iram.text : ALIGN(4)
+  {
+    _stext = .;
+    _iram_text_start = ABSOLUTE(.);
+    *(.iram0.literal .iram.literal .iram.text.literal .iram0.text .iram.text)
+    _iram_text_end = ABSOLUTE(.);
+  } >sof_iram_text_start :sof_iram_text_start_phdr
+
+  .rodata : ALIGN(4)
+  {
+    _rodata_start = ABSOLUTE(.);
+    *(.rodata)
+    *(.rodata.*)
+    *(.gnu.linkonce.r.*)
+    *(.rodata1)
+    __XT_EXCEPTION_TABLE__ = ABSOLUTE(.);
+    KEEP (*(.xt_except_table))
+    KEEP (*(.gcc_except_table))
+    *(.gnu.linkonce.e.*)
+    *(.gnu.version_r)
+    KEEP (*(.eh_frame))
+    /*  C++ constructor and destructor tables, properly ordered:  */
+    KEEP (*crtbegin.o(.ctors))
+    KEEP (*(EXCLUDE_FILE (*crtend.o) .ctors))
+    KEEP (*(SORT(.ctors.*)))
+    KEEP (*(.ctors))
+    KEEP (*crtbegin.o(.dtors))
+    KEEP (*(EXCLUDE_FILE (*crtend.o) .dtors))
+    KEEP (*(SORT(.dtors.*)))
+    KEEP (*(.dtors))
+    /*  C++ exception handlers table:  */
+    __XT_EXCEPTION_DESCS__ = ABSOLUTE(.);
+    *(.xt_except_desc)
+    *(.gnu.linkonce.h.*)
+    __XT_EXCEPTION_DESCS_END__ = ABSOLUTE(.);
+    *(.xt_except_desc_end)
+    *(.dynamic)
+    *(.gnu.version_d)
+    . = ALIGN(4);		/* this table MUST be 4-byte aligned */
+    _bss_table_start = ABSOLUTE(.);
+    LONG(_bss_start)
+    LONG(_bss_end)
+    _bss_table_end = ABSOLUTE(.);
+    _rodata_end = ABSOLUTE(.);
+  } >sof_sdram0 :sof_sdram0_phdr
+
+  .module_init : ALIGN(4)
+  {
+   _module_init_start = ABSOLUTE(.);
+    *(*.module_init)
+    _module_init_end = ABSOLUTE(.);
+  } >sof_sdram0 :sof_sdram0_phdr
+
+  .text : ALIGN(4)
+  {
+    _stext = .;
+    _text_start = ABSOLUTE(.);
+    *(.entry.text)
+    *(.init.literal)
+    KEEP(*(.init))
+    *(.literal .text .literal.* .text.* .stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.*)
+    *(.fini.literal)
+    KEEP(*(.fini))
+    *(.gnu.version)
+    _text_end = ABSOLUTE(.);
+    _etext = .;
+  } >sof_sdram0 :sof_sdram0_phdr
+
+  .reset.rodata : ALIGN(4)
+  {
+    _reset_rodata_start = ABSOLUTE(.);
+    *(.reset.rodata)
+    _reset_rodata_end = ABSOLUTE(.);
+  } >sof_sdram0 :sof_sdram0_phdr
+
+
+  .data : ALIGN(4)
+  {
+    _data_start = ABSOLUTE(.);
+    *(.data)
+    *(.data.*)
+    *(.gnu.linkonce.d.*)
+    KEEP(*(.gnu.linkonce.d.*personality*))
+    *(.data1)
+    *(.sdata)
+    *(.sdata.*)
+    *(.gnu.linkonce.s.*)
+    *(.sdata2)
+    *(.sdata2.*)
+    *(.gnu.linkonce.s2.*)
+    KEEP(*(.jcr))
+    _data_end = ABSOLUTE(.);
+  } >sof_sdram0 :sof_sdram0_phdr
+
+  .lit4 : ALIGN(4)
+  {
+    _lit4_start = ABSOLUTE(.);
+    *(*.lit4)
+    *(.lit4.*)
+    *(.gnu.linkonce.lit4.*)
+    _lit4_end = ABSOLUTE(.);
+  } >sof_sdram0 :sof_sdram0_phdr
+
+  .bss (NOLOAD) : ALIGN(8)
+  {
+    . = ALIGN (8);
+    _bss_start = ABSOLUTE(.);
+    *(.dynsbss)
+    *(.sbss)
+    *(.sbss.*)
+    *(.gnu.linkonce.sb.*)
+    *(.scommon)
+    *(.sbss2)
+    *(.sbss2.*)
+    *(.gnu.linkonce.sb2.*)
+    *(.dynbss)
+    *(.bss)
+    *(.bss.*)
+    *(.gnu.linkonce.b.*)
+    *(COMMON)
+    . = ALIGN (8);
+    _bss_end = ABSOLUTE(.);
+  } >sof_sdram0 :sof_sdram0_phdr
+
+  /* stack */
+  _end = SOF_STACK_END;
+  PROVIDE(end = SOF_STACK_END);
+  _stack_sentry = SOF_STACK_END;
+  __stack = SOF_STACK_BASE;
+
+  .debug  0 :  { *(.debug) }
+  .line  0 :  { *(.line) }
+  .debug_srcinfo  0 :  { *(.debug_srcinfo) }
+  .debug_sfnames  0 :  { *(.debug_sfnames) }
+  .debug_aranges  0 :  { *(.debug_aranges) }
+  .debug_pubnames  0 :  { *(.debug_pubnames) }
+  .debug_info  0 :  { *(.debug_info) }
+  .debug_abbrev  0 :  { *(.debug_abbrev) }
+  .debug_line  0 :  { *(.debug_line) }
+  .debug_frame  0 :  { *(.debug_frame) }
+  .debug_str  0 :  { *(.debug_str) }
+  .debug_loc  0 :  { *(.debug_loc) }
+  .debug_macinfo  0 :  { *(.debug_macinfo) }
+  .debug_weaknames  0 :  { *(.debug_weaknames) }
+  .debug_funcnames  0 :  { *(.debug_funcnames) }
+  .debug_typenames  0 :  { *(.debug_typenames) }
+  .debug_varnames  0 :  { *(.debug_varnames) }
+
+  .xt.insn 0 :
+  {
+    KEEP (*(.xt.insn))
+    KEEP (*(.gnu.linkonce.x.*))
+  }
+  .xt.prop 0 :
+  {
+    KEEP (*(.xt.prop))
+    KEEP (*(.xt.prop.*))
+    KEEP (*(.gnu.linkonce.prop.*))
+  }
+  .xt.lit 0 :
+  {
+    KEEP (*(.xt.lit))
+    KEEP (*(.xt.lit.*))
+    KEEP (*(.gnu.linkonce.p.*))
+  }
+  .xt.profile_range 0 :
+  {
+    KEEP (*(.xt.profile_range))
+    KEEP (*(.gnu.linkonce.profile_range.*))
+  }
+  .xt.profile_ranges 0 :
+  {
+    KEEP (*(.xt.profile_ranges))
+    KEEP (*(.gnu.linkonce.xt.profile_ranges.*))
+  }
+  .xt.profile_files 0 :
+  {
+    KEEP (*(.xt.profile_files))
+    KEEP (*(.gnu.linkonce.xt.profile_files.*))
+  }
+
+  .system_heap (NOLOAD) : ALIGN(8)
+  {
+    . = ALIGN (32);
+    _system_heap_start = ABSOLUTE(.);
+    . = . + HEAP_SYSTEM_SIZE;
+    _system_heap_end = ABSOLUTE(.);
+  } >system_heap :system_heap_phdr
+
+  .system_runtime_heap (NOLOAD) : ALIGN(8)
+  {
+    . = ALIGN (32);
+    _system_runtime_heap_start = ABSOLUTE(.);
+    . = . + HEAP_SYS_RUNTIME_SIZE;
+    _system_runtime_heap_end = ABSOLUTE(.);
+  } >system_runtime_heap :system_runtime_heap_phdr
+
+  .runtime_heap (NOLOAD) : ALIGN(8)
+  {
+    . = ALIGN (32);
+    _runtime_heap_start = ABSOLUTE(.);
+    . = . + HEAP_RUNTIME_SIZE;
+    _runtime_heap_end = ABSOLUTE(.);
+  } >runtime_heap :runtime_heap_phdr
+
+  .buffer_heap (NOLOAD) : ALIGN(8)
+  {
+    . = ALIGN (32);
+    _system_heap_start = ABSOLUTE(.);
+    . = . + HEAP_BUFFER_SIZE;
+    _system_heap_end = ABSOLUTE(.);
+  } >buffer_heap :buffer_heap_phdr
+
+  .sof_stack (NOLOAD) : ALIGN(8)
+  {
+    . = ALIGN (4096);
+    _sof_stack_start = ABSOLUTE(.);
+    . = . + SOF_STACK_TOTAL_SIZE;
+    _sof_stack_end = ABSOLUTE(.);
+  } >sof_stack :sof_stack_phdr
+
+  .static_log_entries (COPY) : ALIGN(1024)
+  {
+    *(*.static_log*)
+  } > static_log_entries_seg :static_log_entries_phdr
+
+  .fw_ready : ALIGN(4)
+  {
+    KEEP (*(.fw_ready))
+  } >sof_sdram0 :sof_sdram0_phdr
+}

--- a/src/platform/imx8/include/arch/xtensa/config/core-isa.h
+++ b/src/platform/imx8/include/arch/xtensa/config/core-isa.h
@@ -1,0 +1,633 @@
+/* 
+ * xtensa/config/core-isa.h -- HAL definitions that are dependent on Xtensa
+ *				processor CORE configuration
+ *
+ *  See <xtensa/config/core.h>, which includes this file, for more details.
+ */
+
+/* Xtensa processor core configuration information.
+
+   Customer ID=12445; Build=0x700c0; Copyright (c) 1999-2017 Tensilica Inc.
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+   IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+   CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+   TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
+
+#if !defined __XCC__
+
+#ifndef _XTENSA_CORE_CONFIGURATION_H
+#define _XTENSA_CORE_CONFIGURATION_H
+
+
+/****************************************************************************
+	    Parameters Useful for Any Code, USER or PRIVILEGED
+ ****************************************************************************/
+
+/*
+ *  Note:  Macros of the form XCHAL_HAVE_*** have a value of 1 if the option is
+ *  configured, and a value of 0 otherwise.  These macros are always defined.
+ */
+
+
+/*----------------------------------------------------------------------
+				ISA
+  ----------------------------------------------------------------------*/
+
+#define XCHAL_HAVE_BE			0	/* big-endian byte ordering */
+#define XCHAL_HAVE_WINDOWED		1	/* windowed registers option */
+#define XCHAL_NUM_AREGS			32	/* num of physical addr regs */
+#define XCHAL_NUM_AREGS_LOG2		5	/* log2(XCHAL_NUM_AREGS) */
+#define XCHAL_MAX_INSTRUCTION_SIZE	11	/* max instr bytes (3..8) */
+#define XCHAL_HAVE_DEBUG		1	/* debug option */
+#define XCHAL_HAVE_DENSITY		1	/* 16-bit instructions */
+#define XCHAL_HAVE_LOOPS		1	/* zero-overhead loops */
+#define XCHAL_LOOP_BUFFER_SIZE		0	/* zero-ov. loop instr buffer size */
+#define XCHAL_HAVE_NSA			1	/* NSA/NSAU instructions */
+#define XCHAL_HAVE_MINMAX		1	/* MIN/MAX instructions */
+#define XCHAL_HAVE_SEXT			1	/* SEXT instruction */
+#define XCHAL_HAVE_DEPBITS		0	/* DEPBITS instruction */
+#define XCHAL_HAVE_CLAMPS		1	/* CLAMPS instruction */
+#define XCHAL_HAVE_MUL16		1	/* MUL16S/MUL16U instructions */
+#define XCHAL_HAVE_MUL32		1	/* MULL instruction */
+#define XCHAL_HAVE_MUL32_HIGH		1	/* MULUH/MULSH instructions */
+#define XCHAL_HAVE_DIV32		1	/* QUOS/QUOU/REMS/REMU instructions */
+#define XCHAL_HAVE_L32R			1	/* L32R instruction */
+#define XCHAL_HAVE_ABSOLUTE_LITERALS	0	/* non-PC-rel (extended) L32R */
+#define XCHAL_HAVE_CONST16		0	/* CONST16 instruction */
+#define XCHAL_HAVE_ADDX			1	/* ADDX#/SUBX# instructions */
+#define XCHAL_HAVE_WIDE_BRANCHES	0	/* B*.W18 or B*.W15 instr's */
+#define XCHAL_HAVE_PREDICTED_BRANCHES	0	/* B[EQ/EQZ/NE/NEZ]T instr's */
+#define XCHAL_HAVE_CALL4AND12		1	/* (obsolete option) */
+#define XCHAL_HAVE_ABS			1	/* ABS instruction */
+/*#define XCHAL_HAVE_POPC		0*/	/* POPC instruction */
+/*#define XCHAL_HAVE_CRC		0*/	/* CRC instruction */
+#define XCHAL_HAVE_RELEASE_SYNC		1	/* L32AI/S32RI instructions */
+#define XCHAL_HAVE_S32C1I		1	/* S32C1I instruction */
+#define XCHAL_HAVE_SPECULATION		0	/* speculation */
+#define XCHAL_HAVE_FULL_RESET		1	/* all regs/state reset */
+#define XCHAL_NUM_CONTEXTS		1	/* */
+#define XCHAL_NUM_MISC_REGS		2	/* num of scratch regs (0..4) */
+#define XCHAL_HAVE_TAP_MASTER		0	/* JTAG TAP control instr's */
+#define XCHAL_HAVE_PRID			1	/* processor ID register */
+#define XCHAL_HAVE_EXTERN_REGS		1	/* WER/RER instructions */
+#define XCHAL_HAVE_MX			0	/* MX core (Tensilica internal) */
+#define XCHAL_HAVE_MP_INTERRUPTS	0	/* interrupt distributor port */
+#define XCHAL_HAVE_MP_RUNSTALL		0	/* core RunStall control port */
+#define XCHAL_HAVE_PSO			0	/* Power Shut-Off */
+#define XCHAL_HAVE_PSO_CDM		0	/* core/debug/mem pwr domains */
+#define XCHAL_HAVE_PSO_FULL_RETENTION	0	/* all regs preserved on PSO */
+#define XCHAL_HAVE_THREADPTR		1	/* THREADPTR register */
+#define XCHAL_HAVE_BOOLEANS		1	/* boolean registers */
+#define XCHAL_HAVE_CP			1	/* CPENABLE reg (coprocessor) */
+#define XCHAL_CP_MAXCFG			2	/* max allowed cp id plus one */
+#define XCHAL_HAVE_MAC16		0	/* MAC16 package */
+
+#define XCHAL_HAVE_FUSION		 0	/* Fusion*/
+#define XCHAL_HAVE_FUSION_FP	 0	        /* Fusion FP option */
+#define XCHAL_HAVE_FUSION_LOW_POWER 0	/* Fusion Low Power option */
+#define XCHAL_HAVE_FUSION_AES	 0	        /* Fusion BLE/Wifi AES-128 CCM option */
+#define XCHAL_HAVE_FUSION_CONVENC	 0       /* Fusion Conv Encode option */
+#define XCHAL_HAVE_FUSION_LFSR_CRC	 0	/* Fusion LFSR-CRC option */
+#define XCHAL_HAVE_FUSION_BITOPS	 0	/* Fusion Bit Operations Support option */
+#define XCHAL_HAVE_FUSION_AVS	 0	/* Fusion AVS option */
+#define XCHAL_HAVE_FUSION_16BIT_BASEBAND	 0	/* Fusion 16-bit Baseband option */
+#define XCHAL_HAVE_FUSION_VITERBI        0     /* Fusion Viterbi option */
+#define XCHAL_HAVE_FUSION_SOFTDEMAP      0   /* Fusion Soft Bit Demap option */
+#define XCHAL_HAVE_HIFIPRO		0	/* HiFiPro Audio Engine pkg */
+#define XCHAL_HAVE_HIFI4		1	/* HiFi4 Audio Engine pkg */
+#define XCHAL_HAVE_HIFI4_VFPU		1	/* HiFi4 Audio Engine VFPU option */
+#define XCHAL_HAVE_HIFI3		1	/* HiFi3 Audio Engine pkg */
+#define XCHAL_HAVE_HIFI3_VFPU		0	/* HiFi3 Audio Engine VFPU option */
+#define XCHAL_HAVE_HIFI2		0	/* HiFi2 Audio Engine pkg */
+#define XCHAL_HAVE_HIFI2EP		0	/* HiFi2EP */
+#define XCHAL_HAVE_HIFI_MINI		0	
+
+
+#define XCHAL_HAVE_VECTORFPU2005	1	/* vector or user floating-point pkg */
+#define XCHAL_HAVE_USER_DPFPU         0       /* user DP floating-point pkg */
+#define XCHAL_HAVE_USER_SPFPU         1       /* user DP floating-point pkg */
+#define XCHAL_HAVE_FP                 1      /* single prec floating point */
+#define XCHAL_HAVE_FP_DIV             1  /* FP with DIV instructions */
+#define XCHAL_HAVE_FP_RECIP           1        /* FP with RECIP instructions */
+#define XCHAL_HAVE_FP_SQRT            1 /* FP with SQRT instructions */
+#define XCHAL_HAVE_FP_RSQRT           1        /* FP with RSQRT instructions */
+#define XCHAL_HAVE_DFP                        0     /* double precision FP pkg */
+#define XCHAL_HAVE_DFP_DIV            0 /* DFP with DIV instructions */
+#define XCHAL_HAVE_DFP_RECIP          0       /* DFP with RECIP instructions*/
+#define XCHAL_HAVE_DFP_SQRT           0        /* DFP with SQRT instructions */
+#define XCHAL_HAVE_DFP_RSQRT          0       /* DFP with RSQRT instructions*/
+#define XCHAL_HAVE_DFP_ACCEL		0	/* double precision FP acceleration pkg */
+#define XCHAL_HAVE_DFP_accel		XCHAL_HAVE_DFP_ACCEL				/* for backward compatibility */
+
+#define XCHAL_HAVE_DFPU_SINGLE_ONLY    0                 	/* DFPU Coprocessor, single precision only */
+#define XCHAL_HAVE_DFPU_SINGLE_DOUBLE  0               	/* DFPU Coprocessor, single and double precision */
+#define XCHAL_HAVE_VECTRA1		0	/* Vectra I  pkg */
+#define XCHAL_HAVE_VECTRALX		0	/* Vectra LX pkg */
+#define XCHAL_HAVE_PDX4		        0	/* PDX4 */
+#define XCHAL_HAVE_CONNXD2		0	/* ConnX D2 pkg */
+#define XCHAL_HAVE_CONNXD2_DUALLSFLIX   0	/* ConnX D2 & Dual LoadStore Flix */
+#define XCHAL_HAVE_BBE16		0	/* ConnX BBE16 pkg */
+#define XCHAL_HAVE_BBE16_RSQRT		0	/* BBE16 & vector recip sqrt */
+#define XCHAL_HAVE_BBE16_VECDIV		0	/* BBE16 & vector divide */
+#define XCHAL_HAVE_BBE16_DESPREAD	0	/* BBE16 & despread */
+#define XCHAL_HAVE_BBENEP		0	/* ConnX BBENEP pkgs */
+#define XCHAL_HAVE_BSP3			0	/* ConnX BSP3 pkg */
+#define XCHAL_HAVE_BSP3_TRANSPOSE	0	/* BSP3 & transpose32x32 */
+#define XCHAL_HAVE_SSP16		0	/* ConnX SSP16 pkg */
+#define XCHAL_HAVE_SSP16_VITERBI	0	/* SSP16 & viterbi */
+#define XCHAL_HAVE_TURBO16		0	/* ConnX Turbo16 pkg */
+#define XCHAL_HAVE_BBP16		0	/* ConnX BBP16 pkg */
+#define XCHAL_HAVE_FLIX3		0	/* basic 3-way FLIX option */
+#define XCHAL_HAVE_GRIVPEP              0   /*  GRIVPEP is General Release of IVPEP */
+#define XCHAL_HAVE_GRIVPEP_HISTOGRAM    0   /* Histogram option on GRIVPEP */
+
+
+/*----------------------------------------------------------------------
+				MISC
+  ----------------------------------------------------------------------*/
+
+#define XCHAL_NUM_LOADSTORE_UNITS	2	/* load/store units */
+#define XCHAL_NUM_WRITEBUFFER_ENTRIES	16	/* size of write buffer */
+#define XCHAL_INST_FETCH_WIDTH		16	/* instr-fetch width in bytes */
+#define XCHAL_DATA_WIDTH		16	/* data width in bytes */
+#define XCHAL_DATA_PIPE_DELAY		2	/* d-side pipeline delay
+						   (1 = 5-stage, 2 = 7-stage) */
+#define XCHAL_CLOCK_GATING_GLOBAL	1	/* global clock gating */
+#define XCHAL_CLOCK_GATING_FUNCUNIT	1	/* funct. unit clock gating */
+/*  In T1050, applies to selected core load and store instructions (see ISA): */
+#define XCHAL_UNALIGNED_LOAD_EXCEPTION	1	/* unaligned loads cause exc. */
+#define XCHAL_UNALIGNED_STORE_EXCEPTION	1	/* unaligned stores cause exc.*/
+#define XCHAL_UNALIGNED_LOAD_HW		0	/* unaligned loads work in hw */
+#define XCHAL_UNALIGNED_STORE_HW	0	/* unaligned stores work in hw*/
+
+#define XCHAL_SW_VERSION		1100004	/* sw version of this header */
+
+#define XCHAL_CORE_ID			"hifi4_nxp_v3_3_1_2_dev"	/* alphanum core name
+						   (CoreID) set in the Xtensa
+						   Processor Generator */
+
+#define XCHAL_BUILD_UNIQUE_ID		0x000700C0	/* 22-bit sw build ID */
+
+/*
+ *  These definitions describe the hardware targeted by this software.
+ */
+#define XCHAL_HW_CONFIGID0		0xC2B3FBFE	/* ConfigID hi 32 bits*/
+#define XCHAL_HW_CONFIGID1		0x1D0700C0	/* ConfigID lo 32 bits*/
+#define XCHAL_HW_VERSION_NAME		"LX6.0.4"	/* full version name */
+#define XCHAL_HW_VERSION_MAJOR		2600	/* major ver# of targeted hw */
+#define XCHAL_HW_VERSION_MINOR		4	/* minor ver# of targeted hw */
+#define XCHAL_HW_VERSION		260004	/* major*100+minor */
+#define XCHAL_HW_REL_LX6		1
+#define XCHAL_HW_REL_LX6_0		1
+#define XCHAL_HW_REL_LX6_0_4		1
+#define XCHAL_HW_CONFIGID_RELIABLE	1
+/*  If software targets a *range* of hardware versions, these are the bounds: */
+#define XCHAL_HW_MIN_VERSION_MAJOR	2600	/* major v of earliest tgt hw */
+#define XCHAL_HW_MIN_VERSION_MINOR	4	/* minor v of earliest tgt hw */
+#define XCHAL_HW_MIN_VERSION		260004	/* earliest targeted hw */
+#define XCHAL_HW_MAX_VERSION_MAJOR	2600	/* major v of latest tgt hw */
+#define XCHAL_HW_MAX_VERSION_MINOR	4	/* minor v of latest tgt hw */
+#define XCHAL_HW_MAX_VERSION		260004	/* latest targeted hw */
+
+
+/*----------------------------------------------------------------------
+				CACHE
+  ----------------------------------------------------------------------*/
+
+#define XCHAL_ICACHE_LINESIZE		128	/* I-cache line size in bytes */
+#define XCHAL_DCACHE_LINESIZE		128	/* D-cache line size in bytes */
+#define XCHAL_ICACHE_LINEWIDTH		7	/* log2(I line size in bytes) */
+#define XCHAL_DCACHE_LINEWIDTH		7	/* log2(D line size in bytes) */
+
+#define XCHAL_ICACHE_SIZE		32768	/* I-cache size in bytes or 0 */
+#define XCHAL_DCACHE_SIZE		49152	/* D-cache size in bytes or 0 */
+
+#define XCHAL_DCACHE_IS_WRITEBACK	1	/* writeback feature */
+#define XCHAL_DCACHE_IS_COHERENT	0	/* MP coherence feature */
+
+#define XCHAL_HAVE_PREFETCH		1	/* PREFCTL register */
+#define XCHAL_HAVE_PREFETCH_L1		1	/* prefetch to L1 dcache */
+#define XCHAL_PREFETCH_CASTOUT_LINES	1	/* dcache pref. castout bufsz */
+#define XCHAL_PREFETCH_ENTRIES		16	/* cache prefetch entries */
+#define XCHAL_PREFETCH_BLOCK_ENTRIES	8	/* prefetch block streams */
+#define XCHAL_HAVE_CACHE_BLOCKOPS	1	/* block prefetch for caches */
+#define XCHAL_HAVE_ICACHE_TEST		1	/* Icache test instructions */
+#define XCHAL_HAVE_DCACHE_TEST		1	/* Dcache test instructions */
+#define XCHAL_HAVE_ICACHE_DYN_WAYS	0	/* Icache dynamic way support */
+#define XCHAL_HAVE_DCACHE_DYN_WAYS	0	/* Dcache dynamic way support */
+
+
+
+
+/****************************************************************************
+    Parameters Useful for PRIVILEGED (Supervisory or Non-Virtualized) Code
+ ****************************************************************************/
+
+
+#ifndef XTENSA_HAL_NON_PRIVILEGED_ONLY
+
+/*----------------------------------------------------------------------
+				CACHE
+  ----------------------------------------------------------------------*/
+
+#define XCHAL_HAVE_PIF			1	/* any outbound PIF present */
+#define XCHAL_HAVE_AXI			1	/* AXI bus */
+
+#define XCHAL_HAVE_PIF_WR_RESP			1	/* pif write response */
+#define XCHAL_HAVE_PIF_REQ_ATTR			1	/* pif attribute */
+
+/*  If present, cache size in bytes == (ways * 2^(linewidth + setwidth)).  */
+
+/*  Number of cache sets in log2(lines per way):  */
+#define XCHAL_ICACHE_SETWIDTH		7
+#define XCHAL_DCACHE_SETWIDTH		7
+
+/*  Cache set associativity (number of ways):  */
+#define XCHAL_ICACHE_WAYS		2
+#define XCHAL_DCACHE_WAYS		3
+
+/*  Cache features:  */
+#define XCHAL_ICACHE_LINE_LOCKABLE	1
+#define XCHAL_DCACHE_LINE_LOCKABLE	1
+#define XCHAL_ICACHE_ECC_PARITY		0
+#define XCHAL_DCACHE_ECC_PARITY		0
+
+/*  Cache access size in bytes (affects operation of SICW instruction):  */
+#define XCHAL_ICACHE_ACCESS_SIZE	16
+#define XCHAL_DCACHE_ACCESS_SIZE	16
+
+#define XCHAL_DCACHE_BANKS		2	/* number of banks */
+
+/*  Number of encoded cache attr bits (see <xtensa/hal.h> for decoded bits):  */
+#define XCHAL_CA_BITS			4
+
+
+/*----------------------------------------------------------------------
+			INTERNAL I/D RAM/ROMs and XLMI
+  ----------------------------------------------------------------------*/
+
+#define XCHAL_NUM_INSTROM		0	/* number of core instr. ROMs */
+#define XCHAL_NUM_INSTRAM		1	/* number of core instr. RAMs */
+#define XCHAL_NUM_DATAROM		0	/* number of core data ROMs */
+#define XCHAL_NUM_DATARAM		2	/* number of core data RAMs */
+#define XCHAL_NUM_URAM			0	/* number of core unified RAMs*/
+#define XCHAL_NUM_XLMI			0	/* number of core XLMI ports */
+
+/*  Instruction RAM 0:  */
+#define XCHAL_INSTRAM0_VADDR		0x596F8000	/* virtual address */
+#define XCHAL_INSTRAM0_PADDR		0x596F8000	/* physical address */
+#define XCHAL_INSTRAM0_SIZE		2048	/* size in bytes */
+#define XCHAL_INSTRAM0_ECC_PARITY	0	/* ECC/parity type, 0=none */
+
+/*  Data RAM 0:  */
+#define XCHAL_DATARAM0_VADDR		0x596E8000	/* virtual address */
+#define XCHAL_DATARAM0_PADDR		0x596E8000	/* physical address */
+#define XCHAL_DATARAM0_SIZE		32768	/* size in bytes */
+#define XCHAL_DATARAM0_ECC_PARITY	0	/* ECC/parity type, 0=none */
+#define XCHAL_DATARAM0_BANKS		1	/* number of banks */
+
+/*  Data RAM 1:  */
+#define XCHAL_DATARAM1_VADDR		0x596F0000	/* virtual address */
+#define XCHAL_DATARAM1_PADDR		0x596F0000	/* physical address */
+#define XCHAL_DATARAM1_SIZE		32768	/* size in bytes */
+#define XCHAL_DATARAM1_ECC_PARITY	0	/* ECC/parity type, 0=none */
+#define XCHAL_DATARAM1_BANKS		1	/* number of banks */
+
+#define XCHAL_HAVE_IMEM_LOADSTORE	1	/* can load/store to IROM/IRAM*/
+
+
+/*----------------------------------------------------------------------
+			INTERRUPTS and TIMERS
+  ----------------------------------------------------------------------*/
+
+#define XCHAL_HAVE_INTERRUPTS		1	/* interrupt option */
+#define XCHAL_HAVE_HIGHPRI_INTERRUPTS	1	/* med/high-pri. interrupts */
+#define XCHAL_HAVE_NMI			1	/* non-maskable interrupt */
+#define XCHAL_HAVE_CCOUNT		1	/* CCOUNT reg. (timer option) */
+#define XCHAL_NUM_TIMERS		2	/* number of CCOMPAREn regs */
+#define XCHAL_NUM_INTERRUPTS		32	/* number of interrupts */
+#define XCHAL_NUM_INTERRUPTS_LOG2	5	/* ceil(log2(NUM_INTERRUPTS)) */
+#define XCHAL_NUM_EXTINTERRUPTS		26	/* num of external interrupts */
+#define XCHAL_NUM_INTLEVELS		4	/* number of interrupt levels
+						   (not including level zero) */
+#define XCHAL_EXCM_LEVEL		2	/* level masked by PS.EXCM */
+	/* (always 1 in XEA1; levels 2 .. EXCM_LEVEL are "medium priority") */
+
+/*  Masks of interrupts at each interrupt level:  */
+#define XCHAL_INTLEVEL1_MASK		0x00000100
+#define XCHAL_INTLEVEL2_MASK		0x7FFFFEF4
+#define XCHAL_INTLEVEL3_MASK		0x8000000A
+#define XCHAL_INTLEVEL4_MASK		0x00000000
+#define XCHAL_INTLEVEL5_MASK		0x00000001
+#define XCHAL_INTLEVEL6_MASK		0x00000000
+#define XCHAL_INTLEVEL7_MASK		0x00000000
+
+/*  Masks of interrupts at each range 1..n of interrupt levels:  */
+#define XCHAL_INTLEVEL1_ANDBELOW_MASK	0x00000100
+#define XCHAL_INTLEVEL2_ANDBELOW_MASK	0x7FFFFFF4
+#define XCHAL_INTLEVEL3_ANDBELOW_MASK	0xFFFFFFFE
+#define XCHAL_INTLEVEL4_ANDBELOW_MASK	0xFFFFFFFE
+#define XCHAL_INTLEVEL5_ANDBELOW_MASK	0xFFFFFFFF
+#define XCHAL_INTLEVEL6_ANDBELOW_MASK	0xFFFFFFFF
+#define XCHAL_INTLEVEL7_ANDBELOW_MASK	0xFFFFFFFF
+
+/*  Level of each interrupt:  */
+#define XCHAL_INT0_LEVEL		5
+#define XCHAL_INT1_LEVEL		3
+#define XCHAL_INT2_LEVEL		2
+#define XCHAL_INT3_LEVEL		3
+#define XCHAL_INT4_LEVEL		2
+#define XCHAL_INT5_LEVEL		2
+#define XCHAL_INT6_LEVEL		2
+#define XCHAL_INT7_LEVEL		2
+#define XCHAL_INT8_LEVEL		1
+#define XCHAL_INT9_LEVEL		2
+#define XCHAL_INT10_LEVEL		2
+#define XCHAL_INT11_LEVEL		2
+#define XCHAL_INT12_LEVEL		2
+#define XCHAL_INT13_LEVEL		2
+#define XCHAL_INT14_LEVEL		2
+#define XCHAL_INT15_LEVEL		2
+#define XCHAL_INT16_LEVEL		2
+#define XCHAL_INT17_LEVEL		2
+#define XCHAL_INT18_LEVEL		2
+#define XCHAL_INT19_LEVEL		2
+#define XCHAL_INT20_LEVEL		2
+#define XCHAL_INT21_LEVEL		2
+#define XCHAL_INT22_LEVEL		2
+#define XCHAL_INT23_LEVEL		2
+#define XCHAL_INT24_LEVEL		2
+#define XCHAL_INT25_LEVEL		2
+#define XCHAL_INT26_LEVEL		2
+#define XCHAL_INT27_LEVEL		2
+#define XCHAL_INT28_LEVEL		2
+#define XCHAL_INT29_LEVEL		2
+#define XCHAL_INT30_LEVEL		2
+#define XCHAL_INT31_LEVEL		3
+#define XCHAL_DEBUGLEVEL		4	/* debug interrupt level */
+#define XCHAL_HAVE_DEBUG_EXTERN_INT	1	/* OCD external db interrupt */
+#define XCHAL_NMILEVEL			5	/* NMI "level" (for use with
+						   EXCSAVE/EPS/EPC_n, RFI n) */
+
+/*  Type of each interrupt:  */
+#define XCHAL_INT0_TYPE 	XTHAL_INTTYPE_NMI
+#define XCHAL_INT1_TYPE 	XTHAL_INTTYPE_EXTERN_EDGE
+#define XCHAL_INT2_TYPE 	XTHAL_INTTYPE_TIMER
+#define XCHAL_INT3_TYPE 	XTHAL_INTTYPE_TIMER
+#define XCHAL_INT4_TYPE 	XTHAL_INTTYPE_EXTERN_EDGE
+#define XCHAL_INT5_TYPE 	XTHAL_INTTYPE_EXTERN_EDGE
+#define XCHAL_INT6_TYPE 	XTHAL_INTTYPE_EXTERN_EDGE
+#define XCHAL_INT7_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT8_TYPE 	XTHAL_INTTYPE_SOFTWARE
+#define XCHAL_INT9_TYPE 	XTHAL_INTTYPE_SOFTWARE
+#define XCHAL_INT10_TYPE 	XTHAL_INTTYPE_WRITE_ERROR
+#define XCHAL_INT11_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT12_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT13_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT14_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT15_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT16_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT17_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT18_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT19_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT20_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT21_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT22_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT23_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT24_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT25_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT26_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT27_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT28_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT29_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT30_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT31_TYPE 	XTHAL_INTTYPE_PROFILING
+
+/*  Masks of interrupts for each type of interrupt:  */
+#define XCHAL_INTTYPE_MASK_UNCONFIGURED	0x00000000
+#define XCHAL_INTTYPE_MASK_SOFTWARE	0x00000300
+#define XCHAL_INTTYPE_MASK_EXTERN_EDGE	0x00000072
+#define XCHAL_INTTYPE_MASK_EXTERN_LEVEL	0x7FFFF880
+#define XCHAL_INTTYPE_MASK_TIMER	0x0000000C
+#define XCHAL_INTTYPE_MASK_NMI		0x00000001
+#define XCHAL_INTTYPE_MASK_WRITE_ERROR	0x00000400
+#define XCHAL_INTTYPE_MASK_PROFILING	0x80000000
+
+/*  Interrupt numbers assigned to specific interrupt sources:  */
+#define XCHAL_TIMER0_INTERRUPT		2	/* CCOMPARE0 */
+#define XCHAL_TIMER1_INTERRUPT		3	/* CCOMPARE1 */
+#define XCHAL_TIMER2_INTERRUPT		XTHAL_TIMER_UNCONFIGURED
+#define XCHAL_TIMER3_INTERRUPT		XTHAL_TIMER_UNCONFIGURED
+#define XCHAL_NMI_INTERRUPT		0	/* non-maskable interrupt */
+#define XCHAL_WRITE_ERROR_INTERRUPT	10	/* write-error interrupt */
+#define XCHAL_PROFILING_INTERRUPT	31	/* profiling interrupt */
+
+/*  Interrupt numbers for levels at which only one interrupt is configured:  */
+#define XCHAL_INTLEVEL1_NUM		8
+#define XCHAL_INTLEVEL5_NUM		0
+/*  (There are many interrupts each at level(s) 2, 3.)  */
+
+
+/*
+ *  External interrupt mapping.
+ *  These macros describe how Xtensa processor interrupt numbers
+ *  (as numbered internally, eg. in INTERRUPT and INTENABLE registers)
+ *  map to external BInterrupt<n> pins, for those interrupts
+ *  configured as external (level-triggered, edge-triggered, or NMI).
+ *  See the Xtensa processor databook for more details.
+ */
+
+/*  Core interrupt numbers mapped to each EXTERNAL BInterrupt pin number:  */
+#define XCHAL_EXTINT0_NUM		0	/* (intlevel 5) */
+#define XCHAL_EXTINT1_NUM		1	/* (intlevel 3) */
+#define XCHAL_EXTINT2_NUM		4	/* (intlevel 2) */
+#define XCHAL_EXTINT3_NUM		5	/* (intlevel 2) */
+#define XCHAL_EXTINT4_NUM		6	/* (intlevel 2) */
+#define XCHAL_EXTINT5_NUM		7	/* (intlevel 2) */
+#define XCHAL_EXTINT6_NUM		11	/* (intlevel 2) */
+#define XCHAL_EXTINT7_NUM		12	/* (intlevel 2) */
+#define XCHAL_EXTINT8_NUM		13	/* (intlevel 2) */
+#define XCHAL_EXTINT9_NUM		14	/* (intlevel 2) */
+#define XCHAL_EXTINT10_NUM		15	/* (intlevel 2) */
+#define XCHAL_EXTINT11_NUM		16	/* (intlevel 2) */
+#define XCHAL_EXTINT12_NUM		17	/* (intlevel 2) */
+#define XCHAL_EXTINT13_NUM		18	/* (intlevel 2) */
+#define XCHAL_EXTINT14_NUM		19	/* (intlevel 2) */
+#define XCHAL_EXTINT15_NUM		20	/* (intlevel 2) */
+#define XCHAL_EXTINT16_NUM		21	/* (intlevel 2) */
+#define XCHAL_EXTINT17_NUM		22	/* (intlevel 2) */
+#define XCHAL_EXTINT18_NUM		23	/* (intlevel 2) */
+#define XCHAL_EXTINT19_NUM		24	/* (intlevel 2) */
+#define XCHAL_EXTINT20_NUM		25	/* (intlevel 2) */
+#define XCHAL_EXTINT21_NUM		26	/* (intlevel 2) */
+#define XCHAL_EXTINT22_NUM		27	/* (intlevel 2) */
+#define XCHAL_EXTINT23_NUM		28	/* (intlevel 2) */
+#define XCHAL_EXTINT24_NUM		29	/* (intlevel 2) */
+#define XCHAL_EXTINT25_NUM		30	/* (intlevel 2) */
+/*  EXTERNAL BInterrupt pin numbers mapped to each core interrupt number:  */
+#define XCHAL_INT0_EXTNUM		0	/* (intlevel 5) */
+#define XCHAL_INT1_EXTNUM		1	/* (intlevel 3) */
+#define XCHAL_INT4_EXTNUM		2	/* (intlevel 2) */
+#define XCHAL_INT5_EXTNUM		3	/* (intlevel 2) */
+#define XCHAL_INT6_EXTNUM		4	/* (intlevel 2) */
+#define XCHAL_INT7_EXTNUM		5	/* (intlevel 2) */
+#define XCHAL_INT11_EXTNUM		6	/* (intlevel 2) */
+#define XCHAL_INT12_EXTNUM		7	/* (intlevel 2) */
+#define XCHAL_INT13_EXTNUM		8	/* (intlevel 2) */
+#define XCHAL_INT14_EXTNUM		9	/* (intlevel 2) */
+#define XCHAL_INT15_EXTNUM		10	/* (intlevel 2) */
+#define XCHAL_INT16_EXTNUM		11	/* (intlevel 2) */
+#define XCHAL_INT17_EXTNUM		12	/* (intlevel 2) */
+#define XCHAL_INT18_EXTNUM		13	/* (intlevel 2) */
+#define XCHAL_INT19_EXTNUM		14	/* (intlevel 2) */
+#define XCHAL_INT20_EXTNUM		15	/* (intlevel 2) */
+#define XCHAL_INT21_EXTNUM		16	/* (intlevel 2) */
+#define XCHAL_INT22_EXTNUM		17	/* (intlevel 2) */
+#define XCHAL_INT23_EXTNUM		18	/* (intlevel 2) */
+#define XCHAL_INT24_EXTNUM		19	/* (intlevel 2) */
+#define XCHAL_INT25_EXTNUM		20	/* (intlevel 2) */
+#define XCHAL_INT26_EXTNUM		21	/* (intlevel 2) */
+#define XCHAL_INT27_EXTNUM		22	/* (intlevel 2) */
+#define XCHAL_INT28_EXTNUM		23	/* (intlevel 2) */
+#define XCHAL_INT29_EXTNUM		24	/* (intlevel 2) */
+#define XCHAL_INT30_EXTNUM		25	/* (intlevel 2) */
+
+
+/*----------------------------------------------------------------------
+			EXCEPTIONS and VECTORS
+  ----------------------------------------------------------------------*/
+
+#define XCHAL_XEA_VERSION		2	/* Xtensa Exception Architecture
+						   number: 1 == XEA1 (old)
+							   2 == XEA2 (new)
+							   0 == XEAX (extern) or TX */
+#define XCHAL_HAVE_XEA1			0	/* Exception Architecture 1 */
+#define XCHAL_HAVE_XEA2			1	/* Exception Architecture 2 */
+#define XCHAL_HAVE_XEAX			0	/* External Exception Arch. */
+#define XCHAL_HAVE_EXCEPTIONS		1	/* exception option */
+#define XCHAL_HAVE_HALT			0	/* halt architecture option */
+#define XCHAL_HAVE_BOOTLOADER		0	/* boot loader (for TX) */
+#define XCHAL_HAVE_MEM_ECC_PARITY	0	/* local memory ECC/parity */
+#define XCHAL_HAVE_VECTOR_SELECT	1	/* relocatable vectors */
+#define XCHAL_HAVE_VECBASE		1	/* relocatable vectors */
+#define XCHAL_VECBASE_RESET_VADDR	0x596F8400  /* VECBASE reset value */
+#define XCHAL_VECBASE_RESET_PADDR	0x596F8400
+#define XCHAL_RESET_VECBASE_OVERLAP	0
+
+#define XCHAL_RESET_VECTOR0_VADDR	0x596F8000
+#define XCHAL_RESET_VECTOR0_PADDR	0x596F8000
+#define XCHAL_RESET_VECTOR1_VADDR	0x596F8660
+#define XCHAL_RESET_VECTOR1_PADDR	0x596F8660
+#define XCHAL_RESET_VECTOR_VADDR	0x596F8000
+#define XCHAL_RESET_VECTOR_PADDR	0x596F8000
+#define XCHAL_USER_VECOFS		0x0000021C
+#define XCHAL_USER_VECTOR_VADDR		0x596F861C
+#define XCHAL_USER_VECTOR_PADDR		0x596F861C
+#define XCHAL_KERNEL_VECOFS		0x000001FC
+#define XCHAL_KERNEL_VECTOR_VADDR	0x596F85FC
+#define XCHAL_KERNEL_VECTOR_PADDR	0x596F85FC
+#define XCHAL_DOUBLEEXC_VECOFS		0x0000023C
+#define XCHAL_DOUBLEEXC_VECTOR_VADDR	0x596F863C
+#define XCHAL_DOUBLEEXC_VECTOR_PADDR	0x596F863C
+#define XCHAL_WINDOW_OF4_VECOFS		0x00000000
+#define XCHAL_WINDOW_UF4_VECOFS		0x00000040
+#define XCHAL_WINDOW_OF8_VECOFS		0x00000080
+#define XCHAL_WINDOW_UF8_VECOFS		0x000000C0
+#define XCHAL_WINDOW_OF12_VECOFS	0x00000100
+#define XCHAL_WINDOW_UF12_VECOFS	0x00000140
+#define XCHAL_WINDOW_VECTORS_VADDR	0x596F8400
+#define XCHAL_WINDOW_VECTORS_PADDR	0x596F8400
+#define XCHAL_INTLEVEL2_VECOFS		0x0000017C
+#define XCHAL_INTLEVEL2_VECTOR_VADDR	0x596F857C
+#define XCHAL_INTLEVEL2_VECTOR_PADDR	0x596F857C
+#define XCHAL_INTLEVEL3_VECOFS		0x0000019C
+#define XCHAL_INTLEVEL3_VECTOR_VADDR	0x596F859C
+#define XCHAL_INTLEVEL3_VECTOR_PADDR	0x596F859C
+#define XCHAL_INTLEVEL4_VECOFS		0x000001BC
+#define XCHAL_INTLEVEL4_VECTOR_VADDR	0x596F85BC
+#define XCHAL_INTLEVEL4_VECTOR_PADDR	0x596F85BC
+#define XCHAL_DEBUG_VECOFS		XCHAL_INTLEVEL4_VECOFS
+#define XCHAL_DEBUG_VECTOR_VADDR	XCHAL_INTLEVEL4_VECTOR_VADDR
+#define XCHAL_DEBUG_VECTOR_PADDR	XCHAL_INTLEVEL4_VECTOR_PADDR
+#define XCHAL_NMI_VECOFS		0x000001DC
+#define XCHAL_NMI_VECTOR_VADDR		0x596F85DC
+#define XCHAL_NMI_VECTOR_PADDR		0x596F85DC
+#define XCHAL_INTLEVEL5_VECOFS		XCHAL_NMI_VECOFS
+#define XCHAL_INTLEVEL5_VECTOR_VADDR	XCHAL_NMI_VECTOR_VADDR
+#define XCHAL_INTLEVEL5_VECTOR_PADDR	XCHAL_NMI_VECTOR_PADDR
+
+
+/*----------------------------------------------------------------------
+				DEBUG MODULE
+  ----------------------------------------------------------------------*/
+
+/*  Misc  */
+#define XCHAL_HAVE_DEBUG_ERI		1	/* ERI to debug module */
+#define XCHAL_HAVE_DEBUG_APB		1	/* APB to debug module */
+#define XCHAL_HAVE_DEBUG_JTAG		1	/* JTAG to debug module */
+
+/*  On-Chip Debug (OCD)  */
+#define XCHAL_HAVE_OCD			1	/* OnChipDebug option */
+#define XCHAL_NUM_IBREAK		2	/* number of IBREAKn regs */
+#define XCHAL_NUM_DBREAK		2	/* number of DBREAKn regs */
+#define XCHAL_HAVE_OCD_DIR_ARRAY	0	/* faster OCD option (to LX4) */
+#define XCHAL_HAVE_OCD_LS32DDR		1	/* L32DDR/S32DDR (faster OCD) */
+
+/*  TRAX (in core)  */
+#define XCHAL_HAVE_TRAX			1	/* TRAX in debug module */
+#define XCHAL_TRAX_MEM_SIZE		512	/* TRAX memory size in bytes */
+#define XCHAL_TRAX_MEM_SHAREABLE	1	/* start/end regs; ready sig. */
+#define XCHAL_TRAX_ATB_WIDTH		32	/* ATB width (bits), 0=no ATB */
+#define XCHAL_TRAX_TIME_WIDTH		0	/* timestamp bitwidth, 0=none */
+
+/*  Perf counters  */
+#define XCHAL_NUM_PERF_COUNTERS		2	/* performance counters */
+
+
+/*----------------------------------------------------------------------
+				MMU
+  ----------------------------------------------------------------------*/
+
+/*  See core-matmap.h header file for more details.  */
+
+#define XCHAL_HAVE_TLBS			1	/* inverse of HAVE_CACHEATTR */
+#define XCHAL_HAVE_SPANNING_WAY		1	/* one way maps I+D 4GB vaddr */
+#define XCHAL_SPANNING_WAY		0	/* TLB spanning way number */
+#define XCHAL_HAVE_IDENTITY_MAP		1	/* vaddr == paddr always */
+#define XCHAL_HAVE_CACHEATTR		0	/* CACHEATTR register present */
+#define XCHAL_HAVE_MIMIC_CACHEATTR	1	/* region protection */
+#define XCHAL_HAVE_XLT_CACHEATTR	0	/* region prot. w/translation */
+#define XCHAL_HAVE_PTP_MMU		0	/* full MMU (with page table
+						   [autorefill] and protection)
+						   usable for an MMU-based OS */
+/*  If none of the above last 4 are set, it's a custom TLB configuration.  */
+
+#define XCHAL_MMU_ASID_BITS		0	/* number of bits in ASIDs */
+#define XCHAL_MMU_RINGS			1	/* number of rings (1..4) */
+#define XCHAL_MMU_RING_BITS		0	/* num of bits in RING field */
+
+#endif /* !XTENSA_HAL_NON_PRIVILEGED_ONLY */
+
+
+#endif /* _XTENSA_CORE_CONFIGURATION_H */
+
+#else
+
+#error "xcc should not use this header"
+
+#endif /* __XCC__ */

--- a/src/platform/imx8/include/arch/xtensa/config/core-matmap.h
+++ b/src/platform/imx8/include/arch/xtensa/config/core-matmap.h
@@ -1,0 +1,314 @@
+/* 
+ * xtensa/config/core-matmap.h -- Memory access and translation mapping
+ *	parameters (CHAL) of the Xtensa processor core configuration.
+ *
+ *  If you are using Xtensa Tools, see <xtensa/config/core.h> (which includes
+ *  this file) for more details.
+ *
+ *  In the Xtensa processor products released to date, all parameters
+ *  defined in this file are derivable (at least in theory) from
+ *  information contained in the core-isa.h header file.
+ *  In particular, the following core configuration parameters are relevant:
+ *	XCHAL_HAVE_CACHEATTR
+ *	XCHAL_HAVE_MIMIC_CACHEATTR
+ *	XCHAL_HAVE_XLT_CACHEATTR
+ *	XCHAL_HAVE_PTP_MMU
+ *	XCHAL_ITLB_ARF_ENTRIES_LOG2
+ *	XCHAL_DTLB_ARF_ENTRIES_LOG2
+ *	XCHAL_DCACHE_IS_WRITEBACK
+ *	XCHAL_ICACHE_SIZE		(presence of I-cache)
+ *	XCHAL_DCACHE_SIZE		(presence of D-cache)
+ *	XCHAL_HW_VERSION_MAJOR
+ *	XCHAL_HW_VERSION_MINOR
+ */
+
+/* Customer ID=12445; Build=0x700c0; Copyright (c) 1999-2017 Tensilica Inc.
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+   IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+   CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+   TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
+
+
+#ifndef XTENSA_CONFIG_CORE_MATMAP_H
+#define XTENSA_CONFIG_CORE_MATMAP_H
+
+
+/*----------------------------------------------------------------------
+			CACHE (MEMORY ACCESS) ATTRIBUTES
+  ----------------------------------------------------------------------*/
+
+
+/*  Cache Attribute encodings -- lists of access modes for each cache attribute:  */
+#define XCHAL_FCA_LIST		XTHAL_FAM_EXCEPTION	XCHAL_SEP \
+				XTHAL_FAM_CACHED	XCHAL_SEP \
+				XTHAL_FAM_BYPASS	XCHAL_SEP \
+				XTHAL_FAM_CACHED	XCHAL_SEP \
+				XTHAL_FAM_CACHED	XCHAL_SEP \
+				XTHAL_FAM_CACHED	XCHAL_SEP \
+				XTHAL_FAM_BYPASS	XCHAL_SEP \
+				XTHAL_FAM_EXCEPTION	XCHAL_SEP \
+				XTHAL_FAM_EXCEPTION	XCHAL_SEP \
+				XTHAL_FAM_EXCEPTION	XCHAL_SEP \
+				XTHAL_FAM_EXCEPTION	XCHAL_SEP \
+				XTHAL_FAM_EXCEPTION	XCHAL_SEP \
+				XTHAL_FAM_EXCEPTION	XCHAL_SEP \
+				XTHAL_FAM_EXCEPTION	XCHAL_SEP \
+				XTHAL_FAM_EXCEPTION	XCHAL_SEP \
+				XTHAL_FAM_EXCEPTION
+#define XCHAL_LCA_LIST		XTHAL_LAM_CACHED_NOALLOC	XCHAL_SEP \
+				XTHAL_LAM_CACHED	XCHAL_SEP \
+				XTHAL_LAM_BYPASSG	XCHAL_SEP \
+				XTHAL_LAM_EXCEPTION	XCHAL_SEP \
+				XTHAL_LAM_CACHED	XCHAL_SEP \
+				XTHAL_LAM_CACHED	XCHAL_SEP \
+				XTHAL_LAM_BYPASSG	XCHAL_SEP \
+				XTHAL_LAM_EXCEPTION	XCHAL_SEP \
+				XTHAL_LAM_EXCEPTION	XCHAL_SEP \
+				XTHAL_LAM_EXCEPTION	XCHAL_SEP \
+				XTHAL_LAM_EXCEPTION	XCHAL_SEP \
+				XTHAL_LAM_EXCEPTION	XCHAL_SEP \
+				XTHAL_LAM_EXCEPTION	XCHAL_SEP \
+				XTHAL_LAM_EXCEPTION	XCHAL_SEP \
+				XTHAL_LAM_ISOLATE	XCHAL_SEP \
+				XTHAL_LAM_EXCEPTION
+#define XCHAL_SCA_LIST		XTHAL_SAM_WRITETHRU	XCHAL_SEP \
+				XTHAL_SAM_WRITETHRU	XCHAL_SEP \
+				XTHAL_SAM_BYPASS	XCHAL_SEP \
+				XTHAL_SAM_EXCEPTION	XCHAL_SEP \
+				XTHAL_SAM_WRITEBACK	XCHAL_SEP \
+				XTHAL_SAM_WRITEBACK_NOALLOC	XCHAL_SEP \
+				XTHAL_SAM_BYPASS	XCHAL_SEP \
+				XTHAL_SAM_EXCEPTION	XCHAL_SEP \
+				XTHAL_SAM_EXCEPTION	XCHAL_SEP \
+				XTHAL_SAM_EXCEPTION	XCHAL_SEP \
+				XTHAL_SAM_EXCEPTION	XCHAL_SEP \
+				XTHAL_SAM_EXCEPTION	XCHAL_SEP \
+				XTHAL_SAM_EXCEPTION	XCHAL_SEP \
+				XTHAL_SAM_EXCEPTION	XCHAL_SEP \
+				XTHAL_SAM_ISOLATE	XCHAL_SEP \
+				XTHAL_SAM_EXCEPTION
+
+
+/*
+ *  Specific encoded cache attribute values of general interest.
+ *  If a specific cache mode is not available, the closest available
+ *  one is returned instead (eg. writethru instead of writeback,
+ *  bypass instead of writethru).
+ */
+#define XCHAL_CA_BYPASS  		2	/* cache disabled (bypassed) mode */
+#define XCHAL_CA_BYPASSBUF  		6	/* cache disabled (bypassed) bufferable mode */
+#define XCHAL_CA_WRITETHRU		1	/* cache enabled (write-through) mode */
+#define XCHAL_CA_WRITEBACK		4	/* cache enabled (write-back) mode */
+#define XCHAL_HAVE_CA_WRITEBACK_NOALLOC	1	/* write-back no-allocate availability */
+#define XCHAL_CA_WRITEBACK_NOALLOC	5	/* cache enabled (write-back no-allocate) mode */
+#define XCHAL_CA_ILLEGAL		15	/* no access allowed (all cause exceptions) mode */
+#define XCHAL_CA_ISOLATE		14	/* cache isolate (accesses go to cache not memory) mode */
+
+
+/*----------------------------------------------------------------------
+				MMU
+  ----------------------------------------------------------------------*/
+
+/*
+ *  General notes on MMU parameters.
+ *
+ *  Terminology:
+ *	ASID = address-space ID (acts as an "extension" of virtual addresses)
+ *	VPN  = virtual page number
+ *	PPN  = physical page number
+ *	CA   = encoded cache attribute (access modes)
+ *	TLB  = translation look-aside buffer (term is stretched somewhat here)
+ *	I    = instruction (fetch accesses)
+ *	D    = data (load and store accesses)
+ *	way  = each TLB (ITLB and DTLB) consists of a number of "ways"
+ *		that simultaneously match the virtual address of an access;
+ *		a TLB successfully translates a virtual address if exactly
+ *		one way matches the vaddr; if none match, it is a miss;
+ *		if multiple match, one gets a "multihit" exception;
+ *		each way can be independently configured in terms of number of
+ *		entries, page sizes, which fields are writable or constant, etc.
+ *	set  = group of contiguous ways with exactly identical parameters
+ *	ARF  = auto-refill; hardware services a 1st-level miss by loading a PTE
+ *		from the page table and storing it in one of the auto-refill ways;
+ *		if this PTE load also misses, a miss exception is posted for s/w.
+ *	min-wired = a "min-wired" way can be used to map a single (minimum-sized)
+ * 		page arbitrarily under program control; it has a single entry,
+ *		is non-auto-refill (some other way(s) must be auto-refill),
+ *		all its fields (VPN, PPN, ASID, CA) are all writable, and it
+ *		supports the XCHAL_MMU_MIN_PTE_PAGE_SIZE page size (a current
+ *		restriction is that this be the only page size it supports).
+ *
+ *  TLB way entries are virtually indexed.
+ *  TLB ways that support multiple page sizes:
+ *	- must have all writable VPN and PPN fields;
+ *	- can only use one page size at any given time (eg. setup at startup),
+ *	  selected by the respective ITLBCFG or DTLBCFG special register,
+ *	  whose bits n*4+3 .. n*4 index the list of page sizes for way n
+ *	  (XCHAL_xTLB_SETm_PAGESZ_LOG2_LIST for set m corresponding to way n);
+ *	  this list may be sparse for auto-refill ways because auto-refill
+ *	  ways have independent lists of supported page sizes sharing a
+ *	  common encoding with PTE entries; the encoding is the index into
+ *	  this list; unsupported sizes for a given way are zero in the list;
+ *	  selecting unsupported sizes results in undefined hardware behaviour;
+ *	- is only possible for ways 0 thru 7 (due to ITLBCFG/DTLBCFG definition).
+ */
+
+#define XCHAL_MMU_ASID_INVALID		0	/* ASID value indicating invalid address space */
+#define XCHAL_MMU_ASID_KERNEL		0	/* ASID value indicating kernel (ring 0) address space */
+#define XCHAL_MMU_SR_BITS		0	/* number of size-restriction bits supported */
+#define XCHAL_MMU_CA_BITS		4	/* number of bits needed to hold cache attribute encoding */
+#define XCHAL_MMU_MAX_PTE_PAGE_SIZE	29	/* max page size in a PTE structure (log2) */
+#define XCHAL_MMU_MIN_PTE_PAGE_SIZE	29	/* min page size in a PTE structure (log2) */
+
+
+/***  Instruction TLB:  ***/
+
+#define XCHAL_ITLB_WAY_BITS		0	/* number of bits holding the ways */
+#define XCHAL_ITLB_WAYS			1	/* number of ways (n-way set-associative TLB) */
+#define XCHAL_ITLB_ARF_WAYS		0	/* number of auto-refill ways */
+#define XCHAL_ITLB_SETS			1	/* number of sets (groups of ways with identical settings) */
+
+/*  Way set to which each way belongs:  */
+#define XCHAL_ITLB_WAY0_SET		0
+
+/*  Ways sets that are used by hardware auto-refill (ARF):  */
+#define XCHAL_ITLB_ARF_SETS		0	/* number of auto-refill sets */
+
+/*  Way sets that are "min-wired" (see terminology comment above):  */
+#define XCHAL_ITLB_MINWIRED_SETS	0	/* number of "min-wired" sets */
+
+
+/*  ITLB way set 0 (group of ways 0 thru 0):  */
+#define XCHAL_ITLB_SET0_WAY			0	/* index of first way in this way set */
+#define XCHAL_ITLB_SET0_WAYS			1	/* number of (contiguous) ways in this way set */
+#define XCHAL_ITLB_SET0_ENTRIES_LOG2		3	/* log2(number of entries in this way) */
+#define XCHAL_ITLB_SET0_ENTRIES			8	/* number of entries in this way (always a power of 2) */
+#define XCHAL_ITLB_SET0_ARF			0	/* 1=autorefill by h/w, 0=non-autorefill (wired/constant/static) */
+#define XCHAL_ITLB_SET0_PAGESIZES		1	/* number of supported page sizes in this way */
+#define XCHAL_ITLB_SET0_PAGESZ_BITS		0	/* number of bits to encode the page size */
+#define XCHAL_ITLB_SET0_PAGESZ_LOG2_MIN		29	/* log2(minimum supported page size) */
+#define XCHAL_ITLB_SET0_PAGESZ_LOG2_MAX		29	/* log2(maximum supported page size) */
+#define XCHAL_ITLB_SET0_PAGESZ_LOG2_LIST	29	/* list of log2(page size)s, separated by XCHAL_SEP;
+							   2^PAGESZ_BITS entries in list, unsupported entries are zero */
+#define XCHAL_ITLB_SET0_ASID_CONSTMASK		0	/* constant ASID bits; 0 if all writable */
+#define XCHAL_ITLB_SET0_VPN_CONSTMASK		0x00000000	/* constant VPN bits, not including entry index bits; 0 if all writable */
+#define XCHAL_ITLB_SET0_PPN_CONSTMASK		0xE0000000	/* constant PPN bits, including entry index bits; 0 if all writable */
+#define XCHAL_ITLB_SET0_CA_CONSTMASK		0	/* constant CA bits; 0 if all writable */
+#define XCHAL_ITLB_SET0_ASID_RESET		0	/* 1 if ASID reset values defined (and all writable); 0 otherwise */
+#define XCHAL_ITLB_SET0_VPN_RESET		0	/* 1 if VPN reset values defined (and all writable); 0 otherwise */
+#define XCHAL_ITLB_SET0_PPN_RESET		0	/* 1 if PPN reset values defined (and all writable); 0 otherwise */
+#define XCHAL_ITLB_SET0_CA_RESET		1	/* 1 if CA reset values defined (and all writable); 0 otherwise */
+/*  Constant VPN values for each entry of ITLB way set 0 (because VPN_CONSTMASK is non-zero):  */
+#define XCHAL_ITLB_SET0_E0_VPN_CONST		0x00000000
+#define XCHAL_ITLB_SET0_E1_VPN_CONST		0x20000000
+#define XCHAL_ITLB_SET0_E2_VPN_CONST		0x40000000
+#define XCHAL_ITLB_SET0_E3_VPN_CONST		0x60000000
+#define XCHAL_ITLB_SET0_E4_VPN_CONST		0x80000000
+#define XCHAL_ITLB_SET0_E5_VPN_CONST		0xA0000000
+#define XCHAL_ITLB_SET0_E6_VPN_CONST		0xC0000000
+#define XCHAL_ITLB_SET0_E7_VPN_CONST		0xE0000000
+/*  Constant PPN values for each entry of ITLB way set 0 (because PPN_CONSTMASK is non-zero):  */
+#define XCHAL_ITLB_SET0_E0_PPN_CONST		0x00000000
+#define XCHAL_ITLB_SET0_E1_PPN_CONST		0x20000000
+#define XCHAL_ITLB_SET0_E2_PPN_CONST		0x40000000
+#define XCHAL_ITLB_SET0_E3_PPN_CONST		0x60000000
+#define XCHAL_ITLB_SET0_E4_PPN_CONST		0x80000000
+#define XCHAL_ITLB_SET0_E5_PPN_CONST		0xA0000000
+#define XCHAL_ITLB_SET0_E6_PPN_CONST		0xC0000000
+#define XCHAL_ITLB_SET0_E7_PPN_CONST		0xE0000000
+/*  Reset CA values for each entry of ITLB way set 0 (because SET0_CA_RESET is non-zero):  */
+#define XCHAL_ITLB_SET0_E0_CA_RESET		0x02
+#define XCHAL_ITLB_SET0_E1_CA_RESET		0x02
+#define XCHAL_ITLB_SET0_E2_CA_RESET		0x02
+#define XCHAL_ITLB_SET0_E3_CA_RESET		0x02
+#define XCHAL_ITLB_SET0_E4_CA_RESET		0x02
+#define XCHAL_ITLB_SET0_E5_CA_RESET		0x02
+#define XCHAL_ITLB_SET0_E6_CA_RESET		0x02
+#define XCHAL_ITLB_SET0_E7_CA_RESET		0x02
+
+
+/***  Data TLB:  ***/
+
+#define XCHAL_DTLB_WAY_BITS		0	/* number of bits holding the ways */
+#define XCHAL_DTLB_WAYS			1	/* number of ways (n-way set-associative TLB) */
+#define XCHAL_DTLB_ARF_WAYS		0	/* number of auto-refill ways */
+#define XCHAL_DTLB_SETS			1	/* number of sets (groups of ways with identical settings) */
+
+/*  Way set to which each way belongs:  */
+#define XCHAL_DTLB_WAY0_SET		0
+
+/*  Ways sets that are used by hardware auto-refill (ARF):  */
+#define XCHAL_DTLB_ARF_SETS		0	/* number of auto-refill sets */
+
+/*  Way sets that are "min-wired" (see terminology comment above):  */
+#define XCHAL_DTLB_MINWIRED_SETS	0	/* number of "min-wired" sets */
+
+
+/*  DTLB way set 0 (group of ways 0 thru 0):  */
+#define XCHAL_DTLB_SET0_WAY			0	/* index of first way in this way set */
+#define XCHAL_DTLB_SET0_WAYS			1	/* number of (contiguous) ways in this way set */
+#define XCHAL_DTLB_SET0_ENTRIES_LOG2		3	/* log2(number of entries in this way) */
+#define XCHAL_DTLB_SET0_ENTRIES			8	/* number of entries in this way (always a power of 2) */
+#define XCHAL_DTLB_SET0_ARF			0	/* 1=autorefill by h/w, 0=non-autorefill (wired/constant/static) */
+#define XCHAL_DTLB_SET0_PAGESIZES		1	/* number of supported page sizes in this way */
+#define XCHAL_DTLB_SET0_PAGESZ_BITS		0	/* number of bits to encode the page size */
+#define XCHAL_DTLB_SET0_PAGESZ_LOG2_MIN		29	/* log2(minimum supported page size) */
+#define XCHAL_DTLB_SET0_PAGESZ_LOG2_MAX		29	/* log2(maximum supported page size) */
+#define XCHAL_DTLB_SET0_PAGESZ_LOG2_LIST	29	/* list of log2(page size)s, separated by XCHAL_SEP;
+							   2^PAGESZ_BITS entries in list, unsupported entries are zero */
+#define XCHAL_DTLB_SET0_ASID_CONSTMASK		0	/* constant ASID bits; 0 if all writable */
+#define XCHAL_DTLB_SET0_VPN_CONSTMASK		0x00000000	/* constant VPN bits, not including entry index bits; 0 if all writable */
+#define XCHAL_DTLB_SET0_PPN_CONSTMASK		0xE0000000	/* constant PPN bits, including entry index bits; 0 if all writable */
+#define XCHAL_DTLB_SET0_CA_CONSTMASK		0	/* constant CA bits; 0 if all writable */
+#define XCHAL_DTLB_SET0_ASID_RESET		0	/* 1 if ASID reset values defined (and all writable); 0 otherwise */
+#define XCHAL_DTLB_SET0_VPN_RESET		0	/* 1 if VPN reset values defined (and all writable); 0 otherwise */
+#define XCHAL_DTLB_SET0_PPN_RESET		0	/* 1 if PPN reset values defined (and all writable); 0 otherwise */
+#define XCHAL_DTLB_SET0_CA_RESET		1	/* 1 if CA reset values defined (and all writable); 0 otherwise */
+/*  Constant VPN values for each entry of DTLB way set 0 (because VPN_CONSTMASK is non-zero):  */
+#define XCHAL_DTLB_SET0_E0_VPN_CONST		0x00000000
+#define XCHAL_DTLB_SET0_E1_VPN_CONST		0x20000000
+#define XCHAL_DTLB_SET0_E2_VPN_CONST		0x40000000
+#define XCHAL_DTLB_SET0_E3_VPN_CONST		0x60000000
+#define XCHAL_DTLB_SET0_E4_VPN_CONST		0x80000000
+#define XCHAL_DTLB_SET0_E5_VPN_CONST		0xA0000000
+#define XCHAL_DTLB_SET0_E6_VPN_CONST		0xC0000000
+#define XCHAL_DTLB_SET0_E7_VPN_CONST		0xE0000000
+/*  Constant PPN values for each entry of DTLB way set 0 (because PPN_CONSTMASK is non-zero):  */
+#define XCHAL_DTLB_SET0_E0_PPN_CONST		0x00000000
+#define XCHAL_DTLB_SET0_E1_PPN_CONST		0x20000000
+#define XCHAL_DTLB_SET0_E2_PPN_CONST		0x40000000
+#define XCHAL_DTLB_SET0_E3_PPN_CONST		0x60000000
+#define XCHAL_DTLB_SET0_E4_PPN_CONST		0x80000000
+#define XCHAL_DTLB_SET0_E5_PPN_CONST		0xA0000000
+#define XCHAL_DTLB_SET0_E6_PPN_CONST		0xC0000000
+#define XCHAL_DTLB_SET0_E7_PPN_CONST		0xE0000000
+/*  Reset CA values for each entry of DTLB way set 0 (because SET0_CA_RESET is non-zero):  */
+#define XCHAL_DTLB_SET0_E0_CA_RESET		0x02
+#define XCHAL_DTLB_SET0_E1_CA_RESET		0x02
+#define XCHAL_DTLB_SET0_E2_CA_RESET		0x02
+#define XCHAL_DTLB_SET0_E3_CA_RESET		0x02
+#define XCHAL_DTLB_SET0_E4_CA_RESET		0x02
+#define XCHAL_DTLB_SET0_E5_CA_RESET		0x02
+#define XCHAL_DTLB_SET0_E6_CA_RESET		0x02
+#define XCHAL_DTLB_SET0_E7_CA_RESET		0x02
+
+
+
+
+#endif /*XTENSA_CONFIG_CORE_MATMAP_H*/
+

--- a/src/platform/imx8/include/arch/xtensa/config/defs.h
+++ b/src/platform/imx8/include/arch/xtensa/config/defs.h
@@ -1,0 +1,38 @@
+/* Definitions for Xtensa instructions, types, and protos. */
+
+/* Customer ID=12445; Build=0x700c0; Copyright (c) 2003-2004 Tensilica Inc.
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+   IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+   CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+   TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
+
+/* NOTE: This file exists only for backward compatibility with T1050
+   and earlier Xtensa releases.  It includes only a subset of the
+   available header files.  */
+
+#ifndef _XTENSA_BASE_HEADER
+#define _XTENSA_BASE_HEADER
+
+#ifdef __XTENSA__
+
+#include <xtensa/tie/xt_core.h>
+#include <xtensa/tie/xt_misc.h>
+#include <xtensa/tie/xt_booleans.h>
+
+#endif /* __XTENSA__ */
+#endif /* !_XTENSA_BASE_HEADER */

--- a/src/platform/imx8/include/arch/xtensa/config/specreg.h
+++ b/src/platform/imx8/include/arch/xtensa/config/specreg.h
@@ -1,0 +1,101 @@
+/*
+ * Xtensa Special Register symbolic names
+ */
+
+/* $Id: //depot/rel/Eaglenest/Xtensa/SWConfig/hal/specreg.h.tpp#1 $ */
+
+/* Customer ID=12445; Build=0x700c0; Copyright (c) 1998-2002 Tensilica Inc.
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+   IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+   CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+   TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
+
+#ifndef XTENSA_SPECREG_H
+#define XTENSA_SPECREG_H
+
+/*  Include these special register bitfield definitions, for historical reasons:  */
+#include <xtensa/corebits.h>
+
+
+/*  Special registers:  */
+#define LBEG		0
+#define LEND		1
+#define LCOUNT		2
+#define SAR		3
+#define BR		4
+#define SCOMPARE1	12
+#define PREFCTL		40
+#define WINDOWBASE	72
+#define WINDOWSTART	73
+#define IBREAKENABLE	96
+#define ATOMCTL		99
+#define DDR		104
+#define IBREAKA_0	128
+#define IBREAKA_1	129
+#define DBREAKA_0	144
+#define DBREAKA_1	145
+#define DBREAKC_0	160
+#define DBREAKC_1	161
+#define EPC_1		177
+#define EPC_2		178
+#define EPC_3		179
+#define EPC_4		180
+#define EPC_5		181
+#define DEPC		192
+#define EPS_2		194
+#define EPS_3		195
+#define EPS_4		196
+#define EPS_5		197
+#define EXCSAVE_1	209
+#define EXCSAVE_2	210
+#define EXCSAVE_3	211
+#define EXCSAVE_4	212
+#define EXCSAVE_5	213
+#define CPENABLE	224
+#define INTERRUPT	226
+#define INTENABLE	228
+#define PS		230
+#define VECBASE		231
+#define EXCCAUSE	232
+#define DEBUGCAUSE	233
+#define CCOUNT		234
+#define PRID		235
+#define ICOUNT		236
+#define ICOUNTLEVEL	237
+#define EXCVADDR	238
+#define CCOMPARE_0	240
+#define CCOMPARE_1	241
+#define MISC_REG_0	244
+#define MISC_REG_1	245
+
+/*  Special cases (bases of special register series):  */
+#define IBREAKA		128
+#define DBREAKA		144
+#define DBREAKC		160
+#define EPC		176
+#define EPS		192
+#define EXCSAVE		208
+#define CCOMPARE	240
+
+/*  Special names for read-only and write-only interrupt registers:  */
+#define INTREAD		226
+#define INTSET		226
+#define INTCLEAR	227
+
+#endif /* XTENSA_SPECREG_H */
+

--- a/src/platform/imx8/include/arch/xtensa/config/system.h
+++ b/src/platform/imx8/include/arch/xtensa/config/system.h
@@ -1,0 +1,270 @@
+/* 
+ * xtensa/config/system.h -- HAL definitions that are dependent on SYSTEM configuration
+ *
+ *  NOTE: The location and contents of this file are highly subject to change.
+ *
+ *  Source for configuration-independent binaries (which link in a
+ *  configuration-specific HAL library) must NEVER include this file.
+ *  The HAL itself has historically included this file in some instances,
+ *  but this is not appropriate either, because the HAL is meant to be
+ *  core-specific but system independent.
+ */
+
+/* Customer ID=12445; Build=0x700c0; Copyright (c) 2000-2010 Tensilica Inc.
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+   IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+   CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+   TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
+
+
+#ifndef XTENSA_CONFIG_SYSTEM_H
+#define XTENSA_CONFIG_SYSTEM_H
+
+/*#include <xtensa/hal.h>*/
+
+
+
+/*----------------------------------------------------------------------
+				CONFIGURED SOFTWARE OPTIONS
+  ----------------------------------------------------------------------*/
+
+#define XSHAL_USE_ABSOLUTE_LITERALS	0	/* (sw-only option, whether software uses absolute literals) */
+#define XSHAL_HAVE_TEXT_SECTION_LITERALS 1 /* Set if there is some memory that allows both code and literals.  */
+
+#define XSHAL_ABI			XTHAL_ABI_WINDOWED	/* (sw-only option, selected ABI) */
+/*  The above maps to one of the following constants:  */
+#define XTHAL_ABI_WINDOWED		0
+#define XTHAL_ABI_CALL0			1
+/*  Alternatives:  */
+/*#define XSHAL_WINDOWED_ABI		1*/	/* set if windowed ABI selected */
+/*#define XSHAL_CALL0_ABI		0*/	/* set if call0 ABI selected */
+
+#define XSHAL_CLIB			XTHAL_CLIB_NEWLIB	/* (sw-only option, selected C library) */
+/*  The above maps to one of the following constants:  */
+#define XTHAL_CLIB_NEWLIB		0
+#define XTHAL_CLIB_UCLIBC		1
+#define XTHAL_CLIB_XCLIB		2
+/*  Alternatives:  */
+/*#define XSHAL_NEWLIB			1*/	/* set if newlib C library selected */
+/*#define XSHAL_UCLIBC			0*/	/* set if uCLibC C library selected */
+/*#define XSHAL_XCLIB			0*/	/* set if Xtensa C library selected */
+
+#define XSHAL_USE_FLOATING_POINT	1
+
+#define XSHAL_FLOATING_POINT_ABI	1
+
+/*  SW workarounds enabled for HW errata:  */
+
+/*----------------------------------------------------------------------
+				DEVICE ADDRESSES
+  ----------------------------------------------------------------------*/
+
+/*
+ *  Strange place to find these, but the configuration GUI
+ *  allows moving these around to account for various core
+ *  configurations.  Specific boards (and their BSP software)
+ *  will have specific meanings for these components.
+ */
+
+/*  I/O Block areas:  */
+#define XSHAL_IOBLOCK_CACHED_VADDR	0x70000000
+#define XSHAL_IOBLOCK_CACHED_PADDR	0x70000000
+#define XSHAL_IOBLOCK_CACHED_SIZE	0x0E000000
+
+#define XSHAL_IOBLOCK_BYPASS_VADDR	0x50000000
+#define XSHAL_IOBLOCK_BYPASS_PADDR	0x50000000
+#define XSHAL_IOBLOCK_BYPASS_SIZE	0x0E000000
+
+/*  System ROM:  */
+#define XSHAL_ROM_VADDR		0x80720000
+#define XSHAL_ROM_PADDR		0x80720000
+#define XSHAL_ROM_SIZE		0x00020000
+/*  Largest available area (free of vectors):  */
+#define XSHAL_ROM_AVAIL_VADDR	0x80720000
+#define XSHAL_ROM_AVAIL_VSIZE	0x00020000
+
+/*  System RAM:  */
+#define XSHAL_RAM_VADDR		0x80700000
+#define XSHAL_RAM_PADDR		0x80700000
+#define XSHAL_RAM_VSIZE		0x00020000
+#define XSHAL_RAM_PSIZE		0x00020000
+#define XSHAL_RAM_SIZE		XSHAL_RAM_PSIZE
+/*  Largest available area (free of vectors):  */
+#define XSHAL_RAM_AVAIL_VADDR	0x80700000
+#define XSHAL_RAM_AVAIL_VSIZE	0x00020000
+
+/*
+ *  Shadow system RAM (same device as system RAM, at different address).
+ *  (Emulation boards need this for the SONIC Ethernet driver
+ *   when data caches are configured for writeback mode.)
+ *  NOTE: on full MMU configs, this points to the BYPASS virtual address
+ *  of system RAM, ie. is the same as XSHAL_RAM_* except that virtual
+ *  addresses are viewed through the BYPASS static map rather than
+ *  the CACHED static map.
+ */
+#define XSHAL_RAM_BYPASS_VADDR		0x20000000
+#define XSHAL_RAM_BYPASS_PADDR		0x20000000
+#define XSHAL_RAM_BYPASS_PSIZE		0x00020000
+
+/*  Alternate system RAM (different device than system RAM):  */
+/*#define XSHAL_ALTRAM_[VP]ADDR		...not configured...*/
+/*#define XSHAL_ALTRAM_SIZE		...not configured...*/
+
+/*  Some available location in which to place devices in a simulation (eg. XTMP):  */
+#define XSHAL_SIMIO_CACHED_VADDR	0xC0000000
+#define XSHAL_SIMIO_BYPASS_VADDR	0xC0000000
+#define XSHAL_SIMIO_PADDR		0xC0000000
+#define XSHAL_SIMIO_SIZE		0x20000000
+
+
+/*----------------------------------------------------------------------
+ *  For use by reference testbench exit and diagnostic routines.
+ */
+#define XSHAL_MAGIC_EXIT		0xa0000000
+
+/*----------------------------------------------------------------------
+ *			DEVICE-ADDRESS DEPENDENT...
+ *
+ *  Values written to CACHEATTR special register (or its equivalent)
+ *  to enable and disable caches in various modes.
+ *----------------------------------------------------------------------*/
+
+/*----------------------------------------------------------------------
+			BACKWARD COMPATIBILITY ...
+  ----------------------------------------------------------------------*/
+
+/*
+ *  NOTE:  the following two macros are DEPRECATED.  Use the latter
+ *  board-specific macros instead, which are specially tuned for the
+ *  particular target environments' memory maps.
+ */
+#define XSHAL_CACHEATTR_BYPASS		XSHAL_XT2000_CACHEATTR_BYPASS	/* disable caches in bypass mode */
+#define XSHAL_CACHEATTR_DEFAULT		XSHAL_XT2000_CACHEATTR_DEFAULT	/* default setting to enable caches (no writeback!) */
+
+/*----------------------------------------------------------------------
+				GENERIC
+  ----------------------------------------------------------------------*/
+
+/*  For the following, a 512MB region is used if it contains a system (PIF) RAM,
+ *  system (PIF) ROM, local memory, or XLMI.  */
+
+/*  These set any unused 512MB region to cache-BYPASS attribute:  */
+#define XSHAL_ALLVALID_CACHEATTR_WRITEBACK	0x22242422	/* enable caches in write-back mode */
+#define XSHAL_ALLVALID_CACHEATTR_WRITEALLOC	0x22212122	/* enable caches in write-allocate mode */
+#define XSHAL_ALLVALID_CACHEATTR_WRITETHRU	0x22212122	/* enable caches in write-through mode */
+#define XSHAL_ALLVALID_CACHEATTR_BYPASS		0x22222222	/* disable caches in bypass mode */
+#define XSHAL_ALLVALID_CACHEATTR_DEFAULT	XSHAL_ALLVALID_CACHEATTR_WRITEBACK	/* default setting to enable caches */
+
+/*  These set any unused 512MB region to ILLEGAL attribute:  */
+#define XSHAL_STRICT_CACHEATTR_WRITEBACK	0xFFF4F4FF	/* enable caches in write-back mode */
+#define XSHAL_STRICT_CACHEATTR_WRITEALLOC	0xFFF1F1FF	/* enable caches in write-allocate mode */
+#define XSHAL_STRICT_CACHEATTR_WRITETHRU	0xFFF1F1FF	/* enable caches in write-through mode */
+#define XSHAL_STRICT_CACHEATTR_BYPASS		0xFFF2F2FF	/* disable caches in bypass mode */
+#define XSHAL_STRICT_CACHEATTR_DEFAULT		XSHAL_STRICT_CACHEATTR_WRITEBACK	/* default setting to enable caches */
+
+/*  These set the first 512MB, if unused, to ILLEGAL attribute to help catch
+ *  NULL-pointer dereference bugs; all other unused 512MB regions are set
+ *  to cache-BYPASS attribute:  */
+#define XSHAL_TRAPNULL_CACHEATTR_WRITEBACK	0x2224242F	/* enable caches in write-back mode */
+#define XSHAL_TRAPNULL_CACHEATTR_WRITEALLOC	0x2221212F	/* enable caches in write-allocate mode */
+#define XSHAL_TRAPNULL_CACHEATTR_WRITETHRU	0x2221212F	/* enable caches in write-through mode */
+#define XSHAL_TRAPNULL_CACHEATTR_BYPASS		0x2222222F	/* disable caches in bypass mode */
+#define XSHAL_TRAPNULL_CACHEATTR_DEFAULT	XSHAL_TRAPNULL_CACHEATTR_WRITEBACK	/* default setting to enable caches */
+
+/*----------------------------------------------------------------------
+			ISS (Instruction Set Simulator) SPECIFIC ...
+  ----------------------------------------------------------------------*/
+
+/*  For now, ISS defaults to the TRAPNULL settings:  */
+#define XSHAL_ISS_CACHEATTR_WRITEBACK	XSHAL_TRAPNULL_CACHEATTR_WRITEBACK
+#define XSHAL_ISS_CACHEATTR_WRITEALLOC	XSHAL_TRAPNULL_CACHEATTR_WRITEALLOC
+#define XSHAL_ISS_CACHEATTR_WRITETHRU	XSHAL_TRAPNULL_CACHEATTR_WRITETHRU
+#define XSHAL_ISS_CACHEATTR_BYPASS	XSHAL_TRAPNULL_CACHEATTR_BYPASS
+#define XSHAL_ISS_CACHEATTR_DEFAULT	XSHAL_TRAPNULL_CACHEATTR_WRITEBACK
+
+#define XSHAL_ISS_PIPE_REGIONS	0
+#define XSHAL_ISS_SDRAM_REGIONS	0
+
+
+/*----------------------------------------------------------------------
+			XT2000 BOARD SPECIFIC ...
+  ----------------------------------------------------------------------*/
+
+/*  For the following, a 512MB region is used if it contains any system RAM,
+ *  system ROM, local memory, XLMI, or other XT2000 board device or memory.
+ *  Regions containing devices are forced to cache-BYPASS mode regardless
+ *  of whether the macro is _WRITEBACK vs. _BYPASS etc.  */
+
+/*  These set any 512MB region unused on the XT2000 to ILLEGAL attribute:  */
+#define XSHAL_XT2000_CACHEATTR_WRITEBACK	0xFFF4422F	/* enable caches in write-back mode */
+#define XSHAL_XT2000_CACHEATTR_WRITEALLOC	0xFFF1122F	/* enable caches in write-allocate mode */
+#define XSHAL_XT2000_CACHEATTR_WRITETHRU	0xFFF1122F	/* enable caches in write-through mode */
+#define XSHAL_XT2000_CACHEATTR_BYPASS		0xFFF2222F	/* disable caches in bypass mode */
+#define XSHAL_XT2000_CACHEATTR_DEFAULT		XSHAL_XT2000_CACHEATTR_WRITEBACK	/* default setting to enable caches */
+
+#define XSHAL_XT2000_PIPE_REGIONS	0x00000000	/* BusInt pipeline regions */
+#define XSHAL_XT2000_SDRAM_REGIONS	0x00000104	/* BusInt SDRAM regions */
+
+
+/*----------------------------------------------------------------------
+				VECTOR INFO AND SIZES
+  ----------------------------------------------------------------------*/
+
+#define XSHAL_VECTORS_PACKED		0
+#define XSHAL_STATIC_VECTOR_SELECT	0
+#define XSHAL_RESET_VECTOR_VADDR	0x596F8000
+#define XSHAL_RESET_VECTOR_PADDR	0x596F8000
+
+/*
+ *  Sizes allocated to vectors by the system (memory map) configuration.
+ *  These sizes are constrained by core configuration (eg. one vector's
+ *  code cannot overflow into another vector) but are dependent on the
+ *  system or board (or LSP) memory map configuration.
+ *
+ *  Whether or not each vector happens to be in a system ROM is also
+ *  a system configuration matter, sometimes useful, included here also:
+ */
+#define XSHAL_RESET_VECTOR_SIZE	0x000002E0
+#define XSHAL_RESET_VECTOR_ISROM	0
+#define XSHAL_USER_VECTOR_SIZE	0x0000001C
+#define XSHAL_USER_VECTOR_ISROM	0
+#define XSHAL_PROGRAMEXC_VECTOR_SIZE	XSHAL_USER_VECTOR_SIZE	/* for backward compatibility */
+#define XSHAL_USEREXC_VECTOR_SIZE	XSHAL_USER_VECTOR_SIZE	/* for backward compatibility */
+#define XSHAL_KERNEL_VECTOR_SIZE	0x0000001C
+#define XSHAL_KERNEL_VECTOR_ISROM	0
+#define XSHAL_STACKEDEXC_VECTOR_SIZE	XSHAL_KERNEL_VECTOR_SIZE	/* for backward compatibility */
+#define XSHAL_KERNELEXC_VECTOR_SIZE	XSHAL_KERNEL_VECTOR_SIZE	/* for backward compatibility */
+#define XSHAL_DOUBLEEXC_VECTOR_SIZE	0x0000001C
+#define XSHAL_DOUBLEEXC_VECTOR_ISROM	0
+#define XSHAL_WINDOW_VECTORS_SIZE	0x00000178
+#define XSHAL_WINDOW_VECTORS_ISROM	0
+#define XSHAL_INTLEVEL2_VECTOR_SIZE	0x0000001C
+#define XSHAL_INTLEVEL2_VECTOR_ISROM	0
+#define XSHAL_INTLEVEL3_VECTOR_SIZE	0x0000001C
+#define XSHAL_INTLEVEL3_VECTOR_ISROM	0
+#define XSHAL_INTLEVEL4_VECTOR_SIZE	0x0000001C
+#define XSHAL_INTLEVEL4_VECTOR_ISROM	0
+#define XSHAL_DEBUG_VECTOR_SIZE		XSHAL_INTLEVEL4_VECTOR_SIZE
+#define XSHAL_DEBUG_VECTOR_ISROM	XSHAL_INTLEVEL4_VECTOR_ISROM
+#define XSHAL_NMI_VECTOR_SIZE	0x0000001C
+#define XSHAL_NMI_VECTOR_ISROM	0
+#define XSHAL_INTLEVEL5_VECTOR_SIZE	XSHAL_NMI_VECTOR_SIZE
+
+
+#endif /*XTENSA_CONFIG_SYSTEM_H*/
+

--- a/src/platform/imx8/include/arch/xtensa/config/tie-asm.h
+++ b/src/platform/imx8/include/arch/xtensa/config/tie-asm.h
@@ -1,0 +1,316 @@
+/* 
+ * tie-asm.h -- compile-time HAL assembler definitions dependent on CORE & TIE
+ *
+ *  NOTE:  This header file is not meant to be included directly.
+ */
+
+/* This header file contains assembly-language definitions (assembly
+   macros, etc.) for this specific Xtensa processor's TIE extensions
+   and options.  It is customized to this Xtensa processor configuration.
+
+   Customer ID=12445; Build=0x700c0; Copyright (c) 1999-2017 Cadence Design Systems Inc.
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+   IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+   CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+   TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
+
+#ifndef _XTENSA_CORE_TIE_ASM_H
+#define _XTENSA_CORE_TIE_ASM_H
+
+/*  Selection parameter values for save-area save/restore macros:  */
+/*  Option vs. TIE:  */
+#define XTHAL_SAS_TIE	0x0001	/* custom extension or coprocessor */
+#define XTHAL_SAS_OPT	0x0002	/* optional (and not a coprocessor) */
+#define XTHAL_SAS_ANYOT	0x0003	/* both of the above */
+/*  Whether used automatically by compiler:  */
+#define XTHAL_SAS_NOCC	0x0004	/* not used by compiler w/o special opts/code */
+#define XTHAL_SAS_CC	0x0008	/* used by compiler without special opts/code */
+#define XTHAL_SAS_ANYCC	0x000C	/* both of the above */
+/*  ABI handling across function calls:  */
+#define XTHAL_SAS_CALR	0x0010	/* caller-saved */
+#define XTHAL_SAS_CALE	0x0020	/* callee-saved */
+#define XTHAL_SAS_GLOB	0x0040	/* global across function calls (in thread) */
+#define XTHAL_SAS_ANYABI	0x0070	/* all of the above three */
+/*  Misc  */
+#define XTHAL_SAS_ALL	0xFFFF	/* include all default NCP contents */
+#define XTHAL_SAS3(optie,ccuse,abi)	( ((optie) & XTHAL_SAS_ANYOT)  \
+					| ((ccuse) & XTHAL_SAS_ANYCC)  \
+					| ((abi)   & XTHAL_SAS_ANYABI) )
+
+
+    /*
+      *  Macro to store all non-coprocessor (extra) custom TIE and optional state
+      *  (not including zero-overhead loop registers).
+      *  Required parameters:
+      *      ptr         Save area pointer address register (clobbered)
+      *                  (register must contain a 4 byte aligned address).
+      *      at1..at4    Four temporary address registers (first XCHAL_NCP_NUM_ATMPS
+      *                  registers are clobbered, the remaining are unused).
+      *  Optional parameters:
+      *      continue    If macro invoked as part of a larger store sequence, set to 1
+      *                  if this is not the first in the sequence.  Defaults to 0.
+      *      ofs         Offset from start of larger sequence (from value of first ptr
+      *                  in sequence) at which to store.  Defaults to next available space
+      *                  (or 0 if <continue> is 0).
+      *      select      Select what category(ies) of registers to store, as a bitmask
+      *                  (see XTHAL_SAS_xxx constants).  Defaults to all registers.
+      *      alloc       Select what category(ies) of registers to allocate; if any
+      *                  category is selected here that is not in <select>, space for
+      *                  the corresponding registers is skipped without doing any store.
+      */
+    .macro xchal_ncp_store  ptr at1 at2 at3 at4  continue=0 ofs=-1 select=XTHAL_SAS_ALL alloc=0
+	xchal_sa_start	\continue, \ofs
+	// Optional global registers used by default by the compiler:
+	.ifeq (XTHAL_SAS_OPT | XTHAL_SAS_CC | XTHAL_SAS_GLOB) & ~(\select)
+	xchal_sa_align	\ptr, 0, 1016, 4, 4
+	rur.THREADPTR	\at1		// threadptr option
+	s32i	\at1, \ptr, .Lxchal_ofs_+0
+	.set	.Lxchal_ofs_, .Lxchal_ofs_ + 4
+	.elseif ((XTHAL_SAS_OPT | XTHAL_SAS_CC | XTHAL_SAS_GLOB) & ~(\alloc)) == 0
+	xchal_sa_align	\ptr, 0, 1016, 4, 4
+	.set	.Lxchal_ofs_, .Lxchal_ofs_ + 4
+	.endif
+	// Optional caller-saved registers not used by default by the compiler:
+	.ifeq (XTHAL_SAS_OPT | XTHAL_SAS_NOCC | XTHAL_SAS_CALR) & ~(\select)
+	xchal_sa_align	\ptr, 0, 1012, 4, 4
+	rsr.BR	\at1		// boolean option
+	s32i	\at1, \ptr, .Lxchal_ofs_+0
+	rsr.SCOMPARE1	\at1		// conditional store option
+	s32i	\at1, \ptr, .Lxchal_ofs_+4
+	.set	.Lxchal_ofs_, .Lxchal_ofs_ + 8
+	.elseif ((XTHAL_SAS_OPT | XTHAL_SAS_NOCC | XTHAL_SAS_CALR) & ~(\alloc)) == 0
+	xchal_sa_align	\ptr, 0, 1012, 4, 4
+	.set	.Lxchal_ofs_, .Lxchal_ofs_ + 8
+	.endif
+    .endm	// xchal_ncp_store
+
+    /*
+      *  Macro to load all non-coprocessor (extra) custom TIE and optional state
+      *  (not including zero-overhead loop registers).
+      *  Required parameters:
+      *      ptr         Save area pointer address register (clobbered)
+      *                  (register must contain a 4 byte aligned address).
+      *      at1..at4    Four temporary address registers (first XCHAL_NCP_NUM_ATMPS
+      *                  registers are clobbered, the remaining are unused).
+      *  Optional parameters:
+      *      continue    If macro invoked as part of a larger load sequence, set to 1
+      *                  if this is not the first in the sequence.  Defaults to 0.
+      *      ofs         Offset from start of larger sequence (from value of first ptr
+      *                  in sequence) at which to load.  Defaults to next available space
+      *                  (or 0 if <continue> is 0).
+      *      select      Select what category(ies) of registers to load, as a bitmask
+      *                  (see XTHAL_SAS_xxx constants).  Defaults to all registers.
+      *      alloc       Select what category(ies) of registers to allocate; if any
+      *                  category is selected here that is not in <select>, space for
+      *                  the corresponding registers is skipped without doing any load.
+      */
+    .macro xchal_ncp_load  ptr at1 at2 at3 at4  continue=0 ofs=-1 select=XTHAL_SAS_ALL alloc=0
+	xchal_sa_start	\continue, \ofs
+	// Optional global registers used by default by the compiler:
+	.ifeq (XTHAL_SAS_OPT | XTHAL_SAS_CC | XTHAL_SAS_GLOB) & ~(\select)
+	xchal_sa_align	\ptr, 0, 1016, 4, 4
+	l32i	\at1, \ptr, .Lxchal_ofs_+0
+	wur.THREADPTR	\at1		// threadptr option
+	.set	.Lxchal_ofs_, .Lxchal_ofs_ + 4
+	.elseif ((XTHAL_SAS_OPT | XTHAL_SAS_CC | XTHAL_SAS_GLOB) & ~(\alloc)) == 0
+	xchal_sa_align	\ptr, 0, 1016, 4, 4
+	.set	.Lxchal_ofs_, .Lxchal_ofs_ + 4
+	.endif
+	// Optional caller-saved registers not used by default by the compiler:
+	.ifeq (XTHAL_SAS_OPT | XTHAL_SAS_NOCC | XTHAL_SAS_CALR) & ~(\select)
+	xchal_sa_align	\ptr, 0, 1012, 4, 4
+	l32i	\at1, \ptr, .Lxchal_ofs_+0
+	wsr.BR	\at1		// boolean option
+	l32i	\at1, \ptr, .Lxchal_ofs_+4
+	wsr.SCOMPARE1	\at1		// conditional store option
+	.set	.Lxchal_ofs_, .Lxchal_ofs_ + 8
+	.elseif ((XTHAL_SAS_OPT | XTHAL_SAS_NOCC | XTHAL_SAS_CALR) & ~(\alloc)) == 0
+	xchal_sa_align	\ptr, 0, 1012, 4, 4
+	.set	.Lxchal_ofs_, .Lxchal_ofs_ + 8
+	.endif
+    .endm	// xchal_ncp_load
+
+
+#define XCHAL_NCP_NUM_ATMPS	1
+
+    /* 
+     *  Macro to store the state of TIE coprocessor AudioEngineLX.
+     *  Required parameters:
+     *      ptr         Save area pointer address register (clobbered)
+     *                  (register must contain a 8 byte aligned address).
+     *      at1..at4    Four temporary address registers (first XCHAL_CP1_NUM_ATMPS
+     *                  registers are clobbered, the remaining are unused).
+     *  Optional parameters are the same as for xchal_ncp_store.
+     */
+#define xchal_cp_AudioEngineLX_store	xchal_cp1_store
+    .macro	xchal_cp1_store  ptr at1 at2 at3 at4  continue=0 ofs=-1 select=XTHAL_SAS_ALL alloc=0
+	xchal_sa_start \continue, \ofs
+	// Custom caller-saved registers not used by default by the compiler:
+	.ifeq (XTHAL_SAS_TIE | XTHAL_SAS_NOCC | XTHAL_SAS_CALR) & ~(\select)
+	xchal_sa_align	\ptr, 0, 0, 8, 8
+	ae_s64.i	aed0, \ptr, .Lxchal_ofs_+40
+	ae_s64.i	aed1, \ptr, .Lxchal_ofs_+48
+	ae_s64.i	aed2, \ptr, .Lxchal_ofs_+56
+	addi	\ptr, \ptr, 64
+	ae_s64.i	aed3, \ptr, .Lxchal_ofs_+0
+	ae_s64.i	aed4, \ptr, .Lxchal_ofs_+8
+	ae_s64.i	aed5, \ptr, .Lxchal_ofs_+16
+	ae_s64.i	aed6, \ptr, .Lxchal_ofs_+24
+	ae_s64.i	aed7, \ptr, .Lxchal_ofs_+32
+	ae_s64.i	aed8, \ptr, .Lxchal_ofs_+40
+	ae_s64.i	aed9, \ptr, .Lxchal_ofs_+48
+	ae_s64.i	aed10, \ptr, .Lxchal_ofs_+56
+	addi	\ptr, \ptr, 64
+	ae_s64.i	aed11, \ptr, .Lxchal_ofs_+0
+	ae_s64.i	aed12, \ptr, .Lxchal_ofs_+8
+	ae_s64.i	aed13, \ptr, .Lxchal_ofs_+16
+	ae_s64.i	aed14, \ptr, .Lxchal_ofs_+24
+	ae_s64.i	aed15, \ptr, .Lxchal_ofs_+32
+	ae_movae	\at1, aep0
+	s8i	\at1, \ptr, .Lxchal_ofs_+40
+	ae_movae	\at1, aep1
+	s8i	\at1, \ptr, .Lxchal_ofs_+41
+	ae_movae	\at1, aep2
+	s8i	\at1, \ptr, .Lxchal_ofs_+42
+	ae_movae	\at1, aep3
+	s8i	\at1, \ptr, .Lxchal_ofs_+43
+	ae_salign64.i	u0, \ptr, .Lxchal_ofs_+48
+	ae_salign64.i	u1, \ptr, .Lxchal_ofs_+56
+	addi	\ptr, \ptr, 64
+	ae_salign64.i	u2, \ptr, .Lxchal_ofs_+0
+	ae_salign64.i	u3, \ptr, .Lxchal_ofs_+8
+	addi	\ptr, \ptr, -192
+	ae_movvfcrfsr	aed0		// ureg FCR_FSR
+	ae_s64.i	aed0, \ptr, .Lxchal_ofs_+0 + 0
+	rur.AE_OVF_SAR	\at1		// ureg 240
+	s32i	\at1, \ptr, .Lxchal_ofs_+8
+	rur.AE_BITHEAD	\at1		// ureg 241
+	s32i	\at1, \ptr, .Lxchal_ofs_+12
+	rur.AE_TS_FTS_BU_BP	\at1		// ureg 242
+	s32i	\at1, \ptr, .Lxchal_ofs_+16
+	rur.AE_CW_SD_NO	\at1		// ureg 243
+	s32i	\at1, \ptr, .Lxchal_ofs_+20
+	rur.AE_CBEGIN0	\at1		// ureg 246
+	s32i	\at1, \ptr, .Lxchal_ofs_+24
+	rur.AE_CEND0	\at1		// ureg 247
+	s32i	\at1, \ptr, .Lxchal_ofs_+28
+	rur.AE_CBEGIN1	\at1		// ureg 248
+	s32i	\at1, \ptr, .Lxchal_ofs_+32
+	rur.AE_CEND1	\at1		// ureg 249
+	s32i	\at1, \ptr, .Lxchal_ofs_+36
+	.set	.Lxchal_ofs_, .Lxchal_ofs_ + 208
+	.elseif ((XTHAL_SAS_TIE | XTHAL_SAS_NOCC | XTHAL_SAS_CALR) & ~(\alloc)) == 0
+	xchal_sa_align	\ptr, 0, 0, 8, 8
+	.set	.Lxchal_ofs_, .Lxchal_ofs_ + 208
+	.endif
+    .endm	// xchal_cp1_store
+
+    /* 
+     *  Macro to load the state of TIE coprocessor AudioEngineLX.
+     *  Required parameters:
+     *      ptr         Save area pointer address register (clobbered)
+     *                  (register must contain a 8 byte aligned address).
+     *      at1..at4    Four temporary address registers (first XCHAL_CP1_NUM_ATMPS
+     *                  registers are clobbered, the remaining are unused).
+     *  Optional parameters are the same as for xchal_ncp_load.
+     */
+#define xchal_cp_AudioEngineLX_load	xchal_cp1_load
+    .macro	xchal_cp1_load  ptr at1 at2 at3 at4  continue=0 ofs=-1 select=XTHAL_SAS_ALL alloc=0
+	xchal_sa_start \continue, \ofs
+	// Custom caller-saved registers not used by default by the compiler:
+	.ifeq (XTHAL_SAS_TIE | XTHAL_SAS_NOCC | XTHAL_SAS_CALR) & ~(\select)
+	xchal_sa_align	\ptr, 0, 0, 8, 8
+	ae_l64.i	aed0, \ptr, .Lxchal_ofs_+0 + 0		// ureg FCR_FSR
+	ae_movfcrfsrv	aed0
+	l32i	\at1, \ptr, .Lxchal_ofs_+8
+	wur.AE_OVF_SAR	\at1		// ureg 240
+	l32i	\at1, \ptr, .Lxchal_ofs_+12
+	wur.AE_BITHEAD	\at1		// ureg 241
+	l32i	\at1, \ptr, .Lxchal_ofs_+16
+	wur.AE_TS_FTS_BU_BP	\at1		// ureg 242
+	l32i	\at1, \ptr, .Lxchal_ofs_+20
+	wur.AE_CW_SD_NO	\at1		// ureg 243
+	l32i	\at1, \ptr, .Lxchal_ofs_+24
+	wur.AE_CBEGIN0	\at1		// ureg 246
+	l32i	\at1, \ptr, .Lxchal_ofs_+28
+	wur.AE_CEND0	\at1		// ureg 247
+	l32i	\at1, \ptr, .Lxchal_ofs_+32
+	wur.AE_CBEGIN1	\at1		// ureg 248
+	l32i	\at1, \ptr, .Lxchal_ofs_+36
+	wur.AE_CEND1	\at1		// ureg 249
+	ae_l64.i	aed0, \ptr, .Lxchal_ofs_+40
+	ae_l64.i	aed1, \ptr, .Lxchal_ofs_+48
+	ae_l64.i	aed2, \ptr, .Lxchal_ofs_+56
+	addi	\ptr, \ptr, 64
+	ae_l64.i	aed3, \ptr, .Lxchal_ofs_+0
+	ae_l64.i	aed4, \ptr, .Lxchal_ofs_+8
+	ae_l64.i	aed5, \ptr, .Lxchal_ofs_+16
+	ae_l64.i	aed6, \ptr, .Lxchal_ofs_+24
+	ae_l64.i	aed7, \ptr, .Lxchal_ofs_+32
+	ae_l64.i	aed8, \ptr, .Lxchal_ofs_+40
+	ae_l64.i	aed9, \ptr, .Lxchal_ofs_+48
+	ae_l64.i	aed10, \ptr, .Lxchal_ofs_+56
+	addi	\ptr, \ptr, 64
+	ae_l64.i	aed11, \ptr, .Lxchal_ofs_+0
+	ae_l64.i	aed12, \ptr, .Lxchal_ofs_+8
+	ae_l64.i	aed13, \ptr, .Lxchal_ofs_+16
+	ae_l64.i	aed14, \ptr, .Lxchal_ofs_+24
+	ae_l64.i	aed15, \ptr, .Lxchal_ofs_+32
+	addi	\ptr, \ptr, 40
+	l8ui	\at1, \ptr, .Lxchal_ofs_+0
+	ae_movea	aep0, \at1
+	l8ui	\at1, \ptr, .Lxchal_ofs_+1
+	ae_movea	aep1, \at1
+	l8ui	\at1, \ptr, .Lxchal_ofs_+2
+	ae_movea	aep2, \at1
+	l8ui	\at1, \ptr, .Lxchal_ofs_+3
+	ae_movea	aep3, \at1
+	addi	\ptr, \ptr, 8
+	ae_lalign64.i	u0, \ptr, .Lxchal_ofs_+0
+	ae_lalign64.i	u1, \ptr, .Lxchal_ofs_+8
+	ae_lalign64.i	u2, \ptr, .Lxchal_ofs_+16
+	ae_lalign64.i	u3, \ptr, .Lxchal_ofs_+24
+	.set	.Lxchal_pofs_, .Lxchal_pofs_ + 176
+	.set	.Lxchal_ofs_, .Lxchal_ofs_ + 32
+	.elseif ((XTHAL_SAS_TIE | XTHAL_SAS_NOCC | XTHAL_SAS_CALR) & ~(\alloc)) == 0
+	xchal_sa_align	\ptr, 0, 0, 8, 8
+	.set	.Lxchal_ofs_, .Lxchal_ofs_ + 208
+	.endif
+    .endm	// xchal_cp1_load
+
+#define XCHAL_CP1_NUM_ATMPS	1
+#define XCHAL_SA_NUM_ATMPS	1
+
+	/*  Empty macros for unconfigured coprocessors:  */
+	.macro xchal_cp0_store	p a b c d continue=0 ofs=-1 select=-1 ; .endm
+	.macro xchal_cp0_load	p a b c d continue=0 ofs=-1 select=-1 ; .endm
+	.macro xchal_cp2_store	p a b c d continue=0 ofs=-1 select=-1 ; .endm
+	.macro xchal_cp2_load	p a b c d continue=0 ofs=-1 select=-1 ; .endm
+	.macro xchal_cp3_store	p a b c d continue=0 ofs=-1 select=-1 ; .endm
+	.macro xchal_cp3_load	p a b c d continue=0 ofs=-1 select=-1 ; .endm
+	.macro xchal_cp4_store	p a b c d continue=0 ofs=-1 select=-1 ; .endm
+	.macro xchal_cp4_load	p a b c d continue=0 ofs=-1 select=-1 ; .endm
+	.macro xchal_cp5_store	p a b c d continue=0 ofs=-1 select=-1 ; .endm
+	.macro xchal_cp5_load	p a b c d continue=0 ofs=-1 select=-1 ; .endm
+	.macro xchal_cp6_store	p a b c d continue=0 ofs=-1 select=-1 ; .endm
+	.macro xchal_cp6_load	p a b c d continue=0 ofs=-1 select=-1 ; .endm
+	.macro xchal_cp7_store	p a b c d continue=0 ofs=-1 select=-1 ; .endm
+	.macro xchal_cp7_load	p a b c d continue=0 ofs=-1 select=-1 ; .endm
+
+#endif /*_XTENSA_CORE_TIE_ASM_H*/
+

--- a/src/platform/imx8/include/arch/xtensa/config/tie.h
+++ b/src/platform/imx8/include/arch/xtensa/config/tie.h
@@ -1,0 +1,188 @@
+/* 
+ * tie.h -- compile-time HAL definitions dependent on CORE & TIE configuration
+ *
+ *  NOTE:  This header file is not meant to be included directly.
+ */
+
+/* This header file describes this specific Xtensa processor's TIE extensions
+   that extend basic Xtensa core functionality.  It is customized to this
+   Xtensa processor configuration.
+
+   Customer ID=12445; Build=0x700c0; Copyright (c) 1999-2017 Cadence Design Systems Inc.
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+   IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+   CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+   TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
+
+#ifndef _XTENSA_CORE_TIE_H
+#define _XTENSA_CORE_TIE_H
+
+#define XCHAL_CP_NUM			1	/* number of coprocessors */
+#define XCHAL_CP_MAX			2	/* max CP ID + 1 (0 if none) */
+#define XCHAL_CP_MASK			0x02	/* bitmask of all CPs by ID */
+#define XCHAL_CP_PORT_MASK		0x00	/* bitmask of only port CPs */
+
+/*  Basic parameters of each coprocessor:  */
+#define XCHAL_CP1_NAME			"AudioEngineLX"
+#define XCHAL_CP1_IDENT			AudioEngineLX
+#define XCHAL_CP1_SA_SIZE		208	/* size of state save area */
+#define XCHAL_CP1_SA_ALIGN		8	/* min alignment of save area */
+#define XCHAL_CP_ID_AUDIOENGINELX   	1	/* coprocessor ID (0..7) */
+
+/*  Filler info for unassigned coprocessors, to simplify arrays etc:  */
+#define XCHAL_CP0_SA_SIZE		0
+#define XCHAL_CP0_SA_ALIGN		1
+#define XCHAL_CP2_SA_SIZE		0
+#define XCHAL_CP2_SA_ALIGN		1
+#define XCHAL_CP3_SA_SIZE		0
+#define XCHAL_CP3_SA_ALIGN		1
+#define XCHAL_CP4_SA_SIZE		0
+#define XCHAL_CP4_SA_ALIGN		1
+#define XCHAL_CP5_SA_SIZE		0
+#define XCHAL_CP5_SA_ALIGN		1
+#define XCHAL_CP6_SA_SIZE		0
+#define XCHAL_CP6_SA_ALIGN		1
+#define XCHAL_CP7_SA_SIZE		0
+#define XCHAL_CP7_SA_ALIGN		1
+
+/*  Save area for non-coprocessor optional and custom (TIE) state:  */
+#define XCHAL_NCP_SA_SIZE		12
+#define XCHAL_NCP_SA_ALIGN		4
+
+/*  Total save area for optional and custom state (NCP + CPn):  */
+#define XCHAL_TOTAL_SA_SIZE		224	/* with 16-byte align padding */
+#define XCHAL_TOTAL_SA_ALIGN		8	/* actual minimum alignment */
+
+/*
+ * Detailed contents of save areas.
+ * NOTE:  caller must define the XCHAL_SA_REG macro (not defined here)
+ * before expanding the XCHAL_xxx_SA_LIST() macros.
+ *
+ * XCHAL_SA_REG(s,ccused,abikind,kind,opt,name,galign,align,asize,
+ *		dbnum,base,regnum,bitsz,gapsz,reset,x...)
+ *
+ *	s = passed from XCHAL_*_LIST(s), eg. to select how to expand
+ *	ccused = set if used by compiler without special options or code
+ *	abikind = 0 (caller-saved), 1 (callee-saved), or 2 (thread-global)
+ *	kind = 0 (special reg), 1 (TIE user reg), or 2 (TIE regfile reg)
+ *	opt = 0 (custom TIE extension or coprocessor), or 1 (optional reg)
+ *	name = lowercase reg name (no quotes)
+ *	galign = group byte alignment (power of 2) (galign >= align)
+ *	align = register byte alignment (power of 2)
+ *	asize = allocated size in bytes (asize*8 == bitsz + gapsz + padsz)
+ *	  (not including any pad bytes required to galign this or next reg)
+ *	dbnum = unique target number f/debug (see <xtensa-libdb-macros.h>)
+ *	base = reg shortname w/o index (or sr=special, ur=TIE user reg)
+ *	regnum = reg index in regfile, or special/TIE-user reg number
+ *	bitsz = number of significant bits (regfile width, or ur/sr mask bits)
+ *	gapsz = intervening bits, if bitsz bits not stored contiguously
+ *	(padsz = pad bits at end [TIE regfile] or at msbits [ur,sr] of asize)
+ *	reset = register reset value (or 0 if undefined at reset)
+ *	x = reserved for future use (0 until then)
+ *
+ *  To filter out certain registers, e.g. to expand only the non-global
+ *  registers used by the compiler, you can do something like this:
+ *
+ *  #define XCHAL_SA_REG(s,ccused,p...)	SELCC##ccused(p)
+ *  #define SELCC0(p...)
+ *  #define SELCC1(abikind,p...)	SELAK##abikind(p)
+ *  #define SELAK0(p...)		REG(p)
+ *  #define SELAK1(p...)		REG(p)
+ *  #define SELAK2(p...)
+ *  #define REG(kind,tie,name,galn,aln,asz,csz,dbnum,base,rnum,bsz,rst,x...) \
+ *		...what you want to expand...
+ */
+
+#define XCHAL_NCP_SA_NUM	3
+#define XCHAL_NCP_SA_LIST(s)	\
+ XCHAL_SA_REG(s,1,2,1,1,      threadptr, 4, 4, 4,0x03E7,  ur,231, 32,0,0,0) \
+ XCHAL_SA_REG(s,0,0,0,1,             br, 4, 4, 4,0x0204,  sr,4  , 16,0,0,0) \
+ XCHAL_SA_REG(s,0,0,0,1,      scompare1, 4, 4, 4,0x020C,  sr,12 , 32,0,0,0)
+
+#define XCHAL_CP0_SA_NUM	0
+#define XCHAL_CP0_SA_LIST(s)	/* empty */
+
+#define XCHAL_CP1_SA_NUM	33
+#define XCHAL_CP1_SA_LIST(s)	\
+ XCHAL_SA_REG(s,0,0,1,0,        fcr_fsr, 8, 8, 8,0x1019,  ur,-1 ,  7,0,0,0) \
+ XCHAL_SA_REG(s,0,0,1,0,     ae_ovf_sar, 4, 4, 4,0x03F0,  ur,240, 15,0,0,0) \
+ XCHAL_SA_REG(s,0,0,1,0,     ae_bithead, 4, 4, 4,0x03F1,  ur,241, 32,0,0,0) \
+ XCHAL_SA_REG(s,0,0,1,0,ae_ts_fts_bu_bp, 4, 4, 4,0x03F2,  ur,242, 16,0,0,0) \
+ XCHAL_SA_REG(s,0,0,1,0,    ae_cw_sd_no, 4, 4, 4,0x03F3,  ur,243, 29,0,0,0) \
+ XCHAL_SA_REG(s,0,0,1,0,     ae_cbegin0, 4, 4, 4,0x03F6,  ur,246, 32,0,0,0) \
+ XCHAL_SA_REG(s,0,0,1,0,       ae_cend0, 4, 4, 4,0x03F7,  ur,247, 32,0,0,0) \
+ XCHAL_SA_REG(s,0,0,1,0,     ae_cbegin1, 4, 4, 4,0x03F8,  ur,248, 32,0,0,0) \
+ XCHAL_SA_REG(s,0,0,1,0,       ae_cend1, 4, 4, 4,0x03F9,  ur,249, 32,0,0,0) \
+ XCHAL_SA_REG(s,0,0,2,0,           aed0, 8, 8, 8,0x1000, aed,0  , 64,0,0,0) \
+ XCHAL_SA_REG(s,0,0,2,0,           aed1, 8, 8, 8,0x1001, aed,1  , 64,0,0,0) \
+ XCHAL_SA_REG(s,0,0,2,0,           aed2, 8, 8, 8,0x1002, aed,2  , 64,0,0,0) \
+ XCHAL_SA_REG(s,0,0,2,0,           aed3, 8, 8, 8,0x1003, aed,3  , 64,0,0,0) \
+ XCHAL_SA_REG(s,0,0,2,0,           aed4, 8, 8, 8,0x1004, aed,4  , 64,0,0,0) \
+ XCHAL_SA_REG(s,0,0,2,0,           aed5, 8, 8, 8,0x1005, aed,5  , 64,0,0,0) \
+ XCHAL_SA_REG(s,0,0,2,0,           aed6, 8, 8, 8,0x1006, aed,6  , 64,0,0,0) \
+ XCHAL_SA_REG(s,0,0,2,0,           aed7, 8, 8, 8,0x1007, aed,7  , 64,0,0,0) \
+ XCHAL_SA_REG(s,0,0,2,0,           aed8, 8, 8, 8,0x1008, aed,8  , 64,0,0,0) \
+ XCHAL_SA_REG(s,0,0,2,0,           aed9, 8, 8, 8,0x1009, aed,9  , 64,0,0,0) \
+ XCHAL_SA_REG(s,0,0,2,0,          aed10, 8, 8, 8,0x100A, aed,10 , 64,0,0,0) \
+ XCHAL_SA_REG(s,0,0,2,0,          aed11, 8, 8, 8,0x100B, aed,11 , 64,0,0,0) \
+ XCHAL_SA_REG(s,0,0,2,0,          aed12, 8, 8, 8,0x100C, aed,12 , 64,0,0,0) \
+ XCHAL_SA_REG(s,0,0,2,0,          aed13, 8, 8, 8,0x100D, aed,13 , 64,0,0,0) \
+ XCHAL_SA_REG(s,0,0,2,0,          aed14, 8, 8, 8,0x100E, aed,14 , 64,0,0,0) \
+ XCHAL_SA_REG(s,0,0,2,0,          aed15, 8, 8, 8,0x100F, aed,15 , 64,0,0,0) \
+ XCHAL_SA_REG(s,0,0,2,0,           aep0, 1, 1, 1,0x1014, aep,0  ,  8,0,0,0) \
+ XCHAL_SA_REG(s,0,0,2,0,           aep1, 1, 1, 1,0x1015, aep,1  ,  8,0,0,0) \
+ XCHAL_SA_REG(s,0,0,2,0,           aep2, 1, 1, 1,0x1016, aep,2  ,  8,0,0,0) \
+ XCHAL_SA_REG(s,0,0,2,0,           aep3, 1, 1, 1,0x1017, aep,3  ,  8,0,0,0) \
+ XCHAL_SA_REG(s,0,0,2,0,             u0, 8, 8, 8,0x1010,   u,0  , 64,0,0,0) \
+ XCHAL_SA_REG(s,0,0,2,0,             u1, 8, 8, 8,0x1011,   u,1  , 64,0,0,0) \
+ XCHAL_SA_REG(s,0,0,2,0,             u2, 8, 8, 8,0x1012,   u,2  , 64,0,0,0) \
+ XCHAL_SA_REG(s,0,0,2,0,             u3, 8, 8, 8,0x1013,   u,3  , 64,0,0,0)
+
+#define XCHAL_CP2_SA_NUM	0
+#define XCHAL_CP2_SA_LIST(s)	/* empty */
+
+#define XCHAL_CP3_SA_NUM	0
+#define XCHAL_CP3_SA_LIST(s)	/* empty */
+
+#define XCHAL_CP4_SA_NUM	0
+#define XCHAL_CP4_SA_LIST(s)	/* empty */
+
+#define XCHAL_CP5_SA_NUM	0
+#define XCHAL_CP5_SA_LIST(s)	/* empty */
+
+#define XCHAL_CP6_SA_NUM	0
+#define XCHAL_CP6_SA_LIST(s)	/* empty */
+
+#define XCHAL_CP7_SA_NUM	0
+#define XCHAL_CP7_SA_LIST(s)	/* empty */
+
+/* Byte length of instruction from its first nibble (op0 field), per FLIX.  */
+/* (not available, must use XCHAL_BYTE0_FORMAT_LENGTHS for this processor) */
+/* Byte length of instruction from its first byte, per FLIX.  */
+#define XCHAL_BYTE0_FORMAT_LENGTHS	\
+	3,3,3,3,3,3,3,3,2,2,2,2,2,2,6,11, 3,3,3,3,3,3,3,3,2,2,2,2,2,2,6,11,\
+	3,3,3,3,3,3,3,3,2,2,2,2,2,2,6,3, 3,3,3,3,3,3,3,3,2,2,2,2,2,2,6,11,\
+	3,3,3,3,3,3,3,3,2,2,2,2,2,2,6,11, 3,3,3,3,3,3,3,3,2,2,2,2,2,2,6,11,\
+	3,3,3,3,3,3,3,3,2,2,2,2,2,2,6,3, 3,3,3,3,3,3,3,3,2,2,2,2,2,2,6,11,\
+	3,3,3,3,3,3,3,3,2,2,2,2,2,2,6,11, 3,3,3,3,3,3,3,3,2,2,2,2,2,2,6,11,\
+	3,3,3,3,3,3,3,3,2,2,2,2,2,2,6,3, 3,3,3,3,3,3,3,3,2,2,2,2,2,2,6,11,\
+	3,3,3,3,3,3,3,3,2,2,2,2,2,2,6,11, 3,3,3,3,3,3,3,3,2,2,2,2,2,2,6,11,\
+	3,3,3,3,3,3,3,3,2,2,2,2,2,2,6,3, 3,3,3,3,3,3,3,3,2,2,2,2,2,2,6,11
+
+#endif /*_XTENSA_CORE_TIE_H*/
+

--- a/src/platform/imx8/include/platform/clk-map.h
+++ b/src/platform/imx8/include/platform/clk-map.h
@@ -1,0 +1,22 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright 2019 NXP
+ *
+ * Author: Daniel Baluta <daniel.baluta@nxp.com>
+ */
+
+#ifndef __INCLUDE_CLOCK_MAP__
+#define __INCLUDE_CLOCK_MAP__
+
+#include <sof/clk.h>
+static const struct freq_table cpu_freq[] = {
+	{666000000, 666000, 0x0}, /* default */
+};
+
+/* TODO: abstract SSP clk based on platform and remove this from here! */
+static const struct freq_table ssp_freq[] = {
+	{19200000, 19200, 19}, /* default */
+	{25000000, 25000, 12},
+};
+
+#endif

--- a/src/platform/imx8/include/platform/clk.h
+++ b/src/platform/imx8/include/platform/clk.h
@@ -1,0 +1,36 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright 2019 NXP
+ *
+ * Author: Daniel Baluta <daniel.baluta@nxp.com>
+ */
+
+#ifndef __PLATFORM_CLOCK__
+#define __PLATFORM_CLOCK__
+
+#include <sof/io.h>
+
+#define CLK_CPU(x)	(x)
+#define CLK_SSP		1
+
+#define CPU_DEFAULT_IDX		0
+#define SSP_DEFAULT_IDX		1
+
+#define CLK_DEFAULT_CPU_HZ	666000000
+#define CLK_MAX_CPU_HZ		666000000
+
+#define NUM_CLOCKS	1
+
+static inline int clock_platform_set_cpu_freq(uint32_t cpu_freq_enc)
+{
+	return 0;
+}
+
+/* FIXME: compile out clock_platform_set_ssp_freq */
+static inline int clock_platform_set_ssp_freq(uint32_t ssp_freq_enc)
+{
+	/* we don't even have SSP */
+	return 0;
+}
+
+#endif

--- a/src/platform/imx8/include/platform/dai.h
+++ b/src/platform/imx8/include/platform/dai.h
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright 2019 NXP
+ *
+ * Author: Daniel Baluta <daniel.baluta@nxp.com>
+ */
+
+#ifndef __PLATFORM_DAI_H__
+#define __PLATFORM_DAI_H__
+
+int dai_init(void);
+
+#endif

--- a/src/platform/imx8/include/platform/dma.h
+++ b/src/platform/imx8/include/platform/dma.h
@@ -1,0 +1,21 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright 2019 NXP
+ *
+ * Author: Daniel Baluta <daniel.baluta@nxp.com>
+ */
+
+#ifndef __PLATFORM_DMA_H__
+#define __PLATFORM_DMA_H__
+
+#include <stdint.h>
+#include <sof/dma.h>
+
+#define PLATFORM_NUM_DMACS	2
+
+#define DMA_ID_EDMA0	0
+#define DMA_ID_HOST	1
+
+int dmac_init(void);
+
+#endif

--- a/src/platform/imx8/include/platform/idc.h
+++ b/src/platform/imx8/include/platform/idc.h
@@ -1,0 +1,18 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright 2019 NXP
+ *
+ * Author: Daniel Baluta <daniel.baluta@nxp.com>
+ */
+
+#ifndef __INCLUDE_PLATFORM_IDC_H__
+#define __INCLUDE_PLATFORM_IDC_H__
+
+struct idc_msg;
+
+static inline int idc_send_msg(struct idc_msg *msg,
+			       uint32_t mode) { return 0; }
+
+static inline void idc_init(void) { }
+
+#endif

--- a/src/platform/imx8/include/platform/interrupt.h
+++ b/src/platform/imx8/include/platform/interrupt.h
@@ -1,0 +1,48 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright 2019 NXP
+ *
+ * Author: Daniel Baluta <daniel.baluta@nxp.com>
+ */
+
+#ifndef __INCLUDE_PLATFORM_INTERRUPT__
+#define __INCLUDE_PLATFORM_INTERRUPT__
+
+#include <stdint.h>
+#include <string.h>
+#include <sof/interrupt-map.h>
+
+/* IRQ numbers */
+#define IRQ_NUM_TIMER0		2	/* Level 2 */
+#define IRQ_NUM_TIMER1		3	/* Level 3 */
+#define IRQ_NUM_MU		7	/* Level 2 */
+#define IRQ_NUM_SOFTWARE0	8	/* Level 1 */
+#define IRQ_NUM_SOFTWARE1	9	/* Level 2 */
+#define IRQ_NUM_IRQSTR_DSP0	19	/* Level 2 */
+#define IRQ_NUM_IRQSTR_DSP1	19	/* Level 2 */
+#define IRQ_NUM_IRQSTR_DSP2	20	/* Level 2 */
+#define IRQ_NUM_IRQSTR_DSP3	21	/* Level 2 */
+#define IRQ_NUM_IRQSTR_DSP4	22	/* Level 2 */
+#define IRQ_NUM_IRQSTR_DSP5	23	/* Level 2 */
+#define IRQ_NUM_IRQSTR_DSP6	24	/* Level 2 */
+#define IRQ_NUM_IRQSTR_DSP7	25	/* Level 2 */
+
+/* IRQ Masks */
+#define IRQ_MASK_TIMER0		(1 << IRQ_NUM_TIMER0)
+#define IRQ_MASK_TIMER1		(1 << IRQ_NUM_TIMER1)
+#define IRQ_MASK_MU		(1 << IRQ_NUM_MU)
+#define IRQ_MASK_SOFTWARE0	(1 << IRQ_NUM_SOFTWARE0)
+#define IRQ_MASK_SOFTWARE1	(1 << IRQ_NUM_SOFTWARE1)
+#define IRQ_MASK_IRQSTR_DSP0	(1 << IRQ_NUM_IRQSTR_DSP0)
+#define IRQ_MASK_IRQSTR_DSP1	(1 << IRQ_NUM_IRQSTR_DSP1)
+#define IRQ_MASK_IRQSTR_DSP2	(1 << IRQ_NUM_IRQSTR_DSP2)
+#define IRQ_MASK_IRQSTR_DSP3	(1 << IRQ_NUM_IRQSTR_DSP3)
+#define IRQ_MASK_IRQSTR_DSP4	(1 << IRQ_NUM_IRQSTR_DSP4)
+#define IRQ_MASK_IRQSTR_DSP5	(1 << IRQ_NUM_IRQSTR_DSP5)
+#define IRQ_MASK_IRQSTR_DSP6	(1 << IRQ_NUM_IRQSTR_DSP6)
+#define IRQ_MASK_IRQSTR_DSP7	(1 << IRQ_NUM_IRQSTR_DSP7)
+
+/* no nested interrupts */
+#define PLATFORM_IRQ_CHILDREN	0
+
+#endif

--- a/src/platform/imx8/include/platform/mailbox.h
+++ b/src/platform/imx8/include/platform/mailbox.h
@@ -1,0 +1,52 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright 2019 NXP
+ *
+ * Author: Daniel Baluta <daniel.baluta@nxp.com>
+ */
+
+#ifndef __INCLUDE_PLATFORM_MAILBOX__
+#define __INCLUDE_PLATFORM_MAILBOX__
+
+#include <platform/memory.h>
+
+/*
+ * The Window Region on i.MX8 SRAM is organised like this :-
+ * +--------------------------------------------------------------------------+
+ * | Offset              | Region         |  Size                             |
+ * +---------------------+----------------+-----------------------------------+
+ * | SRAM_TRACE_BASE     | Trace Buffer   |  SRAM_TRACE_SIZE                  |
+ * +---------------------+----------------+-----------------------------------+
+ * | SRAM_DEBUG_BASE     | Debug data     |  SRAM_DEBUG_SIZE                  |
+ * +---------------------+----------------+-----------------------------------+
+ * | SRAM_INBOX_BASE     | Inbox          |  SRAM_INBOX_SIZE                  |
+ * +---------------------+----------------+-----------------------------------+
+ * | SRAM_OUTBOX_BASE    | Outbox         |  SRAM_MAILBOX_SIZE                |
+ * +---------------------+----------------+-----------------------------------+
+ */
+
+#define MAILBOX_DSPBOX_SIZE		SRAM_OUTBOX_SIZE
+#define MAILBOX_DSPBOX_BASE		SRAM_OUTBOX_BASE
+#define MAILBOX_DSPBOX_OFFSET		SRAM_OUTBOX_OFFSET
+
+#define MAILBOX_HOSTBOX_SIZE		SRAM_INBOX_SIZE
+#define MAILBOX_HOSTBOX_BASE		SRAM_INBOX_BASE
+#define MAILBOX_HOSTBOX_OFFSET		SRAM_INBOX_OFFSET
+
+#define MAILBOX_DEBUG_SIZE		SRAM_DEBUG_SIZE
+#define MAILBOX_DEBUG_BASE		SRAM_DEBUG_BASE
+#define MAILBOX_DEBUG_OFFSET		SRAM_DEBUG_OFFSET
+
+#define MAILBOX_TRACE_SIZE		SRAM_TRACE_SIZE
+#define MAILBOX_TRACE_BASE		SRAM_TRACE_BASE
+#define MAILBOX_TRACE_OFFSET		SRAM_TRACE_OFFSET
+
+#define MAILBOX_EXCEPTION_SIZE		SRAM_EXCEPT_SIZE
+#define MAILBOX_EXCEPTION_BASE		SRAM_EXCEPT_BASE
+#define MAILBOX_EXCEPTION_OFFSET	SRAM_DEBUG_SIZE
+
+#define MAILBOX_STREAM_SIZE		SRAM_STREAM_SIZE
+#define MAILBOX_STREAM_BASE		SRAM_STREAM_BASE
+#define MAILBOX_STREAM_OFFSET		SRAM_STREAM_OFFSET
+
+#endif

--- a/src/platform/imx8/include/platform/memory.h
+++ b/src/platform/imx8/include/platform/memory.h
@@ -1,0 +1,168 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright 2019 NXP
+ *
+ * Author: Daniel Baluta <daniel.baluta@nxp.com>
+ */
+
+#ifndef __PLATFORM_MEMORY_H__
+#define __PLATFORM_MEMORY_H__
+
+#include <config.h>
+#include <arch/memory.h>
+
+#define PLATFORM_CORE_COUNT             1
+
+/* physical DSP addresses */
+
+#define IRAM_BASE	0x596f8000
+#define IRAM_SIZE	0x800
+
+#define DRAM0_BASE	0x596e8000
+#define DRAM0_SIZE	0x8000
+
+#define DRAM1_BASE	0x596f0000
+#define DRAM1_SIZE	0x8000
+
+#define SDRAM0_BASE	0x92400000
+#define SDRAM0_SIZE	0x800000
+
+#define SDRAM1_BASE	0x92C00000
+#define SDRAM1_SIZE	0x800000
+
+#define XSHAL_MU13_SIDEB_BYPASS_PADDR 0x5D310000
+#define MU_BASE		XSHAL_MU13_SIDEB_BYPASS_PADDR
+
+#define EDMA0_BASE	0x59200000
+#define EDMA0_SIZE	0x10000
+
+#define ESAI_BASE	0x59010000
+#define ESAI_SIZE	0x00001000
+
+#define LOG_ENTRY_ELF_BASE	0x20000000
+#define LOG_ENTRY_ELF_SIZE	0x2000000
+
+/*
+ * The Heap and Stack on i.MX8 are organised like this :-
+ *
+ * +--------------------------------------------------------------------------+
+ * | Offset              | Region         |  Size                             |
+ * +---------------------+----------------+-----------------------------------+
+ * | SDRAM_BASE          | RO Data        |  SOF_DATA_SIZE                    |
+ * |                     | Data           |                                   |
+ * |                     | BSS            |                                   |
+ * +---------------------+----------------+-----------------------------------+
+ * | HEAP_SYSTEM_BASE    | System Heap    |  HEAP_SYSTEM_SIZE                 |
+ * +---------------------+----------------+-----------------------------------+
+ * | HEAP_RUNTIME_BASE   | Runtime Heap   |  HEAP_RUNTIME_SIZE                |
+ * +---------------------+----------------+-----------------------------------+
+ * | HEAP_BUFFER_BASE    | Module Buffers |  HEAP_BUFFER_SIZE                 |
+ * +---------------------+----------------+-----------------------------------+
+ * | SOF_STACK_END       | Stack          |  SOF_STACK_SIZE                   |
+ * +---------------------+----------------+-----------------------------------+
+ * | SOF_STACK_BASE      |                |                                   |
+ * +---------------------+----------------+-----------------------------------+
+ */
+
+/* Mailbox configuration */
+#define SRAM_OUTBOX_BASE	SDRAM1_BASE
+#define SRAM_OUTBOX_SIZE	0x1000
+#define SRAM_OUTBOX_OFFSET	0
+
+#define SRAM_INBOX_BASE		(SRAM_OUTBOX_BASE + SRAM_OUTBOX_SIZE)
+#define SRAM_INBOX_SIZE		0x1000
+#define SRAM_INBOX_OFFSET	SRAM_OUTBOX_SIZE
+
+#define SRAM_DEBUG_BASE		(SRAM_INBOX_BASE + SRAM_INBOX_SIZE)
+#define SRAM_DEBUG_SIZE		0x800
+#define SRAM_DEBUG_OFFSET	(SRAM_INBOX_OFFSET + SRAM_INBOX_SIZE)
+
+#define SRAM_EXCEPT_BASE	(SRAM_DEBUG_BASE + SRAM_DEBUG_SIZE)
+#define SRAM_EXCEPT_SIZE	0x800
+#define SRAM_EXCEPT_OFFSET	(SRAM_DEBUG_OFFSET + SRAM_DEBUG_SIZE)
+
+#define SRAM_STREAM_BASE	(SRAM_EXCEPT_BASE + SRAM_EXCEPT_SIZE)
+#define SRAM_STREAM_SIZE	0x1000
+#define SRAM_STREAM_OFFSET	(SRAM_EXCEPT_OFFSET + SRAM_EXCEPT_SIZE)
+
+#define SRAM_TRACE_BASE		(SRAM_STREAM_BASE + SRAM_STREAM_SIZE)
+#define SRAM_TRACE_SIZE		0x1000
+#define SRAM_TRACE_OFFSET (SRAM_STREAM_OFFSET + SRAM_STREAM_SIZE)
+
+#define SOF_MAILBOX_SIZE	(SRAM_INBOX_SIZE + SRAM_OUTBOX_SIZE \
+				+ SRAM_DEBUG_SIZE + SRAM_EXCEPT_SIZE \
+				+ SRAM_STREAM_SIZE + SRAM_TRACE_SIZE)
+
+/* Heap section sizes for module pool */
+#define HEAP_RT_COUNT8		0
+#define HEAP_RT_COUNT16		48
+#define HEAP_RT_COUNT32		48
+#define HEAP_RT_COUNT64		32
+#define HEAP_RT_COUNT128	32
+#define HEAP_RT_COUNT256	32
+#define HEAP_RT_COUNT512	4
+#define HEAP_RT_COUNT1024	4
+
+/* Heap section sizes for system runtime heap */
+#define HEAP_SYS_RT_COUNT64	64
+#define HEAP_SYS_RT_COUNT512	8
+#define HEAP_SYS_RT_COUNT1024	4
+
+/* Heap configuration */
+
+#define HEAP_SYSTEM_BASE	SDRAM1_BASE + SOF_MAILBOX_SIZE
+#define HEAP_SYSTEM_SIZE	0xe000
+
+#define HEAP_SYSTEM_0_BASE	HEAP_SYSTEM_BASE
+
+#define HEAP_SYS_RUNTIME_BASE	(HEAP_SYSTEM_BASE + HEAP_SYSTEM_SIZE)
+#define HEAP_SYS_RUNTIME_SIZE \
+	(HEAP_SYS_RT_COUNT64 * 64 + HEAP_SYS_RT_COUNT512 * 512 + \
+	HEAP_SYS_RT_COUNT1024 * 1024)
+
+#define HEAP_RUNTIME_BASE	(HEAP_SYS_RUNTIME_BASE + HEAP_SYS_RUNTIME_SIZE)
+#define HEAP_RUNTIME_SIZE \
+	(HEAP_RT_COUNT8 * 8 + HEAP_RT_COUNT16 * 16 + \
+	HEAP_RT_COUNT32 * 32 + HEAP_RT_COUNT64 * 64 + \
+	HEAP_RT_COUNT128 * 128 + HEAP_RT_COUNT256 * 256 + \
+	HEAP_RT_COUNT512 * 512 + HEAP_RT_COUNT1024 * 1024)
+
+#define HEAP_BUFFER_BASE	(HEAP_RUNTIME_BASE + HEAP_RUNTIME_SIZE)
+#define HEAP_BUFFER_SIZE \
+	(SDRAM1_SIZE - SOF_MAILBOX_SIZE - HEAP_RUNTIME_SIZE - SOF_STACK_TOTAL_SIZE -\
+	HEAP_SYS_RUNTIME_SIZE - HEAP_SYSTEM_SIZE)
+
+#define HEAP_BUFFER_BLOCK_SIZE		0x180
+#define HEAP_BUFFER_COUNT	(HEAP_BUFFER_SIZE / HEAP_BUFFER_BLOCK_SIZE)
+
+#define PLATFORM_HEAP_SYSTEM		1 /* one per core */
+#define PLATFORM_HEAP_SYSTEM_RUNTIME	1 /* one per core */
+#define PLATFORM_HEAP_RUNTIME		1
+#define PLATFORM_HEAP_BUFFER		1
+
+/* Stack configuration */
+#define SOF_STACK_SIZE		ARCH_STACK_SIZE
+#define SOF_STACK_TOTAL_SIZE	ARCH_STACK_TOTAL_SIZE
+#define SOF_STACK_BASE		(SDRAM1_BASE + SDRAM1_SIZE)
+#define SOF_STACK_END		(SOF_STACK_BASE - SOF_STACK_TOTAL_SIZE)
+
+/* Vector and literal sizes - not in core-isa.h */
+#define SOF_MEM_VECT_LIT_SIZE		0x4
+#define SOF_MEM_VECT_TEXT_SIZE		0x1c
+#define SOF_MEM_VECT_SIZE		(SOF_MEM_VECT_TEXT_SIZE + SOF_MEM_VECT_LIT_SIZE)
+
+#define SOF_MEM_RESET_TEXT_SIZE		0x2e0
+#define SOF_MEM_RESET_LIT_SIZE		0x120
+#define SOF_MEM_VECBASE_LIT_SIZE	0x178
+
+#define SOF_MEM_RO_SIZE			0x8
+
+#define uncache_to_cache(address)	address
+#define cache_to_uncache(address)	address
+#define is_uncached(address)		0
+
+#if !defined(__ASSEMBLER__) && !defined(LINKER)
+void platform_init_memmap(void);
+#endif
+
+#endif

--- a/src/platform/imx8/include/platform/mu.h
+++ b/src/platform/imx8/include/platform/mu.h
@@ -1,0 +1,63 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright 2019 NXP
+ *
+ * Author: Daniel Baluta <daniel.baluta@nxp.com>
+ */
+
+/* Transmit Register */
+#define IMX_MU_xTRn(x)		(0x00 + 4 * (x))
+/* Receive Register */
+#define IMX_MU_xRRn(x)		(0x10 + 4 * (x))
+/* Status Register */
+#define IMX_MU_xSR		0x20
+#define IMX_MU_xSR_GIPn(x)	BIT(28 + (3 - (x)))
+#define IMX_MU_xSR_RFn(x)	BIT(24 + (3 - (x)))
+#define IMX_MU_xSR_TEn(x)	BIT(20 + (3 - (x)))
+#define IMX_MU_xSR_BRDIP	BIT(9)
+
+/* Control Register */
+#define IMX_MU_xCR		0x24
+/* General Purpose Interrupt Enable */
+#define IMX_MU_xCR_GIEn(x)	BIT(28 + (3 - (x)))
+/* Receive Interrupt Enable */
+#define IMX_MU_xCR_RIEn(x)	BIT(24 + (3 - (x)))
+/* Transmit Interrupt Enable */
+#define IMX_MU_xCR_TIEn(x)	BIT(20 + (3 - (x)))
+/* General Purpose Interrupt Request */
+#define IMX_MU_xCR_GIRn(x)	BIT(16 + (3 - (x)))
+
+static inline uint32_t imx_mu_read(uint32_t reg)
+{
+	return *((volatile uint32_t*)(MU_BASE + reg));
+}
+
+static inline void imx_mu_write(uint32_t val, uint32_t reg)
+{
+	*((volatile uint32_t*)(MU_BASE + reg)) = val;
+}
+
+static inline uint32_t imx_mu_xcr_rmw(uint32_t set, uint32_t clr)
+{
+	volatile uint32_t val;
+
+	val = imx_mu_read(IMX_MU_xCR);
+	val &= ~clr;
+	val |= set;
+	imx_mu_write(val, IMX_MU_xCR);
+
+	return val;
+}
+
+static inline uint32_t imx_mu_xsr_rmw(uint32_t set, uint32_t clr)
+{
+	volatile uint32_t val;
+
+	val = imx_mu_read(IMX_MU_xSR);
+	val &= ~clr;
+	val |= set;
+	imx_mu_write(val, IMX_MU_xSR);
+
+	return val;
+}
+

--- a/src/platform/imx8/include/platform/platform.h
+++ b/src/platform/imx8/include/platform/platform.h
@@ -1,0 +1,98 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright 2019 NXP
+ *
+ * Author: Daniel Baluta <daniel.baluta@nxp.com>
+ */
+
+#ifndef __PLATFORM_PLATFORM_H__
+#define __PLATFORM_PLATFORM_H__
+
+#include <sof/platform.h>
+#include <platform/interrupt.h>
+
+struct sof;
+
+#define PLATFORM_DEFAULT_CLOCK CLK_CPU(0)
+#define PLATFORM_MASTER_CORE_ID	0
+#define PLATFORM_CORE_COUNT	1
+#define LPSRAM_SIZE 16384
+
+#define PLATFORM_WORKQ_DEFAULT_TIMEOUT	1000
+
+/* IPC Interrupt */
+#define PLATFORM_IPC_INTERRUPT	IRQ_NUM_MU
+
+/* Host page size */
+#define HOST_PAGE_SIZE		4096
+#define PLATFORM_PAGE_TABLE_SIZE	256
+
+/* pipeline IRQ */
+#define PLATFORM_SCHEDULE_IRQ	IRQ_NUM_SOFTWARE0
+
+#define PLATFORM_IRQ_TASK_HIGH	IRQ_NUM_SOFTWARE1
+#define PLATFORM_IRQ_TASK_MED	IRQ_NUM_SOFTWARE1
+#define PLATFORM_IRQ_TASK_LOW	IRQ_NUM_SOFTWARE1
+
+#define PLATFORM_SCHEDULE_COST	200
+
+/* maximum preload pipeline depth */
+#define MAX_PRELOAD_SIZE	20
+
+/* DMA treats PHY addresses as host address unless within DSP region */
+#define PLATFORM_HOST_DMA_MASK	0xFF000000
+
+/* Platform stream capabilities */
+#define PLATFORM_MAX_CHANNELS	4
+#define PLATFORM_MAX_STREAMS	5
+
+/* clock source used by scheduler for deadline calculations */
+#define PLATFORM_SCHED_CLOCK	PLATFORM_DEFAULT_CLOCK
+
+/* DMA channel drain timeout in microseconds - TODO: caclulate based on topology */
+#define PLATFORM_DMA_TIMEOUT	1333
+
+/* DMA host transfer timeouts in microseconds */
+#define PLATFORM_HOST_DMA_TIMEOUT	50
+
+/* WorkQ window size in microseconds */
+#define PLATFORM_WORKQ_WINDOW	2000
+
+/* platform WorkQ clock */
+#define PLATFORM_WORKQ_CLOCK	PLATFORM_DEFAULT_CLOCK
+
+/* local buffer size of DMA tracing */
+#define DMA_TRACE_LOCAL_SIZE	HOST_PAGE_SIZE
+
+/* trace bytes flushed during panic */
+#define DMA_FLUSH_TRACE_SIZE	(MAILBOX_TRACE_SIZE >> 2)
+
+/* the interval of DMA trace copying */
+#define DMA_TRACE_PERIOD		500000
+
+/*
+ * the interval of reschedule DMA trace copying in special case like half
+ * fullness of local DMA trace buffer
+ */
+#define DMA_TRACE_RESCHEDULE_TIME	100
+
+/* DSP should be idle in this time frame */
+#define PLATFORM_IDLE_TIME	750000
+
+/* DSP default delay in cycles */
+#define PLATFORM_DEFAULT_DELAY	12
+
+/* Platform defined panic code */
+static inline void platform_panic(uint32_t p)
+{
+}
+
+/* Platform defined trace code */
+#define platform_trace_point(__x)
+
+extern struct timer *platform_timer;
+
+extern intptr_t _module_init_start;
+extern intptr_t _module_init_end;
+
+#endif

--- a/src/platform/imx8/include/platform/pm_runtime.h
+++ b/src/platform/imx8/include/platform/pm_runtime.h
@@ -1,0 +1,39 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright 2019 NXP
+ *
+ * Author: Daniel Baluta <daniel.baluta@nxp.com>
+ */
+
+#ifndef __INCLUDE_PLATFORM_PM_RUNTIME__
+#define __INCLUDE_PLATFORM_PM_RUNTIME__
+
+#include <sof/pm_runtime.h>
+
+/**
+ * \brief Initializes platform specific runtime power management.
+ * \param[in,out] prd Runtime power management data.
+ */
+static inline void platform_pm_runtime_init(struct pm_runtime_data *prd) { }
+
+/**
+ * \brief Retrieves platform specific power management resource.
+ *
+ * \param[in] context Type of power management context.
+ * \param[in] index Index of the device.
+ * \param[in] flags Flags, set of RPM_...
+ */
+static inline void platform_pm_runtime_get(enum pm_runtime_context context,
+					   uint32_t index, uint32_t flags) { }
+
+/**
+ * \brief Releases platform specific power management resource.
+ *
+ * \param[in] context Type of power management context.
+ * \param[in] index Index of the device.
+ * \param[in] flags Flags, set of RPM_...
+ */
+static inline void platform_pm_runtime_put(enum pm_runtime_context context,
+					   uint32_t index, uint32_t flags) { }
+
+#endif /* __INCLUDE_PLATFORM_PM_RUNTIME__ */

--- a/src/platform/imx8/include/platform/timer.h
+++ b/src/platform/imx8/include/platform/timer.h
@@ -1,0 +1,21 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright 2019 NXP
+ *
+ * Author: Daniel Baluta <daniel.baluta@nxp.com>
+ */
+
+#ifndef __PLATFORM_TIMER_H__
+#define __PLATFORM_TIMER_H__
+
+#include <stdint.h>
+#include <sof/timer.h>
+#include <platform/interrupt.h>
+
+#define TIMER_COUNT	2
+
+/* timer numbers must use associated IRQ number */
+#define TIMER0		IRQ_NUM_TIMER0
+#define TIMER1		IRQ_NUM_TIMER1
+
+#endif

--- a/src/platform/imx8/memory.c
+++ b/src/platform/imx8/memory.c
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright 2019 NXP
+//
+// Author: Daniel Baluta <daniel.baluta@nxp.com>
+
+#include <sof/alloc.h>
+#include <uapi/ipc/header.h>
+
+/* Heap blocks for system runtime */
+static struct block_hdr sys_rt_block64[HEAP_SYS_RT_COUNT64];
+static struct block_hdr sys_rt_block512[HEAP_SYS_RT_COUNT512];
+static struct block_hdr sys_rt_block1024[HEAP_SYS_RT_COUNT1024];
+
+/* Heap memory for system runtime */
+static struct block_map sys_rt_heap_map[] = {
+	BLOCK_DEF(64, HEAP_SYS_RT_COUNT64, sys_rt_block64),
+	BLOCK_DEF(512, HEAP_SYS_RT_COUNT512, sys_rt_block512),
+	BLOCK_DEF(1024, HEAP_SYS_RT_COUNT1024, sys_rt_block1024),
+};
+
+/* Heap blocks for modules */
+static struct block_hdr mod_block16[HEAP_RT_COUNT16];
+static struct block_hdr mod_block32[HEAP_RT_COUNT32];
+static struct block_hdr mod_block64[HEAP_RT_COUNT64];
+static struct block_hdr mod_block128[HEAP_RT_COUNT128];
+static struct block_hdr mod_block256[HEAP_RT_COUNT256];
+static struct block_hdr mod_block512[HEAP_RT_COUNT512];
+static struct block_hdr mod_block1024[HEAP_RT_COUNT1024];
+
+/* Heap memory map for modules */
+static struct block_map rt_heap_map[] = {
+	BLOCK_DEF(16, HEAP_RT_COUNT16, mod_block16),
+	BLOCK_DEF(32, HEAP_RT_COUNT32, mod_block32),
+	BLOCK_DEF(64, HEAP_RT_COUNT64, mod_block64),
+	BLOCK_DEF(128, HEAP_RT_COUNT128, mod_block128),
+	BLOCK_DEF(256, HEAP_RT_COUNT256, mod_block256),
+	BLOCK_DEF(512, HEAP_RT_COUNT512, mod_block512),
+	BLOCK_DEF(1024, HEAP_RT_COUNT1024, mod_block1024),
+};
+
+/* Heap blocks for buffers */
+static struct block_hdr buf_block[HEAP_BUFFER_COUNT];
+
+/* Heap memory map for buffers */
+static struct block_map buf_heap_map[] = {
+	BLOCK_DEF(HEAP_BUFFER_BLOCK_SIZE, HEAP_BUFFER_COUNT, buf_block),
+};
+
+struct mm memmap = {
+	.system[0] = {
+		.heap = HEAP_SYSTEM_BASE,
+		.size = HEAP_SYSTEM_SIZE,
+		.info = {.free = HEAP_SYSTEM_SIZE,},
+		.caps = SOF_MEM_CAPS_RAM | SOF_MEM_CAPS_CACHE |
+			SOF_MEM_CAPS_DMA,
+	},
+	.system_runtime[0] = {
+		.blocks = ARRAY_SIZE(sys_rt_heap_map),
+		.map = sys_rt_heap_map,
+		.heap = HEAP_SYS_RUNTIME_BASE,
+		.size = HEAP_SYS_RUNTIME_SIZE,
+		.info = {.free = HEAP_SYS_RUNTIME_SIZE,},
+		.caps = SOF_MEM_CAPS_RAM | SOF_MEM_CAPS_CACHE |
+			SOF_MEM_CAPS_DMA,
+	},
+	.runtime[0] = {
+		.blocks = ARRAY_SIZE(rt_heap_map),
+		.map = rt_heap_map,
+		.heap = HEAP_RUNTIME_BASE,
+		.size = HEAP_RUNTIME_SIZE,
+		.info = {.free = HEAP_RUNTIME_SIZE,},
+		.caps = SOF_MEM_CAPS_RAM | SOF_MEM_CAPS_CACHE |
+			SOF_MEM_CAPS_DMA,
+	},
+	.buffer[0] = {
+		.blocks = ARRAY_SIZE(buf_heap_map),
+		.map = buf_heap_map,
+		.heap = HEAP_BUFFER_BASE,
+		.size = HEAP_BUFFER_SIZE,
+		.info = {.free = HEAP_BUFFER_SIZE,},
+		.caps = SOF_MEM_CAPS_RAM | SOF_MEM_CAPS_CACHE |
+			SOF_MEM_CAPS_DMA,
+	},
+	.total = {.free = HEAP_SYSTEM_SIZE + HEAP_SYS_RUNTIME_SIZE +
+			HEAP_RUNTIME_SIZE + HEAP_BUFFER_SIZE,},
+};
+
+void platform_init_memmap(void)
+{
+	/* memmap has been initialized statically as a part of .data */
+}

--- a/src/platform/imx8/platform.c
+++ b/src/platform/imx8/platform.c
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright 2019 NXP
+//
+// Author: Daniel Baluta <daniel.baluta@nxp.com>
+
+#include <platform/memory.h>
+#include <platform/mailbox.h>
+#include <sof/edma.h>
+#include <platform/dma.h>
+#include <platform/dai.h>
+#include <platform/clk.h>
+#include <platform/timer.h>
+#include <platform/mu.h>
+#include <uapi/ipc/info.h>
+#include <sof/mailbox.h>
+#include <sof/dai.h>
+#include <sof/interrupt.h>
+#include <sof/sof.h>
+#include <sof/clk.h>
+#include <sof/schedule.h>
+#include <sof/ipc.h>
+#include <sof/trace.h>
+#include <sof/agent.h>
+#include <sof/dma-trace.h>
+#include <sof/audio/component.h>
+#include <sof/cpu.h>
+#include <sof/notifier.h>
+#include <config.h>
+#include <string.h>
+#include <version.h>
+
+static const struct sof_ipc_fw_ready ready
+	__attribute__((section(".fw_ready"))) = {
+	.hdr = {
+		.cmd = SOF_IPC_FW_READY,
+		.size = sizeof(struct sof_ipc_fw_ready),
+	},
+	/* dspbox is for DSP initiated IPC, hostbox is for host initiated IPC */
+	.version = {
+		.hdr.size = sizeof(struct sof_ipc_fw_version),
+		.micro = SOF_MICRO,
+		.minor = SOF_MINOR,
+		.major = SOF_MAJOR,
+#ifdef DEBUG_BUILD
+		/* only added in debug for reproducability in releases */
+		.build = SOF_BUILD,
+		.date = __DATE__,
+		.time = __TIME__,
+#endif
+		.tag = SOF_TAG,
+		.abi_version = SOF_ABI_VERSION,
+	},
+	.flags = DEBUG_SET_FW_READY_FLAGS,
+};
+
+#define NUM_IMX_WINDOWS		6
+
+static const struct sof_ipc_window sram_window = {
+	.ext_hdr	= {
+		.hdr.cmd = SOF_IPC_FW_READY,
+		.hdr.size = sizeof(struct sof_ipc_window) +
+			sizeof(struct sof_ipc_window_elem) * NUM_IMX_WINDOWS,
+		.type	= SOF_IPC_EXT_WINDOW,
+	},
+	.num_windows	= NUM_IMX_WINDOWS,
+	.window	= {
+		{
+			.type	= SOF_IPC_REGION_UPBOX,
+			.id	= 0,	/* map to host window 0 */
+			.flags	= 0, // TODO: set later
+			.size	= MAILBOX_DSPBOX_SIZE,
+			.offset	= MAILBOX_DSPBOX_OFFSET,
+		},
+		{
+			.type	= SOF_IPC_REGION_DOWNBOX,
+			.id	= 0,	/* map to host window 0 */
+			.flags	= 0, // TODO: set later
+			.size	= MAILBOX_HOSTBOX_SIZE,
+			.offset	= MAILBOX_HOSTBOX_OFFSET,
+		},
+		{
+			.type	= SOF_IPC_REGION_DEBUG,
+			.id	= 0,	/* map to host window 0 */
+			.flags	= 0, // TODO: set later
+			.size	= MAILBOX_DEBUG_SIZE,
+			.offset	= MAILBOX_DEBUG_OFFSET,
+		},
+		{
+			.type	= SOF_IPC_REGION_TRACE,
+			.id	= 0,	/* map to host window 0 */
+			.flags	= 0, // TODO: set later
+			.size	= MAILBOX_TRACE_SIZE,
+			.offset	= MAILBOX_TRACE_OFFSET,
+		},
+		{
+			.type	= SOF_IPC_REGION_STREAM,
+			.id	= 0,	/* map to host window 0 */
+			.flags	= 0, // TODO: set later
+			.size	= MAILBOX_STREAM_SIZE,
+			.offset	= MAILBOX_STREAM_OFFSET,
+		},
+		{
+			.type	= SOF_IPC_REGION_EXCEPTION,
+			.id	= 0,	/* map to host window 0 */
+			.flags	= 0, // TODO: set later
+			.size	= MAILBOX_EXCEPTION_SIZE,
+			.offset	= MAILBOX_EXCEPTION_OFFSET,
+		},
+	},
+};
+
+
+struct timesource_data platform_generic_queue[] = {
+{
+	.timer = {
+		.id = TIMER0,
+		.irq = IRQ_NUM_TIMER0,
+	},
+	.clk = PLATFORM_WORKQ_CLOCK,
+	.timer_set = platform_timer_set,
+	.timer_clear = platform_timer_clear,
+	.timer_get = platform_timer_get,
+},
+};
+struct timer *platform_timer =
+	&platform_generic_queue[PLATFORM_MASTER_CORE_ID].timer;
+
+
+int platform_boot_complete(uint32_t boot_message)
+{
+	mailbox_dspbox_write(0, &ready, sizeof(ready));
+	mailbox_dspbox_write(sizeof(ready), &sram_window,
+			     sram_window.ext_hdr.hdr.size);
+
+	/* now interrupt host to tell it we are done booting */
+	imx_mu_xcr_rmw(IMX_MU_xCR_GIRn(1), 0);
+
+	/* boot now complete so we can relax the CPU */
+	/* For now skip this to gain more processing performance
+	 * for SRC component.
+	 */
+	/* clock_set_freq(CLK_CPU, CLK_DEFAULT_CPU_HZ); */
+
+	return 0;
+}
+
+int platform_init(struct sof *sof)
+{
+	int ret;
+	struct dai *esai;
+
+	clock_init();
+	scheduler_init();
+
+	platform_timer_start(platform_timer);
+	sa_init(sof);
+
+	clock_set_freq(CLK_CPU(cpu_get_id()), CLK_MAX_CPU_HZ);
+
+	/* init DMA */
+	ret = edma_init();
+	if (ret < 0)
+		return -ENODEV;
+
+	/* initialize the host IPC mechanims */
+	ipc_init(sof);
+
+	ret = dai_init();
+	if (ret < 0)
+		return -ENODEV;
+
+	esai = dai_get(SOF_DAI_IMX_ESAI, 0, DAI_CREAT);
+	if (!esai)
+		return -ENODEV;
+
+	dai_probe(esai);
+
+	return 0;
+}


### PR DESCRIPTION
This is patch series adds the basic infrastructure to support i.MX8 platforms. First two patches are just some cleanup in order to correctly compile and boot the FW.

Next patches introduce xtensa configuration supported by Hifi4 DSP found on i.MX8 platforms, rimage support, basic platform support and skeleton drivers for DAI and DMA.

I want to get the basic patches in because SOF is rapidly changing and I always spend times on fixing the rebase. 

After this gets in I will send the implementation of the drivers and topology files which will make SOF on i.MX8 usable.