### PR TITLE
memcpy: replace all occurrences with memcpy_s

### DIFF
--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -104,7 +104,8 @@ static struct comp_dev *kpb_new(struct sof_ipc_comp *comp)
 	if (!dev)
 		return NULL;
 
-	memcpy(&dev->comp, comp, sizeof(struct sof_ipc_comp_process));
+	assert(!memcpy_s(&dev->comp, sizeof(struct sof_ipc_comp_process),
+			 comp, sizeof(struct sof_ipc_comp_process)));
 
 	cd = rzalloc(RZONE_RUNTIME, SOF_MEM_CAPS_RAM, sizeof(*cd));
 	if (!cd) {
@@ -114,7 +115,8 @@ static struct comp_dev *kpb_new(struct sof_ipc_comp *comp)
 
 	comp_set_drvdata(dev, cd);
 
-	memcpy(&cd->config, ipc_process->data, bs);
+	assert(!memcpy_s(&cd->config, sizeof(cd->config), ipc_process->data,
+			 bs));
 
 	if (cd->config.no_channels > KPB_MAX_SUPPORTED_CHANNELS) {
 		trace_kpb_error("kpb_new() error: "
@@ -512,7 +514,7 @@ static int kpb_copy(struct comp_dev *dev)
 
 	/* Sink and source are both ready and have space */
 	copy_bytes = MIN(sink->free, source->avail);
-	memcpy(sink->w_ptr, source->r_ptr, copy_bytes);
+	assert(!memcpy_s(sink->w_ptr, copy_bytes, source->r_ptr, copy_bytes));
 
 	/* Buffer source data internally in history buffer for future
 	 * use by clients.
@@ -560,7 +562,8 @@ static void kpb_buffer_data(struct comp_data *kpb, struct comp_buffer *source,
 			 * in this buffer, copy what's available and continue
 			 * with next buffer.
 			 */
-			memcpy(buff->w_ptr, read_ptr, space_avail);
+			assert(!memcpy_s(buff->w_ptr, space_avail, read_ptr,
+					 space_avail));
 			/* Update write pointer & requested copy size */
 			buff->w_ptr += space_avail;
 			size_to_copy = size_to_copy - space_avail;
@@ -573,7 +576,8 @@ static void kpb_buffer_data(struct comp_data *kpb, struct comp_buffer *source,
 			 * available in this buffer. In this scenario simply
 			 * copy what was requested.
 			 */
-			memcpy(buff->w_ptr, read_ptr, size_to_copy);
+			assert(!memcpy_s(buff->w_ptr, size_to_copy, read_ptr,
+					 size_to_copy));
 			/* Update write pointer & requested copy size */
 			buff->w_ptr += size_to_copy;
 			/* Reset requested copy size */
@@ -839,7 +843,8 @@ static uint64_t kpb_draining_task(void *arg)
 			}
 		}
 
-		memcpy(sink->w_ptr, buff->r_ptr, size_to_copy);
+		assert(!memcpy_s(sink->w_ptr, size_to_copy, buff->r_ptr,
+				 size_to_copy));
 		buff->r_ptr += (uint32_t)size_to_copy;
 		history_depth -= size_to_copy;
 

--- a/src/lib/dma-trace.c
+++ b/src/lib/dma-trace.c
@@ -361,12 +361,12 @@ void dma_trace_flush(void *t)
 	/* check for buffer wrap */
 	if (buffer->w_ptr - size < buffer->addr) {
 		wrap_count = buffer->w_ptr - buffer->addr;
-		memcpy(t, buffer->end_addr - (size - wrap_count),
-		       size - wrap_count);
-		memcpy(t + (size - wrap_count), buffer->addr,
-		       wrap_count);
+		assert(!memcpy_s(t, size - wrap_count, buffer->end_addr -
+				 (size - wrap_count), size - wrap_count));
+		assert(!memcpy_s(t + (size - wrap_count), wrap_count,
+				 buffer->addr, wrap_count));
 	} else {
-		memcpy(t, buffer->w_ptr - size, size);
+		assert(!memcpy_s(t, size, buffer->w_ptr - size, size));
 	}
 
 	/* writeback trace data */
@@ -432,18 +432,19 @@ static void dtrace_add_event(const char *e, uint32_t length)
 		/* check for buffer wrap */
 		if (margin > length) {
 			/* no wrap */
-			memcpy(buffer->w_ptr, e, length);
+			assert(!memcpy_s(buffer->w_ptr, length, e, length));
 			dcache_writeback_invalidate_region(buffer->w_ptr,
 							   length);
 			buffer->w_ptr += length;
 		} else {
 			/* data is bigger than remaining margin so we wrap */
-			memcpy(buffer->w_ptr, e, margin);
+			assert(!memcpy_s(buffer->w_ptr, margin, e, margin));
 			dcache_writeback_invalidate_region(buffer->w_ptr,
 							   margin);
 			buffer->w_ptr = buffer->addr;
 
-			memcpy(buffer->w_ptr, e + margin, length - margin);
+			assert(!memcpy_s(buffer->w_ptr, length - margin,
+					 e + margin, length - margin));
 			dcache_writeback_invalidate_region(buffer->w_ptr,
 							   length - margin);
 			buffer->w_ptr += length - margin;

--- a/src/lib/panic.c
+++ b/src/lib/panic.c
@@ -46,7 +46,8 @@ void dump_panicinfo(void *addr, struct sof_ipc_panic_info *panic_info)
 {
 	if (!panic_info)
 		return;
-	memcpy(addr, panic_info, sizeof(struct sof_ipc_panic_info));
+	assert(!memcpy_s(addr, sizeof(struct sof_ipc_panic_info), panic_info,
+			 sizeof(struct sof_ipc_panic_info)));
 	dcache_writeback_region(addr, sizeof(struct sof_ipc_panic_info));
 }
 
@@ -100,14 +101,17 @@ void __panic(uint32_t p, char *filename, uint32_t linenum)
 	strlen = rstrlen(filename);
 
 	if (strlen >= SOF_TRACE_FILENAME_SIZE) {
-		memcpy_s(panicinfo.filename, sizeof(panicinfo.filename),
-			 filename + strlen - SOF_TRACE_FILENAME_SIZE,
-			 SOF_TRACE_FILENAME_SIZE);
-		memcpy_s(panicinfo.filename, sizeof(panicinfo.filename),
-			 "...", 3);
+		assert(!memcpy_s(panicinfo.filename,
+				 sizeof(panicinfo.filename),
+				 filename + strlen - SOF_TRACE_FILENAME_SIZE,
+				 SOF_TRACE_FILENAME_SIZE));
+		assert(!memcpy_s(panicinfo.filename,
+				 sizeof(panicinfo.filename),
+				 "...", 3));
 	} else {
-		memcpy_s(panicinfo.filename, sizeof(panicinfo.filename),
-			 filename, strlen + 1);
+		assert(!memcpy_s(panicinfo.filename,
+				 sizeof(panicinfo.filename),
+				 filename, strlen + 1));
 	}
 
 	panic_rewind(p, 0, &panicinfo, NULL);

--- a/src/lib/trace.c
+++ b/src/lib/trace.c
@@ -74,7 +74,7 @@ static void put_header(uint32_t *dst, uint32_t id_0, uint32_t id_1,
 	header.timestamp = timestamp + platform_timer->delta;
 	header.log_entry_address = entry;
 
-	memcpy(dst, &header, sizeof(header));
+	assert(!memcpy_s(dst, sizeof(header), &header, sizeof(header)));
 }
 
 static void mtrace_event(const char *data, uint32_t length)


### PR DESCRIPTION
Replaces all occurrences of memcpy with memcpy_s.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>