### PR TITLE
cmake: git hooks for non-unix os

### DIFF
--- a/scripts/cmake/git-hooks.cmake
+++ b/scripts/cmake/git-hooks.cmake
@@ -5,7 +5,16 @@ if(NOT EXISTS "${SOF_ROOT_SOURCE_DIRECTORY}/.git")
 endif()
 
 if(NOT CMAKE_HOST_UNIX)
-	return()
+	execute_process(
+		COMMAND sh -c echo
+		RESULT_VARIABLE sh_result
+		OUTPUT_QUIET
+		ERROR_QUIET
+	)
+
+	if(NOT (sh_result STREQUAL "0"))
+		return()
+	endif()
 endif()
 
 set(pre_commit_hook "${SOF_ROOT_SOURCE_DIRECTORY}/.git/hooks/pre-commit")


### PR DESCRIPTION
Add support for non-unix systems that have bash shell.

Signed-off-by: Janusz Jankowski <janusz.jankowski@linux.intel.com>