### PR TITLE
Tools: Audio quality test for ssh accessible device

### DIFF
--- a/tools/test/audio/sof-test-perf.sh
+++ b/tools/test/audio/sof-test-perf.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright(c) 2017 Intel Corporation. All rights reserved.
+# Copyright(c) 2019 Intel Corporation. All rights reserved.
 # Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
 
-octave --no-gui src_test_top.m
+octave --no-gui sof_test_perf_top.m
 if [ $? -eq 0 ]; then
     echo "Test passed."
     exit 0

--- a/tools/test/audio/sof_test_perf.m
+++ b/tools/test/audio/sof_test_perf.m
@@ -1,0 +1,314 @@
+%%
+% sof_test_perf - Test audio objective quality of remote SOF device
+%
+% [fail, pass] = sof_test_perf(cfgfn)
+%
+% Inputs
+%   id    - a short string to identify test case
+%   cfgfn - configuration file for test case
+%
+% Outputs
+%   fail - number of failed tests
+%   pass - number of passed tests
+%
+
+% SPDX-License-Identifier: BSD-3-Clause
+% Copyright(c) 2019 Intel Corporation. All rights reserved.
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+
+function [fail, pass] = sof_test_perf(cfgfn)
+
+if nargin < 1
+	test.cfgfn = 'sof_test_perf_config.m';
+else
+	test.cfgfn = cfgfn;
+end
+
+%% Generic settings
+test = test_defaults(test);
+
+%% Plotting
+test.plot_close_windows = 1;    % Workaround for visible windows if Octave hangs
+test.plot_visible = 'off';      % Use off for batch tests and on for interactive
+test.plot_passband_zoom = 1;    % Do a small plot box for only passband
+test.plot_channels_combine = 1; % Plot channels into same figure
+
+%% Cleanup
+test.files_delete = 0;          % Set to 0 to inspect the audio data files
+
+%% Paths to other test functions, plots, reports
+addpath('std_utils');
+addpath('test_utils');
+mkdir_check('plots');
+mkdir_check('reports');
+
+%% Get playback test play and capture configuration
+test = get_config(test);
+
+%% Run tests
+fail = 0;
+pass = 0;
+test.tf = [];
+
+% Check that the configuration has been edited
+if test.play_cfg.ssh && strcmp(test.play_cfg.user, 'user@host.domain')
+	fprintf(1, 'Error: The configuration file %s\n', test.cfgfn);
+	fprintf(1, 'must be edited from default to present an actual test\n');
+	fprintf(1, 'case. Or edit into sof_audio_quality_test_top.m the\n');
+	fprintf(1, 'new test configuration list to execute.\n\n');
+	quit(1);
+end
+
+%% Gain
+[tf(1), g_db] = g_test(test);
+
+if tf(1) == 0
+	%% Frequency response
+	[tf(2), fr_db, fr_hz, fr_3db_hz] = fr_test(test);
+
+	%% Total harmonic distortion plus noise
+	[tf(3), thdnf_low, thdnf_high] = thdnf_test(test);
+end
+
+%% Print results
+test.rfn = sprintf('reports/%s.txt', test.id);
+test.rfh = fopen(test.rfn, 'w');
+
+print_val(test, tf(1), g_db, 'dB', 'Gain', 1);
+
+if tf(1) == 0
+	print_val(test, tf(2), fr_db, '+/- dB', 'Frequency response');
+	print_val(test, tf(2), fr_3db_hz / 1000, 'kHz', '-3 dB frequency');
+	print_val(test, tf(3), thdnf_low, 'dB', 'THD+N -20 dBFS');
+	print_val(test, tf(3), thdnf_high, 'dB', 'THD+N -1 dBFS');
+else
+	fprintf(1, '\n');
+	fprintf(1, 'Warning: The gain test must pass before other tests are executed.\n');
+end
+
+fprintf('\n');
+fclose(test.rfh);
+
+%% Summary
+fail = sum(tf);
+pass = length(tf) - fail;
+
+end
+
+%%
+%% Test execution with help of common functions
+%%
+
+function [fail, g_db] = g_test(test)
+
+%% Reference: AES17 6.2.2 Gain
+c = 20/48;
+test.fu = c * test.fs;
+
+%% Create input file
+test = g_test_input(test);
+
+%% Run test
+test = remote_test_run(test);
+
+%% Measure
+test.ch = test.rec_cfg.ch;
+test = g_test_measure(test);
+
+%% Get output parameters
+fail = test.fail;
+g_db = test.g_db;
+delete_check(test.files_delete, test.fn_in);
+delete_check(test.files_delete, test.fn_out);
+
+end
+
+function [fail, fr_db, fr_hz, fr_3db_hz] = fr_test(test)
+
+%% Reference: AES17 6.2.3 Frequency response
+c1 = 20/48;
+c2 = 23.9/48;
+test.f_lo = 20;            % Measure start at 20 Hz
+test.f_hi = c1 * test.fs;  % Measure end e.g. at 20 kHz
+test.f_max = c2 * test.fs; % Sweep max e.g. at 23.9 kHz
+
+%% Create input file
+test = fr_test_input(test);
+
+%% Run test
+test = remote_test_run(test);
+
+%% Measure
+test.ch = test.rec_cfg.ch;
+test = fr_test_measure(test);
+
+fail = test.fail;
+fr_db = test.rp;
+fr_hz = [test.f_lo test.f_hi];
+fr_3db_hz = test.fr3db_hz;
+delete_check(test.files_delete, test.fn_in);
+delete_check(test.files_delete, test.fn_out);
+
+%% Print
+test_result_print(test, 'Frequency response', 'FR');
+
+end
+
+function [fail, thdnf_low, thdnf_high] = thdnf_test(test)
+
+%% Reference: AES17 6.3.2 THD+N ratio vs. frequency
+c = 20/48;
+test.f_start = 20;
+test.f_end = c * test.fs;
+test.fu = c * test.fs;
+
+%% Create input file
+test = thdnf_test_input(test);
+
+%% Run test
+test = remote_test_run(test);
+
+%% Measure
+test.ch = test.rec_cfg.ch;
+test = thdnf_test_measure(test);
+fail = test.fail;
+thdnf_high = max(test.thdnf_high);
+thdnf_low = max(test.thdnf_low);
+delete_check(test.files_delete, test.fn_in);
+delete_check(test.files_delete, test.fn_out);
+
+%% Print
+test_result_print(test, 'THD+N ratio vs. frequency', 'THDNF');
+
+end
+
+%%
+%% Utilities
+%%
+
+function test = test_defaults(test)
+
+test.fmt = 'wav';
+test.fr_rp_max_db = [];
+test.fr_mask_f = [];
+test.fr_mask_lo = [];
+test.fr_mask_hi = [];
+test.plot_fr_axis = [];
+test.plot_thdn_axis = [];
+
+end
+
+%% Get number of bits from format string
+function bits = sample_format_bits(sft)
+
+switch lower(sft)
+	case 's16_le'
+		bits = 16;
+	case 's24_le'
+		bits = 24;
+	case 's24_3le'
+		bits = 24;
+	case 's24_4le'
+		bits = 24;
+	case 's32_le'
+		bits = 32;
+	otherwise
+		error('Illegal sample format.');
+end
+
+end
+
+
+%% Get configuration for test
+function [test, play, rec] = get_config(test)
+fh = fopen(test.cfgfn);
+cfg = fscanf(fh, '%c');
+fclose(fh);
+eval(cfg);
+
+fprintf('\nThe settings for remote playback are\n');
+fprintf('Use ssh   : %d\n', play.ssh);
+fprintf('User      : %s\n', play.user);
+fprintf('Directory : %s\n', play.dir);
+fprintf('Device    : %s\n', play.dev);
+fprintf('format    : %s\n', play.sft);
+fprintf('Channels  : %d\n', play.nch);
+for i=1:length(play.ch)
+	fprintf('Channel   : %d\n', play.ch(i));
+end
+
+fprintf('\nThe settings for capture are\n');
+fprintf('Use ssh   : %d\n', rec.ssh);
+fprintf('User      : %s\n', rec.user);
+fprintf('Directory : %s\n', rec.dir);
+fprintf('Device    : %s\n', rec.dev);
+fprintf('format    : %s\n', rec.sft);
+fprintf('Channels  : %d\n', rec.nch);
+for i=1:length(play.ch)
+	fprintf('Channel   : %d\n', rec.ch(i));
+end
+fprintf('\n');
+
+rec.fmt = sprintf('-t wav -c %d -f %s -r %d', ...
+	rec.nch, rec.sft, test.fs);
+
+test.play_cfg = play;
+test.rec_cfg = rec;
+test.nch = test.play_cfg.nch;
+test.ch = test.play_cfg.ch;
+test.bits_in = sample_format_bits(test.play_cfg.sft);
+test.bits_out = sample_format_bits(test.rec_cfg.sft);
+
+end
+
+%% Export test result plots
+function test_result_print(t, testverbose, testbrief)
+
+tstr = sprintf('%s %s', t.id, testverbose);
+if nargin > 3
+	title(t.ph, tstr);
+else
+	title(tstr);
+end
+pfn = sprintf('plots/%s_%s.png', t.id, testbrief);
+print(pfn, '-dpng');
+
+if t.plot_close_windows
+	close all;
+end
+
+end
+
+%% Export test result prints
+function print_val(test, fail, val, unit, desc, header)
+
+if nargin < 6
+	header = 0;
+end
+
+if fail
+	fstr = 'Fail';
+else
+	fstr = 'Pass';
+end
+
+if header
+	fprintf('\n');
+	str = sprintf('%7s, %18s', 'Verdict', 'Test case');
+	for i = 1:length(val)
+		str = sprintf('%s, %7s', str, sprintf('Ch%d', test.ch(i)));
+	end
+	str = sprintf('%s, %8s\n', str, 'Unit');
+	fprintf(str);
+	fprintf(test.rfh, str);
+end
+
+str = sprintf('%7s, %18s', fstr, desc);
+for i = 1:length(val)
+	str = sprintf('%s, %7.2f', str, val(i));
+end
+str = sprintf('%s, %8s\n', str, unit);
+
+fprintf(str);
+fprintf(test.rfh, str);
+end

--- a/tools/test/audio/sof_test_perf_README.txt
+++ b/tools/test/audio/sof_test_perf_README.txt
@@ -1,0 +1,123 @@
+SOF audio quality test scripts
+
+1. Introduction
+
+The purpose of the script is to test playback (and/or recording
+quality of a SOF platform with help of PC with a high quality USB
+sound card. Or in other words a sound card with sufficient number of
+analog inputs and outputs with sufficient signal levels handling
+capability, and good analog signal quality. The sound card should be
+better than expected quality of the SOF device.
+
++------+                                      +--------+
+|      |<--- Ethernet or WLAN connection ---->|        |
+|  PC  |             +-------+                | SOF    |
+|      |<--- usb --->| Sound |--- line in --->| device |
++------+             | card  |<-- line out ---|        |
+	  	     +-------+                +--------+
+
+The tests can also use digital interfaces like S/PDIF if available in
+the SOF device. That helps to move testing focus to smaller digital
+signal processing issues instead of usually dominant ADC/DAC
+performance (unless there's a major quality issue).
+
+The key tests to execute to quickly verify playback/recording audio
+quality are gain, frequency response (FR), and total harmonic
+distortion plus noise (THD+N). The test procedure and results reporting
+tries to follow AES17 recommendations.
+
+This work can be taken as a inexpensive introduction to objective
+audio quality parameters testing that should be useful for individual
+developers without access to professional test equipment for relative
+performance indicators testing. Tests like THD+N also work for
+automatic testing needs to quickly flag regressions in playback audio
+integrity.
+
+IMPORTANT NOTE: These test scripts are not calibrated and not suitable
+to produce absolute metric. The results will vary depending on the
+used sound card and depend on correctly done preparations on the
+PC. Therefore for professional usage with need for industry comparable
+metric we recommend instead dedicated test systems and services.
+
+
+2. General preparations
+
+The PC should be installed with a Linux distribution that provides
+octave and octave-signal packaces or use commercial Matlab (R)
+software. For Octave it's recommended to use an initialization script
+that loads the needed packages and disables the pager to freely scroll
+the test text printings without frequently stopping to press <space>
+to proceed.
+
+$ sudo apt-get install octave octave-signal octave-io
+
+$ cat ~/.octaverc
+more off
+pkg load signal
+pkg load io
+
+The SOF device should be made accessible via ssh without
+password. Also the test user should belong to group audio in both PC
+and SOF device.
+
+To avoid including the PC audio server and it's signal processing into
+the test chain it is recommended to disable audio servers like
+pulseaudio permanently (rename the executable /usr/bin/pulseaudio) on
+the test PC and use the ALSA provided sound devices directly.
+
+There is need to go trough the alsamixer settings for the sound card
+and store them persistently. Also on sophisticated sound cards need to
+do internal settings via front panel or dedicated control SW for
+settings those are not exposed to alsamixer.
+
+
+3. Playback and recording test preparations
+
+See script sof_audio_quality_test_config.m. It is a template to
+configure the audio interfaces for test playback and capture of the
+playback. Make a copy of the file for your test setup and edit the
+script sof_audio_quality_test_top.m to use that configuration script
+instead of the default. See line
+
+configs = {'sof_audio_quality_test_config.m'};
+
+The line initializes a cell array of strings. Multiple test
+configurations are added to cell array with comma as separator.
+
+To test playback of SOF device there's need to edit "play.user" to
+correpond to actual test user and hostname or IP address of the
+device. Also edit the "play.dev" to contain the audio playback device
+to test.
+
+For playabck capture to PC edit the "rec.dev", "rec.sft", "rec.nch",
+and "rec.ch" fields. The example is set for a 8ch sound card with SOF
+device connected into analog inputs 1 and 2.
+
+The setting "test.att_rec_db" is important. There must be a sufficient
+analog signal headroom for the sound card ADC to capture SOF DAC
+playback signal without clipping distortion. The example assumes 3 dB
+attenuation but it can be adjusted to be e.g. within 1 - 6 dB.
+
+You can start with 3 dB and run the test script
+sof_audio_quality_test.sh. It won't proceed if the gain test is not
+passing. Based on the reported difference vs. expected 0 dB gain
+adjust the alsamixer settings for you USB sound card capture gain. The
+controls may be also in the front panel.
+
+If the result still deviates from 0 dB and it's known that the
+playback level is correct it is possible to to adjust this attenuation
+parameter to get the 0 dB result.
+
+4. Tests reporting
+
+The script is configured to proceed without opening plot windows to
+desktop. Once the gain test is passed the script executes the FR and
+THD+N tests.
+
+The shell window will show a brief test report and the same will
+appear to directory "reports" with name prefix defined in "test.id" in
+the configuration file.
+
+The plots in PNG format are exported to directory "plots".
+
+That's all, happy testing!!

--- a/tools/test/audio/sof_test_perf_config.m
+++ b/tools/test/audio/sof_test_perf_config.m
@@ -1,0 +1,46 @@
+% SPDX-License-Identifier: BSD-3-Clause
+% Copyright(c) 2019 Intel Corporation. All rights reserved.
+
+%%
+%% Configuration for a playback test
+%%
+
+%% Set user@domain for ssh, need to be set for playback test
+play.user = 'user@host.domain';
+
+%% Other playback settings
+play.ssh = 1;			% Set to 1 for for remote play
+play.dir = '/tmp';             	% directory for temporary files
+play.dev = 'hw:0,0'; 		% Audio device for playback
+play.sft = 'S16_LE'; 		% Sample format to use
+play.nch = 2;         		% Number of playback channels
+play.ch  = [1 2];		% Playback channels to test
+
+%% Set to user@domain for ssh, not set for playback test
+rec.user = '';
+
+%% Other capture settings
+rec.ssh = 0;			% Set to 1 for remote capture
+rec.dir = '/tmp'; 		% Directory for temporary files
+rec.dev = 'hw:1,0'; 		% Audio capture device
+rec.sft = 'S24_3LE'; 		% Sample format to use
+rec.nch = 8; 			% Number audio capture channels
+rec.ch  = [1 2];		% Capture channels to measure
+
+%% Generic settings
+test.id = 'Example';            % Label for test
+test.fs = 48000;		% Sample rate
+test.quick = 1; 		% Speed up some test cases
+test.att_rec_db = 3; 		% Attenuation assumption for capture
+
+%% Gain test case
+test.g_db_tol = 0.5;		% Tolerance for gain
+test.g_db_expect = 0.0;         % Expected gain
+
+%% Frequency response test case, for 20 - 20000 Hz
+test.fr_rp_max_db = 1.0;	     % Upper limit for p-p ripple in dB
+test.plot_fr_axis = [10 30e3 -4 1];  % Plot xmin, xmax, ymin, ymax
+
+%% THD+N test case
+test.thdnf_max = -55;			   % Upper limit for THD+N
+test.plot_thdn_axis = [10 30e3 -90 -40]; % Plot xmin xmax ymin ymax

--- a/tools/test/audio/sof_test_perf_top.m
+++ b/tools/test/audio/sof_test_perf_top.m
@@ -1,0 +1,52 @@
+function sof_test_perf_top
+
+%%
+% audio_test_perf_top - Wrapper function for call from shell
+%
+% audio_test_perf_top()
+%
+% Inputs
+%   none
+%
+% Outputs
+%   shell exit code
+%
+
+% SPDX-License-Identifier: BSD-3-Clause
+% Copyright(c) 2019 Intel Corporation. All rights reserved.
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+
+% Edit to next lines the configs list the actual tests to
+% execute. The syntax used is called a cell array. The
+% script will execute test with each configuration in the
+% array. E.g.
+% configs = {'up2_s16_play_cfg.m', 't100_s16_play_cfg.m'};
+configs = {'sof_test_perf_config.m'};
+
+%% Run tests
+n_fail_tot = 0;
+n_pass_tot = 0;
+n = length(configs);
+for i = 1:n
+	cfg = char(configs(i));
+	[n_fail, n_pass] = sof_test_perf(cfg);
+	n_fail_tot = n_fail_tot + n_fail;
+	n_pass_tot = n_pass_tot + n_pass;
+
+	fprintf('Completed: %s\n', cfg);
+	fprintf('Passed   : %d\n', n_pass);
+	fprintf('Failed   : %d\n\n', n_fail);
+end
+
+if n > 1
+	fprintf('Completed all.\n');
+	fprintf('Passed   : %d\n', n_pass_tot);
+	fprintf('Failed   : %d\n', n_fail_tot);
+end
+
+if n_fail_tot > 0 || n_pass_tot < 1
+	fprintf('Error: Audio quality test failed.\n');
+	quit(1)
+end
+
+fprintf('Success: Audio quality test passed.\n');

--- a/tools/test/audio/src_test.m
+++ b/tools/test/audio/src_test.m
@@ -14,35 +14,9 @@ function [n_fail, n_pass, n_na] = src_test(bits_in, bits_out, fs_in_list, fs_out
 % paremeters are omitted.
 %
 
-%%
-% Copyright (c) 2016, Intel Corporation
-% All rights reserved.
-%
-% Redistribution and use in source and binary forms, with or without
-% modification, are permitted provided that the following conditions are met:
-%   * Redistributions of source code must retain the above copyright
-%     notice, this list of conditions and the following disclaimer.
-%   * Redistributions in binary form must reproduce the above copyright
-%     notice, this list of conditions and the following disclaimer in the
-%     documentation and/or other materials provided with the distribution.
-%   * Neither the name of the Intel Corporation nor the
-%     names of its contributors may be used to endorse or promote products
-%     derived from this software without specific prior written permission.
-%
-% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
-% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-% POSSIBILITY OF SUCH DAMAGE.
-%
+% SPDX-License-Identifier: BSD-3-Clause
+% Copyright(c) 2016 Intel Corporation. All rights reserved.
 % Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
-%
 
 addpath('std_utils');
 addpath('test_utils');
@@ -92,9 +66,9 @@ t.full_test = 1;       % 0 is quick check only, 1 is full set
 %  visibility set to to 0 only console text is seen. The plots are
 %  exported into plots directory in png format and can be viewed from
 %  there.
-t.close_plot_windows = 1;  % Workaround for visible windows if Octave hangs
-t.visible = 'off';         % Use off for batch tests and on for interactive
-t.delete = 1;              % Set to 0 to inspect the audio data files
+t.plot_close_windows = 1;  % Workaround for visible windows if Octave hangs
+t.plot_visible = 'off';    % Use off for batch tests and on for interactive
+t.files_delete = 1;        % Set to 0 to inspect the audio data files
 
 %% Init for test loop
 n_test = 7; % We have next seven test cases for SRC
@@ -235,8 +209,8 @@ test = g_test_measure(test);
 %% Get output parameters
 fail = test.fail;
 g_db = test.g_db;
-delete_check(t.delete, test.fn_in);
-delete_check(t.delete, test.fn_out);
+delete_check(t.files_delete, test.fn_in);
+delete_check(t.files_delete, test.fn_out);
 
 end
 
@@ -246,8 +220,8 @@ function [fail, pm_range_db, range_hz, fr3db_hz] = fr_test(t)
 test = test_defaults_src(t);
 prm = src_param(t.fs1, t.fs2, test.coef_bits);
 
-test.rp_max = prm.rp_tot;      % Max. ripple +/- dB allowed
-test.f_lo = 20;                % For response reporting, measure from 20 Hz
+test.fr_rp_max_db = prm.rp_tot; % Max. ripple +/- dB allowed
+test.f_lo = 20;                 % For response reporting, measure from 20 Hz
 test.f_hi = 0.99 * min(t.fs1,t.fs2)*prm.c_pb; % to designed filter upper frequency
 test.f_max = 0.99 * min(t.fs1/2, t.fs2/2); % Measure up to Nyquist frequency
 
@@ -265,8 +239,8 @@ fail = test.fail;
 pm_range_db = test.rp;
 range_hz = [test.f_lo test.f_hi];
 fr3db_hz = test.fr3db_hz;
-delete_check(t.delete, test.fn_in);
-delete_check(t.delete, test.fn_out);
+delete_check(t.files_delete, test.fn_in);
+delete_check(t.files_delete, test.fn_out);
 
 %% Print
 src_test_result_print(t, 'Frequency response', 'FR', test.ph);
@@ -301,8 +275,8 @@ test.fs = t.fs2;
 test = thdnf_test_measure(test);
 thdnf = max(max(test.thdnf));
 fail = test.fail;
-delete_check(t.delete, test.fn_in);
-delete_check(t.delete, test.fn_out);
+delete_check(t.files_delete, test.fn_in);
+delete_check(t.files_delete, test.fn_out);
 
 %% Print
 src_test_result_print(t, 'THD+N ratio vs. frequency', 'THDNF');
@@ -332,8 +306,8 @@ test = dr_test_measure(test);
 %% Get output parameters
 fail = test.fail;
 dr_db = test.dr_db;
-delete_check(t.delete, test.fn_in);
-delete_check(t.delete, test.fn_out);
+delete_check(t.files_delete, test.fn_in);
+delete_check(t.files_delete, test.fn_out);
 
 end
 
@@ -365,8 +339,8 @@ test.fs = t.fs2;
 test = aap_test_measure(test);
 aap_db = test.aap;
 fail = test.fail;
-delete_check(t.delete, test.fn_in);
-delete_check(t.delete, test.fn_out);
+delete_check(t.files_delete, test.fn_in);
+delete_check(t.files_delete, test.fn_out);
 
 %% Print
 src_test_result_print(t, 'Attenuation of alias products', 'AAP');
@@ -398,8 +372,8 @@ test.fs = t.fs2;
 test = aip_test_measure(test);
 aip_db = test.aip;
 fail = test.fail;
-delete_check(t.delete, test.fn_in);
-delete_check(t.delete, test.fn_out);
+delete_check(t.files_delete, test.fn_in);
+delete_check(t.files_delete, test.fn_out);
 
 %% Print
 src_test_result_print(t, 'Attenuation of image products', 'AIP');
@@ -429,8 +403,8 @@ test = chirp_test_analyze(test);
 src_test_result_print(t, 'Chirp', 'chirpf');
 
 % Delete files unless e.g. debugging and need data to run
-delete_check(t.delete, test.fn_in);
-delete_check(t.delete, test.fn_out);
+delete_check(t.files_delete, test.fn_in);
+delete_check(t.files_delete, test.fn_out);
 
 fail = test.fail;
 end
@@ -448,11 +422,17 @@ test.ch = t.ch;
 test.fs = t.fs1;
 test.fs1 = t.fs1;
 test.fs2 = t.fs2;
-test.mask_f = [];
-test.mask_lo = [];
-test.mask_hi = [];
+test.fr_mask_f = [];
+test.fr_mask_lo = [];
+test.fr_mask_hi = [];
 test.coef_bits = 24; % No need to use actual word length in test
-test.visible = t.visible;
+test.att_rec_db = 0; % Not used in simulation test
+test.quick = 0;      % Test speed is no issue in simulation
+test.plot_visible = t.plot_visible;
+test.plot_channels_combine = 0;
+test.plot_passband_zoom = 1;
+test.plot_fr_axis = [10 100e3 -4 1];
+test.plot_thdn_axis = [10 100e3 -140 -60];
 end
 
 function test = test_run_src(test, t)
@@ -473,7 +453,7 @@ pfn = sprintf('plots/%s_src_%d_%d.png', testacronym, t.fs1, t.fs2);
 % The print command caused a strange error with __osmesa_print__
 % so disable it for now until solved.
 %print(pfn, '-dpng');
-if t.close_plot_windows
+if t.plot_close_windows
 	close all;
 end
 end

--- a/tools/test/audio/std_utils/aap_test_measure.m
+++ b/tools/test/audio/std_utils/aap_test_measure.m
@@ -1,34 +1,8 @@
 function test = aap_test_measure(test)
 
-%%
-% Copyright (c) 2017, Intel Corporation
-% All rights reserved.
-%
-% Redistribution and use in source and binary forms, with or without
-% modification, are permitted provided that the following conditions are met:
-%   * Redistributions of source code must retain the above copyright
-%     notice, this list of conditions and the following disclaimer.
-%   * Redistributions in binary form must reproduce the above copyright
-%     notice, this list of conditions and the following disclaimer in the
-%     documentation and/or other materials provided with the distribution.
-%   * Neither the name of the Intel Corporation nor the
-%     names of its contributors may be used to endorse or promote products
-%     derived from this software without specific prior written permission.
-%
-% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
-% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-% POSSIBILITY OF SUCH DAMAGE.
-%
+% SPDX-License-Identifier: BSD-3-Clause
+% Copyright(c) 2017 Intel Corporation. All rights reserved.
 % Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
-%
 
 %% Reference: AES17 6.6.6 Attenuation of alias products
 %  http://www.aes.org/publications/standards/
@@ -67,7 +41,7 @@ else
         test.fail = 0;
 end
 
-test.fh = figure('visible', test.visible);
+test.fh = figure('visible', test.plot_visible);
 semilogx(test.f, test.m);
 grid on;
 xlabel('Frequency (Hz)');

--- a/tools/test/audio/std_utils/aip_test_measure.m
+++ b/tools/test/audio/std_utils/aip_test_measure.m
@@ -1,34 +1,8 @@
 function test = aip_test_measure(test)
 
-%%
-% Copyright (c) 2017, Intel Corporation
-% All rights reserved.
-%
-% Redistribution and use in source and binary forms, with or without
-% modification, are permitted provided that the following conditions are met:
-%   * Redistributions of source code must retain the above copyright
-%     notice, this list of conditions and the following disclaimer.
-%   * Redistributions in binary form must reproduce the above copyright
-%     notice, this list of conditions and the following disclaimer in the
-%     documentation and/or other materials provided with the distribution.
-%   * Neither the name of the Intel Corporation nor the
-%     names of its contributors may be used to endorse or promote products
-%     derived from this software without specific prior written permission.
-%
-% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
-% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-% POSSIBILITY OF SUCH DAMAGE.
-%
+% SPDX-License-Identifier: BSD-3-Clause
+% Copyright(c) 2019 Intel Corporation. All rights reserved.
 % Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
-%
 
 %% Reference: AES17 6.6.7 Attenuation of image products
 %  http://www.aes.org/publications/standards/
@@ -74,7 +48,7 @@ else
         test.fail = 0;
 end
 
-test.fh = figure('visible', test.visible);
+test.fh = figure('visible', test.plot_visible);
 semilogx(test.f, test.m);
 grid on;
 xlabel('Frequency (Hz)');

--- a/tools/test/audio/std_utils/fr_test_input.m
+++ b/tools/test/audio/std_utils/fr_test_input.m
@@ -41,65 +41,44 @@ function test = fr_test_input(test)
 % t.fs=48e3; t.f_max=20e3; t.bits_in=16; t.ch=1; t.nch=2; t = fr_test_input(t);
 %
 
-%%
-% Copyright (c) 2016, Intel Corporation
-% All rights reserved.
-%
-% Redistribution and use in source and binary forms, with or without
-% modification, are permitted provided that the following conditions are met:
-%   * Redistributions of source code must retain the above copyright
-%     notice, this list of conditions and the following disclaimer.
-%   * Redistributions in binary form must reproduce the above copyright
-%     notice, this list of conditions and the following disclaimer in the
-%     documentation and/or other materials provided with the distribution.
-%   * Neither the name of the Intel Corporation nor the
-%     names of its contributors may be used to endorse or promote products
-%     derived from this software without specific prior written permission.
-%
-% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
-% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-% POSSIBILITY OF SUCH DAMAGE.
-%
+% SPDX-License-Identifier: BSD-3-Clause
+% Copyright(c) 2016 Intel Corporation. All rights reserved.
 % Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
-%
 
 %% Reference: AES17 6.2.3 Frequency response
 %  http://www.aes.org/publications/standards/
 
 if nargin < 1
-        fprintf('Warning, using default parameters!\n');
-        test.fs = 48e3; test.f_max = 0.99*test.fs/2; test.ch=1; test.nch=1;
-        test.bits_in=32;
+	fprintf('Warning, using default parameters!\n');
+	test.fs = 48e3; test.f_max = 0.99*test.fs/2; test.ch=1; test.nch=1;
+	test.bits_in=32;
 end
 
 if test.ch == 0
-        test.ch = 1+round(rand(1,1)*(test.nch-1)); % Test random channel 1..Nch
+	test.ch = 1+round(rand(1,1)*(test.nch-1)); % Test random channel 1..Nch
 end
 
 fprintf('Using parameters Fmax=%.1f kHz, Fs=%.1f, ch=%d, Nch=%d, bits_in=%d\n', ...
-        test.f_max/1e3, test.fs/1e3, test.ch, test.nch, test.bits_in);
+	test.f_max/1e3, test.fs/1e3, test.ch, test.nch, test.bits_in);
 
-test.fn_in = sprintf('fr_test_in.%s', test.fmt);
-test.fn_out =  sprintf('fr_test_out.%s', test.fmt);
+pid = getpid();
+test.fn_in = sprintf('fr_test_in_%d.%s', pid, test.fmt);
+test.fn_out =  sprintf('fr_test_out_%d.%s', pid, test.fmt);
 test.f_ref = 997;
 test.f_min = 20;
 
 %% Use a dense frequency grid to see -3 dB point well
-n_oct = ceil(log(test.f_max/test.f_ref)/log(2)*35);
+if test.quick
+	n_oct = ceil(log(test.f_max/test.f_ref)/log(2)*6);
+else
+	n_oct = ceil(log(test.f_max/test.f_ref)/log(2)*35);
+end
 f = logspace(log10(test.f_ref), log10(test.f_max), n_oct);
 c = f(1)/f(2);
 f_next = test.f_ref*c;
 while (f_next > test.f_min)
-        f = [f_next f];
-        f_next = f_next*c;
+	f = [f_next f];
+	f_next = f_next*c;
 end
 test.f = f;
 
@@ -111,7 +90,7 @@ test.sm = 3; % Seek start marker from 3s from start
 test.em = 3; % Seek end marker from 3s from end
 test.mt = 0.1; % Error if marker positions delta is greater than 0.1s
 test.tc = 10; % Min. 10 cycles of sine wave for a frequency
-t_min = 0.2;
+t_min = 0.1;
 % Use t_min or min cycles count as tone length
 test.tl = max(test.tc*1/min(f),t_min);
 test.a_db = -20;

--- a/tools/test/audio/std_utils/fr_test_measure.m
+++ b/tools/test/audio/std_utils/fr_test_measure.m
@@ -7,15 +7,16 @@ function test = fr_test_measure(test)
 % is read from file t.fn_out.
 %
 % Input parameters
-% t.f_lo    - Measure ripple start frequency
-% t.f_hi    - Measure ripple end frequency
-% t.rp_max  - Max. ripple +/- dB
-% t.mask_f  - Frequencies for mask
-% t.mask_lo - Upper limits of mask
-% t.mask_hi - Lower limits of mask
+% t.f_lo         - Measure ripple start frequency
+% t.f_hi         - Measure ripple end frequency
+% t.fr_rp_max_db - Max. ripple +/- dB
+% t.fr_mask_f    - Frequencies for mask
+% t.fr_mask_lo   - Upper limits of mask
+% t.fr_mask_hi   - Lower limits of mask
 %
 % Output parameters
-% t.m           - Measured frequency response
+% t.f           - Frequency grid (Hz)
+% t.m           - Measured frequency response (dB)
 % t.rp          - Measured ripple +/- dB
 % t.fr3db_hz    - Bandwidth in Hz for -3 dB attenuated response
 % t.fail        - Returns zero for passed
@@ -24,57 +25,36 @@ function test = fr_test_measure(test)
 %
 % E.g.
 % t.fs=48e3; t.f_max=20e3; t.bits_out=16; t.ch=1; t.nch=2; t=fr_test_input(t);
-% t.fn_out=t.fn_in; t.f_lo=20; t.f_hi=20e3; t.rp_max=[]; t.mask_f=[];
+% t.fn_out=t.fn_in; t.f_lo=20; t.f_hi=20e3; t.rp_max=[]; t.fr_mask_f=[];
 % t=fr_test_measure(t);
 %
 
-%%
-% Copyright (c) 2017, Intel Corporation
-% All rights reserved.
-%
-% Redistribution and use in source and binary forms, with or without
-% modification, are permitted provided that the following conditions are met:
-%   * Redistributions of source code must retain the above copyright
-%     notice, this list of conditions and the following disclaimer.
-%   * Redistributions in binary form must reproduce the above copyright
-%     notice, this list of conditions and the following disclaimer in the
-%     documentation and/or other materials provided with the distribution.
-%   * Neither the name of the Intel Corporation nor the
-%     names of its contributors may be used to endorse or promote products
-%     derived from this software without specific prior written permission.
-%
-% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
-% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-% POSSIBILITY OF SUCH DAMAGE.
-%
+% SPDX-License-Identifier: BSD-3-Clause
+% Copyright(c) 2017 Intel Corporation. All rights reserved.
 % Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
-%
 
 %% Reference: AES17 6.2.3 Frequency response
 %  http://www.aes.org/publications/standards/
 
 [x, nx] = load_test_output(test);
 
+default_result = NaN * ones(1,length(test.ch));
+test.rp = default_result;
+test.fr3db_hz = default_result;
 j = 1;
 for channel = test.ch
 
         if nx == 0
-                test.rp(j) = NaN;
-                test.fr3db_hz(j) = NaN;
                 test.fail = 1;
                 return
         end
 
         %% Find sync
         [d, nt, nt_use, nt_skip] = find_test_signal(x(:,j), test);
+	if isempty(d)
+		test.fail = 1;
+		return
+	end
 
         win = hamming(nt_use);
         m0 = zeros(test.nf,1);
@@ -97,10 +77,10 @@ for channel = test.ch
         range_db = max(test.m(idx1,j))-min(test.m(idx1,j));
         test.rp(j) = range_db/2;
         test.fail = 0;
-        if ~isempty(test.rp_max)
-                if test.rp > test.rp_max
-                        fprintf('Failed response +/- %f dBpp (max +/- %f dB)\n', ...
-                                test.rp, test.rp_max);
+        if ~isempty(test.fr_rp_max_db)
+                if test.rp(j) > test.fr_rp_max_db
+                        fprintf('Failed response ch%d +/- %f dBpp (max +/- %f dB)\n', ...
+                                test.ch(j), test.rp(j), test.fr_rp_max_db);
                         test.fail = 1;
                 end
         end
@@ -110,11 +90,11 @@ for channel = test.ch
         test.fr3db_hz(j) = test.f(idx3(end));
 
         %% Interpolate mask in logaritmic frequencies, check
-        if ~isempty(test.mask_f)
+        if ~isempty(test.fr_mask_f)
                 f_log = log(test.f);
-                mask_hi = interp1(log(test.mask_f), test.mask_hi(:,j), ...
+                mask_hi = interp1(log(test.fr_mask_f), test.fr_mask_hi(:,j), ...
                         f_log, 'linear');
-                mask_lo = interp1(log(test.mask_f), test.mask_lo(:,j), ...
+                mask_lo = interp1(log(test.fr_mask_f), test.fr_mask_lo(:,j), ...
                         f_log, 'linear');
                 over_mask = test.m(:,j)-mask_hi';
                 under_mask = mask_lo'-test.m(:,j);
@@ -124,50 +104,89 @@ for channel = test.ch
                 [m_under_mask, iu] = max(under_mask(idx));
                 if m_over_mask > 0
                         fprintf('Failed upper response mask around %.0f Hz\n', ...
-                                test.f(io));
+                                test.f(io(1)));
                         test.fail = 1;
                 end
                 if m_under_mask > 0
                         fprintf('Failed lower response mask around %.0f Hz\n', ...
-                                test.f(iu));
+                                test.f(iu(1)));
                         test.fail = 1;
                 end
         end
 
-        test.fh(j) = figure('visible', test.visible);
-        subplot(1,1,1);
-        test.ph(j) = subplot(1,1,1);
-        %semilogx(test.f, test.m(:,j));
-        plot(test.f, test.m(:,j));
-        grid on;
-        xlabel('Frequency (Hz)');
-        ylabel('Magnitude (dB)');
-        if length(test.mask_f) > 0
-                hold on;
-                plot(test.f, mask_hi, 'r--');
-                plot(test.f, mask_lo, 'r--');
-                hold off;
-        end
-	ax = axis();
-	axis([ax(1:2) -4 1]);
-        if max(max(test.m(idx1,j))-min(test.m(idx1,j))) < 1
-                axes('Position', [ 0.2 0.2 0.4 0.2]);
-                box on;
-                plot(test.f(idx1), test.m(idx1,j));
-                if ~isempty(test.rp_max)
-                        hold on;
-                        plot([test.f_lo test.f_hi], ...
-                                [-test.rp_max/2 -test.rp_max/2], 'r--');
-                        plot([test.f_lo test.f_hi], ...
-                                [ test.rp_max/2  test.rp_max/2], 'r--');
-                        hold off;
-                end
-                grid on;
-                axis([0 test.f_hi -0.1 0.1]);
-        end
 
         %% Next channel to measure
         j=j+1;
+end
+
+%% Do plots
+
+nr = j-1;
+for i = 1:nr
+	test.fh(i) = figure('visible', test.plot_visible);
+	test.ph(i) = subplot(1,1,1);
+
+	if test.plot_channels_combine
+		semilogx(test.f, test.m);
+	else
+		semilogx(test.f, test.m(:,i));
+	end
+
+	grid on;
+	xlabel('Frequency (Hz)');
+	ylabel('Magnitude (dB)');
+	if ~isempty(test.fr_mask_f)
+		hold on;
+		plot(test.f, mask_hi, 'r--');
+		plot(test.f, mask_lo, 'r--');
+		hold off;
+	end
+	axis(test.plot_fr_axis);
+	if test.plot_channels_combine && (test.nch > 1)
+		switch test.nch
+			case 2
+				lstr1 = sprintf("ch%d", test.ch(1));
+				lstr2 = sprintf("ch%d", test.ch(2));
+				legend(lstr1, lstr2, ...
+					'Location', 'NorthEast');
+		end
+	else
+		lstr = sprintf("ch%d", test.ch(i));
+		legend(lstr, 'Location', 'NorthEast');
+	end
+
+	if test.plot_passband_zoom
+		axes('Position', [ 0.2 0.2 0.4 0.2]);
+		box on;
+		i1 = find(test.f < test.f_lo, 1, 'last');
+		i2 = find(test.f > test.f_hi, 1, 'first');
+		if isempty(i1)
+			i1 = 1;
+		end
+		if isempty(i2)
+			i2 = length(test.f);
+		end
+		if test.plot_channels_combine
+			plot(test.f(i1:i2), test.m(i1:i2,:));
+		else
+			plot(test.f(i1:i2), test.m(i1:i2,i));
+		end
+		rp = 1.0;
+		if ~isempty(test.fr_rp_max_db)
+			rp = test.fr_rp_max_db;
+			hold on;
+			plot([test.f_lo test.f_hi], [-rp/2 -rp/2], 'r--');
+			plot([test.f_lo test.f_hi], [ rp/2  rp/2], 'r--');
+			hold off
+		end
+		axis([0 test.f_hi -rp/2-0.05 rp/2+0.05]);
+		grid on;
+	end
+
+	if test.plot_channels_combine
+		break
+	end
+
 end
 
 end

--- a/tools/test/audio/std_utils/g_test_input.m
+++ b/tools/test/audio/std_utils/g_test_input.m
@@ -26,35 +26,9 @@ function test = g_test_input(test)
 % t.mark_a_db - amplitude max of marker tone (dB)
 %
 
-%%
-% Copyright (c) 2016, Intel Corporation
-% All rights reserved.
-%
-% Redistribution and use in source and binary forms, with or without
-% modification, are permitted provided that the following conditions are met:
-%   * Redistributions of source code must retain the above copyright
-%     notice, this list of conditions and the following disclaimer.
-%   * Redistributions in binary form must reproduce the above copyright
-%     notice, this list of conditions and the following disclaimer in the
-%     documentation and/or other materials provided with the distribution.
-%   * Neither the name of the Intel Corporation nor the
-%     names of its contributors may be used to endorse or promote products
-%     derived from this software without specific prior written permission.
-%
-% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
-% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-% POSSIBILITY OF SUCH DAMAGE.
-%
+% SPDX-License-Identifier: BSD-3-Clause
+% Copyright(c) 2017 Intel Corporation. All rights reserved.
 % Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
-%
 
 %% Reference: AES17 6.2.2 Gain
 %  http://www.aes.org/publications/standards/
@@ -69,12 +43,14 @@ if test.ch == 0
         test.ch = 1+round(rand(1,1)*(test.nch-1)); % Test random channel 1..Nch
 end
 
-fprintf('Using parameters Fs=%.1f, bits_in=%d', test.fs/1e3, test.bits_in);
-fprintf(', ch=%d', test.ch );
-fprintf(', Nch=%d\n', test.nch );
+for ch = test.ch
+    fprintf('Using parameters Fs=%.1f, bits_in=%d, ch=%d, Nch=%d\n', ...
+        test.fs/1e3, test.bits_in, ch, test.nch);
+end
 
-test.fn_in = sprintf('g_test_in.%s', test.fmt);
-test.fn_out = sprintf('g_test_out.%s', test.fmt);
+pid = getpid();
+test.fn_in = sprintf('g_test_in_%d.%s', pid, test.fmt);
+test.fn_out = sprintf('g_test_out_%d.%s', pid, test.fmt);
 test.f = 997;
 
 

--- a/tools/test/audio/std_utils/g_test_measure.m
+++ b/tools/test/audio/std_utils/g_test_measure.m
@@ -1,45 +1,21 @@
 function test = g_test_measure(test)
 
-%%
-% Copyright (c) 2017, Intel Corporation
-% All rights reserved.
-%
-% Redistribution and use in source and binary forms, with or without
-% modification, are permitted provided that the following conditions are met:
-%   * Redistributions of source code must retain the above copyright
-%     notice, this list of conditions and the following disclaimer.
-%   * Redistributions in binary form must reproduce the above copyright
-%     notice, this list of conditions and the following disclaimer in the
-%     documentation and/or other materials provided with the distribution.
-%   * Neither the name of the Intel Corporation nor the
-%     names of its contributors may be used to endorse or promote products
-%     derived from this software without specific prior written permission.
-%
-% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
-% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-% POSSIBILITY OF SUCH DAMAGE.
-%
+% SPDX-License-Identifier: BSD-3-Clause
+% Copyright(c) 2017 Intel Corporation. All rights reserved.
 % Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
-%
 
 %% Reference: AES17 6.2.2 Gain
 %  http://www.aes.org/publications/standards/
+
+default_result = NaN * ones(1,length(test.ch));
+test.g_db = default_result;
 
 %% Load output file
 [x, nx] = load_test_output(test);
 
 if nx == 0
-        test.g_db = NaN;
-        test.fail = 1;
-        return
+	test.fail = 1;
+	return
 end
 
 %% Standard low-pass
@@ -47,24 +23,31 @@ y0 = stdlpf(x, test.fu, test.fs);
 
 %% Find sync
 [d, nt, nt_use, nt_skip] = find_test_signal(y0, test);
+if isempty(d)
+	test.fail = 1;
+	return
+end
 
 %% Trim sample by removing first 1s to let the notch to apply
 i1 = d+nt_skip;
 i2 = i1+nt_use-1;
-y = y0(i1:i2);
+y = y0(i1:i2, :);
 
 %% Gain, SNR
 level_in = test.a_db;
 level_out = level_dbfs(y);
-test.g_db = level_out-level_in;
-fprintf('Gain = %6.3f dB (expecting %6.3f dB)\n', test.g_db, test.g_db_expect);
+test.g_db = level_out - level_in + test.att_rec_db;
+for i = 1:length(test.g_db)
+	fprintf('Gain = %6.3f dB (expect %6.3f dB)\n', test.g_db(i), test.g_db_expect);
+end
 
 %% Check pass/fail
 test.fail = 0;
-if abs(test.g_db_expect-test.g_db) > test.g_db_tol
-        fprintf('Failed gain %f dB (max %f dB)\n', test.g_db, test.g_db_tol);
-        test.fail = 1;
+delta_abs = abs(test.g_db_expect - test.g_db);
+idx = find(delta_abs >  test.g_db_tol);
+for i = 1:length(idx)
+	fprintf('Failed ch%d gain %f dB (max %f dB)\n', test.ch(i), test.g_db(i), test.g_db_tol);
+	test.fail = 1;
 end
 
 end
-

--- a/tools/test/audio/std_utils/thdnf_test_input.m
+++ b/tools/test/audio/std_utils/thdnf_test_input.m
@@ -26,35 +26,9 @@ function test = thdnf_test_input(test)
 % t.mark_a_db - amplitude max of marker tone (dB)
 %
 
-%%
-% Copyright (c) 2016, Intel Corporation
-% All rights reserved.
-%
-% Redistribution and use in source and binary forms, with or without
-% modification, are permitted provided that the following conditions are met:
-%   * Redistributions of source code must retain the above copyright
-%     notice, this list of conditions and the following disclaimer.
-%   * Redistributions in binary form must reproduce the above copyright
-%     notice, this list of conditions and the following disclaimer in the
-%     documentation and/or other materials provided with the distribution.
-%   * Neither the name of the Intel Corporation nor the
-%     names of its contributors may be used to endorse or promote products
-%     derived from this software without specific prior written permission.
-%
-% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
-% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-% POSSIBILITY OF SUCH DAMAGE.
-%
+% SPDX-License-Identifier: BSD-3-Clause
+% Copyright(c) 2016 Intel Corporation. All rights reserved.
 % Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
-%
 
 %% Reference: AES17 6.3.2 THD+N ratio vs frequency
 %  http://www.aes.org/publications/standards/
@@ -68,14 +42,16 @@ if test.ch == 0
         test.ch = 1+round(rand(1,1)*(test.nch-1)); % Test random channel 1..Nch
 end
 
-fprintf('Using parameters Fstart=%.0f Hz, Fend=%.0f Hz, Fs=%.1f Hz, bits_in=%d, ch=%d, Nch=%d\n', ...
-        test.f_start, test.f_end, test.fs/1e3, test.bits_in, test.ch, test.nch );
+for ch = test.ch
+    fprintf('Using parameters Fstart=%.0f Hz, Fend=%.0f Hz, Fs=%.1f Hz, bits_in=%d, ch=%d, Nch=%d\n', ...
+        test.f_start, test.f_end, test.fs/1e3, test.bits_in, ch, test.nch );
+end
 
-test.fn_in = sprintf('thdnf_test_in.%s', test.fmt);
-test.fn_out = sprintf('thdnf_test_out.%s', test.fmt);
+pid = getpid();
+test.fn_in = sprintf('thdnf_test_in_%d.%s', pid, test.fmt);
+test.fn_out = sprintf('thdnf_test_out_%d.%s', pid, test.fmt);
 noct = ceil(log(test.f_end/test.f_start)/log(2)); % Max 1 octave steps
 test.f = logspace(log10(test.f_start),log10(test.f_end), noct);
-
 
 %% Tone sweep parameters
 test.is = 20e-3; % Ignore signal from tone start

--- a/tools/test/audio/std_utils/thdnf_test_measure.m
+++ b/tools/test/audio/std_utils/thdnf_test_measure.m
@@ -1,44 +1,21 @@
 function test = thdnf_test_measure(test)
 
-%%
-% Copyright (c) 2017, Intel Corporation
-% All rights reserved.
-%
-% Redistribution and use in source and binary forms, with or without
-% modification, are permitted provided that the following conditions are met:
-%   * Redistributions of source code must retain the above copyright
-%     notice, this list of conditions and the following disclaimer.
-%   * Redistributions in binary form must reproduce the above copyright
-%     notice, this list of conditions and the following disclaimer in the
-%     documentation and/or other materials provided with the distribution.
-%   * Neither the name of the Intel Corporation nor the
-%     names of its contributors may be used to endorse or promote products
-%     derived from this software without specific prior written permission.
-%
-% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
-% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-% POSSIBILITY OF SUCH DAMAGE.
-%
+% SPDX-License-Identifier: BSD-3-Clause
+% Copyright(c) 2017 Intel Corporation. All rights reserved.
 % Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
-%
 
 %% Reference: AES17 6.3.2 THD+N ratio vs frequency
 %  http://www.aes.org/publications/standards/
 
+default_result = NaN * ones(test.nf, length(test.ch));
+test.thdnf_high = default_result;
+test.thdnf_low = default_result;
+
 %% Load output file
 [x, nx] = load_test_output(test);
 if nx == 0
-        test.g_db = NaN;
-        test.fail = 1;
-        return
+	test.fail = 1;
+	return
 end
 
 %% Standard low-pass
@@ -46,38 +23,76 @@ y0 = stdlpf(x, test.fu, test.fs);
 
 %% Find sync
 [d, nt, nt_use, nt_skip] = find_test_signal(y0, test);
+if isempty(d)
+	test.fail = 1;
+	return
+end
 
 %% Measure all test frequencies
-ml = zeros(test.nf,test.na);
-mn = zeros(test.nf,test.na);
-n_notch_settle = round(test.fs*test.nst);
-nn = 1;
-for m=1:test.na
-        for n=1:test.nf
-                fprintf('Measuring %.0f Hz ...\n', test.f(n));
-                i1 = d+(nn-1)*nt+nt_skip;
-                i2 = i1+nt_use-1;
-                nn = nn+1;
-                y0n = stdnotch(y0(i1:i2), test.f(n), test.fs);
-                ml(n,m) = level_dbfs(y0(i1:i2));
-                mn(n,m) = level_dbfs(y0n(n_notch_settle:end));
-        end
+test.fail = 0;
+for i = 1:length(test.ch);
+	ml = zeros(test.nf,test.na);
+	mn = zeros(test.nf,test.na);
+	n_notch_settle = round(test.fs*test.nst);
+	nn = 1;
+	for m=1:test.na
+		for n=1:test.nf
+			fprintf('Measuring %.0f Hz ...\n', test.f(n));
+			i1 = d+(nn-1)*nt+nt_skip;
+			i2 = i1+nt_use-1;
+			nn = nn+1;
+			y0n = stdnotch(y0(i1:i2, i), test.f(n), test.fs);
+			ml(n,m) = level_dbfs(y0(i1:i2, i));
+			mn(n,m) = level_dbfs(y0n(n_notch_settle:end));
+		end
+	end
+
+	test.thdnf = mn - ml;
+	test.thdnf_high(:,i) = test.thdnf(:,1);
+	test.thdnf_low(:,i) = test.thdnf(:,2);
+	if max(max(test.thdnf)) > test.thdnf_max
+		test.fail = 1;
+	end
 end
 
-test.thdnf = mn - ml;
-test.thdnf_high = test.thdnf(:,1);
-test.thdnf_low = test.thdnf(:,2);
-if max(max(test.thdnf)) > test.thdnf_max
-        test.fail = 1;
-else
-        test.fail = 0;
-end
+%% Do plots
+for i = 1:length(test.ch)
+	test.fh(i) = figure('visible', test.plot_visible);
+	test.ph(i) = subplot(1, 1, 1);
 
-test.fh = figure('visible', test.visible);
-semilogx(test.f, test.thdnf(:,1), 'b', test.f, test.thdnf(:,2), 'g--');
-grid on;
-xlabel('Frequency (Hz)');
-ylabel('THD+N (dB)');
-legend('-1 dBFS','-20 dBFS');
+	if test.plot_channels_combine
+		semilogx(test.f, test.thdnf_high, test.f, test.thdnf_low, '--');
+	else
+		semilogx(test.f, test.thdnf_high(:,i), ...
+			test.f, test.thdnf_low(:,i), '--');
+	end
+
+	grid on;
+	if ~isempty(test.plot_thdn_axis);
+		axis(test.plot_thdn_axis);
+
+	xlabel('Frequency (Hz)');
+	ylabel('THD+N (dB)');
+
+	if test.plot_channels_combine && (test.nch > 1)
+		switch test.nch
+			case 2
+				ls1 = sprintf("ch%d  -1 dBFS", test.ch(1));
+				ls2 = sprintf("ch%d  -1 dBFS", test.ch(2));
+				ls3 = sprintf("ch%d -20 dBFS", test.ch(1));
+				ls4 = sprintf("ch%d -20 dBFS", test.ch(2));
+				legend(ls1, ls2, ls3, ls4, 'Location', 'NorthEast');
+		end
+	else
+		ls1 = sprintf("ch%d  -1 dBFS", test.ch(i));
+		ls2 = sprintf("ch%d -20 dBFS", test.ch(i));
+		legend(ls1, ls2, 'Location', 'NorthEast');
+	end
+
+	if test.plot_channels_combine
+		break
+	end
+
+end
 
 end

--- a/tools/test/audio/test_utils/chirp_test_analyze.m
+++ b/tools/test/audio/test_utils/chirp_test_analyze.m
@@ -78,7 +78,7 @@ else if (min(rms_db) < -3) && (test.fs2 + 1 > test.fs1)
      end
 end
 
-test.fh = figure('visible', test.visible);
+test.fh = figure('visible', test.plot_visible);
 ns = 1024;
 no = round(0.9*ns);
 specgram(y(:,1), ns, test.fs, kaiser(ns,27), no);

--- a/tools/test/audio/test_utils/load_test_output.m
+++ b/tools/test/audio/test_utils/load_test_output.m
@@ -14,35 +14,9 @@ function [x, nx] = load_test_output(test)
 % n - number of samples
 %
 
-%%
-% Copyright (c) 2017, Intel Corporation
-% All rights reserved.
-%
-% Redistribution and use in source and binary forms, with or without
-% modification, are permitted provided that the following conditions are met:
-%   * Redistributions of source code must retain the above copyright
-%     notice, this list of conditions and the following disclaimer.
-%   * Redistributions in binary form must reproduce the above copyright
-%     notice, this list of conditions and the following disclaimer in the
-%     documentation and/or other materials provided with the distribution.
-%   * Neither the name of the Intel Corporation nor the
-%     names of its contributors may be used to endorse or promote products
-%     derived from this software without specific prior written permission.
-%
-% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
-% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-% POSSIBILITY OF SUCH DAMAGE.
-%
+% SPDX-License-Identifier: BSD-3-Clause
+% Copyright(c) 2017 Intel Corporation. All rights reserved.
 % Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
-%
 
 %% Integer type for binary files
 switch test.bits_out
@@ -58,7 +32,7 @@ end
 
 %% Check that output file exists
 if exist(test.fn_out)
-        fprintf('Reading output data file %s...\n', test.fn_out);
+	fprintf('Reading output data file %s...\n', test.fn_out);
 	switch lower(test.fmt)
 		case 'txt'
 			out = load(test.fn_out);
@@ -66,11 +40,17 @@ if exist(test.fn_out)
 			fh = fopen(test.fn_out, 'r');
 			out = fread(fh, inf, bfmt);
 			fclose(fh);
+		case 'wav'
+			[x0, fs] = audioread(test.fn_out);
+			x = x0(:,test.ch);
+			sx = size(x);
+			nx = sx(1);
+			return
 		otherwise
 			error('Fmt must be raw or txt.');
 	end
 else
-        out = [];
+	out = [];
 end
 
 %% Exctract channels to measure

--- a/tools/test/audio/test_utils/mix_sweep.m
+++ b/tools/test/audio/test_utils/mix_sweep.m
@@ -1,34 +1,8 @@
 function  test = mix_sweep(test)
 
-%%
-% Copyright (c) 2017, Intel Corporation
-% All rights reserved.
-%
-% Redistribution and use in source and binary forms, with or without
-% modification, are permitted provided that the following conditions are met:
-%   * Redistributions of source code must retain the above copyright
-%     notice, this list of conditions and the following disclaimer.
-%   * Redistributions in binary form must reproduce the above copyright
-%     notice, this list of conditions and the following disclaimer in the
-%     documentation and/or other materials provided with the distribution.
-%   * Neither the name of the Intel Corporation nor the
-%     names of its contributors may be used to endorse or promote products
-%     derived from this software without specific prior written permission.
-%
-% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
-% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-% POSSIBILITY OF SUCH DAMAGE.
-%
+% SPDX-License-Identifier: BSD-3-Clause
+% Copyright(c) 2017 Intel Corporation. All rights reserved.
 % Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
-%
 
 %% Adjust tone lengt to integer number of samples
 test.nt = round(test.tl*test.fs); % Make number of samples per tone
@@ -93,11 +67,14 @@ for m=1:test.na
         end
 end
 
+sx = size(x);
 test.signal = x;
+test.length_n = sx(1);
+test.length_t = sx(1) / test.fs;
 
 %% Output
 fprintf('Writing output data file %s...\n', test.fn_in);
-write_test_data(x, test.fn_in, test.bits_in, test.fmt);
+write_test_data(x, test.fn_in, test.bits_in, test.fmt, test.fs);
 fprintf('Done.\n')
 
 end

--- a/tools/test/audio/test_utils/remote_test_run.m
+++ b/tools/test/audio/test_utils/remote_test_run.m
@@ -1,0 +1,80 @@
+%% Run test with remote/local playback and capture
+%
+%  remote_test_run(test);
+%
+%  Inputs:
+%  test.play_cfg - configuration for playback device
+%  test.fn_in    - filename for audio input
+%  test.length_t - length of audio input in seconds
+%  test.rec_cfg  - configuration for audio capture device
+%  test.fn_out   - filename for audio output
+%
+%  Outputs:
+%
+
+% SPDX-License-Identifier: BSD-3-Clause
+% Copyright(c) 2019 Intel Corporation. All rights reserved.
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+
+function test = remote_test_run(test)
+
+remote_copy_playback(test.fn_in, test.play_cfg);
+tcap = floor(3 + test.length_t);
+remote_capture(test.fn_out, test.rec_cfg, tcap);
+remote_play(test.fn_in, test.play_cfg);
+pause(3);
+remote_copy_capture(test.fn_out, test.rec_cfg);
+
+end
+
+function remote_copy_playback(fn, cfg)
+if cfg.ssh
+	cmd = sprintf('scp %s %s:%s/', fn, cfg.user, cfg.dir);
+	fprintf('Remote copy: %s\n', cmd);
+	system(cmd);
+else
+	cmd = sprintf('cp %s %s/', fn, cfg.dir);
+	fprintf('Local copy: %s\n', cmd);
+end
+end
+
+function y = remote_copy_capture(fn, cfg)
+if cfg.ssh
+	cmd = sprintf('scp %s:%s/%s %s', cfg.user, cfg.dir, fn, fn);
+	del = sprintf('ssh %s rm %s/%s', cfg.user, cfg.dir, fn);
+	fprintf('Remote copy: %s\n', cmd);
+else
+	cmd = sprintf('cp %s/%s %s', cfg.dir, fn, fn);
+	del = sprintf('rm %s/%s', cfg.dir, fn);
+	fprintf('Local copy: %s\n', cmd);
+end
+system(cmd);
+system(del);
+end
+
+function remote_play(fn, cfg)
+if cfg.ssh
+	cmd = sprintf('ssh %s aplay -D%s %s/%s', cfg.user, cfg.dev, cfg.dir, fn);
+	del = sprintf('ssh %s rm %s/%s', cfg.user, cfg.dir, fn);
+	fprintf('Remote play: %s\n', cmd);
+else
+	cmd = sprintf('aplay -D%s %s/%s', cfg.dev, cfg.dir, fn);
+	del = sprintf('rm %s/%s', cfg.dir, fn);
+	fprintf('Local play: %s\n', cmd);
+end
+system(cmd);
+system(del);
+end
+
+function remote_capture(fn, cfg, t)
+if cfg.ssh
+	cmd = sprintf('ssh %s arecord -q -D%s %s -d %d %s/%s &', ...
+		cfg.user, cfg.dev, cfg.fmt, t, cfg.dir, fn);
+	fprintf('Remote capture: %s\n', cmd);
+else
+	cmd = sprintf('arecord -q -D%s %s -d %d %s/%s &', ...
+		cfg.dev, cfg.fmt, t, cfg.dir, fn);
+	fprintf('Local capture: %s\n', cmd);
+end
+system(cmd);
+end

--- a/tools/test/audio/test_utils/write_test_data.m
+++ b/tools/test/audio/test_utils/write_test_data.m
@@ -1,36 +1,14 @@
-function write_test_data(x, fn, bits, fmt)
+function write_test_data(x, fn, bits, fmt, fs)
 
-%%
-% Copyright (c) 2017, Intel Corporation
-% All rights reserved.
-%
-% Redistribution and use in source and binary forms, with or without
-% modification, are permitted provided that the following conditions are met:
-%   * Redistributions of source code must retain the above copyright
-%     notice, this list of conditions and the following disclaimer.
-%   * Redistributions in binary form must reproduce the above copyright
-%     notice, this list of conditions and the following disclaimer in the
-%     documentation and/or other materials provided with the distribution.
-%   * Neither the name of the Intel Corporation nor the
-%     names of its contributors may be used to endorse or promote products
-%     derived from this software without specific prior written permission.
-%
-% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
-% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-% POSSIBILITY OF SUCH DAMAGE.
-%
+% SPDX-License-Identifier: BSD-3-Clause
+% Copyright(c) 2019 Intel Corporation. All rights reserved.
 % Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
-%
 
 switch lower(fmt)
+	case 'wav'
+		y = double(x) / 2^(bits-1);
+		audiowrite(fn, y, fs, 'BitsPerSample', bits);
+		return;
 	case 'raw'
 		fh = fopen(fn, 'wb');
 	case 'txt'


### PR DESCRIPTION
This patch adds a shell script audio_quality_test.sh that
measures gain, frequency response, and total harmonic distortion
plus noise for a remote device.

Matlab or Octave is needed. The shell script launches by default
Octave to process the signal generation and test results analysis
scripts.

The remote device must be set to be accessible by ssh without
passwords. An external high quality USB sound card is recommended
as analog interface to connect to test device's analog interface.

The configuration file audio_quality_test_config.txt must be
edited for the remote device's user account, audio device, audio
format, and capture sound card audio device, and audio format.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>