### PR TITLE
host: remove duplicate dma_stop()

### DIFF
--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -711,7 +711,6 @@ static int host_reset(struct comp_dev *dev)
 #endif
 
 #if CONFIG_DMA_GW
-	dma_stop(hd->dma, hd->chan);
 	dma_channel_put(hd->dma, hd->chan);
 
 	/* free array for hda-dma only, do not free single one for dw-dma */


### PR DESCRIPTION
Remove the duplicate dma_stop() during host_reset().
DMA should already be stopped when the host comp gets
the STOP trigger. This fixes the following error seen
during host reset:
intel/cavs/hda-dma.c:639 hda-dmac: 5 invalid channel -1

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>