### PR TITLE
 alloc: move DEBUG_BLOCK_FREE to kconfig

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -116,6 +116,12 @@ source "src/Kconfig"
 
 menu "Debug"
 
+config DEBUG
+	bool "Enable debug build"
+	default n
+	help
+	  Select for debug build
+
 config GDB_DEBUG
 	bool "GDB Stub"
 	default n
@@ -127,12 +133,6 @@ config DEBUG_HEAP
 	default n
 	help
 	  Select for enable heap alloc debugging
-
-config DEBUG
-	bool "Debug build"
-	default n
-	help
-	  Select for debug build
 
 config BUILD_VM_ROM
 	bool "Build VM ROM"

--- a/Kconfig
+++ b/Kconfig
@@ -134,6 +134,15 @@ config DEBUG_HEAP
 	help
 	  Select for enable heap alloc debugging
 
+config DEBUG_BLOCK_FREE
+	bool "Blocks freeing debug"
+	default n
+	help
+	  It enables checking if free was called multiple times on
+	  already freed block of memory. Enabling this feature increases
+	  number of memory writes and reads, due to checks for memory patterns
+	  that may be performed on allocation and deallocation.
+
 config BUILD_VM_ROM
 	bool "Build VM ROM"
 	default n

--- a/src/lib/alloc.c
+++ b/src/lib/alloc.c
@@ -40,9 +40,10 @@
 #include <stdint.h>
 
 /* debug to set memory value on every allocation */
-#define DEBUG_BLOCK_FREE 0
+#if CONFIG_DEBUG_BLOCK_FREE
 #define DEBUG_BLOCK_FREE_VALUE_8BIT ((uint8_t) 0xa5)
 #define DEBUG_BLOCK_FREE_VALUE_32BIT ((uint32_t) 0xa5a5a5a5)
+#endif
 
 #define trace_mem_error(__e, ...) \
 	trace_error(TRACE_CLASS_MEM, __e, ##__VA_ARGS__)
@@ -63,7 +64,7 @@ extern struct mm memmap;
  *    module removal or calls to rfree(). Saved as part of PM context.
  */
 
-#if DEBUG_BLOCK_FREE
+#if CONFIG_DEBUG_BLOCK_FREE
 /* Check whole memory region for debug pattern to find if memory was freed
  * second time
  */
@@ -117,7 +118,7 @@ static inline uint32_t heap_get_size(struct mm_heap *heap)
 	return size;
 }
 
-#if DEBUG_BLOCK_FREE
+#if CONFIG_DEBUG_BLOCK_FREE
 static void write_pattern(struct mm_heap *heap_map, int heap_depth,
 						  uint8_t pattern)
 {
@@ -425,7 +426,7 @@ static void free_block(void *ptr)
 	if (block < block_map->first_free)
 		block_map->first_free = block;
 
-#if DEBUG_BLOCK_FREE
+#if CONFIG_DEBUG_BLOCK_FREE
 	/* memset the whole block in case of unaligned ptr */
 	validate_memory(
 		(void *)(block_map->base + block_map->block_size * block),
@@ -577,7 +578,7 @@ void *_malloc(int zone, uint32_t caps, size_t bytes)
 		break;
 	}
 
-#if DEBUG_BLOCK_FREE
+#if CONFIG_DEBUG_BLOCK_FREE
 	if (ptr)
 		bzero(ptr, bytes);
 #endif
@@ -656,7 +657,7 @@ static void *alloc_heap_buffer(struct mm_heap *heap, int zone, uint32_t caps,
 	if (ptr && ((zone & RZONE_FLAG_MASK) == RZONE_FLAG_UNCACHED))
 		ptr = cache_to_uncache(ptr);
 
-#if DEBUG_BLOCK_FREE
+#if CONFIG_DEBUG_BLOCK_FREE
 	if (ptr)
 		bzero(ptr, bytes);
 #endif
@@ -833,7 +834,7 @@ void init_heap(struct sof *sof)
 
 	init_heap_map(memmap.buffer, PLATFORM_HEAP_BUFFER);
 
-#if DEBUG_BLOCK_FREE
+#if CONFIG_DEBUG_BLOCK_FREE
 	write_pattern((struct mm_heap *)&memmap.buffer, PLATFORM_HEAP_BUFFER,
 				  DEBUG_BLOCK_FREE_VALUE_8BIT);
 	write_pattern((struct mm_heap *)&memmap.runtime, PLATFORM_HEAP_RUNTIME,

--- a/src/lib/alloc.c
+++ b/src/lib/alloc.c
@@ -41,9 +41,8 @@
 
 /* debug to set memory value on every allocation */
 #define DEBUG_BLOCK_FREE 0
-#define DEBUG_BLOCK_FREE_VALUE 0xa5
-#define DEBUG_BLOCK_FREE_VALUE_32 0xa5a5a5a5
-
+#define DEBUG_BLOCK_FREE_VALUE_8BIT ((uint8_t) 0xa5)
+#define DEBUG_BLOCK_FREE_VALUE_32BIT ((uint32_t) 0xa5a5a5a5)
 
 #define trace_mem_error(__e, ...) \
 	trace_error(TRACE_CLASS_MEM, __e, ##__VA_ARGS__)
@@ -74,7 +73,7 @@ static void validate_memory(void *ptr, size_t size)
 	int i, not_matching = 0;
 
 	for (i = 0; i < size/4; i++) {
-		if (ptr_32[i] != DEBUG_BLOCK_FREE_VALUE_32)
+		if (ptr_32[i] != DEBUG_BLOCK_FREE_VALUE_32BIT)
 			not_matching = 1;
 	}
 
@@ -427,13 +426,13 @@ static void free_block(void *ptr)
 		block_map->first_free = block;
 
 #if DEBUG_BLOCK_FREE
-	/* memset the whole block incase some not aligned ptr */
+	/* memset the whole block in case of unaligned ptr */
 	validate_memory(
 		(void *)(block_map->base + block_map->block_size * block),
 		block_map->block_size * (i - block));
 	memset(
 		(void *)(block_map->base + block_map->block_size * block),
-		DEBUG_BLOCK_FREE_VALUE, block_map->block_size *
+		DEBUG_BLOCK_FREE_VALUE_8BIT, block_map->block_size *
 		(i - block));
 #endif
 }
@@ -836,9 +835,9 @@ void init_heap(struct sof *sof)
 
 #if DEBUG_BLOCK_FREE
 	write_pattern((struct mm_heap *)&memmap.buffer, PLATFORM_HEAP_BUFFER,
-				  DEBUG_BLOCK_FREE_VALUE);
+				  DEBUG_BLOCK_FREE_VALUE_8BIT);
 	write_pattern((struct mm_heap *)&memmap.runtime, PLATFORM_HEAP_RUNTIME,
-				  DEBUG_BLOCK_FREE_VALUE);
+				  DEBUG_BLOCK_FREE_VALUE_8BIT);
 #endif
 
 	dcache_writeback_invalidate_region(&memmap, sizeof(memmap));


### PR DESCRIPTION
Slight refactor - moved DEBUG_BLOCK_FREE from C file to Kconfig. 