### PR TITLE
kmod_scripts: fix hdaudio support

### DIFF
--- a/tools/kmod_scripts/sof_remove.sh
+++ b/tools/kmod_scripts/sof_remove.sh
@@ -71,6 +71,9 @@ remove_module snd_soc_hdac_hda
 remove_module snd_soc_hdac_hdmi
 remove_module snd_soc_dmic
 
+remove_module snd_hda_codec_realtek
+remove_module snd_hda_codec_generic
+
 remove_module snd_soc_acpi
 remove_module snd_hda_ext_core
 


### PR DESCRIPTION
Missing modules obviously.

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>