### PR TITLE
DMIC: Increase start gain ramp length to 400 ms

### DIFF
--- a/src/drivers/intel/cavs/dmic.c
+++ b/src/drivers/intel/cavs/dmic.c
@@ -122,12 +122,12 @@ struct pdm_controllers_configuration {
 /* Hardwired log ramp parameters. The first value is the initial logarithmic
  * gain and the second value is the multiplier for gain to achieve the linear
  * decibels change over time. Currently the coefficient GM needs to be
- * calculated manually. The 300 ms ramp should ensure clean sounding start with
- * any microphone. However it is likely unnecessarily long for machine hearing.
+ * calculated manually. The 400 ms ramp should ensure clean sounding start
+ * with any microphone.
  * TODO: Add ramp characteristic passing via topology.
  */
 #define LOGRAMP_GI 33954 /* -90 dB, Q2.30*/
-#define LOGRAMP_GM 16959 /* Gives 300 ms ramp for -90..0 dB, Q2.14 */
+#define LOGRAMP_GM 16814 /* Gives 400 ms ramp for -90..0 dB, Q2.14 */
 
 /* tracing */
 #define trace_dmic(__e, ...) \


### PR DESCRIPTION
This patch updates the gain update coefficient to achieve
a longer ramp time. The previous 300 ms long ramp was not
enough to conceal all of the slow DC component settling seen
in the beginning of DMIC capture.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>