### PR TITLE
DMIC topology updates patch set

### DIFF
--- a/tools/topology/platform/intel/intel-generic-dmic.m4
+++ b/tools/topology/platform/intel/intel-generic-dmic.m4
@@ -23,10 +23,10 @@ PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	48, 1000, 0, 0)
 
 # Passthrough capture pipeline using max channels defined by CHANNELS.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 16 frames per 1000us deadline on core 0 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-volume-capture-16khz.m4,
-	DMIC_PIPELINE_16k_ID, DMIC_DAI_LINK_16k_ID, CHANNELS, s16le,
-	48, 1000, 0, 0)
+	DMIC_PIPELINE_16k_ID, DMIC_DAI_LINK_16k_ID, CHANNELS, s32le,
+	16, 1000, 0, 0)
 
 #
 # DAIs configuration
@@ -45,11 +45,11 @@ DAI_ADD(sof/pipe-dai-capture.m4,
 	48, 1000, 0, 0)
 
 # capture DAI is DMIC 1 using 2 periods
-# Buffers use s16le format, with 48 frame per 1000us on core 0 with priority 0
+# Buffers use s32le format, with 16 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	DMIC_PIPELINE_16k_ID, DMIC, 1, dmic16k,
-	concat(`PIPELINE_SINK_', DMIC_PIPELINE_16k_ID), 2, s16le,
-	48, 1000, 0, 0)
+	concat(`PIPELINE_SINK_', DMIC_PIPELINE_16k_ID), 2, s32le,
+	16, 1000, 0, 0)
 
 
 dnl PCM_DUPLEX_ADD(name, pcm_id, playback, capture)
@@ -75,9 +75,9 @@ ifelse(CHANNELS, 4,
 ifelse(CHANNELS, 4,
 `DAI_CONFIG(DMIC, 1, DMIC_DAI_LINK_16k_ID, dmic16k,
 	   DMIC_CONFIG(1, 500000, 4800000, 40, 60, 16000,
-		DMIC_WORD_LENGTH(s16le), DMIC, 1,
+		DMIC_WORD_LENGTH(s32le), DMIC, 1,
 		PDM_CONFIG(DMIC, 1, FOUR_CH_PDM0_PDM1)))',
 `DAI_CONFIG(DMIC, 1, DMIC_DAI_LINK_16k_ID, dmic16k,
            DMIC_CONFIG(1, 500000, 4800000, 40, 60, 16000,
-                DMIC_WORD_LENGTH(s16le), DMIC, 1,
+                DMIC_WORD_LENGTH(s32le), DMIC, 1,
                 PDM_CONFIG(DMIC, 1, STEREO_PDM0)))')

--- a/tools/topology/platform/intel/intel-generic-dmic.m4
+++ b/tools/topology/platform/intel/intel-generic-dmic.m4
@@ -18,10 +18,9 @@ dnl     frames, deadline, priority, core)
 
 # Passthrough capture pipeline using max channels defined by CHANNELS.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
-ifelse(CHANNELS, 4, `',
-`PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	DMIC_PIPELINE_48k_ID, DMIC_DAI_LINK_48k_ID, CHANNELS, s32le,
-	48, 1000, 0, 0)')
+	48, 1000, 0, 0)
 
 # Passthrough capture pipeline using max channels defined by CHANNELS.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
@@ -40,11 +39,10 @@ dnl     frames, deadline, priority, core)
 
 # capture DAI is DMIC 0 using 2 periods
 # Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
-ifelse(CHANNELS, 4, `',
-`DAI_ADD(sof/pipe-dai-capture.m4,
+DAI_ADD(sof/pipe-dai-capture.m4,
 	DMIC_PIPELINE_48k_ID, DMIC, 0, dmic01,
 	concat(`PIPELINE_SINK_', DMIC_PIPELINE_48k_ID), 2, s32le,
-	48, 1000, 0, 0)')
+	48, 1000, 0, 0)
 
 # capture DAI is DMIC 1 using 2 periods
 # Buffers use s16le format, with 48 frame per 1000us on core 0 with priority 0
@@ -56,8 +54,7 @@ DAI_ADD(sof/pipe-dai-capture.m4,
 
 dnl PCM_DUPLEX_ADD(name, pcm_id, playback, capture)
 dnl PCM_CAPTURE_ADD(name, pipeline, capture)
-ifelse(CHANNELS, 4, `',
-`PCM_CAPTURE_ADD(DMIC32, DMIC_DAI_LINK_48k_ID, concat(`PIPELINE_PCM_', DMIC_PIPELINE_48k_ID))')
+PCM_CAPTURE_ADD(DMIC32, DMIC_DAI_LINK_48k_ID, concat(`PIPELINE_PCM_', DMIC_PIPELINE_48k_ID))
 PCM_CAPTURE_ADD(DMIC16, DMIC_DAI_LINK_16k_ID, concat(`PIPELINE_PCM_', DMIC_PIPELINE_16k_ID))
 
 #
@@ -66,7 +63,11 @@ PCM_CAPTURE_ADD(DMIC16, DMIC_DAI_LINK_16k_ID, concat(`PIPELINE_PCM_', DMIC_PIPEL
 
 dnl DAI_CONFIG(type, dai_index, link_id, name, ssp_config/dmic_config)
 ifelse(CHANNELS, 4,
-`', `DAI_CONFIG(DMIC, 0, DMIC_DAI_LINK_48k_ID, dmic01,
+`DAI_CONFIG(DMIC, 0, DMIC_DAI_LINK_48k_ID, dmic01,
+	   DMIC_CONFIG(1, 500000, 4800000, 40, 60, 48000,
+		DMIC_WORD_LENGTH(s32le), DMIC, 0,
+		PDM_CONFIG(DMIC, 0, FOUR_CH_PDM0_PDM1)))',
+`DAI_CONFIG(DMIC, 0, DMIC_DAI_LINK_48k_ID, dmic01,
            DMIC_CONFIG(1, 500000, 4800000, 40, 60, 48000,
                 DMIC_WORD_LENGTH(s32le), DMIC, 0,
                 PDM_CONFIG(DMIC, 0, STEREO_PDM0)))')


### PR DESCRIPTION
This patch set consists of two commits

- The first patch adds the missing 4ch 32bit DAI creation. The DAI was not earlier created due to a mistake in topology.
- The second patch changes the 16 kHz DMIC FIFO to use 32 bit bit configuration. It improves a lot audio quality when the signal is amplified in volume control. The pipeline scheduling is also changed to default 1000us (48 frames -> 16 frames scheduling). The comments and actual topology config were conflicting. 