### PR TITLE
memory: new memory layout

### DIFF
--- a/src/arch/xtensa/boot_entry.S
+++ b/src/arch/xtensa/boot_entry.S
@@ -43,7 +43,7 @@ l2_cache_pref:
 #endif
 
 sof_stack_base:
-	.word SOF_STACK_BASE
+	.word __stack
 
 #if !defined CONFIG_SUECREEK
 wnd0_base:

--- a/src/arch/xtensa/smp/xtos/crt1-boards.S
+++ b/src/arch/xtensa/smp/xtos/crt1-boards.S
@@ -231,7 +231,7 @@ xtos_per_core_init_interrupt_mask:
 
 	// Assign stack ptr before PS is initialized to avoid any debugger
 	// side effects and prevent from double exception.
-	xtos_stack_addr_percore_basic sp, a3, _stack_sentry, ARCH_STACK_SIZE
+	xtos_stack_addr_percore sp, a3, _stack_sentry, _sof_core_s_start, SOF_STACK_SIZE
 
 	/*
 	 *  Now that sp (a1) is set, we can set PS as per the application

--- a/src/lib/alloc.c
+++ b/src/lib/alloc.c
@@ -798,8 +798,10 @@ void heap_trace(struct mm_heap *heap, int size) { }
 /* initialise map */
 void init_heap(struct sof *sof)
 {
+	extern uintptr_t _system_heap_start;
+
 	/* sanity check for malformed images or loader issues */
-	if (memmap.system[0].heap != HEAP_SYSTEM_0_BASE)
+	if (memmap.system[0].heap != (uintptr_t)&_system_heap_start)
 		panic(SOF_IPC_PANIC_MEM);
 
 	spinlock_init(&memmap.lock);

--- a/src/platform/apollolake/apollolake.x.in
+++ b/src/platform/apollolake/apollolake.x.in
@@ -90,21 +90,6 @@ MEMORY
   sof_fw :
         org = SOF_FW_BASE,
         len = SOF_FW_MAX_SIZE
-  system_heap :
-        org = HEAP_SYSTEM_0_BASE,
-        len = HEAP_SYSTEM_T_SIZE
-  system_runtime_heap :
-        org = HEAP_SYS_RUNTIME_0_BASE,
-        len = HEAP_SYS_RUNTIME_T_SIZE
-  runtime_heap :
-        org = HEAP_RUNTIME_BASE,
-        len = HEAP_RUNTIME_SIZE
-  buffer_heap :
-        org = HEAP_BUFFER_BASE,
-        len = HEAP_BUFFER_SIZE
-  sof_stack :
-        org = SOF_STACK_END,
-        len = SOF_STACK_BASE - SOF_STACK_END
   buffer_hp_heap :
         org = HEAP_HP_BUFFER_BASE,
         len = HEAP_HP_BUFFER_SIZE
@@ -152,11 +137,6 @@ PHDRS
   vector_double_lit_phdr PT_LOAD;
   vector_double_text_phdr PT_LOAD;
   sof_fw_phdr PT_LOAD;
-  system_heap_phdr PT_LOAD;
-  system_runtime_heap_phdr PT_LOAD;
-  runtime_heap_phdr PT_LOAD;
-  buffer_heap_phdr PT_LOAD;
-  sof_stack_phdr PT_LOAD;
   buffer_hp_heap_phdr PT_LOAD;
   wnd0_phdr PT_LOAD;
   wnd1_phdr PT_LOAD;
@@ -495,28 +475,61 @@ SECTIONS
     *(.bss.*)
     *(.gnu.linkonce.b.*)
     *(COMMON)
-    . = ALIGN (8);
+
+    . = ALIGN (SRAM_BANK_SIZE);
+    _runtime_heap_start = ABSOLUTE(.);
+    . = . + HEAP_RUNTIME_SIZE;
+    _runtime_heap_end = ABSOLUTE(.);
+
+    . = ALIGN (32);
+    _buffer_heap_start = ABSOLUTE(.);
+    . = . + HEAP_BUFFER_SIZE;
+    _buffer_heap_end = ABSOLUTE(.);
+
+    . = ALIGN (SRAM_BANK_SIZE);
+    _system_heap_start = ABSOLUTE(.);
+    . = . + HEAP_SYSTEM_M_SIZE;
+    _system_heap_end = ABSOLUTE(.);
+
+    . = ALIGN (32);
+    _system_runtime_heap_start = ABSOLUTE(.);
+    . = . + HEAP_SYS_RUNTIME_M_SIZE;
+    _system_runtime_heap_end = ABSOLUTE(.);
+
+    . = ALIGN (4096);
+    _sof_stack_start = ABSOLUTE(.);
+    . = . + SOF_STACK_SIZE;
+    _sof_stack_end = ABSOLUTE(.);
+
+    . = ALIGN (SRAM_BANK_SIZE);
+    _sof_core_s_start = ABSOLUTE(.);
+    . = . + SOF_CORE_S_T_SIZE;
+    _sof_core_s_end = ABSOLUTE(.);
+
     _bss_end = ABSOLUTE(.);
   } >sof_fw :sof_fw_phdr
 
   /* stack */
-  _end = SOF_STACK_END;
-  PROVIDE(end = SOF_STACK_END);
-  _stack_sentry = SOF_STACK_END;
-  __stack = SOF_STACK_BASE;
+  _end = _sof_stack_start;
+  PROVIDE(end = _sof_stack_start);
+  _stack_sentry = _sof_stack_start;
+  __stack = _sof_stack_end;
+
+  /* Slave core size */
+  _core_s_size = SOF_CORE_S_SIZE;
 
   /* System Heap */
-  _system_heap = HEAP_SYSTEM_0_BASE;
+  _system_heap = _system_heap_start;
 
   /* system runtime heap */
-  _system_runtime_heap = HEAP_SYS_RUNTIME_0_BASE;
+  _system_runtime_heap = _system_runtime_heap_start;
 
   /* module heap */
-  _module_heap = HEAP_RUNTIME_BASE;
+  _module_heap = _runtime_heap_start;
 
   /* buffer heap */
-  _buffer_heap = HEAP_BUFFER_BASE;
-  _buffer_heap_end = _stack_sentry;
+  _buffer_heap = _buffer_heap_start;
+  _buffer_heap_end = _buffer_heap_end;
 
   .debug  0 :  { *(.debug) }
   .line  0 :  { *(.line) }
@@ -568,46 +581,6 @@ SECTIONS
     KEEP (*(.xt.profile_files))
     KEEP (*(.gnu.linkonce.xt.profile_files.*))
   }
-
-  .system_heap (NOLOAD) : ALIGN(8)
-  {
-    . = ALIGN (32);
-    _system_heap_start = ABSOLUTE(.);
-    . = . + HEAP_SYSTEM_T_SIZE;
-    _system_heap_end = ABSOLUTE(.);
-  } >system_heap :system_heap_phdr
-
-  .system_runtime_heap (NOLOAD) : ALIGN(8)
-  {
-    . = ALIGN (32);
-    _system_runtime_heap_start = ABSOLUTE(.);
-    . = . + HEAP_SYS_RUNTIME_T_SIZE;
-    _system_runtime_heap_end = ABSOLUTE(.);
-  } >system_runtime_heap :system_runtime_heap_phdr
-
-  .runtime_heap (NOLOAD) : ALIGN(8)
-  {
-    . = ALIGN (32);
-    _runtime_heap_start = ABSOLUTE(.);
-    . = . + HEAP_RUNTIME_SIZE;
-    _runtime_heap_end = ABSOLUTE(.);
-  } >runtime_heap :runtime_heap_phdr
-
-  .buffer_heap (NOLOAD) : ALIGN(8)
-  {
-    . = ALIGN (32);
-    _buffer_heap_start = ABSOLUTE(.);
-    . = . + HEAP_BUFFER_SIZE;
-    _buffer_heap_end = ABSOLUTE(.);
-  } >buffer_heap :buffer_heap_phdr
-
-  .sof_stack (NOLOAD) : ALIGN(8)
-  {
-    . = ALIGN (4096);
-    _sof_stack_start = ABSOLUTE(.);
-    . = . + SOF_STACK_TOTAL_SIZE;
-    _sof_stack_end = ABSOLUTE(.);
-  } >sof_stack :sof_stack_phdr
 
   .static_log_entries (COPY) : ALIGN(1024)
   {

--- a/src/platform/apollolake/boot_ldr.x.in
+++ b/src/platform/apollolake/boot_ldr.x.in
@@ -28,11 +28,11 @@ MEMORY
         org = IMR_BOOT_LDR_DATA_BASE,
         len = IMR_BOOT_LDR_DATA_SIZE
   sof_bss_data :
-	org = IMR_BOOT_LDR_BSS_BASE,
+        org = IMR_BOOT_LDR_BSS_BASE,
         len = IMR_BOOT_LDR_BSS_SIZE
   sof_stack :
-        org = SOF_STACK_END,
-        len = SOF_STACK_BASE - SOF_STACK_END
+        org = BOOT_LDR_STACK_BASE,
+        len = BOOT_LDR_STACK_SIZE
   wnd0 :
         org = HP_SRAM_WIN0_BASE,
         len = HP_SRAM_WIN0_SIZE
@@ -180,7 +180,7 @@ SECTIONS
   _memmap_cacheattr_wbna_trapnull = 0xFF42FFF2;
   PROVIDE(_memmap_cacheattr_reset = _memmap_cacheattr_wbna_trapnull);
 
-  __stack = SOF_STACK_BASE;
+  __stack = BOOT_LDR_STACK_BASE + BOOT_LDR_STACK_SIZE;
   __wnd0 = HP_SRAM_WIN0_BASE;
   __wnd0_size = HP_SRAM_WIN0_SIZE;
 

--- a/src/platform/apollolake/include/platform/memory.h
+++ b/src/platform/apollolake/include/platform/memory.h
@@ -152,17 +152,12 @@
 	(HEAP_SYS_RUNTIME_M_SIZE + ((PLATFORM_CORE_COUNT - 1) * \
 	HEAP_SYS_RUNTIME_S_SIZE))
 
-#define HEAP_RUNTIME_BASE \
-	(HEAP_SYS_RUNTIME_0_BASE + HEAP_SYS_RUNTIME_M_SIZE + \
-	((PLATFORM_CORE_COUNT - 1) * HEAP_SYS_RUNTIME_S_SIZE))
-
 #define HEAP_RUNTIME_SIZE \
 	(HEAP_RT_COUNT64 * 64 + HEAP_RT_COUNT128 * 128 + \
 	HEAP_RT_COUNT256 * 256 + HEAP_RT_COUNT512 * 512 + \
 	HEAP_RT_COUNT1024 * 1024)
 
-#define HEAP_BUFFER_BASE	(HEAP_RUNTIME_BASE + HEAP_RUNTIME_SIZE)
-#define HEAP_BUFFER_SIZE	(SOF_STACK_END - HEAP_BUFFER_BASE)
+#define HEAP_BUFFER_SIZE	0x2000
 #define HEAP_BUFFER_BLOCK_SIZE	0x180
 #define HEAP_BUFFER_COUNT	(HEAP_BUFFER_SIZE / HEAP_BUFFER_BLOCK_SIZE)
 
@@ -172,24 +167,44 @@
 /*
  * The HP SRAM Region Apollolake is organised like this :-
  * +--------------------------------------------------------------------------+
- * | Offset              | Region         |  Size                             |
- * +---------------------+----------------+-----------------------------------+
- * | HP_SRAM_BASE        | DMA            |  HEAP_HP_BUFFER_SIZE              |
- * +---------------------+----------------+-----------------------------------+
- * | SRAM_TRACE_BASE     | Trace Buffer W3|  SRAM_TRACE_SIZE                  |
- * +---------------------+----------------+-----------------------------------+
- * | SRAM_DEBUG_BASE     | Debug data  W2 |  SRAM_DEBUG_SIZE                  |
- * +---------------------+----------------+-----------------------------------+
- * | SRAM_EXCEPT_BASE    | Debug data  W2 |  SRAM_EXCEPT_SIZE                 |
- * +---------------------+----------------+-----------------------------------+
- * | SRAM_STREAM_BASE    | Stream data W2 |  SRAM_STREAM_SIZE                 |
- * +---------------------+----------------+-----------------------------------+
- * | SRAM_INBOX_BASE     | Inbox  W1      |  SRAM_INBOX_SIZE                  |
- * +---------------------+----------------+-----------------------------------+
- * | SRAM_SW_REG_BASE    | SW Registers W0|  SRAM_SW_REG_SIZE                 |
- * +---------------------+----------------+-----------------------------------+
- * | SRAM_OUTBOX_BASE    | Outbox W0      |  SRAM_MAILBOX_SIZE                |
- * +---------------------+----------------+-----------------------------------+
+ * | Offset           | Region                  |  Size                       |
+ * +------------------+-------------------------+-----------------------------+
+ * | HP_SRAM_BASE     | DMA                     |  HEAP_HP_BUFFER_SIZE        |
+ * +------------------+-------------------------+-----------------------------+
+ * | SRAM_SW_REG_BASE | SW Registers W0         |  SRAM_SW_REG_SIZE           |
+ * +------------------+-------------------------+-----------------------------+
+ * | SRAM_OUTBOX_BASE | Outbox W0               |  SRAM_MAILBOX_SIZE          |
+ * +------------------+-------------------------+-----------------------------+
+ * | SRAM_INBOX_BASE  | Inbox  W1               |  SRAM_INBOX_SIZE            |
+ * +------------------+-------------------------+-----------------------------+
+ * | SRAM_DEBUG_BASE  | Debug data  W2          |  SRAM_DEBUG_SIZE            |
+ * +------------------+-------------------------+-----------------------------+
+ * | SRAM_EXCEPT_BASE | Debug data  W2          |  SRAM_EXCEPT_SIZE           |
+ * +------------------+-------------------------+-----------------------------+
+ * | SRAM_STREAM_BASE | Stream data W2          |  SRAM_STREAM_SIZE           |
+ * +------------------+-------------------------+-----------------------------+
+ * | SRAM_TRACE_BASE  | Trace Buffer W3         |  SRAM_TRACE_SIZE            |
+ * +------------------+-------------------------+-----------------------------+
+ * | SOF_FW_START     | text                    |                             |
+ * |                  | data                    |                             |
+ * |                  | ----------------------- |                             |
+ * |                  ||BSS:                   ||                             |
+ * |                  ||-----------------------++-----------------------------+
+ * |                  ||Runtime Heap           ||  HEAP_RUNTIME_SIZE          |
+ * |                  ||-----------------------++-----------------------------+
+ * |                  ||Module Buffers         ||  HEAP_BUFFER_SIZE           |
+ * |                  ||-----------------------++-----------------------------+
+ * |                  ||Master core Sys Heap   ||  HEAP_SYSTEM_M_SIZE         |
+ * |                  ||-----------------------++-----------------------------+
+ * |                  ||Master Sys Runtime Heap||  HEAP_SYS_RUNTIME_M_SIZE    |
+ * |                  ||-----------------------++-----------------------------+
+ * |                  ||Master core Stack      ||  SOF_STACK_SIZE             |
+ * |                  ||-----------------------++-----------------------------+
+ * |                  ||Slave core Sys Heap    ||  SOF_CORE_S_T_SIZE          |
+ * |                  ||Slave Sys Runtime Heap ||                             |
+ * |                  ||Slave core Stack       ||                             |
+ * |                  | ----------------------- |                             |
+ * +------------------+-------------------------+-----------------------------+
  */
 
 /* HP SRAM */
@@ -268,9 +283,6 @@
 #define SOF_FW_START		(HP_SRAM_VECBASE_RESET + 0x400)
 #define SOF_FW_BASE		(SOF_FW_START)
 
-/* max size for all var-size sections (text/rodata/bss) */
-#define SOF_FW_MAX_SIZE		(0x41000 - 0x400)
-
 /* Skylake or kabylake HP-SRAM config */
 #elif defined(CONFIG_KABYLAKE) || defined(CONFIG_SKYLAKE)
 
@@ -286,12 +298,12 @@
 #define SOF_FW_START		HP_SRAM_VECBASE_RESET
 #define SOF_FW_BASE		(SOF_FW_START + 0x1000)
 
-/* max size for all var-size sections (text/rodata/bss) */
-#define SOF_FW_MAX_SIZE		0x40000
-
 #else
 #error Platform not specified
 #endif
+
+/* max size for all var-size sections (text/rodata/bss) */
+#define SOF_FW_MAX_SIZE		(HP_SRAM_BASE + HP_SRAM_SIZE - SOF_FW_BASE)
 
 #define SOF_TEXT_START		(SOF_FW_START)
 #define SOF_TEXT_BASE		(SOF_FW_START)
@@ -299,10 +311,12 @@
 /* Stack configuration */
 #define SOF_STACK_SIZE		ARCH_STACK_SIZE
 #define SOF_STACK_TOTAL_SIZE	ARCH_STACK_TOTAL_SIZE
-#define SOF_STACK_BASE		(HP_SRAM_BASE + HP_SRAM_SIZE)
-#define SOF_STACK_END		(SOF_STACK_BASE - SOF_STACK_TOTAL_SIZE)
 
-#define SOF_MEMORY_SIZE		(SOF_STACK_BASE - HP_SRAM_BASE)
+/* SOF Core S configuration */
+#define SOF_CORE_S_SIZE \
+	ALIGN((HEAP_SYSTEM_S_SIZE + HEAP_SYS_RUNTIME_S_SIZE + SOF_STACK_SIZE),\
+		SRAM_BANK_SIZE)
+#define SOF_CORE_S_T_SIZE ((PLATFORM_CORE_COUNT - 1) * SOF_CORE_S_SIZE)
 
 /*
  * The LP SRAM Heap and Stack on Apollolake are organised like this :-
@@ -413,6 +427,10 @@
 #define IMR_BOOT_LDR_DATA_SIZE		0x1000
 #define IMR_BOOT_LDR_BSS_BASE		0xB0100000
 #define IMR_BOOT_LDR_BSS_SIZE		0x10000
+
+/* Temporary stack place for boot_ldr */
+#define BOOT_LDR_STACK_BASE		HEAP_HP_BUFFER_BASE
+#define BOOT_LDR_STACK_SIZE		SOF_STACK_TOTAL_SIZE
 
 /** \brief Manifest base address in IMR - used by boot loader copy procedure. */
 #define IMR_BOOT_LDR_MANIFEST_BASE	0xB0004000

--- a/src/platform/apollolake/rom.x.in
+++ b/src/platform/apollolake/rom.x.in
@@ -82,8 +82,8 @@ MEMORY
 	org = ROM_BASE + 0x800,
         len = ROM_SIZE,
   sof_stack :
-        org = SOF_STACK_END,
-        len = SOF_STACK_BASE - SOF_STACK_END
+        org = BOOT_LDR_STACK_BASE,
+        len = BOOT_LDR_STACK_SIZE
 }
 
 PHDRS
@@ -288,10 +288,10 @@ SECTIONS
   } >sof_text :sof_text_phdr
 
   /* stack */
-  _end = SOF_STACK_END;
-  PROVIDE(end = SOF_STACK_END);
-  _stack_sentry = SOF_STACK_END;
-  __stack = SOF_STACK_BASE;
+  _end = BOOT_LDR_STACK_BASE;
+  PROVIDE(end = BOOT_LDR_STACK_BASE);
+  _stack_sentry = BOOT_LDR_STACK_BASE;
+  __stack = BOOT_LDR_STACK_BASE + BOOT_LDR_STACK_SIZE;
 
   .debug  0 :  { *(.debug) }
   .line  0 :  { *(.line) }

--- a/src/platform/baytrail/baytrail.x.in
+++ b/src/platform/baytrail/baytrail.x.in
@@ -515,9 +515,9 @@ SECTIONS
   .buffer_heap (NOLOAD) : ALIGN(8)
   {
     . = ALIGN (32);
-    _system_heap_start = ABSOLUTE(.);
+    _buffer_heap_start = ABSOLUTE(.);
     . = . + HEAP_BUFFER_SIZE;
-    _system_heap_end = ABSOLUTE(.);
+    _buffer_heap_end = ABSOLUTE(.);
   } >buffer_heap :buffer_heap_phdr
 
   .sof_stack (NOLOAD) : ALIGN(8)

--- a/src/platform/cannonlake/boot_ldr.x.in
+++ b/src/platform/cannonlake/boot_ldr.x.in
@@ -28,11 +28,11 @@ MEMORY
         org = IMR_BOOT_LDR_DATA_BASE,
         len = IMR_BOOT_LDR_DATA_SIZE
   sof_bss_data :
-	org = IMR_BOOT_LDR_BSS_BASE,
+        org = IMR_BOOT_LDR_BSS_BASE,
         len = IMR_BOOT_LDR_BSS_SIZE
   sof_stack :
-        org = SOF_STACK_END,
-        len = SOF_STACK_BASE - SOF_STACK_END
+        org = BOOT_LDR_STACK_BASE,
+        len = BOOT_LDR_STACK_SIZE
   wnd0 :
         org = HP_SRAM_WIN0_BASE,
         len = HP_SRAM_WIN0_SIZE
@@ -180,7 +180,7 @@ SECTIONS
   _memmap_cacheattr_wbna_trapnull = 0xFF42FFF2;
   PROVIDE(_memmap_cacheattr_reset = _memmap_cacheattr_wbna_trapnull);
 
-  __stack = SOF_STACK_BASE;
+  __stack = BOOT_LDR_STACK_BASE + BOOT_LDR_STACK_SIZE;
   __wnd0 = HP_SRAM_WIN0_BASE;
   __wnd0_size = HP_SRAM_WIN0_SIZE;
 

--- a/src/platform/cannonlake/cannonlake.x.in
+++ b/src/platform/cannonlake/cannonlake.x.in
@@ -81,21 +81,6 @@ MEMORY
   sof_fw :
         org = SOF_FW_BASE,
         len = SOF_FW_MAX_SIZE
-  system_heap :
-        org = HEAP_SYSTEM_0_BASE,
-        len = HEAP_SYSTEM_T_SIZE
-  system_runtime_heap :
-        org = HEAP_SYS_RUNTIME_0_BASE,
-        len = HEAP_SYS_RUNTIME_T_SIZE
-  runtime_heap :
-        org = HEAP_RUNTIME_BASE,
-        len = HEAP_RUNTIME_SIZE
-  buffer_heap :
-        org = HEAP_BUFFER_BASE,
-        len = HEAP_BUFFER_SIZE
-  sof_stack :
-        org = SOF_STACK_END,
-        len = SOF_STACK_BASE - SOF_STACK_END
   buffer_hp_heap :
         org = HEAP_HP_BUFFER_BASE,
         len = HEAP_HP_BUFFER_SIZE
@@ -140,11 +125,6 @@ PHDRS
   vector_double_lit_phdr PT_LOAD;
   vector_double_text_phdr PT_LOAD;
   sof_fw_phdr PT_LOAD;
-  system_heap_phdr PT_LOAD;
-  system_runtime_heap_phdr PT_LOAD;
-  runtime_heap_phdr PT_LOAD;
-  buffer_heap_phdr PT_LOAD;
-  sof_stack_phdr PT_LOAD;
   buffer_hp_heap_phdr PT_LOAD;
   wnd0_phdr PT_LOAD;
   wnd1_phdr PT_LOAD;
@@ -457,28 +437,61 @@ SECTIONS
     *(.bss.*)
     *(.gnu.linkonce.b.*)
     *(COMMON)
-    . = ALIGN (8);
+
+    . = ALIGN (SRAM_BANK_SIZE);
+    _runtime_heap_start = ABSOLUTE(.);
+    . = . + HEAP_RUNTIME_SIZE;
+    _runtime_heap_end = ABSOLUTE(.);
+
+    . = ALIGN (32);
+    _buffer_heap_start = ABSOLUTE(.);
+    . = . + HEAP_BUFFER_SIZE;
+    _buffer_heap_end = ABSOLUTE(.);
+
+    . = ALIGN (SRAM_BANK_SIZE);
+    _system_heap_start = ABSOLUTE(.);
+    . = . + HEAP_SYSTEM_M_SIZE;
+    _system_heap_end = ABSOLUTE(.);
+
+    . = ALIGN (32);
+    _system_runtime_heap_start = ABSOLUTE(.);
+    . = . + HEAP_SYS_RUNTIME_M_SIZE;
+    _system_runtime_heap_end = ABSOLUTE(.);
+
+    . = ALIGN (4096);
+    _sof_stack_start = ABSOLUTE(.);
+    . = . + SOF_STACK_SIZE;
+    _sof_stack_end = ABSOLUTE(.);
+
+    . = ALIGN (SRAM_BANK_SIZE);
+    _sof_core_s_start = ABSOLUTE(.);
+    . = . + SOF_CORE_S_T_SIZE;
+    _sof_core_s_end = ABSOLUTE(.);
+
     _bss_end = ABSOLUTE(.);
   } >sof_fw :sof_fw_phdr
 
   /* stack */
-  _end = SOF_STACK_END;
-  PROVIDE(end = SOF_STACK_END);
-  _stack_sentry = SOF_STACK_END;
-  __stack = SOF_STACK_BASE;
+  _end = _sof_stack_start;
+  PROVIDE(end = _sof_stack_start);
+  _stack_sentry = _sof_stack_start;
+  __stack = _sof_stack_end;
+
+  /* Slave core size */
+  _core_s_size = SOF_CORE_S_SIZE;
 
   /* System Heap */
-  _system_heap = HEAP_SYSTEM_0_BASE;
+  _system_heap = _system_heap_start;
 
   /* system runtime heap */
-  _system_runtime_heap = HEAP_SYS_RUNTIME_0_BASE;
+  _system_runtime_heap = _system_runtime_heap_start;
 
   /* module heap */
-  _module_heap = HEAP_RUNTIME_BASE;
+  _module_heap = _runtime_heap_start;
 
   /* buffer heap */
-  _buffer_heap = HEAP_BUFFER_BASE;
-  _buffer_heap_end = _stack_sentry;
+  _buffer_heap = _buffer_heap_start;
+  _buffer_heap_end = _buffer_heap_end;
 
   .debug  0 :  { *(.debug) }
   .line  0 :  { *(.line) }
@@ -530,47 +543,6 @@ SECTIONS
     KEEP (*(.xt.profile_files))
     KEEP (*(.gnu.linkonce.xt.profile_files.*))
   }
-
-  .system_heap (NOLOAD) : ALIGN(8)
-  {
-    . = ALIGN (32);
-    _system_heap_start = ABSOLUTE(.);
-    . = . + HEAP_SYSTEM_T_SIZE;
-    _system_heap_end = ABSOLUTE(.);
-  } >system_heap :system_heap_phdr
-
-  .system_runtime_heap (NOLOAD) : ALIGN(8)
-  {
-    . = ALIGN (32);
-    _system_runtime_heap_start = ABSOLUTE(.);
-    . = . + HEAP_SYS_RUNTIME_T_SIZE;
-    _system_runtime_heap_end = ABSOLUTE(.);
-  } >system_runtime_heap :system_runtime_heap_phdr
-
-  .runtime_heap (NOLOAD) : ALIGN(8)
-  {
-    . = ALIGN (32);
-    _runtime_heap_start = ABSOLUTE(.);
-    . = . + HEAP_RUNTIME_SIZE;
-    _runtime_heap_end = ABSOLUTE(.);
-  } >runtime_heap :runtime_heap_phdr
-
-
-  .buffer_heap (NOLOAD) : ALIGN(8)
-  {
-    . = ALIGN (32);
-    _buffer_heap_start = ABSOLUTE(.);
-    . = . + HEAP_BUFFER_SIZE;
-    _buffer_heap_end = ABSOLUTE(.);
-  } >buffer_heap :buffer_heap_phdr
-
-  .sof_stack (NOLOAD) : ALIGN(8)
-  {
-    . = ALIGN (4096);
-    _sof_stack_start = ABSOLUTE(.);
-    . = . + SOF_STACK_TOTAL_SIZE;
-    _sof_stack_end = ABSOLUTE(.);
-  } >sof_stack :sof_stack_phdr
 
   .static_log_entries (COPY) : ALIGN(1024)
   {

--- a/src/platform/cannonlake/rom.x.in
+++ b/src/platform/cannonlake/rom.x.in
@@ -82,8 +82,8 @@ MEMORY
 	org = ROM_BASE + 0x800,
         len = ROM_SIZE,
   sof_stack :
-        org = SOF_STACK_END,
-        len = SOF_STACK_BASE - SOF_STACK_END
+        org = BOOT_LDR_STACK_BASE,
+        len = BOOT_LDR_STACK_SIZE
 }
 
 PHDRS
@@ -288,10 +288,10 @@ SECTIONS
   } >sof_text :sof_text_phdr
 
   /* stack */
-  _end = SOF_STACK_END;
-  PROVIDE(end = SOF_STACK_END);
-  _stack_sentry = SOF_STACK_END;
-  __stack = SOF_STACK_BASE;
+  _end = BOOT_LDR_STACK_BASE;
+  PROVIDE(end = BOOT_LDR_STACK_BASE);
+  _stack_sentry = BOOT_LDR_STACK_BASE;
+  __stack = BOOT_LDR_STACK_BASE + BOOT_LDR_STACK_SIZE;
 
   .debug  0 :  { *(.debug) }
   .line  0 :  { *(.line) }

--- a/src/platform/haswell/haswell.x.in
+++ b/src/platform/haswell/haswell.x.in
@@ -514,9 +514,9 @@ SECTIONS
   .buffer_heap (NOLOAD) : ALIGN(8)
   {
     . = ALIGN (32);
-    _system_heap_start = ABSOLUTE(.);
+    _buffer_heap_start = ABSOLUTE(.);
     . = . + HEAP_BUFFER_SIZE;
-    _system_heap_end = ABSOLUTE(.);
+    _buffer_heap_end = ABSOLUTE(.);
   } >buffer_heap :buffer_heap_phdr
 
   .sof_stack (NOLOAD) : ALIGN(8)

--- a/src/platform/icelake/boot_ldr.x.in
+++ b/src/platform/icelake/boot_ldr.x.in
@@ -28,11 +28,11 @@ MEMORY
         org = IMR_BOOT_LDR_DATA_BASE,
         len = IMR_BOOT_LDR_DATA_SIZE
   sof_bss_data :
-	org = IMR_BOOT_LDR_BSS_BASE,
+        org = IMR_BOOT_LDR_BSS_BASE,
         len = IMR_BOOT_LDR_BSS_SIZE
   sof_stack :
-        org = SOF_STACK_END,
-        len = SOF_STACK_BASE - SOF_STACK_END
+        org = BOOT_LDR_STACK_BASE,
+        len = BOOT_LDR_STACK_SIZE
   wnd0 :
         org = HP_SRAM_WIN0_BASE,
         len = HP_SRAM_WIN0_SIZE
@@ -184,7 +184,7 @@ SECTIONS
   _memmap_cacheattr_wbna_trapnull = 0xFF42FFF2;
   PROVIDE(_memmap_cacheattr_reset = _memmap_cacheattr_wbna_trapnull);
 
-  __stack = SOF_STACK_BASE;
+  __stack = BOOT_LDR_STACK_BASE + BOOT_LDR_STACK_SIZE;
   __wnd0 = HP_SRAM_WIN0_BASE;
   __wnd0_size = HP_SRAM_WIN0_SIZE;
 

--- a/src/platform/icelake/icelake.x.in
+++ b/src/platform/icelake/icelake.x.in
@@ -81,21 +81,6 @@ MEMORY
   sof_fw :
         org = SOF_FW_BASE,
         len = SOF_FW_MAX_SIZE
-  system_heap :
-        org = HEAP_SYSTEM_0_BASE,
-        len = HEAP_SYSTEM_T_SIZE
-  system_runtime_heap :
-        org = HEAP_SYS_RUNTIME_0_BASE,
-        len = HEAP_SYS_RUNTIME_T_SIZE
-  runtime_heap :
-        org = HEAP_RUNTIME_BASE,
-        len = HEAP_RUNTIME_SIZE
-  buffer_heap :
-        org = HEAP_BUFFER_BASE,
-        len = HEAP_BUFFER_SIZE
-  sof_stack :
-        org = SOF_STACK_END,
-        len = SOF_STACK_BASE - SOF_STACK_END
   buffer_hp_heap :
         org = HEAP_HP_BUFFER_BASE,
         len = HEAP_HP_BUFFER_SIZE
@@ -143,11 +128,6 @@ PHDRS
   vector_double_lit_phdr PT_LOAD;
   vector_double_text_phdr PT_LOAD;
   sof_fw_phdr PT_LOAD;
-  system_heap_phdr PT_LOAD;
-  system_runtime_heap_phdr PT_LOAD;
-  runtime_heap_phdr PT_LOAD;
-  buffer_heap_phdr PT_LOAD;
-  sof_stack_phdr PT_LOAD;
   buffer_hp_heap_phdr PT_LOAD;
   wnd0_phdr PT_LOAD;
   wnd1_phdr PT_LOAD;
@@ -461,28 +441,61 @@ SECTIONS
     *(.bss.*)
     *(.gnu.linkonce.b.*)
     *(COMMON)
-    . = ALIGN (8);
+
+    . = ALIGN (SRAM_BANK_SIZE);
+    _runtime_heap_start = ABSOLUTE(.);
+    . = . + HEAP_RUNTIME_SIZE;
+    _runtime_heap_end = ABSOLUTE(.);
+
+    . = ALIGN (32);
+    _buffer_heap_start = ABSOLUTE(.);
+    . = . + HEAP_BUFFER_SIZE;
+    _buffer_heap_end = ABSOLUTE(.);
+
+    . = ALIGN (SRAM_BANK_SIZE);
+    _system_heap_start = ABSOLUTE(.);
+    . = . + HEAP_SYSTEM_M_SIZE;
+    _system_heap_end = ABSOLUTE(.);
+
+    . = ALIGN (32);
+    _system_runtime_heap_start = ABSOLUTE(.);
+    . = . + HEAP_SYS_RUNTIME_M_SIZE;
+    _system_runtime_heap_end = ABSOLUTE(.);
+
+    . = ALIGN (4096);
+    _sof_stack_start = ABSOLUTE(.);
+    . = . + SOF_STACK_SIZE;
+    _sof_stack_end = ABSOLUTE(.);
+
+    . = ALIGN (SRAM_BANK_SIZE);
+    _sof_core_s_start = ABSOLUTE(.);
+    . = . + SOF_CORE_S_T_SIZE;
+    _sof_core_s_end = ABSOLUTE(.);
+
     _bss_end = ABSOLUTE(.);
   } >sof_fw :sof_fw_phdr
 
   /* stack */
-  _end = SOF_STACK_END;
-  PROVIDE(end = SOF_STACK_END);
-  _stack_sentry = SOF_STACK_END;
-  __stack = SOF_STACK_BASE;
+  _end = _sof_stack_start;
+  PROVIDE(end = _sof_stack_start);
+  _stack_sentry = _sof_stack_start;
+  __stack = _sof_stack_end;
+
+  /* Slave core size */
+  _core_s_size = SOF_CORE_S_SIZE;
 
   /* System Heap */
-  _system_heap = HEAP_SYSTEM_0_BASE;
+  _system_heap = _system_heap_start;
 
   /* system runtime heap */
-  _system_runtime_heap = HEAP_SYS_RUNTIME_0_BASE;
+  _system_runtime_heap = _system_runtime_heap_start;
 
   /* module heap */
-  _module_heap = HEAP_RUNTIME_BASE;
+  _module_heap = _runtime_heap_start;
 
   /* buffer heap */
-  _buffer_heap = HEAP_BUFFER_BASE;
-  _buffer_heap_end = _stack_sentry;
+  _buffer_heap = _buffer_heap_start;
+  _buffer_heap_end = _buffer_heap_end;
 
   .debug  0 :  { *(.debug) }
   .line  0 :  { *(.line) }
@@ -534,46 +547,6 @@ SECTIONS
     KEEP (*(.xt.profile_files))
     KEEP (*(.gnu.linkonce.xt.profile_files.*))
   }
-
-  .system_heap (NOLOAD) : ALIGN(8)
-  {
-    . = ALIGN (32);
-    _system_heap_start = ABSOLUTE(.);
-    . = . + HEAP_SYSTEM_T_SIZE;
-    _system_heap_end = ABSOLUTE(.);
-  } >system_heap :system_heap_phdr
-
-  .system_runtime_heap (NOLOAD) : ALIGN(8)
-  {
-    . = ALIGN (32);
-    _system_runtime_heap_start = ABSOLUTE(.);
-    . = . + HEAP_SYS_RUNTIME_T_SIZE;
-    _system_runtime_heap_end = ABSOLUTE(.);
-  } >system_runtime_heap :system_runtime_heap_phdr
-
-  .runtime_heap (NOLOAD) : ALIGN(8)
-  {
-    . = ALIGN (32);
-    _runtime_heap_start = ABSOLUTE(.);
-    . = . + HEAP_RUNTIME_SIZE;
-    _runtime_heap_end = ABSOLUTE(.);
-  } >runtime_heap :runtime_heap_phdr
-
-  .buffer_heap (NOLOAD) : ALIGN(8)
-  {
-    . = ALIGN (32);
-    _buffer_heap_start = ABSOLUTE(.);
-    . = . + HEAP_BUFFER_SIZE;
-    _buffer_heap_end = ABSOLUTE(.);
-  } >buffer_heap :buffer_heap_phdr
-
-  .sof_stack (NOLOAD) : ALIGN(8)
-  {
-    . = ALIGN (4096);
-    _sof_stack_start = ABSOLUTE(.);
-    . = . + SOF_STACK_TOTAL_SIZE;
-    _sof_stack_end = ABSOLUTE(.);
-  } >sof_stack :sof_stack_phdr
 
   .static_log_entries (COPY) : ALIGN(1024)
   {

--- a/src/platform/icelake/include/platform/memory.h
+++ b/src/platform/icelake/include/platform/memory.h
@@ -120,34 +120,42 @@
 /*
  * The HP SRAM Region on Icelake is organised like this :-
  * +--------------------------------------------------------------------------+
- * | Offset              | Region         |  Size                             |
- * +---------------------+----------------+-----------------------------------+
- * | SRAM_SW_REG_BASE    | SW Registers W0|  SRAM_SW_REG_SIZE                 |
- * +---------------------+----------------+-----------------------------------+
- * | SRAM_OUTBOX_BASE    | Outbox W0      |  SRAM_MAILBOX_SIZE                |
- * +---------------------+----------------+-----------------------------------+
- * | SRAM_INBOX_BASE     | Inbox  W1      |  SRAM_INBOX_SIZE                  |
- * +---------------------+----------------+-----------------------------------+
- * | SRAM_DEBUG_BASE     | Debug data  W2 |  SRAM_DEBUG_SIZE                  |
- * +---------------------+----------------+-----------------------------------+
- * | SRAM_EXCEPT_BASE    | Debug data  W2 |  SRAM_EXCEPT_SIZE                 |
- * +---------------------+----------------+-----------------------------------+
- * | SRAM_STREAM_BASE    | Stream data W2 |  SRAM_STREAM_SIZE                 |
- * +---------------------+----------------+-----------------------------------+
- * | SRAM_TRACE_BASE     | Trace Buffer W3|  SRAM_TRACE_SIZE                  |
- * +---------------------+----------------+-----------------------------------+
- * | HP_SRAM_BASE        | DMA            |  HEAP_HP_BUFFER_SIZE              |
- * +---------------------+----------------+-----------------------------------+
- * | HEAP_SYSTEM_BASE    | System Heap    |  HEAP_SYSTEM_SIZE                 |
- * +---------------------+----------------+-----------------------------------+
- * | HEAP_RUNTIME_BASE   | Runtime Heap   |  HEAP_RUNTIME_SIZE                |
- * +---------------------+----------------+-----------------------------------+
- * | HEAP_BUFFER_BASE    | Module Buffers |  HEAP_BUFFER_SIZE                 |
- * +---------------------+----------------+-----------------------------------+
- * | SOF_STACK_END      | Stack          |  SOF_STACK_SIZE                  |
- * +---------------------+----------------+-----------------------------------+
- * | SOF_STACK_BASE     |                |                                   |
- * +---------------------+----------------+-----------------------------------+
+ * | Offset           | Region                  |  Size                       |
+ * +------------------+-------------------------+-----------------------------+
+ * | SRAM_SW_REG_BASE | SW Registers W0         |  SRAM_SW_REG_SIZE           |
+ * +------------------+-------------------------+-----------------------------+
+ * | SRAM_OUTBOX_BASE | Outbox W0               |  SRAM_MAILBOX_SIZE          |
+ * +------------------+-------------------------+-----------------------------+
+ * | SRAM_INBOX_BASE  | Inbox  W1               |  SRAM_INBOX_SIZE            |
+ * +------------------+-------------------------+-----------------------------+
+ * | SRAM_DEBUG_BASE  | Debug data  W2          |  SRAM_DEBUG_SIZE            |
+ * +------------------+-------------------------+-----------------------------+
+ * | SRAM_EXCEPT_BASE | Debug data  W2          |  SRAM_EXCEPT_SIZE           |
+ * +------------------+-------------------------+-----------------------------+
+ * | SRAM_STREAM_BASE | Stream data W2          |  SRAM_STREAM_SIZE           |
+ * +------------------+-------------------------+-----------------------------+
+ * | SRAM_TRACE_BASE  | Trace Buffer W3         |  SRAM_TRACE_SIZE            |
+ * +------------------+-------------------------+-----------------------------+
+ * | HP_SRAM_BASE     | DMA                     |  HEAP_HP_BUFFER_SIZE        |
+ * +------------------+-------------------------+-----------------------------+
+ * | SOF_FW_START     | text                    |                             |
+ * |                  | data                    |                             |
+ * |                  | BSS                     |                             |
+ * +------------------+-------------------------+-----------------------------+
+ * |                  | Runtime Heap            |  HEAP_RUNTIME_SIZE          |
+ * +------------------+-------------------------+-----------------------------+
+ * |                  | Module Buffers          |  HEAP_BUFFER_SIZE           |
+ * +------------------+-------------------------+-----------------------------+
+ * |                  | Master core Sys Heap    |  HEAP_SYSTEM_M_SIZE         |
+ * +------------------+-------------------------+-----------------------------+
+ * |                  | Master Sys Runtime Heap |  HEAP_SYS_RUNTIME_M_SIZE    |
+ * +------------------+-------------------------+-----------------------------+
+ * |                  | Master core Stack       |  SOF_STACK_SIZE             |
+ * +------------------+-------------------------+-----------------------------+
+ * |                  | Slave core Sys Heap     |  SOF_CORE_S_T_SIZE          |
+ * |                  | Slave Sys Runtime Heap  |                             |
+ * |                  | Slave core Stack        |                             |
+ * +------------------+-------------------------+-----------------------------+
  */
 
 /* HP SRAM */
@@ -156,7 +164,7 @@
 #define HP_SRAM_MASK		0xFF000000
 
 /* HP SRAM Base */
-#define HP_SRAM_VECBASE_RESET	(HP_SRAM_BASE + 0x40000)
+#define HP_SRAM_VECBASE_RESET	(HEAP_HP_BUFFER_BASE + HEAP_HP_BUFFER_SIZE)
 
 /* Heap section sizes for system runtime heap for master core */
 #define HEAP_SYS_RT_0_COUNT64		64
@@ -231,11 +239,11 @@
 			(HEAP_HP_BUFFER_SIZE / HEAP_HP_BUFFER_BLOCK_SIZE)
 
 /* text and data share the same HP L2 SRAM on Icelake */
-#define SOF_FW_START		0xBE040400
+#define SOF_FW_START		(HP_SRAM_VECBASE_RESET + 0x400)
 #define SOF_FW_BASE		(SOF_FW_START)
 
 /* max size for all var-size sections (text/rodata/bss) */
-#define SOF_FW_MAX_SIZE		(0x4A900 - 0x400)
+#define SOF_FW_MAX_SIZE		(HP_SRAM_BASE + HP_SRAM_SIZE - SOF_FW_BASE)
 
 #define SOF_TEXT_START		(SOF_FW_START)
 #define SOF_TEXT_BASE		(SOF_FW_START)
@@ -247,10 +255,6 @@
 #define HEAP_SYSTEM_S_SIZE		0x5000	/* heap slave core size */
 #define HEAP_SYSTEM_T_SIZE \
 	(HEAP_SYSTEM_M_SIZE + ((PLATFORM_CORE_COUNT - 1) * HEAP_SYSTEM_S_SIZE))
-
-#define HEAP_SYS_RUNTIME_0_BASE \
-	(HEAP_SYSTEM_0_BASE + HEAP_SYSTEM_M_SIZE + \
-	((PLATFORM_CORE_COUNT - 1) * HEAP_SYSTEM_S_SIZE))
 
 #define HEAP_SYS_RUNTIME_M_SIZE \
 	(HEAP_SYS_RT_0_COUNT64 * 64 + HEAP_SYS_RT_0_COUNT512 * 512 + \
@@ -264,10 +268,6 @@
 	(HEAP_SYS_RUNTIME_M_SIZE + ((PLATFORM_CORE_COUNT - 1) * \
 	HEAP_SYS_RUNTIME_S_SIZE))
 
-#define HEAP_RUNTIME_BASE \
-	(HEAP_SYS_RUNTIME_0_BASE + HEAP_SYS_RUNTIME_M_SIZE + \
-	((PLATFORM_CORE_COUNT - 1) * HEAP_SYS_RUNTIME_S_SIZE))
-
 #define HEAP_RUNTIME_SIZE \
 	(HEAP_RT_COUNT64 * 64 + HEAP_RT_COUNT128 * 128 + \
 	HEAP_RT_COUNT256 * 256 + HEAP_RT_COUNT512 * 512 + \
@@ -276,16 +276,16 @@
 /* Stack configuration */
 #define SOF_STACK_SIZE		ARCH_STACK_SIZE
 #define SOF_STACK_TOTAL_SIZE	ARCH_STACK_TOTAL_SIZE
-#define SOF_STACK_BASE		(HP_SRAM_BASE + HP_SRAM_SIZE)
-#define SOF_STACK_END		(SOF_STACK_BASE - SOF_STACK_TOTAL_SIZE)
 
-#define HEAP_BUFFER_BASE	(HEAP_RUNTIME_BASE + HEAP_RUNTIME_SIZE)
-#define HEAP_BUFFER_SIZE	\
-	(SOF_STACK_END - HEAP_BUFFER_BASE)
+/* SOF Core S configuration */
+#define SOF_CORE_S_SIZE \
+	ALIGN((HEAP_SYSTEM_S_SIZE + HEAP_SYS_RUNTIME_S_SIZE + SOF_STACK_SIZE),\
+	SRAM_BANK_SIZE)
+#define SOF_CORE_S_T_SIZE ((PLATFORM_CORE_COUNT - 1) * SOF_CORE_S_SIZE)
+
+#define HEAP_BUFFER_SIZE	0xF000
 #define HEAP_BUFFER_BLOCK_SIZE		0x180
 #define HEAP_BUFFER_COUNT	(HEAP_BUFFER_SIZE / HEAP_BUFFER_BLOCK_SIZE)
-
-#define SOF_MEMORY_SIZE		(SOF_STACK_BASE - HP_SRAM_BASE)
 
 /*
  * The LP SRAM Heap and Stack on Icelake are organised like this :-
@@ -393,6 +393,10 @@
 #define IMR_BOOT_LDR_DATA_SIZE		0x1000
 #define IMR_BOOT_LDR_BSS_BASE		0xB0100000
 #define IMR_BOOT_LDR_BSS_SIZE		0x10000
+
+/* Temporary stack place for boot_ldr */
+#define BOOT_LDR_STACK_BASE		HEAP_HP_BUFFER_BASE
+#define BOOT_LDR_STACK_SIZE		SOF_STACK_TOTAL_SIZE
 
 #define uncache_to_cache(address) \
 	((__typeof__((address)))((uint32_t)((address)) + SRAM_ALIAS_OFFSET))

--- a/src/platform/icelake/rom.x.in
+++ b/src/platform/icelake/rom.x.in
@@ -82,8 +82,8 @@ MEMORY
 	org = ROM_BASE + 0x800,
         len = ROM_SIZE,
   sof_stack :
-        org = SOF_STACK_END,
-        len = SOF_STACK_BASE - SOF_STACK_END
+        org = BOOT_LDR_STACK_BASE,
+        len = BOOT_LDR_STACK_SIZE
 }
 
 PHDRS
@@ -288,10 +288,10 @@ SECTIONS
   } >sof_text :sof_text_phdr
 
   /* stack */
-  _end = SOF_STACK_END;
-  PROVIDE(end = SOF_STACK_END);
-  _stack_sentry = SOF_STACK_END;
-  __stack = SOF_STACK_BASE;
+  _end = BOOT_LDR_STACK_BASE;
+  PROVIDE(end = BOOT_LDR_STACK_BASE);
+  _stack_sentry = BOOT_LDR_STACK_BASE;
+  __stack = BOOT_LDR_STACK_BASE + BOOT_LDR_STACK_SIZE;
 
   .debug  0 :  { *(.debug) }
   .line  0 :  { *(.line) }

--- a/src/platform/imx8/imx8.x.in
+++ b/src/platform/imx8/imx8.x.in
@@ -478,9 +478,9 @@ SECTIONS
   .buffer_heap (NOLOAD) : ALIGN(8)
   {
     . = ALIGN (32);
-    _system_heap_start = ABSOLUTE(.);
+    _buffer_heap_start = ABSOLUTE(.);
     . = . + HEAP_BUFFER_SIZE;
-    _system_heap_end = ABSOLUTE(.);
+    _buffer_heap_end = ABSOLUTE(.);
   } >buffer_heap :buffer_heap_phdr
 
   .sof_stack (NOLOAD) : ALIGN(8)

--- a/src/platform/suecreek/boot_ldr.x.in
+++ b/src/platform/suecreek/boot_ldr.x.in
@@ -28,11 +28,11 @@ MEMORY
         org = BOOT_LDR_DATA_BASE,
         len = BOOT_LDR_DATA_SIZE
   sof_bss_data :
-	org = BOOT_LDR_BSS_BASE,
+        org = BOOT_LDR_BSS_BASE,
         len = BOOT_LDR_BSS_SIZE
   sof_stack :
-        org = SOF_STACK_END,
-        len = SOF_STACK_BASE - SOF_STACK_END
+        org = BOOT_LDR_STACK_BASE,
+        len = BOOT_LDR_STACK_SIZE
 }
 
 PHDRS
@@ -176,7 +176,7 @@ SECTIONS
   _memmap_cacheattr_wbna_trapnull = 0xFF42FFF2;
   PROVIDE(_memmap_cacheattr_reset = _memmap_cacheattr_wbna_trapnull);
 
-  __stack = SOF_STACK_BASE;
+  __stack = BOOT_LDR_STACK_BASE + BOOT_LDR_STACK_SIZE;
 
   .debug  0 :  { *(.debug) }
   .line  0 :  { *(.line) }

--- a/src/platform/suecreek/rom.x.in
+++ b/src/platform/suecreek/rom.x.in
@@ -82,8 +82,8 @@ MEMORY
 	org = ROM_BASE + 0x800,
         len = ROM_SIZE,
   sof_stack :
-        org = SOF_STACK_END,
-        len = SOF_STACK_BASE - SOF_STACK_END
+        org = BOOT_LDR_STACK_BASE,
+        len = BOOT_LDR_STACK_SIZE
 }
 
 PHDRS
@@ -288,10 +288,10 @@ SECTIONS
   } >sof_text :sof_text_phdr
 
   /* stack */
-  _end = SOF_STACK_END;
-  PROVIDE(end = SOF_STACK_END);
-  _stack_sentry = SOF_STACK_END;
-  __stack = SOF_STACK_BASE;
+  _end = BOOT_LDR_STACK_BASE;
+  PROVIDE(end = BOOT_LDR_STACK_BASE);
+  _stack_sentry = BOOT_LDR_STACK_BASE;
+  __stack = BOOT_LDR_STACK_BASE + BOOT_LDR_STACK_SIZE;
 
   .debug  0 :  { *(.debug) }
   .line  0 :  { *(.line) }

--- a/src/platform/suecreek/suecreek.x.in
+++ b/src/platform/suecreek/suecreek.x.in
@@ -84,33 +84,9 @@ MEMORY
   vector_double_text :
         org = SOF_MEM_VECBASE + XCHAL_DOUBLEEXC_VECOFS,
         len = SOF_MEM_VECT_TEXT_SIZE
-  sof_text_start :
-       	org = SOF_TEXT_START,
-        len = SOF_TEXT_START_SIZE,
-  sof_text :
-        org = SOF_TEXT_BASE,
-        len = SOF_TEXT_SIZE,
-  sof_data :
-        org = SOF_TEXT_BASE + SOF_TEXT_SIZE,
-        len = SOF_DATA_SIZE
-  sof_bss_data :
-        org = SOF_TEXT_BASE + SOF_TEXT_SIZE + SOF_DATA_SIZE,
-        len = SOF_BSS_DATA_SIZE
-  system_heap :
-        org = HEAP_SYSTEM_0_BASE,
-        len = HEAP_SYSTEM_T_SIZE
-  system_runtime_heap :
-        org = HEAP_SYS_RUNTIME_0_BASE,
-        len = HEAP_SYS_RUNTIME_T_SIZE
-  runtime_heap :
-        org = HEAP_RUNTIME_BASE,
-        len = HEAP_RUNTIME_SIZE
-  buffer_heap :
-        org = HEAP_BUFFER_BASE,
-        len = HEAP_BUFFER_SIZE
-  sof_stack :
-        org = SOF_STACK_END,
-        len = SOF_STACK_BASE - SOF_STACK_END
+  sof_fw :
+       	org = SOF_FW_BASE,
+        len = SOF_FW_MAX_SIZE,
   buffer_hp_heap :
         org = HEAP_HP_BUFFER_BASE,
         len = HEAP_HP_BUFFER_SIZE
@@ -144,15 +120,7 @@ PHDRS
   vector_user_text_phdr PT_LOAD;
   vector_double_lit_phdr PT_LOAD;
   vector_double_text_phdr PT_LOAD;
-  sof_text_start_phdr PT_LOAD;
-  sof_text_phdr PT_LOAD;
-  sof_data_phdr PT_LOAD;
-  sof_bss_data_phdr PT_LOAD;
-  system_heap_phdr PT_LOAD;
-  system_runtime_heap_phdr PT_LOAD;
-  runtime_heap_phdr PT_LOAD;
-  buffer_heap_phdr PT_LOAD;
-  sof_stack_phdr PT_LOAD;
+  sof_fw_phdr PT_LOAD;
   buffer_hp_heap_phdr PT_LOAD;
   static_log_entries_phdr PT_NOTE;
 }
@@ -351,7 +319,7 @@ SECTIONS
     _ResetHandler_text_start = ABSOLUTE(.);
     KEEP (*(.ResetHandler.text))
     _ResetHandler_text_end = ABSOLUTE(.);
-  } >sof_text_start :sof_text_start_phdr
+  } >sof_fw :sof_fw_phdr
 
   .text : ALIGN(4)
   {
@@ -368,9 +336,9 @@ SECTIONS
     KEEP (*(.ResetHandler.text))
     _text_end = ABSOLUTE(.);
     _etext = .;
-  } >sof_text :sof_text_phdr
+  } >sof_fw :sof_fw_phdr
 
-  .rodata : ALIGN(4)
+  .rodata : ALIGN(SRAM_BANK_SIZE) /* TODO: it should be 4096 */
   {
     _rodata_start = ABSOLUTE(.);
     *(.rodata)
@@ -406,14 +374,14 @@ SECTIONS
     LONG(_bss_end)
     _bss_table_end = ABSOLUTE(.);
     _rodata_end = ABSOLUTE(.);
-  } >sof_data :sof_data_phdr
+  } >sof_fw :sof_fw_phdr
 
   .module_init : ALIGN(4)
   {
     _module_init_start = ABSOLUTE(.);
     *(*.module_init)
     _module_init_end = ABSOLUTE(.);
-  } >sof_data :sof_data_phdr
+  } >sof_fw :sof_fw_phdr
 
   .data : ALIGN(4)
   {
@@ -431,7 +399,7 @@ SECTIONS
     *(.gnu.linkonce.s2.*)
     KEEP(*(.jcr))
     _data_end = ABSOLUTE(.);
-  } >sof_data :sof_data_phdr
+  } >sof_fw :sof_fw_phdr
 
   .lit4 : ALIGN(4)
   {
@@ -440,9 +408,14 @@ SECTIONS
     *(.lit4.*)
     *(.gnu.linkonce.lit4.*)
     _lit4_end = ABSOLUTE(.);
-  } >sof_data :sof_data_phdr
+  } >sof_fw :sof_fw_phdr
 
-  .bss (NOLOAD) : ALIGN(8)
+  .fw_ready : ALIGN(4)
+  {
+    KEEP (*(.fw_ready))
+  } >sof_fw :sof_fw_phdr
+
+  .bss (NOLOAD) : ALIGN(4096)
   {
     . = ALIGN (8);
     _bss_start = ABSOLUTE(.);
@@ -459,28 +432,61 @@ SECTIONS
     *(.bss.*)
     *(.gnu.linkonce.b.*)
     *(COMMON)
-    . = ALIGN (8);
+
+	. = ALIGN (SRAM_BANK_SIZE);
+    _runtime_heap_start = ABSOLUTE(.);
+    . = . + HEAP_RUNTIME_SIZE;
+    _runtime_heap_end = ABSOLUTE(.);
+
+    . = ALIGN (32);
+    _buffer_heap_start = ABSOLUTE(.);
+    . = . + HEAP_BUFFER_SIZE;
+    _buffer_heap_end = ABSOLUTE(.);
+
+    . = ALIGN (SRAM_BANK_SIZE);
+    _system_heap_start = ABSOLUTE(.);
+    . = . + HEAP_SYSTEM_M_SIZE;
+    _system_heap_end = ABSOLUTE(.);
+
+    . = ALIGN (32);
+    _system_runtime_heap_start = ABSOLUTE(.);
+    . = . + HEAP_SYS_RUNTIME_M_SIZE;
+    _system_runtime_heap_end = ABSOLUTE(.);
+
+    . = ALIGN (4096);
+    _sof_stack_start = ABSOLUTE(.);
+    . = . + SOF_STACK_SIZE;
+    _sof_stack_end = ABSOLUTE(.);
+
+    . = ALIGN (SRAM_BANK_SIZE);
+    _sof_core_s_start = ABSOLUTE(.);
+    . = . + SOF_CORE_S_T_SIZE;
+    _sof_core_s_end = ABSOLUTE(.);
+
     _bss_end = ABSOLUTE(.);
-  } >sof_bss_data :sof_bss_data_phdr
+  } >sof_fw :sof_fw_phdr
 
   /* stack */
-  _end = SOF_STACK_END;
-  PROVIDE(end = SOF_STACK_END);
-  _stack_sentry = SOF_STACK_END;
-  __stack = SOF_STACK_BASE;
+  _end = _sof_stack_start;
+  PROVIDE(end = _sof_stack_start);
+  _stack_sentry = _sof_stack_start;
+  __stack = _sof_stack_end;
+
+  /* Slave core size */
+  _core_s_size = SOF_CORE_S_SIZE;
 
   /* System Heap */
-  _system_heap = HEAP_SYSTEM_0_BASE;
+  _system_heap = _system_heap_start;
 
   /* system runtime heap */
-  _system_runtime_heap = HEAP_SYS_RUNTIME_0_BASE;
+  _system_runtime_heap = _system_runtime_heap_start;
 
   /* module heap */
-  _module_heap = HEAP_RUNTIME_BASE;
+  _module_heap = _runtime_heap_start;
 
   /* buffer heap */
-  _buffer_heap = HEAP_BUFFER_BASE;
-  _buffer_heap_end = _stack_sentry;
+  _buffer_heap = _buffer_heap_start;
+  _buffer_heap_end = _buffer_heap_end;
 
   .debug  0 :  { *(.debug) }
   .line  0 :  { *(.line) }
@@ -533,53 +539,8 @@ SECTIONS
     KEEP (*(.gnu.linkonce.xt.profile_files.*))
   }
 
-  .system_heap (NOLOAD) : ALIGN(8)
-  {
-    . = ALIGN (32);
-    _system_heap_start = ABSOLUTE(.);
-    . = . + HEAP_SYSTEM_T_SIZE;
-    _system_heap_end = ABSOLUTE(.);
-  } >system_heap :system_heap_phdr
-
-  .system_runtime_heap (NOLOAD) : ALIGN(8)
-  {
-    . = ALIGN (32);
-    _system_runtime_heap_start = ABSOLUTE(.);
-    . = . + HEAP_SYS_RUNTIME_T_SIZE;
-    _system_runtime_heap_end = ABSOLUTE(.);
-  } >system_runtime_heap :system_runtime_heap_phdr
-
-  .runtime_heap (NOLOAD) : ALIGN(8)
-  {
-    . = ALIGN (32);
-    _runtime_heap_start = ABSOLUTE(.);
-    . = . + HEAP_RUNTIME_SIZE;
-    _runtime_heap_end = ABSOLUTE(.);
-  } >runtime_heap :runtime_heap_phdr
-
-  .buffer_heap (NOLOAD) : ALIGN(8)
-  {
-    . = ALIGN (32);
-    _buffer_heap_start = ABSOLUTE(.);
-    . = . + HEAP_BUFFER_SIZE;
-    _buffer_heap_end = ABSOLUTE(.);
-  } >buffer_heap :buffer_heap_phdr
-
-  .sof_stack (NOLOAD) : ALIGN(8)
-  {
-    . = ALIGN (4096);
-    _sof_stack_start = ABSOLUTE(.);
-    . = . + SOF_STACK_TOTAL_SIZE;
-    _sof_stack_end = ABSOLUTE(.);
-  } >sof_stack :sof_stack_phdr
-
   .static_log_entries (COPY) : ALIGN(1024)
   {
     *(*.static_log*)
   } > static_log_entries_seg :static_log_entries_phdr
-
-  .fw_ready : ALIGN(4)
-  {
-    KEEP (*(.fw_ready))
-  } >sof_data :sof_data_phdr
 }

--- a/test/cmocka/include/mock_memory.h
+++ b/test/cmocka/include/mock_memory.h
@@ -1,0 +1,14 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2018 Intel Corporation. All rights reserved.
+ *
+ * Author: Adrian Bonislawski <adrian.bonislawski@linux.intel.com>
+ */
+
+
+/* Memory mock for memmap */
+#define HEAP_RUNTIME_BASE	0xBE200000
+#define HEAP_BUFFER_BASE	0xBE2F0000
+#define HEAP_SYSTEM_0_BASE	0xBE30F000
+#define HEAP_SYS_RUNTIME_0_BASE 0xBE32F000
+#define SOF_CORE_S_START	0xBE390000

--- a/test/cmocka/memory_mock.x.in
+++ b/test/cmocka/memory_mock.x.in
@@ -1,3 +1,5 @@
+#include "include/mock_memory.h"
+
 SECTIONS
 {
 
@@ -8,5 +10,11 @@ SECTIONS
 
     _comp_init_start = .;
     _comp_init_end = .;
+    _module_heap = HEAP_RUNTIME_BASE;
+    _buffer_heap = HEAP_BUFFER_BASE;
+    _system_heap = HEAP_SYSTEM_0_BASE;
+    _system_heap_start = HEAP_SYSTEM_0_BASE;
+    _system_runtime_heap = HEAP_SYS_RUNTIME_0_BASE;
+    _sof_core_s_start = SOF_CORE_S_START;
 }
 INSERT AFTER .text;

--- a/test/cmocka/src/lib/alloc/alloc.c
+++ b/test/cmocka/src/lib/alloc/alloc.c
@@ -284,6 +284,8 @@ static void test_lib_alloc_immediate_free(struct test_case *tc)
 
 static void test_lib_rballoc_filling_preceding_heaps(struct test_case *tc)
 {
+	extern unsigned int _buffer_heap;
+
 	size_t first_heap_size = HEAP_BUFFER_SIZE - tc->alloc_size * 8;
 	size_t second_heap_size = HEAP_HP_BUFFER_SIZE - tc->alloc_size;
 	size_t third_heap_size = 2048;
@@ -294,7 +296,7 @@ static void test_lib_rballoc_filling_preceding_heaps(struct test_case *tc)
 	int *third_mem = rballoc(tc->alloc_zone, SOF_MEM_CAPS_RAM,
 				 third_heap_size);
 
-	assert_ptr_equal(first_mem, HEAP_BUFFER_BASE);
+	assert_ptr_equal(first_mem, (unsigned int)&_buffer_heap);
 	assert_ptr_equal(second_mem, HEAP_HP_BUFFER_BASE);
 	assert_ptr_equal(third_mem, HEAP_LP_BUFFER_BASE);
 


### PR DESCRIPTION
It introduces two significant optimizations:

> Separate the memory (heaps, stack) by cores so if we will turn off a specific core we can also turn off all memory of this core.
> Remove fixed defines and gaps, previously stack was at fixed position - end of memory and buffer heap was everything between stack and fw. Now everything will be packed at sof_fw memory segment and takes only this memory which is really needed, everything else we can turn off.


BSS section now includes heaps and stack
Removed many heap fixed position defines
Removed gap before fw text section in CNL
memmap init is using real linker positions for heaps
Temporary stack for boot_ldr placed in heap_hp_buffer (safe)
use linker stack position in boot entry
use linker heap position in sanity check
sof fw max_size limited to memory configured by memory banks count
    
Using new macro to stack init per core
Stack is no longer a one big block for all cores (core_count*stack_size)
System_runtime_heap and system_heap are no longer a one big block for all cores
    
Memory layout for every slave core aligned to hw memory bank:

    --align to memory bank--
    system_heap
    system_runtime_heap
    stack
    --align to memory bank--
    next slave core..

So if we will turn off a specific core then we are also able to turn off memory "connected" to this core    

Similar layout applies to master core

Signed-off-by: Adrian Bonislawski <adrian.bonislawski@linux.intel.com>