### PR TITLE
Introduce HAVE_RESET_VECTOR_ROM symbol

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -40,6 +40,13 @@ config BOOT_LOADER
 	bool
 	default n
 
+config HAVE_RESET_VECTOR_ROM
+	bool
+	default n
+	help
+	  Select if your platform has the reset vector
+	  in ROM.
+
 config IRQ_MAP
 	bool
 	default n

--- a/src/arch/xtensa/up/xtos/reset-vector.S
+++ b/src/arch/xtensa/up/xtos/reset-vector.S
@@ -83,11 +83,7 @@ _ResetVector:
 #endif
 #endif
 
-/* Apollolake+ have reset vector in ROM */
-#if defined(CONFIG_BAYTRAIL) || defined(CONFIG_CHERRYTRAIL) \
-	|| defined (CONFIG_HASWELL) || defined(CONFIG_BROADWELL) \
-	|| defined(CONFIG_SKYLAKE) || defined(CONFIG_KABYLAKE) \
-	|| defined(CONFIG_IMX8)
+#if defined(CONFIG_HAVE_RESET_VECTOR_ROM)
 	j	_ResetHandler
 #else
 

--- a/src/platform/Kconfig
+++ b/src/platform/Kconfig
@@ -13,6 +13,7 @@ config BAYTRAIL
 	select DMA_SUSPEND_DRAIN
 	select DMA_FIFO_PARTITION
 	select DW_DMA
+	select HAVE_RESET_VECTOR_ROM
 	help
 	  Select if your target platform is Baytrail-compatible
 
@@ -25,6 +26,7 @@ config CHERRYTRAIL
 	select DMA_SUSPEND_DRAIN
 	select DMA_FIFO_PARTITION
 	select DW_DMA
+	select HAVE_RESET_VECTOR_ROM
 	help
 	  Select if your target platform is Cherrytrail-compatible
 
@@ -34,6 +36,7 @@ config HASWELL
 	select TASK_HAVE_PRIORITY_LOW
 	select DMA_AGGREGATED_IRQ
 	select DW_DMA
+	select HAVE_RESET_VECTOR_ROM
 	help
 	  Select if your target platform is Haswell-compatible
 
@@ -43,6 +46,7 @@ config BROADWELL
 	select TASK_HAVE_PRIORITY_LOW
 	select DMA_AGGREGATED_IRQ
 	select DW_DMA
+	select HAVE_RESET_VECTOR_ROM
 	help
 	  Select if your target platform is Broadwell-compatible
 
@@ -124,6 +128,7 @@ config LIBRARY
 
 config IMX8
 	bool "Build for NXP i.MX8"
+	select HAVE_RESET_VECTOR_ROM
 	help
 	  Select if your target platform is imx8-compatible
 


### PR DESCRIPTION
Apollolake+/i.MX have reset vector in ROM. So far we have
used platform config symbols to tell which platforms have
the reset vector in ROM.

Anyhow, things are starting to get ugly here with more
platforms to come so we add an internal config symbol
which will be set by each each platform when needed.

I couldn't find a definition for CONFIG_SKYLAKE and CONFIG_KABYLAKE are these supported now?
