### PR TITLE
MUX: Relocate mux source and header files to match structure.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -14,6 +14,7 @@ src/include/host/*			@ranj063
 src/include/uapi/**			@thesofproject/steering-committee
 src/include/gdb/*			@mrajwa
 src/include/audio/kpb.h			@mrajwa
+src/include/audio/mux.h			@akloniex
 
 # audio component
 src/audio/src*				@singalsu
@@ -22,7 +23,7 @@ src/audio/fir*				@singalsu
 src/audio/iir*				@singalsu
 src/audio/tone.c			@singalsu
 src/audio/kpb.c				@mrajwa
-src/audio/mux*				@akloniex
+src/audio/mux/*				@akloniex
 
 # platforms
 src/arch/xtensa/*			@tlauda

--- a/src/audio/CMakeLists.txt
+++ b/src/audio/CMakeLists.txt
@@ -29,10 +29,7 @@ if(NOT BUILD_LIBRARY)
 		)
 	endif()
 	if(CONFIG_COMP_MUX)
-		add_local_sources(sof
-			mux.c
-			mux_generic.c
-		)
+		add_subdirectory(mux)
 	endif()
 	if(CONFIG_COMP_SWITCH)
 		add_local_sources(sof

--- a/src/audio/mux/CMakeLists.txt
+++ b/src/audio/mux/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_local_sources(sof mux.c mux_generic.c)

--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -40,7 +40,7 @@
 #include <sof/stream.h>
 #include <sof/audio/component.h>
 #include <sof/ipc.h>
-#include "mux.h"
+#include <sof/audio/mux.h>
 
 static int mux_set_values(struct comp_data *cd, struct sof_mux_config *cfg)
 {

--- a/src/audio/mux/mux_generic.c
+++ b/src/audio/mux/mux_generic.c
@@ -32,7 +32,7 @@
 
 #if CONFIG_COMP_MUX
 
-#include "mux.h"
+#include <sof/audio/mux.h>
 
 /*
  * \brief Fetch 16b samples from source buffer and perform routing operations

--- a/src/include/sof/audio/mux.h
+++ b/src/include/sof/audio/mux.h
@@ -29,7 +29,7 @@
  */
 
 /**
- * \file audio/mux.h
+ * \file include/sof/audio/mux.h
  * \brief Multiplexer component header file
  * \authors Artur Kloniecki <arturx.kloniecki@linux.intel.com>
  */


### PR DESCRIPTION
While Mux component was in development, organization of source files and headers of audio components has changed, and Mux didn't conform to the new structure. This PR is to fix this.

Signed-off-by: ArturX Kloniecki <arturx.kloniecki@linux.intel.com>