### PR TITLE
Add CI support for IMX8 platform

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,9 @@ jobs:
       name: "ICL Build"
       script: ./scripts/docker-run.sh ./scripts/xtensa-build-all.sh -l icl
     - stage: compile
+      name: "IMX8 Build"
+      script: ./scripts/docker-run.sh ./scripts/xtensa-build-all.sh -l imx8
+    - stage: compile
       name: "Host Build"
       script: ./scripts/docker-run.sh ./scripts/host-build-all.sh -l
     - stage: test

--- a/scripts/docker_build/sof_builder/Dockerfile
+++ b/scripts/docker_build/sof_builder/Dockerfile
@@ -71,7 +71,7 @@ RUN cd /home/sof && git clone https://github.com/thesofproject/xtensa-overlay.gi
 	mkdir -p /home/sof/work/ && \
 	cd crosstool-ng && git checkout sof-gcc8.1 && \
 	./bootstrap && ./configure --prefix=`pwd` && make && make install && \
-	for arch in byt hsw apl cnl; do \
+	for arch in byt hsw apl cnl imx; do \
 		cp config-${arch}-gcc8.1-gdb8.1 .config && \
 # replace the build dist to save space
 		sed -i 's#${CT_TOP_DIR}\/builds#\/home\/sof\/work#g' .config && \
@@ -85,10 +85,11 @@ ENV PATH="/home/sof/work/xtensa-byt-elf/bin:${PATH}"
 ENV PATH="/home/sof/work/xtensa-hsw-elf/bin:${PATH}"
 ENV PATH="/home/sof/work/xtensa-apl-elf/bin:${PATH}"
 ENV PATH="/home/sof/work/xtensa-cnl-elf/bin:${PATH}"
+ENV PATH="/home/sof/work/xtensa-imx-elf/bin:${PATH}"
 
 RUN cd /home/sof && git clone https://github.com/jcmvbkbc/newlib-xtensa.git newlib-xtensa.git && \
 	cd newlib-xtensa.git && git checkout -b xtensa origin/xtensa && \
-	for arch in byt hsw apl cnl; do \
+	for arch in byt hsw apl cnl imx; do \
 		./configure --target=xtensa-${arch}-elf \
 		--prefix=/home/sof/work/xtensa-root && \
 		make && \

--- a/scripts/docker_build/sof_builder/Dockerfile
+++ b/scripts/docker_build/sof_builder/Dockerfile
@@ -93,7 +93,7 @@ RUN cd /home/sof && git clone https://github.com/jcmvbkbc/newlib-xtensa.git newl
 		--prefix=/home/sof/work/xtensa-root && \
 		make && \
 		make install && \
-		make distclean; \
+		rm -rf etc/config.cache; \
 	done && \
 	cd /home/sof/ && rm -rf newlib-xtensa.git
 

--- a/scripts/xtensa-build-all.sh
+++ b/scripts/xtensa-build-all.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SUPPORTED_PLATFORMS=(byt cht bdw hsw apl cnl sue icl skl kbl)
+SUPPORTED_PLATFORMS=(byt cht bdw hsw apl cnl sue icl skl kbl imx8)
 BUILD_ROM=no
 BUILD_DEBUG=no
 BUILD_FORCE_UP=no
@@ -222,6 +222,13 @@ do
 		HOST="xtensa-cnl-elf"
 		XTENSA_TOOLS_VERSION="RF-2016.4-linux"
 		HAVE_ROM='yes'
+	fi
+	if [ $j == "imx8" ]
+	then
+		PLATFORM="imx8"
+		ARCH="xtensa"
+		ROOT="$pwd/../xtensa-root/xtensa-imx-elf"
+		HOST="xtensa-imx-elf"
 	fi
 	if [ $XTENSA_TOOLS_ROOT ]
 	then


### PR DESCRIPTION
Enable the IMX8 platform support in scripts and docker.
Add support in Travis CI.
Will update the SOF-CI later after this patch merged.