### PR TITLE
topology: apl-nocodec: change pipeline format to s32le to support all…

### DIFF
--- a/tools/topology/sof-apl-nocodec.m4
+++ b/tools/topology/sof-apl-nocodec.m4
@@ -41,73 +41,73 @@ dnl     frames, deadline, priority, core)
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s16le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-low-latency-playback.m4,
-	1, 0, 2, s16le,
+	1, 0, 2, s32le,
 	48, 1000, 0, 0)
 
 # Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s16le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
-	2, 0, 2, s16le,
+	2, 0, 2, s32le,
 	48, 1000, 0, 0)
 
 # Low Latency playback pipeline 3 on PCM 1 using max 2 channels of s16le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
-	3, 1, 2, s16le,
+	3, 1, 2, s32le,
 	48, 1000, 0, 0)
 
 # Low Latency capture pipeline 4 on PCM 1 using max 2 channels of s16le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
-	4, 1, 2, s16le,
+	4, 1, 2, s32le,
 	48, 1000, 0, 0)
 
 # Low Latency playback pipeline 5 on PCM 2 using max 2 channels of s16le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
 #PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
-#	5, 2, 2, s16le,
+#	5, 2, 2, s32le,
 #	48, 1000, 0, 0)
 
 # Low Latency capture pipeline 6 on PCM 2 using max 2 channels of s16le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
 #PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
-#	6, 2, 2, s16le,
+#	6, 2, 2, s32le,
 #	48, 1000, 0, 0)
 
 # Low Latency playback pipeline 7 on PCM 3 using max 2 channels of s16le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
-	7, 3, 2, s16le,
+	7, 3, 2, s32le,
 	48, 1000, 0, 0)
 
 # Low Latency capture pipeline 8 on PCM 3 using max 2 channels of s16le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
-	8, 3, 2, s16le,
+	8, 3, 2, s32le,
 	48, 1000, 0, 0)
 
 # Low Latency playback pipeline 9 on PCM 4 using max 2 channels of s16le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
 #PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
-#	9, 4, 2, s16le,
+#	9, 4, 2, s32le,
 #	48, 1000, 0, 0)
 
 # Low Latency capture pipeline 10 on PCM 4 using max 2 channels of s16le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
 #PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
-#	10, 4, 2, s16le,
+#	10, 4, 2, s32le,
 #	48, 1000, 0, 0)
 
 # Low Latency playback pipeline 11 on PCM 5 using max 2 channels of s16le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
-	11, 5, 2, s16le,
+	11, 5, 2, s32le,
 	48, 1000, 0, 0)
 
 # Low Latency capture pipeline 12 on PCM 5 using max 2 channels of s16le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
-	12, 5, 2, s16le,
+	12, 5, 2, s32le,
 	48, 1000, 0, 0)
 
 # Passthrough capture pipeline 13 on PCM 6 using max 2 channels.


### PR DESCRIPTION
… formats

Pipeline format determines the buffer size calculation. With the
pipeline format set to S16_LE, hw_params fails for S24_LE and S32_LE
formats. So, change the pipeline format to s32le to support all
three formats.

Fixes https://github.com/thesofproject/linux/issues/879