### PR TITLE
dma-trace: fix cache handling

### DIFF
--- a/src/include/sof/dma-trace.h
+++ b/src/include/sof/dma-trace.h
@@ -42,6 +42,7 @@ struct dma_trace_data {
 	uint32_t enabled;
 	uint32_t copy_in_progress;
 	uint32_t stream_tag;
+	uint32_t dropped_entries; /* amount of dropped entries */
 	spinlock_t lock; /* dma trace lock */
 };
 

--- a/src/lib/dma-trace.c
+++ b/src/lib/dma-trace.c
@@ -386,9 +386,7 @@ static void dtrace_add_event(const char *e, uint32_t length)
 			 * if any dropped entries have appeared and there
 			 * is not any overflow, their amount will be logged
 			 */
-#if CONFIG_TRACE
 			uint32_t tmp_dropped_entries = dropped_entries;
-#endif
 			dropped_entries = 0;
 			/*
 			 * this trace_error invocation causes recursion,

--- a/src/lib/dma-trace.c
+++ b/src/lib/dma-trace.c
@@ -19,9 +19,6 @@
 
 static struct dma_trace_data *trace_data;
 
-/* amount of dropped entries */
-static uint32_t dropped_entries;
-
 static int dma_trace_get_avail_data(struct dma_trace_data *d,
 				    struct dma_trace_buf *buffer,
 				    int avail);
@@ -380,14 +377,15 @@ static void dtrace_add_event(const char *e, uint32_t length)
 	overflow = dtrace_calc_buf_overflow(buffer, length);
 
 	/* tracing dropped entries */
-	if (dropped_entries) {
+	if (trace_data->dropped_entries) {
 		if (!overflow) {
 			/*
 			 * if any dropped entries have appeared and there
 			 * is not any overflow, their amount will be logged
 			 */
-			uint32_t tmp_dropped_entries = dropped_entries;
-			dropped_entries = 0;
+			uint32_t tmp_dropped_entries =
+				trace_data->dropped_entries;
+			trace_data->dropped_entries = 0;
 			/*
 			 * this trace_error invocation causes recursion,
 			 * so after it we have to recalculate margin and
@@ -428,7 +426,7 @@ static void dtrace_add_event(const char *e, uint32_t length)
 		trace_data->messages++;
 	} else {
 		/* if there is not enough memory for new log, we drop it */
-		dropped_entries++;
+		trace_data->dropped_entries++;
 	}
 }
 


### PR DESCRIPTION
Fixes cache handling for dma-trace buffer.
Current implementation wasn't fully supporting
multicore traces. This patch changes buffer
writeback invalidations after buffer write to
invalidations before read and writebacks after
write. Also removes not needed cache operations
on retrieving current traces size.

Fixes #1494.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>