### PR TITLE
dma-trace: align copied trace size to DMA burst size

### DIFF
--- a/src/lib/dma-trace.c
+++ b/src/lib/dma-trace.c
@@ -15,6 +15,7 @@
 #include <platform/platform.h>
 #include <sof/lock.h>
 #include <sof/cpu.h>
+#include <sof/audio/format.h>
 #include <stdint.h>
 
 static struct dma_trace_data *trace_data;
@@ -219,7 +220,8 @@ static int dma_trace_get_avail_data(struct dma_trace_data *d,
 		d->old_host_offset = d->host_offset;
 	}
 
-	return avail;
+	/* align data to HD-DMA burst size */
+	return ALIGN_DOWN(avail, PLATFORM_HDA_BURST_SIZE);
 }
 #else
 static int dma_trace_get_avail_data(struct dma_trace_data *d,

--- a/src/platform/apollolake/include/platform/platform.h
+++ b/src/platform/apollolake/include/platform/platform.h
@@ -45,6 +45,9 @@ struct sof;
 /* DGMBS align value */
 #define PLATFORM_HDA_BUFFER_ALIGNMENT	0x20
 
+/* HD-DMA single burst size */
+#define PLATFORM_HDA_BURST_SIZE	32
+
 /* Host page size */
 #define HOST_PAGE_SIZE		4096
 #define PLATFORM_PAGE_TABLE_SIZE	256

--- a/src/platform/cannonlake/include/platform/platform.h
+++ b/src/platform/cannonlake/include/platform/platform.h
@@ -55,6 +55,9 @@ struct sof;
 /* DGMBS align value */
 #define PLATFORM_HDA_BUFFER_ALIGNMENT	0x20
 
+/* HD-DMA single burst size */
+#define PLATFORM_HDA_BURST_SIZE	32
+
 /* Host page size */
 #define HOST_PAGE_SIZE		4096
 #define PLATFORM_PAGE_TABLE_SIZE	256

--- a/src/platform/icelake/include/platform/platform.h
+++ b/src/platform/icelake/include/platform/platform.h
@@ -55,6 +55,9 @@ struct sof;
 /* DGMBS align value */
 #define PLATFORM_HDA_BUFFER_ALIGNMENT	0x20
 
+/* HD-DMA single burst size */
+#define PLATFORM_HDA_BURST_SIZE	32
+
 /* Host page size */
 #define HOST_PAGE_SIZE		4096
 #define PLATFORM_PAGE_TABLE_SIZE	256

--- a/src/platform/suecreek/include/platform/platform.h
+++ b/src/platform/suecreek/include/platform/platform.h
@@ -55,6 +55,9 @@ struct sof;
 /* DGMBS align value */
 #define PLATFORM_HDA_BUFFER_ALIGNMENT	0x20
 
+/* HD-DMA single burst size */
+#define PLATFORM_HDA_BURST_SIZE	32
+
 /* Host page size */
 #define HOST_PAGE_SIZE		4096
 #define PLATFORM_PAGE_TABLE_SIZE	256


### PR DESCRIPTION
Aligns copied trace size to DMA burst size for HD-DMA.
Previously we've copied data on the DSP side and sent
the right offset to the host, but actually if the data
wasn't aligned to the burst size, the host would read
old traces for the part of data not yet pushed to the
host.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>