### PR TITLE
format: add missing #include <stdint.h>

### DIFF
--- a/src/include/sof/audio/format.h
+++ b/src/include/sof/audio/format.h
@@ -10,6 +10,8 @@
 #ifndef AUDIO_FORMAT_H
 #define AUDIO_FORMAT_H
 
+#include <stdint.h>
+
 /* Maximum and minimum values for 24 bit */
 #define INT24_MAXVALUE  8388607
 #define INT24_MINVALUE -8388608


### PR DESCRIPTION
Adds missing stdint header, since we are using types
defined in that file. Right now format.h compiles
by accident.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>