### PR TITLE
sof: unify multiple ALIGN macros

### DIFF
--- a/src/drivers/dw/ssi-spi.c
+++ b/src/drivers/dw/ssi-spi.c
@@ -314,7 +314,7 @@ static uint64_t spi_completion_work(void *data)
 		/* configure to receive next header */
 		spi->ipc_status = IPC_READ;
 		config = spi->config + SPI_DIR_RX;
-		config->transfer_len = ALIGN(sizeof(*hdr), 16);
+		config->transfer_len = ALIGN_UP(sizeof(*hdr), 16);
 		spi_set_config(spi, config);
 		spi_trigger(spi, SPI_TRIGGER_START, SPI_DIR_RX);
 
@@ -349,7 +349,7 @@ int spi_push(struct spi *spi, const void *data, size_t size)
 		return ret;
 
 	/* configure transmit path of SPI-slave */
-	config->transfer_len = ALIGN(size, 16);
+	config->transfer_len = ALIGN_UP(size, 16);
 	ret = spi_set_config(spi, config);
 	if (ret < 0)
 		return ret;
@@ -391,7 +391,7 @@ static int spi_slave_init(struct spi *spi)
 	/* configure receive path of SPI-slave */
 	config->dir = SPI_DIR_RX;
 	config->dest_buf = spi->rx_buffer;
-	config->transfer_len = ALIGN(sizeof(struct sof_ipc_hdr), 16);
+	config->transfer_len = ALIGN_UP(sizeof(struct sof_ipc_hdr), 16);
 
 	ret = spi_set_config(spi, config);
 	if (ret < 0)

--- a/src/include/sof/audio/format.h
+++ b/src/include/sof/audio/format.h
@@ -30,13 +30,6 @@
 #define MINUS_80DB_Q1_31     214748  /* 10^(-80/20) */
 #define MINUS_90DB_Q1_31      67909  /* 10^(-90/20) */
 
-/* Align the number to the nearest alignment value */
-#define ALIGN_UP(size, alignment) \
-	(((size) % (alignment) == 0) ? (size) : \
-	((size) - ((size) % (alignment)) + (alignment)))
-#define ALIGN_DOWN(size, alignment) \
-	((size) - ((size) % (alignment)))
-
 /* Compute the number of shifts
  * This will result in a compiler overflow error if shift bits are out of
  * range as INT64_MAX/MIN is greater than 32 bit Q shift parameter

--- a/src/include/sof/sof.h
+++ b/src/include/sof/sof.h
@@ -24,7 +24,12 @@ struct sa;
 	({const typeof(((type *)0)->member)*__memberptr = (ptr); \
 	(type *)((char *)__memberptr - offsetof(type, member)); })
 
-#define ALIGN(size, align) (((size) + (align) - 1) & ~((align) - 1))
+/* Align the number to the nearest alignment value */
+#define ALIGN_UP(size, alignment) \
+	(((size) % (alignment) == 0) ? (size) : \
+	((size) - ((size) % (alignment)) + (alignment)))
+#define ALIGN_DOWN(size, alignment) \
+	((size) - ((size) % (alignment)))
 
 #define __packed __attribute__((packed))
 


### PR DESCRIPTION
Unifies multiple different align macros spread
across the source code. Now we have ALIGN_UP and
ALIGN_DOWN macros defined in sof.h.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>