### PR TITLE
dw-dma: set ctrl_hi to zero before bit masking

### DIFF
--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -914,6 +914,8 @@ static inline void dw_dma_chan_reload_next(struct dma *dma, int channel,
 	dw_write(dma, DW_SAR(channel), sar);
 	dw_write(dma, DW_DAR(channel), dar);
 
+	lli->ctrl_hi = 0;
+
 	/* set channel class */
 	platform_dw_dma_set_class(chan, lli, class);
 


### PR DESCRIPTION
dw-dma transfer size setting was changed in cleanup and because of that
we need to zero the ctrl_hi value before twiddling the bits.

Signed-off-by: Jaska Uimonen <jaska.uimonen@intel.com>