### PR TITLE
idc: refactor sending in blocking mode

### DIFF
--- a/src/arch/xtensa/smp/include/arch/idc.h
+++ b/src/arch/xtensa/smp/include/arch/idc.h
@@ -14,6 +14,8 @@
 #ifndef __ARCH_IDC_H__
 #define __ARCH_IDC_H__
 
+#include <stdint.h>
+
 struct idc_msg;
 
 void cpu_power_down_core(void);

--- a/src/include/sof/idc.h
+++ b/src/include/sof/idc.h
@@ -91,7 +91,6 @@ struct idc_msg {
 
 /** \brief IDC data. */
 struct idc {
-	spinlock_t lock;		/**< lock mechanism */
 	uint32_t busy_bit_mask;		/**< busy interrupt mask */
 	uint32_t done_bit_mask;		/**< done interrupt mask */
 	struct idc_msg received_msg;	/**< received message */

--- a/src/include/sof/idc.h
+++ b/src/include/sof/idc.h
@@ -16,6 +16,7 @@
 
 #include <sof/schedule.h>
 #include <sof/trace.h>
+#include <stdint.h>
 
 /** \brief IDC trace function. */
 #define trace_idc(__e) \

--- a/src/include/sof/idc.h
+++ b/src/include/sof/idc.h
@@ -36,8 +36,8 @@
 /** \brief IDC send non-blocking flag. */
 #define IDC_NON_BLOCKING	1
 
-/** \brief IDC send timeout in cycles. */
-#define IDC_TIMEOUT	800000
+/** \brief IDC send timeout in microseconds. */
+#define IDC_TIMEOUT	10000
 
 /** \brief IDC task deadline. */
 #define IDC_DEADLINE	100

--- a/src/include/sof/idc.h
+++ b/src/include/sof/idc.h
@@ -19,8 +19,8 @@
 #include <stdint.h>
 
 /** \brief IDC trace function. */
-#define trace_idc(__e) \
-	trace_event(TRACE_CLASS_IDC, __e)
+#define trace_idc(__e, ...) \
+	trace_event(TRACE_CLASS_IDC, __e, ##__VA_ARGS__)
 
 /** \brief IDC trace value function. */
 #define tracev_idc(__e, ...) \

--- a/test/cmocka/src/audio/pipeline/pipeline_mocks.c
+++ b/test/cmocka/src/audio/pipeline/pipeline_mocks.c
@@ -11,6 +11,7 @@
 TRACE_IMPL()
 
 struct ipc *_ipc;
+struct timer *platform_timer;
 
 void platform_dai_timestamp(struct comp_dev *dai,
 	struct sof_ipc_stream_posn *posn)
@@ -102,4 +103,19 @@ void __panic(uint32_t p, char *filename, uint32_t linenum)
 	(void)p;
 	(void)filename;
 	(void)linenum;
+}
+
+uint64_t platform_timer_get(struct timer *timer)
+{
+	(void)timer;
+
+	return 0;
+}
+
+uint64_t clock_ms_to_ticks(int clock, uint64_t ms)
+{
+	(void)clock;
+	(void)ms;
+
+	return 0;
 }

--- a/test/cmocka/src/audio/pipeline/pipeline_mocks.h
+++ b/test/cmocka/src/audio/pipeline/pipeline_mocks.h
@@ -7,6 +7,7 @@
 
 #include <sof/audio/component.h>
 #include <sof/audio/pipeline.h>
+#include <sof/clk.h>
 #include <sof/edf_schedule.h>
 #include <stdarg.h>
 #include <stddef.h>


### PR DESCRIPTION
Refactors IDC sending in blocking mode to
utilize DONE interrupt instead of manually
polling for DONE bit. It allows for removal
of spinlock, which prevented longer IDC
timeouts.

Fixes #1503.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>