### PR TITLE
dai: change starting sequence

### DIFF
--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -502,10 +502,10 @@ static int dai_comp_trigger(struct comp_dev *dev, int cmd)
 		 */
 		if (dd->xrun == 0 && !pipeline_is_preload(dev->pipeline)) {
 			/* start the DAI */
+			dai_trigger(dd->dai, cmd, dev->params.direction);
 			ret = dma_start(dd->dma, dd->chan);
 			if (ret < 0)
 				return ret;
-			dai_trigger(dd->dai, cmd, dev->params.direction);
 		} else {
 			dd->xrun = 0;
 		}
@@ -529,10 +529,10 @@ static int dai_comp_trigger(struct comp_dev *dev, int cmd)
 				return ret;
 
 			/* start the DAI */
+			dai_trigger(dd->dai, cmd, dev->params.direction);
 			ret = dma_start(dd->dma, dd->chan);
 			if (ret < 0)
 				return ret;
-			dai_trigger(dd->dai, cmd, dev->params.direction);
 		} else {
 			dd->xrun = 0;
 		}
@@ -572,11 +572,11 @@ static int dai_copy(struct comp_dev *dev)
 	/* start DMA on preload */
 	if (pipeline_is_preload(dev->pipeline)) {
 		/* start the DAI */
+		dai_trigger(dd->dai, COMP_TRIGGER_START,
+			    dev->params.direction);
 		ret = dma_start(dd->dma, dd->chan);
 		if (ret < 0)
 			return ret;
-		dai_trigger(dd->dai, COMP_TRIGGER_START,
-			    dev->params.direction);
 		platform_dai_wallclock(dev, &dd->wallclock);
 
 		/* let's not copy further */

--- a/src/drivers/intel/cavs/ssp.c
+++ b/src/drivers/intel/cavs/ssp.c
@@ -743,6 +743,9 @@ static void ssp_start(struct dai *dai, int direction)
 		ssp_update_bits(dai, SSRSA, 0x1 << 8, 0x1 << 8);
 	}
 
+	/* wait to get valid fifo status */
+	wait_delay(PLATFORM_SSP_DELAY);
+
 	spin_unlock(&dai->lock);
 }
 
@@ -754,7 +757,7 @@ static void ssp_stop(struct dai *dai, int direction)
 	spin_lock(&dai->lock);
 
 	/* wait to get valid fifo status */
-	wait_delay(PLATFORM_SSP_STOP_DELAY);
+	wait_delay(PLATFORM_SSP_DELAY);
 
 	/* stop Rx if neeed */
 	if (direction == DAI_DIR_CAPTURE &&

--- a/src/platform/apollolake/include/platform/platform.h
+++ b/src/platform/apollolake/include/platform/platform.h
@@ -142,8 +142,8 @@ struct sof;
 /* the watermark for the SSP fifo depth setting */
 #define SSP_FIFO_WATERMARK	8
 
-/* minimal SSP port stop delay in cycles */
-#define PLATFORM_SSP_STOP_DELAY	2400
+/* minimal SSP port delay in cycles */
+#define PLATFORM_SSP_DELAY	2400
 
 /* timer driven scheduling start offset in microseconds */
 #define PLATFORM_TIMER_START_OFFSET	100

--- a/src/platform/cannonlake/include/platform/platform.h
+++ b/src/platform/cannonlake/include/platform/platform.h
@@ -143,8 +143,8 @@ struct sof;
 /* the watermark for the SSP fifo depth setting */
 #define SSP_FIFO_WATERMARK	8
 
-/* minimal SSP port stop delay in cycles */
-#define PLATFORM_SSP_STOP_DELAY	3000
+/* minimal SSP port delay in cycles */
+#define PLATFORM_SSP_DELAY	3000
 
 /* timer driven scheduling start offset in microseconds */
 #define PLATFORM_TIMER_START_OFFSET	100

--- a/src/platform/icelake/include/platform/platform.h
+++ b/src/platform/icelake/include/platform/platform.h
@@ -143,8 +143,8 @@ struct sof;
 /* the watermark for the SSP fifo depth setting */
 #define SSP_FIFO_WATERMARK	8
 
-/* minimal SSP port stop delay in cycles */
-#define PLATFORM_SSP_STOP_DELAY	4800
+/* minimal SSP port delay in cycles */
+#define PLATFORM_SSP_DELAY	4800
 
 /* timer driven scheduling start offset in microseconds */
 #define PLATFORM_TIMER_START_OFFSET	100

--- a/src/platform/suecreek/include/platform/platform.h
+++ b/src/platform/suecreek/include/platform/platform.h
@@ -146,8 +146,8 @@ struct sof;
 /* the watermark for the SSP fifo depth setting */
 #define SSP_FIFO_WATERMARK	8
 
-/* minimal SSP port stop delay in cycles */
-#define PLATFORM_SSP_STOP_DELAY	3000
+/* minimal SSP port delay in cycles */
+#define PLATFORM_SSP_DELAY	3000
 
 /* timer driven scheduling start offset in microseconds */
 #define PLATFORM_TIMER_START_OFFSET	100


### PR DESCRIPTION
Changes starting sequence of DAI. Now IO interface is
started before DMA. The purpose of this change is to
allow slave interfaces to prepare their FIFOs before
DMA starts transferring to them.

Fixes #1466.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>