### PR TITLE
sof: add default ALIGN macro

### DIFF
--- a/src/include/sof/sof.h
+++ b/src/include/sof/sof.h
@@ -30,6 +30,7 @@ struct sa;
 	((size) - ((size) % (alignment)) + (alignment)))
 #define ALIGN_DOWN(size, alignment) \
 	((size) - ((size) % (alignment)))
+#define ALIGN ALIGN_UP
 
 #define __packed __attribute__((packed))
 


### PR DESCRIPTION
This will add default ALIGN macro so #defines which are using ALIGN
can work in main code and linker scripts using linker definition for ALIGN

Signed-off-by: Adrian Bonislawski <adrian.bonislawski@linux.intel.com>