### PR TITLE
Volume: Use min and max volume scale values from IPC

### DIFF
--- a/src/include/sof/audio/volume.h
+++ b/src/include/sof/audio/volume.h
@@ -85,17 +85,20 @@
  * Gain amplitude value is between 0 (mute) ... 2^16 (0dB) ... 2^24 (~+48dB).
  */
 struct comp_data {
-	enum sof_ipc_frame source_format;	/**< source frame format */
-	enum sof_ipc_frame sink_format;		/**< sink frame format */
+	struct task volwork;		/**< volume scheduled work function */
+	struct sof_ipc_ctrl_value_chan *hvol;	/**< host volume readback */
 	int32_t volume[SOF_IPC_MAX_CHANNELS];	/**< current volume */
 	int32_t tvolume[SOF_IPC_MAX_CHANNELS];	/**< target volume */
 	int32_t mvolume[SOF_IPC_MAX_CHANNELS];	/**< mute volume */
+	int32_t ramp_increment[SOF_IPC_MAX_CHANNELS]; /**< for linear ramp */
+	int32_t vol_min;			/**< minimum volume */
+	int32_t vol_max;			/**< maximum volume */
+	int32_t	vol_ramp_range;			/**< max ramp transition */
+	enum sof_ipc_frame source_format;	/**< source frame format */
+	enum sof_ipc_frame sink_format;		/**< sink frame format */
 	/**< volume processing function */
 	void (*scale_vol)(struct comp_dev *dev, struct comp_buffer *sink,
 			  struct comp_buffer *source, uint32_t frames);
-	struct task volwork;	/**< volume scheduled work function */
-	struct sof_ipc_ctrl_value_chan *hvol;	/**< host volume readback */
-	int32_t ramp_increment[SOF_IPC_MAX_CHANNELS];	/**< for linear ramp */
 };
 
 /** \brief Volume processing functions map. */


### PR DESCRIPTION
This patch adds feature to retrieve volume scale min and max from
IPC if the parameters are set. Volume min and max are now used
with ramp time parameter to compute gain ramp step to achieve
constant rate ramps with any volume scale. If the min and max are
zeros the previous FW operation is preserved.

Previously the firmware did not know the volume range so the
volume code uses in volume request a check to prevent exceeding
ramp length specified in topology by step size re-adjust. It was
done to prevent very long ramps to happen with volume scales with
large gain. However the smaller transitions remained longer than
necessary. This patch fixes that last remaining issue.

The ramp length check code is preserved to be compatible with
kernel versions those do not provide the min and max volume scale
values. When provided the check code has no impact.

The patch includes some cosmetic re-arranging of volume comp data
struct fields in addition to adding new the fields vol_ramp_range,
vol_min, and vol_max.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>