### PR TITLE
ssp: cavs: decrease PLATFORM_SSP_DELAY

### DIFF
--- a/src/platform/apollolake/include/platform/platform.h
+++ b/src/platform/apollolake/include/platform/platform.h
@@ -146,7 +146,7 @@ struct sof;
 #define SSP_FIFO_WATERMARK	8
 
 /* minimal SSP port delay in cycles */
-#define PLATFORM_SSP_DELAY	2400
+#define PLATFORM_SSP_DELAY	800
 
 /* timer driven scheduling start offset in microseconds */
 #define PLATFORM_TIMER_START_OFFSET	100

--- a/src/platform/cannonlake/include/platform/platform.h
+++ b/src/platform/cannonlake/include/platform/platform.h
@@ -147,7 +147,7 @@ struct sof;
 #define SSP_FIFO_WATERMARK	8
 
 /* minimal SSP port delay in cycles */
-#define PLATFORM_SSP_DELAY	3000
+#define PLATFORM_SSP_DELAY	1000
 
 /* timer driven scheduling start offset in microseconds */
 #define PLATFORM_TIMER_START_OFFSET	100

--- a/src/platform/icelake/include/platform/platform.h
+++ b/src/platform/icelake/include/platform/platform.h
@@ -147,7 +147,7 @@ struct sof;
 #define SSP_FIFO_WATERMARK	8
 
 /* minimal SSP port delay in cycles */
-#define PLATFORM_SSP_DELAY	4800
+#define PLATFORM_SSP_DELAY	1600
 
 /* timer driven scheduling start offset in microseconds */
 #define PLATFORM_TIMER_START_OFFSET	100

--- a/src/platform/suecreek/include/platform/platform.h
+++ b/src/platform/suecreek/include/platform/platform.h
@@ -150,7 +150,7 @@ struct sof;
 #define SSP_FIFO_WATERMARK	8
 
 /* minimal SSP port delay in cycles */
-#define PLATFORM_SSP_DELAY	3000
+#define PLATFORM_SSP_DELAY	1000
 
 /* timer driven scheduling start offset in microseconds */
 #define PLATFORM_TIMER_START_OFFSET	100


### PR DESCRIPTION
Decreases PLATFORM_SSP_DELAY for cAVS platforms.
This delay is used after SSP start and before stop
to let frame and clock synchronize. It was very long,
so was decreased from 1/8 ms to 1/24 ms. Experiments
show that it's still enough for slave clock to synchronize
and to not lose first data sample.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>