### PR TITLE
pipeline: add missing check for PPL_STATUS_PATH_STOP

### DIFF
--- a/src/audio/pipeline.c
+++ b/src/audio/pipeline.c
@@ -728,7 +728,7 @@ static int pipeline_comp_copy(struct comp_dev *current, void *data, int dir)
 
 	err = pipeline_for_each_comp(current, &pipeline_comp_copy,
 				     data, NULL, dir);
-	if (err < 0)
+	if (err < 0 || err == PPL_STATUS_PATH_STOP)
 		return err;
 
 	if (dir == PPL_DIR_UPSTREAM)


### PR DESCRIPTION
Adds missing check in pipeline_comp_copy for
PPL_STATUS_PATH_STOP. It fixes the issue, where
playback pipeline hasn't been able to stop copying
even with component returning such status.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>