### PR TITLE
dai: fix xrun handling

### DIFF
--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -590,8 +590,7 @@ static int dai_copy(struct comp_dev *dev)
 			return ret;
 		platform_dai_wallclock(dev, &dd->wallclock);
 
-		/* let's not copy further */
-		return 1;
+		return 0;
 	}
 
 	/* get data sizes from DMA */

--- a/src/audio/pipeline.c
+++ b/src/audio/pipeline.c
@@ -388,11 +388,8 @@ int pipeline_prepare(struct pipeline *p, struct comp_dev *dev)
 		goto out;
 	}
 
-	/* pipeline preload needed only for playback streams and capture
-	 * streams scheduled with timer
-	 */
-	p->preload = dev->params.direction == SOF_IPC_STREAM_PLAYBACK ||
-		pipeline_is_timer_driven(p);
+	/* pipeline preload needed only for playback streams */
+	p->preload = dev->params.direction == SOF_IPC_STREAM_PLAYBACK;
 	p->status = COMP_STATE_PREPARE;
 
 out:


### PR DESCRIPTION
Fixes xrun handling by moving check from callback
to copy. Check in callback wasn't making any sense,
because bytes passed there have been already calculated
based on avail/free.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>