### PR TITLE
 dma: refactor callback data

### DIFF
--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -106,12 +106,12 @@ static inline struct dma_sg_elem *next_buffer(struct hc_buf *hc)
  * overflow host period/buffer/page boundaries on each transfer and split the
  * DMA transfer if we do overflow.
  */
-static void host_dma_cb(void *data, uint32_t type, struct dma_sg_elem *next)
+static void host_dma_cb(void *data, uint32_t type, struct dma_cb_data *next)
 {
 	struct comp_dev *dev = (struct comp_dev *)data;
 	struct host_data *hd = comp_get_drvdata(dev);
 #if CONFIG_DMA_GW
-	uint32_t bytes = next->size;
+	uint32_t bytes = next->elem.size;
 #else
 	struct dma_sg_elem *local_elem;
 	struct dma_sg_elem *source_elem;
@@ -206,13 +206,14 @@ static void host_dma_cb(void *data, uint32_t type, struct dma_sg_elem *next)
 
 	/* schedule immediate split transfer if needed */
 	if (need_copy) {
-		next->src = local_elem->src;
-		next->dest = local_elem->dest;
-		next->size = local_elem->size;
+		next->elem.src = local_elem->src;
+		next->elem.dest = local_elem->dest;
+		next->elem.size = local_elem->size;
+		next->status = DMA_CB_STATUS_SPLIT;
 		return;
 	}
 
-	next->size = DMA_RELOAD_END;
+	next->status = DMA_CB_STATUS_END;
 #endif
 }
 

--- a/src/drivers/dw/ssi-spi.c
+++ b/src/drivers/dw/ssi-spi.c
@@ -325,11 +325,11 @@ static uint64_t spi_completion_work(void *data)
 }
 
 static void spi_dma_complete(void *data, uint32_t type,
-			     struct dma_sg_elem *next)
+			     struct dma_cb_data *next)
 {
 	struct spi *spi = data;
 
-	next->size = DMA_RELOAD_END;
+	next->status = DMA_CB_STATUS_END;
 
 	schedule_task(&spi->completion, 0, 100, 0);
 }

--- a/src/drivers/imx/dummy-dma.c
+++ b/src/drivers/imx/dummy-dma.c
@@ -70,7 +70,7 @@ static int dummy_dma_pm_context_store(struct dma *dma)
 }
 
 static int dummy_dma_set_cb(struct dma *dma, unsigned int channel, int type,
-		void (*cb)(void *data, uint32_t type, struct dma_sg_elem *next),
+		void (*cb)(void *data, uint32_t type, struct dma_cb_data *next),
 		void *data)
 {
 	return 0;

--- a/src/drivers/imx/edma.c
+++ b/src/drivers/imx/edma.c
@@ -96,7 +96,7 @@ static int edma_pm_context_store(struct dma *dma)
 }
 
 static int edma_set_cb(struct dma *dma, unsigned int channel, int type,
-		void (*cb)(void *data, uint32_t type, struct dma_sg_elem *next),
+		void (*cb)(void *data, uint32_t type, struct dma_cb_data *next),
 		void *data)
 {
 	return 0;

--- a/src/drivers/intel/cavs/hda-dma.c
+++ b/src/drivers/intel/cavs/hda-dma.c
@@ -314,12 +314,8 @@ static void hda_dma_post_copy(struct dma *dma, struct hda_chan_data *chan,
 {
 	struct dma_cb_data next = { .elem = { .size = bytes } };
 
-	if (chan->cb) {
+	if (chan->cb)
 		chan->cb(chan->cb_data, DMA_CB_TYPE_COPY, &next);
-		if (next.status == DMA_CB_STATUS_END)
-			/* disable channel, finished */
-			hda_dma_stop(dma, chan->index);
-	}
 
 	/* Force Host DMA to exit L1 */
 	if (chan->direction == DMA_DIR_HMEM_TO_LMEM ||

--- a/src/ipc/dma-copy.c
+++ b/src/ipc/dma-copy.c
@@ -51,7 +51,7 @@ static struct dma_sg_elem *sg_get_elem_at(struct dma_sg_config *host_sg,
 
 #if !CONFIG_DMA_GW
 
-static void dma_complete(void *data, uint32_t type, struct dma_sg_elem *next)
+static void dma_complete(void *data, uint32_t type, struct dma_cb_data *next)
 {
 	completion_t *comp = (completion_t *)data;
 
@@ -60,7 +60,7 @@ static void dma_complete(void *data, uint32_t type, struct dma_sg_elem *next)
 
 	ipc_dma_trace_send_position();
 
-	next->size = DMA_RELOAD_END;
+	next->status = DMA_CB_STATUS_END;
 }
 
 #endif

--- a/src/ipc/ipc-host-ptable.c
+++ b/src/ipc/ipc-host-ptable.c
@@ -81,7 +81,7 @@ static int ipc_parse_page_descriptors(uint8_t *page_table,
 	return 0;
 }
 
-static void dma_complete(void *data, uint32_t type, struct dma_sg_elem *next)
+static void dma_complete(void *data, uint32_t type, struct dma_cb_data *next)
 {
 	completion_t *complete = data;
 


### PR DESCRIPTION
Refactors DMA callback data by using dedicated
callback struct along with callback status enum.
Previously field size was used to pass status
from component to DMA, which was misleading
and could cause potential issues e.g. value
0 was a valid number of bytes, but it was
also a value for DMA_RELOAD_END definition.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>