### PR TITLE
logger: add debugfs entries for apl and cnl

### DIFF
--- a/tools/logger/logger.c
+++ b/tools/logger/logger.c
@@ -24,6 +24,7 @@ static const char *debugfs[] = {
 	"dmac0", "dmac1", "ssp0", "ssp1",
 	"ssp2", "iram", "dram", "shim",
 	"mbox", "etrace",
+	"hda", "pp", "dsp",
 };
 
 static void usage(void)


### PR DESCRIPTION
Resolves #1266 

Logger was aware only of debugfs entries for BYT/HSW platfroms.
This commit adds debugfs entries for APL/CNL.

Signed-off-by: Janusz Jankowski <janusz.jankowski@linux.intel.com>