### PR TITLE
scheduler: enable idle task to be executed more than once

### DIFF
--- a/src/audio/pipeline.c
+++ b/src/audio/pipeline.c
@@ -977,5 +977,5 @@ static uint64_t pipeline_task(void *arg)
 	}
 
 	tracev_pipe("pipeline_task() sched");
-	return p->ipc_pipe.period;
+	return pipeline_is_timer_driven(p) ? p->ipc_pipe.period : 0;
 }

--- a/src/lib/edf_schedule.c
+++ b/src/lib/edf_schedule.c
@@ -501,6 +501,7 @@ static void edf_schedule_idle(void)
 	struct list_item *tlist;
 	struct list_item *clist;
 	struct task *task;
+	uint64_t ret;
 
 	/* Are we on passive level? */
 	if (arch_interrupt_get_level() != SOF_IRQ_PASSIVE_LEVEL)
@@ -512,11 +513,13 @@ static void edf_schedule_idle(void)
 
 		/* run task if we find any queued */
 		if (task->state == SOF_TASK_STATE_QUEUED) {
-			task->func(task->data);
-			task->state = SOF_TASK_STATE_COMPLETED;
+			ret = task->func(task->data);
 
-			/* task done, remove it from the list */
-			list_item_del(clist);
+			if (ret == 0) {
+				/* task done, remove it from the list */
+				task->state = SOF_TASK_STATE_COMPLETED;
+				list_item_del(clist);
+			}
 		}
 	}
 }


### PR DESCRIPTION
Some idle task like for example KWD draining needs
significant amount of time to finish their job.
For example, to drain whole history buffer 6 milliseconds
are needed in non-synchronized mode and as much as 2100
milliseconds in synchronized mode with period 400 frames.
Therefore it is vital to exit idle task when it itself
is in *idle* state and allow other tasks to do their
job.
    
Signed-off-by: Marcin Rajwa <marcin.rajwa@linux.intel.com>
