### PR TITLE
cmake: drivers: split dw and intel

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -61,15 +61,7 @@ config MEM_WND
 	bool
 	default n
 
-config DW_SPI
-	bool
-	default n
-
 config INTEL_IOMUX
-	bool
-	default n
-
-config DW_GPIO
 	bool
 	default n
 

--- a/src/drivers/CMakeLists.txt
+++ b/src/drivers/CMakeLists.txt
@@ -2,7 +2,9 @@
 
 if(CONFIG_IMX8)
 	add_subdirectory(imx)
-else()
+endif()
+
+if(CONFIG_INTEL)
 	add_subdirectory(intel)
 endif()
 

--- a/src/drivers/CMakeLists.txt
+++ b/src/drivers/CMakeLists.txt
@@ -4,5 +4,8 @@ if(CONFIG_IMX8)
 	add_subdirectory(imx)
 else()
 	add_subdirectory(intel)
+endif()
+
+if(CONFIG_DW)
 	add_subdirectory(dw)
 endif()

--- a/src/drivers/CMakeLists.txt
+++ b/src/drivers/CMakeLists.txt
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 if(CONFIG_IMX8)
-add_subdirectory(imx)
+	add_subdirectory(imx)
 else()
-add_subdirectory(intel)
-add_subdirectory(dw)
+	add_subdirectory(intel)
+	add_subdirectory(dw)
 endif()

--- a/src/drivers/Kconfig
+++ b/src/drivers/Kconfig
@@ -4,17 +4,6 @@ menu "Drivers"
 
 source "src/drivers/intel/cavs/Kconfig"
 
-config DW
-	bool
-	default n
-	help
-	  This has to be selected if platform supports Designware features.
-
-config DW_DMA
-	bool "Designware DMA driver"
-	depends on DW
-	default n
-	help
-	  Select this to enable support for the Designware DMA controller.
+source "src/drivers/dw/Kconfig"
 
 endmenu # "Drivers"

--- a/src/drivers/Kconfig
+++ b/src/drivers/Kconfig
@@ -4,8 +4,15 @@ menu "Drivers"
 
 source "src/drivers/intel/cavs/Kconfig"
 
+config DW
+	bool
+	default n
+	help
+	  This has to be selected if platform supports Designware features.
+
 config DW_DMA
 	bool "Designware DMA driver"
+	depends on DW
 	default n
 	help
 	  Select this to enable support for the Designware DMA controller.

--- a/src/drivers/dw/CMakeLists.txt
+++ b/src/drivers/dw/CMakeLists.txt
@@ -4,6 +4,10 @@ if(CONFIG_DW_DMA)
 	add_local_sources(sof dma.c)
 endif()
 
-if(CONFIG_SUECREEK)
-	add_local_sources(sof gpio.c ssi-spi.c)
+if(CONFIG_DW_GPIO)
+	add_local_sources(sof gpio.c)
+endif()
+
+if(CONFIG_DW_SPI)
+	add_local_sources(sof ssi-spi.c)
 endif()

--- a/src/drivers/dw/Kconfig
+++ b/src/drivers/dw/Kconfig
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+config DW
+	bool
+	default n
+	help
+	  This has to be selected if platform supports Designware features.
+
+if DW
+
+config DW_DMA
+	bool "Designware DMA driver"
+	default n
+	help
+	  Select this to enable support for the Designware DMA controller.
+
+config DW_SPI
+	bool
+	default n
+
+config DW_GPIO
+	bool
+	default n
+
+endif # DW

--- a/src/platform/Kconfig
+++ b/src/platform/Kconfig
@@ -130,7 +130,7 @@ config ICELAKE
 	select CAVS
 	select CAVS_VERSION_2_0
 	help
-		Select if your target platform is Icelake-compatible
+	  Select if your target platform is Icelake-compatible
 
 config LIBRARY
 	bool "Build Library"

--- a/src/platform/Kconfig
+++ b/src/platform/Kconfig
@@ -14,6 +14,7 @@ config BAYTRAIL
 	select DMA_AGGREGATED_IRQ
 	select DMA_SUSPEND_DRAIN
 	select DMA_FIFO_PARTITION
+	select DW
 	select DW_DMA
 	select HAVE_RESET_VECTOR_ROM
 	help
@@ -27,6 +28,7 @@ config CHERRYTRAIL
 	select DMA_AGGREGATED_IRQ
 	select DMA_SUSPEND_DRAIN
 	select DMA_FIFO_PARTITION
+	select DW
 	select DW_DMA
 	select HAVE_RESET_VECTOR_ROM
 	help
@@ -37,6 +39,7 @@ config HASWELL
 	select HOST_PTABLE
 	select TASK_HAVE_PRIORITY_LOW
 	select DMA_AGGREGATED_IRQ
+	select DW
 	select DW_DMA
 	select HAVE_RESET_VECTOR_ROM
 	help
@@ -47,6 +50,7 @@ config BROADWELL
 	select HOST_PTABLE
 	select TASK_HAVE_PRIORITY_LOW
 	select DMA_AGGREGATED_IRQ
+	select DW
 	select DW_DMA
 	select HAVE_RESET_VECTOR_ROM
 	help
@@ -57,6 +61,7 @@ config APOLLOLAKE
 	select BOOT_LOADER
 	select IRQ_MAP
 	select DMA_GW
+	select DW
 	select DW_DMA
 	select MEM_WND
 	select TASK_HAVE_PRIORITY_LOW
@@ -73,6 +78,7 @@ config CANNONLAKE
 	select BOOT_LOADER
 	select IRQ_MAP
 	select DMA_GW
+	select DW
 	select DW_DMA
 	select MEM_WND
 	select TASK_HAVE_PRIORITY_LOW
@@ -89,6 +95,7 @@ config SUECREEK
 	bool "Build for Suecreek"
 	select BOOT_LOADER
 	select IRQ_MAP
+	select DW
 	select DW_DMA
 	select TASK_HAVE_PRIORITY_LOW
 	select TASK_HAVE_PRIORITY_MEDIUM
@@ -108,6 +115,7 @@ config ICELAKE
 	select BOOT_LOADER
 	select IRQ_MAP
 	select DMA_GW
+	select DW
 	select DW_DMA
 	select MEM_WND
 	select TASK_HAVE_PRIORITY_LOW

--- a/src/platform/Kconfig
+++ b/src/platform/Kconfig
@@ -17,6 +17,7 @@ config BAYTRAIL
 	select DW
 	select DW_DMA
 	select HAVE_RESET_VECTOR_ROM
+	select INTEL
 	help
 	  Select if your target platform is Baytrail-compatible
 
@@ -31,6 +32,7 @@ config CHERRYTRAIL
 	select DW
 	select DW_DMA
 	select HAVE_RESET_VECTOR_ROM
+	select INTEL
 	help
 	  Select if your target platform is Cherrytrail-compatible
 
@@ -42,6 +44,7 @@ config HASWELL
 	select DW
 	select DW_DMA
 	select HAVE_RESET_VECTOR_ROM
+	select INTEL
 	help
 	  Select if your target platform is Haswell-compatible
 
@@ -53,6 +56,7 @@ config BROADWELL
 	select DW
 	select DW_DMA
 	select HAVE_RESET_VECTOR_ROM
+	select INTEL
 	help
 	  Select if your target platform is Broadwell-compatible
 
@@ -144,9 +148,17 @@ config IMX8
 
 endchoice
 
+config INTEL
+	bool
+	default n
+	help
+	  This has to be selected for every Intel platform.
+	  It enables Intel platforms-specific features.
+
 config CAVS
 	bool
 	default n
+	select INTEL
 
 config CAVS_VERSION_1_5
 	depends on CAVS


### PR DESCRIPTION
Resolves #1484 

Every platform should be handled in the same way. Not like it was now that we have some case for non-intel platform and fallback/default for Intel.

~~Assuming CONIG_CAVS is for intel as for now CAVS==INTEL and there is no point in adding symbol that will be 100% overlapping with another. We can add CONFIG_INTEL symbol when there will be non-cavs intel platform.~~ 
Forgot that we have byt&hsw also, so turns out we need that config.