### PR TITLE
platform: fix compile error if PLATFORM_CORE_COUNT is 1

### DIFF
--- a/src/platform/intel/cavs/memory.c
+++ b/src/platform/intel/cavs/memory.c
@@ -18,12 +18,14 @@ static struct block_hdr sys_rt_0_block512[HEAP_SYS_RT_0_COUNT512];
 static struct block_hdr sys_rt_0_block1024[HEAP_SYS_RT_0_COUNT1024];
 
 /* Heap blocks for system runtime for slave core */
+#if PLATFORM_CORE_COUNT > 1
 static struct block_hdr
 	sys_rt_x_block64[PLATFORM_CORE_COUNT - 1][HEAP_SYS_RT_X_COUNT64];
 static struct block_hdr
 	sys_rt_x_block512[PLATFORM_CORE_COUNT - 1][HEAP_SYS_RT_X_COUNT512];
 static struct block_hdr
 	sys_rt_x_block1024[PLATFORM_CORE_COUNT - 1][HEAP_SYS_RT_X_COUNT1024];
+#endif
 
 /* Heap memory for system runtime */
 static struct block_map sys_rt_heap_map[PLATFORM_CORE_COUNT][3] = {


### PR DESCRIPTION
Structs sys_rt_x_blockXXX should not be created if not used

Signed-off-by: Adrian Bonislawski <adrian.bonislawski@linux.intel.com>