### PR TITLE
component: split comp_set_period_bytes method

### DIFF
--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -181,31 +181,6 @@ int comp_set_state(struct comp_dev *dev, int cmd)
 	return ret;
 }
 
-/* set period bytes based on source/sink format */
-void comp_set_period_bytes(struct comp_dev *dev, uint32_t frames,
-			   enum sof_ipc_frame *format, uint32_t *period_bytes)
-{
-	struct sof_ipc_comp_config *sconfig;
-
-	/* get data format */
-	switch (dev->comp.type) {
-	case SOF_COMP_DAI:
-	case SOF_COMP_SG_DAI:
-		/* format comes from DAI/comp config */
-		sconfig = COMP_GET_CONFIG(dev);
-		*format = sconfig->frame_fmt;
-		break;
-	case SOF_COMP_HOST:
-	case SOF_COMP_SG_HOST:
-	default:
-		/* format comes from IPC params */
-		*format = dev->params.frame_fmt;
-		break;
-	}
-
-	*period_bytes = frames * comp_frame_bytes(dev);
-}
-
 void sys_comp_init(void)
 {
 	cd = rzalloc(RZONE_SYS, SOF_MEM_CAPS_RAM, sizeof(*cd));

--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -691,7 +691,6 @@ static int eq_fir_prepare(struct comp_dev *dev)
 	struct sof_ipc_comp_config *config = COMP_GET_CONFIG(dev);
 	struct comp_buffer *sourceb;
 	struct comp_buffer *sinkb;
-	uint32_t source_period_bytes;
 	uint32_t sink_period_bytes;
 	int ret;
 
@@ -711,12 +710,11 @@ static int eq_fir_prepare(struct comp_dev *dev)
 				struct comp_buffer, source_list);
 
 	/* get source data format */
-	comp_set_period_bytes(sourceb->source, dev->frames, &cd->source_format,
-			      &source_period_bytes);
+	cd->source_format = comp_frame_fmt(sourceb->source);
 
-	/* get sink data format */
-	comp_set_period_bytes(sinkb->sink, dev->frames, &cd->sink_format,
-			      &sink_period_bytes);
+	/* get sink data format and period bytes */
+	cd->sink_format = comp_frame_fmt(sinkb->sink);
+	sink_period_bytes = comp_period_bytes(sinkb->sink, dev->frames);
 
 	/* Rewrite params format for this component to match the host side. */
 	if (dev->params.direction == SOF_IPC_STREAM_PLAYBACK)

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -738,7 +738,6 @@ static int eq_iir_prepare(struct comp_dev *dev)
 	struct sof_ipc_comp_config *config = COMP_GET_CONFIG(dev);
 	struct comp_buffer *sourceb;
 	struct comp_buffer *sinkb;
-	uint32_t source_period_bytes;
 	uint32_t sink_period_bytes;
 	int ret;
 
@@ -758,12 +757,11 @@ static int eq_iir_prepare(struct comp_dev *dev)
 				struct comp_buffer, source_list);
 
 	/* get source data format */
-	comp_set_period_bytes(sourceb->source, dev->frames, &cd->source_format,
-			      &source_period_bytes);
+	cd->source_format = comp_frame_fmt(sourceb->source);
 
-	/* get sink data format */
-	comp_set_period_bytes(sinkb->sink, dev->frames, &cd->sink_format,
-			      &sink_period_bytes);
+	/* get sink data format and period bytes */
+	cd->sink_format = comp_frame_fmt(sinkb->sink);
+	sink_period_bytes = comp_period_bytes(sinkb->sink, dev->frames);
 
 	/* Rewrite params format for this component to match the host side. */
 	if (dev->params.direction == SOF_IPC_STREAM_PLAYBACK)

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -373,12 +373,13 @@ static int selector_prepare(struct comp_dev *dev)
 				source_list);
 
 	/* get source data format and period bytes */
-	comp_set_period_bytes(sourceb->source, dev->frames, &cd->source_format,
-			      &cd->source_period_bytes);
+	cd->source_format = comp_frame_fmt(sourceb->source);
+	cd->source_period_bytes = comp_period_bytes(sourceb->source,
+						    dev->frames);
 
 	/* get sink data format and period bytes */
-	comp_set_period_bytes(sinkb->sink, dev->frames, &cd->sink_format,
-			      &cd->sink_period_bytes);
+	cd->sink_format = comp_frame_fmt(sinkb->sink);
+	cd->sink_period_bytes = comp_period_bytes(sinkb->sink, dev->frames);
 
 	/* There is an assumption that sink component will report out
 	 * proper number of channels [1] for selector to actually

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -843,13 +843,13 @@ static int src_prepare(struct comp_dev *dev)
 	sinkb = list_first_item(&dev->bsink_list,
 				struct comp_buffer, source_list);
 
-	/* get source data format */
-	comp_set_period_bytes(sourceb->source, dev->frames, &cd->source_format,
-			      &source_period_bytes);
+	/* get source data format and period bytes */
+	cd->source_format = comp_frame_fmt(sourceb->source);
+	source_period_bytes = comp_period_bytes(sourceb->source, dev->frames);
 
-	/* get sink data format */
-	comp_set_period_bytes(sinkb->sink, dev->frames, &cd->sink_format,
-			      &sink_period_bytes);
+	/* get sink data format and period bytes */
+	cd->sink_format = comp_frame_fmt(sinkb->sink);
+	sink_period_bytes = comp_period_bytes(sinkb->sink, dev->frames);
 
 	/* Rewrite params format for this component to match the host side. */
 	if (dev->params.direction == SOF_IPC_STREAM_PLAYBACK)

--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -534,13 +534,13 @@ static int volume_prepare(struct comp_dev *dev)
 	sinkb = list_first_item(&dev->bsink_list,
 				struct comp_buffer, source_list);
 
-	/* get source data format */
-	comp_set_period_bytes(sourceb->source, dev->frames, &cd->source_format,
-			      &source_period_bytes);
+	/* get source data format and period bytes */
+	cd->source_format = comp_frame_fmt(sourceb->source);
+	source_period_bytes = comp_period_bytes(sourceb->source, dev->frames);
 
-	/* get sink data format */
-	comp_set_period_bytes(sinkb->sink, dev->frames, &cd->sink_format,
-			      &sink_period_bytes);
+	/* get sink data format and period bytes */
+	cd->sink_format = comp_frame_fmt(sinkb->sink);
+	sink_period_bytes = comp_period_bytes(sinkb->sink, dev->frames);
 
 	/* Rewrite params format for this component to match the host side. */
 	if (dev->params.direction == SOF_IPC_STREAM_PLAYBACK)


### PR DESCRIPTION
Splits comp_set_period_bytes method to two separate
functions: comp_frame_fmt and comp_period_bytes.
Setting these two parameters in one function wasn't
intuitive nor atomic enough. Also setting value typed
variables through reference isn't pretty.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>