### PR TITLE
boot_loader: remove deprecated comment

### DIFF
--- a/src/arch/xtensa/boot_loader.c
+++ b/src/arch/xtensa/boot_loader.c
@@ -236,7 +236,6 @@ void boot_master_core(void)
 {
 	int32_t result;
 
-	/* TODO: platform trace should write to HW IPC regs on CNL */
 	platform_trace_point(TRACE_BOOT_LDR_ENTRY);
 
 	/* init the HPSRAM */


### PR DESCRIPTION
Removes deprecated comment from boot_loader.
Memory window is enabled by ROM even before
FW is loaded, so there is no need for usage
of additional registers.

Closes #1389.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>