### PR TITLE
 component: remove checks for xruns

### DIFF
--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -196,24 +196,6 @@ int comp_get_copy_limits(struct comp_dev *dev, struct comp_copy_limits *cl)
 	cl->sink = list_first_item(&dev->bsink_list, struct comp_buffer,
 				   source_list);
 
-	/* check for underrun */
-	if (cl->source->avail == 0) {
-		trace_comp_error("comp_get_copy_limits() error: "
-				 "source component buffer"
-				 " has not enough data available");
-		comp_underrun(dev, cl->source, 0, 0);
-		return -EIO;
-	}
-
-	/* check for overrun */
-	if (cl->sink->free == 0) {
-		trace_comp_error("comp_get_copy_limits() error: "
-				 "sink component buffer"
-				 " has not enough free bytes for copy");
-		comp_overrun(dev, cl->sink, 0, 0);
-		return -EIO;
-	}
-
 	cl->frames = comp_avail_frames(cl->source, cl->sink);
 	cl->source_frame_bytes = comp_frame_bytes(cl->source->source);
 	cl->sink_frame_bytes = comp_frame_bytes(cl->sink->sink);

--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -560,12 +560,12 @@ static int dai_check_for_xrun(struct comp_dev *dev, uint32_t copy_bytes)
 		trace_dai_error_with_ids(dev, "dai_check_for_xrun() "
 					 "error: underrun due to no data "
 					 "available");
-		comp_underrun(dev, dd->dma_buffer, copy_bytes, 0);
+		comp_underrun(dev, dd->dma_buffer, copy_bytes);
 	} else {
 		trace_dai_error_with_ids(dev, "dai_check_for_xrun() "
 					 "error: overrun due to no data "
 					 "available");
-		comp_overrun(dev, dd->dma_buffer, copy_bytes, 0);
+		comp_overrun(dev, dd->dma_buffer, copy_bytes);
 	}
 
 	return -ENODATA;

--- a/src/audio/detect_test.c
+++ b/src/audio/detect_test.c
@@ -573,17 +573,6 @@ static int test_keyword_copy(struct comp_dev *dev)
 	source = list_first_item(&dev->bsource_list,
 				 struct comp_buffer, sink_list);
 
-	/* make sure source component buffer has enough data available for copy
-	 * Also check for XRUNs
-	 */
-	if (!source->avail) {
-		trace_keyword_error("test_keyword_copy() error: "
-				   "source component buffer"
-				   " has not enough data available");
-		comp_underrun(dev, source, 1, 0);
-		return -EIO;	/* xrun */
-	}
-
 	/* copy and perform detection */
 	cd->detect_func(dev, source,
 			source->avail / comp_frame_bytes(dev));

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -482,23 +482,6 @@ static int kpb_copy(struct comp_dev *dev)
 		return -EIO;
 	if (!source->r_ptr || !sink->w_ptr)
 		return -EINVAL;
-	/* Check if there is enough free/available space */
-	if (sink->free == 0) {
-		trace_kpb_error("kpb_copy() error: "
-				"sink component buffer"
-				" has not enough free bytes for copy");
-		comp_overrun(dev, sink, sink->free, 0);
-		/* xrun */
-		return -EIO;
-	}
-	if (source->avail == 0) {
-		trace_kpb_error("kpb_copy() error: "
-				"source component buffer"
-				" has not enough data available");
-		comp_underrun(dev, source, source->avail, 0);
-		/* xrun */
-		return -EIO;
-	}
 
 	/* Sink and source are both ready and have space */
 	copy_bytes = MIN(sink->free, source->avail);

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -270,26 +270,9 @@ static int mixer_copy(struct comp_dev *dev)
 	if (num_mix_sources == 0)
 		return 0;
 
-	/* check for overrun */
-	if (sink->free == 0) {
-		trace_mixer_error("mixer_copy() error: sink component buffer "
-				  "has not enough free bytes for copy");
-		comp_overrun(dev, sink, 0, 0);
-		return -EIO;
-	}
-
 	/* check for underruns */
-	for (i = 0; i < num_mix_sources; i++) {
-		if (sources[i]->avail == 0) {
-			trace_mixer_error("mixer_copy() error: source %u "
-					  "component buffer has not enough "
-					  "data available", i);
-			comp_underrun(dev, sources[i], 0, 0);
-			return -EIO;
-		}
-
+	for (i = 0; i < num_mix_sources; i++)
 		frames = MIN(frames, comp_avail_frames(sources[i], sink));
-	}
 
 	/* Every source has the same format, so calculate bytes based
 	 * on the first one.

--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -234,14 +234,6 @@ static int demux_copy(struct comp_dev *dev)
 	if (source->source->state != dev->state)
 		return 0;
 
-	/* check for underrun */
-	if (source->avail == 0) {
-		trace_mux_error("demux_copy() error: source component buffer "
-				"has not enough data avaialble.");
-		comp_underrun(dev, source, 0, 0);
-		return -EIO;
-	}
-
 	for (i = 0; i < MUX_MAX_STREAMS; i++) {
 		if (!sinks[i])
 			continue;
@@ -310,27 +302,6 @@ static int mux_copy(struct comp_dev *dev)
 	/* check if sink is active */
 	if (sink->sink->state != dev->state)
 		return 0;
-
-	/* check for underrun */
-	for (i = 0; i < MUX_MAX_STREAMS; i++) {
-		if (!sources[i])
-			continue;
-		if (sources[i]->avail == 0) {
-			trace_mux_error("mux_copy() error: source "
-					"component buffer has not enough data "
-					"avaialble.");
-			comp_underrun(dev, sources[i], 0, 0);
-			return -EIO;
-		}
-	}
-
-	/* check for overrun */
-	if (sink->free == 0) {
-		trace_mux_error("mux_copy() error: sink component "
-				"buffer has not enough free bytes.");
-		comp_overrun(dev, sink, 0, 0);
-		return -EIO;
-	}
 
 	for (i = 0; i < MUX_MAX_STREAMS; i++) {
 		if (!sources[i])

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -309,24 +309,6 @@ static int selector_copy(struct comp_dev *dev)
 	sink = list_first_item(&dev->bsink_list, struct comp_buffer,
 			       source_list);
 
-	/* check for underrun */
-	if (source->avail == 0) {
-		trace_selector_error("selector_copy() error: "
-				     "source component buffer has not enough "
-				     "data available");
-		comp_underrun(dev, source, 0, 0);
-		return -EIO;
-	}
-
-	/* check for overrun */
-	if (sink->free == 0) {
-		trace_selector_error("selector_copy() error: "
-				     "sink component buffer has not enough "
-				     "free bytes for copy");
-		comp_overrun(dev, sink, 0, 0);
-		return -EIO;
-	}
-
 	frames = comp_avail_frames(source, sink);
 	source_bytes = frames * comp_frame_bytes(source->source);
 	sink_bytes = frames * comp_frame_bytes(sink->sink);

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -749,20 +749,6 @@ static int src_copy(struct comp_dev *dev)
 	sink = list_first_item(&dev->bsink_list, struct comp_buffer,
 			       source_list);
 
-	/* check for underrun */
-	if (source->avail == 0) {
-		trace_src_error("src_copy() error: Empty source buffer.");
-		comp_underrun(dev, source, 0, 0);
-		return -EIO;
-	}
-
-	/* check for overrun */
-	if (sink->free == 0) {
-		trace_src_error("src_copy() error: Full sink buffer.");
-		comp_overrun(dev, sink, 0, 0);
-		return -EIO;
-	}
-
 	/* Get from buffers and SRC conversion specific block constraints
 	 * how many frames can be processed. If sufficient number of samples
 	 * is not available the processing is omitted.

--- a/src/audio/tone.c
+++ b/src/audio/tone.c
@@ -630,11 +630,7 @@ static int tone_copy(struct comp_dev *dev)
 		return dev->frames;
 	}
 
-	/* XRUN */
-	trace_tone_error("tone_copy() error: "
-			 "sink has not enough free frames");
-	comp_overrun(dev, sink, cd->period_bytes, sink->free);
-	return -EIO;
+	return 0;
 }
 
 static int tone_prepare(struct comp_dev *dev)

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -722,16 +722,14 @@ static inline int comp_get_endpoint_type(struct comp_dev *dev)
  * @param dev Component device.
  * @param source Source buffer.
  * @param copy_bytes Requested size of data to be available.
- * @param min_bytes
  */
 static inline void comp_underrun(struct comp_dev *dev,
 				 struct comp_buffer *source,
-				 uint32_t copy_bytes, uint32_t min_bytes)
+				 uint32_t copy_bytes)
 {
-	trace_comp("comp_underrun(), ((dev->comp.id << 16) | source->avail) ="
-		   " %u, ((min_bytes << 16) | copy_bytes) = %u",
-		  (dev->comp.id << 16) | source->avail,
-		  (min_bytes << 16) | copy_bytes);
+	trace_comp_error("comp_underrun() error: dev->comp.id = %u, "
+			 "source->avail = %u, copy_bytes = %u", dev->comp.id,
+			 source->avail, copy_bytes);
 
 	pipeline_xrun(dev->pipeline, dev, (int32_t)source->avail - copy_bytes);
 }
@@ -741,15 +739,13 @@ static inline void comp_underrun(struct comp_dev *dev,
  * @param dev Component device.
  * @param sink Sink buffer.
  * @param copy_bytes Requested size of free space to be available.
- * @param min_bytes
  */
 static inline void comp_overrun(struct comp_dev *dev, struct comp_buffer *sink,
-	uint32_t copy_bytes, uint32_t min_bytes)
+				uint32_t copy_bytes)
 {
-	trace_comp("comp_overrun(), ((dev->comp.id << 16) | sink->free) = %u, "
-		   "((min_bytes << 16) | copy_bytes) = %u",
-		  (dev->comp.id << 16) | sink->free,
-		  (min_bytes << 16) | copy_bytes);
+	trace_comp_error("comp_overrun() error: dev->comp.id = %u, sink->free "
+			 "= %u, copy_bytes = %u", dev->comp.id, sink->free,
+			 copy_bytes);
 
 	pipeline_xrun(dev->pipeline, dev, (int32_t)copy_bytes - sink->free);
 }


### PR DESCRIPTION
Removes checks for xruns in all components besides
dai. There is no need to check for underrun and
overrun in every component, because no free or avail
space in buffer doesn't mean that data is not continuous.
We can have processing modules inside the pipeline, which
work on different frame sizes than rest of the pipe. In
such cases we will detect false xrun. In the future we
can think about adding xruns checks to the components,
which will be connection points for multiple pipelines
e.g. separate pipe with the mixer in the beginning.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>