### PR TITLE
memory: remove align to memory bank in APL

### DIFF
--- a/src/platform/apollolake/apollolake.x.in
+++ b/src/platform/apollolake/apollolake.x.in
@@ -476,22 +476,22 @@ SECTIONS
     *(.gnu.linkonce.b.*)
     *(COMMON)
 
-    . = ALIGN (SRAM_BANK_SIZE);
+    . = ALIGN (HEAP_BUF_ALIGNMENT);
     _runtime_heap_start = ABSOLUTE(.);
     . = . + HEAP_RUNTIME_SIZE;
     _runtime_heap_end = ABSOLUTE(.);
 
-    . = ALIGN (32);
+    . = ALIGN (HEAP_BUF_ALIGNMENT);
     _buffer_heap_start = ABSOLUTE(.);
     . = . + HEAP_BUFFER_SIZE;
     _buffer_heap_end = ABSOLUTE(.);
 
-    . = ALIGN (SRAM_BANK_SIZE);
+    . = ALIGN (HEAP_BUF_ALIGNMENT);
     _system_heap_start = ABSOLUTE(.);
     . = . + HEAP_SYSTEM_M_SIZE;
     _system_heap_end = ABSOLUTE(.);
 
-    . = ALIGN (32);
+    . = ALIGN (HEAP_BUF_ALIGNMENT);
     _system_runtime_heap_start = ABSOLUTE(.);
     . = . + HEAP_SYS_RUNTIME_M_SIZE;
     _system_runtime_heap_end = ABSOLUTE(.);
@@ -501,7 +501,7 @@ SECTIONS
     . = . + SOF_STACK_SIZE;
     _sof_stack_end = ABSOLUTE(.);
 
-    . = ALIGN (SRAM_BANK_SIZE);
+    . = ALIGN (HEAP_BUF_ALIGNMENT);
     _sof_core_s_start = ABSOLUTE(.);
     . = . + SOF_CORE_S_T_SIZE;
     _sof_core_s_end = ABSOLUTE(.);


### PR DESCRIPTION
Due to small number of memory banks in APL it will be not possible to power down some of them
so there is no point in align to memory banks, this would significantly limit free memory for buffers

Signed-off-by: Adrian Bonislawski <adrian.bonislawski@linux.intel.com>