### PR TITLE
[do not merge] kpb: revert assertions on memcpy_s in kpb_buffer_data()

### DIFF
--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -911,7 +911,7 @@ static void kpb_clear_history_buffer(struct hb *buff)
 	void *start_addr;
 	size_t size;
 
-	trace_kpb("kpb_init_draining()");
+	trace_kpb("kpb_clear_history_buffer()");
 
 	do {
 		start_addr = buff->start_addr;

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -551,8 +551,8 @@ static void kpb_buffer_data(struct comp_data *kpb, struct comp_buffer *source,
 			 * in this buffer, copy what's available and continue
 			 * with next buffer.
 			 */
-			assert(!memcpy_s(buff->w_ptr, space_avail, read_ptr,
-					 space_avail));
+			memcpy_s(buff->w_ptr, space_avail, read_ptr,
+				 space_avail);
 			/* Update write pointer & requested copy size */
 			buff->w_ptr += space_avail;
 			size_to_copy = size_to_copy - space_avail;
@@ -565,8 +565,8 @@ static void kpb_buffer_data(struct comp_data *kpb, struct comp_buffer *source,
 			 * available in this buffer. In this scenario simply
 			 * copy what was requested.
 			 */
-			assert(!memcpy_s(buff->w_ptr, size_to_copy, read_ptr,
-					 size_to_copy));
+			memcpy_s(buff->w_ptr, size_to_copy, read_ptr,
+				 size_to_copy);
 			/* Update write pointer & requested copy size */
 			buff->w_ptr += size_to_copy;
 			/* Reset requested copy size */


### PR DESCRIPTION
This patch fixed the issue of panic during buffering
on HPSRAM memory banks. This panic was caused by assert function
introduced in commit 56b8776c2ace20