### PR TITLE
kwd: align copy function to support 32 bit sample containers

### DIFF
--- a/src/audio/detect_test.c
+++ b/src/audio/detect_test.c
@@ -101,6 +101,7 @@ static void default_detect_test(struct comp_dev *dev,
 	int16_t step;
 	uint32_t count = frames; /**< Assuming single channel */
 	uint32_t sample;
+	uint32_t sample_width = dev->params.sample_container_bytes;
 
 	/* synthetic load */
 	if (cd->config.load_mips)
@@ -108,7 +109,9 @@ static void default_detect_test(struct comp_dev *dev,
 
 	/* perform detection within current period */
 	for (sample = 0; sample < count && !cd->detected; ++sample) {
-		src = buffer_read_frag_s16(source, sample);
+		src = (sample_width == 16) ?
+		       buffer_read_frag_s16(source, sample) :
+		       buffer_read_frag_s32(source, sample);
 		diff = abs(*src) - cd->activation;
 		step = diff >> cd->config.activation_shift;
 

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -891,7 +891,9 @@ static void kpb_drain_samples(void *source, struct comp_buffer *sink,
 
 	for (i = 0; i < frames; i++) {
 		for (channel = 0; channel < KPB_NR_OF_CHANNELS; channel++) {
-			dest = buffer_write_frag_s16(sink, j);
+			dest = (sample_width == 16) ?
+				buffer_write_frag_s16(sink, j) :
+				buffer_write_frag_s32(sink, j);
 			*dest = *src;
 			src++;
 			j++;
@@ -1012,8 +1014,13 @@ static void kpb_copy_samples(struct comp_buffer *sink,
 
 	for (i = 0; i < frames; i++) {
 		for (channel = 0; channel < KPB_NR_OF_CHANNELS; channel++) {
-			src = buffer_read_frag_s16(source, j);
-			dest = buffer_write_frag_s16(sink, j);
+			src = (sample_width == 16) ?
+			       buffer_read_frag_s16(source, j) :
+			       buffer_read_frag_s32(source, j);
+
+			dest = (sample_width == 16) ?
+				buffer_write_frag_s16(sink, j) :
+				buffer_write_frag_s32(sink, j);
 			*dest = *src;
 			j++;
 		}


### PR DESCRIPTION
This patch enables use of 24 bit samples packed in 32
bin containers.

Signed-off-by: Marcin Rajwa <marcin.rajwa@linux.intel.com>