### PR TITLE
buffer: remove circular dependency

### DIFF
--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -14,11 +14,12 @@
 #include <sof/list.h>
 #include <sof/stream.h>
 #include <sof/dma.h>
-#include <sof/audio/component.h>
 #include <sof/trace.h>
 #include <sof/schedule.h>
 #include <sof/cache.h>
 #include <ipc/topology.h>
+
+struct comp_dev;
 
 /* pipeline tracing */
 #define trace_buffer(__e, ...) \


### PR DESCRIPTION
Removes circular dependency between buffer and component
header files.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>