### PR TITLE
host: unify component for all DMA types

### DIFF
--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -5,24 +5,23 @@
 // Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
 //         Keyon Jie <yang.jie@linux.intel.com>
 
-#include <stdint.h>
-#include <stdbool.h>
-#include <stddef.h>
-#include <errno.h>
-#include <sof/sof.h>
-#include <sof/lock.h>
-#include <sof/list.h>
-#include <sof/stream.h>
+#include <arch/cache.h>
+#include <ipc/stream.h>
+#include <ipc/topology.h>
 #include <sof/alloc.h>
-#include <sof/trace.h>
-#include <sof/dma.h>
-#include <sof/ipc.h>
-#include <sof/wait.h>
+#include <sof/audio/buffer.h>
 #include <sof/audio/component.h>
 #include <sof/audio/pipeline.h>
-#include <platform/dma.h>
-#include <arch/cache.h>
-#include <ipc/dai.h>
+#include <sof/dma.h>
+#include <sof/ipc.h>
+#include <sof/list.h>
+#include <sof/math/numbers.h>
+#include <sof/sof.h>
+#include <sof/trace.h>
+#include <errno.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
 
 #define trace_host(__e, ...) \
 	trace_event(TRACE_CLASS_HOST, __e, ##__VA_ARGS__)

--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -730,9 +730,7 @@ static int host_copy_one_shot(struct comp_dev *dev)
 /* copy and process stream data from source to sink buffers */
 static int host_copy(struct comp_dev *dev)
 {
-#if CONFIG_DMA_GW
 	struct host_data *hd = comp_get_drvdata(dev);
-#endif
 	int ret = 0;
 
 	tracev_host("host_copy()");
@@ -740,10 +738,6 @@ static int host_copy(struct comp_dev *dev)
 	if (dev->state != COMP_STATE_ACTIVE)
 		return 0;
 
-	/* TODO: this could be run-time if() based on the same attribute
-	 * as in the host_trigger().
-	 */
-#if CONFIG_DMA_GW
 	/* here only do preload, further copies happen
 	 * in host_buffer_cb()
 	 */
@@ -763,10 +757,6 @@ static int host_copy(struct comp_dev *dev)
 			return ret;
 		}
 	}
-#endif
-	/* For !CONFIG_DMA_GW preload happens in host_trigger() and
-	 * further copies happen in host_buffer_cb()
-	 */
 
 	return ret;
 }

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -684,6 +684,7 @@ static void kpb_init_draining(struct comp_data *kpb, struct kpb_client *cli)
 	struct hb *first_buff = buff;
 	size_t buffered = 0;
 	size_t local_buffered = 0;
+	uint32_t attr = 1;
 
 	trace_kpb("kpb_init_draining()");
 
@@ -767,7 +768,7 @@ static void kpb_init_draining(struct comp_data *kpb, struct kpb_client *cli)
 
 		/* Set host-sink copy mode to blocking */
 		comp_set_attribute(kpb->host_sink->sink,
-				   COMP_ATTR_COPY_BLOCKING, 1);
+				   COMP_ATTR_COPY_BLOCKING, &attr);
 
 		/* Schedule draining task */
 		schedule_task(&kpb->draining_task, 0, 0,
@@ -796,6 +797,7 @@ static uint64_t kpb_draining_task(void *arg)
 	uint32_t drained = 0;
 	uint64_t time_start;
 	uint64_t time_end;
+	uint32_t attr = 0;
 
 	trace_kpb("kpb_draining_task(), start.");
 
@@ -842,7 +844,7 @@ static uint64_t kpb_draining_task(void *arg)
 	*draining_data->state = KPB_STATE_HOST_COPY;
 
 	/* Reset host-sink copy mode back to unblocking */
-	comp_set_attribute(sink->sink, COMP_ATTR_COPY_BLOCKING, 0);
+	comp_set_attribute(sink->sink, COMP_ATTR_COPY_BLOCKING, &attr);
 
 	trace_kpb("kpb_draining_task(), done. %u drained in %d ms.",
 		   drained,

--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -1028,6 +1028,10 @@ static int dw_dma_copy(struct dma *dma, unsigned int channel, int bytes,
 		return -EINVAL;
 	}
 
+	/* do nothing on preload */
+	if (flags & DMA_COPY_PRELOAD)
+		return 0;
+
 	tracev_dwdma("dw_dma_copy(): dma %d channel %d copy",
 		     dma->plat_data.id, channel);
 

--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -1032,6 +1032,10 @@ static int dw_dma_copy(struct dma *dma, unsigned int channel, int bytes,
 	if (flags & DMA_COPY_PRELOAD)
 		return 0;
 
+	/* for one shot copy just start DMA */
+	if (flags & DMA_COPY_ONE_SHOT)
+		return dw_dma_start(dma, channel);
+
 	tracev_dwdma("dw_dma_copy(): dma %d channel %d copy",
 		     dma->plat_data.id, channel);
 

--- a/src/drivers/intel/cavs/hda-dma.c
+++ b/src/drivers/intel/cavs/hda-dma.c
@@ -687,6 +687,9 @@ static int hda_dma_set_config(struct dma *dma, unsigned int channel,
 		return -EINVAL;
 	}
 
+	if (p->chan[channel].status == COMP_STATE_ACTIVE)
+		return 0;
+
 	spin_lock_irq(&dma->lock, flags);
 
 	trace_hddma("hda-dmac: %d channel %d -> config", dma->plat_data.id,

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -131,6 +131,7 @@
  *  @{
  */
 #define COMP_ATTR_COPY_BLOCKING	0	/**< Comp blocking copy attribute */
+#define COMP_ATTR_HOST_BUFFER	1	/**< Comp host buffer attribute */
 /** @}*/
 
 /** \name Trace macros
@@ -192,11 +193,6 @@ struct comp_ops {
 	/** copy and process stream data from source to sink buffers */
 	int (*copy)(struct comp_dev *dev);
 
-	/** host buffer config */
-	int (*host_buffer)(struct comp_dev *dev,
-			   struct dma_sg_elem_array *elem_array,
-			   uint32_t host_size);
-
 	/** position */
 	int (*position)(struct comp_dev *dev,
 		struct sof_ipc_stream_posn *posn);
@@ -206,7 +202,7 @@ struct comp_ops {
 
 	/** set attribute in component */
 	int (*set_attribute)(struct comp_dev *dev, uint32_t type,
-			     uint32_t value);
+			     void *value);
 };
 
 
@@ -374,22 +370,6 @@ static inline int comp_params(struct comp_dev *dev)
 }
 
 /**
- * Component host buffer config.
- * Mandatory for host components, optional for the others.
- * @param dev Component device.
- * @param elem_array SG element array.
- * @param host_size Host ring buffer size.
- * @return 0 if succeeded, error code otherwise.
- */
-static inline int comp_host_buffer(struct comp_dev *dev,
-		struct dma_sg_elem_array *elem_array, uint32_t host_size)
-{
-	if (dev->drv->ops.host_buffer)
-		return dev->drv->ops.host_buffer(dev, elem_array, host_size);
-	return 0;
-}
-
-/**
  * Send component command.
  * @param dev Component device.
  * @param cmd Command.
@@ -508,11 +488,11 @@ static inline void comp_cache(struct comp_dev *dev, int cmd)
  * Sets component attribute.
  * @param dev Component device.
  * @param type Attribute type.
- * @param type Attribute value.
+ * @param value Attribute value.
  * @return 0 if succeeded, error code otherwise.
  */
 static inline int comp_set_attribute(struct comp_dev *dev, uint32_t type,
-				     uint32_t value)
+				     void *value)
 {
 	if (dev->drv->ops.set_attribute)
 		return dev->drv->ops.set_attribute(dev, type, value);

--- a/src/include/sof/dma.h
+++ b/src/include/sof/dma.h
@@ -330,15 +330,18 @@ void dma_sg_free(struct dma_sg_elem_array *ea);
 
 static inline void dma_sg_cache_wb_inv(struct dma_sg_elem_array *ea)
 {
-	dcache_writeback_invalidate_region(ea->elems,
-					   ea->count *
-					   sizeof(struct dma_sg_elem));
+	if (ea->elems)
+		dcache_writeback_invalidate_region(ea->elems,
+						   ea->count *
+						   sizeof(struct dma_sg_elem));
 }
 
 static inline void dma_sg_cache_inv(struct dma_sg_elem_array *ea)
 {
-	dcache_invalidate_region(ea->elems,
-				 ea->count * sizeof(struct dma_sg_elem));
+	if (ea->elems)
+		dcache_invalidate_region(ea->elems,
+					 ea->count *
+					 sizeof(struct dma_sg_elem));
 }
 
 /**

--- a/src/include/sof/dma.h
+++ b/src/include/sof/dma.h
@@ -65,6 +65,7 @@
 /* DMA copy flags */
 #define DMA_COPY_PRELOAD	BIT(0)
 #define DMA_COPY_BLOCKING	BIT(1)
+#define DMA_COPY_ONE_SHOT	BIT(2)
 
 /* We will use this enum in cb handler to inform dma what
  * action we need to perform.

--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -262,7 +262,7 @@ static int ipc_stream_pcm_params(uint32_t stream)
 	if (err < 0)
 		goto error;
 
-	err = comp_host_buffer(cd, &elem_array, ring_size);
+	err = comp_set_attribute(cd, COMP_ATTR_HOST_BUFFER, &elem_array);
 	if (err < 0) {
 		trace_ipc_error("ipc: comp %d host buffer failed %d",
 				pcm_params.comp_id, err);


### PR DESCRIPTION
Unifies host component for all DMA types.
We don't need to branch on CONFIG_DMA_GW anymore.

Closes #1052.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>