### PR TITLE
memcpy: fix bug in arch_memcpy_s

### DIFF
--- a/src/arch/host/include/arch/string.h
+++ b/src/arch/host/include/arch/string.h
@@ -32,8 +32,8 @@ static inline int arch_memcpy_s(void *dest, size_t dest_size,
 	if (!dest || !src)
 		return -EINVAL;
 
-	if ((dest + dest_size >= src && dest + dest_size <= src + src_size) ||
-		(src + src_size >= dest && src + src_size <= dest + dest_size))
+	if ((dest >= src && dest < (src + src_size)) ||
+	    (src >= dest && src < (dest + dest_size)))
 		return -EINVAL;
 
 	if (src_size > dest_size)

--- a/src/arch/xtensa/include/arch/string.h
+++ b/src/arch/xtensa/include/arch/string.h
@@ -43,8 +43,8 @@ static inline int arch_memcpy_s(void *dest, size_t dest_size,
 	if (!dest || !src)
 		return -EINVAL;
 
-	if ((dest + dest_size >= src && dest + dest_size <= src + src_size) ||
-		(src + src_size >= dest && src + src_size <= dest + dest_size))
+	if ((dest >= src && dest < (src + src_size)) ||
+	    (src >= dest && src < (dest + dest_size)))
 		return -EINVAL;
 
 	if (src_size > dest_size)

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -911,7 +911,7 @@ static void kpb_clear_history_buffer(struct hb *buff)
 	void *start_addr;
 	size_t size;
 
-	trace_kpb("kpb_init_draining()");
+	trace_kpb("kpb_clear_history_buffer()");
 
 	do {
 		start_addr = buff->start_addr;

--- a/test/cmocka/src/universal_mocks.c
+++ b/test/cmocka/src/universal_mocks.c
@@ -13,8 +13,8 @@ int memcpy_s(void *dest, size_t dest_size,
 	if (!dest || !src)
 		return -EINVAL;
 
-	if ((dest + dest_size >= src && dest + dest_size <= src + src_size) ||
-		(src + src_size >= dest && src + src_size <= dest + dest_size))
+	if ((dest >= src && dest < (src + src_size)) ||
+	    (src >= dest && src < (dest + dest_size)))
 		return -EINVAL;
 
 	if (src_size > dest_size)


### PR DESCRIPTION
The current implementation of arch_memcpy_s() doesn't
allow to copy from adjecent memory block. This patch fixes
this problem.
