### PR TITLE
 memory: make buffers aligned to CACHE_LINE_SIZE

### DIFF
--- a/src/platform/cannonlake/cannonlake.x.in
+++ b/src/platform/cannonlake/cannonlake.x.in
@@ -443,7 +443,7 @@ SECTIONS
     . = . + HEAP_RUNTIME_SIZE;
     _runtime_heap_end = ABSOLUTE(.);
 
-    . = ALIGN (32);
+    . = ALIGN (HEAP_BUF_ALIGNMENT);
     _buffer_heap_start = ABSOLUTE(.);
     . = . + HEAP_BUFFER_SIZE;
     _buffer_heap_end = ABSOLUTE(.);
@@ -453,7 +453,7 @@ SECTIONS
     . = . + HEAP_SYSTEM_M_SIZE;
     _system_heap_end = ABSOLUTE(.);
 
-    . = ALIGN (32);
+    . = ALIGN (HEAP_BUF_ALIGNMENT);
     _system_runtime_heap_start = ABSOLUTE(.);
     . = . + HEAP_SYS_RUNTIME_M_SIZE;
     _system_runtime_heap_end = ABSOLUTE(.);

--- a/src/platform/icelake/icelake.x.in
+++ b/src/platform/icelake/icelake.x.in
@@ -447,7 +447,7 @@ SECTIONS
     . = . + HEAP_RUNTIME_SIZE;
     _runtime_heap_end = ABSOLUTE(.);
 
-    . = ALIGN (32);
+    . = ALIGN (HEAP_BUF_ALIGNMENT);
     _buffer_heap_start = ABSOLUTE(.);
     . = . + HEAP_BUFFER_SIZE;
     _buffer_heap_end = ABSOLUTE(.);
@@ -457,7 +457,7 @@ SECTIONS
     . = . + HEAP_SYSTEM_M_SIZE;
     _system_heap_end = ABSOLUTE(.);
 
-    . = ALIGN (32);
+    . = ALIGN (HEAP_BUF_ALIGNMENT);
     _system_runtime_heap_start = ABSOLUTE(.);
     . = . + HEAP_SYS_RUNTIME_M_SIZE;
     _system_runtime_heap_end = ABSOLUTE(.);

--- a/src/platform/intel/cavs/include/cavs/memory.h
+++ b/src/platform/intel/cavs/include/cavs/memory.h
@@ -39,6 +39,8 @@
 
 #define LPSRAM_SIZE (PLATFORM_LPSRAM_EBB_COUNT * SRAM_BANK_SIZE)
 
+#define HEAP_BUF_ALIGNMENT		XCHAL_DCACHE_LINESIZE
+
 #if !defined(__ASSEMBLER__) && !defined(LINKER)
 void platform_init_memmap(void);
 #endif

--- a/src/platform/intel/cavs/memory.c
+++ b/src/platform/intel/cavs/memory.c
@@ -12,6 +12,10 @@
 extern uintptr_t _system_heap, _system_runtime_heap, _module_heap;
 extern uintptr_t _buffer_heap, _sof_core_s_start;
 
+/* Check if heap buffers alignment is valid */
+STATIC_ASSERT(0 == (HEAP_BUF_ALIGNMENT % PLATFORM_DCACHE_ALIGN),
+	      invalid_heap_buf_alignment);
+
 /* Heap blocks for system runtime for master core */
 static struct block_hdr sys_rt_0_block64[HEAP_SYS_RT_0_COUNT64];
 static struct block_hdr sys_rt_0_block512[HEAP_SYS_RT_0_COUNT512];

--- a/src/platform/suecreek/suecreek.x.in
+++ b/src/platform/suecreek/suecreek.x.in
@@ -438,7 +438,7 @@ SECTIONS
     . = . + HEAP_RUNTIME_SIZE;
     _runtime_heap_end = ABSOLUTE(.);
 
-    . = ALIGN (32);
+    . = ALIGN (HEAP_BUF_ALIGNMENT);
     _buffer_heap_start = ABSOLUTE(.);
     . = . + HEAP_BUFFER_SIZE;
     _buffer_heap_end = ABSOLUTE(.);
@@ -448,7 +448,7 @@ SECTIONS
     . = . + HEAP_SYSTEM_M_SIZE;
     _system_heap_end = ABSOLUTE(.);
 
-    . = ALIGN (32);
+    . = ALIGN (HEAP_BUF_ALIGNMENT);
     _system_runtime_heap_start = ABSOLUTE(.);
     . = . + HEAP_SYS_RUNTIME_M_SIZE;
     _system_runtime_heap_end = ABSOLUTE(.);


### PR DESCRIPTION
As adviced in PR #1557 it provides better memory/cache performance since it aligns with memory IO burst size and cache line size

This PR will use CACHE_LINE_SIZE in CNL, ICL and SUE
