### PR TITLE
sof-ctl: add support to binary input file.

### DIFF
--- a/tools/ctl/ctl.c
+++ b/tools/ctl/ctl.c
@@ -119,15 +119,41 @@ static void header_dump(struct ctl_data *ctl_data)
 		SOF_ABI_VERSION_PATCH(hdr->abi));
 }
 
-int main(int argc, char *argv[])
+/* dump binary data out with CSV txt format */
+static void csv_data_dump(struct ctl_data *ctl_data)
 {
 	uint32_t *config;
+	int n;
+	int i;
+
+	config = &ctl_data->buffer[2];
+	n = ctl_data->buffer[1] / sizeof(uint32_t);
+
+	/* Print out in CSV txt formal */
+	for (i = 0; i < n; i++) {
+		if (i == n - 1)
+			fprintf(stdout, "%u\n", config[i]);
+		else
+			fprintf(stdout, "%u,", config[i]);
+	}
+}
+
+/*
+ * Print the read kcontrol configuration data with either
+ * 16bit Hex binary format or ASCII CSV format.
+ */
+static void data_dump(struct ctl_data *ctl_data)
+{
+	csv_data_dump(ctl_data);
+}
+
+int main(int argc, char *argv[])
+{
 	char nname[256];
 	int ret;
 	int read;
 	int write;
 	int type;
-	int i;
 	char opt;
 	char *input_file = NULL;
 	struct ctl_data *ctl_data;
@@ -279,17 +305,7 @@ int main(int argc, char *argv[])
 
 		header_dump(ctl_data);
 
-		/* Print the read EQ configuration data with similar syntax
-		 * as the input file format.
-		 */
-		config = (uint32_t *)(ctl_data->buffer + 2);
-		n = ctl_data->buffer[1] / sizeof(uint32_t);
-		for (i = 0; i < n; i++) {
-			if (i == n - 1)
-				fprintf(stdout, "%u\n", config[i]);
-			else
-				fprintf(stdout, "%u,", config[i]);
-		}
+		data_dump(ctl_data);
 	}
 	free(ctl_data->buffer);
 	return 0;

--- a/tools/ctl/ctl.c
+++ b/tools/ctl/ctl.c
@@ -66,6 +66,16 @@ static void usage(char *name)
 	fprintf(stdout, " -b set/get control in binary mode(e.g. for set, use binary input file, for get, dump out in hex format)\n");
 }
 
+static void header_init(struct ctl_data *ctl_data)
+{
+	struct sof_abi_hdr *hdr =
+		(struct sof_abi_hdr *)&ctl_data->buffer[2];
+
+	hdr->magic = SOF_ABI_MAGIC;
+	hdr->type = 0;
+	hdr->abi = SOF_ABI_VERSION;
+}
+
 static int read_setup(struct ctl_data *ctl_data)
 {
 	FILE *fh;

--- a/tools/ctl/ctl.c
+++ b/tools/ctl/ctl.c
@@ -70,6 +70,7 @@ static void usage(char *name)
 	fprintf(stdout, " -b set/get control in binary mode(e.g. for set, use binary input file, for get, dump out in hex format)\n");
 	fprintf(stdout, " -r no abi header for the input file, or not dumping abi header for get.\n");
 	fprintf(stdout, " -o specify the output file.\n");
+	fprintf(stdout, " -t specify the component specified type.\n");
 }
 
 static void header_init(struct ctl_data *ctl_data)
@@ -78,7 +79,7 @@ static void header_init(struct ctl_data *ctl_data)
 		(struct sof_abi_hdr *)&ctl_data->buffer[BUFFER_ABI_OFFSET];
 
 	hdr->magic = SOF_ABI_MAGIC;
-	hdr->type = 0;
+	hdr->type = ctl_data->type;
 	hdr->abi = SOF_ABI_VERSION;
 }
 
@@ -376,7 +377,7 @@ int main(int argc, char *argv[])
 
 	ctl_data->dev = "hw:0";
 
-	while ((opt = getopt(argc, argv, "hD:c:s:n:o:br")) != -1) {
+	while ((opt = getopt(argc, argv, "hD:c:s:n:o:t:br")) != -1) {
 		switch (opt) {
 		case 'D':
 			ctl_data->dev = optarg;
@@ -402,6 +403,8 @@ int main(int argc, char *argv[])
 		case 'r':
 			ctl_data->no_abi = true;
 			break;
+		case 't':
+			ctl_data->type = atoi(optarg);
 			break;
 		case 'h':
 		/* pass through */

--- a/tools/ctl/ctl.c
+++ b/tools/ctl/ctl.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include <sys/stat.h>
 #include <errno.h>
 #include <alsa/asoundlib.h>
 #include "kernel/abi.h"
@@ -145,6 +146,19 @@ static void csv_data_dump(struct ctl_data *ctl_data)
 static void data_dump(struct ctl_data *ctl_data)
 {
 	csv_data_dump(ctl_data);
+}
+
+static int get_file_size(int fd)
+{
+	struct stat st;
+	int ret;
+
+	if (fstat(fd, &st) == -1)
+		ret = -EINVAL;
+	else
+		ret = st.st_size;
+
+	return ret;
 }
 
 int main(int argc, char *argv[])

--- a/tools/ctl/ctl.c
+++ b/tools/ctl/ctl.c
@@ -7,12 +7,47 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
+#include <stdbool.h>
 #include <errno.h>
 #include <alsa/asoundlib.h>
 #include "kernel/abi.h"
 #include "kernel/header.h"
 #include "ipc/stream.h"
 #include "ipc/control.h"
+
+struct ctl_data {
+	/* the input file name */
+	char *input_file;
+
+	/* the input file descriptor */
+	int in_fd;
+	/* the output file descriptor */
+	int out_fd;
+
+	/* cached buffer for input/output */
+	unsigned int *buffer;
+	int buffer_size;
+	int ctrl_size;
+
+	/* flag for input/output format, binary or CSV */
+	bool binary;
+	/* flag for input/output format, with or without abi header */
+	bool no_abi;
+	/* component specific type, default 0 */
+	uint32_t type;
+	/* set or get control value */
+	bool set;
+
+	/* name of sound card device */
+	char *dev;
+	char *cname;
+
+	/* alsa ctl_elem pointers */
+	snd_ctl_t *ctl;
+	snd_ctl_elem_id_t *id;
+	snd_ctl_elem_info_t *info;
+	snd_ctl_elem_value_t *value;
+};
 
 static void usage(char *name)
 {

--- a/tools/ctl/ctl.c
+++ b/tools/ctl/ctl.c
@@ -73,7 +73,7 @@ static int read_setup(unsigned int *data, char setup[], size_t smax)
 static void header_dump(struct sof_abi_hdr *hdr)
 {
 	fprintf(stdout, "hdr: magic 0x%8.8x\n", hdr->magic);
-	fprintf(stdout, "hdr: type %d", hdr->type);
+	fprintf(stdout, "hdr: type %d\n", hdr->type);
 	fprintf(stdout, "hdr: size %d bytes\n", hdr->size);
 	fprintf(stdout, "hdr: abi %d:%d:%d\n",
 		SOF_ABI_VERSION_MAJOR(hdr->abi),


### PR DESCRIPTION
This fixes #1534 #1535 

Adding '-b' to support set/get control in binary mode, e.g. for set(),
using binary input file, for get(), dumping out in hex format.

Adding '-r' to indicate that there is no ABI header for the input file,
or ask for not dumping ABI header during getting.

Adding '-o' to specify the output file where will store the output kcontrol binary values.

Adding '-t' to specify the component specified type in ABI header.

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>