### PR TITLE
topology: pipe-detect: enlarge the bytes kcontrol size for blob settings

### DIFF
--- a/tools/topology/sof/pipe-detect.m4
+++ b/tools/topology/sof/pipe-detect.m4
@@ -49,7 +49,7 @@ C_CONTROLBYTES(DETECTOR, PIPELINE_ID,
         CONTROLBYTES_OPS(bytes, 258 binds the mixer control to bytes get/put handlers, 258, 258),
         CONTROLBYTES_EXTOPS(258 binds the mixer control to bytes get/put handlers, 258, 258),
         , , ,
-        CONTROLBYTES_MAX(, 304),
+        CONTROLBYTES_MAX(, 300000),
         ,
         DETECTOR_priv)
 


### PR DESCRIPTION
For detector component, the size of configure blob can be up to 200KB,
here enlarge the max to meet this requirement.

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>