### PR TITLE
rimage: make .static_log_entries optional section

### DIFF
--- a/rimage/elf.c
+++ b/rimage/elf.c
@@ -524,7 +524,7 @@ int elf_find_section(struct image *image, struct module *module,
 		}
 	}
 
-	fprintf(stderr, "error: can't find section %s in module %s\n", name,
+	fprintf(stderr, "warning: can't find section %s in module %s\n", name,
 		module->elf_file);
 	ret = -EINVAL;
 

--- a/rimage/elf.c
+++ b/rimage/elf.c
@@ -93,8 +93,6 @@ static int elf_read_sections(struct image *image, struct module *module,
 		/* find log entries and fw ready sections */
 		module->logs_index = elf_find_section(image, module,
 						      ".static_log_entries");
-		if (module->logs_index < 0)
-			return module->logs_index;
 
 		module->fw_ready_index = elf_find_section(image, module,
 							  ".fw_ready");


### PR DESCRIPTION
.static_log_entries does not exists if TRACE disabled so it needs to be optional for rimage

This + #1580 will fix: issue #1574 