### PR TITLE
trace: remove unused variables if TRACE disabled

### DIFF
--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -795,13 +795,12 @@ static uint64_t kpb_draining_task(void *arg)
 	size_t size_to_copy;
 	bool move_buffer = false;
 	uint32_t drained = 0;
-	uint64_t time_start;
-	uint64_t time_end;
+	uint64_t time;
 	uint32_t attr = 0;
 
 	trace_kpb("kpb_draining_task(), start.");
 
-	time_start = platform_timer_get(platform_timer);
+	time = platform_timer_get(platform_timer);
 
 	while (history_depth > 0) {
 		size_to_read = (uint32_t)buff->end_addr - (uint32_t)buff->r_ptr;
@@ -836,7 +835,7 @@ static uint64_t kpb_draining_task(void *arg)
 			comp_update_buffer_produce(sink, size_to_copy);
 	}
 
-	time_end =  platform_timer_get(platform_timer);
+	time =  platform_timer_get(platform_timer) - time;
 
 	/* Draining is done. Now switch KPB to copy real time stream
 	 * to client's sink. This state is called "draining on demand"
@@ -848,8 +847,7 @@ static uint64_t kpb_draining_task(void *arg)
 
 	trace_kpb("kpb_draining_task(), done. %u drained in %d ms.",
 		   drained,
-		   (time_end - time_start)
-		   / clock_ms_to_ticks(PLATFORM_DEFAULT_CLOCK, 1));
+		   time / clock_ms_to_ticks(PLATFORM_DEFAULT_CLOCK, 1));
 
 	return 0;
 }

--- a/src/drivers/intel/cavs/hda-dma.c
+++ b/src/drivers/intel/cavs/hda-dma.c
@@ -259,8 +259,6 @@ static int hda_dma_wait_for_buffer_full(struct dma *dma,
 	uint64_t deadline = platform_timer_get(platform_timer) +
 		clock_ms_to_ticks(PLATFORM_DEFAULT_CLOCK, 1) *
 		PLATFORM_HOST_DMA_TIMEOUT / 1000;
-	uint32_t rp;
-	uint32_t wp;
 
 	while (!hda_dma_is_buffer_full(dma, chan)) {
 		if (deadline < platform_timer_get(platform_timer)) {
@@ -268,12 +266,11 @@ static int hda_dma_wait_for_buffer_full(struct dma *dma,
 			if (hda_dma_is_buffer_full(dma, chan))
 				return 0;
 
-			rp = host_dma_reg_read(dma, chan->index, DGBRP);
-			wp = host_dma_reg_read(dma, chan->index, DGBWP);
-
 			trace_hddma_error("hda-dmac: %d wait for buffer full "
 					  "timeout rp 0x%x wp 0x%x",
-					  dma->plat_data.id, rp, wp);
+				dma->plat_data.id,
+				host_dma_reg_read(dma, chan->index, DGBRP),
+				host_dma_reg_read(dma, chan->index, DGBWP));
 			return -ETIME;
 		}
 	}
@@ -287,8 +284,6 @@ static int hda_dma_wait_for_buffer_empty(struct dma *dma,
 	uint64_t deadline = platform_timer_get(platform_timer) +
 		clock_ms_to_ticks(PLATFORM_DEFAULT_CLOCK, 1) *
 		PLATFORM_HOST_DMA_TIMEOUT / 1000;
-	uint32_t rp;
-	uint32_t wp;
 
 	while (!hda_dma_is_buffer_empty(dma, chan)) {
 		if (deadline < platform_timer_get(platform_timer)) {
@@ -296,12 +291,11 @@ static int hda_dma_wait_for_buffer_empty(struct dma *dma,
 			if (hda_dma_is_buffer_empty(dma, chan))
 				return 0;
 
-			rp = host_dma_reg_read(dma, chan->index, DGBRP);
-			wp = host_dma_reg_read(dma, chan->index, DGBWP);
-
 			trace_hddma_error("hda-dmac: %d wait for buffer empty "
 					  "timeout rp 0x%x wp 0x%x",
-					  dma->plat_data.id, rp, wp);
+				dma->plat_data.id,
+				host_dma_reg_read(dma, chan->index, DGBRP),
+				host_dma_reg_read(dma, chan->index, DGBWP));
 			return -ETIME;
 		}
 	}


### PR DESCRIPTION
gcc will show errors if variables are set but not used, this will remove such a situations in fw if TRACE disabled

This + #1579 will fix: issue #1574