### PR TITLE
include: ipc: Fix inconsistency in the comments

### DIFF
--- a/src/include/ipc/header.h
+++ b/src/include/ipc/header.h
@@ -26,7 +26,7 @@
  * 0xGCCCNNNN where
  * - G is global cmd type (4 bits)
  * - C is command type (12 bits)
- * - I is the ID number (16 bits) - monotonic and overflows
+ * - N is the ID number (16 bits) - monotonic and overflows
  *
  * This is sent at the start of the IPM message in the mailbox. Messages should
  * not be sent in the doorbell (special exceptions for firmware).


### PR DESCRIPTION
Use 'N' for the ID number

Signed-off-by: Paul Olaru <paul.olaru@nxp.com>