### PR TITLE
memory: make buffers aligned to BUF_HEAP_ALIGNMENT on the i.MX8

### DIFF
--- a/src/platform/imx8/imx8.x.in
+++ b/src/platform/imx8/imx8.x.in
@@ -461,7 +461,7 @@ SECTIONS
 
   .system_runtime_heap (NOLOAD) : ALIGN(8)
   {
-    . = ALIGN (32);
+    . = ALIGN (HEAP_BUF_ALIGNMENT);
     _system_runtime_heap_start = ABSOLUTE(.);
     . = . + HEAP_SYS_RUNTIME_SIZE;
     _system_runtime_heap_end = ABSOLUTE(.);
@@ -477,7 +477,7 @@ SECTIONS
 
   .buffer_heap (NOLOAD) : ALIGN(8)
   {
-    . = ALIGN (32);
+    . = ALIGN (HEAP_BUF_ALIGNMENT);
     _buffer_heap_start = ABSOLUTE(.);
     . = . + HEAP_BUFFER_SIZE;
     _buffer_heap_end = ABSOLUTE(.);

--- a/src/platform/imx8/include/platform/memory.h
+++ b/src/platform/imx8/include/platform/memory.h
@@ -161,6 +161,8 @@
 #define cache_to_uncache(address)	address
 #define is_uncached(address)		0
 
+#define HEAP_BUF_ALIGNMENT		XCHAL_DCACHE_LINESIZE
+
 #if !defined(__ASSEMBLER__) && !defined(LINKER)
 void platform_init_memmap(void);
 #endif

--- a/src/platform/imx8/memory.c
+++ b/src/platform/imx8/memory.c
@@ -7,6 +7,9 @@
 #include <sof/alloc.h>
 #include <ipc/header.h>
 
+STATIC_ASSERT(0 == (HEAP_BUF_ALIGNMENT % PLATFORM_DCACHE_ALIGN),
+	      invalid_heap_buf_alignment);
+
 /* Heap blocks for system runtime */
 static struct block_hdr sys_rt_block64[HEAP_SYS_RT_COUNT64];
 static struct block_hdr sys_rt_block512[HEAP_SYS_RT_COUNT512];


### PR DESCRIPTION
Similar to PR #1568 this will improve memory/cache performance
by aligning to the cache line size.



Signed-off-by: Paul Olaru <paul.olaru@nxp.com>