### PR TITLE
Sue Creek SSP clock fix and a cosmetic patch

### DIFF
--- a/src/drivers/intel/baytrail/ssp.c
+++ b/src/drivers/intel/baytrail/ssp.c
@@ -86,8 +86,8 @@ static int ssp_context_restore(struct dai *dai)
 }
 
 /* Digital Audio interface formatting */
-static inline int ssp_set_config(struct dai *dai,
-				 struct sof_ipc_dai_config *config)
+static int ssp_set_config(struct dai *dai,
+			  struct sof_ipc_dai_config *config)
 {
 	struct ssp_pdata *ssp = dai_get_drvdata(dai);
 	uint32_t sscr0;

--- a/src/drivers/intel/cavs/ssp.c
+++ b/src/drivers/intel/cavs/ssp.c
@@ -106,8 +106,8 @@ static int ssp_context_restore(struct dai *dai)
 }
 
 /* Digital Audio interface formatting */
-static inline int ssp_set_config(struct dai *dai,
-				 struct sof_ipc_dai_config *config)
+static int ssp_set_config(struct dai *dai,
+			  struct sof_ipc_dai_config *config)
 {
 	struct ssp_pdata *ssp = dai_get_drvdata(dai);
 	uint32_t sscr0;

--- a/src/drivers/intel/haswell/ssp.c
+++ b/src/drivers/intel/haswell/ssp.c
@@ -48,8 +48,8 @@ static int ssp_context_restore(struct dai *dai)
 }
 
 /* Digital Audio interface formatting */
-static inline int ssp_set_config(struct dai *dai,
-				 struct sof_ipc_dai_config *config)
+static int ssp_set_config(struct dai *dai,
+			  struct sof_ipc_dai_config *config)
 {
 	struct ssp_pdata *ssp = dai_get_drvdata(dai);
 	uint32_t sscr0;

--- a/src/platform/suecreek/include/platform/clk-map.h
+++ b/src/platform/suecreek/include/platform/clk-map.h
@@ -19,8 +19,8 @@ static const struct freq_table cpu_freq[] = {
  * (regarding to .freq field)
  */
 static const struct freq_table ssp_freq[] = {
-	{ 38400000, 38400, CLOCK_SSP_XTAL_OSCILLATOR },
-	{ 96000000, 96000, CLOCK_SSP_PLL_FIXED },
+	{ 19200000, 19200, CLOCK_SSP_XTAL_OSCILLATOR },
+	{ 24000000, 24000, CLOCK_SSP_PLL_FIXED },
 };
 
 #endif


### PR DESCRIPTION
The first patch in the series fixes the second regression in #1575 on Sue Creek, which makes it unstable. This alone, however, doesn't fix Sue Creek completely. As described in #1575 there's also another regression, which breaks booting on Sue Creek. Reverting #1483 isn't any longer possible, #1567 doesn't apply any more either.