### PR TITLE
topology: pipe-detect: add kcontrol for model blob

### DIFF
--- a/tools/topology/sof/pipe-detect.m4
+++ b/tools/topology/sof/pipe-detect.m4
@@ -44,21 +44,38 @@ C_CONTROLBYTES(SELECTOR, PIPELINE_ID,
 # Detector initial parameters for Intel KPD.
 include(`detect_test_coef.m4')
 
-# Detector Bytes control with max value of 255
-C_CONTROLBYTES(DETECTOR, PIPELINE_ID,
+# Detector Bytes control for config
+C_CONTROLBYTES(Detector Config, PIPELINE_ID,
+        CONTROLBYTES_OPS(bytes, 258 binds the mixer control to bytes get/put handlers, 258, 258),
+        CONTROLBYTES_EXTOPS(258 binds the mixer control to bytes get/put handlers, 258, 258),
+        , , ,
+        CONTROLBYTES_MAX(, 304),
+        ,
+        DETECTOR_priv)
+
+# Hotword Model initial parameters
+CONTROLBYTES_PRIV(MODEL_priv,
+`       bytes "0x53,0x4f,0x46,0x00,0x01,0x00,0x00,0x00,'
+`       0x00,0x00,0x00,0x00,0x00,0x10,0x00,0x03,'
+`       0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,'
+`       0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00"'
+)
+
+# Detector Bytes control for Hotword Model blob
+C_CONTROLBYTES(Hotword Model, PIPELINE_ID,
         CONTROLBYTES_OPS(bytes, 258 binds the mixer control to bytes get/put handlers, 258, 258),
         CONTROLBYTES_EXTOPS(258 binds the mixer control to bytes get/put handlers, 258, 258),
         , , ,
         CONTROLBYTES_MAX(, 300000),
         ,
-        DETECTOR_priv)
+        MODEL_priv)
 
 #
 # Components and Buffers
 #
 
 # "Detect 0" has 2 sink period and 0 source periods
-W_DETECT(0, PIPELINE_FORMAT, 0, 2, KEYWORD, N_STS(PCM_ID), LIST(`             ', "DETECTOR"))
+W_DETECT(0, PIPELINE_FORMAT, 0, 2, KEYWORD, N_STS(PCM_ID), LIST(`             ', "Detector Config", "Hotword Model"))
 
 W_SELECTOR(0, PIPELINE_FORMAT, 2, 2, LIST(`		', "SELECTOR"))
 


### PR DESCRIPTION
We need to split detector config and model blob, create another bytes
kcontrol for model blob.

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>