### PR TITLE
host: remove using bytes argument in host_buffer_cb

### DIFF
--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -447,8 +447,6 @@ static void host_buffer_cb(void *data, uint32_t bytes)
 		MIN(avail_bytes, hd->dma_buffer->free) :
 		MIN(hd->dma_buffer->avail, free_bytes);
 
-	copy_bytes = MIN(copy_bytes, bytes);
-
 	tracev_host("host_buffer_cb(), copy_bytes = 0x%x", copy_bytes);
 
 	if (hd->copy_blocking)


### PR DESCRIPTION
We do not have to use bytes to count copy_bytes since
copy_bytes variable is calculated based on hda-dma and
host buffer pointers. Bytes variable is not useful here - we 
should copy as much data as available in the host
buffer. Bytes variable gives additional unnecessary
limitation.

Signed-off-by: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>