### PR TITLE
host: add copy_bytes alignment in host_buffer_cb()

### DIFF
--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -1333,6 +1333,23 @@ static int dw_dma_get_data_size(struct dma *dma, unsigned int channel,
 	return 0;
 }
 
+static int dw_dma_get_attribute(struct dma *dma, uint32_t type,
+				uint32_t *value)
+{
+	int ret = 0;
+
+	switch (type) {
+	case DMA_ATTR_BUFFER_ALIGNMENT:
+		*value = DW_DMA_BUFFER_ALIGNMENT;
+		break;
+	default:
+		ret = -EINVAL;
+		break;
+	}
+
+	return ret;
+}
+
 const struct dma_ops dw_dma_ops = {
 	.channel_get		= dw_dma_channel_get,
 	.channel_put		= dw_dma_channel_put,
@@ -1349,4 +1366,5 @@ const struct dma_ops dw_dma_ops = {
 	.probe			= dw_dma_probe,
 	.remove			= dw_dma_remove,
 	.get_data_size		= dw_dma_get_data_size,
+	.get_attribute		= dw_dma_get_attribute,
 };

--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -1342,6 +1342,9 @@ static int dw_dma_get_attribute(struct dma *dma, uint32_t type,
 	case DMA_ATTR_BUFFER_ALIGNMENT:
 		*value = DW_DMA_BUFFER_ALIGNMENT;
 		break;
+	case DMA_ATTR_COPY_ALIGNMENT:
+		*value = DW_DMA_COPY_ALIGNMENT;
+		break;
 	default:
 		ret = -EINVAL;
 		break;

--- a/src/drivers/intel/cavs/hda-dma.c
+++ b/src/drivers/intel/cavs/hda-dma.c
@@ -959,6 +959,9 @@ static int hda_dma_get_attribute(struct dma *dma, uint32_t type,
 	case DMA_ATTR_BUFFER_ALIGNMENT:
 		*value = PLATFORM_HDA_BUFFER_ALIGNMENT;
 		break;
+	case DMA_ATTR_COPY_ALIGNMENT:
+		*value = PLATFORM_HDA_COPY_ALIGNMENT;
+		break;
 	default:
 		ret = -EINVAL;
 		break;

--- a/src/drivers/intel/cavs/hda-dma.c
+++ b/src/drivers/intel/cavs/hda-dma.c
@@ -950,6 +950,23 @@ static int hda_dma_data_size(struct dma *dma, unsigned int channel,
 	return 0;
 }
 
+static int hda_dma_get_attribute(struct dma *dma, uint32_t type,
+				 uint32_t *value)
+{
+	int ret = 0;
+
+	switch (type) {
+	case DMA_ATTR_BUFFER_ALIGNMENT:
+		*value = PLATFORM_HDA_BUFFER_ALIGNMENT;
+		break;
+	default:
+		ret = -EINVAL;
+		break;
+	}
+
+	return ret;
+}
+
 const struct dma_ops hda_host_dma_ops = {
 	.channel_get		= hda_dma_channel_get,
 	.channel_put		= hda_dma_channel_put,
@@ -966,6 +983,7 @@ const struct dma_ops hda_host_dma_ops = {
 	.probe			= hda_dma_probe,
 	.remove			= hda_dma_remove,
 	.get_data_size		= hda_dma_data_size,
+	.get_attribute		= hda_dma_get_attribute,
 };
 
 const struct dma_ops hda_link_dma_ops = {
@@ -984,4 +1002,5 @@ const struct dma_ops hda_link_dma_ops = {
 	.probe			= hda_dma_probe,
 	.remove			= hda_dma_remove,
 	.get_data_size		= hda_dma_data_size,
+	.get_attribute		= hda_dma_get_attribute,
 };

--- a/src/include/sof/dma.h
+++ b/src/include/sof/dma.h
@@ -79,6 +79,9 @@ enum dma_cb_status {
 
 #define DMA_CHAN_INVALID	0xFFFFFFFF
 
+/* DMA attributes */
+#define DMA_ATTR_BUFFER_ALIGNMENT	0
+
 struct dma;
 
 /**
@@ -158,6 +161,8 @@ struct dma_ops {
 
 	int (*get_data_size)(struct dma *dma, unsigned int channel,
 			     uint32_t *avail, uint32_t *free);
+
+	int (*get_attribute)(struct dma *dma, uint32_t type, uint32_t *value);
 };
 
 /* DMA platform data */
@@ -313,6 +318,12 @@ static inline int dma_get_data_size(struct dma *dma, int channel,
 				    uint32_t *avail, uint32_t *free)
 {
 	return dma->ops->get_data_size(dma, channel, avail, free);
+}
+
+static inline int dma_get_attribute(struct dma *dma, uint32_t type,
+				    uint32_t *value)
+{
+	return dma->ops->get_attribute(dma, type, value);
 }
 
 static inline void dma_sg_init(struct dma_sg_elem_array *ea)

--- a/src/include/sof/dma.h
+++ b/src/include/sof/dma.h
@@ -81,6 +81,7 @@ enum dma_cb_status {
 
 /* DMA attributes */
 #define DMA_ATTR_BUFFER_ALIGNMENT	0
+#define DMA_ATTR_COPY_ALIGNMENT		1
 
 struct dma;
 

--- a/src/include/sof/dw-dma.h
+++ b/src/include/sof/dw-dma.h
@@ -130,6 +130,8 @@
 #define trace_dwdma_error(__e, ...) \
 	trace_error(TRACE_CLASS_DMA, __e, ##__VA_ARGS__)
 
+#define DW_DMA_BUFFER_ALIGNMENT 0x20
+
 /* TODO: add FIFO sizes */
 struct dw_chan_data {
 	uint16_t class;

--- a/src/include/sof/dw-dma.h
+++ b/src/include/sof/dw-dma.h
@@ -131,6 +131,7 @@
 	trace_error(TRACE_CLASS_DMA, __e, ##__VA_ARGS__)
 
 #define DW_DMA_BUFFER_ALIGNMENT 0x20
+#define DW_DMA_COPY_ALIGNMENT	0x20
 
 /* TODO: add FIFO sizes */
 struct dw_chan_data {

--- a/src/platform/apollolake/include/platform/platform.h
+++ b/src/platform/apollolake/include/platform/platform.h
@@ -44,6 +44,7 @@ struct sof;
 
 /* DGMBS align value */
 #define PLATFORM_HDA_BUFFER_ALIGNMENT	0x20
+#define PLATFORM_HDA_COPY_ALIGNMENT	0x20
 
 /* HD-DMA single burst size */
 #define PLATFORM_HDA_BURST_SIZE	32

--- a/src/platform/cannonlake/include/platform/platform.h
+++ b/src/platform/cannonlake/include/platform/platform.h
@@ -54,6 +54,7 @@ struct sof;
 
 /* DGMBS align value */
 #define PLATFORM_HDA_BUFFER_ALIGNMENT	0x20
+#define PLATFORM_HDA_COPY_ALIGNMENT	0x20
 
 /* HD-DMA single burst size */
 #define PLATFORM_HDA_BURST_SIZE	32

--- a/src/platform/icelake/include/platform/platform.h
+++ b/src/platform/icelake/include/platform/platform.h
@@ -54,6 +54,7 @@ struct sof;
 
 /* DGMBS align value */
 #define PLATFORM_HDA_BUFFER_ALIGNMENT	0x20
+#define PLATFORM_HDA_COPY_ALIGNMENT	0x20
 
 /* HD-DMA single burst size */
 #define PLATFORM_HDA_BURST_SIZE	32

--- a/src/platform/suecreek/include/platform/platform.h
+++ b/src/platform/suecreek/include/platform/platform.h
@@ -54,6 +54,7 @@ struct sof;
 
 /* DGMBS align value */
 #define PLATFORM_HDA_BUFFER_ALIGNMENT	0x20
+#define PLATFORM_HDA_COPY_ALIGNMENT	0x20
 
 /* HD-DMA single burst size */
 #define PLATFORM_HDA_BURST_SIZE	32


### PR DESCRIPTION
Amount of bytes we copied by host component should be
align to minimal possible chunk of data that can be
copied by hda-dma. In other case there is possibility of
occurrence mismatch between amount data we really copied
and buffer read and write pointers.

Should be merged after #842 
