### PR TITLE
pipeline: change preload conditions

### DIFF
--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -669,7 +669,8 @@ static int host_copy(struct comp_dev *dev)
 	/* here only do preload, further copies happen
 	 * in host_buffer_cb()
 	 */
-	if (pipeline_is_preload(dev->pipeline) && !dev->position) {
+	if (dev->params.direction == SOF_IPC_STREAM_PLAYBACK &&
+	    !dev->position) {
 		ret = dma_copy(hd->dma, hd->chan, hd->dma_buffer->size,
 			       DMA_COPY_PRELOAD);
 		if (ret < 0) {

--- a/src/audio/pipeline.c
+++ b/src/audio/pipeline.c
@@ -388,8 +388,11 @@ int pipeline_prepare(struct pipeline *p, struct comp_dev *dev)
 		goto out;
 	}
 
-	/* pipeline preload needed only for playback streams */
-	p->preload = dev->params.direction == SOF_IPC_STREAM_PLAYBACK;
+	/* pipeline preload needed only for playback streams without active
+	 * sink component (it can be active for e.g. mixer pipelines)
+	 */
+	p->preload = dev->params.direction == SOF_IPC_STREAM_PLAYBACK &&
+		p->sink_comp->state != COMP_STATE_ACTIVE;
 	p->status = COMP_STATE_PREPARE;
 
 out:


### PR DESCRIPTION
Changes pipeline's preload conditions to take into
consideration the situation, where we don't always
want to do playback preload, because the sink part
of pipeline is already running e.g. mixer topology.
However the host component still needs to perform
preload on its own, so for now we make the decision
based on stream's direction.

Fixes #1526.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>