### PR TITLE
 ipc: align stream.h with kernel

### DIFF
--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -107,8 +107,8 @@ static void host_update_position(struct comp_dev *dev, uint32_t bytes)
 	if (hd->local_pos >= hd->host_size)
 		hd->local_pos = 0;
 
-	/* NO_IRQ mode if host_period_size == 0 */
-	if (dev->params.host_period_bytes != 0) {
+	/* NO_IRQ mode if no_period_irq == 1 */
+	if (!dev->params.no_period_irq) {
 		hd->report_pos += bytes;
 
 		/* send IPC message to driver if needed */

--- a/src/include/ipc/stream.h
+++ b/src/include/ipc/stream.h
@@ -90,10 +90,10 @@ struct sof_ipc_stream_params {
 	uint16_t sample_valid_bytes;
 	uint16_t sample_container_bytes;
 
-	/* for notifying host period has completed - 0 means no period IRQ */
 	uint32_t host_period_bytes;
+	uint16_t no_period_irq; /* 1 means period IRQ mode OFF */
 
-	uint32_t reserved[2];
+	uint16_t reserved[3];
 	uint16_t chmap[SOF_IPC_MAX_CHANNELS];	/**< channel map - SOF_CHMAP_ */
 } __attribute__((packed));
 


### PR DESCRIPTION
This change is to align sof_ipc_stream_params with its
    kernel equivalent. The change is needed in both kernel
    and FW because FW needs to use host_period_bytes which
    where previously used to inform host about period IRQ.
    Therefore now we introduce new member for it period_irq
    and let host_period_bytes keep the proper value.
    
Corresponding Kernel PR is here https://github.com/thesofproject/linux/pull/1037

    Signed-off-by: Marcin Rajwa <marcin.rajwa@linux.intel.com>