### PR TITLE
 host: ignore host_trigger() for one shot copy mode

### DIFF
--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -294,6 +294,12 @@ static int host_trigger(struct comp_dev *dev, int cmd)
 		return ret;
 	}
 
+	/* we should ignore any trigger commands when doing one shot,
+	 * because transfers will start in copy and stop automatically
+	 */
+	if (hd->copy_type == COMP_COPY_ONE_SHOT)
+		return ret;
+
 	if (hd->chan < 0) {
 		trace_host_error("host_trigger() error: no dma channel "
 				 "configured");
@@ -460,8 +466,7 @@ static void host_buffer_cb(void *data, uint32_t bytes)
 
 	if (hd->copy_type == COMP_COPY_BLOCKING)
 		flags |= DMA_COPY_BLOCKING;
-
-	if (!hd->config.cyclic)
+	else if (hd->copy_type == COMP_COPY_ONE_SHOT)
 		flags |= DMA_COPY_ONE_SHOT;
 
 	/* reconfigure transfer */

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -684,7 +684,7 @@ static void kpb_init_draining(struct comp_data *kpb, struct kpb_client *cli)
 	struct hb *first_buff = buff;
 	size_t buffered = 0;
 	size_t local_buffered = 0;
-	uint32_t attr = 1;
+	enum comp_copy_type copy_type = COMP_COPY_BLOCKING;
 
 	trace_kpb("kpb_init_draining()");
 
@@ -767,8 +767,8 @@ static void kpb_init_draining(struct comp_data *kpb, struct kpb_client *cli)
 		kpb->state = KPB_STATE_DRAINING;
 
 		/* Set host-sink copy mode to blocking */
-		comp_set_attribute(kpb->host_sink->sink,
-				   COMP_ATTR_COPY_BLOCKING, &attr);
+		comp_set_attribute(kpb->host_sink->sink, COMP_ATTR_COPY_TYPE,
+				   &copy_type);
 
 		/* Schedule draining task */
 		schedule_task(&kpb->draining_task, 0, 0,
@@ -796,7 +796,7 @@ static uint64_t kpb_draining_task(void *arg)
 	bool move_buffer = false;
 	uint32_t drained = 0;
 	uint64_t time;
-	uint32_t attr = 0;
+	enum comp_copy_type copy_type = COMP_COPY_NORMAL;
 
 	trace_kpb("kpb_draining_task(), start.");
 
@@ -843,7 +843,7 @@ static uint64_t kpb_draining_task(void *arg)
 	*draining_data->state = KPB_STATE_HOST_COPY;
 
 	/* Reset host-sink copy mode back to unblocking */
-	comp_set_attribute(sink->sink, COMP_ATTR_COPY_BLOCKING, &attr);
+	comp_set_attribute(sink->sink, COMP_ATTR_COPY_TYPE, &copy_type);
 
 	trace_kpb("kpb_draining_task(), done. %u drained in %d ms.",
 		   drained,

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -156,6 +156,7 @@ enum comp_endpoint_type {
 enum comp_copy_type {
 	COMP_COPY_NORMAL = 0,
 	COMP_COPY_BLOCKING,
+	COMP_COPY_ONE_SHOT,
 };
 
 struct comp_dev;

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -130,7 +130,7 @@
 /** \name Component attribute types
  *  @{
  */
-#define COMP_ATTR_COPY_BLOCKING	0	/**< Comp blocking copy attribute */
+#define COMP_ATTR_COPY_TYPE	0	/**< Comp copy type attribute */
 #define COMP_ATTR_HOST_BUFFER	1	/**< Comp host buffer attribute */
 /** @}*/
 
@@ -150,6 +150,12 @@ enum comp_endpoint_type {
 	COMP_ENDPOINT_HOST,
 	COMP_ENDPOINT_DAI,
 	COMP_ENDPOINT_NODE
+};
+
+ /* \brief Type of component copy, which can be changed on runtime */
+enum comp_copy_type {
+	COMP_COPY_NORMAL = 0,
+	COMP_COPY_BLOCKING,
 };
 
 struct comp_dev;

--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -205,6 +205,7 @@ static int ipc_stream_pcm_params(uint32_t stream)
 	struct sof_ipc_comp_host *host = NULL;
 	struct dma_sg_elem_array elem_array;
 	uint32_t ring_size;
+	enum comp_copy_type copy_type = COMP_COPY_ONE_SHOT;
 #endif
 	struct sof_ipc_pcm_params pcm_params;
 	struct sof_ipc_pcm_params_reply reply;
@@ -265,6 +266,14 @@ static int ipc_stream_pcm_params(uint32_t stream)
 	err = comp_set_attribute(cd, COMP_ATTR_HOST_BUFFER, &elem_array);
 	if (err < 0) {
 		trace_ipc_error("ipc: comp %d host buffer failed %d",
+				pcm_params.comp_id, err);
+		goto error;
+	}
+
+	/* TODO: should be extracted to platform specific code */
+	err = comp_set_attribute(cd, COMP_ATTR_COPY_TYPE, &copy_type);
+	if (err < 0) {
+		trace_ipc_error("ipc: comp %d setting copy type failed %d",
 				pcm_params.comp_id, err);
 		goto error;
 	}


### PR DESCRIPTION
Ignores host_trigger(), when host component is
configured in one shot copy mode. In such mode
the DMA is started every time in copy and stopped
automatically.

Fixes #1593.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>