### PR TITLE
hda-dma: move HDA_ALIGNMENT defines to hda-dma.c

### DIFF
--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -73,7 +73,7 @@ struct host_data {
 	struct hc_buf *sink;
 	uint32_t split_remaining;
 
-	uint32_t dma_copy_align; /**< Minmal chunk of data possible to be
+	uint32_t dma_copy_align; /**< Minimal chunk of data possible to be
 				   *  copied by dma connected to host
 				   */
 

--- a/src/drivers/intel/cavs/hda-dma.c
+++ b/src/drivers/intel/cavs/hda-dma.c
@@ -19,6 +19,7 @@
 #include <sof/dma.h>
 #include <sof/io.h>
 #include <sof/ipc.h>
+#include <sof/hda-dma.h>
 #include <sof/pm_runtime.h>
 #include <sof/wait.h>
 #include <sof/audio/format.h>
@@ -69,6 +70,10 @@
 #define HDA_DMA_MAX_CHANS		9
 
 #define HDA_STATE_RELEASE	BIT(0)
+
+/* DGMBS align value */
+#define HDA_DMA_BUFFER_ALIGNMENT	0x20
+#define HDA_DMA_COPY_ALIGNMENT		0x20
 
 /*
  * DMA Pointer Trace
@@ -748,7 +753,7 @@ static int hda_dma_set_config(struct dma *dma, unsigned int channel,
 	}
 
 	/* buffer size must be multiple of hda dma burst size */
-	if (buffer_bytes % PLATFORM_HDA_BUFFER_ALIGNMENT) {
+	if (buffer_bytes % HDA_DMA_BUFFER_ALIGNMENT) {
 		trace_hddma_error("hda-dmac: %d chan %d - buffer not DMA "
 				  "aligned 0x%x", dma->plat_data.id, channel,
 				  buffer_bytes);
@@ -767,7 +772,7 @@ static int hda_dma_set_config(struct dma *dma, unsigned int channel,
 	    config->direction == DMA_DIR_HMEM_TO_LMEM)
 		host_dma_reg_write(dma, channel, DGMBS,
 				   ALIGN_UP(buffer_bytes,
-					    PLATFORM_HDA_BUFFER_ALIGNMENT));
+					    HDA_DMA_BUFFER_ALIGNMENT));
 
 	/* firmware control buffer */
 	dgcs = DGCS_FWCB;
@@ -957,10 +962,10 @@ static int hda_dma_get_attribute(struct dma *dma, uint32_t type,
 
 	switch (type) {
 	case DMA_ATTR_BUFFER_ALIGNMENT:
-		*value = PLATFORM_HDA_BUFFER_ALIGNMENT;
+		*value = HDA_DMA_BUFFER_ALIGNMENT;
 		break;
 	case DMA_ATTR_COPY_ALIGNMENT:
-		*value = PLATFORM_HDA_COPY_ALIGNMENT;
+		*value = HDA_DMA_COPY_ALIGNMENT;
 		break;
 	default:
 		ret = -EINVAL;

--- a/src/include/sof/dma-trace.h
+++ b/src/include/sof/dma-trace.h
@@ -42,6 +42,9 @@ struct dma_trace_data {
 	uint32_t enabled;
 	uint32_t copy_in_progress;
 	uint32_t stream_tag;
+	uint32_t dma_copy_align; /**< Minimal chunk of data possible to be
+				   *  copied by dma connected to host
+				   */
 	uint32_t dropped_entries; /* amount of dropped entries */
 	spinlock_t lock; /* dma trace lock */
 };

--- a/src/lib/dma-trace.c
+++ b/src/lib/dma-trace.c
@@ -121,6 +121,16 @@ int dma_trace_init_complete(struct dma_trace_data *d)
 		return ret;
 	}
 
+	ret = dma_get_attribute(d->dc.dmac, DMA_ATTR_COPY_ALIGNMENT,
+				&d->dma_copy_align);
+
+	if (ret < 0) {
+		trace_buffer("dma_trace_init_complete() "
+			     "error: dma_get_attribute()");
+
+		return ret;
+	}
+
 	schedule_task_init(&d->dmat_work, SOF_SCHEDULE_LL,
 			   SOF_TASK_PRI_MED, trace_work, d, 0, 0);
 
@@ -223,7 +233,7 @@ static int dma_trace_get_avail_data(struct dma_trace_data *d,
 	}
 
 	/* align data to HD-DMA burst size */
-	return ALIGN_DOWN(avail, PLATFORM_HDA_BURST_SIZE);
+	return ALIGN_DOWN(avail, d->dma_copy_align);
 }
 #else
 static int dma_trace_get_avail_data(struct dma_trace_data *d,

--- a/src/platform/apollolake/include/platform/platform.h
+++ b/src/platform/apollolake/include/platform/platform.h
@@ -42,9 +42,6 @@ struct sof;
  */
 #define PLATFORM_DEFAULT_CLOCK CLK_SSP
 
-/* HD-DMA single burst size */
-#define PLATFORM_HDA_BURST_SIZE	32
-
 /* Host page size */
 #define HOST_PAGE_SIZE		4096
 #define PLATFORM_PAGE_TABLE_SIZE	256

--- a/src/platform/apollolake/include/platform/platform.h
+++ b/src/platform/apollolake/include/platform/platform.h
@@ -42,10 +42,6 @@ struct sof;
  */
 #define PLATFORM_DEFAULT_CLOCK CLK_SSP
 
-/* DGMBS align value */
-#define PLATFORM_HDA_BUFFER_ALIGNMENT	0x20
-#define PLATFORM_HDA_COPY_ALIGNMENT	0x20
-
 /* HD-DMA single burst size */
 #define PLATFORM_HDA_BURST_SIZE	32
 

--- a/src/platform/cannonlake/include/platform/platform.h
+++ b/src/platform/cannonlake/include/platform/platform.h
@@ -52,10 +52,6 @@ struct sof;
 
 #define MAX_GPDMA_COUNT 2
 
-/* DGMBS align value */
-#define PLATFORM_HDA_BUFFER_ALIGNMENT	0x20
-#define PLATFORM_HDA_COPY_ALIGNMENT	0x20
-
 /* HD-DMA single burst size */
 #define PLATFORM_HDA_BURST_SIZE	32
 

--- a/src/platform/cannonlake/include/platform/platform.h
+++ b/src/platform/cannonlake/include/platform/platform.h
@@ -52,9 +52,6 @@ struct sof;
 
 #define MAX_GPDMA_COUNT 2
 
-/* HD-DMA single burst size */
-#define PLATFORM_HDA_BURST_SIZE	32
-
 /* Host page size */
 #define HOST_PAGE_SIZE		4096
 #define PLATFORM_PAGE_TABLE_SIZE	256

--- a/src/platform/icelake/include/platform/platform.h
+++ b/src/platform/icelake/include/platform/platform.h
@@ -52,10 +52,6 @@ struct sof;
 
 #define MAX_GPDMA_COUNT 2
 
-/* DGMBS align value */
-#define PLATFORM_HDA_BUFFER_ALIGNMENT	0x20
-#define PLATFORM_HDA_COPY_ALIGNMENT	0x20
-
 /* HD-DMA single burst size */
 #define PLATFORM_HDA_BURST_SIZE	32
 

--- a/src/platform/icelake/include/platform/platform.h
+++ b/src/platform/icelake/include/platform/platform.h
@@ -52,9 +52,6 @@ struct sof;
 
 #define MAX_GPDMA_COUNT 2
 
-/* HD-DMA single burst size */
-#define PLATFORM_HDA_BURST_SIZE	32
-
 /* Host page size */
 #define HOST_PAGE_SIZE		4096
 #define PLATFORM_PAGE_TABLE_SIZE	256

--- a/src/platform/suecreek/include/platform/platform.h
+++ b/src/platform/suecreek/include/platform/platform.h
@@ -52,10 +52,6 @@ struct sof;
 
 #define MAX_GPDMA_COUNT 2
 
-/* DGMBS align value */
-#define PLATFORM_HDA_BUFFER_ALIGNMENT	0x20
-#define PLATFORM_HDA_COPY_ALIGNMENT	0x20
-
 /* HD-DMA single burst size */
 #define PLATFORM_HDA_BURST_SIZE	32
 

--- a/src/platform/suecreek/include/platform/platform.h
+++ b/src/platform/suecreek/include/platform/platform.h
@@ -52,9 +52,6 @@ struct sof;
 
 #define MAX_GPDMA_COUNT 2
 
-/* HD-DMA single burst size */
-#define PLATFORM_HDA_BURST_SIZE	32
-
 /* Host page size */
 #define HOST_PAGE_SIZE		4096
 #define PLATFORM_PAGE_TABLE_SIZE	256


### PR DESCRIPTION
I've made little cleanup in hda-dma defines:

1. HDA_BUFFER_ALIGNMENT and HDA_COPY_ALIGNMENT are not platform
specific. I've moved them from specific platform.h files to
hda-dma.c.
2. I've removed PLATFORM_HDA_BURST_SIZE define since it is the same
as HDA_COPY_ALIGNMENT - this change required using dma_get_attribute()
in dma_trace specific functions.

Signed-off-by: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>