### PR TITLE
dw-dma: change release handling for non HW_LLI

### DIFF
--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -352,8 +352,10 @@ static int dw_dma_release(struct dma *dma, unsigned int channel)
 {
 	struct dma_pdata *p = dma_get_drvdata(dma);
 	struct dw_dma_chan_data *chan = p->chan + channel;
+#if CONFIG_HW_LLI
 	uint32_t next_ptr;
 	uint32_t bytes_left;
+#endif
 	uint32_t flags;
 
 	if (channel >= dma->plat_data.channels ||
@@ -371,6 +373,7 @@ static int dw_dma_release(struct dma *dma, unsigned int channel)
 	/* get next lli for proper release */
 	chan->lli_current = (struct dw_lli *)chan->lli_current->llp;
 
+#if CONFIG_HW_LLI
 	/* copy leftover data between current and last lli */
 	next_ptr = DW_DMA_LLI_ADDRESS(chan->lli_current, chan->direction);
 	if (next_ptr >= chan->ptr_data.current_ptr)
@@ -382,6 +385,7 @@ static int dw_dma_release(struct dma *dma, unsigned int channel)
 			(next_ptr - chan->ptr_data.start_ptr);
 
 	dw_dma_copy(dma, channel, bytes_left, 0);
+#endif
 
 	spin_unlock_irq(&dma->lock, flags);
 


### PR DESCRIPTION
Changes DW-DMA release handling for configurations
not using hardware linked list support. We should
not make any additional copies in such case.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>