### PR TITLE
dw-dma: change behavior for preload

### DIFF
--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -1028,12 +1028,8 @@ static int dw_dma_copy(struct dma *dma, unsigned int channel, int bytes,
 		return -EINVAL;
 	}
 
-	/* do nothing on preload */
-	if (flags & DMA_COPY_PRELOAD)
-		return 0;
-
-	/* for one shot copy just start DMA */
-	if (flags & DMA_COPY_ONE_SHOT)
+	/* for preload or one shot copy just start DMA */
+	if (flags & (DMA_COPY_PRELOAD | DMA_COPY_ONE_SHOT))
 		return dw_dma_start(dma, channel);
 
 	tracev_dwdma("dw_dma_copy(): dma %d channel %d copy",


### PR DESCRIPTION
Changes behavior for DMA_COPY_PRELOAD flag.
DW-DMA should just start transfer the same way
as for DMA_COPY_ONE_SHOT. It fixes playback
for platforms using DW-DMA for host transfers.

Fixes #1599.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>