### PR TITLE
Host buffer resize

### DIFF
--- a/src/audio/buffer.c
+++ b/src/audio/buffer.c
@@ -56,19 +56,51 @@ struct comp_buffer *buffer_new(struct sof_ipc_buffer *desc)
 	assert(!memcpy_s(&buffer->ipc_buffer, sizeof(buffer->ipc_buffer),
 		       desc, sizeof(*desc)));
 
-	buffer->size = desc->size;
-	buffer->alloc_size = desc->size;
-	buffer->w_ptr = buffer->addr;
-	buffer->r_ptr = buffer->addr;
-	buffer->end_addr = buffer->addr + buffer->ipc_buffer.size;
-	buffer->free = buffer->ipc_buffer.size;
-	buffer->avail = 0;
-
-	buffer_zero(buffer);
+	buffer_init(buffer, desc->size);
 
 	spinlock_init(&buffer->lock);
 
 	return buffer;
+}
+
+int buffer_set_size(struct comp_buffer *buffer, uint32_t size)
+{
+	void *new_ptr = NULL;
+	struct sof_ipc_buffer *desc = NULL;
+
+	/* validate request */
+	if (size == 0 || size > HEAP_BUFFER_SIZE) {
+		trace_buffer_error("resize error: size = %u is invalid", size);
+		return -EINVAL;
+	}
+
+	desc = &buffer->ipc_buffer;
+	if (!desc) {
+		trace_buffer_error("resize error: invalid buffer desc");
+		return -EINVAL;
+	}
+
+	if (size == desc->size)
+		return 0;
+
+	new_ptr = rbrealloc(buffer->addr, RZONE_BUFFER, desc->caps, size);
+
+	/* we couldn't allocate bigger chunk */
+	if (!new_ptr && size > desc->size) {
+		trace_buffer_error("resize error: can't alloc %u bytes type %u",
+				   desc->size, desc->caps);
+		return -ENOMEM;
+	}
+
+	/* use bigger chunk, else just use the old chunk but set smaller */
+	if (new_ptr)
+		buffer->addr = new_ptr;
+
+	desc->size = size;
+
+	buffer_init(buffer, desc->size);
+
+	return 0;
 }
 
 /* free component in the pipeline */

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -115,6 +115,7 @@ typedef void (*cache_buff_op)(struct comp_buffer *);
 
 /* pipeline buffer creation and destruction */
 struct comp_buffer *buffer_new(struct sof_ipc_buffer *desc);
+int buffer_set_size(struct comp_buffer *buffer, uint32_t size);
 void buffer_free(struct comp_buffer *buffer);
 
 /* called by a component after producing data into this buffer */
@@ -198,20 +199,6 @@ static inline void buffer_reset_pos(struct comp_buffer *buffer)
 	buffer_zero(buffer);
 }
 
-/* set the runtime size of a buffer in bytes and improve the data cache */
-/* performance by only using minimum space needed for runtime params */
-static inline int buffer_set_size(struct comp_buffer *buffer, uint32_t size)
-{
-	if (size > buffer->alloc_size)
-		return -ENOMEM;
-	if (size == 0)
-		return -EINVAL;
-
-	buffer->end_addr = buffer->addr + size;
-	buffer->size = size;
-	return 0;
-}
-
 static inline void *buffer_get_frag(struct comp_buffer *buffer, void *ptr,
 				    uint32_t idx, uint32_t size)
 {
@@ -224,4 +211,15 @@ static inline void *buffer_get_frag(struct comp_buffer *buffer, void *ptr,
 	return current;
 }
 
+static inline void buffer_init(struct comp_buffer *buffer, uint32_t size)
+{
+	buffer->alloc_size = size;
+	buffer->size = size;
+	buffer->w_ptr = buffer->addr;
+	buffer->r_ptr = buffer->addr;
+	buffer->end_addr = buffer->addr + size;
+	buffer->free = size;
+	buffer->avail = 0;
+	buffer_zero(buffer);
+}
 #endif

--- a/test/cmocka/src/audio/buffer/mock.c
+++ b/test/cmocka/src/audio/buffer/mock.c
@@ -38,6 +38,14 @@ void rfree(void *ptr)
 	free(ptr);
 }
 
+void *_brealloc(void *ptr, int zone, uint32_t caps, size_t bytes)
+{
+	(void)zone;
+	(void)caps;
+
+	return realloc(ptr, bytes);
+}
+
 void __panic(uint32_t p, char *filename, uint32_t linenum)
 {
 	(void)p;

--- a/test/cmocka/src/audio/kpb/kpb_mock.c
+++ b/test/cmocka/src/audio/kpb/kpb_mock.c
@@ -39,6 +39,14 @@ void rfree(void *ptr)
 	free(ptr);
 }
 
+void *_brealloc(void *ptr, int zone, uint32_t caps, size_t bytes)
+{
+	(void)zone;
+	(void)caps;
+
+	return realloc(ptr, bytes);
+}
+
 void pipeline_xrun(struct pipeline *p, struct comp_dev *dev, int32_t bytes)
 {
 }

--- a/test/cmocka/src/audio/mixer/mock.c
+++ b/test/cmocka/src/audio/mixer/mock.c
@@ -40,6 +40,14 @@ void rfree(void *ptr)
 	free(ptr);
 }
 
+void *_brealloc(void *ptr, int zone, uint32_t caps, size_t bytes)
+{
+	(void)zone;
+	(void)caps;
+
+	return realloc(ptr, bytes);
+}
+
 void pipeline_xrun(struct pipeline *p, struct comp_dev *dev, int32_t bytes)
 {
 }

--- a/tools/testbench/alloc.c
+++ b/tools/testbench/alloc.c
@@ -36,6 +36,16 @@ void *rballoc(int zone, uint32_t caps, size_t bytes)
 	return malloc(bytes);
 }
 
+void *rrealloc(void *ptr, int zone, uint32_t caps, size_t bytes)
+{
+	return realloc(ptr, bytes);
+}
+
+void *rbrealloc(void *ptr, int zone, uint32_t caps, size_t bytes)
+{
+	return realloc(ptr, bytes);
+}
+
 void heap_trace(struct mm_heap *heap, int size)
 {
 	malloc_info(0, stdout);


### PR DESCRIPTION
Depending on the topology, buffer size might not be multiple of dma
transfer size. So, round host buffer size up to nearest dma transfer
size multiple and possibly resize the host buffer.