### PR TITLE
detect-test: initial default size buffer for model data

### DIFF
--- a/src/audio/detect_test.c
+++ b/src/audio/detect_test.c
@@ -29,6 +29,8 @@
 #define ACTIVATION_DEFAULT_THRESHOLD_S16 \
 	((int16_t)((INT16_MAX) * (ACTIVATION_DEFAULT_THRESHOLD)))
 
+#define INITIAL_MODEL_DATA_SIZE 64
+
 /* default number of samples before detection is activated  */
 #define KEYPHRASE_DEFAULT_PREAMBLE_LENGTH 0
 
@@ -156,15 +158,15 @@ static void free_mem_load(struct comp_data *cd)
 
 static int alloc_mem_load(struct comp_data *cd, uint32_t size)
 {
+	if (!size)
+		return 0;
+
 	if (!cd) {
 		trace_keyword_error("alloc_mem_load() error: invalid cd");
 		return -EINVAL;
 	}
 
 	free_mem_load(cd);
-
-	if (!size)
-		return 0;
 
 	cd->model.data = rballoc(RZONE_BUFFER, SOF_MEM_CAPS_RAM, size);
 
@@ -206,6 +208,7 @@ static struct comp_dev *test_keyword_new(struct sof_ipc_comp *comp)
 		(struct sof_ipc_comp_process *)comp;
 	struct comp_data *cd;
 	struct sof_detect_test_config *cfg;
+	int ret = 0;
 	size_t bs;
 
 	trace_keyword("test_keyword_new()");
@@ -238,7 +241,7 @@ static struct comp_dev *test_keyword_new(struct sof_ipc_comp *comp)
 	bs = ipc_keyword->size;
 
 	if (bs > 0) {
-		if (bs != sizeof(struct sof_detect_test_config)) {
+		if (bs < sizeof(struct sof_detect_test_config)) {
 			trace_keyword_error("test_keyword_new() "
 					"error: invalid data size");
 			goto fail;
@@ -249,6 +252,13 @@ static struct comp_dev *test_keyword_new(struct sof_ipc_comp *comp)
 					"error: failed to apply config");
 			goto fail;
 		}
+	}
+
+	ret = alloc_mem_load(cd, INITIAL_MODEL_DATA_SIZE);
+	if (ret < 0) {
+		trace_keyword_error("test_keyword_new() "
+				    "error: model data initial failed");
+		goto fail;
 	}
 
 	dev->state = COMP_STATE_READY;


### PR DESCRIPTION
We need initial a default buffer for model data at component new()
stage, and make sure we have non-0 size of this buffer otherwise, the
get_data cmd will fail.

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>