### PR TITLE
Some minor fixes for debugging.

### DIFF
--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -1285,6 +1285,11 @@ static int dw_dma_avail_data_size(struct dma *dma, unsigned int channel)
 	if (size < 0)
 		size += chan->ptr_data.buffer_bytes;
 
+	if (!size)
+		trace_dwdma("dw_dma_avail_data_size() "
+			    "size is 0! Channel enable = %d.",
+			    (dw_read(dma, DW_DMA_CHAN_EN) &
+			     DW_CHAN(channel)) ? 1 : 0);
 	return size;
 }
 
@@ -1300,6 +1305,11 @@ static int dw_dma_free_data_size(struct dma *dma, unsigned int channel)
 	if (size < 0)
 		size += chan->ptr_data.buffer_bytes;
 
+	if (!size)
+		trace_dwdma("dw_dma_free_data_size() "
+			    "size is 0! Channel enable = %d.",
+			    (dw_read(dma, DW_DMA_CHAN_EN) &
+			     DW_CHAN(channel)) ? 1 : 0);
 	return size;
 }
 

--- a/src/include/sof/audio/pipeline.h
+++ b/src/include/sof/audio/pipeline.h
@@ -24,7 +24,7 @@
  * It should remain enabled in the situation when the
  * recovery is delegated to the outside of firmware.
  */
-#define NO_XRUN_RECOVERY 0
+#define NO_XRUN_RECOVERY 1
 
 /* pipeline tracing */
 #define trace_pipe(format, ...) \


### PR DESCRIPTION
pipeline: disable FW xrun recovery at the moment to rescue logs
    
dw-dma: add more logs when get avail data fail

