### PR TITLE
Mux: implement comp_reset function.

### DIFF
--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -333,7 +333,9 @@ static int mux_copy(struct comp_dev *dev)
 
 static int mux_reset(struct comp_dev *dev)
 {
-	return 0;
+	trace_mux("mux_reset()");
+
+	return comp_set_state(dev, COMP_TRIGGER_RESET);
 }
 
 static int mux_prepare(struct comp_dev *dev)


### PR DESCRIPTION
Mux component was lacking reset function implementation. This is to
address this issue.

Signed-off-by: ArturX Kloniecki <arturx.kloniecki@linux.intel.com>