### PR TITLE
topology: sof-cml-rt5682: refining for dmic16k pipeline

### DIFF
--- a/tools/topology/sof-cml-rt5682-max98357a.m4
+++ b/tools/topology/sof-cml-rt5682-max98357a.m4
@@ -6,7 +6,7 @@
 
 # Include SOF CML RT5682 Topology
 # This includes topology for RT5682, DMIC and 3 HDMI Pass through pipeline
-include(`sof-cml-rt5682.m4')
+include(`sof-cml-rt5682-kwd.m4')
 
 DEBUG_START
 #

--- a/tools/topology/sof-cml-rt5682-max98357a.m4
+++ b/tools/topology/sof-cml-rt5682-max98357a.m4
@@ -49,8 +49,8 @@ PCM_PLAYBACK_ADD(Speakers, 5, PIPELINE_PCM_7)
 # BE configurations for Speakers - overrides config in ACPI if present
 #
 
-#SSP 1 (ID: 5)
-DAI_CONFIG(SSP, 1, 5, SSP1-Codec,
+#SSP 1 (ID: 6)
+DAI_CONFIG(SSP, 1, 6, SSP1-Codec,
 	SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24000000, codec_mclk_in),
 		SSP_CLOCK(bclk, 1500000, codec_slave),
 		SSP_CLOCK(fsync, 46875, codec_slave),

--- a/tools/topology/sof-cml-rt5682.m4
+++ b/tools/topology/sof-cml-rt5682.m4
@@ -45,7 +45,7 @@ define(`SSP_MCLK_RATE', ifelse(PLATFORM, `icl', `19200000',
 # PCM2 ----> volume -----> iDisp1 (HDMI/DP playback, BE link 3)
 # PCM3 ----> volume -----> iDisp2 (HDMI/DP playback, BE link 4)
 # PCM4 ----> volume -----> iDisp3 (HDMI/DP playback, BE link 5)
-# PCM5 <------------------ DMIC16k (dmic16k, BE link 2)
+# PCM8 <---- volume <----- DMIC16k (dmic16k, BE link 2)
 #
 
 dnl PIPELINE_PCM_ADD(pipeline,
@@ -90,8 +90,8 @@ PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 
 # Passthrough capture pipeline 7 on PCM 5 using max 2 channels.
 # Schedule 16 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
-	7, 5, 2, s16le,
+PIPELINE_PCM_ADD(sof/pipe-volume-capture-16khz.m4,
+	8, 8, 2, s24le,
 	16, 1000, 0, 0)
 
 #
@@ -146,10 +146,10 @@ DAI_ADD(sof/pipe-dai-playback.m4,
 	48, 1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is DMIC16k using 2 periods
-# Buffers use s16le format, with 16 frame per 1000us on core 0 with priority 0
+# Buffers use s32le format, with 16 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
-	7, DMIC, 1, dmic16k,
-	PIPELINE_SINK_7, 2, s16le,
+	8, DMIC, 1, dmic16k,
+	PIPELINE_SINK_8, 2, s32le,
 	16, 1000, 0, 0)
 
 
@@ -160,7 +160,7 @@ PCM_CAPTURE_ADD(DMIC01, 1, PIPELINE_PCM_3)
 PCM_PLAYBACK_ADD(HDMI1, 2, PIPELINE_PCM_4)
 PCM_PLAYBACK_ADD(HDMI2, 3, PIPELINE_PCM_5)
 PCM_PLAYBACK_ADD(HDMI3, 4, PIPELINE_PCM_6)
-PCM_CAPTURE_ADD(DMIC16k, 5, PIPELINE_PCM_7)
+PCM_CAPTURE_ADD(DMIC16k, 8, PIPELINE_PCM_8)
 
 #
 # BE configurations - overrides config in ACPI if present
@@ -183,7 +183,7 @@ DAI_CONFIG(DMIC, 0, 1, dmic01,
 # dmic16k (ID: 2)
 DAI_CONFIG(DMIC, 1, 2, dmic16k,
 	   DMIC_CONFIG(1, 500000, 4800000, 40, 60, 16000,
-		DMIC_WORD_LENGTH(s16le), 400, DMIC, 1,
+		DMIC_WORD_LENGTH(s32le), 400, DMIC, 1,
 		PDM_CONFIG(DMIC, 1, STEREO_PDM0)))
 
 # 3 HDMI/DP outputs (ID: 3,4,5)


### PR DESCRIPTION
Add volume component, change to use 16KHz sample rate, and modify the
PCM ID from 5 to 8, as it is in lower priority comparing with pipelines
like amplifier.

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>