### PR TITLE
EQ IIR: Add HiFi3 optimized version

### DIFF
--- a/src/audio/eq_iir/CMakeLists.txt
+++ b/src/audio/eq_iir/CMakeLists.txt
@@ -1,3 +1,3 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-add_local_sources(sof eq_iir.c iir.c)
+add_local_sources(sof eq_iir.c iir.c iir_hifi3.c)

--- a/src/include/sof/audio/eq_iir/iir.h
+++ b/src/include/sof/audio/eq_iir/iir.h
@@ -15,6 +15,41 @@
 
 struct sof_eq_iir_header_df2t;
 
+/* Get platforms configuration */
+#include <config.h>
+
+/* If next defines are set to 1 the EQ is configured automatically. Setting
+ * to zero temporarily is useful is for testing needs.
+ * Setting EQ_FIR_AUTOARCH to 0 allows to manually set the code variant.
+ */
+#define IIR_AUTOARCH    1
+
+/* Force manually some code variant when IIR_AUTOARCH is set to zero. These
+ * are useful in code debugging.
+ */
+#if IIR_AUTOARCH == 0
+#define IIR_GENERIC	1
+#define IIR_HIFI3	0
+#endif
+
+/* Select optimized code variant when xt-xcc compiler is used */
+#if IIR_AUTOARCH == 1
+#if defined __XCC__
+#include <xtensa/config/core-isa.h>
+#if XCHAL_HAVE_HIFI3 == 1
+#define IIR_GENERIC	0
+#define IIR_HIFI3	1
+#else
+#define IIR_GENERIC	1
+#define IIR_HIFI3	0
+#endif /* XCHAL_HAVE_HIFI3 */
+#else
+/* GCC */
+#define IIR_GENERIC	1
+#define IIR_HIFI3	0
+#endif /* __XCC__ */
+#endif /* IIR_AUTOARCH */
+
 #define IIR_DF2T_NUM_DELAYS 2
 
 struct iir_state_df2t {


### PR DESCRIPTION
This patch adds for HiFi3 xt-xcc compilation for an intrinsics
optimized direct form-II transposed (df2t) filter core version
that executes faster than the generic C version.

Due to HiFi3 instruction set the delay lines are changed from Q3.61
to Q17.47 format. It causes differences in bit-exactness but no
practical audio quality difference to generic C version.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>