### PR TITLE
Topology: Updates for single EQ pipeline definitions

### DIFF
--- a/tools/topology/sof/pipe-eq-fir-volume-playback.m4
+++ b/tools/topology/sof/pipe-eq-fir-volume-playback.m4
@@ -27,12 +27,18 @@ C_CONTROLMIXER(Master Playback Volume, PIPELINE_ID,
 	Channel register and shift for Front Left/Right,
 	LIST(`	', KCONTROL_CHANNEL(FL, 1, 0), KCONTROL_CHANNEL(FR, 1, 1)))
 
+#
+# Volume configuration
+#
+
+W_VENDORTUPLES(playback_pga_tokens, sof_volume_tokens,
+LIST(`		', `SOF_TKN_VOLUME_RAMP_STEP_TYPE	"0"'
+     `		', `SOF_TKN_VOLUME_RAMP_STEP_MS		"250"'))
+
+W_DATA(playback_pga_conf, playback_pga_tokens)
+
 # EQ initial parameters, in this case flat response
-CONTROLBYTES_PRIV(EQFIR_priv,
-`	bytes "0x18,0x00,0x00,0x00,0x02,0x00,0x01,0x00,'
-`	0x00,0x00,0x00,0x00,0x04,0x00,0xff,0xff,'
-`	0x00,0x40,0x00,0x00,0x00,0x00,0x00,0x00"'
-)
+include(`eq_fir_coef_flat.m4')
 
 # EQ Bytes control with max value of 255
 C_CONTROLBYTES(EQFIR, PIPELINE_ID,
@@ -52,7 +58,7 @@ C_CONTROLBYTES(EQFIR, PIPELINE_ID,
 W_PCM_PLAYBACK(PCM_ID, Passthrough Playback, 2, 0)
 
 # "Volume" has 2 source and 2 sink periods
-W_PGA(0, PIPELINE_FORMAT, 2, 2, LIST(`		', "PIPELINE_ID Master Playback Volume"))
+W_PGA(0, PIPELINE_FORMAT, 2, 2, playback_pga_conf, LIST(`		', "PIPELINE_ID Master Playback Volume"))
 
 # "EQ 0" has 2 sink period and 2 source periods
 W_EQ_FIR(0, PIPELINE_FORMAT, 2, 2, LIST(`		', "EQFIR"))

--- a/tools/topology/sof/pipe-eq-iir-volume-playback.m4
+++ b/tools/topology/sof/pipe-eq-iir-volume-playback.m4
@@ -27,16 +27,18 @@ C_CONTROLMIXER(Master Playback Volume, PIPELINE_ID,
 	Channel register and shift for Front Left/Right,
 	LIST(`	', KCONTROL_CHANNEL(FL, 1, 0), KCONTROL_CHANNEL(FR, 1, 1)))
 
+#
+# Volume configuration
+#
+
+W_VENDORTUPLES(playback_pga_tokens, sof_volume_tokens,
+LIST(`		', `SOF_TKN_VOLUME_RAMP_STEP_TYPE	"0"'
+     `		', `SOF_TKN_VOLUME_RAMP_STEP_MS		"250"'))
+
+W_DATA(playback_pga_conf, playback_pga_tokens)
+
 # EQ initial parameters, in this case flat response
-CONTROLBYTES_PRIV(EQIIR_priv,
-`	bytes "0x38,0x00,0x00,0x00,0x02,0x00,0x00,0x00,'
-`	0x01,0x00,0x00,0x00,0x00,0x00,0x00,0x00,'
-`	0x00,0x00,0x00,0x00,0x01,0x00,0x00,0x00,'
-`	0x01,0x00,0x00,0x00,0x00,0x00,0x00,0x00,'
-`	0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,'
-`	0x00,0x00,0x00,0x00,0x9e,0x73,0x13,0x20,'
-`	0x00,0x00,0x00,0x00,0xb2,0x7f,0x00,0x00"'
-)
+include(`eq_iir_coef_flat.m4')
 
 # EQ Bytes control with max value of 255
 C_CONTROLBYTES(EQIIR, PIPELINE_ID,
@@ -56,7 +58,7 @@ C_CONTROLBYTES(EQIIR, PIPELINE_ID,
 W_PCM_PLAYBACK(PCM_ID, Passthrough Playback, 2, 0)
 
 # "Volume" has 2 source and 2 sink periods
-W_PGA(0, PIPELINE_FORMAT, 2, 2, LIST(`		', "PIPELINE_ID Master Playback Volume"))
+W_PGA(0, PIPELINE_FORMAT, 2, 2, playback_pga_conf, LIST(`		', "PIPELINE_ID Master Playback Volume"))
 
 # "EQ 0" has 2 sink period and 2 source periods
 W_EQ_IIR(0, PIPELINE_FORMAT, 2, 2, LIST(`		', "EQIIR"))


### PR DESCRIPTION
This patch provides needed maintenance. The pipelines
missed the volume ramp tokens and caused topology build fail for
topologies those would use the pipeline macros
pipe-eq-fir-volume-playback.m4 and pipe-eq-iir-volume-playback.m4.

The embedded filter coefficients in these pipelines were replaced
by included default FIR and IIR filter coefficients to fix ABI
incompatibility in the configuration blobs and ease future
maintenance of these pipelines.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>