### PR TITLE
Buffer: Allow multiple callbacks registered to buffer component.

### DIFF
--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -79,6 +79,8 @@ struct host_data {
 				   *  copied by dma connected to host
 				   */
 
+	struct buffer_callback buffer_cb;
+
 	/* stream info */
 	struct sof_ipc_stream_posn posn; /* TODO: update this */
 };
@@ -329,6 +331,8 @@ static int host_trigger(struct comp_dev *dev, int cmd)
 	return ret;
 }
 
+static void host_buffer_cb(void *data, int type, void *value_ptr);
+
 static struct comp_dev *host_new(struct sof_ipc_comp *comp)
 {
 	struct sof_ipc_comp_host *ipc_host = (struct sof_ipc_comp_host *)comp;
@@ -381,6 +385,11 @@ static struct comp_dev *host_new(struct sof_ipc_comp *comp)
 	dma_sg_init(&hd->local.elem_array);
 
 	hd->chan = DMA_CHAN_INVALID;
+
+	hd->buffer_cb.cb = &host_buffer_cb;
+	hd->buffer_cb.cb_arg = dev;
+	list_init(&hd->buffer_cb.list);
+
 	hd->copy_type = COMP_COPY_NORMAL;
 	hd->posn.comp_id = comp->id;
 	dev->state = COMP_STATE_READY;
@@ -436,7 +445,7 @@ static int host_elements_reset(struct comp_dev *dev)
 	return 0;
 }
 
-static void host_buffer_cb(void *data, uint32_t bytes)
+static void host_buffer_cb(void *data, int type, void *value_ptr)
 {
 	struct comp_dev *dev = (struct comp_dev *)data;
 	struct host_data *hd = comp_get_drvdata(dev);
@@ -515,8 +524,8 @@ static int host_params(struct comp_dev *dev)
 			struct comp_buffer, source_list);
 
 		/* set callback on buffer consume */
-		buffer_set_cb(hd->dma_buffer, &host_buffer_cb, dev,
-			      BUFF_CB_TYPE_CONSUME);
+		hd->buffer_cb.cb_type = BUFF_CB_TYPE_CONSUME;
+		buffer_add_callback(hd->dma_buffer, &hd->buffer_cb);
 
 		config->direction = DMA_DIR_HMEM_TO_LMEM;
 
@@ -537,8 +546,8 @@ static int host_params(struct comp_dev *dev)
 			struct comp_buffer, sink_list);
 
 		/* set callback on buffer produce */
-		buffer_set_cb(hd->dma_buffer, &host_buffer_cb, dev,
-			      BUFF_CB_TYPE_PRODUCE);
+		hd->buffer_cb.cb_type = BUFF_CB_TYPE_PRODUCE;
+		buffer_add_callback(hd->dma_buffer, &hd->buffer_cb);
 
 		config->direction = DMA_DIR_LMEM_TO_HMEM;
 

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -29,9 +29,25 @@ struct comp_dev;
 #define tracev_buffer(__e, ...) \
 	tracev_event(TRACE_CLASS_BUFFER, __e, ##__VA_ARGS__)
 
-/* buffer callback types */
+/* buffer callback types
+ * Data pointer passed via callback has different meanings, depending on type
+ * of the callback.
+ *
+ * BUFF_CB_TYPE_PRODUCE - uint32_t* pointing to amount of bytes produced
+ * BUFF_CB_TYPE_CONSUME - uint32_t* pointing to amount of bytes consumed
+ * BUFF_CB_TYPE_FREE_COMP - struct comp_buffer* pointing to buffer component
+ *			    being freed
+ */
 #define BUFF_CB_TYPE_PRODUCE	BIT(0)
 #define BUFF_CB_TYPE_CONSUME	BIT(1)
+#define BUFF_CB_TYPE_FREE_COMP	BIT(2)
+
+struct buffer_callback {
+	void (*cb)(void *arg, int type, void *data);
+	void *cb_arg;		/* self pointer returned for callee */
+	int cb_type;		/* type of callback */
+	struct list_item list;	/* item in list of callbacks */
+};
 
 /* audio component buffer - connects 2 audio components together in pipeline */
 struct comp_buffer {
@@ -57,10 +73,7 @@ struct comp_buffer {
 	struct list_item source_list;	/* list in comp buffers */
 	struct list_item sink_list;	/* list in comp buffers */
 
-	/* callbacks */
-	void (*cb)(void *data, uint32_t bytes);
-	void *cb_data;
-	int cb_type;
+	struct list_item callback_list; /* list of callbacks */
 
 	spinlock_t lock; /* component buffer spinlock */
 };
@@ -222,4 +235,11 @@ static inline void buffer_init(struct comp_buffer *buffer, uint32_t size)
 	buffer->avail = 0;
 	buffer_zero(buffer);
 }
+
+static inline void buffer_add_callback(struct comp_buffer *buffer,
+				       struct buffer_callback *cb)
+{
+	list_item_append(&cb->list, &buffer->callback_list);
+}
+
 #endif /* __SOF_AUDIO_BUFFER_H__ */

--- a/test/cmocka/src/audio/kpb/kpb_buffer.c
+++ b/test/cmocka/src/audio/kpb/kpb_buffer.c
@@ -170,7 +170,7 @@ static struct comp_buffer *mock_comp_buffer(void **state,
 		break;
 	}
 
-	buffer->cb = NULL;
+	list_init(&buffer->callback_list);
 
 	return buffer;
 }


### PR DESCRIPTION
In order to allow multiple callbacks registered to single buffer
component, buffer_callback structure is created and list of callbacks
nested into comp_buffer.

Signed-off-by: ArturX Kloniecki <arturx.kloniecki@linux.intel.com>