### PR TITLE
kconfig: IS_ENABLED macro

### DIFF
--- a/src/include/sof/common.h
+++ b/src/include/sof/common.h
@@ -3,6 +3,7 @@
  * Copyright(c) 2019 Intel Corporation. All rights reserved.
  *
  * Author: Tomasz Lauda <tomasz.lauda@linux.intel.com>
+ *         Janusz Jankowski <janusz.jankowski@linux.intel.com>
  */
 
 #ifndef __SOF_COMMON_H__
@@ -36,5 +37,21 @@
 #define STATIC_ASSERT(COND, MESSAGE)	\
 	__attribute__((unused))		\
 	typedef char META_CONCAT(assertion_failed_, MESSAGE)[(COND) ? 1 : -1]
+
+/* Allows checking preprocessor symbols in compile-time.
+ * Returns true for config with value 1, false for undefined or any other value.
+ *
+ * Expression like (CONFIG_MY ? a : b) rises compilation error when CONFIG_MY
+ * is undefined, (IS_ENABLED(CONFIG_MY) ? a : b) can be used instead of it.
+ *
+ * It is intended to be used with Kconfig's bool configs - it should rise
+ * error for other types, except positive integers, but it shouldn't be
+ * used with them.
+ */
+#define IS_ENABLED(config) IS_ENABLED_STEP_1(config)
+#define IS_ENABLED_DUMMY_1 0,
+#define IS_ENABLED_STEP_1(config) IS_ENABLED_STEP_2(IS_ENABLED_DUMMY_ ## config)
+#define IS_ENABLED_STEP_2(values) IS_ENABLED_STEP_3(values 1, 0)
+#define IS_ENABLED_STEP_3(ignore, value, ...) (!!(value))
 
 #endif /* __SOF_COMMON_H__ */


### PR DESCRIPTION
Allows checking preprocessor symbols in compile-time.
Returns true for config with value 1, false for undefined
or any other value.

Expression like (CONFIG_MY ? a : b) rises compilation error when
CONFIG_MY is undefined, (IS_ENABLED(CONFIG_MY) ? a : b) can be
used instead of it.

It is intended to be used with Kconfig's bool configs - it should rise
error for other types, except positive integers, but it shouldn't be
used with them.

Signed-off-by: Janusz Jankowski <janusz.jankowski@linux.intel.com>