### PR TITLE
task: move task structure and defines to the right header

### DIFF
--- a/src/arch/xtensa/drivers/idc.c
+++ b/src/arch/xtensa/drivers/idc.c
@@ -18,6 +18,7 @@
 #include <sof/lib/shim.h>
 #include <sof/platform.h>
 #include <sof/schedule/schedule.h>
+#include <sof/schedule/task.h>
 #include <ipc/control.h>
 #include <ipc/stream.h>
 #include <ipc/topology.h>

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -29,6 +29,7 @@
 #include <sof/math/numbers.h>
 #include <sof/platform.h>
 #include <sof/schedule/schedule.h>
+#include <sof/schedule/task.h>
 #include <sof/string.h>
 #include <sof/ut.h>
 #include <ipc/topology.h>

--- a/src/audio/pipeline_static.c
+++ b/src/audio/pipeline_static.c
@@ -13,6 +13,7 @@
 #include <sof/audio/pipeline.h>
 #include <sof/common.h>
 #include <sof/drivers/ipc.h>
+#include <sof/schedule/task.h>
 #include <sof/trace/trace.h>
 #include <ipc/dai.h>
 #include <ipc/stream.h>

--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -27,6 +27,7 @@
 #include <sof/math/numbers.h>
 #include <sof/platform.h>
 #include <sof/schedule/schedule.h>
+#include <sof/schedule/task.h>
 #include <sof/string.h>
 #include <sof/trace/trace.h>
 #include <ipc/control.h>

--- a/src/drivers/dw/ssi-spi.c
+++ b/src/drivers/dw/ssi-spi.c
@@ -19,6 +19,7 @@
 #include <sof/lib/wait.h>
 #include <sof/platform.h>
 #include <sof/schedule/schedule.h>
+#include <sof/schedule/task.h>
 #include <sof/spinlock.h>
 #include <sof/string.h>
 #include <ipc/header.h>

--- a/src/drivers/imx/ipc.c
+++ b/src/drivers/imx/ipc.c
@@ -13,6 +13,7 @@
 #include <sof/list.h>
 #include <sof/platform.h>
 #include <sof/schedule/schedule.h>
+#include <sof/schedule/task.h>
 #include <sof/spinlock.h>
 #include <ipc/header.h>
 #include <ipc/topology.h>

--- a/src/drivers/intel/cavs/dmic.c
+++ b/src/drivers/intel/cavs/dmic.c
@@ -22,6 +22,7 @@
 #include <sof/math/decibels.h>
 #include <sof/math/numbers.h>
 #include <sof/schedule/schedule.h>
+#include <sof/schedule/task.h>
 #include <sof/spinlock.h>
 #include <sof/string.h>
 #include <sof/trace/trace.h>

--- a/src/drivers/intel/cavs/ipc.c
+++ b/src/drivers/intel/cavs/ipc.c
@@ -16,6 +16,7 @@
 #include <sof/list.h>
 #include <sof/platform.h>
 #include <sof/schedule/schedule.h>
+#include <sof/schedule/task.h>
 #include <sof/spinlock.h>
 #include <ipc/header.h>
 #include <config.h>

--- a/src/drivers/intel/cavs/sue-ipc.c
+++ b/src/drivers/intel/cavs/sue-ipc.c
@@ -12,6 +12,7 @@
 #include <sof/lib/wait.h>
 #include <sof/list.h>
 #include <sof/schedule/schedule.h>
+#include <sof/schedule/task.h>
 #include <sof/spinlock.h>
 #include <ipc/header.h>
 #include <stddef.h>

--- a/src/drivers/intel/haswell/ipc.c
+++ b/src/drivers/intel/haswell/ipc.c
@@ -14,6 +14,7 @@
 #include <sof/list.h>
 #include <sof/platform.h>
 #include <sof/schedule/schedule.h>
+#include <sof/schedule/task.h>
 #include <sof/spinlock.h>
 #include <ipc/header.h>
 #include <ipc/topology.h>

--- a/src/include/sof/audio/pipeline.h
+++ b/src/include/sof/audio/pipeline.h
@@ -8,7 +8,7 @@
 #ifndef __SOF_AUDIO_PIPELINE_H__
 #define __SOF_AUDIO_PIPELINE_H__
 
-#include <sof/schedule/schedule.h>
+#include <sof/schedule/task.h>
 #include <sof/spinlock.h>
 #include <sof/trace/trace.h>
 #include <ipc/topology.h>

--- a/src/include/sof/audio/volume.h
+++ b/src/include/sof/audio/volume.h
@@ -18,7 +18,7 @@
 
 #include <sof/audio/component.h>
 #include <sof/bit.h>
-#include <sof/schedule/schedule.h>
+#include <sof/schedule/task.h>
 #include <sof/trace/trace.h>
 #include <ipc/stream.h>
 #include <stddef.h>

--- a/src/include/sof/drivers/dmic.h
+++ b/src/include/sof/drivers/dmic.h
@@ -56,7 +56,7 @@
 #include <sof/bit.h>
 #include <sof/lib/dai.h>
 #include <sof/lib/wait.h>
-#include <sof/schedule/schedule.h>
+#include <sof/schedule/task.h>
 #include <stdint.h>
 
 /* Parameters used in modes computation */

--- a/src/include/sof/drivers/idc.h
+++ b/src/include/sof/drivers/idc.h
@@ -16,7 +16,7 @@
 
 #include <arch/drivers/idc.h>
 #include <platform/drivers/idc.h>
-#include <sof/schedule/schedule.h>
+#include <sof/schedule/task.h>
 #include <sof/trace/trace.h>
 #include <stdint.h>
 

--- a/src/include/sof/drivers/ipc.h
+++ b/src/include/sof/drivers/ipc.h
@@ -11,7 +11,7 @@
 
 #include <sof/list.h>
 #include <sof/platform.h>
-#include <sof/schedule/schedule.h>
+#include <sof/schedule/task.h>
 #include <sof/spinlock.h>
 #include <sof/trace/dma-trace.h>
 #include <sof/trace/trace.h>

--- a/src/include/sof/lib/agent.h
+++ b/src/include/sof/lib/agent.h
@@ -8,7 +8,7 @@
 #ifndef __SOF_LIB_AGENT_H__
 #define __SOF_LIB_AGENT_H__
 
-#include <sof/schedule/schedule.h>
+#include <sof/schedule/task.h>
 #include <stdint.h>
 
 struct sof;

--- a/src/include/sof/lib/wait.h
+++ b/src/include/sof/lib/wait.h
@@ -15,6 +15,7 @@
 #include <arch/lib/wait.h>
 #include <sof/drivers/timer.h>
 #include <sof/schedule/schedule.h>
+#include <sof/schedule/task.h>
 #include <sof/spinlock.h>
 #include <sof/trace/trace.h>
 #include <stdint.h>

--- a/src/include/sof/schedule/edf_schedule.h
+++ b/src/include/sof/schedule/edf_schedule.h
@@ -8,6 +8,7 @@
 #ifndef __SOF_SCHEDULE_EDF_SCHEDULE_H__
 #define __SOF_SCHEDULE_EDF_SCHEDULE_H__
 
+#include <sof/schedule/task.h>
 #include <sof/trace/trace.h>
 #include <stdint.h>
 

--- a/src/include/sof/schedule/ll_schedule.h
+++ b/src/include/sof/schedule/ll_schedule.h
@@ -14,6 +14,7 @@
 #define __SOF_SCHEDULE_LL_SCHEDULE_H__
 
 #include <sof/drivers/timer.h>
+#include <sof/schedule/task.h>
 #include <sof/trace/trace.h>
 #include <stdint.h>
 

--- a/src/include/sof/schedule/schedule.h
+++ b/src/include/sof/schedule/schedule.h
@@ -34,25 +34,6 @@ enum {
 	SOF_SCHEDULE_COUNT
 };
 
-#define SOF_TASK_PRI_HIGH	0	/* priority level 0 - high */
-#define SOF_TASK_PRI_MED	4	/* priority level 4 - medium */
-#define SOF_TASK_PRI_LOW	9	/* priority level 9 - low */
-
-#define SOF_TASK_PRI_COUNT	10	/* range of priorities (0-9) */
-
-#define SOF_TASK_PRI_IPC	SOF_TASK_PRI_LOW
-#define SOF_TASK_PRI_IDC	SOF_TASK_PRI_LOW
-
-/* task states */
-#define SOF_TASK_STATE_INIT		0
-#define SOF_TASK_STATE_QUEUED		1
-#define SOF_TASK_STATE_PENDING		2
-#define SOF_TASK_STATE_RUNNING		3
-#define SOF_TASK_STATE_PREEMPTED	4
-#define SOF_TASK_STATE_COMPLETED	5
-#define SOF_TASK_STATE_FREE		6
-#define SOF_TASK_STATE_CANCEL		7
-
 /* Scheduler flags */
 /* Sync/Async only supported by ll scheduler atm */
 #define SOF_SCHEDULE_FLAG_ASYNC (0 << 0) /* task scheduled asynchronously */
@@ -71,20 +52,6 @@ struct scheduler_ops {
 	int (*scheduler_init)(void);
 	void (*scheduler_free)(void);
 	void (*scheduler_run)(void);
-};
-
-struct task {
-	uint16_t type;
-	uint64_t start;
-	uint16_t priority;
-	uint16_t state;
-	uint16_t core;
-	void *data;
-	uint64_t (*func)(void *data);
-	struct list_item list;
-	struct list_item irq_list;	/* list for assigned irq level */
-	const struct scheduler_ops *ops;
-	void *private;
 };
 
 struct schedule_data {

--- a/src/include/sof/schedule/task.h
+++ b/src/include/sof/schedule/task.h
@@ -9,9 +9,44 @@
 #define __SOF_SCHEDULE_TASK_H__
 
 #include <arch/schedule/task.h>
+#include <sof/list.h>
+#include <stdint.h>
 
+struct scheduler_ops;
 struct sof;
-struct task;
+
+#define SOF_TASK_PRI_HIGH	0	/* priority level 0 - high */
+#define SOF_TASK_PRI_MED	4	/* priority level 4 - medium */
+#define SOF_TASK_PRI_LOW	9	/* priority level 9 - low */
+
+#define SOF_TASK_PRI_COUNT	10	/* range of priorities (0-9) */
+
+#define SOF_TASK_PRI_IPC	SOF_TASK_PRI_LOW
+#define SOF_TASK_PRI_IDC	SOF_TASK_PRI_LOW
+
+/* task states */
+#define SOF_TASK_STATE_INIT		0
+#define SOF_TASK_STATE_QUEUED		1
+#define SOF_TASK_STATE_PENDING		2
+#define SOF_TASK_STATE_RUNNING		3
+#define SOF_TASK_STATE_PREEMPTED	4
+#define SOF_TASK_STATE_COMPLETED	5
+#define SOF_TASK_STATE_FREE		6
+#define SOF_TASK_STATE_CANCEL		7
+
+struct task {
+	uint16_t type;
+	uint64_t start;
+	uint16_t priority;
+	uint16_t state;
+	uint16_t core;
+	void *data;
+	uint64_t (*func)(void *data);
+	struct list_item list;
+	struct list_item irq_list;	/* list for assigned irq level */
+	const struct scheduler_ops *ops;
+	void *private;
+};
 
 int do_task_master_core(struct sof *sof);
 

--- a/src/include/sof/trace/dma-trace.h
+++ b/src/include/sof/trace/dma-trace.h
@@ -9,7 +9,7 @@
 #define __SOF_TRACE_DMA_TRACE_H__
 
 #include <sof/lib/dma.h>
-#include <sof/schedule/schedule.h>
+#include <sof/schedule/task.h>
 #include <sof/spinlock.h>
 #include <stdint.h>
 

--- a/src/lib/agent.c
+++ b/src/lib/agent.c
@@ -19,6 +19,7 @@
 #include <sof/debug/panic.h>
 #include <sof/platform.h>
 #include <sof/schedule/schedule.h>
+#include <sof/schedule/task.h>
 #include <sof/sof.h>
 #include <sof/trace/trace.h>
 #include <ipc/topology.h>

--- a/src/schedule/ll_schedule.c
+++ b/src/schedule/ll_schedule.c
@@ -33,6 +33,7 @@
 #include <sof/platform.h>
 #include <sof/schedule/ll_schedule.h>
 #include <sof/schedule/schedule.h>
+#include <sof/schedule/task.h>
 #include <sof/spinlock.h>
 #include <ipc/topology.h>
 #include <errno.h>

--- a/src/schedule/schedule.c
+++ b/src/schedule/schedule.c
@@ -8,6 +8,7 @@
 
 #include <sof/lib/alloc.h>
 #include <sof/schedule/schedule.h>
+#include <sof/schedule/task.h>
 #include <ipc/topology.h>
 #include <errno.h>
 #include <stdint.h>

--- a/src/trace/dma-trace.c
+++ b/src/trace/dma-trace.c
@@ -14,6 +14,7 @@
 #include <sof/lib/dma.h>
 #include <sof/platform.h>
 #include <sof/schedule/schedule.h>
+#include <sof/schedule/task.h>
 #include <sof/sof.h>
 #include <sof/spinlock.h>
 #include <sof/string.h>

--- a/test/cmocka/src/audio/kpb/kpb_buffer.c
+++ b/test/cmocka/src/audio/kpb/kpb_buffer.c
@@ -23,6 +23,7 @@
 #include "kpb_mock.h"
 #include <sof/list.h>
 #include <sof/lib/notifier.h>
+#include <sof/schedule/task.h>
 #include <user/kpb.h>
 
 /*! Local data types */

--- a/test/cmocka/src/audio/kpb/kpb_mock.c
+++ b/test/cmocka/src/audio/kpb/kpb_mock.c
@@ -15,6 +15,7 @@
 #include <sof/lib/notifier.h>
 #include <sof/audio/component.h>
 #include <sof/drivers/timer.h>
+#include <sof/schedule/schedule.h>
 #include <mock_trace.h>
 #include <sof/lib/clk.h>
 

--- a/test/cmocka/src/audio/pipeline/pipeline_free.c
+++ b/test/cmocka/src/audio/pipeline/pipeline_free.c
@@ -8,6 +8,7 @@
 #include <sof/audio/component.h>
 #include <sof/audio/pipeline.h>
 #include <sof/schedule/edf_schedule.h>
+#include <sof/schedule/task.h>
 #include "pipeline_mocks.h"
 #include "pipeline_connection_mocks.h"
 #include <stdarg.h>

--- a/test/cmocka/src/audio/pipeline/pipeline_mocks.h
+++ b/test/cmocka/src/audio/pipeline/pipeline_mocks.h
@@ -9,6 +9,7 @@
 #include <sof/audio/pipeline.h>
 #include <sof/lib/clk.h>
 #include <sof/schedule/edf_schedule.h>
+#include <sof/schedule/schedule.h>
 #include <stdarg.h>
 #include <stddef.h>
 #include <setjmp.h>


### PR DESCRIPTION
Moves task structure and defines to the sof/task.h,
where they should be from the beginning. sof/schedule.h is
just for scheduler related things.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>