### PR TITLE
mux: return PPL_STATUS_PATH_STOP in mux_trigger()

### DIFF
--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -405,9 +405,16 @@ err:
 
 static int mux_trigger(struct comp_dev *dev, int cmd)
 {
+	int ret = 0;
+
 	trace_mux("mux_trigger(), command = %u", cmd);
 
-	return comp_set_state(dev, cmd);
+	ret = comp_set_state(dev, cmd);
+
+	if (ret == COMP_STATUS_STATE_ALREADY_SET)
+		ret = PPL_STATUS_PATH_STOP;
+
+	return ret;
 }
 
 struct comp_driver comp_mux = {


### PR DESCRIPTION
This commit does not change FW behaviour since
both COMP_STATUS_STATE_ALREADY_SET and PPL_STATUS_PATH_STOP
defines are equal to 1. It just makes code more clear.

Signed-off-by: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>