### PR TITLE
trace: deduplicate TRACE_CLASS defines

### DIFF
--- a/src/arch/xtensa/lib/cpu.c
+++ b/src/arch/xtensa/lib/cpu.c
@@ -19,6 +19,7 @@
 #include <sof/schedule/schedule.h>
 #include <sof/spinlock.h>
 #include <sof/trace/trace.h>
+#include <user/trace.h>
 #include <xtos-structs.h>
 #include <stdint.h>
 

--- a/src/arch/xtensa/schedule/task.c
+++ b/src/arch/xtensa/schedule/task.c
@@ -20,6 +20,7 @@
 #include <sof/spinlock.h>
 #include <sof/trace/trace.h>
 #include <ipc/topology.h>
+#include <user/trace.h>
 #include <config.h>
 #include <xtos-structs.h>
 #include <errno.h>

--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -22,6 +22,7 @@
 #include <ipc/dai.h>
 #include <ipc/stream.h>
 #include <ipc/topology.h>
+#include <user/trace.h>
 #include <errno.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/src/audio/detect_test.c
+++ b/src/audio/detect_test.c
@@ -23,6 +23,7 @@
 #include <ipc/topology.h>
 #include <kernel/abi.h>
 #include <user/detect_test.h>
+#include <user/trace.h>
 #include <errno.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -24,6 +24,7 @@
 #include <ipc/topology.h>
 #include <kernel/abi.h>
 #include <user/eq.h>
+#include <user/trace.h>
 #include <errno.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -25,6 +25,7 @@
 #include <ipc/stream.h>
 #include <ipc/topology.h>
 #include <user/eq.h>
+#include <user/trace.h>
 #include <errno.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -20,6 +20,7 @@
 #include <sof/trace/trace.h>
 #include <ipc/stream.h>
 #include <ipc/topology.h>
+#include <user/trace.h>
 #include <errno.h>
 #include <stdbool.h>
 #include <stddef.h>

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -34,6 +34,7 @@
 #include <sof/ut.h>
 #include <ipc/topology.h>
 #include <user/kpb.h>
+#include <user/trace.h>
 #include <errno.h>
 #include <stdbool.h>
 #include <stddef.h>

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -23,6 +23,7 @@
 #include <sof/ut.h>
 #include <ipc/stream.h>
 #include <ipc/topology.h>
+#include <user/trace.h>
 #include <stddef.h>
 #include <stdint.h>
 

--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -22,6 +22,7 @@
 #include <sof/trace/trace.h>
 #include <ipc/control.h>
 #include <ipc/topology.h>
+#include <user/trace.h>
 #include <errno.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -28,6 +28,7 @@
 #include <ipc/stream.h>
 #include <ipc/topology.h>
 #include <kernel/abi.h>
+#include <user/trace.h>
 #include <errno.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -24,6 +24,7 @@
 #include <ipc/control.h>
 #include <ipc/stream.h>
 #include <ipc/topology.h>
+#include <user/trace.h>
 #include <errno.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/src/audio/switch.c
+++ b/src/audio/switch.c
@@ -8,6 +8,7 @@
 #include <sof/common.h>
 #include <sof/trace/trace.h>
 #include <ipc/topology.h>
+#include <user/trace.h>
 #include <stddef.h>
 
 /* tracing */

--- a/src/audio/tone.c
+++ b/src/audio/tone.c
@@ -24,6 +24,7 @@
 #include <ipc/stream.h>
 #include <ipc/topology.h>
 #include <user/tone.h>
+#include <user/trace.h>
 #include <errno.h>
 #include <stdbool.h>
 #include <stddef.h>

--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -33,6 +33,7 @@
 #include <ipc/control.h>
 #include <ipc/stream.h>
 #include <ipc/topology.h>
+#include <user/trace.h>
 #include <errno.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/src/drivers/intel/baytrail/ssp.c
+++ b/src/drivers/intel/baytrail/ssp.c
@@ -16,6 +16,7 @@
 #include <ipc/dai-intel.h>
 #include <ipc/stream.h>
 #include <ipc/topology.h>
+#include <user/trace.h>
 #include <errno.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/src/drivers/intel/cavs/dmic.c
+++ b/src/drivers/intel/cavs/dmic.c
@@ -29,6 +29,7 @@
 #include <ipc/dai.h>
 #include <ipc/dai-intel.h>
 #include <ipc/topology.h>
+#include <user/trace.h>
 #include <errno.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/src/drivers/intel/cavs/hda-dma.c
+++ b/src/drivers/intel/cavs/hda-dma.c
@@ -19,6 +19,7 @@
 #include <sof/spinlock.h>
 #include <sof/trace/trace.h>
 #include <ipc/topology.h>
+#include <user/trace.h>
 #include <errno.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/src/drivers/intel/cavs/soundwire.c
+++ b/src/drivers/intel/cavs/soundwire.c
@@ -8,6 +8,7 @@
 #include <sof/lib/dma.h>
 #include <sof/trace/trace.h>
 #include <ipc/dai.h>
+#include <user/trace.h>
 
 #define trace_soundwire(__e, ...) \
 	trace_event(TRACE_CLASS_SOUNDWIRE, __e, ##__VA_ARGS__)

--- a/src/drivers/intel/cavs/ssp.c
+++ b/src/drivers/intel/cavs/ssp.c
@@ -22,6 +22,7 @@
 #include <ipc/dai-intel.h>
 #include <ipc/stream.h>
 #include <ipc/topology.h>
+#include <user/trace.h>
 #include <errno.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/src/drivers/intel/haswell/ssp.c
+++ b/src/drivers/intel/haswell/ssp.c
@@ -17,6 +17,7 @@
 #include <ipc/dai-intel.h>
 #include <ipc/stream.h>
 #include <ipc/topology.h>
+#include <user/trace.h>
 #include <errno.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -16,6 +16,7 @@
 #include <sof/spinlock.h>
 #include <sof/trace/trace.h>
 #include <ipc/topology.h>
+#include <user/trace.h>
 #include <stddef.h>
 #include <stdint.h>
 

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -27,6 +27,7 @@
 #include <ipc/stream.h>
 #include <ipc/topology.h>
 #include <kernel/abi.h>
+#include <user/trace.h>
 #include <config.h>
 #include <errno.h>
 #include <stddef.h>

--- a/src/include/sof/audio/kpb.h
+++ b/src/include/sof/audio/kpb.h
@@ -9,6 +9,7 @@
 #define __SOF_AUDIO_KPB_H__
 
 #include <sof/trace/trace.h>
+#include <user/trace.h>
 #include <stdint.h>
 
 struct comp_buffer;

--- a/src/include/sof/audio/mux.h
+++ b/src/include/sof/audio/mux.h
@@ -21,6 +21,7 @@
 #include <sof/common.h>
 #include <sof/platform.h>
 #include <sof/trace/trace.h>
+#include <user/trace.h>
 #include <stdint.h>
 
 struct comp_buffer;

--- a/src/include/sof/audio/pipeline.h
+++ b/src/include/sof/audio/pipeline.h
@@ -12,6 +12,7 @@
 #include <sof/spinlock.h>
 #include <sof/trace/trace.h>
 #include <ipc/topology.h>
+#include <user/trace.h>
 #include <stdbool.h>
 #include <stdint.h>
 

--- a/src/include/sof/audio/selector.h
+++ b/src/include/sof/audio/selector.h
@@ -17,6 +17,7 @@
 #include <sof/trace/trace.h>
 #include <ipc/stream.h>
 #include <user/selector.h>
+#include <user/trace.h>
 #include <stdint.h>
 
 struct comp_buffer;

--- a/src/include/sof/audio/volume.h
+++ b/src/include/sof/audio/volume.h
@@ -21,6 +21,7 @@
 #include <sof/schedule/task.h>
 #include <sof/trace/trace.h>
 #include <ipc/stream.h>
+#include <user/trace.h>
 #include <stddef.h>
 #include <stdint.h>
 

--- a/src/include/sof/drivers/dw-dma.h
+++ b/src/include/sof/drivers/dw-dma.h
@@ -14,6 +14,7 @@
 #include <sof/common.h>
 #include <sof/lib/dma.h>
 #include <sof/trace/trace.h>
+#include <user/trace.h>
 #include <stdint.h>
 
 /* channel registers */

--- a/src/include/sof/drivers/idc.h
+++ b/src/include/sof/drivers/idc.h
@@ -18,6 +18,7 @@
 #include <platform/drivers/idc.h>
 #include <sof/schedule/task.h>
 #include <sof/trace/trace.h>
+#include <user/trace.h>
 #include <stdint.h>
 
 /** \brief IDC trace function. */

--- a/src/include/sof/drivers/interrupt.h
+++ b/src/include/sof/drivers/interrupt.h
@@ -14,6 +14,7 @@
 #include <sof/list.h>
 #include <sof/spinlock.h>
 #include <sof/trace/trace.h>
+#include <user/trace.h>
 #include <stdint.h>
 
 #define trace_irq(__e)	trace_event(TRACE_CLASS_IRQ, __e)

--- a/src/include/sof/drivers/ipc.h
+++ b/src/include/sof/drivers/ipc.h
@@ -16,6 +16,7 @@
 #include <sof/trace/dma-trace.h>
 #include <sof/trace/trace.h>
 #include <ipc/header.h>
+#include <user/trace.h>
 #include <stdint.h>
 
 struct comp_buffer;

--- a/src/include/sof/drivers/ssp.h
+++ b/src/include/sof/drivers/ssp.h
@@ -15,6 +15,7 @@
 #include <sof/trace/trace.h>
 #include <ipc/dai.h>
 #include <ipc/dai-intel.h>
+#include <user/trace.h>
 #include <config.h>
 #include <stdint.h>
 

--- a/src/include/sof/lib/alloc.h
+++ b/src/include/sof/lib/alloc.h
@@ -15,6 +15,7 @@
 #include <sof/lib/memory.h>
 #include <sof/spinlock.h>
 #include <sof/string.h>
+#include <user/trace.h>
 #include <config.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/src/include/sof/lib/pm_runtime.h
+++ b/src/include/sof/lib/pm_runtime.h
@@ -17,6 +17,7 @@
 #include <platform/lib/pm_runtime.h>
 #include <sof/spinlock.h>
 #include <sof/trace/trace.h>
+#include <user/trace.h>
 #include <stdint.h>
 
 /** \addtogroup pm_runtime PM Runtime

--- a/src/include/sof/lib/wait.h
+++ b/src/include/sof/lib/wait.h
@@ -17,6 +17,7 @@
 #include <sof/schedule/schedule.h>
 #include <sof/schedule/task.h>
 #include <sof/trace/trace.h>
+#include <user/trace.h>
 #include <config.h>
 #include <stdint.h>
 

--- a/src/include/sof/schedule/edf_schedule.h
+++ b/src/include/sof/schedule/edf_schedule.h
@@ -10,6 +10,7 @@
 
 #include <sof/schedule/task.h>
 #include <sof/trace/trace.h>
+#include <user/trace.h>
 #include <stdint.h>
 
 /* schedule tracing */

--- a/src/include/sof/schedule/ll_schedule.h
+++ b/src/include/sof/schedule/ll_schedule.h
@@ -16,6 +16,7 @@
 #include <sof/drivers/timer.h>
 #include <sof/schedule/task.h>
 #include <sof/trace/trace.h>
+#include <user/trace.h>
 #include <stdint.h>
 
 /* ll tracing */

--- a/src/include/sof/schedule/schedule.h
+++ b/src/include/sof/schedule/schedule.h
@@ -11,6 +11,7 @@
 
 #include <sof/list.h>
 #include <sof/trace/trace.h>
+#include <user/trace.h>
 #include <stdint.h>
 
 struct edf_schedule_data;

--- a/src/include/sof/spinlock.h
+++ b/src/include/sof/spinlock.h
@@ -66,6 +66,7 @@
 #include <sof/debug/panic.h>
 #include <sof/trace/trace.h>
 #include <ipc/trace.h>
+#include <user/trace.h>
 #include <stdint.h>
 
 #define DBG_LOCK_USERS		8

--- a/src/include/sof/trace/trace.h
+++ b/src/include/sof/trace/trace.h
@@ -60,41 +60,6 @@ struct sof;
 #define TRACE_BOOT_PLATFORM_SPI		(TRACE_BOOT_PLATFORM + 0x200)
 #define TRACE_BOOT_PLATFORM_DMA_TRACE	(TRACE_BOOT_PLATFORM + 0x210)
 
-/* trace event classes - high 8 bits*/
-#define TRACE_CLASS_IRQ		(1 << 24)
-#define TRACE_CLASS_IPC		(2 << 24)
-#define TRACE_CLASS_PIPE	(3 << 24)
-#define TRACE_CLASS_HOST	(4 << 24)
-#define TRACE_CLASS_DAI		(5 << 24)
-#define TRACE_CLASS_DMA		(6 << 24)
-#define TRACE_CLASS_SSP		(7 << 24)
-#define TRACE_CLASS_COMP	(8 << 24)
-#define TRACE_CLASS_WAIT	(9 << 24)
-#define TRACE_CLASS_LOCK	(10 << 24)
-#define TRACE_CLASS_MEM		(11 << 24)
-#define TRACE_CLASS_MIXER	(12 << 24)
-#define TRACE_CLASS_BUFFER	(13 << 24)
-#define TRACE_CLASS_VOLUME	(14 << 24)
-#define TRACE_CLASS_SWITCH	(15 << 24)
-#define TRACE_CLASS_MUX		(16 << 24)
-#define TRACE_CLASS_SRC         (17 << 24)
-#define TRACE_CLASS_TONE        (18 << 24)
-#define TRACE_CLASS_EQ_FIR      (19 << 24)
-#define TRACE_CLASS_EQ_IIR      (20 << 24)
-#define TRACE_CLASS_SA		(21 << 24)
-#define TRACE_CLASS_DMIC	(22 << 24)
-#define TRACE_CLASS_POWER	(23 << 24)
-#define TRACE_CLASS_IDC		(24 << 24)
-#define TRACE_CLASS_CPU		(25 << 24)
-#define TRACE_CLASS_CLK		(26 << 24)
-#define TRACE_CLASS_EDF		(27 << 24)
-#define TRACE_CLASS_KPB		(28 << 24)
-#define TRACE_CLASS_SELECTOR	(29 << 24)
-#define TRACE_CLASS_SCHEDULE	(30 << 24)
-#define TRACE_CLASS_SCHEDULE_LL	(31 << 24)
-#define TRACE_CLASS_SOUNDWIRE	(32 << 24)
-#define TRACE_CLASS_KEYWORD	(33 << 24)
-
 #if CONFIG_LIBRARY
 
 #include <stdio.h>
@@ -195,7 +160,6 @@ void trace_init(struct sof *sof);
 
 #if CONFIG_TRACE
 
-#include <user/trace.h>
 #include <sof/platform.h>
 /*
  * trace_event macro definition

--- a/src/include/user/trace.h
+++ b/src/include/user/trace.h
@@ -52,11 +52,14 @@ struct system_time {
 #define TRACE_CLASS_POWER	(23 << 24)
 #define TRACE_CLASS_IDC		(24 << 24)
 #define TRACE_CLASS_CPU		(25 << 24)
+#define TRACE_CLASS_CLK		(26 << 24)
 #define TRACE_CLASS_EDF		(27 << 24)
 #define TRACE_CLASS_KPB		(28 << 24)
 #define TRACE_CLASS_SELECTOR	(29 << 24)
 #define TRACE_CLASS_SCHEDULE	(30 << 24)
 #define TRACE_CLASS_SCHEDULE_LL	(31 << 24)
+#define TRACE_CLASS_SOUNDWIRE	(32 << 24)
+#define TRACE_CLASS_KEYWORD	(33 << 24)
 
 #define LOG_ENABLE		1  /* Enable logging */
 #define LOG_DISABLE		0  /* Disable logging */

--- a/src/ipc/dma-copy.c
+++ b/src/ipc/dma-copy.c
@@ -10,6 +10,7 @@
 #include <sof/lib/wait.h>
 #include <sof/platform.h>
 #include <sof/trace/trace.h>
+#include <user/trace.h>
 #include <config.h>
 #include <errno.h>
 #include <stddef.h>

--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -43,6 +43,7 @@
 #include <ipc/stream.h>
 #include <ipc/topology.h>
 #include <ipc/trace.h>
+#include <user/trace.h>
 #include <config.h>
 #include <errno.h>
 #include <stdbool.h>

--- a/src/lib/agent.c
+++ b/src/lib/agent.c
@@ -24,6 +24,7 @@
 #include <sof/trace/trace.h>
 #include <ipc/topology.h>
 #include <ipc/trace.h>
+#include <user/trace.h>
 #include <stdint.h>
 
 #define trace_sa(__e, ...) \

--- a/src/lib/alloc.c
+++ b/src/lib/alloc.c
@@ -15,6 +15,7 @@
 #include <sof/string.h>
 #include <sof/trace/trace.h>
 #include <ipc/trace.h>
+#include <user/trace.h>
 #include <config.h>
 #include <errno.h>
 #include <stddef.h>

--- a/src/lib/clk.c
+++ b/src/lib/clk.c
@@ -16,6 +16,7 @@
 #include <sof/spinlock.h>
 #include <sof/trace/trace.h>
 #include <ipc/topology.h>
+#include <user/trace.h>
 #include <stddef.h>
 #include <stdint.h>
 

--- a/src/lib/dai.c
+++ b/src/lib/dai.c
@@ -7,6 +7,7 @@
 #include <sof/lib/dai.h>
 #include <sof/spinlock.h>
 #include <sof/trace/trace.h>
+#include <user/trace.h>
 #include <errno.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/src/lib/dma.c
+++ b/src/lib/dma.c
@@ -10,6 +10,7 @@
 #include <sof/spinlock.h>
 #include <sof/trace/trace.h>
 #include <ipc/topology.h>
+#include <user/trace.h>
 #include <errno.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/src/lib/wait.c
+++ b/src/lib/wait.c
@@ -14,6 +14,7 @@
 #include <sof/platform.h>
 #include <sof/schedule/schedule.h>
 #include <sof/trace/trace.h>
+#include <user/trace.h>
 #include <errno.h>
 #include <stdint.h>
 

--- a/src/platform/intel/cavs/lib/pm_runtime.c
+++ b/src/platform/intel/cavs/lib/pm_runtime.c
@@ -21,6 +21,7 @@
 #include <sof/spinlock.h>
 #include <sof/trace/trace.h>
 #include <ipc/topology.h>
+#include <user/trace.h>
 #include <config.h>
 #include <stdint.h>
 

--- a/tools/logger/convert.c
+++ b/tools/logger/convert.c
@@ -12,6 +12,7 @@
 #include <unistd.h>
 #include <math.h>
 #include <kernel/abi.h>
+#include <user/trace.h>
 #include "convert.h"
 
 #define CEIL(a, b) ((a+b-1)/b)

--- a/tools/logger/convert.c
+++ b/tools/logger/convert.c
@@ -90,11 +90,16 @@ static const char * get_component_name(uint32_t component_id) {
 		CASE(SA);
 		CASE(DMIC);
 		CASE(POWER);
+		CASE(IDC);
+		CASE(CPU);
+		CASE(CLK);
 		CASE(EDF);
 		CASE(KPB);
 		CASE(SELECTOR);
 		CASE(SCHEDULE);
 		CASE(SCHEDULE_LL);
+		CASE(SOUNDWIRE);
+		CASE(KEYWORD);
 	default: return "unknown";
 	}
 }

--- a/tools/logger/convert.h
+++ b/tools/logger/convert.h
@@ -11,7 +11,6 @@
  */
 
 #include <stdio.h>
-#include <user/trace.h>
 #include <ipc/info.h>
 #include <rimage/file_format.h>
 

--- a/tools/testbench/trace.c
+++ b/tools/testbench/trace.c
@@ -44,6 +44,16 @@ char *get_trace_class(uint32_t trace_class)
 		CASE(SA);
 		CASE(DMIC);
 		CASE(POWER);
+		CASE(IDC);
+		CASE(CPU);
+		CASE(CLK);
+		CASE(EDF);
+		CASE(KPB);
+		CASE(SELECTOR);
+		CASE(SCHEDULE);
+		CASE(SCHEDULE_LL);
+		CASE(SOUNDWIRE);
+		CASE(KEYWORD);
 	default: return "unknown";
 	}
 }


### PR DESCRIPTION
These traces shouldn't be duplicated, they should be in
more public header because they are used outside of FW.

Signed-off-by: Janusz Jankowski <janusz.jankowski@linux.intel.com>