### PR TITLE
comp: add comp_set_sink_buffer() function

### DIFF
--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -95,6 +95,33 @@ void comp_unregister(struct comp_driver *drv)
 	spin_unlock(&cd->lock);
 }
 
+int comp_set_sink_buffer(struct comp_dev *dev, uint32_t period_bytes,
+			 uint32_t periods)
+{
+	struct comp_buffer *sinkb;
+	int ret = 0;
+
+	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer,
+				source_list);
+
+	/* components connected to dma configure buffer independently */
+	if (!sinkb->sink->is_dma_connected) {
+		ret = buffer_set_size(sinkb, period_bytes * periods);
+		if (ret < 0) {
+			trace_comp_error("comp_set_sink_buffer() error: "
+					 "buffer_set_size() failed");
+			return ret;
+		}
+	} else if (sinkb->size < period_bytes * periods) {
+		trace_comp_error("comp_set_sink_buffer() error: "
+				 "sink buffer size is not sufficient");
+		ret = -EINVAL;
+		return ret;
+	}
+
+	return ret;
+}
+
 int comp_set_state(struct comp_dev *dev, int cmd)
 {
 	int requested_state = comp_get_requested_state(cmd);

--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -738,11 +738,11 @@ static int eq_fir_prepare(struct comp_dev *dev)
 		dev->params.frame_fmt = cd->sink_format;
 
 	/* set downstream buffer size */
-	ret = buffer_set_size(sinkb,
-			      sink_period_bytes * config->periods_sink);
+	ret = comp_set_sink_buffer(dev, sink_period_bytes,
+				   config->periods_sink);
 	if (ret < 0) {
 		trace_eq_error("eq_fir_prepare() error: "
-			       "buffer_set_size() failed");
+			       "comp_set_sink_buffer() failed");
 		goto err;
 	}
 

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -778,11 +778,11 @@ static int eq_iir_prepare(struct comp_dev *dev)
 		dev->params.frame_fmt = cd->sink_format;
 
 	/* set downstream buffer size */
-	ret = buffer_set_size(sinkb,
-			      sink_period_bytes * config->periods_sink);
+	ret = comp_set_sink_buffer(dev, sink_period_bytes,
+				   config->periods_sink);
 	if (ret < 0) {
 		trace_eq_error("eq_iir_prepare() error: "
-			       "buffer_set_size() failed");
+			       "comp_set_sink_buffer() failed");
 		goto err;
 	}
 

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -153,7 +153,6 @@ static void mixer_free(struct comp_dev *dev)
 static int mixer_params(struct comp_dev *dev)
 {
 	struct sof_ipc_comp_config *config = COMP_GET_CONFIG(dev);
-	struct comp_buffer *sink;
 	uint32_t period_bytes;
 	int ret;
 
@@ -166,14 +165,12 @@ static int mixer_params(struct comp_dev *dev)
 		return -EINVAL;
 	}
 
-	sink = list_first_item(&dev->bsink_list, struct comp_buffer,
-			       source_list);
-
 	/* set downstream buffer size */
-	ret = buffer_set_size(sink, period_bytes * config->periods_sink);
+	ret = comp_set_sink_buffer(dev, period_bytes,
+				   config->periods_sink);
 	if (ret < 0) {
 		trace_mixer_error("mixer_params() error: "
-				  "buffer_set_size() failed");
+				  "comp_set_sink_buffer() failed");
 		return ret;
 	}
 

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -380,11 +380,11 @@ static int selector_prepare(struct comp_dev *dev)
 		       sinkb->sink->params.channels);
 
 	/* set downstream buffer size */
-	ret = buffer_set_size(sinkb, cd->sink_period_bytes *
-			      config->periods_sink);
+	ret = comp_set_sink_buffer(dev, cd->sink_period_bytes,
+				   config->periods_sink);
 	if (ret < 0) {
 		trace_selector_error("selector_prepare() error: "
-				     "buffer_set_size() failed");
+				     "comp_set_sink_buffer() failed");
 		goto err;
 	}
 

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -848,10 +848,11 @@ static int src_prepare(struct comp_dev *dev)
 		dev->params.frame_fmt = cd->sink_format;
 
 	/* set downstream buffer size */
-	ret = buffer_set_size(sinkb, sink_period_bytes * config->periods_sink);
+	ret = comp_set_sink_buffer(dev, sink_period_bytes,
+				   config->periods_sink);
 	if (ret < 0) {
 		trace_src_error("src_prepare() error: "
-				"buffer_set_size() failed");
+				"comp_set_sink_buffer() failed");
 		goto err;
 	}
 

--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -616,10 +616,13 @@ static int volume_prepare(struct comp_dev *dev)
 		dev->params.frame_fmt = cd->sink_format;
 
 	/* set downstream buffer size */
-	ret = buffer_set_size(sinkb, sink_period_bytes * config->periods_sink);
+	ret = comp_set_sink_buffer(dev, sink_period_bytes,
+				   config->periods_sink);
+
 	if (ret < 0) {
 		trace_volume_error("volume_prepare() error: "
-				   "buffer_set_size() failed");
+				   "comp_set_sink_buffer() failed");
+
 		goto err;
 	}
 

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -379,6 +379,15 @@ static inline void comp_free(struct comp_dev *dev)
 int comp_set_state(struct comp_dev *dev, int cmd);
 
 /**
+ * Set component's sink buffer size
+ * @param dev Component device.
+ * @param period_bytes Amount of bytes in one period.
+ * @param periods Amount of periods.
+ */
+int comp_set_sink_buffer(struct comp_dev *dev, uint32_t period_bytes,
+			 uint32_t periods);
+
+/**
  * Component parameter init.
  * @param dev Component device.
  * @return 0 if succeeded, error code otherwise.

--- a/test/cmocka/src/audio/component/mock.c
+++ b/test/cmocka/src/audio/component/mock.c
@@ -25,6 +25,14 @@ void *rzalloc(int zone, uint32_t caps, size_t bytes)
 	return calloc(bytes, 1);
 }
 
+int buffer_set_size(struct comp_buffer *buffer, uint32_t size)
+{
+	(void)buffer;
+	(void)size;
+
+	return 0;
+}
+
 void pipeline_xrun(struct pipeline *p, struct comp_dev *dev, int32_t bytes)
 {
 }

--- a/test/cmocka/src/audio/mixer/mock.c
+++ b/test/cmocka/src/audio/mixer/mock.c
@@ -53,6 +53,27 @@ void pipeline_xrun(struct pipeline *p, struct comp_dev *dev, int32_t bytes)
 {
 }
 
+int comp_set_sink_buffer(struct comp_dev *dev, uint32_t period_bytes,
+			 uint32_t periods)
+{
+	struct comp_buffer *sinkb;
+	int ret = 0;
+
+	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer,
+				source_list);
+
+	if (!sinkb->sink->is_dma_connected) {
+		ret = buffer_set_size(sinkb, period_bytes * periods);
+		if (ret < 0)
+			return ret;
+	} else if (sinkb->size < period_bytes * periods) {
+		ret = -EINVAL;
+		return ret;
+	}
+
+	return ret;
+}
+
 int comp_set_state(struct comp_dev *dev, int cmd)
 {
 	return 0;


### PR DESCRIPTION
Component in comp_prepare() should change sink buffer
only when sink component is not connected to dma. 
comp_set_sink_buffer() checks whether sink component
is not connected to dma and only in that case tries to
resize sink buffer.

This PR also add dai buffer alignment in order to provide the same
alignment as in the host side. Otherwise it may appear buffer 
mismatch between host and dai (in simple host->dai pipeline)
resulting in issue #1650

PR fixes #1650

