### PR TITLE
Revert " ipc: align stream.h with kernel"

### DIFF
--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -114,8 +114,8 @@ static void host_update_position(struct comp_dev *dev, uint32_t bytes)
 	if (hd->local_pos >= hd->host_size)
 		hd->local_pos = 0;
 
-	/* NO_IRQ mode if no_period_irq == 1 */
-	if (!dev->params.no_period_irq) {
+	/* NO_IRQ mode if host_period_size == 0 */
+	if (dev->params.host_period_bytes != 0) {
 		hd->report_pos += bytes;
 
 		/* send IPC message to driver if needed */

--- a/src/include/ipc/stream.h
+++ b/src/include/ipc/stream.h
@@ -91,10 +91,10 @@ struct sof_ipc_stream_params {
 	uint16_t sample_valid_bytes;
 	uint16_t sample_container_bytes;
 
+	/* for notifying host period has completed - 0 means no period IRQ */
 	uint32_t host_period_bytes;
-	uint16_t no_period_irq; /* 1 means period IRQ mode OFF */
 
-	uint16_t reserved[3];
+	uint32_t reserved[2];
 	uint16_t chmap[SOF_IPC_MAX_CHANNELS];	/**< channel map - SOF_CHMAP_ */
 } __attribute__((packed));
 


### PR DESCRIPTION
Reverts thesofproject/sof#1592

It was merged too early - PR https://github.com/thesofproject/linux/pull/1082 on kernel side was merged to different branch than sof-dev.
PR that was planned to be merged together is still pending - https://github.com/thesofproject/linux/pull/1037