### PR TITLE
alloc: fix blocks update in alloc_cont_blocks()

### DIFF
--- a/src/lib/alloc.c
+++ b/src/lib/alloc.c
@@ -268,7 +268,7 @@ static void *alloc_cont_blocks(struct mm_heap *heap, int level,
 		map->first_free += count;
 
 	/* update each block */
-	for (current = start; current < count; current++) {
+	for (current = start; current < start + count; current++) {
 		hdr = &map->block[current];
 		hdr->used = 1;
 	}


### PR DESCRIPTION
Add proper stop condition during block hdr update
in alloc_cont_blocks() function.

Signed-off-by: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>