### PR TITLE
topology: add demux pipeline to CML max98357a tplg

### DIFF
--- a/tools/topology/CMakeLists.txt
+++ b/tools/topology/CMakeLists.txt
@@ -68,6 +68,7 @@ set(TPLGS
 	"sof-cml-demux-rt5682\;sof-cml-demux-rt5682\;-DPLATFORM=whl"
 	"sof-cnl-nocodec\;sof-cnl-nocodec"
 	"sof-cml-rt5682-max98357a\;sof-cml-rt5682-max98357a\;-DPLATFORM=cml"
+	"sof-cml-demux-rt5682-max98357a\;sof-cml-demux-rt5682-max98357a\;-DPLATFORM=cml"
 )
 
 add_custom_target(topologies ALL)

--- a/tools/topology/sof-cml-demux-rt5682-max98357a.m4
+++ b/tools/topology/sof-cml-demux-rt5682-max98357a.m4
@@ -1,0 +1,56 @@
+#
+# Topology for Cometlake with rt5682 headset on SSP0, max98357a spk on SSP1
+#
+# Adding max98357a spk on SSP1 on top of sof-cml-rt5682.
+#
+
+# Include SOF CML RT5682 Topology
+# This includes topology for RT5682, DMIC and 3 HDMI Pass through pipeline
+include(`sof-cml-demux-rt5682.m4')
+
+# Define the Speaker pipeline
+#
+# PCM6  ----> volume (pipe 8) ----> SSP1 (speaker - maxim98357a, BE link 5)
+#
+
+dnl PIPELINE_PCM_ADD(pipeline,
+dnl     pipe id, pcm, max channels, format,
+dnl     frames, deadline, priority, core)
+
+# Low Latency playback pipeline 8 on PCM 6 using max 2 channels of s32le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-src-volume-playback.m4,
+	8, 6, 2, s32le,
+	48, 1000, 0, 0)
+
+#
+# Speaker DAIs configuration
+#
+
+dnl DAI_ADD(pipeline,
+dnl     pipe id, dai type, dai_index, dai_be,
+dnl     buffer, periods, format,
+dnl     frames, deadline, priority, core)
+
+# playback DAI is SSP1 using 2 periods
+# Buffers use s16le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+	8, SSP, 1, SSP1-Codec,
+	PIPELINE_SOURCE_8, 2, s16le,
+	48, 1000, 0, 0)
+
+# PCM Low Latency, id 0
+dnl PCM_PLAYBACK_ADD(name, pcm_id, playback)
+PCM_PLAYBACK_ADD(Speakers, 6, PIPELINE_PCM_8)
+
+#
+# BE configurations for Speakers - overrides config in ACPI if present
+#
+
+#SSP 1 (ID: 6)
+DAI_CONFIG(SSP, 1, 6, SSP1-Codec,
+	SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24000000, codec_mclk_in),
+		SSP_CLOCK(bclk, 1500000, codec_slave),
+		SSP_CLOCK(fsync, 46875, codec_slave),
+		SSP_TDM(2, 16, 3, 3),
+		SSP_CONFIG_DATA(SSP, 1, 16)))


### PR DESCRIPTION
This topology will add a mux pipeline to support echo reference for CML.

Signed-off-by: Zhang Keqiao <keqiao.zhang@linux.intel.com>