### PR TITLE
sys_agent: add option to temporarily enable/disable

### DIFF
--- a/src/include/sof/lib/agent.h
+++ b/src/include/sof/lib/agent.h
@@ -9,6 +9,7 @@
 #define __SOF_LIB_AGENT_H__
 
 #include <sof/schedule/task.h>
+#include <stdbool.h>
 #include <stdint.h>
 
 struct sof;
@@ -18,9 +19,12 @@ struct sa {
 	uint64_t last_idle;	/* time of last idle */
 	uint64_t ticks;
 	struct task work;
+	bool is_active;
 };
 
 void sa_enter_idle(struct sof *sof);
 void sa_init(struct sof *sof);
+void sa_disable(void);
+void sa_enable(void);
 
 #endif /* __SOF_LIB_AGENT_H__ */

--- a/src/lib/agent.c
+++ b/src/lib/agent.c
@@ -32,6 +32,8 @@
 #define trace_sa_value(__e, ...) \
 	trace_value_atomic(__e, ##__VA_ARGS__)
 
+struct sa *sa;
+
 /*
  * Notify the SA that we are about to enter idle state (WFI).
  */
@@ -52,7 +54,8 @@ static uint64_t validate(void *data)
 	delta = current - sa->last_idle;
 
 	/* were we last idle longer than timeout */
-	if (delta > sa->ticks) {
+
+	if (delta > sa->ticks && sa->is_active) {
 		trace_sa("validate(), idle longer than timeout, delta = %u",
 			delta);
 		panic(SOF_IPC_PANIC_IDLE);
@@ -63,7 +66,6 @@ static uint64_t validate(void *data)
 
 void sa_init(struct sof *sof)
 {
-	struct sa *sa;
 
 	trace_sa("sa_init()");
 
@@ -73,13 +75,26 @@ void sa_init(struct sof *sof)
 	/* set default tick timeout */
 	sa->ticks = clock_ms_to_ticks(PLATFORM_WORKQ_CLOCK, 1) *
 		PLATFORM_IDLE_TIME / 1000;
+
 	trace_sa("sa_init(), sa->ticks = %u", sa->ticks);
 
 	/* set lst idle time to now to give time for boot completion */
 	sa->last_idle = platform_timer_get(platform_timer) + sa->ticks;
+	sa->is_active = true;
 
 	schedule_task_init(&sa->work, SOF_SCHEDULE_LL, SOF_TASK_PRI_HIGH,
 			   validate, sa, 0, 0);
 
 	schedule_task(&sa->work, PLATFORM_IDLE_TIME, 0, 0);
+}
+
+void sa_disable(void)
+{
+	sa->is_active = false;
+}
+
+void sa_enable(void)
+{
+	sa->is_active = true;
+	sa->last_idle = platform_timer_get(platform_timer);
 }


### PR DESCRIPTION
This patch adds an option to temporarily disable system
agent. This is especially needed when SOF is performing
long last tasks like draining.

Signed-off-by: Marcin Rajwa <marcin.rajwa@linux.intel.com>