### PR TITLE
[DO NOT MERGE] topology: update sof_ipc_comp_process struct

### DIFF
--- a/src/include/ipc/topology.h
+++ b/src/include/ipc/topology.h
@@ -182,9 +182,16 @@ struct sof_ipc_comp_process {
 	struct sof_ipc_comp_config config;
 	uint32_t size;	/**< size of bespoke data section in bytes */
 	uint32_t type;	/**< sof_ipc_effect_type */
+	uint32_t min_sink_bytes;   /**< min sink buffer size measured in
+				     *  bytes required to run module
+				     */
+	uint32_t min_source_bytes; /**< amount of data measured in
+				     *  bytes available at source buffer
+				     *  required to run module
+				     */
 
 	/* reserved for future use */
-	uint32_t reserved[7];
+	uint32_t reserved[5];
 
 	unsigned char data[0];
 } __attribute__((packed));

--- a/src/include/kernel/abi.h
+++ b/src/include/kernel/abi.h
@@ -29,7 +29,7 @@
 
 /** \brief SOF ABI version major, minor and patch numbers */
 #define SOF_ABI_MAJOR 3
-#define SOF_ABI_MINOR 9
+#define SOF_ABI_MINOR 10
 #define SOF_ABI_PATCH 0
 
 /** \brief SOF ABI version number. Format within 32bit word is MMmmmppp */


### PR DESCRIPTION
Add two parameters to sof_ipc_comp_process struct
in order to allow configuration of the component
processing variable frames (components should be
able to process frames which are not multiple of
period bytes).
Added parameters are:
- min_sink_bytes - min sink buffer size measured
in bytes required to run module;
- min_source_bytes - amount of data measured
in bytes available at source buffer required to
run module.

There is also simple processing component (which can
be template proposal in future; now it only copies required
number of samples defined by min_sink_bytes/min_source_bytes
parameter), tested up to 10 ms frame on different formats with slim 
driver, available here:
https://github.com/bkokoszx/sof/tree/topic/variable-frame-comp-template

Signed-off-by: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>