### PR TITLE
trace: fix build error if traces are disabled

### DIFF
--- a/src/drivers/intel/cavs/interrupt.c
+++ b/src/drivers/intel/cavs/interrupt.c
@@ -10,6 +10,7 @@
 #include <sof/common.h>
 #include <sof/drivers/interrupt.h>
 #include <sof/lib/cpu.h>
+#include <sof/lib/shim.h>
 #include <sof/list.h>
 #include <sof/spinlock.h>
 #include <stdbool.h>


### PR DESCRIPTION
This will fix interrupt.c build error if configured without traces.

Signed-off-by: Adrian Bonislawski <adrian.bonislawski@linux.intel.com>