### PR TITLE
[skip ci]scripts: update glib support for fuzzer

### DIFF
--- a/scripts/docker_build/sof_builder/Dockerfile
+++ b/scripts/docker_build/sof_builder/Dockerfile
@@ -47,7 +47,8 @@ RUN apt-get -y update && \
 		wget \
 		unzip \
 		cmake \
-		python3
+		python3 \
+		libglib2.0-dev
 
 
 # Use ToT alsa utils for the latest topology patches.


### PR DESCRIPTION
Install libglib2.0-dev with apt.

Signed-off-by: Pan Xiuli <xiuli.pan@linux.intel.com>