### PR TITLE
arch: xtensa: Fix exception handlers

### DIFF
--- a/src/arch/xtensa/xtos/exc-table.S
+++ b/src/arch/xtensa/xtos/exc-table.S
@@ -36,6 +36,9 @@
 	.global	xtos_c_handler_table
 	.align 4
 xtos_c_handler_table:
+	.rept	XCHAL_EXCCAUSE_NUM
+	.word	xtos_p_none
+	.endr
 
 	/*
 	 *  Default/empty exception C handler.


### PR DESCRIPTION
Before the commit the C exception handler table was declared empty
(suspiciously). This also caused my own tests to fail to call the panic
code whenever an exception occurred.

This commit fixes this by actually declaring the slots themselves and
initializing them to xtos_p_none, and also setting the correct size (64 * 4 instead of 0).

Signed-off-by: Paul Olaru <paul.olaru@nxp.com>