### PR TITLE
panic: Distinguish exceptions from other panics

### DIFF
--- a/src/debug/panic.c
+++ b/src/debug/panic.c
@@ -88,5 +88,14 @@ void __panic(uint32_t p, char *filename, uint32_t linenum)
 				 filename, strlen + 1));
 	}
 
+	/* To distinguish regular panic() calls from exceptions, we will
+	 * set a reserved value for the exception cause (63) so the
+	 * coredumper tool could distinguish between the situations.
+	 */
+	__asm__ __volatile__("movi a3, 63\n\t"
+			     "wsr.exccause a3\n\t"
+			     "esync" : : :
+			     "a3", "memory");
+
 	panic_rewind(p, 0, &panicinfo, NULL);
 }

--- a/tools/coredumper/sof-coredump-reader.py
+++ b/tools/coredumper/sof-coredump-reader.py
@@ -729,7 +729,9 @@ class CoreDumpReader(object):
 			stdoutPrint("set *0x{:08x}=0x{:08x}\n"
 				.format(addr, dw))
 
-		if self.core_dump.exccause:
+                # Exccause 63 is reserved for panics; the other causes come
+                # from actual exceptions
+		if self.core_dump.exccause != 63:
 			verbosePrint("\n# *EXCEPTION*\n")
 			verbosePrint("# exccause: " + EXCCAUSE_CODE[self.core_dump.exccause][0])
 			if EXCCAUSE_CODE[self.core_dump.exccause][1]:


### PR DESCRIPTION
Whenever one calls panic(), it eventually ends up in __panic. Here, the
various parameters (filename, line number etc.) are configured and
prepared for the upcoming panic dump.

For the sof-coredumper tool to work properly with panics, we need to
clear exccause (otherwise we would have a random value that may not even
be valid -- the exccause register is uninitialized at boot).

This does cause issues in case the exception code is in fact 0 (illegal
instruction) so hopefully this type of exception won't happen. The
exception dump will still work fine but the tool won't show this
particular cause in verbose mode.

Signed-off-by: Paul Olaru <paul.olaru@nxp.com>