### PR TITLE
ll_schedule: fix possible race condition

### DIFF
--- a/src/schedule/ll_schedule.c
+++ b/src/schedule/ll_schedule.c
@@ -105,11 +105,8 @@ static inline void ll_clear_timer(struct ll_schedule_data *queue)
 	if (!atomic_sub(&ll_shared_ctx->total_num_work, 1))
 		queue->ts->timer_clear(&queue->ts->timer);
 
-	if (!atomic_sub(&queue->num_ll, 1)) {
-		timer_disable(&queue->ts->timer);
-		atomic_sub(&ll_shared_ctx->timer_clients, 1);
+	if (!atomic_sub(&queue->num_ll, 1))
 		ll_shared_ctx->timers[cpu_get_id()] = NULL;
-	}
 }
 
 /* is there any work pending in the current time window ? */

--- a/src/schedule/ll_schedule.c
+++ b/src/schedule/ll_schedule.c
@@ -509,7 +509,7 @@ static struct ll_schedule_data *work_new_queue(struct timesource_data *ts)
 	struct ll_schedule_data *queue;
 
 	/* init work queue */
-	queue = rmalloc(RZONE_SYS, SOF_MEM_CAPS_RAM, sizeof(*queue));
+	queue = rzalloc(RZONE_SYS, SOF_MEM_CAPS_RAM, sizeof(*queue));
 	list_init(&queue->tasks);
 
 	spinlock_init(&queue->lock);


### PR DESCRIPTION
Fixes very rare race condition, when multiple cores
schedule something in low latency scheduler. We should
allow for timer client to execute one more time after
being cancelled. There won't be any tasks on the list
to process, but at least we will stop everything
gracefully.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>