### PR TITLE
task: abstract slave core functions to arch layer

### DIFF
--- a/src/arch/xtensa/include/arch/init.h
+++ b/src/arch/xtensa/include/arch/init.h
@@ -18,10 +18,13 @@
 
 #include <sof/debug/panic.h>
 #include <ipc/trace.h>
+#include <config.h>
 #include <xtensa/corebits.h>
 #include <xtensa/xtruntime.h>
 #include <stddef.h>
 #include <stdint.h>
+
+struct sof;
 
 /**
  * \brief Called in the case of exception.
@@ -125,6 +128,16 @@ static inline void register_exceptions(void)
  * \brief Called from assembler context with no return or parameters.
  */
 static inline void __memmap_init(void) { }
+
+#if CONFIG_SMP
+
+int slave_core_init(struct sof *sof);
+
+#else
+
+static inline int slave_core_init(struct sof *sof) { return 0; }
+
+#endif /* CONFIG_SMP */
 
 #endif /* __ARCH_INIT_H__ */
 

--- a/src/arch/xtensa/include/arch/schedule/task.h
+++ b/src/arch/xtensa/include/arch/schedule/task.h
@@ -18,6 +18,7 @@
 
 #include <sof/list.h>
 #include <sof/spinlock.h>
+#include <config.h>
 
 /** \brief IRQ task data. */
 struct irq_task {
@@ -26,7 +27,19 @@ struct irq_task {
 	int irq;		/**< IRQ level */
 };
 
+struct sof;
 struct task;
+
+#if CONFIG_SMP
+
+/**
+ * \brief Starts slave core main task.
+ * \param[in,out] sof Main context.
+ * \return Error code.
+ */
+int do_task_slave_core(struct sof *sof);
+
+#endif
 
 /**
  * \brief Returns IRQ low task data.

--- a/src/arch/xtensa/init.c
+++ b/src/arch/xtensa/init.c
@@ -11,18 +11,9 @@
  */
 
 #include <sof/common.h>
-#include <sof/debug/panic.h>
-#include <sof/drivers/idc.h>
-#include <sof/drivers/interrupt.h>
 #include <sof/init.h>
 #include <sof/lib/cpu.h>
-#include <sof/lib/notifier.h>
-#include <sof/schedule/schedule.h>
-#include <sof/schedule/task.h>
 #include <sof/sof.h>
-#include <sof/spinlock.h>
-#include <sof/trace/trace.h>
-#include <ipc/trace.h>
 #include <config.h>
 #include <xtensa/xtruntime-frames.h>
 #include <xtos-structs.h>
@@ -95,6 +86,18 @@ int arch_init(struct sof *sof)
 	return 0;
 }
 
+#if CONFIG_SMP
+
+#include <sof/debug/panic.h>
+#include <sof/drivers/idc.h>
+#include <sof/drivers/interrupt.h>
+#include <sof/lib/notifier.h>
+#include <sof/schedule/schedule.h>
+#include <sof/schedule/task.h>
+#include <sof/spinlock.h>
+#include <sof/trace/trace.h>
+#include <ipc/trace.h>
+
 int slave_core_init(struct sof *sof)
 {
 	int err;
@@ -128,3 +131,5 @@ int slave_core_init(struct sof *sof)
 
 	return err;
 }
+
+#endif

--- a/src/arch/xtensa/schedule/task.c
+++ b/src/arch/xtensa/schedule/task.c
@@ -13,6 +13,7 @@
 #include <sof/drivers/interrupt.h>
 #include <sof/lib/alloc.h>
 #include <sof/lib/cpu.h>
+#include <sof/lib/wait.h>
 #include <sof/list.h>
 #include <sof/platform.h>
 #include <sof/schedule/schedule.h>
@@ -26,6 +27,25 @@
 #include <errno.h>
 #include <stddef.h>
 #include <stdint.h>
+
+#if CONFIG_SMP
+
+int do_task_slave_core(struct sof *sof)
+{
+	/* main audio IDC processing loop */
+	while (1) {
+		/* sleep until next IDC */
+		wait_for_interrupt(0);
+
+		/* schedule any idle tasks */
+		schedule();
+	}
+
+	/* something bad happened */
+	return -EIO;
+}
+
+#endif
 
 struct irq_task **task_irq_low_get(void)
 {

--- a/src/include/sof/init.h
+++ b/src/include/sof/init.h
@@ -17,8 +17,6 @@ int main(int argc, char *argv[]);
 
 int master_core_init(struct sof *sof);
 
-int slave_core_init(struct sof *sof);
-
 int arch_init(struct sof *sof);
 
 #endif /* __SOF_INIT_H__ */

--- a/src/include/sof/schedule/task.h
+++ b/src/include/sof/schedule/task.h
@@ -50,8 +50,6 @@ struct task {
 
 int do_task_master_core(struct sof *sof);
 
-int do_task_slave_core(struct sof *sof);
-
 static inline int allocate_tasks(void)
 {
 	return arch_allocate_tasks();

--- a/src/schedule/task.c
+++ b/src/schedule/task.c
@@ -70,18 +70,3 @@ int do_task_master_core(struct sof *sof)
 	/* something bad happened */
 	return -EIO;
 }
-
-int do_task_slave_core(struct sof *sof)
-{
-	/* main audio IDC processing loop */
-	while (1) {
-		/* sleep until next IDC */
-		wait_for_interrupt(0);
-
-		/* schedule any idle tasks */
-		schedule();
-	}
-
-	/* something bad happened */
-	return -EIO;
-}


### PR DESCRIPTION
Abstracts slave core functions to arch layer. It doesn't
make sense to compile them, if they won't be used.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>