### PR TITLE
Fix kmod scripts

### DIFF
--- a/tools/kmod_scripts/sof_insert.sh
+++ b/tools/kmod_scripts/sof_insert.sh
@@ -37,4 +37,6 @@ insert_module snd_soc_rt700
 insert_module sof_acpi_dev
 insert_module sof_pci_dev
 
+insert_module snd_sof_acpi
+insert_module snd_sof_pci
 

--- a/tools/kmod_scripts/sof_insert.sh
+++ b/tools/kmod_scripts/sof_insert.sh
@@ -32,6 +32,8 @@ insert_module snd_soc_wm8804_i2c
 insert_module snd_soc_max98357a
 insert_module snd_soc_max98090
 
+insert_module snd_soc_rt700
+
 insert_module sof_acpi_dev
 insert_module sof_pci_dev
 

--- a/tools/kmod_scripts/sof_insert.sh
+++ b/tools/kmod_scripts/sof_insert.sh
@@ -30,6 +30,7 @@ insert_module snd_soc_rt5682
 insert_module snd_soc_pcm512x_i2c
 insert_module snd_soc_wm8804_i2c
 insert_module snd_soc_max98357a
+insert_module snd_soc_max98090
 
 insert_module sof_acpi_dev
 insert_module sof_pci_dev

--- a/tools/kmod_scripts/sof_remove.sh
+++ b/tools/kmod_scripts/sof_remove.sh
@@ -41,6 +41,7 @@ remove_module snd_soc_sst_cht_bsw_rt5645
 remove_module snd_soc_sst_cht_bsw_rt5672
 remove_module snd_soc_sst_glk_rt5682_max98357a
 remove_module snd_soc_skl_hda_dsp
+remove_module snd_soc_cnl_rt700
 
 remove_module snd_sof
 remove_module snd_sof_nocodec

--- a/tools/kmod_scripts/sof_remove.sh
+++ b/tools/kmod_scripts/sof_remove.sh
@@ -16,6 +16,9 @@ remove_module() {
 
 remove_module sof_pci_dev
 remove_module sof_acpi_dev
+remove_module snd_sof_pci
+remove_module snd_sof_acpi
+
 remove_module snd_sof_intel_byt
 remove_module snd_sof_intel_bdw
 remove_module snd_sof_intel_hda_common

--- a/tools/kmod_scripts/sof_remove.sh
+++ b/tools/kmod_scripts/sof_remove.sh
@@ -67,6 +67,8 @@ remove_module snd_soc_rl6347a
 remove_module snd_soc_wm8804_i2c
 remove_module snd_soc_wm8804
 
+remove_module snd_soc_max98090
+remove_module snd_soc_ts3a227e
 remove_module snd_soc_max98357a
 
 remove_module snd_soc_hdac_hda


### PR DESCRIPTION
Deal with missed codecs, new ones for SoundWire support and renaming of PCI/ACPI modules done by Jaroslav (the last part is required for tests with this week's upstream merge).