### PR TITLE
cmake: link sof libraries as private

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,12 +163,12 @@ add_library(sof_ld_scripts INTERFACE)
 
 # declare target with no sources to let cmake know about it
 add_executable(sof "")
-target_link_libraries(sof sof_options)
-target_link_libraries(sof sof_ld_scripts)
-target_link_libraries(sof sof_ld_flags)
+target_link_libraries(sof PRIVATE sof_options)
+target_link_libraries(sof PRIVATE sof_ld_scripts)
+target_link_libraries(sof PRIVATE sof_ld_flags)
 
 sof_add_build_counter_rule()
 
 add_subdirectory(src)
 
-target_link_libraries(sof sof_lib)
+target_link_libraries(sof PRIVATE sof_lib)


### PR DESCRIPTION
In function target_link_libraries visibility modifiers have to be
consistent, otherwise we will get error while trying to use modifier,
if it wasn't used in root CMakeLists.

Signed-off-by: Janusz Jankowski <janusz.jankowski@linux.intel.com>