### PR TITLE
[WIP] dw-dma: set current_ptr to valid value after release

### DIFF
--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -469,18 +469,22 @@ static void host_buffer_cb(void *data, uint32_t bytes)
 	uint32_t flags = 0;
 	int ret;
 
-	/* get data sizes from DMA */
-	ret = dma_get_data_size(hd->dma, hd->chan, &avail_bytes, &free_bytes);
-	if (ret < 0) {
-		trace_host_error("host_buffer_cb() error: dma_get_data_size() "
-				 "failed, ret = %u", ret);
-		return;
-	}
+	if (hd->copy_type != COMP_COPY_ONE_SHOT) {
+		/* get data sizes from DMA */
+		ret = dma_get_data_size(hd->dma, hd->chan, &avail_bytes,
+					&free_bytes);
+		if (ret < 0) {
+			trace_host_error("host_buffer_cb() error: "
+					 "dma_get_data_size() failed, ret = %u",
+					 ret);
+			return;
+		}
 
-	/* calculate minimum size to copy */
-	copy_bytes = dev->params.direction == SOF_IPC_STREAM_PLAYBACK ?
-		MIN(avail_bytes, hd->dma_buffer->free) :
-		MIN(hd->dma_buffer->avail, free_bytes);
+		/* calculate minimum size to copy */
+		copy_bytes = dev->params.direction == SOF_IPC_STREAM_PLAYBACK ?
+			MIN(avail_bytes, hd->dma_buffer->free) :
+			MIN(hd->dma_buffer->avail, free_bytes);
+	}
 
 	/* copy_bytes should be aligned to minimum possible chunk of data to be
 	 * copied by dma.

--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -357,8 +357,8 @@ static int dw_dma_release(struct dma *dma, unsigned int channel)
 {
 	struct dma_pdata *p = dma_get_drvdata(dma);
 	struct dw_dma_chan_data *chan = p->chan + channel;
-#if CONFIG_HW_LLI
 	uint32_t next_ptr;
+#if CONFIG_HW_LLI
 	uint32_t bytes_left;
 #endif
 	uint32_t flags;
@@ -378,9 +378,9 @@ static int dw_dma_release(struct dma *dma, unsigned int channel)
 	/* get next lli for proper release */
 	chan->lli_current = (struct dw_lli *)chan->lli_current->llp;
 
-#if CONFIG_HW_LLI
 	/* copy leftover data between current and last lli */
 	next_ptr = DW_DMA_LLI_ADDRESS(chan->lli_current, chan->direction);
+#if CONFIG_HW_LLI
 	if (next_ptr >= chan->ptr_data.current_ptr)
 		bytes_left = next_ptr - chan->ptr_data.current_ptr;
 	else
@@ -390,6 +390,8 @@ static int dw_dma_release(struct dma *dma, unsigned int channel)
 			(next_ptr - chan->ptr_data.start_ptr);
 
 	dw_dma_copy(dma, channel, bytes_left, 0);
+#else
+	chan->ptr_data.current_ptr = next_ptr;
 #endif
 
 	irq_local_enable(flags);


### PR DESCRIPTION
Sets current_ptr to valid value after releasing the transfer
for DW-DMA not supporting hardware linked lists. Not aligning
the pointer will end up in xrun reported after pause - release
sequence on platforms like byt and cht.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>