### PR TITLE
imx8: dai: Initialize esai spinlock

### DIFF
--- a/src/platform/imx8/lib/dai.c
+++ b/src/platform/imx8/lib/dai.c
@@ -30,6 +30,12 @@ static struct dai_type_info dti[] = {
 
 int dai_init(void)
 {
+	int i;
+
+	 /* initialize spin locks early to enable ref counting */
+	for (i = 0; i < ARRAY_SIZE(esai); i++)
+		spinlock_init(&esai[i].lock);
+
 	dai_install(dti, ARRAY_SIZE(dti));
 	return 0;
 }


### PR DESCRIPTION
ESAI implementation is still dummy, anyhow we need to initialize ESAI
spinlock in order to avoid FW crashes.

Similar with commit 2ee7a24f97d298f ("byt: hsw: ssp: move spinlock init
to earlier stage") we initialize the spinlock in an early stage at
dai_init.

We started to notice the crash after commit f7abaf7b3346e ("spinlock: allocate
spinlocks in uncached memory") which requires that the lock must be
dynamically allocated at init. Before, the lock was statically allocated
and there were no crashes.

Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>