### PR TITLE
ipc: fix sideband IPC (cAVS 1.8+) registers names and layout and make defs common

### DIFF
--- a/src/drivers/imx/ipc.c
+++ b/src/drivers/imx/ipc.c
@@ -104,25 +104,13 @@ static void irq_handler(void *arg)
 
 void ipc_platform_do_cmd(struct ipc *ipc)
 {
+	struct sof_ipc_cmd_hdr *hdr;
 	/* Use struct ipc_data *iipc = ipc_get_drvdata(ipc); if needed */
-	struct sof_ipc_reply reply;
-	int32_t err;
 
-	/* perform command and return any error */
-	err = ipc_cmd();
-	if (err > 0) {
-		goto done; /* reply created and copied by cmd() */
-	} else {
-		/* send std error reply */
-		reply.error = err;
-	}
+	/* perform command */
+	hdr = mailbox_validate();
+	ipc_cmd(hdr);
 
-	/* send std error/ok reply */
-	reply.hdr.cmd = SOF_IPC_GLB_REPLY;
-	reply.hdr.size = sizeof(reply);
-	mailbox_hostbox_write(0, &reply, sizeof(reply));
-
-done:
 	ipc->host_pending = 0;
 
 	/* enable GP interrupt #0 - accept new messages */

--- a/src/drivers/intel/baytrail/ipc.c
+++ b/src/drivers/intel/baytrail/ipc.c
@@ -103,26 +103,14 @@ static void irq_handler(void *arg)
 
 void ipc_platform_do_cmd(struct ipc *ipc)
 {
+	struct sof_ipc_cmd_hdr *hdr;
 	/* Use struct ipc_data *iipc = ipc_get_drvdata(ipc); if needed */
-	struct sof_ipc_reply reply;
 	uint32_t ipcxh;
-	int32_t err;
 
-	/* perform command and return any error */
-	err = ipc_cmd();
-	if (err > 0) {
-		goto done; /* reply created and copied by cmd() */
-	} else {
-		/* send std error reply */
-		reply.error = err;
-	}
+	/* perform command */
+	hdr = mailbox_validate();
+	ipc_cmd(hdr);
 
-	/* send std error/ok reply */
-	reply.hdr.cmd = SOF_IPC_GLB_REPLY;
-	reply.hdr.size = sizeof(reply);
-	mailbox_hostbox_write(0, &reply, sizeof(reply));
-
-done:
 	ipc->host_pending = 0;
 
 	/* clear BUSY bit and set DONE bit - accept new messages */

--- a/src/drivers/intel/cavs/ipc.c
+++ b/src/drivers/intel/cavs/ipc.c
@@ -157,7 +157,7 @@ void ipc_platform_do_cmd(struct ipc *ipc)
 	ipc_write(IPC_DIPCT, ipc_read(IPC_DIPCT) | IPC_DIPCT_BUSY);
 #else
 	ipc_write(IPC_DIPCTDR, ipc_read(IPC_DIPCTDR) | IPC_DIPCTDR_BUSY);
-	ipc_write(IPC_DIPCTDA, ipc_read(IPC_DIPCTDA) | IPC_DIPCTDA_BUSY);
+	ipc_write(IPC_DIPCTDA, ipc_read(IPC_DIPCTDA) | IPC_DIPCTDA_DONE);
 #endif
 
 #if CONFIG_DEBUG_IPC_COUNTERS

--- a/src/drivers/intel/cavs/ipc.c
+++ b/src/drivers/intel/cavs/ipc.c
@@ -135,21 +135,12 @@ static void ipc_irq_handler(void *arg)
 
 void ipc_platform_do_cmd(struct ipc *ipc)
 {
-	struct sof_ipc_reply reply;
-	int32_t err;
+	struct sof_ipc_cmd_hdr *hdr;
 
-	/* perform command and return any error */
-	err = ipc_cmd();
+	hdr = mailbox_validate();
 
-	/* if err > 0, reply created and copied by cmd() */
-	if (err <= 0) {
-		/* send std error/ok reply */
-		reply.error = err;
-
-		reply.hdr.cmd = SOF_IPC_GLB_REPLY;
-		reply.hdr.size = sizeof(reply);
-		mailbox_hostbox_write(0, &reply, sizeof(reply));
-	}
+	/* perform command */
+	ipc_cmd(hdr);
 
 	ipc->host_pending = 0;
 

--- a/src/drivers/intel/haswell/ipc.c
+++ b/src/drivers/intel/haswell/ipc.c
@@ -98,25 +98,13 @@ static void irq_handler(void *arg)
 
 void ipc_platform_do_cmd(struct ipc *ipc)
 {
+	struct sof_ipc_cmd_hdr *hdr;
 	/* Use struct ipc_data *iipc = ipc_get_drvdata(ipc); if needed */
-	struct sof_ipc_reply reply;
-	int32_t err;
 
-	/* perform command and return any error */
-	err = ipc_cmd();
-	if (err > 0) {
-		goto done; /* reply created and copied by cmd() */
-	} else {
-		/* send std error reply */
-		reply.error = err;
-	}
+	/* perform command */
+	hdr = mailbox_validate();
+	ipc_cmd(hdr);
 
-	/* send std error/ok reply */
-	reply.hdr.cmd = SOF_IPC_GLB_REPLY;
-	reply.hdr.size = sizeof(reply);
-	mailbox_hostbox_write(0, &reply, sizeof(reply));
-
-done:
 	ipc->host_pending = 0;
 
 	/* clear BUSY bit and set DONE bit - accept new messages */

--- a/src/include/sof/drivers/ipc.h
+++ b/src/include/sof/drivers/ipc.h
@@ -240,6 +240,15 @@ int ipc_dma_trace_send_position(void);
 /* get posn offset by pipeline. */
 int ipc_get_posn_offset(struct ipc *ipc, struct pipeline *pipe);
 
-int ipc_cmd(void);
+struct sof_ipc_cmd_hdr *mailbox_validate(void);
+
+/**
+ * Generic IPC command handler. Expects that IPC command (the header plus
+ * any optional payload) is deserialized from the IPC HW by the platform
+ * specific method.
+ *
+ * @param hdr Points to the IPC command header.
+ */
+void ipc_cmd(struct sof_ipc_cmd_hdr *hdr);
 
 #endif /* __SOF_DRIVERS_IPC_H__ */

--- a/src/platform/cannonlake/include/platform/lib/shim.h
+++ b/src/platform/cannonlake/include/platform/lib/shim.h
@@ -12,6 +12,7 @@
 #ifndef __PLATFORM_LIB_SHIM_H__
 #define __PLATFORM_LIB_SHIM_H__
 
+#include <cavs/drivers/sideband-ipc.h>
 #include <sof/bit.h>
 #include <sof/lib/memory.h>
 
@@ -27,33 +28,6 @@
 #define IPC_DIPCIDA		0x14
 #define IPC_DIPCIDD		0x18
 #define IPC_DIPCCTL		0x28
-
-
-/* DIPCTDR */
-#define IPC_DIPCTDR_BUSY	(1 << 31)
-#define IPC_DIPCTDR_MSG_MASK	0x7FFFFFFF
-
-/* DIPCTDA */
-#define IPC_DIPCTDA_BUSY	(1 << 31)
-#define IPC_DIPCTDA_MSG_MASK	0x7FFFFFFF
-
-/* DIPCTE */
-#define IPC_DIPCTE_MSG_MASK	0x3FFFFFFF
-
-/* DIPCIDA*/
-#define IPC_DIPCIDA_DONE	(1 << 31)
-
-/* DIPCIDR */
-#define IPC_DIPCIDR_BUSY	(1 << 31)
-#define IPC_DIPCIDR_MSG_MASK	0x7FFFFFFF
-
-/* DIPCIE */
-#define IPC_DIPCIE_DONE		(1 << 31)
-#define IPC_DIPCIE_MSG_MASK	0x3FFFFFFF
-
-/* DIPCCTL */
-#define IPC_DIPCCTL_IPCIDIE	(1 << 1)
-#define IPC_DIPCCTL_IPCTBIE	(1 << 0)
 
 #define IPC_DSP_OFFSET		0x10
 

--- a/src/platform/cannonlake/power_down.S
+++ b/src/platform/cannonlake/power_down.S
@@ -125,7 +125,7 @@ beqz pu32_hpsram_mask, _PD_SEND_IPC
 _PD_SEND_IPC:
 /* Send IPC to host informing of PD completion - Clear BUSY
  * bit by writing IPC_DIPCTDR_BUSY to IPC_DIPCTDR
- * and writing IPC_DIPCTDA_BUSY to IPC_DIPCTDA
+ * and writing IPC_DIPCTDA_DONE to IPC_DIPCTDA
  */
 	movi temp_reg0, IPC_HOST_BASE
 	l32i temp_reg1, temp_reg0, IPC_DIPCTDR
@@ -134,7 +134,7 @@ _PD_SEND_IPC:
 	s32i temp_reg1, temp_reg0, IPC_DIPCTDR
 
 	l32i temp_reg1, temp_reg0, IPC_DIPCTDA
-	movi temp_reg2, IPC_DIPCTDA_BUSY
+	movi temp_reg2, IPC_DIPCTDA_DONE
 	or temp_reg1, temp_reg1, temp_reg2
 	s32i temp_reg1, temp_reg0, IPC_DIPCTDA
 

--- a/src/platform/icelake/include/platform/lib/shim.h
+++ b/src/platform/icelake/include/platform/lib/shim.h
@@ -12,6 +12,7 @@
 #ifndef __PLATFORM_LIB_SHIM_H__
 #define __PLATFORM_LIB_SHIM_H__
 
+#include <cavs/drivers/sideband-ipc.h>
 #include <sof/bit.h>
 #include <sof/lib/memory.h>
 
@@ -27,33 +28,6 @@
 #define IPC_DIPCIDA		0x14
 #define IPC_DIPCIDD		0x18
 #define IPC_DIPCCTL		0x28
-
-
-/* DIPCTDR */
-#define IPC_DIPCTDR_BUSY	(1 << 31)
-#define IPC_DIPCTDR_MSG_MASK	0x7FFFFFFF
-
-/* DIPCTDA */
-#define IPC_DIPCTDA_BUSY	(1 << 31)
-#define IPC_DIPCTDA_MSG_MASK	0x7FFFFFFF
-
-/* DIPCTE */
-#define IPC_DIPCTE_MSG_MASK	0x3FFFFFFF
-
-/* DIPCIDA*/
-#define IPC_DIPCIDA_DONE	(1 << 31)
-
-/* DIPCIDR */
-#define IPC_DIPCIDR_BUSY	(1 << 31)
-#define IPC_DIPCIDR_MSG_MASK	0x7FFFFFFF
-
-/* DIPCIE */
-#define IPC_DIPCIE_DONE		(1 << 31)
-#define IPC_DIPCIE_MSG_MASK	0x3FFFFFFF
-
-/* DIPCCTL */
-#define IPC_DIPCCTL_IPCIDIE	(1 << 1)
-#define IPC_DIPCCTL_IPCTBIE	(1 << 0)
 
 #define IPC_DSP_OFFSET		0x10
 

--- a/src/platform/intel/cavs/include/cavs/drivers/sideband-ipc.h
+++ b/src/platform/intel/cavs/include/cavs/drivers/sideband-ipc.h
@@ -1,0 +1,46 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2019 Intel Corporation. All rights reserved.
+ *
+ * Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
+ *         Keyon Jie <yang.jie@linux.intel.com>
+ *         Rander Wang <rander.wang@intel.com>
+ */
+
+/**
+ * \file platform/intel/cavs/include/cavs/drivers/sideband-ipc.h
+ * \brief Defines layout of IPC registers for cAVS platforms with sideband IPC.
+ */
+
+#ifndef __CAVS_DRIVERS_SIDEBAND_IPC_H__
+#define __CAVS_DRIVERS_SIDEBAND_IPC_H__
+
+#include <sof/bit.h>
+
+/* DIPCTDR */
+#define IPC_DIPCTDR_BUSY	BIT(31)
+#define IPC_DIPCTDR_MSG_MASK	MASK(30, 0)
+
+/* DIPCTDA - ack from target to initiator */
+#define IPC_DIPCTDA_DONE	BIT(31)
+#define IPC_DIPCTDA_MSG_MASK	MASK(30, 0)
+
+/* DIPCTDD */
+#define IPC_DIPCTDD_MSG_MASK	MASK(30, 0)
+
+/* DIPCIDA*/
+#define IPC_DIPCIDA_DONE	BIT(31)
+#define IPC_DIPCIDA_MSG_MASK	MASK(30, 0)
+
+/* DIPCIDR */
+#define IPC_DIPCIDR_BUSY	BIT(31)
+#define IPC_DIPCIDR_MSG_MASK	MASK(30, 0)
+
+/* DIPCIDD */
+#define IPC_DIPCIDD_MSG_MASK	MASK(31, 0)
+
+/* DIPCCTL */
+#define IPC_DIPCCTL_IPCIDIE	BIT(1)
+#define IPC_DIPCCTL_IPCTBIE	BIT(0)
+
+#endif

--- a/src/platform/suecreek/include/platform/lib/shim.h
+++ b/src/platform/suecreek/include/platform/lib/shim.h
@@ -12,6 +12,7 @@
 #ifndef __PLATFORM_LIB_SHIM_H__
 #define __PLATFORM_LIB_SHIM_H__
 
+#include <cavs/drivers/sideband-ipc.h>
 #include <sof/bit.h>
 #include <sof/lib/memory.h>
 
@@ -27,33 +28,6 @@
 #define IPC_DIPCIDA		0x14
 #define IPC_DIPCIDD		0x18
 #define IPC_DIPCCTL		0x28
-
-
-/* DIPCTDR */
-#define IPC_DIPCTDR_BUSY	(1 << 31)
-#define IPC_DIPCTDR_MSG_MASK	0x7FFFFFFF
-
-/* DIPCTDA */
-#define IPC_DIPCTDA_BUSY	(1 << 31)
-#define IPC_DIPCTDA_MSG_MASK	0x7FFFFFFF
-
-/* DIPCTE */
-#define IPC_DIPCTE_MSG_MASK	0x3FFFFFFF
-
-/* DIPCIDA*/
-#define IPC_DIPCIDA_DONE	(1 << 31)
-
-/* DIPCIDR */
-#define IPC_DIPCIDR_BUSY	(1 << 31)
-#define IPC_DIPCIDR_MSG_MASK	0x7FFFFFFF
-
-/* DIPCIE */
-#define IPC_DIPCIE_DONE		(1 << 31)
-#define IPC_DIPCIE_MSG_MASK	0x3FFFFFFF
-
-/* DIPCCTL */
-#define IPC_DIPCCTL_IPCIDIE	(1 << 1)
-#define IPC_DIPCCTL_IPCTBIE	(1 << 0)
 
 #define IPC_DSP_OFFSET		0x10
 


### PR DESCRIPTION
The first two patches are a minor cleanup in the IPC flow as well as cAVS 1.8 IPC HW definition fixes. Pls see their descriptions for full explanation.
