### PR TITLE
cmake: support for 3rd party static libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,10 @@ add_library(sof_options INTERFACE)
 
 target_link_libraries(sof_options INTERFACE sof_public_headers)
 
+# interface library that is used only as container for sof statically
+# linked libraries
+add_library(sof_static_libraries INTERFACE)
+
 # get compiler name and version
 execute_process(
 	COMMAND ${CMAKE_C_COMPILER} --version
@@ -117,6 +121,7 @@ target_include_directories(sof_public_headers INTERFACE ${GENERATED_DIRECTORY}/i
 if(BUILD_LIBRARY)
 	add_library(sof SHARED "")
 	target_link_libraries(sof PRIVATE sof_options)
+	target_link_libraries(sof PRIVATE sof_static_libraries)
 	install(TARGETS sof DESTINATION lib)
 
 	add_subdirectory(src)
@@ -166,9 +171,8 @@ add_executable(sof "")
 target_link_libraries(sof PRIVATE sof_options)
 target_link_libraries(sof PRIVATE sof_ld_scripts)
 target_link_libraries(sof PRIVATE sof_ld_flags)
+target_link_libraries(sof PRIVATE sof_static_libraries)
 
 sof_add_build_counter_rule()
 
 add_subdirectory(src)
-
-target_link_libraries(sof PRIVATE sof_lib)

--- a/scripts/cmake/misc.cmake
+++ b/scripts/cmake/misc.cmake
@@ -43,3 +43,19 @@ function(add_local_sources target)
 		target_sources(${target} PRIVATE ${path})
 	endforeach()
 endfunction()
+
+# Declares new static lib with given name and path that will be linked
+# to sof binary.
+function(sof_add_static_library lib_name lib_path)
+	# we need libs to be visible in the root CMakeLists, so use GLOBAL
+	add_library(${lib_name} STATIC IMPORTED GLOBAL)
+
+	if(IS_ABSOLUTE ${lib_path})
+		set(lib_abs_path ${lib_path})
+	else()
+		set(lib_abs_path ${CMAKE_CURRENT_SOURCE_DIR}/${lib_path})
+	endif()
+
+	set_target_properties(${lib_name} PROPERTIES IMPORTED_LOCATION ${lib_abs_path})
+	target_link_libraries(sof_static_libraries INTERFACE ${lib_name})
+endfunction()

--- a/src/arch/xtensa/CMakeLists.txt
+++ b/src/arch/xtensa/CMakeLists.txt
@@ -154,24 +154,21 @@ add_local_sources(sof
 	exc-dump.S
 )
 
-add_library(sof_lib INTERFACE)
-target_link_libraries(sof_lib INTERFACE sof_options)
-
 # TODO: order of these libraries does matter, what is bad,
 # we should switch to building with thin archives without symbols index
 # and made it before final link so dependencies won't matter
-target_link_libraries(sof_lib INTERFACE xtos)
-target_link_libraries(sof_lib INTERFACE hal)
+target_link_libraries(sof_static_libraries INTERFACE xtos)
+target_link_libraries(sof_static_libraries INTERFACE hal)
 
-target_link_libraries(sof_lib INTERFACE xlevel2)
-target_link_libraries(sof_lib INTERFACE xlevel3)
-target_link_libraries(sof_lib INTERFACE xlevel4)
-target_link_libraries(sof_lib INTERFACE xlevel5)
+target_link_libraries(sof_static_libraries INTERFACE xlevel2)
+target_link_libraries(sof_static_libraries INTERFACE xlevel3)
+target_link_libraries(sof_static_libraries INTERFACE xlevel4)
+target_link_libraries(sof_static_libraries INTERFACE xlevel5)
 
 if(build_bootloader)
 	add_local_sources(sof main-entry.S)
 else()
-	target_link_libraries(sof_lib INTERFACE reset)
+	target_link_libraries(sof_static_libraries INTERFACE reset)
 endif()
 
 target_link_libraries(sof_ld_flags INTERFACE "-lgcc")


### PR DESCRIPTION
This PR  enables linking to precompiled static libs.

Example usage:
```cmake
# f.e. in src/audio/my_comp
sof_add_static_library(myClosedLib "path/to/lib/relative/to/current/dir/or/absolute")
```