### PR TITLE
[RFC] lib: dai: Introduce generic DAI I/O access functions

### DIFF
--- a/src/drivers/intel/cavs/dmic.c
+++ b/src/drivers/intel/cavs/dmic.c
@@ -18,7 +18,6 @@
 #include <sof/lib/cpu.h>
 #include <sof/lib/dai.h>
 #include <sof/lib/dma.h>
-#include <sof/lib/io.h>
 #include <sof/lib/pm_runtime.h>
 #include <sof/math/decibels.h>
 #include <sof/math/numbers.h>
@@ -154,18 +153,18 @@ static int dmic_active_fifos;
 
 static void dmic_write(struct dai *dai, uint32_t reg, uint32_t value)
 {
-	io_reg_write(dai_base(dai) + reg, value);
+	dai_write(dai, reg, value);
 }
 
 static uint32_t dmic_read(struct dai *dai, uint32_t reg)
 {
-	return io_reg_read(dai_base(dai) + reg);
+	return dai_read(dai, reg);
 }
 
 static void dmic_update_bits(struct dai *dai, uint32_t reg, uint32_t mask,
 			     uint32_t value)
 {
-	io_reg_update_bits(dai_base(dai) + reg, mask, value);
+	dai_update_bits(dai, reg, mask, value);
 }
 
 /* this ramps volume changes over time */

--- a/src/include/sof/drivers/ssp.h
+++ b/src/include/sof/drivers/ssp.h
@@ -10,7 +10,6 @@
 
 #include <sof/bit.h>
 #include <sof/lib/dai.h>
-#include <sof/lib/io.h>
 #include <sof/lib/wait.h>
 #include <sof/trace/trace.h>
 #include <ipc/dai.h>
@@ -240,19 +239,18 @@ struct ssp_pdata {
 
 static inline void ssp_write(struct dai *dai, uint32_t reg, uint32_t value)
 {
-	io_reg_write(dai_base(dai) + reg, value);
+	dai_write(dai, reg, value);
 }
 
 static inline uint32_t ssp_read(struct dai *dai, uint32_t reg)
 {
-	return io_reg_read(dai_base(dai) + reg);
+	return dai_read(dai, reg);
 }
 
 static inline void ssp_update_bits(struct dai *dai, uint32_t reg, uint32_t mask,
 	uint32_t value)
 {
-	io_reg_update_bits(dai_base(dai) + reg, mask, value);
+	dai_update_bits(dai, reg, mask, value);
 }
-
 
 #endif /* __SOF_DRIVERS_SSP_H__ */

--- a/src/include/sof/lib/dai.h
+++ b/src/include/sof/lib/dai.h
@@ -18,6 +18,7 @@
 
 #include <platform/lib/dai.h>
 #include <sof/bit.h>
+#include <sof/lib/io.h>
 #include <sof/spinlock.h>
 #include <errno.h>
 #include <stddef.h>
@@ -226,6 +227,22 @@ static inline int dai_get_info(struct dai *dai, int info)
 	}
 
 	return ret;
+}
+
+static inline void dai_write(struct dai *dai, uint32_t reg, uint32_t value)
+{
+	io_reg_write(dai_base(dai) + reg, value);
+}
+
+static inline uint32_t dai_read(struct dai *dai, uint32_t reg)
+{
+	return io_reg_read(dai_base(dai) + reg);
+}
+
+static inline void dai_update_bits(struct dai *dai, uint32_t reg,
+				   uint32_t mask, uint32_t value)
+{
+	io_reg_update_bits(dai_base(dai) + reg, mask, value);
 }
 
 /** @}*/


### PR DESCRIPTION
Hi all,

I want to hear your opinion on having some generic DAI I/O access functions.

We will introduce IMX DAIs (SAI, ESAI) and for this, one should write identical:
* esai_read / sai_read
* esai_write / sai_write 

functions. 

Instead we can directly use the newly introduced generic functions:
* dai_read
* dai_write, etc

For the moment I wrapped ssp_read/dmic_read/etc around the newly introduce generic functions but in the future one might actually replace all ssp_read/dmic_read calls with dai_read functions.

What do you say?