### PR TITLE
ipc: cavs: read short request directly from ipc registers

### DIFF
--- a/src/drivers/intel/cavs/ipc.c
+++ b/src/drivers/intel/cavs/ipc.c
@@ -19,9 +19,19 @@
 #include <sof/schedule/task.h>
 #include <sof/spinlock.h>
 #include <ipc/header.h>
+#if CAVS_VERSION >= CAVS_VERSION_1_8
+#include <ipc/header-intel-cavs.h>
+#include <ipc/pm.h>
+#endif
 #include <config.h>
 #include <stddef.h>
 #include <stdint.h>
+
+#if CAVS_VERSION >= CAVS_VERSION_1_8
+
+#define CAVS_IPC_TYPE_S(x)		((x) & CAVS_IPC_TYPE_MASK)
+
+#endif
 
 extern struct ipc *_ipc;
 
@@ -118,17 +128,68 @@ static void ipc_irq_handler(void *arg)
 	}
 }
 
+#if CAVS_VERSION >= CAVS_VERSION_1_8
+static struct sof_ipc_cmd_hdr *ipc_cavs_read_set_d0ix(uint32_t dr, uint32_t dd)
+{
+	struct sof_ipc_pm_gate *cmd = _ipc->comp_data;
+
+	cmd->hdr.cmd = SOF_IPC_GLB_PM_MSG | SOF_IPC_PM_GATE;
+	cmd->hdr.size = sizeof(*cmd);
+	cmd->flags = dd & CAVS_IPC_MOD_SETD0IX_BIT_MASK;
+
+	return &cmd->hdr;
+}
+
+static struct sof_ipc_cmd_hdr *ipc_cavs_read_msg(void)
+{
+	struct sof_ipc_cmd_hdr *hdr;
+	uint32_t dr;
+	uint32_t dd;
+
+	dr = ipc_read(IPC_DIPCTDR);
+	dd = ipc_read(IPC_DIPCTDD);
+
+	/* if there is no cAVS module IPC in regs go the previous path */
+	if (!(dr & CAVS_IPC_MSG_TGT))
+		return mailbox_validate();
+
+	switch (CAVS_IPC_TYPE_S(dr)) {
+	case CAVS_IPC_MOD_SET_D0IX:
+		hdr = ipc_cavs_read_set_d0ix(dr, dd);
+		break;
+	default:
+		return NULL;
+	}
+
+	dcache_writeback_region(hdr, hdr->size);
+
+	return hdr;
+}
+#endif
+
 static enum task_state ipc_platform_do_cmd(void *data)
 {
 #if !CONFIG_SUECREEK
 	struct ipc *ipc = data;
 #endif
 	struct sof_ipc_cmd_hdr *hdr;
+	struct sof_ipc_reply reply;
 
+#if CAVS_VERSION >= CAVS_VERSION_1_8
+	hdr = ipc_cavs_read_msg();
+#else
 	hdr = mailbox_validate();
-
+#endif
 	/* perform command */
-	ipc_cmd(hdr);
+	if (hdr)
+		ipc_cmd(hdr);
+	else {
+		/* send invalid command error in reply */
+		reply.error = -EINVAL;
+		reply.hdr.cmd = SOF_IPC_GLB_REPLY;
+		reply.hdr.size = sizeof(reply);
+		mailbox_hostbox_write(0, &reply, sizeof(reply));
+	}
 
 	/* are we about to enter D3 ? */
 #if !CONFIG_SUECREEK

--- a/src/include/ipc/header-intel-cavs.h
+++ b/src/include/ipc/header-intel-cavs.h
@@ -1,0 +1,96 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2019 Intel Corporation. All rights reserved.
+ *
+ * Author: Marcin Maka <marcin.maka@linux.intel.com>
+ */
+
+/**
+ * \file include/ipc/header-intel-cavs.h
+ * \brief IPC command header for Intel cAVS platforms
+ * \author Marcin Maka <marcin.maka@linux.intel.com>
+ */
+
+#ifndef __IPC_HEADER_INTEL_CAVS_H__
+#define __IPC_HEADER_INTEL_CAVS_H__
+
+#include <sof/bit.h>
+
+/* Primary register, mapped to
+ * - DIPCTDR (HIPCIDR) in sideband IPC (cAVS 1.8+)
+ * - DIPCT in cAVS 1.5 IPC
+ *
+ * Secondary register, mapped to:
+ * - DIPCTDD (HIPCIDD) in sideband IPC (cAVS 1.8+)
+ * - DIPCTE in cAVS 1.5 IPC
+ */
+
+/* Common bits in primary register */
+
+#define CAVS_IPC_RSVD_31		BIT(31)
+
+/** \brief Target, 0 - global message, 1 - message to a module */
+#define CAVS_IPC_MSG_TGT		BIT(30)
+
+/** \brief Direction, 0 - request, 1 - response */
+#define CAVS_IPC_RSP			BIT(29)
+
+#define CAVS_IPC_TYPE_SHIFT		24
+#define CAVS_IPC_TYPE_MASK		MASK(28, 24)
+#define CAVS_IPC_TYPE(x)		((x) << CAVS_IPC_TYPE_SHIFT)
+
+/* Bits in primary register for Module messages (CAVS_IPC_MSG_TGT set to 1) */
+
+/** \brief ID of the target module instance */
+#define CAVS_IPC_MOD_INSTANCE_ID_MASK	MASK(23, 16)
+
+/** \brief ID of the target module */
+#define CAVS_IPC_MOD_ID_MASK		MASK(15, 0)
+
+/* Definition of bits in secondary register are message specific
+ * and are defined for each message separately later.
+ */
+
+/* Primary register :: type value for Module messages */
+
+#define CAVS_IPC_MOD_INIT_INSTANCE	CAVS_IPC_TYPE(0x0U)
+#define CAVS_IPC_MOD_CFG_GET		CAVS_IPC_TYPE(0x1U)
+#define CAVS_IPC_MOD_CFG_SET		CAVS_IPC_TYPE(0x2U)
+#define CAVS_IPC_MOD_LARGE_CFG_GET	CAVS_IPC_TYPE(0x3U)
+#define CAVS_IPC_MOD_LARGE_CFG_SET	CAVS_IPC_TYPE(0x4U)
+#define CAVS_IPC_MOD_BIND		CAVS_IPC_TYPE(0x5U)
+#define CAVS_IPC_MOD_UNBIND		CAVS_IPC_TYPE(0x6U)
+#define CAVS_IPC_MOD_SET_DX		CAVS_IPC_TYPE(0x7U)
+#define CAVS_IPC_MOD_SET_D0IX		CAVS_IPC_TYPE(0x8U)
+#define CAVS_IPC_MOD_ENTER_RESTORE	CAVS_IPC_TYPE(0x9U)
+#define CAVS_IPC_MOD_EXIT_RESTORE	CAVS_IPC_TYPE(0xaU)
+#define CAVS_IPC_MOD_DELETE_INSTANCE	CAVS_IPC_TYPE(0xbU)
+#define CAVS_IPC_MOD_NOTIFICATION	CAVS_IPC_TYPE(0xcU)
+
+/* Secondary register bits for Module::SetD0iX
+ * ( Primary
+ *     tgt = 1 (module message)
+ *     rsp = 0 (request)
+ *     type = CAVS_IPC_MOD_SET_D0IX
+ * )
+ */
+
+/** \brief Valid bits for SetD0ix */
+#define CAVS_IPC_MOD_SETD0IX_BIT_MASK	MASK(7, 0)
+
+/** \brief Disable DMA tracing (0 - keep tracing, 1 - to disable DMA trace) */
+#define CAVS_IPC_MOD_SETD0IX_NO_TRACE	BIT(4)
+
+/** \brief Prevent clock gating (0 - cg allowed, 1 - DSP clock always on) */
+#define CAVS_IPC_MOD_SETD0IX_PCG	BIT(3)
+
+/** \brief Prevent power gating (0 - D0ix transitions allowed) */
+#define CAVS_IPC_MOD_SETD0IX_PPG	BIT(2)
+
+/** \brief Streaming active */
+#define CAVS_IPC_MOD_SETD0IX_STREAMING	BIT(1)
+
+/** \brief Legacy wake type, unused in cAVS 1.8+ */
+#define CAVS_IPC_MOD_SETD0IX_WAKE_TYPE	BIT(0)
+
+#endif /* __IPC_HEADER_INTEL_CAVS_H__ */

--- a/src/include/ipc/header.h
+++ b/src/include/ipc/header.h
@@ -102,6 +102,7 @@
 #define SOF_IPC_PM_CLK_GET			SOF_CMD_TYPE(0x005)
 #define SOF_IPC_PM_CLK_REQ			SOF_CMD_TYPE(0x006)
 #define SOF_IPC_PM_CORE_ENABLE			SOF_CMD_TYPE(0x007)
+#define SOF_IPC_PM_GATE				SOF_CMD_TYPE(0x008)
 
 /** \name DSP Command: Component runtime config - multiple different types
  *  @{

--- a/src/include/ipc/pm.h
+++ b/src/include/ipc/pm.h
@@ -54,4 +54,26 @@ struct sof_ipc_pm_core_config {
 	uint32_t enable_mask;
 } __attribute__((packed));
 
+struct sof_ipc_pm_gate {
+	struct sof_ipc_cmd_hdr hdr;
+	uint32_t flags;
+
+	/* reserved for future use */
+	uint32_t reserved[5];
+} __attribute__((packed));
+
+#define SOF_PM_PG_RSVD		BIT(0)
+
+/** \brief Indicates whether streaming is active */
+#define SOF_PM_PG_STREAMING	BIT(1)
+
+/** \brief Prevent power gating (0 - deep power state transitions allowed) */
+#define SOF_PM_PPG		BIT(2)
+
+/** \brief Prevent clock gating (0 - cg allowed, 1 - DSP clock always on) */
+#define SOF_PM_PCG		BIT(3)
+
+/** \brief Disable DMA tracing (0 - keep tracing, 1 - to disable DMA trace) */
+#define SOF_PM_NO_TRACE		BIT(4)
+
 #endif /* __IPC_PM_H__ */

--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -665,6 +665,17 @@ static int ipc_pm_core_enable(uint32_t header)
 	return 0;
 }
 
+static int ipc_pm_gate(uint32_t header)
+{
+	struct sof_ipc_pm_gate pm_gate;
+
+	IPC_COPY_CMD(pm_gate, _ipc->comp_data);
+
+	/* TODO: handle the flags */
+
+	return 0;
+}
+
 static int ipc_glb_pm_message(uint32_t header)
 {
 	uint32_t cmd = iCS(header);
@@ -678,6 +689,8 @@ static int ipc_glb_pm_message(uint32_t header)
 		return ipc_pm_context_size(header);
 	case SOF_IPC_PM_CORE_ENABLE:
 		return ipc_pm_core_enable(header);
+	case SOF_IPC_PM_GATE:
+		return ipc_pm_gate(header);
 	case SOF_IPC_PM_CLK_SET:
 	case SOF_IPC_PM_CLK_GET:
 	case SOF_IPC_PM_CLK_REQ:


### PR DESCRIPTION
Selected cAVS IPC messages are transferred to the DSP using IPC registers and no mailbox located in SRAM which is the only safe way to send a message to the cAVS DSP when the DSP is in a lower power state.

A message is translated by the cavs ipc layer and then passed to the common ipc command handler.

Response always use the mailbox since there is no way to write the *T registers back with the current bi-directional communication implemented using a single *T register set.

Note: This is a proposal, moved from #1720. Intel cAVS specific change, no impact to the common code, no impact to other platforms. Payload byte order changed as suggested.