### PR TITLE
topology: change byt/cht max media pcm rate to 48kHz

### DIFF
--- a/tools/topology/sof-cht-nocodec.m4
+++ b/tools/topology/sof-cht-nocodec.m4
@@ -63,7 +63,7 @@ DAI_ADD(sof/pipe-dai-playback.m4,
 PIPELINE_PCM_ADD(sof/pipe-pcm-media.m4,
 	3, 1, 2, s32le,
 	4000, 1, 0,
-	8000, 96000, 48000,
+	8000, 48000, 48000,
 	0, PIPELINE_PLAYBACK_SCHED_COMP_1)
 
 # Connect pipelines together


### PR DESCRIPTION
Byt doesn't have enough memory to accomodate buffer size
increase from updating media pipeline's pcm_max_rate to
96kHz. So limit it to 48khz.

Signed-off-by: Jaska Uimonen <jaska.uimonen@intel.com>