### PR TITLE
dmic: fix stop after pause

### DIFF
--- a/src/drivers/intel/cavs/dmic.c
+++ b/src/drivers/intel/cavs/dmic.c
@@ -1366,6 +1366,12 @@ static void dmic_stop(struct dai *dai)
 
 	trace_dmic("dmic_stop()");
 	spin_lock(dai->lock);
+
+	if (dmic->state != COMP_STATE_ACTIVE) {
+		trace_dmic("dmic_stop(), already stopped");
+		goto out;
+	}
+
 	dmic->state = COMP_STATE_PREPARE;
 
 	/* Stop FIFO packers and set FIFO initialize bits */
@@ -1411,6 +1417,7 @@ static void dmic_stop(struct dai *dai)
 
 	dmic_active_fifos--;
 
+out:
 	spin_unlock(dai->lock);
 }
 


### PR DESCRIPTION
This PR fixes bug that makes active FIFOs count go below 0,
if you call stop after pause.

Signed-off-by: Janusz Jankowski <janusz.jankowski@linux.intel.com>