### PR TITLE
ipc: align stream.h with kernel

### DIFF
--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -134,8 +134,8 @@ static void host_update_position(struct comp_dev *dev, uint32_t bytes)
 	if (hd->local_pos >= hd->host_size)
 		hd->local_pos = 0;
 
-	/* NO_IRQ mode if host_period_size == 0 */
-	if (dev->params.host_period_bytes != 0) {
+	/* Don't send stream position if no_stream_position == 1 */
+	if (!dev->params.no_stream_position) {
 		hd->report_pos += bytes;
 
 		/* send IPC message to driver if needed */

--- a/src/include/ipc/stream.h
+++ b/src/include/ipc/stream.h
@@ -91,10 +91,10 @@ struct sof_ipc_stream_params {
 	uint16_t sample_valid_bytes;
 	uint16_t sample_container_bytes;
 
-	/* for notifying host period has completed - 0 means no period IRQ */
 	uint32_t host_period_bytes;
+	uint16_t no_stream_position; /**< 1 means don't send stream position */
 
-	uint32_t reserved[2];
+	uint16_t reserved[3];
 	uint16_t chmap[SOF_IPC_MAX_CHANNELS];	/**< channel map - SOF_CHMAP_ */
 } __attribute__((packed));
 


### PR DESCRIPTION
This patch fixes the incorrect check for
    host_period_bytes. This value was incorrectly used
    to store host request for stream position. So
    we introduced dedicated parameter for this purpose
    (no_stream_position) and update all related checks accordingly.
    
    Signed-off-by: Marcin Rajwa <marcin.rajwa@linux.intel.com>