### PR TITLE
notifier: send idc notifications in non blocking mode

### DIFF
--- a/src/lib/notifier.c
+++ b/src/lib/notifier.c
@@ -14,7 +14,7 @@
 #include <sof/spinlock.h>
 #include <ipc/topology.h>
 
-static struct notify_data _notify_data;
+static struct notify_data _notify_data __aligned(PLATFORM_DCACHE_ALIGN);
 
 void notifier_register(struct notifier *notifier)
 {

--- a/src/lib/notifier.c
+++ b/src/lib/notifier.c
@@ -76,7 +76,7 @@ void notifier_event(struct notify_data *notify_data)
 				notifier_notify();
 			} else if (cpu_is_core_enabled(i)) {
 				notify_msg.core = i;
-				idc_send_msg(&notify_msg, IDC_BLOCKING);
+				idc_send_msg(&notify_msg, IDC_NON_BLOCKING);
 			}
 		}
 	}


### PR DESCRIPTION
Changes the way of sending notifications to slave cores
from blocking to non blocking mode. Blocking mode isn't
the best solution, because potentially we can be on higher
interrupt level, then the one for receiving idc result.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>