### PR TITLE
dma: Fix dma_chan_irq macro for APL.

### DIFF
--- a/src/platform/apollolake/include/platform/lib/dma.h
+++ b/src/platform/apollolake/include/platform/lib/dma.h
@@ -47,7 +47,7 @@
 #define DMA_HANDSHAKE_SSP5_TX	12
 #define DMA_HANDSHAKE_SSP5_RX	13
 
-#define dma_chan_irq(dma, chan) (dma_irq(dma) + channel)
+#define dma_chan_irq(dma, chan) (dma_irq(dma) + chan)
 
 int dmac_init(void);
 


### PR DESCRIPTION
Signed-off-by: ArturX Kloniecki <arturx.kloniecki@linux.intel.com>