### PR TITLE
dmic: ssp: correct misused dma_get_drvdata instead of dai_get_drvdata.

### DIFF
--- a/src/drivers/intel/cavs/dmic.c
+++ b/src/drivers/intel/cavs/dmic.c
@@ -1569,7 +1569,7 @@ static int dmic_remove(struct dai *dai)
 	/* Disable DMIC power */
 	pm_runtime_put_sync(DMIC_POW, dai->index);
 
-	rfree(dma_get_drvdata(dai));
+	rfree(dai_get_drvdata(dai));
 	dai_set_drvdata(dai, NULL);
 
 	rfree(dmic_prm[0]);

--- a/src/drivers/intel/cavs/ssp.c
+++ b/src/drivers/intel/cavs/ssp.c
@@ -936,7 +936,7 @@ static int ssp_remove(struct dai *dai)
 {
 	pm_runtime_put_sync(SSP_CLK, dai->index);
 
-	rfree(dma_get_drvdata(dai));
+	rfree(dai_get_drvdata(dai));
 	dai_set_drvdata(dai, NULL);
 
 	return 0;


### PR DESCRIPTION
Signed-off-by: ArturX Kloniecki <arturx.kloniecki@linux.intel.com>