### PR TITLE
dma: Refactor channel operations interface

### DIFF
--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -55,7 +55,7 @@
 
 struct dai_data {
 	/* local DMA config */
-	int chan;
+	struct dma_chan_data *chan;
 	struct dma_sg_config config;
 	struct comp_buffer *dma_buffer;
 
@@ -203,7 +203,7 @@ static struct comp_dev *dai_new(struct sof_ipc_comp *comp)
 	dd->dai_pos = NULL;
 	dd->dai_pos_blks = 0;
 	dd->xrun = 0;
-	dd->chan = DMA_CHAN_INVALID;
+	dd->chan = NULL;
 
 	dev->state = COMP_STATE_READY;
 	return dev;
@@ -218,7 +218,7 @@ static void dai_free(struct comp_dev *dev)
 {
 	struct dai_data *dd = comp_get_drvdata(dev);
 
-	dma_channel_put(dd->dma, dd->chan);
+	dma_channel_put(dd->dma, dd->chan->index);
 	dma_put(dd->dma);
 
 	dai_put(dd->dai);
@@ -446,7 +446,7 @@ static int dai_prepare(struct comp_dev *dev)
 		return ret;
 	}
 
-	ret = dma_set_config(dd->dma, dd->chan, &dd->config);
+	ret = dma_set_config(dd->dma, dd->chan->index, &dd->config);
 	if (ret < 0)
 		comp_set_state(dev, COMP_TRIGGER_RESET);
 
@@ -500,7 +500,7 @@ static int dai_comp_trigger(struct comp_dev *dev, int cmd)
 		if (dd->xrun == 0 && !pipeline_is_preload(dev->pipeline)) {
 			/* start the DAI */
 			dai_trigger(dd->dai, cmd, dev->params.direction);
-			ret = dma_start(dd->dma, dd->chan);
+			ret = dma_start(dd->dma, dd->chan->index);
 			if (ret < 0)
 				return ret;
 		} else {
@@ -521,13 +521,13 @@ static int dai_comp_trigger(struct comp_dev *dev, int cmd)
 		/* only start the DAI if we are not XRUN handling */
 		if (dd->xrun == 0) {
 			/* recover valid start position */
-			ret = dma_release(dd->dma, dd->chan);
+			ret = dma_release(dd->dma, dd->chan->index);
 			if (ret < 0)
 				return ret;
 
 			/* start the DAI */
 			dai_trigger(dd->dai, cmd, dev->params.direction);
-			ret = dma_start(dd->dma, dd->chan);
+			ret = dma_start(dd->dma, dd->chan->index);
 			if (ret < 0)
 				return ret;
 		} else {
@@ -545,7 +545,7 @@ static int dai_comp_trigger(struct comp_dev *dev, int cmd)
 	case COMP_TRIGGER_PAUSE:
 	case COMP_TRIGGER_STOP:
 		trace_dai_with_ids(dev, "dai_comp_trigger(), PAUSE/STOP");
-		ret = dma_stop(dd->dma, dd->chan);
+		ret = dma_stop(dd->dma, dd->chan->index);
 		dai_trigger(dd->dai, COMP_TRIGGER_STOP, dev->params.direction);
 		break;
 	default:
@@ -600,7 +600,7 @@ static int dai_copy(struct comp_dev *dev)
 		/* start the DAI */
 		dai_trigger(dd->dai, COMP_TRIGGER_START,
 			    dev->params.direction);
-		ret = dma_start(dd->dma, dd->chan);
+		ret = dma_start(dd->dma, dd->chan->index);
 		if (ret < 0)
 			return ret;
 		platform_dai_wallclock(dev, &dd->wallclock);
@@ -609,7 +609,8 @@ static int dai_copy(struct comp_dev *dev)
 	}
 
 	/* get data sizes from DMA */
-	ret = dma_get_data_size(dd->dma, dd->chan, &avail_bytes, &free_bytes);
+	ret = dma_get_data_size(dd->dma, dd->chan->index, &avail_bytes,
+				&free_bytes);
 	if (ret < 0)
 		return ret;
 
@@ -625,7 +626,7 @@ static int dai_copy(struct comp_dev *dev)
 	if (ret < 0 || ret == PPL_STATUS_PATH_STOP)
 		return ret;
 
-	ret = dma_copy(dd->dma, dd->chan, copy_bytes, 0);
+	ret = dma_copy(dd->dma, dd->chan->index, copy_bytes, 0);
 	if (ret < 0)
 		trace_dai_error("dai_copy() error: ret = %u", ret);
 
@@ -734,9 +735,9 @@ static int dai_config(struct comp_dev *dev, struct sof_ipc_dai_config *config)
 		 * Free the channel that is currently in use before
 		 * assigning the new one.
 		 */
-		if (dd->chan != DMA_CHAN_INVALID) {
-			dma_channel_put(dd->dma, dd->chan);
-			dd->chan = DMA_CHAN_INVALID;
+		if (dd->chan) {
+			dma_channel_put(dd->dma, dd->chan->index);
+			dd->chan = NULL;
 		}
 		break;
 	default:
@@ -756,19 +757,19 @@ static int dai_config(struct comp_dev *dev, struct sof_ipc_dai_config *config)
 	}
 
 	if (channel != DMA_CHAN_INVALID) {
-		if (dd->chan == DMA_CHAN_INVALID)
+		if (!dd->chan)
 			/* get dma channel at first config only */
 			dd->chan = dma_channel_get(dd->dma, channel);
 
-		if (dd->chan < 0) {
+		if (!dd->chan) {
 			trace_dai_error_with_ids(dev, "dai_config() error: "
 						 "dma_channel_get() failed");
-			dd->chan = DMA_CHAN_INVALID;
+			dd->chan = NULL;
 			return -EIO;
 		}
 
 		/* set up callback */
-		dma_set_cb(dd->dma, dd->chan,
+		dma_set_cb(dd->dma, dd->chan->index,
 			   DMA_CB_TYPE_IRQ | DMA_CB_TYPE_COPY,
 			   dai_dma_cb, dev);
 		dev->is_dma_connected = 1;

--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -345,7 +345,7 @@ static int host_trigger(struct comp_dev *dev, int cmd)
 
 	switch (cmd) {
 	case COMP_TRIGGER_START:
-		ret = dma_start(hd->dma, hd->chan->index);
+		ret = dma_start(hd->chan);
 		if (ret < 0)
 			trace_host_error_with_ids(dev, "host_trigger() error: "
 						  "dma_start() failed, "
@@ -353,7 +353,7 @@ static int host_trigger(struct comp_dev *dev, int cmd)
 		break;
 	case COMP_TRIGGER_STOP:
 	case COMP_TRIGGER_XRUN:
-		ret = dma_stop(hd->dma, hd->chan->index);
+		ret = dma_stop(hd->chan);
 		if (ret < 0)
 			trace_host_error_with_ids(dev, "host_trigger(): dma "
 						  "stop failed: %d", ret);
@@ -498,7 +498,7 @@ static uint32_t host_buffer_get_copy_bytes(struct comp_dev *dev)
 		local_elem->size = copy_bytes;
 	} else {
 		/* get data sizes from DMA */
-		ret = dma_get_data_size(hd->dma, hd->chan->index, &avail_bytes,
+		ret = dma_get_data_size(hd->chan, &avail_bytes,
 					&free_bytes);
 		if (ret < 0) {
 			trace_host_error("host_buffer_cb() error: "
@@ -537,14 +537,14 @@ static void host_buffer_cb(void *data, uint32_t bytes)
 		flags |= DMA_COPY_ONE_SHOT;
 
 	/* reconfigure transfer */
-	ret = dma_set_config(hd->dma, hd->chan->index, &hd->config);
+	ret = dma_set_config(hd->chan, &hd->config);
 	if (ret < 0) {
 		trace_host_error("host_buffer_cb() error: dma_set_config() "
 				 "failed, ret = %u", ret);
 		return;
 	}
 
-	ret = dma_copy(hd->dma, hd->chan->index, copy_bytes, flags);
+	ret = dma_copy(hd->chan, copy_bytes, flags);
 	if (ret < 0)
 		trace_host_error("host_buffer_cb() error: dma_copy() failed, "
 				 "ret = %u", ret);
@@ -671,11 +671,11 @@ static int host_params(struct comp_dev *dev)
 		return -ENODEV;
 	}
 
-	err = dma_set_config(hd->dma, hd->chan->index, &hd->config);
+	err = dma_set_config(hd->chan, &hd->config);
 	if (err < 0) {
 		trace_host_error_with_ids(dev, "host_params() error: "
 					  "dma_set_config() failed");
-		dma_channel_put(hd->dma, hd->chan->index);
+		dma_channel_put(hd->chan);
 		hd->chan = NULL;
 		return err;
 	}
@@ -691,7 +691,7 @@ static int host_params(struct comp_dev *dev)
 	}
 
 	/* set up callback */
-	dma_set_cb(hd->dma, hd->chan->index, DMA_CB_TYPE_IRQ |
+	dma_set_cb(hd->chan, DMA_CB_TYPE_IRQ |
 		   DMA_CB_TYPE_COPY, host_dma_cb, dev);
 
 	return 0;
@@ -749,7 +749,7 @@ static int host_reset(struct comp_dev *dev)
 
 	trace_host_with_ids(dev, "host_reset()");
 
-	dma_channel_put(hd->dma, hd->chan->index);
+	dma_channel_put(hd->chan);
 
 	/* free all DMA elements */
 	dma_sg_free(&hd->host.elem_array);
@@ -784,7 +784,7 @@ static int host_copy(struct comp_dev *dev)
 	 */
 	if (dev->params.direction == SOF_IPC_STREAM_PLAYBACK &&
 	    !dev->position) {
-		ret = dma_copy(hd->dma, hd->chan->index, hd->dma_buffer->size,
+		ret = dma_copy(hd->chan, hd->dma_buffer->size,
 			       DMA_COPY_PRELOAD);
 		if (ret < 0) {
 			if (ret == -ENODATA) {

--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -184,7 +184,8 @@ static void dw_dma_increment_pointer(struct dw_dma_chan_data *chan, int bytes)
 }
 
 /* allocate next free DMA channel */
-static int dw_dma_channel_get(struct dma *dma, unsigned int req_chan)
+static struct dma_chan_data *dw_dma_channel_get(struct dma *dma,
+						unsigned int req_chan)
 {
 	uint32_t flags;
 	int i;
@@ -207,7 +208,7 @@ static int dw_dma_channel_get(struct dma *dma, unsigned int req_chan)
 
 		/* return channel */
 		spin_unlock_irq(dma->lock, flags);
-		return i;
+		return &dma->chan[i];
 	}
 
 	/* DMA controller has no free channels */
@@ -215,7 +216,7 @@ static int dw_dma_channel_get(struct dma *dma, unsigned int req_chan)
 	trace_dwdma_error("dw_dma_channel_get() error: dma %d "
 			  "no free channels", dma->plat_data.id);
 
-	return -ENODEV;
+	return NULL;
 }
 
 /* channel must not be running when this is called */

--- a/src/drivers/imx/dummy-dma.c
+++ b/src/drivers/imx/dummy-dma.c
@@ -15,42 +15,42 @@ static struct dma_chan_data *dummy_dma_channel_get(struct dma *dma,
 }
 
 /* channel must not be running when this is called */
-static void dummy_dma_channel_put(struct dma *dma, unsigned int channel)
+static void dummy_dma_channel_put(struct dma_chan_data *channel)
 {
 }
 
-static int dummy_dma_start(struct dma *dma, unsigned int channel)
-{
-	return 0;
-}
-
-
-static int dummy_dma_release(struct dma *dma, unsigned int channel)
+static int dummy_dma_start(struct dma_chan_data *channel)
 {
 	return 0;
 }
 
-static int dummy_dma_pause(struct dma *dma, unsigned int channel)
+
+static int dummy_dma_release(struct dma_chan_data *channel)
 {
 	return 0;
 }
 
-static int dummy_dma_stop(struct dma *dma, unsigned int channel)
+static int dummy_dma_pause(struct dma_chan_data *channel)
+{
+	return 0;
+}
+
+static int dummy_dma_stop(struct dma_chan_data *channel)
 {
 	return 0;
 }
 
 /* fill in "status" with current DMA channel state and position */
-static int dummy_dma_status(struct dma *dma, unsigned int channel,
-			 struct dma_chan_status *status,
-			 uint8_t direction)
+static int dummy_dma_status(struct dma_chan_data *channel,
+			    struct dma_chan_status *status,
+			    uint8_t direction)
 {
 	return 0;
 }
 
 /* set the DMA channel configuration, source/target address, buffer sizes */
-static int dummy_dma_set_config(struct dma *dma, unsigned int channel,
-			     struct dma_sg_config *config)
+static int dummy_dma_set_config(struct dma_chan_data *channel,
+				struct dma_sg_config *config)
 {
 	return 0;
 }
@@ -67,14 +67,14 @@ static int dummy_dma_pm_context_store(struct dma *dma)
 	return 0;
 }
 
-static int dummy_dma_set_cb(struct dma *dma, unsigned int channel, int type,
+static int dummy_dma_set_cb(struct dma_chan_data *channel, int type,
 		void (*cb)(void *data, uint32_t type, struct dma_cb_data *next),
 		void *data)
 {
 	return 0;
 }
 
-static int dummy_dma_copy(struct dma *dma, unsigned int channel, int bytes,
+static int dummy_dma_copy(struct dma_chan_data *channel, int bytes,
 			  uint32_t flags)
 {
 	return 0;
@@ -90,7 +90,7 @@ static int dummy_dma_remove(struct dma *dma)
 	return 0;
 }
 
-static int dummy_dma_get_data_size(struct dma *dma, unsigned int channel,
+static int dummy_dma_get_data_size(struct dma_chan_data *channel,
 				   uint32_t *avail, uint32_t *free)
 {
 	return 0;

--- a/src/drivers/imx/dummy-dma.c
+++ b/src/drivers/imx/dummy-dma.c
@@ -8,9 +8,10 @@
 #include <stdint.h>
 
 /* allocate next free DMA channel */
-static int dummy_dma_channel_get(struct dma *dma, unsigned int req_chan)
+static struct dma_chan_data *dummy_dma_channel_get(struct dma *dma,
+						   unsigned int req_chan)
 {
-	return 0;
+	return NULL;
 }
 
 /* channel must not be running when this is called */

--- a/src/drivers/imx/edma.c
+++ b/src/drivers/imx/edma.c
@@ -36,9 +36,10 @@ static inline void edma_update_bits(struct dma *dma, uint32_t reg,
 }
 
 /* acquire the specific DMA channel */
-static int edma_channel_get(struct dma *dma, unsigned int req_chan)
+static struct dma_chan_data *edma_channel_get(struct dma *dma,
+					      unsigned int req_chan)
 {
-	return 0;
+	return NULL;
 }
 
 /* channel must not be running when this is called */

--- a/src/drivers/imx/edma.c
+++ b/src/drivers/imx/edma.c
@@ -43,39 +43,39 @@ static struct dma_chan_data *edma_channel_get(struct dma *dma,
 }
 
 /* channel must not be running when this is called */
-static void edma_channel_put(struct dma *dma, unsigned int channel)
+static void edma_channel_put(struct dma_chan_data *channel)
 {
 }
 
-static int edma_start(struct dma *dma, unsigned int channel)
-{
-	return 0;
-}
-
-static int edma_release(struct dma *dma, unsigned int channel)
+static int edma_start(struct dma_chan_data *channel)
 {
 	return 0;
 }
 
-static int edma_pause(struct dma *dma, unsigned int channel)
+static int edma_release(struct dma_chan_data *channel)
 {
 	return 0;
 }
 
-static int edma_stop(struct dma *dma, unsigned int channel)
+static int edma_pause(struct dma_chan_data *channel)
 {
 	return 0;
 }
 
-static int edma_status(struct dma *dma, unsigned int channel,
+static int edma_stop(struct dma_chan_data *channel)
+{
+	return 0;
+}
+
+static int edma_status(struct dma_chan_data *channel,
 		       struct dma_chan_status *status, uint8_t direction)
 {
 	return 0;
 }
 
 /* set the DMA channel configuration, source/target address, buffer sizes */
-static int edma_set_config(struct dma *dma, unsigned int channel,
-			     struct dma_sg_config *config)
+static int edma_set_config(struct dma_chan_data *channel,
+			   struct dma_sg_config *config)
 {
 	return 0;
 }
@@ -93,7 +93,7 @@ static int edma_pm_context_store(struct dma *dma)
 	return 0;
 }
 
-static int edma_set_cb(struct dma *dma, unsigned int channel, int type,
+static int edma_set_cb(struct dma_chan_data *channel, int type,
 		void (*cb)(void *data, uint32_t type, struct dma_cb_data *next),
 		void *data)
 {

--- a/src/drivers/intel/cavs/hda-dma.c
+++ b/src/drivers/intel/cavs/hda-dma.c
@@ -434,14 +434,15 @@ static int hda_dma_host_copy(struct dma *dma, unsigned int channel, int bytes,
 }
 
 /* acquire the specific DMA channel */
-static int hda_dma_channel_get(struct dma *dma, unsigned int channel)
+static struct dma_chan_data *hda_dma_channel_get(struct dma *dma,
+						 unsigned int channel)
 {
 	uint32_t flags;
 
 	if (channel >= dma->plat_data.channels) {
 		trace_hddma_error("hda-dmac: %d invalid channel %d",
 				  dma->plat_data.id, channel);
-		return -EINVAL;
+		return NULL;
 	}
 
 	spin_lock_irq(dma->lock, flags);
@@ -457,14 +458,14 @@ static int hda_dma_channel_get(struct dma *dma, unsigned int channel)
 
 		/* return channel */
 		spin_unlock_irq(dma->lock, flags);
-		return channel;
+		return &dma->chan[channel];
 	}
 
 	/* DMAC has no free channels */
 	spin_unlock_irq(dma->lock, flags);
 	trace_hddma_error("hda-dmac: %d no free channel %d", dma->plat_data.id,
 			  channel);
-	return -ENODEV;
+	return NULL;
 }
 
 /* channel must not be running when this is called */

--- a/src/include/sof/lib/dma.h
+++ b/src/include/sof/lib/dma.h
@@ -187,6 +187,25 @@ struct dma {
 	int sref;		/**< simple ref counter, guarded by lock */
 	const struct dma_ops *ops;
 	atomic_t num_channels_busy; /* number of busy channels */
+	struct dma_chan_data *chan; /* channels array */
+	void *private;
+};
+
+struct dma_chan_data {
+	struct dma *dma;
+
+	uint32_t status;
+	uint32_t direction;
+	uint32_t desc_count;
+	uint32_t index;
+
+	/* client callback function */
+	void (*cb)(void *data, uint32_t type, struct dma_cb_data *next);
+	/* client callback data */
+	void *cb_data;
+	/* callback type */
+	int cb_type;
+
 	void *private;
 };
 
@@ -231,6 +250,10 @@ void dma_put(struct dma *dma);
 	dma->plat_data.chan_size
 #define dma_chan_base(dma, chan) \
 	(dma->plat_data.base + chan * dma->plat_data.chan_size)
+#define dma_chan_get_data(chan)	\
+	((chan)->private)
+#define dma_chan_set_data(chan, data) \
+	((chan)->private = data)
 
 /* DMA API
  * Programming flow is :-

--- a/src/include/sof/lib/dma.h
+++ b/src/include/sof/lib/dma.h
@@ -136,7 +136,8 @@ struct dma_chan_status {
 /* DMA operations */
 struct dma_ops {
 
-	int (*channel_get)(struct dma *dma, unsigned int req_channel);
+	struct dma_chan_data *(*channel_get)(struct dma *dma,
+					     unsigned int req_channel);
 	void (*channel_put)(struct dma *dma, unsigned int channel);
 
 	int (*start)(struct dma *dma, unsigned int channel);
@@ -267,7 +268,8 @@ void dma_put(struct dma *dma);
  * 6) dma_channel_put()
  */
 
-static inline int dma_channel_get(struct dma *dma, int req_channel)
+static inline struct dma_chan_data *dma_channel_get(struct dma *dma,
+						    int req_channel)
 {
 	return dma->ops->channel_get(dma, req_channel);
 }
@@ -404,7 +406,7 @@ static inline uint32_t dma_sg_get_size(struct dma_sg_elem_array *ea)
 /* generic DMA DSP <-> Host copier */
 
 struct dma_copy {
-	int chan;
+	struct dma_chan_data *chan;
 	struct dma *dmac;
 	completion_t complete;
 };
@@ -415,7 +417,7 @@ int dma_copy_new(struct dma_copy *dc);
 /* free dma copy context resources */
 static inline void dma_copy_free(struct dma_copy *dc)
 {
-	dma_channel_put(dc->dmac, dc->chan);
+	dma_channel_put(dc->dmac, dc->chan->index);
 }
 
 /* DMA copy data from host to DSP */

--- a/src/ipc/dma-copy.c
+++ b/src/ipc/dma-copy.c
@@ -78,7 +78,7 @@ int dma_copy_to_host_nowait(struct dma_copy *dc, struct dma_sg_config *host_sg,
 	int ret;
 
 	/* tell gateway to copy */
-	ret = dma_copy(dc->dmac, dc->chan->index, size, 0);
+	ret = dma_copy(dc->chan, size, 0);
 	if (ret < 0)
 		return ret;
 
@@ -125,11 +125,11 @@ int dma_copy_to_host_nowait(struct dma_copy *dc, struct dma_sg_config *host_sg,
 	config.elem_array.count = 1;
 
 	/* start the DMA */
-	err = dma_set_config(dc->dmac, dc->chan->index, &config);
+	err = dma_set_config(dc->chan, &config);
 	if (err < 0)
 		return err;
 
-	err = dma_start(dc->dmac, dc->chan->index);
+	err = dma_start(dc->chan);
 	if (err < 0)
 		return err;
 
@@ -162,8 +162,7 @@ int dma_copy_new(struct dma_copy *dc)
 	}
 
 	dc->complete.timeout = 100;	/* wait 100 usecs for DMA to finish */
-	dma_set_cb(dc->dmac, dc->chan->index, DMA_CB_TYPE_IRQ, dma_complete,
-		   &dc->complete);
+	dma_set_cb(dc->chan, DMA_CB_TYPE_IRQ, dma_complete, &dc->complete);
 #endif
 
 	return 0;

--- a/src/ipc/ipc-host-ptable.c
+++ b/src/ipc/ipc-host-ptable.c
@@ -122,7 +122,7 @@ static int ipc_get_page_descriptors(struct dma *dmac, uint8_t *page_table,
 	config.elem_array.elems = &elem;
 	config.elem_array.count = 1;
 
-	ret = dma_set_config(dmac, chan, &config);
+	ret = dma_set_config(chan, &config);
 	if (ret < 0) {
 		trace_ipc_error("ipc_get_page_descriptors() error: "
 				"dma_set_config() failed");
@@ -130,12 +130,12 @@ static int ipc_get_page_descriptors(struct dma *dmac, uint8_t *page_table,
 	}
 
 	/* set up callback */
-	dma_set_cb(dmac, chan->index, DMA_CB_TYPE_IRQ, dma_complete, &complete);
+	dma_set_cb(chan, DMA_CB_TYPE_IRQ, dma_complete, &complete);
 
 	wait_init(&complete);
 
 	/* start the copy of page table to DSP */
-	ret = dma_start(dmac, chan->index);
+	ret = dma_start(chan);
 	if (ret < 0) {
 		trace_ipc_error("ipc_get_page_descriptors() error: "
 				"dma_start() failed");
@@ -150,7 +150,7 @@ static int ipc_get_page_descriptors(struct dma *dmac, uint8_t *page_table,
 
 	/* compressed page tables now in buffer at _ipc->page_table */
 out:
-	dma_channel_put(dmac, chan->index);
+	dma_channel_put(chan);
 	return ret;
 }
 

--- a/src/platform/cannonlake/include/platform/lib/memory.h
+++ b/src/platform/cannonlake/include/platform/lib/memory.h
@@ -238,7 +238,7 @@
 #define SOF_TEXT_BASE		(SOF_FW_START)
 
 /* Heap section sizes for system runtime heap for master core */
-#define HEAP_SYS_RT_0_COUNT64		64
+#define HEAP_SYS_RT_0_COUNT64		128
 #define HEAP_SYS_RT_0_COUNT512		16
 #define HEAP_SYS_RT_0_COUNT1024		4
 

--- a/src/platform/icelake/include/platform/lib/memory.h
+++ b/src/platform/icelake/include/platform/lib/memory.h
@@ -231,7 +231,7 @@
 #define SOF_TEXT_BASE		(SOF_FW_START)
 
 /* Heap section sizes for system runtime heap for master core */
-#define HEAP_SYS_RT_0_COUNT64		64
+#define HEAP_SYS_RT_0_COUNT64		128
 #define HEAP_SYS_RT_0_COUNT512		16
 #define HEAP_SYS_RT_0_COUNT1024		4
 

--- a/src/trace/dma-trace.c
+++ b/src/trace/dma-trace.c
@@ -215,11 +215,11 @@ static int dma_trace_start(struct dma_trace_data *d)
 	if (err < 0)
 		return err;
 
-	err = dma_set_config(d->dc.dmac, d->dc.chan->index, &config);
+	err = dma_set_config(d->dc.chan, &config);
 	if (err < 0)
 		return err;
 
-	err = dma_start(d->dc.dmac, d->dc.chan->index);
+	err = dma_start(d->dc.chan);
 
 	return err;
 }

--- a/src/trace/dma-trace.c
+++ b/src/trace/dma-trace.c
@@ -215,11 +215,11 @@ static int dma_trace_start(struct dma_trace_data *d)
 	if (err < 0)
 		return err;
 
-	err = dma_set_config(d->dc.dmac, d->dc.chan, &config);
+	err = dma_set_config(d->dc.dmac, d->dc.chan->index, &config);
 	if (err < 0)
 		return err;
 
-	err = dma_start(d->dc.dmac, d->dc.chan);
+	err = dma_start(d->dc.dmac, d->dc.chan->index);
 
 	return err;
 }
@@ -296,7 +296,7 @@ int dma_trace_enable(struct dma_trace_data *d)
 #endif
 
 	/* validate DMA context */
-	if (d->dc.dmac == NULL || d->dc.chan < 0) {
+	if (!d->dc.dmac || !d->dc.chan) {
 		trace_buffer_error_atomic("dma_trace_enable() error: not "
 					  "valid");
 		return -ENODEV;


### PR DESCRIPTION
Extract common part of *_dma_chan_data into dma_chan_data structure with private pointer for class-specific data access, and expose it to the consumer for later use throughout lifecycle.
This is done in order to simplify API, as well as a preparation for future implementation of callbacks system for which it would be beneficial to have separate 'event caller' instances for each of the DMA channels for consumer to register to, as opposed to current, single DMA 'caller' exposed for registration.

Depends on fix: https://github.com/thesofproject/sof/pull/1751