### PR TITLE
ipc: Fix compile error

### DIFF
--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -1072,7 +1072,7 @@ static int ipc_glb_test_message(uint32_t header)
 void ipc_cmd(struct sof_ipc_cmd_hdr *hdr)
 {
 	struct sof_ipc_reply reply;
-	uint32_t type;
+	uint32_t type = 0;
 	int ret;
 
 	if (hdr == NULL) {


### PR DESCRIPTION
src/include/sof/trace/trace.h:309:32: error: 'type' may be used uninitialized in this function [-Werror=maybe-uninitialized]

src/ipc/handler.c:1075:11: note: 'type' was declared here
  uint32_t type;

This happens when hdr is NULL (even if it may never be at runtime the
compiler still complains) and verbose traces are enabled.

Signed-off-by: Paul Olaru <paul.olaru@nxp.com>

Additional comments: I uncovered this issue while rebasing my own working branch; somehow my config differed from default and lead to this error.

This variant of fixing it requires SEMVER minor ABI update. Another variant would be to just hardcode 0 as an initial value.