### PR TITLE
Zephyr: Fix audio distortions

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -64,7 +64,6 @@ zephyr_library_sources(
 	../src/math/trig.c
 	# SOF src/drivers
 	../src/drivers/dw/dma.c
-	../src/drivers/intel/cavs/dmic.c
 	../src/drivers/intel/cavs/hda.c
 	../src/drivers/intel/cavs/hda-dma.c
 	../src/drivers/intel/cavs/ssp.c
@@ -105,6 +104,9 @@ zephyr_library_sources_ifdef(CONFIG_SOF_COMP_IIR
 zephyr_library_sources_ifdef(CONFIG_SOF_COMP_SEL
 	../src/audio/selector/selector_generic.c
 	../src/audio/selector/selector.c)
+zephyr_library_sources_ifdef(CONFIG_SOF_USE_DMIC
+	../src/drivers/intel/cavs/dmic.c
+	)
 
 zephyr_library_link_libraries(SOF)
 target_link_libraries(SOF INTERFACE zephyr_interface)

--- a/zephyr/alloc.c
+++ b/zephyr/alloc.c
@@ -12,34 +12,110 @@
 #include <stdio.h>
 #include <sof/alloc.h>
 #include <kernel.h>
+#include <sys/util.h>
 
-/* testbench mem alloc definition */
+/* Describe one mem_slab */
+struct memslab_map {
+	uint16_t block_size;    /* size of block in bytes */
+	uint16_t count;         /* number of blocks */
+	uint32_t size;          /* size of buffer */
+	struct k_mem_slab slab;
+	void* buffer;           /* pointer to buffer */
+} __aligned(PLATFORM_DCACHE_ALIGN);
 
-void *rmalloc(int zone, uint32_t caps, size_t bytes)
+#define MEMSLAB_DEF(sz, cnt, buf) \
+	{ .block_size = sz, .count = cnt, .buffer = buf, \
+	  .size = (sz * cnt), \
+	}
+
+#define BUF_ALIGN	__aligned(WB_UP(PLATFORM_DCACHE_ALIGN))
+
+
+/*
+ * RZONE_BUFFER for DMA
+ */
+static struct k_mem_slab hp_dma_buffer;
+static struct memslab_map hp_dma_buffer_map =
+	MEMSLAB_DEF(HEAP_HP_BUFFER_BLOCK_SIZE, HEAP_HP_BUFFER_COUNT,
+		    (void *)HEAP_HP_BUFFER_BASE);
+
+/*
+ * RZONE_BUFFER for non-DMA
+ *
+ * TODO: figure out a good block size.
+ */
+#define _HEAP_BUFFER_BLOCK_SIZE		1024
+#define _HEAP_BUFFER_COUNT		32
+#define _HEAP_BUFFER_SIZE \
+	(_HEAP_BUFFER_COUNT * _HEAP_BUFFER_BLOCK_SIZE)
+
+static struct k_mem_slab heap_buffer;
+static BUF_ALIGN uint8_t _heap_buf[_HEAP_BUFFER_SIZE];
+static struct memslab_map heap_buffer_map =
+	MEMSLAB_DEF(_HEAP_BUFFER_BLOCK_SIZE,
+		    _HEAP_BUFFER_COUNT,
+		    _heap_buf);
+
+
+void malloc_init(void)
+{
+	/* Initialize RZONE_BUFFER */
+	k_mem_slab_init(&hp_dma_buffer, (void *)HEAP_HP_BUFFER_BASE,
+			HEAP_HP_BUFFER_BLOCK_SIZE, HEAP_HP_BUFFER_COUNT);
+
+	k_mem_slab_init(&heap_buffer, _heap_buf,
+			_HEAP_BUFFER_BLOCK_SIZE, _HEAP_BUFFER_COUNT);
+}
+
+
+void *rmalloc(uint32_t zone, uint32_t caps, size_t bytes)
 {
 	return k_malloc(bytes);
 }
 
-void *rzalloc(int zone, uint32_t caps, size_t bytes)
+void *rzalloc(uint32_t zone, uint32_t caps, size_t bytes)
 {
 	return k_calloc(bytes, 1);
 }
 
+void *rballoc(uint32_t zone, uint32_t caps, size_t bytes)
+{
+	void *ptr = NULL;
+
+	if (caps & SOF_MEM_CAPS_DMA) {
+		k_mem_slab_alloc(&heap_buffer, &ptr, K_NO_WAIT);
+	} else {
+		k_mem_slab_alloc(&hp_dma_buffer, &ptr, K_NO_WAIT);
+	}
+
+	return ptr;
+}
+
+static bool free_in_slab(struct memslab_map *map, void *ptr)
+{
+	uintptr_t begin = (uintptr_t)map->buffer;
+	uintptr_t end = begin + map->size;
+	uintptr_t addr = (uintptr_t)ptr;
+
+	if ((addr >= begin) && (addr < end)) {
+		k_mem_slab_free(&map->slab, &ptr);
+		return true;
+	}
+
+	return false;
+}
+
 void rfree(void *ptr)
 {
+	/* RZONE_BUFFER */
+	if (free_in_slab(&hp_dma_buffer_map, ptr)) {
+		return;
+	}
+
+	if (free_in_slab(&heap_buffer_map, ptr)) {
+		return;
+	}
+
+	/* Not in mem_slab, so assume k_mem_pool */
 	k_free(ptr);
-}
-
-void *rballoc(int zone, uint32_t caps, size_t bytes)
-{
-	return k_malloc(bytes);
-}
-
-void heap_trace(struct mm_heap *heap, int size)
-{
-}
-
-void heap_trace_all(int force)
-{
-	heap_trace(NULL, 0);
 }

--- a/zephyr/include/sof/alloc.h
+++ b/zephyr/include/sof/alloc.h
@@ -1,0 +1,74 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2016 Intel Corporation. All rights reserved.
+ *
+ * Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
+ *         Keyon Jie <yang.jie@linux.intel.com>
+ */
+
+#ifndef __INCLUDE_ALLOC__
+#define __INCLUDE_ALLOC__
+
+#include <stdlib.h>
+#include <sof/string.h>
+#include <stdint.h>
+#include <sof/bit.h>
+#include <sof/platform.h>
+#include <platform/platform.h>
+#include <arch/spinlock.h>
+#include <ipc/topology.h>
+struct sof;
+
+/* Heap Memory Zones
+ *
+ * The heap has three different zones from where memory can be allocated :-
+ *
+ * 1) System Zone. Fixed size heap where alloc always succeeds and is never
+ * freed. Used by any init code that will never give up the memory.
+ *
+ * 2) Runtime Zone. Main and larger heap zone where allocs are not guaranteed to
+ * succeed. Memory can be freed here.
+ *
+ * 3) Buffer Zone. Largest heap zone intended for audio buffers.
+ *
+ * 4) System Runtime Zone. Heap zone intended for runtime objects allocated
+ * by the kernel part of the code.
+ *
+ * See platform/memory.h for heap size configuration and mappings.
+ */
+
+/* heap zone types */
+#define RZONE_SYS		BIT(0)
+#define RZONE_RUNTIME		BIT(1)
+#define RZONE_BUFFER		BIT(2)
+#define RZONE_SYS_RUNTIME	BIT(3)
+
+/* heap zone flags */
+#define RZONE_FLAG_UNCACHED	BIT(4)
+
+#define RZONE_TYPE_MASK	0xf
+#define RZONE_FLAG_MASK	0xf0
+
+/* heap allocation and free */
+void *rmalloc(uint32_t zone, uint32_t caps, size_t bytes);
+void *rzalloc(uint32_t zone, uint32_t caps, size_t bytes);
+void *rballoc(uint32_t zone, uint32_t caps, size_t bytes);
+void rfree(void *ptr);
+
+/* system heap allocation for specific core */
+void *rzalloc_core_sys(int core, size_t bytes);
+
+/* utility */
+#define bzero(ptr, size) \
+	arch_bzero(ptr, size)
+
+int rstrlen(const char *s);
+int rstrcmp(const char *s1, const char *s2);
+
+/* status */
+static inline void heap_trace_all(int force) {};
+static inline void heap_trace(void *heap, int size) {};
+
+void malloc_init(void);
+
+#endif


### PR DESCRIPTION
Zephyr's k_mem_pool may not allocate memory aligned to cache lines and/or DMA transfers. So use mem_slab instead for buffers so each buffer is aligned correctly for DMA transfers and cache line manipulations.