### PR TITLE
topology: align sof-icl-rt700 and sof-cml-rt700

### DIFF
--- a/tools/topology/sof-cml-rt700.m4
+++ b/tools/topology/sof-cml-rt700.m4
@@ -26,6 +26,7 @@ DEBUG_START
 # PCM1 <--- volume <---- ALH 3 BE dailink 1
 # PCM2 <---------------- DMIC01 (dmic0 capture, BE dailink 2)
 # PCM3 <---------------- DMIC16k (dmic16k, BE dailink 3)
+#
 
 dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,
@@ -38,10 +39,10 @@ PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
-# Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s32le.
+# Low Latency capture pipeline 2 on PCM 1 using max 2 channels of s32le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
-	2, 0, 2, s32le,
+	2, 1, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 

--- a/tools/topology/sof-icl-rt700.m4
+++ b/tools/topology/sof-icl-rt700.m4
@@ -6,7 +6,6 @@
 include(`utils.m4')
 include(`dai.m4')
 include(`pipeline.m4')
-#include(`alh.m4')
 
 # Include TLV library
 include(`common/tlv.m4')
@@ -97,7 +96,6 @@ DAI_ADD(sof/pipe-dai-capture.m4,
 	4, DMIC, 1, dmic16k,
 	PIPELINE_SINK_4, 2, s16le,
 	16, 1000, 0, 0)
-
 
 # PCM Low Latency, id 0
 dnl PCM_PLAYBACK_ADD(name, pcm_id, playback)


### PR DESCRIPTION
No need to have any whitespace or extra comments

CML had one issue with the PCM capture, now using PCM1 as for ICL

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>