### PR TITLE
ll_scheduler: add check for newly calculated timeout

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -48,6 +48,7 @@ src/ipc/*				@xiulipan @bardliao
 src/ipc/sue-ipc.c			@lyakh
 src/lib/*				@libinyang
 src/gdb/*				@mrajwa
+src/schedule				@tlauda @mrajwa
 
 # other helpers
 test/**					@jajanusz

--- a/src/arch/host/include/arch/drivers/timer.h
+++ b/src/arch/host/include/arch/drivers/timer.h
@@ -21,8 +21,8 @@ static inline void arch_timer_unregister(struct timer *timer) {}
 static inline void arch_timer_enable(struct timer *timer) {}
 static inline void arch_timer_disable(struct timer *timer) {}
 static inline uint32_t arch_timer_get_system(struct timer *timer) {return 0; }
-static inline int arch_timer_set(struct timer *timer,
-	uint64_t ticks) {return 0; }
+static inline int64_t arch_timer_set(struct timer *timer,
+				     uint64_t ticks) {return 0; }
 static inline void arch_timer_clear(struct timer *timer) {}
 
 #endif /* __ARCH_DRIVERS_TIMER_H__ */

--- a/src/arch/xtensa/drivers/timer.c
+++ b/src/arch/xtensa/drivers/timer.c
@@ -103,7 +103,7 @@ uint64_t arch_timer_get_system(struct timer *timer)
 	return time;
 }
 
-int arch_timer_set(struct timer *timer, uint64_t ticks)
+int64_t arch_timer_set(struct timer *timer, uint64_t ticks)
 {
 	uint32_t time = 1;
 	uint32_t hitimeout = ticks >> 32;

--- a/src/arch/xtensa/include/arch/drivers/timer.h
+++ b/src/arch/xtensa/include/arch/drivers/timer.h
@@ -63,7 +63,7 @@ static inline void arch_timer_disable(struct timer *timer)
 
 uint64_t arch_timer_get_system(struct timer *timer);
 
-int arch_timer_set(struct timer *timer, uint64_t ticks);
+int64_t arch_timer_set(struct timer *timer, uint64_t ticks);
 
 static inline void arch_timer_clear(struct timer *timer)
 {

--- a/src/drivers/imx/timer.c
+++ b/src/drivers/imx/timer.c
@@ -22,7 +22,7 @@ void platform_timer_stop(struct timer *timer)
 	arch_timer_disable(timer);
 }
 
-int platform_timer_set(struct timer *timer, uint64_t ticks)
+int64_t platform_timer_set(struct timer *timer, uint64_t ticks)
 {
 	return arch_timer_set(timer, ticks);
 }

--- a/src/drivers/intel/baytrail/timer.c
+++ b/src/drivers/intel/baytrail/timer.c
@@ -75,7 +75,7 @@ void platform_timer_stop(struct timer *timer)
 	shim_write(SHIM_EXT_TIMER_CNTLH, SHIM_EXT_TIMER_CLEAR);
 }
 
-int platform_timer_set(struct timer *timer, uint64_t ticks)
+int64_t platform_timer_set(struct timer *timer, uint64_t ticks)
 {
 	uint32_t time = 1;
 	uint32_t hitimeout = ticks >> 32;

--- a/src/drivers/intel/haswell/timer.c
+++ b/src/drivers/intel/haswell/timer.c
@@ -23,7 +23,7 @@ void platform_timer_stop(struct timer *timer)
 	arch_timer_disable(timer);
 }
 
-int platform_timer_set(struct timer *timer, uint64_t ticks)
+int64_t platform_timer_set(struct timer *timer, uint64_t ticks)
 {
 	return arch_timer_set(timer, ticks);
 }

--- a/src/include/sof/drivers/timer.h
+++ b/src/include/sof/drivers/timer.h
@@ -25,7 +25,7 @@ void timer_unregister(struct timer *timer, void *arg);
 void timer_enable(struct timer *timer, void *arg, int core);
 void timer_disable(struct timer *timer, void *arg, int core);
 
-static inline int timer_set(struct timer *timer, uint64_t ticks)
+static inline int64_t timer_set(struct timer *timer, uint64_t ticks)
 {
 	return arch_timer_set(timer, ticks);
 }
@@ -46,7 +46,7 @@ static inline uint64_t timer_get_system(struct timer *timer)
 	return arch_timer_get_system(timer);
 }
 
-int platform_timer_set(struct timer *timer, uint64_t ticks);
+int64_t platform_timer_set(struct timer *timer, uint64_t ticks);
 void platform_timer_clear(struct timer *timer);
 uint64_t platform_timer_get(struct timer *timer);
 void platform_timer_start(struct timer *timer);


### PR DESCRIPTION
This patch checks if newly created timeout is not a
past time. Such issue will lead to dead scheduler.


NOTE! This will cause slight delay in tasks start time (only when previous tasks took more than scheduled period). I keep investigating what potential consequences it can cause, as for now it looks pretty safe.

Signed-off-by: Marcin Rajwa <marcin.rajwa@linux.intel.com>