### PR TITLE
platform: imx: Enable IRQ_STEER driver

### DIFF
--- a/src/drivers/imx/interrupt.c
+++ b/src/drivers/imx/interrupt.c
@@ -241,7 +241,7 @@ static inline void handle_irq_batch(struct irq_cascade_desc *cascade,
 	while (status) {
 		bit = get_first_irq(status);
 		handled = false;
-		status &= ~(1 << bit); /* Release interrupt */
+		status &= ~(1ull << bit); /* Release interrupt */
 
 		spin_lock(cascade->lock);
 

--- a/src/platform/imx8/platform.c
+++ b/src/platform/imx8/platform.c
@@ -156,6 +156,8 @@ int platform_init(struct sof *sof)
 
 	clock_set_freq(CLK_CPU(cpu_get_id()), CLK_MAX_CPU_HZ);
 
+	platform_interrupt_init();
+
 	/* init DMA */
 	ret = edma_init();
 	if (ret < 0)


### PR DESCRIPTION
In #1747 I forgot to actually call the platform_interrupt_init() function 
where I register the IRQ_STEER controller. This patch fixes that and activates
the IRQ_STEER controller.

(also, this passed the smoke test, namely I am in fact getting correctly numbered interrupts from the WIP code on the ESAI and EDMA drivers)

Signed-off-by: Paul Olaru <paul.olaru@nxp.com>