### PR TITLE
drivers: interrupts: Fix invalid trace_error call

### DIFF
--- a/src/drivers/interrupt.c
+++ b/src/drivers/interrupt.c
@@ -96,7 +96,8 @@ int interrupt_get_irq(unsigned int irq, const char *name)
 	/* If a name is specified, irq must be <= PLATFORM_IRQ_CHILDREN */
 	if (irq >= PLATFORM_IRQ_CHILDREN) {
 		trace_error(TRACE_CLASS_IRQ,
-			    "error: IRQ %d invalid as a child interrupt!");
+			    "error: IRQ %d invalid as a child interrupt!",
+			    irq);
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
This error showed up while I was testing the IRQ_STEER call as printing
a weird value instead of a normal IRQ number (and I had an inconsistent
tree that lead to this error condition).

Signed-off-by: Paul Olaru <paul.olaru@nxp.com>