### PR TITLE
topology: Update CML topologies

### DIFF
--- a/tools/topology/CMakeLists.txt
+++ b/tools/topology/CMakeLists.txt
@@ -75,6 +75,7 @@ set(TPLGS
 	"sof-cnl-nocodec\;sof-cnl-nocodec"
 	"sof-cml-rt5682-max98357a\;sof-cml-rt5682-max98357a\;-DPLATFORM=cml"
 	"sof-cml-demux-rt5682-max98357a\;sof-cml-demux-rt5682-max98357a\;-DPLATFORM=cml"
+	"sof-cml-rt1011-rt5682\;sof-cml-rt1011-rt5682\;-DPLATFORM=cml"
 	"sof-tgl-nocodec\;sof-tgl-nocodec"
 	"sof-tgl-rt1308\;sof-tgl-rt1308"
 	"sof-tgl-rt1308-nohdmi\;sof-tgl-rt1308-nohdmi"

--- a/tools/topology/get_abi.sh
+++ b/tools/topology/get_abi.sh
@@ -5,6 +5,20 @@
 MAJOR=`grep '#define SOF_ABI_MAJOR ' $1/src/include/kernel/abi.h | grep -E ".[[:digit:]]$" -o`
 MINOR=`grep '#define SOF_ABI_MINOR ' $1/src/include/kernel/abi.h | grep -E ".[[:digit:]]$" -o`
 PATCH=`grep '#define SOF_ABI_PATCH ' $1/src/include/kernel/abi.h | grep -E ".[[:digit:]]$" -o`
+MAJOR_SHIFT=`grep '#define SOF_ABI_MAJOR_SHIFT'\
+	$1/src/include/kernel/abi.h | grep -E ".[[:digit:]]$" -o`
+MINOR_SHIFT=`grep '#define SOF_ABI_MINOR_SHIFT'\
+	$1/src/include/kernel/abi.h | grep -E ".[[:digit:]]$" -o`
+
+major_val=$(($MAJOR << $MAJOR_SHIFT))
+minor_val=$(($MINOR << $MINOR_SHIFT))
+abi_version_3_8=$((3<<$MAJOR_SHIFT | 8<<$MINOR_SHIFT))
+abi_version=$(($major_val | $minor_val))
+abi_version_3_9_or_greater=$(($abi_version > $abi_version_3_8))
+
 printf "define(\`SOF_ABI_MAJOR', \`0x%02x')\n" $MAJOR > abi.h
 printf "define(\`SOF_ABI_MINOR', \`0x%02x')\n" $MINOR >> abi.h
 printf "define(\`SOF_ABI_PATCH', \`0x%02x')\n" $PATCH >> abi.h
+printf "define(\`SOF_ABI_VERSION', \`0x%x')\n" $abi_version >> abi.h
+printf "define(\`SOF_ABI_VERSION_3_9_OR_GRT', \`%d')\n"\
+	$abi_version_3_9_or_greater >> abi.h

--- a/tools/topology/sof-cml-demux-rt5682-max98357a.m4
+++ b/tools/topology/sof-cml-demux-rt5682-max98357a.m4
@@ -21,10 +21,17 @@ dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 8 on PCM 6 using max 2 channels of s32le.
 # Schedule 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_ADD(sof/pipe-src-volume-playback.m4,
-	8, 6, 2, s32le,
-	1000, 0, 0,
-	48000, 48000, 48000)
+# pipe-src pipeline is needed for older SSP config
+
+ifelse(SOF_ABI_VERSION_3_9_OR_GRT, `1',
+`PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+        7, 5, 2, s32le,
+        1000, 0, 0,
+        48000, 48000, 48000)',
+`PIPELINE_PCM_ADD(sof/pipe-src-volume-playback.m4,
+        7, 5, 2, s32le,
+        1000, 0, 0,
+        48000, 48000, 48000)')
 
 #
 # Speaker DAIs configuration
@@ -37,10 +44,17 @@ dnl     deadline, priority, core)
 
 # playback DAI is SSP1 using 2 periods
 # Buffers use s16le format, with 48 frame per 1000us on core 0 with priority 0
-DAI_ADD(sof/pipe-dai-playback.m4,
-	8, SSP, 1, SSP1-Codec,
-	PIPELINE_SOURCE_8, 2, s16le,
-	1000, 0, 0)
+#With m/n divider available we can support 24 bit playback
+
+ifelse(SOF_ABI_VERSION_3_9_OR_GRT, `1',
+`DAI_ADD(sof/pipe-dai-playback.m4,
+        7, SSP, 1, SSP1-Codec,
+        PIPELINE_SOURCE_7, 2, s24le,
+        1000, 0, 0)',
+`DAI_ADD(sof/pipe-dai-playback.m4,
+        7, SSP, 1, SSP1-Codec,
+        PIPELINE_SOURCE_7, 2, s16le,
+        1000, 0, 0)')
 
 # PCM Low Latency, id 0
 dnl PCM_PLAYBACK_ADD(name, pcm_id, playback)
@@ -51,9 +65,18 @@ PCM_PLAYBACK_ADD(Speakers, 6, PIPELINE_PCM_8)
 #
 
 #SSP 1 (ID: 6)
-DAI_CONFIG(SSP, 1, 6, SSP1-Codec,
-	SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24000000, codec_mclk_in),
-		SSP_CLOCK(bclk, 1500000, codec_slave),
-		SSP_CLOCK(fsync, 46875, codec_slave),
-		SSP_TDM(2, 16, 3, 3),
-		SSP_CONFIG_DATA(SSP, 1, 16)))
+# Use BCLK derived using m/n divider only on later versions
+
+ifelse(SOF_ABI_VERSION_3_9_OR_GRT, `1',
+`DAI_CONFIG(SSP, 1, 6, SSP1-Codec,
+        SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24000000, codec_mclk_in),
+                SSP_CLOCK(bclk, 2304000, codec_slave),
+                SSP_CLOCK(fsync, 48000, codec_slave),
+                SSP_TDM(2, 24, 3, 3),
+                SSP_CONFIG_DATA(SSP, 1, 24)))',
+`DAI_CONFIG(SSP, 1, 6, SSP1-Codec,
+        SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24000000, codec_mclk_in),
+                SSP_CLOCK(bclk, 1500000, codec_slave),
+                SSP_CLOCK(fsync, 46875, codec_slave),
+                SSP_TDM(2, 16, 3, 3),
+                SSP_CONFIG_DATA(SSP, 1, 16)))')

--- a/tools/topology/sof-cml-rt1011-rt5682.m4
+++ b/tools/topology/sof-cml-rt1011-rt5682.m4
@@ -1,0 +1,68 @@
+#
+# Topology for Cometlake with rt1011 spk on SSP1
+#
+
+# Include SOF CML RT5682 Topology
+# This includes topology for RT5682, DMIC and 3 HDMI Pass through pipeline
+include(`sof-cml-rt5682-kwd.m4')
+include(`abi.h')
+DEBUG_START
+#
+# Define the Speaker pipeline
+#
+# PCM5  ----> volume (pipe 7) ----> SSP1 (speaker - rt1011, BE link 5)
+#
+
+dnl PIPELINE_PCM_ADD(pipeline,
+dnl     pipe id, pcm, max channels, format,
+dnl     frames, deadline, priority, core)
+
+# Low Latency playback pipeline 7 on PCM 5 using max 2 channels of s32le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	7, 5, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+#
+# Speaker DAIs configuration
+#
+
+dnl DAI_ADD(pipeline,
+dnl     pipe id, dai type, dai_index, dai_be,
+dnl     buffer, periods, format,
+dnl     frames, deadline, priority, core)
+
+# playback DAI is SSP1 using 2 periods
+# Buffers use s16le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+	7, SSP, 1, SSP1-Codec,
+	PIPELINE_SOURCE_7, 2, s24le,
+	48, 1000, 0, 0)
+
+# PCM Low Latency, id 0
+dnl PCM_PLAYBACK_ADD(name, pcm_id, playback)
+PCM_PLAYBACK_ADD(Speakers, 5, PIPELINE_PCM_7)
+
+#
+# BE configurations for Speakers - overrides config in ACPI if present
+#
+
+#SSP 1 (ID: 6)
+#Use BCLK delay in SSP_CONFIG_DATA only on supporting version
+
+ifelse(SOF_ABI_VERSION_3_9_OR_GRT, `1',
+`DAI_CONFIG(SSP, 1, 6, SSP1-Codec,
+	SSP_CONFIG(DSP_A, SSP_CLOCK(mclk, 24000000, codec_mclk_in),
+		SSP_CLOCK(bclk, 4800000, codec_slave),
+		SSP_CLOCK(fsync, 48000, codec_slave),
+		SSP_TDM(4, 25, 3, 15),
+		SSP_CONFIG_DATA(SSP, 1, 24, 0, 0, 10)))',
+`DAI_CONFIG(SSP, 1, 6, SSP1-Codec,
+        SSP_CONFIG(DSP_A, SSP_CLOCK(mclk, 24000000, codec_mclk_in),
+                SSP_CLOCK(bclk, 4800000, codec_slave),
+                SSP_CLOCK(fsync, 48000, codec_slave),
+                SSP_TDM(4, 25, 3, 15),
+                SSP_CONFIG_DATA(SSP, 1, 24)))')
+
+DEBUG_END

--- a/tools/topology/sof-cml-rt5682-max98357a.m4
+++ b/tools/topology/sof-cml-rt5682-max98357a.m4
@@ -7,6 +7,7 @@
 # Include SOF CML RT5682 Topology
 # This includes topology for RT5682, DMIC and 3 HDMI Pass through pipeline
 include(`sof-cml-rt5682-kwd.m4')
+include(`abi.h')
 
 DEBUG_START
 #
@@ -23,10 +24,17 @@ dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 7 on PCM 5 using max 2 channels of s32le.
 # Set 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_ADD(sof/pipe-src-volume-playback.m4,
+# pipe-src pipeline is needed for older SSP config
+
+ifelse(SOF_ABI_VERSION_3_9_OR_GRT, `1',
+`PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	7, 5, 2, s32le,
 	1000, 0, 0,
-	48000, 48000, 48000)
+	48000, 48000, 48000)',
+`PIPELINE_PCM_ADD(sof/pipe-src-volume-playback.m4,
+        7, 5, 2, s32le,
+        1000, 0, 0,
+        48000, 48000, 48000)')
 
 #
 # Speaker DAIs configuration
@@ -39,10 +47,17 @@ dnl     deadline, priority, core)
 
 # playback DAI is SSP1 using 2 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
-DAI_ADD(sof/pipe-dai-playback.m4,
+#With m/n divider available we can support 24 bit playback
+
+ifelse(SOF_ABI_VERSION_3_9_OR_GRT, `1',
+`DAI_ADD(sof/pipe-dai-playback.m4,
 	7, SSP, 1, SSP1-Codec,
-	PIPELINE_SOURCE_7, 2, s16le,
-	1000, 0, 0)
+	PIPELINE_SOURCE_7, 2, s24le,
+	1000, 0, 0)',
+`DAI_ADD(sof/pipe-dai-playback.m4,
+        7, SSP, 1, SSP1-Codec,
+        PIPELINE_SOURCE_7, 2, s16le,
+        1000, 0, 0)')
 
 # PCM Low Latency, id 0
 dnl PCM_PLAYBACK_ADD(name, pcm_id, playback)
@@ -53,11 +68,20 @@ PCM_PLAYBACK_ADD(Speakers, 5, PIPELINE_PCM_7)
 #
 
 #SSP 1 (ID: 6)
-DAI_CONFIG(SSP, 1, 6, SSP1-Codec,
+# Use BCLK derived using m/n divider only on later versions
+
+ifelse(SOF_ABI_VERSION_3_9_OR_GRT, `1',
+`DAI_CONFIG(SSP, 1, 6, SSP1-Codec,
 	SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24000000, codec_mclk_in),
-		SSP_CLOCK(bclk, 1500000, codec_slave),
-		SSP_CLOCK(fsync, 46875, codec_slave),
-		SSP_TDM(2, 16, 3, 3),
-		SSP_CONFIG_DATA(SSP, 1, 16)))
+		SSP_CLOCK(bclk, 2304000, codec_slave),
+		SSP_CLOCK(fsync, 48000, codec_slave),
+		SSP_TDM(2, 24, 3, 3),
+		SSP_CONFIG_DATA(SSP, 1, 24)))',
+`DAI_CONFIG(SSP, 1, 6, SSP1-Codec,
+        SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24000000, codec_mclk_in),
+                SSP_CLOCK(bclk, 1500000, codec_slave),
+                SSP_CLOCK(fsync, 46875, codec_slave),
+                SSP_TDM(2, 16, 3, 3),
+                SSP_CONFIG_DATA(SSP, 1, 16)))')
 
 DEBUG_END


### PR DESCRIPTION
With m/n divider support, we can now support 24 bit/ 48k
on max98357a.

Signed-off-by: Sathya Prakash M R <sathya.prakash.m.r@intel.com>