### PR TITLE
drivers: imx: interrupt: Add convenience interrupt number translation

### DIFF
--- a/src/platform/imx8/include/platform/drivers/interrupt.h
+++ b/src/platform/imx8/include/platform/drivers/interrupt.h
@@ -44,6 +44,19 @@
 #define PLATFORM_IRQ_HW_NUM	XCHAL_NUM_INTERRUPTS
 #define PLATFORM_IRQ_CHILDREN	64
 
+/* irqstr_get_sof_int() - Convert IRQ_STEER interrupt to SOF logical
+ * interrupt
+ * @irqstr_int Shared IRQ_STEER interrupt
+ *
+ * Get the SOF interrupt number for a shared IRQ_STEER interrupt number.
+ * The IRQ_STEER number is the one specified in the hardware description
+ * manuals, while the SOF interrupt number is the one usable with the
+ * interrupt_register and interrupt_enable functions.
+ *
+ * Return: SOF interrupt number
+ */
+int irqstr_get_sof_int(int irqstr_int);
+
 #endif /* __PLATFORM_DRIVERS_INTERRUPT_H__ */
 
 #else


### PR DESCRIPTION
The interrupt numbers needed by the IRQ_STEER driver and those needed by
SOF's interrupt_* functions differ. While for this particular platform
it is known that there is a simple offset of 32, I implement this more
complex function to ensure that the interrupt numbers remain valid even
if somehow another cascaded interrupt controller is added.

This function is needed because the pure interrupt_get_irq() function
cannot properly treat the whole controller as only one, since it
receives interrupts over 8 hardware lines. This function determines
which hardware line is used then calls interrupt_get_irq() with the
correct controller name.

Signed-off-by: Paul Olaru <paul.olaru@nxp.com>

Additional comments: I intend to use this in the EDMA and ESAI drivers, although other IMX drivers that use IRQ_STEER should similarly use this. Only hardware interrupts can be passed directly to SOF.

Example usage:
```
int irq = irqstr_get_sof_int(EDMA_IRQ);
if (irq < 0)
        return -EINVAL;
int rc = interrupt_register(irq, IRQ_AUTO_UNMASK, &edma_irq, arg);
...
interrupt_enable(irq, arg);
```
