### PR TITLE
scripts: allocate tty on docker

### DIFF
--- a/scripts/docker-run.sh
+++ b/scripts/docker-run.sh
@@ -8,5 +8,5 @@
 #  To build topology:
 #  ./scripts/docker-run.sh ./scripts/build-tools.sh
 
-docker run -i -v `pwd`:/home/sof/work/sof.git \
+docker run -i -t -v `pwd`:/home/sof/work/sof.git \
 	   --user `id -u` sof $@


### PR DESCRIPTION
Bash and menuconfig cannot run without this flag. Docker-run just hangs
without it

Signed-off-by: Curtis Malainey <cujomalainey@google.com>