### PR TITLE
[SDW release] Refine FW and topology to make 16/24 bit pipeline work

### DIFF
--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -676,6 +676,7 @@ static int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn)
 
 static int dai_config(struct comp_dev *dev, struct sof_ipc_dai_config *config)
 {
+	struct sof_ipc_comp_config *dconfig = COMP_GET_CONFIG(dev);
 	struct dai_data *dd = comp_get_drvdata(dev);
 	int channel = 0;
 	int i;
@@ -773,6 +774,12 @@ static int dai_config(struct comp_dev *dev, struct sof_ipc_dai_config *config)
 		 * it is recalculated in dai_params() later
 		 */
 		dd->frame_bytes = 4;
+
+		/* SDW HW FIFO requires 32bit MSB aligned sample data for
+		 * all formats, such as 8/16/24/32 bits. Now set frame_fmt
+		 * to S32_LE to let volume component do the conversion.
+		 */
+		dconfig->frame_fmt = SOF_IPC_FRAME_S32_LE;
 
 		/* As with HDA, the DMA channel is assigned in runtime,
 		 * not during topology parsing.

--- a/tools/topology/sof-cml-rt700.m4
+++ b/tools/topology/sof-cml-rt700.m4
@@ -35,14 +35,14 @@ dnl     frames, deadline, priority, core)
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
-	1, 0, 2, s32le,
+	1, 0, 2, s24le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 2 on PCM 1 using max 2 channels of s32le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
-	2, 1, 2, s32le,
+	2, 1, 2, s24le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
@@ -73,14 +73,14 @@ dnl     frames, deadline, priority, core)
 # Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, ALH, 0x102, SDW1-Playback,
-	PIPELINE_SOURCE_1, 2, s32le,
+	PIPELINE_SOURCE_1, 2, s24le,
 	1000, 0, 0)
 
 # capture DAI is ALH(SDW1 PIN3) using 2 periods
 # Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	2, ALH, 0x103, SDW1-Capture,
-	PIPELINE_SINK_2, 2, s32le,
+	PIPELINE_SINK_2, 2, s24le,
 	1000, 0, 0)
 
 # capture DAI is DMIC01 using 2 periods

--- a/tools/topology/sof-icl-rt700.m4
+++ b/tools/topology/sof-icl-rt700.m4
@@ -35,14 +35,14 @@ dnl     frames, deadline, priority, core)
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
-	1, 0, 2, s32le,
+	1, 0, 2, s24le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 2 on PCM 1 using max 2 channels of s32le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
-	2, 1, 2, s32le,
+	2, 1, 2, s24le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
@@ -73,14 +73,14 @@ dnl     frames, deadline, priority, core)
 # Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, ALH, 2, SDW0-Playback,
-	PIPELINE_SOURCE_1, 2, s32le,
+	PIPELINE_SOURCE_1, 2, s24le,
 	1000, 0, 0)
 
 # capture DAI is ALH(SDW0 PIN2) using 2 periods
 # Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	2, ALH, 3, SDW0-Capture,
-	PIPELINE_SINK_2, 2, s32le,
+	PIPELINE_SINK_2, 2, s24le,
 	1000, 0, 0)
 
 # capture DAI is DMIC01 using 2 periods


### PR DESCRIPTION
Now the sdw HW FIFO only accept 32bit sample, so force
dai format to 32bit to let volume component do the
conversion.