### PR TITLE
sof-ctl: fix segfault when no ctl name given

### DIFF
--- a/tools/ctl/ctl.c
+++ b/tools/ctl/ctl.c
@@ -544,7 +544,7 @@ int main(int argc, char *argv[])
 	if (!ctl_data->cname) {
 		fprintf(stderr, "Error: No control was requested.\n");
 		usage(argv[0]);
-		goto data_free;
+		goto struct_free;
 
 	}
 


### PR DESCRIPTION
If no control name is passed to sof-ctl, it currently pops an error,
dumps the usage and then segfaults:

root@gr-mrb:~# sof-ctl -D hw:0
Error: No control was requested.
Usage:   ...
Segmentation fault (core dumped)

Fix all that by jumping to the right label.

Signed-off-by: Dragos Tarcatu <dragos_tarcatu@mentor.com>