### PR TITLE
ssp: pm: reset M/N and check CPA

### DIFF
--- a/src/drivers/intel/cavs/ssp.c
+++ b/src/drivers/intel/cavs/ssp.c
@@ -924,6 +924,10 @@ static int ssp_probe(struct dai *dai)
 	ssp->state[DAI_DIR_PLAYBACK] = COMP_STATE_READY;
 	ssp->state[DAI_DIR_CAPTURE] = COMP_STATE_READY;
 
+	/* Reset M/N, power-gating functions need it */
+	mn_reg_write(0x100 + dai->index * 0x8 + 0x0, 1);
+	mn_reg_write(0x100 + dai->index * 0x8 + 0x4, 1);
+
 	/* Enable SSP power */
 	pm_runtime_get_sync(SSP_POW, dai->index);
 

--- a/src/platform/intel/cavs/lib/pm_runtime.c
+++ b/src/platform/intel/cavs/lib/pm_runtime.c
@@ -95,28 +95,36 @@ static inline void cavs_pm_runtime_en_ssp_clk_gating(uint32_t index)
 static inline void cavs_pm_runtime_en_ssp_power(uint32_t index)
 {
 #if CONFIG_TIGERLAKE
+	uint32_t reg;
+
 	trace_power("en_ssp_power index %d", index);
 
 	io_reg_write(I2SLCTL, io_reg_read(I2SLCTL) | I2SLCTL_SPA(index));
 
-	/* TODO: Check if powered on.
-	 * Should read CPA, but it's not getting set right after SPA is written,
-	 * need to check if there are other HW dependencies.
-	 */
+	/* Check if powered on. */
+	do {
+		reg = io_reg_read(I2SLCTL);
+	} while (!(reg & I2SLCTL_CPA(index)));
+
+	trace_power("en_ssp_power I2SLCTL %08x", reg);
 #endif
 }
 
 static inline void cavs_pm_runtime_dis_ssp_power(uint32_t index)
 {
 #if CONFIG_TIGERLAKE
+	uint32_t reg;
+
 	trace_power("dis_ssp_power index %d", index);
 
 	io_reg_write(I2SLCTL, io_reg_read(I2SLCTL) & (~I2SLCTL_SPA(index)));
 
-	/* TODO: Check if powered off.
-	 * Should read CPA, but it's not getting set right after SPA is written,
-	 * need to check if there are other HW dependencies.
-	 */
+	/* Check if powered off. */
+	do {
+		reg = io_reg_read(I2SLCTL);
+	} while (reg & I2SLCTL_CPA(index));
+
+	trace_power("dis_ssp_power I2SLCTL %08x", reg);
 #endif
 }
 #endif


### PR DESCRIPTION
Some shim registers need M/N to not be 0/0 (state after dsp reset) in order to work.