### PR TITLE
topology: soundwire: cleanup -rt700 files and add support for RTK 3-in-1 board

### DIFF
--- a/tools/kmod_scripts/sof_insert.sh
+++ b/tools/kmod_scripts/sof_insert.sh
@@ -33,6 +33,9 @@ insert_module snd_soc_max98357a
 insert_module snd_soc_max98090
 
 insert_module snd_soc_rt700
+insert_module snd_soc_rt711
+insert_module snd_soc_rt1308_sdw
+insert_module snd_soc_rt715
 
 insert_module sof_acpi_dev
 insert_module sof_pci_dev

--- a/tools/kmod_scripts/sof_remove.sh
+++ b/tools/kmod_scripts/sof_remove.sh
@@ -44,7 +44,8 @@ remove_module snd_soc_sst_cht_bsw_rt5645
 remove_module snd_soc_sst_cht_bsw_rt5672
 remove_module snd_soc_sst_glk_rt5682_max98357a
 remove_module snd_soc_skl_hda_dsp
-remove_module snd_soc_cnl_rt700
+remove_module snd_soc_sdw_rt700
+remove_module snd_soc_sdw_rt711_rt1308_rt715
 
 remove_module snd_sof
 remove_module snd_sof_nocodec
@@ -58,6 +59,9 @@ remove_module snd_soc_rt274
 remove_module snd_soc_rt286
 remove_module snd_soc_rt298
 remove_module snd_soc_rt700
+remove_module snd_soc_rt711
+remove_module snd_soc_rt1308_sdw
+remove_module snd_soc_rt715
 remove_module snd_soc_rt5640
 remove_module snd_soc_rt5645
 remove_module snd_soc_rt5651

--- a/tools/topology/CMakeLists.txt
+++ b/tools/topology/CMakeLists.txt
@@ -62,6 +62,7 @@ set(TPLGS
 	"sof-icl-dmic-4ch\;sof-icl-dmic-4ch"
 	"sof-icl-rt700\;sof-icl-rt700\;-DPLATFORM=icl"
 	"sof-cml-rt700\;sof-cml-rt700\;-DPLATFORM=cml"
+	"sof-icl-rt711-rt1308-rt715\;sof-icl-rt711-rt1308-rt715\;-DPLATFORM=icl"
 	"sof-apl-src-pcm512x\;sof-apl-src-pcm512x"
 	"sof-cml-rt5682\;sof-cml-rt5682\;-DPLATFORM=cml"
 	"sof-cml-rt5682\;sof-whl-rt5682\;-DPLATFORM=whl"

--- a/tools/topology/sof-cml-rt700.m4
+++ b/tools/topology/sof-cml-rt700.m4
@@ -30,7 +30,9 @@ DEBUG_START
 
 dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,
-dnl     frames, deadline, priority, core)
+dnl     period, priority, core,
+dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
+dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
@@ -67,7 +69,7 @@ PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
 dnl DAI_ADD(pipeline,
 dnl     pipe id, dai type, dai_index, dai_be,
 dnl     buffer, periods, format,
-dnl     frames, deadline, priority, core)
+dnl     deadline, priority, core, time_domain)
 
 # playback DAI is ALH(SDW1 PIN2) using 2 periods
 # Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0

--- a/tools/topology/sof-icl-rt700.m4
+++ b/tools/topology/sof-icl-rt700.m4
@@ -30,7 +30,9 @@ DEBUG_START
 
 dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,
-dnl     frames, deadline, priority, core)
+dnl     period, priority, core,
+dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
+dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
@@ -67,7 +69,7 @@ PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
 dnl DAI_ADD(pipeline,
 dnl     pipe id, dai type, dai_index, dai_be,
 dnl     buffer, periods, format,
-dnl     frames, deadline, priority, core)
+dnl     deadline, priority, core, time_domain)
 
 # playback DAI is ALH(SDW0 PIN2) using 2 periods
 # Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0

--- a/tools/topology/sof-icl-rt711-rt1308-rt715.m4
+++ b/tools/topology/sof-icl-rt711-rt1308-rt715.m4
@@ -1,0 +1,144 @@
+#
+# Topology for Icelake with rt711 + rt1308 (x2) + rt715.
+#
+
+# Include topology builder
+include(`utils.m4')
+include(`dai.m4')
+include(`pipeline.m4')
+
+# Include TLV library
+include(`common/tlv.m4')
+
+# Include Token library
+include(`sof/tokens.m4')
+
+# Include ICL DSP configuration
+include(`platform/intel/icl.m4')
+
+DEBUG_START
+
+#
+# Define the pipelines
+#
+# PCM0 ---> volume ----> ALH 2 BE dailink 0
+# PCM1 <--- volume <---- ALH 3 BE dailink 1
+# PCM2 ---> volume ----> ALH 2 BE dailink 2
+# PCM3 ---> volume ----> ALH 2 BE dailink 3
+# PCM4 <--- volume <---- ALH 2 BE dailink 4
+
+dnl PIPELINE_PCM_ADD(pipeline,
+dnl     pipe id, pcm, max channels, format,
+dnl     period, priority, core,
+dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
+dnl     time_domain, sched_comp)
+
+# Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	1, 0, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency capture pipeline 2 on PCM 1 using max 2 channels of s32le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
+	2, 1, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency playback pipeline 3 on PCM 2 using max 2 channels of s32le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	3, 2, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency playback pipeline 4 on PCM 3 using max 2 channels of s32le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	4, 3, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency capture pipeline 5 on PCM 4 using max 2 channels of s32le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
+	5, 4, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+#
+# DAIs configuration
+#
+
+dnl DAI_ADD(pipeline,
+dnl     pipe id, dai type, dai_index, dai_be,
+dnl     buffer, periods, format,
+dnl     deadline, priority, core, time_domain)
+
+# playback DAI is ALH(SDW0 PIN2) using 2 periods
+# Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+	1, ALH, 2, SDW0-Playback,
+	PIPELINE_SOURCE_1, 2, s32le,
+	1000, 0, 0)
+
+# capture DAI is ALH(SDW0 PIN2) using 2 periods
+# Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-capture.m4,
+	2, ALH, 3, SDW0-Capture,
+	PIPELINE_SINK_2, 2, s32le,
+	1000, 0, 0)
+
+# playback DAI is ALH(SDW1 PIN2) using 2 periods
+# Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+	3, ALH, 0x102, SDW1-Playback,
+	PIPELINE_SOURCE_3, 2, s32le,
+	1000, 0, 0)
+
+# playback DAI is ALH(SDW2 PIN2) using 2 periods
+# Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+	4, ALH, 0x202, SDW2-Playback,
+	PIPELINE_SOURCE_4, 2, s32le,
+	1000, 0, 0)
+
+# capture DAI is ALH(SDW3 PIN2) using 2 periods
+# Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-capture.m4,
+	5, ALH, 0x302, SDW3-Capture,
+	PIPELINE_SINK_5, 2, s32le,
+	1000, 0, 0)
+
+
+# PCM Low Latency, id 0
+dnl PCM_PLAYBACK_ADD(name, pcm_id, playback)
+PCM_PLAYBACK_ADD(SDW0-speakers, 0, PIPELINE_PCM_1)
+PCM_CAPTURE_ADD(SDW0-mics, 1, PIPELINE_PCM_2)
+PCM_PLAYBACK_ADD(SDW1-speakers, 2, PIPELINE_PCM_3)
+PCM_PLAYBACK_ADD(SDW2-speakers, 3, PIPELINE_PCM_4)
+PCM_CAPTURE_ADD(SDW3-mics, 4, PIPELINE_PCM_5)
+
+#
+# BE configurations - overrides config in ACPI if present
+#
+
+#ALH dai index = ((link_id << 8) | PDI id)
+#ALH SDW0 Pin2 (ID: 0)
+DAI_CONFIG(ALH, 2, 0, SDW0-Playback)
+
+#ALH SDW0 Pin3 (ID: 1)
+DAI_CONFIG(ALH, 3, 1, SDW0-Capture)
+
+#ALH SDW1 Pin2 (ID: 2)
+DAI_CONFIG(ALH, 0x102, 2, SDW1-Playback)
+
+#ALH SDW2 Pin2 (ID: 3)
+DAI_CONFIG(ALH, 0x202, 3, SDW2-Playback)
+
+#ALH SDW3 Pin2 (ID: 4)
+DAI_CONFIG(ALH, 0x302, 4, SDW3-Capture)
+
+DEBUG_END


### PR DESCRIPTION
These patches could also be applied to @slawblauciak 's https://github.com/thesofproject/sof/pull/1638

with the latest kernel branch for SoundWire playback and capture seem to be functional with the 3-in-1 board (except for the timeout issue in MSI mode).