### PR TITLE
ipc: return valid error in ipc_dma_trace_config

### DIFF
--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -736,7 +736,7 @@ static int ipc_dma_trace_config(uint32_t header)
 	return 0;
 
 error:
-	return -EINVAL;
+	return err;
 }
 
 /* send DMA trace host buffer position to host */

--- a/src/ipc/ipc-host-ptable.c
+++ b/src/ipc/ipc-host-ptable.c
@@ -187,5 +187,5 @@ int ipc_process_host_buffer(struct ipc *ipc,
 	return 0;
 error:
 	dma_sg_free(elem_array);
-	return -EINVAL;
+	return err;
 }


### PR DESCRIPTION
Fixes the bug, where any error in ipc_dma_trace_config handling
was always returned as -EINVAL.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>