### PR TITLE
Tools: EQ: Don't force upper case EQ response name

### DIFF
--- a/tools/tune/eq/eq_tplg_write.m
+++ b/tools/tune/eq/eq_tplg_write.m
@@ -44,7 +44,7 @@ blob8_new(1:n_orig) = blob8;
 fh = fopen(fn, 'w');
 nl = 8;
 fprintf(fh, '# %s %s\n', comment, date());
-fprintf(fh, 'CONTROLBYTES_PRIV(EQ%s_priv,\n', upper(eqtype));
+fprintf(fh, 'CONTROLBYTES_PRIV(EQ%s_priv,\n', eqtype);
 fprintf(fh, '`       bytes "');
 for i = 1:nl:n_new
 	if i > 1


### PR DESCRIPTION
The existing IIR response names are not all upper case. This patch
removes the conversion to upper case to be able to automatically
generate the topology m4 syntax example equalizers.

Without this patch run of example_iir_eq.m script causes successive
topologies build to fail.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>