### PR TITLE
pipeline: don't disable IRQ on prepare() and params()

### DIFF
--- a/src/audio/pipeline.c
+++ b/src/audio/pipeline.c
@@ -336,22 +336,17 @@ int pipeline_params(struct pipeline *p, struct comp_dev *host,
 {
 	struct pipeline_data data;
 	int ret;
-	uint32_t flags;
 
 	trace_pipe_with_ids(p, "pipeline_params()");
 
 	data.params = params;
 	data.start = host;
 
-	irq_local_disable(flags);
-
 	ret = pipeline_comp_params(host, &data, host->params.direction);
 	if (ret < 0) {
 		trace_pipe_error("pipeline_params() error: ret = %d, host->"
 				 "comp.id = %u", ret, host->comp.id);
 	}
-
-	irq_local_enable(flags);
 
 	return ret;
 }

--- a/src/audio/pipeline.c
+++ b/src/audio/pipeline.c
@@ -395,19 +395,16 @@ int pipeline_prepare(struct pipeline *p, struct comp_dev *dev)
 {
 	struct pipeline_data ppl_data;
 	int ret = 0;
-	uint32_t flags;
 
 	trace_pipe_with_ids(p, "pipeline_prepare()");
 
 	ppl_data.start = dev;
 
-	irq_local_disable(flags);
-
 	ret = pipeline_comp_prepare(dev, &ppl_data, dev->params.direction);
 	if (ret < 0) {
 		trace_pipe_error("pipeline_prepare() error: ret = %d,"
 				 "dev->comp.id = %u", ret, dev->comp.id);
-		goto out;
+		return ret;
 	}
 
 	/* pipeline preload needed only for playback streams without active
@@ -417,8 +414,6 @@ int pipeline_prepare(struct pipeline *p, struct comp_dev *dev)
 		p->sink_comp->state != COMP_STATE_ACTIVE;
 	p->status = COMP_STATE_PREPARE;
 
-out:
-	irq_local_enable(flags);
 	return ret;
 }
 


### PR DESCRIPTION
This patch removes the IRQ disable during
pipeline_params() and pipeline_prepare() as there
is no potential race condition. Also, The disable of IRQs
result in long delays in queued interrupts.

Signed-off-by: Marcin Rajwa <marcin.rajwa@linux.intel.com>