### PR TITLE
kpb: add missing flag to task init

### DIFF
--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -404,7 +404,7 @@ static int kpb_prepare(struct comp_dev *dev)
 			   kpb_draining_task, /* task function */
 			   &kpb->draining_task_data, /* task private data */
 			   0, /* core on which we should run */
-			   0);
+			   SOF_SCHEDULE_FLAG_IDLE);
 
 	/* Search for KPB related sinks.
 	 * NOTE! We assume here that channel selector component device


### PR DESCRIPTION
Adds missing flag during draining task initialization.
It's needed at the moment, so the EDF scheduler can ignore
deadline for this task. Scheduling flags will be soon
refactored.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>