### PR TITLE
schedule: introduce ll_schedule_domain

### DIFF
--- a/src/arch/xtensa/include/arch/drivers/timer.h
+++ b/src/arch/xtensa/include/arch/drivers/timer.h
@@ -20,7 +20,6 @@ struct timer {
 	int irq;
 	int logical_irq;	/* used for external timers */
 	const char *irq_name;
-	unsigned int core;
 	void *timer_data;	/* used by core */
 	uint32_t hitime;	/* high end of 64bit timer */
 	uint32_t hitimeout;

--- a/src/arch/xtensa/include/arch/drivers/timer.h
+++ b/src/arch/xtensa/include/arch/drivers/timer.h
@@ -15,18 +15,13 @@
 
 #define ARCH_TIMER_COUNT	3
 
-struct timer_irq {
-	int logical_irq;
-	void *irq_arg;
-};
-
 struct timer {
 	uint32_t id;
 	int irq;
+	int logical_irq;	/* used for external timers */
 	const char *irq_name;
 	unsigned int core;
 	void *timer_data;	/* used by core */
-	struct timer_irq *tirq;	/* dynamic non-cacheable IRQ data */
 	uint32_t hitime;	/* high end of 64bit timer */
 	uint32_t hitimeout;
 	uint32_t lowtimeout;

--- a/src/arch/xtensa/init.c
+++ b/src/arch/xtensa/init.c
@@ -96,6 +96,7 @@ int arch_init(struct sof *sof)
 #include <sof/drivers/idc.h>
 #include <sof/drivers/interrupt.h>
 #include <sof/lib/notifier.h>
+#include <sof/platform.h>
 #include <sof/schedule/edf_schedule.h>
 #include <sof/schedule/ll_schedule.h>
 #include <sof/schedule/schedule.h>
@@ -123,7 +124,7 @@ int slave_core_init(struct sof *sof)
 
 	trace_point(TRACE_BOOT_PLATFORM_SCHED);
 	scheduler_init_edf(sof);
-	scheduler_init_ll();
+	scheduler_init_ll(platform_timer_domain);
 
 	/* initialize IDC mechanism */
 	trace_point(TRACE_BOOT_PLATFORM_IDC);

--- a/src/drivers/imx/timer.c
+++ b/src/drivers/imx/timer.c
@@ -74,35 +74,26 @@ void platform_dai_wallclock(struct comp_dev *dai, uint64_t *wallclock)
 
 int timer_register(struct timer *timer, void(*handler)(void *arg), void *arg)
 {
-	struct timer_irq *tirq = timer->tirq;
-
 	switch (timer->id) {
 	case TIMER0:
 	case TIMER1:
-		tirq->irq_arg = arg;
 		return arch_timer_register(timer, handler, arg);
 	default:
 		return -EINVAL;
 	}
 }
 
-void timer_unregister(struct timer *timer)
+void timer_unregister(struct timer *timer, void *arg)
 {
-	struct timer_irq *tirq = timer->tirq;
-
-	interrupt_unregister(timer->irq, tirq->irq_arg);
+	interrupt_unregister(timer->irq, arg);
 }
 
-void timer_enable(struct timer *timer)
+void timer_enable(struct timer *timer, void *arg, int core)
 {
-	struct timer_irq *tirq = timer->tirq;
-
-	interrupt_enable(timer->irq, tirq->irq_arg);
+	interrupt_enable(timer->irq, arg);
 }
 
-void timer_disable(struct timer *timer)
+void timer_disable(struct timer *timer, void *arg, int core)
 {
-	struct timer_irq *tirq = timer->tirq;
-
-	interrupt_disable(timer->irq, tirq->irq_arg);
+	interrupt_disable(timer->irq, arg);
 }

--- a/src/drivers/intel/baytrail/timer.c
+++ b/src/drivers/intel/baytrail/timer.c
@@ -200,12 +200,8 @@ static int platform_timer_register(struct timer *timer,
 	return ret;
 }
 
-int timer_register(struct timer *timer, void(*handler)(void *arg), void *arg)
+int timer_register(struct timer *timer, void (*handler)(void *arg), void *arg)
 {
-	struct timer_irq *tirq = timer->tirq;
-
-	tirq->irq_arg = arg;
-
 	switch (timer->id) {
 	case TIMER0:
 	case TIMER1:
@@ -218,23 +214,17 @@ int timer_register(struct timer *timer, void(*handler)(void *arg), void *arg)
 	}
 }
 
-void timer_unregister(struct timer *timer)
+void timer_unregister(struct timer *timer, void *arg)
 {
-	struct timer_irq *tirq = timer->tirq;
-
-	interrupt_unregister(timer->irq, tirq->irq_arg);
+	interrupt_unregister(timer->irq, arg);
 }
 
-void timer_enable(struct timer *timer)
+void timer_enable(struct timer *timer, void *arg, int core)
 {
-	struct timer_irq *tirq = timer->tirq;
-
-	interrupt_enable(timer->irq, tirq->irq_arg);
+	interrupt_enable(timer->irq, arg);
 }
 
-void timer_disable(struct timer *timer)
+void timer_disable(struct timer *timer, void *arg, int core)
 {
-	struct timer_irq *tirq = timer->tirq;
-
-	interrupt_disable(timer->irq, tirq->irq_arg);
+	interrupt_disable(timer->irq, arg);
 }

--- a/src/drivers/intel/haswell/timer.c
+++ b/src/drivers/intel/haswell/timer.c
@@ -74,12 +74,8 @@ void platform_dai_wallclock(struct comp_dev *dai, uint64_t *wallclock)
 	*wallclock = timer_get_system(platform_timer);
 }
 
-int timer_register(struct timer *timer, void(*handler)(void *arg), void *arg)
+int timer_register(struct timer *timer, void (*handler)(void *arg), void *arg)
 {
-	struct timer_irq *tirq = timer->tirq;
-
-	tirq->irq_arg = arg;
-
 	switch (timer->id) {
 	case TIMER0:
 	case TIMER1:
@@ -90,23 +86,17 @@ int timer_register(struct timer *timer, void(*handler)(void *arg), void *arg)
 	}
 }
 
-void timer_unregister(struct timer *timer)
+void timer_unregister(struct timer *timer, void *arg)
 {
-	struct timer_irq *tirq = timer->tirq;
-
-	interrupt_unregister(timer->irq, tirq->irq_arg);
+	interrupt_unregister(timer->irq, arg);
 }
 
-void timer_enable(struct timer *timer)
+void timer_enable(struct timer *timer, void *arg, int core)
 {
-	struct timer_irq *tirq = timer->tirq;
-
-	interrupt_enable(timer->irq, tirq->irq_arg);
+	interrupt_enable(timer->irq, arg);
 }
 
-void timer_disable(struct timer *timer)
+void timer_disable(struct timer *timer, void *arg, int core)
 {
-	struct timer_irq *tirq = timer->tirq;
-
-	interrupt_disable(timer->irq, tirq->irq_arg);
+	interrupt_disable(timer->irq, arg);
 }

--- a/src/include/sof/drivers/timer.h
+++ b/src/include/sof/drivers/timer.h
@@ -20,17 +20,6 @@ struct sof_ipc_stream_posn;
 #define TIMER3	3
 #define TIMER4	4
 
-struct timesource_data {
-	struct timer timer;
-	int clk;
-	int notifier;
-	int (*timer_set)(struct timer *t, uint64_t ticks);
-	void (*timer_clear)(struct timer *t);
-	uint64_t (*timer_get)(struct timer *t);
-};
-
-extern struct timesource_data platform_generic_queue[];
-
 int timer_register(struct timer *timer, void (*handler)(void *arg), void *arg);
 void timer_unregister(struct timer *timer, void *arg);
 void timer_enable(struct timer *timer, void *arg, int core);

--- a/src/include/sof/drivers/timer.h
+++ b/src/include/sof/drivers/timer.h
@@ -31,11 +31,10 @@ struct timesource_data {
 
 extern struct timesource_data platform_generic_queue[];
 
-int timer_register(struct timer *timer,
-	void (*handler)(void *arg), void *arg);
-void timer_unregister(struct timer *timer);
-void timer_enable(struct timer *timer);
-void timer_disable(struct timer *timer);
+int timer_register(struct timer *timer, void (*handler)(void *arg), void *arg);
+void timer_unregister(struct timer *timer, void *arg);
+void timer_enable(struct timer *timer, void *arg, int core);
+void timer_disable(struct timer *timer, void *arg, int core);
 
 static inline int timer_set(struct timer *timer, uint64_t ticks)
 {

--- a/src/include/sof/lib/notifier.h
+++ b/src/include/sof/lib/notifier.h
@@ -44,6 +44,9 @@ struct notifier {
 	void (*cb)(int message, void *cb_data, void *event_data);
 };
 
+#define NOTIFIER_CLK_CHANGE_ID(clk) \
+	((clk) == CLK_SSP ? NOTIFIER_ID_SSP_FREQ : NOTIFIER_ID_CPU_FREQ)
+
 struct notify **arch_notify_get(void);
 
 void notifier_register(struct notifier *notifier);

--- a/src/include/sof/schedule/ll_schedule.h
+++ b/src/include/sof/schedule/ll_schedule.h
@@ -18,6 +18,8 @@
 #include <user/trace.h>
 #include <stdint.h>
 
+struct ll_schedule_domain;
+
 /* ll tracing */
 #define trace_ll(format, ...) \
 	trace_event(TRACE_CLASS_SCHEDULE_LL, format, ##__VA_ARGS__)
@@ -37,6 +39,6 @@ struct ll_task_pdata {
 	uint64_t period;
 };
 
-int scheduler_init_ll(void);
+int scheduler_init_ll(struct ll_schedule_domain *domain);
 
 #endif /* __SOF_SCHEDULE_LL_SCHEDULE_H__ */

--- a/src/include/sof/schedule/ll_schedule_domain.h
+++ b/src/include/sof/schedule/ll_schedule_domain.h
@@ -1,0 +1,125 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2019 Intel Corporation. All rights reserved.
+ *
+ * Author: Tomasz Lauda <tomasz.lauda@linux.intel.com>
+ */
+
+#ifndef __SOF_SCHEDULE_LL_SCHEDULE_DOMAIN_H__
+#define __SOF_SCHEDULE_LL_SCHEDULE_DOMAIN_H__
+
+#include <sof/atomic.h>
+#include <sof/debug/panic.h>
+#include <sof/lib/alloc.h>
+#include <sof/lib/cpu.h>
+#include <sof/lib/clk.h>
+#include <sof/spinlock.h>
+#include <sof/trace/trace.h>
+#include <ipc/topology.h>
+#include <user/trace.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+struct ll_schedule_domain;
+struct task;
+
+struct ll_schedule_domain_ops {
+	int (*domain_register)(struct ll_schedule_domain *domain,
+			       uint64_t period, struct task *task,
+			       void (*handler)(void *arg), void *arg);
+	void (*domain_unregister)(struct ll_schedule_domain *domain,
+				  uint32_t num_tasks);
+	void (*domain_enable)(struct ll_schedule_domain *domain, int core);
+	void (*domain_disable)(struct ll_schedule_domain *domain, int core);
+	void (*domain_set)(struct ll_schedule_domain *domain, uint64_t start);
+	void (*domain_clear)(struct ll_schedule_domain *domain);
+	bool (*domain_is_pending)(struct ll_schedule_domain *domain,
+				  struct task *task);
+};
+
+struct ll_schedule_domain {
+	uint64_t last_tick;
+	spinlock_t *lock;
+	atomic_t total_num_tasks;
+	atomic_t num_clients;
+	bool registered[PLATFORM_CORE_COUNT];
+	uint32_t ticks_per_ms;
+	int type;
+	int clk;
+	const struct ll_schedule_domain_ops *ops;
+	void *private;
+};
+
+#define ll_sch_domain_set_pdata(domain, data) ((domain)->private = (data))
+
+#define ll_sch_domain_get_pdata(domain) ((domain)->private)
+
+static inline struct ll_schedule_domain *domain_init(int type, int clk,
+				const struct ll_schedule_domain_ops *ops)
+{
+	struct ll_schedule_domain *domain;
+
+	domain = rzalloc(RZONE_SYS | RZONE_FLAG_UNCACHED, SOF_MEM_CAPS_RAM,
+			 sizeof(*domain));
+	domain->type = type;
+	domain->clk = clk;
+	domain->ticks_per_ms = clock_ms_to_ticks(clk, 1);
+	domain->ops = ops;
+
+	spinlock_init(&domain->lock);
+	atomic_init(&domain->total_num_tasks, 0);
+	atomic_init(&domain->num_clients, 0);
+
+	return domain;
+}
+
+static inline int domain_register(struct ll_schedule_domain *domain,
+				  uint64_t period, struct task *task,
+				  void (*handler)(void *arg), void *arg)
+{
+	assert(domain->ops->domain_register);
+
+	return domain->ops->domain_register(domain, period, task, handler, arg);
+}
+
+static inline void domain_unregister(struct ll_schedule_domain *domain,
+				     uint32_t num_tasks)
+{
+	assert(domain->ops->domain_unregister);
+
+	domain->ops->domain_unregister(domain, num_tasks);
+}
+
+static inline void domain_enable(struct ll_schedule_domain *domain, int core)
+{
+	if (domain->ops->domain_enable)
+		domain->ops->domain_enable(domain, core);
+}
+
+static inline void domain_disable(struct ll_schedule_domain *domain, int core)
+{
+	if (domain->ops->domain_disable)
+		domain->ops->domain_disable(domain, core);
+}
+
+static inline void domain_set(struct ll_schedule_domain *domain, uint64_t start)
+{
+	if (domain->ops->domain_set)
+		domain->ops->domain_set(domain, start);
+}
+
+static inline void domain_clear(struct ll_schedule_domain *domain)
+{
+	if (domain->ops->domain_clear)
+		domain->ops->domain_clear(domain);
+}
+
+static inline bool domain_is_pending(struct ll_schedule_domain *domain,
+				     struct task *task)
+{
+	assert(domain->ops->domain_is_pending);
+
+	return domain->ops->domain_is_pending(domain, task);
+}
+
+#endif /* __SOF_SCHEDULE_LL_SCHEDULE_DOMAIN_H__ */

--- a/src/include/sof/schedule/ll_schedule_domain.h
+++ b/src/include/sof/schedule/ll_schedule_domain.h
@@ -22,6 +22,7 @@
 
 struct ll_schedule_domain;
 struct task;
+struct timer;
 
 struct ll_schedule_domain_ops {
 	int (*domain_register)(struct ll_schedule_domain *domain,
@@ -121,5 +122,8 @@ static inline bool domain_is_pending(struct ll_schedule_domain *domain,
 
 	return domain->ops->domain_is_pending(domain, task);
 }
+
+struct ll_schedule_domain *timer_domain_init(struct timer *timer, int clk,
+					     uint64_t timeout);
 
 #endif /* __SOF_SCHEDULE_LL_SCHEDULE_DOMAIN_H__ */

--- a/src/lib/agent.c
+++ b/src/lib/agent.c
@@ -73,7 +73,7 @@ void sa_init(struct sof *sof)
 	sof->sa = sa;
 
 	/* set default tick timeout */
-	sa->ticks = clock_ms_to_ticks(PLATFORM_WORKQ_CLOCK, 1) *
+	sa->ticks = clock_ms_to_ticks(PLATFORM_DEFAULT_CLOCK, 1) *
 		PLATFORM_IDLE_TIME / 1000;
 
 	trace_sa("sa_init(), sa->ticks = %u", sa->ticks);

--- a/src/platform/apollolake/include/platform/platform.h
+++ b/src/platform/apollolake/include/platform/platform.h
@@ -75,12 +75,6 @@ struct timer;
 /* DMA host transfer timeouts in microseconds */
 #define PLATFORM_HOST_DMA_TIMEOUT	200
 
-/* DMA link transfer timeouts in microseconds
- * TODO: timeout should be reduced
- * (DMA might needs some further changes to do that)
- */
-#define PLATFORM_LINK_DMA_TIMEOUT	1000
-
 /* WorkQ window size in microseconds */
 #define PLATFORM_WORKQ_WINDOW	2000
 

--- a/src/platform/apollolake/include/platform/platform.h
+++ b/src/platform/apollolake/include/platform/platform.h
@@ -75,9 +75,6 @@ struct timer;
 /* DMA host transfer timeouts in microseconds */
 #define PLATFORM_HOST_DMA_TIMEOUT	200
 
-/* WorkQ window size in microseconds */
-#define PLATFORM_WORKQ_WINDOW	2000
-
 /* platform WorkQ clock */
 #define PLATFORM_WORKQ_CLOCK	PLATFORM_DEFAULT_CLOCK
 

--- a/src/platform/apollolake/include/platform/platform.h
+++ b/src/platform/apollolake/include/platform/platform.h
@@ -24,6 +24,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+struct ll_schedule_domain;
 struct timer;
 
 /*! \def PLATFORM_DEFAULT_CLOCK
@@ -147,6 +148,8 @@ static inline void platform_panic(uint32_t p)
 	mailbox_sw_reg_write(SRAM_REG_FW_TRACEP, (__x))
 
 extern struct timer *platform_timer;
+
+extern struct ll_schedule_domain *platform_timer_domain;
 
 extern intptr_t _module_init_start;
 extern intptr_t _module_init_end;

--- a/src/platform/apollolake/include/platform/platform.h
+++ b/src/platform/apollolake/include/platform/platform.h
@@ -75,9 +75,6 @@ struct timer;
 /* DMA host transfer timeouts in microseconds */
 #define PLATFORM_HOST_DMA_TIMEOUT	200
 
-/* platform WorkQ clock */
-#define PLATFORM_WORKQ_CLOCK	PLATFORM_DEFAULT_CLOCK
-
 /* work queue default timeout in microseconds */
 #define PLATFORM_WORKQ_DEFAULT_TIMEOUT	1000
 

--- a/src/platform/apollolake/include/platform/platform.h
+++ b/src/platform/apollolake/include/platform/platform.h
@@ -75,8 +75,10 @@ struct timer;
 /* DMA host transfer timeouts in microseconds */
 #define PLATFORM_HOST_DMA_TIMEOUT	200
 
-/* work queue default timeout in microseconds */
-#define PLATFORM_WORKQ_DEFAULT_TIMEOUT	1000
+/*! \def PLATFORM_LL_DEFAULT_TIMEOUT
+ *  \brief low latency scheduler default timeout in microseconds
+ */
+#define PLATFORM_LL_DEFAULT_TIMEOUT	1000
 
 /* Host finish work schedule delay in microseconds */
 #define PLATFORM_HOST_FINISH_DELAY	100

--- a/src/platform/baytrail/include/platform/platform.h
+++ b/src/platform/baytrail/include/platform/platform.h
@@ -79,9 +79,6 @@ struct timer;
 /* DMA host transfer timeouts in microseconds */
 #define PLATFORM_HOST_DMA_TIMEOUT	200
 
-/* WorkQ window size in microseconds */
-#define PLATFORM_WORKQ_WINDOW	2000
-
 /* platform WorkQ clock */
 #define PLATFORM_WORKQ_CLOCK	PLATFORM_DEFAULT_CLOCK
 

--- a/src/platform/baytrail/include/platform/platform.h
+++ b/src/platform/baytrail/include/platform/platform.h
@@ -27,6 +27,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+struct ll_schedule_domain;
 struct timer;
 
 /*! \def PLATFORM_DEFAULT_CLOCK
@@ -126,6 +127,8 @@ static inline void platform_panic(uint32_t p)
 	shim_write(SHIM_IPCXL, (__x & 0x3fffffff))
 
 extern struct timer *platform_timer;
+
+extern struct ll_schedule_domain *platform_timer_domain;
 
 extern intptr_t _module_init_start;
 extern intptr_t _module_init_end;

--- a/src/platform/baytrail/include/platform/platform.h
+++ b/src/platform/baytrail/include/platform/platform.h
@@ -79,9 +79,6 @@ struct timer;
 /* DMA host transfer timeouts in microseconds */
 #define PLATFORM_HOST_DMA_TIMEOUT	200
 
-/* platform WorkQ clock */
-#define PLATFORM_WORKQ_CLOCK	PLATFORM_DEFAULT_CLOCK
-
 /* local buffer size of DMA tracing */
 #define DMA_TRACE_LOCAL_SIZE	HOST_PAGE_SIZE
 

--- a/src/platform/baytrail/include/platform/platform.h
+++ b/src/platform/baytrail/include/platform/platform.h
@@ -39,10 +39,10 @@ struct timer;
  */
 #define PLATFORM_DEFAULT_CLOCK CLK_SSP
 
-/*! \def PLATFORM_WORKQ_DEFAULT_TIMEOUT
- *  \brief work queue default timeout in microseconds
+/*! \def PLATFORM_LL_DEFAULT_TIMEOUT
+ *  \brief low latency scheduler default timeout in microseconds
  */
-#define PLATFORM_WORKQ_DEFAULT_TIMEOUT	1000
+#define PLATFORM_LL_DEFAULT_TIMEOUT	1000
 
 /* IPC Interrupt */
 #define PLATFORM_IPC_INTERRUPT	IRQ_NUM_EXT_IA

--- a/src/platform/baytrail/include/platform/platform.h
+++ b/src/platform/baytrail/include/platform/platform.h
@@ -79,12 +79,6 @@ struct timer;
 /* DMA host transfer timeouts in microseconds */
 #define PLATFORM_HOST_DMA_TIMEOUT	200
 
-/* DMA link transfer timeouts in microseconds
- * TODO: timeout should be reduced
- * (DMA might needs some further changes to do that)
- */
-#define PLATFORM_LINK_DMA_TIMEOUT	1000
-
 /* WorkQ window size in microseconds */
 #define PLATFORM_WORKQ_WINDOW	2000
 

--- a/src/platform/baytrail/platform.c
+++ b/src/platform/baytrail/platform.c
@@ -192,7 +192,7 @@ int platform_init(struct sof *sof)
 	/* init low latency domains and schedulers */
 	platform_timer_domain =
 		timer_domain_init(platform_timer, PLATFORM_DEFAULT_CLOCK,
-				  PLATFORM_WORKQ_DEFAULT_TIMEOUT);
+				  PLATFORM_LL_DEFAULT_TIMEOUT);
 	scheduler_init_ll(platform_timer_domain);
 
 	/* init the system agent */

--- a/src/platform/cannonlake/include/platform/platform.h
+++ b/src/platform/cannonlake/include/platform/platform.h
@@ -85,12 +85,6 @@ struct timer;
 /* DMA host transfer timeouts in microseconds */
 #define PLATFORM_HOST_DMA_TIMEOUT	200
 
-/* DMA link transfer timeouts in microseconds
- * TODO: timeout should be reduced
- * (DMA might needs some further changes to do that)
- */
-#define PLATFORM_LINK_DMA_TIMEOUT	1000
-
 /* WorkQ window size in microseconds */
 #define PLATFORM_WORKQ_WINDOW	2000
 

--- a/src/platform/cannonlake/include/platform/platform.h
+++ b/src/platform/cannonlake/include/platform/platform.h
@@ -85,9 +85,6 @@ struct timer;
 /* DMA host transfer timeouts in microseconds */
 #define PLATFORM_HOST_DMA_TIMEOUT	200
 
-/* WorkQ window size in microseconds */
-#define PLATFORM_WORKQ_WINDOW	2000
-
 /* platform WorkQ clock */
 #define PLATFORM_WORKQ_CLOCK	PLATFORM_DEFAULT_CLOCK
 

--- a/src/platform/cannonlake/include/platform/platform.h
+++ b/src/platform/cannonlake/include/platform/platform.h
@@ -25,6 +25,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+struct ll_schedule_domain;
 struct timer;
 
 /*! \def PLATFORM_DEFAULT_CLOCK
@@ -148,6 +149,8 @@ static inline void platform_panic(uint32_t p)
 	mailbox_sw_reg_write(SRAM_REG_FW_TRACEP, (__x))
 
 extern struct timer *platform_timer;
+
+extern struct ll_schedule_domain *platform_timer_domain;
 
 extern intptr_t _module_init_start;
 extern intptr_t _module_init_end;

--- a/src/platform/cannonlake/include/platform/platform.h
+++ b/src/platform/cannonlake/include/platform/platform.h
@@ -85,9 +85,6 @@ struct timer;
 /* DMA host transfer timeouts in microseconds */
 #define PLATFORM_HOST_DMA_TIMEOUT	200
 
-/* platform WorkQ clock */
-#define PLATFORM_WORKQ_CLOCK	PLATFORM_DEFAULT_CLOCK
-
 /* Host finish work schedule delay in microseconds */
 #define PLATFORM_HOST_FINISH_DELAY	100
 

--- a/src/platform/cannonlake/include/platform/platform.h
+++ b/src/platform/cannonlake/include/platform/platform.h
@@ -37,10 +37,10 @@ struct timer;
  */
 #define PLATFORM_DEFAULT_CLOCK CLK_SSP
 
-/*! \def PLATFORM_WORKQ_DEFAULT_TIMEOUT
- *  \brief work queue default timeout in microseconds
+/*! \def PLATFORM_LL_DEFAULT_TIMEOUT
+ *  \brief low latency scheduler default timeout in microseconds
  */
-#define PLATFORM_WORKQ_DEFAULT_TIMEOUT	1000
+#define PLATFORM_LL_DEFAULT_TIMEOUT	1000
 
 #define PLATFORM_WAITI_DELAY	1
 

--- a/src/platform/haswell/include/platform/platform.h
+++ b/src/platform/haswell/include/platform/platform.h
@@ -75,12 +75,6 @@ struct timer;
 /* DMA host transfer timeouts in microseconds */
 #define PLATFORM_HOST_DMA_TIMEOUT	200
 
-/* DMA link transfer timeouts in microseconds
- * TODO: timeout should be reduced
- * (DMA might needs some further changes to do that)
- */
-#define PLATFORM_LINK_DMA_TIMEOUT	1000
-
 /* WorkQ window size in microseconds */
 #define PLATFORM_WORKQ_WINDOW	2000
 

--- a/src/platform/haswell/include/platform/platform.h
+++ b/src/platform/haswell/include/platform/platform.h
@@ -75,9 +75,6 @@ struct timer;
 /* DMA host transfer timeouts in microseconds */
 #define PLATFORM_HOST_DMA_TIMEOUT	200
 
-/* platform WorkQ clock */
-#define PLATFORM_WORKQ_CLOCK	PLATFORM_DEFAULT_CLOCK
-
 /* local buffer size of DMA tracing */
 #define DMA_TRACE_LOCAL_SIZE	HOST_PAGE_SIZE
 

--- a/src/platform/haswell/include/platform/platform.h
+++ b/src/platform/haswell/include/platform/platform.h
@@ -23,6 +23,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+struct ll_schedule_domain;
 struct timer;
 
 /*! \def PLATFORM_DEFAULT_CLOCK
@@ -119,6 +120,8 @@ static inline void platform_panic(uint32_t p)
 	shim_write(SHIM_IPCX, ((__x) & 0x3fffffff))
 
 extern struct timer *platform_timer;
+
+extern struct ll_schedule_domain *platform_timer_domain;
 
 extern intptr_t _module_init_start;
 extern intptr_t _module_init_end;

--- a/src/platform/haswell/include/platform/platform.h
+++ b/src/platform/haswell/include/platform/platform.h
@@ -75,9 +75,6 @@ struct timer;
 /* DMA host transfer timeouts in microseconds */
 #define PLATFORM_HOST_DMA_TIMEOUT	200
 
-/* WorkQ window size in microseconds */
-#define PLATFORM_WORKQ_WINDOW	2000
-
 /* platform WorkQ clock */
 #define PLATFORM_WORKQ_CLOCK	PLATFORM_DEFAULT_CLOCK
 

--- a/src/platform/haswell/include/platform/platform.h
+++ b/src/platform/haswell/include/platform/platform.h
@@ -35,10 +35,10 @@ struct timer;
  */
 #define PLATFORM_DEFAULT_CLOCK CLK_CPU(0)
 
-/*! \def PLATFORM_WORKQ_DEFAULT_TIMEOUT
- *  \brief work queue default timeout in microseconds
+/*! \def PLATFORM_LL_DEFAULT_TIMEOUT
+ *  \brief low latency scheduler default timeout in microseconds
  */
-#define PLATFORM_WORKQ_DEFAULT_TIMEOUT	1000
+#define PLATFORM_LL_DEFAULT_TIMEOUT	1000
 
 /* IPC Interrupt */
 #define PLATFORM_IPC_INTERRUPT	IRQ_NUM_EXT_IA

--- a/src/platform/haswell/platform.c
+++ b/src/platform/haswell/platform.c
@@ -181,7 +181,7 @@ int platform_init(struct sof *sof)
 	/* init low latency domains and schedulers */
 	platform_timer_domain =
 		timer_domain_init(platform_timer, PLATFORM_DEFAULT_CLOCK,
-				  PLATFORM_WORKQ_DEFAULT_TIMEOUT);
+				  PLATFORM_LL_DEFAULT_TIMEOUT);
 	scheduler_init_ll(platform_timer_domain);
 
 	/* init the system agent */

--- a/src/platform/icelake/include/platform/platform.h
+++ b/src/platform/icelake/include/platform/platform.h
@@ -85,12 +85,6 @@ struct timer;
 /* DMA host transfer timeouts in microseconds */
 #define PLATFORM_HOST_DMA_TIMEOUT	200
 
-/* DMA link transfer timeouts in microseconds
- * TODO: timeout should be reduced
- * (DMA might needs some further changes to do that)
- */
-#define PLATFORM_LINK_DMA_TIMEOUT	1000
-
 /* WorkQ window size in microseconds */
 #define PLATFORM_WORKQ_WINDOW	2000
 

--- a/src/platform/icelake/include/platform/platform.h
+++ b/src/platform/icelake/include/platform/platform.h
@@ -85,9 +85,6 @@ struct timer;
 /* DMA host transfer timeouts in microseconds */
 #define PLATFORM_HOST_DMA_TIMEOUT	200
 
-/* WorkQ window size in microseconds */
-#define PLATFORM_WORKQ_WINDOW	2000
-
 /* platform WorkQ clock */
 #define PLATFORM_WORKQ_CLOCK	PLATFORM_DEFAULT_CLOCK
 

--- a/src/platform/icelake/include/platform/platform.h
+++ b/src/platform/icelake/include/platform/platform.h
@@ -25,6 +25,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+struct ll_schedule_domain;
 struct timer;
 
 /*! \def PLATFORM_DEFAULT_CLOCK
@@ -148,6 +149,8 @@ static inline void platform_panic(uint32_t p)
 	mailbox_sw_reg_write(SRAM_REG_FW_TRACEP, (__x))
 
 extern struct timer *platform_timer;
+
+extern struct ll_schedule_domain *platform_timer_domain;
 
 extern intptr_t _module_init_start;
 extern intptr_t _module_init_end;

--- a/src/platform/icelake/include/platform/platform.h
+++ b/src/platform/icelake/include/platform/platform.h
@@ -85,9 +85,6 @@ struct timer;
 /* DMA host transfer timeouts in microseconds */
 #define PLATFORM_HOST_DMA_TIMEOUT	200
 
-/* platform WorkQ clock */
-#define PLATFORM_WORKQ_CLOCK	PLATFORM_DEFAULT_CLOCK
-
 /* Host finish work schedule delay in microseconds */
 #define PLATFORM_HOST_FINISH_DELAY	100
 

--- a/src/platform/icelake/include/platform/platform.h
+++ b/src/platform/icelake/include/platform/platform.h
@@ -37,10 +37,10 @@ struct timer;
  */
 #define PLATFORM_DEFAULT_CLOCK CLK_SSP
 
-/*! \def PLATFORM_WORKQ_DEFAULT_TIMEOUT
- *  \brief work queue default timeout in microseconds
+/*! \def PLATFORM_LL_DEFAULT_TIMEOUT
+ *  \brief low latency scheduler default timeout in microseconds
  */
-#define PLATFORM_WORKQ_DEFAULT_TIMEOUT	1000
+#define PLATFORM_LL_DEFAULT_TIMEOUT	1000
 
 #define PLATFORM_WAITI_DELAY	1
 

--- a/src/platform/imx8/include/platform/platform.h
+++ b/src/platform/imx8/include/platform/platform.h
@@ -59,9 +59,6 @@ struct timer;
 /* DMA host transfer timeouts in microseconds */
 #define PLATFORM_HOST_DMA_TIMEOUT	50
 
-/* platform WorkQ clock */
-#define PLATFORM_WORKQ_CLOCK	PLATFORM_DEFAULT_CLOCK
-
 /* local buffer size of DMA tracing */
 #define DMA_TRACE_LOCAL_SIZE	HOST_PAGE_SIZE
 

--- a/src/platform/imx8/include/platform/platform.h
+++ b/src/platform/imx8/include/platform/platform.h
@@ -18,6 +18,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+struct ll_schedule_domain;
 struct timer;
 
 #define PLATFORM_DEFAULT_CLOCK CLK_CPU(0)
@@ -94,6 +95,8 @@ static inline void platform_panic(uint32_t p)
 #define platform_trace_point(__x)
 
 extern struct timer *platform_timer;
+
+extern struct ll_schedule_domain *platform_timer_domain;
 
 extern intptr_t _module_init_start;
 extern intptr_t _module_init_end;

--- a/src/platform/imx8/include/platform/platform.h
+++ b/src/platform/imx8/include/platform/platform.h
@@ -24,7 +24,10 @@ struct timer;
 #define PLATFORM_DEFAULT_CLOCK CLK_CPU(0)
 #define LPSRAM_SIZE 16384
 
-#define PLATFORM_WORKQ_DEFAULT_TIMEOUT	1000
+/*! \def PLATFORM_LL_DEFAULT_TIMEOUT
+ *  \brief low latency scheduler default timeout in microseconds
+ */
+#define PLATFORM_LL_DEFAULT_TIMEOUT	1000
 
 /* IPC Interrupt */
 #define PLATFORM_IPC_INTERRUPT		IRQ_NUM_MU

--- a/src/platform/imx8/include/platform/platform.h
+++ b/src/platform/imx8/include/platform/platform.h
@@ -59,9 +59,6 @@ struct timer;
 /* DMA host transfer timeouts in microseconds */
 #define PLATFORM_HOST_DMA_TIMEOUT	50
 
-/* WorkQ window size in microseconds */
-#define PLATFORM_WORKQ_WINDOW	2000
-
 /* platform WorkQ clock */
 #define PLATFORM_WORKQ_CLOCK	PLATFORM_DEFAULT_CLOCK
 

--- a/src/platform/imx8/platform.c
+++ b/src/platform/imx8/platform.c
@@ -148,7 +148,7 @@ int platform_init(struct sof *sof)
 	/* init low latency domains and schedulers */
 	platform_timer_domain =
 		timer_domain_init(platform_timer, PLATFORM_DEFAULT_CLOCK,
-				  PLATFORM_WORKQ_DEFAULT_TIMEOUT);
+				  PLATFORM_LL_DEFAULT_TIMEOUT);
 	scheduler_init_ll(platform_timer_domain);
 
 	platform_timer_start(platform_timer);

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -373,7 +373,7 @@ int platform_init(struct sof *sof)
 	/* init low latency domains and schedulers */
 	platform_timer_domain =
 		timer_domain_init(platform_timer, PLATFORM_DEFAULT_CLOCK,
-				  PLATFORM_WORKQ_DEFAULT_TIMEOUT);
+				  PLATFORM_LL_DEFAULT_TIMEOUT);
 	scheduler_init_ll(platform_timer_domain);
 
 	/* init the system agent */

--- a/src/platform/library/include/platform/platform.h
+++ b/src/platform/library/include/platform/platform.h
@@ -25,10 +25,10 @@ struct timer;
  */
 #define PLATFORM_DEFAULT_CLOCK CLK_CPU(0)
 
-/*! \def PLATFORM_WORKQ_DEFAULT_TIMEOUT
- *  \brief work queue default timeout in microseconds
+/*! \def PLATFORM_LL_DEFAULT_TIMEOUT
+ *  \brief low latency scheduler default timeout in microseconds
  */
-#define PLATFORM_WORKQ_DEFAULT_TIMEOUT	1000
+#define PLATFORM_LL_DEFAULT_TIMEOUT	1000
 
 /* Host page size */
 #define HOST_PAGE_SIZE		4096

--- a/src/platform/suecreek/include/platform/platform.h
+++ b/src/platform/suecreek/include/platform/platform.h
@@ -81,9 +81,6 @@ struct timer;
 /* DMA host transfer timeouts in microseconds */
 #define PLATFORM_HOST_DMA_TIMEOUT	200
 
-/* WorkQ window size in microseconds */
-#define PLATFORM_WORKQ_WINDOW	2000
-
 /* platform WorkQ clock */
 #define PLATFORM_WORKQ_CLOCK	PLATFORM_DEFAULT_CLOCK
 

--- a/src/platform/suecreek/include/platform/platform.h
+++ b/src/platform/suecreek/include/platform/platform.h
@@ -81,9 +81,6 @@ struct timer;
 /* DMA host transfer timeouts in microseconds */
 #define PLATFORM_HOST_DMA_TIMEOUT	200
 
-/* platform WorkQ clock */
-#define PLATFORM_WORKQ_CLOCK	PLATFORM_DEFAULT_CLOCK
-
 /* Host finish work schedule delay in microseconds */
 #define PLATFORM_HOST_FINISH_DELAY	100
 

--- a/src/platform/suecreek/include/platform/platform.h
+++ b/src/platform/suecreek/include/platform/platform.h
@@ -81,12 +81,6 @@ struct timer;
 /* DMA host transfer timeouts in microseconds */
 #define PLATFORM_HOST_DMA_TIMEOUT	200
 
-/* DMA link transfer timeouts in microseconds
- * TODO: timeout should be reduced
- * (DMA might needs some further changes to do that)
- */
-#define PLATFORM_LINK_DMA_TIMEOUT	1000
-
 /* WorkQ window size in microseconds */
 #define PLATFORM_WORKQ_WINDOW	2000
 

--- a/src/platform/suecreek/include/platform/platform.h
+++ b/src/platform/suecreek/include/platform/platform.h
@@ -37,10 +37,10 @@ struct timer;
  */
 #define PLATFORM_DEFAULT_CLOCK CLK_SSP
 
-/*! \def PLATFORM_WORKQ_DEFAULT_TIMEOUT
- *  \brief work queue default timeout in microseconds
+/*! \def PLATFORM_LL_DEFAULT_TIMEOUT
+ *  \brief low latency scheduler default timeout in microseconds
  */
-#define PLATFORM_WORKQ_DEFAULT_TIMEOUT	1000
+#define PLATFORM_LL_DEFAULT_TIMEOUT	1000
 
 #define PLATFORM_WAITI_DELAY	1
 

--- a/src/platform/suecreek/include/platform/platform.h
+++ b/src/platform/suecreek/include/platform/platform.h
@@ -25,6 +25,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+struct ll_schedule_domain;
 struct timer;
 
 /*! \def PLATFORM_DEFAULT_CLOCK
@@ -160,6 +161,8 @@ static inline void platform_panic(uint32_t p)
 #define platform_trace_point(__x)
 #endif
 extern struct timer *platform_timer;
+
+extern struct ll_schedule_domain *platform_timer_domain;
 
 extern intptr_t _module_init_start;
 extern intptr_t _module_init_end;

--- a/src/platform/tigerlake/include/platform/platform.h
+++ b/src/platform/tigerlake/include/platform/platform.h
@@ -92,9 +92,6 @@ struct timer;
 /* DMA host transfer timeouts in microseconds */
 #define PLATFORM_HOST_DMA_TIMEOUT	200
 
-/* platform WorkQ clock */
-#define PLATFORM_WORKQ_CLOCK	PLATFORM_DEFAULT_CLOCK
-
 /* Host finish work schedule delay in microseconds */
 #define PLATFORM_HOST_FINISH_DELAY	100
 

--- a/src/platform/tigerlake/include/platform/platform.h
+++ b/src/platform/tigerlake/include/platform/platform.h
@@ -25,6 +25,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+struct ll_schedule_domain;
 struct timer;
 
 /*! \def PLATFORM_DEFAULT_CLOCK
@@ -155,6 +156,8 @@ static inline void platform_panic(uint32_t p)
 	mailbox_sw_reg_write(SRAM_REG_FW_TRACEP, (__x))
 
 extern struct timer *platform_timer;
+
+extern struct ll_schedule_domain *platform_timer_domain;
 
 extern intptr_t _module_init_start;
 extern intptr_t _module_init_end;

--- a/src/platform/tigerlake/include/platform/platform.h
+++ b/src/platform/tigerlake/include/platform/platform.h
@@ -92,9 +92,6 @@ struct timer;
 /* DMA host transfer timeouts in microseconds */
 #define PLATFORM_HOST_DMA_TIMEOUT	200
 
-/* WorkQ window size in microseconds */
-#define PLATFORM_WORKQ_WINDOW	2000
-
 /* platform WorkQ clock */
 #define PLATFORM_WORKQ_CLOCK	PLATFORM_DEFAULT_CLOCK
 

--- a/src/platform/tigerlake/include/platform/platform.h
+++ b/src/platform/tigerlake/include/platform/platform.h
@@ -92,12 +92,6 @@ struct timer;
 /* DMA host transfer timeouts in microseconds */
 #define PLATFORM_HOST_DMA_TIMEOUT	200
 
-/* DMA link transfer timeouts in microseconds
- * TODO: timeout should be reduced
- * (DMA might needs some further changes to do that)
- */
-#define PLATFORM_LINK_DMA_TIMEOUT	1000
-
 /* WorkQ window size in microseconds */
 #define PLATFORM_WORKQ_WINDOW	2000
 

--- a/src/platform/tigerlake/include/platform/platform.h
+++ b/src/platform/tigerlake/include/platform/platform.h
@@ -37,10 +37,10 @@ struct timer;
  */
 #define PLATFORM_DEFAULT_CLOCK CLK_SSP
 
-/*! \def PLATFORM_WORKQ_DEFAULT_TIMEOUT
- *  \brief work queue default timeout in microseconds
+/*! \def PLATFORM_LL_DEFAULT_TIMEOUT
+ *  \brief low latency scheduler default timeout in microseconds
  */
-#define PLATFORM_WORKQ_DEFAULT_TIMEOUT	1000
+#define PLATFORM_LL_DEFAULT_TIMEOUT	1000
 
 #define PLATFORM_WAITI_DELAY	1
 

--- a/src/schedule/CMakeLists.txt
+++ b/src/schedule/CMakeLists.txt
@@ -5,4 +5,5 @@ add_local_sources(sof
 	ll_schedule.c
 	schedule.c
 	task.c
+	timer_domain.c
 )

--- a/src/schedule/ll_schedule.c
+++ b/src/schedule/ll_schedule.c
@@ -4,541 +4,275 @@
 //
 // Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
 //         Keyon Jie <yang.jie@linux.intel.com>
-
-/*
- * Generic delayed work queue support.
- *
- * Work can be queued to run after a microsecond timeout on either the system
- * work queue or a private work queue. It's expected most users will use the
- * system work queue as private work queues depend on available architecture
- * timers.
- *
- * The work on the system work queue should be short duration and not delay
- * any other work on this queue. If you have longer duration work (like audio
- * processing) then use a private work queue.
- *
- * The generic work queues are intended to stay in time synchronisation with
- * any CPU clock changes. i.e. timeouts will remain constant regardless of CPU
- * frequency changes.
- */
+//         Tomasz Lauda <tomasz.lauda@linux.intel.com>
 
 #include <sof/atomic.h>
 #include <sof/common.h>
+#include <sof/drivers/interrupt.h>
 #include <sof/drivers/timer.h>
 #include <sof/lib/alloc.h>
+#include <sof/lib/cache.h>
 #include <sof/lib/clk.h>
 #include <sof/lib/cpu.h>
 #include <sof/lib/notifier.h>
 #include <sof/list.h>
 #include <sof/platform.h>
 #include <sof/schedule/ll_schedule.h>
+#include <sof/schedule/ll_schedule_domain.h>
 #include <sof/schedule/schedule.h>
 #include <sof/schedule/task.h>
-#include <sof/sof.h>
 #include <sof/spinlock.h>
 #include <ipc/topology.h>
 #include <errno.h>
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
 struct ll_schedule_data {
 	struct list_item tasks;			/* list of ll tasks */
-	uint64_t timeout;			/* timeout for next queue run */
-	uint32_t window_size;			/* window size for pending ll */
-	struct notifier notifier;		/* notify CPU freq changes */
-	struct timesource_data *ts;		/* time source for work queue */
-	uint32_t ticks_per_msec;		/* ticks per msec */
-	atomic_t num_ll;			/* number of queued ll items */
+	atomic_t num_tasks;			/* number of ll tasks */
+	struct notifier notifier;		/* notify frequency changes */
+	struct ll_schedule_domain *domain;	/* scheduling domain */
 };
-
-struct ll_queue_shared_context {
-	spinlock_t *lock;		/* lock to synchronize many cores */
-	atomic_t total_num_work;	/* number of total queued ll items */
-	atomic_t timer_clients;		/* number of timer clients */
-	uint64_t last_tick;		/* time of last tick */
-
-	/* registered timers */
-	struct timer *timers[PLATFORM_CORE_COUNT];
-	void *irq_arg[PLATFORM_CORE_COUNT];
-};
-
-static struct ll_queue_shared_context *ll_shared_ctx;
 
 struct scheduler_ops schedule_ll_ops;
 
-/* calculate next timeout */
-static uint64_t queue_calc_next_timeout(struct ll_schedule_data *queue,
-					uint64_t start)
+static bool schedule_ll_is_pending(struct ll_schedule_data *sch)
 {
-	return queue->ticks_per_msec * queue->timeout / 1000 + start;
-}
+	struct list_item *tlist;
+	struct task *task;
+	uint32_t pending_count = 0;
 
-static uint64_t ll_get_timer(struct ll_schedule_data *queue)
-{
-	return queue->ts->timer_get(&queue->ts->timer);
-}
+	/* mark each valid task as pending */
+	list_for_item(tlist, &sch->tasks) {
+		task = container_of(tlist, struct task, list);
 
-static void ll_set_timer(struct ll_schedule_data *queue)
-{
-	int core = cpu_get_id();
-	uint64_t ticks;
-
-	spin_lock(ll_shared_ctx->lock);
-
-	if (atomic_add(&queue->num_ll, 1) == 1)
-		ll_shared_ctx->timers[core] = &queue->ts->timer;
-
-	if (atomic_add(&ll_shared_ctx->total_num_work, 1) == 1) {
-		ticks = queue_calc_next_timeout(queue, ll_get_timer(queue));
-		ll_shared_ctx->last_tick = ticks;
-		queue->ts->timer_set(&queue->ts->timer, ticks);
-		atomic_add(&ll_shared_ctx->timer_clients, 1);
-		timer_enable(&queue->ts->timer, ll_shared_ctx->irq_arg[core],
-			     core);
-	}
-
-	spin_unlock(ll_shared_ctx->lock);
-}
-
-static void ll_clear_timer(struct ll_schedule_data *queue)
-{
-	spin_lock(ll_shared_ctx->lock);
-
-	if (!atomic_sub(&ll_shared_ctx->total_num_work, 1))
-		queue->ts->timer_clear(&queue->ts->timer);
-
-	if (!atomic_sub(&queue->num_ll, 1))
-		ll_shared_ctx->timers[cpu_get_id()] = NULL;
-
-	spin_unlock(ll_shared_ctx->lock);
-}
-
-/* is there any work pending in the current time window ? */
-static int is_ll_pending(struct ll_schedule_data *queue)
-{
-	struct list_item *wlist;
-	struct task *ll_task;
-	uint64_t win_end;
-	uint64_t win_start;
-	int pending_count = 0;
-
-	/* get the current valid window of work */
-	win_end = ll_get_timer(queue);
-	win_start = win_end - queue->window_size;
-
-	/* mark each valid work item in this time period as pending */
-	list_for_item(wlist, &queue->tasks) {
-		ll_task = container_of(wlist, struct task, list);
-
-		/* correct the pending flag window for overflow */
-		if (win_end > win_start) {
-			/* mark pending work */
-			if (ll_task->start >= win_start &&
-				ll_task->start <= win_end) {
-				ll_task->state =
-					SOF_TASK_STATE_PENDING;
-				pending_count++;
-			} else {
-				ll_task->state = SOF_TASK_STATE_INIT;
-			}
-		} else {
-			/* mark pending work */
-			if ((ll_task->start <= win_end ||
-				(ll_task->start >= win_start &&
-				ll_task->start < UINT64_MAX))) {
-				ll_task->state =
-					SOF_TASK_STATE_PENDING;
-				pending_count++;
-			} else {
-				ll_task->state = SOF_TASK_STATE_INIT;
-			}
+		if (domain_is_pending(sch->domain, task)) {
+			task->state = SOF_TASK_STATE_PENDING;
+			pending_count++;
 		}
 	}
 
-	return pending_count;
+	return pending_count > 0;
 }
 
-static void ll_next_timeout(struct ll_schedule_data *queue,
-			    struct task *work)
+static void schedule_ll_task_update_start(struct ll_schedule_data *sch,
+					  struct task *task)
 {
-	/* reschedule work */
-	struct ll_task_pdata *ll_task_pdata = ll_sch_get_pdata(work);
-	uint64_t next_d;
+	struct ll_task_pdata *pdata = ll_sch_get_pdata(task);
+	uint64_t next;
 
-	next_d = queue->ticks_per_msec * ll_task_pdata->period / 1000;
+	next = sch->domain->ticks_per_ms * pdata->period / 1000;
 
-	if (work->flags & SOF_SCHEDULE_FLAG_SYNC) {
-		work->start += next_d;
-	} else {
-		/* calc next run based on work request */
-		work->start = next_d + ll_shared_ctx->last_tick;
-	}
+	if (task->flags & SOF_SCHEDULE_FLAG_SYNC)
+		task->start += next;
+	else
+		task->start = next + sch->domain->last_tick;
 }
 
-/* run all pending work */
-static void run_ll(struct ll_schedule_data *queue, uint32_t *flags)
+static void schedule_ll_tasks_execute(struct ll_schedule_data *sch,
+				      uint32_t *flags)
 {
 	struct list_item *wlist;
 	struct list_item *tlist;
-	struct task *ll_task;
+	struct task *task;
 	int cpu = cpu_get_id();
 
-	/* check each work item in queue for pending */
-	list_for_item_safe(wlist, tlist, &queue->tasks) {
-		ll_task = container_of(wlist, struct task, list);
+	/* check each task in the list for pending */
+	list_for_item_safe(wlist, tlist, &sch->tasks) {
+		task = container_of(wlist, struct task, list);
 
-		/* run work if its pending and remove from the queue */
-		if (ll_task->state == SOF_TASK_STATE_PENDING) {
-			/* work can run in non atomic context */
+		/* run task if its pending and remove from the list */
+		if (task->state == SOF_TASK_STATE_PENDING) {
+			/* task can run in non atomic context */
 			irq_local_enable(*flags);
-			ll_task->state = ll_task->func(ll_task->data);
+			task->state = task->func(task->data);
 			irq_local_disable(*flags);
 
-			/* do we need reschedule this work ? */
-			if (ll_task->state == SOF_TASK_STATE_COMPLETED) {
-				list_item_del(&ll_task->list);
-				atomic_sub(&ll_shared_ctx->total_num_work, 1);
+			/* do we need to reschedule this task */
+			if (task->state == SOF_TASK_STATE_COMPLETED) {
+				list_item_del(&task->list);
+				atomic_sub(&sch->domain->total_num_tasks, 1);
 
-				/* don't enable irq, if no more work to do */
-				if (!atomic_sub(&queue->num_ll, 1))
-					ll_shared_ctx->timers[cpu] = NULL;
+				/* don't enable irq, if no more tasks to do */
+				if (!atomic_sub(&sch->num_tasks, 1))
+					sch->domain->registered[cpu] = false;
 			} else {
-				/* get next work timeout */
-				ll_next_timeout(queue, ll_task);
+				/* update task's start time */
+				schedule_ll_task_update_start(sch, task);
 			}
 		}
 	}
 }
 
-static uint64_t calc_delta_ticks(uint64_t current, uint64_t work)
-{
-	/* does work run in next cycle ? */
-	if (work >= current)
-		return work - current;
-
-	return UINT64_MAX - current + work;
-}
-
-/* re calculate timers for queue after CPU frequency change */
-static void queue_recalc_timers(struct ll_schedule_data *queue,
-				struct clock_notify_data *clk_data)
-{
-	struct list_item *wlist;
-	struct task *ll_task;
-	uint64_t delta_ticks;
-	uint64_t delta_msecs;
-	uint64_t current;
-
-	/* get current time */
-	current = ll_get_timer(queue);
-
-	/* recalculate timers for each work item */
-	list_for_item(wlist, &queue->tasks) {
-		ll_task = container_of(wlist, struct task, list);
-		delta_ticks = calc_delta_ticks(current, ll_task->start);
-		delta_msecs = delta_ticks /
-			clk_data->old_ticks_per_msec;
-
-		/* is work within next msec, then schedule it now */
-		if (delta_msecs > 0)
-			ll_task->start = current +
-				queue->ticks_per_msec * delta_msecs;
-		else
-			ll_task->start = current +
-				(queue->ticks_per_msec >> 3);
-	}
-}
-
-/* enable all registered timers */
-static void queue_enable_registered_timers(void)
+static void schedule_ll_clients_enable(struct ll_schedule_data *sch)
 {
 	int i;
 
 	for (i = 0; i < PLATFORM_CORE_COUNT; i++) {
-		if (ll_shared_ctx->timers[i]) {
-			atomic_add(&ll_shared_ctx->timer_clients, 1);
-			timer_enable(ll_shared_ctx->timers[i],
-				     ll_shared_ctx->irq_arg[i], i);
+		if (sch->domain->registered[i]) {
+			atomic_add(&sch->domain->num_clients, 1);
+			domain_enable(sch->domain, i);
 		}
 	}
 }
 
-/* reschedule queue */
-static void queue_reschedule(struct ll_schedule_data *queue)
+static void schedule_ll_clients_reschedule(struct ll_schedule_data *sch)
 {
-	uint64_t ticks;
+	/* clear domain */
+	domain_clear(sch->domain);
 
-	/* clear only if all timer clients are done */
-	if (!atomic_sub(&ll_shared_ctx->timer_clients, 1)) {
-		/* clear timer */
-		queue->ts->timer_clear(&queue->ts->timer);
-
-		/* re-arm only if there is work to do */
-		if (atomic_read(&ll_shared_ctx->total_num_work)) {
-			/* re-arm timer */
-			ticks = queue_calc_next_timeout
-				(queue,
-				 ll_shared_ctx->last_tick);
-			ll_shared_ctx->last_tick = ticks;
-			queue->ts->timer_set(&queue->ts->timer, ticks);
-
-			queue_enable_registered_timers();
-		}
+	/* rearm only if there is work to do */
+	if (atomic_read(&sch->domain->total_num_tasks)) {
+		domain_set(sch->domain, sch->domain->last_tick);
+		schedule_ll_clients_enable(sch);
 	}
 }
 
-/* run the work queue */
-static void queue_run(void *data)
+static void schedule_ll_tasks_run(void *data)
 {
-	struct ll_schedule_data *queue = (struct ll_schedule_data *)data;
+	struct ll_schedule_data *sch = data;
+	uint32_t flags;
+
+	domain_disable(sch->domain, cpu_get_id());
+
+	irq_local_disable(flags);
+
+	/* run tasks if there are any pending */
+	if (schedule_ll_is_pending(sch))
+		schedule_ll_tasks_execute(sch, &flags);
+
+	spin_lock(sch->domain->lock);
+
+	/* reschedule only if all clients are done */
+	if (!atomic_sub(&sch->domain->num_clients, 1))
+		schedule_ll_clients_reschedule(sch);
+
+	spin_unlock(sch->domain->lock);
+
+	irq_local_enable(flags);
+}
+
+static int schedule_ll_domain_set(struct ll_schedule_data *sch,
+				  struct task *task, uint64_t period)
+{
 	int core = cpu_get_id();
-	uint32_t flags;
+	int ret;
 
-	timer_disable(&queue->ts->timer, ll_shared_ctx->irq_arg[core], core);
-
-	irq_local_disable(flags);
-
-	/* run work if there is any pending */
-	if (is_ll_pending(queue))
-		run_ll(queue, &flags);
-
-	spin_lock(ll_shared_ctx->lock);
-
-	/* re-calc timer and re-arm */
-	queue_reschedule(queue);
-
-	spin_unlock(ll_shared_ctx->lock);
-
-	irq_local_enable(flags);
-}
-
-/* notification of CPU frequency changes - atomic PRE and POST sequence */
-static void ll_notify(int message, void *data, void *event_data)
-{
-	struct ll_schedule_data *queue = (struct ll_schedule_data *)data;
-	struct clock_notify_data *clk_data =
-		(struct clock_notify_data *)event_data;
-	uint32_t flags;
-
-	irq_local_disable(flags);
-
-	/* we need to re-calculate timer when CPU frequency changes */
-	if (message == CLOCK_NOTIFY_POST) {
-		/* CPU frequency update complete */
-		/* scale the window size to clock speed */
-		queue->ticks_per_msec = clock_ms_to_ticks(queue->ts->clk, 1);
-		queue->window_size =
-			queue->ticks_per_msec * PLATFORM_WORKQ_WINDOW / 1000;
-		queue_recalc_timers(queue, clk_data);
-	} else if (message == CLOCK_NOTIFY_PRE) {
-		/* CPU frequency update pending */
+	ret = domain_register(sch->domain, period, task, &schedule_ll_tasks_run,
+			      sch);
+	if (ret < 0) {
+		trace_ll_error("schedule_ll_domain_set() error: cannot "
+			       "register domain %d", ret);
+		return ret;
 	}
 
-	irq_local_enable(flags);
+	spin_lock(sch->domain->lock);
+
+	if (atomic_add(&sch->num_tasks, 1) == 1)
+		sch->domain->registered[core] = true;
+
+	if (atomic_add(&sch->domain->total_num_tasks, 1) == 1) {
+		domain_set(sch->domain, platform_timer_get(platform_timer));
+		atomic_add(&sch->domain->num_clients, 1);
+		domain_enable(sch->domain, core);
+	}
+
+	spin_unlock(sch->domain->lock);
+
+	return 0;
 }
 
-static void insert_task_to_queue(struct task *w, struct list_item *q_list)
+static void schedule_ll_domain_clear(struct ll_schedule_data *sch)
 {
-	struct task *ll_task;
-	struct list_item *wlist;
+	spin_lock(sch->domain->lock);
 
-	/* works are adding to queue in order */
-	list_for_item(wlist, q_list) {
-		ll_task = container_of(wlist, struct task, list);
-		if (w->priority <= ll_task->priority) {
-			list_item_append(&w->list, &ll_task->list);
+	if (!atomic_sub(&sch->domain->total_num_tasks, 1)) {
+		domain_clear(sch->domain);
+		sch->domain->last_tick = 0;
+	}
+
+	if (!atomic_sub(&sch->num_tasks, 1)) {
+		sch->domain->registered[cpu_get_id()] = false;
+
+		/* reschedule if there is no more clients waiting */
+		if (!atomic_sub(&sch->domain->num_clients, 1))
+			schedule_ll_clients_reschedule(sch);
+	}
+
+	spin_unlock(sch->domain->lock);
+
+	domain_unregister(sch->domain, atomic_read(&sch->num_tasks));
+}
+
+static void schedule_ll_task_insert(struct task *task, struct list_item *tasks)
+{
+	struct list_item *tlist;
+	struct task *curr_task;
+
+	/* tasks are added into the list in order */
+	list_for_item(tlist, tasks) {
+		curr_task = container_of(tlist, struct task, list);
+		if (task->priority <= curr_task->priority) {
+			list_item_append(&task->list, &curr_task->list);
 			return;
 		}
 	}
 
 	/* if task has not been added, means that it has the lowest
-	 * priority in queue and it should be added at the end of the list
+	 * priority and should be added at the end of the list
 	 */
-	list_item_append(&w->list, q_list);
+	list_item_append(&task->list, tasks);
 }
 
 static void schedule_ll_task(void *data, struct task *task, uint64_t start,
 			     uint64_t period)
 {
 	struct ll_schedule_data *sch = data;
-	struct ll_task_pdata *ll_pdata;
-	struct task *ll_task;
-	struct list_item *wlist;
+	struct ll_task_pdata *pdata;
+	struct list_item *tlist;
+	struct task *curr_task;
 	uint32_t flags;
 
 	irq_local_disable(flags);
 
-	/* check to see if we are already scheduled ? */
-	list_for_item(wlist, &sch->tasks) {
-		ll_task = container_of(wlist, struct task, list);
+	/* check if task is already scheduled */
+	list_for_item(tlist, &sch->tasks) {
+		curr_task = container_of(tlist, struct task, list);
 
 		/* keep original start */
-		if (ll_task == task)
+		if (curr_task == task)
 			goto out;
 	}
 
-	task->start = sch->ticks_per_msec * start / 1000;
-
-	/* convert start micro seconds to CPU clock ticks */
-	if (task->flags & SOF_SCHEDULE_FLAG_SYNC)
-		task->start += ll_get_timer(sch);
-	else
-		task->start += ll_shared_ctx->last_tick;
-
-	ll_pdata = ll_sch_get_pdata(task);
+	pdata = ll_sch_get_pdata(task);
 
 	/* invalidate if slave core */
 	if (cpu_is_slave(task->core))
-		dcache_invalidate_region(ll_pdata, sizeof(*ll_pdata));
+		dcache_invalidate_region(pdata, sizeof(*pdata));
 
-	ll_pdata->period = period;
+	pdata->period = period;
 
-	/* insert work into list */
-	insert_task_to_queue(task, &sch->tasks);
+	/* insert task into the list */
+	schedule_ll_task_insert(task, &sch->tasks);
 
-	ll_set_timer(sch);
+	/* set schedule domain */
+	if (schedule_ll_domain_set(sch, task, period) < 0) {
+		list_item_del(&task->list);
+		goto out;
+	}
+
+	task->start = sch->domain->ticks_per_ms * start / 1000;
+
+	if (task->flags & SOF_SCHEDULE_FLAG_SYNC)
+		task->start += platform_timer_get(platform_timer);
+	else
+		task->start += sch->domain->last_tick;
 
 out:
 	irq_local_enable(flags);
 }
 
-static void reschedule_ll_task(void *data, struct task *task, uint64_t start)
-{
-	struct ll_schedule_data *sch = data;
-	struct task *ll_task;
-	struct list_item *wlist;
-	uint32_t flags;
-	uint64_t time;
-
-	time = sch->ticks_per_msec * start / 1000;
-
-	/* convert start micro seconds to CPU clock ticks */
-	if (task->flags & SOF_SCHEDULE_FLAG_SYNC)
-		time += ll_get_timer(sch);
-	else
-		time += ll_shared_ctx->last_tick;
-
-	irq_local_disable(flags);
-
-	/* check to see if we are already scheduled */
-	list_for_item(wlist, &sch->tasks) {
-		ll_task = container_of(wlist, struct task, list);
-		/* found it */
-		if (ll_task == task)
-			goto found;
-	}
-
-	insert_task_to_queue(task, &sch->tasks);
-
-	ll_set_timer(sch);
-
-found:
-	/* re-calc timer and re-arm */
-	task->start = time;
-
-	irq_local_enable(flags);
-}
-
-static void schedule_ll_task_cancel(void *data, struct task *task)
-{
-	struct ll_schedule_data *sch = data;
-	struct task *ll_task;
-	struct list_item *wlist;
-	uint32_t flags;
-
-	irq_local_disable(flags);
-
-	/* check to see if we are scheduled */
-	list_for_item(wlist, &sch->tasks) {
-		ll_task = container_of(wlist, struct task, list);
-
-		/* found it */
-		if (ll_task == task) {
-			ll_clear_timer(sch);
-			break;
-		}
-	}
-
-	/* remove work from list */
-	task->state = SOF_TASK_STATE_CANCEL;
-	list_item_del(&task->list);
-
-	irq_local_enable(flags);
-}
-
-static void schedule_ll_task_free(void *data, struct task *task)
-{
-	struct ll_task_pdata *ll_pdata;
-	uint32_t flags;
-
-	irq_local_disable(flags);
-
-	/* release the resources */
-	task->state = SOF_TASK_STATE_FREE;
-	ll_pdata = ll_sch_get_pdata(task);
-	rfree(ll_pdata);
-	ll_sch_set_pdata(task, NULL);
-
-	irq_local_enable(flags);
-}
-
-static struct ll_schedule_data *work_new_queue(struct timesource_data *ts)
-{
-	struct ll_schedule_data *queue;
-
-	/* init work queue */
-	queue = rzalloc(RZONE_SYS, SOF_MEM_CAPS_RAM, sizeof(*queue));
-	list_init(&queue->tasks);
-
-	atomic_init(&queue->num_ll, 0);
-	queue->ts = ts;
-	queue->ticks_per_msec = clock_ms_to_ticks(queue->ts->clk, 1);
-	queue->window_size = queue->ticks_per_msec *
-		PLATFORM_WORKQ_WINDOW / 1000;
-
-	/* TODO: configurable through IPC */
-	queue->timeout = PLATFORM_WORKQ_DEFAULT_TIMEOUT;
-
-	/* notification of clk changes */
-	queue->notifier.cb = ll_notify;
-	queue->notifier.cb_data = queue;
-	queue->notifier.id = ts->notifier;
-	notifier_register(&queue->notifier);
-
-	return queue;
-}
-
-int scheduler_init_ll(void)
-{
-	struct ll_schedule_data *sch;
-	struct timesource_data *ts;
-	int cpu;
-
-	cpu = cpu_get_id();
-	ts = &platform_generic_queue[cpu];
-
-	sch = work_new_queue(ts);
-	scheduler_init(SOF_SCHEDULE_LL, &schedule_ll_ops, sch);
-
-	if (cpu == PLATFORM_MASTER_CORE_ID) {
-		ll_shared_ctx = rzalloc(RZONE_SYS | RZONE_FLAG_UNCACHED,
-					SOF_MEM_CAPS_RAM,
-					sizeof(*ll_shared_ctx));
-		spinlock_init(&ll_shared_ctx->lock);
-		atomic_init(&ll_shared_ctx->total_num_work, 0);
-		atomic_init(&ll_shared_ctx->timer_clients, 0);
-	}
-
-	/* register system timer */
-	timer_register(&platform_generic_queue[cpu].timer, queue_run, sch);
-
-	/* save interrupt argument */
-	ll_shared_ctx->irq_arg[cpu] = sch;
-
-	return 0;
-}
-
-/* initialise our work */
 static int schedule_ll_task_init(void *data, struct task *task)
 {
 	struct ll_task_pdata *ll_pdata;
@@ -564,15 +298,89 @@ static int schedule_ll_task_init(void *data, struct task *task)
 	return 0;
 }
 
+static void schedule_ll_task_free(void *data, struct task *task)
+{
+	struct ll_task_pdata *ll_pdata;
+	uint32_t flags;
+
+	irq_local_disable(flags);
+
+	/* release the resources */
+	task->state = SOF_TASK_STATE_FREE;
+	ll_pdata = ll_sch_get_pdata(task);
+	rfree(ll_pdata);
+	ll_sch_set_pdata(task, NULL);
+
+	irq_local_enable(flags);
+}
+
+static void schedule_ll_task_cancel(void *data, struct task *task)
+{
+	struct ll_schedule_data *sch = data;
+	struct list_item *tlist;
+	struct task *curr_task;
+	uint32_t flags;
+
+	irq_local_disable(flags);
+
+	/* check to see if we are scheduled */
+	list_for_item(tlist, &sch->tasks) {
+		curr_task = container_of(tlist, struct task, list);
+
+		/* found it */
+		if (curr_task == task) {
+			schedule_ll_domain_clear(sch);
+			break;
+		}
+	}
+
+	/* remove work from list */
+	task->state = SOF_TASK_STATE_CANCEL;
+	list_item_del(&task->list);
+
+	irq_local_enable(flags);
+}
+
+static void reschedule_ll_task(void *data, struct task *task, uint64_t start)
+{
+	struct ll_schedule_data *sch = data;
+	struct list_item *tlist;
+	struct task *curr_task;
+	uint32_t flags;
+	uint64_t time;
+
+	time = sch->domain->ticks_per_ms * start / 1000;
+
+	if (task->flags & SOF_SCHEDULE_FLAG_SYNC)
+		time += platform_timer_get(platform_timer);
+	else
+		time += sch->domain->last_tick;
+
+	irq_local_disable(flags);
+
+	/* check to see if we are already scheduled */
+	list_for_item(tlist, &sch->tasks) {
+		curr_task = container_of(tlist, struct task, list);
+		/* found it */
+		if (curr_task == task) {
+			/* set start time */
+			task->start = time;
+			goto out;
+		}
+	}
+
+	trace_ll_error("reschedule_ll_task() error: task not found");
+
+out:
+	irq_local_enable(flags);
+}
+
 static void scheduler_free_ll(void *data)
 {
 	struct ll_schedule_data *sch = data;
 	uint32_t flags;
 
 	irq_local_disable(flags);
-
-	timer_unregister(&sch->ts->timer,
-			 ll_shared_ctx->irq_arg[cpu_get_id()]);
 
 	notifier_unregister(&sch->notifier);
 
@@ -581,14 +389,72 @@ static void scheduler_free_ll(void *data)
 	irq_local_enable(flags);
 }
 
+static void ll_scheduler_recalculate_tasks(struct ll_schedule_data *sch,
+					   struct clock_notify_data *clk_data)
+{
+	uint64_t current = platform_timer_get(platform_timer);
+	struct list_item *tlist;
+	struct task *task;
+	uint64_t delta_ms;
+
+	list_for_item(tlist, &sch->tasks) {
+		task = container_of(tlist, struct task, list);
+		delta_ms = (task->start - current) /
+			clk_data->old_ticks_per_msec;
+
+		task->start = delta_ms ?
+			current + sch->domain->ticks_per_ms * delta_ms :
+			current + (sch->domain->ticks_per_ms >> 3);
+	}
+}
+
+static void ll_scheduler_notify(int message, void *data, void *event_data)
+{
+	struct ll_schedule_data *sch = data;
+	struct clock_notify_data *clk_data = event_data;
+	uint32_t flags;
+
+	irq_local_disable(flags);
+
+	/* we need to recalculate tasks when clock frequency changes */
+	if (message == CLOCK_NOTIFY_POST) {
+		sch->domain->ticks_per_ms = clock_ms_to_ticks(sch->domain->clk,
+							      1);
+		ll_scheduler_recalculate_tasks(sch, clk_data);
+	}
+
+	irq_local_enable(flags);
+}
+
+int scheduler_init_ll(struct ll_schedule_domain *domain)
+{
+	struct ll_schedule_data *sch;
+
+	/* initialize scheduler private data */
+	sch = rzalloc(RZONE_SYS, SOF_MEM_CAPS_RAM, sizeof(*sch));
+	list_init(&sch->tasks);
+	atomic_init(&sch->num_tasks, 0);
+	sch->domain = domain;
+
+	/* notification of clock changes */
+	sch->notifier.cb = ll_scheduler_notify;
+	sch->notifier.cb_data = sch;
+	sch->notifier.id = NOTIFIER_CLK_CHANGE_ID(domain->clk);
+	notifier_register(&sch->notifier);
+
+	scheduler_init(domain->type, &schedule_ll_ops, sch);
+
+	return 0;
+}
+
 struct scheduler_ops schedule_ll_ops = {
 	.schedule_task		= schedule_ll_task,
 	.schedule_task_init	= schedule_ll_task_init,
+	.schedule_task_free	= schedule_ll_task_free,
+	.schedule_task_cancel	= schedule_ll_task_cancel,
+	.reschedule_task	= reschedule_ll_task,
+	.scheduler_free		= scheduler_free_ll,
 	.schedule_task_running	= NULL,
 	.schedule_task_complete	= NULL,
-	.reschedule_task	= reschedule_ll_task,
-	.schedule_task_cancel	= schedule_ll_task_cancel,
-	.schedule_task_free	= schedule_ll_task_free,
-	.scheduler_free		= scheduler_free_ll,
 	.scheduler_run		= NULL
 };

--- a/src/schedule/timer_domain.c
+++ b/src/schedule/timer_domain.c
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2019 Intel Corporation. All rights reserved.
+//
+// Author: Tomasz Lauda <tomasz.lauda@linux.intel.com>
+
+#include <sof/drivers/timer.h>
+#include <sof/lib/alloc.h>
+#include <sof/lib/cpu.h>
+#include <sof/platform.h>
+#include <sof/schedule/ll_schedule_domain.h>
+#include <sof/schedule/schedule.h>
+#include <sof/schedule/task.h>
+#include <ipc/topology.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+struct timer_domain {
+	struct timer *timer;
+	uint64_t timeout;
+	void *arg[PLATFORM_CORE_COUNT];
+};
+
+struct ll_schedule_domain_ops timer_domain_ops;
+
+static int timer_domain_register(struct ll_schedule_domain *domain,
+				 uint64_t period, struct task *task,
+				 void (*handler)(void *arg), void *arg)
+{
+	struct timer_domain *timer_domain = ll_sch_domain_get_pdata(domain);
+	int core = cpu_get_id();
+
+	/* tasks already registered on this core */
+	if (timer_domain->arg[core])
+		return 0;
+
+	timer_domain->arg[core] = arg;
+
+	return timer_register(timer_domain->timer, handler, arg);
+}
+
+static void timer_domain_unregister(struct ll_schedule_domain *domain,
+				    uint32_t num_tasks)
+{
+	struct timer_domain *timer_domain = ll_sch_domain_get_pdata(domain);
+	int core = cpu_get_id();
+
+	/* tasks still registered on this core */
+	if (!timer_domain->arg[core] || num_tasks)
+		return;
+
+	timer_unregister(timer_domain->timer, timer_domain->arg[core]);
+
+	timer_domain->arg[core] = NULL;
+}
+
+static void timer_domain_enable(struct ll_schedule_domain *domain, int core)
+{
+	struct timer_domain *timer_domain = ll_sch_domain_get_pdata(domain);
+
+	timer_enable(timer_domain->timer, timer_domain->arg[core], core);
+}
+
+static void timer_domain_disable(struct ll_schedule_domain *domain, int core)
+{
+	struct timer_domain *timer_domain = ll_sch_domain_get_pdata(domain);
+
+	timer_disable(timer_domain->timer, timer_domain->arg[core], core);
+}
+
+static void timer_domain_set(struct ll_schedule_domain *domain, uint64_t start)
+{
+	struct timer_domain *timer_domain = ll_sch_domain_get_pdata(domain);
+	uint64_t ticks = domain->ticks_per_ms * timer_domain->timeout / 1000 +
+		start;
+
+	platform_timer_set(timer_domain->timer, ticks);
+
+	domain->last_tick = ticks;
+}
+
+static void timer_domain_clear(struct ll_schedule_domain *domain)
+{
+	struct timer_domain *timer_domain = ll_sch_domain_get_pdata(domain);
+
+	platform_timer_clear(timer_domain->timer);
+}
+
+static bool timer_domain_is_pending(struct ll_schedule_domain *domain,
+				    struct task *task)
+{
+	return task->start <= platform_timer_get(platform_timer);
+}
+
+struct ll_schedule_domain *timer_domain_init(struct timer *timer, int clk,
+					     uint64_t timeout)
+{
+	struct ll_schedule_domain *domain;
+	struct timer_domain *timer_domain;
+
+	domain = domain_init(SOF_SCHEDULE_LL, clk, &timer_domain_ops);
+
+	timer_domain = rzalloc(RZONE_SYS | RZONE_FLAG_UNCACHED,
+			       SOF_MEM_CAPS_RAM, sizeof(*timer_domain));
+	timer_domain->timer = timer;
+	timer_domain->timeout = timeout;
+
+	ll_sch_domain_set_pdata(domain, timer_domain);
+
+	return domain;
+}
+
+struct ll_schedule_domain_ops timer_domain_ops = {
+	.domain_register	= timer_domain_register,
+	.domain_unregister	= timer_domain_unregister,
+	.domain_enable		= timer_domain_enable,
+	.domain_disable		= timer_domain_disable,
+	.domain_set		= timer_domain_set,
+	.domain_clear		= timer_domain_clear,
+	.domain_is_pending	= timer_domain_is_pending
+};


### PR DESCRIPTION
This patch introduces new structure called ll_schedule_domain.
It will be used to initialize ll scheduler with different
types of scheduling time domains. Right now it's only working
based on timer interrupts, but will be extended.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>