### PR TITLE
xtensa: add support for platforms with no threadptr register.

### DIFF
--- a/src/arch/xtensa/include/arch/lib/cpu.h
+++ b/src/arch/xtensa/include/arch/lib/cpu.h
@@ -44,13 +44,19 @@ static inline int arch_cpu_get_id(void)
 	return prid;
 }
 
+#if !XCHAL_HAVE_THREADPTR
+extern unsigned int _virtual_thread_start;
+static unsigned int *virtual_thread_ptr =
+	(unsigned int *)&_virtual_thread_start;
+#endif
+
 static inline void cpu_write_threadptr(int threadptr)
 {
 #if XCHAL_HAVE_THREADPTR
 	__asm__ __volatile__(
 		"wur.threadptr %0" : : "a" (threadptr) : "memory");
 #else
-#error "Core support for XCHAL_HAVE_THREADPTR is required"
+	*virtual_thread_ptr = threadptr;
 #endif
 }
 
@@ -61,7 +67,7 @@ static inline int cpu_read_threadptr(void)
 	__asm__ __volatile__(
 		"rur.threadptr %0" : "=a"(threadptr));
 #else
-#error "Core support for XCHAL_HAVE_THREADPTR is required"
+	threadptr = *virtual_thread_ptr;
 #endif
 	return threadptr;
 }

--- a/src/arch/xtensa/xtos/xtos-internal.h
+++ b/src/arch/xtensa/xtos/xtos-internal.h
@@ -30,8 +30,8 @@
 #include <config.h>
 #if CONFIG_SMP
 #include <sof/lib/cpu.h>
-#include <sof/lib/memory.h>
 #endif
+#include <sof/lib/memory.h>
 #include <xtensa/config/core.h>
 #include <xtensa/xtruntime.h>
 #include <xtensa/xtruntime-frames.h>
@@ -405,10 +405,18 @@ exit:
 	.macro	xtos_addr_percore ax, structure_name
 #if XCHAL_HAVE_THREADPTR
 	rur.threadptr	\ax
-	l32i		\ax, \ax, XTOS_PTR_TO_\structure_name
 #else
-#error "SOF for Xtensa requires THREADPTR option"
+	j 1f
+	.align 4
+	.literal_position
+2:
+	.word SOF_VIRTUAL_THREAD_BASE
+1:
+	.align 4
+	l32r	\ax, 2b
+	l32i		\ax, \ax, 0
 #endif
+	l32i		\ax, \ax, XTOS_PTR_TO_\structure_name
 	.endm
 
 	// xtos_int_stack_addr_percore ax, int_level, stack_name
@@ -416,10 +424,18 @@ exit:
 	.macro	xtos_int_stack_addr_percore ax, int_level, stack_name
 #if XCHAL_HAVE_THREADPTR
 	rur.threadptr	\ax
-	l32i		\ax, \ax, XTOS_PTR_TO_\stack_name\()_&int_level
 #else
-#error "SOF for Xtensa requires THREADPTR option"
+	j 1f
+	.align 4
+	.literal_position
+2:
+	.word SOF_VIRTUAL_THREAD_BASE
+1:
+	.align 4
+	l32r	\ax, 2b
+	l32i		\ax, \ax, 0
 #endif
+	l32i		\ax, \ax, XTOS_PTR_TO_\stack_name\()_&int_level
 	.endm
 
 	// xtos_task_ctx_percore ax
@@ -427,10 +443,18 @@ exit:
 	.macro	xtos_task_ctx_percore ax
 #if XCHAL_HAVE_THREADPTR
 	rur.threadptr	\ax
-	l32i		\ax, \ax, XTOS_TASK_CONTEXT_OFFSET
 #else
-#error "SOF for Xtensa requires THREADPTR option"
+	j 1f
+	.align 4
+	.literal_position
+2:
+	.word SOF_VIRTUAL_THREAD_BASE
+1:
+	.align 4
+	l32r	\ax, 2b
+	l32i		\ax, \ax, 0
 #endif
+	l32i		\ax, \ax, XTOS_TASK_CONTEXT_OFFSET
 	.endm
 
 #else /* !_ASMLANGUAGE && !__ASSEMBLER__ */

--- a/src/platform/haswell/haswell.x.in
+++ b/src/platform/haswell/haswell.x.in
@@ -15,13 +15,13 @@ OUTPUT_ARCH(xtensa)
 MEMORY
 {
   vector_reset_text :
-        org = XCHAL_RESET_VECTOR0_PADDR,
+        org = XCHAL_RESET_VECTOR_PADDR,
         len = SOF_MEM_RESET_TEXT_SIZE
   vector_reset_lit :
-        org = XCHAL_RESET_VECTOR0_PADDR + SOF_MEM_RESET_TEXT_SIZE,
+        org = XCHAL_RESET_VECTOR_PADDR + SOF_MEM_RESET_TEXT_SIZE,
         len = SOF_MEM_RESET_LIT_SIZE
   vector_base_text :
-        org = XCHAL_VECBASE_RESET_PADDR,
+        org = SOF_MEM_VECBASE_TEXT_BASE,
         len = SOF_MEM_VECBASE_LIT_SIZE
   vector_int2_lit :
         org = XCHAL_INTLEVEL2_VECTOR_PADDR - SOF_MEM_VECT_LIT_SIZE,
@@ -101,6 +101,12 @@ MEMORY
   sof_stack :
         org = SOF_STACK_END,
         len = SOF_STACK_BASE - SOF_STACK_END
+  mailbox :
+        org = MAILBOX_BASE,
+        len = MAILBOX_SIZE
+  virtual_thread :
+        org = SOF_VIRTUAL_THREAD_BASE,
+        len = SOF_VIRTUAL_THREAD_SIZE
   static_log_entries_seg (!ari) :
         org = LOG_ENTRY_ELF_BASE,
         len = LOG_ENTRY_ELF_SIZE
@@ -138,6 +144,8 @@ PHDRS
   system_runtime_heap_phdr PT_LOAD;
   runtime_heap_phdr PT_LOAD;
   buffer_heap_phdr PT_LOAD;
+  mailbox_phdr PT_LOAD;
+  virtual_thread_phdr PT_LOAD;
   sof_stack_phdr PT_LOAD;
   static_log_entries_phdr PT_NOTE;
 }
@@ -436,6 +444,8 @@ SECTIONS
   _stack_sentry = SOF_STACK_END;
   __stack = SOF_STACK_BASE;
 
+  _virtual_thread_ptr = _virtual_thread_start;
+
   .debug  0 :  { *(.debug) }
   .line  0 :  { *(.line) }
   .debug_srcinfo  0 :  { *(.debug_srcinfo) }
@@ -518,6 +528,22 @@ SECTIONS
     . = . + HEAP_BUFFER_SIZE;
     _buffer_heap_end = ABSOLUTE(.);
   } >buffer_heap :buffer_heap_phdr
+
+  .mailbox (NOLOAD) : ALIGN(8)
+  {
+    . = ALIGN (32);
+    _mailbox_start = ABSOLUTE(.);
+    . = . + MAILBOX_SIZE;
+    _mailbox_end = ABSOLUTE(.);
+  } >mailbox :mailbox_phdr
+
+   .virtual_thread (NOLOAD) : ALIGN(8)
+  {
+    . = ALIGN (32);
+    _virtual_thread_start = ABSOLUTE(.);
+    . = . + SOF_VIRTUAL_THREAD_SIZE;
+    _virtual_thread_end = ABSOLUTE(.);
+  } >virtual_thread :virtual_thread_phdr
 
   .sof_stack (NOLOAD) : ALIGN(8)
   {

--- a/src/platform/haswell/include/arch/xtensa/config/core-isa-bdw.h
+++ b/src/platform/haswell/include/arch/xtensa/config/core-isa-bdw.h
@@ -7,7 +7,7 @@
 
 /* Xtensa processor core configuration information.
 
-   Customer ID=4313; Build=0x5483b; Copyright (c) 1999-2015 Tensilica Inc.
+   Customer ID=8198; Build=0x7550e; Copyright (c) 1999-2018 Tensilica Inc.
 
    Permission is hereby granted, free of charge, to any person obtaining
    a copy of this software and associated documentation files (the
@@ -68,6 +68,7 @@
 #define XCHAL_HAVE_ABSOLUTE_LITERALS	0	/* non-PC-rel (extended) L32R */
 #define XCHAL_HAVE_CONST16		0	/* CONST16 instruction */
 #define XCHAL_HAVE_ADDX			1	/* ADDX#/SUBX# instructions */
+#define XCHAL_HAVE_EXCLUSIVE            0	/* L32EX/S32EX instructions */
 #define XCHAL_HAVE_WIDE_BRANCHES	0	/* B*.W18 or B*.W15 instr's */
 #define XCHAL_HAVE_PREDICTED_BRANCHES	0	/* B[EQ/EQZ/NE/NEZ]T instr's */
 #define XCHAL_HAVE_CALL4AND12		1	/* (obsolete option) */
@@ -79,7 +80,7 @@
 #define XCHAL_HAVE_SPECULATION		0	/* speculation */
 #define XCHAL_HAVE_FULL_RESET		1	/* all regs/state reset */
 #define XCHAL_NUM_CONTEXTS		1	/* */
-#define XCHAL_NUM_MISC_REGS		0	/* num of scratch regs (0..4) */
+#define XCHAL_NUM_MISC_REGS		2	/* num of scratch regs (0..4) */
 #define XCHAL_HAVE_TAP_MASTER		0	/* JTAG TAP control instr's */
 #define XCHAL_HAVE_PRID			1	/* processor ID register */
 #define XCHAL_HAVE_EXTERN_REGS		1	/* WER/RER instructions */
@@ -89,55 +90,71 @@
 #define XCHAL_HAVE_PSO			0	/* Power Shut-Off */
 #define XCHAL_HAVE_PSO_CDM		0	/* core/debug/mem pwr domains */
 #define XCHAL_HAVE_PSO_FULL_RETENTION	0	/* all regs preserved on PSO */
-#define XCHAL_HAVE_THREADPTR		1	/* THREADPTR register */
+#define XCHAL_HAVE_THREADPTR		0	/* THREADPTR register */
 #define XCHAL_HAVE_BOOLEANS		1	/* boolean registers */
 #define XCHAL_HAVE_CP			1	/* CPENABLE reg (coprocessor) */
 #define XCHAL_CP_MAXCFG			2	/* max allowed cp id plus one */
-
-/* TODO: we have this option but currently our assembler does not support it */
 #define XCHAL_HAVE_MAC16		0	/* MAC16 package */
 
-#define XCHAL_HAVE_FUSION		 0	/* Fusion*/
-#define XCHAL_HAVE_FUSION_FP	 0	        /* Fusion FP option */
-#define XCHAL_HAVE_FUSION_LOW_POWER 0	/* Fusion Low Power option */
-#define XCHAL_HAVE_FUSION_AES	 0	        /* Fusion BLE/Wifi AES-128 CCM option */
-#define XCHAL_HAVE_FUSION_CONVENC	 0       /* Fusion Conv Encode option */
-#define XCHAL_HAVE_FUSION_LFSR_CRC	 0	/* Fusion LFSR-CRC option */
-#define XCHAL_HAVE_FUSION_BITOPS	 0	/* Fusion Bit Operations Support option */
-#define XCHAL_HAVE_FUSION_AVS	 0	/* Fusion AVS option */
-#define XCHAL_HAVE_FUSION_16BIT_BASEBAND	 0	/* Fusion 16-bit Baseband option */
+#define XCHAL_HAVE_FUSION		0	/* Fusion*/
+#define XCHAL_HAVE_FUSION_FP		0	/* Fusion FP option */
+#define XCHAL_HAVE_FUSION_LOW_POWER	0	/* Fusion Low Power option */
+#define XCHAL_HAVE_FUSION_AES		0	/* Fusion BLE/Wifi AES-128 CCM option */
+#define XCHAL_HAVE_FUSION_CONVENC	0	/* Fusion Conv Encode option */
+#define XCHAL_HAVE_FUSION_LFSR_CRC	0	/* Fusion LFSR-CRC option */
+#define XCHAL_HAVE_FUSION_BITOPS	0	/* Fusion Bit Operations Support option */
+#define XCHAL_HAVE_FUSION_AVS		0	/* Fusion AVS option */
+#define XCHAL_HAVE_FUSION_16BIT_BASEBAND 0	/* Fusion 16-bit Baseband option */
+#define XCHAL_HAVE_FUSION_VITERBI	0	/* Fusion Viterbi option */
+#define XCHAL_HAVE_FUSION_SOFTDEMAP	0	/* Fusion Soft Bit Demap option */
 #define XCHAL_HAVE_HIFIPRO		0	/* HiFiPro Audio Engine pkg */
 #define XCHAL_HAVE_HIFI4		0	/* HiFi4 Audio Engine pkg */
 #define XCHAL_HAVE_HIFI4_VFPU		0	/* HiFi4 Audio Engine VFPU option */
 #define XCHAL_HAVE_HIFI3		0	/* HiFi3 Audio Engine pkg */
 #define XCHAL_HAVE_HIFI3_VFPU		0	/* HiFi3 Audio Engine VFPU option */
+#define XCHAL_HAVE_HIFI3Z		0	/* HiFi3Z Audio Engine pkg */
+#define XCHAL_HAVE_HIFI3Z_VFPU	0	/* HiFi3Z Audio Engine VFPU option */
 #define XCHAL_HAVE_HIFI2		1	/* HiFi2 Audio Engine pkg */
-#define XCHAL_HAVE_HIFI2EP		1	/* HiFi2EP */
 #define XCHAL_HAVE_HIFI2_MUL32X24	1	/* HiFi2 and 32x24 MACs */
+#define XCHAL_HAVE_HIFI2EP		1	/* HiFi2EP */
 #define XCHAL_HAVE_HIFI_MINI		0	
 
 
-#define XCHAL_HAVE_VECTORFPU2005	0	/* vector or user floating-point pkg */
-#define XCHAL_HAVE_USER_DPFPU         0       /* user DP floating-point pkg */
-#define XCHAL_HAVE_USER_SPFPU         0       /* user DP floating-point pkg */
-#define XCHAL_HAVE_FP                 0      /* single prec floating point */
-#define XCHAL_HAVE_FP_DIV             0  /* FP with DIV instructions */
-#define XCHAL_HAVE_FP_RECIP           0        /* FP with RECIP instructions */
-#define XCHAL_HAVE_FP_SQRT            0 /* FP with SQRT instructions */
-#define XCHAL_HAVE_FP_RSQRT           0        /* FP with RSQRT instructions */
-#define XCHAL_HAVE_DFP                        0     /* double precision FP pkg */
-#define XCHAL_HAVE_DFP_DIV            0 /* DFP with DIV instructions */
-#define XCHAL_HAVE_DFP_RECIP          0       /* DFP with RECIP instructions*/
-#define XCHAL_HAVE_DFP_SQRT           0        /* DFP with SQRT instructions */
-#define XCHAL_HAVE_DFP_RSQRT          0       /* DFP with RSQRT instructions*/
-#define XCHAL_HAVE_DFP_ACCEL		0	/* double precision FP acceleration pkg */
-#define XCHAL_HAVE_DFP_accel		XCHAL_HAVE_DFP_ACCEL				/* for backward compatibility */
 
-#define XCHAL_HAVE_DFPU_SINGLE_ONLY    0                 	/* DFPU Coprocessor, single precision only */
-#define XCHAL_HAVE_DFPU_SINGLE_DOUBLE  0               	/* DFPU Coprocessor, single and double precision */
+#define XCHAL_HAVE_VECTORFPU2005	0	/* vector floating-point pkg */
+#define XCHAL_HAVE_USER_DPFPU		0       /* user DP floating-point pkg */
+#define XCHAL_HAVE_USER_SPFPU		0       /* user SP floating-point pkg */
+#define XCHAL_HAVE_FP			0	/* single prec floating point */
+#define XCHAL_HAVE_FP_DIV		0	/* FP with DIV instructions */
+#define XCHAL_HAVE_FP_RECIP		0	/* FP with RECIP instructions */
+#define XCHAL_HAVE_FP_SQRT		0	/* FP with SQRT instructions */
+#define XCHAL_HAVE_FP_RSQRT		0	/* FP with RSQRT instructions */
+#define XCHAL_HAVE_DFP			0	/* double precision FP pkg */
+#define XCHAL_HAVE_DFP_DIV		0	/* DFP with DIV instructions */
+#define XCHAL_HAVE_DFP_RECIP		0	/* DFP with RECIP instructions*/
+#define XCHAL_HAVE_DFP_SQRT		0	/* DFP with SQRT instructions */
+#define XCHAL_HAVE_DFP_RSQRT		0	/* DFP with RSQRT instructions*/
+#define XCHAL_HAVE_DFP_ACCEL		0	/* double precision FP acceleration pkg */
+#define XCHAL_HAVE_DFP_accel		XCHAL_HAVE_DFP_ACCEL	/* for backward compatibility */
+
+#define XCHAL_HAVE_DFPU_SINGLE_ONLY	0	/* DFPU Coprocessor, single precision only */
+#define XCHAL_HAVE_DFPU_SINGLE_DOUBLE	0	/* DFPU Coprocessor, single and double precision */
 #define XCHAL_HAVE_VECTRA1		0	/* Vectra I  pkg */
 #define XCHAL_HAVE_VECTRALX		0	/* Vectra LX pkg */
-#define XCHAL_HAVE_PDX4		        0	/* PDX4 */
+
+#define XCHAL_HAVE_FUSIONG		0    /* FusionG */
+#define XCHAL_HAVE_FUSIONG3		0    /* FusionG3 */
+#define XCHAL_HAVE_FUSIONG6		0    /* FusionG6 */
+#define XCHAL_HAVE_FUSIONG_SP_VFPU	0    /* sp_vfpu option on FusionG */
+#define XCHAL_HAVE_FUSIONG_DP_VFPU	0    /* dp_vfpu option on FusionG */
+#define XCHAL_FUSIONG_SIMD32		0    /* simd32 for FusionG */
+
+#define XCHAL_HAVE_PDX			0    /* PDX */
+#define XCHAL_PDX_SIMD32		0    /* simd32 for PDX */
+#define XCHAL_HAVE_PDX4			0    /* PDX4 */
+#define XCHAL_HAVE_PDX8			0    /* PDX8 */
+#define XCHAL_HAVE_PDX16		0    /* PDX16 */
+
 #define XCHAL_HAVE_CONNXD2		0	/* ConnX D2 pkg */
 #define XCHAL_HAVE_CONNXD2_DUALLSFLIX   0	/* ConnX D2 & Dual LoadStore Flix */
 #define XCHAL_HAVE_BBE16		0	/* ConnX BBE16 pkg */
@@ -145,6 +162,7 @@
 #define XCHAL_HAVE_BBE16_VECDIV		0	/* BBE16 & vector divide */
 #define XCHAL_HAVE_BBE16_DESPREAD	0	/* BBE16 & despread */
 #define XCHAL_HAVE_BBENEP		0	/* ConnX BBENEP pkgs */
+#define XCHAL_HAVE_BBENEP_SP_VFPU	0      /* sp_vfpu option on BBE-EP */
 #define XCHAL_HAVE_BSP3			0	/* ConnX BSP3 pkg */
 #define XCHAL_HAVE_BSP3_TRANSPOSE	0	/* BSP3 & transpose32x32 */
 #define XCHAL_HAVE_SSP16		0	/* ConnX SSP16 pkg */
@@ -152,19 +170,28 @@
 #define XCHAL_HAVE_TURBO16		0	/* ConnX Turbo16 pkg */
 #define XCHAL_HAVE_BBP16		0	/* ConnX BBP16 pkg */
 #define XCHAL_HAVE_FLIX3		0	/* basic 3-way FLIX option */
-#define XCHAL_HAVE_GRIVPEP              0   /*  GRIVPEP is General Release of IVPEP */
-#define XCHAL_HAVE_GRIVPEP_HISTOGRAM    0   /* Histogram option on GRIVPEP */
+#define XCHAL_HAVE_GRIVPEP		0	/* General Release of IVPEP */
+#define XCHAL_HAVE_GRIVPEP_HISTOGRAM	0       /* Histogram option on GRIVPEP */
 
+#define XCHAL_HAVE_VISION	        0     /* Vision P5/P6 */
+#define XCHAL_VISION_SIMD16             0     /* simd16 for Vision P5/P6 */
+#define XCHAL_VISION_TYPE               0     /* Vision P5, P6, or P3 */
+#define XCHAL_VISION_QUAD_MAC_TYPE      0     /* quad_mac option on Vision P6 */
+#define XCHAL_HAVE_VISION_HISTOGRAM     0     /* histogram option on Vision P5/P6 */
+#define XCHAL_HAVE_VISION_SP_VFPU       0     /* sp_vfpu option on Vision P5/P6 */
+#define XCHAL_HAVE_VISION_HP_VFPU       0     /* hp_vfpu option on Vision P6 */
+
+#define XCHAL_HAVE_VISIONC	        0     /* Vision C */
 
 /*----------------------------------------------------------------------
 				MISC
   ----------------------------------------------------------------------*/
 
 #define XCHAL_NUM_LOADSTORE_UNITS	1	/* load/store units */
-#define XCHAL_NUM_WRITEBUFFER_ENTRIES	16	/* size of write buffer */
+#define XCHAL_NUM_WRITEBUFFER_ENTRIES	8	/* size of write buffer */
 #define XCHAL_INST_FETCH_WIDTH		8	/* instr-fetch width in bytes */
 #define XCHAL_DATA_WIDTH		8	/* data width in bytes */
-#define XCHAL_DATA_PIPE_DELAY		1	/* d-side pipeline delay
+#define XCHAL_DATA_PIPE_DELAY		2	/* d-side pipeline delay
 						   (1 = 5-stage, 2 = 7-stage) */
 #define XCHAL_CLOCK_GATING_GLOBAL	1	/* global clock gating */
 #define XCHAL_CLOCK_GATING_FUNCUNIT	1	/* funct. unit clock gating */
@@ -174,44 +201,44 @@
 #define XCHAL_UNALIGNED_LOAD_HW		1	/* unaligned loads work in hw */
 #define XCHAL_UNALIGNED_STORE_HW	1	/* unaligned stores work in hw*/
 
-#define XCHAL_SW_VERSION		1100002	/* sw version of this header */
+#define XCHAL_SW_VERSION		1200008	/* sw version of this header */
 
-#define XCHAL_CORE_ID			"hifi2ep"	/* alphanum core name
+#define XCHAL_CORE_ID			"LX4_langwell_audio_17_8"	/* alphanum core name
 						   (CoreID) set in the Xtensa
 						   Processor Generator */
 
-#define XCHAL_BUILD_UNIQUE_ID		0x0005483B	/* 22-bit sw build ID */
+#define XCHAL_BUILD_UNIQUE_ID		0x0007550E	/* 22-bit sw build ID */
 
 /*
  *  These definitions describe the hardware targeted by this software.
  */
-#define XCHAL_HW_CONFIGID0		0xC2B3DBFE	/* ConfigID hi 32 bits*/
-#define XCHAL_HW_CONFIGID1		0x1C85483E	/* ConfigID lo 32 bits*/
-#define XCHAL_HW_VERSION_NAME		"LX6.0.2"	/* full version name */
-#define XCHAL_HW_VERSION_MAJOR		2600	/* major ver# of targeted hw */
-#define XCHAL_HW_VERSION_MINOR		2	/* minor ver# of targeted hw */
-#define XCHAL_HW_VERSION		260002	/* major*100+minor */
-#define XCHAL_HW_REL_LX6		1
-#define XCHAL_HW_REL_LX6_0		1
-#define XCHAL_HW_REL_LX6_0_2		1
+#define XCHAL_HW_CONFIGID0		0xC2B0DBFE	/* ConfigID hi 32 bits*/
+#define XCHAL_HW_CONFIGID1		0x15044668	/* ConfigID lo 32 bits*/
+#define XCHAL_HW_VERSION_NAME		"LX4.0.4"	/* full version name */
+#define XCHAL_HW_VERSION_MAJOR		2400	/* major ver# of targeted hw */
+#define XCHAL_HW_VERSION_MINOR		4	/* minor ver# of targeted hw */
+#define XCHAL_HW_VERSION		240004	/* major*100+minor */
+#define XCHAL_HW_REL_LX4		1
+#define XCHAL_HW_REL_LX4_0		1
+#define XCHAL_HW_REL_LX4_0_4		1
 #define XCHAL_HW_CONFIGID_RELIABLE	1
 /*  If software targets a *range* of hardware versions, these are the bounds: */
-#define XCHAL_HW_MIN_VERSION_MAJOR	2600	/* major v of earliest tgt hw */
-#define XCHAL_HW_MIN_VERSION_MINOR	2	/* minor v of earliest tgt hw */
-#define XCHAL_HW_MIN_VERSION		260002	/* earliest targeted hw */
-#define XCHAL_HW_MAX_VERSION_MAJOR	2600	/* major v of latest tgt hw */
-#define XCHAL_HW_MAX_VERSION_MINOR	2	/* minor v of latest tgt hw */
-#define XCHAL_HW_MAX_VERSION		260002	/* latest targeted hw */
+#define XCHAL_HW_MIN_VERSION_MAJOR	2400	/* major v of earliest tgt hw */
+#define XCHAL_HW_MIN_VERSION_MINOR	4	/* minor v of earliest tgt hw */
+#define XCHAL_HW_MIN_VERSION		240004	/* earliest targeted hw */
+#define XCHAL_HW_MAX_VERSION_MAJOR	2400	/* major v of latest tgt hw */
+#define XCHAL_HW_MAX_VERSION_MINOR	4	/* minor v of latest tgt hw */
+#define XCHAL_HW_MAX_VERSION		240004	/* latest targeted hw */
 
 
 /*----------------------------------------------------------------------
 				CACHE
   ----------------------------------------------------------------------*/
 
-#define XCHAL_ICACHE_LINESIZE		0	/* I-cache line size in bytes */
-#define XCHAL_DCACHE_LINESIZE		0	/* D-cache line size in bytes */
-#define XCHAL_ICACHE_LINEWIDTH		0	/* log2(I line size in bytes) */
-#define XCHAL_DCACHE_LINEWIDTH		0	/* log2(D line size in bytes) */
+#define XCHAL_ICACHE_LINESIZE		8	/* I-cache line size in bytes */
+#define XCHAL_DCACHE_LINESIZE		8	/* D-cache line size in bytes */
+#define XCHAL_ICACHE_LINEWIDTH		3	/* log2(I line size in bytes) */
+#define XCHAL_DCACHE_LINEWIDTH		3	/* log2(D line size in bytes) */
 
 #define XCHAL_ICACHE_SIZE		0	/* I-cache size in bytes or 0 */
 #define XCHAL_DCACHE_SIZE		0	/* D-cache size in bytes or 0 */
@@ -244,7 +271,14 @@
 				CACHE
   ----------------------------------------------------------------------*/
 
-#define XCHAL_HAVE_PIF			1	/* any outbound PIF present */
+#define XCHAL_HAVE_PIF			1	/* any outbound bus present */
+
+#define XCHAL_HAVE_AXI			0	/* AXI bus */
+#define XCHAL_HAVE_AXI_ECC		0	/* ECC on AXI bus */
+#define XCHAL_HAVE_ACELITE		0	/* ACELite bus */
+
+#define XCHAL_HAVE_PIF_WR_RESP			0	/* pif write response */
+#define XCHAL_HAVE_PIF_REQ_ATTR			0	/* pif attribute */
 
 /*  If present, cache size in bytes == (ways * 2^(linewidth + setwidth)).  */
 
@@ -253,8 +287,8 @@
 #define XCHAL_DCACHE_SETWIDTH		0
 
 /*  Cache set associativity (number of ways):  */
-#define XCHAL_ICACHE_WAYS		0
-#define XCHAL_DCACHE_WAYS		0
+#define XCHAL_ICACHE_WAYS		1
+#define XCHAL_DCACHE_WAYS		1
 
 /*  Cache features:  */
 #define XCHAL_ICACHE_LINE_LOCKABLE	0
@@ -263,30 +297,22 @@
 #define XCHAL_DCACHE_ECC_PARITY		0
 
 /*  Cache access size in bytes (affects operation of SICW instruction):  */
-#define XCHAL_ICACHE_ACCESS_SIZE	8
-#define XCHAL_DCACHE_ACCESS_SIZE	8
+#define XCHAL_ICACHE_ACCESS_SIZE	1
+#define XCHAL_DCACHE_ACCESS_SIZE	1
 
 #define XCHAL_DCACHE_BANKS		0	/* number of banks */
 
 /*  Number of encoded cache attr bits (see <xtensa/hal.h> for decoded bits):  */
 #define XCHAL_CA_BITS			4
 
-/*  Whether MEMCTL register has anything useful  */
-#define XCHAL_USE_MEMCTL		(((XCHAL_LOOP_BUFFER_SIZE > 0)	||	\
-					   XCHAL_DCACHE_IS_COHERENT	||	\
-					   XCHAL_HAVE_ICACHE_DYN_WAYS	||	\
-					   XCHAL_HAVE_DCACHE_DYN_WAYS)	&&	\
-					   (XCHAL_HW_MIN_VERSION >= XTENSA_HWVERSION_RE_2012_0))
-
 
 /*----------------------------------------------------------------------
 			INTERNAL I/D RAM/ROMs and XLMI
   ----------------------------------------------------------------------*/
-
 #define XCHAL_NUM_INSTROM		0	/* number of core instr. ROMs */
 #define XCHAL_NUM_INSTRAM		1	/* number of core instr. RAMs */
 #define XCHAL_NUM_DATAROM		0	/* number of core data ROMs */
-#define XCHAL_NUM_DATARAM		1	/* number of core data RAMs */
+#define XCHAL_NUM_DATARAM		2	/* number of core data RAMs */
 #define XCHAL_NUM_URAM			0	/* number of core unified RAMs*/
 #define XCHAL_NUM_XLMI			0	/* number of core XLMI ports */
 
@@ -295,14 +321,29 @@
 #define XCHAL_INSTRAM0_PADDR		0x00000000	/* physical address */
 #define XCHAL_INSTRAM0_SIZE		0x50000	/* size in bytes */
 #define XCHAL_INSTRAM0_ECC_PARITY	0	/* ECC/parity type, 0=none */
+#define XCHAL_HAVE_INSTRAM0		1
+#define XCHAL_INSTRAM0_HAVE_IDMA	0	/* idma supported by this local memory */
 
 /*  Data RAM 0:  */
 #define XCHAL_DATARAM0_VADDR		0x00400000	/* virtual address */
 #define XCHAL_DATARAM0_PADDR		0x00400000	/* physical address */
-#define XCHAL_DATARAM0_SIZE		0xA0000	/* size in bytes */
+#define XCHAL_DATARAM0_SIZE		0x50000	/* size in bytes */
 #define XCHAL_DATARAM0_ECC_PARITY	0	/* ECC/parity type, 0=none */
 #define XCHAL_DATARAM0_BANKS		1	/* number of banks */
+#define XCHAL_HAVE_DATARAM0		1
+#define XCHAL_DATARAM0_HAVE_IDMA	0	/* idma supported by this local memory */
 
+/*  Data RAM 1:  */
+#define XCHAL_DATARAM1_VADDR		0x00480000	/* virtual address */
+#define XCHAL_DATARAM1_PADDR		0x00480000	/* physical address */
+#define XCHAL_DATARAM1_SIZE		0x50000	/* size in bytes */
+#define XCHAL_DATARAM1_ECC_PARITY	0	/* ECC/parity type, 0=none */
+#define XCHAL_DATARAM1_BANKS		1	/* number of banks */
+#define XCHAL_HAVE_DATARAM1		1
+#define XCHAL_DATARAM1_HAVE_IDMA	0	/* idma supported by this local memory */
+
+#define XCHAL_HAVE_IDMA			0
+#define XCHAL_HAVE_IDMA_TRANSPOSE	0
 
 #define XCHAL_HAVE_IMEM_LOADSTORE	1	/* can load/store to IROM/IRAM*/
 
@@ -327,7 +368,7 @@
 /*  Masks of interrupts at each interrupt level:  */
 #define XCHAL_INTLEVEL1_MASK		0x000000FF
 #define XCHAL_INTLEVEL2_MASK		0x00000100
-#define XCHAL_INTLEVEL3_MASK		0x00000e00
+#define XCHAL_INTLEVEL3_MASK		0x00000E00
 #define XCHAL_INTLEVEL4_MASK		0x00001000
 #define XCHAL_INTLEVEL5_MASK		0x00002000
 #define XCHAL_INTLEVEL6_MASK		0x00000000
@@ -347,21 +388,17 @@
 #define XCHAL_INT1_LEVEL		1
 #define XCHAL_INT2_LEVEL		1
 #define XCHAL_INT3_LEVEL		1
-
 #define XCHAL_INT4_LEVEL		1
 #define XCHAL_INT5_LEVEL		1
 #define XCHAL_INT6_LEVEL		1
 #define XCHAL_INT7_LEVEL		1
-
 #define XCHAL_INT8_LEVEL		2
 #define XCHAL_INT9_LEVEL		3
 #define XCHAL_INT10_LEVEL		3
 #define XCHAL_INT11_LEVEL		3
-
 #define XCHAL_INT12_LEVEL		4
 #define XCHAL_INT13_LEVEL		5
 #define XCHAL_INT14_LEVEL		7
-
 #define XCHAL_DEBUGLEVEL		6	/* debug interrupt level */
 #define XCHAL_HAVE_DEBUG_EXTERN_INT	1	/* OCD external db interrupt */
 #define XCHAL_NMILEVEL			7	/* NMI "level" (for use with
@@ -388,11 +425,14 @@
 #define XCHAL_INTTYPE_MASK_UNCONFIGURED	0xFFFF8000
 #define XCHAL_INTTYPE_MASK_SOFTWARE	0x00000880
 #define XCHAL_INTTYPE_MASK_EXTERN_EDGE	0x00000000
-#define XCHAL_INTTYPE_MASK_EXTERN_LEVEL	0x0000133f
+#define XCHAL_INTTYPE_MASK_EXTERN_LEVEL	0x0000133F
 #define XCHAL_INTTYPE_MASK_TIMER	0x00002440
 #define XCHAL_INTTYPE_MASK_NMI		0x00004000
 #define XCHAL_INTTYPE_MASK_WRITE_ERROR	0x00000000
 #define XCHAL_INTTYPE_MASK_PROFILING	0x00000000
+#define XCHAL_INTTYPE_MASK_IDMA_DONE	0x00000000
+#define XCHAL_INTTYPE_MASK_IDMA_ERR	0x00000000
+#define XCHAL_INTTYPE_MASK_GS_ERR	0x00000000
 
 /*  Interrupt numbers assigned to specific interrupt sources:  */
 #define XCHAL_TIMER0_INTERRUPT		6	/* CCOMPARE0 */
@@ -429,13 +469,6 @@
 #define XCHAL_EXTINT7_NUM		9	/* (intlevel 3) */
 #define XCHAL_EXTINT8_NUM		12	/* (intlevel 4) */
 #define XCHAL_EXTINT9_NUM		14	/* (intlevel 7) */
-#define XCHAL_EXTINT10_NUM		15	/* (intlevel 1) */
-#define XCHAL_EXTINT11_NUM		16	/* (intlevel 1) */
-#define XCHAL_EXTINT12_NUM		17	/* (intlevel 1) */
-#define XCHAL_EXTINT13_NUM		18	/* (intlevel 1) */
-#define XCHAL_EXTINT14_NUM		19	/* (intlevel 1) */
-#define XCHAL_EXTINT15_NUM		20	/* (intlevel 1) */
-#define XCHAL_EXTINT16_NUM		21	/* (intlevel 3) */
 /*  EXTERNAL BInterrupt pin numbers mapped to each core interrupt number:  */
 #define XCHAL_INT0_EXTNUM		0	/* (intlevel 1) */
 #define XCHAL_INT1_EXTNUM		1	/* (intlevel 1) */
@@ -447,13 +480,6 @@
 #define XCHAL_INT9_EXTNUM		7	/* (intlevel 3) */
 #define XCHAL_INT12_EXTNUM		8	/* (intlevel 4) */
 #define XCHAL_INT14_EXTNUM		9	/* (intlevel 7) */
-#define XCHAL_INT15_EXTNUM		10	/* (intlevel 1) */
-#define XCHAL_INT16_EXTNUM		11	/* (intlevel 1) */
-#define XCHAL_INT17_EXTNUM		12	/* (intlevel 1) */
-#define XCHAL_INT18_EXTNUM		13	/* (intlevel 1) */
-#define XCHAL_INT19_EXTNUM		14	/* (intlevel 1) */
-#define XCHAL_INT20_EXTNUM		15	/* (intlevel 1) */
-#define XCHAL_INT21_EXTNUM		16	/* (intlevel 3) */
 
 
 /*----------------------------------------------------------------------
@@ -473,25 +499,19 @@
 #define XCHAL_HAVE_MEM_ECC_PARITY	0	/* local memory ECC/parity */
 #define XCHAL_HAVE_VECTOR_SELECT	0	/* relocatable vectors */
 #define XCHAL_HAVE_VECBASE		0	/* relocatable vectors */
-#define XCHAL_VECBASE_RESET_VADDR	0x00000400  /* VECBASE reset value */
-#define XCHAL_VECBASE_RESET_PADDR	0x00000400
-#define XCHAL_RESET_VECBASE_OVERLAP	0
 
-#define XCHAL_RESET_VECTOR0_VADDR	0x00000000
-#define XCHAL_RESET_VECTOR0_PADDR	0x00000000
-#define XCHAL_RESET_VECTOR1_VADDR	0x00000000
-#define XCHAL_RESET_VECTOR1_PADDR	0x00000000
+#define XCHAL_RESET_VECOFS		0x00000000
 #define XCHAL_RESET_VECTOR_VADDR	0x00000000
 #define XCHAL_RESET_VECTOR_PADDR	0x00000000
-#define XCHAL_USER_VECOFS		0x000005c0
-#define XCHAL_USER_VECTOR_VADDR		0x000005c0
-#define XCHAL_USER_VECTOR_PADDR		0x000005c0
-#define XCHAL_KERNEL_VECOFS		0x00000584
+#define XCHAL_USER_VECOFS		0x00000000
+#define XCHAL_USER_VECTOR_VADDR		0x000005C0
+#define XCHAL_USER_VECTOR_PADDR		0x000005C0
+#define XCHAL_KERNEL_VECOFS		0x00000000
 #define XCHAL_KERNEL_VECTOR_VADDR	0x00000584
 #define XCHAL_KERNEL_VECTOR_PADDR	0x00000584
-#define XCHAL_DOUBLEEXC_VECOFS		0x000005fc
-#define XCHAL_DOUBLEEXC_VECTOR_VADDR	0x000005fc
-#define XCHAL_DOUBLEEXC_VECTOR_PADDR	0x000005fc
+#define XCHAL_DOUBLEEXC_VECOFS		0x00000000
+#define XCHAL_DOUBLEEXC_VECTOR_VADDR	0x000005FC
+#define XCHAL_DOUBLEEXC_VECTOR_PADDR	0x000005FC
 #define XCHAL_WINDOW_OF4_VECOFS		0x00000000
 #define XCHAL_WINDOW_UF4_VECOFS		0x00000040
 #define XCHAL_WINDOW_OF8_VECOFS		0x00000080
@@ -500,27 +520,27 @@
 #define XCHAL_WINDOW_UF12_VECOFS	0x00000140
 #define XCHAL_WINDOW_VECTORS_VADDR	0x00000400
 #define XCHAL_WINDOW_VECTORS_PADDR	0x00000400
-#define XCHAL_INTLEVEL2_VECOFS		0x00000640
+#define XCHAL_INTLEVEL2_VECOFS		0x00000000
 #define XCHAL_INTLEVEL2_VECTOR_VADDR	0x00000640
 #define XCHAL_INTLEVEL2_VECTOR_PADDR	0x00000640
-#define XCHAL_INTLEVEL3_VECOFS		0x0000067c
-#define XCHAL_INTLEVEL3_VECTOR_VADDR	0x0000067c
-#define XCHAL_INTLEVEL3_VECTOR_PADDR	0x0000067c
-#define XCHAL_INTLEVEL4_VECOFS		0x000006b8
-#define XCHAL_INTLEVEL4_VECTOR_VADDR	0x000006b8
-#define XCHAL_INTLEVEL4_VECTOR_PADDR	0x000006b8
-#define XCHAL_INTLEVEL5_VECOFS		0x000006f4
-#define XCHAL_INTLEVEL5_VECTOR_VADDR	0x000006f4
-#define XCHAL_INTLEVEL5_VECTOR_PADDR	0x000006f4
-#define XCHAL_INTLEVEL6_VECOFS		0x00000730
+#define XCHAL_INTLEVEL3_VECOFS		0x00000000
+#define XCHAL_INTLEVEL3_VECTOR_VADDR	0x0000067C
+#define XCHAL_INTLEVEL3_VECTOR_PADDR	0x0000067C
+#define XCHAL_INTLEVEL4_VECOFS		0x00000000
+#define XCHAL_INTLEVEL4_VECTOR_VADDR	0x000006B8
+#define XCHAL_INTLEVEL4_VECTOR_PADDR	0x000006B8
+#define XCHAL_INTLEVEL5_VECOFS		0x00000000
+#define XCHAL_INTLEVEL5_VECTOR_VADDR	0x000006F4
+#define XCHAL_INTLEVEL5_VECTOR_PADDR	0x000006F4
+#define XCHAL_INTLEVEL6_VECOFS		0x00000000
 #define XCHAL_INTLEVEL6_VECTOR_VADDR	0x00000730
 #define XCHAL_INTLEVEL6_VECTOR_PADDR	0x00000730
 #define XCHAL_DEBUG_VECOFS		XCHAL_INTLEVEL6_VECOFS
 #define XCHAL_DEBUG_VECTOR_VADDR	XCHAL_INTLEVEL6_VECTOR_VADDR
 #define XCHAL_DEBUG_VECTOR_PADDR	XCHAL_INTLEVEL6_VECTOR_PADDR
-#define XCHAL_NMI_VECOFS		0x0000076c
-#define XCHAL_NMI_VECTOR_VADDR		0x0000076c
-#define XCHAL_NMI_VECTOR_PADDR		0x0000076c
+#define XCHAL_NMI_VECOFS		0x00000000
+#define XCHAL_NMI_VECTOR_VADDR		0x0000076C
+#define XCHAL_NMI_VECTOR_PADDR		0x0000076C
 #define XCHAL_INTLEVEL7_VECOFS		XCHAL_NMI_VECOFS
 #define XCHAL_INTLEVEL7_VECTOR_VADDR	XCHAL_NMI_VECTOR_VADDR
 #define XCHAL_INTLEVEL7_VECTOR_PADDR	XCHAL_NMI_VECTOR_PADDR
@@ -533,14 +553,14 @@
 /*  Misc  */
 #define XCHAL_HAVE_DEBUG_ERI		0	/* ERI to debug module */
 #define XCHAL_HAVE_DEBUG_APB		0	/* APB to debug module */
-#define XCHAL_HAVE_DEBUG_JTAG		1	/* JTAG to debug module */
+#define XCHAL_HAVE_DEBUG_JTAG		0	/* JTAG to debug module */
 
 /*  On-Chip Debug (OCD)  */
 #define XCHAL_HAVE_OCD			1	/* OnChipDebug option */
 #define XCHAL_NUM_IBREAK		2	/* number of IBREAKn regs */
 #define XCHAL_NUM_DBREAK		2	/* number of DBREAKn regs */
 #define XCHAL_HAVE_OCD_DIR_ARRAY	1	/* faster OCD option (to LX4) */
-#define XCHAL_HAVE_OCD_LS32DDR		1	/* L32DDR/S32DDR (faster OCD) */
+#define XCHAL_HAVE_OCD_LS32DDR		0	/* L32DDR/S32DDR (faster OCD) */
 
 /*  TRAX (in core)  */
 #define XCHAL_HAVE_TRAX			0	/* TRAX in debug module */
@@ -562,18 +582,32 @@
 #define XCHAL_HAVE_TLBS			1	/* inverse of HAVE_CACHEATTR */
 #define XCHAL_HAVE_SPANNING_WAY		1	/* one way maps I+D 4GB vaddr */
 #define XCHAL_SPANNING_WAY		0	/* TLB spanning way number */
-#define XCHAL_HAVE_IDENTITY_MAP		0	/* vaddr == paddr always */
+#define XCHAL_HAVE_IDENTITY_MAP		1	/* vaddr == paddr always */
 #define XCHAL_HAVE_CACHEATTR		0	/* CACHEATTR register present */
 #define XCHAL_HAVE_MIMIC_CACHEATTR	1	/* region protection */
 #define XCHAL_HAVE_XLT_CACHEATTR	0	/* region prot. w/translation */
 #define XCHAL_HAVE_PTP_MMU		0	/* full MMU (with page table
 						   [autorefill] and protection)
 						   usable for an MMU-based OS */
-/*  If none of the above last 4 are set, it's a custom TLB configuration.  */
+
+/*  If none of the above last 5 are set, it's a custom TLB configuration.  */
 
 #define XCHAL_MMU_ASID_BITS		0	/* number of bits in ASIDs */
 #define XCHAL_MMU_RINGS			1	/* number of rings (1..4) */
 #define XCHAL_MMU_RING_BITS		0	/* num of bits in RING field */
+
+/*----------------------------------------------------------------------
+				MPU
+  ----------------------------------------------------------------------*/
+#define XCHAL_HAVE_MPU			0 
+#define XCHAL_MPU_ENTRIES		0
+
+#define XCHAL_MPU_ALIGN_REQ		1	/* MPU requires alignment of entries to background map */
+#define XCHAL_MPU_BACKGROUND_ENTRIES	0	/* number of entries in bg map*/
+#define XCHAL_MPU_BG_CACHEADRDIS	0	/* default CACHEADRDIS for bg */
+ 
+#define XCHAL_MPU_ALIGN_BITS		0
+#define XCHAL_MPU_ALIGN			0
 
 #endif /* !XTENSA_HAL_NON_PRIVILEGED_ONLY */
 

--- a/src/platform/haswell/include/arch/xtensa/config/core-isa-hsw.h
+++ b/src/platform/haswell/include/arch/xtensa/config/core-isa-hsw.h
@@ -68,6 +68,7 @@
 #define XCHAL_HAVE_ABSOLUTE_LITERALS	0	/* non-PC-rel (extended) L32R */
 #define XCHAL_HAVE_CONST16		0	/* CONST16 instruction */
 #define XCHAL_HAVE_ADDX			1	/* ADDX#/SUBX# instructions */
+#define XCHAL_HAVE_EXCLUSIVE            0	/* L32EX/S32EX instructions */
 #define XCHAL_HAVE_WIDE_BRANCHES	0	/* B*.W18 or B*.W15 instr's */
 #define XCHAL_HAVE_PREDICTED_BRANCHES	0	/* B[EQ/EQZ/NE/NEZ]T instr's */
 #define XCHAL_HAVE_CALL4AND12		1	/* (obsolete option) */
@@ -79,7 +80,7 @@
 #define XCHAL_HAVE_SPECULATION		0	/* speculation */
 #define XCHAL_HAVE_FULL_RESET		1	/* all regs/state reset */
 #define XCHAL_NUM_CONTEXTS		1	/* */
-#define XCHAL_NUM_MISC_REGS		0	/* num of scratch regs (0..4) */
+#define XCHAL_NUM_MISC_REGS		2	/* num of scratch regs (0..4) */
 #define XCHAL_HAVE_TAP_MASTER		0	/* JTAG TAP control instr's */
 #define XCHAL_HAVE_PRID			1	/* processor ID register */
 #define XCHAL_HAVE_EXTERN_REGS		1	/* WER/RER instructions */
@@ -89,55 +90,71 @@
 #define XCHAL_HAVE_PSO			0	/* Power Shut-Off */
 #define XCHAL_HAVE_PSO_CDM		0	/* core/debug/mem pwr domains */
 #define XCHAL_HAVE_PSO_FULL_RETENTION	0	/* all regs preserved on PSO */
-#define XCHAL_HAVE_THREADPTR		1	/* THREADPTR register */
+#define XCHAL_HAVE_THREADPTR		0	/* THREADPTR register */
 #define XCHAL_HAVE_BOOLEANS		1	/* boolean registers */
 #define XCHAL_HAVE_CP			1	/* CPENABLE reg (coprocessor) */
 #define XCHAL_CP_MAXCFG			2	/* max allowed cp id plus one */
-
-/* TODO: we have this option but currently our assembler does not support it */
 #define XCHAL_HAVE_MAC16		0	/* MAC16 package */
 
-#define XCHAL_HAVE_FUSION		 0	/* Fusion*/
-#define XCHAL_HAVE_FUSION_FP	 0	        /* Fusion FP option */
-#define XCHAL_HAVE_FUSION_LOW_POWER 0	/* Fusion Low Power option */
-#define XCHAL_HAVE_FUSION_AES	 0	        /* Fusion BLE/Wifi AES-128 CCM option */
-#define XCHAL_HAVE_FUSION_CONVENC	 0       /* Fusion Conv Encode option */
-#define XCHAL_HAVE_FUSION_LFSR_CRC	 0	/* Fusion LFSR-CRC option */
-#define XCHAL_HAVE_FUSION_BITOPS	 0	/* Fusion Bit Operations Support option */
-#define XCHAL_HAVE_FUSION_AVS	 0	/* Fusion AVS option */
-#define XCHAL_HAVE_FUSION_16BIT_BASEBAND	 0	/* Fusion 16-bit Baseband option */
+#define XCHAL_HAVE_FUSION		0	/* Fusion*/
+#define XCHAL_HAVE_FUSION_FP		0	/* Fusion FP option */
+#define XCHAL_HAVE_FUSION_LOW_POWER	0	/* Fusion Low Power option */
+#define XCHAL_HAVE_FUSION_AES		0	/* Fusion BLE/Wifi AES-128 CCM option */
+#define XCHAL_HAVE_FUSION_CONVENC	0	/* Fusion Conv Encode option */
+#define XCHAL_HAVE_FUSION_LFSR_CRC	0	/* Fusion LFSR-CRC option */
+#define XCHAL_HAVE_FUSION_BITOPS	0	/* Fusion Bit Operations Support option */
+#define XCHAL_HAVE_FUSION_AVS		0	/* Fusion AVS option */
+#define XCHAL_HAVE_FUSION_16BIT_BASEBAND 0	/* Fusion 16-bit Baseband option */
+#define XCHAL_HAVE_FUSION_VITERBI	0	/* Fusion Viterbi option */
+#define XCHAL_HAVE_FUSION_SOFTDEMAP	0	/* Fusion Soft Bit Demap option */
 #define XCHAL_HAVE_HIFIPRO		0	/* HiFiPro Audio Engine pkg */
 #define XCHAL_HAVE_HIFI4		0	/* HiFi4 Audio Engine pkg */
 #define XCHAL_HAVE_HIFI4_VFPU		0	/* HiFi4 Audio Engine VFPU option */
 #define XCHAL_HAVE_HIFI3		0	/* HiFi3 Audio Engine pkg */
 #define XCHAL_HAVE_HIFI3_VFPU		0	/* HiFi3 Audio Engine VFPU option */
+#define XCHAL_HAVE_HIFI3Z		0	/* HiFi3Z Audio Engine pkg */
+#define XCHAL_HAVE_HIFI3Z_VFPU	0	/* HiFi3Z Audio Engine VFPU option */
 #define XCHAL_HAVE_HIFI2		1	/* HiFi2 Audio Engine pkg */
-#define XCHAL_HAVE_HIFI2EP		1	/* HiFi2EP */
 #define XCHAL_HAVE_HIFI2_MUL32X24	1	/* HiFi2 and 32x24 MACs */
+#define XCHAL_HAVE_HIFI2EP		1	/* HiFi2EP */
 #define XCHAL_HAVE_HIFI_MINI		0	
 
 
-#define XCHAL_HAVE_VECTORFPU2005	0	/* vector or user floating-point pkg */
-#define XCHAL_HAVE_USER_DPFPU         0       /* user DP floating-point pkg */
-#define XCHAL_HAVE_USER_SPFPU         0       /* user DP floating-point pkg */
-#define XCHAL_HAVE_FP                 0      /* single prec floating point */
-#define XCHAL_HAVE_FP_DIV             0  /* FP with DIV instructions */
-#define XCHAL_HAVE_FP_RECIP           0        /* FP with RECIP instructions */
-#define XCHAL_HAVE_FP_SQRT            0 /* FP with SQRT instructions */
-#define XCHAL_HAVE_FP_RSQRT           0        /* FP with RSQRT instructions */
-#define XCHAL_HAVE_DFP                        0     /* double precision FP pkg */
-#define XCHAL_HAVE_DFP_DIV            0 /* DFP with DIV instructions */
-#define XCHAL_HAVE_DFP_RECIP          0       /* DFP with RECIP instructions*/
-#define XCHAL_HAVE_DFP_SQRT           0        /* DFP with SQRT instructions */
-#define XCHAL_HAVE_DFP_RSQRT          0       /* DFP with RSQRT instructions*/
-#define XCHAL_HAVE_DFP_ACCEL		0	/* double precision FP acceleration pkg */
-#define XCHAL_HAVE_DFP_accel		XCHAL_HAVE_DFP_ACCEL				/* for backward compatibility */
 
-#define XCHAL_HAVE_DFPU_SINGLE_ONLY    0                 	/* DFPU Coprocessor, single precision only */
-#define XCHAL_HAVE_DFPU_SINGLE_DOUBLE  0               	/* DFPU Coprocessor, single and double precision */
+#define XCHAL_HAVE_VECTORFPU2005	0	/* vector floating-point pkg */
+#define XCHAL_HAVE_USER_DPFPU		0       /* user DP floating-point pkg */
+#define XCHAL_HAVE_USER_SPFPU		0       /* user SP floating-point pkg */
+#define XCHAL_HAVE_FP			0	/* single prec floating point */
+#define XCHAL_HAVE_FP_DIV		0	/* FP with DIV instructions */
+#define XCHAL_HAVE_FP_RECIP		0	/* FP with RECIP instructions */
+#define XCHAL_HAVE_FP_SQRT		0	/* FP with SQRT instructions */
+#define XCHAL_HAVE_FP_RSQRT		0	/* FP with RSQRT instructions */
+#define XCHAL_HAVE_DFP			0	/* double precision FP pkg */
+#define XCHAL_HAVE_DFP_DIV		0	/* DFP with DIV instructions */
+#define XCHAL_HAVE_DFP_RECIP		0	/* DFP with RECIP instructions*/
+#define XCHAL_HAVE_DFP_SQRT		0	/* DFP with SQRT instructions */
+#define XCHAL_HAVE_DFP_RSQRT		0	/* DFP with RSQRT instructions*/
+#define XCHAL_HAVE_DFP_ACCEL		0	/* double precision FP acceleration pkg */
+#define XCHAL_HAVE_DFP_accel		XCHAL_HAVE_DFP_ACCEL	/* for backward compatibility */
+
+#define XCHAL_HAVE_DFPU_SINGLE_ONLY	0	/* DFPU Coprocessor, single precision only */
+#define XCHAL_HAVE_DFPU_SINGLE_DOUBLE	0	/* DFPU Coprocessor, single and double precision */
 #define XCHAL_HAVE_VECTRA1		0	/* Vectra I  pkg */
 #define XCHAL_HAVE_VECTRALX		0	/* Vectra LX pkg */
-#define XCHAL_HAVE_PDX4		        0	/* PDX4 */
+
+#define XCHAL_HAVE_FUSIONG		0    /* FusionG */
+#define XCHAL_HAVE_FUSIONG3		0    /* FusionG3 */
+#define XCHAL_HAVE_FUSIONG6		0    /* FusionG6 */
+#define XCHAL_HAVE_FUSIONG_SP_VFPU	0    /* sp_vfpu option on FusionG */
+#define XCHAL_HAVE_FUSIONG_DP_VFPU	0    /* dp_vfpu option on FusionG */
+#define XCHAL_FUSIONG_SIMD32		0    /* simd32 for FusionG */
+
+#define XCHAL_HAVE_PDX			0    /* PDX */
+#define XCHAL_PDX_SIMD32		0    /* simd32 for PDX */
+#define XCHAL_HAVE_PDX4			0    /* PDX4 */
+#define XCHAL_HAVE_PDX8			0    /* PDX8 */
+#define XCHAL_HAVE_PDX16		0    /* PDX16 */
+
 #define XCHAL_HAVE_CONNXD2		0	/* ConnX D2 pkg */
 #define XCHAL_HAVE_CONNXD2_DUALLSFLIX   0	/* ConnX D2 & Dual LoadStore Flix */
 #define XCHAL_HAVE_BBE16		0	/* ConnX BBE16 pkg */
@@ -145,6 +162,7 @@
 #define XCHAL_HAVE_BBE16_VECDIV		0	/* BBE16 & vector divide */
 #define XCHAL_HAVE_BBE16_DESPREAD	0	/* BBE16 & despread */
 #define XCHAL_HAVE_BBENEP		0	/* ConnX BBENEP pkgs */
+#define XCHAL_HAVE_BBENEP_SP_VFPU	0      /* sp_vfpu option on BBE-EP */
 #define XCHAL_HAVE_BSP3			0	/* ConnX BSP3 pkg */
 #define XCHAL_HAVE_BSP3_TRANSPOSE	0	/* BSP3 & transpose32x32 */
 #define XCHAL_HAVE_SSP16		0	/* ConnX SSP16 pkg */
@@ -152,19 +170,28 @@
 #define XCHAL_HAVE_TURBO16		0	/* ConnX Turbo16 pkg */
 #define XCHAL_HAVE_BBP16		0	/* ConnX BBP16 pkg */
 #define XCHAL_HAVE_FLIX3		0	/* basic 3-way FLIX option */
-#define XCHAL_HAVE_GRIVPEP              0   /*  GRIVPEP is General Release of IVPEP */
-#define XCHAL_HAVE_GRIVPEP_HISTOGRAM    0   /* Histogram option on GRIVPEP */
+#define XCHAL_HAVE_GRIVPEP		0	/* General Release of IVPEP */
+#define XCHAL_HAVE_GRIVPEP_HISTOGRAM	0       /* Histogram option on GRIVPEP */
 
+#define XCHAL_HAVE_VISION	        0     /* Vision P5/P6 */
+#define XCHAL_VISION_SIMD16             0     /* simd16 for Vision P5/P6 */
+#define XCHAL_VISION_TYPE               0     /* Vision P5, P6, or P3 */
+#define XCHAL_VISION_QUAD_MAC_TYPE      0     /* quad_mac option on Vision P6 */
+#define XCHAL_HAVE_VISION_HISTOGRAM     0     /* histogram option on Vision P5/P6 */
+#define XCHAL_HAVE_VISION_SP_VFPU       0     /* sp_vfpu option on Vision P5/P6 */
+#define XCHAL_HAVE_VISION_HP_VFPU       0     /* hp_vfpu option on Vision P6 */
+
+#define XCHAL_HAVE_VISIONC	        0     /* Vision C */
 
 /*----------------------------------------------------------------------
 				MISC
   ----------------------------------------------------------------------*/
 
 #define XCHAL_NUM_LOADSTORE_UNITS	1	/* load/store units */
-#define XCHAL_NUM_WRITEBUFFER_ENTRIES	16	/* size of write buffer */
+#define XCHAL_NUM_WRITEBUFFER_ENTRIES	8	/* size of write buffer */
 #define XCHAL_INST_FETCH_WIDTH		8	/* instr-fetch width in bytes */
 #define XCHAL_DATA_WIDTH		8	/* data width in bytes */
-#define XCHAL_DATA_PIPE_DELAY		1	/* d-side pipeline delay
+#define XCHAL_DATA_PIPE_DELAY		2	/* d-side pipeline delay
 						   (1 = 5-stage, 2 = 7-stage) */
 #define XCHAL_CLOCK_GATING_GLOBAL	1	/* global clock gating */
 #define XCHAL_CLOCK_GATING_FUNCUNIT	1	/* funct. unit clock gating */
@@ -174,9 +201,9 @@
 #define XCHAL_UNALIGNED_LOAD_HW		1	/* unaligned loads work in hw */
 #define XCHAL_UNALIGNED_STORE_HW	1	/* unaligned stores work in hw*/
 
-#define XCHAL_SW_VERSION		1100002	/* sw version of this header */
+#define XCHAL_SW_VERSION		1200008	/* sw version of this header */
 
-#define XCHAL_CORE_ID			"hifi2ep"	/* alphanum core name
+#define XCHAL_CORE_ID			"LX4_langwell_audio_17_8"	/* alphanum core name
 						   (CoreID) set in the Xtensa
 						   Processor Generator */
 
@@ -185,33 +212,33 @@
 /*
  *  These definitions describe the hardware targeted by this software.
  */
-#define XCHAL_HW_CONFIGID0		0xC2B3DBFE	/* ConfigID hi 32 bits*/
-#define XCHAL_HW_CONFIGID1		0x1C85483E	/* ConfigID lo 32 bits*/
-#define XCHAL_HW_VERSION_NAME		"LX6.0.2"	/* full version name */
-#define XCHAL_HW_VERSION_MAJOR		2600	/* major ver# of targeted hw */
-#define XCHAL_HW_VERSION_MINOR		2	/* minor ver# of targeted hw */
-#define XCHAL_HW_VERSION		260002	/* major*100+minor */
-#define XCHAL_HW_REL_LX6		1
-#define XCHAL_HW_REL_LX6_0		1
-#define XCHAL_HW_REL_LX6_0_2		1
+#define XCHAL_HW_CONFIGID0		0xC2B0DBFE	/* ConfigID hi 32 bits*/
+#define XCHAL_HW_CONFIGID1		0x15044668	/* ConfigID lo 32 bits*/
+#define XCHAL_HW_VERSION_NAME		"LX4.0.4"	/* full version name */
+#define XCHAL_HW_VERSION_MAJOR		2400	/* major ver# of targeted hw */
+#define XCHAL_HW_VERSION_MINOR		4	/* minor ver# of targeted hw */
+#define XCHAL_HW_VERSION		240004	/* major*100+minor */
+#define XCHAL_HW_REL_LX4		1
+#define XCHAL_HW_REL_LX4_0		1
+#define XCHAL_HW_REL_LX4_0_4		1
 #define XCHAL_HW_CONFIGID_RELIABLE	1
 /*  If software targets a *range* of hardware versions, these are the bounds: */
-#define XCHAL_HW_MIN_VERSION_MAJOR	2600	/* major v of earliest tgt hw */
-#define XCHAL_HW_MIN_VERSION_MINOR	2	/* minor v of earliest tgt hw */
-#define XCHAL_HW_MIN_VERSION		260002	/* earliest targeted hw */
-#define XCHAL_HW_MAX_VERSION_MAJOR	2600	/* major v of latest tgt hw */
-#define XCHAL_HW_MAX_VERSION_MINOR	2	/* minor v of latest tgt hw */
-#define XCHAL_HW_MAX_VERSION		260002	/* latest targeted hw */
+#define XCHAL_HW_MIN_VERSION_MAJOR	2400	/* major v of earliest tgt hw */
+#define XCHAL_HW_MIN_VERSION_MINOR	4	/* minor v of earliest tgt hw */
+#define XCHAL_HW_MIN_VERSION		240004	/* earliest targeted hw */
+#define XCHAL_HW_MAX_VERSION_MAJOR	2400	/* major v of latest tgt hw */
+#define XCHAL_HW_MAX_VERSION_MINOR	4	/* minor v of latest tgt hw */
+#define XCHAL_HW_MAX_VERSION		240004	/* latest targeted hw */
 
 
 /*----------------------------------------------------------------------
 				CACHE
   ----------------------------------------------------------------------*/
 
-#define XCHAL_ICACHE_LINESIZE		0	/* I-cache line size in bytes */
-#define XCHAL_DCACHE_LINESIZE		0	/* D-cache line size in bytes */
-#define XCHAL_ICACHE_LINEWIDTH		0	/* log2(I line size in bytes) */
-#define XCHAL_DCACHE_LINEWIDTH		0	/* log2(D line size in bytes) */
+#define XCHAL_ICACHE_LINESIZE		8	/* I-cache line size in bytes */
+#define XCHAL_DCACHE_LINESIZE		8	/* D-cache line size in bytes */
+#define XCHAL_ICACHE_LINEWIDTH		3	/* log2(I line size in bytes) */
+#define XCHAL_DCACHE_LINEWIDTH		3	/* log2(D line size in bytes) */
 
 #define XCHAL_ICACHE_SIZE		0	/* I-cache size in bytes or 0 */
 #define XCHAL_DCACHE_SIZE		0	/* D-cache size in bytes or 0 */
@@ -244,7 +271,14 @@
 				CACHE
   ----------------------------------------------------------------------*/
 
-#define XCHAL_HAVE_PIF			1	/* any outbound PIF present */
+#define XCHAL_HAVE_PIF			1	/* any outbound bus present */
+
+#define XCHAL_HAVE_AXI			0	/* AXI bus */
+#define XCHAL_HAVE_AXI_ECC		0	/* ECC on AXI bus */
+#define XCHAL_HAVE_ACELITE		0	/* ACELite bus */
+
+#define XCHAL_HAVE_PIF_WR_RESP			0	/* pif write response */
+#define XCHAL_HAVE_PIF_REQ_ATTR			0	/* pif attribute */
 
 /*  If present, cache size in bytes == (ways * 2^(linewidth + setwidth)).  */
 
@@ -253,8 +287,8 @@
 #define XCHAL_DCACHE_SETWIDTH		0
 
 /*  Cache set associativity (number of ways):  */
-#define XCHAL_ICACHE_WAYS		0
-#define XCHAL_DCACHE_WAYS		0
+#define XCHAL_ICACHE_WAYS		1
+#define XCHAL_DCACHE_WAYS		1
 
 /*  Cache features:  */
 #define XCHAL_ICACHE_LINE_LOCKABLE	0
@@ -263,30 +297,22 @@
 #define XCHAL_DCACHE_ECC_PARITY		0
 
 /*  Cache access size in bytes (affects operation of SICW instruction):  */
-#define XCHAL_ICACHE_ACCESS_SIZE	8
-#define XCHAL_DCACHE_ACCESS_SIZE	8
+#define XCHAL_ICACHE_ACCESS_SIZE	1
+#define XCHAL_DCACHE_ACCESS_SIZE	1
 
 #define XCHAL_DCACHE_BANKS		0	/* number of banks */
 
 /*  Number of encoded cache attr bits (see <xtensa/hal.h> for decoded bits):  */
 #define XCHAL_CA_BITS			4
 
-/*  Whether MEMCTL register has anything useful  */
-#define XCHAL_USE_MEMCTL		(((XCHAL_LOOP_BUFFER_SIZE > 0)	||	\
-					   XCHAL_DCACHE_IS_COHERENT	||	\
-					   XCHAL_HAVE_ICACHE_DYN_WAYS	||	\
-					   XCHAL_HAVE_DCACHE_DYN_WAYS)	&&	\
-					   (XCHAL_HW_MIN_VERSION >= XTENSA_HWVERSION_RE_2012_0))
-
 
 /*----------------------------------------------------------------------
 			INTERNAL I/D RAM/ROMs and XLMI
   ----------------------------------------------------------------------*/
-
 #define XCHAL_NUM_INSTROM		0	/* number of core instr. ROMs */
 #define XCHAL_NUM_INSTRAM		1	/* number of core instr. RAMs */
 #define XCHAL_NUM_DATAROM		0	/* number of core data ROMs */
-#define XCHAL_NUM_DATARAM		1	/* number of core data RAMs */
+#define XCHAL_NUM_DATARAM		2	/* number of core data RAMs */
 #define XCHAL_NUM_URAM			0	/* number of core unified RAMs*/
 #define XCHAL_NUM_XLMI			0	/* number of core XLMI ports */
 
@@ -295,14 +321,29 @@
 #define XCHAL_INSTRAM0_PADDR		0x00000000	/* physical address */
 #define XCHAL_INSTRAM0_SIZE		0x50000	/* size in bytes */
 #define XCHAL_INSTRAM0_ECC_PARITY	0	/* ECC/parity type, 0=none */
+#define XCHAL_HAVE_INSTRAM0		1
+#define XCHAL_INSTRAM0_HAVE_IDMA	0	/* idma supported by this local memory */
 
 /*  Data RAM 0:  */
 #define XCHAL_DATARAM0_VADDR		0x00400000	/* virtual address */
 #define XCHAL_DATARAM0_PADDR		0x00400000	/* physical address */
-#define XCHAL_DATARAM0_SIZE		0x80000	/* size in bytes */
+#define XCHAL_DATARAM0_SIZE		0x50000	/* size in bytes */
 #define XCHAL_DATARAM0_ECC_PARITY	0	/* ECC/parity type, 0=none */
 #define XCHAL_DATARAM0_BANKS		1	/* number of banks */
+#define XCHAL_HAVE_DATARAM0		1
+#define XCHAL_DATARAM0_HAVE_IDMA	0	/* idma supported by this local memory */
 
+/*  Data RAM 1:  */
+#define XCHAL_DATARAM1_VADDR		0x00480000	/* virtual address */
+#define XCHAL_DATARAM1_PADDR		0x00480000	/* physical address */
+#define XCHAL_DATARAM1_SIZE		0x30000	/* size in bytes */
+#define XCHAL_DATARAM1_ECC_PARITY	0	/* ECC/parity type, 0=none */
+#define XCHAL_DATARAM1_BANKS		1	/* number of banks */
+#define XCHAL_HAVE_DATARAM1		1
+#define XCHAL_DATARAM1_HAVE_IDMA	0	/* idma supported by this local memory */
+
+#define XCHAL_HAVE_IDMA			0
+#define XCHAL_HAVE_IDMA_TRANSPOSE	0
 
 #define XCHAL_HAVE_IMEM_LOADSTORE	1	/* can load/store to IROM/IRAM*/
 
@@ -327,7 +368,7 @@
 /*  Masks of interrupts at each interrupt level:  */
 #define XCHAL_INTLEVEL1_MASK		0x000000FF
 #define XCHAL_INTLEVEL2_MASK		0x00000100
-#define XCHAL_INTLEVEL3_MASK		0x00000e00
+#define XCHAL_INTLEVEL3_MASK		0x00000E00
 #define XCHAL_INTLEVEL4_MASK		0x00001000
 #define XCHAL_INTLEVEL5_MASK		0x00002000
 #define XCHAL_INTLEVEL6_MASK		0x00000000
@@ -347,21 +388,17 @@
 #define XCHAL_INT1_LEVEL		1
 #define XCHAL_INT2_LEVEL		1
 #define XCHAL_INT3_LEVEL		1
-
 #define XCHAL_INT4_LEVEL		1
 #define XCHAL_INT5_LEVEL		1
 #define XCHAL_INT6_LEVEL		1
 #define XCHAL_INT7_LEVEL		1
-
 #define XCHAL_INT8_LEVEL		2
 #define XCHAL_INT9_LEVEL		3
 #define XCHAL_INT10_LEVEL		3
 #define XCHAL_INT11_LEVEL		3
-
 #define XCHAL_INT12_LEVEL		4
 #define XCHAL_INT13_LEVEL		5
 #define XCHAL_INT14_LEVEL		7
-
 #define XCHAL_DEBUGLEVEL		6	/* debug interrupt level */
 #define XCHAL_HAVE_DEBUG_EXTERN_INT	1	/* OCD external db interrupt */
 #define XCHAL_NMILEVEL			7	/* NMI "level" (for use with
@@ -388,11 +425,14 @@
 #define XCHAL_INTTYPE_MASK_UNCONFIGURED	0xFFFF8000
 #define XCHAL_INTTYPE_MASK_SOFTWARE	0x00000880
 #define XCHAL_INTTYPE_MASK_EXTERN_EDGE	0x00000000
-#define XCHAL_INTTYPE_MASK_EXTERN_LEVEL	0x0000133f
+#define XCHAL_INTTYPE_MASK_EXTERN_LEVEL	0x0000133F
 #define XCHAL_INTTYPE_MASK_TIMER	0x00002440
 #define XCHAL_INTTYPE_MASK_NMI		0x00004000
 #define XCHAL_INTTYPE_MASK_WRITE_ERROR	0x00000000
 #define XCHAL_INTTYPE_MASK_PROFILING	0x00000000
+#define XCHAL_INTTYPE_MASK_IDMA_DONE	0x00000000
+#define XCHAL_INTTYPE_MASK_IDMA_ERR	0x00000000
+#define XCHAL_INTTYPE_MASK_GS_ERR	0x00000000
 
 /*  Interrupt numbers assigned to specific interrupt sources:  */
 #define XCHAL_TIMER0_INTERRUPT		6	/* CCOMPARE0 */
@@ -429,13 +469,6 @@
 #define XCHAL_EXTINT7_NUM		9	/* (intlevel 3) */
 #define XCHAL_EXTINT8_NUM		12	/* (intlevel 4) */
 #define XCHAL_EXTINT9_NUM		14	/* (intlevel 7) */
-#define XCHAL_EXTINT10_NUM		15	/* (intlevel 1) */
-#define XCHAL_EXTINT11_NUM		16	/* (intlevel 1) */
-#define XCHAL_EXTINT12_NUM		17	/* (intlevel 1) */
-#define XCHAL_EXTINT13_NUM		18	/* (intlevel 1) */
-#define XCHAL_EXTINT14_NUM		19	/* (intlevel 1) */
-#define XCHAL_EXTINT15_NUM		20	/* (intlevel 1) */
-#define XCHAL_EXTINT16_NUM		21	/* (intlevel 3) */
 /*  EXTERNAL BInterrupt pin numbers mapped to each core interrupt number:  */
 #define XCHAL_INT0_EXTNUM		0	/* (intlevel 1) */
 #define XCHAL_INT1_EXTNUM		1	/* (intlevel 1) */
@@ -447,13 +480,6 @@
 #define XCHAL_INT9_EXTNUM		7	/* (intlevel 3) */
 #define XCHAL_INT12_EXTNUM		8	/* (intlevel 4) */
 #define XCHAL_INT14_EXTNUM		9	/* (intlevel 7) */
-#define XCHAL_INT15_EXTNUM		10	/* (intlevel 1) */
-#define XCHAL_INT16_EXTNUM		11	/* (intlevel 1) */
-#define XCHAL_INT17_EXTNUM		12	/* (intlevel 1) */
-#define XCHAL_INT18_EXTNUM		13	/* (intlevel 1) */
-#define XCHAL_INT19_EXTNUM		14	/* (intlevel 1) */
-#define XCHAL_INT20_EXTNUM		15	/* (intlevel 1) */
-#define XCHAL_INT21_EXTNUM		16	/* (intlevel 3) */
 
 
 /*----------------------------------------------------------------------
@@ -473,25 +499,19 @@
 #define XCHAL_HAVE_MEM_ECC_PARITY	0	/* local memory ECC/parity */
 #define XCHAL_HAVE_VECTOR_SELECT	0	/* relocatable vectors */
 #define XCHAL_HAVE_VECBASE		0	/* relocatable vectors */
-#define XCHAL_VECBASE_RESET_VADDR	0x00000400  /* VECBASE reset value */
-#define XCHAL_VECBASE_RESET_PADDR	0x00000400
-#define XCHAL_RESET_VECBASE_OVERLAP	0
 
-#define XCHAL_RESET_VECTOR0_VADDR	0x00000000
-#define XCHAL_RESET_VECTOR0_PADDR	0x00000000
-#define XCHAL_RESET_VECTOR1_VADDR	0x00000000
-#define XCHAL_RESET_VECTOR1_PADDR	0x00000000
+#define XCHAL_RESET_VECOFS		0x00000000
 #define XCHAL_RESET_VECTOR_VADDR	0x00000000
 #define XCHAL_RESET_VECTOR_PADDR	0x00000000
-#define XCHAL_USER_VECOFS		0x000005c0
-#define XCHAL_USER_VECTOR_VADDR		0x000005c0
-#define XCHAL_USER_VECTOR_PADDR		0x000005c0
-#define XCHAL_KERNEL_VECOFS		0x00000584
+#define XCHAL_USER_VECOFS		0x00000000
+#define XCHAL_USER_VECTOR_VADDR		0x000005C0
+#define XCHAL_USER_VECTOR_PADDR		0x000005C0
+#define XCHAL_KERNEL_VECOFS		0x00000000
 #define XCHAL_KERNEL_VECTOR_VADDR	0x00000584
 #define XCHAL_KERNEL_VECTOR_PADDR	0x00000584
-#define XCHAL_DOUBLEEXC_VECOFS		0x000005fc
-#define XCHAL_DOUBLEEXC_VECTOR_VADDR	0x000005fc
-#define XCHAL_DOUBLEEXC_VECTOR_PADDR	0x000005fc
+#define XCHAL_DOUBLEEXC_VECOFS		0x00000000
+#define XCHAL_DOUBLEEXC_VECTOR_VADDR	0x000005FC
+#define XCHAL_DOUBLEEXC_VECTOR_PADDR	0x000005FC
 #define XCHAL_WINDOW_OF4_VECOFS		0x00000000
 #define XCHAL_WINDOW_UF4_VECOFS		0x00000040
 #define XCHAL_WINDOW_OF8_VECOFS		0x00000080
@@ -500,27 +520,27 @@
 #define XCHAL_WINDOW_UF12_VECOFS	0x00000140
 #define XCHAL_WINDOW_VECTORS_VADDR	0x00000400
 #define XCHAL_WINDOW_VECTORS_PADDR	0x00000400
-#define XCHAL_INTLEVEL2_VECOFS		0x00000640
+#define XCHAL_INTLEVEL2_VECOFS		0x00000000
 #define XCHAL_INTLEVEL2_VECTOR_VADDR	0x00000640
 #define XCHAL_INTLEVEL2_VECTOR_PADDR	0x00000640
-#define XCHAL_INTLEVEL3_VECOFS		0x0000067c
-#define XCHAL_INTLEVEL3_VECTOR_VADDR	0x0000067c
-#define XCHAL_INTLEVEL3_VECTOR_PADDR	0x0000067c
-#define XCHAL_INTLEVEL4_VECOFS		0x000006b8
-#define XCHAL_INTLEVEL4_VECTOR_VADDR	0x000006b8
-#define XCHAL_INTLEVEL4_VECTOR_PADDR	0x000006b8
-#define XCHAL_INTLEVEL5_VECOFS		0x000006f4
-#define XCHAL_INTLEVEL5_VECTOR_VADDR	0x000006f4
-#define XCHAL_INTLEVEL5_VECTOR_PADDR	0x000006f4
-#define XCHAL_INTLEVEL6_VECOFS		0x00000730
+#define XCHAL_INTLEVEL3_VECOFS		0x00000000
+#define XCHAL_INTLEVEL3_VECTOR_VADDR	0x0000067C
+#define XCHAL_INTLEVEL3_VECTOR_PADDR	0x0000067C
+#define XCHAL_INTLEVEL4_VECOFS		0x00000000
+#define XCHAL_INTLEVEL4_VECTOR_VADDR	0x000006B8
+#define XCHAL_INTLEVEL4_VECTOR_PADDR	0x000006B8
+#define XCHAL_INTLEVEL5_VECOFS		0x00000000
+#define XCHAL_INTLEVEL5_VECTOR_VADDR	0x000006F4
+#define XCHAL_INTLEVEL5_VECTOR_PADDR	0x000006F4
+#define XCHAL_INTLEVEL6_VECOFS		0x00000000
 #define XCHAL_INTLEVEL6_VECTOR_VADDR	0x00000730
 #define XCHAL_INTLEVEL6_VECTOR_PADDR	0x00000730
 #define XCHAL_DEBUG_VECOFS		XCHAL_INTLEVEL6_VECOFS
 #define XCHAL_DEBUG_VECTOR_VADDR	XCHAL_INTLEVEL6_VECTOR_VADDR
 #define XCHAL_DEBUG_VECTOR_PADDR	XCHAL_INTLEVEL6_VECTOR_PADDR
-#define XCHAL_NMI_VECOFS		0x0000076c
-#define XCHAL_NMI_VECTOR_VADDR		0x0000076c
-#define XCHAL_NMI_VECTOR_PADDR		0x0000076c
+#define XCHAL_NMI_VECOFS		0x00000000
+#define XCHAL_NMI_VECTOR_VADDR		0x0000076C
+#define XCHAL_NMI_VECTOR_PADDR		0x0000076C
 #define XCHAL_INTLEVEL7_VECOFS		XCHAL_NMI_VECOFS
 #define XCHAL_INTLEVEL7_VECTOR_VADDR	XCHAL_NMI_VECTOR_VADDR
 #define XCHAL_INTLEVEL7_VECTOR_PADDR	XCHAL_NMI_VECTOR_PADDR
@@ -533,14 +553,14 @@
 /*  Misc  */
 #define XCHAL_HAVE_DEBUG_ERI		0	/* ERI to debug module */
 #define XCHAL_HAVE_DEBUG_APB		0	/* APB to debug module */
-#define XCHAL_HAVE_DEBUG_JTAG		1	/* JTAG to debug module */
+#define XCHAL_HAVE_DEBUG_JTAG		0	/* JTAG to debug module */
 
 /*  On-Chip Debug (OCD)  */
 #define XCHAL_HAVE_OCD			1	/* OnChipDebug option */
 #define XCHAL_NUM_IBREAK		2	/* number of IBREAKn regs */
 #define XCHAL_NUM_DBREAK		2	/* number of DBREAKn regs */
 #define XCHAL_HAVE_OCD_DIR_ARRAY	1	/* faster OCD option (to LX4) */
-#define XCHAL_HAVE_OCD_LS32DDR		1	/* L32DDR/S32DDR (faster OCD) */
+#define XCHAL_HAVE_OCD_LS32DDR		0	/* L32DDR/S32DDR (faster OCD) */
 
 /*  TRAX (in core)  */
 #define XCHAL_HAVE_TRAX			0	/* TRAX in debug module */
@@ -562,18 +582,32 @@
 #define XCHAL_HAVE_TLBS			1	/* inverse of HAVE_CACHEATTR */
 #define XCHAL_HAVE_SPANNING_WAY		1	/* one way maps I+D 4GB vaddr */
 #define XCHAL_SPANNING_WAY		0	/* TLB spanning way number */
-#define XCHAL_HAVE_IDENTITY_MAP		0	/* vaddr == paddr always */
+#define XCHAL_HAVE_IDENTITY_MAP		1	/* vaddr == paddr always */
 #define XCHAL_HAVE_CACHEATTR		0	/* CACHEATTR register present */
 #define XCHAL_HAVE_MIMIC_CACHEATTR	1	/* region protection */
 #define XCHAL_HAVE_XLT_CACHEATTR	0	/* region prot. w/translation */
 #define XCHAL_HAVE_PTP_MMU		0	/* full MMU (with page table
 						   [autorefill] and protection)
 						   usable for an MMU-based OS */
-/*  If none of the above last 4 are set, it's a custom TLB configuration.  */
+
+/*  If none of the above last 5 are set, it's a custom TLB configuration.  */
 
 #define XCHAL_MMU_ASID_BITS		0	/* number of bits in ASIDs */
 #define XCHAL_MMU_RINGS			1	/* number of rings (1..4) */
 #define XCHAL_MMU_RING_BITS		0	/* num of bits in RING field */
+
+/*----------------------------------------------------------------------
+				MPU
+  ----------------------------------------------------------------------*/
+#define XCHAL_HAVE_MPU			0 
+#define XCHAL_MPU_ENTRIES		0
+
+#define XCHAL_MPU_ALIGN_REQ		1	/* MPU requires alignment of entries to background map */
+#define XCHAL_MPU_BACKGROUND_ENTRIES	0	/* number of entries in bg map*/
+#define XCHAL_MPU_BG_CACHEADRDIS	0	/* default CACHEADRDIS for bg */
+ 
+#define XCHAL_MPU_ALIGN_BITS		0
+#define XCHAL_MPU_ALIGN			0
 
 #endif /* !XTENSA_HAL_NON_PRIVILEGED_ONLY */
 

--- a/src/platform/haswell/include/platform/lib/memory.h
+++ b/src/platform/haswell/include/platform/lib/memory.h
@@ -25,7 +25,7 @@ void platform_init_memmap(void);
 #define DRAM0_BASE	0x00400000
 #define DRAM0_VBASE	0x00400000
 
-#define MAILBOX_SIZE	0x00001000
+#define MAILBOX_SIZE	(0x00001000 - SOF_VIRTUAL_THREAD_SIZE)
 #define DMA0_SIZE	0x00001000
 #define DMA1_SIZE	0x00001000
 #define SSP0_SIZE	0x00001000
@@ -69,6 +69,8 @@ void platform_init_memmap(void);
  * | HEAP_BUFFER_BASE    | Module Buffers |  HEAP_BUFFER_SIZE                 |
  * +---------------------+----------------+-----------------------------------+
  * | MAILBOX_BASE        | Mailbox        |  MAILBOX_SIZE                     |
+ * +---------------------+----------------+-----------------------------------+
+ * | VIRTUAL_THREAD_BASE | Vthread Ptr    | SOF_VIRTUAL_THREAD_SIZE           |
  * +---------------------+----------------+-----------------------------------+
  * | SOF_STACK_END       | Stack          |  SOF_STACK_SIZE                   |
  * +---------------------+----------------+-----------------------------------+
@@ -116,7 +118,7 @@ void platform_init_memmap(void);
 #define HEAP_BUFFER_SIZE \
 	(DRAM0_SIZE - HEAP_RUNTIME_SIZE - SOF_STACK_TOTAL_SIZE -\
 	 HEAP_SYS_RUNTIME_SIZE - HEAP_SYSTEM_SIZE - SOF_DATA_SIZE -\
-	 MAILBOX_SIZE)
+	 SOF_VIRTUAL_THREAD_SIZE - MAILBOX_SIZE)
 
 #define HEAP_BUFFER_BLOCK_SIZE		0x180
 #define HEAP_BUFFER_COUNT \
@@ -133,7 +135,11 @@ void platform_init_memmap(void);
 #define SOF_STACK_BASE		(DRAM0_BASE + DRAM0_SIZE)
 #define SOF_STACK_END		(SOF_STACK_BASE - SOF_STACK_TOTAL_SIZE)
 
-#define MAILBOX_BASE			(SOF_STACK_END - MAILBOX_SIZE)
+/* Virtual threadptr */
+#define SOF_VIRTUAL_THREAD_SIZE	0x20
+#define SOF_VIRTUAL_THREAD_BASE (SOF_STACK_END - SOF_VIRTUAL_THREAD_SIZE)
+
+#define MAILBOX_BASE			(SOF_VIRTUAL_THREAD_BASE - MAILBOX_SIZE)
 
 /* Vector and literal sizes - not in core-isa.h */
 #define SOF_MEM_VECT_LIT_SIZE		0x4
@@ -143,6 +149,7 @@ void platform_init_memmap(void);
 
 #define SOF_MEM_RESET_TEXT_SIZE	0x2e0
 #define SOF_MEM_RESET_LIT_SIZE		0x120
+#define SOF_MEM_VECBASE_TEXT_BASE	0x400
 #define SOF_MEM_VECBASE_LIT_SIZE	0x178
 
 #define SOF_MEM_RO_SIZE		0x8


### PR DESCRIPTION
Provide a virtual threadptr register in the memory map using a linker
area below the stack. This can then be referenced instead of the register
for ISAs that dont support threadptr.

This patch also includes initial support for HSW/BDW platforms.

TODO: This patch now allow BDW to boot on real HW and updated qemu, but it fails on any context switch to IRQ level1 ? i.e. scheduling IRQs seem to work but any IPC (level1) will process and then break next scheduler IRQ invocation (causing a kernel exception). @tlauda any ideas ? 

Signed-off-by: Liam Girdwood <liam.r.girdwood@linux.intel.com>