### PR TITLE
common: add missing include

### DIFF
--- a/src/include/sof/common.h
+++ b/src/include/sof/common.h
@@ -10,6 +10,7 @@
 #define __SOF_COMMON_H__
 
 #include <sof/trace/preproc.h>
+#include <stddef.h>
 
 /* use same syntax as Linux for simplicity */
 #define ARRAY_SIZE(x) (sizeof(x) / sizeof(x[0]))


### PR DESCRIPTION
Adds missing include of stddef.h, which defines offsetof
macro.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>