### PR TITLE
trace: move platform_trace_point to dedicated headers

### DIFF
--- a/src/include/sof/trace/trace.h
+++ b/src/include/sof/trace/trace.h
@@ -10,9 +10,16 @@
 #ifndef __SOF_TRACE_TRACE_H__
 #define __SOF_TRACE_TRACE_H__
 
+#if CONFIG_TRACE
+#include <platform/trace/trace.h>
+#endif
+#include <sof/common.h>
 #include <sof/trace/preproc.h>
 #include <config.h>
 #include <stdint.h>
+#if CONFIG_LIBRARY
+#include <stdio.h>
+#endif
 
 struct sof;
 
@@ -61,8 +68,6 @@ struct sof;
 #define TRACE_BOOT_PLATFORM_DMA_TRACE	(TRACE_BOOT_PLATFORM + 0x210)
 
 #if CONFIG_LIBRARY
-
-#include <stdio.h>
 
 extern int test_bench_trace;
 char *get_trace_class(uint32_t trace_class);
@@ -160,7 +165,6 @@ void trace_init(struct sof *sof);
 
 #if CONFIG_TRACE
 
-#include <sof/platform.h>
 /*
  * trace_event macro definition
  *
@@ -253,8 +257,6 @@ void trace_init(struct sof *sof);
 #endif
 
 #ifndef CONFIG_LIBRARY
-
-#include <sof/common.h>
 
 #define _DECLARE_LOG_ENTRY(lvl, format, comp_class, params, ids)\
 	__attribute__((section(".static_log." #lvl)))		\

--- a/src/platform/apollolake/include/platform/platform.h
+++ b/src/platform/apollolake/include/platform/platform.h
@@ -142,10 +142,6 @@ static inline void platform_panic(uint32_t p)
 	ipc_write(IPC_DIPCI, 0x80000000 | (p & 0x3fffffff));
 }
 
-/* Platform defined trace code */
-#define platform_trace_point(__x) \
-	mailbox_sw_reg_write(SRAM_REG_FW_TRACEP, (__x))
-
 extern struct timer *platform_timer;
 
 extern intptr_t _module_init_start;

--- a/src/platform/apollolake/include/platform/trace/trace.h
+++ b/src/platform/apollolake/include/platform/trace/trace.h
@@ -1,0 +1,26 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2019 Intel Corporation. All rights reserved.
+ *
+ * Author: Tomasz Lauda <tomasz.lauda@linux.intel.com>
+ */
+
+#ifdef __SOF_TRACE_TRACE_H__
+
+#ifndef __PLATFORM_TRACE_TRACE_H__
+#define __PLATFORM_TRACE_TRACE_H__
+
+#include <sof/lib/mailbox.h>
+#include <sof/lib/memory.h>
+
+/* Platform defined trace code */
+#define platform_trace_point(__x) \
+	mailbox_sw_reg_write(SRAM_REG_FW_TRACEP, (__x))
+
+#endif /* __PLATFORM_TRACE_TRACE_H__ */
+
+#else
+
+#error "This file shouldn't be included from outside of sof/trace/trace.h"
+
+#endif /* __SOF_TRACE_TRACE_H__ */

--- a/src/platform/baytrail/include/platform/trace/trace.h
+++ b/src/platform/baytrail/include/platform/trace/trace.h
@@ -1,0 +1,25 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2019 Intel Corporation. All rights reserved.
+ *
+ * Author: Tomasz Lauda <tomasz.lauda@linux.intel.com>
+ */
+
+#ifdef __SOF_TRACE_TRACE_H__
+
+#ifndef __PLATFORM_TRACE_TRACE_H__
+#define __PLATFORM_TRACE_TRACE_H__
+
+#include <sof/lib/shim.h>
+
+/* Platform defined trace code */
+#define platform_trace_point(__x) \
+	shim_write(SHIM_IPCXL, (__x & 0x3fffffff))
+
+#endif /* __PLATFORM_TRACE_TRACE_H__ */
+
+#else
+
+#error "This file shouldn't be included from outside of sof/trace/trace.h"
+
+#endif /* __SOF_TRACE_TRACE_H__ */

--- a/src/platform/cannonlake/include/platform/platform.h
+++ b/src/platform/cannonlake/include/platform/platform.h
@@ -143,10 +143,6 @@ static inline void platform_panic(uint32_t p)
 	ipc_write(IPC_DIPCIDR, 0x80000000 | (p & 0x3fffffff));
 }
 
-/* Platform defined trace code */
-#define platform_trace_point(__x) \
-	mailbox_sw_reg_write(SRAM_REG_FW_TRACEP, (__x))
-
 extern struct timer *platform_timer;
 
 extern intptr_t _module_init_start;

--- a/src/platform/cannonlake/include/platform/trace/trace.h
+++ b/src/platform/cannonlake/include/platform/trace/trace.h
@@ -1,0 +1,26 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2019 Intel Corporation. All rights reserved.
+ *
+ * Author: Tomasz Lauda <tomasz.lauda@linux.intel.com>
+ */
+
+#ifdef __SOF_TRACE_TRACE_H__
+
+#ifndef __PLATFORM_TRACE_TRACE_H__
+#define __PLATFORM_TRACE_TRACE_H__
+
+#include <sof/lib/mailbox.h>
+#include <sof/lib/memory.h>
+
+/* Platform defined trace code */
+#define platform_trace_point(__x) \
+	mailbox_sw_reg_write(SRAM_REG_FW_TRACEP, (__x))
+
+#endif /* __PLATFORM_TRACE_TRACE_H__ */
+
+#else
+
+#error "This file shouldn't be included from outside of sof/trace/trace.h"
+
+#endif /* __SOF_TRACE_TRACE_H__ */

--- a/src/platform/haswell/include/platform/platform.h
+++ b/src/platform/haswell/include/platform/platform.h
@@ -114,10 +114,6 @@ static inline void platform_panic(uint32_t p)
 	shim_write(SHIM_IPCD, (SHIM_IPCD_BUSY | p));
 }
 
-/* Platform defined trace code */
-#define platform_trace_point(__x) \
-	shim_write(SHIM_IPCX, ((__x) & 0x3fffffff))
-
 extern struct timer *platform_timer;
 
 extern intptr_t _module_init_start;

--- a/src/platform/haswell/include/platform/trace/trace.h
+++ b/src/platform/haswell/include/platform/trace/trace.h
@@ -1,0 +1,25 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2019 Intel Corporation. All rights reserved.
+ *
+ * Author: Tomasz Lauda <tomasz.lauda@linux.intel.com>
+ */
+
+#ifdef __SOF_TRACE_TRACE_H__
+
+#ifndef __PLATFORM_TRACE_TRACE_H__
+#define __PLATFORM_TRACE_TRACE_H__
+
+#include <sof/lib/shim.h>
+
+/* Platform defined trace code */
+#define platform_trace_point(__x) \
+	shim_write(SHIM_IPCX, ((__x) & 0x3fffffff))
+
+#endif /* __PLATFORM_TRACE_TRACE_H__ */
+
+#else
+
+#error "This file shouldn't be included from outside of sof/trace/trace.h"
+
+#endif /* __SOF_TRACE_TRACE_H__ */

--- a/src/platform/icelake/include/platform/platform.h
+++ b/src/platform/icelake/include/platform/platform.h
@@ -143,10 +143,6 @@ static inline void platform_panic(uint32_t p)
 	ipc_write(IPC_DIPCIDR, 0x80000000 | (p & 0x3fffffff));
 }
 
-/* Platform defined trace code */
-#define platform_trace_point(__x) \
-	mailbox_sw_reg_write(SRAM_REG_FW_TRACEP, (__x))
-
 extern struct timer *platform_timer;
 
 extern intptr_t _module_init_start;

--- a/src/platform/icelake/include/platform/trace/trace.h
+++ b/src/platform/icelake/include/platform/trace/trace.h
@@ -1,0 +1,26 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2019 Intel Corporation. All rights reserved.
+ *
+ * Author: Tomasz Lauda <tomasz.lauda@linux.intel.com>
+ */
+
+#ifdef __SOF_TRACE_TRACE_H__
+
+#ifndef __PLATFORM_TRACE_TRACE_H__
+#define __PLATFORM_TRACE_TRACE_H__
+
+#include <sof/lib/mailbox.h>
+#include <sof/lib/memory.h>
+
+/* Platform defined trace code */
+#define platform_trace_point(__x) \
+	mailbox_sw_reg_write(SRAM_REG_FW_TRACEP, (__x))
+
+#endif /* __PLATFORM_TRACE_TRACE_H__ */
+
+#else
+
+#error "This file shouldn't be included from outside of sof/trace/trace.h"
+
+#endif /* __SOF_TRACE_TRACE_H__ */

--- a/src/platform/imx8/include/platform/platform.h
+++ b/src/platform/imx8/include/platform/platform.h
@@ -90,9 +90,6 @@ static inline void platform_panic(uint32_t p)
 {
 }
 
-/* Platform defined trace code */
-#define platform_trace_point(__x)
-
 extern struct timer *platform_timer;
 
 extern intptr_t _module_init_start;

--- a/src/platform/imx8/include/platform/trace/trace.h
+++ b/src/platform/imx8/include/platform/trace/trace.h
@@ -1,0 +1,22 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2019 Intel Corporation. All rights reserved.
+ *
+ * Author: Tomasz Lauda <tomasz.lauda@linux.intel.com>
+ */
+
+#ifdef __SOF_TRACE_TRACE_H__
+
+#ifndef __PLATFORM_TRACE_TRACE_H__
+#define __PLATFORM_TRACE_TRACE_H__
+
+/* Platform defined trace code */
+#define platform_trace_point(__x)
+
+#endif /* __PLATFORM_TRACE_TRACE_H__ */
+
+#else
+
+#error "This file shouldn't be included from outside of sof/trace/trace.h"
+
+#endif /* __SOF_TRACE_TRACE_H__ */

--- a/src/platform/suecreek/include/platform/platform.h
+++ b/src/platform/suecreek/include/platform/platform.h
@@ -147,17 +147,10 @@ static inline void platform_panic(uint32_t p)
 	ipc_write(IPC_DIPCIDD, MAILBOX_EXCEPTION_OFFSET + 2 * 0x20000);
 	ipc_write(IPC_DIPCIDR, 0x80000000 | (p & 0x3fffffff));
 }
-
-/* Platform defined trace code */
-#define platform_trace_point(__x) \
-	mailbox_sw_reg_write(SRAM_REG_FW_TRACEP, (__x))
 #else
 static inline void platform_panic(uint32_t p)
 {
 }
-
-/* Platform defined trace code */
-#define platform_trace_point(__x)
 #endif
 extern struct timer *platform_timer;
 

--- a/src/platform/suecreek/include/platform/trace/trace.h
+++ b/src/platform/suecreek/include/platform/trace/trace.h
@@ -1,0 +1,22 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2019 Intel Corporation. All rights reserved.
+ *
+ * Author: Tomasz Lauda <tomasz.lauda@linux.intel.com>
+ */
+
+#ifdef __SOF_TRACE_TRACE_H__
+
+#ifndef __PLATFORM_TRACE_TRACE_H__
+#define __PLATFORM_TRACE_TRACE_H__
+
+/* Platform defined trace code */
+#define platform_trace_point(__x)
+
+#endif /* __PLATFORM_TRACE_TRACE_H__ */
+
+#else
+
+#error "This file shouldn't be included from outside of sof/trace/trace.h"
+
+#endif /* __SOF_TRACE_TRACE_H__ */

--- a/src/platform/tigerlake/include/platform/platform.h
+++ b/src/platform/tigerlake/include/platform/platform.h
@@ -150,10 +150,6 @@ static inline void platform_panic(uint32_t p)
 	ipc_write(IPC_DIPCIDR, 0x80000000 | (p & 0x3fffffff));
 }
 
-/* Platform defined trace code */
-#define platform_trace_point(__x) \
-	mailbox_sw_reg_write(SRAM_REG_FW_TRACEP, (__x))
-
 extern struct timer *platform_timer;
 
 extern intptr_t _module_init_start;

--- a/src/platform/tigerlake/include/platform/trace/trace.h
+++ b/src/platform/tigerlake/include/platform/trace/trace.h
@@ -1,0 +1,26 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2019 Intel Corporation. All rights reserved.
+ *
+ * Author: Tomasz Lauda <tomasz.lauda@linux.intel.com>
+ */
+
+#ifdef __SOF_TRACE_TRACE_H__
+
+#ifndef __PLATFORM_TRACE_TRACE_H__
+#define __PLATFORM_TRACE_TRACE_H__
+
+#include <sof/lib/mailbox.h>
+#include <sof/lib/memory.h>
+
+/* Platform defined trace code */
+#define platform_trace_point(__x) \
+	mailbox_sw_reg_write(SRAM_REG_FW_TRACEP, (__x))
+
+#endif /* __PLATFORM_TRACE_TRACE_H__ */
+
+#else
+
+#error "This file shouldn't be included from outside of sof/trace/trace.h"
+
+#endif /* __SOF_TRACE_TRACE_H__ */


### PR DESCRIPTION
Moves platform_trace_point macro from platform/platform.h
to platform/trace/trace.h. This way we don't need to
include platform header from generic sof/trace/trace.h.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>