### PR TITLE
alloc: fix first free update in alloc_cont_blocks()

### DIFF
--- a/src/lib/alloc.c
+++ b/src/lib/alloc.c
@@ -283,7 +283,14 @@ static void *alloc_cont_blocks(struct mm_heap *heap, int level,
 	heap->info.free -= count * map->block_size;
 	/* update first_free if needed */
 	if (map->first_free == start)
-		map->first_free += count;
+		/* find first available free block */
+		for (map->first_free += count; map->first_free < map->count;
+			map->first_free++) {
+			hdr = &map->block[map->first_free];
+
+			if (!hdr->used)
+				break;
+		}
 
 	/* update each block */
 	for (current = start; current < start + count; current++) {


### PR DESCRIPTION
In alloc_cont_blocks() function after allocation we should
check whether new first_free block has been already used.
If it was used, we should find first not used block.

fixes #1714

Signed-off-by: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>