### PR TITLE
Arch xtensa wait.h cleanup

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -32,6 +32,13 @@ config LP_SRAM
 	  memory for specific platform. Until this options is enabled firmware will
 	  not enable any of LPSRAM memory banks.
 
+config WAITI_DELAY
+	bool "Enable delay before WAITI instruction"
+	default n
+	help
+	  Some cAVS platforms may require additional delay to flush loads
+	  and stores before entering WAITI.
+
 endmenu
 
 config HOST_PTABLE

--- a/src/arch/xtensa/include/arch/lib/wait.h
+++ b/src/arch/xtensa/include/arch/lib/wait.h
@@ -12,11 +12,11 @@
 
 #include <sof/debug/panic.h>
 #include <sof/drivers/interrupt.h>
-#include <sof/platform.h>
 #include <ipc/trace.h>
+#include <config.h>
 #include <xtensa/xtruntime.h>
 
-#if defined(PLATFORM_WAITI_DELAY)
+#if (CONFIG_WAITI_DELAY)
 
 static inline void arch_wait_for_interrupt(int level)
 {

--- a/src/arch/xtensa/include/arch/lib/wait.h
+++ b/src/arch/xtensa/include/arch/lib/wait.h
@@ -5,8 +5,6 @@
  * Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
  */
 
-#ifdef __SOF_LIB_WAIT_H__
-
 #ifndef __ARCH_LIB_WAIT_H__
 #define __ARCH_LIB_WAIT_H__
 
@@ -61,9 +59,3 @@ static inline void idelay(int n)
 }
 
 #endif /* __ARCH_LIB_WAIT_H__ */
-
-#else
-
-#error "This file shouldn't be included from outside of sof/lib/wait.h"
-
-#endif /* __SOF_LIB_WAIT_H__ */

--- a/src/platform/Kconfig
+++ b/src/platform/Kconfig
@@ -82,6 +82,7 @@ config CANNONLAKE
 	select DMA_FIFO_PARTITION
 	select CAVS
 	select CAVS_VERSION_1_8
+	select WAITI_DELAY
 	help
 	  Select if your target platform is Cannonlake-compatible
 
@@ -99,6 +100,7 @@ config SUECREEK
 	select DMA_FIFO_PARTITION
 	select CAVS
 	select CAVS_VERSION_2_0
+	select WAITI_DELAY
 	help
 	  Select if your target platform is Suecreek-compatible
 
@@ -115,6 +117,7 @@ config ICELAKE
 	select DMA_FIFO_PARTITION
 	select CAVS
 	select CAVS_VERSION_2_0
+	select WAITI_DELAY
 	help
 	  Select if your target platform is Icelake-compatible
 
@@ -133,6 +136,7 @@ config TIGERLAKE
 	select DMA_FIFO_PARTITION
 	select CAVS
 	select CAVS_VERSION_2_5
+	select WAITI_DELAY
 	help
 	  Select if your target platform is Tigerlake-compatible
 

--- a/src/platform/cannonlake/include/platform/platform.h
+++ b/src/platform/cannonlake/include/platform/platform.h
@@ -41,8 +41,6 @@ struct timer;
  */
 #define PLATFORM_WORKQ_DEFAULT_TIMEOUT	1000
 
-#define PLATFORM_WAITI_DELAY	1
-
 #define MAX_GPDMA_COUNT 2
 
 /* Host page size */

--- a/src/platform/icelake/include/platform/platform.h
+++ b/src/platform/icelake/include/platform/platform.h
@@ -41,8 +41,6 @@ struct timer;
  */
 #define PLATFORM_WORKQ_DEFAULT_TIMEOUT	1000
 
-#define PLATFORM_WAITI_DELAY	1
-
 #define MAX_GPDMA_COUNT 2
 
 /* Host page size */

--- a/src/platform/intel/cavs/lib/pm_memory.c
+++ b/src/platform/intel/cavs/lib/pm_memory.c
@@ -5,6 +5,7 @@
  * Author: Jakub Dabek <jakub.dabek@intel.com>
  */
 
+#include <cavs/version.h>
 #include <sof/bit.h>
 #include <sof/lib/io.h>
 #include <sof/lib/memory.h>
@@ -13,7 +14,6 @@
 #include <sof/lib/wait.h>
 #include <sof/trace/trace.h>
 #include <user/trace.h>
-#include <version.h>
 #include <stdint.h>
 
 #define trace_mem_pm(__e, ...) \

--- a/src/platform/suecreek/include/platform/platform.h
+++ b/src/platform/suecreek/include/platform/platform.h
@@ -41,8 +41,6 @@ struct timer;
  */
 #define PLATFORM_WORKQ_DEFAULT_TIMEOUT	1000
 
-#define PLATFORM_WAITI_DELAY	1
-
 #define MAX_GPDMA_COUNT 2
 
 /* Host page size */

--- a/src/platform/tigerlake/include/platform/platform.h
+++ b/src/platform/tigerlake/include/platform/platform.h
@@ -41,8 +41,6 @@ struct timer;
  */
 #define PLATFORM_WORKQ_DEFAULT_TIMEOUT	1000
 
-#define PLATFORM_WAITI_DELAY	1
-
 #define MAX_GPDMA_COUNT 2
 
 /* Host page size */


### PR DESCRIPTION
The patches are required to remove circular dependencies that appear while introducing a new platform_wait... layer between the lib and the architecture layers.