### PR TITLE
src: do not treat 0 size input data as error

### DIFF
--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -762,8 +762,8 @@ static int src_copy(struct comp_dev *dev)
 	 */
 	ret = src_get_copy_limits(cd, source, sink);
 	if (ret) {
-		trace_src_error("No data to process.");
-		return ret;
+		trace_src("No data to process.");
+		return PPL_STATUS_PATH_STOP;
 	}
 
 	cd->src_func(dev, source, sink, &consumed, &produced);


### PR DESCRIPTION
Currently SRC returns error when 0 size input or output data is detected
and pipeline interpretes this as fatal xrun error. This could happen
for example when host dma has no time to fill in first iteration of
samples. So instead of error, return 0 in this case as SRC in the
middle of the pipeline should handle also occasional 0 size data.

Signed-off-by: Jaska Uimonen <jaska.uimonen@intel.com>