### PR TITLE
Tools: Test: Updates for testbench to match other changes in SOF

### DIFF
--- a/tools/test/audio/src_run.sh
+++ b/tools/test/audio/src_run.sh
@@ -12,9 +12,11 @@ FN_IN=$5
 FN_OUT=$6
 
 # The HOST_ROOT path need to be retrived from SOFT .configure command
-HOST_ROOT=../../../tools/testbench/build_testbench/install
-HOST_EXE=$HOST_ROOT/bin/testbench
-HOST_LIB=$HOST_ROOT/lib
+HOST_ROOT=../../testbench/build_testbench
+HOST_EXE=$HOST_ROOT/install/bin/testbench
+HOST_LIB=$HOST_ROOT/sof_ep/install/lib
+TPLG_LIB=$HOST_ROOT/sof_parser/install/lib
+export LD_LIBRARY_PATH=$HOST_LIB:$TPLG_LIB
 
 # Use topology from component test topologies
 INFMT=s${BITS_IN}le
@@ -42,9 +44,9 @@ arg1="-d -r $FS1 -R $FS2 -i $FN_IN -o $FN_OUT -t $TPLG"
 arg2="-a src=libsof_${COMP}.so $CMDFMT"
 CMD1="$arg1 $arg2"
 CMD="$CMD0 $CMD1"
-export LD_LIBRARY_PATH=$HOST_LIB
 
 # Run test bench
-echo "Command: $CMD0"
-echo "Arg:     $CMD1"
+echo "Command:     $CMD0"
+echo "Arg:         $CMD1"
+echo "Ld lib path: $LD_LIBRARY_PATH"
 $CMD

--- a/tools/testbench/schedule.c
+++ b/tools/testbench/schedule.c
@@ -13,36 +13,67 @@
 #include <sof/lib/wait.h>
 #include <stdlib.h>
 
-static struct schedule_data *sch;
+static struct schedulers *testbench_schedulers_ptr; /* Initialized as NULL */
 
 struct schedulers **arch_schedulers_get(void)
 {
-	return NULL;
+	return &testbench_schedulers_ptr;
 }
 
-/* testbench work definition */
 int schedule_task_init(struct task *task, uint16_t type, uint16_t priority,
 		       enum task_state (*func)(void *data), void *data,
 		       uint16_t core, uint32_t flags)
 {
+	struct schedulers *schedulers = *arch_schedulers_get();
+	struct schedule_data *sch;
+	struct list_item *slist;
+	int ret = 0;
+
+	if (type >= SOF_SCHEDULE_COUNT) {
+		ret = -EINVAL;
+		goto out;
+	}
+
 	task->type = type;
 	task->priority = priority;
 	task->core = core;
+	task->flags = flags;
 	task->state = SOF_TASK_STATE_INIT;
 	task->func = func;
 	task->data = data;
 
-	if (task->type == sch->type && sch->ops->schedule_task_init)
-		return sch->ops->schedule_task_init(sch->data, task);
-	else
-		return -ENOENT;
+	list_for_item(slist, &schedulers->list) {
+		sch = container_of(slist, struct schedule_data, list);
+		if (type == sch->type && sch->ops->schedule_task_init)
+			return sch->ops->schedule_task_init(sch->data, task);
+	}
+
+out:
+	return ret;
+}
+
+static void scheduler_register(struct schedule_data *scheduler)
+{
+	struct schedulers **sch = arch_schedulers_get();
+
+	if (!*sch) {
+		/* init schedulers list */
+		*sch = malloc(sizeof(**sch));
+		list_init(&(*sch)->list);
+	}
+
+	list_item_append(&scheduler->list, &(*sch)->list);
 }
 
 void scheduler_init(int type, const struct scheduler_ops *ops, void *data)
 {
+	struct schedule_data *sch;
+
 	sch = malloc(sizeof(*sch));
 	list_init(&sch->list);
 	sch->type = type;
 	sch->ops = ops;
 	sch->data = data;
+
+	scheduler_register(sch);
 }

--- a/tools/testbench/testbench.c
+++ b/tools/testbench/testbench.c
@@ -187,9 +187,12 @@ int main(int argc, char **argv)
 	int n_in, n_out, ret;
 	int i;
 
-	/* initialize input and output sample rates */
+	/* initialize input and output sample rates, files, etc. */
 	tp.fs_in = 0;
 	tp.fs_out = 0;
+	tp.bits_in = 0;
+	tp.input_file = NULL;
+	tp.output_file = NULL;
 
 	/* command line arguments*/
 	parse_input_args(argc, argv, &tp);


### PR DESCRIPTION
This patch updates the locations of "make install" libraries default
install locations into shell script to run SRC test cases. The script
also now prints the used LD_LIBRARY path to ease setting up code
debugging.

The segfault of testbench executable is fixed by returning a valid
pointer reference instead of a NULL from test dummy function
arch_schedulers_get().  The rest of testbench version of schedule.c
was also updated to be like the current real version module.

Finally in the testbench.c main the file names string pointers are
initilizated to null as well as the word length parameter to avoid
a segfault if executable is started without command line arguments
to see the usage help text.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>