### PR TITLE
assert: Do not call assert() with side effects in the argument

### DIFF
--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -50,6 +50,7 @@ struct comp_dev *comp_new(struct sof_ipc_comp *comp)
 {
 	struct comp_dev *cdev;
 	struct comp_driver *drv;
+	int ret;
 
 	/* find the driver for our new component */
 	drv = get_drv(comp->type);
@@ -68,8 +69,9 @@ struct comp_dev *comp_new(struct sof_ipc_comp *comp)
 	}
 
 	/* init component */
-	assert(!memcpy_s(&cdev->comp, sizeof(cdev->comp),
-		comp, sizeof(*comp)));
+	ret = memcpy_s(&cdev->comp, sizeof(cdev->comp),
+		       comp, sizeof(*comp));
+	assert(!ret);
 
 	cdev->drv = drv;
 	list_init(&cdev->bsource_list);

--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -145,6 +145,7 @@ static struct comp_dev *dai_new(struct sof_ipc_comp *comp)
 	struct sof_ipc_comp_dai *ipc_dai = (struct sof_ipc_comp_dai *)comp;
 	struct dai_data *dd;
 	uint32_t dir, caps, dma_dev;
+	int ret;
 
 	trace_dai("dai_new()");
 
@@ -159,8 +160,9 @@ static struct comp_dev *dai_new(struct sof_ipc_comp *comp)
 		return NULL;
 
 	dai = (struct sof_ipc_comp_dai *)&dev->comp;
-	assert(!memcpy_s(dai, sizeof(*dai), ipc_dai,
-	   sizeof(struct sof_ipc_comp_dai)));
+	ret = memcpy_s(dai, sizeof(*dai), ipc_dai,
+		       sizeof(struct sof_ipc_comp_dai));
+	assert(!ret);
 
 	dd = rzalloc(RZONE_RUNTIME, SOF_MEM_CAPS_RAM, sizeof(*dd));
 	if (!dd) {

--- a/src/audio/detect_test.c
+++ b/src/audio/detect_test.c
@@ -232,9 +232,11 @@ static int test_keyword_apply_config(struct comp_dev *dev,
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 	uint16_t sample_width;
+	int ret;
 
-	assert(!memcpy_s(&cd->config, sizeof(cd->config), cfg,
-			 sizeof(struct sof_detect_test_config)));
+	ret = memcpy_s(&cd->config, sizeof(cd->config), cfg,
+		       sizeof(struct sof_detect_test_config));
+	assert(!ret);
 
 	sample_width = cd->config.sample_width;
 
@@ -274,8 +276,9 @@ static struct comp_dev *test_keyword_new(struct sof_ipc_comp *comp)
 		return NULL;
 
 	keyword = (struct sof_ipc_comp_process *)&dev->comp;
-	assert(!memcpy_s(keyword, sizeof(*keyword), ipc_keyword,
-		 sizeof(struct sof_ipc_comp_process)));
+	ret = memcpy_s(keyword, sizeof(*keyword), ipc_keyword,
+		       sizeof(struct sof_ipc_comp_process));
+	assert(!ret);
 
 	cd = rzalloc(RZONE_RUNTIME, SOF_MEM_CAPS_RAM, sizeof(*cd));
 
@@ -432,9 +435,10 @@ static int test_keyword_set_model(struct comp_dev *dev,
 		return -EINVAL;
 	}
 
-	assert(!memcpy_s(cd->model.data + cd->model.data_pos,
-			 cd->model.data_size - cd->model.data_pos,
-			 cdata->data->data, cdata->num_elems));
+	ret = memcpy_s(cd->model.data + cd->model.data_pos,
+		       cd->model.data_size - cd->model.data_pos,
+		       cdata->data->data, cdata->num_elems);
+	assert(!ret);
 
 	cd->model.data_pos += cdata->num_elems;
 
@@ -528,7 +532,9 @@ static int test_keyword_get_config(struct comp_dev *dev,
 	if (bs == 0 || bs > size)
 		return -EINVAL;
 
-	assert(!memcpy_s(cdata->data->data, size, &cd->config, bs));
+	ret = memcpy_s(cdata->data->data, size, &cd->config, bs);
+	assert(!ret);
+
 	cdata->data->abi = SOF_ABI_VERSION;
 	cdata->data->size = bs;
 
@@ -564,8 +570,10 @@ static int test_keyword_get_model(struct comp_dev *dev,
 			return -EINVAL;
 		}
 
-		assert(!memcpy_s(cdata->data->data, size,
-				 cd->model.data + cd->model.data_pos, bs));
+		ret = memcpy_s(cdata->data->data, size,
+			       cd->model.data + cd->model.data_pos, bs);
+		assert(!ret);
+
 		cdata->data->abi = SOF_ABI_VERSION;
 		cdata->data->size = cd->model.data_size;
 		cd->model.data_pos += bs;

--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -379,6 +379,7 @@ static struct comp_dev *eq_fir_new(struct sof_ipc_comp *comp)
 		= (struct sof_ipc_comp_process *)comp;
 	size_t bs = ipc_fir->size;
 	int i;
+	int ret;
 
 	trace_eq("eq_fir_new()");
 
@@ -402,8 +403,9 @@ static struct comp_dev *eq_fir_new(struct sof_ipc_comp *comp)
 		return NULL;
 
 	fir = (struct sof_ipc_comp_process *)&dev->comp;
-	assert(!memcpy_s(fir, sizeof(*fir), ipc_fir,
-			 sizeof(struct sof_ipc_comp_process)));
+	ret = memcpy_s(fir, sizeof(*fir), ipc_fir,
+		       sizeof(struct sof_ipc_comp_process));
+	assert(!ret);
 
 	cd = rzalloc(RZONE_RUNTIME, SOF_MEM_CAPS_RAM, sizeof(*cd));
 	if (!cd) {
@@ -428,7 +430,8 @@ static struct comp_dev *eq_fir_new(struct sof_ipc_comp *comp)
 			return NULL;
 		}
 
-		assert(!memcpy_s(cd->config, bs, ipc_fir->data, bs));
+		ret = memcpy_s(cd->config, bs, ipc_fir->data, bs);
+		assert(!ret);
 	}
 
 	for (i = 0; i < PLATFORM_MAX_CHANNELS; i++)
@@ -495,9 +498,11 @@ static int fir_cmd_get_data(struct comp_dev *dev,
 			trace_eq("fir_cmd_get_data(), blob size %zu "
 				 "msg index %u max size %u offset %zu", bs,
 				 cdata->msg_index, max_size, offset);
-			assert(!memcpy_s(dst, ((struct sof_abi_hdr *)
-					 (cdata->data))->size, src + offset,
-					 bs));
+			ret = memcpy_s(dst, ((struct sof_abi_hdr *)
+				       (cdata->data))->size, src + offset,
+				       bs);
+			assert(!ret);
+
 			cdata->data->abi = SOF_ABI_VERSION;
 			cdata->data->size = bs;
 		} else {
@@ -602,9 +607,10 @@ static int fir_cmd_set_data(struct comp_dev *dev,
 		/* Just copy the configuration. The EQ will be initialized in
 		 * prepare().
 		 */
-		assert(!memcpy_s(dst + offset, cdata->num_elems +
-				 cdata->elems_remaining - offset, src,
-				 cdata->num_elems));
+		ret = memcpy_s(dst + offset, cdata->num_elems +
+			       cdata->elems_remaining - offset, src,
+			       cdata->num_elems);
+		assert(!ret);
 
 		/* we can check data when elems_remaining == 0 */
 		break;

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -467,6 +467,7 @@ static struct comp_dev *eq_iir_new(struct sof_ipc_comp *comp)
 		(struct sof_ipc_comp_process *)comp;
 	size_t bs = ipc_iir->size;
 	int i;
+	int ret;
 
 	trace_eq("eq_iir_new()");
 
@@ -490,8 +491,9 @@ static struct comp_dev *eq_iir_new(struct sof_ipc_comp *comp)
 		return NULL;
 
 	iir = (struct sof_ipc_comp_process *)&dev->comp;
-	assert(!memcpy_s(iir, sizeof(*iir), ipc_iir,
-			 sizeof(struct sof_ipc_comp_process)));
+	ret = memcpy_s(iir, sizeof(*iir), ipc_iir,
+		       sizeof(struct sof_ipc_comp_process));
+	assert(!ret);
 
 	cd = rzalloc(RZONE_RUNTIME, SOF_MEM_CAPS_RAM, sizeof(*cd));
 	if (!cd) {
@@ -517,7 +519,8 @@ static struct comp_dev *eq_iir_new(struct sof_ipc_comp *comp)
 			return NULL;
 		}
 
-		assert(!memcpy_s(cd->config, bs, ipc_iir->data, bs));
+		ret = memcpy_s(cd->config, bs, ipc_iir->data, bs);
+		assert(!ret);
 	}
 
 	for (i = 0; i < PLATFORM_MAX_CHANNELS; i++)
@@ -568,10 +571,11 @@ static int iir_cmd_get_data(struct comp_dev *dev,
 			if (bs > SOF_EQ_IIR_MAX_SIZE || bs == 0 ||
 			    bs > max_size)
 				return -EINVAL;
-			assert(!memcpy_s(cdata->data->data,
-					 ((struct sof_abi_hdr *)
-					 (cdata->data))->size, cd->config,
-					 bs));
+			ret = memcpy_s(cdata->data->data,
+				       ((struct sof_abi_hdr *)
+				       (cdata->data))->size, cd->config,
+				       bs);
+			assert(!ret);
 
 			cdata->data->abi = SOF_ABI_VERSION;
 			cdata->data->size = bs;
@@ -667,7 +671,8 @@ static int iir_cmd_set_data(struct comp_dev *dev,
 		/* Just copy the configurate. The EQ will be initialized in
 		 * prepare().
 		 */
-		assert(!memcpy_s(cd->config, bs, cdata->data->data, bs));
+		ret = memcpy_s(cd->config, bs, cdata->data->data, bs);
+		assert(!ret);
 		break;
 	default:
 		trace_eq_error("iir_cmd_set_data() error: invalid cdata->cmd");

--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -344,6 +344,7 @@ static struct comp_dev *host_new(struct sof_ipc_comp *comp)
 	struct comp_dev *dev;
 	struct host_data *hd;
 	uint32_t dir;
+	int ret;
 
 	trace_host("host_new()");
 
@@ -358,8 +359,9 @@ static struct comp_dev *host_new(struct sof_ipc_comp *comp)
 		return NULL;
 
 	host = (struct sof_ipc_comp_host *)&dev->comp;
-	assert(!memcpy_s(host, sizeof(*host),
-			 ipc_host, sizeof(struct sof_ipc_comp_host)));
+	ret = memcpy_s(host, sizeof(*host),
+		       ipc_host, sizeof(struct sof_ipc_comp_host));
+	assert(!ret);
 
 	hd = rzalloc(RZONE_RUNTIME, SOF_MEM_CAPS_RAM, sizeof(*hd));
 	if (!hd) {

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -100,6 +100,7 @@ static struct comp_dev *kpb_new(struct sof_ipc_comp *comp)
 	size_t bs = ipc_process->size;
 	struct comp_dev *dev;
 	struct comp_data *kpb;
+	int ret;
 
 	trace_kpb("kpb_new()");
 
@@ -114,8 +115,9 @@ static struct comp_dev *kpb_new(struct sof_ipc_comp *comp)
 	if (!dev)
 		return NULL;
 
-	assert(!memcpy_s(&dev->comp, sizeof(struct sof_ipc_comp_process),
-			 comp, sizeof(struct sof_ipc_comp_process)));
+	ret = memcpy_s(&dev->comp, sizeof(struct sof_ipc_comp_process),
+		       comp, sizeof(struct sof_ipc_comp_process));
+	assert(!ret);
 
 	kpb = rzalloc(RZONE_RUNTIME, SOF_MEM_CAPS_RAM, sizeof(*kpb));
 	if (!kpb) {
@@ -125,8 +127,9 @@ static struct comp_dev *kpb_new(struct sof_ipc_comp *comp)
 
 	comp_set_drvdata(dev, kpb);
 
-	assert(!memcpy_s(&kpb->config, sizeof(kpb->config), ipc_process->data,
-			 bs));
+	ret = memcpy_s(&kpb->config, sizeof(kpb->config), ipc_process->data,
+		       bs);
+	assert(!ret);
 
 	if (!kpb_is_sample_width_supported(kpb->config.sampling_width)) {
 		trace_kpb_error("kpb_new() error: "

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -111,6 +111,7 @@ static struct comp_dev *mixer_new(struct sof_ipc_comp *comp)
 	struct sof_ipc_comp_mixer *ipc_mixer =
 		(struct sof_ipc_comp_mixer *)comp;
 	struct mixer_data *md;
+	int ret;
 
 	trace_mixer("mixer_new()");
 
@@ -126,8 +127,9 @@ static struct comp_dev *mixer_new(struct sof_ipc_comp *comp)
 
 	mixer = (struct sof_ipc_comp_mixer *)&dev->comp;
 
-	assert(!memcpy_s(mixer, sizeof(*mixer), ipc_mixer,
-	    sizeof(struct sof_ipc_comp_mixer)));
+	ret = memcpy_s(mixer, sizeof(*mixer), ipc_mixer,
+		       sizeof(struct sof_ipc_comp_mixer));
+	assert(!ret);
 
 	md = rzalloc(RZONE_RUNTIME, SOF_MEM_CAPS_RAM, sizeof(*md));
 	if (!md) {

--- a/src/audio/pipeline.c
+++ b/src/audio/pipeline.c
@@ -44,6 +44,7 @@ struct pipeline *pipeline_new(struct sof_ipc_pipe_new *pipe_desc,
 			      struct comp_dev *cd)
 {
 	struct pipeline *p;
+	int ret;
 
 	trace_pipe("pipeline_new()");
 
@@ -58,8 +59,9 @@ struct pipeline *pipeline_new(struct sof_ipc_pipe_new *pipe_desc,
 	p->sched_comp = cd;
 	p->status = COMP_STATE_INIT;
 
-	assert(!memcpy_s(&p->ipc_pipe, sizeof(p->ipc_pipe),
-	   pipe_desc, sizeof(*pipe_desc)));
+	ret = memcpy_s(&p->ipc_pipe, sizeof(p->ipc_pipe),
+		       pipe_desc, sizeof(*pipe_desc));
+	assert(!ret);
 
 	return p;
 }

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -108,8 +108,9 @@ static struct comp_dev *selector_new(struct sof_ipc_comp *comp)
 	if (!dev)
 		return NULL;
 
-	assert(!memcpy_s(&dev->comp, sizeof(struct sof_ipc_comp_process), comp,
-			 sizeof(struct sof_ipc_comp_process)));
+	ret = memcpy_s(&dev->comp, sizeof(struct sof_ipc_comp_process), comp,
+		       sizeof(struct sof_ipc_comp_process));
+	assert(!ret);
 
 	cd = rzalloc(RZONE_RUNTIME, SOF_MEM_CAPS_RAM, sizeof(*cd));
 	if (!cd) {
@@ -119,8 +120,8 @@ static struct comp_dev *selector_new(struct sof_ipc_comp *comp)
 
 	comp_set_drvdata(dev, cd);
 
-	assert(!memcpy_s(&cd->config, sizeof(cd->config), ipc_process->data,
-			 bs));
+	ret = memcpy_s(&cd->config, sizeof(cd->config), ipc_process->data, bs);
+	assert(!ret);
 
 	/* verification of initial parameters */
 	ret = sel_set_channel_values(cd, cd->config.in_channels_count,
@@ -224,9 +225,10 @@ static int selector_ctrl_get_data(struct comp_dev *dev,
 		trace_selector("selector_ctrl_get_data(), SOF_CTRL_CMD_BINARY");
 
 		/* Copy back to user space */
-		assert(!memcpy_s(cdata->data->data, ((struct sof_abi_hdr *)
-				 (cdata->data))->size, &cd->config,
-				 sizeof(cd->config)));
+		ret = memcpy_s(cdata->data->data, ((struct sof_abi_hdr *)
+			       (cdata->data))->size, &cd->config,
+			       sizeof(cd->config));
+		assert(!ret);
 
 		cdata->data->abi = SOF_ABI_VERSION;
 		cdata->data->size = sizeof(cd->config);

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -435,6 +435,7 @@ static void src_copy_s32(struct comp_dev *dev,
 	int n_wrap_snk;
 	int n_wrap_min;
 	int n_copy;
+	int ret;
 
 	n = frames * dev->params.channels;
 	while (n > 0) {
@@ -443,8 +444,9 @@ static void src_copy_s32(struct comp_dev *dev,
 		n_wrap_min = (n_wrap_src < n_wrap_snk) ?
 			n_wrap_src : n_wrap_snk;
 		n_copy = (n < n_wrap_min) ? n : n_wrap_min;
-		assert(!memcpy_s(snk, n_copy * sizeof(int32_t), src,
-				 n_copy * sizeof(int32_t)));
+		ret = memcpy_s(snk, n_copy * sizeof(int32_t), src,
+			       n_copy * sizeof(int32_t));
+		assert(!ret);
 
 		/* Update and check both source and destination for wrap */
 		n -= n_copy;
@@ -470,6 +472,7 @@ static void src_copy_s16(struct comp_dev *dev,
 	int n_wrap_snk;
 	int n_wrap_min;
 	int n_copy;
+	int ret;
 
 	n = frames * dev->params.channels;
 	while (n > 0) {
@@ -478,8 +481,9 @@ static void src_copy_s16(struct comp_dev *dev,
 		n_wrap_min = (n_wrap_src < n_wrap_snk) ?
 			n_wrap_src : n_wrap_snk;
 		n_copy = (n < n_wrap_min) ? n : n_wrap_min;
-		assert(!memcpy_s(snk, n_copy * sizeof(int16_t), src,
-				 n_copy * sizeof(int16_t)));
+		ret = memcpy_s(snk, n_copy * sizeof(int16_t), src,
+			       n_copy * sizeof(int16_t));
+		assert(!ret);
 
 		/* Update and check both source and destination for wrap */
 		n -= n_copy;
@@ -498,6 +502,7 @@ static struct comp_dev *src_new(struct sof_ipc_comp *comp)
 	struct sof_ipc_comp_src *src;
 	struct sof_ipc_comp_src *ipc_src = (struct sof_ipc_comp_src *)comp;
 	struct comp_data *cd;
+	int ret;
 
 	trace_src("src_new()");
 
@@ -520,8 +525,9 @@ static struct comp_dev *src_new(struct sof_ipc_comp *comp)
 
 	src = (struct sof_ipc_comp_src *)&dev->comp;
 
-	assert(!memcpy_s(src, sizeof(*src), ipc_src,
-			 sizeof(struct sof_ipc_comp_src)));
+	ret = memcpy_s(src, sizeof(*src), ipc_src,
+		       sizeof(struct sof_ipc_comp_src));
+	assert(!ret);
 
 	cd = rzalloc(RZONE_RUNTIME, SOF_MEM_CAPS_RAM, sizeof(*cd));
 	if (!cd) {

--- a/src/audio/tone.c
+++ b/src/audio/tone.c
@@ -378,6 +378,7 @@ static struct comp_dev *tone_new(struct sof_ipc_comp *comp)
 	struct sof_ipc_comp_tone *ipc_tone = (struct sof_ipc_comp_tone *)comp;
 	struct comp_data *cd;
 	int i;
+	int ret;
 
 	trace_tone("tone_new()");
 
@@ -392,8 +393,9 @@ static struct comp_dev *tone_new(struct sof_ipc_comp *comp)
 		return NULL;
 
 	tone = (struct sof_ipc_comp_tone *)&dev->comp;
-	assert(!memcpy_s(tone, sizeof(*tone), ipc_tone,
-	   sizeof(struct sof_ipc_comp_tone)));
+	ret = memcpy_s(tone, sizeof(*tone), ipc_tone,
+		       sizeof(struct sof_ipc_comp_tone));
+	assert(!ret);
 
 	cd = rzalloc(RZONE_RUNTIME, SOF_MEM_CAPS_RAM, sizeof(*cd));
 	if (!cd) {

--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -139,6 +139,7 @@ static struct comp_dev *volume_new(struct sof_ipc_comp *comp)
 		(struct sof_ipc_comp_volume *)comp;
 	struct comp_data *cd;
 	int i;
+	int ret;
 
 	trace_volume("volume_new()");
 
@@ -153,8 +154,9 @@ static struct comp_dev *volume_new(struct sof_ipc_comp *comp)
 		return NULL;
 
 	vol = (struct sof_ipc_comp_volume *)&dev->comp;
-	assert(!memcpy_s(vol, sizeof(*vol), ipc_vol,
-			 sizeof(struct sof_ipc_comp_volume)));
+	ret = memcpy_s(vol, sizeof(*vol), ipc_vol,
+		       sizeof(struct sof_ipc_comp_volume));
+	assert(!ret);
 
 	cd = rzalloc(RZONE_RUNTIME, SOF_MEM_CAPS_RAM, sizeof(*cd));
 	if (!cd) {

--- a/src/debug/panic.c
+++ b/src/debug/panic.c
@@ -19,10 +19,14 @@
 
 void dump_panicinfo(void *addr, struct sof_ipc_panic_info *panic_info)
 {
+	int ret;
+
 	if (!panic_info)
 		return;
-	assert(!memcpy_s(addr, sizeof(struct sof_ipc_panic_info), panic_info,
-			 sizeof(struct sof_ipc_panic_info)));
+	ret = memcpy_s(addr, sizeof(struct sof_ipc_panic_info), panic_info,
+		       sizeof(struct sof_ipc_panic_info));
+	/* TODO are asserts even safe in this context? */
+	assert(!ret);
 	dcache_writeback_region(addr, sizeof(struct sof_ipc_panic_info));
 }
 
@@ -71,21 +75,27 @@ void __panic(uint32_t p, char *filename, uint32_t linenum)
 {
 	struct sof_ipc_panic_info panicinfo = { .linenum = linenum };
 	int strlen;
+	int ret;
 
 	strlen = rstrlen(filename);
 
 	if (strlen >= SOF_TRACE_FILENAME_SIZE) {
-		assert(!memcpy_s(panicinfo.filename,
-				 sizeof(panicinfo.filename),
-				 filename + strlen - SOF_TRACE_FILENAME_SIZE,
-				 SOF_TRACE_FILENAME_SIZE));
-		assert(!memcpy_s(panicinfo.filename,
-				 sizeof(panicinfo.filename),
-				 "...", 3));
+		ret = memcpy_s(panicinfo.filename,
+			       sizeof(panicinfo.filename),
+			       filename + strlen - SOF_TRACE_FILENAME_SIZE,
+			       SOF_TRACE_FILENAME_SIZE);
+		/* TODO are asserts safe in this context? */
+		assert(!ret);
+
+		ret = memcpy_s(panicinfo.filename,
+			       sizeof(panicinfo.filename),
+			       "...", 3);
+		assert(!ret);
 	} else {
-		assert(!memcpy_s(panicinfo.filename,
-				 sizeof(panicinfo.filename),
-				 filename, strlen + 1));
+		ret = memcpy_s(panicinfo.filename,
+			       sizeof(panicinfo.filename),
+			       filename, strlen + 1);
+		assert(!ret);
 	}
 
 	/* To distinguish regular panic() calls from exceptions, we will

--- a/src/drivers/dw/ssi-spi.c
+++ b/src/drivers/dw/ssi-spi.c
@@ -350,7 +350,8 @@ int spi_push(struct spi *spi, const void *data, size_t size)
 	spi->ipc_status = IPC_WRITE;
 
 	/* Actually we have to send IPC messages in one go */
-	assert(!memcpy_s(config->src_buf, config->buffer_size, data, size));
+	ret = memcpy_s(config->src_buf, config->buffer_size, data, size);
+	assert(!ret);
 
 	dcache_writeback_region(config->src_buf, size);
 

--- a/src/drivers/intel/cavs/dmic.c
+++ b/src/drivers/intel/cavs/dmic.c
@@ -1111,8 +1111,9 @@ static int dmic_set_config(struct dai *dai, struct sof_ipc_dai_config *config)
 	/* Copy the new DMIC params to persistent.  The last request
 	 * determines the parameters.
 	 */
-	assert(!memcpy_s(dmic_prm[di], sizeof(*dmic_prm[di]), &config->dmic,
-	       sizeof(struct sof_ipc_dai_dmic_params)));
+	ret = memcpy_s(dmic_prm[di], sizeof(*dmic_prm[di]), &config->dmic,
+		       sizeof(struct sof_ipc_dai_dmic_params));
+	assert(!ret);
 
 	if (config->dmic.num_pdm_active > DMIC_HW_CONTROLLERS) {
 		trace_dmic_error("dmic_set_config() error: the requested "
@@ -1127,12 +1128,12 @@ static int dmic_set_config(struct dai *dai, struct sof_ipc_dai_config *config)
 		for (j = 0; j < config->dmic.num_pdm_active; j++) {
 			/* copy the pdm controller params id the id's match */
 			if (dmic_prm[di]->pdm[i].id == config->dmic.pdm[j].id) {
-				assert(!memcpy_s(&dmic_prm[di]->pdm[i],
-				       sizeof(
-				       dmic_prm[di]->pdm[i]),
-				       &config->dmic.pdm[j],
-				       sizeof(
-				       struct sof_ipc_dai_dmic_pdm_ctrl)));
+				ret = memcpy_s(&dmic_prm[di]->pdm[i],
+					       sizeof(dmic_prm[di]->pdm[i]),
+					       &config->dmic.pdm[j],
+					       sizeof(
+					       struct sof_ipc_dai_dmic_pdm_ctrl));
+				assert(!ret);
 			}
 		}
 	}

--- a/src/include/sof/debug/debug.h
+++ b/src/include/sof/debug/debug.h
@@ -140,6 +140,8 @@ static inline uint32_t dump_stack(uint32_t p, void *addr, size_t offset,
 		sizeof(void *);
 	uintptr_t stack_top = (uintptr_t)arch_get_stack_ptr() + offset;
 	size_t size = stack_bottom - stack_top;
+	int ret;
+
 	*stack_ptr = stack_top;
 
 	/* is stack smashed ? */
@@ -154,8 +156,8 @@ static inline uint32_t dump_stack(uint32_t p, void *addr, size_t offset,
 		size = limit;
 
 	/* copy stack contents and writeback */
-	assert(!memcpy_s(addr, limit,
-			 (void *)stack_top, size - sizeof(void *)));
+	ret = memcpy_s(addr, limit, (void *)stack_top, size - sizeof(void *));
+	assert(!ret);
 	dcache_writeback_region(addr, size - sizeof(void *));
 
 	return p;

--- a/src/include/sof/lib/mailbox.h
+++ b/src/include/sof/lib/mailbox.h
@@ -48,8 +48,10 @@
 static inline
 void mailbox_dspbox_write(size_t offset, const void *src, size_t bytes)
 {
-	assert(!memcpy_s((void *)(MAILBOX_DSPBOX_BASE + offset),
-			 MAILBOX_DSPBOX_SIZE - offset, src, bytes));
+	int ret = memcpy_s((void *)(MAILBOX_DSPBOX_BASE + offset),
+			   MAILBOX_DSPBOX_SIZE - offset, src, bytes);
+
+	assert(!ret);
 	dcache_writeback_region((void *)(MAILBOX_DSPBOX_BASE + offset), bytes);
 }
 
@@ -57,18 +59,22 @@ static inline
 void mailbox_dspbox_read(void *dest, size_t dest_size,
 			 size_t offset, size_t bytes)
 {
+	int ret;
+
 	dcache_invalidate_region((void *)(MAILBOX_DSPBOX_BASE + offset),
 				 bytes);
-	assert(!memcpy_s(dest, dest_size,
-			 (void *)(MAILBOX_DSPBOX_BASE + offset),
-			 bytes));
+	ret = memcpy_s(dest, dest_size,
+		       (void *)(MAILBOX_DSPBOX_BASE + offset), bytes);
+	assert(!ret);
 }
 
 static inline
 void mailbox_hostbox_write(size_t offset, const void *src, size_t bytes)
 {
-	assert(!memcpy_s((void *)(MAILBOX_HOSTBOX_BASE + offset),
-			 MAILBOX_HOSTBOX_SIZE - offset, src, bytes));
+	int ret = memcpy_s((void *)(MAILBOX_HOSTBOX_BASE + offset),
+			   MAILBOX_HOSTBOX_SIZE - offset, src, bytes);
+
+	assert(!ret);
 	dcache_writeback_region((void *)(MAILBOX_HOSTBOX_BASE + offset), bytes);
 }
 
@@ -76,18 +82,22 @@ static inline
 void mailbox_hostbox_read(void *dest, size_t dest_size,
 			  size_t offset, size_t bytes)
 {
+	int ret;
+
 	dcache_invalidate_region((void *)(MAILBOX_HOSTBOX_BASE + offset),
 				 bytes);
-	assert(!memcpy_s(dest, dest_size,
-			 (void *)(MAILBOX_HOSTBOX_BASE + offset),
-			 bytes));
+	ret = memcpy_s(dest, dest_size,
+		       (void *)(MAILBOX_HOSTBOX_BASE + offset), bytes);
+	assert(!ret);
 }
 
 static inline
 void mailbox_stream_write(size_t offset, const void *src, size_t bytes)
 {
-	assert(!memcpy_s((void *)(MAILBOX_STREAM_BASE + offset),
-			 MAILBOX_STREAM_SIZE - offset, src, bytes));
+	int ret = memcpy_s((void *)(MAILBOX_STREAM_BASE + offset),
+			   MAILBOX_STREAM_SIZE - offset, src, bytes);
+
+	assert(!ret);
 	dcache_writeback_region((void *)(MAILBOX_STREAM_BASE + offset),
 				bytes);
 }

--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -87,18 +87,22 @@
 
 #define _IPC_COPY_CMD(rx, tx, rx_size)					\
 	do {								\
+		int ___ret;						\
 		if (rx_size > tx->size) {				\
-			assert(!memcpy_s(rx, rx_size, tx, tx->size));	\
+			___ret = memcpy_s(rx, rx_size, tx, tx->size);	\
+			assert(!___ret);				\
 			bzero((void *)rx + tx->size, rx_size - tx->size);\
 			trace_ipc("ipc: hdr 0x%x rx (%d) > tx (%d)",	\
 				  rx->cmd, rx_size, tx->size);		\
 		} else if (tx->size > rx_size) {			\
-			assert(!memcpy_s(rx, rx_size, tx, rx_size));	\
+			___ret = memcpy_s(rx, rx_size, tx, rx_size);	\
+			assert(!___ret);				\
 			trace_ipc("ipc: hdr 0x%x tx (%d) > rx (%d)",	\
 				  rx->cmd, tx->size, rx_size);		\
-		} else							\
-			assert(!memcpy_s(rx, rx_size, tx, rx_size));	\
-									\
+		} else	{						\
+			___ret = memcpy_s(rx, rx_size, tx, rx_size);	\
+			assert(!___ret);				\
+		}							\
 	} while (0)
 
 /* copies whole message from Tx to Rx, follows above ABI rules */
@@ -1267,9 +1271,10 @@ int ipc_queue_host_message(struct ipc *ipc, uint32_t header, void *tx_data,
 	msg->tx_size = tx_bytes;
 
 	/* copy mailbox data to message */
-	if (tx_bytes > 0 && tx_bytes < SOF_IPC_MSG_MAX_SIZE)
-		assert(!memcpy_s(msg->tx_data, msg->tx_size, tx_data,
-				 tx_bytes));
+	if (tx_bytes > 0 && tx_bytes < SOF_IPC_MSG_MAX_SIZE) {
+		ret = memcpy_s(msg->tx_data, msg->tx_size, tx_data, tx_bytes);
+		assert(!ret);
+	}
 
 	if (!found) {
 		/* now queue the message */

--- a/src/schedule/task.c
+++ b/src/schedule/task.c
@@ -57,14 +57,16 @@ void task_main_init(void)
 {
 	struct task **main_task = task_main_get();
 	int cpu = cpu_get_id();
+	int ret;
 	task_main main_main = cpu == PLATFORM_MASTER_CORE_ID ?
 		&task_main_master_core : &task_main_slave_core;
 
 	*main_task = rzalloc(RZONE_SYS, SOF_MEM_CAPS_RAM, sizeof(**main_task));
 
-	assert(!schedule_task_init(*main_task, SOF_SCHEDULE_EDF,
-				   SOF_TASK_PRI_IDLE, main_main, NULL, NULL,
-				   cpu, SOF_SCHEDULE_FLAG_IDLE));
+	ret = schedule_task_init(*main_task, SOF_SCHEDULE_EDF,
+				 SOF_TASK_PRI_IDLE, main_main, NULL, NULL,
+				 cpu, SOF_SCHEDULE_FLAG_IDLE);
+	assert(!ret);
 }
 
 void task_main_free(void)

--- a/src/trace/trace.c
+++ b/src/trace/trace.c
@@ -47,6 +47,7 @@ static void put_header(uint32_t *dst, uint32_t id_0, uint32_t id_1,
 		       uint32_t entry, uint64_t timestamp)
 {
 	struct log_entry_header header;
+	int ret;
 
 	header.id_0 = id_0 & TRACE_ID_MASK;
 	header.id_1 = id_1 & TRACE_ID_MASK;
@@ -54,7 +55,8 @@ static void put_header(uint32_t *dst, uint32_t id_0, uint32_t id_1,
 	header.timestamp = timestamp + platform_timer->delta;
 	header.log_entry_address = entry;
 
-	assert(!memcpy_s(dst, sizeof(header), &header, sizeof(header)));
+	ret = memcpy_s(dst, sizeof(header), &header, sizeof(header));
+	assert(!ret);
 }
 
 static void mtrace_event(const char *data, uint32_t length)


### PR DESCRIPTION
If the assert semantics are changed to be the more usual ones, on
disabling asserts the calls that I changed would have also removed the
desirable side effects when the assertion itself passed (no memcpy_s
would have occurred, in particular). I have changed the usage of the
assert() macro so that the code becomes immune to such a change.

Signed-off-by: Paul Olaru <paul.olaru@nxp.com>

Fixes #1761 