### PR TITLE
schedule: implement DMA scheduling domain

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -85,16 +85,16 @@ config HW_LLI
 	  Any platforms with hardware linked list support
 	  should set this.
 
-config DMA_AGGREGATED_IRQ
+config DW_DMA_AGGREGATED_IRQ
 	bool
 	default n
 	help
-	  Some platforms cannot register interrupt per DMA channel
+	  Some platforms cannot register interrupt per DW-DMA channel
 	  and have the possibility only to register interrupts per
 	  DMA controller, which require manual handling of aggregated
 	  irq.
 
-	  Any platforms with DMA aggregated interrupts support
+	  Any platforms with DW-DMA aggregated interrupts support
 	  should set this.
 
 config DMA_SUSPEND_DRAIN

--- a/src/arch/xtensa/init.c
+++ b/src/arch/xtensa/init.c
@@ -132,6 +132,7 @@ int slave_core_init(struct sof *sof)
 	trace_point(TRACE_BOOT_PLATFORM_SCHED);
 	scheduler_init_edf(sof);
 	scheduler_init_ll(platform_timer_domain);
+	scheduler_init_ll(platform_dma_domain);
 
 	/* initialize IDC mechanism */
 	trace_point(TRACE_BOOT_PLATFORM_IDC);

--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -248,6 +248,7 @@ static int dai_playback_params(struct comp_dev *dev, uint32_t period_bytes)
 	config->irq_disabled = pipeline_is_timer_driven(dev->pipeline);
 	config->dest_dev = dai_get_handshake(dd->dai, dev->params.direction,
 					     dd->stream_id);
+	config->is_scheduling_source = comp_is_scheduling_source(dev);
 
 	trace_dai_with_ids(dev, "dai_playback_params() "
 			   "dest_dev = %d stream_id = %d "
@@ -313,6 +314,7 @@ static int dai_capture_params(struct comp_dev *dev, uint32_t period_bytes)
 	config->irq_disabled = pipeline_is_timer_driven(dev->pipeline);
 	config->src_dev = dai_get_handshake(dd->dai, dev->params.direction,
 					    dd->stream_id);
+	config->is_scheduling_source = comp_is_scheduling_source(dev);
 
 	/* TODO: Make this code platform-specific or move it driver callback */
 	if (dai_get_info(dd->dai, DAI_INFO_TYPE) == SOF_DAI_INTEL_DMIC) {

--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -627,6 +627,7 @@ static int host_params(struct comp_dev *dev)
 	config->dest_width = comp_sample_bytes(dev);
 	config->cyclic = 0;
 	config->irq_disabled = pipeline_is_timer_driven(dev->pipeline);
+	config->is_scheduling_source = comp_is_scheduling_source(dev);
 
 	host_elements_reset(dev);
 

--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -224,8 +224,6 @@ static void host_dma_cb(void *data, uint32_t type, struct dma_cb_data *next)
 	/* callback for one shot copy */
 	if (hd->copy_type == COMP_COPY_ONE_SHOT)
 		host_one_shot_cb(dev, bytes);
-
-	next->status = DMA_CB_STATUS_END;
 }
 
 static int create_local_elems(struct comp_dev *dev, uint32_t buffer_count,

--- a/src/audio/pipeline.c
+++ b/src/audio/pipeline.c
@@ -428,7 +428,7 @@ int pipeline_prepare(struct pipeline *p, struct comp_dev *dev)
 
 	/* initialize task if necessary */
 	if (!p->pipe_task) {
-		type = pipeline_is_timer_driven(p) ? SOF_SCHEDULE_LL :
+		type = pipeline_is_timer_driven(p) ? SOF_SCHEDULE_LL_TIMER :
 			SOF_SCHEDULE_EDF;
 
 		p->pipe_task = pipeline_task_init(p, type, pipeline_task);

--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -163,8 +163,8 @@ static struct comp_dev *volume_new(struct sof_ipc_comp *comp)
 	}
 
 	comp_set_drvdata(dev, cd);
-	schedule_task_init(&cd->volwork, SOF_SCHEDULE_LL, SOF_TASK_PRI_MED,
-			   vol_work, NULL, dev, 0, 0);
+	schedule_task_init(&cd->volwork, SOF_SCHEDULE_LL_TIMER,
+			   SOF_TASK_PRI_MED, vol_work, NULL, dev, 0, 0);
 
 	/* Set the default volumes. If IPC sets min_value or max_value to
 	 * not-zero, use them. Otherwise set to internal limits and notify

--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -1216,7 +1216,6 @@ static int dw_dma_probe(struct dma *dma)
 	for (i = 0, chan = dma->chan; i < dma->plat_data.channels;
 	     i++, chan++) {
 		chan->status = COMP_STATE_INIT;
-		chan->index = i;
 		chan->dma = dma;
 		chan->index = i;
 		chan->core = DMA_CORE_INVALID;

--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -328,6 +328,9 @@ static int dw_dma_start(struct dma_chan_data *channel)
 		ret = dw_dma_interrupt_register(channel);
 
 	if (!ret) {
+		/* assign core */
+		channel->core = cpu_get_id();
+
 		/* enable the channel */
 		channel->status = COMP_STATE_ACTIVE;
 		dma_reg_write(dma, DW_DMA_CHAN_EN,
@@ -1240,6 +1243,7 @@ static int dw_dma_probe(struct dma *dma)
 		chan->index = i;
 		chan->dma = dma;
 		chan->index = i;
+		chan->core = DMA_CORE_INVALID;
 
 		dw_chan = rzalloc(RZONE_SYS_RUNTIME | RZONE_FLAG_UNCACHED,
 				  SOF_MEM_CAPS_RAM, sizeof(*dw_chan));

--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -539,6 +539,7 @@ static int dw_dma_set_config(struct dma_chan_data *channel,
 
 	/* default channel config */
 	channel->direction = config->direction;
+	channel->is_scheduling_source = config->is_scheduling_source;
 	dw_chan->irq_disabled = config->irq_disabled;
 	dw_chan->cfg_lo = DW_CFG_LOW_DEF;
 	dw_chan->cfg_hi = DW_CFG_HIGH_DEF;

--- a/src/drivers/imx/dummy-dma.c
+++ b/src/drivers/imx/dummy-dma.c
@@ -96,6 +96,12 @@ static int dummy_dma_get_data_size(struct dma_chan_data *channel,
 	return 0;
 }
 
+static int dummy_dma_interrupt(struct dma_chan_data *channel,
+			       enum dma_irq_cmd cmd)
+{
+	return 0;
+}
+
 const struct dma_ops dummy_dma_ops = {
 	.channel_get	= dummy_dma_channel_get,
 	.channel_put	= dummy_dma_channel_put,
@@ -112,4 +118,5 @@ const struct dma_ops dummy_dma_ops = {
 	.probe		= dummy_dma_probe,
 	.remove		= dummy_dma_remove,
 	.get_data_size	= dummy_dma_get_data_size,
+	.interrupt	= dummy_dma_interrupt,
 };

--- a/src/drivers/imx/edma.c
+++ b/src/drivers/imx/edma.c
@@ -110,6 +110,11 @@ static int edma_remove(struct dma *dma)
 	return 0;
 }
 
+static int edma_interrupt(struct dma_chan_data *channel, enum dma_irq_cmd cmd)
+{
+	return 0;
+}
+
 const struct dma_ops edma_ops = {
 	.channel_get	= edma_channel_get,
 	.channel_put	= edma_channel_put,
@@ -124,4 +129,5 @@ const struct dma_ops edma_ops = {
 	.pm_context_store	= edma_pm_context_store,
 	.probe		= edma_probe,
 	.remove		= edma_remove,
+	.interrupt	= edma_interrupt,
 };

--- a/src/drivers/intel/cavs/dmic.c
+++ b/src/drivers/intel/cavs/dmic.c
@@ -1067,7 +1067,7 @@ static int dmic_set_config(struct dai *dai, struct sof_ipc_dai_config *config)
 	trace_dmic("dmic_set_config(), dai->index = %d", di);
 
 	/* Initialize start sequence handler */
-	schedule_task_init(&dmic->dmicwork, SOF_SCHEDULE_LL,
+	schedule_task_init(&dmic->dmicwork, SOF_SCHEDULE_LL_TIMER,
 			   SOF_TASK_PRI_MED, dmic_work, NULL, dai, 0,
 			   SOF_SCHEDULE_FLAG_ASYNC);
 

--- a/src/drivers/intel/cavs/hda-dma.c
+++ b/src/drivers/intel/cavs/hda-dma.c
@@ -13,6 +13,7 @@
 #include <sof/drivers/timer.h>
 #include <sof/lib/alloc.h>
 #include <sof/lib/clk.h>
+#include <sof/lib/cpu.h>
 #include <sof/lib/dma.h>
 #include <sof/lib/pm_runtime.h>
 #include <sof/platform.h>
@@ -477,6 +478,8 @@ static int hda_dma_start(struct dma_chan_data *channel)
 	hda_dma_enable_unlock(channel);
 
 	channel->status = COMP_STATE_ACTIVE;
+	channel->core = cpu_get_id();
+
 out:
 	irq_local_enable(flags);
 	return ret;
@@ -743,6 +746,7 @@ static int hda_dma_probe(struct dma *dma)
 		chan->dma = dma;
 		chan->index = i;
 		chan->status = COMP_STATE_INIT;
+		chan->core = DMA_CORE_INVALID;
 
 		hda_chan = rzalloc(RZONE_SYS_RUNTIME | RZONE_FLAG_UNCACHED,
 				   SOF_MEM_CAPS_RAM,

--- a/src/drivers/intel/cavs/hda-dma.c
+++ b/src/drivers/intel/cavs/hda-dma.c
@@ -607,6 +607,7 @@ static int hda_dma_set_config(struct dma_chan_data *channel,
 	/* default channel config */
 	channel->direction = config->direction;
 	channel->desc_count = config->elem_array.count;
+	channel->is_scheduling_source = config->is_scheduling_source;
 
 	/* validate - HDA only supports continuous elems of same size  */
 	for (i = 0; i < config->elem_array.count; i++) {

--- a/src/drivers/intel/cavs/hda-dma.c
+++ b/src/drivers/intel/cavs/hda-dma.c
@@ -60,8 +60,6 @@
 /* DGBS */
 #define DGBS_MASK	0xfffff0
 
-#define HDA_DMA_MAX_CHANS		9
-
 #define HDA_STATE_RELEASE	BIT(0)
 
 /* DGMBS align value */
@@ -783,7 +781,7 @@ static int hda_dma_remove(struct dma *dma)
 
 	trace_hddma("hda-dmac :%d -> remove", dma->plat_data.id);
 
-	for (i = 0; i < HDA_DMA_MAX_CHANS; i++)
+	for (i = 0; i < dma->plat_data.channels; i++)
 		rfree(dma_chan_get_data(&dma->chan[i]));
 
 	rfree(dma->chan);

--- a/src/drivers/intel/cavs/hda-dma.c
+++ b/src/drivers/intel/cavs/hda-dma.c
@@ -880,6 +880,13 @@ static int hda_dma_get_attribute(struct dma *dma, uint32_t type,
 	return ret;
 }
 
+static int hda_dma_interrupt(struct dma_chan_data *channel,
+			     enum dma_irq_cmd cmd)
+{
+	/* HDA-DMA doesn't support interrupts */
+	return -EINVAL;
+}
+
 const struct dma_ops hda_host_dma_ops = {
 	.channel_get		= hda_dma_channel_get,
 	.channel_put		= hda_dma_channel_put,
@@ -897,6 +904,7 @@ const struct dma_ops hda_host_dma_ops = {
 	.remove			= hda_dma_remove,
 	.get_data_size		= hda_dma_data_size,
 	.get_attribute		= hda_dma_get_attribute,
+	.interrupt		= hda_dma_interrupt,
 };
 
 const struct dma_ops hda_link_dma_ops = {
@@ -916,4 +924,5 @@ const struct dma_ops hda_link_dma_ops = {
 	.remove			= hda_dma_remove,
 	.get_data_size		= hda_dma_data_size,
 	.get_attribute		= hda_dma_get_attribute,
+	.interrupt		= hda_dma_interrupt,
 };

--- a/src/drivers/intel/cavs/idc.c
+++ b/src/drivers/intel/cavs/idc.c
@@ -192,9 +192,8 @@ static int idc_pipeline_trigger(uint32_t cmd)
 		 * Should be removed after changing memory management for
 		 * slave cores.
 		 */
-		if (pcm_dev->cd->pipeline->pipe_task->type ==
-		    SOF_SCHEDULE_EDF) {
-			task = pcm_dev->cd->pipeline->pipe_task;
+		if (pcm_dev->cd->pipeline->preload_task) {
+			task = pcm_dev->cd->pipeline->preload_task;
 			edf_pdata = edf_sch_get_pdata(task);
 			dcache_invalidate_region(edf_pdata, sizeof(*edf_pdata));
 			task_context_cache(edf_pdata->ctx, CACHE_INVALIDATE);
@@ -214,9 +213,8 @@ static int idc_pipeline_trigger(uint32_t cmd)
 		 * Should be removed after changing memory management for
 		 * slave cores.
 		 */
-		if (pcm_dev->cd->pipeline->pipe_task->type ==
-		    SOF_SCHEDULE_EDF) {
-			task = pcm_dev->cd->pipeline->pipe_task;
+		if (pcm_dev->cd->pipeline->preload_task) {
+			task = pcm_dev->cd->pipeline->preload_task;
 			edf_pdata = edf_sch_get_pdata(task);
 			task_context_cache(edf_pdata->ctx, CACHE_WRITEBACK_INV);
 			dcache_writeback_invalidate_region(edf_pdata,

--- a/src/drivers/intel/cavs/idc.c
+++ b/src/drivers/intel/cavs/idc.c
@@ -192,8 +192,9 @@ static int idc_pipeline_trigger(uint32_t cmd)
 		 * Should be removed after changing memory management for
 		 * slave cores.
 		 */
-		if (pcm_dev->cd->pipeline->pipe_task.type == SOF_SCHEDULE_EDF) {
-			task = &pcm_dev->cd->pipeline->pipe_task;
+		if (pcm_dev->cd->pipeline->pipe_task->type ==
+		    SOF_SCHEDULE_EDF) {
+			task = pcm_dev->cd->pipeline->pipe_task;
 			edf_pdata = edf_sch_get_pdata(task);
 			dcache_invalidate_region(edf_pdata, sizeof(*edf_pdata));
 			task_context_cache(edf_pdata->ctx, CACHE_INVALIDATE);
@@ -213,8 +214,9 @@ static int idc_pipeline_trigger(uint32_t cmd)
 		 * Should be removed after changing memory management for
 		 * slave cores.
 		 */
-		if (pcm_dev->cd->pipeline->pipe_task.type == SOF_SCHEDULE_EDF) {
-			task = &pcm_dev->cd->pipeline->pipe_task;
+		if (pcm_dev->cd->pipeline->pipe_task->type ==
+		    SOF_SCHEDULE_EDF) {
+			task = pcm_dev->cd->pipeline->pipe_task;
 			edf_pdata = edf_sch_get_pdata(task);
 			task_context_cache(edf_pdata->ctx, CACHE_WRITEBACK_INV);
 			dcache_writeback_invalidate_region(edf_pdata,

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -29,6 +29,7 @@
 #include <user/trace.h>
 #include <config.h>
 #include <errno.h>
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -758,6 +759,16 @@ static inline void comp_overrun(struct comp_dev *dev, struct comp_buffer *sink,
 			 copy_bytes);
 
 	pipeline_xrun(dev->pipeline, dev, (int32_t)copy_bytes - sink->free);
+}
+
+/**
+ * Called to check whether component schedules its pipeline.
+ * @param dev Component device.
+ * @return True if this is scheduling component, false otherwise.
+ */
+static inline bool comp_is_scheduling_source(struct comp_dev *dev)
+{
+	return dev == dev->pipeline->sched_comp;
 }
 
 /**

--- a/src/include/sof/audio/pipeline.h
+++ b/src/include/sof/audio/pipeline.h
@@ -78,7 +78,7 @@ struct pipeline {
 	bool preload;			/* is pipeline preload needed */
 
 	/* scheduling */
-	struct task pipe_task;		/* pipeline processing task */
+	struct task *pipe_task;		/* pipeline processing task */
 
 	/* component that drives scheduling in this pipe */
 	struct comp_dev *sched_comp;

--- a/src/include/sof/audio/pipeline.h
+++ b/src/include/sof/audio/pipeline.h
@@ -79,6 +79,7 @@ struct pipeline {
 
 	/* scheduling */
 	struct task *pipe_task;		/* pipeline processing task */
+	struct task *preload_task;	/* pipeline preload task */
 
 	/* component that drives scheduling in this pipe */
 	struct comp_dev *sched_comp;

--- a/src/include/sof/lib/dma.h
+++ b/src/include/sof/lib/dma.h
@@ -225,6 +225,8 @@ struct dma_chan_data {
 	void *private;
 };
 
+extern struct dma dma[];
+
 /**
  *  \brief Plugs platform specific DMA array once initialized into the lib.
  *

--- a/src/include/sof/lib/dma.h
+++ b/src/include/sof/lib/dma.h
@@ -87,6 +87,7 @@ enum dma_irq_cmd {
 };
 
 #define DMA_CHAN_INVALID	0xFFFFFFFF
+#define DMA_CORE_INVALID	0xFFFFFFFF
 
 /* DMA attributes */
 #define DMA_ATTR_BUFFER_ALIGNMENT	0
@@ -208,6 +209,7 @@ struct dma_chan_data {
 	uint32_t direction;
 	uint32_t desc_count;
 	uint32_t index;
+	uint32_t core;
 
 	/* client callback function */
 	void (*cb)(void *data, uint32_t type, struct dma_cb_data *next);

--- a/src/include/sof/lib/dma.h
+++ b/src/include/sof/lib/dma.h
@@ -73,7 +73,6 @@
  */
 enum dma_cb_status {
 	DMA_CB_STATUS_RELOAD = 0,
-	DMA_CB_STATUS_SPLIT,
 	DMA_CB_STATUS_END,
 };
 

--- a/src/include/sof/lib/dma.h
+++ b/src/include/sof/lib/dma.h
@@ -132,6 +132,8 @@ struct dma_sg_config {
 	struct dma_sg_elem_array elem_array;	/* array of dma_sg elems */
 	bool scatter;
 	bool irq_disabled;
+	/* true if configured DMA channel is the scheduling source */
+	bool is_scheduling_source;
 };
 
 struct dma_chan_status {
@@ -210,6 +212,8 @@ struct dma_chan_data {
 	uint32_t desc_count;
 	uint32_t index;
 	uint32_t core;
+	/* true if this DMA channel is the scheduling source */
+	bool is_scheduling_source;
 
 	/* client callback function */
 	void (*cb)(void *data, uint32_t type, struct dma_cb_data *next);
@@ -432,6 +436,11 @@ static inline void dma_chan_reg_update_bits(struct dma_chan_data *channel,
 {
 	io_reg_update_bits(dma_chan_base(channel->dma, channel->index) + reg,
 			   mask, value);
+}
+
+static inline bool dma_is_scheduling_source(struct dma_chan_data *channel)
+{
+	return channel->is_scheduling_source;
 }
 
 static inline void dma_sg_init(struct dma_sg_elem_array *ea)

--- a/src/include/sof/lib/dma.h
+++ b/src/include/sof/lib/dma.h
@@ -79,6 +79,14 @@ enum dma_cb_status {
 	DMA_CB_STATUS_END,
 };
 
+/* DMA interrupt commands */
+enum dma_irq_cmd {
+	DMA_IRQ_STATUS_GET = 0,
+	DMA_IRQ_CLEAR,
+	DMA_IRQ_MASK,
+	DMA_IRQ_UNMASK
+};
+
 #define DMA_CHAN_INVALID	0xFFFFFFFF
 
 /* DMA attributes */
@@ -166,6 +174,8 @@ struct dma_ops {
 			     uint32_t *free);
 
 	int (*get_attribute)(struct dma *dma, uint32_t type, uint32_t *value);
+
+	int (*interrupt)(struct dma_chan_data *channel, enum dma_irq_cmd cmd);
 };
 
 /* DMA platform data */
@@ -354,6 +364,12 @@ static inline int dma_get_attribute(struct dma *dma, uint32_t type,
 				    uint32_t *value)
 {
 	return dma->ops->get_attribute(dma, type, value);
+}
+
+static inline int dma_interrupt(struct dma_chan_data *channel,
+				enum dma_irq_cmd cmd)
+{
+	return channel->dma->ops->interrupt(channel, cmd);
 }
 
 /* DMA hardware register operations */

--- a/src/include/sof/lib/dma.h
+++ b/src/include/sof/lib/dma.h
@@ -21,7 +21,6 @@
 #include <sof/bit.h>
 #include <sof/lib/cache.h>
 #include <sof/lib/io.h>
-#include <sof/lib/wait.h>
 #include <sof/spinlock.h>
 #include <stdbool.h>
 #include <stddef.h>
@@ -485,7 +484,6 @@ static inline uint32_t dma_sg_get_size(struct dma_sg_elem_array *ea)
 struct dma_copy {
 	struct dma_chan_data *chan;
 	struct dma *dmac;
-	completion_t complete;
 };
 
 /* init dma copy context */

--- a/src/include/sof/lib/dma.h
+++ b/src/include/sof/lib/dma.h
@@ -74,7 +74,6 @@
 enum dma_cb_status {
 	DMA_CB_STATUS_RELOAD = 0,
 	DMA_CB_STATUS_SPLIT,
-	DMA_CB_STATUS_IGNORE,
 	DMA_CB_STATUS_END,
 };
 

--- a/src/include/sof/lib/wait.h
+++ b/src/include/sof/lib/wait.h
@@ -69,7 +69,7 @@ static inline void wait_init(completion_t *comp)
 
 	c->complete = 0;
 
-	schedule_task_init(&comp->work, SOF_SCHEDULE_LL, SOF_TASK_PRI_MED,
+	schedule_task_init(&comp->work, SOF_SCHEDULE_LL_TIMER, SOF_TASK_PRI_MED,
 			   _wait_cb, NULL, comp, 0, 0);
 }
 

--- a/src/include/sof/schedule/ll_schedule_domain.h
+++ b/src/include/sof/schedule/ll_schedule_domain.h
@@ -20,6 +20,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+struct dma;
 struct ll_schedule_domain;
 struct task;
 struct timer;
@@ -125,5 +126,9 @@ static inline bool domain_is_pending(struct ll_schedule_domain *domain,
 
 struct ll_schedule_domain *timer_domain_init(struct timer *timer, int clk,
 					     uint64_t timeout);
+
+struct ll_schedule_domain *dma_multi_chan_domain_init(struct dma *dma_array,
+						      uint32_t num_dma, int clk,
+						      bool aggregated_irq);
 
 #endif /* __SOF_SCHEDULE_LL_SCHEDULE_DOMAIN_H__ */

--- a/src/include/sof/schedule/schedule.h
+++ b/src/include/sof/schedule/schedule.h
@@ -29,7 +29,7 @@
 /* SOF_SCHEDULE_ type comes from topology */
 enum {
 	SOF_SCHEDULE_EDF = 0,	/* EDF scheduler */
-	SOF_SCHEDULE_LL,	/* Low latency scheduler */
+	SOF_SCHEDULE_LL_TIMER,	/* Low latency timer scheduler */
 	SOF_SCHEDULE_COUNT
 };
 

--- a/src/include/sof/schedule/schedule.h
+++ b/src/include/sof/schedule/schedule.h
@@ -28,8 +28,18 @@
 
 /* SOF_SCHEDULE_ type comes from topology */
 enum {
-	SOF_SCHEDULE_EDF = 0,	/* EDF scheduler */
-	SOF_SCHEDULE_LL_TIMER,	/* Low latency timer scheduler */
+	/* EDF scheduler - schedules based on task's deadline */
+	SOF_SCHEDULE_EDF = 0,
+
+	/* Low latency timer scheduler - schedules immediately on selected
+	 * timer's tick
+	 */
+	SOF_SCHEDULE_LL_TIMER,
+
+	/* Low latency DMA scheduler - schedules immediately on scheduling
+	 * component's DMA interrupt
+	 */
+	SOF_SCHEDULE_LL_DMA,
 	SOF_SCHEDULE_COUNT
 };
 

--- a/src/lib/agent.c
+++ b/src/lib/agent.c
@@ -83,7 +83,7 @@ void sa_init(struct sof *sof)
 	sa->last_idle = platform_timer_get(platform_timer) + sa->ticks;
 	sa->is_active = true;
 
-	schedule_task_init(&sa->work, SOF_SCHEDULE_LL, SOF_TASK_PRI_HIGH,
+	schedule_task_init(&sa->work, SOF_SCHEDULE_LL_TIMER, SOF_TASK_PRI_HIGH,
 			   validate, NULL, sa, 0, 0);
 
 	schedule_task(&sa->work, PLATFORM_IDLE_TIME, PLATFORM_IDLE_TIME);

--- a/src/platform/Kconfig
+++ b/src/platform/Kconfig
@@ -9,7 +9,7 @@ choice
 config BAYTRAIL
 	bool "Build for Baytrail"
 	select HOST_PTABLE
-	select DMA_AGGREGATED_IRQ
+	select DW_DMA_AGGREGATED_IRQ
 	select DMA_SUSPEND_DRAIN
 	select DMA_FIFO_PARTITION
 	select DW
@@ -22,7 +22,7 @@ config BAYTRAIL
 config CHERRYTRAIL
 	bool "Build for Cherrytrail"
 	select HOST_PTABLE
-	select DMA_AGGREGATED_IRQ
+	select DW_DMA_AGGREGATED_IRQ
 	select DMA_SUSPEND_DRAIN
 	select DMA_FIFO_PARTITION
 	select DW
@@ -35,7 +35,7 @@ config CHERRYTRAIL
 config HASWELL
 	bool "Build for Haswell"
 	select HOST_PTABLE
-	select DMA_AGGREGATED_IRQ
+	select DW_DMA_AGGREGATED_IRQ
 	select DW
 	select DW_DMA
 	select HAVE_RESET_VECTOR_ROM
@@ -46,7 +46,7 @@ config HASWELL
 config BROADWELL
 	bool "Build for Broadwell"
 	select HOST_PTABLE
-	select DMA_AGGREGATED_IRQ
+	select DW_DMA_AGGREGATED_IRQ
 	select DW
 	select DW_DMA
 	select HAVE_RESET_VECTOR_ROM
@@ -78,7 +78,7 @@ config CANNONLAKE
 	select DW_DMA
 	select MEM_WND
 	select HW_LLI
-	select DMA_AGGREGATED_IRQ
+	select DW_DMA_AGGREGATED_IRQ
 	select DMA_FIFO_PARTITION
 	select CAVS
 	select CAVS_VERSION_1_8
@@ -96,7 +96,7 @@ config SUECREEK
 	select INTEL_IOMUX
 	select DW_GPIO
 	select HW_LLI
-	select DMA_AGGREGATED_IRQ
+	select DW_DMA_AGGREGATED_IRQ
 	select DMA_FIFO_PARTITION
 	select CAVS
 	select CAVS_VERSION_2_0
@@ -113,7 +113,7 @@ config ICELAKE
 	select DW_DMA
 	select MEM_WND
 	select HW_LLI
-	select DMA_AGGREGATED_IRQ
+	select DW_DMA_AGGREGATED_IRQ
 	select DMA_FIFO_PARTITION
 	select CAVS
 	select CAVS_VERSION_2_0
@@ -132,7 +132,7 @@ config TIGERLAKE
 	select TASK_HAVE_PRIORITY_LOW
 	select TASK_HAVE_PRIORITY_MEDIUM
 	select HW_LLI
-	select DMA_AGGREGATED_IRQ
+	select DW_DMA_AGGREGATED_IRQ
 	select DMA_FIFO_PARTITION
 	select CAVS
 	select CAVS_VERSION_2_5

--- a/src/platform/apollolake/include/platform/lib/dma.h
+++ b/src/platform/apollolake/include/platform/lib/dma.h
@@ -11,6 +11,9 @@
 #ifndef __PLATFORM_LIB_DMA_H__
 #define __PLATFORM_LIB_DMA_H__
 
+/* number of supported DMACs */
+#define PLATFORM_NUM_DMACS	6
+
 /* available DMACs */
 #define DMA_GP_LP_DMAC0		0
 #define DMA_GP_LP_DMAC1		1

--- a/src/platform/apollolake/include/platform/lib/dma.h
+++ b/src/platform/apollolake/include/platform/lib/dma.h
@@ -14,6 +14,9 @@
 /* number of supported DMACs */
 #define PLATFORM_NUM_DMACS	6
 
+/* max number of supported DMA channels */
+#define PLATFORM_MAX_DMA_CHAN	8
+
 /* available DMACs */
 #define DMA_GP_LP_DMAC0		0
 #define DMA_GP_LP_DMAC1		1

--- a/src/platform/apollolake/include/platform/platform.h
+++ b/src/platform/apollolake/include/platform/platform.h
@@ -143,6 +143,7 @@ void platform_wait_for_interrupt(int level);
 extern struct timer *platform_timer;
 
 extern struct ll_schedule_domain *platform_timer_domain;
+extern struct ll_schedule_domain *platform_dma_domain;
 
 extern intptr_t _module_init_start;
 extern intptr_t _module_init_end;

--- a/src/platform/baytrail/include/platform/drivers/dw-dma.h
+++ b/src/platform/baytrail/include/platform/drivers/dw-dma.h
@@ -20,6 +20,9 @@
 #define PLATFORM_NUM_DW_DMACS	2
 #endif
 
+/* index of the first DW-DMAC in the array */
+#define PLATFORM_DW_DMA_INDEX	0
+
 /* CTL_HI */
 #define DW_CTLH_CLASS(x)	SET_BITS(31, 29, x)
 #define DW_CTLH_WEIGHT(x)	SET_BITS(28, 18, x)

--- a/src/platform/baytrail/include/platform/drivers/dw-dma.h
+++ b/src/platform/baytrail/include/platform/drivers/dw-dma.h
@@ -11,6 +11,14 @@
 #define __PLATFORM_DRIVERS_DW_DMA_H__
 
 #include <sof/bit.h>
+#include <config.h>
+
+/* number of supported DW-DMACs */
+#if CONFIG_CHERRYTRAIL_EXTRA_DW_DMA
+#define PLATFORM_NUM_DW_DMACS	3
+#else
+#define PLATFORM_NUM_DW_DMACS	2
+#endif
 
 /* CTL_HI */
 #define DW_CTLH_CLASS(x)	SET_BITS(31, 29, x)

--- a/src/platform/baytrail/include/platform/lib/dma.h
+++ b/src/platform/baytrail/include/platform/lib/dma.h
@@ -19,6 +19,9 @@
 #define PLATFORM_NUM_DMACS	2
 #endif
 
+/* max number of supported DMA channels */
+#define PLATFORM_MAX_DMA_CHAN	8
+
 #define DMA_ID_DMAC0	0
 #define DMA_ID_DMAC1	1
 #define DMA_ID_DMAC2	2

--- a/src/platform/baytrail/include/platform/platform.h
+++ b/src/platform/baytrail/include/platform/platform.h
@@ -128,6 +128,7 @@ static inline void platform_wait_for_interrupt(int level)
 extern struct timer *platform_timer;
 
 extern struct ll_schedule_domain *platform_timer_domain;
+extern struct ll_schedule_domain *platform_dma_domain;
 
 extern intptr_t _module_init_start;
 extern intptr_t _module_init_end;

--- a/src/platform/cannonlake/include/platform/lib/dma.h
+++ b/src/platform/cannonlake/include/platform/lib/dma.h
@@ -12,6 +12,9 @@
 #ifndef __PLATFORM_LIB_DMA_H__
 #define __PLATFORM_LIB_DMA_H__
 
+/* number of supported DMACs */
+#define PLATFORM_NUM_DMACS	6
+
 /* available DMACs */
 #define DMA_GP_LP_DMAC0		0
 #define DMA_GP_LP_DMAC1		1

--- a/src/platform/cannonlake/include/platform/lib/dma.h
+++ b/src/platform/cannonlake/include/platform/lib/dma.h
@@ -15,6 +15,9 @@
 /* number of supported DMACs */
 #define PLATFORM_NUM_DMACS	6
 
+/* max number of supported DMA channels */
+#define PLATFORM_MAX_DMA_CHAN	9
+
 /* available DMACs */
 #define DMA_GP_LP_DMAC0		0
 #define DMA_GP_LP_DMAC1		1

--- a/src/platform/cannonlake/include/platform/platform.h
+++ b/src/platform/cannonlake/include/platform/platform.h
@@ -140,6 +140,7 @@ void platform_wait_for_interrupt(int level);
 extern struct timer *platform_timer;
 
 extern struct ll_schedule_domain *platform_timer_domain;
+extern struct ll_schedule_domain *platform_dma_domain;
 
 extern intptr_t _module_init_start;
 extern intptr_t _module_init_end;

--- a/src/platform/haswell/include/platform/drivers/dw-dma.h
+++ b/src/platform/haswell/include/platform/drivers/dw-dma.h
@@ -15,6 +15,9 @@
 /* number of supported DW-DMACs */
 #define PLATFORM_NUM_DW_DMACS	2
 
+/* index of the first DW-DMAC in the array */
+#define PLATFORM_DW_DMA_INDEX	0
+
 /* CTL_HI */
 #define DW_CTLH_DONE(x)		SET_BIT(12, x)
 #define DW_CTLH_BLOCK_TS_MASK	MASK(11, 0)

--- a/src/platform/haswell/include/platform/drivers/dw-dma.h
+++ b/src/platform/haswell/include/platform/drivers/dw-dma.h
@@ -12,6 +12,9 @@
 
 #include <sof/bit.h>
 
+/* number of supported DW-DMACs */
+#define PLATFORM_NUM_DW_DMACS	2
+
 /* CTL_HI */
 #define DW_CTLH_DONE(x)		SET_BIT(12, x)
 #define DW_CTLH_BLOCK_TS_MASK	MASK(11, 0)

--- a/src/platform/haswell/include/platform/lib/dma.h
+++ b/src/platform/haswell/include/platform/lib/dma.h
@@ -12,6 +12,9 @@
 
 #define PLATFORM_NUM_DMACS		2
 
+/* max number of supported DMA channels */
+#define PLATFORM_MAX_DMA_CHAN	8
+
 #define DMA_ID_DMAC0			0
 #define DMA_ID_DMAC1			1
 

--- a/src/platform/haswell/include/platform/lib/memory.h
+++ b/src/platform/haswell/include/platform/lib/memory.h
@@ -100,7 +100,7 @@ void platform_init_memmap(void);
 #define SOF_DATA_SIZE			0xC000
 
 #define HEAP_SYSTEM_BASE		(DRAM0_BASE + SOF_DATA_SIZE)
-#define HEAP_SYSTEM_SIZE		0x3000
+#define HEAP_SYSTEM_SIZE		0x4000
 
 #define HEAP_SYSTEM_0_BASE		HEAP_SYSTEM_BASE
 

--- a/src/platform/haswell/include/platform/platform.h
+++ b/src/platform/haswell/include/platform/platform.h
@@ -117,6 +117,7 @@ static inline void platform_wait_for_interrupt(int level)
 extern struct timer *platform_timer;
 
 extern struct ll_schedule_domain *platform_timer_domain;
+extern struct ll_schedule_domain *platform_dma_domain;
 
 extern intptr_t _module_init_start;
 extern intptr_t _module_init_end;

--- a/src/platform/icelake/include/platform/lib/dma.h
+++ b/src/platform/icelake/include/platform/lib/dma.h
@@ -12,6 +12,9 @@
 #ifndef __PLATFORM_LIB_DMA_H__
 #define __PLATFORM_LIB_DMA_H__
 
+/* number of supported DMACs */
+#define PLATFORM_NUM_DMACS	6
+
 /* available DMACs */
 #define DMA_GP_LP_DMAC0		0
 #define DMA_GP_LP_DMAC1		1

--- a/src/platform/icelake/include/platform/lib/dma.h
+++ b/src/platform/icelake/include/platform/lib/dma.h
@@ -15,6 +15,9 @@
 /* number of supported DMACs */
 #define PLATFORM_NUM_DMACS	6
 
+/* max number of supported DMA channels */
+#define PLATFORM_MAX_DMA_CHAN	9
+
 /* available DMACs */
 #define DMA_GP_LP_DMAC0		0
 #define DMA_GP_LP_DMAC1		1

--- a/src/platform/icelake/include/platform/platform.h
+++ b/src/platform/icelake/include/platform/platform.h
@@ -140,6 +140,7 @@ void platform_wait_for_interrupt(int level);
 extern struct timer *platform_timer;
 
 extern struct ll_schedule_domain *platform_timer_domain;
+extern struct ll_schedule_domain *platform_dma_domain;
 
 extern intptr_t _module_init_start;
 extern intptr_t _module_init_end;

--- a/src/platform/imx8/include/platform/lib/dma.h
+++ b/src/platform/imx8/include/platform/lib/dma.h
@@ -18,6 +18,8 @@
 #define DMA_ID_EDMA0	0
 #define DMA_ID_HOST	1
 
+#define dma_chan_irq(dma, chan) (dma_irq(dma) + chan)
+
 int dmac_init(void);
 
 #endif /* __PLATFORM_LIB_DMA_H__ */

--- a/src/platform/imx8/include/platform/lib/dma.h
+++ b/src/platform/imx8/include/platform/lib/dma.h
@@ -12,6 +12,9 @@
 
 #define PLATFORM_NUM_DMACS	2
 
+/* max number of supported DMA channels */
+#define PLATFORM_MAX_DMA_CHAN	32
+
 #define DMA_ID_EDMA0	0
 #define DMA_ID_HOST	1
 

--- a/src/platform/intel/cavs/include/cavs/drivers/dw-dma.h
+++ b/src/platform/intel/cavs/include/cavs/drivers/dw-dma.h
@@ -20,6 +20,9 @@
 #define PLATFORM_NUM_DW_DMACS	2
 #endif
 
+/* index of the first DW-DMAC in the array */
+#define PLATFORM_DW_DMA_INDEX	0
+
 /* CTL_HI */
 #define DW_CTLH_CLASS(x)	SET_BITS(31, 29, x)
 #define DW_CTLH_WEIGHT(x)	SET_BITS(28, 18, x)

--- a/src/platform/intel/cavs/include/cavs/drivers/dw-dma.h
+++ b/src/platform/intel/cavs/include/cavs/drivers/dw-dma.h
@@ -11,6 +11,14 @@
 #define __CAVS_LIB_DW_DMA_H__
 
 #include <sof/bit.h>
+#include <config.h>
+
+/* number of supported DW-DMACs */
+#if CONFIG_SUECREEK
+#define PLATFORM_NUM_DW_DMACS	3
+#else
+#define PLATFORM_NUM_DW_DMACS	2
+#endif
 
 /* CTL_HI */
 #define DW_CTLH_CLASS(x)	SET_BITS(31, 29, x)

--- a/src/platform/intel/cavs/lib/dma.c
+++ b/src/platform/intel/cavs/lib/dma.c
@@ -22,18 +22,15 @@
 #define DMAC_HOST_OUT_CHANNELS_COUNT 6
 #define DMAC_LINK_IN_CHANNELS_COUNT 8
 #define DMAC_LINK_OUT_CHANNELS_COUNT 8
-#define CAVS_PLATFORM_NUM_DMACS		6
 #elif CONFIG_CANNONLAKE || CONFIG_ICELAKE || CONFIG_TIGERLAKE
 #define DMAC0_CLASS 6
 #define DMAC1_CLASS 7
 #define DMAC_HOST_OUT_CHANNELS_COUNT 9
 #define DMAC_LINK_IN_CHANNELS_COUNT 9
 #define DMAC_LINK_OUT_CHANNELS_COUNT 7
-#define CAVS_PLATFORM_NUM_DMACS		6
 #elif CONFIG_SUECREEK
 #define DMAC0_CLASS 6
 #define DMAC1_CLASS 7
-#define CAVS_PLATFORM_NUM_DMACS		3
 #endif
 
 static struct dw_drv_plat_data dmac0 = {
@@ -107,7 +104,7 @@ static struct dw_drv_plat_data dmac1 = {
 };
 
 #if CONFIG_SUECREEK
-static struct dma dma[CAVS_PLATFORM_NUM_DMACS] = {
+static struct dma dma[PLATFORM_NUM_DMACS] = {
 {	/* LP GP DMAC 0 */
 	.plat_data = {
 		.id		= DMA_GP_LP_DMAC0,
@@ -156,7 +153,7 @@ static struct dma dma[CAVS_PLATFORM_NUM_DMACS] = {
 };
 
 #else
-static struct dma dma[CAVS_PLATFORM_NUM_DMACS] = {
+static struct dma dma[PLATFORM_NUM_DMACS] = {
 {	/* Low Power GP DMAC 0 */
 	.plat_data = {
 		.id		= DMA_GP_LP_DMAC0,

--- a/src/platform/intel/cavs/lib/dma.c
+++ b/src/platform/intel/cavs/lib/dma.c
@@ -104,7 +104,7 @@ static struct dw_drv_plat_data dmac1 = {
 };
 
 #if CONFIG_SUECREEK
-static struct dma dma[PLATFORM_NUM_DMACS] = {
+struct dma dma[PLATFORM_NUM_DMACS] = {
 {	/* LP GP DMAC 0 */
 	.plat_data = {
 		.id		= DMA_GP_LP_DMAC0,
@@ -153,7 +153,7 @@ static struct dma dma[PLATFORM_NUM_DMACS] = {
 };
 
 #else
-static struct dma dma[PLATFORM_NUM_DMACS] = {
+struct dma dma[PLATFORM_NUM_DMACS] = {
 {	/* Low Power GP DMAC 0 */
 	.plat_data = {
 		.id		= DMA_GP_LP_DMAC0,

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -26,6 +26,8 @@
 #include <sof/lib/memory.h>
 #include <sof/lib/notifier.h>
 #include <sof/lib/pm_runtime.h>
+#include <sof/lib/wait.h>
+#include <sof/platform.h>
 #include <sof/schedule/edf_schedule.h>
 #include <sof/schedule/ll_schedule.h>
 #include <sof/schedule/ll_schedule_domain.h>

--- a/src/platform/suecreek/include/platform/lib/dma.h
+++ b/src/platform/suecreek/include/platform/lib/dma.h
@@ -15,6 +15,9 @@
 /* number of supported DMACs */
 #define PLATFORM_NUM_DMACS	3
 
+/* max number of supported DMA channels */
+#define PLATFORM_MAX_DMA_CHAN	8
+
 /* available DMACs */
 #define DMA_GP_LP_DMAC0		0
 #define DMA_GP_LP_DMAC1		1

--- a/src/platform/suecreek/include/platform/lib/dma.h
+++ b/src/platform/suecreek/include/platform/lib/dma.h
@@ -12,6 +12,9 @@
 #ifndef __PLATFORM_LIB_DMA_H__
 #define __PLATFORM_LIB_DMA_H__
 
+/* number of supported DMACs */
+#define PLATFORM_NUM_DMACS	3
+
 /* available DMACs */
 #define DMA_GP_LP_DMAC0		0
 #define DMA_GP_LP_DMAC1		1

--- a/src/platform/suecreek/include/platform/platform.h
+++ b/src/platform/suecreek/include/platform/platform.h
@@ -150,6 +150,7 @@ void platform_wait_for_interrupt(int level);
 extern struct timer *platform_timer;
 
 extern struct ll_schedule_domain *platform_timer_domain;
+extern struct ll_schedule_domain *platform_dma_domain;
 
 extern intptr_t _module_init_start;
 extern intptr_t _module_init_end;

--- a/src/platform/tigerlake/include/platform/lib/dma.h
+++ b/src/platform/tigerlake/include/platform/lib/dma.h
@@ -12,6 +12,9 @@
 #ifndef __PLATFORM_LIB_DMA_H__
 #define __PLATFORM_LIB_DMA_H__
 
+/* number of supported DMACs */
+#define PLATFORM_NUM_DMACS	6
+
 /* available DMACs */
 #define DMA_GP_LP_DMAC0		0
 #define DMA_GP_LP_DMAC1		1

--- a/src/platform/tigerlake/include/platform/lib/dma.h
+++ b/src/platform/tigerlake/include/platform/lib/dma.h
@@ -15,6 +15,9 @@
 /* number of supported DMACs */
 #define PLATFORM_NUM_DMACS	6
 
+/* max number of supported DMA channels */
+#define PLATFORM_MAX_DMA_CHAN	9
+
 /* available DMACs */
 #define DMA_GP_LP_DMAC0		0
 #define DMA_GP_LP_DMAC1		1

--- a/src/platform/tigerlake/include/platform/platform.h
+++ b/src/platform/tigerlake/include/platform/platform.h
@@ -140,6 +140,7 @@ void platform_wait_for_interrupt(int level);
 extern struct timer *platform_timer;
 
 extern struct ll_schedule_domain *platform_timer_domain;
+extern struct ll_schedule_domain *platform_dma_domain;
 
 extern intptr_t _module_init_start;
 extern intptr_t _module_init_end;

--- a/src/schedule/CMakeLists.txt
+++ b/src/schedule/CMakeLists.txt
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 add_local_sources(sof
+	dma_multi_chan_domain.c
 	edf_schedule.c
 	ll_schedule.c
 	schedule.c

--- a/src/schedule/dma_multi_chan_domain.c
+++ b/src/schedule/dma_multi_chan_domain.c
@@ -1,0 +1,304 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2019 Intel Corporation. All rights reserved.
+//
+// Author: Tomasz Lauda <tomasz.lauda@linux.intel.com>
+
+#include <sof/audio/component.h>
+#include <sof/bit.h>
+#include <sof/drivers/interrupt.h>
+#include <sof/lib/alloc.h>
+#include <sof/lib/cpu.h>
+#include <sof/lib/dma.h>
+#include <sof/schedule/ll_schedule_domain.h>
+#include <sof/schedule/schedule.h>
+#include <sof/schedule/task.h>
+#include <ipc/topology.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+struct dma_domain_data {
+	int irq;
+	struct task *task;
+	void (*handler)(void *arg);
+	void *arg;
+};
+
+struct dma_domain {
+	struct dma *dma_array;	/* pointer to scheduling DMAs */
+	uint32_t num_dma;	/* number of scheduling DMAs */
+	bool aggregated_irq;	/* true if aggregated interrupts */
+
+	/* mask of currently running channels */
+	uint32_t channel_mask[PLATFORM_NUM_DMACS][PLATFORM_CORE_COUNT];
+	/* array of arguments for aggregated mode */
+	struct dma_domain_data *arg[PLATFORM_NUM_DMACS][PLATFORM_CORE_COUNT];
+	/* array of registered channels data */
+	struct dma_domain_data data[PLATFORM_NUM_DMACS][PLATFORM_MAX_DMA_CHAN];
+};
+
+struct ll_schedule_domain_ops dma_multi_chan_domain_ops;
+
+/**
+ * \brief Generic DMA interrupt handler.
+ * \param[in,out] data Pointer to DMA domain data.
+ */
+static void dma_multi_chan_domain_irq_handler(void *data)
+{
+	struct dma_domain_data *domain_data = data;
+
+	/* just call registered handler */
+	domain_data->handler(domain_data->arg);
+}
+
+/**
+ * \brief Registers and enables selected DMA interrupt.
+ * \param[in,out] data Pointer to DMA domain data.
+ * \param[in,out] handler Pointer to DMA interrupt handler.
+ * \return Error code.
+ */
+static int dma_multi_chan_domain_irq_register(struct dma_domain_data *data,
+					      void (*handler)(void *arg))
+{
+	int ret;
+
+	/* always go through dma_multi_chan_domain_irq_handler,
+	 * so we have different arg registered for every channel
+	 */
+	ret = interrupt_register(data->irq, IRQ_AUTO_UNMASK,
+				 dma_multi_chan_domain_irq_handler, data);
+	if (ret < 0)
+		return ret;
+
+	interrupt_enable(data->irq, data);
+
+	return 0;
+}
+
+/**
+ * \brief Registers task to DMA domain.
+ * \param[in,out] domain Pointer to schedule domain.
+ * \param[in] period Period of the scheduled task.
+ * \param[in,out] task Task to be registered.
+ * \param[in,out] handler Pointer to DMA interrupt handler.
+ * \param[in,out] arg Pointer to DMA interrupt handler's argument.
+ * \return Error code.
+ *
+ * Keeps track of potential double registrations and handles non aggregated
+ * DMA interrupts (different irq number per DMA channel).
+ */
+static int dma_multi_chan_domain_register(struct ll_schedule_domain *domain,
+					  uint64_t period, struct task *task,
+					  void (*handler)(void *arg), void *arg)
+{
+	struct dma_domain *dma_domain = ll_sch_domain_get_pdata(domain);
+	struct dma *dmas = dma_domain->dma_array;
+	int core = cpu_get_id();
+	int ret;
+	int i;
+	int j;
+
+	for (i = 0; i < dma_domain->num_dma; ++i) {
+		for (j = 0; j < dmas[i].plat_data.channels; ++j) {
+			/* channel not set as scheduling source */
+			if (!dma_is_scheduling_source(&dmas[i].chan[j]))
+				continue;
+
+			/* channel not running */
+			if (dmas[i].chan[j].status != COMP_STATE_ACTIVE)
+				continue;
+
+			/* channel owned by different core */
+			if (core != dmas[i].chan[j].core)
+				continue;
+
+			/* channel has been already running */
+			if (dma_domain->channel_mask[i][core] & BIT(j))
+				continue;
+
+			dma_interrupt(&dmas[i].chan[j], DMA_IRQ_CLEAR);
+
+			/* register only if not aggregated or not registered */
+			if (!dma_domain->aggregated_irq ||
+			    !dma_domain->channel_mask[i][core]) {
+				ret = dma_multi_chan_domain_irq_register(
+						&dma_domain->data[i][j],
+						handler);
+				if (ret < 0)
+					return ret;
+
+				dma_domain->data[i][j].handler = handler;
+				dma_domain->data[i][j].arg = arg;
+
+				/* needed to unregister aggregated interrupts */
+				dma_domain->arg[i][core] =
+					&dma_domain->data[i][j];
+			}
+
+			interrupt_clear_mask(dma_domain->data[i][j].irq,
+					     BIT(j));
+
+			dma_interrupt(&dmas[i].chan[j], DMA_IRQ_UNMASK);
+
+			dma_domain->data[i][j].task = task;
+			dma_domain->channel_mask[i][core] |= BIT(j);
+
+			return 0;
+		}
+	}
+
+	return 0;
+}
+
+/**
+ * \brief Unregisters and disables selected DMA interrupt.
+ * \param[in,out] data data Pointer to DMA domain data.
+ */
+static void dma_multi_chan_domain_irq_unregister(struct dma_domain_data *data)
+{
+	interrupt_disable(data->irq, data);
+
+	interrupt_unregister(data->irq, data);
+}
+
+/**
+ * \brief Unregisters task from DMA domain.
+ * \param[in,out] domain Pointer to schedule domain.
+ * \param[in] num_tasks Number of currently scheduled tasks.
+ */
+static void dma_multi_chan_domain_unregister(struct ll_schedule_domain *domain,
+					     uint32_t num_tasks)
+{
+	struct dma_domain *dma_domain = ll_sch_domain_get_pdata(domain);
+	struct dma *dmas = dma_domain->dma_array;
+	int core = cpu_get_id();
+	int i;
+	int j;
+
+	for (i = 0; i < dma_domain->num_dma; ++i) {
+		for (j = 0; j < dmas[i].plat_data.channels; ++j) {
+			/* channel not set as scheduling source */
+			if (!dma_is_scheduling_source(&dmas[i].chan[j]))
+				continue;
+
+			/* channel still running */
+			if (dmas[i].chan[j].status == COMP_STATE_ACTIVE)
+				continue;
+
+			/* channel owned by different core */
+			if (core != dmas[i].chan[j].core)
+				continue;
+
+			/* channel hasn't been running */
+			if (!(dma_domain->channel_mask[i][core] & BIT(j)))
+				continue;
+
+			dma_interrupt(&dmas[i].chan[j], DMA_IRQ_MASK);
+			dma_interrupt(&dmas[i].chan[j], DMA_IRQ_CLEAR);
+			interrupt_clear_mask(dma_domain->data[i][j].irq,
+					     BIT(j));
+
+			dma_domain->data[i][j].task = NULL;
+			dma_domain->channel_mask[i][core] &= ~BIT(j);
+
+			/* unregister interrupt */
+			if (!dma_domain->aggregated_irq)
+				dma_multi_chan_domain_irq_unregister(
+						&dma_domain->data[i][j]);
+			else if (!dma_domain->channel_mask[i][core])
+				dma_multi_chan_domain_irq_unregister(
+						dma_domain->arg[i][core]);
+
+			return;
+		}
+	}
+}
+
+/**
+ * \brief Checks if given task should be executed.
+ * \param[in,out] domain Pointer to schedule domain.
+ * \param[in,out] task Task to be checked.
+ * \return True is task should be executed, false otherwise.
+ */
+static bool dma_multi_chan_domain_is_pending(struct ll_schedule_domain *domain,
+					     struct task *task)
+{
+	struct dma_domain *dma_domain = ll_sch_domain_get_pdata(domain);
+	struct dma *dmas = dma_domain->dma_array;
+	uint32_t status;
+	int i;
+	int j;
+
+	for (i = 0; i < dma_domain->num_dma; ++i) {
+		for (j = 0; j < dmas[i].plat_data.channels; ++j) {
+			status = dma_interrupt(&dmas[i].chan[j],
+					       DMA_IRQ_STATUS_GET);
+			if (!status)
+				continue;
+
+			/* not this task */
+			if (dma_domain->data[i][j].task != task)
+				continue;
+
+			/* clear interrupt */
+			dma_interrupt(&dmas[i].chan[j], DMA_IRQ_CLEAR);
+			interrupt_clear_mask(dma_domain->data[i][j].irq,
+					     BIT(j));
+
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
+ * \brief Initializes DMA multichannel scheduling domain.
+ * \param[in,out] dma_array Array of DMAs to be scheduled on.
+ * \param[in] num_dma Number of DMAs passed as dma_array.
+ * \param[in] clk Platform clock to base calculations on.
+ * \param[in] aggregated_irq True if all DMAs share the same interrupt line.
+ * \return Pointer to initialized scheduling domain object.
+ */
+struct ll_schedule_domain *dma_multi_chan_domain_init(struct dma *dma_array,
+						      uint32_t num_dma, int clk,
+						      bool aggregated_irq)
+{
+	struct ll_schedule_domain *domain;
+	struct dma_domain *dma_domain;
+	struct dma *dma;
+	int i;
+	int j;
+
+	domain = domain_init(SOF_SCHEDULE_LL_DMA, clk,
+			     &dma_multi_chan_domain_ops);
+
+	dma_domain = rzalloc(RZONE_SYS | RZONE_FLAG_UNCACHED, SOF_MEM_CAPS_RAM,
+			     sizeof(*dma_domain));
+	dma_domain->dma_array = dma_array;
+	dma_domain->num_dma = num_dma;
+	dma_domain->aggregated_irq = aggregated_irq;
+
+	/* retrieve IRQ numbers for each DMA channel */
+	for (i = 0; i < num_dma; ++i) {
+		dma = &dma_array[i];
+		for (j = 0; j < dma->plat_data.channels; ++j)
+			dma_domain->data[i][j].irq = interrupt_get_irq(
+				dma_chan_irq(dma, j), dma_irq_name(dma));
+	}
+
+	ll_sch_domain_set_pdata(domain, dma_domain);
+
+	return domain;
+}
+
+struct ll_schedule_domain_ops dma_multi_chan_domain_ops = {
+	.domain_register	= dma_multi_chan_domain_register,
+	.domain_unregister	= dma_multi_chan_domain_unregister,
+	.domain_is_pending	= dma_multi_chan_domain_is_pending,
+	.domain_set		= NULL,
+	.domain_enable		= NULL,
+	.domain_disable		= NULL,
+	.domain_clear		= NULL,
+};

--- a/src/schedule/timer_domain.c
+++ b/src/schedule/timer_domain.c
@@ -117,7 +117,7 @@ struct ll_schedule_domain *timer_domain_init(struct timer *timer, int clk,
 	struct ll_schedule_domain *domain;
 	struct timer_domain *timer_domain;
 
-	domain = domain_init(SOF_SCHEDULE_LL, clk, &timer_domain_ops);
+	domain = domain_init(SOF_SCHEDULE_LL_TIMER, clk, &timer_domain_ops);
 
 	timer_domain = rzalloc(RZONE_SYS | RZONE_FLAG_UNCACHED,
 			       SOF_MEM_CAPS_RAM, sizeof(*timer_domain));

--- a/src/trace/dma-trace.c
+++ b/src/trace/dma-trace.c
@@ -138,7 +138,7 @@ int dma_trace_init_complete(struct dma_trace_data *d)
 		return ret;
 	}
 
-	schedule_task_init(&d->dmat_work, SOF_SCHEDULE_LL,
+	schedule_task_init(&d->dmat_work, SOF_SCHEDULE_LL_TIMER,
 			   SOF_TASK_PRI_MED, trace_work, NULL, d, 0, 0);
 
 	return 0;

--- a/test/cmocka/src/audio/pipeline/pipeline_connection_mocks.c
+++ b/test/cmocka/src/audio/pipeline/pipeline_connection_mocks.c
@@ -37,7 +37,9 @@ struct pipeline_connect_data *get_standard_connect_objects(void)
 
 	pipe->ipc_pipe = pipe_desc;
 	pipe->status = COMP_STATE_INIT;
-	pipe->pipe_task.type = SOF_SCHEDULE_EDF;
+
+	pipe->pipe_task = calloc(sizeof(struct task), 1);
+	pipe->pipe_task->type = SOF_SCHEDULE_EDF;
 
 	schedulers = calloc(sizeof(struct schedulers), 1);
 	list_init(&schedulers->list);

--- a/test/cmocka/src/audio/pipeline/pipeline_free.c
+++ b/test/cmocka/src/audio/pipeline/pipeline_free.c
@@ -73,9 +73,9 @@ static void test_audio_pipeline_free_sheduler_task_free(void **state)
 	/*Testing component*/
 	pipeline_free(&result);
 
-	assert_int_equal(result.pipe_task.state, SOF_TASK_STATE_FREE);
-	assert_ptr_equal(NULL, result.pipe_task.data);
-	assert_ptr_equal(NULL, result.pipe_task.run);
+	assert_int_equal(result.pipe_task->state, SOF_TASK_STATE_FREE);
+	assert_ptr_equal(NULL, result.pipe_task->data);
+	assert_ptr_equal(NULL, result.pipe_task->run);
 }
 
 static void test_audio_pipeline_free_disconnect_full(void **state)


### PR DESCRIPTION
Implements DMA scheduling domain. It allows to initialize
another low latency scheduler and schedule on any DMA channel.
The functionality stays the same as the one already done in
DMA drivers e.g. DW-DMA.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>