### PR TITLE
agent: refactor agent to be more useful

### DIFF
--- a/src/arch/xtensa/init.c
+++ b/src/arch/xtensa/init.c
@@ -140,7 +140,7 @@ int slave_core_init(struct sof *sof)
 	platform_interrupt_init();
 
 	trace_point(TRACE_BOOT_PLATFORM_SCHED);
-	scheduler_init_edf(sof);
+	scheduler_init_edf();
 	scheduler_init_ll(platform_timer_domain);
 	scheduler_init_ll(platform_dma_domain);
 

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -22,7 +22,6 @@
 #include <sof/debug/panic.h>
 #include <sof/drivers/ipc.h>
 #include <sof/drivers/timer.h>
-#include <sof/lib/agent.h>
 #include <sof/lib/alloc.h>
 #include <sof/lib/clk.h>
 #include <sof/lib/notifier.h>
@@ -987,9 +986,6 @@ static void kpb_init_draining(struct comp_dev *dev, struct kpb_client *cli)
 		/* Pause selector copy. */
 		kpb->sel_sink->sink->state = COMP_STATE_PAUSED;
 
-		/* Disable system agent during draining */
-		sa_disable();
-
 		/* Schedule draining task */
 		schedule_task(&kpb->draining_task, 0, 0);
 	}
@@ -1128,9 +1124,6 @@ out:
 	 * variables.
 	 */
 	(void)(draining_time_end - draining_time_start);
-
-	/* Enable system agent back */
-	sa_enable();
 
 	return SOF_TASK_STATE_COMPLETED;
 }

--- a/src/include/sof/lib/agent.h
+++ b/src/include/sof/lib/agent.h
@@ -16,14 +16,14 @@ struct sof;
 
 /* simple agent */
 struct sa {
-	uint64_t last_idle;	/* time of last idle */
-	uint64_t ticks;
+	uint64_t last_check;	/* time of last activity checking */
+	uint64_t panic_timeout;	/* threshold of panic */
+	uint64_t warn_timeout;	/* threshold of warning */
 	struct task work;
 	bool is_active;
 };
 
-void sa_enter_idle(struct sof *sof);
-void sa_init(struct sof *sof);
+void sa_init(struct sof *sof, uint64_t timeout);
 void sa_disable(void);
 void sa_enable(void);
 

--- a/src/include/sof/lib/agent.h
+++ b/src/include/sof/lib/agent.h
@@ -20,11 +20,8 @@ struct sa {
 	uint64_t panic_timeout;	/* threshold of panic */
 	uint64_t warn_timeout;	/* threshold of warning */
 	struct task work;
-	bool is_active;
 };
 
 void sa_init(struct sof *sof, uint64_t timeout);
-void sa_disable(void);
-void sa_enable(void);
 
 #endif /* __SOF_LIB_AGENT_H__ */

--- a/src/include/sof/schedule/edf_schedule.h
+++ b/src/include/sof/schedule/edf_schedule.h
@@ -13,8 +13,6 @@
 #include <user/trace.h>
 #include <stdint.h>
 
-struct sof;
-
 /* schedule tracing */
 #define trace_edf_sch(format, ...) \
 	trace_event(TRACE_CLASS_EDF, format, ##__VA_ARGS__)
@@ -35,6 +33,6 @@ struct edf_task_pdata {
 	void *ctx;
 };
 
-int scheduler_init_edf(struct sof *sof);
+int scheduler_init_edf(void);
 
 #endif /* __SOF_SCHEDULE_EDF_SCHEDULE_H__ */

--- a/src/include/sof/schedule/task.h
+++ b/src/include/sof/schedule/task.h
@@ -57,7 +57,7 @@ enum task_state task_main_master_core(void *data);
 
 enum task_state task_main_slave_core(void *data);
 
-void task_main_init(struct sof *sof);
+void task_main_init(void);
 
 void task_main_free(void);
 

--- a/src/lib/agent.c
+++ b/src/lib/agent.c
@@ -32,6 +32,8 @@
 	trace_event_atomic(TRACE_CLASS_SA, __e, ##__VA_ARGS__)
 #define trace_sa_value(__e, ...) \
 	trace_value_atomic(__e, ##__VA_ARGS__)
+#define trace_sa_error(__e, ...) \
+	trace_error(TRACE_CLASS_SA, __e, ##__VA_ARGS__)
 
 struct sa *sa;
 

--- a/src/lib/agent.c
+++ b/src/lib/agent.c
@@ -44,22 +44,20 @@ static enum task_state validate(void *data)
 	uint64_t current;
 	uint64_t delta;
 
-	if (sa->is_active) {
-		current = platform_timer_get(platform_timer);
-		delta = current - sa->last_check;
+	current = platform_timer_get(platform_timer);
+	delta = current - sa->last_check;
 
-		/* panic timeout */
-		if (delta > sa->panic_timeout)
-			panic(SOF_IPC_PANIC_IDLE);
+	/* panic timeout */
+	if (delta > sa->panic_timeout)
+		panic(SOF_IPC_PANIC_IDLE);
 
-		/* warning timeout */
-		if (delta > sa->warn_timeout)
-			trace_sa_error("validate(), ll drift detected, delta = "
-				       "%u", delta);
+	/* warning timeout */
+	if (delta > sa->warn_timeout)
+		trace_sa_error("validate(), ll drift detected, delta = "
+			       "%u", delta);
 
-		/* update last_check to current */
-		sa->last_check = current;
-	}
+	/* update last_check to current */
+	sa->last_check = current;
 
 	return SOF_TASK_STATE_RESCHEDULE;
 }
@@ -90,17 +88,5 @@ void sa_init(struct sof *sof, uint64_t timeout)
 	schedule_task(&sa->work, 0, timeout);
 
 	/* set last check time to now to give time for boot completion */
-	sa->last_check = platform_timer_get(platform_timer);
-	sa->is_active = true;
-}
-
-void sa_disable(void)
-{
-	sa->is_active = false;
-}
-
-void sa_enable(void)
-{
-	sa->is_active = true;
 	sa->last_check = platform_timer_get(platform_timer);
 }

--- a/src/platform/Kconfig
+++ b/src/platform/Kconfig
@@ -236,4 +236,13 @@ config FIRMWARE_SHORT_NAME
 	  3-characters long firmware identifer
 	  used by rimage to decide how to build final binary
 
+config SYSTICK_PERIOD
+	int "System tick period in microseconds"
+	default 1000
+	help
+	  Defines platform system tick period. It is used to
+	  drive timer based low latency scheduler and also
+	  as a timeout check value for system agent.
+	  Value should be provided in microseconds.
+
 endmenu

--- a/src/platform/apollolake/include/platform/platform.h
+++ b/src/platform/apollolake/include/platform/platform.h
@@ -56,11 +56,6 @@ struct timer;
 #define PLATFORM_MAX_CHANNELS	8
 #define PLATFORM_MAX_STREAMS	16
 
-/*! \def PLATFORM_LL_DEFAULT_TIMEOUT
- *  \brief low latency scheduler default timeout in microseconds
- */
-#define PLATFORM_LL_DEFAULT_TIMEOUT	1000
-
 /* local buffer size of DMA tracing */
 #define DMA_TRACE_LOCAL_SIZE	(HOST_PAGE_SIZE * 2)
 

--- a/src/platform/apollolake/include/platform/platform.h
+++ b/src/platform/apollolake/include/platform/platform.h
@@ -71,9 +71,6 @@ struct timer;
  */
 #define DMA_TRACE_RESCHEDULE_TIME	500
 
-/* DSP should be idle in this time frame */
-#define PLATFORM_IDLE_TIME	750000
-
 /* platform has DMA memory type */
 #define PLATFORM_MEM_HAS_DMA
 

--- a/src/platform/baytrail/include/platform/platform.h
+++ b/src/platform/baytrail/include/platform/platform.h
@@ -40,11 +40,6 @@ struct timer;
  */
 #define PLATFORM_DEFAULT_CLOCK CLK_SSP
 
-/*! \def PLATFORM_LL_DEFAULT_TIMEOUT
- *  \brief low latency scheduler default timeout in microseconds
- */
-#define PLATFORM_LL_DEFAULT_TIMEOUT	1000
-
 /* IPC Interrupt */
 #define PLATFORM_IPC_INTERRUPT	IRQ_NUM_EXT_IA
 #define PLATFORM_IPC_INTERRUPT_NAME	NULL

--- a/src/platform/baytrail/include/platform/platform.h
+++ b/src/platform/baytrail/include/platform/platform.h
@@ -71,9 +71,6 @@ struct timer;
  */
 #define DMA_TRACE_RESCHEDULE_TIME	100
 
-/* DSP should be idle in this time frame */
-#define PLATFORM_IDLE_TIME	750000
-
 /* DSP default delay in cycles */
 #define PLATFORM_DEFAULT_DELAY	12
 

--- a/src/platform/baytrail/platform.c
+++ b/src/platform/baytrail/platform.c
@@ -190,7 +190,7 @@ int platform_init(struct sof *sof)
 	clock_init();
 
 	trace_point(TRACE_BOOT_PLATFORM_SCHED);
-	scheduler_init_edf(sof);
+	scheduler_init_edf();
 
 	/* init low latency timer domain and scheduler */
 	platform_timer_domain =

--- a/src/platform/baytrail/platform.c
+++ b/src/platform/baytrail/platform.c
@@ -208,7 +208,7 @@ int platform_init(struct sof *sof)
 
 	/* init the system agent */
 	trace_point(TRACE_BOOT_PLATFORM_AGENT);
-	sa_init(sof);
+	sa_init(sof, CONFIG_SYSTICK_PERIOD);
 
 	/* Set CPU to default frequency for booting */
 	trace_point(TRACE_BOOT_PLATFORM_CPU_FREQ);

--- a/src/platform/baytrail/platform.c
+++ b/src/platform/baytrail/platform.c
@@ -195,7 +195,7 @@ int platform_init(struct sof *sof)
 	/* init low latency timer domain and scheduler */
 	platform_timer_domain =
 		timer_domain_init(platform_timer, PLATFORM_DEFAULT_CLOCK,
-				  PLATFORM_LL_DEFAULT_TIMEOUT);
+				  CONFIG_SYSTICK_PERIOD);
 	scheduler_init_ll(platform_timer_domain);
 
 	/* init low latency multi channel DW-DMA domain and scheduler */

--- a/src/platform/cannonlake/include/platform/platform.h
+++ b/src/platform/cannonlake/include/platform/platform.h
@@ -74,9 +74,6 @@ struct timer;
  */
 #define DMA_TRACE_RESCHEDULE_TIME	500
 
-/* DSP should be idle in this time frame */
-#define PLATFORM_IDLE_TIME	750000
-
 /* DSP default delay in cycles */
 #define PLATFORM_DEFAULT_DELAY	12
 

--- a/src/platform/cannonlake/include/platform/platform.h
+++ b/src/platform/cannonlake/include/platform/platform.h
@@ -37,11 +37,6 @@ struct timer;
  */
 #define PLATFORM_DEFAULT_CLOCK CLK_SSP
 
-/*! \def PLATFORM_LL_DEFAULT_TIMEOUT
- *  \brief low latency scheduler default timeout in microseconds
- */
-#define PLATFORM_LL_DEFAULT_TIMEOUT	1000
-
 #define MAX_GPDMA_COUNT 2
 
 /* Host page size */

--- a/src/platform/haswell/include/platform/platform.h
+++ b/src/platform/haswell/include/platform/platform.h
@@ -36,11 +36,6 @@ struct timer;
  */
 #define PLATFORM_DEFAULT_CLOCK CLK_CPU(0)
 
-/*! \def PLATFORM_LL_DEFAULT_TIMEOUT
- *  \brief low latency scheduler default timeout in microseconds
- */
-#define PLATFORM_LL_DEFAULT_TIMEOUT	1000
-
 /* IPC Interrupt */
 #define PLATFORM_IPC_INTERRUPT	IRQ_NUM_EXT_IA
 #define PLATFORM_IPC_INTERRUPT_NAME	NULL

--- a/src/platform/haswell/include/platform/platform.h
+++ b/src/platform/haswell/include/platform/platform.h
@@ -67,9 +67,6 @@ struct timer;
  */
 #define DMA_TRACE_RESCHEDULE_TIME	100
 
-/* DSP should be idle in this time frame */
-#define PLATFORM_IDLE_TIME	750000
-
 /* DSP default delay in cycles */
 #define PLATFORM_DEFAULT_DELAY	12
 

--- a/src/platform/haswell/platform.c
+++ b/src/platform/haswell/platform.c
@@ -196,7 +196,7 @@ int platform_init(struct sof *sof)
 
 	/* init the system agent */
 	trace_point(TRACE_BOOT_PLATFORM_AGENT);
-	sa_init(sof);
+	sa_init(sof, CONFIG_SYSTICK_PERIOD);
 
 	/* Set CPU to default frequency for booting */
 	trace_point(TRACE_BOOT_PLATFORM_CPU_FREQ);

--- a/src/platform/haswell/platform.c
+++ b/src/platform/haswell/platform.c
@@ -178,7 +178,7 @@ int platform_init(struct sof *sof)
 	clock_init();
 
 	trace_point(TRACE_BOOT_PLATFORM_SCHED);
-	scheduler_init_edf(sof);
+	scheduler_init_edf();
 
 	/* init low latency timer domain and scheduler */
 	platform_timer_domain =

--- a/src/platform/haswell/platform.c
+++ b/src/platform/haswell/platform.c
@@ -183,7 +183,7 @@ int platform_init(struct sof *sof)
 	/* init low latency timer domain and scheduler */
 	platform_timer_domain =
 		timer_domain_init(platform_timer, PLATFORM_DEFAULT_CLOCK,
-				  PLATFORM_LL_DEFAULT_TIMEOUT);
+				  CONFIG_SYSTICK_PERIOD);
 	scheduler_init_ll(platform_timer_domain);
 
 	/* init low latency multi channel DW-DMA domain and scheduler */

--- a/src/platform/icelake/include/platform/platform.h
+++ b/src/platform/icelake/include/platform/platform.h
@@ -74,9 +74,6 @@ struct timer;
  */
 #define DMA_TRACE_RESCHEDULE_TIME	500
 
-/* DSP should be idle in this time frame */
-#define PLATFORM_IDLE_TIME	750000
-
 /* DSP default delay in cycles */
 #define PLATFORM_DEFAULT_DELAY	12
 

--- a/src/platform/icelake/include/platform/platform.h
+++ b/src/platform/icelake/include/platform/platform.h
@@ -37,11 +37,6 @@ struct timer;
  */
 #define PLATFORM_DEFAULT_CLOCK CLK_SSP
 
-/*! \def PLATFORM_LL_DEFAULT_TIMEOUT
- *  \brief low latency scheduler default timeout in microseconds
- */
-#define PLATFORM_LL_DEFAULT_TIMEOUT	1000
-
 #define MAX_GPDMA_COUNT 2
 
 /* Host page size */

--- a/src/platform/imx8/include/platform/platform.h
+++ b/src/platform/imx8/include/platform/platform.h
@@ -56,9 +56,6 @@ struct timer;
  */
 #define DMA_TRACE_RESCHEDULE_TIME	100
 
-/* DSP should be idle in this time frame */
-#define PLATFORM_IDLE_TIME	750000
-
 /* DSP default delay in cycles */
 #define PLATFORM_DEFAULT_DELAY	12
 

--- a/src/platform/imx8/include/platform/platform.h
+++ b/src/platform/imx8/include/platform/platform.h
@@ -25,11 +25,6 @@ struct timer;
 #define PLATFORM_DEFAULT_CLOCK CLK_CPU(0)
 #define LPSRAM_SIZE 16384
 
-/*! \def PLATFORM_LL_DEFAULT_TIMEOUT
- *  \brief low latency scheduler default timeout in microseconds
- */
-#define PLATFORM_LL_DEFAULT_TIMEOUT	1000
-
 /* IPC Interrupt */
 #define PLATFORM_IPC_INTERRUPT		IRQ_NUM_MU
 #define PLATFORM_IPC_INTERRUPT_NAME	NULL

--- a/src/platform/imx8/platform.c
+++ b/src/platform/imx8/platform.c
@@ -150,7 +150,7 @@ int platform_init(struct sof *sof)
 	/* init low latency domains and schedulers */
 	platform_timer_domain =
 		timer_domain_init(platform_timer, PLATFORM_DEFAULT_CLOCK,
-				  PLATFORM_LL_DEFAULT_TIMEOUT);
+				  CONFIG_SYSTICK_PERIOD);
 	scheduler_init_ll(platform_timer_domain);
 
 	/* Init EDMA platform domain */

--- a/src/platform/imx8/platform.c
+++ b/src/platform/imx8/platform.c
@@ -145,7 +145,7 @@ int platform_init(struct sof *sof)
 
 	platform_interrupt_init();
 	clock_init();
-	scheduler_init_edf(sof);
+	scheduler_init_edf();
 
 	/* init low latency domains and schedulers */
 	platform_timer_domain =

--- a/src/platform/imx8/platform.c
+++ b/src/platform/imx8/platform.c
@@ -163,7 +163,7 @@ int platform_init(struct sof *sof)
 	scheduler_init_ll(platform_dma_domain);
 
 	platform_timer_start(platform_timer);
-	sa_init(sof);
+	sa_init(sof, CONFIG_SYSTICK_PERIOD);
 
 	clock_set_freq(CLK_CPU(cpu_get_id()), CLK_MAX_CPU_HZ);
 

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -383,7 +383,7 @@ int platform_init(struct sof *sof)
 	/* init low latency timer domain and scheduler */
 	platform_timer_domain =
 		timer_domain_init(platform_timer, PLATFORM_DEFAULT_CLOCK,
-				  PLATFORM_LL_DEFAULT_TIMEOUT);
+				  CONFIG_SYSTICK_PERIOD);
 	scheduler_init_ll(platform_timer_domain);
 
 	/* init low latency single channel DW-DMA domain and scheduler */

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -396,7 +396,7 @@ int platform_init(struct sof *sof)
 
 	/* init the system agent */
 	trace_point(TRACE_BOOT_PLATFORM_AGENT);
-	sa_init(sof);
+	sa_init(sof, CONFIG_SYSTICK_PERIOD);
 
 	/* Set CPU to max frequency for booting (single shim_write below) */
 	trace_point(TRACE_BOOT_PLATFORM_CPU_FREQ);

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -378,7 +378,7 @@ int platform_init(struct sof *sof)
 	clock_init();
 
 	trace_point(TRACE_BOOT_PLATFORM_SCHED);
-	scheduler_init_edf(sof);
+	scheduler_init_edf();
 
 	/* init low latency timer domain and scheduler */
 	platform_timer_domain =

--- a/src/platform/library/include/platform/platform.h
+++ b/src/platform/library/include/platform/platform.h
@@ -26,11 +26,6 @@ struct timer;
  */
 #define PLATFORM_DEFAULT_CLOCK CLK_CPU(0)
 
-/*! \def PLATFORM_LL_DEFAULT_TIMEOUT
- *  \brief low latency scheduler default timeout in microseconds
- */
-#define PLATFORM_LL_DEFAULT_TIMEOUT	1000
-
 /* Host page size */
 #define HOST_PAGE_SIZE		4096
 

--- a/src/platform/suecreek/include/platform/platform.h
+++ b/src/platform/suecreek/include/platform/platform.h
@@ -70,9 +70,6 @@ struct timer;
  */
 #define DMA_TRACE_RESCHEDULE_TIME	500
 
-/* DSP should be idle in this time frame */
-#define PLATFORM_IDLE_TIME	750000
-
 /* baud-rate used for uart port trace log */
 #define PATFORM_TRACE_UART_BAUDRATE		115200
 

--- a/src/platform/suecreek/include/platform/platform.h
+++ b/src/platform/suecreek/include/platform/platform.h
@@ -37,11 +37,6 @@ struct timer;
  */
 #define PLATFORM_DEFAULT_CLOCK CLK_SSP
 
-/*! \def PLATFORM_LL_DEFAULT_TIMEOUT
- *  \brief low latency scheduler default timeout in microseconds
- */
-#define PLATFORM_LL_DEFAULT_TIMEOUT	1000
-
 #define MAX_GPDMA_COUNT 2
 
 /* Host page size */

--- a/src/platform/tigerlake/include/platform/platform.h
+++ b/src/platform/tigerlake/include/platform/platform.h
@@ -74,9 +74,6 @@ struct timer;
  */
 #define DMA_TRACE_RESCHEDULE_TIME	500
 
-/* DSP should be idle in this time frame */
-#define PLATFORM_IDLE_TIME	750000
-
 /* DSP default delay in cycles */
 #define PLATFORM_DEFAULT_DELAY	12
 

--- a/src/platform/tigerlake/include/platform/platform.h
+++ b/src/platform/tigerlake/include/platform/platform.h
@@ -37,11 +37,6 @@ struct timer;
  */
 #define PLATFORM_DEFAULT_CLOCK CLK_SSP
 
-/*! \def PLATFORM_LL_DEFAULT_TIMEOUT
- *  \brief low latency scheduler default timeout in microseconds
- */
-#define PLATFORM_LL_DEFAULT_TIMEOUT	1000
-
 #define MAX_GPDMA_COUNT 2
 
 /* Host page size */

--- a/src/schedule/edf_schedule.c
+++ b/src/schedule/edf_schedule.c
@@ -259,7 +259,7 @@ static void schedule_edf_task_free(void *data, struct task *task)
 	irq_local_enable(flags);
 }
 
-int scheduler_init_edf(struct sof *sof)
+int scheduler_init_edf(void)
 {
 	struct edf_schedule_data *edf_sch;
 
@@ -272,7 +272,7 @@ int scheduler_init_edf(struct sof *sof)
 	scheduler_init(SOF_SCHEDULE_EDF, &schedule_edf_ops, edf_sch);
 
 	/* initialize main task context before enabling interrupt */
-	task_main_init(sof);
+	task_main_init();
 
 	/* configure EDF scheduler interrupt */
 	edf_sch->irq = interrupt_get_irq(PLATFORM_SCHEDULE_IRQ,

--- a/src/schedule/task.c
+++ b/src/schedule/task.c
@@ -41,12 +41,9 @@ static void sys_module_init(void)
 
 enum task_state task_main_master_core(void *data)
 {
-	struct sof *sof = data;
-
 	/* main audio processing loop */
 	while (1) {
 		/* sleep until next IPC or DMA */
-		sa_enter_idle(sof);
 		wait_for_interrupt(0);
 
 		/* now process any IPC messages to host */

--- a/src/schedule/task.c
+++ b/src/schedule/task.c
@@ -53,7 +53,7 @@ enum task_state task_main_master_core(void *data)
 	return SOF_TASK_STATE_COMPLETED;
 }
 
-void task_main_init(struct sof *sof)
+void task_main_init(void)
 {
 	struct task **main_task = task_main_get();
 	int cpu = cpu_get_id();
@@ -63,8 +63,8 @@ void task_main_init(struct sof *sof)
 	*main_task = rzalloc(RZONE_SYS, SOF_MEM_CAPS_RAM, sizeof(**main_task));
 
 	assert(!schedule_task_init(*main_task, SOF_SCHEDULE_EDF,
-				   SOF_TASK_PRI_IDLE, main_main, NULL, sof, cpu,
-				   SOF_SCHEDULE_FLAG_IDLE));
+				   SOF_TASK_PRI_IDLE, main_main, NULL, NULL,
+				   cpu, SOF_SCHEDULE_FLAG_IDLE));
 }
 
 void task_main_free(void)

--- a/tools/testbench/common_test.c
+++ b/tools/testbench/common_test.c
@@ -36,7 +36,7 @@ int tb_pipeline_setup(struct sof *sof)
 	}
 
 	/* init scheduler */
-	if (scheduler_init_edf(sof) < 0) {
+	if (scheduler_init_edf() < 0) {
 		fprintf(stderr, "error: edf scheduler init\n");
 		return -EINVAL;
 	}

--- a/tools/testbench/edf_schedule.c
+++ b/tools/testbench/edf_schedule.c
@@ -54,7 +54,7 @@ static int schedule_edf_task_init(void *data, struct task *task)
 }
 
 /* initialize scheduler */
-int scheduler_init_edf(struct sof *sof)
+int scheduler_init_edf(void)
 {
 	trace_edf_sch("edf_scheduler_init()");
 	sch = malloc(sizeof(*sch));


### PR DESCRIPTION
Refactors agent's functionality to really verify DSP
responsiveness. Instead of updating last_idle time
on passive level before entering waiti, let's change it
to last_check and update it on actual scheduler task
execution. Task is executed above passive level, so it
should preempt every other long running processing.
Since we don't have any additional precautions to guarantee
that low latency tick will happen exactly at the scheduled time,
let's define warning and panic thresholds to control stability
of the system.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>