### PR TITLE
task: add option to provide stack allocated externally

### DIFF
--- a/src/arch/xtensa/include/arch/schedule/task.h
+++ b/src/arch/xtensa/include/arch/schedule/task.h
@@ -48,9 +48,11 @@ int task_context_alloc(void **task_ctx);
  * \param[in] arg0 First argument to be passed to entry function.
  * \param[in] arg1 Second argument to be passed to entry function.
  * \param[in] task_core Id of the core that task will be executed on.
+ * \param[in] stack Address of the stack, if NULL then allocated internally.
+ * \param[in] stack_size Size of the stack, ignored if stack is NULL.
  */
 int task_context_init(void *task_ctx, void *entry, void *arg0, void *arg1,
-		      int task_core);
+		      int task_core, void *stack, int stack_size);
 
 /**
  * \brief Frees task context.

--- a/src/arch/xtensa/include/xtensa/xtruntime-frames.h
+++ b/src/arch/xtensa/include/xtensa/xtruntime-frames.h
@@ -154,10 +154,14 @@ STRUCT_END(xtos_structures_pointers)
  * xtos_task_context contains information about currently
  * executed task
  */
+
+#define XTOS_TASK_CONTEXT_OWN_STACK	1
+
 STRUCT_BEGIN
 STRUCT_FIELD (UserFrame*,4,TC_,stack_pointer)
 STRUCT_FIELD (void*,4,TC_,stack_base)
 STRUCT_FIELD (long,4,TC_,stack_size)
+STRUCT_FIELD (long,4,TC_,flags)
 STRUCT_END(xtos_task_context)
 
 #if defined(_ASMLANGUAGE) || defined(__ASSEMBLER__)

--- a/src/schedule/edf_schedule.c
+++ b/src/schedule/edf_schedule.c
@@ -173,7 +173,7 @@ static int schedule_edf_task_init(void *data, struct task *task)
 	if (task_context_alloc(&edf_pdata->ctx) < 0)
 		goto error;
 	if (task_context_init(edf_pdata->ctx, &schedule_edf_task_run,
-			      task, data, task->core) < 0)
+			      task, data, task->core, NULL, 0) < 0)
 		goto error;
 
 	/* flush for slave core */


### PR DESCRIPTION
Dynamic allocations of the stack with the default size
may impact the performance in case of frequently re-initiated
short tasks. This option may be useful in that case.

Signed-off-by: Marcin Maka <marcin.maka@linux.intel.com>