### PR TITLE
buffer: add overwrite in circular wrap case

### DIFF
--- a/src/audio/buffer.c
+++ b/src/audio/buffer.c
@@ -163,6 +163,10 @@ void comp_update_buffer_produce(struct comp_buffer *buffer, uint32_t bytes)
 		buffer->w_ptr = buffer->addr +
 			(buffer->w_ptr - buffer->end_addr);
 
+	/* "overwrite" old data in circular wrap case */
+	if (bytes > buffer->free)
+		buffer->r_ptr = buffer->w_ptr;
+
 	/* calculate available bytes */
 	if (buffer->r_ptr < buffer->w_ptr)
 		buffer->avail = buffer->w_ptr - buffer->r_ptr;

--- a/test/cmocka/src/audio/buffer/buffer_wrap.c
+++ b/test/cmocka/src/audio/buffer/buffer_wrap.c
@@ -45,12 +45,15 @@ static void test_audio_buffer_write_fill_10_bytes_and_write_5(void **state)
 	memcpy(buf->w_ptr, &more_bytes, 5);
 	comp_update_buffer_produce(buf, 5);
 
-	uint8_t ref[10] = {10, 11, 12, 13, 14, 5, 6, 7, 8, 9};
+	uint8_t ref_1[5] = {5, 6, 7, 8, 9};
+	uint8_t ref_2[5] = {10, 11, 12, 13, 14};
 
-	assert_int_equal(buf->avail, 5);
-	assert_int_equal(buf->free, 5);
-	assert_ptr_equal(buf->w_ptr, buf->r_ptr + 5);
-	assert_int_equal(memcmp(buf->r_ptr, &ref, 10), 0);
+	assert_int_equal(buf->avail, 10);
+	assert_int_equal(buf->free, 0);
+	assert_ptr_equal(buf->w_ptr, buf->r_ptr);
+	assert_int_equal(memcmp(buf->r_ptr, &ref_1, 5), 0);
+	comp_update_buffer_consume(buf, 5);
+	assert_int_equal(memcmp(buf->r_ptr, &ref_2, 5), 0);
 
 	buffer_free(buf);
 }


### PR DESCRIPTION
In case when we overwrite "old" data in buffer
(when buffer is full) we should align r_ptr
with w_ptr.

e.g.
we have full buffer:
buffer->avail = 10
buffer->free = 0
buffer->r_ptr = buffer->w_ptr = 0 

we produce additional 5 bytes:
comp_update_buffer_produce(buf, 5)

Here, we should align r_ptr with w_ptr, because
we have still 10 bytes data available.
buffer->avail = 10
buffer->free = 0
buffer->r_ptr = buffer->w_ptr = 5

Signed-off-by: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>