### PR TITLE
drivers: imx: timer: Remove implementation for timer_start

### DIFF
--- a/src/drivers/imx/timer.c
+++ b/src/drivers/imx/timer.c
@@ -14,7 +14,7 @@
 
 void platform_timer_start(struct timer *timer)
 {
-	arch_timer_enable(timer);
+	//nothing to do on IMX for cpu timer
 }
 
 void platform_timer_stop(struct timer *timer)


### PR DESCRIPTION
This function is called too early for native timers to work. On the
other platform which uses native timers (Haswell) this function is also
empty.

With a non-empty such function I would get a timer interrupt before
registering for it.

Signed-off-by: Paul Olaru <paul.olaru@nxp.com>