### PR TITLE
platforms: Enable optional cherrytrail DMA

### DIFF
--- a/src/platform/Kconfig
+++ b/src/platform/Kconfig
@@ -193,6 +193,14 @@ config CAVS_VERSION_2_5
 	help
 	  Select for CAVS version 2.5
 
+config CONFIG_CHERRYTRAIL_EXTRA_DW_DMA
+	bool "Support Cherrytrail 3rd DMAC"
+	default n if !CHERRYTRAIL
+	depends on CHERRYTRAIL
+	help
+	  Select if you need support for all 3 DMACs versus the default 2 used
+	  in baytrail.
+
 # TODO: it should just take manifest version and offsets
 config FIRMWARE_SHORT_NAME
 	string "Rimage firmware name"

--- a/src/platform/baytrail/include/platform/lib/dma.h
+++ b/src/platform/baytrail/include/platform/lib/dma.h
@@ -13,7 +13,7 @@
 
 #include <config.h>
 
-#if defined CONFIG_CHERRYTRAIL
+#if defined CONFIG_CHERRYTRAIL_EXTRA_DW_DMA
 #define PLATFORM_NUM_DMACS	3
 #else
 #define PLATFORM_NUM_DMACS	2

--- a/src/platform/baytrail/lib/dma.c
+++ b/src/platform/baytrail/lib/dma.c
@@ -81,7 +81,7 @@ static struct dw_drv_plat_data dmac1 = {
 	},
 };
 
-#if defined CONFIG_CHERRYTRAIL
+#if defined CONFIG_CHERRYTRAIL_EXTRA_DW_DMA
 static struct dw_drv_plat_data dmac2 = {
 	.chan[0] = {
 		.class	= 7,
@@ -149,7 +149,7 @@ struct dma dma[PLATFORM_NUM_DMACS] = {
 	},
 	.ops		= &dw_dma_ops,
 },
-#if defined CONFIG_CHERRYTRAIL
+#if defined CONFIG_CHERRYTRAIL_EXTRA_DW_DMA
 {
 	.plat_data = {
 		.id		= DMA_ID_DMAC2,


### PR DESCRIPTION
The 3rd DMAC that CHT has seems to be causing issues. Since it is not
needed lets make it optional so the platform can be usable.

related to #1847

@lgirdwood I am not sure this is best place to set this config, let me know if I should move it