### PR TITLE
Add CHT fixes to CML release

### DIFF
--- a/src/platform/Kconfig
+++ b/src/platform/Kconfig
@@ -178,6 +178,14 @@ config CAVS_VERSION_2_0
 	help
 	  Select for CAVS version 2.0
 
+config CONFIG_CHERRYTRAIL_EXTRA_DW_DMA
+	bool "Support Cherrytrail 3rd DMAC"
+	default n if !CHERRYTRAIL
+	depends on CHERRYTRAIL
+	help
+	  Select if you need support for all 3 DMACs versus the default 2 used
+	  in baytrail.
+
 # TODO: it should just take manifest version and offsets
 config FIRMWARE_SHORT_NAME
 	string "Rimage firmware name"

--- a/src/platform/baytrail/include/platform/lib/dma.h
+++ b/src/platform/baytrail/include/platform/lib/dma.h
@@ -13,7 +13,7 @@
 
 #include <config.h>
 
-#if defined CONFIG_CHERRYTRAIL
+#if defined CONFIG_CHERRYTRAIL_EXTRA_DW_DMA
 #define PLATFORM_NUM_DMACS	3
 #else
 #define PLATFORM_NUM_DMACS	2

--- a/src/platform/baytrail/lib/dma.c
+++ b/src/platform/baytrail/lib/dma.c
@@ -81,7 +81,7 @@ static struct dw_drv_plat_data dmac1 = {
 	},
 };
 
-#if defined CONFIG_CHERRYTRAIL
+#if defined CONFIG_CHERRYTRAIL_EXTRA_DW_DMA
 static struct dw_drv_plat_data dmac2 = {
 	.chan[0] = {
 		.class	= 7,
@@ -149,7 +149,7 @@ struct dma dma[PLATFORM_NUM_DMACS] = {
 	},
 	.ops		= &dw_dma_ops,
 },
-#if defined CONFIG_CHERRYTRAIL
+#if defined CONFIG_CHERRYTRAIL_EXTRA_DW_DMA
 {
 	.plat_data = {
 		.id		= DMA_ID_DMAC2,

--- a/tools/topology/sof-cht-max98090.m4
+++ b/tools/topology/sof-cht-max98090.m4
@@ -39,6 +39,19 @@ PIPELINE_PCM_ADD(sof/pipe-low-latency-capture.m4,
 	2, 0, 2, s32le,
 	48, 1000, 0, 0)
 
+#
+# DAI configuration
+#
+# SSP port 2 is our only pipeline DAI
+#
+
+# playback DAI is SSP2 using 2 periods
+# Buffers use s16le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+	1, SSP, 2, SSP2-Codec,
+	PIPELINE_SOURCE_1, 2, s16le,
+	48, 1000, 0, 0)
+
 # PCM Media Playback pipeline 3 on PCM 1 using max 2 channels of s32le.
 # Schedule 192 frames per 4000us deadline on core 0 with priority 1
 PIPELINE_PCM_ADD(sof/pipe-pcm-media.m4,
@@ -55,19 +68,6 @@ SectionGraph."pipe-cht-max98090" {
 		dapm(PIPELINE_MIXER_1, PIPELINE_SOURCE_3)
 	]
 }
-
-#
-# DAI configuration
-#
-# SSP port 2 is our only pipeline DAI
-#
-
-# playback DAI is SSP2 using 2 periods
-# Buffers use s16le format, with 48 frame per 1000us on core 0 with priority 0
-DAI_ADD(sof/pipe-dai-playback.m4,
-	1, SSP, 2, SSP2-Codec,
-	PIPELINE_SOURCE_1, 2, s16le,
-	48, 1000, 0, 0)
 
 # capture DAI is SSP2 using 2 periods
 # Buffers use s16le format, with 48 frame per 1000us on core 0 with priority 0

--- a/tools/topology/sof-cht-max98090.m4
+++ b/tools/topology/sof-cht-max98090.m4
@@ -88,3 +88,6 @@ DAI_CONFIG(SSP, 2, 0, SSP2-Codec,
 		      SSP_CLOCK(fsync, 48000, codec_slave),
 		      SSP_TDM(2, 20, 3, 3),
 		      SSP_CONFIG_DATA(SSP, 2, 16)))
+
+VIRTUAL_WIDGET(ssp2 Rx, out_drv, 1)
+VIRTUAL_WIDGET(ssp2 Tx, out_drv, 2)

--- a/tools/topology/sof-cht-max98090.m4
+++ b/tools/topology/sof-cht-max98090.m4
@@ -43,7 +43,8 @@ PIPELINE_PCM_ADD(sof/pipe-low-latency-capture.m4,
 # Schedule 192 frames per 4000us deadline on core 0 with priority 1
 PIPELINE_PCM_ADD(sof/pipe-pcm-media.m4,
 	3, 1, 2, s32le,
-	192, 4000, 1, 0)
+	192, 4000, 1, 0,
+	0, PIPELINE_PLAYBACK_SCHED_COMP_1)
 
 # Connect pipelines together
 SectionGraph."pipe-cht-max98090" {


### PR DESCRIPTION
CHT and CML share the same kernel, therefore the fixes need to be instep on the same branches. This will allow strago boards to start using SOF for their uprev.

Notes: "topology: sof-cht-max98090: fix media pipeline" and "topology: sof-cht-max98090 move dai definition above media pipeline" did not apply cleanly and the HACK commit will be replaced once the final solution for disabling the CHT dmac has been merged into master