### PR TITLE
[RFC] clock: set max cpu clock for cannonlake platform

### DIFF
--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -402,6 +402,7 @@ int platform_init(struct sof *sof)
 	shim_write(SHIM_LPSCTL, shim_read(SHIM_LPSCTL));
 
 #elif CONFIG_CANNONLAKE
+	clock_set_freq(CLK_CPU(cpu_get_id()), CLK_MAX_CPU_HZ);
 
 	/* initialize PM for boot */
 	shim_write(SHIM_CLKCTL,


### PR DESCRIPTION
The setting existed long time ago and was removed by a clock rework. Please check Icelake code, you will find the difference.

This PR fix a HW hang issue on some coffee-lake devices when doing multi-pipeline tests