### PR TITLE
arch: xtensa: fix stack dump for exceptions in irq handlers

### DIFF
--- a/src/arch/xtensa/include/xtensa/xtruntime-frames.h
+++ b/src/arch/xtensa/include/xtensa/xtruntime-frames.h
@@ -147,6 +147,8 @@ STRUCT_FIELD(void*,4,XTOS_PTR_TO_,xtos_stack_for_interrupt_2)
 STRUCT_FIELD(void*,4,XTOS_PTR_TO_,xtos_stack_for_interrupt_3)
 STRUCT_FIELD(void*,4,XTOS_PTR_TO_,xtos_stack_for_interrupt_4)
 STRUCT_FIELD(void*,4,XTOS_PTR_TO_,xtos_stack_for_interrupt_5)
+STRUCT_FIELD(void*,4,XTOS_PTR_TO_,xtos_interrupt_ctx)
+STRUCT_FIELD(void*,4,XTOS_PTR_TO_,xtos_saved_ctx)
 STRUCT_FIELD(void*,4,XTOS_PTR_TO_,xtos_saved_sp)
 STRUCT_END(xtos_structures_pointers)
 

--- a/src/arch/xtensa/init.c
+++ b/src/arch/xtensa/init.c
@@ -68,6 +68,7 @@ static void initialize_pointers_per_core(void)
 	core_data = core_data_ptr[core];
 
 	p = &core_data->thread_data_ptr->xtos_ptrs;
+	p->xtos_interrupt_ctx = &core_data->xtos_interrupt_ctx;
 	p->xtos_saved_sp = &core_data->xtos_saved_sp;
 	p->xtos_stack_for_interrupt_1 = core_data->xtos_stack_for_interrupt_1;
 	p->xtos_stack_for_interrupt_2 = core_data->xtos_stack_for_interrupt_2;

--- a/src/arch/xtensa/init.c
+++ b/src/arch/xtensa/init.c
@@ -10,6 +10,7 @@
  * \authors Liam Girdwood <liam.r.girdwood@linux.intel.com>
  */
 
+#include "xtos-internal.h"
 #include <sof/common.h>
 #include <sof/init.h>
 #include <sof/lib/cpu.h>
@@ -17,10 +18,15 @@
 #include <config.h>
 #include <xtensa/xtruntime-frames.h>
 #include <xtos-structs.h>
+#include <stddef.h>
 #include <stdint.h>
 
 /* UserFrame's size needs to be 16 bytes aligned */
 STATIC_ASSERT((sizeof(UserFrame) % 16) == 0, invalid_UserFrame_alignment);
+
+/* verify xtos_active_task offset */
+STATIC_ASSERT(offsetof(struct thread_data, xtos_active_task) ==
+	      XTOS_TASK_CONTEXT_OFFSET, invalid_xtos_active_task_offset);
 
 #if CONFIG_DEBUG_LOCKS
 /** \brief Debug lock. */

--- a/src/arch/xtensa/xtos/int-medpri-dispatcher.S
+++ b/src/arch/xtensa/xtos/int-medpri-dispatcher.S
@@ -152,6 +152,19 @@ no_context:
 	s32i	a1, a13, 0
 	addi	a1, a13, SOF_STACK_SIZE
 
+	/* set stack base and size for interrupt context */
+	xtos_addr_percore	a11, xtos_interrupt_ctx
+	s32i	a13, a11, TC_stack_base
+	movi	a13, SOF_STACK_SIZE
+	s32i	a13, a11, TC_stack_size
+
+	/* save task context */
+	xtos_task_ctx_percore	a13
+	xtos_store_percore	a13, a14, xtos_saved_ctx
+
+	/* set interrupt task context */
+	xtos_task_ctx_store_percore	a11, a14
+
 /* Load the handler from the table, initialize two args (interrupt
  * number and exception stack frame), then call the interrupt handler.
  * Note: The callx12 preserves the original user task's a4..a15.*/
@@ -202,6 +215,19 @@ no_context:
 
 	_beqz	a15, LABEL(spurious,int)
 
+	/* set stack base and size for interrupt context */
+	xtos_addr_percore	a11, xtos_interrupt_ctx
+	s32i	a13, a11, TC_stack_base
+	movi	a13, SOF_STACK_SIZE
+	s32i	a13, a11, TC_stack_size
+
+	/* save task context */
+	xtos_task_ctx_percore	a13
+	xtos_store_percore	a13, a14, xtos_saved_ctx
+
+	/* set interrupt task context */
+	xtos_task_ctx_store_percore	a11, a14
+
 /* Loop to handle all pending interrupts. */
 
 LABEL(.L1,_loop0):
@@ -232,6 +258,14 @@ LABEL(.L1,_loop0):
 
 /* Restore everything, and return. */
 
+	/* restore task context if needed */
+	xtos_task_ctx_percore	a11
+	xtos_addr_percore	a12, xtos_interrupt_ctx
+	bne	a11, a12, restore_cp
+	xtos_addr_percore	a12, xtos_saved_ctx
+	xtos_task_ctx_store_percore	a12, a11
+
+restore_cp:
 #if __XCC__
 #if (XCHAL_CP_MASK & CP0_MASK)
 	xtos_task_ctx_percore	a11

--- a/src/arch/xtensa/xtos/xea1/int-lowpri-dispatcher.S
+++ b/src/arch/xtensa/xtos/xea1/int-lowpri-dispatcher.S
@@ -146,6 +146,19 @@ no_context:
 
 	_beqz	a15, LABEL(spurious,int)
 
+	/* set stack base and size for interrupt context */
+	xtos_addr_percore	a11, xtos_interrupt_ctx
+	s32i	a13, a11, TC_stack_base
+	movi	a13, SOF_STACK_SIZE
+	s32i	a13, a11, TC_stack_size
+
+	/* save task context */
+	xtos_task_ctx_percore	a13
+	xtos_store_percore	a13, a14, xtos_saved_ctx
+
+	/* set interrupt task context */
+	xtos_task_ctx_store_percore	a11, a14
+
 /* Loop to handle all pending interrupts. */
 
 LABEL(.L1,_loop0):
@@ -174,6 +187,14 @@ LABEL(.L1,_loop0):
 
 /* Restore everything, and return. */
 
+	/* restore task context if needed */
+	xtos_task_ctx_percore	a11
+	xtos_addr_percore	a12, xtos_interrupt_ctx
+	bne	a11, a12, restore_cp
+	xtos_addr_percore	a12, xtos_saved_ctx
+	xtos_task_ctx_store_percore	a12, a11
+
+restore_cp:
 #if __XCC__
 #if (XCHAL_CP_MASK & CP0_MASK)
 	xtos_task_ctx_percore	a11

--- a/src/arch/xtensa/xtos/xea2/int-lowpri-dispatcher.S
+++ b/src/arch/xtensa/xtos/xea2/int-lowpri-dispatcher.S
@@ -146,6 +146,19 @@ no_context:
 
 	_beqz	a15, LABEL(spurious,int)
 
+	/* set stack base and size for interrupt context */
+	xtos_addr_percore	a11, xtos_interrupt_ctx
+	s32i	a13, a11, TC_stack_base
+	movi	a13, SOF_STACK_SIZE
+	s32i	a13, a11, TC_stack_size
+
+	/* save task context */
+	xtos_task_ctx_percore	a13
+	xtos_store_percore	a13, a14, xtos_saved_ctx
+
+	/* set interrupt task context */
+	xtos_task_ctx_store_percore	a11, a14
+
 /* Loop to handle all pending interrupts. */
 
 LABEL(.L1,_loop0):
@@ -174,6 +187,14 @@ LABEL(.L1,_loop0):
 
 /* Restore everything, and return. */
 
+	/* restore task context if needed */
+	xtos_task_ctx_percore	a11
+	xtos_addr_percore	a12, xtos_interrupt_ctx
+	bne	a11, a12, restore_cp
+	xtos_addr_percore	a12, xtos_saved_ctx
+	xtos_task_ctx_store_percore	a12, a11
+
+restore_cp:
 #if __XCC__
 #if (XCHAL_CP_MASK & CP0_MASK)
 	xtos_task_ctx_percore	a11

--- a/src/arch/xtensa/xtos/xtos-internal.h
+++ b/src/arch/xtensa/xtos/xtos-internal.h
@@ -114,7 +114,7 @@
 # endif
 #endif
 
-#define XTOS_TASK_CONTEXT_OFFSET	40
+#define XTOS_TASK_CONTEXT_OFFSET	48
 
 #if defined(_ASMLANGUAGE) || defined(__ASSEMBLER__)
 /***********   Useful macros   ***********/

--- a/src/arch/xtensa/xtos/xtos-internal.h
+++ b/src/arch/xtensa/xtos/xtos-internal.h
@@ -114,6 +114,7 @@
 # endif
 #endif
 
+#define XTOS_TASK_CONTEXT_OFFSET	40
 
 #if defined(_ASMLANGUAGE) || defined(__ASSEMBLER__)
 /***********   Useful macros   ***********/
@@ -314,8 +315,6 @@ XTOS_PENDING_OFS:	.space	4	/* _xtos_pending variable */
 # else
 #  define IFNSA(a,b)	b
 # endif
-
-#define XTOS_TASK_CONTEXT_OFFSET	40
 
 	// get_prid ax
 	// Extracts core id.

--- a/src/arch/xtensa/xtos/xtos-internal.h
+++ b/src/arch/xtensa/xtos/xtos-internal.h
@@ -419,6 +419,25 @@ exit:
 	l32i		\ax, \ax, XTOS_PTR_TO_\structure_name
 	.endm
 
+	// xtos_store_percore ax, ay, structure_name
+	// Stores register value under the selected structure per core.
+	.macro	xtos_store_percore ax, ay, structure_name
+#if XCHAL_HAVE_THREADPTR
+	rur.threadptr	\ay
+#else
+	j 1f
+	.align 4
+	.literal_position
+2:
+	.word SOF_VIRTUAL_THREAD_BASE
+1:
+	.align 4
+	l32r	\ay, 2b
+	l32i	\ay, \ay, 0
+#endif
+	s32i		\ax, \ay, XTOS_PTR_TO_\structure_name
+	.endm
+
 	// xtos_int_stack_addr_percore ax, int_level, stack_name
 	// Pointer to dedicated interrupt stack.
 	.macro	xtos_int_stack_addr_percore ax, int_level, stack_name
@@ -455,6 +474,25 @@ exit:
 	l32i		\ax, \ax, 0
 #endif
 	l32i		\ax, \ax, XTOS_TASK_CONTEXT_OFFSET
+	.endm
+
+	// xtos_task_ctx_store_percore ax, ay
+	// Changes task context to point to the selected address.
+	.macro	xtos_task_ctx_store_percore ax, ay
+#if XCHAL_HAVE_THREADPTR
+	rur.threadptr	\ay
+#else
+	j 1f
+	.align 4
+	.literal_position
+2:
+	.word SOF_VIRTUAL_THREAD_BASE
+1:
+	.align 4
+	l32r	\ay, 2b
+	l32i	\ay, \ay, 0
+#endif
+	s32i		\ax, \ay, XTOS_TASK_CONTEXT_OFFSET
 	.endm
 
 #else /* !_ASMLANGUAGE && !__ASSEMBLER__ */

--- a/src/arch/xtensa/xtos/xtos-structs.h
+++ b/src/arch/xtensa/xtos/xtos-structs.h
@@ -33,6 +33,7 @@ struct xtos_core_data {
 	uint8_t xtos_stack_for_interrupt_3[SOF_STACK_SIZE];
 	uint8_t xtos_stack_for_interrupt_4[SOF_STACK_SIZE];
 	uint8_t xtos_stack_for_interrupt_5[SOF_STACK_SIZE];
+	xtos_task_context xtos_interrupt_ctx;
 	uintptr_t xtos_saved_sp;
 	struct thread_data *thread_data_ptr;
 };


### PR DESCRIPTION
Fixes stack dump procedure for exceptions happening in interrupt
handlers. Stack base and size haven't been set to the interrupt's
one in current task context, so when exception happened during
interrupt processing we've got SOF_IPC_PANIC_STACK cause instead
of the real one.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>