### PR TITLE
[RFC] sof: lib: dma: Add register access helper functions

### DIFF
--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -94,12 +94,12 @@ static int dw_dma_copy(struct dma_chan_data *channel, int bytes,
 
 static inline void dw_write(struct dma *dma, uint32_t reg, uint32_t value)
 {
-	io_reg_write(dma_base(dma) + reg, value);
+	dma_reg_write(dma, reg, value);
 }
 
 static inline uint32_t dw_read(struct dma *dma, uint32_t reg)
 {
-	return io_reg_read(dma_base(dma) + reg);
+	return dma_reg_read(dma, reg);
 }
 
 static void dw_dma_interrupt_mask(struct dma_chan_data *channel)

--- a/src/drivers/intel/cavs/hda-dma.c
+++ b/src/drivers/intel/cavs/hda-dma.c
@@ -137,20 +137,19 @@ static int hda_dma_stop(struct dma_chan_data *channel);
 static inline uint32_t host_dma_reg_read(struct dma_chan_data *chan,
 					 uint32_t reg)
 {
-	return io_reg_read(dma_chan_base(chan->dma, chan->index) + reg);
+	return dma_chan_reg_read(chan, reg);
 }
 
 static inline void host_dma_reg_write(struct dma_chan_data *chan,
 				      uint32_t reg, uint32_t value)
 {
-	io_reg_write(dma_chan_base(chan->dma, chan->index) + reg, value);
+	dma_chan_reg_write(chan, reg, value);
 }
 
 static inline void hda_update_bits(struct dma_chan_data *chan,
 				   uint32_t reg, uint32_t mask, uint32_t value)
 {
-	io_reg_update_bits(dma_chan_base(chan->dma, chan->index) + reg,  mask,
-			   value);
+	dma_chan_reg_update_bits(chan, reg, mask, value);
 }
 
 static inline void hda_dma_inc_fp(struct dma_chan_data *chan,

--- a/src/include/sof/lib/dma.h
+++ b/src/include/sof/lib/dma.h
@@ -20,6 +20,7 @@
 #include <sof/atomic.h>
 #include <sof/bit.h>
 #include <sof/lib/cache.h>
+#include <sof/lib/io.h>
 #include <sof/lib/wait.h>
 #include <sof/spinlock.h>
 #include <stdbool.h>
@@ -353,6 +354,67 @@ static inline int dma_get_attribute(struct dma *dma, uint32_t type,
 				    uint32_t *value)
 {
 	return dma->ops->get_attribute(dma, type, value);
+}
+
+/* DMA hardware register operations */
+static inline uint32_t dma_reg_read(struct dma *dma, uint32_t reg)
+{
+	return io_reg_read(dma_base(dma) + reg);
+}
+
+static inline uint16_t dma_reg_read16(struct dma *dma, uint32_t reg)
+{
+	return io_reg_read16(dma_base(dma) + reg);
+}
+
+static inline void dma_reg_write(struct dma *dma, uint32_t reg, uint32_t value)
+{
+	io_reg_write(dma_base(dma) + reg, value);
+}
+
+static inline void dma_reg_write16(struct dma *dma, uint32_t reg,
+				   uint16_t value)
+{
+	io_reg_write16(dma_base(dma) + reg, value);
+}
+
+static inline void dma_reg_update_bits(struct dma *dma, uint32_t reg,
+				       uint32_t mask, uint32_t value)
+{
+	io_reg_update_bits(dma_base(dma) + reg, mask, value);
+}
+
+static inline uint32_t dma_chan_reg_read(struct dma_chan_data *channel,
+					 uint32_t reg)
+{
+	return io_reg_read(dma_chan_base(channel->dma, channel->index) + reg);
+}
+
+static inline uint16_t dma_chan_reg_read16(struct dma_chan_data *channel,
+					   uint32_t reg)
+{
+	return io_reg_read16(dma_chan_base(channel->dma, channel->index) + reg);
+}
+
+static inline void dma_chan_reg_write(struct dma_chan_data *channel,
+				      uint32_t reg, uint32_t value)
+{
+	io_reg_write(dma_chan_base(channel->dma, channel->index) + reg, value);
+}
+
+static inline void dma_chan_reg_write16(struct dma_chan_data *channel,
+					uint32_t reg, uint16_t value)
+{
+	io_reg_write16(dma_chan_base(channel->dma, channel->index) + reg,
+		       value);
+}
+
+static inline void dma_chan_reg_update_bits(struct dma_chan_data *channel,
+					    uint32_t reg, uint32_t mask,
+					    uint32_t value)
+{
+	io_reg_update_bits(dma_chan_base(channel->dma, channel->index) + reg,
+			   mask, value);
 }
 
 static inline void dma_sg_init(struct dma_sg_elem_array *ea)


### PR DESCRIPTION
These functions replace the raw io_reg_* functions for accessing the DMA
hardware registers.

Every DMA driver makes auxiliary functions for accessing the hardware
registers; this is an effort to make common functions for this purpose.

This commit adds the generic functions.

Signed-off-by: Paul Olaru <paul.olaru@nxp.com>

I wonder how the DW DMA driver can use these, since it uses dma_base instead of dma_chan_base for computing the I/O addresses. Should I add other functions for that case and possibly rename those I introduce with this patch?

Cannot test locally, so I rely on CI to help me fix the build if it breaks.