### PR TITLE
[RFC] topology: add capture mute switch and led info

### DIFF
--- a/src/include/kernel/tokens.h
+++ b/src/include/kernel/tokens.h
@@ -106,4 +106,8 @@
 /* ESAI */
 #define SOF_TKN_IMX_ESAI_MCLK_ID		1100
 
+/* Led control for mute switches */
+#define SOF_TKN_MUTE_LED_USE			1300
+#define SOF_TKN_MUTE_LED_DIRECTION		1301
+
 #endif /* __KERNEL_TOKENS_H__ */

--- a/tools/topology/m4/mixercontrol.m4
+++ b/tools/topology/m4/mixercontrol.m4
@@ -28,8 +28,23 @@ define(`CONTROLMIXER_OPS',
 `		put STR($4)'
 `	}')
 
-dnl C_CONTROLMIXER(name, index, ops, max, invert, tlv, KCONTROL_CHANNELS)
+
+define(`N_CONTROLMIXER', `CONTROLMIXER'PIPELINE_ID`.'$1)
+
+dnl C_CONTROLMIXER(name, index, ops, max, invert, tlv, comment, KCONTROL_CHANNELS, useleds, ledsdir)
 define(`C_CONTROLMIXER',
+`ifelse(`$#', `10',
+`SectionVendorTuples."'N_CONTROLMIXER($2)`_tuples_w" {'
+`	tokens "sof_led_tokens"'
+`	tuples."word" {'
+`		SOF_TKN_MUTE_LED_USE'		$9
+`		SOF_TKN_MUTE_LED_DIRECTION'	$10
+`	}'
+`}'
+`SectionData."'N_CONTROLMIXER($2)`_data_w" {'
+`	tuples "'N_CONTROLMIXER($2)`_tuples_w"'
+`}'
+,` ')'
 `SectionControlMixer."ifdef(`CONTROL_NAME', CONTROL_NAME, $2 $1)" {'
 `'
 `	# control belongs to this index group'
@@ -43,7 +58,11 @@ define(`C_CONTROLMIXER',
 `	$4'
 `	invert STR($5)'
 `	$6'
-
+`ifelse(`$#', `10',
+`	data ['
+`		"'N_CONTROLMIXER($2)`_data_w"'
+`	]'
+,` ')'
 `}')
 
 divert(0)dnl

--- a/tools/topology/sof/pipe-eq-capture.m4
+++ b/tools/topology/sof/pipe-eq-capture.m4
@@ -15,8 +15,10 @@ include(`bytecontrol.m4')
 include(`mixercontrol.m4')
 include(`eq_iir.m4')
 
-define(`CONTROL_NAME', Capture Volume)
 define(`PGA_NAME', Dmic0)
+define(`CONTROL_NAME_VOLUME', Capture Volume)
+define(`CONTROL_NAME_SWITCH', Capture Switch)
+define(`CONTROL_NAME', `CONTROL_NAME_VOLUME')
 
 #
 # Controls
@@ -33,6 +35,17 @@ C_CONTROLMIXER(Master Capture Volume, PIPELINE_ID,
 	Channel register and shift for Front Left/Right,
 	LIST(`	', KCONTROL_CHANNEL(FL, 1, 0), KCONTROL_CHANNEL(FR, 1, 1)))
 
+define(`CONTROL_NAME', `CONTROL_NAME_SWITCH')
+
+# Switch type Mixer Control with max value of 1
+C_CONTROLMIXER(Master Capture Switch, PIPELINE_ID,
+	CONTROLMIXER_OPS(volsw, 259 binds the mixer control to switch get/put handlers, 259, 259),
+	CONTROLMIXER_MAX(max 1 indicates switch type control, 1),
+	false,
+	,
+	Channel register and shift for Front Left/Right,
+	LIST(`	', KCONTROL_CHANNEL(FL, 2, 0), KCONTROL_CHANNEL(FR, 2, 1)),
+	"1", "1")
 
 # Volume Configuration
 W_VENDORTUPLES(capture_pga_tokens, sof_volume_tokens,
@@ -68,7 +81,7 @@ W_PCM_CAPTURE(PCM_ID, Highpass Capture, 0, 2)
 # "Volume" has 2 source and 2 sink periods
 W_PGA(0, PIPELINE_FORMAT, 2, 2,
 	 capture_pga_conf, LIST(`		',
-		"CONTROL_NAME"))
+		"CONTROL_NAME_VOLUME", "CONTROL_NAME_SWITCH"))
 
 # "EQ 0" has 2 sink period and 2 source periods
 W_EQ_IIR(0, PIPELINE_FORMAT, 2, 2, LIST(`		', "EQIIR_C48"))
@@ -99,8 +112,10 @@ P_GRAPH(pipe-pass-capture-PIPELINE_ID, PIPELINE_ID,
 	`dapm(N_BUFFER(1), N_EQ_IIR(0))',
 	`dapm(N_EQ_IIR(0), N_BUFFER(2))'))
 
-undefine(`CONTROL_NAME')
 undefine(`PGA_NAME')
+undefine(`CONTROL_NAME')
+undefine(`CONTROL_NAME_VOLUME')
+undefine(`CONTROL_NAME_SWITCH')
 
 #
 # Pipeline Source and Sinks

--- a/tools/topology/sof/tokens.m4
+++ b/tools/topology/sof/tokens.m4
@@ -96,3 +96,8 @@ SectionVendorTokens."sof_process_tokens" {
 SectionVendorTokens."sof_esai_tokens" {
 	SOF_TKN_IMX_ESAI_MCLK_ID		"1100"
 }
+
+SectionVendorTokens."sof_led_tokens" {
+	SOF_TKN_MUTE_LED_USE			"1300"
+	SOF_TKN_MUTE_LED_DIRECTION		"1301"
+}


### PR DESCRIPTION
Add mute switch to capture playback pipeline's volume component. This
will show in user space alsa controls as 1 element with 2 controls
(volume and mute switch). Some user space audio software like this a
lot.

Add also binary data to switch control to enable possible use of acpi
leds with mute switch.

Signed-off-by: Jaska Uimonen <jaska.uimonen@intel.com>