### PR TITLE
dma-trace: free the elem_array after used

### DIFF
--- a/src/ipc/dma-copy.c
+++ b/src/ipc/dma-copy.c
@@ -154,6 +154,9 @@ int dma_copy_new(struct dma_copy *dc)
 	}
 
 #if !CONFIG_DMA_GW
+	/* free previous used channel */
+	if (dc->chan)
+		dma_channel_put(dc->chan);
 	/* get DMA channel from DMAC0 */
 	dc->chan = dma_channel_get(dc->dmac, 0);
 	if (!dc->chan) {
@@ -172,6 +175,10 @@ int dma_copy_new(struct dma_copy *dc)
 
 int dma_copy_set_stream_tag(struct dma_copy *dc, uint32_t stream_tag)
 {
+	/* free previous used channel */
+	if (dc->chan)
+		dma_channel_put(dc->chan);
+
 	/* get DMA channel from DMAC */
 	dc->chan = dma_channel_get(dc->dmac, stream_tag - 1);
 	if (!dc->chan) {

--- a/src/trace/dma-trace.c
+++ b/src/trace/dma-trace.c
@@ -161,9 +161,10 @@ static int dma_trace_buffer_init(struct dma_trace_data *d)
 	struct dma_trace_buf *buffer = &d->dmatb;
 
 	/* allocate new buffer */
-	buffer->addr = rballoc(RZONE_BUFFER,
-			       SOF_MEM_CAPS_RAM | SOF_MEM_CAPS_DMA,
-			       DMA_TRACE_LOCAL_SIZE);
+	if (!buffer->addr)
+		buffer->addr = rballoc(RZONE_BUFFER,
+				       SOF_MEM_CAPS_RAM | SOF_MEM_CAPS_DMA,
+				       DMA_TRACE_LOCAL_SIZE);
 	if (!buffer->addr) {
 		trace_buffer_error("dma_trace_buffer_init() error: "
 				   "alloc failed");

--- a/src/trace/dma-trace.c
+++ b/src/trace/dma-trace.c
@@ -210,13 +210,14 @@ static int dma_trace_start(struct dma_trace_data *d)
 	config.dest_width = sizeof(uint32_t);
 	config.cyclic = 0;
 
-	err = dma_sg_alloc(&config.elem_array, RZONE_SYS,
+	err = dma_sg_alloc(&config.elem_array, RZONE_RUNTIME,
 			   config.direction,
 			   elem_num, elem_size, elem_addr, 0);
 	if (err < 0)
 		return err;
 
 	err = dma_set_config(d->dc.chan, &config);
+	dma_sg_free(&config.elem_array);
 	if (err < 0)
 		return err;
 


### PR DESCRIPTION
The sg elem_array is only for one time used, let's free it after used,
to avoid memory leak when the dma-trace is started multiple times.

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>