### PR TITLE
dai: fix dma channel free

### DIFF
--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -219,7 +219,9 @@ static void dai_free(struct comp_dev *dev)
 {
 	struct dai_data *dd = comp_get_drvdata(dev);
 
-	dma_channel_put(dd->chan);
+	if (dd->chan)
+		dma_channel_put(dd->chan);
+
 	dma_put(dd->dma);
 
 	dai_put(dd->dai);


### PR DESCRIPTION
Fixes freeing of dma channel. It's set during dai configuration,
so we should first check if it exists.

Fixes #1878.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>