### PR TITLE
interrupt: cavs: run cascaded irq handler in non atomic ctx

### DIFF
--- a/src/drivers/imx/interrupt.c
+++ b/src/drivers/imx/interrupt.c
@@ -252,7 +252,11 @@ static inline void handle_irq_batch(struct irq_cascade_desc *cascade,
 			child = container_of(clist, struct irq_desc, irq_list);
 
 			if (child->handler && (child->cpu_mask & 1 << core)) {
+				/* run handler in non atomic context */
+				spin_unlock(cascade->lock);
 				child->handler(child->handler_arg);
+				spin_lock(cascade->lock);
+
 				handled = true;
 			}
 		}

--- a/src/drivers/intel/cavs/interrupt.c
+++ b/src/drivers/intel/cavs/interrupt.c
@@ -65,7 +65,11 @@ static inline void irq_lvl2_handler(void *data, int level, uint32_t ilxsd,
 			child = container_of(clist, struct irq_desc, irq_list);
 
 			if (child->handler && (child->cpu_mask & 1 << core)) {
+				/* run handler in non atomic context */
+				spin_unlock(cascade->lock);
 				child->handler(child->handler_arg);
+				spin_lock(cascade->lock);
+
 				handled = true;
 			}
 		}


### PR DESCRIPTION
Runs interrupt handlers for cascaded interrupts in non atomic
context. Otherwise we are blocking other cores during execution,
which is not needed, since we only need to protect integrity of
the list.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>