### PR TITLE
host: verify if channel exists before resetting it

### DIFF
--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -746,7 +746,8 @@ static int host_reset(struct comp_dev *dev)
 
 	trace_host_with_ids(dev, "host_reset()");
 
-	dma_channel_put(hd->chan);
+	if (hd->chan)
+		dma_channel_put(hd->chan);
 
 	/* free all DMA elements */
 	dma_sg_free(&hd->host.elem_array);


### PR DESCRIPTION
This patch provides a check for channel existence
before performing any action on it during reset
procedure.

Signed-off-by: Marcin Rajwa <marcin.rajwa@linux.intel.com>