### PR TITLE
ipc: add complete task callback

### DIFF
--- a/src/arch/xtensa/include/arch/lib/wait.h
+++ b/src/arch/xtensa/include/arch/lib/wait.h
@@ -20,8 +20,8 @@ static inline void arch_wait_for_interrupt(int level)
 {
 	int i;
 
-	/* can only enter WFI when at run level 0 i.e. not IRQ level */
-	if (arch_interrupt_get_level() > 0)
+	/* need to make sure the interrupt level won't be lowered */
+	if (arch_interrupt_get_level() > level)
 		panic(SOF_IPC_PANIC_WFI);
 
 	/* this sequence must be atomic on LX6 */
@@ -43,8 +43,8 @@ static inline void arch_wait_for_interrupt(int level)
 
 static inline void arch_wait_for_interrupt(int level)
 {
-	/* can only enter WFI when at run level 0 i.e. not IRQ level */
-	if (arch_interrupt_get_level() > 0)
+	/* need to make sure the interrupt level won't be lowered */
+	if (arch_interrupt_get_level() > level)
 		panic(SOF_IPC_PANIC_WFI);
 
 	asm volatile("waiti 0");

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -402,6 +402,7 @@ static int kpb_prepare(struct comp_dev *dev)
 			   SOF_SCHEDULE_EDF, /* utilize EDF scheduler */
 			   SOF_TASK_PRI_ALMOST_IDLE, /* almost idle priority */
 			   kpb_draining_task, /* task function */
+			   NULL, /* no complete function */
 			   &kpb->draining_task_data, /* task private data */
 			   0, /* core on which we should run */
 			   SOF_SCHEDULE_FLAG_IDLE);

--- a/src/audio/pipeline.c
+++ b/src/audio/pipeline.c
@@ -66,7 +66,7 @@ struct pipeline *pipeline_new(struct sof_ipc_pipe_new *pipe_desc,
 	type = pipeline_is_timer_driven(p) ? SOF_SCHEDULE_LL :
 		SOF_SCHEDULE_EDF;
 	schedule_task_init(&p->pipe_task, type, pipe_desc->priority,
-			   pipeline_task, p, pipe_desc->core, 0);
+			   pipeline_task, NULL, p, pipe_desc->core, 0);
 
 	return p;
 }

--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -164,7 +164,7 @@ static struct comp_dev *volume_new(struct sof_ipc_comp *comp)
 
 	comp_set_drvdata(dev, cd);
 	schedule_task_init(&cd->volwork, SOF_SCHEDULE_LL, SOF_TASK_PRI_MED,
-			   vol_work, dev, 0, 0);
+			   vol_work, NULL, dev, 0, 0);
 
 	/* Set the default volumes. If IPC sets min_value or max_value to
 	 * not-zero, use them. Otherwise set to internal limits and notify

--- a/src/drivers/dw/ssi-spi.c
+++ b/src/drivers/dw/ssi-spi.c
@@ -303,7 +303,6 @@ static enum task_state spi_completion_work(void *data)
 		dcache_invalidate_region(spi->rx_buffer, SPI_BUFFER_SIZE);
 		mailbox_hostbox_write(0, spi->rx_buffer, hdr->size);
 
-		_ipc->host_pending = 1;
 		ipc_schedule_process(_ipc);
 
 		break;

--- a/src/drivers/dw/ssi-spi.c
+++ b/src/drivers/dw/ssi-spi.c
@@ -414,7 +414,7 @@ static int spi_slave_init(struct spi *spi)
 
 	spi->completion.private = NULL;
 	return schedule_task_init(&spi->completion, SOF_SCHEDULE_EDF,
-			SOF_TASK_PRI_MED, spi_completion_work, spi, 0, 0);
+			SOF_TASK_PRI_MED, spi_completion_work, NULL, spi, 0, 0);
 }
 
 int spi_probe(struct spi *spi)

--- a/src/drivers/imx/ipc.c
+++ b/src/drivers/imx/ipc.c
@@ -112,6 +112,11 @@ void ipc_platform_do_cmd(struct ipc *ipc)
 	ipc_cmd(hdr);
 
 	ipc->host_pending = 0;
+}
+
+static void ipc_platform_complete_cmd(void *data)
+{
+	struct ipc *ipc = data;
 
 	/* enable GP interrupt #0 - accept new messages */
 	imx_mu_xcr_rmw(IMX_MU_xCR_GIEn(0), 0);
@@ -169,7 +174,8 @@ int platform_ipc_init(struct ipc *ipc)
 
 	/* schedule */
 	schedule_task_init(&_ipc->ipc_task, SOF_SCHEDULE_EDF, SOF_TASK_PRI_IPC,
-			   ipc_process_task, NULL, _ipc, 0, 0);
+			   ipc_process_task, ipc_platform_complete_cmd, _ipc, 0,
+			   0);
 
 #if CONFIG_HOST_PTABLE
 	/* allocate page table buffer */

--- a/src/drivers/imx/ipc.c
+++ b/src/drivers/imx/ipc.c
@@ -91,7 +91,7 @@ static void irq_handler(void *arg)
 	}
 }
 
-void ipc_platform_do_cmd(struct ipc *ipc)
+static enum task_state ipc_platform_do_cmd(void *data)
 {
 	struct sof_ipc_cmd_hdr *hdr;
 	/* Use struct ipc_data *iipc = ipc_get_drvdata(ipc); if needed */
@@ -99,6 +99,8 @@ void ipc_platform_do_cmd(struct ipc *ipc)
 	/* perform command */
 	hdr = mailbox_validate();
 	ipc_cmd(hdr);
+
+	return SOF_TASK_STATE_COMPLETED;
 }
 
 static void ipc_platform_complete_cmd(void *data)
@@ -161,8 +163,8 @@ int platform_ipc_init(struct ipc *ipc)
 
 	/* schedule */
 	schedule_task_init(&_ipc->ipc_task, SOF_SCHEDULE_EDF, SOF_TASK_PRI_IPC,
-			   ipc_process_task, ipc_platform_complete_cmd, _ipc, 0,
-			   0);
+			   ipc_platform_do_cmd, ipc_platform_complete_cmd, _ipc,
+			   0, 0);
 
 #if CONFIG_HOST_PTABLE
 	/* allocate page table buffer */

--- a/src/drivers/imx/ipc.c
+++ b/src/drivers/imx/ipc.c
@@ -169,7 +169,7 @@ int platform_ipc_init(struct ipc *ipc)
 
 	/* schedule */
 	schedule_task_init(&_ipc->ipc_task, SOF_SCHEDULE_EDF, SOF_TASK_PRI_IPC,
-			   ipc_process_task, _ipc, 0, 0);
+			   ipc_process_task, NULL, _ipc, 0, 0);
 
 #if CONFIG_HOST_PTABLE
 	/* allocate page table buffer */

--- a/src/drivers/intel/baytrail/ipc.c
+++ b/src/drivers/intel/baytrail/ipc.c
@@ -18,6 +18,7 @@
 #include <sof/spinlock.h>
 #include <ipc/header.h>
 #include <ipc/topology.h>
+#include <stddef.h>
 #include <stdint.h>
 
 extern struct ipc *_ipc;
@@ -186,7 +187,7 @@ int platform_ipc_init(struct ipc *ipc)
 
 	/* schedule */
 	schedule_task_init(&_ipc->ipc_task, SOF_SCHEDULE_EDF, SOF_TASK_PRI_IPC,
-			   ipc_process_task, _ipc, 0, 0);
+			   ipc_process_task, NULL, _ipc, 0, 0);
 
 #if CONFIG_HOST_PTABLE
 	/* allocate page table buffer */

--- a/src/drivers/intel/baytrail/ipc.c
+++ b/src/drivers/intel/baytrail/ipc.c
@@ -87,17 +87,7 @@ static void irq_handler(void *arg)
 		/* Mask Busy interrupt before return */
 		shim_write(SHIM_IMRD, shim_read(SHIM_IMRD) | SHIM_IMRD_BUSY);
 
-		/* TODO: place message in Q and process later */
-		/* It's not Q ATM, may overwrite */
-		if (_ipc->host_pending) {
-			trace_ipc_error("ipc: dropping msg");
-			trace_ipc_error(" isr 0x%x imrd 0x%x ipcxh 0x%x",
-					isr, shim_read(SHIM_IMRD),
-					shim_read(SHIM_IPCXH));
-		} else {
-			_ipc->host_pending = 1;
-			ipc_schedule_process(_ipc);
-		}
+		ipc_schedule_process(_ipc);
 	}
 }
 
@@ -109,8 +99,6 @@ void ipc_platform_do_cmd(struct ipc *ipc)
 	/* perform command */
 	hdr = mailbox_validate();
 	ipc_cmd(hdr);
-
-	ipc->host_pending = 0;
 }
 
 static void ipc_platform_complete_cmd(void *data)

--- a/src/drivers/intel/baytrail/ipc.c
+++ b/src/drivers/intel/baytrail/ipc.c
@@ -91,7 +91,7 @@ static void irq_handler(void *arg)
 	}
 }
 
-void ipc_platform_do_cmd(struct ipc *ipc)
+static enum task_state ipc_platform_do_cmd(void *data)
 {
 	struct sof_ipc_cmd_hdr *hdr;
 	/* Use struct ipc_data *iipc = ipc_get_drvdata(ipc); if needed */
@@ -99,6 +99,8 @@ void ipc_platform_do_cmd(struct ipc *ipc)
 	/* perform command */
 	hdr = mailbox_validate();
 	ipc_cmd(hdr);
+
+	return SOF_TASK_STATE_COMPLETED;
 }
 
 static void ipc_platform_complete_cmd(void *data)
@@ -179,8 +181,8 @@ int platform_ipc_init(struct ipc *ipc)
 
 	/* schedule */
 	schedule_task_init(&_ipc->ipc_task, SOF_SCHEDULE_EDF, SOF_TASK_PRI_IPC,
-			   ipc_process_task, ipc_platform_complete_cmd, _ipc, 0,
-			   0);
+			   ipc_platform_do_cmd, ipc_platform_complete_cmd, _ipc,
+			   0, 0);
 
 #if CONFIG_HOST_PTABLE
 	/* allocate page table buffer */

--- a/src/drivers/intel/cavs/dmic.c
+++ b/src/drivers/intel/cavs/dmic.c
@@ -1068,7 +1068,7 @@ static int dmic_set_config(struct dai *dai, struct sof_ipc_dai_config *config)
 
 	/* Initialize start sequence handler */
 	schedule_task_init(&dmic->dmicwork, SOF_SCHEDULE_LL,
-			   SOF_TASK_PRI_MED, dmic_work, dai, 0,
+			   SOF_TASK_PRI_MED, dmic_work, NULL, dai, 0,
 			   SOF_SCHEDULE_FLAG_ASYNC);
 
 

--- a/src/drivers/intel/cavs/idc.c
+++ b/src/drivers/intel/cavs/idc.c
@@ -27,6 +27,7 @@
 #include <xtos-structs.h>
 #include <errno.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
 extern struct ipc *_ipc;
@@ -371,7 +372,7 @@ int idc_init(void)
 
 	/* process task */
 	schedule_task_init(&(*idc)->idc_task, SOF_SCHEDULE_EDF,
-			   SOF_TASK_PRI_IDC, idc_do_cmd, *idc, core, 0);
+			   SOF_TASK_PRI_IDC, idc_do_cmd, NULL, *idc, core, 0);
 
 	/* configure interrupt */
 	(*idc)->irq = interrupt_get_irq(PLATFORM_IDC_INTERRUPT,

--- a/src/drivers/intel/cavs/ipc.c
+++ b/src/drivers/intel/cavs/ipc.c
@@ -86,22 +86,7 @@ static void ipc_irq_handler(void *arg)
 		increment_ipc_received_counter();
 #endif
 
-		/* TODO: place message in Q and process later */
-		/* It's not Q ATM, may overwrite */
-		if (_ipc->host_pending) {
-			trace_ipc_error("ipc: dropping msg");
-#if CAVS_VERSION == CAVS_VERSION_1_5
-			trace_ipc_error(" dipct 0x%x dipcie 0x%x dipcctl 0x%x",
-					dipct, dipcie, ipc_read(IPC_DIPCCTL));
-#else
-			trace_ipc_error(" dipctdr 0x%x dipcida 0x%x "
-					"dipcctl 0x%x", dipctdr, dipcida,
-					ipc_read(IPC_DIPCCTL));
-#endif
-		} else {
-			_ipc->host_pending = 1;
-			ipc_schedule_process(_ipc);
-		}
+		ipc_schedule_process(_ipc);
 	}
 
 	/* reply message(done) from host */
@@ -141,8 +126,6 @@ void ipc_platform_do_cmd(struct ipc *ipc)
 
 	/* perform command */
 	ipc_cmd(hdr);
-
-	ipc->host_pending = 0;
 
 	/* are we about to enter D3 ? */
 #if CAVS_VERSION < CAVS_VERSION_2_0

--- a/src/drivers/intel/cavs/ipc.c
+++ b/src/drivers/intel/cavs/ipc.c
@@ -230,7 +230,7 @@ int platform_ipc_init(struct ipc *ipc)
 
 	/* schedule */
 	schedule_task_init(&_ipc->ipc_task, SOF_SCHEDULE_EDF, SOF_TASK_PRI_IPC,
-			   ipc_process_task, _ipc, 0, 0);
+			   ipc_process_task, NULL, _ipc, 0, 0);
 
 	/* configure interrupt */
 	irq = interrupt_get_irq(PLATFORM_IPC_INTERRUPT,

--- a/src/drivers/intel/cavs/ipc.c
+++ b/src/drivers/intel/cavs/ipc.c
@@ -151,6 +151,13 @@ void ipc_platform_do_cmd(struct ipc *ipc)
 		platform_pm_runtime_power_off();
 	}
 #endif
+}
+
+static void ipc_platform_complete_cmd(void *data)
+{
+#if CAVS_VERSION >= CAVS_VERSION_2_0
+	struct ipc *ipc = data;
+#endif
 
 	/* write 1 to clear busy, and trigger interrupt to host*/
 #if CAVS_VERSION == CAVS_VERSION_1_5
@@ -230,7 +237,8 @@ int platform_ipc_init(struct ipc *ipc)
 
 	/* schedule */
 	schedule_task_init(&_ipc->ipc_task, SOF_SCHEDULE_EDF, SOF_TASK_PRI_IPC,
-			   ipc_process_task, NULL, _ipc, 0, 0);
+			   ipc_process_task, ipc_platform_complete_cmd, _ipc, 0,
+			   0);
 
 	/* configure interrupt */
 	irq = interrupt_get_irq(PLATFORM_IPC_INTERRUPT,

--- a/src/drivers/intel/cavs/sue-ipc.c
+++ b/src/drivers/intel/cavs/sue-ipc.c
@@ -34,8 +34,6 @@ void ipc_platform_do_cmd(struct ipc *ipc)
 			     0, sizeof(reply));
 	spi_push(spi_get(SOF_SPI_INTEL_SLAVE), &reply, sizeof(reply));
 
-	ipc->host_pending = 0;
-
 	// TODO: signal audio work to enter D3 in normal context
 	/* are we about to enter D3 ? */
 	if (ipc->pm_prepare_D3) {

--- a/src/drivers/intel/cavs/sue-ipc.c
+++ b/src/drivers/intel/cavs/sue-ipc.c
@@ -21,8 +21,9 @@
 extern struct ipc *_ipc;
 
 /* No private data for IPC */
-void ipc_platform_do_cmd(struct ipc *ipc)
+static enum task_state ipc_platform_do_cmd(void *data)
 {
+	struct ipc *ipc = data;
 	struct sof_ipc_cmd_hdr *hdr;
 	struct sof_ipc_reply reply;
 
@@ -40,6 +41,8 @@ void ipc_platform_do_cmd(struct ipc *ipc)
 		while (1)
 			wait_for_interrupt(0);
 	}
+
+	return SOF_TASK_STATE_COMPLETED;
 }
 
 void ipc_platform_send_msg(struct ipc *ipc)
@@ -79,7 +82,7 @@ int platform_ipc_init(struct ipc *ipc)
 
 	/* schedule */
 	schedule_task_init(&_ipc->ipc_task, SOF_SCHEDULE_EDF, SOF_TASK_PRI_MED,
-			   ipc_process_task, NULL, _ipc, 0, 0);
+			   ipc_platform_do_cmd, NULL, _ipc, 0, 0);
 
 	return 0;
 }

--- a/src/drivers/intel/cavs/sue-ipc.c
+++ b/src/drivers/intel/cavs/sue-ipc.c
@@ -81,7 +81,7 @@ int platform_ipc_init(struct ipc *ipc)
 
 	/* schedule */
 	schedule_task_init(&_ipc->ipc_task, SOF_SCHEDULE_EDF, SOF_TASK_PRI_MED,
-			   ipc_process_task, _ipc, 0, 0);
+			   ipc_process_task, NULL, _ipc, 0, 0);
 
 	return 0;
 }

--- a/src/drivers/intel/haswell/ipc.c
+++ b/src/drivers/intel/haswell/ipc.c
@@ -18,7 +18,6 @@
 #include <sof/spinlock.h>
 #include <ipc/header.h>
 #include <ipc/topology.h>
-#include <stddef.h>
 #include <stdint.h>
 
 extern struct ipc *_ipc;
@@ -107,6 +106,11 @@ void ipc_platform_do_cmd(struct ipc *ipc)
 	ipc_cmd(hdr);
 
 	ipc->host_pending = 0;
+}
+
+static void ipc_platform_complete_cmd(void *data)
+{
+	struct ipc *ipc = data;
 
 	/* clear BUSY bit and set DONE bit - accept new messages */
 	shim_write(SHIM_IPCX, SHIM_IPCX_DONE);
@@ -177,7 +181,8 @@ int platform_ipc_init(struct ipc *ipc)
 
 	/* schedule */
 	schedule_task_init(&_ipc->ipc_task, SOF_SCHEDULE_EDF, SOF_TASK_PRI_IPC,
-			   ipc_process_task, NULL, _ipc, 0, 0);
+			   ipc_process_task, ipc_platform_complete_cmd, _ipc, 0,
+			   0);
 
 #if CONFIG_HOST_PTABLE
 	/* allocate page table buffer */

--- a/src/drivers/intel/haswell/ipc.c
+++ b/src/drivers/intel/haswell/ipc.c
@@ -82,17 +82,7 @@ static void irq_handler(void *arg)
 		/* Mask Busy interrupt before return */
 		shim_write(SHIM_IMRD, shim_read(SHIM_IMRD) | SHIM_IMRD_BUSY);
 
-		/* TODO: place message in Q and process later */
-		/* It's not Q ATM, may overwrite */
-		if (_ipc->host_pending) {
-			trace_ipc_error("ipc: dropping msg");
-			trace_ipc_error(" isr 0x%x imrd 0x%x ipcx 0x%x",
-					isr, shim_read(SHIM_IMRD),
-					shim_read(SHIM_IPCX));
-		} else {
-			_ipc->host_pending = 1;
-			ipc_schedule_process(_ipc);
-		}
+		ipc_schedule_process(_ipc);
 	}
 }
 
@@ -104,8 +94,6 @@ void ipc_platform_do_cmd(struct ipc *ipc)
 	/* perform command */
 	hdr = mailbox_validate();
 	ipc_cmd(hdr);
-
-	ipc->host_pending = 0;
 }
 
 static void ipc_platform_complete_cmd(void *data)

--- a/src/drivers/intel/haswell/ipc.c
+++ b/src/drivers/intel/haswell/ipc.c
@@ -86,7 +86,7 @@ static void irq_handler(void *arg)
 	}
 }
 
-void ipc_platform_do_cmd(struct ipc *ipc)
+static enum task_state ipc_platform_do_cmd(void *data)
 {
 	struct sof_ipc_cmd_hdr *hdr;
 	/* Use struct ipc_data *iipc = ipc_get_drvdata(ipc); if needed */
@@ -94,6 +94,8 @@ void ipc_platform_do_cmd(struct ipc *ipc)
 	/* perform command */
 	hdr = mailbox_validate();
 	ipc_cmd(hdr);
+
+	return SOF_TASK_STATE_COMPLETED;
 }
 
 static void ipc_platform_complete_cmd(void *data)
@@ -169,8 +171,8 @@ int platform_ipc_init(struct ipc *ipc)
 
 	/* schedule */
 	schedule_task_init(&_ipc->ipc_task, SOF_SCHEDULE_EDF, SOF_TASK_PRI_IPC,
-			   ipc_process_task, ipc_platform_complete_cmd, _ipc, 0,
-			   0);
+			   ipc_platform_do_cmd, ipc_platform_complete_cmd, _ipc,
+			   0, 0);
 
 #if CONFIG_HOST_PTABLE
 	/* allocate page table buffer */

--- a/src/drivers/intel/haswell/ipc.c
+++ b/src/drivers/intel/haswell/ipc.c
@@ -18,6 +18,7 @@
 #include <sof/spinlock.h>
 #include <ipc/header.h>
 #include <ipc/topology.h>
+#include <stddef.h>
 #include <stdint.h>
 
 extern struct ipc *_ipc;
@@ -176,7 +177,7 @@ int platform_ipc_init(struct ipc *ipc)
 
 	/* schedule */
 	schedule_task_init(&_ipc->ipc_task, SOF_SCHEDULE_EDF, SOF_TASK_PRI_IPC,
-			   ipc_process_task, _ipc, 0, 0);
+			   ipc_process_task, NULL, _ipc, 0, 0);
 
 #if CONFIG_HOST_PTABLE
 	/* allocate page table buffer */

--- a/src/include/sof/drivers/ipc.h
+++ b/src/include/sof/drivers/ipc.h
@@ -95,7 +95,6 @@ struct ipc_shared_context {
 };
 
 struct ipc {
-	uint32_t host_pending;
 	spinlock_t *lock;	/* locking mechanism */
 	void *comp_data;
 

--- a/src/include/sof/drivers/ipc.h
+++ b/src/include/sof/drivers/ipc.h
@@ -146,7 +146,6 @@ int platform_ipc_init(struct ipc *ipc);
 void ipc_free(struct ipc *ipc);
 
 int ipc_process_msg_queue(void);
-enum task_state ipc_process_task(void *data);
 void ipc_schedule_process(struct ipc *ipc);
 
 int ipc_stream_send_position(struct comp_dev *cdev,
@@ -159,7 +158,6 @@ int ipc_stream_send_xrun(struct comp_dev *cdev,
 int ipc_queue_host_message(struct ipc *ipc, uint32_t header, void *tx_data,
 			   size_t tx_bytes, uint32_t replace);
 
-void ipc_platform_do_cmd(struct ipc *ipc);
 void ipc_platform_send_msg(struct ipc *ipc);
 
 /**

--- a/src/include/sof/lib/wait.h
+++ b/src/include/sof/lib/wait.h
@@ -20,6 +20,7 @@
 #include <sof/trace/trace.h>
 #include <user/trace.h>
 #include <config.h>
+#include <stddef.h>
 #include <stdint.h>
 
 typedef struct {
@@ -69,7 +70,7 @@ static inline void wait_init(completion_t *comp)
 	c->complete = 0;
 
 	schedule_task_init(&comp->work, SOF_SCHEDULE_LL, SOF_TASK_PRI_MED,
-			   _wait_cb, comp, 0, 0);
+			   _wait_cb, NULL, comp, 0, 0);
 }
 
 static inline void wait_clear(completion_t *comp)

--- a/src/include/sof/schedule/schedule.h
+++ b/src/include/sof/schedule/schedule.h
@@ -171,8 +171,9 @@ static inline void schedule(void)
 }
 
 int schedule_task_init(struct task *task, uint16_t type, uint16_t priority,
-		       enum task_state (*run)(void *data), void *data,
-		       uint16_t core, uint32_t flags);
+		       enum task_state (*run)(void *data),
+		       void (*complete)(void *data), void *data, uint16_t core,
+		       uint32_t flags);
 
 void scheduler_init(int type, const struct scheduler_ops *ops, void *data);
 

--- a/src/include/sof/schedule/schedule.h
+++ b/src/include/sof/schedule/schedule.h
@@ -171,7 +171,7 @@ static inline void schedule(void)
 }
 
 int schedule_task_init(struct task *task, uint16_t type, uint16_t priority,
-		       enum task_state (*func)(void *data), void *data,
+		       enum task_state (*run)(void *data), void *data,
 		       uint16_t core, uint32_t flags);
 
 void scheduler_init(int type, const struct scheduler_ops *ops, void *data);

--- a/src/include/sof/schedule/task.h
+++ b/src/include/sof/schedule/task.h
@@ -20,8 +20,8 @@ struct sof;
 #define SOF_TASK_PRI_IDLE	INT16_MAX	/* lowest possible priority */
 #define SOF_TASK_PRI_ALMOST_IDLE	(SOF_TASK_PRI_IDLE - 1)
 
-#define SOF_TASK_PRI_IPC	SOF_TASK_PRI_LOW
-#define SOF_TASK_PRI_IDC	SOF_TASK_PRI_LOW
+#define SOF_TASK_PRI_IPC	SOF_TASK_PRI_HIGH
+#define SOF_TASK_PRI_IDC	SOF_TASK_PRI_HIGH
 
 /* task default stack size in bytes */
 #define SOF_TASK_DEFAULT_STACK_SIZE	2048

--- a/src/include/sof/schedule/task.h
+++ b/src/include/sof/schedule/task.h
@@ -48,6 +48,7 @@ struct task {
 	enum task_state state;
 	void *data;
 	enum task_state (*run)(void *data);
+	void (*complete)(void *data);
 	struct list_item list;
 	void *private;
 };

--- a/src/include/sof/schedule/task.h
+++ b/src/include/sof/schedule/task.h
@@ -47,7 +47,7 @@ struct task {
 	uint16_t flags;
 	enum task_state state;
 	void *data;
-	enum task_state (*func)(void *data);
+	enum task_state (*run)(void *data);
 	struct list_item list;
 	void *private;
 };

--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -1292,8 +1292,7 @@ int ipc_process_msg_queue(void)
 
 enum task_state ipc_process_task(void *data)
 {
-	if (_ipc->host_pending)
-		ipc_platform_do_cmd(_ipc);
+	ipc_platform_do_cmd(_ipc);
 
 	return SOF_TASK_STATE_COMPLETED;
 }

--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -1290,13 +1290,6 @@ int ipc_process_msg_queue(void)
 	return 0;
 }
 
-enum task_state ipc_process_task(void *data)
-{
-	ipc_platform_do_cmd(_ipc);
-
-	return SOF_TASK_STATE_COMPLETED;
-}
-
 void ipc_schedule_process(struct ipc *ipc)
 {
 	schedule_task(&ipc->ipc_task, 0, 100);

--- a/src/lib/agent.c
+++ b/src/lib/agent.c
@@ -25,6 +25,7 @@
 #include <ipc/topology.h>
 #include <ipc/trace.h>
 #include <user/trace.h>
+#include <stddef.h>
 #include <stdint.h>
 
 #define trace_sa(__e, ...) \
@@ -83,7 +84,7 @@ void sa_init(struct sof *sof)
 	sa->is_active = true;
 
 	schedule_task_init(&sa->work, SOF_SCHEDULE_LL, SOF_TASK_PRI_HIGH,
-			   validate, sa, 0, 0);
+			   validate, NULL, sa, 0, 0);
 
 	schedule_task(&sa->work, PLATFORM_IDLE_TIME, PLATFORM_IDLE_TIME);
 }

--- a/src/schedule/edf_schedule.c
+++ b/src/schedule/edf_schedule.c
@@ -37,10 +37,10 @@ static void schedule_edf(void *data);
 static void schedule_edf_task_run(struct task *task, void *data)
 {
 	while (1) {
-		/* execute task function and remove task from the list
+		/* execute task run function and remove task from the list
 		 * only if completed
 		 */
-		if (task->func(task->data) == SOF_TASK_STATE_COMPLETED)
+		if (task->run(task->data) == SOF_TASK_STATE_COMPLETED)
 			schedule_edf_task_complete(data, task);
 
 		/* find new task for execution */

--- a/src/schedule/edf_schedule.c
+++ b/src/schedule/edf_schedule.c
@@ -215,6 +215,10 @@ static void schedule_edf_task_complete(void *data, struct task *task)
 
 	irq_local_disable(flags);
 
+	/* execute task complete function if exists */
+	if (task->complete)
+		task->complete(task->data);
+
 	task->state = SOF_TASK_STATE_COMPLETED;
 	list_item_del(&task->list);
 

--- a/src/schedule/ll_schedule.c
+++ b/src/schedule/ll_schedule.c
@@ -83,7 +83,7 @@ static void schedule_ll_tasks_execute(struct ll_schedule_data *sch)
 
 		/* run task if its pending and remove from the list */
 		if (task->state == SOF_TASK_STATE_PENDING) {
-			task->state = task->func(task->data);
+			task->state = task->run(task->data);
 
 			/* do we need to reschedule this task */
 			if (task->state == SOF_TASK_STATE_COMPLETED) {

--- a/src/schedule/schedule.c
+++ b/src/schedule/schedule.c
@@ -19,8 +19,9 @@
 #include <stdint.h>
 
 int schedule_task_init(struct task *task, uint16_t type, uint16_t priority,
-		       enum task_state (*run)(void *data), void *data,
-		       uint16_t core, uint32_t flags)
+		       enum task_state (*run)(void *data),
+		       void (*complete)(void *data), void *data, uint16_t core,
+		       uint32_t flags)
 {
 	struct schedulers *schedulers = *arch_schedulers_get();
 	struct schedule_data *sch;
@@ -40,6 +41,7 @@ int schedule_task_init(struct task *task, uint16_t type, uint16_t priority,
 	task->flags = flags;
 	task->state = SOF_TASK_STATE_INIT;
 	task->run = run;
+	task->complete = complete;
 	task->data = data;
 
 	list_for_item(slist, &schedulers->list) {

--- a/src/schedule/schedule.c
+++ b/src/schedule/schedule.c
@@ -19,7 +19,7 @@
 #include <stdint.h>
 
 int schedule_task_init(struct task *task, uint16_t type, uint16_t priority,
-		       enum task_state (*func)(void *data), void *data,
+		       enum task_state (*run)(void *data), void *data,
 		       uint16_t core, uint32_t flags)
 {
 	struct schedulers *schedulers = *arch_schedulers_get();
@@ -39,7 +39,7 @@ int schedule_task_init(struct task *task, uint16_t type, uint16_t priority,
 	task->core = core;
 	task->flags = flags;
 	task->state = SOF_TASK_STATE_INIT;
-	task->func = func;
+	task->run = run;
 	task->data = data;
 
 	list_for_item(slist, &schedulers->list) {

--- a/src/schedule/task.c
+++ b/src/schedule/task.c
@@ -21,6 +21,7 @@
 #include <sof/sof.h>
 #include <ipc/topology.h>
 #include <errno.h>
+#include <stddef.h>
 #include <stdint.h>
 
 #if STATIC_PIPE
@@ -65,7 +66,7 @@ void task_main_init(struct sof *sof)
 	*main_task = rzalloc(RZONE_SYS, SOF_MEM_CAPS_RAM, sizeof(**main_task));
 
 	assert(!schedule_task_init(*main_task, SOF_SCHEDULE_EDF,
-				   SOF_TASK_PRI_IDLE, main_main, sof, cpu,
+				   SOF_TASK_PRI_IDLE, main_main, NULL, sof, cpu,
 				   SOF_SCHEDULE_FLAG_IDLE));
 }
 

--- a/src/trace/dma-trace.c
+++ b/src/trace/dma-trace.c
@@ -139,7 +139,7 @@ int dma_trace_init_complete(struct dma_trace_data *d)
 	}
 
 	schedule_task_init(&d->dmat_work, SOF_SCHEDULE_LL,
-			   SOF_TASK_PRI_MED, trace_work, d, 0, 0);
+			   SOF_TASK_PRI_MED, trace_work, NULL, d, 0, 0);
 
 	return 0;
 }

--- a/test/cmocka/src/audio/kpb/kpb_mock.c
+++ b/test/cmocka/src/audio/kpb/kpb_mock.c
@@ -68,8 +68,9 @@ void notifier_unregister(struct notifier *notifier)
 }
 
 int schedule_task_init(struct task *task, uint16_t type, uint16_t priority,
-		       enum task_state (*run)(void *data), void *data,
-		       uint16_t core, uint32_t xflags)
+		       enum task_state (*run)(void *data),
+		       void (*complete)(void *data), void *data, uint16_t core,
+		       uint32_t xflags)
 {
 	return 0;
 }

--- a/test/cmocka/src/audio/kpb/kpb_mock.c
+++ b/test/cmocka/src/audio/kpb/kpb_mock.c
@@ -68,7 +68,7 @@ void notifier_unregister(struct notifier *notifier)
 }
 
 int schedule_task_init(struct task *task, uint16_t type, uint16_t priority,
-		       enum task_state (*func)(void *data), void *data,
+		       enum task_state (*run)(void *data), void *data,
 		       uint16_t core, uint32_t xflags)
 {
 	return 0;

--- a/test/cmocka/src/audio/pipeline/pipeline_connection_mocks.h
+++ b/test/cmocka/src/audio/pipeline/pipeline_connection_mocks.h
@@ -33,6 +33,6 @@ void cleanup_test_data(struct pipeline_connect_data *data);
 static inline void schedule_task_mock_free(void *data, struct task *task)
 {
 	task->state = SOF_TASK_STATE_FREE;
-	task->func = NULL;
+	task->run = NULL;
 	task->data = NULL;
 }

--- a/test/cmocka/src/audio/pipeline/pipeline_free.c
+++ b/test/cmocka/src/audio/pipeline/pipeline_free.c
@@ -75,7 +75,7 @@ static void test_audio_pipeline_free_sheduler_task_free(void **state)
 
 	assert_int_equal(result.pipe_task.state, SOF_TASK_STATE_FREE);
 	assert_ptr_equal(NULL, result.pipe_task.data);
-	assert_ptr_equal(NULL, result.pipe_task.func);
+	assert_ptr_equal(NULL, result.pipe_task.run);
 }
 
 static void test_audio_pipeline_free_disconnect_full(void **state)

--- a/test/cmocka/src/audio/pipeline/pipeline_mocks.c
+++ b/test/cmocka/src/audio/pipeline/pipeline_mocks.c
@@ -27,13 +27,15 @@ void platform_dai_timestamp(struct comp_dev *dai,
 }
 
 int schedule_task_init(struct task *task, uint16_t type, uint16_t priority,
-		       enum task_state (*run)(void *data), void *data,
-		       uint16_t core, uint32_t xflags)
+		       enum task_state (*run)(void *data),
+		       void (*complete)(void *data), void *data, uint16_t core,
+		       uint32_t xflags)
 {
 	(void)task;
 	(void)type;
 	(void)priority;
 	(void)run;
+	(void)complete;
 	(void)data;
 	(void)core;
 	(void)xflags;

--- a/test/cmocka/src/audio/pipeline/pipeline_mocks.c
+++ b/test/cmocka/src/audio/pipeline/pipeline_mocks.c
@@ -27,13 +27,13 @@ void platform_dai_timestamp(struct comp_dev *dai,
 }
 
 int schedule_task_init(struct task *task, uint16_t type, uint16_t priority,
-		       enum task_state (*func)(void *data), void *data,
+		       enum task_state (*run)(void *data), void *data,
 		       uint16_t core, uint32_t xflags)
 {
 	(void)task;
 	(void)type;
 	(void)priority;
-	(void)func;
+	(void)run;
 	(void)data;
 	(void)core;
 	(void)xflags;

--- a/tools/testbench/edf_schedule.c
+++ b/tools/testbench/edf_schedule.c
@@ -37,8 +37,8 @@ static void schedule_edf_task(void *data, struct task *task, uint64_t start,
 	list_item_prepend(&task->list, &sch->list);
 	task->state = SOF_TASK_STATE_QUEUED;
 
-	if (task->func)
-		task->func(task->data);
+	if (task->run)
+		task->run(task->data);
 
 	schedule_edf_task_complete(task);
 }
@@ -87,7 +87,7 @@ static void schedule_edf_task_cancel(void *data, struct task *task)
 static void schedule_edf_task_free(void *data, struct task *task)
 {
 	task->state = SOF_TASK_STATE_FREE;
-	task->func = NULL;
+	task->run = NULL;
 	task->data = NULL;
 
 	free(edf_sch_get_pdata(task));

--- a/tools/testbench/schedule.c
+++ b/tools/testbench/schedule.c
@@ -21,8 +21,9 @@ struct schedulers **arch_schedulers_get(void)
 }
 
 int schedule_task_init(struct task *task, uint16_t type, uint16_t priority,
-		       enum task_state (*run)(void *data), void *data,
-		       uint16_t core, uint32_t flags)
+		       enum task_state (*run)(void *data),
+		       void (*complete)(void *data), void *data, uint16_t core,
+		       uint32_t flags)
 {
 	struct schedulers *schedulers = *arch_schedulers_get();
 	struct schedule_data *sch;
@@ -40,6 +41,7 @@ int schedule_task_init(struct task *task, uint16_t type, uint16_t priority,
 	task->flags = flags;
 	task->state = SOF_TASK_STATE_INIT;
 	task->run = run;
+	task->complete = complete;
 	task->data = data;
 
 	list_for_item(slist, &schedulers->list) {

--- a/tools/testbench/schedule.c
+++ b/tools/testbench/schedule.c
@@ -21,7 +21,7 @@ struct schedulers **arch_schedulers_get(void)
 }
 
 int schedule_task_init(struct task *task, uint16_t type, uint16_t priority,
-		       enum task_state (*func)(void *data), void *data,
+		       enum task_state (*run)(void *data), void *data,
 		       uint16_t core, uint32_t flags)
 {
 	struct schedulers *schedulers = *arch_schedulers_get();
@@ -39,7 +39,7 @@ int schedule_task_init(struct task *task, uint16_t type, uint16_t priority,
 	task->core = core;
 	task->flags = flags;
 	task->state = SOF_TASK_STATE_INIT;
-	task->func = func;
+	task->run = run;
 	task->data = data;
 
 	list_for_item(slist, &schedulers->list) {


### PR DESCRIPTION
Changes ipc task implementation, so it accepts new messages from
host in a complete task callback. This way we will avoid the
situation, where host will send another message before we
truly complete current ipc task.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>