### PR TITLE
Add nocodec pipeline for i.MX8QXP board

### DIFF
--- a/src/include/ipc/dai-imx.h
+++ b/src/include/ipc/dai-imx.h
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright 2019 NXP
+ *
+ * Author: Daniel Baluta <daniel.baluta@nxp.com>
+ */
+
+#ifndef __IPC_DAI_IMX_H__
+#define __IPC_DAI_IMX_H__
+
+#include <ipc/header.h>
+#include <stdint.h>
+
+/* ESAI Configuration Request - SOF_IPC_DAI_ESAI_CONFIG */
+struct sof_ipc_dai_esai_params {
+	struct sof_ipc_hdr hdr;
+
+	/* MCLK */
+	uint16_t reserved1;
+	uint16_t mclk_id;
+	uint32_t mclk_rate; /* MCLK frequency in Hz */
+	uint32_t mclk_direction;
+
+	/* TDM */
+	uint32_t tdm_slots;
+	uint32_t rx_slots;
+	uint32_t tx_slots;
+	uint16_t tdm_slot_width;
+	uint16_t reserved2;	/* alignment */
+
+} __attribute__((packed));
+
+#endif /* __IPC_DAI_IMX_H__ */

--- a/src/include/ipc/dai.h
+++ b/src/include/ipc/dai.h
@@ -17,6 +17,7 @@
 #define __IPC_DAI_H__
 
 #include <ipc/dai-intel.h>
+#include <ipc/dai-imx.h>
 #include <ipc/header.h>
 #include <stdint.h>
 
@@ -81,6 +82,7 @@ struct sof_ipc_dai_config {
 		struct sof_ipc_dai_dmic_params dmic;
 		struct sof_ipc_dai_hda_params hda;
 		struct sof_ipc_dai_alh_params alh;
+		struct sof_ipc_dai_esai_params esai;
 	};
 } __attribute__((packed));
 

--- a/src/include/kernel/abi.h
+++ b/src/include/kernel/abi.h
@@ -29,7 +29,7 @@
 
 /** \brief SOF ABI version major, minor and patch numbers */
 #define SOF_ABI_MAJOR 3
-#define SOF_ABI_MINOR 10
+#define SOF_ABI_MINOR 11
 #define SOF_ABI_PATCH 0
 
 /** \brief SOF ABI version number. Format within 32bit word is MMmmmppp */

--- a/src/include/kernel/tokens.h
+++ b/src/include/kernel/tokens.h
@@ -103,4 +103,7 @@
 /* for backward compatibility */
 #define SOF_TKN_EFFECT_TYPE	SOF_TKN_PROCESS_TYPE
 
+/* ESAI */
+#define SOF_TKN_IMX_ESAI_MCLK_ID		1100
+
 #endif /* __KERNEL_TOKENS_H__ */

--- a/tools/topology/CMakeLists.txt
+++ b/tools/topology/CMakeLists.txt
@@ -80,6 +80,7 @@ set(TPLGS
 	"sof-tgl-nocodec\;sof-tgl-nocodec"
 	"sof-tgl-rt1308\;sof-tgl-rt1308"
 	"sof-tgl-rt1308-nohdmi\;sof-tgl-rt1308-nohdmi"
+	"sof-imx8qxp-nocodec\;sof-imx8qxp-nocodec"
 )
 
 add_custom_target(topologies ALL)

--- a/tools/topology/m4/dai.m4
+++ b/tools/topology/m4/dai.m4
@@ -125,13 +125,13 @@ define(`D_DAI', `SectionDAI."'N_DAI`" {'
 
 dnl DAI Config)
 define(`N_DAI_CONFIG', `DAICONFIG.'$1)
-dnl DAI_CONFIG(type, idx, link_id, name, ssp_config/dmic_config)
+dnl DAI_CONFIG(type, idx, link_id, name, esai_config/ssp_config/dmic_config)
 define(`DO_DAI_CONFIG',
 `SectionHWConfig."'$1$2`" {'
 `'
 `	id		"'$3`"'
 `'
-`	ifelse($1, `SSP', $5, `}')'
+`	ifelse($1, `SSP', $5, $1, `ESAI', $5, `}')'
 `ifelse($1, `DMIC', $5, `')'
 `SectionVendorTuples."'N_DAI_CONFIG($1$2)`_tuples_common" {'
 `	tokens "sof_dai_tokens"'

--- a/tools/topology/platform/common/esai.m4
+++ b/tools/topology/platform/common/esai.m4
@@ -1,0 +1,45 @@
+divert(-1)
+
+dnl ESAI related macros
+
+dnl ESAI_CLOCK(clock, freq, codec_master, polarity)
+dnl polarity is optional
+define(`ESAI_CLOCK',
+	$1		STR($3)
+	$1_freq		STR($2))
+	`ifelse($4, `inverted', `$1_invert	"true"',`')')
+
+dnl ESAI_TDM(slots, width, tx_mask, rx_mask)
+define(`ESAI_TDM',
+`	tdm_slots	'STR($1)
+`	tdm_slot_width	'STR($2)
+`	tx_slots	'STR($3)
+`	rx_slots	'STR($4)
+)
+
+dnl ESAI_CONFIG(format, mclk, bclk, fsync, tdm, esai_config_data)
+define(`ESAI_CONFIG',
+`	format		"'$1`"'
+`	'$2
+`	'$3
+`	'$4
+`	'$5
+`}'
+$6
+)
+
+dnl ESAI_CONFIG_DATA(type, idx, mclk_id)
+dnl mclk_id is optional
+define(`ESAI_CONFIG_DATA',
+`SectionVendorTuples."'N_DAI_CONFIG($1$2)`_tuples" {'
+`	tokens "sof_esai_tokens"'
+`	tuples."short" {'
+`		SOF_TKN_IMX_ESAI_MCLK_ID'	ifelse($3, `', "0", STR($3))
+`	}'
+`}'
+`SectionData."'N_DAI_CONFIG($1$2)`_data" {'
+`	tuples "'N_DAI_CONFIG($1$2)`_tuples"'
+`}'
+)
+
+divert(0)dnl

--- a/tools/topology/platform/imx/imx8qxp.m4
+++ b/tools/topology/platform/imx/imx8qxp.m4
@@ -1,0 +1,14 @@
+#
+# i.MX8QXP differentiation for pipelines and components
+#
+
+include(`memory.m4')
+
+# Low Latency PCM Configuration
+W_VENDORTUPLES(pipe_ll_schedule_plat_tokens, sof_sched_tokens, LIST(`		', `SOF_TKN_SCHED_MIPS	"50000"'))
+W_DATA(pipe_ll_schedule_plat, pipe_ll_schedule_plat_tokens)
+
+# DAI schedule Configuration - scheduled by IRQ
+W_VENDORTUPLES(pipe_dai_schedule_plat_tokens, sof_sched_tokens, LIST(`		', `SOF_TKN_SCHED_MIPS	"5000"'))
+W_DATA(pipe_dai_schedule_plat, pipe_dai_schedule_plat_tokens)
+

--- a/tools/topology/sof-imx8qxp-nocodec.m4
+++ b/tools/topology/sof-imx8qxp-nocodec.m4
@@ -1,0 +1,68 @@
+#
+# Topology for i.MX8QXP board with nocodec
+#
+
+# Include topology builder
+include(`utils.m4')
+include(`dai.m4')
+include(`pipeline.m4')
+include(`esai.m4')
+include(`pcm.m4')
+include(`buffer.m4')
+
+# Include TLV library
+include(`common/tlv.m4')
+
+# Include Token library
+include(`sof/tokens.m4')
+
+# Include DSP configuration
+include(`platform/imx/imx8qxp.m4')
+
+#
+# Define the pipelines
+#
+# PCM0 ---> Volume ---> ESAI0 (NoCodec)
+#
+
+dnl PIPELINE_PCM_ADD(pipeline,
+dnl     pipe id, pcm, max channels, format,
+dnl     period, priority, core,
+dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
+dnl     time_domain, sched_comp)
+
+# Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s24le
+# Set 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	1, 0, 2, s24le,
+	1000, 0, 0,
+	8000, 96000, 48000)
+
+#
+# DAIs configuration
+#
+
+dnl DAI_ADD(pipeline,
+dnl     pipe id, dai type, dai_index, dai_be,
+dnl     buffer, periods, format,
+dnl     deadline, priority, core)
+
+# playback DAI is ESAI0 using 2 periods
+# Buffers use s24le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+	1, ESAI, 0, NoCodec-0,
+	PIPELINE_SOURCE_1, 2, s24le,
+	1000, 0, 0)
+
+dnl PCM_PLAYBACK_ADD(name, pcm_id, playback)
+
+# PCM Low Latency, id 0
+PCM_PLAYBACK_ADD(Port0, 0, PIPELINE_PCM_1)
+
+dnl DAI_CONFIG(type, dai_index, link_id, name, esai_config)
+DAI_CONFIG(ESAI, 0, 0, NoCodec-0,
+	ESAI_CONFIG(I2S, ESAI_CLOCK(mclk, 49152000, codec_mclk_in),
+		ESAI_CLOCK(bclk, 3072000, codec_slave),
+		ESAI_CLOCK(fsync, 48000, codec_slave),
+		ESAI_TDM(2, 32, 3, 3),
+		ESAI_CONFIG_DATA(ESAI, 0, 0)))

--- a/tools/topology/sof/tokens.m4
+++ b/tools/topology/sof/tokens.m4
@@ -92,3 +92,7 @@ SectionVendorTokens."sof_tone_tokens" {
 SectionVendorTokens."sof_process_tokens" {
 	SOF_TKN_PROCESS_TYPE			"900"
 }
+
+SectionVendorTokens."sof_esai_tokens" {
+	SOF_TKN_IMX_ESAI_MCLK_ID		"1100"
+}


### PR DESCRIPTION
i.MX8QXP contains one ESAI0 interface. This patch series adds helper m4 macros for ESAI and creates a simple playback topology with ESAI0 and nocodec.

With this we can test Dummy DMA, EDMA and ESAI drivers.

Corresponding changes for Linux kernel side will be sent right away.
