### PR TITLE
topology: add ipc for smart amplifier component

### DIFF
--- a/src/include/ipc/topology.h
+++ b/src/include/ipc/topology.h
@@ -46,6 +46,7 @@ enum sof_comp_type {
 	SOF_COMP_DEMUX,
 	SOF_COMP_ASRC,		/**< Asynchronous sample rate converter */
 	SOF_COMP_DCBLOCK,
+	SOF_COMP_SMART_AMP,		/**< smart amplifier component */
 	/* keep FILEREAD/FILEWRITE as the last ones */
 	SOF_COMP_FILEREAD = 10000,	/**< host test based file IO */
 	SOF_COMP_FILEWRITE = 10001,	/**< host test based file IO */

--- a/src/include/kernel/abi.h
+++ b/src/include/kernel/abi.h
@@ -29,7 +29,7 @@
 
 /** \brief SOF ABI version major, minor and patch numbers */
 #define SOF_ABI_MAJOR 3
-#define SOF_ABI_MINOR 15
+#define SOF_ABI_MINOR 16
 #define SOF_ABI_PATCH 0
 
 /** \brief SOF ABI version number. Format within 32bit word is MMmmmppp */


### PR DESCRIPTION
Add ```SOF_COMP_SMART_AMP``` type for smart amp component.
Basic topology using smart amplifier component
could be as follows:

                +--------------------------------------------+
    +------+    | +---+  +---------------+  +---+  +-------+ |
    | Host |----->|Buf|->|   Smart Amp   |->|Buf|->|SSP Dai|----------+
    +------+    | +---+  +---------------+  +---+  +-------+ |        |
                +----------------^---------------------------+        |
                                 |                                    |
                               +---+                                  |
                               |Buf|                                  | 
                               +---+                                  |
                                 ^                                    |
                +----------------|-----------------------------+      |
    +------+    | +---+  +-------|---------+  +---+  +-------+ |      |
    | Host |<-----|Buf|<-|      Demux      |<-|Buf|<-|SSP Dai|<-------+
    +------+    | +---+  +-----------------+  +---+  +-------+ |
                +----------------------------------------------+

Basic topology contains Smart Amp component in playback pipeline and Demux
component in capture pipeline. There is a additional buffer (feedback)
between them in order to process "feedback".

Signed-off-by: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>