### PR TITLE
topology: change 50kHz topology to use volume component

### DIFF
--- a/tools/topology/sof-apl-src-50khz-pcm512x.m4
+++ b/tools/topology/sof-apl-src-50khz-pcm512x.m4
@@ -34,7 +34,7 @@ dnl     time_domain, sched_comp)
 
 # Playback pipeline 1 on PCM 0 using max 2 channels of s24le.
 # Schedule 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_ADD(sof/pipe-src-playback.m4,
+PIPELINE_PCM_ADD(sof/pipe-src-volume-playback.m4,
 	1, 0, 2, s24le,
 	1000, 0, 0,
 	48000, 50000, 50000)


### PR DESCRIPTION
Currently having different amount of periods between DAI and the
component before it is not allowed. This is because it is not allowed to
resize dma connected buffers. So make 50kHz topology use src-volume
pipeline, which has additional volume component, which in turn has
correct amount of periods for the DAI connection.

Signed-off-by: Jaska Uimonen <jaska.uimonen@intel.com>