### PR TITLE
interrupt: remove unmask parameter

### DIFF
--- a/src/drivers/imx/ipc.c
+++ b/src/drivers/imx/ipc.c
@@ -175,8 +175,7 @@ int platform_ipc_init(struct ipc *ipc)
 #endif
 
 	/* configure interrupt */
-	interrupt_register(PLATFORM_IPC_INTERRUPT, IRQ_AUTO_UNMASK,
-			   irq_handler, _ipc);
+	interrupt_register(PLATFORM_IPC_INTERRUPT, irq_handler, _ipc);
 	interrupt_enable(PLATFORM_IPC_INTERRUPT, _ipc);
 
 	/* enable GP #0 for Host -> DSP message notification

--- a/src/drivers/intel/baytrail/ipc.c
+++ b/src/drivers/intel/baytrail/ipc.c
@@ -199,8 +199,7 @@ int platform_ipc_init(struct ipc *ipc)
 	iipc->dh_buffer.dmac = dma_get(dir, caps, dev, DMA_ACCESS_SHARED);
 
 	/* configure interrupt */
-	interrupt_register(PLATFORM_IPC_INTERRUPT, IRQ_AUTO_UNMASK,
-			   irq_handler, ipc);
+	interrupt_register(PLATFORM_IPC_INTERRUPT, irq_handler, ipc);
 	interrupt_enable(PLATFORM_IPC_INTERRUPT, ipc);
 
 	/* Unmask Busy and Done interrupts */

--- a/src/drivers/intel/cavs/dmic.c
+++ b/src/drivers/intel/cavs/dmic.c
@@ -1537,8 +1537,7 @@ static int dmic_probe(struct dai *dai)
 		return ret;
 	}
 
-	ret = interrupt_register(dmic->irq, IRQ_AUTO_UNMASK,
-				 dmic_irq_handler, dai);
+	ret = interrupt_register(dmic->irq, dmic_irq_handler, dai);
 	if (ret < 0) {
 		trace_dmic_error("dmic failed to allocate IRQ");
 		rfree(dmic);

--- a/src/drivers/intel/cavs/idc.c
+++ b/src/drivers/intel/cavs/idc.c
@@ -379,8 +379,7 @@ int idc_init(void)
 					PLATFORM_IDC_INTERRUPT_NAME);
 	if ((*idc)->irq < 0)
 		return (*idc)->irq;
-	ret = interrupt_register((*idc)->irq, IRQ_AUTO_UNMASK, idc_irq_handler,
-				 *idc);
+	ret = interrupt_register((*idc)->irq, idc_irq_handler, *idc);
 	if (ret < 0)
 		return ret;
 	interrupt_enable((*idc)->irq, *idc);

--- a/src/drivers/intel/cavs/ipc.c
+++ b/src/drivers/intel/cavs/ipc.c
@@ -233,7 +233,7 @@ int platform_ipc_init(struct ipc *ipc)
 				PLATFORM_IPC_INTERRUPT_NAME);
 	if (irq < 0)
 		return irq;
-	interrupt_register(irq, IRQ_AUTO_UNMASK, ipc_irq_handler, ipc);
+	interrupt_register(irq, ipc_irq_handler, ipc);
 	interrupt_enable(irq, ipc);
 
 	/* enable IPC interrupts from host */

--- a/src/drivers/intel/cavs/timer.c
+++ b/src/drivers/intel/cavs/timer.c
@@ -107,8 +107,7 @@ static int platform_timer_register(struct timer *timer,
 	if (timer->logical_irq < 0)
 		return timer->logical_irq;
 
-	err = interrupt_register(timer->logical_irq, IRQ_MANUAL_UNMASK, handler,
-				 arg);
+	err = interrupt_register(timer->logical_irq, handler, arg);
 	if (err < 0)
 		return err;
 

--- a/src/drivers/intel/haswell/ipc.c
+++ b/src/drivers/intel/haswell/ipc.c
@@ -189,8 +189,7 @@ int platform_ipc_init(struct ipc *ipc)
 	iipc->dh_buffer.dmac = dma_get(dir, caps, dev, DMA_ACCESS_SHARED);
 
 	/* configure interrupt */
-	interrupt_register(PLATFORM_IPC_INTERRUPT, IRQ_AUTO_UNMASK,
-			   irq_handler, ipc);
+	interrupt_register(PLATFORM_IPC_INTERRUPT, irq_handler, ipc);
 	interrupt_enable(PLATFORM_IPC_INTERRUPT, ipc);
 
 	/* Unmask Busy and Done interrupts */

--- a/src/drivers/intel/pmc-ipc.c
+++ b/src/drivers/intel/pmc-ipc.c
@@ -137,8 +137,7 @@ int platform_ipc_pmc_init(void)
 		       sizeof(struct intel_ipc_pmc_data));
 
 	/* configure interrupt */
-	interrupt_register(IRQ_NUM_EXT_PMC, IRQ_AUTO_UNMASK, irq_handler,
-			   _pmc);
+	interrupt_register(IRQ_NUM_EXT_PMC, irq_handler, _pmc);
 	interrupt_enable(IRQ_NUM_EXT_PMC, _pmc);
 
 	/* Unmask Busy and Done interrupts */

--- a/src/include/sof/drivers/interrupt.h
+++ b/src/include/sof/drivers/interrupt.h
@@ -22,9 +22,6 @@
 #define trace_irq_error(__e, ...) \
 	trace_error(TRACE_CLASS_IRQ,  __e, ##__VA_ARGS__)
 
-#define IRQ_MANUAL_UNMASK	0
-#define IRQ_AUTO_UNMASK		1
-
 /**
  * \brief child IRQ descriptor for cascading IRQ controllers.
  */
@@ -42,9 +39,6 @@ struct irq_desc {
 	int irq;			/**< virtual IRQ number */
 	void (*handler)(void *arg);	/**< interrupt handler function */
 	void *handler_arg;		/**< interrupt handler argument */
-	int unmask;			/**< whether irq should be
-					  * automatically unmasked
-					  */
 	uint32_t cpu_mask;		/**< a mask of CPUs on which this
 					  * interrupt is enabled
 					  */
@@ -112,8 +106,7 @@ struct irq_cascade_tmpl {
 	bool global_mask;
 };
 
-int interrupt_register(uint32_t irq, int unmask, void(*handler)(void *arg),
-		       void *arg);
+int interrupt_register(uint32_t irq, void(*handler)(void *arg), void *arg);
 void interrupt_unregister(uint32_t irq, const void *arg);
 uint32_t interrupt_enable(uint32_t irq, void *arg);
 uint32_t interrupt_disable(uint32_t irq, void *arg);

--- a/src/schedule/dma_multi_chan_domain.c
+++ b/src/schedule/dma_multi_chan_domain.c
@@ -66,8 +66,8 @@ static int dma_multi_chan_domain_irq_register(struct dma_domain_data *data,
 	/* always go through dma_multi_chan_domain_irq_handler,
 	 * so we have different arg registered for every channel
 	 */
-	ret = interrupt_register(data->irq, IRQ_AUTO_UNMASK,
-				 dma_multi_chan_domain_irq_handler, data);
+	ret = interrupt_register(data->irq, dma_multi_chan_domain_irq_handler,
+				 data);
 	if (ret < 0)
 		return ret;
 

--- a/src/schedule/edf_schedule.c
+++ b/src/schedule/edf_schedule.c
@@ -280,8 +280,7 @@ int scheduler_init_edf(struct sof *sof)
 	if (edf_sch->irq < 0)
 		return edf_sch->irq;
 
-	interrupt_register(edf_sch->irq, IRQ_AUTO_UNMASK, edf_scheduler_run,
-			   edf_sch);
+	interrupt_register(edf_sch->irq, edf_scheduler_run, edf_sch);
 	interrupt_enable(edf_sch->irq, edf_sch);
 
 	return 0;


### PR DESCRIPTION
Removes unmask parameter from interrupt structures and functions.
It's not been used for a long time now.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>