### PR TITLE
 host: refine stream position update for FW version before 3.11

### DIFF
--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -165,8 +165,12 @@ static void host_update_position(struct comp_dev *dev, uint32_t bytes)
 	if (!dev->params.no_stream_position) {
 		hd->report_pos += bytes;
 
-		/* send IPC message to driver if needed */
-		if (hd->report_pos >= dev->params.host_period_bytes) {
+		/* host_period_bytes is set to zero to disable position update
+		 * by IPC for FW version before 3.11, so send IPC message to
+		 * driver according to this condition and report_pos.
+		 */
+		if (dev->params.host_period_bytes != 0 &&
+		    hd->report_pos >= dev->params.host_period_bytes) {
 			hd->report_pos = 0;
 
 			/* send timestamped position to host


### PR DESCRIPTION
FW sends stream position message to kernel for its version before
3.11. In kernel, no_stream_position will be set to 1 for FW version
after 3.10, and host_period_bytes will be set to 0 for other versions.
So in host_update_position, the condition is always true for "hd->report_pos
 />= dev->params.host_period_bytes" for FW version before 3.11

Now check the condition dev->params.host_period_bytes != 0 according to
commit: b39b17ddf3e

Signed-off-by: Rander Wang <rander.wang@linux.intel.com>