### PR TITLE
topology: Add topology for i.MX8QXP with cs42888 codec

### DIFF
--- a/tools/topology/CMakeLists.txt
+++ b/tools/topology/CMakeLists.txt
@@ -82,6 +82,7 @@ set(TPLGS
 	"sof-tgl-rt1308\;sof-tgl-rt1308"
 	"sof-tgl-rt1308-nohdmi\;sof-tgl-rt1308-nohdmi"
 	"sof-imx8qxp-nocodec\;sof-imx8qxp-nocodec"
+	"sof-imx8qxp-cs42888\;sof-imx8qxp-cs42888"
 )
 
 add_custom_target(topologies ALL)

--- a/tools/topology/sof-imx8qxp-cs42888.m4
+++ b/tools/topology/sof-imx8qxp-cs42888.m4
@@ -1,0 +1,68 @@
+#
+# Topology for i.MX8QXP board with cs42888 codec
+#
+
+# Include topology builder
+include(`utils.m4')
+include(`dai.m4')
+include(`pipeline.m4')
+include(`esai.m4')
+include(`pcm.m4')
+include(`buffer.m4')
+
+# Include TLV library
+include(`common/tlv.m4')
+
+# Include Token library
+include(`sof/tokens.m4')
+
+# Include DSP configuration
+include(`platform/imx/imx8qxp.m4')
+
+#
+# Define the pipelines
+#
+# PCM0 ----> volume -----> ESAI0 (cs42888)
+#
+
+dnl PIPELINE_PCM_ADD(pipeline,
+dnl     pipe id, pcm, max channels, format,
+dnl     period, priority, core,
+dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
+dnl     time_domain, sched_comp)
+
+# Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s24le.
+# Set 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	1, 0, 2, s24le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+#
+# DAIs configuration
+#
+
+dnl DAI_ADD(pipeline,
+dnl     pipe id, dai type, dai_index, dai_be,
+dnl     buffer, periods, format,
+dnl     period, priority, core, time_domain)
+
+# playback DAI is ESAI0 using 2 periods
+# Buffers use s24le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+	1, ESAI, 0, ESAI0-Codec,
+	PIPELINE_SOURCE_1, 2, s24le,
+	1000, 0, 0)
+
+# PCM Low Latency, id 0
+
+dnl PCM_PLAYBACK_ADD(name, pcm_id, playback)
+PCM_PLAYBACK_ADD(Port0, 0, PIPELINE_PCM_1)
+
+dnl DAI_CONFIG(type, idx, link_id, name, esai_config)
+DAI_CONFIG(ESAI, 0, 0, ESAI0-Codec,
+	ESAI_CONFIG(I2S, ESAI_CLOCK(mclk, 49152000, codec_mclk_in),
+		ESAI_CLOCK(bclk, 3072000, codec_slave),
+		ESAI_CLOCK(fsync, 48000, codec_slave),
+		ESAI_TDM(2, 32, 3, 3),
+		ESAI_CONFIG_DATA(ESAI, 0, 0)))


### PR DESCRIPTION
This pipelines adds support for S24_LE, 2 channels, 48KHz playback.

cs42888 codec is connected to i.MX8QXP board on ESAI0 interface
as follows:
i.MX8QXP CPU board <--> i.MX8 base board <-> Audio I/O card
(setup similar with i.MX8QM, so this topology can be used as it is
be i.MX8QM also in the future).

Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>