### PR TITLE
platform: imx: Change the ordering of initializations in platform_init

### DIFF
--- a/src/platform/imx8/platform.c
+++ b/src/platform/imx8/platform.c
@@ -142,6 +142,7 @@ int platform_init(struct sof *sof)
 	int ret;
 	struct dai *esai;
 
+	platform_interrupt_init();
 	clock_init();
 	scheduler_init_edf(sof);
 
@@ -155,8 +156,6 @@ int platform_init(struct sof *sof)
 	sa_init(sof);
 
 	clock_set_freq(CLK_CPU(cpu_get_id()), CLK_MAX_CPU_HZ);
-
-	platform_interrupt_init();
 
 	/* init DMA */
 	ret = edma_init();


### PR DESCRIPTION
We first initialize the interrupts (IRQ_STEER controller) before
initializing the DMA domain because the interrupt numbers/names in the
DMA controller will be queried in the domain initialization.

Signed-off-by: Paul Olaru <paul.olaru@nxp.com>