### PR TITLE
timer: fix return values of platform_timer_set and arch_timer_set

### DIFF
--- a/src/arch/xtensa/drivers/timer.c
+++ b/src/arch/xtensa/drivers/timer.c
@@ -133,5 +133,5 @@ int64_t arch_timer_set(struct timer *timer, uint64_t ticks)
 	xthal_set_ccompare(timer->id, time);
 
 	arch_interrupt_global_enable(flags);
-	return 0;
+	return ticks;
 }

--- a/src/drivers/intel/baytrail/timer.c
+++ b/src/drivers/intel/baytrail/timer.c
@@ -106,7 +106,7 @@ int64_t platform_timer_set(struct timer *timer, uint64_t ticks)
 
 	arch_interrupt_global_enable(flags);
 
-	return 0;
+	return ticks;
 }
 
 void platform_timer_clear(struct timer *timer)


### PR DESCRIPTION
Fixes return value of platform_timer_set and arch_timer_set functions.
Change was introduced for cAVS platforms, which accidentally broke
these functions for other platforms. The intention of this functions
is to return value of set ticks, so the timer scheduler can check
for delays.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>