### PR TITLE
[RFC] Proposal for file layout for alternative RTOS support in SOF

### DIFF
--- a/src/arch/zephyr/include/arch/atomic.h
+++ b/src/arch/zephyr/include/arch/atomic.h
@@ -1,0 +1,6 @@
+#ifndef __ARCH_ATOMIC_H_
+#define __ARCH_ATOMIC_H_
+
+/* #define here to prevent SOF's own arch/atomic.h being included */
+
+#endif

--- a/src/arch/zephyr/include/arch/debug/gdb/init.h
+++ b/src/arch/zephyr/include/arch/debug/gdb/init.h
@@ -1,0 +1,12 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2019 Intel Corporation. All rights reserved.
+ *
+ * Author: Marcin Rajwa <marcin.rajwa@linux.intel.com>
+ */
+
+/*
+ * Header file for init.S
+ */
+
+extern void gdb_init_debug_exception(void);

--- a/src/arch/zephyr/include/arch/debug/gdb/utilities.h
+++ b/src/arch/zephyr/include/arch/debug/gdb/utilities.h
@@ -1,0 +1,16 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2019 Intel Corporation. All rights reserved.
+ *
+ * Author: Marcin Rajwa <marcin.rajwa@linux.intel.com>
+ */
+
+/*
+ * Header file for Xtensa-GDB utilities.
+ */
+
+void arch_gdb_read_sr(int sr);
+void arch_gdb_write_sr(int sr, int *sregs);
+unsigned char arch_gdb_load_from_memory(void *mem);
+void arch_gdb_memory_load_and_store(void *mem, unsigned char ch);
+void arch_gdb_single_step(int *sregs);

--- a/src/arch/zephyr/include/arch/debug/gdb/xtensa-defs.h
+++ b/src/arch/zephyr/include/arch/debug/gdb/xtensa-defs.h
@@ -1,0 +1,27 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2019 Intel Corporation. All rights reserved.
+ *
+ * Author: Marcin Rajwa <marcin.rajwa@linux.intel.com>
+ */
+
+/*
+ * Header file for xtensa specific defs for GDB.
+ */
+
+#ifndef XTENSA_DEFS_H
+#define XTENSA_DEFS_H
+
+#include <xtensa/specreg.h>
+#include <xtensa/config/core-isa.h>
+#include <xtensa/corebits.h>
+#include <config.h>
+
+#define _AREG0		256
+
+#define STACK_SIZE	1024
+#define DEBUG_PC	(EPC + XCHAL_DEBUGLEVEL)
+#define DEBUG_EXCSAVE	(EXCSAVE + XCHAL_DEBUGLEVEL)
+#define DEBUG_PS	(EPS + XCHAL_DEBUGLEVEL)
+
+#endif /* XTENSA_DEFS_H */

--- a/src/arch/zephyr/include/arch/debug/offset-defs.h
+++ b/src/arch/zephyr/include/arch/debug/offset-defs.h
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2019 Intel Corporation. All rights reserved.
+ */
+
+#include <xtensa/config/core-isa.h>
+
+#define REG_OFFSET_EXCCAUSE     0x0
+#define REG_OFFSET_EXCVADDR     0x4
+#define REG_OFFSET_PS           0x8
+#define REG_OFFSET_EPC1         0xc
+#define REG_OFFSET_EPC2         0x10
+#define REG_OFFSET_EPC3         0x14
+#define REG_OFFSET_EPC4         0x18
+#define REG_OFFSET_EPC5         0x1c
+#define REG_OFFSET_EPC6         0x20
+#define REG_OFFSET_EPC7         0x24
+#define REG_OFFSET_EPS2         0x28
+#define REG_OFFSET_EPS3         0x2c
+#define REG_OFFSET_EPS4         0x30
+#define REG_OFFSET_EPS5         0x34
+#define REG_OFFSET_EPS6         0x38
+#define REG_OFFSET_EPS7         0x3c
+#define REG_OFFSET_DEPC         0x40
+#define REG_OFFSET_INTENABLE    0x44
+#define REG_OFFSET_INTERRUPT    0x48
+#define REG_OFFSET_SAR          0x4c
+#define REG_OFFSET_DEBUGCAUSE   0x50
+#define REG_OFFSET_WINDOWBASE   0x54
+#define REG_OFFSET_WINDOWSTART  0x58
+#define REG_OFFSET_EXCSAVE1     0x5c
+#define REG_OFFSET_AR_BEGIN     0x60
+#define REG_OFFSET_AR_END       (REG_OFFSET_AR_BEGIN + 4 * XCHAL_NUM_AREGS)

--- a/src/arch/zephyr/include/arch/debug/panic.h
+++ b/src/arch/zephyr/include/arch/debug/panic.h
@@ -1,0 +1,62 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2019 Intel Corporation. All rights reserved.
+ *
+ * Author: Tomasz Lauda <tomasz.lauda@linux.intel.com>
+ */
+
+#ifdef __SOF_DEBUG_PANIC_H__
+
+#ifndef __ARCH_DEBUG_PANIC_H__
+#define __ARCH_DEBUG_PANIC_H__
+
+#include <sof/lib/cache.h>
+#include <ipc/trace.h>
+#include <ipc/xtensa.h>
+#include <xtensa/config/core-isa.h>
+#include <stdint.h>
+
+/* xtensa core specific oops size */
+#define ARCH_OOPS_SIZE (sizeof(struct sof_ipc_dsp_oops_xtensa) \
+			+ (XCHAL_NUM_AREGS * sizeof(uint32_t)))
+
+void arch_dump_regs_a(void *dump_buf);
+
+static inline void fill_core_dump(struct sof_ipc_dsp_oops_xtensa *oops,
+				  uintptr_t stack_ptr, uintptr_t *epc1)
+{
+	oops->arch_hdr.arch = ARCHITECTURE_ID;
+	oops->arch_hdr.totalsize = ARCH_OOPS_SIZE;
+#if XCHAL_HW_CONFIGID_RELIABLE
+	oops->plat_hdr.configidhi = XCHAL_HW_CONFIGID0;
+	oops->plat_hdr.configidlo = XCHAL_HW_CONFIGID1;
+#else
+	oops->plat_hdr.configidhi = 0;
+	oops->plat_hdr.configidlo = 0;
+#endif
+	oops->plat_hdr.numaregs = XCHAL_NUM_AREGS;
+	oops->plat_hdr.stackoffset = oops->arch_hdr.totalsize
+				     + sizeof(struct sof_ipc_panic_info);
+	oops->plat_hdr.stackptr = stack_ptr;
+
+	if (epc1)
+		oops->epc1 = *epc1;
+
+	arch_dump_regs_a((void *)&oops->exccause);
+}
+
+static inline void arch_dump_regs(void *dump_buf, uintptr_t stack_ptr,
+				  uintptr_t *epc1)
+{
+	fill_core_dump(dump_buf, stack_ptr, epc1);
+
+	dcache_writeback_region(dump_buf, ARCH_OOPS_SIZE);
+}
+
+#endif /* __ARCH_DEBUG_PANIC_H__ */
+
+#else
+
+#error "This file shouldn't be included from outside of sof/debug/panic.h"
+
+#endif /* __SOF_DEBUG_PANIC_H__ */

--- a/src/arch/zephyr/include/arch/drivers/idc.h
+++ b/src/arch/zephyr/include/arch/drivers/idc.h
@@ -1,0 +1,50 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2018 Intel Corporation. All rights reserved.
+ *
+ * Author: Tomasz Lauda <tomasz.lauda@linux.intel.com>
+ */
+
+/**
+ * \file arch/xtensa/include/arch/drivers/idc.h
+ * \brief Xtensa architecture IDC header file
+ * \authors Tomasz Lauda <tomasz.lauda@linux.intel.com>
+ */
+
+#ifdef __SOF_DRIVERS_IDC_H__
+
+#ifndef __ARCH_DRIVERS_IDC_H__
+#define __ARCH_DRIVERS_IDC_H__
+
+#include <config.h>
+#include <stdint.h>
+
+struct idc_msg;
+
+#if CONFIG_SMP
+
+void cpu_power_down_core(void);
+
+void idc_enable_interrupts(int target_core, int source_core);
+int arch_idc_send_msg(struct idc_msg *msg, uint32_t mode);
+int arch_idc_init(void);
+void idc_free(void);
+
+#else
+
+static inline int arch_idc_send_msg(struct idc_msg *msg, uint32_t mode)
+{
+	return 0;
+}
+
+static inline int arch_idc_init(void) { return 0; }
+
+#endif /* CONFIG_SMP */
+
+#endif /* __ARCH_DRIVERS_IDC_H__ */
+
+#else
+
+#error "This file shouldn't be included from outside of sof/drivers/idc.h"
+
+#endif /* __SOF_DRIVERS_IDC_H__ */

--- a/src/arch/zephyr/include/arch/drivers/interrupt.h
+++ b/src/arch/zephyr/include/arch/drivers/interrupt.h
@@ -1,0 +1,51 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2016 Intel Corporation. All rights reserved.
+ *
+ * Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
+ */
+
+#ifndef __ARCH_INTERRUPT_H
+#define __ARCH_INTERRUPT_H
+
+#include <irq.h>
+
+#include <stdint.h>
+#include <stdlib.h>
+
+static inline int arch_interrupt_register(int irq,
+	void (*handler)(void *arg), void *arg) {return 0; }
+static inline void arch_interrupt_unregister(int irq) {}
+static inline uint32_t arch_interrupt_enable_mask(uint32_t mask) {return 0; }
+static inline uint32_t arch_interrupt_disable_mask(uint32_t mask) {return 0; }
+
+static inline uint32_t arch_interrupt_get_level(void)
+{
+	uint32_t level;
+
+	__asm__ __volatile__(
+		"       rsr.ps %0\n"
+		"       extui  %0, %0, 0, 4\n"
+		: "=&a" (level) :: "memory");
+
+	return level;
+}
+
+static inline void arch_interrupt_set(int irq) {}
+static inline void arch_interrupt_clear(int irq) {}
+static inline uint32_t arch_interrupt_get_enabled(void) {return 0; }
+static inline uint32_t arch_interrupt_get_status(void) {return 0; }
+static inline int arch_interrupt_init(void) {return 0; }
+
+static inline uint32_t arch_interrupt_global_disable(void)
+{
+	return irq_lock();
+}
+
+static inline void arch_interrupt_global_enable(uint32_t flags)
+{
+	irq_unlock(flags);
+}
+
+#endif
+

--- a/src/arch/zephyr/include/arch/drivers/timer.h
+++ b/src/arch/zephyr/include/arch/drivers/timer.h
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2016 Intel Corporation. All rights reserved.
+ *
+ * Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
+ */
+
+#ifndef __ARCH_TIMER_H_
+#define __ARCH_TIMER_H_
+
+#include <kernel.h>
+
+struct timer {
+	uint32_t id;
+	uint32_t irq;
+	void *timer_data;	/* used by core */
+	uint32_t hitime;	/* high end of 64bit timer */
+	uint32_t hitimeout;
+	uint32_t lowtimeout;
+	uint64_t delta;
+};
+
+static inline int arch_timer_register(struct timer *timer,
+	void (*handler)(void *arg), void *arg) {return 0; }
+static inline void arch_timer_unregister(struct timer *timer) {}
+static inline void arch_timer_enable(struct timer *timer) {}
+static inline void arch_timer_disable(struct timer *timer) {}
+static inline uint32_t arch_timer_get_system(struct timer *timer) {return 0; }
+static inline int arch_timer_set(struct timer *timer,
+	uint64_t ticks) {return 0; }
+static inline void arch_timer_clear(struct timer *timer) {}
+
+#endif

--- a/src/arch/zephyr/include/arch/init.h
+++ b/src/arch/zephyr/include/arch/init.h
@@ -1,0 +1,124 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2016 Intel Corporation. All rights reserved.
+ *
+ * Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
+ */
+
+/**
+ * \file arch/xtensa/include/arch/init.h
+ * \brief Arch init header file
+ * \authors Liam Girdwood <liam.r.girdwood@linux.intel.com>
+ */
+
+#ifndef __ARCH_INIT_H__
+#define __ARCH_INIT_H__
+
+#include <xtensa/hal.h>
+#include <xtensa/xtruntime.h>
+#include <sof/panic.h>
+
+/**
+ * \brief Called in the case of exception.
+ */
+static inline void exception(void)
+{
+	uintptr_t epc1;
+
+	__asm__ __volatile__("rsr %0, EPC1" : "=a" (epc1) : : "memory");
+
+	/* now panic and rewind 8 stack frames. */
+	/* TODO: we could invoke a GDB stub here */
+	panic_rewind(SOF_IPC_PANIC_EXCEPTION, 8 * sizeof(uint32_t),
+		     NULL, &epc1);
+}
+
+/**
+ * \brief Registers exception handlers.
+ */
+static inline void register_exceptions(void)
+{
+
+	/* 0 - 9 */
+	_xtos_set_exception_handler(
+		EXCCAUSE_ILLEGAL, (void *)&exception);
+	_xtos_set_exception_handler(
+		EXCCAUSE_SYSCALL, (void *)&exception);
+	_xtos_set_exception_handler(
+		EXCCAUSE_INSTR_ERROR, (void *)&exception);
+	_xtos_set_exception_handler(
+		EXCCAUSE_LOAD_STORE_ERROR, (void *)&exception);
+	_xtos_set_exception_handler(
+		EXCCAUSE_ALLOCA, (void *)&exception);
+	_xtos_set_exception_handler(
+		EXCCAUSE_DIVIDE_BY_ZERO, (void *)&exception);
+	_xtos_set_exception_handler(
+		EXCCAUSE_SPECULATION, (void *)&exception);
+	_xtos_set_exception_handler(
+		EXCCAUSE_PRIVILEGED, (void *)&exception);
+	_xtos_set_exception_handler(
+		EXCCAUSE_UNALIGNED, (void *)&exception);
+
+	/* Reserved				10..11 */
+
+	_xtos_set_exception_handler(
+		EXCCAUSE_INSTR_DATA_ERROR, (void *)&exception);
+	_xtos_set_exception_handler(
+		EXCCAUSE_LOAD_STORE_DATA_ERROR, (void *)&exception);
+	_xtos_set_exception_handler(
+		EXCCAUSE_INSTR_ADDR_ERROR, (void *)&exception);
+	_xtos_set_exception_handler(
+		EXCCAUSE_LOAD_STORE_ADDR_ERROR, (void *)&exception);
+	_xtos_set_exception_handler(
+		EXCCAUSE_ITLB_MISS, (void *)&exception);
+	_xtos_set_exception_handler(
+		EXCCAUSE_ITLB_MULTIHIT, (void *)&exception);
+	_xtos_set_exception_handler(
+		EXCCAUSE_INSTR_RING, (void *)&exception);
+
+	/* Reserved				19 */
+
+	_xtos_set_exception_handler(
+		EXCCAUSE_INSTR_PROHIBITED, (void *)&exception);
+
+	/* Reserved				21..23 */
+	_xtos_set_exception_handler(
+		EXCCAUSE_DTLB_MISS, (void *)&exception);
+	_xtos_set_exception_handler(
+		EXCCAUSE_DTLB_MULTIHIT, (void *)&exception);
+	_xtos_set_exception_handler(
+		EXCCAUSE_LOAD_STORE_RING, (void *)&exception);
+
+	/* Reserved				27 */
+	_xtos_set_exception_handler(
+		EXCCAUSE_LOAD_PROHIBITED, (void *)&exception);
+	_xtos_set_exception_handler(
+		EXCCAUSE_STORE_PROHIBITED, (void *)&exception);
+
+	/* Reserved				30..31 */
+	_xtos_set_exception_handler(
+		EXCCAUSE_CP0_DISABLED, (void *)&exception);
+	_xtos_set_exception_handler(
+		EXCCAUSE_CP1_DISABLED, (void *)&exception);
+	_xtos_set_exception_handler(
+		EXCCAUSE_CP2_DISABLED, (void *)&exception);
+	_xtos_set_exception_handler(
+		EXCCAUSE_CP3_DISABLED, (void *)&exception);
+	_xtos_set_exception_handler(
+		EXCCAUSE_CP4_DISABLED, (void *)&exception);
+	_xtos_set_exception_handler(
+		EXCCAUSE_CP5_DISABLED, (void *)&exception);
+	_xtos_set_exception_handler(
+		EXCCAUSE_CP6_DISABLED, (void *)&exception);
+	_xtos_set_exception_handler(
+		EXCCAUSE_CP7_DISABLED, (void *)&exception);
+
+	/* Reserved				40..63 */
+}
+
+/**
+ * \brief Called from assembler context with no return or parameters.
+ */
+static inline void __memmap_init(void) { }
+
+#endif

--- a/src/arch/zephyr/include/arch/lib/cache.h
+++ b/src/arch/zephyr/include/arch/lib/cache.h
@@ -1,0 +1,74 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2017 Intel Corporation. All rights reserved.
+ *
+ * Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
+ */
+
+#ifndef __INCLUDE_ARCH_CACHE__
+#define __INCLUDE_ARCH_CACHE__
+
+#include <stdint.h>
+#include <stddef.h>
+#include <xtensa/config/core.h>
+#include <xtensa/hal.h>
+
+#define DCACHE_LINE_SIZE	XCHAL_DCACHE_LINESIZE
+
+static inline void dcache_writeback_region(void *addr, size_t size)
+{
+#if XCHAL_DCACHE_SIZE > 0
+	xthal_dcache_region_writeback(addr, size);
+#endif
+}
+
+static inline void dcache_writeback_all(void)
+{
+#if XCHAL_DCACHE_SIZE > 0
+	xthal_dcache_all_writeback();
+#endif
+}
+
+static inline void dcache_invalidate_region(void *addr, size_t size)
+{
+#if XCHAL_DCACHE_SIZE > 0
+	xthal_dcache_region_invalidate(addr, size);
+#endif
+}
+
+static inline void dcache_invalidate_all(void)
+{
+#if XCHAL_DCACHE_SIZE > 0
+	xthal_dcache_all_invalidate();
+#endif
+}
+
+static inline void icache_invalidate_region(void *addr, size_t size)
+{
+#if XCHAL_ICACHE_SIZE > 0
+	xthal_icache_region_invalidate(addr, size);
+#endif
+}
+
+static inline void icache_invalidate_all(void)
+{
+#if XCHAL_ICACHE_SIZE > 0
+	xthal_icache_all_invalidate();
+#endif
+}
+
+static inline void dcache_writeback_invalidate_region(void *addr, size_t size)
+{
+#if XCHAL_DCACHE_SIZE > 0
+	xthal_dcache_region_writeback_inv(addr, size);
+#endif
+}
+
+static inline void dcache_writeback_invalidate_all(void)
+{
+#if XCHAL_DCACHE_SIZE > 0
+	xthal_dcache_all_writeback_inv();
+#endif
+}
+
+#endif

--- a/src/arch/zephyr/include/arch/lib/cpu.h
+++ b/src/arch/zephyr/include/arch/lib/cpu.h
@@ -1,0 +1,52 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2018 Intel Corporation. All rights reserved.
+ *
+ * Author: Rander Wang <rander.wang@linux.intel.com>
+ */
+
+#ifndef __INCLUDE_ARCH_CPU__
+#define __INCLUDE_ARCH_CPU__
+
+#include <xtensa/config/core.h>
+
+void arch_cpu_enable_core(int id);
+
+void arch_cpu_disable_core(int id);
+
+int arch_cpu_is_core_enabled(int id);
+
+static inline int arch_cpu_get_id(void)
+{
+	int prid;
+#if XCHAL_HAVE_PRID
+	__asm__("rsr.prid %0" : "=a"(prid));
+#else
+	prid = PLATFORM_MASTER_CORE_ID;
+#endif
+	return prid;
+}
+
+static inline void cpu_write_threadptr(int threadptr)
+{
+#if XCHAL_HAVE_THREADPTR
+	__asm__ __volatile__(
+		"wur.threadptr %0" : : "a" (threadptr) : "memory");
+#else
+#error "Core support for XCHAL_HAVE_THREADPTR is required"
+#endif
+}
+
+static inline int cpu_read_threadptr(void)
+{
+	int threadptr;
+#if XCHAL_HAVE_THREADPTR
+	__asm__ __volatile__(
+		"rur.threadptr %0" : "=a"(threadptr));
+#else
+#error "Core support for XCHAL_HAVE_THREADPTR is required"
+#endif
+	return threadptr;
+}
+
+#endif

--- a/src/arch/zephyr/include/arch/lib/wait.h
+++ b/src/arch/zephyr/include/arch/lib/wait.h
@@ -1,0 +1,61 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2017 Intel Corporation. All rights reserved.
+ *
+ * Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
+ */
+
+#ifndef __ARCH_WAIT_H_
+#define __ARCH_WAIT_H_
+
+#include <xtensa/xtruntime.h>
+#include <arch/interrupt.h>
+#include <sof/panic.h>
+
+#include <ipc/trace.h>
+
+#if defined(PLATFORM_WAITI_DELAY)
+
+static inline void arch_wait_for_interrupt(int level)
+{
+	int i;
+
+	/* can only enter WFI when at run level 0 i.e. not IRQ level */
+	if (arch_interrupt_get_level() > 0)
+		panic(SOF_IPC_PANIC_WFI);
+
+	/* this sequence must be atomic on LX6 */
+	XTOS_SET_INTLEVEL(5);
+
+	/* LX6 needs a delay */
+	for (i = 0; i < 128; i++)
+		__asm__ volatile("nop");
+
+	/* and to flush all loads/stores prior to wait */
+	__asm__ volatile("isync");
+	__asm__ volatile("extw");
+
+	/* now wait */
+	__asm__ volatile("waiti 0");
+}
+
+#else
+
+static inline void arch_wait_for_interrupt(int level)
+{
+	/* can only enter WFI when at run level 0 i.e. not IRQ level */
+	if (arch_interrupt_get_level() > 0)
+		panic(SOF_IPC_PANIC_WFI);
+
+	__asm__ volatile("waiti 0");
+}
+
+#endif
+
+static inline void idelay(int n)
+{
+	while (n--)
+		__asm__ volatile("nop");
+}
+
+#endif

--- a/src/arch/zephyr/include/arch/schedule/task.h
+++ b/src/arch/zephyr/include/arch/schedule/task.h
@@ -1,0 +1,69 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2017 Intel Corporation. All rights reserved.
+ *
+ * Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
+ */
+
+/**
+ * \file arch/xtensa/include/arch/task.h
+ * \brief Arch task header file
+ * \authors Liam Girdwood <liam.r.girdwood@linux.intel.com>
+ */
+
+#ifndef __ARCH_TASK_H_
+#define __ARCH_TASK_H_
+
+#include <sof/list.h>
+
+#include <arch/spinlock.h>
+
+/** \brief IRQ task data. */
+struct irq_task {
+	spinlock_t lock;	/**< lock */
+	struct list_item list;	/**< list of tasks */
+	uint32_t irq;		/**< IRQ level */
+};
+
+struct task;
+
+/**
+ * \brief Returns IRQ low task data.
+ * \return Pointer to pointer of IRQ low task data.
+ */
+struct irq_task **task_irq_low_get(void);
+
+/**
+ * \brief Returns IRQ medium task data.
+ * \return Pointer to pointer of IRQ medium task data.
+ */
+struct irq_task **task_irq_med_get(void);
+
+/**
+ * \brief Returns IRQ high task data.
+ * \return Pointer to pointer of IRQ high task data.
+ */
+struct irq_task **task_irq_high_get(void);
+
+/**
+ * \brief Runs task.
+ * \param[in,out] task Task data.
+ */
+int arch_run_task(struct task *task);
+
+/**
+ * \brief Allocates IRQ tasks.
+ */
+int arch_allocate_tasks(void);
+
+/**
+ * \brief Frees IRQ tasks.
+ */
+void arch_free_tasks(void);
+
+/**
+ * \brief Assigns IRQ tasks to interrupts.
+ */
+int arch_assign_tasks(void);
+
+#endif

--- a/src/arch/zephyr/include/arch/sof.h
+++ b/src/arch/zephyr/include/arch/sof.h
@@ -1,0 +1,77 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2016 Intel Corporation. All rights reserved.
+ *
+ * Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
+ *         Janusz Jankowski <janusz.jankowski@linux.intel.com>
+ */
+
+#ifndef __INCLUDE_ARCH_SOF__
+#define __INCLUDE_ARCH_SOF__
+
+#include <stdint.h>
+#include <stddef.h>
+#include <sof/mailbox.h>
+#include <ipc/xtensa.h>
+#include <arch/offset-defs.h>
+
+/* architecture specific stack frames to dump */
+#define ARCH_STACK_DUMP_FRAMES		32
+
+/* xtensa core specific oops size */
+#define ARCH_OOPS_SIZE (sizeof(struct sof_ipc_dsp_oops_xtensa) \
+			+ (XCHAL_NUM_AREGS * sizeof(uint32_t)))
+
+/* entry point to main firmware */
+void _ResetVector(void);
+
+void boot_master_core(void);
+
+void arch_dump_regs_a(void *dump_buf, uint32_t ps);
+
+static inline void *arch_get_stack_ptr(void)
+{
+	void *ptr;
+
+	/* stack pointer is in a1 */
+	__asm__ __volatile__ ("mov %0, a1"
+		: "=a" (ptr)
+		:
+		: "memory");
+	return ptr;
+}
+
+static inline void fill_core_dump(struct sof_ipc_dsp_oops_xtensa *oops,
+				  uint32_t ps, uintptr_t stack_ptr,
+				  uintptr_t *epc1)
+{
+	oops->arch_hdr.arch = ARCHITECTURE_ID;
+	oops->arch_hdr.totalsize = ARCH_OOPS_SIZE;
+#if XCHAL_HW_CONFIGID_RELIABLE
+	oops->plat_hdr.configidhi = XCHAL_HW_CONFIGID0;
+	oops->plat_hdr.configidlo = XCHAL_HW_CONFIGID1;
+#else
+	oops->plat_hdr.configidhi = 0;
+	oops->plat_hdr.configidlo = 0;
+#endif
+	oops->plat_hdr.numaregs = XCHAL_NUM_AREGS;
+	oops->plat_hdr.stackoffset = oops->arch_hdr.totalsize
+				     + sizeof(struct sof_ipc_panic_info);
+	oops->plat_hdr.stackptr = stack_ptr;
+
+	oops->epc1 = *epc1;
+
+	arch_dump_regs_a((void *)&oops->exccause, ps);
+}
+
+static inline void arch_dump_regs(uint32_t ps, uintptr_t stack_ptr,
+				  uintptr_t *epc1)
+{
+	void *buf = (void *)mailbox_get_exception_base();
+
+	fill_core_dump(buf, ps, stack_ptr, epc1);
+
+	dcache_writeback_region(buf, ARCH_OOPS_SIZE);
+}
+
+#endif

--- a/src/arch/zephyr/include/arch/spinlock.h
+++ b/src/arch/zephyr/include/arch/spinlock.h
@@ -1,0 +1,71 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2016 Intel Corporation. All rights reserved.
+ *
+ * Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
+ */
+
+#ifndef __ARCH_SPINLOCK_H_
+#define __ARCH_SPINLOCK_H_
+
+#include <stdint.h>
+#include <errno.h>
+
+typedef struct {
+	volatile uint32_t lock;
+#if DEBUG_LOCKS
+	uint32_t user;
+#endif
+} spinlock_t;
+
+static inline void arch_spinlock_init(spinlock_t *lock)
+{
+	lock->lock = 0;
+}
+
+static inline void arch_spin_lock(spinlock_t *lock)
+{
+	uint32_t result, current;
+
+	__asm__ __volatile__(
+		"1:     l32i    %1, %2, 0\n"
+		"       wsr     %1, scompare1\n"
+		"       movi    %0, 1\n"
+		"       s32c1i  %0, %2, 0\n"
+		"       bne     %0, %1, 1b\n"
+		: "=&a" (result), "=&a" (current)
+		: "a" (&lock->lock)
+		: "memory");
+}
+
+static inline int arch_try_lock(spinlock_t *lock)
+{
+	uint32_t result, current;
+
+	__asm__ __volatile__(
+		"       l32i    %1, %2, 0\n"
+		"       wsr     %1, scompare1\n"
+		"       movi    %0, 1\n"
+		"       s32c1i  %0, %2, 0\n"
+		: "=&a" (result), "=&a" (current)
+		: "a" (&lock->lock)
+		: "memory");
+
+	if (result)
+		return 0; /* lock failed */
+	return 1; /* lock acquired */
+}
+
+static inline void arch_spin_unlock(spinlock_t *lock)
+{
+	uint32_t result;
+
+	__asm__ __volatile__(
+		"       movi    %0, 0\n"
+		"       s32ri   %0, %1, 0\n"
+		: "=&a" (result)
+		: "a" (&lock->lock)
+		: "memory");
+}
+
+#endif

--- a/src/arch/zephyr/include/arch/string.h
+++ b/src/arch/zephyr/include/arch/string.h
@@ -1,0 +1,82 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2018 Intel Corporation. All rights reserved.
+ *
+ * Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
+ */
+
+#ifndef __INCLUDE_ARCH_STRING_SOF__
+#define __INCLUDE_ARCH_STRING_SOF__
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define arch_memcpy(dest, src, size) \
+	xthal_memcpy(dest, src, size)
+
+#if __XCC__ && !defined(UNIT_TEST)
+#define arch_bzero(ptr, size)	\
+	memset_s(ptr, size, 0, size)
+#else
+#define arch_bzero(ptr, size)	\
+	memset(ptr, 0, size)
+#endif
+
+void *memcpy(void *dest, const void *src, size_t length);
+void *memset(void *dest, int data, size_t count);
+void *xthal_memcpy(void *dst, const void *src, size_t len);
+
+int memset_s(void *dest, size_t dest_size,
+	     int data, size_t count);
+int memcpy_s(void *dest, size_t dest_size,
+	     const void *src, size_t src_size);
+
+#if __XCC__ && !CONFIG_LIBRARY
+void *__vec_memcpy(void *dst, const void *src, size_t len);
+void *__vec_memset(void *dest, int data, size_t src_size);
+#endif
+
+static inline int arch_memcpy_s(void *dest, size_t dest_size,
+				const void *src, size_t src_size)
+{
+	if (!dest || !src)
+		return -EINVAL;
+
+	if (((char *)dest + dest_size >= (char *)src &&
+	     (char *)dest + dest_size <= (char *)src + src_size) ||
+		((char *)src + src_size >= (char *)dest &&
+		 (char *)src + src_size <= (char *)dest + dest_size))
+		return -EINVAL;
+
+	if (src_size > dest_size)
+		return -EINVAL;
+
+#if __XCC__ && !CONFIG_LIBRARY
+	__vec_memcpy(dest, src, src_size);
+#else
+	memcpy(dest, src, src_size);
+#endif
+
+	return 0;
+}
+
+static inline int arch_memset_s(void *dest, size_t dest_size,
+				int data, size_t count)
+{
+	if (!dest)
+		return -EINVAL;
+
+	if (count > dest_size)
+		return -EINVAL;
+
+#if __XCC__ && !CONFIG_LIBRARY
+	if (!__vec_memset(dest, data, count))
+		return -ENOMEM;
+#else
+	memset(dest, data, count);
+#endif
+	return 0;
+}
+
+#endif

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -1,0 +1,113 @@
+if(CONFIG_SOF)
+zephyr_interface_library_named(SOF)
+
+# Includes needed by headers under SoC's include/platform
+zephyr_include_directories(../src/platform/intel/cavs/include)
+
+# include redefines incompatible things on src/include
+target_include_directories(SOF INTERFACE
+	include
+	#../src/arch/host/include
+	../src/platform/intel/cavs/include
+	../src/include)
+
+if(CONFIG_SMP)
+target_include_directories(SOF INTERFACE ../src/arch/xtensa/smp/include)
+else()
+target_include_directories(SOF INTERFACE ../src/arch/xtensa/up/include)
+endif()
+
+zephyr_library()
+zephyr_library_compile_definitions(CONFIG_LIBRARY=1)
+zephyr_library_sources(
+	# Dummy version, might move these to Zephyr
+	alloc.c
+	dma-trace.c
+	ll_schedule.c
+	edf_schedule.c
+	schedule.c
+	panic.c
+	pm.c
+	ipc.c
+	interrupt.c
+	# Modified drivers from SOF
+	drivers/intel/cavs/interrupt.c
+	# SOF src/audio
+	../src/audio/host.c
+	../src/audio/pipeline.c
+	#../src/audio/pipeline_static.c
+	../src/audio/component.c
+	../src/audio/buffer.c
+	../src/audio/dai.c
+	# SOF src/ipc
+	../src/ipc/ipc.c
+	../src/ipc/handler.c
+	# SOF src/lib
+	../src/lib/lib.c
+	../src/lib/dai.c
+	../src/lib/dma.c
+	#../src/lib/alloc.c
+	#../src/lib/ll_schedule.c
+	#../src/lib/notifier.c
+	#../src/lib/edf_schedule.c
+	#../src/lib/schedule.c
+	#../src/lib/agent.c
+	#../src/lib/interrupt.c
+	#../src/lib/pm_runtime.c
+	../src/lib/clk.c
+	#../src/lib/dma.c
+	#../src/lib/dai.c
+	#../src/lib/panic.c
+	#../src/lib/wait.c
+	# SOF src/math
+	../src/math/numbers.c
+	../src/math/trig.c
+	# SOF src/drivers
+	../src/drivers/dw/dma.c
+	../src/drivers/intel/cavs/hda.c
+	../src/drivers/intel/cavs/hda-dma.c
+	../src/drivers/intel/cavs/ssp.c
+	# Platform code
+	#../src/platform/intel/cavs/pm_runtime.c
+	../src/drivers/intel/cavs/timer.c
+	# SOF CAVS platform code
+	../src/platform/intel/cavs/dai.c
+	../src/platform/intel/cavs/dma.c
+)
+
+zephyr_library_sources_ifdef(CONFIG_SOF_STATIC_PIPELINE pipeline_static.c)
+zephyr_library_sources_ifdef(CONFIG_SOF_COMP_DAI ../src/audio/dai.c)
+zephyr_library_sources_ifdef(CONFIG_SOF_COMP_TONE ../src/audio/tone.c)
+zephyr_library_sources_ifdef(CONFIG_SOF_COMP_MIXER ../src/audio/mixer.c)
+zephyr_library_sources_ifdef(CONFIG_SOF_COMP_MUX ../src/audio/mux/mux.c ../src/audio/mux/mux_generic.c)
+zephyr_library_sources_ifdef(CONFIG_SOF_COMP_SWITCH ../src/audio/switch.c)
+#zephyr_library_sources_ifdef(CONFIG_SOF_COMP_KPB ../src/audio/kpb.c)
+zephyr_library_sources_ifdef(CONFIG_SOF_COMP_TEST_KEYPHRASE
+	../src/audio/detect_test.c)
+zephyr_library_sources_ifdef(CONFIG_SOF_COMP_VOLUME
+	../src/audio/volume/volume_generic.c
+	../src/audio/volume/volume_hifi3.c
+	../src/audio/volume/volume.c)
+zephyr_library_sources_ifdef(CONFIG_SOF_COMP_SRC
+	../src/audio/src/src_generic.c
+	../src/audio/src/src_hifi2ep.c
+	../src/audio/src/src_hifi3.c
+	../src/audio/src/src.c)
+zephyr_library_sources_ifdef(CONFIG_SOF_COMP_FIR
+	../src/audio/eq_fir/eq_fir.c
+	../src/audio/eq_fir/fir_hifi2ep.c
+	../src/audio/eq_fir/fir_hifi3.c
+	../src/audio/eq_fir/fir.c)
+zephyr_library_sources_ifdef(CONFIG_SOF_COMP_IIR
+	../src/audio/eq_iir/eq_iir.c
+	../src/audio/eq_iir/iir.c)
+zephyr_library_sources_ifdef(CONFIG_SOF_COMP_SEL
+	../src/audio/selector/selector_generic.c
+	../src/audio/selector/selector.c)
+zephyr_library_sources_ifdef(CONFIG_SOF_USE_DMIC
+	../src/drivers/intel/cavs/dmic.c
+	)
+
+zephyr_library_link_libraries(SOF)
+target_link_libraries(SOF INTERFACE zephyr_interface)
+endif()

--- a/zephyr/README.md
+++ b/zephyr/README.md
@@ -4,6 +4,12 @@
 
 Zephyr folder contains a west [module](https://docs.zephyrproject.org/latest/guides/modules.html)
 
+### Sources in 'zephyr/sof-wrapper'
+
+This directory contains wrapped implementations of generic SOF OS services,
+implementing the public SOF interface, but using Zephyr OS for 
+the implementation.
+
 ### Porting
 
 At current stage this effort is not trying to reconsile APIs from Zephyr with

--- a/zephyr/README.md
+++ b/zephyr/README.md
@@ -1,0 +1,25 @@
+# SOF on top of Zephyr
+
+### West
+
+Zephyr folder contains a west [module](https://docs.zephyrproject.org/latest/guides/modules.html)
+
+### Porting
+
+At current stage this effort is not trying to reconsile APIs from Zephyr with
+SOF, although that may be possible that would require reworking a few key
+areas, here is a few points that are not straight forward:
+
+1. Board + device tree vs platform header: Zephyr makes use of board
+   definitions plus device trees to describe the memory areas, buses,
+   peripherals, etc, while SOF has a platform header which serves for the same
+   purpose.
+
+2. Static vs dynamic allocation: Zephyr is tuned to have static allocation to
+   minimize the RAM usage as much as possible, SOF in the other hand takes a
+   more traditional approach so most of its APIs end up allocating objects
+   dynamically.
+
+3. Indirect vs direct waiters: SOF has dedicated APIs to wait for conditions,
+   events, while Zephyr embed this sort of mechanism into its APIs so calls to
+   them can make a thread wait for some condition.

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,0 +1,2 @@
+build:
+  cmake: zephyr/

--- a/zephyr/sof-wrappers/alloc.c
+++ b/zephyr/sof-wrappers/alloc.c
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2018 Intel Corporation. All rights reserved.
+//
+// Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+//         Liam Girdwood <liam.r.girdwood@linux.intel.com>
+//         Keyon Jie <yang.jie@linux.intel.com>
+//         Ranjani Sridharan <ranjani.sridharan@linux.intel.com>
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <sys/util.h>
+
+#include <sof/alloc.h>
+#include <kernel.h>
+
+/* Describe one mem_slab */
+struct memslab_map {
+	uint16_t block_size;    /* size of block in bytes */
+	uint16_t count;         /* number of blocks */
+	uint32_t size;          /* size of buffer */
+	struct k_mem_slab slab;
+	void* buffer;           /* pointer to buffer */
+} __aligned(PLATFORM_DCACHE_ALIGN);
+
+#define MEMSLAB_DEF(sz, cnt, buf) \
+	{ .block_size = sz, .count = cnt, .buffer = buf, \
+	  .size = (sz * cnt), \
+	}
+
+#define BUF_ALIGN	__aligned(WB_UP(PLATFORM_DCACHE_ALIGN))
+
+
+/*
+ * RZONE_BUFFER for DMA
+ */
+static struct k_mem_slab hp_dma_buffer;
+static struct memslab_map hp_dma_buffer_map =
+	MEMSLAB_DEF(HEAP_HP_BUFFER_BLOCK_SIZE, HEAP_HP_BUFFER_COUNT,
+		    (void *)HEAP_HP_BUFFER_BASE);
+
+/*
+ * RZONE_BUFFER for non-DMA
+ *
+ * TODO: figure out a good block size.
+ */
+#define _HEAP_BUFFER_BLOCK_SIZE		1024
+#define _HEAP_BUFFER_COUNT		32
+#define _HEAP_BUFFER_SIZE \
+	(_HEAP_BUFFER_COUNT * _HEAP_BUFFER_BLOCK_SIZE)
+
+static struct k_mem_slab heap_buffer;
+static BUF_ALIGN uint8_t _heap_buf[_HEAP_BUFFER_SIZE];
+static struct memslab_map heap_buffer_map =
+	MEMSLAB_DEF(_HEAP_BUFFER_BLOCK_SIZE,
+		    _HEAP_BUFFER_COUNT,
+		    _heap_buf);
+
+
+void malloc_init(void)
+{
+	/* Initialize RZONE_BUFFER */
+	k_mem_slab_init(&hp_dma_buffer, (void *)HEAP_HP_BUFFER_BASE,
+			HEAP_HP_BUFFER_BLOCK_SIZE, HEAP_HP_BUFFER_COUNT);
+
+	k_mem_slab_init(&heap_buffer, _heap_buf,
+			_HEAP_BUFFER_BLOCK_SIZE, _HEAP_BUFFER_COUNT);
+}
+
+
+void *rmalloc(uint32_t zone, uint32_t caps, size_t bytes)
+{
+	return k_malloc(bytes);
+}
+
+void *rzalloc(uint32_t zone, uint32_t caps, size_t bytes)
+{
+	return k_calloc(bytes, 1);
+}
+
+void *rballoc(uint32_t zone, uint32_t caps, size_t bytes)
+{
+	void *ptr = NULL;
+
+	if (caps & SOF_MEM_CAPS_DMA) {
+		k_mem_slab_alloc(&heap_buffer, &ptr, K_NO_WAIT);
+	} else {
+		k_mem_slab_alloc(&hp_dma_buffer, &ptr, K_NO_WAIT);
+	}
+
+	return ptr;
+}
+
+static bool free_in_slab(struct memslab_map *map, void *ptr)
+{
+	uintptr_t begin = (uintptr_t)map->buffer;
+	uintptr_t end = begin + map->size;
+	uintptr_t addr = (uintptr_t)ptr;
+
+	if ((addr >= begin) && (addr < end)) {
+		k_mem_slab_free(&map->slab, &ptr);
+		return true;
+	}
+
+	return false;
+}
+
+void rfree(void *ptr)
+{
+	/* RZONE_BUFFER */
+	if (free_in_slab(&hp_dma_buffer_map, ptr)) {
+		return;
+	}
+
+	if (free_in_slab(&heap_buffer_map, ptr)) {
+		return;
+	}
+
+	/* Not in mem_slab, so assume k_mem_pool */
+	k_free(ptr);
+}

--- a/zephyr/sof-wrappers/edf_schedule.c
+++ b/zephyr/sof-wrappers/edf_schedule.c
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2019 Intel Corporation. All rights reserved.
+//
+// Author: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>
+
+#include <sof/audio/component.h>
+#include <sof/task.h>
+#include <stdint.h>
+#include <sof/edf_schedule.h>
+#include <sof/wait.h>
+
+#include <kernel.h>
+
+struct k_work_q edf_workq;
+K_THREAD_STACK_DEFINE(edf_workq_stack, 8192);
+
+static void edf_work_handler(struct k_work *work)
+{
+	struct task *task = CONTAINER_OF(work, struct task, z_delayed_work);
+
+	task->state = SOF_TASK_STATE_RUNNING;
+
+	if (task->func)
+		task->func(task->data);
+
+	task->state = SOF_TASK_STATE_COMPLETED;
+}
+
+/* schedule task */
+static void schedule_edf_task(struct task *task, uint64_t start,
+			      uint64_t deadline, uint32_t flags)
+{
+	k_delayed_work_submit_to_queue_us(&edf_workq,
+					  &task->z_delayed_work,
+					  start);
+
+	task->state = SOF_TASK_STATE_QUEUED;
+}
+
+static int schedule_edf_task_init(struct task *task, uint32_t xflags)
+{
+	k_delayed_work_init(&task->z_delayed_work, edf_work_handler);
+
+	return 0;
+}
+
+/* initialize scheduler */
+static int edf_scheduler_init(void)
+{
+	trace_edf_sch("edf_scheduler_init()");
+
+	k_work_q_start(&edf_workq,
+		       edf_workq_stack,
+		       K_THREAD_STACK_SIZEOF(edf_workq_stack),
+		       -1);
+	k_thread_name_set(&edf_workq.thread, "edf_workq");
+
+	return 0;
+}
+
+static int schedule_edf_task_cancel(struct task *task)
+{
+	int ret = 0;
+
+	if (task->state == SOF_TASK_STATE_QUEUED) {
+		ret = k_delayed_work_cancel(&task->z_delayed_work);
+
+		/* delete task */
+		task->state = SOF_TASK_STATE_CANCEL;
+	}
+
+	return ret;
+}
+
+static void schedule_edf_task_free(struct task *task)
+{
+	task->state = SOF_TASK_STATE_FREE;
+	task->func = NULL;
+	task->data = NULL;
+}
+
+struct scheduler_ops schedule_edf_ops = {
+	.schedule_task		= schedule_edf_task,
+	.schedule_task_init	= schedule_edf_task_init,
+	.schedule_task_running	= NULL,
+	.schedule_task_complete = NULL,
+	.reschedule_task	= NULL,
+	.schedule_task_cancel	= schedule_edf_task_cancel,
+	.schedule_task_free	= schedule_edf_task_free,
+	.scheduler_init		= edf_scheduler_init,
+	.scheduler_free		= NULL,
+	.scheduler_run		= NULL,
+};

--- a/zephyr/sof-wrappers/interrupt.c
+++ b/zephyr/sof-wrappers/interrupt.c
@@ -1,0 +1,49 @@
+#include <device.h>
+
+#include <sof/interrupt.h>
+#include <sof/interrupt-map.h>
+
+static uint32_t to_zephyr_irq(uint32_t sof_irq) {
+	return SOC_AGGREGATE_IRQ(SOF_IRQ_BIT(sof_irq),
+				 SOF_IRQ_NUMBER(sof_irq));
+}
+
+int interrupt_register(uint32_t irq, int unmask, void (*handler)(void *arg),
+		       void *arg)
+{
+	uint32_t zephyr_irq = to_zephyr_irq(irq);
+	int ret;
+
+	ret = irq_connect_dynamic(zephyr_irq, 0, handler, arg, 0);
+
+	if ((ret == 0) && (IRQ_AUTO_UNMASK == unmask)) {
+		irq_enable(zephyr_irq);
+	}
+
+	return ret;
+}
+
+void interrupt_unregister(uint32_t irq)
+{
+	uint32_t zephyr_irq = to_zephyr_irq(irq);
+
+	/*
+	 * There is no "unregister" (or "disconnect") for
+	 * interrupts in Zephyr. So just disable it.
+	 */
+	irq_disable(zephyr_irq);
+}
+
+uint32_t interrupt_enable(uint32_t irq)
+{
+	irq_enable(to_zephyr_irq(irq));
+
+	return 0;
+}
+
+uint32_t interrupt_disable(uint32_t irq)
+{
+	irq_disable(to_zephyr_irq(irq));
+
+	return 0;
+}

--- a/zephyr/sof-wrappers/ll_schedule.c
+++ b/zephyr/sof-wrappers/ll_schedule.c
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2019 Intel Corporation. All rights reserved.
+//
+// Author: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>
+
+#include <sof/audio/component.h>
+#include <sof/task.h>
+#include <stdint.h>
+#include <sof/ll_schedule.h>
+#include <sof/wait.h>
+
+#include <kernel.h>
+
+struct k_work_q ll_workq;
+K_THREAD_STACK_DEFINE(ll_workq_stack, 8192);
+
+static void ll_work_handler(struct k_work *work)
+{
+	struct task *task = CONTAINER_OF(work, struct task, z_delayed_work);
+
+	task->state = SOF_TASK_STATE_RUNNING;
+
+	if (task->func)
+		task->func(task->data);
+
+	task->state = SOF_TASK_STATE_COMPLETED;
+}
+
+/* schedule task */
+static void schedule_ll_task(struct task *task, uint64_t start,
+			      uint64_t deadline, uint32_t flags)
+{
+	k_delayed_work_submit_to_queue_us(&ll_workq,
+					  &task->z_delayed_work,
+					  start);
+
+	task->state = SOF_TASK_STATE_QUEUED;
+}
+
+static int schedule_ll_task_init(struct task *task, uint32_t xflags)
+{
+	k_delayed_work_init(&task->z_delayed_work, ll_work_handler);
+
+	return 0;
+}
+
+/* initialize scheduler */
+static int ll_scheduler_init(void)
+{
+	trace_ll("ll_scheduler_init()");
+
+	k_work_q_start(&ll_workq,
+		       ll_workq_stack,
+		       K_THREAD_STACK_SIZEOF(ll_workq_stack),
+		       -1);
+	k_thread_name_set(&ll_workq.thread, "ll_workq");
+
+	return 0;
+}
+
+static int schedule_ll_task_cancel(struct task *task)
+{
+	int ret = 0;
+
+	if (task->state == SOF_TASK_STATE_QUEUED) {
+		ret = k_delayed_work_cancel(&task->z_delayed_work);
+
+		/* delete task */
+		task->state = SOF_TASK_STATE_CANCEL;
+	}
+
+	return ret;
+}
+
+static void schedule_ll_task_free(struct task *task)
+{
+	task->state = SOF_TASK_STATE_FREE;
+	task->func = NULL;
+	task->data = NULL;
+}
+
+struct scheduler_ops schedule_ll_ops = {
+	.schedule_task		= schedule_ll_task,
+	.schedule_task_init	= schedule_ll_task_init,
+	.schedule_task_running	= NULL,
+	.schedule_task_complete = NULL,
+	.reschedule_task	= NULL,
+	.schedule_task_cancel	= schedule_ll_task_cancel,
+	.schedule_task_free	= schedule_ll_task_free,
+	.scheduler_init		= ll_scheduler_init,
+	.scheduler_free		= NULL,
+	.scheduler_run		= NULL,
+};

--- a/zephyr/sof-wrappers/schedule.c
+++ b/zephyr/sof-wrappers/schedule.c
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2019 Intel Corporation. All rights reserved.
+//
+// Author: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>
+
+/* Generic scheduler */
+#include <sof/schedule.h>
+#include <sof/edf_schedule.h>
+#include <sof/ll_schedule.h>
+
+static const struct scheduler_ops *schedulers[SOF_SCHEDULE_COUNT] = {
+	&schedule_edf_ops,              /* SOF_SCHEDULE_EDF */
+	&schedule_ll_ops		/* SOF_SCHEDULE_LL */
+};
+
+int schedule_task_init(struct task *task, uint16_t type, uint16_t priority,
+		       uint64_t (*func)(void *data), void *data, uint16_t core,
+		       uint32_t xflags)
+{
+	int ret = 0;
+
+	if (type >= SOF_SCHEDULE_COUNT) {
+		trace_schedule_error("schedule_task_init() error: "
+				     "invalid task type");
+		ret = -EINVAL;
+		goto out;
+	}
+
+	task->type = type;
+	task->priority = priority;
+	task->core = core;
+	task->state = SOF_TASK_STATE_INIT;
+	task->func = func;
+	task->data = data;
+	task->ops = schedulers[task->type];
+
+	if (task->ops->schedule_task_init)
+		ret = task->ops->schedule_task_init(task, xflags);
+out:
+	return ret;
+}
+
+void schedule_task_free(struct task *task)
+{
+	if (task->ops->schedule_task_free)
+		task->ops->schedule_task_free(task);
+}
+
+void schedule_task(struct task *task, uint64_t start, uint64_t deadline,
+		   uint32_t flags)
+{
+	if (task->ops->schedule_task)
+		task->ops->schedule_task(task, start, deadline, flags);
+}
+
+void reschedule_task(struct task *task, uint64_t start)
+{
+	if (task->ops->reschedule_task)
+		task->ops->reschedule_task(task, start);
+}
+
+int schedule_task_cancel(struct task *task)
+{
+	if (task->ops->schedule_task_cancel)
+		return task->ops->schedule_task_cancel(task);
+	return 0;
+}
+
+void schedule_task_running(struct task *task)
+{
+	if (task->ops->schedule_task_running)
+		task->ops->schedule_task_running(task);
+}
+
+void schedule_task_complete(struct task *task)
+{
+	if (task->ops->schedule_task_complete)
+		task->ops->schedule_task_complete(task);
+}
+
+int scheduler_init(void)
+{
+	int i = 0;
+	int ret = 0;
+
+	for (i = 0; i < SOF_SCHEDULE_COUNT; i++) {
+		if (schedulers[i]->scheduler_init) {
+			ret = schedulers[i]->scheduler_init();
+			if (ret < 0)
+				goto out;
+		}
+	}
+out:
+	return ret;
+}
+
+void schedule_free(void)
+{
+	int i;
+
+	for (i = 0; i < SOF_SCHEDULE_COUNT; i++) {
+		if (schedulers[i]->scheduler_free)
+			schedulers[i]->scheduler_free();
+	}
+}
+
+void schedule(void)
+{
+	int i = 0;
+
+	for (i = 0; i < SOF_SCHEDULE_COUNT; i++) {
+		if (schedulers[i]->scheduler_run)
+			schedulers[i]->scheduler_run();
+	}
+}


### PR DESCRIPTION
A patchset to discuss architectural options in how to integrate alternative RTOS support into SOF. 

Patch uses Zephyr PoC content as example, but the result is not a buildable patchset at this point. Once high-level view is agreed, a buildable patchset will be worked on.

This proposal takes the idea of spllit alt-RTOS support into three main parts:

1)	new architecture with headers+impl
2)	sof-wrapper implementation of OS services
3)	build integration (in this case zephyr/ subfolder defining RTOS build rules as a West module)

