### PR TITLE
dw-dma: reload lli in irq_callback

### DIFF
--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -769,6 +769,14 @@ static inline void dw_dma_chan_reload_lli(struct dma_chan_data *channel)
 		return;
 	}
 
+	/* channel not active */
+	if (channel->status != COMP_STATE_ACTIVE)
+		return;
+
+	/* channel still transferring previous lli */
+	if (dma_reg_read(dma, DW_DMA_CHAN_EN) & DW_CHAN(channel->index))
+		return;
+
 	/* get current and next block pointers */
 	lli = (struct dw_lli *)lli->llp;
 	dw_chan->lli_current = lli;
@@ -814,8 +822,7 @@ static void dw_dma_verify_transfer(struct dma_chan_data *channel,
 	}
 #else
 	/* check for reload channel:
-	 * next->status is DMA_CB_STATUS_END, stop this dma copy;
-	 * otherwise, reload lli
+	 * next->status is DMA_CB_STATUS_END, stop this dma copy.
 	 */
 	switch (next->status) {
 	case DMA_CB_STATUS_END:
@@ -824,7 +831,6 @@ static void dw_dma_verify_transfer(struct dma_chan_data *channel,
 			(struct dw_lli *)dw_chan->lli_current->llp;
 		break;
 	default:
-		dw_dma_chan_reload_lli(channel);
 		break;
 	}
 #endif
@@ -953,6 +959,9 @@ static int dw_dma_probe(struct dma *dma)
 		chan->dma = dma;
 		chan->index = i;
 		chan->core = DMA_CORE_INVALID;
+#if !CONFIG_HW_LLI
+		chan->irq_callback = dw_dma_chan_reload_lli;
+#endif
 
 		dw_chan = rzalloc(RZONE_SYS_RUNTIME | RZONE_FLAG_UNCACHED,
 				  SOF_MEM_CAPS_RAM, sizeof(*dw_chan));
@@ -1003,11 +1012,7 @@ static int dw_dma_avail_data_size(struct dma_chan_data *channel)
 {
 	struct dw_dma_chan_data *dw_chan = dma_chan_get_data(channel);
 	int32_t read_ptr = dw_chan->ptr_data.current_ptr;
-#if CONFIG_HW_LLI
 	int32_t write_ptr = dma_reg_read(channel->dma, DW_DAR(channel->index));
-#else
-	int32_t write_ptr = ((struct dw_lli *)dw_chan->lli_current->llp)->dar;
-#endif
 	int size;
 
 	size = write_ptr - read_ptr;
@@ -1025,11 +1030,7 @@ static int dw_dma_avail_data_size(struct dma_chan_data *channel)
 static int dw_dma_free_data_size(struct dma_chan_data *channel)
 {
 	struct dw_dma_chan_data *dw_chan = dma_chan_get_data(channel);
-#if CONFIG_HW_LLI
 	int32_t read_ptr = dma_reg_read(channel->dma, DW_SAR(channel->index));
-#else
-	int32_t read_ptr = ((struct dw_lli *)dw_chan->lli_current->llp)->sar;
-#endif
 	int32_t write_ptr = dw_chan->ptr_data.current_ptr;
 	int size;
 

--- a/src/include/sof/lib/dma.h
+++ b/src/include/sof/lib/dma.h
@@ -220,6 +220,11 @@ struct dma_chan_data {
 	/* callback type */
 	int cb_type;
 
+	/* called by the DMA domain right after receiving an interrupt,
+	 * so should execute very time-sensitive operations
+	 */
+	void (*irq_callback)(struct dma_chan_data *channel);
+
 	void *private;
 };
 

--- a/src/schedule/dma_multi_chan_domain.c
+++ b/src/schedule/dma_multi_chan_domain.c
@@ -241,6 +241,10 @@ static bool dma_multi_chan_domain_is_pending(struct ll_schedule_domain *domain,
 			if (dma_domain->data[i][j].task != task)
 				continue;
 
+			/* execute callback if exists */
+			if (dmas[i].chan[j].irq_callback)
+				dmas[i].chan[j].irq_callback(&dmas[i].chan[j]);
+
 			/* clear interrupt */
 			dma_interrupt(&dmas[i].chan[j], DMA_IRQ_CLEAR);
 			interrupt_clear_mask(dma_domain->data[i][j].irq,


### PR DESCRIPTION
For DW-DMA without hardware linked list support we need
to manually reload linked list items after every interrupt.
It's very time-sensitive and even the slightest drift can
cause glitches, so this patch moves lli reload routine
to be called from DMA domain as an interrupt callback.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>