### PR TITLE
topology: cml: fix errors in topologies

### DIFF
--- a/tools/topology/sof-cml-demux-rt5682-max98357a.m4
+++ b/tools/topology/sof-cml-demux-rt5682-max98357a.m4
@@ -27,7 +27,7 @@ dnl     pipeline_rate, time_domain)
 ifelse(SOF_ABI_VERSION_3_9_OR_GRT, `1',
 `PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
         7, 5, 2, s32le,
-        1000, 0, 0, SSP, 1, s16le, 3,
+        1000, 0, 0, SSP, 1, s24le, 3,
         48000, 48000, 48000)',
 `PIPELINE_PCM_DAI_ADD(sof/pipe-src-volume-playback.m4,
         7, 5, 2, s32le,

--- a/tools/topology/sof-cml-rt5682-max98357a.m4
+++ b/tools/topology/sof-cml-rt5682-max98357a.m4
@@ -28,11 +28,11 @@ dnl     pipeline_rate, time_domain)
 # pipe-src pipeline is needed for older SSP config
 
 ifelse(SOF_ABI_VERSION_3_9_OR_GRT, `1',
-`PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+`PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
 	7, 5, 2, s32le,
-	1000, 0, 0, SSP, 1, s16le, 3,
+	1000, 0, 0, SSP, 1, s24le, 3,
 	48000, 48000, 48000)',
-`PIPELINE_PCM_ADD(sof/pipe-src-volume-playback.m4,
+`PIPELINE_PCM_DAI_ADD(sof/pipe-src-volume-playback.m4,
         7, 5, 2, s32le,
         1000, 0, 0, SSP, 1, s16le, 3,
         48000, 48000, 48000)')

--- a/tools/topology/sof/pipe-src-volume-playback.m4
+++ b/tools/topology/sof/pipe-src-volume-playback.m4
@@ -56,8 +56,8 @@ LIST(`		', `SOF_TKN_VOLUME_RAMP_STEP_TYPE	"0"'
 
 W_DATA(playback_pga_conf, playback_pga_tokens)
 
-# "Volume" has 2 source and x sink periods
-W_PGA(0, PIPELINE_FORMAT, DAI_PERIODS, 2, playback_pga_conf, LIST(`		', "PIPELINE_ID Master Playback Volume"))
+# "Volume" has 3 source and x sink periods
+W_PGA(0, PIPELINE_FORMAT, DAI_PERIODS, 3, playback_pga_conf, LIST(`		', "PIPELINE_ID Master Playback Volume"))
 
 # Playback Buffers
 W_BUFFER(0, COMP_BUFFER_SIZE(3,


### PR DESCRIPTION
Fixes SSP format and used pipeline macro in CML topologies.

Fixes: cfe81f5 ("topology: cml: cnl: use 3 periods for SSP, DMIC and ALH DAIs")

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>

Fixes #1923.