### PR TITLE
drivers: imx: edma: Remove hardcoding of interrupt numbers

### DIFF
--- a/src/include/sof/drivers/edma.h
+++ b/src/include/sof/drivers/edma.h
@@ -91,4 +91,15 @@ int edma_init(void);
 #define trace_edma_error(format, ...) trace_error(TRACE_CLASS_DMA,\
 						  format, ##__VA_ARGS__)
 
+#define EDMA0_ESAI_CHAN_RX	6
+#define EDMA0_ESAI_CHAN_TX	7
+#define EDMA0_SAI_CHAN_RX	14
+#define EDMA0_SAI_CHAN_TX	15
+#define EDMA0_CHAN_MAX		32
+
+#define EDMA0_ESAI_CHAN_RX_IRQ	442
+#define EDMA0_ESAI_CHAN_TX_IRQ	442
+#define EDMA0_SAI_CHAN_RX_IRQ	349
+#define EDMA0_SAI_CHAN_TX_IRQ	349
+
 #endif /* __SOF_DRIVERS_EDMA_H__ */

--- a/src/platform/imx8/include/platform/lib/dma.h
+++ b/src/platform/imx8/include/platform/lib/dma.h
@@ -18,18 +18,9 @@
 #define DMA_ID_EDMA0	0
 #define DMA_ID_HOST	1
 
-/*
- * IRQ line 442 (ESAI0_DMA_INT) groups
- *	- DMA#0 interrupt #6, ESAI0 receive channel
- *	- DMA#0 interrupt #7, ESAI0 transmit channel
- * Converting this to internal SOF irq representation we get
- *	- irq = 442 % 64 = 58
- *	- irq_name = irq_name_irqsteer[442 / 64] = "irqsteer6"
- *
- * TODO: Remove hardcoded values and add generic implementation
- */
-#define dma_chan_irq(dma, chan) 58
-#define dma_chan_irq_name(dma, chan) "irqsteer6"
+#define dma_chan_irq(dma, chan) \
+	irqstr_get_sof_int(((int *)dma->plat_data.drv_plat_data)[chan])
+#define dma_chan_irq_name(dma, chan) dma_irq_name(dma)
 
 int dmac_init(void);
 

--- a/src/platform/imx8/lib/dma.c
+++ b/src/platform/imx8/lib/dma.c
@@ -14,6 +14,13 @@
 extern struct dma_ops dummy_dma_ops;
 extern struct dma_ops edma_ops;
 
+static int edma0_ints[EDMA0_CHAN_MAX] = {
+	[EDMA0_ESAI_CHAN_RX] = EDMA0_ESAI_CHAN_RX_IRQ,
+	[EDMA0_ESAI_CHAN_TX] = EDMA0_ESAI_CHAN_TX_IRQ,
+	[EDMA0_SAI_CHAN_RX] = EDMA0_SAI_CHAN_RX_IRQ,
+	[EDMA0_SAI_CHAN_TX] = EDMA0_SAI_CHAN_TX_IRQ,
+};
+
 struct dma dma[PLATFORM_NUM_DMACS] = {
 {
 	.plat_data = {
@@ -23,6 +30,7 @@ struct dma dma[PLATFORM_NUM_DMACS] = {
 		.base		= EDMA0_BASE,
 		.chan_size	= EDMA0_SIZE,
 		.channels	= 32,
+		.drv_plat_data	= edma0_ints,
 	},
 	.ops	= &edma_ops,
 },


### PR DESCRIPTION
Initially I have hardcoded the specific values required for the ESAI.
That however is highly inflexible.

This commit refactors that to allow a more flexible declaration so that
other DMA clients can also get their proper interrupt numbers.

Only hardware which delivers its DMA interrupts via IRQ_STEER is
supported, however on this platform that is fine (all DMA channels
deliver their interrupts as shared interrupts via IRQ_STEER).

Signed-off-by: Paul Olaru <paul.olaru@nxp.com>

@groncarolo @jlacla I think you can use this and add your corresponding defines in the table so I'll unblock the SAI driver, right?