### PR TITLE
Add EDMA scheduling domain

### DIFF
--- a/src/drivers/imx/edma.c
+++ b/src/drivers/imx/edma.c
@@ -331,6 +331,8 @@ static int edma_set_config(struct dma_chan_data *channel,
 
 	trace_edma("EDMA: set config");
 
+	channel->is_scheduling_source = config->is_scheduling_source;
+
 	switch (config->direction) {
 	case DMA_DIR_MEM_TO_DEV:
 		soff = config->src_width;

--- a/src/platform/imx8/platform.c
+++ b/src/platform/imx8/platform.c
@@ -118,6 +118,7 @@ struct timer timer = {
 struct timer *platform_timer = &timer;
 
 struct ll_schedule_domain *platform_timer_domain;
+struct ll_schedule_domain *platform_dma_domain;
 
 int platform_boot_complete(uint32_t boot_message)
 {
@@ -151,6 +152,15 @@ int platform_init(struct sof *sof)
 		timer_domain_init(platform_timer, PLATFORM_DEFAULT_CLOCK,
 				  PLATFORM_LL_DEFAULT_TIMEOUT);
 	scheduler_init_ll(platform_timer_domain);
+
+	/* Init EDMA platform domain */
+	platform_dma_domain =
+		dma_multi_chan_domain_init(
+		    &dma[0],
+		    1,
+		    PLATFORM_DEFAULT_CLOCK,
+		    false);
+	scheduler_init_ll(platform_dma_domain);
 
 	platform_timer_start(platform_timer);
 	sa_init(sof);


### PR DESCRIPTION
On the i.MX platform the EDMA driver is responsible for scheduling all the
copies inside each pipeline which uses this controller. This patch set allows
this to happen.

@groncarolo This commit actually allows the IRQ numbers from #1931 to
be considered. So you will need both this PR and that one if you want to
test the SAI driver.