### PR TITLE
cnl: Access to HPSRAM power gating status register - macro updated

### DIFF
--- a/src/platform/cannonlake/include/platform/lib/shim.h
+++ b/src/platform/cannonlake/include/platform/lib/shim.h
@@ -175,7 +175,7 @@
 #define HSPGISTS1		0x71D28
 
 #define SHIM_HSPGCTL(x)	(HSPGCTL0 + 0x10 * (x))
-#define SHIM_HSPGISTS(x)	(HSPGISTS0 + 0x18 * (x))
+#define SHIM_HSPGISTS(x)	(HSPGISTS0 + 0x10 * (x))
 
 #define LSPGCTL			0x71D50
 #define LSRMCTL			0x71D54


### PR DESCRIPTION
Macro modified for SRAM segments > 0 fixed by register offset update to a proper value.


Signed-off-by: Lech Betlej <lech.betlej@linux.intel.com>