### PR TITLE
topology: sof-icl-rt711-rt1308-rt715-hdmi: use 3 periods for ALH

### DIFF
--- a/tools/topology/sof-icl-rt711-rt1308-rt715-hdmi.m4
+++ b/tools/topology/sof-icl-rt711-rt1308-rt715-hdmi.m4
@@ -30,46 +30,53 @@ DEBUG_START
 # PCM6 ---> volume <---- iDisp2
 # PCM7 ---> volume <---- iDisp3
 
+dnl PIPELINE_PCM_DAI_ADD(pipeline,
+dnl     pipe id, pcm, max channels, format,
+dnl     period, priority, core,
+dnl     dai type, dai_index, dai format,
+dnl     dai periods, pcm_min_rate, pcm_max_rate,
+dnl     pipeline_rate, time_domain)
+
+# Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
+	1, 0, 2, s32le,
+	1000, 0, 0, ALH, 2, s32le, 3,
+	48000, 48000, 48000)
+
+# Low Latency capture pipeline 2 on PCM 1 using max 2 channels of s32le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
+	2, 1, 2, s32le,
+	1000, 0, 0, ALH, 3, s32le, 3,
+	48000, 48000, 48000)
+
+# Low Latency playback pipeline 3 on PCM 2 using max 2 channels of s32le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
+	3, 2, 2, s32le,
+	1000, 0, 0, ALH, 0x102, s32le, 3,
+	48000, 48000, 48000)
+
+# Low Latency playback pipeline 4 on PCM 3 using max 2 channels of s32le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
+	4, 3, 2, s32le,
+	1000, 0, 0, ALH, 0x202, s32le, 3,
+	48000, 48000, 48000)
+
+# Low Latency capture pipeline 5 on PCM 4 using max 2 channels of s32le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
+	5, 4, 2, s32le,
+	1000, 0, 0, ALH, 0x302, s32le, 3,
+	48000, 48000, 48000)
+
 dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,
 dnl     period, priority, core,
 dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
-
-# Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
-	1, 0, 2, s32le,
-	1000, 0, 0,
-	48000, 48000, 48000)
-
-# Low Latency capture pipeline 2 on PCM 1 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
-	2, 1, 2, s32le,
-	1000, 0, 0,
-	48000, 48000, 48000)
-
-# Low Latency playback pipeline 3 on PCM 2 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
-	3, 2, 2, s32le,
-	1000, 0, 0,
-	48000, 48000, 48000)
-
-# Low Latency playback pipeline 4 on PCM 3 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
-	4, 3, 2, s32le,
-	1000, 0, 0,
-	48000, 48000, 48000)
-
-# Low Latency capture pipeline 5 on PCM 4 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
-	5, 4, 2, s32le,
-	1000, 0, 0,
-	48000, 48000, 48000)
 
 # Low Latency playback pipeline 6 on PCM 5 using max 2 channels of s32le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
@@ -101,39 +108,39 @@ dnl     pipe id, dai type, dai_index, dai_be,
 dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
-# playback DAI is ALH(SDW0 PIN2) using 2 periods
+# playback DAI is ALH(SDW0 PIN2) using 3 periods
 # Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, ALH, 2, SDW0-Playback,
-	PIPELINE_SOURCE_1, 2, s32le,
+	PIPELINE_SOURCE_1, 3, s32le,
 	1000, 0, 0)
 
-# capture DAI is ALH(SDW0 PIN2) using 2 periods
+# capture DAI is ALH(SDW0 PIN2) using 3 periods
 # Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	2, ALH, 3, SDW0-Capture,
-	PIPELINE_SINK_2, 2, s32le,
+	PIPELINE_SINK_2, 3, s32le,
 	1000, 0, 0)
 
-# playback DAI is ALH(SDW1 PIN2) using 2 periods
+# playback DAI is ALH(SDW1 PIN2) using 3 periods
 # Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	3, ALH, 0x102, SDW1-Playback,
-	PIPELINE_SOURCE_3, 2, s32le,
+	PIPELINE_SOURCE_3, 3, s32le,
 	1000, 0, 0)
 
-# playback DAI is ALH(SDW2 PIN2) using 2 periods
+# playback DAI is ALH(SDW2 PIN2) using 3 periods
 # Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	4, ALH, 0x202, SDW2-Playback,
-	PIPELINE_SOURCE_4, 2, s32le,
+	PIPELINE_SOURCE_4, 3, s32le,
 	1000, 0, 0)
 
-# capture DAI is ALH(SDW3 PIN2) using 2 periods
+# capture DAI is ALH(SDW3 PIN2) using 3 periods
 # Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	5, ALH, 0x302, SDW3-Capture,
-	PIPELINE_SINK_5, 2, s32le,
+	PIPELINE_SINK_5, 3, s32le,
 	1000, 0, 0)
 
 # playback DAI is iDisp1 using 2 periods


### PR DESCRIPTION
Changes ICL topology to use 3 periods for buffer connected to ALH DAI.
This topology has been forgotten, when such changes were done.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>