### PR TITLE
pipeline: schedule pipelines separately

### DIFF
--- a/src/drivers/intel/cavs/dmic.c
+++ b/src/drivers/intel/cavs/dmic.c
@@ -1533,8 +1533,7 @@ static int dmic_probe(struct dai *dai)
 
 	/* Initialize start sequence handler */
 	schedule_task_init(&dmic->dmicwork, SOF_SCHEDULE_LL_TIMER,
-			   SOF_TASK_PRI_MED, dmic_work, NULL, dai, 0,
-			   SOF_SCHEDULE_FLAG_ASYNC);
+			   SOF_TASK_PRI_MED, dmic_work, NULL, dai, 0, 0);
 
 	/* Enable DMIC power */
 	pm_runtime_get_sync(DMIC_POW, dai->index);

--- a/src/include/sof/audio/pipeline.h
+++ b/src/include/sof/audio/pipeline.h
@@ -9,7 +9,6 @@
 #define __SOF_AUDIO_PIPELINE_H__
 
 #include <sof/lib/cpu.h>
-#include <sof/schedule/task.h>
 #include <sof/trace/trace.h>
 #include <ipc/topology.h>
 #include <user/trace.h>
@@ -18,10 +17,11 @@
 
 struct comp_buffer;
 struct comp_dev;
+struct ipc;
 struct sof_ipc_buffer;
 struct sof_ipc_pcm_params;
 struct sof_ipc_stream_posn;
-struct ipc;
+struct task;
 
 /*
  * This flag disables firmware-side xrun recovery.
@@ -158,8 +158,6 @@ void pipeline_schedule_cancel(struct pipeline *p);
 /* get time pipeline timestamps from host to dai */
 void pipeline_get_timestamp(struct pipeline *p, struct comp_dev *host_dev,
 			    struct sof_ipc_stream_posn *posn);
-
-void pipeline_schedule(void *arg);
 
 /* notify host that we have XRUN */
 void pipeline_xrun(struct pipeline *p, struct comp_dev *dev, int32_t bytes);

--- a/src/include/sof/schedule/ll_schedule_domain.h
+++ b/src/include/sof/schedule/ll_schedule_domain.h
@@ -47,6 +47,7 @@ struct ll_schedule_domain {
 	uint32_t ticks_per_ms;		/**< number of clock ticks per ms */
 	int type;			/**< domain type */
 	int clk;			/**< source clock */
+	bool synchronous;		/**< are tasks should be synchronous */
 	void *private;			/**< pointer to private data */
 	bool registered[PLATFORM_CORE_COUNT];		/**< registered cores */
 	const struct ll_schedule_domain_ops *ops;	/**< domain ops */

--- a/src/include/sof/schedule/ll_schedule_domain.h
+++ b/src/include/sof/schedule/ll_schedule_domain.h
@@ -30,7 +30,7 @@ struct ll_schedule_domain_ops {
 			       uint64_t period, struct task *task,
 			       void (*handler)(void *arg), void *arg);
 	void (*domain_unregister)(struct ll_schedule_domain *domain,
-				  uint32_t num_tasks);
+				  struct task *task, uint32_t num_tasks);
 	void (*domain_enable)(struct ll_schedule_domain *domain, int core);
 	void (*domain_disable)(struct ll_schedule_domain *domain, int core);
 	void (*domain_set)(struct ll_schedule_domain *domain, uint64_t start);
@@ -85,11 +85,11 @@ static inline int domain_register(struct ll_schedule_domain *domain,
 }
 
 static inline void domain_unregister(struct ll_schedule_domain *domain,
-				     uint32_t num_tasks)
+				     struct task *task, uint32_t num_tasks)
 {
 	assert(domain->ops->domain_unregister);
 
-	domain->ops->domain_unregister(domain, num_tasks);
+	domain->ops->domain_unregister(domain, task, num_tasks);
 }
 
 static inline void domain_enable(struct ll_schedule_domain *domain, int core)

--- a/src/include/sof/schedule/ll_schedule_domain.h
+++ b/src/include/sof/schedule/ll_schedule_domain.h
@@ -57,8 +57,9 @@ struct ll_schedule_domain {
 
 #define ll_sch_domain_get_pdata(domain) ((domain)->private)
 
-static inline struct ll_schedule_domain *domain_init(int type, int clk,
-				const struct ll_schedule_domain_ops *ops)
+static inline struct ll_schedule_domain *domain_init
+				(int type, int clk, bool synchronous,
+				 const struct ll_schedule_domain_ops *ops)
 {
 	struct ll_schedule_domain *domain;
 
@@ -66,6 +67,7 @@ static inline struct ll_schedule_domain *domain_init(int type, int clk,
 			 sizeof(*domain));
 	domain->type = type;
 	domain->clk = clk;
+	domain->synchronous = synchronous;
 	domain->ticks_per_ms = clock_ms_to_ticks(clk, 1);
 	domain->ops = ops;
 

--- a/src/include/sof/schedule/ll_schedule_domain.h
+++ b/src/include/sof/schedule/ll_schedule_domain.h
@@ -40,16 +40,16 @@ struct ll_schedule_domain_ops {
 };
 
 struct ll_schedule_domain {
-	uint64_t last_tick;
-	spinlock_t *lock;
-	atomic_t total_num_tasks;
-	atomic_t num_clients;
-	bool registered[PLATFORM_CORE_COUNT];
-	uint32_t ticks_per_ms;
-	int type;
-	int clk;
-	const struct ll_schedule_domain_ops *ops;
-	void *private;
+	uint64_t last_tick;		/**< timestamp of last run */
+	spinlock_t *lock;		/**< standard lock */
+	atomic_t total_num_tasks;	/**< total number of registered tasks */
+	atomic_t num_clients;		/**< number of registered cores */
+	uint32_t ticks_per_ms;		/**< number of clock ticks per ms */
+	int type;			/**< domain type */
+	int clk;			/**< source clock */
+	void *private;			/**< pointer to private data */
+	bool registered[PLATFORM_CORE_COUNT];		/**< registered cores */
+	const struct ll_schedule_domain_ops *ops;	/**< domain ops */
 };
 
 #define ll_sch_domain_set_pdata(domain, data) ((domain)->private = (data))

--- a/src/include/sof/schedule/schedule.h
+++ b/src/include/sof/schedule/schedule.h
@@ -9,6 +9,7 @@
 #ifndef __SOF_SCHEDULE_SCHEDULE_H__
 #define __SOF_SCHEDULE_SCHEDULE_H__
 
+#include <sof/bit.h>
 #include <sof/common.h>
 #include <sof/list.h>
 #include <sof/schedule/task.h>
@@ -44,10 +45,7 @@ enum {
 };
 
 /* Scheduler flags */
-/* Sync/Async only supported by ll scheduler atm */
-#define SOF_SCHEDULE_FLAG_ASYNC (0 << 0) /* task scheduled asynchronously */
-#define SOF_SCHEDULE_FLAG_SYNC	(1 << 0) /* task scheduled synchronously */
-#define SOF_SCHEDULE_FLAG_IDLE  (2 << 0)
+#define SOF_SCHEDULE_FLAG_IDLE	BIT(0)
 
 struct scheduler_ops {
 	void (*schedule_task)(void *data, struct task *task, uint64_t start,

--- a/src/include/sof/schedule/task.h
+++ b/src/include/sof/schedule/task.h
@@ -10,8 +10,10 @@
 
 #include <arch/schedule/task.h>
 #include <sof/list.h>
+#include <stdbool.h>
 #include <stdint.h>
 
+struct comp_dev;
 struct sof;
 
 #define SOF_TASK_PRI_HIGH	0	/* priority level 0 - high */
@@ -52,6 +54,15 @@ struct task {
 	struct list_item list;
 	void *private;
 };
+
+/** \brief Task type registered by pipelines. */
+struct pipeline_task {
+	struct task task;		/**< parent structure */
+	bool registrable;		/**< should task be registered on irq */
+	struct comp_dev *sched_comp;	/**< pipeline scheduling component */
+};
+
+#define pipeline_task_get(task) ((struct pipeline_task *)(task))
 
 enum task_state task_main_master_core(void *data);
 

--- a/src/schedule/dma_multi_chan_domain.c
+++ b/src/schedule/dma_multi_chan_domain.c
@@ -289,7 +289,7 @@ struct ll_schedule_domain *dma_multi_chan_domain_init(struct dma *dma_array,
 	trace_ll("dma_multi_chan_domain_init(): num_dma %d, clk %d, "
 		 "aggregated_irq %d", num_dma, clk, aggregated_irq);
 
-	domain = domain_init(SOF_SCHEDULE_LL_DMA, clk,
+	domain = domain_init(SOF_SCHEDULE_LL_DMA, clk, true,
 			     &dma_multi_chan_domain_ops);
 
 	dma_domain = rzalloc(RZONE_SYS | RZONE_FLAG_UNCACHED, SOF_MEM_CAPS_RAM,

--- a/src/schedule/dma_multi_chan_domain.c
+++ b/src/schedule/dma_multi_chan_domain.c
@@ -172,9 +172,11 @@ static void dma_multi_chan_domain_irq_unregister(struct dma_domain_data *data)
 /**
  * \brief Unregisters task from DMA domain.
  * \param[in,out] domain Pointer to schedule domain.
+ * \param[in,out] task Task to be unregistered from the domain..
  * \param[in] num_tasks Number of currently scheduled tasks.
  */
 static void dma_multi_chan_domain_unregister(struct ll_schedule_domain *domain,
+					     struct task *task,
 					     uint32_t num_tasks)
 {
 	struct dma_domain *dma_domain = ll_sch_domain_get_pdata(domain);

--- a/src/schedule/dma_single_chan_domain.c
+++ b/src/schedule/dma_single_chan_domain.c
@@ -494,7 +494,7 @@ struct ll_schedule_domain *dma_single_chan_domain_init(struct dma *dma_array,
 	trace_ll("dma_single_chan_domain_init(): num_dma %d, clk %d", num_dma,
 		 clk);
 
-	domain = domain_init(SOF_SCHEDULE_LL_DMA, clk,
+	domain = domain_init(SOF_SCHEDULE_LL_DMA, clk, false,
 			     &dma_single_chan_domain_ops);
 
 	dma_domain = rzalloc(RZONE_SYS | RZONE_FLAG_UNCACHED, SOF_MEM_CAPS_RAM,

--- a/src/schedule/dma_single_chan_domain.c
+++ b/src/schedule/dma_single_chan_domain.c
@@ -333,9 +333,11 @@ static void dma_domain_unregister_owner(struct ll_schedule_domain *domain,
 /**
  * \brief Unregisters task from DMA domain.
  * \param[in,out] domain Pointer to schedule domain.
+ * \param[in,out] task Task to be unregistered from the domain.
  * \param[in] num_tasks Number of currently scheduled tasks.
  */
 static void dma_single_chan_domain_unregister(struct ll_schedule_domain *domain,
+					      struct task *task,
 					      uint32_t num_tasks)
 {
 	struct dma_domain *dma_domain = ll_sch_domain_get_pdata(domain);

--- a/src/schedule/ll_schedule.c
+++ b/src/schedule/ll_schedule.c
@@ -64,7 +64,7 @@ static void schedule_ll_task_update_start(struct ll_schedule_data *sch,
 
 	next = sch->domain->ticks_per_ms * pdata->period / 1000;
 
-	if (task->flags & SOF_SCHEDULE_FLAG_SYNC)
+	if (sch->domain->synchronous)
 		task->start += next;
 	else
 		task->start = next + last_tick;
@@ -275,7 +275,7 @@ static void schedule_ll_task(void *data, struct task *task, uint64_t start,
 
 	task->start = sch->domain->ticks_per_ms * start / 1000;
 
-	if (task->flags & SOF_SCHEDULE_FLAG_SYNC)
+	if (sch->domain->synchronous)
 		task->start += platform_timer_get(platform_timer);
 	else
 		task->start += sch->domain->last_tick;
@@ -362,7 +362,7 @@ static void reschedule_ll_task(void *data, struct task *task, uint64_t start)
 
 	time = sch->domain->ticks_per_ms * start / 1000;
 
-	if (task->flags & SOF_SCHEDULE_FLAG_SYNC)
+	if (sch->domain->synchronous)
 		time += platform_timer_get(platform_timer);
 	else
 		time += sch->domain->last_tick;

--- a/src/schedule/ll_schedule.c
+++ b/src/schedule/ll_schedule.c
@@ -191,7 +191,8 @@ static int schedule_ll_domain_set(struct ll_schedule_data *sch,
 	return 0;
 }
 
-static void schedule_ll_domain_clear(struct ll_schedule_data *sch)
+static void schedule_ll_domain_clear(struct ll_schedule_data *sch,
+				     struct task *task)
 {
 	spin_lock(sch->domain->lock);
 
@@ -212,7 +213,7 @@ static void schedule_ll_domain_clear(struct ll_schedule_data *sch)
 
 	spin_unlock(sch->domain->lock);
 
-	domain_unregister(sch->domain, atomic_read(&sch->num_tasks));
+	domain_unregister(sch->domain, task, atomic_read(&sch->num_tasks));
 }
 
 static void schedule_ll_task_insert(struct task *task, struct list_item *tasks)
@@ -339,7 +340,7 @@ static void schedule_ll_task_cancel(void *data, struct task *task)
 
 		/* found it */
 		if (curr_task == task) {
-			schedule_ll_domain_clear(sch);
+			schedule_ll_domain_clear(sch, task);
 			break;
 		}
 	}

--- a/src/schedule/timer_domain.c
+++ b/src/schedule/timer_domain.c
@@ -56,7 +56,7 @@ static int timer_domain_register(struct ll_schedule_domain *domain,
 }
 
 static void timer_domain_unregister(struct ll_schedule_domain *domain,
-				    uint32_t num_tasks)
+				    struct task *task, uint32_t num_tasks)
 {
 	struct timer_domain *timer_domain = ll_sch_domain_get_pdata(domain);
 	int core = cpu_get_id();

--- a/src/schedule/timer_domain.c
+++ b/src/schedule/timer_domain.c
@@ -126,7 +126,8 @@ struct ll_schedule_domain *timer_domain_init(struct timer *timer, int clk,
 
 	trace_ll("timer_domain_init(): clk %d, timeout %u", clk, timeout);
 
-	domain = domain_init(SOF_SCHEDULE_LL_TIMER, clk, &timer_domain_ops);
+	domain = domain_init(SOF_SCHEDULE_LL_TIMER, clk, false,
+			     &timer_domain_ops);
 
 	timer_domain = rzalloc(RZONE_SYS | RZONE_FLAG_UNCACHED,
 			       SOF_MEM_CAPS_RAM, sizeof(*timer_domain));

--- a/tools/topology/sof-apl-demux-pcm512x.m4
+++ b/tools/topology/sof-apl-demux-pcm512x.m4
@@ -85,7 +85,7 @@ W_DAI_IN(SSP, 5, SSP5-Codec, s24le, 3, 0)
 # Capture pipeline 5 from demux on PCM 5 using max 2 channels of s32le.
 PIPELINE_PCM_ADD(sof/pipe-passthrough-capture-sched.m4,
 	5, 4, 2, s32le,
-	1000, 0, 0,
+	1000, 1, 0,
 	48000, 48000, 48000,
 	SCHEDULE_TIME_DOMAIN_TIMER,
 	PIPELINE_PLAYBACK_SCHED_COMP_1)

--- a/tools/topology/sof-apl-keyword-detect.m4
+++ b/tools/topology/sof-apl-keyword-detect.m4
@@ -66,7 +66,7 @@ dnl     sched_comp, time_domain,
 dnl     pcm_min_rate, pcm_max_rate, pipeline_rate)
 PIPELINE_ADD(sof/pipe-detect.m4,
 	2, 2, s16le,
-	KWD_PIPE_SCH_DEADLINE_US, 0, 0,
+	KWD_PIPE_SCH_DEADLINE_US, 1, 0,
 	PIPELINE_SCHED_COMP_1,
 	SCHEDULE_TIME_DOMAIN_TIMER,
 	16000, 16000, 16000)

--- a/tools/topology/sof-apl-nocodec.m4
+++ b/tools/topology/sof-apl-nocodec.m4
@@ -148,10 +148,10 @@ DAI_ADD(sof/pipe-dai-playback.m4,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # Media playback pipeline 14 on PCM 7 using max 2 channels of s16le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 4000us deadline on core 0 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-pcm-media.m4,
 	14, 7, 2, s16le,
-	1000, 0, 0,
+	4000, 0, 0,
 	48000, 48000, 48000,
 	SCHEDULE_TIME_DOMAIN_TIMER,
 	PIPELINE_PLAYBACK_SCHED_COMP_1)

--- a/tools/topology/sof-bdw-codec.m4
+++ b/tools/topology/sof-bdw-codec.m4
@@ -32,10 +32,10 @@ define(PIPE_NAME, ifelse(CODEC, `RT5640', pipe-bdw-rt5640,
 #
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline on core 0 with priority 1
 PIPELINE_PCM_ADD(sof/pipe-low-latency-playback.m4,
 	1, 0, 2, s32le,
-	1000, 0, 0,
+	1000, 1, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s32le.
@@ -46,10 +46,10 @@ PIPELINE_PCM_ADD(sof/pipe-low-latency-capture.m4,
 	48000, 48000, 48000)
 
 # PCM Media Playback pipeline 3 on PCM 1 using max 2 channels of s32le.
-# 2000us deadline on core 0 with priority 1
+# 2000us deadline on core 0 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-pcm-media.m4,
 	3, 1, 2, s32le,
-	2000, 1, 0,
+	2000, 0, 0,
 	8000, 96000, 48000)
 
 # Connect pipelines together
@@ -69,11 +69,11 @@ SectionGraph."PIPE_NAME" {
 #
 
 # playback DAI is SSP0 using 2 periods
-# Buffers use s24le format, 1000us deadline on core 0 with priority 0
+# Buffers use s24le format, 1000us deadline on core 0 with priority 1
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, 0, Codec,
 	PIPELINE_SOURCE_1, 2, s24le,
-	1000, 0, 0)
+	1000, 1, 0)
 
 # capture DAI is SSP0 using 2 periods
 # Buffers use s24le format, 1000us deadline on core 0 with priority 0

--- a/tools/topology/sof-byt-codec.m4
+++ b/tools/topology/sof-byt-codec.m4
@@ -38,10 +38,10 @@ define(PIPE_NAME, ifelse(CODEC, `RT5682', pipe-byt-rt5682,
 #
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline on core 0 with priority 1
 PIPELINE_PCM_ADD(sof/pipe-low-latency-playback.m4,
 	1, 0, 2, s32le,
-	1000, 0, 0,
+	1000, 1, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s32le.
@@ -58,17 +58,17 @@ PIPELINE_PCM_ADD(sof/pipe-low-latency-capture.m4,
 #
 
 # playback DAI is SSP2 using 2 periods
-# Buffers use s24le format, 1000us deadline on core 0 with priority 0
+# Buffers use s24le format, 1000us deadline on core 0 with priority 1
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, 2, SSP2-Codec,
 	PIPELINE_SOURCE_1, 2, s24le,
-	1000, 0, 0)
+	1000, 1, 0)
 
 # PCM Media Playback pipeline 3 on PCM 1 using max 2 channels of s32le.
-# 4000us deadline on core 0 with priority 1
+# 4000us deadline on core 0 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-pcm-media.m4,
 	3, 1, 2, s16le,
-	1000, 1, 0,
+	1000, 0, 0,
 	8000, 96000, 48000,
 	0, PIPELINE_PLAYBACK_SCHED_COMP_1)
 

--- a/tools/topology/sof-byt-codec.m4
+++ b/tools/topology/sof-byt-codec.m4
@@ -68,7 +68,7 @@ DAI_ADD(sof/pipe-dai-playback.m4,
 # 4000us deadline on core 0 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-pcm-media.m4,
 	3, 1, 2, s16le,
-	1000, 0, 0,
+	4000, 0, 0,
 	8000, 96000, 48000,
 	0, PIPELINE_PLAYBACK_SCHED_COMP_1)
 

--- a/tools/topology/sof-cht-max98090.m4
+++ b/tools/topology/sof-cht-max98090.m4
@@ -28,10 +28,10 @@ include(`platform/intel/cht.m4')
 #
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline on core 0 with priority 1
 PIPELINE_PCM_ADD(sof/pipe-low-latency-playback.m4,
 	1, 0, 2, s32le,
-	1000, 0, 0,
+	1000, 1, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s32le.
@@ -48,17 +48,17 @@ PIPELINE_PCM_ADD(sof/pipe-low-latency-capture.m4,
 #
 
 # playback DAI is SSP2 using 2 periods
-# Buffers use s16le format, 1000us deadline on core 0 with priority 0
+# Buffers use s16le format, 1000us deadline on core 0 with priority 1
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, 2, SSP2-Codec,
 	PIPELINE_SOURCE_1, 2, s16le,
-	1000, 0, 0)
+	1000, 1, 0)
 
 # PCM Media Playback pipeline 3 on PCM 1 using max 2 channels of s32le.
-# 4000us deadline on core 0 with priority 1
+# 4000us deadline on core 0 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-pcm-media.m4,
 	3, 1, 2, s32le,
-	1000, 1, 0,
+	1000, 0, 0,
 	8000, 48000, 48000,
 	0, PIPELINE_PLAYBACK_SCHED_COMP_1)
 

--- a/tools/topology/sof-cht-max98090.m4
+++ b/tools/topology/sof-cht-max98090.m4
@@ -58,7 +58,7 @@ DAI_ADD(sof/pipe-dai-playback.m4,
 # 4000us deadline on core 0 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-pcm-media.m4,
 	3, 1, 2, s32le,
-	1000, 0, 0,
+	4000, 0, 0,
 	8000, 48000, 48000,
 	0, PIPELINE_PLAYBACK_SCHED_COMP_1)
 

--- a/tools/topology/sof-cht-nocodec.m4
+++ b/tools/topology/sof-cht-nocodec.m4
@@ -32,10 +32,10 @@ define(PIPE_NAME, ifelse(PLATFORM, `cht', pipe-cht-nocodec,
 #
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline on core 0 with priority 1
 PIPELINE_PCM_ADD(sof/pipe-low-latency-playback.m4,
 	1, 0, 2, s32le,
-	1000, 0, 0,
+	1000, 1, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s32le.
@@ -52,17 +52,17 @@ PIPELINE_PCM_ADD(sof/pipe-low-latency-capture.m4,
 #
 
 # playback DAI is SSP2 using 2 periods
-# Buffers use s24le format, 1000us deadline on core 0 with priority 0
+# Buffers use s24le format, 1000us deadline on core 0 with priority 1
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, 2, NoCodec-2,
 	PIPELINE_SOURCE_1, 2, s24le,
-	1000, 0, 0)
+	1000, 1, 0)
 
 # PCM Media Playback pipeline 3 on PCM 1 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 1
+# 1000us deadline on core 0 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-pcm-media.m4,
 	3, 1, 2, s32le,
-	1000, 1, 0,
+	1000, 0, 0,
 	8000, 48000, 48000,
 	0, PIPELINE_PLAYBACK_SCHED_COMP_1)
 

--- a/tools/topology/sof-cht-nocodec.m4
+++ b/tools/topology/sof-cht-nocodec.m4
@@ -59,10 +59,10 @@ DAI_ADD(sof/pipe-dai-playback.m4,
 	1000, 1, 0)
 
 # PCM Media Playback pipeline 3 on PCM 1 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 4000us deadline on core 0 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-pcm-media.m4,
 	3, 1, 2, s32le,
-	1000, 0, 0,
+	4000, 0, 0,
 	8000, 48000, 48000,
 	0, PIPELINE_PLAYBACK_SCHED_COMP_1)
 

--- a/tools/topology/sof-cml-demux-rt5682.m4
+++ b/tools/topology/sof-cml-demux-rt5682.m4
@@ -113,7 +113,7 @@ DAI_ADD(sof/pipe-dai-capture.m4,
 # Capture pipeline 5 on PCM 5 using max 2 channels of s32le.
 PIPELINE_PCM_ADD(sof/pipe-passthrough-capture-sched.m4,
 	5, 5, 2, s32le,
-	1000, 0, 0,
+	1000, 1, 0,
 	48000, 48000, 48000,
 	SCHEDULE_TIME_DOMAIN_TIMER)
 

--- a/tools/topology/sof-cml-rt5682-kwd.m4
+++ b/tools/topology/sof-cml-rt5682-kwd.m4
@@ -185,7 +185,7 @@ dnl     sched_comp, time_domain,
 dnl     pcm_min_rate, pcm_max_rate, pipeline_rate)
 PIPELINE_ADD(sof/pipe-detect.m4,
 	9, 2, s24le,
-	KWD_PIPE_SCH_DEADLINE_US, 0, 0,
+	KWD_PIPE_SCH_DEADLINE_US, 1, 0,
 	PIPELINE_SCHED_COMP_8,
 	SCHEDULE_TIME_DOMAIN_TIMER,
 	16000, 16000, 16000)

--- a/tools/topology/sof-glk-da7219-kwd.m4
+++ b/tools/topology/sof-glk-da7219-kwd.m4
@@ -181,7 +181,7 @@ dnl     sched_comp, time_domain,
 dnl     pcm_min_rate, pcm_max_rate, pipeline_rate)
 PIPELINE_ADD(sof/pipe-detect.m4,
 	     9, 2, s16le,
-	     KWD_PIPE_SCH_DEADLINE_US, 0, 0,
+	     KWD_PIPE_SCH_DEADLINE_US, 1, 0,
 	     PIPELINE_SCHED_COMP_8, SCHEDULE_TIME_DOMAIN_TIMER,
 	     16000, 16000, 16000)
 

--- a/tools/topology/sof-hsw-rt5640.m4
+++ b/tools/topology/sof-hsw-rt5640.m4
@@ -28,10 +28,10 @@ include(`platform/intel/hsw.m4')
 #
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline on core 0 with priority 1
 PIPELINE_PCM_ADD(sof/pipe-low-latency-playback.m4,
 	1, 0, 2, s32le,
-	1000, 0, 0,
+	1000, 1, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s32le.
@@ -42,10 +42,10 @@ PIPELINE_PCM_ADD(sof/pipe-low-latency-capture.m4,
 	48000, 48000, 48000)
 
 # PCM Media Playback pipeline 3 on PCM 1 using max 2 channels of s32le.
-# 4000us deadline on core 0 with priority 1
+# 4000us deadline on core 0 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-pcm-media.m4,
 	3, 1, 2, s32le,
-	4000, 1, 0,
+	4000, 0, 0,
 	8000, 96000, 48000)
 
 # Connect pipelines together
@@ -65,11 +65,11 @@ SectionGraph."pipe-hsw-rt5640" {
 #
 
 # playback DAI is SSP0 using 2 periods
-# Buffers use s24le format, 1000us deadline on core 0 with priority 0
+# Buffers use s24le format, 1000us deadline on core 0 with priority 1
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, 0, Codec,
 	PIPELINE_SOURCE_1, 2, s24le,
-	1000, 0, 0)
+	1000, 1, 0)
 
 # capture DAI is SSP0 using 2 periods
 # Buffers use s24le format, 1000us deadline on core 0 with priority 0


### PR DESCRIPTION
This patch enables separate scheduling of connected
pipelines. It allows for different scheduling periods
between connected pipelines and flexible controlling
of such topologies.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>

Fixes #1502.