### PR TITLE
[DO NOT MERGE]topology: sof-apl-pcm-512x: remove HDMI pipelines

### DIFF
--- a/tools/topology/CMakeLists.txt
+++ b/tools/topology/CMakeLists.txt
@@ -25,9 +25,7 @@ set(TPLGS
 	"sof-hda-generic\;sof-hda-generic\;-DCHANNELS=0"
 	"sof-hda-generic\;sof-hda-generic-2ch\;-DCHANNELS=2"
 	"sof-hda-generic\;sof-hda-generic-4ch\;-DCHANNELS=4"
-	"sof-hda-generic-idisp\;sof-hda-generic-idisp\;-DCHANNELS=0"
-	"sof-hda-generic-idisp\;sof-hda-generic-idisp-2ch\;-DCHANNELS=2"
-	"sof-hda-generic-idisp\;sof-hda-generic-idisp-4ch\;-DCHANNELS=4"
+	"sof-hda-generic-idisp\;sof-hda-generic-idisp"
 	"sof-apl-nocodec\;sof-apl-nocodec"
 	"sof-apl-keyword-detect\;sof-apl-keyword-detect"
 	"sof-bdw-codec\;sof-bdw-rt286\;-DCODEC=RT286"
@@ -85,6 +83,8 @@ set(TPLGS
 	"sof-tgl-rt711-rt1308\;sof-tgl-rt711-rt1308-nohdmi"
 	"sof-imx8qxp-nocodec\;sof-imx8qxp-nocodec"
 	"sof-imx8qxp-cs42888\;sof-imx8qxp-cs42888"
+	"sof-dmic-generic\;sof-dmic-generic-2ch\;-DCHANNELS=2"
+	"sof-dmic-generic\;sof-dmic-generic-4ch\;-DCHANNELS=4"
 )
 
 add_custom_target(topologies ALL)

--- a/tools/topology/sof-apl-nocodec.m4
+++ b/tools/topology/sof-apl-nocodec.m4
@@ -44,92 +44,85 @@ dnl     pipeline_rate, time_domain)
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s16le.
 # Set 1000us deadline on core 0 with priority 0
 PIPELINE_PCM_DAI_ADD(sof/pipe-low-latency-playback.m4,
-	1, 0, 2, s32le,
+	11, 0, 2, s32le,
 	1000, 0, 0, SSP, 0, s16le, 3,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s16le.
 # 1000us deadline on core 0 with priority 0
 PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
-	2, 0, 2, s32le,
+	12, 0, 2, s32le,
 	1000, 0, 0, SSP, 0, s16le, 3,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 3 on PCM 1 using max 2 channels of s16le.
 # 1000us deadline on core 0 with priority 0
 PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
-	3, 1, 2, s32le,
+	13, 1, 2, s32le,
 	1000, 0, 0, SSP, 1, s16le, 3,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 4 on PCM 1 using max 2 channels of s16le.
 # 1000us deadline on core 0 with priority 0
 PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
-	4, 1, 2, s32le,
+	14, 1, 2, s32le,
 	1000, 0, 0, SSP, 1, s16le, 3,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 5 on PCM 2 using max 2 channels of s16le.
 # 1000us deadline on core 0 with priority 0
 #PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
-#	5, 2, 2, s32le,
+#	15, 2, 2, s32le,
 #	1000, 0, 0, SSP, 2, s16le, 3,
 #	48000, 48000, 48000)
 
 # Low Latency capture pipeline 6 on PCM 2 using max 2 channels of s16le.
 # 1000us deadline on core 0 with priority 0
 #PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
-#	6, 2, 2, s32le,
+#	16, 2, 2, s32le,
 #	1000, 0, 0, SSP, 2, s16le, 3,
 #	48000, 48000, 48000)
 
 # Low Latency playback pipeline 7 on PCM 3 using max 2 channels of s16le.
 # 1000us deadline on core 0 with priority 0
 PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
-	7, 3, 2, s32le,
+	17, 3, 2, s32le,
 	1000, 0, 0, SSP, 3, s16le, 3,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 8 on PCM 3 using max 2 channels of s16le.
 # 1000us deadline on core 0 with priority 0
 PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
-	8, 3, 2, s32le,
+	18, 3, 2, s32le,
 	1000, 0, 0, SSP, 3, s16le, 3,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 9 on PCM 4 using max 2 channels of s16le.
 # 1000us deadline on core 0 with priority 0
 #PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
-#	9, 4, 2, s32le,
+#	19, 4, 2, s32le,
 #	1000, 0, 0, SSP, 4, s16le, 3,
 #	48000, 48000, 48000)
 
 # Low Latency capture pipeline 10 on PCM 4 using max 2 channels of s16le.
 # 1000us deadline on core 0 with priority 0
 #PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
-#	10, 4, 2, s32le,
+#	20, 4, 2, s32le,
 #	1000, 0, 0, SSP, 4, s16le, 3,
 #	48000, 48000, 48000)
 
 # Low Latency playback pipeline 11 on PCM 5 using max 2 channels of s16le.
 # 1000us deadline on core 0 with priority 0
 PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
-	11, 5, 2, s32le,
+	21, 5, 2, s32le,
 	1000, 0, 0, SSP, 5, s16le, 3,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 12 on PCM 5 using max 2 channels of s16le.
 # 1000us deadline on core 0 with priority 0
 PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
-	12, 5, 2, s32le,
+	22, 5, 2, s32le,
 	1000, 0, 0, SSP, 5, s16le, 3,
-	48000, 48000, 48000)
-
-# Passthrough capture pipeline 13 on PCM 6 using max 2 channels.
-# 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-passthrough-capture.m4,
-	13, 6, 2, s32le,
-	1000, 0, 0, DMIC, 0, s32le, 3,
 	48000, 48000, 48000)
 
 #
@@ -144,18 +137,17 @@ dnl     deadline, priority, core, time_domain)
 # playback DAI is SSP0 using 3 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
-	1, SSP, 0, NoCodec-0,
-	PIPELINE_SOURCE_1, 3, s16le,
-	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+	11, SSP, 0, NoCodec-0,
+	PIPELINE_SOURCE_11, 3, s16le,
+	1000, 0, 0)
 
 # Media playback pipeline 14 on PCM 7 using max 2 channels of s16le.
 # Set 1000us deadline on core 0 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-pcm-media.m4,
-	14, 7, 2, s16le,
+	24, 7, 2, s16le,
 	1000, 0, 0,
 	48000, 48000, 48000,
-	SCHEDULE_TIME_DOMAIN_TIMER,
-	PIPELINE_PLAYBACK_SCHED_COMP_1)
+	0, PIPELINE_PLAYBACK_SCHED_COMP_11)
 
 # Connect pipelines together
 SectionGraph."media-pipeline" {
@@ -163,103 +155,95 @@ SectionGraph."media-pipeline" {
 
 	lines [
 		# media 0
-		dapm(PIPELINE_MIXER_1, PIPELINE_SOURCE_14)
+		dapm(PIPELINE_MIXER_11, PIPELINE_SOURCE_24)
 	]
 }
 
 # capture DAI is SSP0 using 3 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
-	2, SSP, 0, NoCodec-0,
-	PIPELINE_SINK_2, 3, s16le,
+	12, SSP, 0, NoCodec-0,
+	PIPELINE_SINK_12, 3, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is SSP1 using 3 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
-	3, SSP, 1, NoCodec-1,
-	PIPELINE_SOURCE_3, 3, s16le,
-	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+	13, SSP, 1, NoCodec-1,
+	PIPELINE_SOURCE_13, 3, s16le,
+	1000, 0, 0)
 
 # capture DAI is SSP1 using 3 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
-	4, SSP, 1, NoCodec-1,
-	PIPELINE_SINK_4, 3, s16le,
-	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+	14, SSP, 1, NoCodec-1,
+	PIPELINE_SINK_14, 3, s16le,
+	1000, 0, 0)
 
 # playback DAI is SSP2 using 3 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 #DAI_ADD(sof/pipe-dai-playback.m4,
-#	5, SSP, 2, NoCodec-2,
-#	PIPELINE_SOURCE_5, 3, s16le,
-#	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+#	15, SSP, 2, NoCodec-2,
+#	PIPELINE_SOURCE_15, 3, s16le,
+#	1000, 0, 0)
 
 # capture DAI is SSP2 using 3 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 #DAI_ADD(sof/pipe-dai-capture.m4,
-#	6, SSP, 2, NoCodec-2,
-#	PIPELINE_SINK_6, 3, s16le,
-#	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+#	16, SSP, 2, NoCodec-2,
+#	PIPELINE_SINK_16, 3, s16le,
+#	1000, 0, 0)
 
 # playback DAI is SSP3 using 3 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
-	7, SSP, 3, NoCodec-3,
-	PIPELINE_SOURCE_7, 3, s16le,
-	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+	17, SSP, 3, NoCodec-3,
+	PIPELINE_SOURCE_17, 3, s16le,
+	1000, 0, 0)
 
 # capture DAI is SSP3 using 3 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
-	8, SSP, 3, NoCodec-3,
-	PIPELINE_SINK_8, 3, s16le,
-	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+	18, SSP, 3, NoCodec-3,
+	PIPELINE_SINK_18, 3, s16le,
+	1000, 0, 0)
 
 # playback DAI is SSP4 using 3 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 #DAI_ADD(sof/pipe-dai-playback.m4,
-#	9, SSP, 4, NoCodec-4,
-#	PIPELINE_SOURCE_9, 3, s16le,
-#	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+#	19, SSP, 4, NoCodec-4,
+#	PIPELINE_SOURCE_19, 3, s16le,
+#	1000, 0, 0)
 
 # capture DAI is SSP4 using 3 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 #DAI_ADD(sof/pipe-dai-capture.m4,
-#	10, SSP, 4, NoCodec-4,
-#	PIPELINE_SINK_10, 3, s16le,
-#	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+#	20, SSP, 4, NoCodec-4,
+#	PIPELINE_SINK_20, 3, s16le,
+#	1000, 0, 0)
 
 # playback DAI is SSP5 using 3 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
-	11, SSP, 5, NoCodec-5,
-	PIPELINE_SOURCE_11, 3, s16le,
-	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+	21, SSP, 5, NoCodec-5,
+	PIPELINE_SOURCE_21, 3, s16le,
+	1000, 0, 0)
 
 # capture DAI is SSP5 using 3 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
-	12, SSP, 5, NoCodec-5,
-	PIPELINE_SINK_12, 3, s16le,
-	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
-
-# capture DAI is DMIC 0 using 3 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
-DAI_ADD(sof/pipe-dai-capture.m4,
-	13, DMIC, 0, NoCodec-6,
-	PIPELINE_SINK_13, 3, s32le,
-	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+	22, SSP, 5, NoCodec-5,
+	PIPELINE_SINK_22, 3, s16le,
+	1000, 0, 0)
 
 dnl PCM_DUPLEX_ADD(name, pcm_id, playback, capture)
-PCM_DUPLEX_ADD(Port0, 0, PIPELINE_PCM_1, PIPELINE_PCM_2)
-PCM_DUPLEX_ADD(Port1, 1, PIPELINE_PCM_3, PIPELINE_PCM_4)
-#PCM_DUPLEX_ADD(Port2, 2, PIPELINE_PCM_5, PIPELINE_PCM_6)
-PCM_DUPLEX_ADD(Port3, 3, PIPELINE_PCM_7, PIPELINE_PCM_8)
-#PCM_DUPLEX_ADD(Port4, 4, PIPELINE_PCM_9, PIPELINE_PCM_10)
-PCM_DUPLEX_ADD(Port5, 5, PIPELINE_PCM_11, PIPELINE_PCM_12)
+PCM_DUPLEX_ADD(Port0, 0, PIPELINE_PCM_11, PIPELINE_PCM_12)
+PCM_DUPLEX_ADD(Port1, 1, PIPELINE_PCM_13, PIPELINE_PCM_14)
+#PCM_DUPLEX_ADD(Port2, 2, PIPELINE_PCM_15, PIPELINE_PCM_16)
+PCM_DUPLEX_ADD(Port3, 3, PIPELINE_PCM_17, PIPELINE_PCM_18)
+#PCM_DUPLEX_ADD(Port4, 4, PIPELINE_PCM_19, PIPELINE_PCM_20)
+PCM_DUPLEX_ADD(Port5, 5, PIPELINE_PCM_21, PIPELINE_PCM_22)
 dnl PCM_CAPTURE_ADD(name, pipeline, capture)
-PCM_CAPTURE_ADD(DMIC01, 6, PIPELINE_PCM_13)
 
 #
 # BE configurations - overrides config in ACPI if present
@@ -309,14 +293,3 @@ DAI_CONFIG(SSP, 5, 5, NoCodec-5,
 		      SSP_CLOCK(fsync, 48000, codec_slave),
 		      SSP_TDM(2, 16, 3, 3),
 		      SSP_CONFIG_DATA(SSP, 5, 16, 0, SSP_QUIRK_LBM)))
-
-DAI_CONFIG(DMIC, 0, 6, NoCodec-6,
-	   dnl DMIC_CONFIG(driver_version, clk_min, clk_mac, duty_min, duty_max,
-	   dnl		   sample_rate, fifo word length, unmute time, type,
-	   dnl		   dai_index, pdm controller config)
-	   DMIC_CONFIG(1, 500000, 4800000, 40, 60, 48000,
-		DMIC_WORD_LENGTH(s32le), 400, DMIC, 0,
-		dnl PDM_CONFIG(type, dai_index, num pdm active, pdm tuples list)
-		dnl STEREO_PDM0 is a pre-defined pdm config for stereo capture
-		PDM_CONFIG(DMIC, 0, STEREO_PDM0)))
-

--- a/tools/topology/sof-apl-pcm512x.m4
+++ b/tools/topology/sof-apl-pcm512x.m4
@@ -1,5 +1,5 @@
 #
-# Topology for generic Apollolake UP^2 with pcm512x codec and HDMI.
+# Topology for generic Apollolake UP^2 with pcm512x codec
 #
 
 # Include topology builder
@@ -23,9 +23,6 @@ DEBUG_START
 # Define the pipelines
 #
 # PCM0 ----> volume -----> SSP5 (pcm512x)
-# PCM1 ----> volume -----> iDisp1
-# PCM2 ----> volume -----> iDisp2
-# PCM3 ----> volume -----> iDisp3
 #
 
 dnl PIPELINE_PCM_DAI_ADD(pipeline,
@@ -40,33 +37,6 @@ dnl     pipeline_rate, time_domain)
 PIPELINE_PCM_DAI_ADD(sof/pipe-low-latency-playback.m4,
 	1, 0, 2, s32le,
 	1000, 0, 0, SSP, 5, s24le, 3,
-	48000, 48000, 48000)
-
-dnl PIPELINE_PCM_ADD(pipeline,
-dnl     pipe id, pcm, max channels, format,
-dnl     period, priority, core,
-dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
-dnl     time_domain, sched_comp)
-
-# Low Latency playback pipeline 2 on PCM 1 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
-	2, 1, 2, s32le,
-	1000, 0, 0,
-	48000, 48000, 48000)
-
-# Low Latency playback pipeline 3 on PCM 2 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
-	3, 2, 2, s32le,
-	1000, 0, 0,
-	48000, 48000, 48000)
-
-# Low Latency playback pipeline 4 on PCM 3 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
-	4, 3, 2, s32le,
-	1000, 0, 0,
 	48000, 48000, 48000)
 
 #
@@ -103,33 +73,9 @@ SectionGraph."media-pipeline" {
 	]
 }
 
-# playback DAI is iDisp1 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
-DAI_ADD(sof/pipe-dai-playback.m4,
-	2, HDA, 0, iDisp1,
-	PIPELINE_SOURCE_2, 2, s32le,
-	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
-
-# playback DAI is iDisp2 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
-DAI_ADD(sof/pipe-dai-playback.m4,
-	3, HDA, 1, iDisp2,
-	PIPELINE_SOURCE_3, 2, s32le,
-	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
-
-# playback DAI is iDisp3 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
-DAI_ADD(sof/pipe-dai-playback.m4,
-	4, HDA, 2, iDisp3,
-	PIPELINE_SOURCE_4, 2, s32le,
-	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
-
 # PCM Low Latency, id 0
 dnl PCM_PLAYBACK_ADD(name, pcm_id, playback)
 PCM_PLAYBACK_ADD(Port5, 0, PIPELINE_PCM_1)
-PCM_PLAYBACK_ADD(HDMI1, 1, PIPELINE_PCM_2)
-PCM_PLAYBACK_ADD(HDMI2, 2, PIPELINE_PCM_3)
-PCM_PLAYBACK_ADD(HDMI3, 3, PIPELINE_PCM_4)
 
 #
 # BE configurations - overrides config in ACPI if present
@@ -142,10 +88,5 @@ DAI_CONFIG(SSP, 5, 0, SSP5-Codec,
 		SSP_CLOCK(fsync, 48000, codec_slave),
 		SSP_TDM(2, 32, 3, 3),
 		SSP_CONFIG_DATA(SSP, 5, 24)))
-
-# 3 HDMI/DP outputs (ID: 1,2,3)
-DAI_CONFIG(HDA, 0, 1, iDisp1)
-DAI_CONFIG(HDA, 1, 2, iDisp2)
-DAI_CONFIG(HDA, 2, 3, iDisp3)
 
 DEBUG_END

--- a/tools/topology/sof-dmic-generic.m4
+++ b/tools/topology/sof-dmic-generic.m4
@@ -1,0 +1,97 @@
+#
+# Topology for SKL+ HDA Generic machine w/ iDISP codec only
+#
+
+# Include topology builder
+include(`utils.m4')
+include(`dai.m4')
+include(`pipeline.m4')
+
+# Include TLV library
+include(`common/tlv.m4')
+
+# Include Token library
+include(`sof/tokens.m4')
+
+# Include bxt DSP configuration
+include(`platform/intel/bxt.m4')
+
+include(`platform/intel/dmic.m4')
+
+#
+# Define the pipelines
+#
+
+dnl PIPELINE_PCM_DAI_ADD(pipeline,
+dnl     pipe id, pcm, max channels, format,
+dnl     period, priority, core,
+dnl     dai type, dai_index, dai format,
+dnl     dai periods, pcm_min_rate, pcm_max_rate,
+dnl     pipeline_rate, time_domain)
+
+# Passthrough capture pipeline using max channels defined by CHANNELS.
+
+# Set 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_DAI_ADD(sof/pipe-eq-capture.m4,
+	5, 0, CHANNELS, s32le,
+	1000, 0, 0, DMIC, 0, s32le, 3, 48000, 48000, 48000)
+
+# Passthrough capture pipeline using max channels defined by CHANNELS.
+
+# Schedule with 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_DAI_ADD(sof/pipe-eq-capture-16khz.m4,
+	6, 1, CHANNELS, s32le,
+	1000, 0, 0, DMIC, 1, s32le, 3, 16000, 16000, 16000)
+
+#
+# DAIs configuration
+#
+
+dnl DAI_ADD(pipeline,
+dnl     pipe id, dai type, dai_index, dai_be,
+dnl     buffer, periods, format,
+dnl     deadline, priority, core, time_domain)
+
+# capture DAI is DMIC 0 using 3 periods
+# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-capture.m4,
+	5, DMIC, 0, DMIC-0,
+	PIPELINE_SINK_5, 3, s32le,
+	1000, 0, 0, 48000, 48000, 48000)
+
+# capture DAI is DMIC 1 using 3 periods
+# Buffers use s32le format, with 16 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-capture.m4,
+	6, DMIC, 1, DMIC-1,
+	PIPELINE_SINK_6, 3, s32le,
+	1000, 0, 0, 16000, 16000, 16000)
+
+dnl PCM_DUPLEX_ADD(name, pcm_id, playback, capture)
+dnl PCM_CAPTURE_ADD(name, pipeline, capture)
+PCM_CAPTURE_ADD(DMIC48kHz, 0, PIPELINE_PCM_5)
+PCM_CAPTURE_ADD(DMIC16kHz, 1, PIPELINE_PCM_6)
+
+#
+# BE configurations - overrides config in ACPI if present
+#
+
+dnl DAI_CONFIG(type, dai_index, link_id, name, ssp_config/dmic_config)
+ifelse(CHANNELS, 4,
+`DAI_CONFIG(DMIC, 0, 0, DMIC-0,
+	   DMIC_CONFIG(1, 500000, 4800000, 40, 60, 48000,
+		DMIC_WORD_LENGTH(s32le), 200, DMIC, 0,
+		PDM_CONFIG(DMIC, 0, FOUR_CH_PDM0_PDM1)))',
+`DAI_CONFIG(DMIC, 0, 0, DMIC-0,
+           DMIC_CONFIG(1, 500000, 4800000, 40, 60, 48000,
+                DMIC_WORD_LENGTH(s32le), 200, DMIC, 0,
+                PDM_CONFIG(DMIC, 0, STEREO_PDM0)))')
+
+ifelse(CHANNELS, 4,
+`DAI_CONFIG(DMIC, 1, 1, DMIC-1,
+	   DMIC_CONFIG(1, 500000, 4800000, 40, 60, 16000,
+		DMIC_WORD_LENGTH(s32le), 400, DMIC, 1,
+		PDM_CONFIG(DMIC, 1, FOUR_CH_PDM0_PDM1)))',
+`DAI_CONFIG(DMIC, 1, 1, DMIC-1,
+           DMIC_CONFIG(1, 500000, 4800000, 40, 60, 16000,
+                DMIC_WORD_LENGTH(s32le), 400, DMIC, 1,
+                PDM_CONFIG(DMIC, 1, STEREO_PDM0)))')

--- a/tools/topology/sof-glk-da7219.m4
+++ b/tools/topology/sof-glk-da7219.m4
@@ -16,17 +16,12 @@ include(`sof/tokens.m4')
 
 # Include bxt DSP configuration
 include(`platform/intel/bxt.m4')
-include(`platform/intel/dmic.m4')
 
 #
 # Define the pipelines
 #
 # PCM0  ----> volume (pipe 1)   -----> SSP1 (speaker - maxim98357a, BE link 0)
 # PCM1  <---> volume (pipe 2,3) <----> SSP2 (headset - da7219, BE link 1)
-# PCM99 <---- DMIC0 (dmic capture, BE link 2)
-# PCM5  ----> volume (pipe 5)   -----> iDisp1 (HDMI/DP playback, BE link 3)
-# PCM6  ----> Volume (pipe 6)   -----> iDisp2 (HDMI/DP playback, BE link 4)
-# PCM7  ----> volume (pipe 7)   -----> iDisp3 (HDMI/DP playback, BE link 5)
 #
 
 dnl PIPELINE_PCM_DAI_ADD(pipeline,
@@ -55,44 +50,6 @@ PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
 PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
 	3, 1, 2, s32le,
 	1000, 0, 0, SSP, 2, s16le, 3,
-	48000, 48000, 48000)
-
-# Low Latency capture pipeline 4 on PCM 99 using max 4 channels of s32le.
-# 1000us deadline on core 0 with priority 0
-#PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
-PIPELINE_PCM_DAI_ADD(sof/pipe-passthrough-capture.m4,
-	4, 99, 4, s16le,
-	1000, 0, 0, DMIC, 0, s16le, 3,
-	48000, 48000, 48000)
-
-dnl PIPELINE_PCM_ADD(pipeline,
-dnl     pipe id, pcm, max channels, format,
-dnl     period, priority, core,
-dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
-dnl     time_domain, sched_comp)
-
-# Low Latency playback pipeline 5 on PCM 5 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
-# PIPELINE_PCM_ADD(sof/pipe-passthrough-playback.m4,
-PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
-        5, 5, 2, s32le,
-        1000, 0, 0,
-	48000, 48000, 48000)
-
-# Low Latency playback pipeline 6 on PCM 6 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
-# PIPELINE_PCM_ADD(sof/pipe-passthrough-playback.m4,
-PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
-        6, 6, 2, s32le,
-        1000, 0, 0,
-	48000, 48000, 48000)
-
-# Low Latency playback pipeline 7 on PCM 7 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
-# PIPELINE_PCM_ADD(sof/pipe-passthrough-playback.m4,
-PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
-        7, 7, 2, s32le,
-        1000, 0, 0,
 	48000, 48000, 48000)
 
 #
@@ -125,40 +82,8 @@ DAI_ADD(sof/pipe-dai-capture.m4,
 	PIPELINE_SINK_3, 3, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is DMIC0 using 3 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
-DAI_ADD(sof/pipe-dai-capture.m4,
-	4, DMIC, 0, dmic01,
-	PIPELINE_SINK_4, 3, s16le,
-	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
-
-# playback DAI is iDisp1 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
-DAI_ADD(sof/pipe-dai-playback.m4,
-        5, HDA, 3, iDisp1,
-        PIPELINE_SOURCE_5, 2, s32le,
-        1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
-
-# playback DAI is iDisp2 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
-DAI_ADD(sof/pipe-dai-playback.m4,
-        6, HDA, 4, iDisp2,
-        PIPELINE_SOURCE_6, 2, s32le,
-        1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
-
-# playback DAI is iDisp3 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
-DAI_ADD(sof/pipe-dai-playback.m4,
-        7, HDA, 5, iDisp3,
-        PIPELINE_SOURCE_7, 2, s32le,
-        1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
-
 PCM_PLAYBACK_ADD(Speakers, 0, PIPELINE_PCM_1)
 PCM_DUPLEX_ADD(Headset, 1, PIPELINE_PCM_2, PIPELINE_PCM_3)
-PCM_CAPTURE_ADD(DMIC01, 99, PIPELINE_PCM_4)
-PCM_PLAYBACK_ADD(HDMI1, 5, PIPELINE_PCM_5)
-PCM_PLAYBACK_ADD(HDMI2, 6, PIPELINE_PCM_6)
-PCM_PLAYBACK_ADD(HDMI3, 7, PIPELINE_PCM_7)
 
 #
 # BE configurations - overrides config in ACPI if present
@@ -179,17 +104,6 @@ DAI_CONFIG(SSP, 2, 1, SSP2-Codec,
 		SSP_CLOCK(fsync, 48000, codec_slave),
 		SSP_TDM(2, 20, 3, 3),
 		SSP_CONFIG_DATA(SSP, 2, 16, 1)))
-
-# dmic01 (id: 2)
-DAI_CONFIG(DMIC, 0, 2, dmic01,
-	DMIC_CONFIG(1, 500000, 4800000, 40, 60, 48000,
-		DMIC_WORD_LENGTH(s16le), 400, DMIC, 0,
-		PDM_CONFIG(DMIC, 0, FOUR_CH_PDM0_PDM1)))
-
-# 3 HDMI/DP outputs (ID: 3,4,5)
-DAI_CONFIG(HDA, 3, 3, iDisp1)
-DAI_CONFIG(HDA, 4, 4, iDisp2)
-DAI_CONFIG(HDA, 5, 5, iDisp3)
 
 ## remove warnings with SST hard-coded routes
 

--- a/tools/topology/sof-hda-generic-idisp.m4
+++ b/tools/topology/sof-hda-generic-idisp.m4
@@ -16,18 +16,6 @@ include(`sof/tokens.m4')
 # Include bxt DSP configuration
 include(`platform/intel/bxt.m4')
 
-# Define pipeline id for intel-generic-dmic.m4
-# to generate dmic setting
-
-ifelse(CHANNELS, `0', ,
-`
-define(DMIC_PIPELINE_48k_ID, `5')
-define(DMIC_PIPELINE_16k_ID, `6')
-
-include(`platform/intel/intel-generic-dmic.m4')
-'
-)
-
 #
 # Define the pipelines
 #
@@ -45,21 +33,21 @@ dnl     time_domain, sched_comp)
 # Low Latency playback pipeline 2 on PCM 1 using max 2 channels of s32le.
 # Set 1000us deadline on core 0 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
-	2, 1, 2, s32le,
+	7, 1, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 3 on PCM 2 using max 2 channels of s32le.
 # Set 1000us deadline on core 0 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
-	3, 2, 2, s32le,
+	8, 2, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 4 on PCM 3 using max 2 channels of s32le.
 # Set 1000us deadline on core 0 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
-	4, 3, 2, s32le,
+	9, 3, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
@@ -75,29 +63,29 @@ dnl     deadline, priority, core)
 # playback DAI is iDisp1 using 2 periods
 # Buffers use s32le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
-	2, HDA, 0, iDisp1,
-	PIPELINE_SOURCE_2, 2, s32le,
+	7, HDA, 0, iDisp1,
+	PIPELINE_SOURCE_7, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp2 using 2 periods
 # Buffers use s32le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
-	3, HDA, 1, iDisp2,
-	PIPELINE_SOURCE_3, 2, s32le,
+	8, HDA, 1, iDisp2,
+	PIPELINE_SOURCE_8, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp3 using 2 periods
 # Buffers use s32le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
-	4, HDA, 2, iDisp3,
-	PIPELINE_SOURCE_4, 2, s32le,
+	9, HDA, 2, iDisp3,
+	PIPELINE_SOURCE_9, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # PCM Low Latency, id 0
 dnl PCM_PLAYBACK_ADD(name, pcm_id, playback)
-PCM_PLAYBACK_ADD(HDMI1, 1, PIPELINE_PCM_2)
-PCM_PLAYBACK_ADD(HDMI2, 2, PIPELINE_PCM_3)
-PCM_PLAYBACK_ADD(HDMI3, 3, PIPELINE_PCM_4)
+PCM_PLAYBACK_ADD(HDMI1, 1, PIPELINE_PCM_7)
+PCM_PLAYBACK_ADD(HDMI2, 2, PIPELINE_PCM_8)
+PCM_PLAYBACK_ADD(HDMI3, 3, PIPELINE_PCM_9)
 
 #
 # BE configurations - overrides config in ACPI if present

--- a/tools/topology/sof-hda-generic.m4
+++ b/tools/topology/sof-hda-generic.m4
@@ -15,18 +15,6 @@ include(`sof/tokens.m4')
 # Include bxt DSP configuration
 include(`platform/intel/bxt.m4')
 
-# Define pipeline id for intel-generic-dmic.m4
-# to generate dmic setting
-
-ifelse(CHANNELS, `0', ,
-`
-define(DMIC_PIPELINE_48k_ID, `10')
-define(DMIC_PIPELINE_16k_ID, `11')
-
-include(`platform/intel/intel-generic-dmic.m4')
-'
-)
-
 #
 # Define the pipelines
 #


### PR DESCRIPTION
Remove the HDMI pipelines from the topology. These will be added when the iDisp topology is loaded.

This change is to test the linux PR https://github.com/thesofproject/linux/pull/1200 which separates the SSP audio and iDisp audio into separate clients. 