### PR TITLE
Topic/imx/sai topology

### DIFF
--- a/src/include/ipc/dai-imx.h
+++ b/src/include/ipc/dai-imx.h
@@ -30,4 +30,22 @@ struct sof_ipc_dai_esai_params {
 
 } __attribute__((packed));
 
+/* SAI Configuration Request - SOF_IPC_DAI_SAI_CONFIG */
+struct sof_ipc_dai_sai_params {
+	struct sof_ipc_hdr hdr;
+
+	/* MCLK */
+	uint16_t reserved1;
+	uint16_t mclk_id;
+	uint32_t mclk_rate; /* MCLK frequency in Hz */
+	uint32_t mclk_direction;
+
+	/* TDM */
+	uint32_t tdm_slots;
+	uint32_t rx_slots;
+	uint32_t tx_slots;
+	uint16_t tdm_slot_width;
+	uint16_t reserved2;	/* alignment */
+
+} __attribute__((packed));
 #endif /* __IPC_DAI_IMX_H__ */

--- a/src/include/ipc/dai.h
+++ b/src/include/ipc/dai.h
@@ -83,6 +83,7 @@ struct sof_ipc_dai_config {
 		struct sof_ipc_dai_hda_params hda;
 		struct sof_ipc_dai_alh_params alh;
 		struct sof_ipc_dai_esai_params esai;
+		struct sof_ipc_dai_sai_params sai;
 	};
 } __attribute__((packed));
 

--- a/src/include/kernel/tokens.h
+++ b/src/include/kernel/tokens.h
@@ -103,6 +103,9 @@
 /* for backward compatibility */
 #define SOF_TKN_EFFECT_TYPE	SOF_TKN_PROCESS_TYPE
 
+/* SAI */
+#define SOF_TKN_IMX_SAI_MCLK_ID			1000
+
 /* ESAI */
 #define SOF_TKN_IMX_ESAI_MCLK_ID		1100
 

--- a/tools/topology/CMakeLists.txt
+++ b/tools/topology/CMakeLists.txt
@@ -88,6 +88,7 @@ set(TPLGS
 	"sof-imx8qxp-nocodec\;sof-imx8qxp-nocodec"
 	"sof-imx8qxp-cs42888\;sof-imx8qxp-cs42888"
 	"sof-imx8qxp-nocodec-sai\;sof-imx8qxp-nocodec-sai"
+	"sof-imx8qxp-wm8960\;sof-imx8qxp-wm8960"
 )
 
 add_custom_target(topologies ALL)

--- a/tools/topology/CMakeLists.txt
+++ b/tools/topology/CMakeLists.txt
@@ -87,6 +87,7 @@ set(TPLGS
 	"sof-tgl-rt711-rt1308\;sof-tgl-rt711-rt1308-nohdmi"
 	"sof-imx8qxp-nocodec\;sof-imx8qxp-nocodec"
 	"sof-imx8qxp-cs42888\;sof-imx8qxp-cs42888"
+	"sof-imx8qxp-nocodec-sai\;sof-imx8qxp-nocodec-sai"
 )
 
 add_custom_target(topologies ALL)

--- a/tools/topology/m4/dai.m4
+++ b/tools/topology/m4/dai.m4
@@ -125,13 +125,13 @@ define(`D_DAI', `SectionDAI."'N_DAI`" {'
 
 dnl DAI Config)
 define(`N_DAI_CONFIG', `DAICONFIG.'$1)
-dnl DAI_CONFIG(type, idx, link_id, name, esai_config/ssp_config/dmic_config)
+dnl DAI_CONFIG(type, idx, link_id, name, sai_config/esai_config/ssp_config/dmic_config)
 define(`DO_DAI_CONFIG',
 `SectionHWConfig."'$1$2`" {'
 `'
 `	id		"'$3`"'
 `'
-`	ifelse($1, `SSP', $5, $1, `ESAI', $5, `}')'
+`	ifelse($1, `SSP', $5, $1, `ESAI', $5, $1, `SAI', $5, `}')'
 `ifelse($1, `DMIC', $5, `')'
 `SectionVendorTuples."'N_DAI_CONFIG($1$2)`_tuples_common" {'
 `	tokens "sof_dai_tokens"'

--- a/tools/topology/platform/common/sai.m4
+++ b/tools/topology/platform/common/sai.m4
@@ -1,0 +1,45 @@
+divert(-1)
+
+dnl SAI related macros
+
+dnl SAI_CLOCK(clock, freq, codec_master, polarity)
+dnl polarity is optional
+define(`SAI_CLOCK',
+	$1		STR($3)
+	$1_freq		STR($2))
+	`ifelse($4, `inverted', `$1_invert	"true"',`')')
+
+dnl SAI_TDM(slots, width, tx_mask, rx_mask)
+define(`SAI_TDM',
+`	tdm_slots	'STR($1)
+`	tdm_slot_width	'STR($2)
+`	tx_slots	'STR($3)
+`	rx_slots	'STR($4)
+)
+
+dnl SAI_CONFIG(format, mclk, bclk, fsync, tdm, sai_config_data)
+define(`SAI_CONFIG',
+`	format		"'$1`"'
+`	'$2
+`	'$3
+`	'$4
+`	'$5
+`}'
+$6
+)
+
+dnl SAI_CONFIG_DATA(type, idx, mclk_id)
+dnl mclk_id is optional
+define(`SAI_CONFIG_DATA',
+`SectionVendorTuples."'N_DAI_CONFIG($1$2)`_tuples" {'
+`	tokens "sof_sai_tokens"'
+`	tuples."short" {'
+`		SOF_TKN_IMX_SAI_MCLK_ID'	ifelse($3, `', "0", STR($3))
+`	}'
+`}'
+`SectionData."'N_DAI_CONFIG($1$2)`_data" {'
+`	tuples "'N_DAI_CONFIG($1$2)`_tuples"'
+`}'
+)
+
+divert(0)dnl

--- a/tools/topology/sof-imx8qxp-nocodec-sai.m4
+++ b/tools/topology/sof-imx8qxp-nocodec-sai.m4
@@ -1,0 +1,68 @@
+#
+# Topology for i.MX8QXP board with nocodec
+#
+
+# Include topology builder
+include(`utils.m4')
+include(`dai.m4')
+include(`pipeline.m4')
+include(`sai.m4')
+include(`pcm.m4')
+include(`buffer.m4')
+
+# Include TLV library
+include(`common/tlv.m4')
+
+# Include Token library
+include(`sof/tokens.m4')
+
+# Include DSP configuration
+include(`platform/imx/imx8qxp.m4')
+
+#
+# Define the pipelines
+#
+# PCM0 ---> Volume ---> SAI1 (NoCodec)
+#
+
+dnl PIPELINE_PCM_ADD(pipeline,
+dnl     pipe id, pcm, max channels, format,
+dnl     period, priority, core,
+dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
+dnl     time_domain, sched_comp)
+
+# Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s24le
+# Set 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	1, 0, 2, s24le,
+	1000, 0, 0,
+	8000, 96000, 48000)
+
+#
+# DAIs configuration
+#
+
+dnl DAI_ADD(pipeline,
+dnl     pipe id, dai type, dai_index, dai_be,
+dnl     buffer, periods, format,
+dnl     deadline, priority, core)
+
+# playback DAI is SAI1 using 2 periods
+# Buffers use s24le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+	1, SAI, 1, NoCodec-0,
+	PIPELINE_SOURCE_1, 2, s24le,
+	1000, 0, 0)
+
+dnl PCM_PLAYBACK_ADD(name, pcm_id, playback)
+
+# PCM Low Latency, id 0
+PCM_PLAYBACK_ADD(Port0, 0, PIPELINE_PCM_1)
+
+dnl DAI_CONFIG(type, dai_index, link_id, name, sai_config)
+DAI_CONFIG(SAI, 1, 0, NoCodec-0,
+	SAI_CONFIG(I2S, SAI_CLOCK(mclk, 49152000, codec_mclk_in),
+		SAI_CLOCK(bclk, 3072000, codec_slave),
+		SAI_CLOCK(fsync, 48000, codec_slave),
+		SAI_TDM(2, 32, 3, 3),
+		SAI_CONFIG_DATA(SAI, 1, 0)))

--- a/tools/topology/sof-imx8qxp-wm8960.m4
+++ b/tools/topology/sof-imx8qxp-wm8960.m4
@@ -1,0 +1,68 @@
+#
+# Topology for i.MX8QXP board with wm8960 codec
+#
+
+# Include topology builder
+include(`utils.m4')
+include(`dai.m4')
+include(`pipeline.m4')
+include(`sai.m4')
+include(`pcm.m4')
+include(`buffer.m4')
+
+# Include TLV library
+include(`common/tlv.m4')
+
+# Include Token library
+include(`sof/tokens.m4')
+
+# Include DSP configuration
+include(`platform/imx/imx8qxp.m4')
+
+#
+# Define the pipelines
+#
+# PCM0 ----> volume -----> SAI1 (wm8960)
+#
+
+dnl PIPELINE_PCM_ADD(pipeline,
+dnl     pipe id, pcm, max channels, format,
+dnl     period, priority, core,
+dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
+dnl     time_domain, sched_comp)
+
+# Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s24le.
+# Set 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	1, 0, 2, s24le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+#
+# DAIs configuration
+#
+
+dnl DAI_ADD(pipeline,
+dnl     pipe id, dai type, dai_index, dai_be,
+dnl     buffer, periods, format,
+dnl     period, priority, core, time_domain)
+
+# playback DAI is SAI1 using 2 periods
+# Buffers use s24le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+	1, SAI, 1, SAI1-Codec,
+	PIPELINE_SOURCE_1, 2, s24le,
+	1000, 0, 0)
+
+# PCM Low Latency, id 0
+
+dnl PCM_PLAYBACK_ADD(name, pcm_id, playback)
+PCM_PLAYBACK_ADD(Port0, 0, PIPELINE_PCM_1)
+
+dnl DAI_CONFIG(type, idx, link_id, name, sai_config)
+DAI_CONFIG(SAI, 1, 0, SAI1-Codec,
+	SAI_CONFIG(I2S, SAI_CLOCK(mclk, 49152000, codec_mclk_in),
+		SAI_CLOCK(bclk, 3072000, codec_slave),
+		SAI_CLOCK(fsync, 48000, codec_slave),
+		SAI_TDM(2, 32, 3, 3),
+		SAI_CONFIG_DATA(SAI, 1, 0)))

--- a/tools/topology/sof/tokens.m4
+++ b/tools/topology/sof/tokens.m4
@@ -93,6 +93,10 @@ SectionVendorTokens."sof_process_tokens" {
 	SOF_TKN_PROCESS_TYPE			"900"
 }
 
+SectionVendorTokens."sof_sai_tokens" {
+	SOF_TKN_IMX_SAI_MCLK_ID			"1000"
+}
+
 SectionVendorTokens."sof_esai_tokens" {
 	SOF_TKN_IMX_ESAI_MCLK_ID		"1100"
 }


### PR DESCRIPTION
This small patch set adds SAI topologies both with wm8960 codec and no-codec
It adds a SAI parameter that for now looks like the ESAI but in a near future it will evolve independently
There is a parallel kernel patch that introduces SAI params 
