### PR TITLE
notifier: Extend capabilities of notifier to serve as event hub for all callback types

### DIFF
--- a/src/arch/host/CMakeLists.txt
+++ b/src/arch/host/CMakeLists.txt
@@ -6,3 +6,5 @@ target_include_directories(sof_public_headers INTERFACE ${PROJECT_SOURCE_DIR}/sr
 
 # C & ASM flags
 target_compile_options(sof_options INTERFACE -g -O3 -Wall -Werror -Wl,-EL -Wmissing-prototypes -Wimplicit-fallthrough=3 -Wpointer-arith)
+
+add_subdirectory(lib)

--- a/src/arch/host/lib/CMakeLists.txt
+++ b/src/arch/host/lib/CMakeLists.txt
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+add_local_sources(sof notifier.c)

--- a/src/arch/host/lib/notifier.c
+++ b/src/arch/host/lib/notifier.c
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2019 Intel Corporation. All rights reserved.
+//
+// Author: Artur Kloniecki <arturx.kloniecki@linux.intel.com>
+
+/**
+ * \file arch/host/lib/notifier.c
+ * \brief Host notifier implementation file
+ * \authors Artur Kloniecki <arturx.kloniecki@linux.intel.com>
+ */
+
+#include <ipc/topology.h>
+#include <sof/lib/alloc.h>
+#include <sof/lib/notifier.h>
+
+static struct notify *host_notify;
+
+struct notify **arch_notify_get(void)
+{
+	if (!host_notify)
+		host_notify = rzalloc(RZONE_SYS, SOF_MEM_CAPS_RAM,
+				      sizeof(*host_notify));
+	return &host_notify;
+}

--- a/src/audio/buffer.c
+++ b/src/audio/buffer.c
@@ -115,8 +115,7 @@ void buffer_free(struct comp_buffer *buffer)
 	trace_buffer("buffer_free()");
 
 	notifier_event(buffer, NOTIFIER_ID_BUFFER_FREE,
-		       NOTIFIER_TARGET_CORE_LOCAL, &cb_data,
-		       sizeof(cb_data));
+		       NOTIFIER_TARGET_CORE_LOCAL, &cb_data, sizeof(cb_data));
 
 	/* In case some listeners didn't unregister from buffer's callbacks */
 	notifier_unregister_all(NULL, buffer);

--- a/src/audio/buffer.c
+++ b/src/audio/buffer.c
@@ -108,7 +108,18 @@ int buffer_set_size(struct comp_buffer *buffer, uint32_t size)
 /* free component in the pipeline */
 void buffer_free(struct comp_buffer *buffer)
 {
+	struct buffer_cb_free cb_data = {
+		.buffer = buffer,
+	};
+
 	trace_buffer("buffer_free()");
+
+	notifier_event(buffer, NOTIFIER_ID_BUFFER_FREE,
+		       NOTIFIER_TARGET_CORE_LOCAL, &cb_data,
+		       sizeof(cb_data));
+
+	/* In case some listeners didn't unregister from buffer's callbacks */
+	notifier_unregister_all(NULL, buffer);
 
 	list_item_del(&buffer->source_list);
 	list_item_del(&buffer->sink_list);

--- a/src/audio/detect_test.c
+++ b/src/audio/detect_test.c
@@ -81,8 +81,6 @@ struct comp_data {
 	uint32_t history_depth; /** defines draining size in bytes. */
 
 	uint16_t sample_valid_bytes;
-
-	struct notify_data event;
 	struct kpb_event_data event_data;
 	struct kpb_client client_data;
 
@@ -146,11 +144,9 @@ static void notify_kpb(struct comp_dev *dev)
 	cd->event_data.event_id = KPB_EVENT_BEGIN_DRAINING;
 	cd->event_data.client_data = &cd->client_data;
 
-	cd->event.id = NOTIFIER_ID_KPB_CLIENT_EVT;
-	cd->event.target_core_mask = NOTIFIER_TARGET_CORE_ALL_MASK;
-	cd->event.data = &cd->event_data;
-
-	notifier_event(&cd->event);
+	notifier_event(dev, NOTIFIER_ID_KPB_CLIENT_EVT,
+		       NOTIFIER_TARGET_CORE_ALL_MASK, &cd->event_data,
+		       sizeof(cd->event_data));
 }
 
 static void detect_test_notify(struct comp_dev *dev)

--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -761,9 +761,11 @@ static int dw_dma_pm_context_store(struct dma *dma)
 }
 
 #if !CONFIG_HW_LLI
-/* reload using LLI data */
-static inline void dw_dma_chan_reload_lli(struct dma_chan_data *channel)
+/* reload using LLI data from DMA IRQ cb */
+static inline void dw_dma_chan_reload_lli_cb(void *arg, enum notify_id type,
+					     void *data)
 {
+	struct dma_chan_data *channel = data;
 	struct dma *dma = channel->dma;
 	struct dw_dma_chan_data *dw_chan = dma_chan_get_data(channel);
 	struct dw_lli *lli = dw_chan->lli_current;
@@ -967,7 +969,8 @@ static int dw_dma_probe(struct dma *dma)
 		chan->index = i;
 		chan->core = DMA_CORE_INVALID;
 #if !CONFIG_HW_LLI
-		chan->irq_callback = dw_dma_chan_reload_lli;
+		notifier_register(chan, chan, NOTIFIER_ID_DMA_IRQ,
+				  dw_dma_chan_reload_lli_cb);
 #endif
 
 		dw_chan = rzalloc(RZONE_SYS_RUNTIME | RZONE_FLAG_UNCACHED,

--- a/src/drivers/intel/cavs/idc.c
+++ b/src/drivers/intel/cavs/idc.c
@@ -260,7 +260,7 @@ static void idc_cmd(struct idc_msg *msg)
 		idc_component_command(msg->extension);
 		break;
 	case iTS(IDC_MSG_NOTIFY):
-		notifier_notify();
+		notifier_notify_remote();
 		break;
 	default:
 		trace_idc_error("idc_cmd() error: invalid msg->header = %u",

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -68,17 +68,18 @@ struct comp_buffer {
 	struct list_item source_list;	/* list in comp buffers */
 	struct list_item sink_list;	/* list in comp buffers */
 
-	/* callbacks */
-	void (*cb)(void *data, uint32_t bytes);
-	void *cb_data;
-	int cb_type;
-
 	/* runtime stream params */
 	uint32_t frame_fmt;	/**< enum sof_ipc_frame */
 	uint32_t buffer_fmt;	/**< enum sof_ipc_buffer_format */
 	uint32_t rate;
 	uint16_t channels;
 	uint16_t chmap[SOF_IPC_MAX_CHANNELS];	/**< channel map - SOF_CHMAP_ */
+};
+
+struct buffer_cb_transact {
+	struct comp_buffer *buffer;
+	uint32_t transaction_amount;
+	void *transaction_begin_address;
 };
 
 #define buffer_comp_list(buffer, dir) \

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -82,6 +82,10 @@ struct buffer_cb_transact {
 	void *transaction_begin_address;
 };
 
+struct buffer_cb_free {
+	struct comp_buffer *buffer;
+};
+
 #define buffer_comp_list(buffer, dir) \
 	((dir) == PPL_DIR_DOWNSTREAM ? &buffer->source_list : \
 	 &buffer->sink_list)

--- a/src/include/sof/lib/clk.h
+++ b/src/include/sof/lib/clk.h
@@ -22,6 +22,7 @@ struct clock_notify_data {
 	uint32_t old_ticks_per_msec;
 	uint32_t freq;
 	uint32_t ticks_per_msec;
+	uint32_t message;
 };
 
 struct freq_table {

--- a/src/include/sof/lib/dma.h
+++ b/src/include/sof/lib/dma.h
@@ -211,11 +211,6 @@ struct dma_chan_data {
 	/* true if this DMA channel is the scheduling source */
 	bool is_scheduling_source;
 
-	/* called by the DMA domain right after receiving an interrupt,
-	 * so should execute very time-sensitive operations
-	 */
-	void (*irq_callback)(struct dma_chan_data *channel);
-
 	void *private;
 };
 

--- a/src/include/sof/lib/notifier.h
+++ b/src/include/sof/lib/notifier.h
@@ -27,6 +27,7 @@ enum notify_id {
 	NOTIFIER_ID_BUFFER_PRODUCE,		/* struct buffer_cb_transact* */
 	NOTIFIER_ID_BUFFER_CONSUME,		/* struct buffer_cb_transact* */
 	NOTIFIER_ID_BUFFER_FREE,		/* struct buffer_cb_free* */
+	NOTIFIER_ID_DMA_COPY,			/* struct dma_cb_data* */
 	NOTIFIER_ID_COUNT
 };
 

--- a/src/include/sof/lib/notifier.h
+++ b/src/include/sof/lib/notifier.h
@@ -28,6 +28,7 @@ enum notify_id {
 	NOTIFIER_ID_BUFFER_CONSUME,		/* struct buffer_cb_transact* */
 	NOTIFIER_ID_BUFFER_FREE,		/* struct buffer_cb_free* */
 	NOTIFIER_ID_DMA_COPY,			/* struct dma_cb_data* */
+	NOTIFIER_ID_DMA_IRQ,			/* struct dma_chan_data * */
 	NOTIFIER_ID_COUNT
 };
 

--- a/src/include/sof/lib/notifier.h
+++ b/src/include/sof/lib/notifier.h
@@ -15,7 +15,8 @@
 struct sof;
 
 /* notifier target core masks */
-#define NOTIFIER_TARGET_CORE_MASK(x)	(1 << x)
+#define NOTIFIER_TARGET_CORE_MASK(x)	(1 << (x))
+#define NOTIFIER_TARGET_CORE_LOCAL	NOTIFIER_TARGET_CORE_MASK(cpu_get_id())
 #define NOTIFIER_TARGET_CORE_ALL_MASK	0xFFFFFFFF
 
 enum notify_id {
@@ -23,6 +24,8 @@ enum notify_id {
 	NOTIFIER_ID_SSP_FREQ,			/* struct clock_notify_data * */
 	NOTIFIER_ID_KPB_CLIENT_EVT,		/* struct kpb_event_data * */
 	NOTIFIER_ID_DMA_DOMAIN_CHANGE,		/* struct dma_chan_data * */
+	NOTIFIER_ID_BUFFER_PRODUCE,		/* struct buffer_cb_transact* */
+	NOTIFIER_ID_BUFFER_CONSUME,		/* struct buffer_cb_transact* */
 	NOTIFIER_ID_COUNT
 };
 

--- a/src/include/sof/lib/notifier.h
+++ b/src/include/sof/lib/notifier.h
@@ -26,6 +26,7 @@ enum notify_id {
 	NOTIFIER_ID_DMA_DOMAIN_CHANGE,		/* struct dma_chan_data * */
 	NOTIFIER_ID_BUFFER_PRODUCE,		/* struct buffer_cb_transact* */
 	NOTIFIER_ID_BUFFER_CONSUME,		/* struct buffer_cb_transact* */
+	NOTIFIER_ID_BUFFER_FREE,		/* struct buffer_cb_free* */
 	NOTIFIER_ID_COUNT
 };
 

--- a/src/include/user/trace.h
+++ b/src/include/user/trace.h
@@ -62,6 +62,7 @@ struct system_time {
 #define TRACE_CLASS_KEYWORD	(33 << 24)
 #define TRACE_CLASS_CHMAP	(34 << 24)
 #define TRACE_CLASS_ASRC	(35 << 24)
+#define TRACE_CLASS_NOTIFIER	(36 << 24)
 
 #define LOG_ENABLE		1  /* Enable logging */
 #define LOG_DISABLE		0  /* Disable logging */

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 if(BUILD_LIBRARY)
-	add_local_sources(sof lib.c )
+	add_local_sources(sof
+		lib.c
+		notifier.c)
 	return()
 endif()
 

--- a/src/lib/notifier.c
+++ b/src/lib/notifier.c
@@ -5,6 +5,7 @@
 // Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
 
 #include <sof/common.h>
+#include <sof/debug/panic.h>
 #include <sof/drivers/idc.h>
 #include <sof/lib/alloc.h>
 #include <sof/lib/cache.h>
@@ -14,82 +15,160 @@
 #include <sof/spinlock.h>
 #include <ipc/topology.h>
 
-static struct notify_data _notify_data __aligned(PLATFORM_DCACHE_ALIGN);
+struct notify_data {
+	void *caller;
+	enum notify_id type;
+	uint32_t data_size;
+	void *data;
+} __aligned(PLATFORM_DCACHE_ALIGN);
 
-void notifier_register(struct notifier *notifier)
+static struct notify_data _notify_data[PLATFORM_CORE_COUNT]
+	__aligned(PLATFORM_DCACHE_ALIGN);
+
+struct callback_handle {
+	void *receiver;
+	void *caller;
+	void (*cb)(void *arg, enum notify_id, void *data);
+	struct list_item list;
+};
+
+int notifier_register(void *receiver, void *caller, enum notify_id type,
+		      void (*cb)(void *arg, enum notify_id type, void *data))
 {
 	struct notify *notify = *arch_notify_get();
+	struct callback_handle *handle;
+
+	assert(type >= NOTIFIER_ID_CPU_FREQ && type < NOTIFIER_ID_COUNT);
+
+	handle = rzalloc(RZONE_SYS_RUNTIME, SOF_MEM_CAPS_RAM, sizeof(*handle));
+
+	if (!handle)
+		return -ENOMEM;
+
+	handle->receiver = receiver;
+	handle->caller = caller;
+	handle->cb = cb;
 
 	spin_lock(notify->lock);
-	list_item_prepend(&notifier->list, &notify->list);
+	list_item_prepend(&handle->list, &notify->list[type]);
 	spin_unlock(notify->lock);
+
+	return 0;
 }
 
-void notifier_unregister(struct notifier *notifier)
-{
-	struct notify *notify = *arch_notify_get();
-
-	spin_lock(notify->lock);
-	list_item_del(&notifier->list);
-	spin_unlock(notify->lock);
-}
-
-void notifier_notify(void)
+void notifier_unregister(void *receiver, void *caller, enum notify_id type)
 {
 	struct notify *notify = *arch_notify_get();
 	struct list_item *wlist;
-	struct notifier *n;
+	struct list_item *tlist;
+	struct callback_handle *handle;
 
-	if (!list_is_empty(&notify->list)) {
-		dcache_invalidate_region(&_notify_data, sizeof(_notify_data));
-		dcache_invalidate_region(_notify_data.data,
-					 _notify_data.data_size);
+	assert(type >= NOTIFIER_ID_CPU_FREQ && type < NOTIFIER_ID_COUNT);
 
-		/* iterate through notifiers and send event to
-		 * interested clients
-		 */
-		list_for_item(wlist, &notify->list) {
-			n = container_of(wlist, struct notifier, list);
-			if (n->id == _notify_data.id)
-				n->cb(_notify_data.message, n->cb_data,
-				      _notify_data.data);
+	/*
+	 * Unregister all matching callbacks
+	 * If receiver is NULL, unregister all callbacks with matching callers
+	 * If caller is NULL, unregister all callbacks with matching receivers
+	 *
+	 * Event producer might force unregister all receivers by passing
+	 * receiver NULL
+	 * Event consumer might unregister from all callers by passing caller
+	 * NULL
+	 */
+	spin_lock(notify->lock);
+	list_for_item_safe(wlist, tlist, &notify->list[type]) {
+		handle = container_of(wlist, struct callback_handle, list);
+		if ((!receiver || handle->receiver == receiver) &&
+		    (!caller || handle->caller == caller)) {
+			list_item_del(&handle->list);
+			rfree(handle);
 		}
+	}
+	spin_unlock(notify->lock);
+}
+
+void notifier_unregister_all(void *receiver, void *caller)
+{
+	int i;
+
+	for (i = NOTIFIER_ID_CPU_FREQ; i < NOTIFIER_ID_COUNT; i++)
+		notifier_unregister(receiver, caller, i);
+}
+
+static void notifier_notify(void *caller, enum notify_id type, void *data)
+{
+	struct notify *notify = *arch_notify_get();
+	struct list_item *wlist;
+	struct list_item *tlist;
+	struct callback_handle *handle;
+
+	/* iterate through notifiers and send event to
+	 * interested clients
+	 */
+	list_for_item_safe(wlist, tlist, &notify->list[type]) {
+		handle = container_of(wlist, struct callback_handle, list);
+		if (!caller || !handle->caller || handle->caller == caller)
+			handle->cb(handle->receiver, type, data);
 	}
 }
 
-void notifier_event(struct notify_data *notify_data)
+void notifier_notify_remote(void)
 {
 	struct notify *notify = *arch_notify_get();
+	struct notify_data *notify_data = &_notify_data[cpu_get_id()];
+
+	dcache_invalidate_region(notify_data, sizeof(*notify_data));
+	if (!list_is_empty(&notify->list[notify_data->type])) {
+		dcache_invalidate_region(notify_data->data,
+					 notify_data->data_size);
+		notifier_notify(notify_data->caller, notify_data->type,
+				notify_data->data);
+	}
+}
+
+void notifier_event(void *caller, enum notify_id type, uint32_t core_mask,
+		    void *data, uint32_t data_size)
+{
+	struct notify_data *notify_data;
 	struct idc_msg notify_msg = { IDC_MSG_NOTIFY, IDC_MSG_NOTIFY_EXT };
 	int i;
 
-	spin_lock(notify->lock);
-
-	_notify_data = *notify_data;
-	dcache_writeback_region(_notify_data.data, _notify_data.data_size);
-	dcache_writeback_region(&_notify_data, sizeof(_notify_data));
-
 	/* notify selected targets */
 	for (i = 0; i < PLATFORM_CORE_COUNT; i++) {
-		if (_notify_data.target_core_mask & (1 << i)) {
+		if (core_mask & NOTIFIER_TARGET_CORE_MASK(i)) {
 			if (i == cpu_get_id()) {
-				notifier_notify();
+				notifier_notify(caller, type, data);
 			} else if (cpu_is_core_enabled(i)) {
 				notify_msg.core = i;
+				notify_data = &_notify_data[i];
+				notify_data->caller = caller;
+				notify_data->type = type;
+
+				/* NOTE: for transcore events, payload has to
+				 * be allocated on heap, not on stack
+				 */
+				notify_data->data = data;
+				notify_data->data_size = data_size;
+
+				dcache_writeback_region(notify_data->data,
+							data_size);
+				dcache_writeback_region(notify_data,
+							sizeof(*notify_data));
+
 				idc_send_msg(&notify_msg, IDC_NON_BLOCKING);
 			}
 		}
 	}
-
-	spin_unlock(notify->lock);
 }
 
 void init_system_notify(struct sof *sof)
 {
 	struct notify **notify = arch_notify_get();
+	int i;
 	*notify = rzalloc(RZONE_SYS, SOF_MEM_CAPS_RAM, sizeof(**notify));
 
-	list_init(&(*notify)->list);
+	for (i = NOTIFIER_ID_CPU_FREQ; i < NOTIFIER_ID_COUNT; i++)
+		list_init(&(*notify)->list[i]);
 	spinlock_init(&(*notify)->lock);
 }
 

--- a/src/lib/notifier.c
+++ b/src/lib/notifier.c
@@ -15,6 +15,13 @@
 #include <sof/spinlock.h>
 #include <ipc/topology.h>
 
+#define trace_notifier(__e, ...) \
+	trace_event(TRACE_CLASS_NOTIFIER, __e, ##__VA_ARGS__)
+#define tracev_notifier(__e, ...) \
+	tracev_event(TRACE_CLASS_NOTIFIER, __e, ##__VA_ARGS__)
+#define trace_notifier_error(__e, ...) \
+	trace_error(TRACE_CLASS_NOTIFIER, __e, ##__VA_ARGS__)
+
 struct notify_data {
 	void *caller;
 	enum notify_id type;
@@ -42,8 +49,11 @@ int notifier_register(void *receiver, void *caller, enum notify_id type,
 
 	handle = rzalloc(RZONE_SYS_RUNTIME, SOF_MEM_CAPS_RAM, sizeof(*handle));
 
-	if (!handle)
+	if (!handle) {
+		trace_notifier_error("notifier_register() error: callback "
+				     "handle allocation failed.");
 		return -ENOMEM;
+	}
 
 	handle->receiver = receiver;
 	handle->caller = caller;

--- a/src/platform/apollolake/include/platform/lib/memory.h
+++ b/src/platform/apollolake/include/platform/lib/memory.h
@@ -250,12 +250,12 @@
 #define SOF_TEXT_BASE		(SOF_FW_START)
 
 /* Heap section sizes for system runtime heap for master core */
-#define HEAP_SYS_RT_0_COUNT64		72
+#define HEAP_SYS_RT_0_COUNT64		128
 #define HEAP_SYS_RT_0_COUNT512		16
 #define HEAP_SYS_RT_0_COUNT1024		4
 
 /* Heap section sizes for system runtime heap for slave core */
-#define HEAP_SYS_RT_X_COUNT64		32
+#define HEAP_SYS_RT_X_COUNT64		64
 #define HEAP_SYS_RT_X_COUNT512		8
 #define HEAP_SYS_RT_X_COUNT1024		4
 

--- a/src/platform/cannonlake/include/platform/lib/memory.h
+++ b/src/platform/cannonlake/include/platform/lib/memory.h
@@ -237,7 +237,7 @@
 #define HEAP_SYS_RT_0_COUNT1024		4
 
 /* Heap section sizes for system runtime heap for slave core */
-#define HEAP_SYS_RT_X_COUNT64		32
+#define HEAP_SYS_RT_X_COUNT64		64
 #define HEAP_SYS_RT_X_COUNT512		8
 #define HEAP_SYS_RT_X_COUNT1024		4
 

--- a/src/platform/icelake/include/platform/lib/memory.h
+++ b/src/platform/icelake/include/platform/lib/memory.h
@@ -234,7 +234,7 @@
 #define HEAP_SYS_RT_0_COUNT1024		4
 
 /* Heap section sizes for system runtime heap for slave core */
-#define HEAP_SYS_RT_X_COUNT64		32
+#define HEAP_SYS_RT_X_COUNT64		64
 #define HEAP_SYS_RT_X_COUNT512		8
 #define HEAP_SYS_RT_X_COUNT1024		4
 

--- a/src/platform/tigerlake/include/platform/lib/memory.h
+++ b/src/platform/tigerlake/include/platform/lib/memory.h
@@ -242,7 +242,7 @@
 #define HEAP_SYS_RT_0_COUNT1024		4
 
 /* Heap section sizes for system runtime heap for slave core */
-#define HEAP_SYS_RT_X_COUNT64		32
+#define HEAP_SYS_RT_X_COUNT64		64
 #define HEAP_SYS_RT_X_COUNT512		8
 #define HEAP_SYS_RT_X_COUNT1024		4
 

--- a/src/schedule/dma_multi_chan_domain.c
+++ b/src/schedule/dma_multi_chan_domain.c
@@ -11,6 +11,7 @@
 #include <sof/lib/alloc.h>
 #include <sof/lib/cpu.h>
 #include <sof/lib/dma.h>
+#include <sof/lib/notifier.h>
 #include <sof/platform.h>
 #include <sof/schedule/ll_schedule.h>
 #include <sof/schedule/ll_schedule_domain.h>
@@ -272,9 +273,10 @@ static bool dma_multi_chan_domain_is_pending(struct ll_schedule_domain *domain,
 			    platform_timer_get(platform_timer))
 				continue;
 
-			/* execute callback if exists */
-			if (dmas[i].chan[j].irq_callback)
-				dmas[i].chan[j].irq_callback(&dmas[i].chan[j]);
+			notifier_event(&dmas[i].chan[j], NOTIFIER_ID_DMA_IRQ,
+				       NOTIFIER_TARGET_CORE_LOCAL,
+				       &dmas[i].chan[j],
+				       sizeof(struct dma_chan_data));
 
 			/* clear interrupt */
 			if (pipe_task->registrable) {

--- a/test/cmocka/src/audio/buffer/CMakeLists.txt
+++ b/test/cmocka/src/audio/buffer/CMakeLists.txt
@@ -3,23 +3,27 @@
 cmocka_test(buffer_copy
 	buffer_copy.c
 	mock.c
+	${PROJECT_SOURCE_DIR}/test/cmocka/src/notifier_mocks.c
 	${PROJECT_SOURCE_DIR}/src/audio/buffer.c
 )
 
 cmocka_test(buffer_new
 	buffer_new.c
 	mock.c
+	${PROJECT_SOURCE_DIR}/test/cmocka/src/notifier_mocks.c
 	${PROJECT_SOURCE_DIR}/src/audio/buffer.c
 )
 
 cmocka_test(buffer_wrap
 	buffer_wrap.c
 	mock.c
+	${PROJECT_SOURCE_DIR}/test/cmocka/src/notifier_mocks.c
 	${PROJECT_SOURCE_DIR}/src/audio/buffer.c
 )
 
 cmocka_test(buffer_write
 	buffer_write.c
 	mock.c
+	${PROJECT_SOURCE_DIR}/test/cmocka/src/notifier_mocks.c
 	${PROJECT_SOURCE_DIR}/src/audio/buffer.c
 )

--- a/test/cmocka/src/audio/kpb/CMakeLists.txt
+++ b/test/cmocka/src/audio/kpb/CMakeLists.txt
@@ -4,6 +4,7 @@ cmocka_test(kpb
 	${PROJECT_SOURCE_DIR}/src/audio/kpb.c
 	kpb_buffer.c
 	kpb_mock.c
+	${PROJECT_SOURCE_DIR}/test/cmocka/src/notifier_mocks.c
 	${PROJECT_SOURCE_DIR}/src/audio/buffer.c
 	${PROJECT_SOURCE_DIR}/src/lib/agent.c
 	#${PROJECT_SOURCE_DIR}/src/audio/component.c

--- a/test/cmocka/src/audio/kpb/kpb_buffer.c
+++ b/test/cmocka/src/audio/kpb/kpb_buffer.c
@@ -36,7 +36,6 @@ struct comp_data {
 	enum kpb_state state; /**< current state of KPB component */
 	uint32_t kpb_no_of_clients; /**< number of registered clients */
 	struct kpb_client clients[KPB_MAX_NO_OF_CLIENTS];
-	struct notifier kpb_events; /**< KPB events object */
 	struct task draining_task;
 	uint32_t source_period_bytes; /**< source number of period bytes */
 	uint32_t sink_period_bytes; /**< sink number of period bytes */
@@ -170,8 +169,6 @@ static struct comp_buffer *mock_comp_buffer(void **state,
 		buffer->w_ptr = sink_data;
 		break;
 	}
-
-	buffer->cb = NULL;
 
 	return buffer;
 }

--- a/test/cmocka/src/audio/kpb/kpb_mock.c
+++ b/test/cmocka/src/audio/kpb/kpb_mock.c
@@ -61,14 +61,6 @@ int comp_set_state(struct comp_dev *dev, int cmd)
 	return 0;
 }
 
-void notifier_register(struct notifier *notifier)
-{
-}
-
-void notifier_unregister(struct notifier *notifier)
-{
-}
-
 int schedule_task_init(struct task *task, uint16_t type, uint16_t priority,
 		       enum task_state (*run)(void *data),
 		       void (*complete)(void *data), void *data, uint16_t core,

--- a/test/cmocka/src/audio/mixer/CMakeLists.txt
+++ b/test/cmocka/src/audio/mixer/CMakeLists.txt
@@ -4,6 +4,7 @@ cmocka_test(mixer
 	mixer_test.c
 	mock.c
 	comp_mock.c
+	${PROJECT_SOURCE_DIR}/test/cmocka/src/notifier_mocks.c
 	${PROJECT_SOURCE_DIR}/src/audio/buffer.c
 	${PROJECT_SOURCE_DIR}/src/audio/mixer.c
 )

--- a/test/cmocka/src/audio/pipeline/CMakeLists.txt
+++ b/test/cmocka/src/audio/pipeline/CMakeLists.txt
@@ -21,6 +21,7 @@ cmocka_test(pipeline_new
 	pipeline_new.c
 	pipeline_mocks.c
 	pipeline_mocks_rzalloc.c
+	${PROJECT_SOURCE_DIR}/test/cmocka/src/notifier_mocks.c
 	${PROJECT_SOURCE_DIR}/src/audio/pipeline.c
 )
 
@@ -28,6 +29,7 @@ cmocka_test(pipeline_new_allocation
 	pipeline_new_allocation.c
 	pipeline_mocks.c
 	pipeline_new_allocation_mocks.c
+	${PROJECT_SOURCE_DIR}/test/cmocka/src/notifier_mocks.c
 	${PROJECT_SOURCE_DIR}/src/audio/pipeline.c
 )
 
@@ -36,6 +38,7 @@ cmocka_test(pipeline_connect_upstream
 	pipeline_mocks.c
 	pipeline_mocks_rzalloc.c
 	pipeline_connection_mocks.c
+	${PROJECT_SOURCE_DIR}/test/cmocka/src/notifier_mocks.c
 	${PROJECT_SOURCE_DIR}/src/audio/pipeline.c
 )
 
@@ -44,5 +47,6 @@ cmocka_test(pipeline_free
 	pipeline_mocks.c
 	pipeline_mocks_rzalloc.c
 	pipeline_connection_mocks.c
+	${PROJECT_SOURCE_DIR}/test/cmocka/src/notifier_mocks.c
 	${PROJECT_SOURCE_DIR}/src/audio/pipeline.c
 )

--- a/test/cmocka/src/notifier_mocks.c
+++ b/test/cmocka/src/notifier_mocks.c
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2019 Intel Corporation. All rights reserved.
+//
+// Author: Artur Kloniecki <arturx.kloniecki@linux.intel.com>
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <sof/lib/alloc.h>
+#include <sof/lib/notifier.h>
+#include <sof/list.h>
+#include <sof/common.h>
+
+struct callback_handle {
+	void *receiver;
+	void *caller;
+	void (*cb)(void *arg, enum notify_id, void *data);
+	struct list_item list;
+};
+
+static struct notify *_notify;
+
+struct notify **arch_notify_get(void)
+{
+	int i;
+
+	if (!_notify) {
+		_notify = malloc(sizeof(*_notify));
+
+		for (i = 0; i < NOTIFIER_ID_COUNT; i++)
+			list_init(&_notify->list[i]);
+	}
+
+	return &_notify;
+}
+
+void notifier_event(void *caller, enum notify_id type, uint32_t core_mask,
+		    void *data, uint32_t data_size)
+{
+	struct notify *notify = *arch_notify_get();
+	struct list_item *wlist;
+	struct list_item *tlist;
+	struct callback_handle *handle;
+
+	list_for_item_safe(wlist, tlist, &notify->list[type]) {
+		handle = container_of(wlist, struct callback_handle, list);
+		if (!caller || !handle->caller || handle->caller == caller)
+			handle->cb(handle->receiver, type, data);
+	}
+}
+
+int notifier_register(void *receiver, void *caller, enum notify_id type,
+	void (*cb)(void *arg, enum notify_id type, void *data))
+{
+	struct notify *notify = *arch_notify_get();
+	struct callback_handle *handle;
+
+	if (type >= NOTIFIER_ID_COUNT)
+		return -EINVAL;
+
+	handle = rzalloc(0, 0, sizeof(struct callback_handle));
+
+	if (!handle)
+		return -ENOMEM;
+
+	list_init(&handle->list);
+	handle->receiver = receiver;
+	handle->caller = caller;
+	handle->cb = cb;
+
+	list_item_append(&handle->list, &notify->list[type]);
+
+	return 0;
+}
+
+void notifier_unregister(void *receiver, void *caller, enum notify_id type)
+{
+	struct notify *notify = *arch_notify_get();
+	struct list_item *wlist;
+	struct list_item *tlist;
+	struct callback_handle *handle;
+
+	if (type >= NOTIFIER_ID_COUNT)
+		return;
+
+	list_for_item_safe(wlist, tlist, &notify->list[type]) {
+		handle = container_of(wlist, struct callback_handle, list);
+		if ((!receiver || handle->receiver == receiver) &&
+		    (!caller || handle->caller == caller)) {
+			list_item_del(&handle->list);
+			free(handle);
+		}
+	}
+}
+
+void notifier_unregister_all(void *receiver, void *caller)
+{
+	int i;
+
+	for (i = 0; i < NOTIFIER_ID_COUNT; i++)
+		notifier_unregister(receiver, caller, i);
+}

--- a/tools/logger/convert.c
+++ b/tools/logger/convert.c
@@ -102,6 +102,7 @@ static const char * get_component_name(uint32_t component_id) {
 		CASE(KEYWORD);
 		CASE(CHMAP);
 		CASE(ASRC);
+		CASE(NOTIFIER);
 	default: return "unknown";
 	}
 }

--- a/tools/testbench/trace.c
+++ b/tools/testbench/trace.c
@@ -56,6 +56,7 @@ char *get_trace_class(uint32_t trace_class)
 		CASE(KEYWORD);
 		CASE(CHMAP);
 		CASE(ASRC);
+		CASE(NOTIFIER);
 	default: return "unknown";
 	}
 }


### PR DESCRIPTION
Notifier event handling is extended to handle more dynamic, nested callbacks. It also handles allocation of memory for said callbacks and unifies the interface across different event producers, as well as provides better scalability by allowing multiple callbacks being registered to single event.
The idea is to collect many different events into single event hub, for unification of interface and ease of use.