### PR TITLE
ipc: return an error on dai not found

### DIFF
--- a/src/ipc/ipc.c
+++ b/src/ipc/ipc.c
@@ -397,7 +397,7 @@ int ipc_comp_dai_config(struct ipc *ipc, struct sof_ipc_dai_config *config)
 	struct ipc_comp_dev *icd;
 	struct list_item *clist;
 	struct comp_dev *dev;
-	int ret = 0;
+	int ret = -ENODEV;
 
 	/* for each component */
 	list_for_item(clist, &ipc->shared_ctx->comp_list) {


### PR DESCRIPTION
Returns an error, when there is no DAI component
connected to the DAI index specified by DAI config
IPC.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>