### PR TITLE
Topic/imx/edma fixes

### DIFF
--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -796,6 +796,10 @@ static int dai_config(struct comp_dev *dev, struct sof_ipc_dai_config *config)
 		trace_dai_with_ids(dev, "dai_config(), channel = %d",
 				   channel);
 		break;
+	case SOF_DAI_IMX_SAI:
+		dd->config.burst_elems =
+			dd->dai->plat_data.fifo[dev->params.direction].depth;
+		break;
 	default:
 		/* other types of DAIs not handled for now */
 		trace_dai_error_with_ids(dev, "dai_config() error: Handling of "

--- a/src/drivers/imx/edma.c
+++ b/src/drivers/imx/edma.c
@@ -435,6 +435,9 @@ static int edma_remove(struct dma *dma)
 
 static int edma_interrupt(struct dma_chan_data *channel, enum dma_irq_cmd cmd)
 {
+	if (channel->status != COMP_STATE_INIT)
+		return 0;
+
 	switch (cmd) {
 	case DMA_IRQ_STATUS_GET:
 		return dma_chan_reg_read(channel, EDMA_CH_INT);

--- a/src/platform/imx8/lib/dai.c
+++ b/src/platform/imx8/lib/dai.c
@@ -31,11 +31,18 @@ static struct dai sai[] = {
 		.base = SAI_1_BASE,
 		.fifo[SOF_IPC_STREAM_PLAYBACK] = {
 			.offset		= SAI_1_BASE + REG_SAI_TDR0,
+			/* use depth to model the HW FIFO size:
+			 * each channel includes a 64 x 32 bit FIFO
+			 * that can be accessed using Transmit or
+			 * Receive Data Registers
+			 */
+			.depth		= 64,  /* in 4 bytes words */
 			.handshake	= EDMA_HANDSHAKE(EDMA0_SAI_CHAN_TX_IRQ,
 							 EDMA0_SAI_CHAN_TX),
 		},
 		.fifo[SOF_IPC_STREAM_CAPTURE] = {
 			.offset		= SAI_1_BASE + REG_SAI_RDR0,
+			.depth		= 64,  /* in 4 bytes words */
 			.handshake	= EDMA_HANDSHAKE(EDMA0_SAI_CHAN_RX_IRQ,
 							 EDMA0_SAI_CHAN_RX),
 		},


### PR DESCRIPTION
This patch set contains:
- one patch to avoid accessing EDMA channel registers if they are not in READY state
- one patch to parameterize EDMA iteration size on FIFO size that changes using different interfaces (ESAI or SAI)