### PR TITLE
detector: send IPC notification to host before draining starts

### DIFF
--- a/src/audio/detect_test.c
+++ b/src/audio/detect_test.c
@@ -125,6 +125,11 @@ static void notify_host(struct comp_dev *dev)
 	event.num_elems = 0;
 
 	ipc_send_comp_notification(dev, &event);
+
+	/* Send queued IPC message right away to wake host up ASAP
+	 * NOTE! This will only send one IPC from the list!
+	 */
+	ipc_platform_send_msg();
 }
 
 static void notify_kpb(struct comp_dev *dev)

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -386,10 +386,8 @@ static int kpb_prepare(struct comp_dev *dev)
 
 	if (kpb->state == KPB_STATE_RESETTING ||
 	    kpb->state == KPB_STATE_RESET_FINISHING) {
-		trace_kpb_error_with_ids(dev, "kpb_prepare() error: "
-					 "can not prepare KPB "
-					 "due to ongoing reset, state log %d",
-					 kpb->state_log);
+		trace_kpb_error("kpb_prepare() error: can not prepare KPB due to ongoing reset, state log %x",
+				kpb->state_log);
 		return -EBUSY;
 	}
 
@@ -502,8 +500,8 @@ static int kpb_reset(struct comp_dev *dev)
 	struct comp_data *kpb = comp_get_drvdata(dev);
 	int ret = 0;
 
-	trace_kpb_with_ids(dev, "kpb_reset(): resetting from state %d, "
-			   "state log %d", kpb->state, kpb->state_log);
+	trace_kpb("kpb_reset(): resetting from state %d, state log %x",
+		  kpb->state, kpb->state_log);
 
 	switch (kpb->state) {
 	case KPB_STATE_BUFFERING:
@@ -678,10 +676,8 @@ static int kpb_copy(struct comp_dev *dev)
 		ret = PPL_STATUS_PATH_STOP;
 		break;
 	default:
-		trace_kpb_error_with_ids(dev, "kpb_copy(): wrong state, "
-					 "copy forbidden. "
-					 "(state %d, state log %d)",
-					 kpb->state, kpb->state_log);
+		trace_kpb_error("kpb_copy(): wrong state (state %d, state log %x)",
+				kpb->state, kpb->state_log);
 		ret = -EIO;
 		break;
 	}
@@ -739,11 +735,9 @@ static int kpb_buffer_data(struct comp_dev *dev, struct comp_buffer *source,
 		/* Are we stuck in buffering? */
 		current_time = platform_timer_get(platform_timer);
 		if (timeout < current_time) {
-			trace_kpb_error_with_ids(dev, "kpb_buffer_data(): "
-					"timeout of %d [ms] "
-					"(current state %d, state log %d)",
-					(current_time - timeout),
-					kpb->state, kpb->state_log);
+			trace_kpb_error("kpb_buffer_data(): timeout of %d [ms] (current state %d, state log %x)",
+					current_time - timeout, kpb->state,
+					kpb->state_log);
 			return -ETIME;
 		}
 


### PR DESCRIPTION
This patch enables callbacks on IPC message.
This functionality is useful when you want to do extra work on FW side right after IPC to host has been sent.

Signed-off-by: Marcin Rajwa <marcin.rajwa@linux.intel.com>