### PR TITLE
host: fix wrong trace value

### DIFF
--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -487,7 +487,7 @@ static void host_buffer_cb(void *data, uint32_t bytes)
 	uint32_t flags = 0;
 	int ret;
 
-	tracev_host("host_buffer_cb(), copy_bytes = 0x%x", copy_bytes);
+	tracev_host("host_buffer_cb(), bytes = 0x%x", bytes);
 
 	if (hd->copy_type == COMP_COPY_BLOCKING)
 		flags |= DMA_COPY_BLOCKING;


### PR DESCRIPTION
This patch fixes the trace message which logs always zero
value.

Signed-off-by: Marcin Rajwa <marcin.rajwa@linux.intel.com>