### PR TITLE
drivers: imx: edma: fix accessing register logic

### DIFF
--- a/src/drivers/imx/edma.c
+++ b/src/drivers/imx/edma.c
@@ -442,7 +442,7 @@ static int edma_remove(struct dma *dma)
 
 static int edma_interrupt(struct dma_chan_data *channel, enum dma_irq_cmd cmd)
 {
-	if (channel->status != COMP_STATE_INIT)
+	if (channel->status == COMP_STATE_INIT)
 		return 0;
 
 	switch (cmd) {


### PR DESCRIPTION
channel must not be accessed when status *is* INIT

Signed-off-by: Guido Roncarolo <guido.roncarolo@nxp.com>