### PR TITLE
platform: imx: Increase system runtime heap size

### DIFF
--- a/src/platform/imx8/include/platform/lib/memory.h
+++ b/src/platform/imx8/include/platform/lib/memory.h
@@ -111,9 +111,9 @@
 #define HEAP_RT_COUNT2048	4
 
 /* Heap section sizes for system runtime heap */
-#define HEAP_SYS_RT_COUNT64	64
-#define HEAP_SYS_RT_COUNT512	8
-#define HEAP_SYS_RT_COUNT1024	4
+#define HEAP_SYS_RT_COUNT64	128
+#define HEAP_SYS_RT_COUNT512	16
+#define HEAP_SYS_RT_COUNT1024	8
 
 /* Heap configuration */
 


### PR DESCRIPTION
The introduction of the DMA multi channel domain made it so the cascaded
interrupt handling fails to allocate memory from this heap. Increasing
the size of the system runtime heap will allow the registering of
cascaded interrupts (and in particular the EDMA interrupt within the DMA
scheduling domain) to continue.

Signed-off-by: Paul Olaru <paul.olaru@nxp.com>