### PR TITLE
dma: alloc separate buffers for DMAs

### DIFF
--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -98,33 +98,6 @@ void comp_unregister(struct comp_driver *drv)
 	irq_local_enable(flags);
 }
 
-int comp_set_sink_buffer(struct comp_dev *dev, uint32_t period_bytes,
-			 uint32_t periods)
-{
-	struct comp_buffer *sinkb;
-	int ret = 0;
-
-	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer,
-				source_list);
-
-	/* components connected to dma configure buffer independently */
-	if (!sinkb->sink->is_dma_connected) {
-		ret = buffer_set_size(sinkb, period_bytes * periods);
-		if (ret < 0) {
-			trace_comp_error("comp_set_sink_buffer() error: "
-					 "buffer_set_size() failed");
-			return ret;
-		}
-	} else if (sinkb->size < period_bytes * periods) {
-		trace_comp_error("comp_set_sink_buffer() error: "
-				 "sink buffer size is not sufficient");
-		ret = -EINVAL;
-		return ret;
-	}
-
-	return ret;
-}
-
 int comp_set_state(struct comp_dev *dev, int cmd)
 {
 	int requested_state = comp_get_requested_state(cmd);

--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -65,6 +65,10 @@ struct dai_data {
 	uint32_t frame_bytes;
 	int xrun;		/* true if we are doing xrun recovery */
 
+	/* processing function */
+	void (*process)(struct comp_buffer *source, struct comp_buffer *sink,
+			uint32_t bytes);
+
 	uint32_t dai_pos_blks;	/* position in bytes (nearest block) */
 	uint64_t start_position;	/* position on start */
 
@@ -80,6 +84,7 @@ static void dai_dma_cb(void *data, uint32_t type, struct dma_cb_data *next)
 	struct comp_dev *dev = (struct comp_dev *)data;
 	struct dai_data *dd = comp_get_drvdata(dev);
 	uint32_t bytes = next->elem.size;
+	struct comp_buffer *local_buffer;
 	void *buffer_ptr;
 
 	tracev_dai_with_ids(dev, "dai_dma_cb()");
@@ -106,15 +111,21 @@ static void dai_dma_cb(void *data, uint32_t type, struct dma_cb_data *next)
 	}
 
 	if (dev->params.direction == SOF_IPC_STREAM_PLAYBACK) {
-		/* recalc available buffer space */
-		comp_update_buffer_consume(dd->dma_buffer, bytes);
+		local_buffer = list_first_item(&dev->bsource_list,
+					       struct comp_buffer, sink_list);
 
-		buffer_ptr = dd->dma_buffer->r_ptr;
+		dma_buffer_copy_to(local_buffer, dd->dma_buffer, dd->process,
+				   bytes);
+
+		buffer_ptr = local_buffer->r_ptr;
 	} else {
-		/* recalc available buffer space */
-		comp_update_buffer_produce(dd->dma_buffer, bytes);
+		local_buffer = list_first_item(&dev->bsink_list,
+					       struct comp_buffer, source_list);
 
-		buffer_ptr = dd->dma_buffer->w_ptr;
+		dma_buffer_copy_from(dd->dma_buffer, local_buffer, dd->process,
+				     bytes);
+
+		buffer_ptr = local_buffer->w_ptr;
 	}
 
 	/* update host position (in bytes offset) for drivers */
@@ -210,14 +221,13 @@ static void dai_free(struct comp_dev *dev)
 }
 
 /* set component audio SSP and DMA configuration */
-static int dai_playback_params(struct comp_dev *dev, uint32_t period_bytes)
+static int dai_playback_params(struct comp_dev *dev, uint32_t period_bytes,
+			       uint32_t period_count)
 {
 	struct dai_data *dd = comp_get_drvdata(dev);
 	struct dma_sg_config *config = &dd->config;
-	struct sof_ipc_comp_config *dai_config;
-	int err;
-	uint32_t buffer_size;
 	uint32_t fifo;
+	int err;
 
 	/* set up DMA configuration */
 	config->direction = DMA_DIR_MEM_TO_DEV;
@@ -236,25 +246,6 @@ static int dai_playback_params(struct comp_dev *dev, uint32_t period_bytes)
 			   config->dest_dev, dd->stream_id,
 			   config->src_width, config->dest_width);
 
-	/* set up local and host DMA elems to reset values */
-	dai_config = COMP_GET_CONFIG(dev);
-	buffer_size = dai_config->periods_source * period_bytes;
-
-	/* resize the buffer if space is available to align with period size */
-	err = buffer_set_size(dd->dma_buffer, buffer_size);
-	if (err < 0) {
-		trace_dai_error_with_ids(dev, "dai_playback_params() error: "
-					 "buffer_set_size() failed to resize "
-					 "buffer. dai_config->periods_source ="
-					 " %u; period_bytes = %u; "
-					 "buffer_size = %u; "
-					 "dd->dma_buffer->alloc_size = %u",
-					 dai_config->periods_source,
-					 period_bytes, buffer_size,
-					 dd->dma_buffer->alloc_size);
-		return err;
-	}
-
 	if (!config->elem_array.elems) {
 		fifo = dai_get_fifo(dd->dai, dev->params.direction,
 				    dd->stream_id);
@@ -264,9 +255,9 @@ static int dai_playback_params(struct comp_dev *dev, uint32_t period_bytes)
 
 		err = dma_sg_alloc(&config->elem_array, RZONE_RUNTIME,
 				   config->direction,
-				   dai_config->periods_source,
+				   period_count,
 				   period_bytes,
-				   (uintptr_t)(dd->dma_buffer->r_ptr),
+				   (uintptr_t)(dd->dma_buffer->addr),
 				   fifo);
 		if (err < 0) {
 			trace_dai_error_with_ids(dev, "dai_playback_params() "
@@ -279,14 +270,13 @@ static int dai_playback_params(struct comp_dev *dev, uint32_t period_bytes)
 	return 0;
 }
 
-static int dai_capture_params(struct comp_dev *dev, uint32_t period_bytes)
+static int dai_capture_params(struct comp_dev *dev, uint32_t period_bytes,
+			      uint32_t period_count)
 {
 	struct dai_data *dd = comp_get_drvdata(dev);
 	struct dma_sg_config *config = &dd->config;
-	struct sof_ipc_comp_config *dai_config;
-	int err;
-	uint32_t buffer_size;
 	uint32_t fifo;
+	int err;
 
 	/* set up DMA configuration */
 	config->direction = DMA_DIR_DEV_TO_MEM;
@@ -316,25 +306,6 @@ static int dai_capture_params(struct comp_dev *dev, uint32_t period_bytes)
 			   config->src_dev, dd->stream_id,
 			   config->src_width, config->dest_width);
 
-	/* set up local and host DMA elems to reset values */
-	dai_config = COMP_GET_CONFIG(dev);
-	buffer_size = dai_config->periods_sink * period_bytes;
-
-	/* resize the buffer if space is available to align with period size */
-	err = buffer_set_size(dd->dma_buffer, buffer_size);
-	if (err < 0) {
-		trace_dai_error_with_ids(dev, "dai_capture_params() error: "
-					 "buffer_set_size() failed to resize "
-					 "buffer. dai_config->periods_sink = "
-					 "%u; period_bytes = %u; "
-					 "buffer_size = %u; "
-					 "dd->dma_buffer->alloc_size = %u",
-					 dai_config->periods_sink,
-					 period_bytes, buffer_size,
-					 dd->dma_buffer->alloc_size);
-		return err;
-	}
-
 	if (!config->elem_array.elems) {
 		fifo = dai_get_fifo(dd->dai, dev->params.direction,
 				    dd->stream_id);
@@ -344,9 +315,9 @@ static int dai_capture_params(struct comp_dev *dev, uint32_t period_bytes)
 
 		err = dma_sg_alloc(&config->elem_array, RZONE_RUNTIME,
 				   config->direction,
-				   dai_config->periods_sink,
+				   period_count,
 				   period_bytes,
-				   (uintptr_t)(dd->dma_buffer->w_ptr),
+				   (uintptr_t)(dd->dma_buffer->addr),
 				   fifo);
 		if (err < 0) {
 			trace_dai_error_with_ids(dev, "dai_capture_params() "
@@ -363,7 +334,10 @@ static int dai_params(struct comp_dev *dev)
 {
 	struct dai_data *dd = comp_get_drvdata(dev);
 	struct sof_ipc_comp_config *dconfig = COMP_GET_CONFIG(dev);
+	uint32_t period_count;
 	uint32_t period_bytes;
+	uint32_t buffer_size;
+	uint32_t addr_align;
 	uint32_t align;
 	int err;
 
@@ -386,6 +360,12 @@ static int dai_params(struct comp_dev *dev)
 	/* for DAI, we should configure its frame_fmt from topology */
 	dev->params.frame_fmt = dconfig->frame_fmt;
 
+	/* set processing function */
+	if (dev->params.frame_fmt == SOF_IPC_FRAME_S16_LE)
+		dd->process = buffer_copy_s16;
+	else
+		dd->process = buffer_copy_s32;
+
 	/* calculate period size based on config */
 	dd->frame_bytes = comp_frame_bytes(dev);
 	if (!dd->frame_bytes) {
@@ -394,36 +374,66 @@ static int dai_params(struct comp_dev *dev)
 		return -EINVAL;
 	}
 
-	err = dma_get_attribute(dd->dma, DMA_ATTR_BUFFER_ALIGNMENT, &align);
+	err = dma_get_attribute(dd->dma, DMA_ATTR_BUFFER_ADDRESS_ALIGNMENT,
+				&addr_align);
 	if (err < 0) {
-		trace_dai_error("dai_params(): could not get dma buffer "
-				"alignment");
+		trace_dai_error_with_ids(dev, "dai_params() error: could not "
+					 "get dma buffer address alignment, "
+					 "err = %d", err);
 		return err;
 	}
 
-	period_bytes = ALIGN_UP(dev->frames * dd->frame_bytes, align);
-
-	if (!period_bytes) {
-		trace_dai_error_with_ids(dev, "dai_params() error: device has "
-					 "no bytes (no frames to copy to sink).");
+	err = dma_get_attribute(dd->dma, DMA_ATTR_BUFFER_ALIGNMENT, &align);
+	if (err < 0 || !align) {
+		trace_dai_error_with_ids(dev, "dai_params() error: could not "
+				"get valid dma buffer alignment, err = %d, "
+				"align = %u", err, align);
 		return -EINVAL;
 	}
 
-	if (dev->params.direction == SOF_IPC_STREAM_PLAYBACK) {
-		dd->dma_buffer = list_first_item(&dev->bsource_list,
-						 struct comp_buffer,
-						 sink_list);
-		dd->dma_buffer->r_ptr = dd->dma_buffer->addr;
-
-		return dai_playback_params(dev, period_bytes);
+	err = dma_get_attribute(dd->dma, DMA_ATTR_BUFFER_PERIOD_COUNT,
+				&period_count);
+	if (err < 0 || !period_count) {
+		trace_dai_error_with_ids(dev, "dai_params() error: could not "
+					  "get valid dma buffer period count, "
+					  "err = %d, period_count = %u", err,
+					  period_count);
+		return -EINVAL;
 	}
 
-	dd->dma_buffer = list_first_item(&dev->bsink_list,
-					 struct comp_buffer, source_list);
-	dd->dma_buffer->w_ptr = dd->dma_buffer->addr;
+	period_bytes = dev->frames * dd->frame_bytes;
+	if (!period_bytes) {
+		trace_dai_error_with_ids(dev, "dai_params() error: invalid "
+					 "period_bytes.");
+		return -EINVAL;
+	}
 
-	return dai_capture_params(dev, period_bytes);
+	/* calculate DMA buffer size */
+	buffer_size = ALIGN_UP(period_count * period_bytes, align);
 
+	/* alloc DMA buffer or change its size if exists */
+	if (dd->dma_buffer) {
+		err = buffer_set_size(dd->dma_buffer, buffer_size);
+		if (err < 0) {
+			trace_dai_error_with_ids(dev, "dai_params() error: "
+						 "buffer_set_size() failed, "
+						 "buffer_size = %u",
+						 buffer_size);
+			return err;
+		}
+	} else {
+		dd->dma_buffer = buffer_alloc(buffer_size, SOF_MEM_CAPS_DMA,
+					      addr_align);
+		if (!dd->dma_buffer) {
+			trace_dai_error_with_ids(dev, "dai_params() error: "
+						 "failed to alloc dma buffer");
+			return -ENOMEM;
+		}
+	}
+
+	return dev->params.direction == SOF_IPC_STREAM_PLAYBACK ?
+		dai_playback_params(dev, period_bytes, period_count) :
+		dai_capture_params(dev, period_bytes, period_count);
 }
 
 static int dai_prepare(struct comp_dev *dev)
@@ -482,6 +492,11 @@ static int dai_reset(struct comp_dev *dev)
 	trace_dai_with_ids(dev, "dai_reset()");
 
 	dma_sg_free(&config->elem_array);
+
+	if (dd->dma_buffer) {
+		buffer_free(dd->dma_buffer);
+		dd->dma_buffer = NULL;
+	}
 
 	dd->dai_pos_blks = 0;
 	if (dd->dai_pos)
@@ -589,6 +604,7 @@ static int dai_comp_trigger(struct comp_dev *dev, int cmd)
 static int dai_check_for_xrun(struct comp_dev *dev, uint32_t copy_bytes)
 {
 	struct dai_data *dd = comp_get_drvdata(dev);
+	struct comp_buffer *local_buffer;
 
 	/* data available for copy */
 	if (copy_bytes)
@@ -603,12 +619,16 @@ static int dai_check_for_xrun(struct comp_dev *dev, uint32_t copy_bytes)
 		trace_dai_error_with_ids(dev, "dai_check_for_xrun() "
 					 "error: underrun due to no data "
 					 "available");
-		comp_underrun(dev, dd->dma_buffer, copy_bytes);
+		local_buffer = list_first_item(&dev->bsource_list,
+					       struct comp_buffer, sink_list);
+		comp_underrun(dev, local_buffer, copy_bytes);
 	} else {
 		trace_dai_error_with_ids(dev, "dai_check_for_xrun() "
 					 "error: overrun due to no data "
 					 "available");
-		comp_overrun(dev, dd->dma_buffer, copy_bytes);
+		local_buffer = list_first_item(&dev->bsink_list,
+					       struct comp_buffer, source_list);
+		comp_overrun(dev, local_buffer, copy_bytes);
 	}
 
 	return -ENODATA;
@@ -618,6 +638,7 @@ static int dai_check_for_xrun(struct comp_dev *dev, uint32_t copy_bytes)
 static int dai_copy(struct comp_dev *dev)
 {
 	struct dai_data *dd = comp_get_drvdata(dev);
+	struct comp_buffer *local_buffer;
 	uint32_t avail_bytes = 0;
 	uint32_t free_bytes = 0;
 	uint32_t copy_bytes = 0;
@@ -644,9 +665,15 @@ static int dai_copy(struct comp_dev *dev)
 		return ret;
 
 	/* calculate minimum size to copy */
-	copy_bytes = dev->params.direction == SOF_IPC_STREAM_PLAYBACK ?
-		MIN(dd->dma_buffer->avail, free_bytes) :
-		MIN(avail_bytes, dd->dma_buffer->free);
+	if (dev->params.direction == SOF_IPC_STREAM_PLAYBACK) {
+		local_buffer = list_first_item(&dev->bsource_list,
+					       struct comp_buffer, sink_list);
+		copy_bytes = MIN(local_buffer->avail, free_bytes);
+	} else {
+		local_buffer = list_first_item(&dev->bsink_list,
+					       struct comp_buffer, source_list);
+		copy_bytes = MIN(avail_bytes, local_buffer->free);
+	}
 
 	tracev_dai_with_ids(dev, "dai_copy(), copy_bytes = 0x%x", copy_bytes);
 
@@ -831,7 +858,6 @@ static int dai_config(struct comp_dev *dev, struct sof_ipc_dai_config *config)
 
 		/* set up callback */
 		dma_set_cb(dd->chan, DMA_CB_TYPE_COPY, dai_dma_cb, dev);
-		dev->is_dma_connected = 1;
 	}
 
 	return 0;

--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -540,11 +540,8 @@ static int dai_comp_trigger(struct comp_dev *dev, int cmd)
 	case COMP_TRIGGER_START:
 		trace_dai_with_ids(dev, "dai_comp_trigger(), START");
 
-		/* only start the DAI if we are not XRUN handling
-		 * and the pipeline is not preloaded as in this
-		 * case start is deferred to the first copy call
-		 */
-		if (dd->xrun == 0 && !pipeline_is_preload(dev->pipeline)) {
+		/* only start the DAI if we are not XRUN handling */
+		if (dd->xrun == 0) {
 			/* start the DAI */
 			dai_trigger(dd->dai, cmd, dev->params.direction);
 			ret = dma_start(dd->chan);
@@ -645,19 +642,6 @@ static int dai_copy(struct comp_dev *dev)
 	int ret = 0;
 
 	tracev_dai_with_ids(dev, "dai_copy()");
-
-	/* start DMA on preload */
-	if (pipeline_is_preload(dev->pipeline)) {
-		/* start the DAI */
-		dai_trigger(dd->dai, COMP_TRIGGER_START,
-			    dev->params.direction);
-		ret = dma_start(dd->chan);
-		if (ret < 0)
-			return ret;
-		dai_update_start_position(dev);
-
-		return 0;
-	}
 
 	/* get data sizes from DMA */
 	ret = dma_get_data_size(dd->chan, &avail_bytes, &free_bytes);

--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -603,13 +603,9 @@ static int dai_check_for_xrun(struct comp_dev *dev, uint32_t copy_bytes)
 	struct dai_data *dd = comp_get_drvdata(dev);
 	struct comp_buffer *local_buffer;
 
-	/* data available for copy */
-	if (copy_bytes)
+	/* data available for copy or just starting */
+	if (copy_bytes || dd->start_position == dev->position)
 		return 0;
-
-	/* no data yet, we're just starting */
-	if (dd->start_position == dev->position)
-		return PPL_STATUS_PATH_STOP;
 
 	/* xrun occurred */
 	if (dev->params.direction == SOF_IPC_STREAM_PLAYBACK) {
@@ -663,7 +659,7 @@ static int dai_copy(struct comp_dev *dev)
 
 	/* check for underrun or overrun */
 	ret = dai_check_for_xrun(dev, copy_bytes);
-	if (ret < 0 || ret == PPL_STATUS_PATH_STOP)
+	if (ret < 0)
 		return ret;
 
 	ret = dma_copy(dd->chan, copy_bytes, 0);

--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -733,12 +733,10 @@ static int eq_fir_prepare(struct comp_dev *dev)
 	else
 		dev->params.frame_fmt = cd->sink_format;
 
-	/* set downstream buffer size */
-	ret = comp_set_sink_buffer(dev, sink_period_bytes,
-				   config->periods_sink);
-	if (ret < 0) {
+	if (sinkb->size < config->periods_sink * sink_period_bytes) {
 		trace_eq_error("eq_fir_prepare() error: "
-			       "comp_set_sink_buffer() failed");
+			       "sink buffer size is insufficient");
+		ret = -ENOMEM;
 		goto err;
 	}
 

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -778,12 +778,10 @@ static int eq_iir_prepare(struct comp_dev *dev)
 	else
 		dev->params.frame_fmt = cd->sink_format;
 
-	/* set downstream buffer size */
-	ret = comp_set_sink_buffer(dev, sink_period_bytes,
-				   config->periods_sink);
-	if (ret < 0) {
+	if (sinkb->size < config->periods_sink * sink_period_bytes) {
 		trace_eq_error("eq_iir_prepare() error: "
-			       "comp_set_sink_buffer() failed");
+			       "sink buffer size is insufficient");
+		ret = -ENOMEM;
 		goto err;
 	}
 

--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -531,7 +531,8 @@ static void realign_buffer(struct host_data *hd)
 					SOF_MEM_CAPS_DMA,
 					hd->dma_buffer->alloc_size,
 					buffer_alignment);
-		buffer_init(hd->dma_buffer, hd->dma_buffer->alloc_size);
+		buffer_init(hd->dma_buffer, hd->dma_buffer->alloc_size,
+			    SOF_MEM_CAPS_DMA);
 	}
 }
 

--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -77,7 +77,6 @@ struct host_data {
 	struct dma_chan_data *chan;
 	struct dma_sg_config config;
 	struct comp_buffer *dma_buffer;
-	uint32_t period_bytes;	/**< Size of a single period (in bytes) */
 
 	/* host position reporting related */
 	uint32_t host_size;	/**< Host buffer size (in bytes) */
@@ -95,12 +94,13 @@ struct host_data {
 	struct hc_buf *source;
 	struct hc_buf *sink;
 
-	/* helper used in split transactions */
-	uint32_t split_value;
-
 	uint32_t dma_copy_align; /**< Minimal chunk of data possible to be
 				   *  copied by dma connected to host
 				   */
+
+	/* processing function */
+	void (*process)(struct comp_buffer *source, struct comp_buffer *sink,
+			uint32_t bytes);
 
 	/* stream info */
 	struct sof_ipc_stream_posn posn; /* TODO: update this */
@@ -136,11 +136,19 @@ static uint32_t host_dma_get_split(struct host_data *hd, uint32_t bytes)
 static void host_update_position(struct comp_dev *dev, uint32_t bytes)
 {
 	struct host_data *hd = comp_get_drvdata(dev);
+	struct comp_buffer *local_buffer;
 
-	if (dev->params.direction == SOF_IPC_STREAM_PLAYBACK)
-		comp_update_buffer_produce(hd->dma_buffer, bytes);
-	else
-		comp_update_buffer_consume(hd->dma_buffer, bytes);
+	if (dev->params.direction == SOF_IPC_STREAM_PLAYBACK) {
+		local_buffer = list_first_item(&dev->bsink_list,
+					       struct comp_buffer, source_list);
+		dma_buffer_copy_from(hd->dma_buffer, local_buffer, hd->process,
+				     bytes);
+	} else {
+		local_buffer = list_first_item(&dev->bsource_list,
+					       struct comp_buffer, sink_list);
+		dma_buffer_copy_to(local_buffer, hd->dma_buffer, hd->process,
+				   bytes);
+	}
 
 	dev->position += bytes;
 
@@ -291,10 +299,10 @@ static int host_trigger(struct comp_dev *dev, int cmd)
 		return ret;
 	}
 
-	/* we should ignore any trigger commands when doing one shot,
-	 * because transfers will start in copy and stop automatically
+	/* we should ignore any trigger commands besides start
+	 * when doing one shot, because transfers will stop automatically
 	 */
-	if (hd->copy_type == COMP_COPY_ONE_SHOT)
+	if (cmd != COMP_TRIGGER_START && hd->copy_type == COMP_COPY_ONE_SHOT)
 		return ret;
 
 	if (!hd->chan) {
@@ -378,7 +386,6 @@ static struct comp_dev *host_new(struct sof_ipc_comp *comp)
 	hd->copy_type = COMP_COPY_NORMAL;
 	hd->posn.comp_id = comp->id;
 	dev->state = COMP_STATE_READY;
-	dev->is_dma_connected = 1;
 
 	return dev;
 }
@@ -430,122 +437,15 @@ static int host_elements_reset(struct comp_dev *dev)
 	return 0;
 }
 
-static uint32_t host_buffer_get_copy_bytes(struct comp_dev *dev)
-{
-	struct host_data *hd = comp_get_drvdata(dev);
-	struct dma_sg_elem *local_elem = hd->config.elem_array.elems;
-	uint32_t avail_bytes = 0;
-	uint32_t free_bytes = 0;
-	uint32_t copy_bytes = 0;
-	int ret;
-
-	if (hd->copy_type == COMP_COPY_ONE_SHOT) {
-		/* calculate minimum size to copy */
-		copy_bytes = dev->params.direction == SOF_IPC_STREAM_PLAYBACK ?
-			hd->dma_buffer->free : hd->dma_buffer->avail;
-
-		/* copy_bytes should be aligned to minimum possible chunk of
-		 * data to be copied by dma.
-		 */
-		copy_bytes = ALIGN_DOWN(copy_bytes, hd->dma_copy_align);
-
-		hd->split_value = host_dma_get_split(hd, copy_bytes);
-		if (hd->split_value)
-			copy_bytes -= hd->split_value;
-
-		local_elem->size = copy_bytes;
-	} else {
-		/* get data sizes from DMA */
-		ret = dma_get_data_size(hd->chan, &avail_bytes,
-					&free_bytes);
-		if (ret < 0) {
-			trace_host_error("host_buffer_cb() error: "
-					 "dma_get_data_size() failed, ret = %u",
-					 ret);
-			return 0;
-		}
-
-		/* calculate minimum size to copy */
-		copy_bytes = dev->params.direction == SOF_IPC_STREAM_PLAYBACK ?
-			MIN(avail_bytes, hd->dma_buffer->free) :
-			MIN(hd->dma_buffer->avail, free_bytes);
-
-		/* copy_bytes should be aligned to minimum possible chunk of
-		 * data to be copied by dma.
-		 */
-		copy_bytes = ALIGN_DOWN(copy_bytes, hd->dma_copy_align);
-	}
-
-	return copy_bytes;
-}
-
-static void host_buffer_cb(void *data, uint32_t bytes)
-{
-	struct comp_dev *dev = (struct comp_dev *)data;
-	struct host_data *hd = comp_get_drvdata(dev);
-	uint32_t copy_bytes = 0;
-	uint32_t flags = 0;
-	int ret;
-
-	tracev_host("host_buffer_cb(), bytes = 0x%x", bytes);
-
-	if (hd->copy_type == COMP_COPY_BLOCKING)
-		flags |= DMA_COPY_BLOCKING;
-	else if (hd->copy_type == COMP_COPY_ONE_SHOT)
-		flags |= DMA_COPY_ONE_SHOT;
-
-	/* copy including all split transfers */
-	do {
-		copy_bytes = host_buffer_get_copy_bytes(dev);
-
-		/* reconfigure transfer */
-		ret = dma_set_config(hd->chan, &hd->config);
-		if (ret < 0) {
-			trace_host_error("host_buffer_cb() error: "
-					 "dma_set_config() failed, ret = %u",
-					 ret);
-			hd->split_value = 0;
-			return;
-		}
-
-		ret = dma_copy(hd->chan, copy_bytes, flags);
-		if (ret < 0) {
-			trace_host_error("host_buffer_cb() error: dma_copy() "
-					 "failed, ret = %u", ret);
-			hd->split_value = 0;
-			return;
-		}
-	} while (hd->split_value);
-}
-
-static void realign_buffer(struct host_data *hd)
-{
-	uint32_t buffer_alignment;
-
-	dma_get_attribute(hd->dma, DMA_ATTR_BUFFER_ADDRESS_ALIGNMENT,
-			  &buffer_alignment);
-
-	if ((uintptr_t)hd->dma_buffer->addr % buffer_alignment) {
-		hd->dma_buffer->addr =
-			rbrealloc_align(hd->dma_buffer->addr, RZONE_BUFFER,
-					SOF_MEM_CAPS_DMA,
-					hd->dma_buffer->alloc_size,
-					buffer_alignment);
-		buffer_init(hd->dma_buffer, hd->dma_buffer->alloc_size,
-			    SOF_MEM_CAPS_DMA);
-	}
-}
-
 /* configure the DMA params and descriptors for host buffer IO */
 static int host_params(struct comp_dev *dev)
 {
 	struct host_data *hd = comp_get_drvdata(dev);
-	struct sof_ipc_comp_config *cconfig = COMP_GET_CONFIG(dev);
 	struct dma_sg_config *config = &hd->config;
-	uint32_t buffer_size;
-	uint32_t buffer_count;
-	uint32_t buffer_single_size;
 	uint32_t period_count;
+	uint32_t period_bytes;
+	uint32_t buffer_size;
+	uint32_t addr_align;
 	uint32_t align;
 	int err;
 
@@ -554,91 +454,85 @@ static int host_params(struct comp_dev *dev)
 	/* host params always installed by pipeline IPC */
 	hd->host_size = dev->params.buffer.size;
 
-	err = dma_get_attribute(hd->dma, DMA_ATTR_BUFFER_ALIGNMENT, &align);
+	/* retrieve DMA buffer address alignment */
+	err = dma_get_attribute(hd->dma, DMA_ATTR_BUFFER_ADDRESS_ALIGNMENT,
+				&addr_align);
 	if (err < 0) {
-		trace_host_error_with_ids(dev, "could not get dma buffer "
-					  "alignment");
+		trace_host_error_with_ids(dev, "host_params() error: could not "
+					  "get dma buffer address alignment, "
+					  "err = %d", err);
 		return err;
 	}
 
-	/* determine source and sink buffer elems */
-	if (dev->params.direction == SOF_IPC_STREAM_PLAYBACK) {
-		hd->dma_buffer = list_first_item(&dev->bsink_list,
-			struct comp_buffer, source_list);
-
-		realign_buffer(hd);
-
-		/* set callback on buffer consume */
-		buffer_set_cb(hd->dma_buffer, &host_buffer_cb, dev,
-			      BUFF_CB_TYPE_CONSUME);
-
-		config->direction = DMA_DIR_HMEM_TO_LMEM;
-
-		period_count = cconfig->periods_sink;
-
-		buffer_count = hd->host.elem_array.count ? 1 : period_count;
-		buffer_single_size = ALIGN_UP(dev->frames *
-					      comp_frame_bytes(dev),
-					      align);
-
-		if (hd->host.elem_array.count)
-			buffer_single_size *= period_count;
-
-		hd->source = &hd->host;
-		hd->sink = &hd->local;
-	} else {
-		hd->dma_buffer = list_first_item(&dev->bsource_list,
-			struct comp_buffer, sink_list);
-
-		realign_buffer(hd);
-
-		/* set callback on buffer produce */
-		buffer_set_cb(hd->dma_buffer, &host_buffer_cb, dev,
-			      BUFF_CB_TYPE_PRODUCE);
-
-		config->direction = DMA_DIR_LMEM_TO_HMEM;
-
-		period_count = cconfig->periods_source;
-
-		buffer_count = hd->host.elem_array.count ? 1 : period_count;
-		buffer_single_size = ALIGN_UP(dev->frames *
-					      comp_frame_bytes(dev),
-					      align);
-
-		if (hd->host.elem_array.count)
-			buffer_single_size *= period_count;
-
-		hd->source = &hd->local;
-		hd->sink = &hd->host;
-	}
-
-	/* validate period count */
-	if (!period_count) {
-		trace_host_error_with_ids(dev, "host_params() error: invalid "
-					  "period_count");
+	/* retrieve DMA buffer size alignment */
+	err = dma_get_attribute(hd->dma, DMA_ATTR_BUFFER_ALIGNMENT, &align);
+	if (err < 0 || !align) {
+		trace_host_error_with_ids(dev, "host_params() error: could not "
+					  "get valid dma buffer alignment, err "
+					  "= %d, align = %u", err, align);
 		return -EINVAL;
 	}
 
-	hd->period_bytes = ALIGN_UP(dev->frames * comp_frame_bytes(dev), align);
+	/* retrieve DMA buffer period count */
+	err = dma_get_attribute(hd->dma, DMA_ATTR_BUFFER_PERIOD_COUNT,
+				&period_count);
+	if (err < 0 || !period_count) {
+		trace_host_error_with_ids(dev, "host_params() error: could not "
+					  "get valid dma buffer period count, "
+					  "err = %d, period_count = %u", err,
+					  period_count);
+		return -EINVAL;
+	}
 
-	if (hd->period_bytes == 0) {
+	period_bytes = dev->frames * comp_frame_bytes(dev);
+	if (!period_bytes) {
 		trace_host_error_with_ids(dev, "host_params() error: invalid "
 					  "period_bytes");
 		return -EINVAL;
 	}
 
-	/* resize the buffer if space is available to align with period size */
-	buffer_size = period_count * hd->period_bytes;
-	err = buffer_set_size(hd->dma_buffer, buffer_size);
-	if (err < 0) {
-		trace_host_error_with_ids(dev, "host_params() error:"
-					  "buffer_set_size() failed, "
-					  "buffer_size = %u", buffer_size);
-		return err;
+	/* determine source and sink buffer elements */
+	if (dev->params.direction == SOF_IPC_STREAM_PLAYBACK) {
+		config->direction = DMA_DIR_HMEM_TO_LMEM;
+		hd->source = &hd->host;
+		hd->sink = &hd->local;
+	} else {
+		config->direction = DMA_DIR_LMEM_TO_HMEM;
+		hd->source = &hd->local;
+		hd->sink = &hd->host;
+	}
+
+	/* TODO: should be taken from DMA */
+	if (hd->host.elem_array.count) {
+		period_bytes *= period_count;
+		period_count = 1;
+	}
+
+	/* calculate DMA buffer size */
+	buffer_size = ALIGN_UP(period_count * period_bytes, align);
+
+	/* alloc DMA buffer or change its size if exists */
+	if (hd->dma_buffer) {
+		err = buffer_set_size(hd->dma_buffer, buffer_size);
+		if (err < 0) {
+			trace_host_error_with_ids(dev, "host_params() error: "
+						  "buffer_set_size() failed, "
+						  "buffer_size = %u",
+						  buffer_size);
+			return err;
+		}
+	} else {
+		hd->dma_buffer = buffer_alloc(buffer_size, SOF_MEM_CAPS_DMA,
+					      addr_align);
+		if (!hd->dma_buffer) {
+			trace_host_error_with_ids(dev, "host_params() error: "
+						  "failed to alloc dma buffer");
+			return -ENOMEM;
+		}
 	}
 
 	/* create SG DMA elems for local DMA buffer */
-	err = create_local_elems(dev, buffer_count, buffer_single_size);
+	err = create_local_elems(dev, period_count, buffer_size / period_count);
 	if (err < 0)
 		return err;
 
@@ -685,6 +579,12 @@ static int host_params(struct comp_dev *dev)
 	/* set up callback */
 	dma_set_cb(hd->chan, DMA_CB_TYPE_COPY, host_dma_cb, dev);
 
+	/* set processing function */
+	if (dev->params.frame_fmt == SOF_IPC_FRAME_S16_LE)
+		hd->process = buffer_copy_s16;
+	else
+		hd->process = buffer_copy_s32;
+
 	return 0;
 }
 
@@ -704,7 +604,6 @@ static int host_prepare(struct comp_dev *dev)
 
 	hd->local_pos = 0;
 	hd->report_pos = 0;
-	hd->split_value = 0;
 	dev->position = 0;
 
 	return 0;
@@ -747,6 +646,12 @@ static int host_reset(struct comp_dev *dev)
 	dma_sg_free(&hd->local.elem_array);
 	dma_sg_free(&hd->config.elem_array);
 
+	/* free DMA buffer */
+	if (hd->dma_buffer) {
+		buffer_free(hd->dma_buffer);
+		hd->dma_buffer = NULL;
+	}
+
 	/* reset dma channel as we have put it */
 	hd->chan = NULL;
 
@@ -759,10 +664,80 @@ static int host_reset(struct comp_dev *dev)
 	return 0;
 }
 
+static uint32_t host_buffer_get_copy_bytes(struct comp_dev *dev)
+{
+	struct host_data *hd = comp_get_drvdata(dev);
+	struct dma_sg_elem *local_elem = hd->config.elem_array.elems;
+	struct comp_buffer *local_buffer;
+	uint32_t avail_bytes = 0;
+	uint32_t free_bytes = 0;
+	uint32_t copy_bytes = 0;
+	uint32_t split_value;
+	int ret;
+
+	if (hd->copy_type == COMP_COPY_ONE_SHOT) {
+		/* calculate minimum size to copy */
+		if (dev->params.direction == SOF_IPC_STREAM_PLAYBACK) {
+			local_buffer = list_first_item(&dev->bsink_list,
+						       struct comp_buffer,
+						       source_list);
+			copy_bytes = local_buffer->free;
+		} else {
+			local_buffer = list_first_item(&dev->bsource_list,
+						       struct comp_buffer,
+						       sink_list);
+			copy_bytes = local_buffer->avail;
+		}
+
+		/* copy_bytes should be aligned to minimum possible chunk of
+		 * data to be copied by dma.
+		 */
+		copy_bytes = ALIGN_DOWN(copy_bytes, hd->dma_copy_align);
+
+		split_value = host_dma_get_split(hd, copy_bytes);
+		if (split_value)
+			copy_bytes -= split_value;
+
+		local_elem->size = copy_bytes;
+	} else {
+		/* get data sizes from DMA */
+		ret = dma_get_data_size(hd->chan, &avail_bytes,
+					&free_bytes);
+		if (ret < 0) {
+			trace_host_error("host_buffer_cb() error: "
+					 "dma_get_data_size() failed, ret = %u",
+					 ret);
+			return 0;
+		}
+
+		/* calculate minimum size to copy */
+		if (dev->params.direction == SOF_IPC_STREAM_PLAYBACK) {
+			local_buffer = list_first_item(&dev->bsink_list,
+						       struct comp_buffer,
+						       source_list);
+			copy_bytes = MIN(avail_bytes, local_buffer->free);
+		} else {
+			local_buffer = list_first_item(&dev->bsource_list,
+						       struct comp_buffer,
+						       sink_list);
+			copy_bytes = MIN(local_buffer->avail, free_bytes);
+		}
+
+		/* copy_bytes should be aligned to minimum possible chunk of
+		 * data to be copied by dma.
+		 */
+		copy_bytes = ALIGN_DOWN(copy_bytes, hd->dma_copy_align);
+	}
+
+	return copy_bytes;
+}
+
 /* copy and process stream data from source to sink buffers */
 static int host_copy(struct comp_dev *dev)
 {
 	struct host_data *hd = comp_get_drvdata(dev);
+	uint32_t copy_bytes = 0;
+	uint32_t flags = 0;
 	int ret = 0;
 
 	tracev_host_with_ids(dev, "host_copy()");
@@ -770,26 +745,35 @@ static int host_copy(struct comp_dev *dev)
 	if (dev->state != COMP_STATE_ACTIVE)
 		return 0;
 
-	/* here only do preload, further copies happen
-	 * in host_buffer_cb()
-	 */
-	if (dev->params.direction == SOF_IPC_STREAM_PLAYBACK &&
-	    !dev->position) {
-		ret = dma_copy(hd->chan, hd->dma_buffer->size,
-			       DMA_COPY_PRELOAD);
-		if (ret < 0) {
-			if (ret == -ENODATA) {
-				/* preload not finished, so stop processing */
-				trace_host_with_ids(dev, "host_copy(), preload"
-						    " not yet finished");
-				return PPL_STATUS_PATH_STOP;
-			}
+	if (hd->copy_type == COMP_COPY_BLOCKING)
+		flags |= DMA_COPY_BLOCKING;
+	else if (hd->copy_type == COMP_COPY_ONE_SHOT)
+		flags |= DMA_COPY_ONE_SHOT;
 
-			trace_host_error_with_ids(dev, "host_copy() error: "
-						  "dma_copy() failed, "
-						  "ret = %u", ret);
-			return ret;
-		}
+	/* update first transfer manually */
+	if (!dev->position && flags & COMP_COPY_ONE_SHOT)
+		host_one_shot_cb(dev, hd->dma_buffer->size);
+
+	copy_bytes = host_buffer_get_copy_bytes(dev);
+	if (!copy_bytes) {
+		trace_host_with_ids(dev, "host_copy(): no bytes to copy");
+		return ret;
+	}
+
+	/* reconfigure transfer */
+	ret = dma_set_config(hd->chan, &hd->config);
+	if (ret < 0) {
+		trace_host_error("host_copy() error: "
+				 "dma_set_config() failed, ret = %u",
+				 ret);
+		return ret;
+	}
+
+	ret = dma_copy(hd->chan, copy_bytes, flags);
+	if (ret < 0) {
+		trace_host_error("host_copy() error: dma_copy() "
+				 "failed, ret = %u", ret);
+		return ret;
 	}
 
 	return ret;

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -618,7 +618,6 @@ static int kpb_copy(struct comp_dev *dev)
 		comp_update_buffer_produce(sink, copy_bytes);
 		comp_update_buffer_consume(source, copy_bytes);
 
-		ret = PPL_STATUS_PATH_STOP;
 		break;
 	case KPB_STATE_DRAINING:
 		/* In draining state we only buffer data in internal,
@@ -1083,8 +1082,10 @@ static enum task_state kpb_draining_task(void *arg)
 			move_buffer = false;
 		}
 
-		if (size_to_copy)
+		if (size_to_copy) {
 			comp_update_buffer_produce(sink, size_to_copy);
+			comp_copy(sink->sink);
+		}
 
 		if (period_bytes >= period_bytes_limit) {
 			current_time = platform_timer_get(platform_timer);

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -154,8 +154,8 @@ static void mixer_free(struct comp_dev *dev)
 static int mixer_params(struct comp_dev *dev)
 {
 	struct sof_ipc_comp_config *config = COMP_GET_CONFIG(dev);
+	struct comp_buffer *sinkb;
 	uint32_t period_bytes;
-	int ret;
 
 	trace_mixer("mixer_params()");
 
@@ -166,13 +166,13 @@ static int mixer_params(struct comp_dev *dev)
 		return -EINVAL;
 	}
 
-	/* set downstream buffer size */
-	ret = comp_set_sink_buffer(dev, period_bytes,
-				   config->periods_sink);
-	if (ret < 0) {
+	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer,
+				source_list);
+
+	if (sinkb->size < config->periods_sink * period_bytes) {
 		trace_mixer_error("mixer_params() error: "
-				  "comp_set_sink_buffer() failed");
-		return ret;
+				  "sink buffer size is insufficient");
+		return -ENOMEM;
 	}
 
 	return 0;

--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -228,7 +228,7 @@ static int demux_copy(struct comp_dev *dev)
 		sink = container_of(clist, struct comp_buffer, source_list);
 		if (sink->sink->state == dev->state) {
 			num_sinks++;
-			i = get_stream_index(cd, sink->ipc_buffer.comp.pipeline_id);
+			i = get_stream_index(cd, sink->pipeline_id);
 			sinks[i] = sink;
 		}
 	}
@@ -297,7 +297,7 @@ static int mux_copy(struct comp_dev *dev)
 		source = container_of(clist, struct comp_buffer, sink_list);
 		if (source->source->state == dev->state) {
 			num_sources++;
-			i = get_stream_index(cd, source->ipc_buffer.comp.pipeline_id);
+			i = get_stream_index(cd, source->pipeline_id);
 			sources[i] = source;
 		}
 	}

--- a/src/audio/pipeline.c
+++ b/src/audio/pipeline.c
@@ -72,7 +72,7 @@ int pipeline_connect(struct comp_dev *comp, struct comp_buffer *buffer,
 	uint32_t flags;
 
 	trace_pipe("pipeline: connect comp %d and buffer %d",
-		   comp->comp.id, buffer->ipc_buffer.comp.id);
+		   comp->comp.id, buffer->id);
 
 	irq_local_disable(flags);
 	list_item_prepend(buffer_comp_list(buffer, dir),

--- a/src/audio/pipeline.c
+++ b/src/audio/pipeline.c
@@ -373,12 +373,7 @@ static int pipeline_comp_task_init(struct pipeline *p)
 {
 	uint32_t type;
 
-	/* pipeline preload needed only for playback streams without active
-	 * sink component (it can be active for e.g. mixer pipelines)
-	 */
-	p->preload =
-		p->sink_comp->params.direction == SOF_IPC_STREAM_PLAYBACK &&
-		p->sink_comp->state != COMP_STATE_ACTIVE;
+	p->preload = false;
 
 	/* initialize task if necessary */
 	if (!p->pipe_task) {
@@ -829,21 +824,6 @@ static int pipeline_copy(struct pipeline *p)
 	if (p->source_comp->params.direction == SOF_IPC_STREAM_PLAYBACK) {
 		dir = PPL_DIR_UPSTREAM;
 		start = p->sink_comp;
-
-		/* if not pipeline preload then copy sink comp first */
-		if (!p->preload && comp_is_active(start)) {
-			ret = comp_copy(start);
-			if (ret < 0) {
-				trace_pipe_error("pipeline_copy() error: "
-						 "ret = %d", ret);
-				return ret;
-			}
-
-			start = comp_get_previous(start, dir);
-			if (!start)
-				/* nothing else to do */
-				return ret;
-		}
 	} else {
 		dir = PPL_DIR_DOWNSTREAM;
 		start = p->source_comp;

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -380,12 +380,10 @@ static int selector_prepare(struct comp_dev *dev)
 	trace_selector("selector_prepare(): sink->params.channels = %u",
 		       sinkb->sink->params.channels);
 
-	/* set downstream buffer size */
-	ret = comp_set_sink_buffer(dev, cd->sink_period_bytes,
-				   config->periods_sink);
-	if (ret < 0) {
+	if (sinkb->size < config->periods_sink * cd->sink_period_bytes) {
 		trace_selector_error("selector_prepare() error: "
-				     "comp_set_sink_buffer() failed");
+				     "sink buffer size is insufficient");
+		ret = -ENOMEM;
 		goto err;
 	}
 

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -820,12 +820,10 @@ static int src_prepare(struct comp_dev *dev)
 	else
 		dev->params.frame_fmt = cd->sink_format;
 
-	/* set downstream buffer size */
-	ret = comp_set_sink_buffer(dev, sink_period_bytes,
-				   config->periods_sink);
-	if (ret < 0) {
+	if (sinkb->size < config->periods_sink * sink_period_bytes) {
 		trace_src_error("src_prepare() error: "
-				"comp_set_sink_buffer() failed");
+				"sink buffer size is insufficient");
+		ret = -ENOMEM;
 		goto err;
 	}
 

--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -615,14 +615,10 @@ static int volume_prepare(struct comp_dev *dev)
 	else
 		dev->params.frame_fmt = cd->sink_format;
 
-	/* set downstream buffer size */
-	ret = comp_set_sink_buffer(dev, sink_period_bytes,
-				   config->periods_sink);
-
-	if (ret < 0) {
+	if (sinkb->size < config->periods_sink * sink_period_bytes) {
 		trace_volume_error("volume_prepare() error: "
-				   "comp_set_sink_buffer() failed");
-
+				  "sink buffer size is insufficient");
+		ret = -ENOMEM;
 		goto err;
 	}
 

--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -853,12 +853,21 @@ static int dw_dma_copy(struct dma_chan_data *channel, int bytes,
 		.status = DMA_CB_STATUS_END
 	};
 
-	/* for preload and one shot copy just start the DMA and wait */
-	if (flags & (DMA_COPY_PRELOAD | DMA_COPY_ONE_SHOT)) {
+	tracev_dwdma("dw_dma_copy(): dma %d channel %d copy",
+		     channel->dma->plat_data.id, channel->index);
+
+	if (channel->cb && channel->cb_type & DMA_CB_TYPE_COPY)
+		channel->cb(channel->cb_data, DMA_CB_TYPE_COPY, &next);
+
+	if (flags & DMA_COPY_ONE_SHOT) {
+		/* for one shot copy start the DMA */
 		ret = dw_dma_start(channel);
 		if (ret < 0)
 			return ret;
+	}
 
+	if (flags & DMA_COPY_BLOCKING) {
+		/* wait for transfer finish */
 		ret = poll_for_register_delay(dma_base(channel->dma) +
 					      DW_DMA_CHAN_EN,
 					      DW_CHAN(channel->index), 0,
@@ -866,12 +875,6 @@ static int dw_dma_copy(struct dma_chan_data *channel, int bytes,
 		if (ret < 0)
 			return ret;
 	}
-
-	tracev_dwdma("dw_dma_copy(): dma %d channel %d copy",
-		     channel->dma->plat_data.id, channel->index);
-
-	if (channel->cb && channel->cb_type & DMA_CB_TYPE_COPY)
-		channel->cb(channel->cb_data, DMA_CB_TYPE_COPY, &next);
 
 	dw_dma_verify_transfer(channel, &next);
 

--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -65,6 +65,12 @@ struct dw_dma_chan_data {
  */
 static const uint32_t burst_elems[] = {1, 2, 4, 8};
 
+#if CONFIG_HW_LLI
+#define DW_DMA_BUFFER_PERIOD_COUNT	3
+#else
+#define DW_DMA_BUFFER_PERIOD_COUNT	2
+#endif
+
 static void dw_dma_interrupt_mask(struct dma_chan_data *channel)
 {
 	/* mask block, transfer and error interrupts for channel */
@@ -1082,6 +1088,9 @@ static int dw_dma_get_attribute(struct dma *dma, uint32_t type,
 		break;
 	case DMA_ATTR_BUFFER_ADDRESS_ALIGNMENT:
 		*value = PLATFORM_DCACHE_ALIGN;
+		break;
+	case DMA_ATTR_BUFFER_PERIOD_COUNT:
+		*value = DW_DMA_BUFFER_PERIOD_COUNT;
 		break;
 	default:
 		ret = -EINVAL;

--- a/src/drivers/generic/dummy-dma.c
+++ b/src/drivers/generic/dummy-dma.c
@@ -58,6 +58,8 @@ struct dma_chan_pdata {
 	bool cyclic;
 };
 
+#define DUMMY_DMA_BUFFER_PERIOD_COUNT	2
+
 /**
  * \brief Copy the currently-in-progress DMA SG elem
  * \param[in,out] pdata: Private data structure for this DMA channel
@@ -525,6 +527,9 @@ static int dummy_dma_get_attribute(struct dma *dma, uint32_t type,
 		break;
 	case DMA_ATTR_BUFFER_ADDRESS_ALIGNMENT:
 		*value = PLATFORM_DCACHE_ALIGN;
+		break;
+	case DMA_ATTR_BUFFER_PERIOD_COUNT:
+		*value = DUMMY_DMA_BUFFER_PERIOD_COUNT;
 		break;
 	default:
 		return -ENOENT; /* Attribute not found */

--- a/src/drivers/imx/edma.c
+++ b/src/drivers/imx/edma.c
@@ -493,6 +493,9 @@ static int edma_get_attribute(struct dma *dma, uint32_t type, uint32_t *value)
 	case DMA_ATTR_BUFFER_ADDRESS_ALIGNMENT:
 		*value = PLATFORM_DCACHE_ALIGN;
 		break;
+	case DMA_ATTR_BUFFER_PERIOD_COUNT:
+		*value = EDMA_BUFFER_PERIOD_COUNT;
+		break;
 	default:
 		return -ENOENT; /* Attribute not found */
 	}

--- a/src/drivers/intel/cavs/hda-dma.c
+++ b/src/drivers/intel/cavs/hda-dma.c
@@ -70,6 +70,9 @@
 /* DMA host transfer timeout in microseconds */
 #define HDA_DMA_TIMEOUT	200
 
+/* DMA number of buffer periods */
+#define HDA_DMA_BUFFER_PERIOD_COUNT	2
+
 /*
  * DMA Pointer Trace
  *
@@ -882,6 +885,9 @@ static int hda_dma_get_attribute(struct dma *dma, uint32_t type,
 		break;
 	case DMA_ATTR_BUFFER_ADDRESS_ALIGNMENT:
 		*value = HDA_DMA_BUFFER_ADDRESS_ALIGNMENT;
+		break;
+	case DMA_ATTR_BUFFER_PERIOD_COUNT:
+		*value = HDA_DMA_BUFFER_PERIOD_COUNT;
 		break;
 	default:
 		ret = -EINVAL;

--- a/src/drivers/intel/cavs/hda-dma.c
+++ b/src/drivers/intel/cavs/hda-dma.c
@@ -277,10 +277,22 @@ static void hda_dma_post_copy(struct dma_chan_data *chan, int bytes)
 	if (chan->cb)
 		chan->cb(chan->cb_data, DMA_CB_TYPE_COPY, &next);
 
-	/* Force Host DMA to exit L1 */
 	if (chan->direction == DMA_DIR_HMEM_TO_LMEM ||
-	    chan->direction == DMA_DIR_LMEM_TO_HMEM)
+	    chan->direction == DMA_DIR_LMEM_TO_HMEM) {
+		/* set BFPI to let host gateway know we have read size,
+		 * which will trigger next copy start.
+		 */
+		hda_dma_inc_fp(chan, bytes);
+
+		/* Force Host DMA to exit L1 */
 		pm_runtime_put(PM_RUNTIME_HOST_DMA_L1, 0);
+	} else {
+		/*
+		 * set BFPI to let link gateway know we have read size,
+		 * which will trigger next copy start.
+		 */
+		hda_dma_inc_link_fp(chan, bytes);
+	}
 }
 
 static int hda_dma_link_copy_ch(struct dma_chan_data *chan, int bytes)
@@ -298,11 +310,6 @@ static int hda_dma_link_copy_ch(struct dma_chan_data *chan, int bytes)
 	if (dgcs & DGCS_BOR)
 		dma_chan_reg_update_bits(chan, DGCS, DGCS_BOR, DGCS_BOR);
 
-	/*
-	 * set BFPI to let link gateway know we have read size,
-	 * which will trigger next copy start.
-	 */
-	hda_dma_inc_link_fp(chan, bytes);
 	hda_dma_post_copy(chan, bytes);
 
 	hda_dma_get_dbg_vals(chan, HDA_DBG_POST, HDA_DBG_LINK);
@@ -370,11 +377,6 @@ static int hda_dma_host_copy(struct dma_chan_data *channel, int bytes,
 			hda_dma_is_buffer_empty(channel);
 		if (!ret)
 			return -ENODATA;
-	} else {
-		/* set BFPI to let host gateway know we have read size,
-		 * which will trigger next copy start.
-		 */
-		hda_dma_inc_fp(channel, bytes);
 	}
 
 	/* blocking mode copy */

--- a/src/drivers/intel/cavs/hda-dma.c
+++ b/src/drivers/intel/cavs/hda-dma.c
@@ -370,15 +370,6 @@ static int hda_dma_host_copy(struct dma_chan_data *channel, int bytes,
 
 	hda_dma_get_dbg_vals(channel, HDA_DBG_PRE, HDA_DBG_HOST);
 
-	if (flags & DMA_COPY_PRELOAD) {
-		/* report lack of data if preload is not yet finished */
-		ret = channel->direction == DMA_DIR_HMEM_TO_LMEM ?
-			hda_dma_is_buffer_full(channel) :
-			hda_dma_is_buffer_empty(channel);
-		if (!ret)
-			return -ENODATA;
-	}
-
 	/* blocking mode copy */
 	if (flags & DMA_COPY_BLOCKING) {
 		ret = channel->direction == DMA_DIR_HMEM_TO_LMEM ?

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -227,4 +227,41 @@ static inline void buffer_init(struct comp_buffer *buffer, uint32_t size,
 	buffer->avail = 0;
 	buffer_zero(buffer);
 }
+
+static inline void buffer_copy_s16(struct comp_buffer *source,
+				   struct comp_buffer *sink, uint32_t bytes)
+{
+	uint32_t frames = bytes / sizeof(int16_t);
+	uint32_t buff_frag = 0;
+	int16_t *src;
+	int16_t *dst;
+	uint32_t i;
+
+	for (i = 0; i < frames; i++) {
+		src = buffer_read_frag_s16(source, buff_frag);
+		dst = buffer_write_frag_s16(sink, buff_frag);
+		*dst = *src;
+
+		buff_frag++;
+	}
+}
+
+static inline void buffer_copy_s32(struct comp_buffer *source,
+				   struct comp_buffer *sink, uint32_t bytes)
+{
+	uint32_t frames = bytes / sizeof(int32_t);
+	uint32_t buff_frag = 0;
+	int32_t *src;
+	int32_t *dst;
+	uint32_t i;
+
+	for (i = 0; i < frames; i++) {
+		src = buffer_read_frag_s32(source, buff_frag);
+		dst = buffer_write_frag_s32(sink, buff_frag);
+		*dst = *src;
+
+		buff_frag++;
+	}
+}
+
 #endif /* __SOF_AUDIO_BUFFER_H__ */

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -116,6 +116,7 @@ struct comp_buffer {
 typedef void (*cache_buff_op)(struct comp_buffer *);
 
 /* pipeline buffer creation and destruction */
+struct comp_buffer *buffer_alloc(uint32_t size, uint32_t caps, uint32_t align);
 struct comp_buffer *buffer_new(struct sof_ipc_buffer *desc);
 int buffer_set_size(struct comp_buffer *buffer, uint32_t size);
 void buffer_free(struct comp_buffer *buffer);

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -48,8 +48,10 @@ struct comp_buffer {
 	void *addr;		/* buffer base address */
 	void *end_addr;		/* buffer end address */
 
-	/* IPC configuration */
-	struct sof_ipc_buffer ipc_buffer;
+	/* configuration */
+	uint32_t id;
+	uint32_t pipeline_id;
+	uint32_t caps;
 
 	/* connected components */
 	struct comp_dev *source;	/* source component */
@@ -129,7 +131,7 @@ static inline void buffer_zero(struct comp_buffer *buffer)
 	tracev_buffer("buffer_zero()");
 
 	bzero(buffer->addr, buffer->size);
-	if (buffer->ipc_buffer.caps & SOF_MEM_CAPS_DMA)
+	if (buffer->caps & SOF_MEM_CAPS_DMA)
 		dcache_writeback_region(buffer->addr, buffer->size);
 }
 
@@ -211,10 +213,12 @@ static inline void *buffer_get_frag(struct comp_buffer *buffer, void *ptr,
 	return current;
 }
 
-static inline void buffer_init(struct comp_buffer *buffer, uint32_t size)
+static inline void buffer_init(struct comp_buffer *buffer, uint32_t size,
+			       uint32_t caps)
 {
 	buffer->alloc_size = size;
 	buffer->size = size;
+	buffer->caps = caps;
 	buffer->w_ptr = buffer->addr;
 	buffer->r_ptr = buffer->addr;
 	buffer->end_addr = buffer->addr + size;

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -233,7 +233,6 @@ struct comp_dev {
 
 	/* runtime */
 	uint16_t state;		   /**< COMP_STATE_ */
-	uint16_t is_dma_connected; /**< component is connected to DMA */
 	uint64_t position;	   /**< component rendering position */
 	uint32_t frames;	   /**< number of frames we copy to sink */
 	uint32_t output_rate;      /**< 0 means all output rates are fine */

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -380,15 +380,6 @@ static inline void comp_free(struct comp_dev *dev)
 int comp_set_state(struct comp_dev *dev, int cmd);
 
 /**
- * Set component's sink buffer size
- * @param dev Component device.
- * @param period_bytes Amount of bytes in one period.
- * @param periods Amount of periods.
- */
-int comp_set_sink_buffer(struct comp_dev *dev, uint32_t period_bytes,
-			 uint32_t periods);
-
-/**
  * Component parameter init.
  * @param dev Component device.
  * @return 0 if succeeded, error code otherwise.

--- a/src/include/sof/audio/pipeline.h
+++ b/src/include/sof/audio/pipeline.h
@@ -75,11 +75,9 @@ struct pipeline {
 	/* runtime status */
 	int32_t xrun_bytes;		/* last xrun length */
 	uint32_t status;		/* pipeline status */
-	bool preload;			/* is pipeline preload needed */
 
 	/* scheduling */
 	struct task *pipe_task;		/* pipeline processing task */
-	struct task *preload_task;	/* pipeline preload task */
 
 	/* component that drives scheduling in this pipe */
 	struct comp_dev *sched_comp;
@@ -100,12 +98,6 @@ static inline bool pipeline_is_same_sched_comp(struct pipeline *current,
 					       struct pipeline *previous)
 {
 	return current->sched_comp == previous->sched_comp;
-}
-
-/* checks if pipeline is in preload phase */
-static inline bool pipeline_is_preload(struct pipeline *p)
-{
-	return p->preload;
 }
 
 /* checks if pipeline is scheduled with timer */

--- a/src/include/sof/drivers/dw-dma.h
+++ b/src/include/sof/drivers/dw-dma.h
@@ -137,8 +137,8 @@
 #define trace_dwdma_error(__e, ...) \
 	trace_error(TRACE_CLASS_DMA, __e, ##__VA_ARGS__)
 
-#define DW_DMA_BUFFER_ALIGNMENT 0x20
-#define DW_DMA_COPY_ALIGNMENT	0x20
+#define DW_DMA_BUFFER_ALIGNMENT 0x4
+#define DW_DMA_COPY_ALIGNMENT	0x4
 
 /* TODO: add FIFO sizes */
 struct dw_chan_data {

--- a/src/include/sof/drivers/edma.h
+++ b/src/include/sof/drivers/edma.h
@@ -75,6 +75,8 @@
 
 int edma_init(void);
 
+#define EDMA_BUFFER_PERIOD_COUNT	2
+
 #define EDMA_TCD_ALIGNMENT		32
 
 #define EDMA_HS_GET_IRQ(hs) (((hs) & MASK(8, 0)) >> 0)

--- a/src/include/sof/lib/dma.h
+++ b/src/include/sof/lib/dma.h
@@ -66,9 +66,8 @@ struct comp_buffer;
 #define DMA_CB_TYPE_COPY	BIT(1)
 
 /* DMA copy flags */
-#define DMA_COPY_PRELOAD	BIT(0)
-#define DMA_COPY_BLOCKING	BIT(1)
-#define DMA_COPY_ONE_SHOT	BIT(2)
+#define DMA_COPY_BLOCKING	BIT(0)
+#define DMA_COPY_ONE_SHOT	BIT(1)
 
 /* We will use this enum in cb handler to inform dma what
  * action we need to perform.

--- a/src/include/sof/lib/dma.h
+++ b/src/include/sof/lib/dma.h
@@ -91,6 +91,7 @@ enum dma_irq_cmd {
 #define DMA_ATTR_BUFFER_ALIGNMENT		0
 #define DMA_ATTR_COPY_ALIGNMENT			1
 #define DMA_ATTR_BUFFER_ADDRESS_ALIGNMENT	2
+#define DMA_ATTR_BUFFER_PERIOD_COUNT		3
 
 struct dma;
 

--- a/src/include/sof/lib/dma.h
+++ b/src/include/sof/lib/dma.h
@@ -26,6 +26,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+struct comp_buffer;
+
 /** \addtogroup sof_dma_drivers DMA Drivers
  *  DMA Drivers API specification.
  *  @{
@@ -506,6 +508,16 @@ static inline uint32_t dma_sg_get_size(struct dma_sg_elem_array *ea)
 
 	return size;
 }
+
+/* copies data from DMA buffer using provided processing function */
+void dma_buffer_copy_from(struct comp_buffer *source, struct comp_buffer *sink,
+	void (*process)(struct comp_buffer *, struct comp_buffer *, uint32_t),
+	uint32_t bytes);
+
+/* copies data to DMA buffer using provided processing function */
+void dma_buffer_copy_to(struct comp_buffer *source, struct comp_buffer *sink,
+	void (*process)(struct comp_buffer *, struct comp_buffer *, uint32_t),
+	uint32_t bytes);
 
 /* generic DMA DSP <-> Host copier */
 

--- a/src/ipc/dma-copy.c
+++ b/src/ipc/dma-copy.c
@@ -112,7 +112,8 @@ int dma_copy_to_host_nowait(struct dma_copy *dc, struct dma_sg_config *host_sg,
 	if (err < 0)
 		return err;
 
-	err = dma_copy(dc->chan, local_sg_elem.size, DMA_COPY_ONE_SHOT);
+	err = dma_copy(dc->chan, local_sg_elem.size,
+		       DMA_COPY_ONE_SHOT | DMA_COPY_BLOCKING);
 	if (err < 0)
 		return err;
 

--- a/src/ipc/ipc-host-ptable.c
+++ b/src/ipc/ipc-host-ptable.c
@@ -120,7 +120,7 @@ static int ipc_get_page_descriptors(struct dma *dmac, uint8_t *page_table,
 	}
 
 	/* start the copy of page table to DSP */
-	ret = dma_copy(chan, elem.size, DMA_COPY_ONE_SHOT);
+	ret = dma_copy(chan, elem.size, DMA_COPY_ONE_SHOT | DMA_COPY_BLOCKING);
 	if (ret < 0) {
 		trace_ipc_error("ipc_get_page_descriptors() error: "
 				"dma_start() failed");

--- a/src/ipc/ipc.c
+++ b/src/ipc/ipc.c
@@ -51,7 +51,7 @@ struct ipc_comp_dev *ipc_get_comp_by_id(struct ipc *ipc, uint32_t id)
 				return icd;
 			break;
 		case COMP_TYPE_BUFFER:
-			if (icd->cb->ipc_buffer.comp.id == id)
+			if (icd->cb->id == id)
 				return icd;
 			break;
 		case COMP_TYPE_PIPELINE:
@@ -83,7 +83,7 @@ struct ipc_comp_dev *ipc_get_comp_by_ppl_id(struct ipc *ipc, uint16_t type,
 				return icd;
 			break;
 		case COMP_TYPE_BUFFER:
-			if (icd->cb->ipc_buffer.comp.pipeline_id == ppl_id)
+			if (icd->cb->pipeline_id == ppl_id)
 				return icd;
 			break;
 		case COMP_TYPE_PIPELINE:

--- a/src/lib/dma.c
+++ b/src/lib/dma.c
@@ -242,7 +242,7 @@ void dma_buffer_copy_to(struct comp_buffer *source, struct comp_buffer *sink,
 	sink->w_ptr += bytes;
 
 	/* check for pointer wrap */
-	if (source->r_ptr >= sink->end_addr)
+	if (sink->w_ptr >= sink->end_addr)
 		sink->w_ptr = sink->addr +
 			(sink->w_ptr - sink->end_addr);
 

--- a/test/cmocka/src/audio/mixer/mock.c
+++ b/test/cmocka/src/audio/mixer/mock.c
@@ -55,27 +55,6 @@ void pipeline_xrun(struct pipeline *p, struct comp_dev *dev, int32_t bytes)
 {
 }
 
-int comp_set_sink_buffer(struct comp_dev *dev, uint32_t period_bytes,
-			 uint32_t periods)
-{
-	struct comp_buffer *sinkb;
-	int ret = 0;
-
-	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer,
-				source_list);
-
-	if (!sinkb->sink->is_dma_connected) {
-		ret = buffer_set_size(sinkb, period_bytes * periods);
-		if (ret < 0)
-			return ret;
-	} else if (sinkb->size < period_bytes * periods) {
-		ret = -EINVAL;
-		return ret;
-	}
-
-	return ret;
-}
-
 int comp_set_state(struct comp_dev *dev, int cmd)
 {
 	return 0;

--- a/test/cmocka/src/audio/mux/util.h
+++ b/test/cmocka/src/audio/mux/util.h
@@ -29,7 +29,7 @@ static inline struct comp_buffer *create_test_sink(struct comp_dev *dev,
 	buffer->sink->params.channels = channels;
 	buffer->free = 0;
 	buffer->avail = 0;
-	buffer->ipc_buffer.comp.pipeline_id = pipeline_id;
+	buffer->pipeline_id = pipeline_id;
 
 	return buffer;
 }
@@ -57,7 +57,7 @@ static inline struct comp_buffer *create_test_source(struct comp_dev *dev,
 	buffer->source->params.channels = channels;
 	buffer->free = 0;
 	buffer->avail = 0;
-	buffer->ipc_buffer.comp.pipeline_id = pipeline_id;
+	buffer->pipeline_id = pipeline_id;
 
 	return buffer;
 }

--- a/tools/topology/platform/intel/intel-generic-dmic.m4
+++ b/tools/topology/platform/intel/intel-generic-dmic.m4
@@ -12,26 +12,25 @@ define(DMIC_DAI_LINK_16k_ID, `7')
 # Define the pipelines
 #
 
-dnl PIPELINE_PCM_DAI_ADD(pipeline,
+dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,
 dnl     period, priority, core,
-dnl     dai type, dai_index, dai format,
-dnl     dai periods, pcm_min_rate, pcm_max_rate,
-dnl     pipeline_rate, time_domain)
+dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
+dnl     time_domain, sched_comp)
 
 # Passthrough capture pipeline using max channels defined by CHANNELS.
 
 # Set 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-eq-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-eq-capture.m4,
 	DMIC_PIPELINE_48k_ID, DMIC_DAI_LINK_48k_ID, CHANNELS, s32le,
-	1000, 0, 0, DMIC, 0, s32le, 3, 48000, 48000, 48000)
+	1000, 0, 0, 48000, 48000, 48000)
 
 # Passthrough capture pipeline using max channels defined by CHANNELS.
 
 # Schedule with 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-eq-capture-16khz.m4,
+PIPELINE_PCM_ADD(sof/pipe-eq-capture-16khz.m4,
 	DMIC_PIPELINE_16k_ID, DMIC_DAI_LINK_16k_ID, CHANNELS, s32le,
-	1000, 0, 0, DMIC, 1, s32le, 3, 16000, 16000, 16000)
+	1000, 0, 0, 16000, 16000, 16000)
 
 #
 # DAIs configuration
@@ -42,18 +41,18 @@ dnl     pipe id, dai type, dai_index, dai_be,
 dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
-# capture DAI is DMIC 0 using 3 periods
+# capture DAI is DMIC 0 using 2 periods
 # Buffers use s32le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	DMIC_PIPELINE_48k_ID, DMIC, 0, dmic01,
-	concat(`PIPELINE_SINK_', DMIC_PIPELINE_48k_ID), 3, s32le,
+	concat(`PIPELINE_SINK_', DMIC_PIPELINE_48k_ID), 2, s32le,
 	1000, 0, 0, 48000, 48000, 48000)
 
-# capture DAI is DMIC 1 using 3 periods
+# capture DAI is DMIC 1 using 2 periods
 # Buffers use s32le format, with 16 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	DMIC_PIPELINE_16k_ID, DMIC, 1, dmic16k,
-	concat(`PIPELINE_SINK_', DMIC_PIPELINE_16k_ID), 3, s32le,
+	concat(`PIPELINE_SINK_', DMIC_PIPELINE_16k_ID), 2, s32le,
 	1000, 0, 0, 16000, 16000, 16000)
 
 dnl PCM_DUPLEX_ADD(name, pcm_id, playback, capture)

--- a/tools/topology/sof-apl-da7219.m4
+++ b/tools/topology/sof-apl-da7219.m4
@@ -29,46 +29,39 @@ include(`platform/intel/dmic.m4')
 # PCM7  ----> volume (pipe 7)   -----> iDisp3 (HDMI/DP playback, BE link 5)
 #
 
-dnl PIPELINE_PCM_DAI_ADD(pipeline,
-dnl     pipe id, pcm, max channels, format,
-dnl     period, priority, core,
-dnl     dai type, dai_index, dai format,
-dnl     dai periods, pcm_min_rate, pcm_max_rate,
-dnl     pipeline_rate, time_domain)
-
-# Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
-	1, 0, 2, s32le,
-	1000, 0, 0, SSP, 5, s16le, 3,
-	48000, 48000, 48000)
-
-# Low Latency playback pipeline 2 on PCM 1 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
-	2, 1, 2, s32le,
-	1000, 0, 0, SSP, 1, s16le, 3,
-	48000, 48000, 48000)
-
-# Low Latency capture pipeline 3 on PCM 1 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
-	3, 1, 2, s32le,
-	1000, 0, 0, SSP, 1, s16le, 3,
-	48000, 48000, 48000)
-
-# Low Latency capture pipeline 4 on PCM 99 using max 4 channels of s32le.
-# 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-passthrough-capture.m4,
-	4, 99, 2, s32le,
-	1000, 0, 0, DMIC, 0, s32le, 3,
-	48000, 48000, 48000)
-
 dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,
 dnl     period, priority, core,
 dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
+
+# Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
+# 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	1, 0, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency playback pipeline 2 on PCM 1 using max 2 channels of s32le.
+# 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	2, 1, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency capture pipeline 3 on PCM 1 using max 2 channels of s32le.
+# 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
+	3, 1, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency capture pipeline 4 on PCM 99 using max 4 channels of s32le.
+# 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
+	4, 99, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
 
 # Low Latency playback pipeline 5 on PCM 5 using max 2 channels of s32le.
 # 1000us deadline on core 0 with priority 0
@@ -103,32 +96,32 @@ dnl     pipe id, dai type, dai_index, dai_be,
 dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
-# playback DAI is SSP5 using 3 periods
+# playback DAI is SSP5 using 2 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, 5, SSP5-Codec,
-	PIPELINE_SOURCE_1, 3, s16le,
+	PIPELINE_SOURCE_1, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# playback DAI is SSP1 using 3 periods
+# playback DAI is SSP1 using 2 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	2, SSP, 1, SSP1-Codec,
-	PIPELINE_SOURCE_2, 3, s16le,
+	PIPELINE_SOURCE_2, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is SSP1 using 3 periods
+# capture DAI is SSP1 using 2 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	3, SSP, 1, SSP1-Codec,
-	PIPELINE_SINK_3, 3, s16le,
+	PIPELINE_SINK_3, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is DMIC0 using 3 periods
+# capture DAI is DMIC0 using 2 periods
 # Buffers use s32le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	4, DMIC, 0, dmic01,
-	PIPELINE_SINK_4, 3, s32le,
+	PIPELINE_SINK_4, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp1 using 2 periods

--- a/tools/topology/sof-apl-demux-pcm512x.m4
+++ b/tools/topology/sof-apl-demux-pcm512x.m4
@@ -29,25 +29,18 @@ DEBUG_START
 # PCM4 <---- demux
 #
 
-dnl PIPELINE_PCM_DAI_ADD(pipeline,
-dnl     pipe id, pcm, max channels, format,
-dnl     period, priority, core,
-dnl     dai type, dai_index, dai format,
-dnl     dai periods, pcm_min_rate, pcm_max_rate,
-dnl     pipeline_rate, time_domain)
-
-# Demux pipeline 1 on PCM 0 using max 2 channels of s32le.
-# Set 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-demux-playback.m4,
-	1, 0, 2, s32le,
-	1000, 0, 0, SSP, 5, s24le, 3,
-	48000, 48000, 48000)
-
 dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,
 dnl     period, priority, core,
 dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
+
+# Demux pipeline 1 on PCM 0 using max 2 channels of s32le.
+# Set 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-demux-playback.m4,
+	1, 0, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
 
 # Low Latency playback pipeline 2 on PCM 1 using max 2 channels of s32le.
 # Set 1000us deadline on core 0 with priority 0
@@ -79,11 +72,11 @@ dnl     pipe id, dai type, dai_index, dai_be,
 dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
-# playback DAI is SSP5 using 3 periods
+# playback DAI is SSP5 using 2 periods
 # Buffers use s24le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, 5, SSP5-Codec,
-	PIPELINE_SOURCE_1, 3, s24le,
+	PIPELINE_SOURCE_1, 2, s24le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # currently this dai is here as "virtual" capture backend

--- a/tools/topology/sof-apl-dmic-a2ch-b2ch.m4
+++ b/tools/topology/sof-apl-dmic-a2ch-b2ch.m4
@@ -28,25 +28,24 @@ include(`platform/intel/dmic.m4')
 # PCM7 <----- DMIC7 (DMIC16k)
 #
 
-dnl PIPELINE_PCM_DAI_ADD(pipeline,
+dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,
 dnl     period, priority, core,
-dnl     dai type, dai_index, dai format,
-dnl     dai periods, pcm_min_rate, pcm_max_rate,
-dnl     pipeline_rate, time_domain)
+dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
+dnl     time_domain, sched_comp)
 
 # Passthrough capture pipeline 6 on PCM 6 using max channels 2.
 # Set 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	6, 6, 2, s32le,
-	1000, 0, 0, DMIC, 0, s32le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Passthrough capture pipeline 7 on PCM 7 using max channels 2.
 # Set 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture-16khz.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-capture-16khz.m4,
 	7, 7, 2, s32le,
-	1000, 0, 0, DMIC, 1, s32le, 3,
+	1000, 0, 0,
 	16000, 16000, 16000)
 
 #
@@ -58,18 +57,18 @@ dnl     pipe id, dai type, dai_index, dai_be,
 dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
-# capture DAI is DMIC 0 using 3 periods
+# capture DAI is DMIC 0 using 2 periods
 # Buffers use s32le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	6, DMIC, 0, NoCodec-6,
-	PIPELINE_SINK_6, 3, s32le,
+	PIPELINE_SINK_6, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is DMIC 1 using 3 periods
+# capture DAI is DMIC 1 using 2 periods
 # Buffers use s32le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	7, DMIC, 1, NoCodec-7,
-	PIPELINE_SINK_7, 3, s32le,
+	PIPELINE_SINK_7, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 

--- a/tools/topology/sof-apl-dmic-a2ch-b4ch.m4
+++ b/tools/topology/sof-apl-dmic-a2ch-b4ch.m4
@@ -28,25 +28,24 @@ include(`platform/intel/dmic.m4')
 # PCM7 <----- DMIC7 (DMIC16k)
 #
 
-dnl PIPELINE_PCM_DAI_ADD(pipeline,
+dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,
 dnl     period, priority, core,
-dnl     dai type, dai_index, dai format,
-dnl     dai periods, pcm_min_rate, pcm_max_rate,
-dnl     pipeline_rate, time_domain)
+dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
+dnl     time_domain, sched_comp)
 
 # Passthrough capture pipeline 6 on PCM 6 using max channels 2
 # Set 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	6, 6, 2, s16le,
-	1000, 0, 0, DMIC, 0, s16le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Passthrough capture pipeline 7 on PCM 7 using max channels 4.
 # Set 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture-16khz.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-capture-16khz.m4,
 	7, 7, 4, s32le,
-	1000, 0, 0, DMIC, 1, s32le, 3,
+	1000, 0, 0,
 	16000, 16000, 16000)
 
 #
@@ -58,18 +57,18 @@ dnl     pipe id, dai type, dai_index, dai_be,
 dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
-# capture DAI is DMIC 0 using 3 periods
+# capture DAI is DMIC 0 using 2 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	6, DMIC, 0, NoCodec-6,
-	PIPELINE_SINK_6, 3, s16le,
+	PIPELINE_SINK_6, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is DMIC 1 using 3 periods
+# capture DAI is DMIC 1 using 2 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	7, DMIC, 1, NoCodec-7,
-	PIPELINE_SINK_7, 3, s32le,
+	PIPELINE_SINK_7, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 

--- a/tools/topology/sof-apl-dmic-a2ch.m4
+++ b/tools/topology/sof-apl-dmic-a2ch.m4
@@ -27,18 +27,17 @@ include(`platform/intel/dmic.m4')
 # PCM6 <----- DMIC6 (DMIC01)
 #
 
-dnl PIPELINE_PCM_DAI_ADD(pipeline,
+dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,
 dnl     period, priority, core,
-dnl     dai type, dai_index, dai format,
-dnl     dai periods, pcm_min_rate, pcm_max_rate,
-dnl     pipeline_rate, time_domain)
+dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
+dnl     time_domain, sched_comp)
 
 # Passthrough capture pipeline 6 on PCM 6 using max channels 2.
 # Set 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	6, 6, 2, s32le,
-	1000, 0, 0, DMIC, 0, s32le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 #
@@ -50,11 +49,11 @@ dnl     pipe id, dai type, dai_index, dai_be,
 dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
-# capture DAI is DMIC 0 using 3 periods
+# capture DAI is DMIC 0 using 2 periods
 # Buffers use s32le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	6, DMIC, 0, NoCodec-6,
-	PIPELINE_SINK_6, 3, s32le,
+	PIPELINE_SINK_6, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 dnl PCM_DUPLEX_ADD(name, pcm_id, playback, capture)

--- a/tools/topology/sof-apl-dmic-a4ch-b2ch.m4
+++ b/tools/topology/sof-apl-dmic-a4ch-b2ch.m4
@@ -28,25 +28,24 @@ include(`platform/intel/dmic.m4')
 # PCM7 <----- DMIC7 (DMIC16k)
 #
 
-dnl PIPELINE_PCM_DAI_ADD(pipeline,
+dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,
 dnl     period, priority, core,
-dnl     dai type, dai_index, dai format,
-dnl     dai periods, pcm_min_rate, pcm_max_rate,
-dnl     pipeline_rate, time_domain)
+dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
+dnl     time_domain, sched_comp)
 
 # Passthrough capture pipeline 6 on PCM 6 using max channels 4.
 # Set 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	6, 6, 4, s16le,
-	1000, 0, 0, DMIC, 0, s16le, 3,
+	1000, 0, 0, DMIC,
 	48000, 48000, 48000)
 
 # Passthrough capture pipeline 7 on PCM 7 using max channels 2.
 # Set 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture-16khz.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-capture-16khz.m4,
 	7, 7, 2, s16le,
-	1000, 0, 0, DMIC, 1, s16le, 3,
+	1000, 0, 0, DMIC,
 	16000, 16000, 16000)
 
 #
@@ -58,18 +57,18 @@ dnl     pipe id, dai type, dai_index, dai_be,
 dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
-# capture DAI is DMIC 0 using 3 periods
+# capture DAI is DMIC 0 using 2 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	6, DMIC, 0, NoCodec-6,
-	PIPELINE_SINK_6, 3, s16le,
+	PIPELINE_SINK_6, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is DMIC 1 using 3 periods
+# capture DAI is DMIC 1 using 2 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	7, DMIC, 1, NoCodec-7,
-	PIPELINE_SINK_7, 3, s16le,
+	PIPELINE_SINK_7, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 dnl PCM_DUPLEX_ADD(name, pcm_id, playback, capture)

--- a/tools/topology/sof-apl-dmic-b2ch.m4
+++ b/tools/topology/sof-apl-dmic-b2ch.m4
@@ -27,18 +27,17 @@ include(`platform/intel/dmic.m4')
 # PCM7 <----- DMIC7 (DMIC16k)
 #
 
-dnl PIPELINE_PCM_DAI_ADD(pipeline,
+dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,
 dnl     period, priority, core,
-dnl     dai type, dai_index, dai format,
-dnl     dai periods, pcm_min_rate, pcm_max_rate,
-dnl     pipeline_rate, time_domain)
+dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
+dnl     time_domain, sched_comp)
 
 # Passthrough capture pipeline 7 on PCM 7 using max channels 2.
 # Set 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture-16khz.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-capture-16khz.m4,
 	7, 7, 2, s32le,
-	1000, 0, 0, DMIC, 1, s32le, 3,
+	1000, 0, 0,
 	16000, 16000, 16000)
 
 #
@@ -50,11 +49,11 @@ dnl     pipe id, dai type, dai_index, dai_be,
 dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
-# capture DAI is DMIC 1 using 3 periods
+# capture DAI is DMIC 1 using 2 periods
 # Buffers use s32le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	7, DMIC, 1, NoCodec-7,
-	PIPELINE_SINK_7, 3, s32le,
+	PIPELINE_SINK_7, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 

--- a/tools/topology/sof-apl-dmic.m4
+++ b/tools/topology/sof-apl-dmic.m4
@@ -27,25 +27,24 @@ define(DMIC_PDM_CONFIG, ifelse(CHANNELS, `4', ``FOUR_CH_PDM0_PDM1'',
 # PCM7 <----- DMIC7 (DMIC16k)
 #
 
-dnl PIPELINE_PCM_DAI_ADD(pipeline,
+dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,
 dnl     period, priority, core,
-dnl     dai type, dai_index, dai format,
-dnl     dai periods, pcm_min_rate, pcm_max_rate,
-dnl     pipeline_rate, time_domain)
+dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
+dnl     time_domain, sched_comp)
 
 # Passthrough capture pipeline 6 on PCM 6 using max channels defined by CHANNELS.
 # Set 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	6, 6, CHANNELS, s32le,
-	1000, 0, 0, DMIC, 0, s32le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Passthrough capture pipeline 7 on PCM 7 using max channels defined by CHANNELS.
 # Set 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	7, 7, CHANNELS, s32le,
-	1000, 0, 0, DMIC, 1, s16le, 3,
+	1000, 0, 0,
 	16000, 16000, 16000)
 
 #
@@ -57,18 +56,18 @@ dnl     pipe id, dai type, dai_index, dai_be,
 dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
-# capture DAI is DMIC 0 using 3 periods
+# capture DAI is DMIC 0 using 2 periods
 # Buffers use s32le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	6, DMIC, 0, NoCodec-6,
-	PIPELINE_SINK_6, 3, s32le,
+	PIPELINE_SINK_6, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is DMIC 1 using 3 periods
+# capture DAI is DMIC 1 using 2 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	7, DMIC, 1, NoCodec-7,
-	PIPELINE_SINK_7, 3, s16le,
+	PIPELINE_SINK_7, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 

--- a/tools/topology/sof-apl-eq-dmic.m4
+++ b/tools/topology/sof-apl-eq-dmic.m4
@@ -23,18 +23,17 @@ include(`platform/intel/dmic.m4')
 # PCM6 <---- EQ IIR <----- DMIC6 (DMIC01)
 #
 
-dnl PIPELINE_PCM_DAI_ADD(pipeline,
+dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,
 dnl     period, priority, core,
-dnl     dai type, dai_index, dai format,
-dnl     dai periods, pcm_min_rate, pcm_max_rate,
-dnl     pipeline_rate, time_domain)
+dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
+dnl     time_domain, sched_comp)
 
 # Passthrough capture pipeline 13 on PCM 6 using max 4 channels.
 # 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-eq-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-eq-capture.m4,
 	1, 6, 4, s32le,
-	1000, 0, 0, DMIC, 0, s32le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 #
@@ -47,11 +46,11 @@ dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
 
-# capture DAI is DMIC 0 using 3 periods
+# capture DAI is DMIC 0 using 2 periods
 # Buffers use s32le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	1, DMIC, 0, NoCodec-6,
-	PIPELINE_SINK_1, 3, s32le,
+	PIPELINE_SINK_1, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 dnl PCM_DUPLEX_ADD(name, pcm_id, playback, capture)

--- a/tools/topology/sof-apl-eq-pcm512x.m4
+++ b/tools/topology/sof-apl-eq-pcm512x.m4
@@ -23,18 +23,17 @@ include(`platform/intel/bxt.m4')
 # PCM0 ----> EQ IIR ----> EQ FIR ----> volume ----> SSP5 (pcm512x)
 #
 
-dnl PIPELINE_PCM_DAI_ADD(pipeline,
+dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,
 dnl     period, priority, core,
-dnl     dai type, dai_index, dai format,
-dnl     dai periods, pcm_min_rate, pcm_max_rate,
-dnl     pipeline_rate, time_domain)
+dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
+dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
 # 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-eq-volume-playback.m4,
+PIPELINE_PCM_ADD(sof/pipe-eq-volume-playback.m4,
 	1, 0, 2, s32le,
-	1000, 0, 0, SSP, 5, s24le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 #
@@ -46,11 +45,11 @@ dnl     pipe id, dai type, dai_index, dai_be,
 dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
-# playback DAI is SSP5 using 3 periods
+# playback DAI is SSP5 using 2 periods
 # Buffers use s24le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, 5, SSP5-Codec,
-	PIPELINE_SOURCE_1, 3, s24le,
+	PIPELINE_SOURCE_1, 2, s24le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # PCM Low Latency, id 0

--- a/tools/topology/sof-apl-keyword-detect.m4
+++ b/tools/topology/sof-apl-keyword-detect.m4
@@ -27,18 +27,17 @@ define(KWD_PIPE_SCH_DEADLINE_US, 20000)
 #               |
 # Keyword <-----+
 
-dnl PIPELINE_PCM_DAI_ADD(pipeline,
+dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,
 dnl     period, priority, core,
-dnl     dai type, dai_index, dai format,
-dnl     dai periods, pcm_min_rate, pcm_max_rate,
-dnl     pipeline_rate, time_domain)
+dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
+dnl     time_domain, sched_comp)
 
 # Passthrough capture pipeline 1 on PCM 0 using max 2 channels.
 # Schedule 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-kfbm-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-kfbm-capture.m4,
 	1, 0, 2, s16le,
-	KWD_PIPE_SCH_DEADLINE_US, 0, 0, DMIC, 1, s16le, 3,
+	KWD_PIPE_SCH_DEADLINE_US, 0, 0,
 	16000, 16000, 16000)
 
 #
@@ -51,11 +50,11 @@ dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
 
-# capture DAI is DMIC 0 using 3 periods
+# capture DAI is DMIC 0 using 2 periods
 # Buffers use s16le format, with 320 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	1, DMIC, 1, NoCodec-6,
-	PIPELINE_SINK_1, 3, s16le,
+	PIPELINE_SINK_1, 2, s16le,
 	KWD_PIPE_SCH_DEADLINE_US,
 	0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 

--- a/tools/topology/sof-apl-nocodec.m4
+++ b/tools/topology/sof-apl-nocodec.m4
@@ -34,102 +34,101 @@ include(`platform/intel/dmic.m4')
 # PCM6 <---- volume <----- DMIC6 (DMIC01)
 #
 
-dnl PIPELINE_PCM_DAI_ADD(pipeline,
+dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,
 dnl     period, priority, core,
-dnl     dai type, dai_index, dai format,
-dnl     dai periods, pcm_min_rate, pcm_max_rate,
-dnl     pipeline_rate, time_domain)
+dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
+dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s16le.
 # Set 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-low-latency-playback.m4,
+PIPELINE_PCM_ADD(sof/pipe-low-latency-playback.m4,
 	1, 0, 2, s32le,
-	1000, 0, 0, SSP, 0, s16le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s16le.
 # 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	2, 0, 2, s32le,
-	1000, 0, 0, SSP, 0, s16le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 3 on PCM 1 using max 2 channels of s16le.
 # 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	3, 1, 2, s32le,
-	1000, 0, 0, SSP, 1, s16le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 4 on PCM 1 using max 2 channels of s16le.
 # 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	4, 1, 2, s32le,
-	1000, 0, 0, SSP, 1, s16le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 5 on PCM 2 using max 2 channels of s16le.
 # 1000us deadline on core 0 with priority 0
-#PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
+#PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 #	5, 2, 2, s32le,
-#	1000, 0, 0, SSP, 2, s16le, 3,
+#	1000, 0, 0,
 #	48000, 48000, 48000)
 
 # Low Latency capture pipeline 6 on PCM 2 using max 2 channels of s16le.
 # 1000us deadline on core 0 with priority 0
-#PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
+#PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 #	6, 2, 2, s32le,
-#	1000, 0, 0, SSP, 2, s16le, 3,
+#	1000, 0, 0,
 #	48000, 48000, 48000)
 
 # Low Latency playback pipeline 7 on PCM 3 using max 2 channels of s16le.
 # 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	7, 3, 2, s32le,
-	1000, 0, 0, SSP, 3, s16le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 8 on PCM 3 using max 2 channels of s16le.
 # 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	8, 3, 2, s32le,
-	1000, 0, 0, SSP, 3, s16le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 9 on PCM 4 using max 2 channels of s16le.
 # 1000us deadline on core 0 with priority 0
-#PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
+#PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 #	9, 4, 2, s32le,
-#	1000, 0, 0, SSP, 4, s16le, 3,
+#	1000, 0, 0,
 #	48000, 48000, 48000)
 
 # Low Latency capture pipeline 10 on PCM 4 using max 2 channels of s16le.
 # 1000us deadline on core 0 with priority 0
-#PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
+#PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 #	10, 4, 2, s32le,
-#	1000, 0, 0, SSP, 4, s16le, 3,
+#	1000, 0, 0,
 #	48000, 48000, 48000)
 
 # Low Latency playback pipeline 11 on PCM 5 using max 2 channels of s16le.
 # 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	11, 5, 2, s32le,
-	1000, 0, 0, SSP, 5, s16le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 12 on PCM 5 using max 2 channels of s16le.
 # 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	12, 5, 2, s32le,
-	1000, 0, 0, SSP, 5, s16le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Passthrough capture pipeline 13 on PCM 6 using max 2 channels.
 # 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-passthrough-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
 	13, 6, 2, s32le,
-	1000, 0, 0, DMIC, 0, s32le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 #
@@ -141,11 +140,11 @@ dnl     pipe id, dai type, dai_index, dai_be,
 dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
-# playback DAI is SSP0 using 3 periods
+# playback DAI is SSP0 using 2 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, 0, NoCodec-0,
-	PIPELINE_SOURCE_1, 3, s16le,
+	PIPELINE_SOURCE_1, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # Media playback pipeline 14 on PCM 7 using max 2 channels of s16le.
@@ -167,88 +166,88 @@ SectionGraph."media-pipeline" {
 	]
 }
 
-# capture DAI is SSP0 using 3 periods
+# capture DAI is SSP0 using 2 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	2, SSP, 0, NoCodec-0,
-	PIPELINE_SINK_2, 3, s16le,
+	PIPELINE_SINK_2, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# playback DAI is SSP1 using 3 periods
+# playback DAI is SSP1 using 2 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	3, SSP, 1, NoCodec-1,
-	PIPELINE_SOURCE_3, 3, s16le,
+	PIPELINE_SOURCE_3, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is SSP1 using 3 periods
+# capture DAI is SSP1 using 2 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	4, SSP, 1, NoCodec-1,
-	PIPELINE_SINK_4, 3, s16le,
+	PIPELINE_SINK_4, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# playback DAI is SSP2 using 3 periods
+# playback DAI is SSP2 using 2 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 #DAI_ADD(sof/pipe-dai-playback.m4,
 #	5, SSP, 2, NoCodec-2,
-#	PIPELINE_SOURCE_5, 3, s16le,
+#	PIPELINE_SOURCE_5, 2, s16le,
 #	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is SSP2 using 3 periods
+# capture DAI is SSP2 using 2 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 #DAI_ADD(sof/pipe-dai-capture.m4,
 #	6, SSP, 2, NoCodec-2,
-#	PIPELINE_SINK_6, 3, s16le,
+#	PIPELINE_SINK_6, 2, s16le,
 #	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# playback DAI is SSP3 using 3 periods
+# playback DAI is SSP3 using 2 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	7, SSP, 3, NoCodec-3,
-	PIPELINE_SOURCE_7, 3, s16le,
+	PIPELINE_SOURCE_7, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is SSP3 using 3 periods
+# capture DAI is SSP3 using 2 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	8, SSP, 3, NoCodec-3,
-	PIPELINE_SINK_8, 3, s16le,
+	PIPELINE_SINK_8, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# playback DAI is SSP4 using 3 periods
+# playback DAI is SSP4 using 2 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 #DAI_ADD(sof/pipe-dai-playback.m4,
 #	9, SSP, 4, NoCodec-4,
-#	PIPELINE_SOURCE_9, 3, s16le,
+#	PIPELINE_SOURCE_9, 2, s16le,
 #	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is SSP4 using 3 periods
+# capture DAI is SSP4 using 2 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 #DAI_ADD(sof/pipe-dai-capture.m4,
 #	10, SSP, 4, NoCodec-4,
-#	PIPELINE_SINK_10, 3, s16le,
+#	PIPELINE_SINK_10, 2, s16le,
 #	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# playback DAI is SSP5 using 3 periods
+# playback DAI is SSP5 using 2 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	11, SSP, 5, NoCodec-5,
-	PIPELINE_SOURCE_11, 3, s16le,
+	PIPELINE_SOURCE_11, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is SSP5 using 3 periods
+# capture DAI is SSP5 using 2 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	12, SSP, 5, NoCodec-5,
-	PIPELINE_SINK_12, 3, s16le,
+	PIPELINE_SINK_12, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is DMIC 0 using 3 periods
+# capture DAI is DMIC 0 using 2 periods
 # Buffers use s32le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	13, DMIC, 0, NoCodec-6,
-	PIPELINE_SINK_13, 3, s32le,
+	PIPELINE_SINK_13, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 dnl PCM_DUPLEX_ADD(name, pcm_id, playback, capture)

--- a/tools/topology/sof-apl-pcm512x-nohdmi.m4
+++ b/tools/topology/sof-apl-pcm512x-nohdmi.m4
@@ -25,18 +25,17 @@ DEBUG_START
 # PCM0 ----> volume -----> SSP5 (pcm512x)
 #
 
-dnl PIPELINE_PCM_DAI_ADD(pipeline,
+dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,
 dnl     period, priority, core,
-dnl     dai type, dai_index, dai format,
-dnl     dai periods, pcm_min_rate, pcm_max_rate,
-dnl     pipeline_rate, time_domain)
+dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
+dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
 # Set 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	1, 0, 2, s32le,
-	1000, 0, 0, SSP, 5, s24le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 #
@@ -48,11 +47,11 @@ dnl     pipe id, dai type, dai_index, dai_be,
 dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
-# playback DAI is SSP5 using 3 periods
+# playback DAI is SSP5 using 2 periods
 # Buffers use s24le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, 5, SSP5-Codec,
-	PIPELINE_SOURCE_1, 3, s24le,
+	PIPELINE_SOURCE_1, 2, s24le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # PCM Low Latency, id 0

--- a/tools/topology/sof-apl-pcm512x.m4
+++ b/tools/topology/sof-apl-pcm512x.m4
@@ -28,25 +28,18 @@ DEBUG_START
 # PCM3 ----> volume -----> iDisp3
 #
 
-dnl PIPELINE_PCM_DAI_ADD(pipeline,
-dnl     pipe id, pcm, max channels, format,
-dnl     period, priority, core,
-dnl     dai type, dai_index, dai format,
-dnl     dai periods, pcm_min_rate, pcm_max_rate,
-dnl     pipeline_rate, time_domain)
-
-# Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
-# Set 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-low-latency-playback.m4,
-	1, 0, 2, s32le,
-	1000, 0, 0, SSP, 5, s24le, 3,
-	48000, 48000, 48000)
-
 dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,
 dnl     period, priority, core,
 dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
+
+# Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
+# Set 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-low-latency-playback.m4,
+	1, 0, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
 
 # Low Latency playback pipeline 2 on PCM 1 using max 2 channels of s32le.
 # 1000us deadline on core 0 with priority 0
@@ -78,11 +71,11 @@ dnl     pipe id, dai type, dai_index, dai_be,
 dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
-# playback DAI is SSP5 using 3 periods
+# playback DAI is SSP5 using 2 periods
 # Buffers use s24le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, 5, SSP5-Codec,
-	PIPELINE_SOURCE_1, 3, s24le,
+	PIPELINE_SOURCE_1, 2, s24le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # Media playback pipeline 5 on PCM 4 using max 2 channels of s16le.

--- a/tools/topology/sof-apl-rt298.m4
+++ b/tools/topology/sof-apl-rt298.m4
@@ -26,25 +26,18 @@ include(`platform/intel/bxt.m4')
 # PCM7  ----> volume (pipe 7)   -----> iDisp3 (HDMI/DP playback, BE link 5)
 #
 
-dnl PIPELINE_PCM_DAI_ADD(pipeline,
-dnl     pipe id, pcm, max channels, format,
-dnl     period, priority, core,
-dnl     dai type, dai_index, dai format,
-dnl     dai periods, pcm_min_rate, pcm_max_rate,
-dnl     pipeline_rate, time_domain)
-
-# Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
-	1, 0, 2, s32le,
-	1000, 0, 0, SSP, 5, s24le, 3,
-	48000, 48000, 48000)
-
 dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,
 dnl     period, priority, core,
 dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
+
+# Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
+# 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	1, 0, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
 
 # Low Latency playback pipeline 5 on PCM 5 using max 2 channels of s16le.
 # 1000us deadline on core 0 with priority 0
@@ -75,11 +68,11 @@ dnl     pipe id, dai type, dai_index, dai_be,
 dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
-# playback DAI is SSP5 using 3 periods
+# playback DAI is SSP5 using 2 periods
 # Buffers use s24le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, 5, SSP5-Codec,
-	PIPELINE_SOURCE_1, 3, s24le,
+	PIPELINE_SOURCE_1, 2, s24le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp1 using 2 periods

--- a/tools/topology/sof-apl-src-50khz-pcm512x.m4
+++ b/tools/topology/sof-apl-src-50khz-pcm512x.m4
@@ -26,18 +26,17 @@ DEBUG_START
 # PCM0 ----> src -----> SSP5 (pcm512x)
 #
 
-dnl PIPELINE_PCM_DAI_ADD(pipeline,
+dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,
 dnl     period, priority, core,
-dnl     dai type, dai_index, dai format,
-dnl     dai periods, pcm_min_rate, pcm_max_rate,
-dnl     pipeline_rate, time_domain)
+dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
+dnl     time_domain, sched_comp)
 
 # Playback pipeline 1 on PCM 0 using max 2 channels of s24le.
 # Schedule 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-src-volume-playback.m4,
+PIPELINE_PCM_ADD(sof/pipe-src-volume-playback.m4,
 	1, 0, 2, s24le,
-	1000, 0, 0, SSP, 5, s24le, 3,
+	1000, 0, 0,
 	48000, 50000, 50000)
 
 #
@@ -49,11 +48,11 @@ dnl     pipe id, dai type, dai_index, dai_be,
 dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
-# playback DAI is SSP5 using 3 periods
+# playback DAI is SSP5 using 2 periods
 # Buffers use s24le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, 5, SSP5-Codec,
-	PIPELINE_SOURCE_1, 3, s24le,
+	PIPELINE_SOURCE_1, 2, s24le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # PCM, id 0

--- a/tools/topology/sof-apl-src-dmic.m4
+++ b/tools/topology/sof-apl-src-dmic.m4
@@ -30,25 +30,24 @@ DEBUG_START
 # PCM7 <--- Volume <--- SRC <--- DMIC7 (DMIC16k)
 #
 
-dnl PIPELINE_PCM_DAI_ADD(pipeline,
+dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,
 dnl     period, priority, core,
-dnl     dai type, dai_index, dai format,
-dnl     dai periods, pcm_min_rate, pcm_max_rate,
-dnl     pipeline_rate, time_domain)
+dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
+dnl     time_domain, sched_comp)
 
 # SRC capture pipeline 6 on PCM 6 using max channels 2.
 # Set 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-src-volume-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-src-volume-capture.m4,
 	6, 6, 2, s32le,
-	1000, 0, 0, DMIC, 0, s32le, 3,
+	1000, 0, 0,
 	8000, 48000, 48000)
 
 # SRC capture pipeline 7 on PCM 7 using max channels 2.
 # Set 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-src-volume-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-src-volume-capture.m4,
 	7, 7, 2, s32le,
-	1000, 0, 0, DMIC, 1, s32le, 3,
+	1000, 0, 0,
 	8000, 48000, 16000)
 
 #
@@ -60,18 +59,18 @@ dnl     pipe id, dai type, dai_index, dai_be,
 dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
-# capture DAI is DMIC 0 using 3 periods
+# capture DAI is DMIC 0 using 2 periods
 # Buffers use s32le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	6, DMIC, 0, NoCodec-6,
-	PIPELINE_SINK_6, 3, s32le,
+	PIPELINE_SINK_6, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is DMIC 1 using 3 periods
+# capture DAI is DMIC 1 using 2 periods
 # Buffers use s32le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	7, DMIC, 1, NoCodec-7,
-	PIPELINE_SINK_7, 3, s32le,
+	PIPELINE_SINK_7, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 dnl PCM_DUPLEX_ADD(name, pcm_id, playback, capture)

--- a/tools/topology/sof-apl-src-pcm512x.m4
+++ b/tools/topology/sof-apl-src-pcm512x.m4
@@ -26,18 +26,17 @@ DEBUG_START
 # PCM0 ----> src -----> SSP5 (pcm512x)
 #
 
-dnl PIPELINE_PCM_DAI_ADD(pipeline,
+dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,
 dnl     period, priority, core,
-dnl     dai type, dai_index, dai format,
-dnl     dai periods, pcm_min_rate, pcm_max_rate,
-dnl     pipeline_rate, time_domain)
+dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
+dnl     time_domain, sched_comp)
 
 # Playback pipeline 1 on PCM 0 using max 2 channels of s24le.
 # Set 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-src-volume-playback.m4,
+PIPELINE_PCM_ADD(sof/pipe-src-volume-playback.m4,
 	1, 0, 2, s24le,
-	1000, 0, 0, SSP, 5, s24le, 3,
+	1000, 0, 0,
 	8000, 96000, 48000)
 
 #
@@ -49,11 +48,11 @@ dnl     pipe id, dai type, dai_index, dai_be,
 dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
-# playback DAI is SSP5 using 3 periods
+# playback DAI is SSP5 using 2 periods
 # Buffers use s24le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, 5, SSP5-Codec,
-	PIPELINE_SOURCE_1, 3, s24le,
+	PIPELINE_SOURCE_1, 2, s24le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # PCM, id 0

--- a/tools/topology/sof-apl-tdf8532.m4
+++ b/tools/topology/sof-apl-tdf8532.m4
@@ -28,80 +28,80 @@ include(`platform/intel/bxt.m4')
 # PCM5 <----> Volume <----> SSP5(TestPin out/in)
 #
 
-dnl PIPELINE_PCM_DAI_ADD(pipeline,
+dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,
 dnl     period, priority, core,
-dnl     dai type, dai_index, dai format,
-dnl     dai periods, pcm_min_rate, pcm_max_rate,
-dnl     pipeline_rate, time_domain)
+dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
+dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 4 channels of s32le.
 # 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	1, 0, 4, s32le,
-	1000, 0, 0, SSP, 4, s32le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 2 on PCM 1 using max 8 channels of s32le.
 # 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	2, 1, 8, s32le,
-	1000, 0, 0, SSP, 2, s32le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 3 on PCM 1 using max 8 channels of s32le.
 # 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	3, 1, 8, s32le,
-	1000, 0, 0, SSP, 2, s32le, 3, 48000, 48000, 48000)
+	1000, 0, 0,
+	48000, 48000, 48000)
 
 # Low Latency playback pipeline 4 on PCM 2 using max 2 channels of s16le.
 # 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	4, 2, 2, s16le,
-	1000, 0, 0, SSP, 0, s16le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 5 on PCM 2 using max 2 channels of s16le.
 # 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	5, 2, 2, s16le,
-	1000, 0, 0, SSP, 0, s16le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 6 on PCM 3 using max 2 channels of s16le.
 # 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	6, 3, 2, s16le,
-	1000, 0, 0, SSP, 1, s16le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 7 on PCM 4 using max 2 channels of s16le.
 # 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	7, 4, 2, s16le,
-	1000, 0, 0, SSP, 3, s16le, 2,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 8 on PCM 4 using max 2 channels of s16le.
 # 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	8, 4, 2, s16le,
-	1000, 0, 0, SSP, 3, s16le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 9 on PCM 5 using max 2 channels of s16le.
 # 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	9, 5, 2, s16le,
-	1000, 0, 0, SSP, 5, s16le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 10 on PCM 5 using max 2 channels of s16le.
 # 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	10, 5, 2, s16le,
-	1000, 0, 0, SSP, 5, s16le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 
@@ -114,74 +114,74 @@ dnl     pipe id, dai type, dai_index, dai_be,
 dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
-# playback DAI is SSP0 using 3 periods
+# playback DAI is SSP0 using 2 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	4, SSP, 0, SSP0-Codec,
-	PIPELINE_SOURCE_4, 3, s16le,
+	PIPELINE_SOURCE_4, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is SSP0 using 3 periods
+# capture DAI is SSP0 using 2 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	5, SSP, 0, SSP0-Codec,
-	PIPELINE_SINK_5, 3, s16le,
+	PIPELINE_SINK_5, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is SSP1 using 3 periods
+# capture DAI is SSP1 using 2 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	6, SSP, 1, SSP1-Codec,
-	PIPELINE_SINK_6, 3, s16le,
+	PIPELINE_SINK_6, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# playback DAI is SSP2 using 3 periods
+# playback DAI is SSP2 using 2 periods
 # Buffers use s32le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	2, SSP, 2, SSP2-Codec,
-	PIPELINE_SOURCE_2, 3, s32le,
+	PIPELINE_SOURCE_2, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is SSP2 using 3 periods
+# capture DAI is SSP2 using 2 periods
 # Buffers use s32le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	3, SSP, 2, SSP2-Codec,
-	PIPELINE_SINK_3, 3, s32le,
+	PIPELINE_SINK_3, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# playback DAI is SSP3 using 3 periods
+# playback DAI is SSP3 using 2 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	7, SSP, 3, SSP3-Codec,
-	PIPELINE_SOURCE_7, 3, s16le,
+	PIPELINE_SOURCE_7, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is SSP3 using 3 periods
+# capture DAI is SSP3 using 2 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	8, SSP, 3, SSP3-Codec,
-	PIPELINE_SINK_8, 3, s16le,
+	PIPELINE_SINK_8, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# playback DAI is SSP4 using 3 periods
+# playback DAI is SSP4 using 2 periods
 # Buffers use s32le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, 4, SSP4-Codec,
-	PIPELINE_SOURCE_1, 3, s32le,
+	PIPELINE_SOURCE_1, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# playback DAI is SSP5 using 3 periods
+# playback DAI is SSP5 using 2 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	9, SSP, 5, SSP5-Codec,
-	PIPELINE_SOURCE_9, 3, s16le,
+	PIPELINE_SOURCE_9, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is SSP5 using 3 periods
+# capture DAI is SSP5 using 2 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	10, SSP, 5, SSP5-Codec,
-	PIPELINE_SINK_10, 3, s16le,
+	PIPELINE_SINK_10, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # PCM Low Latency, id 0

--- a/tools/topology/sof-apl-wm8804.m4
+++ b/tools/topology/sof-apl-wm8804.m4
@@ -23,18 +23,17 @@ include(`platform/intel/bxt.m4')
 # PCM0 ----> volume -----> SSP5 (wm8804)
 #
 
-dnl PIPELINE_PCM_DAI_ADD(pipeline,
+dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,
 dnl     period, priority, core,
-dnl     dai type, dai_index, dai format,
-dnl     dai periods, pcm_min_rate, pcm_max_rate,
-dnl     pipeline_rate, time_domain)
+dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
+dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
 # 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	1, 0, 2, s32le,
-	1000, 0, 0, SSP, 5, s24le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 #
@@ -46,11 +45,11 @@ dnl     pipe id, dai type, dai_index, dai_be,
 dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
-# playback DAI is SSP5 using 3 periods
+# playback DAI is SSP5 using 2 periods
 # Buffers use s24le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, 5, SSP5-Codec,
-	PIPELINE_SOURCE_1, 3, s24le,
+	PIPELINE_SOURCE_1, 2, s24le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # PCM Low Latency, id 0

--- a/tools/topology/sof-cml-demux-rt5682-max98357a.m4
+++ b/tools/topology/sof-cml-demux-rt5682-max98357a.m4
@@ -13,25 +13,24 @@ include(`sof-cml-demux-rt5682.m4')
 # PCM6  ----> volume (pipe 8) ----> SSP1 (speaker - maxim98357a, BE link 5)
 #
 
-dnl PIPELINE_PCM_DAI_ADD(pipeline,
+dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,
 dnl     period, priority, core,
-dnl     dai type, dai_index, dai format,
-dnl     dai periods, pcm_min_rate, pcm_max_rate,
-dnl     pipeline_rate, time_domain)
+dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
+dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 8 on PCM 6 using max 2 channels of s32le.
 # Schedule 1000us deadline on core 0 with priority 0
 # pipe-src pipeline is needed for older SSP config
 
 ifelse(SOF_ABI_VERSION_3_9_OR_GRT, `1',
-`PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
+`PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
         8, 6, 2, s32le,
-        1000, 0, 0, SSP, 1, s24le, 3,
+        1000, 0, 0,
         48000, 48000, 48000)',
-`PIPELINE_PCM_DAI_ADD(sof/pipe-src-volume-playback.m4,
+`PIPELINE_PCM_ADD(sof/pipe-src-volume-playback.m4,
         8, 6, 2, s32le,
-        1000, 0, 0, SSP, 1, s16le, 3,
+        1000, 0, 0,
         48000, 48000, 48000)')
 
 #
@@ -43,18 +42,18 @@ dnl     pipe id, dai type, dai_index, dai_be,
 dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
-# playback DAI is SSP1 using 3 periods
+# playback DAI is SSP1 using 2 periods
 # Buffers use s16le format, with 48 frame per 1000us on core 0 with priority 0
 #With m/n divider available we can support 24 bit playback
 
 ifelse(SOF_ABI_VERSION_3_9_OR_GRT, `1',
 `DAI_ADD(sof/pipe-dai-playback.m4,
         8, SSP, 1, SSP1-Codec,
-        PIPELINE_SOURCE_7, 3, s24le,
+        PIPELINE_SOURCE_7, 2, s24le,
         1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)',
 `DAI_ADD(sof/pipe-dai-playback.m4,
         8, SSP, 1, SSP1-Codec,
-        PIPELINE_SOURCE_7, 3, s16le,
+        PIPELINE_SOURCE_7, 2, s16le,
         1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)')
 
 # PCM Low Latency, id 0

--- a/tools/topology/sof-cml-demux-rt5682.m4
+++ b/tools/topology/sof-cml-demux-rt5682.m4
@@ -39,39 +39,32 @@ define(`SSP_NAME', ifelse(PLATFORM, `whl', `SSP1-Codec',
 # PCM5 <---- demux
 #
 
-dnl PIPELINE_PCM_DAI_ADD(pipeline,
-dnl     pipe id, pcm, max channels, format,
-dnl     period, priority, core,
-dnl     dai type, dai_index, dai format,
-dnl     dai periods, pcm_min_rate, pcm_max_rate,
-dnl     pipeline_rate, time_domain)
-
-# Demux pipeline 1 on PCM 0 using max 2 channels of s24le.
-# Set 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-demux-playback.m4,
-	1, 0, 2, s24le,
-	1000, 0, 0, SSP, SSP_INDEX, s24le, 3,
-	48000, 48000, 48000)
-
-# Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s24le.
-# Set 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
-	2, 0, 2, s24le,
-	1000, 0, 0, SSP, SSP_INDEX, s24le, 3,
-	48000, 48000, 48000)
-
-# Passthrough capture pipeline 3 on PCM 1 using max 4 channels.
-# Set 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-passthrough-capture.m4,
-	3, 1, 4, s32le,
-	1000, 0, 0, DMIC, 0, s32le, 3,
-	48000, 48000, 48000)
-
 dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,
 dnl     period, priority, core,
 dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
+
+# Demux pipeline 1 on PCM 0 using max 2 channels of s24le.
+# Set 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-demux-playback.m4,
+	1, 0, 2, s24le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s24le.
+# Set 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
+	2, 0, 2, s24le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Passthrough capture pipeline 3 on PCM 1 using max 4 channels.
+# Set 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
+	3, 1, 4, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
 
 # Low Latency playback pipeline 4 on PCM 2 using max 2 channels of s32le.
 # Set 1000us deadline on core 0 with priority 0
@@ -103,18 +96,18 @@ dnl     pipe id, dai type, dai_index, dai_be,
 dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
-# playback DAI is SSP(SPP_INDEX) using 3 periods
+# playback DAI is SSP(SPP_INDEX) using 2 periods
 # Buffers use s24le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, SSP_INDEX, SSP_NAME,
-	PIPELINE_SOURCE_1, 3, s24le,
+	PIPELINE_SOURCE_1, 2, s24le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is SSP(SSP_INDEX) using 3 periods
+# capture DAI is SSP(SSP_INDEX) using 2 periods
 # Buffers use s24le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	2, SSP,SSP_INDEX, SSP_NAME,
-	PIPELINE_SINK_2, 3, s24le,
+	PIPELINE_SINK_2, 2, s24le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # Capture pipeline 5 on PCM 5 using max 2 channels of s32le.
@@ -144,11 +137,11 @@ SectionGraph."PIPE_CAP_VIRT" {
 	]
 }
 
-# capture DAI is DMIC01 using 3 periods
+# capture DAI is DMIC01 using 2 periods
 # Buffers use s32le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	3, DMIC, 0, dmic01,
-	PIPELINE_SINK_3, 3, s32le,
+	PIPELINE_SINK_3, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp1 using 2 periods

--- a/tools/topology/sof-cml-rt1011-rt5682.m4
+++ b/tools/topology/sof-cml-rt1011-rt5682.m4
@@ -13,18 +13,17 @@ DEBUG_START
 # PCM5  ----> volume (pipe 7) ----> SSP1 (speaker - rt1011, BE link 5)
 #
 
-dnl PIPELINE_PCM_DAI_ADD(pipeline,
+dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,
 dnl     period, priority, core,
-dnl     dai type, dai_index, dai format,
-dnl     dai periods, pcm_min_rate, pcm_max_rate,
-dnl     pipeline_rate, time_domain)
+dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
+dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 7 on PCM 5 using max 2 channels of s32le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	7, 5, 2, s32le,
-	1000, 0, 0, SSP, 1, s24le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 #
@@ -36,11 +35,11 @@ dnl     pipe id, dai type, dai_index, dai_be,
 dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
-# playback DAI is SSP1 using 3 periods
+# playback DAI is SSP1 using 2 periods
 # Buffers use s16le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	7, SSP, 1, SSP1-Codec,
-	PIPELINE_SOURCE_7, 3, s24le,
+	PIPELINE_SOURCE_7, 2, s24le,
 	48, 1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # PCM Low Latency, id 0

--- a/tools/topology/sof-cml-rt5682-kwd.m4
+++ b/tools/topology/sof-cml-rt5682-kwd.m4
@@ -52,39 +52,32 @@ define(`SSP_MCLK_RATE', ifelse(PLATFORM, `icl', `19200000',
 # Detector <--- selector (pipe 9) <---+
 #
 
-dnl PIPELINE_PCM_DAI_ADD(pipeline,
-dnl     pipe id, pcm, max channels, format,
-dnl     period, priority, core,
-dnl     dai type, dai_index, dai format,
-dnl     dai periods, pcm_min_rate, pcm_max_rate,
-dnl     pipeline_rate, time_domain)
-
-# Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s24le.
-# Schedule 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
-	1, 0, 2, s24le,
-	1000, 0, 0, SSP, SSP_INDEX, s24le, 3,
-	48000, 48000, 48000)
-
-# Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s24le.
-# Schedule 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
-	2, 0, 2, s24le,
-	1000, 0, 0, SSP, SSP_INDEX, s24le, 3,
-	48000, 48000, 48000)
-
-# Passthrough capture pipeline 3 on PCM 1 using max 4 channels.
-# Schedule 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-passthrough-capture.m4,
-	3, 1, 4, s32le,
-	1000, 0, 0, DMIC, 0, s32le, 3,
-	48000, 48000, 48000)
-
 dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,
 dnl     period, priority, core,
 dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
+
+# Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s24le.
+# Schedule 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	1, 0, 2, s24le,
+	1000, 0, 0, SSP,
+	48000, 48000, 48000)
+
+# Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s24le.
+# Schedule 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
+	2, 0, 2, s24le,
+	1000, 0, 0, SSP,
+	48000, 48000, 48000)
+
+# Passthrough capture pipeline 3 on PCM 1 using max 4 channels.
+# Schedule 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
+	3, 1, 4, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
 
 # Low Latency playback pipeline 4 on PCM 2 using max 2 channels of s32le.
 # Schedule 1000us deadline on core 0 with priority 0
@@ -116,25 +109,25 @@ dnl     pipe id, dai type, dai_index, dai_be,
 dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
-# playback DAI is SSP(SPP_INDEX) using 3 periods
+# playback DAI is SSP(SPP_INDEX) using 2 periods
 # Buffers use s24le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, SSP_INDEX, SSP_NAME,
-	PIPELINE_SOURCE_1, 3, s24le,
+	PIPELINE_SOURCE_1, 2, s24le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is SSP(SSP_INDEX) using 3 periods
+# capture DAI is SSP(SSP_INDEX) using 2 periods
 # Buffers use s24le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	2, SSP,SSP_INDEX, SSP_NAME,
-	PIPELINE_SINK_2, 3, s24le,
+	PIPELINE_SINK_2, 2, s24le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is DMIC01 using 3 periods
+# capture DAI is DMIC01 using 2 periods
 # Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	3, DMIC, 0, dmic01,
-	PIPELINE_SINK_3, 3, s32le,
+	PIPELINE_SINK_3, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp1 using 2 periods

--- a/tools/topology/sof-cml-rt5682-max98357a.m4
+++ b/tools/topology/sof-cml-rt5682-max98357a.m4
@@ -16,25 +16,24 @@ DEBUG_START
 # PCM5  ----> volume (pipe 7) ----> SSP1 (speaker - maxim98357a, BE link 5)
 #
 
-dnl PIPELINE_PCM_DAI_ADD(pipeline,
+dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,
 dnl     period, priority, core,
-dnl     dai type, dai_index, dai format,
-dnl     dai periods, pcm_min_rate, pcm_max_rate,
-dnl     pipeline_rate, time_domain)
+dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
+dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 7 on PCM 5 using max 2 channels of s32le.
 # Set 1000us deadline on core 0 with priority 0
 # pipe-src pipeline is needed for older SSP config
 
 ifelse(SOF_ABI_VERSION_3_9_OR_GRT, `1',
-`PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
+`PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	7, 5, 2, s32le,
-	1000, 0, 0, SSP, 1, s24le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)',
-`PIPELINE_PCM_DAI_ADD(sof/pipe-src-volume-playback.m4,
+`PIPELINE_PCM_ADD(sof/pipe-src-volume-playback.m4,
         7, 5, 2, s32le,
-        1000, 0, 0, SSP, 1, s16le, 3,
+        1000, 0, 0,
         48000, 48000, 48000)')
 
 #
@@ -46,18 +45,18 @@ dnl     pipe id, dai type, dai_index, dai_be,
 dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
-# playback DAI is SSP1 using 3 periods
+# playback DAI is SSP1 using 2 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 #With m/n divider available we can support 24 bit playback
 
 ifelse(SOF_ABI_VERSION_3_9_OR_GRT, `1',
 `DAI_ADD(sof/pipe-dai-playback.m4,
 	7, SSP, 1, SSP1-Codec,
-	PIPELINE_SOURCE_7, 3, s24le,
+	PIPELINE_SOURCE_7, 2, s24le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)',
 `DAI_ADD(sof/pipe-dai-playback.m4,
         7, SSP, 1, SSP1-Codec,
-        PIPELINE_SOURCE_7, 3, s16le,
+        PIPELINE_SOURCE_7, 2, s16le,
         1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)')
 
 # PCM Low Latency, id 0

--- a/tools/topology/sof-cml-rt5682.m4
+++ b/tools/topology/sof-cml-rt5682.m4
@@ -48,39 +48,32 @@ define(`SSP_MCLK_RATE', ifelse(PLATFORM, `icl', `19200000',
 # PCM8 <---- volume <----- DMIC16k (dmic16k, BE link 2)
 #
 
-dnl PIPELINE_PCM_DAI_ADD(pipeline,
-dnl     pipe id, pcm, max channels, format,
-dnl     period, priority, core,
-dnl     dai type, dai_index, dai format,
-dnl     dai periods, pcm_min_rate, pcm_max_rate,
-dnl     pipeline_rate, time_domain)
-
-# Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s24le.
-# 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
-	1, 0, 2, s24le,
-	1000, 0, 0, SSP, SSP_INDEX, s24le, 3,
-	48000, 48000, 48000)
-
-# Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s24le.
-# 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
-	2, 0, 2, s24le,
-	1000, 0, 0, SSP, SSP_INDEX, s24le, 3,
-	48000, 48000, 48000)
-
-# Passthrough capture pipeline 3 on PCM 1 using max 4 channels.
-# 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-passthrough-capture.m4,
-	3, 1, 4, s32le,
-	1000, 0, 0, DMIC, 0, s32le, 3,
-	48000, 48000, 48000)
-
 dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,
 dnl     period, priority, core,
 dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
+
+# Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s24le.
+# 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	1, 0, 2, s24le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s24le.
+# 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
+	2, 0, 2, s24le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Passthrough capture pipeline 3 on PCM 1 using max 4 channels.
+# 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
+	3, 1, 4, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
 
 # Low Latency playback pipeline 4 on PCM 2 using max 2 channels of s32le.
 # 1000us deadline on core 0 with priority 0
@@ -105,9 +98,9 @@ PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 
 # Passthrough capture pipeline 7 on PCM 5 using max 2 channels.
 # Schedule 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture-16khz.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-capture-16khz.m4,
 	8, 8, 2, s24le,
-	1000, 0, 0, DMIC, 1, s32le, 3,
+	1000, 0, 0,
 	16000, 16000, 16000)
 
 #
@@ -119,25 +112,25 @@ dnl     pipe id, dai type, dai_index, dai_be,
 dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
-# playback DAI is SSP(SPP_INDEX) using 3 periods
+# playback DAI is SSP(SPP_INDEX) using 2 periods
 # Buffers use s24le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, SSP_INDEX, SSP_NAME,
-	PIPELINE_SOURCE_1, 3, s24le,
+	PIPELINE_SOURCE_1, 2, s24le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is SSP(SSP_INDEX) using 3 periods
+# capture DAI is SSP(SSP_INDEX) using 2 periods
 # Buffers use s24le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	2, SSP,SSP_INDEX, SSP_NAME,
-	PIPELINE_SINK_2, 3, s24le,
+	PIPELINE_SINK_2, 2, s24le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is DMIC01 using 3 periods
+# capture DAI is DMIC01 using 2 periods
 # Buffers use s32le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	3, DMIC, 0, dmic01,
-	PIPELINE_SINK_3, 3, s32le,
+	PIPELINE_SINK_3, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp1 using 2 periods
@@ -161,11 +154,11 @@ DAI_ADD(sof/pipe-dai-playback.m4,
 	PIPELINE_SOURCE_6, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is DMIC16k using 3 periods
+# capture DAI is DMIC16k using 2 periods
 # Buffers use s32le format, with 16 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	8, DMIC, 1, dmic16k,
-	PIPELINE_SINK_8, 3, s32le,
+	PIPELINE_SINK_8, 2, s32le,
 	16, 1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 

--- a/tools/topology/sof-cml-rt700.m4
+++ b/tools/topology/sof-cml-rt700.m4
@@ -31,46 +31,39 @@ DEBUG_START
 # PCM6 ----> volume -----> iDisp3 (HDMI/DP playback, BE link 6)
 #
 
-dnl PIPELINE_PCM_DAI_ADD(pipeline,
-dnl     pipe id, pcm, max channels, format,
-dnl     period, priority, core,
-dnl     dai type, dai_index, dai format,
-dnl     dai periods, pcm_min_rate, pcm_max_rate,
-dnl     pipeline_rate, time_domain)
-
-# Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
-	1, 0, 2, s24le,
-	1000, 0, 0, ALH, 0x102, s24le, 3,
-	48000, 48000, 48000)
-
-# Low Latency capture pipeline 2 on PCM 1 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
-	2, 1, 2, s24le,
-	1000, 0, 0, ALH, 0x102, s24le, 3,
-	48000, 48000, 48000)
-
-# Passthrough capture pipeline 3 on PCM 2 using max 4 channels.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-passthrough-capture.m4,
-	3, 2, 4, s32le,
-	1000, 0, 0, DMIC, 0, s32le, 3,
-	48000, 48000, 48000)
-
-# Passthrough capture pipeline 4 on PCM 3 using max 2 channels.
-# Schedule 16 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-passthrough-capture.m4,
-	4, 3, 2, s16le,
-	1000, 0, 0, DMIC, 1, s16le, 3,
-	16000, 16000, 16000)
-
 dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,
 dnl     period, priority, core,
 dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
+
+# Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	1, 0, 2, s24le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency capture pipeline 2 on PCM 1 using max 2 channels of s32le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
+	2, 1, 2, s24le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Passthrough capture pipeline 3 on PCM 2 using max 4 channels.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
+	3, 2, 4, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Passthrough capture pipeline 4 on PCM 3 using max 2 channels.
+# Schedule 16 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
+	4, 3, 2, s16le,
+	1000, 0, 0,
+	16000, 16000, 16000)
 
 # Low Latency playback pipeline 5 on PCM 4 using max 2 channels of s32le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
@@ -102,32 +95,32 @@ dnl     pipe id, dai type, dai_index, dai_be,
 dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
-# playback DAI is ALH(SDW1 PIN2) using 3 periods
+# playback DAI is ALH(SDW1 PIN2) using 2 periods
 # Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, ALH, 0x102, SDW1-Playback,
-	PIPELINE_SOURCE_1, 3, s24le,
+	PIPELINE_SOURCE_1, 2, s24le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is ALH(SDW1 PIN3) using 3 periods
+# capture DAI is ALH(SDW1 PIN3) using 2 periods
 # Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	2, ALH, 0x103, SDW1-Capture,
-	PIPELINE_SINK_2, 3, s24le,
+	PIPELINE_SINK_2, 2, s24le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is DMIC01 using 3 periods
+# capture DAI is DMIC01 using 2 periods
 # Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	3, DMIC, 0, dmic01,
-	PIPELINE_SINK_3, 3, s32le,
+	PIPELINE_SINK_3, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is DMIC16k using 3 periods
+# capture DAI is DMIC16k using 2 periods
 # Buffers use s16le format, with 16 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	4, DMIC, 1, dmic16k,
-	PIPELINE_SINK_4, 3, s16le,
+	PIPELINE_SINK_4, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp1 using 2 periods

--- a/tools/topology/sof-cml-src-rt5682.m4
+++ b/tools/topology/sof-cml-src-rt5682.m4
@@ -31,39 +31,32 @@ DEBUG_START
 # PCM4 ----> volume -----> iDisp3
 #
 
-dnl PIPELINE_PCM_DAI_ADD(pipeline,
-dnl     pipe id, pcm, max channels, format,
-dnl     period, priority, core,
-dnl     dai type, dai_index, dai format,
-dnl     dai periods, pcm_min_rate, pcm_max_rate,
-dnl     pipeline_rate, time_domain)
-
-# Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s24le.
-# Set 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-src-volume-playback.m4,
-	1, 0, 2, s24le,
-	1000, 0, 0, SSP, 1, s24le, 3,
-	8000, 96000, 48000)
-
-# Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s24le.
-# Set 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
-	2, 0, 2, s24le,
-	1000, 0, 0, SSP, 1, s24le, 3,
-	48000, 48000, 48000)
-
-# Passthrough capture pipeline 3 on PCM 1 using max 4 channels.
-# Set 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-passthrough-capture.m4,
-	3, 1, 4, s32le,
-	1000, 0, 0, DMIC, 0, s32le, 3,
-	48000, 48000, 48000)
-
 dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,
 dnl     period, priority, core,
 dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
+
+# Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s24le.
+# Set 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-src-volume-playback.m4,
+	1, 0, 2, s24le,
+	1000, 0, 0,
+	8000, 96000, 48000)
+
+# Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s24le.
+# Set 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
+	2, 0, 2, s24le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Passthrough capture pipeline 3 on PCM 1 using max 4 channels.
+# Set 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
+	3, 1, 4, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
 
 # Low Latency playback pipeline 4 on PCM 2 using max 2 channels of s32le.
 # Set 1000us deadline on core 0 with priority 0
@@ -95,25 +88,25 @@ dnl     pipe id, dai type, dai_index, dai_be,
 dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
-# playback DAI is SSP1 using 3 periods
+# playback DAI is SSP1 using 2 periods
 # Buffers use s24le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, 1, SSP1-Codec,
-	PIPELINE_SOURCE_1, 3, s24le,
+	PIPELINE_SOURCE_1, 2, s24le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is SSP1 using 3 periods
+# capture DAI is SSP1 using 2 periods
 # Buffers use s24le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	2, SSP, 1, SSP1-Codec,
-	PIPELINE_SINK_2, 3, s24le,
+	PIPELINE_SINK_2, 2, s24le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is DMIC01 using 3 periods
+# capture DAI is DMIC01 using 2 periods
 # Buffers use s32le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	3, DMIC, 0, dmic01,
-	PIPELINE_SINK_3, 3, s32le,
+	PIPELINE_SINK_3, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp1 using 2 periods

--- a/tools/topology/sof-cnl-nocodec.m4
+++ b/tools/topology/sof-cnl-nocodec.m4
@@ -27,60 +27,59 @@ include(`platform/intel/dmic.m4')
 # PCM3 <---- volume <----- DMIC3 (DMIC01)
 #
 
-dnl PIPELINE_PCM_DAI_ADD(pipeline,
+dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,
 dnl     period, priority, core,
-dnl     dai type, dai_index, dai format,
-dnl     dai periods, pcm_min_rate, pcm_max_rate,
-dnl     pipeline_rate, time_domain)
+dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
+dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s24le.
 # Set 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	1, 0, 2, s24le,
-	1000, 0, 0, SSP, 0, s24le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s24le.
 # Set 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	2, 0, 2, s24le,
-	1000, 0, 0, SSP, 0, s24le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 3 on PCM 1 using max 2 channels of s24le.
 # Set 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	3, 1, 2, s24le,
-	1000, 0, 0, SSP, 1, s24le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 4 on PCM 1 using max 2 channels of s24le.
 # Set 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	4, 1, 2, s24le,
-	1000, 0, 0, SSP, 1, s24le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 5 on PCM 2 using max 2 channels of s24le.
 # Set 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	5, 2, 2, s24le,
-	1000, 0, 0, SSP, 2, s24le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 6 on PCM 2 using max 2 channels of s24le.
 # Set 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	6, 2, 2, s24le,
-	1000, 0, 0, SSP, 2, s24le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Passthrough capture pipeline 7 on PCM 3 using max 4 channels.
 # Set 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-passthrough-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
 	7, 3, 4, s32le,
-	1000, 0, 0, DMIC, 0, s32le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 #
@@ -92,53 +91,53 @@ dnl     pipe id, dai type, dai_index, dai_be,
 dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
-# playback DAI is SSP0 using 3 periods
+# playback DAI is SSP0 using 2 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, 0, NoCodec-0,
-	PIPELINE_SOURCE_1, 3, s24le,
+	PIPELINE_SOURCE_1, 2, s24le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is SSP0 using 3 periods
+# capture DAI is SSP0 using 2 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	2, SSP, 0, NoCodec-0,
-	PIPELINE_SINK_2, 3, s24le,
+	PIPELINE_SINK_2, 2, s24le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# playback DAI is SSP1 using 3 periods
+# playback DAI is SSP1 using 2 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	3, SSP, 1, NoCodec-1,
-	PIPELINE_SOURCE_3, 3, s24le,
+	PIPELINE_SOURCE_3, 2, s24le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is SSP1 using 3 periods
+# capture DAI is SSP1 using 2 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	4, SSP, 1, NoCodec-1,
-	PIPELINE_SINK_4, 3, s24le,
+	PIPELINE_SINK_4, 2, s24le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# playback DAI is SSP2 using 3 periods
+# playback DAI is SSP2 using 2 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	5, SSP, 2, NoCodec-2,
-	PIPELINE_SOURCE_5, 3, s24le,
+	PIPELINE_SOURCE_5, 2, s24le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is SSP2 using 3 periods
+# capture DAI is SSP2 using 2 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	6, SSP, 2, NoCodec-2,
-	PIPELINE_SINK_6, 3, s24le,
+	PIPELINE_SINK_6, 2, s24le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is DMIC 0 using 3 periods
+# capture DAI is DMIC 0 using 2 periods
 # Buffers use s32le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	7, DMIC, 0, NoCodec-3,
-	PIPELINE_SINK_7, 3, s32le,
+	PIPELINE_SINK_7, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 dnl PCM_DUPLEX_ADD(name, pcm_id, playback, capture)

--- a/tools/topology/sof-cnl-rt274.m4
+++ b/tools/topology/sof-cnl-rt274.m4
@@ -24,25 +24,24 @@ include(`platform/intel/cnl.m4')
 #
 #
 
-dnl PIPELINE_PCM_DAI_ADD(pipeline,
+dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,
 dnl     period, priority, core,
-dnl     dai type, dai_index, dai format,
-dnl     dai periods, pcm_min_rate, pcm_max_rate,
-dnl     pipeline_rate, time_domain)
+dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
+dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s24le.
 # 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	1, 0, 2, s24le,
-	1000, 0, 0, SSP, 0, s24le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s24le.
 # 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	2, 0, 2, s24le,
-	1000, 0, 0, SSP, 0, s24le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 #
@@ -56,18 +55,18 @@ dnl     pipe id, dai type, dai_index, dai_be,
 dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
-# playback DAI is SSP0 using 3 periods
+# playback DAI is SSP0 using 2 periods
 # Buffers use s24le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, 0, SSP0-Codec,
-	PIPELINE_SOURCE_1, 3, s24le,
+	PIPELINE_SOURCE_1, 2, s24le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is SSP0 using 3 periods
+# capture DAI is SSP0 using 2 periods
 # Buffers use s24le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	2, SSP, 0, SSP0-Codec,
-	PIPELINE_SINK_2, 3, s24le,
+	PIPELINE_SINK_2, 2, s24le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # PCM Low Latency

--- a/tools/topology/sof-glk-da7219-kwd.m4
+++ b/tools/topology/sof-glk-da7219-kwd.m4
@@ -34,46 +34,39 @@ define(KWD_PIPE_SCH_DEADLINE_US, 20000)
 # Detector <--- selector (pipe 9) <---+
 #
 
-dnl PIPELINE_PCM_DAI_ADD(pipeline,
-dnl     pipe id, pcm, max channels, format,
-dnl     period, priority, core,
-dnl     dai type, dai_index, dai format,
-dnl     dai periods, pcm_min_rate, pcm_max_rate,
-dnl     pipeline_rate, time_domain)
-
-# Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
-# Set 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
-	1, 0, 2, s32le,
-	1000, 0, 0, SSP, 1, s16le, 3,
-	48000, 48000, 48000)
-
-# Low Latency playback pipeline 2 on PCM 1 using max 2 channels of s32le.
-# Set 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
-	2, 1, 2, s32le,
-	1000, 0, 0, SSP, 2, s16le, 3,
-	48000, 48000, 48000)
-
-# Low Latency capture pipeline 3 on PCM 1 using max 2 channels of s32le.
-# Set 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
-	3, 1, 2, s32le,
-	1000, 0, 0, SSP, 2, s16le, 3,
-	48000, 48000, 48000)
-
-# Low Latency capture pipeline 4 on PCM 99 using max 4 channels of s32le.
-# Set 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
-	4, 99, 4, s16le,
-	1000, 0, 0, DMIC, 0, s16le, 3,
-	48000, 48000, 48000)
-
 dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,
 dnl     period, priority, core,
 dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
+
+# Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
+# Set 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	1, 0, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency playback pipeline 2 on PCM 1 using max 2 channels of s32le.
+# Set 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	2, 1, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency capture pipeline 3 on PCM 1 using max 2 channels of s32le.
+# Set 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
+	3, 1, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency capture pipeline 4 on PCM 99 using max 4 channels of s32le.
+# Set 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
+	4, 99, 4, s16le,
+	1000, 0, 0,
+	48000, 48000, 48000)
 
 # Low Latency playback pipeline 5 on PCM 5 using max 2 channels of s32le.
 # Set 1000us deadline on core 0 with priority 0
@@ -105,32 +98,32 @@ dnl     pipe id, dai type, dai_index, dai_be,
 dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
-# playback DAI is SSP1 using 3 periods
+# playback DAI is SSP1 using 2 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, 1, SSP1-Codec,
-	PIPELINE_SOURCE_1, 3, s16le,
+	PIPELINE_SOURCE_1, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# playback DAI is SSP2 using 3 periods
+# playback DAI is SSP2 using 2 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	2, SSP, 2, SSP2-Codec,
-	PIPELINE_SOURCE_2, 3, s16le,
+	PIPELINE_SOURCE_2, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is SSP2 using 3 periods
+# capture DAI is SSP2 using 2 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	3, SSP, 2, SSP2-Codec,
-	PIPELINE_SINK_3, 3, s16le,
+	PIPELINE_SINK_3, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is DMIC0 using 3 periods
+# capture DAI is DMIC0 using 2 periods
 # Buffers use s32le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	4, DMIC, 0, dmic01,
-	PIPELINE_SINK_4, 3, s16le,
+	PIPELINE_SINK_4, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp1 using 2 periods

--- a/tools/topology/sof-glk-da7219.m4
+++ b/tools/topology/sof-glk-da7219.m4
@@ -29,47 +29,40 @@ include(`platform/intel/dmic.m4')
 # PCM7  ----> volume (pipe 7)   -----> iDisp3 (HDMI/DP playback, BE link 5)
 #
 
-dnl PIPELINE_PCM_DAI_ADD(pipeline,
-dnl     pipe id, pcm, max channels, format,
-dnl     period, priority, core,
-dnl     dai type, dai_index, dai format,
-dnl     dai periods, pcm_min_rate, pcm_max_rate,
-dnl     pipeline_rate, time_domain)
-
-# Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
-	1, 0, 2, s32le,
-	1000, 0, 0, SSP, 1, s16le, 3,
-	48000, 48000, 48000)
-
-# Low Latency playback pipeline 2 on PCM 1 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
-	2, 1, 2, s32le,
-	1000, 0, 0, SSP, 2, s16le, 3,
-	48000, 48000, 48000)
-
-# Low Latency capture pipeline 3 on PCM 1 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
-	3, 1, 2, s32le,
-	1000, 0, 0, SSP, 2, s16le, 3,
-	48000, 48000, 48000)
-
-# Low Latency capture pipeline 4 on PCM 99 using max 4 channels of s32le.
-# 1000us deadline on core 0 with priority 0
-#PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
-PIPELINE_PCM_DAI_ADD(sof/pipe-passthrough-capture.m4,
-	4, 99, 4, s16le,
-	1000, 0, 0, DMIC, 0, s16le, 3,
-	48000, 48000, 48000)
-
 dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,
 dnl     period, priority, core,
 dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
+
+# Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
+# 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	1, 0, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency playback pipeline 2 on PCM 1 using max 2 channels of s32le.
+# 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	2, 1, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency capture pipeline 3 on PCM 1 using max 2 channels of s32le.
+# 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
+	3, 1, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency capture pipeline 4 on PCM 99 using max 4 channels of s32le.
+# 1000us deadline on core 0 with priority 0
+#PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
+	4, 99, 4, s16le,
+	1000, 0, 0,
+	48000, 48000, 48000)
 
 # Low Latency playback pipeline 5 on PCM 5 using max 2 channels of s32le.
 # 1000us deadline on core 0 with priority 0
@@ -104,32 +97,32 @@ dnl     pipe id, dai type, dai_index, dai_be,
 dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
-# playback DAI is SSP1 using 3 periods
+# playback DAI is SSP1 using 2 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, 1, SSP1-Codec,
-	PIPELINE_SOURCE_1, 3, s16le,
+	PIPELINE_SOURCE_1, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# playback DAI is SSP2 using 3 periods
+# playback DAI is SSP2 using 2 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	2, SSP, 2, SSP2-Codec,
-	PIPELINE_SOURCE_2, 3, s16le,
+	PIPELINE_SOURCE_2, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is SSP2 using 3 periods
+# capture DAI is SSP2 using 2 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	3, SSP, 2, SSP2-Codec,
-	PIPELINE_SINK_3, 3, s16le,
+	PIPELINE_SINK_3, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is DMIC0 using 3 periods
+# capture DAI is DMIC0 using 2 periods
 # Buffers use s32le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	4, DMIC, 0, dmic01,
-	PIPELINE_SINK_4, 3, s16le,
+	PIPELINE_SINK_4, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp1 using 2 periods

--- a/tools/topology/sof-glk-rt5682.m4
+++ b/tools/topology/sof-glk-rt5682.m4
@@ -32,47 +32,40 @@ include(`platform/intel/dmic.m4')
 # PCM7  ----> volume (pipe 7)   -----> iDisp3 (HDMI/DP playback, BE link 5)
 #
 
-dnl PIPELINE_PCM_DAI_ADD(pipeline,
-dnl     pipe id, pcm, max channels, format,
-dnl     period, priority, core,
-dnl     dai type, dai_index, dai format,
-dnl     dai periods, pcm_min_rate, pcm_max_rate,
-dnl     pipeline_rate, time_domain)
-
-# Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
-	1, 0, 2, s32le,
-	1000, 0, 0, SSP, 1, s16le, 3,
-	48000, 48000, 48000)
-
-# Low Latency playback pipeline 2 on PCM 1 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
-	2, 1, 2, s32le,
-	1000, 0, 0, SSP, 2, s16le, 3,
-	48000, 48000, 48000)
-
-# Low Latency capture pipeline 3 on PCM 1 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
-	3, 1, 2, s32le,
-	1000, 0, 0, SSP, 2, s16le, 3,
-	48000, 48000, 48000)
-
-# Low Latency capture pipeline 4 on PCM 99 using max 4 channels of s16le.
-# 1000us deadline on core 0 with priority 0
-#PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
-PIPELINE_PCM_DAI_ADD(sof/pipe-passthrough-capture.m4,
-	4, 99, 4, s16le,
-	1000, 0, 0, DMIC, 0, s16le, 3,
-	48000, 48000, 48000)
-
 dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,
 dnl     period, priority, core,
 dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
+
+# Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
+# 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	1, 0, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency playback pipeline 2 on PCM 1 using max 2 channels of s32le.
+# 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	2, 1, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency capture pipeline 3 on PCM 1 using max 2 channels of s32le.
+# 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
+	3, 1, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency capture pipeline 4 on PCM 99 using max 4 channels of s16le.
+# 1000us deadline on core 0 with priority 0
+#PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
+	4, 99, 4, s16le,
+	1000, 0, 0,
+	48000, 48000, 48000)
 
 # Low Latency playback pipeline 5 on PCM 5 using max 2 channels of s16le.
 # 1000us deadline on core 0 with priority 0
@@ -107,32 +100,32 @@ dnl     pipe id, dai type, dai_index, dai_be,
 dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
-# playback DAI is SSP1 using 3 periods
+# playback DAI is SSP1 using 2 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, 1, SSP1-Codec,
-	PIPELINE_SOURCE_1, 3, s16le,
+	PIPELINE_SOURCE_1, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# playback DAI is SSP1 using 3 periods
+# playback DAI is SSP1 using 2 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	2, SSP, 2, SSP2-Codec,
-	PIPELINE_SOURCE_2, 3, s16le,
+	PIPELINE_SOURCE_2, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is SSP1 using 3 periods
+# capture DAI is SSP1 using 2 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	3, SSP, 2, SSP2-Codec,
-	PIPELINE_SINK_3, 3, s16le,
+	PIPELINE_SINK_3, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is DMIC0 using 3 periods
+# capture DAI is DMIC0 using 2 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	4, DMIC, 0, dmic01,
-	PIPELINE_SINK_4, 3, s16le,
+	PIPELINE_SINK_4, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp1 using 2 periods

--- a/tools/topology/sof-icl-dmic-4ch.m4
+++ b/tools/topology/sof-icl-dmic-4ch.m4
@@ -23,18 +23,17 @@ include(`platform/intel/dmic.m4')
 # PCM6 <---- volume <----- DMIC01 (dmic0 capture)
 #
 
-dnl PIPELINE_PCM_DAI_ADD(pipeline,
+dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,
 dnl     period, priority, core,
-dnl     dai type, dai_index, dai format,
-dnl     dai periods, pcm_min_rate, pcm_max_rate,
-dnl     pipeline_rate, time_domain)
+dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
+dnl     time_domain, sched_comp)
 
 # Passthrough capture pipeline 1 on PCM 1 using max 4 channels.
 # 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-passthrough-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
 	1, 1, 4, s32le,
-	1000, 0, 0, DMIC, 0, s32le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 #
@@ -47,11 +46,11 @@ dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
 
-# capture DAI is DMIC 0 using 3 periods
+# capture DAI is DMIC 0 using 2 periods
 # Buffers use s32le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	1, DMIC, 0, dmic01,
-	PIPELINE_SINK_1, 3, s32le,
+	PIPELINE_SINK_1, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 dnl PCM_DUPLEX_ADD(name, pcm_id, playback, capture)

--- a/tools/topology/sof-icl-nocodec.m4
+++ b/tools/topology/sof-icl-nocodec.m4
@@ -23,25 +23,24 @@ include(`platform/intel/icl.m4')
 # PCM0 <---> Volume <---> SSP0 (NoCodec)
 #
 
-dnl PIPELINE_PCM_DAI_ADD(pipeline,
+dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,
 dnl     period, priority, core,
-dnl     dai type, dai_index, dai format,
-dnl     dai periods, pcm_min_rate, pcm_max_rate,
-dnl     pipeline_rate, time_domain)
+dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
+dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s24le.
 # 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	1, 0, 2, s24le,
-	1000, 0, 0, SSP, 0, s24le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s24le.
 # 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	2, 0, 2, s24le,
-	1000, 0, 0, SSP, 0, s24le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 #
@@ -55,18 +54,18 @@ dnl     pipe id, dai type, dai_index, dai_be,
 dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
-# playback DAI is SSP0 using 3 periods
+# playback DAI is SSP0 using 2 periods
 # Buffers use s24le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, 0, NoCodec-0,
-	PIPELINE_SOURCE_1, 3, s24le,
+	PIPELINE_SOURCE_1, 2, s24le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is SSP0 using 3 periods
+# capture DAI is SSP0 using 2 periods
 # Buffers use s24le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	2, SSP, 0, NoCodec-0,
-	PIPELINE_SINK_2, 3, s24le,
+	PIPELINE_SINK_2, 2, s24le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # PCM Low Latency

--- a/tools/topology/sof-icl-rt700.m4
+++ b/tools/topology/sof-icl-rt700.m4
@@ -31,46 +31,39 @@ DEBUG_START
 # PCM6 ----> volume -----> iDisp3 (HDMI/DP playback, BE link 6)
 #
 
-dnl PIPELINE_PCM_DAI_ADD(pipeline,
-dnl     pipe id, pcm, max channels, format,
-dnl     period, priority, core,
-dnl     dai type, dai_index, dai format,
-dnl     dai periods, pcm_min_rate, pcm_max_rate,
-dnl     pipeline_rate, time_domain)
-
-# Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
-	1, 0, 2, s24le,
-	1000, 0, 0, ALH, 2, s24le, 3,
-	48000, 48000, 48000)
-
-# Low Latency capture pipeline 2 on PCM 1 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
-	2, 1, 2, s24le,
-	1000, 0, 0, ALH, 3, s24le, 3,
-	48000, 48000, 48000)
-
-# Passthrough capture pipeline 3 on PCM 2 using max 4 channels.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-passthrough-capture.m4,
-	3, 2, 4, s32le,
-	1000, 0, 0, DMIC, 0, s32le, 3,
-	48000, 48000, 48000)
-
-# Passthrough capture pipeline 4 on PCM 3 using max 2 channels.
-# Schedule 16 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-passthrough-capture.m4,
-	4, 3, 2, s16le,
-	1000, 0, 0, DMIC, 1, s16le, 3,
-	16000, 16000, 16000)
-
 dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,
 dnl     period, priority, core,
 dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
+
+# Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	1, 0, 2, s24le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency capture pipeline 2 on PCM 1 using max 2 channels of s32le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
+	2, 1, 2, s24le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Passthrough capture pipeline 3 on PCM 2 using max 4 channels.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
+	3, 2, 4, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Passthrough capture pipeline 4 on PCM 3 using max 2 channels.
+# Schedule 16 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
+	4, 3, 2, s16le,
+	1000, 0, 0,
+	16000, 16000, 16000)
 
 # Low Latency playback pipeline 5 on PCM 4 using max 2 channels of s32le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
@@ -102,32 +95,32 @@ dnl     pipe id, dai type, dai_index, dai_be,
 dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
-# playback DAI is ALH(SDW0 PIN2) using 3 periods
+# playback DAI is ALH(SDW0 PIN2) using 2 periods
 # Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, ALH, 2, SDW0-Playback,
-	PIPELINE_SOURCE_1, 3, s24le,
+	PIPELINE_SOURCE_1, 2, s24le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is ALH(SDW0 PIN2) using 3 periods
+# capture DAI is ALH(SDW0 PIN2) using 2 periods
 # Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	2, ALH, 3, SDW0-Capture,
-	PIPELINE_SINK_2, 3, s24le,
+	PIPELINE_SINK_2, 2, s24le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is DMIC01 using 3 periods
+# capture DAI is DMIC01 using 2 periods
 # Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	3, DMIC, 0, dmic01,
-	PIPELINE_SINK_3, 3, s32le,
+	PIPELINE_SINK_3, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is DMIC16k using 3 periods
+# capture DAI is DMIC16k using 2 periods
 # Buffers use s16le format, with 16 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	4, DMIC, 1, dmic16k,
-	PIPELINE_SINK_4, 3, s16le,
+	PIPELINE_SINK_4, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp1 using 2 periods

--- a/tools/topology/sof-icl-rt711-rt1308-rt715-hdmi.m4
+++ b/tools/topology/sof-icl-rt711-rt1308-rt715-hdmi.m4
@@ -30,53 +30,46 @@ DEBUG_START
 # PCM6 ---> volume <---- iDisp2
 # PCM7 ---> volume <---- iDisp3
 
-dnl PIPELINE_PCM_DAI_ADD(pipeline,
-dnl     pipe id, pcm, max channels, format,
-dnl     period, priority, core,
-dnl     dai type, dai_index, dai format,
-dnl     dai periods, pcm_min_rate, pcm_max_rate,
-dnl     pipeline_rate, time_domain)
-
-# Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
-	1, 0, 2, s32le,
-	1000, 0, 0, ALH, 2, s32le, 3,
-	48000, 48000, 48000)
-
-# Low Latency capture pipeline 2 on PCM 1 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
-	2, 1, 2, s32le,
-	1000, 0, 0, ALH, 3, s32le, 3,
-	48000, 48000, 48000)
-
-# Low Latency playback pipeline 3 on PCM 2 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
-	3, 2, 2, s32le,
-	1000, 0, 0, ALH, 0x102, s32le, 3,
-	48000, 48000, 48000)
-
-# Low Latency playback pipeline 4 on PCM 3 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
-	4, 3, 2, s32le,
-	1000, 0, 0, ALH, 0x202, s32le, 3,
-	48000, 48000, 48000)
-
-# Low Latency capture pipeline 5 on PCM 4 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
-	5, 4, 2, s32le,
-	1000, 0, 0, ALH, 0x302, s32le, 3,
-	48000, 48000, 48000)
-
 dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,
 dnl     period, priority, core,
 dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
+
+# Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	1, 0, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency capture pipeline 2 on PCM 1 using max 2 channels of s32le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
+	2, 1, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency playback pipeline 3 on PCM 2 using max 2 channels of s32le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	3, 2, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency playback pipeline 4 on PCM 3 using max 2 channels of s32le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	4, 3, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency capture pipeline 5 on PCM 4 using max 2 channels of s32le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
+	5, 4, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
 
 # Low Latency playback pipeline 6 on PCM 5 using max 2 channels of s32le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
@@ -108,39 +101,39 @@ dnl     pipe id, dai type, dai_index, dai_be,
 dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
-# playback DAI is ALH(SDW0 PIN2) using 3 periods
+# playback DAI is ALH(SDW0 PIN2) using 2 periods
 # Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, ALH, 2, SDW0-Playback,
-	PIPELINE_SOURCE_1, 3, s32le,
+	PIPELINE_SOURCE_1, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is ALH(SDW0 PIN2) using 3 periods
+# capture DAI is ALH(SDW0 PIN2) using 2 periods
 # Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	2, ALH, 3, SDW0-Capture,
-	PIPELINE_SINK_2, 3, s32le,
+	PIPELINE_SINK_2, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# playback DAI is ALH(SDW1 PIN2) using 3 periods
+# playback DAI is ALH(SDW1 PIN2) using 2 periods
 # Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	3, ALH, 0x102, SDW1-Playback,
-	PIPELINE_SOURCE_3, 3, s32le,
+	PIPELINE_SOURCE_3, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# playback DAI is ALH(SDW2 PIN2) using 3 periods
+# playback DAI is ALH(SDW2 PIN2) using 2 periods
 # Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	4, ALH, 0x202, SDW2-Playback,
-	PIPELINE_SOURCE_4, 3, s32le,
+	PIPELINE_SOURCE_4, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is ALH(SDW3 PIN2) using 3 periods
+# capture DAI is ALH(SDW3 PIN2) using 2 periods
 # Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	5, ALH, 0x302, SDW3-Capture,
-	PIPELINE_SINK_5, 3, s32le,
+	PIPELINE_SINK_5, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp1 using 2 periods

--- a/tools/topology/sof-icl-rt711-rt1308-rt715.m4
+++ b/tools/topology/sof-icl-rt711-rt1308-rt715.m4
@@ -27,46 +27,45 @@ DEBUG_START
 # PCM3 ---> volume ----> ALH 2 BE dailink 3
 # PCM4 <--- volume <---- ALH 2 BE dailink 4
 
-dnl PIPELINE_PCM_DAI_ADD(pipeline,
+dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,
 dnl     period, priority, core,
-dnl     dai type, dai_index, dai format,
-dnl     dai periods, pcm_min_rate, pcm_max_rate,
-dnl     pipeline_rate, time_domain)
+dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
+dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	1, 0, 2, s32le,
-	1000, 0, 0, ALH, 2, s32le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 2 on PCM 1 using max 2 channels of s32le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	2, 1, 2, s32le,
-	1000, 0, 0, ALH, 3, s32le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 3 on PCM 2 using max 2 channels of s32le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	3, 2, 2, s32le,
-	1000, 0, 0, ALH, 0x102, s32le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 4 on PCM 3 using max 2 channels of s32le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	4, 3, 2, s32le,
-	1000, 0, 0, ALH, 0x202, s32le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 5 on PCM 4 using max 2 channels of s32le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	5, 4, 2, s32le,
-	1000, 0, 0, ALH, 0x302, s32le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 #
@@ -78,39 +77,39 @@ dnl     pipe id, dai type, dai_index, dai_be,
 dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
-# playback DAI is ALH(SDW0 PIN2) using 3 periods
+# playback DAI is ALH(SDW0 PIN2) using 2 periods
 # Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, ALH, 2, SDW0-Playback,
-	PIPELINE_SOURCE_1, 3, s32le,
+	PIPELINE_SOURCE_1, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is ALH(SDW0 PIN2) using 3 periods
+# capture DAI is ALH(SDW0 PIN2) using 2 periods
 # Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	2, ALH, 3, SDW0-Capture,
-	PIPELINE_SINK_2, 3, s32le,
+	PIPELINE_SINK_2, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# playback DAI is ALH(SDW1 PIN2) using 3 periods
+# playback DAI is ALH(SDW1 PIN2) using 2 periods
 # Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	3, ALH, 0x102, SDW1-Playback,
-	PIPELINE_SOURCE_3, 3, s32le,
+	PIPELINE_SOURCE_3, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# playback DAI is ALH(SDW2 PIN2) using 3 periods
+# playback DAI is ALH(SDW2 PIN2) using 2 periods
 # Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	4, ALH, 0x202, SDW2-Playback,
-	PIPELINE_SOURCE_4, 3, s32le,
+	PIPELINE_SOURCE_4, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is ALH(SDW3 PIN2) using 3 periods
+# capture DAI is ALH(SDW3 PIN2) using 2 periods
 # Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	5, ALH, 0x302, SDW3-Capture,
-	PIPELINE_SINK_5, 3, s32le,
+	PIPELINE_SINK_5, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 

--- a/tools/topology/sof-tgl-nocodec.m4
+++ b/tools/topology/sof-tgl-nocodec.m4
@@ -31,60 +31,59 @@ include(`platform/intel/dmic.m4')
 # PCM6 <---- volume <----- DMIC6 (DMIC01)
 #
 
-dnl PIPELINE_PCM_DAI_ADD(pipeline,
+dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,
 dnl     period, priority, core,
-dnl     dai type, dai_index, dai format,
-dnl     dai periods, pcm_min_rate, pcm_max_rate,
-dnl     pipeline_rate, time_domain)
+dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
+dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s16le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	1, 0, 2, s16le,
-	1000, 0, 0, SSP, 0, s16le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s16le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	2, 0, 2, s16le,
-	1000, 0, 0, SSP, 0, s16le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 3 on PCM 1 using max 2 channels of s16le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	3, 1, 2, s16le,
-	1000, 0, 0, SSP, 1, s16le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 4 on PCM 1 using max 2 channels of s16le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	4, 1, 2, s16le,
-	1000, 0, 0, SSP, 1, s16le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 5 on PCM 2 using max 2 channels of s16le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	5, 2, 2, s16le,
-	1000, 0, 0, SSP, 2, s16le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 6 on PCM 2 using max 2 channels of s16le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	6, 2, 2, s16le,
-	1000, 0, 0, SSP, 2, s16le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Passthrough capture pipeline 13 on PCM 6 using max 2 channels.
 # 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-passthrough-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
 	13, 6, 2, s32le,
-	1000, 0, 0, DMIC, 0, s32le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)
 #
 # DAIs configuration
@@ -95,53 +94,53 @@ dnl     pipe id, dai type, dai_index, dai_be,
 dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
-# playback DAI is SSP0 using 3 periods
+# playback DAI is SSP0 using 2 periods
 # Buffers use s16le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, 0, NoCodec-0,
-	PIPELINE_SOURCE_1, 3, s16le,
+	PIPELINE_SOURCE_1, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is SSP0 using 3 periods
+# capture DAI is SSP0 using 2 periods
 # Buffers use s16le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	2, SSP, 0, NoCodec-0,
-	PIPELINE_SINK_2, 3, s16le,
+	PIPELINE_SINK_2, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# playback DAI is SSP1 using 3 periods
+# playback DAI is SSP1 using 2 periods
 # Buffers use s16le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	3, SSP, 1, NoCodec-1,
-	PIPELINE_SOURCE_3, 3, s16le,
+	PIPELINE_SOURCE_3, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is SSP1 using 3 periods
+# capture DAI is SSP1 using 2 periods
 # Buffers use s16le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	4, SSP, 1, NoCodec-1,
-	PIPELINE_SINK_4, 3, s16le,
+	PIPELINE_SINK_4, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# playback DAI is SSP2 using 3 periods
+# playback DAI is SSP2 using 2 periods
 # Buffers use s16le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	5, SSP, 2, NoCodec-2,
-	PIPELINE_SOURCE_5, 3, s16le,
+	PIPELINE_SOURCE_5, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is SSP2 using 3 periods
+# capture DAI is SSP2 using 2 periods
 # Buffers use s16le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	6, SSP, 2, NoCodec-2,
-	PIPELINE_SINK_6, 3, s16le,
+	PIPELINE_SINK_6, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is DMIC 0 using 3 periods
+# capture DAI is DMIC 0 using 2 periods
 # Buffers use s32le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	13, DMIC, 0, NoCodec-6,
-	PIPELINE_SINK_13, 3, s32le,
+	PIPELINE_SINK_13, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 dnl PCM_DUPLEX_ADD(name, pcm_id, playback, capture)

--- a/tools/topology/sof-tgl-rt711-rt1308.m4
+++ b/tools/topology/sof-tgl-rt711-rt1308.m4
@@ -38,46 +38,45 @@ ifelse(HDMI, `1',
 # PCM8 ----> volume -----> iDisp3 (HDMI/DP playback, BE link 8)
 ')
 
-dnl PIPELINE_PCM_DAI_ADD(pipeline,
+dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,
 dnl     period, priority, core,
-dnl     dai type, dai_index, dai format,
-dnl     dai periods, pcm_min_rate, pcm_max_rate,
-dnl     pipeline_rate, time_domain)
+dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
+dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	1, 0, 2, s32le,
-	1000, 0, 0, ALH, 2, s32le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 2 on PCM 1 using max 2 channels of s32le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	2, 1, 2, s32le,
-	1000, 0, 0, ALH, 3, s32le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 3 on PCM 2 using max 2 channels of s24le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	3, 2, 2, s24le,
-	1000, 0, 0, SSP, 2, s24le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Passthrough capture pipeline 4 on PCM 3 using max 4 channels.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-passthrough-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
 	4, 3, 4, s32le,
-	1000, 0, 0, DMIC, 0, s32le, 3,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Passthrough capture pipeline 5 on PCM 4 using max 4 channels.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-passthrough-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
 	5, 4, 4, s16le,
-	1000, 0, 0, DMIC, 1, s16le, 3,
+	1000, 0, 0,
 	16000, 16000, 16000)
 
 ifelse(HDMI, `1',
@@ -120,39 +119,39 @@ dnl     pipe id, dai type, dai_index, dai_be,
 dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
-# playback DAI is ALH(SDW0 PIN2) using 3 periods
+# playback DAI is ALH(SDW0 PIN2) using 2 periods
 # Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, ALH, 2, SDW0-Playback,
-	PIPELINE_SOURCE_1, 3, s32le,
+	PIPELINE_SOURCE_1, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is ALH(SDW0 PIN2) using 3 periods
+# capture DAI is ALH(SDW0 PIN2) using 2 periods
 # Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	2, ALH, 3, SDW0-Capture,
-	PIPELINE_SINK_2, 3, s32le,
+	PIPELINE_SINK_2, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# playback DAI is SSP2 using 3 periods
+# playback DAI is SSP2 using 2 periods
 # Buffers use s24le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	3, SSP, 2, SSP2-Codec,
-	PIPELINE_SOURCE_3, 3, s24le,
+	PIPELINE_SOURCE_3, 2, s24le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is DMIC01 using 3 periods
+# capture DAI is DMIC01 using 2 periods
 # Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	4, DMIC, 0, dmic01,
-	PIPELINE_SINK_4, 3, s32le,
+	PIPELINE_SINK_4, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is DMIC16k using 3 periods
+# capture DAI is DMIC16k using 2 periods
 # Buffers use s16le format, with 16 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	5, DMIC, 1, dmic16k,
-	PIPELINE_SINK_5, 3, s16le,
+	PIPELINE_SINK_5, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 ifelse(HDMI, `1',


### PR DESCRIPTION
Currently DMAs are using buffers on pipelines connected to either
host or dai components. This causes many problems in firmware logic
e.g. we need to preload playback pipelines with data or we need
to manually override buffer sizes, if the buffer isn't complaint
with specific DMA requirements. Also it requires from topology
creators to know some hardware specific things on each platform
like that for timer based scheduling on cAVS platforms we need
to have 3 periods in buffers connected to dai components.
This patch allocates separate buffers for DMAs, which are made
complaint by using different DMA attributes first. We no longer
need to preload playback streams, because we can start DMA
right away and just let it transfer zeroes before any valid
data will come.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>