### PR TITLE
sof: Fix compile errors when traces are disabled.

### DIFF
--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -1120,6 +1120,11 @@ out:
 		  (draining_time_end - draining_time_start)
 		  / clock_ms_to_ticks(PLATFORM_DEFAULT_CLOCK, 1));
 
+	/* If traces are disabled, prevent compile error from unused
+	 * variables.
+	 */
+	(void)(draining_time_end - draining_time_start);
+
 	/* Enable system agent back */
 	sa_enable();
 

--- a/src/schedule/timer_domain.c
+++ b/src/schedule/timer_domain.c
@@ -32,6 +32,9 @@ static inline void timer_report_delay(int id, uint64_t delay)
 
 	trace_ll_error("timer_report_delay(): timer %d delayed by %d uS %d "
 		       "ticks", id, ll_delay_us, delay);
+
+	/* Fix compile error when traces are disabled */
+	(void)ll_delay_us;
 }
 
 static int timer_domain_register(struct ll_schedule_domain *domain,


### PR DESCRIPTION
This fixes #1980 on the i.MX platform and should fix it on the others.

I cannot check platform specific code in other platforms, and CI doesn't
test this case. @keyonjie Can you please check if the code builds with this PR?