### PR TITLE
platform: imx: Enable caching on the i.MX platform

### DIFF
--- a/src/platform/imx8/imx8.x.in
+++ b/src/platform/imx8/imx8.x.in
@@ -148,7 +148,8 @@ _memmap_cacheattr_bp_strict = 0x22F22FFF;
 _memmap_cacheattr_wb_allvalid = 0x44224222;
 _memmap_cacheattr_wt_allvalid = 0x11221222;
 _memmap_cacheattr_bp_allvalid = 0x22222222;
-PROVIDE(_memmap_cacheattr_reset = _memmap_cacheattr_wbna_trapnull);
+_memmap_cacheattr_imx8_wt_allvalid = 0x22212222;
+PROVIDE(_memmap_cacheattr_reset = _memmap_cacheattr_imx8_wt_allvalid);
 
 SECTIONS
 {


### PR DESCRIPTION
This improves the performance quite significantly -- pipeline_copy on
the simple ESAI pipeline (the cs42888 pipeline) took around 781us before
while with caching I got times of 15us at a minimum (a 50-fold
improvement).

Signed-off-by: Paul Olaru <paul.olaru@nxp.com>

@tlauda Thanks for the suggestion in the mailing list, it helped hugely as you can see.