### PR TITLE
dma-trace: fix race condition during initialization

### DIFF
--- a/src/trace/dma-trace.c
+++ b/src/trace/dma-trace.c
@@ -159,26 +159,33 @@ int dma_trace_host_buffer(struct dma_trace_data *d,
 static int dma_trace_buffer_init(struct dma_trace_data *d)
 {
 	struct dma_trace_buf *buffer = &d->dmatb;
+	void *buf;
+	unsigned int flags;
 
 	/* allocate new buffer */
-	buffer->addr = rballoc(RZONE_BUFFER,
-			       SOF_MEM_CAPS_RAM | SOF_MEM_CAPS_DMA,
-			       DMA_TRACE_LOCAL_SIZE);
-	if (!buffer->addr) {
+	buf = rballoc(RZONE_BUFFER,
+		      SOF_MEM_CAPS_RAM | SOF_MEM_CAPS_DMA,
+		      DMA_TRACE_LOCAL_SIZE);
+	if (!buf) {
 		trace_buffer_error("dma_trace_buffer_init() error: "
 				   "alloc failed");
 		return -ENOMEM;
 	}
 
-	bzero(buffer->addr, DMA_TRACE_LOCAL_SIZE);
-	dcache_writeback_region(buffer->addr, DMA_TRACE_LOCAL_SIZE);
+	bzero(buf, DMA_TRACE_LOCAL_SIZE);
+	dcache_writeback_region(buf, DMA_TRACE_LOCAL_SIZE);
 
-	/* initialise the DMA buffer */
+	/* initialise the DMA buffer, whole sequence in section */
+	spin_lock_irq(d->lock, flags);
+
+	buffer->addr  = buf;
 	buffer->size = DMA_TRACE_LOCAL_SIZE;
 	buffer->w_ptr = buffer->addr;
 	buffer->r_ptr = buffer->addr;
 	buffer->end_addr = buffer->addr + buffer->size;
 	buffer->avail = 0;
+
+	spin_unlock_irq(d->lock, flags);
 
 	return 0;
 }


### PR DESCRIPTION
dtrace_event...() is protected by dmatb.addr verification
which may be assigned while other buffer attributes are
not set yet. It results in assert in case the initialization
is pre-empted by a code that attempts to log something.

Signed-off-by: Marcin Maka <marcin.maka@linux.intel.com>