### PR TITLE
agent: add option to disable system agent

### DIFF
--- a/src/include/sof/lib/agent.h
+++ b/src/include/sof/lib/agent.h
@@ -9,6 +9,7 @@
 #define __SOF_LIB_AGENT_H__
 
 #include <sof/schedule/task.h>
+#include <config.h>
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -22,6 +23,14 @@ struct sa {
 	struct task work;
 };
 
+#if CONFIG_HAVE_AGENT
+
 void sa_init(struct sof *sof, uint64_t timeout);
+
+#else
+
+static inline void sa_init(struct sof *sof, uint64_t timeout) { }
+
+#endif
 
 #endif /* __SOF_LIB_AGENT_H__ */

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -5,11 +5,14 @@ if(BUILD_LIBRARY)
 	return()
 endif()
 
+if(CONFIG_HAVE_AGENT)
+	add_local_sources(sof agent.c)
+endif()
+
 add_local_sources(sof
 	lib.c
 	alloc.c
 	notifier.c
-	agent.c
 	pm_runtime.c
 	clk.c
 	dma.c

--- a/src/platform/Kconfig
+++ b/src/platform/Kconfig
@@ -245,4 +245,12 @@ config SYSTICK_PERIOD
 	  as a timeout check value for system agent.
 	  Value should be provided in microseconds.
 
+config HAVE_AGENT
+	bool "Enable system agent"
+	default y
+	help
+	  Enables system agent. It can be disabled on systems
+	  which are still unstable and cannot assure that
+	  system agent will always execute on time.
+
 endmenu


### PR DESCRIPTION
Adds config option to disable system agent. It's helpful
on the still unstable systems, which cannot guarantee that
agent will execute on time.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>