### PR TITLE
scripts:xtensa-build-all: update to use 2017.8 toolchain for CNL

### DIFF
--- a/scripts/xtensa-build-all.sh
+++ b/scripts/xtensa-build-all.sh
@@ -199,10 +199,10 @@ do
 	then
 		PLATFORM="cannonlake"
 		ARCH="xtensa-smp"
-		XTENSA_CORE="X6H3CNL_2016_4_linux"
+		XTENSA_CORE="X6H3CNL_2017_8"
 		ROOT="$pwd/../xtensa-root/xtensa-cnl-elf"
 		HOST="xtensa-cnl-elf"
-		XTENSA_TOOLS_VERSION="RF-2016.4-linux"
+		XTENSA_TOOLS_VERSION="RG-2017.8-linux"
 		HAVE_ROM='yes'
 	fi
 	if [ $j == "sue" ]


### PR DESCRIPTION
Let's align to use the newer 2017.8 toolchain for CNL building.

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>