### PR TITLE
[skip ci]CI: travis: disable agent for QEMU test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ jobs:
     - &qemuboottest
       stage: qemutest
       script:
-        - sed -i $(($(grep "config SYSTICK_PERIOD" -n src/platform/Kconfig | cut -f1 -d:)+2))"s/1000/10000/" src/platform/Kconfig
+        - sed -i $(($(grep "config HAVE_AGENT" -n src/platform/Kconfig | cut -f1 -d:)+2))"s/default y/default n/" src/platform/Kconfig
         - ./scripts/docker-run.sh ./scripts/xtensa-build-all.sh -r -j $PLATFORM
         - ./scripts/docker-qemu.sh ../sof.git/scripts/qemu-check.sh $PLATFORM
       env: PLATFORM=byt


### PR DESCRIPTION
QEMU boot test will random fail with agent. Disable it to make sure
QEMU boot test will not fail.

Signed-off-by: Pan Xiuli <xiuli.pan@linux.intel.com>

Please merge after https://github.com/thesofproject/sof/pull/1998