### PR TITLE
sof: spinlock: Fix several compile errors related to spinlock debug

### DIFF
--- a/src/arch/xtensa/init.c
+++ b/src/arch/xtensa/init.c
@@ -15,6 +15,7 @@
 #include <sof/init.h>
 #include <sof/lib/cpu.h>
 #include <sof/sof.h>
+#include <sof/spinlock.h>
 #include <config.h>
 #include <xtensa/xtruntime-frames.h>
 #include <xtos-structs.h>

--- a/src/include/sof/spinlock.h
+++ b/src/include/sof/spinlock.h
@@ -15,6 +15,7 @@
 
 #include <arch/spinlock.h>
 #include <sof/drivers/interrupt.h>
+#include <sof/trace/trace.h>
 #include <config.h>
 
 /*
@@ -84,7 +85,7 @@ extern uint32_t lock_dbg_user[DBG_LOCK_USERS];
 #define spinlock_init(lock) \
 	do { \
 		arch_spinlock_init(lock); \
-		(lock)->user = __LINE__; \
+		(*lock)->user = __LINE__; \
 	} while (0)
 
 /* panic on deadlock */

--- a/src/include/sof/spinlock.h
+++ b/src/include/sof/spinlock.h
@@ -76,7 +76,7 @@
 #define trace_lock(__e)		trace_error_atomic(TRACE_CLASS_LOCK, __e)
 #define tracev_lock(__e)	tracev_event_atomic(TRACE_CLASS_LOCK, __e)
 #define trace_lock_error(__e)	trace_error_atomic(TRACE_CLASS_LOCK, __e)
-#define trace_lock_value(__e)	_trace_error_atomic(__e)
+#define trace_lock_value(__e)	trace_error_value_atomic(__e)
 
 extern uint32_t lock_dbg_atomic;
 extern uint32_t lock_dbg_user[DBG_LOCK_USERS];


### PR DESCRIPTION
Signed-off-by: Paul Olaru <paul.olaru@nxp.com>

Fixes #2015 