### PR TITLE
pipeline: add rfree pipe_task in pipeline_free

### DIFF
--- a/src/audio/pipeline.c
+++ b/src/audio/pipeline.c
@@ -229,8 +229,10 @@ int pipeline_free(struct pipeline *p)
 	}
 
 	/* remove from any scheduling */
-	if (p->pipe_task)
+	if (p->pipe_task) {
 		schedule_task_free(p->pipe_task);
+		rfree(p->pipe_task);
+	}
 
 	/* now free the pipeline */
 	rfree(p);


### PR DESCRIPTION
Memory allocated for p->pipe_task should be freed
in pipeline_free() in order to avoid memory leaks.

Signed-off-by: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>