### PR TITLE
Topology: Use SCHEDULE_TIME_DOMAIN_DMA with the WM8804 default topology

### DIFF
--- a/tools/topology/sof-apl-wm8804.m4
+++ b/tools/topology/sof-apl-wm8804.m4
@@ -50,7 +50,7 @@ dnl     deadline, priority, core, time_domain)
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, 5, SSP5-Codec,
 	PIPELINE_SOURCE_1, 2, s24le,
-	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_DMA)
 
 # PCM Low Latency, id 0
 PCM_PLAYBACK_ADD(Port5, 0, PIPELINE_PCM_1)


### PR DESCRIPTION
The topology for UP2 + HiFiBerry Digi+ Pro sound card needs to
use for the pipeline host - volume - DAI the DMA interrupts
synchronized scheduling since the DAI is configured as I2S slave.
The timer based scheduling is applicable for this interface only
with ASRC that is not used by this simple topology.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>