### PR TITLE
scripts: qemu: change ipc shm file name for cavs platform

### DIFF
--- a/scripts/qemu-check.sh
+++ b/scripts/qemu-check.sh
@@ -58,7 +58,7 @@ do
 	if [ $j == "apl" ]
 	then
 		READY_IPC="00 00 00 f0"
-		SHM_IPC_REG=qemu-bridge-ipc-io
+		SHM_IPC_REG="qemu-bridge-ipc(|-dsp)-io"
 		OUTBOX_OFFSET="7000"
 		SHM_MBOX=qemu-bridge-hp-sram-mem
 		ROM="-r ../sof.git/build_${j}_gcc/src/arch/xtensa/rom-$j.bin"
@@ -66,7 +66,7 @@ do
 	if [ $j == "skl" ]
 	then
 		READY_IPC="00 00 00 f0"
-		SHM_IPC_REG=qemu-bridge-ipc-io
+		SHM_IPC_REG="qemu-bridge-ipc(|-dsp)-io"
 		OUTBOX_OFFSET="7000"
 		SHM_MBOX=qemu-bridge-hp-sram-mem
 		ROM="-r ../sof.git/build_${j}_gcc/src/arch/xtensa/rom-$j.bin"
@@ -74,7 +74,7 @@ do
 	if [ $j == "kbl" ]
 	then
 		READY_IPC="00 00 00 f0"
-		SHM_IPC_REG=qemu-bridge-ipc-io
+		SHM_IPC_REG="qemu-bridge-ipc(|-dsp)-io"
 		OUTBOX_OFFSET="7000"
 		SHM_MBOX=qemu-bridge-hp-sram-mem
 		ROM="-r ../sof.git/build_${j}_gcc/src/arch/xtensa/rom-$j.bin"
@@ -82,7 +82,7 @@ do
 	if [ $j == "cnl" ]
 	then
 		READY_IPC="00 00 00 f0"
-		SHM_IPC_REG=qemu-bridge-ipc-io
+		SHM_IPC_REG="qemu-bridge-ipc(|-dsp)-io"
 		OUTBOX_OFFSET="5000"
 		SHM_MBOX=qemu-bridge-hp-sram-mem
 		ROM="-r ../sof.git/build_${j}_gcc/src/arch/xtensa/rom-$j.bin"
@@ -90,7 +90,7 @@ do
 	if [ $j == "icl" ]
 	then
 		READY_IPC="00 00 00 f0"
-		SHM_IPC_REG=qemu-bridge-ipc-io
+		SHM_IPC_REG="qemu-bridge-ipc(|-dsp)-io"
 		OUTBOX_OFFSET="5000"
 		SHM_MBOX=qemu-bridge-hp-sram-mem
 		ROM="-r ../sof.git/build_${j}_gcc/src/arch/xtensa/rom-$j.bin"
@@ -99,15 +99,18 @@ do
 	./xtensa-host.sh $PLATFORM -k ../sof.git/build_${j}_gcc/src/arch/xtensa/$FWNAME $ROM -o 2.0 ../sof.git/dump-$j.txt
 	# dump log into sof.git incase running in docker
 
+	# use regular expression to match the SHM IPC REG file name
+	SHM_IPC_REG_FILE=$(ls /dev/shm/ | grep -E $SHM_IPC_REG)
+
 	# check if ready ipc header is in the ipc regs
-	IPC_REG=$(hexdump -C /dev/shm/$SHM_IPC_REG | grep "$READY_IPC")
+	IPC_REG=$(hexdump -C /dev/shm/$SHM_IPC_REG_FILE | grep "$READY_IPC")
 	# check if ready ipc message is in the mbox
 	IPC_MSG=$(hexdump -C /dev/shm/$SHM_MBOX | grep -A 4 "$READY_MSG" | grep -A 4 "$OUTBOX_OFFSET")
 
 	if [ "$IPC_REG" ]; then
 		echo "ipc reg dump:"
 		# directly output the log to be nice to look
-		hexdump -C /dev/shm/$SHM_IPC_REG | grep "$READY_IPC"
+		hexdump -C /dev/shm/$SHM_IPC_REG_FILE | grep "$READY_IPC"
 		if [ "$IPC_MSG" ]; then
 			echo "ipc message dump:"
 			# directly output the log to be nice to look


### PR DESCRIPTION
The cavs platform IPC shm file name in QEMU is changed
from ipc-io to ipc-dsp-io.
Use wildcard to smoothly pass the transition of the QEMU update.

Signed-off-by: Pan Xiuli <xiuli.pan@linux.intel.com>