### PR TITLE
sof: trace: Do not have empty trace macros when traces are off

### DIFF
--- a/src/include/sof/debug/debug.h
+++ b/src/include/sof/debug/debug.h
@@ -122,13 +122,13 @@
 	(IS_ENABLED(CONFIG_GDB_DEBUG) ? SOF_IPC_INFO_GDB : 0)		\
 )
 
-#define dbg()
-#define dbg_at(__x)
-#define dbg_val(__v)
-#define dbg_val_at(__v, __x)
-#define dump(addr, count)
-#define dump_object(__o)
-#define dump_object_ptr(__o)
+#define dbg() do {} while (0)
+#define dbg_at(__x) do {} while (0)
+#define dbg_val(__v) do {} while (0)
+#define dbg_val_at(__v, __x) do {} while (0)
+#define dump(addr, count) do {} while (0)
+#define dump_object(__o) do {} while (0)
+#define dump_object_ptr(__o) do {} while (0)
 #endif
 
 /* dump stack as part of panic */

--- a/src/include/sof/spinlock.h
+++ b/src/include/sof/spinlock.h
@@ -172,8 +172,8 @@ extern uint32_t lock_dbg_user[DBG_LOCK_USERS];
 
 #else
 
-#define trace_lock(__e)
-#define tracev_lock(__e)
+#define trace_lock(__e) do {} while (0)
+#define tracev_lock(__e) do {} while (0)
 
 #define spin_lock_dbg()
 #define spin_unlock_dbg()

--- a/src/include/sof/spinlock.h
+++ b/src/include/sof/spinlock.h
@@ -175,8 +175,8 @@ extern uint32_t lock_dbg_user[DBG_LOCK_USERS];
 #define trace_lock(__e) do {} while (0)
 #define tracev_lock(__e) do {} while (0)
 
-#define spin_lock_dbg()
-#define spin_unlock_dbg()
+#define spin_lock_dbg() do {} while (0)
+#define spin_unlock_dbg() do {} while (0)
 
 /* all SMP spinlocks need init, nothing todo on UP */
 #define spinlock_init(lock) \

--- a/src/include/sof/trace/trace.h
+++ b/src/include/sof/trace/trace.h
@@ -225,13 +225,13 @@ void trace_init(struct sof *sof);
 #define tracev_value(x)	trace_value(x)
 #define tracev_value_atomic(x)	trace_value_atomic(x)
 #else
-#define tracev_event(...)
-#define tracev_event_with_ids(...)
-#define tracev_event_atomic(...)
-#define tracev_event_atomic_with_ids(...)
+#define tracev_event(...) do {} while (0)
+#define tracev_event_with_ids(...) do {} while (0)
+#define tracev_event_atomic(...) do {} while (0)
+#define tracev_event_atomic_with_ids(...) do {} while (0)
 
-#define tracev_value(x)
-#define tracev_value_atomic(x)
+#define tracev_value(x) do {} while (0)
+#define tracev_value_atomic(x) do {} while (0)
 #endif
 
 /* error tracing */
@@ -338,30 +338,30 @@ do {									\
 #endif
 #else
 
-#define	trace_event(...)
-#define	trace_event_atomic(...)
-#define trace_event_with_ids(...)
-#define trace_event_atomic_with_ids(...)
+#define	trace_event(...) do {} while (0)
+#define	trace_event_atomic(...) do {} while (0)
+#define trace_event_with_ids(...) do {} while (0)
+#define trace_event_atomic_with_ids(...) do {} while (0)
 
-#define trace_error_with_ids(...)
-#define trace_error(...)
-#define trace_error_atomic(...)
-#define trace_error_atomic_with_ids(...)
+#define trace_error_with_ids(...) do {} while (0)
+#define trace_error(...) do {} while (0)
+#define trace_error_atomic(...) do {} while (0)
+#define trace_error_atomic_with_ids(...) do {} while (0)
 
-#define trace_error_value(x)
-#define trace_error_value_atomic(x)
+#define trace_error_value(x) do {} while (0)
+#define trace_error_value_atomic(x) do {} while (0)
 
-#define trace_value(x)
-#define trace_value_atomic(x)
+#define trace_value(x) do {} while (0)
+#define trace_value_atomic(x) do {} while (0)
 
-#define trace_point(x)
+#define trace_point(x) do {} while (0)
 
-#define tracev_event(...)
-#define tracev_event_with_ids(...)
-#define tracev_event_atomic(...)
-#define tracev_event_atomic_with_ids(...)
-#define tracev_value(x)
-#define tracev_value_atomic(x)
+#define tracev_event(...) do {} while (0)
+#define tracev_event_with_ids(...) do {} while (0)
+#define tracev_event_atomic(...) do {} while (0)
+#define tracev_event_atomic_with_ids(...) do {} while (0)
+#define tracev_value(x) do {} while (0)
+#define tracev_value_atomic(x) do {} while (0)
 
 #endif
 


### PR DESCRIPTION
This commit allows code such as:

```c
if (ret < 0)
  trace_error("error: %d", ret);
return ret;
```

to work properly.

Fixes #1999 