### PR TITLE
sof: build: Disallow void pointer arithmetic

### DIFF
--- a/src/arch/host/CMakeLists.txt
+++ b/src/arch/host/CMakeLists.txt
@@ -5,4 +5,4 @@ target_include_directories(sof_public_headers INTERFACE ${PROJECT_SOURCE_DIR}/sr
 target_include_directories(sof_public_headers INTERFACE ${PROJECT_SOURCE_DIR}/src/platform/library/include)
 
 # C & ASM flags
-target_compile_options(sof_options INTERFACE -g -O3 -Wall -Werror -Wl,-EL -Wmissing-prototypes -Wimplicit-fallthrough=3)
+target_compile_options(sof_options INTERFACE -g -O3 -Wall -Werror -Wl,-EL -Wmissing-prototypes -Wimplicit-fallthrough=3 -Wpointer-arith)

--- a/src/arch/host/include/arch/string.h
+++ b/src/arch/host/include/arch/string.h
@@ -34,8 +34,8 @@ static inline int arch_memcpy_s(void *dest, size_t dest_size,
 	if (!dest || !src)
 		return -EINVAL;
 
-	if ((dest >= src && dest < (src + src_size)) ||
-	    (src >= dest && src < (dest + dest_size)))
+	if ((dest >= src && (char *)dest < ((char *)src + src_size)) ||
+	    (src >= dest && (char *)src < ((char *)dest + dest_size)))
 		return -EINVAL;
 
 	if (src_size > dest_size)

--- a/src/arch/xtensa/CMakeLists.txt
+++ b/src/arch/xtensa/CMakeLists.txt
@@ -77,7 +77,7 @@ target_compile_options(sof_options INTERFACE ${stdlib_flag} -fno-inline-function
 #      better to have set of default flags and change it only for special cases
 #   3) custom function that is used instead of target_sources and sets flags
 #      for each added source based on file extension
-target_compile_options(sof_options INTERFACE $<$<COMPILE_LANGUAGE:C>:-O2 -g -Wall -Werror -Wl,-EL -Wmissing-prototypes -mtext-section-literals>)
+target_compile_options(sof_options INTERFACE $<$<COMPILE_LANGUAGE:C>:-O2 -g -Wall -Werror -Wl,-EL -Wmissing-prototypes -Wpointer-arith -mtext-section-literals>)
 
 if(BUILD_UNIT_TESTS)
 	# rest of this file is not needed for unit tests

--- a/src/arch/xtensa/boot_loader.c
+++ b/src/arch/xtensa/boot_loader.c
@@ -130,7 +130,8 @@ static uint32_t get_fw_size_in_use(void)
 	/* Calculate fw size passed in BASEFW module in MANIFEST */
 	for (i = MAN_SKIP_ENTRIES; i < hdr->num_module_entries; i++) {
 		platform_trace_point(TRACE_BOOT_LDR_PARSE_MODULE + i);
-		mod = (void *)desc + SOF_MAN_MODULE_OFFSET(i);
+		mod = (struct sof_man_module *)((char *)desc +
+						SOF_MAN_MODULE_OFFSET(i));
 		if (strcmp((char *)mod->name, "BASEFW"))
 			continue;
 		for (i = 0; i < MANIFEST_SEGMENT_COUNT; i++) {
@@ -160,7 +161,8 @@ static void parse_manifest(void)
 	for (i = MAN_SKIP_ENTRIES; i < hdr->num_module_entries; i++) {
 
 		platform_trace_point(TRACE_BOOT_LDR_PARSE_MODULE + i);
-		mod = (void *)desc + SOF_MAN_MODULE_OFFSET(i);
+		mod = (struct sof_man_module *)((char *)desc +
+						SOF_MAN_MODULE_OFFSET(i));
 		parse_module(hdr, mod);
 	}
 }

--- a/src/arch/xtensa/include/arch/string.h
+++ b/src/arch/xtensa/include/arch/string.h
@@ -47,8 +47,8 @@ static inline int arch_memcpy_s(void *dest, size_t dest_size,
 	if (!dest || !src)
 		return -EINVAL;
 
-	if ((dest >= src && dest < (src + src_size)) ||
-	    (src >= dest && src < (dest + dest_size)))
+	if ((dest >= src && (char *)dest < ((char *)src + src_size)) ||
+	    (src >= dest && (char *)src < ((char *)dest + dest_size)))
 		return -EINVAL;
 
 	if (src_size > dest_size)

--- a/src/arch/xtensa/schedule/task.c
+++ b/src/arch/xtensa/schedule/task.c
@@ -92,7 +92,8 @@ int task_context_init(void *task_ctx, void *entry, void *arg0, void *arg1,
 	bzero(ctx->stack_base, ctx->stack_size);
 
 	/* set initial stack pointer */
-	sp = ctx->stack_base + ctx->stack_size - sizeof(UserFrame);
+	sp = (UserFrame *)((char *)ctx->stack_base + ctx->stack_size -
+			   sizeof(UserFrame));
 
 	/* entry point */
 	sp->pc = (uint32_t)entry;

--- a/src/audio/buffer.c
+++ b/src/audio/buffer.c
@@ -132,12 +132,12 @@ void comp_update_buffer_produce(struct comp_buffer *buffer, uint32_t bytes)
 
 	irq_local_disable(flags);
 
-	buffer->w_ptr += bytes;
+	buffer->w_ptr = (char *)buffer->w_ptr + bytes;
 
 	/* check for pointer wrap */
 	if (buffer->w_ptr >= buffer->end_addr)
-		buffer->w_ptr = buffer->addr +
-			(buffer->w_ptr - buffer->end_addr);
+		buffer->w_ptr = (char *)buffer->addr +
+			((char *)buffer->w_ptr - (char *)buffer->end_addr);
 
 	/* "overwrite" old data in circular wrap case */
 	if (bytes > buffer->free)
@@ -145,11 +145,12 @@ void comp_update_buffer_produce(struct comp_buffer *buffer, uint32_t bytes)
 
 	/* calculate available bytes */
 	if (buffer->r_ptr < buffer->w_ptr)
-		buffer->avail = buffer->w_ptr - buffer->r_ptr;
+		buffer->avail = (char *)buffer->w_ptr - (char *)buffer->r_ptr;
 	else if (buffer->r_ptr == buffer->w_ptr)
 		buffer->avail = buffer->size; /* full */
 	else
-		buffer->avail = buffer->size - (buffer->r_ptr - buffer->w_ptr);
+		buffer->avail = buffer->size -
+			((char *)buffer->r_ptr - (char *)buffer->w_ptr);
 
 	/* calculate free bytes */
 	buffer->free = buffer->size - buffer->avail;
@@ -187,20 +188,21 @@ void comp_update_buffer_consume(struct comp_buffer *buffer, uint32_t bytes)
 
 	irq_local_disable(flags);
 
-	buffer->r_ptr += bytes;
+	buffer->r_ptr = (char *)buffer->r_ptr + bytes;
 
 	/* check for pointer wrap */
 	if (buffer->r_ptr >= buffer->end_addr)
-		buffer->r_ptr = buffer->addr +
-			(buffer->r_ptr - buffer->end_addr);
+		buffer->r_ptr = (char *)buffer->addr +
+			((char *)buffer->r_ptr - (char *)buffer->end_addr);
 
 	/* calculate available bytes */
 	if (buffer->r_ptr < buffer->w_ptr)
-		buffer->avail = buffer->w_ptr - buffer->r_ptr;
+		buffer->avail = (char *)buffer->w_ptr - (char *)buffer->r_ptr;
 	else if (buffer->r_ptr == buffer->w_ptr)
 		buffer->avail = 0; /* empty */
 	else
-		buffer->avail = buffer->size - (buffer->r_ptr - buffer->w_ptr);
+		buffer->avail = buffer->size -
+			((char *)buffer->r_ptr - (char *)buffer->w_ptr);
 
 	/* calculate free bytes */
 	buffer->free = buffer->size - buffer->avail;

--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -134,7 +134,7 @@ static void dai_dma_cb(void *data, uint32_t type, struct dma_cb_data *next)
 	if (dd->dai_pos) {
 		dd->dai_pos_blks += bytes;
 		*dd->dai_pos = dd->dai_pos_blks +
-			buffer_ptr - dd->dma_buffer->addr;
+			(char *)buffer_ptr - (char *)dd->dma_buffer->addr;
 	}
 }
 

--- a/src/audio/detect_test.c
+++ b/src/audio/detect_test.c
@@ -435,7 +435,7 @@ static int test_keyword_set_model(struct comp_dev *dev,
 		return -EINVAL;
 	}
 
-	ret = memcpy_s(cd->model.data + cd->model.data_pos,
+	ret = memcpy_s((char *)cd->model.data + cd->model.data_pos,
 		       cd->model.data_size - cd->model.data_pos,
 		       cdata->data->data, cdata->num_elems);
 	assert(!ret);
@@ -571,7 +571,8 @@ static int test_keyword_get_model(struct comp_dev *dev,
 		}
 
 		ret = memcpy_s(cdata->data->data, size,
-			       cd->model.data + cd->model.data_pos, bs);
+			       (char *)cd->model.data + cd->model.data_pos,
+			       bs);
 		assert(!ret);
 
 		cdata->data->abi = SOF_ABI_VERSION;

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -222,7 +222,8 @@ static size_t kpb_allocate_history_buffer(struct comp_data *kpb)
 			trace_kpb("kpb new memory block: %d", ca_size);
 			allocated_size += ca_size;
 			history_buffer->start_addr = new_mem_block;
-			history_buffer->end_addr = new_mem_block + ca_size;
+			history_buffer->end_addr = (char *)new_mem_block +
+				ca_size;
 			history_buffer->w_ptr = new_mem_block;
 			history_buffer->r_ptr = new_mem_block;
 			history_buffer->state = KPB_BUFFER_FREE;
@@ -721,7 +722,7 @@ static int kpb_buffer_data(struct comp_dev *dev, struct comp_buffer *source,
 			kpb_buffer_samples(source, offset, buff->w_ptr,
 					   space_avail, sample_width);
 			/* Update write pointer & requested copy size */
-			buff->w_ptr += space_avail;
+			buff->w_ptr = (char *)buff->w_ptr + space_avail;
 			size_to_copy = size_to_copy - space_avail;
 			/* Update read pointer's offset before continuing
 			 * with next buffer.
@@ -735,7 +736,7 @@ static int kpb_buffer_data(struct comp_dev *dev, struct comp_buffer *source,
 			kpb_buffer_samples(source, offset, buff->w_ptr,
 					   size_to_copy, sample_width);
 			/* Update write pointer & requested copy size */
-			buff->w_ptr += size_to_copy;
+			buff->w_ptr = (char *)buff->w_ptr + size_to_copy;
 			/* Reset requested copy size */
 			size_to_copy = 0;
 		}
@@ -945,8 +946,8 @@ static void kpb_init_draining(struct comp_dev *dev, struct kpb_client *cli)
 					buff = buff->prev;
 					buffered += (uint32_t)buff->end_addr -
 						    (uint32_t)buff->w_ptr;
-					buff->r_ptr = buff->w_ptr + (buffered -
-						      history_depth);
+					buff->r_ptr = (char *)buff->w_ptr +
+						      (buffered - history_depth);
 					break;
 				}
 				buff = buff->prev;
@@ -954,7 +955,7 @@ static void kpb_init_draining(struct comp_dev *dev, struct kpb_client *cli)
 				buff->r_ptr = buff->start_addr;
 				break;
 			} else {
-				buff->r_ptr = buff->start_addr +
+				buff->r_ptr = (char *)buff->start_addr +
 					      (buffered - history_depth);
 				break;
 			}
@@ -1072,7 +1073,7 @@ static enum task_state kpb_draining_task(void *arg)
 		kpb_drain_samples(buff->r_ptr, sink, size_to_copy,
 				  sample_width);
 
-		buff->r_ptr += (uint32_t)size_to_copy;
+		buff->r_ptr = (char *)buff->r_ptr + (uint32_t)size_to_copy;
 		history_depth -= size_to_copy;
 		drained += size_to_copy;
 		period_bytes += size_to_copy;

--- a/src/audio/pipeline_static.c
+++ b/src/audio/pipeline_static.c
@@ -383,7 +383,8 @@ int init_static_pipeline(struct ipc *ipc)
 					goto error;
 
 				/* next component - sizes not constant */
-				c = (void *)c + c->hdr.size;
+				c = (struct sof_ipc_comp *)
+				     ((char *)c + c->hdr.size);
 			}
 		}
 

--- a/src/audio/src/src_generic.c
+++ b/src/audio/src/src_generic.c
@@ -292,7 +292,7 @@ void src_polyphase_stage_cir(struct src_stage_prm *s)
 					   fir_delay, fir_end, fir_length,
 					   taps_x_nch, cfg->shift, nch);
 			wp += nch_x_odm;
-			cp += subfilter_size;
+			cp = (char *)cp + subfilter_size;
 			src_inc_wrap(&wp, out_delay_end, out_size);
 			rp -= nch_x_idm; /* Next sub-filter start */
 			src_dec_wrap(&rp, fir_delay, fir_size);
@@ -391,7 +391,7 @@ void src_polyphase_stage_cir_s16(struct src_stage_prm *s)
 					   fir_delay, fir_end, fir_length,
 					   taps_x_nch, cfg->shift, nch);
 			wp += nch_x_odm;
-			cp += subfilter_size;
+			cp = (char *)cp + subfilter_size;
 			src_inc_wrap(&wp, out_delay_end, out_size);
 			rp -= nch_x_idm; /* Next sub-filter start */
 			src_dec_wrap(&rp, fir_delay, fir_size);

--- a/src/audio/src/src_hifi3.c
+++ b/src/audio/src/src_hifi3.c
@@ -385,7 +385,7 @@ void src_polyphase_stage_cir(struct src_stage_prm *s)
 		for (i = 0; i < cfg->num_of_subfilters; i++) {
 			fir_filter(rp, cp, wp, taps_div_4, cfg->shift, nch);
 			wp += nch_x_odm;
-			cp += subfilter_size;
+			cp = (char *)cp + subfilter_size;
 			src_inc_wrap((int32_t **)&wp, out_delay_end, out_size);
 
 			/* Circular advance pointer rp by number of
@@ -510,7 +510,7 @@ void src_polyphase_stage_cir_s16(struct src_stage_prm *s)
 		for (i = 0; i < cfg->num_of_subfilters; i++) {
 			fir_filter(rp, cp, wp, taps_div_4, cfg->shift, nch);
 			wp += nch_x_odm;
-			cp += subfilter_size;
+			cp = (char *)cp + subfilter_size;
 			src_inc_wrap((int32_t **)&wp, out_delay_end, out_size);
 
 			/* Circular advance pointer rp by number of

--- a/src/debug/panic.c
+++ b/src/debug/panic.c
@@ -34,21 +34,21 @@ void dump_panicinfo(void *addr, struct sof_ipc_panic_info *panic_info)
 void panic_rewind(uint32_t p, uint32_t stack_rewind_frames,
 		  struct sof_ipc_panic_info *panic_info, uintptr_t *data)
 {
-	void *ext_offset;
+	char *ext_offset;
 	size_t count;
 	uintptr_t stack_ptr;
 
 	/* disable all IRQs */
 	interrupt_global_disable();
 
-	ext_offset = (void *)mailbox_get_exception_base() + ARCH_OOPS_SIZE;
+	ext_offset = (char *)mailbox_get_exception_base() + ARCH_OOPS_SIZE;
 
 	/* dump panic info, filename ane linenum */
 	dump_panicinfo(ext_offset, panic_info);
 	ext_offset += sizeof(struct sof_ipc_panic_info);
 
 	count = MAILBOX_EXCEPTION_SIZE -
-		(size_t)(ext_offset - mailbox_get_exception_base());
+		(size_t)(ext_offset - (char *)mailbox_get_exception_base());
 
 	/* flush last trace messages */
 #if CONFIG_TRACE

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -205,11 +205,12 @@ static inline void buffer_reset_pos(struct comp_buffer *buffer)
 static inline void *buffer_get_frag(struct comp_buffer *buffer, void *ptr,
 				    uint32_t idx, uint32_t size)
 {
-	void *current = ptr + (idx * size);
+	void *current = (char *)ptr + (idx * size);
 
 	/* check for pointer wrap */
 	if (current >= buffer->end_addr)
-		current = buffer->addr + (current - buffer->end_addr);
+		current = (char *)buffer->addr +
+			((char *)current - (char *)buffer->end_addr);
 
 	return current;
 }
@@ -222,7 +223,7 @@ static inline void buffer_init(struct comp_buffer *buffer, uint32_t size,
 	buffer->caps = caps;
 	buffer->w_ptr = buffer->addr;
 	buffer->r_ptr = buffer->addr;
-	buffer->end_addr = buffer->addr + size;
+	buffer->end_addr = (char *)buffer->addr + size;
 	buffer->free = size;
 	buffer->avail = 0;
 	buffer_zero(buffer);

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -287,7 +287,7 @@ struct comp_copy_limits {
 
 /** \brief Retrieves component device config data. */
 #define COMP_GET_CONFIG(dev) \
-	(struct sof_ipc_comp_config *)((void *)&dev->comp + \
+	(struct sof_ipc_comp_config *)((char *)&dev->comp + \
 	sizeof(struct sof_ipc_comp))
 
 /** \brief Sets the driver private data. */

--- a/src/include/sof/trace/dma-trace.h
+++ b/src/include/sof/trace/dma-trace.h
@@ -59,7 +59,7 @@ void dtrace_event_atomic(const char *e, uint32_t length);
 
 static inline uint32_t dtrace_calc_buf_margin(struct dma_trace_buf *buffer)
 {
-	return buffer->end_addr - buffer->w_ptr;
+	return (char *)buffer->end_addr - (char *)buffer->w_ptr;
 }
 
 #endif /* __SOF_TRACE_DMA_TRACE_H__ */

--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -91,7 +91,7 @@
 		if (rx_size > tx->size) {				\
 			___ret = memcpy_s(rx, rx_size, tx, tx->size);	\
 			assert(!___ret);				\
-			bzero((void *)rx + tx->size, rx_size - tx->size);\
+			bzero((char *)rx + tx->size, rx_size - tx->size);\
 			trace_ipc("ipc: hdr 0x%x rx (%d) > tx (%d)",	\
 				  rx->cmd, rx_size, tx->size);		\
 		} else if (tx->size > rx_size) {			\

--- a/src/lib/alloc.c
+++ b/src/lib/alloc.c
@@ -217,7 +217,7 @@ static void *align_ptr(struct mm_heap *heap, uint32_t alignment,
 		mod_align = alignment - ((uintptr_t)ptr % alignment);
 
 	/* Calculate aligned pointer */
-	ptr = ptr + mod_align;
+	ptr = (char *)ptr + mod_align;
 
 	return ptr;
 }
@@ -845,7 +845,7 @@ static void _rfree_unlocked(void *ptr)
 
 	/* panic if pointer is from system heap */
 	if (ptr >= (void *)cpu_heap->heap &&
-	    ptr < (void *)cpu_heap->heap + cpu_heap->size) {
+	    (char *)ptr < (char *)cpu_heap->heap + cpu_heap->size) {
 		trace_error(TRACE_CLASS_MEM, "rfree() error: "
 			   "attempt to free system heap = %p, cpu = %d",
 			    (uintptr_t)ptr, cpu_get_id());

--- a/src/lib/dma.c
+++ b/src/lib/dma.c
@@ -197,8 +197,8 @@ void dma_buffer_copy_from(struct comp_buffer *source, struct comp_buffer *sink,
 	uint32_t tail = 0;
 
 	/* source buffer contains data copied by DMA */
-	if (source->r_ptr + bytes > source->end_addr) {
-		head = source->end_addr - source->r_ptr;
+	if ((char *)source->r_ptr + bytes > (char *)source->end_addr) {
+		head = (char *)source->end_addr - (char *)source->r_ptr;
 		tail = bytes - head;
 	}
 
@@ -209,12 +209,12 @@ void dma_buffer_copy_from(struct comp_buffer *source, struct comp_buffer *sink,
 	/* process data */
 	process(source, sink, bytes);
 
-	source->r_ptr += bytes;
+	source->r_ptr = (char *)source->r_ptr + bytes;
 
 	/* check for pointer wrap */
 	if (source->r_ptr >= source->end_addr)
-		source->r_ptr = source->addr +
-			(source->r_ptr - source->end_addr);
+		source->r_ptr = (char *)source->addr +
+			((char *)source->r_ptr - (char *)source->end_addr);
 
 	comp_update_buffer_produce(sink, bytes);
 }
@@ -230,8 +230,8 @@ void dma_buffer_copy_to(struct comp_buffer *source, struct comp_buffer *sink,
 	process(source, sink, bytes);
 
 	/* sink buffer contains data meant to copied to DMA */
-	if (sink->w_ptr + bytes > sink->end_addr) {
-		head = sink->end_addr - sink->w_ptr;
+	if ((char *)sink->w_ptr + bytes > (char *)sink->end_addr) {
+		head = (char *)sink->end_addr - (char *)sink->w_ptr;
 		tail = bytes - head;
 	}
 
@@ -239,12 +239,12 @@ void dma_buffer_copy_to(struct comp_buffer *source, struct comp_buffer *sink,
 	if (tail)
 		dcache_writeback_region(sink->addr, tail);
 
-	sink->w_ptr += bytes;
+	sink->w_ptr = (char *)sink->w_ptr + bytes;
 
 	/* check for pointer wrap */
 	if (sink->w_ptr >= sink->end_addr)
-		sink->w_ptr = sink->addr +
-			(sink->w_ptr - sink->end_addr);
+		sink->w_ptr = (char *)sink->addr +
+			((char *)sink->w_ptr - (char *)sink->end_addr);
 
 	comp_update_buffer_consume(source, bytes);
 }

--- a/src/platform/intel/cavs/lib/pm_memory.c
+++ b/src/platform/intel/cavs/lib/pm_memory.c
@@ -170,7 +170,7 @@ void set_power_gate_for_memory_address_range(void *ptr,
 {
 	uint32_t start_bank_id;
 	uint32_t ending_bank_id;
-	void *end_ptr = ptr + size;
+	void *end_ptr = (char *)ptr + size;
 
 	/* if ptr is not aligned to bank size change it to
 	 * closest possible memory address at the start of bank
@@ -183,7 +183,7 @@ void set_power_gate_for_memory_address_range(void *ptr,
 		end_ptr = (void *)ALIGN_DOWN((uintptr_t)ptr, SRAM_BANK_SIZE);
 
 	/* return if no full bank could be found for enabled gate control */
-	if (end_ptr - ptr < SRAM_BANK_SIZE) {
+	if ((char *)end_ptr - (char *)ptr < SRAM_BANK_SIZE) {
 		trace_mem_pm("Could not find full bank "
 			"to perform gating operation");
 		return;

--- a/src/platform/intel/cavs/lib/pm_runtime.c
+++ b/src/platform/intel/cavs/lib/pm_runtime.c
@@ -271,7 +271,7 @@ static inline void cavs_pm_runtime_core_dis_memory(uint32_t index)
 	/* Address is calculated for index (0 for the master core) minus one
 	 * since _sof_core_s_start is first slave core stack address
 	 */
-	core_memory_ptr = (void *)&_sof_core_s_start
+	core_memory_ptr = (char *)&_sof_core_s_start
 		+ (index - 1) * SOF_CORE_S_SIZE;
 
 	set_power_gate_for_memory_address_range(core_memory_ptr,
@@ -289,7 +289,7 @@ static inline void cavs_pm_runtime_core_en_memory(uint32_t index)
 	/* Address is calculated for index (0 for the master core) minus one
 	 * since _sof_core_s_start is first slave core stack address
 	 */
-	core_memory_ptr = (void *)&_sof_core_s_start
+	core_memory_ptr = (char *)&_sof_core_s_start
 		+ (index - 1) * SOF_CORE_S_SIZE;
 
 	set_power_gate_for_memory_address_range(core_memory_ptr,

--- a/test/cmocka/src/audio/buffer/buffer_write.c
+++ b/test/cmocka/src/audio/buffer/buffer_write.c
@@ -39,7 +39,7 @@ static void test_audio_buffer_write_10_bytes_out_of_256_and_read_back
 
 	assert_int_equal(buf->avail, 10);
 	assert_int_equal(buf->free, 246);
-	assert_ptr_equal(buf->w_ptr, buf->r_ptr + 10);
+	assert_ptr_equal(buf->w_ptr, (char *)buf->r_ptr + 10);
 
 	assert_int_equal(memcmp(buf->r_ptr, &bytes, 10), 0);
 

--- a/test/cmocka/src/universal_mocks.c
+++ b/test/cmocka/src/universal_mocks.c
@@ -13,8 +13,8 @@ int memcpy_s(void *dest, size_t dest_size,
 	if (!dest || !src)
 		return -EINVAL;
 
-	if ((dest >= src && dest < (src + src_size)) ||
-	    (src >= dest && src < (dest + dest_size)))
+	if ((dest >= src && (char *)dest < ((char *)src + src_size)) ||
+	    (src >= dest && (char *)src < ((char *)dest + dest_size)))
 		return -EINVAL;
 
 	if (src_size > dest_size)


### PR DESCRIPTION
Void pointer arithmetic isn't supported in Zephyr. This pull request removes it.

Signed-off-by: Paul Olaru <paul.olaru@nxp.com>

~Draft because I only added the flag so I get compile errors, without actually removing anything. I believe I should also add the flag on host?~ (no longer draft, host is also covered)

Fixes: #1913 