### PR TITLE
dma: remove spinlock_init() in dw_dma_probe()

### DIFF
--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -956,8 +956,6 @@ static int dw_dma_probe(struct dma *dma)
 		goto out;
 	}
 
-	spinlock_init(&dma->lock);
-
 	ret = dw_dma_setup(dma);
 	if (ret < 0)
 		return ret;


### PR DESCRIPTION
Remove spinlock_init() in dw_dma_probe() function
in order to avoid memory leaks. spinlock_init() is
invoked in dmac_init() platform/*/lib/dma.c
files.

Signed-off-by: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>