### PR TITLE
pcm_converter: add implementations

### DIFF
--- a/src/audio/CMakeLists.txt
+++ b/src/audio/CMakeLists.txt
@@ -57,6 +57,7 @@ if(NOT BUILD_LIBRARY)
 			detect_test.c
 		)
 	endif()
+	add_subdirectory(pcm_converter)
 	return()
 endif()
 

--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -108,16 +108,17 @@ static void dai_dma_cb(void *data, uint32_t type, struct dma_cb_data *next)
 		local_buffer = list_first_item(&dev->bsource_list,
 					       struct comp_buffer, sink_list);
 
-		dma_buffer_copy_to(local_buffer, dd->dma_buffer, dd->process,
-				   bytes);
+		dma_buffer_copy_to(local_buffer, bytes, dd->dma_buffer, bytes,
+				   dd->process, bytes / comp_sample_bytes(dev));
 
 		buffer_ptr = local_buffer->r_ptr;
 	} else {
 		local_buffer = list_first_item(&dev->bsink_list,
 					       struct comp_buffer, source_list);
 
-		dma_buffer_copy_from(dd->dma_buffer, local_buffer, dd->process,
-				     bytes);
+		dma_buffer_copy_from(dd->dma_buffer, bytes, local_buffer, bytes,
+				     dd->process,
+				     bytes / comp_sample_bytes(dev));
 
 		buffer_ptr = local_buffer->w_ptr;
 	}

--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -192,16 +192,7 @@ static void eq_fir_s16_passthrough(struct fir_state_32x16 fir[],
 				   struct comp_buffer *sink,
 				   int frames, int nch)
 {
-	int16_t *x;
-	int16_t *y;
-	int i;
-	int n = frames * nch;
-
-	for (i = 0; i < n; i++) {
-		x = buffer_read_frag_s16(source, i);
-		y = buffer_write_frag_s16(sink, i);
-		*y = *x;
-	}
+	buffer_copy_s16(source, sink, frames * nch);
 }
 #endif /* CONFIG_FORMAT_S16LE */
 
@@ -211,16 +202,7 @@ static void eq_fir_s32_passthrough(struct fir_state_32x16 fir[],
 				   struct comp_buffer *sink,
 				   int frames, int nch)
 {
-	int32_t *x;
-	int32_t *y;
-	int i;
-	int n = frames * nch;
-
-	for (i = 0; i < n; i++) {
-		x = buffer_read_frag_s32(source, i);
-		y = buffer_write_frag_s32(sink, i);
-		*y = *x;
-	}
+	buffer_copy_s32(source, sink, frames * nch);
 }
 #endif /* CONFIG_FORMAT_S24LE || CONFIG_FORMAT_S32LE */
 

--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -784,10 +784,10 @@ static int eq_fir_prepare(struct comp_dev *dev)
 				struct comp_buffer, source_list);
 
 	/* get source data format */
-	cd->source_format = comp_frame_fmt(sourceb->source);
+	cd->source_format = sourceb->source->params.frame_fmt;
 
 	/* get sink data format and period bytes */
-	cd->sink_format = comp_frame_fmt(sinkb->sink);
+	cd->sink_format = sinkb->sink->params.frame_fmt;
 	sink_period_bytes = comp_period_bytes(sinkb->sink, dev->frames);
 
 	/* Rewrite params format for this component to match the host side. */

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -826,10 +826,10 @@ static int eq_iir_prepare(struct comp_dev *dev)
 				struct comp_buffer, source_list);
 
 	/* get source data format */
-	cd->source_format = comp_frame_fmt(sourceb->source);
+	cd->source_format = sourceb->source->params.frame_fmt;
 
 	/* get sink data format and period bytes */
-	cd->sink_format = comp_frame_fmt(sinkb->sink);
+	cd->sink_format = sinkb->sink->params.frame_fmt;
 	sink_period_bytes = comp_period_bytes(sinkb->sink, dev->frames);
 
 	/* Rewrite params format for this component to match the host side. */

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -225,16 +225,7 @@ static void eq_iir_s16_pass(struct comp_dev *dev,
 			    struct comp_buffer *sink,
 			    uint32_t frames)
 {
-	int16_t *x;
-	int16_t *y;
-	int i;
-	int n = frames * dev->params.channels;
-
-	for (i = 0; i < n; i++) {
-		x = buffer_read_frag_s16(source, i);
-		y = buffer_write_frag_s16(sink, i);
-		*y = *x;
-	}
+	buffer_copy_s16(source, sink, frames * dev->params.channels);
 }
 #endif /* CONFIG_FORMAT_S16LE */
 
@@ -244,16 +235,7 @@ static void eq_iir_s32_pass(struct comp_dev *dev,
 			    struct comp_buffer *sink,
 			    uint32_t frames)
 {
-	int32_t *x;
-	int32_t *y;
-	int i;
-	int n = frames * dev->params.channels;
-
-	for (i = 0; i < n; i++) {
-		x = buffer_read_frag_s32(source, i);
-		y = buffer_write_frag_s32(sink, i);
-		*y = *x;
-	}
+	buffer_copy_s32(source, sink, frames * dev->params.channels);
 }
 #endif /* CONFIG_FORMAT_S24LE || CONFIG_FORMAT_S32LE */
 

--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -7,6 +7,7 @@
 
 #include <sof/audio/buffer.h>
 #include <sof/audio/component.h>
+#include <sof/audio/pcm_converter.h>
 #include <sof/audio/pipeline.h>
 #include <sof/common.h>
 #include <sof/debug/panic.h>
@@ -587,10 +588,8 @@ static int host_params(struct comp_dev *dev)
 	dma_set_cb(hd->chan, DMA_CB_TYPE_COPY, host_dma_cb, dev);
 
 	/* set processing function */
-	if (dev->params.frame_fmt == SOF_IPC_FRAME_S16_LE)
-		hd->process = buffer_copy_s16;
-	else
-		hd->process = buffer_copy_s32;
+	hd->process = pcm_get_conversion_function(dev->params.frame_fmt,
+						  dev->params.frame_fmt);
 
 	return 0;
 }

--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -141,13 +141,14 @@ static void host_update_position(struct comp_dev *dev, uint32_t bytes)
 	if (dev->params.direction == SOF_IPC_STREAM_PLAYBACK) {
 		local_buffer = list_first_item(&dev->bsink_list,
 					       struct comp_buffer, source_list);
-		dma_buffer_copy_from(hd->dma_buffer, local_buffer, hd->process,
-				     bytes);
+		dma_buffer_copy_from(hd->dma_buffer, bytes, local_buffer, bytes,
+				     hd->process,
+				     bytes / comp_sample_bytes(dev));
 	} else {
 		local_buffer = list_first_item(&dev->bsource_list,
 					       struct comp_buffer, sink_list);
-		dma_buffer_copy_to(local_buffer, hd->dma_buffer, hd->process,
-				   bytes);
+		dma_buffer_copy_to(local_buffer, bytes, hd->dma_buffer, bytes,
+				   hd->process, bytes / comp_sample_bytes(dev));
 	}
 
 	dev->position += bytes;

--- a/src/audio/pcm_converter/CMakeLists.txt
+++ b/src/audio/pcm_converter/CMakeLists.txt
@@ -1,3 +1,3 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-add_local_sources(sof pcm_converter_generic.c)
+add_local_sources(sof pcm_converter_generic.c pcm_converter_hifi3.c)

--- a/src/audio/pcm_converter/CMakeLists.txt
+++ b/src/audio/pcm_converter/CMakeLists.txt
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+add_local_sources(sof pcm_converter_generic.c)

--- a/src/audio/pcm_converter/pcm_converter_generic.c
+++ b/src/audio/pcm_converter/pcm_converter_generic.c
@@ -10,9 +10,12 @@
  * \authors Tomasz Lauda <tomasz.lauda@linux.intel.com>
  */
 
+#include <sof/audio/pcm_converter.h>
+
+#ifdef PCM_CONVERTER_GENERIC
+
 #include <sof/audio/buffer.h>
 #include <sof/audio/format.h>
-#include <sof/audio/pcm_converter.h>
 #include <sof/common.h>
 #include <ipc/stream.h>
 #include <config.h>
@@ -152,3 +155,5 @@ const struct pcm_func_map pcm_func_map[] = {
 };
 
 const size_t pcm_func_count = ARRAY_SIZE(pcm_func_map);
+
+#endif

--- a/src/audio/pcm_converter/pcm_converter_generic.c
+++ b/src/audio/pcm_converter/pcm_converter_generic.c
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2019 Intel Corporation. All rights reserved.
+//
+// Author: Tomasz Lauda <tomasz.lauda@linux.intel.com>
+
+/**
+ * \file audio/pcm_converter/pcm_converter_generic.c
+ * \brief PCM converter generic processing implementation
+ * \authors Tomasz Lauda <tomasz.lauda@linux.intel.com>
+ */
+
+#include <sof/audio/buffer.h>
+#include <sof/audio/format.h>
+#include <sof/audio/pcm_converter.h>
+#include <sof/common.h>
+#include <ipc/stream.h>
+#include <config.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#if CONFIG_FORMAT_S16LE && CONFIG_FORMAT_S24LE
+
+static void pcm_convert_s16_to_s24(struct comp_buffer *source,
+				   struct comp_buffer *sink, uint32_t samples)
+{
+	uint32_t buff_frag = 0;
+	int16_t *src;
+	int32_t *dst;
+	uint32_t i;
+
+	for (i = 0; i < samples; i++) {
+		src = buffer_read_frag_s16(source, buff_frag);
+		dst = buffer_write_frag_s32(sink, buff_frag);
+		*dst = *src << 8;
+		buff_frag++;
+	}
+}
+
+static void pcm_convert_s24_to_s16(struct comp_buffer *source,
+				   struct comp_buffer *sink, uint32_t samples)
+{
+	uint32_t buff_frag = 0;
+	int32_t *src;
+	int16_t *dst;
+	uint32_t i;
+
+	for (i = 0; i < samples; i++) {
+		src = buffer_read_frag_s32(source, buff_frag);
+		dst = buffer_write_frag_s16(sink, buff_frag);
+		*dst = sat_int16(Q_SHIFT_RND(sign_extend_s24(*src), 23, 15));
+		buff_frag++;
+	}
+}
+
+#endif /* CONFIG_FORMAT_S16LE && CONFIG_FORMAT_S24LE */
+
+#if CONFIG_FORMAT_S16LE && CONFIG_FORMAT_S32LE
+
+static void pcm_convert_s16_to_s32(struct comp_buffer *source,
+				   struct comp_buffer *sink, uint32_t samples)
+{
+	uint32_t buff_frag = 0;
+	int16_t *src;
+	int32_t *dst;
+	uint32_t i;
+
+	for (i = 0; i < samples; i++) {
+		src = buffer_read_frag_s16(source, buff_frag);
+		dst = buffer_write_frag_s32(sink, buff_frag);
+		*dst = *src << 16;
+		buff_frag++;
+	}
+}
+
+static void pcm_convert_s32_to_s16(struct comp_buffer *source,
+				   struct comp_buffer *sink, uint32_t samples)
+{
+	uint32_t buff_frag = 0;
+	int32_t *src;
+	int16_t *dst;
+	uint32_t i;
+
+	for (i = 0; i < samples; i++) {
+		src = buffer_read_frag_s32(source, buff_frag);
+		dst = buffer_write_frag_s16(sink, buff_frag);
+		*dst = sat_int16(Q_SHIFT_RND(*src, 31, 15));
+		buff_frag++;
+	}
+}
+
+#endif /* CONFIG_FORMAT_S16LE && CONFIG_FORMAT_S32LE */
+
+#if CONFIG_FORMAT_S24LE && CONFIG_FORMAT_S32LE
+
+static void pcm_convert_s24_to_s32(struct comp_buffer *source,
+				   struct comp_buffer *sink, uint32_t samples)
+{
+	uint32_t buff_frag = 0;
+	int32_t *src;
+	int32_t *dst;
+	uint32_t i;
+
+	for (i = 0; i < samples; i++) {
+		src = buffer_read_frag_s32(source, buff_frag);
+		dst = buffer_write_frag_s32(sink, buff_frag);
+		*dst = *src << 8;
+		buff_frag++;
+	}
+}
+
+static void pcm_convert_s32_to_s24(struct comp_buffer *source,
+				   struct comp_buffer *sink, uint32_t samples)
+{
+	uint32_t buff_frag = 0;
+	int32_t *src;
+	int32_t *dst;
+	uint32_t i;
+
+	for (i = 0; i < samples; i++) {
+		src = buffer_read_frag_s32(source, buff_frag);
+		dst = buffer_write_frag_s32(sink, buff_frag);
+		*dst = sat_int24(Q_SHIFT_RND(*src, 31, 23));
+		buff_frag++;
+	}
+}
+
+#endif /* CONFIG_FORMAT_S24LE && CONFIG_FORMAT_S32LE */
+
+const struct pcm_func_map pcm_func_map[] = {
+#if CONFIG_FORMAT_S16LE
+	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S16_LE, buffer_copy_s16 },
+#endif /* CONFIG_FORMAT_S16LE */
+#if CONFIG_FORMAT_S24LE
+	{ SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S24_4LE, buffer_copy_s32 },
+#endif /* CONFIG_FORMAT_S24LE */
+#if CONFIG_FORMAT_S32LE
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, buffer_copy_s32 },
+#endif /* CONFIG_FORMAT_S32LE */
+#if CONFIG_FORMAT_S16LE && CONFIG_FORMAT_S24LE
+	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S24_4LE, pcm_convert_s16_to_s24 },
+	{ SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S16_LE, pcm_convert_s24_to_s16 },
+#endif /* CONFIG_FORMAT_S16LE && CONFIG_FORMAT_S24LE */
+#if CONFIG_FORMAT_S16LE && CONFIG_FORMAT_S32LE
+	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S32_LE, pcm_convert_s16_to_s32 },
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE, pcm_convert_s32_to_s16 },
+#endif /* CONFIG_FORMAT_S16LE && CONFIG_FORMAT_S32LE */
+#if CONFIG_FORMAT_S24LE && CONFIG_FORMAT_S32LE
+	{ SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S32_LE, pcm_convert_s24_to_s32 },
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, pcm_convert_s32_to_s24 },
+#endif /* CONFIG_FORMAT_S24LE && CONFIG_FORMAT_S32LE */
+};
+
+const size_t pcm_func_count = ARRAY_SIZE(pcm_func_map);

--- a/src/audio/pcm_converter/pcm_converter_hifi3.c
+++ b/src/audio/pcm_converter/pcm_converter_hifi3.c
@@ -1,0 +1,592 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2019 Intel Corporation. All rights reserved.
+//
+// Author: Tomasz Lauda <tomasz.lauda@linux.intel.com>
+
+/**
+ * \file audio/pcm_converter/pcm_converter_hifi3.c
+ * \brief PCM converter HiFi3 processing implementation
+ * \authors Tomasz Lauda <tomasz.lauda@linux.intel.com>
+ */
+
+#include <sof/audio/pcm_converter.h>
+
+#ifdef PCM_CONVERTER_HIFI3
+
+#include <sof/audio/buffer.h>
+#include <sof/common.h>
+#include <ipc/stream.h>
+#include <xtensa/tie/xt_hifi3.h>
+#include <config.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/**
+ * \brief Sets buffer to be circular using HiFi3 functions.
+ * \param[in,out] buffer Circular buffer.
+ */
+static void pcm_converter_setup_circular(struct comp_buffer *buffer)
+{
+	AE_SETCBEGIN0(buffer->addr);
+	AE_SETCEND0(buffer->end_addr);
+}
+
+#if CONFIG_FORMAT_S16LE && CONFIG_FORMAT_S24LE
+
+/**
+ * \brief HiFi3 enabled PCM conversion from 16 bit to 24 bit.
+ * \param[in,out] source Source buffer.
+ * \param[in,out] sink Destination buffer.
+ * \param[in] samples Number of samples to process.
+ */
+static void pcm_convert_s16_to_s24(struct comp_buffer *source,
+				   struct comp_buffer *sink, uint32_t samples)
+{
+	ae_int16 *in = (ae_int16 *)source->r_ptr;
+	ae_int32 *out = (ae_int32 *)sink->w_ptr;
+	ae_int16x4 sample = AE_ZERO16();
+	ae_valign align_out = AE_ZALIGN64();
+	ae_int16x4 *in16x4;
+	ae_int32x2 *out32x2;
+	int i = 0;
+
+	/* required alignment for AE_L16X4_XC */
+	while (!IS_ALIGNED((uintptr_t)in, 8)) {
+		/* set source as circular buffer */
+		pcm_converter_setup_circular(source);
+
+		/* load one 16 bit sample */
+		AE_L16_XC(sample, in, sizeof(ae_int16));
+
+		/* set sink as circular buffer */
+		pcm_converter_setup_circular(sink);
+
+		/* shift right and store one 32 bit sample */
+		AE_S32_L_XC(AE_SRAI32(AE_CVT32X2F16_32(sample), 8), out,
+			    sizeof(ae_int32));
+
+		if (++i == samples)
+			return;
+	}
+
+	in16x4 = (ae_int16x4 *)in;
+	out32x2 = (ae_int32x2 *)out;
+
+	/* main loop processes 4 samples at a time */
+	while (i < samples - 3) {
+		/* set source as circular buffer */
+		pcm_converter_setup_circular(source);
+
+		/* load four 16 bit samples */
+		AE_L16X4_XC(sample, in16x4, sizeof(ae_int16x4));
+
+		/* set sink as circular buffer */
+		pcm_converter_setup_circular(sink);
+
+		/* shift right and store four 32 bit samples */
+		AE_SA32X2_IC(AE_SRAI32(AE_CVT32X2F16_32(sample), 8), align_out,
+			     out32x2);
+		AE_SA32X2_IC(AE_SRAI32(AE_CVT32X2F16_10(sample), 8), align_out,
+			     out32x2);
+
+		i += 4;
+	}
+
+	/* flush align_out register to memory */
+	AE_SA64POS_FC(align_out, out32x2);
+
+	in = (ae_int16 *)in16x4;
+	out = (ae_int32 *)out32x2;
+
+	while (i++ != samples) {
+		/* set source as circular buffer */
+		pcm_converter_setup_circular(source);
+
+		/* load one 16 bit sample */
+		AE_L16_XC(sample, in, sizeof(ae_int16));
+
+		/* set sink as circular buffer */
+		pcm_converter_setup_circular(sink);
+
+		/* shift right and store one 32 bit sample */
+		AE_S32_L_XC(AE_SRAI32(AE_CVT32X2F16_32(sample), 8), out,
+			    sizeof(ae_int32));
+	}
+}
+
+/**
+ * \brief HiFi3 enabled PCM shift from 24 bit to 16 bit.
+ * \param[in] sample Input sample.
+ * \return Shifted sample.
+ */
+static ae_int32x2 pcm_shift_s24_to_s16(ae_int32x2 sample)
+{
+	/* shift with saturation and rounding */
+	sample = AE_SLAA32(sample, 8);
+	sample = AE_SRAI32R(sample, 16);
+	sample = AE_SLAI32S(sample, 16);
+	sample = AE_SRAI32(sample, 16);
+
+	return sample;
+}
+
+/**
+ * \brief HiFi3 enabled PCM conversion from 24 bit to 16 bit.
+ * \param[in,out] source Source buffer.
+ * \param[in,out] sink Destination buffer.
+ * \param[in] samples Number of samples to process.
+ */
+static void pcm_convert_s24_to_s16(struct comp_buffer *source,
+				   struct comp_buffer *sink, uint32_t samples)
+{
+	ae_int32x2 *in = (ae_int32x2 *)source->r_ptr;
+	ae_int16x4 *out = (ae_int16x4 *)sink->w_ptr;
+	ae_int16x4 sample = AE_ZERO16();
+	ae_int32x2 sample_1 = AE_ZERO32();
+	ae_int32x2 sample_2 = AE_ZERO32();
+	ae_valign align_out = AE_ZALIGN64();
+	int i = 0;
+	int leftover;
+
+	/* required alignment for AE_L32X2_XC */
+	if (!IS_ALIGNED((uintptr_t)in, 8)) {
+		/* set source as circular buffer */
+		pcm_converter_setup_circular(source);
+
+		/* load one 32 bit sample */
+		AE_L32_XC(sample_1, (ae_int32 *)in, sizeof(ae_int32));
+
+		/* shift and round */
+		sample_1 = pcm_shift_s24_to_s16(sample_1);
+		sample = AE_MOVINT16X4_FROMINT32X2(sample_1);
+
+		/* set sink as circular buffer */
+		pcm_converter_setup_circular(sink);
+
+		/* store one 16 bit sample */
+		AE_S16_0_XC(AE_MOVAD16_0(sample), (ae_int16 *)out,
+			    sizeof(ae_int16));
+
+		samples--;
+	}
+
+	/* main loop processes 4 samples at a time */
+	while (i < samples - 3) {
+		/* set source as circular buffer */
+		pcm_converter_setup_circular(source);
+
+		/* load four 32 bit samples */
+		AE_L32X2_XC(sample_1, in, sizeof(ae_int32x2));
+		AE_L32X2_XC(sample_2, in, sizeof(ae_int32x2));
+
+		/* set sink as circular buffer */
+		pcm_converter_setup_circular(sink);
+
+		/* shift and round */
+		sample_1 = pcm_shift_s24_to_s16(sample_1);
+		sample_2 = pcm_shift_s24_to_s16(sample_2);
+
+		/* store four 16 bit samples */
+		sample = AE_CVT16X4(sample_1, sample_2);
+		AE_SA16X4_IC(sample, align_out, out);
+
+		i += 4;
+	}
+
+	/* flush align_out register to memory */
+	AE_SA64POS_FC(align_out, out);
+
+	leftover = samples - i;
+
+	while (leftover) {
+		/* set source as circular buffer */
+		pcm_converter_setup_circular(source);
+
+		/* load two 32 bit samples */
+		AE_L32X2_XC(sample_1, in, sizeof(ae_int32x2));
+
+		/* shift and round */
+		sample_1 = pcm_shift_s24_to_s16(sample_1);
+		sample = AE_MOVINT16X4_FROMINT32X2(sample_1);
+
+		/* set sink as circular buffer */
+		pcm_converter_setup_circular(sink);
+
+		/* store one 16 bit sample */
+		AE_S16_0_XC(AE_MOVAD16_2(sample), (ae_int16 *)out,
+			    sizeof(ae_int16));
+
+		/* no more samples to process */
+		if (leftover == 1)
+			return;
+
+		/* store one 16 bit sample */
+		AE_S16_0_XC(AE_MOVAD16_0(sample), (ae_int16 *)out,
+			    sizeof(ae_int16));
+
+		leftover -= 2;
+	}
+}
+
+#endif /* CONFIG_FORMAT_S16LE && CONFIG_FORMAT_S24LE */
+
+#if CONFIG_FORMAT_S16LE && CONFIG_FORMAT_S32LE
+
+/**
+ * \brief HiFi3 enabled PCM conversion from 16 bit to 32 bit.
+ * \param[in,out] source Source buffer.
+ * \param[in,out] sink Destination buffer.
+ * \param[in] samples Number of samples to process.
+ */
+static void pcm_convert_s16_to_s32(struct comp_buffer *source,
+				   struct comp_buffer *sink, uint32_t samples)
+{
+	ae_int16 *in = (ae_int16 *)source->r_ptr;
+	ae_int32 *out = (ae_int32 *)sink->w_ptr;
+	ae_int16x4 sample = AE_ZERO16();
+	ae_valign align_out = AE_ZALIGN64();
+	ae_int16x4 *in16x4;
+	ae_int32x2 *out32x2;
+	int i = 0;
+
+	/* required alignment for AE_L16X4_XC */
+	while (!IS_ALIGNED((uintptr_t)in, 8)) {
+		/* set source as circular buffer */
+		pcm_converter_setup_circular(source);
+
+		/* load one 16 bit sample */
+		AE_L16_XC(sample, in, sizeof(ae_int16));
+
+		/* set sink as circular buffer */
+		pcm_converter_setup_circular(sink);
+
+		/* store one 32 bit sample */
+		AE_S32_L_XC(AE_CVT32X2F16_32(sample), out, sizeof(ae_int32));
+
+		if (++i == samples)
+			return;
+	}
+
+	in16x4 = (ae_int16x4 *)in;
+	out32x2 = (ae_int32x2 *)out;
+
+	/* main loop processes 4 samples at a time */
+	while (i < samples - 3) {
+		/* set source as circular buffer */
+		pcm_converter_setup_circular(source);
+
+		/* load four 16 bit samples */
+		AE_L16X4_XC(sample, in16x4, sizeof(ae_int16x4));
+
+		/* set sink as circular buffer */
+		pcm_converter_setup_circular(sink);
+
+		/* store two 32 bit samples */
+		AE_SA32X2_IC(AE_CVT32X2F16_32(sample), align_out, out32x2);
+		AE_SA32X2_IC(AE_CVT32X2F16_10(sample), align_out, out32x2);
+
+		i += 4;
+	}
+
+	/* flush align_out register to memory */
+	AE_SA64POS_FC(align_out, out32x2);
+
+	in = (ae_int16 *)in16x4;
+	out = (ae_int32 *)out32x2;
+
+	while (i++ != samples) {
+		/* set source as circular buffer */
+		pcm_converter_setup_circular(source);
+
+		/* load one 16 bit sample */
+		AE_L16_XC(sample, in, sizeof(ae_int16));
+
+		/* set sink as circular buffer */
+		pcm_converter_setup_circular(sink);
+
+		/* store one 32 bit sample */
+		AE_S32_L_XC(AE_CVT32X2F16_32(sample), out, sizeof(ae_int32));
+	}
+}
+
+/**
+ * \brief HiFi3 enabled PCM conversion from 32 bit to 16 bit.
+ * \param[in,out] source Source buffer.
+ * \param[in,out] sink Destination buffer.
+ * \param[in] samples Number of samples to process.
+ */
+static void pcm_convert_s32_to_s16(struct comp_buffer *source,
+				   struct comp_buffer *sink, uint32_t samples)
+{
+	ae_int32x2 *in = (ae_int32x2 *)source->r_ptr;
+	ae_int16x4 *out = (ae_int16x4 *)sink->w_ptr;
+	ae_int16x4 sample = AE_ZERO16();
+	ae_int32x2 sample_1 = AE_ZERO32();
+	ae_int32x2 sample_2 = AE_ZERO32();
+	ae_valign align_out = AE_ZALIGN64();
+	int i = 0;
+	int leftover;
+
+	/* required alignment for AE_L32X2_XC */
+	if (!IS_ALIGNED((uintptr_t)in, 8)) {
+		/* set source as circular buffer */
+		pcm_converter_setup_circular(source);
+
+		/* load one 32 bit sample */
+		AE_L32_XC(sample_1, (ae_int32 *)in, sizeof(ae_int32));
+
+		/* shift and round */
+		sample = AE_ROUND16X4F32SSYM(sample_1, sample_1);
+
+		/* set sink as circular buffer */
+		pcm_converter_setup_circular(sink);
+
+		/* store one 16 bit sample */
+		AE_S16_0_XC(AE_MOVAD16_0(sample), (ae_int16 *)out,
+			    sizeof(ae_int16));
+
+		samples--;
+	}
+
+	/* main loop processes 4 samples at a time */
+	while (i < samples - 3) {
+		/* set source as circular buffer */
+		pcm_converter_setup_circular(source);
+
+		/* load four 32 bit samples */
+		AE_L32X2_XC(sample_1, in, sizeof(ae_int32x2));
+		AE_L32X2_XC(sample_2, in, sizeof(ae_int32x2));
+
+		/* set sink as circular buffer */
+		pcm_converter_setup_circular(sink);
+
+		/* shift and round */
+		sample = AE_ROUND16X4F32SSYM(sample_1, sample_2);
+
+		/* store four 16 bit samples */
+		AE_SA16X4_IC(sample, align_out, out);
+
+		i += 4;
+	}
+
+	/* flush align_out register to memory */
+	AE_SA64POS_FC(align_out, out);
+
+	leftover = samples - i;
+
+	while (leftover) {
+		/* set source as circular buffer */
+		pcm_converter_setup_circular(source);
+
+		/* load two 32 bit samples */
+		AE_L32X2_XC(sample_1, in, sizeof(ae_int32x2));
+
+		/* shift and round */
+		sample = AE_ROUND16X4F32SSYM(sample_1, sample_1);
+
+		/* set sink as circular buffer */
+		pcm_converter_setup_circular(sink);
+
+		/* store one 16 bit sample */
+		AE_S16_0_XC(AE_MOVAD16_1(sample), (ae_int16 *)out,
+			    sizeof(ae_int16));
+
+		/* no more samples to process */
+		if (leftover == 1)
+			return;
+
+		/* store one 16 bit sample */
+		AE_S16_0_XC(AE_MOVAD16_0(sample), (ae_int16 *)out,
+			    sizeof(ae_int16));
+
+		leftover -= 2;
+	}
+}
+
+#endif /* CONFIG_FORMAT_S16LE && CONFIG_FORMAT_S32LE */
+
+#if CONFIG_FORMAT_S24LE && CONFIG_FORMAT_S32LE
+
+/**
+ * \brief HiFi3 enabled PCM conversion from 24 bit to 32 bit.
+ * \param[in,out] source Source buffer.
+ * \param[in,out] sink Destination buffer.
+ * \param[in] samples Number of samples to process.
+ */
+static void pcm_convert_s24_to_s32(struct comp_buffer *source,
+				   struct comp_buffer *sink, uint32_t samples)
+{
+	ae_int32x2 *in = (ae_int32x2 *)source->r_ptr;
+	ae_int32x2 *out = (ae_int32x2 *)sink->w_ptr;
+	ae_int32x2 sample = AE_ZERO32();
+	ae_valign align_out = AE_ZALIGN64();
+	int i;
+
+	/* required alignment for AE_L32X2_XC */
+	if (!IS_ALIGNED((uintptr_t)in, 8)) {
+		/* set source as circular buffer */
+		pcm_converter_setup_circular(source);
+
+		/* load one 32 bit sample */
+		AE_L32_XC(sample, (ae_int32 *)in, sizeof(ae_int32));
+
+		/* set sink as circular buffer */
+		pcm_converter_setup_circular(sink);
+
+		/* shift left and store one 32 bit sample */
+		AE_S32_L_XC(AE_SLAI32(sample, 8), (ae_int32 *)out,
+			    sizeof(ae_int32));
+
+		samples--;
+	}
+
+	/* main loop processes 2 samples at a time */
+	for (i = 0; i < samples / 2; i++) {
+		/* set source as circular buffer */
+		pcm_converter_setup_circular(source);
+
+		/* load two 32 bit samples */
+		AE_L32X2_XC(sample, in, sizeof(ae_int32x2));
+
+		/* set sink as circular buffer */
+		pcm_converter_setup_circular(sink);
+
+		/* shift left and store two 32 bit samples */
+		AE_SA32X2_IC(AE_SLAI32(sample, 8), align_out, out);
+	}
+
+	/* flush align_out register to memory */
+	AE_SA64POS_FC(align_out, out);
+
+	/* no more samples to process */
+	if (!(samples % 2))
+		return;
+
+	/* set source as circular buffer */
+	pcm_converter_setup_circular(source);
+
+	/* load one 32 bit sample */
+	AE_L32_XC(sample, (ae_int32 *)in, 0);
+
+	/* set sink as circular buffer */
+	pcm_converter_setup_circular(sink);
+
+	/* shift left and store one 32 bit sample */
+	AE_S32_L_XC(AE_SLAI32(sample, 8), (ae_int32 *)out, 0);
+}
+
+/**
+ * \brief HiFi3 enabled PCM shift from 32 bit to 24 bit.
+ * \param[in] sample Input sample.
+ * \return Shifted sample.
+ */
+static ae_int32x2 pcm_shift_s32_to_s24(ae_int32x2 sample)
+{
+	/* shift with saturation and rounding */
+	sample = AE_SRAI32R(sample, 8);
+	sample = AE_SLAI32S(sample, 8);
+	sample = AE_SRAI32(sample, 8);
+
+	return sample;
+}
+
+/**
+ * \brief HiFi3 enabled PCM conversion from 32 bit to 24 bit.
+ * \param[in,out] source Source buffer.
+ * \param[in,out] sink Destination buffer.
+ * \param[in] samples Number of samples to process.
+ */
+static void pcm_convert_s32_to_s24(struct comp_buffer *source,
+				   struct comp_buffer *sink, uint32_t samples)
+{
+	ae_int32x2 *in = (ae_int32x2 *)source->r_ptr;
+	ae_int32x2 *out = (ae_int32x2 *)sink->w_ptr;
+	ae_int32x2 sample = AE_ZERO32();
+	ae_valign align_out = AE_ZALIGN64();
+	int i;
+
+	/* required alignment for AE_L32X2_XC */
+	if (!IS_ALIGNED((uintptr_t)in, 8)) {
+		/* set source as circular buffer */
+		pcm_converter_setup_circular(source);
+
+		/* load one 32 bit sample */
+		AE_L32_XC(sample, (ae_int32 *)in, sizeof(ae_int32));
+
+		/* set sink as circular buffer */
+		pcm_converter_setup_circular(sink);
+
+		/* shift right and store one 32 bit sample */
+		sample = pcm_shift_s32_to_s24(sample);
+		AE_S32_L_XC(sample, (ae_int32 *)out, sizeof(ae_int32));
+
+		samples--;
+	}
+
+	/* main loop processes 2 samples at a time */
+	for (i = 0; i < samples / 2; i++) {
+		/* set source as circular buffer */
+		pcm_converter_setup_circular(source);
+
+		/* load two 32 bit samples */
+		AE_L32X2_XC(sample, in, sizeof(ae_int32x2));
+
+		/* set sink as circular buffer */
+		pcm_converter_setup_circular(sink);
+
+		/* shift right and store two 32 bit samples */
+		sample = pcm_shift_s32_to_s24(sample);
+		AE_SA32X2_IC(sample, align_out, out);
+	}
+
+	/* flush align_out register to memory */
+	AE_SA64POS_FC(align_out, out);
+
+	/* no more samples to process */
+	if (!(samples % 2))
+		return;
+
+	/* set source as circular buffer */
+	pcm_converter_setup_circular(source);
+
+	/* load one 32 bit sample */
+	AE_L32_XC(sample, (ae_int32 *)in, 0);
+
+	/* set sink as circular buffer */
+	pcm_converter_setup_circular(sink);
+
+	/* shift right and store one 32 bit sample */
+	sample = pcm_shift_s32_to_s24(sample);
+	AE_S32_L_XC(sample, (ae_int32 *)out, 0);
+}
+
+#endif /* CONFIG_FORMAT_S24LE && CONFIG_FORMAT_S32LE */
+
+const struct pcm_func_map pcm_func_map[] = {
+#if CONFIG_FORMAT_S16LE
+	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S16_LE, buffer_copy_s16 },
+#endif /* CONFIG_FORMAT_S16LE */
+#if CONFIG_FORMAT_S24LE
+	{ SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S24_4LE, buffer_copy_s32 },
+#endif /* CONFIG_FORMAT_S24LE */
+#if CONFIG_FORMAT_S32LE
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, buffer_copy_s32 },
+#endif /* CONFIG_FORMAT_S32LE */
+#if CONFIG_FORMAT_S16LE && CONFIG_FORMAT_S24LE
+	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S24_4LE, pcm_convert_s16_to_s24 },
+	{ SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S16_LE, pcm_convert_s24_to_s16 },
+#endif /* CONFIG_FORMAT_S16LE && CONFIG_FORMAT_S24LE */
+#if CONFIG_FORMAT_S16LE && CONFIG_FORMAT_S32LE
+	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S32_LE, pcm_convert_s16_to_s32 },
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE, pcm_convert_s32_to_s16 },
+#endif /* CONFIG_FORMAT_S16LE && CONFIG_FORMAT_S32LE */
+#if CONFIG_FORMAT_S24LE && CONFIG_FORMAT_S32LE
+	{ SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S32_LE, pcm_convert_s24_to_s32 },
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, pcm_convert_s32_to_s24 },
+#endif /* CONFIG_FORMAT_S24LE && CONFIG_FORMAT_S32LE */
+};
+
+const size_t pcm_func_count = ARRAY_SIZE(pcm_func_map);
+
+#endif

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -373,12 +373,12 @@ static int selector_prepare(struct comp_dev *dev)
 				source_list);
 
 	/* get source data format and period bytes */
-	cd->source_format = comp_frame_fmt(sourceb->source);
+	cd->source_format = sourceb->source->params.frame_fmt;
 	cd->source_period_bytes = comp_period_bytes(sourceb->source,
 						    dev->frames);
 
 	/* get sink data format and period bytes */
-	cd->sink_format = comp_frame_fmt(sinkb->sink);
+	cd->sink_format = sinkb->sink->params.frame_fmt;
 	cd->sink_period_bytes = comp_period_bytes(sinkb->sink, dev->frames);
 
 	/* There is an assumption that sink component will report out

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -439,34 +439,10 @@ static void src_copy_s32(struct comp_dev *dev,
 			 int *n_read, int *n_written)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
-	int32_t *src = (int32_t *)source->r_ptr;
-	int32_t *snk = (int32_t *)sink->w_ptr;
 	int frames = cd->param.blk_in;
-	int n;
-	int n_wrap_src;
-	int n_wrap_snk;
-	int n_wrap_min;
-	int n_copy;
-	int ret;
 
-	n = frames * dev->params.channels;
-	while (n > 0) {
-		n_wrap_src = (int32_t *)source->end_addr - src;
-		n_wrap_snk = (int32_t *)sink->end_addr - snk;
-		n_wrap_min = (n_wrap_src < n_wrap_snk) ?
-			n_wrap_src : n_wrap_snk;
-		n_copy = (n < n_wrap_min) ? n : n_wrap_min;
-		ret = memcpy_s(snk, n_copy * sizeof(int32_t), src,
-			       n_copy * sizeof(int32_t));
-		assert(!ret);
+	buffer_copy_s32(source, sink, frames * dev->params.channels);
 
-		/* Update and check both source and destination for wrap */
-		n -= n_copy;
-		src += n_copy;
-		snk += n_copy;
-		src_inc_wrap(&src, source->end_addr, source->size);
-		src_inc_wrap(&snk, sink->end_addr, sink->size);
-	}
 	*n_read = frames;
 	*n_written = frames;
 }
@@ -477,34 +453,10 @@ static void src_copy_s16(struct comp_dev *dev,
 			 int *n_read, int *n_written)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
-	int16_t *src = (int16_t *)source->r_ptr;
-	int16_t *snk = (int16_t *)sink->w_ptr;
 	int frames = cd->param.blk_in;
-	int n;
-	int n_wrap_src;
-	int n_wrap_snk;
-	int n_wrap_min;
-	int n_copy;
-	int ret;
 
-	n = frames * dev->params.channels;
-	while (n > 0) {
-		n_wrap_src = (int16_t *)source->end_addr - src;
-		n_wrap_snk = (int16_t *)sink->end_addr - snk;
-		n_wrap_min = (n_wrap_src < n_wrap_snk) ?
-			n_wrap_src : n_wrap_snk;
-		n_copy = (n < n_wrap_min) ? n : n_wrap_min;
-		ret = memcpy_s(snk, n_copy * sizeof(int16_t), src,
-			       n_copy * sizeof(int16_t));
-		assert(!ret);
+	buffer_copy_s16(source, sink, frames * dev->params.channels);
 
-		/* Update and check both source and destination for wrap */
-		n -= n_copy;
-		src += n_copy;
-		snk += n_copy;
-		src_inc_wrap_s16(&src, source->end_addr, source->size);
-		src_inc_wrap_s16(&snk, sink->end_addr, sink->size);
-	}
 	*n_read = frames;
 	*n_written = frames;
 }

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -838,11 +838,11 @@ static int src_prepare(struct comp_dev *dev)
 				struct comp_buffer, source_list);
 
 	/* get source data format and period bytes */
-	cd->source_format = comp_frame_fmt(sourceb->source);
+	cd->source_format = sourceb->source->params.frame_fmt;
 	source_period_bytes = comp_period_bytes(sourceb->source, dev->frames);
 
 	/* get sink data format and period bytes */
-	cd->sink_format = comp_frame_fmt(sinkb->sink);
+	cd->sink_format = sinkb->sink->params.frame_fmt;
 	sink_period_bytes = comp_period_bytes(sinkb->sink, dev->frames);
 
 	/* Rewrite params format for this component to match the host side. */

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -16,6 +16,7 @@
 #include <sof/trace/trace.h>
 #include <ipc/topology.h>
 #include <user/trace.h>
+#include <config.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -229,6 +230,8 @@ static inline void buffer_init(struct comp_buffer *buffer, uint32_t size,
 	buffer_zero(buffer);
 }
 
+#if CONFIG_FORMAT_S16LE
+
 static inline void buffer_copy_s16(struct comp_buffer *source,
 				   struct comp_buffer *sink, uint32_t samples)
 {
@@ -246,6 +249,10 @@ static inline void buffer_copy_s16(struct comp_buffer *source,
 	}
 }
 
+#endif /* CONFIG_FORMAT_S16LE */
+
+#if CONFIG_FORMAT_S24LE || CONFIG_FORMAT_S32LE
+
 static inline void buffer_copy_s32(struct comp_buffer *source,
 				   struct comp_buffer *sink, uint32_t samples)
 {
@@ -262,5 +269,7 @@ static inline void buffer_copy_s32(struct comp_buffer *source,
 		buff_frag++;
 	}
 }
+
+#endif /* CONFIG_FORMAT_S24LE || CONFIG_FORMAT_S32LE */
 
 #endif /* __SOF_AUDIO_BUFFER_H__ */

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -230,15 +230,14 @@ static inline void buffer_init(struct comp_buffer *buffer, uint32_t size,
 }
 
 static inline void buffer_copy_s16(struct comp_buffer *source,
-				   struct comp_buffer *sink, uint32_t bytes)
+				   struct comp_buffer *sink, uint32_t samples)
 {
-	uint32_t frames = bytes / sizeof(int16_t);
 	uint32_t buff_frag = 0;
 	int16_t *src;
 	int16_t *dst;
 	uint32_t i;
 
-	for (i = 0; i < frames; i++) {
+	for (i = 0; i < samples; i++) {
 		src = buffer_read_frag_s16(source, buff_frag);
 		dst = buffer_write_frag_s16(sink, buff_frag);
 		*dst = *src;
@@ -248,15 +247,14 @@ static inline void buffer_copy_s16(struct comp_buffer *source,
 }
 
 static inline void buffer_copy_s32(struct comp_buffer *source,
-				   struct comp_buffer *sink, uint32_t bytes)
+				   struct comp_buffer *sink, uint32_t samples)
 {
-	uint32_t frames = bytes / sizeof(int32_t);
 	uint32_t buff_frag = 0;
 	int32_t *src;
 	int32_t *dst;
 	uint32_t i;
 
-	for (i = 0; i < frames; i++) {
+	for (i = 0; i < samples; i++) {
 		src = buffer_read_frag_s32(source, buff_frag);
 		dst = buffer_write_frag_s32(sink, buff_frag);
 		*dst = *src;

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -17,6 +17,7 @@
 #define __SOF_AUDIO_COMPONENT_H__
 
 #include <sof/audio/buffer.h>
+#include <sof/audio/format.h>
 #include <sof/audio/pipeline.h>
 #include <sof/debug/panic.h>
 #include <sof/list.h>
@@ -611,17 +612,7 @@ static inline struct comp_dev *comp_get_previous(struct comp_dev *dev, int dir)
  */
 static inline uint32_t comp_frame_bytes(struct comp_dev *dev)
 {
-	/* calculate period size based on params */
-	switch (dev->params.frame_fmt) {
-	case SOF_IPC_FRAME_S16_LE:
-		return 2 * dev->params.channels;
-	case SOF_IPC_FRAME_S24_4LE:
-	case SOF_IPC_FRAME_S32_LE:
-	case SOF_IPC_FRAME_FLOAT:
-		return 4 * dev->params.channels;
-	default:
-		return 0;
-	}
+	return frame_bytes(dev->params.frame_fmt, dev->params.channels);
 }
 
 /**
@@ -631,17 +622,7 @@ static inline uint32_t comp_frame_bytes(struct comp_dev *dev)
  */
 static inline uint32_t comp_sample_bytes(struct comp_dev *dev)
 {
-	/* calculate period size based on params */
-	switch (dev->params.frame_fmt) {
-	case SOF_IPC_FRAME_S16_LE:
-		return 2;
-	case SOF_IPC_FRAME_S24_4LE:
-	case SOF_IPC_FRAME_S32_LE:
-	case SOF_IPC_FRAME_FLOAT:
-		return 4;
-	default:
-		return 0;
-	}
+	return sample_bytes(dev->params.frame_fmt);
 }
 
 /**

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -646,32 +646,6 @@ static inline uint32_t comp_avail_frames(struct comp_buffer *source,
 }
 
 /**
- * Returns frame format based on component device's type.
- * @param dev Component device.
- * @return Frame format.
- */
-static inline enum sof_ipc_frame comp_frame_fmt(struct comp_dev *dev)
-{
-	struct sof_ipc_comp_config *sconfig;
-	enum sof_ipc_frame frame_fmt;
-
-	switch (dev->comp.type) {
-	case SOF_COMP_DAI:
-	case SOF_COMP_SG_DAI:
-		/* format comes from DAI/comp config */
-		sconfig = COMP_GET_CONFIG(dev);
-		frame_fmt = sconfig->frame_fmt;
-		break;
-	default:
-		/* format comes from IPC params */
-		frame_fmt = dev->params.frame_fmt;
-		break;
-	}
-
-	return frame_fmt;
-}
-
-/**
  * Returns component state based on requested command.
  * @param cmd Request command.
  * @return Component state.

--- a/src/include/sof/audio/format.h
+++ b/src/include/sof/audio/format.h
@@ -10,6 +10,7 @@
 #ifndef __SOF_AUDIO_FORMAT_H__
 #define __SOF_AUDIO_FORMAT_H__
 
+#include <ipc/stream.h>
 #include <stdint.h>
 
 /* Maximum and minimum values for 24 bit */
@@ -158,6 +159,16 @@ static inline int16_t q_multsr_sat_16x16(int16_t x, int32_t y,
 static inline int32_t sign_extend_s24(int32_t x)
 {
 	return (x << 8) >> 8;
+}
+
+static inline uint32_t sample_bytes(enum sof_ipc_frame fmt)
+{
+	return fmt == SOF_IPC_FRAME_S16_LE ? 2 : 4;
+}
+
+static inline uint32_t frame_bytes(enum sof_ipc_frame fmt, uint32_t channels)
+{
+	return sample_bytes(fmt) * channels;
 }
 
 #endif /* __SOF_AUDIO_FORMAT_H__ */

--- a/src/include/sof/audio/pcm_converter.h
+++ b/src/include/sof/audio/pcm_converter.h
@@ -1,0 +1,63 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2019 Intel Corporation. All rights reserved.
+ *
+ * Author: Tomasz Lauda <tomasz.lauda@linux.intel.com>
+ */
+
+/**
+ * \file audio/pcm_converter.h
+ * \brief PCM converter header file
+ * \authors Tomasz Lauda <tomasz.lauda@linux.intel.com>
+ */
+
+#ifndef __SOF_AUDIO_PCM_CONVERTER_H__
+#define __SOF_AUDIO_PCM_CONVERTER_H__
+
+#include <ipc/stream.h>
+#include <stddef.h>
+#include <stdint.h>
+
+struct comp_buffer;
+
+/** \brief PCM conversion functions map. */
+struct pcm_func_map {
+	enum sof_ipc_frame source;	/**< source frame format */
+	enum sof_ipc_frame sink;	/**< sink frame format */
+	/**< PCM conversion function */
+	void (*func)(struct comp_buffer *source, struct comp_buffer *sink,
+		     uint32_t samples);
+};
+
+/** \brief Map of formats with dedicated conversion functions. */
+extern const struct pcm_func_map pcm_func_map[];
+
+/** \brief Number of conversion functions. */
+extern const uint32_t pcm_func_count;
+
+typedef void (*conversion)(struct comp_buffer *, struct comp_buffer *,
+			   uint32_t);
+
+/**
+ * \brief Retrieves PCM conversion function.
+ * \param[in] in Source frame format.
+ * \param[in] out Sink frame format.
+ */
+static inline conversion pcm_get_conversion_function(enum sof_ipc_frame in,
+						     enum sof_ipc_frame out)
+{
+	uint32_t i;
+
+	for (i = 0; i < pcm_func_count; i++) {
+		if (in != pcm_func_map[i].source)
+			continue;
+		if (out != pcm_func_map[i].sink)
+			continue;
+
+		return pcm_func_map[i].func;
+	}
+
+	return NULL;
+}
+
+#endif /* __SOF_AUDIO_PCM_CONVERTER_H__ */

--- a/src/include/sof/audio/pcm_converter.h
+++ b/src/include/sof/audio/pcm_converter.h
@@ -20,6 +20,21 @@
 
 struct comp_buffer;
 
+#define PCM_CONVERTER_GENERIC
+
+#if __XCC__
+
+#include <xtensa/config/core-isa.h>
+
+#if XCHAL_HAVE_HIFI3
+
+#undef PCM_CONVERTER_GENERIC
+#define PCM_CONVERTER_HIFI3
+
+#endif
+
+#endif
+
 /** \brief PCM conversion functions map. */
 struct pcm_func_map {
 	enum sof_ipc_frame source;	/**< source frame format */

--- a/src/include/sof/audio/volume.h
+++ b/src/include/sof/audio/volume.h
@@ -110,8 +110,6 @@ struct comp_data {
 	int32_t vol_min;			/**< minimum volume */
 	int32_t vol_max;			/**< maximum volume */
 	int32_t	vol_ramp_range;			/**< max ramp transition */
-	enum sof_ipc_frame source_format;	/**< source frame format */
-	enum sof_ipc_frame sink_format;		/**< sink frame format */
 	/**< volume processing function */
 	void (*scale_vol)(struct comp_dev *dev, struct comp_buffer *sink,
 			  struct comp_buffer *source, uint32_t frames);
@@ -119,8 +117,7 @@ struct comp_data {
 
 /** \brief Volume processing functions map. */
 struct comp_func_map {
-	uint16_t source;			/**< source frame format */
-	uint16_t sink;				/**< sink frame format */
+	uint16_t frame_fmt;	/**< frame format */
 	/**< volume processing function */
 	void (*func)(struct comp_dev *dev, struct comp_buffer *sink,
 		     struct comp_buffer *source, uint32_t frames);
@@ -141,14 +138,11 @@ typedef void (*scale_vol)(struct comp_dev *, struct comp_buffer *,
  */
 static inline scale_vol vol_get_processing_function(struct comp_dev *dev)
 {
-	struct comp_data *cd = comp_get_drvdata(dev);
 	int i;
 
 	/* map the volume function for source and sink buffers */
 	for (i = 0; i < func_count; i++) {
-		if (cd->source_format != func_map[i].source)
-			continue;
-		if (cd->sink_format != func_map[i].sink)
+		if (dev->params.frame_fmt != func_map[i].frame_fmt)
 			continue;
 
 		return func_map[i].func;

--- a/src/include/sof/common.h
+++ b/src/include/sof/common.h
@@ -19,8 +19,9 @@
 	(type *)((char *)__memberptr - offsetof(type, member)); })
 
 /* Align the number to the nearest alignment value */
+#define IS_ALIGNED(size, alignment) ((size) % (alignment) == 0)
 #define ALIGN_UP(size, alignment) \
-	(((size) % (alignment) == 0) ? (size) : \
+	(IS_ALIGNED(size, alignment) ? (size) : \
 	((size) - ((size) % (alignment)) + (alignment)))
 #define ALIGN_DOWN(size, alignment) \
 	((size) - ((size) % (alignment)))

--- a/src/include/sof/lib/dma.h
+++ b/src/include/sof/lib/dma.h
@@ -509,14 +509,18 @@ static inline uint32_t dma_sg_get_size(struct dma_sg_elem_array *ea)
 }
 
 /* copies data from DMA buffer using provided processing function */
-void dma_buffer_copy_from(struct comp_buffer *source, struct comp_buffer *sink,
-	void (*process)(struct comp_buffer *, struct comp_buffer *, uint32_t),
-	uint32_t bytes);
+void dma_buffer_copy_from(struct comp_buffer *source, uint32_t source_bytes,
+			  struct comp_buffer *sink, uint32_t sink_bytes,
+			  void (*process)(struct comp_buffer *,
+					  struct comp_buffer *, uint32_t),
+			  uint32_t samples);
 
 /* copies data to DMA buffer using provided processing function */
-void dma_buffer_copy_to(struct comp_buffer *source, struct comp_buffer *sink,
-	void (*process)(struct comp_buffer *, struct comp_buffer *, uint32_t),
-	uint32_t bytes);
+void dma_buffer_copy_to(struct comp_buffer *source, uint32_t source_bytes,
+			struct comp_buffer *sink, uint32_t sink_bytes,
+			void (*process)(struct comp_buffer *,
+					struct comp_buffer *, uint32_t),
+			uint32_t samples);
 
 /* generic DMA DSP <-> Host copier */
 

--- a/tools/topology/sof/pipe-kfbm-capture.m4
+++ b/tools/topology/sof/pipe-kfbm-capture.m4
@@ -44,25 +44,6 @@ C_CONTROLBYTES(KPB, PIPELINE_ID,
 	,
 	KPB_priv)
 
-# Volume Mixer control with max value of 80
-C_CONTROLMIXER(KWD Capture Volume, PIPELINE_ID,
-	CONTROLMIXER_OPS(volsw, 256 binds the mixer control to volume get/put handlers, 256, 256),
-	CONTROLMIXER_MAX(, 80),
-	false,
-	CONTROLMIXER_TLV(TLV 80 steps from -50dB to +30dB for 1dB, vtlv_m50s1),
-	Channel register and shift for Front Left/Right,
-	LIST(`	', KCONTROL_CHANNEL(FL, 1, 0), KCONTROL_CHANNEL(FR, 1, 1)))
-
-#
-# Volume configuration
-#
-
-W_VENDORTUPLES(capture_pga_tokens, sof_volume_tokens,
-LIST(`		', `SOF_TKN_VOLUME_RAMP_STEP_TYPE	"0"'
-     `		', `SOF_TKN_VOLUME_RAMP_STEP_MS		"250"'))
-
-W_DATA(capture_pga_conf, capture_pga_tokens)
-
 #
 # Components and Buffers
 #
@@ -70,9 +51,6 @@ W_DATA(capture_pga_conf, capture_pga_tokens)
 # Host "Passthrough Capture" PCM
 # with 0 sink and 2 source periods
 W_PCM_CAPTURE(PCM_ID, Sound Trigger Capture, 0, 2, 2)
-
-# "Volume" has x source and 2 sink periods
-W_PGA(0, PIPELINE_FORMAT, 2, DAI_PERIODS, capture_pga_conf, LIST(`		', "PIPELINE_ID KWD Capture Volume"))
 
 # "KPBM" has 2 source and 2 sink periods
 W_KPBM(0, PIPELINE_FORMAT, 2, 2, PIPELINE_ID, LIST(`             ', "KPB"))
@@ -85,25 +63,19 @@ W_BUFFER(0, COMP_BUFFER_SIZE(DAI_PERIODS,
 W_BUFFER(1, COMP_BUFFER_SIZE(2,
 	COMP_SAMPLE_SIZE(PIPELINE_FORMAT), PIPELINE_CHANNELS, COMP_PERIOD_FRAMES(PCM_MAX_RATE, SCHEDULE_PERIOD)),
 	PLATFORM_HOST_MEM_CAP)
-# Capture Buffers
-W_BUFFER(2, COMP_BUFFER_SIZE(2,
-	COMP_SAMPLE_SIZE(PIPELINE_FORMAT), PIPELINE_CHANNELS, COMP_PERIOD_FRAMES(PCM_MAX_RATE, SCHEDULE_PERIOD)),
-	PLATFORM_HOST_MEM_CAP)
 
 #
 # Pipeline Graph
 #
-#  host PCM_C <-- B2 <--+- KPBM 0 <-- B1 <-- volume 0 <-- B0 <-- source DAI0
+#  host PCM_C <-- B1 <--+- KPBM 0 <-- B0 <-- source DAI0
 #                	|
 #            Others  <--
 
 P_GRAPH(pipe-kpbm-capture-PIPELINE_ID, PIPELINE_ID,
 	LIST(`		',
-	`dapm(N_PCMC(PCM_ID), N_BUFFER(2))',
-	`dapm(N_BUFFER(2), N_KPBM(0, PIPELINE_ID))',
-	`dapm(N_KPBM(0, PIPELINE_ID), N_BUFFER(1))',
-	`dapm(N_BUFFER(1), N_PGA(0, PIPELINE_ID))',
-	`dapm(N_PGA(0, PIPELINE_ID), N_BUFFER(0))'))
+	`dapm(N_PCMC(PCM_ID), N_BUFFER(1))',
+	`dapm(N_BUFFER(1), N_KPBM(0, PIPELINE_ID))',
+	`dapm(N_KPBM(0, PIPELINE_ID), N_BUFFER(0))'))
 
 #
 # Pipeline Source and Sinks


### PR DESCRIPTION
Implements generic and HiFi3 versions of PCM converter library component.
This module provides static functions, which allows to copy
buffer data with frame format conversion.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>