### PR TITLE
host: dai: handle dma buffer in cache functions

### DIFF
--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -870,6 +870,8 @@ static void dai_cache(struct comp_dev *dev, int cmd)
 
 		dma_sg_cache_wb_inv(&dd->config.elem_array);
 
+		dcache_writeback_invalidate_region(dd->dma_buffer,
+						   sizeof(*dd->dma_buffer));
 		dcache_writeback_invalidate_region(dd->dai, sizeof(*dd->dai));
 		dcache_writeback_invalidate_region(dd->dma, sizeof(*dd->dma));
 		dcache_writeback_invalidate_region(dd, sizeof(*dd));
@@ -885,6 +887,8 @@ static void dai_cache(struct comp_dev *dev, int cmd)
 		dcache_invalidate_region(dd, sizeof(*dd));
 		dcache_invalidate_region(dd->dma, sizeof(*dd->dma));
 		dcache_invalidate_region(dd->dai, sizeof(*dd->dai));
+		dcache_invalidate_region(dd->dma_buffer,
+					 sizeof(*dd->dma_buffer));
 
 		dma_sg_cache_inv(&dd->config.elem_array);
 		break;

--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -800,6 +800,8 @@ static void host_cache(struct comp_dev *dev, int cmd)
 		dma_sg_cache_wb_inv(&hd->config.elem_array);
 		dma_sg_cache_wb_inv(&hd->local.elem_array);
 
+		dcache_writeback_invalidate_region(hd->dma_buffer,
+						   sizeof(*hd->dma_buffer));
 		dcache_writeback_invalidate_region(hd->dma, sizeof(*hd->dma));
 		dcache_writeback_invalidate_region(hd, sizeof(*hd));
 		dcache_writeback_invalidate_region(dev, sizeof(*dev));
@@ -814,6 +816,8 @@ static void host_cache(struct comp_dev *dev, int cmd)
 
 		dcache_invalidate_region(hd, sizeof(*hd));
 		dcache_invalidate_region(hd->dma, sizeof(*hd->dma));
+		dcache_invalidate_region(hd->dma_buffer,
+					 sizeof(*hd->dma_buffer));
 
 		dma_sg_cache_inv(&hd->local.elem_array);
 		dma_sg_cache_inv(&hd->config.elem_array);


### PR DESCRIPTION
Adds missing writebacks and invalidations of DMA buffer in
host and dai components.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>