### PR TITLE
kmod_scripts: add support for snd_soc_rt1011

### DIFF
--- a/tools/kmod_scripts/sof_insert.sh
+++ b/tools/kmod_scripts/sof_insert.sh
@@ -36,6 +36,7 @@ insert_module snd_soc_rt700
 insert_module snd_soc_rt711
 insert_module snd_soc_rt1308_sdw
 insert_module snd_soc_rt715
+insert_module snd_soc_rt1011
 
 insert_module sof_acpi_dev
 insert_module sof_pci_dev

--- a/tools/kmod_scripts/sof_remove.sh
+++ b/tools/kmod_scripts/sof_remove.sh
@@ -62,6 +62,7 @@ remove_module snd_soc_rt700
 remove_module snd_soc_rt711
 remove_module snd_soc_rt1308_sdw
 remove_module snd_soc_rt715
+remove_module snd_soc_rt1011
 remove_module snd_soc_rt5640
 remove_module snd_soc_rt5645
 remove_module snd_soc_rt5651


### PR DESCRIPTION
Adds support for inserting and removing snd_soc_rt1011 codec
in kmod_scripts.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>

Fixes #2027.