### PR TITLE
components: add schedule_task_free() in comp_free() functions

### DIFF
--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -230,6 +230,9 @@ static void volume_free(struct comp_dev *dev)
 
 	trace_volume("volume_free()");
 
+	/* remove scheduling */
+	schedule_task_free(&cd->volwork);
+
 	rfree(cd);
 	rfree(dev);
 }


### PR DESCRIPTION
PR adds schedule_task_free() in comp_free() functions in order to
avoid memory leaks and if needed moves schedule_task_init()
from comp_prepare() to comp_new()(comp_prepare() could be
invoked several times for one component instance).