### PR TITLE
kpb: rework of validation of host params

### DIFF
--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -60,6 +60,7 @@ struct comp_data {
 	size_t hb_buffer_size;
 	size_t host_buffer_size;
 	size_t host_period_size;
+	bool sync_draining_mode;
 };
 
 /*! KPB private functions */
@@ -81,9 +82,9 @@ static void kpb_drain_samples(void *source, struct comp_buffer *sink,
 static void kpb_buffer_samples(struct comp_buffer *source, uint32_t start,
 			       void *sink, size_t size, size_t sample_width);
 static void kpb_reset_history_buffer(struct hb *buff);
-static inline bool validate_host_params(size_t host_period_size,
-					size_t host_buffer_size,
-					size_t bytes_per_ms);
+static inline bool validate_host_params(struct comp_dev *dev,
+					size_t host_period_size,
+					size_t host_buffer_size);
 static inline void kpb_change_state(struct comp_data *kpb,
 				    enum kpb_state state);
 
@@ -457,6 +458,9 @@ static int kpb_prepare(struct comp_dev *dev)
 				   (uint32_t)kpb->host_sink);
 		ret = -EIO;
 	}
+
+	/* Disallow sync_draining_mode for now */
+	kpb->sync_draining_mode = false;
 
 	kpb_change_state(kpb, KPB_STATE_RUN);
 
@@ -929,11 +933,10 @@ static void kpb_init_draining(struct comp_dev *dev, struct kpb_client *cli)
 	} else if (kpb->buffered_data < history_depth ||
 		   kpb->hb_buffer_size < history_depth) {
 		trace_kpb_error("kpb_init_draining() error: not enough data in history buffer");
-	} else if (!validate_host_params(host_period_size,
-					 host_buffer_size,
-					 bytes_per_ms)) {
-		trace_kpb_error_with_ids(dev, "kpb_init_draining() error: "
-					 "wrong host params.");
+	} else if (!validate_host_params(dev,
+					 host_period_size,
+					 host_buffer_size)) {
+		trace_kpb_error("kpb_init_draining() error: wrong host params.");
 	} else {
 		/* Draining accepted, find proper buffer to start reading
 		 * At this point we are guaranteed that there is enough data
@@ -1387,26 +1390,53 @@ static void kpb_reset_history_buffer(struct hb *buff)
 	} while (buff != first_buff);
 }
 
-static inline bool validate_host_params(size_t host_period_size,
-					size_t host_buffer_size,
-					size_t bytes_per_ms)
+static inline bool validate_host_params(struct comp_dev *dev,
+					size_t host_period_size,
+					size_t host_buffer_size)
 {
-	/* Check host period size sanity.
-	 * Here we check if host period size (which defines interval
-	 * time) will allow us to drain more data then the interval
-	 * takes - as only such condition guarantees draining will end.
-	 * The formula:
-	 *	drained_data_in_one_interval_ms > interval_break_ms
-	 * where:
-	 * drained_data_in_one_interval_ms = (host_period_size * 2) [ms]
-	 * interval_break_ms = host_period_size / bytes_per_ms [ms]
+	/* The aim of this function is to perform basic check of host params
+	 * and reject them if they won't allow for stable draining.
+	 * Note however that this is highly recommended for host buffer to
+	 * be of history buffer size. This will quarantee "safe" draining.
+	 * By safe we mean no XRUNs(host was unable to read data on time),
+	 * or loss of data due to host delayed read. The later condition
+	 * is very likely after wake up from power state like d0ix.
 	 */
+	struct comp_data *kpb = comp_get_drvdata(dev);
+	size_t sample_width = kpb->config.sampling_width;
+	size_t bytes_per_ms = KPB_SAMPLES_PER_MS *
+			      (KPB_SAMPLE_CONTAINER_SIZE(sample_width) / 8) *
+			      kpb->config.channels;
+	size_t pipeline_period_size = (dev->pipeline->ipc_pipe.period / 1000)
+					* bytes_per_ms;
 
-	if (host_period_size < bytes_per_ms || /* Out of control */
-	    host_period_size >= (host_buffer_size / 2)) /* XRUN */
+	if (!host_period_size || !host_buffer_size) {
+		/* Wrong host params */
 		return false;
+	} else if (!kpb->sync_draining_mode) {
+		/* Sync draining is not allowed, so host buffer shall be
+		 * big enough to store whole history buffer.
+		 */
+		return host_buffer_size >= kpb->hb_buffer_size;
+	}
 
-	return true;
+	/* Sync draining allowed. Check if we can perform draining
+	 * with current settings.
+	 * In this mode we copy host period size to host
+	 * (to avoid overwrite of buffered data by real time stream
+	 * this period shall be bigger than pipeline period) and
+	 * give host the same time to read it. Therefore, in worst
+	 * case scenario, we copy one period of real time data + some
+	 * of buffered data.
+	 */
+	if (host_buffer_size > kpb->hb_buffer_size)
+		return true;
+
+	/* Host period must be smaller (faster) than
+	 * pipeline period otherwise draining will never end.
+	 */
+	return host_period_size < pipeline_period_size;
+
 }
 
 /**

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -137,7 +137,7 @@ static struct comp_dev *kpb_new(struct sof_ipc_comp *comp)
 		return NULL;
 	}
 
-	if (kpb->config.no_channels > KPB_MAX_SUPPORTED_CHANNELS) {
+	if (kpb->config.channels > KPB_MAX_SUPPORTED_CHANNELS) {
 		trace_kpb_error_with_ids(dev, "kpb_new() error: "
 		"no of channels exceeded the limit");
 		return NULL;
@@ -896,7 +896,7 @@ static void kpb_init_draining(struct comp_dev *dev, struct kpb_client *cli)
 	struct comp_data *kpb = comp_get_drvdata(dev);
 	bool is_sink_ready = (kpb->host_sink->sink->state == COMP_STATE_ACTIVE);
 	size_t sample_width = kpb->config.sampling_width;
-	size_t history_depth = cli->history_depth * kpb->config.no_channels *
+	size_t history_depth = cli->history_depth * kpb->config.channels *
 			       (kpb->config.sampling_freq / 1000) *
 			       (KPB_SAMPLE_CONTAINER_SIZE(sample_width) / 8);
 	struct hb *buff = kpb->history_buffer;
@@ -908,9 +908,9 @@ static void kpb_init_draining(struct comp_dev *dev, struct kpb_client *cli)
 	size_t host_period_size = kpb->host_period_size;
 	size_t host_buffer_size = kpb->host_buffer_size;
 	size_t ticks_per_ms = clock_ms_to_ticks(PLATFORM_DEFAULT_CLOCK, 1);
-	size_t bytes_per_ms = KPB_SAMPLING_WIDTH *
+	size_t bytes_per_ms = KPB_SAMPLES_PER_MS *
 			      (KPB_SAMPLE_CONTAINER_SIZE(sample_width) / 8) *
-			      kpb->config.no_channels;
+			      kpb->config.channels;
 	size_t period_bytes_limit = 0;
 
 	trace_kpb_with_ids(dev, "kpb_init_draining(): requested draining "
@@ -1189,7 +1189,7 @@ static void kpb_drain_samples(void *source, struct comp_buffer *sink,
 	size_t frames = KPB_BYTES_TO_FRAMES(size, sample_width);
 
 	for (i = 0; i < frames; i++) {
-		for (channel = 0; channel < KPB_NR_OF_CHANNELS; channel++) {
+		for (channel = 0; channel < KPB_NUM_OF_CHANNELS; channel++) {
 			switch (sample_width) {
 #if CONFIG_FORMAT_S16LE
 			case 16:
@@ -1236,7 +1236,7 @@ static void kpb_buffer_samples(struct comp_buffer *source, uint32_t start,
 	size_t frames = KPB_BYTES_TO_FRAMES(size, sample_width);
 
 	for (i = 0; i < frames; i++) {
-		for (channel = 0; channel < KPB_NR_OF_CHANNELS; channel++) {
+		for (channel = 0; channel < KPB_NUM_OF_CHANNELS; channel++) {
 			switch (sample_width) {
 			case 16:
 				src = buffer_read_frag_s16(source, j);
@@ -1333,7 +1333,7 @@ static void kpb_copy_samples(struct comp_buffer *sink,
 	size_t frames = KPB_BYTES_TO_FRAMES(size, sample_width);
 
 	for (i = 0; i < frames; i++) {
-		for (channel = 0; channel < KPB_NR_OF_CHANNELS; channel++) {
+		for (channel = 0; channel < KPB_NUM_OF_CHANNELS; channel++) {
 			switch (sample_width) {
 #if CONFIG_FORMAT_S16LE
 			case 16:

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -57,7 +57,7 @@ struct comp_data {
 	bool is_internal_buffer_full;
 	size_t buffered_data;
 	struct dd draining_task_data;
-	size_t kpb_buffer_size;
+	size_t hb_buffer_size;
 	size_t host_buffer_size;
 	size_t host_period_size;
 };
@@ -182,7 +182,7 @@ static size_t kpb_allocate_history_buffer(struct comp_data *kpb)
 	struct hb *history_buffer;
 	struct hb *new_hb = NULL;
 	/*! Total allocation size */
-	size_t hb_size = kpb->kpb_buffer_size;
+	size_t hb_size = kpb->hb_buffer_size;
 	/*! Current allocation size */
 	size_t ca_size = hb_size;
 	/*! Memory caps priorites for history buffer */
@@ -397,7 +397,7 @@ static int kpb_prepare(struct comp_dev *dev)
 	kpb_change_state(kpb, KPB_STATE_PREPARING);
 	kpb->kpb_no_of_clients = 0;
 	kpb->buffered_data = 0;
-	kpb->kpb_buffer_size = KPB_MAX_BUFFER_SIZE(kpb->config.sampling_width);
+	kpb->hb_buffer_size = KPB_MAX_BUFFER_SIZE(kpb->config.sampling_width);
 	kpb->sel_sink = NULL;
 	kpb->host_sink = NULL;
 
@@ -406,9 +406,8 @@ static int kpb_prepare(struct comp_dev *dev)
 		allocated_size = kpb_allocate_history_buffer(kpb);
 
 		/* Have we allocated what we requested? */
-		if (allocated_size < kpb->kpb_buffer_size) {
-			trace_kpb_error_with_ids(dev, "Failed to allocate "
-						 "space for KPB buffer/s");
+		if (allocated_size < kpb->hb_buffer_size) {
+			trace_kpb_error("kpb_prepare() error: failed to allocate space for KPB buffer/s");
 			kpb_free_history_buffer(kpb->history_buffer);
 			kpb->history_buffer = NULL;
 			return -EINVAL;
@@ -597,7 +596,7 @@ static int kpb_copy(struct comp_dev *dev)
 		/* Buffer source data internally in history buffer for future
 		 * use by clients.
 		 */
-		if (source->avail <= kpb->kpb_buffer_size) {
+		if (source->avail <= kpb->hb_buffer_size) {
 			ret = kpb_buffer_data(dev, source, copy_bytes);
 			if (ret) {
 				trace_kpb_error_with_ids(dev, "kpb_copy(): "
@@ -605,7 +604,7 @@ static int kpb_copy(struct comp_dev *dev)
 							 "failed.");
 				goto out;
 			}
-			if (kpb->buffered_data < kpb->kpb_buffer_size)
+			if (kpb->buffered_data < kpb->hb_buffer_size)
 				kpb->buffered_data += copy_bytes;
 			else
 				kpb->is_internal_buffer_full = true;
@@ -652,7 +651,7 @@ static int kpb_copy(struct comp_dev *dev)
 		/* In draining state we only buffer data in internal,
 		 * history buffer.
 		 */
-		if (source->avail <= kpb->kpb_buffer_size) {
+		if (source->avail <= kpb->hb_buffer_size) {
 			ret = kpb_buffer_data(dev, source, source->avail);
 			if (ret) {
 				trace_kpb_error_with_ids(dev, "kpb_copy(): "
@@ -928,9 +927,8 @@ static void kpb_init_draining(struct comp_dev *dev, struct kpb_client *cli)
 		trace_kpb_error_with_ids(dev, "kpb_init_draining() error: "
 					 "sink not ready for draining");
 	} else if (kpb->buffered_data < history_depth ||
-		   kpb->kpb_buffer_size < history_depth) {
-		trace_kpb_error_with_ids(dev, "kpb_init_draining() error: "
-					 "not enough data in history buffer");
+		   kpb->hb_buffer_size < history_depth) {
+		trace_kpb_error("kpb_init_draining() error: not enough data in history buffer");
 	} else if (!validate_host_params(host_period_size,
 					 host_buffer_size,
 					 bytes_per_ms)) {
@@ -999,6 +997,7 @@ static void kpb_init_draining(struct comp_dev *dev, struct kpb_client *cli)
 		 * take place. This time will be used to synchronize us with
 		 * an end application interrupts.
 		 */
+
 		drain_interval = (host_period_size / bytes_per_ms) *
 				 ticks_per_ms;
 		/* In draining intervals we will fill only two periods

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -402,6 +402,11 @@ static int kpb_prepare(struct comp_dev *dev)
 	kpb->sel_sink = NULL;
 	kpb->host_sink = NULL;
 
+	if (!validate_host_params(dev, kpb->host_period_size,
+				  kpb->host_buffer_size)) {
+		trace_kpb_error("kpb_prepare() error: wrong host params.");
+		return -EINVAL;
+	}
 	if (!kpb->history_buffer) {
 		/* Allocate history buffer */
 		allocated_size = kpb_allocate_history_buffer(kpb);
@@ -933,10 +938,6 @@ static void kpb_init_draining(struct comp_dev *dev, struct kpb_client *cli)
 	} else if (kpb->buffered_data < history_depth ||
 		   kpb->hb_buffer_size < history_depth) {
 		trace_kpb_error("kpb_init_draining() error: not enough data in history buffer");
-	} else if (!validate_host_params(dev,
-					 host_period_size,
-					 host_buffer_size)) {
-		trace_kpb_error("kpb_init_draining() error: wrong host params.");
 	} else {
 		/* Draining accepted, find proper buffer to start reading
 		 * At this point we are guaranteed that there is enough data

--- a/src/include/sof/audio/kpb.h
+++ b/src/include/sof/audio/kpb.h
@@ -121,6 +121,7 @@ struct dd {
 	size_t drain_interval;
 	size_t pb_limit; /**< Period bytes limit */
 	struct comp_dev *dev;
+	bool sync_mode_on;
 };
 
 #ifdef UNIT_TEST

--- a/src/include/sof/audio/kpb.h
+++ b/src/include/sof/audio/kpb.h
@@ -33,21 +33,22 @@ struct comp_buffer;
 
 /* KPB internal defines */
 #define KPB_MAX_BUFF_TIME 2100 /**< time of buffering in miliseconds */
-#define KPB_MAX_SUPPORTED_CHANNELS 2
-#define	KPB_SAMPLING_WIDTH 16 /**< number of bits */
-#define	KPB_SAMPLNG_FREQUENCY 16000 /* max sampling frequency in Hz */
-#define KPB_NR_OF_CHANNELS 2
+#define KPB_MAX_SUPPORTED_CHANNELS 2 /**< number of supported channels */
+/**< number of samples taken each milisecond */
+#define	KPB_SAMPLES_PER_MS (KPB_SAMPLNG_FREQUENCY / 1000)
+#define	KPB_SAMPLNG_FREQUENCY 16000 /**< supported sampling frequency in Hz */
+#define KPB_NUM_OF_CHANNELS 2
 #define KPB_SAMPLE_CONTAINER_SIZE(sw) ((sw == 16) ? 16 : 32)
 #define KPB_MAX_BUFFER_SIZE(sw) ((KPB_SAMPLNG_FREQUENCY / 1000) * \
 	(KPB_SAMPLE_CONTAINER_SIZE(sw) / 8) * KPB_MAX_BUFF_TIME * \
-	KPB_NR_OF_CHANNELS)
+	KPB_NUM_OF_CHANNELS)
 #define KPB_MAX_NO_OF_CLIENTS 2
 #define KPB_NO_OF_HISTORY_BUFFERS 2 /**< no of internal buffers */
 #define KPB_ALLOCATION_STEP 0x100
 #define KPB_NO_OF_MEM_POOLS 3
 #define KPB_BYTES_TO_FRAMES(bytes, sample_width) \
 	(bytes / ((KPB_SAMPLE_CONTAINER_SIZE(sample_width) / 8) * \
-	KPB_NR_OF_CHANNELS))
+	KPB_NUM_OF_CHANNELS))
 
 enum kpb_state {
 	KPB_STATE_DISABLED = 0,

--- a/src/include/user/kpb.h
+++ b/src/include/user/kpb.h
@@ -14,7 +14,7 @@
 struct sof_kpb_config {
 	uint32_t size; /**< kpb size in bytes */
 	uint32_t caps; /**< SOF_MEM_CAPS_ */
-	uint32_t no_channels; /**< no of channels */
+	uint32_t channels; /**< number of channels */
 	uint32_t history_depth; /**< time of buffering in milliseconds */
 	uint32_t sampling_freq; /**< frequency in hertz */
 	uint32_t sampling_width; /**< number of bits */

--- a/test/cmocka/src/audio/kpb/kpb_buffer.c
+++ b/test/cmocka/src/audio/kpb/kpb_buffer.c
@@ -114,7 +114,7 @@ static int buffering_test_setup(void **state)
 	.size = sizeof(struct sof_kpb_config),
 	.no_channels = 2,
 	.sampling_freq = KPB_SAMPLNG_FREQUENCY,
-	.sampling_width = KPB_SAMPLING_WIDTH,
+	.sampling_width = KPB_SAMPLE_CONTAINER_SIZE(16),
 	};
 
 	/* Register KPB component to use its internal functions */


### PR DESCRIPTION
This patch reworks the validation of host params so KPB can make use
of host buffer bigger than internal history buffer.

Signed-off-by: Marcin Rajwa <marcin.rajwa@linux.intel.com>