### PR TITLE
kmod_scripts: add support for common hdmi

### DIFF
--- a/tools/kmod_scripts/sof_remove.sh
+++ b/tools/kmod_scripts/sof_remove.sh
@@ -82,6 +82,7 @@ remove_module snd_soc_max98357a
 
 remove_module snd_soc_hdac_hda
 remove_module snd_soc_hdac_hdmi
+remove_module snd_hda_codec_hdmi
 remove_module snd_soc_dmic
 
 remove_module snd_hda_codec_realtek


### PR DESCRIPTION
The HDMI codec may also use snd_hda_codec_hdmi

Signed-off-by: Pan Xiuli <xiuli.pan@linux.intel.com>