### PR TITLE
platform: imx: Fix NUM_CLOCKS being too small

### DIFF
--- a/src/platform/imx8/include/platform/lib/clk.h
+++ b/src/platform/imx8/include/platform/lib/clk.h
@@ -21,7 +21,7 @@
 #define CLK_DEFAULT_CPU_HZ	666000000
 #define CLK_MAX_CPU_HZ		666000000
 
-#define NUM_CLOCKS	1
+#define NUM_CLOCKS	2
 
 #define NUM_CPU_FREQ	1
 #define NUM_SSP_FREQ	2


### PR DESCRIPTION
Since SOF requires CLK_SSP to be defined and the SSP clock should be
separate from the actual CPU clock increasing the array size to 2 should
fix it.

This is a hack because i.MX doesn't actually have a SSP clock but SOF
unconditionally uses CLK_SSP macro.

Fixes out-of-bounds access revealed by pull request #1950.

Signed-off-by: Paul Olaru <paul.olaru@nxp.com>