### PR TITLE
checkpatch: SOF-specific changes

### DIFF
--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -2825,6 +2825,19 @@ sub process {
 			}
 		}
 
+# Check for added, moved or deleted files
+		if (!$SOF &&
+		    (!$reported_maintainer_file && !$in_commit_log &&
+		     ($line =~ /^(?:new|deleted) file mode\s*\d+\s*$/ ||
+		      $line =~ /^rename (?:from|to) [\w\/\.\-]+\s*$/ ||
+		      ($line =~ /\{\s*([\w\/\.\-]*)\s*\=\>\s*([\w\/\.\-]*)\s*\}/ &&
+		       (defined($1) || defined($2)))))) {
+			$is_patch = 1;
+			$reported_maintainer_file = 1;
+			WARN("FILE_PATH_CHANGES",
+			     "added, moved or deleted file(s), does MAINTAINERS need updating?\n" . $herecurr);
+		}
+
 # Check for wrappage within a valid hunk of the file
 		if ($realcnt != 0 && $line !~ m{^(?:\+|-| |\\ No newline|$)}) {
 			ERROR("CORRUPTED_PATCH",

--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -5952,7 +5952,8 @@ sub process {
 		}
 
 # check for c99 types like uint8_t used outside of uapi/ and tools/
-		if ($realfile !~ m@\binclude/uapi/@ &&
+		if (!$SOF &&
+		    $realfile !~ m@\binclude/uapi/@ &&
 		    $realfile !~ m@\btools/@ &&
 		    $line =~ /\b($Declare)\s*$Ident\s*[=;,\[]/) {
 			my $type = $1;

--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -22,6 +22,7 @@ my $V = '0.32';
 
 use Getopt::Long qw(:config no_auto_abbrev);
 
+my $SOF = 1; # enables SOF-specific behaviour
 my $quiet = 0;
 my $tree = 1;
 my $chk_signoff = 1;
@@ -2618,9 +2619,10 @@ sub process {
 
 # Check if ABI is being updated.  If so, there's probably no need to
 # emit the "does ABI need updating?" message on file add/move/delete
-		if ($line =~ /#define SOF_ABI_MAJOR*/ ||
-		    $line =~ /#define SOF_ABI_MINOR*/ ||
-		    $line =~ /#define SOF_ABI_PATCH*/) {
+		if ($SOF &&
+		    ($line =~ /#define SOF_ABI_MAJOR*/ ||
+		     $line =~ /#define SOF_ABI_MINOR*/ ||
+		     $line =~ /#define SOF_ABI_PATCH*/)) {
 			$reported_abi_update = 1;
 		}
 
@@ -3291,7 +3293,8 @@ sub process {
 		}
 
 # UAPI ABI version
-		if ($realfile =~ m@^(src/include/ipc/|src/include/kernel/|src/include/user/)@ &&
+		if ($SOF &&
+		    $realfile =~ m@^(src/include/ipc/|src/include/kernel/|src/include/user/)@ &&
 		    $rawline =~ /^\+/ &&
 		    !$reported_abi_update) {
 			WARN("ABI update ??",
@@ -6009,7 +6012,7 @@ sub process {
 		}
 
 # check for memcpy uses that should be memcpy_s
-		if ($line =~ /memcpy\s*\(.*/) {
+		if ($SOF && ($line =~ /memcpy\s*\(.*/)) {
 			my $fmt = get_quoted_string($line, $rawline);
 			$fmt =~ s/%%//g;
 			if ($fmt !~ /%/) {


### PR DESCRIPTION
Add checkpatch setting to make it easier to keep smaller delta with additional checkpatch + disable ints check that is not applicable to SOF.