### PR TITLE
checkpatch: check ABI updates before warning on it

### DIFF
--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -2403,6 +2403,16 @@ sub process {
 			# simplify matching -- only bother with positive lines.
 			$line = sanitise_line($rawline);
 		}
+
+		# Check if ABI is being updated.  If so, there's probably no need to
+		# emit the "does ABI need updating?" message on file add/move/delete
+		if ($SOF &&
+		    ($line =~ /\+#define SOF_ABI_MAJOR*/ ||
+		     $line =~ /\+#define SOF_ABI_MINOR*/ ||
+		     $line =~ /\+#define SOF_ABI_PATCH*/)) {
+			$reported_abi_update = 1;
+		}
+
 		push(@lines, $line);
 
 		if ($realcnt > 1) {
@@ -2617,14 +2627,6 @@ sub process {
 			}
 		}
 
-# Check if ABI is being updated.  If so, there's probably no need to
-# emit the "does ABI need updating?" message on file add/move/delete
-		if ($SOF &&
-		    ($line =~ /#define SOF_ABI_MAJOR*/ ||
-		     $line =~ /#define SOF_ABI_MINOR*/ ||
-		     $line =~ /#define SOF_ABI_PATCH*/)) {
-			$reported_abi_update = 1;
-		}
 
 # Check if MAINTAINERS is being updated.  If so, there's probably no need to
 # emit the "does MAINTAINERS need updating?" message on file add/move/delete


### PR DESCRIPTION
checkpatch is currently checking for changes that need ABI updates
and actual ABI changes in the same loop in process(). So if some
file that needs an ABI change comes first, a WARNING will be issued.

Look for an actual ABI change before starting to crunch the entire
patch line by line.

Signed-off-by: Dragos Tarcatu <dragos_tarcatu@mentor.com>

Fixes: #2052 