### PR TITLE
 cmake: optimization levels

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -157,6 +157,40 @@ config INTERRUPT_LEVEL_5
 
 source "src/Kconfig"
 
+choice
+	prompt "Optimization"
+	default OPTIMIZE_FOR_PERFORMANCE
+	help
+	  Controls how compiler should optimize binary.
+	  This config should affect only compiler settings and is
+	  not meant to be used for conditional compilation of code.
+
+config OPTIMIZE_FOR_PERFORMANCE
+	bool "Optimize for performance"
+	help
+	  Apply compiler optimizations prioritizing performance.
+	  It means -O2 for GCC or equivalent for other compilers.
+
+config OPTIMIZE_FOR_SIZE
+	bool "Optimize for size"
+	help
+	  Apply compiler optimizations prioritizing binary size.
+	  It means -Os for GCC or equivalent for other compilers.
+
+config OPTIMIZE_FOR_DEBUG
+	bool "Optimize for debug"
+	help
+	  Apply compiler optimizations prioritizing debugging experience.
+	  It means -Og for GCC or equivalent for other compilers.
+
+config OPTIMIZE_FOR_NONE
+	bool "Don't optimize"
+	help
+	  Apply no compiler optimizations.
+	  It means -O0 for GCC or equivalent for other compilers.
+
+endchoice
+
 menu "Debug"
 
 config DEBUG

--- a/src/arch/xtensa/CMakeLists.txt
+++ b/src/arch/xtensa/CMakeLists.txt
@@ -61,6 +61,16 @@ else()
 	set(stdlib_flag "-nostdlib")
 endif()
 
+if(CONFIG_OPTIMIZE_FOR_PERFORMANCE)
+	set(optimization_flag "-O2")
+elseif(CONFIG_OPTIMIZE_FOR_SIZE)
+	set(optimization_flag "-Os")
+elseif(CONFIG_OPTIMIZE_FOR_DEBUG)
+	set(optimization_flag "-Og")
+elseif(CONFIG_OPTIMIZE_FOR_NONE)
+	set(optimization_flag "-O0")
+endif()
+
 # linker flags
 target_link_libraries(sof_options INTERFACE ${stdlib_flag} -Wl,--no-check-sections -ucall_user_start -Wl,-static)
 
@@ -77,7 +87,7 @@ target_compile_options(sof_options INTERFACE ${stdlib_flag} -fno-inline-function
 #      better to have set of default flags and change it only for special cases
 #   3) custom function that is used instead of target_sources and sets flags
 #      for each added source based on file extension
-target_compile_options(sof_options INTERFACE $<$<COMPILE_LANGUAGE:C>:-O2 -g -Wall -Werror -Wl,-EL -Wmissing-prototypes -Wpointer-arith -mtext-section-literals>)
+target_compile_options(sof_options INTERFACE $<$<COMPILE_LANGUAGE:C>: ${optimization_flag} -g -Wall -Werror -Wl,-EL -Wmissing-prototypes -Wpointer-arith -mtext-section-literals>)
 
 if(BUILD_UNIT_TESTS)
 	# rest of this file is not needed for unit tests


### PR DESCRIPTION
Introduces configs for optimization levels.
F.e. Baytrail needs -Os to fit  in IRAM when using XCC (probably tried to inline too much with -O2), as shown in #2024 