### PR TITLE
cavs: pm: cores power gating

### DIFF
--- a/src/arch/xtensa/lib/cpu.c
+++ b/src/arch/xtensa/lib/cpu.c
@@ -48,6 +48,8 @@ void arch_cpu_enable_core(int id)
 	irq_local_disable(flags);
 
 	if (!arch_cpu_is_core_enabled(id)) {
+		pm_runtime_get(PM_RUNTIME_DSP, id);
+
 		/* Turn on stack memory for core */
 		pm_runtime_get(CORE_MEMORY_POW, id);
 
@@ -132,6 +134,8 @@ void cpu_power_down_core(void)
 
 	/* Turn off stack memory for core */
 	pm_runtime_put(CORE_MEMORY_POW, cpu_get_id());
+
+	pm_runtime_put(PM_RUNTIME_DSP, cpu_get_id());
 
 	/* arch_wait_for_interrupt() not used, because it will cause panic.
 	 * This code is executed on irq lvl > 0, which is expected.

--- a/src/platform/cannonlake/include/platform/lib/shim.h
+++ b/src/platform/cannonlake/include/platform/lib/shim.h
@@ -149,9 +149,15 @@
 
 #define SHIM_PWRCTL		0x90
 #define SHIM_PWRCTL_TCPDSPPG(x)	BIT(x)
+#define SHIM_PWRCTL_TCPCTLPG	BIT(4)
 
 #define SHIM_PWRSTS		0x92
+
 #define SHIM_LPSCTL		0x94
+#define SHIM_LPSCTL_BID		BIT(7)
+#define SHIM_LPSCTL_FDSPRUN	BIT(9)
+#define SHIM_LPSCTL_BATTR_0	BIT(12)
+
 #define SHIM_LSPGCTL		0x50
 
 /** \brief GPDMA shim registers Control */

--- a/src/platform/icelake/include/platform/lib/shim.h
+++ b/src/platform/icelake/include/platform/lib/shim.h
@@ -114,8 +114,15 @@
 #define SHIM_CLKSTS		0x7C
 
 #define SHIM_PWRCTL		0x90
-#define SHIM_PWRSTS		0x92
 #define SHIM_PWRCTL_TCPDSPPG(x)	BIT(x)
+#define SHIM_PWRCTL_TCPCTLPG	BIT(4)
+
+#define SHIM_PWRSTS		0x92
+
+#define SHIM_LPSCTL		0x94
+#define SHIM_LPSCTL_BID		BIT(7)
+#define SHIM_LPSCTL_FDSPRUN	BIT(9)
+#define SHIM_LPSCTL_BATTR_0	BIT(12)
 
 /* LP GPDMA Force Dynamic Clock Gating bits, 0--enable */
 #define SHIM_CLKCTL_LPGPDMAFDCGB(x)	(0x1 << (26 + x))

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -439,9 +439,7 @@ int platform_init(struct sof *sof)
 	shim_write(SHIM_GPDMA_CLKCTL(1), SHIM_CLKCTL_LPGPDMAFDCGB);
 
 	/* prevent DSP Common power gating */
-	shim_write16(SHIM_PWRCTL, SHIM_PWRCTL_TCPDSPPG(0) |
-		     SHIM_PWRCTL_TCPDSPPG(1) | SHIM_PWRCTL_TCPDSPPG(2) |
-		     SHIM_PWRCTL_TCPDSPPG(3));
+	pm_runtime_get(PM_RUNTIME_DSP, PLATFORM_MASTER_CORE_ID);
 
 #elif CONFIG_ICELAKE || CONFIG_SUECREEK || CONFIG_TIGERLAKE
 	/* TODO: need to merge as for APL */
@@ -456,9 +454,7 @@ int platform_init(struct sof *sof)
 	io_reg_write(GPDMA_CLKCTL(1), GPDMA_FDCGB);
 
 	/* prevent DSP Common power gating */
-	shim_write16(SHIM_PWRCTL, SHIM_PWRCTL_TCPDSPPG(0) |
-		     SHIM_PWRCTL_TCPDSPPG(1) | SHIM_PWRCTL_TCPDSPPG(2) |
-		     SHIM_PWRCTL_TCPDSPPG(3));
+	pm_runtime_get(PM_RUNTIME_DSP, PLATFORM_MASTER_CORE_ID);
 #endif
 
 	/* init DMACs */

--- a/src/platform/suecreek/include/platform/lib/shim.h
+++ b/src/platform/suecreek/include/platform/lib/shim.h
@@ -114,8 +114,15 @@
 #define SHIM_CLKSTS		0x7C
 
 #define SHIM_PWRCTL		0x90
-#define SHIM_PWRSTS		0x92
 #define SHIM_PWRCTL_TCPDSPPG(x)	BIT(x)
+#define SHIM_PWRCTL_TCPCTLPG	BIT(4)
+
+#define SHIM_PWRSTS		0x92
+
+#define SHIM_LPSCTL		0x94
+#define SHIM_LPSCTL_BID		BIT(7)
+#define SHIM_LPSCTL_FDSPRUN	BIT(9)
+#define SHIM_LPSCTL_BATTR_0	BIT(12)
 
 /* LP GPDMA Force Dynamic Clock Gating bits, 0--enable */
 #define SHIM_CLKCTL_LPGPDMAFDCGB(x)	(0x1 << (26 + x))

--- a/src/platform/tigerlake/include/platform/lib/shim.h
+++ b/src/platform/tigerlake/include/platform/lib/shim.h
@@ -114,8 +114,15 @@
 #define SHIM_CLKSTS		0x7C
 
 #define SHIM_PWRCTL		0x90
-#define SHIM_PWRSTS		0x92
 #define SHIM_PWRCTL_TCPDSPPG(x)	BIT(x)
+#define SHIM_PWRCTL_TCPCTLPG	BIT(4)
+
+#define SHIM_PWRSTS		0x92
+
+#define SHIM_LPSCTL		0x94
+#define SHIM_LPSCTL_BID		BIT(7)
+#define SHIM_LPSCTL_FDSPRUN	BIT(9)
+#define SHIM_LPSCTL_BATTR_0	BIT(12)
 
 /* LP GPDMA Force Dynamic Clock Gating bits, 0--enable */
 #define SHIM_CLKCTL_LPGPDMAFDCGB(x)	(0x1 << (26 + x))


### PR DESCRIPTION
Control of power gating for dsp cores implemented as pm-runtime operations for cavs platforms. Replaced direct read/writes of shim registers in the platform code.