### PR TITLE
component: add min_sink/source_bytes to comp_dev struct

### DIFF
--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -249,6 +249,15 @@ struct comp_dev {
 	uint32_t output_rate;      /**< 0 means all output rates are fine */
 	struct pipeline *pipeline; /**< pipeline we belong to */
 
+	uint32_t min_sink_bytes;   /**< min free sink buffer size measured in
+				     *  bytes required to run component's
+				     *  processing
+				     */
+	uint32_t min_source_bytes; /**< amount of data measured in bytes
+				     *  available at source buffer required
+				     *  to run component's processing
+				     */
+
 	/** common runtime configuration for downstream/upstream */
 	struct sof_ipc_stream_params params;
 


### PR DESCRIPTION
Add two parameters to comp_dev struct in order to allow
configuration of the component processing variable frames.
Added parameters are:
- min_sink_bytes - min free sink buffer size measure in bytes
  required to run component's processing;
- min_source_bytes - amount of data measured in bytes
  available at source buffer required to run component's processing.

Every component could update those parameters in 
comp_params() due to pcm params change.
Signed-off-by: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>