### PR TITLE
checkpatch: disable __func__ warning

### DIFF
--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -5498,7 +5498,8 @@ sub process {
 # This does not work very well for -f --file checking as it depends on patch
 # context providing the function name or a single line form for in-file
 # function declarations
-		if ($line =~ /^\+.*$String/ &&
+		if (!$SOF &&
+		    $line =~ /^\+.*$String/ &&
 		    defined($context_function) &&
 		    get_quoted_string($line, $rawline) =~ /\b$context_function\b/ &&
 		    length(get_quoted_string($line, $rawline)) != (length($context_function) + 2)) {


### PR DESCRIPTION
Traces in SOF are used like ` trace("<func>() info")`,
in that case `__func__` is not convenient, because it is not literal
and it would be needed to use %s everywhere and change
all current traces.

Signed-off-by: Janusz Jankowski <janusz.jankowski@linux.intel.com>