### PR TITLE
cnl: clk: add config option to select default ro clock

### DIFF
--- a/src/platform/Kconfig
+++ b/src/platform/Kconfig
@@ -218,6 +218,14 @@ config CONFIG_CHERRYTRAIL_EXTRA_DW_DMA
 	  Select if you need support for all 3 DMACs versus the default 2 used
 	  in baytrail.
 
+config CAVS_LPRO
+	bool "Enable low power ring oscillator as the default clock"
+	default n if !CANNONLAKE
+	depends on CANNONLAKE
+	help
+	  Select if you want to use 120MHz LPRO as the DSP clock source.
+	  This option is required to support S0ix/D0ix mode.
+
 # TODO: it should just take manifest version and offsets
 config FIRMWARE_SHORT_NAME
 	string "Rimage firmware name"

--- a/src/platform/cannonlake/include/platform/lib/clk.h
+++ b/src/platform/cannonlake/include/platform/lib/clk.h
@@ -16,7 +16,11 @@
 
 #define CLK_MAX_CPU_HZ	400000000
 
+#if CONFIG_CAVS_LPRO
+#define CPU_DEFAULT_IDX	0
+#else
 #define CPU_DEFAULT_IDX	1
+#endif
 
 #define SSP_DEFAULT_IDX	0
 


### PR DESCRIPTION
A new config option allows to select between the default
ring oscillator used to clock the dsp core and memory
on Intel Cannonlake platform.

CANNONLAKE_LPRO sets the default clock to 120MHz low power
oscillator, otherwise 400MHz oscillator is used.

Signed-off-by: Marcin Maka <marcin.maka@linux.intel.com>