### PR TITLE
cavs: pm-runtime: enable dsp master core state transitions

### DIFF
--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -25,6 +25,7 @@
 #include <sof/lib/alloc.h>
 #include <sof/lib/clk.h>
 #include <sof/lib/notifier.h>
+#include <sof/lib/pm_runtime.h>
 #include <sof/list.h>
 #include <sof/math/numbers.h>
 #include <sof/platform.h>
@@ -1050,6 +1051,8 @@ static enum task_state kpb_draining_task(void *arg)
 
 	trace_kpb("kpb_draining_task(), start.");
 
+	pm_runtime_disable(PM_RUNTIME_DSP, PLATFORM_MASTER_CORE_ID);
+
 	/* Change KPB internal state to DRAINING */
 	kpb_change_state(kpb, KPB_STATE_DRAINING);
 
@@ -1149,6 +1152,8 @@ out:
 	 * variables.
 	 */
 	(void)(draining_time_end - draining_time_start);
+
+	pm_runtime_enable(PM_RUNTIME_DSP, PLATFORM_MASTER_CORE_ID);
 
 	return SOF_TASK_STATE_COMPLETED;
 }

--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -671,7 +671,10 @@ static int ipc_pm_gate(uint32_t header)
 
 	IPC_COPY_CMD(pm_gate, _ipc->comp_data);
 
-	/* TODO: handle the flags */
+	if (pm_gate.flags & SOF_PM_PPG)
+		pm_runtime_disable(PM_RUNTIME_DSP, PLATFORM_MASTER_CORE_ID);
+	else
+		pm_runtime_enable(PM_RUNTIME_DSP, PLATFORM_MASTER_CORE_ID);
 
 	return 0;
 }

--- a/src/platform/intel/cavs/lib/pm_runtime.c
+++ b/src/platform/intel/cavs/lib/pm_runtime.c
@@ -76,6 +76,8 @@ static inline void cavs_pm_runtime_enable_dsp(bool enable)
 	enable ? --pprd->dsp_d0_sref : ++pprd->dsp_d0_sref;
 
 	irq_local_enable(flags);
+
+	trace_power("pm_runtime_enable_dsp dsp_d0_sref %d", pprd->dsp_d0_sref);
 }
 
 static inline bool cavs_pm_runtime_is_active_dsp(void)

--- a/test/cmocka/src/audio/kpb/kpb_mock.c
+++ b/test/cmocka/src/audio/kpb/kpb_mock.c
@@ -13,6 +13,7 @@
 
 #include <sof/lib/alloc.h>
 #include <sof/lib/notifier.h>
+#include <sof/lib/pm_runtime.h>
 #include <sof/audio/component.h>
 #include <sof/drivers/timer.h>
 #include <sof/schedule/schedule.h>
@@ -103,3 +104,16 @@ struct schedulers **arch_schedulers_get(void)
 {
 	return NULL;
 }
+
+void pm_runtime_enable(enum pm_runtime_context context, uint32_t index)
+{
+	(void)context;
+	(void)index;
+}
+
+void pm_runtime_disable(enum pm_runtime_context context, uint32_t index)
+{
+	(void)context;
+	(void)index;
+}
+


### PR DESCRIPTION
Power Management for DSP Core(s)
================================

DSP cores are managed by providing `PM_RUNTIME_DSP` context id and core
index to the pm-runtime API functions.

Some platforms may provide advanced power management of the DSP cores,
including clock gating in idle, complete power gating in idle, etc.
depending on how the cores are integrated on that platform.

An implementation of platform API may provide customized idle entry
function `platform_wait_for_interrupt()` which may simply call
`arch_wait_for_interrupt()` or perform more sophisticated power
transition in order to get a better power savings when the DSP core is
in idle.

An advanced power transitions may last longer since the DSP core /
platform has to some back from a deeper power state. This additional
latency is not always acceptable, for instance during platform
initialization it might be better to complete the initial setup faster,
with shorter IPC interrupt response times. The platform initialization
code (`platform_init()`) may disable the advanced pm-runtime of the DSP
core by calling `pm_runtime_disable(PM_RUNTIME_DSP, 0)` and let the
driver enable it once the initialization is complete, by sending
`PM_GATE (PreventPowerGating=0)` IPC request. The `PM_GATE` handler
calls either `pm_runtime_enable(PM_RUNTIME_DSP, 0)` or
`pm_runtime_disable(PM_RUNTIME_DSP, 0)` depending on the value of the
`PPG` flag. Note that enable/disable calls are ref-counted since there
might be other internal clients interested in disabling transitions to
deeper power states in order to keep the `waiti` entry/exit latency
minimal.

`pm_runtime_is_active(PM_RUNTIME_DSP, 0)` may be used to query the
ref-counter state and decide whether transitions to deeper power states
are allowed inside the `platform_wait_for_interrupt()`.

![image](https://user-images.githubusercontent.com/40028148/68936613-36dd0080-079b-11ea-9c03-2d77f610cf63.png)

![image](https://user-images.githubusercontent.com/40028148/68936638-478d7680-079b-11ea-8eea-4b63d20763db.png)


cAVS pm-runtime for DSP core 0
==============================

cAVS provides two levels of power savings for DSP cores:

-   clock gating,
-   power gating in idle, important part of *D0i3* state.

The clock gating is enabled by default. When a DSP core enters idle
(calls `waiti`), the clock signal is gated (note that `CCOUNT` is not
incremented in this state, so the only reliable always running clock is
the Wall Clock).

The power gating mechanism is enabled if the *CAVS\_LPS* config option
is set. The `waiti` entry/exit transitions driven by the Low Power
Sequencer (LPS), so that the platform is able to shut the DSP core down
on `waiti` entry, listens for the interrupts and powers the DSP core up
on interrupt.

The LPS mechanism is used only if `pm_runtime_is_active()` returns
*false* meaning that DPS core 0 does not have to be locked in D0 state.

Note the cAVS simply uses `pm_runtime_get()` /`pm_runtime_set()`
operations to setup the power gating for D0i3 since the programming is
the same as for D3.

![image](https://user-images.githubusercontent.com/40028148/68936697-6429ae80-079b-11ea-86ff-bdde1917ac0d.png)

