### PR TITLE
Topic/imx/sai fix 4 playback

### DIFF
--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -798,6 +798,19 @@ static int dai_config(struct comp_dev *dev, struct sof_ipc_dai_config *config)
 		handshake = dai_get_handshake(dd->dai, dev->params.direction,
 					      dd->stream_id);
 		channel = EDMA_HS_GET_CHAN(handshake);
+
+		switch (dev->params.frame_fmt) {
+		case SOF_IPC_FRAME_S16_LE:
+			dd->frame_bytes = 2;
+			break;
+		case SOF_IPC_FRAME_S24_4LE:
+		case SOF_IPC_FRAME_S32_LE:
+			dd->frame_bytes = 4;
+			break;
+		default:
+			return -EINVAL;
+		}
+
 		dd->config.burst_elems =
 			dd->dai->plat_data.fifo[dev->params.direction].depth;
 		break;

--- a/src/include/sof/drivers/sai.h
+++ b/src/include/sof/drivers/sai.h
@@ -225,7 +225,11 @@
 #define SAI_FLAG_PMQOS   BIT(0)
 
 #define SAI_FIFO_WORD_SIZE	64
-#define SAI_CLOCK_DIV		0x3
+/* Divides down the audio master clock to generate the bit clock when
+ * configured for an internal bit clock.
+ * The division value is (DIV + 1) * 2.
+ */
+#define SAI_CLOCK_DIV		0x7
 #define SAI_TDM_SLOTS		2
 
 extern const struct dai_driver sai_driver;

--- a/tools/topology/sof-imx8qxp-wm8960.m4
+++ b/tools/topology/sof-imx8qxp-wm8960.m4
@@ -50,7 +50,7 @@ dnl     period, priority, core, time_domain)
 # playback DAI is SAI1 using 2 periods
 # Buffers use s24le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
-	1, SAI, 1, SAI1-Codec,
+	1, SAI, 1, be.wm8960-hifi,
 	PIPELINE_SOURCE_1, 2, s24le,
 	1000, 0, 0)
 
@@ -60,9 +60,9 @@ dnl PCM_PLAYBACK_ADD(name, pcm_id, playback)
 PCM_PLAYBACK_ADD(Port0, 0, PIPELINE_PCM_1)
 
 dnl DAI_CONFIG(type, idx, link_id, name, sai_config)
-DAI_CONFIG(SAI, 1, 0, SAI1-Codec,
-	SAI_CONFIG(I2S, SAI_CLOCK(mclk, 49152000, codec_mclk_in),
-		SAI_CLOCK(bclk, 3072000, codec_slave),
-		SAI_CLOCK(fsync, 48000, codec_slave),
+DAI_CONFIG(SAI, 1, 0, be.wm8960-hifi,
+	SAI_CONFIG(I2S, SAI_CLOCK(mclk, 12288000, codec_mclk_in),
+		SAI_CLOCK(bclk, 3072000, codec_master),
+		SAI_CLOCK(fsync, 48000, codec_master),
 		SAI_TDM(2, 32, 3, 3),
 		SAI_CONFIG_DATA(SAI, 1, 0)))


### PR DESCRIPTION
This patch set corrects:
- topology link name
- clock divider in SAI dai
- configures frame_bytes from format
:x