### PR TITLE
platform: imx: Do not perform early get/init of the DAI

### DIFF
--- a/src/platform/baytrail/platform.c
+++ b/src/platform/baytrail/platform.c
@@ -246,33 +246,27 @@ int platform_init(struct sof *sof)
 	ssp0 = dai_get(SOF_DAI_INTEL_SSP, 0, DAI_CREAT);
 	if (ssp0 == NULL)
 		return -ENODEV;
-	dai_probe(ssp0);
 
 	ssp1 = dai_get(SOF_DAI_INTEL_SSP, 1, DAI_CREAT);
 	if (ssp1 == NULL)
 		return -ENODEV;
-	dai_probe(ssp1);
 
 	ssp2 = dai_get(SOF_DAI_INTEL_SSP, 2, DAI_CREAT);
 	if (ssp2 == NULL)
 		return -ENODEV;
-	dai_probe(ssp2);
 
 #if defined CONFIG_CHERRYTRAIL
 	ssp3 = dai_get(SOF_DAI_INTEL_SSP, 3, DAI_CREAT);
 	if (ssp3 == NULL)
 		return -ENODEV;
-	dai_probe(ssp3);
 
 	ssp4 = dai_get(SOF_DAI_INTEL_SSP, 4, DAI_CREAT);
 	if (ssp4 == NULL)
 		return -ENODEV;
-	dai_probe(ssp4);
 
 	ssp5 = dai_get(SOF_DAI_INTEL_SSP, 5, DAI_CREAT);
 	if (ssp5 == NULL)
 		return -ENODEV;
-	dai_probe(ssp5);
 #endif
 
 #if CONFIG_TRACE

--- a/src/platform/haswell/platform.c
+++ b/src/platform/haswell/platform.c
@@ -226,12 +226,10 @@ int platform_init(struct sof *sof)
 	ssp0 = dai_get(SOF_DAI_INTEL_SSP, 0, DAI_CREAT);
 	if (ssp0 == NULL)
 		return -ENODEV;
-	dai_probe(ssp0);
 
 	ssp1 = dai_get(SOF_DAI_INTEL_SSP, 1, DAI_CREAT);
 	if (ssp1 == NULL)
 		return -ENODEV;
-	dai_probe(ssp1);
 
 #if CONFIG_TRACE
 	/* Initialize DMA for Trace*/

--- a/src/platform/imx8/platform.c
+++ b/src/platform/imx8/platform.c
@@ -141,7 +141,6 @@ int platform_boot_complete(uint32_t boot_message)
 int platform_init(struct sof *sof)
 {
 	int ret;
-	struct dai *esai;
 
 	platform_interrupt_init();
 	clock_init();
@@ -178,12 +177,6 @@ int platform_init(struct sof *sof)
 	ret = dai_init();
 	if (ret < 0)
 		return -ENODEV;
-
-	esai = dai_get(SOF_DAI_IMX_ESAI, 0, DAI_CREAT);
-	if (!esai)
-		return -ENODEV;
-
-	dai_probe(esai);
 
 	return 0;
 }


### PR DESCRIPTION
It isn't necessary to do a dai_get this early for the ESAI; the SAI
doesn't even have one.

Calling dai_probe() after dai_get() is pointless since dai_probe() was
already called from a previous dai_get() with CREAT flag (in particular
the one which incremented sref from 0 to 1).

Signed-off-by: Paul Olaru <paul.olaru@nxp.com>

I wonder if the last thing I said above doesn't also apply to other instances
of this that I have noticed (calling dai_probe() after dai_get() ).