### PR TITLE
logger: fix build errors with gcc 9.1.x

### DIFF
--- a/tools/logger/convert.c
+++ b/tools/logger/convert.c
@@ -305,17 +305,19 @@ static int serial_read(const struct convert_config *config,
 {
 	struct log_entry_header dma_log;
 	size_t len;
-	uint32_t *n;
+	uint8_t *n;
 	int ret;
 
-	for (len = 0, n = (uint32_t *)&dma_log; len < sizeof(dma_log); n++) {
-		ret = read(config->serial_fd, n, sizeof(*n));
+	for (len = 0, n = (uint8_t *)&dma_log; len < sizeof(dma_log);
+		n += sizeof(uint32_t)) {
+
+		ret = read(config->serial_fd, n, sizeof(*n) * sizeof(uint32_t));
 		if (ret < 0)
 			return -errno;
 
 		/* In the beginning we read 1 spurious byte */
-		if (ret < sizeof(*n))
-			n--;
+		if (ret < sizeof(*n) * sizeof(uint32_t))
+			n -= sizeof(uint32_t);
 		else
 			len += ret;
 	}


### PR DESCRIPTION
Latest GCC does additional checks. This patch fixes the following build
error.

Scanning dependencies of target sof-logger
[  0%] Building C object logger/CMakeFiles/sof-logger.dir/convert.c.o
/home/lrg/work/sof/sof/tools/logger/convert.c: In function ‘serial_read’:
/home/lrg/work/sof/sof/tools/logger/convert.c:311:2: error: converting a packed ‘struct log_entry_header’ pointer (alignment 1) to a ‘uint32_t’ {aka ‘unsigned int’} pointer (alignment 4) may result in an unaligned pointer value [-Werror=address-of-packed-member]
  311 |  for (len = 0, n = (uint32_t *)&dma_log; len < sizeof(dma_log); n++) {
      |  ^~~
In file included from /home/lrg/work/sof/sof/tools/logger/convert.c:15:
/home/lrg/work/sof/sof/tools/../src/include/user/trace.h:94:8: note: defined here
   94 | struct log_entry_header {
      |        ^~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make[2]: *** [logger/CMakeFiles/sof-logger.dir/build.make:76: logger/CMakeFiles/sof-logger.dir/convert.c.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:91: logger/CMakeFiles/sof-logger.dir/all] Error 2
make: *** [Makefile:130: all] Error 2

Signed-off-by: Liam Girdwood <liam.r.girdwood@linux.intel.com>