### PR TITLE
sof: make .rodata deterministic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,8 @@ if(BUILD_LIBRARY)
 
 	add_subdirectory(src)
 
+	sof_append_relative_path_definitions(sof)
+
 	get_target_property(incdirs sof_public_headers INTERFACE_INCLUDE_DIRECTORIES)
 
 	# we append slash at the end to make CMake copy contents of directories
@@ -176,3 +178,5 @@ target_link_libraries(sof PRIVATE sof_static_libraries)
 sof_add_build_counter_rule()
 
 add_subdirectory(src)
+
+sof_append_relative_path_definitions(sof)

--- a/scripts/cmake/misc.cmake
+++ b/scripts/cmake/misc.cmake
@@ -59,3 +59,22 @@ function(sof_add_static_library lib_name lib_path)
 	set_target_properties(${lib_name} PROPERTIES IMPORTED_LOCATION ${lib_abs_path})
 	target_link_libraries(sof_static_libraries INTERFACE ${lib_name})
 endfunction()
+
+# Appends literal with path of the source file relative to the project root
+# It is useful if sources in given target need deterministic relative path
+# to the actually compiled file.
+# __FILE is not always suitable as C standard states that __FILE__ expands to
+# input file name, that usually is absolute path what will cause f.e. .rodata
+# size to be dependent on where project is physically located on the disk.
+function(sof_append_relative_path_definitions target)
+	get_target_property(sources ${target} SOURCES)
+	foreach(src ${sources})
+		get_filename_component(ABS_PATH ${src} ABSOLUTE)
+		file(RELATIVE_PATH rel ${PROJECT_SOURCE_DIR} ${ABS_PATH})
+		set_property(
+			SOURCE ${src}
+			APPEND
+			PROPERTY COMPILE_DEFINITIONS
+			RELATIVE_FILE="${rel}")
+	endforeach()
+endfunction()

--- a/src/arch/xtensa/CMakeLists.txt
+++ b/src/arch/xtensa/CMakeLists.txt
@@ -221,6 +221,7 @@ if(build_bootloader)
 	target_link_libraries(bootloader PRIVATE "-lgcc")
 	target_link_libraries(bootloader PRIVATE "-T${PROJECT_BINARY_DIR}/${platform_bootldr_ld_script}")
 	sof_add_ld_script(bootloader ${platform_bootldr_ld_script})
+	sof_append_relative_path_definitions(bootloader)
 
 	add_custom_target(
 		bootloader_dump

--- a/src/audio/CMakeLists.txt
+++ b/src/audio/CMakeLists.txt
@@ -74,6 +74,7 @@ function(sof_audio_add_module lib_name compile_flags)
 	target_link_libraries(${lib_name} PRIVATE -Wl,--export-dynamic)
 	target_compile_options(${lib_name} PRIVATE ${compile_flags})
 	add_local_sources(${lib_name} ${ARGN})
+	sof_append_relative_path_definitions(${lib_name})
 	install(TARGETS ${lib_name} DESTINATION lib)
 endfunction()
 

--- a/src/include/sof/debug/debug.h
+++ b/src/include/sof/debug/debug.h
@@ -21,6 +21,11 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#ifndef RELATIVE_FILE
+#error "This file requires RELATIVE_FILE to be defined. " \
+	"Add it to CMake's target with sof_append_relative_path_definitions."
+#endif
+
 #if CONFIG_DEBUG
 
 #include <sof/lib/mailbox.h>
@@ -37,8 +42,9 @@
 #define dbg() \
 	do { \
 		volatile uint32_t *__m = (uint32_t *)mailbox_get_debug_base(); \
-		*(__m++) = (__FILE__[0] << 24) + (__FILE__[1] << 16) +\
-			 (__FILE__[2] << 8) + (__FILE__[3]); \
+		*(__m++) = (RELATIVE_FILE[0] << 24) + \
+			   (RELATIVE_FILE[1] << 16) + \
+			   (RELATIVE_FILE[2] << 8) + (RELATIVE_FILE[3]); \
 		*(__m++) = (__func__[0] << 24) + (__func__[1] << 16) + \
 			(__func__[2] << 8) + (__func__[3]); \
 		*__m = __LINE__; \
@@ -49,8 +55,9 @@
 	do { \
 		volatile uint32_t *__m = \
 			(uint32_t *)mailbox_get_debug_base() + __x; \
-		*(__m++) = (__FILE__[0] << 24) + (__FILE__[1] << 16) +\
-			 (__FILE__[2] << 8) + (__FILE__[3]); \
+		*(__m++) = (RELATIVE_FILE[0] << 24) + \
+			   (RELATIVE_FILE[1] << 16) + \
+			   (RELATIVE_FILE[2] << 8) + (RELATIVE_FILE[3]); \
 		*(__m++) = (__func__[0] << 24) + (__func__[1] << 16) + \
 			(__func__[2] << 8) + (__func__[3]); \
 		*__m = __LINE__; \

--- a/src/include/sof/debug/panic.h
+++ b/src/include/sof/debug/panic.h
@@ -12,13 +12,18 @@
 #include <ipc/trace.h>
 #include <stdint.h>
 
+#ifndef RELATIVE_FILE
+#error "This file requires RELATIVE_FILE to be defined. " \
+	"Add it to CMake's target with sof_append_relative_path_definitions."
+#endif
+
 void dump_panicinfo(void *addr, struct sof_ipc_panic_info *panic_info);
 void panic_rewind(uint32_t p, uint32_t stack_rewind_frames,
 		  struct sof_ipc_panic_info *panic_info, uintptr_t *data);
 void __panic(uint32_t p, char *filename, uint32_t linenum);
 
 /* panic dump filename and linenumber of the call */
-#define panic(x) __panic((x), (__FILE__), (__LINE__))
+#define panic(x) __panic((x), (RELATIVE_FILE), (__LINE__))
 
 /* runtime assertion */
 #define assert(cond) (void)((cond) || (panic(SOF_IPC_PANIC_ASSERT), 0))

--- a/src/include/sof/trace/trace.h
+++ b/src/include/sof/trace/trace.h
@@ -10,6 +10,11 @@
 #ifndef __SOF_TRACE_TRACE_H__
 #define __SOF_TRACE_TRACE_H__
 
+#ifndef RELATIVE_FILE
+#error "This file requires RELATIVE_FILE to be defined. " \
+	"Add it to CMake's target with sof_append_relative_path_definitions."
+#endif
+
 #if CONFIG_TRACE
 #include <platform/trace/trace.h>
 #endif
@@ -229,7 +234,7 @@ void trace_init(struct sof *sof);
 		uint32_t line_idx;				\
 		uint32_t file_name_len;				\
 		uint32_t text_len;				\
-		const char file_name[sizeof(__FILE__)];		\
+		const char file_name[sizeof(RELATIVE_FILE)];	\
 		const char text[sizeof(format)];		\
 	} log_entry = {						\
 		lvl,						\
@@ -237,9 +242,9 @@ void trace_init(struct sof *sof);
 		ids,						\
 		params,						\
 		__LINE__,					\
-		sizeof(__FILE__),				\
+		sizeof(RELATIVE_FILE),				\
 		sizeof(format),					\
-		__FILE__,					\
+		RELATIVE_FILE,					\
 		format						\
 	}
 
@@ -282,7 +287,7 @@ do {									\
 		uint32_t line_idx;				\
 		uint32_t file_name_len;				\
 		uint32_t text_len;				\
-		const char file_name[sizeof(__FILE__)];		\
+		const char file_name[sizeof(RELATIVE_FILE)];		\
 		const char text[sizeof(format)];		\
 	} log_entry = {						\
 		lvl,						\
@@ -290,9 +295,9 @@ do {									\
 		ids,						\
 		params,						\
 		__LINE__,					\
-		sizeof(__FILE__),				\
+		sizeof(RELATIVE_FILE),				\
 		sizeof(format),					\
-		__FILE__,					\
+		RELATIVE_FILE,					\
 		format						\
 	}
 #endif

--- a/test/cmocka/CMakeLists.txt
+++ b/test/cmocka/CMakeLists.txt
@@ -57,6 +57,7 @@ SET(arch_src ${PROJECT_SOURCE_DIR}/src/arch/xtensa/idc.c)
 add_library(universal_mock STATIC ${PROJECT_SOURCE_DIR}/test/cmocka/src/universal_mocks.c)
 target_link_libraries(universal_mock PRIVATE sof_options)
 link_libraries(universal_mock)
+sof_append_relative_path_definitions(universal_mock)
 
 # creates exectuable for new test and adds it as test for ctest
 function(cmocka_test test_name)
@@ -74,6 +75,8 @@ function(cmocka_test test_name)
 	target_compile_definitions(${test_name} PRIVATE -D_UINTPTR_T_DEFINED)
 
 	add_test(NAME ${test_name} COMMAND xt-run --exit_with_target_code ${test_name})
+
+	sof_append_relative_path_definitions(${test_name})
 endfunction()
 
 add_subdirectory(src)

--- a/test/cmocka/src/audio/mux/CMakeLists.txt
+++ b/test/cmocka/src/audio/mux/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(
 	${PROJECT_SOURCE_DIR}/src/audio/mux/mux_generic.c
 	${PROJECT_SOURCE_DIR}/src/audio/component.c
 )
+sof_append_relative_path_definitions(audio_mux)
 
 target_link_libraries(audio_mux PRIVATE sof_options)
 

--- a/test/cmocka/src/audio/pipeline/CMakeLists.txt
+++ b/test/cmocka/src/audio/pipeline/CMakeLists.txt
@@ -10,6 +10,7 @@ if(CONFIG_SMP)
 	link_libraries(-Wl,--gc-sections)
 
 	add_library(pipeline_lib STATIC ${arch_src})
+	sof_append_relative_path_definitions(pipeline_lib)
 
 	target_link_libraries(pipeline_lib PRIVATE sof_options)
 

--- a/test/cmocka/src/audio/selector/CMakeLists.txt
+++ b/test/cmocka/src/audio/selector/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(audio_for_selector STATIC
 	${PROJECT_SOURCE_DIR}/src/audio/selector/selector.c
 	${PROJECT_SOURCE_DIR}/src/audio/selector/selector_generic.c
 )
+sof_append_relative_path_definitions(audio_for_selector)
 
 target_link_libraries(audio_for_selector PRIVATE sof_options)
 

--- a/test/cmocka/src/audio/volume/CMakeLists.txt
+++ b/test/cmocka/src/audio/volume/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(audio_for_volume STATIC
 	${PROJECT_SOURCE_DIR}/src/audio/volume/volume_generic.c
 	${PROJECT_SOURCE_DIR}/src/audio/volume/volume_hifi3.c
 )
+sof_append_relative_path_definitions(audio_for_volume)
 
 target_link_libraries(audio_for_volume PRIVATE sof_options)
 

--- a/test/cmocka/src/debugability/macros.c
+++ b/test/cmocka/src/debugability/macros.c
@@ -42,7 +42,7 @@ static void test_debugability_macros_declare_log_entry(void **state)
 			"uint32_t line_idx; "
 			"uint32_t file_name_len; "
 			"uint32_t text_len; "
-			"const char file_name[sizeof(\"" __FILE__ "\")]; "
+			"const char file_name[sizeof(\"" RELATIVE_FILE "\")]; "
 			"const char text[sizeof(\"Message\")]; "
 		"} log_entry = { "
 			"1"
@@ -50,9 +50,9 @@ static void test_debugability_macros_declare_log_entry(void **state)
 			"1"
 			"1"
 			"32"
-			"sizeof(\"" __FILE__ "\")"
+			"sizeof(\"" RELATIVE_FILE "\")"
 			"sizeof(\"Message\")"
-			"\"" __FILE__ "\""
+			"\"" RELATIVE_FILE "\""
 			"\"Message\" "
 		"}";
 	(void)state;

--- a/tools/testbench/CMakeLists.txt
+++ b/tools/testbench/CMakeLists.txt
@@ -4,6 +4,8 @@ cmake_minimum_required(VERSION 3.10)
 
 project(SOF_TESTBENCH C)
 
+include(../../scripts/cmake/misc.cmake)
+
 add_executable(testbench
 	testbench.c
 	alloc.c
@@ -17,6 +19,8 @@ add_executable(testbench
 	topology.c
 	trace.c
 )
+
+sof_append_relative_path_definitions(testbench)
 
 target_include_directories(testbench PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 


### PR DESCRIPTION
Because of `__FILE__` macro paths used f.e. in panics are dependent on where project is built.
Also compiler doesn't care about the fact that we use just part of that path and if `__FILE__` is referenced it gets inserted as whole into .rodata of compilation unit.
This PR introduces custom RELATIVE_FILE to overcome this issue and make given sof build has the same size no matter where it's built. (+ it saves some space)