### PR TITLE
include: ipc: Update comment for type field of sof_ipc_comp_process

### DIFF
--- a/src/include/ipc/topology.h
+++ b/src/include/ipc/topology.h
@@ -181,7 +181,7 @@ struct sof_ipc_comp_process {
 	struct sof_ipc_comp comp;
 	struct sof_ipc_comp_config config;
 	uint32_t size;	/**< size of bespoke data section in bytes */
-	uint32_t type;	/**< sof_ipc_effect_type */
+	uint32_t type;	/**< sof_ipc_process_type */
 
 	/* reserved for future use */
 	uint32_t reserved[7];


### PR DESCRIPTION
We need this in order to match the exact comment from the
similar file in the Linux kernel.

sof_ipc_effect_type was the old name of the component no longer
used now.

Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>