### PR TITLE
kmod_scripts: add support for soundwire_generic_allocation

### DIFF
--- a/tools/kmod_scripts/sof_remove.sh
+++ b/tools/kmod_scripts/sof_remove.sh
@@ -94,6 +94,7 @@ remove_module snd_hda_ext_core
 remove_module soundwire_intel_init
 remove_module soundwire_intel
 remove_module soundwire_cadence
+remove_module soundwire_generic_allocation
 remove_module regmap_sdw
 remove_module soundwire_bus
 


### PR DESCRIPTION
new module added, needs to be listed in sof_remove.sh

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>