### PR TITLE
spinlock: spin_try_lock refinement

### DIFF
--- a/src/drivers/intel/cavs/dmic.c
+++ b/src/drivers/intel/cavs/dmic.c
@@ -163,7 +163,7 @@ static enum task_state dmic_work(void *data)
 
 	tracev_dmic("dmic_work()");
 
-	spin_try_lock(dai->lock, ret);
+	ret = spin_try_lock(dai->lock);
 	if (!ret) {
 		tracev_dmic("dmic_work(): spin_try_lock(dai->lock, ret)"
 			    "failed: RESCHEDULE");

--- a/src/include/sof/spinlock.h
+++ b/src/include/sof/spinlock.h
@@ -189,11 +189,11 @@ extern uint32_t lock_dbg_user[DBG_LOCK_USERS];
 		arch_spin_lock(lock); \
 	} while (0)
 
-#define spin_try_lock(lock, ret) \
-	do { \
+#define spin_try_lock(lock) \
+	({ \
 		spin_lock_dbg(); \
-		ret = arch_try_lock(lock); \
-	} while (0)
+		arch_try_lock(lock); \
+	})
 
 #define spin_unlock(lock) \
 	do { \


### PR DESCRIPTION
Use block expression instead of do {} while(0) macro
in spin_try_lock in order to return its value in a
safer way.

Signed-off-by: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>