### PR TITLE
[RFC] topology: move volume/switch control naming to upper level

### DIFF
--- a/tools/topology/m4/mixercontrol.m4
+++ b/tools/topology/m4/mixercontrol.m4
@@ -28,39 +28,39 @@ define(`CONTROLMIXER_OPS',
 `		put STR($4)'
 `	}')
 
+dnl N_CONTROLMIXER(name)
+define(`N_CONTROLMIXER', PIPELINE_ID $1)
 
-define(`N_CONTROLMIXER', `CONTROLMIXER'PIPELINE_ID`.'$1)
-
-dnl C_CONTROLMIXER(name, index, ops, max, invert, tlv, comment, KCONTROL_CHANNELS, useleds, ledsdir)
+dnl C_CONTROLMIXER(name, ops, max, invert, tlv, comment, KCONTROL_CHANNELS, useleds, ledsdir)
 define(`C_CONTROLMIXER',
-`ifelse(`$#', `10',
-`SectionVendorTuples."'N_CONTROLMIXER($2)`_tuples_w" {'
+`ifelse(`$#', `9',
+`SectionVendorTuples."'$1`_tuples_w" {'
 `	tokens "sof_led_tokens"'
 `	tuples."word" {'
-`		SOF_TKN_MUTE_LED_USE'		$9
-`		SOF_TKN_MUTE_LED_DIRECTION'	$10
+`		SOF_TKN_MUTE_LED_USE'		$8
+`		SOF_TKN_MUTE_LED_DIRECTION'	$9
 `	}'
 `}'
-`SectionData."'N_CONTROLMIXER($2)`_data_w" {'
-`	tuples "'N_CONTROLMIXER($2)`_tuples_w"'
+`SectionData."'$1`_data_w" {'
+`	tuples "'$1`_tuples_w"'
 `}'
 ,` ')'
-`SectionControlMixer."ifdef(`CONTROL_NAME', CONTROL_NAME, $2 $1)" {'
+`SectionControlMixer."'$1`" {'
 `'
 `	# control belongs to this index group'
-`	index STR($2)'
+`	index "PIPELINE_ID"'
 `'
-`	#$7'
-`	$8'
+`	#$6'
+`	$7'
 `	# control uses bespoke driver get/put/info ID'
-`	$3'
+`	$2'
 `'
-`	$4'
-`	invert STR($5)'
-`	$6'
-`ifelse(`$#', `10',
+`	$3'
+`	invert STR($4)'
+`	$5'
+`ifelse(`$#', `9',
 `	data ['
-`		"'N_CONTROLMIXER($2)`_data_w"'
+`		"'$1`_data_w"'
 `	]'
 ,` ')'
 `}')

--- a/tools/topology/m4/pga.m4
+++ b/tools/topology/m4/pga.m4
@@ -2,38 +2,37 @@ divert(-1)
 
 dnl Define macro for PGA widget
 
-dnl PGA name)
-
+dnl N_PGA(name)
 define(`N_PGA', `PGA'PIPELINE_ID`.'$1)
 
 dnl W_PGA(name, format, periods_sink, periods_source, kcontrol0. kcontrol1...etc)
 define(`W_PGA',
-`SectionVendorTuples."'N_PGA($1)`_tuples_w" {'
+`SectionVendorTuples."'$1`_tuples_w" {'
 `	tokens "sof_comp_tokens"'
 `	tuples."word" {'
 `		SOF_TKN_COMP_PERIOD_SINK_COUNT'		STR($3)
 `		SOF_TKN_COMP_PERIOD_SOURCE_COUNT'	STR($4)
 `	}'
 `}'
-`SectionData."'N_PGA($1)`_data_w" {'
-`	tuples "'N_PGA($1)`_tuples_w"'
+`SectionData."'$1`_data_w" {'
+`	tuples "'$1`_tuples_w"'
 `}'
-`SectionVendorTuples."'N_PGA($1)`_tuples_str" {'
+`SectionVendorTuples."'$1`_tuples_str" {'
 `	tokens "sof_comp_tokens"'
 `	tuples."string" {'
 `		SOF_TKN_COMP_FORMAT'	STR($2)
 `	}'
 `}'
-`SectionData."'N_PGA($1)`_data_str" {'
-`	tuples "'N_PGA($1)`_tuples_str"'
+`SectionData."'$1`_data_str" {'
+`	tuples "'$1`_tuples_str"'
 `}'
-`SectionWidget.ifdef(`PGA_NAME', "`PGA_NAME'", "`N_PGA($1)'") {'
+`SectionWidget."'$1`" {'
 `	index "'PIPELINE_ID`"'
 `	type "pga"'
 `	no_pm "true"'
 `	data ['
-`		"'N_PGA($1)`_data_w"'
-`		"'N_PGA($1)`_data_str"'
+`		"'$1`_data_w"'
+`		"'$1`_data_str"'
 `		"'$5`"'
 `	]'
 `	mixer ['

--- a/tools/topology/sof/pipe-asrc-volume-capture.m4
+++ b/tools/topology/sof/pipe-asrc-volume-capture.m4
@@ -19,7 +19,7 @@ include(`pga.m4')
 #
 
 # Volume Mixer control with max value of 32
-C_CONTROLMIXER(Master Capture Volume, PIPELINE_ID,
+C_CONTROLMIXER(N_CONTROLMIXER(Master Capture Volume),
 	CONTROLMIXER_OPS(volsw,
 		256 binds the mixer control to volume get/put handlers,
 		256, 256),
@@ -67,8 +67,8 @@ W_DATA(MY_ASRC_CONF, MY_ASRC_TOKENS)
 # "ASRC" has 3 sink and 3 source periods
 W_ASRC(0, PIPELINE_FORMAT, 3, 3, MY_ASRC_CONF)
 
-# "Volume" has 3 sink and x source periods
-W_PGA(0, PIPELINE_FORMAT, 3, DAI_PERIODS, MY_PGA_CONF,
+# "Volume" has x source and 3 sink periods
+W_PGA(N_PGA(0), PIPELINE_FORMAT, 3, DAI_PERIODS, MY_PGA_CONF,
 	LIST(`		', "PIPELINE_ID Master Capture Volume"))
 
 # Capture Buffers

--- a/tools/topology/sof/pipe-asrc-volume-playback.m4
+++ b/tools/topology/sof/pipe-asrc-volume-playback.m4
@@ -18,7 +18,7 @@ include(`pipeline.m4')
 # Controls
 #
 # Volume Mixer control with max value of 32
-C_CONTROLMIXER(Master Playback Volume, PIPELINE_ID,
+C_CONTROLMIXER(N_CONTROLMIXER(Master Playback Volume),
 	CONTROLMIXER_OPS(volsw,
 		256 binds the mixer control to volume get/put handlers,
 		256, 256),
@@ -61,8 +61,8 @@ LIST(`		', `SOF_TKN_VOLUME_RAMP_STEP_TYPE	"0"'
      `		', `SOF_TKN_VOLUME_RAMP_STEP_MS		"250"'))
 W_DATA(MY_PGA_CONF, MY_PGA_TOKENS)
 
-# "Volume" has x sink and 2 source periods
-W_PGA(0, PIPELINE_FORMAT, DAI_PERIODS, 2, MY_PGA_CONF,
+# "Volume" has 2 source and x sink periods
+W_PGA(N_PGA(0), PIPELINE_FORMAT, DAI_PERIODS, 2, MY_PGA_CONF,
 	 LIST(`		', "PIPELINE_ID Master Playback Volume"))
 
 # Playback Buffers

--- a/tools/topology/sof/pipe-eq-capture-16khz.m4
+++ b/tools/topology/sof/pipe-eq-capture-16khz.m4
@@ -14,15 +14,12 @@ include(`pipeline.m4')
 include(`bytecontrol.m4')
 include(`eq_iir.m4')
 
-define(`CONTROL_NAME', Capture Volume)
-define(`PGA_NAME', Dmic1)
-
 #
 # Controls
 #
 
 # Volume Mixer control with max value of 32
-C_CONTROLMIXER(Master Capture Volume, PIPELINE_ID,
+C_CONTROLMIXER(Capture Volume,
 	CONTROLMIXER_OPS(volsw,
 		256 binds the mixer control to volume get/put handlers,
 		256, 256),
@@ -64,9 +61,9 @@ C_CONTROLBYTES(EQIIR_C16, PIPELINE_ID,
 W_PCM_CAPTURE(PCM_ID, Highpass Capture, 0, 2)
 
 # "Volume" has 2 source and 2 sink periods
-W_PGA(0, PIPELINE_FORMAT, 2, 2,
+W_PGA(Dmic1, PIPELINE_FORMAT, 2, 2,
 	 capture_pga_conf, LIST(`		',
-		"CONTROL_NAME"))
+		"Capture Volume"))
 
 # "EQ 0" has 2 sink period and x source periods
 W_EQ_IIR(0, PIPELINE_FORMAT, 2, DAI_PERIODS, LIST(`		', "EQIIR_C16"))
@@ -92,13 +89,10 @@ W_BUFFER(2, COMP_BUFFER_SIZE(DAI_PERIODS,
 P_GRAPH(pipe-pass-capture-PIPELINE_ID, PIPELINE_ID,
 	LIST(`		',
 	`dapm(N_PCMC(PCM_ID), N_BUFFER(0))',
-	`dapm(N_BUFFER(0), PGA_NAME)',
-	`dapm(PGA_NAME, N_BUFFER(1))',
+	`dapm(N_BUFFER(0), Dmic1)',
+	`dapm(Dmic1, N_BUFFER(1))',
 	`dapm(N_BUFFER(1), N_EQ_IIR(0))',
 	`dapm(N_EQ_IIR(0), N_BUFFER(2))'))
-
-undefine(`CONTROL_NAME')
-undefine(`PGA_NAME')
 
 #
 # Pipeline Source and Sinks

--- a/tools/topology/sof/pipe-eq-capture.m4
+++ b/tools/topology/sof/pipe-eq-capture.m4
@@ -15,17 +15,12 @@ include(`bytecontrol.m4')
 include(`mixercontrol.m4')
 include(`eq_iir.m4')
 
-define(`PGA_NAME', Dmic0)
-define(`CONTROL_NAME_VOLUME', Capture Volume)
-define(`CONTROL_NAME_SWITCH', Capture Switch)
-define(`CONTROL_NAME', `CONTROL_NAME_VOLUME')
-
 #
 # Controls
 #
 
 # Volume Mixer control with max value of 32
-C_CONTROLMIXER(Master Capture Volume, PIPELINE_ID,
+C_CONTROLMIXER(Capture Volume,
 	CONTROLMIXER_OPS(volsw,
 		256 binds the mixer control to volume get/put handlers,
 		256, 256),
@@ -35,10 +30,8 @@ C_CONTROLMIXER(Master Capture Volume, PIPELINE_ID,
 	Channel register and shift for Front Left/Right,
 	LIST(`	', KCONTROL_CHANNEL(FL, 1, 0), KCONTROL_CHANNEL(FR, 1, 1)))
 
-define(`CONTROL_NAME', `CONTROL_NAME_SWITCH')
-
 # Switch type Mixer Control with max value of 1
-C_CONTROLMIXER(Master Capture Switch, PIPELINE_ID,
+C_CONTROLMIXER(Capture Switch,
 	CONTROLMIXER_OPS(volsw, 259 binds the mixer control to switch get/put handlers, 259, 259),
 	CONTROLMIXER_MAX(max 1 indicates switch type control, 1),
 	false,
@@ -79,9 +72,9 @@ C_CONTROLBYTES(EQIIR_C48, PIPELINE_ID,
 W_PCM_CAPTURE(PCM_ID, Highpass Capture, 0, 2)
 
 # "Volume" has 2 source and 2 sink periods
-W_PGA(0, PIPELINE_FORMAT, 2, 2,
+W_PGA(Dmic0, PIPELINE_FORMAT, 2, 2,
 	 capture_pga_conf, LIST(`		',
-		"CONTROL_NAME_VOLUME", "CONTROL_NAME_SWITCH"))
+		"Capture Volume", "Capture Switch"))
 
 # "EQ 0" has 2 sink period and x source periods
 W_EQ_IIR(0, PIPELINE_FORMAT, 2, DAI_PERIODS, LIST(`		', "EQIIR_C48"))
@@ -107,15 +100,10 @@ W_BUFFER(2, COMP_BUFFER_SIZE(DAI_PERIODS,
 P_GRAPH(pipe-pass-capture-PIPELINE_ID, PIPELINE_ID,
 	LIST(`		',
 	`dapm(N_PCMC(PCM_ID), N_BUFFER(0))',
-	`dapm(N_BUFFER(0), PGA_NAME)',
-	`dapm(PGA_NAME, N_BUFFER(1))',
+	`dapm(N_BUFFER(0), Dmic0)',
+	`dapm(Dmic0, N_BUFFER(1))',
 	`dapm(N_BUFFER(1), N_EQ_IIR(0))',
 	`dapm(N_EQ_IIR(0), N_BUFFER(2))'))
-
-undefine(`PGA_NAME')
-undefine(`CONTROL_NAME')
-undefine(`CONTROL_NAME_VOLUME')
-undefine(`CONTROL_NAME_SWITCH')
 
 #
 # Pipeline Source and Sinks

--- a/tools/topology/sof/pipe-eq-fir-volume-playback.m4
+++ b/tools/topology/sof/pipe-eq-fir-volume-playback.m4
@@ -19,7 +19,7 @@ include(`eq_fir.m4')
 # Controls
 #
 # Volume Mixer control with max value of 32
-C_CONTROLMIXER(Master Playback Volume, PIPELINE_ID,
+C_CONTROLMIXER(N_CONTROLMIXER(Master Playback Volume),
 	CONTROLMIXER_OPS(volsw, 256 binds the mixer control to volume get/put handlers, 256, 256),
 	CONTROLMIXER_MAX(, 32),
 	false,
@@ -58,7 +58,7 @@ C_CONTROLBYTES(EQFIR, PIPELINE_ID,
 W_PCM_PLAYBACK(PCM_ID, Passthrough Playback, 2, 0)
 
 # "Volume" has 2 source and x sink periods
-W_PGA(0, PIPELINE_FORMAT, DAI_PERIODS, 2, playback_pga_conf, LIST(`		', "PIPELINE_ID Master Playback Volume"))
+W_PGA(N_PGA(0), PIPELINE_FORMAT, DAI_PERIODS, 2, playback_pga_conf, LIST(`		', "PIPELINE_ID Master Playback Volume"))
 
 # "EQ 0" has 2 sink period and 2 source periods
 W_EQ_FIR(0, PIPELINE_FORMAT, 2, 2, LIST(`		', "EQFIR"))

--- a/tools/topology/sof/pipe-eq-iir-volume-playback.m4
+++ b/tools/topology/sof/pipe-eq-iir-volume-playback.m4
@@ -19,7 +19,7 @@ include(`eq_iir.m4')
 # Controls
 #
 # Volume Mixer control with max value of 32
-C_CONTROLMIXER(Master Playback Volume, PIPELINE_ID,
+C_CONTROLMIXER(N_CONTROLMIXER(Master Playback Volume),
 	CONTROLMIXER_OPS(volsw, 256 binds the mixer control to volume get/put handlers, 256, 256),
 	CONTROLMIXER_MAX(, 32),
 	false,
@@ -58,7 +58,7 @@ C_CONTROLBYTES(EQIIR, PIPELINE_ID,
 W_PCM_PLAYBACK(PCM_ID, Passthrough Playback, 2, 0)
 
 # "Volume" has 2 source and x sink periods
-W_PGA(0, PIPELINE_FORMAT, DAI_PERIODS, 2, playback_pga_conf, LIST(`		', "PIPELINE_ID Master Playback Volume"))
+W_PGA(N_PGA(0), PIPELINE_FORMAT, DAI_PERIODS, 2, playback_pga_conf, LIST(`		', "PIPELINE_ID Master Playback Volume"))
 
 # "EQ 0" has 2 sink period and 2 source periods
 W_EQ_IIR(0, PIPELINE_FORMAT, 2, 2, LIST(`		', "EQIIR"))

--- a/tools/topology/sof/pipe-eq-volume-playback.m4
+++ b/tools/topology/sof/pipe-eq-volume-playback.m4
@@ -20,7 +20,7 @@ include(`eq_fir.m4')
 # Controls
 #
 # Volume Mixer control with max value of 32
-C_CONTROLMIXER(Master Playback Volume, PIPELINE_ID,
+C_CONTROLMIXER(N_CONTROLMIXER(Master Playback Volume),
 	CONTROLMIXER_OPS(volsw, 256 binds the mixer control to volume get/put handlers, 256, 256),
 	CONTROLMIXER_MAX(, 32),
 	false,
@@ -72,7 +72,7 @@ C_CONTROLBYTES(EQFIR, PIPELINE_ID,
 W_PCM_PLAYBACK(PCM_ID, Passthrough Playback, 2, 0)
 
 # "Volume" has 2 source and x sink periods
-W_PGA(0, PIPELINE_FORMAT, DAI_PERIODS, 2, playback_pga_conf, LIST(`		', "PIPELINE_ID Master Playback Volume"))
+W_PGA(N_PGA(0), PIPELINE_FORMAT, DAI_PERIODS, 2, playback_pga_conf, LIST(`		', "PIPELINE_ID Master Playback Volume"))
 
 # "EQ 0" has 2 sink period and 2 source periods
 W_EQ_IIR(0, PIPELINE_FORMAT, 2, 2, LIST(`		', "EQIIR"))

--- a/tools/topology/sof/pipe-highpass-capture.m4
+++ b/tools/topology/sof/pipe-highpass-capture.m4
@@ -19,7 +19,7 @@ include(`eq_iir.m4')
 # Controls
 #
 # Volume Mixer control with max value of 32
-C_CONTROLMIXER(Master Capture Volume, PIPELINE_ID,
+C_CONTROLMIXER(N_CONTROLMIXER(Master Capture Volume),
 	CONTROLMIXER_OPS(volsw,
 		256 binds the mixer control to volume get/put handlers,
 		256, 256),
@@ -70,7 +70,7 @@ C_CONTROLBYTES(MY_EQIIR_BYTES, PIPELINE_ID,
 W_PCM_CAPTURE(PCM_ID, Highpass Capture, 0, 2)
 
 # "Volume" has 2 sink and 2 source periods
-W_PGA(0, PIPELINE_FORMAT, 2, DAI_PERIODS, MY_PGA_CONF,
+W_PGA(N_PGA(0), PIPELINE_FORMAT, 2, DAI_PERIODS, MY_PGA_CONF,
 	LIST(`		', "PIPELINE_ID Master Capture Volume"))
 
 # "EQ_IIR 0" has 2 sink and x source periods

--- a/tools/topology/sof/pipe-low-latency-capture.m4
+++ b/tools/topology/sof/pipe-low-latency-capture.m4
@@ -15,7 +15,7 @@ include(`mixercontrol.m4')
 # Controls
 #
 # Volume Mixer control with max value of 32
-C_CONTROLMIXER(PCM PCM_ID Capture Volume, PIPELINE_ID,
+C_CONTROLMIXER(N_CONTROLMIXER(PCM PCM_ID Capture Volume),
 	CONTROLMIXER_OPS(volsw, 256 binds the mixer control to volume get/put handlers, 256, 256),
 	CONTROLMIXER_MAX(, 40),
 	false,
@@ -42,7 +42,7 @@ W_DATA(capture_pga_conf, capture_pga_tokens)
 W_PCM_CAPTURE(PCM_ID, Low Latency Capture, 0, 2)
 
 # "Capture Volume" has 2 sink and x source periods for host and DAI ping-pong
-W_PGA(0, PIPELINE_FORMAT, 2, DAI_PERIODS, capture_pga_conf, LIST(`		', "PIPELINE_ID PCM PCM_ID Capture Volume"))
+W_PGA(N_PGA(0), PIPELINE_FORMAT, 2, DAI_PERIODS, capture_pga_conf, LIST(`		', "PIPELINE_ID PCM PCM_ID Capture Volume"))
 
 # Capture Buffers
 W_BUFFER(0, COMP_BUFFER_SIZE(DAI_PERIODS,

--- a/tools/topology/sof/pipe-low-latency-playback.m4
+++ b/tools/topology/sof/pipe-low-latency-playback.m4
@@ -31,7 +31,7 @@ include(`mixercontrol.m4')
 # Controls
 #
 # Volume Mixer control with max value of 32
-C_CONTROLMIXER(PCM PCM_ID Playback Volume, PIPELINE_ID,
+C_CONTROLMIXER(N_CONTROLMIXER(PCM PCM_ID Playback Volume),
 	CONTROLMIXER_OPS(volsw, 256 binds the mixer control to volume get/put handlers, 256, 256),
 	CONTROLMIXER_MAX(, 32),
 	false,
@@ -40,7 +40,7 @@ C_CONTROLMIXER(PCM PCM_ID Playback Volume, PIPELINE_ID,
 	LIST(KCONTROL_CHANNEL(FL, 0, 0), KCONTROL_CHANNEL(FR, 0, 1)))
 
 # Volume Mixer control with max value of 32
-C_CONTROLMIXER(Master Playback Volume, PIPELINE_ID,
+C_CONTROLMIXER(N_CONTROLMIXER(Master Playback Volume),
 	CONTROLMIXER_OPS(volsw, 256 binds the mixer control to volume get/put handlers, 256, 256),
 	CONTROLMIXER_MAX(, 32),
 	false,
@@ -67,10 +67,10 @@ W_DATA(playback_pga_conf, playback_pga_tokens)
 W_PCM_PLAYBACK(PCM_ID, Low Latency Playback, 2, 0)
 
 # "Playback Volume" has 2 sink periods and 2 source periods for host ping-pong
-W_PGA(0, PIPELINE_FORMAT, 2, 2, playback_pga_conf, LIST(`		', "PIPELINE_ID PCM PCM_ID Playback Volume"))
+W_PGA(N_PGA(0), PIPELINE_FORMAT, 2, 2, playback_pga_conf, LIST(`		', "PIPELINE_ID PCM PCM_ID Playback Volume"))
 
 # "Master Playback Volume" has 2 source and x sink periods for DAI ping-pong
-W_PGA(1, PIPELINE_FORMAT, DAI_PERIODS, 2, playback_pga_conf, LIST(`		', "PIPELINE_ID Master Playback Volume"))
+W_PGA(N_PGA(1), PIPELINE_FORMAT, DAI_PERIODS, 2, playback_pga_conf, LIST(`		', "PIPELINE_ID Master Playback Volume"))
 
 # Mixer 0 has 2 sink and source periods.
 W_MIXER(0, PIPELINE_FORMAT, 2, 2)

--- a/tools/topology/sof/pipe-pcm-media.m4
+++ b/tools/topology/sof/pipe-pcm-media.m4
@@ -20,7 +20,7 @@ include(`pcm.m4')
 # Controls
 #
 # Volume Mixer control with max value of 32
-C_CONTROLMIXER(PCM PCM_ID Playback Volume, PIPELINE_ID,
+C_CONTROLMIXER(N_CONTROLMIXER(PCM PCM_ID Playback Volume),
 	CONTROLMIXER_OPS(volsw, 256 binds the mixer control to volume get/put handlers, 256, 256),
 	CONTROLMIXER_MAX(, 32),
 	false,
@@ -55,7 +55,7 @@ W_DATA(playback_pga_conf, playback_pga_tokens)
 W_PCM_PLAYBACK(PCM_ID, Media Playback, 2, 0)
 
 # "Playback Volume" has 2 sink period and 2 source periods for host ping-pong
-W_PGA(0, PIPELINE_FORMAT, 2, 2, playback_pga_conf, LIST(`		', "PIPELINE_ID PCM PCM_ID Playback Volume"))
+W_PGA(N_PGA(0), PIPELINE_FORMAT, 2, 2, playback_pga_conf, LIST(`		', "PIPELINE_ID PCM PCM_ID Playback Volume"))
 
 # "SRC 0" has 2 sink and source periods.
 W_SRC(0, PIPELINE_FORMAT, 2, 2, media_src_conf)

--- a/tools/topology/sof/pipe-src-volume-capture.m4
+++ b/tools/topology/sof/pipe-src-volume-capture.m4
@@ -19,7 +19,7 @@ include(`pga.m4')
 #
 
 # Volume Mixer control with max value of 32
-C_CONTROLMIXER(Master Capture Volume, PIPELINE_ID,
+C_CONTROLMIXER(N_CONTROLMIXER(Master Capture Volume),
 	CONTROLMIXER_OPS(volsw,
 		256 binds the mixer control to volume get/put handlers,
 		256, 256),
@@ -63,7 +63,7 @@ W_DATA(MY_SRC_CONF, MY_SRC_TOKENS)
 W_SRC(0, PIPELINE_FORMAT, 3, 3, MY_SRC_CONF)
 
 # "Volume" has x source and 3 sink periods
-W_PGA(0, PIPELINE_FORMAT, DAI_PERIODS, 3, MY_PGA_CONF,
+W_PGA(N_PGA(0), PIPELINE_FORMAT, DAI_PERIODS, 3, MY_PGA_CONF,
 	LIST(`		', "PIPELINE_ID Master Capture Volume"))
 
 # Capture Buffers

--- a/tools/topology/sof/pipe-src-volume-playback.m4
+++ b/tools/topology/sof/pipe-src-volume-playback.m4
@@ -18,7 +18,7 @@ include(`pipeline.m4')
 # Controls
 #
 # Volume Mixer control with max value of 32
-C_CONTROLMIXER(Master Playback Volume, PIPELINE_ID,
+C_CONTROLMIXER(N_CONTROLMIXER(Master Playback Volume),
 	CONTROLMIXER_OPS(volsw, 256 binds the mixer control to volume get/put handlers, 256, 256),
 	CONTROLMIXER_MAX(, 32),
 	false,
@@ -57,7 +57,7 @@ LIST(`		', `SOF_TKN_VOLUME_RAMP_STEP_TYPE	"0"'
 W_DATA(playback_pga_conf, playback_pga_tokens)
 
 # "Volume" has 3 source and x sink periods
-W_PGA(0, PIPELINE_FORMAT, DAI_PERIODS, 3, playback_pga_conf, LIST(`		', "PIPELINE_ID Master Playback Volume"))
+W_PGA(N_PGA(0), PIPELINE_FORMAT, DAI_PERIODS, 3, playback_pga_conf, LIST(`		', "PIPELINE_ID Master Playback Volume"))
 
 # Playback Buffers
 W_BUFFER(0, COMP_BUFFER_SIZE(3,

--- a/tools/topology/sof/pipe-tone.m4
+++ b/tools/topology/sof/pipe-tone.m4
@@ -20,7 +20,7 @@ include(`pipeline.m4')
 #
 
 # Volume Mixer control with max value of 32
-C_CONTROLMIXER(Tone Volume, PIPELINE_ID,
+C_CONTROLMIXER(N_CONTROLMIXER(Tone Volume),
 	CONTROLMIXER_OPS(volsw, 256 binds the mixer control to volume get/put handlers, 256, 256),
 	CONTROLMIXER_MAX(, 32),
 	false,
@@ -29,7 +29,7 @@ C_CONTROLMIXER(Tone Volume, PIPELINE_ID,
 	LIST(`	', KCONTROL_CHANNEL(FL, 1, 0), KCONTROL_CHANNEL(FR, 1, 1)))
 
 # Switch type Mixer Control with max value of 1
-C_CONTROLMIXER(Tone Switch, PIPELINE_ID,
+C_CONTROLMIXER(N_CONTROLMIXER(Tone Switch),
 	CONTROLMIXER_OPS(volsw, 259 binds the mixer control to switch get/put handlers, 259, 259),
 	CONTROLMIXER_MAX(max 1 indicates switch type control, 1),
 	false,
@@ -55,7 +55,7 @@ W_DATA(playback_pga_conf, playback_pga_tokens)
 W_TONE(0, PIPELINE_FORMAT, 2, 0, LIST(`		', "PIPELINE_ID Tone Switch"))
 
 # "Tone Volume" has 2 sink period and 2 source periods
-W_PGA(0, PIPELINE_FORMAT, 2, 2, playback_pga_conf, LIST(`		', "PIPELINE_ID Tone Volume"))
+W_PGA(N_PGA(0), PIPELINE_FORMAT, 2, 2, playback_pga_conf, LIST(`		', "PIPELINE_ID Tone Volume"))
 
 # Low Latency Buffers
 W_BUFFER(0,COMP_BUFFER_SIZE(2,

--- a/tools/topology/sof/pipe-volume-capture-16khz.m4
+++ b/tools/topology/sof/pipe-volume-capture-16khz.m4
@@ -20,7 +20,7 @@ include(`pipeline.m4')
 # Controls
 #
 # Volume Mixer control with max value of 32
-C_CONTROLMIXER(Master Capture Volume, PIPELINE_ID,
+C_CONTROLMIXER(N_CONTROLMIXER(Master Capture Volume),
 	CONTROLMIXER_OPS(volsw, 256 binds the mixer control to volume get/put handlers, 256, 256),
 	CONTROLMIXER_MAX(, 80),
 	false,
@@ -47,7 +47,7 @@ W_DATA(playback_pga_conf, playback_pga_tokens)
 W_PCM_CAPTURE(PCM_ID, Passthrough Capture, 0, 2)
 
 # "Volume" has x source and 2 sink periods
-W_PGA(0, PIPELINE_FORMAT, 2, DAI_PERIODS, playback_pga_conf, LIST(`		', "PIPELINE_ID Master Capture Volume"))
+W_PGA(N_PGA(0), PIPELINE_FORMAT, 2, DAI_PERIODS, playback_pga_conf, LIST(`		', "PIPELINE_ID Master Capture Volume"))
 
 # Capture Buffers
 W_BUFFER(0, COMP_BUFFER_SIZE(2,

--- a/tools/topology/sof/pipe-volume-capture-sched.m4
+++ b/tools/topology/sof/pipe-volume-capture-sched.m4
@@ -17,7 +17,7 @@ include(`pipeline.m4')
 # Controls
 #
 # Volume Mixer control with max value of 32
-C_CONTROLMIXER(Master Capture Volume, PIPELINE_ID,
+C_CONTROLMIXER(N_CONTROLMIXER(Master Capture Volume),
 	CONTROLMIXER_OPS(volsw, 256 binds the mixer control to volume get/put handlers, 256, 256),
 	CONTROLMIXER_MAX(, 80),
 	false,
@@ -34,7 +34,7 @@ C_CONTROLMIXER(Master Capture Volume, PIPELINE_ID,
 W_PCM_CAPTURE(PCM_ID, Passthrough Capture, 0, 2)
 
 # "Volume" has x source and 2 sink periods
-W_PGA(0, PIPELINE_FORMAT, 2, DAI_PERIODS, LIST(`		', "PIPELINE_ID Master Capture Volume"))
+W_PGA(N_PGA(0), PIPELINE_FORMAT, 2, DAI_PERIODS, LIST(`		', "PIPELINE_ID Master Capture Volume"))
 
 # Capture Buffers
 W_BUFFER(0, COMP_BUFFER_SIZE(2,

--- a/tools/topology/sof/pipe-volume-capture.m4
+++ b/tools/topology/sof/pipe-volume-capture.m4
@@ -17,7 +17,7 @@ include(`pipeline.m4')
 # Controls
 #
 # Volume Mixer control with max value of 32
-C_CONTROLMIXER(Master Capture Volume, PIPELINE_ID,
+C_CONTROLMIXER(N_CONTROLMIXER(Master Capture Volume),
 	CONTROLMIXER_OPS(volsw, 256 binds the mixer control to volume get/put handlers, 256, 256),
 	CONTROLMIXER_MAX(, 80),
 	false,
@@ -44,7 +44,7 @@ W_DATA(capture_pga_conf, capture_pga_tokens)
 W_PCM_CAPTURE(PCM_ID, Passthrough Capture, 0, 2)
 
 # "Volume" has x source and 2 sink periods
-W_PGA(0, PIPELINE_FORMAT, 2, DAI_PERIODS, capture_pga_conf, LIST(`		', "PIPELINE_ID Master Capture Volume"))
+W_PGA(N_PGA(0), PIPELINE_FORMAT, 2, DAI_PERIODS, capture_pga_conf, LIST(`		', "PIPELINE_ID Master Capture Volume"))
 
 # Capture Buffers
 W_BUFFER(0, COMP_BUFFER_SIZE(2,

--- a/tools/topology/sof/pipe-volume-demux-playback.m4
+++ b/tools/topology/sof/pipe-volume-demux-playback.m4
@@ -35,7 +35,7 @@ C_CONTROLBYTES(DEMUX, PIPELINE_ID,
 	DEMUX_priv)
 
 # Volume Mixer control with max value of 32
-C_CONTROLMIXER(Master Playback Volume, PIPELINE_ID,
+C_CONTROLMIXER(N_CONTROLMIXER(Master Playback Volume),
 	CONTROLMIXER_OPS(volsw, 256 binds the mixer control to volume get/put handlers, 256, 256),
 	CONTROLMIXER_MAX(, 32),
 	false,
@@ -62,7 +62,7 @@ W_DATA(playback_pga_conf, playback_pga_tokens)
 W_PCM_PLAYBACK(PCM_ID, Low Latency Playback, 2, 0)
 
 # "Master Playback Volume" has 2 source and x sink periods for DAI ping-pong
-W_PGA(1, PIPELINE_FORMAT, DAI_PERIODS, 2, playback_pga_conf, LIST(`		', "PIPELINE_ID Master Playback Volume"))
+W_PGA(N_PGA(1), PIPELINE_FORMAT, DAI_PERIODS, 2, playback_pga_conf, LIST(`		', "PIPELINE_ID Master Playback Volume"))
 
 # Mux 0 has 2 sink and source periods.
 W_MUXDEMUX(0, 1, PIPELINE_FORMAT, 2, 2, LIST(`         ', "DEMUX"))

--- a/tools/topology/sof/pipe-volume-playback.m4
+++ b/tools/topology/sof/pipe-volume-playback.m4
@@ -17,7 +17,7 @@ include(`pipeline.m4')
 # Controls
 #
 # Volume Mixer control with max value of 32
-C_CONTROLMIXER(Master Playback Volume, PIPELINE_ID,
+C_CONTROLMIXER(N_CONTROLMIXER(Master Playback Volume),
 	CONTROLMIXER_OPS(volsw, 256 binds the mixer control to volume get/put handlers, 256, 256),
 	CONTROLMIXER_MAX(, 32),
 	false,
@@ -43,9 +43,8 @@ W_DATA(playback_pga_conf, playback_pga_tokens)
 # with 2 sink and 0 source periods
 W_PCM_PLAYBACK(PCM_ID, Passthrough Playback, 2, 0)
 
-
 # "Volume" has 2 source and x sink periods
-W_PGA(0, PIPELINE_FORMAT, DAI_PERIODS, 2, playback_pga_conf, LIST(`		', "PIPELINE_ID Master Playback Volume"))
+W_PGA(N_PGA(0), PIPELINE_FORMAT, DAI_PERIODS, 2, playback_pga_conf, LIST(`		', "PIPELINE_ID Master Playback Volume"))
 
 # Playback Buffers
 W_BUFFER(0, COMP_BUFFER_SIZE(2,


### PR DESCRIPTION
Dmic volume and switch naming was hardcoded into capture eq pipelines,
which introduced problems when creating several instances of those
pipelines. So move the naming defines up 1 level to the topologies
using those pipelines.

Signed-off-by: Jaska Uimonen <jaska.uimonen@intel.com>