### PR TITLE
clk: platform agnostic clocks

### DIFF
--- a/src/drivers/intel/cavs/ssp.c
+++ b/src/drivers/intel/cavs/ssp.c
@@ -387,7 +387,7 @@ static int ssp_set_config(struct dai *dai,
 	}
 
 	if (clk_index >= 0) {
-		mdivc |= MCDSS(ssp_freq[clk_index].enc);
+		mdivc |= MCDSS(ssp_freq_sources[clk_index]);
 		mdivr_val = ssp_freq[clk_index].freq / config->ssp.mclk_rate;
 	} else {
 		trace_ssp_error("ssp_set_config() error: MCLK %d",
@@ -408,13 +408,13 @@ static int ssp_set_config(struct dai *dai,
 	}
 
 	if (clk_index >= 0) {
-		mdivc |= MNDSS(ssp_freq[clk_index].enc);
+		mdivc |= MNDSS(ssp_freq_sources[clk_index]);
 		mdiv = ssp_freq[clk_index].freq / config->ssp.bclk_rate;
 
 		/* select M/N output for bclk in case of Audio Cardinal
 		 * or PLL Fixed clock.
 		 */
-		if (ssp_freq[clk_index].enc != CLOCK_SSP_XTAL_OSCILLATOR)
+		if (ssp_freq_sources[clk_index] != SSP_CLOCK_XTAL_OSCILLATOR)
 			sscr0 |= SSCR0_ECS;
 	} else {
 		/* check if we can get target BCLK with M/N */
@@ -435,7 +435,7 @@ static int ssp_set_config(struct dai *dai,
 
 		trace_ssp("ssp_set_config(), M = %d, N = %d", i2s_m, i2s_n);
 
-		mdivc |= MNDSS(ssp_freq[clk_index].enc);
+		mdivc |= MNDSS(ssp_freq_sources[clk_index]);
 
 		/* M/N requires external clock to be selected */
 		sscr0 |= SSCR0_ECS;

--- a/src/include/sof/drivers/ssp.h
+++ b/src/include/sof/drivers/ssp.h
@@ -9,6 +9,7 @@
 #define __SOF_DRIVERS_SSP_H__
 
 #include <sof/bit.h>
+#include <sof/lib/clk.h>
 #include <sof/lib/dai.h>
 #include <sof/lib/wait.h>
 #include <sof/trace/trace.h>
@@ -18,11 +19,12 @@
 #include <config.h>
 #include <stdint.h>
 
-#define SSP_CLK_AUDIO	0
-#define SSP_CLK_NET_PLL	1
-#define SSP_CLK_EXT	2
-#define SSP_CLK_NET	3
-#define SSP_CLK_DEFAULT        4
+#define SSP_CLOCK_XTAL_OSCILLATOR	0x0
+#define SSP_CLOCK_AUDIO_CARDINAL	0x1
+#define SSP_CLOCK_PLL_FIXED		0x2
+
+extern struct freq_table *ssp_freq;
+extern uint32_t *ssp_freq_sources;
 
 /* SSP register offsets */
 #define SSCR0		0x00

--- a/src/include/sof/lib/clk.h
+++ b/src/include/sof/lib/clk.h
@@ -3,6 +3,7 @@
  * Copyright(c) 2016 Intel Corporation. All rights reserved.
  *
  * Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
+ *         Janusz Jankowski <janusz.jankowski@linux.intel.com>
  */
 
 #ifndef __SOF_LIB_CLK_H__
@@ -16,10 +17,6 @@ struct timer;
 #define CLOCK_NOTIFY_PRE	0
 #define CLOCK_NOTIFY_POST	1
 
-#define CLOCK_SSP_XTAL_OSCILLATOR		0x0
-#define CLOCK_SSP_AUDIO_CARDINAL		0x1
-#define CLOCK_SSP_PLL_FIXED			0x2
-
 struct clock_notify_data {
 	uint32_t old_freq;
 	uint32_t old_ticks_per_msec;
@@ -30,12 +27,18 @@ struct clock_notify_data {
 struct freq_table {
 	uint32_t freq;
 	uint32_t ticks_per_msec;
-	uint32_t enc;
 };
 
-extern struct freq_table *cpu_freq;
+struct clock_info {
+	uint32_t freqs_num;
+	struct freq_table *freqs;
+	uint32_t default_freq_idx;
+	uint32_t notification_id;
+	uint32_t notification_mask;
+	int (*set_freq)(int clock, int freq_idx);
+};
 
-extern struct freq_table *ssp_freq;
+extern struct clock_info *clocks;
 
 uint32_t clock_get_freq(int clock);
 

--- a/src/platform/apollolake/lib/clk.c
+++ b/src/platform/apollolake/lib/clk.c
@@ -3,14 +3,22 @@
 // Copyright(c) 2019 Intel Corporation. All rights reserved.
 //
 // Author: Tomasz Lauda <tomasz.lauda@linux.intel.com>
+//         Janusz Jankowski <janusz.jankowski@linux.intel.com>
 
 #include <sof/common.h>
+#include <sof/drivers/ssp.h>
 #include <sof/lib/clk.h>
 
 static struct freq_table platform_cpu_freq[] = {
-	{ 100000000, 100000, 0x3 },
-	{ 200000000, 200000, 0x1 },
-	{ CLK_MAX_CPU_HZ, 400000, 0x0 }, /* the default one */
+	{ 100000000, 100000 },
+	{ 200000000, 200000 },
+	{ CLK_MAX_CPU_HZ, 400000 },
+};
+
+uint32_t cpu_freq_enc[] = {
+	0x3,
+	0x1,
+	0x0,
 };
 
 STATIC_ASSERT(NUM_CPU_FREQ == ARRAY_SIZE(platform_cpu_freq),
@@ -22,12 +30,19 @@ struct freq_table *cpu_freq = platform_cpu_freq;
  * (regarding to .freq field)
  */
 static struct freq_table platform_ssp_freq[] = {
-	{ 19200000, 19200, CLOCK_SSP_XTAL_OSCILLATOR }, /* the default one */
-	{ 24576000, 24576, CLOCK_SSP_AUDIO_CARDINAL },
-	{ 96000000, 96000, CLOCK_SSP_PLL_FIXED },
+	{ 19200000, 19200 },
+	{ 24576000, 24576 },
+	{ 96000000, 96000 },
+};
+
+static uint32_t platform_ssp_freq_sources[] = {
+	SSP_CLOCK_XTAL_OSCILLATOR,
+	SSP_CLOCK_AUDIO_CARDINAL,
+	SSP_CLOCK_PLL_FIXED,
 };
 
 STATIC_ASSERT(NUM_SSP_FREQ == ARRAY_SIZE(platform_ssp_freq),
 	      invalid_number_of_ssp_frequencies);
 
 struct freq_table *ssp_freq = platform_ssp_freq;
+uint32_t *ssp_freq_sources = platform_ssp_freq_sources;

--- a/src/platform/baytrail/include/platform/lib/clk.h
+++ b/src/platform/baytrail/include/platform/lib/clk.h
@@ -34,22 +34,6 @@
 #define NUM_CPU_FREQ	8
 #define NUM_SSP_FREQ	2
 
-static inline int clock_platform_set_cpu_freq(uint32_t cpu_freq_enc)
-{
-	/* set CPU frequency request for CCU */
-	io_reg_update_bits(SHIM_BASE + SHIM_FR_LAT_REQ, SHIM_FR_LAT_CLK_MASK,
-			   cpu_freq_enc);
-
-	/* send freq request to SC */
-	return ipc_pmc_send_msg(PMC_SET_LPECLK);
-}
-
-static inline int clock_platform_set_ssp_freq(uint32_t ssp_freq_enc)
-{
-	/* send SSP freq request to SC */
-	return ipc_pmc_send_msg(ssp_freq_enc);
-}
-
 #endif /* __PLATFORM_LIB_CLK_H__ */
 
 #else

--- a/src/platform/baytrail/lib/clk.c
+++ b/src/platform/baytrail/lib/clk.c
@@ -3,34 +3,48 @@
 // Copyright(c) 2019 Intel Corporation. All rights reserved.
 //
 // Author: Tomasz Lauda <tomasz.lauda@linux.intel.com>
+//         Janusz Jankowski <janusz.jankowski@linux.intel.com>
 
 #include <sof/common.h>
+#include <sof/drivers/ssp.h>
 #include <sof/lib/clk.h>
+#include <sof/lib/notifier.h>
 #include <config.h>
 
 #if CONFIG_BAYTRAIL
 static struct freq_table platform_cpu_freq[] = {
-	{ 25000000, 25000, 0x0 },
-	{ 25000000, 25000, 0x1 },
-	{ 50000000, 50000, 0x2 },
-	{ 50000000, 50000, 0x3 }, /* default */
-	{ 100000000, 100000, 0x4 },
-	{ 200000000, 200000, 0x5 },
-	{ 267000000, 267000, 0x6 },
-	{ 343000000, 343000, 0x7 },
+	{ 25000000, 25000 },
+	{ 25000000, 25000 },
+	{ 50000000, 50000 },
+	{ 50000000, 50000 }, /* default */
+	{ 100000000, 100000 },
+	{ 200000000, 200000 },
+	{ 267000000, 267000 },
+	{ 343000000, 343000 },
 };
 #elif CONFIG_CHERRYTRAIL
 static struct freq_table platform_cpu_freq[] = {
-	{ 19200000, 19200, 0x0 },
-	{ 19200000, 19200, 0x1 },
-	{ 38400000, 38400, 0x2 },
-	{ 50000000, 50000, 0x3 }, /* default */
-	{ 100000000, 100000, 0x4 },
-	{ 200000000, 200000, 0x5 },
-	{ 267000000, 267000, 0x6 },
-	{ 343000000, 343000, 0x7 },
+	{ 19200000, 19200 },
+	{ 19200000, 19200 },
+	{ 38400000, 38400 },
+	{ 50000000, 50000 }, /* default */
+	{ 100000000, 100000 },
+	{ 200000000, 200000 },
+	{ 267000000, 267000 },
+	{ 343000000, 343000 },
 };
 #endif
+
+static uint32_t cpu_freq_enc[] = {
+	0x0,
+	0x1,
+	0x2,
+	0x3,
+	0x4,
+	0x5,
+	0x6,
+	0x7,
+};
 
 STATIC_ASSERT(NUM_CPU_FREQ == ARRAY_SIZE(platform_cpu_freq),
 	      invalid_number_of_cpu_frequencies);
@@ -38,11 +52,59 @@ STATIC_ASSERT(NUM_CPU_FREQ == ARRAY_SIZE(platform_cpu_freq),
 struct freq_table *cpu_freq = platform_cpu_freq;
 
 static struct freq_table platform_ssp_freq[] = {
-	{ 19200000, 19200, PMC_SET_SSP_19M2 }, /* default */
-	{ 25000000, 25000, PMC_SET_SSP_25M },
+	{ 19200000, 19200 }, /* default */
+	{ 25000000, 25000 },
+};
+
+static uint32_t platform_ssp_freq_sources[] = {
+	PMC_SET_SSP_19M2,
+	PMC_SET_SSP_25M,
 };
 
 STATIC_ASSERT(NUM_SSP_FREQ == ARRAY_SIZE(platform_ssp_freq),
 	      invalid_number_of_ssp_frequencies);
 
 struct freq_table *ssp_freq = platform_ssp_freq;
+uint32_t *ssp_freq_sources = platform_ssp_freq_sources;
+
+static inline int clock_platform_set_cpu_freq(int clock, int freq_idx)
+{
+	uint32_t enc = cpu_freq_enc[freq_idx];
+
+	/* set CPU frequency request for CCU */
+	io_reg_update_bits(SHIM_BASE + SHIM_FR_LAT_REQ, SHIM_FR_LAT_CLK_MASK,
+			   enc);
+
+	/* send freq request to SC */
+	return ipc_pmc_send_msg(PMC_SET_LPECLK);
+}
+
+static int clock_platform_set_ssp_freq(int clock, int freq_idx)
+{
+	/* send SSP freq request to SC */
+	return ipc_pmc_send_msg(platform_ssp_freq_sources[freq_idx]);
+}
+
+static struct clock_info platform_clocks_info[] = {
+	{
+		.freqs_num = NUM_CPU_FREQ,
+		.freqs = platform_cpu_freq,
+		.default_freq_idx = CPU_DEFAULT_IDX,
+		.notification_id = NOTIFIER_ID_CPU_FREQ,
+		.notification_mask = NOTIFIER_TARGET_CORE_MASK(0),
+		.set_freq = clock_platform_set_cpu_freq,
+	},
+	{
+		.freqs_num = NUM_SSP_FREQ,
+		.freqs = platform_ssp_freq,
+		.default_freq_idx = SSP_DEFAULT_IDX,
+		.notification_id = NOTIFIER_ID_SSP_FREQ,
+		.notification_mask = NOTIFIER_TARGET_CORE_ALL_MASK,
+		.set_freq = clock_platform_set_ssp_freq,
+	}
+};
+
+STATIC_ASSERT(ARRAY_SIZE(platform_clocks_info) == NUM_CLOCKS,
+	      invalid_number_of_clocks);
+
+struct clock_info *clocks = platform_clocks_info;

--- a/src/platform/cannonlake/lib/clk.c
+++ b/src/platform/cannonlake/lib/clk.c
@@ -3,13 +3,20 @@
 // Copyright(c) 2019 Intel Corporation. All rights reserved.
 //
 // Author: Tomasz Lauda <tomasz.lauda@linux.intel.com>
+//         Janusz Jankowski <janusz.jankowski@linux.intel.com>
 
 #include <sof/common.h>
+#include <sof/drivers/ssp.h>
 #include <sof/lib/clk.h>
 
 static struct freq_table platform_cpu_freq[] = {
-	{ 120000000, 120000, 0x0 },
-	{ CLK_MAX_CPU_HZ, 400000, 0x4 }, /* default */
+	{ 120000000, 120000 },
+	{ CLK_MAX_CPU_HZ, 400000 },
+};
+
+uint32_t cpu_freq_enc[] = {
+	0x0,
+	0x4,
 };
 
 STATIC_ASSERT(NUM_CPU_FREQ == ARRAY_SIZE(platform_cpu_freq),
@@ -21,12 +28,17 @@ struct freq_table *cpu_freq = platform_cpu_freq;
  * (regarding to .freq field)
  */
 static struct freq_table platform_ssp_freq[] = {
-	{ 24000000, 24000, CLOCK_SSP_XTAL_OSCILLATOR }, /* default */
-	{ 96000000, 96000, CLOCK_SSP_PLL_FIXED },
+	{ 24000000, 24000 },
+	{ 96000000, 96000 },
+};
+
+static uint32_t platform_ssp_freq_sources[] = {
+	SSP_CLOCK_XTAL_OSCILLATOR,
+	SSP_CLOCK_PLL_FIXED,
 };
 
 STATIC_ASSERT(NUM_SSP_FREQ == ARRAY_SIZE(platform_ssp_freq),
 	      invalid_number_of_ssp_frequencies);
 
-
 struct freq_table *ssp_freq = platform_ssp_freq;
+uint32_t *ssp_freq_sources = platform_ssp_freq_sources;

--- a/src/platform/haswell/include/platform/lib/clk.h
+++ b/src/platform/haswell/include/platform/lib/clk.h
@@ -28,20 +28,6 @@
 #define NUM_CPU_FREQ	6
 #define NUM_SSP_FREQ	1
 
-static inline int clock_platform_set_cpu_freq(uint32_t cpu_freq_enc)
-{
-	/* set CPU frequency request for CCU */
-	io_reg_update_bits(SHIM_BASE + SHIM_CSR, SHIM_CSR_DCS_MASK,
-			   cpu_freq_enc);
-
-	return 0;
-}
-
-static inline int clock_platform_set_ssp_freq(uint32_t ssp_freq_enc)
-{
-	return 0;
-}
-
 #endif /* __PLATFORM_LIB_CLK_H__ */
 
 #else

--- a/src/platform/haswell/lib/clk.c
+++ b/src/platform/haswell/lib/clk.c
@@ -3,29 +3,79 @@
 // Copyright(c) 2019 Intel Corporation. All rights reserved.
 //
 // Author: Tomasz Lauda <tomasz.lauda@linux.intel.com>
+//         Janusz Jankowski <janusz.jankowski@linux.intel.com>
 
 #include <sof/common.h>
+#include <sof/drivers/ssp.h>
 #include <sof/lib/clk.h>
+#include <sof/lib/notifier.h>
 
 static struct freq_table platform_cpu_freq[] = {
-	{ 32000000, 32000, 0x6 },
-	{ 80000000, 80000, 0x2 },
-	{ 160000000, 160000, 0x1 },
-	{ 320000000, 320000, 0x4 }, /* default */
-	{ 320000000, 320000, 0x0 },
-	{ 160000000, 160000, 0x5 },
+	{ 32000000, 32000 },
+	{ 80000000, 80000 },
+	{ 160000000, 160000 },
+	{ 320000000, 320000 },
+	{ 320000000, 320000 },
+	{ 160000000, 160000 },
+};
+
+static uint32_t cpu_freq_enc[] = {
+	0x6,
+	0x2,
+	0x1,
+	0x4,
+	0x0,
+	0x5,
 };
 
 STATIC_ASSERT(NUM_CPU_FREQ == ARRAY_SIZE(platform_cpu_freq),
 	      invalid_number_of_cpu_frequencies);
 
-struct freq_table *cpu_freq = platform_cpu_freq;
-
 static struct freq_table platform_ssp_freq[] = {
-	{ 24000000, 24000, 0 }, /* default */
+	{ 24000000, 24000 },
+};
+
+static uint32_t platform_ssp_freq_sources[] = {
+	0,
 };
 
 STATIC_ASSERT(NUM_SSP_FREQ == ARRAY_SIZE(platform_ssp_freq),
 	      invalid_number_of_ssp_frequencies);
 
 struct freq_table *ssp_freq = platform_ssp_freq;
+uint32_t *ssp_freq_sources = platform_ssp_freq_sources;
+
+static int clock_platform_set_cpu_freq(int clock, int freq_idx)
+{
+	uint32_t enc = cpu_freq_enc[freq_idx];
+
+	/* set CPU frequency request for CCU */
+	io_reg_update_bits(SHIM_BASE + SHIM_CSR, SHIM_CSR_DCS_MASK,
+			   enc);
+
+	return 0;
+}
+
+static struct clock_info platform_clocks_info[] = {
+	{
+		.freqs_num = NUM_CPU_FREQ,
+		.freqs = platform_cpu_freq,
+		.default_freq_idx = CPU_DEFAULT_IDX,
+		.notification_id = NOTIFIER_ID_CPU_FREQ,
+		.notification_mask = NOTIFIER_TARGET_CORE_MASK(0),
+		.set_freq = clock_platform_set_cpu_freq,
+	},
+	{
+		.freqs_num = NUM_SSP_FREQ,
+		.freqs = platform_ssp_freq,
+		.default_freq_idx = SSP_DEFAULT_IDX,
+		.notification_id = NOTIFIER_ID_SSP_FREQ,
+		.notification_mask = NOTIFIER_TARGET_CORE_ALL_MASK,
+		.set_freq = NULL,
+	}
+};
+
+STATIC_ASSERT(ARRAY_SIZE(platform_clocks_info) == NUM_CLOCKS,
+	      invalid_number_of_clocks);
+
+struct clock_info *clocks = platform_clocks_info;

--- a/src/platform/icelake/lib/clk.c
+++ b/src/platform/icelake/lib/clk.c
@@ -3,13 +3,20 @@
 // Copyright(c) 2019 Intel Corporation. All rights reserved.
 //
 // Author: Tomasz Lauda <tomasz.lauda@linux.intel.com>
+//         Janusz Jankowski <janusz.jankowski@linux.intel.com>
 
 #include <sof/common.h>
+#include <sof/drivers/ssp.h>
 #include <sof/lib/clk.h>
 
 static struct freq_table platform_cpu_freq[] = {
-	{ 120000000, 120000, 0x0 },
-	{ CLK_MAX_CPU_HZ, 400000, 0x4 }, /* default */
+	{ 120000000, 120000 },
+	{ CLK_MAX_CPU_HZ, 400000 },
+};
+
+uint32_t cpu_freq_enc[] = {
+	0x0,
+	0x4,
 };
 
 STATIC_ASSERT(NUM_CPU_FREQ == ARRAY_SIZE(platform_cpu_freq),
@@ -21,12 +28,19 @@ struct freq_table *cpu_freq = platform_cpu_freq;
  * (regarding to .freq field)
  */
 static struct freq_table platform_ssp_freq[] = {
-	{ 24576000, 24576, CLOCK_SSP_AUDIO_CARDINAL },
-	{ 38400000, 38400, CLOCK_SSP_XTAL_OSCILLATOR }, /* default */
-	{ 96000000, 96000, CLOCK_SSP_PLL_FIXED },
+	{ 24576000, 24576 },
+	{ 38400000, 38400 },
+	{ 96000000, 96000 },
+};
+
+static uint32_t platform_ssp_freq_sources[] = {
+	SSP_CLOCK_AUDIO_CARDINAL,
+	SSP_CLOCK_XTAL_OSCILLATOR,
+	SSP_CLOCK_PLL_FIXED,
 };
 
 STATIC_ASSERT(NUM_SSP_FREQ == ARRAY_SIZE(platform_ssp_freq),
 	      invalid_number_of_ssp_frequencies);
 
 struct freq_table *ssp_freq = platform_ssp_freq;
+uint32_t *ssp_freq_sources = platform_ssp_freq_sources;

--- a/src/platform/imx8/include/platform/lib/clk.h
+++ b/src/platform/imx8/include/platform/lib/clk.h
@@ -26,17 +26,7 @@
 #define NUM_CPU_FREQ	1
 #define NUM_SSP_FREQ	2
 
-static inline int clock_platform_set_cpu_freq(uint32_t cpu_freq_enc)
-{
-	return 0;
-}
-
-/* FIXME: compile out clock_platform_set_ssp_freq */
-static inline int clock_platform_set_ssp_freq(uint32_t ssp_freq_enc)
-{
-	/* we don't even have SSP */
-	return 0;
-}
+void platform_clock_init(void);
 
 #endif /* __PLATFORM_LIB_CLK_H__ */
 

--- a/src/platform/imx8/platform.c
+++ b/src/platform/imx8/platform.c
@@ -144,6 +144,7 @@ int platform_init(struct sof *sof)
 	struct dai *esai;
 
 	platform_interrupt_init();
+	platform_clock_init();
 	clock_init();
 	scheduler_init_edf();
 

--- a/src/platform/intel/cavs/include/cavs/lib/clk.h
+++ b/src/platform/intel/cavs/include/cavs/lib/clk.h
@@ -35,23 +35,10 @@
 /** \brief Total number of clocks */
 #define NUM_CLOCKS	(CLK_SSP + 1)
 
-static inline int clock_platform_set_cpu_freq(uint32_t cpu_freq_enc)
-{
-	/* set CPU frequency request for CCU */
-#if CAVS_VERSION == CAVS_VERSION_1_5
-	io_reg_update_bits(SHIM_BASE + SHIM_CLKCTL, SHIM_CLKCTL_HDCS, 0);
-#endif
-	io_reg_update_bits(SHIM_BASE + SHIM_CLKCTL,
-			   SHIM_CLKCTL_DPCS_MASK(cpu_get_id()),
-			   cpu_freq_enc);
+extern struct freq_table *cpu_freq;
+extern uint32_t cpu_freq_enc[];
 
-	return 0;
-}
-
-static inline int clock_platform_set_ssp_freq(uint32_t ssp_freq_enc)
-{
-	return 0;
-}
+void platform_clock_init(void);
 
 #endif /* __CAVS_LIB_CLK_H__ */
 

--- a/src/platform/intel/cavs/lib/CMakeLists.txt
+++ b/src/platform/intel/cavs/lib/CMakeLists.txt
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 add_local_sources(sof
+	clk.c
 	dai.c
 	dma.c
 	memory.c

--- a/src/platform/intel/cavs/lib/clk.c
+++ b/src/platform/intel/cavs/lib/clk.c
@@ -2,41 +2,31 @@
 //
 // Copyright(c) 2019 Intel Corporation. All rights reserved.
 //
-// Author: Tomasz Lauda <tomasz.lauda@linux.intel.com>
-//         Janusz Jankowski <janusz.jankowski@linux.intel.com>
+// Author: Janusz Jankowski <janusz.jankowski@linux.intel.com>
 
 #include <sof/common.h>
 #include <sof/drivers/ssp.h>
 #include <sof/lib/clk.h>
 #include <sof/lib/notifier.h>
 
-static struct freq_table platform_cpu_freq[] = {
-	{ 666000000, 666000 },
-};
-
-STATIC_ASSERT(NUM_CPU_FREQ == ARRAY_SIZE(platform_cpu_freq),
-	      invalid_number_of_cpu_frequencies);
-
-/* TODO: abstract SSP clk based on platform and remove this from here! */
-static struct freq_table platform_ssp_freq[] = {
-	{ 19200000, 19200 },
-	{ 25000000, 25000 },
-};
-
-uint32_t platform_ssp_freq_sources[] = {
-	19,
-	12,
-};
-
-STATIC_ASSERT(NUM_SSP_FREQ == ARRAY_SIZE(platform_ssp_freq),
-	      invalid_number_of_ssp_frequencies);
-
-struct freq_table *ssp_freq = platform_ssp_freq;
-uint32_t *ssp_freq_sources = platform_ssp_freq_sources;
-
 static struct clock_info platform_clocks_info[NUM_CLOCKS];
 
 struct clock_info *clocks = platform_clocks_info;
+
+static int clock_platform_set_cpu_freq(int clock, int freq_idx)
+{
+	uint32_t enc = cpu_freq_enc[freq_idx];
+
+	/* set CPU frequency request for CCU */
+#if CAVS_VERSION == CAVS_VERSION_1_5
+	io_reg_update_bits(SHIM_BASE + SHIM_CLKCTL, SHIM_CLKCTL_HDCS, 0);
+#endif
+	io_reg_update_bits(SHIM_BASE + SHIM_CLKCTL,
+			   SHIM_CLKCTL_DPCS_MASK(cpu_get_id()),
+			   enc);
+
+	return 0;
+}
 
 void platform_clock_init(void)
 {
@@ -45,17 +35,17 @@ void platform_clock_init(void)
 	for (i = 0; i < PLATFORM_CORE_COUNT; i++) {
 		platform_clocks_info[i] = (struct clock_info) {
 			.freqs_num = NUM_CPU_FREQ,
-			.freqs = platform_cpu_freq,
+			.freqs = cpu_freq,
 			.default_freq_idx = CPU_DEFAULT_IDX,
 			.notification_id = NOTIFIER_ID_CPU_FREQ,
 			.notification_mask = NOTIFIER_TARGET_CORE_MASK(i),
-			.set_freq = NULL,
+			.set_freq = clock_platform_set_cpu_freq,
 		};
 	}
 
 	platform_clocks_info[CLK_SSP] = (struct clock_info) {
 		.freqs_num = NUM_SSP_FREQ,
-		.freqs = platform_ssp_freq,
+		.freqs = ssp_freq,
 		.default_freq_idx = SSP_DEFAULT_IDX,
 		.notification_id = NOTIFIER_ID_SSP_FREQ,
 		.notification_mask = NOTIFIER_TARGET_CORE_ALL_MASK,

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -341,6 +341,7 @@ int platform_init(struct sof *sof)
 	platform_timer_start(platform_timer);
 
 	trace_point(TRACE_BOOT_PLATFORM_CLOCK);
+	platform_clock_init();
 	clock_init();
 
 	trace_point(TRACE_BOOT_PLATFORM_SCHED);

--- a/src/platform/suecreek/lib/clk.c
+++ b/src/platform/suecreek/lib/clk.c
@@ -3,13 +3,20 @@
 // Copyright(c) 2019 Intel Corporation. All rights reserved.
 //
 // Author: Tomasz Lauda <tomasz.lauda@linux.intel.com>
+//         Janusz Jankowski <janusz.jankowski@linux.intel.com>
 
 #include <sof/common.h>
+#include <sof/drivers/ssp.h>
 #include <sof/lib/clk.h>
 
 static struct freq_table platform_cpu_freq[] = {
-	{ 120000000, 120000, 0x0 },
-	{ CLK_MAX_CPU_HZ, 400000, 0x4 }, /* default */
+	{ 120000000, 120000 },
+	{ CLK_MAX_CPU_HZ, 400000 },
+};
+
+uint32_t cpu_freq_enc[] = {
+	0x0,
+	0x4,
 };
 
 STATIC_ASSERT(NUM_CPU_FREQ == ARRAY_SIZE(platform_cpu_freq),
@@ -21,11 +28,17 @@ struct freq_table *cpu_freq = platform_cpu_freq;
  * (regarding to .freq field)
  */
 static struct freq_table platform_ssp_freq[] = {
-	{ 19200000, 19200, CLOCK_SSP_XTAL_OSCILLATOR }, /* default */
-	{ 24000000, 24000, CLOCK_SSP_PLL_FIXED },
+	{ 19200000, 19200 },
+	{ 24000000, 24000 },
+};
+
+static uint32_t platform_ssp_freq_sources[] = {
+	SSP_CLOCK_XTAL_OSCILLATOR,
+	SSP_CLOCK_PLL_FIXED,
 };
 
 STATIC_ASSERT(NUM_SSP_FREQ == ARRAY_SIZE(platform_ssp_freq),
 	      invalid_number_of_ssp_frequencies);
 
 struct freq_table *ssp_freq = platform_ssp_freq;
+uint32_t *ssp_freq_sources = platform_ssp_freq_sources;

--- a/src/platform/tigerlake/lib/clk.c
+++ b/src/platform/tigerlake/lib/clk.c
@@ -3,13 +3,20 @@
 // Copyright(c) 2019 Intel Corporation. All rights reserved.
 //
 // Author: Tomasz Lauda <tomasz.lauda@linux.intel.com>
+//         Janusz Jankowski <janusz.jankowski@linux.intel.com>
 
 #include <sof/common.h>
+#include <sof/drivers/ssp.h>
 #include <sof/lib/clk.h>
 
 static struct freq_table platform_cpu_freq[] = {
-	{ 120000000, 120000, 0x0 },
-	{ CLK_MAX_CPU_HZ, 400000, 0x4 }, /* default */
+	{ 120000000, 120000 },
+	{ CLK_MAX_CPU_HZ, 400000 },
+};
+
+uint32_t cpu_freq_enc[] = {
+	0x0,
+	0x4,
 };
 
 STATIC_ASSERT(NUM_CPU_FREQ == ARRAY_SIZE(platform_cpu_freq),
@@ -21,12 +28,19 @@ struct freq_table *cpu_freq = platform_cpu_freq;
  * (regarding to .freq field)
  */
 static struct freq_table platform_ssp_freq[] = {
-	{ 24576000, 24576, CLOCK_SSP_AUDIO_CARDINAL },
-	{ 38400000, 38400, CLOCK_SSP_XTAL_OSCILLATOR }, /* default */
-	{ 96000000, 96000, CLOCK_SSP_PLL_FIXED },
+	{ 24576000, 24576 },
+	{ 38400000, 38400 },
+	{ 96000000, 96000 },
+};
+
+static uint32_t platform_ssp_freq_sources[] = {
+	SSP_CLOCK_AUDIO_CARDINAL,
+	SSP_CLOCK_XTAL_OSCILLATOR,
+	SSP_CLOCK_PLL_FIXED,
 };
 
 STATIC_ASSERT(NUM_SSP_FREQ == ARRAY_SIZE(platform_ssp_freq),
 	      invalid_number_of_ssp_frequencies);
 
 struct freq_table *ssp_freq = platform_ssp_freq;
+uint32_t *ssp_freq_sources = platform_ssp_freq_sources;


### PR DESCRIPTION
Create abstract interface for clocks and move platform specific
clocks code to platform folders.
It was also necessary to move SSP clocks declarations to
SSP driver code to decouple clocks logic from mandatory
SSP clocks.

Signed-off-by: Janusz Jankowski <janusz.jankowski@linux.intel.com>