### PR TITLE
trace: use trace_point instead of platform_* in boot_loader.c

### DIFF
--- a/src/arch/xtensa/boot_loader.c
+++ b/src/arch/xtensa/boot_loader.c
@@ -85,7 +85,7 @@ static void parse_module(struct sof_man_fw_header *hdr,
 	/* each module has 3 segments */
 	for (i = 0; i < MANIFEST_SEGMENT_COUNT; i++) {
 
-		platform_trace_point(TRACE_BOOT_LDR_PARSE_SEGMENT + i);
+		trace_point(TRACE_BOOT_LDR_PARSE_SEGMENT + i);
 		switch (mod->segment[i].flags.r.type) {
 		case SOF_MAN_SEGMENT_TEXT:
 		case SOF_MAN_SEGMENT_DATA:
@@ -129,7 +129,7 @@ static uint32_t get_fw_size_in_use(void)
 
 	/* Calculate fw size passed in BASEFW module in MANIFEST */
 	for (i = MAN_SKIP_ENTRIES; i < hdr->num_module_entries; i++) {
-		platform_trace_point(TRACE_BOOT_LDR_PARSE_MODULE + i);
+		trace_point(TRACE_BOOT_LDR_PARSE_MODULE + i);
 		mod = (struct sof_man_module *)((char *)desc +
 						SOF_MAN_MODULE_OFFSET(i));
 		if (strcmp((char *)mod->name, "BASEFW"))
@@ -160,7 +160,7 @@ static void parse_manifest(void)
 	/* copy module to SRAM  - skip bootloader module */
 	for (i = MAN_SKIP_ENTRIES; i < hdr->num_module_entries; i++) {
 
-		platform_trace_point(TRACE_BOOT_LDR_PARSE_MODULE + i);
+		trace_point(TRACE_BOOT_LDR_PARSE_MODULE + i);
 		mod = (struct sof_man_module *)((char *)desc +
 						SOF_MAN_MODULE_OFFSET(i));
 		parse_module(hdr, mod);
@@ -318,10 +318,10 @@ void boot_master_core(void)
 {
 	int32_t result;
 
-	platform_trace_point(TRACE_BOOT_LDR_ENTRY);
+	trace_point(TRACE_BOOT_LDR_ENTRY);
 
 	/* init the HPSRAM */
-	platform_trace_point(TRACE_BOOT_LDR_HPSRAM);
+	trace_point(TRACE_BOOT_LDR_HPSRAM);
 	result = hp_sram_init();
 	if (result < 0) {
 		platform_panic(SOF_IPC_PANIC_MEM);
@@ -330,7 +330,7 @@ void boot_master_core(void)
 
 #if CONFIG_LP_SRAM
 	/* init the LPSRAM */
-	platform_trace_point(TRACE_BOOT_LDR_LPSRAM);
+	trace_point(TRACE_BOOT_LDR_LPSRAM);
 
 	result = lp_sram_init();
 	if (result < 0) {
@@ -341,12 +341,12 @@ void boot_master_core(void)
 
 #if CONFIG_BOOT_LOADER
 	/* parse manifest and copy modules */
-	platform_trace_point(TRACE_BOOT_LDR_MANIFEST);
+	trace_point(TRACE_BOOT_LDR_MANIFEST);
 	parse_manifest();
 
 	hp_sram_power_off_unused_banks(get_fw_size_in_use());
 #endif
 	/* now call SOF entry */
-	platform_trace_point(TRACE_BOOT_LDR_JUMP);
+	trace_point(TRACE_BOOT_LDR_JUMP);
 	_ResetVector();
 }


### PR DESCRIPTION
After disabling tracing code have compilation error because of
implicit declaration of platform_trace_point function.
After calling through trace_point it is replaced with empty
define after disabling trace.

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>