### PR TITLE
include: Remove doxygen warnings during documentation generation

### DIFF
--- a/src/include/ipc/header.h
+++ b/src/include/ipc/header.h
@@ -104,6 +104,8 @@
 #define SOF_IPC_PM_CORE_ENABLE			SOF_CMD_TYPE(0x007)
 #define SOF_IPC_PM_GATE				SOF_CMD_TYPE(0x008)
 
+/** @} */
+
 /** \name DSP Command: Component runtime config - multiple different types
  *  @{
  */

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -323,6 +323,8 @@ struct comp_copy_limits {
 	((dir) == PPL_DIR_DOWNSTREAM ? &comp->bsink_list : \
 	 &comp->bsource_list)
 
+/** @}*/
+
 /** \name Declare module macro
  *  \brief Usage at the end of an independent module file:
  *         DECLARE_MODULE(sys_*_init);

--- a/src/include/sof/lib/pm_memory.h
+++ b/src/include/sof/lib/pm_memory.h
@@ -41,9 +41,9 @@ struct ebb_data {
  *
  * \param[in] ptr Ptr to address from which to start gating.
  * \param[in] size Size of memory to manage.
- * \param[in] bit Boolean deciding banks desired state (1 powered 0 gated).
+ * \param[in] enabled Boolean deciding banks desired state (1 powered 0 gated).
  */
 void set_power_gate_for_memory_address_range(void *ptr,
-					     uint32_t size, uint32_t power);
+					     uint32_t size, uint32_t enabled);
 
 #endif /* __SOF_LIB_PM_MEMORY_H__ */


### PR DESCRIPTION
The changes fix command unbalanced groupings and remove discrepancy
between parameters in function declaration & definition of
set_power_gate_for_memory_address_range() function.

Signed-off-by: Lech Betlej <lech.betlej@linux.intel.com>