### PR TITLE
dw-dma: enable channel linear link position

### DIFF
--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -267,6 +267,9 @@ static int dw_dma_start(struct dma_chan_data *channel)
 	/* assign core */
 	channel->core = cpu_get_id();
 
+	/* enable linear link position */
+	platform_dw_dma_llp_enable(dma, channel);
+
 	/* enable the channel */
 	channel->status = COMP_STATE_ACTIVE;
 	dma_reg_write(dma, DW_DMA_CHAN_EN, DW_CHAN_UNMASK(channel->index));
@@ -392,6 +395,9 @@ static int dw_dma_stop(struct dma_chan_data *channel)
 	dcache_writeback_region(dw_chan->lli,
 				sizeof(struct dw_lli) * channel->desc_count);
 #endif
+
+	/* disable linear link position */
+	platform_dw_dma_llp_disable(dma, channel);
 
 	channel->status = COMP_STATE_PREPARE;
 
@@ -633,6 +639,8 @@ static int dw_dma_set_config(struct dma_chan_data *channel,
 			dw_chan->cfg_lo |= DW_CFG_RELOAD_DST;
 #endif
 			dw_chan->cfg_hi |= DW_CFGH_DST(config->dest_dev);
+			platform_dw_dma_llp_config(channel->dma, channel,
+						   config->dest_dev);
 			break;
 		case DMA_DIR_DEV_TO_MEM:
 			lli_desc->ctrl_lo |= DW_CTLL_FC_P2M | DW_CTLL_SRC_FIX |
@@ -648,6 +656,8 @@ static int dw_dma_set_config(struct dma_chan_data *channel,
 			dw_chan->cfg_lo |= DW_CFG_RELOAD_SRC;
 #endif
 			dw_chan->cfg_hi |= DW_CFGH_SRC(config->src_dev);
+			platform_dw_dma_llp_config(channel->dma, channel,
+						   config->src_dev);
 			break;
 		case DMA_DIR_DEV_TO_DEV:
 			lli_desc->ctrl_lo |= DW_CTLL_FC_P2P | DW_CTLL_SRC_FIX |

--- a/src/platform/apollolake/include/platform/lib/shim.h
+++ b/src/platform/apollolake/include/platform/lib/shim.h
@@ -201,6 +201,15 @@
 
 #define SHIM_SPSREQ_RVNNP	(0x1 << 0)
 
+/** \brief GPDMA shim registers Control */
+#define SHIM_GPDMA_BASE_OFFSET	0xC00
+#define SHIM_GPDMA_BASE(x)	(SHIM_GPDMA_BASE_OFFSET + (x) * 0x80)
+
+/** \brief GPDMA Channel Linear Link Position Control */
+#define SHIM_GPDMA_CHLLPC(x, y)		(SHIM_GPDMA_BASE(x) + (y) * 0x10)
+#define SHIM_GPDMA_CHLLPC_EN		BIT(5)
+#define SHIM_GPDMA_CHLLPC_DHRS(x)	SET_BITS(4, 0, x)
+
 /** \brief LDO Control */
 #define SHIM_LDOCTL		0xA4
 #define SHIM_LDOCTL_HPSRAM_MASK	(3 << 0)

--- a/src/platform/baytrail/include/platform/drivers/dw-dma.h
+++ b/src/platform/baytrail/include/platform/drivers/dw-dma.h
@@ -12,6 +12,11 @@
 
 #include <sof/bit.h>
 #include <config.h>
+#include <stdint.h>
+
+struct dma;
+struct dma_chan_data;
+
 
 /* number of supported DW-DMACs */
 #if CONFIG_CHERRYTRAIL_EXTRA_DW_DMA
@@ -47,6 +52,16 @@
 
 #define platform_dw_dma_set_transfer_size(chan, lli, size) \
 	(lli->ctrl_hi |= (size & DW_CTLH_BLOCK_TS_MASK))
+
+static inline void platform_dw_dma_llp_config(struct dma *dma,
+					      struct dma_chan_data *chan,
+					      uint32_t config) { }
+
+static inline void platform_dw_dma_llp_enable(struct dma *dma,
+					      struct dma_chan_data *chan) { }
+
+static inline void platform_dw_dma_llp_disable(struct dma *dma,
+					       struct dma_chan_data *chan) { }
 
 #endif /* __PLATFORM_DRIVERS_DW_DMA_H__ */
 

--- a/src/platform/cannonlake/include/platform/lib/shim.h
+++ b/src/platform/cannonlake/include/platform/lib/shim.h
@@ -163,11 +163,16 @@
 /** \brief GPDMA shim registers Control */
 #define SHIM_GPDMA_BASE_OFFSET	0x6500
 #define SHIM_GPDMA_BASE(x)	(SHIM_GPDMA_BASE_OFFSET + (x) * 0x100)
+
 /** \brief GPDMA Clock Control */
 #define SHIM_GPDMA_CLKCTL(x)	(SHIM_GPDMA_BASE(x) + 0x4)
-
 /* LP GPDMA Force Dynamic Clock Gating bits, 0--enable */
 #define SHIM_CLKCTL_LPGPDMAFDCGB	BIT(0)
+
+/** \brief GPDMA Channel Linear Link Position Control */
+#define SHIM_GPDMA_CHLLPC(x, y)		(SHIM_GPDMA_BASE(x) + 0x10 + (y) * 0x10)
+#define SHIM_GPDMA_CHLLPC_EN		BIT(7)
+#define SHIM_GPDMA_CHLLPC_DHRS(x)	SET_BITS(6, 0, x)
 
 #define L2LMCAP			0x71D00
 #define L2MPAT			0x71D04

--- a/src/platform/haswell/include/platform/drivers/dw-dma.h
+++ b/src/platform/haswell/include/platform/drivers/dw-dma.h
@@ -11,6 +11,10 @@
 #define __PLATFORM_DRIVERS_DW_DMA_H__
 
 #include <sof/bit.h>
+#include <stdint.h>
+
+struct dma;
+struct dma_chan_data;
 
 /* number of supported DW-DMACs */
 #define PLATFORM_NUM_DW_DMACS	2
@@ -45,6 +49,16 @@
 	(lli->ctrl_hi |= ((size / (1 << ((lli->ctrl_lo & \
 		DW_CTLL_SRC_WIDTH_MASK) >> DW_CTLL_SRC_WIDTH_SHIFT))) & \
 		DW_CTLH_BLOCK_TS_MASK))
+
+static inline void platform_dw_dma_llp_config(struct dma *dma,
+					      struct dma_chan_data *chan,
+					      uint32_t config) { }
+
+static inline void platform_dw_dma_llp_enable(struct dma *dma,
+					      struct dma_chan_data *chan) { }
+
+static inline void platform_dw_dma_llp_disable(struct dma *dma,
+					       struct dma_chan_data *chan) { }
 
 #endif /* __PLATFORM_DRIVERS_DW_DMA_H__ */
 

--- a/src/platform/icelake/include/platform/lib/shim.h
+++ b/src/platform/icelake/include/platform/lib/shim.h
@@ -125,7 +125,6 @@
 #define SHIM_LPSCTL_BATTR_0	BIT(12)
 
 /* LP GPDMA Force Dynamic Clock Gating bits, 0--enable */
-#define SHIM_CLKCTL_LPGPDMAFDCGB(x)	(0x1 << (26 + x))
 #define SHIM_CLKCTL_TCPLCG(x)		(0x1 << (16 + x))
 
 /* Core clock PLL divisor */
@@ -143,8 +142,19 @@
 /* HP memory clock PLL divisor */
 #define SHIM_CLKCTL_HPMPCS	(0x1 << 0)
 
-#define GPDMA_CLKCTL(x)		(0x78404 + x*0x100)
-#define GPDMA_FDCGB		(0x1 << 0)
+/** \brief GPDMA shim registers Control */
+#define SHIM_GPDMA_BASE_OFFSET	0x6500
+#define SHIM_GPDMA_BASE(x)	(SHIM_GPDMA_BASE_OFFSET + (x) * 0x100)
+
+/** \brief GPDMA Clock Control */
+#define SHIM_GPDMA_CLKCTL(x)	(SHIM_GPDMA_BASE(x) + 0x4)
+/* LP GPDMA Force Dynamic Clock Gating bits, 0--enable */
+#define SHIM_CLKCTL_LPGPDMAFDCGB	BIT(0)
+
+/** \brief GPDMA Channel Linear Link Position Control */
+#define SHIM_GPDMA_CHLLPC(x, y)		(SHIM_GPDMA_BASE(x) + 0x10 + (y) * 0x10)
+#define SHIM_GPDMA_CHLLPC_EN		BIT(7)
+#define SHIM_GPDMA_CHLLPC_DHRS(x)	SET_BITS(6, 0, x)
 
 #define L2LMCAP			0x71D00
 #define L2MPAT			0x71D04

--- a/src/platform/intel/cavs/include/cavs/drivers/dw-dma.h
+++ b/src/platform/intel/cavs/include/cavs/drivers/dw-dma.h
@@ -11,7 +11,10 @@
 #define __CAVS_LIB_DW_DMA_H__
 
 #include <sof/bit.h>
+#include <sof/lib/dma.h>
+#include <sof/lib/shim.h>
 #include <config.h>
+#include <stdint.h>
 
 /* number of supported DW-DMACs */
 #if CONFIG_SUECREEK
@@ -51,11 +54,36 @@
 #define DW_CFG_LOW_DEF		0x3
 #define DW_CFG_HIGH_DEF		0x0
 
+/* LLPC address */
+#define DW_CHLLPC(dma, chan) \
+	SHIM_GPDMA_CHLLPC((dma)->plat_data.id, (chan)->index)
+
 #define platform_dw_dma_set_class(chan, lli, class) \
 	(lli->ctrl_hi |= DW_CTLH_CLASS(class))
 
 #define platform_dw_dma_set_transfer_size(chan, lli, size) \
 	(lli->ctrl_hi |= (size & DW_CTLH_BLOCK_TS_MASK))
+
+static inline void platform_dw_dma_llp_config(struct dma *dma,
+					      struct dma_chan_data *chan,
+					      uint32_t config)
+{
+	shim_write(DW_CHLLPC(dma, chan), SHIM_GPDMA_CHLLPC_DHRS(config));
+}
+
+static inline void platform_dw_dma_llp_enable(struct dma *dma,
+					      struct dma_chan_data *chan)
+{
+	shim_write(DW_CHLLPC(dma, chan),
+		   shim_read(DW_CHLLPC(dma, chan)) | SHIM_GPDMA_CHLLPC_EN);
+}
+
+static inline void platform_dw_dma_llp_disable(struct dma *dma,
+					       struct dma_chan_data *chan)
+{
+	shim_write(DW_CHLLPC(dma, chan),
+		   shim_read(DW_CHLLPC(dma, chan)) & ~SHIM_GPDMA_CHLLPC_EN);
+}
 
 #endif /* __CAVS_LIB_DW_DMA_H__ */
 

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -420,8 +420,8 @@ int platform_init(struct sof *sof)
 		SHIM_CLKCTL_TCPLCG(0));
 
 	/* prevent LP GPDMA 0&1 clock gating */
-	io_reg_write(GPDMA_CLKCTL(0), GPDMA_FDCGB);
-	io_reg_write(GPDMA_CLKCTL(1), GPDMA_FDCGB);
+	shim_write(SHIM_GPDMA_CLKCTL(0), SHIM_CLKCTL_LPGPDMAFDCGB);
+	shim_write(SHIM_GPDMA_CLKCTL(1), SHIM_CLKCTL_LPGPDMAFDCGB);
 
 	/* prevent DSP Common power gating */
 	pm_runtime_get(PM_RUNTIME_DSP, PLATFORM_MASTER_CORE_ID);

--- a/src/platform/suecreek/include/platform/lib/shim.h
+++ b/src/platform/suecreek/include/platform/lib/shim.h
@@ -125,7 +125,6 @@
 #define SHIM_LPSCTL_BATTR_0	BIT(12)
 
 /* LP GPDMA Force Dynamic Clock Gating bits, 0--enable */
-#define SHIM_CLKCTL_LPGPDMAFDCGB(x)	(0x1 << (26 + x))
 #define SHIM_CLKCTL_TCPLCG(x)		(0x1 << (16 + x))
 
 /* Core clock PLL divisor */
@@ -143,8 +142,19 @@
 /* HP memory clock PLL divisor */
 #define SHIM_CLKCTL_HPMPCS	(0x1 << 0)
 
-#define GPDMA_CLKCTL(x)		(0x78404 + x*0x100)
-#define GPDMA_FDCGB		(0x1 << 0)
+/** \brief GPDMA shim registers Control */
+#define SHIM_GPDMA_BASE_OFFSET	0x6500
+#define SHIM_GPDMA_BASE(x)	(SHIM_GPDMA_BASE_OFFSET + (x) * 0x100)
+
+/** \brief GPDMA Clock Control */
+#define SHIM_GPDMA_CLKCTL(x)	(SHIM_GPDMA_BASE(x) + 0x4)
+/* LP GPDMA Force Dynamic Clock Gating bits, 0--enable */
+#define SHIM_CLKCTL_LPGPDMAFDCGB	BIT(0)
+
+/** \brief GPDMA Channel Linear Link Position Control */
+#define SHIM_GPDMA_CHLLPC(x, y)		(SHIM_GPDMA_BASE(x) + 0x10 + (y) * 0x10)
+#define SHIM_GPDMA_CHLLPC_EN		BIT(7)
+#define SHIM_GPDMA_CHLLPC_DHRS(x)	SET_BITS(6, 0, x)
 
 #define L2LMCAP			0x71D00
 #define L2MPAT			0x71D04

--- a/src/platform/tigerlake/include/platform/lib/shim.h
+++ b/src/platform/tigerlake/include/platform/lib/shim.h
@@ -125,7 +125,6 @@
 #define SHIM_LPSCTL_BATTR_0	BIT(12)
 
 /* LP GPDMA Force Dynamic Clock Gating bits, 0--enable */
-#define SHIM_CLKCTL_LPGPDMAFDCGB(x)	(0x1 << (26 + x))
 #define SHIM_CLKCTL_TCPLCG(x)		(0x1 << (16 + x))
 
 /* Core clock PLL divisor */
@@ -143,8 +142,19 @@
 /* HP memory clock PLL divisor */
 #define SHIM_CLKCTL_HPMPCS	(0x1 << 0)
 
-#define GPDMA_CLKCTL(x)		(0x78404 + x*0x100)
-#define GPDMA_FDCGB		(0x1 << 0)
+/** \brief GPDMA shim registers Control */
+#define SHIM_GPDMA_BASE_OFFSET	0x6500
+#define SHIM_GPDMA_BASE(x)	(SHIM_GPDMA_BASE_OFFSET + (x) * 0x100)
+
+/** \brief GPDMA Clock Control */
+#define SHIM_GPDMA_CLKCTL(x)	(SHIM_GPDMA_BASE(x) + 0x4)
+/* LP GPDMA Force Dynamic Clock Gating bits, 0--enable */
+#define SHIM_CLKCTL_LPGPDMAFDCGB	BIT(0)
+
+/** \brief GPDMA Channel Linear Link Position Control */
+#define SHIM_GPDMA_CHLLPC(x, y)		(SHIM_GPDMA_BASE(x) + 0x10 + (y) * 0x10)
+#define SHIM_GPDMA_CHLLPC_EN		BIT(7)
+#define SHIM_GPDMA_CHLLPC_DHRS(x)	SET_BITS(6, 0, x)
 
 /* I2S SHIM Registers */
 #define I2SLCTL			0x71C04


### PR DESCRIPTION
Enables DW-DMA channel linear link position counter based
on the selected peripheral connection. It can be used
to retrieve timestamping information on platforms supporting it.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>