### PR TITLE
Align interrupt stacks to 16 bytes

### DIFF
--- a/src/arch/xtensa/xtos/xtos-structs.h
+++ b/src/arch/xtensa/xtos/xtos-structs.h
@@ -9,6 +9,7 @@
 #define __XTOS_XTOS_STRUCTS_H__
 
 #include "xtos-internal.h"
+#include <sof/common.h>
 #include <sof/lib/memory.h>
 #include <config.h>
 #include <xtensa/xtruntime-frames.h>
@@ -29,19 +30,19 @@ struct xtos_core_data {
 	struct XtosInterruptStructure xtos_int_data;
 #endif
 #if CONFIG_INTERRUPT_LEVEL_1
-	uint8_t xtos_stack_for_interrupt_1[SOF_STACK_SIZE];
+	uint8_t xtos_stack_for_interrupt_1[SOF_STACK_SIZE] __aligned(16);
 #endif
 #if CONFIG_INTERRUPT_LEVEL_2
-	uint8_t xtos_stack_for_interrupt_2[SOF_STACK_SIZE];
+	uint8_t xtos_stack_for_interrupt_2[SOF_STACK_SIZE] __aligned(16);
 #endif
 #if CONFIG_INTERRUPT_LEVEL_3
-	uint8_t xtos_stack_for_interrupt_3[SOF_STACK_SIZE];
+	uint8_t xtos_stack_for_interrupt_3[SOF_STACK_SIZE] __aligned(16);
 #endif
 #if CONFIG_INTERRUPT_LEVEL_4
-	uint8_t xtos_stack_for_interrupt_4[SOF_STACK_SIZE];
+	uint8_t xtos_stack_for_interrupt_4[SOF_STACK_SIZE] __aligned(16);
 #endif
 #if CONFIG_INTERRUPT_LEVEL_5
-	uint8_t xtos_stack_for_interrupt_5[SOF_STACK_SIZE];
+	uint8_t xtos_stack_for_interrupt_5[SOF_STACK_SIZE] __aligned(16);
 #endif
 	xtos_task_context xtos_interrupt_ctx;
 	uintptr_t xtos_saved_sp;


### PR DESCRIPTION
~This is required for the vectorial instructions emitted by xcc to not~
~trigger a DSP panic within the DMA multi-channel domain.~

~The stack should normally be already aligned when entering this~
~function, but apparently it isn't so this code does a manual alignment.~

~The compiler assumes the alignment is already there when generating code~
~and preserves it when it is, but the question is what happens when it is~
~only aligned to a multiple of 4.~

~Signed-off-by: Paul Olaru <paul.olaru@nxp.com>~

~How can I study exactly what causes the stack to become unaligned at that point?~

**EDIT**: The original issue was fixed by just aligning the interrupt stacks themselves.
So I just do that and wonder how they weren't already aligned.