### PR TITLE
platform: imx: Enable WAITI_DELAY

### DIFF
--- a/src/platform/Kconfig
+++ b/src/platform/Kconfig
@@ -166,6 +166,7 @@ config IMX8
 	select INTERRUPT_LEVEL_3
 	select HOST_PTABLE
 	select DUMMY_DMA
+	select WAITI_DELAY
 	help
 	  Select if your target platform is imx8-compatible
 


### PR DESCRIPTION
The description of this switch says that any LX6 Xtensa architecture revision DSP
should have this enabled, and the particular DSP in the i.MX8 does fit
this description.

Considering the comment in code:

`src/arch/xtensa/include/arch/lib/wait.h:30` : `        /* LX6 needs a delay */`

Signed-off-by: Paul Olaru <paul.olaru@nxp.com>