### PR TITLE
byt-ipc: refine the IPC DONE mask

### DIFF
--- a/src/drivers/intel/baytrail/ipc.c
+++ b/src/drivers/intel/baytrail/ipc.c
@@ -55,9 +55,6 @@ out:
 
 	/* clear DONE bit - tell Host we have completed */
 	shim_write(SHIM_IPCDH, shim_read(SHIM_IPCDH) & ~SHIM_IPCDH_DONE);
-
-	/* unmask Done interrupt */
-	shim_write(SHIM_IMRD, shim_read(SHIM_IMRD) & ~SHIM_IMRD_DONE);
 }
 
 static void irq_handler(void *arg)
@@ -150,6 +147,9 @@ void ipc_platform_send_msg(struct ipc *ipc)
 	ipc->shared_ctx->dsp_msg = msg;
 	tracev_ipc("ipc: msg tx -> 0x%x", msg->header);
 
+	/* Unmask Done interrupts first to receive ack */
+	shim_write(SHIM_IMRD, shim_read(SHIM_IMRD) & ~SHIM_IMRD_DONE);
+
 	/* now interrupt host to tell it we have message sent */
 	shim_write(SHIM_IPCDL, msg->header);
 	shim_write(SHIM_IPCDH, SHIM_IPCDH_BUSY);
@@ -202,9 +202,10 @@ int platform_ipc_init(struct ipc *ipc)
 	interrupt_register(PLATFORM_IPC_INTERRUPT, irq_handler, ipc);
 	interrupt_enable(PLATFORM_IPC_INTERRUPT, ipc);
 
-	/* Unmask Busy and Done interrupts */
+	/* Unmask Busy and mask Done interrupts */
 	imrd = shim_read(SHIM_IMRD);
-	imrd &= ~(SHIM_IMRD_BUSY | SHIM_IMRD_DONE);
+	imrd &= ~SHIM_IMRD_BUSY;
+	imrd |= SHIM_IMRD_DONE;
 	shim_write(SHIM_IMRD, imrd);
 
 	return 0;

--- a/src/platform/baytrail/platform.c
+++ b/src/platform/baytrail/platform.c
@@ -135,6 +135,9 @@ int platform_boot_complete(uint32_t boot_message)
 	mailbox_dspbox_write(sizeof(ready), &sram_window,
 			     sram_window.ext_hdr.hdr.size);
 
+	/* Unmask Done interrupts first to receive ack */
+	shim_write(SHIM_IMRD, shim_read(SHIM_IMRD) & ~SHIM_IMRD_DONE);
+
 	/* now interrupt host to tell it we are done booting */
 	shim_write(SHIM_IPCDL, SOF_IPC_FW_READY | outbox);
 	shim_write(SHIM_IPCDH, SHIM_IPCDH_BUSY);

--- a/src/platform/haswell/platform.c
+++ b/src/platform/haswell/platform.c
@@ -131,6 +131,9 @@ int platform_boot_complete(uint32_t boot_message)
 	mailbox_dspbox_write(sizeof(ready), &sram_window,
 			     sram_window.ext_hdr.hdr.size);
 
+	/* Unmask Done interrupts first to receive ack */
+	shim_write(SHIM_IMRD, shim_read(SHIM_IMRD) & ~SHIM_IMRD_DONE);
+
 	/* now interrupt host to tell it we are done booting */
 	shim_write(SHIM_IPCD, outbox | SHIM_IPCD_BUSY);
 


### PR DESCRIPTION
Refine the IPCD DONE mask sequence:
1. After initialized, mask the IPCD DONE.
2. Enable/unmask IPCD DONE at new message sending to host.
3. Disable/mask IPCD DONE once the FW initiated IPC handling is done.

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>