### PR TITLE
sof: spinlock: Refactor spinlock related macros

### DIFF
--- a/src/arch/host/include/arch/spinlock.h
+++ b/src/arch/host/include/arch/spinlock.h
@@ -15,6 +15,10 @@ struct spinlock {
 
 static inline void arch_spinlock_init(struct spinlock **lock) {}
 static inline void arch_spin_lock(struct spinlock *lock) {}
+static inline int arch_try_lock(struct spinlock *lock)
+{
+	return 1;
+}
 static inline void arch_spin_unlock(struct spinlock *lock) {}
 
 #endif /* __ARCH_SPINLOCK_H__ */

--- a/src/arch/host/include/arch/spinlock.h
+++ b/src/arch/host/include/arch/spinlock.h
@@ -10,12 +10,12 @@
 #ifndef __ARCH_SPINLOCK_H__
 #define __ARCH_SPINLOCK_H__
 
-typedef struct {
-} spinlock_t;
+struct spinlock {
+};
 
-static inline void arch_spinlock_init(spinlock_t **lock) {}
-static inline void arch_spin_lock(spinlock_t *lock) {}
-static inline void arch_spin_unlock(spinlock_t *lock) {}
+static inline void arch_spinlock_init(struct spinlock **lock) {}
+static inline void arch_spin_lock(struct spinlock *lock) {}
+static inline void arch_spin_unlock(struct spinlock *lock) {}
 
 #endif /* __ARCH_SPINLOCK_H__ */
 

--- a/src/arch/xtensa/include/arch/spinlock.h
+++ b/src/arch/xtensa/include/arch/spinlock.h
@@ -13,14 +13,14 @@
 #include <config.h>
 #include <stdint.h>
 
-typedef struct {
+struct spinlock {
 	volatile uint32_t lock;
 #if CONFIG_DEBUG_LOCKS
 	uint32_t user;
 #endif
-} spinlock_t;
+};
 
-static inline void arch_spin_lock(spinlock_t *lock)
+static inline void arch_spin_lock(struct spinlock *lock)
 {
 	uint32_t result;
 
@@ -35,7 +35,7 @@ static inline void arch_spin_lock(spinlock_t *lock)
 		: "memory");
 }
 
-static inline int arch_try_lock(spinlock_t *lock)
+static inline int arch_try_lock(struct spinlock *lock)
 {
 	uint32_t result;
 
@@ -52,7 +52,7 @@ static inline int arch_try_lock(spinlock_t *lock)
 	return result ? 0 : 1;
 }
 
-static inline void arch_spin_unlock(spinlock_t *lock)
+static inline void arch_spin_unlock(struct spinlock *lock)
 {
 	uint32_t result;
 
@@ -64,7 +64,7 @@ static inline void arch_spin_unlock(spinlock_t *lock)
 		: "memory");
 }
 
-void arch_spinlock_init(spinlock_t **lock);
+void arch_spinlock_init(struct spinlock **lock);
 
 #endif /* __ARCH_SPINLOCK_H__ */
 

--- a/src/include/sof/drivers/interrupt.h
+++ b/src/include/sof/drivers/interrupt.h
@@ -12,7 +12,7 @@
 #include <platform/drivers/interrupt.h>
 #include <sof/lib/cpu.h>
 #include <sof/list.h>
-#include <sof/spinlock.h>
+#include <sof/spinlock_t.h>
 #include <sof/trace/trace.h>
 #include <user/trace.h>
 #include <stdbool.h>

--- a/src/include/sof/lib/wait.h
+++ b/src/include/sof/lib/wait.h
@@ -17,6 +17,7 @@
 #include <sof/platform.h>
 #include <sof/schedule/schedule.h>
 #include <sof/schedule/task.h>
+#include <sof/spinlock.h>
 #include <sof/trace/trace.h>
 #include <user/trace.h>
 #include <config.h>

--- a/src/include/sof/spinlock.h
+++ b/src/include/sof/spinlock.h
@@ -73,9 +73,12 @@
 #define DBG_LOCK_USERS		8
 #define DBG_LOCK_TRIES		10000
 
-#define trace_lock(__e)		trace_error_atomic(TRACE_CLASS_LOCK, __e)
-#define tracev_lock(__e)	tracev_event_atomic(TRACE_CLASS_LOCK, __e)
-#define trace_lock_error(__e)	trace_error_atomic(TRACE_CLASS_LOCK, __e)
+#define trace_lock(__e, ...)		trace_error_atomic(TRACE_CLASS_LOCK,\
+						   __e, ##__VA_ARGS__)
+#define tracev_lock(__e, ...)		tracev_event_atomic(TRACE_CLASS_LOCK,\
+						    __e, ##__VA_ARGS__)
+#define trace_lock_error(__e, ...)	trace_error_atomic(TRACE_CLASS_LOCK, \
+						   __e, ##__VA_ARGS__)
 
 extern uint32_t lock_dbg_atomic;
 extern uint32_t lock_dbg_user[DBG_LOCK_USERS];
@@ -97,8 +100,8 @@ extern uint32_t lock_dbg_user[DBG_LOCK_USERS];
 		} \
 		if (__tries == 0) { \
 			trace_lock_error("DED"); \
-			trace_lock_value(__LINE__); \
-			trace_lock_value((lock)->user); \
+			trace_lock_error("line: %d", __LINE__); \
+			trace_lock_error("user: %d", (lock)->user); \
 			panic(SOF_IPC_PANIC_DEADLOCK); /* lock not acquired */ \
 		} \
 	} while (0)
@@ -111,11 +114,12 @@ extern uint32_t lock_dbg_user[DBG_LOCK_USERS];
 			int  __count = lock_dbg_atomic >= DBG_LOCK_USERS \
 				? DBG_LOCK_USERS : lock_dbg_atomic; \
 			trace_lock_error("eal"); \
-			trace_lock_value(__LINE__); \
-			trace_lock_value(lock_dbg_atomic); \
+			trace_lock_error("line: %d", __LINE__); \
+			trace_lock_error("dbg_atomic: %d", lock_dbg_atomic); \
 			for (__i = 0; __i < __count; __i++) { \
-				trace_lock_value((lock_dbg_atomic << 24) | \
-					lock_dbg_user[__i]); \
+				trace_lock_error("value: %d", \
+						 (lock_dbg_atomic << 24) | \
+						  lock_dbg_user[__i]); \
 			} \
 		} \
 	} while (0)
@@ -123,13 +127,13 @@ extern uint32_t lock_dbg_user[DBG_LOCK_USERS];
 #define spin_lock_dbg() \
 	do { \
 		trace_lock("LcE"); \
-		trace_lock_value(__LINE__); \
+		trace_lock("line: %d", __LINE__); \
 	} while (0)
 
 #define spin_unlock_dbg() \
 	do { \
 		trace_lock("LcX"); \
-		trace_lock_value(__LINE__); \
+		trace_lock("line: %d", __LINE__); \
 	} while (0)
 
 #else

--- a/src/include/sof/spinlock_t.h
+++ b/src/include/sof/spinlock_t.h
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright 2019 NXP
+ *
+ * Author: Paul Olaru <paul.olaru@nxp.com>
+ */
+
+#ifndef __SOF_SPINLOCK_T_H__
+#define __SOF_SPINLOCK_T_H__
+
+struct spinlock; /**< Forward declaration */
+
+typedef struct spinlock spinlock_t;
+
+#endif /* __SOF_SPINLOCK_T_H__ */


### PR DESCRIPTION
This refactor allows some extra type checking to happen which was not
permitted by a macro-only approach.

Signed-off-by: Paul Olaru <paul.olaru@nxp.com>

Draft because I believe I may split commits or change approach, dependent
on feedback.