### PR TITLE
cannonlake: keep run in waiti loop for power_down

### DIFF
--- a/src/platform/intel/cavs/lib/power_down.S
+++ b/src/platform/intel/cavs/lib/power_down.S
@@ -154,8 +154,7 @@ loop:
     extw
     extw
     waiti 5
-    1:
-    j 1b
+    j _PD_SLEEP
 
 .size power_down , . - power_down
 


### PR DESCRIPTION
To align with apollolake, keep run in the waiti while(1) loop for power
down.

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>