### PR TITLE
platform: imx: Remove all references to SSP clock

### DIFF
--- a/src/include/sof/lib/notifier.h
+++ b/src/include/sof/lib/notifier.h
@@ -45,8 +45,12 @@ struct notifier {
 	void (*cb)(int message, void *cb_data, void *event_data);
 };
 
+#if defined(CLK_SSP) && defined(NOTIFIER_ID_SSP_FREQ)
 #define NOTIFIER_CLK_CHANGE_ID(clk) \
 	((clk) == CLK_SSP ? NOTIFIER_ID_SSP_FREQ : NOTIFIER_ID_CPU_FREQ)
+#else
+#define NOTIFIER_CLK_CHANGE_ID(clk) NOTIFIER_ID_CPU_FREQ
+#endif
 
 struct notify **arch_notify_get(void);
 

--- a/src/platform/imx8/include/platform/lib/clk.h
+++ b/src/platform/imx8/include/platform/lib/clk.h
@@ -13,18 +13,15 @@
 #include <stdint.h>
 
 #define CLK_CPU(x)	(x)
-#define CLK_SSP		1
 
 #define CPU_DEFAULT_IDX		0
-#define SSP_DEFAULT_IDX		1
 
 #define CLK_DEFAULT_CPU_HZ	666000000
 #define CLK_MAX_CPU_HZ		666000000
 
-#define NUM_CLOCKS	2
+#define NUM_CLOCKS	1
 
 #define NUM_CPU_FREQ	1
-#define NUM_SSP_FREQ	2
 
 void platform_clock_init(void);
 

--- a/src/platform/imx8/lib/clk.c
+++ b/src/platform/imx8/lib/clk.c
@@ -6,7 +6,6 @@
 //         Janusz Jankowski <janusz.jankowski@linux.intel.com>
 
 #include <sof/common.h>
-#include <sof/drivers/ssp.h>
 #include <sof/lib/clk.h>
 #include <sof/lib/notifier.h>
 
@@ -16,23 +15,6 @@ static struct freq_table platform_cpu_freq[] = {
 
 STATIC_ASSERT(NUM_CPU_FREQ == ARRAY_SIZE(platform_cpu_freq),
 	      invalid_number_of_cpu_frequencies);
-
-/* TODO: abstract SSP clk based on platform and remove this from here! */
-static struct freq_table platform_ssp_freq[] = {
-	{ 19200000, 19200 },
-	{ 25000000, 25000 },
-};
-
-uint32_t platform_ssp_freq_sources[] = {
-	19,
-	12,
-};
-
-STATIC_ASSERT(NUM_SSP_FREQ == ARRAY_SIZE(platform_ssp_freq),
-	      invalid_number_of_ssp_frequencies);
-
-struct freq_table *ssp_freq = platform_ssp_freq;
-uint32_t *ssp_freq_sources = platform_ssp_freq_sources;
 
 static struct clock_info platform_clocks_info[NUM_CLOCKS];
 
@@ -52,13 +34,4 @@ void platform_clock_init(void)
 			.set_freq = NULL,
 		};
 	}
-
-	platform_clocks_info[CLK_SSP] = (struct clock_info) {
-		.freqs_num = NUM_SSP_FREQ,
-		.freqs = platform_ssp_freq,
-		.default_freq_idx = SSP_DEFAULT_IDX,
-		.notification_id = NOTIFIER_ID_SSP_FREQ,
-		.notification_mask = NOTIFIER_TARGET_CORE_ALL_MASK,
-		.set_freq = NULL,
-	};
 }


### PR DESCRIPTION
The i.MX platform doesn't have an SSP clock so it shouldn't have dummy
defines related to that. This patch set removes said defines.

Here there is also another minor change required for this removal to take
place. I'm waiting on comments on how it can be done better but for now
adding that #if #else guard seems to be the easiest solution.

Fixes #2049 