### PR TITLE
[RFC]component: move pcm params from component to buffer struct

### DIFF
--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -206,9 +206,9 @@ int comp_get_copy_limits(struct comp_dev *dev, struct comp_copy_limits *cl)
 	cl->sink = list_first_item(&dev->bsink_list, struct comp_buffer,
 				   source_list);
 
-	cl->frames = comp_avail_frames(cl->source, cl->sink);
-	cl->source_frame_bytes = comp_frame_bytes(cl->source->source);
-	cl->sink_frame_bytes = comp_frame_bytes(cl->sink->sink);
+	cl->frames = buffer_avail_frames(cl->source, cl->sink);
+	cl->source_frame_bytes = buffer_frame_bytes(cl->source);
+	cl->sink_frame_bytes = buffer_frame_bytes(cl->sink);
 	cl->source_bytes = cl->frames * cl->source_frame_bytes;
 	cl->sink_bytes = cl->frames * cl->sink_frame_bytes;
 

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -341,6 +341,24 @@ static int kpb_trigger(struct comp_dev *dev, int cmd)
 }
 
 /**
+ * \brief KPB params.
+ * \param[in] dev - component device pointer.
+ * \param[in] params - pcm params.
+ * \return none.
+ */
+static int kpb_params(struct comp_dev *dev,
+		      struct sof_ipc_stream_params *params)
+{
+	struct comp_data *kpb = comp_get_drvdata(dev);
+
+	kpb->host_buffer_size = params->buffer.size;
+	kpb->host_period_size = params->host_period_bytes;
+	kpb->config.sampling_width = params->sample_container_bytes * 8;
+
+	return 0;
+}
+
+/**
  * \brief Prepare key phrase buffer.
  * \param[in] dev - kpb component device pointer.
  *
@@ -379,9 +397,6 @@ static int kpb_prepare(struct comp_dev *dev)
 	kpb_change_state(kpb, KPB_STATE_PREPARING);
 	kpb->kpb_no_of_clients = 0;
 	kpb->buffered_data = 0;
-	kpb->host_buffer_size = dev->params.buffer.size;
-	kpb->host_period_size = dev->params.host_period_bytes;
-	kpb->config.sampling_width = dev->params.sample_container_bytes * 8;
 	kpb->kpb_buffer_size = KPB_MAX_BUFFER_SIZE(kpb->config.sampling_width);
 	kpb->sel_sink = NULL;
 	kpb->host_sink = NULL;
@@ -1422,7 +1437,7 @@ struct comp_driver comp_kpb = {
 		.prepare = kpb_prepare,
 		.reset = kpb_reset,
 		.cache = kpb_cache,
-		.params = NULL,
+		.params = kpb_params,
 	},
 };
 

--- a/src/audio/switch.c
+++ b/src/audio/switch.c
@@ -44,7 +44,8 @@ static void switch_free(struct comp_dev *dev)
 }
 
 /* set component audio stream parameters */
-static int switch_params(struct comp_dev *dev)
+static int switch_params(struct comp_dev *dev,
+			 struct sof_ipc_stream_params *params)
 {
 
 	return 0;

--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -249,7 +249,8 @@ static void volume_free(struct comp_dev *dev)
  *
  * All done in prepare() since we need to know source and sink component params.
  */
-static int volume_params(struct comp_dev *dev)
+static int volume_params(struct comp_dev *dev,
+			 struct sof_ipc_stream_params *params)
 {
 	trace_volume_with_ids(dev, "volume_params()");
 
@@ -617,7 +618,7 @@ static int volume_prepare(struct comp_dev *dev)
 				struct comp_buffer, source_list);
 
 	/* get sink period bytes */
-	sink_period_bytes = comp_period_bytes(sinkb->sink, dev->frames);
+	sink_period_bytes = buffer_period_bytes(sinkb, dev->frames);
 
 	if (sinkb->size < config->periods_sink * sink_period_bytes) {
 		trace_volume_error_with_ids(dev, "volume_prepare() error: "
@@ -630,8 +631,8 @@ static int volume_prepare(struct comp_dev *dev)
 	if (!cd->scale_vol) {
 		trace_volume_error_with_ids
 			(dev,
-			 "volume_prepare() error: invalid cd->scale_vol, dev->params.frame_fmt = %u, dev->params.channels = %u",
-			 dev->params.frame_fmt, dev->params.channels);
+			 "volume_prepare() error: invalid cd->scale_vol");
+
 		ret = -EINVAL;
 		goto err;
 	}

--- a/src/audio/volume/volume_generic.c
+++ b/src/audio/volume/volume_generic.c
@@ -80,7 +80,7 @@ static void vol_s16_to_s24(struct comp_dev *dev, struct comp_buffer *sink,
 
 	/* Samples are Q1.15 and volume is Q8.16 */
 	for (i = 0; i < frames; i++) {
-		for (channel = 0; channel < dev->params.channels; channel++) {
+		for (channel = 0; channel < sink->channels; channel++) {
 			src = buffer_read_frag_s16(source, buff_frag);
 			dest = buffer_write_frag_s32(sink, buff_frag);
 
@@ -113,7 +113,7 @@ static void vol_s24_to_s16(struct comp_dev *dev, struct comp_buffer *sink,
 
 	/* Samples are Q1.23 --> Q1.15 and volume is Q8.16 */
 	for (i = 0; i < frames; i++) {
-		for (channel = 0; channel < dev->params.channels; channel++) {
+		for (channel = 0; channel < sink->channels; channel++) {
 			src = buffer_read_frag_s32(source, buff_frag);
 			dest = buffer_write_frag_s32(sink, buff_frag);
 
@@ -162,7 +162,7 @@ static void vol_s16_to_s32(struct comp_dev *dev, struct comp_buffer *sink,
 
 	/* Samples are Q1.15 --> Q1.31 and volume is Q8.16 */
 	for (i = 0; i < frames; i++) {
-		for (channel = 0; channel < dev->params.channels; channel++) {
+		for (channel = 0; channel < sink->channels; channel++) {
 			src = buffer_read_frag_s16(source, buff_frag);
 			dest = buffer_write_frag_s32(sink, buff_frag);
 			*dest = q_multsr_sat_32x32
@@ -196,7 +196,7 @@ static void vol_s32_to_s16(struct comp_dev *dev, struct comp_buffer *sink,
 
 	/* Samples are Q1.31 --> Q1.15 and volume is Q8.16 */
 	for (i = 0; i < frames; i++) {
-		for (channel = 0; channel < dev->params.channels; channel++) {
+		for (channel = 0; channel < sink->channels; channel++) {
 			src = buffer_read_frag_s32(source, buff_frag);
 			dest = buffer_write_frag_s16(sink, buff_frag);
 
@@ -244,7 +244,7 @@ static void vol_s32_to_s24(struct comp_dev *dev, struct comp_buffer *sink,
 
 	/* Samples are Q1.31 --> Q1.23 and volume is Q8.16 */
 	for (i = 0; i < frames; i++) {
-		for (channel = 0; channel < dev->params.channels; channel++) {
+		for (channel = 0; channel < sink->channels; channel++) {
 			src = buffer_read_frag_s32(source, buff_frag);
 			dest = buffer_write_frag_s32(sink, buff_frag);
 
@@ -277,7 +277,7 @@ static void vol_s24_to_s32(struct comp_dev *dev, struct comp_buffer *sink,
 
 	/* Samples are Q1.23 --> Q1.31 and volume is Q8.16 */
 	for (i = 0; i < frames; i++) {
-		for (channel = 0; channel < dev->params.channels; channel++) {
+		for (channel = 0; channel < sink->channels; channel++) {
 			src = buffer_read_frag_s32(source, buff_frag);
 			dest = buffer_write_frag_s32(sink, buff_frag);
 
@@ -331,7 +331,7 @@ static void vol_s24_to_s24(struct comp_dev *dev, struct comp_buffer *sink,
 
 	/* Samples are Q1.23 --> Q1.23 and volume is Q8.16 */
 	for (i = 0; i < frames; i++) {
-		for (channel = 0; channel < dev->params.channels; channel++) {
+		for (channel = 0; channel < sink->channels; channel++) {
 			src = buffer_read_frag_s32(source, buff_frag);
 			dest = buffer_write_frag_s32(sink, buff_frag);
 
@@ -366,7 +366,7 @@ static void vol_s32_to_s32(struct comp_dev *dev, struct comp_buffer *sink,
 
 	/* Samples are Q1.31 --> Q1.31 and volume is Q8.16 */
 	for (i = 0; i < frames; i++) {
-		for (channel = 0; channel < dev->params.channels; channel++) {
+		for (channel = 0; channel < sink->channels; channel++) {
 			src = buffer_read_frag_s32(source, buff_frag);
 			dest = buffer_write_frag_s32(sink, buff_frag);
 
@@ -403,7 +403,7 @@ static void vol_s16_to_s16(struct comp_dev *dev, struct comp_buffer *sink,
 
 	/* Samples are Q1.15 --> Q1.15 and volume is Q8.16 */
 	for (i = 0; i < frames; i++) {
-		for (channel = 0; channel < dev->params.channels; channel++) {
+		for (channel = 0; channel < sink->channels; channel++) {
 			src = buffer_read_frag_s16(source, buff_frag);
 			dest = buffer_write_frag_s16(sink, buff_frag);
 

--- a/src/audio/volume/volume_hifi3.c
+++ b/src/audio/volume/volume_hifi3.c
@@ -65,7 +65,7 @@ static void vol_s16_to_sX(struct comp_dev *dev, struct comp_buffer *sink,
 	/* Main processing loop */
 	for (i = 0; i < frames; i++) {
 		/* Processing per channel */
-		for (channel = 0; channel < dev->params.channels; channel++) {
+		for (channel = 0; channel < sink->channels; channel++) {
 			/* Set source as circular buffer */
 			vol_setup_circular(source);
 
@@ -126,7 +126,7 @@ static void vol_sX_to_s16(struct comp_dev *dev, struct comp_buffer *sink,
 	/* Main processing loop */
 	for (i = 0; i < frames; i++) {
 		/* Processing per channel */
-		for (channel = 0; channel < dev->params.channels; channel++) {
+		for (channel = 0; channel < sink->channels; channel++) {
 			/* Set source as circular buffer */
 			vol_setup_circular(source);
 
@@ -187,7 +187,7 @@ static void vol_s24_to_s24_s32(struct comp_dev *dev, struct comp_buffer *sink,
 	/* Main processing loop */
 	for (i = 0; i < frames; i++) {
 		/* Processing per channel */
-		for (channel = 0; channel < dev->params.channels; channel++) {
+		for (channel = 0; channel < sink->channels; channel++) {
 			/* Set source as circular buffer */
 			vol_setup_circular(source);
 
@@ -247,7 +247,7 @@ static void vol_s32_to_s24_s32(struct comp_dev *dev, struct comp_buffer *sink,
 	/* Main processing loop */
 	for (i = 0; i < frames; i++) {
 		/* Processing per channel */
-		for (channel = 0; channel < dev->params.channels; channel++) {
+		for (channel = 0; channel < sink->channels; channel++) {
 			/* Set source as circular buffer */
 			vol_setup_circular(source);
 
@@ -306,7 +306,7 @@ static void vol_s16_to_s16(struct comp_dev *dev, struct comp_buffer *sink,
 	/* Main processing loop */
 	for (i = 0; i < frames; i++) {
 		/* Processing per channel */
-		for (channel = 0; channel < dev->params.channels; channel++) {
+		for (channel = 0; channel < sink->channels; channel++) {
 			/* Set source as circular buffer */
 			vol_setup_circular(source);
 

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -195,7 +195,7 @@ struct comp_ops {
 
 	/** set component audio stream parameters */
 	int (*dai_config)(struct comp_dev *dev,
-		struct sof_ipc_dai_config *dai_config);
+			  struct sof_ipc_dai_config *dai_config);
 
 	/** used to pass standard and bespoke commands (with optional data) */
 	int (*cmd)(struct comp_dev *dev, int cmd, void *data,

--- a/src/include/sof/audio/volume.h
+++ b/src/include/sof/audio/volume.h
@@ -138,11 +138,15 @@ typedef void (*scale_vol)(struct comp_dev *, struct comp_buffer *,
  */
 static inline scale_vol vol_get_processing_function(struct comp_dev *dev)
 {
+	struct comp_buffer *sinkb;
 	int i;
+
+	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer,
+				source_list);
 
 	/* map the volume function for source and sink buffers */
 	for (i = 0; i < func_count; i++) {
-		if (dev->params.frame_fmt != func_map[i].frame_fmt)
+		if (sinkb->frame_fmt != func_map[i].frame_fmt)
 			continue;
 
 		return func_map[i].func;

--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -215,11 +215,11 @@ static int ipc_stream_pcm_params(uint32_t stream)
 	struct dma_sg_elem_array elem_array;
 	uint32_t ring_size;
 	enum comp_copy_type copy_type = COMP_COPY_ONE_SHOT;
+	struct comp_dev *cd;
 #endif
 	struct sof_ipc_pcm_params pcm_params;
 	struct sof_ipc_pcm_params_reply reply;
 	struct ipc_comp_dev *pcm_dev;
-	struct comp_dev *cd;
 	int err, reset_err, posn_offset;
 
 	/* copy message with ABI safe method */
@@ -241,15 +241,13 @@ static int ipc_stream_pcm_params(uint32_t stream)
 		return -EINVAL;
 	}
 
-	/* set params component params */
-	cd = pcm_dev->cd;
 	if (IPC_IS_SIZE_INVALID(pcm_params.params)) {
 		IPC_SIZE_ERROR_TRACE(TRACE_CLASS_IPC, pcm_params.params);
 		return -EINVAL;
 	}
-	cd->params = pcm_params.params;
 
 #if CONFIG_HOST_PTABLE
+	cd = pcm_dev->cd;
 
 	/*
 	 * walk in both directions to check if the pipeline is hostless

--- a/test/cmocka/src/audio/mixer/comp_mock.c
+++ b/test/cmocka/src/audio/mixer/comp_mock.c
@@ -23,7 +23,8 @@ static void mock_comp_free(struct comp_dev *dev)
 	free(dev);
 }
 
-static int mock_comp_params(struct comp_dev *dev)
+static int mock_comp_params(struct comp_dev *dev,
+			    struct sof_ipc_stream_params *params)
 {
 	return 0;
 }

--- a/test/cmocka/src/audio/mux/util.h
+++ b/test/cmocka/src/audio/mux/util.h
@@ -25,8 +25,8 @@ static inline struct comp_buffer *create_test_sink(struct comp_dev *dev,
 	/* alloc sink and set default parameters */
 	buffer->sink = calloc(1, sizeof(struct comp_dev));
 	buffer->sink->state = COMP_STATE_PREPARE;
-	buffer->sink->params.frame_fmt = frame_fmt;
-	buffer->sink->params.channels = channels;
+	buffer->frame_fmt = frame_fmt;
+	buffer->channels = channels;
 	buffer->free = 0;
 	buffer->avail = 0;
 	buffer->pipeline_id = pipeline_id;
@@ -53,8 +53,8 @@ static inline struct comp_buffer *create_test_source(struct comp_dev *dev,
 	/* alloc source and set default parameters */
 	buffer->source = calloc(1, sizeof(struct comp_dev));
 	buffer->source->state = COMP_STATE_PREPARE;
-	buffer->source->params.frame_fmt = frame_fmt;
-	buffer->source->params.channels = channels;
+	buffer->frame_fmt = frame_fmt;
+	buffer->channels = channels;
 	buffer->free = 0;
 	buffer->avail = 0;
 	buffer->pipeline_id = pipeline_id;

--- a/tools/testbench/include/testbench/file.h
+++ b/tools/testbench/include/testbench/file.h
@@ -40,6 +40,7 @@ struct file_comp_data {
 	uint32_t frame_bytes;
 	uint32_t rate;
 	struct file_state fs;
+	int sample_container_bytes;
 	int (*file_func)(struct comp_dev *dev, struct comp_buffer *sink,
 			 struct comp_buffer *source, uint32_t frames);
 


### PR DESCRIPTION
Moving pcm params from component to buffer is the first
step to improve parameter propagation within pipelines (#1280).
This commit moves several pcm paremeters (framet_fmt, buffer_fmt,
rate, channels, chmap, except direction) to comp_buffer struct.
Some of specific parameters are moved to private host and
kpb data.

Signed-off-by: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>