### PR TITLE
pm: cavs: fix literal dcache lock in power down

### DIFF
--- a/src/platform/intel/cavs/include/cavs/lib/asm_memory_management.h
+++ b/src/platform/intel/cavs/include/cavs/lib/asm_memory_management.h
@@ -63,14 +63,15 @@
 	bne \ax, \mask, 1b
 .endm
 
-.macro m_cavs_lpsram_power_down_entire ax, ay, az
+.macro m_cavs_lpsram_power_down_entire ax, ay, az, loop_cnt_addr
 	movi \az, LSPGISTS
 	movi \ax, LSPGCTL
 	movi \ay, LPSRAM_MASK()
 	s32i \ay, \ax, 0
 	memw
   // assumed that HDA shared dma buffer will be in LPSRAM
-	movi \ax, 4096
+	movi \ax, \loop_cnt_addr
+	l32i \ax, \ax, 0
 1 :
 	addi \ax, \ax, -1
 	bnez \ax, 1b

--- a/src/platform/intel/cavs/lib/CMakeLists.txt
+++ b/src/platform/intel/cavs/lib/CMakeLists.txt
@@ -1,5 +1,12 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
+add_library(pdown STATIC "")
+target_link_libraries(pdown sof_options)
+target_compile_options(pdown PRIVATE -mtext-section-literals)
+
+add_local_sources(pdown power_down.S)
+target_link_libraries(sof_static_libraries INTERFACE pdown)
+
 add_local_sources(sof
 	clk.c
 	dai.c
@@ -7,7 +14,6 @@ add_local_sources(sof
 	memory.c
 	pm_runtime.c
 	pm_memory.c
-	power_down.S
 )
 
 if(CONFIG_MEM_WND)

--- a/src/platform/intel/cavs/lib/power_down.S
+++ b/src/platform/intel/cavs/lib/power_down.S
@@ -23,10 +23,16 @@
 
 	.section .text, "ax"
 	.align 64
-literals:
+power_down_literals:
 	.literal_position
+ipc_flag:
+	.word IPC_DIPCTDR_BUSY
+sram_dis_loop_cnt:
+	.word 4096
+
 	.global power_down
 	.type power_down, @function
+
 /**
  * Perform power down.
  *
@@ -52,7 +58,7 @@ power_down:
 	// xthal_dcache_region_lock(&literals, 128);
 	// xthal_dcache_region_lock(&powerdown, 256);
 	// xthal_dcache_region_lock(&pu32_hpsram_mask, 64);
-	movi pfl_reg, literals
+	movi pfl_reg, power_down_literals
 	dpfl pfl_reg, 0
 	dpfl pfl_reg, 64
 
@@ -72,7 +78,8 @@ _PD_DISABLE_LPSRAM:
  * }
  */
 	beqz b_enable_lpsram, _PD_DISABLE_HPSRAM
-	m_cavs_lpsram_power_down_entire temp_reg0, temp_reg1, temp_reg2
+	m_cavs_lpsram_power_down_entire temp_reg0, temp_reg1, temp_reg2,\
+					sram_dis_loop_cnt
 	j _PD_DISABLE_HPSRAM
 
 _PD_DISABLE_HPSRAM:
@@ -132,12 +139,12 @@ _PD_SEND_IPC:
  */
 	movi temp_reg0, IPC_HOST_BASE
 	l32i temp_reg1, temp_reg0, IPC_DIPCTDR
-	movi temp_reg2, IPC_DIPCTDR_BUSY
+	movi temp_reg2, ipc_flag
+	l32i temp_reg2, temp_reg2, 0
 	or temp_reg1, temp_reg1, temp_reg2
 	s32i temp_reg1, temp_reg0, IPC_DIPCTDR
 
 	l32i temp_reg1, temp_reg0, IPC_DIPCTDA
-	movi temp_reg2, IPC_DIPCTDA_DONE
 	or temp_reg1, temp_reg1, temp_reg2
 	s32i temp_reg1, temp_reg0, IPC_DIPCTDA
 


### PR DESCRIPTION
Compiler options has to be changed in order to compute
the literal block address correctly.

Some literals must be declared explicitly and loaded
indirectly to make sure that compiler does not optimize
the out to another shared region.

Signed-off-by: Marcin Maka <marcin.maka@linux.intel.com>