### PR TITLE
trace: Add Kconfig options to enable verbose tracing only from certain classes

### DIFF
--- a/src/audio/asrc/asrc.c
+++ b/src/audio/asrc/asrc.c
@@ -29,20 +29,17 @@
 #define trace_asrc(__e, ...)					\
 	trace_event(TRACE_CLASS_SRC, __e, ##__VA_ARGS__)
 #define trace_asrc_with_ids(comp_ptr, __e, ...)			\
-	trace_event_comp(TRACE_CLASS_SRC, comp_ptr,		\
-			 __e, ##__VA_ARGS__)
+	trace_event_comp(SRC, comp_ptr, __e, ##__VA_ARGS__)
 
 #define tracev_asrc(__e, ...) \
 	tracev_event(TRACE_CLASS_SRC, __e, ##__VA_ARGS__)
 #define tracev_asrc_with_ids(comp_ptr, __e, ...)		\
-	tracev_event_comp(TRACE_CLASS_SRC, comp_ptr,		\
-			  __e, ##__VA_ARGS__)
+	tracev_event_comp(SRC, comp_ptr, __e, ##__VA_ARGS__)
 
 #define trace_asrc_error(__e, ...) \
 	trace_error(TRACE_CLASS_SRC, __e, ##__VA_ARGS__)
 #define trace_asrc_error_with_ids(comp_ptr, __e, ...)		\
-	trace_error_comp(TRACE_CLASS_SRC, comp_ptr,		\
-			 __e, ##__VA_ARGS__)
+	trace_error_comp(SRC, comp_ptr, __e, ##__VA_ARGS__)
 
 /* asrc component private data */
 struct comp_data {

--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -34,20 +34,17 @@
 #define trace_dai(__e, ...)					\
 	trace_event(TRACE_CLASS_DAI, __e, ##__VA_ARGS__)
 #define trace_dai_with_ids(comp_ptr, __e, ...)			\
-	trace_event_comp(TRACE_CLASS_DAI, comp_ptr,		\
-			 __e, ##__VA_ARGS__)
+	trace_event_comp(DAI, comp_ptr, __e, ##__VA_ARGS__)
 
 #define tracev_dai(__e, ...)					\
 	tracev_event(TRACE_CLASS_DAI, __e, ##__VA_ARGS__)
 #define tracev_dai_with_ids(comp_ptr, __e, ...)			\
-	tracev_event_comp(TRACE_CLASS_DAI, comp_ptr,		\
-			  __e, ##__VA_ARGS__)
+	tracev_event_comp(DAI, comp_ptr, __e, ##__VA_ARGS__)
 
 #define trace_dai_error(__e, ...)				\
 	trace_error(TRACE_CLASS_DAI, __e, ##__VA_ARGS__)
 #define trace_dai_error_with_ids(comp_ptr, __e, ...)		\
-	trace_error_comp(TRACE_CLASS_DAI, comp_ptr,		\
-			 __e, ##__VA_ARGS__)
+	trace_error_comp(DAI, comp_ptr, __e, ##__VA_ARGS__)
 
 struct dai_data {
 	/* local DMA config */

--- a/src/audio/detect_test.c
+++ b/src/audio/detect_test.c
@@ -35,20 +35,17 @@
 #define trace_keyword(__e, ...) \
 	trace_event(TRACE_CLASS_KEYWORD, __e, ##__VA_ARGS__)
 #define trace_keyword_with_ids(comp_ptr, __e, ...)		\
-	trace_event_comp(TRACE_CLASS_KEYWORD, comp_ptr,		\
-			 __e, ##__VA_ARGS__)
+	trace_event_comp(KEYWORD, comp_ptr, __e, ##__VA_ARGS__)
 
 #define tracev_keyword(__e, ...) \
 	tracev_event(TRACE_CLASS_KEYWORD, __e, ##__VA_ARGS__)
 #define tracev_keyword_with_ids(comp_ptr, __e, ...)		\
-	tracev_event_comp(TRACE_CLASS_KEYWORD, comp_ptr,	\
-			  __e, ##__VA_ARGS__)
+	tracev_event_comp(KEYWORD, comp_ptr, __e, ##__VA_ARGS__)
 
 #define trace_keyword_error(__e, ...) \
 	trace_error(TRACE_CLASS_KEYWORD, __e, ##__VA_ARGS__)
 #define trace_keyword_error_with_ids(comp_ptr, __e, ...)	\
-	trace_error_comp(TRACE_CLASS_KEYWORD, comp_ptr,		\
-			 __e, ##__VA_ARGS__)
+	trace_error_comp(KEYWORD, comp_ptr, __e, ##__VA_ARGS__)
 
 #define ACTIVATION_DEFAULT_SHIFT 3
 #define ACTIVATION_DEFAULT_DIVIDER_S16 0.5

--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -44,19 +44,16 @@
 /* tracing */
 #define trace_eq(__e, ...) trace_event(TRACE_CLASS_EQ_FIR, __e, ##__VA_ARGS__)
 #define trace_eq_with_ids(comp_ptr, __e, ...)			\
-	trace_event_comp(TRACE_CLASS_EQ_FIR, comp_ptr,		\
-			 __e, ##__VA_ARGS__)
+	trace_event_comp(EQ_FIR, comp_ptr, __e, ##__VA_ARGS__)
 
 #define tracev_eq(__e, ...) tracev_event(TRACE_CLASS_EQ_FIR, __e, ##__VA_ARGS__)
 #define tracev_eq_with_ids(comp_ptr, __e, ...)			\
-	tracev_event_comp(TRACE_CLASS_EQ_FIR, comp_ptr,		\
-			  __e, ##__VA_ARGS__)
+	tracev_event_comp(EQ_FIR, comp_ptr, __e, ##__VA_ARGS__)
 
 #define trace_eq_error(__e, ...) \
 	trace_error(TRACE_CLASS_EQ_FIR, __e, ##__VA_ARGS__)
 #define trace_eq_error_with_ids(comp_ptr, __e, ...)		\
-	trace_error_comp(TRACE_CLASS_EQ_FIR, comp_ptr,		\
-			 __e, ##__VA_ARGS__)
+	trace_error_comp(EQ_FIR, comp_ptr, __e, ##__VA_ARGS__)
 
 /* src component private data */
 struct comp_data {

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -33,19 +33,16 @@
 /* tracing */
 #define trace_eq(__e, ...) trace_event(TRACE_CLASS_EQ_IIR, __e, ##__VA_ARGS__)
 #define trace_eq_with_ids(comp_ptr, __e, ...)			\
-	trace_event_comp(TRACE_CLASS_EQ_IIR, comp_ptr,		\
-			 __e, ##__VA_ARGS__)
+	trace_event_comp(EQ_IIR, comp_ptr, __e, ##__VA_ARGS__)
 
 #define tracev_eq(__e, ...) tracev_event(TRACE_CLASS_EQ_IIR, __e, ##__VA_ARGS__)
 #define tracev_eq_with_ids(comp_ptr, __e, ...)			\
-	tracev_event_comp(TRACE_CLASS_EQ_IIR, comp_ptr,		\
-			  __e, ##__VA_ARGS__)
+	tracev_event_comp(EQ_IIR, comp_ptr, __e, ##__VA_ARGS__)
 
 #define trace_eq_error(__e, ...)				\
 	trace_error(TRACE_CLASS_EQ_IIR, __e, ##__VA_ARGS__)
 #define trace_eq_error_with_ids(comp_ptr, __e, ...)		\
-	trace_error_comp(TRACE_CLASS_EQ_IIR, comp_ptr,		\
-			 __e, ##__VA_ARGS__)
+	trace_error_comp(EQ_IIR, comp_ptr, __e, ##__VA_ARGS__)
 
 /* IIR component private data */
 struct comp_data {

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -31,20 +31,17 @@
 #define trace_mixer(__e, ...) \
 	trace_event(TRACE_CLASS_MIXER, __e, ##__VA_ARGS__)
 #define trace_mixer_with_ids(comp_ptr, __e, ...)		\
-	trace_event_comp(TRACE_CLASS_MIXER, comp_ptr,		\
-			 __e, ##__VA_ARGS__)
+	trace_event_comp(MIXER, comp_ptr, __e, ##__VA_ARGS__)
 
 #define tracev_mixer(__e, ...) \
 	tracev_event(TRACE_CLASS_MIXER, __e, ##__VA_ARGS__)
 #define tracev_mixer_with_ids(comp_ptr, __e, ...)		\
-	tracev_event_comp(TRACE_CLASS_MIXER, comp_ptr,		\
-			  __e, ##__VA_ARGS__)
+	tracev_event_comp(MIXER, comp_ptr, __e, ##__VA_ARGS__)
 
 #define trace_mixer_error(__e, ...) \
 	trace_error(TRACE_CLASS_MIXER, __e, ##__VA_ARGS__)
 #define trace_mixer_error_with_ids(comp_ptr, __e, ...)		\
-	trace_error_comp(TRACE_CLASS_MIXER, comp_ptr,		\
-			 __e, ##__VA_ARGS__)
+	trace_error_comp(MIXER, comp_ptr, __e, ##__VA_ARGS__)
 
 /* mixer component private data */
 struct mixer_data {

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -41,20 +41,17 @@
 #define trace_src(__e, ...) \
 	trace_event(TRACE_CLASS_SRC, __e, ##__VA_ARGS__)
 #define trace_src_with_ids(comp_ptr, __e, ...)			\
-	trace_event_comp(TRACE_CLASS_SRC, comp_ptr,		\
-			 __e, ##__VA_ARGS__)
+	trace_event_comp(SRC, comp_ptr, __e, ##__VA_ARGS__)
 
 #define tracev_src(__e, ...) \
 	tracev_event(TRACE_CLASS_SRC, __e, ##__VA_ARGS__)
 #define tracev_src_with_ids(comp_ptr, __e, ...)			\
-	tracev_event_comp(TRACE_CLASS_SRC, comp_ptr,		\
-			  __e, ##__VA_ARGS__)
+	tracev_event_comp(SRC, comp_ptr, __e, ##__VA_ARGS__)
 
 #define trace_src_error(__e, ...) \
 	trace_error(TRACE_CLASS_SRC, __e, ##__VA_ARGS__)
 #define trace_src_error_with_ids(comp_ptr, __e, ...)		\
-	trace_error_comp(TRACE_CLASS_SRC, comp_ptr,		\
-			 __e, ##__VA_ARGS__)
+	trace_error_comp(SRC, comp_ptr, __e, ##__VA_ARGS__)
 
 /* The FIR maximum lengths are per channel so need to multiply them */
 #define MAX_FIR_DELAY_SIZE_XNCH (PLATFORM_MAX_CHANNELS * MAX_FIR_DELAY_SIZE)

--- a/src/audio/switch.c
+++ b/src/audio/switch.c
@@ -15,20 +15,17 @@
 #define trace_switch(__e, ...) \
 	trace_event(TRACE_CLASS_SWITCH, __e, ##__VA_ARGS__)
 #define trace_switch_with_ids(comp_ptr, __e, ...)		\
-	trace_event_comp(TRACE_CLASS_SWITCH, comp_ptr,		\
-			 __e, ##__VA_ARGS__)
+	trace_event_comp(SWITCH, comp_ptr, __e, ##__VA_ARGS__)
 
 #define tracev_switch(__e, ...) \
 	tracev_event(TRACE_CLASS_SWITCH, __e, ##__VA_ARGS__)
 #define tracev_switch_with_ids(comp_ptr, __e, ...)		\
-	tracev_event_comp(TRACE_CLASS_SWITCH, comp_ptr,		\
-			  __e, ##__VA_ARGS__)
+	tracev_event_comp(SWITCH, comp_ptr, __e, ##__VA_ARGS__)
 
 #define trace_switch_error(__e, ...) \
 	trace_error(TRACE_CLASS_SWITCH, __e, ##__VA_ARGS__)
 #define trace_switch_error_with_ids(comp_ptr, __e, ...)		\
-	trace_error_comp(TRACE_CLASS_SWITCH, comp_ptr,		\
-			 __e, ##__VA_ARGS__)
+	trace_error_comp(SWITCH, comp_ptr, __e, ##__VA_ARGS__)
 
 
 static struct comp_dev *switch_new(struct sof_ipc_comp *comp)

--- a/src/audio/tone.c
+++ b/src/audio/tone.c
@@ -34,20 +34,17 @@
 #define trace_tone(__e, ...) \
 	trace_event(TRACE_CLASS_TONE, __e, ##__VA_ARGS__)
 #define trace_tone_with_ids(comp_ptr, __e, ...)			\
-	trace_event_comp(TRACE_CLASS_TONE, comp_ptr,		\
-			 __e, ##__VA_ARGS__)
+	trace_event_comp(TONE, comp_ptr, __e, ##__VA_ARGS__)
 
 #define tracev_tone(__e, ...) \
 	tracev_event(TRACE_CLASS_TONE, __e, ##__VA_ARGS__)
 #define tracev_tone_with_ids(comp_ptr, __e, ...)		\
-	tracev_event_comp(TRACE_CLASS_TONE, comp_ptr,		\
-			  __e, ##__VA_ARGS__)
+	tracev_event_comp(TONE, comp_ptr, __e, ##__VA_ARGS__)
 
 #define trace_tone_error(__e, ...) \
 	trace_error(TRACE_CLASS_TONE, __e, ##__VA_ARGS__)
 #define trace_tone_error_with_ids(comp_ptr, __e, ...)		\
-	trace_error_comp(TRACE_CLASS_TONE, comp_ptr,		\
-			 __e, ##__VA_ARGS__)
+	trace_error_comp(TONE, comp_ptr, __e, ##__VA_ARGS__)
 
 /* Convert float frequency in Hz to Q16.16 fractional format */
 #define TONE_FREQ(f) Q_CONVERT_FLOAT(f, 16)

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -146,20 +146,17 @@ struct dai_hw_params;
 #define trace_comp(__e, ...) \
 	trace_event(TRACE_CLASS_COMP, __e, ##__VA_ARGS__)
 #define trace_comp_with_ids(comp_ptr, __e, ...)			\
-	trace_event_comp(TRACE_CLASS_COMP, comp_ptr,		\
-			 __e, ##__VA_ARGS__)
+	trace_event_comp(COMP, comp_ptr, __e, ##__VA_ARGS__)
 
 #define tracev_comp(__e, ...) \
 	tracev_event(TRACE_CLASS_COMP, __e, ##__VA_ARGS__)
 #define tracev_comp_with_ids(comp_ptr, __e, ...)		\
-	tracev_event_comp(TRACE_CLASS_COMP, comp_ptr,		\
-			  __e, ##__VA_ARGS__)
+	tracev_event_comp(COMP, comp_ptr, __e, ##__VA_ARGS__)
 
 #define trace_comp_error(__e, ...) \
 	trace_error(TRACE_CLASS_COMP, __e, ##__VA_ARGS__)
 #define trace_comp_error_with_ids(comp_ptr, __e, ...)		\
-	trace_error_comp(TRACE_CLASS_COMP, comp_ptr,		\
-			 __e, ##__VA_ARGS__)
+	trace_error_comp(COMP, comp_ptr, __e, ##__VA_ARGS__)
 /** @}*/
 
 /* \brief Type of endpoint this component is connected to in a pipeline */

--- a/src/include/sof/audio/kpb.h
+++ b/src/include/sof/audio/kpb.h
@@ -17,19 +17,16 @@ struct comp_buffer;
 /* KPB tracing */
 #define trace_kpb(__e, ...) trace_event(TRACE_CLASS_KPB, __e, ##__VA_ARGS__)
 #define trace_kpb_with_ids(comp_ptr, __e, ...)			\
-	trace_event_comp(TRACE_CLASS_KPB, comp_ptr,		\
-			 __e, ##__VA_ARGS__)
+	trace_event_comp(KPB, comp_ptr, __e, ##__VA_ARGS__)
 
 #define tracev_kpb(__e, ...) tracev_event(TRACE_CLASS_KPB, __e, ##__VA_ARGS__)
 #define tracev_kpb_with_ids(comp_ptr, __e, ...)			\
-	tracev_event_comp(TRACE_CLASS_KPB, comp_ptr,		\
-			  __e, ##__VA_ARGS__)
+	tracev_event_comp(KPB, comp_ptr, __e, ##__VA_ARGS__)
 
 #define trace_kpb_error(__e, ...) trace_error(TRACE_CLASS_KPB, __e, \
 					      ##__VA_ARGS__)
 #define trace_kpb_error_with_ids(comp_ptr, __e, ...)		\
-	trace_error_comp(TRACE_CLASS_KPB, comp_ptr,		\
-			 __e, ##__VA_ARGS__)
+	trace_error_comp(KPB, comp_ptr, __e, ##__VA_ARGS__)
 
 /* KPB internal defines */
 #define KPB_MAX_BUFF_TIME 2100 /**< time of buffering in miliseconds */

--- a/src/include/sof/audio/mux.h
+++ b/src/include/sof/audio/mux.h
@@ -31,20 +31,17 @@ struct comp_dev;
  /* tracing */
 #define trace_mux(__e, ...) trace_event(TRACE_CLASS_MUX, __e, ##__VA_ARGS__)
 #define trace_mux_with_ids(comp_ptr, __e, ...)			\
-	trace_event_comp(TRACE_CLASS_MUX, comp_ptr,		\
-			 __e, ##__VA_ARGS__)
+	trace_event_comp(MUX, comp_ptr, __e, ##__VA_ARGS__)
 
 #define tracev_mux(__e, ...) \
 	tracev_event(TRACE_CLASS_MUX, __e, ##__VA_ARGS__)
 #define tracev_mux_with_ids(comp_ptr, __e, ...)			\
-	tracev_event_comp(TRACE_CLASS_MUX, comp_ptr,		\
-			  __e, ##__VA_ARGS__)
+	tracev_event_comp(MUX, comp_ptr, __e, ##__VA_ARGS__)
 
 #define trace_mux_error(__e, ...) \
 	trace_error(TRACE_CLASS_MUX, __e, ##__VA_ARGS__)
 #define trace_mux_error_with_ids(comp_ptr, __e, ...)		\
-	trace_error_comp(TRACE_CLASS_MUX, comp_ptr,		\
-			 __e, ##__VA_ARGS__)
+	trace_error_comp(MUX, comp_ptr, __e, ##__VA_ARGS__)
 
 /** \brief Supported streams count. */
 #define MUX_MAX_STREAMS 4

--- a/src/include/sof/audio/selector.h
+++ b/src/include/sof/audio/selector.h
@@ -27,22 +27,19 @@ struct comp_dev;
 #define trace_selector(__e, ...) \
 	trace_event(TRACE_CLASS_SELECTOR, __e, ##__VA_ARGS__)
 #define trace_selector_with_ids(comp_ptr, __e, ...)		\
-	trace_event_comp(TRACE_CLASS_SELECTOR, comp_ptr,	\
-			 __e, ##__VA_ARGS__)
+	trace_event_comp(SELECTOR, comp_ptr, __e, ##__VA_ARGS__)
 
 /** \brief Selector trace verbose function. */
 #define tracev_selector(__e, ...) \
 	tracev_event(TRACE_CLASS_SELECTOR, __e, ##__VA_ARGS__)
 #define tracev_selector_with_ids(comp_ptr, __e, ...)		\
-	tracev_event_comp(TRACE_CLASS_SELECTOR, comp_ptr,	\
-			  __e, ##__VA_ARGS__)
+	tracev_event_comp(SELECTOR, comp_ptr, __e, ##__VA_ARGS__)
 
 /** \brief Selector trace error function. */
 #define trace_selector_error(__e, ...) \
 	trace_error(TRACE_CLASS_SELECTOR, __e, ##__VA_ARGS__)
 #define trace_selector_error_with_ids(comp_ptr, __e, ...)	\
-	trace_error_comp(TRACE_CLASS_SELECTOR, comp_ptr,	\
-			 __e, ##__VA_ARGS__)
+	trace_error_comp(SELECTOR, comp_ptr, __e, ##__VA_ARGS__)
 
 /** \brief Supported channel count on input. */
 #define SEL_SOURCE_2CH 2

--- a/src/include/sof/audio/volume.h
+++ b/src/include/sof/audio/volume.h
@@ -43,22 +43,19 @@ struct sof_ipc_ctrl_value_chan;
 #define trace_volume(__e, ...) \
 	trace_event(TRACE_CLASS_VOLUME, __e, ##__VA_ARGS__)
 #define trace_volume_with_ids(comp_ptr, __e, ...)		\
-	trace_event_comp(TRACE_CLASS_VOLUME, comp_ptr,		\
-			 __e, ##__VA_ARGS__)
+	trace_event_comp(VOLUME, comp_ptr, __e, ##__VA_ARGS__)
 
 /** \brief Volume trace value function. */
 #define tracev_volume(__e, ...) \
 	tracev_event(TRACE_CLASS_VOLUME, __e, ##__VA_ARGS__)
 #define tracev_volume_with_ids(comp_ptr, __e, ...)		\
-	tracev_event_comp(TRACE_CLASS_VOLUME, comp_ptr,		\
-			  __e, ##__VA_ARGS__)
+	tracev_event_comp(VOLUME, comp_ptr, __e, ##__VA_ARGS__)
 
 /** \brief Volume trace error function. */
 #define trace_volume_error(__e, ...) \
 	trace_error(TRACE_CLASS_VOLUME, __e, ##__VA_ARGS__)
 #define trace_volume_error_with_ids(comp_ptr, __e, ...)		\
-	trace_error_comp(TRACE_CLASS_VOLUME, comp_ptr,		\
-			 __e, ##__VA_ARGS__)
+	trace_error_comp(VOLUME, comp_ptr, __e, ##__VA_ARGS__)
 
 //** \brief Volume gain Qx.y integer x number of bits including sign bit. */
 #define VOL_QXY_X 8

--- a/src/include/sof/trace/trace-verbose-private.h
+++ b/src/include/sof/trace/trace-verbose-private.h
@@ -1,0 +1,557 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2019 Intel Corporation. All rights reserved.
+ *
+ * Author: Artur Kloniecki <arturx.kloniecki@linux.intel.com>
+ */
+
+#ifndef __SOF_TRACE_TRACE_VERBOSE_PRIVATE_H__
+#define __SOF_TRACE_TRACE_VERBOSE_PRIVATE_H__
+
+#include <config.h>
+
+#if CONFIG_TRACE_VERBOSE_IRQ
+#define tracev_TRACE_CLASS_IRQ(...)		\
+	trace_event(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_IRQ(...)		\
+	trace_event_with_ids(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_IRQ(...)	\
+	trace_event_atomic(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_IRQ(...)	\
+	trace_event_atomic_with_ids(__VA_ARGS__)
+#else
+#define tracev_TRACE_CLASS_IRQ(...)		UNUSED(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_IRQ(...)		UNUSED(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_IRQ(...)	UNUSED(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_IRQ(...)	UNUSED(__VA_ARGS__)
+#endif /* CONFIG_TRACE_VERBOSE_IRQ */
+
+#if CONFIG_TRACE_VERBOSE_IPC
+#define tracev_TRACE_CLASS_IPC(...)		\
+	trace_event(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_IPC(...)		\
+	trace_event_with_ids(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_IPC(...)	\
+	trace_event_atomic(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_IPC(...)	\
+	trace_event_atomic_with_ids(__VA_ARGS__)
+#else
+#define tracev_TRACE_CLASS_IPC(...)		UNUSED(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_IPC(...)		UNUSED(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_IPC(...)	UNUSED(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_IPC(...)	UNUSED(__VA_ARGS__)
+#endif /* CONFIG_TRACE_VERBOSE_IPC */
+
+#if CONFIG_TRACE_VERBOSE_PIPE
+#define tracev_TRACE_CLASS_PIPE(...)		\
+	trace_event(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_PIPE(...)	\
+	trace_event_with_ids(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_PIPE(...)	\
+	trace_event_atomic(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_PIPE(...)	\
+	trace_event_atomic_with_ids(__VA_ARGS__)
+#else
+#define tracev_TRACE_CLASS_PIPE(...)		UNUSED(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_PIPE(...)	UNUSED(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_PIPE(...)	UNUSED(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_PIPE(...)	UNUSED(__VA_ARGS__)
+#endif /* CONFIG_TRACE_VERBOSE_PIPE */
+
+#if CONFIG_TRACE_VERBOSE_HOST
+#define tracev_TRACE_CLASS_HOST(...)		\
+	trace_event(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_HOST(...)	\
+	trace_event_with_ids(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_HOST(...)	\
+	trace_event_atomic(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_HOST(...)	\
+	trace_event_atomic_with_ids(__VA_ARGS__)
+#else
+#define tracev_TRACE_CLASS_HOST(...)		UNUSED(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_HOST(...)	UNUSED(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_HOST(...)	UNUSED(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_HOST(...)	UNUSED(__VA_ARGS__)
+#endif /* CONFIG_TRACE_VERBOSE_HOST */
+
+#if CONFIG_TRACE_VERBOSE_DAI
+#define tracev_TRACE_CLASS_DAI(...)		\
+	trace_event(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_DAI(...)		\
+	trace_event_with_ids(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_DAI(...)	\
+	trace_event_atomic(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_DAI(...)	\
+	trace_event_atomic_with_ids(__VA_ARGS__)
+#else
+#define tracev_TRACE_CLASS_DAI(...)		UNUSED(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_DAI(...)		UNUSED(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_DAI(...)	UNUSED(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_DAI(...)	UNUSED(__VA_ARGS__)
+#endif /* CONFIG_TRACE_VERBOSE_DAI */
+
+#if CONFIG_TRACE_VERBOSE_DMA
+#define tracev_TRACE_CLASS_DMA(...)		\
+	trace_event(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_DMA(...)		\
+	trace_event_with_ids(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_DMA(...)	\
+	trace_event_atomic(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_DMA(...)	\
+	trace_event_atomic_with_ids(__VA_ARGS__)
+#else
+#define tracev_TRACE_CLASS_DMA(...)		UNUSED(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_DMA(...)		UNUSED(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_DMA(...)	UNUSED(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_DMA(...)	UNUSED(__VA_ARGS__)
+#endif /* CONFIG_TRACE_VERBOSE_DMA */
+
+#if CONFIG_TRACE_VERBOSE_SSP
+#define tracev_TRACE_CLASS_SSP(...)		\
+	trace_event(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_SSP(...)		\
+	trace_event_with_ids(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_SSP(...)	\
+	trace_event_atomic(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_SSP(...)	\
+	trace_event_atomic_with_ids(__VA_ARGS__)
+#else
+#define tracev_TRACE_CLASS_SSP(...)		UNUSED(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_SSP(...)		UNUSED(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_SSP(...)	UNUSED(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_SSP(...)	UNUSED(__VA_ARGS__)
+#endif /* CONFIG_TRACE_VERBOSE_SSP */
+
+#if CONFIG_TRACE_VERBOSE_COMP
+#define tracev_TRACE_CLASS_COMP(...)		\
+	trace_event(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_COMP(...)	\
+	trace_event_with_ids(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_COMP(...)	\
+	trace_event_atomic(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_COMP(...)	\
+	trace_event_atomic_with_ids(__VA_ARGS__)
+#else
+#define tracev_TRACE_CLASS_COMP(...)		UNUSED(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_COMP(...)	UNUSED(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_COMP(...)	UNUSED(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_COMP(...)	UNUSED(__VA_ARGS__)
+#endif /* CONFIG_TRACE_VERBOSE_COMP */
+
+#if CONFIG_TRACE_VERBOSE_WAIT
+#define tracev_TRACE_CLASS_WAIT(...)		\
+	trace_event(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_WAIT(...)	\
+	trace_event_with_ids(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_WAIT(...)	\
+	trace_event_atomic(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_WAIT(...)	\
+	trace_event_atomic_with_ids(__VA_ARGS__)
+#else
+#define tracev_TRACE_CLASS_WAIT(...)		UNUSED(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_WAIT(...)	UNUSED(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_WAIT(...)	UNUSED(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_WAIT(...)	UNUSED(__VA_ARGS__)
+#endif /* CONFIG_TRACE_VERBOSE_WAIT */
+
+#if CONFIG_TRACE_VERBOSE_LOCK
+#define tracev_TRACE_CLASS_LOCK(...)		\
+	trace_event(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_LOCK(...)	\
+	trace_event_with_ids(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_LOCK(...)	\
+	trace_event_atomic(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_LOCK(...)	\
+	trace_event_atomic_with_ids(__VA_ARGS__)
+#else
+#define tracev_TRACE_CLASS_LOCK(...)		UNUSED(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_LOCK(...)	UNUSED(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_LOCK(...)	UNUSED(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_LOCK(...)	UNUSED(__VA_ARGS__)
+#endif /* CONFIG_TRACE_VERBOSE_LOCK */
+
+#if CONFIG_TRACE_VERBOSE_MEM
+#define tracev_TRACE_CLASS_MEM(...)		\
+	trace_event(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_MEM(...)		\
+	trace_event_with_ids(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_MEM(...)	\
+	trace_event_atomic(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_MEM(...)	\
+	trace_event_atomic_with_ids(__VA_ARGS__)
+#else
+#define tracev_TRACE_CLASS_MEM(...)		UNUSED(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_MEM(...)		UNUSED(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_MEM(...)	UNUSED(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_MEM(...)	UNUSED(__VA_ARGS__)
+#endif /* CONFIG_TRACE_VERBOSE_MEM */
+
+#if CONFIG_TRACE_VERBOSE_MIXER
+#define tracev_TRACE_CLASS_MIXER(...)		\
+	trace_event(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_MIXER(...)	\
+	trace_event_with_ids(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_MIXER(...)	\
+	trace_event_atomic(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_MIXER(...)\
+	trace_event_atomic_with_ids(__VA_ARGS__)
+#else
+#define tracev_TRACE_CLASS_MIXER(...)			UNUSED(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_MIXER(...)		UNUSED(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_MIXER(...)		UNUSED(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_MIXER(...)	UNUSED(__VA_ARGS__)
+#endif /* CONFIG_TRACE_VERBOSE_MIXER */
+
+#if CONFIG_TRACE_VERBOSE_BUFFER
+#define tracev_TRACE_CLASS_BUFFER(...)			\
+	trace_event(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_BUFFER(...)		\
+	trace_event_with_ids(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_BUFFER(...)		\
+	trace_event_atomic(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_BUFFER(...)	\
+	trace_event_atomic_with_ids(__VA_ARGS__)
+#else
+#define tracev_TRACE_CLASS_BUFFER(...)			UNUSED(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_BUFFER(...)		UNUSED(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_BUFFER(...)		UNUSED(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_BUFFER(...)	UNUSED(__VA_ARGS__)
+#endif /* CONFIG_TRACE_VERBOSE_BUFFER */
+
+#if CONFIG_TRACE_VERBOSE_VOLUME
+#define tracev_TRACE_CLASS_VOLUME(...)			\
+	trace_event(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_VOLUME(...)		\
+	trace_event_with_ids(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_VOLUME(...)		\
+	trace_event_atomic(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_VOLUME(...)	\
+	trace_event_atomic_with_ids(__VA_ARGS__)
+#else
+#define tracev_TRACE_CLASS_VOLUME(...)			UNUSED(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_VOLUME(...)		UNUSED(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_VOLUME(...)		UNUSED(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_VOLUME(...)	UNUSED(__VA_ARGS__)
+#endif /* CONFIG_TRACE_VERBOSE_VOLUME */
+
+#if CONFIG_TRACE_VERBOSE_SWITCH
+#define tracev_TRACE_CLASS_SWITCH(...)			\
+	trace_event(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_SWITCH(...)		\
+	trace_event_with_ids(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_SWITCH(...)		\
+	trace_event_atomic(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_SWITCH(...)	\
+	trace_event_atomic_with_ids(__VA_ARGS__)
+#else
+#define tracev_TRACE_CLASS_SWITCH(...)			UNUSED(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_SWITCH(...)		UNUSED(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_SWITCH(...)		UNUSED(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_SWITCH(...)	UNUSED(__VA_ARGS__)
+#endif /* CONFIG_TRACE_VERBOSE_SWITCH */
+
+#if CONFIG_TRACE_VERBOSE_MUX
+#define tracev_TRACE_CLASS_MUX(...)		\
+	trace_event(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_MUX(...)		\
+	trace_event_with_ids(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_MUX(...)	\
+	trace_event_atomic(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_MUX(...)	\
+	trace_event_atomic_with_ids(__VA_ARGS__)
+#else
+#define tracev_TRACE_CLASS_MUX(...)		UNUSED(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_MUX(...)		UNUSED(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_MUX(...)	UNUSED(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_MUX(...)	UNUSED(__VA_ARGS__)
+#endif /* CONFIG_TRACE_VERBOSE_MUX */
+
+#if CONFIG_TRACE_VERBOSE_SRC
+#define tracev_TRACE_CLASS_SRC(...)		\
+	trace_event(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_SRC(...)		\
+	trace_event_with_ids(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_SRC(...)	\
+	trace_event_atomic(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_SRC(...)	\
+	trace_event_atomic_with_ids(__VA_ARGS__)
+#else
+#define tracev_TRACE_CLASS_SRC(...)		UNUSED(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_SRC(...)		UNUSED(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_SRC(...)	UNUSED(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_SRC(...)	UNUSED(__VA_ARGS__)
+#endif /* CONFIG_TRACE_VERBOSE_SRC */
+
+#if CONFIG_TRACE_VERBOSE_TONE
+#define tracev_TRACE_CLASS_TONE(...)		\
+	trace_event(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_TONE(...)	\
+	trace_event_with_ids(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_TONE(...)	\
+	trace_event_atomic(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_TONE(...)	\
+	trace_event_atomic_with_ids(__VA_ARGS__)
+#else
+#define tracev_TRACE_CLASS_TONE(...)		UNUSED(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_TONE(...)	UNUSED(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_TONE(...)	UNUSED(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_TONE(...)	UNUSED(__VA_ARGS__)
+#endif /* CONFIG_TRACE_VERBOSE_TONE */
+
+#if CONFIG_TRACE_VERBOSE_EQ_FIR
+#define tracev_TRACE_CLASS_EQ_FIR(...)			\
+	trace_event(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_EQ_FIR(...)		\
+	trace_event_with_ids(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_EQ_FIR(...)		\
+	trace_event_atomic(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_EQ_FIR(...)	\
+	trace_event_atomic_with_ids(__VA_ARGS__)
+#else
+#define tracev_TRACE_CLASS_EQ_FIR(...)			UNUSED(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_EQ_FIR(...)		UNUSED(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_EQ_FIR(...)		UNUSED(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_EQ_FIR(...)	UNUSED(__VA_ARGS__)
+#endif /* CONFIG_TRACE_VERBOSE_EQ_FIR */
+
+#if CONFIG_TRACE_VERBOSE_EQ_IIR
+#define tracev_TRACE_CLASS_EQ_IIR(...)			\
+	trace_event(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_EQ_IIR(...)		\
+	trace_event_with_ids(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_EQ_IIR(...)		\
+	trace_event_atomic(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_EQ_IIR(...)	\
+	trace_event_atomic_with_ids(__VA_ARGS__)
+#else
+#define tracev_TRACE_CLASS_EQ_IIR(...)			UNUSED(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_EQ_IIR(...)		UNUSED(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_EQ_IIR(...)		UNUSED(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_EQ_IIR(...)	UNUSED(__VA_ARGS__)
+#endif /* CONFIG_TRACE_VERBOSE_EQ_IIR */
+
+#if CONFIG_TRACE_VERBOSE_SA
+#define tracev_TRACE_CLASS_SA(...)		\
+	trace_event(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_SA(...)		\
+	trace_event_with_ids(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_SA(...)	\
+	trace_event_atomic(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_SA(...)	\
+	trace_event_atomic_with_ids(__VA_ARGS__)
+#else
+#define tracev_TRACE_CLASS_SA(...)		UNUSED(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_SA(...)		UNUSED(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_SA(...)	UNUSED(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_SA(...)	UNUSED(__VA_ARGS__)
+#endif /* CONFIG_TRACE_VERBOSE_SA */
+
+#if CONFIG_TRACE_VERBOSE_DMIC
+#define tracev_TRACE_CLASS_DMIC(...)		\
+	trace_event(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_DMIC(...)	\
+	trace_event_with_ids(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_DMIC(...)	\
+	trace_event_atomic(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_DMIC(...)	\
+	trace_event_atomic_with_ids(__VA_ARGS__)
+#else
+#define tracev_TRACE_CLASS_DMIC(...)		UNUSED(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_DMIC(...)	UNUSED(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_DMIC(...)	UNUSED(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_DMIC(...)	UNUSED(__VA_ARGS__)
+#endif /* CONFIG_TRACE_VERBOSE_DMIC */
+
+#if CONFIG_TRACE_VERBOSE_POWER
+#define tracev_TRACE_CLASS_POWER(...)		\
+	trace_event(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_POWER(...)	\
+	trace_event_with_ids(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_POWER(...)	\
+	trace_event_atomic(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_POWER(...)\
+	trace_event_atomic_with_ids(__VA_ARGS__)
+#else
+#define tracev_TRACE_CLASS_POWER(...)			UNUSED(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_POWER(...)		UNUSED(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_POWER(...)		UNUSED(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_POWER(...)	UNUSED(__VA_ARGS__)
+#endif /* CONFIG_TRACE_VERBOSE_POWER */
+
+#if CONFIG_TRACE_VERBOSE_IDC
+#define tracev_TRACE_CLASS_IDC(...)		\
+	trace_event(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_IDC(...)		\
+	trace_event_with_ids(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_IDC(...)	\
+	trace_event_atomic(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_IDC(...)	\
+	trace_event_atomic_with_ids(__VA_ARGS__)
+#else
+#define tracev_TRACE_CLASS_IDC(...)		UNUSED(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_IDC(...)		UNUSED(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_IDC(...)	UNUSED(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_IDC(...)	UNUSED(__VA_ARGS__)
+#endif /* CONFIG_TRACE_VERBOSE_IDC */
+
+#if CONFIG_TRACE_VERBOSE_CPU
+#define tracev_TRACE_CLASS_CPU(...)		\
+	trace_event(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_CPU(...)		\
+	trace_event_with_ids(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_CPU(...)	\
+	trace_event_atomic(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_CPU(...)	\
+	trace_event_atomic_with_ids(__VA_ARGS__)
+#else
+#define tracev_TRACE_CLASS_CPU(...)		UNUSED(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_CPU(...)		UNUSED(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_CPU(...)	UNUSED(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_CPU(...)	UNUSED(__VA_ARGS__)
+#endif /* CONFIG_TRACE_VERBOSE_CPU */
+
+#if CONFIG_TRACE_VERBOSE_CLK
+#define tracev_TRACE_CLASS_CLK(...)		\
+	trace_event(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_CLK(...)		\
+	trace_event_with_ids(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_CLK(...)	\
+	trace_event_atomic(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_CLK(...)	\
+	trace_event_atomic_with_ids(__VA_ARGS__)
+#else
+#define tracev_TRACE_CLASS_CLK(...)		UNUSED(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_CLK(...)		UNUSED(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_CLK(...)	UNUSED(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_CLK(...)	UNUSED(__VA_ARGS__)
+#endif /* CONFIG_TRACE_VERBOSE_CLK */
+
+#if CONFIG_TRACE_VERBOSE_EDF
+#define tracev_TRACE_CLASS_EDF(...)		\
+	trace_event(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_EDF(...)		\
+	trace_event_with_ids(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_EDF(...)	\
+	trace_event_atomic(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_EDF(...)	\
+	trace_event_atomic_with_ids(__VA_ARGS__)
+#else
+#define tracev_TRACE_CLASS_EDF(...)		UNUSED(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_EDF(...)		UNUSED(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_EDF(...)	UNUSED(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_EDF(...)	UNUSED(__VA_ARGS__)
+#endif /* CONFIG_TRACE_VERBOSE_EDF */
+
+#if CONFIG_TRACE_VERBOSE_KPB
+#define tracev_TRACE_CLASS_KPB(...)		\
+	trace_event(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_KPB(...)		\
+	trace_event_with_ids(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_KPB(...)	\
+	trace_event_atomic(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_KPB(...)	\
+	trace_event_atomic_with_ids(__VA_ARGS__)
+#else
+#define tracev_TRACE_CLASS_KPB(...)		UNUSED(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_KPB(...)		UNUSED(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_KPB(...)	UNUSED(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_KPB(...)	UNUSED(__VA_ARGS__)
+#endif /* CONFIG_TRACE_VERBOSE_KPB */
+
+#if CONFIG_TRACE_VERBOSE_SELECTOR
+#define tracev_TRACE_CLASS_SELECTOR(...)		\
+	trace_event(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_SELECTOR(...)		\
+	trace_event_with_ids(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_SELECTOR(...)		\
+	trace_event_atomic(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_SELECTOR(...)	\
+	trace_event_atomic_with_ids(__VA_ARGS__)
+#else
+#define tracev_TRACE_CLASS_SELECTOR(...)		UNUSED(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_SELECTOR(...)		UNUSED(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_SELECTOR(...)		UNUSED(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_SELECTOR(...)	UNUSED(__VA_ARGS__)
+#endif /* CONFIG_TRACE_VERBOSE_SELECTOR */
+
+#if CONFIG_TRACE_VERBOSE_SCHEDULE
+#define tracev_TRACE_CLASS_SCHEDULE(...)		\
+	trace_event(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_SCHEDULE(...)		\
+	trace_event_with_ids(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_SCHEDULE(...)		\
+	trace_event_atomic(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_SCHEDULE(...)	\
+	trace_event_atomic_with_ids(__VA_ARGS__)
+#else
+#define tracev_TRACE_CLASS_SCHEDULE(...)		UNUSED(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_SCHEDULE(...)		UNUSED(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_SCHEDULE(...)		UNUSED(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_SCHEDULE(...)	UNUSED(__VA_ARGS__)
+#endif /* CONFIG_TRACE_VERBOSE_SCHEDULE */
+
+#if CONFIG_TRACE_VERBOSE_SCHEDULE_LL
+#define tracev_TRACE_CLASS_SCHEDULE_LL(...)		\
+	trace_event(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_SCHEDULE_LL(...)		\
+	trace_event_with_ids(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_SCHEDULE_LL(...)	\
+	trace_event_atomic(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_SCHEDULE_LL(...)	\
+	trace_event_atomic_with_ids(__VA_ARGS__)
+#else
+#define tracev_TRACE_CLASS_SCHEDULE_LL(...)		UNUSED(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_SCHEDULE_LL(...)		UNUSED(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_SCHEDULE_LL(...)	UNUSED(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_SCHEDULE_LL(...)	UNUSED(__VA_ARGS__)
+#endif /* CONFIG_TRACE_VERBOSE_SCHEDULE_LL */
+
+#if CONFIG_TRACE_VERBOSE_ALH
+#define tracev_TRACE_CLASS_ALH(...)		\
+	trace_event(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_ALH(...)		\
+	trace_event_with_ids(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_ALH(...)	\
+	trace_event_atomic(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_ALH(...)	\
+	trace_event_atomic_with_ids(__VA_ARGS__)
+#else
+#define tracev_TRACE_CLASS_ALH(...)		UNUSED(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_ALH(...)		UNUSED(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_ALH(...)	UNUSED(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_ALH(...)	UNUSED(__VA_ARGS__)
+#endif /* CONFIG_TRACE_VERBOSE_ALH */
+
+#if CONFIG_TRACE_VERBOSE_KEYWORD
+#define tracev_TRACE_CLASS_KEYWORD(...)			\
+	trace_event(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_KEYWORD(...)		\
+	trace_event_with_ids(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_KEYWORD(...)		\
+	trace_event_atomic(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_KEYWORD(...)	\
+	trace_event_atomic_with_ids(__VA_ARGS__)
+#else
+#define tracev_TRACE_CLASS_KEYWORD(...)			UNUSED(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_KEYWORD(...)		UNUSED(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_KEYWORD(...)		UNUSED(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_KEYWORD(...)	UNUSED(__VA_ARGS__)
+#endif /* CONFIG_TRACE_VERBOSE_KEYWORD */
+
+#if CONFIG_TRACE_VERBOSE_CHMAP
+#define tracev_TRACE_CLASS_CHMAP(...)			\
+	trace_event(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_CHMAP(...)		\
+	trace_event_with_ids(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_CHMAP(...)		\
+	trace_event_atomic(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_CHMAP(...)	\
+	trace_event_atomic_with_ids(__VA_ARGS__)
+#else
+#define tracev_TRACE_CLASS_CHMAP(...)			UNUSED(__VA_ARGS__)
+#define tracev_ids_TRACE_CLASS_CHMAP(...)		UNUSED(__VA_ARGS__)
+#define tracev_atomic_TRACE_CLASS_CHMAP(...)		UNUSED(__VA_ARGS__)
+#define tracev_atomic_ids_TRACE_CLASS_CHMAP(...)	UNUSED(__VA_ARGS__)
+#endif /* CONFIG_TRACE_VERBOSE_CHMAP */
+
+#endif /* __SOF_TRACE_TRACE_VERBOSE_PRIVATE_H__ */

--- a/src/include/sof/trace/trace.h
+++ b/src/include/sof/trace/trace.h
@@ -19,8 +19,9 @@
 #include <platform/trace/trace.h>
 #endif
 #include <sof/common.h>
-#include <sof/trace/preproc.h>
 #include <config.h>
+#include <sof/trace/preproc.h>
+#include <sof/trace/trace-verbose-private.h>
 #include <stdint.h>
 #if CONFIG_LIBRARY
 #include <stdio.h>
@@ -287,7 +288,7 @@ do {									\
 		uint32_t line_idx;				\
 		uint32_t file_name_len;				\
 		uint32_t text_len;				\
-		const char file_name[sizeof(RELATIVE_FILE)];		\
+		const char file_name[sizeof(RELATIVE_FILE)];	\
 		const char text[sizeof(format)];		\
 	} log_entry = {						\
 		lvl,						\
@@ -318,11 +319,14 @@ do {									\
 
 /* verbose tracing */
 #if CONFIG_TRACEV
-#define tracev_event(...) trace_event(__VA_ARGS__)
-#define tracev_event_with_ids(...) trace_event_with_ids(__VA_ARGS__)
-#define tracev_event_atomic(...) trace_event_atomic(__VA_ARGS__)
-#define tracev_event_atomic_with_ids(...) \
-	trace_event_atomic_with_ids(__VA_ARGS__)
+#define tracev_event(class, ...)		\
+	tracev_##class(class, __VA_ARGS__)
+#define tracev_event_with_ids(class, ...)	\
+	tracev_ids_##class(class, __VA_ARGS__)
+#define tracev_event_atomic(class, ...)		\
+	tracev_atomic_##class(class, __VA_ARGS__)
+#define tracev_event_atomic_with_ids(class, ...)\
+	tracev_atomic_ids_##class(class, __VA_ARGS__)
 #else
 #define tracev_event(class, format, ...) \
 	trace_unused(class, -1, -1, format, ##__VA_ARGS__)
@@ -332,7 +336,6 @@ do {									\
 	trace_unused(class, -1, -1, format, ##__VA_ARGS__)
 #define tracev_event_atomic_with_ids(class, id_0, id_1, format, ...) \
 	trace_unused(class, id_0, id_1, format, ##__VA_ARGS__)
-
 #endif
 
 /* error tracing */
@@ -365,7 +368,7 @@ do {									\
 
 /* tracing from component */
 #define _trace_comp_build(fun, class, comp_ptr, format, ...)		\
-		fun(class, comp_ptr->comp.pipeline_id,			\
+		fun(TRACE_CLASS_##class, comp_ptr->comp.pipeline_id,	\
 		    comp_ptr->comp.id, format, ##__VA_ARGS__)
 
 #define trace_event_comp(...) _trace_comp_build(trace_event_with_ids,	\

--- a/src/trace/Kconfig
+++ b/src/trace/Kconfig
@@ -10,13 +10,6 @@ config TRACE
 	help
 	  Enabling traces. All traces (normal and error) are sent by dma.
 
-config TRACEV
-	bool "Trace verbose"
-	depends on TRACE
-	default n
-	help
-	  Enabling verbose traces.
-
 config TRACEE
 	bool "Trace error"
 	depends on TRACE
@@ -30,5 +23,220 @@ config TRACEM
 	default n
 	help
 	  Sending all traces by mailbox additionally.
+
+config TRACEV
+	bool "Trace verbose"
+	depends on TRACE
+	default n
+	help
+	  Enabling verbose traces.
+
+if TRACEV
+
+config TRACE_VERBOSE_IRQ
+	bool "Trace verbose IRQ"
+	default n
+	help
+	  Enable verbose tracing of TRACE_CLASS_IRQ.
+
+config TRACE_VERBOSE_IPC
+	bool "Trace verbose IPC"
+	default n
+	help
+	  Enable verbose tracing of TRACE_CLASS_IPC.
+
+config TRACE_VERBOSE_PIPE
+	bool "Trace verbose PIPE"
+	default n
+	help
+	  Enable verbose tracing of TRACE_CLASS_PIPE.
+
+config TRACE_VERBOSE_HOST
+	bool "Trace verbose HOST"
+	default n
+	help
+	  Enable verbose tracing of TRACE_CLASS_HOST.
+
+config TRACE_VERBOSE_DAI
+	bool "Trace verbose DAI"
+	default n
+	help
+	  Enable verbose tracing of TRACE_CLASS_DAI.
+
+config TRACE_VERBOSE_DMA
+	bool "Trace verbose DMA"
+	default n
+	help
+	  Enable verbose tracing of TRACE_CLASS_DMA.
+
+config TRACE_VERBOSE_SSP
+	bool "Trace verbose SSP"
+	default n
+	help
+	  Enable verbose tracing of TRACE_CLASS_SSP.
+
+config TRACE_VERBOSE_COMP
+	bool "Trace verbose COMP"
+	default n
+	help
+	  Enable verbose tracing of TRACE_CLASS_COMP.
+
+config TRACE_VERBOSE_WAIT
+	bool "Trace verbose WAIT"
+	default n
+	help
+	  Enable verbose tracing of TRACE_CLASS_WAIT.
+
+config TRACE_VERBOSE_LOCK
+	bool "Trace verbose LOCK"
+	default n
+	help
+	  Enable verbose tracing of TRACE_CLASS_LOCK.
+
+config TRACE_VERBOSE_MEM
+	bool "Trace verbose MEM"
+	default n
+	help
+	  Enable verbose tracing of TRACE_CLASS_MEM.
+
+config TRACE_VERBOSE_MIXER
+	bool "Trace verbose MIXER"
+	default n
+	help
+	  Enable verbose tracing of TRACE_CLASS_MIXER.
+
+config TRACE_VERBOSE_BUFFER
+	bool "Trace verbose BUFFER"
+	default n
+	help
+	  Enable verbose tracing of TRACE_CLASS_BUFFER.
+
+config TRACE_VERBOSE_VOLUME
+	bool "Trace verbose VOLUME"
+	default n
+	help
+	  Enable verbose tracing of TRACE_CLASS_VOLUME.
+
+config TRACE_VERBOSE_SWITCH
+	bool "Trace verbose SWITCH"
+	default n
+	help
+	  Enable verbose tracing of TRACE_CLASS_SWITCH.
+
+config TRACE_VERBOSE_MUX
+	bool "Trace verbose MUX"
+	default n
+	help
+	  Enable verbose tracing of TRACE_CLASS_MUX.
+
+config TRACE_VERBOSE_SRC
+	bool "Trace verbose SRC"
+	default n
+	help
+	  Enable verbose tracing of TRACE_CLASS_SRC.
+
+config TRACE_VERBOSE_TONE
+	bool "Trace verbose TONE"
+	default n
+	help
+	  Enable verbose tracing of TRACE_CLASS_TONE.
+
+config TRACE_VERBOSE_EQ_FIR
+	bool "Trace verbose EQ_FIR"
+	default n
+	help
+	  Enable verbose tracing of TRACE_CLASS_EQ_FIR.
+
+config TRACE_VERBOSE_EQ_IIR
+	bool "Trace verbose EQ_IIR"
+	default n
+	help
+	  Enable verbose tracing of TRACE_CLASS_EQ_IIR.
+
+config TRACE_VERBOSE_SA
+	bool "Trace verbose SA"
+	default n
+	help
+	  Enable verbose tracing of TRACE_CLASS_SA.
+
+config TRACE_VERBOSE_DMIC
+	bool "Trace verbose DMIC"
+	default n
+	help
+	  Enable verbose tracing of TRACE_CLASS_DMIC.
+
+config TRACE_VERBOSE_POWER
+	bool "Trace verbose POWER"
+	default n
+	help
+	  Enable verbose tracing of TRACE_CLASS_POWER.
+
+config TRACE_VERBOSE_IDC
+	bool "Trace verbose IDC"
+	default n
+	help
+	  Enable verbose tracing of TRACE_CLASS_IDC.
+
+config TRACE_VERBOSE_CPU
+	bool "Trace verbose CPU"
+	default n
+	help
+	  Enable verbose tracing of TRACE_CLASS_CPU.
+
+config TRACE_VERBOSE_CLK
+	bool "Trace verbose CLK"
+	default n
+	help
+	  Enable verbose tracing of TRACE_CLASS_CLK.
+
+config TRACE_VERBOSE_EDF
+	bool "Trace verbose EDF"
+	default n
+	help
+	  Enable verbose tracing of TRACE_CLASS_EDF.
+
+config TRACE_VERBOSE_KPB
+	bool "Trace verbose KPB"
+	default n
+	help
+	  Enable verbose tracing of TRACE_CLASS_KPB.
+
+config TRACE_VERBOSE_SELECTOR
+	bool "Trace verbose SELECTOR"
+	default n
+	help
+	  Enable verbose tracing of TRACE_CLASS_SELECTOR.
+
+config TRACE_VERBOSE_SCHEDULE
+	bool "Trace verbose SCHEDULE"
+	default n
+	help
+	  Enable verbose tracing of TRACE_CLASS_SCHEDULE.
+
+config TRACE_VERBOSE_SCHEDULE_LL
+	bool "Trace verbose SCHEDULE_LL"
+	default n
+	help
+	  Enable verbose tracing of TRACE_CLASS_SCHEDULE_LL.
+
+config TRACE_VERBOSE_ALH
+	bool "Trace verbose ALH"
+	default n
+	help
+	  Enable verbose tracing of TRACE_CLASS_ALH.
+
+config TRACE_VERBOSE_KEYWORD
+	bool "Trace verbose KEYWORD"
+	default n
+	help
+	  Enable verbose tracing of TRACE_CLASS_KEYWORD.
+
+config TRACE_VERBOSE_CHMAP
+	bool "Trace verbose CHMAP"
+	default n
+	help
+	  Enable verbose tracing of TRACE_CLASS_CHMAP.
+
+endif # TRACEV
 
 endmenu


### PR DESCRIPTION
Currently, after enabling TRACEV via Kconfig, message log is flooded
with various messages, most of which do not help to debug specific
issues, due to vast volume of messages sent. This patch adds Kconfig
options for each TRACE_CLASS, to enable logs from this class specifically.

Signed-off-by: ArturX Kloniecki <arturx.kloniecki@linux.intel.com>

As next step in trace verbosity overhaul, I would like to take advantage of this feature, and degrade many of trace messages (e.g. reporting function entry) to Verbose level, which would reduce noise in production logs, lower used bandwidth, while still providing developers the possibility to cleanly enable certain log classes for debugging purposes.