### PR TITLE
byt: ipc: Move WFI to run level 0

### DIFF
--- a/src/drivers/intel/baytrail/ipc.c
+++ b/src/drivers/intel/baytrail/ipc.c
@@ -105,7 +105,6 @@ static enum task_state ipc_platform_do_cmd(void *data)
 
 static void ipc_platform_complete_cmd(void *data)
 {
-	struct ipc *ipc = data;
 	uint32_t ipcxh;
 
 	/* clear BUSY bit and set DONE bit - accept new messages */
@@ -116,13 +115,6 @@ static void ipc_platform_complete_cmd(void *data)
 
 	/* unmask busy interrupt */
 	shim_write(SHIM_IMRD, shim_read(SHIM_IMRD) & ~SHIM_IMRD_BUSY);
-
-	// TODO: signal audio work to enter D3 in normal context
-	/* are we about to enter D3 ? */
-	if (ipc->pm_prepare_D3) {
-		while (1)
-			wait_for_interrupt(0);
-	}
 }
 
 void ipc_platform_send_msg(struct ipc *ipc)

--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -636,6 +636,8 @@ static int ipc_pm_context_restore(uint32_t header)
 
 	trace_ipc("ipc: pm -> restore");
 
+	_ipc->pm_prepare_D3 = 0;
+
 	/* restore context placeholder */
 	//mailbox_hostbox_write(0, pm_ctx, sizeof(*pm_ctx));
 

--- a/src/schedule/task.c
+++ b/src/schedule/task.c
@@ -29,6 +29,8 @@
 #include <ipc/trace.h>
 #endif
 
+extern struct ipc *_ipc;
+
 typedef enum task_state (*task_main)(void *);
 
 static void sys_module_init(void)
@@ -46,8 +48,13 @@ enum task_state task_main_master_core(void *data)
 		/* sleep until next IPC or DMA */
 		wait_for_interrupt(0);
 
-		/* now process any IPC messages to host */
-		ipc_process_msg_queue();
+		/*
+		 * now process any IPC messages to host
+		 * if we're not entering runtime suspend.
+		 */
+		if (_ipc && !_ipc->pm_prepare_D3)
+			ipc_process_msg_queue();
+
 	}
 
 	return SOF_TASK_STATE_COMPLETED;


### PR DESCRIPTION
When entering runtime suspend or system suspend, the host
driver sends a CTX_SAVE IPC. When this IPC is received,
the FW should call wait_for_interrupt from run level 0.
The IPC task is not at run level 0, therefore this
should be done in the main audio task, which runs at level 0.

Additionally, in the case of baytrail, the DSP doesn't
enter D3 in the case of runtime suspend. So, when the host
tried to resume the DSP, the pm_prepare_D3 flag is not reset
to 0. So, we need to explicitly reset it to 0 when the
host sends the CTX_RESTORE IPC.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>