### PR TITLE
platform: cht: reset ssp clk M/N dividers on boot

### DIFF
--- a/src/platform/baytrail/platform.c
+++ b/src/platform/baytrail/platform.c
@@ -241,6 +241,22 @@ int platform_init(struct sof *sof)
 	shim_write(SHIM_PIMRH, shim_read(SHIM_PIMRH) | 0x00000700);
 #endif
 
+	/* Reset M/N SSP clock dividers */
+	shim_write(SHIM_SSP0_DIVL, 1);
+	shim_write(SHIM_SSP0_DIVH, 0x80000001);
+	shim_write(SHIM_SSP1_DIVL, 1);
+	shim_write(SHIM_SSP1_DIVH, 0x80000001);
+	shim_write(SHIM_SSP2_DIVL, 1);
+	shim_write(SHIM_SSP2_DIVH, 0x80000001);
+#if defined CONFIG_CHERRYTRAIL
+	shim_write(SHIM_SSP3_DIVL, 1);
+	shim_write(SHIM_SSP3_DIVH, 0x80000001);
+	shim_write(SHIM_SSP4_DIVL, 1);
+	shim_write(SHIM_SSP4_DIVH, 0x80000001);
+	shim_write(SHIM_SSP5_DIVL, 1);
+	shim_write(SHIM_SSP5_DIVH, 0x80000001);
+#endif
+
 	/* init SSP ports */
 	trace_point(TRACE_BOOT_PLATFORM_SSP);
 	ssp0 = dai_get(SOF_DAI_INTEL_SSP, 0, DAI_CREAT);


### PR DESCRIPTION
The firmware may have modified these values to execute features such as
a boot beep. Therefore we cannot assume they are set to their defaults.
Lets write the defaults just to be safe.

Fixes #1847

Signed-off-by: Curtis Malainey <cujomalainey@google.com>