### PR TITLE
Topology: Fix DAI_ADD function call in sof-cml-rt1011-rt5682 topology

### DIFF
--- a/tools/topology/sof-cml-rt1011-rt5682.m4
+++ b/tools/topology/sof-cml-rt1011-rt5682.m4
@@ -40,7 +40,7 @@ dnl     deadline, priority, core, time_domain)
 DAI_ADD(sof/pipe-dai-playback.m4,
 	7, SSP, 1, SSP1-Codec,
 	PIPELINE_SOURCE_7, 2, s24le,
-	48, 1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # PCM Low Latency, id 0
 dnl PCM_PLAYBACK_ADD(name, pcm_id, playback)


### PR DESCRIPTION
This patch fixes DAI_ADD function call for speaker pipeline.
The function call had incorrect number of agruments passed which was causing issues with playback.