### PR TITLE
topology: sof-byt-codec make virtual widgets conditional

### DIFF
--- a/tools/topology/sof-byt-codec.m4
+++ b/tools/topology/sof-byt-codec.m4
@@ -94,9 +94,12 @@ DAI_CONFIG(SSP, SSP_NUM, 0, SSP2-Codec,
 		      SSP_TDM(2, 25, 3, 3),
 		      SSP_CONFIG_DATA(SSP, SSP_NUM, 24)))
 
-VIRTUAL_WIDGET(ssp2 Rx, out_drv, 1)
-VIRTUAL_WIDGET(ssp2 Tx, out_drv, 2)
-VIRTUAL_WIDGET(ssp0 Tx, out_drv, 3)
+ifelse(SSP_NUM, 2,
+`VIRTUAL_WIDGET(ssp2 Rx, out_drv, 1)
+VIRTUAL_WIDGET(ssp2 Tx, out_drv, 2)', ,)
+
+ifelse(SSP_NUM, 0,
+`VIRTUAL_WIDGET(ssp0 Tx, out_drv, 3)
 VIRTUAL_WIDGET(ssp0 Rx, out_drv, 4)
 VIRTUAL_DAPM_ROUTE_IN(modem_in, SSP, 0, IN, 0)
-VIRTUAL_DAPM_ROUTE_OUT(modem_out, SSP, 0, OUT, 1)
+VIRTUAL_DAPM_ROUTE_OUT(modem_out, SSP, 0, OUT, 1)', ,)


### PR DESCRIPTION
Creating all possible virtual widgets seems to cause problems in certain
topology loading scenarios, so make virtual widget creation dependent on SSP
numbering.

Signed-off-by: Jaska Uimonen <jaska.uimonen@intel.com>