### PR TITLE
edf_schedule: improve algorithm to use dynamic deadlines

### DIFF
--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -160,8 +160,6 @@ static struct comp_dev *kpb_new(struct sof_ipc_comp *comp)
 
 	/* Initialize draining task */
 	schedule_task_init_edf(&kpb->draining_task, /* task structure */
-			       /* almost idle priority */
-			       SOF_TASK_PRI_ALMOST_IDLE,
 			       &ops, /* task ops */
 			       &kpb->draining_task_data, /* task private data */
 			       0, /* core on which we should run */

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -87,6 +87,11 @@ static inline bool validate_host_params(size_t host_period_size,
 static inline void kpb_change_state(struct comp_data *kpb,
 				    enum kpb_state state);
 
+static uint64_t kpb_task_deadline(void *data)
+{
+	return SOF_TASK_DEADLINE_ALMOST_IDLE;
+}
+
 /**
  * \brief Create a key phrase buffer component.
  * \param[in] comp - generic ipc component pointer.
@@ -97,7 +102,10 @@ static struct comp_dev *kpb_new(struct sof_ipc_comp *comp)
 {
 	struct sof_ipc_comp_process *ipc_process =
 					(struct sof_ipc_comp_process *)comp;
-	struct task_ops ops = { .run = kpb_draining_task, };
+	struct task_ops ops = {
+		.run = kpb_draining_task,
+		.get_deadline = kpb_task_deadline,
+	};
 	size_t bs = ipc_process->size;
 	struct comp_dev *dev;
 	struct comp_data *kpb;

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -163,7 +163,7 @@ static struct comp_dev *kpb_new(struct sof_ipc_comp *comp)
 			       &ops, /* task ops */
 			       &kpb->draining_task_data, /* task private data */
 			       0, /* core on which we should run */
-			       SOF_SCHEDULE_FLAG_IDLE);
+			       0); /* no flags */
 
 	/* Init basic component data */
 	kpb->history_buffer = NULL;

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -28,6 +28,7 @@
 #include <sof/list.h>
 #include <sof/math/numbers.h>
 #include <sof/platform.h>
+#include <sof/schedule/edf_schedule.h>
 #include <sof/schedule/schedule.h>
 #include <sof/schedule/task.h>
 #include <sof/string.h>
@@ -149,14 +150,14 @@ static struct comp_dev *kpb_new(struct sof_ipc_comp *comp)
 	}
 
 	/* Initialize draining task */
-	schedule_task_init(&kpb->draining_task, /* task structure */
-			   SOF_SCHEDULE_EDF, /* utilize EDF scheduler */
-			   SOF_TASK_PRI_ALMOST_IDLE, /* almost idle priority */
-			   kpb_draining_task, /* task function */
-			   NULL, /* no complete function */
-			   &kpb->draining_task_data, /* task private data */
-			   0, /* core on which we should run */
-			   SOF_SCHEDULE_FLAG_IDLE);
+	schedule_task_init_edf(&kpb->draining_task, /* task structure */
+			       /* almost idle priority */
+			       SOF_TASK_PRI_ALMOST_IDLE,
+			       kpb_draining_task, /* task function */
+			       NULL, /* no complete function */
+			       &kpb->draining_task_data, /* task private data */
+			       0, /* core on which we should run */
+			       SOF_SCHEDULE_FLAG_IDLE);
 
 	/* Init basic component data */
 	kpb->history_buffer = NULL;

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -97,6 +97,7 @@ static struct comp_dev *kpb_new(struct sof_ipc_comp *comp)
 {
 	struct sof_ipc_comp_process *ipc_process =
 					(struct sof_ipc_comp_process *)comp;
+	struct task_ops ops = { .run = kpb_draining_task, };
 	size_t bs = ipc_process->size;
 	struct comp_dev *dev;
 	struct comp_data *kpb;
@@ -153,8 +154,7 @@ static struct comp_dev *kpb_new(struct sof_ipc_comp *comp)
 	schedule_task_init_edf(&kpb->draining_task, /* task structure */
 			       /* almost idle priority */
 			       SOF_TASK_PRI_ALMOST_IDLE,
-			       kpb_draining_task, /* task function */
-			       NULL, /* no complete function */
+			       &ops, /* task ops */
 			       &kpb->draining_task_data, /* task private data */
 			       0, /* core on which we should run */
 			       SOF_SCHEDULE_FLAG_IDLE);

--- a/src/audio/pipeline.c
+++ b/src/audio/pipeline.c
@@ -18,6 +18,7 @@
 #include <sof/lib/cpu.h>
 #include <sof/list.h>
 #include <sof/math/numbers.h>
+#include <sof/schedule/ll_schedule.h>
 #include <sof/schedule/schedule.h>
 #include <sof/schedule/task.h>
 #include <sof/spinlock.h>
@@ -407,8 +408,8 @@ static struct task *pipeline_task_init(struct pipeline *p, uint32_t type,
 	if (!task)
 		return NULL;
 
-	if (schedule_task_init(&task->task, type, p->ipc_pipe.priority, func,
-			       NULL, p, p->ipc_pipe.core, 0) < 0) {
+	if (schedule_task_init_ll(&task->task, type, p->ipc_pipe.priority, func,
+				  p, p->ipc_pipe.core, 0) < 0) {
 		rfree(task);
 		return NULL;
 	}

--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -26,6 +26,7 @@
 #include <sof/list.h>
 #include <sof/math/numbers.h>
 #include <sof/platform.h>
+#include <sof/schedule/ll_schedule.h>
 #include <sof/schedule/schedule.h>
 #include <sof/schedule/task.h>
 #include <sof/string.h>
@@ -174,8 +175,8 @@ static struct comp_dev *volume_new(struct sof_ipc_comp *comp)
 	}
 
 	comp_set_drvdata(dev, cd);
-	schedule_task_init(&cd->volwork, SOF_SCHEDULE_LL_TIMER,
-			   SOF_TASK_PRI_MED, vol_work, NULL, dev, 0, 0);
+	schedule_task_init_ll(&cd->volwork, SOF_SCHEDULE_LL_TIMER,
+			      SOF_TASK_PRI_MED, vol_work, dev, 0, 0);
 
 	/* Set the default volumes. If IPC sets min_value or max_value to
 	 * not-zero, use them. Otherwise set to internal limits and notify

--- a/src/drivers/dw/ssi-spi.c
+++ b/src/drivers/dw/ssi-spi.c
@@ -18,6 +18,7 @@
 #include <sof/lib/memory.h>
 #include <sof/lib/wait.h>
 #include <sof/platform.h>
+#include <sof/schedule/ll_schedule.h>
 #include <sof/schedule/schedule.h>
 #include <sof/schedule/task.h>
 #include <sof/spinlock.h>
@@ -404,9 +405,9 @@ static int spi_slave_init(struct spi *spi)
 
 	spi->completion.private = NULL;
 
-	ret = schedule_task_init(&spi->completion, SOF_SCHEDULE_LL_DMA,
-				 SOF_TASK_PRI_MED, spi_completion_work, NULL,
-				 spi, 0, 0);
+	ret = schedule_task_init_ll(&spi->completion, SOF_SCHEDULE_LL_DMA,
+				    SOF_TASK_PRI_MED, spi_completion_work,
+				    spi, 0, 0);
 	if (ret < 0)
 		return ret;
 

--- a/src/drivers/imx/ipc.c
+++ b/src/drivers/imx/ipc.c
@@ -13,6 +13,7 @@
 #include <sof/lib/wait.h>
 #include <sof/list.h>
 #include <sof/platform.h>
+#include <sof/schedule/edf_schedule.h>
 #include <sof/schedule/schedule.h>
 #include <sof/schedule/task.h>
 #include <sof/spinlock.h>
@@ -154,9 +155,9 @@ int platform_ipc_init(struct ipc *ipc)
 	_ipc = ipc;
 
 	/* schedule */
-	schedule_task_init(&_ipc->ipc_task, SOF_SCHEDULE_EDF, SOF_TASK_PRI_IPC,
-			   ipc_platform_do_cmd, ipc_platform_complete_cmd, _ipc,
-			   0, 0);
+	schedule_task_init_edf(&_ipc->ipc_task, SOF_TASK_PRI_IPC,
+			       ipc_platform_do_cmd, ipc_platform_complete_cmd,
+			       _ipc, 0, 0);
 
 #if CONFIG_HOST_PTABLE
 	/* allocate page table buffer */

--- a/src/drivers/imx/ipc.c
+++ b/src/drivers/imx/ipc.c
@@ -68,7 +68,7 @@ static void irq_handler(void *arg)
 	}
 }
 
-static enum task_state ipc_platform_do_cmd(void *data)
+enum task_state ipc_platform_do_cmd(void *data)
 {
 	struct sof_ipc_cmd_hdr *hdr;
 	/* Use struct ipc_data *iipc = ipc_get_drvdata(ipc); if needed */
@@ -80,7 +80,7 @@ static enum task_state ipc_platform_do_cmd(void *data)
 	return SOF_TASK_STATE_COMPLETED;
 }
 
-static void ipc_platform_complete_cmd(void *data)
+void ipc_platform_complete_cmd(void *data)
 {
 	struct ipc *ipc = data;
 
@@ -156,8 +156,7 @@ int platform_ipc_init(struct ipc *ipc)
 
 	/* schedule */
 	schedule_task_init_edf(&_ipc->ipc_task, SOF_TASK_PRI_IPC,
-			       ipc_platform_do_cmd, ipc_platform_complete_cmd,
-			       _ipc, 0, 0);
+			       &ipc_task_ops, _ipc, 0, 0);
 
 #if CONFIG_HOST_PTABLE
 	/* allocate page table buffer */

--- a/src/drivers/imx/ipc.c
+++ b/src/drivers/imx/ipc.c
@@ -155,8 +155,7 @@ int platform_ipc_init(struct ipc *ipc)
 	_ipc = ipc;
 
 	/* schedule */
-	schedule_task_init_edf(&_ipc->ipc_task, SOF_TASK_PRI_IPC,
-			       &ipc_task_ops, _ipc, 0, 0);
+	schedule_task_init_edf(&_ipc->ipc_task, &ipc_task_ops, _ipc, 0, 0);
 
 #if CONFIG_HOST_PTABLE
 	/* allocate page table buffer */

--- a/src/drivers/intel/baytrail/ipc.c
+++ b/src/drivers/intel/baytrail/ipc.c
@@ -143,8 +143,7 @@ int platform_ipc_init(struct ipc *ipc)
 	ipc_set_drvdata(_ipc, iipc);
 
 	/* schedule */
-	schedule_task_init_edf(&_ipc->ipc_task, SOF_TASK_PRI_IPC,
-			       &ipc_task_ops, _ipc, 0, 0);
+	schedule_task_init_edf(&_ipc->ipc_task, &ipc_task_ops, _ipc, 0, 0);
 
 #if CONFIG_HOST_PTABLE
 	/* allocate page table buffer */

--- a/src/drivers/intel/baytrail/ipc.c
+++ b/src/drivers/intel/baytrail/ipc.c
@@ -65,7 +65,7 @@ static void irq_handler(void *arg)
 	}
 }
 
-static enum task_state ipc_platform_do_cmd(void *data)
+enum task_state ipc_platform_do_cmd(void *data)
 {
 	struct sof_ipc_cmd_hdr *hdr;
 	/* Use struct ipc_data *iipc = ipc_get_drvdata(ipc); if needed */
@@ -77,7 +77,7 @@ static enum task_state ipc_platform_do_cmd(void *data)
 	return SOF_TASK_STATE_COMPLETED;
 }
 
-static void ipc_platform_complete_cmd(void *data)
+void ipc_platform_complete_cmd(void *data)
 {
 	uint32_t ipcxh;
 
@@ -144,8 +144,7 @@ int platform_ipc_init(struct ipc *ipc)
 
 	/* schedule */
 	schedule_task_init_edf(&_ipc->ipc_task, SOF_TASK_PRI_IPC,
-			       ipc_platform_do_cmd, ipc_platform_complete_cmd,
-			       _ipc, 0, 0);
+			       &ipc_task_ops, _ipc, 0, 0);
 
 #if CONFIG_HOST_PTABLE
 	/* allocate page table buffer */

--- a/src/drivers/intel/baytrail/ipc.c
+++ b/src/drivers/intel/baytrail/ipc.c
@@ -14,6 +14,7 @@
 #include <sof/lib/wait.h>
 #include <sof/list.h>
 #include <sof/platform.h>
+#include <sof/schedule/edf_schedule.h>
 #include <sof/schedule/schedule.h>
 #include <sof/spinlock.h>
 #include <ipc/header.h>
@@ -142,9 +143,9 @@ int platform_ipc_init(struct ipc *ipc)
 	ipc_set_drvdata(_ipc, iipc);
 
 	/* schedule */
-	schedule_task_init(&_ipc->ipc_task, SOF_SCHEDULE_EDF, SOF_TASK_PRI_IPC,
-			   ipc_platform_do_cmd, ipc_platform_complete_cmd, _ipc,
-			   0, 0);
+	schedule_task_init_edf(&_ipc->ipc_task, SOF_TASK_PRI_IPC,
+			       ipc_platform_do_cmd, ipc_platform_complete_cmd,
+			       _ipc, 0, 0);
 
 #if CONFIG_HOST_PTABLE
 	/* allocate page table buffer */

--- a/src/drivers/intel/cavs/dmic.c
+++ b/src/drivers/intel/cavs/dmic.c
@@ -21,6 +21,7 @@
 #include <sof/lib/pm_runtime.h>
 #include <sof/math/decibels.h>
 #include <sof/math/numbers.h>
+#include <sof/schedule/ll_schedule.h>
 #include <sof/schedule/schedule.h>
 #include <sof/schedule/task.h>
 #include <sof/spinlock.h>
@@ -1532,8 +1533,8 @@ static int dmic_probe(struct dai *dai)
 	}
 
 	/* Initialize start sequence handler */
-	schedule_task_init(&dmic->dmicwork, SOF_SCHEDULE_LL_TIMER,
-			   SOF_TASK_PRI_MED, dmic_work, NULL, dai, 0, 0);
+	schedule_task_init_ll(&dmic->dmicwork, SOF_SCHEDULE_LL_TIMER,
+			      SOF_TASK_PRI_MED, dmic_work, dai, 0, 0);
 
 	/* Enable DMIC power */
 	pm_runtime_get_sync(DMIC_POW, dai->index);

--- a/src/drivers/intel/cavs/idc.c
+++ b/src/drivers/intel/cavs/idc.c
@@ -333,9 +333,12 @@ static uint32_t idc_get_done_bit_mask(int core)
  */
 int idc_init(void)
 {
-	struct task_ops ops = { .run = idc_do_cmd, };
 	int core = cpu_get_id();
 	int ret;
+	struct task_ops ops = {
+		.run = idc_do_cmd,
+		.get_deadline = ipc_task_deadline,
+	};
 
 	trace_idc("arch_idc_init()");
 

--- a/src/drivers/intel/cavs/idc.c
+++ b/src/drivers/intel/cavs/idc.c
@@ -333,6 +333,7 @@ static uint32_t idc_get_done_bit_mask(int core)
  */
 int idc_init(void)
 {
+	struct task_ops ops = { .run = idc_do_cmd, };
 	int core = cpu_get_id();
 	int ret;
 
@@ -345,8 +346,8 @@ int idc_init(void)
 	(*idc)->done_bit_mask = idc_get_done_bit_mask(core);
 
 	/* process task */
-	schedule_task_init_edf(&(*idc)->idc_task, SOF_TASK_PRI_IDC, idc_do_cmd,
-			       NULL, *idc, core, 0);
+	schedule_task_init_edf(&(*idc)->idc_task, SOF_TASK_PRI_IDC, &ops, *idc,
+			       core, 0);
 
 	/* configure interrupt */
 	(*idc)->irq = interrupt_get_irq(PLATFORM_IDC_INTERRUPT,

--- a/src/drivers/intel/cavs/idc.c
+++ b/src/drivers/intel/cavs/idc.c
@@ -349,8 +349,7 @@ int idc_init(void)
 	(*idc)->done_bit_mask = idc_get_done_bit_mask(core);
 
 	/* process task */
-	schedule_task_init_edf(&(*idc)->idc_task, SOF_TASK_PRI_IDC, &ops, *idc,
-			       core, 0);
+	schedule_task_init_edf(&(*idc)->idc_task, &ops, *idc, core, 0);
 
 	/* configure interrupt */
 	(*idc)->irq = interrupt_get_irq(PLATFORM_IDC_INTERRUPT,

--- a/src/drivers/intel/cavs/idc.c
+++ b/src/drivers/intel/cavs/idc.c
@@ -345,8 +345,8 @@ int idc_init(void)
 	(*idc)->done_bit_mask = idc_get_done_bit_mask(core);
 
 	/* process task */
-	schedule_task_init(&(*idc)->idc_task, SOF_SCHEDULE_EDF,
-			   SOF_TASK_PRI_IDC, idc_do_cmd, NULL, *idc, core, 0);
+	schedule_task_init_edf(&(*idc)->idc_task, SOF_TASK_PRI_IDC, idc_do_cmd,
+			       NULL, *idc, core, 0);
 
 	/* configure interrupt */
 	(*idc)->irq = interrupt_get_irq(PLATFORM_IDC_INTERRUPT,

--- a/src/drivers/intel/cavs/ipc.c
+++ b/src/drivers/intel/cavs/ipc.c
@@ -283,8 +283,7 @@ int platform_ipc_init(struct ipc *ipc)
 	ipc_set_drvdata(_ipc, NULL);
 
 	/* schedule */
-	schedule_task_init_edf(&_ipc->ipc_task, SOF_TASK_PRI_IPC,
-			       &ipc_task_ops, _ipc, 0, 0);
+	schedule_task_init_edf(&_ipc->ipc_task, &ipc_task_ops, _ipc, 0, 0);
 
 	/* configure interrupt */
 	irq = interrupt_get_irq(PLATFORM_IPC_INTERRUPT,

--- a/src/drivers/intel/cavs/ipc.c
+++ b/src/drivers/intel/cavs/ipc.c
@@ -168,7 +168,7 @@ static struct sof_ipc_cmd_hdr *ipc_cavs_read_msg(void)
 }
 #endif
 
-static enum task_state ipc_platform_do_cmd(void *data)
+enum task_state ipc_platform_do_cmd(void *data)
 {
 #if !CONFIG_SUECREEK
 	struct ipc *ipc = data;
@@ -203,7 +203,7 @@ static enum task_state ipc_platform_do_cmd(void *data)
 	return SOF_TASK_STATE_COMPLETED;
 }
 
-static void ipc_platform_complete_cmd(void *data)
+void ipc_platform_complete_cmd(void *data)
 {
 #if CONFIG_SUECREEK
 	struct ipc *ipc = data;
@@ -284,8 +284,7 @@ int platform_ipc_init(struct ipc *ipc)
 
 	/* schedule */
 	schedule_task_init_edf(&_ipc->ipc_task, SOF_TASK_PRI_IPC,
-			       ipc_platform_do_cmd, ipc_platform_complete_cmd,
-			       _ipc, 0, 0);
+			       &ipc_task_ops, _ipc, 0, 0);
 
 	/* configure interrupt */
 	irq = interrupt_get_irq(PLATFORM_IPC_INTERRUPT,

--- a/src/drivers/intel/cavs/ipc.c
+++ b/src/drivers/intel/cavs/ipc.c
@@ -15,6 +15,7 @@
 #include <sof/lib/wait.h>
 #include <sof/list.h>
 #include <sof/platform.h>
+#include <sof/schedule/edf_schedule.h>
 #include <sof/schedule/schedule.h>
 #include <sof/schedule/task.h>
 #include <sof/spinlock.h>
@@ -282,9 +283,9 @@ int platform_ipc_init(struct ipc *ipc)
 	ipc_set_drvdata(_ipc, NULL);
 
 	/* schedule */
-	schedule_task_init(&_ipc->ipc_task, SOF_SCHEDULE_EDF, SOF_TASK_PRI_IPC,
-			   ipc_platform_do_cmd, ipc_platform_complete_cmd, _ipc,
-			   0, 0);
+	schedule_task_init_edf(&_ipc->ipc_task, SOF_TASK_PRI_IPC,
+			       ipc_platform_do_cmd, ipc_platform_complete_cmd,
+			       _ipc, 0, 0);
 
 	/* configure interrupt */
 	irq = interrupt_get_irq(PLATFORM_IPC_INTERRUPT,

--- a/src/drivers/intel/cavs/sue-ipc.c
+++ b/src/drivers/intel/cavs/sue-ipc.c
@@ -11,6 +11,7 @@
 #include <sof/lib/mailbox.h>
 #include <sof/lib/wait.h>
 #include <sof/list.h>
+#include <sof/schedule/edf_schedule.h>
 #include <sof/schedule/schedule.h>
 #include <sof/schedule/task.h>
 #include <sof/spinlock.h>
@@ -78,8 +79,8 @@ int platform_ipc_init(struct ipc *ipc)
 	ipc_set_drvdata(_ipc, NULL);
 
 	/* schedule */
-	schedule_task_init(&_ipc->ipc_task, SOF_SCHEDULE_EDF, SOF_TASK_PRI_MED,
-			   ipc_platform_do_cmd, NULL, _ipc, 0, 0);
+	schedule_task_init_edf(&_ipc->ipc_task, SOF_TASK_PRI_MED,
+			       ipc_platform_do_cmd, NULL, _ipc, 0, 0);
 
 	return 0;
 }

--- a/src/drivers/intel/cavs/sue-ipc.c
+++ b/src/drivers/intel/cavs/sue-ipc.c
@@ -83,8 +83,7 @@ int platform_ipc_init(struct ipc *ipc)
 	ipc_set_drvdata(_ipc, NULL);
 
 	/* schedule */
-	schedule_task_init_edf(&_ipc->ipc_task, SOF_TASK_PRI_MED, &ipc_task_ops,
-			       _ipc, 0, 0);
+	schedule_task_init_edf(&_ipc->ipc_task, &ipc_task_ops, _ipc, 0, 0);
 
 	return 0;
 }

--- a/src/drivers/intel/cavs/sue-ipc.c
+++ b/src/drivers/intel/cavs/sue-ipc.c
@@ -22,7 +22,7 @@
 extern struct ipc *_ipc;
 
 /* No private data for IPC */
-static enum task_state ipc_platform_do_cmd(void *data)
+enum task_state ipc_platform_do_cmd(void *data)
 {
 	struct ipc *ipc = data;
 	struct sof_ipc_cmd_hdr *hdr;
@@ -44,6 +44,10 @@ static enum task_state ipc_platform_do_cmd(void *data)
 	}
 
 	return SOF_TASK_STATE_COMPLETED;
+}
+
+void ipc_platform_complete_cmd(void *data)
+{
 }
 
 void ipc_platform_send_msg(void)
@@ -79,8 +83,8 @@ int platform_ipc_init(struct ipc *ipc)
 	ipc_set_drvdata(_ipc, NULL);
 
 	/* schedule */
-	schedule_task_init_edf(&_ipc->ipc_task, SOF_TASK_PRI_MED,
-			       ipc_platform_do_cmd, NULL, _ipc, 0, 0);
+	schedule_task_init_edf(&_ipc->ipc_task, SOF_TASK_PRI_MED, &ipc_task_ops,
+			       _ipc, 0, 0);
 
 	return 0;
 }

--- a/src/drivers/intel/haswell/ipc.c
+++ b/src/drivers/intel/haswell/ipc.c
@@ -13,6 +13,7 @@
 #include <sof/lib/wait.h>
 #include <sof/list.h>
 #include <sof/platform.h>
+#include <sof/schedule/edf_schedule.h>
 #include <sof/schedule/schedule.h>
 #include <sof/schedule/task.h>
 #include <sof/spinlock.h>
@@ -139,9 +140,9 @@ int platform_ipc_init(struct ipc *ipc)
 	ipc_set_drvdata(_ipc, iipc);
 
 	/* schedule */
-	schedule_task_init(&_ipc->ipc_task, SOF_SCHEDULE_EDF, SOF_TASK_PRI_IPC,
-			   ipc_platform_do_cmd, ipc_platform_complete_cmd, _ipc,
-			   0, 0);
+	schedule_task_init_edf(&_ipc->ipc_task, SOF_TASK_PRI_IPC,
+			       ipc_platform_do_cmd, ipc_platform_complete_cmd,
+			       _ipc, 0, 0);
 
 #if CONFIG_HOST_PTABLE
 	/* allocate page table buffer */

--- a/src/drivers/intel/haswell/ipc.c
+++ b/src/drivers/intel/haswell/ipc.c
@@ -59,7 +59,7 @@ static void irq_handler(void *arg)
 	}
 }
 
-static enum task_state ipc_platform_do_cmd(void *data)
+enum task_state ipc_platform_do_cmd(void *data)
 {
 	struct sof_ipc_cmd_hdr *hdr;
 	/* Use struct ipc_data *iipc = ipc_get_drvdata(ipc); if needed */
@@ -71,7 +71,7 @@ static enum task_state ipc_platform_do_cmd(void *data)
 	return SOF_TASK_STATE_COMPLETED;
 }
 
-static void ipc_platform_complete_cmd(void *data)
+void ipc_platform_complete_cmd(void *data)
 {
 	struct ipc *ipc = data;
 
@@ -141,8 +141,7 @@ int platform_ipc_init(struct ipc *ipc)
 
 	/* schedule */
 	schedule_task_init_edf(&_ipc->ipc_task, SOF_TASK_PRI_IPC,
-			       ipc_platform_do_cmd, ipc_platform_complete_cmd,
-			       _ipc, 0, 0);
+			       &ipc_task_ops, _ipc, 0, 0);
 
 #if CONFIG_HOST_PTABLE
 	/* allocate page table buffer */

--- a/src/drivers/intel/haswell/ipc.c
+++ b/src/drivers/intel/haswell/ipc.c
@@ -140,8 +140,7 @@ int platform_ipc_init(struct ipc *ipc)
 	ipc_set_drvdata(_ipc, iipc);
 
 	/* schedule */
-	schedule_task_init_edf(&_ipc->ipc_task, SOF_TASK_PRI_IPC,
-			       &ipc_task_ops, _ipc, 0, 0);
+	schedule_task_init_edf(&_ipc->ipc_task, &ipc_task_ops, _ipc, 0, 0);
 
 #if CONFIG_HOST_PTABLE
 	/* allocate page table buffer */

--- a/src/include/sof/drivers/ipc.h
+++ b/src/include/sof/drivers/ipc.h
@@ -112,6 +112,8 @@ struct ipc {
 #define ipc_get_drvdata(ipc) \
 	((ipc)->private)
 
+extern struct task_ops ipc_task_ops;
+
 
 int ipc_init(struct sof *sof);
 
@@ -130,6 +132,10 @@ int ipc_init(struct sof *sof);
  * ipc_get_drvdata().
  */
 int platform_ipc_init(struct ipc *ipc);
+
+enum task_state ipc_platform_do_cmd(void *data);
+
+void ipc_platform_complete_cmd(void *data);
 
 void ipc_free(struct ipc *ipc);
 

--- a/src/include/sof/drivers/ipc.h
+++ b/src/include/sof/drivers/ipc.h
@@ -114,6 +114,16 @@ struct ipc {
 
 extern struct task_ops ipc_task_ops;
 
+static inline uint64_t ipc_task_deadline(void *data)
+{
+	/* TODO: Currently it's a workaround to execute IPC tasks ASAP.
+	 * In the future IPCs should have a cycle budget and deadline
+	 * should be calculated based on that value. This means every
+	 * IPC should have its own maximum number of cycles that is required
+	 * to finish processing. This will allow us to calculate task deadline.
+	 */
+	return SOF_TASK_DEADLINE_NOW;
+}
 
 int ipc_init(struct sof *sof);
 

--- a/src/include/sof/lib/wait.h
+++ b/src/include/sof/lib/wait.h
@@ -15,6 +15,7 @@
 #include <arch/lib/wait.h>
 #include <sof/drivers/timer.h>
 #include <sof/platform.h>
+#include <sof/schedule/ll_schedule.h>
 #include <sof/schedule/schedule.h>
 #include <sof/schedule/task.h>
 #include <sof/spinlock.h>
@@ -70,8 +71,8 @@ static inline void wait_init(completion_t *comp)
 
 	c->complete = 0;
 
-	schedule_task_init(&comp->work, SOF_SCHEDULE_LL_TIMER, SOF_TASK_PRI_MED,
-			   _wait_cb, NULL, comp, 0, 0);
+	schedule_task_init_ll(&comp->work, SOF_SCHEDULE_LL_TIMER,
+			      SOF_TASK_PRI_MED, _wait_cb, comp, 0, 0);
 }
 
 static inline void wait_clear(completion_t *comp)

--- a/src/include/sof/schedule/edf_schedule.h
+++ b/src/include/sof/schedule/edf_schedule.h
@@ -34,8 +34,7 @@ struct edf_task_pdata {
 
 int scheduler_init_edf(void);
 
-int schedule_task_init_edf(struct task *task, uint16_t priority,
-			   const struct task_ops *ops, void *data,
-			   uint16_t core, uint32_t flags);
+int schedule_task_init_edf(struct task *task, const struct task_ops *ops,
+			   void *data, uint16_t core, uint32_t flags);
 
 #endif /* __SOF_SCHEDULE_EDF_SCHEDULE_H__ */

--- a/src/include/sof/schedule/edf_schedule.h
+++ b/src/include/sof/schedule/edf_schedule.h
@@ -29,7 +29,6 @@
 #define edf_sch_get_pdata(task) task->private
 
 struct edf_task_pdata {
-	uint64_t deadline;
 	void *ctx;
 };
 

--- a/src/include/sof/schedule/edf_schedule.h
+++ b/src/include/sof/schedule/edf_schedule.h
@@ -36,8 +36,7 @@ struct edf_task_pdata {
 int scheduler_init_edf(void);
 
 int schedule_task_init_edf(struct task *task, uint16_t priority,
-			   enum task_state (*run)(void *data),
-			   void (*complete)(void *data), void *data,
+			   const struct task_ops *ops, void *data,
 			   uint16_t core, uint32_t flags);
 
 #endif /* __SOF_SCHEDULE_EDF_SCHEDULE_H__ */

--- a/src/include/sof/schedule/edf_schedule.h
+++ b/src/include/sof/schedule/edf_schedule.h
@@ -35,4 +35,9 @@ struct edf_task_pdata {
 
 int scheduler_init_edf(void);
 
+int schedule_task_init_edf(struct task *task, uint16_t priority,
+			   enum task_state (*run)(void *data),
+			   void (*complete)(void *data), void *data,
+			   uint16_t core, uint32_t flags);
+
 #endif /* __SOF_SCHEDULE_EDF_SCHEDULE_H__ */

--- a/src/include/sof/schedule/ll_schedule.h
+++ b/src/include/sof/schedule/ll_schedule.h
@@ -41,4 +41,8 @@ struct ll_task_pdata {
 
 int scheduler_init_ll(struct ll_schedule_domain *domain);
 
+int schedule_task_init_ll(struct task *task, uint16_t type, uint16_t priority,
+			  enum task_state (*run)(void *data), void *data,
+			  uint16_t core, uint32_t flags);
+
 #endif /* __SOF_SCHEDULE_LL_SCHEDULE_H__ */

--- a/src/include/sof/schedule/schedule.h
+++ b/src/include/sof/schedule/schedule.h
@@ -45,9 +45,6 @@ enum {
 	SOF_SCHEDULE_COUNT
 };
 
-/* Scheduler flags */
-#define SOF_SCHEDULE_FLAG_IDLE	BIT(0)
-
 struct scheduler_ops {
 	void (*schedule_task)(void *data, struct task *task, uint64_t start,
 			      uint64_t period);

--- a/src/include/sof/schedule/task.h
+++ b/src/include/sof/schedule/task.h
@@ -45,6 +45,7 @@ enum task_state {
 struct task_ops {
 	enum task_state (*run)(void *data);
 	void (*complete)(void *data);
+	uint64_t (*get_deadline)(void *data);
 };
 
 struct task {
@@ -80,6 +81,13 @@ static inline void task_complete(struct task *task)
 {
 	if (task->ops.complete)
 		task->ops.complete(task->data);
+}
+
+static inline uint64_t task_get_deadline(struct task *task)
+{
+	assert(task->ops.get_deadline);
+
+	return task->ops.get_deadline(task->data);
 }
 
 enum task_state task_main_master_core(void *data);

--- a/src/include/sof/schedule/task.h
+++ b/src/include/sof/schedule/task.h
@@ -17,19 +17,20 @@
 struct comp_dev;
 struct sof;
 
+/** \brief Predefined LL task priorities. */
 #define SOF_TASK_PRI_HIGH	0	/* priority level 0 - high */
 #define SOF_TASK_PRI_MED	4	/* priority level 4 - medium */
 #define SOF_TASK_PRI_LOW	9	/* priority level 9 - low */
 
-/* predefined EDF task deadlines */
+/** \brief Predefined EDF task deadlines. */
 #define SOF_TASK_DEADLINE_IDLE		UINT64_MAX
 #define SOF_TASK_DEADLINE_ALMOST_IDLE	(SOF_TASK_DEADLINE_IDLE - 1)
 #define SOF_TASK_DEADLINE_NOW		0
 
-/* task default stack size in bytes */
+/** \brief EDF task's default stack size in bytes. */
 #define SOF_TASK_DEFAULT_STACK_SIZE	2048
 
-/* task states */
+/** \brief Task states. */
 enum task_state {
 	SOF_TASK_STATE_INIT = 0,
 	SOF_TASK_STATE_QUEUED,
@@ -42,23 +43,25 @@ enum task_state {
 	SOF_TASK_STATE_RESCHEDULE,
 };
 
+/** \brief Task operations. */
 struct task_ops {
-	enum task_state (*run)(void *data);
-	void (*complete)(void *data);
-	uint64_t (*get_deadline)(void *data);
+	enum task_state (*run)(void *data);	/**< task's main operation */
+	void (*complete)(void *data);		/**< executed on completion */
+	uint64_t (*get_deadline)(void *data);	/**< returns current deadline */
 };
 
+/** \brief Task used by schedulers. */
 struct task {
-	uint64_t start;
-	uint16_t type;
-	uint16_t priority;
-	uint16_t core;
-	uint16_t flags;
-	enum task_state state;
-	void *data;
-	struct list_item list;
-	void *private;
-	struct task_ops ops;
+	uint64_t start;		/**< start time */
+	uint16_t type;		/**< type of the task (LL or EDF) */
+	uint16_t priority;	/**< priority of the task (used by LL) */
+	uint16_t core;		/**< execution core */
+	uint16_t flags;		/**< custom flags */
+	enum task_state state;	/**< current state */
+	void *data;		/**< custom data passed to all ops */
+	struct list_item list;	/**< used by schedulers to hold tasks */
+	void *private;		/**< task private data */
+	struct task_ops ops;	/**< task operations */
 };
 
 /** \brief Task type registered by pipelines. */

--- a/src/include/sof/schedule/task.h
+++ b/src/include/sof/schedule/task.h
@@ -20,11 +20,6 @@ struct sof;
 #define SOF_TASK_PRI_HIGH	0	/* priority level 0 - high */
 #define SOF_TASK_PRI_MED	4	/* priority level 4 - medium */
 #define SOF_TASK_PRI_LOW	9	/* priority level 9 - low */
-#define SOF_TASK_PRI_IDLE	INT16_MAX	/* lowest possible priority */
-#define SOF_TASK_PRI_ALMOST_IDLE	(SOF_TASK_PRI_IDLE - 1)
-
-#define SOF_TASK_PRI_IPC	SOF_TASK_PRI_HIGH
-#define SOF_TASK_PRI_IDC	SOF_TASK_PRI_HIGH
 
 /* predefined EDF task deadlines */
 #define SOF_TASK_DEADLINE_IDLE		UINT64_MAX

--- a/src/include/sof/schedule/task.h
+++ b/src/include/sof/schedule/task.h
@@ -26,6 +26,11 @@ struct sof;
 #define SOF_TASK_PRI_IPC	SOF_TASK_PRI_HIGH
 #define SOF_TASK_PRI_IDC	SOF_TASK_PRI_HIGH
 
+/* predefined EDF task deadlines */
+#define SOF_TASK_DEADLINE_IDLE		UINT64_MAX
+#define SOF_TASK_DEADLINE_ALMOST_IDLE	(SOF_TASK_DEADLINE_IDLE - 1)
+#define SOF_TASK_DEADLINE_NOW		0
+
 /* task default stack size in bytes */
 #define SOF_TASK_DEFAULT_STACK_SIZE	2048
 

--- a/src/ipc/ipc.c
+++ b/src/ipc/ipc.c
@@ -481,3 +481,8 @@ int ipc_init(struct sof *sof)
 
 	return platform_ipc_init(sof->ipc);
 }
+
+struct task_ops ipc_task_ops = {
+	.run		= ipc_platform_do_cmd,
+	.complete	= ipc_platform_complete_cmd,
+};

--- a/src/ipc/ipc.c
+++ b/src/ipc/ipc.c
@@ -485,4 +485,5 @@ int ipc_init(struct sof *sof)
 struct task_ops ipc_task_ops = {
 	.run		= ipc_platform_do_cmd,
 	.complete	= ipc_platform_complete_cmd,
+	.get_deadline	= ipc_task_deadline,
 };

--- a/src/lib/agent.c
+++ b/src/lib/agent.c
@@ -19,6 +19,7 @@
 #include <sof/lib/clk.h>
 #include <sof/debug/panic.h>
 #include <sof/platform.h>
+#include <sof/schedule/ll_schedule.h>
 #include <sof/schedule/schedule.h>
 #include <sof/schedule/task.h>
 #include <sof/sof.h>
@@ -80,8 +81,8 @@ void sa_init(struct sof *sof, uint64_t timeout)
 		 "sa->panic_timeout = %u", ticks, sa->warn_timeout,
 		 sa->panic_timeout);
 
-	schedule_task_init(&sa->work, SOF_SCHEDULE_LL_TIMER, SOF_TASK_PRI_HIGH,
-			   validate, NULL, sa, 0, 0);
+	schedule_task_init_ll(&sa->work, SOF_SCHEDULE_LL_TIMER,
+			      SOF_TASK_PRI_HIGH, validate, sa, 0, 0);
 
 	schedule_task(&sa->work, 0, timeout);
 

--- a/src/schedule/edf_schedule.c
+++ b/src/schedule/edf_schedule.c
@@ -71,8 +71,7 @@ static void edf_scheduler_run(void *data)
 		task = container_of(tlist, struct task, list);
 
 		if (task->state != SOF_TASK_STATE_QUEUED &&
-		    task->state != SOF_TASK_STATE_RUNNING &&
-		    task->state != SOF_TASK_STATE_RESCHEDULE)
+		    task->state != SOF_TASK_STATE_RUNNING)
 			continue;
 
 		edf_pdata = edf_sch_get_pdata(task);

--- a/src/schedule/edf_schedule.c
+++ b/src/schedule/edf_schedule.c
@@ -132,15 +132,14 @@ static void schedule_edf_task(void *data, struct task *task, uint64_t start,
 	schedule_edf(data);
 }
 
-int schedule_task_init_edf(struct task *task, uint16_t priority,
-			   const struct task_ops *ops, void *data,
-			   uint16_t core, uint32_t flags)
+int schedule_task_init_edf(struct task *task, const struct task_ops *ops,
+			   void *data, uint16_t core, uint32_t flags)
 {
 	struct edf_task_pdata *edf_pdata = NULL;
 	int ret = 0;
 
-	ret = schedule_task_init(task, SOF_SCHEDULE_EDF, priority, ops->run,
-				 data, core, flags);
+	ret = schedule_task_init(task, SOF_SCHEDULE_EDF, 0, ops->run, data,
+				 core, flags);
 	if (ret < 0)
 		return ret;
 

--- a/src/schedule/ll_schedule.c
+++ b/src/schedule/ll_schedule.c
@@ -283,9 +283,16 @@ out:
 	irq_local_enable(flags);
 }
 
-static int schedule_ll_task_init(void *data, struct task *task)
+int schedule_task_init_ll(struct task *task, uint16_t type, uint16_t priority,
+			  enum task_state (*run)(void *data), void *data,
+			  uint16_t core, uint32_t flags)
 {
 	struct ll_task_pdata *ll_pdata;
+	int ret = 0;
+
+	ret = schedule_task_init(task, type, priority, run, data, core, flags);
+	if (ret < 0)
+		return ret;
 
 	if (ll_sch_get_pdata(task))
 		return -EEXIST;
@@ -294,7 +301,7 @@ static int schedule_ll_task_init(void *data, struct task *task)
 			   sizeof(*ll_pdata));
 
 	if (!ll_pdata) {
-		trace_ll_error("schedule_ll_task_init() error: alloc failed");
+		trace_ll_error("schedule_task_init_ll() error: alloc failed");
 		return -ENOMEM;
 	}
 
@@ -458,7 +465,6 @@ int scheduler_init_ll(struct ll_schedule_domain *domain)
 
 const struct scheduler_ops schedule_ll_ops = {
 	.schedule_task		= schedule_ll_task,
-	.schedule_task_init	= schedule_ll_task_init,
 	.schedule_task_free	= schedule_ll_task_free,
 	.schedule_task_cancel	= schedule_ll_task_cancel,
 	.reschedule_task	= reschedule_ll_task,

--- a/src/schedule/ll_schedule.c
+++ b/src/schedule/ll_schedule.c
@@ -83,7 +83,7 @@ static void schedule_ll_tasks_execute(struct ll_schedule_data *sch,
 
 		/* run task if its pending and remove from the list */
 		if (task->state == SOF_TASK_STATE_PENDING) {
-			task->state = task->run(task->data);
+			task->state = task_run(task);
 
 			/* do we need to reschedule this task */
 			if (task->state == SOF_TASK_STATE_COMPLETED) {

--- a/src/schedule/schedule.c
+++ b/src/schedule/schedule.c
@@ -29,7 +29,7 @@ int schedule_task_init(struct task *task, uint16_t type, uint16_t priority,
 	task->core = core;
 	task->flags = flags;
 	task->state = SOF_TASK_STATE_INIT;
-	task->run = run;
+	task->ops.run = run;
 	task->data = data;
 
 	return 0;

--- a/src/schedule/schedule.c
+++ b/src/schedule/schedule.c
@@ -6,33 +6,22 @@
 
 /* Generic scheduler */
 
-#include <sof/common.h>
 #include <sof/lib/alloc.h>
-#include <sof/lib/cache.h>
-#include <sof/lib/cpu.h>
 #include <sof/list.h>
 #include <sof/schedule/schedule.h>
 #include <sof/schedule/task.h>
-#include <sof/sof.h>
 #include <ipc/topology.h>
 #include <errno.h>
 #include <stdint.h>
 
 int schedule_task_init(struct task *task, uint16_t type, uint16_t priority,
-		       enum task_state (*run)(void *data),
-		       void (*complete)(void *data), void *data, uint16_t core,
-		       uint32_t flags)
+		       enum task_state (*run)(void *data), void *data,
+		       uint16_t core, uint32_t flags)
 {
-	struct schedulers *schedulers = *arch_schedulers_get();
-	struct schedule_data *sch;
-	struct list_item *slist;
-	int ret = 0;
-
 	if (type >= SOF_SCHEDULE_COUNT) {
 		trace_schedule_error("schedule_task_init() error: "
 				     "invalid task type");
-		ret = -EINVAL;
-		goto out;
+		return -EINVAL;
 	}
 
 	task->type = type;
@@ -41,17 +30,9 @@ int schedule_task_init(struct task *task, uint16_t type, uint16_t priority,
 	task->flags = flags;
 	task->state = SOF_TASK_STATE_INIT;
 	task->run = run;
-	task->complete = complete;
 	task->data = data;
 
-	list_for_item(slist, &schedulers->list) {
-		sch = container_of(slist, struct schedule_data, list);
-		if (type == sch->type && sch->ops->schedule_task_init)
-			return sch->ops->schedule_task_init(sch->data, task);
-	}
-
-out:
-	return ret;
+	return 0;
 }
 
 static void scheduler_register(struct schedule_data *scheduler)

--- a/src/schedule/task.c
+++ b/src/schedule/task.c
@@ -16,6 +16,7 @@
 #include <sof/lib/cpu.h>
 #include <sof/lib/wait.h>
 #include <sof/platform.h>
+#include <sof/schedule/edf_schedule.h>
 #include <sof/schedule/schedule.h>
 #include <sof/schedule/task.h>
 #include <sof/sof.h>
@@ -65,9 +66,8 @@ void task_main_init(void)
 
 	*main_task = rzalloc(RZONE_SYS, SOF_MEM_CAPS_RAM, sizeof(**main_task));
 
-	ret = schedule_task_init(*main_task, SOF_SCHEDULE_EDF,
-				 SOF_TASK_PRI_IDLE, main_main, NULL, NULL,
-				 cpu, SOF_SCHEDULE_FLAG_IDLE);
+	ret = schedule_task_init_edf(*main_task, SOF_TASK_PRI_IDLE, main_main,
+				     NULL, NULL, cpu, SOF_SCHEDULE_FLAG_IDLE);
 	assert(!ret);
 }
 

--- a/src/schedule/task.c
+++ b/src/schedule/task.c
@@ -42,6 +42,11 @@ static void sys_module_init(void)
 		((void(*)(void))(*module_init))();
 }
 
+static uint64_t task_main_deadline(void *data)
+{
+	return SOF_TASK_DEADLINE_IDLE;
+}
+
 enum task_state task_main_master_core(void *data)
 {
 	/* main audio processing loop */
@@ -63,7 +68,10 @@ void task_main_init(void)
 	int ret;
 	task_main main_main = cpu == PLATFORM_MASTER_CORE_ID ?
 		&task_main_master_core : &task_main_slave_core;
-	struct task_ops ops = { .run = main_main, };
+	struct task_ops ops = {
+		.run = main_main,
+		.get_deadline = task_main_deadline,
+	};
 
 	*main_task = rzalloc(RZONE_SYS, SOF_MEM_CAPS_RAM, sizeof(**main_task));
 

--- a/src/schedule/task.c
+++ b/src/schedule/task.c
@@ -75,8 +75,8 @@ void task_main_init(void)
 
 	*main_task = rzalloc(RZONE_SYS, SOF_MEM_CAPS_RAM, sizeof(**main_task));
 
-	ret = schedule_task_init_edf(*main_task, SOF_TASK_PRI_IDLE, &ops, NULL,
-				     cpu, SOF_SCHEDULE_FLAG_IDLE);
+	ret = schedule_task_init_edf(*main_task, &ops, NULL, cpu,
+				     SOF_SCHEDULE_FLAG_IDLE);
 	assert(!ret);
 }
 

--- a/src/schedule/task.c
+++ b/src/schedule/task.c
@@ -75,8 +75,7 @@ void task_main_init(void)
 
 	*main_task = rzalloc(RZONE_SYS, SOF_MEM_CAPS_RAM, sizeof(**main_task));
 
-	ret = schedule_task_init_edf(*main_task, &ops, NULL, cpu,
-				     SOF_SCHEDULE_FLAG_IDLE);
+	ret = schedule_task_init_edf(*main_task, &ops, NULL, cpu, 0);
 	assert(!ret);
 }
 

--- a/src/schedule/task.c
+++ b/src/schedule/task.c
@@ -63,11 +63,12 @@ void task_main_init(void)
 	int ret;
 	task_main main_main = cpu == PLATFORM_MASTER_CORE_ID ?
 		&task_main_master_core : &task_main_slave_core;
+	struct task_ops ops = { .run = main_main, };
 
 	*main_task = rzalloc(RZONE_SYS, SOF_MEM_CAPS_RAM, sizeof(**main_task));
 
-	ret = schedule_task_init_edf(*main_task, SOF_TASK_PRI_IDLE, main_main,
-				     NULL, NULL, cpu, SOF_SCHEDULE_FLAG_IDLE);
+	ret = schedule_task_init_edf(*main_task, SOF_TASK_PRI_IDLE, &ops, NULL,
+				     cpu, SOF_SCHEDULE_FLAG_IDLE);
 	assert(!ret);
 }
 

--- a/src/trace/dma-trace.c
+++ b/src/trace/dma-trace.c
@@ -13,6 +13,7 @@
 #include <sof/lib/cpu.h>
 #include <sof/lib/dma.h>
 #include <sof/platform.h>
+#include <sof/schedule/ll_schedule.h>
 #include <sof/schedule/schedule.h>
 #include <sof/schedule/task.h>
 #include <sof/sof.h>
@@ -138,8 +139,8 @@ int dma_trace_init_complete(struct dma_trace_data *d)
 		return ret;
 	}
 
-	schedule_task_init(&d->dmat_work, SOF_SCHEDULE_LL_TIMER,
-			   SOF_TASK_PRI_MED, trace_work, NULL, d, 0, 0);
+	schedule_task_init_ll(&d->dmat_work, SOF_SCHEDULE_LL_TIMER,
+			      SOF_TASK_PRI_MED, trace_work, d, 0, 0);
 
 	return 0;
 }

--- a/test/cmocka/src/audio/kpb/kpb_mock.c
+++ b/test/cmocka/src/audio/kpb/kpb_mock.c
@@ -71,8 +71,7 @@ int schedule_task_init(struct task *task, uint16_t type, uint16_t priority,
 }
 
 int schedule_task_init_edf(struct task *task, uint16_t priority,
-			   enum task_state (*run)(void *data),
-			   void (*complete)(void *data), void *data,
+			   const struct task_ops *ops, void *data,
 			   uint16_t core, uint32_t flags)
 {
 	return 0;

--- a/test/cmocka/src/audio/kpb/kpb_mock.c
+++ b/test/cmocka/src/audio/kpb/kpb_mock.c
@@ -70,9 +70,8 @@ int schedule_task_init(struct task *task, uint16_t type, uint16_t priority,
 	return 0;
 }
 
-int schedule_task_init_edf(struct task *task, uint16_t priority,
-			   const struct task_ops *ops, void *data,
-			   uint16_t core, uint32_t flags)
+int schedule_task_init_edf(struct task *task, const struct task_ops *ops,
+			   void *data, uint16_t core, uint32_t flags)
 {
 	return 0;
 }

--- a/test/cmocka/src/audio/kpb/kpb_mock.c
+++ b/test/cmocka/src/audio/kpb/kpb_mock.c
@@ -15,6 +15,8 @@
 #include <sof/lib/notifier.h>
 #include <sof/audio/component.h>
 #include <sof/drivers/timer.h>
+#include <sof/schedule/edf_schedule.h>
+#include <sof/schedule/ll_schedule.h>
 #include <sof/schedule/schedule.h>
 #include <mock_trace.h>
 #include <sof/lib/clk.h>
@@ -62,9 +64,23 @@ int comp_set_state(struct comp_dev *dev, int cmd)
 }
 
 int schedule_task_init(struct task *task, uint16_t type, uint16_t priority,
-		       enum task_state (*run)(void *data),
-		       void (*complete)(void *data), void *data, uint16_t core,
-		       uint32_t xflags)
+		       enum task_state (*run)(void *data), void *data,
+		       uint16_t core, uint32_t flags)
+{
+	return 0;
+}
+
+int schedule_task_init_edf(struct task *task, uint16_t priority,
+			   enum task_state (*run)(void *data),
+			   void (*complete)(void *data), void *data,
+			   uint16_t core, uint32_t flags)
+{
+	return 0;
+}
+
+int schedule_task_init_ll(struct task *task, uint16_t type, uint16_t priority,
+			  enum task_state (*run)(void *data), void *data,
+			  uint16_t core, uint32_t flags)
 {
 	return 0;
 }

--- a/test/cmocka/src/audio/pipeline/pipeline_connection_mocks.h
+++ b/test/cmocka/src/audio/pipeline/pipeline_connection_mocks.h
@@ -33,6 +33,6 @@ void cleanup_test_data(struct pipeline_connect_data *data);
 static inline void schedule_task_mock_free(void *data, struct task *task)
 {
 	task->state = SOF_TASK_STATE_FREE;
-	task->run = NULL;
+	task->ops.run = NULL;
 	task->data = NULL;
 }

--- a/test/cmocka/src/audio/pipeline/pipeline_free.c
+++ b/test/cmocka/src/audio/pipeline/pipeline_free.c
@@ -75,7 +75,7 @@ static void test_audio_pipeline_free_sheduler_task_free(void **state)
 
 	assert_int_equal(result.pipe_task->state, SOF_TASK_STATE_FREE);
 	assert_ptr_equal(NULL, result.pipe_task->data);
-	assert_ptr_equal(NULL, result.pipe_task->run);
+	assert_ptr_equal(NULL, result.pipe_task->ops.run);
 }
 
 static void test_audio_pipeline_free_disconnect_full(void **state)

--- a/test/cmocka/src/audio/pipeline/pipeline_mocks.c
+++ b/test/cmocka/src/audio/pipeline/pipeline_mocks.c
@@ -27,19 +27,24 @@ void platform_dai_timestamp(struct comp_dev *dai,
 }
 
 int schedule_task_init(struct task *task, uint16_t type, uint16_t priority,
-		       enum task_state (*run)(void *data),
-		       void (*complete)(void *data), void *data, uint16_t core,
-		       uint32_t xflags)
+		       enum task_state (*run)(void *data), void *data,
+		       uint16_t core, uint32_t flags)
 {
 	(void)task;
 	(void)type;
 	(void)priority;
 	(void)run;
-	(void)complete;
 	(void)data;
 	(void)core;
-	(void)xflags;
+	(void)flags;
 
+	return 0;
+}
+
+int schedule_task_init_ll(struct task *task, uint16_t type, uint16_t priority,
+			  enum task_state (*run)(void *data), void *data,
+			  uint16_t core, uint32_t flags)
+{
 	return 0;
 }
 

--- a/test/cmocka/src/audio/pipeline/pipeline_mocks.h
+++ b/test/cmocka/src/audio/pipeline/pipeline_mocks.h
@@ -9,6 +9,7 @@
 #include <sof/audio/pipeline.h>
 #include <sof/lib/clk.h>
 #include <sof/schedule/edf_schedule.h>
+#include <sof/schedule/ll_schedule.h>
 #include <sof/schedule/schedule.h>
 #include <stdarg.h>
 #include <stddef.h>

--- a/tools/testbench/CMakeLists.txt
+++ b/tools/testbench/CMakeLists.txt
@@ -13,6 +13,7 @@ add_executable(testbench
 	file.c
 	ipc.c
 	schedule.c
+	ll_schedule.c
 	edf_schedule.c
 	panic.c
 	timer.c

--- a/tools/testbench/edf_schedule.c
+++ b/tools/testbench/edf_schedule.c
@@ -43,12 +43,23 @@ static void schedule_edf_task(void *data, struct task *task, uint64_t start,
 	schedule_edf_task_complete(task);
 }
 
-static int schedule_edf_task_init(void *data, struct task *task)
+int schedule_task_init_edf(struct task *task, uint16_t priority,
+			   enum task_state (*run)(void *data),
+			   void (*complete)(void *data), void *data,
+			   uint16_t core, uint32_t flags)
 {
 	struct edf_task_pdata *edf_pdata;
+	int ret = 0;
+
+	ret = schedule_task_init(task, SOF_SCHEDULE_EDF, priority, run, data,
+				 core, flags);
+	if (ret < 0)
+		return ret;
 
 	edf_pdata = malloc(sizeof(*edf_pdata));
 	edf_sch_set_pdata(task, edf_pdata);
+
+	task->complete = complete;
 
 	return 0;
 }
@@ -96,7 +107,6 @@ static void schedule_edf_task_free(void *data, struct task *task)
 
 struct scheduler_ops schedule_edf_ops = {
 	.schedule_task		= schedule_edf_task,
-	.schedule_task_init	= schedule_edf_task_init,
 	.schedule_task_running	= NULL,
 	.schedule_task_complete = NULL,
 	.reschedule_task	= NULL,

--- a/tools/testbench/edf_schedule.c
+++ b/tools/testbench/edf_schedule.c
@@ -43,15 +43,14 @@ static void schedule_edf_task(void *data, struct task *task, uint64_t start,
 	schedule_edf_task_complete(task);
 }
 
-int schedule_task_init_edf(struct task *task, uint16_t priority,
-			   const struct task_ops *ops, void *data,
-			   uint16_t core, uint32_t flags)
+int schedule_task_init_edf(struct task *task, const struct task_ops *ops,
+			   void *data, uint16_t core, uint32_t flags)
 {
 	struct edf_task_pdata *edf_pdata;
 	int ret = 0;
 
-	ret = schedule_task_init(task, SOF_SCHEDULE_EDF, priority, ops->run,
-				 data, core, flags);
+	ret = schedule_task_init(task, SOF_SCHEDULE_EDF, 0, ops->run, data,
+				 core, flags);
 	if (ret < 0)
 		return ret;
 

--- a/tools/testbench/ipc.c
+++ b/tools/testbench/ipc.c
@@ -19,6 +19,15 @@ struct ipc_data {
 	struct ipc_data_host_buffer dh_buffer;
 };
 
+enum task_state ipc_platform_do_cmd(void *data)
+{
+	return SOF_TASK_STATE_COMPLETED;
+}
+
+void ipc_platform_complete_cmd(void *data)
+{
+}
+
 int platform_ipc_init(struct ipc *ipc)
 {
 	struct ipc_data *iipc;

--- a/tools/testbench/ll_schedule.c
+++ b/tools/testbench/ll_schedule.c
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2019 Intel Corporation. All rights reserved.
+//
+// Author: Tomasz Lauda <tomasz.lauda@linux.intel.com>
+
+#include <sof/schedule/ll_schedule.h>
+
+int schedule_task_init_ll(struct task *task, uint16_t type, uint16_t priority,
+			  enum task_state (*run)(void *data), void *data,
+			  uint16_t core, uint32_t flags)
+{
+	return 0;
+}

--- a/tools/testbench/schedule.c
+++ b/tools/testbench/schedule.c
@@ -21,19 +21,11 @@ struct schedulers **arch_schedulers_get(void)
 }
 
 int schedule_task_init(struct task *task, uint16_t type, uint16_t priority,
-		       enum task_state (*run)(void *data),
-		       void (*complete)(void *data), void *data, uint16_t core,
-		       uint32_t flags)
+		       enum task_state (*run)(void *data), void *data,
+		       uint16_t core, uint32_t flags)
 {
-	struct schedulers *schedulers = *arch_schedulers_get();
-	struct schedule_data *sch;
-	struct list_item *slist;
-	int ret = 0;
-
-	if (type >= SOF_SCHEDULE_COUNT) {
-		ret = -EINVAL;
-		goto out;
-	}
+	if (type >= SOF_SCHEDULE_COUNT)
+		return -EINVAL;
 
 	task->type = type;
 	task->priority = priority;
@@ -41,17 +33,9 @@ int schedule_task_init(struct task *task, uint16_t type, uint16_t priority,
 	task->flags = flags;
 	task->state = SOF_TASK_STATE_INIT;
 	task->run = run;
-	task->complete = complete;
 	task->data = data;
 
-	list_for_item(slist, &schedulers->list) {
-		sch = container_of(slist, struct schedule_data, list);
-		if (type == sch->type && sch->ops->schedule_task_init)
-			return sch->ops->schedule_task_init(sch->data, task);
-	}
-
-out:
-	return ret;
+	return 0;
 }
 
 static void scheduler_register(struct schedule_data *scheduler)

--- a/tools/testbench/schedule.c
+++ b/tools/testbench/schedule.c
@@ -32,7 +32,7 @@ int schedule_task_init(struct task *task, uint16_t type, uint16_t priority,
 	task->core = core;
 	task->flags = flags;
 	task->state = SOF_TASK_STATE_INIT;
-	task->run = run;
+	task->ops.run = run;
 	task->data = data;
 
 	return 0;


### PR DESCRIPTION
Improves EDF scheduling algorithm to use dynamically calculated
deadlines instead of static ones. It also simplifies the way
it chooses the next task to be executed and is first step for
further simplifications.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>