### PR TITLE
comp: fetch params from sink buffer

### DIFF
--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -174,24 +174,20 @@ static int mixer_params(struct comp_dev *dev,
 {
 	struct sof_ipc_comp_config *config = COMP_GET_CONFIG(dev);
 	struct comp_buffer *sinkb;
-	struct comp_buffer *sourceb;
 	uint32_t period_bytes;
 
 	trace_mixer_with_ids(dev, "mixer_params()");
 
-	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer,
-				  sink_list);
+	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer,
+							source_list);
 
 	/* calculate period size based on config */
-	period_bytes = dev->frames * buffer_frame_bytes(sourceb);
+	period_bytes = dev->frames * buffer_frame_bytes(sinkb);
 	if (period_bytes == 0) {
 		trace_mixer_error_with_ids(dev, "mixer_params() error: "
 					   "period_bytes = 0");
 		return -EINVAL;
 	}
-
-	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer,
-				source_list);
 
 	if (sinkb->size < config->periods_sink * period_bytes) {
 		trace_mixer_error_with_ids(dev, "mixer_params() error: "

--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -145,15 +145,15 @@ static int mux_params(struct comp_dev *dev,
 		      struct sof_ipc_stream_params *params)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
-	struct comp_buffer *sourceb;
+	struct comp_buffer *sinkb;
 
 	trace_mux_with_ids(dev, "mux_params() Karol");
 
-	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer,
-				  sink_list);
+	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer,
+				  source_list);
 
-	cd->config.num_channels = sourceb->channels;
-	cd->config.frame_format = sourceb->frame_fmt;
+	cd->config.num_channels = sinkb->channels;
+	cd->config.frame_format = sinkb->frame_fmt;
 
 	return 0;
 }


### PR DESCRIPTION
Fetches params (for mux and demux) from sink buffer
(sink buffer params are set in pipeline_set_params() before
mixer/mux_params()). For mux and mixer components some
of source buffer can be unset yet in mixer/mux_params(). 

Fixes #2154 

Signed-off-by: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>