### PR TITLE
gitignore: Ignore ctags cache files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ CMakeFiles
 doc/*.cmake
 doc/*.ninja
 doc/Makefile
+
+/tags
+/TAGS


### PR DESCRIPTION
We don't need to accidentally commit ctags files. The linux kernel
ignores these definitions, let's ignore them too.

Signed-off-by: Curtis Malainey <cujomalainey@google.com>