### PR TITLE
byt: fix SHIM_SHIM_END copy paste error

### DIFF
--- a/src/platform/baytrail/include/platform/lib/shim.h
+++ b/src/platform/baytrail/include/platform/lib/shim.h
@@ -55,7 +55,16 @@
 #define SHIM_SSP5_DIVH		0x114
 
 #define SHIM_SHIM_BEGIN		SHIM_CSR
-#define SHIM_SHIM_END		SHIM_HDMC
+
+#if defined CONFIG_BAYTRAIL
+
+#define SHIM_SHIM_END		SHIM_SSP2_DIVH
+
+#elif defined CONFIG_CHERRYTRAIL
+
+#define SHIM_SHIM_END		SHIM_SSP5_DIVH
+
+#endif
 
 /* CSR 0x0 */
 #define SHIM_CSR_RST		(0x1 << 0)


### PR DESCRIPTION
It appears that this definition was copied from the haswell definitions
but this register does not actually exist. Therefore we should use the
correct registers depending on the platform.

Signed-off-by: Curtis Malainey <cujomalainey@google.com>