### PR TITLE
gitignore: Ignore cscope cache files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,7 @@ doc/Makefile
 
 /tags
 /TAGS
+
+# cscope files
+cscope.*
+ncscope.*


### PR DESCRIPTION
We don't need to accidentally commit cscope files. The linux kernel
ignores these definitions, let's ignore them too.
This commit was inspired from a similar commit adding ctags cache files.

Signed-off-by: Diana Cretu <diana.cretu@nxp.com>