### PR TITLE
platform: imx: Enable DMA trace on the i.MX8 platform

### DIFF
--- a/src/platform/imx8/platform.c
+++ b/src/platform/imx8/platform.c
@@ -179,5 +179,11 @@ int platform_init(struct sof *sof)
 	if (ret < 0)
 		return -ENODEV;
 
+#if CONFIG_TRACE
+	/* Initialize DMA for Trace*/
+	trace_point(TRACE_BOOT_PLATFORM_DMA_TRACE);
+	dma_trace_init_complete(sof->dmat);
+#endif
+
 	return 0;
 }

--- a/src/platform/imx8/platform.c
+++ b/src/platform/imx8/platform.c
@@ -185,5 +185,8 @@ int platform_init(struct sof *sof)
 	dma_trace_init_complete(sof->dmat);
 #endif
 
+	/* show heap status */
+	heap_trace_all(1);
+
 	return 0;
 }


### PR DESCRIPTION
For some reason I omitted to do this when the Dummy DMA (host DMA) driver was usable. Now I have seen that the solution was in fact this simple (the DMA trace init complete call wasn't originally there because that required a working host DMA, which initially didn't exist).