### PR TITLE
[WIP] [RFC] sof: include: Move forward declarations to new <sof/types.h>

### DIFF
--- a/src/arch/host/include/arch/spinlock.h
+++ b/src/arch/host/include/arch/spinlock.h
@@ -10,8 +10,10 @@
 #ifndef __ARCH_SPINLOCK_H__
 #define __ARCH_SPINLOCK_H__
 
-typedef struct {
-} spinlock_t;
+struct _spinlock_t {
+};
+
+typedef struct _spinlock_t spinlock_t;
 
 static inline void arch_spinlock_init(spinlock_t **lock) {}
 static inline void arch_spin_lock(spinlock_t *lock) {}

--- a/src/arch/xtensa/include/arch/spinlock.h
+++ b/src/arch/xtensa/include/arch/spinlock.h
@@ -13,12 +13,14 @@
 #include <config.h>
 #include <stdint.h>
 
-typedef struct {
+struct _spinlock_t {
 	volatile uint32_t lock;
 #if CONFIG_DEBUG_LOCKS
 	uint32_t user;
 #endif
-} spinlock_t;
+};
+
+typedef struct _spinlock_t spinlock_t;
 
 static inline void arch_spin_lock(spinlock_t *lock)
 {

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -18,6 +18,7 @@
 #include <sof/math/numbers.h>
 #include <sof/string.h>
 #include <sof/trace/trace.h>
+#include <sof/types.h>
 #include <ipc/stream.h>
 #include <ipc/topology.h>
 #include <user/trace.h>
@@ -25,8 +26,6 @@
 #include <config.h>
 #include <stddef.h>
 #include <stdint.h>
-
-struct comp_dev;
 
 /* buffer tracing */
 #define trace_buffer(__e, ...) \

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -23,6 +23,7 @@
 #include <sof/list.h>
 #include <sof/math/numbers.h>
 #include <sof/trace/trace.h>
+#include <sof/types.h>
 #include <ipc/control.h>
 #include <ipc/stream.h>
 #include <ipc/topology.h>
@@ -33,11 +34,6 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
-
-struct comp_dev;
-struct sof_ipc_dai_config;
-struct sof_ipc_stream_posn;
-struct dai_hw_params;
 
 /** \addtogroup component_api Component API
  *  Component API specification.

--- a/src/include/sof/audio/eq_fir/fir.h
+++ b/src/include/sof/audio/eq_fir/fir.h
@@ -11,14 +11,12 @@
 #define __SOF_AUDIO_EQ_FIR_FIR_H__
 
 #include <sof/audio/eq_fir/fir_config.h>
+#include <sof/types.h>
 
 #if FIR_GENERIC
 
 #include <sof/audio/format.h>
 #include <stdint.h>
-
-struct comp_buffer;
-struct sof_eq_fir_coef_data;
 
 struct fir_state_32x16 {
 	int rwi; /* Circular read and write index */

--- a/src/include/sof/audio/eq_fir/fir_hifi2ep.h
+++ b/src/include/sof/audio/eq_fir/fir_hifi2ep.h
@@ -9,15 +9,13 @@
 #define __SOF_AUDIO_EQ_FIR_FIR_HIFI2EP_H__
 
 #include <sof/audio/eq_fir/fir_config.h>
+#include <sof/types.h>
 
 #if FIR_HIFIEP
 
 #include <xtensa/config/defs.h>
 #include <xtensa/tie/xt_hifi2.h>
 #include <stdint.h>
-
-struct comp_buffer;
-struct sof_eq_fir_coef_data;
 
 struct fir_state_32x16 {
 	ae_p24x2f *rwp; /* Circular read and write pointer */

--- a/src/include/sof/audio/eq_fir/fir_hifi3.h
+++ b/src/include/sof/audio/eq_fir/fir_hifi3.h
@@ -9,14 +9,13 @@
 #define __SOF_AUDIO_EQ_FIR_FIR_HIFI3_H__
 
 #include <sof/audio/eq_fir/fir_config.h>
+#include <sof/types.h>
 
 #if FIR_HIFI3
 
 #include <sof/audio/buffer.h>
 #include <xtensa/config/defs.h>
 #include <xtensa/tie/xt_hifi3.h>
-
-struct sof_eq_fir_coef_data;
 
 struct fir_state_32x16 {
 	ae_int32 *rwp; /* Circular read and write pointer */

--- a/src/include/sof/audio/eq_iir/eq_iir.h
+++ b/src/include/sof/audio/eq_iir/eq_iir.h
@@ -10,10 +10,8 @@
 #ifndef __SOF_AUDIO_EQ_IIR_EQ_IIR_H__
 #define __SOF_AUDIO_EQ_IIR_EQ_IIR_H__
 
+#include <sof/types.h>
 #include <stdint.h>
-
-struct comp_buffer;
-struct comp_dev;
 
 /** \brief IIR EQ processing functions map item. */
 struct eq_iir_func_map {

--- a/src/include/sof/audio/eq_iir/iir.h
+++ b/src/include/sof/audio/eq_iir/iir.h
@@ -10,10 +10,9 @@
 #ifndef __SOF_AUDIO_EQ_IIR_IIR_H__
 #define __SOF_AUDIO_EQ_IIR_IIR_H__
 
+#include <sof/types.h>
 #include <stddef.h>
 #include <stdint.h>
-
-struct sof_eq_iir_header_df2t;
 
 /* Get platforms configuration */
 #include <config.h>

--- a/src/include/sof/audio/kpb.h
+++ b/src/include/sof/audio/kpb.h
@@ -9,10 +9,9 @@
 #define __SOF_AUDIO_KPB_H__
 
 #include <sof/trace/trace.h>
+#include <sof/types.h>
 #include <user/trace.h>
 #include <stdint.h>
-
-struct comp_buffer;
 
 /* KPB tracing */
 #define trace_kpb(__e, ...) trace_event(TRACE_CLASS_KPB, __e, ##__VA_ARGS__)

--- a/src/include/sof/audio/mux.h
+++ b/src/include/sof/audio/mux.h
@@ -21,12 +21,10 @@
 #include <sof/common.h>
 #include <sof/platform.h>
 #include <sof/trace/trace.h>
+#include <sof/types.h>
 #include <sof/ut.h>
 #include <user/trace.h>
 #include <stdint.h>
-
-struct comp_buffer;
-struct comp_dev;
 
  /* tracing */
 #define trace_mux(__e, ...) trace_event(TRACE_CLASS_MUX, __e, ##__VA_ARGS__)

--- a/src/include/sof/audio/pcm_converter.h
+++ b/src/include/sof/audio/pcm_converter.h
@@ -14,11 +14,10 @@
 #ifndef __SOF_AUDIO_PCM_CONVERTER_H__
 #define __SOF_AUDIO_PCM_CONVERTER_H__
 
+#include <sof/types.h>
 #include <ipc/stream.h>
 #include <stddef.h>
 #include <stdint.h>
-
-struct comp_buffer;
 
 #define PCM_CONVERTER_GENERIC
 

--- a/src/include/sof/audio/pipeline.h
+++ b/src/include/sof/audio/pipeline.h
@@ -10,18 +10,11 @@
 
 #include <sof/lib/cpu.h>
 #include <sof/trace/trace.h>
+#include <sof/types.h>
 #include <ipc/topology.h>
 #include <user/trace.h>
 #include <stdbool.h>
 #include <stdint.h>
-
-struct comp_buffer;
-struct comp_dev;
-struct ipc;
-struct sof_ipc_buffer;
-struct sof_ipc_pcm_params;
-struct sof_ipc_stream_posn;
-struct task;
 
 /*
  * This flag disables firmware-side xrun recovery.

--- a/src/include/sof/audio/selector.h
+++ b/src/include/sof/audio/selector.h
@@ -15,13 +15,11 @@
 #define __SOF_AUDIO_SELECTOR_H__
 
 #include <sof/trace/trace.h>
+#include <sof/types.h>
 #include <ipc/stream.h>
 #include <user/selector.h>
 #include <user/trace.h>
 #include <stdint.h>
-
-struct comp_buffer;
-struct comp_dev;
 
 /** \brief Selector trace function. */
 #define trace_selector(__e, ...) \

--- a/src/include/sof/audio/stream.h
+++ b/src/include/sof/audio/stream.h
@@ -9,8 +9,7 @@
 #ifndef __SOF_AUDIO_STREAM_H__
 #define __SOF_AUDIO_STREAM_H__
 
-struct sof_ipc_pcm_params;
-struct sof_ipc_vorbis_params;
+#include <sof/types.h>
 
 enum stream_type {
 	STREAM_TYPE_PCM		= 0,

--- a/src/include/sof/audio/volume.h
+++ b/src/include/sof/audio/volume.h
@@ -20,13 +20,11 @@
 #include <sof/bit.h>
 #include <sof/schedule/task.h>
 #include <sof/trace/trace.h>
+#include <sof/types.h>
 #include <ipc/stream.h>
 #include <user/trace.h>
 #include <stddef.h>
 #include <stdint.h>
-
-struct comp_buffer;
-struct sof_ipc_ctrl_value_chan;
 
 #define CONFIG_GENERIC
 

--- a/src/include/sof/drivers/interrupt.h
+++ b/src/include/sof/drivers/interrupt.h
@@ -12,8 +12,8 @@
 #include <platform/drivers/interrupt.h>
 #include <sof/lib/cpu.h>
 #include <sof/list.h>
-#include <sof/spinlock.h>
 #include <sof/trace/trace.h>
+#include <sof/types.h>
 #include <user/trace.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/src/include/sof/drivers/ipc.h
+++ b/src/include/sof/drivers/ipc.h
@@ -15,25 +15,10 @@
 #include <sof/spinlock.h>
 #include <sof/trace/dma-trace.h>
 #include <sof/trace/trace.h>
+#include <sof/types.h>
 #include <ipc/header.h>
 #include <user/trace.h>
 #include <stdint.h>
-
-struct comp_buffer;
-struct comp_dev;
-struct dai_config;
-struct dma;
-struct dma_sg_elem_array;
-struct pipeline;
-struct sof;
-struct sof_ipc_buffer;
-struct sof_ipc_comp;
-struct sof_ipc_comp_event;
-struct sof_ipc_dai_config;
-struct sof_ipc_host_buffer;
-struct sof_ipc_pipe_comp_connect;
-struct sof_ipc_pipe_new;
-struct sof_ipc_stream_posn;
 
 #define trace_ipc(format, ...) \
 	trace_event(TRACE_CLASS_IPC, format, ##__VA_ARGS__)

--- a/src/include/sof/drivers/timer.h
+++ b/src/include/sof/drivers/timer.h
@@ -8,11 +8,9 @@
 #ifndef __SOF_DRIVERS_TIMER_H__
 #define __SOF_DRIVERS_TIMER_H__
 
+#include <sof/types.h>
 #include <arch/drivers/timer.h>
 #include <stdint.h>
-
-struct comp_dev;
-struct sof_ipc_stream_posn;
 
 #define TIMER0	0
 #define TIMER1	1

--- a/src/include/sof/init.h
+++ b/src/include/sof/init.h
@@ -8,9 +8,8 @@
 #ifndef __SOF_INIT_H__
 #define __SOF_INIT_H__
 
+#include <sof/types.h>
 #include <arch/init.h>
-
-struct sof;
 
 /* main firmware entry point - argc and argv not currently used */
 int main(int argc, char *argv[]);

--- a/src/include/sof/lib/agent.h
+++ b/src/include/sof/lib/agent.h
@@ -9,11 +9,10 @@
 #define __SOF_LIB_AGENT_H__
 
 #include <sof/schedule/task.h>
+#include <sof/types.h>
 #include <config.h>
 #include <stdbool.h>
 #include <stdint.h>
-
-struct sof;
 
 /* simple agent */
 struct sa {

--- a/src/include/sof/lib/alloc.h
+++ b/src/include/sof/lib/alloc.h
@@ -15,14 +15,11 @@
 #include <sof/lib/memory.h>
 #include <sof/spinlock.h>
 #include <sof/string.h>
+#include <sof/types.h>
 #include <user/trace.h>
 #include <config.h>
 #include <stddef.h>
 #include <stdint.h>
-
-struct dma_copy;
-struct dma_sg_config;
-struct sof;
 
 /* Heap Memory Zones
  *

--- a/src/include/sof/lib/clk.h
+++ b/src/include/sof/lib/clk.h
@@ -9,10 +9,9 @@
 #ifndef __SOF_LIB_CLK_H__
 #define __SOF_LIB_CLK_H__
 
+#include <sof/types.h>
 #include <platform/lib/clk.h>
 #include <stdint.h>
-
-struct timer;
 
 #define CLOCK_NOTIFY_PRE	0
 #define CLOCK_NOTIFY_POST	1

--- a/src/include/sof/lib/dai.h
+++ b/src/include/sof/lib/dai.h
@@ -20,12 +20,10 @@
 #include <sof/bit.h>
 #include <sof/lib/io.h>
 #include <sof/spinlock.h>
+#include <sof/types.h>
 #include <errno.h>
 #include <stddef.h>
 #include <stdint.h>
-
-struct dai;
-struct sof_ipc_dai_config;
 
 /** \addtogroup sof_dai_drivers DAI Drivers
  *  DAI Drivers API specification.

--- a/src/include/sof/lib/dma.h
+++ b/src/include/sof/lib/dma.h
@@ -22,11 +22,10 @@
 #include <sof/lib/cache.h>
 #include <sof/lib/io.h>
 #include <sof/spinlock.h>
+#include <sof/types.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
-
-struct comp_buffer;
 
 /** \addtogroup sof_dma_drivers DMA Drivers
  *  DMA Drivers API specification.
@@ -93,8 +92,6 @@ enum dma_irq_cmd {
 #define DMA_ATTR_COPY_ALIGNMENT			1
 #define DMA_ATTR_BUFFER_ADDRESS_ALIGNMENT	2
 #define DMA_ATTR_BUFFER_PERIOD_COUNT		3
-
-struct dma;
 
 /**
  *  \brief Element of SG list (as array item).

--- a/src/include/sof/lib/notifier.h
+++ b/src/include/sof/lib/notifier.h
@@ -10,9 +10,8 @@
 
 #include <sof/list.h>
 #include <sof/spinlock.h>
+#include <sof/types.h>
 #include <stdint.h>
-
-struct sof;
 
 /* notifier target core masks */
 #define NOTIFIER_TARGET_CORE_MASK(x)	(1 << x)

--- a/src/include/sof/platform.h
+++ b/src/include/sof/platform.h
@@ -18,9 +18,8 @@
 
 #if !defined(__ASSEMBLER__) && !defined(LINKER)
 
+#include <sof/types.h>
 #include <stdint.h>
-
-struct sof;
 
 /** \addtogroup platform_api Platform API
  *  Platform API specification.

--- a/src/include/sof/schedule/ll_schedule.h
+++ b/src/include/sof/schedule/ll_schedule.h
@@ -15,10 +15,9 @@
 
 #include <sof/schedule/task.h>
 #include <sof/trace/trace.h>
+#include <sof/types.h>
 #include <user/trace.h>
 #include <stdint.h>
-
-struct ll_schedule_domain;
 
 /* ll tracing */
 #define trace_ll(format, ...) \

--- a/src/include/sof/schedule/ll_schedule_domain.h
+++ b/src/include/sof/schedule/ll_schedule_domain.h
@@ -15,15 +15,11 @@
 #include <sof/lib/clk.h>
 #include <sof/spinlock.h>
 #include <sof/trace/trace.h>
+#include <sof/types.h>
 #include <ipc/topology.h>
 #include <user/trace.h>
 #include <stdbool.h>
 #include <stdint.h>
-
-struct dma;
-struct ll_schedule_domain;
-struct task;
-struct timer;
 
 struct ll_schedule_domain_ops {
 	int (*domain_register)(struct ll_schedule_domain *domain,

--- a/src/include/sof/schedule/task.h
+++ b/src/include/sof/schedule/task.h
@@ -10,11 +10,9 @@
 
 #include <arch/schedule/task.h>
 #include <sof/list.h>
+#include <sof/types.h>
 #include <stdbool.h>
 #include <stdint.h>
-
-struct comp_dev;
-struct sof;
 
 #define SOF_TASK_PRI_HIGH	0	/* priority level 0 - high */
 #define SOF_TASK_PRI_MED	4	/* priority level 4 - medium */

--- a/src/include/sof/sof.h
+++ b/src/include/sof/sof.h
@@ -9,10 +9,7 @@
 #define __SOF_SOF_H__
 
 #include <arch/sof.h>
-
-struct dma_trace_data;
-struct ipc;
-struct sa;
+#include <sof/types.h>
 
 /* general firmware context */
 struct sof {

--- a/src/include/sof/spinlock.h
+++ b/src/include/sof/spinlock.h
@@ -16,6 +16,7 @@
 #include <arch/spinlock.h>
 #include <sof/drivers/interrupt.h>
 #include <sof/trace/trace.h>
+#include <sof/types.h>
 #include <config.h>
 
 /*

--- a/src/include/sof/trace/dma-trace.h
+++ b/src/include/sof/trace/dma-trace.h
@@ -11,9 +11,8 @@
 #include <sof/lib/dma.h>
 #include <sof/schedule/task.h>
 #include <sof/spinlock.h>
+#include <sof/types.h>
 #include <stdint.h>
-
-struct sof;
 
 struct dma_trace_buf {
 	void *w_ptr;		/* buffer write pointer */

--- a/src/include/sof/trace/trace.h
+++ b/src/include/sof/trace/trace.h
@@ -20,13 +20,12 @@
 #endif
 #include <sof/common.h>
 #include <sof/trace/preproc.h>
+#include <sof/types.h>
 #include <config.h>
 #include <stdint.h>
 #if CONFIG_LIBRARY
 #include <stdio.h>
 #endif
-
-struct sof;
 
 /* bootloader trace values */
 #define TRACE_BOOT_LDR_ENTRY		0x100

--- a/src/include/sof/types.h
+++ b/src/include/sof/types.h
@@ -43,4 +43,10 @@ struct timer;
 struct sof_eq_fir_coef_data;
 struct sof_eq_iir_header_df2t;
 
+/* Arch specific */
+struct _spinlock_t;
+
+/* Typedefs */
+typedef struct _spinlock_t spinlock_t;
+
 #endif /* __SOF_TYPES_H__ */

--- a/src/include/sof/types.h
+++ b/src/include/sof/types.h
@@ -1,0 +1,46 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2019 NXP
+ *
+ * Author: Paul Olaru <paul.olaru@nxp.com>
+ */
+#ifndef __SOF_TYPES_H__
+#define __SOF_TYPES_H__
+#include <stdint.h>
+
+struct comp_buffer;
+struct comp_dev;
+struct dai;
+struct dai_config;
+struct dai_hw_params;
+struct dma;
+struct dma_copy;
+struct dma_sg_config;
+struct dma_sg_elem_array;
+struct dma_trace_data;
+struct ipc;
+struct ll_schedule_domain;
+struct pipeline;
+struct sa;
+struct sof;
+struct sof_ipc_buffer;
+struct sof_ipc_comp;
+struct sof_ipc_comp_event;
+struct sof_ipc_ctrl_value_chan;
+struct sof_ipc_dai_config;
+struct sof_ipc_host_buffer;
+struct sof_ipc_pcm_params;
+struct sof_ipc_pipe_comp_connect;
+struct sof_ipc_pipe_new;
+struct sof_ipc_stream_posn;
+struct sof_ipc_vorbis_params;
+struct task;
+struct timer;
+
+/* Highly specific types which still aren't conditionally compiled;
+ * their uses may however be conditionally compiled.
+ */
+struct sof_eq_fir_coef_data;
+struct sof_eq_iir_header_df2t;
+
+#endif /* __SOF_TYPES_H__ */

--- a/src/platform/imx8/include/platform/platform.h
+++ b/src/platform/imx8/include/platform/platform.h
@@ -16,11 +16,9 @@
 #include <sof/drivers/interrupt.h>
 #include <sof/lib/clk.h>
 #include <sof/lib/mailbox.h>
+#include <sof/types.h>
 #include <stddef.h>
 #include <stdint.h>
-
-struct ll_schedule_domain;
-struct timer;
 
 #define PLATFORM_DEFAULT_CLOCK CLK_CPU(0)
 #define LPSRAM_SIZE 16384


### PR DESCRIPTION
A small number of forward declarations are very specific and don't need
to be moved. The others were moved into a new header.

A future commit intends to use this header instead of others when only
type declarations (structures and typedefs) are needed from one of the
other headers.

Signed-off-by: Paul Olaru <paul.olaru@nxp.com>

WIP: Will soon add a second commit to remove certain direct header includes and dependencies.

The cyclic dependencies that I intend to fix with this pull request as it evolves were discovered in #2122. I intend to fix that one once this one arrives to a final form.