### PR TITLE
topology: add TGL tplg for max98357a amp and ALC5682 Headset codec

### DIFF
--- a/tools/topology/CMakeLists.txt
+++ b/tools/topology/CMakeLists.txt
@@ -108,6 +108,7 @@ set(TPLGS
 	"sof-imx8qxp-cs42888\;sof-imx8qxp-cs42888"
 	"sof-imx8qxp-nocodec-sai\;sof-imx8qxp-nocodec-sai"
 	"sof-imx8qxp-wm8960\;sof-imx8qxp-wm8960"
+	"sof-tgl-max98357a-rt5682\;sof-tgl-max98357a-rt5682"
 )
 
 add_custom_target(topologies ALL)

--- a/tools/topology/sof-tgl-max98357a-rt5682.m4
+++ b/tools/topology/sof-tgl-max98357a-rt5682.m4
@@ -1,0 +1,202 @@
+#
+# Topology for Tigerlake with Max98357a amp + rt5682 codec + DMIC + 4 HDMI
+#
+
+# Include topology builder
+include(`utils.m4')
+include(`dai.m4')
+include(`pipeline.m4')
+include(`ssp.m4')
+
+# Include TLV library
+include(`common/tlv.m4')
+
+# Include Token library
+include(`sof/tokens.m4')
+
+# Include Tigerlake DSP configuration
+include(`platform/intel/tgl.m4')
+include(`platform/intel/dmic.m4')
+DEBUG_START
+
+#
+# Define the pipelines
+#
+# PCM0 ---> volume ----> SSP1  (Speaker - max98357a)
+# PCM1 <---> volume <----> SSP0  (Headset - ALC5682)
+# PCM99 <---- volume <----- DMIC01 (dmic0 capture)
+# PCM2 ----> volume -----> iDisp1
+# PCM3 ----> volume -----> iDisp2
+# PCM4 ----> volume -----> iDisp3
+# PCM5 ----> volume -----> iDisp4
+
+dnl PIPELINE_PCM_ADD(pipeline,
+dnl     pipe id, pcm, max channels, format,
+dnl     frames, deadline, priority, core)
+
+# Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s24le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	1, 0, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency playback pipeline 2 on PCM 1 using max 2 channels of s24le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	2, 1, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency capture pipeline 3 on PCM 1 using max 2 channels of s24le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
+	3, 1, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+# Passthrough capture pipeline 4 on PCM 99 using max 4 channels.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
+	4, 99, 4, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency playback pipeline 2 on PCM 2 using max 2 channels of s32le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	5, 2, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency playback pipeline 3 on PCM 3 using max 2 channels of s32le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	6, 3, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency playback pipeline 4 on PCM 4 using max 2 channels of s32le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	7, 4, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency playback pipeline 5 on PCM 5 using max 2 channels of s32le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	8, 5, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# DAIs configuration
+#
+
+dnl DAI_ADD(pipeline,
+dnl     pipe id, dai type, dai_index, dai_be,
+dnl     buffer, periods, format,
+dnl     frames, deadline, priority, core)
+
+# playback DAI is SSP1 using 2 periods
+# Buffers use s16le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+	1, SSP, 1, SSP1-Codec,
+	PIPELINE_SOURCE_1, 2, s16le,
+	1000, 0, 0)
+# playback DAI is SSP0 using 2 periods
+# Buffers use s24le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+	2, SSP, 0, SSP0-Codec,
+	PIPELINE_SOURCE_2, 2, s24le,
+	1000, 0, 0)
+
+# capture DAI is SSP0 using 2 periods
+# Buffers use s24le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-capture.m4,
+	3, SSP, 0, SSP0-Codec,
+	PIPELINE_SINK_3, 2, s24le,
+	1000, 0, 0)
+
+# capture DAI is DMIC01 using 2 periods
+# Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-capture.m4,
+	4, DMIC, 0, dmic01,
+	PIPELINE_SINK_4, 2, s32le,
+	1000, 0, 0)
+
+# playback DAI is iDisp1 using 2 periods
+# Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+	5, HDA, 0, iDisp1,
+	PIPELINE_SOURCE_5, 2, s32le,
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+
+# playback DAI is iDisp2 using 2 periods
+# Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+	6, HDA, 1, iDisp2,
+	PIPELINE_SOURCE_6, 2, s32le,
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+
+# playback DAI is iDisp3 using 2 periods
+# Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+	7, HDA, 2, iDisp3,
+	PIPELINE_SOURCE_7, 2, s32le,
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+
+# playback DAI is iDisp4 using 2 periods
+# Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+	8, HDA, 3, iDisp4,
+	PIPELINE_SOURCE_8, 2, s32le,
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+
+# PCM Low Latency, id 0
+dnl PCM_PLAYBACK_ADD(name, pcm_id, playback)
+PCM_PLAYBACK_ADD(max357a-spk, 0, PIPELINE_PCM_1)
+PCM_DUPLEX_ADD(Headset, 1, PIPELINE_PCM_2, PIPELINE_PCM_3)
+PCM_CAPTURE_ADD(DMIC48kHz, 99, PIPELINE_PCM_4)
+PCM_PLAYBACK_ADD(HDMI1, 2, PIPELINE_PCM_5)
+PCM_PLAYBACK_ADD(HDMI2, 3, PIPELINE_PCM_6)
+PCM_PLAYBACK_ADD(HDMI3, 4, PIPELINE_PCM_7)
+PCM_PLAYBACK_ADD(HDMI4, 5, PIPELINE_PCM_8)
+
+#
+# BE conf2igurations - overrides config in ACPI if present
+#
+dnl DAI_CONFIG(type, dai_index, link_id, name, ssp_config/dmic_config)
+dnl SSP_CONFIG(format, mclk, bclk, fsync, tdm, ssp_config_data)
+dnl SSP_CLOCK(clock, freq, codec_master, polarity)
+dnl SSP_CONFIG_DATA(type, idx, valid bits, mclk_id)
+dnl mclk_id is optional
+dnl ssp1-maxmspk
+
+# SSP 1 (ID: 7)
+DAI_CONFIG(SSP, 1, 7, SSP1-Codec,
+	SSP_CONFIG(I2S, SSP_CLOCK(mclk, 19200000, codec_mclk_in),
+		SSP_CLOCK(bclk, 1536000, codec_slave),
+		SSP_CLOCK(fsync, 48000, codec_slave),
+		SSP_TDM(2, 16, 3, 3),
+		SSP_CONFIG_DATA(SSP, 1, 16)))
+# SSP 0 (ID: 0)
+DAI_CONFIG(SSP, 0, 0, SSP0-Codec,
+	SSP_CONFIG(I2S, SSP_CLOCK(mclk, 19200000, codec_mclk_in),
+		SSP_CLOCK(bclk, 2400000, codec_slave),
+		SSP_CLOCK(fsync, 48000, codec_slave),
+		SSP_TDM(2, 25, 3, 3),
+		SSP_CONFIG_DATA(SSP, 0, 24)))
+
+# dmic01 (ID: 1)
+DAI_CONFIG(DMIC, 0, 1, dmic01,
+	DMIC_CONFIG(1, 500000, 4800000, 40, 60, 48000,
+		DMIC_WORD_LENGTH(s32le), 400, DMIC, 0,
+		PDM_CONFIG(DMIC, 0, FOUR_CH_PDM0_PDM1)))
+
+# 4 HDMI/DP outputs (ID: 3,4,5,6)
+DAI_CONFIG(HDA, 0, 3, iDisp1)
+DAI_CONFIG(HDA, 1, 4, iDisp2)
+DAI_CONFIG(HDA, 2, 5, iDisp3)
+DAI_CONFIG(HDA, 3, 6, iDisp4)
+
+DEBUG_END


### PR DESCRIPTION
Add TGL topology for the DUT which has the following audio configuration:
        Max98357A speaker (I2S)
        ALC5682 headset codec (I2S)
        DMIC
        4 HDMI devices
