### PR TITLE
[RFC] dai: dma: synchronize between cores

### DIFF
--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -146,8 +146,6 @@ static struct dma_chan_data *dw_dma_channel_get(struct dma *dma,
 
 		dma->chan[i].status = COMP_STATE_READY;
 
-		atomic_add(&dma->num_channels_busy, 1);
-
 		/* return channel */
 		spin_unlock_irq(dma->lock, flags);
 		return &dma->chan[i];
@@ -182,7 +180,6 @@ static void dw_dma_channel_put_unlocked(struct dma_chan_data *channel)
 	dw_chan->ptr_data.start_ptr = 0;
 	dw_chan->ptr_data.end_ptr = 0;
 	dw_chan->ptr_data.buffer_bytes = 0;
-	atomic_sub(&channel->dma->num_channels_busy, 1);
 }
 
 /* channel must not be running when this is called */
@@ -993,9 +990,6 @@ static int dw_dma_probe(struct dma *dma)
 
 		dma_chan_set_data(chan, dw_chan);
 	}
-
-	/* init number of channels draining */
-	atomic_init(&dma->num_channels_busy, 0);
 
 	return 0;
 

--- a/src/drivers/generic/dummy-dma.c
+++ b/src/drivers/generic/dummy-dma.c
@@ -230,8 +230,6 @@ static struct dma_chan_data *dummy_dma_channel_get(struct dma *dma,
 		if (dma->chan[i].status == COMP_STATE_INIT) {
 			dma->chan[i].status = COMP_STATE_READY;
 
-			atomic_add(&dma->num_channels_busy, 1);
-
 			/* return channel */
 			spin_unlock_irq(dma->lock, flags);
 			return &dma->chan[i];
@@ -260,7 +258,6 @@ static void dummy_dma_channel_put_unlocked(struct dma_chan_data *channel)
 	ch->w_pos = 0;
 
 	channel->status = COMP_STATE_INIT;
-	atomic_sub(&channel->dma->num_channels_busy, 1);
 }
 
 /**
@@ -465,8 +462,6 @@ static int dummy_dma_probe(struct dma *dma)
 		dma->chan[i].status = COMP_STATE_INIT;
 		dma->chan[i].private = &chanp[i];
 	}
-
-	atomic_init(&dma->num_channels_busy, 0);
 
 	return 0;
 }

--- a/src/drivers/imx/edma.c
+++ b/src/drivers/imx/edma.c
@@ -99,7 +99,6 @@ static struct dma_chan_data *edma_channel_get(struct dma *dma,
 		return NULL;
 	}
 
-	atomic_add(&dma->num_channels_busy, 1);
 	channel->status = COMP_STATE_READY;
 	spin_unlock_irq(dma->lock, flags);
 
@@ -118,7 +117,6 @@ static void edma_channel_put(struct dma_chan_data *channel)
 
 	spin_lock_irq(dma->lock, flags);
 	channel->status = COMP_STATE_INIT;
-	atomic_sub(&channel->dma->num_channels_busy, 1);
 	spin_unlock_irq(dma->lock, flags);
 }
 

--- a/src/drivers/intel/cavs/hda-dma.c
+++ b/src/drivers/intel/cavs/hda-dma.c
@@ -402,8 +402,6 @@ static struct dma_chan_data *hda_dma_channel_get(struct dma *dma,
 	if (dma->chan[channel].status == COMP_STATE_INIT) {
 		dma->chan[channel].status = COMP_STATE_READY;
 
-		atomic_add(&dma->num_channels_busy, 1);
-
 		/* return channel */
 		spin_unlock_irq(dma->lock, flags);
 		return &dma->chan[channel];
@@ -440,8 +438,6 @@ static void hda_dma_channel_put(struct dma_chan_data *channel)
 	spin_lock_irq(dma->lock, flags);
 	hda_dma_channel_put_unlocked(channel);
 	spin_unlock_irq(dma->lock, flags);
-
-	atomic_sub(&dma->num_channels_busy, 1);
 }
 
 static int hda_dma_start(struct dma_chan_data *channel)
@@ -753,9 +749,6 @@ static int hda_dma_probe(struct dma *dma)
 
 		dma_chan_set_data(chan, hda_chan);
 	}
-
-	/* init number of channels draining */
-	atomic_init(&dma->num_channels_busy, 0);
 
 	return 0;
 

--- a/src/include/sof/lib/dma.h
+++ b/src/include/sof/lib/dma.h
@@ -201,7 +201,6 @@ struct dma {
 	spinlock_t *lock;	/**< locking mechanism */
 	int sref;		/**< simple ref counter, guarded by lock */
 	const struct dma_ops *ops;
-	atomic_t num_channels_busy; /* number of busy channels */
 	struct dma_chan_data *chan; /* channels array */
 	void *private;
 };

--- a/src/lib/dma.c
+++ b/src/lib/dma.c
@@ -90,10 +90,8 @@ struct dma *dma_get(uint32_t dir, uint32_t cap, uint32_t dev, uint32_t flags)
 		for (d = lib_dma.dma_array;
 		     d < lib_dma.dma_array + lib_dma.num_dmas;
 		     d++) {
-			trace_error(TRACE_CLASS_DMA, " DMAC ID %d users %d "
-				    "busy channels %d", d->plat_data.id,
-				    d->sref,
-				    atomic_read(&d->num_channels_busy));
+			trace_error(TRACE_CLASS_DMA, " DMAC ID %d users %d",
+				    d->plat_data.id, d->sref);
 			trace_error(TRACE_CLASS_DMA, "  caps 0x%x dev 0x%x",
 				    d->plat_data.caps, d->plat_data.devs);
 		}
@@ -123,9 +121,8 @@ struct dma *dma_get(uint32_t dir, uint32_t cap, uint32_t dev, uint32_t flags)
 	if (!ret)
 		dmin->sref++;
 
-	trace_event(TRACE_CLASS_DMA, "dma_get() ID %d sref = %d "
-		    "busy channels %d", dmin->plat_data.id, dmin->sref,
-		    atomic_read(&dmin->num_channels_busy));
+	trace_event(TRACE_CLASS_DMA, "dma_get() ID %d sref = %d",
+		    dmin->plat_data.id, dmin->sref);
 
 	spin_unlock(dmin->lock);
 	return !ret ? dmin : NULL;


### PR DESCRIPTION
Adds invalidate and writeback cache operations in order to
synchronize DMA and DAI lists between cores.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>