### PR TITLE
workaround: disable hifi3 pcm conversion

### DIFF
--- a/src/audio/Kconfig
+++ b/src/audio/Kconfig
@@ -236,4 +236,10 @@ config FORMAT_FLOAT
 	help
 	  Support floating point processing data format
 
+config FORMAT_CONVERT_HIFI3
+	bool "HIFI3 optimized conversion"
+	default n
+	help
+	  Use HIFI3 extensions for optimized format conversion (experimental).
+
 endmenu

--- a/src/include/sof/audio/pcm_converter.h
+++ b/src/include/sof/audio/pcm_converter.h
@@ -26,7 +26,7 @@ struct comp_buffer;
 
 #include <xtensa/config/core-isa.h>
 
-#if XCHAL_HAVE_HIFI3
+#if XCHAL_HAVE_HIFI3 && CONFIG_FORMAT_CONVERT_HIFI3
 
 #undef PCM_CONVERTER_GENERIC
 #define PCM_CONVERTER_HIFI3


### PR DESCRIPTION
Due to stability issues of hifi3 pcm conversion the
used implementation should be switched to generic.

This is a temporary measure, the hifi3 implementation
should be enabled again once stability issues are resolved.

Signed-off-by: Slawomir Blauciak <slawomir.blauciak@linux.intel.com>