### PR TITLE
init: remove need to access sof struct on slave cores

### DIFF
--- a/src/arch/xtensa/include/arch/init.h
+++ b/src/arch/xtensa/include/arch/init.h
@@ -24,8 +24,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-struct sof;
-
 /**
  * \brief Called in the case of exception.
  */
@@ -131,11 +129,11 @@ static inline void __memmap_init(void) { }
 
 #if CONFIG_SMP
 
-int slave_core_init(struct sof *sof);
+int slave_core_init(void);
 
 #else
 
-static inline int slave_core_init(struct sof *sof) { return 0; }
+static inline int slave_core_init(void) { return 0; }
 
 #endif /* CONFIG_SMP */
 

--- a/src/arch/xtensa/init.c
+++ b/src/arch/xtensa/init.c
@@ -98,10 +98,9 @@ static void initialize_pointers_per_core(void)
 
 /**
  * \brief Initializes architecture.
- * \param[in,out] sof Firmware main context.
  * \return Error status.
  */
-int arch_init(struct sof *sof)
+int arch_init(void)
 {
 	initialize_pointers_per_core();
 	register_exceptions();
@@ -123,18 +122,18 @@ int arch_init(struct sof *sof)
 #include <sof/trace/trace.h>
 #include <ipc/trace.h>
 
-int slave_core_init(struct sof *sof)
+int slave_core_init(void)
 {
 	int err;
 
 	/* init architecture */
 	trace_point(TRACE_BOOT_ARCH);
-	err = arch_init(sof);
+	err = arch_init();
 	if (err < 0)
 		panic(SOF_IPC_PANIC_ARCH);
 
 	trace_point(TRACE_BOOT_SYS_NOTIFIER);
-	init_system_notify(sof);
+	init_system_notify();
 
 	/* interrupts need to be initialized before any usage */
 	trace_point(TRACE_BOOT_PLATFORM_IRQ);

--- a/src/include/sof/init.h
+++ b/src/include/sof/init.h
@@ -15,8 +15,8 @@ struct sof;
 /* main firmware entry point - argc and argv not currently used */
 int main(int argc, char *argv[]);
 
-int master_core_init(struct sof *sof);
+int master_core_init(int argc, char *argv[], struct sof *sof);
 
-int arch_init(struct sof *sof);
+int arch_init(void);
 
 #endif /* __SOF_INIT_H__ */

--- a/src/include/sof/lib/notifier.h
+++ b/src/include/sof/lib/notifier.h
@@ -12,8 +12,6 @@
 #include <sof/spinlock.h>
 #include <stdint.h>
 
-struct sof;
-
 /* notifier target core masks */
 #define NOTIFIER_TARGET_CORE_MASK(x)	(1 << x)
 #define NOTIFIER_TARGET_CORE_ALL_MASK	0xFFFFFFFF
@@ -60,7 +58,7 @@ void notifier_unregister(struct notifier *notifier);
 void notifier_notify(void);
 void notifier_event(struct notify_data *notify_data);
 
-void init_system_notify(struct sof *sof);
+void init_system_notify(void);
 
 void free_system_notify(void);
 

--- a/src/init/init.c
+++ b/src/init/init.c
@@ -26,13 +26,17 @@
 /* main firmware context */
 static struct sof sof;
 
-int master_core_init(struct sof *sof)
+int master_core_init(int argc, char *argv[], struct sof *sof)
 {
 	int err, i;
 
+	/* setup context */
+	sof->argc = argc;
+	sof->argv = argv;
+
 	/* init architecture */
 	trace_point(TRACE_BOOT_ARCH);
-	err = arch_init(sof);
+	err = arch_init();
 	if (err < 0)
 		panic(SOF_IPC_PANIC_ARCH);
 
@@ -49,7 +53,7 @@ int master_core_init(struct sof *sof)
 #endif
 
 	trace_point(TRACE_BOOT_SYS_NOTIFIER);
-	init_system_notify(sof);
+	init_system_notify();
 
 	trace_point(TRACE_BOOT_SYS_POWER);
 	pm_runtime_init();
@@ -78,14 +82,10 @@ int main(int argc, char *argv[])
 
 	trace_point(TRACE_BOOT_START);
 
-	/* setup context */
-	sof.argc = argc;
-	sof.argv = argv;
-
 	if (cpu_get_id() == PLATFORM_MASTER_CORE_ID)
-		err = master_core_init(&sof);
+		err = master_core_init(argc, argv, &sof);
 	else
-		err = slave_core_init(&sof);
+		err = slave_core_init();
 
 	/* should never get here */
 	panic(SOF_IPC_PANIC_TASK);

--- a/src/lib/notifier.c
+++ b/src/lib/notifier.c
@@ -84,7 +84,7 @@ void notifier_event(struct notify_data *notify_data)
 	spin_unlock(notify->lock);
 }
 
-void init_system_notify(struct sof *sof)
+void init_system_notify(void)
 {
 	struct notify **notify = arch_notify_get();
 	*notify = rzalloc(RZONE_SYS, SOF_MEM_CAPS_RAM, sizeof(**notify));


### PR DESCRIPTION
Moves sof structure initialization to master core to avoid
data being overwritten by slave cores in case of future use.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>