### PR TITLE
schedule: make ops constant

### DIFF
--- a/src/schedule/dma_multi_chan_domain.c
+++ b/src/schedule/dma_multi_chan_domain.c
@@ -41,7 +41,7 @@ struct dma_domain {
 	struct dma_domain_data data[PLATFORM_NUM_DMACS][PLATFORM_MAX_DMA_CHAN];
 };
 
-struct ll_schedule_domain_ops dma_multi_chan_domain_ops;
+const struct ll_schedule_domain_ops dma_multi_chan_domain_ops;
 
 /**
  * \brief Generic DMA interrupt handler.
@@ -334,7 +334,7 @@ struct ll_schedule_domain *dma_multi_chan_domain_init(struct dma *dma_array,
 	return domain;
 }
 
-struct ll_schedule_domain_ops dma_multi_chan_domain_ops = {
+const struct ll_schedule_domain_ops dma_multi_chan_domain_ops = {
 	.domain_register	= dma_multi_chan_domain_register,
 	.domain_unregister	= dma_multi_chan_domain_unregister,
 	.domain_is_pending	= dma_multi_chan_domain_is_pending,

--- a/src/schedule/dma_single_chan_domain.c
+++ b/src/schedule/dma_single_chan_domain.c
@@ -43,7 +43,7 @@ struct dma_domain {
 	struct dma_domain_data data[PLATFORM_CORE_COUNT];
 };
 
-struct ll_schedule_domain_ops dma_single_chan_domain_ops;
+const struct ll_schedule_domain_ops dma_single_chan_domain_ops;
 
 static void dma_single_chan_domain_enable(struct ll_schedule_domain *domain,
 					  int core);
@@ -541,7 +541,7 @@ struct ll_schedule_domain *dma_single_chan_domain_init(struct dma *dma_array,
 	return domain;
 }
 
-struct ll_schedule_domain_ops dma_single_chan_domain_ops = {
+const struct ll_schedule_domain_ops dma_single_chan_domain_ops = {
 	.domain_register	= dma_single_chan_domain_register,
 	.domain_unregister	= dma_single_chan_domain_unregister,
 	.domain_enable		= dma_single_chan_domain_enable,

--- a/src/schedule/edf_schedule.c
+++ b/src/schedule/edf_schedule.c
@@ -28,7 +28,7 @@ struct edf_schedule_data {
 	int irq;
 };
 
-struct scheduler_ops schedule_edf_ops;
+const struct scheduler_ops schedule_edf_ops;
 
 static void schedule_edf_task_complete(void *data, struct task *task);
 static void schedule_edf_task_running(void *data, struct task *task);
@@ -312,7 +312,7 @@ static void schedule_edf(void *data)
 	interrupt_set(edf_sch->irq);
 }
 
-struct scheduler_ops schedule_edf_ops = {
+const struct scheduler_ops schedule_edf_ops = {
 	.schedule_task		= schedule_edf_task,
 	.schedule_task_init	= schedule_edf_task_init,
 	.schedule_task_running	= schedule_edf_task_running,

--- a/src/schedule/ll_schedule.c
+++ b/src/schedule/ll_schedule.c
@@ -35,7 +35,7 @@ struct ll_schedule_data {
 	struct ll_schedule_domain *domain;	/* scheduling domain */
 };
 
-struct scheduler_ops schedule_ll_ops;
+const struct scheduler_ops schedule_ll_ops;
 
 static bool schedule_ll_is_pending(struct ll_schedule_data *sch)
 {
@@ -458,7 +458,7 @@ int scheduler_init_ll(struct ll_schedule_domain *domain)
 	return 0;
 }
 
-struct scheduler_ops schedule_ll_ops = {
+const struct scheduler_ops schedule_ll_ops = {
 	.schedule_task		= schedule_ll_task,
 	.schedule_task_init	= schedule_ll_task_init,
 	.schedule_task_free	= schedule_ll_task_free,

--- a/src/schedule/timer_domain.c
+++ b/src/schedule/timer_domain.c
@@ -23,7 +23,7 @@ struct timer_domain {
 	void *arg[PLATFORM_CORE_COUNT];
 };
 
-struct ll_schedule_domain_ops timer_domain_ops;
+const struct ll_schedule_domain_ops timer_domain_ops;
 
 static inline void timer_report_delay(int id, uint64_t delay)
 {
@@ -139,7 +139,7 @@ struct ll_schedule_domain *timer_domain_init(struct timer *timer, int clk,
 	return domain;
 }
 
-struct ll_schedule_domain_ops timer_domain_ops = {
+const struct ll_schedule_domain_ops timer_domain_ops = {
 	.domain_register	= timer_domain_register,
 	.domain_unregister	= timer_domain_unregister,
 	.domain_enable		= timer_domain_enable,


### PR DESCRIPTION
Makes schedulers and scheduling domains ops constant and effectively
puts them in rodata segment.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>