### PR TITLE
clk: remove unnecessary additional structures

### DIFF
--- a/src/include/sof/drivers/ssp.h
+++ b/src/include/sof/drivers/ssp.h
@@ -23,8 +23,8 @@
 #define SSP_CLOCK_AUDIO_CARDINAL	0x1
 #define SSP_CLOCK_PLL_FIXED		0x2
 
-extern struct freq_table *ssp_freq;
-extern uint32_t *ssp_freq_sources;
+extern const struct freq_table *ssp_freq;
+extern const uint32_t *ssp_freq_sources;
 
 /* SSP register offsets */
 #define SSCR0		0x00

--- a/src/include/sof/lib/clk.h
+++ b/src/include/sof/lib/clk.h
@@ -10,6 +10,7 @@
 #define __SOF_LIB_CLK_H__
 
 #include <platform/lib/clk.h>
+#include <sof/spinlock.h>
 #include <stdint.h>
 
 struct timer;
@@ -34,8 +35,10 @@ struct clock_info {
 	uint32_t freqs_num;
 	const struct freq_table *freqs;
 	uint32_t default_freq_idx;
+	uint32_t current_freq_idx;
 	uint32_t notification_id;
 	uint32_t notification_mask;
+	spinlock_t *lock;
 	int (*set_freq)(int clock, int freq_idx);
 };
 
@@ -48,7 +51,5 @@ void clock_set_freq(int clock, uint32_t hz);
 uint64_t clock_ms_to_ticks(int clock, uint64_t ms);
 
 void platform_timer_set_delta(struct timer *timer, uint64_t ns);
-
-void clock_init(void);
 
 #endif /* __SOF_LIB_CLK_H__ */

--- a/src/include/sof/lib/clk.h
+++ b/src/include/sof/lib/clk.h
@@ -32,7 +32,7 @@ struct freq_table {
 
 struct clock_info {
 	uint32_t freqs_num;
-	struct freq_table *freqs;
+	const struct freq_table *freqs;
 	uint32_t default_freq_idx;
 	uint32_t notification_id;
 	uint32_t notification_mask;

--- a/src/lib/clk.c
+++ b/src/lib/clk.c
@@ -101,6 +101,6 @@ void platform_timer_set_delta(struct timer *timer, uint64_t ns)
 		clk_info->freqs[clk_info->current_freq_idx].ticks_per_msec;
 	uint64_t ticks;
 
-	ticks = ticks_per_msec / 1000 * ns / 1000;
+	ticks = ticks_per_msec * ns / 1000000;
 	timer->delta = ticks - platform_timer_get(timer);
 }

--- a/src/platform/apollolake/lib/clk.c
+++ b/src/platform/apollolake/lib/clk.c
@@ -9,13 +9,13 @@
 #include <sof/drivers/ssp.h>
 #include <sof/lib/clk.h>
 
-static struct freq_table platform_cpu_freq[] = {
+const struct freq_table platform_cpu_freq[] = {
 	{ 100000000, 100000 },
 	{ 200000000, 200000 },
 	{ CLK_MAX_CPU_HZ, 400000 },
 };
 
-uint32_t cpu_freq_enc[] = {
+const uint32_t cpu_freq_enc[] = {
 	0x3,
 	0x1,
 	0x0,
@@ -24,18 +24,18 @@ uint32_t cpu_freq_enc[] = {
 STATIC_ASSERT(NUM_CPU_FREQ == ARRAY_SIZE(platform_cpu_freq),
 	      invalid_number_of_cpu_frequencies);
 
-struct freq_table *cpu_freq = platform_cpu_freq;
+const struct freq_table *cpu_freq = platform_cpu_freq;
 
 /* IMPORTANT: array should be filled in increasing order
  * (regarding to .freq field)
  */
-static struct freq_table platform_ssp_freq[] = {
+const struct freq_table platform_ssp_freq[] = {
 	{ 19200000, 19200 },
 	{ 24576000, 24576 },
 	{ 96000000, 96000 },
 };
 
-static uint32_t platform_ssp_freq_sources[] = {
+const uint32_t platform_ssp_freq_sources[] = {
 	SSP_CLOCK_XTAL_OSCILLATOR,
 	SSP_CLOCK_AUDIO_CARDINAL,
 	SSP_CLOCK_PLL_FIXED,
@@ -44,5 +44,5 @@ static uint32_t platform_ssp_freq_sources[] = {
 STATIC_ASSERT(NUM_SSP_FREQ == ARRAY_SIZE(platform_ssp_freq),
 	      invalid_number_of_ssp_frequencies);
 
-struct freq_table *ssp_freq = platform_ssp_freq;
-uint32_t *ssp_freq_sources = platform_ssp_freq_sources;
+const struct freq_table *ssp_freq = platform_ssp_freq;
+const uint32_t *ssp_freq_sources = platform_ssp_freq_sources;

--- a/src/platform/baytrail/include/platform/lib/clk.h
+++ b/src/platform/baytrail/include/platform/lib/clk.h
@@ -34,6 +34,8 @@
 #define NUM_CPU_FREQ	8
 #define NUM_SSP_FREQ	2
 
+void platform_clock_init(void);
+
 #endif /* __PLATFORM_LIB_CLK_H__ */
 
 #else

--- a/src/platform/baytrail/lib/clk.c
+++ b/src/platform/baytrail/lib/clk.c
@@ -9,6 +9,7 @@
 #include <sof/drivers/ssp.h>
 #include <sof/lib/clk.h>
 #include <sof/lib/notifier.h>
+#include <sof/spinlock.h>
 #include <config.h>
 
 #if CONFIG_BAYTRAIL
@@ -90,6 +91,7 @@ static struct clock_info platform_clocks_info[] = {
 		.freqs_num = NUM_CPU_FREQ,
 		.freqs = platform_cpu_freq,
 		.default_freq_idx = CPU_DEFAULT_IDX,
+		.current_freq_idx = CPU_DEFAULT_IDX,
 		.notification_id = NOTIFIER_ID_CPU_FREQ,
 		.notification_mask = NOTIFIER_TARGET_CORE_MASK(0),
 		.set_freq = clock_platform_set_cpu_freq,
@@ -98,6 +100,7 @@ static struct clock_info platform_clocks_info[] = {
 		.freqs_num = NUM_SSP_FREQ,
 		.freqs = platform_ssp_freq,
 		.default_freq_idx = SSP_DEFAULT_IDX,
+		.current_freq_idx = SSP_DEFAULT_IDX,
 		.notification_id = NOTIFIER_ID_SSP_FREQ,
 		.notification_mask = NOTIFIER_TARGET_CORE_ALL_MASK,
 		.set_freq = clock_platform_set_ssp_freq,
@@ -108,3 +111,11 @@ STATIC_ASSERT(ARRAY_SIZE(platform_clocks_info) == NUM_CLOCKS,
 	      invalid_number_of_clocks);
 
 struct clock_info *clocks = platform_clocks_info;
+
+void platform_clock_init(void)
+{
+	int i;
+
+	for (i = 0; i < NUM_CLOCKS; i++)
+		spinlock_init(&platform_clocks_info[i].lock);
+}

--- a/src/platform/baytrail/lib/clk.c
+++ b/src/platform/baytrail/lib/clk.c
@@ -12,7 +12,7 @@
 #include <config.h>
 
 #if CONFIG_BAYTRAIL
-static struct freq_table platform_cpu_freq[] = {
+const struct freq_table platform_cpu_freq[] = {
 	{ 25000000, 25000 },
 	{ 25000000, 25000 },
 	{ 50000000, 50000 },
@@ -23,7 +23,7 @@ static struct freq_table platform_cpu_freq[] = {
 	{ 343000000, 343000 },
 };
 #elif CONFIG_CHERRYTRAIL
-static struct freq_table platform_cpu_freq[] = {
+const struct freq_table platform_cpu_freq[] = {
 	{ 19200000, 19200 },
 	{ 19200000, 19200 },
 	{ 38400000, 38400 },
@@ -35,7 +35,7 @@ static struct freq_table platform_cpu_freq[] = {
 };
 #endif
 
-static uint32_t cpu_freq_enc[] = {
+const uint32_t cpu_freq_enc[] = {
 	0x0,
 	0x1,
 	0x2,
@@ -49,14 +49,14 @@ static uint32_t cpu_freq_enc[] = {
 STATIC_ASSERT(NUM_CPU_FREQ == ARRAY_SIZE(platform_cpu_freq),
 	      invalid_number_of_cpu_frequencies);
 
-struct freq_table *cpu_freq = platform_cpu_freq;
+const struct freq_table *cpu_freq = platform_cpu_freq;
 
-static struct freq_table platform_ssp_freq[] = {
+const struct freq_table platform_ssp_freq[] = {
 	{ 19200000, 19200 }, /* default */
 	{ 25000000, 25000 },
 };
 
-static uint32_t platform_ssp_freq_sources[] = {
+const uint32_t platform_ssp_freq_sources[] = {
 	PMC_SET_SSP_19M2,
 	PMC_SET_SSP_25M,
 };
@@ -64,8 +64,8 @@ static uint32_t platform_ssp_freq_sources[] = {
 STATIC_ASSERT(NUM_SSP_FREQ == ARRAY_SIZE(platform_ssp_freq),
 	      invalid_number_of_ssp_frequencies);
 
-struct freq_table *ssp_freq = platform_ssp_freq;
-uint32_t *ssp_freq_sources = platform_ssp_freq_sources;
+const struct freq_table *ssp_freq = platform_ssp_freq;
+const uint32_t *ssp_freq_sources = platform_ssp_freq_sources;
 
 static inline int clock_platform_set_cpu_freq(int clock, int freq_idx)
 {

--- a/src/platform/baytrail/platform.c
+++ b/src/platform/baytrail/platform.c
@@ -187,7 +187,7 @@ int platform_init(struct sof *sof)
 	platform_timer_start(platform_timer);
 
 	trace_point(TRACE_BOOT_PLATFORM_CLOCK);
-	clock_init();
+	platform_clock_init();
 
 	trace_point(TRACE_BOOT_PLATFORM_SCHED);
 	scheduler_init_edf();

--- a/src/platform/cannonlake/lib/clk.c
+++ b/src/platform/cannonlake/lib/clk.c
@@ -9,19 +9,19 @@
 #include <sof/drivers/ssp.h>
 #include <sof/lib/clk.h>
 
-static struct freq_table platform_cpu_freq[] = {
+const struct freq_table platform_cpu_freq[] = {
 	{ 120000000, 120000 },
 	{ CLK_MAX_CPU_HZ, 400000 },
 };
 
-uint32_t cpu_freq_enc[] = {
+const uint32_t cpu_freq_enc[] = {
 	SHIM_CLKCTL_RLROSCC | SHIM_CLKCTL_OCS_LP_RING |
 		SHIM_CLKCTL_HMCS_DIV2 | SHIM_CLKCTL_LMCS_DIV4,
 	SHIM_CLKCTL_RHROSCC | SHIM_CLKCTL_OCS_HP_RING |
 		SHIM_CLKCTL_HMCS_DIV2 | SHIM_CLKCTL_LMCS_DIV4,
 };
 
-uint32_t cpu_freq_status_mask[] = {
+const uint32_t cpu_freq_status_mask[] = {
 	SHIM_CLKSTS_LROSCCS,
 	SHIM_CLKSTS_HROSCCS,
 };
@@ -29,17 +29,17 @@ uint32_t cpu_freq_status_mask[] = {
 STATIC_ASSERT(NUM_CPU_FREQ == ARRAY_SIZE(platform_cpu_freq),
 	      invalid_number_of_cpu_frequencies);
 
-struct freq_table *cpu_freq = platform_cpu_freq;
+const struct freq_table *cpu_freq = platform_cpu_freq;
 
 /* IMPORTANT: array should be filled in increasing order
  * (regarding to .freq field)
  */
-static struct freq_table platform_ssp_freq[] = {
+const static struct freq_table platform_ssp_freq[] = {
 	{ 24000000, 24000 },
 	{ 96000000, 96000 },
 };
 
-static uint32_t platform_ssp_freq_sources[] = {
+const static uint32_t platform_ssp_freq_sources[] = {
 	SSP_CLOCK_XTAL_OSCILLATOR,
 	SSP_CLOCK_PLL_FIXED,
 };
@@ -47,5 +47,5 @@ static uint32_t platform_ssp_freq_sources[] = {
 STATIC_ASSERT(NUM_SSP_FREQ == ARRAY_SIZE(platform_ssp_freq),
 	      invalid_number_of_ssp_frequencies);
 
-struct freq_table *ssp_freq = platform_ssp_freq;
-uint32_t *ssp_freq_sources = platform_ssp_freq_sources;
+const struct freq_table *ssp_freq = platform_ssp_freq;
+const uint32_t *ssp_freq_sources = platform_ssp_freq_sources;

--- a/src/platform/haswell/include/platform/lib/clk.h
+++ b/src/platform/haswell/include/platform/lib/clk.h
@@ -28,6 +28,8 @@
 #define NUM_CPU_FREQ	6
 #define NUM_SSP_FREQ	1
 
+void platform_clock_init(void);
+
 #endif /* __PLATFORM_LIB_CLK_H__ */
 
 #else

--- a/src/platform/haswell/lib/clk.c
+++ b/src/platform/haswell/lib/clk.c
@@ -10,7 +10,7 @@
 #include <sof/lib/clk.h>
 #include <sof/lib/notifier.h>
 
-static struct freq_table platform_cpu_freq[] = {
+const struct freq_table platform_cpu_freq[] = {
 	{ 32000000, 32000 },
 	{ 80000000, 80000 },
 	{ 160000000, 160000 },
@@ -19,7 +19,7 @@ static struct freq_table platform_cpu_freq[] = {
 	{ 160000000, 160000 },
 };
 
-static uint32_t cpu_freq_enc[] = {
+const uint32_t cpu_freq_enc[] = {
 	0x6,
 	0x2,
 	0x1,
@@ -31,19 +31,19 @@ static uint32_t cpu_freq_enc[] = {
 STATIC_ASSERT(NUM_CPU_FREQ == ARRAY_SIZE(platform_cpu_freq),
 	      invalid_number_of_cpu_frequencies);
 
-static struct freq_table platform_ssp_freq[] = {
+const struct freq_table platform_ssp_freq[] = {
 	{ 24000000, 24000 },
 };
 
-static uint32_t platform_ssp_freq_sources[] = {
+const uint32_t platform_ssp_freq_sources[] = {
 	0,
 };
 
 STATIC_ASSERT(NUM_SSP_FREQ == ARRAY_SIZE(platform_ssp_freq),
 	      invalid_number_of_ssp_frequencies);
 
-struct freq_table *ssp_freq = platform_ssp_freq;
-uint32_t *ssp_freq_sources = platform_ssp_freq_sources;
+const struct freq_table *ssp_freq = platform_ssp_freq;
+const uint32_t *ssp_freq_sources = platform_ssp_freq_sources;
 
 static int clock_platform_set_cpu_freq(int clock, int freq_idx)
 {

--- a/src/platform/haswell/lib/clk.c
+++ b/src/platform/haswell/lib/clk.c
@@ -9,6 +9,7 @@
 #include <sof/drivers/ssp.h>
 #include <sof/lib/clk.h>
 #include <sof/lib/notifier.h>
+#include <sof/spinlock.h>
 
 const struct freq_table platform_cpu_freq[] = {
 	{ 32000000, 32000 },
@@ -61,6 +62,7 @@ static struct clock_info platform_clocks_info[] = {
 		.freqs_num = NUM_CPU_FREQ,
 		.freqs = platform_cpu_freq,
 		.default_freq_idx = CPU_DEFAULT_IDX,
+		.current_freq_idx = CPU_DEFAULT_IDX,
 		.notification_id = NOTIFIER_ID_CPU_FREQ,
 		.notification_mask = NOTIFIER_TARGET_CORE_MASK(0),
 		.set_freq = clock_platform_set_cpu_freq,
@@ -69,6 +71,7 @@ static struct clock_info platform_clocks_info[] = {
 		.freqs_num = NUM_SSP_FREQ,
 		.freqs = platform_ssp_freq,
 		.default_freq_idx = SSP_DEFAULT_IDX,
+		.current_freq_idx = SSP_DEFAULT_IDX,
 		.notification_id = NOTIFIER_ID_SSP_FREQ,
 		.notification_mask = NOTIFIER_TARGET_CORE_ALL_MASK,
 		.set_freq = NULL,
@@ -79,3 +82,11 @@ STATIC_ASSERT(ARRAY_SIZE(platform_clocks_info) == NUM_CLOCKS,
 	      invalid_number_of_clocks);
 
 struct clock_info *clocks = platform_clocks_info;
+
+void platform_clock_init(void)
+{
+	int i;
+
+	for (i = 0; i < NUM_CLOCKS; i++)
+		spinlock_init(&platform_clocks_info[i].lock);
+}

--- a/src/platform/haswell/platform.c
+++ b/src/platform/haswell/platform.c
@@ -175,7 +175,7 @@ int platform_init(struct sof *sof)
 	platform_timer_start(platform_timer);
 
 	trace_point(TRACE_BOOT_PLATFORM_CLOCK);
-	clock_init();
+	platform_clock_init();
 
 	trace_point(TRACE_BOOT_PLATFORM_SCHED);
 	scheduler_init_edf();

--- a/src/platform/icelake/lib/clk.c
+++ b/src/platform/icelake/lib/clk.c
@@ -9,19 +9,19 @@
 #include <sof/drivers/ssp.h>
 #include <sof/lib/clk.h>
 
-static struct freq_table platform_cpu_freq[] = {
+const struct freq_table platform_cpu_freq[] = {
 	{ 120000000, 120000 },
 	{ CLK_MAX_CPU_HZ, 400000 },
 };
 
-uint32_t cpu_freq_enc[] = {
+const uint32_t cpu_freq_enc[] = {
 	SHIM_CLKCTL_RLROSCC | SHIM_CLKCTL_OCS_LP_RING |
 		SHIM_CLKCTL_HMCS_DIV2 | SHIM_CLKCTL_LMCS_DIV4,
 	SHIM_CLKCTL_RHROSCC | SHIM_CLKCTL_OCS_HP_RING |
 		SHIM_CLKCTL_HMCS_DIV2 | SHIM_CLKCTL_LMCS_DIV4,
 };
 
-uint32_t cpu_freq_status_mask[] = {
+const uint32_t cpu_freq_status_mask[] = {
 	SHIM_CLKSTS_LROSCCS,
 	SHIM_CLKSTS_HROSCCS,
 };
@@ -29,18 +29,18 @@ uint32_t cpu_freq_status_mask[] = {
 STATIC_ASSERT(NUM_CPU_FREQ == ARRAY_SIZE(platform_cpu_freq),
 	      invalid_number_of_cpu_frequencies);
 
-struct freq_table *cpu_freq = platform_cpu_freq;
+const struct freq_table *cpu_freq = platform_cpu_freq;
 
 /* IMPORTANT: array should be filled in increasing order
  * (regarding to .freq field)
  */
-static struct freq_table platform_ssp_freq[] = {
+const struct freq_table platform_ssp_freq[] = {
 	{ 24576000, 24576 },
 	{ 38400000, 38400 },
 	{ 96000000, 96000 },
 };
 
-static uint32_t platform_ssp_freq_sources[] = {
+const uint32_t platform_ssp_freq_sources[] = {
 	SSP_CLOCK_AUDIO_CARDINAL,
 	SSP_CLOCK_XTAL_OSCILLATOR,
 	SSP_CLOCK_PLL_FIXED,
@@ -49,5 +49,5 @@ static uint32_t platform_ssp_freq_sources[] = {
 STATIC_ASSERT(NUM_SSP_FREQ == ARRAY_SIZE(platform_ssp_freq),
 	      invalid_number_of_ssp_frequencies);
 
-struct freq_table *ssp_freq = platform_ssp_freq;
-uint32_t *ssp_freq_sources = platform_ssp_freq_sources;
+const struct freq_table *ssp_freq = platform_ssp_freq;
+const uint32_t *ssp_freq_sources = platform_ssp_freq_sources;

--- a/src/platform/imx8/lib/clk.c
+++ b/src/platform/imx8/lib/clk.c
@@ -9,7 +9,7 @@
 #include <sof/lib/clk.h>
 #include <sof/lib/notifier.h>
 
-static struct freq_table platform_cpu_freq[] = {
+const struct freq_table platform_cpu_freq[] = {
 	{ 666000000, 666000 },
 };
 

--- a/src/platform/imx8/lib/clk.c
+++ b/src/platform/imx8/lib/clk.c
@@ -8,6 +8,7 @@
 #include <sof/common.h>
 #include <sof/lib/clk.h>
 #include <sof/lib/notifier.h>
+#include <sof/spinlock.h>
 
 const struct freq_table platform_cpu_freq[] = {
 	{ 666000000, 666000 },
@@ -29,9 +30,12 @@ void platform_clock_init(void)
 			.freqs_num = NUM_CPU_FREQ,
 			.freqs = platform_cpu_freq,
 			.default_freq_idx = CPU_DEFAULT_IDX,
+			.current_freq_idx = CPU_DEFAULT_IDX,
 			.notification_id = NOTIFIER_ID_CPU_FREQ,
 			.notification_mask = NOTIFIER_TARGET_CORE_MASK(i),
 			.set_freq = NULL,
 		};
+
+		spinlock_init(&platform_clocks_info[i].lock);
 	}
 }

--- a/src/platform/imx8/platform.c
+++ b/src/platform/imx8/platform.c
@@ -144,7 +144,6 @@ int platform_init(struct sof *sof)
 
 	platform_interrupt_init();
 	platform_clock_init();
-	clock_init();
 	scheduler_init_edf();
 
 	/* init low latency domains and schedulers */

--- a/src/platform/intel/cavs/include/cavs/lib/clk.h
+++ b/src/platform/intel/cavs/include/cavs/lib/clk.h
@@ -35,9 +35,9 @@
 /** \brief Total number of clocks */
 #define NUM_CLOCKS	(CLK_SSP + 1)
 
-extern struct freq_table *cpu_freq;
-extern uint32_t cpu_freq_enc[];
-extern uint32_t cpu_freq_status_mask[];
+extern const struct freq_table *cpu_freq;
+extern const uint32_t cpu_freq_enc[];
+extern const uint32_t cpu_freq_status_mask[];
 
 void platform_clock_init(void);
 

--- a/src/platform/intel/cavs/lib/clk.c
+++ b/src/platform/intel/cavs/lib/clk.c
@@ -8,6 +8,7 @@
 #include <sof/drivers/ssp.h>
 #include <sof/lib/clk.h>
 #include <sof/lib/notifier.h>
+#include <sof/spinlock.h>
 
 static struct clock_info platform_clocks_info[NUM_CLOCKS];
 
@@ -56,18 +57,24 @@ void platform_clock_init(void)
 			.freqs_num = NUM_CPU_FREQ,
 			.freqs = cpu_freq,
 			.default_freq_idx = CPU_DEFAULT_IDX,
+			.current_freq_idx = CPU_DEFAULT_IDX,
 			.notification_id = NOTIFIER_ID_CPU_FREQ,
 			.notification_mask = NOTIFIER_TARGET_CORE_MASK(i),
 			.set_freq = clock_platform_set_cpu_freq,
 		};
+
+		spinlock_init(&platform_clocks_info[i].lock);
 	}
 
 	platform_clocks_info[CLK_SSP] = (struct clock_info) {
 		.freqs_num = NUM_SSP_FREQ,
 		.freqs = ssp_freq,
 		.default_freq_idx = SSP_DEFAULT_IDX,
+		.current_freq_idx = SSP_DEFAULT_IDX,
 		.notification_id = NOTIFIER_ID_SSP_FREQ,
 		.notification_mask = NOTIFIER_TARGET_CORE_ALL_MASK,
 		.set_freq = NULL,
 	};
+
+	spinlock_init(&platform_clocks_info[CLK_SSP].lock);
 }

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -355,7 +355,6 @@ int platform_init(struct sof *sof)
 
 	trace_point(TRACE_BOOT_PLATFORM_CLOCK);
 	platform_clock_init();
-	clock_init();
 
 	trace_point(TRACE_BOOT_PLATFORM_SCHED);
 	scheduler_init_edf();

--- a/src/platform/suecreek/lib/clk.c
+++ b/src/platform/suecreek/lib/clk.c
@@ -9,19 +9,19 @@
 #include <sof/drivers/ssp.h>
 #include <sof/lib/clk.h>
 
-static struct freq_table platform_cpu_freq[] = {
+const struct freq_table platform_cpu_freq[] = {
 	{ 120000000, 120000 },
 	{ CLK_MAX_CPU_HZ, 400000 },
 };
 
-uint32_t cpu_freq_enc[] = {
+const uint32_t cpu_freq_enc[] = {
 	SHIM_CLKCTL_RLROSCC | SHIM_CLKCTL_OCS_LP_RING |
 		SHIM_CLKCTL_HMCS_DIV2 | SHIM_CLKCTL_LMCS_DIV4,
 	SHIM_CLKCTL_RHROSCC | SHIM_CLKCTL_OCS_HP_RING |
 		SHIM_CLKCTL_HMCS_DIV2 | SHIM_CLKCTL_LMCS_DIV4,
 };
 
-uint32_t cpu_freq_status_mask[] = {
+const uint32_t cpu_freq_status_mask[] = {
 	SHIM_CLKSTS_LROSCCS,
 	SHIM_CLKSTS_HROSCCS,
 };
@@ -29,17 +29,17 @@ uint32_t cpu_freq_status_mask[] = {
 STATIC_ASSERT(NUM_CPU_FREQ == ARRAY_SIZE(platform_cpu_freq),
 	      invalid_number_of_cpu_frequencies);
 
-struct freq_table *cpu_freq = platform_cpu_freq;
+const struct freq_table *cpu_freq = platform_cpu_freq;
 
 /* IMPORTANT: array should be filled in increasing order
  * (regarding to .freq field)
  */
-static struct freq_table platform_ssp_freq[] = {
+const struct freq_table platform_ssp_freq[] = {
 	{ 19200000, 19200 },
 	{ 24000000, 24000 },
 };
 
-static uint32_t platform_ssp_freq_sources[] = {
+const uint32_t platform_ssp_freq_sources[] = {
 	SSP_CLOCK_XTAL_OSCILLATOR,
 	SSP_CLOCK_PLL_FIXED,
 };
@@ -47,5 +47,5 @@ static uint32_t platform_ssp_freq_sources[] = {
 STATIC_ASSERT(NUM_SSP_FREQ == ARRAY_SIZE(platform_ssp_freq),
 	      invalid_number_of_ssp_frequencies);
 
-struct freq_table *ssp_freq = platform_ssp_freq;
-uint32_t *ssp_freq_sources = platform_ssp_freq_sources;
+const struct freq_table *ssp_freq = platform_ssp_freq;
+const uint32_t *ssp_freq_sources = platform_ssp_freq_sources;

--- a/src/platform/tigerlake/lib/clk.c
+++ b/src/platform/tigerlake/lib/clk.c
@@ -9,19 +9,19 @@
 #include <sof/drivers/ssp.h>
 #include <sof/lib/clk.h>
 
-static struct freq_table platform_cpu_freq[] = {
+const struct freq_table platform_cpu_freq[] = {
 	{ 120000000, 120000 },
 	{ CLK_MAX_CPU_HZ, 400000 },
 };
 
-uint32_t cpu_freq_enc[] = {
+const uint32_t cpu_freq_enc[] = {
 	SHIM_CLKCTL_RLROSCC | SHIM_CLKCTL_OCS_LP_RING |
 		SHIM_CLKCTL_HMCS_DIV2 | SHIM_CLKCTL_LMCS_DIV4,
 	SHIM_CLKCTL_RHROSCC | SHIM_CLKCTL_OCS_HP_RING |
 		SHIM_CLKCTL_HMCS_DIV2 | SHIM_CLKCTL_LMCS_DIV4,
 };
 
-uint32_t cpu_freq_status_mask[] = {
+const uint32_t cpu_freq_status_mask[] = {
 	SHIM_CLKSTS_LROSCCS,
 	SHIM_CLKSTS_HROSCCS,
 };
@@ -29,18 +29,18 @@ uint32_t cpu_freq_status_mask[] = {
 STATIC_ASSERT(NUM_CPU_FREQ == ARRAY_SIZE(platform_cpu_freq),
 	      invalid_number_of_cpu_frequencies);
 
-struct freq_table *cpu_freq = platform_cpu_freq;
+const struct freq_table *cpu_freq = platform_cpu_freq;
 
 /* IMPORTANT: array should be filled in increasing order
  * (regarding to .freq field)
  */
-static struct freq_table platform_ssp_freq[] = {
+const struct freq_table platform_ssp_freq[] = {
 	{ 24576000, 24576 },
 	{ 38400000, 38400 },
 	{ 96000000, 96000 },
 };
 
-static uint32_t platform_ssp_freq_sources[] = {
+const uint32_t platform_ssp_freq_sources[] = {
 	SSP_CLOCK_AUDIO_CARDINAL,
 	SSP_CLOCK_XTAL_OSCILLATOR,
 	SSP_CLOCK_PLL_FIXED,
@@ -49,5 +49,5 @@ static uint32_t platform_ssp_freq_sources[] = {
 STATIC_ASSERT(NUM_SSP_FREQ == ARRAY_SIZE(platform_ssp_freq),
 	      invalid_number_of_ssp_frequencies);
 
-struct freq_table *ssp_freq = platform_ssp_freq;
-uint32_t *ssp_freq_sources = platform_ssp_freq_sources;
+const struct freq_table *ssp_freq = platform_ssp_freq;
+const uint32_t *ssp_freq_sources = platform_ssp_freq_sources;


### PR DESCRIPTION
Refactors generic clock API to simplify used data structures.
It makes more sense now and spares us a little bit of memory.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>