### PR TITLE
math: allow crc32 calculations on non-continuous data blocks

### DIFF
--- a/src/audio/detect_test.c
+++ b/src/audio/detect_test.c
@@ -495,7 +495,8 @@ static int test_keyword_set_model(struct comp_dev *dev,
 
 	if (done) {
 		/* Set model data done, update crc value */
-		cd->model.crc = crc32(cd->model.data, cd->model.data_size);
+		cd->model.crc = crc32(0, cd->model.data,
+				      cd->model.data_size);
 		trace_keyword_with_ids(dev, "keyword_ctrl_set_model() "
 				       "done, memory_size = 0x%x, crc = 0x%08x",
 				       cd->model.data_size, cd->model.crc);

--- a/src/include/sof/math/numbers.h
+++ b/src/include/sof/math/numbers.h
@@ -71,7 +71,7 @@ int32_t find_max_abs_int32(int32_t vec[], int vec_length);
  */
 int norm_int32(int32_t val);
 
-uint32_t crc32(const void *data, uint32_t bytes);
+uint32_t crc32(uint32_t base, const void *data, uint32_t bytes);
 
 /* merges two 16-bit values into a single 32-bit value */
 #define merge_16b16b(high, low) (((uint32_t)(high) << 16) | \

--- a/src/math/numbers.c
+++ b/src/math/numbers.c
@@ -113,9 +113,9 @@ int norm_int32(int32_t val)
  * https://en.wikipedia.org/wiki/Cyclic_redundancy_check#CRC-32_algorithm
  * 0xEDB88320 is the reversed polynomial representation
  */
-uint32_t crc32(const void *data, uint32_t bytes)
+uint32_t crc32(uint32_t base, const void *data, uint32_t bytes)
 {
-	uint32_t crc = 0xFFFFFFFF;
+	uint32_t crc = ~base;
 	uint32_t cur;
 	int i;
 	int j;


### PR DESCRIPTION
This will allow to "continue" crc calculations when data is not a continuous block in memory.

Signed-off-by: Adrian Bonislawski <adrian.bonislawski@linux.intel.com>