### PR TITLE
ipc: optimize memory usage for IPC notifications

### DIFF
--- a/src/audio/pipeline.c
+++ b/src/audio/pipeline.c
@@ -57,6 +57,8 @@ struct pipeline *pipeline_new(struct sof_ipc_pipe_new *pipe_desc,
 
 	/* init pipeline */
 	p->sched_comp = cd;
+	p->posn_offset = pipe_desc->pipeline_id *
+		sizeof(struct sof_ipc_stream_posn);
 	p->status = COMP_STATE_INIT;
 
 	ret = memcpy_s(&p->ipc_pipe, sizeof(p->ipc_pipe),

--- a/src/drivers/imx/ipc.c
+++ b/src/drivers/imx/ipc.c
@@ -133,10 +133,8 @@ void ipc_platform_send_msg(void)
 	spin_lock_irq(_ipc->lock, flags);
 
 	/* any messages to send ? */
-	if (list_is_empty(&_ipc->shared_ctx->msg_list)) {
-		_ipc->shared_ctx->dsp_pending = 0;
+	if (list_is_empty(&_ipc->shared_ctx->msg_list))
 		goto out;
-	}
 
 	/* can't send notification when one is in progress */
 	if (imx_mu_read(IMX_MU_xCR) & IMX_MU_xCR_GIRn(1))

--- a/src/drivers/imx/ipc.c
+++ b/src/drivers/imx/ipc.c
@@ -125,16 +125,16 @@ static void ipc_platform_complete_cmd(void *data)
 	}
 }
 
-void ipc_platform_send_msg(struct ipc *ipc)
+void ipc_platform_send_msg(void)
 {
 	struct ipc_msg *msg;
 	uint32_t flags;
 
-	spin_lock_irq(ipc->lock, flags);
+	spin_lock_irq(_ipc->lock, flags);
 
 	/* any messages to send ? */
-	if (list_is_empty(&ipc->shared_ctx->msg_list)) {
-		ipc->shared_ctx->dsp_pending = 0;
+	if (list_is_empty(&_ipc->shared_ctx->msg_list)) {
+		_ipc->shared_ctx->dsp_pending = 0;
 		goto out;
 	}
 
@@ -143,20 +143,20 @@ void ipc_platform_send_msg(struct ipc *ipc)
 		goto out;
 
 	/* now send the message */
-	msg = list_first_item(&ipc->shared_ctx->msg_list, struct ipc_msg,
+	msg = list_first_item(&_ipc->shared_ctx->msg_list, struct ipc_msg,
 			      list);
 	mailbox_dspbox_write(0, msg->tx_data, msg->tx_size);
 	list_item_del(&msg->list);
-	ipc->shared_ctx->dsp_msg = msg;
+	_ipc->shared_ctx->dsp_msg = msg;
 	tracev_ipc("ipc: msg tx -> 0x%x", msg->header);
 
 	/* now interrupt host to tell it we have sent a message */
 	imx_mu_xcr_rmw(IMX_MU_xCR_GIRn(1), 0);
 
-	list_item_append(&msg->list, &ipc->shared_ctx->empty_list);
+	list_item_append(&msg->list, &_ipc->shared_ctx->empty_list);
 
 out:
-	spin_unlock_irq(ipc->lock, flags);
+	spin_unlock_irq(_ipc->lock, flags);
 }
 
 #if CONFIG_HOST_PTABLE

--- a/src/drivers/intel/baytrail/ipc.c
+++ b/src/drivers/intel/baytrail/ipc.c
@@ -117,16 +117,16 @@ static void ipc_platform_complete_cmd(void *data)
 	shim_write(SHIM_IMRD, shim_read(SHIM_IMRD) & ~SHIM_IMRD_BUSY);
 }
 
-void ipc_platform_send_msg(struct ipc *ipc)
+void ipc_platform_send_msg(void)
 {
 	struct ipc_msg *msg;
 	uint32_t flags;
 
-	spin_lock_irq(ipc->lock, flags);
+	spin_lock_irq(_ipc->lock, flags);
 
 	/* any messages to send ? */
-	if (list_is_empty(&ipc->shared_ctx->msg_list)) {
-		ipc->shared_ctx->dsp_pending = 0;
+	if (list_is_empty(&_ipc->shared_ctx->msg_list)) {
+		_ipc->shared_ctx->dsp_pending = 0;
 		goto out;
 	}
 
@@ -135,21 +135,21 @@ void ipc_platform_send_msg(struct ipc *ipc)
 		goto out;
 
 	/* now send the message */
-	msg = list_first_item(&ipc->shared_ctx->msg_list, struct ipc_msg,
+	msg = list_first_item(&_ipc->shared_ctx->msg_list, struct ipc_msg,
 			      list);
 	mailbox_dspbox_write(0, msg->tx_data, msg->tx_size);
 	list_item_del(&msg->list);
-	ipc->shared_ctx->dsp_msg = msg;
+	_ipc->shared_ctx->dsp_msg = msg;
 	tracev_ipc("ipc: msg tx -> 0x%x", msg->header);
 
 	/* now interrupt host to tell it we have message sent */
 	shim_write(SHIM_IPCDL, msg->header);
 	shim_write(SHIM_IPCDH, SHIM_IPCDH_BUSY);
 
-	list_item_append(&msg->list, &ipc->shared_ctx->empty_list);
+	list_item_append(&msg->list, &_ipc->shared_ctx->empty_list);
 
 out:
-	spin_unlock_irq(ipc->lock, flags);
+	spin_unlock_irq(_ipc->lock, flags);
 }
 
 struct ipc_data_host_buffer *ipc_platform_get_host_buffer(struct ipc *ipc)

--- a/src/drivers/intel/baytrail/ipc.c
+++ b/src/drivers/intel/baytrail/ipc.c
@@ -27,39 +27,6 @@ struct ipc_data {
 	struct ipc_data_host_buffer dh_buffer;
 };
 
-static void do_notify(void)
-{
-	uint32_t flags;
-	struct ipc_msg *msg;
-
-	spin_lock_irq(_ipc->lock, flags);
-	msg = _ipc->shared_ctx->dsp_msg;
-	if (!msg)
-		goto out;
-
-	tracev_ipc("ipc: not rx -> 0x%x", msg->header);
-
-	/* copy the data returned from DSP */
-	if (msg->rx_size && msg->rx_size < SOF_IPC_MSG_MAX_SIZE)
-		mailbox_dspbox_read(msg->rx_data, SOF_IPC_MSG_MAX_SIZE,
-				    0, msg->rx_size);
-
-	/* any callback ? */
-	if (msg->cb)
-		msg->cb(msg->cb_data, msg->rx_data);
-
-	list_item_append(&msg->list, &_ipc->shared_ctx->empty_list);
-
-out:
-	spin_unlock_irq(_ipc->lock, flags);
-
-	/* clear DONE bit - tell Host we have completed */
-	shim_write(SHIM_IPCDH, shim_read(SHIM_IPCDH) & ~SHIM_IPCDH_DONE);
-
-	/* unmask Done interrupt */
-	shim_write(SHIM_IMRD, shim_read(SHIM_IMRD) & ~SHIM_IMRD_DONE);
-}
-
 static void irq_handler(void *arg)
 {
 	uint32_t isr;
@@ -77,7 +44,13 @@ static void irq_handler(void *arg)
 
 		/* Mask Done interrupt before return */
 		shim_write(SHIM_IMRD, shim_read(SHIM_IMRD) | SHIM_IMRD_DONE);
-		do_notify();
+
+		/* clear DONE bit - tell Host we have completed */
+		shim_write(SHIM_IPCDH,
+			   shim_read(SHIM_IPCDH) & ~SHIM_IPCDH_DONE);
+
+		/* unmask Done interrupt */
+		shim_write(SHIM_IMRD, shim_read(SHIM_IMRD) & ~SHIM_IMRD_DONE);
 	}
 
 	/* new message from host */
@@ -137,7 +110,6 @@ void ipc_platform_send_msg(void)
 			      list);
 	mailbox_dspbox_write(0, msg->tx_data, msg->tx_size);
 	list_item_del(&msg->list);
-	_ipc->shared_ctx->dsp_msg = msg;
 	tracev_ipc("ipc: msg tx -> 0x%x", msg->header);
 
 	/* now interrupt host to tell it we have message sent */

--- a/src/drivers/intel/baytrail/ipc.c
+++ b/src/drivers/intel/baytrail/ipc.c
@@ -125,10 +125,8 @@ void ipc_platform_send_msg(void)
 	spin_lock_irq(_ipc->lock, flags);
 
 	/* any messages to send ? */
-	if (list_is_empty(&_ipc->shared_ctx->msg_list)) {
-		_ipc->shared_ctx->dsp_pending = 0;
+	if (list_is_empty(&_ipc->shared_ctx->msg_list))
 		goto out;
-	}
 
 	/* can't send notification when one is in progress */
 	if (shim_read(SHIM_IPCDH) & (SHIM_IPCDH_BUSY | SHIM_IPCDH_DONE))

--- a/src/drivers/intel/cavs/ipc.c
+++ b/src/drivers/intel/cavs/ipc.c
@@ -256,7 +256,6 @@ void ipc_platform_send_msg(void)
 			      list);
 	mailbox_dspbox_write(0, msg->tx_data, msg->tx_size);
 	list_item_del(&msg->list);
-	_ipc->shared_ctx->dsp_msg = msg;
 	tracev_ipc("ipc: msg tx -> 0x%x", msg->header);
 
 	/* now interrupt host to tell it we have message sent */

--- a/src/drivers/intel/cavs/ipc.c
+++ b/src/drivers/intel/cavs/ipc.c
@@ -124,7 +124,7 @@ static void ipc_irq_handler(void *arg)
 			  ipc_read(IPC_DIPCCTL) | IPC_DIPCCTL_IPCIDIE);
 
 		/* send next message to host */
-		ipc_process_msg_queue();
+		ipc_platform_send_msg();
 	}
 }
 

--- a/src/drivers/intel/cavs/ipc.c
+++ b/src/drivers/intel/cavs/ipc.c
@@ -232,16 +232,16 @@ static void ipc_platform_complete_cmd(void *data)
 #endif
 }
 
-void ipc_platform_send_msg(struct ipc *ipc)
+void ipc_platform_send_msg(void)
 {
 	struct ipc_msg *msg;
 	uint32_t flags;
 
-	spin_lock_irq(ipc->lock, flags);
+	spin_lock_irq(_ipc->lock, flags);
 
 	/* any messages to send ? */
-	if (list_is_empty(&ipc->shared_ctx->msg_list)) {
-		ipc->shared_ctx->dsp_pending = 0;
+	if (list_is_empty(&_ipc->shared_ctx->msg_list)) {
+		_ipc->shared_ctx->dsp_pending = 0;
 		goto out;
 	}
 
@@ -254,11 +254,11 @@ void ipc_platform_send_msg(struct ipc *ipc)
 		goto out;
 
 	/* now send the message */
-	msg = list_first_item(&ipc->shared_ctx->msg_list, struct ipc_msg,
+	msg = list_first_item(&_ipc->shared_ctx->msg_list, struct ipc_msg,
 			      list);
 	mailbox_dspbox_write(0, msg->tx_data, msg->tx_size);
 	list_item_del(&msg->list);
-	ipc->shared_ctx->dsp_msg = msg;
+	_ipc->shared_ctx->dsp_msg = msg;
 	tracev_ipc("ipc: msg tx -> 0x%x", msg->header);
 
 	/* now interrupt host to tell it we have message sent */
@@ -270,10 +270,10 @@ void ipc_platform_send_msg(struct ipc *ipc)
 	ipc_write(IPC_DIPCIDR, 0x80000000 | msg->header);
 #endif
 
-	list_item_append(&msg->list, &ipc->shared_ctx->empty_list);
+	list_item_append(&msg->list, &_ipc->shared_ctx->empty_list);
 
 out:
-	spin_unlock_irq(ipc->lock, flags);
+	spin_unlock_irq(_ipc->lock, flags);
 }
 
 int platform_ipc_init(struct ipc *ipc)

--- a/src/drivers/intel/cavs/ipc.c
+++ b/src/drivers/intel/cavs/ipc.c
@@ -240,10 +240,8 @@ void ipc_platform_send_msg(void)
 	spin_lock_irq(_ipc->lock, flags);
 
 	/* any messages to send ? */
-	if (list_is_empty(&_ipc->shared_ctx->msg_list)) {
-		_ipc->shared_ctx->dsp_pending = 0;
+	if (list_is_empty(&_ipc->shared_ctx->msg_list))
 		goto out;
-	}
 
 #if CAVS_VERSION == CAVS_VERSION_1_5
 	if (ipc_read(IPC_DIPCI) & IPC_DIPCI_BUSY)

--- a/src/drivers/intel/cavs/sue-ipc.c
+++ b/src/drivers/intel/cavs/sue-ipc.c
@@ -61,7 +61,6 @@ void ipc_platform_send_msg(void)
 			      list);
 	mailbox_dspbox_write(0, msg->tx_data, msg->tx_size);
 	list_item_del(&msg->list);
-	_ipc->shared_ctx->dsp_msg = msg;
 	tracev_ipc("ipc: msg tx -> 0x%x", msg->header);
 
 	/* now interrupt host to tell it we have message sent */

--- a/src/drivers/intel/cavs/sue-ipc.c
+++ b/src/drivers/intel/cavs/sue-ipc.c
@@ -53,10 +53,8 @@ void ipc_platform_send_msg(void)
 	spin_lock_irq(_ipc->lock, flags);
 
 	/* any messages to send ? */
-	if (list_is_empty(&_ipc->shared_ctx->msg_list)) {
-		_ipc->shared_ctx->dsp_pending = 0;
+	if (list_is_empty(&_ipc->shared_ctx->msg_list))
 		goto out;
-	}
 
 	/* now send the message */
 	msg = list_first_item(&_ipc->shared_ctx->msg_list, struct ipc_msg,

--- a/src/drivers/intel/cavs/sue-ipc.c
+++ b/src/drivers/intel/cavs/sue-ipc.c
@@ -45,33 +45,33 @@ static enum task_state ipc_platform_do_cmd(void *data)
 	return SOF_TASK_STATE_COMPLETED;
 }
 
-void ipc_platform_send_msg(struct ipc *ipc)
+void ipc_platform_send_msg(void)
 {
 	struct ipc_msg *msg;
 	uint32_t flags;
 
-	spin_lock_irq(ipc->lock, flags);
+	spin_lock_irq(_ipc->lock, flags);
 
 	/* any messages to send ? */
-	if (list_is_empty(&ipc->shared_ctx->msg_list)) {
-		ipc->shared_ctx->dsp_pending = 0;
+	if (list_is_empty(&_ipc->shared_ctx->msg_list)) {
+		_ipc->shared_ctx->dsp_pending = 0;
 		goto out;
 	}
 
 	/* now send the message */
-	msg = list_first_item(&ipc->shared_ctx->msg_list, struct ipc_msg,
+	msg = list_first_item(&_ipc->shared_ctx->msg_list, struct ipc_msg,
 			      list);
 	mailbox_dspbox_write(0, msg->tx_data, msg->tx_size);
 	list_item_del(&msg->list);
-	ipc->shared_ctx->dsp_msg = msg;
+	_ipc->shared_ctx->dsp_msg = msg;
 	tracev_ipc("ipc: msg tx -> 0x%x", msg->header);
 
 	/* now interrupt host to tell it we have message sent */
 
-	list_item_append(&msg->list, &ipc->shared_ctx->empty_list);
+	list_item_append(&msg->list, &_ipc->shared_ctx->empty_list);
 
 out:
-	spin_unlock_irq(ipc->lock, flags);
+	spin_unlock_irq(_ipc->lock, flags);
 }
 
 int platform_ipc_init(struct ipc *ipc)

--- a/src/drivers/intel/haswell/ipc.c
+++ b/src/drivers/intel/haswell/ipc.c
@@ -116,16 +116,16 @@ static void ipc_platform_complete_cmd(void *data)
 	}
 }
 
-void ipc_platform_send_msg(struct ipc *ipc)
+void ipc_platform_send_msg(void)
 {
 	struct ipc_msg *msg;
 	uint32_t flags;
 
-	spin_lock_irq(ipc->lock, flags);
+	spin_lock_irq(_ipc->lock, flags);
 
 	/* any messages to send ? */
-	if (list_is_empty(&ipc->shared_ctx->msg_list)) {
-		ipc->shared_ctx->dsp_pending = 0;
+	if (list_is_empty(&_ipc->shared_ctx->msg_list)) {
+		_ipc->shared_ctx->dsp_pending = 0;
 		goto out;
 	}
 
@@ -134,20 +134,20 @@ void ipc_platform_send_msg(struct ipc *ipc)
 		goto out;
 
 	/* now send the message */
-	msg = list_first_item(&ipc->shared_ctx->msg_list, struct ipc_msg,
+	msg = list_first_item(&_ipc->shared_ctx->msg_list, struct ipc_msg,
 			      list);
 	mailbox_dspbox_write(0, msg->tx_data, msg->tx_size);
 	list_item_del(&msg->list);
-	ipc->shared_ctx->dsp_msg = msg;
+	_ipc->shared_ctx->dsp_msg = msg;
 	tracev_ipc("ipc: msg tx -> 0x%x", msg->header);
 
 	/* now interrupt host to tell it we have message sent */
 	shim_write(SHIM_IPCD, SHIM_IPCD_BUSY);
 
-	list_item_append(&msg->list, &ipc->shared_ctx->empty_list);
+	list_item_append(&msg->list, &_ipc->shared_ctx->empty_list);
 
 out:
-	spin_unlock_irq(ipc->lock, flags);
+	spin_unlock_irq(_ipc->lock, flags);
 }
 
 struct ipc_data_host_buffer *ipc_platform_get_host_buffer(struct ipc *ipc)

--- a/src/drivers/intel/haswell/ipc.c
+++ b/src/drivers/intel/haswell/ipc.c
@@ -124,10 +124,8 @@ void ipc_platform_send_msg(void)
 	spin_lock_irq(_ipc->lock, flags);
 
 	/* any messages to send ? */
-	if (list_is_empty(&_ipc->shared_ctx->msg_list)) {
-		_ipc->shared_ctx->dsp_pending = 0;
+	if (list_is_empty(&_ipc->shared_ctx->msg_list))
 		goto out;
-	}
 
 	/* can't send nofication when one is in progress */
 	if (shim_read(SHIM_IPCD) & (SHIM_IPCD_BUSY | SHIM_IPCD_DONE))

--- a/src/include/sof/drivers/ipc.h
+++ b/src/include/sof/drivers/ipc.h
@@ -17,6 +17,7 @@
 #include <sof/trace/trace.h>
 #include <ipc/header.h>
 #include <user/trace.h>
+#include <stdbool.h>
 #include <stdint.h>
 
 struct comp_buffer;
@@ -143,7 +144,7 @@ int ipc_stream_send_xrun(struct comp_dev *cdev,
 	struct sof_ipc_stream_posn *posn);
 
 int ipc_queue_host_message(struct ipc *ipc, uint32_t header, void *tx_data,
-			   size_t tx_bytes, uint32_t replace);
+			   size_t tx_bytes, bool replace);
 
 void ipc_platform_send_msg(void);
 

--- a/src/include/sof/drivers/ipc.h
+++ b/src/include/sof/drivers/ipc.h
@@ -86,7 +86,6 @@ struct ipc_msg {
 
 struct ipc_shared_context {
 	struct ipc_msg *dsp_msg;	/* current message to host */
-	uint32_t dsp_pending;
 	struct list_item msg_list;
 	struct list_item empty_list;
 	struct ipc_msg message[MSG_QUEUE_SIZE];

--- a/src/include/sof/drivers/ipc.h
+++ b/src/include/sof/drivers/ipc.h
@@ -77,15 +77,10 @@ struct ipc_msg {
 	uint32_t header;	/* specific to platform */
 	uint32_t tx_size;	/* payload size in bytes */
 	uint8_t tx_data[SOF_IPC_MSG_MAX_SIZE];	/* pointer to payload data */
-	uint32_t rx_size;	/* payload size in bytes */
-	uint8_t rx_data[SOF_IPC_MSG_MAX_SIZE];	/* pointer to payload data */
 	struct list_item list;
-	void (*cb)(void *cb_data, void *mailbox_data);
-	void *cb_data;
 };
 
 struct ipc_shared_context {
-	struct ipc_msg *dsp_msg;	/* current message to host */
 	struct list_item msg_list;
 	struct list_item empty_list;
 	struct ipc_msg message[MSG_QUEUE_SIZE];

--- a/src/include/sof/drivers/ipc.h
+++ b/src/include/sof/drivers/ipc.h
@@ -144,7 +144,6 @@ int platform_ipc_init(struct ipc *ipc);
 
 void ipc_free(struct ipc *ipc);
 
-int ipc_process_msg_queue(void);
 void ipc_schedule_process(struct ipc *ipc);
 
 int ipc_stream_send_position(struct comp_dev *cdev,

--- a/src/include/sof/drivers/ipc.h
+++ b/src/include/sof/drivers/ipc.h
@@ -82,9 +82,8 @@ struct ipc_msg {
 };
 
 struct ipc_shared_context {
-	struct list_item msg_list;
-	struct list_item empty_list;
-	struct ipc_msg message[MSG_QUEUE_SIZE];
+	struct list_item msg_list;	/* queue of messages to be sent */
+	struct list_item empty_list;	/* queue of empty messages */
 
 	struct list_item comp_list;	/* list of component devices */
 };

--- a/src/include/sof/drivers/ipc.h
+++ b/src/include/sof/drivers/ipc.h
@@ -103,9 +103,6 @@ struct ipc {
 	/* PM */
 	int pm_prepare_D3;	/* do we need to prepare for D3 */
 
-	/* mmap for posn_offset */
-	struct pipeline *posn_map[PLATFORM_MAX_STREAMS];
-
 	/* context shared between cores */
 	struct ipc_shared_context *shared_ctx;
 
@@ -234,9 +231,6 @@ int ipc_comp_dai_config(struct ipc *ipc, struct sof_ipc_dai_config *config);
 
 /* send DMA trace host buffer position to host */
 int ipc_dma_trace_send_position(void);
-
-/* get posn offset by pipeline. */
-int ipc_get_posn_offset(struct ipc *ipc, struct pipeline *pipe);
 
 struct sof_ipc_cmd_hdr *mailbox_validate(void);
 

--- a/src/include/sof/drivers/ipc.h
+++ b/src/include/sof/drivers/ipc.h
@@ -97,9 +97,6 @@ struct ipc {
 	spinlock_t *lock;	/* locking mechanism */
 	void *comp_data;
 
-	/* RX call back */
-	int (*cb)(struct ipc_msg *msg);
-
 	/* DMA for Trace*/
 	struct dma_trace_data *dmat;
 

--- a/src/include/sof/drivers/ipc.h
+++ b/src/include/sof/drivers/ipc.h
@@ -158,7 +158,7 @@ int ipc_stream_send_xrun(struct comp_dev *cdev,
 int ipc_queue_host_message(struct ipc *ipc, uint32_t header, void *tx_data,
 			   size_t tx_bytes, uint32_t replace);
 
-void ipc_platform_send_msg(struct ipc *ipc);
+void ipc_platform_send_msg(void);
 
 /**
  * \brief Data provided by the platform which use ipc...page_descriptors().

--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -220,7 +220,7 @@ static int ipc_stream_pcm_params(uint32_t stream)
 	struct sof_ipc_pcm_params pcm_params;
 	struct sof_ipc_pcm_params_reply reply;
 	struct ipc_comp_dev *pcm_dev;
-	int err, reset_err, posn_offset;
+	int err, reset_err;
 
 	/* copy message with ABI safe method */
 	IPC_COPY_CMD(pcm_params, _ipc->comp_data);
@@ -308,20 +308,12 @@ pipe_params:
 		goto error;
 	}
 
-	posn_offset = ipc_get_posn_offset(_ipc, pcm_dev->cd->pipeline);
-	if (posn_offset < 0) {
-		err = posn_offset;
-		trace_ipc_error("ipc: pipe %d comp %d posn offset failed %d",
-				pcm_dev->cd->pipeline->ipc_pipe.pipeline_id,
-				pcm_params.comp_id, err);
-		goto error;
-	}
 	/* write component values to the outbox */
 	reply.rhdr.hdr.size = sizeof(reply);
 	reply.rhdr.hdr.cmd = stream;
 	reply.rhdr.error = 0;
 	reply.comp_id = pcm_params.comp_id;
-	reply.posn_offset = posn_offset;
+	reply.posn_offset = pcm_dev->cd->pipeline->posn_offset;
 	mailbox_hostbox_write(0, &reply, sizeof(reply));
 	return 1;
 

--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -1289,11 +1289,9 @@ int ipc_queue_host_message(struct ipc *ipc, uint32_t header, void *tx_data,
 		assert(!ret);
 	}
 
-	if (!found) {
+	if (!found)
 		/* now queue the message */
-		ipc->shared_ctx->dsp_pending = 1;
 		list_item_append(&msg->list, &ipc->shared_ctx->msg_list);
-	}
 
 out:
 	spin_unlock_irq(ipc->lock, flags);
@@ -1303,8 +1301,7 @@ out:
 /* process current message */
 int ipc_process_msg_queue(void)
 {
-	if (_ipc->shared_ctx->dsp_pending)
-		ipc_platform_send_msg();
+	ipc_platform_send_msg();
 	return 0;
 }
 

--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -1247,7 +1247,8 @@ int ipc_queue_host_message(struct ipc *ipc, uint32_t header, void *tx_data,
 			   size_t tx_bytes, bool replace)
 {
 	struct ipc_msg *msg = NULL;
-	uint32_t flags, found = 0;
+	bool found = false;
+	uint32_t flags;
 	int ret = 0;
 
 	ipc = cache_to_uncache(ipc);
@@ -1260,13 +1261,14 @@ int ipc_queue_host_message(struct ipc *ipc, uint32_t header, void *tx_data,
 
 	/* do we need to use a new empty message? */
 	if (msg)
-		found = 1;
+		found = true;
 	else
 		msg = msg_get_empty(ipc);
 
-	if (msg == NULL) {
-		trace_ipc_error("ipc: msg hdr for 0x%08x not found "
-				"replace %d", header, replace);
+	if (!msg) {
+		trace_ipc_error(
+			"ipc_queue_host_message() error: msg hdr for 0x%08x not found",
+			header);
 		ret = -EBUSY;
 		goto out;
 	}
@@ -1281,8 +1283,8 @@ int ipc_queue_host_message(struct ipc *ipc, uint32_t header, void *tx_data,
 		assert(!ret);
 	}
 
+	/* queue new message if it's not replacement */
 	if (!found)
-		/* now queue the message */
 		list_item_append(&msg->list, &ipc->shared_ctx->msg_list);
 
 out:

--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -1298,13 +1298,6 @@ out:
 	return ret;
 }
 
-/* process current message */
-int ipc_process_msg_queue(void)
-{
-	ipc_platform_send_msg();
-	return 0;
-}
-
 void ipc_schedule_process(struct ipc *ipc)
 {
 	schedule_task(&ipc->ipc_task, 0, 100);

--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -403,7 +403,7 @@ int ipc_stream_send_position(struct comp_dev *cdev,
 
 	mailbox_stream_write(cdev->pipeline->posn_offset, posn, sizeof(*posn));
 	return ipc_queue_host_message(_ipc, posn->rhdr.hdr.cmd, posn,
-				      sizeof(*posn), 0);
+				      sizeof(*posn), false);
 }
 
 /* send component notification */
@@ -417,7 +417,7 @@ int ipc_send_comp_notification(struct comp_dev *cdev,
 	event->src_comp_id = cdev->comp.id;
 
 	return ipc_queue_host_message(_ipc, event->rhdr.hdr.cmd, event,
-				      sizeof(*event), 0);
+				      sizeof(*event), false);
 }
 
 /* send stream position TODO: send compound message  */
@@ -432,7 +432,7 @@ int ipc_stream_send_xrun(struct comp_dev *cdev,
 
 	mailbox_stream_write(cdev->pipeline->posn_offset, posn, sizeof(*posn));
 	return ipc_queue_host_message(_ipc, posn->rhdr.hdr.cmd, posn,
-				      sizeof(*posn), 0);
+				      sizeof(*posn), false);
 }
 
 static int ipc_stream_trigger(uint32_t header)
@@ -763,7 +763,7 @@ int ipc_dma_trace_send_position(void)
 	posn.rhdr.hdr.size = sizeof(posn);
 
 	return ipc_queue_host_message(_ipc, posn.rhdr.hdr.cmd, &posn,
-				      sizeof(posn), 1);
+				      sizeof(posn), true);
 }
 
 static int ipc_glb_debug_message(uint32_t header)
@@ -1244,7 +1244,7 @@ static inline struct ipc_msg *msg_find(struct ipc *ipc, uint32_t header,
 }
 
 int ipc_queue_host_message(struct ipc *ipc, uint32_t header, void *tx_data,
-			   size_t tx_bytes, uint32_t replace)
+			   size_t tx_bytes, bool replace)
 {
 	struct ipc_msg *msg = NULL;
 	uint32_t flags, found = 0;

--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -1304,7 +1304,7 @@ out:
 int ipc_process_msg_queue(void)
 {
 	if (_ipc->shared_ctx->dsp_pending)
-		ipc_platform_send_msg(_ipc);
+		ipc_platform_send_msg();
 	return 0;
 }
 

--- a/src/ipc/ipc.c
+++ b/src/ipc/ipc.c
@@ -131,27 +131,6 @@ static struct ipc_comp_dev *ipc_get_ppl_comp(struct ipc *ipc,
 	return NULL;
 }
 
-int ipc_get_posn_offset(struct ipc *ipc, struct pipeline *pipe)
-{
-	int i;
-	uint32_t posn_size = sizeof(struct sof_ipc_stream_posn);
-
-	for (i = 0; i < PLATFORM_MAX_STREAMS; i++) {
-		if (ipc->posn_map[i] == pipe)
-			return pipe->posn_offset;
-	}
-
-	for (i = 0; i < PLATFORM_MAX_STREAMS; i++) {
-		if (ipc->posn_map[i] == NULL) {
-			ipc->posn_map[i] = pipe;
-			pipe->posn_offset = i * posn_size;
-			return pipe->posn_offset;
-		}
-	}
-
-	return -EINVAL;
-}
-
 int ipc_comp_new(struct ipc *ipc, struct sof_ipc_comp *comp)
 {
 	struct comp_dev *cd;

--- a/src/ipc/ipc.c
+++ b/src/ipc/ipc.c
@@ -449,6 +449,7 @@ int ipc_comp_dai_config(struct ipc *ipc, struct sof_ipc_dai_config *config)
 
 int ipc_init(struct sof *sof)
 {
+	struct ipc_msg *msg;
 	int i;
 
 	trace_ipc("ipc_init()");
@@ -471,9 +472,12 @@ int ipc_init(struct sof *sof)
 	list_init(&sof->ipc->shared_ctx->msg_list);
 	list_init(&sof->ipc->shared_ctx->comp_list);
 
-	for (i = 0; i < MSG_QUEUE_SIZE; i++)
-		list_item_prepend(&sof->ipc->shared_ctx->message[i].list,
+	for (i = 0; i < MSG_QUEUE_SIZE; i++) {
+		msg = rzalloc(RZONE_SYS | RZONE_FLAG_UNCACHED, SOF_MEM_CAPS_RAM,
+			      sizeof(*msg));
+		list_item_prepend(&msg->list,
 				  &sof->ipc->shared_ctx->empty_list);
+	}
 
 	return platform_ipc_init(sof->ipc);
 }

--- a/src/ipc/ipc.c
+++ b/src/ipc/ipc.c
@@ -467,7 +467,6 @@ int ipc_init(struct sof *sof)
 
 	dcache_writeback_region(sof->ipc, sizeof(*sof->ipc));
 
-	sof->ipc->shared_ctx->dsp_msg = NULL;
 	list_init(&sof->ipc->shared_ctx->empty_list);
 	list_init(&sof->ipc->shared_ctx->msg_list);
 	list_init(&sof->ipc->shared_ctx->comp_list);

--- a/src/schedule/task.c
+++ b/src/schedule/task.c
@@ -49,7 +49,7 @@ enum task_state task_main_master_core(void *data)
 		wait_for_interrupt(0);
 
 		if (_ipc && !_ipc->pm_prepare_D3)
-			ipc_process_msg_queue();
+			ipc_platform_send_msg();
 	}
 
 	return SOF_TASK_STATE_COMPLETED;

--- a/src/schedule/task.c
+++ b/src/schedule/task.c
@@ -48,13 +48,8 @@ enum task_state task_main_master_core(void *data)
 		/* sleep until next IPC or DMA */
 		wait_for_interrupt(0);
 
-		/*
-		 * now process any IPC messages to host
-		 * if we're not entering runtime suspend.
-		 */
 		if (_ipc && !_ipc->pm_prepare_D3)
 			ipc_process_msg_queue();
-
 	}
 
 	return SOF_TASK_STATE_COMPLETED;


### PR DESCRIPTION
Refactors IPC notification sending in order to minimize allocated
memory space. Instead of statically allocating the whole queue of
twelve ipc_msg structures, let's do it dynamically if there is the
actual need of sending message to host.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>