### PR TITLE
topology: graph: Add PIPELINE_ID to graph name

### DIFF
--- a/tools/topology/m4/utils.m4
+++ b/tools/topology/m4/utils.m4
@@ -49,9 +49,9 @@ define(`COMP_FORMAT_NAME',
 	$1, `float', `FLOAT_LE',
 	)')
 
-dnl P_GRAPH(name, CONNECTIONS)
+dnl P_GRAPH(NAME, PIPELINE_ID, CONNECTIONS)
 define(`P_GRAPH',
-`SectionGraph.STR($1) {'
+`SectionGraph.STR($1 $2) {'
 `	index STR($2)'
 `'
 `	lines ['


### PR DESCRIPTION
Add the PIPELINE_ID to the graph section name to
make them unique for the platback and capture pipelines
that are associated with the same SSP.

Fixes https://github.com/thesofproject/sof/issues/2201