### PR TITLE
mux: using channel map as mux configuration

### DIFF
--- a/src/audio/mux/mux_generic.c
+++ b/src/audio/mux/mux_generic.c
@@ -64,22 +64,21 @@ static void demux_s16le(struct comp_dev *dev, struct comp_buffer *sink,
 			struct comp_buffer *source, uint32_t frames,
 			struct mux_stream_data *data)
 {
-	struct comp_data *cd = comp_get_drvdata(dev);
 	int32_t sample;
 	int16_t *dst;
 	uint8_t i;
 	uint8_t out_ch;
 
 	for (i = 0; i < frames; i++) {
-		for (out_ch = 0; out_ch < data->num_channels; out_ch++) {
+		for (out_ch = 0; out_ch < sink->channels; out_ch++) {
 			sample = calc_sample_s16le(source,
-						   cd->config.num_channels,
-						   i * cd->config.num_channels,
+						   source->channels,
+						   i * source->channels,
 						   data->mask[out_ch]);
 
 			/* saturate to 16 bits */
 			dst = buffer_write_frag_s16(sink,
-				i * data->num_channels + out_ch);
+				i * sink->channels + out_ch);
 			*dst = sat_int16(sample);
 		}
 	}
@@ -103,7 +102,6 @@ static void mux_s16le(struct comp_dev *dev, struct comp_buffer *sink,
 		      struct comp_buffer **sources, uint32_t frames,
 		      struct mux_stream_data *data)
 {
-	struct comp_data *cd = comp_get_drvdata(dev);
 	struct comp_buffer *source;
 	uint8_t i;
 	uint8_t j;
@@ -112,7 +110,7 @@ static void mux_s16le(struct comp_dev *dev, struct comp_buffer *sink,
 	int32_t sample;
 
 	for (i = 0; i < frames; i++) {
-		for (out_ch = 0; out_ch < cd->config.num_channels; out_ch++) {
+		for (out_ch = 0; out_ch < sink->channels; out_ch++) {
 			sample = 0;
 
 			for (j = 0; j < MUX_MAX_STREAMS; j++) {
@@ -121,12 +119,12 @@ static void mux_s16le(struct comp_dev *dev, struct comp_buffer *sink,
 					continue;
 
 				sample += calc_sample_s16le(source,
-						data[j].num_channels,
-						i * data[j].num_channels,
+						source->channels,
+						i * source->channels,
 						data[j].mask[out_ch]);
 			}
 			dst = buffer_write_frag_s16(sink,
-				i * data->num_channels + out_ch);
+				i * sink->channels + out_ch);
 			*dst = sat_int16(sample);
 		}
 	}
@@ -179,22 +177,21 @@ static void demux_s24le(struct comp_dev *dev, struct comp_buffer *sink,
 			struct comp_buffer *source, uint32_t frames,
 			struct mux_stream_data *data)
 {
-	struct comp_data *cd = comp_get_drvdata(dev);
 	int32_t sample;
 	int32_t *dst;
 	uint8_t i;
 	uint8_t out_ch;
 
 	for (i = 0; i < frames; i++) {
-		for (out_ch = 0; out_ch < data->num_channels; out_ch++) {
+		for (out_ch = 0; out_ch < sink->channels; out_ch++) {
 			sample = calc_sample_s24le(source,
-						   cd->config.num_channels,
-						   i * cd->config.num_channels,
+						   source->channels,
+						   i * source->channels,
 						   data->mask[out_ch]);
 
 			/* saturate to 24 bits */
 			dst = buffer_write_frag_s32(sink,
-				i * data->num_channels + out_ch);
+				i * sink->channels + out_ch);
 			*dst = sat_int24(sample);
 		}
 	}
@@ -218,7 +215,6 @@ static void mux_s24le(struct comp_dev *dev, struct comp_buffer *sink,
 		      struct comp_buffer **sources, uint32_t frames,
 		      struct mux_stream_data *data)
 {
-	struct comp_data *cd = comp_get_drvdata(dev);
 	struct comp_buffer *source;
 	uint8_t i;
 	uint8_t j;
@@ -227,7 +223,7 @@ static void mux_s24le(struct comp_dev *dev, struct comp_buffer *sink,
 	int32_t sample;
 
 	for (i = 0; i < frames; i++) {
-		for (out_ch = 0; out_ch < cd->config.num_channels; out_ch++) {
+		for (out_ch = 0; out_ch < sink->channels; out_ch++) {
 			sample = 0;
 			for (j = 0; j < MUX_MAX_STREAMS; j++) {
 				source = sources[j];
@@ -235,12 +231,12 @@ static void mux_s24le(struct comp_dev *dev, struct comp_buffer *sink,
 					continue;
 
 				sample += calc_sample_s24le(source,
-						data[j].num_channels,
-						i * data[j].num_channels,
+						source->channels,
+						i * source->channels,
 						data[j].mask[out_ch]);
 			}
 			dst = buffer_write_frag_s32(sink,
-				i * data->num_channels + out_ch);
+				i * sink->channels + out_ch);
 			*dst = sat_int24(sample);
 		}
 	}
@@ -293,22 +289,21 @@ static void demux_s32le(struct comp_dev *dev, struct comp_buffer *sink,
 			struct comp_buffer *source, uint32_t frames,
 			struct mux_stream_data *data)
 {
-	struct comp_data *cd = comp_get_drvdata(dev);
 	int64_t sample;
 	int32_t *dst;
 	uint8_t i;
 	uint8_t out_ch;
 
 	for (i = 0; i < frames; i++) {
-		for (out_ch = 0; out_ch < data->num_channels; out_ch++) {
+		for (out_ch = 0; out_ch < sink->channels; out_ch++) {
 			sample = calc_sample_s32le(source,
-						   cd->config.num_channels,
-						   i * cd->config.num_channels,
+						   source->channels,
+						   i * source->channels,
 						   data->mask[out_ch]);
 
 			/* saturate to 32 bits */
 			dst = buffer_write_frag_s32(sink,
-				i * data->num_channels + out_ch);
+				i * sink->channels + out_ch);
 			*dst = sat_int32(sample);
 		}
 	}
@@ -332,7 +327,6 @@ static void mux_s32le(struct comp_dev *dev, struct comp_buffer *sink,
 		      struct comp_buffer **sources, uint32_t frames,
 		      struct mux_stream_data *data)
 {
-	struct comp_data *cd = comp_get_drvdata(dev);
 	struct comp_buffer *source;
 	uint8_t i;
 	uint8_t j;
@@ -341,7 +335,7 @@ static void mux_s32le(struct comp_dev *dev, struct comp_buffer *sink,
 	int64_t sample;
 
 	for (i = 0; i < frames; i++) {
-		for (out_ch = 0; out_ch < cd->config.num_channels; out_ch++) {
+		for (out_ch = 0; out_ch < sink->channels; out_ch++) {
 			sample = 0;
 			for (j = 0; j < MUX_MAX_STREAMS; j++) {
 				source = sources[j];
@@ -349,12 +343,12 @@ static void mux_s32le(struct comp_dev *dev, struct comp_buffer *sink,
 					continue;
 
 				sample += calc_sample_s32le(source,
-						data[j].num_channels,
-						i * data[j].num_channels,
+						source->channels,
+						i * source->channels,
 						data[j].mask[out_ch]);
 			}
 			dst = buffer_write_frag_s32(sink,
-				i * data->num_channels + out_ch);
+				i * sink->channels + out_ch);
 			*dst = sat_int32(sample);
 		}
 	}
@@ -376,11 +370,14 @@ const struct comp_func_map mux_func_map[] = {
 
 mux_func mux_get_processing_function(struct comp_dev *dev)
 {
-	struct comp_data *cd = comp_get_drvdata(dev);
+	struct comp_buffer *sinkb;
 	uint8_t i;
 
+	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer,
+				source_list);
+
 	for (i = 0; i < ARRAY_SIZE(mux_func_map); i++) {
-		if (cd->config.frame_format == mux_func_map[i].frame_format)
+		if (sinkb->frame_fmt == mux_func_map[i].frame_format)
 			return mux_func_map[i].mux_proc_func;
 	}
 
@@ -389,11 +386,14 @@ mux_func mux_get_processing_function(struct comp_dev *dev)
 
 demux_func demux_get_processing_function(struct comp_dev *dev)
 {
-	struct comp_data *cd = comp_get_drvdata(dev);
+	struct comp_buffer *sinkb;
 	uint8_t i;
 
+	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer,
+				source_list);
+
 	for (i = 0; i < ARRAY_SIZE(mux_func_map); i++) {
-		if (cd->config.frame_format == mux_func_map[i].frame_format)
+		if (sinkb->frame_fmt == mux_func_map[i].frame_format)
 			return mux_func_map[i].demux_proc_func;
 	}
 

--- a/src/include/sof/audio/mux.h
+++ b/src/include/sof/audio/mux.h
@@ -18,6 +18,7 @@
 
 #if CONFIG_COMP_MUX
 
+#include <sof/audio/channel_map.h>
 #include <sof/common.h>
 #include <sof/platform.h>
 #include <sof/trace/trace.h>
@@ -55,10 +56,7 @@ STATIC_ASSERT(MUX_MAX_STREAMS < PLATFORM_MAX_STREAMS,
 
 struct mux_stream_data {
 	uint32_t pipeline_id;
-	uint8_t num_channels;
 	uint8_t mask[PLATFORM_MAX_CHANNELS];
-
-	uint8_t reserved[(20 - PLATFORM_MAX_CHANNELS - 1) % 4]; // padding to ensure proper alignment of following instances
 };
 
 typedef void(*demux_func)(struct comp_dev *dev, struct comp_buffer *sink,
@@ -68,23 +66,13 @@ typedef void(*mux_func)(struct comp_dev *dev, struct comp_buffer *sink,
 			  struct comp_buffer **sources, uint32_t frames,
 			  struct mux_stream_data *data);
 
-struct sof_mux_config {
-	uint16_t frame_format;
-	uint16_t num_channels;
-	uint16_t num_streams;
-
-	uint16_t reserved; // padding to ensure proper alignment
-
-	struct mux_stream_data streams[];
-};
-
 struct comp_data {
 	union {
 		mux_func mux;
 		demux_func demux;
 	};
 
-	struct sof_mux_config config;
+	struct mux_stream_data streams[MUX_MAX_STREAMS];
 };
 
 struct comp_func_map {

--- a/test/cmocka/src/audio/mux/CMakeLists.txt
+++ b/test/cmocka/src/audio/mux/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(
 	${PROJECT_SOURCE_DIR}/src/audio/mux/mux.c
 	${PROJECT_SOURCE_DIR}/src/audio/mux/mux_generic.c
 	${PROJECT_SOURCE_DIR}/src/audio/component.c
+	${PROJECT_SOURCE_DIR}/src/audio/channel_map.c
 )
 sof_append_relative_path_definitions(audio_mux)
 

--- a/test/cmocka/src/audio/mux/mux_copy.c
+++ b/test/cmocka/src/audio/mux/mux_copy.c
@@ -103,27 +103,35 @@ static int setup_group(void **state)
 static struct sof_ipc_comp_process *create_mux_comp_ipc(struct test_data *td)
 {
 	size_t ipc_size = sizeof(struct sof_ipc_comp_process);
-	size_t mux_size = sizeof(struct sof_mux_config)
-			  + MUX_MAX_STREAMS * sizeof(struct mux_stream_data);
+	size_t mux_size = get_stream_map_size(td->mask);
 	struct sof_ipc_comp_process *ipc = calloc(1, ipc_size + mux_size);
-	struct sof_mux_config *mux = (struct sof_mux_config *)&ipc->data;
+	struct sof_ipc_stream_map *stream_map = (struct sof_ipc_stream_map *)&ipc->data;
+	struct sof_ipc_channel_map *chmap;
+	char *w_ptr = (char *)&stream_map->ch_map;
 	int i, j;
+
+	stream_map->num_ch_map = 0;
+
+	/* for all streams */
+	for (i = 0; i < MUX_MAX_STREAMS; ++i) {
+		/* generate a channel map for each channel */
+		for (j = 0; j < PLATFORM_MAX_CHANNELS; ++j) {
+			chmap = (struct sof_ipc_channel_map *)w_ptr;
+
+			chmap->ch_index = j;
+			chmap->ext_id = i;
+			chmap->ch_mask = td->mask[i][j];
+
+			stream_map->num_ch_map++;
+			w_ptr += sizeof(*chmap) + (popcount(chmap->ch_mask) *
+				 sizeof(*chmap->ch_coeffs));
+		}
+	}
 
 	ipc->comp.hdr.size = sizeof(struct sof_ipc_comp_process);
 	ipc->comp.type = SOF_COMP_MUX;
 	ipc->config.hdr.size = sizeof(struct sof_ipc_comp_config);
-	ipc->size = mux_size;
-
-	mux->frame_format = td->format;
-	mux->num_channels = PLATFORM_MAX_CHANNELS;
-	mux->num_streams = MUX_MAX_STREAMS;
-
-	for (i = 0; i < MUX_MAX_STREAMS; ++i) {
-		mux->streams[i].pipeline_id = i;
-		mux->streams[i].num_channels = PLATFORM_MAX_CHANNELS;
-		for (j = 0; j < PLATFORM_MAX_CHANNELS; ++j)
-			mux->streams[i].mask[j] = td->mask[i][j];
-	}
+	ipc->size = w_ptr - (char *)stream_map;
 
 	return ipc;
 }

--- a/test/cmocka/src/audio/mux/mux_prepare.c
+++ b/test/cmocka/src/audio/mux/mux_prepare.c
@@ -5,6 +5,8 @@
 // Author: Daniel Bogdzia <danielx.bogdzia@linux.intel.com>
 //         Janusz Jankowski <janusz.jankowski@linux.intel.com>
 
+#include "util.h"
+
 #include <sof/audio/component.h>
 #include <sof/audio/mux.h>
 
@@ -18,6 +20,7 @@
 struct test_data {
 	struct comp_dev *dev;
 	struct comp_data *cd;
+	struct comp_buffer *sink;
 };
 
 static int setup_group(void **state)
@@ -60,6 +63,7 @@ static int teardown_test_case(void **state)
 {
 	struct test_data *td = *state;
 
+	free_test_sink(td->sink);
 	comp_free(td->dev);
 	free(td);
 
@@ -71,8 +75,10 @@ static void test_mux_prepare_invalid_float(void **state)
 {
 	struct test_data *td = *state;
 
-	/* set frame format value to unsupported value */
-	td->cd->config.frame_format = SOF_IPC_FRAME_FLOAT;
+	td->sink = create_test_sink(td->dev,
+				    MUX_MAX_STREAMS + 1,
+				    SOF_IPC_FRAME_FLOAT,
+				    PLATFORM_MAX_CHANNELS);
 
 	assert_int_equal(comp_prepare(td->dev), -EINVAL);
 }
@@ -83,7 +89,10 @@ static void test_mux_prepare_valid_s16le(void **state)
 {
 	struct test_data *td = *state;
 
-	td->cd->config.frame_format = SOF_IPC_FRAME_S16_LE;
+	td->sink = create_test_sink(td->dev,
+				    MUX_MAX_STREAMS + 1,
+				    SOF_IPC_FRAME_S16_LE,
+				    PLATFORM_MAX_CHANNELS);
 
 	assert_int_equal(comp_prepare(td->dev), 0);
 }
@@ -94,7 +103,10 @@ static void test_mux_prepare_valid_s24_4le(void **state)
 {
 	struct test_data *td = *state;
 
-	td->cd->config.frame_format = SOF_IPC_FRAME_S24_4LE;
+	td->sink = create_test_sink(td->dev,
+				    MUX_MAX_STREAMS + 1,
+				    SOF_IPC_FRAME_S24_4LE,
+				    PLATFORM_MAX_CHANNELS);
 
 	assert_int_equal(comp_prepare(td->dev), 0);
 }
@@ -105,7 +117,10 @@ static void test_mux_prepare_valid_s32le(void **state)
 {
 	struct test_data *td = *state;
 
-	td->cd->config.frame_format = SOF_IPC_FRAME_S32_LE;
+	td->sink = create_test_sink(td->dev,
+				    MUX_MAX_STREAMS + 1,
+				    SOF_IPC_FRAME_S32_LE,
+				    PLATFORM_MAX_CHANNELS);
 
 	assert_int_equal(comp_prepare(td->dev), 0);
 }

--- a/test/cmocka/src/audio/mux/util.h
+++ b/test/cmocka/src/audio/mux/util.h
@@ -67,3 +67,20 @@ static inline void free_test_source(struct comp_buffer *buffer)
 	free(buffer->source);
 	free(buffer);
 }
+
+static inline size_t get_stream_map_size(uint8_t mask[][PLATFORM_MAX_CHANNELS])
+{
+	size_t size = 0;
+	int i, j;
+
+	/* Stream map size depends on ch_coeffs flexible array */
+	for (i = 0; i < MUX_MAX_STREAMS; ++i) {
+		for (j = 0; j < PLATFORM_MAX_CHANNELS; ++j) {
+			/* mask bit count describes flexible array size */
+			size += sizeof(struct sof_ipc_channel_map) +
+				(popcount(mask[i][j]) *
+				sizeof(((struct sof_ipc_channel_map *)0)->ch_coeffs[0]));
+		}
+	}
+	return sizeof(struct sof_ipc_stream_map) + size;
+}


### PR DESCRIPTION
Previous sof_mux_config will be deleted along with global frame_format and num_channels for mux.
Mux will obtain format data from buffer params.