### PR TITLE
Fix build failures with CONFIG_GDB_DEBUG

### DIFF
--- a/src/arch/xtensa/debug/CMakeLists.txt
+++ b/src/arch/xtensa/debug/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-if (CONFIG_GDB)
+if (CONFIG_GDB_DEBUG)
 	add_subdirectory(gdb)
 endif()

--- a/src/debug/gdb/ringbuffer.c
+++ b/src/debug/gdb/ringbuffer.c
@@ -10,9 +10,9 @@
 #define BUFFER_OFFSET 0x120
 
 volatile struct ring * const rx = (void *) SRAM_DEBUG_BASE;
-volatile struct ring * const tx = (void *) SRAM_DEBUG_BASE + BUFFER_OFFSET;
-volatile struct ring * const debug = (void *) SRAM_DEBUG_BASE +
-					      (2*BUFFER_OFFSET);
+volatile struct ring * const tx = (void *)(SRAM_DEBUG_BASE + BUFFER_OFFSET);
+volatile struct ring * const debug = (void *)(SRAM_DEBUG_BASE +
+					      (2 * BUFFER_OFFSET));
 
 void init_buffers(void)
 {


### PR DESCRIPTION
If `Debug ---> GDB Stub` configuration option is enabled, the build is currently failing because of some pointer arithmetic errors and link-time errors. These patches are fixing those. 

For baytrail, the build still fails as it has no SRAM_DEBUG_BASE:
      
    sof/src/debug/gdb/ringbuffer.c:12:44: error: 'SRAM_DEBUG_BASE' undeclared here (not in a function); did you mean 'MAILBOX_DEBUG_BASE'?
     volatile struct ring * const rx = (void *) SRAM_DEBUG_BASE;
                                                ^~~~~~~~~~~~~~~
                                                MAILBOX_DEBUG_BASE

