### PR TITLE
ll_schedule: fix task insertion

### DIFF
--- a/src/schedule/ll_schedule.c
+++ b/src/schedule/ll_schedule.c
@@ -223,8 +223,10 @@ static void schedule_ll_task_insert(struct task *task, struct list_item *tasks)
 	/* tasks are added into the list in order */
 	list_for_item(tlist, tasks) {
 		curr_task = container_of(tlist, struct task, list);
-		if (task->priority <= curr_task->priority) {
-			list_item_append(&task->list, &curr_task->list);
+
+		/* insert task into the list */
+		if (task->priority > curr_task->priority) {
+			list_item_prepend(&task->list, &curr_task->list);
 			return;
 		}
 	}


### PR DESCRIPTION
Fixes low latency task insertion into the priority list.
From now on tasks will be inserted in the right order based
on their priority and time of insertion.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>

Fixes #2219.