### PR TITLE
[WIP] sa: log warning as standard trace

### DIFF
--- a/src/lib/agent.c
+++ b/src/lib/agent.c
@@ -51,8 +51,8 @@ static enum task_state validate(void *data)
 
 	/* warning timeout */
 	if (delta > sa->warn_timeout)
-		trace_sa_error("validate(), ll drift detected, delta = "
-			       "%u", delta);
+		trace_sa("validate(), ll drift detected, delta = "
+			 "%u", delta);
 
 	/* update last_check to current */
 	sa->last_check = current;


### PR DESCRIPTION
In current implementation system agent cannot reliably detect drift.
It print errors when there is just difference in time delta.
It's better to make it non-error trace, because it may be useful for
debugging with verbose traces enabled.

Signed-off-by: Janusz Jankowski <janusz.jankowski@linux.intel.com>