### PR TITLE
eq_iir: eq_fir: set *_delay pointer to NULL when freed

### DIFF
--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -263,6 +263,7 @@ static void eq_fir_free_delaylines(struct comp_data *cd)
 	 * each FIR channel delay line to NULL.
 	 */
 	rfree(cd->fir_delay);
+	cd->fir_delay = NULL;
 	cd->fir_delay_size = 0;
 	for (i = 0; i < PLATFORM_MAX_CHANNELS; i++)
 		fir[i].delay = NULL;

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -361,6 +361,7 @@ static void eq_iir_free_delaylines(struct comp_data *cd)
 	 * each IIR channel delay line to NULL.
 	 */
 	rfree(cd->iir_delay);
+	cd->iir_delay = NULL;
 	cd->iir_delay_size = 0;
 	for (i = 0; i < PLATFORM_MAX_CHANNELS; i++)
 		iir[i].delay = NULL;


### PR DESCRIPTION
Sets *_delay pointer to NULL when freed to prevent attempts
to free the buffer multiple times.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>

Fixes #2176 