### PR TITLE
dai: ALH set burst_elems

### DIFF
--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -747,6 +747,9 @@ static int dai_config(struct comp_dev *dev, struct sof_ipc_dai_config *config)
 		 */
 		dconfig->frame_fmt = SOF_IPC_FRAME_S32_LE;
 
+		dd->config.burst_elems =
+			dd->dai->plat_data.fifo[dai->direction].depth;
+
 		/* As with HDA, the DMA channel is assigned in runtime,
 		 * not during topology parsing.
 		 */

--- a/src/platform/cannonlake/include/platform/drivers/alh.h
+++ b/src/platform/cannonlake/include/platform/drivers/alh.h
@@ -84,6 +84,8 @@ static const uint8_t alh_handshake_map[64] = {
 	-1,	/* 63 - INVALID */
 };
 
+#define ALH_GPDMA_BURST_LENGTH	4
+
 #endif /* __PLATFORM_DRIVERS_ALH__ */
 
 #else

--- a/src/platform/icelake/include/platform/drivers/alh.h
+++ b/src/platform/icelake/include/platform/drivers/alh.h
@@ -84,6 +84,8 @@ static const uint8_t alh_handshake_map[64] = {
 	-1,	/* 63 - INVALID */
 };
 
+#define ALH_GPDMA_BURST_LENGTH	4
+
 #endif /* __PLATFORM_DRIVERS_ALH__ */
 
 #else

--- a/src/platform/intel/cavs/lib/dai.c
+++ b/src/platform/intel/cavs/lib/dai.c
@@ -156,6 +156,14 @@ int dai_init(void)
 		alh[i].index = (i / DAI_NUM_ALH_BI_DIR_LINKS_GROUP) << 8 |
 			(i % DAI_NUM_ALH_BI_DIR_LINKS_GROUP);
 		alh[i].drv = &alh_driver;
+
+		/* set burst length to align with DMAT value in the
+		 * Audio Link Hub.
+		 */
+		alh[i].plat_data.fifo[SOF_IPC_STREAM_PLAYBACK].depth =
+			ALH_GPDMA_BURST_LENGTH;
+		alh[i].plat_data.fifo[SOF_IPC_STREAM_CAPTURE].depth =
+			ALH_GPDMA_BURST_LENGTH;
 		spinlock_init(&alh[i].lock);
 	}
 #endif

--- a/src/platform/tigerlake/include/platform/drivers/alh.h
+++ b/src/platform/tigerlake/include/platform/drivers/alh.h
@@ -84,6 +84,8 @@ static const uint8_t alh_handshake_map[64] = {
 	-1,	/* 63 - INVALID */
 };
 
+#define ALH_GPDMA_BURST_LENGTH	4
+
 #endif /* __PLATFORM_DRIVERS_ALH__ */
 
 #else


### PR DESCRIPTION
The burst length of GP-DMA should align to DMAT setting
in Audio Link Hub, or XRUN will happen. We don't change
DMAT setting since it is also used by cAVS FW.

Tested on CML.
And this PR doesn't make current kernel failed to work with SDW