### PR TITLE
interrupt: make irq names const

### DIFF
--- a/src/arch/xtensa/include/arch/drivers/interrupt.h
+++ b/src/arch/xtensa/include/arch/drivers/interrupt.h
@@ -15,11 +15,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-extern char irq_name_level2[];
-extern char irq_name_level3[];
-extern char irq_name_level4[];
-extern char irq_name_level5[];
-
 static inline int arch_interrupt_register(int irq,
 	void (*handler)(void *arg), void *arg)
 {

--- a/src/drivers/intel/cavs/interrupt.c
+++ b/src/drivers/intel/cavs/interrupt.c
@@ -26,16 +26,16 @@
 #define LVL2_MAX_TRIES		1000
 
 #if CONFIG_INTERRUPT_LEVEL_2
-char irq_name_level2[] = "level2";
+const char irq_name_level2[] = "level2";
 #endif
 #if CONFIG_INTERRUPT_LEVEL_3
-char irq_name_level3[] = "level3";
+const char irq_name_level3[] = "level3";
 #endif
 #if CONFIG_INTERRUPT_LEVEL_4
-char irq_name_level4[] = "level4";
+const char irq_name_level4[] = "level4";
 #endif
 #if CONFIG_INTERRUPT_LEVEL_5
-char irq_name_level5[] = "level5";
+const char irq_name_level5[] = "level5";
 #endif
 
 /*

--- a/src/platform/apollolake/include/platform/drivers/interrupt.h
+++ b/src/platform/apollolake/include/platform/drivers/interrupt.h
@@ -11,6 +11,7 @@
 #ifndef __PLATFORM_DRIVERS_INTERRUPT_H__
 #define __PLATFORM_DRIVERS_INTERRUPT_H__
 
+#include <cavs/drivers/interrupt.h>
 #include <sof/bit.h>
 #include <config.h>
 

--- a/src/platform/cannonlake/include/platform/drivers/interrupt.h
+++ b/src/platform/cannonlake/include/platform/drivers/interrupt.h
@@ -12,6 +12,7 @@
 #ifndef __PLATFORM_DRIVERS_INTERRUPT_H__
 #define __PLATFORM_DRIVERS_INTERRUPT_H__
 
+#include <cavs/drivers/interrupt.h>
 #include <sof/bit.h>
 #include <config.h>
 

--- a/src/platform/icelake/include/platform/drivers/interrupt.h
+++ b/src/platform/icelake/include/platform/drivers/interrupt.h
@@ -12,6 +12,7 @@
 #ifndef __PLATFORM_DRIVERS_INTERRUPT_H__
 #define __PLATFORM_DRIVERS_INTERRUPT_H__
 
+#include <cavs/drivers/interrupt.h>
 #include <sof/bit.h>
 #include <config.h>
 

--- a/src/platform/intel/cavs/include/cavs/drivers/interrupt.h
+++ b/src/platform/intel/cavs/include/cavs/drivers/interrupt.h
@@ -10,10 +10,10 @@
 #ifndef __CAVS_DRIVERS_INTERRUPT_H__
 #define __CAVS_DRIVERS_INTERRUPT_H__
 
-extern char irq_name_level2[];
-extern char irq_name_level3[];
-extern char irq_name_level4[];
-extern char irq_name_level5[];
+extern const char irq_name_level2[];
+extern const char irq_name_level3[];
+extern const char irq_name_level4[];
+extern const char irq_name_level5[];
 
 #endif /* __CAVS_DRIVERS_INTERRUPT_H__ */
 

--- a/src/platform/intel/cavs/include/cavs/drivers/interrupt.h
+++ b/src/platform/intel/cavs/include/cavs/drivers/interrupt.h
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2019 Intel Corporation. All rights reserved.
+ *
+ * Author: Tomasz Lauda <tomasz.lauda@linux.intel.com>
+ */
+
+#ifdef __PLATFORM_DRIVERS_INTERRUPT_H__
+
+#ifndef __CAVS_DRIVERS_INTERRUPT_H__
+#define __CAVS_DRIVERS_INTERRUPT_H__
+
+extern char irq_name_level2[];
+extern char irq_name_level3[];
+extern char irq_name_level4[];
+extern char irq_name_level5[];
+
+#endif /* __CAVS_DRIVERS_INTERRUPT_H__ */
+
+#else
+
+#error "This file shouldn't be included from outside of platform/drivers/interrupt.h"
+
+#endif /* __PLATFORM_DRIVERS_INTERRUPT_H__ */

--- a/src/platform/suecreek/include/platform/drivers/interrupt.h
+++ b/src/platform/suecreek/include/platform/drivers/interrupt.h
@@ -12,6 +12,7 @@
 #ifndef __PLATFORM_DRIVERS_INTERRUPT_H__
 #define __PLATFORM_DRIVERS_INTERRUPT_H__
 
+#include <cavs/drivers/interrupt.h>
 #include <sof/bit.h>
 #include <sof/drivers/interrupt-map.h>
 #include <config.h>

--- a/src/platform/tigerlake/include/platform/drivers/interrupt.h
+++ b/src/platform/tigerlake/include/platform/drivers/interrupt.h
@@ -12,6 +12,7 @@
 #ifndef __PLATFORM_DRIVERS_INTERRUPT_H__
 #define __PLATFORM_DRIVERS_INTERRUPT_H__
 
+#include <cavs/drivers/interrupt.h>
 #include <sof/bit.h>
 #include <config.h>
 


### PR DESCRIPTION
Changes interrupt controller names to const.
They are not supposed to be modified.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>