### PR TITLE
ASRC: Fix memory leak in reset()

### DIFF
--- a/src/audio/asrc/asrc.c
+++ b/src/audio/asrc/asrc.c
@@ -567,7 +567,15 @@ static int asrc_copy(struct comp_dev *dev)
 
 static int asrc_reset(struct comp_dev *dev)
 {
+	struct comp_data *cd = comp_get_drvdata(dev);
+
 	trace_asrc_with_ids(dev, "asrc_reset()");
+
+	/* Free the allocations those were done in prepare() */
+	rfree(cd->asrc_obj);
+	rfree(cd->buf);
+	cd->asrc_obj = NULL;
+	cd->buf = NULL;
 
 	comp_set_state(dev, COMP_TRIGGER_RESET);
 	return 0;


### PR DESCRIPTION
This patch adds the missing freeing of data structures those
were allocated in prepare(). Successive pipeline runs without
suspend in between have consumed more and more RAM every time.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>