### PR TITLE
scripts: checkpatch: accept long trace strings (80+ characters)

### DIFF
--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -466,7 +466,8 @@ our $logFunctions = qr{(?x:
 	WARN(?:_RATELIMIT|_ONCE|)|
 	panic|
 	MODULE_[A-Z_]+|
-	seq_vprintf|seq_printf|seq_puts
+	seq_vprintf|seq_printf|seq_puts|
+	trace[a-z_]+
 )};
 
 our $allocFunctions = qr{(?x:


### PR DESCRIPTION
This is an exception similar to the kernel pr_...() family.
Having a log string in a single line is much more readable for
a person who works with the trace output frequently.

Splitting trace strings into multiple lines seems to be a worse
alternative since it generates another warning anyway and encourages
developers to create very long trace entries which are wrapped
on a trace console and less readable.

Signed-off-by: Marcin Maka <marcin.maka@linux.intel.com>