### PR TITLE
ipc: add NO_TRACE flag to SETD0IX IPC

### DIFF
--- a/src/drivers/intel/cavs/ipc.c
+++ b/src/drivers/intel/cavs/ipc.c
@@ -141,7 +141,7 @@ static struct sof_ipc_cmd_hdr *ipc_cavs_read_set_d0ix(uint32_t dr, uint32_t dd)
 	return &cmd->hdr;
 }
 
-static struct sof_ipc_cmd_hdr *ipc_cavs_read_msg(void)
+static struct sof_ipc_cmd_hdr *ipc_compact_read_msg(void)
 {
 	struct sof_ipc_cmd_hdr *hdr;
 	uint32_t dr;
@@ -177,7 +177,7 @@ enum task_state ipc_platform_do_cmd(void *data)
 	struct sof_ipc_reply reply;
 
 #if CAVS_VERSION >= CAVS_VERSION_1_8
-	hdr = ipc_cavs_read_msg();
+	hdr = ipc_compact_read_msg();
 #else
 	hdr = mailbox_validate();
 #endif

--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -663,10 +663,18 @@ static int ipc_pm_gate(uint32_t header)
 
 	IPC_COPY_CMD(pm_gate, _ipc->comp_data);
 
+	/* pause dma trace firstly if needed */
+	if (pm_gate.flags & SOF_PM_NO_TRACE)
+		trace_off();
+
 	if (pm_gate.flags & SOF_PM_PPG)
 		pm_runtime_disable(PM_RUNTIME_DSP, PLATFORM_MASTER_CORE_ID);
 	else
 		pm_runtime_enable(PM_RUNTIME_DSP, PLATFORM_MASTER_CORE_ID);
+
+	/* resume dma trace if needed */
+	if (!(pm_gate.flags & SOF_PM_NO_TRACE))
+		trace_on();
 
 	return 0;
 }


### PR DESCRIPTION
Traces must be turned off when entering D0ix state
on cAVS platform in order to stop generating ipc
interrupts to the host, waking it up, when the dma
trace buffer is flushed.

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>