### PR TITLE
arch: Panic exceptions with detailed exception name

### DIFF
--- a/src/arch/xtensa/include/arch/init.h
+++ b/src/arch/xtensa/include/arch/init.h
@@ -17,6 +17,8 @@
 #define __ARCH_INIT_H__
 
 #include <sof/debug/panic.h>
+#include <sof/math/numbers.h>
+#include <sof/string.h>
 #include <ipc/trace.h>
 #include <config.h>
 #include <xtensa/corebits.h>
@@ -24,20 +26,81 @@
 #include <stddef.h>
 #include <stdint.h>
 
+/* When set to 1, then exceptions message contains exception name */
+#define DETAILED_EXCEPTIONS 1
+
+/**
+ * \brief Called in the case of exception, pass extra information.
+ *
+ * \param name exception name
+ * \param code exception extra numerical information
+ */
+static inline void exception_ext(const char *name, int code)
+{
+	uintptr_t epc1;
+	struct sof_ipc_panic_info info;
+	struct sof_ipc_panic_info *pinfo;
+
+	__asm__ __volatile__("rsr %0, EPC1" : "=a" (epc1) : : "memory");
+
+	if (name) {
+		/* fill exception information */
+		info.code = SOF_IPC_PANIC_EXCEPTION;
+		info.hdr.size = sizeof(info);
+		info.linenum = code;
+		memcpy_s(info.filename, sizeof(info.filename) - 1,
+			 name, rstrlen(name));
+		pinfo = &info;
+	} else {
+		pinfo = NULL;
+	}
+
+	/* now panic and rewind 8 stack frames. */
+	/* TODO: we could invoke a GDB stub here */
+	panic_rewind(SOF_IPC_PANIC_EXCEPTION, 8 * sizeof(uint32_t),
+		     pinfo, &epc1);
+}
+
 /**
  * \brief Called in the case of exception.
  */
 static inline void exception(void)
 {
-	uintptr_t epc1;
-
-	__asm__ __volatile__("rsr %0, EPC1" : "=a" (epc1) : : "memory");
-
-	/* now panic and rewind 8 stack frames. */
-	/* TODO: we could invoke a GDB stub here */
-	panic_rewind(SOF_IPC_PANIC_EXCEPTION, 8 * sizeof(uint32_t),
-		     NULL, &epc1);
+	exception_ext(NULL, 0);
 }
+
+/* macro to build detailed exception callbacks */
+#if DETAILED_EXCEPTIONS
+#define BUILD_EXCEPTION(name) \
+	static inline void exception_##name(void) \
+	{ \
+		exception_ext(#name, 0); \
+	}
+#define FUN_EXCEPTION(name) exception_##name
+#else
+#define BUILD_EXCEPTION(name)
+#define FUN_EXCEPTION(name) exception
+#endif
+
+/* Detailed exception callbacks */
+
+BUILD_EXCEPTION(EXCCAUSE_ILLEGAL)
+BUILD_EXCEPTION(EXCCAUSE_SYSCALL)
+BUILD_EXCEPTION(EXCCAUSE_INSTR_ERROR)
+BUILD_EXCEPTION(EXCCAUSE_LOAD_STORE_ERROR)
+BUILD_EXCEPTION(EXCCAUSE_ALLOCA)
+BUILD_EXCEPTION(EXCCAUSE_DIVIDE_BY_ZERO)
+BUILD_EXCEPTION(EXCCAUSE_PRIVILEGED)
+BUILD_EXCEPTION(EXCCAUSE_UNALIGNED)
+BUILD_EXCEPTION(EXCCAUSE_INSTR_DATA_ERROR)
+BUILD_EXCEPTION(EXCCAUSE_LOAD_STORE_DATA_ERROR)
+BUILD_EXCEPTION(EXCCAUSE_INSTR_ADDR_ERROR)
+BUILD_EXCEPTION(EXCCAUSE_LOAD_STORE_ADDR_ERROR)
+BUILD_EXCEPTION(EXCCAUSE_INSTR_RING)
+BUILD_EXCEPTION(EXCCAUSE_INSTR_PROHIBITED)
+BUILD_EXCEPTION(EXCCAUSE_LOAD_STORE_RING)
+BUILD_EXCEPTION(EXCCAUSE_LOAD_PROHIBITED)
+BUILD_EXCEPTION(EXCCAUSE_STORE_PROHIBITED)
 
 /**
  * \brief Registers exception handlers.
@@ -47,45 +110,45 @@ static inline void register_exceptions(void)
 
 	/* 0 - 9 */
 	_xtos_set_exception_handler(
-		EXCCAUSE_ILLEGAL, (void *)&exception);
+		EXCCAUSE_ILLEGAL, &FUN_EXCEPTION(EXCCAUSE_ILLEGAL));
 	_xtos_set_exception_handler(
-		EXCCAUSE_SYSCALL, (void *)&exception);
+		EXCCAUSE_SYSCALL, &FUN_EXCEPTION(EXCCAUSE_SYSCALL));
 	_xtos_set_exception_handler(
-		EXCCAUSE_INSTR_ERROR, (void *)&exception);
+		EXCCAUSE_INSTR_ERROR, &FUN_EXCEPTION(EXCCAUSE_INSTR_ERROR));
 	_xtos_set_exception_handler(
-		EXCCAUSE_LOAD_STORE_ERROR, (void *)&exception);
+		EXCCAUSE_LOAD_STORE_ERROR, &FUN_EXCEPTION(EXCCAUSE_LOAD_STORE_ERROR));
 	_xtos_set_exception_handler(
-		EXCCAUSE_ALLOCA, (void *)&exception);
+		EXCCAUSE_ALLOCA, &FUN_EXCEPTION(EXCCAUSE_ALLOCA));
 	_xtos_set_exception_handler(
-		EXCCAUSE_DIVIDE_BY_ZERO, (void *)&exception);
+		EXCCAUSE_DIVIDE_BY_ZERO, &FUN_EXCEPTION(EXCCAUSE_DIVIDE_BY_ZERO));
 	_xtos_set_exception_handler(
-		EXCCAUSE_SPECULATION, (void *)&exception);
+		EXCCAUSE_SPECULATION, &exception);
 	_xtos_set_exception_handler(
-		EXCCAUSE_PRIVILEGED, (void *)&exception);
+		EXCCAUSE_PRIVILEGED, &FUN_EXCEPTION(EXCCAUSE_PRIVILEGED));
 	_xtos_set_exception_handler(
-		EXCCAUSE_UNALIGNED, (void *)&exception);
+		EXCCAUSE_UNALIGNED, &FUN_EXCEPTION(EXCCAUSE_UNALIGNED));
 
 	/* Reserved				10..11 */
 
 	_xtos_set_exception_handler(
-		EXCCAUSE_INSTR_DATA_ERROR, (void *)&exception);
+		EXCCAUSE_INSTR_DATA_ERROR, &FUN_EXCEPTION(EXCCAUSE_INSTR_DATA_ERROR));
 	_xtos_set_exception_handler(
-		EXCCAUSE_LOAD_STORE_DATA_ERROR, (void *)&exception);
+		EXCCAUSE_LOAD_STORE_DATA_ERROR, &FUN_EXCEPTION(EXCCAUSE_LOAD_STORE_DATA_ERROR));
 	_xtos_set_exception_handler(
-		EXCCAUSE_INSTR_ADDR_ERROR, (void *)&exception);
+		EXCCAUSE_INSTR_ADDR_ERROR, &FUN_EXCEPTION(EXCCAUSE_INSTR_ADDR_ERROR));
 	_xtos_set_exception_handler(
-		EXCCAUSE_LOAD_STORE_ADDR_ERROR, (void *)&exception);
+		EXCCAUSE_LOAD_STORE_ADDR_ERROR, &FUN_EXCEPTION(EXCCAUSE_LOAD_STORE_ADDR_ERROR));
 	_xtos_set_exception_handler(
 		EXCCAUSE_ITLB_MISS, (void *)&exception);
 	_xtos_set_exception_handler(
 		EXCCAUSE_ITLB_MULTIHIT, (void *)&exception);
 	_xtos_set_exception_handler(
-		EXCCAUSE_INSTR_RING, (void *)&exception);
+		EXCCAUSE_INSTR_RING, &FUN_EXCEPTION(EXCCAUSE_INSTR_RING));
 
 	/* Reserved				19 */
 
 	_xtos_set_exception_handler(
-		EXCCAUSE_INSTR_PROHIBITED, (void *)&exception);
+		EXCCAUSE_INSTR_PROHIBITED, &FUN_EXCEPTION(EXCCAUSE_INSTR_PROHIBITED));
 
 	/* Reserved				21..23 */
 	_xtos_set_exception_handler(
@@ -93,13 +156,13 @@ static inline void register_exceptions(void)
 	_xtos_set_exception_handler(
 		EXCCAUSE_DTLB_MULTIHIT, (void *)&exception);
 	_xtos_set_exception_handler(
-		EXCCAUSE_LOAD_STORE_RING, (void *)&exception);
+		EXCCAUSE_LOAD_STORE_RING, &FUN_EXCEPTION(EXCCAUSE_LOAD_STORE_RING));
 
 	/* Reserved				27 */
 	_xtos_set_exception_handler(
-		EXCCAUSE_LOAD_PROHIBITED, (void *)&exception);
+		EXCCAUSE_LOAD_PROHIBITED, &FUN_EXCEPTION(EXCCAUSE_LOAD_PROHIBITED));
 	_xtos_set_exception_handler(
-		EXCCAUSE_STORE_PROHIBITED, (void *)&exception);
+		EXCCAUSE_STORE_PROHIBITED, &FUN_EXCEPTION(EXCCAUSE_STORE_PROHIBITED));
 
 	/* Reserved				30..31 */
 	_xtos_set_exception_handler(


### PR DESCRIPTION
Fill sof_ipc_panic_info struct after exception occurres and
use filename field to pass exception detailed name.

Introduced BUILD_EXCEPTION and FUN_EXCEPTION macros to
make easy firmware size optimization and usage generic
eception callback when only optimization for size is active.

Lines with more that 80 chars are not splitted to keep eye-catch
pattern during calling _xtos_set_exception_handler functions,
where exceptions names are one below other.

Moreover remove redundant (void *) casting in edited lines.

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>