### PR TITLE
trace: Add pipeline id to buffer traces

### DIFF
--- a/src/audio/buffer.c
+++ b/src/audio/buffer.c
@@ -80,7 +80,8 @@ int buffer_set_size(struct comp_buffer *buffer, uint32_t size)
 
 	/* validate request */
 	if (size == 0 || size > HEAP_BUFFER_SIZE) {
-		trace_buffer_error("resize error: size = %u is invalid", size);
+		trace_buffer_error_with_ids(buffer, "resize error: size = %u is invalid",
+					    size);
 		return -EINVAL;
 	}
 
@@ -91,8 +92,8 @@ int buffer_set_size(struct comp_buffer *buffer, uint32_t size)
 
 	/* we couldn't allocate bigger chunk */
 	if (!new_ptr && size > buffer->size) {
-		trace_buffer_error("resize error: can't alloc %u bytes type %u",
-				   buffer->size, buffer->caps);
+		trace_buffer_error_with_ids(buffer, "resize error: can't alloc %u bytes type %u",
+					    buffer->size, buffer->caps);
 		return -ENOMEM;
 	}
 
@@ -112,7 +113,7 @@ void buffer_free(struct comp_buffer *buffer)
 		.buffer = buffer,
 	};
 
-	trace_buffer("buffer_free()");
+	trace_buffer_with_ids(buffer, "buffer_free()");
 
 	notifier_event(buffer, NOTIFIER_ID_BUFFER_FREE,
 		       NOTIFIER_TARGET_CORE_LOCAL, &cb_data, sizeof(cb_data));
@@ -137,12 +138,12 @@ void comp_update_buffer_produce(struct comp_buffer *buffer, uint32_t bytes)
 
 	/* return if no bytes */
 	if (!bytes) {
-		trace_buffer("comp_update_buffer_produce(), "
-			     "no bytes to produce, source->comp.id = %u, "
-			     "source->comp.type = %u, sink->comp.id = %u, "
-			     "sink->comp.type = %u", buffer->source->comp.id,
-			     buffer->source->comp.type, buffer->sink->comp.id,
-			     buffer->sink->comp.type);
+		trace_buffer_with_ids(buffer,
+				      "comp_update_buffer_produce(), no bytes to produce, source->comp.id = %u, source->comp.type = %u, sink->comp.id = %u, sink->comp.type = %u",
+				      buffer->source->comp.id,
+				      buffer->source->comp.type,
+				      buffer->sink->comp.id,
+				      buffer->sink->comp.type);
 		return;
 	}
 
@@ -176,15 +177,14 @@ void comp_update_buffer_produce(struct comp_buffer *buffer, uint32_t bytes)
 
 	irq_local_enable(flags);
 
-	tracev_buffer("comp_update_buffer_produce(), ((buffer->avail << 16) | "
-		      "buffer->free) = %08x, ((buffer->id << 16) | "
-		      "buffer->size) = %08x",
-		      (buffer->avail << 16) | buffer->free,
-		      (buffer->id << 16) | buffer->size);
-	tracev_buffer("comp_update_buffer_produce(), ((buffer->r_ptr - buffer"
-		      "->addr) << 16 | (buffer->w_ptr - buffer->addr)) = %08x",
-		      ((char *)buffer->r_ptr - (char *)buffer->addr) << 16 |
-		      ((char *)buffer->w_ptr - (char *)buffer->addr));
+	tracev_buffer_with_ids(buffer,
+			       "comp_update_buffer_produce(), ((buffer->avail << 16) | buffer->free) = %08x, ((buffer->id << 16) | buffer->size) = %08x",
+			       (buffer->avail << 16) | buffer->free,
+			       (buffer->id << 16) | buffer->size);
+	tracev_buffer_with_ids(buffer,
+			       "comp_update_buffer_produce(), ((buffer->r_ptr - buffer->addr) << 16 | (buffer->w_ptr - buffer->addr)) = %08x",
+			       ((char *)buffer->r_ptr - (char *)buffer->addr) << 16 |
+			       ((char *)buffer->w_ptr - (char *)buffer->addr));
 }
 
 void comp_update_buffer_consume(struct comp_buffer *buffer, uint32_t bytes)
@@ -198,12 +198,12 @@ void comp_update_buffer_consume(struct comp_buffer *buffer, uint32_t bytes)
 
 	/* return if no bytes */
 	if (!bytes) {
-		trace_buffer("comp_update_buffer_consume(), "
-			     "no bytes to consume, source->comp.id = %u, "
-			     "source->comp.type = %u, sink->comp.id = %u, "
-			     "sink->comp.type = %u", buffer->source->comp.id,
-			     buffer->source->comp.type, buffer->sink->comp.id,
-			     buffer->sink->comp.type);
+		trace_buffer_with_ids(buffer,
+				      "comp_update_buffer_consume(), no bytes to consume, source->comp.id = %u, source->comp.type = %u, sink->comp.id = %u, sink->comp.type = %u",
+				      buffer->source->comp.id,
+				      buffer->source->comp.type,
+				      buffer->sink->comp.id,
+				      buffer->sink->comp.type);
 		return;
 	}
 
@@ -233,13 +233,10 @@ void comp_update_buffer_consume(struct comp_buffer *buffer, uint32_t bytes)
 
 	irq_local_enable(flags);
 
-	tracev_buffer("comp_update_buffer_consume(), "
-		      "(buffer->avail << 16) | buffer->free = %08x, "
-		      "(buffer->id << 16) | buffer->size = %08x, "
-		      "(buffer->r_ptr - buffer->addr) << 16 | "
-		      "(buffer->w_ptr - buffer->addr)) = %08x",
-		      (buffer->avail << 16) | buffer->free,
-		      (buffer->id << 16) | buffer->size,
-		      ((char *)buffer->r_ptr - (char *)buffer->addr) << 16 |
-		      ((char *)buffer->w_ptr - (char *)buffer->addr));
+	tracev_buffer_with_ids(buffer,
+			       "comp_update_buffer_consume(), (buffer->avail << 16) | buffer->free = %08x, (buffer->id << 16) | buffer->size = %08x, (buffer->r_ptr - buffer->addr) << 16 | (buffer->w_ptr - buffer->addr)) = %08x",
+			       (buffer->avail << 16) | buffer->free,
+			       (buffer->id << 16) | buffer->size,
+			       ((char *)buffer->r_ptr - (char *)buffer->addr) << 16 |
+			       ((char *)buffer->w_ptr - (char *)buffer->addr));
 }

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -31,12 +31,23 @@ struct comp_dev;
 /* buffer tracing */
 #define trace_buffer(__e, ...) \
 	trace_event(TRACE_CLASS_BUFFER, __e, ##__VA_ARGS__)
-#define trace_buffer_error(__e, ...) \
-	trace_error(TRACE_CLASS_BUFFER, __e, ##__VA_ARGS__)
+#define trace_buffer_with_ids(buf_ptr, __e, ...) \
+	trace_event_with_ids(TRACE_CLASS_BUFFER, (buf_ptr)->pipeline_id, \
+			     (buf_ptr)->id, __e, ##__VA_ARGS__)
+
 #define tracev_buffer(__e, ...) \
 	tracev_event(TRACE_CLASS_BUFFER, __e, ##__VA_ARGS__)
+#define tracev_buffer_with_ids(buf_ptr, __e, ...) \
+	tracev_event_with_ids(TRACE_CLASS_BUFFER, (buf_ptr)->pipeline_id, \
+			      (buf_ptr)->id, __e, ##__VA_ARGS__)
+
+#define trace_buffer_error(__e, ...) \
+	trace_error(TRACE_CLASS_BUFFER, __e, ##__VA_ARGS__)
 #define trace_buffer_error_atomic(__e, ...) \
 	trace_error_atomic(TRACE_CLASS_BUFFER, __e, ##__VA_ARGS__)
+#define trace_buffer_error_with_ids(buf_ptr, __e, ...) \
+	trace_error_with_ids(TRACE_CLASS_BUFFER, (buf_ptr)->pipeline_id, \
+			     (buf_ptr)->id, __e, ##__VA_ARGS__)
 
 /* buffer callback types */
 #define BUFF_CB_TYPE_PRODUCE	BIT(0)
@@ -148,7 +159,7 @@ void comp_update_buffer_consume(struct comp_buffer *buffer, uint32_t bytes);
 
 static inline void buffer_zero(struct comp_buffer *buffer)
 {
-	tracev_buffer("buffer_zero()");
+	tracev_buffer_with_ids(buffer, "buffer_zero()");
 
 	bzero(buffer->addr, buffer->size);
 	if (buffer->caps & SOF_MEM_CAPS_DMA)


### PR DESCRIPTION
It will be helpful during debugging components
to see correlated pipeline id.

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>