### PR TITLE
Topology: FIR: Increase maximum size of configuration data blob

### DIFF
--- a/tools/topology/sof/pipe-eq-volume-playback.m4
+++ b/tools/topology/sof/pipe-eq-volume-playback.m4
@@ -59,7 +59,7 @@ C_CONTROLBYTES(EQFIR, PIPELINE_ID,
 	CONTROLBYTES_OPS(bytes, 258 binds the mixer control to bytes get/put handlers, 258, 258),
 	CONTROLBYTES_EXTOPS(258 binds the mixer control to bytes get/put handlers, 258, 258),
 	, , ,
-	CONTROLBYTES_MAX(, 304),
+	CONTROLBYTES_MAX(, 4096),
 	,
 	EQFIR_priv)
 


### PR DESCRIPTION
This patch increases the max. size to 4 kB. Such size allows
setting up e.g. 8ch 192 tap FIR. The multiple part configuration
IPC support has existed in the EQ component for a while and this
limit in topology has remained not updated.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>