### PR TITLE
sof: spinlock: Fix placement of spin_try_lock

### DIFF
--- a/src/include/sof/spinlock.h
+++ b/src/include/sof/spinlock.h
@@ -143,6 +143,8 @@ extern uint32_t lock_dbg_user[DBG_LOCK_USERS];
 #define spin_lock_dbg(line) do {} while (0)
 #define spin_unlock_dbg(line) do {} while (0)
 
+#endif
+
 static inline int _spin_try_lock(spinlock_t *lock, int line)
 {
 	spin_lock_dbg(line);
@@ -150,8 +152,6 @@ static inline int _spin_try_lock(spinlock_t *lock, int line)
 }
 
 #define spin_try_lock(lock) _spin_try_lock(lock, __LINE__)
-
-#endif
 
 /* all SMP spinlocks need init, nothing todo on UP */
 static inline void _spinlock_init(spinlock_t **lock, int line)


### PR DESCRIPTION
Enabling CONFIG_LOCK_DEBUG currently breaks the build for APL as
spin_try_lock is undefined.

src/drivers/intel/cavs/dmic.c:167:8:
error: implicit declaration of function 'spin_try_lock';
did you mean 'arch_try_lock'? [-Werror=implicit-function-declaration]
  ret = spin_try_lock(dai->lock);
        ^~~~~~~~~~~~~

Fix that by making sure spin_try_lock gets defined regardless of
either CONFIG_LOCK_DEBUG is enabled or not.

Signed-off-by: Dragos Tarcatu <dragos_tarcatu@mentor.com>