### PR TITLE
platform: remove unused mn functions

### DIFF
--- a/src/platform/apollolake/include/platform/platform.h
+++ b/src/platform/apollolake/include/platform/platform.h
@@ -115,15 +115,6 @@ extern struct ll_schedule_domain *platform_dma_domain;
 extern intptr_t _module_init_start;
 extern intptr_t _module_init_end;
 
-/*
- * APIs declared here are defined for every platform and IPC mechanism.
- */
-
-int platform_ssp_set_mn(uint32_t ssp_port, uint32_t source, uint32_t rate,
-	uint32_t bclk_fs);
-
-void platform_ssp_disable_mn(uint32_t ssp_port);
-
 #endif
 #endif /* __PLATFORM_PLATFORM_H__ */
 

--- a/src/platform/cannonlake/include/platform/platform.h
+++ b/src/platform/cannonlake/include/platform/platform.h
@@ -112,15 +112,6 @@ extern struct ll_schedule_domain *platform_dma_domain;
 extern intptr_t _module_init_start;
 extern intptr_t _module_init_end;
 
-/*
- * APIs declared here are defined for every platform and IPC mechanism.
- */
-
-int platform_ssp_set_mn(uint32_t ssp_port, uint32_t source, uint32_t rate,
-	uint32_t bclk_fs);
-
-void platform_ssp_disable_mn(uint32_t ssp_port);
-
 #endif
 #endif /* __PLATFORM_PLATFORM_H__ */
 

--- a/src/platform/icelake/include/platform/platform.h
+++ b/src/platform/icelake/include/platform/platform.h
@@ -112,15 +112,6 @@ extern struct ll_schedule_domain *platform_dma_domain;
 extern intptr_t _module_init_start;
 extern intptr_t _module_init_end;
 
-/*
- * APIs declared here are defined for every platform and IPC mechanism.
- */
-
-int platform_ssp_set_mn(uint32_t ssp_port, uint32_t source, uint32_t rate,
-	uint32_t bclk_fs);
-
-void platform_ssp_disable_mn(uint32_t ssp_port);
-
 #endif
 #endif /* __PLATFORM_PLATFORM_H__ */
 

--- a/src/platform/suecreek/include/platform/platform.h
+++ b/src/platform/suecreek/include/platform/platform.h
@@ -122,15 +122,6 @@ extern struct ll_schedule_domain *platform_dma_domain;
 extern intptr_t _module_init_start;
 extern intptr_t _module_init_end;
 
-/*
- * APIs declared here are defined for every platform and IPC mechanism.
- */
-
-int platform_ssp_set_mn(uint32_t ssp_port, uint32_t source, uint32_t rate,
-	uint32_t bclk_fs);
-
-void platform_ssp_disable_mn(uint32_t ssp_port);
-
 #endif
 #endif /* __PLATFORM_PLATFORM_H__ */
 

--- a/src/platform/tigerlake/include/platform/platform.h
+++ b/src/platform/tigerlake/include/platform/platform.h
@@ -112,15 +112,6 @@ extern struct ll_schedule_domain *platform_dma_domain;
 extern intptr_t _module_init_start;
 extern intptr_t _module_init_end;
 
-/*
- * APIs declared here are defined for every platform and IPC mechanism.
- */
-
-int platform_ssp_set_mn(uint32_t ssp_port, uint32_t source, uint32_t rate,
-	uint32_t bclk_fs);
-
-void platform_ssp_disable_mn(uint32_t ssp_port);
-
 #endif
 #endif /* __PLATFORM_PLATFORM_H__ */
 


### PR DESCRIPTION
These functions are unused and can be deleted.

Signed-off-by: Janusz Jankowski <janusz.jankowski@linux.intel.com>