### PR TITLE
cmake: version: consider unannotated tags

### DIFF
--- a/scripts/cmake/version.cmake
+++ b/scripts/cmake/version.cmake
@@ -21,7 +21,7 @@ if(EXISTS ${TARBALL_VERSION_SOURCE_PATH})
 	message(STATUS "Found ${TARBALL_VERSION_FILE_NAME}")
 	message(STATUS "Version: ${GIT_TAG} / ${GIT_LOG_HASH}")
 else()
-	execute_process(COMMAND git describe --abbrev=4
+	execute_process(COMMAND git describe --tags --abbrev=4
 		OUTPUT_VARIABLE GIT_TAG
 		OUTPUT_STRIP_TRAILING_WHITESPACE
 		ERROR_QUIET


### PR DESCRIPTION
Command git describe looks only for annotated tags, but we should
get any tag reachable from master, that's why --tags flag is needed.

Signed-off-by: Janusz Jankowski <janusz.jankowski@linux.intel.com>