### PR TITLE
ipc: multidai abi

### DIFF
--- a/src/drivers/imx/esai.c
+++ b/src/drivers/imx/esai.c
@@ -89,13 +89,14 @@ static int esai_context_restore(struct dai *dai)
 }
 
 static inline int esai_set_config(struct dai *dai,
-				 struct sof_ipc_dai_config *config)
+				  struct sof_ipc_dai_config *config,
+				  int config_idx)
 {
 	uint32_t xcr = 0, xccr = 0, mask;
 
 	tracev_esai("ESAI: set_config format 0x%04x",
-		    config->format);
-	switch (config->format & SOF_DAI_FMT_FORMAT_MASK) {
+		    config->params.format);
+	switch (config->params.format & SOF_DAI_FMT_FORMAT_MASK) {
 	case SOF_DAI_FMT_I2S:
 		/* Data on rising edge of bclk, frame low, 1clk before
 		 * data
@@ -134,7 +135,7 @@ static inline int esai_set_config(struct dai *dai,
 		return -EINVAL;
 	}
 
-	switch (config->format & SOF_DAI_FMT_INV_MASK) {
+	switch (config->params.format & SOF_DAI_FMT_INV_MASK) {
 	case SOF_DAI_FMT_NB_NF:
 		 /* Nothing to do for both normal cases */
 		break;
@@ -155,7 +156,7 @@ static inline int esai_set_config(struct dai *dai,
 		return -EINVAL;
 	}
 
-	switch (config->format & SOF_DAI_FMT_MASTER_MASK) {
+	switch (config->params.format & SOF_DAI_FMT_MASTER_MASK) {
 	case SOF_DAI_FMT_CBM_CFM:
 		/* Nothing to do in the registers */
 		break;

--- a/src/drivers/imx/sai.c
+++ b/src/drivers/imx/sai.c
@@ -95,7 +95,8 @@ static int sai_context_restore(struct dai *dai)
 }
 
 static inline int sai_set_config(struct dai *dai,
-				 struct sof_ipc_dai_config *config)
+				 struct sof_ipc_dai_config *config,
+				 int config_idx)
 {
 	trace_sai("SAI: sai_set_config");
 	uint32_t val_cr2 = 0, val_cr4 = 0, val_cr5 = 0;
@@ -103,7 +104,7 @@ static inline int sai_set_config(struct dai *dai,
 	/* TODO: this value will be provided by config */
 	uint32_t sywd = 32;
 
-	switch (config->format & SOF_DAI_FMT_FORMAT_MASK) {
+	switch (config->params.format & SOF_DAI_FMT_FORMAT_MASK) {
 	case SOF_DAI_FMT_I2S:
 		/*
 		 * Frame low, 1clk before data, one word length for frame sync,
@@ -162,7 +163,7 @@ static inline int sai_set_config(struct dai *dai,
 	}
 
 	/* DAI clock inversion */
-	switch (config->format & SOF_DAI_FMT_INV_MASK) {
+	switch (config->params.format & SOF_DAI_FMT_INV_MASK) {
 	case SOF_DAI_FMT_IB_IF:
 		/* Invert both clocks */
 		val_cr2 ^= REG_SAI_CR2_BCP;
@@ -184,7 +185,7 @@ static inline int sai_set_config(struct dai *dai,
 	}
 
 	/* DAI clock master masks */
-	switch (config->format & SOF_DAI_FMT_MASTER_MASK) {
+	switch (config->params.format & SOF_DAI_FMT_MASTER_MASK) {
 	case SOF_DAI_FMT_CBS_CFS:
 		trace_sai("SAI: codec is slave");
 		val_cr2 |= REG_SAI_CR2_MSEL_MCLK1;

--- a/src/drivers/intel/cavs/alh.c
+++ b/src/drivers/intel/cavs/alh.c
@@ -27,10 +27,11 @@ static int alh_trigger(struct dai *dai, int cmd, int direction)
 	return 0;
 }
 
-static int alh_set_config(struct dai *dai, struct sof_ipc_dai_config *config)
+static int alh_set_config(struct dai *dai, struct sof_ipc_dai_config *config,
+			  int config_idx)
 {
-	trace_alh("alh_set_config() config->format = 0x%4x",
-		  config->format);
+	trace_alh("alh_set_config() config->params.format = 0x%4x",
+		  config->params.format);
 
 	return 0;
 }

--- a/src/drivers/intel/cavs/hda.c
+++ b/src/drivers/intel/cavs/hda.c
@@ -23,7 +23,7 @@ static int hda_trigger(struct dai *dai, int cmd, int direction)
 }
 
 static int hda_set_config(struct dai *dai,
-			  struct sof_ipc_dai_config *config)
+			  struct sof_ipc_dai_config *config, int config_idx)
 {
 	return 0;
 }

--- a/src/include/ipc/dai.h
+++ b/src/include/ipc/dai.h
@@ -16,6 +16,7 @@
 #ifndef __IPC_DAI_H__
 #define __IPC_DAI_H__
 
+#include <ipc/channel_map.h>
 #include <ipc/dai-intel.h>
 #include <ipc/dai-imx.h>
 #include <ipc/header.h>
@@ -63,9 +64,7 @@ enum sof_ipc_dai_type {
 	SOF_DAI_IMX_ESAI,               /**< i.MX ESAI */
 };
 
-/* general purpose DAI configuration */
-struct sof_ipc_dai_config {
-	struct sof_ipc_cmd_hdr hdr;
+struct sof_ipc_dai_base_params {
 	uint32_t type;		/**< DAI type - enum sof_ipc_dai_type */
 	uint32_t dai_index;	/**< index of this type dai */
 
@@ -74,16 +73,26 @@ struct sof_ipc_dai_config {
 	uint16_t reserved16;	/**< alignment */
 
 	/* reserved for future use */
-	uint32_t reserved[8];
+	uint32_t reserved[4];
+} __attribute__((packed));
+
+/* general purpose DAI configuration */
+struct sof_ipc_dai_config {
+	struct sof_ipc_cmd_hdr hdr;
+	struct sof_ipc_dai_base_params params;
+
+	/* reserved for future use */
+	uint32_t reserved[3];
+	uint32_t num_configs;
 
 	/* HW specific data */
 	union {
-		struct sof_ipc_dai_ssp_params ssp;
-		struct sof_ipc_dai_dmic_params dmic;
-		struct sof_ipc_dai_hda_params hda;
-		struct sof_ipc_dai_alh_params alh;
-		struct sof_ipc_dai_esai_params esai;
-		struct sof_ipc_dai_sai_params sai;
+		struct sof_ipc_dai_ssp_params ssp[0];
+		struct sof_ipc_dai_dmic_params dmic[0];
+		struct sof_ipc_dai_hda_params hda[0];
+		struct sof_ipc_dai_alh_params alh[0];
+		struct sof_ipc_dai_esai_params esai[0];
+		struct sof_ipc_dai_sai_params sai[0];
 	};
 } __attribute__((packed));
 

--- a/src/include/ipc/dai.h
+++ b/src/include/ipc/dai.h
@@ -62,6 +62,7 @@ enum sof_ipc_dai_type {
 	SOF_DAI_INTEL_ALH,		/**< Intel ALH */
 	SOF_DAI_IMX_SAI,                /**< i.MX SAI */
 	SOF_DAI_IMX_ESAI,               /**< i.MX ESAI */
+	SOF_DAI_MULTIDAI,		/**< MultiDAI */
 };
 
 struct sof_ipc_dai_base_params {
@@ -74,6 +75,16 @@ struct sof_ipc_dai_base_params {
 
 	/* reserved for future use */
 	uint32_t reserved[4];
+} __attribute__((packed));
+
+struct sof_ipc_multidai_params {
+	struct sof_ipc_cmd_hdr hdr;
+
+	uint32_t num_dais;
+	uint32_t reserved[5];
+
+	struct sof_ipc_stream_map stream_map;
+	struct sof_ipc_dai_base_params params[0];
 } __attribute__((packed));
 
 /* general purpose DAI configuration */
@@ -93,6 +104,7 @@ struct sof_ipc_dai_config {
 		struct sof_ipc_dai_alh_params alh[0];
 		struct sof_ipc_dai_esai_params esai[0];
 		struct sof_ipc_dai_sai_params sai[0];
+		struct sof_ipc_multidai_params multidai[0];
 	};
 } __attribute__((packed));
 

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -197,7 +197,8 @@ struct comp_ops {
 
 	/** set component audio stream parameters */
 	int (*dai_config)(struct comp_dev *dev,
-			  struct sof_ipc_dai_config *dai_config);
+			  struct sof_ipc_dai_config *dai_config,
+			  int config_idx);
 
 	/** used to pass standard and bespoke commands (with optional data) */
 	int (*cmd)(struct comp_dev *dev, int cmd, void *data,
@@ -519,10 +520,10 @@ static inline int comp_reset(struct comp_dev *dev)
  * @return 0 if succeeded, error code otherwise.
  */
 static inline int comp_dai_config(struct comp_dev *dev,
-	struct sof_ipc_dai_config *config)
+	struct sof_ipc_dai_config *config, int config_idx)
 {
 	if (dev->drv->ops.dai_config)
-		return dev->drv->ops.dai_config(dev, config);
+		return dev->drv->ops.dai_config(dev, config, config_idx);
 	return 0;
 }
 

--- a/src/include/sof/drivers/ipc.h
+++ b/src/include/sof/drivers/ipc.h
@@ -236,7 +236,8 @@ struct ipc_comp_dev *ipc_get_comp_by_ppl_id(struct ipc *ipc, uint16_t type,
 /*
  * Configure all DAI components attached to DAI.
  */
-int ipc_comp_dai_config(struct ipc *ipc, struct sof_ipc_dai_config *config);
+int ipc_comp_dai_config(struct ipc *ipc, struct sof_ipc_dai_config *config,
+			int config_idx);
 
 /* send DMA trace host buffer position to host */
 int ipc_dma_trace_send_position(void);

--- a/src/include/sof/drivers/ssp.h
+++ b/src/include/sof/drivers/ssp.h
@@ -235,7 +235,6 @@ struct ssp_pdata {
 	uint32_t psp;
 	uint32_t state[2];		/* SSP_STATE_ for each direction */
 	completion_t drain_complete;
-	struct sof_ipc_dai_config config;
 	struct sof_ipc_dai_ssp_params params;
 };
 

--- a/src/include/sof/lib/dai.h
+++ b/src/include/sof/lib/dai.h
@@ -61,7 +61,8 @@ struct sof_ipc_dai_config;
  * \brief DAI operations - all optional
  */
 struct dai_ops {
-	int (*set_config)(struct dai *dai, struct sof_ipc_dai_config *config);
+	int (*set_config)(struct dai *dai, struct sof_ipc_dai_config *config,
+			  int config_idx);
 	int (*trigger)(struct dai *dai, int cmd, int direction);
 	int (*pm_context_restore)(struct dai *dai);
 	int (*pm_context_store)(struct dai *dai);
@@ -212,9 +213,10 @@ void dai_put(struct dai *dai);
  * \brief Digital Audio interface formatting
  */
 static inline int dai_set_config(struct dai *dai,
-				 struct sof_ipc_dai_config *config)
+				 struct sof_ipc_dai_config *config,
+				 int config_idx)
 {
-	int ret = dai->drv->ops.set_config(dai, config);
+	int ret = dai->drv->ops.set_config(dai, config, config_idx);
 
 	platform_shared_commit(dai, sizeof(*dai));
 

--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -552,12 +552,13 @@ static int ipc_dai_config(uint32_t header)
 	/* copy message with ABI safe method */
 	IPC_COPY_CMD(config, ipc->comp_data);
 
-	trace_ipc("ipc: dai %d.%d -> config ", config.type,
-		  config.dai_index);
+	trace_ipc("ipc: dai %d.%d -> config ", config.params.type,
+		  config.params.dai_index);
 
 	/* send params to all DAI components who use that physical DAI */
 	return ipc_comp_dai_config(ipc,
-				   (struct sof_ipc_dai_config *)ipc->comp_data);
+				   (struct sof_ipc_dai_config *)ipc->comp_data,
+				   0);
 }
 
 static int ipc_glb_dai_message(uint32_t header)

--- a/src/ipc/ipc.c
+++ b/src/ipc/ipc.c
@@ -546,7 +546,8 @@ int ipc_pipeline_complete(struct ipc *ipc, uint32_t comp_id)
 	return ret;
 }
 
-int ipc_comp_dai_config(struct ipc *ipc, struct sof_ipc_dai_config *config)
+int ipc_comp_dai_config(struct ipc *ipc, struct sof_ipc_dai_config *config,
+			int config_idx)
 {
 	bool comp_on_core[PLATFORM_CORE_COUNT] = { false };
 	struct sof_ipc_comp_dai *dai;
@@ -580,9 +581,10 @@ int ipc_comp_dai_config(struct ipc *ipc, struct sof_ipc_dai_config *config)
 			 * set config if comp dai_index matches
 			 * config dai_index.
 			 */
-			if (dai->dai_index == config->dai_index &&
-			    dai->type == config->type) {
-				ret = comp_dai_config(icd->cd, config);
+			if (dai->dai_index == config->params.dai_index &&
+			    dai->type == config->params.type) {
+				ret = comp_dai_config(icd->cd, config,
+						      config_idx);
 				platform_shared_commit(icd, sizeof(*icd));
 				if (ret < 0)
 					break;


### PR DESCRIPTION
Introduces configuration IPC ABI for the MultiDAI

MultiDAI is a new logical DAI type responsible for allocation of multiple physical child DAI and transparently managing them, routing the audio data.

Signed-off-by: Slawomir Blauciak <slawomir.blauciak@linux.intel.com>