### PR TITLE
EQ FIR: Add support for runtime reconfiguration

### DIFF
--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -303,15 +303,13 @@ static int eq_fir_init_coef(struct sof_eq_fir_config *config,
 	/* Initialize 1st phase */
 	for (i = 0; i < nch; i++) {
 		/* Check for not reading past blob response to channel assign
-		 * map. If the blob has smaller channel map then apply for
-		 * additional channels the response that was used for the first
-		 * channel. This allows to use mono blobs to setup multi
-		 * channel equalization without stopping to an error.
+		 * map. The previous channel response is assigned for any
+		 * additional channels in the stream. It allows to use single
+		 * channel configuration to setup multi channel equalization
+		 * with the same response.
 		 */
 		if (i < config->channels_in_config)
 			resp = assign_response[i];
-		else
-			resp = assign_response[0];
 
 		if (resp < 0) {
 			/* Initialize EQ channel to bypass and continue with

--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -290,8 +290,6 @@ static int eq_fir_init_coef(struct sof_eq_fir_config *config,
 	coef_data = &config->data[config->channels_in_config];
 	for (i = 0; i < SOF_EQ_FIR_MAX_RESPONSES; i++) {
 		if (i < config->number_of_responses) {
-			trace_eq("eq_fir_setup(), "
-				 "index of respose start position = %u", j);
 			eq = (struct sof_eq_fir_coef_data *)&coef_data[j];
 			lookup[i] = eq;
 			j += SOF_EQ_FIR_COEF_NHEADER + coef_data[j];
@@ -315,12 +313,17 @@ static int eq_fir_init_coef(struct sof_eq_fir_config *config,
 			/* Initialize EQ channel to bypass and continue with
 			 * next channel response.
 			 */
+			trace_eq("eq_fir_init_coef(), ch %d is set to bypass",
+				 i);
 			fir_reset(&fir[i]);
 			continue;
 		}
 
-		if (resp >= config->number_of_responses)
+		if (resp >= config->number_of_responses) {
+			trace_eq_error("eq_fir_init_coef(), requested response %d"
+				 " exceeds what has been defined", resp);
 			return -EINVAL;
+		}
 
 		/* Initialize EQ coefficients. */
 		eq = lookup[resp];

--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -670,12 +670,6 @@ static int eq_fir_cmd(struct comp_dev *dev, int cmd, void *data,
 	case COMP_CMD_GET_DATA:
 		ret = fir_cmd_get_data(dev, cdata, max_data_size);
 		break;
-	case COMP_CMD_SET_VALUE:
-		trace_eq_with_ids(dev, "eq_fir_cmd(), COMP_CMD_SET_VALUE");
-		break;
-	case COMP_CMD_GET_VALUE:
-		trace_eq_with_ids(dev, "eq_fir_cmd(), COMP_CMD_GET_VALUE");
-		break;
 	default:
 		trace_eq_error_with_ids(dev, "eq_fir_cmd() error: "
 					"invalid command");

--- a/src/audio/eq_fir/fir.c
+++ b/src/audio/eq_fir/fir.c
@@ -33,23 +33,26 @@ void fir_reset(struct fir_state_32x16 *fir)
 	 */
 }
 
-size_t fir_init_coef(struct fir_state_32x16 *fir,
-		     struct sof_eq_fir_coef_data *config)
+int fir_delay_size(struct sof_eq_fir_coef_data *config)
+{
+	/* Check for sane FIR length. The generic version does not
+	 * have other constraints.
+	 */
+	if (config->length > SOF_EQ_FIR_MAX_LENGTH || config->length < 1)
+		return -EINVAL;
+
+	return config->length * sizeof(int32_t);
+}
+
+int fir_init_coef(struct fir_state_32x16 *fir,
+		  struct sof_eq_fir_coef_data *config)
 {
 	fir->rwi = 0;
 	fir->length = (int)config->length;
 	fir->taps = fir->length; /* The same for generic C version */
 	fir->out_shift = (int)config->out_shift;
 	fir->coef = &config->coef[0];
-	fir->delay = NULL;
-
-	/* Check for sane FIR length. The length is constrained to be a
-	 * multiple of 4 for optimized code.
-	 */
-	if (fir->length > SOF_EQ_FIR_MAX_LENGTH || fir->length < 1)
-		return -EINVAL;
-
-	return fir->length * sizeof(int32_t);
+	return 0;
 }
 
 void fir_init_delay(struct fir_state_32x16 *fir, int32_t **data)

--- a/src/audio/eq_fir/fir_hifi3.c
+++ b/src/audio/eq_fir/fir_hifi3.c
@@ -32,30 +32,35 @@ void fir_reset(struct fir_state_32x16 *fir)
 	 */
 }
 
-size_t fir_init_coef(struct fir_state_32x16 *fir,
-		     struct sof_eq_fir_coef_data *config)
+int fir_delay_size(struct sof_eq_fir_coef_data *config)
+{
+	/* Check FIR tap count for implementation specific constraints */
+	if (config->length > SOF_EQ_FIR_MAX_LENGTH || config->length < 4)
+		return -EINVAL;
+
+	/* The optimization requires the tap count to be multiple of four */
+	if (config->length & 0x3)
+		return -EINVAL;
+
+	/* The dual sample version needs one more delay entry. To preserve
+	 * align for 64 bits need to add two.
+	 */
+	return (config->length + 2) * sizeof(int32_t);
+}
+
+int fir_init_coef(struct fir_state_32x16 *fir,
+		  struct sof_eq_fir_coef_data *config)
 {
 	/* The length is taps plus two since the filter computes two
 	 * samples per call. Length plus one would be minimum but the add
 	 * must be even. The even length is needed for 64 bit loads from delay
 	 * lines with 32 bit samples.
 	 */
-	fir->rwp = NULL;
 	fir->taps = (int)config->length;
 	fir->length = fir->taps + 2;
 	fir->out_shift = (int)config->out_shift;
 	fir->coef = (ae_f16x4 *)&config->coef[0];
-	fir->delay = NULL;
-	fir->delay_end = NULL;
-
-	/* Check FIR tap count for implementation specific constraints */
-	if (fir->taps > SOF_EQ_FIR_MAX_LENGTH || fir->taps < 4)
-		return -EINVAL;
-
-	if (fir->taps & 3)
-		return -EINVAL;
-
-	return fir->length * sizeof(int32_t);
+	return 0;
 }
 
 void fir_init_delay(struct fir_state_32x16 *fir, int32_t **data)

--- a/src/include/sof/audio/eq_fir/fir.h
+++ b/src/include/sof/audio/eq_fir/fir.h
@@ -31,8 +31,10 @@ struct fir_state_32x16 {
 
 void fir_reset(struct fir_state_32x16 *fir);
 
-size_t fir_init_coef(struct fir_state_32x16 *fir,
-		     struct sof_eq_fir_coef_data *config);
+int fir_delay_size(struct sof_eq_fir_coef_data *config);
+
+int fir_init_coef(struct fir_state_32x16 *fir,
+		  struct sof_eq_fir_coef_data *config);
 
 void fir_init_delay(struct fir_state_32x16 *fir, int32_t **data);
 

--- a/src/include/sof/audio/eq_fir/fir_hifi2ep.h
+++ b/src/include/sof/audio/eq_fir/fir_hifi2ep.h
@@ -32,8 +32,10 @@ struct fir_state_32x16 {
 
 void fir_reset(struct fir_state_32x16 *fir);
 
-size_t fir_init_coef(struct fir_state_32x16 *fir,
-		     struct sof_eq_fir_coef_data *config);
+int fir_delay_size(struct sof_eq_fir_coef_data *config);
+
+int fir_init_coef(struct fir_state_32x16 *fir,
+		  struct sof_eq_fir_coef_data *config);
 
 void fir_init_delay(struct fir_state_32x16 *fir, int32_t **data);
 

--- a/src/include/sof/audio/eq_fir/fir_hifi3.h
+++ b/src/include/sof/audio/eq_fir/fir_hifi3.h
@@ -31,8 +31,10 @@ struct fir_state_32x16 {
 
 void fir_reset(struct fir_state_32x16 *fir);
 
-size_t fir_init_coef(struct fir_state_32x16 *fir,
-		     struct sof_eq_fir_coef_data *config);
+int fir_delay_size(struct sof_eq_fir_coef_data *config);
+
+int fir_init_coef(struct fir_state_32x16 *fir,
+		  struct sof_eq_fir_coef_data *config);
 
 void fir_init_delay(struct fir_state_32x16 *fir, int32_t **data);
 


### PR DESCRIPTION
This pull request adds to FIR capability to change the configuration during playback or capture plus other changes to align the features with recent updates to IIR. There are four commits:

- Add support for runtime reconfiguration

- Remove handling of set/get value commands

- Extrapolate channels response map with last valid

- Add trace verbosity and align with IIR trace output


