### PR TITLE
pcm_converter: Properly handle CONFIG_FORMAT_CONVERT_HIFI3

### DIFF
--- a/src/include/sof/audio/pcm_converter.h
+++ b/src/include/sof/audio/pcm_converter.h
@@ -15,6 +15,7 @@
 #define __SOF_AUDIO_PCM_CONVERTER_H__
 
 #include <ipc/stream.h>
+#include <config.h>
 #include <stddef.h>
 #include <stdint.h>
 


### PR DESCRIPTION
Include config.h in header where this define is used

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>