### PR TITLE
sof: add all global structures to main firmware context

### DIFF
--- a/src/arch/host/include/arch/lib/cache.h
+++ b/src/arch/host/include/arch/lib/cache.h
@@ -12,8 +12,6 @@
 
 #include <stddef.h>
 
-#define PLATFORM_DCACHE_ALIGN	sizeof(void *)
-
 static inline void dcache_writeback_region(void *addr, size_t size) {}
 static inline void dcache_invalidate_region(void *addr, size_t size) {}
 static inline void icache_invalidate_region(void *addr, size_t size) {}

--- a/src/arch/xtensa/include/arch/init.h
+++ b/src/arch/xtensa/include/arch/init.h
@@ -24,6 +24,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+struct sof;
+
 /**
  * \brief Called in the case of exception.
  */
@@ -129,11 +131,11 @@ static inline void __memmap_init(void) { }
 
 #if CONFIG_SMP
 
-int slave_core_init(void);
+int slave_core_init(struct sof *sof);
 
 #else
 
-static inline int slave_core_init(void) { return 0; }
+static inline int slave_core_init(struct sof *sof) { return 0; }
 
 #endif /* CONFIG_SMP */
 

--- a/src/arch/xtensa/init.c
+++ b/src/arch/xtensa/init.c
@@ -134,7 +134,7 @@ int slave_core_init(struct sof *sof)
 		panic(SOF_IPC_PANIC_ARCH);
 
 	trace_point(TRACE_BOOT_SYS_NOTIFIER);
-	init_system_notify();
+	init_system_notify(sof);
 
 	/* interrupts need to be initialized before any usage */
 	trace_point(TRACE_BOOT_PLATFORM_IRQ);

--- a/src/arch/xtensa/init.c
+++ b/src/arch/xtensa/init.c
@@ -116,6 +116,7 @@ int arch_init(void)
 #include <sof/platform.h>
 #include <sof/schedule/edf_schedule.h>
 #include <sof/schedule/ll_schedule.h>
+#include <sof/schedule/ll_schedule_domain.h>
 #include <sof/schedule/schedule.h>
 #include <sof/schedule/task.h>
 #include <sof/spinlock.h>
@@ -141,8 +142,8 @@ int slave_core_init(void)
 
 	trace_point(TRACE_BOOT_PLATFORM_SCHED);
 	scheduler_init_edf();
-	scheduler_init_ll(platform_timer_domain);
-	scheduler_init_ll(platform_dma_domain);
+	scheduler_init_ll(timer_domain_get());
+	scheduler_init_ll(dma_domain_get());
 
 	/* initialize IDC mechanism */
 	trace_point(TRACE_BOOT_PLATFORM_IDC);

--- a/src/arch/xtensa/init.c
+++ b/src/arch/xtensa/init.c
@@ -123,7 +123,7 @@ int arch_init(void)
 #include <sof/trace/trace.h>
 #include <ipc/trace.h>
 
-int slave_core_init(void)
+int slave_core_init(struct sof *sof)
 {
 	int err;
 

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -712,6 +712,7 @@ static int kpb_buffer_data(struct comp_dev *dev, struct comp_buffer *source,
 	enum kpb_state state_preserved = kpb->state;
 	struct dd *draining_data = &kpb->draining_task_data;
 	size_t sample_width = kpb->config.sampling_width;
+	struct timer *timer = timer_get();
 
 	tracev_kpb_with_ids(dev, "kpb_buffer_data()");
 
@@ -723,7 +724,7 @@ static int kpb_buffer_data(struct comp_dev *dev, struct comp_buffer *source,
 
 	kpb_change_state(kpb, KPB_STATE_BUFFERING);
 
-	timeout = platform_timer_get(platform_timer) +
+	timeout = platform_timer_get(timer) +
 		  clock_ms_to_ticks(PLATFORM_DEFAULT_CLOCK, 1);
 	/* Let's store audio stream data in internal history buffer */
 	while (size_to_copy) {
@@ -737,7 +738,7 @@ static int kpb_buffer_data(struct comp_dev *dev, struct comp_buffer *source,
 		}
 
 		/* Are we stuck in buffering? */
-		current_time = platform_timer_get(platform_timer);
+		current_time = platform_timer_get(timer);
 		if (timeout < current_time) {
 			trace_kpb_error_with_ids(dev, "kpb_buffer_data(): "
 					"timeout of %d [ms] "
@@ -1065,7 +1066,8 @@ static enum task_state kpb_draining_task(void *arg)
 	uint64_t current_time = 0;
 	size_t period_bytes = 0;
 	size_t period_bytes_limit = draining_data->pb_limit;
-	size_t period_copy_start = platform_timer_get(platform_timer);
+	struct timer *timer = timer_get();
+	size_t period_copy_start = platform_timer_get(timer);
 	size_t time_taken = 0;
 	size_t *rt_stream_update = &draining_data->buffered_while_draining;
 	struct comp_data *kpb = comp_get_drvdata(draining_data->dev);
@@ -1077,7 +1079,7 @@ static enum task_state kpb_draining_task(void *arg)
 	/* Change KPB internal state to DRAINING */
 	kpb_change_state(kpb, KPB_STATE_DRAINING);
 
-	draining_time_start = platform_timer_get(platform_timer);
+	draining_time_start = platform_timer_get(timer);
 
 	while (history_depth > 0) {
 		/* Have we received reset request? */
@@ -1089,12 +1091,12 @@ static enum task_state kpb_draining_task(void *arg)
 		/* Are we ready to drain further or host still need some time
 		 * to read the data already provided?
 		 */
-		if (next_copy_time > platform_timer_get(platform_timer)) {
+		if (next_copy_time > platform_timer_get(timer)) {
 			period_bytes = 0;
-			period_copy_start = platform_timer_get(platform_timer);
+			period_copy_start = platform_timer_get(timer);
 			continue;
 		} else if (next_copy_time == 0) {
-			period_copy_start = platform_timer_get(platform_timer);
+			period_copy_start = platform_timer_get(timer);
 		}
 
 		size_to_read = (uint32_t)buff->end_addr - (uint32_t)buff->r_ptr;
@@ -1133,7 +1135,7 @@ static enum task_state kpb_draining_task(void *arg)
 		}
 
 		if (period_bytes >= period_bytes_limit) {
-			current_time = platform_timer_get(platform_timer);
+			current_time = platform_timer_get(timer);
 			time_taken = current_time - period_copy_start;
 			next_copy_time = current_time + drain_interval -
 					 time_taken;
@@ -1151,7 +1153,7 @@ static enum task_state kpb_draining_task(void *arg)
 		}
 	}
 out:
-	draining_time_end = platform_timer_get(platform_timer);
+	draining_time_end = platform_timer_get(timer);
 
 	/* Draining is done. Now switch KPB to copy real time stream
 	 * to client's sink. This state is called "draining on demand"

--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -468,7 +468,7 @@ static int dw_dma_status(struct dma_chan_data *channel,
 	status->state = channel->status;
 	status->r_pos = dma_reg_read(channel->dma, DW_SAR(channel->index));
 	status->w_pos = dma_reg_read(channel->dma, DW_DAR(channel->index));
-	status->timestamp = timer_get_system(platform_timer);
+	status->timestamp = timer_get_system(timer_get());
 
 	return 0;
 }

--- a/src/drivers/dw/ssi-spi.c
+++ b/src/drivers/dw/ssi-spi.c
@@ -133,8 +133,6 @@ struct spi {
 #define spi_reg_write(spi, reg, val) \
 			io_reg_write(spi->plat_data->base + reg, val)
 
-extern struct ipc *_ipc;
-
 static void spi_start(struct spi *spi, int direction)
 {
 	/* disable SPI first before config */
@@ -304,7 +302,7 @@ static enum task_state spi_completion_work(void *data)
 		dcache_invalidate_region(spi->rx_buffer, SPI_BUFFER_SIZE);
 		mailbox_hostbox_write(0, spi->rx_buffer, hdr->size);
 
-		ipc_schedule_process(_ipc);
+		ipc_schedule_process(ipc_get());
 
 		break;
 	case IPC_WRITE:	/* DSP -> HOST */

--- a/src/drivers/generic/dummy-dma.c
+++ b/src/drivers/generic/dummy-dma.c
@@ -314,7 +314,7 @@ static int dummy_dma_status(struct dma_chan_data *channel,
 	status->r_pos = ch->r_pos;
 	status->w_pos = ch->w_pos;
 
-	status->timestamp = timer_get_system(platform_timer);
+	status->timestamp = timer_get_system(timer_get());
 	return 0;
 }
 

--- a/src/drivers/imx/edma.c
+++ b/src/drivers/imx/edma.c
@@ -219,7 +219,7 @@ static int edma_status(struct dma_chan_data *channel,
 	 */
 	status->r_pos = dma_chan_reg_read(channel, EDMA_TCD_SADDR);
 	status->w_pos = dma_chan_reg_read(channel, EDMA_TCD_DADDR);
-	status->timestamp = timer_get_system(platform_timer);
+	status->timestamp = timer_get_system(timer_get());
 	return 0;
 }
 

--- a/src/drivers/imx/ipc.c
+++ b/src/drivers/imx/ipc.c
@@ -9,6 +9,7 @@
 #include <sof/drivers/ipc.h>
 #include <sof/drivers/mu.h>
 #include <sof/lib/alloc.h>
+#include <sof/lib/dma.h>
 #include <sof/lib/mailbox.h>
 #include <sof/lib/wait.h>
 #include <sof/list.h>

--- a/src/drivers/imx/timer.c
+++ b/src/drivers/imx/timer.c
@@ -61,7 +61,7 @@ void platform_dai_timestamp(struct comp_dev *dai,
 		posn->flags |= SOF_TIME_DAI_VALID;
 
 	/* get SSP wallclock - DAI sets this to stream start value */
-	posn->wallclock = timer_get_system(platform_timer) - posn->wallclock;
+	posn->wallclock = timer_get_system(timer_get()) - posn->wallclock;
 	posn->flags |= SOF_TIME_WALL_VALID | SOF_TIME_WALL_64;
 }
 
@@ -69,7 +69,7 @@ void platform_dai_timestamp(struct comp_dev *dai,
 void platform_dai_wallclock(struct comp_dev *dai, uint64_t *wallclock)
 {
 	/* only 1 wallclock on imx8 */
-	*wallclock = timer_get_system(platform_timer);
+	*wallclock = timer_get_system(timer_get());
 }
 
 int timer_register(struct timer *timer, void(*handler)(void *arg), void *arg)

--- a/src/drivers/intel/baytrail/ipc.c
+++ b/src/drivers/intel/baytrail/ipc.c
@@ -21,8 +21,6 @@
 #include <ipc/topology.h>
 #include <stdint.h>
 
-extern struct ipc *_ipc;
-
 /* private data for IPC */
 struct ipc_data {
 	struct ipc_data_host_buffer dh_buffer;
@@ -30,6 +28,7 @@ struct ipc_data {
 
 static void irq_handler(void *arg)
 {
+	struct ipc *ipc = arg;
 	uint32_t isr;
 	uint32_t imrd;
 
@@ -61,7 +60,7 @@ static void irq_handler(void *arg)
 		/* Mask Busy interrupt before return */
 		shim_write(SHIM_IMRD, shim_read(SHIM_IMRD) | SHIM_IMRD_BUSY);
 
-		ipc_schedule_process(_ipc);
+		ipc_schedule_process(ipc);
 	}
 }
 
@@ -93,13 +92,14 @@ void ipc_platform_complete_cmd(void *data)
 
 void ipc_platform_send_msg(void)
 {
+	struct ipc *ipc = ipc_get();
 	struct ipc_msg *msg;
 	uint32_t flags;
 
-	spin_lock_irq(_ipc->lock, flags);
+	spin_lock_irq(ipc->lock, flags);
 
 	/* any messages to send ? */
-	if (list_is_empty(&_ipc->shared_ctx->msg_list))
+	if (list_is_empty(&ipc->shared_ctx->msg_list))
 		goto out;
 
 	/* can't send notification when one is in progress */
@@ -107,7 +107,7 @@ void ipc_platform_send_msg(void)
 		goto out;
 
 	/* now send the message */
-	msg = list_first_item(&_ipc->shared_ctx->msg_list, struct ipc_msg,
+	msg = list_first_item(&ipc->shared_ctx->msg_list, struct ipc_msg,
 			      list);
 	mailbox_dspbox_write(0, msg->tx_data, msg->tx_size);
 	list_item_del(&msg->list);
@@ -117,10 +117,10 @@ void ipc_platform_send_msg(void)
 	shim_write(SHIM_IPCDL, msg->header);
 	shim_write(SHIM_IPCDH, SHIM_IPCDH_BUSY);
 
-	list_item_append(&msg->list, &_ipc->shared_ctx->empty_list);
+	list_item_append(&msg->list, &ipc->shared_ctx->empty_list);
 
 out:
-	spin_unlock_irq(_ipc->lock, flags);
+	spin_unlock_irq(ipc->lock, flags);
 }
 
 struct ipc_data_host_buffer *ipc_platform_get_host_buffer(struct ipc *ipc)
@@ -135,15 +135,13 @@ int platform_ipc_init(struct ipc *ipc)
 	struct ipc_data *iipc;
 	uint32_t imrd, dir, caps, dev;
 
-	_ipc = ipc;
-
 	/* init ipc data */
 	iipc = rzalloc(SOF_MEM_ZONE_SYS, 0, SOF_MEM_CAPS_RAM,
 		       sizeof(struct ipc_data));
-	ipc_set_drvdata(_ipc, iipc);
+	ipc_set_drvdata(ipc, iipc);
 
 	/* schedule */
-	schedule_task_init_edf(&_ipc->ipc_task, &ipc_task_ops, _ipc, 0, 0);
+	schedule_task_init_edf(&ipc->ipc_task, &ipc_task_ops, ipc, 0, 0);
 
 #if CONFIG_HOST_PTABLE
 	/* allocate page table buffer */

--- a/src/drivers/intel/baytrail/timer.c
+++ b/src/drivers/intel/baytrail/timer.c
@@ -168,7 +168,7 @@ void platform_dai_timestamp(struct comp_dev *dai,
 		posn->flags |= SOF_TIME_DAI_VALID;
 
 	/* get SSP wallclock - DAI sets this to stream start value */
-	posn->wallclock = platform_timer_get(platform_timer) - posn->wallclock;
+	posn->wallclock = platform_timer_get(timer_get()) - posn->wallclock;
 	posn->wallclock_hz = clock_get_freq(PLATFORM_DEFAULT_CLOCK);
 	posn->flags |= SOF_TIME_WALL_VALID | SOF_TIME_WALL_64;
 }
@@ -177,7 +177,7 @@ void platform_dai_timestamp(struct comp_dev *dai,
 void platform_dai_wallclock(struct comp_dev *dai, uint64_t *wallclock)
 {
 	/* only 1 wallclock on BYT */
-	*wallclock = platform_timer_get(platform_timer);
+	*wallclock = platform_timer_get(timer_get());
 }
 
 static int platform_timer_register(struct timer *timer,

--- a/src/drivers/intel/cavs/hda-dma.c
+++ b/src/drivers/intel/cavs/hda-dma.c
@@ -225,12 +225,13 @@ static inline int hda_dma_is_buffer_empty(struct dma_chan_data *chan)
 
 static int hda_dma_wait_for_buffer_full(struct dma_chan_data *chan)
 {
-	uint64_t deadline = platform_timer_get(platform_timer) +
+	struct timer *timer = timer_get();
+	uint64_t deadline = platform_timer_get(timer) +
 		clock_ms_to_ticks(PLATFORM_DEFAULT_CLOCK, 1) *
 		HDA_DMA_TIMEOUT / 1000;
 
 	while (!hda_dma_is_buffer_full(chan)) {
-		if (deadline < platform_timer_get(platform_timer)) {
+		if (deadline < platform_timer_get(timer)) {
 			/* safe check in case we've got preempted after read */
 			if (hda_dma_is_buffer_full(chan))
 				return 0;
@@ -249,12 +250,13 @@ static int hda_dma_wait_for_buffer_full(struct dma_chan_data *chan)
 
 static int hda_dma_wait_for_buffer_empty(struct dma_chan_data *chan)
 {
-	uint64_t deadline = platform_timer_get(platform_timer) +
+	struct timer *timer = timer_get();
+	uint64_t deadline = platform_timer_get(timer) +
 		clock_ms_to_ticks(PLATFORM_DEFAULT_CLOCK, 1) *
 		HDA_DMA_TIMEOUT / 1000;
 
 	while (!hda_dma_is_buffer_empty(chan)) {
-		if (deadline < platform_timer_get(platform_timer)) {
+		if (deadline < platform_timer_get(timer)) {
 			/* safe check in case we've got preempted after read */
 			if (hda_dma_is_buffer_empty(chan))
 				return 0;
@@ -555,7 +557,7 @@ static int hda_dma_status(struct dma_chan_data *channel,
 	status->state = channel->status;
 	status->r_pos = dma_chan_reg_read(channel, DGBRP);
 	status->w_pos = dma_chan_reg_read(channel, DGBWP);
-	status->timestamp = timer_get_system(platform_timer);
+	status->timestamp = timer_get_system(timer_get());
 
 	return 0;
 }

--- a/src/drivers/intel/cavs/idc.c
+++ b/src/drivers/intel/cavs/idc.c
@@ -124,6 +124,7 @@ static void idc_irq_handler(void *arg)
  */
 int idc_send_msg(struct idc_msg *msg, uint32_t mode)
 {
+	struct timer *timer = timer_get();
 	struct idc *idc = *idc_get();
 	int core = cpu_get_id();
 	uint64_t deadline;
@@ -136,12 +137,12 @@ int idc_send_msg(struct idc_msg *msg, uint32_t mode)
 	idc_write(IPC_IDCITC(msg->core), core, msg->header | IPC_IDCITC_BUSY);
 
 	if (mode == IDC_BLOCKING) {
-		deadline = platform_timer_get(platform_timer) +
+		deadline = platform_timer_get(timer) +
 			clock_ms_to_ticks(PLATFORM_DEFAULT_CLOCK, 1) *
 			IDC_TIMEOUT / 1000;
 
 		while (!idc->msg_processed[msg->core]) {
-			if (deadline < platform_timer_get(platform_timer)) {
+			if (deadline < platform_timer_get(timer)) {
 				/* safe check in case we've got preempted
 				 * after read
 				 */

--- a/src/drivers/intel/cavs/idc.c
+++ b/src/drivers/intel/cavs/idc.c
@@ -30,8 +30,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-extern struct ipc *_ipc;
-
 /**
  * \brief Returns IDC data.
  * \return Pointer to pointer of IDC data.
@@ -166,7 +164,7 @@ int idc_send_msg(struct idc_msg *msg, uint32_t mode)
  */
 static int idc_pipeline_trigger(uint32_t cmd)
 {
-	struct ipc *ipc = cache_to_uncache(_ipc);
+	struct ipc *ipc = cache_to_uncache(ipc_get());
 	struct sof_ipc_stream *data = ipc->comp_data;
 	struct ipc_comp_dev *pcm_dev;
 	int ret;
@@ -210,7 +208,7 @@ static int idc_pipeline_trigger(uint32_t cmd)
  */
 static int idc_component_command(uint32_t cmd)
 {
-	struct ipc *ipc = cache_to_uncache(_ipc);
+	struct ipc *ipc = cache_to_uncache(ipc_get());
 	struct sof_ipc_ctrl_data *data = ipc->comp_data;
 	struct ipc_comp_dev *comp_dev;
 	int ret;

--- a/src/drivers/intel/haswell/timer.c
+++ b/src/drivers/intel/haswell/timer.c
@@ -62,7 +62,7 @@ void platform_dai_timestamp(struct comp_dev *dai,
 		posn->flags |= SOF_TIME_DAI_VALID;
 
 	/* get SSP wallclock - DAI sets this to stream start value */
-	posn->wallclock = timer_get_system(platform_timer) - posn->wallclock;
+	posn->wallclock = timer_get_system(timer_get()) - posn->wallclock;
 	posn->wallclock_hz = clock_get_freq(PLATFORM_DEFAULT_CLOCK);
 	posn->flags |= SOF_TIME_WALL_VALID | SOF_TIME_WALL_64;
 }
@@ -71,7 +71,7 @@ void platform_dai_timestamp(struct comp_dev *dai,
 void platform_dai_wallclock(struct comp_dev *dai, uint64_t *wallclock)
 {
 	/* only 1 wallclock on HSW */
-	*wallclock = timer_get_system(platform_timer);
+	*wallclock = timer_get_system(timer_get());
 }
 
 int timer_register(struct timer *timer, void (*handler)(void *arg), void *arg)

--- a/src/include/sof/drivers/edma.h
+++ b/src/include/sof/drivers/edma.h
@@ -73,8 +73,6 @@
 #define EDMA_TCD_ATTR_DSIZE_32BYTE	0x0005
 #define EDMA_TCD_ATTR_DSIZE_64BYTE	0x0006
 
-int edma_init(void);
-
 #define EDMA_BUFFER_PERIOD_COUNT	2
 
 #define EDMA_TCD_ALIGNMENT		32

--- a/src/include/sof/drivers/ipc.h
+++ b/src/include/sof/drivers/ipc.h
@@ -12,6 +12,7 @@
 #include <sof/list.h>
 #include <sof/platform.h>
 #include <sof/schedule/task.h>
+#include <sof/sof.h>
 #include <sof/spinlock.h>
 #include <sof/trace/trace.h>
 #include <ipc/header.h>
@@ -109,6 +110,11 @@ struct ipc {
 	((ipc)->private)
 
 extern struct task_ops ipc_task_ops;
+
+static inline struct ipc *ipc_get(void)
+{
+	return sof_get()->ipc;
+}
 
 static inline uint64_t ipc_task_deadline(void *data)
 {

--- a/src/include/sof/drivers/ipc.h
+++ b/src/include/sof/drivers/ipc.h
@@ -13,7 +13,6 @@
 #include <sof/platform.h>
 #include <sof/schedule/task.h>
 #include <sof/spinlock.h>
-#include <sof/trace/dma-trace.h>
 #include <sof/trace/trace.h>
 #include <ipc/header.h>
 #include <user/trace.h>
@@ -91,9 +90,6 @@ struct ipc_shared_context {
 struct ipc {
 	spinlock_t *lock;	/* locking mechanism */
 	void *comp_data;
-
-	/* DMA for Trace*/
-	struct dma_trace_data *dmat;
 
 	/* PM */
 	int pm_prepare_D3;	/* do we need to prepare for D3 */

--- a/src/include/sof/drivers/timer.h
+++ b/src/include/sof/drivers/timer.h
@@ -9,6 +9,7 @@
 #define __SOF_DRIVERS_TIMER_H__
 
 #include <arch/drivers/timer.h>
+#include <sof/sof.h>
 #include <stdint.h>
 
 struct comp_dev;
@@ -24,6 +25,11 @@ int timer_register(struct timer *timer, void (*handler)(void *arg), void *arg);
 void timer_unregister(struct timer *timer, void *arg);
 void timer_enable(struct timer *timer, void *arg, int core);
 void timer_disable(struct timer *timer, void *arg, int core);
+
+static inline struct timer *timer_get(void)
+{
+	return sof_get()->platform_timer;
+}
 
 static inline int64_t timer_set(struct timer *timer, uint64_t ticks)
 {

--- a/src/include/sof/lib/alloc.h
+++ b/src/include/sof/lib/alloc.h
@@ -13,6 +13,7 @@
 #include <sof/common.h>
 #include <sof/lib/cache.h>
 #include <sof/lib/memory.h>
+#include <sof/sof.h>
 #include <sof/spinlock.h>
 #include <sof/string.h>
 #include <sof/trace/trace.h>
@@ -23,7 +24,6 @@
 
 struct dma_copy;
 struct dma_sg_config;
-struct sof;
 
 #define trace_mem_error(__e, ...) \
 	trace_error(TRACE_CLASS_MEM, __e, ##__VA_ARGS__)
@@ -254,5 +254,11 @@ void free_heap(enum mem_zone zone);
 /* status */
 void heap_trace_all(int force);
 void heap_trace(struct mm_heap *heap, int size);
+
+/* retrieve memory map pointer */
+static inline struct mm *memmap_get(void)
+{
+	return sof_get()->memory_map;
+}
 
 #endif /* __SOF_LIB_ALLOC_H__ */

--- a/src/include/sof/lib/clk.h
+++ b/src/include/sof/lib/clk.h
@@ -10,6 +10,7 @@
 #define __SOF_LIB_CLK_H__
 
 #include <platform/lib/clk.h>
+#include <sof/sof.h>
 #include <sof/spinlock.h>
 #include <stdint.h>
 
@@ -42,8 +43,6 @@ struct clock_info {
 	int (*set_freq)(int clock, int freq_idx);
 };
 
-extern struct clock_info *clocks;
-
 uint32_t clock_get_freq(int clock);
 
 void clock_set_freq(int clock, uint32_t hz);
@@ -51,5 +50,10 @@ void clock_set_freq(int clock, uint32_t hz);
 uint64_t clock_ms_to_ticks(int clock, uint64_t ms);
 
 void platform_timer_set_delta(struct timer *timer, uint64_t ns);
+
+static inline struct clock_info *clocks_get(void)
+{
+	return sof_get()->clocks;
+}
 
 #endif /* __SOF_LIB_CLK_H__ */

--- a/src/include/sof/lib/dai.h
+++ b/src/include/sof/lib/dai.h
@@ -122,6 +122,14 @@ struct dai_type_info {
 };
 
 /**
+ * \brief Holds information about array of DAIs grouped by type.
+ */
+struct dai_info {
+	struct dai_type_info *dai_type_array;
+	size_t num_dai_types;
+};
+
+/**
  * \brief API to initialize a platform DAI.
  *
  * \param[in] sof Pointer to firmware main context.

--- a/src/include/sof/lib/dai.h
+++ b/src/include/sof/lib/dai.h
@@ -121,6 +121,11 @@ struct dai_type_info {
 };
 
 /**
+ * \brief API to initialize a platform DAI.
+ */
+int dai_init(void);
+
+/**
  * \brief Plugs platform specific DAI array once initialized into the lib.
  *
  * Lib serves the DAIs to other FW elements with dai_get()

--- a/src/include/sof/lib/dai.h
+++ b/src/include/sof/lib/dai.h
@@ -25,6 +25,7 @@
 #include <stdint.h>
 
 struct dai;
+struct sof;
 struct sof_ipc_dai_config;
 
 /** \addtogroup sof_dai_drivers DAI Drivers
@@ -122,8 +123,10 @@ struct dai_type_info {
 
 /**
  * \brief API to initialize a platform DAI.
+ *
+ * \param[in] sof Pointer to firmware main context.
  */
-int dai_init(void);
+int dai_init(struct sof *sof);
 
 /**
  * \brief Plugs platform specific DAI array once initialized into the lib.

--- a/src/include/sof/lib/dai.h
+++ b/src/include/sof/lib/dai.h
@@ -19,13 +19,13 @@
 #include <platform/lib/dai.h>
 #include <sof/bit.h>
 #include <sof/lib/io.h>
+#include <sof/sof.h>
 #include <sof/spinlock.h>
 #include <errno.h>
 #include <stddef.h>
 #include <stdint.h>
 
 struct dai;
-struct sof;
 struct sof_ipc_dai_config;
 
 /** \addtogroup sof_dai_drivers DAI Drivers
@@ -135,16 +135,6 @@ struct dai_info {
  * \param[in] sof Pointer to firmware main context.
  */
 int dai_init(struct sof *sof);
-
-/**
- * \brief Plugs platform specific DAI array once initialized into the lib.
- *
- * Lib serves the DAIs to other FW elements with dai_get()
- *
- * \param[in] dai_type_array Array of DAI arrays grouped by type.
- * \param[in] num_dai_types Number of elements in the dai_type_array.
- */
-void dai_install(struct dai_type_info *dai_type_array, size_t num_dai_types);
 
 /**
  * \brief API to request a platform DAI.
@@ -279,6 +269,11 @@ static inline void dai_update_bits(struct dai *dai, uint32_t reg,
 				   uint32_t mask, uint32_t value)
 {
 	io_reg_update_bits(dai_base(dai) + reg, mask, value);
+}
+
+static inline struct dai_info *dai_info_get(void)
+{
+	return sof_get()->dai_info;
 }
 
 /** @}*/

--- a/src/include/sof/lib/dma.h
+++ b/src/include/sof/lib/dma.h
@@ -216,6 +216,11 @@ struct dma_chan_data {
 	void *private;
 };
 
+struct dma_info {
+	struct dma *dma_array;
+	size_t num_dmas;
+};
+
 extern struct dma dma[];
 
 /**

--- a/src/include/sof/lib/dma.h
+++ b/src/include/sof/lib/dma.h
@@ -22,13 +22,13 @@
 #include <sof/lib/alloc.h>
 #include <sof/lib/cache.h>
 #include <sof/lib/io.h>
+#include <sof/sof.h>
 #include <sof/spinlock.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
 struct comp_buffer;
-struct sof;
 
 /** \addtogroup sof_dma_drivers DMA Drivers
  *  DMA Drivers API specification.
@@ -229,16 +229,6 @@ extern struct dma dma[];
  * \param[in] sof Pointer to firmware main context.
  */
 int dmac_init(struct sof *sof);
-
-/**
- *  \brief Plugs platform specific DMA array once initialized into the lib.
- *
- *  Lib serves the DMAs to other FW elements by dma_get()
- *
- *  \param[in] dma_array Array of DMAs.
- *  \param[in] num_dmas Number of elements in dma_array.
- */
-void dma_install(struct dma *dma_array, size_t num_dmas);
 
 /**
  * \brief API to request a platform DMAC.
@@ -539,6 +529,11 @@ int dma_copy_to_host_nowait(struct dma_copy *dc, struct dma_sg_config *host_sg,
 	int32_t host_offset, void *local_ptr, int32_t size);
 
 int dma_copy_set_stream_tag(struct dma_copy *dc, uint32_t stream_tag);
+
+static inline struct dma_info *dma_info_get(void)
+{
+	return sof_get()->dma_info;
+}
 
 /** @}*/
 

--- a/src/include/sof/lib/dma.h
+++ b/src/include/sof/lib/dma.h
@@ -218,6 +218,11 @@ struct dma_chan_data {
 extern struct dma dma[];
 
 /**
+ * \brief API to initialize a platform DMA controllers.
+ */
+int dmac_init(void);
+
+/**
  *  \brief Plugs platform specific DMA array once initialized into the lib.
  *
  *  Lib serves the DMAs to other FW elements by dma_get()

--- a/src/include/sof/lib/dma.h
+++ b/src/include/sof/lib/dma.h
@@ -28,6 +28,7 @@
 #include <stdint.h>
 
 struct comp_buffer;
+struct sof;
 
 /** \addtogroup sof_dma_drivers DMA Drivers
  *  DMA Drivers API specification.
@@ -219,8 +220,10 @@ extern struct dma dma[];
 
 /**
  * \brief API to initialize a platform DMA controllers.
+ *
+ * \param[in] sof Pointer to firmware main context.
  */
-int dmac_init(void);
+int dmac_init(struct sof *sof);
 
 /**
  *  \brief Plugs platform specific DMA array once initialized into the lib.

--- a/src/include/sof/lib/notifier.h
+++ b/src/include/sof/lib/notifier.h
@@ -8,6 +8,8 @@
 #ifndef __SOF_LIB_NOTIFIER_H__
 #define __SOF_LIB_NOTIFIER_H__
 
+#include <sof/common.h>
+#include <sof/lib/memory.h>
 #include <sof/list.h>
 #include <sof/spinlock.h>
 #include <stdint.h>
@@ -34,6 +36,13 @@ struct notify {
 	spinlock_t *lock;	/* notifier lock */
 	struct list_item list[NOTIFIER_ID_COUNT]; /* list of callback handles */
 };
+
+struct notify_data {
+	void *caller;
+	enum notify_id type;
+	uint32_t data_size;
+	void *data;
+} __aligned(PLATFORM_DCACHE_ALIGN);
 
 #ifdef CLK_SSP
 #define NOTIFIER_CLK_CHANGE_ID(clk) \

--- a/src/include/sof/lib/notifier.h
+++ b/src/include/sof/lib/notifier.h
@@ -11,10 +11,9 @@
 #include <sof/common.h>
 #include <sof/lib/memory.h>
 #include <sof/list.h>
+#include <sof/sof.h>
 #include <sof/spinlock.h>
 #include <stdint.h>
-
-struct sof;
 
 /* notifier target core masks */
 #define NOTIFIER_TARGET_CORE_MASK(x)	(1 << (x))
@@ -67,5 +66,10 @@ void notifier_event(void *caller, enum notify_id type, uint32_t core_mask,
 void init_system_notify(struct sof *sof);
 
 void free_system_notify(void);
+
+static inline struct notify_data *notify_data_get(void)
+{
+	return sof_get()->notify_data;
+}
 
 #endif /* __SOF_LIB_NOTIFIER_H__ */

--- a/src/include/sof/lib/notifier.h
+++ b/src/include/sof/lib/notifier.h
@@ -14,6 +14,8 @@
 #include <sof/spinlock.h>
 #include <stdint.h>
 
+struct sof;
+
 /* notifier target core masks */
 #define NOTIFIER_TARGET_CORE_MASK(x)	(1 << (x))
 #define NOTIFIER_TARGET_CORE_LOCAL	NOTIFIER_TARGET_CORE_MASK(cpu_get_id())
@@ -62,7 +64,7 @@ void notifier_notify_remote(void);
 void notifier_event(void *caller, enum notify_id type, uint32_t core_mask,
 		    void *data, uint32_t data_size);
 
-void init_system_notify(void);
+void init_system_notify(struct sof *sof);
 
 void free_system_notify(void);
 

--- a/src/include/sof/lib/pm_runtime.h
+++ b/src/include/sof/lib/pm_runtime.h
@@ -16,12 +16,11 @@
 #define __SOF_LIB_PM_RUNTIME_H__
 
 #include <platform/lib/pm_runtime.h>
+#include <sof/sof.h>
 #include <sof/spinlock.h>
 #include <sof/trace/trace.h>
 #include <user/trace.h>
 #include <stdint.h>
-
-struct sof;
 
 /** \addtogroup pm_runtime PM Runtime
  *  PM runtime specification.
@@ -118,6 +117,16 @@ void pm_runtime_disable(enum pm_runtime_context context, uint32_t index);
  * @return true if the resource is active or pm disabled, false otherwise.
  */
 bool pm_runtime_is_active(enum pm_runtime_context context, uint32_t index);
+
+/**
+ * \brief Retrieves pointer to runtime power management data.
+ *
+ * @return Runtime power management data pointer.
+ */
+static inline struct pm_runtime_data *pm_runtime_data_get(void)
+{
+	return sof_get()->prd;
+}
 
 /** @}*/
 

--- a/src/include/sof/lib/pm_runtime.h
+++ b/src/include/sof/lib/pm_runtime.h
@@ -21,6 +21,8 @@
 #include <user/trace.h>
 #include <stdint.h>
 
+struct sof;
+
 /** \addtogroup pm_runtime PM Runtime
  *  PM runtime specification.
  *  @{
@@ -57,7 +59,7 @@ struct pm_runtime_data {
 /**
  * \brief Initializes runtime power management.
  */
-void pm_runtime_init(void);
+void pm_runtime_init(struct sof *sof);
 
 /**
  * \brief Retrieves power management resource (async).

--- a/src/include/sof/schedule/ll_schedule_domain.h
+++ b/src/include/sof/schedule/ll_schedule_domain.h
@@ -13,6 +13,7 @@
 #include <sof/lib/alloc.h>
 #include <sof/lib/cpu.h>
 #include <sof/lib/clk.h>
+#include <sof/sof.h>
 #include <sof/spinlock.h>
 #include <sof/trace/trace.h>
 #include <ipc/topology.h>
@@ -56,6 +57,16 @@ struct ll_schedule_domain {
 #define ll_sch_domain_set_pdata(domain, data) ((domain)->private = (data))
 
 #define ll_sch_domain_get_pdata(domain) ((domain)->private)
+
+static inline struct ll_schedule_domain *timer_domain_get(void)
+{
+	return sof_get()->platform_timer_domain;
+}
+
+static inline struct ll_schedule_domain *dma_domain_get(void)
+{
+	return sof_get()->platform_dma_domain;
+}
 
 static inline struct ll_schedule_domain *domain_init
 				(int type, int clk, bool synchronous,

--- a/src/include/sof/sof.h
+++ b/src/include/sof/sof.h
@@ -12,6 +12,7 @@
 #include <sof/common.h>
 #include <sof/lib/memory.h>
 
+struct clock_info;
 struct dma_trace_data;
 struct ipc;
 struct sa;
@@ -40,6 +41,9 @@ struct sof {
 
 	/* generic trace structure */
 	struct trace *trace;
+
+	/* platform clock information */
+	struct clock_info *clocks;
 
 	__aligned(PLATFORM_DCACHE_ALIGN) int alignment[0];
 } __aligned(PLATFORM_DCACHE_ALIGN);

--- a/src/include/sof/sof.h
+++ b/src/include/sof/sof.h
@@ -14,6 +14,7 @@
 
 struct clock_info;
 struct dai_info;
+struct dma_info;
 struct dma_trace_data;
 struct ipc;
 struct ll_schedule_domain;
@@ -71,6 +72,9 @@ struct sof {
 
 	/* platform dai information */
 	struct dai_info *dai_info;
+
+	/* platform DMA information */
+	struct dma_info *dma_info;
 
 	__aligned(PLATFORM_DCACHE_ALIGN) int alignment[0];
 } __aligned(PLATFORM_DCACHE_ALIGN);

--- a/src/include/sof/sof.h
+++ b/src/include/sof/sof.h
@@ -17,6 +17,7 @@ struct dma_trace_data;
 struct ipc;
 struct ll_schedule_domain;
 struct mm;
+struct notify_data;
 struct pm_runtime_data;
 struct sa;
 struct timer;
@@ -63,6 +64,9 @@ struct sof {
 
 	/* runtime power management data */
 	struct pm_runtime_data *prd;
+
+	/* shared notifier data */
+	struct notify_data *notify_data;
 
 	__aligned(PLATFORM_DCACHE_ALIGN) int alignment[0];
 } __aligned(PLATFORM_DCACHE_ALIGN);

--- a/src/include/sof/sof.h
+++ b/src/include/sof/sof.h
@@ -13,6 +13,7 @@
 #include <sof/lib/memory.h>
 
 struct clock_info;
+struct dai_info;
 struct dma_trace_data;
 struct ipc;
 struct ll_schedule_domain;
@@ -67,6 +68,9 @@ struct sof {
 
 	/* shared notifier data */
 	struct notify_data *notify_data;
+
+	/* platform dai information */
+	struct dai_info *dai_info;
 
 	__aligned(PLATFORM_DCACHE_ALIGN) int alignment[0];
 } __aligned(PLATFORM_DCACHE_ALIGN);

--- a/src/include/sof/sof.h
+++ b/src/include/sof/sof.h
@@ -16,6 +16,7 @@ struct clock_info;
 struct dma_trace_data;
 struct ipc;
 struct sa;
+struct timer;
 struct trace;
 
 /**
@@ -44,6 +45,9 @@ struct sof {
 
 	/* platform clock information */
 	struct clock_info *clocks;
+
+	/* default platform timer */
+	struct timer *platform_timer;
 
 	__aligned(PLATFORM_DCACHE_ALIGN) int alignment[0];
 } __aligned(PLATFORM_DCACHE_ALIGN);

--- a/src/include/sof/sof.h
+++ b/src/include/sof/sof.h
@@ -15,6 +15,7 @@
 struct clock_info;
 struct dma_trace_data;
 struct ipc;
+struct ll_schedule_domain;
 struct sa;
 struct timer;
 struct trace;
@@ -48,6 +49,12 @@ struct sof {
 
 	/* default platform timer */
 	struct timer *platform_timer;
+
+	/* timer domain for driving timer LL scheduler */
+	struct ll_schedule_domain *platform_timer_domain;
+
+	/* DMA domain for driving DMA LL scheduler */
+	struct ll_schedule_domain *platform_dma_domain;
 
 	__aligned(PLATFORM_DCACHE_ALIGN) int alignment[0];
 } __aligned(PLATFORM_DCACHE_ALIGN);

--- a/src/include/sof/sof.h
+++ b/src/include/sof/sof.h
@@ -16,6 +16,7 @@ struct clock_info;
 struct dma_trace_data;
 struct ipc;
 struct ll_schedule_domain;
+struct mm;
 struct sa;
 struct timer;
 struct trace;
@@ -55,6 +56,9 @@ struct sof {
 
 	/* DMA domain for driving DMA LL scheduler */
 	struct ll_schedule_domain *platform_dma_domain;
+
+	/* memory map */
+	struct mm *memory_map;
 
 	__aligned(PLATFORM_DCACHE_ALIGN) int alignment[0];
 } __aligned(PLATFORM_DCACHE_ALIGN);

--- a/src/include/sof/sof.h
+++ b/src/include/sof/sof.h
@@ -15,6 +15,7 @@
 struct dma_trace_data;
 struct ipc;
 struct sa;
+struct trace;
 
 /**
  * \brief General firmware context.
@@ -36,6 +37,9 @@ struct sof {
 
 	/* DMA for Trace*/
 	struct dma_trace_data *dmat;
+
+	/* generic trace structure */
+	struct trace *trace;
 
 	__aligned(PLATFORM_DCACHE_ALIGN) int alignment[0];
 } __aligned(PLATFORM_DCACHE_ALIGN);

--- a/src/include/sof/sof.h
+++ b/src/include/sof/sof.h
@@ -9,12 +9,20 @@
 #define __SOF_SOF_H__
 
 #include <arch/sof.h>
+#include <sof/common.h>
+#include <sof/lib/memory.h>
 
 struct dma_trace_data;
 struct ipc;
 struct sa;
 
-/* general firmware context */
+/**
+ * \brief General firmware context.
+ * This structure holds all the global pointers, which can potentially
+ * be accessed by SMP code, hence it should be aligned to platform's
+ * data cache line size. Alignments in the both beginning and end are needed
+ * to avoid potential before and after data evictions.
+ */
 struct sof {
 	/* init data */
 	int argc;
@@ -28,6 +36,8 @@ struct sof {
 
 	/* DMA for Trace*/
 	struct dma_trace_data *dmat;
-};
+
+	__aligned(PLATFORM_DCACHE_ALIGN) int alignment[0];
+} __aligned(PLATFORM_DCACHE_ALIGN);
 
 #endif /* __SOF_SOF_H__ */

--- a/src/include/sof/sof.h
+++ b/src/include/sof/sof.h
@@ -17,6 +17,7 @@ struct dma_trace_data;
 struct ipc;
 struct ll_schedule_domain;
 struct mm;
+struct pm_runtime_data;
 struct sa;
 struct timer;
 struct trace;
@@ -59,6 +60,9 @@ struct sof {
 
 	/* memory map */
 	struct mm *memory_map;
+
+	/* runtime power management data */
+	struct pm_runtime_data *prd;
 
 	__aligned(PLATFORM_DCACHE_ALIGN) int alignment[0];
 } __aligned(PLATFORM_DCACHE_ALIGN);

--- a/src/include/sof/sof.h
+++ b/src/include/sof/sof.h
@@ -40,4 +40,6 @@ struct sof {
 	__aligned(PLATFORM_DCACHE_ALIGN) int alignment[0];
 } __aligned(PLATFORM_DCACHE_ALIGN);
 
+struct sof *sof_get(void);
+
 #endif /* __SOF_SOF_H__ */

--- a/src/include/sof/trace/dma-trace.h
+++ b/src/include/sof/trace/dma-trace.h
@@ -10,6 +10,7 @@
 
 #include <sof/lib/dma.h>
 #include <sof/schedule/task.h>
+#include <sof/sof.h>
 #include <sof/spinlock.h>
 #include <stdint.h>
 
@@ -56,6 +57,11 @@ void dma_trace_off(void);
 
 void dtrace_event(const char *e, uint32_t size);
 void dtrace_event_atomic(const char *e, uint32_t length);
+
+static inline struct dma_trace_data *dma_trace_data_get(void)
+{
+	return sof_get()->dmat;
+}
 
 static inline uint32_t dtrace_calc_buf_margin(struct dma_trace_buf *buffer)
 {

--- a/src/include/sof/trace/trace.h
+++ b/src/include/sof/trace/trace.h
@@ -19,6 +19,8 @@
 #include <platform/trace/trace.h>
 #endif
 #include <sof/common.h>
+#include <sof/sof.h>
+#include <sof/spinlock_t.h>
 #include <sof/trace/preproc.h>
 #include <config.h>
 #include <stdint.h>
@@ -27,6 +29,12 @@
 #endif
 
 struct sof;
+
+struct trace {
+	uint32_t pos ;	/* trace position */
+	uint32_t enable;
+	spinlock_t *lock; /* locking mechanism */
+};
 
 /* bootloader trace values */
 #define TRACE_BOOT_LDR_ENTRY		0x100
@@ -170,6 +178,11 @@ void trace_flush(void);
 void trace_on(void);
 void trace_off(void);
 void trace_init(struct sof *sof);
+
+static inline struct trace *trace_get(void)
+{
+	return sof_get()->trace;
+}
 
 #define trace_unused(class, id_0, id_1, format, ...) \
 	UNUSED(id_0, id_1, ##__VA_ARGS__)

--- a/src/init/init.c
+++ b/src/init/init.c
@@ -33,7 +33,7 @@ struct sof *sof_get(void)
 
 int master_core_init(int argc, char *argv[], struct sof *sof)
 {
-	int err, i;
+	int err;
 
 	/* setup context */
 	sof->argc = argc;
@@ -62,11 +62,6 @@ int master_core_init(int argc, char *argv[], struct sof *sof)
 
 	trace_point(TRACE_BOOT_SYS_POWER);
 	pm_runtime_init();
-
-	/* Turn off memory for all unused cores */
-	for (i = 0; i < PLATFORM_CORE_COUNT; i++)
-		if (i != PLATFORM_MASTER_CORE_ID)
-			pm_runtime_put(CORE_MEMORY_POW, i);
 
 	/* init the platform */
 	err = platform_init(sof);

--- a/src/init/init.c
+++ b/src/init/init.c
@@ -61,7 +61,7 @@ int master_core_init(int argc, char *argv[], struct sof *sof)
 	init_system_notify();
 
 	trace_point(TRACE_BOOT_SYS_POWER);
-	pm_runtime_init();
+	pm_runtime_init(sof);
 
 	/* init the platform */
 	err = platform_init(sof);

--- a/src/init/init.c
+++ b/src/init/init.c
@@ -26,6 +26,11 @@
 /* main firmware context */
 static struct sof sof;
 
+struct sof *sof_get(void)
+{
+	return &sof;
+}
+
 int master_core_init(int argc, char *argv[], struct sof *sof)
 {
 	int err, i;

--- a/src/init/init.c
+++ b/src/init/init.c
@@ -47,7 +47,7 @@ int master_core_init(int argc, char *argv[], struct sof *sof)
 
 	/* initialise system services */
 	trace_point(TRACE_BOOT_SYS_HEAP);
-	platform_init_memmap();
+	platform_init_memmap(sof);
 	init_heap(sof);
 
 	interrupt_init();

--- a/src/init/init.c
+++ b/src/init/init.c
@@ -85,7 +85,7 @@ int main(int argc, char *argv[])
 	if (cpu_get_id() == PLATFORM_MASTER_CORE_ID)
 		err = master_core_init(argc, argv, &sof);
 	else
-		err = slave_core_init();
+		err = slave_core_init(&sof);
 
 	/* should never get here */
 	panic(SOF_IPC_PANIC_TASK);

--- a/src/init/init.c
+++ b/src/init/init.c
@@ -58,7 +58,7 @@ int master_core_init(int argc, char *argv[], struct sof *sof)
 #endif
 
 	trace_point(TRACE_BOOT_SYS_NOTIFIER);
-	init_system_notify();
+	init_system_notify(sof);
 
 	trace_point(TRACE_BOOT_SYS_POWER);
 	pm_runtime_init(sof);

--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -605,7 +605,7 @@ static int ipc_pm_context_save(uint32_t header)
 	/* TODO: clear any outstanding platform IRQs - TODO refine */
 
 	/* TODO: stop ALL timers */
-	platform_timer_stop(platform_timer);
+	platform_timer_stop(timer_get());
 
 	/* TODO: disable SSP and DMA HW */
 
@@ -706,15 +706,16 @@ static int ipc_dma_trace_config(uint32_t header)
 	uint32_t ring_size;
 #endif
 	struct sof_ipc_dma_trace_params_ext params;
+	struct timer *timer = timer_get();
 	int err;
 
 	/* copy message with ABI safe method */
 	IPC_COPY_CMD(params, _ipc->comp_data);
 
 	if (iCS(header) == SOF_IPC_TRACE_DMA_PARAMS_EXT)
-		platform_timer_set_delta(platform_timer, params.timestamp_ns);
+		platform_timer_set_delta(timer, params.timestamp_ns);
 	else
-		platform_timer->delta = 0;
+		timer->delta = 0;
 
 #if CONFIG_SUECREEK
 	return 0;

--- a/src/ipc/ipc.c
+++ b/src/ipc/ipc.c
@@ -459,7 +459,6 @@ int ipc_init(struct sof *sof)
 			   sizeof(*sof->ipc));
 	sof->ipc->comp_data = rzalloc(SOF_MEM_ZONE_SYS, 0, SOF_MEM_CAPS_RAM,
 				      SOF_IPC_MSG_MAX_SIZE);
-	sof->ipc->dmat = sof->dmat;
 
 	spinlock_init(&sof->ipc->lock);
 

--- a/src/lib/agent.c
+++ b/src/lib/agent.c
@@ -43,7 +43,7 @@ static enum task_state validate(void *data)
 	uint64_t current;
 	uint64_t delta;
 
-	current = platform_timer_get(platform_timer);
+	current = platform_timer_get(timer_get());
 	delta = current - sa->last_check;
 
 	/* panic timeout */
@@ -87,5 +87,5 @@ void sa_init(struct sof *sof, uint64_t timeout)
 	schedule_task(&sa->work, 0, timeout);
 
 	/* set last check time to now to give time for boot completion */
-	sa->last_check = platform_timer_get(platform_timer);
+	sa->last_check = platform_timer_get(timer_get());
 }

--- a/src/lib/clk.c
+++ b/src/lib/clk.c
@@ -43,14 +43,14 @@ static inline uint32_t clock_get_nearest_freq_idx(const struct freq_table *tab,
 
 uint32_t clock_get_freq(int clock)
 {
-	struct clock_info *clk_info = &clocks[clock];
+	struct clock_info *clk_info = clocks_get() + clock;
 
 	return clk_info->freqs[clk_info->current_freq_idx].freq;
 }
 
 void clock_set_freq(int clock, uint32_t hz)
 {
-	struct clock_info *clk_info = &clocks[clock];
+	struct clock_info *clk_info = clocks_get() + clock;
 	uint32_t idx;
 	uint32_t flags;
 
@@ -89,14 +89,14 @@ void clock_set_freq(int clock, uint32_t hz)
 
 uint64_t clock_ms_to_ticks(int clock, uint64_t ms)
 {
-	struct clock_info *clk_info = &clocks[clock];
+	struct clock_info *clk_info = clocks_get() + clock;
 
 	return clk_info->freqs[clk_info->current_freq_idx].ticks_per_msec * ms;
 }
 
 void platform_timer_set_delta(struct timer *timer, uint64_t ns)
 {
-	struct clock_info *clk_info = &clocks[PLATFORM_DEFAULT_CLOCK];
+	struct clock_info *clk_info = clocks_get() + PLATFORM_DEFAULT_CLOCK;
 	uint32_t ticks_per_msec =
 		clk_info->freqs[clk_info->current_freq_idx].ticks_per_msec;
 	uint64_t ticks;

--- a/src/lib/dai.c
+++ b/src/lib/dai.c
@@ -14,11 +14,6 @@
 
 #define trace_dai(__e, ...) trace_event(TRACE_CLASS_DAI, __e, ##__VA_ARGS__)
 
-struct dai_info {
-	struct dai_type_info *dai_type_array;
-	size_t num_dai_types;
-};
-
 static struct dai_info lib_dai = {
 	.dai_type_array = NULL,
 	.num_dai_types = 0

--- a/src/lib/dai.c
+++ b/src/lib/dai.c
@@ -14,23 +14,13 @@
 
 #define trace_dai(__e, ...) trace_event(TRACE_CLASS_DAI, __e, ##__VA_ARGS__)
 
-static struct dai_info lib_dai = {
-	.dai_type_array = NULL,
-	.num_dai_types = 0
-};
-
-void dai_install(struct dai_type_info *dai_type_array, size_t num_dai_types)
-{
-	lib_dai.dai_type_array = dai_type_array;
-	lib_dai.num_dai_types = num_dai_types;
-}
-
 static inline struct dai_type_info *dai_find_type(uint32_t type)
 {
+	struct dai_info *info = dai_info_get();
 	struct dai_type_info *dti;
 
-	for (dti = lib_dai.dai_type_array;
-	     dti < lib_dai.dai_type_array + lib_dai.num_dai_types; dti++) {
+	for (dti = info->dai_type_array;
+	     dti < info->dai_type_array + info->num_dai_types; dti++) {
 		if (dti->type == type)
 			return dti;
 	}

--- a/src/lib/dma.c
+++ b/src/lib/dma.c
@@ -17,11 +17,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-struct dma_info {
-	struct dma *dma_array;
-	size_t num_dmas;
-};
-
 static struct dma_info lib_dma = {
 	.dma_array = NULL,
 	.num_dmas = 0

--- a/src/lib/dma.c
+++ b/src/lib/dma.c
@@ -17,30 +17,20 @@
 #include <stddef.h>
 #include <stdint.h>
 
-static struct dma_info lib_dma = {
-	.dma_array = NULL,
-	.num_dmas = 0
-};
-
-void dma_install(struct dma *dma_array, size_t num_dmas)
-{
-	lib_dma.dma_array = dma_array;
-	lib_dma.num_dmas = num_dmas;
-}
-
 struct dma *dma_get(uint32_t dir, uint32_t cap, uint32_t dev, uint32_t flags)
 {
+	struct dma_info *info = dma_info_get();
 	int users, ret;
 	int min_users = INT32_MAX;
 	struct dma *d = NULL, *dmin = NULL;
 
-	if (!lib_dma.num_dmas) {
+	if (!info->num_dmas) {
 		trace_error(TRACE_CLASS_DMA, "dma_get(): No DMACs installed");
 		return NULL;
 	}
 
 	/* find DMAC with free channels that matches request */
-	for (d = lib_dma.dma_array; d < lib_dma.dma_array + lib_dma.num_dmas;
+	for (d = info->dma_array; d < info->dma_array + info->num_dmas;
 	     d++) {
 		/* skip if this DMAC does not support the requested dir */
 		if (dir && (d->plat_data.dir & dir) == 0)
@@ -82,8 +72,8 @@ struct dma *dma_get(uint32_t dir, uint32_t cap, uint32_t dev, uint32_t flags)
 		trace_error(TRACE_CLASS_DMA, "No DMAC dir %d caps 0x%x "
 			    "dev 0x%x flags 0x%x", dir, cap, dev, flags);
 
-		for (d = lib_dma.dma_array;
-		     d < lib_dma.dma_array + lib_dma.num_dmas;
+		for (d = info->dma_array;
+		     d < info->dma_array + info->num_dmas;
 		     d++) {
 			trace_error(TRACE_CLASS_DMA, " DMAC ID %d users %d "
 				    "busy channels %d", d->plat_data.id,

--- a/src/lib/notifier.c
+++ b/src/lib/notifier.c
@@ -22,13 +22,6 @@
 #define trace_notifier_error(__e, ...) \
 	trace_error(TRACE_CLASS_NOTIFIER, __e, ##__VA_ARGS__)
 
-struct notify_data {
-	void *caller;
-	enum notify_id type;
-	uint32_t data_size;
-	void *data;
-} __aligned(PLATFORM_DCACHE_ALIGN);
-
 static struct notify_data _notify_data[PLATFORM_CORE_COUNT]
 	__aligned(PLATFORM_DCACHE_ALIGN);
 

--- a/src/lib/notifier.c
+++ b/src/lib/notifier.c
@@ -12,6 +12,7 @@
 #include <sof/lib/cpu.h>
 #include <sof/lib/notifier.h>
 #include <sof/list.h>
+#include <sof/sof.h>
 #include <sof/spinlock.h>
 #include <ipc/topology.h>
 
@@ -165,7 +166,7 @@ void notifier_event(void *caller, enum notify_id type, uint32_t core_mask,
 	}
 }
 
-void init_system_notify(void)
+void init_system_notify(struct sof *sof)
 {
 	struct notify **notify = arch_notify_get();
 	int i;

--- a/src/lib/pm_runtime.c
+++ b/src/lib/pm_runtime.c
@@ -12,6 +12,7 @@
 
 #include <sof/lib/alloc.h>
 #include <sof/lib/pm_runtime.h>
+#include <sof/sof.h>
 #include <sof/spinlock.h>
 #include <ipc/topology.h>
 #include <stdint.h>
@@ -19,7 +20,7 @@
 /** \brief Runtime power management data pointer. */
 static struct pm_runtime_data *prd;
 
-void pm_runtime_init(void)
+void pm_runtime_init(struct sof *sof)
 {
 	prd = rzalloc(SOF_MEM_ZONE_SYS, 0, SOF_MEM_CAPS_RAM, sizeof(*prd));
 	spinlock_init(&prd->lock);

--- a/src/lib/pm_runtime.c
+++ b/src/lib/pm_runtime.c
@@ -21,8 +21,6 @@ static struct pm_runtime_data *prd;
 
 void pm_runtime_init(void)
 {
-	trace_pm("pm_runtime_init()");
-
 	prd = rzalloc(SOF_MEM_ZONE_SYS, 0, SOF_MEM_CAPS_RAM, sizeof(*prd));
 	spinlock_init(&prd->lock);
 

--- a/src/lib/pm_runtime.c
+++ b/src/lib/pm_runtime.c
@@ -17,15 +17,13 @@
 #include <ipc/topology.h>
 #include <stdint.h>
 
-/** \brief Runtime power management data pointer. */
-static struct pm_runtime_data *prd;
-
 void pm_runtime_init(struct sof *sof)
 {
-	prd = rzalloc(SOF_MEM_ZONE_SYS, 0, SOF_MEM_CAPS_RAM, sizeof(*prd));
-	spinlock_init(&prd->lock);
+	sof->prd = rzalloc(SOF_MEM_ZONE_SYS, 0, SOF_MEM_CAPS_RAM,
+			   sizeof(*sof->prd));
+	spinlock_init(&sof->prd->lock);
 
-	platform_pm_runtime_init(prd);
+	platform_pm_runtime_init(sof->prd);
 }
 
 void pm_runtime_get(enum pm_runtime_context context, uint32_t index)

--- a/src/lib/wait.c
+++ b/src/lib/wait.c
@@ -97,8 +97,9 @@ int poll_for_register_delay(uint32_t reg, uint32_t mask,
 
 void wait_delay(uint64_t number_of_clks)
 {
-	uint64_t current = platform_timer_get(platform_timer);
+	struct timer *timer = timer_get();
+	uint64_t current = platform_timer_get(timer);
 
-	while ((platform_timer_get(platform_timer) - current) < number_of_clks)
+	while ((platform_timer_get(timer) - current) < number_of_clks)
 		idelay(PLATFORM_DEFAULT_DELAY);
 }

--- a/src/platform/apollolake/include/platform/lib/dai.h
+++ b/src/platform/apollolake/include/platform/lib/dai.h
@@ -34,8 +34,6 @@
 /** \brief Number of HD/A Link Inputs */
 #define DAI_NUM_HDA_IN		7
 
-int dai_init(void);
-
 #endif /* __PLATFORM_LIB_DAI_H__ */
 
 #else

--- a/src/platform/apollolake/include/platform/lib/dma.h
+++ b/src/platform/apollolake/include/platform/lib/dma.h
@@ -56,8 +56,6 @@
 #define dma_chan_irq(dma, chan) (dma_irq(dma) + chan)
 #define dma_chan_irq_name(dma, chan) dma_irq_name(dma)
 
-int dmac_init(void);
-
 #endif /* __PLATFORM_LIB_DMA_H__ */
 
 #else

--- a/src/platform/apollolake/include/platform/platform.h
+++ b/src/platform/apollolake/include/platform/platform.h
@@ -107,8 +107,6 @@ static inline void platform_panic(uint32_t p)
  */
 void platform_wait_for_interrupt(int level);
 
-extern struct timer *platform_timer;
-
 extern struct ll_schedule_domain *platform_timer_domain;
 extern struct ll_schedule_domain *platform_dma_domain;
 

--- a/src/platform/apollolake/include/platform/platform.h
+++ b/src/platform/apollolake/include/platform/platform.h
@@ -107,9 +107,6 @@ static inline void platform_panic(uint32_t p)
  */
 void platform_wait_for_interrupt(int level);
 
-extern struct ll_schedule_domain *platform_timer_domain;
-extern struct ll_schedule_domain *platform_dma_domain;
-
 extern intptr_t _module_init_start;
 extern intptr_t _module_init_end;
 

--- a/src/platform/baytrail/include/platform/lib/clk.h
+++ b/src/platform/baytrail/include/platform/lib/clk.h
@@ -15,6 +15,8 @@
 #include <sof/lib/shim.h>
 #include <stdint.h>
 
+struct sof;
+
 #define CLK_CPU(x)	(x)
 #define CLK_SSP		1
 
@@ -34,7 +36,7 @@
 #define NUM_CPU_FREQ	8
 #define NUM_SSP_FREQ	2
 
-void platform_clock_init(void);
+void platform_clock_init(struct sof *sof);
 
 #endif /* __PLATFORM_LIB_CLK_H__ */
 

--- a/src/platform/baytrail/include/platform/lib/dai.h
+++ b/src/platform/baytrail/include/platform/lib/dai.h
@@ -10,8 +10,6 @@
 #ifndef __PLATFORM_LIB_DAI_H__
 #define __PLATFORM_LIB_DAI_H__
 
-int dai_init(void);
-
 #endif /* __PLATFORM_LIB_DAI_H__ */
 
 #else

--- a/src/platform/baytrail/include/platform/lib/dma.h
+++ b/src/platform/baytrail/include/platform/lib/dma.h
@@ -44,8 +44,6 @@
 #define dma_chan_irq(dma, chan) dma_irq(dma)
 #define dma_chan_irq_name(dma, chan) dma_irq_name(dma)
 
-int dmac_init(void);
-
 #endif /* __PLATFORM_LIB_DMA_H__ */
 
 #else

--- a/src/platform/baytrail/include/platform/lib/memory.h
+++ b/src/platform/baytrail/include/platform/lib/memory.h
@@ -14,7 +14,9 @@
 
 #if !defined(__ASSEMBLER__) && !defined(LINKER)
 
-void platform_init_memmap(void);
+struct sof;
+
+void platform_init_memmap(struct sof *sof);
 
 static inline void *platform_shared_get(void *ptr, int bytes)
 {

--- a/src/platform/baytrail/include/platform/platform.h
+++ b/src/platform/baytrail/include/platform/platform.h
@@ -101,8 +101,6 @@ static inline void platform_wait_for_interrupt(int level)
 #define platform_trace_point(__x) \
 	shim_write(SHIM_IPCXL, (__x & 0x3fffffff))
 
-extern struct timer *platform_timer;
-
 extern struct ll_schedule_domain *platform_timer_domain;
 extern struct ll_schedule_domain *platform_dma_domain;
 

--- a/src/platform/baytrail/include/platform/platform.h
+++ b/src/platform/baytrail/include/platform/platform.h
@@ -101,9 +101,6 @@ static inline void platform_wait_for_interrupt(int level)
 #define platform_trace_point(__x) \
 	shim_write(SHIM_IPCXL, (__x & 0x3fffffff))
 
-extern struct ll_schedule_domain *platform_timer_domain;
-extern struct ll_schedule_domain *platform_dma_domain;
-
 extern intptr_t _module_init_start;
 extern intptr_t _module_init_end;
 

--- a/src/platform/baytrail/lib/clk.c
+++ b/src/platform/baytrail/lib/clk.c
@@ -119,4 +119,6 @@ void platform_clock_init(struct sof *sof)
 
 	for (i = 0; i < NUM_CLOCKS; i++)
 		spinlock_init(&platform_clocks_info[i].lock);
+
+	sof->clocks = clocks;
 }

--- a/src/platform/baytrail/lib/clk.c
+++ b/src/platform/baytrail/lib/clk.c
@@ -9,6 +9,7 @@
 #include <sof/drivers/ssp.h>
 #include <sof/lib/clk.h>
 #include <sof/lib/notifier.h>
+#include <sof/sof.h>
 #include <sof/spinlock.h>
 #include <config.h>
 
@@ -112,7 +113,7 @@ STATIC_ASSERT(ARRAY_SIZE(platform_clocks_info) == NUM_CLOCKS,
 
 struct clock_info *clocks = platform_clocks_info;
 
-void platform_clock_init(void)
+void platform_clock_init(struct sof *sof)
 {
 	int i;
 

--- a/src/platform/baytrail/lib/dai.c
+++ b/src/platform/baytrail/lib/dai.c
@@ -124,6 +124,11 @@ static struct dai_type_info dti[] = {
 	}
 };
 
+static struct dai_info lib_dai = {
+	.dai_type_array = dti,
+	.num_dai_types = ARRAY_SIZE(dti)
+};
+
 int dai_init(struct sof *sof)
 {
 	int i;
@@ -132,6 +137,7 @@ int dai_init(struct sof *sof)
 	for (i = 0; i < ARRAY_SIZE(ssp); i++)
 		spinlock_init(&ssp[i].lock);
 
-	dai_install(dti, ARRAY_SIZE(dti));
+	sof->dai_info = &lib_dai;
+
 	return 0;
 }

--- a/src/platform/baytrail/lib/dai.c
+++ b/src/platform/baytrail/lib/dai.c
@@ -10,6 +10,7 @@
 #include <sof/lib/dai.h>
 #include <sof/lib/dma.h>
 #include <sof/lib/memory.h>
+#include <sof/sof.h>
 #include <ipc/dai.h>
 #include <ipc/stream.h>
 #include <config.h>
@@ -123,7 +124,7 @@ static struct dai_type_info dti[] = {
 	}
 };
 
-int dai_init(void)
+int dai_init(struct sof *sof)
 {
 	int i;
 

--- a/src/platform/baytrail/lib/dma.c
+++ b/src/platform/baytrail/lib/dma.c
@@ -8,6 +8,7 @@
 #include <sof/drivers/dw-dma.h>
 #include <sof/drivers/interrupt.h>
 #include <sof/lib/dma.h>
+#include <sof/sof.h>
 #include <sof/spinlock.h>
 #include <config.h>
 
@@ -169,7 +170,7 @@ struct dma dma[PLATFORM_NUM_DMACS] = {
 };
 
 /* Initialize all platform DMAC's */
-int dmac_init(void)
+int dmac_init(struct sof *sof)
 {
 	int i;
 	/* no probing before first use */

--- a/src/platform/baytrail/lib/dma.c
+++ b/src/platform/baytrail/lib/dma.c
@@ -169,6 +169,11 @@ struct dma dma[PLATFORM_NUM_DMACS] = {
 #endif
 };
 
+static struct dma_info lib_dma = {
+	.dma_array = dma,
+	.num_dmas = ARRAY_SIZE(dma)
+};
+
 /* Initialize all platform DMAC's */
 int dmac_init(struct sof *sof)
 {
@@ -181,8 +186,7 @@ int dmac_init(struct sof *sof)
 	for (i = 0; i < ARRAY_SIZE(dma); i++)
 		spinlock_init(&dma[i].lock);
 
-	/* tell the lib DMAs are ready to use */
-	dma_install(dma, ARRAY_SIZE(dma));
+	sof->dma_info = &lib_dma;
 
 	return 0;
 }

--- a/src/platform/baytrail/lib/memory.c
+++ b/src/platform/baytrail/lib/memory.c
@@ -92,4 +92,5 @@ struct mm memmap = {
 void platform_init_memmap(struct sof *sof)
 {
 	/*  memmap has been initialized statically as a part of .data */
+	sof->memory_map = &memmap;
 }

--- a/src/platform/baytrail/lib/memory.c
+++ b/src/platform/baytrail/lib/memory.c
@@ -7,6 +7,7 @@
 #include <sof/common.h>
 #include <sof/lib/alloc.h>
 #include <sof/lib/memory.h>
+#include <sof/sof.h>
 #include <ipc/topology.h>
 
 /* Heap blocks for system runtime */
@@ -88,7 +89,7 @@ struct mm memmap = {
 			HEAP_RUNTIME_SIZE + HEAP_BUFFER_SIZE,},
 };
 
-void platform_init_memmap(void)
+void platform_init_memmap(struct sof *sof)
 {
 	/*  memmap has been initialized statically as a part of .data */
 }

--- a/src/platform/baytrail/platform.c
+++ b/src/platform/baytrail/platform.c
@@ -237,7 +237,7 @@ int platform_init(struct sof *sof)
 	ipc_init(sof);
 
 	trace_point(TRACE_BOOT_PLATFORM_DAI);
-	ret = dai_init();
+	ret = dai_init(sof);
 	if (ret < 0)
 		return -ENODEV;
 

--- a/src/platform/baytrail/platform.c
+++ b/src/platform/baytrail/platform.c
@@ -175,6 +175,8 @@ int platform_init(struct sof *sof)
 #endif
 	int ret;
 
+	sof->platform_timer = &timer;
+
 	/* clear mailbox for early trace and debug */
 	trace_point(TRACE_BOOT_PLATFORM_MBOX);
 	bzero((void *)MAILBOX_BASE, MAILBOX_SIZE);

--- a/src/platform/baytrail/platform.c
+++ b/src/platform/baytrail/platform.c
@@ -228,7 +228,7 @@ int platform_init(struct sof *sof)
 
 	/* init DMACs */
 	trace_point(TRACE_BOOT_PLATFORM_DMA);
-	ret = dmac_init();
+	ret = dmac_init(sof);
 	if (ret < 0)
 		return -ENODEV;
 

--- a/src/platform/baytrail/platform.c
+++ b/src/platform/baytrail/platform.c
@@ -195,7 +195,7 @@ int platform_init(struct sof *sof)
 
 	/* init timers, clocks and schedulers */
 	trace_point(TRACE_BOOT_PLATFORM_TIMER);
-	platform_timer_start(platform_timer);
+	platform_timer_start(sof->platform_timer);
 
 	trace_point(TRACE_BOOT_PLATFORM_CLOCK);
 	platform_clock_init(sof);
@@ -205,7 +205,7 @@ int platform_init(struct sof *sof)
 
 	/* init low latency timer domain and scheduler */
 	platform_timer_domain =
-		timer_domain_init(platform_timer, PLATFORM_DEFAULT_CLOCK,
+		timer_domain_init(sof->platform_timer, PLATFORM_DEFAULT_CLOCK,
 				  CONFIG_SYSTICK_PERIOD);
 	scheduler_init_ll(platform_timer_domain);
 

--- a/src/platform/baytrail/platform.c
+++ b/src/platform/baytrail/platform.c
@@ -125,9 +125,6 @@ struct timer timer = {
 
 struct timer *platform_timer = &timer;
 
-struct ll_schedule_domain *platform_timer_domain;
-struct ll_schedule_domain *platform_dma_domain;
-
 int platform_boot_complete(uint32_t boot_message)
 {
 	uint32_t mb_offset = 0;
@@ -204,18 +201,18 @@ int platform_init(struct sof *sof)
 	scheduler_init_edf();
 
 	/* init low latency timer domain and scheduler */
-	platform_timer_domain =
+	sof->platform_timer_domain =
 		timer_domain_init(sof->platform_timer, PLATFORM_DEFAULT_CLOCK,
 				  CONFIG_SYSTICK_PERIOD);
-	scheduler_init_ll(platform_timer_domain);
+	scheduler_init_ll(sof->platform_timer_domain);
 
 	/* init low latency multi channel DW-DMA domain and scheduler */
-	platform_dma_domain =
+	sof->platform_dma_domain =
 		dma_multi_chan_domain_init(
 				&dma[PLATFORM_DW_DMA_INDEX],
 				PLATFORM_NUM_DW_DMACS,
 				PLATFORM_DEFAULT_CLOCK, true);
-	scheduler_init_ll(platform_dma_domain);
+	scheduler_init_ll(sof->platform_dma_domain);
 
 	/* init the system agent */
 	trace_point(TRACE_BOOT_PLATFORM_AGENT);

--- a/src/platform/baytrail/platform.c
+++ b/src/platform/baytrail/platform.c
@@ -196,7 +196,7 @@ int platform_init(struct sof *sof)
 	platform_timer_start(platform_timer);
 
 	trace_point(TRACE_BOOT_PLATFORM_CLOCK);
-	platform_clock_init();
+	platform_clock_init(sof);
 
 	trace_point(TRACE_BOOT_PLATFORM_SCHED);
 	scheduler_init_edf();

--- a/src/platform/cannonlake/include/platform/lib/dai.h
+++ b/src/platform/cannonlake/include/platform/lib/dai.h
@@ -42,8 +42,6 @@
 /** \brief Number of contiguous ALH bi-dir links */
 #define DAI_NUM_ALH_BI_DIR_LINKS_GROUP	6
 
-int dai_init(void);
-
 #endif /* __PLATFORM_LIB_DAI_H__ */
 
 #else

--- a/src/platform/cannonlake/include/platform/lib/dma.h
+++ b/src/platform/cannonlake/include/platform/lib/dma.h
@@ -57,8 +57,6 @@
 #define dma_chan_irq(dma, chan) dma_irq(dma)
 #define dma_chan_irq_name(dma, chan) dma_irq_name(dma)
 
-int dmac_init(void);
-
 #endif /* __PLATFORM_LIB_DMA_H__ */
 
 #else

--- a/src/platform/cannonlake/include/platform/platform.h
+++ b/src/platform/cannonlake/include/platform/platform.h
@@ -104,9 +104,6 @@ static inline void platform_panic(uint32_t p)
  */
 void platform_wait_for_interrupt(int level);
 
-extern struct ll_schedule_domain *platform_timer_domain;
-extern struct ll_schedule_domain *platform_dma_domain;
-
 extern intptr_t _module_init_start;
 extern intptr_t _module_init_end;
 

--- a/src/platform/cannonlake/include/platform/platform.h
+++ b/src/platform/cannonlake/include/platform/platform.h
@@ -104,8 +104,6 @@ static inline void platform_panic(uint32_t p)
  */
 void platform_wait_for_interrupt(int level);
 
-extern struct timer *platform_timer;
-
 extern struct ll_schedule_domain *platform_timer_domain;
 extern struct ll_schedule_domain *platform_dma_domain;
 

--- a/src/platform/haswell/include/platform/lib/clk.h
+++ b/src/platform/haswell/include/platform/lib/clk.h
@@ -14,6 +14,8 @@
 #include <sof/lib/shim.h>
 #include <stdint.h>
 
+struct sof;
+
 #define CLK_CPU(x)	(x)
 #define CLK_SSP		1
 
@@ -28,7 +30,7 @@
 #define NUM_CPU_FREQ	6
 #define NUM_SSP_FREQ	1
 
-void platform_clock_init(void);
+void platform_clock_init(struct sof *sof);
 
 #endif /* __PLATFORM_LIB_CLK_H__ */
 

--- a/src/platform/haswell/include/platform/lib/dai.h
+++ b/src/platform/haswell/include/platform/lib/dai.h
@@ -10,8 +10,6 @@
 #ifndef __PLATFORM_LIB_DAI_H__
 #define __PLATFORM_LIB_DAI_H__
 
-int dai_init(void);
-
 #endif /* __PLATFORM_LIB_DAI_H__ */
 
 #else

--- a/src/platform/haswell/include/platform/lib/dma.h
+++ b/src/platform/haswell/include/platform/lib/dma.h
@@ -38,8 +38,6 @@
 #define dma_chan_irq(dma, chan) dma_irq(dma)
 #define dma_chan_irq_name(dma, chan) dma_irq_name(dma)
 
-int dmac_init(void);
-
 #endif /* __PLATFORM_LIB_DMA_H__ */
 
 #else

--- a/src/platform/haswell/include/platform/lib/memory.h
+++ b/src/platform/haswell/include/platform/lib/memory.h
@@ -14,7 +14,9 @@
 
 #if !defined(__ASSEMBLER__) && !defined(LINKER)
 
-void platform_init_memmap(void);
+struct sof;
+
+void platform_init_memmap(struct sof *sof);
 
 static inline void *platform_shared_get(void *ptr, int bytes)
 {

--- a/src/platform/haswell/include/platform/platform.h
+++ b/src/platform/haswell/include/platform/platform.h
@@ -90,8 +90,6 @@ static inline void platform_wait_for_interrupt(int level)
 	arch_wait_for_interrupt(level);
 }
 
-extern struct timer *platform_timer;
-
 extern struct ll_schedule_domain *platform_timer_domain;
 extern struct ll_schedule_domain *platform_dma_domain;
 

--- a/src/platform/haswell/include/platform/platform.h
+++ b/src/platform/haswell/include/platform/platform.h
@@ -90,9 +90,6 @@ static inline void platform_wait_for_interrupt(int level)
 	arch_wait_for_interrupt(level);
 }
 
-extern struct ll_schedule_domain *platform_timer_domain;
-extern struct ll_schedule_domain *platform_dma_domain;
-
 extern intptr_t _module_init_start;
 extern intptr_t _module_init_end;
 

--- a/src/platform/haswell/lib/clk.c
+++ b/src/platform/haswell/lib/clk.c
@@ -90,4 +90,6 @@ void platform_clock_init(struct sof *sof)
 
 	for (i = 0; i < NUM_CLOCKS; i++)
 		spinlock_init(&platform_clocks_info[i].lock);
+
+	sof->clocks = clocks;
 }

--- a/src/platform/haswell/lib/clk.c
+++ b/src/platform/haswell/lib/clk.c
@@ -9,6 +9,7 @@
 #include <sof/drivers/ssp.h>
 #include <sof/lib/clk.h>
 #include <sof/lib/notifier.h>
+#include <sof/sof.h>
 #include <sof/spinlock.h>
 
 const struct freq_table platform_cpu_freq[] = {
@@ -83,7 +84,7 @@ STATIC_ASSERT(ARRAY_SIZE(platform_clocks_info) == NUM_CLOCKS,
 
 struct clock_info *clocks = platform_clocks_info;
 
-void platform_clock_init(void)
+void platform_clock_init(struct sof *sof)
 {
 	int i;
 

--- a/src/platform/haswell/lib/dai.c
+++ b/src/platform/haswell/lib/dai.c
@@ -9,6 +9,7 @@
 #include <sof/drivers/ssp.h>
 #include <sof/lib/dai.h>
 #include <sof/lib/dma.h>
+#include <sof/sof.h>
 #include <ipc/dai.h>
 #include <ipc/stream.h>
 
@@ -55,7 +56,7 @@ static struct dai_type_info dti[] = {
 	}
 };
 
-int dai_init(void)
+int dai_init(struct sof *sof)
 {
 	int i;
 

--- a/src/platform/haswell/lib/dai.c
+++ b/src/platform/haswell/lib/dai.c
@@ -56,6 +56,11 @@ static struct dai_type_info dti[] = {
 	}
 };
 
+static struct dai_info lib_dai = {
+	.dai_type_array = dti,
+	.num_dai_types = ARRAY_SIZE(dti)
+};
+
 int dai_init(struct sof *sof)
 {
 	int i;
@@ -64,6 +69,7 @@ int dai_init(struct sof *sof)
 	for (i = 0; i < ARRAY_SIZE(ssp); i++)
 		spinlock_init(&ssp[i].lock);
 
-	dai_install(dti, ARRAY_SIZE(dti));
+	sof->dai_info = &lib_dai;
+
 	return 0;
 }

--- a/src/platform/haswell/lib/dma.c
+++ b/src/platform/haswell/lib/dma.c
@@ -114,6 +114,11 @@ struct dma dma[PLATFORM_NUM_DMACS] = {
 	.ops		= &dw_dma_ops,
 },};
 
+static struct dma_info lib_dma = {
+	.dma_array = dma,
+	.num_dmas = ARRAY_SIZE(dma)
+};
+
 /* Initialize all platform DMAC's */
 int dmac_init(struct sof *sof)
 {
@@ -133,8 +138,7 @@ int dmac_init(struct sof *sof)
 	io_reg_update_bits(SHIM_BASE + SHIM_IMRD,
 			   SHIM_IMRD_DMAC1, 0);
 
-	/* tell the lib DMAs are ready to use */
-	dma_install(dma, ARRAY_SIZE(dma));
+	sof->dma_info = &lib_dma;
 
 	return 0;
 }

--- a/src/platform/haswell/lib/dma.c
+++ b/src/platform/haswell/lib/dma.c
@@ -11,6 +11,7 @@
 #include <sof/lib/io.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/shim.h>
+#include <sof/sof.h>
 #include <sof/spinlock.h>
 
 static struct dw_drv_plat_data dmac0 = {
@@ -114,7 +115,7 @@ struct dma dma[PLATFORM_NUM_DMACS] = {
 },};
 
 /* Initialize all platform DMAC's */
-int dmac_init(void)
+int dmac_init(struct sof *sof)
 {
 	int i;
 	/* no probing before first use */

--- a/src/platform/haswell/lib/memory.c
+++ b/src/platform/haswell/lib/memory.c
@@ -92,4 +92,5 @@ struct mm memmap = {
 void platform_init_memmap(struct sof *sof)
 {
 	/*  memmap has been initialized statically as a part of .data */
+	sof->memory_map = &memmap;
 }

--- a/src/platform/haswell/lib/memory.c
+++ b/src/platform/haswell/lib/memory.c
@@ -7,6 +7,7 @@
 #include <sof/common.h>
 #include <sof/lib/alloc.h>
 #include <sof/lib/memory.h>
+#include <sof/sof.h>
 #include <ipc/topology.h>
 
 /* Heap blocks for system runtime */
@@ -88,7 +89,7 @@ struct mm memmap = {
 			HEAP_RUNTIME_SIZE + HEAP_BUFFER_SIZE,},
 };
 
-void platform_init_memmap(void)
+void platform_init_memmap(struct sof *sof)
 {
 	/*  memmap has been initialized statically as a part of .data */
 }

--- a/src/platform/haswell/platform.c
+++ b/src/platform/haswell/platform.c
@@ -184,7 +184,7 @@ int platform_init(struct sof *sof)
 	platform_timer_start(platform_timer);
 
 	trace_point(TRACE_BOOT_PLATFORM_CLOCK);
-	platform_clock_init();
+	platform_clock_init(sof);
 
 	trace_point(TRACE_BOOT_PLATFORM_SCHED);
 	scheduler_init_edf();

--- a/src/platform/haswell/platform.c
+++ b/src/platform/haswell/platform.c
@@ -121,9 +121,6 @@ struct timer timer = {
 
 struct timer *platform_timer = &timer;
 
-struct ll_schedule_domain *platform_timer_domain;
-struct ll_schedule_domain *platform_dma_domain;
-
 int platform_boot_complete(uint32_t boot_message)
 {
 	uint32_t mb_offset = 0;
@@ -192,18 +189,18 @@ int platform_init(struct sof *sof)
 	scheduler_init_edf();
 
 	/* init low latency timer domain and scheduler */
-	platform_timer_domain =
+	sof->platform_timer_domain =
 		timer_domain_init(sof->platform_timer, PLATFORM_DEFAULT_CLOCK,
 				  CONFIG_SYSTICK_PERIOD);
-	scheduler_init_ll(platform_timer_domain);
+	scheduler_init_ll(sof->platform_timer_domain);
 
 	/* init low latency multi channel DW-DMA domain and scheduler */
-	platform_dma_domain =
+	sof->platform_dma_domain =
 		dma_multi_chan_domain_init(
 				&dma[PLATFORM_DW_DMA_INDEX],
 				PLATFORM_NUM_DW_DMACS,
 				PLATFORM_DEFAULT_CLOCK, true);
-	scheduler_init_ll(platform_dma_domain);
+	scheduler_init_ll(sof->platform_dma_domain);
 
 	/* init the system agent */
 	trace_point(TRACE_BOOT_PLATFORM_AGENT);

--- a/src/platform/haswell/platform.c
+++ b/src/platform/haswell/platform.c
@@ -216,7 +216,7 @@ int platform_init(struct sof *sof)
 
 	/* init DMACs */
 	trace_point(TRACE_BOOT_PLATFORM_DMA);
-	ret = dmac_init();
+	ret = dmac_init(sof);
 	if (ret < 0)
 		return -ENODEV;
 

--- a/src/platform/haswell/platform.c
+++ b/src/platform/haswell/platform.c
@@ -183,7 +183,7 @@ int platform_init(struct sof *sof)
 
 	/* init timers, clocks and schedulers */
 	trace_point(TRACE_BOOT_PLATFORM_TIMER);
-	platform_timer_start(platform_timer);
+	platform_timer_start(sof->platform_timer);
 
 	trace_point(TRACE_BOOT_PLATFORM_CLOCK);
 	platform_clock_init(sof);
@@ -193,7 +193,7 @@ int platform_init(struct sof *sof)
 
 	/* init low latency timer domain and scheduler */
 	platform_timer_domain =
-		timer_domain_init(platform_timer, PLATFORM_DEFAULT_CLOCK,
+		timer_domain_init(sof->platform_timer, PLATFORM_DEFAULT_CLOCK,
 				  CONFIG_SYSTICK_PERIOD);
 	scheduler_init_ll(platform_timer_domain);
 

--- a/src/platform/haswell/platform.c
+++ b/src/platform/haswell/platform.c
@@ -225,7 +225,7 @@ int platform_init(struct sof *sof)
 	ipc_init(sof);
 
 	trace_point(TRACE_BOOT_PLATFORM_DAI);
-	ret = dai_init();
+	ret = dai_init(sof);
 	if (ret < 0)
 		return -ENODEV;
 

--- a/src/platform/haswell/platform.c
+++ b/src/platform/haswell/platform.c
@@ -172,6 +172,8 @@ int platform_init(struct sof *sof)
 	struct dai *ssp1;
 	int ret;
 
+	sof->platform_timer = &timer;
+
 	/* clear mailbox for early trace and debug */
 	trace_point(TRACE_BOOT_PLATFORM_MBOX);
 	bzero((void *)MAILBOX_BASE, MAILBOX_SIZE);

--- a/src/platform/icelake/include/platform/lib/dai.h
+++ b/src/platform/icelake/include/platform/lib/dai.h
@@ -42,8 +42,6 @@
 /** \brief Number of contiguous ALH bi-dir links */
 #define DAI_NUM_ALH_BI_DIR_LINKS_GROUP	6
 
-int dai_init(void);
-
 #endif /* __PLATFORM_LIB_DAI_H__ */
 
 #else

--- a/src/platform/icelake/include/platform/lib/dma.h
+++ b/src/platform/icelake/include/platform/lib/dma.h
@@ -57,8 +57,6 @@
 #define dma_chan_irq(dma, chan) dma_irq(dma)
 #define dma_chan_irq_name(dma, chan) dma_irq_name(dma)
 
-int dmac_init(void);
-
 #endif /* __PLATFORM_LIB_DMA_H__ */
 
 #else

--- a/src/platform/icelake/include/platform/platform.h
+++ b/src/platform/icelake/include/platform/platform.h
@@ -104,9 +104,6 @@ static inline void platform_panic(uint32_t p)
  */
 void platform_wait_for_interrupt(int level);
 
-extern struct ll_schedule_domain *platform_timer_domain;
-extern struct ll_schedule_domain *platform_dma_domain;
-
 extern intptr_t _module_init_start;
 extern intptr_t _module_init_end;
 

--- a/src/platform/icelake/include/platform/platform.h
+++ b/src/platform/icelake/include/platform/platform.h
@@ -104,8 +104,6 @@ static inline void platform_panic(uint32_t p)
  */
 void platform_wait_for_interrupt(int level);
 
-extern struct timer *platform_timer;
-
 extern struct ll_schedule_domain *platform_timer_domain;
 extern struct ll_schedule_domain *platform_dma_domain;
 

--- a/src/platform/imx8/include/platform/lib/clk.h
+++ b/src/platform/imx8/include/platform/lib/clk.h
@@ -12,6 +12,8 @@
 
 #include <stdint.h>
 
+struct sof;
+
 #define CLK_CPU(x)	(x)
 
 #define CPU_DEFAULT_IDX		0
@@ -23,7 +25,7 @@
 
 #define NUM_CPU_FREQ	1
 
-void platform_clock_init(void);
+void platform_clock_init(struct sof *sof);
 
 #endif /* __PLATFORM_LIB_CLK_H__ */
 

--- a/src/platform/imx8/include/platform/lib/dai.h
+++ b/src/platform/imx8/include/platform/lib/dai.h
@@ -10,8 +10,6 @@
 #ifndef __PLATFORM_LIB_DAI_H__
 #define __PLATFORM_LIB_DAI_H__
 
-int dai_init(void);
-
 #endif /* __PLATFORM_LIB_DAI_H__ */
 
 #else

--- a/src/platform/imx8/include/platform/lib/dma.h
+++ b/src/platform/imx8/include/platform/lib/dma.h
@@ -22,8 +22,6 @@
 	irqstr_get_sof_int(((int *)dma->plat_data.drv_plat_data)[chan])
 #define dma_chan_irq_name(dma, chan) dma_irq_name(dma)
 
-int dmac_init(void);
-
 #endif /* __PLATFORM_LIB_DMA_H__ */
 
 #else

--- a/src/platform/imx8/include/platform/lib/memory.h
+++ b/src/platform/imx8/include/platform/lib/memory.h
@@ -173,7 +173,9 @@
 
 #if !defined(__ASSEMBLER__) && !defined(LINKER)
 
-void platform_init_memmap(void);
+struct sof;
+
+void platform_init_memmap(struct sof *sof);
 
 static inline void *platform_shared_get(void *ptr, int bytes)
 {

--- a/src/platform/imx8/include/platform/platform.h
+++ b/src/platform/imx8/include/platform/platform.h
@@ -74,8 +74,6 @@ static inline void platform_wait_for_interrupt(int level)
 	arch_wait_for_interrupt(level);
 }
 
-extern struct ll_schedule_domain *platform_timer_domain;
-
 extern intptr_t _module_init_start;
 extern intptr_t _module_init_end;
 #endif

--- a/src/platform/imx8/include/platform/platform.h
+++ b/src/platform/imx8/include/platform/platform.h
@@ -74,8 +74,6 @@ static inline void platform_wait_for_interrupt(int level)
 	arch_wait_for_interrupt(level);
 }
 
-extern struct timer *platform_timer;
-
 extern struct ll_schedule_domain *platform_timer_domain;
 
 extern intptr_t _module_init_start;

--- a/src/platform/imx8/lib/clk.c
+++ b/src/platform/imx8/lib/clk.c
@@ -39,4 +39,6 @@ void platform_clock_init(struct sof *sof)
 
 		spinlock_init(&platform_clocks_info[i].lock);
 	}
+
+	sof->clocks = clocks;
 }

--- a/src/platform/imx8/lib/clk.c
+++ b/src/platform/imx8/lib/clk.c
@@ -8,6 +8,7 @@
 #include <sof/common.h>
 #include <sof/lib/clk.h>
 #include <sof/lib/notifier.h>
+#include <sof/sof.h>
 #include <sof/spinlock.h>
 
 const struct freq_table platform_cpu_freq[] = {
@@ -21,7 +22,7 @@ static struct clock_info platform_clocks_info[NUM_CLOCKS];
 
 struct clock_info *clocks = platform_clocks_info;
 
-void platform_clock_init(void)
+void platform_clock_init(struct sof *sof)
 {
 	int i;
 

--- a/src/platform/imx8/lib/dai.c
+++ b/src/platform/imx8/lib/dai.c
@@ -76,6 +76,11 @@ static struct dai_type_info dti[] = {
 	},
 };
 
+static struct dai_info lib_dai = {
+	.dai_type_array = dti,
+	.num_dai_types = ARRAY_SIZE(dti)
+};
+
 int dai_init(struct sof *sof)
 {
 	int i;
@@ -87,6 +92,7 @@ int dai_init(struct sof *sof)
 	for (i = 0; i < ARRAY_SIZE(sai); i++)
 		spinlock_init(&sai[i].lock);
 
-	dai_install(dti, ARRAY_SIZE(dti));
+	sof->dai_info = &lib_dai;
+
 	return 0;
 }

--- a/src/platform/imx8/lib/dai.c
+++ b/src/platform/imx8/lib/dai.c
@@ -10,6 +10,7 @@
 #include <sof/drivers/sai.h>
 #include <sof/lib/dai.h>
 #include <sof/lib/memory.h>
+#include <sof/sof.h>
 #include <sof/spinlock.h>
 #include <ipc/dai.h>
 #include <ipc/stream.h>
@@ -75,7 +76,7 @@ static struct dai_type_info dti[] = {
 	},
 };
 
-int dai_init(void)
+int dai_init(struct sof *sof)
 {
 	int i;
 

--- a/src/platform/imx8/lib/dma.c
+++ b/src/platform/imx8/lib/dma.c
@@ -9,6 +9,7 @@
 #include <sof/drivers/interrupt.h>
 #include <sof/lib/dma.h>
 #include <sof/lib/memory.h>
+#include <sof/sof.h>
 #include <sof/spinlock.h>
 
 extern struct dma_ops dummy_dma_ops;
@@ -45,7 +46,7 @@ struct dma dma[PLATFORM_NUM_DMACS] = {
 },
 };
 
-int dmac_init(void)
+int dmac_init(struct sof *sof)
 {
 	int i;
 

--- a/src/platform/imx8/lib/dma.c
+++ b/src/platform/imx8/lib/dma.c
@@ -45,7 +45,7 @@ struct dma dma[PLATFORM_NUM_DMACS] = {
 },
 };
 
-int edma_init(void)
+int dmac_init(void)
 {
 	int i;
 

--- a/src/platform/imx8/lib/dma.c
+++ b/src/platform/imx8/lib/dma.c
@@ -46,6 +46,11 @@ struct dma dma[PLATFORM_NUM_DMACS] = {
 },
 };
 
+static struct dma_info lib_dma = {
+	.dma_array = dma,
+	.num_dmas = ARRAY_SIZE(dma)
+};
+
 int dmac_init(struct sof *sof)
 {
 	int i;
@@ -54,8 +59,7 @@ int dmac_init(struct sof *sof)
 	for (i = 0; i < ARRAY_SIZE(dma); i++)
 		spinlock_init(&dma[i].lock);
 
-	/* tell the lib DMAs are ready to use */
-	dma_install(dma, ARRAY_SIZE(dma));
+	sof->dma_info = &lib_dma;
 
 	return 0;
 }

--- a/src/platform/imx8/lib/memory.c
+++ b/src/platform/imx8/lib/memory.c
@@ -8,6 +8,7 @@
 #include <sof/lib/alloc.h>
 #include <sof/lib/memory.h>
 #include <sof/platform.h>
+#include <sof/sof.h>
 #include <ipc/topology.h>
 
 /* Heap blocks for system runtime */
@@ -91,7 +92,7 @@ struct mm memmap = {
 			HEAP_RUNTIME_SIZE + HEAP_BUFFER_SIZE,},
 };
 
-void platform_init_memmap(void)
+void platform_init_memmap(struct sof *sof)
 {
 	/* memmap has been initialized statically as a part of .data */
 }

--- a/src/platform/imx8/lib/memory.c
+++ b/src/platform/imx8/lib/memory.c
@@ -95,4 +95,5 @@ struct mm memmap = {
 void platform_init_memmap(struct sof *sof)
 {
 	/* memmap has been initialized statically as a part of .data */
+	sof->memory_map = &memmap;
 }

--- a/src/platform/imx8/platform.c
+++ b/src/platform/imx8/platform.c
@@ -15,12 +15,14 @@
 #include <sof/lib/clk.h>
 #include <sof/lib/cpu.h>
 #include <sof/lib/dai.h>
+#include <sof/lib/dma.h>
 #include <sof/lib/mailbox.h>
 #include <sof/platform.h>
 #include <sof/schedule/edf_schedule.h>
 #include <sof/schedule/ll_schedule.h>
 #include <sof/schedule/ll_schedule_domain.h>
 #include <sof/sof.h>
+#include <sof/trace/dma-trace.h>
 #include <ipc/dai.h>
 #include <ipc/header.h>
 #include <ipc/info.h>

--- a/src/platform/imx8/platform.c
+++ b/src/platform/imx8/platform.c
@@ -153,7 +153,7 @@ int platform_init(struct sof *sof)
 	int ret;
 
 	platform_interrupt_init();
-	platform_clock_init();
+	platform_clock_init(sof);
 	scheduler_init_edf();
 
 	/* init low latency domains and schedulers */

--- a/src/platform/imx8/platform.c
+++ b/src/platform/imx8/platform.c
@@ -118,9 +118,6 @@ struct timer timer = {
 
 struct timer *platform_timer = &timer;
 
-struct ll_schedule_domain *platform_timer_domain;
-struct ll_schedule_domain *platform_dma_domain;
-
 int platform_boot_complete(uint32_t boot_message)
 {
 	uint32_t mb_offset = 0;
@@ -159,19 +156,19 @@ int platform_init(struct sof *sof)
 	scheduler_init_edf();
 
 	/* init low latency domains and schedulers */
-	platform_timer_domain =
+	sof->platform_timer_domain =
 		timer_domain_init(sof->platform_timer, PLATFORM_DEFAULT_CLOCK,
 				  CONFIG_SYSTICK_PERIOD);
-	scheduler_init_ll(platform_timer_domain);
+	scheduler_init_ll(sof->platform_timer_domain);
 
 	/* Init EDMA platform domain */
-	platform_dma_domain =
+	sof->platform_dma_domain =
 		dma_multi_chan_domain_init(
 		    &dma[0],
 		    1,
 		    PLATFORM_DEFAULT_CLOCK,
 		    false);
-	scheduler_init_ll(platform_dma_domain);
+	scheduler_init_ll(sof->platform_dma_domain);
 
 	platform_timer_start(sof->platform_timer);
 	sa_init(sof, CONFIG_SYSTICK_PERIOD);

--- a/src/platform/imx8/platform.c
+++ b/src/platform/imx8/platform.c
@@ -152,6 +152,8 @@ int platform_init(struct sof *sof)
 {
 	int ret;
 
+	sof->platform_timer = &timer;
+
 	platform_interrupt_init();
 	platform_clock_init(sof);
 	scheduler_init_edf();

--- a/src/platform/imx8/platform.c
+++ b/src/platform/imx8/platform.c
@@ -160,7 +160,7 @@ int platform_init(struct sof *sof)
 
 	/* init low latency domains and schedulers */
 	platform_timer_domain =
-		timer_domain_init(platform_timer, PLATFORM_DEFAULT_CLOCK,
+		timer_domain_init(sof->platform_timer, PLATFORM_DEFAULT_CLOCK,
 				  CONFIG_SYSTICK_PERIOD);
 	scheduler_init_ll(platform_timer_domain);
 
@@ -173,7 +173,7 @@ int platform_init(struct sof *sof)
 		    false);
 	scheduler_init_ll(platform_dma_domain);
 
-	platform_timer_start(platform_timer);
+	platform_timer_start(sof->platform_timer);
 	sa_init(sof, CONFIG_SYSTICK_PERIOD);
 
 	clock_set_freq(CLK_CPU(cpu_get_id()), CLK_MAX_CPU_HZ);

--- a/src/platform/imx8/platform.c
+++ b/src/platform/imx8/platform.c
@@ -185,7 +185,7 @@ int platform_init(struct sof *sof)
 	/* initialize the host IPC mechanims */
 	ipc_init(sof);
 
-	ret = dai_init();
+	ret = dai_init(sof);
 	if (ret < 0)
 		return -ENODEV;
 

--- a/src/platform/imx8/platform.c
+++ b/src/platform/imx8/platform.c
@@ -178,7 +178,7 @@ int platform_init(struct sof *sof)
 	clock_set_freq(CLK_CPU(cpu_get_id()), CLK_MAX_CPU_HZ);
 
 	/* init DMA */
-	ret = edma_init();
+	ret = dmac_init();
 	if (ret < 0)
 		return -ENODEV;
 

--- a/src/platform/imx8/platform.c
+++ b/src/platform/imx8/platform.c
@@ -178,7 +178,7 @@ int platform_init(struct sof *sof)
 	clock_set_freq(CLK_CPU(cpu_get_id()), CLK_MAX_CPU_HZ);
 
 	/* init DMA */
-	ret = dmac_init();
+	ret = dmac_init(sof);
 	if (ret < 0)
 		return -ENODEV;
 

--- a/src/platform/intel/cavs/include/cavs/lib/clk.h
+++ b/src/platform/intel/cavs/include/cavs/lib/clk.h
@@ -24,6 +24,8 @@
 #include <sof/lib/shim.h>
 #include <stdint.h>
 
+struct sof;
+
 /** \brief Core(s) settings, up to PLATFORM_CORE_COUNT */
 #define CLK_CPU(x)	(x)
 
@@ -39,7 +41,7 @@ extern const struct freq_table *cpu_freq;
 extern const uint32_t cpu_freq_enc[];
 extern const uint32_t cpu_freq_status_mask[];
 
-void platform_clock_init(void);
+void platform_clock_init(struct sof *sof);
 
 #endif /* __CAVS_LIB_CLK_H__ */
 

--- a/src/platform/intel/cavs/include/cavs/lib/memory.h
+++ b/src/platform/intel/cavs/include/cavs/lib/memory.h
@@ -66,6 +66,8 @@
 
 #if !defined(__ASSEMBLER__) && !defined(LINKER)
 
+struct sof;
+
 #define SRAM_ALIAS_BASE		0x9E000000
 #define SRAM_ALIAS_MASK		0xFF000000
 #define SRAM_ALIAS_OFFSET	0x20000000
@@ -108,7 +110,7 @@ static inline void *platform_rfree_prepare(void *ptr)
 	return is_uncached(ptr) ? uncache_to_cache(ptr) : ptr;
 }
 
-void platform_init_memmap(void);
+void platform_init_memmap(struct sof *sof);
 
 #endif
 

--- a/src/platform/intel/cavs/lib/clk.c
+++ b/src/platform/intel/cavs/lib/clk.c
@@ -8,6 +8,7 @@
 #include <sof/drivers/ssp.h>
 #include <sof/lib/clk.h>
 #include <sof/lib/notifier.h>
+#include <sof/sof.h>
 #include <sof/spinlock.h>
 
 static struct clock_info platform_clocks_info[NUM_CLOCKS];
@@ -48,7 +49,7 @@ static int clock_platform_set_cpu_freq(int clock, int freq_idx)
 	return 0;
 }
 
-void platform_clock_init(void)
+void platform_clock_init(struct sof *sof)
 {
 	int i;
 

--- a/src/platform/intel/cavs/lib/clk.c
+++ b/src/platform/intel/cavs/lib/clk.c
@@ -78,4 +78,6 @@ void platform_clock_init(struct sof *sof)
 	};
 
 	spinlock_init(&platform_clocks_info[CLK_SSP].lock);
+
+	sof->clocks = clocks;
 }

--- a/src/platform/intel/cavs/lib/dai.c
+++ b/src/platform/intel/cavs/lib/dai.c
@@ -116,6 +116,11 @@ static struct dai_type_info dti[] = {
 #endif
 };
 
+static struct dai_info lib_dai = {
+	.dai_type_array = dti,
+	.num_dai_types = ARRAY_SIZE(dti)
+};
+
 int dai_init(struct sof *sof)
 {
 	int i;
@@ -161,6 +166,7 @@ int dai_init(struct sof *sof)
 	}
 #endif
 
-	dai_install(dti, ARRAY_SIZE(dti));
+	sof->dai_info = &lib_dai;
+
 	return 0;
 }

--- a/src/platform/intel/cavs/lib/dai.c
+++ b/src/platform/intel/cavs/lib/dai.c
@@ -13,6 +13,7 @@
 #include <sof/lib/dai.h>
 #include <sof/lib/dma.h>
 #include <sof/lib/memory.h>
+#include <sof/sof.h>
 #include <sof/spinlock.h>
 #include <ipc/dai.h>
 #include <ipc/stream.h>
@@ -115,7 +116,7 @@ static struct dai_type_info dti[] = {
 #endif
 };
 
-int dai_init(void)
+int dai_init(struct sof *sof)
 {
 	int i;
 #if CONFIG_CAVS_SSP

--- a/src/platform/intel/cavs/lib/dma.c
+++ b/src/platform/intel/cavs/lib/dma.c
@@ -237,6 +237,11 @@ struct dma dma[PLATFORM_NUM_DMACS] = {
 },};
 #endif
 
+static struct dma_info lib_dma = {
+	.dma_array = dma,
+	.num_dmas = ARRAY_SIZE(dma)
+};
+
 /* Initialize all platform DMAC's */
 int dmac_init(struct sof *sof)
 {
@@ -249,8 +254,7 @@ int dmac_init(struct sof *sof)
 	for (i = 0; i < ARRAY_SIZE(dma); i++)
 		spinlock_init(&dma[i].lock);
 
-	/* tell the lib DMAs are ready to use */
-	dma_install(dma, ARRAY_SIZE(dma));
+	sof->dma_info = &lib_dma;
 
 	return 0;
 }

--- a/src/platform/intel/cavs/lib/dma.c
+++ b/src/platform/intel/cavs/lib/dma.c
@@ -13,6 +13,7 @@
 #include <sof/drivers/interrupt.h>
 #include <sof/lib/dma.h>
 #include <sof/lib/memory.h>
+#include <sof/sof.h>
 #include <sof/spinlock.h>
 #include <config.h>
 
@@ -237,7 +238,7 @@ struct dma dma[PLATFORM_NUM_DMACS] = {
 #endif
 
 /* Initialize all platform DMAC's */
-int dmac_init(void)
+int dmac_init(struct sof *sof)
 {
 	int i;
 	/* no probing before first use */

--- a/src/platform/intel/cavs/lib/memory.c
+++ b/src/platform/intel/cavs/lib/memory.c
@@ -181,4 +181,6 @@ void platform_init_memmap(struct sof *sof)
 	memmap.total.free = HEAP_SYSTEM_T_SIZE + HEAP_SYS_RUNTIME_T_SIZE +
 		HEAP_RUNTIME_SIZE + HEAP_BUFFER_SIZE +
 		HEAP_LP_BUFFER_SIZE;
+
+	sof->memory_map = &memmap;
 }

--- a/src/platform/intel/cavs/lib/memory.c
+++ b/src/platform/intel/cavs/lib/memory.c
@@ -11,6 +11,7 @@
 #include <sof/lib/cpu.h>
 #include <sof/lib/memory.h>
 #include <sof/platform.h>
+#include <sof/sof.h>
 #include <ipc/topology.h>
 #include <stdint.h>
 
@@ -105,7 +106,7 @@ static struct block_map lp_buf_heap_map[] = {
 
 struct mm memmap;
 
-void platform_init_memmap(void)
+void platform_init_memmap(struct sof *sof)
 {
 	int i;
 

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -341,6 +341,8 @@ int platform_init(struct sof *sof)
 #endif
 	int ret;
 
+	sof->platform_timer = &timer;
+
 	/* pm runtime already initialized, request the DSP to stay in D0
 	 * until we are allowed to do full power gating (by the IPC req).
 	 */

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -364,7 +364,7 @@ int platform_init(struct sof *sof)
 	platform_timer_start(platform_timer);
 
 	trace_point(TRACE_BOOT_PLATFORM_CLOCK);
-	platform_clock_init();
+	platform_clock_init(sof);
 
 	trace_point(TRACE_BOOT_PLATFORM_SCHED);
 	scheduler_init_edf();

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -257,9 +257,6 @@ struct timer timer = {
 	.irq_name = irq_name_level2,
 };
 
-struct ll_schedule_domain *platform_timer_domain;
-struct ll_schedule_domain *platform_dma_domain;
-
 #if CONFIG_DW_SPI
 
 #include <sof/drivers/spi.h>
@@ -376,18 +373,18 @@ int platform_init(struct sof *sof)
 	scheduler_init_edf();
 
 	/* init low latency timer domain and scheduler */
-	platform_timer_domain =
+	sof->platform_timer_domain =
 		timer_domain_init(sof->platform_timer, PLATFORM_DEFAULT_CLOCK,
 				  CONFIG_SYSTICK_PERIOD);
-	scheduler_init_ll(platform_timer_domain);
+	scheduler_init_ll(sof->platform_timer_domain);
 
 	/* init low latency single channel DW-DMA domain and scheduler */
-	platform_dma_domain =
+	sof->platform_dma_domain =
 		dma_single_chan_domain_init
 			(&dma[PLATFORM_DW_DMA_INDEX],
 			 PLATFORM_NUM_DW_DMACS,
 			 PLATFORM_DEFAULT_CLOCK);
-	scheduler_init_ll(platform_dma_domain);
+	scheduler_init_ll(sof->platform_dma_domain);
 
 	/* init the system agent */
 	trace_point(TRACE_BOOT_PLATFORM_AGENT);

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -473,7 +473,7 @@ int platform_init(struct sof *sof)
 
 	/* init DAIs */
 	trace_point(TRACE_BOOT_PLATFORM_DAI);
-	ret = dai_init();
+	ret = dai_init(sof);
 	if (ret < 0)
 		return ret;
 

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -340,8 +340,14 @@ int platform_init(struct sof *sof)
 	struct spi *spi_dev;
 #endif
 	int ret;
+	int i;
 
 	sof->platform_timer = &timer;
+
+	/* Turn off memory for all unused cores */
+	for (i = 0; i < PLATFORM_CORE_COUNT; i++)
+		if (i != PLATFORM_MASTER_CORE_ID)
+			pm_runtime_put(CORE_MEMORY_POW, i);
 
 	/* pm runtime already initialized, request the DSP to stay in D0
 	 * until we are allowed to do full power gating (by the IPC req).

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -257,8 +257,6 @@ struct timer timer = {
 	.irq_name = irq_name_level2,
 };
 
-struct timer *platform_timer = &timer;
-
 struct ll_schedule_domain *platform_timer_domain;
 struct ll_schedule_domain *platform_dma_domain;
 
@@ -369,7 +367,7 @@ int platform_init(struct sof *sof)
 
 	/* init timers, clocks and schedulers */
 	trace_point(TRACE_BOOT_PLATFORM_TIMER);
-	platform_timer_start(platform_timer);
+	platform_timer_start(sof->platform_timer);
 
 	trace_point(TRACE_BOOT_PLATFORM_CLOCK);
 	platform_clock_init(sof);
@@ -379,7 +377,7 @@ int platform_init(struct sof *sof)
 
 	/* init low latency timer domain and scheduler */
 	platform_timer_domain =
-		timer_domain_init(platform_timer, PLATFORM_DEFAULT_CLOCK,
+		timer_domain_init(sof->platform_timer, PLATFORM_DEFAULT_CLOCK,
 				  CONFIG_SYSTICK_PERIOD);
 	scheduler_init_ll(platform_timer_domain);
 

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -457,7 +457,7 @@ int platform_init(struct sof *sof)
 
 	/* init DMACs */
 	trace_point(TRACE_BOOT_PLATFORM_DMA);
-	ret = dmac_init();
+	ret = dmac_init(sof);
 	if (ret < 0)
 		return ret;
 

--- a/src/platform/library/include/platform/lib/memory.h
+++ b/src/platform/library/include/platform/lib/memory.h
@@ -10,6 +10,8 @@
 #ifndef __PLATFORM_LIB_MEMORY_H__
 #define __PLATFORM_LIB_MEMORY_H__
 
+#define PLATFORM_DCACHE_ALIGN	sizeof(void *)
+
 #define HEAP_BUFFER_SIZE	(1024 * 128)
 #define SOF_STACK_SIZE		0x1000
 

--- a/src/platform/library/include/platform/platform.h
+++ b/src/platform/library/include/platform/platform.h
@@ -51,8 +51,6 @@ static inline void platform_wait_for_interrupt(int level)
 	arch_wait_for_interrupt(level);
 }
 
-extern struct timer *platform_timer;
-
 #endif /* __PLATFORM_PLATFORM_H__ */
 
 #else

--- a/src/platform/suecreek/include/platform/lib/dai.h
+++ b/src/platform/suecreek/include/platform/lib/dai.h
@@ -32,8 +32,6 @@
 /** \brief Number of HD/A Link Inputs */
 #define DAI_NUM_HDA_IN		7
 
-int dai_init(void);
-
 #endif /* __PLATFORM_LIB_DAI_H__ */
 
 #else

--- a/src/platform/suecreek/include/platform/lib/dma.h
+++ b/src/platform/suecreek/include/platform/lib/dma.h
@@ -46,8 +46,6 @@
 #define dma_chan_irq(dma, chan) dma_irq(dma)
 #define dma_chan_irq_name(dma, chan) dma_irq_name(dma)
 
-int dmac_init(void);
-
 #endif /* __PLATFORM_LIB_DMA_H__ */
 
 #else

--- a/src/platform/suecreek/include/platform/platform.h
+++ b/src/platform/suecreek/include/platform/platform.h
@@ -114,9 +114,6 @@ static inline void platform_panic(uint32_t p)
  */
 void platform_wait_for_interrupt(int level);
 
-extern struct ll_schedule_domain *platform_timer_domain;
-extern struct ll_schedule_domain *platform_dma_domain;
-
 extern intptr_t _module_init_start;
 extern intptr_t _module_init_end;
 

--- a/src/platform/suecreek/include/platform/platform.h
+++ b/src/platform/suecreek/include/platform/platform.h
@@ -114,8 +114,6 @@ static inline void platform_panic(uint32_t p)
  */
 void platform_wait_for_interrupt(int level);
 
-extern struct timer *platform_timer;
-
 extern struct ll_schedule_domain *platform_timer_domain;
 extern struct ll_schedule_domain *platform_dma_domain;
 

--- a/src/platform/tigerlake/include/platform/lib/dai.h
+++ b/src/platform/tigerlake/include/platform/lib/dai.h
@@ -42,8 +42,6 @@
 /** \brief Number of contiguous ALH bi-dir links */
 #define DAI_NUM_ALH_BI_DIR_LINKS_GROUP	4
 
-int dai_init(void);
-
 #endif /* __PLATFORM_LIB_DAI_H__ */
 
 #else

--- a/src/platform/tigerlake/include/platform/lib/dma.h
+++ b/src/platform/tigerlake/include/platform/lib/dma.h
@@ -57,8 +57,6 @@
 #define dma_chan_irq(dma, chan) dma_irq(dma)
 #define dma_chan_irq_name(dma, chan) dma_irq_name(dma)
 
-int dmac_init(void);
-
 #endif /* __PLATFORM_LIB_DMA_H__ */
 
 #else

--- a/src/platform/tigerlake/include/platform/platform.h
+++ b/src/platform/tigerlake/include/platform/platform.h
@@ -104,9 +104,6 @@ static inline void platform_panic(uint32_t p)
  */
 void platform_wait_for_interrupt(int level);
 
-extern struct ll_schedule_domain *platform_timer_domain;
-extern struct ll_schedule_domain *platform_dma_domain;
-
 extern intptr_t _module_init_start;
 extern intptr_t _module_init_end;
 

--- a/src/platform/tigerlake/include/platform/platform.h
+++ b/src/platform/tigerlake/include/platform/platform.h
@@ -104,8 +104,6 @@ static inline void platform_panic(uint32_t p)
  */
 void platform_wait_for_interrupt(int level);
 
-extern struct timer *platform_timer;
-
 extern struct ll_schedule_domain *platform_timer_domain;
 extern struct ll_schedule_domain *platform_dma_domain;
 

--- a/src/schedule/dma_multi_chan_domain.c
+++ b/src/schedule/dma_multi_chan_domain.c
@@ -270,7 +270,7 @@ static bool dma_multi_chan_domain_is_pending(struct ll_schedule_domain *domain,
 			/* it's too soon for this task */
 			if (!pipe_task->registrable &&
 			    pipe_task->task.start >
-			    platform_timer_get(platform_timer))
+			    platform_timer_get(timer_get()))
 				continue;
 
 			notifier_event(&dmas[i].chan[j], NOTIFIER_ID_DMA_IRQ,

--- a/src/schedule/dma_single_chan_domain.c
+++ b/src/schedule/dma_single_chan_domain.c
@@ -427,7 +427,7 @@ static void dma_single_chan_domain_set(struct ll_schedule_domain *domain,
 		return;
 
 	if (dma_domain->channel_changed) {
-		domain->last_tick = platform_timer_get(platform_timer);
+		domain->last_tick = platform_timer_get(timer_get());
 
 		dma_domain->channel_changed = false;
 	} else {
@@ -463,7 +463,7 @@ static void dma_single_chan_domain_clear(struct ll_schedule_domain *domain)
 static bool dma_single_chan_domain_is_pending(struct ll_schedule_domain *domain,
 					      struct task *task)
 {
-	return task->start <= platform_timer_get(platform_timer);
+	return task->start <= platform_timer_get(timer_get());
 }
 
 /**

--- a/src/schedule/edf_schedule.c
+++ b/src/schedule/edf_schedule.c
@@ -114,7 +114,7 @@ static void schedule_edf_task(void *data, struct task *task, uint64_t start,
 	}
 
 	/* get current time */
-	current = platform_timer_get(platform_timer);
+	current = platform_timer_get(timer_get());
 
 	ticks_per_ms = clock_ms_to_ticks(edf_sch->clock, 1);
 

--- a/src/schedule/ll_schedule.c
+++ b/src/schedule/ll_schedule.c
@@ -180,7 +180,7 @@ static int schedule_ll_domain_set(struct ll_schedule_data *sch,
 		sch->domain->registered[core] = true;
 
 	if (atomic_add(&sch->domain->total_num_tasks, 1) == 1) {
-		domain_set(sch->domain, platform_timer_get(platform_timer));
+		domain_set(sch->domain, platform_timer_get(timer_get()));
 		atomic_add(&sch->domain->num_clients, 1);
 		domain_enable(sch->domain, core);
 	}
@@ -278,7 +278,7 @@ static void schedule_ll_task(void *data, struct task *task, uint64_t start,
 	task->start = sch->domain->ticks_per_ms * start / 1000;
 
 	if (sch->domain->synchronous)
-		task->start += platform_timer_get(platform_timer);
+		task->start += platform_timer_get(timer_get());
 	else
 		task->start += sch->domain->last_tick;
 
@@ -372,7 +372,7 @@ static void reschedule_ll_task(void *data, struct task *task, uint64_t start)
 	time = sch->domain->ticks_per_ms * start / 1000;
 
 	if (sch->domain->synchronous)
-		time += platform_timer_get(platform_timer);
+		time += platform_timer_get(timer_get());
 	else
 		time += sch->domain->last_tick;
 
@@ -413,7 +413,7 @@ static void scheduler_free_ll(void *data)
 static void ll_scheduler_recalculate_tasks(struct ll_schedule_data *sch,
 					   struct clock_notify_data *clk_data)
 {
-	uint64_t current = platform_timer_get(platform_timer);
+	uint64_t current = platform_timer_get(timer_get());
 	struct list_item *tlist;
 	struct task *task;
 	uint64_t delta_ms;

--- a/src/schedule/task.c
+++ b/src/schedule/task.c
@@ -30,8 +30,6 @@
 #include <ipc/trace.h>
 #endif
 
-extern struct ipc *_ipc;
-
 typedef enum task_state (*task_main)(void *);
 
 static void sys_module_init(void)
@@ -54,7 +52,7 @@ enum task_state task_main_master_core(void *data)
 		/* sleep until next IPC or DMA */
 		wait_for_interrupt(0);
 
-		if (_ipc && !_ipc->pm_prepare_D3)
+		if (ipc_get() && !ipc_get()->pm_prepare_D3)
 			ipc_platform_send_msg();
 	}
 

--- a/src/schedule/timer_domain.c
+++ b/src/schedule/timer_domain.c
@@ -115,7 +115,7 @@ static void timer_domain_clear(struct ll_schedule_domain *domain)
 static bool timer_domain_is_pending(struct ll_schedule_domain *domain,
 				    struct task *task)
 {
-	return task->start <= platform_timer_get(platform_timer);
+	return task->start <= platform_timer_get(timer_get());
 }
 
 struct ll_schedule_domain *timer_domain_init(struct timer *timer, int clk,

--- a/src/trace/trace.c
+++ b/src/trace/trace.c
@@ -45,7 +45,7 @@ static void put_header(uint32_t *dst, uint32_t id_0, uint32_t id_1,
 	header.id_0 = id_0 & TRACE_ID_MASK;
 	header.id_1 = id_1 & TRACE_ID_MASK;
 	header.core_id = cpu_get_id();
-	header.timestamp = timestamp + platform_timer->delta;
+	header.timestamp = timestamp + timer_get()->delta;
 	header.log_entry_address = entry;
 
 	ret = memcpy_s(dst, sizeof(header), &header, sizeof(header));
@@ -105,7 +105,7 @@ META_IF_ELSE(is_atomic)(_atomic)()					\
 		return;							\
 									\
 	put_header(dt, id_0, id_1, log_entry,				\
-		   platform_timer_get(platform_timer));			\
+		   platform_timer_get(timer_get()));			\
 									\
 	_TRACE_EVENT_NTH_PAYLOAD_IMPL(arg_count)			\
 	META_IF_ELSE(is_atomic)						\

--- a/test/cmocka/src/audio/kpb/kpb_mock.c
+++ b/test/cmocka/src/audio/kpb/kpb_mock.c
@@ -24,6 +24,8 @@
 
 TRACE_IMPL()
 
+static struct sof sof;
+
 void *_balloc(uint32_t flags, uint32_t caps, size_t bytes,
 	      uint32_t alignment)
 {
@@ -122,5 +124,10 @@ void pm_runtime_disable(enum pm_runtime_context context, uint32_t index)
 {
 	(void)context;
 	(void)index;
+}
+
+struct sof *sof_get(void)
+{
+	return &sof;
 }
 

--- a/test/cmocka/src/audio/kpb/kpb_mock.h
+++ b/test/cmocka/src/audio/kpb/kpb_mock.h
@@ -6,5 +6,3 @@
  */
 
 int comp_set_state(struct comp_dev *dev, int cmd);
-
-struct timer *platform_timer;

--- a/test/cmocka/src/lib/alloc/alloc.c
+++ b/test/cmocka/src/lib/alloc/alloc.c
@@ -217,7 +217,7 @@ static struct test_case test_cases[] = {
 static int setup(void **state)
 {
 	sof = malloc(sizeof(struct sof));
-	platform_init_memmap();
+	platform_init_memmap(sof);
 	init_heap(sof);
 
 	return 0;

--- a/test/cmocka/src/lib/alloc/alloc.c
+++ b/test/cmocka/src/lib/alloc/alloc.c
@@ -16,10 +16,6 @@
 #include <ipc/header.h>
 #include <ipc/topology.h>
 
-extern struct mm memmap;
-
-static struct sof *sof;
-
 enum test_type {
 	TEST_BULK = 0,
 	TEST_ZERO,
@@ -216,26 +212,24 @@ static struct test_case test_cases[] = {
 
 static int setup(void **state)
 {
-	sof = malloc(sizeof(struct sof));
-	platform_init_memmap(sof);
-	init_heap(sof);
+	platform_init_memmap(sof_get());
+	init_heap(sof_get());
 
 	return 0;
 }
 
 static int teardown(void **state)
 {
-	free(sof);
-
 	return 0;
 }
 
 static int clear_sys(void **state)
 {
+	struct mm *memmap = memmap_get();
 	int sysheap_idx = 0;
 
-	for (; sysheap_idx < ARRAY_SIZE(memmap.system); ++sysheap_idx) {
-		struct mm_heap *cpu_heap = &memmap.system[sysheap_idx];
+	for (; sysheap_idx < ARRAY_SIZE(memmap->system); ++sysheap_idx) {
+		struct mm_heap *cpu_heap = &memmap->system[sysheap_idx];
 
 		cpu_heap->info.used = 0;
 		cpu_heap->info.free = cpu_heap->size;

--- a/test/cmocka/src/lib/alloc/mock.c
+++ b/test/cmocka/src/lib/alloc/mock.c
@@ -19,6 +19,8 @@ TRACE_IMPL()
 struct dma_copy;
 struct dma_sg_config;
 
+static struct sof sof;
+
 void arch_dump_regs_a(void *dump_buf)
 {
 	(void)dump_buf;
@@ -38,4 +40,9 @@ void trace_flush(void)
 volatile void *task_context_get(void)
 {
 	return NULL;
+}
+
+struct sof *sof_get(void)
+{
+	return &sof;
 }

--- a/tools/testbench/testbench.c
+++ b/tools/testbench/testbench.c
@@ -33,6 +33,11 @@ static int sched_id; /* comp id for scheduling comp */
 /* compatible variables, not used */
 intptr_t _comp_init_start, _comp_init_end;
 
+struct sof *sof_get()
+{
+	return &sof;
+}
+
 /*
  * Parse shared library from user input
  * Currently only handles volume and src comp


### PR DESCRIPTION
This set of patches adds all global structures to main firmware context. It's the first step to achieve easier and more understandable multicore support. Since all of this data can be accessed by many different cores we need to avoid cache synchronization problems by having only one point of access, which we can control.