### PR TITLE
drivers: intel: deduplicate ssp trace macros

### DIFF
--- a/src/drivers/intel/baytrail/ssp.c
+++ b/src/drivers/intel/baytrail/ssp.c
@@ -22,14 +22,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-/* tracing */
-#define trace_ssp(__e, ...) \
-	trace_event(TRACE_CLASS_SSP, __e, ##__VA_ARGS__)
-#define trace_ssp_error(__e, ...) \
-	trace_error(TRACE_CLASS_SSP, __e, ##__VA_ARGS__)
-#define tracev_ssp(__e, ...) \
-	tracev_event(TRACE_CLASS_SSP, __e, ##__VA_ARGS__)
-
 /* empty SSP receive FIFO */
 static void ssp_empty_rx_fifo(struct dai *dai)
 {

--- a/src/drivers/intel/cavs/ssp.c
+++ b/src/drivers/intel/cavs/ssp.c
@@ -28,14 +28,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-/* tracing */
-#define trace_ssp(__e, ...) \
-	trace_event(TRACE_CLASS_SSP, __e, ##__VA_ARGS__)
-#define trace_ssp_error(__e, ...) \
-	trace_error(TRACE_CLASS_SSP, __e, ##__VA_ARGS__)
-#define tracev_ssp(__e, ...) \
-	tracev_event(TRACE_CLASS_SSP, __e, ##__VA_ARGS__)
-
 /**
  * \brief Finds valid M/(N * SCR) values for given frequencies.
  * \param[in] freq SSP clock frequency.

--- a/src/drivers/intel/haswell/ssp.c
+++ b/src/drivers/intel/haswell/ssp.c
@@ -22,14 +22,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-/* tracing */
-#define trace_ssp(__e, ...) \
-	trace_event(TRACE_CLASS_SSP, __e, ##__VA_ARGS__)
-#define trace_ssp_error(__e, ...) \
-	trace_error(TRACE_CLASS_SSP, __e, ##__VA_ARGS__)
-#define tracev_ssp(__e, ...) \
-	tracev_event(TRACE_CLASS_SSP, __e, ##__VA_ARGS__)
-
 /* save SSP context prior to entering D3 */
 static int ssp_context_store(struct dai *dai)
 {


### PR DESCRIPTION
Trace macros are already defined in ssp.h.

Signed-off-by: Janusz Jankowski <janusz.jankowski@linux.intel.com>