### PR TITLE
pcm_converter: buffer: Add const keyword to data source

### DIFF
--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -63,9 +63,7 @@ struct dai_data {
 	enum sof_ipc_frame frame_fmt;
 	int xrun;		/* true if we are doing xrun recovery */
 
-	/* processing function */
-	void (*process)(struct comp_buffer *source, struct comp_buffer *sink,
-			uint32_t bytes);
+	pcm_converter_func process;	/* processing function */
 
 	uint32_t dai_pos_blks;	/* position in bytes (nearest block) */
 	uint64_t start_position;	/* position on start */

--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -104,9 +104,7 @@ struct host_data {
 				   *  copied by dma connected to host
 				   */
 
-	/* processing function */
-	void (*process)(struct comp_buffer *source, struct comp_buffer *sink,
-			uint32_t bytes);
+	pcm_converter_func process;	/**< processing function */
 
 	/* stream info */
 	struct sof_ipc_stream_posn posn; /* TODO: update this */

--- a/src/audio/pcm_converter/pcm_converter_generic.c
+++ b/src/audio/pcm_converter/pcm_converter_generic.c
@@ -24,7 +24,7 @@
 
 #if CONFIG_FORMAT_S16LE && CONFIG_FORMAT_S24LE
 
-static void pcm_convert_s16_to_s24(struct comp_buffer *source,
+static void pcm_convert_s16_to_s24(const struct comp_buffer *source,
 				   struct comp_buffer *sink, uint32_t samples)
 {
 	uint32_t buff_frag = 0;
@@ -40,7 +40,7 @@ static void pcm_convert_s16_to_s24(struct comp_buffer *source,
 	}
 }
 
-static void pcm_convert_s24_to_s16(struct comp_buffer *source,
+static void pcm_convert_s24_to_s16(const struct comp_buffer *source,
 				   struct comp_buffer *sink, uint32_t samples)
 {
 	uint32_t buff_frag = 0;
@@ -60,7 +60,7 @@ static void pcm_convert_s24_to_s16(struct comp_buffer *source,
 
 #if CONFIG_FORMAT_S16LE && CONFIG_FORMAT_S32LE
 
-static void pcm_convert_s16_to_s32(struct comp_buffer *source,
+static void pcm_convert_s16_to_s32(const struct comp_buffer *source,
 				   struct comp_buffer *sink, uint32_t samples)
 {
 	uint32_t buff_frag = 0;
@@ -76,7 +76,7 @@ static void pcm_convert_s16_to_s32(struct comp_buffer *source,
 	}
 }
 
-static void pcm_convert_s32_to_s16(struct comp_buffer *source,
+static void pcm_convert_s32_to_s16(const struct comp_buffer *source,
 				   struct comp_buffer *sink, uint32_t samples)
 {
 	uint32_t buff_frag = 0;
@@ -96,7 +96,7 @@ static void pcm_convert_s32_to_s16(struct comp_buffer *source,
 
 #if CONFIG_FORMAT_S24LE && CONFIG_FORMAT_S32LE
 
-static void pcm_convert_s24_to_s32(struct comp_buffer *source,
+static void pcm_convert_s24_to_s32(const struct comp_buffer *source,
 				   struct comp_buffer *sink, uint32_t samples)
 {
 	uint32_t buff_frag = 0;
@@ -112,7 +112,7 @@ static void pcm_convert_s24_to_s32(struct comp_buffer *source,
 	}
 }
 
-static void pcm_convert_s32_to_s24(struct comp_buffer *source,
+static void pcm_convert_s32_to_s24(const struct comp_buffer *source,
 				   struct comp_buffer *sink, uint32_t samples)
 {
 	uint32_t buff_frag = 0;

--- a/src/audio/pcm_converter/pcm_converter_generic.c
+++ b/src/audio/pcm_converter/pcm_converter_generic.c
@@ -156,4 +156,4 @@ const struct pcm_func_map pcm_func_map[] = {
 
 const size_t pcm_func_count = ARRAY_SIZE(pcm_func_map);
 
-#endif
+#endif /* PCM_CONVERTER_GENERIC */

--- a/src/audio/pcm_converter/pcm_converter_hifi3.c
+++ b/src/audio/pcm_converter/pcm_converter_hifi3.c
@@ -26,7 +26,7 @@
  * \brief Sets buffer to be circular using HiFi3 functions.
  * \param[in,out] buffer Circular buffer.
  */
-static void pcm_converter_setup_circular(struct comp_buffer *buffer)
+static void pcm_converter_setup_circular(const struct comp_buffer *buffer)
 {
 	AE_SETCBEGIN0(buffer->addr);
 	AE_SETCEND0(buffer->end_addr);
@@ -40,7 +40,7 @@ static void pcm_converter_setup_circular(struct comp_buffer *buffer)
  * \param[in,out] sink Destination buffer.
  * \param[in] samples Number of samples to process.
  */
-static void pcm_convert_s16_to_s24(struct comp_buffer *source,
+static void pcm_convert_s16_to_s24(const struct comp_buffer *source,
 				   struct comp_buffer *sink, uint32_t samples)
 {
 	ae_int16 *in = (ae_int16 *)source->r_ptr;
@@ -137,7 +137,7 @@ static ae_int32x2 pcm_shift_s24_to_s16(ae_int32x2 sample)
  * \param[in,out] sink Destination buffer.
  * \param[in] samples Number of samples to process.
  */
-static void pcm_convert_s24_to_s16(struct comp_buffer *source,
+static void pcm_convert_s24_to_s16(const struct comp_buffer *source,
 				   struct comp_buffer *sink, uint32_t samples)
 {
 	ae_int32x2 *in = (ae_int32x2 *)source->r_ptr;
@@ -239,7 +239,7 @@ static void pcm_convert_s24_to_s16(struct comp_buffer *source,
  * \param[in,out] sink Destination buffer.
  * \param[in] samples Number of samples to process.
  */
-static void pcm_convert_s16_to_s32(struct comp_buffer *source,
+static void pcm_convert_s16_to_s32(const struct comp_buffer *source,
 				   struct comp_buffer *sink, uint32_t samples)
 {
 	ae_int16 *in = (ae_int16 *)source->r_ptr;
@@ -316,7 +316,7 @@ static void pcm_convert_s16_to_s32(struct comp_buffer *source,
  * \param[in,out] sink Destination buffer.
  * \param[in] samples Number of samples to process.
  */
-static void pcm_convert_s32_to_s16(struct comp_buffer *source,
+static void pcm_convert_s32_to_s16(const struct comp_buffer *source,
 				   struct comp_buffer *sink, uint32_t samples)
 {
 	ae_int32x2 *in = (ae_int32x2 *)source->r_ptr;
@@ -414,7 +414,7 @@ static void pcm_convert_s32_to_s16(struct comp_buffer *source,
  * \param[in,out] sink Destination buffer.
  * \param[in] samples Number of samples to process.
  */
-static void pcm_convert_s24_to_s32(struct comp_buffer *source,
+static void pcm_convert_s24_to_s32(const struct comp_buffer *source,
 				   struct comp_buffer *sink, uint32_t samples)
 {
 	ae_int32x2 *in = (ae_int32x2 *)source->r_ptr;
@@ -497,7 +497,7 @@ static ae_int32x2 pcm_shift_s32_to_s24(ae_int32x2 sample)
  * \param[in,out] sink Destination buffer.
  * \param[in] samples Number of samples to process.
  */
-static void pcm_convert_s32_to_s24(struct comp_buffer *source,
+static void pcm_convert_s32_to_s24(const struct comp_buffer *source,
 				   struct comp_buffer *sink, uint32_t samples)
 {
 	ae_int32x2 *in = (ae_int32x2 *)source->r_ptr;

--- a/src/audio/pcm_converter/pcm_converter_hifi3.c
+++ b/src/audio/pcm_converter/pcm_converter_hifi3.c
@@ -589,4 +589,4 @@ const struct pcm_func_map pcm_func_map[] = {
 
 const size_t pcm_func_count = ARRAY_SIZE(pcm_func_map);
 
-#endif
+#endif /* PCM_CONVERTER_HIFI3 */

--- a/src/audio/pcm_converter/pcm_converter_hifi3.c
+++ b/src/audio/pcm_converter/pcm_converter_hifi3.c
@@ -26,10 +26,10 @@
  * \brief Sets buffer to be circular using HiFi3 functions.
  * \param[in,out] buffer Circular buffer.
  */
-static void pcm_converter_setup_circular(const struct comp_buffer *buffer)
+static void pcm_converter_setup_circular(const struct comp_buffer *source)
 {
-	AE_SETCBEGIN0(buffer->addr);
-	AE_SETCEND0(buffer->end_addr);
+	AE_SETCBEGIN0(source->addr);
+	AE_SETCEND0(source->end_addr);
 }
 
 #if CONFIG_FORMAT_S16LE && CONFIG_FORMAT_S24LE

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -233,8 +233,9 @@ static inline void buffer_reset_pos(struct comp_buffer *buffer, void *data)
 	buffer_zero(buffer);
 }
 
-static inline void *buffer_get_frag(struct comp_buffer *buffer, void *ptr,
-				    uint32_t idx, uint32_t size)
+static inline void *buffer_get_frag(const struct comp_buffer *buffer,
+				    const void *ptr, uint32_t idx,
+				    uint32_t size)
 {
 	void *current = (char *)ptr + (idx * size);
 
@@ -311,7 +312,7 @@ static inline void buffer_init(struct comp_buffer *buffer, uint32_t size,
 	buffer_zero(buffer);
 }
 
-static inline void buffer_copy(struct comp_buffer *source,
+static inline void buffer_copy(const struct comp_buffer *source,
 			       struct comp_buffer *sink, uint32_t bytes)
 {
 	void *src = source->r_ptr;
@@ -345,7 +346,7 @@ static inline void buffer_copy(struct comp_buffer *source,
 
 #if CONFIG_FORMAT_S16LE
 
-static inline void buffer_copy_s16(struct comp_buffer *source,
+static inline void buffer_copy_s16(const struct comp_buffer *source,
 				   struct comp_buffer *sink, uint32_t samples)
 {
 	buffer_copy(source, sink, samples * sizeof(int16_t));
@@ -355,7 +356,7 @@ static inline void buffer_copy_s16(struct comp_buffer *source,
 
 #if CONFIG_FORMAT_S24LE || CONFIG_FORMAT_S32LE
 
-static inline void buffer_copy_s32(struct comp_buffer *source,
+static inline void buffer_copy_s32(const struct comp_buffer *source,
 				   struct comp_buffer *sink, uint32_t samples)
 {
 	buffer_copy(source, sink, samples * sizeof(int32_t));

--- a/src/include/sof/audio/pcm_converter.h
+++ b/src/include/sof/audio/pcm_converter.h
@@ -36,13 +36,20 @@ struct comp_buffer;
 
 #endif
 
+/**
+ * \brief PCM conversion function interface for data in circular buffer
+ * \param source buffer with samples to process, read pointer is not modified
+ * \param sink output buffer, write pointer is not modified
+ * \param samples number of samples to convert
+ */
+typedef void (*pcm_converter_func)(struct comp_buffer *source,
+				   struct comp_buffer *sink, uint32_t samples);
+
 /** \brief PCM conversion functions map. */
 struct pcm_func_map {
 	enum sof_ipc_frame source;	/**< source frame format */
 	enum sof_ipc_frame sink;	/**< sink frame format */
-	/**< PCM conversion function */
-	void (*func)(struct comp_buffer *source, struct comp_buffer *sink,
-		     uint32_t samples);
+	pcm_converter_func func; /**< PCM conversion function */
 };
 
 /** \brief Map of formats with dedicated conversion functions. */
@@ -51,16 +58,14 @@ extern const struct pcm_func_map pcm_func_map[];
 /** \brief Number of conversion functions. */
 extern const uint32_t pcm_func_count;
 
-typedef void (*conversion)(struct comp_buffer *, struct comp_buffer *,
-			   uint32_t);
-
 /**
  * \brief Retrieves PCM conversion function.
  * \param[in] in Source frame format.
  * \param[in] out Sink frame format.
  */
-static inline conversion pcm_get_conversion_function(enum sof_ipc_frame in,
-						     enum sof_ipc_frame out)
+static inline pcm_converter_func
+pcm_get_conversion_function(enum sof_ipc_frame in,
+			    enum sof_ipc_frame out)
 {
 	uint32_t i;
 

--- a/src/include/sof/audio/pcm_converter.h
+++ b/src/include/sof/audio/pcm_converter.h
@@ -42,7 +42,7 @@ struct comp_buffer;
  * \param sink output buffer, write pointer is not modified
  * \param samples number of samples to convert
  */
-typedef void (*pcm_converter_func)(struct comp_buffer *source,
+typedef void (*pcm_converter_func)(const struct comp_buffer *source,
 				   struct comp_buffer *sink, uint32_t samples);
 
 /** \brief PCM conversion functions map. */

--- a/src/include/sof/lib/dma.h
+++ b/src/include/sof/lib/dma.h
@@ -486,14 +486,14 @@ static inline uint32_t dma_sg_get_size(struct dma_sg_elem_array *ea)
 /* copies data from DMA buffer using provided processing function */
 void dma_buffer_copy_from(struct comp_buffer *source, uint32_t source_bytes,
 			  struct comp_buffer *sink, uint32_t sink_bytes,
-			  void (*process)(struct comp_buffer *,
+			  void (*process)(const struct comp_buffer *,
 					  struct comp_buffer *, uint32_t),
 			  uint32_t samples);
 
 /* copies data to DMA buffer using provided processing function */
 void dma_buffer_copy_to(struct comp_buffer *source, uint32_t source_bytes,
 			struct comp_buffer *sink, uint32_t sink_bytes,
-			void (*process)(struct comp_buffer *,
+			void (*process)(const struct comp_buffer *,
 					struct comp_buffer *, uint32_t),
 			uint32_t samples);
 

--- a/src/lib/dma.c
+++ b/src/lib/dma.c
@@ -191,7 +191,7 @@ void dma_sg_free(struct dma_sg_elem_array *elem_array)
 
 void dma_buffer_copy_from(struct comp_buffer *source, uint32_t source_bytes,
 			  struct comp_buffer *sink, uint32_t sink_bytes,
-			  void (*process)(struct comp_buffer *,
+			  void (*process)(const struct comp_buffer *,
 					  struct comp_buffer *, uint32_t),
 			  uint32_t samples)
 {
@@ -223,7 +223,7 @@ void dma_buffer_copy_from(struct comp_buffer *source, uint32_t source_bytes,
 
 void dma_buffer_copy_to(struct comp_buffer *source, uint32_t source_bytes,
 			struct comp_buffer *sink, uint32_t sink_bytes,
-			void (*process)(struct comp_buffer *,
+			void (*process)(const struct comp_buffer *,
 					struct comp_buffer *, uint32_t),
 			uint32_t samples)
 {


### PR DESCRIPTION
Input buffer should be explicit marked as const to indicate
that input samples and other comp_buffer fields shouldn't
be modified (especially r_ptr/w_ptr).