### PR TITLE
drivers: intel: M/N initial driver and fixes

### DIFF
--- a/src/drivers/intel/cavs/CMakeLists.txt
+++ b/src/drivers/intel/cavs/CMakeLists.txt
@@ -25,6 +25,10 @@ if(CONFIG_CAVS_SSP)
 	add_local_sources(sof ssp.c)
 endif()
 
+if(CONFIG_CAVS_MN)
+	add_local_sources(sof mn.c)
+endif()
+
 if(CONFIG_CAVS_ALH)
 	add_local_sources(sof alh.c)
 endif()

--- a/src/drivers/intel/cavs/Kconfig
+++ b/src/drivers/intel/cavs/Kconfig
@@ -96,9 +96,17 @@ endmenu # "Decimation factors"
 
 endif # CAVS_DMIC
 
+config CAVS_MN
+	bool
+	depends on CAVS
+	default n
+	help
+	  Select this to enable driver for Intel M/N divider.
+
 config CAVS_SSP
 	bool "Intel cAVS SSP driver"
 	depends on CAVS
+	select CAVS_MN
 	default n
 	help
 	  Select this to enable Intel cAVS Synchronous Serial Port (SSP) driver.

--- a/src/drivers/intel/cavs/mn.c
+++ b/src/drivers/intel/cavs/mn.c
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2020 Intel Corporation. All rights reserved.
+//
+// Author: Janusz Jankowski <janusz.jankowski@linux.intel.com>
+
+#include <sof/drivers/mn.h>
+#include <sof/drivers/ssp.h>
+#include <sof/lib/shim.h>
+#include <sof/math/numbers.h>
+#include <sof/trace/trace.h>
+
+/* tracing */
+#define trace_mn(__e, ...) \
+	trace_event(TRACE_CLASS_MN, __e, ##__VA_ARGS__)
+#define trace_mn_error(__e, ...) \
+	trace_error(TRACE_CLASS_MN, __e, ##__VA_ARGS__)
+#define tracev_mn(__e, ...) \
+	tracev_event(TRACE_CLASS_MN, __e, ##__VA_ARGS__)
+
+int mn_set_mclk(uint16_t mclk_id, uint32_t mclk_rate)
+{
+	uint32_t mdivr;
+	uint32_t mdivr_val;
+	uint32_t mdivc = mn_reg_read(MN_MDIVCTRL);
+	int i;
+	int clk_index = -1;
+
+	if (mclk_id > 1) {
+		trace_mn_error("error: mclk ID (%d) > 1", mclk_id);
+		return -EINVAL;
+	}
+
+	/* Enable MCLK Divider */
+	mdivc |= MN_MDIVCTRL_M_DIV_ENABLE;
+
+	/* searching the smallest possible mclk source */
+	for (i = MAX_SSP_FREQ_INDEX; i >= 0; i--) {
+		if (mclk_rate > ssp_freq[i].freq)
+			break;
+
+		if (ssp_freq[i].freq % mclk_rate == 0)
+			clk_index = i;
+	}
+
+	if (clk_index >= 0) {
+		mdivc |= MCDSS(ssp_freq_sources[clk_index]);
+	} else {
+		trace_mn_error("error: MCLK %d", mclk_rate);
+		return -EINVAL;
+	}
+
+	mdivr_val = ssp_freq[clk_index].freq / mclk_rate;
+
+	switch (mdivr_val) {
+	case 1:
+		mdivr = 0x00000fff; /* bypass divider for MCLK */
+		break;
+	case 2:
+		mdivr = 0x0; /* 1/2 */
+		break;
+	case 4:
+		mdivr = 0x2; /* 1/4 */
+		break;
+	case 8:
+		mdivr = 0x6; /* 1/8 */
+		break;
+	default:
+		trace_mn_error("error: invalid mdivr_val %d", mdivr_val);
+		return -EINVAL;
+	}
+
+	mn_reg_write(MN_MDIVCTRL, mdivc);
+	mn_reg_write(MN_MDIVR(mclk_id), mdivr);
+
+	return 0;
+}
+
+/**
+ * \brief Finds valid M/(N * SCR) values for given frequencies.
+ * \param[in] freq SSP clock frequency.
+ * \param[in] bclk Bit clock frequency.
+ * \param[out] out_scr_div SCR divisor.
+ * \param[out] out_m M value of M/N divider.
+ * \param[out] out_n N value of M/N divider.
+ * \return true if found suitable values, false otherwise.
+ */
+static bool find_mn(uint32_t freq, uint32_t bclk,
+		    uint32_t *out_scr_div, uint32_t *out_m, uint32_t *out_n)
+{
+	uint32_t m, n, mn_div;
+	uint32_t scr_div;
+
+	/* M/(N * scr_div) has to be less than 1/2 */
+	if ((bclk * 2) >= freq)
+		return false;
+
+	scr_div = freq / bclk;
+
+	/* odd SCR gives lower duty cycle */
+	if (scr_div > 1 && scr_div % 2 != 0)
+		--scr_div;
+
+	/* clamp to valid SCR range */
+	scr_div = MIN(scr_div, (SSCR0_SCR_MASK >> 8) + 1);
+
+	/* find highest even divisor */
+	while (scr_div > 1 && freq % scr_div != 0)
+		scr_div -= 2;
+
+	/* compute M/N with smallest dividend and divisor */
+	mn_div = gcd(bclk, freq / scr_div);
+
+	m = bclk / mn_div;
+	n = freq / scr_div / mn_div;
+
+	/* M/N values can be up to 24 bits */
+	if (n & (~0xffffff))
+		return false;
+
+	*out_scr_div = scr_div;
+	*out_m = m;
+	*out_n = n;
+
+	return true;
+}
+
+int mn_set_bclk(uint32_t dai_index, uint32_t bclk_rate,
+		uint32_t *out_scr_div, bool *out_need_ecs)
+{
+	uint32_t i2s_m = 1;
+	uint32_t i2s_n = 1;
+	uint32_t mdivc = mn_reg_read(MN_MDIVCTRL);
+	int i;
+	int clk_index = -1;
+
+	*out_need_ecs = false;
+
+	/* searching the smallest possible bclk source */
+	for (i = MAX_SSP_FREQ_INDEX; i >= 0; i--) {
+		if (bclk_rate > ssp_freq[i].freq)
+			break;
+
+		if (ssp_freq[i].freq % bclk_rate == 0)
+			clk_index = i;
+	}
+
+	if (clk_index >= 0) {
+		mdivc |= MNDSS(ssp_freq_sources[clk_index]);
+		*out_scr_div = ssp_freq[clk_index].freq / bclk_rate;
+
+		/* select M/N output for bclk in case of Audio Cardinal
+		 * or PLL Fixed clock.
+		 */
+		if (ssp_freq_sources[clk_index] != SSP_CLOCK_XTAL_OSCILLATOR)
+			*out_need_ecs = true;
+	} else {
+		/* check if we can get target BCLK with M/N */
+		for (i = 0; i <= MAX_SSP_FREQ_INDEX; i++) {
+			if (find_mn(ssp_freq[i].freq, bclk_rate,
+				    out_scr_div, &i2s_m, &i2s_n)) {
+				clk_index = i;
+				break;
+			}
+		}
+
+		if (clk_index < 0) {
+			trace_mn_error("error: BCLK %d", bclk_rate);
+			return -EINVAL;
+		}
+
+		trace_mn("M = %d, N = %d", i2s_m, i2s_n);
+
+		mdivc |= MNDSS(ssp_freq_sources[clk_index]);
+
+		/* M/N requires external clock to be selected */
+		*out_need_ecs = true;
+	}
+
+	mn_reg_write(MN_MDIVCTRL, mdivc);
+	mn_reg_write(MN_MDIV_M_VAL(dai_index), i2s_m);
+	mn_reg_write(MN_MDIV_N_VAL(dai_index), i2s_n);
+
+	return 0;
+}
+
+void mn_reset_bclk_divider(uint32_t dai_index)
+{
+	mn_reg_write(MN_MDIV_M_VAL(dai_index), 1);
+	mn_reg_write(MN_MDIV_N_VAL(dai_index), 1);
+}

--- a/src/drivers/intel/cavs/mn.c
+++ b/src/drivers/intel/cavs/mn.c
@@ -19,10 +19,35 @@
 #define tracev_mn(__e, ...) \
 	tracev_event(TRACE_CLASS_MN, __e, ##__VA_ARGS__)
 
+/** \brief BCLKs can be driven by multiple sources - M/N or XTAL directly.
+ *	   Even in the case of M/N, the actual clock source can be XTAL,
+ *	   Audio cardinal clock (24.576) or 96 MHz PLL.
+ *	   The MN block is not really the source of clocks, but rather
+ *	   an intermediate component.
+ *	   Input for source is shared by all outputs coming from that source
+ *	   and once it's in use, it can be adjusted only with dividers.
+ *	   In order to change input, the source should not be in use, that's why
+ *	   it's necessary to keep track of BCLKs sources to know when it's safe
+ *	   to change shared input clock.
+ */
+enum bclk_source {
+	MN_BCLK_SOURCE_NONE = 0, /**< port is not using any clock */
+	MN_BCLK_SOURCE_MN, /**< port is using clock driven by M/N */
+	MN_BCLK_SOURCE_XTAL, /**< port is using XTAL directly */
+};
+
 static spinlock_t mn_lock;
+
+static enum bclk_source bclk_sources[(DAI_NUM_SSP_BASE + DAI_NUM_SSP_EXT)];
+static int bclk_source_mn_clock;
 
 void mn_init(void)
 {
+	int i;
+
+	for (i = 0; i < ARRAY_SIZE(bclk_sources); i++)
+		bclk_sources[i] = MN_BCLK_SOURCE_NONE;
+
 	spinlock_init(&mn_lock);
 }
 
@@ -106,13 +131,20 @@ static bool find_mn(uint32_t freq, uint32_t bclk,
 		    uint32_t *out_scr_div, uint32_t *out_m, uint32_t *out_n)
 {
 	uint32_t m, n, mn_div;
-	uint32_t scr_div;
+	uint32_t scr_div = freq / bclk;
+
+	/* check if just SCR is enough */
+	if (freq % bclk == 0 && scr_div < (SSCR0_SCR_MASK >> 8) + 1) {
+		*out_scr_div = scr_div;
+		*out_m = 1;
+		*out_n = 1;
+
+		return true;
+	}
 
 	/* M/(N * scr_div) has to be less than 1/2 */
 	if ((bclk * 2) >= freq)
 		return false;
-
-	scr_div = freq / bclk;
 
 	/* odd SCR gives lower duty cycle */
 	if (scr_div > 1 && scr_div % 2 != 0)
@@ -142,71 +174,192 @@ static bool find_mn(uint32_t freq, uint32_t bclk,
 	return true;
 }
 
+/**
+ * \brief Finds index of clock valid for given BCLK rate.
+ *	  Clock that can use just SCR is preferred.
+ *	  M/N other than 1/1 is used only if there are no other possibilities.
+ * \param[in] bclk Bit clock frequency.
+ * \param[out] scr_div SCR divisor.
+ * \param[out] m M value of M/N divider.
+ * \param[out] n N value of M/N divider.
+ * \return index of suitable clock if could find it, -1 otherwise.
+ */
+static int find_bclk_source(uint32_t bclk,
+			    uint32_t *scr_div, uint32_t *m, uint32_t *n)
+{
+	int i;
+
+	/* searching the smallest possible bclk source */
+	for (i = 0; i <= MAX_SSP_FREQ_INDEX; i++)
+		if (ssp_freq[i].freq % bclk == 0) {
+			*scr_div = ssp_freq[i].freq / bclk;
+			return i;
+		}
+
+	/* check if we can get target BCLK with M/N */
+	for (i = 0; i <= MAX_SSP_FREQ_INDEX; i++)
+		if (find_mn(ssp_freq[i].freq, bclk,
+			    scr_div, m, n))
+			return i;
+
+	return -1;
+}
+
+/**
+ * \brief Checks if given clock is used as source for any BCLK.
+ * \param[in] clk_src Bit clock source.
+ * \return true if any port use given clock source, false otherwise.
+ */
+static inline bool is_bclk_source_in_use(enum bclk_source clk_src)
+{
+	int i;
+
+	for (i = 0; i < ARRAY_SIZE(bclk_sources); i++)
+		if (bclk_sources[i] == clk_src)
+			return true;
+	return false;
+}
+
+/**
+ * \brief Configures M/N source clock for BCLK.
+ *	  All ports that use M/N share the same source, so it should be changed
+ *	  only if there are no other ports using M/N already.
+ * \param[in] bclk Bit clock frequency.
+ * \param[out] scr_div SCR divisor.
+ * \param[out] m M value of M/N divider.
+ * \param[out] n N value of M/N divider.
+ * \return 0 on success, error code otherwise.
+ */
+static inline int setup_initial_bclk_mn_source(uint32_t bclk, uint32_t *scr_div,
+					       uint32_t *m, uint32_t *n)
+{
+	int clk_index = find_bclk_source(bclk, scr_div, m, n);
+
+	if (clk_index < 0) {
+		trace_mn_error("error: BCLK %d, no valid source", bclk);
+		return -EINVAL;
+	}
+
+	bclk_source_mn_clock = clk_index;
+
+	mn_reg_write(MN_MDIVCTRL, (mn_reg_read(MN_MDIVCTRL) |
+				   MNDSS(ssp_freq_sources[clk_index])));
+	return 0;
+}
+
+/**
+ * \brief Finds valid M/(N * SCR) values for source clock that is already locked
+ *	  because other ports use it.
+ * \param[in] bclk Bit clock frequency.
+ * \param[out] scr_div SCR divisor.
+ * \param[out] m M value of M/N divider.
+ * \param[out] n N value of M/N divider.
+ * \return 0 on success, error code otherwise.
+ */
+static inline int setup_current_bclk_mn_source(uint32_t bclk, uint32_t *scr_div,
+					       uint32_t *m, uint32_t *n)
+{
+	/* source for M/N is already set, no need to do it */
+	if (find_mn(ssp_freq[bclk_source_mn_clock].freq, bclk, scr_div, m, n))
+		return 0;
+
+	trace_mn_error("error: BCLK %d, no valid configuration for already selected source = %d",
+		       bclk, bclk_source_mn_clock);
+	return -EINVAL;
+}
+
+#if CAVS_VERSION >= CAVS_VERSION_2_0
+static inline bool check_bclk_xtal_source(uint32_t bclk, bool mn_in_use,
+					  uint32_t *scr_div)
+{
+	/* since cAVS 2.0 bypassing XTAL (ECS=0) is not supported */
+	return false;
+}
+#else
+/**
+ * \brief Checks if XTAL source for BCLK should be used.
+ *	  Before cAVS 2.0 BCLK could use XTAL directly (without M/N).
+ *	  BCLK that use M/N = 1/1 or bypass XTAL is preferred.
+ * \param[in] bclk Bit clock frequency.
+ * \param[in] mn_in_use True if M/N source is already locked by another port.
+ * \param[out] scr_div SCR divisor.
+ * \return true if XTAL source should be used, false otherwise.
+ */
+static inline bool check_bclk_xtal_source(uint32_t bclk, bool mn_in_use,
+					  uint32_t *scr_div)
+{
+	int i;
+
+	for (i = 0; i <= MAX_SSP_FREQ_INDEX; i++) {
+		if (ssp_freq[i].freq % bclk != 0)
+			continue;
+
+		if (ssp_freq_sources[i] == SSP_CLOCK_XTAL_OSCILLATOR) {
+			/* XTAL turned out to be lowest source that can work
+			 * just with SCR, so use it
+			 */
+			*scr_div = ssp_freq[i].freq / bclk;
+			return true;
+		}
+
+		/* if M/N is already set up for desired clock,
+		 * we can quit and let M/N logic handle it
+		 */
+		if (!mn_in_use || bclk_source_mn_clock == i)
+			return false;
+	}
+
+	return false;
+}
+#endif
+
 int mn_set_bclk(uint32_t dai_index, uint32_t bclk_rate,
 		uint32_t *out_scr_div, bool *out_need_ecs)
 {
-	uint32_t i2s_m = 1;
-	uint32_t i2s_n = 1;
-	uint32_t mdivc;
-	int i;
-	int clk_index = -1;
+	uint32_t m = 1;
+	uint32_t n = 1;
 	int ret = 0;
-
-	*out_need_ecs = false;
+	bool mn_in_use;
 
 	spin_lock(&mn_lock);
-	mdivc = mn_reg_read(MN_MDIVCTRL);
 
-	/* searching the smallest possible bclk source */
-	for (i = MAX_SSP_FREQ_INDEX; i >= 0; i--) {
-		if (bclk_rate > ssp_freq[i].freq)
-			break;
+	bclk_sources[dai_index] = MN_BCLK_SOURCE_NONE;
 
-		if (ssp_freq[i].freq % bclk_rate == 0)
-			clk_index = i;
+	mn_in_use = is_bclk_source_in_use(MN_BCLK_SOURCE_MN);
+
+	if (check_bclk_xtal_source(bclk_rate, mn_in_use, out_scr_div)) {
+		bclk_sources[dai_index] = MN_BCLK_SOURCE_XTAL;
+		*out_need_ecs = false;
+		goto out;
 	}
 
-	if (clk_index >= 0) {
-		mdivc |= MNDSS(ssp_freq_sources[clk_index]);
-		*out_scr_div = ssp_freq[clk_index].freq / bclk_rate;
+	*out_need_ecs = true;
 
-		/* select M/N output for bclk in case of Audio Cardinal
-		 * or PLL Fixed clock.
-		 */
-		if (ssp_freq_sources[clk_index] != SSP_CLOCK_XTAL_OSCILLATOR)
-			*out_need_ecs = true;
-	} else {
-		/* check if we can get target BCLK with M/N */
-		for (i = 0; i <= MAX_SSP_FREQ_INDEX; i++) {
-			if (find_mn(ssp_freq[i].freq, bclk_rate,
-				    out_scr_div, &i2s_m, &i2s_n)) {
-				clk_index = i;
-				break;
-			}
-		}
+	if (mn_in_use)
+		ret = setup_current_bclk_mn_source(bclk_rate,
+						   out_scr_div, &m, &n);
+	else
+		ret = setup_initial_bclk_mn_source(bclk_rate,
+						   out_scr_div, &m, &n);
 
-		if (clk_index < 0) {
-			trace_mn_error("error: BCLK %d", bclk_rate);
-			ret = -EINVAL;
-			goto out;
-		}
+	if (ret >= 0) {
+		bclk_sources[dai_index] = MN_BCLK_SOURCE_MN;
 
-		trace_mn("M = %d, N = %d", i2s_m, i2s_n);
-
-		mdivc |= MNDSS(ssp_freq_sources[clk_index]);
-
-		/* M/N requires external clock to be selected */
-		*out_need_ecs = true;
+		mn_reg_write(MN_MDIV_M_VAL(dai_index), m);
+		mn_reg_write(MN_MDIV_N_VAL(dai_index), n);
 	}
-
-	mn_reg_write(MN_MDIVCTRL, mdivc);
-	mn_reg_write(MN_MDIV_M_VAL(dai_index), i2s_m);
-	mn_reg_write(MN_MDIV_N_VAL(dai_index), i2s_n);
 
 out:
 	spin_unlock(&mn_lock);
 
 	return ret;
+}
+
+void mn_release_bclk(uint32_t dai_index)
+{
+	spin_lock(&mn_lock);
+	bclk_sources[dai_index] = MN_BCLK_SOURCE_NONE;
+	spin_unlock(&mn_lock);
 }
 
 void mn_reset_bclk_divider(uint32_t dai_index)

--- a/src/drivers/intel/cavs/mn.c
+++ b/src/drivers/intel/cavs/mn.c
@@ -60,8 +60,9 @@ int mn_set_mclk(uint16_t mclk_id, uint32_t mclk_rate)
 	int clk_index = -1;
 	int ret = 0;
 
-	if (mclk_id > 1) {
-		trace_mn_error("error: mclk ID (%d) > 1", mclk_id);
+	if (mclk_id >= DAI_NUM_SSP_MCLK) {
+		trace_mn_error("error: mclk ID (%d) >= %d",
+			       mclk_id, DAI_NUM_SSP_MCLK);
 		return -EINVAL;
 	}
 

--- a/src/drivers/intel/cavs/ssp.c
+++ b/src/drivers/intel/cavs/ssp.c
@@ -785,8 +785,11 @@ static int ssp_probe(struct dai *dai)
 
 static int ssp_remove(struct dai *dai)
 {
+	struct ssp_pdata *ssp = dai_get_drvdata(dai);
+
 	pm_runtime_put_sync(SSP_CLK, dai->index);
 
+	mn_release_mclk(ssp->config.ssp.mclk_id);
 	mn_release_bclk(dai->index);
 
 	/* Disable SSP power */

--- a/src/drivers/intel/cavs/ssp.c
+++ b/src/drivers/intel/cavs/ssp.c
@@ -787,6 +787,8 @@ static int ssp_remove(struct dai *dai)
 {
 	pm_runtime_put_sync(SSP_CLK, dai->index);
 
+	mn_release_bclk(dai->index);
+
 	/* Disable SSP power */
 	pm_runtime_put_sync(SSP_POW, dai->index);
 

--- a/src/include/sof/drivers/mn.h
+++ b/src/include/sof/drivers/mn.h
@@ -27,6 +27,11 @@
 #define MN_MDIV_N_VAL(x) (0x100 + (x) * 0x8 + 0x4)
 
 /**
+ * \brief Initializes MN driver.
+ */
+void mn_init(void);
+
+/**
  * \brief Finds and sets valid combination of MCLK source and divider to
  *	  achieve requested MCLK rate.
  *	  M value of M/N is not supported for MCLK, only divider can be used.

--- a/src/include/sof/drivers/mn.h
+++ b/src/include/sof/drivers/mn.h
@@ -1,0 +1,58 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2020 Intel Corporation. All rights reserved.
+ *
+ * Author: Janusz Jankowski <janusz.jankowski@linux.intel.com>
+ */
+
+#ifndef __SOF_DRIVERS_MN_H__
+#define __SOF_DRIVERS_MN_H__
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/** \brief Offset of MCLK Divider Control Register. */
+#define MN_MDIVCTRL 0x0
+
+/** \brief Enables the output of MCLK Divider. */
+#define MN_MDIVCTRL_M_DIV_ENABLE BIT(0)
+
+/** \brief Offset of MCLK Divider x Ratio Register. */
+#define MN_MDIVR(x) (0x80 + (x) * 0x4)
+
+/** \brief Offset of BCLK x M/N Divider M Value Register. */
+#define MN_MDIV_M_VAL(x) (0x100 + (x) * 0x8 + 0x0)
+
+/** \brief Offset of BCLK x M/N Divider N Value Register. */
+#define MN_MDIV_N_VAL(x) (0x100 + (x) * 0x8 + 0x4)
+
+/**
+ * \brief Finds and sets valid combination of MCLK source and divider to
+ *	  achieve requested MCLK rate.
+ *	  M value of M/N is not supported for MCLK, only divider can be used.
+ * \param[in] mclk_id id of master clock for which rate should be set.
+ * \param[in] mclk_rate master clock frequency.
+ * \return 0 on success otherwise a negative error code.
+ */
+int mn_set_mclk(uint16_t mclk_id, uint32_t mclk_rate);
+
+/**
+ * \brief Finds and sets valid combination of BCLK source and M/N to
+ *	  achieve requested BCLK rate.
+ * \param[in] dai_index DAI index (SSP port).
+ * \param[in] bclk_rate Bit clock frequency.
+ * \param[out] out_scr_div SCR divisor that should be set by caller to achieve
+ *			   requested BCLK rate.
+ * \param[out] out_need_ecs If set to true, the caller should configure ECS.
+ * \return 0 on success otherwise a negative error code.
+ */
+int mn_set_bclk(uint32_t dai_index, uint32_t bclk_rate,
+		uint32_t *out_scr_div, bool *out_need_ecs);
+
+/**
+ * \brief Resets M & N values of M/N divider for given DAI index.
+ * \param[in] dai_index DAI index (SSP port).
+ */
+void mn_reset_bclk_divider(uint32_t dai_index);
+
+#endif /* __SOF_DRIVERS_MN_H__ */

--- a/src/include/sof/drivers/mn.h
+++ b/src/include/sof/drivers/mn.h
@@ -34,12 +34,20 @@ void mn_init(void);
 /**
  * \brief Finds and sets valid combination of MCLK source and divider to
  *	  achieve requested MCLK rate.
+ *	  User should release clock when it is no longer needed to allow
+ *	  driver to change MCLK M/N source when user count drops to 0.
  *	  M value of M/N is not supported for MCLK, only divider can be used.
  * \param[in] mclk_id id of master clock for which rate should be set.
  * \param[in] mclk_rate master clock frequency.
  * \return 0 on success otherwise a negative error code.
  */
 int mn_set_mclk(uint16_t mclk_id, uint32_t mclk_rate);
+
+/**
+ * \brief Release previously requested MCLK for given MCLK ID.
+ * \param[in] mclk_id id of master clock.
+ */
+void mn_release_mclk(uint32_t mclk_id);
 
 /**
  * \brief Finds and sets valid combination of BCLK source and M/N to

--- a/src/include/sof/drivers/mn.h
+++ b/src/include/sof/drivers/mn.h
@@ -44,15 +44,24 @@ int mn_set_mclk(uint16_t mclk_id, uint32_t mclk_rate);
 /**
  * \brief Finds and sets valid combination of BCLK source and M/N to
  *	  achieve requested BCLK rate.
+ *	  User should release clock when it is no longer needed to allow
+ *	  driver to change M/N source when user count drops to 0.
  * \param[in] dai_index DAI index (SSP port).
  * \param[in] bclk_rate Bit clock frequency.
  * \param[out] out_scr_div SCR divisor that should be set by caller to achieve
  *			   requested BCLK rate.
  * \param[out] out_need_ecs If set to true, the caller should configure ECS.
  * \return 0 on success otherwise a negative error code.
+ * \see mn_release_bclk()
  */
 int mn_set_bclk(uint32_t dai_index, uint32_t bclk_rate,
 		uint32_t *out_scr_div, bool *out_need_ecs);
+
+/**
+ * \brief Release previously requested BCLK for given DAI.
+ * \param[in] dai_index DAI index (SSP port).
+ */
+void mn_release_bclk(uint32_t dai_index);
 
 /**
  * \brief Resets M & N values of M/N divider for given DAI index.

--- a/src/include/user/trace.h
+++ b/src/include/user/trace.h
@@ -63,6 +63,7 @@ struct system_time {
 #define TRACE_CLASS_CHMAP	(34 << 24)
 #define TRACE_CLASS_ASRC	(35 << 24)
 #define TRACE_CLASS_NOTIFIER	(36 << 24)
+#define TRACE_CLASS_MN		(37 << 24)
 
 #define LOG_ENABLE		1  /* Enable logging */
 #define LOG_DISABLE		0  /* Disable logging */

--- a/src/platform/apollolake/include/platform/lib/dai.h
+++ b/src/platform/apollolake/include/platform/lib/dai.h
@@ -26,6 +26,9 @@
 /** \brief Number of 'extended' SSP ports available */
 #define DAI_NUM_SSP_EXT		2
 
+/** \brief Number of SSP MCLKs available */
+#define DAI_NUM_SSP_MCLK	2
+
 /* HD/A */
 
 /** \brief Number of HD/A Link Outputs */

--- a/src/platform/cannonlake/include/platform/lib/dai.h
+++ b/src/platform/cannonlake/include/platform/lib/dai.h
@@ -26,6 +26,9 @@
 /** \brief Number of 'extended' SSP ports available */
 #define DAI_NUM_SSP_EXT		0
 
+/** \brief Number of SSP MCLKs available */
+#define DAI_NUM_SSP_MCLK	2
+
 /* HD/A */
 
 /** \brief Number of HD/A Link Outputs */

--- a/src/platform/icelake/include/platform/lib/dai.h
+++ b/src/platform/icelake/include/platform/lib/dai.h
@@ -26,6 +26,9 @@
 /** \brief Number of 'extended' SSP ports available */
 #define DAI_NUM_SSP_EXT		0
 
+/** \brief Number of SSP MCLKs available */
+#define DAI_NUM_SSP_MCLK	2
+
 /* HD/A */
 
 /** \brief Number of HD/A Link Outputs */

--- a/src/platform/intel/cavs/lib/dai.c
+++ b/src/platform/intel/cavs/lib/dai.c
@@ -10,6 +10,7 @@
 #include <sof/common.h>
 #include <sof/drivers/hda.h>
 #include <sof/drivers/interrupt.h>
+#include <sof/drivers/mn.h>
 #include <sof/lib/dai.h>
 #include <sof/lib/dma.h>
 #include <sof/lib/memory.h>
@@ -151,6 +152,10 @@ int dai_init(struct sof *sof)
 	}
 
 	platform_shared_commit(dai, sizeof(*dai) * ARRAY_SIZE(ssp));
+#endif
+
+#if CONFIG_CAVS_MN
+	mn_init();
 #endif
 
 	dai = cache_to_uncache((struct dai *)hda);

--- a/src/platform/suecreek/include/platform/lib/dai.h
+++ b/src/platform/suecreek/include/platform/lib/dai.h
@@ -26,6 +26,9 @@
 /** \brief Number of 'extended' SSP ports available */
 #define DAI_NUM_SSP_EXT		0
 
+/** \brief Number of SSP MCLKs available */
+#define DAI_NUM_SSP_MCLK	2
+
 /** \brief Number of HD/A Link Outputs */
 #define DAI_NUM_HDA_OUT		9
 

--- a/src/platform/tigerlake/include/platform/lib/dai.h
+++ b/src/platform/tigerlake/include/platform/lib/dai.h
@@ -26,6 +26,9 @@
 /** \brief Number of 'extended' SSP ports available */
 #define DAI_NUM_SSP_EXT		0
 
+/** \brief Number of SSP MCLKs available */
+#define DAI_NUM_SSP_MCLK	2
+
 /* HD/A */
 
 /** \brief Number of HD/A Link Outputs */

--- a/tools/logger/convert.c
+++ b/tools/logger/convert.c
@@ -103,6 +103,7 @@ static const char * get_component_name(uint32_t component_id) {
 		CASE(CHMAP);
 		CASE(ASRC);
 		CASE(NOTIFIER);
+		CASE(MN);
 	default: return "unknown";
 	}
 }

--- a/tools/testbench/trace.c
+++ b/tools/testbench/trace.c
@@ -57,6 +57,7 @@ char *get_trace_class(uint32_t trace_class)
 		CASE(CHMAP);
 		CASE(ASRC);
 		CASE(NOTIFIER);
+		CASE(MN);
 	default: return "unknown";
 	}
 }


### PR DESCRIPTION
Initial MN driver version that should fix 2 major problems:
1) BCLK & MCLK logic was written like there were only 1 SSP port in existence, topologies with more SSPs in use could result in incorrect settings (config 2nd overriding source clock for config 1st etc).
2) ECS bit support was dropped in cAVS 2.0 and M/N is only supported source for BCLKs.
   
Fixes #2084   
 
