### PR TITLE
Add support for i.MX8

### DIFF
--- a/rimage/file_simple.c
+++ b/rimage/file_simple.c
@@ -568,3 +568,26 @@ const struct adsp machine_imx8 = {
 	.machine_id = MACHINE_IMX8,
 	.write_firmware = simple_write_firmware,
 };
+
+const struct adsp machine_imx8x = {
+	.name = "imx8x",
+	.mem_zones = {
+		[SOF_FW_BLK_TYPE_IRAM] = {
+			.base = IMX8_IRAM_BASE,
+			.size = IMX8_IRAM_SIZE,
+			.host_offset = IMX8_IRAM_HOST_OFFSET,
+		},
+		[SOF_FW_BLK_TYPE_DRAM] = {
+			.base = IMX8_DRAM_BASE,
+			.size = IMX8_DRAM_SIZE,
+			.host_offset = 0,
+		},
+		[SOF_FW_BLK_TYPE_SRAM] = {
+			.base = IMX8_SRAM_BASE,
+			.size = IMX8_SRAM_SIZE,
+			.host_offset = 0,
+		},
+	},
+	.machine_id = MACHINE_IMX8X,
+	.write_firmware = simple_write_firmware,
+};

--- a/rimage/rimage.c
+++ b/rimage/rimage.c
@@ -27,6 +27,7 @@ static const struct adsp *machine[] = {
 	&machine_kbl,
 	&machine_skl,
 	&machine_imx8,
+	&machine_imx8x,
 };
 
 static void usage(char *name)

--- a/rimage/rimage.h
+++ b/rimage/rimage.h
@@ -38,6 +38,7 @@ enum machine_id {
 	MACHINE_TIGERLAKE,
 	MACHINE_SUECREEK,
 	MACHINE_IMX8,
+	MACHINE_IMX8X,
 	MACHINE_MAX
 };
 
@@ -193,6 +194,6 @@ extern const struct adsp machine_sue;
 extern const struct adsp machine_skl;
 extern const struct adsp machine_kbl;
 extern const struct adsp machine_imx8;
-
+extern const struct adsp machine_imx8x;
 
 #endif

--- a/src/arch/xtensa/CMakeLists.txt
+++ b/src/arch/xtensa/CMakeLists.txt
@@ -25,6 +25,8 @@ elseif(CONFIG_TIGERLAKE)
 	endif()
 elseif(CONFIG_IMX8)
 	set(platform_folder imx8)
+elseif(CONFIG_IMX8X)
+	set(platform_folder imx8)
 endif()
 
 set(fw_name ${CONFIG_FIRMWARE_SHORT_NAME})

--- a/src/arch/xtensa/configs/imx8x_defconfig
+++ b/src/arch/xtensa/configs/imx8x_defconfig
@@ -1,0 +1,1 @@
+CONFIG_IMX8X=y

--- a/src/drivers/CMakeLists.txt
+++ b/src/drivers/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-if(CONFIG_IMX8)
+if(CONFIG_IMX)
 	add_subdirectory(imx)
 endif()
 

--- a/src/drivers/imx/interrupt.c
+++ b/src/drivers/imx/interrupt.c
@@ -69,8 +69,13 @@
  * usage in this driver.
  */
 
-#define IRQSTR_BASE_ADDR_QXP	0x51080000
-#define IRQSTR_BASE_ADDR	IRQSTR_BASE_ADDR_QXP
+#if defined CONFIG_IMX8
+#define IRQSTR_BASE_ADDR	0x510A0000
+#endif
+
+#if defined CONFIG_IMX8X
+#define IRQSTR_BASE_ADDR	0x51080000
+#endif
 
 /* The MASK, SET (unused) and STATUS registers are 512-bit registers
  * split into 16 32-bit registers that we can directly access.

--- a/src/platform/CMakeLists.txt
+++ b/src/platform/CMakeLists.txt
@@ -14,7 +14,7 @@ elseif(CONFIG_ICELAKE)
 	add_subdirectory(icelake)
 elseif(CONFIG_TIGERLAKE)
 	add_subdirectory(tigerlake)
-elseif(CONFIG_IMX8)
+elseif(CONFIG_IMX8 OR CONFIG_IMX8X)
 	add_subdirectory(imx8)
 endif()
 

--- a/src/platform/Kconfig
+++ b/src/platform/Kconfig
@@ -171,6 +171,19 @@ config IMX8
 	help
 	  Select if your target platform is imx8-compatible
 
+config IMX8X
+	bool "Build for NXP i.MX8X"
+	select HAVE_RESET_VECTOR_ROM
+	select INTERRUPT_LEVEL_1
+	select INTERRUPT_LEVEL_2
+	select INTERRUPT_LEVEL_3
+	select HOST_PTABLE
+	select DUMMY_DMA
+	select WAITI_DELAY
+	select IMX
+	help
+	  Select if your target platform is imx8x-compatible
+
 endchoice
 
 config INTEL
@@ -247,6 +260,7 @@ config FIRMWARE_SHORT_NAME
 	default "icl" if ICELAKE
 	default "tgl" if TIGERLAKE
 	default "imx8" if IMX8
+	default "imx8x" if IMX8X
 	default ""
 	help
 	  3-characters long firmware identifer

--- a/src/platform/Kconfig
+++ b/src/platform/Kconfig
@@ -167,6 +167,7 @@ config IMX8
 	select HOST_PTABLE
 	select DUMMY_DMA
 	select WAITI_DELAY
+	select IMX
 	help
 	  Select if your target platform is imx8-compatible
 
@@ -178,6 +179,13 @@ config INTEL
 	help
 	  This has to be selected for every Intel platform.
 	  It enables Intel platforms-specific features.
+
+config IMX
+	bool
+	default n
+	help
+	  This has to be selected for every i.MX NXP platform.
+	  It enables NXP platforms-specific features.
 
 config CAVS
 	bool


### PR DESCRIPTION
Short explanation for i.MX8 naming.

i.MX8 has 3 major platform sub-families:
* i.MX8
* i.MX8X
* i.MX8M

Looking at the integration of Hifi4 DSP, i.MX8 and i.MX8X are pretty similar. So, for this reason when
I added initial support I referred to both i.MX8 and i.MX8X as i.MX8, but in fact only i.MX8X was supported.

There is one notable difference -  IRQSTEER address is different. The current supported IRQSTEER address is the one in i.MX8X. So, this PR separates i.MX8X/i.MX8 like baytrail is separated from cherrytrail (using basically the same source files) with CONFIG_IMX8 / CONFIG_IMX8X to select the correct code.

Support for i.MX8M is in preparation and a patch will be sent soon.
