### PR TITLE
kpb: get correct threshold with valid bits

### DIFF
--- a/src/audio/detect_test.c
+++ b/src/audio/detect_test.c
@@ -783,7 +783,7 @@ static int test_keyword_prepare(struct comp_dev *dev)
 		 * according to host new format.
 		 */
 		cd->config.activation_threshold =
-			test_keyword_get_threshold(dev, sample_width);
+			test_keyword_get_threshold(dev, valid_bits);
 	}
 
 	return comp_set_state(dev, COMP_TRIGGER_PREPARE);


### PR DESCRIPTION
We should get threshold with valid bits rather than sample width. this patch fix  [KWD trigger failure under s16le](https://github.com/thesofproject/sof/issues/2113)
