### PR TITLE
Trace: dai unified identification and cleanup

### DIFF
--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -676,8 +676,8 @@ static int dai_config(struct comp_dev *dev, struct sof_ipc_dai_config *config)
 	int channel = 0;
 	int handshake;
 
-	trace_dai_comp_with_ids(dev, "config dai %d type %d",
-				config->dai_index, config->type);
+	trace_dai_comp_with_ids(dev, "dai_config() dai %d.%d",
+				config->type, config->dai_index);
 
 	/* cannot configure DAI while active */
 	if (dev->state == COMP_STATE_ACTIVE) {
@@ -691,7 +691,7 @@ static int dai_config(struct comp_dev *dev, struct sof_ipc_dai_config *config)
 		dd->config.burst_elems = config->ssp.tdm_slots;
 		break;
 	case SOF_DAI_INTEL_DMIC:
-		trace_dai_comp_with_ids(dev, "dai_config(), config->type = SOF_DAI_INTEL_DMIC");
+		tracev_dai_comp_with_ids(dev, "dai_config(), config->type = SOF_DAI_INTEL_DMIC");
 
 		/* We can use always the largest burst length. */
 		dd->config.burst_elems = 8;

--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -33,21 +33,21 @@
 #include <stdint.h>
 
 /* tracing */
-#define trace_dai(__e, ...)					\
+#define trace_dai_comp(__e, ...)				\
 	trace_event(TRACE_CLASS_DAI, __e, ##__VA_ARGS__)
-#define trace_dai_with_ids(comp_ptr, __e, ...)			\
+#define trace_dai_comp_with_ids(comp_ptr, __e, ...)		\
 	trace_event_comp(TRACE_CLASS_DAI, comp_ptr,		\
 			 __e, ##__VA_ARGS__)
 
-#define tracev_dai(__e, ...)					\
+#define tracev_dai_comp(__e, ...)				\
 	tracev_event(TRACE_CLASS_DAI, __e, ##__VA_ARGS__)
-#define tracev_dai_with_ids(comp_ptr, __e, ...)			\
+#define tracev_dai_comp_with_ids(comp_ptr, __e, ...)		\
 	tracev_event_comp(TRACE_CLASS_DAI, comp_ptr,		\
 			  __e, ##__VA_ARGS__)
 
-#define trace_dai_error(__e, ...)				\
+#define trace_dai_comp_error(__e, ...)				\
 	trace_error(TRACE_CLASS_DAI, __e, ##__VA_ARGS__)
-#define trace_dai_error_with_ids(comp_ptr, __e, ...)		\
+#define trace_dai_comp_error_with_ids(comp_ptr, __e, ...)	\
 	trace_error_comp(TRACE_CLASS_DAI, comp_ptr,		\
 			 __e, ##__VA_ARGS__)
 
@@ -86,7 +86,7 @@ static void dai_dma_cb(void *arg, enum notify_id type, void *data)
 	uint32_t samples = bytes / sample_bytes(dd->frame_fmt);
 	void *buffer_ptr;
 
-	tracev_dai_with_ids(dev, "dai_dma_cb()");
+	tracev_dai_comp_with_ids(dev, "dai_dma_cb()");
 
 	next->status = DMA_CB_STATUS_RELOAD;
 
@@ -144,7 +144,7 @@ static struct comp_dev *dai_new(struct sof_ipc_comp *comp)
 	uint32_t dir, caps, dma_dev;
 	int ret;
 
-	trace_dai("dai_new()");
+	trace_dai_comp("dai_new()");
 
 	if (IPC_IS_SIZE_INVALID(ipc_dai->config)) {
 		IPC_SIZE_ERROR_TRACE(TRACE_CLASS_DAI, ipc_dai->config);
@@ -171,8 +171,7 @@ static struct comp_dev *dai_new(struct sof_ipc_comp *comp)
 
 	dd->dai = dai_get(dai->type, dai->dai_index, DAI_CREAT);
 	if (!dd->dai) {
-		trace_dai_error("dai_new() error: dai_get() failed to create "
-				"DAI.");
+		trace_dai_comp_error("dai_new() error: dai_get() failed to create DAI.");
 		goto error;
 	}
 
@@ -185,8 +184,7 @@ static struct comp_dev *dai_new(struct sof_ipc_comp *comp)
 
 	dd->dma = dma_get(dir, caps, dma_dev, DMA_ACCESS_SHARED);
 	if (!dd->dma) {
-		trace_dai_error("dai_new() error: dma_get() failed to get "
-				"shared access to DMA.");
+		trace_dai_comp_error("dai_new() error: dma_get() failed to get shared access to DMA.");
 		goto error;
 	}
 
@@ -246,18 +244,16 @@ static int dai_playback_params(struct comp_dev *dev, uint32_t period_bytes,
 	config->is_scheduling_source = comp_is_scheduling_source(dev);
 	config->period = dev->pipeline->ipc_pipe.period;
 
-	trace_dai_with_ids(dev, "dai_playback_params() "
-			   "dest_dev = %d stream_id = %d "
-			   "src_width = %d dest_width = %d",
-			   config->dest_dev, dd->stream_id,
-			   config->src_width, config->dest_width);
+	trace_dai_comp_with_ids(dev, "dai_playback_params() dest_dev = %d stream_id = %d src_width = %d dest_width = %d",
+				config->dest_dev, dd->stream_id,
+				config->src_width, config->dest_width);
 
 	if (!config->elem_array.elems) {
 		fifo = dai_get_fifo(dd->dai, dev->direction,
 				    dd->stream_id);
 
-		trace_dai_with_ids(dev, "dai_playback_params() "
-				   "fifo %X", fifo);
+		trace_dai_comp_with_ids(dev, "dai_playback_params() fifo %X",
+					fifo);
 
 		err = dma_sg_alloc(&config->elem_array, SOF_MEM_ZONE_RUNTIME,
 				   config->direction,
@@ -266,9 +262,8 @@ static int dai_playback_params(struct comp_dev *dev, uint32_t period_bytes,
 				   (uintptr_t)(dd->dma_buffer->stream.addr),
 				   fifo);
 		if (err < 0) {
-			trace_dai_error_with_ids(dev, "dai_playback_params() "
-						 "error: dma_sg_alloc() failed "
-						 "with err = %d", err);
+			trace_dai_comp_error_with_ids(dev, "dai_playback_params() error: dma_sg_alloc() failed with err = %d",
+						      err);
 			return err;
 		}
 	}
@@ -310,18 +305,16 @@ static int dai_capture_params(struct comp_dev *dev, uint32_t period_bytes,
 		config->dest_width = sample_bytes(dd->frame_fmt);
 	}
 
-	trace_dai_with_ids(dev, "dai_capture_params() "
-			   "src_dev = %d stream_id = %d "
-			   "src_width = %d dest_width = %d",
-			   config->src_dev, dd->stream_id,
-			   config->src_width, config->dest_width);
+	trace_dai_comp_with_ids(dev, "dai_capture_params() src_dev = %d stream_id = %d src_width = %d dest_width = %d",
+				config->src_dev, dd->stream_id,
+				config->src_width, config->dest_width);
 
 	if (!config->elem_array.elems) {
 		fifo = dai_get_fifo(dd->dai, dev->direction,
 				    dd->stream_id);
 
-		trace_dai_with_ids(dev, "dai_capture_params() "
-				   "fifo %X", fifo);
+		trace_dai_comp_with_ids(dev, "dai_capture_params() fifo %X",
+					fifo);
 
 		err = dma_sg_alloc(&config->elem_array, SOF_MEM_ZONE_RUNTIME,
 				   config->direction,
@@ -330,9 +323,8 @@ static int dai_capture_params(struct comp_dev *dev, uint32_t period_bytes,
 				   (uintptr_t)(dd->dma_buffer->stream.addr),
 				   fifo);
 		if (err < 0) {
-			trace_dai_error_with_ids(dev, "dai_capture_params() "
-						 "error: dma_sg_alloc() failed "
-						 "with err = %d", err);
+			trace_dai_comp_error_with_ids(dev, "dai_capture_params() error: dma_sg_alloc() failed with err = %d",
+						      err);
 			return err;
 		}
 	}
@@ -353,7 +345,7 @@ static int dai_params(struct comp_dev *dev,
 	uint32_t align;
 	int err;
 
-	trace_dai_with_ids(dev, "dai_params()");
+	trace_dai_comp_with_ids(dev, "dai_params()");
 
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK)
 		dd->local_buffer = list_first_item(&dev->bsource_list,
@@ -366,42 +358,37 @@ static int dai_params(struct comp_dev *dev,
 
 	/* check if already configured */
 	if (dev->state == COMP_STATE_PREPARE) {
-		trace_dai_with_ids(dev, "dai_params() component has been "
-				   "already configured.");
+		trace_dai_comp_with_ids(dev, "dai_params() component has been already configured.");
 		return 0;
 	}
 
 	/* can set params on only init state */
 	if (dev->state != COMP_STATE_READY) {
-		trace_dai_error_with_ids(dev, "dai_params() error: Component"
-					 " is not in init state.");
+		trace_dai_comp_error_with_ids(dev, "dai_params() error: Component is not in init state.");
 		return -EINVAL;
 	}
 
 	err = dma_get_attribute(dd->dma, DMA_ATTR_BUFFER_ADDRESS_ALIGNMENT,
 				&addr_align);
 	if (err < 0) {
-		trace_dai_error_with_ids(dev, "dai_params() error: could not "
-					 "get dma buffer address alignment, "
-					 "err = %d", err);
+		trace_dai_comp_error_with_ids(dev, "dai_params() error: could not get dma buffer address alignment, err = %d",
+					      err);
 		return err;
 	}
 
 	err = dma_get_attribute(dd->dma, DMA_ATTR_BUFFER_ALIGNMENT, &align);
 	if (err < 0 || !align) {
-		trace_dai_error_with_ids(dev, "dai_params() error: could not "
-				"get valid dma buffer alignment, err = %d, "
-				"align = %u", err, align);
+		trace_dai_comp_error_with_ids(dev, "dai_params() error: could not get valid dma buffer alignment, err = %d, align = %u",
+					      err, align);
 		return -EINVAL;
 	}
 
 	err = dma_get_attribute(dd->dma, DMA_ATTR_BUFFER_PERIOD_COUNT,
 				&period_count);
 	if (err < 0 || !period_count) {
-		trace_dai_error_with_ids(dev, "dai_params() error: could not "
-					  "get valid dma buffer period count, "
-					  "err = %d, period_count = %u", err,
-					  period_count);
+		trace_dai_comp_error_with_ids(dev, "dai_params() error: could not get valid dma buffer period count, err = %d, period_count = %u",
+					      err,
+					      period_count);
 		return -EINVAL;
 	}
 
@@ -414,8 +401,7 @@ static int dai_params(struct comp_dev *dev,
 	/* calculate period size */
 	period_bytes = dev->frames * frame_size;
 	if (!period_bytes) {
-		trace_dai_error_with_ids(dev, "dai_params() error: invalid "
-					 "period_bytes.");
+		trace_dai_comp_error_with_ids(dev, "dai_params() error: invalid period_bytes.");
 		return -EINVAL;
 	}
 
@@ -426,18 +412,15 @@ static int dai_params(struct comp_dev *dev,
 	if (dd->dma_buffer) {
 		err = buffer_set_size(dd->dma_buffer, buffer_size);
 		if (err < 0) {
-			trace_dai_error_with_ids(dev, "dai_params() error: "
-						 "buffer_set_size() failed, "
-						 "buffer_size = %u",
-						 buffer_size);
+			trace_dai_comp_error_with_ids(dev, "dai_params() error: buffer_set_size() failed, buffer_size = %u",
+						      buffer_size);
 			return err;
 		}
 	} else {
 		dd->dma_buffer = buffer_alloc(buffer_size, SOF_MEM_CAPS_DMA,
 					      addr_align);
 		if (!dd->dma_buffer) {
-			trace_dai_error_with_ids(dev, "dai_params() error: "
-						 "failed to alloc dma buffer");
+			trace_dai_comp_error_with_ids(dev, "dai_params() error: failed to alloc dma buffer");
 			return -ENOMEM;
 		}
 	}
@@ -452,7 +435,7 @@ static int dai_prepare(struct comp_dev *dev)
 	struct dai_data *dd = comp_get_drvdata(dev);
 	int ret = 0;
 
-	trace_dai_with_ids(dev, "dai_prepare()");
+	trace_dai_comp_with_ids(dev, "dai_prepare()");
 
 	ret = comp_set_state(dev, COMP_TRIGGER_PREPARE);
 	if (ret < 0)
@@ -464,15 +447,13 @@ static int dai_prepare(struct comp_dev *dev)
 	dev->position = 0;
 
 	if (!dd->chan) {
-		trace_dai_error_with_ids(dev, "dai_prepare() error: Missing "
-					 "dd->chan.");
+		trace_dai_comp_error_with_ids(dev, "dai_prepare() error: Missing dd->chan.");
 		comp_set_state(dev, COMP_TRIGGER_RESET);
 		return -EINVAL;
 	}
 
 	if (!dd->config.elem_array.elems) {
-		trace_dai_error_with_ids(dev, "dai_prepare() error: Missing "
-					 "dd->config.elem_array.elems.");
+		trace_dai_comp_error_with_ids(dev, "dai_prepare() error: Missing dd->config.elem_array.elems.");
 		comp_set_state(dev, COMP_TRIGGER_RESET);
 		return -EINVAL;
 	}
@@ -501,7 +482,7 @@ static int dai_reset(struct comp_dev *dev)
 	struct dai_data *dd = comp_get_drvdata(dev);
 	struct dma_sg_config *config = &dd->config;
 
-	trace_dai_with_ids(dev, "dai_reset()");
+	trace_dai_comp_with_ids(dev, "dai_reset()");
 
 	dma_sg_free(&config->elem_array);
 
@@ -539,7 +520,7 @@ static int dai_comp_trigger(struct comp_dev *dev, int cmd)
 	struct dai_data *dd = comp_get_drvdata(dev);
 	int ret;
 
-	trace_dai_with_ids(dev, "dai_comp_trigger(), command = %u", cmd);
+	trace_dai_comp_with_ids(dev, "dai_comp_trigger(), command = %u", cmd);
 
 	ret = comp_set_state(dev, cmd);
 	if (ret < 0)
@@ -550,7 +531,7 @@ static int dai_comp_trigger(struct comp_dev *dev, int cmd)
 
 	switch (cmd) {
 	case COMP_TRIGGER_START:
-		trace_dai_with_ids(dev, "dai_comp_trigger(), START");
+		trace_dai_comp_with_ids(dev, "dai_comp_trigger(), START");
 
 		/* only start the DAI if we are not XRUN handling */
 		if (dd->xrun == 0) {
@@ -592,13 +573,13 @@ static int dai_comp_trigger(struct comp_dev *dev, int cmd)
 		dai_update_start_position(dev);
 		break;
 	case COMP_TRIGGER_XRUN:
-		trace_dai_with_ids(dev, "dai_comp_trigger(), XRUN");
+		trace_dai_comp_with_ids(dev, "dai_comp_trigger(), XRUN");
 		dd->xrun = 1;
 
 		/* fallthrough */
 	case COMP_TRIGGER_PAUSE:
 	case COMP_TRIGGER_STOP:
-		trace_dai_with_ids(dev, "dai_comp_trigger(), PAUSE/STOP");
+		trace_dai_comp_with_ids(dev, "dai_comp_trigger(), PAUSE/STOP");
 		ret = dma_stop(dd->chan);
 		dai_trigger(dd->dai, COMP_TRIGGER_STOP, dev->direction);
 		break;
@@ -615,12 +596,10 @@ static void dai_report_xrun(struct comp_dev *dev, uint32_t bytes)
 	struct dai_data *dd = comp_get_drvdata(dev);
 
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK) {
-		trace_dai_error_with_ids(dev, "dai_report_xrun() error: "
-					 "underrun due to no data available");
+		trace_dai_comp_error_with_ids(dev, "dai_report_xrun() error: underrun due to no data available");
 		comp_underrun(dev, dd->local_buffer, bytes);
 	} else {
-		trace_dai_error_with_ids(dev, "dai_report_xrun() error: "
-					 "overrun due to no data available");
+		trace_dai_comp_error_with_ids(dev, "dai_report_xrun() error: overrun due to no data available");
 		comp_overrun(dev, dd->local_buffer, bytes);
 	}
 }
@@ -636,7 +615,7 @@ static int dai_copy(struct comp_dev *dev)
 	uint32_t sink_samples;
 	int ret = 0;
 
-	tracev_dai_with_ids(dev, "dai_copy()");
+	tracev_dai_comp_with_ids(dev, "dai_copy()");
 
 	/* get data sizes from DMA */
 	ret = dma_get_data_size(dd->chan, &avail_bytes, &free_bytes);
@@ -660,7 +639,8 @@ static int dai_copy(struct comp_dev *dev)
 			sample_bytes(dd->frame_fmt);
 	}
 
-	tracev_dai_with_ids(dev, "dai_copy(), copy_bytes = 0x%x", copy_bytes);
+	tracev_dai_comp_with_ids(dev, "dai_copy(), copy_bytes = 0x%x",
+				 copy_bytes);
 
 	/* return if it's not stream start */
 	if (!copy_bytes && dd->start_position != dev->position)
@@ -696,14 +676,12 @@ static int dai_config(struct comp_dev *dev, struct sof_ipc_dai_config *config)
 	int channel = 0;
 	int handshake;
 
-	trace_dai_with_ids(dev, "config comp %d pipe %d dai %d type %d",
-			   dev->comp.id, dev->comp.pipeline_id,
-			   config->dai_index, config->type);
+	trace_dai_comp_with_ids(dev, "config dai %d type %d",
+				config->dai_index, config->type);
 
 	/* cannot configure DAI while active */
 	if (dev->state == COMP_STATE_ACTIVE) {
-		trace_dai_error_with_ids(dev, "dai_config() error: Component "
-					 "is in active state.");
+		trace_dai_comp_error_with_ids(dev, "dai_config() error: Component is in active state.");
 		return -EINVAL;
 	}
 
@@ -713,22 +691,19 @@ static int dai_config(struct comp_dev *dev, struct sof_ipc_dai_config *config)
 		dd->config.burst_elems = config->ssp.tdm_slots;
 		break;
 	case SOF_DAI_INTEL_DMIC:
-		trace_dai_with_ids(dev, "dai_config(), config->type = "
-				   "SOF_DAI_INTEL_DMIC");
+		trace_dai_comp_with_ids(dev, "dai_config(), config->type = SOF_DAI_INTEL_DMIC");
 
 		/* We can use always the largest burst length. */
 		dd->config.burst_elems = 8;
 
-		trace_dai_with_ids(dev, "dai_config(), "
-				   "config->dmic.fifo_bits = %u; "
-				   "config->dmic.num_pdm_active = %u;",
-				   config->dmic.fifo_bits,
-				   config->dmic.num_pdm_active);
+		trace_dai_comp_with_ids(dev, "dai_config(), config->dmic.fifo_bits = %u config->dmic.num_pdm_active = %u",
+					config->dmic.fifo_bits,
+					config->dmic.num_pdm_active);
 		break;
 	case SOF_DAI_INTEL_HDA:
 		channel = config->hda.link_dma_ch;
-		trace_dai_with_ids(dev, "dai_config(), channel = %d",
-				   channel);
+		trace_dai_comp_with_ids(dev, "dai_config(), channel = %d",
+					channel);
 
 		/*
 		 * For HDA DAIs, the driver sends the DAI_CONFIG IPC
@@ -756,8 +731,8 @@ static int dai_config(struct comp_dev *dev, struct sof_ipc_dai_config *config)
 		 */
 		channel = config->alh.stream_id;
 		dd->stream_id = config->alh.stream_id;
-		trace_dai_with_ids(dev, "dai_config(), channel = %d",
-				   channel);
+		trace_dai_comp_with_ids(dev, "dai_config(), channel = %d",
+					channel);
 		break;
 	case SOF_DAI_IMX_SAI:
 		handshake = dai_get_handshake(dd->dai, dai->direction,
@@ -777,12 +752,7 @@ static int dai_config(struct comp_dev *dev, struct sof_ipc_dai_config *config)
 		break;
 	default:
 		/* other types of DAIs not handled for now */
-		trace_dai_error_with_ids(dev, "dai_config() error: Handling of "
-					 "DAIs other than SOF_DAI_INTEL_SSP, "
-					 "SOF_DAI_INTEL_ALH, "
-					 "SOF_DAI_INTEL_DMIC or "
-					 "SOF_DAI_INTEL_HDA is not handled for "
-					 "now.");
+		trace_dai_comp_error_with_ids(dev, "dai_config() error: Unknown dai type");
 		break;
 	}
 
@@ -798,8 +768,7 @@ static int dai_config(struct comp_dev *dev, struct sof_ipc_dai_config *config)
 			dd->chan = dma_channel_get(dd->dma, channel);
 
 		if (!dd->chan) {
-			trace_dai_error_with_ids(dev, "dai_config() error: "
-						 "dma_channel_get() failed");
+			trace_dai_comp_error_with_ids(dev, "dai_config() error: dma_channel_get() failed");
 			dd->chan = NULL;
 			return -EIO;
 		}
@@ -818,7 +787,7 @@ static int dai_ts_config(struct comp_dev *dev)
 	struct timestamp_cfg *cfg = &dd->ts_config;
 	struct sof_ipc_comp_dai *dai = (struct sof_ipc_comp_dai *)&dev->comp;
 
-	tracev_dai("dai_ts_config()");
+	tracev_dai_comp_with_ids(dev, "dai_ts_config()");
 	cfg->type = dd->dai->drv->type;
 	cfg->direction = dai->direction;
 	cfg->index = dd->dai->index;
@@ -835,7 +804,7 @@ static int dai_ts_start(struct comp_dev *dev)
 {
 	struct dai_data *dd = comp_get_drvdata(dev);
 
-	tracev_dai("dai_ts_start()");
+	tracev_dai_comp_with_ids(dev, "dai_ts_start()");
 	if (!dd->dai->drv->ts_ops.ts_start)
 		return -ENXIO;
 
@@ -846,7 +815,7 @@ static int dai_ts_stop(struct comp_dev *dev)
 {
 	struct dai_data *dd = comp_get_drvdata(dev);
 
-	tracev_dai("dai_ts_stop()");
+	tracev_dai_comp_with_ids(dev, "dai_ts_stop()");
 	if (!dd->dai->drv->ts_ops.ts_stop)
 		return -ENXIO;
 
@@ -857,7 +826,7 @@ static int dai_ts_get(struct comp_dev *dev, struct timestamp_data *tsd)
 {
 	struct dai_data *dd = comp_get_drvdata(dev);
 
-	tracev_dai("dai_ts_get()");
+	tracev_dai_comp_with_ids(dev, "dai_ts_get()");
 	if (!dd->dai->drv->ts_ops.ts_get)
 		return -ENXIO;
 

--- a/src/include/sof/lib/dai.h
+++ b/src/include/sof/lib/dai.h
@@ -22,6 +22,7 @@
 #include <sof/lib/memory.h>
 #include <sof/sof.h>
 #include <sof/spinlock.h>
+#include <sof/trace/trace.h>
 #include <errno.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -146,6 +147,24 @@ struct dai_type_info {
 	struct dai *dai_array;	/**< Array of DAIs */
 	size_t num_dais;	/**< Number of elements in dai_array */
 };
+
+#define trace_dai_with_ids(klass, dai_ptr, format, ...) \
+	trace_event_with_ids(klass,			\
+			     dai_ptr->drv->type,	\
+			     dai_ptr->index,		\
+			     format, ##__VA_ARGS__)
+
+#define trace_dai_error_with_ids(klass, dai_ptr, format, ...)	\
+	trace_error_with_ids(klass,				\
+			     dai_ptr->drv->type,		\
+			     dai_ptr->index,			\
+			     format, ##__VA_ARGS__)
+
+#define tracev_dai_with_ids(klass, dai_ptr, format, ...)	\
+	tracev_event_with_ids(klass,				\
+			      dai_ptr->drv->type,		\
+			      dai_ptr->index,			\
+			      format, ##__VA_ARGS__)
 
 /**
  * \brief Holds information about array of DAIs grouped by type.

--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -552,7 +552,7 @@ static int ipc_dai_config(uint32_t header)
 	/* copy message with ABI safe method */
 	IPC_COPY_CMD(config, ipc->comp_data);
 
-	trace_ipc("ipc: dai %d,%d -> config ", config.type,
+	trace_ipc("ipc: dai %d.%d -> config ", config.type,
 		  config.dai_index);
 
 	/* send params to all DAI components who use that physical DAI */

--- a/src/lib/dai.c
+++ b/src/lib/dai.c
@@ -54,8 +54,8 @@ struct dai *dai_get(uint32_t type, uint32_t index, uint32_t flags)
 		if (!ret)
 			d->sref++;
 
-		trace_dai("dai_get(), d = %p, sref = %d",
-			  (uintptr_t)d, d->sref);
+		trace_dai("dai_get %d.%d new sref %d",
+			  type, index, d->sref);
 
 		platform_shared_commit(d, sizeof(*d));
 
@@ -63,8 +63,8 @@ struct dai *dai_get(uint32_t type, uint32_t index, uint32_t flags)
 
 		return !ret ? d : NULL;
 	}
-	trace_error(TRACE_CLASS_DAI, "dai_get() error: "
-		    "type = %d, index = %d not found", type, index);
+	trace_error(TRACE_CLASS_DAI, "dai_get error: %d.%d not found",
+		    type, index);
 	return NULL;
 }
 
@@ -76,13 +76,12 @@ void dai_put(struct dai *dai)
 	if (--dai->sref == 0) {
 		ret = dai_remove(dai);
 		if (ret < 0) {
-			trace_error(TRACE_CLASS_DAI,
-				    "dai_put() error: "
-				    "dai_remove() failed ret = %d", ret);
+			trace_error(TRACE_CLASS_DAI, "dai_put error: %d.%d dai_remove() failed ret = %d",
+				    dai->drv->type, dai->index, ret);
 		}
 	}
-	trace_event(TRACE_CLASS_DAI, "dai_put(), dai = %p, sref = %d",
-		    (uintptr_t)dai, dai->sref);
+	trace_event(TRACE_CLASS_DAI, "dai_put %d.%d new sref %d",
+		    dai->drv->type, dai->index, dai->sref);
 	platform_shared_commit(dai, sizeof(*dai));
 	spin_unlock(&dai->lock);
 }


### PR DESCRIPTION
Ssp and other dai traces should follow the dmic example once there is no objection on re-using trace entry id's for dai type and index (instead of sending them sometimes as arguments).