### PR TITLE
Fix macro expansion warnings being treated as errors

### DIFF
--- a/tools/topology/CMakeLists.txt
+++ b/tools/topology/CMakeLists.txt
@@ -119,6 +119,7 @@ set(TPLGS
 	"sof-imx8qxp-wm8960\;sof-imx8qxp-wm8960"
 	"sof-tgl-max98357a-rt5682\;sof-tgl-max98357a-rt5682"
 	"sof-jsl-da7219\;sof-jsl-da7219"
+	"sof-jsl-rt5682-rt1015\;sof-jsl-rt5682-rt1015"
 )
 
 add_custom_target(topologies ALL)

--- a/tools/topology/sof-jsl-rt5682-rt1015.m4
+++ b/tools/topology/sof-jsl-rt5682-rt1015.m4
@@ -1,0 +1,188 @@
+#
+# Topology for JasperLake with rt1015 amp + rt5682 codec + DMIC + 3 HDMI
+#
+
+# Include topology builder
+include(`utils.m4')
+include(`dai.m4')
+include(`pipeline.m4')
+include(`ssp.m4')
+
+# Include TLV library
+include(`common/tlv.m4')
+
+# Include Token library
+include(`sof/tokens.m4')
+
+# Include JasperLake DSP configuration
+include(`platform/intel/icl.m4')
+include(`platform/intel/dmic.m4')
+DEBUG_START
+
+#
+# Define the pipelines
+#
+# PCM0 ---> volume ----> SSP1  (Speaker - ALC1015)
+# PCM1 <---> volume <----> SSP0  (Headset - ALC5682)
+# PCM5 <---- volume <----- DMIC01 (dmic0 capture)
+# PCM2 ----> volume -----> iDisp1
+# PCM3 ----> volume -----> iDisp2
+# PCM4 ----> volume -----> iDisp3
+
+dnl PIPELINE_PCM_ADD(pipeline,
+dnl     pipe id, pcm, max channels, format,
+dnl     frames, deadline, priority, core)
+
+# Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s24le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	1, 0, 2, s24le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency playback pipeline 2 on PCM 1 using max 2 channels of s24le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	2, 1, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency capture pipeline 3 on PCM 1 using max 2 channels of s24le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
+	3, 1, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+# Passthrough capture pipeline 4 on PCM 5 using max 4 channels.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
+	4, 5, 4, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency playback pipeline 2 on PCM 2 using max 2 channels of s32le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	5, 2, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency playback pipeline 3 on PCM 3 using max 2 channels of s32le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	6, 3, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency playback pipeline 4 on PCM 4 using max 2 channels of s32le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	7, 4, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# DAIs configuration
+#
+
+dnl DAI_ADD(pipeline,
+dnl     pipe id, dai type, dai_index, dai_be,
+dnl     buffer, periods, format,
+dnl     frames, deadline, priority, core)
+
+# playback DAI is SSP1 using 2 periods
+# Buffers use s16le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+	1, SSP, 1, SSP1-Codec,
+	PIPELINE_SOURCE_1, 2, s24le,
+	1000, 0, 0)
+# playback DAI is SSP0 using 2 periods
+# Buffers use s24le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+	2, SSP, 0, SSP0-Codec,
+	PIPELINE_SOURCE_2, 2, s24le,
+	1000, 0, 0)
+
+# capture DAI is SSP0 using 2 periods
+# Buffers use s24le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-capture.m4,
+	3, SSP, 0, SSP0-Codec,
+	PIPELINE_SINK_3, 2, s24le,
+	1000, 0, 0)
+
+# capture DAI is DMIC01 using 2 periods
+# Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-capture.m4,
+	4, DMIC, 0, dmic01,
+	PIPELINE_SINK_4, 2, s32le,
+	1000, 0, 0)
+
+# playback DAI is iDisp1 using 2 periods
+# Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+	5, HDA, 0, iDisp1,
+	PIPELINE_SOURCE_5, 2, s32le,
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+
+# playback DAI is iDisp2 using 2 periods
+# Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+	6, HDA, 1, iDisp2,
+	PIPELINE_SOURCE_6, 2, s32le,
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+
+# playback DAI is iDisp3 using 2 periods
+# Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+	7, HDA, 2, iDisp3,
+	PIPELINE_SOURCE_7, 2, s32le,
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+
+# PCM Low Latency, id 0
+dnl PCM_PLAYBACK_ADD(name, pcm_id, playback)
+PCM_PLAYBACK_ADD(rt1015-spk, 0, PIPELINE_PCM_1)
+PCM_DUPLEX_ADD(Headset, 1, PIPELINE_PCM_2, PIPELINE_PCM_3)
+PCM_CAPTURE_ADD(DMIC, 5, PIPELINE_PCM_4)
+PCM_PLAYBACK_ADD(HDMI1, 2, PIPELINE_PCM_5)
+PCM_PLAYBACK_ADD(HDMI2, 3, PIPELINE_PCM_6)
+PCM_PLAYBACK_ADD(HDMI3, 4, PIPELINE_PCM_7)
+
+#
+# BE conf2igurations - overrides config in ACPI if present
+# The ID is based on the order defined in sof-rt5682.c machine driver.
+#
+dnl DAI_CONFIG(type, dai_index, link_id, name, ssp_config/dmic_config)
+dnl SSP_CONFIG(format, mclk, bclk, fsync, tdm, ssp_config_data)
+dnl SSP_CLOCK(clock, freq, codec_master, polarity)
+dnl SSP_CONFIG_DATA(type, idx, valid bits, mclk_id)
+
+# SSP 1 (ID: 7)
+DAI_CONFIG(SSP, 1, 6, SSP1-Codec,
+	SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24000000, codec_mclk_in),
+		SSP_CLOCK(bclk, 2400000, codec_slave),
+		SSP_CLOCK(fsync, 48000, codec_slave),
+		SSP_TDM(2, 25, 3, 3),
+		SSP_CONFIG_DATA(SSP, 1, 24)))
+
+# SSP 0 (ID: 0)
+DAI_CONFIG(SSP, 0, 0, SSP0-Codec,
+	SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24000000, codec_mclk_in),
+		SSP_CLOCK(bclk, 2400000, codec_slave),
+		SSP_CLOCK(fsync, 48000, codec_slave),
+		SSP_TDM(2, 25, 3, 3),
+		SSP_CONFIG_DATA(SSP, 0, 24)))
+
+# dmic01 (ID: 1)
+DAI_CONFIG(DMIC, 0, 1, dmic01,
+	DMIC_CONFIG(1, 500000, 4800000, 40, 60, 48000,
+		DMIC_WORD_LENGTH(s32le), 400, DMIC, 0,
+		PDM_CONFIG(DMIC, 0, FOUR_CH_PDM0_PDM1)))
+
+# DMIC16kHz (ID: 2)
+# placeholder.
+
+# 4 HDMI/DP outputs (ID: 3,4,5)
+DAI_CONFIG(HDA, 0, 3, iDisp1)
+DAI_CONFIG(HDA, 1, 4, iDisp2)
+DAI_CONFIG(HDA, 2, 5, iDisp3)
+
+DEBUG_END


### PR DESCRIPTION
When HP_MEMORY_BANKS is configured to 16, the build produces
the following error with gcc tool chains:

In file included from /home/yzhi/work/sof/sof/src/arch/xtensa/boot_loader.c:7:0:
/work/sof/sof/src/arch/xtensa/boot_loader.c: In function 'hp_sram_pm_banks':
/work/sof/sof/src/include/sof/bit.h:13:10: error: left shift count >= width of type [-Werror=shift-count-overflow]
  (((1ULL << ((b_hi) - (b_lo) + 1ULL)) - 1ULL) << (b_lo))
          ^
/work/sof/sof/src/arch/xtensa/boot_loader.c:190:31: note: in expansion of macro 'MASK'
   ebb_avail_mask1 = (uint32_t)MASK(PLATFORM_HPSRAM_EBB_COUNT -
                               ^~~~
cc1: all warnings being treated as errors
src/arch/xtensa/CMakeFiles/bootloader.dir/build.make:75: recipe for target 'src/arch/xtensa/CMakeFiles/bootloader.dir/boot_loader.c.o' failed
make[3]: *** [src/arch/xtensa/CMakeFiles/bootloader.dir/boot_loader.c.o] Error 1
make[3]: Leaving directory '/home/yzhi/work/sof/sof/build_icl_gcc'
CMakeFiles/Makefile2:1356: recipe for target 'src/arch/xtensa/CMakeFiles/bootloader.dir/all' failed
make[2]: *** [src/arch/xtensa/CMakeFiles/bootloader.dir/all] Error 2
make[2]: *** Waiting for unfinished jobs....
[ 48%] Linking C executable sof

Signed-off-by: Yong Zhi <yong.zhi@intel.com>