### PR TITLE
ipc: take NO_TRACE flag of SETD0IX IPC from host

### DIFF
--- a/src/drivers/intel/cavs/ipc.c
+++ b/src/drivers/intel/cavs/ipc.c
@@ -140,7 +140,7 @@ static struct sof_ipc_cmd_hdr *ipc_cavs_read_set_d0ix(uint32_t dr, uint32_t dd)
 	return &cmd->hdr;
 }
 
-static struct sof_ipc_cmd_hdr *ipc_cavs_read_msg(void)
+static struct sof_ipc_cmd_hdr *ipc_compact_read_msg(void)
 {
 	struct sof_ipc_cmd_hdr *hdr;
 	uint32_t dr;
@@ -176,7 +176,7 @@ enum task_state ipc_platform_do_cmd(void *data)
 	struct sof_ipc_reply reply;
 
 #if CAVS_VERSION >= CAVS_VERSION_1_8
-	hdr = ipc_cavs_read_msg();
+	hdr = ipc_compact_read_msg();
 #else
 	hdr = mailbox_validate();
 #endif

--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -665,10 +665,18 @@ static int ipc_pm_gate(uint32_t header)
 
 	IPC_COPY_CMD(pm_gate, ipc_get()->comp_data);
 
+	/* pause dma trace firstly if needed */
+	if (pm_gate.flags & SOF_PM_NO_TRACE)
+		trace_off();
+
 	if (pm_gate.flags & SOF_PM_PPG)
 		pm_runtime_disable(PM_RUNTIME_DSP, PLATFORM_MASTER_CORE_ID);
 	else
 		pm_runtime_enable(PM_RUNTIME_DSP, PLATFORM_MASTER_CORE_ID);
+
+	/* resume dma trace if needed */
+	if (!(pm_gate.flags & SOF_PM_NO_TRACE))
+		trace_on();
 
 	return 0;
 }


### PR DESCRIPTION
When entering D0ix, we can run FW with either DMA trace on (e.g. the
host system is in S0) or off (e.g. the host system is in S0ix), here
take the NO_TRACE flag passed from host and response to it.

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>