### PR TITLE
Pcm512x capture

### DIFF
--- a/tools/topology/sof-apl-pcm512x.m4
+++ b/tools/topology/sof-apl-pcm512x.m4
@@ -22,7 +22,7 @@ DEBUG_START
 #
 # Define the pipelines
 #
-# PCM0 ----> volume -----> SSP5 (pcm512x)
+# PCM0 <---> volume <----> SSP5 (pcm512x)
 # PCM1 ----> volume -----> iDisp1
 # PCM2 ----> volume -----> iDisp2
 # PCM3 ----> volume -----> iDisp3
@@ -38,6 +38,13 @@ dnl     time_domain, sched_comp)
 # Set 1000us deadline on core 0 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-low-latency-playback.m4,
 	1, 0, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s32le.
+# 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
+	6, 0, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
@@ -76,6 +83,13 @@ dnl     deadline, priority, core, time_domain)
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, 5, SSP5-Codec,
 	PIPELINE_SOURCE_1, 2, s24le,
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+
+# capture DAI is SSP5 using 2 periods
+# Buffers use s16le format, 1000us deadline on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-capture.m4,
+	6, SSP, 5, SSP5-Codec,
+	PIPELINE_SINK_6, 2, s24le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # Media playback pipeline 5 on PCM 4 using max 2 channels of s16le.
@@ -119,7 +133,7 @@ DAI_ADD(sof/pipe-dai-playback.m4,
 
 # PCM Low Latency, id 0
 dnl PCM_PLAYBACK_ADD(name, pcm_id, playback)
-PCM_PLAYBACK_ADD(Port5, 0, PIPELINE_PCM_1)
+PCM_DUPLEX_ADD(Port5, 0, PIPELINE_PCM_1, PIPELINE_PCM_6)
 PCM_PLAYBACK_ADD(HDMI1, 1, PIPELINE_PCM_2)
 PCM_PLAYBACK_ADD(HDMI2, 2, PIPELINE_PCM_3)
 PCM_PLAYBACK_ADD(HDMI3, 3, PIPELINE_PCM_4)

--- a/tools/topology/sof-apl-pcm512x.m4
+++ b/tools/topology/sof-apl-pcm512x.m4
@@ -16,6 +16,7 @@ include(`sof/tokens.m4')
 
 # Include Apollolake DSP configuration
 include(`platform/intel/bxt.m4')
+include(`platform/intel/dmic.m4')
 
 DEBUG_START
 
@@ -26,6 +27,9 @@ DEBUG_START
 # PCM1 ----> volume -----> iDisp1
 # PCM2 ----> volume -----> iDisp2
 # PCM3 ----> volume -----> iDisp3
+# PCM4 ----> volume -----> Media Playback 4
+# PCM5 <------------------ DMIC0 (DMIC)
+# PCM6 <------------------ DMIC1 (DMIC16kHz)
 #
 
 dnl PIPELINE_PCM_ADD(pipeline,
@@ -69,6 +73,20 @@ PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
+# DMIC passthrough capture pipeline 7 on PCM 4 using max 2 channels.
+# 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-eq-capture.m4,
+	7, 5, 4, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# DMIC16kHz passthrough capture pipeline 8 on PCM 5 using max 2 channels.
+# 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-eq-capture-16khz.m4,
+	8, 6, 2, s16le,
+	1000, 0, 0,
+	16000, 16000, 16000)
+
 #
 # DAIs configuration
 #
@@ -110,6 +128,20 @@ SectionGraph."media-pipeline" {
 	]
 }
 
+# capture DAI is DMIC using 2 periods
+# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-capture.m4,
+	7, DMIC, 0, dmic01,
+	PIPELINE_SINK_7, 2, s32le,
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+
+# capture DAI is DMIC16kHz using 2 periods
+# Buffers use s16le format, 1000us deadline on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-capture.m4,
+	8, DMIC, 1, dmic16k,
+	PIPELINE_SINK_8, 2, s16le,
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+
 # playback DAI is iDisp1 using 2 periods
 # Buffers use s32le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
@@ -137,11 +169,14 @@ PCM_DUPLEX_ADD(Port5, 0, PIPELINE_PCM_1, PIPELINE_PCM_6)
 PCM_PLAYBACK_ADD(HDMI1, 1, PIPELINE_PCM_2)
 PCM_PLAYBACK_ADD(HDMI2, 2, PIPELINE_PCM_3)
 PCM_PLAYBACK_ADD(HDMI3, 3, PIPELINE_PCM_4)
+PCM_CAPTURE_ADD(DMIC, 5, PIPELINE_PCM_7)
+PCM_CAPTURE_ADD(DMIC16kHz, 6, PIPELINE_PCM_8)
 
 #
 # BE configurations - overrides config in ACPI if present
 #
 
+dnl DAI_CONFIG(type, dai_index, link_id, name, ssp_config/dmic_config)
 #SSP 5 (ID: 0)
 DAI_CONFIG(SSP, 5, 0, SSP5-Codec,
 	SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24576000, codec_mclk_in),
@@ -150,9 +185,21 @@ DAI_CONFIG(SSP, 5, 0, SSP5-Codec,
 		SSP_TDM(2, 32, 3, 3),
 		SSP_CONFIG_DATA(SSP, 5, 24)))
 
-# 3 HDMI/DP outputs (ID: 1,2,3)
-DAI_CONFIG(HDA, 0, 1, iDisp1)
-DAI_CONFIG(HDA, 1, 2, iDisp2)
-DAI_CONFIG(HDA, 2, 3, iDisp3)
+# DMIC (ID: 1)
+DAI_CONFIG(DMIC, 0, 1, dmic01,
+	   DMIC_CONFIG(1, 500000, 4800000, 40, 60, 48000,
+		DMIC_WORD_LENGTH(s32le), 400, DMIC, 0,
+		PDM_CONFIG(DMIC, 0, FOUR_CH_PDM0_PDM1)))
+
+# DMIC16kHz (ID: 2)
+DAI_CONFIG(DMIC, 1, 2, dmic16k,
+	   DMIC_CONFIG(1, 500000, 4800000, 40, 60, 16000,
+		DMIC_WORD_LENGTH(s16le), 400, DMIC, 1,
+		PDM_CONFIG(DMIC, 1, STEREO_PDM0)))
+
+# 3 HDMI/DP outputs (ID: 3,4,5)
+DAI_CONFIG(HDA, 0, 3, iDisp1)
+DAI_CONFIG(HDA, 1, 4, iDisp2)
+DAI_CONFIG(HDA, 2, 5, iDisp3)
 
 DEBUG_END


### PR DESCRIPTION
2 patches to add capture support on Up^2 boards using a DMIC board and an analog input on the HiFiBerry DAC+ADC codec card. Note, that it should be used with https://github.com/thesofproject/linux/pull/1714