### PR TITLE
Topology: Apply high-pass filter to rt715 capture pipelines

### DIFF
--- a/tools/topology/sof-icl-rt711-rt1308-rt715-hdmi.m4
+++ b/tools/topology/sof-icl-rt711-rt1308-rt715-hdmi.m4
@@ -71,7 +71,7 @@ PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 
 # Low Latency capture pipeline 5 on PCM 4 using max 2 channels of s32le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-highpass-capture.m4,
 	5, 4, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)

--- a/tools/topology/sof-icl-rt711-rt1308-rt715.m4
+++ b/tools/topology/sof-icl-rt711-rt1308-rt715.m4
@@ -63,7 +63,7 @@ PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 
 # Low Latency capture pipeline 5 on PCM 4 using max 2 channels of s32le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-highpass-capture.m4,
 	5, 4, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)


### PR DESCRIPTION
This patch mitigates the start transient in capture from rt715
codec. The start transient is DC pulse that can be attenuated
significantly with a high-pass filter. The pipeline macro
pipe-highpass-capture.m4 adds a 40 Hz second order IIR filter
into the beginning of pipeline. The volume control in this pipeline
is also set to a longer 400 ms ramp length (normally 250 ms) that
is sufficient to conceal PCM waveform issues before the IIR filter
settles to DC level.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>