### PR TITLE
kpb: rework of validation of host params

### DIFF
--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -59,7 +59,7 @@ struct comp_data {
 	bool is_internal_buffer_full;
 	size_t buffered_data;
 	struct dd draining_task_data;
-	size_t kpb_buffer_size;
+	size_t buffer_size;
 	size_t host_buffer_size;
 	size_t host_period_size;
 };
@@ -191,7 +191,7 @@ static size_t kpb_allocate_history_buffer(struct comp_data *kpb)
 	struct hb *history_buffer;
 	struct hb *new_hb = NULL;
 	/*! Total allocation size */
-	size_t hb_size = kpb->kpb_buffer_size;
+	size_t hb_size = kpb->buffer_size;
 	/*! Current allocation size */
 	size_t ca_size = hb_size;
 	/*! Memory caps priorites for history buffer */
@@ -404,7 +404,7 @@ static int kpb_prepare(struct comp_dev *dev)
 	kpb_change_state(kpb, KPB_STATE_PREPARING);
 	kpb->kpb_no_of_clients = 0;
 	kpb->buffered_data = 0;
-	kpb->kpb_buffer_size = KPB_MAX_BUFFER_SIZE(kpb->config.sampling_width);
+	kpb->buffer_size = KPB_MAX_BUFFER_SIZE(kpb->config.sampling_width);
 	kpb->sel_sink = NULL;
 	kpb->host_sink = NULL;
 
@@ -413,9 +413,8 @@ static int kpb_prepare(struct comp_dev *dev)
 		allocated_size = kpb_allocate_history_buffer(kpb);
 
 		/* Have we allocated what we requested? */
-		if (allocated_size < kpb->kpb_buffer_size) {
-			trace_kpb_error_with_ids(dev, "Failed to allocate "
-						 "space for KPB buffer/s");
+		if (allocated_size < kpb->buffer_size) {
+			trace_kpb_error("kpb_prepare() error: failed to allocate space for KPB buffer/s");
 			kpb_free_history_buffer(kpb->history_buffer);
 			kpb->history_buffer = NULL;
 			return -EINVAL;
@@ -604,7 +603,7 @@ static int kpb_copy(struct comp_dev *dev)
 		/* Buffer source data internally in history buffer for future
 		 * use by clients.
 		 */
-		if (source->stream.avail <= kpb->kpb_buffer_size) {
+		if (source->stream.avail <= kpb->buffer_size) {
 			ret = kpb_buffer_data(dev, source, copy_bytes);
 			if (ret) {
 				trace_kpb_error_with_ids(dev, "kpb_copy(): "
@@ -612,7 +611,7 @@ static int kpb_copy(struct comp_dev *dev)
 							 "failed.");
 				goto out;
 			}
-			if (kpb->buffered_data < kpb->kpb_buffer_size)
+			if (kpb->buffered_data < kpb->buffer_size)
 				kpb->buffered_data += copy_bytes;
 			else
 				kpb->is_internal_buffer_full = true;
@@ -658,7 +657,7 @@ static int kpb_copy(struct comp_dev *dev)
 		/* In draining state we only buffer data in internal,
 		 * history buffer.
 		 */
-		if (source->stream.avail <= kpb->kpb_buffer_size) {
+		if (source->stream.avail <= kpb->buffer_size) {
 			ret = kpb_buffer_data(dev, source,
 					      source->stream.avail);
 			if (ret) {
@@ -932,9 +931,8 @@ static void kpb_init_draining(struct comp_dev *dev, struct kpb_client *cli)
 		trace_kpb_error_with_ids(dev, "kpb_init_draining() error: "
 					 "sink not ready for draining");
 	} else if (kpb->buffered_data < history_depth ||
-		   kpb->kpb_buffer_size < history_depth) {
-		trace_kpb_error_with_ids(dev, "kpb_init_draining() error: "
-					 "not enough data in history buffer");
+		   kpb->buffer_size < history_depth) {
+		trace_kpb_error("kpb_init_draining() error: not enough data in history buffer");
 	} else if (!validate_host_params(host_period_size,
 					 host_buffer_size,
 					 bytes_per_ms)) {
@@ -1003,6 +1001,7 @@ static void kpb_init_draining(struct comp_dev *dev, struct kpb_client *cli)
 		 * take place. This time will be used to synchronize us with
 		 * an end application interrupts.
 		 */
+
 		drain_interval = (host_period_size / bytes_per_ms) *
 				 ticks_per_ms;
 		/* In draining intervals we will fill only two periods

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -149,7 +149,7 @@ static struct comp_dev *kpb_new(struct sof_ipc_comp *comp)
 		return NULL;
 	}
 
-	if (kpb->config.no_channels > KPB_MAX_SUPPORTED_CHANNELS) {
+	if (kpb->config.channels > KPB_MAX_SUPPORTED_CHANNELS) {
 		trace_kpb_error_with_ids(dev, "kpb_new() error: "
 		"no of channels exceeded the limit");
 		return NULL;
@@ -900,7 +900,7 @@ static void kpb_init_draining(struct comp_dev *dev, struct kpb_client *cli)
 	struct comp_data *kpb = comp_get_drvdata(dev);
 	bool is_sink_ready = (kpb->host_sink->sink->state == COMP_STATE_ACTIVE);
 	size_t sample_width = kpb->config.sampling_width;
-	size_t history_depth = cli->history_depth * kpb->config.no_channels *
+	size_t history_depth = cli->history_depth * kpb->config.channels *
 			       (kpb->config.sampling_freq / 1000) *
 			       (KPB_SAMPLE_CONTAINER_SIZE(sample_width) / 8);
 	struct hb *buff = kpb->history_buffer;
@@ -912,9 +912,9 @@ static void kpb_init_draining(struct comp_dev *dev, struct kpb_client *cli)
 	size_t host_period_size = kpb->host_period_size;
 	size_t host_buffer_size = kpb->host_buffer_size;
 	size_t ticks_per_ms = clock_ms_to_ticks(PLATFORM_DEFAULT_CLOCK, 1);
-	size_t bytes_per_ms = KPB_SAMPLING_WIDTH *
+	size_t bytes_per_ms = KPB_SAMPLES_PER_MS *
 			      (KPB_SAMPLE_CONTAINER_SIZE(sample_width) / 8) *
-			      kpb->config.no_channels;
+			      kpb->config.channels;
 	size_t period_bytes_limit = 0;
 
 	trace_kpb_with_ids(dev, "kpb_init_draining(): requested draining "
@@ -1198,7 +1198,7 @@ static void kpb_drain_samples(void *source, struct audio_stream *sink,
 	size_t frames = KPB_BYTES_TO_FRAMES(size, sample_width);
 
 	for (i = 0; i < frames; i++) {
-		for (channel = 0; channel < KPB_NR_OF_CHANNELS; channel++) {
+		for (channel = 0; channel < KPB_NUM_OF_CHANNELS; channel++) {
 			switch (sample_width) {
 #if CONFIG_FORMAT_S16LE
 			case 16:
@@ -1246,7 +1246,7 @@ static void kpb_buffer_samples(const struct audio_stream *source,
 	size_t frames = KPB_BYTES_TO_FRAMES(size, sample_width);
 
 	for (i = 0; i < frames; i++) {
-		for (channel = 0; channel < KPB_NR_OF_CHANNELS; channel++) {
+		for (channel = 0; channel < KPB_NUM_OF_CHANNELS; channel++) {
 			switch (sample_width) {
 			case 16:
 				src = audio_stream_read_frag_s16(source, j);
@@ -1343,7 +1343,7 @@ static void kpb_copy_samples(struct audio_stream *sink,
 	size_t frames = KPB_BYTES_TO_FRAMES(size, sample_width);
 
 	for (i = 0; i < frames; i++) {
-		for (channel = 0; channel < KPB_NR_OF_CHANNELS; channel++) {
+		for (channel = 0; channel < KPB_NUM_OF_CHANNELS; channel++) {
 			switch (sample_width) {
 #if CONFIG_FORMAT_S16LE
 			case 16:

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -409,6 +409,11 @@ static int kpb_prepare(struct comp_dev *dev)
 	kpb->sel_sink = NULL;
 	kpb->host_sink = NULL;
 
+	if (!validate_host_params(dev, kpb->host_period_size,
+				  kpb->host_buffer_size)) {
+		trace_kpb_error("kpb_prepare() error: wrong host params.");
+		return -EINVAL;
+	}
 	if (!kpb->history_buffer) {
 		/* Allocate history buffer */
 		allocated_size = kpb_allocate_history_buffer(kpb);
@@ -936,10 +941,6 @@ static void kpb_init_draining(struct comp_dev *dev, struct kpb_client *cli)
 	} else if (kpb->buffered_data < history_depth ||
 		   kpb->buffer_size < history_depth) {
 		trace_kpb_error("kpb_init_draining() error: not enough data in history buffer");
-	} else if (!validate_host_params(dev,
-					 host_period_size,
-					 host_buffer_size)) {
-		trace_kpb_error("kpb_init_draining() error: wrong host params.");
 	} else {
 		/* Draining accepted, find proper buffer to start reading
 		 * At this point we are guaranteed that there is enough data

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -45,7 +45,7 @@
 
 /* KPB private data, runtime data */
 struct comp_data {
-	uint64_t state_log;
+	uint64_t state_log; /**< keeps record of KPB recent states */
 	enum kpb_state state; /**< current state of KPB component */
 	uint32_t kpb_no_of_clients; /**< number of registered clients */
 	struct kpb_client clients[KPB_MAX_NO_OF_CLIENTS];
@@ -53,15 +53,17 @@ struct comp_data {
 	uint32_t source_period_bytes; /**< source number of period bytes */
 	uint32_t sink_period_bytes; /**< sink number of period bytes */
 	struct sof_kpb_config config;   /**< component configuration data */
-	struct comp_buffer *sel_sink; /**< real time sink (channel selector ) */
+	struct comp_buffer *sel_sink; /**< real time sink (channel selector )*/
 	struct comp_buffer *host_sink; /**< draining sink (client) */
-	struct hb *history_buffer;
-	size_t buffered_data;
+	struct hb *history_buffer; /**< internal history buffer */
+	size_t buffered_data; /**< keeps info about amount of buffered data */
 	struct dd draining_task_data;
-	size_t buffer_size;
-	size_t host_buffer_size;
-	size_t host_period_size;
-	bool sync_draining_mode;
+	size_t buffer_size; /**< size of internal history buffer */
+	size_t host_buffer_size; /**< size of host buffer */
+	size_t host_period_size; /**< size of history period */
+	bool sync_draining_mode; /**< should we synchronize draining with
+				   * host?
+				   */
 };
 
 /*! KPB private functions */

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -56,7 +56,6 @@ struct comp_data {
 	struct comp_buffer *sel_sink; /**< real time sink (channel selector ) */
 	struct comp_buffer *host_sink; /**< draining sink (client) */
 	struct hb *history_buffer;
-	bool is_internal_buffer_full;
 	size_t buffered_data;
 	struct dd draining_task_data;
 	size_t buffer_size;
@@ -529,7 +528,6 @@ static int kpb_reset(struct comp_dev *dev)
 		break;
 	default:
 		kpb->buffered_data = 0;
-		kpb->is_internal_buffer_full = false;
 
 		if (kpb->history_buffer) {
 			/* Reset history buffer - zero its data, reset pointers
@@ -622,8 +620,6 @@ static int kpb_copy(struct comp_dev *dev)
 			}
 			if (kpb->buffered_data < kpb->buffer_size)
 				kpb->buffered_data += copy_bytes;
-			else
-				kpb->is_internal_buffer_full = true;
 		} else {
 			trace_kpb_error_with_ids(dev, "kpb_copy(): "
 						 "too much data to buffer.");

--- a/src/include/sof/audio/kpb.h
+++ b/src/include/sof/audio/kpb.h
@@ -125,6 +125,7 @@ struct dd {
 	size_t drain_interval;
 	size_t pb_limit; /**< Period bytes limit */
 	struct comp_dev *dev;
+	bool sync_mode_on;
 };
 
 #ifdef UNIT_TEST

--- a/src/include/sof/audio/kpb.h
+++ b/src/include/sof/audio/kpb.h
@@ -49,6 +49,10 @@ struct comp_buffer;
 #define KPB_BYTES_TO_FRAMES(bytes, sample_width) \
 	(bytes / ((KPB_SAMPLE_CONTAINER_SIZE(sample_width) / 8) * \
 	KPB_NUM_OF_CHANNELS))
+/**< Defines how much faster draining is in comparison to pipeline copy. */
+#define KPB_DRAIN_NUM_OF_PPL_PERIODS_AT_ONCE 2
+/**< Host buffer shall be at least two times bigger than history buffer. */
+#define HOST_BUFFER_MIN_SIZE(hb) (hb * 2)
 
 enum kpb_state {
 	KPB_STATE_DISABLED = 0,

--- a/src/include/sof/audio/kpb.h
+++ b/src/include/sof/audio/kpb.h
@@ -33,21 +33,22 @@ struct comp_buffer;
 
 /* KPB internal defines */
 #define KPB_MAX_BUFF_TIME 2100 /**< time of buffering in miliseconds */
-#define KPB_MAX_SUPPORTED_CHANNELS 2
-#define	KPB_SAMPLING_WIDTH 16 /**< number of bits */
-#define	KPB_SAMPLNG_FREQUENCY 16000 /* max sampling frequency in Hz */
-#define KPB_NR_OF_CHANNELS 2
+#define KPB_MAX_SUPPORTED_CHANNELS 2 /**< number of supported channels */
+/**< number of samples taken each milisecond */
+#define	KPB_SAMPLES_PER_MS (KPB_SAMPLNG_FREQUENCY / 1000)
+#define	KPB_SAMPLNG_FREQUENCY 16000 /**< supported sampling frequency in Hz */
+#define KPB_NUM_OF_CHANNELS 2
 #define KPB_SAMPLE_CONTAINER_SIZE(sw) ((sw == 16) ? 16 : 32)
 #define KPB_MAX_BUFFER_SIZE(sw) ((KPB_SAMPLNG_FREQUENCY / 1000) * \
 	(KPB_SAMPLE_CONTAINER_SIZE(sw) / 8) * KPB_MAX_BUFF_TIME * \
-	KPB_NR_OF_CHANNELS)
+	KPB_NUM_OF_CHANNELS)
 #define KPB_MAX_NO_OF_CLIENTS 2
 #define KPB_NO_OF_HISTORY_BUFFERS 2 /**< no of internal buffers */
 #define KPB_ALLOCATION_STEP 0x100
 #define KPB_NO_OF_MEM_POOLS 3
 #define KPB_BYTES_TO_FRAMES(bytes, sample_width) \
 	(bytes / ((KPB_SAMPLE_CONTAINER_SIZE(sample_width) / 8) * \
-	KPB_NR_OF_CHANNELS))
+	KPB_NUM_OF_CHANNELS))
 
 enum kpb_state {
 	KPB_STATE_DISABLED = 0,

--- a/src/include/user/kpb.h
+++ b/src/include/user/kpb.h
@@ -14,7 +14,7 @@
 struct sof_kpb_config {
 	uint32_t size; /**< kpb size in bytes */
 	uint32_t caps; /**< SOF_MEM_CAPS_ */
-	uint32_t no_channels; /**< no of channels */
+	uint32_t channels; /**< number of channels */
 	uint32_t history_depth; /**< time of buffering in milliseconds */
 	uint32_t sampling_freq; /**< frequency in hertz */
 	uint32_t sampling_width; /**< number of bits */

--- a/test/cmocka/src/audio/kpb/kpb_buffer.c
+++ b/test/cmocka/src/audio/kpb/kpb_buffer.c
@@ -113,7 +113,7 @@ static int buffering_test_setup(void **state)
 	.size = sizeof(struct sof_kpb_config),
 	.no_channels = 2,
 	.sampling_freq = KPB_SAMPLNG_FREQUENCY,
-	.sampling_width = KPB_SAMPLING_WIDTH,
+	.sampling_width = KPB_SAMPLE_CONTAINER_SIZE(16),
 	};
 
 	/* Register KPB component to use its internal functions */


### PR DESCRIPTION
This patch adds rework of validation of host params for WoV feature + refactor several variables to make them more meaningful.

NOTE! This patch require a change in WoV related test cases - the host buffer size must be at least twice as big as FW buffer size which is 4200 [ms] = 537600 [bytes] (calculated for S24_LE format).