### PR TITLE
ipc: component: add core id to sof_ipc_comp

### DIFF
--- a/src/include/ipc/topology.h
+++ b/src/include/ipc/topology.h
@@ -61,9 +61,10 @@ struct sof_ipc_comp {
 	uint32_t id;
 	enum sof_comp_type type;
 	uint32_t pipeline_id;
+	uint32_t core;
 
 	/* reserved for future use */
-	uint32_t reserved[2];
+	uint32_t reserved[1];
 } __attribute__((packed));
 
 /*

--- a/src/include/kernel/abi.h
+++ b/src/include/kernel/abi.h
@@ -29,7 +29,7 @@
 
 /** \brief SOF ABI version major, minor and patch numbers */
 #define SOF_ABI_MAJOR 3
-#define SOF_ABI_MINOR 12
+#define SOF_ABI_MINOR 13
 #define SOF_ABI_PATCH 0
 
 /** \brief SOF ABI version number. Format within 32bit word is MMmmmppp */


### PR DESCRIPTION
Adds core id to sof_ipc_comp. The intention of this change
is to incorporate full SMP flow in DSP for IPC handling.
Right now all components and buffers are created on master core
and cache is synchronized between cores, when pipeline is supposed
to run on slave core. With this change we can detect on which core
particular component is supposed to be running and let that core
do the work of handling IPC.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>

Matching kernel PR: https://github.com/thesofproject/linux/pull/1739