### PR TITLE
component: remove debug trace

### DIFF
--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -39,8 +39,6 @@ static const struct comp_driver *get_drv(uint32_t type)
 			goto out;
 		}
 
-		trace_buffer_error("addr = 0x%x", (uintptr_t)info);
-
 		platform_shared_commit(info, sizeof(*info));
 	}
 


### PR DESCRIPTION
Removes debug trace, which has been merged by accident.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>