### PR TITLE
platform: use dma from sof context for domain initialization

### DIFF
--- a/src/drivers/imx/edma.c
+++ b/src/drivers/imx/edma.c
@@ -119,10 +119,10 @@ static void edma_channel_put(struct dma_chan_data *channel)
 
 	notifier_unregister_all(NULL, channel);
 
-	spin_lock_irq(&dma->lock, flags);
+	spin_lock_irq(&channel->dma->lock, flags);
 	channel->status = COMP_STATE_INIT;
 	atomic_sub(&channel->dma->num_channels_busy, 1);
-	spin_unlock_irq(&dma->lock, flags);
+	spin_unlock_irq(&channel->dma->lock, flags);
 }
 
 static int edma_start(struct dma_chan_data *channel)

--- a/src/include/sof/lib/dma.h
+++ b/src/include/sof/lib/dma.h
@@ -222,8 +222,6 @@ struct dma_info {
 	size_t num_dmas;
 };
 
-extern struct dma dma[];
-
 /**
  * \brief API to initialize a platform DMA controllers.
  *

--- a/src/platform/baytrail/platform.c
+++ b/src/platform/baytrail/platform.c
@@ -206,14 +206,6 @@ int platform_init(struct sof *sof)
 				  CONFIG_SYSTICK_PERIOD);
 	scheduler_init_ll(sof->platform_timer_domain);
 
-	/* init low latency multi channel DW-DMA domain and scheduler */
-	sof->platform_dma_domain =
-		dma_multi_chan_domain_init(
-				&dma[PLATFORM_DW_DMA_INDEX],
-				PLATFORM_NUM_DW_DMACS,
-				PLATFORM_DEFAULT_CLOCK, true);
-	scheduler_init_ll(sof->platform_dma_domain);
-
 	/* init the system agent */
 	trace_point(TRACE_BOOT_PLATFORM_AGENT);
 	sa_init(sof, CONFIG_SYSTICK_PERIOD);
@@ -231,6 +223,13 @@ int platform_init(struct sof *sof)
 	ret = dmac_init(sof);
 	if (ret < 0)
 		return -ENODEV;
+
+	/* init low latency multi channel DW-DMA domain and scheduler */
+	sof->platform_dma_domain = dma_multi_chan_domain_init
+			(&sof->dma_info->dma_array[PLATFORM_DW_DMA_INDEX],
+			 PLATFORM_NUM_DW_DMACS,
+			 PLATFORM_DEFAULT_CLOCK, true);
+	scheduler_init_ll(sof->platform_dma_domain);
 
 	/* initialise the host IPC mechanisms */
 	trace_point(TRACE_BOOT_PLATFORM_IPC);

--- a/src/platform/haswell/platform.c
+++ b/src/platform/haswell/platform.c
@@ -194,14 +194,6 @@ int platform_init(struct sof *sof)
 				  CONFIG_SYSTICK_PERIOD);
 	scheduler_init_ll(sof->platform_timer_domain);
 
-	/* init low latency multi channel DW-DMA domain and scheduler */
-	sof->platform_dma_domain =
-		dma_multi_chan_domain_init(
-				&dma[PLATFORM_DW_DMA_INDEX],
-				PLATFORM_NUM_DW_DMACS,
-				PLATFORM_DEFAULT_CLOCK, true);
-	scheduler_init_ll(sof->platform_dma_domain);
-
 	/* init the system agent */
 	trace_point(TRACE_BOOT_PLATFORM_AGENT);
 	sa_init(sof, CONFIG_SYSTICK_PERIOD);
@@ -219,6 +211,13 @@ int platform_init(struct sof *sof)
 	ret = dmac_init(sof);
 	if (ret < 0)
 		return -ENODEV;
+
+	/* init low latency multi channel DW-DMA domain and scheduler */
+	sof->platform_dma_domain = dma_multi_chan_domain_init
+			(&sof->dma_info->dma_array[PLATFORM_DW_DMA_INDEX],
+			 PLATFORM_NUM_DW_DMACS,
+			 PLATFORM_DEFAULT_CLOCK, true);
+	scheduler_init_ll(sof->platform_dma_domain);
 
 	/* initialise the host IPC mechanisms */
 	trace_point(TRACE_BOOT_PLATFORM_IPC);

--- a/src/platform/imx8/platform.c
+++ b/src/platform/imx8/platform.c
@@ -163,15 +163,6 @@ int platform_init(struct sof *sof)
 				  CONFIG_SYSTICK_PERIOD);
 	scheduler_init_ll(sof->platform_timer_domain);
 
-	/* Init EDMA platform domain */
-	sof->platform_dma_domain =
-		dma_multi_chan_domain_init(
-		    &dma[0],
-		    1,
-		    PLATFORM_DEFAULT_CLOCK,
-		    false);
-	scheduler_init_ll(sof->platform_dma_domain);
-
 	platform_timer_start(sof->platform_timer);
 	sa_init(sof, CONFIG_SYSTICK_PERIOD);
 
@@ -181,6 +172,12 @@ int platform_init(struct sof *sof)
 	ret = dmac_init(sof);
 	if (ret < 0)
 		return -ENODEV;
+
+	/* Init EDMA platform domain */
+	sof->platform_dma_domain = dma_multi_chan_domain_init
+			(&sof->dma_info->dma_array[0], 1,
+			 PLATFORM_DEFAULT_CLOCK, false);
+	scheduler_init_ll(sof->platform_dma_domain);
 
 	/* initialize the host IPC mechanims */
 	ipc_init(sof);

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -384,14 +384,6 @@ int platform_init(struct sof *sof)
 				  CONFIG_SYSTICK_PERIOD);
 	scheduler_init_ll(sof->platform_timer_domain);
 
-	/* init low latency single channel DW-DMA domain and scheduler */
-	sof->platform_dma_domain =
-		dma_single_chan_domain_init
-			(&dma[PLATFORM_DW_DMA_INDEX],
-			 PLATFORM_NUM_DW_DMACS,
-			 PLATFORM_DEFAULT_CLOCK);
-	scheduler_init_ll(sof->platform_dma_domain);
-
 	/* init the system agent */
 	trace_point(TRACE_BOOT_PLATFORM_AGENT);
 	sa_init(sof, CONFIG_SYSTICK_PERIOD);
@@ -466,6 +458,14 @@ int platform_init(struct sof *sof)
 	ret = dmac_init(sof);
 	if (ret < 0)
 		return ret;
+
+	/* init low latency single channel DW-DMA domain and scheduler */
+	sof->platform_dma_domain =
+		dma_single_chan_domain_init
+			(&sof->dma_info->dma_array[PLATFORM_DW_DMA_INDEX],
+			 PLATFORM_NUM_DW_DMACS,
+			 PLATFORM_DEFAULT_CLOCK);
+	scheduler_init_ll(sof->platform_dma_domain);
 
 	/* initialize the host IPC mechanisms */
 	trace_point(TRACE_BOOT_PLATFORM_IPC);


### PR DESCRIPTION
Changes sequence of initialization in platform_init(),
so that DMA scheduling domain can be initialized with the DMA
taken through sof context. This allows for removal of another
externed global variable.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>