### PR TITLE
arch: smp: new and more error resistant SMP implementation

### DIFF
--- a/src/arch/xtensa/lib/cpu.c
+++ b/src/arch/xtensa/lib/cpu.c
@@ -21,6 +21,7 @@
 #include <sof/lib/pm_runtime.h>
 #include <sof/lib/wait.h>
 #include <sof/schedule/schedule.h>
+#include <sof/sof.h>
 #include <sof/trace/trace.h>
 #include <user/trace.h>
 #include <xtos-structs.h>
@@ -33,7 +34,6 @@
 
 extern struct core_context *core_ctx_ptr[PLATFORM_CORE_COUNT];
 extern struct xtos_core_data *core_data_ptr[PLATFORM_CORE_COUNT];
-extern unsigned int _bss_start, _bss_end;
 
 __aligned(PLATFORM_DCACHE_ALIGN) static union {
 	uint32_t value;
@@ -112,10 +112,8 @@ void cpu_alloc_core_context(int core)
 	dcache_writeback_invalidate_region(core_ctx_ptr,
 					   sizeof(core_ctx_ptr));
 
-	/* writeback bss region to share static pointers */
-	dcache_writeback_region((void *)&_bss_start,
-				(unsigned int)&_bss_end -
-				(unsigned int)&_bss_start);
+	/* share pointer to sof context */
+	dcache_writeback_region(sof_get(), sizeof(*sof_get()));
 }
 
 void cpu_power_down_core(void)

--- a/src/arch/xtensa/lib/cpu.c
+++ b/src/arch/xtensa/lib/cpu.c
@@ -35,10 +35,7 @@
 extern struct core_context *core_ctx_ptr[PLATFORM_CORE_COUNT];
 extern struct xtos_core_data *core_data_ptr[PLATFORM_CORE_COUNT];
 
-__aligned(PLATFORM_DCACHE_ALIGN) static union {
-	uint32_t value;
-	uint8_t bytes[PLATFORM_DCACHE_ALIGN];
-} active_cores_mask;
+static uint32_t active_cores_mask;
 
 void arch_cpu_enable_core(int id)
 {
@@ -63,7 +60,7 @@ void arch_cpu_enable_core(int id)
 		/* send IDC power up message */
 		idc_send_msg(&power_up, IDC_NON_BLOCKING);
 
-		active_cores_mask.value |= (1 << id);
+		active_cores_mask |= (1 << id);
 	}
 
 	irq_local_enable(flags);
@@ -80,7 +77,7 @@ void arch_cpu_disable_core(int id)
 	if (arch_cpu_is_core_enabled(id)) {
 		idc_send_msg(&power_down, IDC_NON_BLOCKING);
 
-		active_cores_mask.value ^= (1 << id);
+		active_cores_mask ^= (1 << id);
 	}
 
 	irq_local_enable(flags);
@@ -89,7 +86,7 @@ void arch_cpu_disable_core(int id)
 int arch_cpu_is_core_enabled(int id)
 {
 	return id == PLATFORM_MASTER_CORE_ID ||
-		active_cores_mask.value & (1 << id);
+		active_cores_mask & (1 << id);
 }
 
 void cpu_alloc_core_context(int core)

--- a/src/arch/xtensa/schedule/task.c
+++ b/src/arch/xtensa/schedule/task.c
@@ -112,10 +112,6 @@ int task_context_init(void *task_ctx, void *entry, void *arg0, void *arg1,
 
 	ctx->stack_pointer = sp;
 
-	/* flush for slave core */
-	if (cpu_is_slave(task_core))
-		task_context_cache(ctx, CACHE_WRITEBACK_INV);
-
 	return 0;
 }
 
@@ -130,21 +126,4 @@ void task_context_free(void *task_ctx)
 	ctx->stack_pointer = NULL;
 
 	rfree(ctx);
-}
-
-void task_context_cache(void *task_ctx, int cmd)
-{
-	xtos_task_context *ctx = task_ctx;
-
-	switch (cmd) {
-	case CACHE_WRITEBACK_INV:
-		dcache_writeback_invalidate_region(ctx->stack_base,
-						   ctx->stack_size);
-		dcache_writeback_invalidate_region(ctx, sizeof(*ctx));
-		break;
-	case CACHE_INVALIDATE:
-		dcache_invalidate_region(ctx, sizeof(*ctx));
-		dcache_invalidate_region(ctx->stack_base, ctx->stack_size);
-		break;
-	}
 }

--- a/src/audio/buffer.c
+++ b/src/audio/buffer.c
@@ -70,6 +70,7 @@ struct comp_buffer *buffer_new(struct sof_ipc_buffer *desc)
 	if (buffer) {
 		buffer->id = desc->comp.id;
 		buffer->pipeline_id = desc->comp.pipeline_id;
+		buffer->core = desc->comp.core;
 	}
 
 	return buffer;

--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -807,39 +807,6 @@ static int dai_config(struct comp_dev *dev, struct sof_ipc_dai_config *config)
 	return dai_set_config(dd->dai, config);
 }
 
-static void dai_cache(struct comp_dev *dev, int cmd)
-{
-	struct dai_data *dd;
-
-	switch (cmd) {
-	case CACHE_WRITEBACK_INV:
-		trace_dai_with_ids(dev, "dai_cache(), CACHE_WRITEBACK_INV");
-
-		dd = comp_get_drvdata(dev);
-
-		dma_sg_cache_wb_inv(&dd->config.elem_array);
-
-		dcache_writeback_invalidate_region(dd->dma_buffer,
-						   sizeof(*dd->dma_buffer));
-		dcache_writeback_invalidate_region(dd, sizeof(*dd));
-		dcache_writeback_invalidate_region(dev, sizeof(*dev));
-		break;
-
-	case CACHE_INVALIDATE:
-		trace_dai_with_ids(dev, "dai_cache(), CACHE_INVALIDATE");
-
-		dcache_invalidate_region(dev, sizeof(*dev));
-
-		dd = comp_get_drvdata(dev);
-		dcache_invalidate_region(dd, sizeof(*dd));
-		dcache_invalidate_region(dd->dma_buffer,
-					 sizeof(*dd->dma_buffer));
-
-		dma_sg_cache_inv(&dd->config.elem_array);
-		break;
-	}
-}
-
 static const struct comp_driver comp_dai = {
 	.type	= SOF_COMP_DAI,
 	.ops	= {
@@ -852,7 +819,6 @@ static const struct comp_driver comp_dai = {
 		.reset		= dai_reset,
 		.dai_config	= dai_config,
 		.position	= dai_position,
-		.cache		= dai_cache,
 	},
 };
 

--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -799,7 +799,7 @@ static int dai_config(struct comp_dev *dev, struct sof_ipc_dai_config *config)
 		}
 	}
 
-	return 0;
+	return dai_set_config(dd->dai, config);
 }
 
 static void dai_cache(struct comp_dev *dev, int cmd)

--- a/src/audio/detect_test.c
+++ b/src/audio/detect_test.c
@@ -12,7 +12,6 @@
 #include <sof/debug/panic.h>
 #include <sof/drivers/ipc.h>
 #include <sof/lib/alloc.h>
-#include <sof/lib/cache.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/notifier.h>
 #include <sof/lib/wait.h>
@@ -796,33 +795,6 @@ static int test_keyword_prepare(struct comp_dev *dev)
 	return comp_set_state(dev, COMP_TRIGGER_PREPARE);
 }
 
-static void test_keyword_cache(struct comp_dev *dev, int cmd)
-{
-	struct comp_data *cd;
-
-	switch (cmd) {
-	case CACHE_WRITEBACK_INV:
-		trace_keyword_with_ids(dev, "test_keyword_cache(), "
-				       "CACHE_WRITEBACK_INV");
-
-		cd = comp_get_drvdata(dev);
-
-		dcache_writeback_invalidate_region(cd, sizeof(*cd));
-		dcache_writeback_invalidate_region(dev, sizeof(*dev));
-		break;
-
-	case CACHE_INVALIDATE:
-		trace_keyword_with_ids(dev, "test_keyword_cache(), "
-				       "CACHE_INVALIDATE");
-
-		dcache_invalidate_region(dev, sizeof(*dev));
-
-		cd = comp_get_drvdata(dev);
-		dcache_invalidate_region(cd, sizeof(*cd));
-		break;
-	}
-}
-
 static const struct comp_driver comp_keyword = {
 	.type	= SOF_COMP_KEYWORD_DETECT,
 	.ops	= {
@@ -834,7 +806,6 @@ static const struct comp_driver comp_keyword = {
 		.copy		= test_keyword_copy,
 		.prepare	= test_keyword_prepare,
 		.reset		= test_keyword_reset,
-		.cache		= test_keyword_cache,
 	},
 };
 

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -486,11 +486,6 @@ static int kpb_cmd(struct comp_dev *dev, int cmd, void *data,
 	return ret;
 }
 
-static void kpb_cache(struct comp_dev *dev, int cmd)
-{
-	/* TODO: writeback history buffer */
-}
-
 /**
  * \brief Resets KPB component.
  * \param[in,out] dev KPB base component device.
@@ -1444,7 +1439,6 @@ static const struct comp_driver comp_kpb = {
 		.copy = kpb_copy,
 		.prepare = kpb_prepare,
 		.reset = kpb_reset,
-		.cache = kpb_cache,
 		.params = kpb_params,
 	},
 };

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -14,7 +14,6 @@
 #include <sof/debug/panic.h>
 #include <sof/drivers/ipc.h>
 #include <sof/lib/alloc.h>
-#include <sof/lib/cache.h>
 #include <sof/lib/memory.h>
 #include <sof/list.h>
 #include <sof/math/numbers.h>
@@ -417,31 +416,6 @@ static int mixer_prepare(struct comp_dev *dev)
 	return downstream;
 }
 
-static void mixer_cache(struct comp_dev *dev, int cmd)
-{
-	struct mixer_data *md;
-
-	switch (cmd) {
-	case CACHE_WRITEBACK_INV:
-		trace_mixer_with_ids(dev, "mixer_cache(), CACHE_WRITEBACK_INV");
-
-		md = comp_get_drvdata(dev);
-
-		dcache_writeback_invalidate_region(md, sizeof(*md));
-		dcache_writeback_invalidate_region(dev, sizeof(*dev));
-		break;
-
-	case CACHE_INVALIDATE:
-		trace_mixer_with_ids(dev, "mixer_cache(), CACHE_INVALIDATE");
-
-		dcache_invalidate_region(dev, sizeof(*dev));
-
-		md = comp_get_drvdata(dev);
-		dcache_invalidate_region(md, sizeof(*md));
-		break;
-	}
-}
-
 static const struct comp_driver comp_mixer = {
 	.type	= SOF_COMP_MIXER,
 	.ops	= {
@@ -452,7 +426,6 @@ static const struct comp_driver comp_mixer = {
 		.trigger	= mixer_trigger,
 		.copy		= mixer_copy,
 		.reset		= mixer_reset,
-		.cache		= mixer_cache,
 	},
 };
 

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -20,7 +20,6 @@
 #include <sof/debug/panic.h>
 #include <sof/drivers/ipc.h>
 #include <sof/lib/alloc.h>
-#include <sof/lib/cache.h>
 #include <sof/lib/memory.h>
 #include <sof/list.h>
 #include <sof/string.h>
@@ -459,38 +458,6 @@ static int selector_reset(struct comp_dev *dev)
 	return ret == 0 ? PPL_STATUS_PATH_STOP : ret;
 }
 
-/**
- * \brief Executes cache operation on selector component.
- * \param[in,out] dev Selector base component device.
- * \param[in] cmd Cache command.
- */
-static void selector_cache(struct comp_dev *dev, int cmd)
-{
-	struct comp_data *cd;
-
-	switch (cmd) {
-	case CACHE_WRITEBACK_INV:
-		trace_selector_with_ids(dev, "selector_cache(), "
-					"CACHE_WRITEBACK_INV");
-
-		cd = comp_get_drvdata(dev);
-
-		dcache_writeback_invalidate_region(cd, sizeof(*cd));
-		dcache_writeback_invalidate_region(dev, sizeof(*dev));
-		break;
-
-	case CACHE_INVALIDATE:
-		trace_selector_with_ids(dev, "selector_cache(), "
-					"CACHE_INVALIDATE");
-
-		dcache_invalidate_region(dev, sizeof(*dev));
-
-		cd = comp_get_drvdata(dev);
-		dcache_invalidate_region(cd, sizeof(*cd));
-		break;
-	}
-}
-
 /** \brief Selector component definition. */
 static const struct comp_driver comp_selector = {
 	.type	= SOF_COMP_SELECTOR,
@@ -503,7 +470,6 @@ static const struct comp_driver comp_selector = {
 		.copy		= selector_copy,
 		.prepare	= selector_prepare,
 		.reset		= selector_reset,
-		.cache		= selector_cache,
 	},
 };
 

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -15,7 +15,6 @@
 #include <sof/debug/panic.h>
 #include <sof/drivers/ipc.h>
 #include <sof/lib/alloc.h>
-#include <sof/lib/cache.h>
 #include <sof/lib/memory.h>
 #include <sof/list.h>
 #include <sof/math/numbers.h>
@@ -894,41 +893,6 @@ static int src_reset(struct comp_dev *dev)
 	return 0;
 }
 
-static void src_cache(struct comp_dev *dev, int cmd)
-{
-	struct comp_data *cd;
-
-	switch (cmd) {
-	case CACHE_WRITEBACK_INV:
-		trace_src_with_ids(dev, "src_cache(), CACHE_WRITEBACK_INV");
-
-		cd = comp_get_drvdata(dev);
-
-		if (cd->delay_lines)
-			dcache_writeback_invalidate_region
-				(cd->delay_lines,
-				 sizeof(int32_t) * cd->param.total);
-
-		dcache_writeback_invalidate_region(cd, sizeof(*cd));
-		dcache_writeback_invalidate_region(dev, sizeof(*dev));
-		break;
-
-	case CACHE_INVALIDATE:
-		trace_src_with_ids(dev, "src_cache(), CACHE_INVALIDATE");
-
-		dcache_invalidate_region(dev, sizeof(*dev));
-
-		cd = comp_get_drvdata(dev);
-		dcache_invalidate_region(cd, sizeof(*cd));
-
-		if (cd->delay_lines)
-			dcache_invalidate_region
-				(cd->delay_lines,
-				 sizeof(int32_t) * cd->param.total);
-		break;
-	}
-}
-
 static const struct comp_driver comp_src = {
 	.type = SOF_COMP_SRC,
 	.ops = {
@@ -940,7 +904,6 @@ static const struct comp_driver comp_src = {
 		.copy = src_copy,
 		.prepare = src_prepare,
 		.reset = src_reset,
-		.cache = src_cache,
 	},
 };
 

--- a/src/audio/tone.c
+++ b/src/audio/tone.c
@@ -14,7 +14,6 @@
 #include <sof/debug/panic.h>
 #include <sof/drivers/ipc.h>
 #include <sof/lib/alloc.h>
-#include <sof/lib/cache.h>
 #include <sof/lib/memory.h>
 #include <sof/list.h>
 #include <sof/math/trig.h>
@@ -725,31 +724,6 @@ static int tone_reset(struct comp_dev *dev)
 	return 0;
 }
 
-static void tone_cache(struct comp_dev *dev, int cmd)
-{
-	struct comp_data *cd;
-
-	switch (cmd) {
-	case CACHE_WRITEBACK_INV:
-		trace_tone_with_ids(dev, "tone_cache(), CACHE_WRITEBACK_INV");
-
-		cd = comp_get_drvdata(dev);
-
-		dcache_writeback_invalidate_region(cd, sizeof(*cd));
-		dcache_writeback_invalidate_region(dev, sizeof(*dev));
-		break;
-
-	case CACHE_INVALIDATE:
-		trace_tone_with_ids(dev, "tone_cache(), CACHE_INVALIDATE");
-
-		dcache_invalidate_region(dev, sizeof(*dev));
-
-		cd = comp_get_drvdata(dev);
-		dcache_invalidate_region(cd, sizeof(*cd));
-		break;
-	}
-}
-
 static const struct comp_driver comp_tone = {
 	.type = SOF_COMP_TONE,
 	.ops = {
@@ -761,7 +735,6 @@ static const struct comp_driver comp_tone = {
 		.copy = tone_copy,
 		.prepare = tone_prepare,
 		.reset = tone_reset,
-		.cache = tone_cache,
 	},
 };
 

--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -22,7 +22,6 @@
 #include <sof/debug/panic.h>
 #include <sof/drivers/ipc.h>
 #include <sof/lib/alloc.h>
-#include <sof/lib/cache.h>
 #include <sof/lib/memory.h>
 #include <sof/list.h>
 #include <sof/math/numbers.h>
@@ -712,37 +711,6 @@ static int volume_reset(struct comp_dev *dev)
 	return 0;
 }
 
-/**
- * \brief Executes cache operation on volume component.
- * \param[in,out] dev Volume base component device.
- * \param[in] cmd Cache command.
- */
-static void volume_cache(struct comp_dev *dev, int cmd)
-{
-	struct comp_data *cd;
-
-	switch (cmd) {
-	case CACHE_WRITEBACK_INV:
-		trace_volume_with_ids(dev, "volume_cache(), "
-				      "CACHE_WRITEBACK_INV");
-
-		cd = comp_get_drvdata(dev);
-
-		dcache_writeback_invalidate_region(cd, sizeof(*cd));
-		dcache_writeback_invalidate_region(dev, sizeof(*dev));
-		break;
-
-	case CACHE_INVALIDATE:
-		trace_volume_with_ids(dev, "volume_cache(), CACHE_INVALIDATE");
-
-		dcache_invalidate_region(dev, sizeof(*dev));
-
-		cd = comp_get_drvdata(dev);
-		dcache_invalidate_region(cd, sizeof(*cd));
-		break;
-	}
-}
-
 /** \brief Volume component definition. */
 static const struct comp_driver comp_volume = {
 	.type	= SOF_COMP_VOLUME,
@@ -755,7 +723,6 @@ static const struct comp_driver comp_volume = {
 		.copy		= volume_copy,
 		.prepare	= volume_prepare,
 		.reset		= volume_reset,
-		.cache		= volume_cache,
 	},
 };
 

--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -976,8 +976,8 @@ static int dw_dma_probe(struct dma *dma)
 		chan->index = i;
 		chan->core = DMA_CORE_INVALID;
 
-		dw_chan = rzalloc(SOF_MEM_ZONE_SYS_RUNTIME, SOF_MEM_FLAG_SHARED,
-				  SOF_MEM_CAPS_RAM, sizeof(*dw_chan));
+		dw_chan = rzalloc(SOF_MEM_ZONE_SYS_RUNTIME, 0, SOF_MEM_CAPS_RAM,
+				  sizeof(*dw_chan));
 
 		if (!dw_chan) {
 			trace_dwdma_error("dw_dma_probe() error: dma %d "

--- a/src/drivers/generic/dummy-dma.c
+++ b/src/drivers/generic/dummy-dma.c
@@ -439,8 +439,7 @@ static int dummy_dma_probe(struct dma *dma)
 		return -ENOMEM;
 	}
 
-	chanp = rzalloc(SOF_MEM_ZONE_SYS_RUNTIME, SOF_MEM_FLAG_SHARED,
-			SOF_MEM_CAPS_RAM,
+	chanp = rzalloc(SOF_MEM_ZONE_SYS_RUNTIME, 0, SOF_MEM_CAPS_RAM,
 			dma->plat_data.channels * sizeof(chanp[0]));
 	if (!chanp) {
 		rfree(dma->chan);

--- a/src/drivers/intel/cavs/dmic.c
+++ b/src/drivers/intel/cavs/dmic.c
@@ -1512,8 +1512,8 @@ static int dmic_probe(struct dai *dai)
 		return -EEXIST; /* already created */
 
 	/* allocate private data */
-	dmic = rzalloc(SOF_MEM_ZONE_SYS_RUNTIME, SOF_MEM_FLAG_SHARED,
-		       SOF_MEM_CAPS_RAM, sizeof(*dmic));
+	dmic = rzalloc(SOF_MEM_ZONE_SYS_RUNTIME, 0, SOF_MEM_CAPS_RAM,
+		       sizeof(*dmic));
 	if (!dmic) {
 		trace_dmic_error("dmic_probe() error: alloc failed");
 		return -ENOMEM;

--- a/src/drivers/intel/cavs/hda-dma.c
+++ b/src/drivers/intel/cavs/hda-dma.c
@@ -733,8 +733,8 @@ static int hda_dma_probe(struct dma *dma)
 		chan->status = COMP_STATE_INIT;
 		chan->core = DMA_CORE_INVALID;
 
-		hda_chan = rzalloc(SOF_MEM_ZONE_SYS_RUNTIME,
-				   SOF_MEM_FLAG_SHARED, SOF_MEM_CAPS_RAM,
+		hda_chan = rzalloc(SOF_MEM_ZONE_SYS_RUNTIME, 0,
+				   SOF_MEM_CAPS_RAM,
 				   sizeof(struct hda_chan_data));
 		if (!hda_chan) {
 			trace_hddma_error("hda-dma: %d channel %d private data "

--- a/src/drivers/intel/cavs/idc.c
+++ b/src/drivers/intel/cavs/idc.c
@@ -230,6 +230,17 @@ static int idc_component_command(uint32_t cmd)
 }
 
 /**
+ * \brief Executes IDC IPC processing message.
+ */
+static void idc_ipc(void)
+{
+	struct ipc *ipc = ipc_get();
+	struct sof_ipc_cmd_hdr *hdr = ipc->comp_data;
+
+	ipc_cmd(hdr);
+}
+
+/**
  * \brief Executes IDC message based on type.
  * \param[in,out] msg Pointer to IDC message.
  */
@@ -249,6 +260,9 @@ static void idc_cmd(struct idc_msg *msg)
 		break;
 	case iTS(IDC_MSG_NOTIFY):
 		notifier_notify_remote();
+		break;
+	case iTS(IDC_MSG_IPC):
+		idc_ipc();
 		break;
 	default:
 		trace_idc_error("idc_cmd() error: invalid msg->header = %u",

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -70,6 +70,7 @@ struct comp_buffer {
 	uint32_t id;
 	uint32_t pipeline_id;
 	uint32_t caps;
+	uint32_t core;
 
 	/* connected components */
 	struct comp_dev *source;	/* source component */

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -144,8 +144,6 @@ struct buffer_cb_free {
 #define buffer_write_frag_s32(buffer, idx) \
 	buffer_get_frag(buffer, buffer->w_ptr, idx, sizeof(int32_t))
 
-typedef void (*cache_buff_op)(struct comp_buffer *, void *);
-
 /* pipeline buffer creation and destruction */
 struct comp_buffer *buffer_alloc(uint32_t size, uint32_t caps, uint32_t align);
 struct comp_buffer *buffer_new(struct sof_ipc_buffer *desc);
@@ -191,31 +189,6 @@ static inline uint32_t comp_buffer_get_copy_bytes(struct comp_buffer *source,
 		return sink->free;
 	else
 		return source->avail;
-}
-
-static inline void comp_buffer_cache_wtb_inv(struct comp_buffer *buffer,
-					     void *data)
-{
-	dcache_writeback_invalidate_region(buffer, sizeof(*buffer));
-}
-
-static inline void comp_buffer_cache_inv(struct comp_buffer *buffer, void *data)
-{
-	dcache_invalidate_region(buffer, sizeof(*buffer));
-}
-
-static inline cache_buff_op comp_buffer_cache_op(int cmd)
-{
-	switch (cmd) {
-	case CACHE_WRITEBACK_INV:
-		return &comp_buffer_cache_wtb_inv;
-	case CACHE_INVALIDATE:
-		return &comp_buffer_cache_inv;
-	default:
-		trace_buffer_error("comp_buffer_cache_op() error: "
-				   "invalid cmd = %u", cmd);
-		return NULL;
-	}
 }
 
 static inline void buffer_reset_pos(struct comp_buffer *buffer, void *data)

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -218,9 +218,6 @@ struct comp_ops {
 	int (*position)(struct comp_dev *dev,
 		struct sof_ipc_stream_posn *posn);
 
-	/** cache operation on component data */
-	void (*cache)(struct comp_dev *dev, int cmd);
-
 	/** set attribute in component */
 	int (*set_attribute)(struct comp_dev *dev, uint32_t type,
 			     void *value);
@@ -530,17 +527,6 @@ static inline int comp_position(struct comp_dev *dev,
 }
 
 /**
- * Component L1 cache command (invalidate, writeback, ...).
- * @param dev Component device
- * @param cmd Command.
- */
-static inline void comp_cache(struct comp_dev *dev, int cmd)
-{
-	if (dev->drv->ops.cache)
-		dev->drv->ops.cache(dev, cmd);
-}
-
-/**
  * Sets component attribute.
  * @param dev Component device.
  * @param type Attribute type.
@@ -593,27 +579,6 @@ static inline int comp_is_single_pipeline(struct comp_dev *current,
 static inline int comp_is_active(struct comp_dev *current)
 {
 	return current->state == COMP_STATE_ACTIVE;
-}
-
-/**
- * Retrieves previous connected component.
- * @param dev Component device.
- * @param dir Component stream direction.
- * @return Previous connected component device.
- */
-static inline struct comp_dev *comp_get_previous(struct comp_dev *dev, int dir)
-{
-	struct list_item *buffer_list = comp_buffer_list(dev, dir);
-	struct comp_dev *prev = NULL;
-	struct comp_buffer *buffer;
-
-	if (!list_is_empty(buffer_list)) {
-		buffer = buffer_from_list(buffer_list->next,
-					  struct comp_buffer, dir);
-		prev = buffer_get_comp(buffer, dir);
-	}
-
-	return prev;
 }
 
 /**

--- a/src/include/sof/drivers/idc.h
+++ b/src/include/sof/drivers/idc.h
@@ -71,20 +71,12 @@
 #define IDC_MSG_POWER_DOWN	IDC_TYPE(0x2)
 #define IDC_MSG_POWER_DOWN_EXT	IDC_EXTENSION(0x0)
 
-/** \brief IDC trigger pipeline message. */
-#define IDC_MSG_PPL_TRIGGER		IDC_TYPE(0x3)
-#define IDC_MSG_PPL_TRIGGER_EXT(x)	IDC_EXTENSION(x)
-
-/** \brief IDC component command message. */
-#define IDC_MSG_COMP_CMD	IDC_TYPE(0x4)
-#define IDC_MSG_COMP_CMD_EXT(x)	IDC_EXTENSION(x)
-
 /** \brief IDC notify message. */
-#define IDC_MSG_NOTIFY		IDC_TYPE(0x5)
+#define IDC_MSG_NOTIFY		IDC_TYPE(0x3)
 #define IDC_MSG_NOTIFY_EXT	IDC_EXTENSION(0x0)
 
 /** \brief IDC IPC processing message. */
-#define IDC_MSG_IPC		IDC_TYPE(0x6)
+#define IDC_MSG_IPC		IDC_TYPE(0x4)
 #define IDC_MSG_IPC_EXT		IDC_EXTENSION(0x0)
 
 /** \brief Decodes IDC message type. */

--- a/src/include/sof/drivers/idc.h
+++ b/src/include/sof/drivers/idc.h
@@ -83,6 +83,10 @@
 #define IDC_MSG_NOTIFY		IDC_TYPE(0x5)
 #define IDC_MSG_NOTIFY_EXT	IDC_EXTENSION(0x0)
 
+/** \brief IDC IPC processing message. */
+#define IDC_MSG_IPC		IDC_TYPE(0x6)
+#define IDC_MSG_IPC_EXT		IDC_EXTENSION(0x0)
+
 /** \brief Decodes IDC message type. */
 #define iTS(x)	(((x) >> IDC_TYPE_SHIFT) & IDC_TYPE_MASK)
 

--- a/src/include/sof/drivers/ipc.h
+++ b/src/include/sof/drivers/ipc.h
@@ -61,6 +61,8 @@ struct sof_ipc_stream_posn;
 /* IPC generic component device */
 struct ipc_comp_dev {
 	uint16_t type;	/* COMP_TYPE_ */
+	uint16_t core;
+	uint32_t id;
 
 	/* component type data */
 	union {

--- a/src/include/sof/drivers/ipc.h
+++ b/src/include/sof/drivers/ipc.h
@@ -252,4 +252,11 @@ struct sof_ipc_cmd_hdr *mailbox_validate(void);
  */
 void ipc_cmd(struct sof_ipc_cmd_hdr *hdr);
 
+/**
+ * \brief IPC message to be processed on other core.
+ * @param[in] core Core id for IPC to be processed on.
+ * @return 1 if successful (reply sent by other core), error code otherwise.
+ */
+int ipc_process_on_core(uint32_t core);
+
 #endif /* __SOF_DRIVERS_IPC_H__ */

--- a/src/include/sof/drivers/ipc.h
+++ b/src/include/sof/drivers/ipc.h
@@ -61,7 +61,6 @@ struct sof_ipc_stream_posn;
 /* IPC generic component device */
 struct ipc_comp_dev {
 	uint16_t type;	/* COMP_TYPE_ */
-	uint16_t state;
 
 	/* component type data */
 	union {

--- a/src/include/sof/drivers/mn.h
+++ b/src/include/sof/drivers/mn.h
@@ -8,6 +8,7 @@
 #ifndef __SOF_DRIVERS_MN_H__
 #define __SOF_DRIVERS_MN_H__
 
+#include <sof/sof.h>
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -29,7 +30,7 @@
 /**
  * \brief Initializes MN driver.
  */
-void mn_init(void);
+void mn_init(struct sof *sof);
 
 /**
  * \brief Finds and sets valid combination of MCLK source and divider to
@@ -76,5 +77,14 @@ void mn_release_bclk(uint32_t dai_index);
  * \param[in] dai_index DAI index (SSP port).
  */
 void mn_reset_bclk_divider(uint32_t dai_index);
+
+/**
+ * \brief Retrieves M/N dividers structure.
+ * \return Pointer to M/N dividers structure.
+ */
+static inline struct mn *mn_get(void)
+{
+	return sof_get()->mn;
+}
 
 #endif /* __SOF_DRIVERS_MN_H__ */

--- a/src/include/sof/lib/cpu.h
+++ b/src/include/sof/lib/cpu.h
@@ -35,6 +35,11 @@ static inline bool cpu_is_slave(int id)
 	return id != PLATFORM_MASTER_CORE_ID;
 }
 
+static inline bool cpu_is_me(int id)
+{
+	return id == cpu_get_id();
+}
+
 static inline void cpu_enable_core(int id)
 {
 	arch_cpu_enable_core(id);

--- a/src/include/sof/lib/dma.h
+++ b/src/include/sof/lib/dma.h
@@ -20,7 +20,6 @@
 #include <sof/atomic.h>
 #include <sof/bit.h>
 #include <sof/lib/alloc.h>
-#include <sof/lib/cache.h>
 #include <sof/lib/io.h>
 #include <sof/lib/memory.h>
 #include <sof/sof.h>
@@ -573,22 +572,6 @@ int dma_sg_alloc(struct dma_sg_elem_array *ea,
 		 uintptr_t dma_buffer_addr, uintptr_t external_addr);
 
 void dma_sg_free(struct dma_sg_elem_array *ea);
-
-static inline void dma_sg_cache_wb_inv(struct dma_sg_elem_array *ea)
-{
-	if (ea->elems)
-		dcache_writeback_invalidate_region(ea->elems,
-						   ea->count *
-						   sizeof(struct dma_sg_elem));
-}
-
-static inline void dma_sg_cache_inv(struct dma_sg_elem_array *ea)
-{
-	if (ea->elems)
-		dcache_invalidate_region(ea->elems,
-					 ea->count *
-					 sizeof(struct dma_sg_elem));
-}
 
 /**
  * \brief Get the total size of SG buffer

--- a/src/include/sof/lib/mailbox.h
+++ b/src/include/sof/lib/mailbox.h
@@ -12,6 +12,7 @@
 #include <platform/lib/mailbox.h>
 #include <sof/debug/panic.h>
 #include <sof/lib/cache.h>
+#include <sof/lib/memory.h>
 #include <sof/string.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/src/include/sof/sof.h
+++ b/src/include/sof/sof.h
@@ -21,6 +21,7 @@ struct dma_trace_data;
 struct ipc;
 struct ll_schedule_domain;
 struct mm;
+struct mn;
 struct notify_data;
 struct pm_runtime_data;
 struct sa;
@@ -86,6 +87,9 @@ struct sof {
 
 	/* list of registered component drivers */
 	struct comp_driver_list *comp_drivers;
+
+	/* M/N dividers */
+	struct mn *mn;
 
 	__aligned(PLATFORM_DCACHE_ALIGN) int alignment[0];
 } __aligned(PLATFORM_DCACHE_ALIGN);

--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -530,8 +530,6 @@ static int ipc_dai_config(uint32_t header)
 {
 	struct ipc *ipc = ipc_get();
 	struct sof_ipc_dai_config config;
-	struct dai *dai;
-	int ret;
 
 	/* copy message with ABI safe method */
 	IPC_COPY_CMD(config, ipc->comp_data);
@@ -539,27 +537,9 @@ static int ipc_dai_config(uint32_t header)
 	trace_ipc("ipc: dai %d,%d -> config ", config.type,
 		  config.dai_index);
 
-	/* get DAI */
-	dai = dai_get(config.type, config.dai_index, 0 /* existing only */);
-	if (dai == NULL) {
-		trace_ipc_error("ipc: dai %d,%d not found",
-				config.type, config.dai_index);
-		return -ENODEV;
-	}
-
-	/* configure DAI */
-	ret = dai_set_config(dai,
-			     (struct sof_ipc_dai_config *)ipc->comp_data);
-	dai_put(dai); /* free ref immediately */
-	if (ret < 0) {
-		trace_ipc_error("ipc: dai %d,%d config failed %d",
-				config.type, config.dai_index, ret);
-		return ret;
-	}
-
-	/* now send params to all DAI components who use that physical DAI */
+	/* send params to all DAI components who use that physical DAI */
 	return ipc_comp_dai_config(ipc,
-				  (struct sof_ipc_dai_config *)ipc->comp_data);
+				   (struct sof_ipc_dai_config *)ipc->comp_data);
 }
 
 static int ipc_glb_dai_message(uint32_t header)

--- a/src/ipc/ipc.c
+++ b/src/ipc/ipc.c
@@ -45,22 +45,8 @@ struct ipc_comp_dev *ipc_get_comp_by_id(struct ipc *ipc, uint32_t id)
 
 	list_for_item(clist, &ipc->comp_list) {
 		icd = container_of(clist, struct ipc_comp_dev, list);
-		switch (icd->type) {
-		case COMP_TYPE_COMPONENT:
-			if (icd->cd->comp.id == id)
-				return icd;
-			break;
-		case COMP_TYPE_BUFFER:
-			if (icd->cb->id == id)
-				return icd;
-			break;
-		case COMP_TYPE_PIPELINE:
-			if (icd->pipeline->ipc_pipe.comp_id == id)
-				return icd;
-			break;
-		default:
-			break;
-		}
+		if (icd->id == id)
+			return icd;
 
 		platform_shared_commit(icd, sizeof(*icd));
 	}
@@ -170,6 +156,8 @@ int ipc_comp_new(struct ipc *ipc, struct sof_ipc_comp *comp)
 	}
 	icd->cd = cd;
 	icd->type = COMP_TYPE_COMPONENT;
+	icd->core = comp->core;
+	icd->id = comp->id;
 
 	/* add new component to the list */
 	list_item_append(&icd->list, &ipc->comp_list);
@@ -240,6 +228,8 @@ int ipc_buffer_new(struct ipc *ipc, struct sof_ipc_buffer *desc)
 	}
 	ibd->cb = buffer;
 	ibd->type = COMP_TYPE_BUFFER;
+	ibd->core = desc->comp.core;
+	ibd->id = desc->comp.id;
 
 	/* add new buffer to the list */
 	list_item_append(&ibd->list, &ipc->comp_list);
@@ -372,6 +362,8 @@ int ipc_pipeline_new(struct ipc *ipc,
 
 	ipc_pipe->pipeline = pipe;
 	ipc_pipe->type = COMP_TYPE_PIPELINE;
+	ipc_pipe->core = pipe_desc->core;
+	ipc_pipe->id = pipe_desc->comp_id;
 
 	/* add new pipeline to the list */
 	list_item_append(&ipc_pipe->list, &ipc->comp_list);

--- a/src/platform/intel/cavs/lib/dai.c
+++ b/src/platform/intel/cavs/lib/dai.c
@@ -155,7 +155,7 @@ int dai_init(struct sof *sof)
 #endif
 
 #if CONFIG_CAVS_MN
-	mn_init();
+	mn_init(sof);
 #endif
 
 	dai = cache_to_uncache((struct dai *)hda);

--- a/src/platform/library/include/platform/lib/memory.h
+++ b/src/platform/library/include/platform/lib/memory.h
@@ -29,6 +29,10 @@
 
 #define SHARED_DATA
 
+#define uncache_to_cache(address)	(address)
+#define cache_to_uncache(address)	(address)
+#define is_uncached(address)		0
+
 static inline void *platform_shared_get(void *ptr, int bytes)
 {
 	return ptr;

--- a/src/schedule/ll_schedule.c
+++ b/src/schedule/ll_schedule.c
@@ -11,7 +11,6 @@
 #include <sof/drivers/interrupt.h>
 #include <sof/drivers/timer.h>
 #include <sof/lib/alloc.h>
-#include <sof/lib/cache.h>
 #include <sof/lib/clk.h>
 #include <sof/lib/cpu.h>
 #include <sof/lib/memory.h>
@@ -296,10 +295,6 @@ static void schedule_ll_task(void *data, struct task *task, uint64_t start,
 
 	pdata = ll_sch_get_pdata(task);
 
-	/* invalidate if slave core */
-	if (cpu_is_slave(task->core))
-		dcache_invalidate_region(pdata, sizeof(*pdata));
-
 	trace_ll("task add %p task->priority %d start %u period %u",
 		 (uintptr_t)task, task->priority, start, period);
 
@@ -348,11 +343,6 @@ int schedule_task_init_ll(struct task *task, uint16_t type, uint16_t priority,
 		trace_ll_error("schedule_task_init_ll() error: alloc failed");
 		return -ENOMEM;
 	}
-
-	/* flush for slave core */
-	if (cpu_is_slave(task->core))
-		dcache_writeback_invalidate_region(ll_pdata,
-						   sizeof(*ll_pdata));
 
 	ll_sch_set_pdata(task, ll_pdata);
 


### PR DESCRIPTION
This set of patches adds new and more error resistant SMP implementation. Components are now created and configured directly on the core on which they will be running. Previously they were all created on master core, which later manually synchronized memory between cores, which was very error prone. New implementation is much cleaner and allows to remove many lines of code.