### PR TITLE
[DO NOT MERGE]CI: travis: add IMX8M build check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ env:
   - PLATFORM=jsl
   - PLATFORM=imx8
   - PLATFORM=imx8x
+  - PLATFORM=imx8m
 
 script: ./scripts/docker-run.sh ./scripts/xtensa-build-all.sh -j $PLATFORM
 


### PR DESCRIPTION
Enable imx8x build check in travis. One needs a new gcc/xtensa
toolchain.

Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>