### PR TITLE
audio_stream: Add assertion in init function

### DIFF
--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -36,8 +36,8 @@ struct audio_stream {
 
 	/* runtime stream params */
 	uint32_t frame_fmt;	/**< enum sof_ipc_frame */
-	uint32_t rate;
-	uint16_t channels;
+	uint32_t rate;		/**< number of data frames per second [Hz] */
+	uint16_t channels;	/**< number of samples in each frame */
 };
 
 #define audio_stream_read_frag(buffer, idx, size) \

--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -200,6 +200,9 @@ static inline void audio_stream_reset(struct audio_stream *buffer)
 static inline void audio_stream_init(struct audio_stream *buffer,
 				     void *buff_addr, uint32_t size)
 {
+	assert(buffer);
+	assert(buff_addr);
+
 	buffer->size = size;
 	buffer->addr = buff_addr;
 	buffer->end_addr = (char *)buffer->addr + size;


### PR DESCRIPTION
Assert input pointers in init function to avoid situation when some
error during memory allocation in higher level of api occurred and
won't be properly handled.

Such an issue also may be easily introduced during implementing
unit tests, but as there will be properly handled assertion, there
won't be problem with debugging.

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>