### PR TITLE
pcm_converter: audio_stream: Pass offset to first sample to function call

### DIFF
--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -185,7 +185,7 @@ static void eq_fir_s16_passthrough(struct fir_state_32x16 fir[],
 				   struct audio_stream *sink,
 				   int frames, int nch)
 {
-	audio_stream_copy_s16(source, sink, frames * nch);
+	audio_stream_copy_s16(source, 0, sink, 0, frames * nch);
 }
 #endif /* CONFIG_FORMAT_S16LE */
 
@@ -195,7 +195,7 @@ static void eq_fir_s32_passthrough(struct fir_state_32x16 fir[],
 				   struct audio_stream *sink,
 				   int frames, int nch)
 {
-	audio_stream_copy_s32(source, sink, frames * nch);
+	audio_stream_copy_s32(source, 0, sink, 0, frames * nch);
 }
 #endif /* CONFIG_FORMAT_S24LE || CONFIG_FORMAT_S32LE */
 

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -223,7 +223,7 @@ static void eq_iir_s16_pass(const struct comp_dev *dev,
 			    struct audio_stream *sink,
 			    uint32_t frames)
 {
-	audio_stream_copy_s16(source, sink, frames * source->channels);
+	audio_stream_copy_s16(source, 0, sink, 0, frames * source->channels);
 }
 #endif /* CONFIG_FORMAT_S16LE */
 
@@ -233,7 +233,7 @@ static void eq_iir_s32_pass(const struct comp_dev *dev,
 			    struct audio_stream *sink,
 			    uint32_t frames)
 {
-	audio_stream_copy_s32(source, sink, frames * source->channels);
+	audio_stream_copy_s32(source, 0, sink, 0, frames * source->channels);
 }
 #endif /* CONFIG_FORMAT_S24LE || CONFIG_FORMAT_S32LE */
 

--- a/src/audio/pcm_converter/pcm_converter_generic.c
+++ b/src/audio/pcm_converter/pcm_converter_generic.c
@@ -25,7 +25,8 @@
 #if CONFIG_FORMAT_S16LE && CONFIG_FORMAT_S24LE
 
 static void pcm_convert_s16_to_s24(const struct audio_stream *source,
-				   struct audio_stream *sink, uint32_t samples)
+				   uint32_t ioffset, struct audio_stream *sink,
+				   uint32_t ooffset, uint32_t samples)
 {
 	uint32_t buff_frag = 0;
 	int16_t *src;
@@ -33,15 +34,16 @@ static void pcm_convert_s16_to_s24(const struct audio_stream *source,
 	uint32_t i;
 
 	for (i = 0; i < samples; i++) {
-		src = audio_stream_read_frag_s16(source, buff_frag);
-		dst = audio_stream_write_frag_s32(sink, buff_frag);
+		src = audio_stream_read_frag_s16(source, buff_frag + ioffset);
+		dst = audio_stream_write_frag_s32(sink, buff_frag + ooffset);
 		*dst = *src << 8;
 		buff_frag++;
 	}
 }
 
 static void pcm_convert_s24_to_s16(const struct audio_stream *source,
-				   struct audio_stream *sink, uint32_t samples)
+				   uint32_t ioffset, struct audio_stream *sink,
+				   uint32_t ooffset, uint32_t samples)
 {
 	uint32_t buff_frag = 0;
 	int32_t *src;
@@ -49,8 +51,8 @@ static void pcm_convert_s24_to_s16(const struct audio_stream *source,
 	uint32_t i;
 
 	for (i = 0; i < samples; i++) {
-		src = audio_stream_read_frag_s32(source, buff_frag);
-		dst = audio_stream_write_frag_s16(sink, buff_frag);
+		src = audio_stream_read_frag_s32(source, buff_frag + ioffset);
+		dst = audio_stream_write_frag_s16(sink, buff_frag + ooffset);
 		*dst = sat_int16(Q_SHIFT_RND(sign_extend_s24(*src), 23, 15));
 		buff_frag++;
 	}
@@ -61,7 +63,8 @@ static void pcm_convert_s24_to_s16(const struct audio_stream *source,
 #if CONFIG_FORMAT_S16LE && CONFIG_FORMAT_S32LE
 
 static void pcm_convert_s16_to_s32(const struct audio_stream *source,
-				   struct audio_stream *sink, uint32_t samples)
+				   uint32_t ioffset, struct audio_stream *sink,
+				   uint32_t ooffset, uint32_t samples)
 {
 	uint32_t buff_frag = 0;
 	int16_t *src;
@@ -69,15 +72,16 @@ static void pcm_convert_s16_to_s32(const struct audio_stream *source,
 	uint32_t i;
 
 	for (i = 0; i < samples; i++) {
-		src = audio_stream_read_frag_s16(source, buff_frag);
-		dst = audio_stream_write_frag_s32(sink, buff_frag);
+		src = audio_stream_read_frag_s16(source, buff_frag + ioffset);
+		dst = audio_stream_write_frag_s32(sink, buff_frag + ooffset);
 		*dst = *src << 16;
 		buff_frag++;
 	}
 }
 
 static void pcm_convert_s32_to_s16(const struct audio_stream *source,
-				   struct audio_stream *sink, uint32_t samples)
+				   uint32_t ioffset, struct audio_stream *sink,
+				   uint32_t ooffset, uint32_t samples)
 {
 	uint32_t buff_frag = 0;
 	int32_t *src;
@@ -85,8 +89,8 @@ static void pcm_convert_s32_to_s16(const struct audio_stream *source,
 	uint32_t i;
 
 	for (i = 0; i < samples; i++) {
-		src = audio_stream_read_frag_s32(source, buff_frag);
-		dst = audio_stream_write_frag_s16(sink, buff_frag);
+		src = audio_stream_read_frag_s32(source, buff_frag + ioffset);
+		dst = audio_stream_write_frag_s16(sink, buff_frag + ooffset);
 		*dst = sat_int16(Q_SHIFT_RND(*src, 31, 15));
 		buff_frag++;
 	}
@@ -97,7 +101,8 @@ static void pcm_convert_s32_to_s16(const struct audio_stream *source,
 #if CONFIG_FORMAT_S24LE && CONFIG_FORMAT_S32LE
 
 static void pcm_convert_s24_to_s32(const struct audio_stream *source,
-				   struct audio_stream *sink, uint32_t samples)
+				   uint32_t ioffset, struct audio_stream *sink,
+				   uint32_t ooffset, uint32_t samples)
 {
 	uint32_t buff_frag = 0;
 	int32_t *src;
@@ -105,15 +110,16 @@ static void pcm_convert_s24_to_s32(const struct audio_stream *source,
 	uint32_t i;
 
 	for (i = 0; i < samples; i++) {
-		src = audio_stream_read_frag_s32(source, buff_frag);
-		dst = audio_stream_write_frag_s32(sink, buff_frag);
+		src = audio_stream_read_frag_s32(source, buff_frag + ioffset);
+		dst = audio_stream_write_frag_s32(sink, buff_frag + ooffset);
 		*dst = *src << 8;
 		buff_frag++;
 	}
 }
 
 static void pcm_convert_s32_to_s24(const struct audio_stream *source,
-				   struct audio_stream *sink, uint32_t samples)
+				   uint32_t ioffset, struct audio_stream *sink,
+				   uint32_t ooffset, uint32_t samples)
 {
 	uint32_t buff_frag = 0;
 	int32_t *src;
@@ -121,8 +127,8 @@ static void pcm_convert_s32_to_s24(const struct audio_stream *source,
 	uint32_t i;
 
 	for (i = 0; i < samples; i++) {
-		src = audio_stream_read_frag_s32(source, buff_frag);
-		dst = audio_stream_write_frag_s32(sink, buff_frag);
+		src = audio_stream_read_frag_s32(source, buff_frag + ioffset);
+		dst = audio_stream_write_frag_s32(sink, buff_frag + ooffset);
 		*dst = sat_int24(Q_SHIFT_RND(*src, 31, 23));
 		buff_frag++;
 	}

--- a/src/audio/pcm_converter/pcm_converter_hifi3.c
+++ b/src/audio/pcm_converter/pcm_converter_hifi3.c
@@ -41,10 +41,11 @@ static void pcm_converter_setup_circular(const struct audio_stream *source)
  * \param[in] samples Number of samples to process.
  */
 static void pcm_convert_s16_to_s24(const struct audio_stream *source,
-				   struct audio_stream *sink, uint32_t samples)
+				   uint32_t ioffset, struct audio_stream *sink,
+				   uint32_t ooffset, uint32_t samples)
 {
-	ae_int16 *in = (ae_int16 *)source->r_ptr;
-	ae_int32 *out = (ae_int32 *)sink->w_ptr;
+	ae_int16 *in = audio_stream_read_frag(source, ioffset, sizeof(int16_t));
+	ae_int32 *out = audio_stream_write_frag(sink, ooffset, sizeof(int32_t));
 	ae_int16x4 sample = AE_ZERO16();
 	ae_valign align_out = AE_ZALIGN64();
 	ae_int16x4 *in16x4;
@@ -138,10 +139,13 @@ static ae_int32x2 pcm_shift_s24_to_s16(ae_int32x2 sample)
  * \param[in] samples Number of samples to process.
  */
 static void pcm_convert_s24_to_s16(const struct audio_stream *source,
-				   struct audio_stream *sink, uint32_t samples)
+				   uint32_t ioffset, struct audio_stream *sink,
+				   uint32_t ooffset, uint32_t samples)
 {
-	ae_int32x2 *in = (ae_int32x2 *)source->r_ptr;
-	ae_int16x4 *out = (ae_int16x4 *)sink->w_ptr;
+	ae_int32x2 *in = audio_stream_read_frag(source, ioffset,
+						sizeof(int32_t));
+	ae_int16x4 *out = audio_stream_write_frag(sink, ooffset,
+						  sizeof(int16_t));
 	ae_int16x4 sample = AE_ZERO16();
 	ae_int32x2 sample_1 = AE_ZERO32();
 	ae_int32x2 sample_2 = AE_ZERO32();
@@ -240,10 +244,13 @@ static void pcm_convert_s24_to_s16(const struct audio_stream *source,
  * \param[in] samples Number of samples to process.
  */
 static void pcm_convert_s16_to_s32(const struct audio_stream *source,
-				   struct audio_stream *sink, uint32_t samples)
+				   uint32_t ioffset, struct audio_stream *sink,
+				   uint32_t ooffset, uint32_t samples)
 {
-	ae_int16 *in = (ae_int16 *)source->r_ptr;
-	ae_int32 *out = (ae_int32 *)sink->w_ptr;
+	ae_int16 *in = audio_stream_read_frag(source, ioffset,
+					      sizeof(int16_t));
+	ae_int32 *out = audio_stream_write_frag(sink, ooffset,
+						sizeof(int32_t));
 	ae_int16x4 sample = AE_ZERO16();
 	ae_valign align_out = AE_ZALIGN64();
 	ae_int16x4 *in16x4;
@@ -317,10 +324,13 @@ static void pcm_convert_s16_to_s32(const struct audio_stream *source,
  * \param[in] samples Number of samples to process.
  */
 static void pcm_convert_s32_to_s16(const struct audio_stream *source,
-				   struct audio_stream *sink, uint32_t samples)
+				   uint32_t ioffset, struct audio_stream *sink,
+				   uint32_t ooffset, uint32_t samples)
 {
-	ae_int32x2 *in = (ae_int32x2 *)source->r_ptr;
-	ae_int16x4 *out = (ae_int16x4 *)sink->w_ptr;
+	ae_int32x2 *in = audio_stream_read_frag(source, ioffset,
+						sizeof(int32_t));
+	ae_int16x4 *out = audio_stream_write_frag(sink, ooffset,
+						  sizeof(int16_t));
 	ae_int16x4 sample = AE_ZERO16();
 	ae_int32x2 sample_1 = AE_ZERO32();
 	ae_int32x2 sample_2 = AE_ZERO32();
@@ -415,10 +425,13 @@ static void pcm_convert_s32_to_s16(const struct audio_stream *source,
  * \param[in] samples Number of samples to process.
  */
 static void pcm_convert_s24_to_s32(const struct audio_stream *source,
-				   struct audio_stream *sink, uint32_t samples)
+				   uint32_t ioffset, struct audio_stream *sink,
+				   uint32_t ooffset, uint32_t samples)
 {
-	ae_int32x2 *in = (ae_int32x2 *)source->r_ptr;
-	ae_int32x2 *out = (ae_int32x2 *)sink->w_ptr;
+	ae_int32x2 *in = audio_stream_read_frag(source, ioffset,
+						sizeof(int32_t));
+	ae_int32x2 *out = audio_stream_write_frag(sink, ooffset,
+						  sizeof(int32_t));
 	ae_int32x2 sample = AE_ZERO32();
 	ae_valign align_out = AE_ZALIGN64();
 	int i;
@@ -498,10 +511,13 @@ static ae_int32x2 pcm_shift_s32_to_s24(ae_int32x2 sample)
  * \param[in] samples Number of samples to process.
  */
 static void pcm_convert_s32_to_s24(const struct audio_stream *source,
-				   struct audio_stream *sink, uint32_t samples)
+				   uint32_t ioffset, struct audio_stream *sink,
+				   uint32_t ooffset, uint32_t samples)
 {
-	ae_int32x2 *in = (ae_int32x2 *)source->r_ptr;
-	ae_int32x2 *out = (ae_int32x2 *)sink->w_ptr;
+	ae_int32x2 *in = audio_stream_read_frag(source, ioffset,
+						sizeof(int32_t));
+	ae_int32x2 *out = audio_stream_write_frag(sink, ooffset,
+						  sizeof(int32_t));
 	ae_int32x2 sample = AE_ZERO32();
 	ae_valign align_out = AE_ZALIGN64();
 	int i;

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -443,7 +443,7 @@ static void src_copy_s32(struct comp_dev *dev,
 	struct comp_data *cd = comp_get_drvdata(dev);
 	int frames = cd->param.blk_in;
 
-	audio_stream_copy_s32(source, sink, frames * source->channels);
+	audio_stream_copy_s32(source, 0, sink, 0, frames * source->channels);
 
 	*n_read = frames;
 	*n_written = frames;
@@ -458,7 +458,7 @@ static void src_copy_s16(struct comp_dev *dev,
 	struct comp_data *cd = comp_get_drvdata(dev);
 	int frames = cd->param.blk_in;
 
-	audio_stream_copy_s16(source, sink, frames * source->channels);
+	audio_stream_copy_s16(source, 0, sink, 0, frames * source->channels);
 
 	*n_read = frames;
 	*n_written = frames;

--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -207,10 +207,14 @@ static inline void audio_stream_init(struct audio_stream *buffer,
 }
 
 static inline void audio_stream_copy(const struct audio_stream *source,
-				     struct audio_stream *sink, uint32_t bytes)
+				     uint32_t ioffset_bytes,
+				     struct audio_stream *sink,
+				     uint32_t ooffset_bytes, uint32_t bytes)
 {
-	void *src = source->r_ptr;
-	void *snk = sink->w_ptr;
+	void *src = audio_stream_wrap(source,
+				      (char *)source->r_ptr + ioffset_bytes);
+	void *snk = audio_stream_wrap(sink,
+				      (char *)sink->w_ptr + ooffset_bytes);
 	uint32_t bytes_src;
 	uint32_t bytes_snk;
 	uint32_t bytes_copied;
@@ -236,10 +240,14 @@ static inline void audio_stream_copy(const struct audio_stream *source,
 #if CONFIG_FORMAT_S16LE
 
 static inline void audio_stream_copy_s16(const struct audio_stream *source,
+					 uint32_t ioffset,
 					 struct audio_stream *sink,
-					 uint32_t samples)
+					 uint32_t ooffset, uint32_t samples)
 {
-	audio_stream_copy(source, sink, samples * sizeof(int16_t));
+	const int ssize = sizeof(int16_t);
+
+	audio_stream_copy(source, ioffset * ssize, sink, ooffset * ssize,
+			  samples * ssize);
 }
 
 #endif /* CONFIG_FORMAT_S16LE */
@@ -247,10 +255,14 @@ static inline void audio_stream_copy_s16(const struct audio_stream *source,
 #if CONFIG_FORMAT_S24LE || CONFIG_FORMAT_S32LE || CONFIG_FORMAT_FLOAT
 
 static inline void audio_stream_copy_s32(const struct audio_stream *source,
+					 uint32_t ioffset,
 					 struct audio_stream *sink,
-					 uint32_t samples)
+					 uint32_t ooffset, uint32_t samples)
 {
-	audio_stream_copy(source, sink, samples * sizeof(int32_t));
+	const int ssize = sizeof(int32_t);
+
+	audio_stream_copy(source, ioffset * ssize, sink, ooffset * ssize,
+			  samples * ssize);
 }
 
 #endif /* CONFIG_FORMAT_S24LE || CONFIG_FORMAT_S32LE || CONFIG_FORMAT_FLOAT */

--- a/src/include/sof/audio/pcm_converter.h
+++ b/src/include/sof/audio/pcm_converter.h
@@ -39,11 +39,14 @@ struct audio_stream;
 /**
  * \brief PCM conversion function interface for data in circular buffer
  * \param source buffer with samples to process, read pointer is not modified
+ * \param ioffset offset to first sample in source stream
  * \param sink output buffer, write pointer is not modified
+ * \param ooffset offset to first sample in sink stream
  * \param samples number of samples to convert
  */
 typedef void (*pcm_converter_func)(const struct audio_stream *source,
-				   struct audio_stream *sink, uint32_t samples);
+				   uint32_t ioffset, struct audio_stream *sink,
+				   uint32_t ooffset, uint32_t samples);
 
 /** \brief PCM conversion functions map. */
 struct pcm_func_map {

--- a/src/include/sof/lib/dma.h
+++ b/src/include/sof/lib/dma.h
@@ -224,7 +224,8 @@ struct dma_info {
 
 struct audio_stream;
 typedef void (*dma_process_func)(const struct audio_stream *source,
-				 struct audio_stream *sink, uint32_t frames);
+				 uint32_t ioffset, struct audio_stream *sink,
+				 uint32_t ooffset, uint32_t frames);
 
 /**
  * \brief API to initialize a platform DMA controllers.

--- a/src/lib/dma.c
+++ b/src/lib/dma.c
@@ -205,7 +205,7 @@ void dma_buffer_copy_from(struct comp_buffer *source, uint32_t source_bytes,
 		dcache_invalidate_region(istream->addr, tail);
 
 	/* process data */
-	process(istream, &sink->stream, samples);
+	process(istream, 0, &sink->stream, 0, samples);
 
 	istream->r_ptr = (char *)istream->r_ptr + source_bytes;
 	istream->r_ptr = audio_stream_wrap(istream, istream->r_ptr);
@@ -222,7 +222,7 @@ void dma_buffer_copy_to(struct comp_buffer *source, uint32_t source_bytes,
 	struct audio_stream *ostream = &sink->stream;
 
 	/* process data */
-	process(&source->stream, ostream, samples);
+	process(&source->stream, 0, ostream, 0, samples);
 
 	/* sink buffer contains data meant to copied to DMA */
 	if ((char *)ostream->w_ptr + sink_bytes > (char *)ostream->end_addr) {


### PR DESCRIPTION
pcm_converter: audio_stream: Pass offset to first sample to function call

During conversion every available data sample from source stream through
temporary buffer. Size of this buffer may be big enougth to always convert
each data stream in one pass and converter interface doesn't need to be
changed but then capacity of this buffer must be same as source stream
(in samples). In this scenario memory management is very inefficient,
espially with grow of number of components with such a need.

There are also a few solution to use smaller buffers instead.
It can by achieved by:
1) manually moving r_ptr in source stream in component copy() routine,
   what shouldn't happen in such a place
2) calling buffer_consume() after each portion of samples, what leads
   to data fragmentation and performance issues
3) introducing offset argument in converter interface

As we can see, solution number 3 is best one.
Moreover introducing data offset for processing function is common
technique and doesn't introduce visible performance issues.

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>