### PR TITLE
memory: remove uncache macros from several platforms

### DIFF
--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -817,7 +817,7 @@ static void dw_dma_verify_transfer(struct dma_chan_data *channel,
 {
 	struct dw_dma_chan_data *dw_chan = dma_chan_get_data(channel);
 #if CONFIG_HW_LLI
-	struct dw_lli *ll_uncached = cache_to_uncache(dw_chan->lli_current);
+	struct dw_lli *lli = platform_dw_dma_lli_get(dw_chan->lli_current);
 
 	switch (next->status) {
 	case DMA_CB_STATUS_END:
@@ -826,11 +826,11 @@ static void dw_dma_verify_transfer(struct dma_chan_data *channel,
 			      DW_CHAN_MASK(channel->index));
 		/* fallthrough */
 	default:
-		while (ll_uncached->ctrl_hi & DW_CTLH_DONE(1)) {
-			ll_uncached->ctrl_hi &= ~DW_CTLH_DONE(1);
+		while (lli->ctrl_hi & DW_CTLH_DONE(1)) {
+			lli->ctrl_hi &= ~DW_CTLH_DONE(1);
 			dw_chan->lli_current =
 				(struct dw_lli *)dw_chan->lli_current->llp;
-			ll_uncached = cache_to_uncache(dw_chan->lli_current);
+			lli = platform_dw_dma_lli_get(dw_chan->lli_current);
 		}
 		break;
 	}

--- a/src/include/sof/lib/mailbox.h
+++ b/src/include/sof/lib/mailbox.h
@@ -12,15 +12,9 @@
 #include <platform/lib/mailbox.h>
 #include <sof/debug/panic.h>
 #include <sof/lib/cache.h>
-#include <sof/lib/memory.h>
 #include <sof/string.h>
 #include <stddef.h>
 #include <stdint.h>
-
-/* For those platform did not have SW_REG window, use DEBUG at now */
-#ifndef MAILBOX_SW_REG_BASE
-#define MAILBOX_SW_REG_BASE MAILBOX_DEBUG_BASE
-#endif  /* MAILBOX_SW_REG_BASE */
 
 #define mailbox_get_exception_base() \
 	MAILBOX_EXCEPTION_BASE
@@ -101,16 +95,6 @@ void mailbox_stream_write(size_t offset, const void *src, size_t bytes)
 	assert(!ret);
 	dcache_writeback_region((void *)(MAILBOX_STREAM_BASE + offset),
 				bytes);
-}
-
-static inline
-void mailbox_sw_reg_write(size_t offset, uint32_t src)
-{
-	volatile uint32_t *ptr;
-
-	ptr = (volatile uint32_t *)(MAILBOX_SW_REG_BASE + offset);
-	ptr = cache_to_uncache(ptr);
-	*ptr = src;
 }
 
 #endif /* __SOF_LIB_MAILBOX_H__ */

--- a/src/platform/baytrail/include/platform/lib/mailbox.h
+++ b/src/platform/baytrail/include/platform/lib/mailbox.h
@@ -12,6 +12,7 @@
 
 #include <sof/lib/memory.h>
 #include <config.h>
+#include <stdint.h>
 
 #define MAILBOX_HOST_OFFSET	0x144000
 
@@ -54,6 +55,14 @@
 
 #define MAILBOX_TRACE_BASE \
 	(MAILBOX_BASE + MAILBOX_TRACE_OFFSET)
+
+static inline void mailbox_sw_reg_write(size_t offset, uint32_t src)
+{
+	volatile uint32_t *ptr;
+
+	ptr = (volatile uint32_t *)(MAILBOX_DEBUG_BASE + offset);
+	*ptr = src;
+}
 
 #endif /* __PLATFORM_LIB_MAILBOX_H__ */
 

--- a/src/platform/baytrail/include/platform/lib/memory.h
+++ b/src/platform/baytrail/include/platform/lib/memory.h
@@ -193,10 +193,6 @@ static inline void *platform_rfree_prepare(void *ptr)
 
 #define SOF_MEM_RO_SIZE			0x8
 
-#define uncache_to_cache(address)	address
-#define cache_to_uncache(address)	address
-#define is_uncached(address)		0
-
 #endif /* __PLATFORM_LIB_MEMORY_H__ */
 
 #else

--- a/src/platform/haswell/include/platform/lib/mailbox.h
+++ b/src/platform/haswell/include/platform/lib/mailbox.h
@@ -12,6 +12,7 @@
 
 #include <sof/lib/memory.h>
 #include <config.h>
+#include <stdint.h>
 
 #if CONFIG_BROADWELL
 #define MAILBOX_HOST_OFFSET	0x0009E000
@@ -58,6 +59,14 @@
 
 #define MAILBOX_TRACE_BASE \
 	(MAILBOX_BASE + MAILBOX_TRACE_OFFSET)
+
+static inline void mailbox_sw_reg_write(size_t offset, uint32_t src)
+{
+	volatile uint32_t *ptr;
+
+	ptr = (volatile uint32_t *)(MAILBOX_DEBUG_BASE + offset);
+	*ptr = src;
+}
 
 #endif /* __PLATFORM_LIB_MAILBOX_H__ */
 

--- a/src/platform/haswell/include/platform/lib/memory.h
+++ b/src/platform/haswell/include/platform/lib/memory.h
@@ -187,10 +187,6 @@ static inline void *platform_rfree_prepare(void *ptr)
 
 #define SOF_MEM_RO_SIZE		0x8
 
-#define uncache_to_cache(address)	address
-#define cache_to_uncache(address)	address
-#define is_uncached(address)		0
-
 #endif /* __PLATFORM_LIB_MEMORY_H__ */
 
 #else

--- a/src/platform/imx8/include/platform/lib/mailbox.h
+++ b/src/platform/imx8/include/platform/lib/mailbox.h
@@ -11,6 +11,7 @@
 #define __PLATFORM_LIB_MAILBOX_H__
 
 #include <sof/lib/memory.h>
+#include <stdint.h>
 
 /*
  * The Window Region on i.MX8 SRAM is organised like this :-
@@ -50,6 +51,14 @@
 #define MAILBOX_STREAM_SIZE		SRAM_STREAM_SIZE
 #define MAILBOX_STREAM_BASE		SRAM_STREAM_BASE
 #define MAILBOX_STREAM_OFFSET		SRAM_STREAM_OFFSET
+
+static inline void mailbox_sw_reg_write(size_t offset, uint32_t src)
+{
+	volatile uint32_t *ptr;
+
+	ptr = (volatile uint32_t *)(MAILBOX_DEBUG_BASE + offset);
+	*ptr = src;
+}
 
 #endif /* __PLATFORM_LIB_MAILBOX_H__ */
 

--- a/src/platform/imx8/include/platform/lib/memory.h
+++ b/src/platform/imx8/include/platform/lib/memory.h
@@ -165,10 +165,6 @@
 
 #define SOF_MEM_RO_SIZE			0x8
 
-#define uncache_to_cache(address)	address
-#define cache_to_uncache(address)	address
-#define is_uncached(address)		0
-
 #define HEAP_BUF_ALIGNMENT		PLATFORM_DCACHE_ALIGN
 
 #if !defined(__ASSEMBLER__) && !defined(LINKER)

--- a/src/platform/imx8m/include/platform/lib/mailbox.h
+++ b/src/platform/imx8m/include/platform/lib/mailbox.h
@@ -11,6 +11,7 @@
 #define __PLATFORM_LIB_MAILBOX_H__
 
 #include <sof/lib/memory.h>
+#include <stdint.h>
 
 /*
  * The Window Region on i.MX8 SRAM is organised like this :-
@@ -50,6 +51,14 @@
 #define MAILBOX_STREAM_SIZE		SRAM_STREAM_SIZE
 #define MAILBOX_STREAM_BASE		SRAM_STREAM_BASE
 #define MAILBOX_STREAM_OFFSET		SRAM_STREAM_OFFSET
+
+static inline void mailbox_sw_reg_write(size_t offset, uint32_t src)
+{
+	volatile uint32_t *ptr;
+
+	ptr = (volatile uint32_t *)(MAILBOX_DEBUG_BASE + offset);
+	*ptr = src;
+}
 
 #endif /* __PLATFORM_LIB_MAILBOX_H__ */
 

--- a/src/platform/imx8m/include/platform/lib/memory.h
+++ b/src/platform/imx8m/include/platform/lib/memory.h
@@ -162,10 +162,6 @@
 
 #define SOF_MEM_RO_SIZE			0x8
 
-#define uncache_to_cache(address)	address
-#define cache_to_uncache(address)	address
-#define is_uncached(address)		0
-
 #define HEAP_BUF_ALIGNMENT		PLATFORM_DCACHE_ALIGN
 
 #if !defined(__ASSEMBLER__) && !defined(LINKER)

--- a/src/platform/intel/cavs/include/cavs/drivers/dw-dma.h
+++ b/src/platform/intel/cavs/include/cavs/drivers/dw-dma.h
@@ -85,6 +85,11 @@ static inline void platform_dw_dma_llp_disable(struct dma *dma,
 		   shim_read(DW_CHLLPC(dma, chan)) & ~SHIM_GPDMA_CHLLPC_EN);
 }
 
+static inline struct dw_lli *platform_dw_dma_lli_get(struct dw_lli *lli)
+{
+	return cache_to_uncache(lli);
+}
+
 #endif /* __CAVS_LIB_DW_DMA_H__ */
 
 #else

--- a/src/platform/intel/cavs/include/cavs/lib/mailbox.h
+++ b/src/platform/intel/cavs/include/cavs/lib/mailbox.h
@@ -12,6 +12,7 @@
 #define __CAVS_LIB_MAILBOX_H__
 
 #include <sof/lib/memory.h>
+#include <stdint.h>
 
 /*
  * The Window Region on HPSRAM for cAVS platforms is organised like this :-
@@ -59,6 +60,15 @@
 
 #define MAILBOX_SW_REG_SIZE	SRAM_SW_REG_SIZE
 #define MAILBOX_SW_REG_BASE	SRAM_SW_REG_BASE
+
+static inline void mailbox_sw_reg_write(size_t offset, uint32_t src)
+{
+	volatile uint32_t *ptr;
+
+	ptr = (volatile uint32_t *)(MAILBOX_SW_REG_BASE + offset);
+	ptr = cache_to_uncache(ptr);
+	*ptr = src;
+}
 
 #endif /* __CAVS_LIB_MAILBOX_H__ */
 

--- a/src/platform/library/include/platform/lib/mailbox.h
+++ b/src/platform/library/include/platform/lib/mailbox.h
@@ -11,6 +11,7 @@
 #define __PLATFORM_LIB_MAILBOX_H__
 
 #include <sof/lib/memory.h>
+#include <stdint.h>
 
 #define MAILBOX_HOST_OFFSET	0x144000
 
@@ -47,6 +48,8 @@
 #define MAILBOX_TRACE_SIZE	0x380
 #define MAILBOX_TRACE_BASE \
 	(MAILBOX_BASE + MAILBOX_TRACE_OFFSET)
+
+static inline void mailbox_sw_reg_write(size_t offset, uint32_t src) { }
 
 #endif /* __PLATFORM_LIB_MAILBOX_H__ */
 

--- a/src/platform/library/include/platform/lib/memory.h
+++ b/src/platform/library/include/platform/lib/memory.h
@@ -29,10 +29,6 @@
 
 #define SHARED_DATA
 
-#define uncache_to_cache(address)	(address)
-#define cache_to_uncache(address)	(address)
-#define is_uncached(address)		0
-
 static inline void *platform_shared_get(void *ptr, int bytes)
 {
 	return ptr;


### PR DESCRIPTION
Removes uncache macros from platforms, which don't support
uncached memory region.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>