### PR TITLE
Audio stream:  use enum data type for frame_fmt field

### DIFF
--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -20,6 +20,7 @@
 #include <sof/math/numbers.h>
 #include <sof/lib/alloc.h>
 #include <sof/lib/cache.h>
+#include <ipc/stream.h>
 #include <config.h>
 #include <stdint.h>
 
@@ -35,7 +36,7 @@ struct audio_stream {
 	void *end_addr;		/* buffer end address */
 
 	/* runtime stream params */
-	uint32_t frame_fmt;	/**< enum sof_ipc_frame */
+	enum sof_ipc_frame frame_fmt;	/**< sample data format */
 	uint32_t rate;
 	uint16_t channels;
 };

--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -37,8 +37,8 @@ struct audio_stream {
 
 	/* runtime stream params */
 	enum sof_ipc_frame frame_fmt;	/**< sample data format */
-	uint32_t rate;
-	uint16_t channels;
+	uint32_t rate;		/**< number of data frames per second [Hz] */
+	uint16_t channels;	/**< number of samples in each frame */
 };
 
 #define audio_stream_read_frag(buffer, idx, size) \


### PR DESCRIPTION
Field frame_fmt is treated as sof_ipc_frame in code so data type
in declaration should be same. Update field comment to be more
appropriate with new data type.

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>