### PR TITLE
gcc: build fixes for GCC 9.x

### DIFF
--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -287,8 +287,9 @@ static int eq_fir_init_coef(struct sof_eq_fir_config *config,
 
 	/* Collect index of respose start positions in all_coefficients[]  */
 	j = 0;
-	assign_response = &config->data[0];
-	coef_data = &config->data[config->channels_in_config];
+	assign_response = ASSUME_ALIGNED(&config->data[0], 4);
+	coef_data = ASSUME_ALIGNED(&config->data[config->channels_in_config],
+				   4);
 	for (i = 0; i < SOF_EQ_FIR_MAX_RESPONSES; i++) {
 		if (i < config->number_of_responses) {
 			eq = (struct sof_eq_fir_coef_data *)&coef_data[j];

--- a/src/audio/eq_fir/fir.c
+++ b/src/audio/eq_fir/fir.c
@@ -10,6 +10,7 @@
 
 #if FIR_GENERIC
 
+#include <sof/common.h>
 #include <sof/audio/buffer.h>
 #include <sof/audio/eq_fir/fir.h>
 #include <sof/audio/format.h>
@@ -51,7 +52,7 @@ int fir_init_coef(struct fir_state_32x16 *fir,
 	fir->length = (int)config->length;
 	fir->taps = fir->length; /* The same for generic C version */
 	fir->out_shift = (int)config->out_shift;
-	fir->coef = &config->coef[0];
+	fir->coef = ASSUME_ALIGNED(&config->coef[0], 4);
 	return 0;
 }
 

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -396,8 +396,9 @@ static int eq_iir_init_coef(struct sof_eq_iir_config *config,
 
 	/* Collect index of response start positions in all_coefficients[]  */
 	j = 0;
-	assign_response = &config->data[0];
-	coef_data = &config->data[config->channels_in_config];
+	assign_response = ASSUME_ALIGNED(&config->data[0], 4);
+	coef_data = ASSUME_ALIGNED(&config->data[config->channels_in_config],
+				   4);
 	for (i = 0; i < SOF_EQ_IIR_MAX_RESPONSES; i++) {
 		if (i < config->number_of_responses) {
 			eq = (struct sof_eq_iir_header_df2t *)&coef_data[j];

--- a/src/audio/eq_iir/iir.c
+++ b/src/audio/eq_iir/iir.c
@@ -6,6 +6,7 @@
 //         Liam Girdwood <liam.r.girdwood@linux.intel.com>
 //         Keyon Jie <yang.jie@linux.intel.com>
 
+#include <sof/common.h>
 #include <sof/audio/eq_iir/iir.h>
 #include <sof/audio/format.h>
 #include <user/eq.h>
@@ -28,7 +29,7 @@ int iir_init_coef_df2t(struct iir_state_df2t *iir,
 {
 	iir->biquads = config->num_sections;
 	iir->biquads_in_series = config->num_sections_in_series;
-	iir->coef = config->biquads;
+	iir->coef = ASSUME_ALIGNED(config->biquads, 4);
 
 	return 0;
 }

--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -171,7 +171,8 @@ static int mux_ctrl_set_cmd(struct comp_dev *dev,
 
 	switch (cdata->cmd) {
 	case SOF_CTRL_CMD_BINARY:
-		cfg = (struct sof_mux_config *)cdata->data->data;
+		cfg = (struct sof_mux_config *)
+		      ASSUME_ALIGNED(cdata->data->data, 4);
 
 		ret = mux_set_values(cd, cfg);
 		break;

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -200,7 +200,9 @@ static int selector_ctrl_set_data(struct comp_dev *dev,
 		trace_selector_with_ids(dev, "selector_ctrl_set_data(), "
 					"SOF_CTRL_CMD_BINARY");
 
-		cfg = (struct sof_sel_config *)cdata->data->data;
+		cfg = (struct sof_sel_config *)
+		      ASSUME_ALIGNED(cdata->data->data, 4);
+
 		/* Just copy the configuration & verify input params.*/
 		ret = sel_set_channel_values(cd, cfg->in_channels_count,
 					     cfg->out_channels_count,

--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -477,24 +477,24 @@ static int dw_dma_status(struct dma_chan_data *channel,
  * It is requested by BYT, HSW, BDW. For other
  * platforms, the mask is zero.
  */
-static void dw_dma_mask_address(struct dma_sg_elem *sg_elem, uint32_t *sar,
-				uint32_t *dar, uint32_t direction)
+static void dw_dma_mask_address(struct dma_sg_elem *sg_elem,
+				struct dw_lli *lli_desc, uint32_t direction)
 {
-	*sar = sg_elem->src;
-	*dar = sg_elem->dest;
+	lli_desc->sar = sg_elem->src;
+	lli_desc->dar = sg_elem->dest;
 
 	switch (direction) {
 	case DMA_DIR_LMEM_TO_HMEM:
 	case DMA_DIR_MEM_TO_DEV:
-		*sar |= PLATFORM_DW_DMA_HOST_MASK;
+		lli_desc->sar |= PLATFORM_DW_DMA_HOST_MASK;
 		break;
 	case DMA_DIR_HMEM_TO_LMEM:
 	case DMA_DIR_DEV_TO_MEM:
-		*dar |= PLATFORM_DW_DMA_HOST_MASK;
+		lli_desc->dar |= PLATFORM_DW_DMA_HOST_MASK;
 		break;
 	case DMA_DIR_MEM_TO_MEM:
-		*sar |= PLATFORM_DW_DMA_HOST_MASK;
-		*dar |= PLATFORM_DW_DMA_HOST_MASK;
+		lli_desc->sar |= PLATFORM_DW_DMA_HOST_MASK;
+		lli_desc->dar |= PLATFORM_DW_DMA_HOST_MASK;
 		break;
 	default:
 		break;
@@ -733,8 +733,7 @@ static int dw_dma_set_config(struct dma_chan_data *channel,
 			goto out;
 		}
 
-		dw_dma_mask_address(sg_elem, &lli_desc->sar, &lli_desc->dar,
-				    config->direction);
+		dw_dma_mask_address(sg_elem, lli_desc, config->direction);
 
 		if (sg_elem->size > DW_CTLH_BLOCK_TS_MASK) {
 			trace_dwdma_error("dw_dma_set_config() error: dma %d "

--- a/src/include/sof/common.h
+++ b/src/include/sof/common.h
@@ -63,5 +63,19 @@
 #define IS_ENABLED_STEP_2(values) IS_ENABLED_STEP_3(values 1, 0)
 #define IS_ENABLED_STEP_3(ignore, value, ...) (!!(value))
 
+#if defined __XCC__
+/* XCC does not currently check alignment for packed data so no need for any
+ * compiler hints.
+ */
+#define ASSUME_ALIGNED(x, a)	x
+#else
+/* GCC 9.x has checks for pointer alignment within packed structures when
+ * cast from one type to another. This macro should only be used after checking
+ * alignment. This compiler builtin may not be available on all compilers so
+ * this macro can be defined as NULL if needed.
+ */
+#define ASSUME_ALIGNED(x, a) __builtin_assume_aligned(x, a)
+#endif /* __XCC__ */
+
 #endif /* __ASSEMBLER__ */
 #endif /* __SOF_COMMON_H__ */


### PR DESCRIPTION
GCC 9.x introduces checks for packed data alignment when being passed or
cast as different types. Fix these issues.