### PR TITLE
IPC: add polling support

### DIFF
--- a/src/drivers/Kconfig
+++ b/src/drivers/Kconfig
@@ -18,4 +18,14 @@ config DUMMY_DMA
 
 	  If unsure, select "n".
 
+config IPC_POLLING
+	bool "Enable IPC Polling support"
+	default n
+	help
+	  Select this to enable support for simple IPC polling. This allows
+	  users like GDB and boot loader a simple IPC mechanism that does not
+	  depend on IRQ or a scheduler.
+
+	  If unsure, select "n".
+
 endmenu # "Drivers"

--- a/src/drivers/imx/ipc.c
+++ b/src/drivers/imx/ipc.c
@@ -200,3 +200,93 @@ int platform_ipc_init(struct ipc *ipc)
 	return 0;
 }
 
+#if CONFIG_IPC_POLLING
+
+int ipc_platform_poll_init(void)
+{
+	return 0;
+}
+
+/* tell host we have completed command */
+void ipc_platform_poll_set_cmd_done(void)
+{
+	/* enable GP interrupt #0 - accept new messages */
+	imx_mu_xcr_rmw(IMX_MU_xCR_GIEn(0), 0);
+
+	/* request GP interrupt #0 - notify host that reply is ready */
+	imx_mu_xcr_rmw(IMX_MU_xCR_GIRn(0), 0);
+}
+
+/* read the IPC register for any new command messages */
+int ipc_platform_poll_is_cmd_pending(void)
+{
+	uint32_t status;
+
+	/* Interrupt arrived, check src */
+	status = imx_mu_read(IMX_MU_xSR);
+
+	/* new message from host */
+	if (status & IMX_MU_xSR_GIPn(0)) {
+
+		/* Disable GP interrupt #0 */
+		imx_mu_xcr_rmw(0, IMX_MU_xCR_GIEn(0));
+
+		/* Clear GP pending interrupt #0 */
+		imx_mu_xsr_rmw(IMX_MU_xSR_GIPn(0), 0);
+
+		interrupt_clear(PLATFORM_IPC_INTERRUPT);
+
+		/*new message */
+		return 1;
+	}
+
+	/* no new message */
+	return 0;
+}
+
+int ipc_platform_poll_is_host_ready(void)
+{
+	uint32_t status;
+
+	/* Interrupt arrived, check src */
+	status = imx_mu_read(IMX_MU_xSR);
+
+	/* reply message(done) from host */
+	if (status & IMX_MU_xSR_GIPn(1)) {
+		/* Disable GP interrupt #1 */
+		imx_mu_xcr_rmw(0, IMX_MU_xCR_GIEn(1));
+
+		/* Clear GP pending interrupt #1 */
+		imx_mu_xsr_rmw(IMX_MU_xSR_GIPn(1), 0);
+
+		interrupt_clear(PLATFORM_IPC_INTERRUPT);
+
+		/* unmask GP interrupt #1 */
+		imx_mu_xcr_rmw(IMX_MU_xCR_GIEn(1), 0);
+
+		/* host done */
+		return 1;
+	}
+
+	/* host still pending */
+	return 0;
+}
+
+int ipc_platform_poll_tx_host_msg(struct ipc_msg *msg)
+{
+	/* can't send notification when one is in progress */
+	if (imx_mu_read(IMX_MU_xCR) & IMX_MU_xCR_GIRn(1))
+		return 0;
+
+	/* now send the message */
+	mailbox_dspbox_write(0, msg->tx_data, msg->tx_size);
+
+	/* now interrupt host to tell it we have sent a message */
+	imx_mu_xcr_rmw(IMX_MU_xCR_GIRn(1), 0);
+
+	/* message sent */
+	platform_shared_commit(msg, sizeof(*msg));
+	return 1;
+}
+
+#endif

--- a/src/drivers/intel/baytrail/ipc.c
+++ b/src/drivers/intel/baytrail/ipc.c
@@ -181,3 +181,92 @@ int platform_ipc_init(struct ipc *ipc)
 
 	return 0;
 }
+
+#if CONFIG_IPC_POLLING
+
+int ipc_platform_poll_init(void)
+{
+	return 0;
+}
+
+/* tell host we have completed command */
+void ipc_platform_poll_set_cmd_done(void)
+{
+	ipc_platform_complete_cmd(NULL);
+}
+
+/* read the IPC register for any new command messages */
+int ipc_platform_poll_is_cmd_pending(void)
+{
+	uint32_t isr;
+	uint32_t imrd;
+
+	/* Interrupt arrived, check src */
+	isr = shim_read(SHIM_ISRD);
+	imrd = shim_read(SHIM_IMRD);
+
+	/* new message from host */
+	if (isr & SHIM_ISRD_BUSY &&
+	    !(imrd & SHIM_IMRD_BUSY)) {
+
+		/* Mask Busy interrupt before return */
+		shim_write(SHIM_IMRD, shim_read(SHIM_IMRD) | SHIM_IMRD_BUSY);
+
+		/* new message */
+		return 1;
+	}
+
+	/* no new message */
+	return 0;
+}
+
+int ipc_platform_poll_is_host_ready(void)
+{
+	uint32_t isr;
+	uint32_t imrd;
+
+	/* Interrupt arrived, check src */
+	isr = shim_read(SHIM_ISRD);
+	imrd = shim_read(SHIM_IMRD);
+
+	/* reply message(done) from host */
+	if (isr & SHIM_ISRD_DONE &&
+	    !(imrd & SHIM_IMRD_DONE)) {
+
+		/* Mask Done interrupt before return */
+		shim_write(SHIM_IMRD, shim_read(SHIM_IMRD) | SHIM_IMRD_DONE);
+
+		/* clear DONE bit - tell Host we have completed */
+		shim_write(SHIM_IPCDH,
+			   shim_read(SHIM_IPCDH) & ~SHIM_IPCDH_DONE);
+
+		/* unmask Done interrupt */
+		shim_write(SHIM_IMRD, shim_read(SHIM_IMRD) & ~SHIM_IMRD_DONE);
+
+		/* host done */
+		return 1;
+	}
+
+	/* host still pending */
+	return 0;
+}
+
+int ipc_platform_poll_tx_host_msg(struct ipc_msg *msg)
+{
+	/* can't send notification when one is in progress */
+	if (shim_read(SHIM_IPCDH) & (SHIM_IPCDH_BUSY | SHIM_IPCDH_DONE))
+		return 0;
+
+	/* now send the message */
+	mailbox_dspbox_write(0, msg->tx_data, msg->tx_size);
+
+	/* now interrupt host to tell it we have message sent */
+	shim_write(SHIM_IPCDL, msg->header);
+	shim_write(SHIM_IPCDH, SHIM_IPCDH_BUSY);
+
+	/* message sent */
+	platform_shared_commit(msg, sizeof(*msg));
+	return 1;
+}
+
+#endif

--- a/src/include/sof/drivers/ipc.h
+++ b/src/include/sof/drivers/ipc.h
@@ -35,6 +35,7 @@ struct sof_ipc_host_buffer;
 struct sof_ipc_pipe_comp_connect;
 struct sof_ipc_pipe_new;
 struct sof_ipc_stream_posn;
+struct ipc_msg;
 
 #define trace_ipc(format, ...) \
 	trace_event(TRACE_CLASS_IPC, format, ##__VA_ARGS__)
@@ -258,5 +259,34 @@ void ipc_cmd(struct sof_ipc_cmd_hdr *hdr);
  * @return 1 if successful (reply sent by other core), error code otherwise.
  */
 int ipc_process_on_core(uint32_t core);
+
+/**
+ * \brief Initialise IPC hardware for polling mode.
+ * @return 0 if successful error code otherwise.
+ */
+int ipc_platform_poll_init(void);
+
+/**
+ * \brief Tell host DSP has completed command.
+ */
+void ipc_platform_poll_set_cmd_done(void);
+
+/**
+ * \brief Check whether there is a new IPC command from host.
+ * @return 1 if new command is pending from host.
+ */
+int ipc_platform_poll_is_cmd_pending(void);
+
+/**
+ * \brief Check whether host is ready for new IPC from DSP.
+ * @return 1 if host is ready for a new command from DSP.
+ */
+int ipc_platform_poll_is_host_ready(void);
+
+/**
+ * \brief Transmit new message to host.
+ * @return 0 if successful error code otherwise.
+ */
+int ipc_platform_poll_tx_host_msg(struct ipc_msg *msg);
 
 #endif /* __SOF_DRIVERS_IPC_H__ */


### PR DESCRIPTION
This PR takes the current IRQ/scheduler implementation for certain IPC operations and reduces them
to simple IPC command and status polling. Useful for GDB and bootloader stub uses cases. 