### PR TITLE
cavs: enable power gating of unused memory banks for cavs 2.x hw

### DIFF
--- a/src/arch/xtensa/boot_loader.c
+++ b/src/arch/xtensa/boot_loader.c
@@ -4,6 +4,7 @@
 //
 // Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
 
+#include <cavs/version.h>
 #include <sof/bit.h>
 #include <sof/lib/cache.h>
 #include <sof/lib/io.h>
@@ -168,8 +169,7 @@ static void parse_manifest(void)
 }
 #endif
 
-
-#if CONFIG_CANNONLAKE
+#if CAVS_VERSION >= CAVS_VERSION_1_8
 /* function powers up a number of memory banks provided as an argument and
  * gates remaining memory banks
  */
@@ -178,6 +178,7 @@ static int32_t hp_sram_pm_banks(uint32_t banks)
 	int delay_count = 256;
 	uint32_t status;
 	uint32_t ebb_mask0, ebb_mask1, ebb_avail_mask0, ebb_avail_mask1;
+	uint32_t total_banks_count = PLATFORM_HPSRAM_EBB_COUNT;
 
 	shim_write(SHIM_LDOCTL, SHIM_LDOCTL_HPSRAM_LDO_ON);
 
@@ -187,12 +188,12 @@ static int32_t hp_sram_pm_banks(uint32_t banks)
 	/* bit masks reflect total number of available EBB (banks) in each
 	 * segment; current implementation supports 2 segments 0,1
 	 */
-	if (PLATFORM_HPSRAM_EBB_COUNT > EBB_SEGMENT_SIZE) {
+	if (total_banks_count > EBB_SEGMENT_SIZE) {
 		ebb_avail_mask0 = (uint32_t)MASK(EBB_SEGMENT_SIZE - 1, 0);
-		ebb_avail_mask1 = (uint32_t)MASK(PLATFORM_HPSRAM_EBB_COUNT -
+		ebb_avail_mask1 = (uint32_t)MASK(total_banks_count -
 		EBB_SEGMENT_SIZE - 1, 0);
 	} else{
-		ebb_avail_mask0 = (uint32_t)MASK(PLATFORM_HPSRAM_EBB_COUNT - 1,
+		ebb_avail_mask0 = (uint32_t)MASK(total_banks_count - 1,
 		0);
 		ebb_avail_mask1 = 0;
 	}

--- a/src/arch/xtensa/boot_loader.c
+++ b/src/arch/xtensa/boot_loader.c
@@ -168,7 +168,7 @@ static void parse_manifest(void)
 }
 #endif
 
-/* power off unused HPSRAM */
+
 #if CONFIG_CANNONLAKE
 /* function powers up a number of memory banks provided as an argument and
  * gates remaining memory banks
@@ -238,7 +238,7 @@ static int32_t hp_sram_pm_banks(uint32_t banks)
 	return 0;
 }
 
-static uint32_t hp_sram_power_off_memory(uint32_t memory_size)
+static uint32_t hp_sram_power_on_memory(uint32_t memory_size)
 {
 	uint32_t ebb_in_use;
 
@@ -254,12 +254,13 @@ static uint32_t hp_sram_power_off_memory(uint32_t memory_size)
 
 static int32_t hp_sram_power_off_unused_banks(uint32_t memory_size)
 {
-	return hp_sram_power_off_memory(memory_size);
+	/* keep enabled only memory banks used by FW */
+	return hp_sram_power_on_memory(memory_size);
 }
 
 static int32_t hp_sram_init(void)
 {
-	return hp_sram_power_off_memory(HP_SRAM_SIZE);
+	return hp_sram_power_on_memory(HP_SRAM_SIZE);
 }
 
 #else

--- a/src/arch/xtensa/boot_loader.c
+++ b/src/arch/xtensa/boot_loader.c
@@ -170,7 +170,9 @@ static void parse_manifest(void)
 
 /* power off unused HPSRAM */
 #if CONFIG_CANNONLAKE
-
+/* function powers up a number of memory banks provided as an argument and
+ * gates remaining memory banks
+ */
 static int32_t hp_sram_pm_banks(uint32_t banks)
 {
 	int delay_count = 256;
@@ -257,7 +259,7 @@ static int32_t hp_sram_power_off_unused_banks(uint32_t memory_size)
 
 static int32_t hp_sram_init(void)
 {
-	return hp_sram_power_off_memory(SOF_MEMORY_SIZE);
+	return hp_sram_power_off_memory(HP_SRAM_SIZE);
 }
 
 #else

--- a/src/platform/cannonlake/include/platform/lib/memory.h
+++ b/src/platform/cannonlake/include/platform/lib/memory.h
@@ -290,9 +290,6 @@
 	SRAM_BANK_SIZE)
 #define SOF_CORE_S_T_SIZE ((PLATFORM_CORE_COUNT - 1) * SOF_CORE_S_SIZE)
 
-/* Temporary until the boot_loader code get fixed */
-#define SOF_MEMORY_SIZE (HP_SRAM_SIZE)
-
 /*
  * The LP SRAM Heap and Stack on Cannonlake are organised like this :-
  *


### PR DESCRIPTION
The change adds power gating of unused memory banks for cavs 2.0/2.5 hardware on top of previously enabled flow for cavs 1.8.