### PR TITLE
Two topology fixes

### DIFF
--- a/tools/topology/sof-imx8qxp-cs42888.m4
+++ b/tools/topology/sof-imx8qxp-cs42888.m4
@@ -57,14 +57,14 @@ dnl     period, priority, core, time_domain)
 # playback DAI is ESAI0 using 2 periods
 # Buffers use s24le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
-	1, ESAI, 0, ESAI0-Codec,
+	1, ESAI, 0, esai0-cs42888,
 	PIPELINE_SOURCE_1, 2, s24le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_DMA)
 
 # capture DAI is ESAI0 using 2 periods
 # Buffers use s24le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
-	2, ESAI, 0, ESAI0-Codec,
+	2, ESAI, 0, esai0-cs42888,
 	PIPELINE_SINK_2, 2, s24le,
 	1000, 0, 0)
 
@@ -74,7 +74,7 @@ dnl PCM_DUPLEX_ADD(name, pcm_id, playback, capture)
 PCM_DUPLEX_ADD(Port0, 0, PIPELINE_PCM_1, PIPELINE_PCM_2)
 
 dnl DAI_CONFIG(type, idx, link_id, name, esai_config)
-DAI_CONFIG(ESAI, 0, 0, ESAI0-Codec,
+DAI_CONFIG(ESAI, 0, 0, esai0-cs42888,
 	ESAI_CONFIG(I2S, ESAI_CLOCK(mclk, 49152000, codec_mclk_in),
 		ESAI_CLOCK(bclk, 3072000, codec_slave),
 		ESAI_CLOCK(fsync, 48000, codec_slave),

--- a/tools/topology/sof-imx8qxp-wm8960.m4
+++ b/tools/topology/sof-imx8qxp-wm8960.m4
@@ -31,17 +31,17 @@ dnl     period, priority, core,
 dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
 
-# Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s24le.
+# Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
 # Set 1000us deadline on core 0 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
-	1, 0, 2, s24le,
+	1, 0, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
-# Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s24le.
+# Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s32le.
 # Set 1000us deadline on core 0 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
-	2, 0, 2, s24le,
+	2, 0, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 #
@@ -54,17 +54,17 @@ dnl     buffer, periods, format,
 dnl     period, priority, core, time_domain)
 
 # playback DAI is SAI1 using 2 periods
-# Buffers use s24le format, with 48 frame per 1000us on core 0 with priority 0
+# Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SAI, 1, sai1-wm8960-hifi,
-	PIPELINE_SOURCE_1, 2, s24le,
+	PIPELINE_SOURCE_1, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_DMA)
 
 # capture DAI is SAI1 using 2 periods
-# Buffers use s24le format, with 48 frame per 1000us on core 0 with priority 0
+# Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	2, SAI, 1, sai1-wm8960-hifi,
-	PIPELINE_SINK_2, 2, s24le,
+	PIPELINE_SINK_2, 2, s32le,
 	1000, 0, 0)
 
 

--- a/tools/topology/sof-imx8qxp-wm8960.m4
+++ b/tools/topology/sof-imx8qxp-wm8960.m4
@@ -56,14 +56,14 @@ dnl     period, priority, core, time_domain)
 # playback DAI is SAI1 using 2 periods
 # Buffers use s24le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
-	1, SAI, 1, be.wm8960-hifi,
+	1, SAI, 1, sai1-wm8960-hifi,
 	PIPELINE_SOURCE_1, 2, s24le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_DMA)
 
 # capture DAI is SAI1 using 2 periods
 # Buffers use s24le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
-	2, SAI, 1, be.wm8960-hifi,
+	2, SAI, 1, sai1-wm8960-hifi,
 	PIPELINE_SINK_2, 2, s24le,
 	1000, 0, 0)
 
@@ -74,7 +74,7 @@ dnl PCM_DUPLEX_ADD(name, pcm_id, playback, capture)
 PCM_DUPLEX_ADD(Port0, 0, PIPELINE_PCM_1, PIPELINE_PCM_2)
 
 dnl DAI_CONFIG(type, idx, link_id, name, sai_config)
-DAI_CONFIG(SAI, 1, 0, be.wm8960-hifi,
+DAI_CONFIG(SAI, 1, 0, sai1-wm8960-hifi,
 	SAI_CONFIG(I2S, SAI_CLOCK(mclk, 12288000, codec_mclk_in),
 		SAI_CLOCK(bclk, 3072000, codec_master),
 		SAI_CLOCK(fsync, 48000, codec_master),


### PR DESCRIPTION
1) Change DAI name, to accomdate the name in machine driver. We hope that we will be able to use simple-card in the exact form that it is in our internal tree.

2) Use s32le instead of s24le for wm8960 codec because SAI doesn't have the 24bit limitation that ESAI has.