### PR TITLE
registers: fix bug lp_sram init

### DIFF
--- a/src/arch/xtensa/boot_loader.c
+++ b/src/arch/xtensa/boot_loader.c
@@ -288,8 +288,8 @@ static int32_t lp_sram_init(void)
 	/* add some delay before writing power registers */
 	idelay(delay_count);
 
-	lspgctl_value = shim_read(SHIM_LSPGCTL);
-	shim_write(SHIM_LSPGCTL, lspgctl_value & !LPSRAM_MASK(0));
+	lspgctl_value = io_reg_read(LSPGISTS);
+	io_reg_write(LSPGCTL, lspgctl_value & ~LPSRAM_MASK(0));
 
 	/* add some delay before checking the status */
 	idelay(delay_count);

--- a/src/platform/apollolake/include/platform/lib/shim.h
+++ b/src/platform/apollolake/include/platform/lib/shim.h
@@ -197,7 +197,7 @@
 #define SHIM_HSPGCTL		0x80
 #define SHIM_LSPGCTL		0x84
 #define SHIM_SPSREQ		0xa0
-#define LSPGCTL			SHIM_LSPGCTL
+#define LSPGCTL			(SHIM_BASE + SHIM_LSPGCTL)
 
 #define SHIM_SPSREQ_RVNNP	(0x1 << 0)
 

--- a/src/platform/cannonlake/include/platform/lib/shim.h
+++ b/src/platform/cannonlake/include/platform/lib/shim.h
@@ -179,8 +179,6 @@
 #define SHIM_LPSCTL_FDSPRUN	BIT(9)
 #define SHIM_LPSCTL_BATTR_0	BIT(12)
 
-#define SHIM_LSPGCTL		0x50
-
 /** \brief GPDMA shim registers Control */
 #define SHIM_GPDMA_BASE_OFFSET	0x6500
 #define SHIM_GPDMA_BASE(x)	(SHIM_GPDMA_BASE_OFFSET + (x) * 0x100)


### PR DESCRIPTION
This patch fixes a bug in LP_SRAM init procedure and
cleans up unused shim offset.

Signed-off-by: Marcin Rajwa <marcin.rajwa@linux.intel.com>