### PR TITLE
volume: make task dynamic

### DIFF
--- a/src/include/sof/audio/volume.h
+++ b/src/include/sof/audio/volume.h
@@ -108,7 +108,7 @@ typedef void (*vol_scale_func)(struct comp_dev *dev, struct audio_stream *sink,
  * Gain amplitude value is between 0 (mute) ... 2^16 (0dB) ... 2^24 (~+48dB).
  */
 struct comp_data {
-	struct task volwork;		/**< volume scheduled work function */
+	struct task *volwork;		/**< volume scheduled work function */
 	struct sof_ipc_ctrl_value_chan *hvol;	/**< host volume readback */
 	int32_t volume[SOF_IPC_MAX_CHANNELS];	/**< current volume */
 	int32_t tvolume[SOF_IPC_MAX_CHANNELS];	/**< target volume */


### PR DESCRIPTION
Makes volume ramping task dynamic meaning it will be
allocated only when needed. There is no need to have it
allocated statically unless the pipeline will be in fact used.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>