### PR TITLE
doxygen: Fill missed argument description in *params functions

### DIFF
--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -305,6 +305,7 @@ static void volume_free(struct comp_dev *dev)
 /**
  * \brief Sets volume component audio stream parameters.
  * \param[in,out] dev Volume base component device.
+ * \param[in] params Audio (PCM) stream parameters (ignored for this component)
  * \return Error code.
  *
  * All done in prepare() since we need to know source and sink component params.

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -425,6 +425,7 @@ int comp_set_state(struct comp_dev *dev, int cmd);
 /**
  * Component parameter init.
  * @param dev Component device.
+ * @param params Audio (PCM) stream parameters to be set
  * @return 0 if succeeded, error code otherwise.
  */
 static inline int comp_params(struct comp_dev *dev,


### PR DESCRIPTION
When some function has doxygen description then each argument should
have short description. In anothar situation, doxygen will generate
warning.

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>