### PR TITLE
wait: Remove unused completion_t with related functions

### DIFF
--- a/src/include/sof/drivers/dmic.h
+++ b/src/include/sof/drivers/dmic.h
@@ -314,7 +314,6 @@
 struct dmic_pdata {
 	uint16_t enable[DMIC_HW_CONTROLLERS];
 	uint32_t state;
-	completion_t drain_complete;
 	struct task dmicwork;
 	int32_t startcount;
 	int32_t gain;

--- a/src/include/sof/drivers/ssp.h
+++ b/src/include/sof/drivers/ssp.h
@@ -234,7 +234,6 @@ struct ssp_pdata {
 	uint32_t sscr1;
 	uint32_t psp;
 	uint32_t state[2];		/* SSP_STATE_ for each direction */
-	completion_t drain_complete;
 	struct sof_ipc_dai_config config;
 	struct sof_ipc_dai_ssp_params params;
 };

--- a/src/include/sof/lib/wait.h
+++ b/src/include/sof/lib/wait.h
@@ -25,12 +25,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-typedef struct {
-	uint32_t complete;
-	struct task work;
-	uint64_t timeout;
-} completion_t;
-
 static inline void wait_for_interrupt(int level)
 {
 	tracev_event(TRACE_CLASS_WAIT, "WFE");
@@ -42,62 +36,12 @@ static inline void wait_for_interrupt(int level)
 	tracev_event(TRACE_CLASS_WAIT, "WFX");
 }
 
-static enum task_state _wait_cb(void *data)
-{
-	volatile completion_t *wc = (volatile completion_t *)data;
-
-	wc->timeout = 1;
-
-	return SOF_TASK_STATE_COMPLETED;
-}
-
-static inline uint32_t wait_is_completed(completion_t *comp)
-{
-	volatile completion_t *c = (volatile completion_t *)comp;
-
-	return c->complete;
-}
-
-static inline void wait_completed(completion_t *comp)
-{
-	volatile completion_t *c = (volatile completion_t *)comp;
-
-	c->complete = 1;
-}
-
-static inline void wait_init(completion_t *comp)
-{
-	volatile completion_t *c = (volatile completion_t *)comp;
-
-	c->complete = 0;
-
-	schedule_task_init_ll(&comp->work, SOF_SCHEDULE_LL_TIMER,
-			      SOF_TASK_PRI_MED, _wait_cb, comp, 0, 0);
-}
-
-static inline void wait_clear(completion_t *comp)
-{
-	volatile completion_t *c = (volatile completion_t *)comp;
-
-	c->complete = 0;
-}
-
-/* simple interrupt based wait for completion */
-static inline void wait_for_completion(completion_t *comp)
-{
-	/* check for completion after every wake from IRQ */
-	while (comp->complete == 0)
-		wait_for_interrupt(0);
-}
-
 /**
  * \brief Waits at least passed number of clocks.
  * \param[in] number_of_clks Minimum number of clocks to wait.
  */
 void wait_delay(uint64_t number_of_clks);
 
-int wait_for_completion_timeout(completion_t *comp);
-int poll_for_completion_delay(completion_t *comp, uint64_t us);
 int poll_for_register_delay(uint32_t reg, uint32_t mask,
 			    uint32_t val, uint64_t us);
 


### PR DESCRIPTION
Unused code shouldn't be present in source code, it only makes system
more difficult to understand.

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>