### PR TITLE
cc_version: Align up struct size with flex array

### DIFF
--- a/src/ipc/cc_version.c
+++ b/src/ipc/cc_version.c
@@ -21,8 +21,8 @@
 const struct sof_ipc_cc_version cc_version = {
 	.ext_hdr = {
 		.hdr.cmd = SOF_IPC_FW_READY,
-		.hdr.size = sizeof(struct sof_ipc_cc_version)
-			    + sizeof(CC_DESC),
+		.hdr.size = ALIGN_UP(sizeof(struct sof_ipc_cc_version)
+				     + sizeof(CC_DESC), 4),
 		.type = SOF_IPC_EXT_CC_INFO,
 	},
 	.micro = CC_MICRO,


### PR DESCRIPTION
Structures with flex array also should have size aligned to 4 bytes
at least to omit misalignment data accec in following data.
As long as CC_DESC is null terminated, padding data doesn't have
any impact on functionality.

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>