### PR TITLE
alternate multi-dai and multi-config proposal

### DIFF
--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -688,7 +688,7 @@ static int dai_config(struct comp_dev *dev, struct sof_ipc_dai_config *config)
 	switch (config->type) {
 	case SOF_DAI_INTEL_SSP:
 		/* set dma burst elems to slot number */
-		dd->config.burst_elems = config->ssp.tdm_slots;
+		dd->config.burst_elems = config->dai_data[0].ssp.tdm_slots;
 		break;
 	case SOF_DAI_INTEL_DMIC:
 		tracev_dai_comp_with_ids(dev, "dai_config(), config->type = SOF_DAI_INTEL_DMIC");
@@ -697,11 +697,11 @@ static int dai_config(struct comp_dev *dev, struct sof_ipc_dai_config *config)
 		dd->config.burst_elems = 8;
 
 		trace_dai_comp_with_ids(dev, "dai_config(), config->dmic.fifo_bits = %u config->dmic.num_pdm_active = %u",
-					config->dmic.fifo_bits,
-					config->dmic.num_pdm_active);
+					config->dai_data[0].dmic.fifo_bits,
+					config->dai_data[0].dmic.num_pdm_active);
 		break;
 	case SOF_DAI_INTEL_HDA:
-		channel = config->hda.link_dma_ch;
+		channel = config->dai_data[0].hda.link_dma_ch;
 		trace_dai_comp_with_ids(dev, "dai_config(), channel = %d",
 					channel);
 
@@ -729,8 +729,8 @@ static int dai_config(struct comp_dev *dev, struct sof_ipc_dai_config *config)
 		/* As with HDA, the DMA channel is assigned in runtime,
 		 * not during topology parsing.
 		 */
-		channel = config->alh.stream_id;
-		dd->stream_id = config->alh.stream_id;
+		channel = config->dai_data[0].alh.stream_id;
+		dd->stream_id = config->dai_data[0].alh.stream_id;
 		trace_dai_comp_with_ids(dev, "dai_config(), channel = %d",
 					channel);
 		break;

--- a/src/drivers/intel/cavs/dmic.c
+++ b/src/drivers/intel/cavs/dmic.c
@@ -1077,7 +1077,7 @@ static int dmic_set_config(struct dai *dai, struct sof_ipc_dai_config *config)
 
 	trace_dmic_id(dai, "dmic_set_config()");
 
-	if (config->dmic.driver_ipc_version != DMIC_IPC_VERSION) {
+	if (config->dai_data[0].dmic.driver_ipc_version != DMIC_IPC_VERSION) {
 		trace_error_dmic_id(dai, "dmic_set_config() error: wrong ipc version");
 		return -EINVAL;
 	}
@@ -1085,8 +1085,8 @@ static int dmic_set_config(struct dai *dai, struct sof_ipc_dai_config *config)
 	/* Compute unmute ramp gain update coefficient. Use the value from
 	 * topology if it is non-zero, otherwise use default length.
 	 */
-	if (config->dmic.unmute_ramp_time)
-		unmute_ramp_time_ms = config->dmic.unmute_ramp_time;
+	if (config->dai_data[0].dmic.unmute_ramp_time)
+		unmute_ramp_time_ms = config->dai_data[0].dmic.unmute_ramp_time;
 	else
 		unmute_ramp_time_ms = LOGRAMP_TIME_MS;
 
@@ -1102,7 +1102,7 @@ static int dmic_set_config(struct dai *dai, struct sof_ipc_dai_config *config)
 		return -EINVAL;
 	}
 
-	if (config->dmic.num_pdm_active > DMIC_HW_CONTROLLERS) {
+	if (config->dai_data[0].dmic.num_pdm_active > DMIC_HW_CONTROLLERS) {
 		trace_error_dmic_id(dai, "dmic_set_config() error: the requested PDM controllers count exceeds platform capability");
 		return -EINVAL;
 	}
@@ -1136,19 +1136,21 @@ static int dmic_set_config(struct dai *dai, struct sof_ipc_dai_config *config)
 	/* Copy the new DMIC params to persistent.  The last request
 	 * determines the parameters.
 	 */
-	ret = memcpy_s(dmic_prm[di], sizeof(*dmic_prm[di]), &config->dmic,
+	ret = memcpy_s(dmic_prm[di], sizeof(*dmic_prm[di]),
+		       &config->dai_data[0].dmic,
 		       sizeof(struct sof_ipc_dai_dmic_params));
 	assert(!ret);
 
 	/* copy the pdm controller params from ipc */
 	for (i = 0; i < DMIC_HW_CONTROLLERS; i++) {
 		dmic_prm[di]->pdm[i].id = i;
-		for (j = 0; j < config->dmic.num_pdm_active; j++) {
+		for (j = 0; j < config->dai_data[0].dmic.num_pdm_active; j++) {
 			/* copy the pdm controller params id the id's match */
-			if (dmic_prm[di]->pdm[i].id == config->dmic.pdm[j].id) {
+			if (dmic_prm[di]->pdm[i].id ==
+			    config->dai_data[0].dmic.pdm[j].id) {
 				ret = memcpy_s(&dmic_prm[di]->pdm[i],
 					       sizeof(dmic_prm[di]->pdm[i]),
-					       &config->dmic.pdm[j],
+					       &config->dai_data[0].dmic.pdm[j],
 					       sizeof(
 					       struct sof_ipc_dai_dmic_pdm_ctrl));
 				assert(!ret);
@@ -1156,8 +1158,8 @@ static int dmic_set_config(struct dai *dai, struct sof_ipc_dai_config *config)
 		}
 	}
 
-	trace_dmic_id(dai, "dmic_set_config(), prm config->dmic.num_pdm_active = %u",
-		      config->dmic.num_pdm_active);
+	trace_dmic_id(dai, "dmic_set_config(), prm config->dai_data[0].dmic.num_pdm_active = %u",
+		      config->dai_data[0].dmic.num_pdm_active);
 	trace_dmic_id(dai, "dmic_set_config(), prm pdmclk_min = %u, pdmclk_max = %u",
 		      dmic_prm[di]->pdmclk_min, dmic_prm[di]->pdmclk_max);
 	trace_dmic_id(dai, "dmic_set_config(), prm duty_min = %u, duty_max = %u",

--- a/src/include/ipc/dai-imx.h
+++ b/src/include/ipc/dai-imx.h
@@ -13,7 +13,7 @@
 
 /* ESAI Configuration Request - SOF_IPC_DAI_ESAI_CONFIG */
 struct sof_ipc_dai_esai_params {
-	struct sof_ipc_hdr hdr;
+	uint32_t reserved0[2];
 
 	/* MCLK */
 	uint16_t reserved1;
@@ -32,7 +32,7 @@ struct sof_ipc_dai_esai_params {
 
 /* SAI Configuration Request - SOF_IPC_DAI_SAI_CONFIG */
 struct sof_ipc_dai_sai_params {
-	struct sof_ipc_hdr hdr;
+	uint32_t reserved0[2];
 
 	/* MCLK */
 	uint16_t reserved1;

--- a/src/include/ipc/dai-imx.h
+++ b/src/include/ipc/dai-imx.h
@@ -13,7 +13,8 @@
 
 /* ESAI Configuration Request - SOF_IPC_DAI_ESAI_CONFIG */
 struct sof_ipc_dai_esai_params {
-	uint32_t reserved0[2];
+	uint32_t subdai_index; /* only used in multi-dai usages */
+	uint32_t reserved0;
 
 	/* MCLK */
 	uint16_t reserved1;
@@ -32,7 +33,8 @@ struct sof_ipc_dai_esai_params {
 
 /* SAI Configuration Request - SOF_IPC_DAI_SAI_CONFIG */
 struct sof_ipc_dai_sai_params {
-	uint32_t reserved0[2];
+	uint32_t subdai_index; /* only used in multi-dai usages */
+	uint32_t reserved0;
 
 	/* MCLK */
 	uint16_t reserved1;

--- a/src/include/ipc/dai-intel.h
+++ b/src/include/ipc/dai-intel.h
@@ -59,7 +59,7 @@
 
 /* SSP Configuration Request - SOF_IPC_DAI_SSP_CONFIG */
 struct sof_ipc_dai_ssp_params {
-	struct sof_ipc_hdr hdr;
+	uint32_t reserved0[2];
 	uint16_t reserved1;
 	uint16_t mclk_id;
 
@@ -91,13 +91,13 @@ struct sof_ipc_dai_ssp_params {
 
 /* HDA Configuration Request - SOF_IPC_DAI_HDA_CONFIG */
 struct sof_ipc_dai_hda_params {
-	struct sof_ipc_hdr hdr;
+	uint32_t reserved0[2];
 	uint32_t link_dma_ch;
 } __attribute__((packed));
 
 /* ALH Configuration Request - SOF_IPC_DAI_ALH_CONFIG */
 struct sof_ipc_dai_alh_params {
-	struct sof_ipc_hdr hdr;
+	uint32_t reserved0[2];
 	uint32_t stream_id;
 
 	/* reserved for future use */
@@ -124,7 +124,7 @@ struct sof_ipc_dai_alh_params {
  * data integrity problems.
  */
 struct sof_ipc_dai_dmic_pdm_ctrl {
-	struct sof_ipc_hdr hdr;
+	uint32_t reserved0[2];
 	uint16_t id;		/**< PDM controller ID */
 
 	uint16_t enable_mic_a;	/**< Use A (left) channel mic (0 or 1)*/
@@ -169,7 +169,7 @@ struct sof_ipc_dai_dmic_pdm_ctrl {
  * treated as an error.
  */
 struct sof_ipc_dai_dmic_params {
-	struct sof_ipc_hdr hdr;
+	uint32_t reserved0[2];
 	uint32_t driver_ipc_version;	/**< Version (1..N) */
 
 	uint32_t pdmclk_min;	/**< Minimum microphone clock in Hz (100000..N) */

--- a/src/include/ipc/dai-intel.h
+++ b/src/include/ipc/dai-intel.h
@@ -59,7 +59,8 @@
 
 /* SSP Configuration Request - SOF_IPC_DAI_SSP_CONFIG */
 struct sof_ipc_dai_ssp_params {
-	uint32_t reserved0[2];
+	uint32_t subdai_index; /* only used in multi-dai usages */
+	uint32_t reserved0;
 	uint16_t reserved1;
 	uint16_t mclk_id;
 
@@ -91,13 +92,15 @@ struct sof_ipc_dai_ssp_params {
 
 /* HDA Configuration Request - SOF_IPC_DAI_HDA_CONFIG */
 struct sof_ipc_dai_hda_params {
-	uint32_t reserved0[2];
+	uint32_t subdai_index; /* only used in multi-dai usages */
+	uint32_t reserved0;
 	uint32_t link_dma_ch;
 } __attribute__((packed));
 
 /* ALH Configuration Request - SOF_IPC_DAI_ALH_CONFIG */
 struct sof_ipc_dai_alh_params {
-	uint32_t reserved0[2];
+	uint32_t subdai_index; /* only used in multi-dai usages */
+	uint32_t reserved0;
 	uint32_t stream_id;
 
 	/* reserved for future use */
@@ -169,7 +172,8 @@ struct sof_ipc_dai_dmic_pdm_ctrl {
  * treated as an error.
  */
 struct sof_ipc_dai_dmic_params {
-	uint32_t reserved0[2];
+	uint32_t subdai_index; /* only used in multi-dai usages */
+	uint32_t reserved0;
 	uint32_t driver_ipc_version;	/**< Version (1..N) */
 
 	uint32_t pdmclk_min;	/**< Minimum microphone clock in Hz (100000..N) */

--- a/src/include/ipc/dai.h
+++ b/src/include/ipc/dai.h
@@ -16,6 +16,7 @@
 #ifndef __IPC_DAI_H__
 #define __IPC_DAI_H__
 
+#include <ipc/channel_map.h>
 #include <ipc/dai-intel.h>
 #include <ipc/dai-imx.h>
 #include <ipc/header.h>
@@ -61,20 +62,28 @@ enum sof_ipc_dai_type {
 	SOF_DAI_INTEL_ALH,		/**< Intel ALH */
 	SOF_DAI_IMX_SAI,                /**< i.MX SAI */
 	SOF_DAI_IMX_ESAI,               /**< i.MX ESAI */
+	SOF_DAI_MULTIDAI = 0xFFFF       /**< config with multiple elements of the same dai type */
 };
 
 /* general purpose DAI configuration */
 struct sof_ipc_dai_config {
 	struct sof_ipc_cmd_hdr hdr;
-	uint32_t type;		/**< DAI type - enum sof_ipc_dai_type */
+
+	uint16_t type;		/**< DAI type - enum sof_ipc_dai_type */
+	uint16_t subdai_type;	/**< only used in multi-dai cases */
 	uint32_t dai_index;	/**< index of this type dai */
 
 	/* physical protocol and clocking */
 	uint16_t format;	/**< SOF_DAI_FMT_ */
-	uint16_t reserved16;	/**< alignment */
+
+	/* we can either have multiple sub-DAIs or multiple configs, not both */
+	uint16_t num_payloads; 	/**< number of configs or number of sub-DAIs */
+
+	uint16_t config_index;	/**< index in dai_data */
 
 	/* reserved for future use */
-	uint32_t reserved[8];
+	uint32_t reserved16;
+	uint32_t reserved[7];
 
 	/* HW specific data */
 	union {
@@ -84,7 +93,13 @@ struct sof_ipc_dai_config {
 		struct sof_ipc_dai_alh_params alh;
 		struct sof_ipc_dai_esai_params esai;
 		struct sof_ipc_dai_sai_params sai;
-	};
+	} dai_data[0];
+
+	/*
+	 * multi-dai stream maps. The ext_id used needs to match subdai_index
+	 * in each _params structure above
+	 */
+	struct sof_ipc_stream_map stream_map;
 } __attribute__((packed));
 
 #endif /* __IPC_DAI_H__ */


### PR DESCRIPTION
PR #2258 has been going in circles for a while, here's a tentative alternate proposal to make progress.

The basic principle is that we cannot mix multi-configurations and multi-dai, it's just unmanageable and needlessly complicated.

we can probably make things work by adding a subtype that relies on all existing definitions, and only add what we need for the multi-dai case: a list of subdai indices and a stream map.

having a list of payloads does enable us to deal with multiple configs, but we still need to figure out how firmware would use a specific configuration at a given time.

@slawblauciak would this work for you? Let's talk tomorrow, shall we?
