### PR TITLE
Bug pause

### DIFF
--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -613,7 +613,7 @@ static int dai_comp_trigger(struct comp_dev *dev, int cmd)
 	case COMP_TRIGGER_STOP:
 		comp_info(dev, "dai_comp_trigger(), PAUSE/STOP");
 		ret = dma_stop(dd->chan);
-		dai_trigger(dd->dai, COMP_TRIGGER_STOP, dev->direction);
+		dai_trigger(dd->dai, cmd, dev->direction);
 		break;
 	default:
 		break;

--- a/src/drivers/intel/baytrail/ssp.c
+++ b/src/drivers/intel/baytrail/ssp.c
@@ -543,31 +543,41 @@ static void ssp_stop(struct dai *dai, int direction)
 
 	/* stop Rx if neeed */
 	if (direction == DAI_DIR_CAPTURE &&
-	    ssp->state[SOF_IPC_STREAM_CAPTURE] == COMP_STATE_ACTIVE) {
+	    ssp->state[SOF_IPC_STREAM_CAPTURE] != COMP_STATE_PREPARE) {
 		ssp_update_bits(dai, SSCR1, SSCR1_RSRE, 0);
 		ssp_empty_rx_fifo(dai);
-		ssp->state[SOF_IPC_STREAM_CAPTURE] = COMP_STATE_PAUSED;
+		ssp->state[SOF_IPC_STREAM_CAPTURE] = COMP_STATE_PREPARE;
 		dai_info(dai, "ssp_stop(), RX stop");
 	}
 
 	/* stop Tx if needed */
 	if (direction == DAI_DIR_PLAYBACK &&
-	    ssp->state[SOF_IPC_STREAM_PLAYBACK] == COMP_STATE_ACTIVE) {
+	    ssp->state[SOF_IPC_STREAM_PLAYBACK] != COMP_STATE_PREPARE) {
 		ssp_update_bits(dai, SSCR1, SSCR1_TSRE, 0);
-		ssp->state[SOF_IPC_STREAM_PLAYBACK] = COMP_STATE_PAUSED;
+		ssp->state[SOF_IPC_STREAM_PLAYBACK] = COMP_STATE_PREPARE;
 		dai_info(dai, "ssp_stop(), TX stop");
 	}
 
 	/* disable SSP port if no users */
-	if (ssp->state[SOF_IPC_STREAM_CAPTURE] != COMP_STATE_ACTIVE &&
-	    ssp->state[SOF_IPC_STREAM_PLAYBACK] != COMP_STATE_ACTIVE) {
+	if (ssp->state[SOF_IPC_STREAM_CAPTURE] == COMP_STATE_PREPARE &&
+	    ssp->state[SOF_IPC_STREAM_PLAYBACK] == COMP_STATE_PREPARE) {
 		ssp_update_bits(dai, SSCR0, SSCR0_SSE, 0);
-		ssp->state[SOF_IPC_STREAM_CAPTURE] = COMP_STATE_PREPARE;
-		ssp->state[SOF_IPC_STREAM_PLAYBACK] = COMP_STATE_PREPARE;
 		dai_info(dai, "ssp_stop(), SSP port disabled");
 	}
 
 	spin_unlock(&dai->lock);
+}
+
+static void ssp_pause(struct dai *dai, int direction)
+{
+	struct ssp_pdata *ssp = dai_get_drvdata(dai);
+
+	if (direction == SOF_IPC_STREAM_CAPTURE)
+		dai_info(dai, "ssp_pause(), RX");
+	else
+		dai_info(dai, "ssp_pause(), TX");
+
+	ssp->state[direction] = COMP_STATE_PAUSED;
 }
 
 static int ssp_trigger(struct dai *dai, int cmd, int direction)
@@ -588,8 +598,10 @@ static int ssp_trigger(struct dai *dai, int cmd, int direction)
 			ssp_start(dai, direction);
 		break;
 	case COMP_TRIGGER_STOP:
-	case COMP_TRIGGER_PAUSE:
 		ssp_stop(dai, direction);
+		break;
+	case COMP_TRIGGER_PAUSE:
+		ssp_pause(dai, direction);
 		break;
 	case COMP_TRIGGER_RESUME:
 		ssp_context_restore(dai);

--- a/src/drivers/intel/cavs/ssp.c
+++ b/src/drivers/intel/cavs/ssp.c
@@ -697,34 +697,44 @@ static void ssp_stop(struct dai *dai, int direction)
 
 	/* stop Rx if neeed */
 	if (direction == DAI_DIR_CAPTURE &&
-	    ssp->state[SOF_IPC_STREAM_CAPTURE] == COMP_STATE_ACTIVE) {
+	    ssp->state[SOF_IPC_STREAM_CAPTURE] != COMP_STATE_PREPARE) {
 		ssp_update_bits(dai, SSCR1, SSCR1_RSRE, 0);
 		ssp_update_bits(dai, SSRSA, SSRSA_RXEN, 0);
 		ssp_empty_rx_fifo(dai);
-		ssp->state[SOF_IPC_STREAM_CAPTURE] = COMP_STATE_PAUSED;
+		ssp->state[SOF_IPC_STREAM_CAPTURE] = COMP_STATE_PREPARE;
 		dai_info(dai, "ssp_stop(), RX stop");
 	}
 
 	/* stop Tx if needed */
 	if (direction == DAI_DIR_PLAYBACK &&
-	    ssp->state[SOF_IPC_STREAM_PLAYBACK] == COMP_STATE_ACTIVE) {
+	    ssp->state[SOF_IPC_STREAM_PLAYBACK] != COMP_STATE_PREPARE) {
 		ssp_empty_tx_fifo(dai);
 		ssp_update_bits(dai, SSCR1, SSCR1_TSRE, 0);
 		ssp_update_bits(dai, SSTSA, SSTSA_TXEN, 0);
-		ssp->state[SOF_IPC_STREAM_PLAYBACK] = COMP_STATE_PAUSED;
+		ssp->state[SOF_IPC_STREAM_PLAYBACK] = COMP_STATE_PREPARE;
 		dai_info(dai, "ssp_stop(), TX stop");
 	}
 
 	/* disable SSP port if no users */
-	if (ssp->state[SOF_IPC_STREAM_CAPTURE] != COMP_STATE_ACTIVE &&
-	    ssp->state[SOF_IPC_STREAM_PLAYBACK] != COMP_STATE_ACTIVE) {
+	if (ssp->state[SOF_IPC_STREAM_CAPTURE] == COMP_STATE_PREPARE &&
+	    ssp->state[SOF_IPC_STREAM_PLAYBACK] == COMP_STATE_PREPARE) {
 		ssp_update_bits(dai, SSCR0, SSCR0_SSE, 0);
-		ssp->state[SOF_IPC_STREAM_CAPTURE] = COMP_STATE_PREPARE;
-		ssp->state[SOF_IPC_STREAM_PLAYBACK] = COMP_STATE_PREPARE;
 		dai_info(dai, "ssp_stop(), SSP port disabled");
 	}
 
 	spin_unlock(&dai->lock);
+}
+
+static void ssp_pause(struct dai *dai, int direction)
+{
+	struct ssp_pdata *ssp = dai_get_drvdata(dai);
+
+	if (direction == SOF_IPC_STREAM_CAPTURE)
+		dai_info(dai, "ssp_pause(), RX");
+	else
+		dai_info(dai, "ssp_pause(), TX");
+
+	ssp->state[direction] = COMP_STATE_PAUSED;
 }
 
 static int ssp_trigger(struct dai *dai, int cmd, int direction)
@@ -745,8 +755,10 @@ static int ssp_trigger(struct dai *dai, int cmd, int direction)
 			ssp_start(dai, direction);
 		break;
 	case COMP_TRIGGER_STOP:
-	case COMP_TRIGGER_PAUSE:
 		ssp_stop(dai, direction);
+		break;
+	case COMP_TRIGGER_PAUSE:
+		ssp_pause(dai, direction);
 		break;
 	case COMP_TRIGGER_RESUME:
 		ssp_context_restore(dai);

--- a/src/drivers/intel/haswell/ssp.c
+++ b/src/drivers/intel/haswell/ssp.c
@@ -459,32 +459,42 @@ static void ssp_stop(struct dai *dai, int direction)
 
 	/* stop Rx if neeed */
 	if (direction == DAI_DIR_CAPTURE &&
-	    ssp->state[SOF_IPC_STREAM_CAPTURE] == COMP_STATE_ACTIVE) {
+	    ssp->state[SOF_IPC_STREAM_CAPTURE] != COMP_STATE_PREPARE) {
 		ssp_update_bits(dai, SSCR1, SSCR1_RSRE, 0);
 		ssp_update_bits(dai, SSCR0, SSCR0_RIM, SSCR0_RIM);
-		ssp->state[SOF_IPC_STREAM_CAPTURE] = COMP_STATE_PAUSED;
+		ssp->state[SOF_IPC_STREAM_CAPTURE] = COMP_STATE_PREPARE;
 		dai_info(dai, "ssp_stop(), RX stop");
 	}
 
 	/* stop Tx if needed */
 	if (direction == DAI_DIR_PLAYBACK &&
-	    ssp->state[SOF_IPC_STREAM_PLAYBACK] == COMP_STATE_ACTIVE) {
+	    ssp->state[SOF_IPC_STREAM_PLAYBACK] != COMP_STATE_PREPARE) {
 		ssp_update_bits(dai, SSCR1, SSCR1_TSRE, 0);
 		ssp_update_bits(dai, SSCR0, SSCR0_TIM, SSCR0_TIM);
-		ssp->state[SOF_IPC_STREAM_PLAYBACK] = COMP_STATE_PAUSED;
+		ssp->state[SOF_IPC_STREAM_PLAYBACK] = COMP_STATE_PREPARE;
 		dai_info(dai, "ssp_stop(), TX stop");
 	}
 
 	/* disable SSP port if no users */
-	if (ssp->state[SOF_IPC_STREAM_CAPTURE] != COMP_STATE_ACTIVE &&
-	    ssp->state[SOF_IPC_STREAM_PLAYBACK] != COMP_STATE_ACTIVE) {
+	if (ssp->state[SOF_IPC_STREAM_CAPTURE] == COMP_STATE_PREPARE &&
+	    ssp->state[SOF_IPC_STREAM_PLAYBACK] == COMP_STATE_PREPARE) {
 		ssp_update_bits(dai, SSCR0, SSCR0_SSE, 0);
-		ssp->state[SOF_IPC_STREAM_CAPTURE] = COMP_STATE_PREPARE;
-		ssp->state[SOF_IPC_STREAM_PLAYBACK] = COMP_STATE_PREPARE;
 		dai_info(dai, "ssp_stop(), SSP port disabled");
 	}
 
 	spin_unlock(&dai->lock);
+}
+
+static void ssp_pause(struct dai *dai, int direction)
+{
+	struct ssp_pdata *ssp = dai_get_drvdata(dai);
+
+	if (direction == SOF_IPC_STREAM_CAPTURE)
+		dai_info(dai, "ssp_pause(), RX");
+	else
+		dai_info(dai, "ssp_pause(), TX");
+
+	ssp->state[direction] = COMP_STATE_PAUSED;
 }
 
 static int ssp_trigger(struct dai *dai, int cmd, int direction)
@@ -505,8 +515,10 @@ static int ssp_trigger(struct dai *dai, int cmd, int direction)
 			ssp_start(dai, direction);
 		break;
 	case COMP_TRIGGER_STOP:
-	case COMP_TRIGGER_PAUSE:
 		ssp_stop(dai, direction);
+		break;
+	case COMP_TRIGGER_PAUSE:
+		ssp_pause(dai, direction);
 		break;
 	case COMP_TRIGGER_RESUME:
 		ssp_context_restore(dai);


### PR DESCRIPTION
https://github.com/thesofproject/sof/issues/2203

dw_dma: Remove redundant write pointer increment

Function dw_dma_increment_pointer is called in each
dw_dma_copy and moves write pointer by number of passed
bytes a priori. Its why this function shouldn't be called
after dma stops before whole transmission ends.
It leads to misalignment in data stored in any queue between
source buffer and output, with data written to this interface
and glitch when first data after release command come.

dw_dma: Shorten DW_DMA_TIMEOUT value below 1 ms

Timeout values above 1ms (task period) shouldn't happen.
In such a situation system agent is likely to panic
because of time drift, what shouldn't happen in such
a situation.

dw_dma: Suspend DMA channel in stop function

Suspend flag should be set regardless of draining mode to stop
draining data from source buffer.

ssp: Keep SSP connected with DMA in pause state

When there is not enough time to wait for FIFO empty and we care about
data continuous - like in pause state - then SSP should be kept connected
with DMA in pause state. Such a solution is less error prone.
After this change, glitches after pause/resume sequence disappear.