### PR TITLE
Testbench: Add packed attribute to file component IPC struct

### DIFF
--- a/tools/testbench/include/testbench/file.h
+++ b/tools/testbench/include/testbench/file.h
@@ -52,5 +52,5 @@ struct sof_ipc_comp_file {
 	struct sof_ipc_comp_config config;
 	char *fn;
 	enum file_mode mode;
-};
+} __attribute__((packed));
 #endif


### PR DESCRIPTION
This patch fixes build fail of testbench. The packed attribute
is added similarly as in IPC structs of other components.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>