### PR TITLE
Introduce new compact trace macros with well known level names

### DIFF
--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -57,16 +57,15 @@ struct comp_dev *comp_new(struct sof_ipc_comp *comp)
 	/* find the driver for our new component */
 	drv = get_drv(comp->type);
 	if (!drv) {
-		trace_comp_error("comp_new() error: driver not found, "
-				 "comp->type = %u", comp->type);
+		trace_error(TRACE_CLASS_COMP, "comp_new() error: driver not found, comp->type = %u",
+			    comp->type);
 		return NULL;
 	}
 
 	/* create the new component */
 	cdev = drv->ops.new(comp);
 	if (!cdev) {
-		trace_comp_error("comp_new() error: "
-				 "unable to create the new component");
+		comp_cl_err(drv, "comp_new() error: unable to create the new component");
 		return NULL;
 	}
 
@@ -112,8 +111,8 @@ int comp_set_state(struct comp_dev *dev, int cmd)
 	int ret = 0;
 
 	if (dev->state == requested_state) {
-		trace_comp_with_ids(dev, "comp_set_state(), "
-				    "state already set to %u", dev->state);
+		comp_info(dev, "comp_set_state(), state already set to %u",
+			  dev->state);
 		return COMP_STATUS_STATE_ALREADY_SET;
 	}
 
@@ -122,10 +121,8 @@ int comp_set_state(struct comp_dev *dev, int cmd)
 		if (dev->state == COMP_STATE_PREPARE) {
 			dev->state = COMP_STATE_ACTIVE;
 		} else {
-			trace_comp_error_with_ids(dev, "comp_set_state() error: "
-						  "wrong state = %u, "
-						  "COMP_TRIGGER_START",
-						  dev->state);
+			comp_err(dev, "comp_set_state() error: wrong state = %u, COMP_TRIGGER_START",
+				 dev->state);
 			ret = -EINVAL;
 		}
 		break;
@@ -133,10 +130,8 @@ int comp_set_state(struct comp_dev *dev, int cmd)
 		if (dev->state == COMP_STATE_PAUSED) {
 			dev->state = COMP_STATE_ACTIVE;
 		} else {
-			trace_comp_error_with_ids(dev, "comp_set_state() error: "
-						  "wrong state = %u, "
-						  "COMP_TRIGGER_RELEASE",
-						  dev->state);
+			comp_err(dev, "comp_set_state() error: wrong state = %u, COMP_TRIGGER_RELEASE",
+				 dev->state);
 			ret = -EINVAL;
 		}
 		break;
@@ -145,10 +140,8 @@ int comp_set_state(struct comp_dev *dev, int cmd)
 		    dev->state == COMP_STATE_PAUSED) {
 			dev->state = COMP_STATE_PREPARE;
 		} else {
-			trace_comp_error_with_ids(dev, "comp_set_state() error: "
-						  "wrong state = %u, "
-						  "COMP_TRIGGER_STOP",
-						  dev->state);
+			comp_err(dev, "comp_set_state() error: wrong state = %u, COMP_TRIGGER_STOP",
+				 dev->state);
 			ret = -EINVAL;
 		}
 		break;
@@ -161,10 +154,8 @@ int comp_set_state(struct comp_dev *dev, int cmd)
 		if (dev->state == COMP_STATE_ACTIVE) {
 			dev->state = COMP_STATE_PAUSED;
 		} else {
-			trace_comp_error_with_ids(dev, "comp_set_state() error: "
-						  "wrong state = %u, "
-						  "COMP_TRIGGER_PAUSE",
-						  dev->state);
+			comp_err(dev, "comp_set_state() error: wrong state = %u, COMP_TRIGGER_PAUSE",
+				 dev->state);
 			ret = -EINVAL;
 		}
 		break;
@@ -172,10 +163,8 @@ int comp_set_state(struct comp_dev *dev, int cmd)
 		/* reset always succeeds */
 		if (dev->state == COMP_STATE_ACTIVE ||
 		    dev->state == COMP_STATE_PAUSED) {
-			trace_comp_error_with_ids(dev, "comp_set_state() error: "
-						  "wrong state = %u, "
-						  "COMP_TRIGGER_RESET",
-						  dev->state);
+			comp_err(dev, "comp_set_state() error: wrong state = %u, COMP_TRIGGER_RESET",
+				 dev->state);
 			ret = 0;
 		}
 		dev->state = COMP_STATE_READY;
@@ -184,10 +173,8 @@ int comp_set_state(struct comp_dev *dev, int cmd)
 		if (dev->state == COMP_STATE_READY) {
 			dev->state = COMP_STATE_PREPARE;
 		} else {
-			trace_comp_error_with_ids(dev, "comp_set_state() error: "
-						  "wrong state = %u, "
-						  "COMP_TRIGGER_PREPARE",
-						  dev->state);
+			comp_err(dev, "comp_set_state() error: wrong state = %u, COMP_TRIGGER_PREPARE",
+				 dev->state);
 			ret = -EINVAL;
 		}
 		break;

--- a/src/audio/pipeline_static.c
+++ b/src/audio/pipeline_static.c
@@ -415,7 +415,7 @@ int init_static_pipeline(struct ipc *ipc)
 	return 0;
 
 error:
-	trace_pipe_error("init_static_pipeline() error");
+	pipe_cl_err("init_static_pipeline() error");
 
 	for (i = 0; i < ARRAY_SIZE(pipeline); i++) {
 

--- a/src/audio/switch.c
+++ b/src/audio/switch.c
@@ -12,28 +12,11 @@
 #include <user/trace.h>
 #include <stddef.h>
 
-/* mixer tracing */
-#define trace_switch(__e, ...) \
-	trace_event(TRACE_CLASS_SWITCH, __e, ##__VA_ARGS__)
-#define trace_switch_with_ids(comp_ptr, __e, ...)		\
-	trace_event_comp(TRACE_CLASS_SWITCH, comp_ptr,		\
-			 __e, ##__VA_ARGS__)
-
-#define tracev_switch(__e, ...) \
-	tracev_event(TRACE_CLASS_SWITCH, __e, ##__VA_ARGS__)
-#define tracev_switch_with_ids(comp_ptr, __e, ...)		\
-	tracev_event_comp(TRACE_CLASS_SWITCH, comp_ptr,		\
-			  __e, ##__VA_ARGS__)
-
-#define trace_switch_error(__e, ...) \
-	trace_error(TRACE_CLASS_SWITCH, __e, ##__VA_ARGS__)
-#define trace_switch_error_with_ids(comp_ptr, __e, ...)		\
-	trace_error_comp(TRACE_CLASS_SWITCH, comp_ptr,		\
-			 __e, ##__VA_ARGS__)
+static const struct comp_driver comp_switch;
 
 static struct comp_dev *switch_new(struct sof_ipc_comp *comp)
 {
-	trace_switch("switch_new()");
+	comp_cl_info(&comp_switch, "switch_new()");
 
 	return NULL;
 }

--- a/src/audio/tone.c
+++ b/src/audio/tone.c
@@ -30,25 +30,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-/* mixer tracing */
-#define trace_tone(__e, ...) \
-	trace_event(TRACE_CLASS_TONE, __e, ##__VA_ARGS__)
-#define trace_tone_with_ids(comp_ptr, __e, ...)			\
-	trace_event_comp(TRACE_CLASS_TONE, comp_ptr,		\
-			 __e, ##__VA_ARGS__)
-
-#define tracev_tone(__e, ...) \
-	tracev_event(TRACE_CLASS_TONE, __e, ##__VA_ARGS__)
-#define tracev_tone_with_ids(comp_ptr, __e, ...)		\
-	tracev_event_comp(TRACE_CLASS_TONE, comp_ptr,		\
-			  __e, ##__VA_ARGS__)
-
-#define trace_tone_error(__e, ...) \
-	trace_error(TRACE_CLASS_TONE, __e, ##__VA_ARGS__)
-#define trace_tone_error_with_ids(comp_ptr, __e, ...)		\
-	trace_error_comp(TRACE_CLASS_TONE, comp_ptr,		\
-			 __e, ##__VA_ARGS__)
-
 /* Convert float frequency in Hz to Q16.16 fractional format */
 #define TONE_FREQ(f) Q_CONVERT_FLOAT(f, 16)
 
@@ -59,6 +40,8 @@
 #define TONE_AMPLITUDE_DEFAULT TONE_GAIN(0.1)      /*  -20 dB  */
 #define TONE_FREQUENCY_DEFAULT TONE_FREQ(997.0)
 #define TONE_NUM_FS            13       /* Table size for 8-192 kHz range */
+
+static const struct comp_driver comp_tone;
 
 /* 2*pi/Fs lookup tables in Q1.31 for each Fs */
 static const int32_t tone_fs_list[TONE_NUM_FS] = {
@@ -392,10 +375,10 @@ static struct comp_dev *tone_new(struct sof_ipc_comp *comp)
 	int i;
 	int ret;
 
-	trace_tone("tone_new()");
+	comp_cl_info(&comp_tone, "tone_new()");
 
 	if (IPC_IS_SIZE_INVALID(ipc_tone->config)) {
-		IPC_SIZE_ERROR_TRACE(TRACE_CLASS_TONE, ipc_tone->config);
+		IPC_SIZE_ERROR_TRACE(TRACE_CLASS_COMP, ipc_tone->config);
 		return NULL;
 	}
 
@@ -432,7 +415,7 @@ static void tone_free(struct comp_dev *dev)
 {
 	struct tone_data *td = comp_get_drvdata(dev);
 
-	trace_tone_with_ids(dev, "tone_free()");
+	comp_info(dev, "tone_free()");
 
 	rfree(td);
 	rfree(dev);
@@ -453,8 +436,8 @@ static int tone_params(struct comp_dev *dev,
 	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer,
 				source_list);
 
-	trace_tone_with_ids(dev, "tone_params(), config->frame_fmt = %u",
-			    config->frame_fmt);
+	comp_info(dev, "tone_params(), config->frame_fmt = %u",
+		  config->frame_fmt);
 
 	/* Tone supports only S32_LE PCM format atm */
 	if (config->frame_fmt != SOF_IPC_FRAME_S32_LE)
@@ -476,15 +459,14 @@ static int tone_cmd_get_value(struct comp_dev *dev,
 	struct comp_data *cd = comp_get_drvdata(dev);
 	int j;
 
-	trace_tone_with_ids(dev, "tone_cmd_get_value()");
+	comp_info(dev, "tone_cmd_get_value()");
 
 	if (cdata->cmd == SOF_CTRL_CMD_SWITCH) {
 		for (j = 0; j < cdata->num_elems; j++) {
 			cdata->chanv[j].channel = j;
 			cdata->chanv[j].value = !cd->sg[j].mute;
-			trace_tone_with_ids(dev, "tone_cmd_get_value(), "
-					    "j = %u, cd->sg[j].mute = %u",
-					    j, cd->sg[j].mute);
+			comp_info(dev, "tone_cmd_get_value(), j = %u, cd->sg[j].mute = %u",
+				  j, cd->sg[j].mute);
 		}
 	}
 	return 0;
@@ -499,18 +481,14 @@ static int tone_cmd_set_value(struct comp_dev *dev,
 	bool val;
 
 	if (cdata->cmd == SOF_CTRL_CMD_SWITCH) {
-		trace_tone_with_ids(dev, "tone_cmd_set_value(), "
-				    "SOF_CTRL_CMD_SWITCH");
+		comp_info(dev, "tone_cmd_set_value(), SOF_CTRL_CMD_SWITCH");
 		for (j = 0; j < cdata->num_elems; j++) {
 			ch = cdata->chanv[j].channel;
 			val = cdata->chanv[j].value;
-			trace_tone_with_ids(dev, "tone_cmd_set_value(), "
-					    "SOF_CTRL_CMD_SWITCH,"
-					    " ch = %u, val = %u", ch, val);
+			comp_info(dev, "tone_cmd_set_value(), SOF_CTRL_CMD_SWITCH, ch = %u, val = %u",
+				  ch, val);
 			if (ch >= PLATFORM_MAX_CHANNELS) {
-				trace_tone_error_with_ids(dev,
-							  "tone_cmd_set_value() error: "
-							  "ch >= PLATFORM_MAX_CHANNELS");
+				comp_err(dev, "tone_cmd_set_value() error: ch >= PLATFORM_MAX_CHANNELS");
 				return -EINVAL;
 			}
 
@@ -521,8 +499,7 @@ static int tone_cmd_set_value(struct comp_dev *dev,
 
 		}
 	} else {
-		trace_tone_error_with_ids(dev, "tone_cmd_set_value() error: "
-					  "invalid cdata->cmd");
+		comp_err(dev, "tone_cmd_set_value() error: invalid cdata->cmd");
 		return -EINVAL;
 	}
 
@@ -538,72 +515,59 @@ static int tone_cmd_set_data(struct comp_dev *dev,
 	uint32_t ch;
 	uint32_t val;
 
-	trace_tone_with_ids(dev, "tone_cmd_set_data()");
+	comp_info(dev, "tone_cmd_set_data()");
 
 	switch (cdata->cmd) {
 	case SOF_CTRL_CMD_ENUM:
-		trace_tone_with_ids(dev, "tone_cmd_set_data(), "
-				    "SOF_CTRL_CMD_ENUM, cdata->index = %u",
-				    cdata->index);
+		comp_info(dev, "tone_cmd_set_data(), SOF_CTRL_CMD_ENUM, cdata->index = %u",
+			  cdata->index);
 		compv = (struct sof_ipc_ctrl_value_comp *)cdata->data->data;
 		for (i = 0; i < (int)cdata->num_elems; i++) {
 			ch = compv[i].index;
 			val = compv[i].svalue;
-			trace_tone_with_ids(dev, "tone_cmd_set_data(), "
-					    "SOF_CTRL_CMD_ENUM, "
-					    "ch = %u, val = %u", ch, val);
+			comp_info(dev, "tone_cmd_set_data(), SOF_CTRL_CMD_ENUM, ch = %u, val = %u",
+				  ch, val);
 			switch (cdata->index) {
 			case SOF_TONE_IDX_FREQUENCY:
-				trace_tone_with_ids(dev, "tone_cmd_set_data(), "
-						    "SOF_TONE_IDX_FREQUENCY");
+				comp_info(dev, "tone_cmd_set_data(), SOF_TONE_IDX_FREQUENCY");
 				tonegen_update_f(&cd->sg[ch], val);
 				break;
 			case SOF_TONE_IDX_AMPLITUDE:
-				trace_tone_with_ids(dev, "tone_cmd_set_data(), "
-						    "SOF_TONE_IDX_AMPLITUDE");
+				comp_info(dev, "tone_cmd_set_data(), SOF_TONE_IDX_AMPLITUDE");
 				tonegen_set_a(&cd->sg[ch], val);
 				break;
 			case SOF_TONE_IDX_FREQ_MULT:
-				trace_tone_with_ids(dev, "tone_cmd_set_data(), "
-						    "SOF_TONE_IDX_FREQ_MULT");
+				comp_info(dev, "tone_cmd_set_data(), SOF_TONE_IDX_FREQ_MULT");
 				tonegen_set_freq_mult(&cd->sg[ch], val);
 				break;
 			case SOF_TONE_IDX_AMPL_MULT:
-				trace_tone_with_ids(dev, "tone_cmd_set_data(), "
-						    "SOF_TONE_IDX_AMPL_MULT");
+				comp_info(dev, "tone_cmd_set_data(), SOF_TONE_IDX_AMPL_MULT");
 				tonegen_set_ampl_mult(&cd->sg[ch], val);
 				break;
 			case SOF_TONE_IDX_LENGTH:
-				trace_tone_with_ids(dev, "tone_cmd_set_data(), "
-						    "SOF_TONE_IDX_LENGTH");
+				comp_info(dev, "tone_cmd_set_data(), SOF_TONE_IDX_LENGTH");
 				tonegen_set_length(&cd->sg[ch], val);
 				break;
 			case SOF_TONE_IDX_PERIOD:
-				trace_tone_with_ids(dev, "tone_cmd_set_data(), "
-						    "SOF_TONE_IDX_PERIOD");
+				comp_info(dev, "tone_cmd_set_data(), SOF_TONE_IDX_PERIOD");
 				tonegen_set_period(&cd->sg[ch], val);
 				break;
 			case SOF_TONE_IDX_REPEATS:
-				trace_tone_with_ids(dev, "tone_cmd_set_data(), "
-						    "SOF_TONE_IDX_REPEATS");
+				comp_info(dev, "tone_cmd_set_data(), SOF_TONE_IDX_REPEATS");
 				tonegen_set_repeats(&cd->sg[ch], val);
 				break;
 			case SOF_TONE_IDX_LIN_RAMP_STEP:
-				trace_tone_with_ids(dev, "tone_cmd_set_data(), "
-						    "SOF_TONE_IDX_LIN_RAMP_STEP");
+				comp_info(dev, "tone_cmd_set_data(), SOF_TONE_IDX_LIN_RAMP_STEP");
 				tonegen_set_linramp(&cd->sg[ch], val);
 				break;
 			default:
-				trace_tone_error_with_ids(dev,
-							  "tone_cmd_set_data() error: "
-							  "invalid cdata->index");
+				comp_err(dev, "tone_cmd_set_data() error: invalid cdata->index");
 				return -EINVAL;
 			}
 		}
 		break;
 	default:
-		trace_tone_error_with_ids(dev, "tone_cmd_set_data() error: "
-					  "invalid cdata->cmd");
+		comp_err(dev, "tone_cmd_set_data() error: invalid cdata->cmd");
 		return -EINVAL;
 	}
 
@@ -617,7 +581,7 @@ static int tone_cmd(struct comp_dev *dev, int cmd, void *data,
 	struct sof_ipc_ctrl_data *cdata = data;
 	int ret = 0;
 
-	trace_tone_with_ids(dev, "tone_cmd()");
+	comp_info(dev, "tone_cmd()");
 
 	switch (cmd) {
 	case COMP_CMD_SET_DATA:
@@ -636,7 +600,7 @@ static int tone_cmd(struct comp_dev *dev, int cmd, void *data,
 
 static int tone_trigger(struct comp_dev *dev, int cmd)
 {
-	trace_tone_with_ids(dev, "tone_trigger()");
+	comp_info(dev, "tone_trigger()");
 
 	return comp_set_state(dev, cmd);
 }
@@ -647,7 +611,7 @@ static int tone_copy(struct comp_dev *dev)
 	struct comp_buffer *sink;
 	struct comp_data *cd = comp_get_drvdata(dev);
 
-	tracev_comp_with_ids(dev, "tone_copy()");
+	comp_dbg(dev, "tone_copy()");
 
 	/* tone component sink buffer */
 	sink = list_first_item(&dev->bsink_list, struct comp_buffer,
@@ -678,7 +642,7 @@ static int tone_prepare(struct comp_dev *dev)
 	int ret;
 	int i;
 
-	trace_tone_with_ids(dev, "tone_prepare()");
+	comp_info(dev, "tone_prepare()");
 
 	ret = comp_set_state(dev, COMP_TRIGGER_PREPARE);
 	if (ret < 0)
@@ -691,10 +655,8 @@ static int tone_prepare(struct comp_dev *dev)
 				  sink_list);
 
 	cd->channels = sourceb->stream.channels;
-	trace_tone_with_ids(dev, "tone_prepare(), "
-			    "cd->channels = %u, "
-			    "cd->rate = %u",
-			    cd->channels, cd->rate);
+	comp_info(dev, "tone_prepare(), cd->channels = %u, cd->rate = %u",
+		  cd->channels, cd->rate);
 
 	for (i = 0; i < cd->channels; i++) {
 		f = tonegen_get_f(&cd->sg[i]);
@@ -714,7 +676,7 @@ static int tone_reset(struct comp_dev *dev)
 	struct comp_data *cd = comp_get_drvdata(dev);
 	int i;
 
-	trace_tone_with_ids(dev, "tone_reset()");
+	comp_info(dev, "tone_reset()");
 
 	/* Initialize with the defaults */
 	for (i = 0; i < PLATFORM_MAX_CHANNELS; i++)

--- a/src/drivers/intel/cavs/alh.c
+++ b/src/drivers/intel/cavs/alh.c
@@ -15,21 +15,16 @@
 #include <user/trace.h>
 #include <stdint.h>
 
-#define trace_alh(__e, ...) trace_event(TRACE_CLASS_ALH, __e, ##__VA_ARGS__)
-#define trace_alh_error(__e, ...) \
-	trace_error(TRACE_CLASS_ALH, __e, ##__VA_ARGS__)
-#define tracev_alh(__e, ...) tracev_event(TRACE_CLASS_ALH, __e, ##__VA_ARGS__)
-
 static int alh_trigger(struct dai *dai, int cmd, int direction)
 {
-	trace_alh("alh_trigger() cmd %d", cmd);
+	dai_info(dai, "alh_trigger() cmd %d", cmd);
 
 	return 0;
 }
 
 static int alh_set_config(struct dai *dai, struct sof_ipc_dai_config *config)
 {
-	trace_alh("alh_set_config() config->format = 0x%4x",
+	dai_info(dai, "alh_set_config() config->format = 0x%4x",
 		  config->format);
 
 	return 0;
@@ -37,28 +32,28 @@ static int alh_set_config(struct dai *dai, struct sof_ipc_dai_config *config)
 
 static int alh_context_store(struct dai *dai)
 {
-	trace_alh("alh_context_store()");
+	dai_info(dai, "alh_context_store()");
 
 	return 0;
 }
 
 static int alh_context_restore(struct dai *dai)
 {
-	trace_alh("alh_context_restore()");
+	dai_info(dai, "alh_context_restore()");
 
 	return 0;
 }
 
 static int alh_probe(struct dai *dai)
 {
-	trace_alh("alh_probe()");
+	dai_info(dai, "alh_probe()");
 
 	return 0;
 }
 
 static int alh_remove(struct dai *dai)
 {
-	trace_alh("alh_remove()");
+	dai_info(dai, "alh_remove()");
 
 	return 0;
 }
@@ -66,7 +61,7 @@ static int alh_remove(struct dai *dai)
 static int alh_get_handshake(struct dai *dai, int direction, int stream_id)
 {
 	if (stream_id >= ARRAY_SIZE(alh_handshake_map)) {
-		trace_alh_error("alh_get_handshake() error: "
+		dai_err(dai, "alh_get_handshake() error: "
 				"stream_id %d out of range", stream_id);
 
 		return -1;

--- a/src/drivers/intel/cavs/hda.c
+++ b/src/drivers/intel/cavs/hda.c
@@ -11,12 +11,6 @@
 #include <sof/lib/dma.h>
 #include <ipc/dai.h>
 
-/* tracing */
-#define trace_hda(__e, ...) \
-	trace_event(TRACE_CLASS_DAI, __e, ##__VA_ARGS__)
-#define trace_hda_error(__e, ...) \
-	trace_error(TRACE_CLASS_DAI, __e, ##__VA_ARGS__)
-
 static int hda_trigger(struct dai *dai, int cmd, int direction)
 {
 	return 0;
@@ -75,7 +69,7 @@ static int hda_ts_config(struct dai *dai, struct timestamp_cfg *cfg)
 	int i;
 
 	if (cfg->type != SOF_DAI_INTEL_HDA) {
-		trace_hda_error("dmic_ts_config(): Illegal DAI type");
+		dai_err(dai, "dmic_ts_config(): Illegal DAI type");
 		return -EINVAL;
 	}
 

--- a/src/include/sof/audio/asrc/asrc_farrow.h
+++ b/src/include/sof/audio/asrc/asrc_farrow.h
@@ -41,6 +41,7 @@
 #ifndef IAS_SRC_FARROW_H
 #define IAS_SRC_FARROW_H
 
+#include <sof/audio/component.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -239,7 +240,8 @@ struct asrc_farrow {
  * @param[in]  bit_depth     The wordlength that will be used for representing
  *                           the PCM samples, must be 16 or 32.
  */
-enum asrc_error_code asrc_get_required_size(int *required_size,
+enum asrc_error_code asrc_get_required_size(struct comp_dev *dev,
+					    int *required_size,
 					    int num_channels,
 					    int bit_depth);
 
@@ -275,7 +277,8 @@ enum asrc_error_code asrc_get_required_size(int *required_size,
  * @param[in] operation_mode Choose 'push' or 'pull', depending on the mode
  *                           you want your ASRC to operate in.
  */
-enum asrc_error_code asrc_initialise(struct asrc_farrow *src_obj,
+enum asrc_error_code asrc_initialise(struct comp_dev *dev,
+				     struct asrc_farrow *src_obj,
 				     int num_channels,
 				     int32_t fs_prim,
 				     int32_t fs_sec,
@@ -336,7 +339,8 @@ enum asrc_error_code asrc_initialise(struct asrc_farrow *src_obj,
  *                               avoid that unconsumed samples are
  *                               overwritten.
  */
-enum asrc_error_code asrc_process_push16(struct asrc_farrow *src_obj,
+enum asrc_error_code asrc_process_push16(struct comp_dev *dev,
+					 struct asrc_farrow *src_obj,
 					 int16_t **__restrict input_buffers,
 					 int input_num_frames,
 					 int16_t **__restrict output_buffers,
@@ -393,7 +397,8 @@ enum asrc_error_code asrc_process_push16(struct asrc_farrow *src_obj,
  *                                avoid that unconsumed samples are
  *                                overwritten.
  */
-enum asrc_error_code asrc_process_push32(struct asrc_farrow *src_obj,
+enum asrc_error_code asrc_process_push32(struct comp_dev *dev,
+					 struct asrc_farrow *src_obj,
 					 int32_t **__restrict input_buffers,
 					 int input_num_frames,
 					 int32_t **__restrict output_buffers,
@@ -457,7 +462,8 @@ enum asrc_error_code asrc_process_push32(struct asrc_farrow *src_obj,
  *                              parameter returns the number of frames
  *                              that have been read.
  */
-enum asrc_error_code asrc_process_pull16(struct asrc_farrow *src_obj,
+enum asrc_error_code asrc_process_pull16(struct comp_dev *dev,
+					 struct asrc_farrow *src_obj,
 					 int16_t **__restrict input_buffers,
 					 int *input_num_frames,
 					 int16_t **__restrict output_buffers,
@@ -520,7 +526,8 @@ enum asrc_error_code asrc_process_pull16(struct asrc_farrow *src_obj,
  *                              parameter returns the number of frames
  *                              that have been read.
  */
-enum asrc_error_code asrc_process_pull32(struct asrc_farrow *src_obj,
+enum asrc_error_code asrc_process_pull32(struct comp_dev *dev,
+					 struct asrc_farrow *src_obj,
 					 int32_t **__restrict input_buffers,
 					 int *input_num_frames,
 					 int32_t **__restrict output_buffers,
@@ -540,7 +547,8 @@ enum asrc_error_code asrc_process_pull32(struct asrc_farrow *src_obj,
  *                       Value should be passed as 2q30 fixed point value.
  *                       For synchrounous operation pass (1 << 30).
  */
-enum asrc_error_code asrc_update_drift(struct asrc_farrow *src_obj,
+enum asrc_error_code asrc_update_drift(struct comp_dev *dev,
+				       struct asrc_farrow *src_obj,
 				       uint32_t clock_skew);
 
 /*
@@ -562,7 +570,8 @@ enum asrc_error_code asrc_update_drift(struct asrc_farrow *src_obj,
  *                                 in one controller loop on the
  *                                 secondary (SSP) side
  */
-enum asrc_error_code asrc_update_fs_ratio(struct asrc_farrow *src_obj,
+enum asrc_error_code asrc_update_fs_ratio(struct comp_dev *dev,
+					  struct asrc_farrow *src_obj,
 					  int primary_num_frames,
 					  int secondary_num_frames);
 
@@ -579,7 +588,8 @@ enum asrc_error_code asrc_update_fs_ratio(struct asrc_farrow *src_obj,
  * @param[in] fs_prim  Primary sampling rate.
  * @param[in] fs_sec   Secondary sampling rate.
  */
-enum asrc_error_code asrc_set_fs_ratio(struct asrc_farrow *src_obj,
+enum asrc_error_code asrc_set_fs_ratio(struct comp_dev *dev,
+				       struct asrc_farrow *src_obj,
 				       int32_t fs_prim, int32_t fs_sec);
 
 /*
@@ -590,7 +600,8 @@ enum asrc_error_code asrc_set_fs_ratio(struct asrc_farrow *src_obj,
  * @param[in] src_obj      Pointer to the ias_src_farrow instance.
  * @param[in] input_format Format parameter.
  */
-enum asrc_error_code asrc_set_input_format(struct asrc_farrow *src_obj,
+enum asrc_error_code asrc_set_input_format(struct comp_dev *dev,
+					   struct asrc_farrow *src_obj,
 					   enum asrc_io_format input_format);
 
 /*
@@ -601,7 +612,8 @@ enum asrc_error_code asrc_set_input_format(struct asrc_farrow *src_obj,
  * @param[in] src_obj        Pointer to the ias_src_farrow instance.
  * @param[in] output_format  Format parameter.
  */
-enum asrc_error_code asrc_set_output_format(struct asrc_farrow *src_obj,
+enum asrc_error_code asrc_set_output_format(struct comp_dev *dev,
+					    struct asrc_farrow *src_obj,
 					    enum asrc_io_format output_format);
 
 /*

--- a/src/include/sof/audio/kpb.h
+++ b/src/include/sof/audio/kpb.h
@@ -14,23 +14,6 @@
 
 struct comp_buffer;
 
-/* KPB tracing */
-#define trace_kpb(__e, ...) trace_event(TRACE_CLASS_KPB, __e, ##__VA_ARGS__)
-#define trace_kpb_with_ids(comp_ptr, __e, ...)			\
-	trace_event_comp(TRACE_CLASS_KPB, comp_ptr,		\
-			 __e, ##__VA_ARGS__)
-
-#define tracev_kpb(__e, ...) tracev_event(TRACE_CLASS_KPB, __e, ##__VA_ARGS__)
-#define tracev_kpb_with_ids(comp_ptr, __e, ...)			\
-	tracev_event_comp(TRACE_CLASS_KPB, comp_ptr,		\
-			  __e, ##__VA_ARGS__)
-
-#define trace_kpb_error(__e, ...) trace_error(TRACE_CLASS_KPB, __e, \
-					      ##__VA_ARGS__)
-#define trace_kpb_error_with_ids(comp_ptr, __e, ...)		\
-	trace_error_comp(TRACE_CLASS_KPB, comp_ptr,		\
-			 __e, ##__VA_ARGS__)
-
 /* KPB internal defines */
 #define KPB_MAX_BUFF_TIME 2100 /**< time of buffering in miliseconds */
 #define KPB_MAX_SUPPORTED_CHANNELS 2 /**< number of supported channels */

--- a/src/include/sof/audio/mux.h
+++ b/src/include/sof/audio/mux.h
@@ -28,24 +28,6 @@
 struct comp_buffer;
 struct comp_dev;
 
- /* tracing */
-#define trace_mux(__e, ...) trace_event(TRACE_CLASS_MUX, __e, ##__VA_ARGS__)
-#define trace_mux_with_ids(comp_ptr, __e, ...)			\
-	trace_event_comp(TRACE_CLASS_MUX, comp_ptr,		\
-			 __e, ##__VA_ARGS__)
-
-#define tracev_mux(__e, ...) \
-	tracev_event(TRACE_CLASS_MUX, __e, ##__VA_ARGS__)
-#define tracev_mux_with_ids(comp_ptr, __e, ...)			\
-	tracev_event_comp(TRACE_CLASS_MUX, comp_ptr,		\
-			  __e, ##__VA_ARGS__)
-
-#define trace_mux_error(__e, ...) \
-	trace_error(TRACE_CLASS_MUX, __e, ##__VA_ARGS__)
-#define trace_mux_error_with_ids(comp_ptr, __e, ...)		\
-	trace_error_comp(TRACE_CLASS_MUX, comp_ptr,		\
-			 __e, ##__VA_ARGS__)
-
 /** \brief Supported streams count. */
 #define MUX_MAX_STREAMS 4
 

--- a/src/include/sof/audio/pipeline.h
+++ b/src/include/sof/audio/pipeline.h
@@ -31,29 +31,33 @@ struct task;
 #define NO_XRUN_RECOVERY 1
 
 /* pipeline tracing */
-#define trace_pipe(format, ...) \
-	trace_event(TRACE_CLASS_PIPE, format, ##__VA_ARGS__)
-#define trace_pipe_with_ids(pipe_ptr, format, ...)		\
-	trace_event_with_ids(TRACE_CLASS_PIPE,			\
-			     pipe_ptr->ipc_pipe.pipeline_id,	\
-			     pipe_ptr->ipc_pipe.comp_id,	\
-			     format, ##__VA_ARGS__)
+#define trace_pipe_get_id(pipe_p) ((pipe_p)->ipc_pipe.pipeline_id)
+#define trace_pipe_get_subid(pipe_p) ((pipe_p)->ipc_pipe.comp_id)
 
-#define trace_pipe_error(format, ...) \
-	trace_error(TRACE_CLASS_PIPE, format, ##__VA_ARGS__)
-#define trace_pipe_error_with_ids(pipe_ptr, format, ...)	\
-	trace_error_with_ids(TRACE_CLASS_PIPE,			\
-			     pipe_ptr->ipc_pipe.pipeline_id,	\
-			     pipe_ptr->ipc_pipe.comp_id,	\
-			     format, ##__VA_ARGS__)
+/* class (driver) level (no device object) tracing */
 
-#define tracev_pipe(format, ...) \
-	tracev_event(TRACE_CLASS_PIPE, format, ##__VA_ARGS__)
-#define tracev_pipe_with_ids(pipe_ptr, format, ...)		\
-	tracev_event_with_ids(TRACE_CLASS_PIPE,			\
-			     pipe_ptr->ipc_pipe.pipeline_id,	\
-			     pipe_ptr->ipc_pipe.comp_id,	\
-			     format, ##__VA_ARGS__)
+#define pipe_cl_err(__e, ...)						\
+	trace_error(TRACE_CLASS_PIPE, __e, ##__VA_ARGS__)
+
+#define pipe_cl_info(__e, ...)						\
+	trace_event(TRACE_CLASS_PIPE, __e, ##__VA_ARGS__)
+
+#define pipe_cl_dbg(__e, ...)						\
+	tracev_event(TRACE_CLASS_PIPE, __e, ##__VA_ARGS__)
+
+/* device tracing */
+
+#define pipe_err(pipe_p, __e, ...)					\
+	trace_dev_err(TRACE_CLASS_PIPE, trace_pipe_get_id,		\
+		      trace_pipe_get_subid, pipe_p, __e, ##__VA_ARGS__)
+
+#define pipe_info(pipe_p, __e, ...)					\
+	trace_dev_info(TRACE_CLASS_PIPE, trace_pipe_get_id,		\
+		       trace_pipe_get_subid, pipe_p, __e, ##__VA_ARGS__)
+
+#define pipe_dbg(pipe_p, __e, ...)					\
+	trace_dev_dbg(TRACE_CLASS_PIPE, trace_pipe_get_id,		\
+		      trace_pipe_get_subid, pipe_p, __e, ##__VA_ARGS__)
 
 /* Pipeline status to stop execution of current path */
 #define PPL_STATUS_PATH_STOP	1

--- a/src/include/sof/audio/selector.h
+++ b/src/include/sof/audio/selector.h
@@ -23,27 +23,6 @@
 struct comp_buffer;
 struct comp_dev;
 
-/** \brief Selector trace function. */
-#define trace_selector(__e, ...) \
-	trace_event(TRACE_CLASS_SELECTOR, __e, ##__VA_ARGS__)
-#define trace_selector_with_ids(comp_ptr, __e, ...)		\
-	trace_event_comp(TRACE_CLASS_SELECTOR, comp_ptr,	\
-			 __e, ##__VA_ARGS__)
-
-/** \brief Selector trace verbose function. */
-#define tracev_selector(__e, ...) \
-	tracev_event(TRACE_CLASS_SELECTOR, __e, ##__VA_ARGS__)
-#define tracev_selector_with_ids(comp_ptr, __e, ...)		\
-	tracev_event_comp(TRACE_CLASS_SELECTOR, comp_ptr,	\
-			  __e, ##__VA_ARGS__)
-
-/** \brief Selector trace error function. */
-#define trace_selector_error(__e, ...) \
-	trace_error(TRACE_CLASS_SELECTOR, __e, ##__VA_ARGS__)
-#define trace_selector_error_with_ids(comp_ptr, __e, ...)	\
-	trace_error_comp(TRACE_CLASS_SELECTOR, comp_ptr,	\
-			 __e, ##__VA_ARGS__)
-
 /** \brief Supported channel count on input. */
 #define SEL_SOURCE_2CH 2
 #define SEL_SOURCE_4CH 4

--- a/src/include/sof/audio/volume.h
+++ b/src/include/sof/audio/volume.h
@@ -39,27 +39,6 @@ struct sof_ipc_ctrl_value_chan;
 
 #endif
 
-/** \brief Volume trace function. */
-#define trace_volume(__e, ...) \
-	trace_event(TRACE_CLASS_VOLUME, __e, ##__VA_ARGS__)
-#define trace_volume_with_ids(comp_ptr, __e, ...)		\
-	trace_event_comp(TRACE_CLASS_VOLUME, comp_ptr,		\
-			 __e, ##__VA_ARGS__)
-
-/** \brief Volume trace value function. */
-#define tracev_volume(__e, ...) \
-	tracev_event(TRACE_CLASS_VOLUME, __e, ##__VA_ARGS__)
-#define tracev_volume_with_ids(comp_ptr, __e, ...)		\
-	tracev_event_comp(TRACE_CLASS_VOLUME, comp_ptr,		\
-			  __e, ##__VA_ARGS__)
-
-/** \brief Volume trace error function. */
-#define trace_volume_error(__e, ...) \
-	trace_error(TRACE_CLASS_VOLUME, __e, ##__VA_ARGS__)
-#define trace_volume_error_with_ids(comp_ptr, __e, ...)		\
-	trace_error_comp(TRACE_CLASS_VOLUME, comp_ptr,		\
-			 __e, ##__VA_ARGS__)
-
 //** \brief Volume gain Qx.y integer x number of bits including sign bit. */
 #define VOL_QXY_X 8
 

--- a/src/include/sof/drivers/ssp.h
+++ b/src/include/sof/drivers/ssp.h
@@ -216,15 +216,6 @@ extern const struct dai_driver ssp_driver;
 
 #endif
 
-/* tracing */
-#define trace_ssp(__e, ...) \
-	trace_event(TRACE_CLASS_SSP, __e, ##__VA_ARGS__)
-#define trace_ssp_error(__e, ...) \
-	trace_error(TRACE_CLASS_SSP, __e, ##__VA_ARGS__)
-#define tracev_ssp(__e, ...) \
-	tracev_event(TRACE_CLASS_SSP, __e, ##__VA_ARGS__)
-
-
 #define ssp_irq(ssp) \
 	ssp->plat_data.irq
 

--- a/src/include/sof/lib/dai.h
+++ b/src/include/sof/lib/dai.h
@@ -148,6 +148,7 @@ struct dai_type_info {
 	size_t num_dais;	/**< Number of elements in dai_array */
 };
 
+/* TODO: to be removed once dais using it are switched to the new one */
 #define trace_dai_with_ids(klass, dai_ptr, format, ...) \
 	trace_event_with_ids(klass,			\
 			     dai_ptr->drv->type,	\
@@ -165,6 +166,35 @@ struct dai_type_info {
 			      dai_ptr->drv->type,		\
 			      dai_ptr->index,			\
 			      format, ##__VA_ARGS__)
+
+/* dai tracing */
+#define trace_dai_get_id(dai_p) ((dai_p)->drv->type)
+#define trace_dai_get_subid(dai_p) ((dai_p)->index)
+
+/* class (driver) level (no device object) tracing */
+
+#define dai_cl_err(drv_p, __e, ...)					\
+	trace_error(TRACE_CLASS_DAI, __e, ##__VA_ARGS__)
+
+#define dai_cl_info(drv_p, __e, ...)					\
+	trace_event(TRACE_CLASS_DAI, __e, ##__VA_ARGS__)
+
+#define dai_cl_dbg(drv_p, __e, ...)					\
+	tracev_event(TRACE_CLASS_DAI, __e, ##__VA_ARGS__)
+
+/* device tracing */
+
+#define dai_err(dai_p, __e, ...)					\
+	trace_dev_err(TRACE_CLASS_DAI, trace_dai_get_id,		\
+		      trace_dai_get_subid, dai_p, __e, ##__VA_ARGS__)
+
+#define dai_info(dai_p, __e, ...)					\
+	trace_dev_info(TRACE_CLASS_DAI, trace_dai_get_id,		\
+		       trace_dai_get_subid, dai_p, __e, ##__VA_ARGS__)
+
+#define dai_dbg(dai_p, __e, ...)					\
+	trace_dev_dbg(TRACE_CLASS_DAI, trace_dai_get_id,		\
+		      trace_dai_get_subid, dai_p, __e, ##__VA_ARGS__)
 
 /**
  * \brief Holds information about array of DAIs grouped by type.

--- a/src/include/sof/lib/dai.h
+++ b/src/include/sof/lib/dai.h
@@ -148,25 +148,6 @@ struct dai_type_info {
 	size_t num_dais;	/**< Number of elements in dai_array */
 };
 
-/* TODO: to be removed once dais using it are switched to the new one */
-#define trace_dai_with_ids(klass, dai_ptr, format, ...) \
-	trace_event_with_ids(klass,			\
-			     dai_ptr->drv->type,	\
-			     dai_ptr->index,		\
-			     format, ##__VA_ARGS__)
-
-#define trace_dai_error_with_ids(klass, dai_ptr, format, ...)	\
-	trace_error_with_ids(klass,				\
-			     dai_ptr->drv->type,		\
-			     dai_ptr->index,			\
-			     format, ##__VA_ARGS__)
-
-#define tracev_dai_with_ids(klass, dai_ptr, format, ...)	\
-	tracev_event_with_ids(klass,				\
-			      dai_ptr->drv->type,		\
-			      dai_ptr->index,			\
-			      format, ##__VA_ARGS__)
-
 /* dai tracing */
 #define trace_dai_get_id(dai_p) ((dai_p)->drv->type)
 #define trace_dai_get_subid(dai_p) ((dai_p)->index)

--- a/src/include/sof/trace/trace.h
+++ b/src/include/sof/trace/trace.h
@@ -376,6 +376,31 @@ do {									\
 	trace_unused(class, id_0, id_1, format, ##__VA_ARGS__)
 #endif
 
+/* tracing from device (component, pipeline, dai, ...) */
+
+/** \brief Trace from a device on err level.
+ *
+ * \param class Trace class, one of TRACE_CLASS_...
+ * \param get_id_m Macro that can retrieve device's id0 from the dev
+ * \param get_subid_m Macro that can retrieve device's id1 from the dev
+ * \param dev Device
+ * \param fmt Format followed by parameters
+ */
+#define trace_dev_err(class, get_id_m, get_subid_m, dev, fmt, ...) \
+	trace_error_with_ids(class, get_id_m(dev), get_subid_m(dev), fmt, \
+			     ##__VA_ARGS__)
+
+/** \brief Trace from a device on info level. */
+#define trace_dev_info(class, get_id_m, get_subid_m, dev, fmt, ...) \
+	trace_event_with_ids(class, get_id_m(dev), get_subid_m(dev), fmt, \
+			     ##__VA_ARGS__)
+
+/** \brief Trace from a device on dbg level. */
+#define trace_dev_dbg(class, get_id_m, get_subid_m, dev, fmt, ...) \
+	tracev_event_with_ids(class, get_id_m(dev), get_subid_m(dev), fmt, \
+			      ##__VA_ARGS__)
+
+/* TODO: remove component specific macros from global header */
 /* tracing from component */
 #define _trace_comp_build(fun, class, comp_ptr, format, ...)		\
 		fun(class, comp_ptr->comp.pipeline_id,			\
@@ -387,5 +412,4 @@ do {									\
 						##__VA_ARGS__)
 #define trace_error_comp(...) _trace_comp_build(trace_error_with_ids,	\
 						##__VA_ARGS__)
-
 #endif /* __SOF_TRACE_TRACE_H__ */

--- a/src/include/sof/trace/trace.h
+++ b/src/include/sof/trace/trace.h
@@ -400,16 +400,4 @@ do {									\
 	tracev_event_with_ids(class, get_id_m(dev), get_subid_m(dev), fmt, \
 			      ##__VA_ARGS__)
 
-/* TODO: remove component specific macros from global header */
-/* tracing from component */
-#define _trace_comp_build(fun, class, comp_ptr, format, ...)		\
-		fun(class, comp_ptr->comp.pipeline_id,			\
-		    comp_ptr->comp.id, format, ##__VA_ARGS__)
-
-#define trace_event_comp(...) _trace_comp_build(trace_event_with_ids,	\
-						##__VA_ARGS__)
-#define tracev_event_comp(...) _trace_comp_build(tracev_event_with_ids,	\
-						##__VA_ARGS__)
-#define trace_error_comp(...) _trace_comp_build(trace_error_with_ids,	\
-						##__VA_ARGS__)
 #endif /* __SOF_TRACE_TRACE_H__ */

--- a/src/include/sof/trace/trace.h
+++ b/src/include/sof/trace/trace.h
@@ -15,7 +15,7 @@
 	"Add it to CMake's target with sof_append_relative_path_definitions."
 #endif
 
-#if CONFIG_TRACE
+#if !CONFIG_LIBRARY && CONFIG_TRACE
 #include <platform/trace/trace.h>
 #endif
 #include <sof/common.h>


### PR DESCRIPTION
This is a proposal of the first step towards #2172.

New set of macros with compact names and well known level names mapped to the existing underlying trace implementation is proposed. Work to be continued for other components and dais once accepted. Driver level `_cl_()` macros defined with `drv` argument for completeness of the interface (drv/comp_p->drv to be used in future to retrieve dai/component info addr - see below).

All components' trace classes are reduced to a common TRACE_CLASS_COMPONENT (dais use a common TRACE_CLASS_DAI re-used from the dai component). Fine filtering, if required, still can be 
done in a debug console using trace entry locations. Precise component identification will be restored in the logger tool once uuids are introduced for components and dais, as a much more scalable and conflict-less way to identify them. Adding a dedicated trace class for each individual component and dai and maintaining it as a flat central list does not scale and does not seem as a way to go (while trace classes are still good enough and cheap as a compile time mechanism for parts of the *infrastructure*).

The trace classes are not moved to the context (as proposed in #2172) which would be required by run-time filtering at the TRACE_CLASS level. Such a move also results in replacing compile time mechanism (zero run-time overhead at the dsp side) to run-time (+extra data to transfer with each entry). Perhaps TRACE_CLASS level filtering, done mostly by the *infrastructure developers* could be configured at compile time, so that new overhead is not necessary? While extensive component and dai log filtering could be easily implemented for run-time, using uuids, for *dai driver and processing component developers*?

Note: dai/component info (uuid+nice name+...) will also be stored at compile-time in a debug section copied to the ldc file and used by the logger. So that no uuids, no module names to print do not need to be h/c in the logger and do not need to be kept in run-time dsp memory. Filtering can be done by translating uuid back to debug addresses by the logger and sending them to fw as run-time ids, (+individual instance ids if required for super selective filtering). The pointer to dai/component info retrieved from drv/comp_p->drv and passed to the trace function probably does not have to be sent as a full new dword, just its index in info record array could be computed and packed inside existing entry structure.