### PR TITLE
ASRC: Remove duplicate timestamp request

### DIFF
--- a/src/audio/asrc/asrc.c
+++ b/src/audio/asrc/asrc.c
@@ -739,7 +739,6 @@ static int asrc_control_loop(struct comp_data *cd)
 	delta_sample = sample - cd->sample_prev;
 	cd->ts_prev = ts;
 	cd->sample_prev = sample;
-	asrc_dai_start_timestamp(cd);
 
 	/* Avoid first delta timestamp(s) those can be off and
 	 * confuse the filter.


### PR DESCRIPTION
This patch removes the unnecessary duplicated function call by mistake.
The proper request is done a few lines above the deleted line.
Fortunately this did not cause any issues.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>