### PR TITLE
dma: refactor dma sg buffer descriptors to allow for multiple targets

### DIFF
--- a/src/drivers/generic/dummy-dma.c
+++ b/src/drivers/generic/dummy-dma.c
@@ -329,15 +329,17 @@ static int dummy_dma_status(struct dma_chan_data *channel,
  * the direction and the actual SG elems for copying.
  */
 static int dummy_dma_set_config(struct dma_chan_data *channel,
-				struct dma_sg_config *config)
+				struct dma_sg_config *config,
+				unsigned int sg_index)
 {
 	struct dma_chan_pdata *ch = dma_chan_get_data(channel);
+	struct dma_sg_elem_array *elem_array;
 	uint32_t flags;
 	int ret = 0;
 
 	spin_lock_irq(&channel->dma->lock, flags);
 
-	if (!config->elem_array.count) {
+	if (!config->sg_array.count) {
 		trace_dummydma_error("dummy-dmac: %d channel %d no DMA descriptors",
 				     channel->dma->plat_data.id,
 				     channel->index);
@@ -346,6 +348,7 @@ static int dummy_dma_set_config(struct dma_chan_data *channel,
 		goto out;
 	}
 
+	elem_array = &config->sg_array.elems[sg_index];
 	channel->direction = config->direction;
 
 	if (config->direction != DMA_DIR_HMEM_TO_LMEM &&
@@ -357,8 +360,8 @@ static int dummy_dma_set_config(struct dma_chan_data *channel,
 		ret = -EINVAL;
 		goto out;
 	}
-	channel->desc_count = config->elem_array.count;
-	ch->elems = &config->elem_array;
+	channel->desc_count = elem_array->count;
+	ch->elems = elem_array;
 	ch->sg_elem_curr_idx = 0;
 	ch->cyclic = config->cyclic;
 

--- a/src/drivers/intel/baytrail/ssp.c
+++ b/src/drivers/intel/baytrail/ssp.c
@@ -620,14 +620,28 @@ static int ssp_probe(struct dai *dai)
 	return 0;
 }
 
-static int ssp_get_handshake(struct dai *dai, int direction, int stream_id)
+static int ssp_get_handshake(struct dai *dai, int direction, int id)
 {
 	return dai->plat_data.fifo[direction].handshake;
 }
 
-static int ssp_get_fifo(struct dai *dai, int direction, int stream_id)
+static int ssp_get_fifo(struct dai *dai, int direction, int id)
 {
 	return dai->plat_data.fifo[direction].offset;
+}
+
+static int ssp_gen_dma_elem_array(struct dai *dai, int direction, int id,
+				  int periods, int period_bytes,
+				  uintptr_t buffer,
+				  struct dma_sg_array *sg_array)
+{
+	int ret = dma_sg_array_alloc(sg_array, 1, SOF_MEM_ZONE_RUNTIME);
+
+	if (ret)
+		return ret;
+
+	return dai_gen_dma_sg_elems(dai, direction, id, periods, period_bytes,
+				    buffer, &sg_array->elems[0]);
 }
 
 const struct dai_driver ssp_driver = {
@@ -642,6 +656,7 @@ const struct dai_driver ssp_driver = {
 		.get_hw_params		= ssp_get_hw_params,
 		.get_handshake		= ssp_get_handshake,
 		.get_fifo		= ssp_get_fifo,
+		.gen_dma_elem_array	= ssp_gen_dma_elem_array,
 		.probe			= ssp_probe,
 	},
 };

--- a/src/drivers/intel/cavs/alh.c
+++ b/src/drivers/intel/cavs/alh.c
@@ -91,6 +91,20 @@ static int alh_get_fifo(struct dai *dai, int direction, int stream_id)
 	return ALH_BASE + offset + ALH_STREAM_OFFSET * stream_id;
 }
 
+static int alh_gen_dma_elem_array(struct dai *dai, int direction, int id,
+				  int periods, int period_bytes,
+				  uintptr_t buffer,
+				  struct dma_sg_array *sg_array)
+{
+	int ret = dma_sg_array_alloc(sg_array, 1, SOF_MEM_ZONE_RUNTIME);
+
+	if (ret)
+		return ret;
+
+	return dai_gen_dma_sg_elems(dai, direction, id, periods, period_bytes,
+				    buffer, &sg_array->elems[0]);
+}
+
 const struct dai_driver alh_driver = {
 	.type = SOF_DAI_INTEL_ALH,
 	.dma_caps = DMA_CAP_GP_LP | DMA_CAP_GP_HP,
@@ -103,6 +117,7 @@ const struct dai_driver alh_driver = {
 		.get_hw_params		= alh_get_hw_params,
 		.get_handshake		= alh_get_handshake,
 		.get_fifo		= alh_get_fifo,
+		.gen_dma_elem_array	= alh_gen_dma_elem_array,
 		.probe			= alh_probe,
 		.remove			= alh_remove,
 	},

--- a/src/drivers/intel/cavs/dmic.c
+++ b/src/drivers/intel/cavs/dmic.c
@@ -1599,14 +1599,28 @@ static int dmic_remove(struct dai *dai)
 	return 0;
 }
 
-static int dmic_get_handshake(struct dai *dai, int direction, int stream_id)
+static int dmic_get_handshake(struct dai *dai, int direction, int id)
 {
 	return dai->plat_data.fifo[SOF_IPC_STREAM_CAPTURE].handshake;
 }
 
-static int dmic_get_fifo(struct dai *dai, int direction, int stream_id)
+static int dmic_get_fifo(struct dai *dai, int direction, int id)
 {
 	return dai->plat_data.fifo[SOF_IPC_STREAM_CAPTURE].offset;
+}
+
+static int dmic_gen_dma_elem_array(struct dai *dai, int direction, int id,
+				   int periods, int period_bytes,
+				   uintptr_t buffer,
+				   struct dma_sg_array *sg_array)
+{
+	int ret = dma_sg_array_alloc(sg_array, 1, SOF_MEM_ZONE_RUNTIME);
+
+	if (ret)
+		return ret;
+
+	return dai_gen_dma_sg_elems(dai, direction, id, periods, period_bytes,
+				    buffer, &sg_array->elems[0]);
 }
 
 /* Functions for HW timestamp */
@@ -1720,6 +1734,7 @@ const struct dai_driver dmic_driver = {
 		.pm_context_restore	= dmic_context_restore,
 		.get_handshake		= dmic_get_handshake,
 		.get_fifo		= dmic_get_fifo,
+		.gen_dma_elem_array	= dmic_gen_dma_elem_array,
 		.probe			= dmic_probe,
 		.remove			= dmic_remove,
 	},

--- a/src/drivers/intel/cavs/hda.c
+++ b/src/drivers/intel/cavs/hda.c
@@ -51,6 +51,20 @@ static int hda_get_fifo(struct dai *dai, int direction, int stream_id)
 	return 0;
 }
 
+static int hda_gen_dma_elem_array(struct dai *dai, int direction, int id,
+				  int periods, int period_bytes,
+				  uintptr_t buffer,
+				  struct dma_sg_array *sg_array)
+{
+	int ret = dma_sg_array_alloc(sg_array, 1, SOF_MEM_ZONE_RUNTIME);
+
+	if (ret)
+		return ret;
+
+	return dai_gen_dma_sg_elems(dai, direction, id, periods, period_bytes,
+				    buffer, &sg_array->elems[0]);
+}
+
 /* Functions for HW timestamp */
 
 static inline uint32_t hda_ts_local_tsctrl_addr(void)
@@ -169,6 +183,7 @@ const struct dai_driver hda_driver = {
 		.get_hw_params		= hda_get_hw_params,
 		.get_handshake		= hda_get_handshake,
 		.get_fifo		= hda_get_fifo,
+		.gen_dma_elem_array	= hda_gen_dma_elem_array,
 		.probe			= hda_dummy,
 		.remove			= hda_dummy,
 	},

--- a/src/drivers/intel/cavs/ssp.c
+++ b/src/drivers/intel/cavs/ssp.c
@@ -816,14 +816,28 @@ static int ssp_remove(struct dai *dai)
 	return 0;
 }
 
-static int ssp_get_handshake(struct dai *dai, int direction, int stream_id)
+static int ssp_get_handshake(struct dai *dai, int direction, int id)
 {
 	return dai->plat_data.fifo[direction].handshake;
 }
 
-static int ssp_get_fifo(struct dai *dai, int direction, int stream_id)
+static int ssp_get_fifo(struct dai *dai, int direction, int id)
 {
 	return dai->plat_data.fifo[direction].offset;
+}
+
+static int ssp_gen_dma_elem_array(struct dai *dai, int direction, int id,
+				  int periods, int period_bytes,
+				  uintptr_t buffer,
+				  struct dma_sg_array *sg_array)
+{
+	int ret = dma_sg_array_alloc(sg_array, 1, SOF_MEM_ZONE_RUNTIME);
+
+	if (ret)
+		return ret;
+
+	return dai_gen_dma_sg_elems(dai, direction, id, periods, period_bytes,
+				    buffer, &sg_array->elems[0]);
 }
 
 /* Functions for HW timestamp */
@@ -992,6 +1006,7 @@ const struct dai_driver ssp_driver = {
 		.get_hw_params		= ssp_get_hw_params,
 		.get_handshake		= ssp_get_handshake,
 		.get_fifo		= ssp_get_fifo,
+		.gen_dma_elem_array	= ssp_gen_dma_elem_array,
 		.probe			= ssp_probe,
 		.remove			= ssp_remove,
 	},

--- a/src/drivers/intel/haswell/ssp.c
+++ b/src/drivers/intel/haswell/ssp.c
@@ -536,14 +536,28 @@ static int ssp_probe(struct dai *dai)
 	return 0;
 }
 
-static int ssp_get_handshake(struct dai *dai, int direction, int stream_id)
+static int ssp_get_handshake(struct dai *dai, int direction, int id)
 {
 	return dai->plat_data.fifo[direction].handshake;
 }
 
-static int ssp_get_fifo(struct dai *dai, int direction, int stream_id)
+static int ssp_get_fifo(struct dai *dai, int direction, int id)
 {
 	return dai->plat_data.fifo[direction].offset;
+}
+
+static int ssp_gen_dma_elem_array(struct dai *dai, int direction, int id,
+				  int periods, int period_bytes,
+				  uintptr_t buffer,
+				  struct dma_sg_array *sg_array)
+{
+	int ret = dma_sg_array_alloc(sg_array, 1, SOF_MEM_ZONE_RUNTIME);
+
+	if (ret)
+		return ret;
+
+	return dai_gen_dma_sg_elems(dai, direction, id, periods, period_bytes,
+				    buffer, &sg_array->elems[0]);
 }
 
 const struct dai_driver ssp_driver = {
@@ -558,6 +572,7 @@ const struct dai_driver ssp_driver = {
 		.get_hw_params		= ssp_get_hw_params,
 		.get_handshake		= ssp_get_handshake,
 		.get_fifo		= ssp_get_fifo,
+		.gen_dma_elem_array	= ssp_gen_dma_elem_array,
 		.probe			= ssp_probe,
 	},
 };

--- a/src/trace/dma-trace.c
+++ b/src/trace/dma-trace.c
@@ -111,7 +111,7 @@ int dma_trace_init_early(struct sof *sof)
 {
 	sof->dmat = rzalloc(SOF_MEM_ZONE_SYS, SOF_MEM_FLAG_SHARED,
 			    SOF_MEM_CAPS_RAM, sizeof(*sof->dmat));
-	dma_sg_init(&sof->dmat->config.elem_array);
+	dma_sg_init(&sof->dmat->config.sg_array);
 	spinlock_init(&sof->dmat->lock);
 
 	ipc_build_trace_posn(&sof->dmat->posn);
@@ -164,7 +164,7 @@ int dma_trace_host_buffer(struct dma_trace_data *d,
 			  uint32_t host_size)
 {
 	d->host_size = host_size;
-	d->config.elem_array = *elem_array;
+	d->config.sg_array.elems[0] = *elem_array;
 
 	platform_shared_commit(d, sizeof(*d));
 
@@ -231,13 +231,18 @@ static int dma_trace_start(struct dma_trace_data *d)
 	config.dest_width = sizeof(uint32_t);
 	config.cyclic = 0;
 
-	err = dma_sg_alloc(&config.elem_array, SOF_MEM_ZONE_SYS,
-			   config.direction,
-			   elem_num, elem_size, elem_addr, 0);
+	err = dma_sg_array_alloc(&config.sg_array, 1, SOF_MEM_ZONE_SYS);
+
+	if (!err) {
+		err = dma_sg_alloc(&config.sg_array.elems[0], SOF_MEM_ZONE_SYS,
+				   config.direction, elem_num, elem_size,
+				   elem_addr, 0);
+	}
+
 	if (err < 0)
 		return err;
 
-	err = dma_set_config(d->dc.chan, &config);
+	err = dma_set_config(d->dc.chan, &config, 0);
 	if (err < 0)
 		return err;
 

--- a/tools/testbench/common_test.c
+++ b/tools/testbench/common_test.c
@@ -205,6 +205,20 @@ void dma_put(struct dma *dma)
 {
 }
 
+int dai_gen_dma_sg_elems(struct dai *dai, int direction, int id,
+			 int periods, int period_bytes,
+			 uintptr_t buffer,
+			 struct dma_sg_elem_array *elem_array)
+{
+	return 0;
+}
+
+int dma_sg_array_alloc(struct dma_sg_array *sg_array, int count,
+		       enum mem_zone zone)
+{
+	return 0;
+}
+
 int dma_sg_alloc(struct dma_sg_elem_array *elem_array,
 		 enum mem_zone zone,
 		 uint32_t direction,
@@ -214,7 +228,11 @@ int dma_sg_alloc(struct dma_sg_elem_array *elem_array,
 	return 0;
 }
 
-void dma_sg_free(struct dma_sg_elem_array *elem_array)
+void dma_sg_free(struct dma_sg_array *sg_array)
+{
+}
+
+void dma_sg_elems_free(struct dma_sg_elem_array *elem_array)
 {
 }
 


### PR DESCRIPTION
This changes the way dma buffer descriptors are stored,
now they allow to have separate descriptors for each physical link.
It's required for multi-link dais/dmas, such as multidai/multidma.

This also moves the code responsible for generating descriptors into
dai drivers, in the form of a new op. This way, the drivers will be able
to dictate the structure of the descriptors.