### PR TITLE
component: add possibility of executing single components on other cores

### DIFF
--- a/src/audio/asrc/asrc.c
+++ b/src/audio/asrc/asrc.c
@@ -274,6 +274,8 @@ static struct comp_dev *asrc_new(const struct comp_driver *drv,
 		return NULL;
 	dev->drv = drv;
 
+	dev->size = COMP_SIZE(struct sof_ipc_comp_asrc);
+
 	asrc = COMP_GET_IPC(dev, sof_ipc_comp_asrc);
 	err = memcpy_s(asrc, sizeof(*asrc), ipc_asrc,
 		       sizeof(struct sof_ipc_comp_asrc));

--- a/src/audio/buffer.c
+++ b/src/audio/buffer.c
@@ -144,7 +144,7 @@ void buffer_free(struct comp_buffer *buffer)
 
 void comp_update_buffer_produce(struct comp_buffer *buffer, uint32_t bytes)
 {
-	uint32_t flags;
+	uint32_t flags = 0;
 	struct buffer_cb_transact cb_data = {
 		.buffer = buffer,
 		.transaction_amount = bytes,
@@ -163,14 +163,14 @@ void comp_update_buffer_produce(struct comp_buffer *buffer, uint32_t bytes)
 		return;
 	}
 
-	irq_local_disable(flags);
+	buffer_lock(buffer, flags);
 
 	audio_stream_produce(&buffer->stream, bytes);
 
 	notifier_event(buffer, NOTIFIER_ID_BUFFER_PRODUCE,
 		       NOTIFIER_TARGET_CORE_LOCAL, &cb_data, sizeof(cb_data));
 
-	irq_local_enable(flags);
+	buffer_unlock(buffer, flags);
 
 	addr = buffer->stream.addr;
 
@@ -187,7 +187,7 @@ void comp_update_buffer_produce(struct comp_buffer *buffer, uint32_t bytes)
 
 void comp_update_buffer_consume(struct comp_buffer *buffer, uint32_t bytes)
 {
-	uint32_t flags;
+	uint32_t flags = 0;
 	struct buffer_cb_transact cb_data = {
 		.buffer = buffer,
 		.transaction_amount = bytes,
@@ -206,14 +206,14 @@ void comp_update_buffer_consume(struct comp_buffer *buffer, uint32_t bytes)
 		return;
 	}
 
-	irq_local_disable(flags);
+	buffer_lock(buffer, flags);
 
 	audio_stream_consume(&buffer->stream, bytes);
 
 	notifier_event(buffer, NOTIFIER_ID_BUFFER_CONSUME,
 		       NOTIFIER_TARGET_CORE_LOCAL, &cb_data, sizeof(cb_data));
 
-	irq_local_enable(flags);
+	buffer_unlock(buffer, flags);
 
 	addr = buffer->stream.addr;
 

--- a/src/audio/buffer.c
+++ b/src/audio/buffer.c
@@ -81,6 +81,8 @@ struct comp_buffer *buffer_new(struct sof_ipc_buffer *desc)
 		buffer->id = desc->comp.id;
 		buffer->pipeline_id = desc->comp.pipeline_id;
 		buffer->core = desc->comp.core;
+
+		dcache_writeback_invalidate_region(buffer, sizeof(*buffer));
 	}
 
 	return buffer;

--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -196,22 +196,14 @@ void sys_comp_init(struct sof *sof)
 	platform_shared_commit(sof->comp_drivers, sizeof(*sof->comp_drivers));
 }
 
-int comp_get_copy_limits(struct comp_dev *dev, struct comp_copy_limits *cl)
+void comp_get_copy_limits(struct comp_buffer *source, struct comp_buffer *sink,
+			  struct comp_copy_limits *cl)
 {
-	/* Get source and sink buffer addresses */
-	cl->source = list_first_item(&dev->bsource_list, struct comp_buffer,
-				     sink_list);
-	cl->sink = list_first_item(&dev->bsink_list, struct comp_buffer,
-				   source_list);
-
-	cl->frames = audio_stream_avail_frames(&cl->source->stream,
-					       &cl->sink->stream);
-	cl->source_frame_bytes = audio_stream_frame_bytes(&cl->source->stream);
-	cl->sink_frame_bytes = audio_stream_frame_bytes(&cl->sink->stream);
+	cl->frames = audio_stream_avail_frames(&source->stream, &sink->stream);
+	cl->source_frame_bytes = audio_stream_frame_bytes(&source->stream);
+	cl->sink_frame_bytes = audio_stream_frame_bytes(&sink->stream);
 	cl->source_bytes = cl->frames * cl->source_frame_bytes;
 	cl->sink_bytes = cl->frames * cl->sink_frame_bytes;
-
-	return 0;
 }
 
 /* Function overwrites PCM parameters (frame_fmt, buffer_fmt, channels, rate)

--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -241,9 +241,11 @@ int comp_verify_params(struct comp_dev *dev, uint32_t flag,
 	struct list_item *source_list;
 	struct list_item *sink_list;
 	struct list_item *clist;
+	struct list_item *curr;
 	struct comp_buffer *sinkb;
 	struct comp_buffer *buf;
 	int dir = dev->direction;
+	uint32_t flags = 0;
 
 	if (!params) {
 		comp_err(dev, "comp_verify_params() error: !params");
@@ -266,6 +268,8 @@ int comp_verify_params(struct comp_dev *dev, uint32_t flag,
 					      struct comp_buffer,
 					      source_list);
 
+		buffer_lock(buf, flags);
+
 		/* update specific pcm parameter with buffer parameter if
 		 * specific flag is set.
 		 */
@@ -278,26 +282,40 @@ int comp_verify_params(struct comp_dev *dev, uint32_t flag,
 
 		/* set component period frames */
 		component_set_period_frames(dev, buf->stream.rate);
+
+		buffer_unlock(buf, flags);
 	} else {
 		/* for other components we iterate over all downstream buffers
 		 * (for playback) or upstream buffers (for capture).
 		 */
 		buffer_list = comp_buffer_list(dev, dir);
+		clist = buffer_list->next;
 
-		list_for_item(clist, buffer_list) {
-			buf = buffer_from_list(clist, struct comp_buffer,
-					       dir);
+		while (clist != buffer_list) {
+			curr = clist;
+
+			buf = buffer_from_list(curr, struct comp_buffer, dir);
+
+			buffer_lock(buf, flags);
+
+			clist = clist->next;
 
 			comp_update_params(flag, params, buf);
 
 			buffer_set_params(buf, params, BUFFER_UPDATE_FORCE);
+
+			buffer_unlock(buf, flags);
 		}
 
 		/* fetch sink buffer in order to calculate period frames */
 		sinkb = list_first_item(&dev->bsink_list, struct comp_buffer,
 					source_list);
 
+		buffer_lock(sinkb, flags);
+
 		component_set_period_frames(dev, sinkb->stream.rate);
+
+		buffer_unlock(sinkb, flags);
 	}
 
 	return 0;

--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -646,6 +646,7 @@ static int dai_copy(struct comp_dev *dev)
 	uint32_t src_samples;
 	uint32_t sink_samples;
 	int ret = 0;
+	uint32_t flags = 0;
 
 	comp_dbg(dev, "dai_copy()");
 
@@ -655,6 +656,8 @@ static int dai_copy(struct comp_dev *dev)
 		dai_report_xrun(dev, 0);
 		return ret;
 	}
+
+	buffer_lock(dd->local_buffer, flags);
 
 	/* calculate minimum size to copy */
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK) {
@@ -670,6 +673,8 @@ static int dai_copy(struct comp_dev *dev)
 		copy_bytes = MIN(src_samples, sink_samples) *
 			sample_bytes(dd->frame_fmt);
 	}
+
+	buffer_unlock(dd->local_buffer, flags);
 
 	comp_dbg(dev, "dai_copy(), copy_bytes = 0x%x", copy_bytes);
 

--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -136,6 +136,8 @@ static struct comp_dev *dai_new(const struct comp_driver *drv,
 		return NULL;
 	dev->drv = drv;
 
+	dev->size = COMP_SIZE(struct sof_ipc_comp_dai);
+
 	dai = COMP_GET_IPC(dev, sof_ipc_comp_dai);
 	ret = memcpy_s(dai, sizeof(*dai), ipc_dai,
 		       sizeof(struct sof_ipc_comp_dai));

--- a/src/audio/detect_test.c
+++ b/src/audio/detect_test.c
@@ -308,6 +308,8 @@ static struct comp_dev *test_keyword_new(const struct comp_driver *drv,
 		return NULL;
 	dev->drv = drv;
 
+	dev->size = COMP_SIZE(struct sof_ipc_comp_process);
+
 	keyword = COMP_GET_IPC(dev, sof_ipc_comp_process);
 	ret = memcpy_s(keyword, sizeof(*keyword), ipc_keyword,
 		       sizeof(struct sof_ipc_comp_process));

--- a/src/audio/detect_test.c
+++ b/src/audio/detect_test.c
@@ -720,6 +720,8 @@ static int test_keyword_copy(struct comp_dev *dev)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 	struct comp_buffer *source;
+	uint32_t frames;
+	uint32_t flags = 0;
 
 	comp_dbg(dev, "test_keyword_copy()");
 
@@ -727,11 +729,14 @@ static int test_keyword_copy(struct comp_dev *dev)
 	source = list_first_item(&dev->bsource_list,
 				 struct comp_buffer, sink_list);
 
+	buffer_lock(source, flags);
+	frames = source->stream.avail /
+		audio_stream_frame_bytes(&source->stream);
+	buffer_unlock(source, flags);
+
 	/* copy and perform detection */
 	buffer_invalidate(source, source->stream.avail);
-	cd->detect_func(dev, &source->stream,
-			source->stream.avail /
-			audio_stream_frame_bytes(&source->stream));
+	cd->detect_func(dev, &source->stream, frames);
 
 	/* calc new available */
 	comp_update_buffer_consume(source, source->stream.avail);

--- a/src/audio/detect_test.c
+++ b/src/audio/detect_test.c
@@ -728,6 +728,7 @@ static int test_keyword_copy(struct comp_dev *dev)
 				 struct comp_buffer, sink_list);
 
 	/* copy and perform detection */
+	buffer_invalidate(source, source->stream.avail);
 	cd->detect_func(dev, &source->stream,
 			source->stream.avail /
 			audio_stream_frame_bytes(&source->stream));

--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -417,6 +417,8 @@ static struct comp_dev *eq_fir_new(const struct comp_driver *drv,
 		return NULL;
 	dev->drv = drv;
 
+	dev->size = COMP_SIZE(struct sof_ipc_comp_process);
+
 	fir = COMP_GET_IPC(dev, sof_ipc_comp_process);
 	ret = memcpy_s(fir, sizeof(*fir), ipc_fir,
 		       sizeof(struct sof_ipc_comp_process));

--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -714,6 +714,7 @@ static int eq_fir_copy(struct comp_dev *dev)
 	struct comp_data *cd = comp_get_drvdata(dev);
 	int ret;
 	int n;
+	uint32_t flags = 0;
 
 	comp_dbg(dev, "eq_fir_copy()");
 
@@ -735,8 +736,14 @@ static int eq_fir_copy(struct comp_dev *dev)
 	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer,
 				source_list);
 
+	buffer_lock(sourceb, flags);
+	buffer_lock(sinkb, flags);
+
 	/* Get source, sink, number of frames etc. to process. */
 	comp_get_copy_limits(sourceb, sinkb, &cl);
+
+	buffer_unlock(sinkb, flags);
+	buffer_unlock(sourceb, flags);
 
 	/*
 	 * Process only even number of frames with the FIR function. The

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -784,6 +784,7 @@ static int eq_iir_copy(struct comp_dev *dev)
 	struct comp_copy_limits cl;
 	struct comp_data *cd = comp_get_drvdata(dev);
 	struct comp_buffer *sourceb;
+	struct comp_buffer *sinkb;
 	int ret;
 
 	comp_dbg(dev, "eq_iir_copy()");
@@ -803,19 +804,18 @@ static int eq_iir_copy(struct comp_dev *dev)
 		}
 	}
 
+	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer,
+				source_list);
+
 	/* Get source, sink, number of frames etc. to process. */
-	ret = comp_get_copy_limits(dev, &cl);
-	if (ret < 0) {
-		comp_err(dev, "eq_iir_copy(), failed comp_get_copy_limits()");
-		return ret;
-	}
+	comp_get_copy_limits(sourceb, sinkb, &cl);
 
 	/* Run EQ function */
-	cd->eq_iir_func(dev, &cl.source->stream, &cl.sink->stream, cl.frames);
+	cd->eq_iir_func(dev, &sourceb->stream, &sinkb->stream, cl.frames);
 
 	/* calc new free and available */
-	comp_update_buffer_consume(cl.source, cl.source_bytes);
-	comp_update_buffer_produce(cl.sink, cl.sink_bytes);
+	comp_update_buffer_consume(sourceb, cl.source_bytes);
+	comp_update_buffer_produce(sinkb, cl.sink_bytes);
 
 	return 0;
 }

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -523,6 +523,8 @@ static struct comp_dev *eq_iir_new(const struct comp_driver *drv,
 		return NULL;
 	dev->drv = drv;
 
+	dev->size = COMP_SIZE(struct sof_ipc_comp_process);
+
 	iir = COMP_GET_IPC(dev, sof_ipc_comp_process);
 	ret = memcpy_s(iir, sizeof(*iir), ipc_iir,
 		       sizeof(struct sof_ipc_comp_process));

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -803,6 +803,7 @@ static int eq_iir_copy(struct comp_dev *dev)
 	struct comp_buffer *sourceb;
 	struct comp_buffer *sinkb;
 	int ret;
+	uint32_t flags = 0;
 
 	comp_dbg(dev, "eq_iir_copy()");
 
@@ -824,8 +825,14 @@ static int eq_iir_copy(struct comp_dev *dev)
 	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer,
 				source_list);
 
+	buffer_lock(sourceb, flags);
+	buffer_lock(sinkb, flags);
+
 	/* Get source, sink, number of frames etc. to process. */
 	comp_get_copy_limits(sourceb, sinkb, &cl);
+
+	buffer_unlock(sinkb, flags);
+	buffer_unlock(sourceb, flags);
 
 	/* Run EQ function */
 	eq_iir_process(dev, sourceb, sinkb, cl.frames, cl.source_bytes,

--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -683,13 +683,18 @@ static uint32_t host_buffer_get_copy_bytes(struct comp_dev *dev)
 	uint32_t copy_bytes = 0;
 	uint32_t split_value;
 	int ret;
+	uint32_t flags = 0;
 
 	if (hd->copy_type == COMP_COPY_ONE_SHOT) {
+		buffer_lock(hd->local_buffer, flags);
+
 		/* calculate minimum size to copy */
 		if (dev->direction == SOF_IPC_STREAM_PLAYBACK)
 			copy_bytes = hd->local_buffer->stream.free;
 		else
 			copy_bytes = hd->local_buffer->stream.avail;
+
+		buffer_unlock(hd->local_buffer, flags);
 
 		/* copy_bytes should be aligned to minimum possible chunk of
 		 * data to be copied by dma.
@@ -711,6 +716,8 @@ static uint32_t host_buffer_get_copy_bytes(struct comp_dev *dev)
 			return 0;
 		}
 
+		buffer_lock(hd->local_buffer, flags);
+
 		/* calculate minimum size to copy */
 		if (dev->direction == SOF_IPC_STREAM_PLAYBACK)
 			copy_bytes = MIN(avail_bytes,
@@ -718,6 +725,8 @@ static uint32_t host_buffer_get_copy_bytes(struct comp_dev *dev)
 		else
 			copy_bytes = MIN(hd->local_buffer->stream.avail,
 					 free_bytes);
+
+		buffer_unlock(hd->local_buffer, flags);
 
 		/* copy_bytes should be aligned to minimum possible chunk of
 		 * data to be copied by dma.

--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -330,6 +330,8 @@ static struct comp_dev *host_new(const struct comp_driver *drv,
 		return NULL;
 	dev->drv = drv;
 
+	dev->size = COMP_SIZE(struct sof_ipc_comp_host);
+
 	host = COMP_GET_IPC(dev, sof_ipc_comp_host);
 	ret = memcpy_s(host, sizeof(*host),
 		       ipc_host, sizeof(struct sof_ipc_comp_host));

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -129,6 +129,8 @@ static struct comp_dev *kpb_new(const struct comp_driver *drv,
 		return NULL;
 	dev->drv = drv;
 
+	dev->size = COMP_SIZE(struct sof_ipc_comp_process);
+
 	ret = memcpy_s(COMP_GET_IPC(dev, sof_ipc_comp_process),
 		       sizeof(struct sof_ipc_comp_process),
 		       comp, sizeof(struct sof_ipc_comp_process));

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -124,6 +124,8 @@ static struct comp_dev *mixer_new(const struct comp_driver *drv,
 		return NULL;
 	dev->drv = drv;
 
+	dev->size = COMP_SIZE(struct sof_ipc_comp_mixer);
+
 	mixer = COMP_GET_IPC(dev, sof_ipc_comp_mixer);
 
 	ret = memcpy_s(mixer, sizeof(*mixer), ipc_mixer,

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -327,10 +327,14 @@ static int mixer_copy(struct comp_dev *dev)
 		 source_bytes, sink_bytes);
 
 	/* mix streams */
-	md->mix_func(dev, &sink->stream, sources_stream, i, frames);
+	for (i = num_mix_sources - 1; i >= 0; i--)
+		buffer_invalidate(sources[i], source_bytes);
+	md->mix_func(dev, &sink->stream, sources_stream, num_mix_sources,
+		     frames);
+	buffer_writeback(sink, sink_bytes);
 
 	/* update source buffer pointers */
-	for (i = --num_mix_sources; i >= 0; i--)
+	for (i = num_mix_sources - 1; i >= 0; i--)
 		comp_update_buffer_consume(sources[i], source_bytes);
 
 	/* update sink buffer pointer */

--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -95,6 +95,8 @@ static struct comp_dev *mux_new(const struct comp_driver *drv,
 		return NULL;
 	dev->drv = drv;
 
+	dev->size = COMP_SIZE(struct sof_ipc_comp_process);
+
 	memcpy_s(COMP_GET_IPC(dev, sof_ipc_comp_process),
 		 sizeof(struct sof_ipc_comp_process),
 		 comp, sizeof(struct sof_ipc_comp_process));

--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -330,8 +330,10 @@ static int demux_copy(struct comp_dev *dev)
 		if (!sinks[i])
 			continue;
 
+		buffer_invalidate(source, source_bytes);
 		cd->demux(dev, &sinks[i]->stream, &source->stream, frames,
 			  &cd->config.streams[i]);
+		buffer_writeback(sinks[i], sinks_bytes[i]);
 	}
 
 	/* update components */
@@ -397,12 +399,14 @@ static int mux_copy(struct comp_dev *dev)
 			continue;
 		sources_bytes[i] = frames *
 				   audio_stream_frame_bytes(sources_stream[i]);
+		buffer_invalidate(sources[i], sources_bytes[i]);
 	}
 	sink_bytes = frames * audio_stream_frame_bytes(&sink->stream);
 
 	/* produce output */
 	cd->mux(dev, &sink->stream, &sources_stream[0], frames,
 		&cd->config.streams[0]);
+	buffer_writeback(sink, sink_bytes);
 
 	/* update components */
 	comp_update_buffer_produce(sink, sink_bytes);

--- a/src/audio/pipeline.c
+++ b/src/audio/pipeline.c
@@ -274,6 +274,7 @@ static int pipeline_comp_hw_params(struct comp_dev *current,
 {
 	struct pipeline_data *ppl_data = data;
 	int ret = 0;
+	uint32_t flags = 0;
 
 	pipe_cl_dbg("pipeline_comp_hw_params(), current->comp.id = %u, dir = %u",
 		    dev_comp_id(current), dir);
@@ -292,9 +293,12 @@ static int pipeline_comp_hw_params(struct comp_dev *current,
 	}
 
 	/* set buffer parameters */
-	if (calling_buf)
+	if (calling_buf) {
+		buffer_lock(calling_buf, flags);
 		buffer_set_params(calling_buf, &ppl_data->params->params,
 				  BUFFER_UPDATE_IF_UNSET);
+		buffer_unlock(calling_buf, flags);
+	}
 
 	return ret;
 }

--- a/src/audio/pipeline.c
+++ b/src/audio/pipeline.c
@@ -143,6 +143,8 @@ static int pipeline_comp_complete(struct comp_dev *current,
 
 	/* complete component init */
 	current->pipeline = ppl_data->p;
+	current->period = ppl_data->p->ipc_pipe.period;
+	current->priority = ppl_data->p->ipc_pipe.priority;
 
 	pipeline_for_each_comp(current, &pipeline_comp_complete, data,
 			       NULL, NULL, dir);

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -102,6 +102,7 @@ static int selector_verify_params(struct comp_dev *dev,
 	struct comp_buffer *sinkb;
 	uint32_t in_channels;
 	uint32_t out_channels;
+	uint32_t flags = 0;
 
 	comp_dbg(dev, "selector_verify_params()");
 
@@ -125,6 +126,8 @@ static int selector_verify_params(struct comp_dev *dev,
 		}
 		in_channels = cd->config.in_channels_count;
 
+		buffer_lock(buffer, flags);
+
 		/* if cd->config.out_channels_count are equal to 0
 		 * (it can vary), we set params->channels to sink buffer
 		 * channels, which were previosly set in
@@ -144,6 +147,8 @@ static int selector_verify_params(struct comp_dev *dev,
 		}
 		out_channels = cd->config.out_channels_count;
 
+		buffer_lock(buffer, flags);
+
 		/* if cd->config.in_channels_count are equal to 0
 		 * (it can vary), we set params->channels to source buffer
 		 * channels, which were previosly set in
@@ -159,6 +164,8 @@ static int selector_verify_params(struct comp_dev *dev,
 
 	/* set component period frames */
 	component_set_period_frames(dev, sinkb->stream.rate);
+
+	buffer_unlock(buffer, flags);
 
 	/* verify input channels */
 	switch (in_channels) {
@@ -370,6 +377,7 @@ static int selector_copy(struct comp_dev *dev)
 	uint32_t frames;
 	uint32_t source_bytes;
 	uint32_t sink_bytes;
+	uint32_t flags = 0;
 
 	comp_dbg(dev, "selector_copy()");
 
@@ -379,9 +387,15 @@ static int selector_copy(struct comp_dev *dev)
 	sink = list_first_item(&dev->bsink_list, struct comp_buffer,
 			       source_list);
 
+	buffer_lock(source, flags);
+	buffer_lock(sink, flags);
+
 	frames = audio_stream_avail_frames(&source->stream, &sink->stream);
 	source_bytes = frames * audio_stream_frame_bytes(&source->stream);
 	sink_bytes = frames * audio_stream_frame_bytes(&sink->stream);
+
+	buffer_unlock(sink, flags);
+	buffer_unlock(source, flags);
 
 	comp_dbg(dev, "selector_copy(), source_bytes = 0x%x, sink_bytes = 0x%x",
 		 source_bytes, sink_bytes);

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -387,7 +387,9 @@ static int selector_copy(struct comp_dev *dev)
 		 source_bytes, sink_bytes);
 
 	/* copy selected channels from in to out */
+	buffer_invalidate(source, source_bytes);
 	cd->sel_func(dev, &sink->stream, &source->stream, frames);
+	buffer_writeback(sink, sink_bytes);
 
 	/* calculate new free and available */
 	comp_update_buffer_produce(sink, sink_bytes);

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -58,6 +58,8 @@ static struct comp_dev *selector_new(const struct comp_driver *drv,
 		return NULL;
 	dev->drv = drv;
 
+	dev->size = COMP_SIZE(struct sof_ipc_comp_process);
+
 	ret = memcpy_s(COMP_GET_IPC(dev, sof_ipc_comp_process),
 		       sizeof(struct sof_ipc_comp_process), comp,
 		       sizeof(struct sof_ipc_comp_process));

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -469,6 +469,8 @@ static struct comp_dev *src_new(const struct comp_driver *drv,
 		return NULL;
 	dev->drv = drv;
 
+	dev->size = COMP_SIZE(struct sof_ipc_comp_src);
+
 	src = COMP_GET_IPC(dev, sof_ipc_comp_src);
 
 	ret = memcpy_s(src, sizeof(*src), ipc_src,

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -767,6 +767,7 @@ static int src_copy(struct comp_dev *dev)
 	struct comp_buffer *source;
 	struct comp_buffer *sink;
 	int ret;
+	uint32_t flags = 0;
 
 	comp_dbg(dev, "src_copy()");
 
@@ -776,11 +777,18 @@ static int src_copy(struct comp_dev *dev)
 	sink = list_first_item(&dev->bsink_list, struct comp_buffer,
 			       source_list);
 
+	buffer_lock(source, flags);
+	buffer_lock(sink, flags);
+
 	/* Get from buffers and SRC conversion specific block constraints
 	 * how many frames can be processed. If sufficient number of samples
 	 * is not available the processing is omitted.
 	 */
 	ret = src_get_copy_limits(cd, source, sink);
+
+	buffer_unlock(sink, flags);
+	buffer_unlock(source, flags);
+
 	if (ret) {
 		comp_info(dev, "No data to process.");
 		return PPL_STATUS_PATH_STOP;

--- a/src/audio/tone.c
+++ b/src/audio/tone.c
@@ -622,6 +622,7 @@ static int tone_copy(struct comp_dev *dev)
 	if (sink->stream.free >= cd->period_bytes) {
 		/* create tone */
 		cd->tone_func(dev, &sink->stream, dev->frames);
+		buffer_writeback(sink, cd->period_bytes);
 
 		/* calc new free and available */
 		comp_update_buffer_produce(sink, cd->period_bytes);

--- a/src/audio/tone.c
+++ b/src/audio/tone.c
@@ -384,6 +384,8 @@ static struct comp_dev *tone_new(const struct comp_driver *drv,
 		return NULL;
 	dev->drv = drv;
 
+	dev->size = COMP_SIZE(struct sof_ipc_comp_tone);
+
 	tone = COMP_GET_IPC(dev, sof_ipc_comp_tone);
 	ret = memcpy_s(tone, sizeof(*tone), ipc_tone,
 		       sizeof(struct sof_ipc_comp_tone));

--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -663,7 +663,9 @@ static int volume_copy(struct comp_dev *dev)
 		 c.source_bytes, c.sink_bytes);
 
 	/* copy and scale volume */
+	buffer_invalidate(source, c.source_bytes);
 	cd->scale_vol(dev, &sink->stream, &source->stream, c.frames);
+	buffer_writeback(sink, c.sink_bytes);
 
 	/* calculate new free and available */
 	comp_update_buffer_produce(sink, c.sink_bytes);

--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -644,6 +644,7 @@ static int volume_copy(struct comp_dev *dev)
 	struct comp_data *cd = comp_get_drvdata(dev);
 	struct comp_buffer *source;
 	struct comp_buffer *sink;
+	uint32_t flags = 0;
 
 	comp_dbg(dev, "volume_copy()");
 
@@ -656,8 +657,14 @@ static int volume_copy(struct comp_dev *dev)
 	sink = list_first_item(&dev->bsink_list, struct comp_buffer,
 			       source_list);
 
+	buffer_lock(source, flags);
+	buffer_lock(sink, flags);
+
 	/* Get source, sink, number of frames etc. to process. */
 	comp_get_copy_limits(source, sink, &c);
+
+	buffer_unlock(sink, flags);
+	buffer_unlock(source, flags);
 
 	comp_dbg(dev, "volume_copy(), source_bytes = 0x%x, sink_bytes = 0x%x",
 		 c.source_bytes, c.sink_bytes);

--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -206,6 +206,8 @@ static struct comp_dev *volume_new(const struct comp_driver *drv,
 		return NULL;
 	dev->drv = drv;
 
+	dev->size = COMP_SIZE(struct sof_ipc_comp_volume);
+
 	vol = COMP_GET_IPC(dev, sof_ipc_comp_volume);
 	ret = memcpy_s(vol, sizeof(*vol), ipc_vol,
 		       sizeof(struct sof_ipc_comp_volume));

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -145,6 +145,22 @@ void comp_update_buffer_produce(struct comp_buffer *buffer, uint32_t bytes);
 /* called by a component after consuming data from this buffer */
 void comp_update_buffer_consume(struct comp_buffer *buffer, uint32_t bytes);
 
+static inline void buffer_invalidate(struct comp_buffer *buffer, uint32_t bytes)
+{
+	if (!buffer->inter_core)
+		return;
+
+	audio_stream_invalidate(&buffer->stream, bytes);
+}
+
+static inline void buffer_writeback(struct comp_buffer *buffer, uint32_t bytes)
+{
+	if (!buffer->inter_core)
+		return;
+
+	audio_stream_writeback(&buffer->stream, bytes);
+}
+
 /**
  * Locks buffer instance for buffers connecting components
  * running on different cores. Buffer parameters will be invalidated

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -28,6 +28,7 @@
 #include <stdint.h>
 
 struct comp_dev;
+struct spinlock_t;
 
 /* buffer tracing */
 #define trace_buffer(__e, ...) \
@@ -65,6 +66,8 @@ struct comp_dev;
 
 /* audio component buffer - connects 2 audio components together in pipeline */
 struct comp_buffer {
+	spinlock_t *lock;		/* locking mechanism */
+
 	/* data buffer */
 	struct audio_stream stream;
 

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -24,6 +24,7 @@
 #include <user/trace.h>
 #include <sof/audio/format.h>
 #include <config.h>
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -76,6 +77,7 @@ struct comp_buffer {
 	uint32_t pipeline_id;
 	uint32_t caps;
 	uint32_t core;
+	bool inter_core; /* true if connected to a comp from another core */
 
 	/* connected components */
 	struct comp_dev *source;	/* source component */

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -685,7 +685,9 @@ static inline int comp_copy(struct comp_dev *dev)
 
 	assert(dev->drv->ops.copy);
 
-	ret = dev->drv->ops.copy(dev);
+	/* copy only if we are the owner of the component */
+	if (cpu_is_me(dev->comp.core))
+		ret = dev->drv->ops.copy(dev);
 
 	comp_shared_commit(dev);
 

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -338,8 +338,6 @@ struct comp_dev {
 
 /** \brief Struct for use with comp_get_copy_limits() function. */
 struct comp_copy_limits {
-	struct comp_buffer *sink;
-	struct comp_buffer *source;
 	int frames;
 	int source_bytes;
 	int sink_bytes;
@@ -871,10 +869,12 @@ static inline bool comp_is_scheduling_source(struct comp_dev *dev)
 
 /**
  * Called by component in copy.
- * @param dev Component device.
+ * @param source Source buffer.
+ * @param sink Sink buffer.
  * @param cl Struct of parameters for use in copy function.
  */
-int comp_get_copy_limits(struct comp_dev *dev, struct comp_copy_limits *cl);
+void comp_get_copy_limits(struct comp_buffer *source, struct comp_buffer *sink,
+			  struct comp_copy_limits *cl);
 
 /**
  * Called by component in  params() function in order to set and update some of

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -298,6 +298,8 @@ struct comp_dev {
 				     *  to run component's processing
 				     */
 
+	uint32_t size;		/**< component's allocated size */
+
 	/** common runtime configuration for downstream/upstream */
 	uint32_t direction;	/**< enum sof_ipc_stream_direction */
 

--- a/src/include/sof/drivers/idc.h
+++ b/src/include/sof/drivers/idc.h
@@ -79,6 +79,22 @@
 #define IDC_MSG_IPC		IDC_TYPE(0x4)
 #define IDC_MSG_IPC_EXT		IDC_EXTENSION(0x0)
 
+/** \brief IDC component params message. */
+#define IDC_MSG_PARAMS		IDC_TYPE(0x5)
+#define IDC_MSG_PARAMS_EXT(x)	IDC_EXTENSION(x)
+
+/** \brief IDC component prepare message. */
+#define IDC_MSG_PREPARE		IDC_TYPE(0x6)
+#define IDC_MSG_PREPARE_EXT(x)	IDC_EXTENSION(x)
+
+/** \brief IDC component trigger message. */
+#define IDC_MSG_TRIGGER		IDC_TYPE(0x7)
+#define IDC_MSG_TRIGGER_EXT(x)	IDC_EXTENSION(x)
+
+/** \brief IDC component reset message. */
+#define IDC_MSG_RESET		IDC_TYPE(0x8)
+#define IDC_MSG_RESET_EXT(x)	IDC_EXTENSION(x)
+
 /** \brief Decodes IDC message type. */
 #define iTS(x)	(((x) >> IDC_TYPE_SHIFT) & IDC_TYPE_MASK)
 

--- a/src/include/sof/drivers/idc.h
+++ b/src/include/sof/drivers/idc.h
@@ -82,11 +82,21 @@
 /** \brief Decodes IDC message type. */
 #define iTS(x)	(((x) >> IDC_TYPE_SHIFT) & IDC_TYPE_MASK)
 
+/** \brief Max IDC message payload size in bytes. */
+#define IDC_MAX_PAYLOAD_SIZE	96
+
+/** \brief IDC message payload. */
+struct idc_payload {
+	uint8_t data[IDC_MAX_PAYLOAD_SIZE];
+};
+
 /** \brief IDC message. */
 struct idc_msg {
 	uint32_t header;	/**< header value */
 	uint32_t extension;	/**< extension value */
 	uint32_t core;		/**< core id */
+	uint32_t size;		/**< payload size in bytes */
+	void *payload;		/**< pointer to payload data */
 };
 
 /** \brief IDC data. */
@@ -96,8 +106,15 @@ struct idc {
 	struct idc_msg received_msg;	/**< received message */
 	struct task idc_task;		/**< IDC processing task */
 	bool msg_processed[PLATFORM_CORE_COUNT];
+	struct idc_payload *payload;
 	int irq;
 };
+
+static inline struct idc_payload *idc_payload_get(struct idc *idc,
+						  uint32_t core)
+{
+	return idc->payload + cpu_get_id();
+}
 
 void idc_enable_interrupts(int target_core, int source_core);
 

--- a/test/cmocka/src/audio/component/mock.c
+++ b/test/cmocka/src/audio/component/mock.c
@@ -28,6 +28,17 @@ void *_zalloc(enum mem_zone zone, uint32_t flags, uint32_t caps, size_t bytes)
 	return calloc(bytes, 1);
 }
 
+void *_realloc(void *ptr, enum mem_zone zone, uint32_t flags, uint32_t caps,
+	       size_t bytes)
+{
+	(void)ptr;
+	(void)zone;
+	(void)flags;
+	(void)caps;
+
+	return realloc(ptr, bytes);
+}
+
 int buffer_set_size(struct comp_buffer *buffer, uint32_t size)
 {
 	(void)buffer;

--- a/test/cmocka/src/audio/mux/mock.c
+++ b/test/cmocka/src/audio/mux/mock.c
@@ -41,3 +41,15 @@ struct schedulers **arch_schedulers_get(void)
 {
 	return NULL;
 }
+
+#if CONFIG_SMP
+
+int idc_send_msg(struct idc_msg *msg, uint32_t mode)
+{
+	(void)msg;
+	(void)mode;
+
+	return 0;
+}
+
+#endif

--- a/test/cmocka/src/audio/mux/mock.c
+++ b/test/cmocka/src/audio/mux/mock.c
@@ -36,3 +36,8 @@ struct sof *sof_get(void)
 {
 	return &sof;
 }
+
+struct schedulers **arch_schedulers_get(void)
+{
+	return NULL;
+}

--- a/test/cmocka/src/common_mocks.c
+++ b/test/cmocka/src/common_mocks.c
@@ -71,3 +71,17 @@ void WEAK __panic(uint32_t p, char *filename, uint32_t linenum)
 {
 	fail_msg("panic: %s:%d (code 0x%X)\n", filename, linenum, p);
 }
+
+uint32_t WEAK _spin_lock_irq(spinlock_t *lock)
+{
+	(void)lock;
+
+	return 0;
+}
+
+void WEAK _spin_unlock_irq(spinlock_t *lock, uint32_t flags, int line)
+{
+	(void)lock;
+	(void)flags;
+	(void)line;
+}


### PR DESCRIPTION
This set of patches adds possibility of executing single component on other core. Rest of the pipeline can run on different core.