### PR TITLE
task: increase default stack size

### DIFF
--- a/src/include/sof/schedule/task.h
+++ b/src/include/sof/schedule/task.h
@@ -28,7 +28,7 @@ struct sof;
 #define SOF_TASK_DEADLINE_NOW		0
 
 /** \brief EDF task's default stack size in bytes. */
-#define SOF_TASK_DEFAULT_STACK_SIZE	2048
+#define SOF_TASK_DEFAULT_STACK_SIZE	3072
 
 /** \brief Task states. */
 enum task_state {


### PR DESCRIPTION
Increases default stack size of EDF tasks.
It looks like some of the IPCs can exceed 2048 bytes of stack
and cause random data corruption. For sure it has been observed
when executing DAI config for DMIC.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>