### PR TITLE
KWD: configure selector out_channel from configured data

### DIFF
--- a/src/audio/detect_test.c
+++ b/src/audio/detect_test.c
@@ -729,8 +729,18 @@ static int test_keyword_prepare(struct comp_dev *dev)
 	struct comp_data *cd = comp_get_drvdata(dev);
 	uint16_t valid_bits = cd->sample_valid_bytes * 8;
 	uint16_t sample_width = cd->config.sample_width;
+	struct comp_buffer *sourceb;
 
 	comp_info(dev, "test_keyword_prepare()");
+
+	/* keyword components will only ever have 1 source */
+	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer,
+				  sink_list);
+
+	if (sourceb->stream.channels != 1) {
+		comp_err(dev, "test_keyword_prepare() error: only single-channel supported");
+		return -EINVAL;
+	}
 
 	if (valid_bits != sample_width) {
 		/* Default threshold value has to be changed

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -173,11 +173,8 @@ static int selector_params(struct comp_dev *dev,
 	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer,
 				source_list);
 
-	/* rewrite channels number for other components */
-	if (dev->direction == SOF_IPC_STREAM_PLAYBACK)
-		sinkb->stream.channels = cd->config.out_channels_count;
-	else
-		sourceb->stream.channels = cd->config.in_channels_count;
+	sourceb->stream.channels = params->channels;
+	sinkb->stream.channels = cd->config.out_channels_count;
 
 	return PPL_STATUS_PATH_STOP;
 }


### PR DESCRIPTION
Detector must work together with selector, for selector, the input
channel number is from upstream, and the output channel number should
come from config file, they are set in component .params() stage.

Move the detector source channel validation from .params() to
.prepare(), as it is available after the whole pipeline (actually the
upstream component -- selector) .params() done, and remove the
hard-coded "1" to make select 2 or more channels possible.

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>