### PR TITLE
abi: define debug abi version for user space dbg interfaces

### DIFF
--- a/src/include/ipc/info.h
+++ b/src/include/ipc/info.h
@@ -40,6 +40,7 @@ enum sof_ipc_ext_data {
 	SOF_IPC_EXT_WINDOW,
 	SOF_IPC_EXT_CC_INFO,
 	SOF_IPC_EXT_PROBE_INFO,
+	SOF_IPC_EXT_USER_ABI_INFO,
 };
 
 /* FW version - SOF_IPC_GLB_VERSION */
@@ -149,6 +150,13 @@ struct sof_ipc_probe_support {
 
 	/* reserved for future use */
 	uint32_t reserved[2];
+} __attribute__((packed));
+
+/* extended data: user abi version(s) */
+struct sof_ipc_user_abi_version {
+	struct sof_ipc_ext_data_hdr ext_hdr;
+
+	uint32_t abi_dbg_version;
 } __attribute__((packed));
 
 #endif /* __IPC_INFO_H__ */

--- a/src/include/kernel/abi.h
+++ b/src/include/kernel/abi.h
@@ -29,7 +29,7 @@
 
 /** \brief SOF ABI version major, minor and patch numbers */
 #define SOF_ABI_MAJOR 3
-#define SOF_ABI_MINOR 13
+#define SOF_ABI_MINOR 14
 #define SOF_ABI_PATCH 0
 
 /** \brief SOF ABI version number. Format within 32bit word is MMmmmppp */

--- a/src/include/sof/fw-ready-metadata.h
+++ b/src/include/sof/fw-ready-metadata.h
@@ -12,5 +12,6 @@
 
 extern const struct sof_ipc_cc_version cc_version;
 extern const struct sof_ipc_probe_support probe_support;
+extern const struct sof_ipc_user_abi_version user_abi_version;
 
 #endif /* __IPC_FW_READY_METADATA_H__ */

--- a/src/include/user/abi_dbg.h
+++ b/src/include/user/abi_dbg.h
@@ -1,0 +1,29 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2020 Intel Corporation. All rights reserved.
+ *
+ * Author: Marcin Maka <marcin.maka@linux.intel.com>
+ */
+
+/**
+ * \file include/user/abi_dbg.h
+ * \brief ABI definitions for debug interfaces accessed by user space apps.
+ * \author Marcin Maka <marcin.maka@linux.intel.com>
+ *
+ * Follows the rules documented in include/user/abi.h.
+ */
+
+#include <kernel/abi.h>
+
+#ifndef __USER_ABI_DBG_H__
+#define __USER_ABI_DBG_H__
+
+#define SOF_ABI_DBG_MAJOR 3
+#define SOF_ABI_DBG_MINOR 14
+#define SOF_ABI_DBG_PATCH 0
+
+#define SOF_ABI_DBG_VERSION SOF_ABI_VER(SOF_ABI_DBG_MAJOR, \
+					SOF_ABI_DBG_MINOR, \
+					SOF_ABI_DBG_PATCH)
+
+#endif /* __USER_ABI_DBG_H__ */

--- a/src/ipc/CMakeLists.txt
+++ b/src/ipc/CMakeLists.txt
@@ -37,7 +37,8 @@ set_property(TARGET data_structs APPEND
 
 add_local_sources(data_structs
 	cc_version.c
-	probe_support.c)
+	probe_support.c
+	user_abi_version.c)
 
 target_link_libraries(data_structs sof_options)
 target_link_libraries(sof_static_libraries INTERFACE data_structs)

--- a/src/ipc/user_abi_version.c
+++ b/src/ipc/user_abi_version.c
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2020 Intel Corporation. All rights reserved.
+//
+// Author: Marcin Maka <marcin.maka@linux.intel.com>
+
+#include <ipc/info.h>
+#include <user/abi_dbg.h>
+
+const struct sof_ipc_user_abi_version user_abi_version
+	__attribute__((section(".fw_ready_metadata"))) = {
+	.ext_hdr = {
+		.hdr.cmd = SOF_IPC_FW_READY,
+		.hdr.size = sizeof(struct sof_ipc_user_abi_version),
+		.type = SOF_IPC_EXT_USER_ABI_INFO,
+	},
+	.abi_dbg_version = SOF_ABI_DBG_VERSION,
+};

--- a/src/platform/baytrail/platform.c
+++ b/src/platform/baytrail/platform.c
@@ -145,6 +145,10 @@ int platform_boot_complete(uint32_t boot_message)
 
 	mailbox_dspbox_write(mb_offset, &probe_support,
 			     probe_support.ext_hdr.hdr.size);
+	mb_offset = mb_offset + probe_support.ext_hdr.hdr.size;
+
+	mailbox_dspbox_write(mb_offset, &user_abi_version,
+			     user_abi_version.ext_hdr.hdr.size);
 
 	/* now interrupt host to tell it we are done booting */
 	shim_write(SHIM_IPCDL, SOF_IPC_FW_READY | outbox);

--- a/src/platform/haswell/platform.c
+++ b/src/platform/haswell/platform.c
@@ -141,6 +141,10 @@ int platform_boot_complete(uint32_t boot_message)
 
 	mailbox_dspbox_write(mb_offset, &probe_support,
 			     probe_support.ext_hdr.hdr.size);
+	mb_offset = mb_offset + probe_support.ext_hdr.hdr.size;
+
+	mailbox_dspbox_write(mb_offset, &user_abi_version,
+			     user_abi_version.ext_hdr.hdr.size);
 
 	/* now interrupt host to tell it we are done booting */
 	shim_write(SHIM_IPCD, outbox | SHIM_IPCD_BUSY);

--- a/src/platform/imx8/platform.c
+++ b/src/platform/imx8/platform.c
@@ -139,6 +139,10 @@ int platform_boot_complete(uint32_t boot_message)
 
 	mailbox_dspbox_write(mb_offset, &probe_support,
 			     probe_support.ext_hdr.hdr.size);
+	mb_offset = mb_offset + probe_support.ext_hdr.hdr.size;
+
+	mailbox_dspbox_write(mb_offset, &user_abi_version,
+			     user_abi_version.ext_hdr.hdr.size);
 
 	/* now interrupt host to tell it we are done booting */
 	imx_mu_xcr_rmw(IMX_MU_xCR_GIRn(1), 0);

--- a/src/platform/imx8m/platform.c
+++ b/src/platform/imx8m/platform.c
@@ -138,6 +138,10 @@ int platform_boot_complete(uint32_t boot_message)
 
 	mailbox_dspbox_write(mb_offset, &probe_support,
 			     probe_support.ext_hdr.hdr.size);
+	mb_offset = mb_offset + probe_support.ext_hdr.hdr.size;
+
+	mailbox_dspbox_write(mb_offset, &user_abi_version,
+			     user_abi_version.ext_hdr.hdr.size);
 
 	/* now interrupt host to tell it we are done booting */
 	imx_mu_xcr_rmw(IMX_MU_xCR_GIRn(1), 0);

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -306,6 +306,10 @@ int platform_boot_complete(uint32_t boot_message)
 
 	mailbox_dspbox_write(mb_offset, &probe_support,
 			     probe_support.ext_hdr.hdr.size);
+	mb_offset = mb_offset + probe_support.ext_hdr.hdr.size;
+
+	mailbox_dspbox_write(mb_offset, &user_abi_version,
+			     user_abi_version.ext_hdr.hdr.size);
 
 	/* tell host we are ready */
 #if CAVS_VERSION == CAVS_VERSION_1_5

--- a/tools/logger/convert.c
+++ b/tools/logger/convert.c
@@ -11,7 +11,7 @@
 #include <errno.h>
 #include <unistd.h>
 #include <math.h>
-#include <kernel/abi.h>
+#include <user/abi_dbg.h>
 #include <user/trace.h>
 #include "convert.h"
 
@@ -445,15 +445,16 @@ int convert(const struct convert_config *config) {
 			return -EINVAL;
 		}
 
-		/* logger and version_file abi verification */
-		if SOF_ABI_VERSION_INCOMPATIBLE(SOF_ABI_VERSION, ver.abi_version) {
+		/* logger and version_file abi dbg verification */
+		if (SOF_ABI_VERSION_INCOMPATIBLE(SOF_ABI_DBG_VERSION,
+						 ver.abi_version)) {
 			fprintf(stderr, "Error: abi version in %s file "
 				"does not coincide with abi version used "
 				"by logger.\n", config->version_file);
 			fprintf(stderr, "logger ABI Version is %d:%d:%d\n",
-				SOF_ABI_VERSION_MAJOR(SOF_ABI_VERSION),
-				SOF_ABI_VERSION_MINOR(SOF_ABI_VERSION),
-				SOF_ABI_VERSION_PATCH(SOF_ABI_VERSION));
+				SOF_ABI_VERSION_MAJOR(SOF_ABI_DBG_VERSION),
+				SOF_ABI_VERSION_MINOR(SOF_ABI_DBG_VERSION),
+				SOF_ABI_VERSION_PATCH(SOF_ABI_DBG_VERSION));
 			fprintf(stderr, "version_file ABI Version is %d:%d:%d\n",
 				SOF_ABI_VERSION_MAJOR(ver.abi_version),
 				SOF_ABI_VERSION_MINOR(ver.abi_version),
@@ -463,14 +464,15 @@ int convert(const struct convert_config *config) {
 	}
 
 	/* default logger and ldc_file abi verification */
-	if SOF_ABI_VERSION_INCOMPATIBLE(SOF_ABI_VERSION, snd.version.abi_version) {
+	if (SOF_ABI_VERSION_INCOMPATIBLE(SOF_ABI_DBG_VERSION,
+					 snd.version.abi_version)) {
 		fprintf(stderr, "Error: abi version in %s file "
 			"does not coincide with abi version used "
 			"by logger.\n", config->ldc_file);
 			fprintf(stderr, "logger ABI Version is %d:%d:%d\n",
-				SOF_ABI_VERSION_MAJOR(SOF_ABI_VERSION),
-				SOF_ABI_VERSION_MINOR(SOF_ABI_VERSION),
-				SOF_ABI_VERSION_PATCH(SOF_ABI_VERSION));
+				SOF_ABI_VERSION_MAJOR(SOF_ABI_DBG_VERSION),
+				SOF_ABI_VERSION_MINOR(SOF_ABI_DBG_VERSION),
+				SOF_ABI_VERSION_PATCH(SOF_ABI_DBG_VERSION));
 			fprintf(stderr, "ldc_file ABI Version is %d:%d:%d\n",
 				SOF_ABI_VERSION_MAJOR(snd.version.abi_version),
 				SOF_ABI_VERSION_MINOR(snd.version.abi_version),


### PR DESCRIPTION
The sof-logger and potentially other debug API clients perform ABI
compatibility check using the single FW ABI version. The same one is used
by the primary FW client which is the kernel driver. If there is a change
made to the debug API, the main ABI has to be updated to protect integrity
of the debug tools while such a change may not affect the kernel driver
at all.

This patch introduces new debug ABI version to be increased when changing
user space debug interfaces while the the main ABI is not affected.
Recompilation and installation of the new driver every time the tunneled
debug protocol is upgraded may be avoided.

Signed-off-by: Marcin Maka <marcin.maka@linux.intel.com>