### PR TITLE
ut: add missing source file to build of KPB

### DIFF
--- a/test/cmocka/src/audio/kpb/CMakeLists.txt
+++ b/test/cmocka/src/audio/kpb/CMakeLists.txt
@@ -7,6 +7,7 @@ cmocka_test(kpb
 	${PROJECT_SOURCE_DIR}/test/cmocka/src/notifier_mocks.c
 	${PROJECT_SOURCE_DIR}/src/audio/buffer.c
 	${PROJECT_SOURCE_DIR}/src/lib/agent.c
+	${PROJECT_SOURCE_DIR}/src/spinlock.c
 	#${PROJECT_SOURCE_DIR}/src/audio/component.c
 )
 target_link_libraries(kpb PRIVATE -lm)


### PR DESCRIPTION
This patch adds missing spinlock.c file to the build of
KPB component.

Signed-off-by: Marcin Rajwa <marcin.rajwa@linux.intel.com>