### PR TITLE
Internal component api improvements

### DIFF
--- a/src/audio/asrc/asrc.c
+++ b/src/audio/asrc/asrc.c
@@ -272,7 +272,7 @@ static struct comp_dev *asrc_new(struct sof_ipc_comp *comp)
 	if (!dev)
 		return NULL;
 
-	asrc = (struct sof_ipc_comp_asrc *)&dev->comp;
+	asrc = COMP_GET_IPC(dev, sof_ipc_comp_asrc);
 	err = memcpy_s(asrc, sizeof(*asrc), ipc_asrc,
 		       sizeof(struct sof_ipc_comp_asrc));
 	assert(!err);
@@ -438,12 +438,12 @@ static int asrc_dai_find(struct comp_dev *dev,
 	int pid;
 
 	/* Get current pipeline ID and walk to find the DAI */
-	pid = dev->comp.pipeline_id;
+	pid = dev_comp_pipe_id(dev);
 	cd->dai_dev = NULL;
 	if (cd->mode == ASRC_OM_PUSH) {
 		/* In push mode check if sink component is DAI */
 		next_dev = sinkb->sink;
-		while (next_dev->comp.type != SOF_COMP_DAI) {
+		while (dev_comp_type(next_dev) != SOF_COMP_DAI) {
 			sinkb = list_first_item(&next_dev->bsink_list,
 						struct comp_buffer,
 						source_list);
@@ -453,7 +453,7 @@ static int asrc_dai_find(struct comp_dev *dev,
 				return -EINVAL;
 			}
 
-			if (next_dev->comp.pipeline_id != pid) {
+			if (dev_comp_pipe_id(next_dev) != pid) {
 				comp_cl_err(&comp_asrc, "No DAI sink in pipeline.");
 				return -EINVAL;
 			}
@@ -461,7 +461,7 @@ static int asrc_dai_find(struct comp_dev *dev,
 	} else {
 		/* In pull mode check if source component is DAI */
 		next_dev = sourceb->source;
-		while (next_dev->comp.type != SOF_COMP_DAI) {
+		while (dev_comp_type(next_dev) != SOF_COMP_DAI) {
 			sourceb = list_first_item(&next_dev->bsource_list,
 						  struct comp_buffer,
 						  sink_list);
@@ -471,7 +471,7 @@ static int asrc_dai_find(struct comp_dev *dev,
 				return -EINVAL;
 			}
 
-			if (next_dev->comp.pipeline_id != pid) {
+			if (dev_comp_pipe_id(next_dev) != pid) {
 				comp_cl_err(&comp_asrc, "No DAI source in pipeline.");
 				return -EINVAL;
 			}
@@ -531,7 +531,7 @@ static int asrc_dai_get_timestamp(struct comp_data *cd,
 static int asrc_prepare(struct comp_dev *dev)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
-	struct sof_ipc_comp_config *config = COMP_GET_CONFIG(dev);
+	struct sof_ipc_comp_config *config = dev_comp_config(dev);
 	struct comp_buffer *sinkb;
 	struct comp_buffer *sourceb;
 	uint32_t source_period_bytes;

--- a/src/audio/asrc/asrc.c
+++ b/src/audio/asrc/asrc.c
@@ -257,11 +257,6 @@ static struct comp_dev *asrc_new(struct sof_ipc_comp *comp)
 
 	comp_cl_info(&comp_asrc, "asrc_new()");
 
-	if (IPC_IS_SIZE_INVALID(ipc_asrc->config)) {
-		IPC_SIZE_ERROR_TRACE(TRACE_CLASS_COMP, ipc_asrc->config);
-		return NULL;
-	}
-
 	comp_cl_info(&comp_asrc, "asrc_new(), source_rate=%d, sink_rate=%d, asynchronous_mode=%d, operation_mode=%d",
 		     ipc_asrc->source_rate, ipc_asrc->sink_rate,
 		     ipc_asrc->asynchronous_mode, ipc_asrc->operation_mode);

--- a/src/audio/buffer.c
+++ b/src/audio/buffer.c
@@ -143,10 +143,10 @@ void comp_update_buffer_produce(struct comp_buffer *buffer, uint32_t bytes)
 	if (!bytes) {
 		trace_buffer_with_ids(buffer,
 				      "comp_update_buffer_produce(), no bytes to produce, source->comp.id = %u, source->comp.type = %u, sink->comp.id = %u, sink->comp.type = %u",
-				      buffer->source->comp.id,
-				      buffer->source->comp.type,
-				      buffer->sink->comp.id,
-				      buffer->sink->comp.type);
+				      dev_comp_id(buffer->source),
+				      dev_comp_type(buffer->source),
+				      dev_comp_id(buffer->sink),
+				      dev_comp_type(buffer->sink));
 		return;
 	}
 
@@ -186,10 +186,10 @@ void comp_update_buffer_consume(struct comp_buffer *buffer, uint32_t bytes)
 	if (!bytes) {
 		trace_buffer_with_ids(buffer,
 				      "comp_update_buffer_consume(), no bytes to consume, source->comp.id = %u, source->comp.type = %u, sink->comp.id = %u, sink->comp.type = %u",
-				      buffer->source->comp.id,
-				      buffer->source->comp.type,
-				      buffer->sink->comp.id,
-				      buffer->sink->comp.type);
+				      dev_comp_id(buffer->source),
+				      dev_comp_type(buffer->source),
+				      dev_comp_id(buffer->sink),
+				      dev_comp_type(buffer->sink));
 		return;
 	}
 

--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -63,9 +63,8 @@ struct comp_dev *comp_new(struct sof_ipc_comp *comp)
 	}
 
 	/* validate size of ipc config */
-	if (IPC_IS_SIZE_INVALID(*COMP_IPC_GET_CONFIG(comp))) {
-		IPC_SIZE_ERROR_TRACE(TRACE_CLASS_COMP,
-				     *COMP_IPC_GET_CONFIG(comp));
+	if (IPC_IS_SIZE_INVALID(*comp_config(comp))) {
+		IPC_SIZE_ERROR_TRACE(TRACE_CLASS_COMP, *comp_config(comp));
 		return NULL;
 	}
 

--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -8,6 +8,7 @@
 #include <sof/common.h>
 #include <sof/debug/panic.h>
 #include <sof/drivers/interrupt.h>
+#include <sof/drivers/ipc.h>
 #include <sof/lib/alloc.h>
 #include <sof/lib/memory.h>
 #include <sof/list.h>
@@ -58,6 +59,13 @@ struct comp_dev *comp_new(struct sof_ipc_comp *comp)
 	if (!drv) {
 		trace_error(TRACE_CLASS_COMP, "comp_new() error: driver not found, comp->type = %u",
 			    comp->type);
+		return NULL;
+	}
+
+	/* validate size of ipc config */
+	if (IPC_IS_SIZE_INVALID(*COMP_IPC_GET_CONFIG(comp))) {
+		IPC_SIZE_ERROR_TRACE(TRACE_CLASS_COMP,
+				     *COMP_IPC_GET_CONFIG(comp));
 		return NULL;
 	}
 

--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -52,7 +52,6 @@ struct comp_dev *comp_new(struct sof_ipc_comp *comp)
 {
 	struct comp_dev *cdev;
 	const struct comp_driver *drv;
-	int ret;
 
 	/* find the driver for our new component */
 	drv = get_drv(comp->type);
@@ -68,11 +67,6 @@ struct comp_dev *comp_new(struct sof_ipc_comp *comp)
 		comp_cl_err(drv, "comp_new() error: unable to create the new component");
 		return NULL;
 	}
-
-	/* init component */
-	ret = memcpy_s(&cdev->comp, sizeof(cdev->comp),
-		       comp, sizeof(*comp));
-	assert(!ret);
 
 	cdev->drv = drv;
 	list_init(&cdev->bsource_list);

--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -134,7 +134,7 @@ static struct comp_dev *dai_new(struct sof_ipc_comp *comp)
 	if (!dev)
 		return NULL;
 
-	dai = (struct sof_ipc_comp_dai *)&dev->comp;
+	dai = COMP_GET_IPC(dev, sof_ipc_comp_dai);
 	ret = memcpy_s(dai, sizeof(*dai), ipc_dai,
 		       sizeof(struct sof_ipc_comp_dai));
 	assert(!ret);
@@ -358,7 +358,7 @@ static int dai_capture_params(struct comp_dev *dev, uint32_t period_bytes,
 static int dai_params(struct comp_dev *dev,
 		      struct sof_ipc_stream_params *params)
 {
-	struct sof_ipc_comp_config *dconfig = COMP_GET_CONFIG(dev);
+	struct sof_ipc_comp_config *dconfig = dev_comp_config(dev);
 	struct dai_data *dd = comp_get_drvdata(dev);
 	uint32_t frame_size;
 	uint32_t period_count;
@@ -697,9 +697,9 @@ static int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn)
 
 static int dai_config(struct comp_dev *dev, struct sof_ipc_dai_config *config)
 {
-	struct sof_ipc_comp_config *dconfig = COMP_GET_CONFIG(dev);
+	struct sof_ipc_comp_config *dconfig = dev_comp_config(dev);
 	struct dai_data *dd = comp_get_drvdata(dev);
-	struct sof_ipc_comp_dai *dai = (struct sof_ipc_comp_dai *)&dev->comp;
+	struct sof_ipc_comp_dai *dai = COMP_GET_IPC(dev, sof_ipc_comp_dai);
 	int channel = 0;
 	int handshake;
 
@@ -810,7 +810,7 @@ static int dai_ts_config(struct comp_dev *dev)
 {
 	struct dai_data *dd = comp_get_drvdata(dev);
 	struct timestamp_cfg *cfg = &dd->ts_config;
-	struct sof_ipc_comp_dai *dai = (struct sof_ipc_comp_dai *)&dev->comp;
+	struct sof_ipc_comp_dai *dai = COMP_GET_IPC(dev, sof_ipc_comp_dai);
 
 	comp_dbg(dev, "dai_ts_config()");
 	cfg->type = dd->dai->drv->type;

--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -129,11 +129,6 @@ static struct comp_dev *dai_new(struct sof_ipc_comp *comp)
 
 	comp_cl_info(&comp_dai, "dai_new()");
 
-	if (IPC_IS_SIZE_INVALID(ipc_dai->config)) {
-		IPC_SIZE_ERROR_TRACE(TRACE_CLASS_DAI, ipc_dai->config);
-		return NULL;
-	}
-
 	dev = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM,
 		      COMP_SIZE(struct sof_ipc_comp_dai));
 	if (!dev)

--- a/src/audio/detect_test.c
+++ b/src/audio/detect_test.c
@@ -303,7 +303,7 @@ static struct comp_dev *test_keyword_new(struct sof_ipc_comp *comp)
 	if (!dev)
 		return NULL;
 
-	keyword = (struct sof_ipc_comp_process *)&dev->comp;
+	keyword = COMP_GET_IPC(dev, sof_ipc_comp_process);
 	ret = memcpy_s(keyword, sizeof(*keyword), ipc_keyword,
 		       sizeof(struct sof_ipc_comp_process));
 	assert(!ret);

--- a/src/audio/detect_test.c
+++ b/src/audio/detect_test.c
@@ -298,11 +298,6 @@ static struct comp_dev *test_keyword_new(struct sof_ipc_comp *comp)
 
 	comp_cl_info(&comp_keyword, "test_keyword_new()");
 
-	if (IPC_IS_SIZE_INVALID(ipc_keyword->config)) {
-		IPC_SIZE_ERROR_TRACE(TRACE_CLASS_KEYWORD, ipc_keyword->config);
-		return NULL;
-	}
-
 	dev = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM,
 		      COMP_SIZE(struct sof_ipc_comp_process));
 	if (!dev)

--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -401,11 +401,6 @@ static struct comp_dev *eq_fir_new(struct sof_ipc_comp *comp)
 
 	comp_cl_info(&comp_eq_fir, "eq_fir_new()");
 
-	if (IPC_IS_SIZE_INVALID(ipc_fir->config)) {
-		IPC_SIZE_ERROR_TRACE(TRACE_CLASS_COMP, ipc_fir->config);
-		return NULL;
-	}
-
 	/* Check first before proceeding with dev and cd that coefficients
 	 * blob size is sane.
 	 */

--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -415,7 +415,7 @@ static struct comp_dev *eq_fir_new(struct sof_ipc_comp *comp)
 	if (!dev)
 		return NULL;
 
-	fir = (struct sof_ipc_comp_process *)&dev->comp;
+	fir = COMP_GET_IPC(dev, sof_ipc_comp_process);
 	ret = memcpy_s(fir, sizeof(*fir), ipc_fir,
 		       sizeof(struct sof_ipc_comp_process));
 	assert(!ret);
@@ -738,7 +738,7 @@ static int eq_fir_copy(struct comp_dev *dev)
 static int eq_fir_prepare(struct comp_dev *dev)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
-	struct sof_ipc_comp_config *config = COMP_GET_CONFIG(dev);
+	struct sof_ipc_comp_config *config = dev_comp_config(dev);
 	struct comp_buffer *sourceb;
 	struct comp_buffer *sinkb;
 	uint32_t sink_period_bytes;

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -520,7 +520,7 @@ static struct comp_dev *eq_iir_new(struct sof_ipc_comp *comp)
 	if (!dev)
 		return NULL;
 
-	iir = (struct sof_ipc_comp_process *)&dev->comp;
+	iir = COMP_GET_IPC(dev, sof_ipc_comp_process);
 	ret = memcpy_s(iir, sizeof(*iir), ipc_iir,
 		       sizeof(struct sof_ipc_comp_process));
 	assert(!ret);
@@ -797,7 +797,7 @@ static int eq_iir_copy(struct comp_dev *dev)
 static int eq_iir_prepare(struct comp_dev *dev)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
-	struct sof_ipc_comp_config *config = COMP_GET_CONFIG(dev);
+	struct sof_ipc_comp_config *config = dev_comp_config(dev);
 	struct comp_buffer *sourceb;
 	struct comp_buffer *sinkb;
 	uint32_t sink_period_bytes;

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -506,11 +506,6 @@ static struct comp_dev *eq_iir_new(struct sof_ipc_comp *comp)
 
 	comp_cl_info(&comp_eq_iir, "eq_iir_new()");
 
-	if (IPC_IS_SIZE_INVALID(ipc_iir->config)) {
-		IPC_SIZE_ERROR_TRACE(TRACE_CLASS_COMP, ipc_iir->config);
-		return NULL;
-	}
-
 	/* Check first before proceeding with dev and cd that coefficients
 	 * blob size is sane.
 	 */

--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -328,7 +328,7 @@ static struct comp_dev *host_new(struct sof_ipc_comp *comp)
 	if (!dev)
 		return NULL;
 
-	host = (struct sof_ipc_comp_host *)&dev->comp;
+	host = COMP_GET_IPC(dev, sof_ipc_comp_host);
 	ret = memcpy_s(host, sizeof(*host),
 		       ipc_host, sizeof(struct sof_ipc_comp_host));
 	assert(!ret);

--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -323,11 +323,6 @@ static struct comp_dev *host_new(struct sof_ipc_comp *comp)
 
 	comp_cl_info(&comp_host, "host_new()");
 
-	if (IPC_IS_SIZE_INVALID(ipc_host->config)) {
-		IPC_SIZE_ERROR_TRACE(TRACE_CLASS_COMP, ipc_host->config);
-		return NULL;
-	}
-
 	dev = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM,
 		      COMP_SIZE(struct sof_ipc_comp_host));
 	if (!dev)

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -122,12 +122,6 @@ static struct comp_dev *kpb_new(struct sof_ipc_comp *comp)
 
 	comp_cl_info(&comp_kpb, "kpb_new()");
 
-	/* Validate input parameters */
-	if (IPC_IS_SIZE_INVALID(ipc_process->config)) {
-		IPC_SIZE_ERROR_TRACE(TRACE_CLASS_COMP, ipc_process->config);
-		return NULL;
-	}
-
 	dev = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM,
 		      COMP_SIZE(struct sof_ipc_comp_process));
 	if (!dev)

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -127,7 +127,8 @@ static struct comp_dev *kpb_new(struct sof_ipc_comp *comp)
 	if (!dev)
 		return NULL;
 
-	ret = memcpy_s(&dev->comp, sizeof(struct sof_ipc_comp_process),
+	ret = memcpy_s(COMP_GET_IPC(dev, sof_ipc_comp_process),
+		       sizeof(struct sof_ipc_comp_process),
 		       comp, sizeof(struct sof_ipc_comp_process));
 	assert(!ret);
 
@@ -491,10 +492,10 @@ static int kpb_prepare(struct comp_dev *dev)
 			ret = -EINVAL;
 			break;
 		}
-		if (sink->sink->comp.type == SOF_COMP_SELECTOR) {
+		if (dev_comp_type(sink->sink) == SOF_COMP_SELECTOR) {
 			/* We found proper real time sink */
 			kpb->sel_sink = sink;
-		} else if (sink->sink->comp.type == SOF_COMP_HOST) {
+		} else if (dev_comp_type(sink->sink) == SOF_COMP_HOST) {
 			/* We found proper host sink */
 			kpb->host_sink = sink;
 		}

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -117,11 +117,6 @@ static struct comp_dev *mixer_new(struct sof_ipc_comp *comp)
 
 	comp_cl_info(&comp_mixer, "mixer_new()");
 
-	if (IPC_IS_SIZE_INVALID(ipc_mixer->config)) {
-		IPC_SIZE_ERROR_TRACE(TRACE_CLASS_COMP, ipc_mixer->config);
-		return NULL;
-	}
-
 	dev = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM,
 		      COMP_SIZE(struct sof_ipc_comp_mixer));
 	if (!dev)

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -122,7 +122,7 @@ static struct comp_dev *mixer_new(struct sof_ipc_comp *comp)
 	if (!dev)
 		return NULL;
 
-	mixer = (struct sof_ipc_comp_mixer *)&dev->comp;
+	mixer = COMP_GET_IPC(dev, sof_ipc_comp_mixer);
 
 	ret = memcpy_s(mixer, sizeof(*mixer), ipc_mixer,
 		       sizeof(struct sof_ipc_comp_mixer));
@@ -168,7 +168,7 @@ static int mixer_verify_params(struct comp_dev *dev,
 static int mixer_params(struct comp_dev *dev,
 			struct sof_ipc_stream_params *params)
 {
-	struct sof_ipc_comp_config *config = COMP_GET_CONFIG(dev);
+	struct sof_ipc_comp_config *config = dev_comp_config(dev);
 	struct comp_buffer *sinkb;
 	uint32_t period_bytes;
 	int err;

--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -93,7 +93,9 @@ static struct comp_dev *mux_new(struct sof_ipc_comp *comp)
 	if (!dev)
 		return NULL;
 
-	memcpy(&dev->comp, comp, sizeof(struct sof_ipc_comp_process));
+	memcpy_s(COMP_GET_IPC(dev, sof_ipc_comp_process),
+		 sizeof(struct sof_ipc_comp_process),
+		 comp, sizeof(struct sof_ipc_comp_process));
 
 	cd = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM,
 		     sizeof(*cd) + MUX_MAX_STREAMS * sizeof(struct mux_stream_data));

--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -88,11 +88,6 @@ static struct comp_dev *mux_new(struct sof_ipc_comp *comp)
 
 	comp_cl_info(&comp_mux, "mux_new()");
 
-	if (IPC_IS_SIZE_INVALID(ipc_process->config)) {
-		IPC_SIZE_ERROR_TRACE(TRACE_CLASS_COMP, ipc_process->config);
-		return NULL;
-	}
-
 	dev = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM,
 		      COMP_SIZE(struct sof_ipc_comp_process));
 	if (!dev)

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -56,7 +56,8 @@ static struct comp_dev *selector_new(struct sof_ipc_comp *comp)
 	if (!dev)
 		return NULL;
 
-	ret = memcpy_s(&dev->comp, sizeof(struct sof_ipc_comp_process), comp,
+	ret = memcpy_s(COMP_GET_IPC(dev, sof_ipc_comp_process),
+		       sizeof(struct sof_ipc_comp_process), comp,
 		       sizeof(struct sof_ipc_comp_process));
 	assert(!ret);
 
@@ -348,7 +349,7 @@ static int selector_trigger(struct comp_dev *dev, int cmd)
 	 * kpb_init_draining() and kpb_draining_task() are interrupted by
 	 * new pipeline_task()
 	 */
-	return sourceb->source->comp.type == SOF_COMP_KPB ?
+	return dev_comp_type(sourceb->source) == SOF_COMP_KPB ?
 		PPL_STATUS_PATH_STOP : ret;
 }
 
@@ -401,7 +402,7 @@ static int selector_prepare(struct comp_dev *dev)
 	struct comp_data *cd = comp_get_drvdata(dev);
 	struct comp_buffer *sinkb;
 	struct comp_buffer *sourceb;
-	struct sof_ipc_comp_config *config = COMP_GET_CONFIG(dev);
+	struct sof_ipc_comp_config *config = dev_comp_config(dev);
 	int ret;
 
 	comp_info(dev, "selector_prepare()");

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -51,11 +51,6 @@ static struct comp_dev *selector_new(struct sof_ipc_comp *comp)
 
 	comp_cl_info(&comp_selector, "selector_new()");
 
-	if (IPC_IS_SIZE_INVALID(ipc_process->config)) {
-		IPC_SIZE_ERROR_TRACE(TRACE_CLASS_COMP, ipc_process->config);
-		return NULL;
-	}
-
 	dev = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM,
 		      COMP_SIZE(struct sof_ipc_comp_process));
 	if (!dev)

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -456,11 +456,6 @@ static struct comp_dev *src_new(struct sof_ipc_comp *comp)
 
 	comp_cl_info(&comp_src, "src_new()");
 
-	if (IPC_IS_SIZE_INVALID(ipc_src->config)) {
-		IPC_SIZE_ERROR_TRACE(TRACE_CLASS_COMP, ipc_src->config);
-		return NULL;
-	}
-
 	/* validate init data - either SRC sink or source rate must be set */
 	if (ipc_src->source_rate == 0 && ipc_src->sink_rate == 0) {
 		comp_cl_err(&comp_src, "src_new() error: SRC sink and source rate are not set");

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -467,7 +467,7 @@ static struct comp_dev *src_new(struct sof_ipc_comp *comp)
 	if (!dev)
 		return NULL;
 
-	src = (struct sof_ipc_comp_src *)&dev->comp;
+	src = COMP_GET_IPC(dev, sof_ipc_comp_src);
 
 	ret = memcpy_s(src, sizeof(*src), ipc_src,
 		       sizeof(struct sof_ipc_comp_src));
@@ -785,7 +785,7 @@ static int src_copy(struct comp_dev *dev)
 static int src_prepare(struct comp_dev *dev)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
-	struct sof_ipc_comp_config *config = COMP_GET_CONFIG(dev);
+	struct sof_ipc_comp_config *config = dev_comp_config(dev);
 	struct comp_buffer *sinkb;
 	struct comp_buffer *sourceb;
 	uint32_t source_period_bytes;

--- a/src/audio/tone.c
+++ b/src/audio/tone.c
@@ -377,11 +377,6 @@ static struct comp_dev *tone_new(struct sof_ipc_comp *comp)
 
 	comp_cl_info(&comp_tone, "tone_new()");
 
-	if (IPC_IS_SIZE_INVALID(ipc_tone->config)) {
-		IPC_SIZE_ERROR_TRACE(TRACE_CLASS_COMP, ipc_tone->config);
-		return NULL;
-	}
-
 	dev = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM,
 		      COMP_SIZE(struct sof_ipc_comp_tone));
 	if (!dev)

--- a/src/audio/tone.c
+++ b/src/audio/tone.c
@@ -382,7 +382,7 @@ static struct comp_dev *tone_new(struct sof_ipc_comp *comp)
 	if (!dev)
 		return NULL;
 
-	tone = (struct sof_ipc_comp_tone *)&dev->comp;
+	tone = COMP_GET_IPC(dev, sof_ipc_comp_tone);
 	ret = memcpy_s(tone, sizeof(*tone), ipc_tone,
 		       sizeof(struct sof_ipc_comp_tone));
 	assert(!ret);
@@ -421,7 +421,7 @@ static int tone_params(struct comp_dev *dev,
 		       struct sof_ipc_stream_params *params)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
-	struct sof_ipc_comp_config *config = COMP_GET_CONFIG(dev);
+	struct sof_ipc_comp_config *config = dev_comp_config(dev);
 	struct comp_buffer *sourceb;
 	struct comp_buffer *sinkb;
 

--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -204,7 +204,7 @@ static struct comp_dev *volume_new(struct sof_ipc_comp *comp)
 	if (!dev)
 		return NULL;
 
-	vol = (struct sof_ipc_comp_volume *)&dev->comp;
+	vol = COMP_GET_IPC(dev, sof_ipc_comp_volume);
 	ret = memcpy_s(vol, sizeof(*vol), ipc_vol,
 		       sizeof(struct sof_ipc_comp_volume));
 	assert(!ret);
@@ -678,7 +678,7 @@ static int volume_prepare(struct comp_dev *dev)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 	struct comp_buffer *sinkb;
-	struct sof_ipc_comp_config *config = COMP_GET_CONFIG(dev);
+	struct sof_ipc_comp_config *config = dev_comp_config(dev);
 	uint32_t sink_period_bytes;
 	int i;
 	int ret;

--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -199,11 +199,6 @@ static struct comp_dev *volume_new(struct sof_ipc_comp *comp)
 
 	comp_cl_info(&comp_volume, "volume_new()");
 
-	if (IPC_IS_SIZE_INVALID(ipc_vol->config)) {
-		IPC_SIZE_ERROR_TRACE(TRACE_CLASS_COMP, ipc_vol->config);
-		return NULL;
-	}
-
 	dev = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM,
 		      COMP_SIZE(struct sof_ipc_comp_volume));
 	if (!dev)

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -338,10 +338,6 @@ struct comp_copy_limits {
 #define COMP_GET_IPC(dev, type) \
 	(struct type *)(&dev->comp)
 
-/** \brief Retrieves component device runtime configuration. */
-#define COMP_GET_PARAMS(dev) \
-	(struct type *)(&dev->params)
-
 /** \brief Retrieves component device config data. */
 #define COMP_GET_CONFIG(dev) \
 	(struct sof_ipc_comp_config *)((char *)&dev->comp + \

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -338,15 +338,65 @@ struct comp_copy_limits {
 #define COMP_GET_IPC(dev, type) \
 	(struct type *)(&dev->comp)
 
-/** \brief Retrieves component device config data. */
-#define COMP_GET_CONFIG(dev) \
-	(struct sof_ipc_comp_config *)((char *)&dev->comp + \
-	sizeof(struct sof_ipc_comp))
+/**
+ * Retrieves component from device.
+ * @param dev Device.
+ * @return Pointer to the component.
+ */
+static inline struct sof_ipc_comp *dev_comp(struct comp_dev *dev)
+{
+	return &dev->comp;
+}
 
-/* todo: this one looks as bad as the prev one, common comp data needs work*/
-/** \brief Retrieves config data from component ipc. */
-#define COMP_IPC_GET_CONFIG(comp) \
-	(struct sof_ipc_comp_config *)((comp) + 1)
+/**
+ * Retrieves Component id from device.
+ * @param dev Device.
+ * @return Component id.
+ */
+static inline uint32_t dev_comp_id(const struct comp_dev *dev)
+{
+	return dev->comp.id;
+}
+
+/**
+ * Retrieves Component pipeline id from device.
+ * @param dev Device.
+ * @return Component pipeline id.
+ */
+static inline uint32_t dev_comp_pipe_id(const struct comp_dev *dev)
+{
+	return dev->comp.pipeline_id;
+}
+
+/**
+ * Retrieves component type from device.
+ * @param dev Device.
+ * @return Component type.
+ */
+static inline enum sof_comp_type dev_comp_type(const struct comp_dev *dev)
+{
+	return dev->comp.type;
+}
+
+/**
+ * Retrieves component config data from device.
+ * @param dev Device.
+ * @return Pointer to the component data.
+ */
+static inline struct sof_ipc_comp_config *dev_comp_config(struct comp_dev *dev)
+{
+	return (struct sof_ipc_comp_config *)(&dev->comp + 1);
+}
+
+/**
+ * Retrieves component config data from component ipc.
+ * @param comp Component ipc data.
+ * @return Pointer to the component config data.
+ */
+static inline struct sof_ipc_comp_config *comp_config(struct sof_ipc_comp *comp)
+{
+	return (struct sof_ipc_comp_config *)(comp + 1);
+}
 
 /** \brief Sets the driver private data. */
 #define comp_set_drvdata(c, data) \
@@ -611,7 +661,7 @@ void sys_comp_init(struct sof *sof);
 static inline int comp_is_single_pipeline(struct comp_dev *current,
 					  struct comp_dev *previous)
 {
-	return current->comp.pipeline_id == previous->comp.pipeline_id;
+	return dev_comp_pipe_id(current) == dev_comp_pipe_id(previous);
 }
 
 /**
@@ -659,7 +709,7 @@ static inline int comp_get_requested_state(int cmd)
 /* \brief Returns comp_endpoint_type of given component */
 static inline int comp_get_endpoint_type(struct comp_dev *dev)
 {
-	switch (dev->comp.type) {
+	switch (dev_comp_type(dev)) {
 	case SOF_COMP_HOST:
 		return COMP_ENDPOINT_HOST;
 	case SOF_COMP_DAI:
@@ -703,7 +753,7 @@ static inline void comp_underrun(struct comp_dev *dev,
 	int32_t bytes = (int32_t)source->stream.avail - copy_bytes;
 
 	comp_err(dev, "comp_underrun() error: dev->comp.id = %u, source->avail = %u, copy_bytes = %u",
-		 dev->comp.id,
+		 dev_comp_id(dev),
 		 source->stream.avail,
 		 copy_bytes);
 

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -347,6 +347,11 @@ struct comp_copy_limits {
 	(struct sof_ipc_comp_config *)((char *)&dev->comp + \
 	sizeof(struct sof_ipc_comp))
 
+/* todo: this one looks as bad as the prev one, common comp data needs work*/
+/** \brief Retrieves config data from component ipc. */
+#define COMP_IPC_GET_CONFIG(comp) \
+	(struct sof_ipc_comp_config *)((comp) + 1)
+
 /** \brief Sets the driver private data. */
 #define comp_set_drvdata(c, data) \
 	(c->private = data)

--- a/src/include/sof/drivers/ipc.h
+++ b/src/include/sof/drivers/ipc.h
@@ -52,12 +52,12 @@ struct ipc_msg;
 
 /* validates internal non tail structures within IPC command structure */
 #define IPC_IS_SIZE_INVALID(object)					\
-	object.hdr.size == sizeof(object) ? 0 : 1
+	(object).hdr.size == sizeof(object) ? 0 : 1
 
 /* convenience error trace for mismatched internal structures */
 #define IPC_SIZE_ERROR_TRACE(class, object)				\
 	trace_error(class, "ipc: size %d expected %d",			\
-		    object.hdr.size, sizeof(object))
+		    (object).hdr.size, sizeof(object))
 
 /* IPC generic component device */
 struct ipc_comp_dev {

--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -420,9 +420,9 @@ int ipc_stream_send_position(struct comp_dev *cdev,
 	struct sof_ipc_stream_posn *posn)
 {
 	posn->rhdr.hdr.cmd = SOF_IPC_GLB_STREAM_MSG | SOF_IPC_STREAM_POSITION |
-		cdev->comp.id;
+		dev_comp_id(cdev);
 	posn->rhdr.hdr.size = sizeof(*posn);
-	posn->comp_id = cdev->comp.id;
+	posn->comp_id = dev_comp_id(cdev);
 
 	mailbox_stream_write(cdev->pipeline->posn_offset, posn, sizeof(*posn));
 	return ipc_queue_host_message(ipc_get(), posn->rhdr.hdr.cmd, posn,
@@ -434,10 +434,10 @@ int ipc_send_comp_notification(const struct comp_dev *cdev,
 			       struct sof_ipc_comp_event *event)
 {
 	event->rhdr.hdr.cmd = SOF_IPC_GLB_COMP_MSG |
-		SOF_IPC_COMP_NOTIFICATION | cdev->comp.id;
+		SOF_IPC_COMP_NOTIFICATION | dev_comp_id(cdev);
 	event->rhdr.hdr.size = sizeof(*event);
-	event->src_comp_type = cdev->comp.type;
-	event->src_comp_id = cdev->comp.id;
+	event->src_comp_type = dev_comp_type(cdev);
+	event->src_comp_id = dev_comp_id(cdev);
 
 	return ipc_queue_host_message(ipc_get(), event->rhdr.hdr.cmd, event,
 				      sizeof(*event), false);
@@ -449,9 +449,9 @@ int ipc_stream_send_xrun(struct comp_dev *cdev,
 {
 	posn->rhdr.hdr.cmd = SOF_IPC_GLB_STREAM_MSG |
 			     SOF_IPC_STREAM_TRIG_XRUN |
-			     cdev->comp.id;
+			     dev_comp_id(cdev);
 	posn->rhdr.hdr.size = sizeof(*posn);
-	posn->comp_id = cdev->comp.id;
+	posn->comp_id = dev_comp_id(cdev);
 
 	mailbox_stream_write(cdev->pipeline->posn_offset, posn, sizeof(*posn));
 	return ipc_queue_host_message(ipc_get(), posn->rhdr.hdr.cmd, posn,

--- a/src/ipc/ipc.c
+++ b/src/ipc/ipc.c
@@ -95,7 +95,7 @@ struct ipc_comp_dev *ipc_get_comp_by_ppl_id(struct ipc *ipc, uint16_t type,
 
 		switch (icd->type) {
 		case COMP_TYPE_COMPONENT:
-			if (icd->cd->comp.pipeline_id == ppl_id)
+			if (dev_comp_pipe_id(icd->cd) == ppl_id)
 				return icd;
 			break;
 		case COMP_TYPE_BUFFER:
@@ -135,7 +135,7 @@ static struct ipc_comp_dev *ipc_get_ppl_comp(struct ipc *ipc,
 			continue;
 		}
 
-		if (icd->cd->comp.pipeline_id == pipeline_id &&
+		if (dev_comp_pipe_id(icd->cd) == pipeline_id &&
 		    list_is_empty(comp_buffer_list(icd->cd, dir)))
 			return icd;
 
@@ -155,13 +155,13 @@ static struct ipc_comp_dev *ipc_get_ppl_comp(struct ipc *ipc,
 			continue;
 		}
 
-		if (icd->cd->comp.pipeline_id == pipeline_id) {
+		if (dev_comp_pipe_id(icd->cd) == pipeline_id) {
 			buffer = buffer_from_list
 					(comp_buffer_list(icd->cd, dir)->next,
 					 struct comp_buffer, dir);
 			buff_comp = buffer_get_comp(buffer, dir);
 			if (buff_comp &&
-			    buff_comp->comp.pipeline_id != pipeline_id)
+			    dev_comp_pipe_id(buff_comp) != pipeline_id)
 				return icd;
 		}
 
@@ -572,9 +572,9 @@ int ipc_comp_dai_config(struct ipc *ipc, struct sof_ipc_dai_config *config)
 			continue;
 		}
 
-		if (icd->cd->comp.type == SOF_COMP_DAI ||
-		    icd->cd->comp.type == SOF_COMP_SG_DAI) {
-			dai = (struct sof_ipc_comp_dai *)&icd->cd->comp;
+		if (dev_comp_type(icd->cd) == SOF_COMP_DAI ||
+		    dev_comp_type(icd->cd) == SOF_COMP_SG_DAI) {
+			dai = COMP_GET_IPC(icd->cd, sof_ipc_comp_dai);
 			platform_shared_commit(icd, sizeof(*icd));
 			/*
 			 * set config if comp dai_index matches

--- a/test/cmocka/src/audio/mixer/mixer_test.c
+++ b/test/cmocka/src/audio/mixer/mixer_test.c
@@ -101,7 +101,8 @@ static struct comp_dev *create_comp(struct sof_ipc_comp *comp,
 
 	assert_non_null(cd);
 
-	memcpy(&cd->comp, comp, sizeof(*comp));
+	memcpy_s(COMP_GET_IPC(cd, sof_ipc_comp), sizeof(struct sof_ipc_comp),
+		 comp, sizeof(*comp));
 	cd->drv = drv;
 	list_init(&cd->bsource_list);
 	list_init(&cd->bsink_list);

--- a/test/cmocka/src/audio/pipeline/pipeline_connect_upstream.c
+++ b/test/cmocka/src/audio/pipeline/pipeline_connect_upstream.c
@@ -148,11 +148,13 @@ static void test_audio_pipeline_complete_connect_downstream_full(void **state)
 {
 	struct pipeline_connect_data *test_data = *state;
 	struct pipeline result = test_data->p;
+	struct sof_ipc_comp *comp;
 
 	cleanup_test_data(test_data);
 
 	/*Connecting first comp to second*/
-	test_data->second->comp.pipeline_id = PIPELINE_ID_SAME;
+	comp = dev_comp(test_data->second);
+	comp->pipeline_id = PIPELINE_ID_SAME;
 	list_item_append(&result.sched_comp->bsink_list,
 					 &test_data->b1->source_list);
 	test_data->b1->source = result.sched_comp;
@@ -177,11 +179,13 @@ static void test_audio_pipeline_complete_connect_upstream_full(void **state)
 {
 	struct pipeline_connect_data *test_data = *state;
 	struct pipeline result = test_data->p;
+	struct sof_ipc_comp *comp;
 
 	cleanup_test_data(test_data);
 
 	/*Connecting first comp to second*/
-	test_data->second->comp.pipeline_id = PIPELINE_ID_SAME;
+	comp = dev_comp(test_data->second);
+	comp->pipeline_id = PIPELINE_ID_SAME;
 	list_item_append(&result.sched_comp->bsource_list,
 					 &test_data->b1->sink_list);
 	test_data->b1->sink = test_data->first;
@@ -200,11 +204,13 @@ static void test_audio_pipeline_complete_connect_upstream_other_pipeline
 {
 	struct pipeline_connect_data *test_data = *state;
 	struct pipeline result = test_data->p;
+	struct sof_ipc_comp *comp;
 
 	cleanup_test_data(test_data);
 
 	/*Connecting first comp to second*/
-	test_data->second->comp.pipeline_id = PIPELINE_ID_DIFFERENT;
+	comp = dev_comp(test_data->second);
+	comp->pipeline_id = PIPELINE_ID_DIFFERENT;
 	list_item_append(&result.sched_comp->bsource_list,
 					 &test_data->b1->sink_list);
 	test_data->b1->sink = test_data->first;

--- a/test/cmocka/src/audio/pipeline/pipeline_connection_mocks.c
+++ b/test/cmocka/src/audio/pipeline/pipeline_connection_mocks.c
@@ -52,18 +52,20 @@ struct pipeline_connect_data *get_standard_connect_objects(void)
 	list_item_append(&sch->list, &schedulers->list);
 
 	struct comp_dev *first = calloc(sizeof(struct comp_dev), 1);
+	struct sof_ipc_comp *first_comp = dev_comp(first);
 
-	first->comp.id = 3;
-	first->comp.pipeline_id = PIPELINE_ID_SAME;
+	first_comp->id = 3;
+	first_comp->pipeline_id = PIPELINE_ID_SAME;
 	list_init(&first->bsink_list);
 	list_init(&first->bsource_list);
 	pipeline_connect_data->first = first;
 	pipe->sched_comp = first;
 
 	struct comp_dev *second = calloc(sizeof(struct comp_dev), 1);
+	struct sof_ipc_comp *second_comp = dev_comp(second);
 
-	second->comp.id = 4;
-	second->comp.pipeline_id = PIPELINE_ID_DIFFERENT;
+	second_comp->id = 4;
+	second_comp->pipeline_id = PIPELINE_ID_DIFFERENT;
 	list_init(&second->bsink_list);
 	list_init(&second->bsource_list);
 	pipeline_connect_data->second = second;

--- a/test/cmocka/src/audio/pipeline/pipeline_free.c
+++ b/test/cmocka/src/audio/pipeline/pipeline_free.c
@@ -82,6 +82,8 @@ static void test_audio_pipeline_free_disconnect_full(void **state)
 {
 	struct pipeline_connect_data *test_data = *state;
 	struct pipeline result = test_data->p;
+	struct sof_ipc_comp *first_comp;
+	struct sof_ipc_comp *second_comp;
 
 	cleanup_test_data(test_data);
 
@@ -89,8 +91,10 @@ static void test_audio_pipeline_free_disconnect_full(void **state)
 	result.source_comp = test_data->first;
 	test_data->first->pipeline = &result;
 	test_data->second->pipeline = &result;
-	test_data->second->comp.pipeline_id = PIPELINE_ID_SAME;
-	test_data->first->comp.pipeline_id = PIPELINE_ID_SAME;
+	first_comp = dev_comp(test_data->first);
+	second_comp = dev_comp(test_data->second);
+	second_comp->pipeline_id = PIPELINE_ID_SAME;
+	first_comp->pipeline_id = PIPELINE_ID_SAME;
 	test_data->b1->source = test_data->first;
 	list_item_append(&result.sched_comp->bsink_list,
 					 &test_data->b1->source_list);

--- a/tools/testbench/file.c
+++ b/tools/testbench/file.c
@@ -418,7 +418,7 @@ static struct comp_dev *file_new(struct sof_ipc_comp *comp)
 	if (!dev)
 		return NULL;
 
-	file = (struct sof_ipc_comp_file *)&dev->comp;
+	file = COMP_GET_IPC(dev, sof_ipc_comp_file);
 	assert(!memcpy_s(file, sizeof(*file), ipc_file,
 		       sizeof(struct sof_ipc_comp_file)));
 
@@ -497,7 +497,7 @@ static int file_params(struct comp_dev *dev,
 		       struct sof_ipc_stream_params *params)
 {
 	struct file_comp_data *cd = comp_get_drvdata(dev);
-	struct sof_ipc_comp_config *config = COMP_GET_CONFIG(dev);
+	struct sof_ipc_comp_config *config = dev_comp_config(dev);
 	struct audio_stream *stream;
 
 	/* file component source or sink buffer */
@@ -618,7 +618,7 @@ static int file_copy(struct comp_dev *dev)
 
 static int file_prepare(struct comp_dev *dev)
 {
-	struct sof_ipc_comp_config *config = COMP_GET_CONFIG(dev);
+	struct sof_ipc_comp_config *config = dev_comp_config(dev);
 	struct comp_buffer *buffer = NULL;
 	struct file_comp_data *cd = comp_get_drvdata(dev);
 	int ret = 0, periods;


### PR DESCRIPTION
This set of patches brings some tiny improvements to the internal component api. Component implementation may interact with the common generic component data in a better controlled way.

Having the device/component data getters implemented, it will be now much easier to refactor the common data into a single structure comp_base { comp, comp_config } which seems important to avoid issues like the incomplete memcpy and tricky access to the comp_config by assuming that it should follow the comp with no explicit data defines by the implementors. Such a refactor will be proposed on top of those changes (as a separate PR) once they are accepted and merged.

There are some tiny cleanup patches included.