### PR TITLE
echo reference signal: Interface and skeleton implementation.

### DIFF
--- a/src/drivers/generic/CMakeLists.txt
+++ b/src/drivers/generic/CMakeLists.txt
@@ -3,3 +3,5 @@
 if (CONFIG_DUMMY_DMA)
 	add_local_sources(sof dummy-dma.c)
 endif()
+
+add_local_sources(sof buf-copier-dma.c)

--- a/src/drivers/generic/CMakeLists.txt
+++ b/src/drivers/generic/CMakeLists.txt
@@ -4,4 +4,6 @@ if (CONFIG_DUMMY_DMA)
 	add_local_sources(sof dummy-dma.c)
 endif()
 
-add_local_sources(sof buf-copier-dma.c)
+add_local_sources(sof
+	buf-copier-dma.c
+	echo-ref.c)

--- a/src/drivers/generic/buf-copier-dma.c
+++ b/src/drivers/generic/buf-copier-dma.c
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2020 Intel Corporation. All rights reserved.
+//
+// Author: Artur Kloniecki <arturx.kloniecki@linux.intel.com>
+//
+
+ /**
+  * \file drivers/generic/buf-copier-dma.c
+  * \brief Driver for Virtual DMA with buffer copying capability.
+  * \author Artur Kloniecki <arturx.kloniecki@linux.intel.com>
+  */
+
+#include <sof/drivers/buf-copier-dma.h>
+#include <sof/lib/dma.h>
+#include <sof/trace/trace.h>
+#include <user/trace.h>
+
+static struct dma_chan_data *buf_copier_dma_channel_get(struct dma *dma,
+							unsigned int req_chan)
+{
+	trace_buf_copier("buf_copier_dma_channel_get()");
+	return NULL;
+}
+
+static void buf_copier_dma_channel_put(struct dma_chan_data *channel)
+{
+	trace_buf_copier("buf_copier_dma_channel_put()");
+}
+
+static int buf_copier_dma_start(struct dma_chan_data *channel)
+{
+	trace_buf_copier("buf_copier_dma_start()");
+	return 0;
+}
+
+static int buf_copier_dma_stop(struct dma_chan_data *channel)
+{
+	trace_buf_copier("buf_copier_dma_stop()");
+	return 0;
+}
+
+static int buf_copier_dma_copy(struct dma_chan_data *channel, int bytes,
+			       uint32_t flags)
+{
+	trace_buf_copier("buf_copier_dma_copy()");
+	return 0;
+}
+
+static int buf_copier_dma_pause(struct dma_chan_data *channel)
+{
+	trace_buf_copier("buf_copier_dma_pause()");
+	return 0;
+}
+
+static int buf_copier_dma_release(struct dma_chan_data *channel)
+{
+	trace_buf_copier("buf_copier_dma_release()");
+	return 0;
+}
+
+static int buf_copier_dma_status(struct dma_chan_data *channel,
+				 struct dma_chan_status *status,
+				 uint8_t direction)
+{
+	trace_buf_copier("buf_copier_dma_status()");
+	return 0;
+}
+
+static int buf_copier_dma_set_config(struct dma_chan_data *channel,
+				     struct dma_sg_config *config)
+{
+	trace_buf_copier("buf_copier_dma_set_config()");
+	return 0;
+}
+
+static int buf_copier_dma_dummy(struct dma *dma)
+{
+	trace_buf_copier("buf_copier_dma_dummy()");
+	return 0;
+}
+
+static int buf_copier_dma_probe(struct dma *dma)
+{
+	trace_buf_copier("buf_copier_dma_probe()");
+	return 0;
+}
+
+static int buf_copier_dma_remove(struct dma *dma)
+{
+	trace_buf_copier("buf_copier_dma_remove()");
+	return 0;
+}
+
+static int buf_copier_dma_get_data_size(struct dma_chan_data *channel,
+					uint32_t *avail, uint32_t *free)
+{
+	trace_buf_copier("buf_copier_dma_get_data_size()");
+	return 0;
+}
+
+static int buf_copier_dma_get_attribute(struct dma *dma, uint32_t type,
+					uint32_t *value)
+{
+	trace_buf_copier("buf_copier_dma_get_attribute()");
+	return 0;
+}
+
+static int buf_copier_dma_interrupt(struct dma_chan_data *channel,
+				    enum dma_irq_cmd cmd)
+{
+	trace_buf_copier("buf_copier_dma_interrupt()");
+	return 0;
+}
+
+const struct dma_ops buf_copier_dma_ops = {
+	.channel_get = buf_copier_dma_channel_get,
+	.channel_put = buf_copier_dma_channel_put,
+	.start = buf_copier_dma_start,
+	.stop = buf_copier_dma_stop,
+	.copy = buf_copier_dma_copy,
+	.pause = buf_copier_dma_pause,
+	.release = buf_copier_dma_release,
+	.status = buf_copier_dma_status,
+	.set_config = buf_copier_dma_set_config,
+	.pm_context_restore = buf_copier_dma_dummy,
+	.pm_context_store = buf_copier_dma_dummy,
+	.probe = buf_copier_dma_probe,
+	.remove = buf_copier_dma_remove,
+	.get_data_size = buf_copier_dma_get_data_size,
+	.get_attribute = buf_copier_dma_get_attribute,
+	.interrupt = buf_copier_dma_interrupt,
+};

--- a/src/drivers/generic/echo-ref.c
+++ b/src/drivers/generic/echo-ref.c
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2020 Intel Corporation. All rights reserved.
+//
+// Author: Artur Kloniecki <arturx.kloniecki@linux.intel.com>
+//
+
+ /**
+  * \file drivers/generic/echo-ref.c
+  * \brief Driver for Echo Reference Signal Virtual DAI
+  * \author Artur Kloniecki <arturx.kloniecki@linux.intel.com>
+  */
+
+#include <ipc/dai.h>
+#include <sof/drivers/echo-ref.h>
+#include <sof/lib/dai.h>
+#include <sof/lib/dma.h>
+#include <sof/trace/trace.h>
+#include <user/trace.h>
+
+static int echo_ref_probe(struct dai *dai)
+{
+	trace_echo("echo_ref_probe()");
+	return 0;
+}
+
+static int echo_ref_remove(struct dai *dai)
+{
+	trace_echo("echo_ref_remove()");
+	return 0;
+}
+
+static int echo_ref_set_config(struct dai *dai,
+			       struct sof_ipc_dai_config *config)
+{
+	trace_echo("echo_ref_set_config()");
+	return 0;
+}
+
+static int echo_ref_trigger(struct dai *dai, int cmd, int direction)
+{
+	trace_echo("echo_ref_trigger()");
+	return 0;
+}
+
+static int echo_ref_get_handshake(struct dai *dai, int direction, int stream_id)
+{
+	trace_echo("echo_ref_get_handshake()");
+	return 0;
+}
+
+static int echo_ref_get_fifo(struct dai *dai, int direction, int stream_id)
+{
+	trace_echo("echo_ref_get_fifo()");
+	return 0;
+}
+
+static int echo_ref_dummy(struct dai *dai)
+{
+	trace_echo("echo_ref_dummy()");
+	return 0;
+}
+
+static int echo_ref_ts_config(struct dai *dai, struct timestamp_cfg *cfg)
+{
+	trace_echo("echo_ref_ts_config()");
+	return 0;
+}
+
+static int echo_ref_ts_start(struct dai *dai, struct timestamp_cfg *cfg)
+{
+	trace_echo("echo_ref_ts_start()");
+	return 0;
+}
+
+static int echo_ref_ts_stop(struct dai *dai, struct timestamp_cfg *cfg)
+{
+	trace_echo("echo_ref_ts_stop()");
+	return 0;
+}
+
+static int echo_ref_ts_get(struct dai *dai, struct timestamp_cfg *cfg,
+			   struct timestamp_data *tsd)
+{
+	trace_echo("echo_ref_ts_get()");
+	return 0;
+}
+
+const struct dai_driver echo_ref_driver = {
+	.type = SOF_DAI_ECHO_REF,
+	.dma_caps = DMA_CAP_GP_LP | DMA_CAP_GP_HP,
+	.dma_dev = DMA_DEV_BUFFER,
+	.ops = {
+		.set_config = echo_ref_set_config,
+		.trigger = echo_ref_trigger,
+		.pm_context_restore = echo_ref_dummy,
+		.pm_context_store = echo_ref_dummy,
+		.get_handshake = echo_ref_get_handshake,
+		.get_fifo = echo_ref_get_fifo,
+		.probe = echo_ref_probe,
+		.remove = echo_ref_remove,
+	},
+	.ts_ops = {
+		.ts_config = echo_ref_ts_config,
+		.ts_start = echo_ref_ts_start,
+		.ts_stop = echo_ref_ts_stop,
+		.ts_get = echo_ref_ts_get,
+	},
+};

--- a/src/include/ipc/dai-generic.h
+++ b/src/include/ipc/dai-generic.h
@@ -1,0 +1,26 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2020 Intel Corporation. All rights reserved.
+ *
+ * Author: Artur Kloniecki <arturx.kloniecki@linux.intel.com>
+ */
+
+/**
+ * \file include/ipc/dai-generic.h
+ * \brief IPC definitions for Generic DAIs
+ * \author Artur Kloniecki <arturx.kloniecki@linux.intel.com>
+ */
+
+#ifndef __IPC_DAI_GENERIC_H__
+#define __IPC_DAI_GENERIC_H__
+
+#include <ipc/header.h>
+#include <stdint.h>
+
+/* Echo Reference Configuration Request - SOF_IPC_DAI_ECHO_CONFIG */
+struct sof_ipc_dai_echo_ref_params {
+	struct sof_ipc_hdr hdr;
+	uint32_t buffer_id;
+} __attribute__((packed));
+
+#endif /* __IPC_DAI_GENERIC_H__ */

--- a/src/include/ipc/dai.h
+++ b/src/include/ipc/dai.h
@@ -16,6 +16,7 @@
 #ifndef __IPC_DAI_H__
 #define __IPC_DAI_H__
 
+#include <ipc/dai-generic.h>
 #include <ipc/dai-intel.h>
 #include <ipc/dai-imx.h>
 #include <ipc/header.h>
@@ -61,6 +62,7 @@ enum sof_ipc_dai_type {
 	SOF_DAI_INTEL_ALH,		/**< Intel ALH */
 	SOF_DAI_IMX_SAI,                /**< i.MX SAI */
 	SOF_DAI_IMX_ESAI,               /**< i.MX ESAI */
+	SOF_DAI_ECHO_REF,		/**< Echo reference virtual DAI */
 };
 
 /* general purpose DAI configuration */
@@ -84,6 +86,7 @@ struct sof_ipc_dai_config {
 		struct sof_ipc_dai_alh_params alh;
 		struct sof_ipc_dai_esai_params esai;
 		struct sof_ipc_dai_sai_params sai;
+		struct sof_ipc_dai_echo_ref_params echo;
 	};
 } __attribute__((packed));
 

--- a/src/include/sof/drivers/buf-copier-dma.h
+++ b/src/include/sof/drivers/buf-copier-dma.h
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2020 Intel Corporation. All rights reserved.
+ *
+ * Author: Artur Kloniecki <arturx.kloniecki@linux.intel.com>
+ */
+
+#ifndef __SOF_DRIVERS_BUF_COPIER_DMA_H__
+#define __SOF_DRIVERS_BUF_COPIER_DMA_H__
+
+#include <sof/lib/dma.h>
+#include <sof/trace/trace.h>
+#include <user/trace.h>
+
+#define trace_buf_copier(__e, ...) \
+	trace_event(TRACE_CLASS_DMA, __e, ##__VA_ARGS__)
+#define tracev_buf_copier(__e, ...) \
+	tracev_event(TRACE_CLASS_DMA, __e, ##__VA_ARGS__)
+#define trace_buf_copier_error(__e, ...) \
+	trace_error(TRACE_CLASS_DMA, __e, ##__VA_ARGS__)
+
+extern const struct dma_ops buf_copier_dma_ops;
+
+#endif /* __SOF_DRIVERS_BUF_COPIER_DMA_H__ */

--- a/src/include/sof/drivers/echo-ref.h
+++ b/src/include/sof/drivers/echo-ref.h
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2020 Intel Corporation. All rights reserved.
+ *
+ * Author: Artur Kloniecki <arturx.kloniecki@linux.intel.com>
+ */
+
+#ifndef __SOF_DRIVERS_ECHO_REF_H__
+#define __SOF_DRIVERS_ECHO_REF_H__
+
+#include <sof/bit.h>
+#include <sof/lib/dai.h>
+#include <sof/trace/trace.h>
+#include <user/trace.h>
+
+#define trace_echo(__e, ...) \
+	trace_event(TRACE_CLASS_DAI, __e, ##__VA_ARGS__)
+#define tracev_echo(__e, ...) \
+	tracev_event(TRACE_CLASS_DAI, __e, ##__VA_ARGS__)
+#define trace_echo_error(__e, ...) \
+	trace_error(TRACE_CLASS_DAI, __e, ##__VA_ARGS__)
+
+extern const struct dai_driver echo_ref_driver;
+#endif /* __SOF_DRIVERS_ECHO_REF_H__ */

--- a/src/include/sof/lib/dma.h
+++ b/src/include/sof/lib/dma.h
@@ -47,6 +47,7 @@ struct comp_buffer;
 #define DMA_CAP_HDA		BIT(0) /**< HDA DMA */
 #define DMA_CAP_GP_LP		BIT(1) /**< GP LP DMA */
 #define DMA_CAP_GP_HP		BIT(2) /**< GP HP DMA */
+#define DMA_CAP_BUF_COPIER	BIT(3) /**< Buffer copying DMA */
 
 /* DMA dev type bitmasks used to define the type of DMA */
 
@@ -58,6 +59,7 @@ struct comp_buffer;
 #define DMA_DEV_ALH		BIT(5) /**< connectable to ALH link */
 #define DMA_DEV_SAI		BIT(6) /**< connectable to SAI fifo */
 #define DMA_DEV_ESAI		BIT(7) /**< connectable to ESAI fifo */
+#define DMA_DEV_BUFFER		BIT(8) /**< connectable to buffer component */
 
 /* DMA access privilege flag */
 #define DMA_ACCESS_EXCLUSIVE	1

--- a/src/platform/apollolake/include/platform/lib/dma.h
+++ b/src/platform/apollolake/include/platform/lib/dma.h
@@ -12,7 +12,7 @@
 #define __PLATFORM_LIB_DMA_H__
 
 /* number of supported DMACs */
-#define PLATFORM_NUM_DMACS	6
+#define PLATFORM_NUM_DMACS	7
 
 /* max number of supported DMA channels */
 #define PLATFORM_MAX_DMA_CHAN	8
@@ -26,6 +26,7 @@
 #define DMA_HOST_OUT_DMAC	5
 #define DMA_LINK_IN_DMAC	6
 #define DMA_LINK_OUT_DMAC	7
+#define DMA_BUF_COPIER		8
 
 /* mappings - TODO improve API to get type */
 #define DMA_ID_DMAC0		DMA_HOST_IN_DMAC
@@ -36,6 +37,7 @@
 #define DMA_ID_DMAC5		DMA_GP_HP_DMAC1
 #define DMA_ID_DMAC6		DMA_LINK_IN_DMAC
 #define DMA_ID_DMAC7		DMA_LINK_OUT_DMAC
+#define DMA_ID_DMAC8		DMA_BUF_COPIER
 
 /* handshakes */
 #define DMA_HANDSHAKE_DMIC_CH0	0

--- a/src/platform/baytrail/include/platform/lib/dma.h
+++ b/src/platform/baytrail/include/platform/lib/dma.h
@@ -14,9 +14,9 @@
 #include <config.h>
 
 #if defined CONFIG_CHERRYTRAIL_EXTRA_DW_DMA
-#define PLATFORM_NUM_DMACS	3
+#define PLATFORM_NUM_DMACS	4
 #else
-#define PLATFORM_NUM_DMACS	2
+#define PLATFORM_NUM_DMACS	3
 #endif
 
 /* max number of supported DMA channels */
@@ -25,6 +25,7 @@
 #define DMA_ID_DMAC0	0
 #define DMA_ID_DMAC1	1
 #define DMA_ID_DMAC2	2
+#define DMA_ID_DMAC3	3
 
 #define DMA_HANDSHAKE_SSP0_RX	0
 #define DMA_HANDSHAKE_SSP0_TX	1

--- a/src/platform/baytrail/lib/dai.c
+++ b/src/platform/baytrail/lib/dai.c
@@ -5,6 +5,7 @@
 // Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
 
 #include <sof/common.h>
+#include <sof/drivers/echo-ref.h>
 #include <sof/drivers/interrupt.h>
 #include <sof/drivers/ssp.h>
 #include <sof/lib/dai.h>
@@ -116,12 +117,24 @@ static SHARED_DATA struct dai ssp[] = {
 #endif
 };
 
+static SHARED_DATA struct dai echo_ref[] = {
+{
+	.index = 0,
+	.drv = &echo_ref_driver,
+},
+};
+
 const struct dai_type_info dti[] = {
 	{
 		.type = SOF_DAI_INTEL_SSP,
 		.dai_array = ssp,
 		.num_dais = ARRAY_SIZE(ssp)
-	}
+	},
+	{
+		.type = SOF_DAI_ECHO_REF,
+		.dai_array = echo_ref,
+		.num_dais = ARRAY_SIZE(echo_ref)
+	},
 };
 
 const struct dai_info lib_dai = {
@@ -138,6 +151,11 @@ int dai_init(struct sof *sof)
 		spinlock_init(&ssp[i].lock);
 
 	platform_shared_commit(ssp, sizeof(*ssp));
+
+	for (i = 0; i < ARRAY_SIZE(echo_ref); i++)
+		spinlock_init(&echo_ref[i].lock);
+
+	platform_shared_commit(echo_ref, sizeof(*echo_ref));
 
 	sof->dai_info = &lib_dai;
 

--- a/src/platform/baytrail/lib/dma.c
+++ b/src/platform/baytrail/lib/dma.c
@@ -5,6 +5,7 @@
 // Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
 
 #include <sof/common.h>
+#include <sof/drivers/buf-copier-dma.h>
 #include <sof/drivers/dw-dma.h>
 #include <sof/drivers/interrupt.h>
 #include <sof/lib/dma.h>
@@ -168,6 +169,17 @@ SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
 	.ops		= &dw_dma_ops,
 },
 #endif
+{
+	/* Buf copier DMAC */
+	.plat_data = {
+		.id = DMA_ID_DMAC2,
+		.dir = DMA_DIR_MEM_TO_MEM,
+		.caps = DMA_CAP_BUF_COPIER,
+		.devs = DMA_DEV_BUFFER,
+		.channels = 1,
+	},
+	.ops = &buf_copier_dma_ops,
+},
 };
 
 const struct dma_info lib_dma = {

--- a/src/platform/cannonlake/include/platform/lib/dma.h
+++ b/src/platform/cannonlake/include/platform/lib/dma.h
@@ -13,7 +13,7 @@
 #define __PLATFORM_LIB_DMA_H__
 
 /* number of supported DMACs */
-#define PLATFORM_NUM_DMACS	6
+#define PLATFORM_NUM_DMACS	7
 
 /* max number of supported DMA channels */
 #define PLATFORM_MAX_DMA_CHAN	9
@@ -27,6 +27,7 @@
 #define DMA_HOST_OUT_DMAC	5
 #define DMA_LINK_IN_DMAC	6
 #define DMA_LINK_OUT_DMAC	7
+#define DMA_BUF_COPIER		8
 
 /* mappings - TODO improve API to get type */
 #define DMA_ID_DMAC0	DMA_HOST_IN_DMAC
@@ -37,6 +38,7 @@
 #define DMA_ID_DMAC5	DMA_GP_HP_DMAC1
 #define DMA_ID_DMAC6	DMA_LINK_IN_DMAC
 #define DMA_ID_DMAC7	DMA_LINK_OUT_DMAC
+#define DMA_ID_DMAC8	DMA_BUF_COPIER
 
 /* handshakes */
 #define DMA_HANDSHAKE_DMIC_CH0	0

--- a/src/platform/haswell/include/platform/lib/dma.h
+++ b/src/platform/haswell/include/platform/lib/dma.h
@@ -10,13 +10,14 @@
 #ifndef __PLATFORM_LIB_DMA_H__
 #define __PLATFORM_LIB_DMA_H__
 
-#define PLATFORM_NUM_DMACS		2
+#define PLATFORM_NUM_DMACS		3
 
 /* max number of supported DMA channels */
 #define PLATFORM_MAX_DMA_CHAN	8
 
 #define DMA_ID_DMAC0			0
 #define DMA_ID_DMAC1			1
+#define DMA_ID_DMAC2			2
 
 #define DMA_HANDSHAKE_SSP1_RX		0
 #define DMA_HANDSHAKE_SSP1_TX		1

--- a/src/platform/haswell/lib/dai.c
+++ b/src/platform/haswell/lib/dai.c
@@ -5,6 +5,7 @@
 // Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
 
 #include <sof/common.h>
+#include <sof/drivers/echo-ref.h>
 #include <sof/drivers/interrupt.h>
 #include <sof/drivers/ssp.h>
 #include <sof/lib/dai.h>
@@ -49,12 +50,24 @@ static SHARED_DATA struct dai ssp[2] = {
 },
 };
 
+static SHARED_DATA struct dai echo_ref[] = {
+{
+	.index = 0,
+	.drv = &echo_ref_driver,
+},
+};
+
 const struct dai_type_info dti[] = {
 	{
 		.type = SOF_DAI_INTEL_SSP,
 		.dai_array = ssp,
 		.num_dais = ARRAY_SIZE(ssp)
-	}
+	},
+	{
+		.type = SOF_DAI_ECHO_REF,
+		.dai_array = echo_ref,
+		.num_dais = ARRAY_SIZE(echo_ref)
+	},
 };
 
 const struct dai_info lib_dai = {
@@ -71,6 +84,11 @@ int dai_init(struct sof *sof)
 		spinlock_init(&ssp[i].lock);
 
 	platform_shared_commit(ssp, sizeof(*ssp));
+
+	for (i = 0; i < ARRAY_SIZE(echo_ref); i++)
+		spinlock_init(&echo_ref[i].lock);
+
+	platform_shared_commit(echo_ref, sizeof(*echo_ref));
 
 	sof->dai_info = &lib_dai;
 

--- a/src/platform/haswell/lib/dma.c
+++ b/src/platform/haswell/lib/dma.c
@@ -5,6 +5,7 @@
 // Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
 
 #include <sof/common.h>
+#include <sof/drivers/buf-copier-dma.h>
 #include <sof/drivers/dw-dma.h>
 #include <sof/drivers/interrupt.h>
 #include <sof/lib/dma.h>
@@ -112,7 +113,19 @@ SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
 		.channels	= 8,
 	},
 	.ops		= &dw_dma_ops,
-},};
+},
+{
+	/* Buf copier DMAC */
+	.plat_data = {
+		.id		= DMA_ID_DMAC2,
+		.dir		= DMA_DIR_MEM_TO_MEM,
+		.caps		= DMA_CAP_BUF_COPIER,
+		.devs		= DMA_DEV_BUFFER,
+		.channels	= 1,
+	},
+	.ops		= &buf_copier_dma_ops,
+},
+};
 
 const struct dma_info lib_dma = {
 	.dma_array = dma,

--- a/src/platform/icelake/include/platform/lib/dma.h
+++ b/src/platform/icelake/include/platform/lib/dma.h
@@ -13,7 +13,7 @@
 #define __PLATFORM_LIB_DMA_H__
 
 /* number of supported DMACs */
-#define PLATFORM_NUM_DMACS	6
+#define PLATFORM_NUM_DMACS	7
 
 /* max number of supported DMA channels */
 #define PLATFORM_MAX_DMA_CHAN	9
@@ -27,6 +27,7 @@
 #define DMA_HOST_OUT_DMAC	5
 #define DMA_LINK_IN_DMAC	6
 #define DMA_LINK_OUT_DMAC	7
+#define DMA_BUF_COPIER		8
 
 /* mappings - TODO improve API to get type */
 #define DMA_ID_DMAC0	DMA_HOST_IN_DMAC
@@ -37,6 +38,7 @@
 #define DMA_ID_DMAC5	DMA_GP_HP_DMAC1
 #define DMA_ID_DMAC6	DMA_LINK_IN_DMAC
 #define DMA_ID_DMAC7	DMA_LINK_OUT_DMAC
+#define DMA_ID_DMAC8	DMA_BUF_COPIER
 
 /* handshakes */
 #define DMA_HANDSHAKE_DMIC_CH0	0

--- a/src/platform/imx8/include/platform/lib/dma.h
+++ b/src/platform/imx8/include/platform/lib/dma.h
@@ -10,13 +10,14 @@
 #ifndef __PLATFORM_LIB_DMA_H__
 #define __PLATFORM_LIB_DMA_H__
 
-#define PLATFORM_NUM_DMACS	2
+#define PLATFORM_NUM_DMACS	3
 
 /* max number of supported DMA channels */
 #define PLATFORM_MAX_DMA_CHAN	32
 
-#define DMA_ID_EDMA0	0
-#define DMA_ID_HOST	1
+#define DMA_ID_EDMA0		0
+#define DMA_ID_HOST		1
+#define DMA_ID_BUF_COPIER	2
 
 #define dma_chan_irq(dma, chan) \
 	irqstr_get_sof_int(((int *)dma->plat_data.drv_plat_data)[chan])

--- a/src/platform/imx8/lib/dai.c
+++ b/src/platform/imx8/lib/dai.c
@@ -5,6 +5,7 @@
 // Author: Daniel Baluta <daniel.baluta@nxp.com>
 
 #include <sof/common.h>
+#include <sof/drivers/echo-ref.h>
 #include <sof/drivers/edma.h>
 #include <sof/drivers/esai.h>
 #include <sof/drivers/sai.h>
@@ -64,6 +65,13 @@ static SHARED_DATA struct dai sai[] = {
 },
 };
 
+static SHARED_DATA struct dai echo_ref[] = {
+{
+	.index = 0,
+	.drv = &echo_ref_driver,
+},
+};
+
 const struct dai_type_info dti[] = {
 	{
 		.type = SOF_DAI_IMX_SAI,
@@ -74,6 +82,11 @@ const struct dai_type_info dti[] = {
 		.type = SOF_DAI_IMX_ESAI,
 		.dai_array = esai,
 		.num_dais = ARRAY_SIZE(esai)
+	},
+	{
+		.type = SOF_DAI_ECHO_REF,
+		.dai_array = echo_ref,
+		.num_dais = ARRAY_SIZE(echo_ref)
 	},
 };
 
@@ -96,6 +109,11 @@ int dai_init(struct sof *sof)
 		spinlock_init(&sai[i].lock);
 
 	platform_shared_commit(sai, sizeof(*sai));
+
+	for (i = 0; i < ARRAY_SIZE(echo_ref); i++)
+		spinlock_init(&echo_ref[i].lock);
+
+	platform_shared_commit(echo_ref, sizeof(*echo_ref));
 
 	sof->dai_info = &lib_dai;
 

--- a/src/platform/imx8/lib/dma.c
+++ b/src/platform/imx8/lib/dma.c
@@ -5,6 +5,7 @@
 // Author: Daniel Baluta <daniel.baluta@nxp.com>
 
 #include <sof/common.h>
+#include <sof/drivers/buf-copier-dma.h>
 #include <sof/drivers/edma.h>
 #include <sof/drivers/interrupt.h>
 #include <sof/lib/dma.h>
@@ -43,6 +44,17 @@ SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
 		.channels	= 16,
 	},
 	.ops	= &dummy_dma_ops,
+},
+{
+	/* Buf copier DMAC */
+	.plat_data = {
+		.id		= DMA_ID_BUF_COPIER,
+		.dir		= DMA_DIR_MEM_TO_MEM,
+		.caps		= DMA_CAP_BUF_COPIER,
+		.devs		= DMA_DEV_BUFFER,
+		.channels	= 1,
+	},
+	.ops	= &buf_copier_dma_ops,
 },
 };
 

--- a/src/platform/imx8m/include/platform/lib/dma.h
+++ b/src/platform/imx8m/include/platform/lib/dma.h
@@ -10,13 +10,14 @@
 #ifndef __PLATFORM_LIB_DMA_H__
 #define __PLATFORM_LIB_DMA_H__
 
-#define PLATFORM_NUM_DMACS	2
+#define PLATFORM_NUM_DMACS	3
 
 /* max number of supported DMA channels */
 #define PLATFORM_MAX_DMA_CHAN	32
 
-#define DMA_ID_EDMA0	0
-#define DMA_ID_HOST	1
+#define DMA_ID_EDMA0		0
+#define DMA_ID_HOST		1
+#define DMA_ID_BUF_COPIER	2
 
 #define dma_chan_irq(dma, chan) \
 	irqstr_get_sof_int(((int *)dma->plat_data.drv_plat_data)[chan])

--- a/src/platform/imx8m/lib/dai.c
+++ b/src/platform/imx8m/lib/dai.c
@@ -5,6 +5,7 @@
 // Author: Daniel Baluta <daniel.baluta@nxp.com>
 
 #include <sof/common.h>
+#include <sof/drivers/echo-ref.h>
 #include <sof/drivers/sai.h>
 #include <sof/lib/dai.h>
 #include <sof/lib/memory.h>
@@ -23,11 +24,23 @@ static SHARED_DATA struct dai sai[] = {
 },
 };
 
+static SHARED_DATA struct dai echo_ref[] = {
+{
+	.index = 0,
+	.drv = &echo_ref_driver,
+},
+};
+
 const struct dai_type_info dti[] = {
 	{
 		.type = SOF_DAI_IMX_SAI,
 		.dai_array = sai,
 		.num_dais = ARRAY_SIZE(sai)
+	},
+	{
+		.type = SOF_DAI_ECHO_REF,
+		.dai_array = echo_ref,
+		.num_dais = ARRAY_SIZE(echo_ref)
 	},
 };
 
@@ -45,6 +58,11 @@ int dai_init(struct sof *sof)
 		spinlock_init(&sai[i].lock);
 
 	platform_shared_commit(sai, sizeof(*sai));
+
+	for (i = 0; i < ARRAY_SIZE(echo_ref); i++)
+		spinlock_init(&echo_ref[i].lock);
+
+	platform_shared_commit(echo_ref, sizeof(*echo_ref));
 
 	sof->dai_info = &lib_dai;
 

--- a/src/platform/imx8m/lib/dma.c
+++ b/src/platform/imx8m/lib/dma.c
@@ -5,6 +5,7 @@
 // Author: Daniel Baluta <daniel.baluta@nxp.com>
 
 #include <sof/common.h>
+#include <sof/drivers/buf-copier-dma.h>
 #include <sof/drivers/interrupt.h>
 #include <sof/lib/dma.h>
 #include <sof/lib/memory.h>
@@ -22,6 +23,17 @@ SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
 		.channels	= 16,
 	},
 	.ops	= &dummy_dma_ops,
+},
+{
+	/* Buf copier DMAC */
+	.plat_data = {
+		.id		= DMA_ID_BUF_COPIER,
+		.dir		= DMA_DIR_MEM_TO_MEM,
+		.caps		= DMA_CAP_BUF_COPIER,
+		.devs		= DMA_DEV_BUFFER,
+		.channels	= 1,
+	},
+	.ops	= &buf_copier_dma_ops,
 },
 };
 

--- a/src/platform/intel/cavs/lib/dai.c
+++ b/src/platform/intel/cavs/lib/dai.c
@@ -8,6 +8,7 @@
 //         Janusz Jankowski <janusz.jankowski@linux.intel.com>
 
 #include <sof/common.h>
+#include <sof/drivers/echo-ref.h>
 #include <sof/drivers/hda.h>
 #include <sof/drivers/interrupt.h>
 #include <sof/drivers/mn.h>
@@ -87,6 +88,7 @@ static SHARED_DATA struct dai alh[DAI_NUM_ALH_BI_DIR_LINKS];
 #endif
 
 static SHARED_DATA struct dai hda[(DAI_NUM_HDA_OUT + DAI_NUM_HDA_IN)];
+static SHARED_DATA struct dai echo_ref[1];
 
 const struct dai_type_info dti[] = {
 #if CONFIG_CAVS_SSP
@@ -113,8 +115,13 @@ const struct dai_type_info dti[] = {
 		.type = SOF_DAI_INTEL_ALH,
 		.dai_array = cache_to_uncache((struct dai *)alh),
 		.num_dais = ARRAY_SIZE(alh)
-	}
+	},
 #endif
+	{
+		.type = SOF_DAI_ECHO_REF,
+		.dai_array = cache_to_uncache((struct dai *)echo_ref),
+		.num_dais = ARRAY_SIZE(echo_ref)
+	},
 };
 
 const struct dai_info lib_dai = {
@@ -199,6 +206,16 @@ int dai_init(struct sof *sof)
 
 	platform_shared_commit(dai, sizeof(*dai) * ARRAY_SIZE(alh));
 #endif
+
+	dai = cache_to_uncache((struct dai *)echo_ref);
+
+	for (i = 0; i < ARRAY_SIZE(echo_ref); i++) {
+		dai[i].index = i;
+		dai[i].drv = &echo_ref_driver;
+		spinlock_init(&dai[i].lock);
+	}
+
+	platform_shared_commit(dai, sizeof(*dai) * ARRAY_SIZE(echo_ref));
 
 	return 0;
 }

--- a/src/platform/intel/cavs/lib/dma.c
+++ b/src/platform/intel/cavs/lib/dma.c
@@ -8,6 +8,7 @@
 //         Janusz Jankowski <janusz.jankowski@linux.intel.com>
 
 #include <sof/common.h>
+#include <sof/drivers/buf-copier-dma.h>
 #include <sof/drivers/dw-dma.h>
 #include <sof/drivers/hda-dma.h>
 #include <sof/drivers/interrupt.h>
@@ -151,6 +152,17 @@ struct SHARED_DATA dma dma[PLATFORM_NUM_DMACS] = {
 	},
 	.ops		= &dw_dma_ops,
 },
+{
+	/* Buf copier DMAC */
+	.plat_data = {
+		.id		= DMA_BUF_COPIER,
+		.dir		= DMA_DIR_MEM_TO_MEM,
+		.caps		= DMA_CAP_BUF_COPIER,
+		.devs		= DMA_DEV_BUFFER,
+		.channels	= 1,
+	},
+	.ops		= &buf_copier_dma_ops,
+},
 };
 
 #else
@@ -234,7 +246,19 @@ SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
 		.chan_size	= GTW_LINK_OUT_STREAM_SIZE,
 	},
 	.ops		= &hda_link_dma_ops,
-},};
+},
+{
+	/* Buf copier DMAC */
+	.plat_data = {
+		.id		= DMA_BUF_COPIER,
+		.dir		= DMA_DIR_MEM_TO_MEM,
+		.caps		= DMA_CAP_BUF_COPIER,
+		.devs		= DMA_DEV_BUFFER,
+		.channels	= 1,
+	},
+	.ops		= &buf_copier_dma_ops,
+},
+};
 #endif
 
 const struct dma_info lib_dma = {

--- a/src/platform/library/include/platform/lib/dma.h
+++ b/src/platform/library/include/platform/lib/dma.h
@@ -12,9 +12,11 @@
 
 #define DMA_ID_DMAC0	0
 #define DMA_ID_DMAC1	1
+#define DMA_ID_DMAC2	2
 
 #define DMA_DEV_PCM			0
 #define DMA_DEV_WAV			1
+#define DMA_BUF_COPIER			2
 
 #endif /* __PLATFORM_LIB_DMA_H__ */
 

--- a/src/platform/suecreek/include/platform/lib/dma.h
+++ b/src/platform/suecreek/include/platform/lib/dma.h
@@ -13,7 +13,7 @@
 #define __PLATFORM_LIB_DMA_H__
 
 /* number of supported DMACs */
-#define PLATFORM_NUM_DMACS	3
+#define PLATFORM_NUM_DMACS	4
 
 /* max number of supported DMA channels */
 #define PLATFORM_MAX_DMA_CHAN	8
@@ -22,12 +22,14 @@
 #define DMA_GP_LP_DMAC0		0
 #define DMA_GP_LP_DMAC1		1
 #define DMA_GP_LP_DMAC2		2
+#define DMA_BUF_COPIER		3
 
 
 /* mappings - TODO improve API to get type */
 #define DMA_ID_DMAC0	DMA_GP_LP_DMAC0
 #define DMA_ID_DMAC1	DMA_GP_LP_DMAC1
 #define DMA_ID_DMAC2	DMA_GP_LP_DMAC1
+#define DMA_ID_DMAC3	DMA_BUF_COPIER
 
 /* handshakes */
 #define DMA_HANDSHAKE_DMIC_CH0	0

--- a/src/platform/tigerlake/include/platform/lib/dma.h
+++ b/src/platform/tigerlake/include/platform/lib/dma.h
@@ -13,7 +13,7 @@
 #define __PLATFORM_LIB_DMA_H__
 
 /* number of supported DMACs */
-#define PLATFORM_NUM_DMACS	6
+#define PLATFORM_NUM_DMACS	7
 
 /* max number of supported DMA channels */
 #define PLATFORM_MAX_DMA_CHAN	9
@@ -27,6 +27,7 @@
 #define DMA_HOST_OUT_DMAC	5
 #define DMA_LINK_IN_DMAC	6
 #define DMA_LINK_OUT_DMAC	7
+#define DMA_BUF_COPIER		8
 
 /* mappings - TODO improve API to get type */
 #define DMA_ID_DMAC0	DMA_HOST_IN_DMAC
@@ -37,6 +38,7 @@
 #define DMA_ID_DMAC5	DMA_GP_HP_DMAC1
 #define DMA_ID_DMAC6	DMA_LINK_IN_DMAC
 #define DMA_ID_DMAC7	DMA_LINK_OUT_DMAC
+#define DMA_ID_DMAC8	DMA_BUF_COPIER
 
 /* handshakes */
 #define DMA_HANDSHAKE_DMIC_CH0	0


### PR DESCRIPTION
Echo reference signal is generated by virtual Echo Ref DAI, accompanied
with virtual buffer copier DMA. DMA will be attached to buffer component
from which echo reference signal will be collected.

As for topology, Echo reference DAI should serve as backend of timer-driven
capture pipeline, to properly report back zero-signal, while source pipeline,
to which it is attached, is paused, stopped or destroyed.

Signed-off-by: ArturX Kloniecki <arturx.kloniecki@linux.intel.com>