### PR TITLE
Init component's back pointer to its driver early

### DIFF
--- a/src/audio/asrc/asrc.c
+++ b/src/audio/asrc/asrc.c
@@ -780,7 +780,8 @@ static int asrc_control_loop(struct comp_dev *dev, struct comp_data *cd)
 	tmp = ((int64_t)COEF_C1) * skew + ((int64_t)COEF_C2) * cd->skew;
 	cd->skew = sat_int32(Q_SHIFT_RND(tmp, 60, 30));
 	asrc_update_drift(dev, cd->asrc_obj, cd->skew);
-	comp_cl_dbg("skew %d %d %d %d", delta_sample, delta_ts, skew, cd->skew);
+	comp_cl_dbg(&comp_asrc, "skew %d %d %d %d", delta_sample, delta_ts,
+		    skew, cd->skew);
 	return 0;
 }
 

--- a/src/audio/asrc/asrc.c
+++ b/src/audio/asrc/asrc.c
@@ -247,7 +247,8 @@ static void src_copy_s16(struct comp_dev *dev,
 	}
 }
 
-static struct comp_dev *asrc_new(struct sof_ipc_comp *comp)
+static struct comp_dev *asrc_new(const struct comp_driver *drv,
+				 struct sof_ipc_comp *comp)
 {
 	struct comp_dev *dev;
 	struct sof_ipc_comp_asrc *asrc;
@@ -271,6 +272,7 @@ static struct comp_dev *asrc_new(struct sof_ipc_comp *comp)
 		      COMP_SIZE(struct sof_ipc_comp_asrc));
 	if (!dev)
 		return NULL;
+	dev->drv = drv;
 
 	asrc = COMP_GET_IPC(dev, sof_ipc_comp_asrc);
 	err = memcpy_s(asrc, sizeof(*asrc), ipc_asrc,

--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -69,13 +69,12 @@ struct comp_dev *comp_new(struct sof_ipc_comp *comp)
 	}
 
 	/* create the new component */
-	cdev = drv->ops.new(comp);
+	cdev = drv->ops.new(drv, comp);
 	if (!cdev) {
 		comp_cl_err(drv, "comp_new() error: unable to create the new component");
 		return NULL;
 	}
 
-	cdev->drv = drv;
 	list_init(&cdev->bsource_list);
 	list_init(&cdev->bsink_list);
 

--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -118,7 +118,8 @@ static void dai_dma_cb(void *arg, enum notify_id type, void *data)
 	}
 }
 
-static struct comp_dev *dai_new(struct sof_ipc_comp *comp)
+static struct comp_dev *dai_new(const struct comp_driver *drv,
+				struct sof_ipc_comp *comp)
 {
 	struct comp_dev *dev;
 	struct sof_ipc_comp_dai *dai;
@@ -133,6 +134,7 @@ static struct comp_dev *dai_new(struct sof_ipc_comp *comp)
 		      COMP_SIZE(struct sof_ipc_comp_dai));
 	if (!dev)
 		return NULL;
+	dev->drv = drv;
 
 	dai = COMP_GET_IPC(dev, sof_ipc_comp_dai);
 	ret = memcpy_s(dai, sizeof(*dai), ipc_dai,

--- a/src/audio/detect_test.c
+++ b/src/audio/detect_test.c
@@ -285,7 +285,8 @@ static int test_keyword_apply_config(struct comp_dev *dev,
 	return 0;
 }
 
-static struct comp_dev *test_keyword_new(struct sof_ipc_comp *comp)
+static struct comp_dev *test_keyword_new(const struct comp_driver *drv,
+					 struct sof_ipc_comp *comp)
 {
 	struct comp_dev *dev;
 	struct sof_ipc_comp_process *keyword;
@@ -302,6 +303,7 @@ static struct comp_dev *test_keyword_new(struct sof_ipc_comp *comp)
 		      COMP_SIZE(struct sof_ipc_comp_process));
 	if (!dev)
 		return NULL;
+	dev->drv = drv;
 
 	keyword = COMP_GET_IPC(dev, sof_ipc_comp_process);
 	ret = memcpy_s(keyword, sizeof(*keyword), ipc_keyword,

--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -388,7 +388,8 @@ static int eq_fir_setup(struct comp_data *cd, int nch)
  * End of algorithm code. Next the standard component methods.
  */
 
-static struct comp_dev *eq_fir_new(struct sof_ipc_comp *comp)
+static struct comp_dev *eq_fir_new(const struct comp_driver *drv,
+				   struct sof_ipc_comp *comp)
 {
 	struct comp_dev *dev;
 	struct comp_data *cd;
@@ -414,6 +415,7 @@ static struct comp_dev *eq_fir_new(struct sof_ipc_comp *comp)
 		      COMP_SIZE(struct sof_ipc_comp_process));
 	if (!dev)
 		return NULL;
+	dev->drv = drv;
 
 	fir = COMP_GET_IPC(dev, sof_ipc_comp_process);
 	ret = memcpy_s(fir, sizeof(*fir), ipc_fir,

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -493,7 +493,8 @@ static int eq_iir_setup(struct comp_data *cd, int nch)
  * End of EQ setup code. Next the standard component methods.
  */
 
-static struct comp_dev *eq_iir_new(struct sof_ipc_comp *comp)
+static struct comp_dev *eq_iir_new(const struct comp_driver *drv,
+				   struct sof_ipc_comp *comp)
 {
 	struct comp_dev *dev;
 	struct comp_data *cd;
@@ -519,6 +520,7 @@ static struct comp_dev *eq_iir_new(struct sof_ipc_comp *comp)
 		      COMP_SIZE(struct sof_ipc_comp_process));
 	if (!dev)
 		return NULL;
+	dev->drv = drv;
 
 	iir = COMP_GET_IPC(dev, sof_ipc_comp_process);
 	ret = memcpy_s(iir, sizeof(*iir), ipc_iir,

--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -312,7 +312,8 @@ static int host_trigger(struct comp_dev *dev, int cmd)
 	return ret;
 }
 
-static struct comp_dev *host_new(struct sof_ipc_comp *comp)
+static struct comp_dev *host_new(const struct comp_driver *drv,
+				 struct sof_ipc_comp *comp)
 {
 	struct sof_ipc_comp_host *ipc_host = (struct sof_ipc_comp_host *)comp;
 	struct sof_ipc_comp_host *host;
@@ -327,6 +328,7 @@ static struct comp_dev *host_new(struct sof_ipc_comp *comp)
 		      COMP_SIZE(struct sof_ipc_comp_host));
 	if (!dev)
 		return NULL;
+	dev->drv = drv;
 
 	host = COMP_GET_IPC(dev, sof_ipc_comp_host);
 	ret = memcpy_s(host, sizeof(*host),
@@ -347,7 +349,7 @@ static struct comp_dev *host_new(struct sof_ipc_comp *comp)
 
 	hd->dma = dma_get(dir, 0, DMA_DEV_HOST, DMA_ACCESS_SHARED);
 	if (!hd->dma) {
-		comp_cl_err(&comp_host, "host_new() error: dma_get() returned NULL");
+		comp_err(dev, "host_new() error: dma_get() returned NULL");
 		rfree(hd);
 		rfree(dev);
 		return NULL;

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -1491,7 +1491,7 @@ static inline bool validate_host_params(struct comp_dev *dev,
 static inline void kpb_change_state(struct comp_data *kpb,
 				    enum kpb_state state)
 {
-	comp_cl_dbg("kpb_change_state(): from %d to %d",
+	comp_cl_dbg(&comp_kpb, "kpb_change_state(): from %d to %d",
 		    kpb->state, state);
 	kpb->state = state;
 	kpb->state_log = (kpb->state_log << 4) | state;

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -107,7 +107,8 @@ static uint64_t kpb_task_deadline(void *data)
  *
  * \return: a pointer to newly created KPB component.
  */
-static struct comp_dev *kpb_new(struct sof_ipc_comp *comp)
+static struct comp_dev *kpb_new(const struct comp_driver *drv,
+				struct sof_ipc_comp *comp)
 {
 	struct sof_ipc_comp_process *ipc_process =
 					(struct sof_ipc_comp_process *)comp;
@@ -126,6 +127,7 @@ static struct comp_dev *kpb_new(struct sof_ipc_comp *comp)
 		      COMP_SIZE(struct sof_ipc_comp_process));
 	if (!dev)
 		return NULL;
+	dev->drv = drv;
 
 	ret = memcpy_s(COMP_GET_IPC(dev, sof_ipc_comp_process),
 		       sizeof(struct sof_ipc_comp_process),

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -106,7 +106,8 @@ static void mix_n_s32(struct comp_dev *dev, struct audio_stream *sink,
 }
 #endif /* CONFIG_FORMAT_S24LE || CONFIG_FORMAT_S32LE */
 
-static struct comp_dev *mixer_new(struct sof_ipc_comp *comp)
+static struct comp_dev *mixer_new(const struct comp_driver *drv,
+				  struct sof_ipc_comp *comp)
 {
 	struct comp_dev *dev;
 	struct sof_ipc_comp_mixer *mixer;
@@ -121,6 +122,7 @@ static struct comp_dev *mixer_new(struct sof_ipc_comp *comp)
 		      COMP_SIZE(struct sof_ipc_comp_mixer));
 	if (!dev)
 		return NULL;
+	dev->drv = drv;
 
 	mixer = COMP_GET_IPC(dev, sof_ipc_comp_mixer);
 

--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -77,7 +77,8 @@ static int mux_set_values(struct comp_data *cd, struct sof_mux_config *cfg)
 	return 0;
 }
 
-static struct comp_dev *mux_new(struct sof_ipc_comp *comp)
+static struct comp_dev *mux_new(const struct comp_driver *drv,
+				struct sof_ipc_comp *comp)
 {
 	struct sof_ipc_comp_process *ipc_process =
 		(struct sof_ipc_comp_process *)comp;
@@ -92,6 +93,7 @@ static struct comp_dev *mux_new(struct sof_ipc_comp *comp)
 		      COMP_SIZE(struct sof_ipc_comp_process));
 	if (!dev)
 		return NULL;
+	dev->drv = drv;
 
 	memcpy_s(COMP_GET_IPC(dev, sof_ipc_comp_process),
 		 sizeof(struct sof_ipc_comp_process),

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -40,7 +40,8 @@ static const struct comp_driver comp_selector;
  * \param[in,out] data Selector base component device.
  * \return Pointer to selector base component device.
  */
-static struct comp_dev *selector_new(struct sof_ipc_comp *comp)
+static struct comp_dev *selector_new(const struct comp_driver *drv,
+				     struct sof_ipc_comp *comp)
 {
 	struct sof_ipc_comp_process *ipc_process =
 		(struct sof_ipc_comp_process *)comp;
@@ -55,6 +56,7 @@ static struct comp_dev *selector_new(struct sof_ipc_comp *comp)
 		      COMP_SIZE(struct sof_ipc_comp_process));
 	if (!dev)
 		return NULL;
+	dev->drv = drv;
 
 	ret = memcpy_s(COMP_GET_IPC(dev, sof_ipc_comp_process),
 		       sizeof(struct sof_ipc_comp_process), comp,

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -446,7 +446,8 @@ static void src_copy_s16(struct comp_dev *dev,
 }
 #endif /* CONFIG_FORMAT_S16LE */
 
-static struct comp_dev *src_new(struct sof_ipc_comp *comp)
+static struct comp_dev *src_new(const struct comp_driver *drv,
+				struct sof_ipc_comp *comp)
 {
 	struct comp_dev *dev;
 	struct sof_ipc_comp_src *src;
@@ -466,6 +467,7 @@ static struct comp_dev *src_new(struct sof_ipc_comp *comp)
 		      COMP_SIZE(struct sof_ipc_comp_src));
 	if (!dev)
 		return NULL;
+	dev->drv = drv;
 
 	src = COMP_GET_IPC(dev, sof_ipc_comp_src);
 

--- a/src/audio/switch.c
+++ b/src/audio/switch.c
@@ -14,7 +14,8 @@
 
 static const struct comp_driver comp_switch;
 
-static struct comp_dev *switch_new(struct sof_ipc_comp *comp)
+static struct comp_dev *switch_new(const struct comp_driver *drv,
+				   struct sof_ipc_comp *comp)
 {
 	comp_cl_info(&comp_switch, "switch_new()");
 

--- a/src/audio/tone.c
+++ b/src/audio/tone.c
@@ -366,7 +366,8 @@ static int tonegen_init(struct tone_state *sg, int32_t fs, int32_t f, int32_t a)
  * End of algorithm code. Next the standard component methods.
  */
 
-static struct comp_dev *tone_new(struct sof_ipc_comp *comp)
+static struct comp_dev *tone_new(const struct comp_driver *drv,
+				 struct sof_ipc_comp *comp)
 {
 	struct comp_dev *dev;
 	struct sof_ipc_comp_tone *tone;
@@ -381,6 +382,7 @@ static struct comp_dev *tone_new(struct sof_ipc_comp *comp)
 		      COMP_SIZE(struct sof_ipc_comp_tone));
 	if (!dev)
 		return NULL;
+	dev->drv = drv;
 
 	tone = COMP_GET_IPC(dev, sof_ipc_comp_tone);
 	ret = memcpy_s(tone, sizeof(*tone), ipc_tone,

--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -187,7 +187,8 @@ static int vol_task_init(struct comp_dev *dev)
  * \param[in] delay Update time.
  * \return Pointer to volume base component device.
  */
-static struct comp_dev *volume_new(struct sof_ipc_comp *comp)
+static struct comp_dev *volume_new(const struct comp_driver *drv,
+				   struct sof_ipc_comp *comp)
 {
 	struct comp_dev *dev;
 	struct sof_ipc_comp_volume *vol;
@@ -203,6 +204,7 @@ static struct comp_dev *volume_new(struct sof_ipc_comp *comp)
 		      COMP_SIZE(struct sof_ipc_comp_volume));
 	if (!dev)
 		return NULL;
+	dev->drv = drv;
 
 	vol = COMP_GET_IPC(dev, sof_ipc_comp_volume);
 	ret = memcpy_s(vol, sizeof(*vol), ipc_vol,

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -189,6 +189,8 @@ enum comp_copy_type {
 	COMP_COPY_ONE_SHOT,
 };
 
+struct comp_driver;
+
 /**
  * Audio component operations - all mandatory.
  *
@@ -197,7 +199,8 @@ enum comp_copy_type {
  */
 struct comp_ops {
 	/** component creation */
-	struct comp_dev *(*new)(struct sof_ipc_comp *comp);
+	struct comp_dev *(*new)(const struct comp_driver *drv,
+				struct sof_ipc_comp *comp);
 
 	/** component destruction */
 	void (*free)(struct comp_dev *dev);

--- a/test/cmocka/src/audio/kpb/kpb_buffer.c
+++ b/test/cmocka/src/audio/kpb/kpb_buffer.c
@@ -120,7 +120,8 @@ static int buffering_test_setup(void **state)
 	sys_comp_kpb_init();
 
 	/* Create KPB component */
-	kpb_dev_mock = kpb_drv_mock.ops.new((struct sof_ipc_comp *)&kpb);
+	kpb_dev_mock = kpb_drv_mock.ops.new(&kpb_drv_mock,
+					    (struct sof_ipc_comp *)&kpb);
 
 	/* Was device created properly?  */
 	assert_non_null(kpb_dev_mock);

--- a/test/cmocka/src/audio/mixer/comp_mock.c
+++ b/test/cmocka/src/audio/mixer/comp_mock.c
@@ -13,9 +13,13 @@
 
 #include "comp_mock.h"
 
-static struct comp_dev *mock_comp_new(struct sof_ipc_comp *comp)
+static struct comp_dev *mock_comp_new(const struct comp_driver *drv,
+				      struct sof_ipc_comp *comp)
 {
-	return calloc(1, sizeof(struct comp_dev));
+	struct comp_dev *dev = calloc(1, sizeof(struct comp_dev));
+
+	dev->drv = drv;
+	return dev;
 }
 
 static void mock_comp_free(struct comp_dev *dev)

--- a/test/cmocka/src/audio/mixer/mixer_test.c
+++ b/test/cmocka/src/audio/mixer/mixer_test.c
@@ -97,7 +97,7 @@ static struct sof_ipc_comp mock_comp = {
 static struct comp_dev *create_comp(struct sof_ipc_comp *comp,
 				    struct comp_driver *drv)
 {
-	struct comp_dev *cd = drv->ops.new(comp);
+	struct comp_dev *cd = drv->ops.new(drv, comp);
 
 	assert_non_null(cd);
 

--- a/tools/testbench/file.c
+++ b/tools/testbench/file.c
@@ -400,7 +400,8 @@ static enum file_format get_file_format(char *filename)
 	return FILE_RAW;
 }
 
-static struct comp_dev *file_new(struct sof_ipc_comp *comp)
+static struct comp_dev *file_new(const struct comp_driver *drv,
+				 struct sof_ipc_comp *comp)
 {
 	struct comp_dev *dev;
 	struct sof_ipc_comp_file *file;
@@ -417,6 +418,7 @@ static struct comp_dev *file_new(struct sof_ipc_comp *comp)
 		      COMP_SIZE(struct sof_ipc_comp_file));
 	if (!dev)
 		return NULL;
+	dev->drv = drv;
 
 	file = COMP_GET_IPC(dev, sof_ipc_comp_file);
 	assert(!memcpy_s(file, sizeof(*file), ipc_file,


### PR DESCRIPTION
Back pointer must be initialized before any instance
level logging is performed by the new() operation since
the instance identification requires access to the uuid
that will be implemented on the component driver level.
