### PR TITLE
platform: imx: Add Kconfig option for i.MX EDMA driver

### DIFF
--- a/src/drivers/Kconfig
+++ b/src/drivers/Kconfig
@@ -18,6 +18,13 @@ config DUMMY_DMA
 
 	  If unsure, select "n".
 
+config IMX_EDMA
+	bool "i.MX EDMA driver"
+	default n
+	depends on IMX
+	help
+	  Select this to enable support for i.MX EDMA DMA controller.
+
 config IPC_POLLING
 	bool "Enable IPC Polling support"
 	default n

--- a/src/drivers/imx/CMakeLists.txt
+++ b/src/drivers/imx/CMakeLists.txt
@@ -1,10 +1,13 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 add_local_sources(sof
-	edma.c
 	esai.c
 	sai.c
 	interrupt.c
 	ipc.c
 	timer.c
 )
+
+if(CONFIG_IMX_EDMA)
+	add_local_sources(sof edma.c)
+endif()

--- a/src/platform/Kconfig
+++ b/src/platform/Kconfig
@@ -171,6 +171,7 @@ config IMX8
 	select DUMMY_DMA
 	select WAITI_DELAY
 	select IMX
+	select IMX_EDMA
 	help
 	  Select if your target platform is imx8-compatible
 
@@ -184,6 +185,7 @@ config IMX8X
 	select DUMMY_DMA
 	select WAITI_DELAY
 	select IMX
+	select IMX_EDMA
 	help
 	  Select if your target platform is imx8x-compatible
 


### PR DESCRIPTION
Not all i.MX platforms have EDMA for DMA controller. So make it a
Kconfig option.

Signed-off-by: Paul Olaru <paul.olaru@nxp.com>