### PR TITLE
eq_fir/irr: refine eq_fir/iir verify() functions

### DIFF
--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -770,12 +770,6 @@ static int eq_fir_prepare(struct comp_dev *dev)
 	sink_period_bytes = audio_stream_period_bytes(&sinkb->stream,
 						      dev->frames);
 
-	/* Rewrite params format for this component to match the host side. */
-	if (dev->direction == SOF_IPC_STREAM_PLAYBACK)
-		sourceb->stream.frame_fmt = cd->source_format;
-	else
-		sinkb->stream.frame_fmt = cd->sink_format;
-
 	if (sinkb->stream.size < config->periods_sink * sink_period_bytes) {
 		comp_err(dev, "eq_fir_prepare() error: sink buffer size is insufficient");
 		ret = -ENOMEM;

--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -481,7 +481,7 @@ static int eq_fir_verify_params(struct comp_dev *dev,
 
 	comp_dbg(dev, "eq_fir_verify_params()");
 
-	ret = comp_verify_params(dev, BUFF_PARAMS_FRAME_FMT, params);
+	ret = comp_verify_params(dev, 0, params);
 	if (ret < 0) {
 		comp_err(dev, "eq_fir_verify_params() error: comp_verify_params() failed.");
 		return ret;

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -829,12 +829,6 @@ static int eq_iir_prepare(struct comp_dev *dev)
 	sink_period_bytes = audio_stream_period_bytes(&sinkb->stream,
 						      dev->frames);
 
-	/* Rewrite params format for this component to match the host side. */
-	if (dev->direction == SOF_IPC_STREAM_PLAYBACK)
-		sourceb->stream.frame_fmt = cd->source_format;
-	else
-		sinkb->stream.frame_fmt = cd->sink_format;
-
 	if (sinkb->stream.size < config->periods_sink * sink_period_bytes) {
 		comp_err(dev, "eq_iir_prepare(), sink buffer size %d is insufficient",
 			 sinkb->stream.size);


### PR DESCRIPTION
This commit refines eq_fir/irr verify() functions:
1. eq_fir component is not able to change stream format,
so we should invoke comp_verify_function() with flag
equal to 0.
2. In eq_iir component we should check whether we can
support frame_fmt conversion due to source and sink
buffer frame_fmt's. If not, we should overwrite sink (playback)
and source (capture) with pcm frame_fmt and not make any
conversion (sink and source frame_fmt will be equal).

Fixes #2401 
