### PR TITLE
host: Fix compilation error with verbose traces enabled

### DIFF
--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -207,7 +207,7 @@ static void host_dma_cb(void *arg, enum notify_id type, void *data)
 	struct host_data *hd = comp_get_drvdata(dev);
 	uint32_t bytes = next->elem.size;
 
-	comp_cl_dbg(&comp_host, "host_dma_cb() %p", &comp_host);
+	comp_cl_dbg(&comp_host, "host_dma_cb() %p", (uintptr_t)&comp_host);
 
 	/* update position */
 	host_update_position(dev, bytes);


### PR DESCRIPTION
src/audio/host.c: In function 'host_dma_cb':
src/audio/host.c:210:46: error: initialization of
'unsigned int' from 'const struct comp_driver *' makes integer from
pointer without a cast [-Werror=int-conversion]
  comp_cl_dbg(&comp_host, "host_dma_cb() %p", &comp_host);

This happens because our tracing system is limited to integer types
for parameters.

Fixes: a87b9085058492 ("trace: component: use err,info,dbg macros")
Suggested-by: Paul Olaru <paul.olaru@nxp.com>
Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>