### PR TITLE
ipc: dai: remove unused hdr field in params

### DIFF
--- a/src/include/ipc/dai-imx.h
+++ b/src/include/ipc/dai-imx.h
@@ -13,7 +13,7 @@
 
 /* ESAI Configuration Request - SOF_IPC_DAI_ESAI_CONFIG */
 struct sof_ipc_dai_esai_params {
-	struct sof_ipc_hdr hdr;
+	uint32_t reserved0;
 
 	/* MCLK */
 	uint16_t reserved1;
@@ -32,7 +32,7 @@ struct sof_ipc_dai_esai_params {
 
 /* SAI Configuration Request - SOF_IPC_DAI_SAI_CONFIG */
 struct sof_ipc_dai_sai_params {
-	struct sof_ipc_hdr hdr;
+	uint32_t reserved0;
 
 	/* MCLK */
 	uint16_t reserved1;

--- a/src/include/ipc/dai-intel.h
+++ b/src/include/ipc/dai-intel.h
@@ -59,7 +59,7 @@
 
 /* SSP Configuration Request - SOF_IPC_DAI_SSP_CONFIG */
 struct sof_ipc_dai_ssp_params {
-	struct sof_ipc_hdr hdr;
+	uint32_t reserved0;
 	uint16_t reserved1;
 	uint16_t mclk_id;
 
@@ -91,13 +91,13 @@ struct sof_ipc_dai_ssp_params {
 
 /* HDA Configuration Request - SOF_IPC_DAI_HDA_CONFIG */
 struct sof_ipc_dai_hda_params {
-	struct sof_ipc_hdr hdr;
+	uint32_t reserved0;
 	uint32_t link_dma_ch;
 } __attribute__((packed));
 
 /* ALH Configuration Request - SOF_IPC_DAI_ALH_CONFIG */
 struct sof_ipc_dai_alh_params {
-	struct sof_ipc_hdr hdr;
+	uint32_t reserved0;
 	uint32_t stream_id;
 
 	/* reserved for future use */
@@ -124,7 +124,7 @@ struct sof_ipc_dai_alh_params {
  * data integrity problems.
  */
 struct sof_ipc_dai_dmic_pdm_ctrl {
-	struct sof_ipc_hdr hdr;
+	uint32_t reserved0;
 	uint16_t id;		/**< PDM controller ID */
 
 	uint16_t enable_mic_a;	/**< Use A (left) channel mic (0 or 1)*/
@@ -169,7 +169,7 @@ struct sof_ipc_dai_dmic_pdm_ctrl {
  * treated as an error.
  */
 struct sof_ipc_dai_dmic_params {
-	struct sof_ipc_hdr hdr;
+	uint32_t reserved0;
 	uint32_t driver_ipc_version;	/**< Version (1..N) */
 
 	uint32_t pdmclk_min;	/**< Minimum microphone clock in Hz (100000..N) */


### PR DESCRIPTION
We don't use this field, move back to reserved.

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>