### PR TITLE
Fix some cppcheck warnings

### DIFF
--- a/src/audio/detect_test.c
+++ b/src/audio/detect_test.c
@@ -712,7 +712,7 @@ static int test_keyword_trigger(struct comp_dev *dev, int cmd)
 		cd->activation = 0;
 	}
 
-	return ret;
+	return 0;
 }
 
 /*  process stream data from source buffer */

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -201,7 +201,7 @@ static size_t kpb_allocate_history_buffer(struct comp_data *kpb,
 	int hb_mcp[KPB_NO_OF_MEM_POOLS] = {SOF_MEM_CAPS_LP, SOF_MEM_CAPS_HP,
 					   SOF_MEM_CAPS_RAM };
 	void *new_mem_block = NULL;
-	size_t temp_ca_size = 0;
+	size_t temp_ca_size;
 	int i = 0;
 	size_t allocated_size = 0;
 
@@ -756,7 +756,7 @@ static int kpb_buffer_data(struct comp_dev *dev,
 	struct hb *buff = kpb->history_buffer;
 	uint32_t offset = 0;
 	uint64_t timeout = 0;
-	uint64_t current_time = 0;
+	uint64_t current_time;
 	enum kpb_state state_preserved = kpb->state;
 	struct dd *draining_data = &kpb->draining_task_data;
 	size_t sample_width = kpb->config.sampling_width;
@@ -960,15 +960,15 @@ static void kpb_init_draining(struct comp_dev *dev, struct kpb_client *cli)
 	struct hb *buff = kpb->history_buffer;
 	struct hb *first_buff = buff;
 	size_t buffered = 0;
-	size_t local_buffered = 0;
+	size_t local_buffered;
 	enum comp_copy_type copy_type = COMP_COPY_NORMAL;
-	size_t drain_interval = 0;
+	size_t drain_interval;
 	size_t host_period_size = kpb->host_period_size;
 	size_t ticks_per_ms = clock_ms_to_ticks(PLATFORM_DEFAULT_CLOCK, 1);
 	size_t bytes_per_ms = KPB_SAMPLES_PER_MS *
 			      (KPB_SAMPLE_CONTAINER_SIZE(sample_width) / 8) *
 			      kpb->config.channels;
-	size_t period_bytes_limit = 0;
+	size_t period_bytes_limit;
 	uint32_t flags;
 
 	comp_info(dev, "kpb_init_draining(): requested draining of %d [ms] from history buffer",
@@ -998,7 +998,6 @@ static void kpb_init_draining(struct comp_dev *dev, struct kpb_client *cli)
 			/* Calculate how much data we have stored in
 			 * current buffer.
 			 */
-			local_buffered = 0;
 			buff->r_ptr = buff->start_addr;
 			if (buff->state == KPB_BUFFER_FREE) {
 				local_buffered = (uint32_t)buff->w_ptr -

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -1246,8 +1246,10 @@ out:
 static void kpb_drain_samples(void *source, struct audio_stream *sink,
 			      size_t size, size_t sample_width)
 {
+#if CONFIG_FORMAT_S16LE || CONFIG_FORMAT_S24LE || CONFIG_FORMAT_S32LE
 	void *dst;
 	void *src = source;
+#endif
 	size_t i;
 	size_t j = 0;
 	size_t channel;
@@ -1389,8 +1391,10 @@ static void kpb_copy_samples(struct comp_buffer *sink,
 			     struct comp_buffer *source, size_t size,
 			     size_t sample_width)
 {
+#if CONFIG_FORMAT_S16LE || CONFIG_FORMAT_S24LE || CONFIG_FORMAT_S32LE
 	void *dst;
 	void *src;
+#endif
 	size_t i;
 	size_t j = 0;
 	size_t channel;

--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -288,8 +288,8 @@ static int dw_dma_start(struct dma_chan_data *channel)
 
 #if CONFIG_HW_LLI
 	/* LLP mode - write LLP pointer unless in scatter mode */
-	dma_reg_write(dma, DW_LLP(channel->index), lli->ctrl_lo &
-		      (DW_CTLL_LLP_D_EN | DW_CTLL_LLP_S_EN) ?
+	dma_reg_write(dma, DW_LLP(channel->index),
+		      (lli->ctrl_lo & (DW_CTLL_LLP_D_EN | DW_CTLL_LLP_S_EN)) ?
 		      (uint32_t)lli : 0);
 #endif
 	/* channel needs to start from scratch, so write SAR and DAR */

--- a/src/drivers/dw/gpio.c
+++ b/src/drivers/dw/gpio.c
@@ -35,7 +35,7 @@ int gpio_write(const struct gpio *gpio, unsigned int port,
 
 int gpio_read(const struct gpio *gpio, unsigned int port)
 {
-	return (io_reg_read(gpio->base + PORTA_DAT_REG) >> port) & 1 ?
+	return ((io_reg_read(gpio->base + PORTA_DAT_REG) >> port) & 1) ?
 		GPIO_LEVEL_HIGH : GPIO_LEVEL_LOW;
 }
 

--- a/src/drivers/dw/ssi-spi.c
+++ b/src/drivers/dw/ssi-spi.c
@@ -108,7 +108,6 @@ struct spi_dma_config {
 
 struct spi_reg_list {
 	uint32_t ctrlr0;
-	uint32_t ctrlr1;
 	uint32_t dmacr;		/* dma control register */
 };
 

--- a/src/include/sof/audio/src/src.h
+++ b/src/include/sof/audio/src/src.h
@@ -115,7 +115,7 @@ void src_polyphase_stage_cir(struct src_stage_prm *s);
 void src_polyphase_stage_cir_s16(struct src_stage_prm *s);
 #endif /* CONFIG_FORMAT_S16LE */
 
-int src_buffer_lengths(struct src_param *p, int fs_in, int fs_out, int nch,
+int src_buffer_lengths(struct src_param *a, int fs_in, int fs_out, int nch,
 		       int source_frames);
 
 int32_t src_input_rates(void);


### PR DESCRIPTION
Some obvious warnings should be fixed.
Additional ones were forwarded to the code owners.

cppcheck --platform=unix32 --force --max-configs=1024 --inconclusive --enable=all src -I src/include
