### PR TITLE
detect_test: guarantee sending detection notification to host

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,7 @@ if(BUILD_LIBRARY)
 	add_subdirectory(ipc)
 	add_subdirectory(audio)
 	add_subdirectory(lib)
+	add_local_sources(sof spinlock.c)
 	return()
 endif()
 

--- a/src/audio/detect_test.c
+++ b/src/audio/detect_test.c
@@ -114,7 +114,7 @@ static void notify_host(const struct comp_dev *dev)
 	/* Send queued IPC message right away to wake host up ASAP
 	 * NOTE! This will only send one IPC from the list!
 	 */
-	ipc_platform_send_msg();
+	ipc_send_queued_msg();
 }
 
 static void notify_kpb(const struct comp_dev *dev)

--- a/src/drivers/imx/ipc.c
+++ b/src/drivers/imx/ipc.c
@@ -106,25 +106,18 @@ void ipc_platform_complete_cmd(void *data)
 	platform_shared_commit(ipc, sizeof(*ipc));
 }
 
-void ipc_platform_send_msg(void)
+void ipc_platform_send_msg(struct ipc_msg *msg)
 {
 	struct ipc *ipc = ipc_get();
-	struct ipc_msg *msg;
 	uint32_t flags;
 
 	spin_lock_irq(&ipc->lock, flags);
-
-	/* any messages to send ? */
-	if (list_is_empty(&ipc->msg_list))
-		goto out;
 
 	/* can't send notification when one is in progress */
 	if (imx_mu_read(IMX_MU_xCR) & IMX_MU_xCR_GIRn(1))
 		goto out;
 
 	/* now send the message */
-	msg = list_first_item(&ipc->msg_list, struct ipc_msg,
-			      list);
 	mailbox_dspbox_write(0, msg->tx_data, msg->tx_size);
 	list_item_del(&msg->list);
 	tracev_ipc("ipc: msg tx -> 0x%x", msg->header);

--- a/src/drivers/intel/haswell/ipc.c
+++ b/src/drivers/intel/haswell/ipc.c
@@ -96,25 +96,18 @@ void ipc_platform_complete_cmd(void *data)
 	platform_shared_commit(ipc, sizeof(*ipc));
 }
 
-void ipc_platform_send_msg(void)
+void ipc_platform_send_msg(struct ipc_msg *msg)
 {
 	struct ipc *ipc = ipc_get();
-	struct ipc_msg *msg;
 	uint32_t flags;
 
 	spin_lock_irq(&ipc->lock, flags);
-
-	/* any messages to send ? */
-	if (list_is_empty(&ipc->msg_list))
-		goto out;
 
 	/* can't send nofication when one is in progress */
 	if (shim_read(SHIM_IPCD) & (SHIM_IPCD_BUSY | SHIM_IPCD_DONE))
 		goto out;
 
 	/* now send the message */
-	msg = list_first_item(&ipc->msg_list, struct ipc_msg,
-			      list);
 	mailbox_dspbox_write(0, msg->tx_data, msg->tx_size);
 	list_item_del(&msg->list);
 	tracev_ipc("ipc: msg tx -> 0x%x", msg->header);

--- a/src/include/sof/drivers/ipc.h
+++ b/src/include/sof/drivers/ipc.h
@@ -160,7 +160,9 @@ int ipc_stream_send_xrun(struct comp_dev *cdev,
 int ipc_queue_host_message(struct ipc *ipc, uint32_t header, void *tx_data,
 			   size_t tx_bytes, bool replace);
 
-void ipc_platform_send_msg(void);
+void ipc_platform_send_msg(struct ipc_msg *msg);
+
+void ipc_send_queued_msg(void);
 
 /**
  * \brief Data provided by the platform which use ipc...page_descriptors().

--- a/src/include/sof/drivers/ipc.h
+++ b/src/include/sof/drivers/ipc.h
@@ -152,6 +152,8 @@ void ipc_schedule_process(struct ipc *ipc);
 
 int ipc_stream_send_position(struct comp_dev *cdev,
 		struct sof_ipc_stream_posn *posn);
+void ipc_build_comp_notification(const struct comp_dev *cdev,
+				 struct sof_ipc_comp_event *event);
 int ipc_send_comp_notification(const struct comp_dev *cdev,
 			       struct sof_ipc_comp_event *event);
 int ipc_stream_send_xrun(struct comp_dev *cdev,

--- a/src/include/sof/drivers/ipc.h
+++ b/src/include/sof/drivers/ipc.h
@@ -157,6 +157,9 @@ int ipc_send_comp_notification(const struct comp_dev *cdev,
 int ipc_stream_send_xrun(struct comp_dev *cdev,
 	struct sof_ipc_stream_posn *posn);
 
+void ipc_prepare_host_message(struct ipc_msg *msg, uint32_t header,
+			      void *tx_data, size_t tx_bytes);
+
 int ipc_queue_host_message(struct ipc *ipc, uint32_t header, void *tx_data,
 			   size_t tx_bytes, bool replace);
 

--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -429,15 +429,21 @@ int ipc_stream_send_position(struct comp_dev *cdev,
 				      sizeof(*posn), false);
 }
 
-/* send component notification */
-int ipc_send_comp_notification(const struct comp_dev *cdev,
-			       struct sof_ipc_comp_event *event)
+void ipc_build_comp_notification(const struct comp_dev *cdev,
+				 struct sof_ipc_comp_event *event)
 {
 	event->rhdr.hdr.cmd = SOF_IPC_GLB_COMP_MSG |
 		SOF_IPC_COMP_NOTIFICATION | dev_comp_id(cdev);
 	event->rhdr.hdr.size = sizeof(*event);
 	event->src_comp_type = dev_comp_type(cdev);
 	event->src_comp_id = dev_comp_id(cdev);
+}
+
+/* send component notification */
+int ipc_send_comp_notification(const struct comp_dev *cdev,
+			       struct sof_ipc_comp_event *event)
+{
+	ipc_build_comp_notification(cdev, event);
 
 	return ipc_queue_host_message(ipc_get(), event->rhdr.hdr.cmd, event,
 				      sizeof(*event), false);

--- a/src/platform/library/include/platform/platform.h
+++ b/src/platform/library/include/platform/platform.h
@@ -15,6 +15,7 @@
 #include <sof/lib/clk.h>
 #include <stdint.h>
 
+struct ipc_msg;
 struct timer;
 
 /*! \def PLATFORM_DEFAULT_CLOCK
@@ -50,6 +51,8 @@ static inline void platform_wait_for_interrupt(int level)
 {
 	arch_wait_for_interrupt(level);
 }
+
+static inline void ipc_platform_send_msg(struct ipc_msg *msg) { }
 
 #endif /* __PLATFORM_PLATFORM_H__ */
 

--- a/src/schedule/task.c
+++ b/src/schedule/task.c
@@ -56,7 +56,7 @@ enum task_state task_main_master_core(void *data)
 		wait_for_interrupt(0);
 
 		if (!ipc->pm_prepare_D3)
-			ipc_platform_send_msg();
+			ipc_send_queued_msg();
 
 		platform_shared_commit(ipc, sizeof(*ipc));
 	}


### PR DESCRIPTION
This patch guarantees detection notification message sending
by preallocating message structure and sending this particular
IPC instead of sending first message from the queue.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>