### PR TITLE
 Create extended manifest

### DIFF
--- a/src/include/kernel/ext_manifest.h
+++ b/src/include/kernel/ext_manifest.h
@@ -71,6 +71,7 @@ struct ext_man_header {
 /* Extended manifest elements identificators */
 enum ext_man_elem_type {
 	EXT_MAN_ELEM_FW_VERSION		= 0,
+	EXT_MAN_ELEM_CC_VERSION		= SOF_IPC_EXT_CC_INFO,
 };
 
 /* extended manifest element header */
@@ -87,6 +88,13 @@ struct ext_man_fw_version {
 	/* use sof_ipc struct because of code re-use */
 	struct sof_ipc_fw_version version;
 	uint32_t flags;
+} __packed;
+
+/* Used C compiler description */
+struct ext_man_cc_version {
+	struct ext_man_elem_header hdr;
+	/* use sof_ipc struct because of code re-use */
+	struct sof_ipc_cc_version cc_version;
 } __packed;
 
 #endif /* __KERNEL_EXT_MANIFEST_H__ */

--- a/src/include/kernel/ext_manifest.h
+++ b/src/include/kernel/ext_manifest.h
@@ -72,6 +72,7 @@ struct ext_man_header {
 enum ext_man_elem_type {
 	EXT_MAN_ELEM_FW_VERSION		= 0,
 	EXT_MAN_ELEM_CC_VERSION		= SOF_IPC_EXT_CC_INFO,
+	EXT_MAN_ELEM_PROBE_INFO		= SOF_IPC_EXT_PROBE_INFO,
 };
 
 /* extended manifest element header */
@@ -95,6 +96,12 @@ struct ext_man_cc_version {
 	struct ext_man_elem_header hdr;
 	/* use sof_ipc struct because of code re-use */
 	struct sof_ipc_cc_version cc_version;
+} __packed;
+
+struct ext_man_probe_support {
+	struct ext_man_elem_header hdr;
+	/* use sof_ipc struct because of code re-use */
+	struct sof_ipc_probe_support probe;
 } __packed;
 
 #endif /* __KERNEL_EXT_MANIFEST_H__ */

--- a/src/include/kernel/ext_manifest.h
+++ b/src/include/kernel/ext_manifest.h
@@ -1,0 +1,78 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2020 Intel Corporation. All rights reserved.
+ *
+ * Author: Karol Trzcinski <karolx.trzcinski@linux.intel.com>
+ */
+
+/*
+ * Extended manifest is a place to store metadata about firmware, known during
+ * compilation time - for example firmware version or used compiler.
+ * Given information are read on host side before firmware startup.
+ * This part of output binary is not signed.
+ *
+ * To add new content to ext_man, in firmware code define struct which starts
+ * with ext_man_elem_head followed by usage dependent content and place whole
+ * struct in "fw_metadata" section. Moreover kernel code should be modified to
+ * properly read new packet.
+ *
+ * Extended manifest is designed to be extensible. In header there is a field
+ * which describe header length, so after appending some data to header then it
+ * can be easily skipped by device with older version of this header.
+ * Unknown ext_man elements should be just skipped by host,
+ * to be backward compatible. Field `ext_man_elem_header.elem_size` should be
+ * used in such a situation.
+ */
+
+#ifndef __KERNEL_EXT_MANIFEST_H__
+#define __KERNEL_EXT_MANIFEST_H__
+
+#include <sof/compiler_attributes.h>
+#include <stdint.h>
+
+/* In ASCII `XMan` */
+#define EXT_MAN_MAGIC_NUMBER	0x6e614d58
+
+/* Build u32 number in format MMmmmppp */
+#define EXT_MAN_BUILD_VERSION(MAJOR, MINOR, PATH) ( \
+	((uint32_t)(MAJOR) << 24) | \
+	((uint32_t)(MINOR) << 12) | \
+	(uint32_t)(PATH))
+
+/* check extended manifest version consistency */
+#define EXT_MAN_VERSION_INCOMPATIBLE(host_ver, cli_ver) ( \
+	((host_ver) & GENMASK(31, 24)) != \
+	((cli_ver) & GENMASK(31, 24)))
+
+/* used extended manifest header version */
+#define EXT_MAN_VERSION		EXT_MAN_BUILD_VERSION(1, 0, 0)
+
+/* struct size alignment for ext_man elements */
+#define EXT_MAN_ALIGN 16
+
+/* extended manifest header, deleting any field breaks backward compatibility */
+struct ext_man_header {
+	uint32_t magic;		/**< identification number, */
+				/**< EXT_MAN_MAGIC_NUMBER */
+	uint32_t full_size;	/**< [bytes] full size of ext_man, */
+				/**< (header + content + padding) */
+	uint32_t header_size;	/**< [bytes] makes header extensionable, */
+				/**< after append new field to ext_man header */
+				/**< then backward compatible won't be lost */
+	uint32_t header_version; /**< value of EXT_MAN_VERSION */
+				/**< not related with following content */
+
+	/* just after this header should be list of ext_man_elem_* elements */
+} __packed;
+
+/* Now define extended manifest elements */
+
+/* extended manifest element header */
+struct ext_man_elem_header {
+	uint32_t type;		/**< EXT_MAN_ELEM_* */
+	uint32_t elem_size;	/**< in bytes, including header size */
+
+	/* just after this header should be type dependent content */
+} __packed;
+
+#endif /* __KERNEL_EXT_MANIFEST_H__ */

--- a/src/include/kernel/ext_manifest.h
+++ b/src/include/kernel/ext_manifest.h
@@ -27,6 +27,7 @@
 #ifndef __KERNEL_EXT_MANIFEST_H__
 #define __KERNEL_EXT_MANIFEST_H__
 
+#include <ipc/info.h>
 #include <sof/compiler_attributes.h>
 #include <stdint.h>
 
@@ -67,12 +68,25 @@ struct ext_man_header {
 
 /* Now define extended manifest elements */
 
+/* Extended manifest elements identificators */
+enum ext_man_elem_type {
+	EXT_MAN_ELEM_FW_VERSION		= 0,
+};
+
 /* extended manifest element header */
 struct ext_man_elem_header {
 	uint32_t type;		/**< EXT_MAN_ELEM_* */
 	uint32_t elem_size;	/**< in bytes, including header size */
 
 	/* just after this header should be type dependent content */
+} __packed;
+
+/* FW version */
+struct ext_man_fw_version {
+	struct ext_man_elem_header hdr;
+	/* use sof_ipc struct because of code re-use */
+	struct sof_ipc_fw_version version;
+	uint32_t flags;
 } __packed;
 
 #endif /* __KERNEL_EXT_MANIFEST_H__ */

--- a/src/init/CMakeLists.txt
+++ b/src/init/CMakeLists.txt
@@ -4,6 +4,17 @@ add_local_sources(sof init.c)
 
 add_library(ext_manifest STATIC "")
 
+# define compiler version
+set_property(TARGET ext_manifest APPEND
+	PROPERTY COMPILE_DEFINITIONS
+	XCC_TOOLS_VERSION="${XCC_TOOLS_VERSION}")
+
+# and optimization settings
+get_optimization_flag(optimization_flag)
+set_property(TARGET ext_manifest APPEND
+	PROPERTY COMPILE_DEFINITIONS
+	CC_OPTIMIZE_FLAGS="${optimization_flag}")
+
 add_local_sources(ext_manifest
 	ext_manifest.c)
 sof_append_relative_path_definitions(ext_manifest)

--- a/src/init/CMakeLists.txt
+++ b/src/init/CMakeLists.txt
@@ -1,3 +1,12 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 add_local_sources(sof init.c)
+
+add_library(ext_manifest STATIC "")
+
+add_local_sources(ext_manifest
+	ext_manifest.c)
+sof_append_relative_path_definitions(ext_manifest)
+
+target_link_libraries(ext_manifest sof_options)
+target_link_libraries(sof_static_libraries INTERFACE ext_manifest)

--- a/src/init/ext_manifest.c
+++ b/src/init/ext_manifest.c
@@ -7,6 +7,7 @@
 
 #include <sof/bit.h>
 #include <sof/common.h>
+#include <sof/compiler_info.h>
 #include <sof/debug/debug.h>
 #include <kernel/abi.h>
 #include <kernel/ext_manifest.h>
@@ -33,4 +34,23 @@ const struct ext_man_fw_version ext_man_fw_ver
 		.abi_version = SOF_ABI_VERSION,
 	},
 	.flags = DEBUG_SET_FW_READY_FLAGS,
+};
+
+const struct ext_man_cc_version ext_man_cc_ver
+	__aligned(EXT_MAN_ALIGN) __section(".fw_metadata") = {
+	.hdr.type = EXT_MAN_ELEM_CC_VERSION,
+	.hdr.elem_size = ALIGN_UP(sizeof(struct ext_man_cc_version),
+				  EXT_MAN_ALIGN),
+	.cc_version = {
+		.ext_hdr.hdr.size = sizeof(struct sof_ipc_cc_version),
+		.ext_hdr.hdr.cmd = SOF_IPC_FW_READY,
+		.ext_hdr.type = SOF_IPC_EXT_CC_INFO,
+		.micro = CC_MICRO,
+		.minor = CC_MINOR,
+		.major = CC_MAJOR,
+		.name = CC_NAME "\0",	///< eg. "XCC", "\0" is needed when
+					///< sizeof(CC_NAME)-1 == sizeof(.name)
+		.optim = CC_OPTIMIZE_FLAGS "\0", ///< eg. "O2"
+		.desc = CC_DESC "\0", ///< eg. " RG-2017.8-linux"
+	},
 };

--- a/src/init/ext_manifest.c
+++ b/src/init/ext_manifest.c
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2020 Intel Corporation. All rights reserved.
+//
+// Author: Karol Trzcinski <karolx.trzcinski@linux.intel.com>
+//
+
+#include <sof/bit.h>
+#include <sof/common.h>
+#include <sof/debug/debug.h>
+#include <kernel/abi.h>
+#include <kernel/ext_manifest.h>
+#include <config.h>
+#include <version.h>
+
+const struct ext_man_fw_version ext_man_fw_ver
+	__aligned(EXT_MAN_ALIGN) __section(".fw_metadata") = {
+	.hdr.type = EXT_MAN_ELEM_FW_VERSION,
+	.hdr.elem_size = ALIGN_UP(sizeof(struct ext_man_fw_version),
+				  EXT_MAN_ALIGN),
+	.version = {
+		.hdr.size = sizeof(struct sof_ipc_fw_version),
+		.micro = SOF_MICRO,
+		.minor = SOF_MINOR,
+		.major = SOF_MAJOR,
+#if CONFIG_DEBUG
+		/* only added in debug for reproducibility in releases */
+		.build = SOF_BUILD,
+		.date = __DATE__,
+		.time = __TIME__,
+#endif
+		.tag = SOF_TAG,
+		.abi_version = SOF_ABI_VERSION,
+	},
+	.flags = DEBUG_SET_FW_READY_FLAGS,
+};

--- a/src/init/ext_manifest.c
+++ b/src/init/ext_manifest.c
@@ -54,3 +54,19 @@ const struct ext_man_cc_version ext_man_cc_ver
 		.desc = CC_DESC "\0", ///< eg. " RG-2017.8-linux"
 	},
 };
+
+const struct ext_man_probe_support ext_man_probe
+	__aligned(EXT_MAN_ALIGN) __section(".fw_metadata") = {
+	.hdr.type = EXT_MAN_ELEM_PROBE_INFO,
+	.hdr.elem_size = ALIGN_UP(sizeof(struct ext_man_probe_support),
+				  EXT_MAN_ALIGN),
+	.probe = {
+		.ext_hdr.hdr.size = sizeof(struct sof_ipc_probe_support),
+		.ext_hdr.hdr.cmd = SOF_IPC_FW_READY,
+		.ext_hdr.type = SOF_IPC_EXT_PROBE_INFO,
+#if CONFIG_PROBE
+		.probe_points_max = CONFIG_PROBE_POINTS_MAX,
+		.injection_dmas_max = CONFIG_PROBE_DMA_MAX
+#endif
+	},
+};

--- a/src/platform/apollolake/apollolake.x.in
+++ b/src/platform/apollolake/apollolake.x.in
@@ -107,6 +107,9 @@ MEMORY
   static_log_entries_seg (!ari) :
         org = LOG_ENTRY_ELF_BASE,
         len = LOG_ENTRY_ELF_SIZE
+  fw_metadata_seg (!ari) :
+        org = EXT_MANIFEST_ELF_BASE,
+        len = EXT_MANIFEST_ELF_SIZE
 }
 
 PHDRS
@@ -142,6 +145,7 @@ PHDRS
 
   static_uuid_entries_phdr PT_NOTE;
   static_log_entries_phdr PT_NOTE;
+  metadata_entries_phdr PT_NOTE;
 }
 
 /*  Default entry point:  */
@@ -156,6 +160,9 @@ PROVIDE(_memmap_vecbase_reset = SOF_MEM_VECBASE);
 /* Various memory-map dependent cache attribute settings: */
 _memmap_cacheattr_wbna_trapnull = 0xFF42FFF2;
 PROVIDE(_memmap_cacheattr_reset = _memmap_cacheattr_wbna_trapnull);
+
+_EXT_MAN_ALIGN_ = 16;
+EXTERN(ext_man_fw_ver)
 
 SECTIONS
 {
@@ -590,4 +597,10 @@ SECTIONS
   {
     *(*.static_log*)
   } > static_log_entries_seg :static_log_entries_phdr
+
+  .fw_metadata (COPY) : ALIGN(1024)
+  {
+    KEEP (*(.fw_metadata))
+    . = ALIGN(_EXT_MAN_ALIGN_);
+  } >fw_metadata_seg :metadata_entries_phdr
 }

--- a/src/platform/apollolake/include/platform/lib/memory.h
+++ b/src/platform/apollolake/include/platform/lib/memory.h
@@ -122,6 +122,9 @@
 #define LOG_ENTRY_ELF_BASE	0x20000000
 #define LOG_ENTRY_ELF_SIZE	0x2000000
 
+#define EXT_MANIFEST_ELF_BASE	(LOG_ENTRY_ELF_BASE + LOG_ENTRY_ELF_SIZE)
+#define EXT_MANIFEST_ELF_SIZE	0x2000000
+
 /*
  * The HP SRAM Region Apollolake is organised like this :-
  * +--------------------------------------------------------------------------+

--- a/src/platform/baytrail/baytrail.x.in
+++ b/src/platform/baytrail/baytrail.x.in
@@ -108,6 +108,9 @@ MEMORY
   static_log_entries_seg (!ari) :
         org = LOG_ENTRY_ELF_BASE,
         len = LOG_ENTRY_ELF_SIZE
+  fw_metadata_seg (!ari) :
+        org = EXT_MANIFEST_ELF_BASE,
+        len = EXT_MANIFEST_ELF_SIZE
 }
 
 PHDRS
@@ -145,6 +148,7 @@ PHDRS
   sof_stack_phdr PT_LOAD;
   static_uuid_entries_phdr PT_NOTE;
   static_log_entries_phdr PT_NOTE;
+  metadata_entries_phdr PT_NOTE;
 }
 
 /*  Default entry point:  */
@@ -171,6 +175,9 @@ _memmap_cacheattr_wb_allvalid = 0x44224222;
 _memmap_cacheattr_wt_allvalid = 0x11221222;
 _memmap_cacheattr_bp_allvalid = 0x22222222;
 PROVIDE(_memmap_cacheattr_reset = _memmap_cacheattr_wbna_trapnull);
+
+_EXT_MAN_ALIGN_ = 16;
+EXTERN(ext_man_fw_ver)
 
 SECTIONS
 {
@@ -542,6 +549,11 @@ SECTIONS
   {
     *(*.static_log*)
   } > static_log_entries_seg :static_log_entries_phdr
+
+  .fw_metadata (COPY) : ALIGN(1024)
+  {
+    KEEP (*(.fw_metadata))
+  } >fw_metadata_seg :metadata_entries_phdr
 
   .fw_ready : ALIGN(4)
   {

--- a/src/platform/baytrail/include/platform/lib/memory.h
+++ b/src/platform/baytrail/include/platform/lib/memory.h
@@ -98,6 +98,9 @@ static inline void *platform_rfree_prepare(void *ptr)
 #define LOG_ENTRY_ELF_BASE	0x20000000
 #define LOG_ENTRY_ELF_SIZE	0x2000000
 
+#define EXT_MANIFEST_ELF_BASE	(LOG_ENTRY_ELF_BASE + LOG_ENTRY_ELF_SIZE)
+#define EXT_MANIFEST_ELF_SIZE	0x2000000
+
 /*
  * The Heap and Stack on Baytrail are organised like this :-
  *

--- a/src/platform/cannonlake/cannonlake.x.in
+++ b/src/platform/cannonlake/cannonlake.x.in
@@ -99,6 +99,9 @@ MEMORY
   static_log_entries_seg (!ari) :
         org = LOG_ENTRY_ELF_BASE,
         len = LOG_ENTRY_ELF_SIZE
+  fw_metadata_seg (!ari) :
+        org = EXT_MANIFEST_ELF_BASE,
+        len = EXT_MANIFEST_ELF_SIZE
 }
 
 PHDRS
@@ -131,6 +134,7 @@ PHDRS
   wnd3_phdr PT_LOAD;
   static_uuid_entries_phdr PT_NOTE;
   static_log_entries_phdr PT_NOTE;
+  metadata_entries_phdr PT_NOTE;
 }
 
 /*  Default entry point:  */
@@ -143,6 +147,9 @@ PROVIDE(_memmap_vecbase_reset = HP_SRAM_VECBASE_RESET);
 /* Various memory-map dependent cache attribute settings: */
 _memmap_cacheattr_wbna_trapnull = 0xFF42FFF2;
 PROVIDE(_memmap_cacheattr_reset = _memmap_cacheattr_wbna_trapnull);
+
+_EXT_MAN_ALIGN_ = 16;
+EXTERN(ext_man_fw_ver)
 
 SECTIONS
 {
@@ -555,4 +562,10 @@ SECTIONS
   {
     *(*.static_log*)
   } > static_log_entries_seg :static_log_entries_phdr
+
+  .fw_metadata (COPY) : ALIGN(1024)
+  {
+    KEEP (*(.fw_metadata))
+    . = ALIGN(_EXT_MAN_ALIGN_);
+  } >fw_metadata_seg :metadata_entries_phdr
 }

--- a/src/platform/cannonlake/include/platform/lib/memory.h
+++ b/src/platform/cannonlake/include/platform/lib/memory.h
@@ -130,6 +130,9 @@
 #define LOG_ENTRY_ELF_BASE	0x20000000
 #define LOG_ENTRY_ELF_SIZE	0x2000000
 
+#define EXT_MANIFEST_ELF_BASE	(LOG_ENTRY_ELF_BASE + LOG_ENTRY_ELF_SIZE)
+#define EXT_MANIFEST_ELF_SIZE	0x2000000
+
 /*
  * The HP SRAM Region on Cannonlake is organised like this :-
  * +--------------------------------------------------------------------------+

--- a/src/platform/haswell/haswell.x.in
+++ b/src/platform/haswell/haswell.x.in
@@ -114,6 +114,9 @@ MEMORY
   static_log_entries_seg (!ari) :
         org = LOG_ENTRY_ELF_BASE,
         len = LOG_ENTRY_ELF_SIZE
+  fw_metadata_seg (!ari) :
+        org = EXT_MANIFEST_ELF_BASE,
+        len = EXT_MANIFEST_ELF_SIZE
 }
 
 PHDRS
@@ -153,6 +156,7 @@ PHDRS
   sof_stack_phdr PT_LOAD;
   static_uuid_entries_phdr PT_NOTE;
   static_log_entries_phdr PT_NOTE;
+  metadata_entries_phdr PT_NOTE;
 }
 
 /*  Default entry point:  */
@@ -179,6 +183,9 @@ _memmap_cacheattr_wb_allvalid = 0x44224222;
 _memmap_cacheattr_wt_allvalid = 0x11221222;
 _memmap_cacheattr_bp_allvalid = 0x22222222;
 PROVIDE(_memmap_cacheattr_reset = _memmap_cacheattr_wbna_trapnull);
+
+_EXT_MAN_ALIGN_ = 16;
+EXTERN(ext_man_fw_ver)
 
 SECTIONS
 {
@@ -573,4 +580,10 @@ SECTIONS
     KEEP (*(.fw_ready))
     KEEP (*(.fw_ready_metadata))
   } >sof_data :sof_data_phdr
+
+  .fw_metadata (COPY) : ALIGN(1024)
+  {
+    KEEP (*(.fw_metadata))
+    . = ALIGN(_EXT_MAN_ALIGN_);
+  } >fw_metadata_seg :metadata_entries_phdr
 }

--- a/src/platform/haswell/include/platform/lib/memory.h
+++ b/src/platform/haswell/include/platform/lib/memory.h
@@ -91,6 +91,9 @@ static inline void *platform_rfree_prepare(void *ptr)
 #define LOG_ENTRY_ELF_BASE	0x20000000
 #define LOG_ENTRY_ELF_SIZE	0x2000000
 
+#define EXT_MANIFEST_ELF_BASE	(LOG_ENTRY_ELF_BASE + LOG_ENTRY_ELF_SIZE)
+#define EXT_MANIFEST_ELF_SIZE	0x2000000
+
 /*
  * The Heap and Stack on Haswell/Broadwell are organised like this :-
  *

--- a/src/platform/icelake/icelake.x.in
+++ b/src/platform/icelake/icelake.x.in
@@ -99,10 +99,16 @@ MEMORY
   static_log_entries_seg (!ari) :
         org = LOG_ENTRY_ELF_BASE,
         len = LOG_ENTRY_ELF_SIZE
+  fw_metadata_seg (!ari) :
+        org = EXT_MANIFEST_ELF_BASE,
+        len = EXT_MANIFEST_ELF_SIZE
   lpsram_mem :
         org = LP_SRAM_BASE,
         len = LP_SRAM_SIZE
 }
+
+_EXT_MAN_ALIGN_ = 16;
+EXTERN(ext_man_fw_ver)
 
 PHDRS
 {
@@ -134,6 +140,7 @@ PHDRS
   wnd3_phdr PT_LOAD;
   static_uuid_entries_phdr PT_NOTE;
   static_log_entries_phdr PT_NOTE;
+  metadata_entries_phdr PT_NOTE;
   lpsram_mem_phdr PT_LOAD;
 }
 
@@ -558,6 +565,12 @@ SECTIONS
   {
     *(*.static_log*)
   } > static_log_entries_seg :static_log_entries_phdr
+
+  .fw_metadata (COPY) : ALIGN(1024)
+  {
+    KEEP (*(.fw_metadata))
+    . = ALIGN(_EXT_MAN_ALIGN_);
+  } >fw_metadata_seg :metadata_entries_phdr
 
   .lpsram(NOLOAD) : ALIGN(8)
   {

--- a/src/platform/icelake/include/platform/lib/memory.h
+++ b/src/platform/icelake/include/platform/lib/memory.h
@@ -130,6 +130,9 @@
 #define LOG_ENTRY_ELF_BASE	0x20000000
 #define LOG_ENTRY_ELF_SIZE	0x2000000
 
+#define EXT_MANIFEST_ELF_BASE	(LOG_ENTRY_ELF_BASE + LOG_ENTRY_ELF_SIZE)
+#define EXT_MANIFEST_ELF_SIZE	0x2000000
+
 /*
  * The HP SRAM Region on Icelake is organised like this :-
  * +--------------------------------------------------------------------------+

--- a/src/platform/imx8/imx8.x.in
+++ b/src/platform/imx8/imx8.x.in
@@ -96,6 +96,9 @@ MEMORY
   static_log_entries_seg (!ari) :
         org = LOG_ENTRY_ELF_BASE,
         len = LOG_ENTRY_ELF_SIZE
+  fw_metadata_seg (!ari) :
+        org = EXT_MANIFEST_ELF_BASE,
+        len = EXT_MANIFEST_ELF_SIZE
 }
 
 PHDRS
@@ -127,6 +130,7 @@ PHDRS
   sof_stack_phdr PT_LOAD;
   static_uuid_entries_phdr PT_NOTE;
   static_log_entries_phdr PT_NOTE;
+  metadata_entries_phdr PT_NOTE;
 }
 
 /*  Default entry point:  */
@@ -154,6 +158,9 @@ _memmap_cacheattr_wt_allvalid = 0x11221222;
 _memmap_cacheattr_bp_allvalid = 0x22222222;
 _memmap_cacheattr_imx8_wt_allvalid = 0x22212222;
 PROVIDE(_memmap_cacheattr_reset = _memmap_cacheattr_imx8_wt_allvalid);
+
+_EXT_MAN_ALIGN_ = 16;
+EXTERN(ext_man_fw_ver)
 
 SECTIONS
 {
@@ -512,4 +519,10 @@ SECTIONS
     KEEP (*(.fw_ready))
     KEEP (*(.fw_ready_metadata))
   } >sof_sdram0 :sof_sdram0_phdr
+
+  .fw_metadata (COPY) : ALIGN(1024)
+  {
+    KEEP (*(.fw_metadata))
+    . = ALIGN(_EXT_MAN_ALIGN_);
+  } >fw_metadata_seg :metadata_entries_phdr
 }

--- a/src/platform/imx8/include/platform/lib/memory.h
+++ b/src/platform/imx8/include/platform/lib/memory.h
@@ -51,6 +51,9 @@
 #define LOG_ENTRY_ELF_BASE	0x20000000
 #define LOG_ENTRY_ELF_SIZE	0x2000000
 
+#define EXT_MANIFEST_ELF_BASE	(LOG_ENTRY_ELF_BASE + LOG_ENTRY_ELF_SIZE)
+#define EXT_MANIFEST_ELF_SIZE	0x2000000
+
 /*
  * The Heap and Stack on i.MX8 are organised like this :-
  *

--- a/src/platform/imx8m/imx8m.x.in
+++ b/src/platform/imx8m/imx8m.x.in
@@ -96,6 +96,9 @@ MEMORY
   static_log_entries_seg (!ari) :
         org = LOG_ENTRY_ELF_BASE,
         len = LOG_ENTRY_ELF_SIZE
+  fw_metadata_seg (!ari) :
+        org = EXT_MANIFEST_ELF_BASE,
+        len = EXT_MANIFEST_ELF_SIZE
 }
 
 PHDRS
@@ -127,6 +130,7 @@ PHDRS
   sof_stack_phdr PT_LOAD;
   static_uuid_entries_phdr PT_NOTE;
   static_log_entries_phdr PT_NOTE;
+  metadata_entries_phdr PT_NOTE;
 }
 
 /*  Default entry point:  */
@@ -154,6 +158,9 @@ _memmap_cacheattr_wt_allvalid = 0x11221222;
 _memmap_cacheattr_bp_allvalid = 0x22222222;
 _memmap_cacheattr_imx8_wt_allvalid = 0x22212222;
 PROVIDE(_memmap_cacheattr_reset = _memmap_cacheattr_imx8_wt_allvalid);
+
+_EXT_MAN_ALIGN_ = 16;
+EXTERN(ext_man_fw_ver)
 
 SECTIONS
 {
@@ -512,4 +519,10 @@ SECTIONS
     KEEP (*(.fw_ready))
     KEEP (*(.fw_ready_metadata))
   } >sof_sdram0 :sof_sdram0_phdr
+
+  .fw_metadata (COPY) : ALIGN(1024)
+  {
+    KEEP (*(.fw_metadata))
+    . = ALIGN(_EXT_MAN_ALIGN_);
+  } >fw_metadata_seg :metadata_entries_phdr
 }

--- a/src/platform/imx8m/include/platform/lib/memory.h
+++ b/src/platform/imx8m/include/platform/lib/memory.h
@@ -51,6 +51,9 @@
 #define LOG_ENTRY_ELF_BASE	0x20000000
 #define LOG_ENTRY_ELF_SIZE	0x2000000
 
+#define EXT_MANIFEST_ELF_BASE	(LOG_ENTRY_ELF_BASE + LOG_ENTRY_ELF_SIZE)
+#define EXT_MANIFEST_ELF_SIZE	0x2000000
+
 /*
  * The Heap and Stack on i.MX8M are organised like this :-
  *

--- a/src/platform/suecreek/include/platform/lib/memory.h
+++ b/src/platform/suecreek/include/platform/lib/memory.h
@@ -154,6 +154,9 @@
 #define LOG_ENTRY_ELF_BASE	0x20000000
 #define LOG_ENTRY_ELF_SIZE	0x2000000
 
+#define EXT_MANIFEST_ELF_BASE	(LOG_ENTRY_ELF_BASE + LOG_ENTRY_ELF_SIZE)
+#define EXT_MANIFEST_ELF_SIZE	0x2000000
+
 /*
  * The HP SRAM Region on Sue Creek is organised like this :-
  * +--------------------------------------------------------------------------+

--- a/src/platform/suecreek/suecreek.x.in
+++ b/src/platform/suecreek/suecreek.x.in
@@ -93,6 +93,9 @@ MEMORY
   static_log_entries_seg (!ari) :
         org = LOG_ENTRY_ELF_BASE,
         len = LOG_ENTRY_ELF_SIZE
+  fw_metadata_seg (!ari) :
+        org = EXT_MANIFEST_ELF_BASE,
+        len = EXT_MANIFEST_ELF_SIZE
 }
 
 PHDRS
@@ -123,6 +126,7 @@ PHDRS
   sof_fw_phdr PT_LOAD;
   static_uuid_entries_phdr PT_NOTE;
   static_log_entries_phdr PT_NOTE;
+  metadata_entries_phdr PT_NOTE;
 }
 
 /*  Default entry point:  */
@@ -150,6 +154,9 @@ _memmap_cacheattr_wt_allvalid = 0x11221222;
 _memmap_cacheattr_bp_allvalid = 0x22222222;
 _memmap_cacheattr_sue_creek = 0xf2ff4242;
 PROVIDE(_memmap_cacheattr_reset = _memmap_cacheattr_sue_creek);
+
+_EXT_MAN_ALIGN_ = 16;
+EXTERN(ext_man_fw_ver)
 
 SECTIONS
 {
@@ -557,4 +564,10 @@ SECTIONS
   {
     *(*.static_log*)
   } > static_log_entries_seg :static_log_entries_phdr
+
+  .fw_metadata (COPY) : ALIGN(1024)
+  {
+    KEEP (*(.fw_metadata))
+    . = ALIGN(_EXT_MAN_ALIGN_);
+  } >fw_metadata_seg :metadata_entries_phdr
 }

--- a/src/platform/tigerlake/include/platform/lib/memory.h
+++ b/src/platform/tigerlake/include/platform/lib/memory.h
@@ -130,6 +130,9 @@
 #define LOG_ENTRY_ELF_BASE	0x20000000
 #define LOG_ENTRY_ELF_SIZE	0x2000000
 
+#define EXT_MANIFEST_ELF_BASE	(LOG_ENTRY_ELF_BASE + LOG_ENTRY_ELF_SIZE)
+#define EXT_MANIFEST_ELF_SIZE	0x2000000
+
 /*
  * The HP SRAM Region on Tigerlake is organised like this :-
  * +--------------------------------------------------------------------------+

--- a/src/platform/tigerlake/tigerlake.x.in
+++ b/src/platform/tigerlake/tigerlake.x.in
@@ -102,6 +102,9 @@ MEMORY
   static_log_entries_seg (!ari) :
         org = LOG_ENTRY_ELF_BASE,
         len = LOG_ENTRY_ELF_SIZE
+  fw_metadata_seg (!ari) :
+        org = EXT_MANIFEST_ELF_BASE,
+        len = EXT_MANIFEST_ELF_SIZE
   lpsram_alt_reset_vec_seg :
         org = LP_SRAM_ALT_RESET_VEC_BASE,
         len = LP_SRAM_ALT_RESET_VEC_SIZE
@@ -147,6 +150,7 @@ PHDRS
   wnd3_phdr PT_LOAD;
   static_uuid_entries_phdr PT_NOTE;
   static_log_entries_phdr PT_NOTE;
+  metadata_entries_phdr PT_NOTE;
   lpsram_mem_phdr PT_LOAD;
   sram_alt_fw_reset_vec_phdr PT_LOAD;
   sram_alt_fw_reset_vec_int_phdr PT_LOAD;
@@ -164,6 +168,8 @@ PROVIDE(_memmap_vecbase_reset = HP_SRAM_VECBASE_RESET);
 _memmap_cacheattr_wbna_trapnull = 0xFF42FFF2;
 PROVIDE(_memmap_cacheattr_reset = _memmap_cacheattr_wbna_trapnull);
 
+_EXT_MAN_ALIGN_ = 16;
+EXTERN(ext_man_fw_ver)
 EXTERN(_LpsramHeader)
 EXTERN(_AltResetVector)
 
@@ -633,6 +639,12 @@ SECTIONS
   {
     *(*.static_log*)
   } > static_log_entries_seg :static_log_entries_phdr
+
+  .fw_metadata (COPY) : ALIGN(1024)
+  {
+    KEEP (*(.fw_metadata))
+    . = ALIGN(_EXT_MAN_ALIGN_);
+  } >fw_metadata_seg :metadata_entries_phdr
 
   .lpsram(NOLOAD) : ALIGN(8)
   {


### PR DESCRIPTION
Extended manifest is a place to store metadata about firmware, known during
compilation time - for example firmware version or used compiler.
Given information are read on host side before firmware startup.
This part of output binary is not signed.


Related with https://github.com/thesofproject/linux/pull/1818/commits