### PR TITLE
[WiP] VirtIO: define topologies for VirtIO host and guest

### DIFF
--- a/tools/topology/CMakeLists.txt
+++ b/tools/topology/CMakeLists.txt
@@ -60,6 +60,8 @@ set(TPLGS
 	"sof-byt-codec\;sof-cht-es8316\;-DCODEC=ES8316\;-DPLATFORM=cht\;-DSSP_NUM=2"
 	"sof-cnl-rt274\;sof-cnl-rt274"
 	"sof-apl-tdf8532\;sof-apl-tdf8532"
+	"sof-apl-pcm512x-mix\;sof-apl-pcm512x-sos"
+	"sof-apl-pcm512x-uos\;sof-apl-pcm512x-uos"
 	"sof-apl-pcm512x\;sof-apl-pcm512x"
 	"sof-apl-pcm512x-nohdmi\;sof-apl-pcm512x-nohdmi"
 	"sof-apl-demux-pcm512x\;sof-apl-demux-pcm512x"

--- a/tools/topology/sof-apl-pcm512x-mix.m4
+++ b/tools/topology/sof-apl-pcm512x-mix.m4
@@ -1,0 +1,206 @@
+#
+# Topology for generic Apollolake UP^2 with pcm512x codec and HDMI.
+#
+
+# Include topology builder
+include(`utils.m4')
+include(`dai.m4')
+include(`pipeline.m4')
+include(`ssp.m4')
+
+# Include TLV library
+include(`common/tlv.m4')
+
+# Include Token library
+include(`sof/tokens.m4')
+
+# Include Apollolake DSP configuration
+include(`platform/intel/bxt.m4')
+
+DEBUG_START
+
+# Define the pipelines
+#
+# PCM0 ---> volume ---> mixer ---> volume ---> SSP5 (pcm512x)
+# VIO2 ---------------->|
+#
+# PCM0 <--- volume <--- demux <--- SSP5
+# VIO5 <----------------|
+#
+# Note: current DEMUX coefficients are hard-coded to multiplex pipelines 1 and
+# 5. We reuse those pipeline IDs for host and guest capture pipelines to avoid
+# breaking other DEMUX users. Therefore we use 2 and 3 for host and guest
+# playback pipelines respectively.
+
+dnl PIPELINE_PCM_ADD(pipeline,
+dnl     pipe id, pcm, max channels, format,
+dnl     frames, deadline, priority, core)
+
+# Low Latency playback pipeline 2 on PCM 0 using max 2 channels of s32le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-low-latency-playback-1vol.m4,
+	2, 0, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Virtual playback PCM and buffer on pipeline 3 to be replaced by a guest
+# pipeline
+SectionWidget."VIO3.0" {
+	index "3"
+	type "aif_in"
+	stream_name "VM FE Playback"
+	no_pm "true"
+}
+
+SectionVendorTuples."BUF3.vm_tuples" {
+	tokens "sof_buffer_tokens"
+	tuples."word" {
+		SOF_TKN_BUF_SIZE	"0"
+		SOF_TKN_BUF_CAPS	"  113"
+	}
+}
+SectionData."BUF3.vm_data" {
+	tuples "BUF3.vm_tuples"
+}
+SectionWidget."BUF3.vm" {
+	index "3"
+	type "buffer"
+	no_pm "true"
+	data [
+		"BUF3.vm_data"
+	]
+}
+
+# Connect pipelines together
+SectionGraph."VIO-playback" {
+       index "3"
+
+       lines [
+               "BUF3.vm, , VIO3.0"
+               "MIXER2.0, , BUF3.vm"
+       ]
+}
+
+SectionPCMCapabilities."VM FE Playback" {
+	channels_min "2"
+	channels_max "2"
+}
+
+SectionPCM."vm_fe_playback" {
+	id "30"
+
+	dai."PortV0" {
+		id "30"
+	}
+
+	# Playback Configuration
+	pcm."playback" {
+
+		capabilities "VM FE Playback"
+	}
+}
+
+# Low Latency capture pipeline 1 on PCM 0 using max 2 channels of s32le.
+# 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-capture-mux.m4,
+	1, 0, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Virtual playback PCM and buffer on pipeline 5 to be replaced by a guest
+# pipeline
+SectionWidget."VIO5.0" {
+	index "5"
+	type "aif_out"
+	stream_name "VM FE Capture"
+	no_pm "true"
+}
+
+SectionVendorTuples."BUF5.vm_tuples" {
+	tokens "sof_buffer_tokens"
+	tuples."word" {
+		SOF_TKN_BUF_SIZE	"0"
+		SOF_TKN_BUF_CAPS	"  113"
+	}
+}
+SectionData."BUF5.vm_data" {
+	tuples "BUF5.vm_tuples"
+}
+SectionWidget."BUF5.vm" {
+	index "5"
+	type "buffer"
+	no_pm "true"
+	data [
+		"BUF5.vm_data"
+	]
+}
+
+# Connect pipelines together
+SectionGraph."VIO-capture" {
+       index "5"
+
+       lines [
+               "VIO5.0, , BUF5.vm"
+               "BUF5.vm, , MUXDEMUX1.0"
+       ]
+}
+
+SectionPCMCapabilities."VM FE Capture" {
+	channels_min "2"
+	channels_max "2"
+}
+
+SectionPCM."vm_fe_capture" {
+	id "50"
+
+	dai."PortV1" {
+		id "50"
+	}
+
+	# Capture Configuration
+	pcm."capture" {
+
+		capabilities "VM FE Capture"
+	}
+}
+
+#
+# DAIs configuration
+#
+
+dnl DAI_ADD(pipeline,
+dnl     pipe id, dai type, dai_index, dai_be,
+dnl     buffer, periods, format,
+dnl     frames, deadline, priority, core)
+
+# playback DAI is SSP5 using 2 periods
+# Buffers use s24le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+	2, SSP, 5, SSP5-Codec,
+	PIPELINE_SOURCE_2, 2, s24le,
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+
+# capture DAI is SSP5 using 2 periods
+# Buffers use s16le format, 1000us deadline on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-capture.m4,
+	1, SSP, 5, SSP5-Codec,
+	PIPELINE_SINK_1, 2, s24le,
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+
+# PCM Low Latency, id 0
+dnl PCM_DUPLEX_ADD(name, pcm_id, playback, capture)
+PCM_DUPLEX_ADD(Port5, 0, PIPELINE_PCM_2, PIPELINE_PCM_1)
+
+#
+# BE configurations - overrides config in ACPI if present
+#
+
+#SSP 5 (ID: 0)
+DAI_CONFIG(SSP, 5, 0, SSP5-Codec,
+	SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24576000, codec_mclk_in),
+		SSP_CLOCK(bclk, 3072000, codec_slave),
+		SSP_CLOCK(fsync, 48000, codec_slave),
+		SSP_TDM(2, 32, 3, 3),
+		SSP_CONFIG_DATA(SSP, 5, 24)))
+
+DEBUG_END

--- a/tools/topology/sof-apl-pcm512x-uos.m4
+++ b/tools/topology/sof-apl-pcm512x-uos.m4
@@ -1,0 +1,124 @@
+#
+# Topology for generic Apollolake UP^2 with pcm512x codec and HDMI - guest part.
+#
+
+# Include topology builder
+include(`utils.m4')
+include(`pcm.m4')
+include(`mixercontrol.m4')
+include(`pipeline.m4')
+include(`ssp.m4')
+
+# Include TLV library
+include(`common/tlv.m4')
+
+# Include Token library
+include(`sof/tokens.m4')
+
+# Include Apollolake DSP configuration
+include(`platform/intel/bxt.m4')
+
+DEBUG_START
+
+# Define the pipelines
+#
+# PCM0 ----> volume (-----> SSP5 (pcm512x))
+# PCM0 (<----- SSP5 (pcm512x))
+
+# Virtual playback PCM
+SectionVendorTuples."VIO3.0_comp_tuples" {
+	tokens "sof_comp_tokens"
+	tuples."word" {
+		SOF_TKN_COMP_REF	"11"
+	}
+}
+SectionData."VIO3.0_comp_data" {
+	tuples "VIO3.0_comp_tuples"
+}
+SectionVendorTuples."VIO3.0_dai_tuples" {
+	tokens "sof_dai_tokens"
+	tuples."word" {
+		SOF_TKN_DAI_DIRECTION	"0"
+	}
+}
+SectionData."VIO3.0_dai_data" {
+	tuples "VIO3.0_dai_tuples"
+}
+SectionWidget."SSP5.OUT" {
+	index "3"
+	type "dai_in"
+	no_pm "true"
+	stream_name "NoCodec-0"
+	data [
+		"VIO3.0_comp_data"
+		"VIO3.0_dai_data"
+	]
+}
+
+# Virtual capture PCM
+SectionVendorTuples."VIO5.0_comp_tuples" {
+	tokens "sof_comp_tokens"
+	tuples."word" {
+		SOF_TKN_COMP_REF	"2"
+	}
+}
+SectionData."VIO5.0_comp_data" {
+	tuples "VIO5.0_comp_tuples"
+}
+SectionVendorTuples."VIO5.0_dai_tuples" {
+	tokens "sof_dai_tokens"
+	tuples."word" {
+		SOF_TKN_DAI_DIRECTION	"1"
+	}
+}
+SectionData."VIO5.0_dai_data" {
+	tuples "VIO5.0_dai_tuples"
+}
+SectionWidget."SSP5.IN" {
+	index "5"
+	type "dai_out"
+	no_pm "true"
+	stream_name "NoCodec-0"
+	data [
+		"VIO5.0_comp_data"
+		"VIO5.0_dai_data"
+	]
+}
+
+dnl PIPELINE_PCM_ADD(pipeline,
+dnl     pipe id, pcm, max channels, format,
+dnl     frames, deadline, priority, core)
+
+# Low Latency playback pipeline 3 on PCM 0 using max 2 channels of s32le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-vm-playback.m4,
+	3, 1, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+W_PIPELINE(SSP5.OUT, 1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER, pipe_media_schedule_plat)
+
+P_GRAPH(SSP5-vm-playback-3, 3,
+	LIST(`		',
+	`dapm(SSP5.OUT, BUF3.1)',
+	))
+
+# Low Latency capture pipeline 5 on PCM 0 using max 2 channels of s32le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-vm-capture.m4,
+	5, 1, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+W_PIPELINE(SSP5.IN, 1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER, pipe_media_schedule_plat)
+
+P_GRAPH(SSP5-vm-capture-5, 5,
+	LIST(`		',
+	`dapm(BUF5.1, SSP5.IN)',
+	))
+
+# PCM Low Latency, id 0
+dnl PCM_DUPLEX_ADD(name, pcm_id, playback, capture)
+PCM_DUPLEX_ADD(Port5, 0, PIPELINE_PCM_3, PIPELINE_PCM_5)
+
+DEBUG_END

--- a/tools/topology/sof/pipe-low-latency-playback-1vol.m4
+++ b/tools/topology/sof/pipe-low-latency-playback-1vol.m4
@@ -1,0 +1,137 @@
+# Low Latency Pipeline
+#
+#  Low Latency Playback PCM mixed into single sink pipe.
+#  Low latency Capture PCM.
+#
+# Pipeline Endpoints for connection are :-
+#
+#	LL Playback Mixer (Mixer)
+#	LL Capture Volume B4 (DAI buffer)
+#	LL Playback Volume B3 (DAI buffer)
+#
+#
+#  host PCM_P --B0--> volume(0P) --B1--+
+#                                      |--ll mixer(M) --B2--> volume(LL) ---B3-->  sink DAI0
+#                     pipeline n+1 >---+
+#                                      |
+#                     pipeline n+2 >---+
+#                                      |
+#                     pipeline n+3 >---+  .....etc....more pipes can be mixed here
+#
+
+# Include topology builder
+include(`utils.m4')
+include(`buffer.m4')
+include(`pcm.m4')
+include(`pga.m4')
+include(`mixer.m4')
+include(`mixercontrol.m4')
+
+#
+# Controls
+#
+# Volume Mixer control with max value of 32
+C_CONTROLMIXER(PCM PCM_ID Playback Volume, PIPELINE_ID,
+	CONTROLMIXER_OPS(volsw, 256 binds the mixer control to volume get/put handlers, 256, 256),
+	CONTROLMIXER_MAX(, 32),
+	false,
+	CONTROLMIXER_TLV(TLV 32 steps from -64dB to 0dB for 2dB, vtlv_m64s2),
+	Channel register and shift for Front Left/Right,
+	LIST(KCONTROL_CHANNEL(FL, 0, 0), KCONTROL_CHANNEL(FR, 0, 1)))
+
+SectionTLV."vtlv_m2s2" {
+	Comment "-2dB step 2dB"
+
+	scale {
+		min "-200"
+		step "200"
+		mute "0"
+	}
+}
+
+# Volume Mixer control with max value of 32
+C_CONTROLMIXER(Master Playback Volume, PIPELINE_ID,
+	CONTROLMIXER_OPS(volsw, 256 binds the mixer control to volume get/put handlers, 256, 256),
+	CONTROLMIXER_MAX(, 32),
+	false,
+	CONTROLMIXER_TLV(TLV 1 step from -2dB to 0dB for 2dB, vtlv_m2s2),
+	Channel register and shift for Front Left/Right,
+	LIST(`	', KCONTROL_CHANNEL(FL, 1, 0), KCONTROL_CHANNEL(FR, 1, 1)))
+
+#
+# Volume configuration
+#
+
+W_VENDORTUPLES(playback_pga_tokens, sof_volume_tokens,
+LIST(`		', `SOF_TKN_VOLUME_RAMP_STEP_TYPE	"0"'
+     `		', `SOF_TKN_VOLUME_RAMP_STEP_MS		"250"'))
+
+W_DATA(playback_pga_conf, playback_pga_tokens)
+
+#
+# Components and Buffers
+#
+
+# Host "Low latency Playback" PCM
+# with 2 sink and 0 source periods
+W_PCM_PLAYBACK(PCM_ID, Low Latency Playback, 2, 0)
+
+# "Playback Volume" has 2 sink periods and 2 source periods for host ping-pong
+W_PGA(0, PIPELINE_FORMAT, 2, 2, playback_pga_conf, LIST(`		', "PIPELINE_ID PCM PCM_ID Playback Volume"))
+
+# "Master Playback Volume" has 2 source and 2 sink periods for DAI ping-pong
+W_PGA(1, PIPELINE_FORMAT, 2, 2, playback_pga_conf, LIST(`		', "PIPELINE_ID Master Playback Volume"))
+
+# Mixer 0 has 2 sink and source periods.
+W_MIXER(0, PIPELINE_FORMAT, 2, 2)
+
+# Low Latency Buffers
+W_BUFFER(0, COMP_BUFFER_SIZE(2,
+	COMP_SAMPLE_SIZE(PIPELINE_FORMAT), PIPELINE_CHANNELS, COMP_PERIOD_FRAMES(PCM_MAX_RATE, SCHEDULE_PERIOD)),
+	PLATFORM_HOST_MEM_CAP)
+W_BUFFER(1, COMP_BUFFER_SIZE(2,
+	COMP_SAMPLE_SIZE(PIPELINE_FORMAT), PIPELINE_CHANNELS,COMP_PERIOD_FRAMES(PCM_MAX_RATE, SCHEDULE_PERIOD)),
+	PLATFORM_COMP_MEM_CAP)
+W_BUFFER(2, COMP_BUFFER_SIZE(2,
+	COMP_SAMPLE_SIZE(PIPELINE_FORMAT), PIPELINE_CHANNELS, COMP_PERIOD_FRAMES(PCM_MAX_RATE, SCHEDULE_PERIOD)),
+	PLATFORM_COMP_MEM_CAP)
+W_BUFFER(3, COMP_BUFFER_SIZE(2,
+	COMP_SAMPLE_SIZE(PIPELINE_FORMAT), PIPELINE_CHANNELS, COMP_PERIOD_FRAMES(PCM_MAX_RATE, SCHEDULE_PERIOD)),
+	PLATFORM_DAI_MEM_CAP)
+
+#
+# Pipeline Graph
+#
+#  host PCM_P --B0--> volume(0P) --B1--+
+#                                      |--ll mixer(M) --B2--> volume(LL) ---B3-->  sink DAI0
+#                     pipeline n+1 >---+
+#                                      |
+#                     pipeline n+2 >---+
+#                                      |
+#                     pipeline n+3 >---+  .....etc....more pipes can be mixed here
+#
+
+P_GRAPH(pipe-ll-playback-PIPELINE_ID, PIPELINE_ID,
+	LIST(`		',
+	`dapm(N_BUFFER(0), N_PCMP(PCM_ID))',
+	`dapm(N_PGA(0), N_BUFFER(0))',
+	`dapm(N_BUFFER(1), N_PGA(0))',
+	`dapm(N_MIXER(0), N_BUFFER(1))',
+	`dapm(N_BUFFER(2), N_MIXER(0))',
+	`dapm(N_PGA(1), N_BUFFER(2))',
+	`dapm(N_BUFFER(3), N_PGA(1))'))
+
+#
+# Pipeline Source and Sinks
+#
+indir(`define', concat(`PIPELINE_SOURCE_', PIPELINE_ID), N_BUFFER(3))
+indir(`define', concat(`PIPELINE_MIXER_', PIPELINE_ID), N_MIXER(0))
+indir(`define', concat(`PIPELINE_PCM_', PIPELINE_ID), Low Latency Playback PCM_ID)
+
+#
+# PCM Configuration
+#
+
+
+# PCM capabilities supported by FW
+PCM_CAPABILITIES(Low Latency Playback PCM_ID, `S32_LE,S24_LE,S16_LE', PCM_MIN_RATE, PCM_MAX_RATE, 2, PIPELINE_CHANNELS, 2, 16, 192, 16384, 65536, 65536)

--- a/tools/topology/sof/pipe-vm-capture.m4
+++ b/tools/topology/sof/pipe-vm-capture.m4
@@ -1,0 +1,66 @@
+include(`buffer.m4')
+include(`pga.m4')
+
+#
+# Controls
+#
+# Volume Mixer control with max value of 32
+C_CONTROLMIXER(Master Capture Volume, PIPELINE_ID,
+	CONTROLMIXER_OPS(volsw, 256 binds the mixer control to volume get/put handlers, 256, 256),
+	CONTROLMIXER_MAX(, 32),
+	false,
+	CONTROLMIXER_TLV(TLV 32 steps from -64dB to 0dB for 2dB, vtlv_m64s2),
+	Channel register and shift for Front Left/Right,
+	LIST(`	', KCONTROL_CHANNEL(FL, 1, 0), KCONTROL_CHANNEL(FR, 1, 1)))
+
+#
+# Components and Buffers
+#
+
+# Host "Passthrough Capture" PCM
+# with 2 sink and 0 source periods
+W_PCM_CAPTURE(PCM_ID, Passthrough Capture, 0, 2)
+
+W_VENDORTUPLES(capture_pga_tokens, sof_volume_tokens,
+LIST(`		', `SOF_TKN_VOLUME_RAMP_STEP_TYPE	"0"'
+     `		', `SOF_TKN_VOLUME_RAMP_STEP_MS		"250"'))
+
+W_DATA(capture_pga_conf, capture_pga_tokens)
+
+# "Volume" has 2 source and 2 sink periods
+W_PGA(0, PIPELINE_FORMAT, 2, 2, capture_pga_conf, LIST(`		', "PIPELINE_ID Master Capture Volume"))
+
+# Capture Buffers
+W_BUFFER(0, COMP_BUFFER_SIZE(2,
+	COMP_SAMPLE_SIZE(PIPELINE_FORMAT), PIPELINE_CHANNELS, COMP_PERIOD_FRAMES(PCM_MAX_RATE, SCHEDULE_PERIOD)),
+	PLATFORM_HOST_MEM_CAP)
+W_BUFFER(1, COMP_BUFFER_SIZE(2,
+	COMP_SAMPLE_SIZE(PIPELINE_FORMAT), PIPELINE_CHANNELS, COMP_PERIOD_FRAMES(PCM_MAX_RATE, SCHEDULE_PERIOD)),
+	PLATFORM_HOST_MEM_CAP)
+
+#
+# Pipeline Graph
+#
+#  host PCM_C <-- B0 <-- volume <-- B1 <-- (host:mixer...)
+
+P_GRAPH(pipe-pass-vol-capture-PIPELINE_ID, PIPELINE_ID,
+	LIST(`		',
+	`dapm(N_PCMC(PCM_ID), N_BUFFER(0))',
+	`dapm(N_BUFFER(0), N_PGA(0))',
+	`dapm(N_PGA(0), N_BUFFER(1))'))
+
+#include(`pipeline.m4')
+
+#
+# Pipeline Source and Sinks
+#
+#indir(`define', concat(`PIPELINE_SOURCE_', PIPELINE_ID), N_BUFFER(1))
+indir(`define', concat(`PIPELINE_PCM_', PIPELINE_ID), Passthrough Capture PCM_ID)
+
+#
+# PCM Configuration
+
+#
+PCM_CAPABILITIES(Passthrough Capture PCM_ID, `S32_LE,S24_LE,S16_LE',
+	PCM_MIN_RATE, PCM_MAX_RATE, PIPELINE_CHANNELS, PIPELINE_CHANNELS,
+	2, 16, 192, 16384, 65536, 65536)

--- a/tools/topology/sof/pipe-vm-playback.m4
+++ b/tools/topology/sof/pipe-vm-playback.m4
@@ -1,0 +1,67 @@
+include(`buffer.m4')
+include(`pga.m4')
+
+#
+# Controls
+#
+# Volume Mixer control with max value of 32
+C_CONTROLMIXER(Master Playback Volume, PIPELINE_ID,
+	CONTROLMIXER_OPS(volsw, 256 binds the mixer control to volume get/put handlers, 256, 256),
+	CONTROLMIXER_MAX(, 32),
+	false,
+	CONTROLMIXER_TLV(TLV 32 steps from -64dB to 0dB for 2dB, vtlv_m64s2),
+	Channel register and shift for Front Left/Right,
+	LIST(`	', KCONTROL_CHANNEL(FL, 1, 0), KCONTROL_CHANNEL(FR, 1, 1)))
+
+#
+# Components and Buffers
+#
+
+# Host "Passthrough Playback" PCM
+# with 2 sink and 0 source periods
+W_PCM_PLAYBACK(PCM_ID, Passthrough Playback, 2, 0)
+
+W_VENDORTUPLES(playback_pga_tokens, sof_volume_tokens,
+LIST(`		', `SOF_TKN_VOLUME_RAMP_STEP_TYPE	"0"'
+     `		', `SOF_TKN_VOLUME_RAMP_STEP_MS		"250"'))
+
+W_DATA(playback_pga_conf, playback_pga_tokens)
+
+# "Volume" has 2 source and 2 sink periods
+W_PGA(0, PIPELINE_FORMAT, 2, 2, playback_pga_conf, LIST(`		', "PIPELINE_ID Master Playback Volume"))
+
+# Playback Buffers
+W_BUFFER(0, COMP_BUFFER_SIZE(2,
+	COMP_SAMPLE_SIZE(PIPELINE_FORMAT), PIPELINE_CHANNELS, COMP_PERIOD_FRAMES(PCM_MAX_RATE, SCHEDULE_PERIOD)),
+	PLATFORM_HOST_MEM_CAP)
+W_BUFFER(1, COMP_BUFFER_SIZE(2,
+	COMP_SAMPLE_SIZE(PIPELINE_FORMAT), PIPELINE_CHANNELS, COMP_PERIOD_FRAMES(PCM_MAX_RATE, SCHEDULE_PERIOD)),
+	PLATFORM_HOST_MEM_CAP)
+
+#
+# Pipeline Graph
+#
+#  host PCM_P --> B0 --> volume --> B1 --> (host:mixer...)
+
+P_GRAPH(pipe-pass-vol-playback-PIPELINE_ID, PIPELINE_ID,
+	LIST(`		',
+	`dapm(N_BUFFER(0), N_PCMP(PCM_ID))',
+	`dapm(N_PGA(0), N_BUFFER(0))',
+	`dapm(N_BUFFER(1), N_PGA(0))',
+	))
+
+#include(`pipeline.m4')
+
+#
+# Pipeline Source and Sinks
+#
+#indir(`define', concat(`PIPELINE_SOURCE_', PIPELINE_ID), N_BUFFER(1))
+indir(`define', concat(`PIPELINE_PCM_', PIPELINE_ID), Passthrough Playback PCM_ID)
+
+#
+# PCM Configuration
+
+#
+PCM_CAPABILITIES(Passthrough Playback PCM_ID, `S32_LE,S24_LE,S16_LE',
+	PCM_MIN_RATE, PCM_MAX_RATE, PIPELINE_CHANNELS, PIPELINE_CHANNELS,
+	2, 16, 192, 16384, 65536, 65536)

--- a/tools/topology/sof/pipe-volume-capture-mux.m4
+++ b/tools/topology/sof/pipe-volume-capture-mux.m4
@@ -1,0 +1,108 @@
+# Demux volume Pipeline capture pipeline
+#
+# Pipeline Endpoints for connection are :-
+#
+#	Capture Demux
+#	B2 (DAI buffer)
+#
+#  host PCM_C <-- B0 <-- Demux(M) <-- B1 <-- volume <-- B2 <-- source DAI0
+#                             |
+#       PCM_C <-- ... <-- pipeline n+1
+
+# Include topology builder
+include(`utils.m4')
+include(`buffer.m4')
+include(`pcm.m4')
+include(`pga.m4')
+include(`dai.m4')
+include(`muxdemux.m4')
+include(`mixercontrol.m4')
+include(`bytecontrol.m4')
+include(`pipeline.m4')
+
+# Use default parameters
+include(`demux_coef_default.m4')
+
+#
+# Controls
+#
+# Demux control
+C_CONTROLBYTES(DEMUX, PIPELINE_ID,
+	CONTROLBYTES_OPS(bytes, 258 binds the demux control to bytes get/put handlers, 258, 258),
+	CONTROLBYTES_EXTOPS(258 binds the demux control to bytes get/put handlers, 258, 258),
+	, , ,
+	CONTROLBYTES_MAX(, 304),
+	,
+	DEMUX_priv)
+
+# Volume Mixer control with max value of 32
+C_CONTROLMIXER(PCM PCM_ID Capture Volume, PIPELINE_ID,
+	CONTROLMIXER_OPS(volsw, 256 binds the mixer control to volume get/put handlers, 256, 256),
+	CONTROLMIXER_MAX(, 80),
+	false,
+	CONTROLMIXER_TLV(TLV 80 steps from -50dB to +30dB for 1dB, vtlv_m50s1),
+	Channel register and shift for Front Left/Right,
+	LIST(`	', KCONTROL_CHANNEL(FL, 2, 0), KCONTROL_CHANNEL(FR, 2, 1)))
+
+#
+# Volume Configuration
+#
+
+W_VENDORTUPLES(capture_pga_tokens, sof_volume_tokens,
+LIST(`		', `SOF_TKN_VOLUME_RAMP_STEP_TYPE	"0"'
+     `		', `SOF_TKN_VOLUME_RAMP_STEP_MS		"250"'))
+
+W_DATA(capture_pga_conf, capture_pga_tokens)
+
+#
+# Components and Buffers
+#
+
+# Host "Passthrough Capture" PCM
+# with 0 sink and 2 source periods
+W_PCM_CAPTURE(PCM_ID, Passthrough Capture, 0, 2)
+
+# "DAI Capture Volume" has 2 source and 2 sink periods for DAI ping-pong
+W_PGA(0, PIPELINE_FORMAT, 2, 2, capture_pga_conf, LIST(`		', "PIPELINE_ID PCM PCM_ID Capture Volume"))
+
+# Mux 0 has 2 sink and source periods.
+W_MUXDEMUX(0, 1, PIPELINE_FORMAT, 2, 2, LIST(`         ', "DEMUX"))
+
+# Capture Buffers
+W_BUFFER(0, COMP_BUFFER_SIZE(2,
+	COMP_SAMPLE_SIZE(PIPELINE_FORMAT), PIPELINE_CHANNELS, COMP_PERIOD_FRAMES(PCM_MAX_RATE, SCHEDULE_PERIOD)),
+	PLATFORM_HOST_MEM_CAP)
+W_BUFFER(1, COMP_BUFFER_SIZE(2,
+	COMP_SAMPLE_SIZE(PIPELINE_FORMAT), PIPELINE_CHANNELS, COMP_PERIOD_FRAMES(PCM_MAX_RATE, SCHEDULE_PERIOD)),
+	PLATFORM_HOST_MEM_CAP)
+W_BUFFER(2, COMP_BUFFER_SIZE(2,
+	COMP_SAMPLE_SIZE(PIPELINE_FORMAT), PIPELINE_CHANNELS, COMP_PERIOD_FRAMES(PCM_MAX_RATE, SCHEDULE_PERIOD)),
+	PLATFORM_HOST_MEM_CAP)
+
+#
+# Pipeline Graph
+#
+#  host PCM_C <-- B0 <-- Volume 0 <-- B1 <-- Demux 0 <-- B2 <-- sink DAI0
+
+P_GRAPH(pipe-pass-vol-capture-PIPELINE_ID, PIPELINE_ID,
+	LIST(`		',
+	`dapm(N_PCMC(PCM_ID), N_BUFFER(0))',
+	`dapm(N_BUFFER(0), N_PGA(0))',
+	`dapm(N_PGA(0), N_BUFFER(1))',
+	`dapm(N_BUFFER(1), N_MUXDEMUX(0))',
+	`dapm(N_MUXDEMUX(0), N_BUFFER(2))'))
+
+#
+# Pipeline Source and Sinks
+#
+indir(`define', concat(`PIPELINE_SINK_', PIPELINE_ID), N_BUFFER(2))
+indir(`define', concat(`PIPELINE_DEMUX_', PIPELINE_ID), N_MUXDEMUX(0))
+indir(`define', concat(`PIPELINE_PCM_', PIPELINE_ID), Passthrough Capture PCM_ID)
+
+#
+# PCM Configuration
+#
+
+PCM_CAPABILITIES(Passthrough Capture PCM_ID, `S32_LE,S24_LE,S16_LE',
+	PCM_MIN_RATE, PCM_MAX_RATE, PIPELINE_CHANNELS, PIPELINE_CHANNELS,
+	2, 16, 192, 16384, 65536, 65536)

--- a/tools/topology/sof/tokens.m4
+++ b/tools/topology/sof/tokens.m4
@@ -58,6 +58,7 @@ SectionVendorTokens."sof_comp_tokens" {
 	SOF_TKN_COMP_FORMAT			"402"
 # Token retired with ABI 3.2, do not use for new capabilities
 #	SOF_TKN_COMP_PRELOAD_COUNT		"403"
+	SOF_TKN_COMP_REF			"404"
 }
 
 SectionVendorTokens."sof_ssp_tokens" {


### PR DESCRIPTION
This patch adds two new topologies for SOF virtualisation: a host
topology for the Up^2 board with a pcm512x HiFiBerry codec board and
a guest topology. The host part is based on the standard pcm512x
topology for the same configuration, but for simplicity it removes
all HDMI pipelines and only keeps two host SSP pipelines for playback
and capture, and adds a mixer and a demux branches for the guest
front end.

This is mostly an example. The final version will likely be more elaborate.