### PR TITLE
dai: add dir arg to get_hw_params function in dai_ops

### DIFF
--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -201,7 +201,7 @@ static void dai_free(struct comp_dev *dev)
 }
 
 static int dai_comp_get_hw_params(struct comp_dev *dev,
-				  struct sof_ipc_stream_params *params)
+				  struct sof_ipc_stream_params *params, int dir)
 {
 	struct dai_data *dd = comp_get_drvdata(dev);
 	int ret = 0;
@@ -209,7 +209,7 @@ static int dai_comp_get_hw_params(struct comp_dev *dev,
 	comp_info(dev, "dai_hw_params()");
 
 	/* fetching hw dai stream params */
-	ret = dai_get_hw_params(dd->dai, params);
+	ret = dai_get_hw_params(dd->dai, params, dir);
 	if (ret < 0) {
 		comp_err(dev, "dai_comp_get_hw_params() error: dai_get_hw_params failed");
 		return ret;
@@ -223,7 +223,7 @@ static int dai_verify_params(struct comp_dev *dev,
 {
 	struct sof_ipc_stream_params hw_params;
 
-	dai_comp_get_hw_params(dev, &hw_params);
+	dai_comp_get_hw_params(dev, &hw_params, params->direction);
 
 	/* checks whether pcm parameters match hardware DAI parameter set
 	 * during dai_set_config(). If hardware parameter is equal to 0, it

--- a/src/audio/pipeline.c
+++ b/src/audio/pipeline.c
@@ -282,7 +282,7 @@ static int pipeline_comp_hw_params(struct comp_dev *current,
 	/* Fetch hardware stream parameters from DAI component */
 	if (dev_comp_type(current) == SOF_COMP_DAI) {
 		ret = comp_dai_get_hw_params(current,
-					     &ppl_data->params->params);
+					     &ppl_data->params->params, dir);
 		if (ret < 0) {
 			pipe_cl_err("pipeline_find_dai_comp(): comp_dai_get_hw_params() error.");
 			return ret;

--- a/src/drivers/intel/baytrail/ssp.c
+++ b/src/drivers/intel/baytrail/ssp.c
@@ -487,8 +487,12 @@ static int ssp_get_hw_params(struct dai *dai,
 	struct ssp_pdata *ssp = dai_get_drvdata(dai);
 
 	params->rate = ssp->params.fsync_rate;
-	params->channels = ssp->params.tdm_slots;
 	params->buffer_fmt = 0;
+
+	if (dir == SOF_IPC_STREAM_PLAYBACK)
+		params->channels = popcount(ssp->params.tx_slots);
+	else
+		params->channels = popcount(ssp->params.rx_slots);
 
 	switch (ssp->params.sample_valid_bits) {
 	case 16:

--- a/src/drivers/intel/baytrail/ssp.c
+++ b/src/drivers/intel/baytrail/ssp.c
@@ -482,7 +482,7 @@ out:
 
 /* get SSP hw params */
 static int ssp_get_hw_params(struct dai *dai,
-			     struct sof_ipc_stream_params  *params)
+			     struct sof_ipc_stream_params  *params, int dir)
 {
 	struct ssp_pdata *ssp = dai_get_drvdata(dai);
 

--- a/src/drivers/intel/cavs/alh.c
+++ b/src/drivers/intel/cavs/alh.c
@@ -32,7 +32,7 @@ static int alh_set_config(struct dai *dai, struct sof_ipc_dai_config *config)
 
 /* get ALH hw params */
 static int alh_get_hw_params(struct dai *dai,
-			     struct sof_ipc_stream_params  *params)
+			     struct sof_ipc_stream_params  *params, int dir)
 {
 	/* 0 means variable */
 	params->rate = 0;

--- a/src/drivers/intel/cavs/dmic.c
+++ b/src/drivers/intel/cavs/dmic.c
@@ -1048,7 +1048,7 @@ static int configure_registers(struct dai *dai,
 
 /* get DMIC hw params */
 static int dmic_get_hw_params(struct dai *dai,
-			      struct sof_ipc_stream_params  *params)
+			      struct sof_ipc_stream_params  *params, int dir)
 {
 	int di = dai->index;
 

--- a/src/drivers/intel/cavs/hda.c
+++ b/src/drivers/intel/cavs/hda.c
@@ -25,7 +25,7 @@ static int hda_set_config(struct dai *dai,
 
 /* get HDA hw params */
 static int hda_get_hw_params(struct dai *dai,
-			     struct sof_ipc_stream_params  *params)
+			     struct sof_ipc_stream_params  *params, int dir)
 {
 	/* 0 means variable */
 	params->rate = 0;

--- a/src/drivers/intel/cavs/ssp.c
+++ b/src/drivers/intel/cavs/ssp.c
@@ -624,8 +624,12 @@ static int ssp_get_hw_params(struct dai *dai,
 	struct ssp_pdata *ssp = dai_get_drvdata(dai);
 
 	params->rate = ssp->params.fsync_rate;
-	params->channels = ssp->params.tdm_slots;
 	params->buffer_fmt = 0;
+
+	if (dir == SOF_IPC_STREAM_PLAYBACK)
+		params->channels = popcount(ssp->params.tx_slots);
+	else
+		params->channels = popcount(ssp->params.rx_slots);
 
 	switch (ssp->params.sample_valid_bits) {
 	case 16:

--- a/src/drivers/intel/cavs/ssp.c
+++ b/src/drivers/intel/cavs/ssp.c
@@ -619,7 +619,7 @@ out:
 
 /* get SSP hw params */
 static int ssp_get_hw_params(struct dai *dai,
-			     struct sof_ipc_stream_params  *params)
+			     struct sof_ipc_stream_params  *params, int dir)
 {
 	struct ssp_pdata *ssp = dai_get_drvdata(dai);
 

--- a/src/drivers/intel/haswell/ssp.c
+++ b/src/drivers/intel/haswell/ssp.c
@@ -390,7 +390,7 @@ out:
 
 /* get SSP hw params */
 static int ssp_get_hw_params(struct dai *dai,
-			     struct sof_ipc_stream_params  *params)
+			     struct sof_ipc_stream_params  *params, int dir)
 {
 	struct ssp_pdata *ssp = dai_get_drvdata(dai);
 

--- a/src/drivers/intel/haswell/ssp.c
+++ b/src/drivers/intel/haswell/ssp.c
@@ -395,8 +395,12 @@ static int ssp_get_hw_params(struct dai *dai,
 	struct ssp_pdata *ssp = dai_get_drvdata(dai);
 
 	params->rate = ssp->params.fsync_rate;
-	params->channels = ssp->params.tdm_slots;
 	params->buffer_fmt = 0;
+
+	if (dir == SOF_IPC_STREAM_PLAYBACK)
+		params->channels = popcount(ssp->params.tx_slots);
+	else
+		params->channels = popcount(ssp->params.rx_slots);
 
 	switch (ssp->params.sample_valid_bits) {
 	case 16:

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -211,7 +211,7 @@ struct comp_ops {
 
 	/** get dai hw parameters */
 	int (*dai_get_hw_params)(struct comp_dev *dev,
-				 struct sof_ipc_stream_params *params);
+				 struct sof_ipc_stream_params *params, int dir);
 
 	/** set component audio stream parameters */
 	int (*dai_config)(struct comp_dev *dev,
@@ -512,10 +512,11 @@ static inline int comp_params(struct comp_dev *dev,
  * @return 0 if succeeded, error code otherwise.
  */
 static inline int comp_dai_get_hw_params(struct comp_dev *dev,
-					 struct sof_ipc_stream_params *params)
+					 struct sof_ipc_stream_params *params,
+					 int dir)
 {
 	if (dev->drv->ops.dai_get_hw_params)
-		return dev->drv->ops.dai_get_hw_params(dev, params);
+		return dev->drv->ops.dai_get_hw_params(dev, params, dir);
 	return -EINVAL;
 }
 

--- a/src/include/sof/lib/dai.h
+++ b/src/include/sof/lib/dai.h
@@ -67,7 +67,7 @@ struct dai_ops {
 	int (*pm_context_restore)(struct dai *dai);
 	int (*pm_context_store)(struct dai *dai);
 	int (*get_hw_params)(struct dai *dai,
-			     struct sof_ipc_stream_params *params);
+			     struct sof_ipc_stream_params *params, int dir);
 	int (*get_handshake)(struct dai *dai, int direction, int stream_id);
 	int (*get_fifo)(struct dai *dai, int direction, int stream_id);
 	int (*probe)(struct dai *dai);
@@ -275,9 +275,10 @@ static inline int dai_pm_context_restore(struct dai *dai)
  * \brief Get Digital Audio interface stream parameters
  */
 static inline int dai_get_hw_params(struct dai *dai,
-				    struct sof_ipc_stream_params *params)
+				    struct sof_ipc_stream_params *params,
+				    int dir)
 {
-	int ret = dai->drv->ops.get_hw_params(dai, params);
+	int ret = dai->drv->ops.get_hw_params(dai, params, dir);
 
 	platform_shared_commit(dai, sizeof(*dai));
 


### PR DESCRIPTION
Hardware stream parameters can be different for
PLAYBACK and CAPTURE direction. get_hw_params()
and dai_get_hw_params() function should return 
parameters correctly depending on the stream direction.

