### PR TITLE
scripts: qemu: Add qemu check for i.MX8 platform

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,3 +64,5 @@ jobs:
       env: PLATFORM=cnl
     - <<: *qemuboottest
       env: PLATFORM=icl
+    - <<: *qemuboottest
+      env: PLATFORM=imx8

--- a/scripts/qemu-check.sh
+++ b/scripts/qemu-check.sh
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright(c) 2018 Intel Corporation. All rights reserved.
 
-SUPPORTED_PLATFORMS=(byt cht bdw hsw apl icl skl kbl cnl)
+SUPPORTED_PLATFORMS=(byt cht bdw hsw apl icl skl kbl cnl imx8)
 READY_MSG="6c 00 00 00 00 00 00 70"
 
 rm -f dump-*.txt
@@ -94,6 +94,12 @@ do
 		OUTBOX_OFFSET="5000"
 		SHM_MBOX=qemu-bridge-hp-sram-mem
 		ROM="-r ../sof.git/build_${j}_gcc/src/arch/xtensa/rom-$j.bin"
+	fi
+	if [ $j == "imx8" ]
+	then
+		READY_IPC="00 00 00 00 00 00 04 c0"
+		SHM_IPC_REG=qemu-bridge-mu-io
+		SHM_MBOX=qemu-bridge-mbox-io
 	fi
 
 	./xtensa-host.sh $PLATFORM -k ../sof.git/build_${j}_gcc/src/arch/xtensa/$FWNAME $ROM -o 2.0 ../sof.git/dump-$j.txt


### PR DESCRIPTION
Enable checks to i.MX8 platform of QEMU now.
Check both IPC header regs and memory window IPC message header.

Signed-off-by: Diana Cretu <diana.cretu@nxp.com>