### PR TITLE
CI: travis: Add boot test for i.MX8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,3 +64,5 @@ jobs:
       env: PLATFORM=cnl
     - <<: *qemuboottest
       env: PLATFORM=icl
+    - <<: *qemuboottest
+      env: PLATFORM=imx8


### PR DESCRIPTION
imx8 is now supported in qemu up to boot. So, add
it to boottest list.

Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>