### PR TITLE
bit: Upgrade BIT macro to use 1UL instead of 1

### DIFF
--- a/src/include/sof/bit.h
+++ b/src/include/sof/bit.h
@@ -8,7 +8,12 @@
 #ifndef __SOF_BIT_H__
 #define __SOF_BIT_H__
 
+#if ASSEMBLY
 #define BIT(b)			(1 << (b))
+#else
+#define BIT(b)			(1UL << (b))
+#endif
+
 #define MASK(b_hi, b_lo)	\
 	(((1ULL << ((b_hi) - (b_lo) + 1ULL)) - 1ULL) << (b_lo))
 #define SET_BIT(b, x)		(((x) & 1) << (b))


### PR DESCRIPTION
In such a solution it is possible to assign BIT(31) to
uint32_t register value without any warning.

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>