### PR TITLE
ssp: Move conversion from SSCR3 value to RFL to bit description section

### DIFF
--- a/src/drivers/intel/cavs/ssp.c
+++ b/src/drivers/intel/cavs/ssp.c
@@ -57,7 +57,7 @@ static void ssp_empty_rx_fifo(struct dai *dai)
 
 	/* empty fifo */
 	if (sssr & SSSR_RNE) {
-		entries = (ssp_read(dai, SSCR3) & SSCR3_RFL_MASK) >> 8;
+		entries = SSCR3_RFL_VAL(ssp_read(dai, SSCR3));
 		for (i = 0; i < entries + 1; i++)
 			ssp_read(dai, SSDR);
 	}

--- a/src/include/sof/drivers/ssp.h
+++ b/src/include/sof/drivers/ssp.h
@@ -192,6 +192,8 @@ extern const struct dai_driver ssp_driver;
 
 #define SSCR3_TFL_MASK	(0x0000003f)
 #define SSCR3_RFL_MASK	(0x00003f00)
+#define SSCR3_TFL_VAL(scr3_val)	(((scr3_val) >> 0) & MASK(5, 0))
+#define SSCR3_RFL_VAL(scr3_val)	(((scr3_val) >> 8) & MASK(5, 0))
 #define SSCR3_TFT_MASK	(0x003f0000)
 #define SSCR3_TX(x) (((x) - 1) << 16)
 #define SSCR3_RFT_MASK	(0x3f000000)


### PR DESCRIPTION
This conversion in source code looks quite magic. It should be described
in header file where are registers bits description.

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>