### PR TITLE
ssp: Use register name instead of bit value

### DIFF
--- a/src/drivers/intel/baytrail/ssp.c
+++ b/src/drivers/intel/baytrail/ssp.c
@@ -466,8 +466,8 @@ static int ssp_set_config(struct dai *dai,
 	ssp_write(dai, SSCR5, sscr5);
 	ssp_write(dai, SSPSP, sspsp);
 	ssp_write(dai, SFIFOTT, sfifott);
-	ssp_write(dai, SSTSA, config->ssp.tx_slots);
-	ssp_write(dai, SSRSA, config->ssp.rx_slots);
+	ssp_write(dai, SSTSA, SSTSA_SSTSA(config->ssp.tx_slots));
+	ssp_write(dai, SSRSA, SSRSA_SSRSA(config->ssp.rx_slots));
 
 	ssp->state[DAI_DIR_PLAYBACK] = COMP_STATE_PREPARE;
 	ssp->state[DAI_DIR_CAPTURE] = COMP_STATE_PREPARE;

--- a/src/drivers/intel/cavs/ssp.c
+++ b/src/drivers/intel/cavs/ssp.c
@@ -172,10 +172,10 @@ static int ssp_set_config(struct dai *dai,
 	ssto = 0x0;
 
 	/* sstsa dynamic setting is TTSA, default 2 slots */
-	sstsa = config->ssp.tx_slots;
+	sstsa = SSTSA_SSTSA(config->ssp.tx_slots);
 
 	/* ssrsa dynamic setting is RTSA, default 2 slots */
-	ssrsa = config->ssp.rx_slots;
+	ssrsa = SSRSA_SSRSA(config->ssp.rx_slots);
 
 	switch (config->format & SOF_DAI_FMT_MASTER_MASK) {
 	case SOF_DAI_FMT_CBM_CFM:
@@ -669,10 +669,10 @@ static void ssp_start(struct dai *dai, int direction)
 	/* enable DMA */
 	if (direction == DAI_DIR_PLAYBACK) {
 		ssp_update_bits(dai, SSCR1, SSCR1_TSRE, SSCR1_TSRE);
-		ssp_update_bits(dai, SSTSA, 0x1 << 8, 0x1 << 8);
+		ssp_update_bits(dai, SSTSA, SSTSA_TXEN, SSTSA_TXEN);
 	} else {
 		ssp_update_bits(dai, SSCR1, SSCR1_RSRE, SSCR1_RSRE);
-		ssp_update_bits(dai, SSRSA, 0x1 << 8, 0x1 << 8);
+		ssp_update_bits(dai, SSRSA, SSRSA_RXEN, SSRSA_RXEN);
 	}
 
 	/* wait to get valid fifo status */
@@ -695,7 +695,7 @@ static void ssp_stop(struct dai *dai, int direction)
 	if (direction == DAI_DIR_CAPTURE &&
 	    ssp->state[SOF_IPC_STREAM_CAPTURE] == COMP_STATE_ACTIVE) {
 		ssp_update_bits(dai, SSCR1, SSCR1_RSRE, 0);
-		ssp_update_bits(dai, SSRSA, 0x1 << 8, 0x0 << 8);
+		ssp_update_bits(dai, SSRSA, SSRSA_RXEN, 0);
 		ssp_empty_rx_fifo(dai);
 		ssp->state[SOF_IPC_STREAM_CAPTURE] = COMP_STATE_PAUSED;
 		dai_info(dai, "ssp_stop(), RX stop");
@@ -706,7 +706,7 @@ static void ssp_stop(struct dai *dai, int direction)
 	    ssp->state[SOF_IPC_STREAM_PLAYBACK] == COMP_STATE_ACTIVE) {
 		ssp_empty_tx_fifo(dai);
 		ssp_update_bits(dai, SSCR1, SSCR1_TSRE, 0);
-		ssp_update_bits(dai, SSTSA, 0x1 << 8, 0x0 << 8);
+		ssp_update_bits(dai, SSTSA, SSTSA_TXEN, 0);
 		ssp->state[SOF_IPC_STREAM_PLAYBACK] = COMP_STATE_PAUSED;
 		dai_info(dai, "ssp_stop(), TX stop");
 	}

--- a/src/drivers/intel/haswell/ssp.c
+++ b/src/drivers/intel/haswell/ssp.c
@@ -365,8 +365,8 @@ static int ssp_set_config(struct dai *dai,
 	ssp_write(dai, SSCR1, sscr1);
 	ssp_write(dai, SSCR2, sscr2);
 	ssp_write(dai, SSPSP, sspsp);
-	ssp_write(dai, SSTSA, config->ssp.tx_slots);
-	ssp_write(dai, SSRSA, config->ssp.rx_slots);
+	ssp_write(dai, SSTSA, SSTSA_SSTSA(config->ssp.tx_slots));
+	ssp_write(dai, SSRSA, SSRSA_SSRSA(config->ssp.rx_slots));
 	ssp_write(dai, SSPSP2, sspsp2);
 
 	ssp->state[DAI_DIR_PLAYBACK] = COMP_STATE_PREPARE;

--- a/src/include/sof/drivers/ssp.h
+++ b/src/include/sof/drivers/ssp.h
@@ -156,6 +156,14 @@ extern const struct dai_driver ssp_driver;
 #define SSP_REG_MAX	SSIOC
 #endif
 
+/* SSTSA bits */
+#define SSTSA_SSTSA(x)		SET_BITS(7, 0, x)
+#define SSTSA_TXEN		BIT(8)
+
+/* SSRSA bits */
+#define SSRSA_SSRSA(x)		SET_BITS(7, 0, x)
+#define SSRSA_RXEN		BIT(8)
+
 /* SSCR3 bits */
 #define SSCR3_FRM_MST_EN	(1 << 0)
 #define SSCR3_I2S_MODE_EN	(1 << 1)


### PR DESCRIPTION
Introduce SSTSA_TXEN and SSRSA_RXEN macro to define bit value in
header file instead of usage raw value in source code.
Moreover use SET_BITS to set Rx/Tx slot value.

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>