### PR TITLE
sof: Add __section macro

### DIFF
--- a/src/include/ipc/channel_map.h
+++ b/src/include/ipc/channel_map.h
@@ -10,7 +10,7 @@
 #define __IPC_CHANNEL_MAP_H__
 
 #include <ipc/header.h>
-#include <sof/common.h>
+#include <sof/compiler_attributes.h>
 #include <stdint.h>
 
 /**

--- a/src/include/sof/audio/channel_map.h
+++ b/src/include/sof/audio/channel_map.h
@@ -9,6 +9,7 @@
 #define __SOF_AUDIO_CHANNEL_MAP_H__
 
 #include <ipc/channel_map.h>
+#include <sof/common.h>
 #include <stdint.h>
 
 /* Returns the size of a channel map in bytes */

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -429,7 +429,7 @@ static inline struct sof_ipc_comp_config *comp_config(struct sof_ipc_comp *comp)
 	static void _module_init(void) { init(); }
 #else
 #define DECLARE_MODULE(init) __attribute__((__used__)) \
-	__attribute__((section(".module_init"))) static void(*f)(void) = init
+	__section(".module_init") static void(*f)(void) = init
 #endif
 
 /** @}*/

--- a/src/include/sof/common.h
+++ b/src/include/sof/common.h
@@ -20,6 +20,7 @@
 #ifndef __ASSEMBLER__
 
 #include <sof/trace/preproc.h>
+#include <sof/compiler_attributes.h>
 #include <stddef.h>
 
 /* use same syntax as Linux for simplicity */
@@ -27,10 +28,6 @@
 #define container_of(ptr, type, member) \
 	({const typeof(((type *)0)->member)*__memberptr = (ptr); \
 	(type *)((char *)__memberptr - offsetof(type, member)); })
-
-#define __packed __attribute__((packed))
-
-#define __aligned(x) __attribute__((__aligned__(x)))
 
 #define ffs(i) __builtin_ffs(i)
 #define ffsl(i) __builtin_ffsl(i)

--- a/src/include/sof/compiler_attributes.h
+++ b/src/include/sof/compiler_attributes.h
@@ -1,0 +1,10 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2019 Intel Corporation. All rights reserved.
+ *
+ * Author: Karol Trzcinski <karolx.trzcinski@linux.intel.com>
+ */
+
+#define __packed __attribute__((packed))
+
+#define __aligned(x) __attribute__((__aligned__(x)))

--- a/src/include/sof/compiler_attributes.h
+++ b/src/include/sof/compiler_attributes.h
@@ -8,3 +8,5 @@
 #define __packed __attribute__((packed))
 
 #define __aligned(x) __attribute__((__aligned__(x)))
+
+#define __section(x) __attribute__((section(x)))

--- a/src/include/sof/trace/trace.h
+++ b/src/include/sof/trace/trace.h
@@ -238,7 +238,7 @@ static inline struct trace *trace_get(void)
 #ifndef CONFIG_LIBRARY
 
 #define _DECLARE_LOG_ENTRY(lvl, format, comp_class, params, ids)\
-	__attribute__((section(".static_log." #lvl)))		\
+	__section(".static_log." #lvl)				\
 	static const struct {					\
 		uint32_t level;					\
 		uint32_t component_class;			\

--- a/src/ipc/cc_version.c
+++ b/src/ipc/cc_version.c
@@ -20,7 +20,7 @@
 	field[ARRAY_SIZE(((struct sof_ipc_cc_version *)(0))->optim) - 1] = 0
 
 const struct sof_ipc_cc_version cc_version
-	__attribute__((section(".fw_ready_metadata"))) = {
+	__section(".fw_ready_metadata") = {
 	.ext_hdr = {
 		.hdr.cmd = SOF_IPC_FW_READY,
 		.hdr.size = ALIGN_UP(sizeof(struct sof_ipc_cc_version)

--- a/src/ipc/probe_support.c
+++ b/src/ipc/probe_support.c
@@ -6,10 +6,11 @@
 
 #include <ipc/info.h>
 #include <sof/fw-ready-metadata.h>
+#include <sof/compiler_attributes.h>
 #include <config.h>
 
 const struct sof_ipc_probe_support probe_support
-	__attribute__((section(".fw_ready_metadata"))) = {
+	__section(".fw_ready_metadata") = {
 	.ext_hdr = {
 		.hdr.cmd = SOF_IPC_FW_READY,
 		.hdr.size = sizeof(struct sof_ipc_probe_support),

--- a/src/platform/baytrail/platform.c
+++ b/src/platform/baytrail/platform.c
@@ -42,7 +42,7 @@
 #include <stdint.h>
 
 static const struct sof_ipc_fw_ready ready
-	__attribute__((section(".fw_ready"))) = {
+	__section(".fw_ready") = {
 	.hdr = {
 		.cmd = SOF_IPC_FW_READY,
 		.size = sizeof(struct sof_ipc_fw_ready),
@@ -67,7 +67,7 @@ static const struct sof_ipc_fw_ready ready
 
 #define NUM_BYT_WINDOWS		6
 static const struct sof_ipc_window sram_window
-	__attribute__((section(".fw_ready_metadata"))) = {
+	__section(".fw_ready_metadata") = {
 	.ext_hdr	= {
 		.hdr.cmd = SOF_IPC_FW_READY,
 		.hdr.size = sizeof(struct sof_ipc_window) +

--- a/src/platform/haswell/platform.c
+++ b/src/platform/haswell/platform.c
@@ -38,7 +38,7 @@
 #include <stdint.h>
 
 static const struct sof_ipc_fw_ready ready
-	__attribute__((section(".fw_ready"))) = {
+	__section(".fw_ready") = {
 	.hdr = {
 		.cmd = SOF_IPC_FW_READY,
 		.size = sizeof(struct sof_ipc_fw_ready),
@@ -63,7 +63,7 @@ static const struct sof_ipc_fw_ready ready
 
 #define NUM_HSW_WINDOWS		6
 static const struct sof_ipc_window sram_window
-	__attribute__((section(".fw_ready_metadata"))) = {
+	__section(".fw_ready_metadata") = {
 	.ext_hdr	= {
 		.hdr.cmd = SOF_IPC_FW_READY,
 		.hdr.size = sizeof(struct sof_ipc_window) +

--- a/src/platform/imx8/platform.c
+++ b/src/platform/imx8/platform.c
@@ -36,7 +36,7 @@
 struct sof;
 
 static const struct sof_ipc_fw_ready ready
-	__attribute__((section(".fw_ready"))) = {
+	__section(".fw_ready") = {
 	.hdr = {
 		.cmd = SOF_IPC_FW_READY,
 		.size = sizeof(struct sof_ipc_fw_ready),
@@ -62,7 +62,7 @@ static const struct sof_ipc_fw_ready ready
 #define NUM_IMX_WINDOWS		6
 
 static const struct sof_ipc_window sram_window
-	__attribute__((section(".fw_ready_metadata"))) = {
+	__section(".fw_ready_metadata") = {
 	.ext_hdr	= {
 		.hdr.cmd = SOF_IPC_FW_READY,
 		.hdr.size = sizeof(struct sof_ipc_window) +

--- a/src/platform/imx8m/platform.c
+++ b/src/platform/imx8m/platform.c
@@ -35,7 +35,7 @@
 struct sof;
 
 static const struct sof_ipc_fw_ready ready
-	__attribute__((section(".fw_ready"))) = {
+	__section(".fw_ready") = {
 	.hdr = {
 		.cmd = SOF_IPC_FW_READY,
 		.size = sizeof(struct sof_ipc_fw_ready),
@@ -61,7 +61,7 @@ static const struct sof_ipc_fw_ready ready
 #define NUM_IMX_WINDOWS		6
 
 static const struct sof_ipc_window sram_window
-	__attribute__((section(".fw_ready_metadata"))) = {
+	__section(".fw_ready_metadata") = {
 	.ext_hdr	= {
 		.hdr.cmd = SOF_IPC_FW_READY,
 		.hdr.size = sizeof(struct sof_ipc_window) +

--- a/src/platform/intel/cavs/include/cavs/lib/memory.h
+++ b/src/platform/intel/cavs/include/cavs/lib/memory.h
@@ -75,7 +75,7 @@ struct sof;
  * align to cache line size instead.
  */
 #if PLATFORM_CORE_COUNT > 1 && !defined(UNIT_TEST)
-#define SHARED_DATA	__attribute__((section(".shared_data")))
+#define SHARED_DATA	__section(".shared_data")
 #else
 #define SHARED_DATA
 #endif

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -49,7 +49,7 @@
 #include <stdint.h>
 
 static const struct sof_ipc_fw_ready ready
-	__attribute__((section(".fw_ready"))) = {
+	__section(".fw_ready") = {
 	.hdr = {
 		.cmd = SOF_IPC_FW_READY,
 		.size = sizeof(struct sof_ipc_fw_ready),
@@ -77,7 +77,7 @@ static const struct sof_ipc_fw_ready ready
 #define NUM_WINDOWS 7
 
 static const struct sof_ipc_window sram_window
-	__attribute__((section(".fw_ready_metadata"))) = {
+	__section(".fw_ready_metadata") = {
 	.ext_hdr	= {
 		.hdr.cmd = SOF_IPC_FW_READY,
 		.hdr.size = sizeof(struct sof_ipc_window) +


### PR DESCRIPTION
Using such a macro is preferred way to define target section
location in used checkpatch version.

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>