### PR TITLE
CI: travis: Add boot test for i.MX8X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,3 +67,5 @@ jobs:
       env: PLATFORM=icl
     - <<: *qemuboottest
       env: PLATFORM=imx8
+    - <<: *qemuboottest
+      env: PLATFORM=imx8x

--- a/scripts/qemu-check.sh
+++ b/scripts/qemu-check.sh
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright(c) 2018 Intel Corporation. All rights reserved.
 
-SUPPORTED_PLATFORMS=(byt cht bdw hsw apl icl skl kbl cnl imx8)
+SUPPORTED_PLATFORMS=(byt cht bdw hsw apl icl skl kbl cnl imx8 imx8x)
 READY_MSG="6c 00 00 00 00 00 00 70"
 
 rm -f dump-*.txt
@@ -95,7 +95,7 @@ do
 		SHM_MBOX=qemu-bridge-hp-sram-mem
 		ROM="-r ../sof.git/build_${j}_gcc/src/arch/xtensa/rom-$j.bin"
 	fi
-	if [ $j == "imx8" ]
+	if [ $j == "imx8" ] || [ $j == "imx8x" ]
 	then
 		READY_IPC="00 00 00 00 00 00 04 c0"
 		SHM_IPC_REG=qemu-bridge-mu-io


### PR DESCRIPTION
imx8x is now supported in qemu up to boot. So, add
it to boottest list.

Signed-off-by: Diana Cretu <diana.cretu@nxp.com>