### PR TITLE
scan: clang static analyzer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ endif()
 
 option(BUILD_LIBRARY "Build library" OFF)
 option(BUILD_UNIT_TESTS "Build unit tests" OFF)
+option(BUILD_CLANG_SCAN "Build for clang's scan-build" OFF)
 
 if(BUILD_LIBRARY)
 	set(ARCH host)

--- a/scripts/cmake/xtensa-toolchain.cmake
+++ b/scripts/cmake/xtensa-toolchain.cmake
@@ -1,4 +1,33 @@
 # SPDX-License-Identifier: BSD-3-Clause
+if(TOOLCHAIN)
+	set(CROSS_COMPILE "${TOOLCHAIN}-")
+else()
+	message(FATAL_ERROR
+		" Please specify toolchain to use.\n"
+		" Examples:\n"
+		" 	1) cmake -DTOOLCHAIN=xt ...\n"
+		" 	2) cmake -DTOOLCHAIN=xtensa-apl-elf ...\n"
+	)
+endif()
+
+if(BUILD_CLANG_SCAN)
+	# scan-build has to set its own compiler,
+	# so we need to unset current one
+	message(STATUS "Reset C Compiler for scan-build")
+	set(CMAKE_C_COMPILER)
+
+	# scan-build proxies only compiler, other tools are used directly
+	find_program(CMAKE_AR NAMES "${CROSS_COMPILE}ar" PATHS ENV PATH NO_DEFAULT_PATH)
+	find_program(CMAKE_RANLIB NAMES "${CROSS_COMPILE}ranlib" PATHS ENV PATH NO_DEFAULT_PATH)
+
+	set(XCC_TOOLS_VERSION "CLANG-SCAN-BUILD")
+
+	if(TOOLCHAIN STREQUAL "xt")
+		set(XCC 1)
+	endif()
+
+	return()
+endif()
 
 message(STATUS "Preparing Xtensa toolchain")
 
@@ -16,17 +45,6 @@ set(CMAKE_C_COMPILER_ID GNU)
 # in case if *_FORCED variables are ignored,
 # try to just compile lib instead of executable
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
-
-if(TOOLCHAIN)
-	set(CROSS_COMPILE "${TOOLCHAIN}-")
-else()
-	message(FATAL_ERROR
-		" Please specify toolchain to use.\n"
-		" Examples:\n"
-		" 	1) cmake -DTOOLCHAIN=xt ...\n"
-		" 	2) cmake -DTOOLCHAIN=xtensa-apl-elf ...\n"
-	)
-endif()
 
 # xt toolchain only partially follows gcc convention
 if(TOOLCHAIN STREQUAL "xt")

--- a/scripts/scan/clang-scan-build-xtensa.sh
+++ b/scripts/scan/clang-scan-build-xtensa.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2020 Intel Corporation. All rights reserved.
+# Author: Janusz Jankowski <janusz.jankowski@linux.intel.com>
+
+# This script configures & performs build for clang's static analyzer.
+
+set -eu
+
+function usage {
+	echo "Usage: $0 -t <toolchain> -c <config> -r <root_dir> [options]"
+	echo "        -t        Toolchain's name."
+	echo "        -c        Name of defconfig."
+	echo "        -r        Xtensa root dir."
+	echo "        [-j n]    Set number of make build jobs."
+	echo "        [-v]      Verbose output."
+	echo "Examples:"
+	echo "        $0 -t xt -c apollolake \\"
+	echo "                -r \$CONFIG_PATH/xtensa-elf"
+	echo "        $0 -t xtensa-cnl-elf -c cannonlake \\"
+	echo "                -r \`pwd\`/../xtensa-cnl-elf"
+}
+
+if [ "$#" -eq 0 ]
+then
+	usage
+	exit 1
+fi
+
+TOOLCHAIN=""
+DEFCONFIG=""
+ROOT_DIR=""
+JOBS=$(nproc --all)
+VERBOSE_CMAKE=OFF
+VERBOSE_SCAN_BUILD=""
+
+while getopts "t:c:r:j:v" OPTION; do
+	case $OPTION in
+		t)
+			TOOLCHAIN=$OPTARG
+			;;
+		c)
+			DEFCONFIG=$OPTARG
+			;;
+		r)
+			ROOT_DIR=$OPTARG
+			;;
+		j)
+			JOBS=$OPTARG
+			;;
+		v)
+			VERBOSE_CMAKE=ON
+			VERBOSE_SCAN_BUILD="-v -v"
+			;;
+		*)
+			echo "Invalid options"
+			usage
+			exit 1
+			;;
+	esac
+done
+
+WORKDIR=`pwd`
+SCRIPT_DIR=$(realpath $(dirname $0))
+PROXY_COMPILER=$SCRIPT_DIR/proxy-gcc.sh
+
+BUILD_DIR=build_clang_scan_${DEFCONFIG}_${TOOLCHAIN}
+
+rm -fr $BUILD_DIR
+mkdir $BUILD_DIR
+cd $BUILD_DIR
+
+scan-build $VERBOSE_SCAN_BUILD cmake \
+	-DBUILD_CLANG_SCAN=ON \
+	-DTOOLCHAIN=$TOOLCHAIN \
+	-DROOT_DIR=$ROOT_DIR \
+	-DCMAKE_VERBOSE_MAKEFILE=$VERBOSE_CMAKE \
+	..
+
+make ${DEFCONFIG}_defconfig
+
+if [[ "$TOOLCHAIN" == "xt" ]]
+then
+	COMPILER=$TOOLCHAIN-xcc
+else
+	COMPILER=$TOOLCHAIN-gcc
+fi
+
+# There are flags that are needed by clang but don't work for xtensa compiler.
+# However clang tries to pass all flags to original compiler, so we need to put
+# proxy compiler in the middle that is going to filter out unsupported flags.
+PROXY_CC=$COMPILER PROXY_REMOVE_FLAGS=-m32 \
+	scan-build $VERBOSE_SCAN_BUILD --use-cc="$PROXY_COMPILER" -o report \
+	make sof -j$JOBS
+
+cd "$WORKDIR"

--- a/scripts/scan/proxy-gcc.sh
+++ b/scripts/scan/proxy-gcc.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2020 Intel Corporation. All rights reserved.
+# Author: Janusz Jankowski <janusz.jankowski@linux.intel.com>
+
+# Utility for filtering flags passed to the compiler.
+
+set -e
+
+out_args=()
+
+for arg in "$@"; do
+	for target in $PROXY_REMOVE_FLAGS; do
+		if [[ $arg = $target ]]; then
+			continue 2
+		fi
+	done
+	out_args+=("$arg")
+done
+
+
+$PROXY_CC "${out_args[@]}"

--- a/src/arch/xtensa/CMakeLists.txt
+++ b/src/arch/xtensa/CMakeLists.txt
@@ -67,11 +67,33 @@ endif()
 
 get_optimization_flag(optimization_flag)
 
+if(BUILD_CLANG_SCAN)
+	# pretend to be xtensa compiler to go trough the same paths for AST
+	target_compile_definitions(sof_options INTERFACE -D__XTENSA__=1)
+
+	if(XCC)
+		# clang has to compile objects in order to analyze sources,
+		# so it needs xcc's headers
+		find_program(XCC_PATH NAMES "xt-xcc" PATHS ENV PATH NO_DEFAULT_PATH)
+		get_filename_component(XCC_DIR ${XCC_PATH} DIRECTORY)
+		target_include_directories(sof_options INTERFACE ${XCC_DIR}/../xtensa-elf/include)
+	endif()
+
+	# Clang by default compiles for host architecture,
+	# but xtensa is always 32 bit, what may cause mismatch in definitions,
+	# that depend on bitness, so force compilation for 32 bit.
+	set(XTENSA_C_ASM_FLAGS -m32)
+	set(XTENSA_C_FLAGS)
+else()
+	set(XTENSA_C_ASM_FLAGS -mlongcalls)
+	set(XTENSA_C_FLAGS -mtext-section-literals)
+endif()
+
 # linker flags
 target_link_libraries(sof_options INTERFACE ${stdlib_flag} -Wl,--no-check-sections -ucall_user_start -Wl,-static)
 
 # C & ASM flags
-target_compile_options(sof_options INTERFACE ${stdlib_flag} -fno-inline-functions -mlongcalls)
+target_compile_options(sof_options INTERFACE ${stdlib_flag} -fno-inline-functions ${XTENSA_C_ASM_FLAGS})
 
 # C flags
 # TODO: Generator expressions are supported only with Make and Ninja,
@@ -83,7 +105,7 @@ target_compile_options(sof_options INTERFACE ${stdlib_flag} -fno-inline-function
 #      better to have set of default flags and change it only for special cases
 #   3) custom function that is used instead of target_sources and sets flags
 #      for each added source based on file extension
-target_compile_options(sof_options INTERFACE $<$<COMPILE_LANGUAGE:C>: -${optimization_flag} -g -Wall -Werror -Wl,-EL -Wmissing-prototypes -Wpointer-arith -mtext-section-literals>)
+target_compile_options(sof_options INTERFACE $<$<COMPILE_LANGUAGE:C>: -${optimization_flag} -g -Wall -Werror -Wl,-EL -Wmissing-prototypes -Wpointer-arith ${XTENSA_C_FLAGS}>)
 
 if(BUILD_UNIT_TESTS)
 	# rest of this file is not needed for unit tests
@@ -279,6 +301,12 @@ if(CONFIG_BUILD_VM_ROM)
 	)
 
 	add_dependencies(bin_extras rom_dump)
+endif()
+
+if(BUILD_CLANG_SCAN)
+	# steps below don't compile parts of fw,
+	# so they are not needed for scan-build
+	return()
 endif()
 
 add_custom_target(

--- a/src/arch/xtensa/CMakeLists.txt
+++ b/src/arch/xtensa/CMakeLists.txt
@@ -193,27 +193,18 @@ target_link_libraries(sof_ld_flags INTERFACE "-lgcc")
 target_link_libraries(sof_ld_flags INTERFACE "-Wl,-Map=sof.map")
 target_link_libraries(sof_ld_flags INTERFACE "-T${PROJECT_BINARY_DIR}/${platform_ld_script}")
 
-# rimage
-
-include(ExternalProject)
-
-ExternalProject_Add(rimage_ep
-	DEPENDS check_version_h
-	DOWNLOAD_COMMAND ""
-	SOURCE_DIR "${PROJECT_SOURCE_DIR}/rimage"
-	PREFIX "${PROJECT_BINARY_DIR}/rimage_ep"
-	BINARY_DIR "${PROJECT_BINARY_DIR}/rimage_ep/build"
-	BUILD_ALWAYS 1
-	CMAKE_ARGS -DVERSION_H_PATH=${VERSION_H_PATH}
-		-DPEM_KEY_PREFIX=${PROJECT_SOURCE_DIR}/rimage/keys
-	INSTALL_COMMAND ""
-)
-
 add_custom_target(
-	prepare_fw_copy_for_rimage
-	DEPENDS sof rimage_ep
+	prepare_sof_post_process
+	DEPENDS sof
 	COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_BINARY_DIR}/sof sof-${fw_name}
 )
+
+# contains steps that should be performed before fw image is ready for being
+# processed by tools like rimage and MEU
+add_custom_target(sof_post_process DEPENDS prepare_sof_post_process)
+
+# contains extra output that should be generated for bin target
+add_custom_target(bin_extras)
 
 # bootloader binary
 
@@ -248,14 +239,46 @@ if(build_bootloader)
 		process_base_module
 		COMMAND ${CMAKE_OBJCOPY} -O binary ${PROJECT_BINARY_DIR}/src/platform/${platform_folder}/base_module mod-${fw_name}.bin
 		COMMAND ${CMAKE_OBJCOPY} --add-section .module=mod-${fw_name}.bin --set-section-flags .module=load,readonly sof-${fw_name}
-		DEPENDS prepare_fw_copy_for_rimage base_module bootloader_dump
+		DEPENDS prepare_sof_post_process base_module bootloader_dump
 		VERBATIM
 		USES_TERMINAL
 	)
-else()
-	set(bootloader_binary_path "")
 
-	add_custom_target(process_base_module DEPENDS prepare_fw_copy_for_rimage)
+	add_dependencies(sof_post_process process_base_module)
+else()
+	set(bootloader_binary_path)
+endif()
+
+if(CONFIG_BUILD_VM_ROM)
+	add_executable(rom "")
+	target_link_libraries(rom PRIVATE sof_options)
+	target_link_libraries(rom PRIVATE "-lgcc")
+	target_link_libraries(rom PRIVATE "-T${PROJECT_BINARY_DIR}/${platform_rom_ld_script}")
+	sof_add_ld_script(rom ${platform_rom_ld_script})
+
+	# We have to make additional define, because sources
+	# are reused for other objects with different flags.
+	target_compile_definitions(rom PRIVATE -DCONFIG_VM_ROM)
+
+	add_local_sources(rom
+		xtos/crt1-boards-rom.S
+		xtos/memctl_default.S
+		xtos/reset-vector.S
+	)
+
+	add_custom_target(
+		rom_dump
+		COMMAND ${CMAKE_COMMAND} -E copy rom rom-${fw_name}
+		COMMAND ${CMAKE_OBJCOPY} -O binary rom rom-${fw_name}.bin
+		COMMAND ${CMAKE_OBJDUMP} -h -D rom > rom-${fw_name}.lmap
+		COMMAND ${CMAKE_OBJDUMP} -S rom > rom-${fw_name}.lst
+		COMMAND ${CMAKE_OBJDUMP} -D rom > rom-${fw_name}.dis
+		DEPENDS rom
+		VERBATIM
+		USES_TERMINAL
+	)
+
+	add_dependencies(bin_extras rom_dump)
 endif()
 
 add_custom_target(
@@ -263,9 +286,25 @@ add_custom_target(
 	COMMAND ${CMAKE_OBJDUMP} -S sof-${fw_name} > sof-${fw_name}.lst
 	COMMAND ${CMAKE_OBJDUMP} -h sof-${fw_name} > sof-${fw_name}.lmap
 	COMMAND ${CMAKE_OBJDUMP} -D sof-${fw_name} > sof-${fw_name}.dis
-	DEPENDS process_base_module
+	DEPENDS sof_post_process
 	VERBATIM
 	USES_TERMINAL
+)
+
+# rimage
+
+include(ExternalProject)
+
+ExternalProject_Add(rimage_ep
+	DEPENDS check_version_h
+	DOWNLOAD_COMMAND ""
+	SOURCE_DIR "${PROJECT_SOURCE_DIR}/rimage"
+	PREFIX "${PROJECT_BINARY_DIR}/rimage_ep"
+	BINARY_DIR "${PROJECT_BINARY_DIR}/rimage_ep/build"
+	BUILD_ALWAYS 1
+	CMAKE_ARGS -DVERSION_H_PATH=${VERSION_H_PATH}
+		-DPEM_KEY_PREFIX=${PROJECT_SOURCE_DIR}/rimage/keys
+	INSTALL_COMMAND ""
 )
 
 if(NOT DEFINED RIMAGE_PRIVATE_KEY)
@@ -307,7 +346,7 @@ if(MEU_PATH)
 			${RIMAGE_MOD_OFFSET_FLAG}
 			${bootloader_binary_path}
 			sof-${fw_name}
-		DEPENDS sof_dump
+		DEPENDS sof_dump rimage_ep
 		VERBATIM
 		USES_TERMINAL
 	)
@@ -347,7 +386,7 @@ else()
 			${RIMAGE_MOD_OFFSET_FLAG}
 			${bootloader_binary_path}
 			sof-${fw_name}
-		DEPENDS sof_dump
+		DEPENDS sof_dump rimage_ep
 		VERBATIM
 		USES_TERMINAL
 	)
@@ -358,7 +397,7 @@ add_custom_target(
 	bin ALL
 	COMMAND ${CMAKE_COMMAND} -E copy sof-${fw_name}.ri ${PROJECT_BINARY_DIR}/sof-${fw_name}.ri
 	COMMAND ${CMAKE_COMMAND} -E copy sof-${fw_name}.ldc ${PROJECT_BINARY_DIR}/sof-${fw_name}.ldc
-	DEPENDS run_meu
+	DEPENDS run_meu bin_extras
 	VERBATIM
 	USES_TERMINAL
 )
@@ -368,35 +407,3 @@ install(
 		${PROJECT_BINARY_DIR}/sof-${fw_name}.ldc
 	DESTINATION bin
 )
-
-if(CONFIG_BUILD_VM_ROM)
-	add_executable(rom "")
-	target_link_libraries(rom PRIVATE sof_options)
-	target_link_libraries(rom PRIVATE "-lgcc")
-	target_link_libraries(rom PRIVATE "-T${PROJECT_BINARY_DIR}/${platform_rom_ld_script}")
-	sof_add_ld_script(rom ${platform_rom_ld_script})
-
-	# We have to make additional define, because sources
-	# are reused for other objects with different flags.
-	target_compile_definitions(rom PRIVATE -DCONFIG_VM_ROM)
-
-	add_local_sources(rom
-		xtos/crt1-boards-rom.S
-		xtos/memctl_default.S
-		xtos/reset-vector.S
-	)
-
-	add_custom_target(
-		rom_dump
-		COMMAND ${CMAKE_COMMAND} -E copy rom rom-${fw_name}
-		COMMAND ${CMAKE_OBJCOPY} -O binary rom rom-${fw_name}.bin
-		COMMAND ${CMAKE_OBJDUMP} -h -D rom > rom-${fw_name}.lmap
-		COMMAND ${CMAKE_OBJDUMP} -S rom > rom-${fw_name}.lst
-		COMMAND ${CMAKE_OBJDUMP} -D rom > rom-${fw_name}.dis
-		DEPENDS rom
-		VERBATIM
-		USES_TERMINAL
-	)
-
-	add_dependencies(bin rom_dump)
-endif()

--- a/src/debug/panic.c
+++ b/src/debug/panic.c
@@ -102,10 +102,12 @@ void __panic(uint32_t p, char *filename, uint32_t linenum)
 	 * set a reserved value for the exception cause (63) so the
 	 * coredumper tool could distinguish between the situations.
 	 */
+#if !__clang_analyzer__
 	__asm__ __volatile__("movi a3, 63\n\t"
 			     "wsr.exccause a3\n\t"
 			     "esync" : : :
 			     "a3", "memory");
+#endif
 
 	panic_rewind(p, 0, &panicinfo, NULL);
 }

--- a/src/include/sof/debug/panic.h
+++ b/src/include/sof/debug/panic.h
@@ -20,7 +20,12 @@
 void dump_panicinfo(void *addr, struct sof_ipc_panic_info *panic_info);
 void panic_rewind(uint32_t p, uint32_t stack_rewind_frames,
 		  struct sof_ipc_panic_info *panic_info, uintptr_t *data);
+#if __clang_analyzer__
+void __panic(uint32_t p, char *filename, uint32_t linenum)
+	__attribute__((analyzer_noreturn));
+#else
 void __panic(uint32_t p, char *filename, uint32_t linenum);
+#endif
 
 /* panic dump filename and linenumber of the call */
 #define panic(x) __panic((x), (RELATIVE_FILE), (__LINE__))


### PR DESCRIPTION
Support for running clang's static analyzer for fw build.
I'm probably going to add also checks for rimage and UTs.

After clang's analyzer we may add also few more checkers like ccpcheck or clang-tidy, but I'd prefer to have at least this one CodeChecker in CI up and running and then we may look for more.