### PR TITLE
ipc: Remove SOF_IPC_EXT_DMA_BUFFER

### DIFF
--- a/src/include/ipc/info.h
+++ b/src/include/ipc/info.h
@@ -36,7 +36,7 @@
 
 /* extended data types that can be appended onto end of sof_ipc_fw_ready */
 enum sof_ipc_ext_data {
-	SOF_IPC_EXT_DMA_BUFFER		= 0,
+	SOF_IPC_EXT_UNUSED		= 0,
 	SOF_IPC_EXT_WINDOW		= 1,
 	SOF_IPC_EXT_CC_INFO		= 2,
 	SOF_IPC_EXT_PROBE_INFO		= 3,
@@ -91,22 +91,6 @@ enum sof_ipc_region {
 struct sof_ipc_ext_data_hdr {
 	struct sof_ipc_cmd_hdr hdr;
 	uint32_t type;		/**< SOF_IPC_EXT_ */
-} __attribute__((packed));
-
-struct sof_ipc_dma_buffer_elem {
-	struct sof_ipc_hdr hdr;
-	uint32_t type;		/**< SOF_IPC_REGION_ */
-	uint32_t id;		/**< platform specific - used to map to host memory */
-	struct sof_ipc_host_buffer buffer;
-} __attribute__((packed));
-
-/* extended data DMA buffers for IPC, trace and debug */
-struct sof_ipc_dma_buffer_data {
-	struct sof_ipc_ext_data_hdr ext_hdr;
-	uint32_t num_buffers;
-
-	/* host files in buffer[n].buffer */
-	struct sof_ipc_dma_buffer_elem buffer[];
 } __attribute__((packed));
 
 struct sof_ipc_window_elem {

--- a/src/include/ipc/info.h
+++ b/src/include/ipc/info.h
@@ -36,11 +36,11 @@
 
 /* extended data types that can be appended onto end of sof_ipc_fw_ready */
 enum sof_ipc_ext_data {
-	SOF_IPC_EXT_DMA_BUFFER = 0,
-	SOF_IPC_EXT_WINDOW,
-	SOF_IPC_EXT_CC_INFO,
-	SOF_IPC_EXT_PROBE_INFO,
-	SOF_IPC_EXT_USER_ABI_INFO,
+	SOF_IPC_EXT_DMA_BUFFER		= 0,
+	SOF_IPC_EXT_WINDOW		= 1,
+	SOF_IPC_EXT_CC_INFO		= 2,
+	SOF_IPC_EXT_PROBE_INFO		= 3,
+	SOF_IPC_EXT_USER_ABI_INFO 	= 4,
 };
 
 /* FW version - SOF_IPC_GLB_VERSION */


### PR DESCRIPTION
ipc: Remove SOF_IPC_EXT_DMA_BUFFER

This enum code, and whats more important, related structures is
unused in whole source code, so it shouldn't be kept.

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>