### PR TITLE
topology: clean up platform specific macro

### DIFF
--- a/tools/topology/platform/intel/cml-mono.m4
+++ b/tools/topology/platform/intel/cml-mono.m4
@@ -1,0 +1,3 @@
+include(`platform/intel/cnl.m4')
+
+define(`MONO', `')

--- a/tools/topology/platform/intel/cml.m4
+++ b/tools/topology/platform/intel/cml.m4
@@ -1,0 +1,13 @@
+include(`platform/intel/cnl.m4')
+
+#SSP setting for CML platform
+undefine(`SSP_INDEX')
+define(`SSP_INDEX', 0)
+
+undefine(`SSP_NAME')
+define(`SSP_NAME', `SSP0-Codec')
+
+undefine(`SSP_MCLK_RATE')
+define(`SSP_MCLK_RATE', `24000000')
+
+include(`platform/intel/dmic.m4')

--- a/tools/topology/platform/intel/icl.m4
+++ b/tools/topology/platform/intel/icl.m4
@@ -36,3 +36,15 @@ W_VENDORTUPLES(pipe_dai_schedule_plat_tokens, sof_sched_tokens,
 		LIST(`		', `SOF_TKN_SCHED_MIPS	"5000"'))
 
 W_DATA(pipe_dai_schedule_plat, pipe_dai_schedule_plat_tokens)
+
+#SSP setting for ICL platform
+undefine(`SSP_INDEX')
+define(`SSP_INDEX', 0)
+
+undefine(`SSP_NAME')
+define(`SSP_NAME', `SSP0-Codec')
+
+undefine(`SSP_MCLK_RATE')
+define(`SSP_MCLK_RATE', `19200000')
+
+include(`platform/intel/dmic.m4')

--- a/tools/topology/platform/intel/whl.m4
+++ b/tools/topology/platform/intel/whl.m4
@@ -1,0 +1,13 @@
+include(`platform/intel/cnl.m4')
+
+#SSP setting for WHL platform
+undefine(`SSP_INDEX')
+define(`SSP_INDEX', 1)
+
+undefine(`SSP_NAME')
+define(`SSP_NAME', `SSP1-Codec')
+
+undefine(`SSP_MCLK_RATE')
+define(`SSP_MCLK_RATE', `24000000')
+
+include(`platform/intel/dmic.m4')

--- a/tools/topology/sof-cml-demux-rt5682.m4
+++ b/tools/topology/sof-cml-demux-rt5682.m4
@@ -14,18 +14,11 @@ include(`common/tlv.m4')
 # Include Token library
 include(`sof/tokens.m4')
 
-# Include Cannonlake DSP configuration
-include(`platform/intel/cnl.m4')
-include(`platform/intel/dmic.m4')
+# Include platform specific DSP configuration
+include(`platform/intel/'PLATFORM`.m4')
 
 DEBUG_START
 
-undefine(`SSP_INDEX')
-define(`SSP_INDEX', ifelse(PLATFORM, `whl', `1',
-	ifelse(PLATFORM, `cml', `0', `')))
-undefine(`SSP_NAME')
-define(`SSP_NAME', ifelse(PLATFORM, `whl', `SSP1-Codec',
-	ifelse(PLATFORM, `cml', `SSP0-Codec', `')))
 
 #
 # Define the pipelines

--- a/tools/topology/sof-cml-rt5682-kwd.m4
+++ b/tools/topology/sof-cml-rt5682-kwd.m4
@@ -14,30 +14,12 @@ include(`common/tlv.m4')
 # Include Token library
 include(`sof/tokens.m4')
 
-# Include Cannonlake or Icelake DSP configuration
-ifelse(PLATFORM, `icl', include(`platform/intel/icl.m4'),
-	ifelse(PLATFORM, `whl', include(`platform/intel/cnl.m4'),
-		ifelse(PLATFORM, `cml', include(`platform/intel/cnl.m4'), `')))
-include(`platform/intel/dmic.m4')
+# Include Platform specific DSP configuration
+include(`platform/intel/'PLATFORM`.m4')
 
 define(KWD_PIPE_SCH_DEADLINE_US, 20000)
 
 DEBUG_START
-
-undefine(`SSP_INDEX')
-define(`SSP_INDEX', ifelse(PLATFORM, `icl', `0',
-	ifelse(PLATFORM, `whl', `1',
-		ifelse(PLATFORM, `cml', `0', `'))))
-
-undefine(`SSP_NAME')
-define(`SSP_NAME', ifelse(PLATFORM, `icl', `SSP0-Codec',
-	ifelse(PLATFORM, `whl', `SSP1-Codec',
-		ifelse(PLATFORM, `cml', `SSP0-Codec', `'))))
-
-undefine(`SSP_MCLK_RATE')
-define(`SSP_MCLK_RATE', ifelse(PLATFORM, `icl', `19200000',
-	ifelse(PLATFORM, `whl', `24000000',
-		ifelse(PLATFORM, `cml', `24000000', `'))))
 
 #
 # Define the pipelines

--- a/tools/topology/sof-cml-rt5682.m4
+++ b/tools/topology/sof-cml-rt5682.m4
@@ -14,28 +14,10 @@ include(`common/tlv.m4')
 # Include Token library
 include(`sof/tokens.m4')
 
-# Include Cannonlake or Icelake DSP configuration
-ifelse(PLATFORM, `icl', include(`platform/intel/icl.m4'),
-	ifelse(PLATFORM, `whl', include(`platform/intel/cnl.m4'),
-		ifelse(PLATFORM, `cml', include(`platform/intel/cnl.m4'), `')))
-include(`platform/intel/dmic.m4')
+# Include Platform specific DSP configuration
+include(`platform/intel/'PLATFORM`.m4')
 
 DEBUG_START
-
-undefine(`SSP_INDEX')
-define(`SSP_INDEX', ifelse(PLATFORM, `icl', `0',
-	ifelse(PLATFORM, `whl', `1',
-		ifelse(PLATFORM, `cml', `0', `'))))
-
-undefine(`SSP_NAME')
-define(`SSP_NAME', ifelse(PLATFORM, `icl', `SSP0-Codec',
-	ifelse(PLATFORM, `whl', `SSP1-Codec',
-		ifelse(PLATFORM, `cml', `SSP0-Codec', `'))))
-
-undefine(`SSP_MCLK_RATE')
-define(`SSP_MCLK_RATE', ifelse(PLATFORM, `icl', `19200000',
-	ifelse(PLATFORM, `whl', `24000000',
-		ifelse(PLATFORM, `cml', `24000000', `'))))
 
 #
 # Define the pipelines

--- a/tools/topology/sof-cml-rt700.m4
+++ b/tools/topology/sof-cml-rt700.m4
@@ -14,8 +14,7 @@ include(`common/tlv.m4')
 include(`sof/tokens.m4')
 
 # Include CML DSP configuration
-include(`platform/intel/cnl.m4')
-include(`platform/intel/dmic.m4')
+include(`platform/intel/cml.m4')
 
 DEBUG_START
 

--- a/tools/topology/sof-cml-src-rt5682.m4
+++ b/tools/topology/sof-cml-src-rt5682.m4
@@ -14,9 +14,8 @@ include(`common/tlv.m4')
 # Include Token library
 include(`sof/tokens.m4')
 
-# Include Cannonlake DSP configuration
-include(`platform/intel/cnl.m4')
-include(`platform/intel/dmic.m4')
+# Include Cometlake DSP configuration
+include(`platform/intel/cml.m4')
 
 DEBUG_START
 

--- a/tools/topology/sof-cnl-rt274.m4
+++ b/tools/topology/sof-cnl-rt274.m4
@@ -14,7 +14,7 @@ include(`common/tlv.m4')
 # Include Token library
 include(`sof/tokens.m4')
 
-# Include Apollolake DSP configuration
+# Include Cannonlake DSP configuration
 include(`platform/intel/cnl.m4')
 
 #

--- a/tools/topology/sof-icl-dmic-4ch.m4
+++ b/tools/topology/sof-icl-dmic-4ch.m4
@@ -13,9 +13,8 @@ include(`common/tlv.m4')
 # Include Token library
 include(`sof/tokens.m4')
 
-# Include Apollolake DSP configuration
-include(`platform/intel/bxt.m4')
-include(`platform/intel/dmic.m4')
+# Include IceLake DSP configuration
+include(`platform/intel/icl.m4')
 
 #
 # Define the pipelines

--- a/tools/topology/sof-icl-rt700.m4
+++ b/tools/topology/sof-icl-rt700.m4
@@ -13,9 +13,8 @@ include(`common/tlv.m4')
 # Include Token library
 include(`sof/tokens.m4')
 
-# Include ICL DSP configuration
+# Include Icelake DSP configuration
 include(`platform/intel/icl.m4')
-include(`platform/intel/dmic.m4')
 
 DEBUG_START
 

--- a/tools/topology/sof-icl-rt711-rt1308-rt715-hdmi.m4
+++ b/tools/topology/sof-icl-rt711-rt1308-rt715-hdmi.m4
@@ -13,11 +13,8 @@ include(`common/tlv.m4')
 # Include Token library
 include(`sof/tokens.m4')
 
-ifelse(PLATFORM, `icl', include(`platform/intel/icl.m4'),
-	ifelse(PLATFORM, `cml-mono', include(`platform/intel/cnl.m4'),
-		ifelse(PLATFORM, `cml', include(`platform/intel/cnl.m4'), `')))
-
-ifelse(PLATFORM, `cml-mono', `define(`MONO', `')', `')
+# Include Platform specific DSP configuration
+include(`platform/intel/'PLATFORM`.m4')
 
 DEBUG_START
 

--- a/tools/topology/sof-icl-rt711-rt1308-rt715.m4
+++ b/tools/topology/sof-icl-rt711-rt1308-rt715.m4
@@ -13,7 +13,7 @@ include(`common/tlv.m4')
 # Include Token library
 include(`sof/tokens.m4')
 
-# Include ICL DSP configuration
+# Include Icelake DSP configuration
 include(`platform/intel/icl.m4')
 
 DEBUG_START


### PR DESCRIPTION
All platform specific changes are moved to new file, platform/intel/all.m4.

Signed-off-by: Fred Oh <fred.oh@linux.intel.com>

Got a review comment from https://github.com/thesofproject/sof/pull/2444
Compared all conf and tplg files before and after this change.