### PR TITLE
comp: remove output_rate field from comp_dev struct

### DIFF
--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -490,8 +490,6 @@ static struct comp_dev *src_new(const struct comp_driver *drv,
 	cd->polyphase_func = NULL;
 	src_polyphase_reset(&cd->src);
 
-	dev->output_rate = ipc_src->sink_rate;
-
 	dev->state = COMP_STATE_READY;
 	return dev;
 }

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -291,7 +291,6 @@ struct comp_dev {
 	uint16_t state;		   /**< COMP_STATE_ */
 	uint64_t position;	   /**< component rendering position */
 	uint32_t frames;	   /**< number of frames we copy to sink */
-	uint32_t output_rate;      /**< 0 means all output rates are fine */
 	struct pipeline *pipeline; /**< pipeline we belong to */
 
 	uint32_t min_sink_bytes;   /**< min free sink buffer size measured in


### PR DESCRIPTION
This commit removes unused ```output_rate``` field from
```comp_dev struct```. If needed, component can retrieve rate
parameters from sink/source buffers.

Signed-off-by: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>