### PR TITLE
Fixes for local variables usage in SRC and ASRC components

### DIFF
--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -365,8 +365,6 @@ static void src_2s(struct comp_dev *dev, const struct audio_stream *source,
 		cd->sbuf_w_ptr = s1.y_wptr;
 		cd->sbuf_avail += s1_blk_out;
 		*n_read += s1.times * cd->src.stage1->blk_in;
-		avail_b -= s1_blk_in * sz;
-		sbuf_free -= s1_blk_out;
 	}
 
 	s2.times = cd->param.stage2_times;
@@ -385,7 +383,6 @@ static void src_2s(struct comp_dev *dev, const struct audio_stream *source,
 
 		cd->sbuf_r_ptr = s2.x_rptr;
 		cd->sbuf_avail -= s2_blk_in;
-		free_b -= s2_blk_out * sz;
 		*n_written += s2.times * cd->src.stage2->blk_out;
 	}
 }

--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -119,7 +119,7 @@ audio_stream_get_copy_bytes(const struct audio_stream *source,
  */
 static inline uint32_t audio_stream_frame_bytes(const struct audio_stream *buf)
 {
-	return frame_bytes(buf->frame_fmt, buf->channels);
+	return get_frame_bytes(buf->frame_fmt, buf->channels);
 }
 
 /**
@@ -129,7 +129,7 @@ static inline uint32_t audio_stream_frame_bytes(const struct audio_stream *buf)
  */
 static inline uint32_t audio_stream_sample_bytes(const struct audio_stream *buf)
 {
-	return sample_bytes(buf->frame_fmt);
+	return get_sample_bytes(buf->frame_fmt);
 }
 
 /**

--- a/src/include/sof/audio/format.h
+++ b/src/include/sof/audio/format.h
@@ -161,14 +161,15 @@ static inline int32_t sign_extend_s24(int32_t x)
 	return (x << 8) >> 8;
 }
 
-static inline uint32_t sample_bytes(enum sof_ipc_frame fmt)
+static inline uint32_t get_sample_bytes(enum sof_ipc_frame fmt)
 {
 	return fmt == SOF_IPC_FRAME_S16_LE ? 2 : 4;
 }
 
-static inline uint32_t frame_bytes(enum sof_ipc_frame fmt, uint32_t channels)
+static inline uint32_t get_frame_bytes(enum sof_ipc_frame fmt,
+				       uint32_t channels)
 {
-	return sample_bytes(fmt) * channels;
+	return get_sample_bytes(fmt) * channels;
 }
 
 #endif /* __SOF_AUDIO_FORMAT_H__ */


### PR DESCRIPTION
This pull request contains cleanup for SRC component and avoiding local variables shadowing of function in ASRC by renaming better the functions in format.h header. Due to function rename DAI component is edited. The functionality of components is not changed.