### PR TITLE
[WIP] pcm_converter: enable HiFi3 version by default

### DIFF
--- a/src/audio/Kconfig
+++ b/src/audio/Kconfig
@@ -243,7 +243,7 @@ config FORMAT_FLOAT
 
 config FORMAT_CONVERT_HIFI3
 	bool "HIFI3 optimized conversion"
-	default n
+	default y
 	help
 	  Use HIFI3 extensions for optimized format conversion (experimental).
 


### PR DESCRIPTION
Enables HiFi3 version of PCM converter.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>