### PR TITLE
dma: Add time unit in comment in dma_chan_data.period description

### DIFF
--- a/src/include/sof/lib/dma.h
+++ b/src/include/sof/lib/dma.h
@@ -209,7 +209,7 @@ struct dma_chan_data {
 	uint32_t desc_count;
 	uint32_t index;
 	uint32_t core;
-	uint64_t period;	/* DMA channel's transfer period */
+	uint64_t period;	/* DMA channel's transfer period in us */
 	/* true if this DMA channel is the scheduling source */
 	bool is_scheduling_source;
 


### PR DESCRIPTION
Time unit is crucial to properly use this field so it is convenient
to have it written in comment near field declaration.

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>