### PR TITLE
drivers: imx: sai: esai: Implement get_hw_params

### DIFF
--- a/src/drivers/imx/esai.c
+++ b/src/drivers/imx/esai.c
@@ -426,6 +426,19 @@ static int esai_get_fifo(struct dai *dai, int direction, int stream_id)
 	}
 }
 
+static int esai_get_hw_params(struct dai *dai,
+			      struct sof_ipc_stream_params *params,
+			      int dir)
+{
+	/* ESAI only currently supports these parameters */
+	params->rate = 48000;
+	params->channels = 2;
+	params->buffer_fmt = 0;
+	params->frame_fmt = SOF_IPC_FRAME_S24_4LE;
+
+	return 0;
+}
+
 const struct dai_driver esai_driver = {
 	.type = SOF_DAI_IMX_ESAI,
 	.dma_dev = DMA_DEV_ESAI,
@@ -437,5 +450,6 @@ const struct dai_driver esai_driver = {
 		.probe			= esai_probe,
 		.get_handshake		= esai_get_handshake,
 		.get_fifo		= esai_get_fifo,
+		.get_hw_params		= esai_get_hw_params,
 	},
 };

--- a/src/drivers/imx/sai.c
+++ b/src/drivers/imx/sai.c
@@ -320,6 +320,19 @@ static int sai_get_fifo(struct dai *dai, int direction, int stream_id)
 	}
 }
 
+static int sai_get_hw_params(struct dai *dai,
+			     struct sof_ipc_stream_params *params,
+			     int dir)
+{
+	/* SAI only currently supports these parameters */
+	params->rate = 48000;
+	params->channels = 2;
+	params->buffer_fmt = 0;
+	params->frame_fmt = SOF_IPC_FRAME_S32_LE;
+
+	return 0;
+}
+
 const struct dai_driver sai_driver = {
 	.type = SOF_DAI_IMX_SAI,
 	.dma_dev = DMA_DEV_SAI,
@@ -331,5 +344,6 @@ const struct dai_driver sai_driver = {
 		.probe			= sai_probe,
 		.get_handshake		= sai_get_handshake,
 		.get_fifo		= sai_get_fifo,
+		.get_hw_params		= sai_get_hw_params,
 	},
 };


### PR DESCRIPTION
Add proper implementation for [e]sai_get_hw_params. This function is
required for all DAI drivers and lacks even assert checks.

Without this implementation we would have a jump to address 0, which
manifested itself as a hang on i.MX8MP (did not test the other platforms
but they are all broken).

Fixes: 55866f28 "comp: dai: implement dai_get_hw_params() function"
Signed-off-by: Paul Olaru <paul.olaru@nxp.com>