### PR TITLE
cavs: clean up of bit setting macros in shim headers

### DIFF
--- a/src/platform/apollolake/include/platform/lib/shim.h
+++ b/src/platform/apollolake/include/platform/lib/shim.h
@@ -26,23 +26,23 @@
 #define IPC_DIPCCTL		0x10
 
 /* DIPCT */
-#define IPC_DIPCT_BUSY		(1 << 31)
+#define IPC_DIPCT_BUSY		BIT(31)
 #define IPC_DIPCT_MSG_MASK	0x7FFFFFFF
 
 /* DIPCTE */
 #define IPC_DIPCTE_MSG_MASK	0x3FFFFFFF
 
 /* DIPCI */
-#define IPC_DIPCI_BUSY		(1 << 31)
+#define IPC_DIPCI_BUSY		BIT(31)
 #define IPC_DIPCI_MSG_MASK	0x7FFFFFFF
 
 /* DIPCIE */
-#define IPC_DIPCIE_DONE		(1 << 30)
+#define IPC_DIPCIE_DONE		BIT(30)
 #define IPC_DIPCIE_MSG_MASK	0x3FFFFFFF
 
 /* DIPCCTL */
-#define IPC_DIPCCTL_IPCIDIE	(1 << 1)
-#define IPC_DIPCCTL_IPCTBIE	(1 << 0)
+#define IPC_DIPCCTL_IPCIDIE	BIT(1)
+#define IPC_DIPCCTL_IPCTBIE	BIT(0)
 
 #define IPC_DSP_OFFSET		0x10
 
@@ -54,23 +54,23 @@
 #define IPC_IDCCTL		0x50
 
 /* IDCTFC */
-#define IPC_IDCTFC_BUSY		(1 << 31)
+#define IPC_IDCTFC_BUSY		BIT(31)
 #define IPC_IDCTFC_MSG_MASK	0x7FFFFFFF
 
 /* IDCTEFC */
 #define IPC_IDCTEFC_MSG_MASK	0x3FFFFFFF
 
 /* IDCITC */
-#define IPC_IDCITC_BUSY		(1 << 31)
+#define IPC_IDCITC_BUSY		BIT(31)
 #define IPC_IDCITC_MSG_MASK	0x7FFFFFFF
 
 /* IDCIETC */
-#define IPC_IDCIETC_DONE	(1 << 30)
+#define IPC_IDCIETC_DONE	BIT(30)
 #define IPC_IDCIETC_MSG_MASK	0x3FFFFFFF
 
 /* IDCCTL */
 #define IPC_IDCCTL_IDCIDIE(x)	(0x100 << (x))
-#define IPC_IDCCTL_IDCTBIE(x)	(0x1 << (x))
+#define IPC_IDCCTL_IDCTBIE(x)	BIT(x)
 
 #define IRQ_CPU_OFFSET	0x40
 
@@ -120,10 +120,10 @@
 #define SHIM_DSPWCT0C		0x30 /* DSP Wall Clock Timer 0 Compare */
 #define SHIM_DSPWCT1C		0x38 /* DSP Wall Clock Timer 1 Compare */
 
-#define SHIM_DSPWCTCS_T1T	(0x1 << 5) /* Timer 1 triggered */
-#define SHIM_DSPWCTCS_T0T	(0x1 << 4) /* Timer 0 triggered */
-#define SHIM_DSPWCTCS_T1A	(0x1 << 1) /* Timer 1 armed */
-#define SHIM_DSPWCTCS_T0A	(0x1 << 0) /* Timer 0 armed */
+#define SHIM_DSPWCTCS_T1T	BIT(5) /* Timer 1 triggered */
+#define SHIM_DSPWCTCS_T0T	BIT(4) /* Timer 0 triggered */
+#define SHIM_DSPWCTCS_T1A	BIT(1) /* Timer 1 armed */
+#define SHIM_DSPWCTCS_T0A	BIT(0) /* Timer 0 armed */
 
 /** \brief Clock control */
 #define SHIM_CLKCTL		0x78
@@ -153,7 +153,7 @@
 #define SHIM_CLKCTL_I2SEFDCGB(x)	BIT(18 + x)
 
 /** \brief Tensilica Core Prevent Local Clock Gating */
-#define SHIM_CLKCTL_TCPLCG_EN(x)	BIT(16 + x)
+#define SHIM_CLKCTL_TCPLCG_EN(x)	BIT(16 + (x))
 #define SHIM_CLKCTL_TCPLCG_DIS(x)	0
 
 /** \brief Core clock PLL divisor */
@@ -199,7 +199,7 @@
 #define SHIM_SPSREQ		0xa0
 #define LSPGCTL			(SHIM_BASE + SHIM_LSPGCTL)
 
-#define SHIM_SPSREQ_RVNNP	(0x1 << 0)
+#define SHIM_SPSREQ_RVNNP	BIT(0)
 
 /** \brief GPDMA shim registers Control */
 #define SHIM_GPDMA_BASE_OFFSET	0xC00
@@ -226,38 +226,37 @@
 #define LSPGISTS		(SHIM_BASE + SHIM_LSPGISTS)
 
 
-#define SHIM_LPSCTL_FDSPRUN	(0X1 << 9)
-#define SHIM_LPSCTL_FDMARUN	(0X1 << 8)
+#define SHIM_LPSCTL_FDSPRUN	BIT(9)
+#define SHIM_LPSCTL_FDMARUN	BIT(8)
 
 #define SHIM_L2_MECS		(SHIM_BASE + 0xd0)
 
 #define SHIM_LPGPDMAC(x)	(0x1110 + (2 * x))
-#define SHIM_LPGPDMAC_CTLOSEL	(1 << 15)
-#define SHIM_LPGPDMAC_CHOSEL	(0xFF)
+#define SHIM_LPGPDMAC_CTLOSEL	BIT(15)
+#define SHIM_LPGPDMAC_CHOSEL	0xFF
 
 #define SHIM_DSPIOPO		0x1118
-#define SHIM_DSPIOPO_DMICOSEL	(1 << 0)
+#define SHIM_DSPIOPO_DMICOSEL	BIT(0)
 #define SHIM_DSPIOPO_I2SOSEL	(0x3F << 8)
 
 #define SHIM_GENO		0x111C
-#define SHIM_GENO_SHIMOSEL	(1 << 0)
-#define SHIM_GENO_MDIVOSEL	(1 << 1)
-#define SHIM_GENO_DIOPTOSEL	(1 << 2)
+#define SHIM_GENO_SHIMOSEL	BIT(0)
+#define SHIM_GENO_MDIVOSEL	BIT(1)
+#define SHIM_GENO_DIOPTOSEL	BIT(2)
 
 #define SHIM_L2_CACHE_CTRL	(SHIM_BASE + 0x500)
 #define SHIM_L2_PREF_CFG	(SHIM_BASE + 0x508)
 #define SHIM_L2_CACHE_PREF	(SHIM_BASE + 0x510)
 
 #define SHIM_SVCFG			0xF4
-#define SHIM_SVCFG_FORCE_L1_EXIT	(0x1 << 1)
-
+#define SHIM_SVCFG_FORCE_L1_EXIT	BIT(1)
 
 /* host windows */
 #define DMWBA(x)		(HOST_WIN_BASE(x) + 0x0)
 #define DMWLO(x)		(HOST_WIN_BASE(x) + 0x4)
 
-#define DMWBA_ENABLE		(1 << 0)
-#define DMWBA_READONLY		(1 << 1)
+#define DMWBA_ENABLE		BIT(0)
+#define DMWBA_READONLY		BIT(1)
 
 #ifndef ASSEMBLY
 

--- a/src/platform/cannonlake/include/platform/lib/shim.h
+++ b/src/platform/cannonlake/include/platform/lib/shim.h
@@ -39,23 +39,23 @@
 #define IPC_IDCCTL		0x50
 
 /* IDCTFC */
-#define IPC_IDCTFC_BUSY		(1 << 31)
+#define IPC_IDCTFC_BUSY		BIT(31)
 #define IPC_IDCTFC_MSG_MASK	0x7FFFFFFF
 
 /* IDCTEFC */
 #define IPC_IDCTEFC_MSG_MASK	0x3FFFFFFF
 
 /* IDCITC */
-#define IPC_IDCITC_BUSY		(1 << 31)
+#define IPC_IDCITC_BUSY		BIT(31)
 #define IPC_IDCITC_MSG_MASK	0x7FFFFFFF
 
 /* IDCIETC */
-#define IPC_IDCIETC_DONE	(1 << 30)
+#define IPC_IDCIETC_DONE	BIT(30)
 #define IPC_IDCIETC_MSG_MASK	0x3FFFFFFF
 
 /* IDCCTL */
 #define IPC_IDCCTL_IDCIDIE(x)	(0x100 << (x))
-#define IPC_IDCCTL_IDCTBIE(x)	(0x1 << (x))
+#define IPC_IDCCTL_IDCTBIE(x)	BIT(x)
 
 #define IRQ_CPU_OFFSET	0x40
 
@@ -105,10 +105,10 @@
 #define SHIM_DSPWCT0C		0x30 /* DSP Wall Clock Timer 0 Compare */
 #define SHIM_DSPWCT1C		0x38 /* DSP Wall Clock Timer 1 Compare */
 
-#define SHIM_DSPWCTCS_T1T	(0x1 << 5) /* Timer 1 triggered */
-#define SHIM_DSPWCTCS_T0T	(0x1 << 4) /* Timer 0 triggered */
-#define SHIM_DSPWCTCS_T1A	(0x1 << 1) /* Timer 1 armed */
-#define SHIM_DSPWCTCS_T0A	(0x1 << 0) /* Timer 0 armed */
+#define SHIM_DSPWCTCS_T1T	BIT(5) /* Timer 1 triggered */
+#define SHIM_DSPWCTCS_T0T	BIT(4) /* Timer 0 triggered */
+#define SHIM_DSPWCTCS_T1A	BIT(1) /* Timer 1 armed */
+#define SHIM_DSPWCTCS_T0A	BIT(0) /* Timer 0 armed */
 
 /** \brief Clock control */
 #define SHIM_CLKCTL		0x78
@@ -223,37 +223,37 @@
 #define SHIM_LDOCTL_LPSRAM_MASK	(3 << 2)
 #define SHIM_LDOCTL_HPSRAM_LDO_ON	(3 << 0)
 #define SHIM_LDOCTL_LPSRAM_LDO_ON	(3 << 2)
-#define SHIM_LDOCTL_HPSRAM_LDO_BYPASS	(1 << 0)
-#define SHIM_LDOCTL_LPSRAM_LDO_BYPASS	(1 << 2)
+#define SHIM_LDOCTL_HPSRAM_LDO_BYPASS	BIT(0)
+#define SHIM_LDOCTL_LPSRAM_LDO_BYPASS	BIT(2)
 #define SHIM_LDOCTL_HPSRAM_LDO_OFF	(0 << 0)
 #define SHIM_LDOCTL_LPSRAM_LDO_OFF	(0 << 2)
 
 #define DSP_INIT_LPGPDMA(x)	(0x71A60 + (2*x))
-#define LPGPDMA_CTLOSEL_FLAG	(1 << 15)
-#define LPGPDMA_CHOSEL_FLAG	(0xFF)
+#define LPGPDMA_CTLOSEL_FLAG	BIT(15)
+#define LPGPDMA_CHOSEL_FLAG	0xFF
 
 #define DSP_INIT_IOPO	0x71A68
-#define IOPO_DMIC_FLAG		(1 << 0)
+#define IOPO_DMIC_FLAG		BIT(0)
 #define IOPO_I2S_FLAG		(7 << 8)
 
 #define DSP_INIT_GENO	0x71A6C
-#define GENO_MDIVOSEL		(1 << 1)
-#define GENO_DIOPTOSEL		(1 << 2)
+#define GENO_MDIVOSEL		BIT(1)
+#define GENO_DIOPTOSEL		BIT(2)
 
 #define DSP_INIT_ALHO	0x71A70
-#define ALHO_ASO_FLAG		(1 << 0)
-#define ALHO_CSO_FLAG		(1 << 1)
-#define ALHO_CFO_FLAG		(1 << 2)
+#define ALHO_ASO_FLAG		BIT(0)
+#define ALHO_CSO_FLAG		BIT(1)
+#define ALHO_CFO_FLAG		BIT(2)
 
 #define SHIM_SVCFG			0xF4
-#define SHIM_SVCFG_FORCE_L1_EXIT	(0x1 << 1)
+#define SHIM_SVCFG_FORCE_L1_EXIT	BIT(1)
 
 /* host windows */
 #define DMWBA(x)		(HOST_WIN_BASE(x) + 0x0)
 #define DMWLO(x)		(HOST_WIN_BASE(x) + 0x4)
 
-#define DMWBA_ENABLE		(1 << 0)
-#define DMWBA_READONLY		(1 << 1)
+#define DMWBA_ENABLE		BIT(0)
+#define DMWBA_READONLY		BIT(1)
 
 /* DMIC power ON bit */
 #define DMICLCTL_SPA	((uint32_t) BIT(0))

--- a/src/platform/cannonlake/include/platform/lib/shim.h
+++ b/src/platform/cannonlake/include/platform/lib/shim.h
@@ -130,7 +130,7 @@
 					 SHIM_CLKCTL_TCPLCG_DIS(2) | \
 					 SHIM_CLKCTL_TCPLCG_DIS(3))
 
-/* Core clock PLL divisor */
+/** \brief Core clock PLL divisor */
 #define SHIM_CLKCTL_DPCS_MASK(x)	BIT(2)
 
 /** \brief DMIC Force Dynamic Clock Gating */
@@ -147,6 +147,21 @@
 /** \brief HP Memory Clock Select */
 #define SHIM_CLKCTL_HMCS_DIV2	0
 #define SHIM_CLKCTL_HMCS_DIV4	BIT(0)
+
+/* Core clock PLL divisor */
+#define SHIM_CLKCTL_DPCS_MASK(x)	BIT(2)
+
+/* Prevent Audio PLL Shutdown */
+#define SHIM_CLKCTL_TCPAPLLS	BIT(7)
+
+/* 0--from PLL, 1--from oscillator */
+#define SHIM_CLKCTL_HDCS	BIT(4)
+
+/* Oscillator select */
+#define SHIM_CLKCTL_HDOCS	BIT(2)
+
+/* HP memory clock PLL divisor */
+#define SHIM_CLKCTL_HPMPCS	BIT(0)
 
 /** \brief Mask for requesting clock
  */
@@ -204,12 +219,12 @@
 #define HSRMCTL0		0x71D14
 #define HSPGISTS0		0x71D18
 
+#define SHIM_HSPGCTL(x)		(HSPGCTL0 + 0x10 * (x))
+#define SHIM_HSPGISTS(x)	(HSPGISTS0 + 0x10 * (x))
+
 #define HSPGCTL1		0x71D20
 #define HSRMCTL1		0x71D24
 #define HSPGISTS1		0x71D28
-
-#define SHIM_HSPGCTL(x)	(HSPGCTL0 + 0x10 * (x))
-#define SHIM_HSPGISTS(x)	(HSPGISTS0 + 0x10 * (x))
 
 #define LSPGCTL			0x71D50
 #define LSRMCTL			0x71D54

--- a/src/platform/icelake/include/platform/lib/shim.h
+++ b/src/platform/icelake/include/platform/lib/shim.h
@@ -39,23 +39,23 @@
 #define IPC_IDCCTL		0x50
 
 /* IDCTFC */
-#define IPC_IDCTFC_BUSY		(1 << 31)
+#define IPC_IDCTFC_BUSY		BIT(31)
 #define IPC_IDCTFC_MSG_MASK	0x7FFFFFFF
 
 /* IDCTEFC */
 #define IPC_IDCTEFC_MSG_MASK	0x3FFFFFFF
 
 /* IDCITC */
-#define IPC_IDCITC_BUSY		(1 << 31)
+#define IPC_IDCITC_BUSY		BIT(31)
 #define IPC_IDCITC_MSG_MASK	0x7FFFFFFF
 
 /* IDCIETC */
-#define IPC_IDCIETC_DONE	(1 << 30)
+#define IPC_IDCIETC_DONE	BIT(30)
 #define IPC_IDCIETC_MSG_MASK	0x3FFFFFFF
 
 /* IDCCTL */
 #define IPC_IDCCTL_IDCIDIE(x)	(0x100 << (x))
-#define IPC_IDCCTL_IDCTBIE(x)	(0x1 << (x))
+#define IPC_IDCCTL_IDCTBIE(x)	BIT(x)
 
 #define IRQ_CPU_OFFSET	0x40
 
@@ -105,10 +105,10 @@
 #define SHIM_DSPWCT0C		0x30 /* DSP Wall Clock Timer 0 Compare */
 #define SHIM_DSPWCT1C		0x38 /* DSP Wall Clock Timer 1 Compare */
 
-#define SHIM_DSPWCTCS_T1T	(0x1 << 5) /* Timer 1 triggered */
-#define SHIM_DSPWCTCS_T0T	(0x1 << 4) /* Timer 0 triggered */
-#define SHIM_DSPWCTCS_T1A	(0x1 << 1) /* Timer 1 armed */
-#define SHIM_DSPWCTCS_T0A	(0x1 << 0) /* Timer 0 armed */
+#define SHIM_DSPWCTCS_T1T	BIT(5) /* Timer 1 triggered */
+#define SHIM_DSPWCTCS_T0T	BIT(4) /* Timer 0 triggered */
+#define SHIM_DSPWCTCS_T1A	BIT(1) /* Timer 1 armed */
+#define SHIM_DSPWCTCS_T0A	BIT(0) /* Timer 0 armed */
 
 /** \brief Clock control */
 #define SHIM_CLKCTL		0x78
@@ -129,6 +129,7 @@
 					 SHIM_CLKCTL_TCPLCG_DIS(1) | \
 					 SHIM_CLKCTL_TCPLCG_DIS(2) | \
 					 SHIM_CLKCTL_TCPLCG_DIS(3))
+
 /** \brief Oscillator Clock Select*/
 #define SHIM_CLKCTL_OCS_HP_RING		BIT(2)
 #define SHIM_CLKCTL_OCS_LP_RING		0
@@ -145,19 +146,19 @@
 #define SHIM_CLKCTL_TCPLCG(x)		(0x1 << (16 + x))
 
 /* Core clock PLL divisor */
-#define SHIM_CLKCTL_DPCS_MASK(x)	(0x1 << 2)
+#define SHIM_CLKCTL_DPCS_MASK(x)	BIT(2)
 
 /* Prevent Audio PLL Shutdown */
-#define SHIM_CLKCTL_TCPAPLLS	(0x1 << 7)
+#define SHIM_CLKCTL_TCPAPLLS	BIT(7)
 
 /* 0--from PLL, 1--from oscillator */
-#define SHIM_CLKCTL_HDCS	(0x1 << 4)
+#define SHIM_CLKCTL_HDCS	BIT(4)
 
 /* Oscillator select */
-#define SHIM_CLKCTL_HDOCS	(0x1 << 2)
+#define SHIM_CLKCTL_HDOCS	BIT(2)
 
 /* HP memory clock PLL divisor */
-#define SHIM_CLKCTL_HPMPCS	(0x1 << 0)
+#define SHIM_CLKCTL_HPMPCS	BIT(0)
 
 /** \brief Mask for requesting clock
  */
@@ -234,37 +235,37 @@
 #define SHIM_LDOCTL_LPSRAM_MASK	(3 << 2)
 #define SHIM_LDOCTL_HPSRAM_LDO_ON	(3 << 0)
 #define SHIM_LDOCTL_LPSRAM_LDO_ON	(3 << 2)
-#define SHIM_LDOCTL_HPSRAM_LDO_BYPASS	(1 << 0)
-#define SHIM_LDOCTL_LPSRAM_LDO_BYPASS	(1 << 2)
+#define SHIM_LDOCTL_HPSRAM_LDO_BYPASS	BIT(0)
+#define SHIM_LDOCTL_LPSRAM_LDO_BYPASS	BIT(2)
 #define SHIM_LDOCTL_HPSRAM_LDO_OFF	(0 << 0)
 #define SHIM_LDOCTL_LPSRAM_LDO_OFF	(0 << 2)
 
 #define DSP_INIT_LPGPDMA(x)	(0x71A60 + (2*x))
-#define LPGPDMA_CTLOSEL_FLAG	(1 << 15)
-#define LPGPDMA_CHOSEL_FLAG	(0xFF)
+#define LPGPDMA_CTLOSEL_FLAG	BIT(15)
+#define LPGPDMA_CHOSEL_FLAG	0xFF
 
 #define DSP_INIT_IOPO	0x71A68
-#define IOPO_DMIC_FLAG		(1 << 0)
+#define IOPO_DMIC_FLAG		BIT(0)
 #define IOPO_I2S_FLAG		MASK(DAI_NUM_SSP_BASE + DAI_NUM_SSP_EXT + 7, 8)
 
 #define DSP_INIT_GENO	0x71A6C
-#define GENO_MDIVOSEL		(1 << 1)
-#define GENO_DIOPTOSEL		(1 << 2)
+#define GENO_MDIVOSEL		BIT(1)
+#define GENO_DIOPTOSEL		BIT(2)
 
 #define DSP_INIT_ALHO	0x71A70
-#define ALHO_ASO_FLAG		(1 << 0)
-#define ALHO_CSO_FLAG		(1 << 1)
-#define ALHO_CFO_FLAG		(1 << 2)
+#define ALHO_ASO_FLAG		BIT(0)
+#define ALHO_CSO_FLAG		BIT(1)
+#define ALHO_CFO_FLAG		BIT(2)
 
 #define SHIM_SVCFG			0xF4
-#define SHIM_SVCFG_FORCE_L1_EXIT	(0x1 << 1)
+#define SHIM_SVCFG_FORCE_L1_EXIT	BIT(1)
 
 /* host windows */
 #define DMWBA(x)		(HOST_WIN_BASE(x) + 0x0)
 #define DMWLO(x)		(HOST_WIN_BASE(x) + 0x4)
 
-#define DMWBA_ENABLE		(1 << 0)
-#define DMWBA_READONLY		(1 << 1)
+#define DMWBA_ENABLE		BIT(0)
+#define DMWBA_READONLY		BIT(1)
 
 /* DMIC power ON bit */
 #define DMICLCTL_SPA	((uint32_t) BIT(0))

--- a/src/platform/icelake/include/platform/lib/shim.h
+++ b/src/platform/icelake/include/platform/lib/shim.h
@@ -142,9 +142,6 @@
 #define SHIM_CLKCTL_HMCS_DIV2	0
 #define SHIM_CLKCTL_HMCS_DIV4	BIT(0)
 
-/* LP GPDMA Force Dynamic Clock Gating bits, 0--enable */
-#define SHIM_CLKCTL_TCPLCG(x)		(0x1 << (16 + x))
-
 /* Core clock PLL divisor */
 #define SHIM_CLKCTL_DPCS_MASK(x)	BIT(2)
 

--- a/src/platform/tigerlake/include/platform/lib/shim.h
+++ b/src/platform/tigerlake/include/platform/lib/shim.h
@@ -39,23 +39,23 @@
 #define IPC_IDCCTL		0x50
 
 /* IDCTFC */
-#define IPC_IDCTFC_BUSY		(1 << 31)
+#define IPC_IDCTFC_BUSY		BIT(31)
 #define IPC_IDCTFC_MSG_MASK	0x7FFFFFFF
 
 /* IDCTEFC */
 #define IPC_IDCTEFC_MSG_MASK	0x3FFFFFFF
 
 /* IDCITC */
-#define IPC_IDCITC_BUSY		(1 << 31)
+#define IPC_IDCITC_BUSY		BIT(31)
 #define IPC_IDCITC_MSG_MASK	0x7FFFFFFF
 
 /* IDCIETC */
-#define IPC_IDCIETC_DONE	(1 << 30)
+#define IPC_IDCIETC_DONE	BIT(30)
 #define IPC_IDCIETC_MSG_MASK	0x3FFFFFFF
 
 /* IDCCTL */
 #define IPC_IDCCTL_IDCIDIE(x)	(0x100 << (x))
-#define IPC_IDCCTL_IDCTBIE(x)	(0x1 << (x))
+#define IPC_IDCCTL_IDCTBIE(x)	BIT(x)
 
 #define IRQ_CPU_OFFSET	0x40
 
@@ -105,10 +105,10 @@
 #define SHIM_DSPWCT0C		0x30 /* DSP Wall Clock Timer 0 Compare */
 #define SHIM_DSPWCT1C		0x38 /* DSP Wall Clock Timer 1 Compare */
 
-#define SHIM_DSPWCTCS_T1T	(0x1 << 5) /* Timer 1 triggered */
-#define SHIM_DSPWCTCS_T0T	(0x1 << 4) /* Timer 0 triggered */
-#define SHIM_DSPWCTCS_T1A	(0x1 << 1) /* Timer 1 armed */
-#define SHIM_DSPWCTCS_T0A	(0x1 << 0) /* Timer 0 armed */
+#define SHIM_DSPWCTCS_T1T	BIT(5) /* Timer 1 triggered */
+#define SHIM_DSPWCTCS_T0T	BIT(4) /* Timer 0 triggered */
+#define SHIM_DSPWCTCS_T1A	BIT(1) /* Timer 1 armed */
+#define SHIM_DSPWCTCS_T0A	BIT(0) /* Timer 0 armed */
 
 /** \brief Clock control */
 #define SHIM_CLKCTL		0x78
@@ -146,19 +146,19 @@
 #define SHIM_CLKCTL_TCPLCG(x)		(0x1 << (16 + x))
 
 /* Core clock PLL divisor */
-#define SHIM_CLKCTL_DPCS_MASK(x)	(0x1 << 2)
+#define SHIM_CLKCTL_DPCS_MASK(x)	BIT(2)
 
 /* Prevent Audio PLL Shutdown */
-#define SHIM_CLKCTL_TCPAPLLS	(0x1 << 7)
+#define SHIM_CLKCTL_TCPAPLLS	BIT(7)
 
 /* 0--from PLL, 1--from oscillator */
-#define SHIM_CLKCTL_HDCS	(0x1 << 4)
+#define SHIM_CLKCTL_HDCS	BIT(4)
 
 /* Oscillator select */
-#define SHIM_CLKCTL_HDOCS	(0x1 << 2)
+#define SHIM_CLKCTL_HDOCS	BIT(2)
 
 /* HP memory clock PLL divisor */
-#define SHIM_CLKCTL_HPMPCS	(0x1 << 0)
+#define SHIM_CLKCTL_HPMPCS	BIT(0)
 
 /** \brief Mask for requesting clock
  */
@@ -244,37 +244,37 @@
 #define SHIM_LDOCTL_LPSRAM_MASK	(3 << 2)
 #define SHIM_LDOCTL_HPSRAM_LDO_ON	(3 << 0)
 #define SHIM_LDOCTL_LPSRAM_LDO_ON	(3 << 2)
-#define SHIM_LDOCTL_HPSRAM_LDO_BYPASS	(1 << 0)
-#define SHIM_LDOCTL_LPSRAM_LDO_BYPASS	(1 << 2)
+#define SHIM_LDOCTL_HPSRAM_LDO_BYPASS	BIT(0)
+#define SHIM_LDOCTL_LPSRAM_LDO_BYPASS	BIT(2)
 #define SHIM_LDOCTL_HPSRAM_LDO_OFF	(0 << 0)
 #define SHIM_LDOCTL_LPSRAM_LDO_OFF	(0 << 2)
 
 #define DSP_INIT_LPGPDMA(x)	(0x71A60 + (2*x))
-#define LPGPDMA_CTLOSEL_FLAG	(1 << 15)
-#define LPGPDMA_CHOSEL_FLAG	(0xFF)
+#define LPGPDMA_CTLOSEL_FLAG	BIT(15)
+#define LPGPDMA_CHOSEL_FLAG	0xFF
 
 #define DSP_INIT_IOPO	0x71A68
-#define IOPO_DMIC_FLAG		(1 << 0)
+#define IOPO_DMIC_FLAG		BIT(0)
 #define IOPO_I2S_FLAG		MASK(DAI_NUM_SSP_BASE + DAI_NUM_SSP_EXT + 7, 8)
 
 #define DSP_INIT_GENO	0x71A6C
-#define GENO_MDIVOSEL		(1 << 1)
-#define GENO_DIOPTOSEL		(1 << 2)
+#define GENO_MDIVOSEL		BIT(1)
+#define GENO_DIOPTOSEL		BIT(2)
 
 #define DSP_INIT_ALHO	0x71A70
-#define ALHO_ASO_FLAG		(1 << 0)
-#define ALHO_CSO_FLAG		(1 << 1)
-#define ALHO_CFO_FLAG		(1 << 2)
+#define ALHO_ASO_FLAG		BIT(0)
+#define ALHO_CSO_FLAG		BIT(1)
+#define ALHO_CFO_FLAG		BIT(2)
 
 #define SHIM_SVCFG			0xF4
-#define SHIM_SVCFG_FORCE_L1_EXIT	(0x1 << 1)
+#define SHIM_SVCFG_FORCE_L1_EXIT	BIT(1)
 
 /* host windows */
 #define DMWBA(x)		(HOST_WIN_BASE(x) + 0x0)
 #define DMWLO(x)		(HOST_WIN_BASE(x) + 0x4)
 
-#define DMWBA_ENABLE		(1 << 0)
-#define DMWBA_READONLY		(1 << 1)
+#define DMWBA_ENABLE		BIT(0)
+#define DMWBA_READONLY		BIT(1)
 
 /* DMIC power ON bit */
 #define DMICLCTL_SPA	((uint32_t) BIT(0))

--- a/src/platform/tigerlake/include/platform/lib/shim.h
+++ b/src/platform/tigerlake/include/platform/lib/shim.h
@@ -142,9 +142,6 @@
 #define SHIM_CLKCTL_HMCS_DIV2	0
 #define SHIM_CLKCTL_HMCS_DIV4	BIT(0)
 
-/* LP GPDMA Force Dynamic Clock Gating bits, 0--enable */
-#define SHIM_CLKCTL_TCPLCG(x)		(0x1 << (16 + x))
-
 /* Core clock PLL divisor */
 #define SHIM_CLKCTL_DPCS_MASK(x)	BIT(2)
 
@@ -225,12 +222,12 @@
 #define HSRMCTL0		0x71D14
 #define HSPGISTS0		0x71D18
 
+#define SHIM_HSPGCTL(x)		(HSPGCTL0 + 0x10 * (x))
+#define SHIM_HSPGISTS(x)	(HSPGISTS0 + 0x10 * (x))
+
 #define HSPGCTL1		0x71D20
 #define HSRMCTL1		0x71D24
 #define HSPGISTS1		0x71D28
-
-#define SHIM_HSPGCTL(x)	(HSPGCTL0 + 0x10 * (x))
-#define SHIM_HSPGISTS(x)	(HSPGISTS0 + 0x10 * (x))
 
 #define LSPGCTL			0x71D50
 #define LSRMCTL			0x71D54


### PR DESCRIPTION
The BIT() macro is used to replace explicit bit shifting in
Apollolake, Cannonlake, Icelake and Tigerlake shim headers.
The headers are slightly modified to include the same registers
/bit definitions (if HW permits).

Signed-off-by: Lech Betlej <lech.betlej@linux.intel.com>