### PR TITLE
Introduce task uuids

### DIFF
--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -50,6 +50,10 @@ static const struct comp_driver comp_kpb;
 DECLARE_SOF_UUID("kpb", kpb_uuid, 0xd8218443, 0x5ff3, 0x4a4c,
 		 0xb3, 0x88, 0x6c, 0xfe, 0x07, 0xb9, 0x56, 0x2e);
 
+/* e50057a5-8b27-4db4-bd79-9a639cee5f50 */
+DECLARE_SOF_UUID("kpb-task", kpb_task_uuid, 0xe50057a5, 0x8b27, 0x4db4,
+		 0xbd, 0x79, 0x9a, 0x63, 0x9c, 0xee, 0x5f, 0x50);
+
 /* KPB private data, runtime data */
 struct comp_data {
 	uint64_t state_log; /**< keeps record of KPB recent states */
@@ -170,6 +174,7 @@ static struct comp_dev *kpb_new(const struct comp_driver *drv,
 
 	/* Initialize draining task */
 	schedule_task_init_edf(&kpb->draining_task, /* task structure */
+			       SOF_UUID(kpb_task_uuid), /* task uuid */
 			       &ops, /* task ops */
 			       &kpb->draining_task_data, /* task private data */
 			       0, /* core on which we should run */

--- a/src/audio/pipeline.c
+++ b/src/audio/pipeline.c
@@ -14,6 +14,7 @@
 #include <sof/drivers/timer.h>
 #include <sof/lib/alloc.h>
 #include <sof/lib/mailbox.h>
+#include <sof/lib/uuid.h>
 #include <sof/list.h>
 #include <sof/math/numbers.h>
 #include <sof/schedule/ll_schedule.h>
@@ -36,6 +37,10 @@ struct pipeline_data {
 	struct pipeline *p;
 	int cmd;
 };
+
+/* f11818eb-e92e-4082-82a3-dc54c604ebb3 */
+DECLARE_SOF_UUID("pipe-task", pipe_task_uuid, 0xf11818eb, 0xe92e, 0x4082,
+		 0x82,  0xa3, 0xdc, 0x54, 0xc6, 0x04, 0xeb, 0xb3);
 
 static enum task_state pipeline_task(void *arg);
 
@@ -426,7 +431,8 @@ static struct task *pipeline_task_init(struct pipeline *p, uint32_t type,
 	if (!task)
 		return NULL;
 
-	if (schedule_task_init_ll(&task->task, type, p->ipc_pipe.priority, func,
+	if (schedule_task_init_ll(&task->task, SOF_UUID(pipe_task_uuid), type,
+				  p->ipc_pipe.priority, func,
 				  p, p->ipc_pipe.core, 0) < 0) {
 		rfree(task);
 		return NULL;

--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -50,6 +50,10 @@ static const struct comp_driver comp_volume;
 DECLARE_SOF_UUID("volume", volume_uuid, 0xb77e677e, 0x5ff4, 0x4188,
 		 0xaf, 0x14, 0xfb, 0xa8, 0xbd, 0xbf, 0x86, 0x82);
 
+/* 34dc0385-fc2f-4f7f-82d2-6cee444533e0 */
+DECLARE_SOF_UUID("volume-task", volume_task_uuid, 0x34dc0385, 0xfc2f, 0x4f7f,
+		 0x82, 0xd2, 0x6c, 0xee, 0x44, 0x45, 0x33, 0xe0);
+
 /**
  * \brief Synchronize host mmap() volume with real value.
  * \param[in,out] cd Volume component private data.
@@ -175,7 +179,8 @@ static int vol_task_init(struct comp_dev *dev)
 	if (!cd->volwork)
 		return -ENOMEM;
 
-	ret = schedule_task_init_ll(cd->volwork, SOF_SCHEDULE_LL_TIMER,
+	ret = schedule_task_init_ll(cd->volwork, SOF_UUID(volume_task_uuid),
+				    SOF_SCHEDULE_LL_TIMER,
 				    SOF_TASK_PRI_MED, vol_work, dev,
 				    cpu_get_id(), 0);
 	if (ret < 0) {

--- a/src/drivers/dw/ssi-spi.c
+++ b/src/drivers/dw/ssi-spi.c
@@ -16,6 +16,7 @@
 #include <sof/lib/io.h>
 #include <sof/lib/mailbox.h>
 #include <sof/lib/memory.h>
+#include <sof/lib/uuid.h>
 #include <sof/lib/wait.h>
 #include <sof/platform.h>
 #include <sof/schedule/ll_schedule.h>
@@ -27,6 +28,11 @@
 #include <ipc/topology.h>
 #include <stddef.h>
 #include <stdint.h>
+
+/* a417b6fb-459d-4cf9-be65-d38dc9057b80 */
+DECLARE_SOF_UUID("spi-completion", spi_compl_task_uuid, 0xa417b6fb,
+		 0x459d, 0x4cf9,
+		 0xbe, 0x65, 0xd3, 0x8d, 0xc9, 0x05, 0x7b, 0x80);
 
 #define	SPI_REG_CTRLR0		0x00
 #define	SPI_REG_CTRLR1		0x04
@@ -402,7 +408,9 @@ static int spi_slave_init(struct spi *spi)
 
 	spi->completion.private = NULL;
 
-	ret = schedule_task_init_ll(&spi->completion, SOF_SCHEDULE_LL_DMA,
+	ret = schedule_task_init_ll(&spi->completion,
+				    SOF_UUID(spi_compl_task_uuid),
+				    SOF_SCHEDULE_LL_DMA,
 				    SOF_TASK_PRI_MED, spi_completion_work,
 				    spi, 0, 0);
 	if (ret < 0)

--- a/src/drivers/imx/ipc.c
+++ b/src/drivers/imx/ipc.c
@@ -12,6 +12,7 @@
 #include <sof/lib/dma.h>
 #include <sof/lib/mailbox.h>
 #include <sof/lib/memory.h>
+#include <sof/lib/uuid.h>
 #include <sof/lib/wait.h>
 #include <sof/list.h>
 #include <sof/platform.h>
@@ -26,6 +27,10 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+
+/* 389c9186-5a7d-4ad1-a02c-a02ecdadfb33 */
+DECLARE_SOF_UUID("ipc-task", ipc_task_uuid, 0x389c9186, 0x5a7d, 0x4ad1,
+		 0xa0, 0x2c, 0xa0, 0x2e, 0xcd, 0xad, 0xfb, 0x33);
 
 struct ipc_data {
 	struct ipc_data_host_buffer dh_buffer;
@@ -166,7 +171,8 @@ int platform_ipc_init(struct ipc *ipc)
 #endif
 
 	/* schedule */
-	schedule_task_init_edf(&ipc->ipc_task, &ipc_task_ops, ipc, 0, 0);
+	schedule_task_init_edf(&ipc->ipc_task, SOF_UUID(ipc_task_uuid),
+			       &ipc_task_ops, ipc, 0, 0);
 
 #if CONFIG_HOST_PTABLE
 	/* allocate page table buffer */

--- a/src/drivers/intel/baytrail/ipc.c
+++ b/src/drivers/intel/baytrail/ipc.c
@@ -12,6 +12,7 @@
 #include <sof/lib/mailbox.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/shim.h>
+#include <sof/lib/uuid.h>
 #include <sof/lib/wait.h>
 #include <sof/list.h>
 #include <sof/platform.h>
@@ -22,6 +23,10 @@
 #include <ipc/topology.h>
 #include <stdbool.h>
 #include <stdint.h>
+
+/* 80ef9faa-a407-47d2-ae50-7973d106489e */
+DECLARE_SOF_UUID("ipc-task", ipc_task_uuid, 0x80ef9faa, 0xa407, 0x47d2,
+		 0xae, 0x50, 0x79, 0x73, 0xd1, 0x06, 0x48, 0x9e);
 
 /* private data for IPC */
 struct ipc_data {
@@ -148,7 +153,8 @@ int platform_ipc_init(struct ipc *ipc)
 	ipc_set_drvdata(ipc, iipc);
 
 	/* schedule */
-	schedule_task_init_edf(&ipc->ipc_task, &ipc_task_ops, ipc, 0, 0);
+	schedule_task_init_edf(&ipc->ipc_task, SOF_UUID(ipc_task_uuid),
+			       &ipc_task_ops, ipc, 0, 0);
 
 #if CONFIG_HOST_PTABLE
 	/* allocate page table buffer */

--- a/src/drivers/intel/cavs/dmic.c
+++ b/src/drivers/intel/cavs/dmic.c
@@ -41,6 +41,10 @@
 DECLARE_SOF_UUID("dmic-dai", dmic_uuid, 0xaafc26fe, 0x3b8d, 0x498d,
 		 0x8b, 0xd6, 0x24, 0x8f, 0xc7, 0x2e, 0xfa, 0x31);
 
+/* 59c87728-d8f9-42f6-b89d-5870a87b0e1e */
+DECLARE_SOF_UUID("dmic-work", dmic_work_task_uuid, 0x59c87728, 0xd8f9, 0x42f6,
+		 0xb8, 0x9d, 0x58, 0x70, 0xa8, 0x7b, 0x0e, 0x1e);
+
 #define DMIC_MAX_MODES 50
 
 /* HW FIR pipeline needs 5 additional cycles per channel for internal
@@ -1564,7 +1568,8 @@ static int dmic_probe(struct dai *dai)
 	}
 
 	/* Initialize start sequence handler */
-	schedule_task_init_ll(&dmic->dmicwork, SOF_SCHEDULE_LL_TIMER,
+	schedule_task_init_ll(&dmic->dmicwork, SOF_UUID(dmic_work_task_uuid),
+			      SOF_SCHEDULE_LL_TIMER,
 			      SOF_TASK_PRI_MED, dmic_work, dai, 0, 0);
 
 	/* Enable DMIC power */

--- a/src/drivers/intel/cavs/idc.c
+++ b/src/drivers/intel/cavs/idc.c
@@ -18,6 +18,7 @@
 #include <sof/lib/memory.h>
 #include <sof/lib/notifier.h>
 #include <sof/lib/shim.h>
+#include <sof/lib/uuid.h>
 #include <sof/platform.h>
 #include <sof/schedule/edf_schedule.h>
 #include <sof/schedule/ll_schedule.h>
@@ -34,6 +35,14 @@
 
 /** \brief IDC message payload per core. */
 static SHARED_DATA struct idc_payload payload[PLATFORM_CORE_COUNT];
+
+/* b90f5a4e-5537-4375-a1df-95485472ff9e */
+DECLARE_SOF_UUID("comp-task", idc_comp_task_uuid, 0xb90f5a4e, 0x5537, 0x4375,
+		 0xa1, 0xdf, 0x95, 0x48, 0x54, 0x72, 0xff, 0x9e);
+
+/* a5dacb0e-88dc-415c-a1b5-3e8df77f1976 */
+DECLARE_SOF_UUID("idc-cmd-task", idc_cmd_task_uuid, 0xa5dacb0e, 0x88dc, 0x415c,
+		 0xa1, 0xb5, 0x3e, 0x8d, 0xf7, 0x7f, 0x19, 0x76);
 
 /**
  * \brief Returns IDC data.
@@ -282,7 +291,9 @@ static int idc_prepare(uint32_t comp_id)
 			goto out;
 		}
 
-		ret = schedule_task_init_ll(dev->task, SOF_SCHEDULE_LL_TIMER,
+		ret = schedule_task_init_ll(dev->task,
+					    SOF_UUID(idc_comp_task_uuid),
+					    SOF_SCHEDULE_LL_TIMER,
 					    dev->priority, comp_task, dev,
 					    dev->comp.core, 0);
 		if (ret < 0) {
@@ -489,7 +500,8 @@ int idc_init(void)
 	(*idc)->payload = cache_to_uncache((struct idc_payload *)payload);
 
 	/* process task */
-	schedule_task_init_edf(&(*idc)->idc_task, &ops, *idc, core, 0);
+	schedule_task_init_edf(&(*idc)->idc_task, SOF_UUID(idc_cmd_task_uuid),
+			       &ops, *idc, core, 0);
 
 	/* configure interrupt */
 	(*idc)->irq = interrupt_get_irq(PLATFORM_IDC_INTERRUPT,

--- a/src/drivers/intel/cavs/ipc.c
+++ b/src/drivers/intel/cavs/ipc.c
@@ -12,6 +12,7 @@
 #include <sof/lib/mailbox.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/pm_runtime.h>
+#include <sof/lib/uuid.h>
 #include <sof/lib/wait.h>
 #include <sof/list.h>
 #include <sof/platform.h>
@@ -34,6 +35,10 @@
 #define CAVS_IPC_TYPE_S(x)		((x) & CAVS_IPC_TYPE_MASK)
 
 #endif
+
+/* 8fa1d42f-bc6f-464b-867f-547af08834da */
+DECLARE_SOF_UUID("ipc-task", ipc_task_uuid, 0x8fa1d42f, 0xbc6f, 0x464b,
+		 0x86, 0x7f, 0x54, 0x7a, 0xf0, 0x88, 0x34, 0xda);
 
 /* No private data for IPC */
 
@@ -290,7 +295,8 @@ int platform_ipc_init(struct ipc *ipc)
 	ipc_set_drvdata(ipc, NULL);
 
 	/* schedule */
-	schedule_task_init_edf(&ipc->ipc_task, &ipc_task_ops, ipc, 0, 0);
+	schedule_task_init_edf(&ipc->ipc_task, SOF_UUID(ipc_task_uuid),
+			       &ipc_task_ops, ipc, 0, 0);
 
 	/* configure interrupt */
 	irq = interrupt_get_irq(PLATFORM_IPC_INTERRUPT,

--- a/src/drivers/intel/cavs/sue-ipc.c
+++ b/src/drivers/intel/cavs/sue-ipc.c
@@ -10,6 +10,7 @@
 #include <sof/drivers/spi.h>
 #include <sof/lib/mailbox.h>
 #include <sof/lib/memory.h>
+#include <sof/lib/uuid.h>
 #include <sof/lib/wait.h>
 #include <sof/list.h>
 #include <sof/schedule/edf_schedule.h>
@@ -19,6 +20,10 @@
 #include <ipc/header.h>
 #include <stddef.h>
 #include <stdint.h>
+
+/* 7552b3a1-98dd-4419-ad6f-fbf21ebfceec */
+DECLARE_SOF_UUID("ipc-task", ipc_task_uuid, 0x7552b3a1, 0x98dd, 0x4419,
+		 0xad, 0x6f, 0xfb, 0xf2, 0x1e, 0xbf, 0xce, 0xec);
 
 /* No private data for IPC */
 enum task_state ipc_platform_do_cmd(void *data)
@@ -72,7 +77,8 @@ int platform_ipc_init(struct ipc *ipc)
 	ipc_set_drvdata(ipc, NULL);
 
 	/* schedule */
-	schedule_task_init_edf(&ipc->ipc_task, &ipc_task_ops, ipc, 0, 0);
+	schedule_task_init_edf(&ipc->ipc_task, SOF_UUID(ipc_task_uuid),
+			       &ipc_task_ops, ipc, 0, 0);
 
 	platform_shared_commit(ipc, sizeof(*ipc));
 

--- a/src/drivers/intel/haswell/ipc.c
+++ b/src/drivers/intel/haswell/ipc.c
@@ -11,6 +11,7 @@
 #include <sof/lib/mailbox.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/shim.h>
+#include <sof/lib/uuid.h>
 #include <sof/lib/wait.h>
 #include <sof/list.h>
 #include <sof/platform.h>
@@ -22,6 +23,10 @@
 #include <ipc/topology.h>
 #include <stdbool.h>
 #include <stdint.h>
+
+/* 092355d4-b1b8-4868-9942-da19427a3249 */
+DECLARE_SOF_UUID("ipc-task", ipc_task_uuid, 0x092355d4, 0xb1b8, 0x4868,
+		 0x99, 0x42, 0xda, 0x19, 0x42, 0x7a, 0x32, 0x49);
 
 /* private data for IPC */
 struct ipc_data {
@@ -149,7 +154,8 @@ int platform_ipc_init(struct ipc *ipc)
 	ipc_set_drvdata(ipc, iipc);
 
 	/* schedule */
-	schedule_task_init_edf(&ipc->ipc_task, &ipc_task_ops, ipc, 0, 0);
+	schedule_task_init_edf(&ipc->ipc_task, SOF_UUID(ipc_task_uuid),
+			       &ipc_task_ops, ipc, 0, 0);
 
 #if CONFIG_HOST_PTABLE
 	/* allocate page table buffer */

--- a/src/include/sof/schedule/edf_schedule.h
+++ b/src/include/sof/schedule/edf_schedule.h
@@ -34,7 +34,8 @@ struct edf_task_pdata {
 
 int scheduler_init_edf(void);
 
-int schedule_task_init_edf(struct task *task, const struct task_ops *ops,
+int schedule_task_init_edf(struct task *task, uint32_t uid,
+			   const struct task_ops *ops,
 			   void *data, uint16_t core, uint32_t flags);
 
 #endif /* __SOF_SCHEDULE_EDF_SCHEDULE_H__ */

--- a/src/include/sof/schedule/ll_schedule.h
+++ b/src/include/sof/schedule/ll_schedule.h
@@ -41,7 +41,8 @@ struct ll_task_pdata {
 
 int scheduler_init_ll(struct ll_schedule_domain *domain);
 
-int schedule_task_init_ll(struct task *task, uint16_t type, uint16_t priority,
+int schedule_task_init_ll(struct task *task,
+			  uint32_t uid, uint16_t type, uint16_t priority,
 			  enum task_state (*run)(void *data), void *data,
 			  uint16_t core, uint32_t flags);
 

--- a/src/include/sof/schedule/schedule.h
+++ b/src/include/sof/schedule/schedule.h
@@ -190,7 +190,8 @@ static inline void schedule(void)
 	}
 }
 
-int schedule_task_init(struct task *task, uint16_t type, uint16_t priority,
+int schedule_task_init(struct task *task,
+		       uint32_t uid, uint16_t type, uint16_t priority,
 		       enum task_state (*run)(void *data), void *data,
 		       uint16_t core, uint32_t flags);
 

--- a/src/include/sof/schedule/task.h
+++ b/src/include/sof/schedule/task.h
@@ -53,6 +53,7 @@ struct task_ops {
 /** \brief Task used by schedulers. */
 struct task {
 	uint64_t start;		/**< start time */
+	uint32_t uid;		/**< Uuid */
 	uint16_t type;		/**< type of the task (LL or EDF) */
 	uint16_t priority;	/**< priority of the task (used by LL) */
 	uint16_t core;		/**< execution core */

--- a/src/lib/agent.c
+++ b/src/lib/agent.c
@@ -17,6 +17,7 @@
 #include <sof/lib/agent.h>
 #include <sof/lib/alloc.h>
 #include <sof/lib/clk.h>
+#include <sof/lib/uuid.h>
 #include <sof/debug/panic.h>
 #include <sof/platform.h>
 #include <sof/schedule/ll_schedule.h>
@@ -34,6 +35,10 @@
 	trace_event_atomic(TRACE_CLASS_SA, __e, ##__VA_ARGS__)
 #define trace_sa_error(__e, ...) \
 	trace_error(TRACE_CLASS_SA, __e, ##__VA_ARGS__)
+
+/* c63c4e75-8f61-4420-9319-1395932efa9e */
+DECLARE_SOF_UUID("agent-work", agent_work_task_uuid, 0xc63c4e75, 0x8f61, 0x4420,
+		 0x93, 0x19, 0x13, 0x95, 0x93, 0x2e, 0xfa, 0x9e);
 
 static enum task_state validate(void *data)
 {
@@ -80,7 +85,8 @@ void sa_init(struct sof *sof, uint64_t timeout)
 	trace_sa("sa_init(), ticks = %u, sof->sa->warn_timeout = %u, sof->sa->panic_timeout = %u",
 		 ticks, sof->sa->warn_timeout, sof->sa->panic_timeout);
 
-	schedule_task_init_ll(&sof->sa->work, SOF_SCHEDULE_LL_TIMER,
+	schedule_task_init_ll(&sof->sa->work, SOF_UUID(agent_work_task_uuid),
+			      SOF_SCHEDULE_LL_TIMER,
 			      SOF_TASK_PRI_HIGH, validate, sof->sa, 0, 0);
 
 	schedule_task(&sof->sa->work, 0, timeout);

--- a/src/schedule/edf_schedule.c
+++ b/src/schedule/edf_schedule.c
@@ -132,13 +132,14 @@ static void schedule_edf_task(void *data, struct task *task, uint64_t start,
 	schedule_edf(data);
 }
 
-int schedule_task_init_edf(struct task *task, const struct task_ops *ops,
+int schedule_task_init_edf(struct task *task, uint32_t uid,
+			   const struct task_ops *ops,
 			   void *data, uint16_t core, uint32_t flags)
 {
 	struct edf_task_pdata *edf_pdata = NULL;
 	int ret = 0;
 
-	ret = schedule_task_init(task, SOF_SCHEDULE_EDF, 0, ops->run, data,
+	ret = schedule_task_init(task, uid, SOF_SCHEDULE_EDF, 0, ops->run, data,
 				 core, flags);
 	if (ret < 0)
 		return ret;

--- a/src/schedule/ll_schedule.c
+++ b/src/schedule/ll_schedule.c
@@ -101,7 +101,8 @@ static void schedule_ll_tasks_execute(struct ll_schedule_data *sch,
 			/* don't enable irq, if no more tasks to do */
 			if (!atomic_sub(&sch->num_tasks, 1))
 				sch->domain->registered[cpu] = false;
-			trace_ll("task complete %p", (uintptr_t)task);
+			trace_ll("task complete %p %s", (uintptr_t)task,
+				 task->uid);
 			trace_ll("num_tasks %d total_num_tasks %d",
 				 atomic_read(&sch->num_tasks),
 				 atomic_read(&sch->domain->total_num_tasks));
@@ -296,8 +297,9 @@ static void schedule_ll_task(void *data, struct task *task, uint64_t start,
 
 	pdata = ll_sch_get_pdata(task);
 
-	trace_ll("task add %p task->priority %d start %u period %u",
-		 (uintptr_t)task, task->priority, start, period);
+	trace_ll("task add %p %s", (uintptr_t)task, task->uid);
+	trace_ll("task params pri %d flags %d start %u period %u",
+		 task->priority, task->flags, start, period);
 
 	pdata->period = period;
 
@@ -377,7 +379,7 @@ static void schedule_ll_task_cancel(void *data, struct task *task)
 
 	irq_local_disable(flags);
 
-	trace_ll("task cancel %p", (uintptr_t)task);
+	trace_ll("task cancel %p %s", (uintptr_t)task, task->uid);
 
 	/* check to see if we are scheduled */
 	list_for_item(tlist, &sch->tasks) {

--- a/src/schedule/ll_schedule.c
+++ b/src/schedule/ll_schedule.c
@@ -323,14 +323,16 @@ out:
 	irq_local_enable(flags);
 }
 
-int schedule_task_init_ll(struct task *task, uint16_t type, uint16_t priority,
+int schedule_task_init_ll(struct task *task,
+			  uint32_t uid, uint16_t type, uint16_t priority,
 			  enum task_state (*run)(void *data), void *data,
 			  uint16_t core, uint32_t flags)
 {
 	struct ll_task_pdata *ll_pdata;
 	int ret = 0;
 
-	ret = schedule_task_init(task, type, priority, run, data, core, flags);
+	ret = schedule_task_init(task, uid, type, priority, run, data, core,
+				 flags);
 	if (ret < 0)
 		return ret;
 

--- a/src/schedule/schedule.c
+++ b/src/schedule/schedule.c
@@ -14,7 +14,8 @@
 #include <errno.h>
 #include <stdint.h>
 
-int schedule_task_init(struct task *task, uint16_t type, uint16_t priority,
+int schedule_task_init(struct task *task,
+		       uint32_t uid, uint16_t type, uint16_t priority,
 		       enum task_state (*run)(void *data), void *data,
 		       uint16_t core, uint32_t flags)
 {
@@ -24,6 +25,7 @@ int schedule_task_init(struct task *task, uint16_t type, uint16_t priority,
 		return -EINVAL;
 	}
 
+	task->uid = uid;
 	task->type = type;
 	task->priority = priority;
 	task->core = core;

--- a/src/schedule/task.c
+++ b/src/schedule/task.c
@@ -15,6 +15,7 @@
 #include <sof/lib/agent.h>
 #include <sof/lib/cpu.h>
 #include <sof/lib/memory.h>
+#include <sof/lib/uuid.h>
 #include <sof/lib/wait.h>
 #include <sof/platform.h>
 #include <sof/schedule/edf_schedule.h>
@@ -32,6 +33,10 @@
 #endif
 
 typedef enum task_state (*task_main)(void *);
+
+/* 37f1d41f-252d-448d-b9c4-1e2bee8e1bf1 */
+DECLARE_SOF_UUID("main-task", main_task_uuid, 0x37f1d41f, 0x252d, 0x448d,
+		 0xb9, 0xc4, 0x1e, 0x2b, 0xee, 0x8e, 0x1b, 0xf1);
 
 static void sys_module_init(void)
 {
@@ -79,7 +84,8 @@ void task_main_init(void)
 	*main_task = rzalloc(SOF_MEM_ZONE_SYS, 0, SOF_MEM_CAPS_RAM,
 			     sizeof(**main_task));
 
-	ret = schedule_task_init_edf(*main_task, &ops, NULL, cpu, 0);
+	ret = schedule_task_init_edf(*main_task, SOF_UUID(main_task_uuid),
+				     &ops, NULL, cpu, 0);
 	assert(!ret);
 }
 

--- a/src/trace/dma-trace.c
+++ b/src/trace/dma-trace.c
@@ -13,6 +13,7 @@
 #include <sof/lib/cpu.h>
 #include <sof/lib/dma.h>
 #include <sof/lib/memory.h>
+#include <sof/lib/uuid.h>
 #include <sof/platform.h>
 #include <sof/schedule/ll_schedule.h>
 #include <sof/schedule/schedule.h>
@@ -27,6 +28,10 @@
 #include <errno.h>
 #include <stddef.h>
 #include <stdint.h>
+
+/* 2b972272-c5b1-4b7e-926f-0fc5cb4c4690 */
+DECLARE_SOF_UUID("dma-trace-task", dma_trace_task_uuid, 0x2b972272, 0xc5b1,
+		 0x4b7e, 0x92, 0x6f, 0x0f, 0xc5, 0xcb, 0x4c, 0x46, 0x90);
 
 static int dma_trace_get_avail_data(struct dma_trace_data *d,
 				    struct dma_trace_buf *buffer,
@@ -149,7 +154,8 @@ int dma_trace_init_complete(struct dma_trace_data *d)
 		goto out;
 	}
 
-	schedule_task_init_ll(&d->dmat_work, SOF_SCHEDULE_LL_TIMER,
+	schedule_task_init_ll(&d->dmat_work, SOF_UUID(dma_trace_task_uuid),
+			      SOF_SCHEDULE_LL_TIMER,
 			      SOF_TASK_PRI_MED, trace_work, d, 0, 0);
 
 out:

--- a/test/cmocka/src/audio/kpb/kpb_mock.c
+++ b/test/cmocka/src/audio/kpb/kpb_mock.c
@@ -35,22 +35,23 @@ int comp_set_state(struct comp_dev *dev, int cmd)
 	return 0;
 }
 
-int schedule_task_init(struct task *task, uint16_t type, uint16_t priority,
-		       enum task_state (*run)(void *data), void *data,
-		       uint16_t core, uint32_t flags)
+int schedule_task_init(struct task *task, uint32_t uid, uint16_t type,
+		       uint16_t priority, enum task_state (*run)(void *data),
+		       void *data, uint16_t core, uint32_t flags)
 {
 	return 0;
 }
 
-int schedule_task_init_edf(struct task *task, const struct task_ops *ops,
-			   void *data, uint16_t core, uint32_t flags)
+int schedule_task_init_edf(struct task *task, uint32_t uid,
+			   const struct task_ops *ops, void *data,
+			   uint16_t core, uint32_t flags)
 {
 	return 0;
 }
 
-int schedule_task_init_ll(struct task *task, uint16_t type, uint16_t priority,
-			  enum task_state (*run)(void *data), void *data,
-			  uint16_t core, uint32_t flags)
+int schedule_task_init_ll(struct task *task, uint32_t uid, uint16_t type,
+			  uint16_t priority, enum task_state (*run)(void *data),
+			  void *data, uint16_t core, uint32_t flags)
 {
 	return 0;
 }

--- a/test/cmocka/src/audio/pipeline/pipeline_mocks.c
+++ b/test/cmocka/src/audio/pipeline/pipeline_mocks.c
@@ -32,11 +32,12 @@ void platform_dai_timestamp(struct comp_dev *dai,
 	(void)posn;
 }
 
-int schedule_task_init(struct task *task, uint16_t type, uint16_t priority,
-		       enum task_state (*run)(void *data), void *data,
-		       uint16_t core, uint32_t flags)
+int schedule_task_init(struct task *task, uint32_t uid, uint16_t type,
+		       uint16_t priority, enum task_state (*run)(void *data),
+		       void *data, uint16_t core, uint32_t flags)
 {
 	(void)task;
+	(void)uid;
 	(void)type;
 	(void)priority;
 	(void)run;
@@ -47,9 +48,9 @@ int schedule_task_init(struct task *task, uint16_t type, uint16_t priority,
 	return 0;
 }
 
-int schedule_task_init_ll(struct task *task, uint16_t type, uint16_t priority,
-			  enum task_state (*run)(void *data), void *data,
-			  uint16_t core, uint32_t flags)
+int schedule_task_init_ll(struct task *task, uint32_t uid, uint16_t type,
+			  uint16_t priority, enum task_state (*run)(void *data),
+			  void *data, uint16_t core, uint32_t flags)
 {
 	return 0;
 }

--- a/tools/testbench/edf_schedule.c
+++ b/tools/testbench/edf_schedule.c
@@ -43,14 +43,15 @@ static void schedule_edf_task(void *data, struct task *task, uint64_t start,
 	schedule_edf_task_complete(task);
 }
 
-int schedule_task_init_edf(struct task *task, const struct task_ops *ops,
-			   void *data, uint16_t core, uint32_t flags)
+int schedule_task_init_edf(struct task *task, uint32_t uid,
+			   const struct task_ops *ops, void *data,
+			   uint16_t core, uint32_t flags)
 {
 	struct edf_task_pdata *edf_pdata;
 	int ret = 0;
 
-	ret = schedule_task_init(task, SOF_SCHEDULE_EDF, 0, ops->run, data,
-				 core, flags);
+	ret = schedule_task_init(task, uid, SOF_SCHEDULE_EDF, 0, ops->run,
+				 data, core, flags);
 	if (ret < 0)
 		return ret;
 

--- a/tools/testbench/ll_schedule.c
+++ b/tools/testbench/ll_schedule.c
@@ -7,13 +7,15 @@
 #include <sof/schedule/ll_schedule.h>
 #include <sof/schedule/schedule.h>
 
-int schedule_task_init_ll(struct task *task, uint16_t type, uint16_t priority,
+int schedule_task_init_ll(struct task *task, uint32_t uid, uint16_t type,
+			  uint16_t priority,
 			  enum task_state (*run)(void *data), void *data,
 			  uint16_t core, uint32_t flags)
 {
 	int ret;
 
-	ret = schedule_task_init(task, type, priority, run, data, core, flags);
+	ret = schedule_task_init(task, uid, type, priority, run, data, core,
+				 flags);
 
 	return ret;
 }

--- a/tools/testbench/schedule.c
+++ b/tools/testbench/schedule.c
@@ -20,13 +20,14 @@ struct schedulers **arch_schedulers_get(void)
 	return &testbench_schedulers_ptr;
 }
 
-int schedule_task_init(struct task *task, uint16_t type, uint16_t priority,
-		       enum task_state (*run)(void *data), void *data,
-		       uint16_t core, uint32_t flags)
+int schedule_task_init(struct task *task, uint32_t uid, uint16_t type,
+		       uint16_t priority, enum task_state (*run)(void *data),
+		       void *data, uint16_t core, uint32_t flags)
 {
 	if (type >= SOF_SCHEDULE_COUNT)
 		return -EINVAL;
 
+	task->uid = uid;
 	task->type = SOF_SCHEDULE_EDF; /* Note: Force EDF scheduler */
 	task->priority = priority;
 	task->core = core;


### PR DESCRIPTION
Defining tasks as named objects makes tracing of their important activities much easier.
See screenshot below
![image](https://user-images.githubusercontent.com/40028148/76145146-325c9080-6087-11ea-98a2-e13ba77988d4.png)
