### PR TITLE
Move component tracepoints to dbg level

### DIFF
--- a/src/audio/buffer.c
+++ b/src/audio/buffer.c
@@ -23,7 +23,7 @@ struct comp_buffer *buffer_alloc(uint32_t size, uint32_t caps, uint32_t align)
 {
 	struct comp_buffer *buffer;
 
-	trace_buffer("buffer_alloc()");
+	tracev_buffer("buffer_alloc()");
 
 	/* validate request */
 	if (size == 0 || size > HEAP_BUFFER_SIZE) {
@@ -127,7 +127,7 @@ void buffer_free(struct comp_buffer *buffer)
 		.buffer = buffer,
 	};
 
-	trace_buffer_with_ids(buffer, "buffer_free()");
+	tracev_buffer_with_ids(buffer, "buffer_free()");
 
 	notifier_event(buffer, NOTIFIER_ID_BUFFER_FREE,
 		       NOTIFIER_TARGET_CORE_LOCAL, &cb_data, sizeof(cb_data));

--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -70,6 +70,9 @@ struct comp_dev *comp_new(struct sof_ipc_comp *comp)
 		return NULL;
 	}
 
+	trace_event(TRACE_CLASS_COMP, "comp new %s type %d pipe_id %d id %d",
+		    drv->uid, comp->type, comp->pipeline_id, comp->id);
+
 	/* create the new component */
 	cdev = drv->ops.new(drv, comp);
 	if (!cdev) {

--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -133,7 +133,7 @@ static struct comp_dev *dai_new(const struct comp_driver *drv,
 	uint32_t dir, caps, dma_dev;
 	int ret;
 
-	comp_cl_info(&comp_dai, "dai_new()");
+	comp_cl_dbg(&comp_dai, "dai_new()");
 
 	dev = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM,
 		      COMP_SIZE(struct sof_ipc_comp_dai));
@@ -215,7 +215,7 @@ static inline int dai_comp_get_hw_params(struct comp_dev *dev,
 	struct dai_data *dd = comp_get_drvdata(dev);
 	int ret = 0;
 
-	comp_info(dev, "dai_hw_params()");
+	comp_dbg(dev, "dai_hw_params()");
 
 	/* fetching hw dai stream params */
 	ret = dai_get_hw_params(dd->dai, params, dir);
@@ -387,7 +387,7 @@ static int dai_params(struct comp_dev *dev,
 	uint32_t align;
 	int err;
 
-	comp_info(dev, "dai_params()");
+	comp_dbg(dev, "dai_params()");
 
 	err = dai_verify_params(dev, params);
 	if (err < 0) {
@@ -480,7 +480,7 @@ static int dai_prepare(struct comp_dev *dev)
 	struct dai_data *dd = comp_get_drvdata(dev);
 	int ret = 0;
 
-	comp_info(dev, "dai_prepare()");
+	comp_dbg(dev, "dai_prepare()");
 
 	ret = comp_set_state(dev, COMP_TRIGGER_PREPARE);
 	if (ret < 0)
@@ -527,7 +527,7 @@ static int dai_reset(struct comp_dev *dev)
 	struct dai_data *dd = comp_get_drvdata(dev);
 	struct dma_sg_config *config = &dd->config;
 
-	comp_info(dev, "dai_reset()");
+	comp_dbg(dev, "dai_reset()");
 
 	dma_sg_free(&config->elem_array);
 
@@ -565,7 +565,7 @@ static int dai_comp_trigger(struct comp_dev *dev, int cmd)
 	struct dai_data *dd = comp_get_drvdata(dev);
 	int ret;
 
-	comp_info(dev, "dai_comp_trigger(), command = %u", cmd);
+	comp_dbg(dev, "dai_comp_trigger(), command = %u", cmd);
 
 	ret = comp_set_state(dev, cmd);
 	if (ret < 0)
@@ -576,7 +576,7 @@ static int dai_comp_trigger(struct comp_dev *dev, int cmd)
 
 	switch (cmd) {
 	case COMP_TRIGGER_START:
-		comp_info(dev, "dai_comp_trigger(), START");
+		comp_dbg(dev, "dai_comp_trigger(), START");
 
 		/* only start the DAI if we are not XRUN handling */
 		if (dd->xrun == 0) {
@@ -624,7 +624,7 @@ static int dai_comp_trigger(struct comp_dev *dev, int cmd)
 		/* fallthrough */
 	case COMP_TRIGGER_PAUSE:
 	case COMP_TRIGGER_STOP:
-		comp_info(dev, "dai_comp_trigger(), PAUSE/STOP");
+		comp_dbg(dev, "dai_comp_trigger(), PAUSE/STOP");
 		ret = dma_stop(dd->chan);
 		dai_trigger(dd->dai, cmd, dev->direction);
 		break;

--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -278,7 +278,7 @@ static int host_trigger(struct comp_dev *dev, int cmd)
 	struct host_data *hd = comp_get_drvdata(dev);
 	int ret = 0;
 
-	comp_info(dev, "host_trigger()");
+	comp_dbg(dev, "host_trigger()");
 
 	ret = comp_set_state(dev, cmd);
 	if (ret < 0)
@@ -331,7 +331,7 @@ static struct comp_dev *host_new(const struct comp_driver *drv,
 	uint32_t dir;
 	int ret;
 
-	comp_cl_info(&comp_host, "host_new()");
+	comp_cl_dbg(&comp_host, "host_new()");
 
 	dev = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM,
 		      COMP_SIZE(struct sof_ipc_comp_host));
@@ -466,7 +466,7 @@ static int host_params(struct comp_dev *dev,
 	uint32_t align;
 	int err;
 
-	comp_info(dev, "host_params()");
+	comp_dbg(dev, "host_params()");
 
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK)
 		hd->local_buffer = list_first_item(&dev->bsink_list,
@@ -620,7 +620,7 @@ static int host_prepare(struct comp_dev *dev)
 	struct host_data *hd = comp_get_drvdata(dev);
 	int ret;
 
-	comp_info(dev, "host_prepare()");
+	comp_dbg(dev, "host_prepare()");
 
 	ret = comp_set_state(dev, COMP_TRIGGER_PREPARE);
 	if (ret < 0)
@@ -663,7 +663,7 @@ static int host_reset(struct comp_dev *dev)
 {
 	struct host_data *hd = comp_get_drvdata(dev);
 
-	comp_info(dev, "host_reset()");
+	comp_dbg(dev, "host_reset()");
 
 	if (hd->chan) {
 		/* remove callback */

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -121,7 +121,7 @@ static struct comp_dev *mixer_new(const struct comp_driver *drv,
 	struct mixer_data *md;
 	int ret;
 
-	comp_cl_info(&comp_mixer, "mixer_new()");
+	comp_cl_dbg(&comp_mixer, "mixer_new()");
 
 	dev = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM,
 		      COMP_SIZE(struct sof_ipc_comp_mixer));
@@ -152,7 +152,7 @@ static void mixer_free(struct comp_dev *dev)
 {
 	struct mixer_data *md = comp_get_drvdata(dev);
 
-	comp_info(dev, "mixer_free()");
+	comp_dbg(dev, "mixer_free()");
 
 	rfree(md);
 	rfree(dev);
@@ -182,7 +182,7 @@ static int mixer_params(struct comp_dev *dev,
 	uint32_t period_bytes;
 	int err;
 
-	comp_info(dev, "mixer_params()");
+	comp_dbg(dev, "mixer_params()");
 
 	err = mixer_verify_params(dev, params);
 	if (err < 0) {
@@ -239,7 +239,7 @@ static int mixer_trigger(struct comp_dev *dev, int cmd)
 	int dir = dev->pipeline->source_comp->direction;
 	int ret;
 
-	comp_info(dev, "mixer_trigger()");
+	comp_dbg(dev, "mixer_trigger()");
 
 	ret = comp_set_state(dev, cmd);
 	if (ret < 0)
@@ -356,7 +356,7 @@ static int mixer_reset(struct comp_dev *dev)
 	struct list_item *blist;
 	struct comp_buffer *source;
 
-	comp_info(dev, "mixer_reset()");
+	comp_dbg(dev, "mixer_reset()");
 
 	list_for_item(blist, &dev->bsource_list) {
 		source = container_of(blist, struct comp_buffer, sink_list);
@@ -387,7 +387,7 @@ static int mixer_prepare(struct comp_dev *dev)
 	int downstream = 0;
 	int ret;
 
-	comp_info(dev, "mixer_prepare()");
+	comp_dbg(dev, "mixer_prepare()");
 
 	sink = list_first_item(&dev->bsink_list, struct comp_buffer,
 			       source_list);

--- a/src/audio/pipeline.c
+++ b/src/audio/pipeline.c
@@ -390,7 +390,13 @@ int pipeline_params(struct pipeline *p, struct comp_dev *host,
 	int dir = params->params.direction;
 	int ret;
 
-	pipe_info(p, "pipeline_params()");
+	pipe_info(p, "pipe params dir %d frame_fmt %d buffer_fmt %d rate %d",
+		  params->params.direction, params->params.frame_fmt,
+		  params->params.buffer_fmt, params->params.rate);
+	pipe_info(p, "pipe params stream_tag %d channels %d sample_valid_bytes %d sample_container_bytes %d",
+		  params->params.stream_tag, params->params.channels,
+		  params->params.sample_valid_bytes,
+		  params->params.sample_container_bytes);
 
 	/* settin hw params */
 	data.start = host;
@@ -511,7 +517,7 @@ int pipeline_prepare(struct pipeline *p, struct comp_dev *dev)
 	struct pipeline_data ppl_data;
 	int ret = 0;
 
-	pipe_info(p, "pipeline_prepare()");
+	pipe_info(p, "pipe prepare");
 
 	ppl_data.start = dev;
 
@@ -639,7 +645,7 @@ int pipeline_trigger(struct pipeline *p, struct comp_dev *host, int cmd)
 	struct pipeline_data data;
 	int ret;
 
-	pipe_info(p, "pipeline_trigger()");
+	pipe_info(p, "pipe trigger cmd %d", cmd);
 
 	/* handle pipeline global checks before going into each components */
 	if (p->xrun_bytes) {
@@ -710,7 +716,7 @@ int pipeline_reset(struct pipeline *p, struct comp_dev *host)
 {
 	int ret = 0;
 
-	pipe_info(p, "pipeline_reset()");
+	pipe_info(p, "pipe reset");
 
 	ret = pipeline_comp_reset(host, NULL, p, host->direction);
 	if (ret < 0) {

--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -203,7 +203,7 @@ static struct comp_dev *volume_new(const struct comp_driver *drv,
 	int i;
 	int ret;
 
-	comp_cl_info(&comp_volume, "volume_new()");
+	comp_cl_dbg(&comp_volume, "volume_new()");
 
 	dev = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM,
 		      COMP_SIZE(struct sof_ipc_comp_volume));
@@ -493,8 +493,8 @@ static int volume_ctrl_set_cmd(struct comp_dev *dev,
 
 	switch (cdata->cmd) {
 	case SOF_CTRL_CMD_VOLUME:
-		comp_info(dev, "volume_ctrl_set_cmd(), SOF_CTRL_CMD_VOLUME, cdata->comp_id = %u",
-			  cdata->comp_id);
+		comp_dbg(dev, "volume_ctrl_set_cmd(), SOF_CTRL_CMD_VOLUME, cdata->comp_id = %u",
+			 cdata->comp_id);
 		for (j = 0; j < cdata->num_elems; j++) {
 			ch = cdata->chanv[j].channel;
 			val = cdata->chanv[j].value;
@@ -526,8 +526,8 @@ static int volume_ctrl_set_cmd(struct comp_dev *dev,
 		break;
 
 	case SOF_CTRL_CMD_SWITCH:
-		comp_info(dev, "volume_ctrl_set_cmd(), SOF_CTRL_CMD_SWITCH, cdata->comp_id = %u",
-			  cdata->comp_id);
+		comp_dbg(dev, "volume_ctrl_set_cmd(), SOF_CTRL_CMD_SWITCH, cdata->comp_id = %u",
+			 cdata->comp_id);
 		for (j = 0; j < cdata->num_elems; j++) {
 			ch = cdata->chanv[j].channel;
 			val = cdata->chanv[j].value;
@@ -584,8 +584,8 @@ static int volume_ctrl_get_cmd(struct comp_dev *dev,
 
 	if (cdata->cmd == SOF_CTRL_CMD_VOLUME ||
 	    cdata->cmd ==  SOF_CTRL_CMD_SWITCH) {
-		comp_info(dev, "volume_ctrl_get_cmd(), SOF_CTRL_CMD_VOLUME / SOF_CTRL_CMD_SWITCH, cdata->comp_id = %u",
-			  cdata->comp_id);
+		comp_dbg(dev, "volume_ctrl_get_cmd(), SOF_CTRL_CMD_VOLUME / SOF_CTRL_CMD_SWITCH, cdata->comp_id = %u",
+			 cdata->comp_id);
 		for (j = 0; j < cdata->num_elems; j++) {
 			cdata->chanv[j].channel = j;
 			cdata->chanv[j].value = cd->tvolume[j];
@@ -613,7 +613,7 @@ static int volume_cmd(struct comp_dev *dev, int cmd, void *data,
 {
 	struct sof_ipc_ctrl_data *cdata = data;
 
-	comp_info(dev, "volume_cmd()");
+	comp_dbg(dev, "volume_cmd()");
 
 	switch (cmd) {
 	case COMP_CMD_SET_VALUE:
@@ -633,7 +633,7 @@ static int volume_cmd(struct comp_dev *dev, int cmd, void *data,
  */
 static int volume_trigger(struct comp_dev *dev, int cmd)
 {
-	comp_info(dev, "volume_trigger()");
+	comp_dbg(dev, "volume_trigger()");
 
 	return comp_set_state(dev, cmd);
 }
@@ -703,7 +703,7 @@ static int volume_prepare(struct comp_dev *dev)
 	int i;
 	int ret;
 
-	comp_info(dev, "volume_prepare()");
+	comp_dbg(dev, "volume_prepare()");
 
 	ret = comp_set_state(dev, COMP_TRIGGER_PREPARE);
 	if (ret < 0)
@@ -767,7 +767,7 @@ err:
  */
 static int volume_reset(struct comp_dev *dev)
 {
-	comp_info(dev, "volume_reset()");
+	comp_dbg(dev, "volume_reset()");
 
 	comp_set_state(dev, COMP_TRIGGER_RESET);
 	return 0;

--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -367,15 +367,15 @@ static inline int volume_set_chan(struct comp_dev *dev, int chan,
 	 */
 	if (v < VOL_MIN) {
 		/* No need to fail, just trace the event. */
-		comp_err(dev, "volume_set_chan: Limited request %d to min. %d",
-			 v, VOL_MIN);
+		comp_warn(dev, "volume_set_chan: Limited request %d to min. %d",
+			  v, VOL_MIN);
 		v = VOL_MIN;
 	}
 
 	if (v > VOL_MAX) {
 		/* No need to fail, just trace the event. */
-		comp_err(dev, "volume_set_chan: Limited request %d to max. %d",
-			 v, VOL_MAX);
+		comp_warn(dev, "volume_set_chan: Limited request %d to max. %d",
+			  v, VOL_MAX);
 		v = VOL_MAX;
 	}
 


### PR DESCRIPTION
Specific component tracepoints are useful for topology bringup phase but later there are just errors interesting, therefore the tracepoints are moved to dbg level while their parent pipeline event traces (when important properties are logged) seems sufficient to observe the ongoing activities. Component 'new' is logged on the infrastructure level using component uuids.