### PR TITLE
probe: Properly report response code and size of arrays in INFO payloads

### DIFF
--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -918,6 +918,7 @@ static int ipc_probe_info(uint32_t header)
 	/* write data to the outbox */
 	if (params->rhdr.hdr.size <= MAILBOX_HOSTBOX_SIZE &&
 	    params->rhdr.hdr.size <= SOF_IPC_MSG_MAX_SIZE) {
+		params->rhdr.error = ret;
 		mailbox_hostbox_write(0, params, params->rhdr.hdr.size);
 		ret = 1;
 	} else {

--- a/src/probe/probe.c
+++ b/src/probe/probe.c
@@ -423,6 +423,8 @@ int probe_dma_info(struct sof_ipc_probe_info_params *data, uint32_t max_size)
 		i++;
 	}
 
+	data->num_elems = j;
+
 	return 1;
 }
 
@@ -1048,6 +1050,8 @@ int probe_point_info(struct sof_ipc_probe_info_params *data, uint32_t max_size)
 
 		i++;
 	}
+
+	data->num_elems = j;
 
 	return 1;
 }


### PR DESCRIPTION
Status (error) code in custom Probe responses is now reported properly.
Size of flexible arrays in Probe INFO responses is now reposted properly.

Signed-off-by: ArturX Kloniecki <arturx.kloniecki@linux.intel.com>