### PR TITLE
Testbench add process components support

### DIFF
--- a/src/audio/CMakeLists.txt
+++ b/src/audio/CMakeLists.txt
@@ -104,12 +104,14 @@ check_optimization(fma -mfma -DOPS_FMA)
 check_optimization(hifi2ep -mhifi2ep -DOPS_HIFI2EP)
 check_optimization(hifi3 -mhifi3 -DOPS_HIFI3)
 
-set(sof_audio_modules volume src asrc)
+set(sof_audio_modules volume src asrc eq-fir eq-iir)
 
 # sources for each module
 set(volume_sources volume/volume.c volume/volume_generic.c)
 set(src_sources src/src.c src/src_generic.c)
 set(asrc_sources asrc/asrc.c asrc/asrc_farrow.c asrc/asrc_farrow_generic.c)
+set(eq-fir_sources eq_fir/eq_fir.c eq_fir/fir.c)
+set(eq-iir_sources eq_iir/eq_iir.c eq_iir/iir.c eq_iir/iir_generic.c)
 
 foreach(audio_module ${sof_audio_modules})
 	# first compile with no optimizations

--- a/tools/fuzzer/topology.c
+++ b/tools/fuzzer/topology.c
@@ -110,14 +110,15 @@ static int load_graph(void *dev, struct comp_info *temp_comp_list,
 }
 
 /* load buffer DAPM widget */
-int load_buffer(void *dev, int comp_id, int pipeline_id, int size)
+int load_buffer(void *dev, int comp_id, int pipeline_id,
+		struct snd_soc_tplg_dapm_widget *widget)
 {
 	struct sof_ipc_buffer buffer;
 	struct fuzz *fuzzer = (struct fuzz *)dev;
 	struct sof_ipc_comp_reply r;
 	int ret;
 
-	ret = tplg_load_buffer(comp_id, pipeline_id, size, &buffer,
+	ret = tplg_load_buffer(comp_id, pipeline_id, widget->priv.size, &buffer,
 			       fuzzer->tplg_file);
 	if (ret < 0)
 		return ret;
@@ -163,9 +164,9 @@ static int load_pcm(void *dev, int comp_id, int pipeline_id, int size, int dir)
 }
 
 int load_aif_in_out(void *dev, int comp_id, int pipeline_id,
-		    int size, int dir, void *tp)
+		    struct snd_soc_tplg_dapm_widget *widget, int dir, void *tp)
 {
-	return load_pcm(dev, comp_id, pipeline_id, size, dir);
+	return load_pcm(dev, comp_id, pipeline_id, widget->priv.size, dir);
 }
 
 /* load dai component */
@@ -196,20 +197,21 @@ static int load_dai(struct fuzz *fuzzer, int comp_id, int pipeline_id,
 }
 
 int load_dai_in_out(void *dev, int comp_id, int pipeline_id,
-		    int size, int dir, void *tp)
+		    struct snd_soc_tplg_dapm_widget *widget, int dir, void *tp)
 {
-	return load_dai(dev, comp_id, pipeline_id, size);
+	return load_dai(dev, comp_id, pipeline_id, widget->priv.size);
 }
 
 /* load pda dapm widget */
-int load_pga(void *dev, int comp_id, int pipeline_id, int size)
+int load_pga(void *dev, int comp_id, int pipeline_id,
+	     struct snd_soc_tplg_dapm_widget *widget)
 {
 	struct fuzz *fuzzer = (struct fuzz *)dev;
 	struct sof_ipc_comp_volume volume;
 	struct sof_ipc_comp_reply r;
 	int ret = 0;
 
-	ret = tplg_load_pga(comp_id, pipeline_id, size, &volume,
+	ret = tplg_load_pga(comp_id, pipeline_id, widget->priv.size, &volume,
 			    fuzzer->tplg_file);
 	if (ret < 0)
 		return ret;
@@ -228,16 +230,16 @@ int load_pga(void *dev, int comp_id, int pipeline_id, int size)
 }
 
 /* load scheduler dapm widget */
-int load_pipeline(void *dev, int comp_id, int pipeline_id, int size,
-		  int sched_id)
+int load_pipeline(void *dev, int comp_id, int pipeline_id,
+		  struct snd_soc_tplg_dapm_widget *widget, int sched_id)
 {
 	struct sof_ipc_pipe_new pipeline;
 	struct fuzz *fuzzer = (struct fuzz *)dev;
 	struct sof_ipc_comp_reply r;
 	int ret;
 
-	ret = tplg_load_pipeline(comp_id, pipeline_id, size, &pipeline,
-				 fuzzer->tplg_file);
+	ret = tplg_load_pipeline(comp_id, pipeline_id, widget->priv.size,
+				 &pipeline, fuzzer->tplg_file);
 	if (ret < 0)
 		return ret;
 
@@ -258,15 +260,15 @@ int load_pipeline(void *dev, int comp_id, int pipeline_id, int size,
 }
 
 /* load src dapm widget */
-int load_src(void *dev, int comp_id, int pipeline_id, int size,
-	     void *params)
+int load_src(void *dev, int comp_id, int pipeline_id,
+	     struct snd_soc_tplg_dapm_widget *widget, void *params)
 {
 	struct fuzz *fuzzer = (struct fuzz *)dev;
 	struct sof_ipc_comp_src src = {0};
 	struct sof_ipc_comp_reply r;
 	int ret = 0;
 
-	ret = tplg_load_src(comp_id, pipeline_id, size, &src,
+	ret = tplg_load_src(comp_id, pipeline_id, widget->priv.size, &src,
 			    fuzzer->tplg_file);
 	if (ret < 0)
 		return ret;
@@ -286,15 +288,15 @@ int load_src(void *dev, int comp_id, int pipeline_id, int size,
 }
 
 /* load asrc dapm widget */
-int load_asrc(void *dev, int comp_id, int pipeline_id, int size,
-	      void *params)
+int load_asrc(void *dev, int comp_id, int pipeline_id,
+	      struct snd_soc_tplg_dapm_widget *widget, void *params)
 {
 	struct fuzz *fuzzer = (struct fuzz *)dev;
 	struct sof_ipc_comp_asrc asrc = {0};
 	struct sof_ipc_comp_reply r;
 	int ret = 0;
 
-	ret = tplg_load_asrc(comp_id, pipeline_id, size, &asrc,
+	ret = tplg_load_asrc(comp_id, pipeline_id, widget->priv.size, &asrc,
 			     fuzzer->tplg_file);
 	if (ret < 0)
 		return ret;
@@ -314,14 +316,15 @@ int load_asrc(void *dev, int comp_id, int pipeline_id, int size,
 }
 
 /* load mixer dapm widget */
-int load_mixer(void *dev, int comp_id, int pipeline_id, int size)
+int load_mixer(void *dev, int comp_id, int pipeline_id,
+	       struct snd_soc_tplg_dapm_widget *widget)
 {
 	struct fuzz *fuzzer = (struct fuzz *)dev;
 	struct sof_ipc_comp_mixer mixer = {0};
 	struct sof_ipc_comp_reply r;
 	int ret = 0;
 
-	ret = tplg_load_mixer(comp_id, pipeline_id, size, &mixer,
+	ret = tplg_load_mixer(comp_id, pipeline_id, widget->priv.size, &mixer,
 			      fuzzer->tplg_file);
 	if (ret < 0)
 		return ret;
@@ -338,6 +341,13 @@ int load_mixer(void *dev, int comp_id, int pipeline_id, int size)
 		fprintf(stderr, "error: message tx failed\n");
 
 	return ret;
+}
+
+/* load effect dapm widget */
+int load_process(void *dev, int comp_id, int pipeline_id,
+		 struct snd_soc_tplg_dapm_widget *widget)
+{
+	return -EINVAL; /* Not implemented */
 }
 
 /* parse topology file and set up pipeline */

--- a/tools/test/audio/asrc_run.sh
+++ b/tools/test/audio/asrc_run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright(c) 2018-2020 Intel Corporation. All rights reserved.
+# Copyright(c) 2020 Intel Corporation. All rights reserved.
 
 if [ -z "$6" ]; then
     echo "Usage:   $0 <bits in> <bits out> <rate in> <rate out> <input> <output>"
@@ -8,7 +8,7 @@ if [ -z "$6" ]; then
     exit
 fi
 
-COMP=src
+COMP=asrc
 DIRECTION=playback
 
 ./comp_run.sh $COMP $DIRECTION $1 $2 $3 $4 $5 $6

--- a/tools/test/audio/comp_run.sh
+++ b/tools/test/audio/comp_run.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2018-2020 Intel Corporation. All rights reserved.
+
+COMP=$1
+DIRECTION=$2
+BITS_IN=$3
+BITS_OUT=$4
+FS1=$5
+FS2=$6
+FN_IN=$7
+FN_OUT=$8
+
+# Paths
+HOST_ROOT=../../testbench/build_testbench
+HOST_EXE=$HOST_ROOT/install/bin/testbench
+HOST_LIB=$HOST_ROOT/sof_ep/install/lib
+TPLG_LIB=$HOST_ROOT/sof_parser/install/lib
+TPLG_DIR=../../test/topology
+
+# Use topology from component test topologies
+INFMT=s${BITS_IN}le
+OUTFMT=s${BITS_OUT}le
+TPLGFN=test-${DIRECTION}-ssp5-mclk-0-I2S-${COMP}-${INFMT}-${OUTFMT}-48k-24576k-codec.tplg
+TPLG=${TPLG_DIR}/${TPLGFN}
+
+# If binary test vectors
+if [ ${FN_IN: -4} == ".raw" ]; then
+    BINFMT="-b S${BITS_IN}_LE"
+else
+    BINFMT=""
+fi
+
+# Run command
+# There is no more need to specify the library explicitly
+#LIB="-a ${COMP}=libsof_${COMP}.so"
+LIB=""
+ARG="-d -r $FS1 -R $FS2 -i $FN_IN -o $FN_OUT -t $TPLG $BINFMT $LIB"
+CMD="$HOST_EXE $ARG"
+export LD_LIBRARY_PATH=$HOST_LIB:$TPLG_LIB
+
+# Run test bench
+echo "Command:         $HOST_EXE"
+echo "Argument:        $ARG"
+echo "LD_LIBRARY_PATH: ${LD_LIBRARY_PATH}"
+
+$CMD

--- a/tools/test/audio/eqfir_run.sh
+++ b/tools/test/audio/eqfir_run.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2020 Intel Corporation. All rights reserved.
+
+if [ -z "$5" ]; then
+    echo "Usage:   $0 <bits in> <bits out> <rate> <input> <output>"
+    echo "Example: $0 16 16 48000 input.raw output.raw"
+    exit
+fi
+
+COMP=eq-fir
+DIRECTION=playback
+
+./comp_run.sh $COMP $DIRECTION $1 $2 $3 $3 $4 $5

--- a/tools/test/audio/eqiir_run.sh
+++ b/tools/test/audio/eqiir_run.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2020 Intel Corporation. All rights reserved.
+
+if [ -z "$5" ]; then
+    echo "Usage:   $0 <bits in> <bits out> <rate> <input> <output>"
+    echo "Example: $0 16 16 48000 input.raw output.raw"
+    exit
+fi
+
+
+COMP=eq-iir
+DIRECTION=playback
+
+./comp_run.sh $COMP $DIRECTION $1 $2 $3 $3 $4 $5

--- a/tools/test/audio/volume_run.sh
+++ b/tools/test/audio/volume_run.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2020 Intel Corporation. All rights reserved.
+
+if [ -z "$5" ]; then
+    echo "Usage:   $0 <bits in> <bits out> <rate> <input> <output>"
+    echo "Example: $0 16 16 48000 input.raw output.raw"
+    exit
+fi
+
+
+COMP=volume
+DIRECTION=playback
+
+./comp_run.sh $COMP $DIRECTION $1 $2 $3 $3 $4 $5

--- a/tools/testbench/file.c
+++ b/tools/testbench/file.c
@@ -49,8 +49,11 @@ static int read_samples_32(struct comp_dev *dev,
 	struct file_comp_data *cd = comp_get_drvdata(dev);
 	int32_t *dest = (int32_t *)sink->w_ptr;
 	int32_t sample;
+	int n_wrap;
+	int n_min;
+	int i;
 	int n_samples = 0;
-	int i, n_wrap, n_min, ret;
+	int ret = 0;
 
 	while (n > 0) {
 		n_wrap = (int32_t *)sink->end_addr - dest;

--- a/tools/testbench/include/testbench/common_test.h
+++ b/tools/testbench/include/testbench/common_test.h
@@ -18,7 +18,7 @@
 #define MAX_LIB_NAME_LEN	256
 
 /* number of widgets types supported in testbench */
-#define NUM_WIDGETS_SUPPORTED	4
+#define NUM_WIDGETS_SUPPORTED	6
 
 struct testbench_prm {
 	char *tplg_file; /* topology file to use */

--- a/tools/topology/sof/pipe-eq-fir-capture.m4
+++ b/tools/topology/sof/pipe-eq-fir-capture.m4
@@ -68,8 +68,8 @@ P_GRAPH(pipe-pass-capture-PIPELINE_ID, PIPELINE_ID,
 #
 # Pipeline Source and Sinks
 #
-indir(`define', concat(`PIPELINE_SINK_', PIPELINE_ID), N_BUFFER(2))
-indir(`define', concat(`PIPELINE_PCM_', PIPELINE_ID), Highpass Capture PCM_ID)
+indir(`define', concat(`PIPELINE_SINK_', PIPELINE_ID), N_BUFFER(1))
+indir(`define', concat(`PIPELINE_PCM_', PIPELINE_ID), EQ FIR Capture PCM_ID)
 
 #
 # PCM Configuration

--- a/tools/topology/sof/pipe-eq-iir-capture.m4
+++ b/tools/topology/sof/pipe-eq-iir-capture.m4
@@ -68,8 +68,8 @@ P_GRAPH(pipe-pass-capture-PIPELINE_ID, PIPELINE_ID,
 #
 # Pipeline Source and Sinks
 #
-indir(`define', concat(`PIPELINE_SINK_', PIPELINE_ID), N_BUFFER(2))
-indir(`define', concat(`PIPELINE_PCM_', PIPELINE_ID), Highpass Capture PCM_ID)
+indir(`define', concat(`PIPELINE_SINK_', PIPELINE_ID), N_BUFFER(1))
+indir(`define', concat(`PIPELINE_PCM_', PIPELINE_ID), EQ IIR Capture PCM_ID)
 
 #
 # PCM Configuration

--- a/tools/tplg_parser/CMakeLists.txt
+++ b/tools/tplg_parser/CMakeLists.txt
@@ -9,6 +9,7 @@ set(sof_source_directory "${PROJECT_SOURCE_DIR}/../..")
 add_library(sof_tplg_parser SHARED tplg_parser.c)
 target_include_directories(sof_tplg_parser PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_include_directories(sof_tplg_parser PRIVATE ${sof_source_directory}/src/include)
+target_compile_options(sof_tplg_parser PRIVATE -g -O -Wall -Werror -Wl,-EL -Wmissing-prototypes -Wimplicit-fallthrough=3)
 
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/tplg_parser
 	DESTINATION include

--- a/tools/tplg_parser/include/tplg_parser/topology.h
+++ b/tools/tplg_parser/include/tplg_parser/topology.h
@@ -42,6 +42,18 @@ static const struct frame_types sof_frames[] = {
 	{"FLOAT_LE", SOF_IPC_FRAME_FLOAT},
 };
 
+/** \brief Types of processing components */
+enum sof_ipc_process_type {
+	SOF_PROCESS_NONE = 0,		/**< None */
+	SOF_PROCESS_EQFIR,		/**< Intel FIR */
+	SOF_PROCESS_EQIIR,		/**< Intel IIR */
+	SOF_PROCESS_KEYWORD_DETECT,	/**< Keyword Detection */
+	SOF_PROCESS_KPB,		/**< KeyPhrase Buffer Manager */
+	SOF_PROCESS_CHAN_SELECTOR,	/**< Channel Selector */
+	SOF_PROCESS_MUX,
+	SOF_PROCESS_DEMUX,
+};
+
 struct sof_topology_token {
 	uint32_t token;
 	uint32_t type;
@@ -124,6 +136,16 @@ static const struct sof_topology_token asrc_tokens[] = {
 		offsetof(struct sof_ipc_comp_asrc, operation_mode), 0},
 };
 
+/* EFFECT */
+int get_token_process_type(void *elem, void *object, uint32_t offset,
+			   uint32_t size);
+
+static const struct sof_topology_token process_tokens[] = {
+	{SOF_TKN_PROCESS_TYPE, SND_SOC_TPLG_TUPLE_TYPE_STRING,
+		get_token_process_type,
+		offsetof(struct sof_ipc_comp_process, type), 0},
+};
+
 /* Tone */
 static const struct sof_topology_token tone_tokens[] = {
 };
@@ -199,6 +221,8 @@ int tplg_load_pga(int comp_id, int pipeline_id, int size,
 		  struct sof_ipc_comp_volume *volume, FILE *file);
 int tplg_load_pipeline(int comp_id, int pipeline_id, int size,
 		       struct sof_ipc_pipe_new *pipeline, FILE *file);
+int tplg_load_one_control(struct snd_soc_tplg_ctl_hdr **ctl, char **priv,
+			  FILE *file);
 int tplg_load_controls(int num_kcontrols, FILE *file);
 int tplg_load_src(int comp_id, int pipeline_id, int size,
 		  struct sof_ipc_comp_src *src, FILE *file);
@@ -206,25 +230,38 @@ int tplg_load_asrc(int comp_id, int pipeline_id, int size,
 		   struct sof_ipc_comp_asrc *asrc, FILE *file);
 int tplg_load_mixer(int comp_id, int pipeline_id, int size,
 		    struct sof_ipc_comp_mixer *mixer, FILE *file);
+int tplg_load_process(int comp_id, int pipeline_id, int size,
+		      struct sof_ipc_comp_process *process, FILE *file);
 int tplg_load_graph(int num_comps, int pipeline_id,
 		    struct comp_info *temp_comp_list, char *pipeline_string,
 		    struct sof_ipc_pipe_comp_connect *connection, FILE *file,
 		    int route_num, int count);
 
-int load_pga(void *dev, int comp_id, int pipeline_id, int size);
+int load_pga(void *dev, int comp_id, int pipeline_id,
+	     struct snd_soc_tplg_dapm_widget *widget);
+
 int load_aif_in_out(void *dev, int comp_id, int pipeline_id,
-		    int size, int dir, void *tp);
+		    struct snd_soc_tplg_dapm_widget *widget, int dir, void *tp);
 int load_dai_in_out(void *dev, int comp_id, int pipeline_id,
-		    int size, int dir, void *tp);
-int load_buffer(void *dev, int comp_id, int pipeline_id, int size);
-int load_pipeline(void *dev, int comp_id, int pipeline_id, int size,
+		    struct snd_soc_tplg_dapm_widget *widget, int dir, void *tp);
+int load_buffer(void *dev, int comp_id, int pipeline_id,
+		struct snd_soc_tplg_dapm_widget *widget);
+int load_pipeline(void *dev, int comp_id, int pipeline_id,
+		  struct snd_soc_tplg_dapm_widget *widget,
 		  int sched_id);
-int load_src(void *dev, int comp_id, int pipeline_id, int size, void *params);
-int load_asrc(void *dev, int comp_id, int pipeline_id, int size, void *params);
-int load_mixer(void *dev, int comp_id, int pipeline_id, int size);
+int load_src(void *dev, int comp_id, int pipeline_id,
+	     struct snd_soc_tplg_dapm_widget *widget, void *params);
+int load_asrc(void *dev, int comp_id, int pipeline_id,
+	      struct snd_soc_tplg_dapm_widget *widget, void *params);
+int load_mixer(void *dev, int comp_id, int pipeline_id,
+	       struct snd_soc_tplg_dapm_widget *widget);
+int load_process(void *dev, int comp_id, int pipeline_id,
+		 struct snd_soc_tplg_dapm_widget *widget);
 int load_widget(void *dev, int dev_type, struct comp_info *temp_comp_list,
 		int comp_id, int comp_index, int pipeline_id, void *tp,
 		int *sched_id, FILE *file);
+
 void register_comp(int comp_type);
 int find_widget(struct comp_info *temp_comp_list, int count, char *name);
+
 #endif


### PR DESCRIPTION
Here's a cleaned up and more complete version of testbench PR. It consists of these commits:

- Testbench: Add processing component load
- Testbench: Fix possible uninitialized use of variable ret
- Testbench: Build topology parser with debug symbols
- Tools: Test: Cleanup component run scripts
- Topology: Fix in EQ only pipelines with macro PIPELINE_SINK


 
 