### PR TITLE
probe: free extraction task in deinit and properly clear probe ptr

### DIFF
--- a/src/probe/probe.c
+++ b/src/probe/probe.c
@@ -311,14 +311,15 @@ int probe_deinit(void)
 	}
 
 	if (_probe->ext_dma.stream_tag != PROBE_DMA_INVALID) {
-		tracev_probe("probe_deinit() Freeing extraction DMA.");
+		tracev_probe("probe_deinit() Freeing task and extraction DMA.");
+		schedule_task_free(&_probe->dmap_work);
 		err = probe_dma_deinit(&_probe->ext_dma);
 		if (err < 0)
 			return err;
 	}
 
+	sof_get()->probe = NULL;
 	rfree(_probe);
-	_probe = NULL;
 
 	return 0;
 }


### PR DESCRIPTION
This will fix probe deinit and free all used memory

Signed-off-by: Adrian Bonislawski <adrian.bonislawski@linux.intel.com>