### PR TITLE
probes-app: build the app with sof tools

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -14,6 +14,7 @@ project(SOF_TOOLS C)
 
 set(SOF_ROOT_SOURCE_DIRECTORY "${PROJECT_SOURCE_DIR}/..")
 
+add_subdirectory(probes)
 add_subdirectory(logger)
 add_subdirectory(ctl)
 add_subdirectory(topology)


### PR DESCRIPTION
this will allow to build probe app from scripts/build-tools.sh

Signed-off-by: Adrian Bonislawski <adrian.bonislawski@linux.intel.com>