### PR TITLE
cc_version: use fixed length for CC_DESC

### DIFF
--- a/src/include/ipc/info.h
+++ b/src/include/ipc/info.h
@@ -120,9 +120,9 @@ struct sof_ipc_cc_version {
 	/* reserved for future use */
 	uint32_t reserved[4];
 
-	char name[16]; /* null terminated compiler name */
-	char optim[4]; /* null terminated compiler -O flag value */
-	char desc[]; /* null terminated compiler description */
+	uint8_t name[16]; /* null terminated compiler name */
+	uint8_t optim[4]; /* null terminated compiler -O flag value */
+	uint8_t desc[]; /* null terminated compiler description */
 } __attribute__((packed));
 
 /* extended data: Probe setup */

--- a/src/include/ipc/info.h
+++ b/src/include/ipc/info.h
@@ -122,7 +122,7 @@ struct sof_ipc_cc_version {
 
 	uint8_t name[16]; /* null terminated compiler name */
 	uint8_t optim[4]; /* null terminated compiler -O flag value */
-	uint8_t desc[]; /* null terminated compiler description */
+	uint8_t desc[32]; /* null terminated compiler description */
 } __attribute__((packed));
 
 /* extended data: Probe setup */

--- a/src/include/kernel/abi.h
+++ b/src/include/kernel/abi.h
@@ -29,7 +29,7 @@
 
 /** \brief SOF ABI version major, minor and patch numbers */
 #define SOF_ABI_MAJOR 3
-#define SOF_ABI_MINOR 14
+#define SOF_ABI_MINOR 15
 #define SOF_ABI_PATCH 0
 
 /** \brief SOF ABI version number. Format within 32bit word is MMmmmppp */

--- a/src/ipc/cc_version.c
+++ b/src/ipc/cc_version.c
@@ -19,12 +19,16 @@
 	field = CC_OPTIMIZE_FLAGS, \
 	field[ARRAY_SIZE(((struct sof_ipc_cc_version *)(0))->optim) - 1] = 0
 
+/* copy CC_DESC to arrays during compilation time */
+#define CC_DESC_COPY(field) \
+	field = CC_DESC, \
+	field[ARRAY_SIZE(((struct sof_ipc_cc_version *)(0))->desc) - 1] = 0
+
 const struct sof_ipc_cc_version cc_version
 	__section(".fw_ready_metadata") = {
 	.ext_hdr = {
 		.hdr.cmd = SOF_IPC_FW_READY,
-		.hdr.size = ALIGN_UP(sizeof(struct sof_ipc_cc_version)
-				     + sizeof(CC_DESC), 4),
+		.hdr.size = sizeof(struct sof_ipc_cc_version),
 		.type = SOF_IPC_EXT_CC_INFO,
 	},
 	.micro = CC_MICRO,
@@ -32,5 +36,5 @@ const struct sof_ipc_cc_version cc_version
 	.major = CC_MAJOR,
 	CC_NAME_COPY(.name),
 	CC_OPTIM_COPY(.optim),
-	.desc = CC_DESC,
+	CC_DESC_COPY(.desc),
 };


### PR DESCRIPTION
Fix ABI version to 3.15.0 on master first.

There is a bug in the Cadence XCC compiler that give us different
linkage section sizes for flex length struct sof_ipc_ext_data in
ELF file compared to GCC version. And there are appending struct
in the same ELF section, this will bring wrong offset for those
struct binary in ELF file.

Example:
When the CC_DESC is " RG-2017.8-linux", we should have struct
length for 0x50 in header size, but the binary length in ELF file
is 0x4c. When the CC_DESC is " RG-2017.8-win", size are both 0x4c

All existing compiler description has length less than
24 bytes. So use a fixed length 24 in this structure.

ABI version 3.16.0

Signed-off-by: Pan Xiuli <xiuli.pan@linux.intel.com>

fix https://github.com/thesofproject/sof/issues/2507