### PR TITLE
buffer: fix locking

### DIFF
--- a/src/audio/asrc/asrc.c
+++ b/src/audio/asrc/asrc.c
@@ -835,8 +835,8 @@ static int asrc_copy(struct comp_dev *dev)
 	sink = list_first_item(&dev->bsink_list, struct comp_buffer,
 			       source_list);
 
-	buffer_lock(source, flags);
-	buffer_lock(sink, flags);
+	buffer_lock(source, &flags);
+	buffer_lock(sink, &flags);
 
 	frames_src = source->stream.avail /
 		     audio_stream_frame_bytes(&source->stream);

--- a/src/audio/buffer.c
+++ b/src/audio/buffer.c
@@ -163,7 +163,7 @@ void comp_update_buffer_produce(struct comp_buffer *buffer, uint32_t bytes)
 		return;
 	}
 
-	buffer_lock(buffer, flags);
+	buffer_lock(buffer, &flags);
 
 	audio_stream_produce(&buffer->stream, bytes);
 
@@ -206,7 +206,7 @@ void comp_update_buffer_consume(struct comp_buffer *buffer, uint32_t bytes)
 		return;
 	}
 
-	buffer_lock(buffer, flags);
+	buffer_lock(buffer, &flags);
 
 	audio_stream_consume(&buffer->stream, bytes);
 

--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -263,7 +263,7 @@ int comp_verify_params(struct comp_dev *dev, uint32_t flag,
 					      struct comp_buffer,
 					      source_list);
 
-		buffer_lock(buf, flags);
+		buffer_lock(buf, &flags);
 
 		/* update specific pcm parameter with buffer parameter if
 		 * specific flag is set.
@@ -291,7 +291,7 @@ int comp_verify_params(struct comp_dev *dev, uint32_t flag,
 
 			buf = buffer_from_list(curr, struct comp_buffer, dir);
 
-			buffer_lock(buf, flags);
+			buffer_lock(buf, &flags);
 
 			clist = clist->next;
 
@@ -306,7 +306,7 @@ int comp_verify_params(struct comp_dev *dev, uint32_t flag,
 		sinkb = list_first_item(&dev->bsink_list, struct comp_buffer,
 					source_list);
 
-		buffer_lock(sinkb, flags);
+		buffer_lock(sinkb, &flags);
 
 		component_set_period_frames(dev, sinkb->stream.rate);
 

--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -670,7 +670,7 @@ static int dai_copy(struct comp_dev *dev)
 		return ret;
 	}
 
-	buffer_lock(dd->local_buffer, flags);
+	buffer_lock(dd->local_buffer, &flags);
 
 	/* calculate minimum size to copy */
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK) {

--- a/src/audio/detect_test.c
+++ b/src/audio/detect_test.c
@@ -738,7 +738,7 @@ static int test_keyword_copy(struct comp_dev *dev)
 	source = list_first_item(&dev->bsource_list,
 				 struct comp_buffer, sink_list);
 
-	buffer_lock(source, flags);
+	buffer_lock(source, &flags);
 	frames = source->stream.avail /
 		audio_stream_frame_bytes(&source->stream);
 	buffer_unlock(source, flags);

--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -741,8 +741,8 @@ static int eq_fir_copy(struct comp_dev *dev)
 	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer,
 				source_list);
 
-	buffer_lock(sourceb, flags);
-	buffer_lock(sinkb, flags);
+	buffer_lock(sourceb, &flags);
+	buffer_lock(sinkb, &flags);
 
 	/* Get source, sink, number of frames etc. to process. */
 	comp_get_copy_limits(sourceb, sinkb, &cl);

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -830,8 +830,8 @@ static int eq_iir_copy(struct comp_dev *dev)
 	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer,
 				source_list);
 
-	buffer_lock(sourceb, flags);
-	buffer_lock(sinkb, flags);
+	buffer_lock(sourceb, &flags);
+	buffer_lock(sinkb, &flags);
 
 	/* Get source, sink, number of frames etc. to process. */
 	comp_get_copy_limits(sourceb, sinkb, &cl);

--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -706,7 +706,7 @@ static uint32_t host_buffer_get_copy_bytes(struct comp_dev *dev)
 	uint32_t flags = 0;
 
 	if (hd->copy_type == COMP_COPY_ONE_SHOT) {
-		buffer_lock(hd->local_buffer, flags);
+		buffer_lock(hd->local_buffer, &flags);
 
 		/* calculate minimum size to copy */
 		if (dev->direction == SOF_IPC_STREAM_PLAYBACK)
@@ -736,7 +736,7 @@ static uint32_t host_buffer_get_copy_bytes(struct comp_dev *dev)
 			return 0;
 		}
 
-		buffer_lock(hd->local_buffer, flags);
+		buffer_lock(hd->local_buffer, &flags);
 
 		/* calculate minimum size to copy */
 		if (dev->direction == SOF_IPC_STREAM_PLAYBACK)

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -616,7 +616,7 @@ static int kpb_copy(struct comp_dev *dev)
 	source = list_first_item(&dev->bsource_list, struct comp_buffer,
 				 sink_list);
 
-	buffer_lock(source, flags);
+	buffer_lock(source, &flags);
 
 	/* Validate source */
 	if (!source || !source->stream.r_ptr) {
@@ -633,7 +633,7 @@ static int kpb_copy(struct comp_dev *dev)
 		/* In normal RUN state we simply copy to our sink. */
 		sink = kpb->sel_sink;
 
-		buffer_lock(sink, flags);
+		buffer_lock(sink, &flags);
 
 		/* Validate sink */
 		if (!sink || !sink->stream.w_ptr) {
@@ -684,7 +684,7 @@ static int kpb_copy(struct comp_dev *dev)
 		/* In host copy state we only copy to host buffer. */
 		sink = kpb->host_sink;
 
-		buffer_lock(sink, flags);
+		buffer_lock(sink, &flags);
 
 		/* Validate sink */
 		if (!sink || !sink->stream.w_ptr) {

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -312,11 +312,11 @@ static int mixer_copy(struct comp_dev *dev)
 	if (num_mix_sources == 0)
 		return 0;
 
-	buffer_lock(sink, flags);
+	buffer_lock(sink, &flags);
 
 	/* check for underruns */
 	for (i = 0; i < num_mix_sources; i++) {
-		buffer_lock(sources[i], flags);
+		buffer_lock(sources[i], &flags);
 		frames = MIN(frames,
 			     audio_stream_avail_frames(sources_stream[i],
 						       &sink->stream));

--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -323,7 +323,7 @@ static int demux_copy(struct comp_dev *dev)
 	source = list_first_item(&dev->bsource_list, struct comp_buffer,
 				 sink_list);
 
-	buffer_lock(source, flags);
+	buffer_lock(source, &flags);
 
 	/* check if source is active */
 	if (source->source->state != dev->state) {
@@ -334,7 +334,7 @@ static int demux_copy(struct comp_dev *dev)
 	for (i = 0; i < MUX_MAX_STREAMS; i++) {
 		if (!sinks[i])
 			continue;
-		buffer_lock(sinks[i], flags);
+		buffer_lock(sinks[i], &flags);
 		avail = audio_stream_avail_frames(&source->stream,
 						  &sinks[i]->stream);
 		frames = MIN(frames, avail);

--- a/src/audio/pipeline.c
+++ b/src/audio/pipeline.c
@@ -310,7 +310,7 @@ static int pipeline_comp_hw_params(struct comp_dev *current,
 
 	/* set buffer parameters */
 	if (calling_buf) {
-		buffer_lock(calling_buf, flags);
+		buffer_lock(calling_buf, &flags);
 		buffer_set_params(calling_buf, &ppl_data->params->params,
 				  BUFFER_UPDATE_IF_UNSET);
 		buffer_unlock(calling_buf, flags);

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -131,7 +131,7 @@ static int selector_verify_params(struct comp_dev *dev,
 		}
 		in_channels = cd->config.in_channels_count;
 
-		buffer_lock(buffer, flags);
+		buffer_lock(buffer, &flags);
 
 		/* if cd->config.out_channels_count are equal to 0
 		 * (it can vary), we set params->channels to sink buffer
@@ -152,7 +152,7 @@ static int selector_verify_params(struct comp_dev *dev,
 		}
 		out_channels = cd->config.out_channels_count;
 
-		buffer_lock(buffer, flags);
+		buffer_lock(buffer, &flags);
 
 		/* if cd->config.in_channels_count are equal to 0
 		 * (it can vary), we set params->channels to source buffer
@@ -392,8 +392,8 @@ static int selector_copy(struct comp_dev *dev)
 	sink = list_first_item(&dev->bsink_list, struct comp_buffer,
 			       source_list);
 
-	buffer_lock(source, flags);
-	buffer_lock(sink, flags);
+	buffer_lock(source, &flags);
+	buffer_lock(sink, &flags);
 
 	frames = audio_stream_avail_frames(&source->stream, &sink->stream);
 	source_bytes = frames * audio_stream_frame_bytes(&source->stream);

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -777,8 +777,8 @@ static int src_copy(struct comp_dev *dev)
 	sink = list_first_item(&dev->bsink_list, struct comp_buffer,
 			       source_list);
 
-	buffer_lock(source, flags);
-	buffer_lock(sink, flags);
+	buffer_lock(source, &flags);
+	buffer_lock(sink, &flags);
 
 	/* Get from buffers and SRC conversion specific block constraints
 	 * how many frames can be processed. If sufficient number of samples

--- a/src/audio/tone.c
+++ b/src/audio/tone.c
@@ -448,8 +448,8 @@ static int tone_params(struct comp_dev *dev,
 	if (config->frame_fmt != SOF_IPC_FRAME_S32_LE)
 		return -EINVAL;
 
-	buffer_lock(sourceb, flags);
-	buffer_lock(sinkb, flags);
+	buffer_lock(sourceb, &flags);
+	buffer_lock(sinkb, &flags);
 
 	sourceb->stream.frame_fmt = config->frame_fmt;
 	sinkb->stream.frame_fmt = config->frame_fmt;
@@ -630,7 +630,7 @@ static int tone_copy(struct comp_dev *dev)
 	sink = list_first_item(&dev->bsink_list, struct comp_buffer,
 			       source_list);
 
-	buffer_lock(sink, flags);
+	buffer_lock(sink, &flags);
 	free = sink->stream.free;
 	buffer_unlock(sink, flags);
 

--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -662,8 +662,8 @@ static int volume_copy(struct comp_dev *dev)
 	sink = list_first_item(&dev->bsink_list, struct comp_buffer,
 			       source_list);
 
-	buffer_lock(source, flags);
-	buffer_lock(sink, flags);
+	buffer_lock(source, &flags);
+	buffer_lock(sink, &flags);
 
 	/* Get source, sink, number of frames etc. to process. */
 	comp_get_copy_limits(source, sink, &c);

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -168,12 +168,12 @@ static inline void buffer_writeback(struct comp_buffer *buffer, uint32_t bytes)
  * @param buffer Buffer instance.
  * @param flags IRQ flags.
  */
-static inline void buffer_lock(struct comp_buffer *buffer, uint32_t flags)
+static inline void buffer_lock(struct comp_buffer *buffer, uint32_t *flags)
 {
 	if (!buffer->inter_core)
 		return;
 
-	spin_lock_irq(buffer->lock, flags);
+	spin_lock_irq(buffer->lock, *flags);
 
 	/* invalidate in case something has changed during our wait */
 	dcache_invalidate_region(buffer, sizeof(*buffer));
@@ -215,7 +215,7 @@ static inline void buffer_reset_pos(struct comp_buffer *buffer, void *data)
 {
 	uint32_t flags = 0;
 
-	buffer_lock(buffer, flags);
+	buffer_lock(buffer, &flags);
 
 	/* reset rw pointers and avail/free bytes counters */
 	audio_stream_reset(&buffer->stream);
@@ -239,7 +239,7 @@ static inline void buffer_reset_params(struct comp_buffer *buffer, void *data)
 {
 	uint32_t flags = 0;
 
-	buffer_lock(buffer, flags);
+	buffer_lock(buffer, &flags);
 
 	buffer->hw_params_configured = false;
 

--- a/src/include/sof/drivers/idc.h
+++ b/src/include/sof/drivers/idc.h
@@ -129,7 +129,7 @@ struct idc {
 static inline struct idc_payload *idc_payload_get(struct idc *idc,
 						  uint32_t core)
 {
-	return idc->payload + cpu_get_id();
+	return idc->payload + core;
 }
 
 void idc_enable_interrupts(int target_core, int source_core);


### PR DESCRIPTION
Fixes buffer_lock function. We need to pass flags by pointer
to use it correctly later to restore correct interrupt level.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>