### PR TITLE
uuid: doc: add more documentation for macros

### DIFF
--- a/src/include/sof/lib/uuid.h
+++ b/src/include/sof/lib/uuid.h
@@ -10,10 +10,16 @@
 
 #include <stdint.h>
 
+/** \addtogroup uuid_api UUID API
+ *  UUID API specification.
+ *  @{
+ */
+
+/** \brief UUID is 16 bytes long */
 #define UUID_SIZE 16
 
 /**
- * \brief UUID (universally unique identifier) structure.
+ * \brief UUID (Universally Unique IDentifier) structure.
  *
  * Use DECLARE_SOF_UUID() to assigned UUID to the fw part (component
  * implementation, dai implementation, ...).
@@ -23,6 +29,9 @@
  * See existing implementation of components and dais for examples how to
  * UUIDs are declared and assigned to the drivers to provide identification
  * of the source for their log entries.
+ *
+ * UUID for a new component may be generated with uuidgen Linux tool, part
+ * of the util-linux package.
  */
 struct sof_uuid {
 	uint32_t a;
@@ -37,7 +46,25 @@ struct sof_uuid {
 			 vd0, vd1, vd2, vd3, vd4, vd5, vd6, vd7)
 
 #define SOF_UUID(uuid_name) 0
+
 #else
+
+/** \brief Declares UUID (aaaaaaaa-bbbb-cccc-d0d1-d2d3d4d5d6d7) and name.
+ *
+ * \param entity_name Name of the object pinted by the software tools.
+ * \param uuid_name Uuid symbol name used with SOF_UUID().
+ * \param va aaaaaaaa value.
+ * \param vb bbbb value.
+ * \param vc cccc value.
+ * \param vd0 d0 value (note how d0 and d1 are grouped in formatted uuid)
+ * \param vd1 d1 value.
+ * \param vd2 d2 value.
+ * \param vd3 d3 value.
+ * \param vd4 d4 value.
+ * \param vd5 d5 value.
+ * \param vd6 d6 value.
+ * \param vd7 d7 value.
+ */
 #define DECLARE_SOF_UUID(entity_name, uuid_name,			\
 			 va, vb, vc,					\
 			 vd0, vd1, vd2, vd3, vd4, vd5, vd6, vd7)	\
@@ -53,6 +80,13 @@ struct sof_uuid {
 		entity_name						\
 	}
 
+/** \brief Creates local unique 32-bit representation of UUID structure.
+ *
+ * \param uuid_name UUID symbol name declared with DECLARE_SOF_UUID().
+ */
 #define SOF_UUID(uuid_name) ((uintptr_t)&(uuid_name))
 #endif
+
+/** @}*/
+
 #endif /* __SOF_LIB_UUID_H__ */


### PR DESCRIPTION
More detailed uuid documentation should be useful for
component developers and others working on named fw
objects (like tasks).

Another patch to sof-docs that refers this API section
and provides detailed description on UUID use in component
overview section.

Signed-off-by: Marcin Maka <marcin.maka@linux.intel.com>