### PR TITLE
[RFC][HACK]: set alh channel = 2 by default

### DIFF
--- a/src/drivers/intel/cavs/alh.c
+++ b/src/drivers/intel/cavs/alh.c
@@ -41,7 +41,7 @@ static int alh_get_hw_params(struct dai *dai,
 {
 	/* 0 means variable */
 	params->rate = 0;
-	params->channels = 0;
+	params->channels = 2;
 	params->buffer_fmt = 0;
 	params->frame_fmt = 0;
 


### PR DESCRIPTION
To avoid it is reset to 0 when second alh is registered to the same
stream.

Signed-off-by: Bard Liao <yung-chuan.liao@linux.intel.com>