### PR TITLE
topology: pipe-volume-demux-playback: Move demux after volume

### DIFF
--- a/tools/topology/sof/pipe-volume-demux-playback.m4
+++ b/tools/topology/sof/pipe-volume-demux-playback.m4
@@ -8,9 +8,9 @@
 #	B2 (DAI buffer)
 #
 #
-#  host PCM_P -- B0 --> Demux(M) -- B1 --> volume -- B2 --> sink DAI0
-#                             |
-#                             pipeline n+1 --> DAI
+#  host PCM_P -- B0 --> volume -- B1 --> Demux(M) -- B2 --> sink DAI0
+#                                              |
+#                                              pipeline n+1 --> DAI
 #
 
 # Include topology builder
@@ -86,10 +86,10 @@ W_BUFFER(2, COMP_BUFFER_SIZE(DAI_PERIODS,
 P_GRAPH(pipe-ll-playback-PIPELINE_ID, PIPELINE_ID,
 	LIST(`		',
 	`dapm(N_BUFFER(0), N_PCMP(PCM_ID))',
-	`dapm(N_MUXDEMUX(0), N_BUFFER(0))',
-	`dapm(N_BUFFER(1), N_MUXDEMUX(0))',
-	`dapm(N_PGA(1), N_BUFFER(1))',
-	`dapm(N_BUFFER(2), N_PGA(1))'))
+	`dapm(N_PGA(1), N_BUFFER(0))',
+	`dapm(N_BUFFER(1), N_PGA(1))',
+	`dapm(N_MUXDEMUX(0), N_BUFFER(1))',
+	`dapm(N_BUFFER(2), N_MUXDEMUX(0))'))
 #
 # Pipeline Source and Sinks
 #


### PR DESCRIPTION
So the volume control will apply to both pipelines.

Signed-off-by: Bard Liao <yung-chuan.liao@linux.intel.com>