### PR TITLE
mailbox: add missing header

### DIFF
--- a/src/platform/baytrail/include/platform/lib/mailbox.h
+++ b/src/platform/baytrail/include/platform/lib/mailbox.h
@@ -12,6 +12,7 @@
 
 #include <sof/lib/memory.h>
 #include <config.h>
+#include <stddef.h>
 #include <stdint.h>
 
 #define MAILBOX_HOST_OFFSET	0x144000

--- a/src/platform/haswell/include/platform/lib/mailbox.h
+++ b/src/platform/haswell/include/platform/lib/mailbox.h
@@ -12,6 +12,7 @@
 
 #include <sof/lib/memory.h>
 #include <config.h>
+#include <stddef.h>
 #include <stdint.h>
 
 #if CONFIG_BROADWELL

--- a/src/platform/imx8/include/platform/lib/mailbox.h
+++ b/src/platform/imx8/include/platform/lib/mailbox.h
@@ -11,6 +11,7 @@
 #define __PLATFORM_LIB_MAILBOX_H__
 
 #include <sof/lib/memory.h>
+#include <stddef.h>
 #include <stdint.h>
 
 /*

--- a/src/platform/imx8m/include/platform/lib/mailbox.h
+++ b/src/platform/imx8m/include/platform/lib/mailbox.h
@@ -11,6 +11,7 @@
 #define __PLATFORM_LIB_MAILBOX_H__
 
 #include <sof/lib/memory.h>
+#include <stddef.h>
 #include <stdint.h>
 
 /*

--- a/src/platform/intel/cavs/include/cavs/lib/mailbox.h
+++ b/src/platform/intel/cavs/include/cavs/lib/mailbox.h
@@ -12,6 +12,7 @@
 #define __CAVS_LIB_MAILBOX_H__
 
 #include <sof/lib/memory.h>
+#include <stddef.h>
 #include <stdint.h>
 
 /*

--- a/src/platform/library/include/platform/lib/mailbox.h
+++ b/src/platform/library/include/platform/lib/mailbox.h
@@ -11,6 +11,7 @@
 #define __PLATFORM_LIB_MAILBOX_H__
 
 #include <sof/lib/memory.h>
+#include <stddef.h>
 #include <stdint.h>
 
 #define MAILBOX_HOST_OFFSET	0x144000


### PR DESCRIPTION
Adds missing header needed for size_t.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>