### PR TITLE
gdb: use mailbox_get_debug_base() macro

### DIFF
--- a/src/debug/gdb/ringbuffer.c
+++ b/src/debug/gdb/ringbuffer.c
@@ -5,13 +5,14 @@
 // Author: Marcin Rajwa <marcin.rajwa@linux.intel.com>
 
 #include <sof/debug/gdb/ringbuffer.h>
-#include <sof/lib/memory.h>
+#include <sof/lib/mailbox.h>
 
 #define BUFFER_OFFSET 0x120
 
-volatile struct ring * const rx = (void *) SRAM_DEBUG_BASE;
-volatile struct ring * const tx = (void *)(SRAM_DEBUG_BASE + BUFFER_OFFSET);
-volatile struct ring * const debug = (void *)(SRAM_DEBUG_BASE +
+volatile struct ring * const rx = (void *)mailbox_get_debug_base();
+volatile struct ring * const tx = (void *)(mailbox_get_debug_base() +
+					   BUFFER_OFFSET);
+volatile struct ring * const debug = (void *)(mailbox_get_debug_base() +
 					      (2 * BUFFER_OFFSET));
 
 void init_buffers(void)


### PR DESCRIPTION
Changes ring buffer to use mailbox_get_debug_base() macro.
It points to the same memory region as previously, but it's
defined for all platforms.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>

Fixes #2248.