### PR TITLE
comp: api: advanced and internal functions separated

### DIFF
--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -4,7 +4,7 @@
 //
 // Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
 
-#include <sof/audio/component.h>
+#include <sof/audio/component_ext.h>
 #include <sof/common.h>
 #include <sof/debug/panic.h>
 #include <sof/drivers/interrupt.h>

--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -6,7 +6,7 @@
 //         Keyon Jie <yang.jie@linux.intel.com>
 
 #include <sof/audio/buffer.h>
-#include <sof/audio/component.h>
+#include <sof/audio/component_ext.h>
 #include <sof/audio/format.h>
 #include <sof/audio/pcm_converter.h>
 #include <sof/audio/pipeline.h>

--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -6,7 +6,7 @@
 //         Keyon Jie <yang.jie@linux.intel.com>
 
 #include <sof/audio/buffer.h>
-#include <sof/audio/component.h>
+#include <sof/audio/component_ext.h>
 #include <sof/audio/pcm_converter.h>
 #include <sof/audio/pipeline.h>
 #include <sof/common.h>

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -15,7 +15,7 @@
  */
 
 #include <sof/audio/buffer.h>
-#include <sof/audio/component.h>
+#include <sof/audio/component_ext.h>
 #include <sof/audio/pipeline.h>
 #include <sof/audio/kpb.h>
 #include <sof/common.h>

--- a/src/audio/pipeline.c
+++ b/src/audio/pipeline.c
@@ -6,7 +6,7 @@
 //         Keyon Jie <yang.jie@linux.intel.com>
 
 #include <sof/audio/buffer.h>
-#include <sof/audio/component.h>
+#include <sof/audio/component_ext.h>
 #include <sof/audio/pipeline.h>
 #include <sof/debug/panic.h>
 #include <sof/drivers/interrupt.h>

--- a/src/drivers/imx/timer.c
+++ b/src/drivers/imx/timer.c
@@ -4,7 +4,7 @@
 //
 // Author: Daniel Baluta <daniel.baluta@nxp.com>
 
-#include <sof/audio/component.h>
+#include <sof/audio/component_ext.h>
 #include <sof/drivers/interrupt.h>
 #include <sof/drivers/timer.h>
 #include <sof/lib/memory.h>

--- a/src/drivers/intel/baytrail/timer.c
+++ b/src/drivers/intel/baytrail/timer.c
@@ -8,7 +8,7 @@
  * Baytrail external timer control.
  */
 
-#include <sof/audio/component.h>
+#include <sof/audio/component_ext.h>
 #include <sof/drivers/interrupt.h>
 #include <sof/drivers/timer.h>
 #include <sof/lib/clk.h>

--- a/src/drivers/intel/cavs/idc.c
+++ b/src/drivers/intel/cavs/idc.c
@@ -4,7 +4,7 @@
 //
 // Author: Tomasz Lauda <tomasz.lauda@linux.intel.com>
 
-#include <sof/audio/component.h>
+#include <sof/audio/component_ext.h>
 #include <sof/audio/pipeline.h>
 #include <sof/debug/panic.h>
 #include <sof/drivers/idc.h>

--- a/src/drivers/intel/cavs/timer.c
+++ b/src/drivers/intel/cavs/timer.c
@@ -7,7 +7,7 @@
 //         Rander Wang <rander.wang@intel.com>
 //         Janusz Jankowski <janusz.jankowski@linux.intel.com>
 
-#include <sof/audio/component.h>
+#include <sof/audio/component_ext.h>
 #include <sof/drivers/interrupt.h>
 #include <sof/drivers/timer.h>
 #include <sof/lib/clk.h>

--- a/src/drivers/intel/haswell/timer.c
+++ b/src/drivers/intel/haswell/timer.c
@@ -4,7 +4,7 @@
 //
 // Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
 
-#include <sof/audio/component.h>
+#include <sof/audio/component_ext.h>
 #include <sof/drivers/interrupt.h>
 #include <sof/drivers/timer.h>
 #include <sof/lib/clk.h>

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -303,11 +303,6 @@ struct comp_driver_info {
 	struct list_item list;		/**< list of component drivers */
 };
 
-/** \brief Holds list of registered components' drivers */
-struct comp_driver_list {
-	struct list_item list;	/**< list of component drivers */
-};
-
 /**
  * Audio component base device "class"
  * - used by other component types.
@@ -448,11 +443,6 @@ static inline struct sof_ipc_comp_config *comp_config(struct sof_ipc_comp *comp)
 #define comp_get_drvdata(c) \
 	c->private
 
-/** \brief Retrieves the component device buffer list. */
-#define comp_buffer_list(comp, dir) \
-	((dir) == PPL_DIR_DOWNSTREAM ? &comp->bsink_list : \
-	 &comp->bsource_list)
-
 /** @}*/
 
 /** \name Declare module macro
@@ -492,51 +482,9 @@ void comp_unregister(struct comp_driver_info *drv);
 
 /** @}*/
 
-/** \name Component creation and destruction - mandatory
- *  @{
- */
-
-/**
- * Creates a new component device.
- * @param comp Parameters of the new component device.
- * @return Pointer to the new component device.
- */
-struct comp_dev *comp_new(struct sof_ipc_comp *comp);
-
-/**
- * Called to delete the specified component device.
- * All data structures previously allocated on the run-time heap
- * must be freed by the implementation of <code>free()</code>.
- * @param dev Component device to be deleted.
- */
-static inline void comp_free(struct comp_dev *dev)
-{
-	assert(dev->drv->ops.free);
-
-	/* free task if shared component */
-	if (dev->is_shared && dev->task) {
-		schedule_task_free(dev->task);
-		rfree(dev->task);
-	}
-
-	dev->drv->ops.free(dev);
-}
-
-/** @}*/
-
 /** \name Component API.
  *  @{
  */
-
-/**
- * Commits component's memory if it's shared.
- * @param dev Component device.
- */
-static inline void comp_shared_commit(struct comp_dev *dev)
-{
-	if (dev->is_shared)
-		platform_shared_commit(dev, sizeof(*dev));
-}
 
 /**
  * Component state set.
@@ -559,357 +507,11 @@ static inline void comp_shared_commit(struct comp_dev *dev)
  */
 int comp_set_state(struct comp_dev *dev, int cmd);
 
-/**
- * Parameter init for component on other core.
- * @param dev Component device.
- * @param params Parameters to be set.
- * @return 0 if succeeded, error code otherwise.
- */
-static inline int comp_params_remote(struct comp_dev *dev,
-				     struct sof_ipc_stream_params *params)
-{
-	struct idc_msg msg = { IDC_MSG_PARAMS, IDC_MSG_PARAMS_EXT(dev->comp.id),
-		dev->comp.core, sizeof(*params), params, };
-
-	return idc_send_msg(&msg, IDC_BLOCKING);
-}
-
-/**
- * Component parameter init.
- * @param dev Component device.
- * @param params Audio (PCM) stream parameters to be set
- * @return 0 if succeeded, error code otherwise.
- */
-static inline int comp_params(struct comp_dev *dev,
-			      struct sof_ipc_stream_params *params)
-{
-	int ret = 0;
-
-	if (dev->drv->ops.params)
-		ret = (dev->is_shared && !cpu_is_me(dev->comp.core)) ?
-			comp_params_remote(dev, params) :
-			dev->drv->ops.params(dev, params);
-
-	comp_shared_commit(dev);
-
-	return ret;
-}
-
-/**
- * Fetch hardware stream parameters - only mandatory for DAI components.
- * @param dev Component device.
- * @param params hw parameters
- * @param dir Pipeline direction (see enum sof_ipc_stream_direction).
- * @return 0 if succeeded, error code otherwise.
- */
-static inline int comp_dai_get_hw_params(struct comp_dev *dev,
-					 struct sof_ipc_stream_params *params,
-					 int dir)
-{
-	int ret = -EINVAL;
-
-	if (dev->drv->ops.dai_get_hw_params)
-		ret = dev->drv->ops.dai_get_hw_params(dev, params, dir);
-
-	comp_shared_commit(dev);
-
-	return ret;
-}
-
-/**
- * Send component command.
- * @param dev Component device.
- * @param cmd Command.
- * @param data Command data.
- * @param max_data_size Max data size.
- * @return 0 if succeeded, error code otherwise.
- */
-static inline int comp_cmd(struct comp_dev *dev, int cmd, void *data,
-			   int max_data_size)
-{
-	struct sof_ipc_ctrl_data *cdata = data;
-	int ret = -EINVAL;
-
-	if (cmd == COMP_CMD_SET_DATA &&
-	    (cdata->data->magic != SOF_ABI_MAGIC ||
-	     SOF_ABI_VERSION_INCOMPATIBLE(SOF_ABI_VERSION, cdata->data->abi))) {
-		comp_err(dev, "comp_cmd() error: invalid version, data->magic = %u, data->abi = %u",
-					 cdata->data->magic, cdata->data->abi);
-		goto out;
-	}
-
-	if (dev->drv->ops.cmd)
-		ret = dev->drv->ops.cmd(dev, cmd, data, max_data_size);
-
-out:
-	comp_shared_commit(dev);
-
-	return ret;
-}
-
-/**
- * Triggers command for component on other core.
- * @param dev Component device.
- * @param cmd Command to be triggered.
- * @return 0 if succeeded, error code otherwise.
- */
-static inline int comp_trigger_remote(struct comp_dev *dev, int cmd)
-{
-	struct idc_msg msg = { IDC_MSG_TRIGGER,
-		IDC_MSG_TRIGGER_EXT(dev->comp.id), dev->comp.core, sizeof(cmd),
-		&cmd, };
-
-	return idc_send_msg(&msg, IDC_BLOCKING);
-}
-
-/**
- * Trigger component - mandatory and atomic.
- * @param dev Component device.
- * @param cmd Command.
- * @return 0 if succeeded, error code otherwise.
- */
-static inline int comp_trigger(struct comp_dev *dev, int cmd)
-{
-	int ret = 0;
-
-	assert(dev->drv->ops.trigger);
-
-	ret = (dev->is_shared && !cpu_is_me(dev->comp.core)) ?
-		comp_trigger_remote(dev, cmd) : dev->drv->ops.trigger(dev, cmd);
-
-	comp_shared_commit(dev);
-
-	return ret;
-}
-
-/**
- * Prepares component on other core.
- * @param dev Component device.
- * @return 0 if succeeded, error code otherwise.
- */
-static inline int comp_prepare_remote(struct comp_dev *dev)
-{
-	struct idc_msg msg = { IDC_MSG_PREPARE,
-		IDC_MSG_PREPARE_EXT(dev->comp.id), dev->comp.core, };
-
-	return idc_send_msg(&msg, IDC_BLOCKING);
-}
-
-/**
- * Prepare component.
- * @param dev Component device.
- * @return 0 if succeeded, error code otherwise.
- */
-static inline int comp_prepare(struct comp_dev *dev)
-{
-	int ret = 0;
-
-	if (dev->drv->ops.prepare)
-		ret = (dev->is_shared && !cpu_is_me(dev->comp.core)) ?
-			comp_prepare_remote(dev) : dev->drv->ops.prepare(dev);
-
-	comp_shared_commit(dev);
-
-	return ret;
-}
-
-/**
- * Copy component buffers - mandatory.
- * @param dev Component device.
- * @return Number of frames copied.
- */
-static inline int comp_copy(struct comp_dev *dev)
-{
-	int ret = 0;
-
-	assert(dev->drv->ops.copy);
-
-	/* copy only if we are the owner of the component */
-	if (cpu_is_me(dev->comp.core))
-		ret = dev->drv->ops.copy(dev);
-
-	comp_shared_commit(dev);
-
-	return ret;
-}
-
-/**
- * Resets component on other core.
- * @param dev Component device.
- * @return 0 if succeeded, error code otherwise.
- */
-static inline int comp_reset_remote(struct comp_dev *dev)
-{
-	struct idc_msg msg = { IDC_MSG_RESET,
-		IDC_MSG_RESET_EXT(dev->comp.id), dev->comp.core, };
-
-	return idc_send_msg(&msg, IDC_BLOCKING);
-}
-
-/**
- * Component reset and free runtime resources.
- * @param dev Component device.
- * @return 0 if succeeded, error code otherwise.
- */
-static inline int comp_reset(struct comp_dev *dev)
-{
-	int ret = 0;
-
-	if (dev->drv->ops.reset)
-		ret = (dev->is_shared && !cpu_is_me(dev->comp.core)) ?
-			comp_reset_remote(dev) : dev->drv->ops.reset(dev);
-
-	comp_shared_commit(dev);
-
-	return ret;
-}
-
-/**
- * DAI configuration - only mandatory for DAI components.
- * @param dev Component device.
- * @param config DAI configuration.
- * @return 0 if succeeded, error code otherwise.
- */
-static inline int comp_dai_config(struct comp_dev *dev,
-	struct sof_ipc_dai_config *config)
-{
-	int ret = 0;
-
-	if (dev->drv->ops.dai_config)
-		ret = dev->drv->ops.dai_config(dev, config);
-
-	comp_shared_commit(dev);
-
-	return ret;
-}
-
-/**
- * Retrieves component rendering position.
- * @param dev Component device.
- * @param posn Position reported by the component device.
- * @return 0 if succeeded, error code otherwise.
- */
-static inline int comp_position(struct comp_dev *dev,
-	struct sof_ipc_stream_posn *posn)
-{
-	int ret = 0;
-
-	if (dev->drv->ops.position)
-		ret = dev->drv->ops.position(dev, posn);
-
-	comp_shared_commit(dev);
-
-	return ret;
-}
-
-/**
- * Sets component attribute.
- * @param dev Component device.
- * @param type Attribute type.
- * @param value Attribute value.
- * @return 0 if succeeded, error code otherwise.
- */
-static inline int comp_set_attribute(struct comp_dev *dev, uint32_t type,
-				     void *value)
-{
-	int ret = 0;
-
-	if (dev->drv->ops.set_attribute)
-		ret = dev->drv->ops.set_attribute(dev, type, value);
-
-	comp_shared_commit(dev);
-
-	return ret;
-}
-
-/** @}*/
-
-/** \name Components API for infrastructure.
- *  @{
- */
-
-/**
- * Allocates and initializes audio component list.
- * To be called once at boot time.
- */
-void sys_comp_init(struct sof *sof);
-
 /** @}*/
 
 /** \name Helpers.
  *  @{
  */
-
-/**
- * Checks if two component devices belong to the same parent pipeline.
- * @param current Component device.
- * @param previous Another component device.
- * @return 1 if children of the same pipeline, 0 otherwise.
- */
-static inline int comp_is_single_pipeline(struct comp_dev *current,
-					  struct comp_dev *previous)
-{
-	return dev_comp_pipe_id(current) == dev_comp_pipe_id(previous);
-}
-
-/**
- * Checks if component device is active.
- * @param current Component device.
- * @return 1 if active, 0 otherwise.
- */
-static inline int comp_is_active(struct comp_dev *current)
-{
-	return current->state == COMP_STATE_ACTIVE;
-}
-
-/**
- * Returns component state based on requested command.
- * @param cmd Request command.
- * @return Component state.
- */
-static inline int comp_get_requested_state(int cmd)
-{
-	int state = COMP_STATE_INIT;
-
-	switch (cmd) {
-	case COMP_TRIGGER_START:
-	case COMP_TRIGGER_RELEASE:
-		state = COMP_STATE_ACTIVE;
-		break;
-	case COMP_TRIGGER_PREPARE:
-	case COMP_TRIGGER_STOP:
-		state = COMP_STATE_PREPARE;
-		break;
-	case COMP_TRIGGER_PAUSE:
-		state = COMP_STATE_PAUSED;
-		break;
-	case COMP_TRIGGER_XRUN:
-	case COMP_TRIGGER_RESET:
-		state = COMP_STATE_READY;
-		break;
-	default:
-		break;
-	}
-
-	return state;
-}
-
-/**
- * \brief Returns endpoint type of given component.
- * @param dev Component device
- * @return Endpoint type, one of comp_endpoint_type.
- */
-static inline int comp_get_endpoint_type(struct comp_dev *dev)
-{
-	switch (dev_comp_type(dev)) {
-	case SOF_COMP_HOST:
-		return COMP_ENDPOINT_HOST;
-	case SOF_COMP_DAI:
-		return COMP_ENDPOINT_DAI;
-	default:
-		return COMP_ENDPOINT_NODE;
-	}
-}
 
 /* \brief Set component period frames */
 static inline void component_set_period_frames(struct comp_dev *current,
@@ -966,16 +568,6 @@ static inline void comp_overrun(struct comp_dev *dev, struct comp_buffer *sink,
 }
 
 /**
- * Called to check whether component schedules its pipeline.
- * @param dev Component device.
- * @return True if this is scheduling component, false otherwise.
- */
-static inline bool comp_is_scheduling_source(struct comp_dev *dev)
-{
-	return dev == dev->pipeline->sched_comp;
-}
-
-/**
  * Called by component in copy.
  * @param source Source buffer.
  * @param sink Sink buffer.
@@ -996,17 +588,6 @@ void comp_get_copy_limits(struct comp_buffer *source, struct comp_buffer *sink,
  */
 int comp_verify_params(struct comp_dev *dev, uint32_t flag,
 		       struct sof_ipc_stream_params *params);
-/**
- * Called to reallocate component in shared memory.
- * @param dev Component device.
- * @return Pointer to reallocated component device.
- */
-struct comp_dev *comp_make_shared(struct comp_dev *dev);
-
-static inline struct comp_driver_list *comp_drivers_get(void)
-{
-	return sof_get()->comp_drivers;
-}
 
 /** @}*/
 

--- a/src/include/sof/audio/component_ext.h
+++ b/src/include/sof/audio/component_ext.h
@@ -1,0 +1,452 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2016 Intel Corporation. All rights reserved.
+ *
+ * Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
+ *         Keyon Jie <yang.jie@linux.intel.com>
+ */
+
+/**
+ * \file include/sof/audio/component_ext.h
+ * \brief Component API for Infrastructure
+ * \author Liam Girdwood <liam.r.girdwood@linux.intel.com>
+ * \author Keyon Jie <yang.jie@linux.intel.com>
+ */
+
+#ifndef __SOF_AUDIO_COMPONENT_INT_H__
+#define __SOF_AUDIO_COMPONENT_INT_H__
+
+#include <sof/audio/component.h>
+#include <sof/drivers/idc.h>
+#include <sof/list.h>
+#include <ipc/topology.h>
+#include <kernel/abi.h>
+#include <stdbool.h>
+
+/** \addtogroup component_api_helpers Component Mgmt API
+ *  @{
+ */
+
+/** \brief Holds list of registered components' drivers */
+struct comp_driver_list {
+	struct list_item list;	/**< list of component drivers */
+};
+
+/** \brief Retrieves the component device buffer list. */
+#define comp_buffer_list(comp, dir) \
+	((dir) == PPL_DIR_DOWNSTREAM ? &comp->bsink_list : \
+	 &comp->bsource_list)
+
+/** \name Component creation and destruction - mandatory
+ *  @{
+ */
+
+/**
+ * Creates a new component device.
+ * @param comp Parameters of the new component device.
+ * @return Pointer to the new component device.
+ */
+struct comp_dev *comp_new(struct sof_ipc_comp *comp);
+
+/**
+ * Called to delete the specified component device.
+ * All data structures previously allocated on the run-time heap
+ * must be freed by the implementation of <code>free()</code>.
+ * @param dev Component device to be deleted.
+ */
+static inline void comp_free(struct comp_dev *dev)
+{
+	assert(dev->drv->ops.free);
+
+	/* free task if shared component */
+	if (dev->is_shared && dev->task) {
+		schedule_task_free(dev->task);
+		rfree(dev->task);
+	}
+
+	dev->drv->ops.free(dev);
+}
+
+/** @}*/
+
+/**
+ * Commits component's memory if it's shared.
+ * @param dev Component device.
+ */
+static inline void comp_shared_commit(struct comp_dev *dev)
+{
+	if (dev->is_shared)
+		platform_shared_commit(dev, sizeof(*dev));
+}
+
+/**
+ * Parameter init for component on other core.
+ * @param dev Component device.
+ * @param params Parameters to be set.
+ * @return 0 if succeeded, error code otherwise.
+ */
+static inline int comp_params_remote(struct comp_dev *dev,
+				     struct sof_ipc_stream_params *params)
+{
+	struct idc_msg msg = { IDC_MSG_PARAMS, IDC_MSG_PARAMS_EXT(dev->comp.id),
+		dev->comp.core, sizeof(*params), params, };
+
+	return idc_send_msg(&msg, IDC_BLOCKING);
+}
+
+/**
+ * Component parameter init.
+ * @param dev Component device.
+ * @param params Audio (PCM) stream parameters to be set
+ * @return 0 if succeeded, error code otherwise.
+ */
+static inline int comp_params(struct comp_dev *dev,
+			      struct sof_ipc_stream_params *params)
+{
+	int ret = 0;
+
+	if (dev->drv->ops.params)
+		ret = (dev->is_shared && !cpu_is_me(dev->comp.core)) ?
+			comp_params_remote(dev, params) :
+			dev->drv->ops.params(dev, params);
+
+	comp_shared_commit(dev);
+
+	return ret;
+}
+
+/**
+ * Fetch hardware stream parameters - only mandatory for DAI components.
+ * @param dev Component device.
+ * @param params hw parameters
+ * @param dir Pipeline direction (see enum sof_ipc_stream_direction).
+ * @return 0 if succeeded, error code otherwise.
+ */
+static inline int comp_dai_get_hw_params(struct comp_dev *dev,
+					 struct sof_ipc_stream_params *params,
+					 int dir)
+{
+	int ret = -EINVAL;
+
+	if (dev->drv->ops.dai_get_hw_params)
+		ret = dev->drv->ops.dai_get_hw_params(dev, params, dir);
+
+	comp_shared_commit(dev);
+
+	return ret;
+}
+
+/**
+ * Send component command.
+ * @param dev Component device.
+ * @param cmd Command.
+ * @param data Command data.
+ * @param max_data_size Max data size.
+ * @return 0 if succeeded, error code otherwise.
+ */
+static inline int comp_cmd(struct comp_dev *dev, int cmd, void *data,
+			   int max_data_size)
+{
+	struct sof_ipc_ctrl_data *cdata = data;
+	int ret = -EINVAL;
+
+	if (cmd == COMP_CMD_SET_DATA &&
+	    (cdata->data->magic != SOF_ABI_MAGIC ||
+	     SOF_ABI_VERSION_INCOMPATIBLE(SOF_ABI_VERSION, cdata->data->abi))) {
+		comp_err(dev, "comp_cmd() error: invalid version, data->magic = %u, data->abi = %u",
+					 cdata->data->magic, cdata->data->abi);
+		goto out;
+	}
+
+	if (dev->drv->ops.cmd)
+		ret = dev->drv->ops.cmd(dev, cmd, data, max_data_size);
+
+out:
+	comp_shared_commit(dev);
+
+	return ret;
+}
+
+/**
+ * Triggers command for component on other core.
+ * @param dev Component device.
+ * @param cmd Command to be triggered.
+ * @return 0 if succeeded, error code otherwise.
+ */
+static inline int comp_trigger_remote(struct comp_dev *dev, int cmd)
+{
+	struct idc_msg msg = { IDC_MSG_TRIGGER,
+		IDC_MSG_TRIGGER_EXT(dev->comp.id), dev->comp.core, sizeof(cmd),
+		&cmd, };
+
+	return idc_send_msg(&msg, IDC_BLOCKING);
+}
+
+/**
+ * Trigger component - mandatory and atomic.
+ * @param dev Component device.
+ * @param cmd Command.
+ * @return 0 if succeeded, error code otherwise.
+ */
+static inline int comp_trigger(struct comp_dev *dev, int cmd)
+{
+	int ret = 0;
+
+	assert(dev->drv->ops.trigger);
+
+	ret = (dev->is_shared && !cpu_is_me(dev->comp.core)) ?
+		comp_trigger_remote(dev, cmd) : dev->drv->ops.trigger(dev, cmd);
+
+	comp_shared_commit(dev);
+
+	return ret;
+}
+
+/**
+ * Prepares component on other core.
+ * @param dev Component device.
+ * @return 0 if succeeded, error code otherwise.
+ */
+static inline int comp_prepare_remote(struct comp_dev *dev)
+{
+	struct idc_msg msg = { IDC_MSG_PREPARE,
+		IDC_MSG_PREPARE_EXT(dev->comp.id), dev->comp.core, };
+
+	return idc_send_msg(&msg, IDC_BLOCKING);
+}
+
+/**
+ * Prepare component.
+ * @param dev Component device.
+ * @return 0 if succeeded, error code otherwise.
+ */
+static inline int comp_prepare(struct comp_dev *dev)
+{
+	int ret = 0;
+
+	if (dev->drv->ops.prepare)
+		ret = (dev->is_shared && !cpu_is_me(dev->comp.core)) ?
+			comp_prepare_remote(dev) : dev->drv->ops.prepare(dev);
+
+	comp_shared_commit(dev);
+
+	return ret;
+}
+
+/**
+ * Copy component buffers - mandatory.
+ * @param dev Component device.
+ * @return Number of frames copied.
+ */
+static inline int comp_copy(struct comp_dev *dev)
+{
+	int ret = 0;
+
+	assert(dev->drv->ops.copy);
+
+	/* copy only if we are the owner of the component */
+	if (cpu_is_me(dev->comp.core))
+		ret = dev->drv->ops.copy(dev);
+
+	comp_shared_commit(dev);
+
+	return ret;
+}
+
+/**
+ * Sets component attribute.
+ * @param dev Component device.
+ * @param type Attribute type.
+ * @param value Attribute value.
+ * @return 0 if succeeded, error code otherwise.
+ */
+static inline int comp_set_attribute(struct comp_dev *dev, uint32_t type,
+				     void *value)
+{
+	int ret = 0;
+
+	if (dev->drv->ops.set_attribute)
+		ret = dev->drv->ops.set_attribute(dev, type, value);
+
+	comp_shared_commit(dev);
+
+	return ret;
+}
+
+/**
+ * Resets component on other core.
+ * @param dev Component device.
+ * @return 0 if succeeded, error code otherwise.
+ */
+static inline int comp_reset_remote(struct comp_dev *dev)
+{
+	struct idc_msg msg = { IDC_MSG_RESET,
+		IDC_MSG_RESET_EXT(dev->comp.id), dev->comp.core, };
+
+	return idc_send_msg(&msg, IDC_BLOCKING);
+}
+
+/**
+ * Component reset and free runtime resources.
+ * @param dev Component device.
+ * @return 0 if succeeded, error code otherwise.
+ */
+static inline int comp_reset(struct comp_dev *dev)
+{
+	int ret = 0;
+
+	if (dev->drv->ops.reset)
+		ret = (dev->is_shared && !cpu_is_me(dev->comp.core)) ?
+			comp_reset_remote(dev) : dev->drv->ops.reset(dev);
+
+	comp_shared_commit(dev);
+
+	return ret;
+}
+
+/**
+ * DAI configuration - only mandatory for DAI components.
+ * @param dev Component device.
+ * @param config DAI configuration.
+ * @return 0 if succeeded, error code otherwise.
+ */
+static inline int comp_dai_config(struct comp_dev *dev,
+	struct sof_ipc_dai_config *config)
+{
+	int ret = 0;
+
+	if (dev->drv->ops.dai_config)
+		ret = dev->drv->ops.dai_config(dev, config);
+
+	comp_shared_commit(dev);
+
+	return ret;
+}
+
+/**
+ * Retrieves component rendering position.
+ * @param dev Component device.
+ * @param posn Position reported by the component device.
+ * @return 0 if succeeded, error code otherwise.
+ */
+static inline int comp_position(struct comp_dev *dev,
+	struct sof_ipc_stream_posn *posn)
+{
+	int ret = 0;
+
+	if (dev->drv->ops.position)
+		ret = dev->drv->ops.position(dev, posn);
+
+	comp_shared_commit(dev);
+
+	return ret;
+}
+
+/** \name Components API for infrastructure.
+ *  @{
+ */
+
+/**
+ * Allocates and initializes audio component list.
+ * To be called once at boot time.
+ */
+void sys_comp_init(struct sof *sof);
+
+/** @}*/
+
+/**
+ * Checks if two component devices belong to the same parent pipeline.
+ * @param current Component device.
+ * @param previous Another component device.
+ * @return 1 if children of the same pipeline, 0 otherwise.
+ */
+static inline int comp_is_single_pipeline(struct comp_dev *current,
+					  struct comp_dev *previous)
+{
+	return dev_comp_pipe_id(current) == dev_comp_pipe_id(previous);
+}
+
+/**
+ * Checks if component device is active.
+ * @param current Component device.
+ * @return 1 if active, 0 otherwise.
+ */
+static inline int comp_is_active(struct comp_dev *current)
+{
+	return current->state == COMP_STATE_ACTIVE;
+}
+
+/**
+ * Returns component state based on requested command.
+ * @param cmd Request command.
+ * @return Component state.
+ */
+static inline int comp_get_requested_state(int cmd)
+{
+	int state = COMP_STATE_INIT;
+
+	switch (cmd) {
+	case COMP_TRIGGER_START:
+	case COMP_TRIGGER_RELEASE:
+		state = COMP_STATE_ACTIVE;
+		break;
+	case COMP_TRIGGER_PREPARE:
+	case COMP_TRIGGER_STOP:
+		state = COMP_STATE_PREPARE;
+		break;
+	case COMP_TRIGGER_PAUSE:
+		state = COMP_STATE_PAUSED;
+		break;
+	case COMP_TRIGGER_XRUN:
+	case COMP_TRIGGER_RESET:
+		state = COMP_STATE_READY;
+		break;
+	default:
+		break;
+	}
+
+	return state;
+}
+
+/**
+ * \brief Returns endpoint type of given component.
+ * @param dev Component device
+ * @return Endpoint type, one of comp_endpoint_type.
+ */
+static inline int comp_get_endpoint_type(struct comp_dev *dev)
+{
+	switch (dev_comp_type(dev)) {
+	case SOF_COMP_HOST:
+		return COMP_ENDPOINT_HOST;
+	case SOF_COMP_DAI:
+		return COMP_ENDPOINT_DAI;
+	default:
+		return COMP_ENDPOINT_NODE;
+	}
+}
+
+/**
+ * Called to check whether component schedules its pipeline.
+ * @param dev Component device.
+ * @return True if this is scheduling component, false otherwise.
+ */
+static inline bool comp_is_scheduling_source(struct comp_dev *dev)
+{
+	return dev == dev->pipeline->sched_comp;
+}
+
+/**
+ * Called to reallocate component in shared memory.
+ * @param dev Component device.
+ * @return Pointer to reallocated component device.
+ */
+struct comp_dev *comp_make_shared(struct comp_dev *dev);
+
+static inline struct comp_driver_list *comp_drivers_get(void)
+{
+	return sof_get()->comp_drivers;
+}
+
+/** @}*/
+
+#endif /* __SOF_AUDIO_COMPONENT_INT_H__ */

--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -13,7 +13,7 @@
  */
 
 #include <sof/audio/buffer.h>
-#include <sof/audio/component.h>
+#include <sof/audio/component_ext.h>
 #include <sof/audio/pipeline.h>
 #include <sof/common.h>
 #include <sof/debug/gdb/gdb.h>

--- a/src/ipc/ipc.c
+++ b/src/ipc/ipc.c
@@ -6,7 +6,7 @@
 //         Keyon Jie <yang.jie@linux.intel.com>
 
 #include <sof/audio/buffer.h>
-#include <sof/audio/component.h>
+#include <sof/audio/component_ext.h>
 #include <sof/audio/pipeline.h>
 #include <sof/common.h>
 #include <sof/drivers/idc.h>

--- a/src/schedule/task.c
+++ b/src/schedule/task.c
@@ -8,7 +8,7 @@
  * Generic audio task.
  */
 
-#include <sof/audio/component.h>
+#include <sof/audio/component_ext.h>
 #include <sof/debug/panic.h>
 #include <sof/drivers/ipc.h>
 #include <sof/lib/alloc.h>

--- a/test/cmocka/src/audio/mux/demux_copy.c
+++ b/test/cmocka/src/audio/mux/demux_copy.c
@@ -7,7 +7,7 @@
 
 #include "util.h"
 
-#include <sof/audio/component.h>
+#include <sof/audio/component_ext.h>
 #include <sof/audio/format.h>
 #include <sof/audio/mux.h>
 

--- a/test/cmocka/src/audio/mux/mux_copy.c
+++ b/test/cmocka/src/audio/mux/mux_copy.c
@@ -7,7 +7,7 @@
 
 #include "util.h"
 
-#include <sof/audio/component.h>
+#include <sof/audio/component_ext.h>
 #include <sof/audio/format.h>
 #include <sof/audio/mux.h>
 

--- a/test/cmocka/src/audio/mux/mux_get_processing_function.c
+++ b/test/cmocka/src/audio/mux/mux_get_processing_function.c
@@ -5,7 +5,7 @@
 // Author: Daniel Bogdzia <danielx.bogdzia@linux.intel.com>
 //         Janusz Jankowski <janusz.jankowski@linux.intel.com>
 
-#include <sof/audio/component.h>
+#include <sof/audio/component_ext.h>
 #include <sof/audio/mux.h>
 
 #include <stdarg.h>

--- a/tools/testbench/include/testbench/common_test.h
+++ b/tools/testbench/include/testbench/common_test.h
@@ -11,7 +11,7 @@
 #include <time.h>
 #include <stdio.h>
 #include <sof/sof.h>
-#include <sof/audio/component.h>
+#include <sof/audio/component_ext.h>
 #include <sof/audio/format.h>
 
 #define DEBUG_MSG_LEN		256


### PR DESCRIPTION
The current content of component.h is a mix of basic api, common
basic helpers for every component developers as well as advanced
functions and macros used by infrastructure and very specialized
components like host, dai, kpb etc.

This patch moves the advanced part to component_ext.h and keeps
only basic part in component.h to avoid overloading effects
component developers with declarations and code they do not use.

Signed-off-by: Marcin Maka <marcin.maka@linux.intel.com>