### PR TITLE
Topology: BYT: Adjust SRC pipeline for lower RAM consumption

### DIFF
--- a/tools/topology/sof-byt-codec.m4
+++ b/tools/topology/sof-byt-codec.m4
@@ -56,11 +56,11 @@ DAI_ADD(sof/pipe-dai-playback.m4,
 	1000, 1, 0, SCHEDULE_TIME_DOMAIN_DMA)
 
 # PCM Media Playback pipeline 3 on PCM 1 using max 2 channels of s32le.
-# 4000us deadline on core 0 with priority 0
+# 1000us deadline on core 0 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-pcm-media.m4,
-	3, 1, 2, s16le,
-	4000, 0, 0,
-	8000, 96000, 48000,
+	3, 1, 2, s32le,
+	1000, 0, 0,
+	8000, 48000, 48000,
 	SCHEDULE_TIME_DOMAIN_DMA,
 	PIPELINE_PLAYBACK_SCHED_COMP_1)
 

--- a/tools/topology/sof/pipe-pcm-media.m4
+++ b/tools/topology/sof/pipe-pcm-media.m4
@@ -54,22 +54,22 @@ W_DATA(playback_pga_conf, playback_pga_tokens)
 # with 2 sink and 0 source periods
 W_PCM_PLAYBACK(PCM_ID, Media Playback, 2, 0)
 
-# "Playback Volume" has 2 sink period and 2 source periods for host ping-pong
-W_PGA(0, PIPELINE_FORMAT, 2, 2, playback_pga_conf, LIST(`		', "PIPELINE_ID PCM PCM_ID Playback Volume"))
+# "Playback Volume" has 3 sink period and 2 source periods for host ping-pong
+W_PGA(0, PIPELINE_FORMAT, 3, 2, playback_pga_conf, LIST(`		', "PIPELINE_ID PCM PCM_ID Playback Volume"))
 
-# "SRC 0" has 2 sink and source periods.
-W_SRC(0, PIPELINE_FORMAT, 2, 2, media_src_conf)
+# "SRC 0" has 3 sink and source periods.
+W_SRC(0, PIPELINE_FORMAT, 3, 3, media_src_conf)
 
-# Media Source Buffers to SRC, make them big enough to deal with 2 * rate.
-W_BUFFER(0, COMP_BUFFER_SIZE(4,
+# Media Source Buffers to SRC
+W_BUFFER(0, COMP_BUFFER_SIZE(2,
 	COMP_SAMPLE_SIZE(PIPELINE_FORMAT), PIPELINE_CHANNELS, COMP_PERIOD_FRAMES(PCM_MAX_RATE, SCHEDULE_PERIOD)),
 	PLATFORM_HOST_MEM_CAP)
-W_BUFFER(1,COMP_BUFFER_SIZE(4,
+W_BUFFER(1,COMP_BUFFER_SIZE(3,
 	COMP_SAMPLE_SIZE(PIPELINE_FORMAT), PIPELINE_CHANNELS, COMP_PERIOD_FRAMES(PCM_MAX_RATE, SCHEDULE_PERIOD)),
 	PLATFORM_COMP_MEM_CAP)
 
 # Buffer B2 is on fixed rate sink side of SRC.
-W_BUFFER(2, COMP_BUFFER_SIZE(4,
+W_BUFFER(2, COMP_BUFFER_SIZE(3,
 	COMP_SAMPLE_SIZE(PIPELINE_FORMAT), PIPELINE_CHANNELS, COMP_PERIOD_FRAMES(PCM_MAX_RATE, SCHEDULE_PERIOD)),
 	PLATFORM_COMP_MEM_CAP)
 


### PR DESCRIPTION
This patch removes support for over 48 kHz sample rates and changes
scheduling to every 1 ms to save in buffers sizes. In pipe-pcm-media.m4
the buffers in the pipeline are reduced by one period from 4 to 3.
These changes should allow the media PCM to work in BYT platform.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>