### PR TITLE
ipc: allocate correct msg size

### DIFF
--- a/src/include/sof/drivers/ipc.h
+++ b/src/include/sof/drivers/ipc.h
@@ -158,7 +158,7 @@ static inline struct ipc_msg *ipc_msg_init(uint32_t header, uint32_t size)
 	struct ipc_msg *msg;
 
 	msg = rzalloc(SOF_MEM_ZONE_RUNTIME, SOF_MEM_FLAG_SHARED,
-		      SOF_MEM_CAPS_RAM, size);
+		      SOF_MEM_CAPS_RAM, sizeof(*msg));
 	if (!msg)
 		return NULL;
 


### PR DESCRIPTION
Msg size should use its own structure's size.
Only payload should be allocated using passed one.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>