### PR TITLE
pipeline: implement proper position offset retrieval

### DIFF
--- a/src/include/sof/sof.h
+++ b/src/include/sof/sof.h
@@ -27,6 +27,7 @@ struct pm_runtime_data;
 struct sa;
 struct timer;
 struct trace;
+struct pipeline_posn;
 struct probe_pdata;
 
 /**
@@ -94,6 +95,9 @@ struct sof {
 
 	/* probes */
 	struct probe_pdata *probe;
+
+	/* pipelines stream position */
+	struct pipeline_posn *pipeline_posn;
 
 	__aligned(PLATFORM_DCACHE_ALIGN) int alignment[0];
 } __aligned(PLATFORM_DCACHE_ALIGN);

--- a/src/platform/apollolake/include/platform/lib/memory.h
+++ b/src/platform/apollolake/include/platform/lib/memory.h
@@ -263,7 +263,7 @@
 /* Heap section sizes for module pool */
 #define HEAP_RT_COUNT64			128
 #define HEAP_RT_COUNT128		64
-#define HEAP_RT_COUNT256		128
+#define HEAP_RT_COUNT256		96
 #define HEAP_RT_COUNT512		8
 #define HEAP_RT_COUNT1024		4
 #define HEAP_RT_COUNT2048		0

--- a/src/schedule/task.c
+++ b/src/schedule/task.c
@@ -9,6 +9,7 @@
  */
 
 #include <sof/audio/component_ext.h>
+#include <sof/audio/pipeline.h>
 #include <sof/debug/panic.h>
 #include <sof/drivers/ipc.h>
 #include <sof/lib/alloc.h>
@@ -103,6 +104,9 @@ int task_main_start(struct sof *sof)
 
 	/* init self-registered modules */
 	sys_module_init();
+
+	/* init pipeline position offsets */
+	pipeline_posn_init(sof);
 
 #if STATIC_PIPE
 	/* init static pipeline */


### PR DESCRIPTION
Implements proper position offset retrieval in order to
update current stream position in mailbox. Previous one
was using pipeline_id in calculations, which has been
failing for bigger values. Lack of error handling has
also been a problem. This new solution uses predefined
list of available offsets and picks the first free from
the list. This way it will fail only if we exceed the
maximum number of simultaneously supported offsets.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>

Fixes #2546.