### PR TITLE
task: reduce default stack size for some platforms

### DIFF
--- a/src/arch/xtensa/schedule/task.c
+++ b/src/arch/xtensa/schedule/task.c
@@ -15,6 +15,7 @@
 #include <sof/lib/alloc.h>
 #include <sof/lib/cache.h>
 #include <sof/lib/cpu.h>
+#include <sof/lib/memory.h>
 #include <sof/lib/wait.h>
 #include <sof/schedule/edf_schedule.h>
 #include <sof/schedule/schedule.h>
@@ -83,10 +84,10 @@ int task_context_init(void *task_ctx, void *entry, void *arg0, void *arg1,
 		ctx->stack_size = stack_size;
 	} else {
 		ctx->stack_base = rballoc(0, SOF_MEM_CAPS_RAM,
-					  SOF_TASK_DEFAULT_STACK_SIZE);
+					  PLATFORM_TASK_DEFAULT_STACK_SIZE);
 		if (!ctx->stack_base)
 			return -ENOMEM;
-		ctx->stack_size = SOF_TASK_DEFAULT_STACK_SIZE;
+		ctx->stack_size = PLATFORM_TASK_DEFAULT_STACK_SIZE;
 		ctx->flags |= XTOS_TASK_CONTEXT_OWN_STACK;
 	}
 	bzero(ctx->stack_base, ctx->stack_size);

--- a/src/include/sof/schedule/task.h
+++ b/src/include/sof/schedule/task.h
@@ -27,9 +27,6 @@ struct sof;
 #define SOF_TASK_DEADLINE_ALMOST_IDLE	(SOF_TASK_DEADLINE_IDLE - 1)
 #define SOF_TASK_DEADLINE_NOW		0
 
-/** \brief EDF task's default stack size in bytes. */
-#define SOF_TASK_DEFAULT_STACK_SIZE	3072
-
 /** \brief Task states. */
 enum task_state {
 	SOF_TASK_STATE_INIT = 0,

--- a/src/platform/baytrail/include/platform/lib/memory.h
+++ b/src/platform/baytrail/include/platform/lib/memory.h
@@ -47,6 +47,9 @@ static inline void *platform_rfree_prepare(void *ptr)
 
 #define PLATFORM_DCACHE_ALIGN	sizeof(void *)
 
+/** \brief EDF task's default stack size in bytes. */
+#define PLATFORM_TASK_DEFAULT_STACK_SIZE	2048
+
 /* physical DSP addresses */
 
 #define SHIM_BASE	0xFF340000

--- a/src/platform/haswell/include/platform/lib/memory.h
+++ b/src/platform/haswell/include/platform/lib/memory.h
@@ -48,6 +48,9 @@ static inline void *platform_rfree_prepare(void *ptr)
 /* data cache line alignment */
 #define PLATFORM_DCACHE_ALIGN	sizeof(void *)
 
+/** \brief EDF task's default stack size in bytes. */
+#define PLATFORM_TASK_DEFAULT_STACK_SIZE	2048
+
 /* physical DSP addresses */
 
 #define SHIM_SIZE	0x00001000

--- a/src/platform/imx8/include/platform/lib/memory.h
+++ b/src/platform/imx8/include/platform/lib/memory.h
@@ -170,6 +170,9 @@
 
 #define HEAP_BUF_ALIGNMENT		PLATFORM_DCACHE_ALIGN
 
+/** \brief EDF task's default stack size in bytes. */
+#define PLATFORM_TASK_DEFAULT_STACK_SIZE	3072
+
 #if !defined(__ASSEMBLER__) && !defined(LINKER)
 
 struct sof;

--- a/src/platform/imx8m/include/platform/lib/memory.h
+++ b/src/platform/imx8m/include/platform/lib/memory.h
@@ -167,6 +167,9 @@
 
 #define HEAP_BUF_ALIGNMENT		PLATFORM_DCACHE_ALIGN
 
+/** \brief EDF task's default stack size in bytes. */
+#define PLATFORM_TASK_DEFAULT_STACK_SIZE	3072
+
 #if !defined(__ASSEMBLER__) && !defined(LINKER)
 
 struct sof;

--- a/src/platform/intel/cavs/include/cavs/lib/memory.h
+++ b/src/platform/intel/cavs/include/cavs/lib/memory.h
@@ -64,6 +64,9 @@
 
 #define HEAP_BUF_ALIGNMENT		PLATFORM_DCACHE_ALIGN
 
+/** \brief EDF task's default stack size in bytes. */
+#define PLATFORM_TASK_DEFAULT_STACK_SIZE	3072
+
 #if !defined(__ASSEMBLER__) && !defined(LINKER)
 
 struct sof;


### PR DESCRIPTION
Reduces default EDF task's stack size for some platforms,
which have less memory and aren't used for more serious
processing.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>

Fixes #2532.