### PR TITLE
trace: move struct definition out of header

### DIFF
--- a/src/include/sof/spinlock.h
+++ b/src/include/sof/spinlock.h
@@ -15,7 +15,6 @@
 
 #include <arch/spinlock.h>
 #include <sof/lib/memory.h>
-#include <sof/trace/trace.h>
 #include <config.h>
 #include <stdint.h>
 

--- a/src/include/sof/trace/trace.h
+++ b/src/include/sof/trace/trace.h
@@ -20,7 +20,6 @@
 #endif
 #include <sof/common.h>
 #include <sof/sof.h>
-#include <sof/spinlock.h>
 #include <sof/trace/preproc.h>
 #include <config.h>
 #include <stdint.h>
@@ -29,12 +28,7 @@
 #endif
 
 struct sof;
-
-struct trace {
-	uint32_t pos ;	/* trace position */
-	uint32_t enable;
-	spinlock_t lock; /* locking mechanism */
-};
+struct trace;
 
 /* bootloader trace values */
 #define TRACE_BOOT_LDR_ENTRY		0x100

--- a/src/trace/trace.c
+++ b/src/trace/trace.c
@@ -23,6 +23,12 @@
 #include <user/trace.h>
 #include <stdint.h>
 
+struct trace {
+	uint32_t pos ;	/* trace position */
+	uint32_t enable;
+	spinlock_t lock; /* locking mechanism */
+};
+
 /* calculates total message size, both header and payload in bytes */
 #define MESSAGE_SIZE(args_num)	\
 	(sizeof(struct log_entry_header) + args_num * sizeof(uint32_t))


### PR DESCRIPTION
Moves trace struct definition out of header.
It isn't used anywhere besides trace unit.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>

Fixes #2334.