### PR TITLE
ipc: buffer: Fix incorrect memory management in ipc_buffer_new()

### DIFF
--- a/src/ipc/ipc.c
+++ b/src/ipc/ipc.c
@@ -267,7 +267,7 @@ int ipc_buffer_new(struct ipc *ipc, struct sof_ipc_buffer *desc)
 	buffer = buffer_new(desc);
 	if (buffer == NULL) {
 		trace_ipc_error("ipc_buffer_new() error: buffer_new() failed");
-		rfree(ibd);
+
 		return -ENOMEM;
 	}
 

--- a/src/ipc/ipc.c
+++ b/src/ipc/ipc.c
@@ -274,7 +274,7 @@ int ipc_buffer_new(struct ipc *ipc, struct sof_ipc_buffer *desc)
 	ibd = rzalloc(SOF_MEM_ZONE_RUNTIME, SOF_MEM_FLAG_SHARED,
 		      SOF_MEM_CAPS_RAM, sizeof(struct ipc_comp_dev));
 	if (ibd == NULL) {
-		rfree(buffer);
+		buffer_free(buffer);
 		return -ENOMEM;
 	}
 	ibd->cb = buffer;


### PR DESCRIPTION
Signed-off-by: Artur Kloniecki <arturx.kloniecki@linux.intel.com>