### PR TITLE
[RFC] dai: dma_buffer: fix pop noise issue when start playback

### DIFF
--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -503,10 +503,8 @@ static int dai_prepare(struct comp_dev *dev)
 		return -EINVAL;
 	}
 
-	/* TODO: not sure what this wb is for? */
-	/* write back buffer contents from cache */
-	dcache_writeback_region(dd->dma_buffer->stream.addr,
-				dd->dma_buffer->stream.size);
+	/* clear dma buffer to avoid pop noise */
+	buffer_zero(dd->dma_buffer);
 
 	/* dma reconfig not required if XRUN handling */
 	if (dd->xrun) {


### PR DESCRIPTION

Another type of pop noise.

The pop noise is generated by invalid data in dma buffer.
Since all buffers are cleared by pipeline_comp_prepare except
dma buffer, so clear it to zero to avoid this issue.

![noise1](https://user-images.githubusercontent.com/39945651/76950025-674ccb00-6944-11ea-9bf5-70ecb1949c93.png)
![noise2](https://user-images.githubusercontent.com/39945651/76950010-61ef8080-6944-11ea-9621-916680b66055.png)