### PR TITLE
cmocka: fix ut building

### DIFF
--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -25,6 +25,7 @@
 #include <sof/list.h>
 #include <sof/string.h>
 #include <sof/trace/trace.h>
+#include <sof/ut.h>
 #include <ipc/control.h>
 #include <ipc/stream.h>
 #include <ipc/topology.h>
@@ -538,7 +539,7 @@ static SHARED_DATA struct comp_driver_info comp_selector_info = {
 };
 
 /** \brief Initializes selector component. */
-static void sys_comp_selector_init(void)
+UT_STATIC void sys_comp_selector_init(void)
 {
 	comp_register(platform_shared_get(&comp_selector_info,
 					  sizeof(comp_selector_info)));

--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -33,6 +33,7 @@
 #include <sof/schedule/task.h>
 #include <sof/string.h>
 #include <sof/trace/trace.h>
+#include <sof/ut.h>
 #include <ipc/control.h>
 #include <ipc/stream.h>
 #include <ipc/topology.h>
@@ -801,7 +802,7 @@ static SHARED_DATA struct comp_driver_info comp_volume_info = {
 /**
  * \brief Initializes volume component.
  */
-static void sys_comp_volume_init(void)
+UT_STATIC void sys_comp_volume_init(void)
 {
 	comp_register(platform_shared_get(&comp_volume_info,
 					  sizeof(comp_volume_info)));

--- a/src/include/sof/audio/selector.h
+++ b/src/include/sof/audio/selector.h
@@ -63,4 +63,8 @@ extern const struct comp_func_map func_map[];
  */
 sel_func sel_get_processing_function(struct comp_dev *dev);
 
+#ifdef UNIT_TEST
+void sys_comp_selector_init(void);
+#endif
+
 #endif /* __SOF_AUDIO_SELECTOR_H__ */

--- a/src/include/sof/audio/volume.h
+++ b/src/include/sof/audio/volume.h
@@ -138,4 +138,8 @@ static inline vol_scale_func vol_get_processing_function(struct comp_dev *dev)
 	return NULL;
 }
 
+#ifdef UNIT_TEST
+void sys_comp_volume_init(void);
+#endif
+
 #endif /* __SOF_AUDIO_VOLUME_H__ */

--- a/test/cmocka/src/audio/selector/CMakeLists.txt
+++ b/test/cmocka/src/audio/selector/CMakeLists.txt
@@ -8,6 +8,9 @@ target_include_directories(selector_test PRIVATE ${PROJECT_SOURCE_DIR}/src/audio
 
 # make small version of libaudio so we don't have to care
 # about unused missing references
+
+add_compile_options(-DUNIT_TEST)
+
 add_library(audio_for_selector STATIC
 	${PROJECT_SOURCE_DIR}/src/audio/selector/selector.c
 	${PROJECT_SOURCE_DIR}/src/audio/selector/selector_generic.c

--- a/test/cmocka/src/audio/volume/CMakeLists.txt
+++ b/test/cmocka/src/audio/volume/CMakeLists.txt
@@ -8,6 +8,9 @@ target_include_directories(volume_process PRIVATE ${PROJECT_SOURCE_DIR}/src/audi
 
 # make small version of libaudio so we don't have to care
 # about unused missing references
+
+add_compile_options(-DUNIT_TEST)
+
 add_library(audio_for_volume STATIC
 	${PROJECT_SOURCE_DIR}/src/audio/volume/volume.c
 	${PROJECT_SOURCE_DIR}/src/audio/volume/volume_generic.c


### PR DESCRIPTION
We don't support section .shared in unit tests,
so add appropriate flags to make files.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>