### PR TITLE
ll-schedule: fix scheduling start on slave cores

### DIFF
--- a/src/include/sof/schedule/ll_schedule_domain.h
+++ b/src/include/sof/schedule/ll_schedule_domain.h
@@ -52,6 +52,7 @@ struct ll_schedule_domain {
 	bool synchronous;		/**< are tasks should be synchronous */
 	void *priv_data;		/**< pointer to private data */
 	bool registered[PLATFORM_CORE_COUNT];		/**< registered cores */
+	bool enabled[PLATFORM_CORE_COUNT];		/**< enabled cores */
 	const struct ll_schedule_domain_ops *ops;	/**< domain ops */
 };
 


### PR DESCRIPTION
This fixes a recently reported and discussed xrun on slave cores.