### PR TITLE
topology: buffer: Add XRUN flags field to struct sof_ipc_buffer.

### DIFF
--- a/src/include/ipc/topology.h
+++ b/src/include/ipc/topology.h
@@ -83,12 +83,23 @@ struct sof_ipc_comp {
 #define SOF_MEM_CAPS_DMA			(1 << 5) /**< DMA'able */
 #define SOF_MEM_CAPS_CACHE			(1 << 6) /**< cacheable */
 #define SOF_MEM_CAPS_EXEC			(1 << 7) /**< executable */
+/*
+ * overrun will cause ring buffer overwrite, instead of XRUN.
+ */
+#define SOF_BUF_OVERRUN_PERMITTED	BIT(0)
+
+/*
+ * underrun will cause readback of 0s, instead of XRUN.
+ */
+#define SOF_BUF_UNDERRUN_PERMITTED	BIT(1)
 
 /* create new component buffer - SOF_IPC_TPLG_BUFFER_NEW */
 struct sof_ipc_buffer {
 	struct sof_ipc_comp comp;
 	uint32_t size;		/**< buffer size in bytes */
 	uint32_t caps;		/**< SOF_MEM_CAPS_ */
+	uint32_t flags;		/**< SOF_BUF_ flags defined above */
+	uint32_t reserved;	/**< reserved for future use */
 } __attribute__((packed));
 
 /* generic component config data - must always be after struct sof_ipc_comp */

--- a/src/include/kernel/abi.h
+++ b/src/include/kernel/abi.h
@@ -29,7 +29,7 @@
 
 /** \brief SOF ABI version major, minor and patch numbers */
 #define SOF_ABI_MAJOR 3
-#define SOF_ABI_MINOR 14
+#define SOF_ABI_MINOR 15
 #define SOF_ABI_PATCH 0
 
 /** \brief SOF ABI version number. Format within 32bit word is MMmmmppp */


### PR DESCRIPTION
2 flags have been added for use during buffer instantiation:
SOF_BUF_OVERRUN_PERMITTED and SOF_BUF_UNDERRUN_PERMITTED,
along with struct sof_ipc_buffer member fields flags and reserved.
Flags field is supposed to hold the above-mentioned flags to allow
some control over XRUN behaviour, i.e. prevent XRUN on buffers which
are allowed to under/overrun by design.
Also added reserved field to the structure in case it comes in handy
some time in the future.

Relates to https://github.com/thesofproject/sof/issues/2478

Signed-off-by: Artur Kloniecki <arturx.kloniecki@linux.intel.com>