### PR TITLE
panic: add __attribute__((noreturn)) #if __GNUC__

### DIFF
--- a/src/include/sof/debug/panic.h
+++ b/src/include/sof/debug/panic.h
@@ -12,6 +12,14 @@
 #include <ipc/trace.h>
 #include <stdint.h>
 
+#ifdef __clang_analyzer__
+#define SOF_NORETURN __attribute__((analyzer_noreturn))
+#elif __GNUC__
+#define SOF_NORETURN __attribute__((noreturn))
+#else
+#define SOF_NORETURN
+#endif
+
 #ifndef RELATIVE_FILE
 #error "This file requires RELATIVE_FILE to be defined. " \
 	"Add it to CMake's target with sof_append_relative_path_definitions."
@@ -19,13 +27,9 @@
 
 void dump_panicinfo(void *addr, struct sof_ipc_panic_info *panic_info);
 void panic_rewind(uint32_t p, uint32_t stack_rewind_frames,
-		  struct sof_ipc_panic_info *panic_info, uintptr_t *data);
-#if __clang_analyzer__
-void __panic(uint32_t p, char *filename, uint32_t linenum)
-	__attribute__((analyzer_noreturn));
-#else
-void __panic(uint32_t p, char *filename, uint32_t linenum);
-#endif
+		  struct sof_ipc_panic_info *panic_info, uintptr_t *data)
+	SOF_NORETURN;
+void __panic(uint32_t p, char *filename, uint32_t linenum) SOF_NORETURN;
 
 /* panic dump filename and linenumber of the call */
 #define panic(x) __panic((x), (RELATIVE_FILE), (__LINE__))

--- a/tools/testbench/panic.c
+++ b/tools/testbench/panic.c
@@ -5,5 +5,9 @@
 // Author: Tomasz Lauda <tomasz.lauda@linux.intel.com>
 
 #include <sof/debug/panic.h>
+#include <stdlib.h>
 
-void __panic(uint32_t p, char *filename, uint32_t linenum) { }
+void __panic(uint32_t p, char *filename, uint32_t linenum)
+{
+	abort();
+}


### PR DESCRIPTION
Commit 9e1a2b251a3e9d added ((analyzer_noreturn)) but only for clang.

Fixes at least these two -Werr build failures and probably similar
others with a different .config or in the future:
```
   sof/src/probe/probe.c: In function 'probe_cb_produce':
   sof/src/probe/probe.c:635:11: error: 'valid_bytes' and
   'container_bytes' may be used uninitialized in this function
   [-Werror=maybe-uninitialized]
```
Build failure reproduced with xtensa-apl-elf-gcc (crosstool-NG
1.23.0.440-3b8c) 7.3.0