### PR TITLE
check patch: "top_of_sof_tree()" so it works out of the box

### DIFF
--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -1104,6 +1104,14 @@ sub top_of_kernel_tree {
 		"fs", "init", "ipc", "kernel", "lib", "scripts",
 	);
 
+	if ($SOF) {
+		@tree_check = (
+			"LICENCE", "README.md", "rimage", "tools",
+			"scripts", "doc", "src", "CODEOWNERS",
+			"CMakeLists.txt",
+		);
+	}
+
 	foreach my $check (@tree_check) {
 		if (! -e $root . '/' . $check) {
 			return 0;


### PR DESCRIPTION
Adjust top_of_kernel_tree() function to SOF so invoking
./scripts/checkpatch.pl works out of the box and doesn't require
figuring what's going on and the existence of the --no-tree option which
sof-ci invokes "behind the scenes".
Compared to --no-tree, this is also enables a couple extra checks like:
`WARNING: use relative pathname instead of absolute in changelog text`

This instead of failing with:

  Must be run from the top-level dir. of a kernel tree

PS: the space between check and patch is here to... defeat checkpatch
itself. It apparently doesn't expect any change to itself.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>