### PR TITLE
test: fix pipeline tests

### DIFF
--- a/test/cmocka/src/audio/pipeline/pipeline_free.c
+++ b/test/cmocka/src/audio/pipeline/pipeline_free.c
@@ -19,6 +19,7 @@
 
 static int setup(void **state)
 {
+	pipeline_posn_init(sof_get());
 	*state = get_standard_connect_objects();
 	return 0;
 }

--- a/test/cmocka/src/audio/pipeline/pipeline_new.c
+++ b/test/cmocka/src/audio/pipeline/pipeline_new.c
@@ -20,6 +20,8 @@ static int setup(void **state)
 	struct pipeline_new_setup_data *pipeline_data = malloc(
 		sizeof(struct pipeline_new_setup_data));
 
+	pipeline_posn_init(sof_get());
+
 	if (pipeline_data == NULL)
 		return -1;
 


### PR DESCRIPTION
Initialize global objects that are required by pipelines
logic - pipeline_posn.

Signed-off-by: Janusz Jankowski <janusz.jankowski@linux.intel.com>