### PR TITLE
pipeline: move pipeline_posn shared data

### DIFF
--- a/src/audio/pipeline.c
+++ b/src/audio/pipeline.c
@@ -42,6 +42,16 @@ struct pipeline_data {
 DECLARE_SOF_UUID("pipe-task", pipe_task_uuid, 0xf11818eb, 0xe92e, 0x4082,
 		 0x82,  0xa3, 0xdc, 0x54, 0xc6, 0x04, 0xeb, 0xb3);
 
+static SHARED_DATA struct pipeline_posn pipeline_posn;
+
+void pipeline_posn_init(struct sof *sof)
+{
+	sof->pipeline_posn = platform_shared_get(&pipeline_posn,
+						 sizeof(pipeline_posn));
+	spinlock_init(&sof->pipeline_posn->lock);
+	platform_shared_commit(sof->pipeline_posn, sizeof(*sof->pipeline_posn));
+}
+
 static enum task_state pipeline_task(void *arg);
 
 /* create new pipeline - returns pipeline id or negative error */

--- a/src/include/sof/audio/pipeline.h
+++ b/src/include/sof/audio/pipeline.h
@@ -120,8 +120,6 @@ struct pipeline_posn {
 	spinlock_t lock;			/**< lock mechanism */
 };
 
-static SHARED_DATA struct pipeline_posn pipeline_posn;
-
 /**
  * \brief Retrieves pipeline position structure.
  * \return Pointer to pipeline position structure.
@@ -135,13 +133,7 @@ static inline struct pipeline_posn *pipeline_posn_get(void)
  * \brief Initializes pipeline position structure.
  * \param[in,out] sof Pointer to sof structure.
  */
-static inline void pipeline_posn_init(struct sof *sof)
-{
-	sof->pipeline_posn = platform_shared_get(&pipeline_posn,
-						 sizeof(pipeline_posn));
-	spinlock_init(&sof->pipeline_posn->lock);
-	platform_shared_commit(sof->pipeline_posn, sizeof(*sof->pipeline_posn));
-}
+void pipeline_posn_init(struct sof *sof);
 
 /**
  * \brief Retrieves first free pipeline position offset.


### PR DESCRIPTION
Like other SHARED_DATA objects, this one should have limited visibility
just to pipeline compilation unit.

Signed-off-by: Janusz Jankowski <janusz.jankowski@linux.intel.com>