### PR TITLE
tools: logger: Create log_err function

### DIFF
--- a/tools/logger/convert.c
+++ b/tools/logger/convert.c
@@ -640,14 +640,14 @@ int convert(struct convert_config *config)
 		fprintf(stderr, "Error: abi version in %s file "
 			"does not coincide with abi version used "
 			"by logger.\n", config->ldc_file);
-			fprintf(stderr, "logger ABI Version is %d:%d:%d\n",
-				SOF_ABI_VERSION_MAJOR(SOF_ABI_DBG_VERSION),
-				SOF_ABI_VERSION_MINOR(SOF_ABI_DBG_VERSION),
-				SOF_ABI_VERSION_PATCH(SOF_ABI_DBG_VERSION));
-			fprintf(stderr, "ldc_file ABI Version is %d:%d:%d\n",
-				SOF_ABI_VERSION_MAJOR(snd.version.abi_version),
-				SOF_ABI_VERSION_MINOR(snd.version.abi_version),
-				SOF_ABI_VERSION_PATCH(snd.version.abi_version));
+		fprintf(stderr, "logger ABI Version is %d:%d:%d\n",
+			SOF_ABI_VERSION_MAJOR(SOF_ABI_DBG_VERSION),
+			SOF_ABI_VERSION_MINOR(SOF_ABI_DBG_VERSION),
+			SOF_ABI_VERSION_PATCH(SOF_ABI_DBG_VERSION));
+		fprintf(stderr, "ldc_file ABI Version is %d:%d:%d\n",
+			SOF_ABI_VERSION_MAJOR(snd.version.abi_version),
+			SOF_ABI_VERSION_MINOR(snd.version.abi_version),
+			SOF_ABI_VERSION_PATCH(snd.version.abi_version));
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
Error during conversion should be logged to stderr and to
output file by default. Such a approach will speed up debugging
process when some error with conversion occurred in CI.

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>