### PR TITLE
DAI: Remove spinlocks for timestamping registers access

### DIFF
--- a/src/drivers/intel/cavs/dmic.c
+++ b/src/drivers/intel/cavs/dmic.c
@@ -1669,7 +1669,6 @@ static int dmic_ts_start(struct dai *dai, struct timestamp_cfg *cfg)
 	uint32_t addr = dmic_ts_local_tsctrl_addr();
 
 	/* Set DMIC timestamp registers */
-	spin_lock(&dai->lock);
 
 	/* First point CDMAS to GPDMA channel that is used by DMIC
 	 * also clear NTK to be sure there is no old timestamp.
@@ -1681,7 +1680,6 @@ static int dmic_ts_start(struct dai *dai, struct timestamp_cfg *cfg)
 	/* Request on demand timestamp */
 	io_reg_write(addr, TS_LOCAL_TSCTRL_ODTS_BIT | cdmas);
 
-	spin_unlock(&dai->lock);
 	return 0;
 }
 
@@ -1700,7 +1698,6 @@ static int dmic_ts_get(struct dai *dai, struct timestamp_cfg *cfg,
 	uint32_t tsctrl = dmic_ts_local_tsctrl_addr();
 
 	/* Read SSP timestamp registers */
-	spin_lock(&dai->lock);
 	ntk = io_reg_read(tsctrl) & TS_LOCAL_TSCTRL_NTK_BIT;
 	if (!ntk)
 		goto out;
@@ -1715,7 +1712,6 @@ static int dmic_ts_get(struct dai *dai, struct timestamp_cfg *cfg,
 	io_reg_write(tsctrl, TS_LOCAL_TSCTRL_NTK_BIT);
 
 out:
-	spin_unlock(&dai->lock);
 	tsd->walclk_rate = cfg->walclk_rate;
 	if (!ntk)
 		return -ENODATA;

--- a/src/drivers/intel/cavs/hda.c
+++ b/src/drivers/intel/cavs/hda.c
@@ -107,8 +107,7 @@ static int hda_ts_start(struct dai *dai, struct timestamp_cfg *cfg)
 	uint32_t cdmas;
 	uint32_t addr = hda_ts_local_tsctrl_addr();
 
-	/* Set DMIC timestamp registers */
-	spin_lock(&dai->lock);
+	/* Set HDA timestamp registers */
 
 	/* Set CDMAS(4:0) to match DMA engine index and direction
 	 * also clear NTK to be sure there is no old timestamp.
@@ -120,7 +119,6 @@ static int hda_ts_start(struct dai *dai, struct timestamp_cfg *cfg)
 	/* Request on demand timestamp */
 	io_reg_write(addr, TS_LOCAL_TSCTRL_ODTS_BIT | cdmas);
 
-	spin_unlock(&dai->lock);
 	return 0;
 }
 
@@ -138,8 +136,6 @@ static int hda_ts_get(struct dai *dai, struct timestamp_cfg *cfg,
 	uint32_t ntk;
 	uint32_t tsctrl = hda_ts_local_tsctrl_addr();
 
-	/* Read SSP timestamp registers */
-	spin_lock(&dai->lock);
 	ntk = io_reg_read(tsctrl) & TS_LOCAL_TSCTRL_NTK_BIT;
 	if (!ntk)
 		goto out;
@@ -154,7 +150,6 @@ static int hda_ts_get(struct dai *dai, struct timestamp_cfg *cfg,
 	io_reg_write(tsctrl, TS_LOCAL_TSCTRL_NTK_BIT);
 
 out:
-	spin_unlock(&dai->lock);
 	tsd->walclk_rate = cfg->walclk_rate;
 	if (!ntk)
 		return -ENODATA;

--- a/src/drivers/intel/cavs/ssp.c
+++ b/src/drivers/intel/cavs/ssp.c
@@ -941,7 +941,6 @@ static int ssp_ts_start(struct dai *dai, struct timestamp_cfg *cfg)
 	uint32_t addr = ssp_ts_local_tsctrl_addr(cfg->index);
 
 	/* Set SSP timestamp registers */
-	spin_lock(&dai->lock);
 
 	/* First point CDMAS to GPDMA channel that is used by this SSP,
 	 * also clear NTK to be sure there is no old timestamp.
@@ -953,7 +952,6 @@ static int ssp_ts_start(struct dai *dai, struct timestamp_cfg *cfg)
 	/* Request on demand timestamp */
 	io_reg_write(addr, TS_LOCAL_TSCTRL_ODTS_BIT | cdmas);
 
-	spin_unlock(&dai->lock);
 	return 0;
 }
 
@@ -972,7 +970,6 @@ static int ssp_ts_get(struct dai *dai, struct timestamp_cfg *cfg,
 	uint32_t tsctrl = ssp_ts_local_tsctrl_addr(cfg->index);
 
 	/* Read SSP timestamp registers */
-	spin_lock(&dai->lock);
 	ntk = io_reg_read(tsctrl) & TS_LOCAL_TSCTRL_NTK_BIT;
 	if (!ntk)
 		goto out;
@@ -987,7 +984,6 @@ static int ssp_ts_get(struct dai *dai, struct timestamp_cfg *cfg,
 	io_reg_write(tsctrl, TS_LOCAL_TSCTRL_NTK_BIT);
 
 out:
-	spin_unlock(&dai->lock);
 	tsd->walclk_rate = cfg->walclk_rate;
 	if (!ntk)
 		return -ENODATA;


### PR DESCRIPTION
This patch removes the spin_lock() and spin_unlock() calls
from DMIC, HDA, and SSP driver code. The removal avoids a pipeline
stall issue that has been seen to happen in ASRC capture pipelines.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>