### PR TITLE
mm: clean alloc api up

### DIFF
--- a/src/arch/xtensa/lib/cpu.c
+++ b/src/arch/xtensa/lib/cpu.c
@@ -17,6 +17,7 @@
 #include <sof/lib/cache.h>
 #include <sof/lib/cpu.h>
 #include <sof/lib/memory.h>
+#include <sof/lib/mm_heap.h>
 #include <sof/lib/notifier.h>
 #include <sof/lib/pm_runtime.h>
 #include <sof/lib/wait.h>

--- a/src/audio/pipeline.c
+++ b/src/audio/pipeline.c
@@ -14,6 +14,7 @@
 #include <sof/drivers/timer.h>
 #include <sof/lib/alloc.h>
 #include <sof/lib/mailbox.h>
+#include <sof/lib/mm_heap.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
 #include <sof/math/numbers.h>

--- a/src/include/sof/lib/alloc.h
+++ b/src/include/sof/lib/alloc.h
@@ -10,20 +10,12 @@
 #define __SOF_LIB_ALLOC_H__
 
 #include <sof/bit.h>
-#include <sof/common.h>
-#include <sof/lib/cache.h>
-#include <sof/lib/memory.h>
-#include <sof/sof.h>
-#include <sof/spinlock.h>
 #include <sof/string.h>
 #include <sof/trace/trace.h>
 #include <user/trace.h>
 #include <config.h>
 #include <stddef.h>
 #include <stdint.h>
-
-struct dma_copy;
-struct dma_sg_config;
 
 #define trace_mem_error(__e, ...) \
 	trace_error(TRACE_CLASS_MEM, __e, ##__VA_ARGS__)
@@ -59,55 +51,6 @@ enum mem_zone {
 /* heap zone flags */
 #define SOF_MEM_FLAG_SHARED	BIT(0)
 
-struct mm_info {
-	uint32_t used;
-	uint32_t free;
-};
-
-struct block_hdr {
-	uint16_t size;		/* size in blocks for continuous allocation */
-	uint16_t used;		/* usage flags for page */
-	void *unaligned_ptr;	/* align ptr */
-} __packed;
-
-struct block_map {
-	uint16_t block_size;	/* size of block in bytes */
-	uint16_t count;		/* number of blocks in map */
-	uint16_t free_count;	/* number of free blocks */
-	uint16_t first_free;	/* index of first free block */
-	struct block_hdr *block;	/* base block header */
-	uint32_t base;		/* base address of space */
-};
-
-#define BLOCK_DEF(sz, cnt, hdr) \
-	{.block_size = sz, .count = cnt, .free_count = cnt, .block = hdr, \
-	 .first_free = 0}
-
-struct mm_heap {
-	uint32_t blocks;
-	struct block_map *map;
-	uint32_t heap;
-	uint32_t size;
-	uint32_t caps;
-	struct mm_info info;
-};
-
-/* heap block memory map */
-struct mm {
-	/* system heap - used during init cannot be freed */
-	struct mm_heap system[PLATFORM_HEAP_SYSTEM];
-	/* system runtime heap - used for runtime system components */
-	struct mm_heap system_runtime[PLATFORM_HEAP_SYSTEM_RUNTIME];
-	/* general heap for components */
-	struct mm_heap runtime[PLATFORM_HEAP_RUNTIME];
-	/* general component buffer heap */
-	struct mm_heap buffer[PLATFORM_HEAP_BUFFER];
-
-	struct mm_info total;
-	uint32_t heap_trace_updated;	/* updates that can be presented */
-	spinlock_t lock;	/* all allocs and frees are atomic */
-};
-
 /* heap allocation and free */
 void *_malloc(enum mem_zone zone, uint32_t flags, uint32_t caps, size_t bytes);
 void *_zalloc(enum mem_zone zone, uint32_t flags, uint32_t caps, size_t bytes);
@@ -119,8 +62,6 @@ void *_brealloc(void *ptr, uint32_t flags, uint32_t caps, size_t bytes,
 void rfree(void *ptr);
 
 #if CONFIG_DEBUG_HEAP
-
-#include <sof/trace/trace.h>
 
 #define rmalloc(zone, flags, caps, bytes)				\
 	({void *_ptr;							\
@@ -239,26 +180,5 @@ void *rzalloc_core_sys(int core, size_t bytes);
 
 int rstrlen(const char *s);
 int rstrcmp(const char *s1, const char *s2);
-
-/* Heap save/restore contents and context for PM D0/D3 events */
-uint32_t mm_pm_context_size(void);
-int mm_pm_context_save(struct dma_copy *dc, struct dma_sg_config *sg);
-int mm_pm_context_restore(struct dma_copy *dc, struct dma_sg_config *sg);
-
-/* heap initialisation */
-void init_heap(struct sof *sof);
-
-/* frees entire heap (supported for slave core system heap atm) */
-void free_heap(enum mem_zone zone);
-
-/* status */
-void heap_trace_all(int force);
-void heap_trace(struct mm_heap *heap, int size);
-
-/* retrieve memory map pointer */
-static inline struct mm *memmap_get(void)
-{
-	return sof_get()->memory_map;
-}
 
 #endif /* __SOF_LIB_ALLOC_H__ */

--- a/src/include/sof/lib/alloc.h
+++ b/src/include/sof/lib/alloc.h
@@ -17,11 +17,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#define trace_mem_error(__e, ...) \
-	trace_error(TRACE_CLASS_MEM, __e, ##__VA_ARGS__)
-#define trace_mem_init(__e, ...) \
-	trace_event(TRACE_CLASS_MEM, __e, ##__VA_ARGS__)
-
 /* Heap Memory Zones
  *
  * The heap has three different zones from where memory can be allocated :-
@@ -61,99 +56,6 @@ void *_brealloc(void *ptr, uint32_t flags, uint32_t caps, size_t bytes,
 		uint32_t alignment);
 void rfree(void *ptr);
 
-#if CONFIG_DEBUG_HEAP
-
-#define rmalloc(zone, flags, caps, bytes)				\
-	({void *_ptr;							\
-	do {								\
-		_ptr = _malloc(zone, flags, caps, bytes);		\
-		if (!_ptr) {						\
-			trace_mem_error("failed to alloc 0x%x bytes caps 0x%x flags 0x%x",\
-					bytes, caps, flags);		\
-			alloc_trace_runtime_heap(caps, bytes);		\
-		}							\
-	} while (0);							\
-	_ptr; })
-
-#define rzalloc(zone, flags, caps, bytes)				\
-	({void *_ptr;							\
-	do {								\
-		_ptr = _zalloc(zone, flags, caps, bytes);		\
-		if (!_ptr) {						\
-			trace_mem_error("failed to alloc 0x%x bytes caps 0x%x flags 0x%x",\
-					bytes, caps, flags);		\
-			alloc_trace_runtime_heap(caps, bytes);		\
-		}							\
-	} while (0);							\
-	_ptr; })
-
-#define rballoc(flags, caps, bytes)				\
-	({void *_ptr;						\
-	do {							\
-		_ptr = _balloc(flags, caps, bytes,		\
-			       PLATFORM_DCACHE_ALIGN);		\
-		if (!_ptr) {					\
-			trace_mem_error("failed to alloc 0x%x bytes caps 0x%x flags 0x%x",\
-					bytes, caps, flags);	\
-			alloc_trace_buffer_heap(caps, bytes);	\
-		}						\
-	} while (0);						\
-	_ptr; })
-
-#define rrealloc(ptr, zone, flags, caps, bytes)				\
-	({void *_ptr;							\
-	do {								\
-		_ptr = _realloc(ptr, zone, flags, caps, bytes);		\
-		if (!_ptr) {						\
-			trace_mem_error("failed to alloc 0x%x bytes caps 0x%x flags 0x%x",\
-					bytes, caps, flags);		\
-			alloc_trace_buffer_heap(caps, bytes);		\
-		}							\
-	} while (0);							\
-	_ptr; })
-
-#define rbrealloc(ptr, flags, caps, bytes)				\
-	({void *_ptr;							\
-	do {								\
-		_ptr = _brealloc(ptr, flags, caps, bytes,		\
-				 PLATFORM_DCACHE_ALIGN);		\
-		if (!_ptr) {						\
-			trace_mem_error("failed to alloc 0x%x bytes caps 0x%x flags 0x%x",\
-					bytes, caps, flags);		\
-			alloc_trace_buffer_heap(caps, bytes);		\
-		}							\
-	} while (0);							\
-	_ptr; })
-
-#define rbrealloc_align(ptr, flags, caps, bytes, alignment)		\
-	({void *_ptr;							\
-	do {								\
-		_ptr = _brealloc(ptr, flags, caps, bytes, alignment);	\
-		if (!_ptr) {						\
-			trace_mem_error("failed to alloc 0x%x bytes caps 0x%x flags 0x%x",\
-					bytes, caps, flags);		\
-			alloc_trace_buffer_heap(caps, bytes);		\
-		}							\
-	} while (0);							\
-	_ptr; })
-
-#define rballoc_align(flags, caps, bytes, alignment)		\
-	({void *_ptr;						\
-	do {							\
-		_ptr = _balloc(flags, caps, bytes, alignment);	\
-		if (!_ptr) {					\
-			trace_mem_error("failed to alloc 0x%x bytes caps 0x%x flags 0x%x",\
-					bytes, caps, flags);	\
-			alloc_trace_buffer_heap(caps, bytes);	\
-		}						\
-	} while (0);						\
-	_ptr; })
-
-void alloc_trace_runtime_heap(uint32_t caps, size_t bytes);
-void alloc_trace_buffer_heap(uint32_t caps, size_t bytes);
-
-#else
-
 #define rmalloc(zone, flags, caps, bytes) \
 	_malloc(zone, flags, caps, bytes)
 #define rzalloc(zone, flags, caps, bytes) \
@@ -168,8 +70,6 @@ void alloc_trace_buffer_heap(uint32_t caps, size_t bytes);
 	_brealloc(ptr, flags, caps, bytes, PLATFORM_DCACHE_ALIGN)
 #define rbrealloc_align(ptr, flags, caps, bytes, alignment) \
 	_brealloc(ptr, flags, caps, bytes, alignment)
-
-#endif
 
 /* system heap allocation for specific core */
 void *rzalloc_core_sys(int core, size_t bytes);

--- a/src/include/sof/lib/mm_heap.h
+++ b/src/include/sof/lib/mm_heap.h
@@ -1,0 +1,95 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2016 Intel Corporation. All rights reserved.
+ *
+ * Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
+ *         Keyon Jie <yang.jie@linux.intel.com>
+ */
+
+#ifndef __SOF_LIB_MM_HEAP_H__
+#define __SOF_LIB_MM_HEAP_H__
+
+#include <sof/common.h>
+#include <sof/lib/alloc.h>
+#include <sof/lib/cache.h>
+#include <sof/lib/memory.h>
+#include <sof/sof.h>
+#include <sof/spinlock.h>
+#include <config.h>
+#include <stddef.h>
+#include <stdint.h>
+
+struct dma_copy;
+struct dma_sg_config;
+
+struct mm_info {
+	uint32_t used;
+	uint32_t free;
+};
+
+struct block_hdr {
+	uint16_t size;		/* size in blocks for continuous allocation */
+	uint16_t used;		/* usage flags for page */
+	void *unaligned_ptr;	/* align ptr */
+} __packed;
+
+struct block_map {
+	uint16_t block_size;	/* size of block in bytes */
+	uint16_t count;		/* number of blocks in map */
+	uint16_t free_count;	/* number of free blocks */
+	uint16_t first_free;	/* index of first free block */
+	struct block_hdr *block;	/* base block header */
+	uint32_t base;		/* base address of space */
+};
+
+#define BLOCK_DEF(sz, cnt, hdr) \
+	{.block_size = sz, .count = cnt, .free_count = cnt, .block = hdr, \
+	 .first_free = 0}
+
+struct mm_heap {
+	uint32_t blocks;
+	struct block_map *map;
+	uint32_t heap;
+	uint32_t size;
+	uint32_t caps;
+	struct mm_info info;
+};
+
+/* heap block memory map */
+struct mm {
+	/* system heap - used during init cannot be freed */
+	struct mm_heap system[PLATFORM_HEAP_SYSTEM];
+	/* system runtime heap - used for runtime system components */
+	struct mm_heap system_runtime[PLATFORM_HEAP_SYSTEM_RUNTIME];
+	/* general heap for components */
+	struct mm_heap runtime[PLATFORM_HEAP_RUNTIME];
+	/* general component buffer heap */
+	struct mm_heap buffer[PLATFORM_HEAP_BUFFER];
+
+	struct mm_info total;
+	uint32_t heap_trace_updated;	/* updates that can be presented */
+	spinlock_t lock;	/* all allocs and frees are atomic */
+};
+
+/* Heap save/restore contents and context for PM D0/D3 events */
+uint32_t mm_pm_context_size(void);
+int mm_pm_context_save(struct dma_copy *dc, struct dma_sg_config *sg);
+int mm_pm_context_restore(struct dma_copy *dc, struct dma_sg_config *sg);
+
+/* heap initialisation */
+void init_heap(struct sof *sof);
+
+/* frees entire heap (supported for slave core system heap atm) */
+void free_heap(enum mem_zone zone);
+
+/* status */
+void heap_trace_all(int force);
+void heap_trace(struct mm_heap *heap, int size);
+
+/* retrieve memory map pointer */
+static inline struct mm *memmap_get(void)
+{
+	return sof_get()->memory_map;
+}
+
+#endif /* __SOF_LIB_MM_HEAP_H__ */

--- a/src/init/init.c
+++ b/src/init/init.c
@@ -12,9 +12,9 @@
 #include <sof/debug/panic.h>
 #include <sof/drivers/interrupt.h>
 #include <sof/init.h>
-#include <sof/lib/alloc.h>
 #include <sof/lib/cpu.h>
 #include <sof/lib/memory.h>
+#include <sof/lib/mm_heap.h>
 #include <sof/lib/notifier.h>
 #include <sof/lib/pm_runtime.h>
 #include <sof/platform.h>

--- a/src/lib/alloc.c
+++ b/src/lib/alloc.c
@@ -11,6 +11,7 @@
 #include <sof/lib/cpu.h>
 #include <sof/lib/dma.h>
 #include <sof/lib/memory.h>
+#include <sof/lib/mm_heap.h>
 #include <sof/spinlock.h>
 #include <sof/string.h>
 #include <ipc/topology.h>

--- a/src/lib/alloc.c
+++ b/src/lib/alloc.c
@@ -601,7 +601,7 @@ void alloc_trace_buffer_heap(uint32_t caps, size_t bytes)
 	/* check buffer heap for capabilities */
 	trace_mem_init("heap: using buffer");
 
-	alloc_trace_heap(RZONE_BUFFER, caps, bytes, memmap->buffer,
+	alloc_trace_heap(SOF_MEM_ZONE_BUFFER, caps, bytes, memmap->buffer,
 			 PLATFORM_HEAP_BUFFER);
 
 	platform_shared_commit(memmap, sizeof(*memmap));

--- a/src/platform/baytrail/lib/memory.c
+++ b/src/platform/baytrail/lib/memory.c
@@ -5,7 +5,7 @@
 // Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
 
 #include <sof/common.h>
-#include <sof/lib/alloc.h>
+#include <sof/lib/mm_heap.h>
 #include <sof/lib/memory.h>
 #include <sof/sof.h>
 #include <ipc/topology.h>

--- a/src/platform/baytrail/platform.c
+++ b/src/platform/baytrail/platform.c
@@ -14,13 +14,13 @@
 #include <sof/drivers/timer.h>
 #include <sof/fw-ready-metadata.h>
 #include <sof/lib/agent.h>
-#include <sof/lib/alloc.h>
 #include <sof/lib/clk.h>
 #include <sof/lib/cpu.h>
 #include <sof/lib/dai.h>
 #include <sof/lib/dma.h>
 #include <sof/lib/mailbox.h>
 #include <sof/lib/memory.h>
+#include <sof/lib/mm_heap.h>
 #include <sof/lib/notifier.h>
 #include <sof/lib/shim.h>
 #include <sof/platform.h>

--- a/src/platform/haswell/lib/memory.c
+++ b/src/platform/haswell/lib/memory.c
@@ -5,7 +5,7 @@
 // Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
 
 #include <sof/common.h>
-#include <sof/lib/alloc.h>
+#include <sof/lib/mm_heap.h>
 #include <sof/lib/memory.h>
 #include <sof/sof.h>
 #include <ipc/topology.h>

--- a/src/platform/haswell/platform.c
+++ b/src/platform/haswell/platform.c
@@ -12,7 +12,6 @@
 #include <sof/drivers/timer.h>
 #include <sof/fw-ready-metadata.h>
 #include <sof/lib/agent.h>
-#include <sof/lib/alloc.h>
 #include <sof/lib/clk.h>
 #include <sof/lib/cpu.h>
 #include <sof/lib/dai.h>
@@ -20,6 +19,7 @@
 #include <sof/lib/io.h>
 #include <sof/lib/mailbox.h>
 #include <sof/lib/memory.h>
+#include <sof/lib/mm_heap.h>
 #include <sof/lib/notifier.h>
 #include <sof/lib/shim.h>
 #include <sof/schedule/edf_schedule.h>

--- a/src/platform/imx8/lib/memory.c
+++ b/src/platform/imx8/lib/memory.c
@@ -5,7 +5,7 @@
 // Author: Daniel Baluta <daniel.baluta@nxp.com>
 
 #include <sof/common.h>
-#include <sof/lib/alloc.h>
+#include <sof/lib/mm_heap.h>
 #include <sof/lib/memory.h>
 #include <sof/platform.h>
 #include <sof/sof.h>

--- a/src/platform/imx8/platform.c
+++ b/src/platform/imx8/platform.c
@@ -19,6 +19,7 @@
 #include <sof/lib/dma.h>
 #include <sof/lib/mailbox.h>
 #include <sof/lib/memory.h>
+#include <sof/lib/mm_heap.h>
 #include <sof/platform.h>
 #include <sof/schedule/edf_schedule.h>
 #include <sof/schedule/ll_schedule.h>

--- a/src/platform/imx8m/lib/memory.c
+++ b/src/platform/imx8m/lib/memory.c
@@ -5,7 +5,7 @@
 // Author: Daniel Baluta <daniel.baluta@nxp.com>
 
 #include <sof/common.h>
-#include <sof/lib/alloc.h>
+#include <sof/lib/mm_heap.h>
 #include <sof/lib/memory.h>
 #include <sof/platform.h>
 #include <sof/sof.h>

--- a/src/platform/imx8m/platform.c
+++ b/src/platform/imx8m/platform.c
@@ -18,6 +18,7 @@
 #include <sof/lib/dma.h>
 #include <sof/lib/mailbox.h>
 #include <sof/lib/memory.h>
+#include <sof/lib/mm_heap.h>
 #include <sof/platform.h>
 #include <sof/schedule/edf_schedule.h>
 #include <sof/schedule/ll_schedule.h>

--- a/src/platform/intel/cavs/lib/memory.c
+++ b/src/platform/intel/cavs/lib/memory.c
@@ -6,7 +6,7 @@
 //         Janusz Jankowski <janusz.jankowski@linux.intel.com>
 
 #include <sof/common.h>
-#include <sof/lib/alloc.h>
+#include <sof/lib/mm_heap.h>
 #include <sof/lib/cache.h>
 #include <sof/lib/cpu.h>
 #include <sof/lib/memory.h>

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -22,7 +22,6 @@
 #include <sof/drivers/timer.h>
 #include <sof/fw-ready-metadata.h>
 #include <sof/lib/agent.h>
-#include <sof/lib/alloc.h>
 #include <sof/lib/cache.h>
 #include <sof/lib/clk.h>
 #include <sof/lib/cpu.h>
@@ -31,6 +30,7 @@
 #include <sof/lib/io.h>
 #include <sof/lib/mailbox.h>
 #include <sof/lib/memory.h>
+#include <sof/lib/mm_heap.h>
 #include <sof/lib/notifier.h>
 #include <sof/lib/pm_runtime.h>
 #include <sof/lib/wait.h>

--- a/test/cmocka/src/audio/pipeline/pipeline_mocks.c
+++ b/test/cmocka/src/audio/pipeline/pipeline_mocks.c
@@ -5,6 +5,7 @@
 // Author: Jakub Dabek <jakub.dabek@linux.intel.com>
 
 #include "pipeline_mocks.h"
+#include <sof/lib/mm_heap.h>
 
 #include <mock_trace.h>
 

--- a/test/cmocka/src/common_mocks.c
+++ b/test/cmocka/src/common_mocks.c
@@ -8,6 +8,7 @@
 #include <errno.h>
 #include <sof/lib/alloc.h>
 #include <sof/drivers/timer.h>
+#include <sof/lib/mm_heap.h>
 #include <stdlib.h>
 #include <stdarg.h>
 #include <stddef.h>

--- a/test/cmocka/src/lib/alloc/alloc.c
+++ b/test/cmocka/src/lib/alloc/alloc.c
@@ -13,6 +13,7 @@
 
 #include <sof/sof.h>
 #include <sof/lib/alloc.h>
+#include <sof/lib/mm_heap.h>
 #include <ipc/header.h>
 #include <ipc/topology.h>
 

--- a/tools/testbench/alloc.c
+++ b/tools/testbench/alloc.c
@@ -12,6 +12,7 @@
 #include <stdio.h>
 #include <malloc.h>
 #include <sof/lib/alloc.h>
+#include <sof/lib/mm_heap.h>
 #include "testbench/common_test.h"
 
 /* testbench mem alloc definition */


### PR DESCRIPTION
All clients that just wants to allocate and free memory does not need to know all the heap management API and internals. Again, physical separation seems better than trying to annotate the header with documentation groups etc.

Duplicated heap debug code was removed from the header. Internal trace definitions moved from the header as well.

Now the alloc.h contains just the "alloc" API, a good starting point for dox-ing and linking to sof-docs for application developers.