### PR TITLE
muxdemux: Properly assign processing function during mux_prepare() call.

### DIFF
--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -477,9 +477,20 @@ static int mux_reset(struct comp_dev *dev)
 
 static int mux_prepare(struct comp_dev *dev)
 {
+	struct comp_data *cd = comp_get_drvdata(dev);
 	int ret;
 
 	comp_info(dev, "mux_prepare()");
+
+	if (dev->comp.type == SOF_COMP_MUX)
+		cd->mux = mux_get_processing_function(dev);
+	else
+		cd->demux = demux_get_processing_function(dev);
+
+	if (!cd->mux && !cd->demux) {
+		comp_err(dev, "mux_prepare() error: Invalid configuration, couldn't find suitable processing function.");
+		return -EINVAL;
+	}
 
 	ret = comp_set_state(dev, COMP_TRIGGER_PREPARE);
 	if (ret) {


### PR DESCRIPTION
Currently, after pipeline params propagation, mux/demux processing
function might not be properly set up, if current params mismatch
ones assigned with binary blob during instantiation.
Similar assignment was there originally, but was lost to the history.

Should resolve https://github.com/thesofproject/sof/issues/2533 and https://github.com/thesofproject/sof/issues/2529

Signed-off-by: Artur Kloniecki <arturx.kloniecki@linux.intel.com>