### PR TITLE
cmocka/cmake: don't re-fetch (and change) cmocka.git on every build

### DIFF
--- a/test/cmocka/CMakeLists.txt
+++ b/test/cmocka/CMakeLists.txt
@@ -14,6 +14,8 @@ else()
 	# Build Cmocka locally
 	ExternalProject_Add(cmocka_git
 		GIT_REPOSITORY https://github.com/thesofproject/cmocka
+		# Don't re-fetch (and change!) the code every time we rebuild
+		UPDATE_DISCONNECTED True
 		PREFIX "${PROJECT_BINARY_DIR}/cmocka_git"
 		BINARY_DIR ${cmocka_binary_directory}
 		CMAKE_ARGS -DCMAKE_BUILD_TYPE=Release


### PR DESCRIPTION
Add "UPDATE_DISCONNECTED True" property in ExternalProject_Add() so:

- Unit tests can be rebuilt without a network connection
- The code can't change from one build to the next without the developer
  being aware.

Found by chance thanks to some network issue.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>