### PR TITLE
test/kpb: fix tests[1] array out of bounds

### DIFF
--- a/test/cmocka/src/audio/kpb/kpb_buffer.c
+++ b/test/cmocka/src/audio/kpb/kpb_buffer.c
@@ -255,7 +255,7 @@ static void null_test_success(void **state)
 /* Test main function */
 int main(void)
 {
-	struct CMUnitTest tests[1];
+	struct CMUnitTest tests[2];
 	struct test_case internal_buffering = {
 		.period_bytes = KPB_MAX_BUFFER_SIZE(16),
 		.history_buffer_size = KPB_MAX_BUFFER_SIZE(16),


### PR DESCRIPTION
As reported by gcc.

Fixes: 0b279e06bc1d. This is a partial, one-line revert of that commit
that decreased the size of this array for no obvious reason.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>