### PR TITLE
Boot test for i.MX8M

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,3 +72,5 @@ jobs:
       env: PLATFORM=imx8
     - <<: *qemuboottest
       env: PLATFORM=imx8x
+    - <<: *qemuboottest
+      env: PLATFORM=imx8m


### PR DESCRIPTION
i.MX8M is now supported in qemu up to boot. So, add it to boottest list.