### PR TITLE
muxdemux: Optimize and cleanup mux/demux internal and external interface.

### DIFF
--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -71,7 +71,6 @@ static int mux_set_values(struct comp_dev *dev, struct comp_data *cd,
 	}
 
 	cd->config.num_channels = cfg->num_channels;
-	cd->config.frame_format = cfg->frame_format;
 
 	for (i = 0; i < cfg->num_streams; i++) {
 		cd->config.streams[i].num_channels = cfg->streams[i].num_channels;
@@ -80,10 +79,12 @@ static int mux_set_values(struct comp_dev *dev, struct comp_data *cd,
 			cd->config.streams[i].mask[j] = cfg->streams[i].mask[j];
 	}
 
-	if (dev->comp.type == SOF_COMP_MUX)
-		cd->mux = mux_get_processing_function(dev);
-	else
-		cd->demux = demux_get_processing_function(dev);
+	if (dev->state > COMP_STATE_INIT) {
+		if (dev->comp.type == SOF_COMP_MUX)
+			cd->mux = mux_get_processing_function(dev);
+		else
+			cd->demux = demux_get_processing_function(dev);
+	}
 
 	return 0;
 }
@@ -104,6 +105,8 @@ static struct comp_dev *mux_new(const struct comp_driver *drv,
 		      COMP_SIZE(struct sof_ipc_comp_process));
 	if (!dev)
 		return NULL;
+
+	dev->state = COMP_STATE_INIT;
 	dev->drv = drv;
 
 	dev->size = COMP_SIZE(struct sof_ipc_comp_process);
@@ -198,7 +201,6 @@ static int mux_params(struct comp_dev *dev,
 				  source_list);
 
 	cd->config.num_channels = sinkb->stream.channels;
-	cd->config.frame_format = sinkb->stream.frame_fmt;
 
 	return 0;
 }

--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -61,21 +61,9 @@ static int mux_set_values(struct comp_dev *dev, struct comp_data *cd,
 		}
 	}
 
-	/* check if number of channels per stream doesn't exceed maximum */
 	for (i = 0; i < cfg->num_streams; i++) {
-		if (cfg->streams[i].num_channels > PLATFORM_MAX_CHANNELS) {
-			comp_cl_err(&comp_mux, "mux_set_values(): configured number of channels for stream %u exceeds platform maximum = "
-				    META_QUOTE(PLATFORM_MAX_CHANNELS), i);
-			return -EINVAL;
-		}
-	}
-
-	cd->config.num_channels = cfg->num_channels;
-
-	for (i = 0; i < cfg->num_streams; i++) {
-		cd->config.streams[i].num_channels = cfg->streams[i].num_channels;
 		cd->config.streams[i].pipeline_id = cfg->streams[i].pipeline_id;
-		for (j = 0; j < cfg->streams[i].num_channels; j++)
+		for (j = 0; j < PLATFORM_MAX_CHANNELS; j++)
 			cd->config.streams[i].mask[j] = cfg->streams[i].mask[j];
 	}
 
@@ -185,8 +173,6 @@ static int mux_verify_params(struct comp_dev *dev,
 static int mux_params(struct comp_dev *dev,
 		      struct sof_ipc_stream_params *params)
 {
-	struct comp_data *cd = comp_get_drvdata(dev);
-	struct comp_buffer *sinkb;
 	int err;
 
 	comp_info(dev, "mux_params()");
@@ -196,11 +182,6 @@ static int mux_params(struct comp_dev *dev,
 		comp_err(dev, "mux_fir_params(): pcm params verification failed.");
 		return -EINVAL;
 	}
-
-	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer,
-				  source_list);
-
-	cd->config.num_channels = sinkb->stream.channels;
 
 	return 0;
 }

--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -359,7 +359,7 @@ static int demux_copy(struct comp_dev *dev)
 			continue;
 
 		buffer_invalidate(source, source_bytes);
-		cd->demux(dev, &sinks[i]->stream, &source->stream, frames,
+		cd->demux(&sinks[i]->stream, &source->stream, frames,
 			  &cd->config.streams[i]);
 		buffer_writeback(sinks[i], sinks_bytes[i]);
 	}
@@ -455,7 +455,7 @@ static int mux_copy(struct comp_dev *dev)
 	sink_bytes = frames * audio_stream_frame_bytes(&sink->stream);
 
 	/* produce output */
-	cd->mux(dev, &sink->stream, &sources_stream[0], frames,
+	cd->mux(&sink->stream, &sources_stream[0], frames,
 		&cd->config.streams[0]);
 	buffer_writeback(sink, sink_bytes);
 

--- a/src/audio/mux/mux_generic.c
+++ b/src/audio/mux/mux_generic.c
@@ -385,11 +385,17 @@ const struct comp_func_map mux_func_map[] = {
 
 mux_func mux_get_processing_function(struct comp_dev *dev)
 {
-	struct comp_data *cd = comp_get_drvdata(dev);
+	struct comp_buffer *sinkb;
 	uint8_t i;
 
+	if (list_is_empty(&dev->bsink_list))
+		return NULL;
+
+	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer,
+				source_list);
+
 	for (i = 0; i < ARRAY_SIZE(mux_func_map); i++) {
-		if (cd->config.frame_format == mux_func_map[i].frame_format)
+		if (sinkb->stream.frame_fmt == mux_func_map[i].frame_format)
 			return mux_func_map[i].mux_proc_func;
 	}
 
@@ -398,11 +404,17 @@ mux_func mux_get_processing_function(struct comp_dev *dev)
 
 demux_func demux_get_processing_function(struct comp_dev *dev)
 {
-	struct comp_data *cd = comp_get_drvdata(dev);
+	struct comp_buffer *sinkb;
 	uint8_t i;
 
+	if (list_is_empty(&dev->bsink_list))
+		return NULL;
+
+	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer,
+				source_list);
+
 	for (i = 0; i < ARRAY_SIZE(mux_func_map); i++) {
-		if (cd->config.frame_format == mux_func_map[i].frame_format)
+		if (sinkb->stream.frame_fmt == mux_func_map[i].frame_format)
 			return mux_func_map[i].demux_proc_func;
 	}
 

--- a/src/audio/mux/mux_generic.c
+++ b/src/audio/mux/mux_generic.c
@@ -53,13 +53,12 @@ UT_STATIC inline int32_t calc_sample_s16le(const struct audio_stream *source,
  * mux_stream_data structure. Each bitmask describes composition of single
  * output channel.
  *
- * \param[in,out] dev Demux base component device.
  * \param[in,out] sink Destination buffer.
  * \param[in,out] source Source buffer.
  * \param[in] frames Number of frames to process.
  * \param[in] data Parameters describing channel count and routing.
  */
-static void demux_s16le(const struct comp_dev *dev, struct audio_stream *sink,
+static void demux_s16le(struct audio_stream *sink,
 			const struct audio_stream *source, uint32_t frames,
 			struct mux_stream_data *data)
 {
@@ -90,14 +89,13 @@ static void demux_s16le(const struct comp_dev *dev, struct audio_stream *sink,
  * of it's channels describing to which channels of output stream it
  * contributes.
  *
- * \param[in,out] dev Demux base component device.
  * \param[in,out] sink Destination buffer.
  * \param[in,out] sources Array of source buffers.
  * \param[in] frames Number of frames to process.
  * \param[in] data Array of parameters describing channel count and routing for
  *		   each stream.
  */
-static void mux_s16le(const struct comp_dev *dev, struct audio_stream *sink,
+static void mux_s16le(struct audio_stream *sink,
 		      const struct audio_stream **sources, uint32_t frames,
 		      struct mux_stream_data *data)
 {
@@ -165,13 +163,12 @@ UT_STATIC inline int32_t calc_sample_s24le(const struct audio_stream *source,
  * mux_stream_data structure. Each bitmask describes composition of single
  * output channel.
  *
- * \param[in,out] dev Demux base component device.
  * \param[in,out] sink Destination buffer.
  * \param[in,out] source Source buffer.
  * \param[in] frames Number of frames to process.
  * \param[in] data Parameters describing channel count and routing.
  */
-static void demux_s24le(const struct comp_dev *dev, struct audio_stream *sink,
+static void demux_s24le(struct audio_stream *sink,
 			const struct audio_stream *source, uint32_t frames,
 			struct mux_stream_data *data)
 {
@@ -202,14 +199,13 @@ static void demux_s24le(const struct comp_dev *dev, struct audio_stream *sink,
  * of it's channels describing to which channels of output stream it
  * contributes.
  *
- * \param[in,out] dev Demux base component device.
  * \param[in,out] sink Destination buffer.
  * \param[in,out] sources Array of source buffers.
  * \param[in] frames Number of frames to process.
  * \param[in] data Array of parameters describing channel count and routing for
  *		   each stream.
  */
-static void mux_s24le(const struct comp_dev *dev, struct audio_stream *sink,
+static void mux_s24le(struct audio_stream *sink,
 		      const struct audio_stream **sources, uint32_t frames,
 		      struct mux_stream_data *data)
 {
@@ -276,13 +272,12 @@ UT_STATIC inline int64_t calc_sample_s32le(const struct audio_stream *source,
  * mux_stream_data structure. Each bitmask describes composition of single
  * output channel.
  *
- * \param[in,out] dev Demux base component device.
  * \param[in,out] sink Destination buffer.
  * \param[in,out] source Source buffer.
  * \param[in] frames Number of frames to process.
  * \param[in] data Parameters describing channel count and routing.
  */
-static void demux_s32le(const struct comp_dev *dev, struct audio_stream *sink,
+static void demux_s32le(struct audio_stream *sink,
 			const struct audio_stream *source, uint32_t frames,
 			struct mux_stream_data *data)
 {
@@ -313,14 +308,13 @@ static void demux_s32le(const struct comp_dev *dev, struct audio_stream *sink,
  * of it's channels describing to which channels of output stream it
  * contributes.
  *
- * \param[in,out] dev Demux base component device.
  * \param[in,out] sink Destination buffer.
  * \param[in,out] sources Array of source buffers.
  * \param[in] frames Number of frames to process.
  * \param[in] data Array of parameters describing channel count and routing for
  *		   each stream.
  */
-static void mux_s32le(const struct comp_dev *dev, struct audio_stream *sink,
+static void mux_s32le(struct audio_stream *sink,
 		      const struct audio_stream **sources, uint32_t frames,
 		      struct mux_stream_data *data)
 {

--- a/src/include/sof/audio/mux.h
+++ b/src/include/sof/audio/mux.h
@@ -43,10 +43,10 @@ struct mux_stream_data {
 	uint8_t reserved[(20 - PLATFORM_MAX_CHANNELS - 1) % 4]; // padding to ensure proper alignment of following instances
 };
 
-typedef void(*demux_func)(const struct comp_dev *dev, struct audio_stream *sink,
+typedef void(*demux_func)(struct audio_stream *sink,
 			  const struct audio_stream *source, uint32_t frames,
 			  struct mux_stream_data *data);
-typedef void(*mux_func)(const struct comp_dev *dev, struct audio_stream *sink,
+typedef void(*mux_func)(struct audio_stream *sink,
 			const struct audio_stream **sources, uint32_t frames,
 			struct mux_stream_data *data);
 

--- a/src/include/sof/audio/mux.h
+++ b/src/include/sof/audio/mux.h
@@ -85,18 +85,15 @@ void sys_comp_mux_init(void);
 
 #if CONFIG_FORMAT_S16LE
 int32_t calc_sample_s16le(const struct audio_stream *source,
-			  uint8_t num_ch, uint32_t offset,
-			  uint8_t mask);
+			  uint32_t offset, uint8_t mask);
 #endif /* CONFIG_FORMAT_S16LE */
 #if CONFIG_FORMAT_S24LE
 int32_t calc_sample_s24le(const struct audio_stream *source,
-			  uint8_t num_ch, uint32_t offset,
-			  uint8_t mask);
+			  uint32_t offset, uint8_t mask);
 #endif /* CONFIG_FORMAT_S24LE */
 #if CONFIG_FORMAT_S32LE
 int64_t calc_sample_s32le(const struct audio_stream *source,
-			  uint8_t num_ch, uint32_t offset,
-			  uint8_t mask);
+			  uint32_t offset, uint8_t mask);
 #endif /* CONFIG_FORMAT_S32LE */
 #endif /* UNIT_TEST */
 

--- a/src/include/sof/audio/mux.h
+++ b/src/include/sof/audio/mux.h
@@ -37,7 +37,7 @@ STATIC_ASSERT(MUX_MAX_STREAMS < PLATFORM_MAX_STREAMS,
 
 struct mux_stream_data {
 	uint32_t pipeline_id;
-	uint8_t num_channels;
+	uint8_t num_channels_deprecated;	/* deprecated in ABI 3.15 */
 	uint8_t mask[PLATFORM_MAX_CHANNELS];
 
 	uint8_t reserved[(20 - PLATFORM_MAX_CHANNELS - 1) % 4]; // padding to ensure proper alignment of following instances
@@ -51,8 +51,8 @@ typedef void(*mux_func)(struct audio_stream *sink,
 			struct mux_stream_data *data);
 
 struct sof_mux_config {
-	uint16_t frame_format;
-	uint16_t num_channels;
+	uint16_t frame_format_deprecated;	/* deprecated in ABI 3.15 */
+	uint16_t num_channels_deprecated;	/* deprecated in ABI 3.15 */
 	uint16_t num_streams;
 
 	uint16_t reserved; // padding to ensure proper alignment

--- a/test/cmocka/src/audio/mux/demux_copy.c
+++ b/test/cmocka/src/audio/mux/demux_copy.c
@@ -102,13 +102,10 @@ static struct sof_ipc_comp_process *create_demux_comp_ipc(struct test_data *td)
 	ipc->config.hdr.size = sizeof(struct sof_ipc_comp_config);
 	ipc->size = mux_size;
 
-	mux->frame_format = td->format;
-	mux->num_channels = PLATFORM_MAX_CHANNELS;
 	mux->num_streams = MUX_MAX_STREAMS;
 
 	for (i = 0; i < MUX_MAX_STREAMS; ++i) {
 		mux->streams[i].pipeline_id = i;
-		mux->streams[i].num_channels = PLATFORM_MAX_CHANNELS;
 		for (j = 0; j < PLATFORM_MAX_CHANNELS; ++j)
 			mux->streams[i].mask[j] = td->mask[i][j];
 	}

--- a/test/cmocka/src/audio/mux/mux_copy.c
+++ b/test/cmocka/src/audio/mux/mux_copy.c
@@ -114,13 +114,10 @@ static struct sof_ipc_comp_process *create_mux_comp_ipc(struct test_data *td)
 	ipc->config.hdr.size = sizeof(struct sof_ipc_comp_config);
 	ipc->size = mux_size;
 
-	mux->frame_format = td->format;
-	mux->num_channels = PLATFORM_MAX_CHANNELS;
 	mux->num_streams = MUX_MAX_STREAMS;
 
 	for (i = 0; i < MUX_MAX_STREAMS; ++i) {
 		mux->streams[i].pipeline_id = i;
-		mux->streams[i].num_channels = PLATFORM_MAX_CHANNELS;
 		for (j = 0; j < PLATFORM_MAX_CHANNELS; ++j)
 			mux->streams[i].mask[j] = td->mask[i][j];
 	}

--- a/test/cmocka/src/audio/mux/mux_generic_calc_sample_s16le.c
+++ b/test/cmocka/src/audio/mux/mux_generic_calc_sample_s16le.c
@@ -75,7 +75,6 @@ static void test_calc_sample(void **state)
 	struct test_data *td = *((struct test_data **)state);
 
 	int32_t ret =  calc_sample_s16le(&td->buffer->stream,
-					 td->channels,
 					 0,
 					 td->mask);
 
@@ -89,6 +88,7 @@ static int setup(void **state)
 
 	td->buffer = calloc(1, sizeof(struct comp_buffer));
 	td->buffer->stream.r_ptr = td->input;
+	td->buffer->stream.channels = td->channels;
 
 	td->expected_result = 0;
 

--- a/test/cmocka/src/audio/mux/mux_generic_calc_sample_s24le.c
+++ b/test/cmocka/src/audio/mux/mux_generic_calc_sample_s24le.c
@@ -77,7 +77,6 @@ static void test_calc_sample(void **state)
 	struct test_data *td = *((struct test_data **)state);
 
 	int32_t ret =  calc_sample_s24le(&td->buffer->stream,
-					 td->channels,
 					 0,
 					 td->mask);
 
@@ -91,6 +90,7 @@ static int setup(void **state)
 
 	td->buffer = calloc(1, sizeof(struct comp_buffer));
 	td->buffer->stream.r_ptr = td->input;
+	td->buffer->stream.channels = td->channels;
 
 	td->expected_result = 0;
 

--- a/test/cmocka/src/audio/mux/mux_generic_calc_sample_s32le.c
+++ b/test/cmocka/src/audio/mux/mux_generic_calc_sample_s32le.c
@@ -77,7 +77,6 @@ static void test_calc_sample(void **state)
 	struct test_data *td = *((struct test_data **)state);
 
 	int64_t ret =  calc_sample_s32le(&td->buffer->stream,
-					 td->channels,
 					 0,
 					 td->mask);
 
@@ -91,6 +90,7 @@ static int setup(void **state)
 
 	td->buffer = calloc(1, sizeof(struct comp_buffer));
 	td->buffer->stream.r_ptr = td->input;
+	td->buffer->stream.channels = td->channels;
 
 	td->expected_result = 0;
 

--- a/test/cmocka/src/audio/mux/mux_get_processing_function.c
+++ b/test/cmocka/src/audio/mux/mux_get_processing_function.c
@@ -5,6 +5,8 @@
 // Author: Daniel Bogdzia <danielx.bogdzia@linux.intel.com>
 //         Janusz Jankowski <janusz.jankowski@linux.intel.com>
 
+#include "util.h"
+
 #include <sof/audio/component_ext.h>
 #include <sof/audio/mux.h>
 
@@ -18,6 +20,7 @@
 struct test_data {
 	struct comp_dev *dev;
 	struct comp_data *cd;
+	struct comp_buffer *sink;
 };
 
 static int setup_group(void **state)
@@ -51,6 +54,8 @@ static int setup_test_case(void **state)
 
 	td->cd = (struct comp_data *)td->dev->priv_data;
 
+	td->sink = create_test_sink(td->dev, 0, 0, 0);
+
 	*state = td;
 
 	return 0;
@@ -61,6 +66,7 @@ static int teardown_test_case(void **state)
 	struct test_data *td = *state;
 
 	comp_free(td->dev);
+	free(td->sink);
 	free(td);
 
 	return 0;
@@ -73,7 +79,7 @@ static void test_mux_get_processing_function_invalid_float(void **state)
 	mux_func func = NULL;
 
 	/* set frame format value to unsupported value */
-	td->cd->config.frame_format = SOF_IPC_FRAME_FLOAT;
+	td->sink->stream.frame_fmt = SOF_IPC_FRAME_FLOAT;
 
 	func = mux_get_processing_function(td->dev);
 
@@ -87,7 +93,7 @@ static void test_mux_get_processing_function_valid_s16le(void **state)
 	struct test_data *td = *state;
 	mux_func func = NULL;
 
-	td->cd->config.frame_format = SOF_IPC_FRAME_S16_LE;
+	td->sink->stream.frame_fmt = SOF_IPC_FRAME_S16_LE;
 
 	func = mux_get_processing_function(td->dev);
 
@@ -101,7 +107,7 @@ static void test_mux_get_processing_function_valid_s24_4le(void **state)
 	struct test_data *td = *state;
 	mux_func func = NULL;
 
-	td->cd->config.frame_format = SOF_IPC_FRAME_S24_4LE;
+	td->sink->stream.frame_fmt = SOF_IPC_FRAME_S24_4LE;
 
 	func = mux_get_processing_function(td->dev);
 
@@ -115,7 +121,7 @@ static void test_mux_get_processing_function_valid_s32le(void **state)
 	struct test_data *td = *state;
 	mux_func func = NULL;
 
-	td->cd->config.frame_format = SOF_IPC_FRAME_S32_LE;
+	td->sink->stream.frame_fmt = SOF_IPC_FRAME_S32_LE;
 
 	func = mux_get_processing_function(td->dev);
 


### PR DESCRIPTION
Remove legacy dependency on config parameters which are no longer necessary and/or can be determined at runtime.
Also obsolete fields in the external API were renamed to 'reserved'. These fields might be removed, although that would cause backward incompatibility.
@lgirdwood @plbossart If you find it beneficial to remove these fields altogether, please let me know, I'll add such change to this PR.