### PR TITLE
Topology: sof-icl-rt711-rt1308-rt715-hdmi: Use demux for platforms with multiple speakers

### DIFF
--- a/tools/topology/sof-icl-rt711-rt1308-rt715-hdmi.m4
+++ b/tools/topology/sof-icl-rt711-rt1308-rt715-hdmi.m4
@@ -51,6 +51,16 @@ PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
+ifdef(`MONO',
+`
+# Low Latency playback pipeline 3 on PCM 2 using max 2 channels of s32le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	3, 2, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+',
+`
 # Low Latency playback pipeline 3 on PCM 2 using max 2 channels of s32le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-volume-demux-playback.m4,
@@ -58,13 +68,13 @@ PIPELINE_PCM_ADD(sof/pipe-volume-demux-playback.m4,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
-ifdef(`MONO', `',
-`# Low Latency playback pipeline 4 on PCM 3 using max 2 channels of s32le.
+# Low Latency playback pipeline 4 on PCM 3 using max 2 channels of s32le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-dai-endpoint.m4,
 	4, 3, 2, s32le,
 	1000, 0, 0,
-	48000, 48000, 48000)')
+	48000, 48000, 48000)
+')
 
 # Low Latency capture pipeline 5 on PCM 4 using max 2 channels of s32le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0


### PR DESCRIPTION
We only need demux for two speaker dais case.

Fixes: 5e8de9f "topology: sof-icl-rt711-rt1308-rt715-hdmi: Merge two pipeline with demux"
Signed-off-by: Bard Liao <yung-chuan.liao@linux.intel.com>

Fixes #2570 