### PR TITLE
tools: logger: Skip double error logs to stdout

### DIFF
--- a/tools/logger/convert.c
+++ b/tools/logger/convert.c
@@ -68,7 +68,9 @@ static void log_err(FILE *out_fd, const char *fmt, ...)
 	if (buff) {
 		vsprintf(buff, fmt, args);
 		fprintf(stderr, "%s", buff);
-		if (out_fd) {
+
+		/* take care about out_fd validity and duplicated logging */
+		if (out_fd && out_fd != stderr && out_fd != stdout) {
 			fprintf(out_fd, "%s", buff);
 			fflush(out_fd);
 		}


### PR DESCRIPTION
When out_fd points standard output then error message shouldn't be
duplicated - duplicated messages only make logger output more messy.

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>