### PR TITLE
scripts: qemu: Add qemu check for i.MX8M platform

### DIFF
--- a/scripts/qemu-check.sh
+++ b/scripts/qemu-check.sh
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright(c) 2018 Intel Corporation. All rights reserved.
 
-SUPPORTED_PLATFORMS=(byt cht bdw hsw apl icl skl kbl cnl imx8 imx8x)
+SUPPORTED_PLATFORMS=(byt cht bdw hsw apl icl skl kbl cnl imx8 imx8x imx8m)
 READY_MSG="6c 00 00 00 00 00 00 70"
 
 rm -f dump-*.txt
@@ -103,7 +103,7 @@ do
 		SHM_MBOX=qemu-bridge-hp-sram-mem
 		ROM="-r ../sof.git/build_${j}_gcc/src/arch/xtensa/rom-$j.bin"
 	fi
-	if [ $j == "imx8" ] || [ $j == "imx8x" ]
+	if [ $j == "imx8" ] || [ $j == "imx8x" ] || [ $j == "imx8m" ]
 	then
 		READY_IPC="00 00 00 00 00 00 04 c0"
 		SHM_IPC_REG=qemu-bridge-mu-io


### PR DESCRIPTION
Enable checks to i.MX8M platform of QEMU now.

Signed-off-by: Diana Cretu <dianacretu2806@gmail.com>