### PR TITLE
Tools: Test: Audio: Add double quotes to shell scripts

### DIFF
--- a/tools/test/audio/asrc_run.sh
+++ b/tools/test/audio/asrc_run.sh
@@ -2,13 +2,25 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright(c) 2020 Intel Corporation. All rights reserved.
 
-if [ -z "$6" ]; then
-    echo "Usage:   $0 <bits in> <bits out> <rate in> <rate out> <input> <output>"
-    echo "Example: $0 16 16 32000 48000 input.raw output.raw"
-    exit
-fi
+usage ()
+{
+    echo "Usage:   $1 <bits in> <bits out> <rate in> <rate out> <input> <output>"
+    echo "Example: $1 16 16 32000 48000 input.raw output.raw"
+}
 
-COMP=asrc
-DIRECTION=playback
+main()
+{
+    local COMP DIRECTION
 
-./comp_run.sh $COMP $DIRECTION $1 $2 $3 $4 $5 $6
+    if [ $# -ne 6 ]; then
+	usage "$0"
+	exit
+    fi
+
+    COMP=asrc
+    DIRECTION=playback
+
+    ./comp_run.sh $COMP $DIRECTION "$@"
+}
+
+main "$@"

--- a/tools/test/audio/comp_run.sh
+++ b/tools/test/audio/comp_run.sh
@@ -25,7 +25,7 @@ TPLGFN=test-${DIRECTION}-ssp5-mclk-0-I2S-${COMP}-${INFMT}-${OUTFMT}-48k-24576k-c
 TPLG=${TPLG_DIR}/${TPLGFN}
 
 # If binary test vectors
-if [ ${FN_IN: -4} == ".raw" ]; then
+if [ "${FN_IN: -4}" == ".raw" ]; then
     BINFMT="-b S${BITS_IN}_LE"
 else
     BINFMT=""

--- a/tools/test/audio/eqfir_run.sh
+++ b/tools/test/audio/eqfir_run.sh
@@ -2,13 +2,25 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright(c) 2020 Intel Corporation. All rights reserved.
 
-if [ -z "$5" ]; then
+usage ()
+{
     echo "Usage:   $0 <bits in> <bits out> <rate> <input> <output>"
     echo "Example: $0 16 16 48000 input.raw output.raw"
-    exit
-fi
+}
 
-COMP=eq-fir
-DIRECTION=playback
+main ()
+{
+    local COMP DIRECTION
 
-./comp_run.sh $COMP $DIRECTION $1 $2 $3 $3 $4 $5
+    if [ $# -ne 5 ]; then
+	usage "$0"
+	exit
+    fi
+
+    COMP=eq-fir
+    DIRECTION=playback
+
+    ./comp_run.sh $COMP $DIRECTION "$1" "$2" "$3" "$3" "$4" "$5"
+}
+
+main "$@"

--- a/tools/test/audio/eqiir_run.sh
+++ b/tools/test/audio/eqiir_run.sh
@@ -2,14 +2,25 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright(c) 2020 Intel Corporation. All rights reserved.
 
-if [ -z "$5" ]; then
+usage ()
+{
     echo "Usage:   $0 <bits in> <bits out> <rate> <input> <output>"
     echo "Example: $0 16 16 48000 input.raw output.raw"
-    exit
-fi
+}
 
+main ()
+{
+    local COMP DIRECTION
 
-COMP=eq-iir
-DIRECTION=playback
+    if [ $# -ne 5 ]; then
+	usage "$0"
+	exit
+    fi
 
-./comp_run.sh $COMP $DIRECTION $1 $2 $3 $3 $4 $5
+    COMP=eq-iir
+    DIRECTION=playback
+
+    ./comp_run.sh $COMP $DIRECTION "$1" "$2" "$3" "$3" "$4" "$5"
+}
+
+main "$@"

--- a/tools/test/audio/src_run.sh
+++ b/tools/test/audio/src_run.sh
@@ -2,13 +2,25 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright(c) 2018-2020 Intel Corporation. All rights reserved.
 
-if [ -z "$6" ]; then
-    echo "Usage:   $0 <bits in> <bits out> <rate in> <rate out> <input> <output>"
-    echo "Example: $0 16 16 32000 48000 input.raw output.raw"
-    exit
-fi
+usage ()
+{
+    echo "Usage:   $1 <bits in> <bits out> <rate in> <rate out> <input> <output>"
+    echo "Example: $1 16 16 32000 48000 input.raw output.raw"
+}
 
-COMP=src
-DIRECTION=playback
+main()
+{
+    local COMP DIRECTION
 
-./comp_run.sh $COMP $DIRECTION $1 $2 $3 $4 $5 $6
+    if [ $# -ne 6 ]; then
+	usage "$0"
+	exit
+    fi
+
+    COMP=src
+    DIRECTION=playback
+
+    ./comp_run.sh $COMP $DIRECTION "$@"
+}
+
+main "$@"

--- a/tools/test/audio/volume_run.sh
+++ b/tools/test/audio/volume_run.sh
@@ -2,14 +2,25 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright(c) 2020 Intel Corporation. All rights reserved.
 
-if [ -z "$5" ]; then
+usage ()
+{
     echo "Usage:   $0 <bits in> <bits out> <rate> <input> <output>"
     echo "Example: $0 16 16 48000 input.raw output.raw"
-    exit
-fi
+}
 
+main ()
+{
+    local COMP DIRECTION
 
-COMP=volume
-DIRECTION=playback
+    if [ $# -ne 5 ]; then
+	usage "$0"
+	exit
+    fi
 
-./comp_run.sh $COMP $DIRECTION $1 $2 $3 $3 $4 $5
+    COMP=volume
+    DIRECTION=playback
+
+    ./comp_run.sh $COMP $DIRECTION "$1" "$2" "$3" "$3" "$4" "$5"
+}
+
+main "$@"


### PR DESCRIPTION
This patch adds the double quotes to shell scripts to avoid fails
with arguments or shell variables when there are space characters.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>