### PR TITLE
cmake: Do not duplicate subdirectory adding for library build

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,21 +2,18 @@
 
 add_subdirectory(platform)
 add_subdirectory(arch)
+add_subdirectory(ipc)
+add_subdirectory(audio)
+add_subdirectory(lib)
+add_local_sources(sof spinlock.c)
 
 if(BUILD_LIBRARY)
-	add_subdirectory(ipc)
-	add_subdirectory(audio)
-	add_subdirectory(lib)
-	add_local_sources(sof spinlock.c)
 	return()
 endif()
 
-add_subdirectory(audio)
 add_subdirectory(debug)
 add_subdirectory(drivers)
 add_subdirectory(init)
-add_subdirectory(ipc)
-add_subdirectory(lib)
 add_subdirectory(math)
 add_subdirectory(schedule)
 
@@ -27,5 +24,3 @@ endif()
 if (CONFIG_PROBE)
 	add_subdirectory(probe)
 endif()
-
-add_local_sources(sof spinlock.c)


### PR DESCRIPTION
Cmake files should have consistent directory linkage scheme
where lines duplication should be avoided.

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>