### PR TITLE
sof: trace: Remove error prefix from logs

### DIFF
--- a/src/audio/asrc/asrc.c
+++ b/src/audio/asrc/asrc.c
@@ -366,12 +366,12 @@ static int asrc_verify_params(struct comp_dev *dev,
 	 */
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK) {
 		if (params->rate != asrc->source_rate && asrc->source_rate) {
-			comp_err(dev, "asrc_verify_params(): error: runtime stream pcm rate does not match rate fetched from ipc.");
+			comp_err(dev, "asrc_verify_params(): runtime stream pcm rate does not match rate fetched from ipc.");
 			return -EINVAL;
 		}
 	} else {
 		if (params->rate != asrc->sink_rate && asrc->sink_rate) {
-			comp_err(dev, "asrc_verify_params(): error: runtime stream pcm rate does not match rate fetched from ipc.");
+			comp_err(dev, "asrc_verify_params(): runtime stream pcm rate does not match rate fetched from ipc.");
 			return -EINVAL;
 		}
 	}
@@ -380,7 +380,7 @@ static int asrc_verify_params(struct comp_dev *dev,
 	 */
 	ret = comp_verify_params(dev, BUFF_PARAMS_RATE, params);
 	if (ret < 0) {
-		comp_err(dev, "asrc_verify_params() error: comp_verify_params() failed.");
+		comp_err(dev, "asrc_verify_params(): comp_verify_params() failed.");
 		return ret;
 	}
 

--- a/src/audio/buffer.c
+++ b/src/audio/buffer.c
@@ -27,8 +27,8 @@ struct comp_buffer *buffer_alloc(uint32_t size, uint32_t caps, uint32_t align)
 
 	/* validate request */
 	if (size == 0 || size > HEAP_BUFFER_SIZE) {
-		trace_buffer_error("buffer_alloc() error: "
-				   "new size = %u is invalid", size);
+		trace_buffer_error("buffer_alloc(): new size = %u is invalid",
+				   size);
 		return NULL;
 	}
 
@@ -36,8 +36,7 @@ struct comp_buffer *buffer_alloc(uint32_t size, uint32_t caps, uint32_t align)
 	buffer = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM,
 			 sizeof(*buffer));
 	if (!buffer) {
-		trace_buffer_error("buffer_alloc() error: "
-				   "could not alloc structure");
+		trace_buffer_error("buffer_alloc(): could not alloc structure");
 		return NULL;
 	}
 
@@ -45,16 +44,14 @@ struct comp_buffer *buffer_alloc(uint32_t size, uint32_t caps, uint32_t align)
 			       SOF_MEM_CAPS_RAM, sizeof(*buffer->lock));
 	if (!buffer->lock) {
 		rfree(buffer);
-		trace_buffer_error("buffer_alloc() error: could not alloc lock");
+		trace_buffer_error("buffer_alloc(): could not alloc lock");
 		return NULL;
 	}
 
 	buffer->stream.addr = rballoc_align(0, caps, size, align);
 	if (!buffer->stream.addr) {
 		rfree(buffer);
-		trace_buffer_error("buffer_alloc() error: "
-				   "could not alloc size = %u "
-				   "bytes of type = %u",
+		trace_buffer_error("buffer_alloc(): could not alloc size = %u bytes of type = %u",
 				   size, caps);
 		return NULL;
 	}
@@ -94,7 +91,7 @@ int buffer_set_size(struct comp_buffer *buffer, uint32_t size)
 
 	/* validate request */
 	if (size == 0 || size > HEAP_BUFFER_SIZE) {
-		trace_buffer_error_with_ids(buffer, "resize error: size = %u is invalid",
+		trace_buffer_error_with_ids(buffer, "resize size = %u is invalid",
 					    size);
 		return -EINVAL;
 	}
@@ -106,7 +103,7 @@ int buffer_set_size(struct comp_buffer *buffer, uint32_t size)
 
 	/* we couldn't allocate bigger chunk */
 	if (!new_ptr && size > buffer->stream.size) {
-		trace_buffer_error_with_ids(buffer, "resize error: can't alloc %u bytes type %u",
+		trace_buffer_error_with_ids(buffer, "resize can't alloc %u bytes type %u",
 					    buffer->stream.size, buffer->caps);
 		return -ENOMEM;
 	}

--- a/src/audio/channel_map.c
+++ b/src/audio/channel_map.c
@@ -21,7 +21,7 @@ struct sof_ipc_channel_map *chmap_get(struct sof_ipc_stream_map *smap,
 	uint32_t byte = 0;
 
 	if (index >= smap->num_ch_map) {
-		trace_error(TRACE_CLASS_CHMAP, "chmap_get() error: "
+		trace_error(TRACE_CLASS_CHMAP, "chmap_get(): "
 			    "index %d out of bounds %d",
 			    index, smap->num_ch_map);
 

--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -59,7 +59,7 @@ struct comp_dev *comp_new(struct sof_ipc_comp *comp)
 	/* find the driver for our new component */
 	drv = get_drv(comp->type);
 	if (!drv) {
-		trace_error(TRACE_CLASS_COMP, "comp_new() error: driver not found, comp->type = %u",
+		trace_error(TRACE_CLASS_COMP, "comp_new(): driver not found, comp->type = %u",
 			    comp->type);
 		return NULL;
 	}
@@ -76,7 +76,7 @@ struct comp_dev *comp_new(struct sof_ipc_comp *comp)
 	/* create the new component */
 	cdev = drv->ops.new(drv, comp);
 	if (!cdev) {
-		comp_cl_err(drv, "comp_new() error: unable to create the new component");
+		comp_cl_err(drv, "comp_new(): unable to create the new component");
 		return NULL;
 	}
 
@@ -130,7 +130,7 @@ int comp_set_state(struct comp_dev *dev, int cmd)
 		if (dev->state == COMP_STATE_PREPARE) {
 			dev->state = COMP_STATE_ACTIVE;
 		} else {
-			comp_err(dev, "comp_set_state() error: wrong state = %u, COMP_TRIGGER_START",
+			comp_err(dev, "comp_set_state(): wrong state = %u, COMP_TRIGGER_START",
 				 dev->state);
 			ret = -EINVAL;
 		}
@@ -139,7 +139,7 @@ int comp_set_state(struct comp_dev *dev, int cmd)
 		if (dev->state == COMP_STATE_PAUSED) {
 			dev->state = COMP_STATE_ACTIVE;
 		} else {
-			comp_err(dev, "comp_set_state() error: wrong state = %u, COMP_TRIGGER_RELEASE",
+			comp_err(dev, "comp_set_state(): wrong state = %u, COMP_TRIGGER_RELEASE",
 				 dev->state);
 			ret = -EINVAL;
 		}
@@ -149,7 +149,7 @@ int comp_set_state(struct comp_dev *dev, int cmd)
 		    dev->state == COMP_STATE_PAUSED) {
 			dev->state = COMP_STATE_PREPARE;
 		} else {
-			comp_err(dev, "comp_set_state() error: wrong state = %u, COMP_TRIGGER_STOP",
+			comp_err(dev, "comp_set_state(): wrong state = %u, COMP_TRIGGER_STOP",
 				 dev->state);
 			ret = -EINVAL;
 		}
@@ -163,7 +163,7 @@ int comp_set_state(struct comp_dev *dev, int cmd)
 		if (dev->state == COMP_STATE_ACTIVE) {
 			dev->state = COMP_STATE_PAUSED;
 		} else {
-			comp_err(dev, "comp_set_state() error: wrong state = %u, COMP_TRIGGER_PAUSE",
+			comp_err(dev, "comp_set_state(): wrong state = %u, COMP_TRIGGER_PAUSE",
 				 dev->state);
 			ret = -EINVAL;
 		}
@@ -172,7 +172,7 @@ int comp_set_state(struct comp_dev *dev, int cmd)
 		/* reset always succeeds */
 		if (dev->state == COMP_STATE_ACTIVE ||
 		    dev->state == COMP_STATE_PAUSED) {
-			comp_err(dev, "comp_set_state() error: wrong state = %u, COMP_TRIGGER_RESET",
+			comp_err(dev, "comp_set_state(): wrong state = %u, COMP_TRIGGER_RESET",
 				 dev->state);
 			ret = 0;
 		}
@@ -182,7 +182,7 @@ int comp_set_state(struct comp_dev *dev, int cmd)
 		if (dev->state == COMP_STATE_READY) {
 			dev->state = COMP_STATE_PREPARE;
 		} else {
-			comp_err(dev, "comp_set_state() error: wrong state = %u, COMP_TRIGGER_PREPARE",
+			comp_err(dev, "comp_set_state(): wrong state = %u, COMP_TRIGGER_PREPARE",
 				 dev->state);
 			ret = -EINVAL;
 		}
@@ -247,7 +247,7 @@ int comp_verify_params(struct comp_dev *dev, uint32_t flag,
 	uint32_t flags = 0;
 
 	if (!params) {
-		comp_err(dev, "comp_verify_params() error: !params");
+		comp_err(dev, "comp_verify_params(): !params");
 		return -EINVAL;
 	}
 
@@ -327,7 +327,7 @@ struct comp_dev *comp_make_shared(struct comp_dev *dev)
 	dev = rrealloc(dev, SOF_MEM_ZONE_RUNTIME, SOF_MEM_FLAG_SHARED,
 		       SOF_MEM_CAPS_RAM, dev->size);
 	if (!dev) {
-		trace_error(TRACE_CLASS_COMP, "comp_make_shared() error: unable to realloc component");
+		trace_error(TRACE_CLASS_COMP, "comp_make_shared(): unable to realloc component");
 		return NULL;
 	}
 

--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -158,7 +158,7 @@ static struct comp_dev *dai_new(const struct comp_driver *drv,
 
 	dd->dai = dai_get(dai->type, dai->dai_index, DAI_CREAT);
 	if (!dd->dai) {
-		comp_cl_err(&comp_dai, "dai_new() error: dai_get() failed to create DAI.");
+		comp_cl_err(&comp_dai, "dai_new(): dai_get() failed to create DAI.");
 		goto error;
 	}
 
@@ -171,7 +171,7 @@ static struct comp_dev *dai_new(const struct comp_driver *drv,
 
 	dd->dma = dma_get(dir, caps, dma_dev, DMA_ACCESS_SHARED);
 	if (!dd->dma) {
-		comp_cl_err(&comp_dai, "dai_new() error: dma_get() failed to get shared access to DMA.");
+		comp_cl_err(&comp_dai, "dai_new(): dma_get() failed to get shared access to DMA.");
 		goto error;
 	}
 
@@ -220,7 +220,7 @@ static inline int dai_comp_get_hw_params(struct comp_dev *dev,
 	/* fetching hw dai stream params */
 	ret = dai_get_hw_params(dd->dai, params, dir);
 	if (ret < 0) {
-		comp_err(dev, "dai_comp_get_hw_params() error: dai_get_hw_params failed");
+		comp_err(dev, "dai_comp_get_hw_params(): dai_get_hw_params failed");
 		return ret;
 	}
 
@@ -250,12 +250,12 @@ static int dai_verify_params(struct comp_dev *dev,
 	 * pcm_converter functions.
 	 */
 	if (hw_params.rate && hw_params.rate != params->rate) {
-		comp_err(dev, "dai_verify_params() error: pcm rate parameter does not match hardware rate");
+		comp_err(dev, "dai_verify_params(): pcm rate parameter does not match hardware rate");
 		return -EINVAL;
 	}
 
 	if (hw_params.channels && hw_params.channels != params->channels) {
-		comp_err(dev, "dai_verify_params() error: pcm channels parameter does not match hardware channels");
+		comp_err(dev, "dai_verify_params(): pcm channels parameter does not match hardware channels");
 		return -EINVAL;
 	}
 
@@ -306,7 +306,7 @@ static int dai_playback_params(struct comp_dev *dev, uint32_t period_bytes,
 				   (uintptr_t)(dd->dma_buffer->stream.addr),
 				   fifo);
 		if (err < 0) {
-			comp_err(dev, "dai_playback_params() error: dma_sg_alloc() failed with err = %d",
+			comp_err(dev, "dai_playback_params(): dma_sg_alloc() failed with err = %d",
 				 err);
 			return err;
 		}
@@ -366,7 +366,7 @@ static int dai_capture_params(struct comp_dev *dev, uint32_t period_bytes,
 				   (uintptr_t)(dd->dma_buffer->stream.addr),
 				   fifo);
 		if (err < 0) {
-			comp_err(dev, "dai_capture_params() error: dma_sg_alloc() failed with err = %d",
+			comp_err(dev, "dai_capture_params(): dma_sg_alloc() failed with err = %d",
 				 err);
 			return err;
 		}
@@ -412,21 +412,21 @@ static int dai_params(struct comp_dev *dev,
 
 	/* can set params on only init state */
 	if (dev->state != COMP_STATE_READY) {
-		comp_err(dev, "dai_params() error: Component is not in init state.");
+		comp_err(dev, "dai_params(): Component is not in init state.");
 		return -EINVAL;
 	}
 
 	err = dma_get_attribute(dd->dma, DMA_ATTR_BUFFER_ADDRESS_ALIGNMENT,
 				&addr_align);
 	if (err < 0) {
-		comp_err(dev, "dai_params() error: could not get dma buffer address alignment, err = %d",
+		comp_err(dev, "dai_params(): could not get dma buffer address alignment, err = %d",
 			 err);
 		return err;
 	}
 
 	err = dma_get_attribute(dd->dma, DMA_ATTR_BUFFER_ALIGNMENT, &align);
 	if (err < 0 || !align) {
-		comp_err(dev, "dai_params() error: could not get valid dma buffer alignment, err = %d, align = %u",
+		comp_err(dev, "dai_params(): could not get valid dma buffer alignment, err = %d, align = %u",
 			 err, align);
 		return -EINVAL;
 	}
@@ -434,7 +434,7 @@ static int dai_params(struct comp_dev *dev,
 	err = dma_get_attribute(dd->dma, DMA_ATTR_BUFFER_PERIOD_COUNT,
 				&period_count);
 	if (err < 0 || !period_count) {
-		comp_err(dev, "dai_params() error: could not get valid dma buffer period count, err = %d, period_count = %u",
+		comp_err(dev, "dai_params(): could not get valid dma buffer period count, err = %d, period_count = %u",
 			 err, period_count);
 		return -EINVAL;
 	}
@@ -446,7 +446,7 @@ static int dai_params(struct comp_dev *dev,
 	/* calculate period size */
 	period_bytes = dev->frames * frame_size;
 	if (!period_bytes) {
-		comp_err(dev, "dai_params() error: invalid period_bytes.");
+		comp_err(dev, "dai_params(): invalid period_bytes.");
 		return -EINVAL;
 	}
 
@@ -457,7 +457,7 @@ static int dai_params(struct comp_dev *dev,
 	if (dd->dma_buffer) {
 		err = buffer_set_size(dd->dma_buffer, buffer_size);
 		if (err < 0) {
-			comp_err(dev, "dai_params() error: buffer_set_size() failed, buffer_size = %u",
+			comp_err(dev, "dai_params(): buffer_set_size() failed, buffer_size = %u",
 				 buffer_size);
 			return err;
 		}
@@ -465,7 +465,7 @@ static int dai_params(struct comp_dev *dev,
 		dd->dma_buffer = buffer_alloc(buffer_size, SOF_MEM_CAPS_DMA,
 					      addr_align);
 		if (!dd->dma_buffer) {
-			comp_err(dev, "dai_params() error: failed to alloc dma buffer");
+			comp_err(dev, "dai_params(): failed to alloc dma buffer");
 			return -ENOMEM;
 		}
 	}
@@ -492,13 +492,13 @@ static int dai_prepare(struct comp_dev *dev)
 	dev->position = 0;
 
 	if (!dd->chan) {
-		comp_err(dev, "dai_prepare() error: Missing dd->chan.");
+		comp_err(dev, "dai_prepare(): Missing dd->chan.");
 		comp_set_state(dev, COMP_TRIGGER_RESET);
 		return -EINVAL;
 	}
 
 	if (!dd->config.elem_array.elems) {
-		comp_err(dev, "dai_prepare() error: Missing dd->config.elem_array.elems.");
+		comp_err(dev, "dai_prepare(): Missing dd->config.elem_array.elems.");
 		comp_set_state(dev, COMP_TRIGGER_RESET);
 		return -EINVAL;
 	}
@@ -639,10 +639,10 @@ static void dai_report_xrun(struct comp_dev *dev, uint32_t bytes)
 	struct dai_data *dd = comp_get_drvdata(dev);
 
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK) {
-		comp_err(dev, "dai_report_xrun() error: underrun due to no data available");
+		comp_err(dev, "dai_report_xrun(): underrun due to no data available");
 		comp_underrun(dev, dd->local_buffer, bytes);
 	} else {
-		comp_err(dev, "dai_report_xrun() error: overrun due to no data available");
+		comp_err(dev, "dai_report_xrun(): overrun due to no data available");
 		comp_overrun(dev, dd->local_buffer, bytes);
 	}
 }
@@ -728,7 +728,7 @@ static int dai_config(struct comp_dev *dev, struct sof_ipc_dai_config *config)
 
 	/* cannot configure DAI while active */
 	if (dev->state == COMP_STATE_ACTIVE) {
-		comp_err(dev, "dai_config() error: Component is in active state.");
+		comp_err(dev, "dai_config(): Component is in active state.");
 		return -EINVAL;
 	}
 
@@ -798,7 +798,7 @@ static int dai_config(struct comp_dev *dev, struct sof_ipc_dai_config *config)
 		break;
 	default:
 		/* other types of DAIs not handled for now */
-		comp_err(dev, "dai_config() error: Unknown dai type");
+		comp_err(dev, "dai_config(): Unknown dai type");
 		break;
 	}
 
@@ -814,7 +814,7 @@ static int dai_config(struct comp_dev *dev, struct sof_ipc_dai_config *config)
 			dd->chan = dma_channel_get(dd->dma, channel);
 
 		if (!dd->chan) {
-			comp_err(dev, "dai_config() error: dma_channel_get() failed");
+			comp_err(dev, "dai_config(): dma_channel_get() failed");
 			dd->chan = NULL;
 			return -EIO;
 		}

--- a/src/audio/detect_test.c
+++ b/src/audio/detect_test.c
@@ -200,7 +200,7 @@ static void default_detect_test(struct comp_dev *dev,
 static void free_mem_load(struct comp_data *cd)
 {
 	if (!cd) {
-		comp_cl_err(&comp_keyword, "free_mem_load() error: invalid cd");
+		comp_cl_err(&comp_keyword, "free_mem_load(): invalid cd");
 		return;
 	}
 
@@ -219,7 +219,7 @@ static int alloc_mem_load(struct comp_data *cd, uint32_t size)
 		return 0;
 
 	if (!cd) {
-		comp_cl_err(&comp_keyword, "alloc_mem_load() error: invalid cd");
+		comp_cl_err(&comp_keyword, "alloc_mem_load(): invalid cd");
 		return -EINVAL;
 	}
 
@@ -327,19 +327,19 @@ static struct comp_dev *test_keyword_new(const struct comp_driver *drv,
 
 	if (bs > 0) {
 		if (bs < sizeof(struct sof_detect_test_config)) {
-			comp_err(dev, "test_keyword_new() error: invalid data size");
+			comp_err(dev, "test_keyword_new(): invalid data size");
 			goto fail;
 		}
 
 		if (test_keyword_apply_config(dev, cfg)) {
-			comp_err(dev, "test_keyword_new() error: failed to apply config");
+			comp_err(dev, "test_keyword_new(): failed to apply config");
 			goto fail;
 		}
 	}
 
 	ret = alloc_mem_load(cd, INITIAL_MODEL_DATA_SIZE);
 	if (ret < 0) {
-		comp_err(dev, "test_keyword_new() error: model data initial failed");
+		comp_err(dev, "test_keyword_new(): model data initial failed");
 		goto fail;
 	}
 
@@ -350,7 +350,7 @@ static struct comp_dev *test_keyword_new(const struct comp_driver *drv,
 
 	cd->msg = ipc_msg_init(cd->event.rhdr.hdr.cmd, sizeof(cd->event));
 	if (!cd->msg) {
-		comp_err(dev, "test_keyword_new() error: ipc notification init failed");
+		comp_err(dev, "test_keyword_new(): ipc notification init failed");
 		goto fail;
 	}
 
@@ -385,7 +385,7 @@ static int test_keyword_verify_params(struct comp_dev *dev,
 
 	ret = comp_verify_params(dev, 0, params);
 	if (ret < 0) {
-		comp_err(dev, "test_keyword_verify_params() error: comp_verify_params() failed");
+		comp_err(dev, "test_keyword_verify_params(): comp_verify_params() failed");
 		return ret;
 	}
 
@@ -418,12 +418,12 @@ static int test_keyword_params(struct comp_dev *dev,
 				  sink_list);
 
 	if (sourceb->stream.channels != 1) {
-		comp_err(dev, "test_keyword_params() error: only single-channel supported");
+		comp_err(dev, "test_keyword_params(): only single-channel supported");
 		return -EINVAL;
 	}
 
 	if (!detector_is_sample_width_supported(sourceb->stream.frame_fmt)) {
-		comp_err(dev, "test_keyword_params() error: only 16-bit format supported");
+		comp_err(dev, "test_keyword_params(): only 16-bit format supported");
 		return -EINVAL;
 	}
 
@@ -451,7 +451,7 @@ static int test_keyword_set_config(struct comp_dev *dev,
 	comp_info(dev, "test_keyword_set_config(), blob size = %u", bs);
 
 	if (bs != sizeof(struct sof_detect_test_config)) {
-		comp_err(dev, "test_keyword_set_config() error: invalid blob size");
+		comp_err(dev, "test_keyword_set_config(): invalid blob size");
 		return -EINVAL;
 	}
 
@@ -476,14 +476,14 @@ static int test_keyword_set_model(struct comp_dev *dev,
 	}
 
 	if (!cd->model.data) {
-		comp_err(dev, "keyword_ctrl_set_model() error: buffer not allocated");
+		comp_err(dev, "keyword_ctrl_set_model(): buffer not allocated");
 		return -EINVAL;
 	}
 
 	if (!cdata->elems_remaining) {
 		if (cdata->num_elems + cd->model.data_pos <
 		    cd->model.data_size) {
-			comp_err(dev, "keyword_ctrl_set_model() error: not enough data to fill the buffer");
+			comp_err(dev, "keyword_ctrl_set_model(): not enough data to fill the buffer");
 
 			/* TODO: anything to do in such a situation? */
 
@@ -496,7 +496,7 @@ static int test_keyword_set_model(struct comp_dev *dev,
 
 	if (cdata->num_elems >
 	    cd->model.data_size - cd->model.data_pos) {
-		comp_err(dev, "keyword_ctrl_set_model() error: too much data");
+		comp_err(dev, "keyword_ctrl_set_model(): too much data");
 		return -EINVAL;
 	}
 
@@ -529,7 +529,7 @@ static int test_keyword_ctrl_set_bin_data(struct comp_dev *dev,
 		 * configuration will be used when playback/capture
 		 * starts.
 		 */
-		comp_err(dev, "keyword_ctrl_set_bin_data() error: driver is busy");
+		comp_err(dev, "keyword_ctrl_set_bin_data(): driver is busy");
 		return -EBUSY;
 	}
 
@@ -541,7 +541,7 @@ static int test_keyword_ctrl_set_bin_data(struct comp_dev *dev,
 		ret = test_keyword_set_model(dev, cdata);
 		break;
 	default:
-		comp_err(dev, "keyword_ctrl_set_bin_data() error: unknown binary data type");
+		comp_err(dev, "keyword_ctrl_set_bin_data(): unknown binary data type");
 		break;
 	}
 
@@ -555,7 +555,7 @@ static int test_keyword_ctrl_set_data(struct comp_dev *dev,
 
 	/* Check version from ABI header */
 	if (SOF_ABI_VERSION_INCOMPATIBLE(SOF_ABI_VERSION, cdata->data->abi)) {
-		comp_err(dev, "test_keyword_cmd_set_data() error: invalid version");
+		comp_err(dev, "test_keyword_cmd_set_data(): invalid version");
 		return -EINVAL;
 	}
 
@@ -568,7 +568,7 @@ static int test_keyword_ctrl_set_data(struct comp_dev *dev,
 		ret = test_keyword_ctrl_set_bin_data(dev, cdata);
 		break;
 	default:
-		comp_err(dev, "test_keyword_cmd_set_data() error: invalid cdata->cmd");
+		comp_err(dev, "test_keyword_cmd_set_data(): invalid cdata->cmd");
 		ret = -EINVAL;
 		break;
 	}
@@ -623,7 +623,7 @@ static int test_keyword_get_model(struct comp_dev *dev,
 
 		bs = cdata->num_elems;
 		if (bs > size) {
-			comp_err(dev, "test_keyword_get_model() error: invalid size %d",
+			comp_err(dev, "test_keyword_get_model(): invalid size %d",
 				 bs);
 			return -EINVAL;
 		}
@@ -638,7 +638,7 @@ static int test_keyword_get_model(struct comp_dev *dev,
 		cd->model.data_pos += bs;
 
 	} else {
-		comp_err(dev, "test_keyword_get_model() error: invalid cd->config");
+		comp_err(dev, "test_keyword_get_model(): invalid cd->config");
 		ret = -EINVAL;
 	}
 
@@ -659,7 +659,7 @@ static int test_keyword_ctrl_get_bin_data(struct comp_dev *dev,
 		ret = test_keyword_get_model(dev, cdata, size);
 		break;
 	default:
-		comp_err(dev, "test_keyword_ctrl_get_bin_data() error: unknown binary data type");
+		comp_err(dev, "test_keyword_ctrl_get_bin_data(): unknown binary data type");
 		break;
 	}
 
@@ -678,7 +678,7 @@ static int test_keyword_ctrl_get_data(struct comp_dev *dev,
 		ret = test_keyword_ctrl_get_bin_data(dev, cdata, size);
 		break;
 	default:
-		comp_err(dev, "test_keyword_ctrl_get_data() error: invalid cdata->cmd");
+		comp_err(dev, "test_keyword_ctrl_get_data(): invalid cdata->cmd");
 		return -EINVAL;
 	}
 

--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -213,7 +213,7 @@ static inline int set_pass_func(struct comp_dev *dev)
 		break;
 #endif /* CONFIG_FORMAT_S24LE || CONFIG_FORMAT_S32LE */
 	default:
-		comp_err(dev, "set_pass_func() error: invalid dev->params.frame_fmt");
+		comp_err(dev, "set_pass_func(): invalid dev->params.frame_fmt");
 		return -EINVAL;
 	}
 	return 0;
@@ -411,7 +411,7 @@ static struct comp_dev *eq_fir_new(const struct comp_driver *drv,
 	 * blob size is sane.
 	 */
 	if (bs > SOF_EQ_FIR_MAX_SIZE) {
-		comp_cl_err(&comp_eq_fir, "eq_fir_new() error: coefficients blob size = %u > SOF_EQ_FIR_MAX_SIZE",
+		comp_cl_err(&comp_eq_fir, "eq_fir_new(): coefficients blob size = %u > SOF_EQ_FIR_MAX_SIZE",
 			    bs);
 		return NULL;
 	}
@@ -490,7 +490,7 @@ static int eq_fir_verify_params(struct comp_dev *dev,
 
 	ret = comp_verify_params(dev, 0, params);
 	if (ret < 0) {
-		comp_err(dev, "eq_fir_verify_params() error: comp_verify_params() failed.");
+		comp_err(dev, "eq_fir_verify_params(): comp_verify_params() failed.");
 		return ret;
 	}
 
@@ -557,12 +557,12 @@ static int fir_cmd_get_data(struct comp_dev *dev,
 			cdata->data->abi = SOF_ABI_VERSION;
 			cdata->data->size = bs;
 		} else {
-			comp_err(dev, "fir_cmd_get_data() error: invalid cd->config");
+			comp_err(dev, "fir_cmd_get_data(): invalid cd->config");
 			ret = -EINVAL;
 		}
 		break;
 	default:
-		comp_err(dev, "fir_cmd_get_data() error: invalid cdata->cmd");
+		comp_err(dev, "fir_cmd_get_data(): invalid cdata->cmd");
 		ret = -EINVAL;
 		break;
 	}
@@ -602,7 +602,7 @@ static int fir_cmd_set_data(struct comp_dev *dev,
 						 cdata->elems_remaining);
 
 			if (!cd->config_new) {
-				comp_err(dev, "fir_cmd_set_data() error: buffer allocation failed");
+				comp_err(dev, "fir_cmd_set_data(): buffer allocation failed");
 				return -EINVAL;
 			}
 
@@ -648,7 +648,7 @@ static int fir_cmd_set_data(struct comp_dev *dev,
 		}
 		break;
 	default:
-		comp_err(dev, "fir_cmd_set_data() error: invalid cdata->cmd");
+		comp_err(dev, "fir_cmd_set_data(): invalid cdata->cmd");
 		ret = -EINVAL;
 		break;
 	}
@@ -673,7 +673,7 @@ static int eq_fir_cmd(struct comp_dev *dev, int cmd, void *data,
 		ret = fir_cmd_get_data(dev, cdata, max_data_size);
 		break;
 	default:
-		comp_err(dev, "eq_fir_cmd() error: invalid command");
+		comp_err(dev, "eq_fir_cmd(): invalid command");
 		ret = -EINVAL;
 	}
 
@@ -803,7 +803,7 @@ static int eq_fir_prepare(struct comp_dev *dev)
 						      dev->frames);
 
 	if (sinkb->stream.size < config->periods_sink * sink_period_bytes) {
-		comp_err(dev, "eq_fir_prepare() error: sink buffer size is insufficient");
+		comp_err(dev, "eq_fir_prepare(): sink buffer size is insufficient");
 		ret = -ENOMEM;
 		goto err;
 	}
@@ -812,7 +812,7 @@ static int eq_fir_prepare(struct comp_dev *dev)
 	if (cd->config && cd->config_ready) {
 		ret = eq_fir_setup(cd, sourceb->stream.channels);
 		if (ret < 0) {
-			comp_err(dev, "eq_fir_prepare() error: eq_fir_setup failed.");
+			comp_err(dev, "eq_fir_prepare(): eq_fir_setup failed.");
 			goto err;
 		}
 

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -615,7 +615,7 @@ static int eq_iir_verify_params(struct comp_dev *dev,
 
 	ret = comp_verify_params(dev, buffer_flag, params);
 	if (ret < 0) {
-		comp_err(dev, "eq_iir_verify_params() error: comp_verify_params() failed.");
+		comp_err(dev, "eq_iir_verify_params(): comp_verify_params() failed.");
 		return ret;
 	}
 

--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -245,7 +245,7 @@ static int create_local_elems(struct comp_dev *dev, uint32_t buffer_count,
 		err = dma_sg_alloc(&hd->config.elem_array, SOF_MEM_ZONE_RUNTIME,
 				   dir, 1, 0, 0, 0);
 		if (err < 0) {
-			comp_err(dev, "create_local_elems() error: dma_sg_alloc() failed");
+			comp_err(dev, "create_local_elems(): dma_sg_alloc() failed");
 			return err;
 		}
 	} else {
@@ -256,7 +256,7 @@ static int create_local_elems(struct comp_dev *dev, uint32_t buffer_count,
 			   buffer_bytes,
 			   (uintptr_t)(hd->dma_buffer->stream.addr), 0);
 	if (err < 0) {
-		comp_err(dev, "create_local_elems() error: dma_sg_alloc() failed");
+		comp_err(dev, "create_local_elems(): dma_sg_alloc() failed");
 		return err;
 	}
 
@@ -296,7 +296,7 @@ static int host_trigger(struct comp_dev *dev, int cmd)
 		return ret;
 
 	if (!hd->chan) {
-		comp_err(dev, "host_trigger() error: no dma channel configured");
+		comp_err(dev, "host_trigger(): no dma channel configured");
 		return -EINVAL;
 	}
 
@@ -304,7 +304,7 @@ static int host_trigger(struct comp_dev *dev, int cmd)
 	case COMP_TRIGGER_START:
 		ret = dma_start(hd->chan);
 		if (ret < 0)
-			comp_err(dev, "host_trigger() error: dma_start() failed, ret = %u",
+			comp_err(dev, "host_trigger(): dma_start() failed, ret = %u",
 				 ret);
 		break;
 	case COMP_TRIGGER_STOP:
@@ -360,7 +360,7 @@ static struct comp_dev *host_new(const struct comp_driver *drv,
 
 	hd->dma = dma_get(dir, 0, DMA_DEV_HOST, DMA_ACCESS_SHARED);
 	if (!hd->dma) {
-		comp_err(dev, "host_new() error: dma_get() returned NULL");
+		comp_err(dev, "host_new(): dma_get() returned NULL");
 		rfree(hd);
 		rfree(dev);
 		return NULL;
@@ -375,7 +375,7 @@ static struct comp_dev *host_new(const struct comp_driver *drv,
 
 	hd->msg = ipc_msg_init(hd->posn.rhdr.hdr.cmd, sizeof(hd->posn));
 	if (!hd->msg) {
-		comp_err(dev, "host_new() error: ipc_msg_init failed");
+		comp_err(dev, "host_new(): ipc_msg_init failed");
 		dma_put(hd->dma);
 		rfree(hd);
 		rfree(dev);
@@ -446,7 +446,7 @@ static int host_verify_params(struct comp_dev *dev,
 
 	ret = comp_verify_params(dev, 0, params);
 	if (ret < 0) {
-		comp_err(dev, "host_verify_params() error: comp_verify_params() failed");
+		comp_err(dev, "host_verify_params(): comp_verify_params() failed");
 		return ret;
 	}
 
@@ -493,7 +493,7 @@ static int host_params(struct comp_dev *dev,
 	err = dma_get_attribute(hd->dma, DMA_ATTR_BUFFER_ADDRESS_ALIGNMENT,
 				&addr_align);
 	if (err < 0) {
-		comp_err(dev, "host_params() error: could not get dma buffer address alignment, err = %d",
+		comp_err(dev, "host_params(): could not get dma buffer address alignment, err = %d",
 			 err);
 		return err;
 	}
@@ -501,7 +501,7 @@ static int host_params(struct comp_dev *dev,
 	/* retrieve DMA buffer size alignment */
 	err = dma_get_attribute(hd->dma, DMA_ATTR_BUFFER_ALIGNMENT, &align);
 	if (err < 0 || !align) {
-		comp_err(dev, "host_params() error: could not get valid dma buffer alignment, err = %d, align = %u",
+		comp_err(dev, "host_params(): could not get valid dma buffer alignment, err = %d, align = %u",
 			 err, align);
 		return -EINVAL;
 	}
@@ -510,7 +510,7 @@ static int host_params(struct comp_dev *dev,
 	err = dma_get_attribute(hd->dma, DMA_ATTR_BUFFER_PERIOD_COUNT,
 				&period_count);
 	if (err < 0 || !period_count) {
-		comp_err(dev, "host_params() error: could not get valid dma buffer period count, err = %d, period_count = %u",
+		comp_err(dev, "host_params(): could not get valid dma buffer period count, err = %d, period_count = %u",
 			 err, period_count);
 		return -EINVAL;
 	}
@@ -519,7 +519,7 @@ static int host_params(struct comp_dev *dev,
 		audio_stream_frame_bytes(&hd->local_buffer->stream);
 
 	if (!period_bytes) {
-		comp_err(dev, "host_params() error: invalid period_bytes");
+		comp_err(dev, "host_params(): invalid period_bytes");
 		return -EINVAL;
 	}
 
@@ -547,7 +547,7 @@ static int host_params(struct comp_dev *dev,
 	if (hd->dma_buffer) {
 		err = buffer_set_size(hd->dma_buffer, buffer_size);
 		if (err < 0) {
-			comp_err(dev, "host_params() error: buffer_set_size() failed, buffer_size = %u",
+			comp_err(dev, "host_params(): buffer_set_size() failed, buffer_size = %u",
 				 buffer_size);
 			return err;
 		}
@@ -555,7 +555,7 @@ static int host_params(struct comp_dev *dev,
 		hd->dma_buffer = buffer_alloc(buffer_size, SOF_MEM_CAPS_DMA,
 					      addr_align);
 		if (!hd->dma_buffer) {
-			comp_err(dev, "host_params() error: failed to alloc dma buffer");
+			comp_err(dev, "host_params(): failed to alloc dma buffer");
 			return -ENOMEM;
 		}
 	}
@@ -583,13 +583,13 @@ static int host_params(struct comp_dev *dev,
 	 */
 	hd->chan = dma_channel_get(hd->dma, hd->stream_tag);
 	if (!hd->chan) {
-		comp_err(dev, "host_params() error: hd->chan is NULL");
+		comp_err(dev, "host_params(): hd->chan is NULL");
 		return -ENODEV;
 	}
 
 	err = dma_set_config(hd->chan, &hd->config);
 	if (err < 0) {
-		comp_err(dev, "host_params() error: dma_set_config() failed");
+		comp_err(dev, "host_params(): dma_set_config() failed");
 		dma_channel_put(hd->chan);
 		hd->chan = NULL;
 		return err;
@@ -599,7 +599,7 @@ static int host_params(struct comp_dev *dev,
 				&hd->dma_copy_align);
 
 	if (err < 0) {
-		comp_err(dev, "host_params() error: dma_get_attribute()");
+		comp_err(dev, "host_params(): dma_get_attribute()");
 
 		return err;
 	}
@@ -731,7 +731,7 @@ static uint32_t host_buffer_get_copy_bytes(struct comp_dev *dev)
 		ret = dma_get_data_size(hd->chan, &avail_bytes,
 					&free_bytes);
 		if (ret < 0) {
-			comp_cl_err(&comp_host, "host_buffer_cb() error: dma_get_data_size() failed, ret = %u",
+			comp_cl_err(&comp_host, "host_buffer_cb(): dma_get_data_size() failed, ret = %u",
 				    ret);
 			return 0;
 		}
@@ -788,14 +788,14 @@ static int host_copy(struct comp_dev *dev)
 	/* reconfigure transfer */
 	ret = dma_set_config(hd->chan, &hd->config);
 	if (ret < 0) {
-		comp_cl_err(&comp_host, "host_copy() error: dma_set_config() failed, ret = %u",
+		comp_cl_err(&comp_host, "host_copy(): dma_set_config() failed, ret = %u",
 			    ret);
 		return ret;
 	}
 
 	ret = dma_copy(hd->chan, copy_bytes, flags);
 	if (ret < 0) {
-		comp_cl_err(&comp_host, "host_copy() error: dma_copy() failed, ret = %u",
+		comp_cl_err(&comp_host, "host_copy(): dma_copy() failed, ret = %u",
 			    ret);
 		return ret;
 	}

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -159,17 +159,17 @@ static struct comp_dev *kpb_new(const struct comp_driver *drv,
 	assert(!ret);
 
 	if (!kpb_is_sample_width_supported(kpb->config.sampling_width)) {
-		comp_err(dev, "kpb_new() error: requested sampling width not supported");
+		comp_err(dev, "kpb_new(): requested sampling width not supported");
 		return NULL;
 	}
 
 	if (kpb->config.channels > KPB_MAX_SUPPORTED_CHANNELS) {
-		comp_err(dev, "kpb_new() error: no of channels exceeded the limit");
+		comp_err(dev, "kpb_new(): no of channels exceeded the limit");
 		return NULL;
 	}
 
 	if (kpb->config.sampling_freq != KPB_SAMPLNG_FREQUENCY) {
-		comp_err(dev, "kpb_new() error: requested sampling frequency not supported");
+		comp_err(dev, "kpb_new(): requested sampling frequency not supported");
 		return NULL;
 	}
 
@@ -378,7 +378,7 @@ static int kbp_verify_params(struct comp_dev *dev,
 
 	ret = comp_verify_params(dev, 0, params);
 	if (ret < 0) {
-		comp_err(dev, "kpb_verify_params() error: comp_verify_params() failed");
+		comp_err(dev, "kpb_verify_params(): comp_verify_params() failed");
 		return ret;
 	}
 
@@ -436,7 +436,7 @@ static int kpb_prepare(struct comp_dev *dev)
 
 	if (kpb->state == KPB_STATE_RESETTING ||
 	    kpb->state == KPB_STATE_RESET_FINISHING) {
-		comp_cl_err(&comp_kpb, "kpb_prepare() error: can not prepare KPB due to ongoing reset, state log %x",
+		comp_cl_err(&comp_kpb, "kpb_prepare(): can not prepare KPB due to ongoing reset, state log %x",
 			    kpb->state_log);
 		return -EBUSY;
 	}
@@ -450,7 +450,7 @@ static int kpb_prepare(struct comp_dev *dev)
 
 	if (!validate_host_params(dev, kpb->host_period_size,
 				  kpb->host_buffer_size, hb_size_req)) {
-		comp_cl_err(&comp_kpb, "kpb_prepare() error: wrong host params.");
+		comp_cl_err(&comp_kpb, "kpb_prepare(): wrong host params.");
 		return -EINVAL;
 	}
 
@@ -475,7 +475,7 @@ static int kpb_prepare(struct comp_dev *dev)
 
 		/* Have we allocated what we requested? */
 		if (kpb->buffer_size < hb_size_req) {
-			comp_cl_err(&comp_kpb, "kpb_prepare() error: failed to allocate space for KPB buffer");
+			comp_cl_err(&comp_kpb, "kpb_prepare(): failed to allocate space for KPB buffer");
 			kpb_free_history_buffer(kpb->history_buffer);
 			kpb->history_buffer = NULL;
 			kpb->buffer_size = 0;
@@ -521,7 +521,7 @@ static int kpb_prepare(struct comp_dev *dev)
 	}
 
 	if (!kpb->sel_sink || !kpb->host_sink) {
-		comp_info(dev, "kpb_prepare() error: could not find sinks: sel_sink %d host_sink %d",
+		comp_info(dev, "kpb_prepare(): could not find sinks: sel_sink %d host_sink %d",
 			  (uint32_t)kpb->sel_sink, (uint32_t)kpb->host_sink);
 		ret = -EIO;
 	}
@@ -657,7 +657,7 @@ static int kpb_copy(struct comp_dev *dev)
 
 		copy_bytes = MIN(sink->stream.free, source->stream.avail);
 		if (!copy_bytes) {
-			comp_err(dev, "kpb_copy() error: nothing to copy sink->free %d source->avail %d",
+			comp_err(dev, "kpb_copy(): nothing to copy sink->free %d source->avail %d",
 				 sink->stream.free, source->stream.avail);
 			ret = PPL_STATUS_PATH_STOP;
 			goto out;
@@ -708,7 +708,7 @@ static int kpb_copy(struct comp_dev *dev)
 
 		copy_bytes = MIN(sink->stream.free, source->stream.avail);
 		if (!copy_bytes) {
-			comp_err(dev, "kpb_copy() error: nothing to copy sink->free %d source->avail %d",
+			comp_err(dev, "kpb_copy(): nothing to copy sink->free %d source->avail %d",
 				 sink->stream.free, source->stream.avail);
 			ret = PPL_STATUS_PATH_STOP;
 			goto out;
@@ -786,7 +786,7 @@ static int kpb_buffer_data(struct comp_dev *dev,
 	if (kpb->state != KPB_STATE_RUN &&
 	    kpb->state != KPB_STATE_DRAINING &&
 	    kpb->state != KPB_STATE_INIT_DRAINING) {
-		comp_err(dev, "kpb_buffer_data() error: wrong state! (current state %d, state log %x)",
+		comp_err(dev, "kpb_buffer_data(): wrong state! (current state %d, state log %x)",
 			 kpb->state, kpb->state_log);
 		return PPL_STATUS_PATH_STOP;
 	}
@@ -908,7 +908,7 @@ static void kpb_event_handler(void *arg, enum notify_id type, void *event_data)
 		/*TODO*/
 		break;
 	default:
-		comp_err(dev, "kpb_cmd() error: unsupported command");
+		comp_err(dev, "kpb_cmd(): unsupported command");
 		break;
 	}
 }
@@ -930,17 +930,17 @@ static int kpb_register_client(struct comp_data *kpb, struct kpb_client *cli)
 	comp_cl_info(&comp_kpb, "kpb_register_client()");
 
 	if (!cli) {
-		comp_cl_err(&comp_kpb, "kpb_register_client() error: no client data");
+		comp_cl_err(&comp_kpb, "kpb_register_client(): no client data");
 		return -EINVAL;
 	}
 	/* Do we have a room for a new client? */
 	if (kpb->kpb_no_of_clients >= KPB_MAX_NO_OF_CLIENTS ||
 	    cli->id >= KPB_MAX_NO_OF_CLIENTS) {
-		comp_cl_err(&comp_kpb, "kpb_register_client() error: no free room for client = %u ",
+		comp_cl_err(&comp_kpb, "kpb_register_client(): no free room for client = %u ",
 			    cli->id);
 		ret = -EINVAL;
 	} else if (kpb->clients[cli->id].state != KPB_CLIENT_UNREGISTERED) {
-		comp_cl_err(&comp_kpb, "kpb_register_client() error: client = %u already registered",
+		comp_cl_err(&comp_kpb, "kpb_register_client(): client = %u already registered",
 			    cli->id);
 		ret = -EINVAL;
 	} else {
@@ -990,15 +990,15 @@ static void kpb_init_draining(struct comp_dev *dev, struct kpb_client *cli)
 		  cli->history_depth);
 
 	if (kpb->state != KPB_STATE_RUN) {
-		comp_err(dev, "kpb_init_draining() error: wrong KPB state");
+		comp_err(dev, "kpb_init_draining(): wrong KPB state");
 	} else if (cli->id > KPB_MAX_NO_OF_CLIENTS) {
-		comp_err(dev, "kpb_init_draining() error: wrong client id");
+		comp_err(dev, "kpb_init_draining(): wrong client id");
 	/* TODO: check also if client is registered */
 	} else if (!is_sink_ready) {
-		comp_err(dev, "kpb_init_draining() error: sink not ready for draining");
+		comp_err(dev, "kpb_init_draining(): sink not ready for draining");
 	} else if (kpb->buffered_data < history_depth ||
 		   kpb->buffer_size < history_depth) {
-		comp_cl_err(&comp_kpb, "kpb_init_draining() error: not enough data in history buffer");
+		comp_cl_err(&comp_kpb, "kpb_init_draining(): not enough data in history buffer");
 	} else {
 		/* Draining accepted, find proper buffer to start reading
 		 * At this point we are guaranteed that there is enough data
@@ -1023,7 +1023,7 @@ static void kpb_init_draining(struct comp_dev *dev, struct kpb_client *cli)
 						 (uint32_t)buff->start_addr;
 				buffered += local_buffered;
 			} else {
-				comp_err(dev, "kpb_init_draining() error: incorrect buffer label");
+				comp_err(dev, "kpb_init_draining(): incorrect buffer label");
 			}
 			/* Check if this is already sufficient to start draining
 			 * if not, go to previous buffer and continue

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -167,7 +167,7 @@ static int mixer_verify_params(struct comp_dev *dev,
 
 	ret = comp_verify_params(dev, BUFF_PARAMS_CHANNELS, params);
 	if (ret < 0) {
-		comp_err(dev, "mixer_verify_params() error: comp_verify_params() failed.");
+		comp_err(dev, "mixer_verify_params(): comp_verify_params() failed.");
 		return ret;
 	}
 
@@ -196,12 +196,12 @@ static int mixer_params(struct comp_dev *dev,
 	/* calculate period size based on config */
 	period_bytes = dev->frames * audio_stream_frame_bytes(&sinkb->stream);
 	if (period_bytes == 0) {
-		comp_err(dev, "mixer_params() error: period_bytes = 0");
+		comp_err(dev, "mixer_params(): period_bytes = 0");
 		return -EINVAL;
 	}
 
 	if (sinkb->stream.size < config->periods_sink * period_bytes) {
-		comp_err(dev, "mixer_params() error: sink buffer size is insufficient");
+		comp_err(dev, "mixer_params(): sink buffer size is insufficient");
 		return -ENOMEM;
 	}
 

--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -44,7 +44,7 @@ static int mux_set_values(struct comp_dev *dev, struct comp_data *cd,
 
 	/* check if number of streams configured doesn't exceed maximum */
 	if (cfg->num_streams > MUX_MAX_STREAMS) {
-		comp_cl_err(&comp_mux, "mux_set_values() error: configured number of streams (%u) exceeds maximum = "
+		comp_cl_err(&comp_mux, "mux_set_values(): configured number of streams (%u) exceeds maximum = "
 			    META_QUOTE(MUX_MAX_STREAMS), cfg->num_streams);
 		return -EINVAL;
 	}
@@ -54,7 +54,7 @@ static int mux_set_values(struct comp_dev *dev, struct comp_data *cd,
 		for (j = i + 1; j < cfg->num_streams; j++) {
 			if (cfg->streams[i].pipeline_id ==
 				cfg->streams[j].pipeline_id) {
-				comp_cl_err(&comp_mux, "mux_set_values() error: multiple configured streams have same pipeline ID = %u",
+				comp_cl_err(&comp_mux, "mux_set_values(): multiple configured streams have same pipeline ID = %u",
 					    cfg->streams[i].pipeline_id);
 				return -EINVAL;
 			}
@@ -64,7 +64,7 @@ static int mux_set_values(struct comp_dev *dev, struct comp_data *cd,
 	/* check if number of channels per stream doesn't exceed maximum */
 	for (i = 0; i < cfg->num_streams; i++) {
 		if (cfg->streams[i].num_channels > PLATFORM_MAX_CHANNELS) {
-			comp_cl_err(&comp_mux, "mux_set_values() error: configured number of channels for stream %u exceeds platform maximum = "
+			comp_cl_err(&comp_mux, "mux_set_values(): configured number of channels for stream %u exceeds platform maximum = "
 				    META_QUOTE(PLATFORM_MAX_CHANNELS), i);
 			return -EINVAL;
 		}
@@ -156,7 +156,7 @@ static uint8_t get_stream_index(struct comp_data *cd, uint32_t pipe_id)
 		if (cd->config.streams[i].pipeline_id == pipe_id)
 			return i;
 
-	comp_cl_err(&comp_mux, "get_stream_index() error: couldn't find configuration for connected pipeline %u",
+	comp_cl_err(&comp_mux, "get_stream_index(): couldn't find configuration for connected pipeline %u",
 		    pipe_id);
 
 	return 0;
@@ -171,7 +171,7 @@ static int mux_verify_params(struct comp_dev *dev,
 
 	ret = comp_verify_params(dev, BUFF_PARAMS_CHANNELS, params);
 	if (ret < 0) {
-		comp_err(dev, "mux_verify_params() error: comp_verify_params() failed.");
+		comp_err(dev, "mux_verify_params(): comp_verify_params() failed.");
 		return ret;
 	}
 
@@ -221,7 +221,7 @@ static int mux_ctrl_set_cmd(struct comp_dev *dev,
 		ret = mux_set_values(dev, cd, cfg);
 		break;
 	default:
-		comp_err(dev, "mux_ctrl_set_cmd() error: invalid cdata->cmd = 0x%08x",
+		comp_err(dev, "mux_ctrl_set_cmd(): invalid cdata->cmd = 0x%08x",
 			 cdata->cmd);
 		ret = -EINVAL;
 		break;
@@ -255,7 +255,7 @@ static int mux_ctrl_get_cmd(struct comp_dev *dev,
 		cdata->data->size = reply_size;
 		break;
 	default:
-		comp_cl_err(&comp_mux, "mux_ctrl_set_cmd() error: invalid cdata->cmd = 0x%08x",
+		comp_cl_err(&comp_mux, "mux_ctrl_set_cmd(): invalid cdata->cmd = 0x%08x",
 			    cdata->cmd);
 		ret = -EINVAL;
 		break;
@@ -301,7 +301,7 @@ static int demux_copy(struct comp_dev *dev)
 	comp_dbg(dev, "demux_copy()");
 
 	if (!cd->demux) {
-		comp_err(dev, "demux_copy() error: no demux processing function for component.");
+		comp_err(dev, "demux_copy(): no demux processing function for component.");
 		comp_set_state(dev, COMP_TRIGGER_RESET);
 		return -EINVAL;
 	}
@@ -392,7 +392,7 @@ static int mux_copy(struct comp_dev *dev)
 	comp_dbg(dev, "mux_copy()");
 
 	if (!cd->mux) {
-		comp_err(dev, "mux_copy() error: no mux processing function for component.");
+		comp_err(dev, "mux_copy(): no mux processing function for component.");
 		comp_set_state(dev, COMP_TRIGGER_RESET);
 		return -EINVAL;
 	}
@@ -488,7 +488,7 @@ static int mux_prepare(struct comp_dev *dev)
 		cd->demux = demux_get_processing_function(dev);
 
 	if (!cd->mux && !cd->demux) {
-		comp_err(dev, "mux_prepare() error: Invalid configuration, couldn't find suitable processing function.");
+		comp_err(dev, "mux_prepare(): Invalid configuration, couldn't find suitable processing function.");
 		return -EINVAL;
 	}
 

--- a/src/audio/pipeline.c
+++ b/src/audio/pipeline.c
@@ -67,7 +67,7 @@ struct pipeline *pipeline_new(struct sof_ipc_pipe_new *pipe_desc,
 	/* allocate new pipeline */
 	p = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM, sizeof(*p));
 	if (!p) {
-		pipe_cl_err("pipeline_new() error: Out of Memory");
+		pipe_cl_err("pipeline_new(): Out of Memory");
 		return NULL;
 	}
 
@@ -77,7 +77,7 @@ struct pipeline *pipeline_new(struct sof_ipc_pipe_new *pipe_desc,
 
 	ret = pipeline_posn_offset_get(&p->posn_offset);
 	if (ret < 0) {
-		pipe_cl_err("pipeline_new() error: pipeline_posn_offset_get failed %d",
+		pipe_cl_err("pipeline_new(): pipeline_posn_offset_get failed %d",
 			    ret);
 		rfree(p);
 		return NULL;
@@ -93,7 +93,7 @@ struct pipeline *pipeline_new(struct sof_ipc_pipe_new *pipe_desc,
 
 	p->msg = ipc_msg_init(posn.rhdr.hdr.cmd, sizeof(posn));
 	if (!p->msg) {
-		pipe_cl_err("pipeline_new() error: ipc_msg_init failed");
+		pipe_cl_err("pipeline_new(): ipc_msg_init failed");
 		rfree(p);
 		return NULL;
 	}
@@ -196,7 +196,7 @@ int pipeline_complete(struct pipeline *p, struct comp_dev *source,
 
 	/* check whether pipeline is already completed */
 	if (p->status != COMP_STATE_INIT) {
-		pipe_err(p, "pipeline_complete() error: Pipeline already completed");
+		pipe_err(p, "pipeline_complete(): Pipeline already completed");
 		return -EINVAL;
 	}
 
@@ -257,7 +257,7 @@ int pipeline_free(struct pipeline *p)
 	/* make sure we are not in use */
 	if (p->source_comp) {
 		if (p->source_comp->state > COMP_STATE_READY) {
-			pipe_err(p, "pipeline_free() error: Pipeline in use, %u, %u",
+			pipe_err(p, "pipeline_free(): Pipeline in use, %u, %u",
 				 dev_comp_id(p->source_comp),
 				 p->source_comp->state);
 			return -EBUSY;
@@ -427,7 +427,7 @@ int pipeline_params(struct pipeline *p, struct comp_dev *host,
 
 	ret = pipeline_comp_hw_params(data.start, NULL, &data, dir);
 	if (ret < 0) {
-		pipe_cl_err("pipeline_prepare() error: ret = %d, dev->comp.id = %u",
+		pipe_cl_err("pipeline_prepare(): ret = %d, dev->comp.id = %u",
 			    ret, dev_comp_id(host));
 		return ret;
 	}
@@ -438,7 +438,7 @@ int pipeline_params(struct pipeline *p, struct comp_dev *host,
 
 	ret = pipeline_comp_params(host, NULL, &data, params->params.direction);
 	if (ret < 0) {
-		pipe_cl_err("pipeline_params() error: ret = %d, host->comp.id = %u",
+		pipe_cl_err("pipeline_params(): ret = %d, host->comp.id = %u",
 			    ret, dev_comp_id(host));
 	}
 
@@ -482,7 +482,7 @@ static int pipeline_comp_task_init(struct pipeline *p)
 
 		p->pipe_task = pipeline_task_init(p, type, pipeline_task);
 		if (!p->pipe_task) {
-			pipe_cl_err("pipeline_prepare() error: task init failed");
+			pipe_cl_err("pipeline_prepare(): task init failed");
 			return -ENOMEM;
 		}
 	}
@@ -547,7 +547,7 @@ int pipeline_prepare(struct pipeline *p, struct comp_dev *dev)
 
 	ret = pipeline_comp_prepare(dev, NULL, &ppl_data, dev->direction);
 	if (ret < 0) {
-		pipe_cl_err("pipeline_prepare() error: ret = %d, dev->comp.id = %u",
+		pipe_cl_err("pipeline_prepare(): ret = %d, dev->comp.id = %u",
 			    ret, dev_comp_id(dev));
 		return ret;
 	}
@@ -644,7 +644,7 @@ static int pipeline_xrun_handle_trigger(struct pipeline *p, int cmd)
 		/* prepare the pipeline */
 		ret = pipeline_prepare(p, p->source_comp);
 		if (ret < 0) {
-			pipe_err(p, "prepare error: ret = %d", ret);
+			pipe_err(p, "prepare: ret = %d", ret);
 			return ret;
 		}
 		/* now ready for start, clear xrun_bytes */
@@ -675,7 +675,7 @@ int pipeline_trigger(struct pipeline *p, struct comp_dev *host, int cmd)
 	if (p->xrun_bytes) {
 		ret = pipeline_xrun_handle_trigger(p, cmd);
 		if (ret < 0) {
-			pipe_err(p, "xrun handle error: ret = %d", ret);
+			pipe_err(p, "xrun handle: ret = %d", ret);
 			return ret;
 		} else if (ret == PPL_STATUS_PATH_STOP)
 			/* no further action needed*/
@@ -687,7 +687,7 @@ int pipeline_trigger(struct pipeline *p, struct comp_dev *host, int cmd)
 
 	ret = pipeline_comp_trigger(host, NULL, &data, host->direction);
 	if (ret < 0) {
-		pipe_cl_err("pipeline_trigger() error: ret = %d, host->comp.id = %u, cmd = %d",
+		pipe_cl_err("pipeline_trigger(): ret = %d, host->comp.id = %u, cmd = %d",
 			    ret, dev_comp_id(host), cmd);
 	}
 
@@ -744,7 +744,7 @@ int pipeline_reset(struct pipeline *p, struct comp_dev *host)
 
 	ret = pipeline_comp_reset(host, NULL, p, host->direction);
 	if (ret < 0) {
-		pipe_cl_err("pipeline_reset() error: ret = %d, host->comp.id = %u",
+		pipe_cl_err("pipeline_reset(): ret = %d, host->comp.id = %u",
 			    ret, dev_comp_id(host));
 	}
 
@@ -815,7 +815,7 @@ static int pipeline_copy(struct pipeline *p)
 
 	ret = pipeline_comp_copy(start, NULL, &data, dir);
 	if (ret < 0)
-		pipe_cl_err("pipeline_copy() error: ret = %d, start->comp.id = %u, dir = %u",
+		pipe_cl_err("pipeline_copy(): ret = %d, start->comp.id = %u, dir = %u",
 			    ret, dev_comp_id(start), dir);
 
 	return ret;
@@ -903,7 +903,7 @@ void pipeline_xrun(struct pipeline *p, struct comp_dev *dev,
 	/* notify all pipeline comps we are in XRUN, and stop copying */
 	ret = pipeline_trigger(p, p->source_comp, COMP_TRIGGER_XRUN);
 	if (ret < 0)
-		pipe_err(p, "pipeline_xrun() error: Pipelines notification about XRUN failed, ret = %d",
+		pipe_err(p, "pipeline_xrun(): Pipelines notification about XRUN failed, ret = %d",
 			 ret);
 
 	memset(&posn, 0, sizeof(posn));
@@ -936,7 +936,7 @@ static int pipeline_xrun_recover(struct pipeline *p)
 	/* prepare the pipeline */
 	ret = pipeline_prepare(p, p->source_comp);
 	if (ret < 0) {
-		pipe_err(p, "pipeline_xrun_recover() error: pipeline_prepare() failed, ret = %d",
+		pipe_err(p, "pipeline_xrun_recover(): pipeline_prepare() failed, ret = %d",
 			 ret);
 		return ret;
 	}
@@ -947,7 +947,7 @@ static int pipeline_xrun_recover(struct pipeline *p)
 	/* restart pipeline comps */
 	ret = pipeline_trigger(p, p->source_comp, COMP_TRIGGER_START);
 	if (ret < 0) {
-		pipe_err(p, "pipeline_xrun_recover() error: pipeline_trigger() failed, ret = %d",
+		pipe_err(p, "pipeline_xrun_recover(): pipeline_trigger() failed, ret = %d",
 			 ret);
 		return ret;
 	}

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -127,7 +127,7 @@ static int selector_verify_params(struct comp_dev *dev,
 					 source_list);
 		if (cd->config.in_channels_count &&
 		    cd->config.in_channels_count != params->channels) {
-			comp_err(dev, "selector_verify_params() error: src in_channels_count does not match pcm channels");
+			comp_err(dev, "selector_verify_params(): src in_channels_count does not match pcm channels");
 			return -EINVAL;
 		}
 		in_channels = cd->config.in_channels_count;
@@ -148,7 +148,7 @@ static int selector_verify_params(struct comp_dev *dev,
 					 sink_list);
 		if (cd->config.out_channels_count &&
 		    cd->config.out_channels_count != params->channels) {
-			comp_err(dev, "selector_verify_params() error: src in_channels_count does not match pcm channels");
+			comp_err(dev, "selector_verify_params(): src in_channels_count does not match pcm channels");
 			return -EINVAL;
 		}
 		out_channels = cd->config.out_channels_count;
@@ -179,7 +179,7 @@ static int selector_verify_params(struct comp_dev *dev,
 	case SEL_SOURCE_4CH:
 		break;
 	default:
-		comp_err(dev, "selector_verify_params() error: in_channels = %u"
+		comp_err(dev, "selector_verify_params(): in_channels = %u"
 			 , in_channels);
 		return -EINVAL;
 	}
@@ -192,19 +192,19 @@ static int selector_verify_params(struct comp_dev *dev,
 	case SEL_SINK_4CH:
 		/* verify proper channels for passthrough mode */
 		if (in_channels != out_channels) {
-			comp_err(dev, "selector_verify_params() error: in_channels = %u, out_channels = %u"
+			comp_err(dev, "selector_verify_params(): in_channels = %u, out_channels = %u"
 				 , in_channels, out_channels);
 			return -EINVAL;
 		}
 		break;
 	default:
-		comp_err(dev, "selector_verify_params() error: out_channels = %u"
+		comp_err(dev, "selector_verify_params(): out_channels = %u"
 			 , out_channels);
 		return -EINVAL;
 	}
 
 	if (cd->config.sel_channel > (SEL_SOURCE_4CH - 1)) {
-		comp_err(dev, "selector_verify_params() error: ch_idx = %u"
+		comp_err(dev, "selector_verify_params(): ch_idx = %u"
 			 , cd->config.sel_channel);
 		return -EINVAL;
 	}
@@ -261,7 +261,7 @@ static int selector_ctrl_set_data(struct comp_dev *dev,
 		cd->config.sel_channel = cfg->sel_channel;
 		break;
 	default:
-		comp_err(dev, "selector_ctrl_set_cmd() error: invalid cdata->cmd = %u",
+		comp_err(dev, "selector_ctrl_set_cmd(): invalid cdata->cmd = %u",
 			 cdata->cmd);
 		ret = -EINVAL;
 		break;
@@ -299,7 +299,7 @@ static int selector_ctrl_get_data(struct comp_dev *dev,
 		break;
 
 	default:
-		comp_err(dev, "selector_ctrl_get_data() error: invalid cdata->cmd");
+		comp_err(dev, "selector_ctrl_get_data(): invalid cdata->cmd");
 		ret = -EINVAL;
 		break;
 	}
@@ -337,7 +337,7 @@ static int selector_cmd(struct comp_dev *dev, int cmd, void *data,
 		comp_info(dev, "selector_cmd(), COMP_CMD_GET_VALUE");
 		break;
 	default:
-		comp_err(dev, "selector_cmd() error: invalid command");
+		comp_err(dev, "selector_cmd(): invalid command");
 		ret = -EINVAL;
 	}
 
@@ -466,21 +466,21 @@ static int selector_prepare(struct comp_dev *dev)
 		  sinkb->stream.channels);
 
 	if (sinkb->stream.size < config->periods_sink * cd->sink_period_bytes) {
-		comp_err(dev, "selector_prepare() error: sink buffer size is insufficient");
+		comp_err(dev, "selector_prepare(): sink buffer size is insufficient");
 		ret = -ENOMEM;
 		goto err;
 	}
 
 	/* validate */
 	if (cd->sink_period_bytes == 0) {
-		comp_err(dev, "selector_prepare() error: cd->sink_period_bytes = 0, dev->frames = %u",
+		comp_err(dev, "selector_prepare(): cd->sink_period_bytes = 0, dev->frames = %u",
 			 dev->frames);
 		ret = -EINVAL;
 		goto err;
 	}
 
 	if (cd->source_period_bytes == 0) {
-		comp_err(dev, "selector_prepare() error: cd->source_period_bytes = 0, dev->frames = %u",
+		comp_err(dev, "selector_prepare(): cd->source_period_bytes = 0, dev->frames = %u",
 			 dev->frames);
 		ret = -EINVAL;
 		goto err;
@@ -488,7 +488,7 @@ static int selector_prepare(struct comp_dev *dev)
 
 	cd->sel_func = sel_get_processing_function(dev);
 	if (!cd->sel_func) {
-		comp_err(dev, "selector_prepare() error: invalid cd->sel_func, cd->source_format = %u, cd->sink_format = %u, cd->out_channels_count = %u",
+		comp_err(dev, "selector_prepare(): invalid cd->sel_func, cd->source_format = %u, cd->sink_format = %u, cd->out_channels_count = %u",
 			 cd->source_format, cd->sink_format,
 			 cd->config.out_channels_count);
 		ret = -EINVAL;

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -107,7 +107,7 @@ int src_buffer_lengths(struct src_param *a, int fs_in, int fs_out, int nch,
 
 	if (nch > PLATFORM_MAX_CHANNELS) {
 		/* TODO: should be device, not class */
-		comp_cl_err(&comp_src, "src_buffer_lengths() error: nch = %u > PLATFORM_MAX_CHANNELS",
+		comp_cl_err(&comp_src, "src_buffer_lengths(): nch = %u > PLATFORM_MAX_CHANNELS",
 			    nch);
 		return -EINVAL;
 	}
@@ -118,7 +118,7 @@ int src_buffer_lengths(struct src_param *a, int fs_in, int fs_out, int nch,
 
 	/* Check that both in and out rates are supported */
 	if (a->idx_in < 0 || a->idx_out < 0) {
-		comp_cl_err(&comp_src, "src_buffer_lengths() error: rates not supported, fs_in: %u, fs_out: %u",
+		comp_cl_err(&comp_src, "src_buffer_lengths(): rates not supported, fs_in: %u, fs_out: %u",
 			    fs_in, fs_out);
 		return -EINVAL;
 	}
@@ -128,7 +128,7 @@ int src_buffer_lengths(struct src_param *a, int fs_in, int fs_out, int nch,
 
 	/* Check from stage1 parameter for a deleted in/out rate combination.*/
 	if (stage1->filter_length < 1) {
-		comp_cl_err(&comp_src, "src_buffer_lengths() error: Non-supported combination sfs_in = %d, fs_out = %d",
+		comp_cl_err(&comp_src, "src_buffer_lengths(): Non-supported combination sfs_in = %d, fs_out = %d",
 			    fs_in, fs_out);
 		return -EINVAL;
 	}
@@ -461,7 +461,7 @@ static struct comp_dev *src_new(const struct comp_driver *drv,
 
 	/* validate init data - either SRC sink or source rate must be set */
 	if (ipc_src->source_rate == 0 && ipc_src->sink_rate == 0) {
-		comp_cl_err(&comp_src, "src_new() error: SRC sink and source rate are not set");
+		comp_cl_err(&comp_src, "src_new(): SRC sink and source rate are not set");
 		return NULL;
 	}
 
@@ -525,12 +525,12 @@ static int src_verify_params(struct comp_dev *dev,
 	 */
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK) {
 		if (src->source_rate && (params->rate != src->source_rate)) {
-			comp_err(dev, "src_verify_params(): error: runtime stream pcm rate does not match rate fetched from ipc.");
+			comp_err(dev, "src_verify_params(): runtime stream pcm rate does not match rate fetched from ipc.");
 			return -EINVAL;
 		}
 	} else {
 		if (src->sink_rate && (params->rate != src->sink_rate)) {
-			comp_err(dev, "src_verify_params(): error: runtime stream pcm rate does not match rate fetched from ipc.");
+			comp_err(dev, "src_verify_params(): runtime stream pcm rate does not match rate fetched from ipc.");
 			return -EINVAL;
 		}
 	}
@@ -539,7 +539,7 @@ static int src_verify_params(struct comp_dev *dev,
 	 */
 	ret = comp_verify_params(dev, BUFF_PARAMS_RATE, params);
 	if (ret < 0) {
-		comp_err(dev, "src_verify_params() error: comp_verify_params() failed.");
+		comp_err(dev, "src_verify_params(): comp_verify_params() failed.");
 		return ret;
 	}
 
@@ -595,7 +595,7 @@ static int src_params(struct comp_dev *dev,
 				 cd->sink_rate,
 				 sourceb->stream.channels, cd->source_frames);
 	if (err < 0) {
-		comp_err(dev, "src_params() error: src_buffer_lengths() failed");
+		comp_err(dev, "src_params(): src_buffer_lengths() failed");
 		return err;
 	}
 
@@ -604,7 +604,7 @@ static int src_params(struct comp_dev *dev,
 
 	delay_lines_size = sizeof(int32_t) * cd->param.total;
 	if (delay_lines_size == 0) {
-		comp_err(dev, "src_params() error: delay_lines_size = 0");
+		comp_err(dev, "src_params(): delay_lines_size = 0");
 		return -EINVAL;
 	}
 
@@ -614,7 +614,7 @@ static int src_params(struct comp_dev *dev,
 
 	cd->delay_lines = rballoc(0, SOF_MEM_CAPS_RAM, delay_lines_size);
 	if (!cd->delay_lines) {
-		comp_err(dev, "src_params() error: failed to alloc cd->delay_lines, delay_lines_size = %u",
+		comp_err(dev, "src_params(): failed to alloc cd->delay_lines, delay_lines_size = %u",
 			 delay_lines_size);
 		return -EINVAL;
 	}
@@ -836,26 +836,26 @@ static int src_prepare(struct comp_dev *dev)
 						      dev->frames);
 
 	if (sinkb->stream.size < config->periods_sink * sink_period_bytes) {
-		comp_err(dev, "src_prepare() error: sink buffer size is insufficient");
+		comp_err(dev, "src_prepare(): sink buffer size is insufficient");
 		ret = -ENOMEM;
 		goto err;
 	}
 
 	/* validate */
 	if (!sink_period_bytes) {
-		comp_err(dev, "src_prepare() error: sink_period_bytes = 0");
+		comp_err(dev, "src_prepare(): sink_period_bytes = 0");
 		ret = -EINVAL;
 		goto err;
 	}
 	if (!source_period_bytes) {
-		comp_err(dev, "src_prepare() error: source_period_bytes = 0");
+		comp_err(dev, "src_prepare(): source_period_bytes = 0");
 		ret = -EINVAL;
 		goto err;
 	}
 
 	/* SRC supports S16_LE, S24_4LE and S32_LE formats */
 	if (cd->source_format != cd->sink_format) {
-		comp_err(dev, "src_prepare() error: Source fmt %d and sink fmt %d are different.",
+		comp_err(dev, "src_prepare(): Source fmt %d and sink fmt %d are different.",
 			 cd->source_format, cd->sink_format);
 		ret = -EINVAL;
 		goto err;
@@ -887,7 +887,7 @@ static int src_prepare(struct comp_dev *dev)
 		break;
 #endif /* CONFIG_FORMAT_S32LE */
 	default:
-		comp_err(dev, "src_prepare() error: invalid format %d",
+		comp_err(dev, "src_prepare(): invalid format %d",
 			 cd->source_format);
 		ret = -EINVAL;
 		goto err;

--- a/src/audio/tone.c
+++ b/src/audio/tone.c
@@ -499,7 +499,7 @@ static int tone_cmd_set_value(struct comp_dev *dev,
 			comp_info(dev, "tone_cmd_set_value(), SOF_CTRL_CMD_SWITCH, ch = %u, val = %u",
 				  ch, val);
 			if (ch >= PLATFORM_MAX_CHANNELS) {
-				comp_err(dev, "tone_cmd_set_value() error: ch >= PLATFORM_MAX_CHANNELS");
+				comp_err(dev, "tone_cmd_set_value(): ch >= PLATFORM_MAX_CHANNELS");
 				return -EINVAL;
 			}
 
@@ -510,7 +510,7 @@ static int tone_cmd_set_value(struct comp_dev *dev,
 
 		}
 	} else {
-		comp_err(dev, "tone_cmd_set_value() error: invalid cdata->cmd");
+		comp_err(dev, "tone_cmd_set_value(): invalid cdata->cmd");
 		return -EINVAL;
 	}
 
@@ -572,13 +572,13 @@ static int tone_cmd_set_data(struct comp_dev *dev,
 				tonegen_set_linramp(&cd->sg[ch], val);
 				break;
 			default:
-				comp_err(dev, "tone_cmd_set_data() error: invalid cdata->index");
+				comp_err(dev, "tone_cmd_set_data(): invalid cdata->index");
 				return -EINVAL;
 			}
 		}
 		break;
 	default:
-		comp_err(dev, "tone_cmd_set_data() error: invalid cdata->cmd");
+		comp_err(dev, "tone_cmd_set_data(): invalid cdata->cmd");
 		return -EINVAL;
 	}
 

--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -74,7 +74,7 @@ static void vol_sync_host(struct comp_dev *dev, unsigned int num_channels)
 		for (n = 0; n < num_channels; n++)
 			cd->hvol[n].value = cd->volume[n];
 	} else {
-		comp_err(dev, "vol_sync_host() error: channels count %d exceeds SOF_IPC_MAX_CHANNELS",
+		comp_err(dev, "vol_sync_host(): channels count %d exceeds SOF_IPC_MAX_CHANNELS",
 			 num_channels);
 	}
 }
@@ -315,7 +315,7 @@ static int volume_verify_params(struct comp_dev *dev,
 
 	ret = comp_verify_params(dev, 0, params);
 	if (ret < 0) {
-		comp_err(dev, "volume_verify_params() error: comp_verify_params() failed.");
+		comp_err(dev, "volume_verify_params(): comp_verify_params() failed.");
 		return ret;
 	}
 
@@ -437,7 +437,7 @@ static inline int volume_set_chan(struct comp_dev *dev, int chan,
 	case SOF_VOLUME_LINEAR_ZC:
 	case SOF_VOLUME_LOG_ZC:
 	default:
-		comp_err(dev, "volume_set_chan() error: invalid ramp type %d",
+		comp_err(dev, "volume_set_chan(): invalid ramp type %d",
 			 pga->ramp);
 		return -EINVAL;
 	}
@@ -493,7 +493,7 @@ static int volume_ctrl_set_cmd(struct comp_dev *dev,
 
 	/* validate */
 	if (cdata->num_elems == 0 || cdata->num_elems > SOF_IPC_MAX_CHANNELS) {
-		comp_err(dev, "volume_ctrl_set_cmd() error: invalid cdata->num_elems");
+		comp_err(dev, "volume_ctrl_set_cmd(): invalid cdata->num_elems");
 		return -EINVAL;
 	}
 
@@ -562,7 +562,7 @@ static int volume_ctrl_set_cmd(struct comp_dev *dev,
 		break;
 
 	default:
-		comp_err(dev, "volume_ctrl_set_cmd() error: invalid cdata->cmd");
+		comp_err(dev, "volume_ctrl_set_cmd(): invalid cdata->cmd");
 		return -EINVAL;
 	}
 
@@ -583,7 +583,7 @@ static int volume_ctrl_get_cmd(struct comp_dev *dev,
 
 	/* validate */
 	if (cdata->num_elems == 0 || cdata->num_elems > SOF_IPC_MAX_CHANNELS) {
-		comp_err(dev, "volume_ctrl_get_cmd() error: invalid cdata->num_elems %u",
+		comp_err(dev, "volume_ctrl_get_cmd(): invalid cdata->num_elems %u",
 			 cdata->num_elems);
 		return -EINVAL;
 	}
@@ -600,7 +600,7 @@ static int volume_ctrl_get_cmd(struct comp_dev *dev,
 				  cdata->chanv[j].value);
 		}
 	} else {
-		comp_err(dev, "volume_ctrl_get_cmd() error: invalid cdata->cmd");
+		comp_err(dev, "volume_ctrl_get_cmd(): invalid cdata->cmd");
 		return -EINVAL;
 	}
 
@@ -727,14 +727,14 @@ static int volume_prepare(struct comp_dev *dev)
 						      dev->frames);
 
 	if (sinkb->stream.size < config->periods_sink * sink_period_bytes) {
-		comp_err(dev, "volume_prepare() error: sink buffer size is insufficient");
+		comp_err(dev, "volume_prepare(): sink buffer size is insufficient");
 		ret = -ENOMEM;
 		goto err;
 	}
 
 	cd->scale_vol = vol_get_processing_function(dev);
 	if (!cd->scale_vol) {
-		comp_err(dev, "volume_prepare() error: invalid cd->scale_vol");
+		comp_err(dev, "volume_prepare(): invalid cd->scale_vol");
 
 		ret = -EINVAL;
 		goto err;

--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -205,8 +205,8 @@ static struct dma_chan_data *dw_dma_channel_get(struct dma *dma,
 
 	/* DMA controller has no free channels */
 	spin_unlock_irq(&dma->lock, flags);
-	trace_dwdma_error("dw_dma_channel_get() error: dma %d "
-			  "no free channels", dma->plat_data.id);
+	trace_dwdma_error("dw_dma_channel_get(): dma %d no free channels",
+			  dma->plat_data.id);
 
 	return NULL;
 }
@@ -268,8 +268,7 @@ static int dw_dma_start(struct dma_chan_data *channel)
 	/* check if channel idle, disabled and ready */
 	if (channel->status != COMP_STATE_PREPARE ||
 	    (dma_reg_read(dma, DW_DMA_CHAN_EN) & DW_CHAN(channel->index))) {
-		trace_dwdma_error("dw_dma_start() error: dma %d channel %d "
-				  "not ready ena 0x%x status 0x%x",
+		trace_dwdma_error("dw_dma_start(): dma %d channel %d not ready ena 0x%x status 0x%x",
 				  dma->plat_data.id, channel->index,
 				  dma_reg_read(dma, DW_DMA_CHAN_EN),
 				  channel->status);
@@ -279,9 +278,8 @@ static int dw_dma_start(struct dma_chan_data *channel)
 
 	/* is valid stream */
 	if (!dw_chan->lli) {
-		trace_dwdma_error("dw_dma_start() error: dma %d channel %d "
-				  "invalid stream", dma->plat_data.id,
-				  channel->index);
+		trace_dwdma_error("dw_dma_start(): dma %d channel %d invalid stream",
+				  dma->plat_data.id, channel->index);
 		ret = -EINVAL;
 		goto out;
 	}
@@ -409,8 +407,8 @@ static int dw_dma_stop(struct dma_chan_data *channel)
 				      DW_CFGL_FIFO_EMPTY,
 				      DW_DMA_TIMEOUT);
 	if (ret < 0)
-		trace_dwdma_error("dw_dma_stop() error: dma %d channel %d "
-				  "timeout", dma->plat_data.id, channel->index);
+		trace_dwdma_error("dw_dma_stop(): dma %d channel %d timeout",
+				  dma->plat_data.id, channel->index);
 #endif
 
 	dma_reg_write(dma, DW_DMA_CHAN_EN, DW_CHAN_MASK(channel->index));
@@ -509,8 +507,7 @@ static int dw_dma_set_config(struct dma_chan_data *channel,
 	dw_chan->cfg_hi = DW_CFG_HIGH_DEF;
 
 	if (!config->elem_array.count) {
-		trace_dwdma_error("dw_dma_set_config() error: dma %d "
-				  "channel %d no elems",
+		trace_dwdma_error("dw_dma_set_config(): dma %d channel %d no elems",
 				  channel->dma->plat_data.id, channel->index);
 		ret = -EINVAL;
 		goto out;
@@ -518,9 +515,8 @@ static int dw_dma_set_config(struct dma_chan_data *channel,
 
 	if (config->irq_disabled &&
 	    config->elem_array.count < DW_DMA_CFG_NO_IRQ_MIN_ELEMS) {
-		trace_dwdma_error("dw_dma_set_config() error: dma %d channel "
-				  "%d not enough elems for config with irq "
-				  "disabled %d", channel->dma->plat_data.id,
+		trace_dwdma_error("dw_dma_set_config(): dma %d channel %d not enough elems for config with irq disabled %d",
+				  channel->dma->plat_data.id,
 				  channel->index, config->elem_array.count);
 		ret = -EINVAL;
 		goto out;
@@ -540,8 +536,7 @@ static int dw_dma_set_config(struct dma_chan_data *channel,
 				       sizeof(struct dw_lli) *
 				       channel->desc_count);
 		if (!dw_chan->lli) {
-			trace_dwdma_error("dw_dma_set_config() error: dma %d "
-					  "channel %d lli alloc failed",
+			trace_dwdma_error("dw_dma_set_config(): dma %d channel %d lli alloc failed",
 					  channel->dma->plat_data.id,
 					  channel->index);
 			ret = -ENOMEM;
@@ -593,8 +588,7 @@ static int dw_dma_set_config(struct dma_chan_data *channel,
 			lli_desc->ctrl_lo |= DW_CTLL_SRC_WIDTH(2);
 			break;
 		default:
-			trace_dwdma_error("dw_dma_set_config() error: dma %d "
-					  "channel %d invalid src width %d",
+			trace_dwdma_error("dw_dma_set_config(): dma %d channel %d invalid src width %d",
 					  channel->dma->plat_data.id,
 					  channel->index, config->src_width);
 			ret = -EINVAL;
@@ -622,8 +616,7 @@ static int dw_dma_set_config(struct dma_chan_data *channel,
 			lli_desc->ctrl_lo |= DW_CTLL_DST_WIDTH(2);
 			break;
 		default:
-			trace_dwdma_error("dw_dma_set_config() error: dma %d "
-					  "channel %d invalid dest width %d",
+			trace_dwdma_error("dw_dma_set_config(): dma %d channel %d invalid dest width %d",
 					  channel->dma->plat_data.id,
 					  channel->index, config->dest_width);
 			ret = -EINVAL;
@@ -701,8 +694,7 @@ static int dw_dma_set_config(struct dma_chan_data *channel,
 				DW_CFGH_DST(config->dest_dev);
 			break;
 		default:
-			trace_dwdma_error("dw_dma_set_config() error: dma %d "
-					  "channel %d invalid direction %d",
+			trace_dwdma_error("dw_dma_set_config(): dma %d channel %d invalid direction %d",
 					  channel->dma->plat_data.id,
 					  channel->index, config->direction);
 			ret = -EINVAL;
@@ -712,8 +704,7 @@ static int dw_dma_set_config(struct dma_chan_data *channel,
 		dw_dma_mask_address(sg_elem, lli_desc, config->direction);
 
 		if (sg_elem->size > DW_CTLH_BLOCK_TS_MASK) {
-			trace_dwdma_error("dw_dma_set_config() error: dma %d "
-					  "channel %d block size too big %d",
+			trace_dwdma_error("dw_dma_set_config(): dma %d channel %d block size too big %d",
 					  channel->dma->plat_data.id,
 					  channel->index, sg_elem->size);
 			ret = -EINVAL;
@@ -934,8 +925,8 @@ static int dw_dma_probe(struct dma *dma)
 			    dma->plat_data.channels);
 
 	if (!dma->chan) {
-		trace_dwdma_error("dw_dma_probe() error: dma %d allocaction of "
-				  "channels failed", dma->plat_data.id);
+		trace_dwdma_error("dw_dma_probe(): dma %d allocaction of channels failed",
+				  dma->plat_data.id);
 		goto out;
 	}
 
@@ -955,9 +946,8 @@ static int dw_dma_probe(struct dma *dma)
 				  sizeof(*dw_chan));
 
 		if (!dw_chan) {
-			trace_dwdma_error("dw_dma_probe() error: dma %d "
-					  "allocaction of channel %d private "
-					  "data failed", dma->plat_data.id, i);
+			trace_dwdma_error("dw_dma_probe(): dma %d allocaction of channel %d private data failed",
+					  dma->plat_data.id, i);
 			goto out;
 		}
 
@@ -1045,8 +1035,7 @@ static int dw_dma_get_data_size(struct dma_chan_data *channel,
 #if CONFIG_HW_LLI
 	if (!(dma_reg_read(channel->dma, DW_DMA_CHAN_EN) &
 	      DW_CHAN(channel->index))) {
-		trace_dwdma_error("dw_dma_get_data_size() error: "
-				  "xrun detected");
+		trace_dwdma_error("dw_dma_get_data_size(): xrun detected");
 		return -ENODATA;
 	}
 #endif

--- a/src/drivers/intel/baytrail/ssp.c
+++ b/src/drivers/intel/baytrail/ssp.c
@@ -211,7 +211,7 @@ static int ssp_set_config(struct dai *dai,
 		cbs = true;
 		break;
 	default:
-		dai_err(dai, "ssp_set_config() error: format & MASTER_MASK EINVAL");
+		dai_err(dai, "ssp_set_config(): format & MASTER_MASK EINVAL");
 		ret = -EINVAL;
 		goto out;
 	}
@@ -231,7 +231,7 @@ static int ssp_set_config(struct dai *dai,
 		sspsp |= SSPSP_SCMODE(2);
 		break;
 	default:
-		dai_err(dai, "ssp_set_config() error: format & INV_MASK EINVAL");
+		dai_err(dai, "ssp_set_config(): format & INV_MASK EINVAL");
 		ret = -EINVAL;
 		goto out;
 	}
@@ -279,7 +279,7 @@ static int ssp_set_config(struct dai *dai,
 
 	/* BCLK is generated from MCLK - must be divisable */
 	if (config->ssp.mclk_rate % config->ssp.bclk_rate) {
-		dai_err(dai, "ssp_set_config() error: MCLK is not divisable");
+		dai_err(dai, "ssp_set_config(): MCLK is not divisable");
 		ret = -EINVAL;
 		goto out;
 	}
@@ -287,7 +287,7 @@ static int ssp_set_config(struct dai *dai,
 	/* divisor must be within SCR range */
 	mdiv = (config->ssp.mclk_rate / config->ssp.bclk_rate) - 1;
 	if (mdiv > (SSCR0_SCR_MASK >> 8)) {
-		dai_err(dai, "ssp_set_config() error: divisor is not within SCR range");
+		dai_err(dai, "ssp_set_config(): divisor is not within SCR range");
 		ret = -EINVAL;
 		goto out;
 	}
@@ -297,7 +297,7 @@ static int ssp_set_config(struct dai *dai,
 
 	/* calc frame width based on BCLK and rate - must be divisable */
 	if (config->ssp.bclk_rate % config->ssp.fsync_rate) {
-		dai_err(dai, "ssp_set_config() error: BLCK is not divisable");
+		dai_err(dai, "ssp_set_config(): BLCK is not divisable");
 		ret = -EINVAL;
 		goto out;
 	}
@@ -306,14 +306,14 @@ static int ssp_set_config(struct dai *dai,
 	bdiv = config->ssp.bclk_rate / config->ssp.fsync_rate;
 	if (bdiv < config->ssp.tdm_slot_width *
 	    config->ssp.tdm_slots) {
-		dai_err(dai, "ssp_set_config() error: not enough BCLKs");
+		dai_err(dai, "ssp_set_config(): not enough BCLKs");
 		ret = -EINVAL;
 		goto out;
 	}
 
 	/* tdm_slot_width must be <= 38 for SSP */
 	if (config->ssp.tdm_slot_width > 38) {
-		dai_err(dai, "ssp_set_config() error: tdm_slot_width > 38");
+		dai_err(dai, "ssp_set_config(): tdm_slot_width > 38");
 		ret = -EINVAL;
 		goto out;
 	}
@@ -436,7 +436,7 @@ static int ssp_set_config(struct dai *dai,
 
 		break;
 	default:
-		dai_err(dai, "ssp_set_config() error: format & FORMAT_MASK EINVAL");
+		dai_err(dai, "ssp_set_config(): format & FORMAT_MASK EINVAL");
 		ret = -EINVAL;
 		goto out;
 	}

--- a/src/drivers/intel/cavs/alh.c
+++ b/src/drivers/intel/cavs/alh.c
@@ -79,7 +79,7 @@ static int alh_remove(struct dai *dai)
 static int alh_get_handshake(struct dai *dai, int direction, int stream_id)
 {
 	if (stream_id >= ARRAY_SIZE(alh_handshake_map)) {
-		dai_err(dai, "alh_get_handshake() error: "
+		dai_err(dai, "alh_get_handshake(): "
 				"stream_id %d out of range", stream_id);
 
 		return -1;

--- a/src/drivers/intel/cavs/dmic.c
+++ b/src/drivers/intel/cavs/dmic.c
@@ -276,28 +276,28 @@ static void find_modes(struct dai *dai,
 	/* Check for sane pdm clock, min 100 kHz, max ioclk/2 */
 	if (dmic_prm[di]->pdmclk_max < DMIC_HW_PDM_CLK_MIN ||
 	    dmic_prm[di]->pdmclk_max > DMIC_HW_IOCLK / 2) {
-		dai_err(dai, "find_modes() error:  pdm clock max not in range");
+		dai_err(dai, "find_modes():  pdm clock max not in range");
 		return;
 	}
 	if (dmic_prm[di]->pdmclk_min < DMIC_HW_PDM_CLK_MIN ||
 	    dmic_prm[di]->pdmclk_min > dmic_prm[di]->pdmclk_max) {
-		dai_err(dai, "find_modes() error:  pdm clock min not in range");
+		dai_err(dai, "find_modes():  pdm clock min not in range");
 		return;
 	}
 
 	/* Check for sane duty cycle */
 	if (dmic_prm[di]->duty_min > dmic_prm[di]->duty_max) {
-		dai_err(dai, "find_modes() error: duty cycle min > max");
+		dai_err(dai, "find_modes(): duty cycle min > max");
 		return;
 	}
 	if (dmic_prm[di]->duty_min < DMIC_HW_DUTY_MIN ||
 	    dmic_prm[di]->duty_min > DMIC_HW_DUTY_MAX) {
-		dai_err(dai, "find_modes() error:  pdm clock min not in range");
+		dai_err(dai, "find_modes():  pdm clock min not in range");
 		return;
 	}
 	if (dmic_prm[di]->duty_max < DMIC_HW_DUTY_MIN ||
 	    dmic_prm[di]->duty_max > DMIC_HW_DUTY_MAX) {
-		dai_err(dai, "find_modes() error: pdm clock max not in range");
+		dai_err(dai, "find_modes(): pdm clock max not in range");
 		return;
 	}
 
@@ -563,7 +563,7 @@ static int select_mode(struct dai *dai,
 	 * the candidates should be sufficient.
 	 */
 	if (modes->num_of_modes == 0) {
-		dai_err(dai, "select_mode() error: no modes available");
+		dai_err(dai, "select_mode(): no modes available");
 		return -EINVAL;
 	}
 
@@ -596,7 +596,7 @@ static int select_mode(struct dai *dai,
 	if (cfg->mfir_a > 0) {
 		cfg->fir_a = get_fir(dai, cfg, cfg->mfir_a);
 		if (!cfg->fir_a) {
-			dai_err(dai, "select_mode() error: cannot find FIR coefficients, mfir_a = %u",
+			dai_err(dai, "select_mode(): cannot find FIR coefficients, mfir_a = %u",
 				cfg->mfir_a);
 			return -EINVAL;
 		}
@@ -605,7 +605,7 @@ static int select_mode(struct dai *dai,
 	if (cfg->mfir_b > 0) {
 		cfg->fir_b = get_fir(dai, cfg, cfg->mfir_b);
 		if (!cfg->fir_b) {
-			dai_err(dai, "select_mode() error: cannot find FIR coefficients, mfir_b = %u",
+			dai_err(dai, "select_mode(): cannot find FIR coefficients, mfir_b = %u",
 				cfg->mfir_b);
 			return -EINVAL;
 		}
@@ -618,7 +618,7 @@ static int select_mode(struct dai *dai,
 	g_cic = mcic * mcic * mcic * mcic * mcic;
 	if (g_cic < 0) {
 		/* Erroneous decimation factor and CIC gain */
-		dai_err(dai, "select_mode() error: erroneous decimation factor and CIC gain");
+		dai_err(dai, "select_mode(): erroneous decimation factor and CIC gain");
 		return -EINVAL;
 	}
 
@@ -645,7 +645,7 @@ static int select_mode(struct dai *dai,
 				     cfg->fir_a->length, gain_to_fir);
 		if (ret < 0) {
 			/* Invalid coefficient set found, should not happen. */
-			dai_err(dai, "select_mode() error: invalid coefficient set found");
+			dai_err(dai, "select_mode(): invalid coefficient set found");
 			return -EINVAL;
 		}
 	} else {
@@ -661,7 +661,7 @@ static int select_mode(struct dai *dai,
 				     cfg->fir_b->length, gain_to_fir);
 		if (ret < 0) {
 			/* Invalid coefficient set found, should not happen. */
-			dai_err(dai, "select_mode() error: invalid coefficient set found");
+			dai_err(dai, "select_mode(): invalid coefficient set found");
 			return -EINVAL;
 		}
 	} else {
@@ -826,7 +826,7 @@ static int configure_registers(struct dai *dai,
 
 	/* pdata is set by dmic_probe(), error if it has not been set */
 	if (!pdata) {
-		dai_err(dai, "configure_registers() error: pdata not set");
+		dai_err(dai, "configure_registers(): pdata not set");
 		return -EINVAL;
 	}
 
@@ -1107,7 +1107,7 @@ static int dmic_set_config(struct dai *dai, struct sof_ipc_dai_config *config)
 	dai_info(dai, "dmic_set_config()");
 
 	if (config->dmic.driver_ipc_version != DMIC_IPC_VERSION) {
-		dai_err(dai, "dmic_set_config() error: wrong ipc version");
+		dai_err(dai, "dmic_set_config(): wrong ipc version");
 		return -EINVAL;
 	}
 
@@ -1127,12 +1127,12 @@ static int dmic_set_config(struct dai *dai, struct sof_ipc_dai_config *config)
 	}
 
 	if (di >= DMIC_HW_FIFOS) {
-		dai_err(dai, "dmic_set_config() error: dai->index exceeds number of FIFOs");
+		dai_err(dai, "dmic_set_config(): dai->index exceeds number of FIFOs");
 		return -EINVAL;
 	}
 
 	if (config->dmic.num_pdm_active > DMIC_HW_CONTROLLERS) {
-		dai_err(dai, "dmic_set_config() error: the requested PDM controllers count exceeds platform capability");
+		dai_err(dai, "dmic_set_config(): the requested PDM controllers count exceeds platform capability");
 		return -EINVAL;
 	}
 
@@ -1154,7 +1154,7 @@ static int dmic_set_config(struct dai *dai, struct sof_ipc_dai_config *config)
 				      SOF_MEM_CAPS_RAM,
 				      DMIC_HW_FIFOS * size);
 		if (!dmic_prm[0]) {
-			dai_err(dai, "dmic_set_config() error: prm not initialized");
+			dai_err(dai, "dmic_set_config(): prm not initialized");
 			return -ENOMEM;
 		}
 		for (i = 1; i < DMIC_HW_FIFOS; i++)
@@ -1200,7 +1200,7 @@ static int dmic_set_config(struct dai *dai, struct sof_ipc_dai_config *config)
 	case 32:
 		break;
 	default:
-		dai_err(dai, "dmic_set_config() error: fifo_bits EINVAL");
+		dai_err(dai, "dmic_set_config(): fifo_bits EINVAL");
 		return -EINVAL;
 	}
 
@@ -1212,20 +1212,20 @@ static int dmic_set_config(struct dai *dai, struct sof_ipc_dai_config *config)
 	 */
 	find_modes(dai, &modes_a, dmic_prm[0]->fifo_fs, di);
 	if (modes_a.num_of_modes == 0 && dmic_prm[0]->fifo_fs > 0) {
-		dai_err(dai, "dmic_set_config() error: No modes found found for FIFO A");
+		dai_err(dai, "dmic_set_config(): No modes found found for FIFO A");
 		return -EINVAL;
 	}
 
 	find_modes(dai, &modes_b, dmic_prm[1]->fifo_fs, di);
 	if (modes_b.num_of_modes == 0 && dmic_prm[1]->fifo_fs > 0) {
-		dai_err(dai, "dmic_set_config() error: No modes found for FIFO B");
+		dai_err(dai, "dmic_set_config(): No modes found for FIFO B");
 		return -EINVAL;
 	}
 
 	match_modes(&modes_ab, &modes_a, &modes_b);
 	ret = select_mode(dai, &cfg, &modes_ab);
 	if (ret < 0) {
-		dai_err(dai, "dmic_set_config() error: select_mode() failed");
+		dai_err(dai, "dmic_set_config(): select_mode() failed");
 		return -EINVAL;
 	}
 
@@ -1246,7 +1246,7 @@ static int dmic_set_config(struct dai *dai, struct sof_ipc_dai_config *config)
 	 */
 	ret = configure_registers(dai, &cfg);
 	if (ret < 0) {
-		dai_err(dai, "dmic_set_config() error: cannot configure registers");
+		dai_err(dai, "dmic_set_config(): cannot configure registers");
 		return -EINVAL;
 	}
 
@@ -1471,12 +1471,12 @@ static int dmic_trigger(struct dai *dai, int cmd, int direction)
 
 	/* dai private is set in dmic_probe(), error if not set */
 	if (!dmic) {
-		dai_err(dai, "dmic_trigger() error: dai not set");
+		dai_err(dai, "dmic_trigger(): dai not set");
 		return -EINVAL;
 	}
 
 	if (direction != DAI_DIR_CAPTURE) {
-		dai_err(dai, "dmic_trigger() error: direction != DAI_DIR_CAPTURE");
+		dai_err(dai, "dmic_trigger(): direction != DAI_DIR_CAPTURE");
 		return -EINVAL;
 	}
 
@@ -1487,7 +1487,7 @@ static int dmic_trigger(struct dai *dai, int cmd, int direction)
 		    dmic->state == COMP_STATE_PAUSED) {
 			dmic_start(dai);
 		} else {
-			dai_err(dai, "dmic_trigger() error: state is not prepare or paused, dmic->state = %u",
+			dai_err(dai, "dmic_trigger(): state is not prepare or paused, dmic->state = %u",
 				dmic->state);
 		}
 		break;
@@ -1524,12 +1524,12 @@ static void dmic_irq_handler(void *data)
 	dai_info(dai, "dmic_irq_handler(), OUTSTAT1 = %u", val1);
 
 	if (val0 & OUTSTAT0_ROR_BIT) {
-		dai_err(dai, "dmic_irq_handler() error: full fifo A or PDM overrun");
+		dai_err(dai, "dmic_irq_handler(): full fifo A or PDM overrun");
 		dai_write(dai, OUTSTAT0, val0);
 	}
 
 	if (val1 & OUTSTAT1_ROR_BIT) {
-		dai_err(dai, "dmic_irq_handler() error: full fifo B or PDM overrun");
+		dai_err(dai, "dmic_irq_handler(): full fifo B or PDM overrun");
 		dai_write(dai, OUTSTAT1, val1);
 	}
 }
@@ -1549,7 +1549,7 @@ static int dmic_probe(struct dai *dai)
 	dmic = rzalloc(SOF_MEM_ZONE_SYS_RUNTIME, 0, SOF_MEM_CAPS_RAM,
 		       sizeof(*dmic));
 	if (!dmic) {
-		dai_err(dai, "dmic_probe() error: alloc failed");
+		dai_err(dai, "dmic_probe(): alloc failed");
 		return -ENOMEM;
 	}
 	dai_set_drvdata(dai, dmic);

--- a/src/drivers/intel/cavs/hda-dma.c
+++ b/src/drivers/intel/cavs/hda-dma.c
@@ -783,10 +783,10 @@ static int hda_dma_link_check_xrun(struct dma_chan_data *chan)
 	uint32_t dgcs = dma_chan_reg_read(chan, DGCS);
 
 	if (chan->direction == DMA_DIR_MEM_TO_DEV && dgcs & DGCS_BUR) {
-		trace_hddma_error("hda_dma_link_check_xrun() error: underrun detected");
+		trace_hddma_error("hda_dma_link_check_xrun(): underrun detected");
 		dma_chan_reg_update_bits(chan, DGCS, DGCS_BUR, DGCS_BUR);
 	} else if (chan->direction == DMA_DIR_DEV_TO_MEM && dgcs & DGCS_BOR) {
-		trace_hddma_error("hda_dma_link_check_xrun() error: overrun detected");
+		trace_hddma_error("hda_dma_link_check_xrun(): overrun detected");
 		dma_chan_reg_update_bits(chan, DGCS, DGCS_BOR, DGCS_BOR);
 	}
 

--- a/src/drivers/intel/cavs/idc.c
+++ b/src/drivers/intel/cavs/idc.c
@@ -204,8 +204,7 @@ int idc_send_msg(struct idc_msg *msg, uint32_t mode)
 				if (idc->msg_processed[msg->core])
 					break;
 
-				trace_idc_error("arch_idc_send_msg() error: "
-						"timeout");
+				trace_idc_error("arch_idc_send_msg(): timeout");
 				return -ETIME;
 			}
 		}
@@ -411,7 +410,7 @@ static void idc_cmd(struct idc_msg *msg)
 		ret = idc_reset(msg->extension);
 		break;
 	default:
-		trace_idc_error("idc_cmd() error: invalid msg->header = %u",
+		trace_idc_error("idc_cmd(): invalid msg->header = %u",
 				msg->header);
 	}
 

--- a/src/drivers/intel/cavs/interrupt.c
+++ b/src/drivers/intel/cavs/interrupt.c
@@ -94,7 +94,7 @@ static inline void irq_lvl2_handler(void *data, int level, uint32_t ilxsd,
 
 		if (!handled) {
 			/* nobody cared ? */
-			trace_irq_error("irq_lvl2_handler() error: "
+			trace_irq_error("irq_lvl2_handler(): "
 					"nobody cared level %d bit %d",
 					level, bit);
 			/* now mask it */
@@ -113,7 +113,7 @@ static inline void irq_lvl2_handler(void *data, int level, uint32_t ilxsd,
 		/* any devices continually interrupting / can't be cleared ? */
 		if (!--tries) {
 			tries = LVL2_MAX_TRIES;
-			trace_irq_error("irq_lvl2_handler() error: "
+			trace_irq_error("irq_lvl2_handler(): "
 					"IRQ storm at level %d status %08X",
 					level, irq_read(ilxsd));
 		}

--- a/src/drivers/intel/cavs/mn.c
+++ b/src/drivers/intel/cavs/mn.c
@@ -117,7 +117,7 @@ static inline int setup_initial_mclk_source(uint32_t mclk_rate)
 	}
 
 	if (clk_index < 0) {
-		trace_mn_error("error: MCLK %d, no valid source",
+		trace_mn_error("MCLK %d, no valid source",
 			       mclk_rate);
 		ret = -EINVAL;
 		goto out;
@@ -150,7 +150,7 @@ static inline int check_current_mclk_source(uint32_t mclk_rate)
 	int ret = 0;
 
 	if (ssp_freq[mn->mclk_source_clock].freq % mclk_rate != 0) {
-		trace_mn_error("error: MCLK %d, no valid configuration for already selected source = %d",
+		trace_mn_error("MCLK %d, no valid configuration for already selected source = %d",
 			       mclk_rate, mn->mclk_source_clock);
 		ret = -EINVAL;
 	}
@@ -184,7 +184,7 @@ static inline int set_mclk_divider(uint16_t mclk_id, uint32_t mdivr_val)
 		mdivr = 0x6; /* 1/8 */
 		break;
 	default:
-		trace_mn_error("error: invalid mdivr_val %d", mdivr_val);
+		trace_mn_error("invalid mdivr_val %d", mdivr_val);
 		return -EINVAL;
 	}
 
@@ -198,7 +198,7 @@ int mn_set_mclk(uint16_t mclk_id, uint32_t mclk_rate)
 	int ret = 0;
 
 	if (mclk_id >= DAI_NUM_SSP_MCLK) {
-		trace_mn_error("error: mclk ID (%d) >= %d",
+		trace_mn_error("mclk ID (%d) >= %d",
 			       mclk_id, DAI_NUM_SSP_MCLK);
 		return -EINVAL;
 	}
@@ -366,7 +366,7 @@ static inline int setup_initial_bclk_mn_source(uint32_t bclk, uint32_t *scr_div,
 	int clk_index = find_bclk_source(bclk, scr_div, m, n);
 
 	if (clk_index < 0) {
-		trace_mn_error("error: BCLK %d, no valid source", bclk);
+		trace_mn_error("BCLK %d, no valid source", bclk);
 		return -EINVAL;
 	}
 
@@ -400,7 +400,7 @@ static inline int setup_current_bclk_mn_source(uint32_t bclk, uint32_t *scr_div,
 		    n))
 		goto out;
 
-	trace_mn_error("error: BCLK %d, no valid configuration for already selected source = %d",
+	trace_mn_error("BCLK %d, no valid configuration for already selected source = %d",
 		       bclk, mn->bclk_source_mn_clock);
 	ret = -EINVAL;
 

--- a/src/drivers/intel/cavs/ssp.c
+++ b/src/drivers/intel/cavs/ssp.c
@@ -136,7 +136,7 @@ static int ssp_set_config(struct dai *dai,
 	/* is playback/capture already running */
 	if (ssp->state[DAI_DIR_PLAYBACK] == COMP_STATE_ACTIVE ||
 	    ssp->state[DAI_DIR_CAPTURE] == COMP_STATE_ACTIVE) {
-		dai_info(dai, "ssp_set_config() error: playback/capture already running");
+		dai_info(dai, "ssp_set_config(): playback/capture already running");
 		ret = -EINVAL;
 		goto out;
 	}
@@ -201,7 +201,7 @@ static int ssp_set_config(struct dai *dai,
 		/* FIXME: this mode has not been tested */
 		break;
 	default:
-		dai_err(dai, "ssp_set_config() error: format & MASTER_MASK EINVAL");
+		dai_err(dai, "ssp_set_config(): format & MASTER_MASK EINVAL");
 		ret = -EINVAL;
 		goto out;
 	}
@@ -221,7 +221,7 @@ static int ssp_set_config(struct dai *dai,
 		inverted_bclk = true; /* handled later with bclk idle */
 		break;
 	default:
-		dai_err(dai, "ssp_set_config() error: format & INV_MASK EINVAL");
+		dai_err(dai, "ssp_set_config(): format & INV_MASK EINVAL");
 		ret = -EINVAL;
 		goto out;
 	}
@@ -280,7 +280,7 @@ static int ssp_set_config(struct dai *dai,
 
 	if (!config->ssp.mclk_rate ||
 	    config->ssp.mclk_rate > ssp_freq[MAX_SSP_FREQ_INDEX].freq) {
-		dai_err(dai, "ssp_set_config() error: invalid MCLK = %d Hz (valid < %d)",
+		dai_err(dai, "ssp_set_config(): invalid MCLK = %d Hz (valid < %d)",
 			config->ssp.mclk_rate,
 			ssp_freq[MAX_SSP_FREQ_INDEX].freq);
 		ret = -EINVAL;
@@ -289,7 +289,7 @@ static int ssp_set_config(struct dai *dai,
 
 	if (!config->ssp.bclk_rate ||
 	    config->ssp.bclk_rate > config->ssp.mclk_rate) {
-		dai_err(dai, "ssp_set_config() error: BCLK %d Hz = 0 or > MCLK %d Hz",
+		dai_err(dai, "ssp_set_config(): BCLK %d Hz = 0 or > MCLK %d Hz",
 			config->ssp.bclk_rate, config->ssp.mclk_rate);
 		ret = -EINVAL;
 		goto out;
@@ -298,7 +298,7 @@ static int ssp_set_config(struct dai *dai,
 	/* MCLK config */
 	ret = mn_set_mclk(config->ssp.mclk_id, config->ssp.mclk_rate);
 	if (ret < 0) {
-		dai_err(dai, "error: invalid mclk_rate = %d for mclk_id = %d",
+		dai_err(dai, "invalid mclk_rate = %d for mclk_id = %d",
 			config->ssp.mclk_id, config->ssp.mclk_rate);
 		goto out;
 	}
@@ -307,7 +307,7 @@ static int ssp_set_config(struct dai *dai,
 	ret = mn_set_bclk(config->dai_index, config->ssp.bclk_rate,
 			  &mdiv, &need_ecs);
 	if (ret < 0) {
-		dai_err(dai, "error: invalid bclk_rate = %d for dai_index = %d",
+		dai_err(dai, "invalid bclk_rate = %d for dai_index = %d",
 			config->ssp.bclk_rate, config->dai_index);
 		goto out;
 	}
@@ -320,7 +320,7 @@ static int ssp_set_config(struct dai *dai,
 
 	/* divisor must be within SCR range */
 	if (mdiv > (SSCR0_SCR_MASK >> 8)) {
-		dai_err(dai, "ssp_set_config() error: divisor %d is not within SCR range",
+		dai_err(dai, "ssp_set_config(): divisor %d is not within SCR range",
 			mdiv);
 		ret = -EINVAL;
 		goto out;
@@ -331,7 +331,7 @@ static int ssp_set_config(struct dai *dai,
 
 	/* calc frame width based on BCLK and rate - must be divisable */
 	if (config->ssp.bclk_rate % config->ssp.fsync_rate) {
-		dai_err(dai, "ssp_set_config() error: BCLK %d is not divisable by rate %d",
+		dai_err(dai, "ssp_set_config(): BCLK %d is not divisable by rate %d",
 			config->ssp.bclk_rate, config->ssp.fsync_rate);
 		ret = -EINVAL;
 		goto out;
@@ -340,7 +340,7 @@ static int ssp_set_config(struct dai *dai,
 	/* must be enough BCLKs for data */
 	bdiv = config->ssp.bclk_rate / config->ssp.fsync_rate;
 	if (bdiv < config->ssp.tdm_slot_width * config->ssp.tdm_slots) {
-		dai_err(dai, "ssp_set_config() error: not enough BCLKs need %d",
+		dai_err(dai, "ssp_set_config(): not enough BCLKs need %d",
 			config->ssp.tdm_slot_width *
 			config->ssp.tdm_slots);
 		ret = -EINVAL;
@@ -349,7 +349,7 @@ static int ssp_set_config(struct dai *dai,
 
 	/* tdm_slot_width must be <= 38 for SSP */
 	if (config->ssp.tdm_slot_width > 38) {
-		dai_err(dai, "ssp_set_config() error: tdm_slot_width %d > 38",
+		dai_err(dai, "ssp_set_config(): tdm_slot_width %d > 38",
 			config->ssp.tdm_slot_width);
 		ret = -EINVAL;
 		goto out;
@@ -359,7 +359,7 @@ static int ssp_set_config(struct dai *dai,
 		   (config->ssp.tdm_per_slot_padding_flag ?
 		    config->ssp.tdm_slot_width : config->ssp.sample_valid_bits);
 	if (bdiv < bdiv_min) {
-		dai_err(dai, "ssp_set_config() error: bdiv(%d) < bdiv_min(%d)",
+		dai_err(dai, "ssp_set_config(): bdiv(%d) < bdiv_min(%d)",
 			bdiv, bdiv_min);
 		ret = -EINVAL;
 		goto out;
@@ -367,7 +367,7 @@ static int ssp_set_config(struct dai *dai,
 
 	frame_end_padding = bdiv - bdiv_min;
 	if (frame_end_padding > SSPSP2_FEP_MASK) {
-		dai_err(dai, "ssp_set_config() error: frame_end_padding too big: %u",
+		dai_err(dai, "ssp_set_config(): frame_end_padding too big: %u",
 			frame_end_padding);
 		ret = -EINVAL;
 		goto out;
@@ -382,7 +382,7 @@ static int ssp_set_config(struct dai *dai,
 		sscr0 |= SSCR0_FRDC(config->ssp.tdm_slots);
 
 		if (bdiv % 2) {
-			dai_err(dai, "ssp_set_config() error: bdiv %d is not divisible by 2",
+			dai_err(dai, "ssp_set_config(): bdiv %d is not divisible by 2",
 				bdiv);
 			ret = -EINVAL;
 			goto out;
@@ -404,7 +404,7 @@ static int ssp_set_config(struct dai *dai,
 		 * of each slot
 		 */
 		if (frame_end_padding % 2) {
-			dai_err(dai, "ssp_set_config() error: frame_end_padding %d is not divisible by 2",
+			dai_err(dai, "ssp_set_config(): frame_end_padding %d is not divisible by 2",
 				frame_end_padding);
 			ret = -EINVAL;
 			goto out;
@@ -414,7 +414,7 @@ static int ssp_set_config(struct dai *dai,
 
 		if (slot_end_padding > SOF_DAI_INTEL_SSP_SLOT_PADDING_MAX) {
 			/* too big padding */
-			dai_err(dai, "ssp_set_config() error: slot_end_padding > %d",
+			dai_err(dai, "ssp_set_config(): slot_end_padding > %d",
 				SOF_DAI_INTEL_SSP_SLOT_PADDING_MAX);
 			ret = -EINVAL;
 			goto out;
@@ -436,7 +436,7 @@ static int ssp_set_config(struct dai *dai,
 		sscr2 &= ~SSCR2_LJDFD;
 
 		if (bdiv % 2) {
-			dai_err(dai, "ssp_set_config() error: bdiv %d is not divisible by 2",
+			dai_err(dai, "ssp_set_config(): bdiv %d is not divisible by 2",
 				bdiv);
 			ret = -EINVAL;
 			goto out;
@@ -458,7 +458,7 @@ static int ssp_set_config(struct dai *dai,
 		 * of each slot
 		 */
 		if (frame_end_padding % 2) {
-			dai_err(dai, "ssp_set_config() error: frame_end_padding %d is not divisible by 2",
+			dai_err(dai, "ssp_set_config(): frame_end_padding %d is not divisible by 2",
 				frame_end_padding);
 			ret = -EINVAL;
 			goto out;
@@ -468,7 +468,7 @@ static int ssp_set_config(struct dai *dai,
 
 		if (slot_end_padding > 15) {
 			/* can't handle padding over 15 bits */
-			dai_err(dai, "ssp_set_config() error: slot_end_padding %d > 15 bits",
+			dai_err(dai, "ssp_set_config(): slot_end_padding %d > 15 bits",
 				slot_end_padding);
 			ret = -EINVAL;
 			goto out;
@@ -503,7 +503,7 @@ static int ssp_set_config(struct dai *dai,
 		/* frame_pulse_width must less or equal 38 */
 		if (ssp->params.frame_pulse_width >
 			SOF_DAI_INTEL_SSP_FRAME_PULSE_WIDTH_MAX) {
-			dai_err(dai, "ssp_set_config() error: frame_pulse_width > %d",
+			dai_err(dai, "ssp_set_config(): frame_pulse_width > %d",
 				SOF_DAI_INTEL_SSP_FRAME_PULSE_WIDTH_MAX);
 			ret = -EINVAL;
 			goto out;
@@ -533,7 +533,7 @@ static int ssp_set_config(struct dai *dai,
 
 			if (slot_end_padding >
 				SOF_DAI_INTEL_SSP_SLOT_PADDING_MAX) {
-				dai_err(dai, "ssp_set_config() error: slot_end_padding > %d",
+				dai_err(dai, "ssp_set_config(): slot_end_padding > %d",
 					SOF_DAI_INTEL_SSP_SLOT_PADDING_MAX);
 				ret = -EINVAL;
 				goto out;
@@ -548,7 +548,7 @@ static int ssp_set_config(struct dai *dai,
 
 		break;
 	default:
-		dai_err(dai, "ssp_set_config() error: invalid format 0x%04x",
+		dai_err(dai, "ssp_set_config(): invalid format 0x%04x",
 			config->format);
 		ret = -EINVAL;
 		goto out;
@@ -578,7 +578,7 @@ static int ssp_set_config(struct dai *dai,
 			sample_width = 4;
 			break;
 	default:
-			dai_err(dai, "ssp_set_config() error: sample_valid_bits %d",
+			dai_err(dai, "ssp_set_config(): sample_valid_bits %d",
 				config->ssp.sample_valid_bits);
 			ret = -EINVAL;
 			goto out;
@@ -789,7 +789,7 @@ static int ssp_probe(struct dai *dai)
 	ssp = rzalloc(SOF_MEM_ZONE_SYS_RUNTIME, SOF_MEM_FLAG_SHARED,
 		      SOF_MEM_CAPS_RAM, sizeof(*ssp));
 	if (!ssp) {
-		dai_err(dai, "ssp_probe() error: alloc failed");
+		dai_err(dai, "ssp_probe(): alloc failed");
 		return -ENOMEM;
 	}
 	dai_set_drvdata(dai, ssp);

--- a/src/drivers/intel/haswell/ssp.c
+++ b/src/drivers/intel/haswell/ssp.c
@@ -76,7 +76,7 @@ static int ssp_set_config(struct dai *dai,
 	/* is playback/capture already running */
 	if (ssp->state[DAI_DIR_PLAYBACK] == COMP_STATE_ACTIVE ||
 	    ssp->state[DAI_DIR_CAPTURE] == COMP_STATE_ACTIVE) {
-		dai_err(dai, "ssp_set_config() error: playback/capture already running");
+		dai_err(dai, "ssp_set_config(): playback/capture already running");
 		ret = -EINVAL;
 		goto out;
 	}
@@ -128,7 +128,7 @@ static int ssp_set_config(struct dai *dai,
 		sscr1 |= SSCR1_SFRMDIR;
 		break;
 	default:
-		dai_err(dai, "ssp_set_config() error: format & MASTER_MASK EINVAL");
+		dai_err(dai, "ssp_set_config(): format & MASTER_MASK EINVAL");
 		ret = -EINVAL;
 		goto out;
 	}
@@ -148,7 +148,7 @@ static int ssp_set_config(struct dai *dai,
 		sspsp |= SSPSP_SCMODE(2);
 		break;
 	default:
-		dai_err(dai, "ssp_set_config() error: format & INV_MASK EINVAL");
+		dai_err(dai, "ssp_set_config(): format & INV_MASK EINVAL");
 		ret = -EINVAL;
 		goto out;
 	}
@@ -195,7 +195,7 @@ static int ssp_set_config(struct dai *dai,
 
 	/* BCLK is generated from MCLK - must be divisable */
 	if (config->ssp.mclk_rate % config->ssp.bclk_rate) {
-		dai_err(dai, "ssp_set_config() error: MCLK is not divisable");
+		dai_err(dai, "ssp_set_config(): MCLK is not divisable");
 		ret = -EINVAL;
 		goto out;
 	}
@@ -203,7 +203,7 @@ static int ssp_set_config(struct dai *dai,
 	/* divisor must be within SCR range */
 	mdiv = (config->ssp.mclk_rate / config->ssp.bclk_rate) - 1;
 	if (mdiv > (SSCR0_SCR_MASK >> 8)) {
-		dai_err(dai, "ssp_set_config() error: divisor is not within SCR range");
+		dai_err(dai, "ssp_set_config(): divisor is not within SCR range");
 		ret = -EINVAL;
 		goto out;
 	}
@@ -213,7 +213,7 @@ static int ssp_set_config(struct dai *dai,
 
 	/* calc frame width based on BCLK and rate - must be divisable */
 	if (config->ssp.bclk_rate % config->ssp.fsync_rate) {
-		dai_err(dai, "ssp_set_config() error: BLCK is not divisable");
+		dai_err(dai, "ssp_set_config(): BLCK is not divisable");
 		ret = -EINVAL;
 		goto out;
 	}
@@ -222,28 +222,28 @@ static int ssp_set_config(struct dai *dai,
 	bdiv = config->ssp.bclk_rate / config->ssp.fsync_rate;
 	if (bdiv < config->ssp.tdm_slot_width *
 	    config->ssp.tdm_slots) {
-		dai_err(dai, "ssp_set_config() error: not enough BCLKs");
+		dai_err(dai, "ssp_set_config(): not enough BCLKs");
 		ret = -EINVAL;
 		goto out;
 	}
 
 	/* tdm_slot_width must be <= 38 for SSP */
 	if (config->ssp.tdm_slot_width > 38) {
-		dai_err(dai, "ssp_set_config() error: tdm_slot_width > 38");
+		dai_err(dai, "ssp_set_config(): tdm_slot_width > 38");
 		ret = -EINVAL;
 		goto out;
 	}
 
 	bdiv_min = config->ssp.tdm_slots * config->ssp.sample_valid_bits;
 	if (bdiv < bdiv_min) {
-		dai_err(dai, "ssp_set_config() error: bdiv < bdiv_min");
+		dai_err(dai, "ssp_set_config(): bdiv < bdiv_min");
 		ret = -EINVAL;
 		goto out;
 	}
 
 	frame_end_padding = bdiv - bdiv_min;
 	if (frame_end_padding > SSPSP2_FEP_MASK) {
-		dai_err(dai, "ssp_set_config() error: frame_end_padding > SSPSP2_FEP_MASK");
+		dai_err(dai, "ssp_set_config(): frame_end_padding > SSPSP2_FEP_MASK");
 		ret = -EINVAL;
 		goto out;
 	}
@@ -281,7 +281,7 @@ static int ssp_set_config(struct dai *dai,
 		sscr0 |= SSCR0_FRDC(config->ssp.tdm_slots);
 
 		if (bdiv % 2) {
-			dai_err(dai, "ssp_set_config() error: bdiv is not divisible by 2");
+			dai_err(dai, "ssp_set_config(): bdiv is not divisible by 2");
 			ret = -EINVAL;
 			goto out;
 		}
@@ -294,7 +294,7 @@ static int ssp_set_config(struct dai *dai,
 		 * of each slot
 		 */
 		if (frame_end_padding % 2) {
-			dai_err(dai, "ssp_set_config() error: frame_end_padding is not divisible by 2");
+			dai_err(dai, "ssp_set_config(): frame_end_padding is not divisible by 2");
 			ret = -EINVAL;
 			goto out;
 		}
@@ -303,7 +303,7 @@ static int ssp_set_config(struct dai *dai,
 
 		if (slot_end_padding > 15) {
 			/* can't handle padding over 15 bits */
-			dai_err(dai, "ssp_set_config() error: slot_end_padding over 15 bits");
+			dai_err(dai, "ssp_set_config(): slot_end_padding over 15 bits");
 			ret = -EINVAL;
 			goto out;
 		}
@@ -342,7 +342,7 @@ static int ssp_set_config(struct dai *dai,
 
 		break;
 	default:
-		dai_err(dai, "ssp_set_config() error: invalid format");
+		dai_err(dai, "ssp_set_config(): invalid format");
 		ret = -EINVAL;
 		goto out;
 	}

--- a/src/drivers/interrupt.c
+++ b/src/drivers/interrupt.c
@@ -44,7 +44,7 @@ int interrupt_cascade_register(const struct irq_cascade_tmpl *tmpl)
 		if (!rstrcmp((*cascade)->name, tmpl->name)) {
 			ret = -EEXIST;
 			trace_error(TRACE_CLASS_IRQ,
-				    "error: cascading IRQ controller name duplication!");
+				    "cascading IRQ controller name duplication!");
 			goto unlock;
 		}
 
@@ -95,7 +95,7 @@ int interrupt_get_irq(unsigned int irq, const char *name)
 	/* If a name is specified, irq must be <= PLATFORM_IRQ_CHILDREN */
 	if (irq >= PLATFORM_IRQ_CHILDREN) {
 		trace_error(TRACE_CLASS_IRQ,
-			    "error: IRQ %d invalid as a child interrupt!",
+			    "IRQ %d invalid as a child interrupt!",
 			    irq);
 		return -EINVAL;
 	}
@@ -183,7 +183,7 @@ static int irq_register_child(struct irq_cascade_desc *cascade, int irq,
 			platform_shared_commit(child, sizeof(*child));
 
 			trace_error(TRACE_CLASS_IRQ,
-				    "error: IRQ 0x%x handler argument re-used!",
+				    "IRQ 0x%x handler argument re-used!",
 				    irq);
 			ret = -EEXIST;
 			goto out;
@@ -346,7 +346,7 @@ static uint32_t irq_disable_child(struct irq_cascade_desc *cascade, int irq,
 
 	if (!child->enable_count[child_idx]) {
 		trace_error(TRACE_CLASS_IRQ,
-			    "error: IRQ %x unbalanced interrupt_disable()",
+			    "IRQ %x unbalanced interrupt_disable()",
 			    irq);
 	} else if (!--child->enable_count[child_idx]) {
 		/* disable the child interrupt */

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -254,7 +254,7 @@ static inline int buffer_set_params(struct comp_buffer *buffer,
 	int i;
 
 	if (!params) {
-		trace_buffer_error("buffer_set_params() error: !params");
+		trace_buffer_error("buffer_set_params(): !params");
 		return -EINVAL;
 	}
 
@@ -263,7 +263,7 @@ static inline int buffer_set_params(struct comp_buffer *buffer,
 
 	ret = audio_stream_set_params(&buffer->stream, params);
 	if (ret < 0) {
-		trace_buffer_error("buffer_set_params() error: audio_stream_set_params failed");
+		trace_buffer_error("buffer_set_params(): audio_stream_set_params failed");
 		return -EINVAL;
 	}
 

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -626,7 +626,7 @@ static inline void comp_underrun(struct comp_dev *dev,
 {
 	int32_t bytes = (int32_t)source->stream.avail - copy_bytes;
 
-	comp_err(dev, "comp_underrun() error: dev->comp.id = %u, source->avail = %u, copy_bytes = %u",
+	comp_err(dev, "comp_underrun(): dev->comp.id = %u, source->avail = %u, copy_bytes = %u",
 		 dev_comp_id(dev),
 		 source->stream.avail,
 		 copy_bytes);
@@ -645,7 +645,7 @@ static inline void comp_overrun(struct comp_dev *dev, struct comp_buffer *sink,
 {
 	int32_t bytes = (int32_t)copy_bytes - sink->stream.free;
 
-	comp_err(dev, "comp_overrun() error: sink->free = %u, copy_bytes = %u",
+	comp_err(dev, "comp_overrun(): sink->free = %u, copy_bytes = %u",
 		 sink->stream.free, copy_bytes);
 
 	pipeline_xrun(dev->pipeline, dev, bytes);

--- a/src/include/sof/audio/component_ext.h
+++ b/src/include/sof/audio/component_ext.h
@@ -120,7 +120,7 @@ static inline int comp_cmd(struct comp_dev *dev, int cmd, void *data,
 	if (cmd == COMP_CMD_SET_DATA &&
 	    (cdata->data->magic != SOF_ABI_MAGIC ||
 	     SOF_ABI_VERSION_INCOMPATIBLE(SOF_ABI_VERSION, cdata->data->abi))) {
-		comp_err(dev, "comp_cmd() error: invalid version, data->magic = %u, data->abi = %u",
+		comp_err(dev, "comp_cmd(): invalid version, data->magic = %u, data->abi = %u",
 			 cdata->data->magic, cdata->data->abi);
 		goto out;
 	}

--- a/src/ipc/dma-copy.c
+++ b/src/ipc/dma-copy.c
@@ -44,8 +44,7 @@ static struct dma_sg_elem *sg_get_elem_at(struct dma_sg_config *host_sg,
 	}
 
 	/* host offset in beyond end of SG buffer */
-	trace_dma_error("sg_get_elem_at() error: "
-			"host offset in beyond end of SG buffer");
+	trace_dma_error("sg_get_elem_at(): host offset in beyond end of SG buffer");
 	return NULL;
 }
 #endif
@@ -139,7 +138,7 @@ int dma_copy_new(struct dma_copy *dc)
 	cap = 0;
 	dc->dmac = dma_get(dir, cap, dev, DMA_ACCESS_SHARED);
 	if (dc->dmac == NULL) {
-		trace_dma_error("dma_copy_new() error: dc->dmac = NULL");
+		trace_dma_error("dma_copy_new(): dc->dmac = NULL");
 		return -ENODEV;
 	}
 
@@ -147,7 +146,7 @@ int dma_copy_new(struct dma_copy *dc)
 	/* get DMA channel from DMAC0 */
 	dc->chan = dma_channel_get(dc->dmac, 0);
 	if (!dc->chan) {
-		trace_dma_error("dma_copy_new() error: dc->chan is NULL");
+		trace_dma_error("dma_copy_new(): dc->chan is NULL");
 		return -ENODEV;
 	}
 #endif
@@ -162,8 +161,7 @@ int dma_copy_set_stream_tag(struct dma_copy *dc, uint32_t stream_tag)
 	/* get DMA channel from DMAC */
 	dc->chan = dma_channel_get(dc->dmac, stream_tag - 1);
 	if (!dc->chan) {
-		trace_dma_error("dma_copy_set_stream_tag() error: "
-				"dc->chan is NULL");
+		trace_dma_error("dma_copy_set_stream_tag(): dc->chan is NULL");
 		return -EINVAL;
 	}
 

--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -787,7 +787,7 @@ static inline int ipc_probe_init(uint32_t header)
 	tracev_ipc("ipc_probe_init()");
 
 	if (dma_provided > 1 || dma_provided < 0) {
-		trace_ipc_error("ipc_probe_init() error: Invalid amount of extraction DMAs specified = %d",
+		trace_ipc_error("ipc_probe_init(): Invalid amount of extraction DMAs specified = %d",
 				dma_provided);
 		return -EINVAL;
 	}
@@ -810,13 +810,13 @@ static inline int ipc_probe_dma_add(uint32_t header)
 	tracev_ipc("ipc_probe_dma_add()");
 
 	if (dmas_count > CONFIG_PROBE_DMA_MAX) {
-		trace_ipc_error("ipc_probe_dma_add() error: Invalid amount of injection DMAs specified = %d. Max is " META_QUOTE(CONFIG_PROBE_DMA_MAX) ".",
+		trace_ipc_error("ipc_probe_dma_add(): Invalid amount of injection DMAs specified = %d. Max is " META_QUOTE(CONFIG_PROBE_DMA_MAX) ".",
 				dmas_count);
 		return -EINVAL;
 	}
 
 	if (dmas_count <= 0) {
-		trace_ipc_error("ipc_probe_dma_add() error: Inferred amount of incjection DMAs in payload is %d. This could indicate corrupt size reported in header or invalid IPC payload.",
+		trace_ipc_error("ipc_probe_dma_add(): Inferred amount of incjection DMAs in payload is %d. This could indicate corrupt size reported in header or invalid IPC payload.",
 				dmas_count);
 		return -EINVAL;
 	}
@@ -832,13 +832,13 @@ static inline int ipc_probe_dma_remove(uint32_t header)
 	tracev_ipc("ipc_probe_dma_remove()");
 
 	if (tags_count > CONFIG_PROBE_DMA_MAX) {
-		trace_ipc_error("ipc_probe_dma_remove() error: Invalid amount of injection DMAs specified = %d. Max is " META_QUOTE(CONFIG_PROBE_DMA_MAX) ".",
+		trace_ipc_error("ipc_probe_dma_remove(): Invalid amount of injection DMAs specified = %d. Max is " META_QUOTE(CONFIG_PROBE_DMA_MAX) ".",
 				tags_count);
 		return -EINVAL;
 	}
 
 	if (tags_count <= 0) {
-		trace_ipc_error("ipc_probe_dma_remove() error: Inferred amount of incjection DMAs in payload is %d. This could indicate corrupt size reported in header or invalid IPC payload.",
+		trace_ipc_error("ipc_probe_dma_remove(): Inferred amount of incjection DMAs in payload is %d. This could indicate corrupt size reported in header or invalid IPC payload.",
 				tags_count);
 		return -EINVAL;
 	}
@@ -854,13 +854,13 @@ static inline int ipc_probe_point_add(uint32_t header)
 	tracev_ipc("ipc_probe_point_add()");
 
 	if (probes_count > CONFIG_PROBE_POINTS_MAX) {
-		trace_ipc_error("ipc_probe_point_add() error: Invalid amount of Probe Points specified = %d. Max is " META_QUOTE(CONFIG_PROBE_POINT_MAX) ".",
+		trace_ipc_error("ipc_probe_point_add(): Invalid amount of Probe Points specified = %d. Max is " META_QUOTE(CONFIG_PROBE_POINT_MAX) ".",
 				probes_count);
 		return -EINVAL;
 	}
 
 	if (probes_count <= 0) {
-		trace_ipc_error("ipc_probe_point_add() error: Inferred amount of Probe Points in payload is %d. This could indicate corrupt size reported in header or invalid IPC payload.",
+		trace_ipc_error("ipc_probe_point_add(): Inferred amount of Probe Points in payload is %d. This could indicate corrupt size reported in header or invalid IPC payload.",
 				probes_count);
 		return -EINVAL;
 	}
@@ -876,13 +876,13 @@ static inline int ipc_probe_point_remove(uint32_t header)
 	tracev_ipc("ipc_probe_point_remove()");
 
 	if (probes_count > CONFIG_PROBE_POINTS_MAX) {
-		trace_ipc_error("ipc_probe_point_remove() error: Invalid amount of Probe Points specified = %d. Max is " META_QUOTE(CONFIG_PROBE_POINT_MAX) ".",
+		trace_ipc_error("ipc_probe_point_remove(): Invalid amount of Probe Points specified = %d. Max is " META_QUOTE(CONFIG_PROBE_POINT_MAX) ".",
 				probes_count);
 		return -EINVAL;
 	}
 
 	if (probes_count <= 0) {
-		trace_ipc_error("ipc_probe_point_remove() error: Inferred amount of Probe Points in payload is %d. This could indicate corrupt size reported in header or invalid IPC payload.",
+		trace_ipc_error("ipc_probe_point_remove(): Inferred amount of Probe Points in payload is %d. This could indicate corrupt size reported in header or invalid IPC payload.",
 				probes_count);
 		return -EINVAL;
 	}
@@ -905,13 +905,13 @@ static int ipc_probe_info(uint32_t header)
 		ret = probe_point_info(params, SOF_IPC_MSG_MAX_SIZE);
 		break;
 	default:
-		trace_ipc_error("ipc_probe_info() error: Invalid probe INFO command = %u",
+		trace_ipc_error("ipc_probe_info(): Invalid probe INFO command = %u",
 				cmd);
 		ret = -EINVAL;
 	}
 
 	if (ret < 0) {
-		trace_ipc_error("ipc_probe_info() error: cmd %u failed", cmd);
+		trace_ipc_error("ipc_probe_info(): cmd %u failed", cmd);
 		return ret;
 	}
 
@@ -922,7 +922,7 @@ static int ipc_probe_info(uint32_t header)
 		mailbox_hostbox_write(0, params, params->rhdr.hdr.size);
 		ret = 1;
 	} else {
-		trace_ipc_error("ipc_probe_get_data() error: probes module returned too much payload for cmd %u - returned %d bytes, max %d",
+		trace_ipc_error("ipc_probe_get_data(): probes module returned too much payload for cmd %u - returned %d bytes, max %d",
 				cmd, params->rhdr.hdr.size,
 				MIN(MAILBOX_HOSTBOX_SIZE,
 				    SOF_IPC_MSG_MAX_SIZE));
@@ -962,7 +962,7 @@ static int ipc_glb_probe(uint32_t header)
 #else
 static inline int ipc_glb_probe(uint32_t header)
 {
-	trace_ipc_error("ipc_glb_probe() error: Probes not enabled by Kconfig.");
+	trace_ipc_error("ipc_glb_probe(): Probes not enabled by Kconfig.");
 
 	return -EINVAL;
 }

--- a/src/ipc/ipc-host-ptable.c
+++ b/src/ipc/ipc-host-ptable.c
@@ -36,16 +36,14 @@ static int ipc_parse_page_descriptors(uint8_t *page_table,
 	if ((ring->size <= HOST_PAGE_SIZE * (ring->pages - 1)) ||
 	    (ring->size > HOST_PAGE_SIZE * ring->pages)) {
 		/* error buffer size */
-		trace_ipc_error("ipc_parse_page_descriptors() error: "
-				"error buffer size");
+		trace_ipc_error("ipc_parse_page_descriptors(): error buffer size");
 		return -EINVAL;
 	}
 
 	elem_array->elems = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM,
 				    sizeof(struct dma_sg_elem) * ring->pages);
 	if (!elem_array->elems) {
-		trace_ipc_error("ipc_parse_page_descriptors() error: "
-		"There is no heap free with this block size: %d",
+		trace_ipc_error("ipc_parse_page_descriptors(): There is no heap free with this block size: %d",
 		sizeof(struct dma_sg_elem) * ring->pages);
 		return -ENOMEM;
 	}
@@ -94,8 +92,7 @@ static int ipc_get_page_descriptors(struct dma *dmac, uint8_t *page_table,
 	/* get DMA channel from DMAC */
 	chan = dma_channel_get(dmac, 0);
 	if (!chan) {
-		trace_ipc_error("ipc_get_page_descriptors() error: chan is "
-				"NULL");
+		trace_ipc_error("ipc_get_page_descriptors(): chan is NULL");
 		return -ENODEV;
 	}
 
@@ -119,16 +116,14 @@ static int ipc_get_page_descriptors(struct dma *dmac, uint8_t *page_table,
 
 	ret = dma_set_config(chan, &config);
 	if (ret < 0) {
-		trace_ipc_error("ipc_get_page_descriptors() error: "
-				"dma_set_config() failed");
+		trace_ipc_error("ipc_get_page_descriptors(): dma_set_config() failed");
 		goto out;
 	}
 
 	/* start the copy of page table to DSP */
 	ret = dma_copy(chan, elem.size, DMA_COPY_ONE_SHOT | DMA_COPY_BLOCKING);
 	if (ret < 0) {
-		trace_ipc_error("ipc_get_page_descriptors() error: "
-				"dma_start() failed");
+		trace_ipc_error("ipc_get_page_descriptors(): dma_start() failed");
 		goto out;
 	}
 

--- a/src/ipc/ipc.c
+++ b/src/ipc/ipc.c
@@ -181,7 +181,7 @@ int ipc_comp_new(struct ipc *ipc, struct sof_ipc_comp *comp)
 	/* check whether component already exists */
 	icd = ipc_get_comp_by_id(ipc, comp->id);
 	if (icd != NULL) {
-		trace_ipc_error("ipc_comp_new() error: comp->id = %u",
+		trace_ipc_error("ipc_comp_new(): comp->id = %u",
 				comp->id);
 		return -EINVAL;
 	}
@@ -189,7 +189,7 @@ int ipc_comp_new(struct ipc *ipc, struct sof_ipc_comp *comp)
 	/* create component */
 	cd = comp_new(comp);
 	if (cd == NULL) {
-		trace_ipc_error("ipc_comp_new() error: component cd = NULL");
+		trace_ipc_error("ipc_comp_new(): component cd = NULL");
 		return -EINVAL;
 	}
 
@@ -197,7 +197,7 @@ int ipc_comp_new(struct ipc *ipc, struct sof_ipc_comp *comp)
 	icd = rzalloc(SOF_MEM_ZONE_RUNTIME, SOF_MEM_FLAG_SHARED,
 		      SOF_MEM_CAPS_RAM, sizeof(struct ipc_comp_dev));
 	if (icd == NULL) {
-		trace_ipc_error("ipc_comp_new() error: alloc failed");
+		trace_ipc_error("ipc_comp_new(): alloc failed");
 		rfree(cd);
 		return -ENOMEM;
 	}
@@ -257,7 +257,7 @@ int ipc_buffer_new(struct ipc *ipc, struct sof_ipc_buffer *desc)
 	/* check whether buffer already exists */
 	ibd = ipc_get_comp_by_id(ipc, desc->comp.id);
 	if (ibd != NULL) {
-		trace_ipc_error("ipc_buffer_new() error: buffer already exists, desc->comp.id = %u",
+		trace_ipc_error("ipc_buffer_new(): buffer already exists, desc->comp.id = %u",
 				desc->comp.id);
 		return -EINVAL;
 	}
@@ -265,7 +265,7 @@ int ipc_buffer_new(struct ipc *ipc, struct sof_ipc_buffer *desc)
 	/* register buffer with pipeline */
 	buffer = buffer_new(desc);
 	if (buffer == NULL) {
-		trace_ipc_error("ipc_buffer_new() error: buffer_new() failed");
+		trace_ipc_error("ipc_buffer_new(): buffer_new() failed");
 
 		return -ENOMEM;
 	}
@@ -389,14 +389,14 @@ int ipc_comp_connect(struct ipc *ipc,
 	/* check whether the components already exist */
 	icd_source = ipc_get_comp_by_id(ipc, connect->source_id);
 	if (icd_source == NULL) {
-		trace_ipc_error("ipc_comp_connect() error: components already exist, connect->source_id = %u",
+		trace_ipc_error("ipc_comp_connect(): components already exist, connect->source_id = %u",
 				connect->source_id);
 		return -EINVAL;
 	}
 
 	icd_sink = ipc_get_comp_by_id(ipc, connect->sink_id);
 	if (icd_sink == NULL) {
-		trace_ipc_error("ipc_comp_connect() error: components already exist, connect->sink_id = %u",
+		trace_ipc_error("ipc_comp_connect(): components already exist, connect->sink_id = %u",
 				connect->sink_id);
 		return -EINVAL;
 	}
@@ -409,7 +409,7 @@ int ipc_comp_connect(struct ipc *ipc,
 		 icd_sink->type == COMP_TYPE_BUFFER)
 		return ipc_comp_to_buffer_connect(icd_source, icd_sink);
 	else {
-		trace_ipc_error("ipc_comp_connect() error: invalid source and sink types, connect->source_id = %u, connect->sink_id = %u",
+		trace_ipc_error("ipc_comp_connect(): invalid source and sink types, connect->source_id = %u, connect->sink_id = %u",
 				connect->source_id, connect->sink_id);
 		return -EINVAL;
 	}
@@ -426,7 +426,7 @@ int ipc_pipeline_new(struct ipc *ipc,
 	/* check whether the pipeline already exists */
 	ipc_pipe = ipc_get_comp_by_id(ipc, pipe_desc->comp_id);
 	if (ipc_pipe != NULL) {
-		trace_ipc_error("ipc_pipeline_new() error: pipeline already exists, pipe_desc->comp_id = %u",
+		trace_ipc_error("ipc_pipeline_new(): pipeline already exists, pipe_desc->comp_id = %u",
 				pipe_desc->comp_id);
 		return -EINVAL;
 	}
@@ -435,7 +435,7 @@ int ipc_pipeline_new(struct ipc *ipc,
 	ipc_pipe = ipc_get_comp_by_ppl_id(ipc, COMP_TYPE_PIPELINE,
 					  pipe_desc->pipeline_id);
 	if (ipc_pipe) {
-		trace_ipc_error("ipc_pipeline_new() error: pipeline id is already taken, pipe_desc->pipeline_id = %u",
+		trace_ipc_error("ipc_pipeline_new(): pipeline id is already taken, pipe_desc->pipeline_id = %u",
 				pipe_desc->pipeline_id);
 		return -EINVAL;
 	}
@@ -443,25 +443,25 @@ int ipc_pipeline_new(struct ipc *ipc,
 	/* find the scheduling component */
 	icd = ipc_get_comp_by_id(ipc, pipe_desc->sched_id);
 	if (icd == NULL) {
-		trace_ipc_error("ipc_pipeline_new() error: cannot find the scheduling component, pipe_desc->sched_id = %u",
+		trace_ipc_error("ipc_pipeline_new(): cannot find the scheduling component, pipe_desc->sched_id = %u",
 				pipe_desc->sched_id);
 		return -EINVAL;
 	}
 
 	if (icd->type != COMP_TYPE_COMPONENT) {
-		trace_ipc_error("ipc_pipeline_new() error: icd->type != COMP_TYPE_COMPONENT");
+		trace_ipc_error("ipc_pipeline_new(): icd->type != COMP_TYPE_COMPONENT");
 		return -EINVAL;
 	}
 
 	if (icd->core != pipe_desc->core) {
-		trace_ipc_error("ipc_pipeline_new() error: icd->core != pipe_desc->core");
+		trace_ipc_error("ipc_pipeline_new(): icd->core != pipe_desc->core");
 		return -EINVAL;
 	}
 
 	/* create the pipeline */
 	pipe = pipeline_new(pipe_desc, icd->cd);
 	if (pipe == NULL) {
-		trace_ipc_error("ipc_pipeline_new() error: pipeline_new() failed");
+		trace_ipc_error("ipc_pipeline_new(): pipeline_new() failed");
 		return -ENOMEM;
 	}
 
@@ -503,7 +503,7 @@ int ipc_pipeline_free(struct ipc *ipc, uint32_t comp_id)
 	/* free buffer and remove from list */
 	ret = pipeline_free(ipc_pipe->pipeline);
 	if (ret < 0) {
-		trace_ipc_error("ipc_pipeline_free() error: pipeline_free() failed");
+		trace_ipc_error("ipc_pipeline_free(): pipeline_free() failed");
 		return ret;
 	}
 	ipc_pipe->pipeline = NULL;
@@ -599,7 +599,7 @@ int ipc_comp_dai_config(struct ipc *ipc, struct sof_ipc_dai_config *config)
 	}
 
 	if (ret < 0) {
-		trace_ipc_error("ipc_comp_dai_config() error: comp_dai_config() failed");
+		trace_ipc_error("ipc_comp_dai_config(): comp_dai_config() failed");
 		return ret;
 	}
 

--- a/src/lib/alloc.c
+++ b/src/lib/alloc.c
@@ -166,7 +166,7 @@ static void *rmalloc_sys(uint32_t flags, int caps, int core, size_t bytes)
 
 	/* always succeeds or panics */
 	if (alignment + bytes > cpu_heap->info.free) {
-		trace_mem_error("rmalloc_sys() error: core = %d, bytes = %d",
+		trace_mem_error("rmalloc_sys(): core = %d, bytes = %d",
 				core, bytes);
 		panic(SOF_IPC_PANIC_MEM);
 	}
@@ -275,8 +275,7 @@ static void *alloc_cont_blocks(struct mm_heap *heap, int level,
 	}
 
 	if (count > map->count || remaining < count) {
-		trace_mem_error("error: %d blocks needed for allocation "
-				"but only %d blocks are remaining",
+		trace_mem_error("%d blocks needed for allocation but only %d blocks are remaining",
 				count, remaining);
 		goto out;
 	}
@@ -445,7 +444,7 @@ static void free_block(void *ptr)
 
 	heap = get_heap_from_ptr(ptr);
 	if (!heap) {
-		trace_mem_error("free_block() error: invalid heap = %p, cpu = %d",
+		trace_mem_error("free_block(): invalid heap = %p, cpu = %d",
 				(uintptr_t)ptr, cpu_get_id());
 		return;
 	}
@@ -466,7 +465,7 @@ static void free_block(void *ptr)
 		platform_shared_commit(heap, sizeof(*heap));
 
 		/* not found */
-		trace_mem_error("free_block() error: invalid ptr = %p cpu = %d",
+		trace_mem_error("free_block(): invalid ptr = %p cpu = %d",
 				(uintptr_t)ptr, cpu_get_id());
 		return;
 	}
@@ -646,7 +645,7 @@ static void *rmalloc_runtime(uint32_t flags, uint32_t caps, size_t bytes)
 		if (!heap) {
 			platform_shared_commit(memmap, sizeof(*memmap));
 
-			trace_mem_error("rmalloc_runtime() error: caps = %x, bytes = %d",
+			trace_mem_error("rmalloc_runtime(): caps = %x, bytes = %d",
 					caps, bytes);
 
 			return NULL;
@@ -676,7 +675,7 @@ static void *_malloc_unlocked(enum mem_zone zone, uint32_t flags, uint32_t caps,
 		ptr = rmalloc_runtime(flags, caps, bytes);
 		break;
 	default:
-		trace_mem_error("rmalloc() error: invalid zone");
+		trace_mem_error("rmalloc(): invalid zone");
 		panic(SOF_IPC_PANIC_MEM); /* logic non recoverable problem */
 		break;
 	}
@@ -879,7 +878,7 @@ static void _rfree_unlocked(void *ptr)
 	/* panic if pointer is from system heap */
 	if (ptr >= (void *)cpu_heap->heap &&
 	    (char *)ptr < (char *)cpu_heap->heap + cpu_heap->size) {
-		trace_mem_error("rfree() error: attempt to free system heap = %p, cpu = %d",
+		trace_mem_error("rfree(): attempt to free system heap = %p, cpu = %d",
 				(uintptr_t)ptr, cpu_get_id());
 		panic(SOF_IPC_PANIC_MEM);
 	}
@@ -987,7 +986,7 @@ void free_heap(enum mem_zone zone)
 	 */
 	if (cpu_get_id() == PLATFORM_MASTER_CORE_ID ||
 	    zone != SOF_MEM_ZONE_SYS) {
-		trace_mem_error("free_heap() error: critical flow issue");
+		trace_mem_error("free_heap(): critical flow issue");
 		panic(SOF_IPC_PANIC_MEM);
 	}
 

--- a/src/lib/dai.c
+++ b/src/lib/dai.c
@@ -63,7 +63,7 @@ struct dai *dai_get(uint32_t type, uint32_t index, uint32_t flags)
 
 		return !ret ? d : NULL;
 	}
-	trace_error(TRACE_CLASS_DAI, "dai_get error: %d.%d not found",
+	trace_error(TRACE_CLASS_DAI, "dai_get: %d.%d not found",
 		    type, index);
 	return NULL;
 }
@@ -76,7 +76,7 @@ void dai_put(struct dai *dai)
 	if (--dai->sref == 0) {
 		ret = dai_remove(dai);
 		if (ret < 0) {
-			trace_error(TRACE_CLASS_DAI, "dai_put error: %d.%d dai_remove() failed ret = %d",
+			trace_error(TRACE_CLASS_DAI, "dai_put: %d.%d dai_remove() failed ret = %d",
 				    dai->drv->type, dai->index, ret);
 		}
 	}

--- a/src/lib/dma.c
+++ b/src/lib/dma.c
@@ -109,7 +109,7 @@ struct dma *dma_get(uint32_t dir, uint32_t cap, uint32_t dev, uint32_t flags)
 		ret = dma_probe(dmin);
 		if (ret < 0) {
 			trace_error(TRACE_CLASS_DMA,
-				    "dma_get() error: dma-probe failed"
+				    "dma_get(): dma-probe failed"
 				    " id = %d, ret = %d",
 				    dmin->plat_data.id, ret);
 		}
@@ -136,8 +136,8 @@ void dma_put(struct dma *dma)
 		ret = dma_remove(dma);
 		if (ret < 0) {
 			trace_error(TRACE_CLASS_DMA,
-				    "dma_put() error: dma_remove() failed id"
-				    " = %d, ret = %d", dma->plat_data.id, ret);
+				    "dma_put(): dma_remove() failed id  = %d, ret = %d",
+				    dma->plat_data.id, ret);
 		}
 	}
 	trace_event(TRACE_CLASS_DMA, "dma_put(), dma = %p, sref = %d",

--- a/src/lib/notifier.c
+++ b/src/lib/notifier.c
@@ -44,8 +44,7 @@ int notifier_register(void *receiver, void *caller, enum notify_id type,
 			 sizeof(*handle));
 
 	if (!handle) {
-		trace_notifier_error("notifier_register() error: callback "
-				     "handle allocation failed.");
+		trace_notifier_error("notifier_register(): callback handle allocation failed.");
 		return -ENOMEM;
 	}
 

--- a/src/probe/probe.c
+++ b/src/probe/probe.c
@@ -82,7 +82,7 @@ static int probe_dma_buffer_init(struct probe_dma_buf *buffer, uint32_t size, ui
 						SOF_MEM_CAPS_DMA, size, align);
 
 	if (!buffer->addr) {
-		trace_probe_error("probe_dma_buffer_init() error: alloc failed");
+		trace_probe_error("probe_dma_buffer_init(): alloc failed");
 		return -ENOMEM;
 	}
 
@@ -118,7 +118,7 @@ static int probe_dma_init(struct probe_dma_ext *dma, uint32_t direction)
 	dma->dc.dmac = dma_get(direction, 0, DMA_DEV_HOST,
 			       DMA_ACCESS_SHARED);
 	if (!dma->dc.dmac) {
-		trace_probe_error("probe_dma_init() error: dma->dc.dmac = NULL");
+		trace_probe_error("probe_dma_init(): dma->dc.dmac = NULL");
 		return -ENODEV;
 	}
 
@@ -170,7 +170,7 @@ static int probe_dma_deinit(struct probe_dma_ext *dma)
 
 	err = dma_stop(dma->dc.chan);
 	if (err < 0) {
-		trace_probe_error("probe_dma_deinit() error: dma_stop() failed");
+		trace_probe_error("probe_dma_deinit(): dma_stop() failed");
 		return err;
 	}
 
@@ -205,7 +205,7 @@ static enum task_state probe_task(void *data)
 		return SOF_TASK_STATE_RESCHEDULE;
 
 	if (err < 0) {
-		trace_probe_error("probe_task() error: dma_copy_to_host_nowait() failed.");
+		trace_probe_error("probe_task(): dma_copy_to_host_nowait() failed.");
 		return err;
 	}
 
@@ -225,7 +225,7 @@ int probe_init(struct probe_dma *probe_dma)
 	tracev_probe("probe_init()");
 
 	if (_probe) {
-		trace_probe_error("probe_init() error: Probes already initialized.");
+		trace_probe_error("probe_init(): Probes already initialized.");
 		return -EINVAL;
 	}
 
@@ -235,7 +235,7 @@ int probe_init(struct probe_dma *probe_dma)
 	_probe = probe_get();
 
 	if (!_probe) {
-		trace_probe_error("probe_init() error: Alloc failed.");
+		trace_probe_error("probe_init(): Alloc failed.");
 		return -ENOMEM;
 	}
 
@@ -249,14 +249,14 @@ int probe_init(struct probe_dma *probe_dma)
 
 		err = probe_dma_init(&_probe->ext_dma, DMA_DIR_LMEM_TO_HMEM);
 		if (err < 0) {
-			trace_probe_error("probe_init() error: probe_dma_init() failed");
+			trace_probe_error("probe_init(): probe_dma_init() failed");
 			_probe->ext_dma.stream_tag = PROBE_DMA_INVALID;
 			return err;
 		}
 
 		err = dma_start(_probe->ext_dma.dc.chan);
 		if (err < 0) {
-			trace_probe_error("probe_init() error: failed to start extraction dma");
+			trace_probe_error("probe_init(): failed to start extraction dma");
 
 			return -EBUSY;
 		}
@@ -289,7 +289,7 @@ int probe_deinit(void)
 	tracev_probe("probe_deinit()");
 
 	if (!_probe) {
-		trace_probe_error("probe_deinit() error: Not initialized.");
+		trace_probe_error("probe_deinit(): Not initialized.");
 
 		return -EINVAL;
 	}
@@ -297,7 +297,7 @@ int probe_deinit(void)
 	/* check for attached injection probe DMAs */
 	for (i = 0; i < CONFIG_PROBE_DMA_MAX; i++) {
 		if (_probe->inject_dma[i].stream_tag != PROBE_DMA_INVALID) {
-			trace_probe_error("probe_deinit() error: Cannot deinitialize with injection DMAs attached.");
+			trace_probe_error("probe_deinit(): Cannot deinitialize with injection DMAs attached.");
 			return -EINVAL;
 		}
 	}
@@ -305,7 +305,7 @@ int probe_deinit(void)
 	/* check for connected probe points */
 	for (i = 0; i < CONFIG_PROBE_POINTS_MAX; i++) {
 		if (_probe->probe_points[i].stream_tag != PROBE_POINT_INVALID) {
-			trace_probe_error("probe_deinit() error: Cannot deinitialize with probe points connected.");
+			trace_probe_error("probe_deinit(): Cannot deinitialize with probe points connected.");
 			return -EINVAL;
 		}
 	}
@@ -336,7 +336,7 @@ int probe_dma_add(uint32_t count, struct probe_dma *probe_dma)
 	tracev_probe("probe_dma_add() count = %u", count);
 
 	if (!_probe) {
-		trace_probe_error("probe_dma_add() error: Not initialized.");
+		trace_probe_error("probe_dma_add(): Not initialized.");
 
 		return -EINVAL;
 	}
@@ -362,14 +362,14 @@ int probe_dma_add(uint32_t count, struct probe_dma *probe_dma)
 			}
 
 			if (stream_tag == probe_dma[i].stream_tag) {
-				trace_probe_error("probe_dma_add() error: Probe DMA %u already attached.",
+				trace_probe_error("probe_dma_add(): Probe DMA %u already attached.",
 						  stream_tag);
 				return -EINVAL;
 			}
 		}
 
 		if (first_free == CONFIG_PROBE_DMA_MAX) {
-			trace_probe_error("probe_dma_add() error: Exceeded maximum number of DMAs attached = " META_QUOTE(CONFIG_PROBE_DMA_MAX));
+			trace_probe_error("probe_dma_add(): Exceeded maximum number of DMAs attached = " META_QUOTE(CONFIG_PROBE_DMA_MAX));
 			return -EINVAL;
 		}
 
@@ -381,7 +381,7 @@ int probe_dma_add(uint32_t count, struct probe_dma *probe_dma)
 		err = probe_dma_init(&_probe->inject_dma[first_free],
 				     DMA_DIR_HMEM_TO_LMEM);
 		if (err < 0) {
-			trace_probe_error("probe_dma_add() error: probe_dma_init() failed");
+			trace_probe_error("probe_dma_add(): probe_dma_init() failed");
 			_probe->inject_dma[first_free].stream_tag =
 				PROBE_DMA_INVALID;
 			return err;
@@ -400,7 +400,7 @@ int probe_dma_info(struct sof_ipc_probe_info_params *data, uint32_t max_size)
 	tracev_probe("probe_dma_info()");
 
 	if (!_probe) {
-		trace_probe_error("probe_dma_info() error: Not initialized.");
+		trace_probe_error("probe_dma_info(): Not initialized.");
 
 		return -EINVAL;
 	}
@@ -457,7 +457,7 @@ int probe_dma_remove(uint32_t count, uint32_t *stream_tag)
 	tracev_probe("probe_dma_remove() count = %u", count);
 
 	if (!_probe) {
-		trace_probe_error("probe_dma_remove() error: Not initialized.");
+		trace_probe_error("probe_dma_remove(): Not initialized.");
 
 		return -EINVAL;
 	}
@@ -507,7 +507,7 @@ static int copy_to_pbuffer(struct probe_dma_buf *pbuf, void *data, uint32_t byte
 
 	/* copy data to probe buffer */
 	if (memcpy_s((void *)pbuf->w_ptr, pbuf->end_addr - pbuf->w_ptr, data, head)) {
-		trace_probe_error("copy_to_pbuffer() error: memcpy_s() failed");
+		trace_probe_error("copy_to_pbuffer(): memcpy_s() failed");
 		return -EINVAL;
 	}
 	dcache_writeback_region((void *)pbuf->w_ptr, head);
@@ -517,7 +517,7 @@ static int copy_to_pbuffer(struct probe_dma_buf *pbuf, void *data, uint32_t byte
 		pbuf->w_ptr = pbuf->addr;
 		if (memcpy_s((void *)pbuf->w_ptr, (char *)pbuf->end_addr - (char *)pbuf->w_ptr,
 			     (char *)data + head, tail)) {
-			trace_probe_error("copy_to_pbuffer() error: memcpy_s() failed");
+			trace_probe_error("copy_to_pbuffer(): memcpy_s() failed");
 			return -EINVAL;
 		}
 		dcache_writeback_region((void *)pbuf->w_ptr, tail);
@@ -563,7 +563,7 @@ static int copy_from_pbuffer(struct probe_dma_buf *pbuf, void *data, uint32_t by
 	/* data from DMA so invalidate it */
 	dcache_invalidate_region((void *)pbuf->r_ptr, head);
 	if (memcpy_s(data, bytes, (void *)pbuf->r_ptr, head)) {
-		trace_probe_error("copy_from_pbuffer() error: memcpy_s() failed");
+		trace_probe_error("copy_from_pbuffer(): memcpy_s() failed");
 		return -EINVAL;
 	}
 
@@ -573,7 +573,7 @@ static int copy_from_pbuffer(struct probe_dma_buf *pbuf, void *data, uint32_t by
 		pbuf->r_ptr = pbuf->addr;
 		dcache_invalidate_region((void *)pbuf->r_ptr, tail);
 		if (memcpy_s((char *)data + head, tail, (void *)pbuf->r_ptr, tail)) {
-			trace_probe_error("copy_from_pbuffer() error: memcpy_s() failed");
+			trace_probe_error("copy_from_pbuffer(): memcpy_s() failed");
 			return -EINVAL;
 		}
 		pbuf->r_ptr = pbuf->r_ptr + tail;
@@ -657,7 +657,7 @@ static uint32_t probe_gen_format(uint32_t frame_fmt, uint32_t rate, uint32_t cha
 		float_fmt = 1;
 		break;
 	default:
-		trace_probe_error("probe_gen_format() error: Invalid frame format specified = 0x%08x",
+		trace_probe_error("probe_gen_format(): Invalid frame format specified = 0x%08x",
 				  frame_fmt);
 		assert(false);
 	}
@@ -754,7 +754,7 @@ static void probe_cb_produce(void *arg, enum notify_id type, void *data)
 			break;
 
 	if (i == CONFIG_PROBE_POINTS_MAX) {
-		trace_probe_error("probe_cb_produce() error: probe not found for buffer id: %d",
+		trace_probe_error("probe_cb_produce(): probe not found for buffer id: %d",
 				  buffer_id);
 		return;
 	}
@@ -804,7 +804,7 @@ static void probe_cb_produce(void *arg, enum notify_id type, void *data)
 			}
 		}
 		if (j == CONFIG_PROBE_DMA_MAX) {
-			trace_probe_error("probe_cb_produce() error: dma not found");
+			trace_probe_error("probe_cb_produce(): dma not found");
 			return;
 		}
 		dma = &_probe->inject_dma[j];
@@ -813,7 +813,7 @@ static void probe_cb_produce(void *arg, enum notify_id type, void *data)
 					&dma->dmapb.avail,
 					&free_bytes);
 		if (ret < 0) {
-			trace_probe_error("probe_cb_produce() error: dma_get_data_size() failed, ret = %u",
+			trace_probe_error("probe_cb_produce(): dma_get_data_size() failed, ret = %u",
 					  ret);
 			goto err;
 		}
@@ -868,7 +868,7 @@ static void probe_cb_produce(void *arg, enum notify_id type, void *data)
 	}
 	return;
 err:
-	trace_probe_error("probe_cb_produce() error: failed to generate probe data");
+	trace_probe_error("probe_cb_produce(): failed to generate probe data");
 }
 
 /**
@@ -887,7 +887,7 @@ static void probe_cb_free(void *arg, enum notify_id type, void *data)
 
 	ret = probe_point_remove(1, &buffer_id);
 	if (ret < 0)
-		trace_probe_error("probe_cb_free() error: probe_point_remove() failed");
+		trace_probe_error("probe_cb_free(): probe_point_remove() failed");
 }
 
 int probe_point_add(uint32_t count, struct probe_point *probe)
@@ -903,7 +903,7 @@ int probe_point_add(uint32_t count, struct probe_point *probe)
 	tracev_probe("probe_point_add() count = %u", count);
 
 	if (!_probe) {
-		trace_probe_error("probe_point_add() error: Not initialized.");
+		trace_probe_error("probe_point_add(): Not initialized.");
 
 		return -EINVAL;
 	}
@@ -916,7 +916,7 @@ int probe_point_add(uint32_t count, struct probe_point *probe)
 
 		if (probe[i].purpose == PROBE_PURPOSE_EXTRACTION &&
 		    _probe->ext_dma.stream_tag == PROBE_DMA_INVALID) {
-			trace_probe_error("probe_point_add() error: Setting probe for extraction, while extraction DMA not enabled.");
+			trace_probe_error("probe_point_add(): Setting probe for extraction, while extraction DMA not enabled.");
 
 			return -EINVAL;
 		}
@@ -924,14 +924,14 @@ int probe_point_add(uint32_t count, struct probe_point *probe)
 		/* check if buffer exists */
 		dev = ipc_get_comp_by_id(ipc_get(), probe[i].buffer_id);
 		if (!dev) {
-			trace_probe_error("probe_point_add() error: No device with ID %u found.",
+			trace_probe_error("probe_point_add(): No device with ID %u found.",
 					  probe[i].buffer_id);
 
 			return -EINVAL;
 		}
 
 		if (dev->type != COMP_TYPE_BUFFER) {
-			trace_probe_error("probe_point_add() error: Device ID %u is not a buffer.",
+			trace_probe_error("probe_point_add(): Device ID %u is not a buffer.",
 					  probe[i].buffer_id);
 
 			return -EINVAL;
@@ -953,7 +953,7 @@ int probe_point_add(uint32_t count, struct probe_point *probe)
 			if (buffer_id == probe[i].buffer_id) {
 				if (_probe->probe_points[j].purpose ==
 				    probe[i].purpose) {
-					trace_probe_error("probe_point_add() error: Probe already attached to buffer %u with purpose %u",
+					trace_probe_error("probe_point_add(): Probe already attached to buffer %u with purpose %u",
 							  buffer_id,
 							  probe[i].purpose);
 
@@ -963,7 +963,7 @@ int probe_point_add(uint32_t count, struct probe_point *probe)
 		}
 
 		if (first_free == CONFIG_PROBE_POINTS_MAX) {
-			trace_probe_error("probe_point_add() error: Maximum number of probe points connected aleady: " META_QUOTE(CONFIG_PROBE_POINTS_MAX));
+			trace_probe_error("probe_point_add(): Maximum number of probe points connected aleady: " META_QUOTE(CONFIG_PROBE_POINTS_MAX));
 
 			return -EINVAL;
 		}
@@ -983,13 +983,13 @@ int probe_point_add(uint32_t count, struct probe_point *probe)
 			}
 
 			if (!dma_found) {
-				trace_probe_error("probe_point_add() error: No DMA with stream tag %u found for injection.",
+				trace_probe_error("probe_point_add(): No DMA with stream tag %u found for injection.",
 						  probe[i].stream_tag);
 
 				return -EINVAL;
 			}
 			if (dma_start(_probe->inject_dma[j].dc.chan) < 0) {
-				trace_probe_error("probe_point_add() error: failed to start dma");
+				trace_probe_error("probe_point_add(): failed to start dma");
 
 				return -EBUSY;
 			}
@@ -1029,7 +1029,7 @@ int probe_point_info(struct sof_ipc_probe_info_params *data, uint32_t max_size)
 	tracev_probe("probe_point_info()");
 
 	if (!_probe) {
-		trace_probe_error("probe_point_info() error: Not initialized.");
+		trace_probe_error("probe_point_info(): Not initialized.");
 
 		return -EINVAL;
 	}
@@ -1067,7 +1067,7 @@ int probe_point_remove(uint32_t count, uint32_t *buffer_id)
 	tracev_probe("probe_point_remove() count = %u", count);
 
 	if (!_probe) {
-		trace_probe_error("probe_point_remove() error: Not initialized.");
+		trace_probe_error("probe_point_remove(): Not initialized.");
 		return -EINVAL;
 	}
 	/* remove each requested probe point */

--- a/src/schedule/edf_schedule.c
+++ b/src/schedule/edf_schedule.c
@@ -150,8 +150,7 @@ int schedule_task_init_edf(struct task *task, uint32_t uid,
 	edf_pdata = rzalloc(SOF_MEM_ZONE_SYS_RUNTIME, 0, SOF_MEM_CAPS_RAM,
 			    sizeof(*edf_pdata));
 	if (!edf_pdata) {
-		trace_edf_sch_error("schedule_task_init_edf() error: alloc "
-				    "failed");
+		trace_edf_sch_error("schedule_task_init_edf(): alloc failed");
 		return -ENOMEM;
 	}
 
@@ -174,8 +173,7 @@ int schedule_task_init_edf(struct task *task, uint32_t uid,
 	return 0;
 
 error:
-	trace_edf_sch_error("schedule_task_init_edf() error: init "
-			    "context failed");
+	trace_edf_sch_error("schedule_task_init_edf(): init context failed");
 	if (edf_pdata->ctx)
 		task_context_free(edf_pdata->ctx);
 	rfree(edf_pdata);

--- a/src/schedule/ll_schedule.c
+++ b/src/schedule/ll_schedule.c
@@ -193,7 +193,7 @@ static int schedule_ll_domain_set(struct ll_schedule_data *sch,
 	ret = domain_register(sch->domain, period, task, &schedule_ll_tasks_run,
 			      sch);
 	if (ret < 0) {
-		trace_ll_error("schedule_ll_domain_set error: cannot register domain %d",
+		trace_ll_error("schedule_ll_domain_set: cannot register domain %d",
 			       ret);
 		return ret;
 	}
@@ -345,7 +345,7 @@ int schedule_task_init_ll(struct task *task,
 			   sizeof(*ll_pdata));
 
 	if (!ll_pdata) {
-		trace_ll_error("schedule_task_init_ll() error: alloc failed");
+		trace_ll_error("schedule_task_init_ll(): alloc failed");
 		return -ENOMEM;
 	}
 
@@ -427,7 +427,7 @@ static void reschedule_ll_task(void *data, struct task *task, uint64_t start)
 		}
 	}
 
-	trace_ll_error("reschedule_ll_task() error: task not found");
+	trace_ll_error("reschedule_ll_task(): task not found");
 
 out:
 	platform_shared_commit(sch->domain, sizeof(*sch->domain));

--- a/src/schedule/schedule.c
+++ b/src/schedule/schedule.c
@@ -20,8 +20,7 @@ int schedule_task_init(struct task *task,
 		       uint16_t core, uint32_t flags)
 {
 	if (type >= SOF_SCHEDULE_COUNT) {
-		trace_schedule_error("schedule_task_init() error: "
-				     "invalid task type");
+		trace_schedule_error("schedule_task_init(): invalid task type");
 		return -EINVAL;
 	}
 

--- a/src/trace/dma-trace.c
+++ b/src/trace/dma-trace.c
@@ -75,8 +75,7 @@ static enum task_state trace_work(void *data)
 	size = dma_copy_to_host_nowait(&d->dc, config, d->posn.host_offset,
 				       buffer->r_ptr, size);
 	if (size < 0) {
-		trace_buffer_error("trace_work() error: "
-				   "dma_copy_to_host_nowait() failed");
+		trace_buffer_error("trace_work(): dma_copy_to_host_nowait() failed");
 		goto out;
 	}
 
@@ -139,8 +138,7 @@ int dma_trace_init_complete(struct dma_trace_data *d)
 	/* init DMA copy context */
 	ret = dma_copy_new(&d->dc);
 	if (ret < 0) {
-		trace_buffer_error("dma_trace_init_complete() error: "
-				   "dma_copy_new() failed");
+		trace_buffer_error("dma_trace_init_complete(): dma_copy_new() failed");
 		goto out;
 	}
 
@@ -148,8 +146,7 @@ int dma_trace_init_complete(struct dma_trace_data *d)
 				&d->dma_copy_align);
 
 	if (ret < 0) {
-		trace_buffer("dma_trace_init_complete() "
-			     "error: dma_get_attribute()");
+		trace_buffer("dma_trace_init_complete(): dma_get_attribute()");
 
 		goto out;
 	}
@@ -188,8 +185,7 @@ static int dma_trace_buffer_init(struct dma_trace_data *d)
 	buf = rballoc(0, SOF_MEM_CAPS_RAM | SOF_MEM_CAPS_DMA,
 		      DMA_TRACE_LOCAL_SIZE);
 	if (!buf) {
-		trace_buffer_error("dma_trace_buffer_init() error: "
-				   "alloc failed");
+		trace_buffer_error("dma_trace_buffer_init(): alloc failed");
 		return -ENOMEM;
 	}
 
@@ -325,8 +321,7 @@ int dma_trace_enable(struct dma_trace_data *d)
 
 	/* validate DMA context */
 	if (!d->dc.dmac || !d->dc.chan) {
-		trace_buffer_error_atomic("dma_trace_enable() error: not "
-					  "valid");
+		trace_buffer_error_atomic("dma_trace_enable(): not valid");
 		err = -ENODEV;
 		goto out;
 	}
@@ -475,8 +470,7 @@ static void dtrace_add_event(const char *e, uint32_t length)
 			 * so after it we have to recalculate margin and
 			 * overflow
 			 */
-			trace_error(0, "dtrace_add_event() error: "
-				    "number of dropped logs = %u",
+			trace_error(0, "dtrace_add_event(): number of dropped logs = %u",
 				    tmp_dropped_entries);
 			margin = dtrace_calc_buf_margin(buffer);
 			overflow = dtrace_calc_buf_overflow(buffer, length);


### PR DESCRIPTION
This prefix is added in logger converter, so it shouldn't be
added manually.

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>