### PR TITLE
testbench: remove unneeded variable

### DIFF
--- a/tools/testbench/ll_schedule.c
+++ b/tools/testbench/ll_schedule.c
@@ -12,10 +12,6 @@ int schedule_task_init_ll(struct task *task, uint32_t uid, uint16_t type,
 			  enum task_state (*run)(void *data), void *data,
 			  uint16_t core, uint32_t flags)
 {
-	int ret;
-
-	ret = schedule_task_init(task, uid, type, priority, run, data, core,
-				 flags);
-
-	return ret;
+	return schedule_task_init(task, uid, type, priority, run, data, core,
+				  flags);
 }


### PR DESCRIPTION
Remove unneeded temporary local variable, its declaration and newlines.

Signed-off-by: Payal Kshirsagar <payalskshirsagar1234@gmail.com>