### PR TITLE
DMIC: Fix FIR scaling issue

### DIFF
--- a/src/drivers/intel/cavs/dmic.c
+++ b/src/drivers/intel/cavs/dmic.c
@@ -628,7 +628,7 @@ static int select_mode(struct dai *dai,
 	/* Calculate remaining gain to FIR in Q format used for gain
 	 * values.
 	 */
-	fir_in_max = (1 << (DMIC_HW_BITS_FIR_INPUT - 1));
+	fir_in_max = INT_MAX(DMIC_HW_BITS_FIR_INPUT);
 	if (cfg->cic_shift >= 0)
 		cic_out_max = g_cic >> cfg->cic_shift;
 	else

--- a/src/include/sof/math/numbers.h
+++ b/src/include/sof/math/numbers.h
@@ -81,4 +81,8 @@ uint32_t crc32(uint32_t base, const void *data, uint32_t bytes);
 #define merge_4b4b(high, low) (((uint8_t)(high) << 4) | \
 			       ((low) & 0xF))
 
+/* Get max and min signed integer values for N bits word length */
+#define INT_MAX(N)	((int64_t)((1ULL << ((N) - 1)) - 1))
+#define INT_MIN(N)	((int64_t)(-((1ULL << ((N) - 1)) - 1) - 1))
+
 #endif /* __SOF_MATH_NUMBERS_H__ */


### PR DESCRIPTION
This pull request fixes a minor issue of very slightly above 0 dB decimation gain. It's not really measurable but it's good to fix it to be pedantic.

Thanks to payalskshirsagar1234@gmail.com for finding the suspicious line with too many brackets without purpose!