### PR TITLE
scripts: build-all: postpone VERBOSE decision to "make" time

### DIFF
--- a/scripts/xtensa-build-all.sh
+++ b/scripts/xtensa-build-all.sh
@@ -9,7 +9,7 @@ BUILD_DEBUG=no
 BUILD_FORCE_UP=no
 BUILD_JOBS=$(nproc --all)
 BUILD_JOBS_NEXT=0
-BUILD_VERBOSE=OFF
+BUILD_VERBOSE=
 
 PATH=$pwd/local/bin:$PATH
 
@@ -59,7 +59,7 @@ else
 
 		elif [[ "$args" == "-v" ]]
 			then
-			BUILD_VERBOSE=ON
+			BUILD_VERBOSE='VERBOSE=1'
 
 		# Build all platforms
 		elif [[ "$args" == "-a" ]]
@@ -323,7 +323,6 @@ do
 
 	cmake -DTOOLCHAIN=$TOOLCHAIN \
 		-DROOT_DIR=$ROOT \
-		-DCMAKE_VERBOSE_MAKEFILE=${BUILD_VERBOSE} \
 		${PRIVATE_KEY_OPTION} \
 		..
 
@@ -358,7 +357,7 @@ do
 		make overrideconfig
 	fi
 
-	make bin -j ${BUILD_JOBS}
+	make bin -j ${BUILD_JOBS} ${BUILD_VERBOSE}
 
 	cd "$WORKDIR"
 done


### PR DESCRIPTION
CMAKE_VERBOSE_MAKE was sometimes "hardcoding" the decision in CMake's
cache. Move that decision to the make invocation.

After running xtensa-build-all.sh [-v], it's now possible to choose
again whether "make -C build_apl_gcc/" should be VERBOSE or not without
starting from scratch and with the exact same configuration.

Before this commit it was possible for make to decide again after a
non-verbose xtensa-build-all.sh but not possible to decide again after a
verbose xtensa-build-all.sh... very confusing.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>