### PR TITLE
scripts: build-all: warn when ignoring unknown arguments

### DIFF
--- a/scripts/xtensa-build-all.sh
+++ b/scripts/xtensa-build-all.sh
@@ -73,6 +73,7 @@ else
 				then
 					PLATFORMS+=$i" "
 					BUILD_JOBS_NEXT=0
+					continue 2
 				fi
 			done
 
@@ -81,7 +82,10 @@ else
 				then
 				BUILD_JOBS=$args
 				BUILD_JOBS_NEXT=0
+				continue
 			fi
+
+			printf '%s: WARN: ignoring arg %s\n' "$0" "$args" >&2
 		fi
 	done
 fi


### PR DESCRIPTION
Example:
```
 $ ./scripts/xtensa-build-all.sh -j3
 ./scripts/xtensa-build-all.sh: WARN: ignoring arg -j3
```
Signed-off-by: Marc Herbert <marc.herbert@intel.com>