### PR TITLE
tools: logger: Add LDC dump option

### DIFF
--- a/tools/logger/convert.c
+++ b/tools/logger/convert.c
@@ -52,6 +52,35 @@ struct proc_ldc_entry {
 
 static const char *BAD_PTR_STR = "<bad uid ptr %x>";
 
+char *vasprintf(const char *format, va_list args)
+{
+	va_list args_copy;
+	int size;
+	char localbuf[1];
+	char *result;
+
+	va_copy(args_copy, args);
+	size = vsnprintf(localbuf, 1, format, args_copy);
+	va_end(args_copy);
+
+	result = calloc(1, size + 1);
+	if (result)
+		vsnprintf(result, size + 1, format, args);
+	return result;
+}
+
+char *asprintf(const char *format, ...)
+{
+	va_list args;
+	char *result;
+
+	va_start(args, format);
+	result = vasprintf(format, args);
+	va_end(args);
+
+	return result;
+}
+
 static void log_err(FILE *out_fd, const char *fmt, ...)
 {
 	ssize_t needed_size;
@@ -80,6 +109,26 @@ static void log_err(FILE *out_fd, const char *fmt, ...)
 	va_end(args);
 }
 
+char *format_uid_raw(const struct sof_uuid *uid_val, int use_colors,
+		     int name_first)
+{
+	const char *name = (const char *)(uid_val + 1) + 4;
+	char *str;
+
+	str = asprintf("%s%s%s<%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x>%s%s%s",
+		use_colors ? KBLU : "",
+		name_first ? name : "",
+		name_first ? " " : "",
+		uid_val->a, uid_val->b, uid_val->c,
+		uid_val->d[0], uid_val->d[1], uid_val->d[2],
+		uid_val->d[3], uid_val->d[4], uid_val->d[5],
+		uid_val->d[6], uid_val->d[7],
+		name_first ? "" : " ",
+		name_first ? "" : name,
+		use_colors ? KNRM : "");
+	return str;
+}
+
 const char *format_uid(const struct snd_sof_uids_header *uids_dict,
 		       uint32_t uid_ptr,
 		       int use_colors)
@@ -94,18 +143,8 @@ const char *format_uid(const struct snd_sof_uids_header *uids_dict,
 		const struct sof_uuid *uid_val = (const struct sof_uuid *)
 			((uint8_t *)uids_dict + uids_dict->data_offset +
 			uid_ptr - uids_dict->base_address);
+		str = format_uid_raw(uid_val, use_colors, 1);
 
-		str = calloc(1, (use_colors ? strlen(KBLU) : 0) + 1 +
-			36 + 1 + *(uint32_t *)(uid_val + 1) + 1 +
-			(use_colors ? strlen(KNRM) : 0));
-		sprintf(str, "%s%s <%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x>%s",
-			use_colors ? KBLU : "",
-			(const char *)(uid_val + 1) + 4,
-			uid_val->a, uid_val->b, uid_val->c,
-			uid_val->d[0], uid_val->d[1], uid_val->d[2],
-			uid_val->d[3], uid_val->d[4], uid_val->d[5],
-			uid_val->d[6], uid_val->d[7],
-			use_colors ? KNRM : "");
 	}
 	return str;
 }

--- a/tools/logger/convert.c
+++ b/tools/logger/convert.c
@@ -163,7 +163,7 @@ static double to_usecs(uint64_t time, double clk)
 
 static inline void print_table_header(FILE *out_fd)
 {
-	fprintf(out_fd, "%18s %18s  %2s %-18s %-29s  %s\n",
+	fprintf(out_fd, "%18s %18s %2s %-18s %-29s  %s\n",
 		"TIMESTAMP", "DELTA", "C#", "COMPONENT", "LOCATION",
 		"CONTENT");
 	fflush(out_fd);

--- a/tools/logger/convert.c
+++ b/tools/logger/convert.c
@@ -690,6 +690,62 @@ static int verify_fw_ver(const struct convert_config *config,
 	return 0;
 }
 
+static int dump_ldc_info(struct convert_config *config,
+			 const struct snd_sof_logs_header *snd)
+{
+	struct snd_sof_uids_header *uids_dict = config->uids_dict;
+	ssize_t remaining = uids_dict->data_length;
+	FILE *out_fd = config->out_fd;
+	uint32_t *name_len_ptr;
+	ssize_t entry_size;
+	uintptr_t uid_addr;
+	uintptr_t uid_ptr;
+	int cnt = 0;
+	char *name;
+
+	fprintf(out_fd, "logger ABI Version is\t%d:%d:%d\n",
+		SOF_ABI_VERSION_MAJOR(SOF_ABI_DBG_VERSION),
+		SOF_ABI_VERSION_MINOR(SOF_ABI_DBG_VERSION),
+		SOF_ABI_VERSION_PATCH(SOF_ABI_DBG_VERSION));
+	fprintf(out_fd, "ldc_file ABI Version is\t%d:%d:%d\n",
+		SOF_ABI_VERSION_MAJOR(snd->version.abi_version),
+		SOF_ABI_VERSION_MINOR(snd->version.abi_version),
+		SOF_ABI_VERSION_PATCH(snd->version.abi_version));
+	fprintf(out_fd, "\n");
+	fprintf(out_fd, "Components uuid dictionary size:\t%ld bytes\n",
+		remaining);
+	fprintf(out_fd, "Components uuid base address:   \t0x%X\n",
+		uids_dict->base_address);
+	fprintf(out_fd, "Components uuid entries:\n");
+	fprintf(out_fd, "\t%10s  %38s %s\n", "ADDRESS", "UUID", "NAME");
+
+	uid_ptr = (uintptr_t)uids_dict + uids_dict->data_offset;
+
+	while (remaining > 0) {
+		name = format_uid_raw((struct sof_uuid *)uid_ptr, 0, 0);
+		uid_addr = uid_ptr - (uintptr_t)uids_dict -
+			    uids_dict->data_offset + uids_dict->base_address;
+		fprintf(out_fd, "\t0x%lX  %s\n", uid_addr, name);
+
+		if (name) {
+			free(name);
+			name = NULL;
+		}
+		/* just after sof_uuid there is name_len in uint32_t format */
+		name_len_ptr = (uint32_t *)(uid_ptr + sizeof(struct sof_uuid));
+		entry_size = ALIGN_UP(*name_len_ptr + sizeof(struct sof_uuid) +
+				      sizeof(uint32_t), 4);
+		remaining -= entry_size;
+		uid_ptr += entry_size;
+		++cnt;
+	}
+
+	fprintf(out_fd, "\t-------------------------------------------------- cnt: %d\n",
+		cnt);
+
+	return 0;
+}
+
 int convert(struct convert_config *config)
 {
 	struct snd_sof_logs_header snd;
@@ -759,6 +815,9 @@ int convert(struct convert_config *config)
 			"Error: failed to read uuid section data.\n");
 		return -ferror(config->ldc_fd);
 	}
+
+	if (config->dump_ldc)
+		return dump_ldc_info(config, &snd);
 
 	return logger_read(config, &snd);
 }

--- a/tools/logger/convert.h
+++ b/tools/logger/convert.h
@@ -36,6 +36,7 @@ struct convert_config {
 	int use_colors;
 	int serial_fd;
 	int raw_output;
+	int dump_ldc;
 	struct snd_sof_uids_header *uids_dict;
 };
 

--- a/tools/logger/logger.c
+++ b/tools/logger/logger.c
@@ -42,7 +42,8 @@ static void usage(void)
 		"default verification file\n", APP_NAME);
 	fprintf(stdout, "%s:\t -v ver_file\t\tEnable checking firmware version "
 		"with ver_file file\n", APP_NAME);
-	fprintf(stdout, "%s:\t -c\t\t\tSet timestamp clock in MHz\n", APP_NAME);
+	fprintf(stdout, "%s:\t -c clock\t\tSet timestamp clock in MHz\n",
+		APP_NAME);
 	fprintf(stdout, "%s:\t -s state_name\t\tTake a snapshot of state\n",
 		APP_NAME);
 	fprintf(stdout, "%s:\t -t\t\t\tDisplay trace data\n", APP_NAME);

--- a/tools/logger/logger.c
+++ b/tools/logger/logger.c
@@ -50,6 +50,7 @@ static void usage(void)
 	fprintf(stdout, "%s:\t -r\t\t\tLess formatted output for "
 		"chained log processors\n",
 		APP_NAME);
+	fprintf(stdout, "%s:\t -d\t\t\tDump ldc information\n", APP_NAME);
 	exit(0);
 }
 
@@ -154,8 +155,9 @@ int main(int argc, char *argv[])
 	config.use_colors = 1;
 	config.serial_fd = -EINVAL;
 	config.raw_output = 0;
+	config.dump_ldc = 0;
 
-	while ((opt = getopt(argc, argv, "ho:i:l:ps:c:u:tev:r")) != -1) {
+	while ((opt = getopt(argc, argv, "ho:i:l:ps:c:u:tev:rd")) != -1) {
 		switch (opt) {
 		case 'o':
 			config.out_file = optarg;
@@ -195,6 +197,9 @@ int main(int argc, char *argv[])
 			/* enabling checking fw version with ver_file file */
 			config.version_fw = 1;
 			config.version_file = optarg;
+			break;
+		case 'd':
+			config.dump_ldc = 1;
 			break;
 		case 'h':
 		default: /* '?' */


### PR DESCRIPTION
Create dump options for logger to print important information from
LDC file, like DBG_ABI version and UUID with corresponding names.

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>

Output:

```
$./sof-logger -i log/dma_trace_1.bin -l log/sof-cnl.ldc -d
logger ABI Version is   4:2:0
ldc_file ABI Version is 4:2:0

Components uuid dictionary size:        824 bytes
Components uuid base address:           0x1FFFA000
Components uuid entries:
           ADDRESS                                    UUID NAME
        0x1FFFA000  <8b9d100c-6d78-418f-90a3-e0e805d0852b> host
        0x1FFFA01C  <f11818eb-e92e-4082-82a3-dc54c604ebb3> pipe-task
        0x1FFFA03C  <34dc0385-fc2f-4f7f-82d2-6cee444533e0> volume-task
        0x1FFFA05C  <b77e677e-5ff4-4188-af14-fba8bdbf8682> volume
        0x1FFFA078  <c1c5326d-8390-46b4-aa47-95c3beca6550> src
        0x1FFFA090  <43a90ce7-f3a5-41df-ac06-ba98651ae6a3> eq-fir
        0x1FFFA0AC  <5150c0e6-27f9-4ec8-8351-c705b642d12f> eq-iir
        0x1FFFA0C8  <04e3f894-2c5c-4f2e-8dc1-694eeaab53fa> tone
        0x1FFFA0E4  <bc06c037-12aa-417c-9a97-89282e321a76> mixer
        0x1FFFA100  <c4b26868-1430-470e-a089-15d1c77f851a> mux
        0x1FFFA118  <385cc44b-f34e-4b9b-8be0-535c5f43a825> switch
        0x1FFFA134  <c2b00d27-ffbc-4150-a51a-245c79c5e54b> dai
        0x1FFFA14C  <e50057a5-8b27-4db4-bd79-9a639cee5f50> kpb-task
        0x1FFFA16C  <d8218443-5ff3-4a4c-b388-6cfe07b9562e> kpb
        0x1FFFA184  <55a88ed5-3d18-46ca-88f1-0ee6eae9930f> selector
        0x1FFFA1A4  <eba8d51f-7827-47b5-82ee-de6e7743af67> kd-test
        0x1FFFA1C0  <c8ec72f6-8526-4faf-9d39-a23d0b541de2> asrc
        0x1FFFA1DC  <bc9ebe20-4577-41bb-9eed-d0cb236328da> hda-dai
        0x1FFFA1F8  <8fa1d42f-bc6f-464b-867f-547af08834da> ipc-task
        0x1FFFA218  <59c87728-d8f9-42f6-b89d-5870a87b0e1e> dmic-work
        0x1FFFA238  <aafc26fe-3b8d-498d-8bd6-248fc72efa31> dmic-dai
        0x1FFFA258  <31458125-95c4-4085-8f3f-497434cb2daf> ssp-dai
        0x1FFFA274  <a8e4218c-e863-4c93-84e7-5c27d2504501> alh-dai
        0x1FFFA290  <b90f5a4e-5537-4375-a1df-95485472ff9e> comp-task
        0x1FFFA2B0  <a5dacb0e-88dc-415c-a1b5-3e8df77f1976> idc-cmd-task
        0x1FFFA2D4  <c63c4e75-8f61-4420-9319-1395932efa9e> agent-work
        0x1FFFA2F4  <37f1d41f-252d-448d-b9c4-1e2bee8e1bf1> main-task
        0x1FFFA314  <2b972272-c5b1-4b7e-926f-0fc5cb4c4690> dma-trace-task
        -------------------------------------------------- cnt: 28
```