### PR TITLE
remove unnecessary parentheses

### DIFF
--- a/src/drivers/intel/baytrail/ssp.c
+++ b/src/drivers/intel/baytrail/ssp.c
@@ -455,8 +455,8 @@ static int ssp_set_config(struct dai *dai,
 	/* FIXME:
 	 * watermarks - (RFT + 1) should equal DMA SRC_MSIZE
 	 */
-	sfifott = (SFIFOTT_TX(2 * active_tx_slots) |
-		   SFIFOTT_RX(2 * active_rx_slots));
+	sfifott = SFIFOTT_TX(2 * active_tx_slots) |
+		  SFIFOTT_RX(2 * active_rx_slots);
 
 	ssp_write(dai, SSCR0, sscr0);
 	ssp_write(dai, SSCR1, sscr1);

--- a/src/platform/intel/cavs/lib/pm_memory.c
+++ b/src/platform/intel/cavs/lib/pm_memory.c
@@ -193,8 +193,8 @@ void set_power_gate_for_memory_address_range(void *ptr,
 	/* Ending bank id has to be lowered by one because it is
 	 * calculated from memory end ptr
 	 */
-	ending_bank_id = (((uintptr_t)end_ptr - HP_SRAM_BASE)
-		/ SRAM_BANK_SIZE - 1);
+	ending_bank_id = ((uintptr_t)end_ptr - HP_SRAM_BASE)
+			/ SRAM_BANK_SIZE - 1;
 
 	set_banks_gating(start_bank_id, ending_bank_id, enabled);
 }


### PR DESCRIPTION
Remove unnecessary parentheses around the right hand side of assignments.