### PR TITLE
Testbench: Fix segfault in pipeline_new() in topology parsing

### DIFF
--- a/tools/testbench/common_test.c
+++ b/tools/testbench/common_test.c
@@ -30,6 +30,8 @@ int tb_pipeline_setup(struct sof *sof)
 	/* init components */
 	sys_comp_init(sof);
 
+	/* other necessary initializations, todo: follow better SOF init */
+	pipeline_posn_init(sof);
 	init_system_notify(sof);
 
 	/* init IPC */

--- a/tools/testbench/topology.c
+++ b/tools/testbench/topology.c
@@ -445,7 +445,7 @@ int load_pipeline(void *dev, int comp_id, int pipeline_id,
 		  struct snd_soc_tplg_dapm_widget *widget, int sched_id)
 {
 	struct sof *sof = (struct sof *)dev;
-	struct sof_ipc_pipe_new pipeline;
+	struct sof_ipc_pipe_new pipeline = {0};
 	int size = widget->priv.size;
 	int ret;
 


### PR DESCRIPTION
This patch fixes the crash by adding initialize of sof->pipeline_posn
into pipeline initialization code.

Also the in load_pipeline() function the pipeline is initialized
to zeros to prevent random values to be passed in not set
struct fields. It didn't fix anything but makes debugging of crash
easier.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>