### PR TITLE
Document alloc.h

### DIFF
--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -240,7 +240,7 @@ struct comp_ops {
 	 * @return Pointer to the new component device.
 	 *
 	 * All required data objects should be allocated from the run-time
-	 * heap (RZONE_RUNTIME).
+	 * heap (SOF_MEM_ZONE_RUNTIME).
 	 * Any component-specific private data is allocated separately and
 	 * pointer is connected to the comp_dev::private by using
 	 * comp_set_drvdata() and later retrieved by comp_get_drvdata().

--- a/src/include/sof/lib/alloc.h
+++ b/src/include/sof/lib/alloc.h
@@ -6,6 +6,13 @@
  *         Keyon Jie <yang.jie@linux.intel.com>
  */
 
+/**
+ * \file include/sof/lib/alloc.h
+ * \brief Memory Allocation API definition
+ * \author Liam Girdwood <liam.r.girdwood@linux.intel.com>
+ * \author Keyon Jie <yang.jie@linux.intel.com>
+ */
+
 #ifndef __SOF_LIB_ALLOC_H__
 #define __SOF_LIB_ALLOC_H__
 
@@ -17,70 +24,161 @@
 #include <stddef.h>
 #include <stdint.h>
 
-/* Heap Memory Zones
+/** \addtogroup alloc_api Memory Allocation API
+ *  @{
+ */
+
+/**
+ * \brief Heap Memory Zones
  *
  * The heap has three different zones from where memory can be allocated :-
  *
  * 1) System Zone. Fixed size heap where alloc always succeeds and is never
  * freed. Used by any init code that will never give up the memory.
  *
- * 2) Runtime Zone. Main and larger heap zone where allocs are not guaranteed to
+ * 2) System Runtime Zone. Heap zone intended for runtime objects allocated
+ * by the kernel part of the code.
+ *
+ * 3) Runtime Zone. Main and larger heap zone where allocs are not guaranteed to
  * succeed. Memory can be freed here.
  *
- * 3) Buffer Zone. Largest heap zone intended for audio buffers.
- *
- * 4) System Runtime Zone. Heap zone intended for runtime objects allocated
- * by the kernel part of the code.
+ * 4) Buffer Zone. Largest heap zone intended for audio buffers.
  *
  * See platform/memory.h for heap size configuration and mappings.
  */
-
-/* heap zone types */
 enum mem_zone {
-	SOF_MEM_ZONE_SYS = 0,
-	SOF_MEM_ZONE_SYS_RUNTIME,
-	SOF_MEM_ZONE_RUNTIME,
-	SOF_MEM_ZONE_BUFFER,
+	SOF_MEM_ZONE_SYS = 0,		/**< System zone */
+	SOF_MEM_ZONE_SYS_RUNTIME,	/**< System-runtime zone */
+	SOF_MEM_ZONE_RUNTIME,		/**< Runtime zone */
+	SOF_MEM_ZONE_BUFFER,		/**< Buffer zone */
 };
 
-/* heap zone flags */
+/** \name Heap zone flags
+ *  @{
+ */
+
+/** \brief Indicates that allocated memory block must be shareable between
+ *	DSP cores.
+ */
 #define SOF_MEM_FLAG_SHARED	BIT(0)
 
-/* heap allocation and free */
+/** @} */
+
+/**
+ * Allocates memory block.
+ * @param zone Zone to allocate memory from, see enum mem_zone.
+ * @param flags Flags, see SOF_MEM_FLAG_...
+ * @param caps Capabilities, see SOF_MEM_CAPS_...
+ * @param bytes Size in bytes.
+ * @return Pointer to the allocated memory or NULL if failed.
+ *
+ * @note Do not use for buffers (SOF_MEM_ZONE_BUFFER zone).
+ *       Use rballoc(), rballoc_align() to allocate memory for buffers.
+ */
 void *rmalloc(enum mem_zone zone, uint32_t flags, uint32_t caps, size_t bytes);
 
+/**
+ * Similar to rmalloc(), guarantees that returned block is zeroed.
+ *
+ * @note Do not use  for buffers (SOF_MEM_ZONE_BUFFER zone).
+ *       rballoc(), rballoc_align() to allocate memory for buffers.
+ */
 void *rzalloc(enum mem_zone zone, uint32_t flags, uint32_t caps, size_t bytes);
 
+/**
+ * Allocates memory block from SOF_MEM_ZONE_BUFFER.
+ * @param flags Flags, see SOF_MEM_FLAG_...
+ * @param caps Capabilities, see SOF_MEM_CAPS_...
+ * @param bytes Size in bytes.
+ * @param alignment Alignment in bytes.
+ * @return Pointer to the allocated memory or NULL if failed.
+ */
 void *rballoc_align(uint32_t flags, uint32_t caps, size_t bytes,
 		    uint32_t alignment);
 
+/**
+ * Similar to rballoc_align(), returns buffer aligned to PLATFORM_DCACHE_ALIGN.
+ */
 static inline void *rballoc(uint32_t flags, uint32_t caps, size_t bytes)
 {
 	return rballoc_align(flags, caps, bytes, PLATFORM_DCACHE_ALIGN);
 }
 
+/**
+ * Changes size of the memory block.
+ * @param ptr Address of the block to resize.
+ * @param zone Zone, see enum mem_zone.
+ * @param flags Flags, see SOF_MEM_FLAG_...
+ * @param caps Capabilities, see SOF_MEM_CAPS_...
+ * @param bytes New size in bytes.
+ * @return Pointer to the resized memory or NULL if failed.
+ *
+ * Note: Do not use for buffers (SOF_MEM_ZONE_BUFFER zone).
+ * Use rballoc(), rballoc_align() to allocate memory for buffers.
+ */
 void *rrealloc(void *ptr, enum mem_zone zone, uint32_t flags, uint32_t caps,
 	       size_t bytes);
 
+/**
+ * Changes size of the memory block allocated from SOF_MEM_ZONE_BUFFER.
+ * @param ptr Address of the block to resize.
+ * @param flags Flags, see SOF_MEM_FLAG_...
+ * @param caps Capabilities, see SOF_MEM_CAPS_...
+ * @param bytes New size in bytes.
+ * @param alignment Alignment in bytes.
+ * @return Pointer to the resized memory of NULL if failed.
+ */
 void *rbrealloc_align(void *ptr, uint32_t flags, uint32_t caps, size_t bytes,
 		      uint32_t alignment);
 
+/**
+ * Similar to rballoc_align(), returns resized buffer aligned to
+ * PLATFORM_DCACHE_ALIGN.
+ */
 static inline void *rbrealloc(void *ptr, uint32_t flags, uint32_t caps,
 			      size_t bytes)
 {
 	return rbrealloc_align(ptr, flags, caps, bytes, PLATFORM_DCACHE_ALIGN);
 }
 
+/**
+ * Frees the memory block.
+ * @param ptr Pointer to the memory block.
+ *
+ * @note Blocks from SOF_MEM_ZONE_SYS cannot be freed, such a call causes
+ *       panic.
+ */
 void rfree(void *ptr);
 
-/* system heap allocation for specific core */
+/**
+ * Allocates memory block from the system heap reserved for the specified core.
+ * @param core Core id.
+ * @param bytes Size in bytes.
+ */
 void *rzalloc_core_sys(int core, size_t bytes);
 
-/* utility */
+/** \brief Zeroes memory block.
+ * @param ptr Pointer to the memory block.
+ * @param size Size of the block in bytes.
+ */
 #define bzero(ptr, size) \
 	arch_bzero(ptr, size)
 
+/**
+ * Calculates length of the null-terminated string.
+ * @param s String.
+ * @return Length of the string in bytes.
+ */
 int rstrlen(const char *s);
+
+/**
+ * Compares two strings, see man strcmp.
+ * @param s1 First string to compare.
+ * @param s2 Second string to compare.
+ * @return See man strcmp.
+ */
 int rstrcmp(const char *s1, const char *s2);
+
+/** @}*/
 
 #endif /* __SOF_LIB_ALLOC_H__ */

--- a/src/include/sof/lib/alloc.h
+++ b/src/include/sof/lib/alloc.h
@@ -47,29 +47,31 @@ enum mem_zone {
 #define SOF_MEM_FLAG_SHARED	BIT(0)
 
 /* heap allocation and free */
-void *_malloc(enum mem_zone zone, uint32_t flags, uint32_t caps, size_t bytes);
-void *_zalloc(enum mem_zone zone, uint32_t flags, uint32_t caps, size_t bytes);
-void *_balloc(uint32_t flags, uint32_t caps, size_t bytes, uint32_t alignment);
-void *_realloc(void *ptr, enum mem_zone zone, uint32_t flags, uint32_t caps,
-	       size_t bytes);
-void *_brealloc(void *ptr, uint32_t flags, uint32_t caps, size_t bytes,
-		uint32_t alignment);
-void rfree(void *ptr);
+void *rmalloc(enum mem_zone zone, uint32_t flags, uint32_t caps, size_t bytes);
 
-#define rmalloc(zone, flags, caps, bytes) \
-	_malloc(zone, flags, caps, bytes)
-#define rzalloc(zone, flags, caps, bytes) \
-	_zalloc(zone, flags, caps, bytes)
-#define rballoc(flags, caps, bytes) \
-	_balloc(flags, caps, bytes, PLATFORM_DCACHE_ALIGN)
-#define rballoc_align(flags, caps, bytes, alignment) \
-	_balloc(flags, caps, bytes, alignment)
-#define rrealloc(ptr, zone, flags, caps, bytes) \
-	_realloc(ptr, zone, flags, caps, bytes)
-#define rbrealloc(ptr, flags, caps, bytes) \
-	_brealloc(ptr, flags, caps, bytes, PLATFORM_DCACHE_ALIGN)
-#define rbrealloc_align(ptr, flags, caps, bytes, alignment) \
-	_brealloc(ptr, flags, caps, bytes, alignment)
+void *rzalloc(enum mem_zone zone, uint32_t flags, uint32_t caps, size_t bytes);
+
+void *rballoc_align(uint32_t flags, uint32_t caps, size_t bytes,
+		    uint32_t alignment);
+
+static inline void *rballoc(uint32_t flags, uint32_t caps, size_t bytes)
+{
+	return rballoc_align(flags, caps, bytes, PLATFORM_DCACHE_ALIGN);
+}
+
+void *rrealloc(void *ptr, enum mem_zone zone, uint32_t flags, uint32_t caps,
+	       size_t bytes);
+
+void *rbrealloc_align(void *ptr, uint32_t flags, uint32_t caps, size_t bytes,
+		      uint32_t alignment);
+
+static inline void *rbrealloc(void *ptr, uint32_t flags, uint32_t caps,
+			      size_t bytes)
+{
+	return rbrealloc_align(ptr, flags, caps, bytes, PLATFORM_DCACHE_ALIGN);
+}
+
+void rfree(void *ptr);
 
 /* system heap allocation for specific core */
 void *rzalloc_core_sys(int core, size_t bytes);

--- a/src/lib/alloc.c
+++ b/src/lib/alloc.c
@@ -702,8 +702,7 @@ static void *_malloc_unlocked(enum mem_zone zone, uint32_t flags, uint32_t caps,
 	return ptr;
 }
 
-/* allocates memory - not for direct use, clients use rmalloc() */
-void *_malloc(enum mem_zone zone, uint32_t flags, uint32_t caps, size_t bytes)
+void *rmalloc(enum mem_zone zone, uint32_t flags, uint32_t caps, size_t bytes)
 {
 	struct mm *memmap = memmap_get();
 	uint32_t lock_flags;
@@ -720,11 +719,11 @@ void *_malloc(enum mem_zone zone, uint32_t flags, uint32_t caps, size_t bytes)
 }
 
 /* allocates and clears memory - not for direct use, clients use rzalloc() */
-void *_zalloc(enum mem_zone zone, uint32_t flags, uint32_t caps, size_t bytes)
+void *rzalloc(enum mem_zone zone, uint32_t flags, uint32_t caps, size_t bytes)
 {
 	void *ptr;
 
-	ptr = _malloc(zone, flags, caps, bytes);
+	ptr = rmalloc(zone, flags, caps, bytes);
 	if (ptr)
 		bzero(ptr, bytes);
 
@@ -857,7 +856,8 @@ static void *_balloc_unlocked(uint32_t flags, uint32_t caps, size_t bytes,
 }
 
 /* allocates continuous buffers - not for direct use, clients use rballoc() */
-void *_balloc(uint32_t flags, uint32_t caps, size_t bytes, uint32_t alignment)
+void *rballoc_align(uint32_t flags, uint32_t caps, size_t bytes,
+		    uint32_t alignment)
 {
 	struct mm *memmap = memmap_get();
 	void *ptr = NULL;
@@ -914,7 +914,7 @@ void rfree(void *ptr)
 	spin_unlock_irq(&memmap->lock, flags);
 }
 
-void *_realloc(void *ptr, enum mem_zone zone, uint32_t flags, uint32_t caps,
+void *rrealloc(void *ptr, enum mem_zone zone, uint32_t flags, uint32_t caps,
 	       size_t bytes)
 {
 	struct mm *memmap = memmap_get();
@@ -940,8 +940,8 @@ void *_realloc(void *ptr, enum mem_zone zone, uint32_t flags, uint32_t caps,
 	return new_ptr;
 }
 
-void *_brealloc(void *ptr, uint32_t flags, uint32_t caps, size_t bytes,
-		uint32_t alignment)
+void *rbrealloc_align(void *ptr, uint32_t flags, uint32_t caps, size_t bytes,
+		      uint32_t alignment)
 {
 	struct mm *memmap = memmap_get();
 	void *new_ptr = NULL;

--- a/test/cmocka/src/audio/component/mock.c
+++ b/test/cmocka/src/audio/component/mock.c
@@ -19,7 +19,7 @@ static struct sof sof;
 
 #if !CONFIG_LIBRARY
 
-void *_zalloc(enum mem_zone zone, uint32_t flags, uint32_t caps, size_t bytes)
+void *rzalloc(enum mem_zone zone, uint32_t flags, uint32_t caps, size_t bytes)
 {
 	(void)zone;
 	(void)flags;
@@ -28,7 +28,7 @@ void *_zalloc(enum mem_zone zone, uint32_t flags, uint32_t caps, size_t bytes)
 	return calloc(bytes, 1);
 }
 
-void *_realloc(void *ptr, enum mem_zone zone, uint32_t flags, uint32_t caps,
+void *rrealloc(void *ptr, enum mem_zone zone, uint32_t flags, uint32_t caps,
 	       size_t bytes)
 {
 	(void)ptr;

--- a/test/cmocka/src/common_mocks.c
+++ b/test/cmocka/src/common_mocks.c
@@ -18,8 +18,8 @@
 
 #define WEAK __attribute__((weak))
 
-void WEAK *_balloc(uint32_t flags, uint32_t caps, size_t bytes,
-		   uint32_t alignment)
+void WEAK *rballoc_align(uint32_t flags, uint32_t caps, size_t bytes,
+			 uint32_t alignment)
 {
 	(void)flags;
 	(void)caps;
@@ -27,7 +27,7 @@ void WEAK *_balloc(uint32_t flags, uint32_t caps, size_t bytes,
 	return malloc(bytes);
 }
 
-void WEAK *_zalloc(enum mem_zone zone, uint32_t flags, uint32_t caps,
+void WEAK *rzalloc(enum mem_zone zone, uint32_t flags, uint32_t caps,
 		   size_t bytes)
 {
 	(void)zone;
@@ -37,8 +37,8 @@ void WEAK *_zalloc(enum mem_zone zone, uint32_t flags, uint32_t caps,
 	return calloc(bytes, 1);
 }
 
-void WEAK *_brealloc(void *ptr, uint32_t flags, uint32_t caps, size_t bytes,
-		     uint32_t alignment)
+void WEAK *rbrealloc_align(void *ptr, uint32_t flags, uint32_t caps,
+			   size_t bytes, uint32_t alignment)
 {
 	(void)flags;
 	(void)caps;

--- a/tools/testbench/alloc.c
+++ b/tools/testbench/alloc.c
@@ -17,12 +17,12 @@
 
 /* testbench mem alloc definition */
 
-void *_malloc(enum mem_zone zone, uint32_t flags, uint32_t caps, size_t bytes)
+void *rmalloc(enum mem_zone zone, uint32_t flags, uint32_t caps, size_t bytes)
 {
 	return malloc(bytes);
 }
 
-void *_zalloc(enum mem_zone zone, uint32_t flags, uint32_t caps, size_t bytes)
+void *rzalloc(enum mem_zone zone, uint32_t flags, uint32_t caps, size_t bytes)
 {
 	return calloc(bytes, 1);
 }
@@ -32,20 +32,20 @@ void rfree(void *ptr)
 	free(ptr);
 }
 
-void *_balloc(uint32_t flags, uint32_t caps, size_t bytes,
-	      uint32_t alignment)
+void *rballoc_align(uint32_t flags, uint32_t caps, size_t bytes,
+		    uint32_t alignment)
 {
 	return malloc(bytes);
 }
 
-void *_realloc(void *ptr, enum mem_zone zone, uint32_t flags, uint32_t caps,
+void *rrealloc(void *ptr, enum mem_zone zone, uint32_t flags, uint32_t caps,
 	       size_t bytes)
 {
 	return realloc(ptr, bytes);
 }
 
-void *_brealloc(void *ptr, uint32_t flags, uint32_t caps, size_t bytes,
-		uint32_t alignment)
+void *rbrealloc_align(void *ptr, uint32_t flags, uint32_t caps, size_t bytes,
+		      uint32_t alignment)
 {
 	return realloc(ptr, bytes);
 }


### PR DESCRIPTION
This is the documentation of alloc.h, including a small final cleanup of the header (transparent to client code) in the first patch.