### PR TITLE
ASRC: SRC: Fail params() when DAI does not provide sink stream format information

### DIFF
--- a/src/audio/asrc/asrc.c
+++ b/src/audio/asrc/asrc.c
@@ -412,6 +412,11 @@ static int asrc_params(struct comp_dev *dev,
 	/* set source/sink_frames/rate */
 	cd->source_rate = sourceb->stream.rate;
 	cd->sink_rate = sinkb->stream.rate;
+	if (!cd->sink_rate) {
+		comp_err(dev, "asrc_params(), zero sink rate");
+		return -EINVAL;
+	}
+
 	cd->sink_frames = dev->frames;
 	cd->source_frames = ceil_divide(dev->frames * cd->source_rate,
 					cd->sink_rate);

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -581,6 +581,10 @@ static int src_params(struct comp_dev *dev,
 	/* Set source/sink_rate/frames */
 	cd->source_rate = sourceb->stream.rate;
 	cd->sink_rate = sinkb->stream.rate;
+	if (!cd->sink_rate) {
+		comp_err(dev, "src_params(), zero sink rate");
+		return -EINVAL;
+	}
 
 	cd->source_frames = dev->frames * cd->source_rate / cd->sink_rate;
 	cd->sink_frames = dev->frames;


### PR DESCRIPTION
This can happen with HDA and ALH and avoids a firmware crash.