### PR TITLE
test: fix mixer_test.c:comp_register() 'uninitialized err' -Werror

### DIFF
--- a/test/cmocka/src/audio/mixer/mixer_test.c
+++ b/test/cmocka/src/audio/mixer/mixer_test.c
@@ -47,12 +47,12 @@ int comp_register(struct comp_driver_info *info)
 		err = memcpy_s(dst, sizeof(drv_mock), info->drv,
 			       sizeof(struct comp_driver));
 		break;
+
+	default:
+		return -ENOTSUP;
 	}
 
-	if (err)
-		return -EINVAL;
-
-	return 0;
+	return err;
 }
 
 struct source {


### PR DESCRIPTION
Fixes:
```
  error: 'err' may be used uninitialized in this function
                           [-Werror=maybe-uninitialized]
  if (err)
     ^
```
As I found nothing in the entire code base checking the return value of
comp_register() (the real function seems to always succeed), I also
simplify the main path and pass through the value returned by
memcpy_s().

Signed-off-by: Marc Herbert <marc.herbert@intel.com>