### PR TITLE
rimage: Add function to read section content with allocation

### DIFF
--- a/rimage/elf.c
+++ b/rimage/elf.c
@@ -89,18 +89,18 @@ static int elf_read_sections(struct image *image, struct module *module,
 		module->fw_ready_index = -EINVAL;
 	} else {
 		/* find manifest module data */
-		module->bss_index = elf_find_section(image, module, ".bss");
+		module->bss_index = elf_find_section(module, ".bss");
 		if (module->bss_index < 0)
 			return module->bss_index;
 
 		/* find log entries and fw ready sections */
-		module->logs_index = elf_find_section(image, module,
+		module->logs_index = elf_find_section(module,
 						      ".static_log_entries");
 
-		module->uids_index = elf_find_section(image, module,
+		module->uids_index = elf_find_section(module,
 						      ".static_uuid_entries");
 
-		module->fw_ready_index = elf_find_section(image, module,
+		module->fw_ready_index = elf_find_section(module,
 							  ".fw_ready");
 		if (module->fw_ready_index < 0)
 			return module->fw_ready_index;
@@ -490,11 +490,10 @@ int elf_validate_modules(struct image *image)
 	return 0;
 }
 
-int elf_find_section(struct image *image, struct module *module,
-		     const char *name)
+int elf_find_section(const struct module *module, const char *name)
 {
 	Elf32_Ehdr *hdr = &module->hdr;
-	Elf32_Shdr *section, *s;
+	const Elf32_Shdr *section, *s;
 	char *buffer;
 	size_t count;
 	int ret, i;
@@ -595,7 +594,7 @@ int elf_parse_module(struct image *image, int module_index, const char *name)
 	/* check limits */
 	elf_module_limits(image, module);
 
-	elf_find_section(image, module, "");
+	elf_find_section(module, "");
 
 	fprintf(stdout, " module: input size %d (0x%x) bytes %d sections\n",
 		module->fw_size, module->fw_size, module->num_sections);

--- a/rimage/manifest.c
+++ b/rimage/manifest.c
@@ -231,7 +231,7 @@ static int man_get_module_manifest(struct image *image, struct module *module,
 	fprintf(stdout, "Module Write: %s\n", module->elf_file);
 
 	/* find manifest module data */
-	man_section_idx = elf_find_section(image, module, ".module");
+	man_section_idx = elf_find_section(module, ".module");
 	if (man_section_idx < 0)
 		return -EINVAL;
 

--- a/rimage/rimage.h
+++ b/rimage/rimage.h
@@ -179,7 +179,7 @@ int elf_validate_modules(struct image *image);
 int elf_find_section(struct image *image, struct module *module,
 		const char *name);
 int elf_validate_section(struct image *image, struct module *module,
-	Elf32_Shdr *section, int index);
+			 Elf32_Shdr *section, int index);
 
 /* supported machines */
 extern const struct adsp machine_byt;

--- a/rimage/rimage.h
+++ b/rimage/rimage.h
@@ -177,6 +177,8 @@ void elf_free_module(struct image *image, int module_index);
 int elf_is_rom(struct image *image, Elf32_Shdr *section);
 int elf_validate_modules(struct image *image);
 int elf_find_section(const struct module *module, const char *name);
+int elf_read_section(const struct image *image, const char *name,
+		     const Elf32_Shdr **dst_section, void **dst_buff);
 int elf_validate_section(struct image *image, struct module *module,
 			 Elf32_Shdr *section, int index);
 

--- a/rimage/rimage.h
+++ b/rimage/rimage.h
@@ -176,8 +176,7 @@ int elf_parse_module(struct image *image, int module_index, const char *name);
 void elf_free_module(struct image *image, int module_index);
 int elf_is_rom(struct image *image, Elf32_Shdr *section);
 int elf_validate_modules(struct image *image);
-int elf_find_section(struct image *image, struct module *module,
-		const char *name);
+int elf_find_section(const struct module *module, const char *name);
 int elf_validate_section(struct image *image, struct module *module,
 			 Elf32_Shdr *section, int index);
 


### PR DESCRIPTION
In many functions there is need to read user section content
and check firmware version or write section content to some
manifest or dictionary. Previously to do it, in each function
was loop to search for proper section in proper module,
then allocate buffer, read content and check for possible error
between each step what is quite overwhelming. After change there
will be one function responsible for this task.

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>