### PR TITLE
topology: cmake: silence super chatty alsatplg unless VERBOSE=1

### DIFF
--- a/tools/topology/CMakeLists.txt
+++ b/tools/topology/CMakeLists.txt
@@ -159,11 +159,25 @@ foreach(tplg ${TPLGS})
 		USES_TERMINAL
 	)
 
+# This use of VERBOSE relies on original CMake behavior.
+# From the add_custom_command() manual:
+#
+#    Use of VERBATIM is recommended as it enables correct behavior.
+#    When VERBATIM is not given the behavior is platform specific because
+#    there is no protection of tool-specific special characters.
+#
+# This is fine because:
+# - We don't expect alsatplg to work on Windows any time soon.
+# - CMake is too afraid to remove the original, no-VERBATIM behavior:
+#      https://gitlab.kitware.com/cmake/cmake/issues/18849
+#
+# Also note that in alsa-utils commit v1.2.2~15-gcbabe7a3f0cc, alsatplg
+# (accidentally?) started ignoring the verbosity level, now it's just
+# verbose or not.
 	add_custom_command(
 		OUTPUT ${output}.tplg
-		COMMAND alsatplg -v 1 -c ${output}.conf -o ${output}.tplg
+		COMMAND alsatplg \$\${VERBOSE:+-v 1} -c ${output}.conf -o ${output}.tplg
 		DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${output}.conf
-		VERBATIM
 		USES_TERMINAL
 	)
 


### PR DESCRIPTION
Successfully tested with both Make and Ninja on Linux.

Non-portable but approved by @jajanusz in former PR #2626

With this commit:
```
$                  make -C tools/build_tools/ | wc -l
    770

$ VERBOSE=anything make -C tools/build_tools/ | wc -l
  10387
```
Signed-off-by: Marc Herbert <marc.herbert@intel.com>