### PR TITLE
scripts: build-tools.sh: Use getopts, breakdown script to functions

### DIFF
--- a/scripts/build-tools.sh
+++ b/scripts/build-tools.sh
@@ -5,27 +5,71 @@
 # fail immediately on any errors
 set -e
 
-cd tools
 
-rm -rf build_tools
+print_usage()
+{
+        cat <<EOFUSAGE
+usage: $0 [-t|-f]
+       [-t] Build test topologies
+       [-f] Build fuzzer"
+EOFUSAGE
+}
 
-mkdir build_tools
-cd build_tools
-cmake ..
-make -j$(nproc)
-for args in $@
-do
-	#build test topologies
-	if [[ "$args" == "-t" ]]; then
-		make tests -j$(nproc)
-	fi
-	#build fuzzer
-	if [[ "$args" == "-f" ]]; then
-		rm -rf build_fuzzer
-		mkdir build_fuzzer
-		cd build_fuzzer
-		cmake ../../fuzzer
-		make -j$(nproc)
-		cd ../
-	fi
-done
+build_tools()
+{
+        cd "$SOF_REPO/tools"
+        rm -rf build_tools
+        mkdir build_tools
+        cd build_tools
+        cmake ..
+        make -j "$NO_PROCESSORS"
+}
+
+build_test()
+{
+        cd "$SOF_REPO/tools/build_tools"
+        make tests -j "$NO_PROCESSORS"
+}
+
+build_fuzzer()
+{
+        cd "$SOF_REPO/tools/build_tools"
+        mkdir build_fuzzer
+        cd build_fuzzer
+        cmake ../../fuzzer
+        make -j "$NO_PROCESSORS"
+}
+
+main()
+{
+        local DO_BUILD_TEST DO_BUILD_FUZZER SCRIPT_DIR SOF_REPO NO_PROCESSORS
+
+        SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+        SOF_REPO=$(dirname "$SCRIPT_DIR")
+        NO_PROCESSORS=$(nproc)
+
+        DO_BUILD_TEST=false
+        DO_BUILD_FUZZER=false
+        while getopts "tf" OPTION; do
+                case "$OPTION" in
+                t) DO_BUILD_TEST=true ;;
+                f) DO_BUILD_FUZZER=true ;;
+                *) print_usage; exit 1;;
+                esac
+        done
+        shift "$(($OPTIND - 1))"
+
+        build_tools
+
+        if "$DO_BUILD_TEST"
+        then
+                build_test
+        fi
+
+        if "$DO_BUILD_FUZZER"
+        then
+                build_fuzzer
+        fi
+}
+
+main "$@"


### PR DESCRIPTION
Use getopts to parse the arguments instead of manual parsing to leave no
room for errors, bugs, and inconsistent conventions introduced by custom
implementation.

Signed-off-by: Shreeya Patel <shreeya.patel23498@gmail.com>