### PR TITLE
Add CODEOWNERS for DCBlocker

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -26,6 +26,7 @@ src/audio/iir*				@singalsu
 src/audio/tone.c			@singalsu
 src/audio/kpb.c				@mrajwa
 src/audio/mux/*				@akloniex
+src/audio/dcblock*			@cujomalainey @dgreid
 
 # platforms
 src/arch/xtensa/*			@tlauda


### PR DESCRIPTION
Add Google owners as owners of imported code

Signed-off-by: Curtis Malainey <curtis@malainey.com>