### PR TITLE
topology: glk: add eq capture for DMIC

### DIFF
--- a/tools/topology/CMakeLists.txt
+++ b/tools/topology/CMakeLists.txt
@@ -70,6 +70,7 @@ set(TPLGS
 	"sof-apl-da7219\;sof-apl-da7219"
 	"sof-glk-da7219-kwd\;sof-glk-da7219-kwd"
 	"sof-glk-da7219\;sof-glk-da7219"
+	"sof-glk-da7219\;sof-glk-eq-da7219\;-DDMICPROC=eq"
 	"sof-glk-rt5682\;sof-glk-rt5682"
 	"sof-icl-nocodec\;sof-icl-nocodec"
 	"sof-apl-pcm512x-nohdmi\;sof-apl-eq-pcm512x\;-DPPROC=eq-volume"

--- a/tools/topology/sof-glk-da7219.m4
+++ b/tools/topology/sof-glk-da7219.m4
@@ -23,7 +23,7 @@ include(`platform/intel/dmic.m4')
 #
 # PCM0  ----> volume (pipe 1)   -----> SSP1 (speaker - maxim98357a, BE link 0)
 # PCM1  <---> volume (pipe 2,3) <----> SSP2 (headset - da7219, BE link 1)
-# PCM99 <---- DMIC0 (dmic capture, BE link 2)
+`# PCM99 <---- 'DMICPROC` <---- DMIC0 (dmic capture, BE link 2)'
 # PCM5  ----> volume (pipe 5)   -----> iDisp1 (HDMI/DP playback, BE link 3)
 # PCM6  ----> Volume (pipe 6)   -----> iDisp2 (HDMI/DP playback, BE link 4)
 # PCM7  ----> volume (pipe 7)   -----> iDisp3 (HDMI/DP playback, BE link 5)
@@ -56,10 +56,13 @@ PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
+# if DMICPROC is not defined, default pipepline is volume
+ifdef(`DMICPROC', , `define(DMICPROC, volume)')
+define(DEF_PIPE_DMIC_CAPTURE, sof/pipe-DMICPROC-capture.m4)
+
 # Low Latency capture pipeline 4 on PCM 99 using max 4 channels of s32le.
 # 1000us deadline on core 0 with priority 0
-#PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
-PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
+PIPELINE_PCM_ADD(DEF_PIPE_DMIC_CAPTURE,
 	4, 99, 4, s16le,
 	1000, 0, 0,
 	48000, 48000, 48000)


### PR DESCRIPTION
glk da7119 bobba platform has DMIC already installed. It is good platform
to test DMIC with and without EQ.

Signed-off-by: Fred Oh <fred.oh@linux.intel.com>

With this PR, sof-glk-eq-da7219 tplg will be generated.
![sof-glk-eq-da7219 tplg](https://user-images.githubusercontent.com/45636982/77865322-8704ae80-71e2-11ea-98ce-181eb6e25a0a.png)
