### PR TITLE
hda-dma: exit L1 only once for all DMA channels

### DIFF
--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -819,7 +819,7 @@ static int dai_config(struct comp_dev *dev, struct sof_ipc_dai_config *config)
 
 		/* setup callback */
 		notifier_register(dev, dd->chan, NOTIFIER_ID_DMA_COPY,
-				  dai_dma_cb);
+				  dai_dma_cb, 0);
 	}
 
 	return dai_set_config(dd->dai, config);

--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -761,7 +761,7 @@ static int host_params(struct comp_dev *dev,
 	}
 
 	/* set up callback */
-	notifier_register(dev, hd->chan, NOTIFIER_ID_DMA_COPY, host_dma_cb);
+	notifier_register(dev, hd->chan, NOTIFIER_ID_DMA_COPY, host_dma_cb, 0);
 
 	/* set copy function */
 	hd->copy = hd->copy_type == COMP_COPY_ONE_SHOT ? host_copy_one_shot :

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -491,7 +491,7 @@ static int kpb_prepare(struct comp_dev *dev)
 
 	/* Register KPB for notification */
 	ret = notifier_register(dev, NULL, NOTIFIER_ID_KPB_CLIENT_EVT,
-				kpb_event_handler);
+				kpb_event_handler, 0);
 	if (ret < 0) {
 		kpb_free_history_buffer(kpb->hd.c_hb);
 		kpb->hd.c_hb = NULL;

--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -197,7 +197,7 @@ static struct dma_chan_data *dw_dma_channel_get(struct dma *dma,
 		atomic_add(&dma->num_channels_busy, 1);
 #if !CONFIG_HW_LLI
 		notifier_register(&dma->chan[i], &dma->chan[i],
-			NOTIFIER_ID_DMA_IRQ, dw_dma_chan_reload_lli_cb);
+			NOTIFIER_ID_DMA_IRQ, dw_dma_chan_reload_lli_cb, 0);
 #endif
 
 		/* return channel */

--- a/src/drivers/intel/cavs/hda-dma.c
+++ b/src/drivers/intel/cavs/hda-dma.c
@@ -23,6 +23,7 @@
 #include <ipc/topology.h>
 #include <user/trace.h>
 #include <errno.h>
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -134,6 +135,10 @@ struct hda_chan_data {
 
 	uint32_t period_bytes;
 	uint32_t buffer_bytes;
+
+	bool irq_disabled;	/**< indicates whether channel is used by the
+				  * pipeline scheduled on DMA
+				  */
 
 #if HDA_DMA_PTR_DBG
 	struct hda_dbg_data dbg_data;
@@ -657,6 +662,7 @@ static int hda_dma_set_config(struct dma_chan_data *channel,
 	hda_chan = dma_chan_get_data(channel);
 	hda_chan->period_bytes = period_bytes;
 	hda_chan->buffer_bytes = buffer_bytes;
+	hda_chan->irq_disabled = config->irq_disabled;
 
 	/* init channel in HW */
 	dma_chan_reg_write(channel, DGBBA, buffer_addr);

--- a/src/include/sof/lib/notifier.h
+++ b/src/include/sof/lib/notifier.h
@@ -8,6 +8,7 @@
 #ifndef __SOF_LIB_NOTIFIER_H__
 #define __SOF_LIB_NOTIFIER_H__
 
+#include <sof/bit.h>
 #include <sof/list.h>
 #include <sof/sof.h>
 #include <stdint.h>
@@ -16,6 +17,9 @@
 #define NOTIFIER_TARGET_CORE_MASK(x)	(1 << (x))
 #define NOTIFIER_TARGET_CORE_LOCAL	NOTIFIER_TARGET_CORE_MASK(cpu_get_id())
 #define NOTIFIER_TARGET_CORE_ALL_MASK	0xFFFFFFFF
+
+/** \brief Notifier flags. */
+#define NOTIFIER_FLAG_AGGREGATE		BIT(0)
 
 enum notify_id {
 	NOTIFIER_ID_CPU_FREQ = 0,		/* struct clock_notify_data * */

--- a/src/include/sof/lib/notifier.h
+++ b/src/include/sof/lib/notifier.h
@@ -51,7 +51,8 @@ struct notify_data {
 struct notify **arch_notify_get(void);
 
 int notifier_register(void *receiver, void *caller, enum notify_id type,
-		void (*cb)(void *arg, enum notify_id type, void *data));
+		      void (*cb)(void *arg, enum notify_id type, void *data),
+		      uint32_t flags);
 void notifier_unregister(void *receiver, void *caller, enum notify_id type);
 void notifier_unregister_all(void *receiver, void *caller);
 

--- a/src/include/sof/lib/notifier.h
+++ b/src/include/sof/lib/notifier.h
@@ -30,6 +30,8 @@ enum notify_id {
 	NOTIFIER_ID_BUFFER_CONSUME,		/* struct buffer_cb_transact* */
 	NOTIFIER_ID_BUFFER_FREE,		/* struct buffer_cb_free* */
 	NOTIFIER_ID_DMA_COPY,			/* struct dma_cb_data* */
+	NOTIFIER_ID_LL_PRE_RUN,			/* NULL */
+	NOTIFIER_ID_LL_POST_RUN,		/* NULL */
 	NOTIFIER_ID_DMA_IRQ,			/* struct dma_chan_data * */
 	NOTIFIER_ID_COUNT
 };

--- a/src/lib/notifier.c
+++ b/src/lib/notifier.c
@@ -15,6 +15,7 @@
 #include <sof/list.h>
 #include <sof/sof.h>
 #include <ipc/topology.h>
+#include <stdint.h>
 
 #define trace_notifier(__e, ...) \
 	trace_event(TRACE_CLASS_NOTIFIER, __e, ##__VA_ARGS__)
@@ -33,7 +34,8 @@ struct callback_handle {
 };
 
 int notifier_register(void *receiver, void *caller, enum notify_id type,
-		      void (*cb)(void *arg, enum notify_id type, void *data))
+		      void (*cb)(void *arg, enum notify_id type, void *data),
+		      uint32_t flags)
 {
 	struct notify *notify = *arch_notify_get();
 	struct callback_handle *handle;

--- a/src/platform/intel/cavs/include/cavs/lib/pm_runtime.h
+++ b/src/platform/intel/cavs/include/cavs/lib/pm_runtime.h
@@ -21,6 +21,7 @@ struct pm_runtime_data;
 /** \brief cAVS specific runtime power management data. */
 struct cavs_pm_runtime_data {
 	int dsp_d0_sref; /**< simple ref counter, accessed by core 0 only */
+	int host_dma_l1_sref; /**< ref counter for Host DMA accesses */
 };
 
 #endif

--- a/src/platform/intel/cavs/lib/pm_runtime.c
+++ b/src/platform/intel/cavs/lib/pm_runtime.c
@@ -81,16 +81,20 @@ static inline void cavs_pm_runtime_enable_dsp(bool enable)
 	irq_local_enable(flags);
 
 	trace_power("pm_runtime_enable_dsp dsp_d0_sref %d", pprd->dsp_d0_sref);
+
+	platform_shared_commit(pprd, sizeof(*pprd));
 }
 
 static inline bool cavs_pm_runtime_is_active_dsp(void)
 {
 	struct pm_runtime_data *prd = pm_runtime_data_get();
 	struct cavs_pm_runtime_data *pprd = prd->platform_data;
+	int is_active = pprd->dsp_d0_sref > 0;
 
 	platform_shared_commit(prd, sizeof(*prd));
+	platform_shared_commit(pprd, sizeof(*pprd));
 
-	return pprd->dsp_d0_sref > 0;
+	return is_active;
 }
 
 #if CONFIG_CAVS_SSP
@@ -368,7 +372,8 @@ void platform_pm_runtime_init(struct pm_runtime_data *prd)
 {
 	struct cavs_pm_runtime_data *pprd;
 
-	pprd = rzalloc(SOF_MEM_ZONE_SYS, 0, SOF_MEM_CAPS_RAM, sizeof(*pprd));
+	pprd = rzalloc(SOF_MEM_ZONE_SYS, SOF_MEM_FLAG_SHARED, SOF_MEM_CAPS_RAM,
+		       sizeof(*pprd));
 	prd->platform_data = pprd;
 }
 

--- a/src/probe/probe.c
+++ b/src/probe/probe.c
@@ -1038,9 +1038,9 @@ int probe_point_add(uint32_t count, struct probe_point *probe)
 			probe[i].stream_tag;
 
 		notifier_register(_probe, dev->cb, NOTIFIER_ID_BUFFER_PRODUCE,
-				  &probe_cb_produce);
+				  &probe_cb_produce, 0);
 		notifier_register(_probe, dev->cb, NOTIFIER_ID_BUFFER_FREE,
-				  &probe_cb_free);
+				  &probe_cb_free, 0);
 	}
 
 	return 0;

--- a/src/schedule/dma_single_chan_domain.c
+++ b/src/schedule/dma_single_chan_domain.c
@@ -247,7 +247,7 @@ static int dma_single_chan_domain_register(struct ll_schedule_domain *domain,
 	/* register for source change notifications */
 	if (register_needed)
 		notifier_register(domain, NULL, NOTIFIER_ID_DMA_DOMAIN_CHANGE,
-				  dma_domain_changed);
+				  dma_domain_changed, 0);
 
 	dma_domain->owner = channel->core;
 

--- a/src/schedule/ll_schedule.c
+++ b/src/schedule/ll_schedule.c
@@ -175,9 +175,15 @@ static void schedule_ll_tasks_run(void *data)
 
 	perf_cnt_init(&sch->pcd);
 
+	notifier_event(sch, NOTIFIER_ID_LL_PRE_RUN,
+		       NOTIFIER_TARGET_CORE_LOCAL, NULL, 0);
+
 	/* run tasks if there are any pending */
 	if (schedule_ll_is_pending(sch))
 		schedule_ll_tasks_execute(sch, last_tick);
+
+	notifier_event(sch, NOTIFIER_ID_LL_POST_RUN,
+		       NOTIFIER_TARGET_CORE_LOCAL, NULL, 0);
 
 	perf_cnt_stamp(&sch->pcd, perf_ll_sched_trace, sch);
 

--- a/src/schedule/ll_schedule.c
+++ b/src/schedule/ll_schedule.c
@@ -530,7 +530,7 @@ int scheduler_init_ll(struct ll_schedule_domain *domain)
 
 	/* notification of clock changes */
 	notifier_register(sch, NULL, NOTIFIER_CLK_CHANGE_ID(domain->clk),
-			  ll_scheduler_notify);
+			  ll_scheduler_notify, 0);
 
 	scheduler_init(domain->type, &schedule_ll_ops, sch);
 

--- a/test/cmocka/src/notifier_mocks.c
+++ b/test/cmocka/src/notifier_mocks.c
@@ -50,7 +50,7 @@ void notifier_event(const void *caller, enum notify_id type, uint32_t core_mask,
 }
 
 int notifier_register(void *receiver, void *caller, enum notify_id type,
-	void (*cb)(void *arg, enum notify_id type, void *data))
+	void (*cb)(void *arg, enum notify_id type, void *data), uint32_t flags)
 {
 	struct notify *notify = *arch_notify_get();
 	struct callback_handle *handle;


### PR DESCRIPTION
Improves host component performance by extracting DMA L1 exit
to be executed commonly for all active DMA channels as registered
callback in low latency scheduler for timer domain. There is no
need to wait so many cycles for every channel separately.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>