### PR TITLE
Enable test bench test in simple scripts and test in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ services:
 stages:
   - test
   - qemutest
+  - testbench
 
 before_install:
   - docker pull thesofproject/sof && docker tag thesofproject/sof sof
@@ -74,3 +75,8 @@ jobs:
       env: PLATFORM=imx8x
     - <<: *qemuboottest
       env: PLATFORM=imx8m
+    - stage: testbench
+      script:
+        - ./scripts/docker-run.sh ./scripts/build-tools.sh -t &> /dev/null
+        - ./scripts/docker-run.sh ./scripts/host-build-all.sh
+        - ./scripts/host-testbench.sh

--- a/tools/test/audio/comp_run.sh
+++ b/tools/test/audio/comp_run.sh
@@ -16,7 +16,7 @@ HOST_ROOT=../../testbench/build_testbench
 HOST_EXE=$HOST_ROOT/install/bin/testbench
 HOST_LIB=$HOST_ROOT/sof_ep/install/lib
 TPLG_LIB=$HOST_ROOT/sof_parser/install/lib
-TPLG_DIR=../../test/topology
+TPLG_DIR=../../build_tools/test/topology
 
 # Use topology from component test topologies
 INFMT=s${BITS_IN}le


### PR DESCRIPTION
Update the host-testbench scripts to test 3 simple testbench
volume, src and eqiir.
Enable Travis CI test for the testbench with this script.