### PR TITLE
Remove unnecessary cast on void pointer

### DIFF
--- a/src/audio/src/src_hifi2ep.c
+++ b/src/audio/src/src_hifi2ep.c
@@ -55,7 +55,7 @@ static inline void fir_filter(ae_q32s *rp, const void *cp, ae_q32s *wp0,
 		AE_LP24F_C(p0, dp, -sizeof(ae_p24f));
 
 		/* Reset coefficient pointer and clear accumulator */
-		coefp = (ae_p16x2s *)cp;
+		coefp = cp;
 		a0 = AE_ZEROQ56();
 		a1 = AE_ZEROQ56();
 
@@ -113,7 +113,7 @@ static inline void fir_filter(ae_q32s *rp, const void *cp, ae_q32s *wp0,
 		AE_LP24F_C(p0, dp, -sizeof(ae_p24f));
 
 		/* Reset coefficient pointer and clear accumulator */
-		coefp = (ae_p16x2s *)cp;
+		coefp = cp;
 		a0 = AE_ZEROQ56();
 
 		/* Compute FIR filter for current channel with four
@@ -187,7 +187,7 @@ static inline void fir_filter(ae_q32s *rp, const void *cp, ae_q32s *wp0,
 		AE_LP24F_C(p0, dp, -sizeof(ae_p24f));
 
 		/* Reset coefficient pointer and clear accumulator */
-		coefp = (ae_p24x2f *)cp;
+		coefp = cp;
 		a0 = AE_ZEROQ56();
 		a1 = AE_ZEROQ56();
 
@@ -249,7 +249,7 @@ static inline void fir_filter(ae_q32s *rp, const void *cp, ae_q32s *wp0,
 		AE_LP24F_C(p0, dp, -sizeof(ae_p24f));
 
 		/* Reset coefficient pointer and clear accumulator */
-		coefp = (ae_p24x2f *)cp;
+		coefp = cp;
 		a0 = AE_ZEROQ56();
 
 		/* Compute FIR filter for current channel with four

--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -87,7 +87,7 @@ static void vol_sync_host(struct comp_dev *dev, unsigned int num_channels)
  */
 static enum task_state vol_work(void *data)
 {
-	struct comp_dev *dev = (struct comp_dev *)data;
+	struct comp_dev *dev = data;
 	struct comp_data *cd = comp_get_drvdata(dev);
 	int32_t vol;
 	int again = 0;

--- a/src/trace/dma-trace.c
+++ b/src/trace/dma-trace.c
@@ -367,7 +367,7 @@ void dma_trace_flush(void *t)
 	}
 
 	/* invalidate trace data */
-	dcache_invalidate_region((void *)t, size);
+	dcache_invalidate_region(t, size);
 
 	/* check for buffer wrap */
 	if ((char *)buffer->w_ptr - size < (char *)buffer->addr) {
@@ -385,7 +385,7 @@ void dma_trace_flush(void *t)
 	}
 
 	/* writeback trace data */
-	dcache_writeback_region((void *)t, size);
+	dcache_writeback_region(t, size);
 
 	platform_shared_commit(trace_data, sizeof(*trace_data));
 }


### PR DESCRIPTION
Assignment to a typed pointer is sufficient in C.
No cast is needed.

Signed-off-by: Simran Singhal <singhalsimran0@gmail.com>