### PR TITLE
Clear small issues found by Coccinelle and Checkpatch.pl

### DIFF
--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -544,9 +544,7 @@ static int kpb_prepare(struct comp_dev *dev)
 static int kpb_cmd(struct comp_dev *dev, int cmd, void *data,
 		   int max_data_size)
 {
-	int ret = 0;
-
-	return ret;
+	return 0;
 }
 
 /**

--- a/src/drivers/intel/cavs/hda-dma.c
+++ b/src/drivers/intel/cavs/hda-dma.c
@@ -305,8 +305,6 @@ static void hda_dma_post_copy(struct dma_chan_data *chan, int bytes)
 
 static int hda_dma_link_copy_ch(struct dma_chan_data *chan, int bytes)
 {
-	int ret = 0;
-
 	tracev_hddma("hda-dmac: %d channel %d -> copy 0x%x bytes",
 		     chan->dma->plat_data.id, chan->index, bytes);
 
@@ -317,7 +315,7 @@ static int hda_dma_link_copy_ch(struct dma_chan_data *chan, int bytes)
 	hda_dma_get_dbg_vals(chan, HDA_DBG_POST, HDA_DBG_LINK);
 	hda_dma_ptr_trace(chan, "link copy", HDA_DBG_LINK);
 
-	return ret;
+	return 0;
 }
 
 /* lock should be held by caller */

--- a/test/cmocka/src/math/numbers/find_max_abs_int32.c
+++ b/test/cmocka/src/math/numbers/find_max_abs_int32.c
@@ -5,6 +5,7 @@
 // Author: Slawomir Blauciak <slawomir.blauciak@linux.intel.com>
 
 #include <sof/math/numbers.h>
+#include <sof/common.h>
 
 #include <stdarg.h>
 #include <stddef.h>
@@ -18,7 +19,7 @@ static void test_math_numbers_find_max_abs_int32_for_neg100_99_98_50_equals_100
 	(void)state;
 
 	int32_t vec[] = {-100, 99, 98, 50};
-	int r = find_max_abs_int32(vec, sizeof(vec) / sizeof(int32_t));
+	int r = find_max_abs_int32(vec, ARRAY_SIZE(vec));
 
 	assert_int_equal(r, 100);
 }
@@ -29,7 +30,7 @@ static void test_math_numbers_find_max_abs_int32_for_neg100_99_98_50_101_equals_
 	(void)state;
 
 	int32_t vec[] = {-100, 99, 98, 50, 101};
-	int r = find_max_abs_int32(vec, sizeof(vec) / sizeof(int32_t));
+	int r = find_max_abs_int32(vec, ARRAY_SIZE(vec));
 
 	assert_int_equal(r, 101);
 }

--- a/test/cmocka/src/math/numbers/find_min_int16.c
+++ b/test/cmocka/src/math/numbers/find_min_int16.c
@@ -5,6 +5,7 @@
 // Author: Slawomir Blauciak <slawomir.blauciak@linux.intel.com>
 
 #include <sof/math/numbers.h>
+#include <sof/common.h>
 
 #include <stdarg.h>
 #include <stddef.h>
@@ -17,7 +18,7 @@ static void test_math_numbers_find_min_int16_for_2_equals_2(void **state)
 	(void)state;
 
 	int16_t vec[] = {2};
-	int r = find_min_int16(vec, sizeof(vec) / sizeof(int16_t));
+	int r = find_min_int16(vec, ARRAY_SIZE(vec));
 
 	assert_int_equal(r, 2);
 }
@@ -28,7 +29,7 @@ static void test_math_numbers_find_min_int16_for_5_2_3_4_1_equals_1
 	(void)state;
 
 	int16_t vec[] = {5, 2, 3, 4, 1};
-	int r = find_min_int16(vec, sizeof(vec) / sizeof(int16_t));
+	int r = find_min_int16(vec, ARRAY_SIZE(vec));
 
 	assert_int_equal(r, 1);
 }


### PR DESCRIPTION
#### Changes commited:

1. Use ARRAY_SIZE:
    ARRAY_SIZE macro in <sof/common.h> is better used when computing array size.

2. Remove unneeded ret variable:
    Return immediately in case of having a ret variable that's always 0.