### PR TITLE
Call default comp_verify_params() from comp_params() if no handler defined in comp_ops

### DIFF
--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -481,40 +481,6 @@ static void eq_fir_free(struct comp_dev *dev)
 	rfree(dev);
 }
 
-static int eq_fir_verify_params(struct comp_dev *dev,
-				struct sof_ipc_stream_params *params)
-{
-	int ret;
-
-	comp_dbg(dev, "eq_fir_verify_params()");
-
-	ret = comp_verify_params(dev, 0, params);
-	if (ret < 0) {
-		comp_err(dev, "eq_fir_verify_params(): comp_verify_params() failed.");
-		return ret;
-	}
-
-	return 0;
-}
-
-/* set component audio stream parameters */
-static int eq_fir_params(struct comp_dev *dev,
-			 struct sof_ipc_stream_params *params)
-{
-	int err;
-
-	comp_info(dev, "eq_fir_params()");
-
-	err = eq_fir_verify_params(dev, params);
-	if (err < 0) {
-		comp_err(dev, "eq_fir_params(): pcm params verification failed.");
-		return -EINVAL;
-	}
-
-	/* All configuration work is postponed to prepare(). */
-	return 0;
-}
-
 static int fir_cmd_get_data(struct comp_dev *dev,
 			    struct sof_ipc_ctrl_data *cdata, int max_size)
 {
@@ -851,7 +817,6 @@ static const struct comp_driver comp_eq_fir = {
 	.ops = {
 		.create = eq_fir_new,
 		.free = eq_fir_free,
-		.params = eq_fir_params,
 		.cmd = eq_fir_cmd,
 		.trigger = eq_fir_trigger,
 		.copy = eq_fir_copy,

--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -306,46 +306,6 @@ static void volume_free(struct comp_dev *dev)
 	rfree(dev);
 }
 
-static int volume_verify_params(struct comp_dev *dev,
-				struct sof_ipc_stream_params *params)
-{
-	int ret;
-
-	comp_dbg(dev, "volume_verify_params()");
-
-	ret = comp_verify_params(dev, 0, params);
-	if (ret < 0) {
-		comp_err(dev, "volume_verify_params(): comp_verify_params() failed.");
-		return ret;
-	}
-
-	return 0;
-}
-
-/**
- * \brief Sets volume component audio stream parameters.
- * \param[in,out] dev Volume base component device.
- * \param[in] params Audio (PCM) stream parameters (ignored for this component)
- * \return Error code.
- *
- * All done in prepare() since we need to know source and sink component params.
- */
-static int volume_params(struct comp_dev *dev,
-			 struct sof_ipc_stream_params *params)
-{
-	int err;
-
-	comp_dbg(dev, "volume_params()");
-
-	err = volume_verify_params(dev, params);
-	if (err < 0) {
-		comp_err(dev, "vol_params(): pcm params verification failed.");
-		return -EINVAL;
-	}
-
-	return 0;
-}
-
 /**
  * \brief Sets channel target volume.
  * \param[in,out] dev Volume base component device.
@@ -786,7 +746,6 @@ static const struct comp_driver comp_volume = {
 	.ops	= {
 		.create		= volume_new,
 		.free		= volume_free,
-		.params		= volume_params,
 		.cmd		= volume_cmd,
 		.trigger	= volume_trigger,
 		.copy		= volume_copy,

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -263,6 +263,10 @@ struct comp_ops {
 	 * Sets component audio stream parameters.
 	 * @param dev Component device.
 	 * @param params Audio (PCM) stream parameters to be set.
+	 *
+	 * Infrastructure calls comp_verify_params() if this handler is not
+	 * defined, therefore it should be left NULL if no extra steps are
+	 * required.
 	 */
 	int (*params)(struct comp_dev *dev,
 		      struct sof_ipc_stream_params *params);

--- a/test/cmocka/src/audio/pipeline/pipeline_mocks.c
+++ b/test/cmocka/src/audio/pipeline/pipeline_mocks.c
@@ -122,3 +122,12 @@ void ipc_msg_send(struct ipc_msg *msg, void *data, bool high_priority)
 	(void)data;
 	(void)high_priority;
 }
+
+int comp_verify_params(struct comp_dev *dev, uint32_t flag,
+		       struct sof_ipc_stream_params *params)
+{
+	(void)dev;
+	(void)flag;
+	(void)params;
+	return 0;
+}


### PR DESCRIPTION
Unification of activities performed in params vs. prepare in other components could be considered and reviewed/simplified to make sure their behavior is consistent, e.g.

- mixer's verification inside params is done in prepare in other components (params cannot be completely removed in this case since custom flags to comp_verify_params() is provided),
- mux probably does not need another inner function,
etc.