### PR TITLE
Set ALH_CONFIG_DATA in DAI_ADD stage

### DIFF
--- a/tools/topology/m4/dai.m4
+++ b/tools/topology/m4/dai.m4
@@ -59,6 +59,7 @@ define(`W_DAI_OUT',
 `		"'N_DAI_OUT`_data_w_comp"'
 `		"'N_DAI_OUT`_data_str"'
 `		"'N_DAI_OUT`_data_comp_str"'
+`		ifdef(`SET_DAICONFIG',`"DAICONFIG.'N_DAI`_data"',`')'
 `	]'
 `}')
 

--- a/tools/topology/sof-icl-rt711-rt1308-rt715-hdmi.m4
+++ b/tools/topology/sof-icl-rt711-rt1308-rt715-hdmi.m4
@@ -145,11 +145,14 @@ DAI_ADD(sof/pipe-dai-playback.m4,
 	PIPELINE_SOURCE_4, 2, s24le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)',
 `ifdef(`MONO', `',
-`DAI_ADD_SCHED(sof/pipe-dai-sched-playback.m4,
+`define(`SET_DAICONFIG',`')
+ALH_CONFIG_DATA(ALH, 0x202, 48000, 2)
+DAI_ADD_SCHED(sof/pipe-dai-sched-playback.m4,
 	4, ALH, 0x202, SDW1-Playback,
 	PIPELINE_SOURCE_4, 2, s24le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER,
 	PIPELINE_PLAYBACK_SCHED_COMP_3)
+undefine(`SET_DAICONFIG',`')
 
 # Connect demux to 2nd pipeline
 SectionGraph."PIPE_DEMUX" {


### PR DESCRIPTION
Currently, we set ALH_CONFIG_DATA as a part of DAI_CONFIG. However,
DAI_CONFIG is only used when we want to connect the DAI to a BE.
So set ALH_CONFIG_DATA in DAI_ADD stage for the DAI which is not configured
by DAI_CONFIG.