### PR TITLE
cmake: add *_overridedefconfig targets

### DIFF
--- a/scripts/cmake/defconfigs.cmake
+++ b/scripts/cmake/defconfigs.cmake
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 # Looks for defconfig files in arch directory
-set(DEFCONFIGS_DIRECTORY "${PROJECT_SOURCE_DIR}/src/arch/${ARCH}/configs/*_defconfig")
-file(GLOB DEFCONFIG_PATHS ${DEFCONFIGS_DIRECTORY})
+set(DEFCONFIGS_DIRECTORY "${PROJECT_SOURCE_DIR}/src/arch/${ARCH}/configs")
+file(GLOB DEFCONFIG_PATHS "${DEFCONFIGS_DIRECTORY}/*_defconfig")
 
 # Adds dependency on defconfigs directory
 set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${DEFCONFIGS_DIRECTORY})

--- a/scripts/cmake/defconfigs.cmake
+++ b/scripts/cmake/defconfigs.cmake
@@ -27,3 +27,27 @@ foreach(defconfig_path ${DEFCONFIG_PATHS})
 		USES_TERMINAL
 	)
 endforeach()
+
+set(OVERRIDE_DEFCONFIGS_DIRECTORY "${DEFCONFIGS_DIRECTORY}/override")
+file(GLOB OVERRIDE_DEFCONFIGS_PATHS "${OVERRIDE_DEFCONFIGS_DIRECTORY}/*.config")
+
+foreach(config_path ${OVERRIDE_DEFCONFIGS_PATHS})
+	get_filename_component(config_name ${config_path} NAME_WE)
+	add_custom_target(
+		"${config_name}_overridedefconfig"
+		COMMAND ${CMAKE_COMMAND} -E copy
+			${config_path}
+			${PROJECT_BINARY_DIR}/override.config
+		COMMAND ${CMAKE_COMMAND} -E env
+			srctree=${PROJECT_SOURCE_DIR}
+			CC_VERSION_TEXT=${CC_VERSION_TEXT}
+			ARCH=${ARCH}
+			${PYTHON3} ${PROJECT_SOURCE_DIR}/scripts/kconfig/overrideconfig.py
+			${PROJECT_SOURCE_DIR}/Kconfig
+			${PROJECT_BINARY_DIR}/override.config
+		WORKING_DIRECTORY ${GENERATED_DIRECTORY}
+		COMMENT "Applying overrideconfig with ${config_name}"
+		VERBATIM
+		USES_TERMINAL
+	)
+endforeach()


### PR DESCRIPTION
Add targets that are meant to be used after defconfig,
to apply configs from <arch>/configs/override on top of defconfigs.
 
Follow up to #2641 