### PR TITLE
Fix copy limits lock

### DIFF
--- a/src/audio/dcblock/dcblock.c
+++ b/src/audio/dcblock/dcblock.c
@@ -301,7 +301,6 @@ static int dcblock_copy(struct comp_dev *dev)
 	struct comp_copy_limits cl;
 	struct comp_buffer *sourceb;
 	struct comp_buffer *sinkb;
-	uint32_t flags = 0;
 
 	comp_dbg(dev, "dcblock_copy()");
 
@@ -310,14 +309,8 @@ static int dcblock_copy(struct comp_dev *dev)
 	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer,
 				source_list);
 
-	buffer_lock(sinkb, &flags);
-	buffer_lock(sourceb, &flags);
-
 	/* Get source, sink, number of frames etc. to process. */
-	comp_get_copy_limits(sourceb, sinkb, &cl);
-
-	buffer_unlock(sinkb, flags);
-	buffer_unlock(sourceb, flags);
+	comp_get_copy_limits_with_lock(sourceb, sinkb, &cl);
 
 	dcblock_process(dev, sourceb, sinkb,
 			cl.frames, cl.source_bytes, cl.sink_bytes);

--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -719,7 +719,6 @@ static int eq_fir_copy(struct comp_dev *dev)
 	struct comp_data *cd = comp_get_drvdata(dev);
 	int ret;
 	int n;
-	uint32_t flags = 0;
 
 	comp_dbg(dev, "eq_fir_copy()");
 
@@ -741,14 +740,8 @@ static int eq_fir_copy(struct comp_dev *dev)
 	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer,
 				source_list);
 
-	buffer_lock(sourceb, &flags);
-	buffer_lock(sinkb, &flags);
-
 	/* Get source, sink, number of frames etc. to process. */
-	comp_get_copy_limits(sourceb, sinkb, &cl);
-
-	buffer_unlock(sinkb, flags);
-	buffer_unlock(sourceb, flags);
+	comp_get_copy_limits_with_lock(sourceb, sinkb, &cl);
 
 	/*
 	 * Process only even number of frames with the FIR function. The

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -808,7 +808,6 @@ static int eq_iir_copy(struct comp_dev *dev)
 	struct comp_buffer *sourceb;
 	struct comp_buffer *sinkb;
 	int ret;
-	uint32_t flags = 0;
 
 	comp_dbg(dev, "eq_iir_copy()");
 
@@ -830,14 +829,8 @@ static int eq_iir_copy(struct comp_dev *dev)
 	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer,
 				source_list);
 
-	buffer_lock(sourceb, &flags);
-	buffer_lock(sinkb, &flags);
-
 	/* Get source, sink, number of frames etc. to process. */
-	comp_get_copy_limits(sourceb, sinkb, &cl);
-
-	buffer_unlock(sinkb, flags);
-	buffer_unlock(sourceb, flags);
+	comp_get_copy_limits_with_lock(sourceb, sinkb, &cl);
 
 	/* Run EQ function */
 	eq_iir_process(dev, sourceb, sinkb, cl.frames, cl.source_bytes,

--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -655,7 +655,6 @@ static int volume_copy(struct comp_dev *dev)
 	struct comp_data *cd = comp_get_drvdata(dev);
 	struct comp_buffer *source;
 	struct comp_buffer *sink;
-	uint32_t flags = 0;
 
 	comp_dbg(dev, "volume_copy()");
 
@@ -668,14 +667,8 @@ static int volume_copy(struct comp_dev *dev)
 	sink = list_first_item(&dev->bsink_list, struct comp_buffer,
 			       source_list);
 
-	buffer_lock(source, &flags);
-	buffer_lock(sink, &flags);
-
 	/* Get source, sink, number of frames etc. to process. */
-	comp_get_copy_limits(source, sink, &c);
-
-	buffer_unlock(sink, flags);
-	buffer_unlock(source, flags);
+	comp_get_copy_limits_with_lock(source, sink, &c);
 
 	comp_dbg(dev, "volume_copy(), source_bytes = 0x%x, sink_bytes = 0x%x",
 		 c.source_bytes, c.sink_bytes);

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -662,10 +662,13 @@ static inline void comp_overrun(struct comp_dev *dev, struct comp_buffer *sink,
 /** @}*/
 
 /**
- * Called by component in copy.
- * @param source Source buffer.
- * @param sink Sink buffer.
- * @param cl Struct of parameters for use in copy function.
+ * Computes source to sink copy operation boundaries including maximum number
+ * of frames that can be transferred (data available in source vs. free space
+ * available in sink).
+ *
+ * @param[in] source Source buffer.
+ * @param[in] sink Sink buffer.
+ * @param[out] cl Current copy limits.
  */
 void comp_get_copy_limits(struct comp_buffer *source, struct comp_buffer *sink,
 			  struct comp_copy_limits *cl);

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -674,6 +674,31 @@ void comp_get_copy_limits(struct comp_buffer *source, struct comp_buffer *sink,
 			  struct comp_copy_limits *cl);
 
 /**
+ * Version of comp_get_copy_limits that locks both buffers to guarantee
+ * consistent state readings.
+ *
+ * @param[in] source Source buffer.
+ * @param[in] sink Sink buffer
+ * @param[out] cl Current copy limits.
+ */
+static inline
+void comp_get_copy_limits_with_lock(struct comp_buffer *source,
+				    struct comp_buffer *sink,
+				    struct comp_copy_limits *cl)
+{
+	uint32_t source_flags = 0;
+	uint32_t sink_flags = 0;
+
+	buffer_lock(source, &source_flags);
+	buffer_lock(sink, &sink_flags);
+
+	comp_get_copy_limits(source, sink, cl);
+
+	buffer_unlock(sink, sink_flags);
+	buffer_unlock(source, source_flags);
+}
+
+/**
  * Called by component in  params() function in order to set and update some of
  * downstream (playback) or upstream (capture) buffer parameters with pcm
  * parameters. There is a possibility to specify which of parameters won't be


### PR DESCRIPTION
Grouping the operations in a function simplifies the components code. It also
guarantees correct double lock with dedicated flags and helps avoid a common bug
in client code where single flags variable is used for both locks. When both
buffers are shared between cores, and single variable is used, the rsil in
second lock returns int level 5 set by the first lock. Later, during unlocking
the original level returned by the first lock is not restored, the dsp stays on
level 5.

Note: it might not be visible on a system which runs the pipeline_copy on level 5 (which is the case for current xtensa arch configuration in sof as ll-scheduler disables local ints by setting 5 into PS.INTLEVEL, so inner spin_lock_irq-s have no real effect).