### PR TITLE
Tools: Add tests for processing components

### DIFF
--- a/tools/test/audio/dcblock_run.sh
+++ b/tools/test/audio/dcblock_run.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# SPDX-License-Identifier: BSD-3-Clause
+
+usage ()
+{
+    echo "Usage:   $0 <bits in> <bits out> <rate> <input> <output>"
+    echo "Example: $0 16 16 48000 input.raw output.raw"
+}
+
+main ()
+{
+    local COMP DIRECTION
+
+    if [ $# -ne 5 ]; then
+	usage "$0"
+	exit
+    fi
+
+    COMP=dcblock
+    DIRECTION=playback
+
+    ./comp_run.sh $COMP $DIRECTION "$1" "$2" "$3" "$3" "$4" "$5"
+}
+
+main "$@"

--- a/tools/test/audio/process_test.m
+++ b/tools/test/audio/process_test.m
@@ -1,0 +1,408 @@
+function  [n_fail, n_pass, n_na] = process_test(comp, bits_in_list, bits_out_list, fs)
+
+% process_test - test objective audio quality parameters
+%
+% process_test(comp, bits_in_list, bits_out_list, fs)
+
+% SPDX-License-Identifier: BSD-3-Clause
+% Copyright(c) 2017-202 Intel Corporation. All rights reserved.
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+
+%% Defaults for call parameters
+if nargin < 1
+	comp = 'EQIIR';
+end
+
+if nargin < 2
+	bits_in_list = [16 32];
+end
+
+if nargin < 3
+	bits_out_list = [16 32];
+end
+
+if nargin < 4
+	fs = 48e3;
+end
+
+%% Paths
+blobpath = '../../topology/m4';
+plots = 'plots';
+reports = 'reports';
+
+t.comp = comp;
+t.blob = fullfile(blobpath, 'eq_iir_coef_flat.m4');
+%t.blob = fullfile(blobpath, 'eq_iir_coef_loudness.m4');
+%t.comp = 'EQIIR';
+%t.comp = 'EQFIR';
+%t.comp = 'volume';
+%t.comp = 'DCblock';
+
+%% Defaults for test
+t.fmt = 'raw';              % Can be 'raw' (fast binary) or 'txt' (debug)
+t.fs = fs;                  % Sample rate from func params
+t.nch = 2;                  % Number of channels
+t.ch = [1 2];               % Test channel 1
+t.bits_in = bits_in_list;   % Input word length from func params
+t.bits_out = bits_out_list; % Output word length from func params
+t.full_test = 1;            % 0 is quick check only, 1 is full set
+
+%% Show graphics or not. With visible plot windows Octave may freeze if too
+%  many windows are kept open. As workaround setting close windows to
+%  1 shows only flashing windows while the test proceeds. With
+%  visibility set to to 0 only console text is seen. The plots are
+%  exported into plots directory in png format and can be viewed from
+%  there.
+t.plot_close_windows = 0;  % Workaround for visible windows if Octave hangs
+t.plot_visible = 'on';     % Use off for batch tests and on for interactive
+t.files_delete = 0;        % Set to 0 to inspect the audio data files
+
+%% Prepare
+addpath('std_utils');
+addpath('test_utils');
+addpath('../../tune/eq');
+mkdir_check(plots);
+mkdir_check(reports);
+n_meas = 5;
+n_bits_in = length(bits_in_list);
+n_bits_out = length(bits_out_list);
+r.bits_in_list = bits_in_list;
+r.bits_out_list = bits_out_list;
+r.g = NaN(n_bits_in, n_bits_out);
+r.dr = NaN(n_bits_in, n_bits_out);
+r.thdnf = NaN(n_bits_in, n_bits_out);
+r.pf = -ones(n_bits_in, n_bits_out, n_meas);
+r.n_fail = 0;
+r.n_pass = 0;
+r.n_skipped = 0;
+r.n_na = 0;
+
+%% Loop all modes to test
+for b = 1:n_bits_out
+	for a = 1:n_bits_in
+		v = -ones(n_meas,1); % Set pass/fail test verdict to not executed
+		tn = 1;
+		t.bits_in = bits_in_list(a);
+		t.bits_out = bits_out_list(b);
+
+                v(1) = chirp_test(t);
+		if v(1) ~= -1 && t.full_test
+			[v(2) g] = g_test(t);
+			[v(3) dr] = dr_test(t);
+			[v(4) thdnf] = thdnf_test(t);
+			v(5) = fr_test(t);
+
+			% TODO: Collect results for all channels, now get worst-case
+			r.g(a, b) = g(1);
+			r.dr(a, b) = min(dr);
+			r.thdnf(a, b) = max(thdnf);
+			r.pf(a, b, :) = v;
+		end
+
+		%% Done, store pass/fail
+		if v(1) ~= -1
+			idx = find(v > 0);
+			r.n_fail = r.n_fail + length(idx);
+			idx = find(v == 0);
+			r.n_pass = r.n_pass + length(idx);
+			idx = find(v == -1);
+			r.n_skipped = r.n_skipped + length(idx);
+			idx = find(v == -2);
+			r.n_na = r.n_na + length(idx);
+		end
+	end
+end
+
+%% Print table with test summary: Gain
+fn = sprintf('%s/g_%s.txt', reports, t.comp);
+print_val(t.comp, 'Gain (dB)', fn, bits_in_list, bits_out_list, r.g, r.pf);
+
+%% Print table with test summary: THD+N vs. frequency
+fn = sprintf('%s/thdnf_%s.txt', reports, t.comp);
+print_val(t.comp, 'Worst-case THD+N vs. frequency', fn, bits_in_list, bits_out_list, r.thdnf, r.pf);
+
+%% Print table with test summary: DR
+fn = sprintf('%s/dr_%s.txt', reports, t.comp);
+print_val(t.comp, 'Dynamic range (dB CCIR-RMS)', fn, bits_in_list, bits_out_list, r.dr, r.pf);
+
+%% Print table with test summary: pass/fail
+fn = 'reports/pf_src.txt';
+print_pf(t.comp', fn, bits_in_list, bits_out_list, r.pf);
+
+fprintf('\n');
+fprintf('Number of passed tests = %d\n', r.n_pass);
+fprintf('Number of failed tests = %d\n', r.n_fail);
+fprintf('Number of non-applicable tests = %d\n', r.n_na);
+fprintf('Number of skipped tests = %d\n', r.n_skipped);
+
+
+if r.n_fail > 0 || r.n_pass < 1
+	fprintf('\nERROR: TEST FAILED!!!\n');
+else
+	fprintf('\nTest passed.\n');
+end
+
+n_fail = r.n_fail;
+n_pass = r.n_pass;
+n_na = r.n_na;
+
+%% Done
+end
+
+
+%%
+%% Test execution with help of common functions
+%%
+
+function fail = chirp_test(t)
+
+fprintf('Spectrogram test %d Hz ...\n', t.fs);
+
+% Create input file
+test = test_defaults(t);
+test = chirp_test_input(test);
+
+% Run test
+test = test_run_process(test, t);
+
+% Analyze
+test = chirp_test_analyze(test);
+test_result_print(t, 'Continuous frequency sweep', 'chirpf');
+
+% Delete files unless e.g. debugging and need data to run
+delete_check(t.files_delete, test.fn_in);
+delete_check(t.files_delete, test.fn_out);
+
+fail = test.fail;
+end
+
+
+%% Reference: AES17 6.2.2 Gain
+function [fail, g_db] = g_test(t)
+
+test = test_defaults(t);
+
+% Create input file
+test = g_test_input(test);
+
+% Run test
+test = test_run_process(test, t);
+
+% EQ gain at test frequency
+channel = 1;
+h = eq_blob_plot(t.blob, 'iir', test.fs, test.f, 0);
+test.g_db_expect = h.m(channel);
+
+% Measure
+test = g_test_measure(test);
+
+% Get output parameters
+fail = test.fail;
+g_db = test.g_db;
+delete_check(t.files_delete, test.fn_in);
+delete_check(t.files_delete, test.fn_out);
+
+end
+
+%% Reference: AES17 6.4.1 Dynamic range
+function [fail, dr_db] = dr_test(t)
+
+test = test_defaults(t);
+
+% Create input file
+test = dr_test_input(test);
+
+% Run test
+test = test_run_process(test, t);
+
+% Measure
+test = dr_test_measure(test);
+
+% Get output parameters
+fail = test.fail;
+dr_db = test.dr_db;
+delete_check(t.files_delete, test.fn_in);
+delete_check(t.files_delete, test.fn_out);
+
+end
+
+%% Reference: AES17 6.3.2 THD+N ratio vs. frequency
+function [fail, thdnf] = thdnf_test(t)
+
+test = test_defaults(t);
+
+% Create input file
+test = thdnf_test_input(test);
+
+% Run test
+test = test_run_process(test, t);
+
+% Measure
+test = thdnf_test_measure(test);
+
+% For EQ use the -20dBFS result and ignore possible -1 dBFS fail
+thdnf = max(test.thdnf_low);
+if thdnf > test.thdnf_max
+  fail = 1;
+else
+  fail = 0;
+end
+delete_check(t.files_delete, test.fn_in);
+delete_check(t.files_delete, test.fn_out);
+
+% Print
+test_result_print(t, 'THD+N ratio vs. frequency', 'THDNF');
+
+end
+
+
+%% Reference: AES17 6.2.3 Frequency response
+function [fail, pm_range_db, range_hz, fr3db_hz] = fr_test(t)
+
+test = test_defaults(t);
+
+% Create input file
+test = fr_test_input(test);
+
+% Run test
+test = test_run_process(test, t);
+
+% Measure
+test = eq_mask(test, t, 0.5);
+test = fr_test_measure(test);
+
+fail = test.fail;
+pm_range_db = test.rp;
+range_hz = [test.f_lo test.f_hi];
+fr3db_hz = test.fr3db_hz;
+delete_check(t.files_delete, test.fn_in);
+delete_check(t.files_delete, test.fn_out);
+
+% Print
+test_result_print(t, 'Frequency response', 'FR', test.ph, test.fh);
+
+end
+
+%% Helper functions
+
+% Create mask from theoretical frequency response calculated from coefficients
+% and align mask to be relative 997 Hz response
+function test = eq_mask(test, t, tol)
+
+if ~strcmp(lower(test.comp), 'eqiir') && ~strcmp(lower(test.comp), 'eqfir')
+	return
+end
+
+test.fr_mask_f = [];
+test.fr_mask_lo = [];
+test.fr_mask_hi = [];
+
+j = 1;
+for channel = t.ch
+	h = eq_blob_plot(t.blob, 'iir', test.fs, test.f, 0);
+	i997 = find(test.f > 997, 1, 'first')-1;
+	m = h.m(:, channel) - h.m(i997, channel);
+	test.fr_mask_f = test.f;
+	test.fr_mask_lo(:,j) = m-tol;
+	test.fr_mask_hi(:,j) = m+tol;
+	j = j + 1;
+end
+
+end
+
+function test = test_defaults(t)
+
+test.comp = t.comp;
+test.fmt = t.fmt;
+test.bits_in = t.bits_in;
+test.bits_out = t.bits_out;
+test.nch = t.nch;
+test.ch = t.ch;
+test.fs = t.fs;
+test.plot_visible = t.plot_visible;
+
+% Misc
+test.quick = 0;
+test.att_rec_db = 0;
+
+% Plotting
+test.plot_channels_combine = 1;
+test.plot_thdn_axis = [10 100e3 -180 -50];
+test.plot_fr_axis = [10 100e3 -20 10 ];
+test.plot_passband_zoom = 0;
+
+% Test constraints
+test.f_start = 20;
+test.f_end = test.fs * 0.41667; % 20 kHz @ 48 kHz
+test.fu = test.fs * 0.41667;    % 20 kHz @ 48 kHz
+test.f_lo = 20;                 % For response reporting, measure from 20 Hz
+test.f_hi = 0.999*t.fs/2 ;      % to designed filter upper frequency
+test.f_max = 0.999*t.fs/2;      % Measure up to min. Nyquist frequency
+test.fs1 = test.fs;
+test.fs2 = test.fs;
+
+% Pass criteria
+test.g_db_tol = 0.1;            % Allow 0.1 dB gain variation
+test.thdnf_max = -50;           % Max. THD+N over frequency for -20 dBFS
+test.dr_db_min = 80;            % Min. DR
+test.fr_rp_max_db = 0.1;        % Allow 0.1 dB frequency response ripple
+
+% A generic relaxed frequency response mask
+test.fr_mask_f = [ 100 400 7000 ];
+for i = 1:t.nch
+	test.fr_mask_lo(:,i) = [-9 -1 -1 ];
+	test.fr_mask_hi(:,i) = [ 1  1  1 ];
+end
+
+end
+
+function test = test_run_process(test, t)
+
+switch lower(test.comp)
+	case 'eqiir'
+		test.ex = './eqiir_run.sh';
+	case 'eqfir'
+		test.ex = './eqiir_run.sh';
+	case 'dcblock'
+		test.ex = './dcblock_run.sh';
+	case 'volume'
+		test.ex = './volume_run.sh';
+	otherwise
+		error('Unknown component');
+end
+
+test.arg = { num2str(test.bits_in) num2str(test.bits_out) ...
+	     num2str(test.fs), test.fn_in, test.fn_out };
+delete_check(1, test.fn_out);
+test = test_run(test);
+
+end
+
+function test_result_print(t, testverbose, testacronym, ph, fh)
+
+tstr = sprintf('%s %s %d-%d %d Hz', ...
+	       testverbose, t.comp, t.bits_in, t.bits_out, t.fs);
+if nargin > 3
+	nph = length(ph);
+	for i=1:nph
+		title(ph(i), tstr);
+	end
+else
+	title(tstr);
+end
+
+if nargin > 4
+	nfh = length(fh);
+	for i=1:nfh
+		figure(fh(i));
+		pfn = sprintf('plots/%s_%s_%d_%d_%d_%d.png', ...
+			      testacronym, t.comp, ...
+			      t.bits_in, t.bits_out, t.fs, i);
+		print(pfn, '-dpng');
+	end
+else
+	pfn = sprintf('plots/%s_%s_%d_%d_%d.png', ...
+		      testacronym, t.comp, t.bits_in, t.bits_out, t.fs);
+	print(pfn, '-dpng');
+end
+end

--- a/tools/test/audio/src_test.m
+++ b/tools/test/audio/src_test.m
@@ -121,43 +121,45 @@ for b = 1:n_fso
         end
 end
 
+%% Scale frequencies to kHz
+k = 1/1000;
+
 %% Print table with test summary: Gain
 fn = 'reports/g_src.txt';
-print_val(fn, fs_in_list, fs_out_list, r.g, r.pf, 'Gain dB');
+print_val('SRC', 'Gain dB', fn, k * fs_in_list, k * fs_out_list, r.g, r.pf);
 
 %% Print table with test summary: FR
 fn = 'reports/fr_src.txt';
-print_fr(fn, fs_in_list, fs_out_list, r.fr_db, r.fr_hz, r.pf);
+print_fr('SRC', fn, k * fs_in_list, k * fs_out_list, r.fr_db, r.fr_hz, r.pf);
 
 %% Print table with test summary: FR
 fn = 'reports/fr_src.txt';
-print_val(fn, fs_in_list, fs_out_list, r.fr3db_hz/1e3, r.pf, ...
-        'Frequency response -3 dB 0 - X kHz');
+print_val('SRC', 'Frequency response -3 dB 0 - X kHz', ...
+	  fn, k * fs_in_list, k * fs_out_list, r.fr3db_hz/1e3, r.pf);
 
 %% Print table with test summary: THD+N vs. frequency
 fn = 'reports/thdnf_src.txt';
-print_val(fn, fs_in_list, fs_out_list, r.thdnf, r.pf, ...
-        'Worst-case THD+N vs. frequency');
+print_val('SRC', 'Worst-case THD+N vs. frequency', ...
+	  fn, k * fs_in_list, k * fs_out_list, r.thdnf, r.pf);
 
 %% Print table with test summary: DR
 fn = 'reports/dr_src.txt';
-print_val(fn, fs_in_list, fs_out_list, r.dr, r.pf, ...
-        'Dynamic range dB (CCIR-RMS)');
+print_val('SRC', 'Dynamic range dB (CCIR-RMS)', ...
+	  fn, k * fs_in_list, k * fs_out_list, r.dr, r.pf);
 
 %% Print table with test summary: AAP
 fn = 'reports/aap_src.txt';
-print_val(fn, fs_in_list, fs_out_list, r.aap, r.pf, ...
-        'Attenuation of alias products dB');
+print_val('SRC', 'Attenuation of alias products dB', ...
+	  fn, k * fs_in_list, k * fs_out_list, r.aap, r.pf);
 
 %% Print table with test summary: AIP
 fn = 'reports/aip_src.txt';
-print_val(fn, fs_in_list, fs_out_list, r.aip, r.pf, ...
-        'Attenuation of image products dB');
-
+print_val('SRC', 'Attenuation of image products dB', ...
+	  fn, k * fs_in_list, k * fs_out_list, r.aip, r.pf);
 
 %% Print table with test summary: pass/fail
 fn = 'reports/pf_src.txt';
-print_pf(fn, fs_in_list, fs_out_list, r.pf);
+print_pf('SRC', fn, k * fs_in_list, k * fs_out_list, r.pf);
 
 fprintf('\n');
 fprintf('Number of passed tests = %d\n', r.n_pass);
@@ -456,148 +458,4 @@ pfn = sprintf('plots/%s_src_%d_%d.png', testacronym, t.fs1, t.fs2);
 if t.plot_close_windows
 	close all;
 end
-end
-
-%% The next are results printing functions
-
-function  print_val(fn, fs_in_list, fs_out_list, val, pf, valstr)
-n_fsi = length(fs_in_list);
-n_fso = length(fs_out_list);
-fh = fopen(fn,'w');
-fprintf(fh,'\n');
-fprintf(fh,'SRC test result: %s\n', valstr);
-fprintf(fh,'%8s, ', 'in \ out');
-for a = 1:n_fso-1
-        fprintf(fh,'%8.1f, ', fs_out_list(a)/1e3);
-end
-fprintf(fh,'%8.1f', fs_out_list(n_fso)/1e3);
-fprintf(fh,'\n');
-for a = 1:n_fsi
-        fprintf(fh,'%8.1f, ', fs_in_list(a)/1e3);
-	for b = 1:n_fso
-                if pf(a,b,1) < 0
-                        cstr = 'x';
-                else
-                        if isnan(val(a,b))
-                                cstr = '-';
-                        else
-                                cstr = sprintf('%8.2f', val(a,b));
-                        end
-                end
-                if b < n_fso
-                        fprintf(fh,'%8s, ', cstr);
-                else
-                        fprintf(fh,'%8s', cstr);
-                end
-        end
-        fprintf(fh,'\n');
-end
-fclose(fh);
-type(fn);
-end
-
-function print_fr(fn, fs_in_list, fs_out_list, fr_db, fr_hz, pf)
-n_fsi = length(fs_in_list);
-n_fso = length(fs_out_list);
-fh = fopen(fn,'w');
-fprintf(fh,'\n');
-fprintf(fh,'SRC test result: Frequency response +/- X.XX dB (YY.Y kHz) \n');
-fprintf(fh,'%8s, ', 'in \ out');
-for a = 1:n_fso-1
-        fprintf(fh,'%12.1f, ', fs_out_list(a)/1e3);
-end
-fprintf(fh,'%12.1f', fs_out_list(n_fso)/1e3);
-fprintf(fh,'\n');
-for a = 1:n_fsi
-        fprintf(fh,'%8.1f, ', fs_in_list(a)/1e3);
-	for b = 1:n_fso
-                if pf(a,b,1) < 0
-                        cstr = 'x';
-                else
-                        cstr = sprintf('%4.2f (%4.1f)', fr_db(a,b), fr_hz(a,b,2)/1e3);
-                end
-                if b < n_fso
-                        fprintf(fh,'%12s, ', cstr);
-                else
-                        fprintf(fh,'%12s', cstr);
-                end
-        end
-        fprintf(fh,'\n');
-end
-fclose(fh);
-type(fn);
-end
-
-function print_fr3db(fn, fs_in_list, fs_out_list, fr3db_hz, pf)
-n_fsi = length(fs_in_list);
-n_fso = length(fs_out_list);
-fh = fopen(fn,'w');
-fprintf(fh,'\n');
-fprintf(fh,'SRC test result: Frequency response -3dB 0 - X.XX kHz\n');
-fprintf(fh,'%8s, ', 'in \ out');
-for a = 1:n_fso-1
-        fprintf(fh,'%8.1f, ', fs_out_list(a)/1e3);
-end
-fprintf(fh,'%8.1f', fs_out_list(n_fso)/1e3);
-fprintf(fh,'\n');
-for a = 1:n_fsi
-        fprintf(fh,'%8.1f, ', fs_in_list(a)/1e3);
-	for b = 1:n_fso
-                if pf(a,b,1) < 0
-                        cstr = 'x';
-                else
-                        cstr = sprintf('%4.1f', fr3db_hz(a,b)/1e3);
-                end
-                if b < n_fso
-                        fprintf(fh,'%8s, ', cstr);
-                else
-                        fprintf(fh,'%8s', cstr);
-                end
-        end
-        fprintf(fh,'\n');
-end
-fclose(fh);
-type(fn);
-end
-
-
-function print_pf(fn, fs_in_list, fs_out_list, pf)
-n_fsi = length(fs_in_list);
-n_fso = length(fs_out_list);
-fh = fopen(fn,'w');
-fprintf(fh,'\n');
-fprintf(fh,'SRC test result: Fails\n');
-fprintf(fh,'%8s, ', 'in \ out');
-for a = 1:n_fso-1
-        fprintf(fh,'%14.1f, ', fs_out_list(a)/1e3);
-end
-fprintf(fh,'%14.1f', fs_out_list(n_fso)/1e3);
-fprintf(fh,'\n');
-spf = size(pf);
-npf = spf(3);
-for a = 1:n_fsi
-        fprintf(fh,'%8.1f, ', fs_in_list(a)/1e3);
-	for b = 1:n_fso
-                if pf(a,b,1) < 0
-                        cstr = 'x';
-                else
-                        cstr = sprintf('%d', pf(a,b,1));
-                        for n=2:npf
-                                if pf(a,b,n) < 0
-                                        cstr = sprintf('%s/x', cstr);
-                                else
-                                        cstr = sprintf('%s/%d', cstr,pf(a,b,n));
-                                end
-                        end
-                end
-                if b < n_fso
-                        fprintf(fh,'%14s, ', cstr);
-                else
-                        fprintf(fh,'%14s', cstr);
-                end
-        end
-        fprintf(fh,'\n');
-end
-fclose(fh);
-type(fn);
 end

--- a/tools/test/audio/test_utils/print_fr.m
+++ b/tools/test/audio/test_utils/print_fr.m
@@ -1,0 +1,64 @@
+% print_fr(comp, filename, prm_in_list, prm_out_list, fr_db, fr_hz, pf)
+%
+% Prints and exports in CSV format a matrix of frequency response widths in Hz
+
+% SPDX-License-Identifier: BSD-3-Clause
+% Copyright(c) 2020 Intel Corporation. All rights reserved.
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+
+function print_fr(comp, fn, prm_in_list, prm_out_list, fr_db, fr_hz, pf)
+
+n_prmi = length(prm_in_list);
+n_prmo = length(prm_out_list);
+fh = fopen(fn,'w');
+fprintf(fh,'\n');
+fprintf(fh,'%s test result: Frequency response +/- X.XX dB (YY.Y kHz) \n', comp);
+fprintf(fh,'%8s, ', 'in \ out');
+
+% Do not print decimals for all integer parameters
+if isequal(floor(prm_in_list), prm_in_list) && isequal(floor(prm_out_list), prm_out_list)
+	int_prms = 1;
+else
+	int_prms = 0;
+end
+
+for a = 1:n_prmo-1
+	if int_prms
+		fprintf(fh,'%12d, ', prm_out_list(a));
+	else
+		fprintf(fh,'%12.1f, ', prm_out_list(a));
+	end
+end
+
+if int_prms
+	fprintf(fh,'%12d', prm_out_list(n_prmo));
+else
+	fprintf(fh,'%12.1f', prm_out_list(n_prmo));
+end
+
+fprintf(fh,'\n');
+for a = 1:n_prmi
+	if int_prms
+		fprintf(fh,'%8d, ', prm_in_list(a));
+	else
+		fprintf(fh,'%8.1f, ', prm_in_list(a));
+	end
+
+	for b = 1:n_prmo
+                if pf(a,b,1) < 0
+                        cstr = 'x';
+                else
+                        cstr = sprintf('%4.2f (%4.1f)', fr_db(a,b), fr_hz(a,b,2)/1e3);
+                end
+                if b < n_prmo
+                        fprintf(fh,'%12s, ', cstr);
+                else
+                        fprintf(fh,'%12s', cstr);
+                end
+        end
+        fprintf(fh,'\n');
+end
+
+fclose(fh);
+type(fn);
+end

--- a/tools/test/audio/test_utils/print_pf.m
+++ b/tools/test/audio/test_utils/print_pf.m
@@ -1,0 +1,72 @@
+% print_pf(comp, filename, prm_in_list, prm_out_list, pf)
+%
+% Prints and exports in CSV format a matrix of overall pass/fail test results
+
+% SPDX-License-Identifier: BSD-3-Clause
+% Copyright(c) 2020 Intel Corporation. All rights reserved.
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+
+function print_pf(comp, fn, prm_in_list, prm_out_list, pf)
+
+n_prmi = length(prm_in_list);
+n_prmo = length(prm_out_list);
+fh = fopen(fn,'w');
+fprintf(fh,'\n');
+fprintf(fh,'%s test result: Fails\n', comp);
+fprintf(fh,'%8s, ', 'in \ out');
+
+% Do not print decimals for all integer parameters
+if isequal(floor(prm_in_list), prm_in_list) && isequal(floor(prm_out_list), prm_out_list)
+	int_prms = 1;
+else
+	int_prms = 0;
+end
+
+for a = 1:n_prmo-1
+	if int_prms
+		fprintf(fh,'%14d, ', prm_out_list(a));
+	else
+		fprintf(fh,'%14.1f, ', prm_out_list(a));
+	end
+end
+
+if int_prms
+	fprintf(fh,'%14d', prm_out_list(n_prmo));
+else
+	fprintf(fh,'%14.1f', prm_out_list(n_prmo));
+end
+
+fprintf(fh,'\n');
+spf = size(pf);
+npf = spf(3);
+for a = 1:n_prmi
+	if int_prms
+		fprintf(fh,'%8d, ', prm_in_list(a));
+	else
+		fprintf(fh,'%8.1f, ', prm_in_list(a));
+	end
+	for b = 1:n_prmo
+                if pf(a,b,1) < 0
+                        cstr = 'x';
+                else
+                        cstr = sprintf('%d', pf(a,b,1));
+                        for n=2:npf
+                                if pf(a,b,n) < 0
+                                        cstr = sprintf('%s/x', cstr);
+                                else
+                                        cstr = sprintf('%s/%d', cstr,pf(a,b,n));
+                                end
+                        end
+                end
+                if b < n_prmo
+                        fprintf(fh,'%14s, ', cstr);
+                else
+                        fprintf(fh,'%14s', cstr);
+                end
+        end
+        fprintf(fh,'\n');
+end
+
+fclose(fh);
+type(fn);
+end

--- a/tools/test/audio/test_utils/print_val.m
+++ b/tools/test/audio/test_utils/print_val.m
@@ -1,0 +1,65 @@
+% print_val(comp, valstr, filename, prm_in_list, prm_out_list, val, pf)
+%
+% Prints and exports in CSV format a matrix of test results
+
+% SPDX-License-Identifier: BSD-3-Clause
+% Copyright(c) 2020 Intel Corporation. All rights reserved.
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+
+function print_val(comp, valstr, fn, prm_in_list, prm_out_list, val, pf)
+
+% Do not print decimals for all integer parameters
+if isequal(floor(prm_in_list), prm_in_list) && isequal(floor(prm_out_list), prm_out_list)
+	int_prms = 1;
+else
+	int_prms = 0;
+end
+
+n_prmi = length(prm_in_list);
+n_prmo = length(prm_out_list);
+fh = fopen(fn,'w');
+fprintf(fh,'\n');
+fprintf(fh,'%s test result: %s\n', comp, valstr);
+fprintf(fh,'%8s, ', 'in \ out');
+for a = 1:n_prmo-1
+	if int_prms
+		fprintf(fh,'%8d, ', prm_out_list(a));
+	else
+		fprintf(fh,'%8.1f, ', prm_out_list(a));
+	end
+end
+
+if int_prms
+	fprintf(fh,'%8d', prm_out_list(n_prmo));
+else
+	fprintf(fh,'%8.1f', prm_out_list(n_prmo));
+end
+
+fprintf(fh,'\n');
+for a = 1:n_prmi
+	if int_prms
+		fprintf(fh,'%8d, ', prm_in_list(a));
+	else
+		fprintf(fh,'%8.1f, ', prm_in_list(a));
+	end
+	for b = 1:n_prmo
+                if pf(a,b,1) < 0
+                        cstr = 'x';
+                else
+                        if isnan(val(a,b))
+                                cstr = '-';
+                        else
+                                cstr = sprintf('%8.2f', val(a,b));
+                        end
+                end
+                if b < n_prmo
+                        fprintf(fh,'%8s, ', cstr);
+                else
+                        fprintf(fh,'%8s', cstr);
+                end
+        end
+        fprintf(fh,'\n');
+end
+fclose(fh);
+type(fn);
+end

--- a/tools/tune/eq/eq_blob_plot.m
+++ b/tools/tune/eq/eq_blob_plot.m
@@ -1,0 +1,140 @@
+function eq = eq_blob_plot(blobfn, eqtype, fs, f, doplot)
+
+% eq = eq_blob_plot(blobfn, eqtype, fs, f, doplot)
+%
+% Plot frequency response of IIR or FIR EQ coefficients blob
+%
+% Inputs
+%
+% blobfn - filename of the blob
+% eqtype - 'iir' or 'fir', if omitted done via string search from blobfn
+% fs     - sample rate, defaults to 48 kHz if omitted
+% f      - frequency vector
+% dpplot
+
+% SPDX-License-Identifier: BSD-3-Clause
+%
+% Copyright (c) 2016-2020, Intel Corporation. All rights reserved.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+
+%% Handle input parameters
+if nargin < 2
+	if findstr(blobfn, '_fir_')
+		eqtype = 'FIR';
+	else
+		eqtype = 'IIR';
+	end
+end
+
+if nargin < 3
+	fs = 48e3;
+end
+
+if nargin < 4 || isempty(f)
+	eq.f = logspace(log10(10),log10(fs/2), 1000);
+else
+	% Freqz() needs two frequency points or more
+	if length(f) < 2
+		f_single = 1;
+		eq.f = [f f];
+	else
+		f_single = 0;
+		eq.f = f;
+	end
+end
+
+if nargin < 5
+	doplot = 1;
+end
+
+%% Read blob as 32 bit integers
+blob = eq_blob_read(blobfn);
+
+%% Group delay with grpdelay() is not working in Octave
+do_group_delay = ~exist('OCTAVE_VERSION', 'builtin');
+
+%% Decode and compute response
+eq.m = [];
+eq.gd = [];
+switch lower(eqtype)
+	case 'fir'
+		hd = eq_fir_blob_decode(blob);
+		eq.m = zeros(length(eq.f), hd.channels_in_config);
+		for i = 1:hd.channels_in_config
+			teq = eq_fir_blob_decode(blob, hd.assign_response(i));
+			h = freqz(teq.b, 1, eq.f, fs);
+			eq.m(:,i) = 20*log10(abs(h));
+			if do_group_delay
+				gd = grpdelay(teq.b, 1, eq.f, fs) / fs;
+				eq.gd(:,i) = gd;
+			end
+		end
+
+	case 'iir'
+		hd = eq_iir_blob_decode(blob);
+		eq.m = zeros(length(eq.f), hd.channels_in_config);
+		for i = 1:hd.channels_in_config
+			teq = eq_iir_blob_decode(blob, hd.assign_response(i));
+			h = freqz(teq.b, teq.a, eq.f, fs);
+			eq.m(:,i) = 20*log10(abs(h));
+			if do_group_delay
+				gd = grpdelay(teq.b, teq.a, eq.f, fs) / fs;
+				eq.gd(:,i) = gd;
+			end
+		end
+end
+
+%% Optional plots
+if doplot
+	eq.fh(1) = figure;
+	semilogx(eq.f, eq.m);
+	ymin = max(min(min(eq.m)), -60);
+	ymax = max(max(eq.m));
+	axis([10 round(fs/2/10)*10 ymin-3 ymax+3 ]);
+	grid on;
+	channel_legends(hd.channels_in_config);
+	xlabel('Frequency (Hz)');
+	ylabel('Amplitude (dB)');
+	title(blobfn, 'Interpreter', 'None');
+
+	if do_group_delay
+		eq.fh(2) = figure;
+		semilogx(eq.f, eq.gd * 1e6);
+		ax = axis();
+		axis([10 round(fs/2/10)*10 ax(3:4) ]);
+		grid on;
+		channel_legends(hd.channels_in_config);
+		xlabel('Frequency (Hz)');
+		ylabel('Group delay (us)');
+		title(blobfn, 'Interpreter', 'None');
+	end
+end
+
+%% Trim avay the duplicated frequency point
+if f_single
+	eq.f = eq.f(1);
+	if do_group_delay
+		eq.gd = eq.gd(1);
+	end
+end
+
+end
+
+%% Helper functions
+function channel_legends(n)
+
+switch n
+	case 2
+		legend('ch1', 'ch2');
+	case 4
+		legend('ch1', 'ch2', 'ch3', 'ch4');
+	case 6
+		legend('ch1', 'ch2', 'ch3', 'ch4', 'ch5', 'ch6');
+	case 8
+		legend('ch1', 'ch2', 'ch3', 'ch4', 'ch5', 'ch6', 'ch7', 'ch8');
+	otherwise
+		error('Illegal number of channels found');
+end
+
+end

--- a/tools/tune/eq/eq_blob_read.m
+++ b/tools/tune/eq/eq_blob_read.m
@@ -1,0 +1,69 @@
+function blob = eq_blob_read(blobfn, fntype)
+
+% SPDX-License-Identifier: BSD-3-Clause
+%
+% Copyright (c) 2020, Intel Corporation. All rights reserved.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+
+%% Use file suffix as type
+if nargin < 2
+	idx = findstr(blobfn, '.');
+	fntype = blobfn(idx(end)+1:end);
+end
+
+%% Read the file
+switch lower(fntype)
+	case 'bin'
+		fh = fopen(blobfn, 'rb');
+		tmp = fread(fh, inf, 'uint32');
+		fclose(fh);
+	case 'txt'
+		fh = fopen(blobfn, 'r');
+		tmp = fscanf(fh, '%u,', Inf);
+		fclose(fh);
+	case 'm4'
+		tmp = get_parse_m4(blobfn);
+	otherwise
+		error('Illegal file type, please give fntype argument');
+
+end
+
+blob = uint32(tmp);
+
+end
+
+%% Parse m4 topology blob
+function blob = get_parse_m4(blobfn)
+
+fh = fopen(blobfn, 'r');
+
+% Ignore two lines from beginning
+ln = fgets(fh);
+ln = fgets(fh);
+
+% Loop until end of file
+n = 1;
+ln = fgets(fh);
+while ln ~= -1
+	idx = findstr(ln, '0x');
+	for i = 1:length(idx)
+		bytes(n) = hex2dec(ln(idx(i)+2:idx(i)+3));
+		n = n + 1;
+	end
+	ln = fgets(fh);
+end
+fclose(fh);
+
+% Convert to 32 bit
+n32 = round(length(bytes)/4);
+blob = zeros(n32, 1);
+for i = 1:n32
+	i8 = (i - 1)*4 + 1;
+	blob(i) = bytes(i8) * 2^0 ...
+		  + bytes(i8 + 1) * 2^8 ...
+		  + bytes(i8 + 2) * 2^16 ...
+		  + bytes(i8 + 3) * 2^24;
+end
+
+end

--- a/tools/tune/eq/eq_fir_blob_decode.m
+++ b/tools/tune/eq/eq_fir_blob_decode.m
@@ -1,4 +1,4 @@
-function eq = eq_fir_blob_decode(blobfn, resp_n, fs, do_plot)
+function eq = eq_fir_blob_decode(blob, resp_n)
 
 %% Decode a FIR EQ binary blob
 %
@@ -16,47 +16,21 @@ function eq = eq_fir_blob_decode(blobfn, resp_n, fs, do_plot)
 % assign_response    - vector of EQ indexes assigned to channels
 % size               - length in bytes
 
-%%
-% Copyright (c) 2016, Intel Corporation
-% All rights reserved.
+% SPDX-License-Identifier: BSD-3-Clause
 %
-% Redistribution and use in source and binary forms, with or without
-% modification, are permitted provided that the following conditions are met:
-%   * Redistributions of source code must retain the above copyright
-%     notice, this list of conditions and the following disclaimer.
-%   * Redistributions in binary form must reproduce the above copyright
-%     notice, this list of conditions and the following disclaimer in the
-%     documentation and/or other materials provided with the distribution.
-%   * Neither the name of the Intel Corporation nor the
-%     names of its contributors may be used to endorse or promote products
-%     derived from this software without specific prior written permission.
-%
-% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
-% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-% POSSIBILITY OF SUCH DAMAGE.
+% Copyright (c) 2016-2020, Intel Corporation. All rights reserved.
 %
 % Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
-%
-
-if nargin < 4
-	do_plot = 0;
-end
-
-if nargin < 3
-        fs = 48e3;
-end
 
 if nargin < 2
-        resp_n = 0;
+	verbose = 1;
+	resp_n = [];
+else
+	verbose = 0;
 end
+
+%% Get ABI information
+[abi_bytes, nbytes_abi] = eq_get_abi(0);
 
 %% Defaults
 eq.b = [];
@@ -65,13 +39,17 @@ eq.channels_in_config = 0;
 eq.number_of_responses = 0;
 eq.assign_response = [];
 
-%% Read binary file
-fh = fopen(blobfn, 'rb');
-blob16 = fread(fh, inf, 'int16');
-fclose(fh);
+%% Convert to 16 bits
+blob16 = zeros(1, length(blob)*2);
+for i = 1:length(blob)
+	i16 = 2*(i - 1) + 1;
+	blob16(i16) = bitand(blob(i), 65535);
+	blob16(i16 + 1) = bitshift(blob(i), -16);
+end
+blob16 = signedint(double(blob16), 16);
 
 %% Decode
-abi = 16;
+abi = nbytes_abi / 2;
 eq.size =  blob16(abi + 1) + 65536*blob16(abi + 2);
 eq.channels_in_config = blob16(abi + 3);
 eq.number_of_responses = blob16(abi + 4);
@@ -85,15 +63,31 @@ reserved7 = blob16(abi + 11);
 reserved8 = blob16(abi + 12);
 eq.assign_response = blob16(abi + 13:abi + 13 + eq.channels_in_config-1);
 
-fprintf('Blob size = %d\n', eq.size);
-fprintf('Channels in config = %d\n', eq.channels_in_config);
-fprintf('Number of responses = %d\n', eq.number_of_responses);
-fprintf('Assign responses =');
-for i=1:length(eq.assign_response)
-	fprintf(' %d', eq.assign_response(i));
+if verbose
+	fprintf('Blob size = %d\n', eq.size);
+	fprintf('Channels in config = %d\n', eq.channels_in_config);
+	fprintf('Number of responses = %d\n', eq.number_of_responses);
+	fprintf('Assign responses =');
+	for i=1:length(eq.assign_response)
+		fprintf(' %d', eq.assign_response(i));
+	end
+	fprintf('\n');
 end
-fprintf('\n');
 
+% Just header request
+if isempty(resp_n)
+	eq.b = [];
+	eq.a = [];
+	return
+end
+
+% Handle pass-through
+if resp_n < 0
+	eq.b = 1;
+	eq.a = 1;
+end
+
+% Normal filter taps retrieve
 if resp_n > eq.number_of_responses-1;
         error('Request of non-available response');
 end
@@ -104,24 +98,19 @@ b16 = blob16(abi + n_blob_header + eq.channels_in_config + 1:end);
 j = 1;
 for i=1:eq.number_of_responses
         filter_length = b16(j);
-        output_shift = b16(j+1);
+        output_shift = double(b16(j+1));
         if i-1 == resp_n
                 bi = b16(j+n_fir_header:j+n_fir_header+filter_length-1);
-                eq.b = 2^(-output_shift)*double(bi)/32768;
+                eq.b = 2^(-output_shift)*bi/32768;
         end
         j = j+filter_length+n_fir_header;
 end
 eq.a = 1;
 
-if do_plot > 0
-	figure;
-	f = logspace(log10(10),log10(fs/2), 500);
-	h = freqz(eq.b, eq.a, f, fs);
-	semilogx(f, 20*log10(abs(h)));
-	axis([20 20e3 -40 20]);
-	grid on;
-	xlabel('Frequency (Hz)');
-	ylabel('Amplitude (dB)');
 end
 
+function y = signedint(x, bits)
+y = x;
+idx = find(x > 2^(bits-1)-1);
+y(idx) = x(idx)-2^bits;
 end

--- a/tools/tune/eq/eq_get_abi.m
+++ b/tools/tune/eq/eq_get_abi.m
@@ -13,7 +13,7 @@ function [bytes, nbytes] = eq_get_abi(setsize)
 
 %% Use sof-ctl to write ABI header into a file
 abifn = 'eq_get_abi.bin';
-cmd = sprintf('sof-ctl -g %d -b -o %s', setsize, abifn);
+cmd = sprintf('sof-ctl -g %d -b -o %s > /dev/null', setsize, abifn);
 system(cmd);
 
 %% Read file and delete it

--- a/tools/tune/eq/eq_iir_blob_decode.m
+++ b/tools/tune/eq/eq_iir_blob_decode.m
@@ -1,8 +1,8 @@
-function eq = eq_iir_blob_decode(blobfn, resp_n, fs, do_plot)
+function eq = eq_iir_blob_decode(ublob, resp_n)
 
 %% Decode an IIR EQ binary blob
 %
-% eq = eq_fir_decode_blob(blobfn, resp_n, fs, do_plot)
+% eq = eq_fir_decode_blob(blobfn, resp_n)
 %
 % blobfn  - file name of EQ setup blob
 % resp_n  - index of response to decode
@@ -16,47 +16,21 @@ function eq = eq_iir_blob_decode(blobfn, resp_n, fs, do_plot)
 % assign response    - vector of EQ indexes assigned to channels
 %
 
-%%
-% Copyright (c) 2016, Intel Corporation
-% All rights reserved.
+% SPDX-License-Identifier: BSD-3-Clause
 %
-% Redistribution and use in source and binary forms, with or without
-% modification, are permitted provided that the following conditions are met:
-%   * Redistributions of source code must retain the above copyright
-%     notice, this list of conditions and the following disclaimer.
-%   * Redistributions in binary form must reproduce the above copyright
-%     notice, this list of conditions and the following disclaimer in the
-%     documentation and/or other materials provided with the distribution.
-%   * Neither the name of the Intel Corporation nor the
-%     names of its contributors may be used to endorse or promote products
-%     derived from this software without specific prior written permission.
-%
-% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
-% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-% POSSIBILITY OF SUCH DAMAGE.
+% Copyright (c) 2016-2020, Intel Corporation. All rights reserved.
 %
 % Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
-%
-
-if nargin < 4
-	do_plot = 0;
-end
-
-if nargin < 3
-        fs = 48e3;
-end
 
 if nargin < 2
-        resp_n = 0;
+	verbose = 1;
+	resp_n = [];
+else
+	verbose = 0;
 end
+
+%% Get ABI information
+[abi_bytes, nbytes_abi] = eq_get_abi(0);
 
 %% Defaults
 eq.b = [];
@@ -65,13 +39,9 @@ eq.channels_in_config = 0;
 eq.number_of_responses = 0;
 eq.assign_response = [];
 
-%% Read binary file
-fh = fopen(blobfn, 'rb');
-blob = fread(fh, inf, 'uint32');
-fclose(fh);
-
 %% Decode
-abi = 8;
+blob = double(ublob);
+abi = nbytes_abi / 4;
 eq.size = blob(abi + 1);
 eq.channels_in_config = blob(abi + 2);
 eq.number_of_responses = blob(abi + 3);
@@ -79,17 +49,33 @@ reserved1 = blob(abi + 4);
 reserved2 = blob(abi + 5);
 reserved3 = blob(abi + 6);
 reserved4 = blob(abi + 7);
-eq.assign_response = blob(abi + 8:abi + 8 + eq.channels_in_config - 1);
+eq.assign_response = signedint(blob(abi + 8:abi + 8 + eq.channels_in_config - 1), 32);
 
-fprintf('Blob size = %d\n', eq.size);
-fprintf('Channels in config = %d\n', eq.channels_in_config);
-fprintf('Number of responses = %d\n', eq.number_of_responses);
-fprintf('Assign responses =');
-for i=1:length(eq.assign_response)
-	fprintf(' %d', eq.assign_response(i));
+if verbose
+	fprintf('Blob size = %d\n', eq.size);
+	fprintf('Channels in config = %d\n', eq.channels_in_config);
+	fprintf('Number of responses = %d\n', eq.number_of_responses);
+	fprintf('Assign responses =');
+	for i=1:length(eq.assign_response)
+		fprintf(' %d', eq.assign_response(i));
+	end
+	fprintf('\n');
 end
-fprintf('\n');
 
+% Just header request
+if isempty(resp_n)
+	eq.b = [];
+	eq.a = [];
+	return
+end
+
+% Handle pass-through
+if resp_n < 0
+	eq.b = 1;
+	eq.a = 1;
+end
+
+% Normal filter taps retrieve
 if resp_n > eq.number_of_responses-1;
         error('Request of non-available response');
 end
@@ -98,7 +84,6 @@ n_blob_header = 7;
 n_iir_header = 6;
 n_iir_section = 7;
 
-f = logspace(log10(10),log10(fs/2), 500);
 j = abi + n_blob_header + eq.channels_in_config + 1;
 eq.b = 1.0;
 eq.a = 1.0;
@@ -116,29 +101,12 @@ for i=1:eq.number_of_responses
                         a0 = [1 -(ai/2^30)];
                         gain = gaini/2^14;
                         b0 = b0 * 2^(-shifti) * gain;
-			if do_plot > 1
-				figure;
-				h = freqz(b0, a0, f, fs);
-				semilogx(f, 20*log10(abs(h)));
-				ax = axis; axis([20 20e3 -40 20]);
-				grid on;
-			end
 			eq.b = conv(eq.b, b0);
 			eq.a = conv(eq.a, a0);
 			k = k + n_iir_section;
                 end
         end
         j = j+section_length;
-end
-
-if do_plot > 0
-	figure;
-	h = freqz(eq.b, eq.a, f, fs);
-	semilogx(f, 20*log10(abs(h)));
-	axis([20 20e3 -40 20]);
-	grid on;
-	xlabel('Frequency (Hz)');
-	ylabel('Amplitude (dB)');
 end
 
 end


### PR DESCRIPTION
This patch adds Octave scripts for objective quality parameters checks for processing components. The standard tests include chirp spectrogram, gain, dynamic range, THD+N over frequency, and frequency response. 

There's still minor general issues/limitations (currently only test for flat response FIR/IIR, failure when testing volume), and need for more test topologies (will use @fredoh9  topology work). But since I feel this is generally useful for processing developers I'd like to share this early.
