### PR TITLE
tools/test: silence alsatplg in tlpg-build.sh unless VERBOSE=1

### DIFF
--- a/tools/test/topology/tplg-build.sh
+++ b/tools/test/topology/tplg-build.sh
@@ -264,6 +264,6 @@ then
 	#execute alsatplg to create topology binary
 	TEST_STRINGS=${TEST_STRINGS%?}
 	echo $TEST_STRINGS | tr '\n' ',' |\
-		xargs -d ',' -P0 -n1 -I string alsatplg -v 1 -c\
+		xargs -d ',' -P0 -n1 -I string alsatplg ${VERBOSE:+-v 1} -c\
 			string".conf" -o string".tplg"
 fi


### PR DESCRIPTION
With this commit:
```
                  ./scripts/build-tools.sh -t -f | wc -l
     525
VERBOSE=anything  ./scripts/build-tools.sh -t -f | wc -l
  137030
```
This a followup to commit aa6c0f2ad11f ("topology: cmake: silence super
chatty alsatplg unless VERBOSE=1")

Signed-off-by: Marc Herbert <marc.herbert@intel.com>