### PR TITLE
scripts: xtensa-build-all.sh: Refactor and improve script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
         &docker-pull-sof
         docker pull thesofproject/sof && docker tag thesofproject/sof sof
       script:
-        ./scripts/docker-run.sh ./scripts/xtensa-build-all.sh -j $PLATFORM
+        ./scripts/docker-run.sh ./scripts/xtensa-build-all.sh $PLATFORM
       env: PLATFORM='sue'
 
     - <<: *build-platform
@@ -50,7 +50,7 @@ jobs:
       stage: tests
       script:
         - sed -i $(($(grep "config HAVE_AGENT" -n src/platform/Kconfig | cut -f1 -d:)+2))"s/default y/default n/" src/platform/Kconfig
-        - ./scripts/docker-run.sh ./scripts/xtensa-build-all.sh -r -j $PLATFORM
+        - ./scripts/docker-run.sh ./scripts/xtensa-build-all.sh -r $PLATFORM
         - ./scripts/docker-qemu.sh ../sof.git/scripts/qemu-check.sh $PLATFORM
       env: PLATFORM='byt cht'
       before_install:

--- a/scripts/xtensa-build-all.sh
+++ b/scripts/xtensa-build-all.sh
@@ -59,6 +59,11 @@ for arg in "$@"; do
 			break
 		fi
 	done
+	if [ $platform == "none" ]; then
+		echo "Error: Unknown platform specified: $arg"
+		echo "Supported platforms are: ${SUPPORTED_PLATFORMS[*]}"
+		exit 1
+	fi
 done
 
 # check target platform(s) have been passed in

--- a/scripts/xtensa-build-all.sh
+++ b/scripts/xtensa-build-all.sh
@@ -10,6 +10,7 @@ BUILD_FORCE_UP=no
 BUILD_JOBS=$(nproc --all)
 BUILD_JOBS_NEXT=0
 BUILD_VERBOSE=
+PLATFORMS=()
 
 PATH=$pwd/local/bin:$PATH
 
@@ -64,14 +65,14 @@ else
 		# Build all platforms
 		elif [[ "$args" == "-a" ]]
 			then
-			PLATFORMS=${SUPPORTED_PLATFORMS[@]}
+			PLATFORMS=("${SUPPORTED_PLATFORMS[@]}")
 		else
 			# check for plaform
 			for i in ${SUPPORTED_PLATFORMS[@]}
 			do
 				if [ $i == $args ]
 				then
-					PLATFORMS+=$i" "
+					PLATFORMS=("${PLATFORMS[@]}" "$i")
 					BUILD_JOBS_NEXT=0
 					continue 2
 				fi
@@ -114,7 +115,7 @@ OLDPATH=$PATH
 WORKDIR="$pwd"
 
 # build platform
-for j in ${PLATFORMS[@]}
+for j in "${PLATFORMS[@]}"
 do
 	HAVE_ROM='no'
 	DEFCONFIG_PATCH=''

--- a/scripts/xtensa-build-all.sh
+++ b/scripts/xtensa-build-all.sh
@@ -101,7 +101,6 @@ do
 			PLATFORM="baytrail"
 			ARCH="xtensa"
 			XTENSA_CORE="Intel_HiFiEP"
-			ROOT="$pwd/../xtensa-root/xtensa-byt-elf"
 			HOST="xtensa-byt-elf"
 			XTENSA_TOOLS_VERSION="RD-2012.5-linux"
 			;;
@@ -109,7 +108,6 @@ do
 			PLATFORM="cherrytrail"
 			ARCH="xtensa"
 			XTENSA_CORE="CHT_audio_hifiep"
-			ROOT="$pwd/../xtensa-root/xtensa-byt-elf"
 			HOST="xtensa-byt-elf"
 			XTENSA_TOOLS_VERSION="RD-2012.5-linux"
 			;;
@@ -117,7 +115,6 @@ do
 			PLATFORM="broadwell"
 			ARCH="xtensa"
 			XTENSA_CORE="LX4_langwell_audio_17_8"
-			ROOT="$pwd/../xtensa-root/xtensa-hsw-elf"
 			HOST="xtensa-hsw-elf"
 			XTENSA_TOOLS_VERSION="RG-2017.8-linux"
 			;;
@@ -125,7 +122,6 @@ do
 			PLATFORM="haswell"
 			ARCH="xtensa"
 			XTENSA_CORE="LX4_langwell_audio_17_8"
-			ROOT="$pwd/../xtensa-root/xtensa-hsw-elf"
 			HOST="xtensa-hsw-elf"
 			XTENSA_TOOLS_VERSION="RG-2017.8-linux"
 			;;
@@ -141,7 +137,6 @@ do
 				HOST="xtensa-apl-elf"
 			fi
 
-			ROOT="$pwd/../xtensa-root/$HOST"
 			XTENSA_TOOLS_VERSION="RG-2017.8-linux"
 			HAVE_ROM='yes'
 			;;
@@ -157,7 +152,6 @@ do
 				HOST="xtensa-apl-elf"
 			fi
 
-			ROOT="$pwd/../xtensa-root/$HOST"
 			XTENSA_TOOLS_VERSION="RG-2017.8-linux"
 			HAVE_ROM='yes'
 			;;
@@ -173,7 +167,6 @@ do
 				HOST="xtensa-apl-elf"
 			fi
 
-			ROOT="$pwd/../xtensa-root/$HOST"
 			XTENSA_TOOLS_VERSION="RG-2017.8-linux"
 			HAVE_ROM='yes'
 			;;
@@ -181,7 +174,6 @@ do
 			PLATFORM="cannonlake"
 			ARCH="xtensa-smp"
 			XTENSA_CORE="X6H3CNL_2017_8"
-			ROOT="$pwd/../xtensa-root/xtensa-cnl-elf"
 			HOST="xtensa-cnl-elf"
 			XTENSA_TOOLS_VERSION="RG-2017.8-linux"
 			HAVE_ROM='yes'
@@ -190,7 +182,6 @@ do
 			PLATFORM="suecreek"
 			ARCH="xtensa"
 			XTENSA_CORE="X6H3CNL_2017_8"
-			ROOT="$pwd/../xtensa-root/xtensa-cnl-elf"
 			HOST="xtensa-cnl-elf"
 			XTENSA_TOOLS_VERSION="RG-2017.8-linux"
 			HAVE_ROM='yes'
@@ -199,7 +190,6 @@ do
 			PLATFORM="icelake"
 			ARCH="xtensa-smp"
 			XTENSA_CORE="X6H3CNL_2017_8"
-			ROOT="$pwd/../xtensa-root/xtensa-cnl-elf"
 			HOST="xtensa-cnl-elf"
 			XTENSA_TOOLS_VERSION="RG-2017.8-linux"
 			HAVE_ROM='yes'
@@ -208,7 +198,6 @@ do
 			PLATFORM="jasperlake"
 			ARCH="xtensa-smp"
 			XTENSA_CORE="X6H3CNL_2017_8"
-			ROOT="$pwd/../xtensa-root/xtensa-cnl-elf"
 			HOST="xtensa-cnl-elf"
 			XTENSA_TOOLS_VERSION="RG-2017.8-linux"
 			HAVE_ROM='yes'
@@ -217,7 +206,6 @@ do
 			PLATFORM="imx8"
 			ARCH="xtensa"
 			XTENSA_CORE="hifi4_nxp_v3_3_1_2_dev"
-			ROOT="$pwd/../xtensa-root/xtensa-imx-elf"
 			HOST="xtensa-imx-elf"
 			XTENSA_TOOLS_VERSION="RF-2016.4-linux"
 			;;
@@ -225,7 +213,6 @@ do
 			PLATFORM="imx8x"
 			ARCH="xtensa"
 			XTENSA_CORE="hifi4_nxp_v3_3_1_2_dev"
-			ROOT="$pwd/../xtensa-root/xtensa-imx-elf"
 			HOST="xtensa-imx-elf"
 			XTENSA_TOOLS_VERSION="RF-2016.4-linux"
 			;;
@@ -233,12 +220,12 @@ do
 			PLATFORM="imx8m"
 			ARCH="xtensa"
 			XTENSA_CORE="hifi4_mscale_v0_0_2_prod"
-			ROOT="$pwd/../xtensa-root/xtensa-imx8m-elf"
 			HOST="xtensa-imx8m-elf"
 			XTENSA_TOOLS_VERSION="RF-2016.4-linux"
 			;;
 
 	esac
+	ROOT="$pwd/../xtensa-root/$HOST"
 
 	if [ $XTENSA_TOOLS_ROOT ]
 	then

--- a/scripts/xtensa-build-all.sh
+++ b/scripts/xtensa-build-all.sh
@@ -138,9 +138,7 @@ do
 		XTENSA_CORE="X4H3I16w2D48w3a_2017_8"
 
 		# test APL compiler aliases and ignore set -e here
-		type xtensa-bxt-elf-gcc > /dev/null 2>&1 && true
-		if [ $? == 0 ]
-		then
+		if type xtensa-bxt-elf-gcc; then
 			HOST="xtensa-bxt-elf"
 		else
 			HOST="xtensa-apl-elf"
@@ -157,9 +155,7 @@ do
 		XTENSA_CORE="X4H3I16w2D48w3a_2017_8"
 
 		# test APL compiler aliases and ignore set -e here
-		type xtensa-bxt-elf-gcc > /dev/null 2>&1 && true
-		if [ $? == 0 ]
-		then
+		if type xtensa-bxt-elf-gcc; then
 			HOST="xtensa-bxt-elf"
 		else
 			HOST="xtensa-apl-elf"
@@ -176,9 +172,7 @@ do
 		XTENSA_CORE="X4H3I16w2D48w3a_2017_8"
 
 		# test APL compiler aliases and ignore set -e here
-		type xtensa-bxt-elf-gcc > /dev/null 2>&1 && true
-		if [ $? == 0 ]
-		then
+		if type xtensa-bxt-elf-gcc; then
 			HOST="xtensa-bxt-elf"
 		else
 			HOST="xtensa-apl-elf"

--- a/scripts/xtensa-build-all.sh
+++ b/scripts/xtensa-build-all.sh
@@ -90,165 +90,155 @@ set -e
 OLDPATH=$PATH
 WORKDIR="$pwd"
 
-# build platform
-for j in "${PLATFORMS[@]}"
+# build platforms
+for platform in "${PLATFORMS[@]}"
 do
 	HAVE_ROM='no'
 	DEFCONFIG_PATCH=''
-	if [ $j == "byt" ]
-	then
-		PLATFORM="baytrail"
-		ARCH="xtensa"
-		XTENSA_CORE="Intel_HiFiEP"
-		ROOT="$pwd/../xtensa-root/xtensa-byt-elf"
-		HOST="xtensa-byt-elf"
-		XTENSA_TOOLS_VERSION="RD-2012.5-linux"
-	fi
-	if [ $j == "cht" ]
-	then
-		PLATFORM="cherrytrail"
-		ARCH="xtensa"
-		XTENSA_CORE="CHT_audio_hifiep"
-		ROOT="$pwd/../xtensa-root/xtensa-byt-elf"
-		HOST="xtensa-byt-elf"
-		XTENSA_TOOLS_VERSION="RD-2012.5-linux"
-	fi
-	if [ $j == "bdw" ]
-	then
-		PLATFORM="broadwell"
-		ARCH="xtensa"
-		XTENSA_CORE="LX4_langwell_audio_17_8"
-		ROOT="$pwd/../xtensa-root/xtensa-hsw-elf"
-		HOST="xtensa-hsw-elf"
-		XTENSA_TOOLS_VERSION="RG-2017.8-linux"
-	fi
-	if [ $j == "hsw" ]
-	then
-		PLATFORM="haswell"
-		ARCH="xtensa"
-		XTENSA_CORE="LX4_langwell_audio_17_8"
-		ROOT="$pwd/../xtensa-root/xtensa-hsw-elf"
-		HOST="xtensa-hsw-elf"
-		XTENSA_TOOLS_VERSION="RG-2017.8-linux"
-	fi
-	if [ $j == "apl" ]
-	then
-		PLATFORM="apollolake"
-		ARCH="xtensa-smp"
-		XTENSA_CORE="X4H3I16w2D48w3a_2017_8"
 
-		# test APL compiler aliases and ignore set -e here
-		if type xtensa-bxt-elf-gcc; then
-			HOST="xtensa-bxt-elf"
-		else
-			HOST="xtensa-apl-elf"
-		fi
+	case $platform in
+		byt)
+			PLATFORM="baytrail"
+			ARCH="xtensa"
+			XTENSA_CORE="Intel_HiFiEP"
+			ROOT="$pwd/../xtensa-root/xtensa-byt-elf"
+			HOST="xtensa-byt-elf"
+			XTENSA_TOOLS_VERSION="RD-2012.5-linux"
+			;;
+		cht)
+			PLATFORM="cherrytrail"
+			ARCH="xtensa"
+			XTENSA_CORE="CHT_audio_hifiep"
+			ROOT="$pwd/../xtensa-root/xtensa-byt-elf"
+			HOST="xtensa-byt-elf"
+			XTENSA_TOOLS_VERSION="RD-2012.5-linux"
+			;;
+		bdw)
+			PLATFORM="broadwell"
+			ARCH="xtensa"
+			XTENSA_CORE="LX4_langwell_audio_17_8"
+			ROOT="$pwd/../xtensa-root/xtensa-hsw-elf"
+			HOST="xtensa-hsw-elf"
+			XTENSA_TOOLS_VERSION="RG-2017.8-linux"
+			;;
+		hsw)
+			PLATFORM="haswell"
+			ARCH="xtensa"
+			XTENSA_CORE="LX4_langwell_audio_17_8"
+			ROOT="$pwd/../xtensa-root/xtensa-hsw-elf"
+			HOST="xtensa-hsw-elf"
+			XTENSA_TOOLS_VERSION="RG-2017.8-linux"
+			;;
+		apl)
+			PLATFORM="apollolake"
+			ARCH="xtensa-smp"
+			XTENSA_CORE="X4H3I16w2D48w3a_2017_8"
 
-		ROOT="$pwd/../xtensa-root/$HOST"
-		XTENSA_TOOLS_VERSION="RG-2017.8-linux"
-		HAVE_ROM='yes'
-	fi
-	if [ $j == "skl" ]
-	then
-		PLATFORM="skylake"
-		ARCH="xtensa"
-		XTENSA_CORE="X4H3I16w2D48w3a_2017_8"
+			# test APL compiler aliases and ignore set -e here
+			if type xtensa-bxt-elf-gcc; then
+				HOST="xtensa-bxt-elf"
+			else
+				HOST="xtensa-apl-elf"
+			fi
 
-		# test APL compiler aliases and ignore set -e here
-		if type xtensa-bxt-elf-gcc; then
-			HOST="xtensa-bxt-elf"
-		else
-			HOST="xtensa-apl-elf"
-		fi
+			ROOT="$pwd/../xtensa-root/$HOST"
+			XTENSA_TOOLS_VERSION="RG-2017.8-linux"
+			HAVE_ROM='yes'
+			;;
+		skl)
+			PLATFORM="skylake"
+			ARCH="xtensa"
+			XTENSA_CORE="X4H3I16w2D48w3a_2017_8"
 
-		ROOT="$pwd/../xtensa-root/$HOST"
-		XTENSA_TOOLS_VERSION="RG-2017.8-linux"
-		HAVE_ROM='yes'
-	fi
-	if [ $j == "kbl" ]
-	then
-		PLATFORM="kabylake"
-		ARCH="xtensa"
-		XTENSA_CORE="X4H3I16w2D48w3a_2017_8"
+			# test APL compiler aliases and ignore set -e here
+			if type xtensa-bxt-elf-gcc; then
+				HOST="xtensa-bxt-elf"
+			else
+				HOST="xtensa-apl-elf"
+			fi
 
-		# test APL compiler aliases and ignore set -e here
-		if type xtensa-bxt-elf-gcc; then
-			HOST="xtensa-bxt-elf"
-		else
-			HOST="xtensa-apl-elf"
-		fi
+			ROOT="$pwd/../xtensa-root/$HOST"
+			XTENSA_TOOLS_VERSION="RG-2017.8-linux"
+			HAVE_ROM='yes'
+			;;
+		kbl)
+			PLATFORM="kabylake"
+			ARCH="xtensa"
+			XTENSA_CORE="X4H3I16w2D48w3a_2017_8"
 
-		ROOT="$pwd/../xtensa-root/$HOST"
-		XTENSA_TOOLS_VERSION="RG-2017.8-linux"
-		HAVE_ROM='yes'
-	fi
-	if [ $j == "cnl" ]
-	then
-		PLATFORM="cannonlake"
-		ARCH="xtensa-smp"
-		XTENSA_CORE="X6H3CNL_2017_8"
-		ROOT="$pwd/../xtensa-root/xtensa-cnl-elf"
-		HOST="xtensa-cnl-elf"
-		XTENSA_TOOLS_VERSION="RG-2017.8-linux"
-		HAVE_ROM='yes'
-	fi
-	if [ $j == "sue" ]
-        then
-		PLATFORM="suecreek"
-		ARCH="xtensa"
-		XTENSA_CORE="X6H3CNL_2017_8"
-		ROOT="$pwd/../xtensa-root/xtensa-cnl-elf"
-		HOST="xtensa-cnl-elf"
-		XTENSA_TOOLS_VERSION="RG-2017.8-linux"
-		HAVE_ROM='yes'
-        fi
-	if [ $j == "icl" ]
-	then
-		PLATFORM="icelake"
-		ARCH="xtensa-smp"
-		XTENSA_CORE="X6H3CNL_2017_8"
-		ROOT="$pwd/../xtensa-root/xtensa-cnl-elf"
-		HOST="xtensa-cnl-elf"
-		XTENSA_TOOLS_VERSION="RG-2017.8-linux"
-		HAVE_ROM='yes'
-	fi
-	if [ $j == "jsl" ]
-	then
-		PLATFORM="jasperlake"
-		ARCH="xtensa-smp"
-		XTENSA_CORE="X6H3CNL_2017_8"
-		ROOT="$pwd/../xtensa-root/xtensa-cnl-elf"
-		HOST="xtensa-cnl-elf"
-		XTENSA_TOOLS_VERSION="RG-2017.8-linux"
-		HAVE_ROM='yes'
-	fi
-	if [ $j == "imx8" ]
-	then
-		PLATFORM="imx8"
-		ARCH="xtensa"
-		XTENSA_CORE="hifi4_nxp_v3_3_1_2_dev"
-		ROOT="$pwd/../xtensa-root/xtensa-imx-elf"
-		HOST="xtensa-imx-elf"
-		XTENSA_TOOLS_VERSION="RF-2016.4-linux"
-	fi
-	if [ $j == "imx8x" ]
-	then
-		PLATFORM="imx8x"
-		ARCH="xtensa"
-		XTENSA_CORE="hifi4_nxp_v3_3_1_2_dev"
-		ROOT="$pwd/../xtensa-root/xtensa-imx-elf"
-		HOST="xtensa-imx-elf"
-		XTENSA_TOOLS_VERSION="RF-2016.4-linux"
-	fi
-	if [ $j == "imx8m" ]
-	then
-		PLATFORM="imx8m"
-		ARCH="xtensa"
-		XTENSA_CORE="hifi4_mscale_v0_0_2_prod"
-		ROOT="$pwd/../xtensa-root/xtensa-imx8m-elf"
-		HOST="xtensa-imx8m-elf"
-		XTENSA_TOOLS_VERSION="RF-2016.4-linux"
-	fi
+			# test APL compiler aliases and ignore set -e here
+			if type xtensa-bxt-elf-gcc; then
+				HOST="xtensa-bxt-elf"
+			else
+				HOST="xtensa-apl-elf"
+			fi
+
+			ROOT="$pwd/../xtensa-root/$HOST"
+			XTENSA_TOOLS_VERSION="RG-2017.8-linux"
+			HAVE_ROM='yes'
+			;;
+		cnl)
+			PLATFORM="cannonlake"
+			ARCH="xtensa-smp"
+			XTENSA_CORE="X6H3CNL_2017_8"
+			ROOT="$pwd/../xtensa-root/xtensa-cnl-elf"
+			HOST="xtensa-cnl-elf"
+			XTENSA_TOOLS_VERSION="RG-2017.8-linux"
+			HAVE_ROM='yes'
+			;;
+		sue)
+			PLATFORM="suecreek"
+			ARCH="xtensa"
+			XTENSA_CORE="X6H3CNL_2017_8"
+			ROOT="$pwd/../xtensa-root/xtensa-cnl-elf"
+			HOST="xtensa-cnl-elf"
+			XTENSA_TOOLS_VERSION="RG-2017.8-linux"
+			HAVE_ROM='yes'
+			;;
+		icl)
+			PLATFORM="icelake"
+			ARCH="xtensa-smp"
+			XTENSA_CORE="X6H3CNL_2017_8"
+			ROOT="$pwd/../xtensa-root/xtensa-cnl-elf"
+			HOST="xtensa-cnl-elf"
+			XTENSA_TOOLS_VERSION="RG-2017.8-linux"
+			HAVE_ROM='yes'
+			;;
+		jsl)
+			PLATFORM="jasperlake"
+			ARCH="xtensa-smp"
+			XTENSA_CORE="X6H3CNL_2017_8"
+			ROOT="$pwd/../xtensa-root/xtensa-cnl-elf"
+			HOST="xtensa-cnl-elf"
+			XTENSA_TOOLS_VERSION="RG-2017.8-linux"
+			HAVE_ROM='yes'
+			;;
+		imx8)
+			PLATFORM="imx8"
+			ARCH="xtensa"
+			XTENSA_CORE="hifi4_nxp_v3_3_1_2_dev"
+			ROOT="$pwd/../xtensa-root/xtensa-imx-elf"
+			HOST="xtensa-imx-elf"
+			XTENSA_TOOLS_VERSION="RF-2016.4-linux"
+			;;
+		imx8x)
+			PLATFORM="imx8x"
+			ARCH="xtensa"
+			XTENSA_CORE="hifi4_nxp_v3_3_1_2_dev"
+			ROOT="$pwd/../xtensa-root/xtensa-imx-elf"
+			HOST="xtensa-imx-elf"
+			XTENSA_TOOLS_VERSION="RF-2016.4-linux"
+			;;
+		imx8m)
+			PLATFORM="imx8m"
+			ARCH="xtensa"
+			XTENSA_CORE="hifi4_mscale_v0_0_2_prod"
+			ROOT="$pwd/../xtensa-root/xtensa-imx8m-elf"
+			HOST="xtensa-imx8m-elf"
+			XTENSA_TOOLS_VERSION="RF-2016.4-linux"
+			;;
+
+	esac
 
 	if [ $XTENSA_TOOLS_ROOT ]
 	then
@@ -288,7 +278,7 @@ do
 		esac
 	fi
 
-	BUILD_DIR=build_${j}_${COMPILER}
+	BUILD_DIR=build_${platform}_${COMPILER}
 	echo "Build in "$BUILD_DIR
 
 	# only delete binary related to this build


### PR DESCRIPTION
- Use getopts for simpler, robust argument parsing
- Exit if an unknown platform is specified
- Derive $ROOT from $HOST instead of explicit assignment
- Use switch case instead of if else for testing string

Signed-off-by: Shreeya Patel <shreeya.patel23498@gmail.com>