### PR TITLE
Make comp_shared simpler and fix data re-initialization

### DIFF
--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -323,11 +323,16 @@ int comp_verify_params(struct comp_dev *dev, uint32_t flag,
 struct comp_dev *comp_make_shared(struct comp_dev *dev)
 {
 	struct comp_dev *old = dev;
+	struct list_item *old_bsource_list = &dev->bsource_list;
+	struct list_item *old_bsink_list = &dev->bsink_list;
 
 	dev = platform_shared_get(dev, dev->size);
 
-	list_init(&dev->bsource_list);
-	list_init(&dev->bsink_list);
+	/* re-link lists with the new heads addresses, init would cut
+	 * links to existing items, local already connected buffers
+	 */
+	list_relink(&dev->bsource_list, old_bsource_list);
+	list_relink(&dev->bsink_list, old_bsink_list);
 	dev->is_shared = true;
 
 	platform_shared_commit(dev, sizeof(*dev));

--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -324,12 +324,7 @@ struct comp_dev *comp_make_shared(struct comp_dev *dev)
 {
 	struct comp_dev *old = dev;
 
-	dev = rrealloc(dev, SOF_MEM_ZONE_RUNTIME, SOF_MEM_FLAG_SHARED,
-		       SOF_MEM_CAPS_RAM, dev->size, dev->size);
-	if (!dev) {
-		trace_error(TRACE_CLASS_COMP, "comp_make_shared(): unable to realloc component");
-		return NULL;
-	}
+	dev = platform_shared_get(dev, dev->size);
 
 	list_init(&dev->bsource_list);
 	list_init(&dev->bsink_list);

--- a/src/include/sof/list.h
+++ b/src/include/sof/list.h
@@ -98,4 +98,27 @@ static inline int list_item_is_last(struct list_item *item,
 	for (item = (list)->next, tmp = item->next;\
 		item != (list); \
 		item = tmp, tmp = item->next)
+
+/**
+ * Re-links the list when head address changed (list moved).
+ * @param new_list New address of the head.
+ * @param old_list Old address of the head.
+ */
+static inline void list_relink(struct list_item *new_list,
+			       struct list_item *old_list)
+{
+	struct list_item *li;
+
+	if (list_is_empty(new_list)) {
+		list_init(new_list);
+	} else {
+		list_for_item(li, new_list)
+			if (li->next == old_list)
+				li->next = new_list; /* for stops here */
+		list_for_item_prev(li, new_list)
+			if (li->prev == old_list)
+				li->prev = new_list; /* for stops here */
+	}
+}
+
 #endif /* __SOF_LIST_H__ */


### PR DESCRIPTION
Realloc seems very expensive if platforms offer simple, quick method.
Fixed scenario for buffer lists described in commit message.