### PR TITLE
alloc: fix potential oob in rrealloc, rbrealloc

### DIFF
--- a/src/audio/buffer.c
+++ b/src/audio/buffer.c
@@ -99,8 +99,8 @@ int buffer_set_size(struct comp_buffer *buffer, uint32_t size)
 	if (size == buffer->stream.size)
 		return 0;
 
-	new_ptr = rbrealloc(buffer->stream.addr, 0, buffer->caps, size,
-			    buffer->stream.size);
+	new_ptr = rbrealloc(buffer->stream.addr, SOF_MEM_FLAG_NO_COPY,
+			    buffer->caps, size, buffer->stream.size);
 
 	/* we couldn't allocate bigger chunk */
 	if (!new_ptr && size > buffer->stream.size) {

--- a/src/audio/buffer.c
+++ b/src/audio/buffer.c
@@ -99,7 +99,8 @@ int buffer_set_size(struct comp_buffer *buffer, uint32_t size)
 	if (size == buffer->stream.size)
 		return 0;
 
-	new_ptr = rbrealloc(buffer->stream.addr, 0, buffer->caps, size);
+	new_ptr = rbrealloc(buffer->stream.addr, 0, buffer->caps, size,
+			    buffer->stream.size);
 
 	/* we couldn't allocate bigger chunk */
 	if (!new_ptr && size > buffer->stream.size) {

--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -325,7 +325,7 @@ struct comp_dev *comp_make_shared(struct comp_dev *dev)
 	struct comp_dev *old = dev;
 
 	dev = rrealloc(dev, SOF_MEM_ZONE_RUNTIME, SOF_MEM_FLAG_SHARED,
-		       SOF_MEM_CAPS_RAM, dev->size);
+		       SOF_MEM_CAPS_RAM, dev->size, dev->size);
 	if (!dev) {
 		trace_error(TRACE_CLASS_COMP, "comp_make_shared(): unable to realloc component");
 		return NULL;

--- a/src/include/sof/lib/alloc.h
+++ b/src/include/sof/lib/alloc.h
@@ -115,7 +115,7 @@ static inline void *rballoc(uint32_t flags, uint32_t caps, size_t bytes)
  * @return Pointer to the resized memory or NULL if failed.
  *
  * Note: Do not use for buffers (SOF_MEM_ZONE_BUFFER zone).
- * Use rballoc(), rballoc_align() to allocate memory for buffers.
+ * Use rbrealloc(), rbrealloc_align() to reallocate memory for buffers.
  */
 void *rrealloc(void *ptr, enum mem_zone zone, uint32_t flags, uint32_t caps,
 	       size_t bytes, size_t old_bytes);

--- a/src/include/sof/lib/alloc.h
+++ b/src/include/sof/lib/alloc.h
@@ -62,6 +62,9 @@ enum mem_zone {
  */
 #define SOF_MEM_FLAG_SHARED	BIT(0)
 
+/** \brief Indicates that original content should not be copied by realloc. */
+#define SOF_MEM_FLAG_NO_COPY	BIT(1)
+
 /** @} */
 
 /**

--- a/src/include/sof/lib/alloc.h
+++ b/src/include/sof/lib/alloc.h
@@ -126,20 +126,22 @@ void *rrealloc(void *ptr, enum mem_zone zone, uint32_t flags, uint32_t caps,
  * @param flags Flags, see SOF_MEM_FLAG_...
  * @param caps Capabilities, see SOF_MEM_CAPS_...
  * @param bytes New size in bytes.
+ * @param old_bytes Old size in bytes.
  * @param alignment Alignment in bytes.
  * @return Pointer to the resized memory of NULL if failed.
  */
 void *rbrealloc_align(void *ptr, uint32_t flags, uint32_t caps, size_t bytes,
-		      uint32_t alignment);
+		      size_t old_bytes, uint32_t alignment);
 
 /**
  * Similar to rballoc_align(), returns resized buffer aligned to
  * PLATFORM_DCACHE_ALIGN.
  */
 static inline void *rbrealloc(void *ptr, uint32_t flags, uint32_t caps,
-			      size_t bytes)
+			      size_t bytes, size_t old_bytes)
 {
-	return rbrealloc_align(ptr, flags, caps, bytes, PLATFORM_DCACHE_ALIGN);
+	return rbrealloc_align(ptr, flags, caps, bytes, old_bytes,
+			       PLATFORM_DCACHE_ALIGN);
 }
 
 /**

--- a/src/include/sof/lib/alloc.h
+++ b/src/include/sof/lib/alloc.h
@@ -111,13 +111,14 @@ static inline void *rballoc(uint32_t flags, uint32_t caps, size_t bytes)
  * @param flags Flags, see SOF_MEM_FLAG_...
  * @param caps Capabilities, see SOF_MEM_CAPS_...
  * @param bytes New size in bytes.
+ * @param old_bytes Old size in bytes.
  * @return Pointer to the resized memory or NULL if failed.
  *
  * Note: Do not use for buffers (SOF_MEM_ZONE_BUFFER zone).
  * Use rballoc(), rballoc_align() to allocate memory for buffers.
  */
 void *rrealloc(void *ptr, enum mem_zone zone, uint32_t flags, uint32_t caps,
-	       size_t bytes);
+	       size_t bytes, size_t old_bytes);
 
 /**
  * Changes size of the memory block allocated from SOF_MEM_ZONE_BUFFER.

--- a/src/lib/alloc.c
+++ b/src/lib/alloc.c
@@ -12,6 +12,7 @@
 #include <sof/lib/dma.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/mm_heap.h>
+#include <sof/math/numbers.h>
 #include <sof/spinlock.h>
 #include <sof/string.h>
 #include <ipc/topology.h>
@@ -913,11 +914,12 @@ void rfree(void *ptr)
 }
 
 void *rrealloc(void *ptr, enum mem_zone zone, uint32_t flags, uint32_t caps,
-	       size_t bytes)
+	       size_t bytes, size_t old_bytes)
 {
 	struct mm *memmap = memmap_get();
 	void *new_ptr = NULL;
 	uint32_t lock_flags;
+	size_t copy_bytes = MIN(bytes, old_bytes);
 
 	if (!bytes)
 		return new_ptr;
@@ -927,7 +929,7 @@ void *rrealloc(void *ptr, enum mem_zone zone, uint32_t flags, uint32_t caps,
 	new_ptr = _malloc_unlocked(zone, flags, caps, bytes);
 
 	if (new_ptr && ptr)
-		memcpy_s(new_ptr, bytes, ptr, bytes);
+		memcpy_s(new_ptr, copy_bytes, ptr, copy_bytes);
 
 	if (new_ptr)
 		_rfree_unlocked(ptr);

--- a/src/lib/alloc.c
+++ b/src/lib/alloc.c
@@ -941,11 +941,12 @@ void *rrealloc(void *ptr, enum mem_zone zone, uint32_t flags, uint32_t caps,
 }
 
 void *rbrealloc_align(void *ptr, uint32_t flags, uint32_t caps, size_t bytes,
-		      uint32_t alignment)
+		      size_t old_bytes, uint32_t alignment)
 {
 	struct mm *memmap = memmap_get();
 	void *new_ptr = NULL;
 	uint32_t lock_flags;
+	size_t copy_bytes = MIN(bytes, old_bytes);
 
 	if (!bytes)
 		return new_ptr;
@@ -955,7 +956,7 @@ void *rbrealloc_align(void *ptr, uint32_t flags, uint32_t caps, size_t bytes,
 	new_ptr = _balloc_unlocked(flags, caps, bytes, alignment);
 
 	if (new_ptr && ptr)
-		memcpy_s(new_ptr, bytes, ptr, bytes);
+		memcpy_s(new_ptr, copy_bytes, ptr, copy_bytes);
 
 	if (new_ptr)
 		_rfree_unlocked(ptr);

--- a/src/lib/alloc.c
+++ b/src/lib/alloc.c
@@ -928,7 +928,7 @@ void *rrealloc(void *ptr, enum mem_zone zone, uint32_t flags, uint32_t caps,
 
 	new_ptr = _malloc_unlocked(zone, flags, caps, bytes);
 
-	if (new_ptr && ptr)
+	if (new_ptr && ptr && !(flags & SOF_MEM_FLAG_NO_COPY))
 		memcpy_s(new_ptr, copy_bytes, ptr, copy_bytes);
 
 	if (new_ptr)
@@ -955,7 +955,7 @@ void *rbrealloc_align(void *ptr, uint32_t flags, uint32_t caps, size_t bytes,
 
 	new_ptr = _balloc_unlocked(flags, caps, bytes, alignment);
 
-	if (new_ptr && ptr)
+	if (new_ptr && ptr && !(flags & SOF_MEM_FLAG_NO_COPY))
 		memcpy_s(new_ptr, copy_bytes, ptr, copy_bytes);
 
 	if (new_ptr)

--- a/test/cmocka/src/audio/component/mock.c
+++ b/test/cmocka/src/audio/component/mock.c
@@ -29,12 +29,13 @@ void *rzalloc(enum mem_zone zone, uint32_t flags, uint32_t caps, size_t bytes)
 }
 
 void *rrealloc(void *ptr, enum mem_zone zone, uint32_t flags, uint32_t caps,
-	       size_t bytes)
+	       size_t bytes, size_t old_bytes)
 {
 	(void)ptr;
 	(void)zone;
 	(void)flags;
 	(void)caps;
+	(void)old_bytes;
 
 	return realloc(ptr, bytes);
 }

--- a/test/cmocka/src/common_mocks.c
+++ b/test/cmocka/src/common_mocks.c
@@ -38,10 +38,11 @@ void WEAK *rzalloc(enum mem_zone zone, uint32_t flags, uint32_t caps,
 }
 
 void WEAK *rbrealloc_align(void *ptr, uint32_t flags, uint32_t caps,
-			   size_t bytes, uint32_t alignment)
+			   size_t bytes, size_t old_bytes, uint32_t alignment)
 {
 	(void)flags;
 	(void)caps;
+	(void)old_bytes;
 
 	return realloc(ptr, bytes);
 }

--- a/tools/testbench/alloc.c
+++ b/tools/testbench/alloc.c
@@ -45,7 +45,7 @@ void *rrealloc(void *ptr, enum mem_zone zone, uint32_t flags, uint32_t caps,
 }
 
 void *rbrealloc_align(void *ptr, uint32_t flags, uint32_t caps, size_t bytes,
-		      uint32_t alignment)
+		      size_t old_bytes, uint32_t alignment)
 {
 	return realloc(ptr, bytes);
 }

--- a/tools/testbench/alloc.c
+++ b/tools/testbench/alloc.c
@@ -39,7 +39,7 @@ void *rballoc_align(uint32_t flags, uint32_t caps, size_t bytes,
 }
 
 void *rrealloc(void *ptr, enum mem_zone zone, uint32_t flags, uint32_t caps,
-	       size_t bytes)
+	       size_t bytes, size_t old_bytes)
 {
 	return realloc(ptr, bytes);
 }


### PR DESCRIPTION
Previous memcpy of bytes is unsafe if new object is larger
then old one (which is probably most popular realloc use).

Typically realloc retrieves the old size internally and does
not need this information passed as argument but sof heap
implementation does not store the exact size of the allocated
memory buffer.

Signed-off-by: Marcin Maka <marcin.maka@linux.intel.com>