### PR TITLE
pipeline: atomic schedule of connected pipelines

### DIFF
--- a/src/include/sof/audio/pipeline.h
+++ b/src/include/sof/audio/pipeline.h
@@ -12,6 +12,7 @@
 #include <sof/lib/cpu.h>
 #include <sof/lib/mailbox.h>
 #include <sof/lib/memory.h>
+#include <sof/list.h>
 #include <sof/sof.h>
 #include <sof/spinlock.h>
 #include <sof/trace/trace.h>
@@ -106,6 +107,8 @@ struct pipeline {
 	struct comp_dev *source_comp;
 	/* sink component for this pipe */
 	struct comp_dev *sink_comp;
+
+	struct list_item list;	/**< list in walk context */
 
 	/* position update */
 	uint32_t posn_offset;		/* position update array offset*/


### PR DESCRIPTION
Implements atomic scheduling of connected pipelines that
supposed to be triggered at the same time. If the trigger
is propagated to the connected pipelines, then the expectation
is that they should be started at the same system tick.
Otherwise it might potentially lead to losing some samples
at the beginning for one of the pipes.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>

Fixes #2736.