### PR TITLE
irqsteer fixes for i.MX8MP

### DIFF
--- a/src/drivers/imx/interrupt.c
+++ b/src/drivers/imx/interrupt.c
@@ -137,6 +137,15 @@ static uint32_t irqstr_get_status_word(uint32_t index)
 	return irqstr_read(IRQSTR_CH_STATUS(index));
 }
 
+static uint32_t irqstr_fixup_irq(uint32_t irq)
+{
+#ifdef CONFIG_IMX8M
+	return irq - 32;
+#else
+	return irq;
+#endif
+}
+
 /* Mask, that is, disable interrupts */
 static void irqstr_mask_int(uint32_t irq)
 {
@@ -144,6 +153,9 @@ static void irqstr_mask_int(uint32_t irq)
 
 	if (irq < IRQSTR_RESERVED_IRQS_NUM || irq >= IRQSTR_IRQS_NUM)
 		return; // Unusable interrupts
+
+	irq = irqstr_fixup_irq(irq);
+
 	mask = IRQSTR_INT_MASK(irq);
 	irqstr_update_bits(IRQSTR_CH_MASK(IRQSTR_INT_REG(irq)), mask, 0);
 }
@@ -155,6 +167,9 @@ static void irqstr_unmask_int(uint32_t irq)
 
 	if (irq < IRQSTR_RESERVED_IRQS_NUM || irq >= IRQSTR_IRQS_NUM)
 		return; // Unusable interrupts
+
+	irq = irqstr_fixup_irq(irq);
+
 	mask = IRQSTR_INT_MASK(irq);
 	irqstr_update_bits(IRQSTR_CH_MASK(IRQSTR_INT_REG(irq)), mask, mask);
 }

--- a/src/drivers/imx/interrupt.c
+++ b/src/drivers/imx/interrupt.c
@@ -159,6 +159,29 @@ static void irqstr_unmask_int(uint32_t irq)
 	irqstr_update_bits(IRQSTR_CH_MASK(IRQSTR_INT_REG(irq)), mask, mask);
 }
 
+#ifdef CONFIG_IMX8M
+
+/* Quirk of the driver in SOF (Quirk is specific to 8MP):
+ * -> IRQSTR has 5 input channels each with 32 interrupts
+ * -> IRQSTR has 3 output channels each with 64 interrupts
+ * -> IRQ in[31:0]    => IRQ out[63:32]   (output channel #0)
+ * -> IRQ in[63:32]   => IRQ out[95:64]   (output channel #1, low half)
+ * -> IRQ in[95:64]   => IRQ out[127:96]  (output channel #1, high half)
+ * -> IRQ in[127:96]  => IRQ out[159:128] (output channel #2, low half)
+ * -> IRQ in[159:128] => IRQ out[191:160] (output channel #2, high half)
+ * Thus in SOF irqsteer we shift everything with 32 and we get:
+ * -> Interrupts 0-31 are not usable
+ * -> Interrupts 32-63 map to hw irqs 0-31 (irqsteer0)
+ * -> Interrupts 64-127 map to hw irqs 32-95 (irqsteer1)
+ * -> Interrupts 128-191 map to hw irqs 96-159 (irqsteer2)
+ */
+
+const char * const irq_name_irqsteer[] = {
+	"irqsteer0",
+	"irqsteer1",
+	"irqsteer2"
+};
+#else
 /* SOF specific part of the driver */
 
 /* Quirk of the driver in SOF (Quirk is specific to 8QXP/8QM):
@@ -180,6 +203,7 @@ const char * const irq_name_irqsteer[] = {
 	"irqsteer6",
 	"irqsteer7"
 };
+#endif
 
 #define IRQ_MAX_TRIES	1000
 

--- a/src/drivers/imx/interrupt.c
+++ b/src/drivers/imx/interrupt.c
@@ -225,6 +225,24 @@ const char * const irq_name_irqsteer[] = {
 /* Extract the 64 status bits corresponding to output interrupt line
  * index (64 input interrupts)
  */
+#ifdef CONFIG_IMX8M
+static uint64_t get_irqsteer_interrupts(uint32_t index)
+{
+	uint64_t result = 0;
+
+	result = irqstr_get_status_word(2 * index);
+	result <<= 32;
+
+	/* line 0 is special only maps interrupts [63..32],
+	 * interval [31..0] is not used
+	 */
+	if (index == 0)
+		return result;
+
+	result |= irqstr_get_status_word(2 * index - 1);
+	return result;
+}
+#else
 static uint64_t get_irqsteer_interrupts(uint32_t index)
 {
 	uint64_t result = irqstr_get_status_word(2 * index + 1);
@@ -233,6 +251,7 @@ static uint64_t get_irqsteer_interrupts(uint32_t index)
 	result |= irqstr_get_status_word(2 * index);
 	return result;
 }
+#endif
 
 /**
  * get_first_irq() Get the first IRQ bit set in this group.

--- a/src/platform/imx8m/include/platform/drivers/interrupt.h
+++ b/src/platform/imx8m/include/platform/drivers/interrupt.h
@@ -72,7 +72,7 @@
  * SOF internal interrupt numbers exactly; rather IRQ_STEER interrupt 0 will be
  * known as interrupt number 32 within SOF.
  */
-#define PLATFORM_IRQ_FIRST_CHILD  PLATFORM_IRQ_HW_NUM
+#define PLATFORM_IRQ_FIRST_CHILD  0
 
 /* irqstr_get_sof_int() - Convert IRQ_STEER interrupt to SOF logical
  * interrupt
@@ -105,15 +105,16 @@ int irqstr_get_sof_int(int irqstr_int);
  */
 #define IRQSTR_CHANCTL			0x00
 
-#define IRQSTR_CH_MASK(n)		(0x04 + 0x04 * (5 - (n)))
-#define IRQSTR_CH_SET(n)		(0x18 + 0x04 * (5 - (n)))
-#define IRQSTR_CH_STATUS(n)		(0x2C + 0x04 * (5 - (n)))
+#define IRQSTR_CH_MASK(n)		(0x04 + 0x04 * (4 - (n)))
+#define IRQSTR_CH_SET(n)		(0x18 + 0x04 * (4 - (n)))
+#define IRQSTR_CH_STATUS(n)		(0x2C + 0x04 * (4 - (n)))
+
 #define IRQSTR_MASTER_DISABLE		0x40
 #define IRQSTR_MASTER_STATUS		0x44
 
 #define IRQSTR_RESERVED_IRQS_NUM	32
 #define IRQSTR_IRQS_NUM			192
-#define IRQSTR_IRQS_REGISTERS_NUM	6
+#define IRQSTR_IRQS_REGISTERS_NUM	5
 #define IRQSTR_IRQS_PER_LINE		64
 
 #endif /* __PLATFORM_DRIVERS_INTERRUPT_H__ */


### PR DESCRIPTION
This is a couple of fixes after we got the correct documentation. Major modification is that on i.MX8MP
we have only 32 x 5 = 160 input irqs steered through 3 x 64 output interrupts. 

It seems to work fine, will keep it RFC for a while to allow @paulstelian97 to do some more testing.