### PR TITLE
CI: travis: add doxygen stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ stages:
   - test
   - qemutest
   - testbench
+  - doxygen
 
 before_install:
   - docker pull thesofproject/sof && docker tag thesofproject/sof sof
@@ -80,3 +81,18 @@ jobs:
         - ./scripts/docker-run.sh ./scripts/build-tools.sh -t &> /dev/null
         - ./scripts/docker-run.sh ./scripts/host-build-all.sh
         - ./scripts/host-testbench.sh
+
+    - stage: doxygen
+
+      before_install: sudo apt-get -y install ninja-build doxygen graphviz
+
+      script:
+
+        # Show ALL warnings. Warnings don't cause doxygen to fail (yet).
+        - mkdir -p doxybuild && pushd doxybuild && cmake -GNinja -S ../doc && ninja -v doc
+        - popd
+
+        # Build again (it's very quick) and report a failure in Travis if
+        # any issue. This time doxygen stops on the first issue.
+        - printf 'WARN_AS_ERROR = YES\n' >> doc/sof.doxygen.in
+        - ninja -C doxybuild -v doc


### PR DESCRIPTION
Before this new stage, doxygen was run only in a completely different
repo (sof-docs). So it was possible to submit totally broken doxygen
changes and get no doxygen feedback at all from CI before merge.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>