### PR TITLE
kpb: fix broken doxygen link to kpbm-state-diagram

### DIFF
--- a/src/include/sof/audio/kpb.h
+++ b/src/include/sof/audio/kpb.h
@@ -41,10 +41,9 @@ struct comp_buffer;
  * the sof-dosc in [kpbm-state-diagram]
  * Therefore any addition of new states or modification of existing ones
  * should have a corresponding update in the sof-docs.
- * [kpbm-state-diagram]: https://thesofproject.github.io/latest/
- * developer_guides/firmware/kd_integration/
- * kd-integration.html#kpbm-state-diagram "Keyphrase buffer manager state
- * diagram"
+ * [kpbm-state-diagram]:
+https://thesofproject.github.io/latest/developer_guides/firmware/kd_integration/kd-integration.html#kpbm-state-diagram
+"Keyphrase buffer manager state diagram"
  */
 enum kpb_state {
 	KPB_STATE_DISABLED = 0,


### PR DESCRIPTION
As reported by PR #2741:
```
sof/src/include/sof/audio/kpb.h:46: warning: explicit link request to 'kpbm' could not be resolved
```

Fixes: 36d4c9f ("kpb: add new state")

Signed-off-by: Marc Herbert <marc.herbert@intel.com>