### PR TITLE
audio stream: Implement XRUN-permitted behaviour

### DIFF
--- a/src/audio/asrc/asrc.c
+++ b/src/audio/asrc/asrc.c
@@ -839,10 +839,8 @@ static int asrc_copy(struct comp_dev *dev)
 	buffer_lock(source, &flags);
 	buffer_lock(sink, &flags);
 
-	frames_src = source->stream.avail /
-		     audio_stream_frame_bytes(&source->stream);
-	frames_snk = sink->stream.free /
-		     audio_stream_frame_bytes(&sink->stream);
+	frames_src = audio_stream_get_avail_frames(&source->stream);
+	frames_snk = audio_stream_get_free_frames(&sink->stream);
 
 	buffer_unlock(sink, flags);
 	buffer_unlock(source, flags);

--- a/src/audio/buffer.c
+++ b/src/audio/buffer.c
@@ -79,6 +79,11 @@ struct comp_buffer *buffer_new(struct sof_ipc_buffer *desc)
 		buffer->pipeline_id = desc->comp.pipeline_id;
 		buffer->core = desc->comp.core;
 
+		buffer->stream.underrun_permitted = desc->flags &
+						    SOF_BUF_UNDERRUN_PERMITTED;
+		buffer->stream.overrun_permitted = desc->flags &
+						   SOF_BUF_OVERRUN_PERMITTED;
+
 		dcache_writeback_invalidate_region(buffer, sizeof(*buffer));
 	}
 

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -707,24 +707,20 @@ static int src_get_copy_limits(struct comp_data *cd,
 	 */
 	if (s2->filter_length > 1) {
 		/* Two polyphase filters case */
-		frames_snk = sink->stream.free /
-			     audio_stream_frame_bytes(&sink->stream);
+		frames_snk = audio_stream_get_free_frames(&sink->stream);
 		frames_snk = MIN(frames_snk, cd->sink_frames + s2->blk_out);
 		sp->stage2_times = frames_snk / s2->blk_out;
-		frames_src = source->stream.avail /
-			     audio_stream_frame_bytes(&source->stream);
+		frames_src = audio_stream_get_avail_frames(&source->stream);
 		frames_src = MIN(frames_src, cd->source_frames + s1->blk_in);
 		sp->stage1_times = frames_src / s1->blk_in;
 		sp->blk_in = sp->stage1_times * s1->blk_in;
 		sp->blk_out = sp->stage2_times * s2->blk_out;
 	} else {
 		/* Single polyphase filter case */
-		frames_snk = sink->stream.free /
-			     audio_stream_frame_bytes(&sink->stream);
+		frames_snk = audio_stream_get_free_frames(&sink->stream);
 		frames_snk = MIN(frames_snk, cd->sink_frames + s1->blk_out);
 		sp->stage1_times = frames_snk / s1->blk_out;
-		frames_src = source->stream.avail /
-			     audio_stream_frame_bytes(&source->stream);
+		frames_src = audio_stream_get_avail_frames(&source->stream);
 		frames_snk = MIN(frames_src, cd->source_frames + s1->blk_in);
 		sp->stage1_times = MIN(sp->stage1_times,
 				       frames_src / s1->blk_in);

--- a/src/audio/tone.c
+++ b/src/audio/tone.c
@@ -627,7 +627,7 @@ static int tone_copy(struct comp_dev *dev)
 			       source_list);
 
 	buffer_lock(sink, &flags);
-	free = sink->stream.free;
+	free = audio_stream_get_free_bytes(&sink->stream);
 	buffer_unlock(sink, flags);
 
 	/* Test that sink has enough free frames. Then run once to maintain

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -652,11 +652,12 @@ static inline void comp_underrun(struct comp_dev *dev,
 				 struct comp_buffer *source,
 				 uint32_t copy_bytes)
 {
-	int32_t bytes = (int32_t)source->stream.avail - copy_bytes;
+	int32_t bytes = (int32_t)audio_stream_get_avail_bytes(&source->stream) -
+			copy_bytes;
 
 	comp_err(dev, "comp_underrun(): dev->comp.id = %u, source->avail = %u, copy_bytes = %u",
 		 dev_comp_id(dev),
-		 source->stream.avail,
+		 audio_stream_get_avail_bytes(&source->stream),
 		 copy_bytes);
 
 	pipeline_xrun(dev->pipeline, dev, bytes);
@@ -671,10 +672,11 @@ static inline void comp_underrun(struct comp_dev *dev,
 static inline void comp_overrun(struct comp_dev *dev, struct comp_buffer *sink,
 				uint32_t copy_bytes)
 {
-	int32_t bytes = (int32_t)copy_bytes - sink->stream.free;
+	int32_t bytes = (int32_t)copy_bytes -
+			audio_stream_get_free_bytes(&sink->stream);
 
 	comp_err(dev, "comp_overrun(): sink->free = %u, copy_bytes = %u",
-		 sink->stream.free, copy_bytes);
+		 audio_stream_get_free_bytes(&sink->stream), copy_bytes);
 
 	pipeline_xrun(dev->pipeline, dev, bytes);
 }


### PR DESCRIPTION
This is follow-up to recently merged PR https://github.com/thesofproject/sof/pull/2580

underrun_permitted and overrun_permitted fields have been added to audio_stream structure and initialized during buffer instantiation.
audio_stream_get_<free/avail>_<bytes/samples/frames> functions have been added to audio stream interface, and all occurrences of old API usage have been replaced with the new one.