### PR TITLE
audio: dcblock: Fix doxygen error for dcblock.h

### DIFF
--- a/src/include/sof/audio/dcblock/dcblock.h
+++ b/src/include/sof/audio/dcblock/dcblock.h
@@ -55,8 +55,9 @@ extern const struct dcblock_func_map dcblock_fnmap[];
 extern const size_t dcblock_fncount;
 
 /**
- * \brief Retrieives DC Blocking processing function.
- * \param[in,out] dev DC Blocking Filter base component device.
+ * \brief Retrieves a DC Blocking processing function matching
+ *	  the source buffer's frame format.
+ * \param src_fmt the frames' format of the source buffer
  */
 static inline dcblock_func dcblock_find_func(enum sof_ipc_frame src_fmt)
 {


### PR DESCRIPTION
This commit fixes a doxygen issue caused by a mismatch between
dcblock_find_func()'s declaration and its corresponding comment block.

Signed-off-by: Sebastiano Carlucci <scarlucci@google.com>