### PR TITLE
audio: dcblock: Fix int overflow issue in dcblocker

### DIFF
--- a/src/audio/dcblock/dcblock_generic.c
+++ b/src/audio/dcblock/dcblock_generic.c
@@ -21,7 +21,7 @@ static int32_t dcblock_generic(struct dcblock_state *state,
 	 * R: Q2.30, y_prev: Q1.31
 	 * R * y_prev: Q3.61
 	 */
-	int64_t out = x - state->x_prev +
+	int64_t out = ((int64_t)x) - state->x_prev +
 		      Q_SHIFT_RND(R * state->y_prev, 61, 31);
 
 	state->y_prev = sat_int32(out);


### PR DESCRIPTION
This patch fixes an integer overflow issue that can occur in the
dcblocker. The overflow happened when doing x - x_prev. If x_prev
was sufficiently large (positive or negative), it caused an overflow.

Casting x to a 64 bit int first fixes this issue.

Signed-off-by: Sebastiano Carlucci <scarlucci@google.com>