### PR TITLE
CI: Travis: disable host-testbench as long as it ignores errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,6 +68,9 @@ jobs:
 
 
     - stage: testbench
+      # Disabled for as long as host-testbench.sh ignores failures, see
+      # https://github.com/thesofproject/sof/issues/2752
+      if: false
       before_install: *docker-pull-sof
       script:
         - ./scripts/docker-run.sh ./scripts/build-tools.sh -t &> /dev/null


### PR DESCRIPTION
See https://github.com/thesofproject/sof/issues/2752

host-testbench.sh exits with success 0 when tests fail. Random, recent, all
green example in PR #2751:

https://travis-ci.org/github/thesofproject/sof/jobs/672996210 is green but:
```
  eqiir test failed!
```
I didn't even have to spend time to search for this example, I only
looked at the most recent PR.

Ignoring failures is the very worst type of validation issue because it
makes everyone think everything is OK when it's not. Hides regressions.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>