### PR TITLE
clang: fix 2 issues reported by scan-build

### DIFF
--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -721,7 +721,6 @@ static int src_get_copy_limits(struct comp_data *cd,
 		frames_snk = MIN(frames_snk, cd->sink_frames + s1->blk_out);
 		sp->stage1_times = frames_snk / s1->blk_out;
 		frames_src = audio_stream_get_avail_frames(&source->stream);
-		frames_snk = MIN(frames_src, cd->source_frames + s1->blk_in);
 		sp->stage1_times = MIN(sp->stage1_times,
 				       frames_src / s1->blk_in);
 		sp->blk_in = sp->stage1_times * s1->blk_in;

--- a/src/include/sof/debug/debug.h
+++ b/src/include/sof/debug/debug.h
@@ -153,7 +153,6 @@ static inline uint32_t dump_stack(uint32_t p, void *addr, size_t offset,
 
 	/* is stack smashed ? */
 	if (stack_top - offset <= stack_limit) {
-		stack_bottom = stack_limit;
 		p = SOF_IPC_PANIC_STACK;
 		return p;
 	}


### PR DESCRIPTION
@singalsu Please check one related to src, because maybe you missed something that's why there was left dead assignment.