### PR TITLE
alloc: remove unused rrealloc

### DIFF
--- a/src/include/sof/lib/alloc.h
+++ b/src/include/sof/lib/alloc.h
@@ -108,22 +108,6 @@ static inline void *rballoc(uint32_t flags, uint32_t caps, size_t bytes)
 }
 
 /**
- * Changes size of the memory block.
- * @param ptr Address of the block to resize.
- * @param zone Zone, see enum mem_zone.
- * @param flags Flags, see SOF_MEM_FLAG_...
- * @param caps Capabilities, see SOF_MEM_CAPS_...
- * @param bytes New size in bytes.
- * @param old_bytes Old size in bytes.
- * @return Pointer to the resized memory or NULL if failed.
- *
- * Note: Do not use for buffers (SOF_MEM_ZONE_BUFFER zone).
- * Use rbrealloc(), rbrealloc_align() to reallocate memory for buffers.
- */
-void *rrealloc(void *ptr, enum mem_zone zone, uint32_t flags, uint32_t caps,
-	       size_t bytes, size_t old_bytes);
-
-/**
  * Changes size of the memory block allocated from SOF_MEM_ZONE_BUFFER.
  * @param ptr Address of the block to resize.
  * @param flags Flags, see SOF_MEM_FLAG_...

--- a/src/lib/alloc.c
+++ b/src/lib/alloc.c
@@ -913,33 +913,6 @@ void rfree(void *ptr)
 	spin_unlock_irq(&memmap->lock, flags);
 }
 
-void *rrealloc(void *ptr, enum mem_zone zone, uint32_t flags, uint32_t caps,
-	       size_t bytes, size_t old_bytes)
-{
-	struct mm *memmap = memmap_get();
-	void *new_ptr = NULL;
-	uint32_t lock_flags;
-	size_t copy_bytes = MIN(bytes, old_bytes);
-
-	if (!bytes)
-		return new_ptr;
-
-	spin_lock_irq(&memmap->lock, lock_flags);
-
-	new_ptr = _malloc_unlocked(zone, flags, caps, bytes);
-
-	if (new_ptr && ptr && !(flags & SOF_MEM_FLAG_NO_COPY))
-		memcpy_s(new_ptr, copy_bytes, ptr, copy_bytes);
-
-	if (new_ptr)
-		_rfree_unlocked(ptr);
-
-	spin_unlock_irq(&memmap->lock, lock_flags);
-
-	DEBUG_TRACE_PTR(ptr, bytes, zone, caps, flags);
-	return new_ptr;
-}
-
 void *rbrealloc_align(void *ptr, uint32_t flags, uint32_t caps, size_t bytes,
 		      size_t old_bytes, uint32_t alignment)
 {

--- a/test/cmocka/src/audio/component/mock.c
+++ b/test/cmocka/src/audio/component/mock.c
@@ -28,18 +28,6 @@ void *rzalloc(enum mem_zone zone, uint32_t flags, uint32_t caps, size_t bytes)
 	return calloc(bytes, 1);
 }
 
-void *rrealloc(void *ptr, enum mem_zone zone, uint32_t flags, uint32_t caps,
-	       size_t bytes, size_t old_bytes)
-{
-	(void)ptr;
-	(void)zone;
-	(void)flags;
-	(void)caps;
-	(void)old_bytes;
-
-	return realloc(ptr, bytes);
-}
-
 int buffer_set_size(struct comp_buffer *buffer, uint32_t size)
 {
 	(void)buffer;

--- a/tools/testbench/alloc.c
+++ b/tools/testbench/alloc.c
@@ -38,12 +38,6 @@ void *rballoc_align(uint32_t flags, uint32_t caps, size_t bytes,
 	return malloc(bytes);
 }
 
-void *rrealloc(void *ptr, enum mem_zone zone, uint32_t flags, uint32_t caps,
-	       size_t bytes, size_t old_bytes)
-{
-	return realloc(ptr, bytes);
-}
-
 void *rbrealloc_align(void *ptr, uint32_t flags, uint32_t caps, size_t bytes,
 		      size_t old_bytes, uint32_t alignment)
 {


### PR DESCRIPTION
rrealloc function is no longer in use, so it is better
to remove it. Unused code is no longer tested so its
quality is unknown.

The current implementation is simple but expensive since
extra calls to malloc/free requires time and risky since
at some point requires double allocation of potentially
large object. Please consider re-implementation instead
of restoring.

Signed-off-by: Marcin Maka <marcin.maka@linux.intel.com>