### PR TITLE
hda: retrieve hda hardware params from ipc

### DIFF
--- a/src/drivers/intel/cavs/alh.c
+++ b/src/drivers/intel/cavs/alh.c
@@ -89,7 +89,7 @@ static int alh_probe(struct dai *dai)
 	alh = rzalloc(SOF_MEM_ZONE_SYS_RUNTIME, 0, SOF_MEM_CAPS_RAM,
 		      sizeof(*alh));
 	if (!alh) {
-		dai_err(dai, "ssp_probe() error: alloc failed");
+		dai_err(dai, "alh_probe() error: alloc failed");
 		return -ENOMEM;
 	}
 	dai_set_drvdata(dai, alh);

--- a/src/include/ipc/dai-intel.h
+++ b/src/include/ipc/dai-intel.h
@@ -96,6 +96,8 @@ struct sof_ipc_dai_ssp_params {
 struct sof_ipc_dai_hda_params {
 	uint32_t reserved0;
 	uint32_t link_dma_ch;
+	uint32_t rate;
+	uint32_t channels;
 } __attribute__((packed));
 
 /* ALH Configuration Request - SOF_IPC_DAI_ALH_CONFIG */

--- a/src/include/kernel/abi.h
+++ b/src/include/kernel/abi.h
@@ -29,7 +29,7 @@
 
 /** \brief SOF ABI version major, minor and patch numbers */
 #define SOF_ABI_MAJOR 3
-#define SOF_ABI_MINOR 15
+#define SOF_ABI_MINOR 16
 #define SOF_ABI_PATCH 0
 
 /** \brief SOF ABI version number. Format within 32bit word is MMmmmppp */

--- a/src/include/sof/drivers/hda.h
+++ b/src/include/sof/drivers/hda.h
@@ -8,7 +8,12 @@
 #ifndef __SOF_DRIVERS_HDA_H__
 #define __SOF_DRIVERS_HDA_H__
 
+#include <ipc/dai-intel.h>
 #include <sof/lib/dai.h>
+
+struct hda_pdata {
+	struct sof_ipc_dai_hda_params params;
+};
 
 extern const struct dai_driver hda_driver;
 


### PR DESCRIPTION
This is an analogous change to what's been done for ALH DAIs.
Similarly, HDA is set up on the host side.

As a result, the firmware normally has no knowledge
of the hardware configuration, which leads to failures
in components, that may modify stream parameters, such as
(de)mux or asrc.

Kernel side PR: https://github.com/thesofproject/linux/pull/2007