### PR TITLE
Move low level trace messages to dbg level

### DIFF
--- a/src/audio/buffer.c
+++ b/src/audio/buffer.c
@@ -70,7 +70,8 @@ struct comp_buffer *buffer_new(struct sof_ipc_buffer *desc)
 {
 	struct comp_buffer *buffer;
 
-	trace_buffer("buffer_new()");
+	trace_buffer("buffer new size 0x%x id %d.%d", desc->size,
+		     desc->comp.pipeline_id, desc->comp.id);
 
 	/* allocate buffer */
 	buffer = buffer_alloc(desc->size, desc->caps, PLATFORM_DCACHE_ALIGN);

--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -70,7 +70,7 @@ struct comp_dev *comp_new(struct sof_ipc_comp *comp)
 		return NULL;
 	}
 
-	trace_event(TRACE_CLASS_COMP, "comp new %s type %d pipe_id %d id %d",
+	trace_event(TRACE_CLASS_COMP, "comp new %s type %d id %d.%d",
 		    drv->uid, comp->type, comp->pipeline_id, comp->id);
 
 	/* create the new component */

--- a/src/audio/pipeline.c
+++ b/src/audio/pipeline.c
@@ -63,7 +63,9 @@ struct pipeline *pipeline_new(struct sof_ipc_pipe_new *pipe_desc,
 	struct pipeline *p;
 	int ret;
 
-	pipe_cl_info("pipeline_new()");
+	pipe_cl_info("pipeline new pipe_id %d period %d priority %d",
+		     pipe_desc->pipeline_id, pipe_desc->period,
+		     pipe_desc->priority);
 
 	/* allocate new pipeline */
 	p = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM, sizeof(*p));
@@ -107,8 +109,10 @@ int pipeline_connect(struct comp_dev *comp, struct comp_buffer *buffer,
 {
 	uint32_t flags;
 
-	pipe_cl_info("pipeline: connect comp %d and buffer %d",
-		     dev_comp_id(comp), buffer->id);
+	if (dir == PPL_CONN_DIR_COMP_TO_BUFFER)
+		comp_info(comp, "connect buffer %d as sink", buffer->id);
+	else
+		comp_info(comp, "connect buffer %d as source", buffer->id);
 
 	irq_local_disable(flags);
 	list_item_prepend(buffer_comp_list(buffer, dir),
@@ -208,7 +212,7 @@ int pipeline_complete(struct pipeline *p, struct comp_dev *source,
 		.comp_data = &data,
 	};
 
-	pipe_info(p, "pipeline_complete()");
+	pipe_info(p, "pipeline complete");
 
 	/* check whether pipeline is already completed */
 	if (p->status != COMP_STATE_INIT) {

--- a/src/include/sof/drivers/ipc.h
+++ b/src/include/sof/drivers/ipc.h
@@ -47,6 +47,8 @@ struct ipc_msg;
 	trace_event(TRACE_CLASS_IPC, format, ##__VA_ARGS__)
 #define tracev_ipc(format, ...) \
 	tracev_event(TRACE_CLASS_IPC, format, ##__VA_ARGS__)
+#define trace_ipc_warn(format, ...) \
+	trace_warn(TRACE_CLASS_IPC, format, ##__VA_ARGS__)
 #define trace_ipc_error(format, ...) \
 	trace_error(TRACE_CLASS_IPC, format, ##__VA_ARGS__)
 

--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -236,7 +236,7 @@ static int ipc_stream_pcm_params(uint32_t stream)
 	if (!cpu_is_me(pcm_dev->core))
 		return ipc_process_on_core(pcm_dev->core);
 
-	trace_ipc("ipc: comp %d -> params", pcm_params.comp_id);
+	tracev_ipc("ipc: comp %d -> params", pcm_params.comp_id);
 
 	/* sanity check comp */
 	if (!pcm_dev->cd->pipeline) {
@@ -354,7 +354,7 @@ static int ipc_stream_pcm_free(uint32_t header)
 	if (!cpu_is_me(pcm_dev->core))
 		return ipc_process_on_core(pcm_dev->core);
 
-	trace_ipc("ipc: comp %d -> free", free_req.comp_id);
+	tracev_ipc("ipc: comp %d -> free", free_req.comp_id);
 
 	/* sanity check comp */
 	if (!pcm_dev->cd->pipeline) {
@@ -438,7 +438,7 @@ static int ipc_stream_trigger(uint32_t header)
 	if (!cpu_is_me(pcm_dev->core))
 		return ipc_process_on_core(pcm_dev->core);
 
-	trace_ipc("ipc: comp %d -> trigger cmd 0x%x", stream.comp_id, ipc_cmd);
+	tracev_ipc("ipc: comp %d -> trigger cmd 0x%x", stream.comp_id, ipc_cmd);
 
 	switch (ipc_cmd) {
 	case SOF_IPC_STREAM_TRIG_START:
@@ -509,8 +509,8 @@ static int ipc_dai_config(uint32_t header)
 	/* copy message with ABI safe method */
 	IPC_COPY_CMD(config, ipc->comp_data);
 
-	trace_ipc("ipc: dai %d.%d -> config ", config.type,
-		  config.dai_index);
+	tracev_ipc("ipc: dai %d.%d -> config ", config.type,
+		   config.dai_index);
 
 	/* send params to all DAI components who use that physical DAI */
 	return ipc_comp_dai_config(ipc,
@@ -992,7 +992,7 @@ static int ipc_comp_value(uint32_t header, uint32_t cmd)
 	if (!cpu_is_me(comp_dev->core))
 		return ipc_process_on_core(comp_dev->core);
 
-	trace_ipc("ipc: comp %d -> cmd %d", data->comp_id, data->cmd);
+	tracev_ipc("ipc: comp %d -> cmd %d", data->comp_id, data->cmd);
 
 	/* get component values */
 	ret = comp_cmd(comp_dev->cd, cmd, data, SOF_IPC_MSG_MAX_SIZE);
@@ -1055,8 +1055,8 @@ static int ipc_glb_tplg_comp_new(uint32_t header)
 	if (!cpu_is_me(comp->core))
 		return ipc_process_on_core(comp->core);
 
-	trace_ipc("ipc: pipe %d comp %d -> new (type %d)", comp->pipeline_id,
-		  comp->id, comp->type);
+	tracev_ipc("ipc: pipe %d comp %d -> new (type %d)", comp->pipeline_id,
+		   comp->id, comp->type);
 
 	/* register component */
 	ret = ipc_comp_new(ipc, comp);
@@ -1091,9 +1091,9 @@ static int ipc_glb_tplg_buffer_new(uint32_t header)
 	if (!cpu_is_me(ipc_buffer.comp.core))
 		return ipc_process_on_core(ipc_buffer.comp.core);
 
-	trace_ipc("ipc: pipe %d buffer %d -> new (0x%x bytes)",
-		  ipc_buffer.comp.pipeline_id, ipc_buffer.comp.id,
-		  ipc_buffer.size);
+	tracev_ipc("ipc: pipe %d buffer %d -> new (0x%x bytes)",
+		   ipc_buffer.comp.pipeline_id, ipc_buffer.comp.id,
+		   ipc_buffer.size);
 
 	ret = ipc_buffer_new(ipc, (struct sof_ipc_buffer *)ipc->comp_data);
 	if (ret < 0) {
@@ -1128,7 +1128,7 @@ static int ipc_glb_tplg_pipe_new(uint32_t header)
 	if (!cpu_is_me(ipc_pipeline.core))
 		return ipc_process_on_core(ipc_pipeline.core);
 
-	trace_ipc("ipc: pipe %d -> new", ipc_pipeline.pipeline_id);
+	tracev_ipc("ipc: pipe %d -> new", ipc_pipeline.pipeline_id);
 
 	ret = ipc_pipeline_new(ipc,
 			       (struct sof_ipc_pipe_new *)ipc->comp_data);

--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -94,13 +94,13 @@
 			___ret = memcpy_s(rx, rx_size, tx, tx->size);	\
 			assert(!___ret);				\
 			bzero((char *)rx + tx->size, rx_size - tx->size);\
-			trace_ipc("ipc: hdr 0x%x rx (%d) > tx (%d)",	\
-				  rx->cmd, rx_size, tx->size);		\
+			tracev_ipc("ipc: hdr 0x%x rx (%d) > tx (%d)",	\
+				   rx->cmd, rx_size, tx->size);		\
 		} else if (tx->size > rx_size) {			\
 			___ret = memcpy_s(rx, rx_size, tx, rx_size);	\
 			assert(!___ret);				\
-			trace_ipc("ipc: hdr 0x%x tx (%d) > rx (%d)",	\
-				  rx->cmd, tx->size, rx_size);		\
+			trace_ipc_warn("ipc: hdr 0x%x tx (%d) > rx (%d)",\
+				       rx->cmd, tx->size, rx_size);	\
 		} else	{						\
 			___ret = memcpy_s(rx, rx_size, tx, rx_size);	\
 			assert(!___ret);				\

--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -1010,7 +1010,7 @@ static int ipc_comp_value(uint32_t header, uint32_t cmd)
 	/* write component values to the outbox */
 	if (_data->rhdr.hdr.size <= MAILBOX_HOSTBOX_SIZE &&
 	    _data->rhdr.hdr.size <= SOF_IPC_MSG_MAX_SIZE) {
-		mailbox_hostbox_write(0, _data, data.rhdr.hdr.size);
+		mailbox_hostbox_write(0, _data, _data->rhdr.hdr.size);
 		ret = 1;
 	} else {
 		trace_ipc_error("ipc: comp %d cmd %u returned %d bytes max %d",

--- a/src/ipc/ipc.c
+++ b/src/ipc/ipc.c
@@ -317,8 +317,8 @@ static int ipc_comp_to_buffer_connect(struct ipc_comp_dev *comp,
 	if (!cpu_is_me(comp->core))
 		return ipc_process_on_core(comp->core);
 
-	trace_ipc("ipc: comp sink %d, source %d  -> connect", buffer->id,
-		  comp->id);
+	tracev_ipc("ipc: comp sink %d, source %d  -> connect", buffer->id,
+		   comp->id);
 
 	/* check if it's a connection between cores */
 	if (buffer->core != comp->core) {
@@ -352,8 +352,8 @@ static int ipc_buffer_to_comp_connect(struct ipc_comp_dev *buffer,
 	if (!cpu_is_me(comp->core))
 		return ipc_process_on_core(comp->core);
 
-	trace_ipc("ipc: comp sink %d, source %d  -> connect", comp->id,
-		  buffer->id);
+	tracev_ipc("ipc: comp sink %d, source %d  -> connect", comp->id,
+		   buffer->id);
 
 	/* check if it's a connection between cores */
 	if (buffer->core != comp->core) {
@@ -529,7 +529,7 @@ int ipc_pipeline_complete(struct ipc *ipc, uint32_t comp_id)
 	if (!cpu_is_me(ipc_pipe->core))
 		return ipc_process_on_core(ipc_pipe->core);
 
-	trace_ipc("ipc: pipe %d -> complete", comp_id);
+	tracev_ipc("ipc: pipe %d -> complete", comp_id);
 
 	pipeline_id = ipc_pipe->pipeline->ipc_pipe.pipeline_id;
 


### PR DESCRIPTION
They are useful while debugging the stack while target (pipeline, component, buffer) traces are sufficient to investigate sequences of events.

PR contains also a cleanup of incomplete ipc data copies to avoid false positive ABI incompatibility alarms.