### PR TITLE
include: common: surround macro argument with parantheses

### DIFF
--- a/src/include/sof/common.h
+++ b/src/include/sof/common.h
@@ -24,7 +24,7 @@
 #include <stddef.h>
 
 /* use same syntax as Linux for simplicity */
-#define ARRAY_SIZE(x) (sizeof(x) / sizeof(x[0]))
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
 #define container_of(ptr, type, member) \
 	({const typeof(((type *)0)->member)*__memberptr = (ptr); \
 	(type *)((char *)__memberptr - offsetof(type, member)); })


### PR DESCRIPTION
This commit fixes the warning generated by clang-tidy due to
bugprone macro parentheses. It is recommended to surround macro
arguments in the replacement list with parentheses. This ensures
that the argument value is calculated properly.

Name of the warning generated: bugprone-macro-parentheses

Signed-off-by: Mohana Datta Yelugoti <ymdatta.work@gmail.com>