### PR TITLE
audio: remove extra blank lines

### DIFF
--- a/src/audio/tone.c
+++ b/src/audio/tone.c
@@ -503,7 +503,6 @@ static int tone_cmd_set_value(struct comp_dev *dev,
 				tonegen_unmute(&cd->sg[ch]);
 			else
 				tonegen_mute(&cd->sg[ch]);
-
 		}
 	} else {
 		comp_err(dev, "tone_cmd_set_value(): invalid cdata->cmd");
@@ -686,7 +685,6 @@ static int tone_prepare(struct comp_dev *dev)
 
 static int tone_reset(struct comp_dev *dev)
 {
-
 	struct comp_data *cd = comp_get_drvdata(dev);
 	int i;
 


### PR DESCRIPTION
Remove extra blank lines before and after curly braces. Problem
reported by checkpatch script.

Signed-off-by: Deepak R Varma <mh12gx2825@gmail.com>