### PR TITLE
doxygen: subgroup dma_copy() to solve conflict with struct dma_copy {}

### DIFF
--- a/src/include/sof/lib/dma.h
+++ b/src/include/sof/lib/dma.h
@@ -319,6 +319,12 @@ static inline int dma_stop(struct dma_chan_data *channel)
 	return ret;
 }
 
+/** \defgroup sof_dma_copy_func static int dma_copy (struct dma_chan_data * channel, int bytes, uint32_t flags)
+ *
+ * This function is in a separate subgroup to solve a name clash with
+ * struct dma_copy {}
+ * @{
+ */
 static inline int dma_copy(struct dma_chan_data *channel, int bytes,
 			   uint32_t flags)
 {
@@ -329,6 +335,7 @@ static inline int dma_copy(struct dma_chan_data *channel, int bytes,
 
 	return ret;
 }
+/** @} */
 
 static inline int dma_pause(struct dma_chan_data *channel)
 {


### PR DESCRIPTION
Name clash reported by sphinx/breathe:
 sof-docs/api/dma-drivers-api.rst:6: WARNING: Duplicate declaration, dma_copy

Before this commit:

- all "dma_copy" links in doxygen pointed to the struct, never to the
  function,
- there was no "dma_copy" link of any kind in sphinx.

With this commit:

- most "dma_copy" links in doxygen are disambiguited and fixed, see
  html/dma_8h_source.html for instance,
- there are dma_copy links to the struct in sphinx.

Once this is a merged, a commit in sof-docs will add the new subgroup
and re-add the function to sof-docs/api/dma-drivers-api.rst

Fixes: fa8abe145c0d ("core: dma: Add DMA copy API.")

Reference:
  http://www.doxygen.nl/manual/grouping.html

Signed-off-by: Marc Herbert <marc.herbert@intel.com>