### PR TITLE
logger: per_cnt: Explicit cast arguments to uint32_t

### DIFF
--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -199,8 +199,9 @@ struct dai_hw_params;
 		      trace_comp_get_subid, comp_p, __e, ##__VA_ARGS__)
 
 #define comp_perf_info(pcd, comp_p)					\
-	comp_info(comp_p, "perf comp_copy peak plat %lu cpu %lu",	\
-		  (pcd)->plat_delta_peak, (pcd)->cpu_delta_peak)
+	comp_info(comp_p, "perf comp_copy peak plat %d cpu %d",		\
+		  (uint32_t)((pcd)->plat_delta_peak),			\
+		  (uint32_t)((pcd)->cpu_delta_peak))
 
 /** @}*/
 

--- a/src/include/sof/lib/perf_cnt.h
+++ b/src/include/sof/lib/perf_cnt.h
@@ -28,11 +28,11 @@ struct perf_cnt_data {
 #if CONFIG_PERFORMANCE_COUNTERS
 
 #define perf_cnt_trace(tclass, pcd) \
-		trace_event(tclass, "perf plat last %lu peak %lu cpu last %lu, peak %lu", \
-			    (pcd)->plat_delta_last,	\
-			    (pcd)->plat_delta_peak,	\
-			    (pcd)->cpu_delta_last,	\
-			    (pcd)->cpu_delta_peak)
+		trace_event(tclass, "perf plat last %u peak %u cpu last %u, peak %u", \
+			    (uint32_t)((pcd)->plat_delta_last),	\
+			    (uint32_t)((pcd)->plat_delta_peak),	\
+			    (uint32_t)((pcd)->cpu_delta_last),	\
+			    (uint32_t)((pcd)->cpu_delta_peak))
 
 /** \brief Clears performance counters data. */
 #define perf_cnt_clear(pcd) memset((pcd), 0, sizeof(struct perf_cnt_data))

--- a/src/lib/agent.c
+++ b/src/lib/agent.c
@@ -38,9 +38,10 @@
 #define trace_sa_error(__e, ...) \
 	trace_error(TRACE_CLASS_SA, __e, ##__VA_ARGS__)
 
-#define perf_sa_trace(pcd, sa)						  \
-	trace_sa("perf sys_load peak plat %lu cpu %lu",  \
-		 (pcd)->plat_delta_peak, (pcd)->cpu_delta_peak)
+#define perf_sa_trace(pcd, sa)				\
+	trace_sa("perf sys_load peak plat %u cpu %u",	\
+		 (uint32_t)((pcd)->plat_delta_peak),	\
+		 (uint32_t)((pcd)->cpu_delta_peak))
 
 /* c63c4e75-8f61-4420-9319-1395932efa9e */
 DECLARE_SOF_UUID("agent-work", agent_work_task_uuid, 0xc63c4e75, 0x8f61, 0x4420,

--- a/src/schedule/ll_schedule.c
+++ b/src/schedule/ll_schedule.c
@@ -43,8 +43,9 @@ struct ll_schedule_data {
 const struct scheduler_ops schedule_ll_ops;
 
 #define perf_ll_sched_trace(pcd, ll_sched)			\
-	trace_ll("perf ll_work peak plat %lu cpu %lu",		\
-		 (pcd)->plat_delta_peak, (pcd)->cpu_delta_peak)
+	trace_ll("perf ll_work peak plat %u cpu %u",		\
+		 (uint32_t)((pcd)->plat_delta_peak),		\
+		 (uint32_t)((pcd)->cpu_delta_peak))
 
 static bool schedule_ll_is_pending(struct ll_schedule_data *sch)
 {


### PR DESCRIPTION
Logger doesn't have possibility to dircetly send 64b arguments
to host, so this arguments should be explicit cast to shorten
data type.
Moreover after putting 64b value to va_arg list in function call
and reading it as 32b will lead to arguments misalignment with
formatting string.

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>