### PR TITLE
component: fix comp_make_shared

### DIFF
--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -322,9 +322,11 @@ int comp_verify_params(struct comp_dev *dev, uint32_t flag,
 
 struct comp_dev *comp_make_shared(struct comp_dev *dev)
 {
-	struct comp_dev *old = dev;
 	struct list_item *old_bsource_list = &dev->bsource_list;
 	struct list_item *old_bsink_list = &dev->bsink_list;
+
+	/* flush cache to share */
+	dcache_writeback_region(dev, dev->size);
 
 	dev = platform_shared_get(dev, dev->size);
 
@@ -336,9 +338,6 @@ struct comp_dev *comp_make_shared(struct comp_dev *dev)
 	dev->is_shared = true;
 
 	platform_shared_commit(dev, sizeof(*dev));
-
-	/* clear cache to avoid later random flushes */
-	dcache_invalidate_region(old, sizeof(*old));
 
 	return dev;
 }

--- a/src/include/sof/list.h
+++ b/src/include/sof/list.h
@@ -109,7 +109,7 @@ static inline void list_relink(struct list_item *new_list,
 {
 	struct list_item *li;
 
-	if (list_is_empty(new_list)) {
+	if (new_list->next == old_list) {
 		list_init(new_list);
 	} else {
 		list_for_item(li, new_list)


### PR DESCRIPTION
Fixes comp_make_shared function by flushing data from cache
before accessing it using shared interface. Also additional
invalidation is no longer needed. It should be handled
automatically by platform_shared_get.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>