### PR TITLE
ASRC: Fix memory allocation fail handling in prepare()

### DIFF
--- a/src/audio/asrc/asrc.c
+++ b/src/audio/asrc/asrc.c
@@ -626,7 +626,7 @@ static int asrc_prepare(struct comp_dev *dev)
 		comp_err(dev, "asrc_prepare(), allocation fail for size %d",
 			 cd->buf_size);
 		ret = -ENOMEM;
-		goto err_free_buf;
+		goto err;
 	}
 
 	sample_bytes = frame_bytes / sourceb->stream.channels;


### PR DESCRIPTION
This patch fixes a minor issue when handling the fail to allocate a
samples buffer. The goto err_free_buf jumps to code "rfree(cd->buf);"
that would attempt free null pointer that is confusing and just
overhead. Only the successive operations of comp_set_state() and
returning -ENOMEM are needed.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>