### PR TITLE
mux: select demux proc function based on source buffer

### DIFF
--- a/src/audio/mux/mux_generic.c
+++ b/src/audio/mux/mux_generic.c
@@ -380,17 +380,17 @@ mux_func mux_get_processing_function(struct comp_dev *dev)
 
 demux_func demux_get_processing_function(struct comp_dev *dev)
 {
-	struct comp_buffer *sinkb;
+	struct comp_buffer *sourceb;
 	uint8_t i;
 
-	if (list_is_empty(&dev->bsink_list))
+	if (list_is_empty(&dev->bsource_list))
 		return NULL;
 
-	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer,
-				source_list);
+	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer,
+				sink_list);
 
 	for (i = 0; i < ARRAY_SIZE(mux_func_map); i++) {
-		if (sinkb->stream.frame_fmt == mux_func_map[i].frame_format)
+		if (sourceb->stream.frame_fmt == mux_func_map[i].frame_format)
 			return mux_func_map[i].demux_proc_func;
 	}
 


### PR DESCRIPTION
Demux should select proc func based on source buffer,
because sink can be not set yet (e.g. this can be observed
in smart amplifier topology scenario where there is
buffer between playback and capture pipeline).

Signed-off-by: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>