### PR TITLE
host: dai: limit number of bytes copied to one period

### DIFF
--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -67,7 +67,7 @@ struct dw_dma_chan_data {
 static const uint32_t burst_elems[] = {1, 2, 4, 8};
 
 #if CONFIG_HW_LLI
-#define DW_DMA_BUFFER_PERIOD_COUNT	3
+#define DW_DMA_BUFFER_PERIOD_COUNT	4
 #else
 #define DW_DMA_BUFFER_PERIOD_COUNT	2
 #endif


### PR DESCRIPTION
This patch limits number of bytes copied from DMA source
to maximum of one period size per one copy. This does not
change anything for DMA driven pipelines, but only for
timer driven. This limitation is to avoid high peak of MCPS
during copy, especially first one, where we usually have
two periods of data ready. Having some demanding processing
component on the pipe can end up in xrun if the MCPS limit
is exceeded.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>