### PR TITLE
ssp: Debug ssp_empty_tx_fifo()

### DIFF
--- a/src/include/sof/drivers/ssp.h
+++ b/src/include/sof/drivers/ssp.h
@@ -217,6 +217,9 @@ extern const struct dai_driver ssp_driver;
 
 #endif
 
+/* For 8000 Hz rate one sample is transmitted within 125us */
+#define SSP_MAX_SEND_TIME_PER_SAMPLE 125
+
 #define ssp_irq(ssp) \
 	ssp->plat_data.irq
 


### PR DESCRIPTION
This function should wait to transmission last element from FIFO,
what is indicated in SSSR and SSCR3 registers.

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>