### PR TITLE
Zephyr API bridge

### DIFF
--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -23,6 +23,7 @@
 #include <sof/drivers/ipc.h>
 #include <sof/drivers/timer.h>
 #include <sof/lib/alloc.h>
+#include <sof/lib/clk.h>
 #include <sof/lib/cache.h>
 #include <sof/lib/cpu.h>
 #include <sof/lib/dai.h>

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -154,35 +154,35 @@ endif()
 # Files used on all platforms.
 # Commented files will be added/removed as integration dictates.
 zephyr_library_sources(
-	#../src/trace/dma-trace.c
-	#../src/trace/trace.c
+	../src/trace/dma-trace.c
+	../src/trace/trace.c
 	#../src/drivers/dw/ssi-spi.c
 	#../src/drivers/dw/gpio.c
 	../src/drivers/dw/dma.c
 	#../src/drivers/interrupt.c
-	#../src/drivers/generic/dummy-dma.c
-	#../src/ipc/dma-copy.c
+	../src/drivers/generic/dummy-dma.c
+	../src/ipc/dma-copy.c
 	../src/ipc/ipc.c
 	../src/ipc/handler.c
-	#../src/ipc/probe_support.c
+	../src/ipc/probe_support.c
 	../src/ipc/user_abi_version.c
 	../src/ipc/ipc-host-ptable.c
 	../src/ipc/cc_version.c
-	#../src/debug/gdb/gdb.c
-	#../src/debug/gdb/ringbuffer.c
+	../src/debug/gdb/gdb.c
+	../src/debug/gdb/ringbuffer.c
 	../src/debug/panic.c
 	../src/spinlock.c
 	../src/math/decibels.c
 	../src/math/numbers.c
 	../src/math/trig.c
 	#../src/init/init.c
-	../src/schedule/task.c
-	../src/schedule/timer_domain.c
-	../src/schedule/schedule.c
-	../src/schedule/edf_schedule.c
-	../src/schedule/dma_single_chan_domain.c
-	../src/schedule/dma_multi_chan_domain.c
-	../src/schedule/ll_schedule.c
+	#../src/schedule/task.c
+	#../src/schedule/timer_domain.c
+	#../src/schedule/schedule.c
+	#../src/schedule/edf_schedule.c
+	#../src/schedule/dma_single_chan_domain.c
+	#../src/schedule/dma_multi_chan_domain.c
+	#../src/schedule/ll_schedule.c
 	../src/lib/clk.c
 	../src/lib/notifier.c
 	../src/lib/lib.c
@@ -232,6 +232,7 @@ zephyr_library_sources(
 	../src/audio/dai.c
 	../src/audio/pipeline.c
 	#../src/probe/probe.c
+	wrapper.c
 )
 
 zephyr_library_link_libraries(SOF)

--- a/zephyr/README
+++ b/zephyr/README
@@ -1,0 +1,49 @@
+SOF with Zephyr RTOS
+====================
+
+SOF currently uses the Cadence Xtos/HAL and it's own kernel functions as
+its RTOS. SOF is moving to use Zephyr as it's RTOS in parallel to current
+releases using xtos.
+
+The initial "alpha" of SOF on Zephyr will use the Zephyr RTOS for boot, IRQs,
+scheduling and memory allocation. Subsequent release will use more Zephyr
+functionality as code is moved from SOF to Zephyr (i.e. EDF scheduler updates
+copied from SOF to Zephyr).
+
+Building SOF on Zephyr
+======================
+
+Zephyr support is still WiP and moving fast so it's best to use the latest
+code. Some familiarity of SOF and Zephyr is also needed here.
+
+SOF
+---
+
+repo: git@github.com:thesofproject/sof.git
+
+branch: lrg/topic/zephyr-app on the SOF repo
+
+
+Zephyr
+------
+
+repo: git@github.com:thesofproject/zephyr.git
+
+branch: intel_adsp_soc_family
+
+Building
+========
+
+SOF on Zephyr only using the UP^2 platform atm, but it should be possible to
+add others platforms as the features are validated on UP^2.
+
+Please checkout the SOF repo to zephyrproject/modules/audio/sof
+
+Then from zephyr directory.
+
+% source zephyr.sh
+
+This will setup the Zephyr environment, code can then be built
+
+% west build -p always  -b up_squared_adsp samples/basic/minimal
+% west sign -t rimage -- -k ../../sof/sof/rimage/keys/otc_private_key.pem

--- a/zephyr/README
+++ b/zephyr/README
@@ -47,3 +47,33 @@ This will setup the Zephyr environment, code can then be built
 
 % west build -p always  -b up_squared_adsp samples/basic/minimal
 % west sign -t rimage -- -k ../../sof/sof/rimage/keys/otc_private_key.pem
+
+
+Testing on Qemu
+===============
+
+Get the SOF qemu sof-v4.2 branch here.
+
+git@github.com:thesofproject/qemu.git
+
+Configure as
+
+./configure' '--prefix=.' '--target-list=xtensa-softmmu,x86_64-softmmu' \
+             '--enable-gtk' '--enable-sdl' '--enable-spice' \
+             '--audio-drv-list=alsa' '--enable-libusb' \
+             '--enable-usb-redir' '--enable-coroutine-pool' \
+             '--disable-opengl' '--enable-fdt'
+
+ Then run make.
+
+FW can be tested as follows using the qemu helper script.
+
+ ./xtensa-host.sh apl \
+     -r ../../sof/sof/build_apl_gcc/src/arch/xtensa/rom-apl.bin \
+     -k ../../zephyrproject/zephyr/build/zephyr/zephyr.ri
+
+Where -r and -k are used to specify the ROM and kernel files.
+
+The ROMS can be built from the SOF repo by running
+
+./scripts/xtensa-build-all.sh  -r -a

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright(c) 2020 Intel Corporation. All rights reserved.
+ *
+ * Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
+ */
+
+#include <sof/lib/alloc.h>
+#include <sof/drivers/interrupt.h>
+#include <sof/lib/dma.h>
+#include <sof/schedule/schedule.h>
+
+/*
+ * Memory
+ */
+void *rmalloc(enum mem_zone zone, uint32_t flags, uint32_t caps, size_t bytes)
+{
+	// TODO: call Zephyr API
+	return NULL;
+}
+
+/**
+ * Similar to rmalloc(), guarantees that returned block is zeroed.
+ *
+ * @note Do not use  for buffers (SOF_MEM_ZONE_BUFFER zone).
+ *       rballoc(), rballoc_align() to allocate memory for buffers.
+ */
+void *rzalloc(enum mem_zone zone, uint32_t flags, uint32_t caps, size_t bytes)
+{
+	// TODO: call Zephyr API
+	return NULL;
+}
+
+/**
+ * Allocates memory block from SOF_MEM_ZONE_BUFFER.
+ * @param flags Flags, see SOF_MEM_FLAG_...
+ * @param caps Capabilities, see SOF_MEM_CAPS_...
+ * @param bytes Size in bytes.
+ * @param alignment Alignment in bytes.
+ * @return Pointer to the allocated memory or NULL if failed.
+ */
+void *rballoc_align(uint32_t flags, uint32_t caps, size_t bytes,
+		    uint32_t alignment)
+{
+	// TODO: call Zephyr API
+	return NULL;
+}
+
+void rfree(void *ptr)
+{
+	// TODO: call Zephyr API
+}
+
+void heap_trace_all(int force)
+{
+}
+
+/*
+ * Interrupts
+ */
+int interrupt_register(uint32_t irq, void(*handler)(void *arg), void *arg)
+{
+	return 0;
+}
+
+void interrupt_unregister(uint32_t irq, const void *arg)
+{
+}
+
+uint32_t interrupt_enable(uint32_t irq, void *arg)
+{
+	return 0;
+}
+
+uint32_t interrupt_disable(uint32_t irq, void *arg)
+{
+	return 0;
+}
+
+void platform_interrupt_init(void)
+{
+}
+
+void platform_interrupt_set(uint32_t irq)
+{
+}
+
+void platform_interrupt_clear(uint32_t irq, uint32_t mask)
+{
+}
+
+uint32_t platform_interrupt_get_enabled(void)
+{
+	return 0;
+}
+
+void interrupt_mask(uint32_t irq, unsigned int cpu)
+{
+}
+
+void interrupt_unmask(uint32_t irq, unsigned int cpu)
+{
+}
+
+void interrupt_init(struct sof *sof)
+{
+}
+
+int interrupt_cascade_register(const struct irq_cascade_tmpl *tmpl)
+{
+	return 0;
+}
+
+struct irq_cascade_desc *interrupt_get_parent(uint32_t irq)
+{
+	return NULL;
+}
+
+int interrupt_get_irq(unsigned int irq, const char *cascade)
+{
+	return 0;
+}
+
+const char irq_name_level2[] = "level2";
+const char irq_name_level5[] = "level5";
+
+/*
+ * Scheduler
+ */
+
+struct schedulers **arch_schedulers_get(void)
+{
+	return NULL;
+}
+
+int scheduler_init_ll(struct ll_schedule_domain *domain)
+{
+	return 0;
+}
+
+int schedule_task_init_ll(struct task *task,
+			  uint32_t uid, uint16_t type, uint16_t priority,
+			  enum task_state (*run)(void *data), void *data,
+			  uint16_t core, uint32_t flags)
+{
+	return 0;
+}
+
+int scheduler_init_edf(void)
+{
+	return 0;
+}
+
+int schedule_task_init_edf(struct task *task, uint32_t uid,
+			   const struct task_ops *ops,
+			   void *data, uint16_t core, uint32_t flags)
+{
+	return 0;
+}
+
+struct ll_schedule_domain *timer_domain_init(struct timer *timer, int clk,
+					     uint64_t timeout)
+{
+	return NULL;
+}
+
+struct ll_schedule_domain *dma_single_chan_domain_init(struct dma *dma_array,
+						       uint32_t num_dma,
+						       int clk)
+{
+	return NULL;
+}
+
+volatile void *task_context_get(void)
+{
+	return NULL;
+}
+
+/*
+ * Timers
+ */
+
+uint32_t arch_timer_get_system(struct timer *timer)
+{
+	return 0;
+}
+
+/*
+ * Notifier
+ */
+
+struct notify **arch_notify_get(void)
+{
+	return NULL;
+}
+
+/*
+ * Debug
+ */
+void arch_dump_regs_a(void *dump_buf)
+{
+
+}
+
+/*
+ * Xtensa
+ */
+
+unsigned int _xtos_ints_off( unsigned int mask )
+{
+	return 0;
+}
+
+/*
+ * entry
+ */
+int task_main_start(struct sof *sof)
+{
+	return 0;
+}


### PR DESCRIPTION
More updates to use Zephyr RTOS. Code now links and boots. SOF code is executed, but stops due to missing API implementations for bridging code.