### PR TITLE
Testbench: Fix topology parse error with volume playback topology

### DIFF
--- a/src/include/kernel/tokens.h
+++ b/src/include/kernel/tokens.h
@@ -71,6 +71,7 @@
 /* Token retired with ABI 3.2, do not use for new capabilities
  * #define SOF_TKN_COMP_PRELOAD_COUNT		403
  */
+#define SOF_TKN_COMP_CORE_ID			404
 
 /* SSP */
 #define SOF_TKN_INTEL_SSP_CLKS_CONTROL		500

--- a/tools/tplg_parser/include/tplg_parser/topology.h
+++ b/tools/tplg_parser/include/tplg_parser/topology.h
@@ -80,6 +80,11 @@ static const struct sof_topology_token buffer_tokens[] = {
 		offsetof(struct sof_ipc_buffer, caps), 0},
 };
 
+static const struct sof_topology_token buffer_comp_tokens[] = {
+	{SOF_TKN_COMP_CORE_ID, SND_SOC_TPLG_TUPLE_TYPE_WORD, get_token_uint32_t,
+		offsetof(struct sof_ipc_comp, core), 0},
+};
+
 /* scheduling */
 static const struct sof_topology_token sched_tokens[] = {
 	{SOF_TKN_SCHED_PERIOD, SND_SOC_TPLG_TUPLE_TYPE_WORD,

--- a/tools/tplg_parser/tplg_parser.c
+++ b/tools/tplg_parser/tplg_parser.c
@@ -147,7 +147,12 @@ int tplg_load_buffer(int comp_id, int pipeline_id, int size,
 			return -EINVAL;
 		}
 
-		tplg_read_array(array, file);
+		ret = tplg_read_array(array, file);
+		if (ret) {
+			fprintf(stderr, "error: read array fail\n");
+			free(array);
+			return ret;
+		}
 
 		/* parse buffer comp tokens */
 		ret = sof_parse_tokens(&buffer->comp, buffer_comp_tokens,
@@ -207,7 +212,14 @@ int tplg_load_pcm(int comp_id, int pipeline_id, int size, int dir,
 		ret = fread(array, read_size, 1, file);
 		if (ret != 1)
 			return -EINVAL;
-		tplg_read_array(array, file);
+
+		ret = tplg_read_array(array, file);
+		if (ret) {
+			fprintf(stderr, "error: read array fail\n");
+			free(array);
+			return ret;
+		}
+
 
 		/* parse comp tokens */
 		ret = sof_parse_tokens(&host->config, comp_tokens,
@@ -269,7 +281,12 @@ int tplg_load_dai(int comp_id, int pipeline_id, int size,
 			return -EINVAL;
 		}
 
-		tplg_read_array(array, file);
+		ret = tplg_read_array(array, file);
+		if (ret) {
+			fprintf(stderr, "error: read array fail\n");
+			free(array);
+			return ret;
+		}
 
 		ret = sof_parse_tokens(comp_dai, dai_tokens,
 				       ARRAY_SIZE(dai_tokens), array,
@@ -321,7 +338,13 @@ int tplg_load_pga(int comp_id, int pipeline_id, int size,
 			free(array);
 			return -EINVAL;
 		}
-		tplg_read_array(array, file);
+
+		ret = tplg_read_array(array, file);
+		if (ret) {
+			fprintf(stderr, "error: read array fail\n");
+			free(array);
+			return ret;
+		}
 
 		/* parse comp tokens */
 		ret = sof_parse_tokens(&volume->config, comp_tokens,
@@ -392,7 +415,8 @@ int tplg_load_pipeline(int comp_id, int pipeline_id, int size,
 		}
 
 		ret = tplg_read_array(array, file);
-		if (ret < 0) {
+		if (ret) {
+			fprintf(stderr, "error: read array fail\n");
 			free(array);
 			return -EINVAL;
 		}
@@ -755,7 +779,12 @@ int tplg_load_src(int comp_id, int pipeline_id, int size,
 			return -EINVAL;
 		}
 
-		tplg_read_array(array, file);
+		ret = tplg_read_array(array, file);
+		if (ret) {
+			fprintf(stderr, "error: read array fail\n");
+			free(array);
+			return ret;
+		}
 
 		/* parse comp tokens */
 		ret = sof_parse_tokens(&src->config, comp_tokens,
@@ -822,7 +851,12 @@ int tplg_load_asrc(int comp_id, int pipeline_id, int size,
 			return -EINVAL;
 		}
 
-		tplg_read_array(array, file);
+		ret = tplg_read_array(array, file);
+		if (ret) {
+			fprintf(stderr, "error: read array fail\n");
+			free(array);
+			return ret;
+		}
 
 		/* parse comp tokens */
 		ret = sof_parse_tokens(&asrc->config, comp_tokens,
@@ -890,7 +924,12 @@ int tplg_load_process(int comp_id, int pipeline_id, int size,
 			return -EINVAL;
 		}
 
-		tplg_read_array(array, file);
+		ret = tplg_read_array(array, file);
+		if (ret) {
+			fprintf(stderr, "error: read array fail\n");
+			free(array);
+			return ret;
+		}
 
 		/* parse comp tokens */
 		ret = sof_parse_tokens(&process->config, comp_tokens,
@@ -958,7 +997,12 @@ int tplg_load_mixer(int comp_id, int pipeline_id, int size,
 			return -EINVAL;
 		}
 
-		tplg_read_array(array, file);
+		ret = tplg_read_array(array, file);
+		if (ret) {
+			fprintf(stderr, "error: read array fail\n");
+			free(array);
+			return ret;
+		}
 
 		/* parse comp tokens */
 		ret = sof_parse_tokens(&mixer->config, comp_tokens,


### PR DESCRIPTION
This first commit adds define for the SOF_TKN_CORE_ID token that is present in some topologies for buffer widget, e.g. pipe-volume-playback.m4. 

The second commit for buffer widget load changes is now changed to quite similar to PCM widget so all the arrays get parsed.

The third commit addresses error codes return. The manually set error code is replaced by -errno with malloc() and fseek() calls.

The fourth commit adds return value checks to tplg_read_array() calls.