### PR TITLE
sof: audio: free memory before returning in error

### DIFF
--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -154,16 +154,19 @@ static struct comp_dev *kpb_new(const struct comp_driver *drv,
 
 	if (!kpb_is_sample_width_supported(kpb->config.sampling_width)) {
 		comp_err(dev, "kpb_new(): requested sampling width not supported");
+		rfree(dev);
 		return NULL;
 	}
 
 	if (kpb->config.channels > KPB_MAX_SUPPORTED_CHANNELS) {
 		comp_err(dev, "kpb_new(): no of channels exceeded the limit");
+		rfree(dev);
 		return NULL;
 	}
 
 	if (kpb->config.sampling_freq != KPB_SAMPLNG_FREQUENCY) {
 		comp_err(dev, "kpb_new(): requested sampling frequency not supported");
+		rfree(dev);
 		return NULL;
 	}
 


### PR DESCRIPTION
Memory allocated for new KPB component should be released before
returning NULL in when one of sampling width or number of channels or
sampling frequency are set to unexpected values.

Signed-off-by: Deepak R Varma <mh12gx2825@gmail.com>