### PR TITLE
kpb: fix race condition in draining task

### DIFF
--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -1218,6 +1218,12 @@ static enum task_state kpb_draining_task(void *arg)
 		if (size_to_copy) {
 			comp_update_buffer_produce(sink, size_to_copy);
 			comp_copy(sink->sink);
+		} else if (!sink->stream.free) {
+			/* There is no free space in sink buffer.
+			 * Call .copy() on sink component so it can
+			 * process its data further.
+			 */
+			comp_copy(sink->sink);
 		}
 
 		if (sync_mode_on && period_bytes >= period_bytes_limit) {


### PR DESCRIPTION
This patch fixes the race condition in the draining
task in which KPB was waiting for sink component to
free space in its input buffer while this component
was waiting for KPB to call its .copy() method
again. This problem has deeper underlying cause,
namely the lack of DMA IRQ which should signal the
end of transaction.

Signed-off-by: Marcin Rajwa <marcin.rajwa@linux.intel.com>