### PR TITLE
Memory: Enable 2 kB module pool for APL, CNL, ICL, TGL, Sue Creek

### DIFF
--- a/src/platform/apollolake/include/platform/lib/memory.h
+++ b/src/platform/apollolake/include/platform/lib/memory.h
@@ -268,7 +268,7 @@
 #define HEAP_RT_COUNT256		96
 #define HEAP_RT_COUNT512		8
 #define HEAP_RT_COUNT1024		4
-#define HEAP_RT_COUNT2048		0
+#define HEAP_RT_COUNT2048		1
 #define HEAP_RT_COUNT4096		1
 
 /* Heap configuration */

--- a/src/platform/cannonlake/include/platform/lib/memory.h
+++ b/src/platform/cannonlake/include/platform/lib/memory.h
@@ -253,7 +253,7 @@
 #define HEAP_RT_COUNT256	128
 #define HEAP_RT_COUNT512	8
 #define HEAP_RT_COUNT1024	4
-#define HEAP_RT_COUNT2048	0
+#define HEAP_RT_COUNT2048	1
 #define HEAP_RT_COUNT4096	1
 
 /* Heap configuration */

--- a/src/platform/icelake/include/platform/lib/memory.h
+++ b/src/platform/icelake/include/platform/lib/memory.h
@@ -250,7 +250,7 @@
 #define HEAP_RT_COUNT256		128
 #define HEAP_RT_COUNT512		8
 #define HEAP_RT_COUNT1024		4
-#define HEAP_RT_COUNT2048		0
+#define HEAP_RT_COUNT2048		1
 #define HEAP_RT_COUNT4096		1
 
 /* Heap configuration */

--- a/src/platform/suecreek/include/platform/lib/memory.h
+++ b/src/platform/suecreek/include/platform/lib/memory.h
@@ -246,7 +246,7 @@
 #define HEAP_RT_COUNT256		80
 #define HEAP_RT_COUNT512		8
 #define HEAP_RT_COUNT1024		4
-#define HEAP_RT_COUNT2048		0
+#define HEAP_RT_COUNT2048		1
 #define HEAP_RT_COUNT4096		1
 
 /* Heap configuration */

--- a/src/platform/tigerlake/include/platform/lib/memory.h
+++ b/src/platform/tigerlake/include/platform/lib/memory.h
@@ -258,7 +258,7 @@
 #define HEAP_RT_COUNT256		128
 #define HEAP_RT_COUNT512		8
 #define HEAP_RT_COUNT1024		4
-#define HEAP_RT_COUNT2048		0
+#define HEAP_RT_COUNT2048		1
 #define HEAP_RT_COUNT4096		1
 
 /* Heap configuration */


### PR DESCRIPTION
This patch enables a single 1 - 2 kB allocation for component
runtime. The disabled 2 kB pool entry caused ASRC component
to fail in some cases.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>