### PR TITLE
pipeline: disable system agent panic for DMA driven pipelines

### DIFF
--- a/src/include/sof/lib/agent.h
+++ b/src/include/sof/lib/agent.h
@@ -8,8 +8,11 @@
 #ifndef __SOF_LIB_AGENT_H__
 #define __SOF_LIB_AGENT_H__
 
+#include <sof/atomic.h>
+#include <sof/lib/memory.h>
 #include <sof/lib/perf_cnt.h>
 #include <sof/schedule/task.h>
+#include <sof/sof.h>
 #include <config.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -25,15 +28,37 @@ struct sa {
 	struct perf_cnt_data pcd;
 #endif
 	struct task work;
+	atomic_t panic_cnt;	/**< ref counter for panic_on_delay property */
+	bool panic_on_delay;	/**< emits panic on delay if true */
 };
 
 #if CONFIG_HAVE_AGENT
+
+/**
+ * Enables or disables panic on agent delay.
+ * @param enabled True for panic enabling, false otherwise.
+ */
+static inline void sa_set_panic_on_delay(bool enabled)
+{
+	struct sa *sa = sof_get()->sa;
+
+	if (enabled)
+		atomic_add(&sa->panic_cnt, 1);
+	else
+		atomic_sub(&sa->panic_cnt, 1);
+
+	/* enable panic only if no refs */
+	sa->panic_on_delay = !atomic_read(&sa->panic_cnt);
+
+	platform_shared_commit(sa, sizeof(*sa));
+}
 
 void sa_init(struct sof *sof, uint64_t timeout);
 
 #else
 
 static inline void sa_init(struct sof *sof, uint64_t timeout) { }
+static inline void sa_set_panic_on_delay(bool enabled) { }
 
 #endif
 

--- a/src/lib/agent.c
+++ b/src/lib/agent.c
@@ -29,6 +29,7 @@
 #include <ipc/topology.h>
 #include <ipc/trace.h>
 #include <user/trace.h>
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -60,7 +61,7 @@ static enum task_state validate(void *data)
 	perf_cnt_stamp(&sa->pcd, perf_sa_trace, sa);
 
 	/* panic timeout */
-	if (delta > sa->panic_timeout)
+	if (sa->panic_on_delay && delta > sa->panic_timeout)
 		panic(SOF_IPC_PANIC_IDLE);
 
 	/* warning timeout */
@@ -91,6 +92,9 @@ void sa_init(struct sof *sof, uint64_t timeout)
 	/* TODO: change values after minimal drifts will be assured */
 	sof->sa->panic_timeout = 2 * ticks;	/* 100% delay */
 	sof->sa->warn_timeout = ticks + ticks / 20;	/* 5% delay */
+
+	atomic_init(&sof->sa->panic_cnt, 0);
+	sof->sa->panic_on_delay = true;
 
 	trace_sa("sa_init(), ticks = %u, sof->sa->warn_timeout = %u, sof->sa->panic_timeout = %u",
 		 ticks, sof->sa->warn_timeout, sof->sa->panic_timeout);


### PR DESCRIPTION
Disables panic emitted by system agent on timer delay, when there
are DMA driven pipelines scheduled on the DSP. With such pipelines
running, timer interrupts can be delayed pretty often, so just
emit warning instead of full panic.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>

Fixes #2696.