### PR TITLE
uuid: Make entries monosized

### DIFF
--- a/src/include/sof/lib/uuid.h
+++ b/src/include/sof/lib/uuid.h
@@ -18,6 +18,9 @@
 /** \brief UUID is 16 bytes long */
 #define UUID_SIZE 16
 
+/** \brief UUID name string max length in bytes, including null termination */
+#define UUID_NAME_MAX_LEN 32
+
 /**
  * \brief UUID (Universally Unique IDentifier) structure.
  *
@@ -38,6 +41,18 @@ struct sof_uuid {
 	uint16_t b;
 	uint16_t c;
 	uint8_t  d[8];
+};
+
+/**
+ * \brief Connects UUID with component description
+ *
+ * Declaration of this structure should be done by DECLARE_SOF_UUID(),
+ * then declaration will be part of `.static_uuids` section and `SMEX` tool
+ * use it during `ldc` file creation.
+ */
+struct sof_uuid_entry {
+	struct sof_uuid id;
+	const char name[UUID_NAME_MAX_LEN];
 };
 
 #if CONFIG_LIBRARY
@@ -69,15 +84,10 @@ struct sof_uuid {
 			 va, vb, vc,					\
 			 vd0, vd1, vd2, vd3, vd4, vd5, vd6, vd7)	\
 	__section(".static_uuids")					\
-	static const struct {						\
-		struct sof_uuid id;					\
-		uint32_t name_len;					\
-		const char name[sizeof(entity_name)];			\
-	} uuid_name = {							\
+	static const struct sof_uuid_entry uuid_name = {		\
 		{.a = va, .b = vb, .c = vc,				\
 		 .d = {vd0, vd1, vd2, vd3, vd4, vd5, vd6, vd7}},	\
-		sizeof(entity_name),					\
-		entity_name						\
+		entity_name "\0"					\
 	}
 
 /** \brief Creates local unique 32-bit representation of UUID structure.

--- a/src/include/user/abi_dbg.h
+++ b/src/include/user/abi_dbg.h
@@ -18,8 +18,8 @@
 #ifndef __USER_ABI_DBG_H__
 #define __USER_ABI_DBG_H__
 
-#define SOF_ABI_DBG_MAJOR 4
-#define SOF_ABI_DBG_MINOR 2
+#define SOF_ABI_DBG_MAJOR 5
+#define SOF_ABI_DBG_MINOR 0
 #define SOF_ABI_DBG_PATCH 0
 
 #define SOF_ABI_DBG_VERSION SOF_ABI_VER(SOF_ABI_DBG_MAJOR, \


### PR DESCRIPTION
It make code dealing with entries simpler, and allow to create
UUID entries dictionary with constant access time to any entry.
As long as struct definition is fixed, then can passed as pointer
with correct type to function call, instead of void pointer.
UUID entries aren't storred in flash memory, so entry size is not
important.
Explicit add zero at the end of entity_name to trigger string overflow
warning for shortest incorrect string length.

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>