### PR TITLE
ipc: extend power management functionality

### DIFF
--- a/src/include/ipc/pm.h
+++ b/src/include/ipc/pm.h
@@ -75,5 +75,7 @@ struct sof_ipc_pm_gate {
 
 /** \brief Disable DMA tracing (0 - keep tracing, 1 - to disable DMA trace) */
 #define SOF_PM_NO_TRACE		BIT(4)
+/** \brief Power gate available LPSRAM banks */
+#define SOF_PM_PG_LPSRAM	BIT(5)
 
 #endif /* __IPC_PM_H__ */

--- a/src/include/sof/lib/pm_runtime.h
+++ b/src/include/sof/lib/pm_runtime.h
@@ -119,6 +119,15 @@ void pm_runtime_disable(enum pm_runtime_context context, uint32_t index);
 bool pm_runtime_is_active(enum pm_runtime_context context, uint32_t index);
 
 /**
+ * \brief Power gate available LPSRAM banks.
+ *
+ * @param none.
+ *
+ * @return 0 if succeeded error code otherwise.
+ */
+int pm_runtime_pg_lpsram(void);
+
+/**
  * \brief Retrieves pointer to runtime power management data.
  *
  * @return Runtime power management data pointer.

--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -629,6 +629,7 @@ static int ipc_pm_core_enable(uint32_t header)
 
 static int ipc_pm_gate(uint32_t header)
 {
+	int ret;
 	struct sof_ipc_pm_gate pm_gate;
 
 	IPC_COPY_CMD(pm_gate, ipc_get()->comp_data);
@@ -641,6 +642,15 @@ static int ipc_pm_gate(uint32_t header)
 		pm_runtime_disable(PM_RUNTIME_DSP, PLATFORM_MASTER_CORE_ID);
 	else
 		pm_runtime_enable(PM_RUNTIME_DSP, PLATFORM_MASTER_CORE_ID);
+
+	if (pm_gate.flags & SOF_PM_PG_LPSRAM) {
+		ret = pm_runtime_pg_lpsram();
+		if (ret) {
+			trace_ipc("ipc_pm_gate() error %d: failed to power gate lpsram",
+				  ret);
+			return ret;
+		}
+	}
 
 	/* resume dma trace if needed */
 	if (!(pm_gate.flags & SOF_PM_NO_TRACE))

--- a/src/lib/pm_runtime.c
+++ b/src/lib/pm_runtime.c
@@ -104,3 +104,10 @@ bool pm_runtime_is_active(enum pm_runtime_context context, uint32_t index)
 		return platform_pm_runtime_is_active(context, index);
 	}
 }
+
+int pm_runtime_pg_lpsram(void)
+{
+	tracev_pm("pm_runtime_pg_lpsram()");
+
+	return platform_pm_pg_lpsram();
+}

--- a/src/platform/apollolake/include/platform/lib/pm_runtime.h
+++ b/src/platform/apollolake/include/platform/lib/pm_runtime.h
@@ -57,6 +57,13 @@ bool platform_pm_runtime_is_active(uint32_t context, uint32_t index);
  */
 void platform_pm_runtime_power_off(void);
 
+/**
+ * \brief Power gates available LPSRAM banks.
+ * \param[in] None.
+ * \param[out] 0 if succeeded error code otherwise.
+ */
+int platform_pm_pg_lpsram(void);
+
 #endif /* __PLATFORM_LIB_PM_RUNTIME_H__ */
 
 #else

--- a/src/platform/apollolake/include/platform/lib/pm_runtime.h
+++ b/src/platform/apollolake/include/platform/lib/pm_runtime.h
@@ -52,7 +52,8 @@ bool platform_pm_runtime_is_active(uint32_t context, uint32_t index);
 
 /**
  * \brief Power gates platform specific hardware resources.
- * \param[in] context Type of power management context.
+ * \param[in] None.
+ * \param[out] None.
  */
 void platform_pm_runtime_power_off(void);
 

--- a/src/platform/cannonlake/include/platform/lib/pm_runtime.h
+++ b/src/platform/cannonlake/include/platform/lib/pm_runtime.h
@@ -54,6 +54,13 @@ bool platform_pm_runtime_is_active(uint32_t context, uint32_t index);
  */
 void platform_pm_runtime_power_off(void);
 
+/**
+ * \brief Power gates available LPSRAM banks.
+ * \param[in] None.
+ * \param[out] 0 if succeeded error code otherwise.
+ */
+int platform_pm_pg_lpsram(void);
+
 #endif /* __PLATFORM_LIB_PM_RUNTIME_H__ */
 
 #else

--- a/src/platform/icelake/include/platform/lib/pm_runtime.h
+++ b/src/platform/icelake/include/platform/lib/pm_runtime.h
@@ -54,6 +54,13 @@ bool platform_pm_runtime_is_active(uint32_t context, uint32_t index);
  */
 void platform_pm_runtime_power_off(void);
 
+/**
+ * \brief Power gates available LPSRAM banks.
+ * \param[in] None.
+ * \param[out] 0 if succeeded error code otherwise.
+ */
+int platform_pm_pg_lpsram(void);
+
 #endif /* __PLATFORM_LIB_PM_RUNTIME_H__ */
 
 #else

--- a/src/platform/intel/cavs/lib/pm_runtime.c
+++ b/src/platform/intel/cavs/lib/pm_runtime.c
@@ -518,3 +518,30 @@ void platform_pm_runtime_power_off(void)
 	power_down(true, hpsram_mask);
 }
 #endif
+
+int platform_pm_pg_lpsram(void)
+{
+	int ret = 0;
+	uint32_t status;
+	uint32_t delay_count, timeout_counter = 256;
+
+	delay_count = timeout_counter;
+
+	io_reg_write(LSPGCTL, LPSRAM_MASK());
+
+	/* add some delay before checking the status */
+	idelay(delay_count);
+
+	/* query the power status of first part of LP memory */
+	status = io_reg_read(LSPGISTS);
+	while ((status & LPSRAM_MASK(0)) != LPSRAM_MASK()) {
+		if (!timeout_counter--) {
+			ret = -ETIME;
+			break;
+		}
+		idelay(delay_count);
+		status = io_reg_read(LSPGISTS);
+	}
+
+	return ret;
+}

--- a/src/platform/tigerlake/include/platform/lib/pm_runtime.h
+++ b/src/platform/tigerlake/include/platform/lib/pm_runtime.h
@@ -54,6 +54,13 @@ bool platform_pm_runtime_is_active(uint32_t context, uint32_t index);
  */
 void platform_pm_runtime_power_off(void);
 
+/**
+ * \brief Power gates available LPSRAM banks.
+ * \param[in] None.
+ * \param[out] 0 if succeeded error code otherwise.
+ */
+int platform_pm_pg_lpsram(void);
+
 #endif /* __PLATFORM_LIB_PM_RUNTIME_H__ */
 
 #else


### PR DESCRIPTION
This patch set extends the functionality of IPC power
management to handle IPC requests to power gate all
available LPSRAM banks.
    
Currently, due to HW bug related to LPSRAM registers
it is necessary for DSP to power gate all LPSRAM banks
before we power down the whole controller. Otherwise,
LPSRAM registers stall, making LPSRAM inaccessible
after following power up of the DSP.
The power down of DSP may i.e. be initiated by module
remove driver procedure. Therefore the IPC message is
essential to take care of LPSRAM.

Signed-off-by: Marcin Rajwa <marcin.rajwa@linux.intel.com>
