### PR TITLE
cmake: fix build without traces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,11 +17,10 @@ if(NOT (${CMAKE_VERSION} VERSION_LESS "3.13.0"))
 	cmake_policy(SET CMP0079 OLD)
 endif()
 
-option(BUILD_LIBRARY "Build library" OFF)
 option(BUILD_UNIT_TESTS "Build unit tests" OFF)
 option(BUILD_CLANG_SCAN "Build for clang's scan-build" OFF)
 
-if(BUILD_LIBRARY)
+if(CONFIG_LIBRARY)
 	set(ARCH host)
 else()
 	# firmware build supports only xtensa arch for now
@@ -119,7 +118,7 @@ include(scripts/cmake/kconfig.cmake)
 add_dependencies(sof_public_headers genconfig check_version_h)
 target_include_directories(sof_public_headers INTERFACE ${GENERATED_DIRECTORY}/include)
 
-if(BUILD_LIBRARY)
+if(CONFIG_LIBRARY)
 	add_library(sof SHARED "")
 	target_link_libraries(sof PRIVATE sof_options)
 	target_link_libraries(sof PRIVATE sof_static_libraries)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,7 +7,7 @@ add_subdirectory(audio)
 add_subdirectory(lib)
 add_local_sources(sof spinlock.c)
 
-if(BUILD_LIBRARY)
+if(CONFIG_LIBRARY)
 	return()
 endif()
 

--- a/src/arch/host/CMakeLists.txt
+++ b/src/arch/host/CMakeLists.txt
@@ -5,6 +5,6 @@ target_include_directories(sof_public_headers INTERFACE ${PROJECT_SOURCE_DIR}/sr
 target_include_directories(sof_public_headers INTERFACE ${PROJECT_SOURCE_DIR}/src/platform/library/include)
 
 # C & ASM flags
-target_compile_options(sof_options INTERFACE -g -O3 -Wall -Werror -Wl,-EL -Wmissing-prototypes -Wimplicit-fallthrough=3 -Wpointer-arith)
+target_compile_options(sof_options INTERFACE -g -O3 -Wall -Werror -Wl,-EL -Wmissing-prototypes -Wimplicit-fallthrough=3 -Wpointer-arith -DCONFIG_LIBRARY)
 
 add_subdirectory(lib)

--- a/src/arch/xtensa/CMakeLists.txt
+++ b/src/arch/xtensa/CMakeLists.txt
@@ -395,10 +395,14 @@ if(MEU_PATH)
 			${RIMAGE_MOD_OFFSET_FLAG}
 			${bootloader_binary_path}
 			sof-${fw_name}
-		DEPENDS sof_dump rimage_ep run_smex
+		DEPENDS sof_dump rimage_ep
 		VERBATIM
 		USES_TERMINAL
 	)
+
+	if(CONFIG_TRACE)
+		add_dependencies(run_rimage run_smex)
+	endif()
 
 	if(NOT DEFINED MEU_OPENSSL)
 		set(MEU_OPENSSL "/usr/bin/openssl")
@@ -434,10 +438,15 @@ else()
 			${RIMAGE_MOD_OFFSET_FLAG}
 			${bootloader_binary_path}
 			sof-${fw_name}
-		DEPENDS sof_dump rimage_ep run_smex
+		DEPENDS sof_dump rimage_ep
 		VERBATIM
 		USES_TERMINAL
 	)
+
+	if (CONFIG_TRACE)
+		add_dependencies(run_rimage run_smex)
+	endif()
+
 	add_custom_target(run_meu DEPENDS run_rimage)
 endif()
 

--- a/src/audio/CMakeLists.txt
+++ b/src/audio/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-if(NOT BUILD_LIBRARY)
+if(NOT CONFIG_LIBRARY)
 	add_local_sources(sof
 		host.c
 		pipeline.c

--- a/src/include/sof/trace/trace.h
+++ b/src/include/sof/trace/trace.h
@@ -15,7 +15,7 @@
 	"Add it to CMake's target with sof_append_relative_path_definitions."
 #endif
 
-#if !CONFIG_LIBRARY && CONFIG_TRACE
+#if !CONFIG_LIBRARY
 #include <platform/trace/trace.h>
 #endif
 #include <sof/common.h>

--- a/src/ipc/CMakeLists.txt
+++ b/src/ipc/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-if(BUILD_LIBRARY)
+if(CONFIG_LIBRARY)
 	add_local_sources(sof
 		ipc.c
 	)

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-if(BUILD_LIBRARY)
+if(CONFIG_LIBRARY)
 	add_local_sources(sof
 		lib.c
 		notifier.c)

--- a/tools/testbench/CMakeLists.txt
+++ b/tools/testbench/CMakeLists.txt
@@ -25,7 +25,7 @@ sof_append_relative_path_definitions(testbench)
 
 target_include_directories(testbench PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
-target_compile_options(testbench PRIVATE -g -O3 -Wall -Werror -Wl,-EL -Wmissing-prototypes -Wimplicit-fallthrough=3)
+target_compile_options(testbench PRIVATE -g -O3 -Wall -Werror -Wl,-EL -Wmissing-prototypes -Wimplicit-fallthrough=3 -DCONFIG_LIBRARY)
 
 target_link_libraries(testbench PRIVATE -ldl -lm)
 

--- a/tools/testbench/CMakeLists.txt
+++ b/tools/testbench/CMakeLists.txt
@@ -42,7 +42,7 @@ ExternalProject_Add(sof_ep
 	SOURCE_DIR "${sof_source_directory}"
 	PREFIX "${PROJECT_BINARY_DIR}/sof_ep"
 	BINARY_DIR "${sof_binary_directory}"
-	CMAKE_ARGS -DBUILD_LIBRARY=ON
+	CMAKE_ARGS -DCONFIG_LIBRARY=ON
 		-DCMAKE_INSTALL_PREFIX=${sof_install_directory}
 		-DCMAKE_VERBOSE_MAKEFILE=${CMAKE_VERBOSE_MAKEFILE}
 	BUILD_ALWAYS 1
@@ -69,7 +69,7 @@ ExternalProject_Add(parser_ep
 	SOURCE_DIR "${parser_source_directory}"
 	PREFIX "${PROJECT_BINARY_DIR}/sof_parser"
 	BINARY_DIR "${PROJECT_BINARY_DIR}/sof_parser/build"
-	CMAKE_ARGS -DBUILD_LIBRARY=ON
+	CMAKE_ARGS -DCONFIG_LIBRARY=ON
 		-DCMAKE_INSTALL_PREFIX=${PROJECT_BINARY_DIR}/sof_parser/install
 		-DCMAKE_VERBOSE_MAKEFILE=${CMAKE_VERBOSE_MAKEFILE}
 	BUILD_COMMAND make


### PR DESCRIPTION
Both patches will allow to build FW with traces disabled