### PR TITLE
topology: fix a typo for SCHEDULE_CORE

### DIFF
--- a/tools/topology/sof/pipe-kfbm-capture.m4
+++ b/tools/topology/sof/pipe-kfbm-capture.m4
@@ -50,7 +50,7 @@ C_CONTROLBYTES(KPB, PIPELINE_ID,
 
 # Host "Passthrough Capture" PCM
 # with 0 sink and 2 source periods
-W_PCM_CAPTURE(PCM_ID, Sound Trigger Capture, 0, 2, 2, SCHEDULE_CORE)
+W_PCM_CAPTURE(PCM_ID, Sound Trigger Capture, 0, 2, SCHEDULE_CORE)
 
 # "KPBM" has 2 source and 2 sink periods
 W_KPBM(0, PIPELINE_FORMAT, 2, 2, PIPELINE_ID, SCHEDULE_CORE,


### PR DESCRIPTION
With define for W_PCM_CAPTURE only need 5 arguments
W_PCM_CAPTURE(pcm, stream, periods_sink, periods_source, core)
Fix the wrong parameter in pipe-kfbm-capture.m4

Signed-off-by: Pan Xiuli <xiuli.pan@linux.intel.com>

Root cause to be typo from https://github.com/thesofproject/sof/pull/2513
Fix https://github.com/thesofproject/linux/issues/2042