### PR TITLE
licence: Include NXP Copyright

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -1,6 +1,7 @@
 /* 
  * BSD 3 Clause
  * Copyright (c) 2016, Intel Corporation
+ * Copyright 2020 NXP
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
This is the standard recommended NXP license copyright.

Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>