### PR TITLE
pipeline: do not cancel task on xrun

### DIFF
--- a/src/audio/pipeline.c
+++ b/src/audio/pipeline.c
@@ -697,7 +697,6 @@ static void pipeline_schedule_triggered(struct pipeline_walk_context *ctx,
 		switch (cmd) {
 		case COMP_TRIGGER_PAUSE:
 		case COMP_TRIGGER_STOP:
-		case COMP_TRIGGER_XRUN:
 			pipeline_schedule_cancel(p);
 			p->status = COMP_STATE_PAUSED;
 			break;


### PR DESCRIPTION
We should not explicitly cancel pipeline task on xrun.
Xrun is handled by different functions and task state
flow will be handled by START and STOP commands.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>