### PR TITLE
lib: imx8m: Switch to SDMA3

### DIFF
--- a/src/platform/imx8m/include/platform/lib/dma.h
+++ b/src/platform/imx8m/include/platform/lib/dma.h
@@ -17,6 +17,7 @@
 
 #define DMA_ID_SDMA2	0
 #define DMA_ID_HOST	1
+#define DMA_ID_SDMA3	2
 
 #define dma_chan_irq(dma, chan) dma_irq(dma)
 #define dma_chan_irq_name(dma, chan) dma_irq_name(dma)

--- a/src/platform/imx8m/lib/dma.c
+++ b/src/platform/imx8m/lib/dma.c
@@ -26,16 +26,16 @@ SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
 },
 {
 	.plat_data = {
-		.id		= DMA_ID_SDMA2,
+		.id		= DMA_ID_SDMA3,
 		/* Note: support is available for MEM_TO_MEM but not
 		 * enabled as it is unneeded
 		 */
 		.dir		= DMA_DIR_MEM_TO_DEV | DMA_DIR_DEV_TO_MEM,
 		.devs		= DMA_DEV_SAI,
-		.base		= SDMA2_BASE,
+		.base		= SDMA3_BASE,
 		.channels	= 32,
-		.irq		= SDMA2_IRQ,
-		.irq_name	= SDMA2_IRQ_NAME,
+		.irq		= SDMA3_IRQ,
+		.irq_name	= SDMA3_IRQ_NAME,
 	},
 	.ops	= &sdma_ops,
 },


### PR DESCRIPTION
Both SDMA2/SDMA3 can move data from SDRAM to Peripherals. Anyhow, SDMA2
is traditionally used by non-DSP use case, so switch to SDMA3 to allow
for future use cases where we could have a scenario with multiple Audio
perhipherals running in parallel.

This also aligns the code with legacy firmware.

Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>