### PR TITLE
logging: Fix logging format specifiers

### DIFF
--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -70,7 +70,7 @@ struct comp_dev *comp_new(struct sof_ipc_comp *comp)
 		return NULL;
 	}
 
-	trace_event(TRACE_CLASS_COMP, "comp new %s type %d id %d.%d",
+	trace_event(TRACE_CLASS_COMP, "comp new %d type %d id %d.%d",
 		    drv->uid, comp->type, comp->pipeline_id, comp->id);
 
 	/* create the new component */

--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -221,7 +221,7 @@ static void host_dma_cb(void *arg, enum notify_id type, void *data)
 	struct host_data *hd = comp_get_drvdata(dev);
 	uint32_t bytes = next->elem.size;
 
-	comp_cl_dbg(&comp_host, "host_dma_cb() %p", (uintptr_t)&comp_host);
+	comp_cl_dbg(&comp_host, "host_dma_cb() %p", &comp_host);
 
 	/* update position */
 	host_update_position(dev, bytes);

--- a/src/lib/dma.c
+++ b/src/lib/dma.c
@@ -141,7 +141,7 @@ void dma_put(struct dma *dma)
 		}
 	}
 	trace_event(TRACE_CLASS_DMA, "dma_put(), dma = %p, sref = %d",
-		   (uintptr_t)dma, dma->sref);
+		    dma, dma->sref);
 	platform_shared_commit(dma, sizeof(*dma));
 	spin_unlock(&dma->lock);
 }


### PR DESCRIPTION
Fixes compiler warnings when building with Zephyr.