### PR TITLE
cavs: platform: fix debug region size in FW ready

### DIFF
--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -111,7 +111,7 @@ static const struct sof_ipc_window sram_window
 			.type	= SOF_IPC_REGION_DEBUG,
 			.id	= 2,	/* map to host window 2 */
 			.flags	= 0, // TODO: set later
-			.size	= MAILBOX_EXCEPTION_SIZE + MAILBOX_DEBUG_SIZE,
+			.size	= MAILBOX_DEBUG_SIZE,
 			.offset	= 0,
 		},
 		{


### PR DESCRIPTION
Fixes debug region size passed in FW ready message.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>