### PR TITLE
 cmake: add option to build unsigned FW

### DIFF
--- a/src/arch/xtensa/CMakeLists.txt
+++ b/src/arch/xtensa/CMakeLists.txt
@@ -366,7 +366,7 @@ if(NOT DEFINED RIMAGE_IMR_TYPE)
 	set(RIMAGE_IMR_TYPE 3)
 endif()
 
-if(MEU_PATH)
+if(MEU_PATH OR DEFINED MEU_NO_SIGN)
 	execute_process(
 		COMMAND ${MEU_PATH}/meu -ver
 		OUTPUT_VARIABLE MEU_VERSION_FULL_TEXT
@@ -414,15 +414,19 @@ if(MEU_PATH)
 		)
 	endif()
 
-	add_custom_target(
-		run_meu
-		COMMAND ${MEU_PATH}/meu -w ./ -s sof-${fw_name}
-			${MEU_FLAGS}
-			-o sof-${fw_name}.ri
-		DEPENDS run_rimage
-		VERBATIM
-		USES_TERMINAL
-	)
+	if(MEU_NO_SIGN)
+		add_custom_target(run_meu DEPENDS run_rimage)
+	else()
+		add_custom_target(
+			run_meu
+			COMMAND ${MEU_PATH}/meu -w ./ -s sof-${fw_name}
+				${MEU_FLAGS}
+				-o sof-${fw_name}.ri
+			DEPENDS run_rimage
+			VERBATIM
+			USES_TERMINAL
+		)
+	endif()
 else()
 	add_custom_target(
 		run_rimage
@@ -441,14 +445,27 @@ else()
 	add_custom_target(run_meu DEPENDS run_rimage)
 endif()
 
-add_custom_target(
-	bin ALL
-	COMMAND ${CMAKE_COMMAND} -E copy sof-${fw_name}.ri ${PROJECT_BINARY_DIR}/sof-${fw_name}.ri
-	COMMAND ${CMAKE_COMMAND} -E copy sof-${fw_name}.ldc ${PROJECT_BINARY_DIR}/sof-${fw_name}.ldc
-	DEPENDS run_meu bin_extras
-	VERBATIM
-	USES_TERMINAL
-)
+if(MEU_NO_SIGN)
+	# copy rimage output that can be used to sign firmware
+	add_custom_target(
+		bin ALL
+		COMMAND ${CMAKE_COMMAND} -E copy sof-${fw_name}.ri.uns ${PROJECT_BINARY_DIR}/sof-${fw_name}.ri.uns
+		COMMAND ${CMAKE_COMMAND} -E copy sof-${fw_name}.ri.met ${PROJECT_BINARY_DIR}/sof-${fw_name}.ri.met
+		COMMAND ${CMAKE_COMMAND} -E copy sof-${fw_name}.ldc ${PROJECT_BINARY_DIR}/sof-${fw_name}.ldc
+		DEPENDS run_meu bin_extras
+		VERBATIM
+		USES_TERMINAL
+	)
+else()
+	add_custom_target(
+		bin ALL
+		COMMAND ${CMAKE_COMMAND} -E copy sof-${fw_name}.ri ${PROJECT_BINARY_DIR}/sof-${fw_name}.ri
+		COMMAND ${CMAKE_COMMAND} -E copy sof-${fw_name}.ldc ${PROJECT_BINARY_DIR}/sof-${fw_name}.ldc
+		DEPENDS run_meu bin_extras
+		VERBATIM
+		USES_TERMINAL
+	)
+endif()
 
 install(
 	FILES ${PROJECT_BINARY_DIR}/sof-${fw_name}.ri

--- a/src/arch/xtensa/CMakeLists.txt
+++ b/src/arch/xtensa/CMakeLists.txt
@@ -367,21 +367,23 @@ if(NOT DEFINED RIMAGE_IMR_TYPE)
 endif()
 
 if(MEU_PATH OR DEFINED MEU_NO_SIGN)
-	execute_process(
-		COMMAND ${MEU_PATH}/meu -ver
-		OUTPUT_VARIABLE MEU_VERSION_FULL_TEXT
-		OUTPUT_STRIP_TRAILING_WHITESPACE
-	)
+	if(NOT DEFINED MEU_OFFSET)
+		execute_process(
+			COMMAND ${MEU_PATH}/meu -ver
+			OUTPUT_VARIABLE MEU_VERSION_FULL_TEXT
+			OUTPUT_STRIP_TRAILING_WHITESPACE
+		)
 
-	string(REGEX MATCH "Version:[\t\n ]*([^\t\n ]+)" ignored "${MEU_VERSION_FULL_TEXT}")
-	set(MEU_VERSION ${CMAKE_MATCH_1})
+		string(REGEX MATCH "Version:[\t\n ]*([^\t\n ]+)" ignored "${MEU_VERSION_FULL_TEXT}")
+		set(MEU_VERSION ${CMAKE_MATCH_1})
 
-	if(MEU_VERSION VERSION_LESS 12.0.0.1035)
-		set(MEU_OFFSET 1152)
-	elseif(MEU_VERSION VERSION_LESS 15.0.0.7041)
-		set(MEU_OFFSET 1088)
-	else()
-		set(MEU_OFFSET 1344)
+		if(MEU_VERSION VERSION_LESS 12.0.0.1035)
+			set(MEU_OFFSET 1152)
+		elseif(MEU_VERSION VERSION_LESS 15.0.0.7041)
+			set(MEU_OFFSET 1088)
+		else()
+			set(MEU_OFFSET 1344)
+		endif()
 	endif()
 
 	add_custom_target(


### PR DESCRIPTION
Add MEU_NO_SIGN cmake flag that can be used to build unsigned FW binary,
that may be later used with MEU for signing.

It's for use cases when you have to build on one OS and sign on another.
To use just add f.e. on TGL `-DMEU_NO_SIGN=ON -DMEU_OFFSET=1344` while executing cmake command.

Edit:
Commit 'Add possibility to specify MEU offset.' is also needed because when there is no meu on local machine buildsystem cannot find correct offset for given version, so it has to be provided manually.