### PR TITLE
topology: add support for rt5682 on link2 in SoundWire mode

### DIFF
--- a/tools/topology/CMakeLists.txt
+++ b/tools/topology/CMakeLists.txt
@@ -95,6 +95,7 @@ set(TPLGS
 	"sof-icl-rt711-rt1308-rt715-hdmi\;sof-cml-rt711-rt1308-mono-rt715\;-DPLATFORM=cml-mono"
 	"sof-icl-rt711-rt1308-rt715-hdmi\;sof-cml-rt711-rt1308-rt715\;-DPLATFORM=cml"
 	"sof-icl-rt711-rt1308-rt715-hdmi\;sof-icl-rt711-rt1308-rt715-hdmi\;-DPLATFORM=icl"
+	"sof-cnl-rt5682-sdw2\;sof-cnl-rt5682-sdw2\;-DPLATFORM=cnl"
 	"sof-apl-asrc-wm8804\;sof-apl-asrc-wm8804"
 	"sof-apl-asrc-pcm512x\;sof-apl-asrc-pcm512x"
 	"sof-apl-src-pcm512x\;sof-apl-src-pcm512x"

--- a/tools/topology/sof-cnl-rt5682-sdw2.m4
+++ b/tools/topology/sof-cnl-rt5682-sdw2.m4
@@ -1,0 +1,146 @@
+#
+# Topology for WHL with rt5682 on link2
+#
+
+# Include topology builder
+include(`utils.m4')
+include(`dai.m4')
+include(`pipeline.m4')
+include(`alh.m4')
+include(`hda.m4')
+
+# Include TLV library
+include(`common/tlv.m4')
+
+# Include Token library
+include(`sof/tokens.m4')
+
+# Include Platform specific DSP configuration
+include(`platform/intel/'PLATFORM`.m4')
+
+DEBUG_START
+
+#
+# Define the pipelines
+#
+# PCM0 ---> volume ----> ALH 2 BE dailink 0
+# PCM1 <--- volume <---- ALH 3 BE dailink 1
+# PCM5 ---> volume ----> iDisp1
+# PCM6 ---> volume ----> iDisp2
+# PCM7 ---> volume ----> iDisp3
+
+dnl PIPELINE_PCM_ADD(pipeline,
+dnl     pipe id, pcm, max channels, format,
+dnl     period, priority, core,
+dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
+dnl     time_domain, sched_comp)
+
+# Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	1, 0, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency capture pipeline 2 on PCM 1 using max 2 channels of s32le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-switch-capture.m4,
+	2, 1, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency playback pipeline 3 on PCM 2 using max 2 channels of s32le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	3, 2, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency playback pipeline 4 on PCM 3 using max 2 channels of s32le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	4, 3, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency playback pipeline 5 on PCM 4 using max 2 channels of s32le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	5, 4, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+#
+# DAIs configuration
+#
+
+dnl DAI_ADD(pipeline,
+dnl     pipe id, dai type, dai_index, dai_be,
+dnl     buffer, periods, format,
+dnl     deadline, priority, core, time_domain)
+
+# playback DAI is ALH(SDW2 PIN2) using 2 periods
+# Buffers use s24le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+	1, ALH, 0x202, SDW2-Playback,
+	PIPELINE_SOURCE_1, 2, s24le,
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+
+# capture DAI is ALH(SDW2 PIN3) using 2 periods
+# Buffers use s24le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-capture.m4,
+	2, ALH, 0x203, SDW2-Capture,
+	PIPELINE_SINK_2, 2, s24le,
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+
+# playback DAI is iDisp1 using 2 periods
+# # Buffers use s32le format, 1000us deadline on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+	3, HDA, 0, iDisp1,
+	PIPELINE_SOURCE_3, 2, s32le,
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+
+# playback DAI is iDisp2 using 2 periods
+# # Buffers use s32le format, 1000us deadline on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+	4, HDA, 1, iDisp2,
+	PIPELINE_SOURCE_4, 2, s32le,
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+
+# playback DAI is iDisp3 using 2 periods
+# # Buffers use s32le format, 1000us deadline on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+	5, HDA, 2, iDisp3,
+	PIPELINE_SOURCE_5, 2, s32le,
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+
+# PCM Low Latency, id 0
+dnl PCM_PLAYBACK_ADD(name, pcm_id, playback)
+PCM_PLAYBACK_ADD(Headphone, 0, PIPELINE_PCM_1)
+PCM_CAPTURE_ADD(Headset mic, 1, PIPELINE_PCM_2)
+PCM_PLAYBACK_ADD(HDMI1, 2, PIPELINE_PCM_3)
+PCM_PLAYBACK_ADD(HDMI2, 3, PIPELINE_PCM_4)
+PCM_PLAYBACK_ADD(HDMI3, 4, PIPELINE_PCM_5)
+
+#
+# BE configurations - overrides config in ACPI if present
+#
+
+#ALH dai index = ((link_id << 8) | PDI id)
+#ALH SDW2 Pin2 (ID: 0)
+DAI_CONFIG(ALH, 0x202, 0, SDW2-Playback,
+	ALH_CONFIG(ALH_CONFIG_DATA(ALH, 0x202, 48000, 2)))
+
+#ALH SDW2 Pin3 (ID: 1)
+DAI_CONFIG(ALH, 0x203, 1, SDW2-Capture,
+	ALH_CONFIG(ALH_CONFIG_DATA(ALH, 0x203, 48000, 2)))
+
+# 3 HDMI/DP outputs (ID: 2,3,4)
+DAI_CONFIG(HDA, 0, 2, iDisp1,
+	HDA_CONFIG(HDA_CONFIG_DATA(HDA, 0, 48000, 2)))
+DAI_CONFIG(HDA, 1, 3, iDisp2,
+	HDA_CONFIG(HDA_CONFIG_DATA(HDA, 1, 48000, 2)))
+DAI_CONFIG(HDA, 2, 4, iDisp3,
+	HDA_CONFIG(HDA_CONFIG_DATA(HDA, 2, 48000, 2)))
+
+DEBUG_END


### PR DESCRIPTION
The UpExtreme provides access to link2 in 2 of the 3 modes. This is
useful to test rt5682 configurations.

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>