### PR TITLE
Logger add possibility to make logs output more compact

### DIFF
--- a/tools/logger/convert.c
+++ b/tools/logger/convert.c
@@ -204,11 +204,14 @@ static double to_usecs(uint64_t time, double clk)
 }
 
 
-static inline void print_table_header(FILE *out_fd)
+static inline void print_table_header(FILE *out_fd, int hide_location)
 {
-	fprintf(out_fd, "%18s %18s %2s %-18s %-29s  %s\n",
-		"TIMESTAMP", "DELTA", "C#", "COMPONENT", "LOCATION",
-		"CONTENT");
+	fprintf(out_fd, "%18s %18s %2s %-18s",
+		"TIMESTAMP", "DELTA", "C#", "COMPONENT");
+	if (!hide_location)
+		fprintf(out_fd, " %-29s", "LOCATION");
+	fprintf(out_fd, "  %s\n", "CONTENT");
+
 	fflush(out_fd);
 }
 
@@ -315,7 +318,8 @@ static char *format_file_name(char *file_name_raw, int full_name)
 static void print_entry_params(FILE *out_fd,
 	const struct snd_sof_uids_header *uids_dict,
 	const struct log_entry_header *dma_log, const struct ldc_entry *entry,
-	uint64_t last_timestamp, double clock, int use_colors, int raw_output)
+	uint64_t last_timestamp, double clock, int use_colors, int raw_output,
+	int hide_location)
 {
 	char ids[TRACE_MAX_IDS_STR];
 	float dt = to_usecs(dma_log->timestamp - last_timestamp, clock);
@@ -335,7 +339,7 @@ static void print_entry_params(FILE *out_fd,
 		ids[0] = '\0';
 
 	if (raw_output) {
-		const char *entry_fmt = "%s%u %u %s%s%s %.6f %.6f (%s:%u) ";
+		const char *entry_fmt = "%s%u %u %s%s%s %.6f %.6f ";
 
 		fprintf(out_fd, entry_fmt,
 			entry->header.level == use_colors ?
@@ -348,9 +352,11 @@ static void print_entry_params(FILE *out_fd,
 			raw_output && strlen(ids) ? "-" : "",
 			ids,
 			to_usecs(dma_log->timestamp, clock),
-			dt,
-			format_file_name(entry->file_name, raw_output),
-			entry->header.line_idx);
+			dt);
+		if (!hide_location)
+			fprintf(out_fd, "(%s:%u) ",
+				format_file_name(entry->file_name, raw_output),
+				entry->header.line_idx);
 	} else {
 		/* timestamp */
 		fprintf(out_fd, "%s[%16.6f] (%16.6f)%s ",
@@ -371,9 +377,10 @@ static void print_entry_params(FILE *out_fd,
 			use_colors ? KNRM : "");
 
 		/* location */
-		fprintf(out_fd, "%24s:%-4u  ",
-			format_file_name(entry->file_name, raw_output),
-			entry->header.line_idx);
+		if (!hide_location)
+			fprintf(out_fd, "%24s:%-4u ",
+				format_file_name(entry->file_name, raw_output),
+				entry->header.line_idx);
 
 		/* level name */
 		fprintf(out_fd, "%s%s",
@@ -525,7 +532,7 @@ static int fetch_entry(const struct convert_config *config,
 			   config->uids_dict,
 			   dma_log, &entry, *last_timestamp,
 			   config->clock, config->use_colors,
-			   config->raw_output);
+			   config->raw_output, config->hide_location);
 	*last_timestamp = dma_log->timestamp;
 
 	/* set f_ldc file position to the beginning */
@@ -603,7 +610,7 @@ static int logger_read(const struct convert_config *config,
 	uint64_t last_timestamp = 0;
 
 	if (!config->raw_output)
-		print_table_header(config->out_fd);
+		print_table_header(config->out_fd, config->hide_location);
 
 	if (config->serial_fd >= 0)
 		/* Wait for CTRL-C */

--- a/tools/logger/convert.h
+++ b/tools/logger/convert.h
@@ -38,6 +38,7 @@ struct convert_config {
 	int raw_output;
 	int dump_ldc;
 	int hide_location;
+	int float_precision;
 	struct snd_sof_uids_header *uids_dict;
 };
 

--- a/tools/logger/convert.h
+++ b/tools/logger/convert.h
@@ -37,6 +37,7 @@ struct convert_config {
 	int serial_fd;
 	int raw_output;
 	int dump_ldc;
+	int hide_location;
 	struct snd_sof_uids_header *uids_dict;
 };
 

--- a/tools/logger/logger.c
+++ b/tools/logger/logger.c
@@ -51,6 +51,8 @@ static void usage(void)
 	fprintf(stdout, "%s:\t -r\t\t\tLess formatted output for "
 		"chained log processors\n",
 		APP_NAME);
+	fprintf(stdout, "%s:\t -L\t\t\tHide log location in source code\n",
+		APP_NAME);
 	fprintf(stdout, "%s:\t -d\t\t\tDump ldc information\n", APP_NAME);
 	exit(0);
 }
@@ -157,8 +159,9 @@ int main(int argc, char *argv[])
 	config.serial_fd = -EINVAL;
 	config.raw_output = 0;
 	config.dump_ldc = 0;
+	config.hide_location = 0;
 
-	while ((opt = getopt(argc, argv, "ho:i:l:ps:c:u:tev:rd")) != -1) {
+	while ((opt = getopt(argc, argv, "ho:i:l:ps:c:u:tev:rdL")) != -1) {
 		switch (opt) {
 		case 'o':
 			config.out_file = optarg;
@@ -198,6 +201,9 @@ int main(int argc, char *argv[])
 			/* enabling checking fw version with ver_file file */
 			config.version_fw = 1;
 			config.version_file = optarg;
+			break;
+		case 'L':
+			config.hide_location = 1;
 			break;
 		case 'd':
 			config.dump_ldc = 1;

--- a/tools/logger/logger.c
+++ b/tools/logger/logger.c
@@ -53,6 +53,8 @@ static void usage(void)
 		APP_NAME);
 	fprintf(stdout, "%s:\t -L\t\t\tHide log location in source code\n",
 		APP_NAME);
+	fprintf(stdout, "%s:\t -f precision\t\t\tset timestamp precision\n",
+		APP_NAME);
 	fprintf(stdout, "%s:\t -d\t\t\tDump ldc information\n", APP_NAME);
 	exit(0);
 }
@@ -160,8 +162,9 @@ int main(int argc, char *argv[])
 	config.raw_output = 0;
 	config.dump_ldc = 0;
 	config.hide_location = 0;
+	config.float_precision = 6;
 
-	while ((opt = getopt(argc, argv, "ho:i:l:ps:c:u:tev:rdL")) != -1) {
+	while ((opt = getopt(argc, argv, "ho:i:l:ps:c:u:tev:rdLf:")) != -1) {
 		switch (opt) {
 		case 'o':
 			config.out_file = optarg;
@@ -204,6 +207,13 @@ int main(int argc, char *argv[])
 			break;
 		case 'L':
 			config.hide_location = 1;
+			break;
+		case 'f':
+			config.float_precision = atoi(optarg);
+			if (config.float_precision < 0) {
+				usage();
+				return -EINVAL;
+			}
 			break;
 		case 'd':
 			config.dump_ldc = 1;


### PR DESCRIPTION
Add option to set timestamp precision and second one to cutout trace location

Original output:
```
$ ./sof-logger -l sof-cnl.ldc -i dma_trace_1.bin
         TIMESTAMP              DELTA C# COMPONENT          LOCATION                      CONTENT
[   497588.489583] (   497588.500000) c0 DMA                .../intel/cavs/hda-dma.c:407  hda-dmac: 4 channel 6 -> get
[   497816.250000] (      227.760422) c0 DMA                .../intel/cavs/hda-dma.c:589  hda-dmac: 4 channel 6 -> config
[   497899.270833] (       83.020836) c0 DMA                .../intel/cavs/hda-dma.c:464  hda-dmac: 4 channel 6 -> start
[   497913.906250] (       14.635417) c0 DMA                .../intel/cavs/hda-dma.c:329  hda-dmac: 4 channel 6 -> enable
[   498012.083333] (       98.177086) c0 SA                          src/lib/agent.c:56   perf sys_load peak plat 25185 cpu 73998
[   498029.322917] (       17.239584) c0 SCHEDULE_LL        ./schedule/ll_schedule.c:178  perf ll_work peak plat 468 cpu 2266
[   498062.968750] (       33.645832) c0 SCHEDULE_LL        ./schedule/ll_schedule.c:304  task add 0x9e0c0080 dma-trace-task <2b972272-c5b1-4b7e-926f-0fc5cb4c4690>
```

With flag -L:
```
$ ../../../build/logger/sof-logger -l sof-cnl.ldc -i dma_trace_1.bin -L
         TIMESTAMP              DELTA C# COMPONENT          CONTENT
[   497588.489583] (   497588.500000) c0 DMA                hda-dmac: 4 channel 6 -> get
[   497816.250000] (      227.760422) c0 DMA                hda-dmac: 4 channel 6 -> config
[   497899.270833] (       83.020836) c0 DMA                hda-dmac: 4 channel 6 -> start
[   497913.906250] (       14.635417) c0 DMA                hda-dmac: 4 channel 6 -> enable
[   498012.083333] (       98.177086) c0 SA                 perf sys_load peak plat 25185 cpu 73998
[   498029.322917] (       17.239584) c0 SCHEDULE_LL        perf ll_work peak plat 468 cpu 2266
[   498062.968750] (       33.645832) c0 SCHEDULE_LL        task add 0x9e0c0080 dma-trace-task <2b972272-c5b1-4b7e-926f-0fc5cb4c4690>
```

With flag -L -f0:
```
$ ../../../build/logger/sof-logger -l sof-cnl.ldc -i dma_trace_1.bin -L -f0
   TIMESTAMP        DELTA C# COMPONENT          CONTENT
[    497588] (    497588) c0 DMA                hda-dmac: 4 channel 6 -> get
[    497816] (       228) c0 DMA                hda-dmac: 4 channel 6 -> config
[    497899] (        83) c0 DMA                hda-dmac: 4 channel 6 -> start
[    497914] (        15) c0 DMA                hda-dmac: 4 channel 6 -> enable
[    498012] (        98) c0 SA                 perf sys_load peak plat 25185 cpu 73998
[    498029] (        17) c0 SCHEDULE_LL        perf ll_work peak plat 468 cpu 2266
[    498063] (        34) c0 SCHEDULE_LL        task add 0x9e0c0080 dma-trace-task <2b972272-c5b1-4b7e-926f-0fc5cb4c4690>
[    498077] (        14) c0 SCHEDULE_LL        task params pri 4 flags 0 start 500000 period 500000
[    498093] (        16) c0 SCHEDULE_LL        num_tasks 2 total_num_tasks 2
[    532524] (     34431) c0 IPC                ipc: hdr 0x30010000 tx (76) > rx (28)
[    532537] (        13) c0 IPC                ipc: pipe 1 comp 0 -> new (type 1)
[    532568] (        31) c0 COMP               comp new host <8b9d100c-6d78-418f-90a3-e0e805d0852b> type 1 pipe_id 1 id 0
```

