### PR TITLE
ext_man: Port SOF_IPC_EXT_WINDOW to extended manifest

### DIFF
--- a/src/include/ipc/info.h
+++ b/src/include/ipc/info.h
@@ -107,7 +107,7 @@ struct sof_ipc_window_elem {
 struct sof_ipc_window {
 	struct sof_ipc_ext_data_hdr ext_hdr;
 	uint32_t num_windows;
-	struct sof_ipc_window_elem window[];
+	struct sof_ipc_window_elem window[SOF_IPC_MAX_ELEMS];
 } __attribute__((packed));
 
 /* extended data, compiler version */

--- a/src/include/kernel/abi.h
+++ b/src/include/kernel/abi.h
@@ -29,7 +29,7 @@
 
 /** \brief SOF ABI version major, minor and patch numbers */
 #define SOF_ABI_MAJOR 3
-#define SOF_ABI_MINOR 16
+#define SOF_ABI_MINOR 17
 #define SOF_ABI_PATCH 0
 
 /** \brief SOF ABI version number. Format within 32bit word is MMmmmppp */

--- a/src/include/kernel/ext_manifest.h
+++ b/src/include/kernel/ext_manifest.h
@@ -47,6 +47,7 @@
 /* Extended manifest elements identificators */
 enum ext_man_elem_type {
 	EXT_MAN_ELEM_FW_VERSION		= 0,
+	EXT_MAN_ELEM_WINDOW		= SOF_IPC_EXT_WINDOW,
 	EXT_MAN_ELEM_CC_VERSION		= SOF_IPC_EXT_CC_INFO,
 	EXT_MAN_ELEM_PROBE_INFO		= SOF_IPC_EXT_PROBE_INFO,
 };
@@ -57,6 +58,13 @@ struct ext_man_fw_version {
 	/* use sof_ipc struct because of code re-use */
 	struct sof_ipc_fw_version version;
 	uint32_t flags;
+} __packed;
+
+/* windows info */
+struct ext_man_windows {
+	struct ext_man_elem_header hdr;
+	/* use sof_ipc struct because of code re-use */
+	struct sof_ipc_window window;
 } __packed;
 
 /* Used C compiler description */

--- a/src/include/kernel/ext_manifest.h
+++ b/src/include/kernel/ext_manifest.h
@@ -32,6 +32,15 @@
 #include <rimage/sof/kernel/ext_manifest.h>
 #include <stdint.h>
 
+/* Macro used to creeate copy of some structure in extended manifest */
+#define EXT_MAN_PORT(XENUM, XSIZE, IPC_ELEM, XNAME, IPC_NAME, CONTENT)	\
+	XNAME __aligned(EXT_MAN_ALIGN) __section(".fw_metadata")	\
+		__attribute__ ((unused)) = {				\
+		.hdr.type = XENUM,					\
+		.hdr.elem_size = ALIGN_UP(XSIZE, EXT_MAN_ALIGN),	\
+		.IPC_ELEM = { CONTENT }					\
+	};								\
+	IPC_NAME = { CONTENT }
 
 /* Now define extended manifest elements */
 

--- a/src/platform/baytrail/platform.c
+++ b/src/platform/baytrail/platform.c
@@ -77,12 +77,18 @@ static const struct sof_ipc_fw_ready ready
 };
 
 #define NUM_BYT_WINDOWS		6
-static const struct sof_ipc_window sram_window
-	__section(".fw_ready_metadata") = {
+
+EXT_MAN_PORT(
+	EXT_MAN_ELEM_WINDOW,
+	sizeof(struct ext_man_windows),
+	window,
+	static const struct ext_man_windows xsram_window,
+	static const struct sof_ipc_window sram_window
+		__section(".fw_ready_metadata"),
+	_META_EXPAND(
 	.ext_hdr	= {
 		.hdr.cmd = SOF_IPC_FW_READY,
-		.hdr.size = sizeof(struct sof_ipc_window) +
-			sizeof(struct sof_ipc_window_elem) * NUM_BYT_WINDOWS,
+		.hdr.size = sizeof(struct sof_ipc_window),
 		.type	= SOF_IPC_EXT_WINDOW,
 	},
 	.num_windows	= NUM_BYT_WINDOWS,
@@ -130,7 +136,7 @@ static const struct sof_ipc_window sram_window
 			.offset	= MAILBOX_EXCEPTION_OFFSET,
 		},
 	},
-};
+));
 
 SHARED_DATA struct timer timer = {
 	.id = TIMER3, /* external timer */

--- a/src/platform/haswell/platform.c
+++ b/src/platform/haswell/platform.c
@@ -32,6 +32,7 @@
 #include <ipc/header.h>
 #include <ipc/info.h>
 #include <kernel/abi.h>
+#include <kernel/ext_manifest.h>
 #include <version.h>
 #include <errno.h>
 #include <stddef.h>
@@ -62,12 +63,18 @@ static const struct sof_ipc_fw_ready ready
 };
 
 #define NUM_HSW_WINDOWS		6
-static const struct sof_ipc_window sram_window
-	__section(".fw_ready_metadata") = {
+
+EXT_MAN_PORT(
+	EXT_MAN_ELEM_WINDOW,
+	sizeof(struct ext_man_windows),
+	window,
+	static const struct ext_man_windows xsram_window,
+	static const struct sof_ipc_window sram_window
+		__section(".fw_ready_metadata"),
+	_META_EXPAND(
 	.ext_hdr	= {
 		.hdr.cmd = SOF_IPC_FW_READY,
-		.hdr.size = sizeof(struct sof_ipc_window) +
-			sizeof(struct sof_ipc_window_elem) * NUM_HSW_WINDOWS,
+		.hdr.size = sizeof(struct sof_ipc_window),
 		.type	= SOF_IPC_EXT_WINDOW,
 	},
 	.num_windows	= NUM_HSW_WINDOWS,
@@ -115,7 +122,7 @@ static const struct sof_ipc_window sram_window
 			.offset	= MAILBOX_EXCEPTION_OFFSET,
 		},
 	},
-};
+));
 
 SHARED_DATA struct timer timer = {
 	.id = TIMER1, /* internal timer */

--- a/src/platform/imx8/platform.c
+++ b/src/platform/imx8/platform.c
@@ -30,6 +30,7 @@
 #include <ipc/header.h>
 #include <ipc/info.h>
 #include <kernel/abi.h>
+#include <kernel/ext_manifest.h>
 #include <version.h>
 #include <errno.h>
 #include <stdint.h>
@@ -62,12 +63,17 @@ static const struct sof_ipc_fw_ready ready
 
 #define NUM_IMX_WINDOWS		6
 
-static const struct sof_ipc_window sram_window
-	__section(".fw_ready_metadata") = {
+EXT_MAN_PORT(
+	EXT_MAN_ELEM_WINDOW,
+	sizeof(struct ext_man_windows),
+	window,
+	static const struct ext_man_windows xsram_window,
+	static const struct sof_ipc_window sram_window
+		__section(".fw_ready_metadata"),
+	_META_EXPAND(
 	.ext_hdr	= {
 		.hdr.cmd = SOF_IPC_FW_READY,
-		.hdr.size = sizeof(struct sof_ipc_window) +
-			sizeof(struct sof_ipc_window_elem) * NUM_IMX_WINDOWS,
+		.hdr.size = sizeof(struct sof_ipc_window),
 		.type	= SOF_IPC_EXT_WINDOW,
 	},
 	.num_windows	= NUM_IMX_WINDOWS,
@@ -115,7 +121,7 @@ static const struct sof_ipc_window sram_window
 			.offset	= MAILBOX_EXCEPTION_OFFSET,
 		},
 	},
-};
+));
 
 SHARED_DATA struct timer timer = {
 	.id = TIMER0, /* internal timer */

--- a/src/platform/imx8m/platform.c
+++ b/src/platform/imx8m/platform.c
@@ -29,6 +29,7 @@
 #include <ipc/header.h>
 #include <ipc/info.h>
 #include <kernel/abi.h>
+#include <kernel/ext_manifest.h>
 #include <version.h>
 #include <errno.h>
 #include <stdint.h>
@@ -61,12 +62,17 @@ static const struct sof_ipc_fw_ready ready
 
 #define NUM_IMX_WINDOWS		6
 
-static const struct sof_ipc_window sram_window
-	__section(".fw_ready_metadata") = {
+EXT_MAN_PORT(
+	EXT_MAN_ELEM_WINDOW,
+	sizeof(struct ext_man_windows),
+	window,
+	static const struct ext_man_windows xsram_window,
+	static const struct sof_ipc_window sram_window
+		__section(".fw_ready_metadata"),
+	_META_EXPAND(
 	.ext_hdr	= {
 		.hdr.cmd = SOF_IPC_FW_READY,
-		.hdr.size = sizeof(struct sof_ipc_window) +
-			sizeof(struct sof_ipc_window_elem) * NUM_IMX_WINDOWS,
+		.hdr.size = sizeof(struct sof_ipc_window),
 		.type	= SOF_IPC_EXT_WINDOW,
 	},
 	.num_windows	= NUM_IMX_WINDOWS,
@@ -114,7 +120,7 @@ static const struct sof_ipc_window sram_window
 			.offset	= MAILBOX_EXCEPTION_OFFSET,
 		},
 	},
-};
+));
 
 SHARED_DATA struct timer timer = {
 	.id = TIMER0, /* internal timer */

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -43,6 +43,7 @@
 #include <ipc/header.h>
 #include <ipc/info.h>
 #include <kernel/abi.h>
+#include <kernel/ext_manifest.h>
 #include <config.h>
 #include <version.h>
 #include <errno.h>
@@ -76,12 +77,17 @@ static const struct sof_ipc_fw_ready ready
 
 #define NUM_WINDOWS 7
 
-static const struct sof_ipc_window sram_window
-	__section(".fw_ready_metadata") = {
+EXT_MAN_PORT(
+	EXT_MAN_ELEM_WINDOW,
+	sizeof(struct ext_man_windows),
+	window,
+	static const struct ext_man_windows xsram_window,
+	static const struct sof_ipc_window sram_window
+		__section(".fw_ready_metadata"),
+	_META_EXPAND(
 	.ext_hdr	= {
 		.hdr.cmd = SOF_IPC_FW_READY,
-		.hdr.size = sizeof(struct sof_ipc_window) +
-			sizeof(struct sof_ipc_window_elem) * NUM_WINDOWS,
+		.hdr.size = sizeof(struct sof_ipc_window),
 		.type	= SOF_IPC_EXT_WINDOW,
 	},
 	.num_windows	= NUM_WINDOWS,
@@ -136,7 +142,7 @@ static const struct sof_ipc_window sram_window
 			.offset	= 0,
 		},
 	},
-};
+));
 #endif
 
 #if CONFIG_CANNONLAKE || CONFIG_ICELAKE || CONFIG_TIGERLAKE


### PR DESCRIPTION
This information known at build time does not need to be
provided in a mailbox.

https://github.com/thesofproject/linux/pull/2087