### PR TITLE
[WIP] ext_manifest: Add UUID dictionary

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "rimage"]
 	path = rimage
 	url = https://github.com/thesofproject/rimage.git
-	branch = master
+	branch = ext-man-uuid

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ set(CMAKE_ASM_FLAGS -DASSEMBLY)
 add_library(sof_public_headers INTERFACE)
 
 target_include_directories(sof_public_headers INTERFACE ${PROJECT_SOURCE_DIR}/src/include)
+target_include_directories(sof_public_headers INTERFACE ${PROJECT_SOURCE_DIR}/rimage/src/include)
 target_include_directories(sof_public_headers INTERFACE ${PROJECT_SOURCE_DIR}/rimage/src/include/sof)
 
 # interface library that is used only as container for sof binary options

--- a/src/include/kernel/ext_manifest.h
+++ b/src/include/kernel/ext_manifest.h
@@ -30,7 +30,7 @@
 #include <ipc/info.h>
 #include <sof/compiler_attributes.h>
 #include <stdint.h>
-#include <rimage/src/include/sof/kernel/ext_manifest.h>
+#include <sof/kernel/ext_manifest.h>
 
 /* FW version */
 struct ext_man_fw_version {

--- a/src/include/kernel/ext_manifest.h
+++ b/src/include/kernel/ext_manifest.h
@@ -53,4 +53,16 @@ struct ext_man_probe_support {
 	struct sof_ipc_probe_support probe;
 } __packed;
 
+/* UUID dictionary */
+struct ext_man_uuid_dict_elem {
+	uint32_t addr;
+	uint8_t uuid[16];
+} __packed;
+
+struct ext_man_uuid_dict {
+	struct ext_man_elem_header hdr;
+	/* filled in rimage by uuid_section content */
+	struct ext_man_uuid_dict_elem entries[];
+} __packed;
+
 #endif /* __KERNEL_EXT_MANIFEST_H__ */

--- a/src/include/kernel/ext_manifest.h
+++ b/src/include/kernel/ext_manifest.h
@@ -30,58 +30,7 @@
 #include <ipc/info.h>
 #include <sof/compiler_attributes.h>
 #include <stdint.h>
-
-/* In ASCII `XMan` */
-#define EXT_MAN_MAGIC_NUMBER	0x6e614d58
-
-/* Build u32 number in format MMmmmppp */
-#define EXT_MAN_BUILD_VERSION(MAJOR, MINOR, PATH) ( \
-	((uint32_t)(MAJOR) << 24) | \
-	((uint32_t)(MINOR) << 12) | \
-	(uint32_t)(PATH))
-
-/* check extended manifest version consistency */
-#define EXT_MAN_VERSION_INCOMPATIBLE(host_ver, cli_ver) ( \
-	((host_ver) & GENMASK(31, 24)) != \
-	((cli_ver) & GENMASK(31, 24)))
-
-/* used extended manifest header version */
-#define EXT_MAN_VERSION		EXT_MAN_BUILD_VERSION(1, 0, 0)
-
-/* struct size alignment for ext_man elements */
-#define EXT_MAN_ALIGN 16
-
-/* extended manifest header, deleting any field breaks backward compatibility */
-struct ext_man_header {
-	uint32_t magic;		/**< identification number, */
-				/**< EXT_MAN_MAGIC_NUMBER */
-	uint32_t full_size;	/**< [bytes] full size of ext_man, */
-				/**< (header + content + padding) */
-	uint32_t header_size;	/**< [bytes] makes header extensionable, */
-				/**< after append new field to ext_man header */
-				/**< then backward compatible won't be lost */
-	uint32_t header_version; /**< value of EXT_MAN_VERSION */
-				/**< not related with following content */
-
-	/* just after this header should be list of ext_man_elem_* elements */
-} __packed;
-
-/* Now define extended manifest elements */
-
-/* Extended manifest elements identificators */
-enum ext_man_elem_type {
-	EXT_MAN_ELEM_FW_VERSION		= 0,
-	EXT_MAN_ELEM_CC_VERSION		= SOF_IPC_EXT_CC_INFO,
-	EXT_MAN_ELEM_PROBE_INFO		= SOF_IPC_EXT_PROBE_INFO,
-};
-
-/* extended manifest element header */
-struct ext_man_elem_header {
-	uint32_t type;		/**< EXT_MAN_ELEM_* */
-	uint32_t elem_size;	/**< in bytes, including header size */
-
-	/* just after this header should be type dependent content */
-} __packed;
+#include <rimage/src/include/sof/kernel/ext_manifest.h>
 
 /* FW version */
 struct ext_man_fw_version {

--- a/src/include/sof/lib/uuid.h
+++ b/src/include/sof/lib/uuid.h
@@ -9,6 +9,7 @@
 #define __SOF_LIB_UUID_H__
 
 #include <sof/common.h>
+#include <kernel/ext_manifest.h>
 
 /** \addtogroup uuid_api UUID API
  *  UUID API specification.
@@ -78,6 +79,17 @@ struct sof_uuid {
 		 .d = {vd0, vd1, vd2, vd3, vd4, vd5, vd6, vd7}},	\
 		sizeof(entity_name),					\
 		entity_name						\
+	};								\
+	__section(".fw_metadata_uuid_dict")				\
+	static const struct ext_man_uuid_dict_elem			\
+	ext_man_uuid_ ## uuid_name = {					\
+		.addr = (uint32_t)&uuid_name,				\
+		.uuid = { (va) & 0xFF, ((va) >> 8) & 0xFF,		\
+			  ((va) >> 16) & 0xFF, ((va) >> 24) & 0xFF,	\
+			  (vb) & 0xFF, ((vb) >> 8) & 0xFF,		\
+			  (vc) & 0xFF, ((vc) >> 8) & 0xFF,		\
+			  (vd0), (vd1), (vd2), (vd3),			\
+			  (vd4), (vd5), (vd6), (vd7) }			\
 	}
 
 /** \brief Creates local unique 32-bit representation of UUID structure.

--- a/src/init/ext_manifest.c
+++ b/src/init/ext_manifest.c
@@ -70,3 +70,14 @@ const struct ext_man_probe_support ext_man_probe
 #endif
 	},
 };
+
+/*
+ * this element size will be updated by rimage,
+ * so size shouldn't be aligned yet.
+ * List of entries will be fetched from `fw_metadata_uuid_dict` section.
+ */
+const struct ext_man_uuid_dict ext_man_uuid_header
+	__aligned(EXT_MAN_ALIGN) __section(".fw_metadata") = {
+	.hdr.type = EXT_MAN_ELEM_UUID_DICT,
+	.hdr.elem_size = sizeof(struct ext_man_uuid_dict),
+};

--- a/src/platform/cannonlake/cannonlake.x.in
+++ b/src/platform/cannonlake/cannonlake.x.in
@@ -568,4 +568,9 @@ SECTIONS
     KEEP (*(.fw_metadata))
     . = ALIGN(_EXT_MAN_ALIGN_);
   } >fw_metadata_seg :metadata_entries_phdr
+
+  .fw_metadata_uuid_dict (COPY) : ALIGN(1024)
+  {
+    KEEP (*(.fw_metadata_uuid_dict))
+  } >fw_metadata_seg :metadata_entries_phdr
 }


### PR DESCRIPTION
Dictionary for tranformation UUID value to UUID entry address used in
FW runtime should be available for driver.

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>