### PR TITLE
 schedule: dma: check irq register result

### DIFF
--- a/src/schedule/dma_single_chan_domain.c
+++ b/src/schedule/dma_single_chan_domain.c
@@ -349,8 +349,13 @@ static void dma_domain_unregister_owner(struct ll_schedule_domain *domain,
 		tr_info(&ll_tr, "dma_domain_unregister_owner(): some channel is still running, registering again");
 
 		/* register again and enable */
-		dma_single_chan_domain_irq_register(channel, data,
-						    data->handler, data->arg);
+		if (dma_single_chan_domain_irq_register(channel, data,
+							data->handler,
+							data->arg) < 0) {
+			tr_err(&ll_tr, "dma_domain_unregister_owner(): couldn't register irq");
+			return;
+		}
+
 		dma_interrupt(data->channel, DMA_IRQ_CLEAR);
 		dma_single_chan_domain_enable(domain, core);
 		dma_domain->channel_changed = true;


### PR DESCRIPTION
Check if re-register failed in dma_domain_unregister_owner.

Signed-off-by: Janusz Jankowski <janusz.jankowski@linux.intel.com>

Error was reported by clang static analyzer as potential null dereference.