### PR TITLE
pipeline: fail to recover from xrun in pipeline_task

### DIFF
--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -790,6 +790,7 @@ static int host_copy(struct comp_dev *dev)
 		if (ret < 0) {
 			trace_host_error("host_copy() error: dma_copy() "
 					 "failed, ret = %u", ret);
+			comp_underrun(dev, hd->dma_buffer, hd->dma_buffer->size, 0);
 			return ret;
 		}
 	}


### PR DESCRIPTION
The pipeline is in active state so pipeline_prepare() always fail and
the pipeline_task() stops the pipeline. A stop trigger could move the
pipeline to prepare state for pipeline_prepare() to run successfully.

Signed-off-by: Brent Lu <brent.lu@intel.com>