### PR TITLE
Audio: EQ IIR: Add support for large configuration blobs plus EQ topology fixes

### DIFF
--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -418,8 +418,8 @@ static int eq_iir_init_coef(struct sof_eq_iir_config *config,
 			/* Initialize EQ channel to bypass and continue with
 			 * next channel response.
 			 */
-			comp_cl_err(&comp_eq_iir, "eq_iir_init_coef(), ch %d is set to bypass",
-				    i);
+			comp_cl_info(&comp_eq_iir, "eq_iir_init_coef(), ch %d is set to bypass",
+				     i);
 			iir_reset_df2t(&iir[i]);
 			continue;
 		}

--- a/tools/topology/sof/pipe-eq-fir-volume-playback.m4
+++ b/tools/topology/sof/pipe-eq-fir-volume-playback.m4
@@ -52,7 +52,7 @@ C_CONTROLBYTES(EQFIR, PIPELINE_ID,
 	CONTROLBYTES_OPS(bytes, 258 binds the mixer control to bytes get/put handlers, 258, 258),
 	CONTROLBYTES_EXTOPS(258 binds the mixer control to bytes get/put handlers, 258, 258),
 	, , ,
-	CONTROLBYTES_MAX(, 304),
+	CONTROLBYTES_MAX(, 4096),
 	,
 	DEF_EQFIR_PRIV)
 

--- a/tools/topology/sof/pipe-eq-iir-eq-fir-volume-playback.m4
+++ b/tools/topology/sof/pipe-eq-iir-eq-fir-volume-playback.m4
@@ -58,7 +58,7 @@ C_CONTROLBYTES(DEF_EQIIR_COEF, PIPELINE_ID,
 	CONTROLBYTES_OPS(bytes, 258 binds the mixer control to bytes get/put handlers, 258, 258),
 	CONTROLBYTES_EXTOPS(258 binds the mixer control to bytes get/put handlers, 258, 258),
 	, , ,
-	CONTROLBYTES_MAX(, 304),
+	CONTROLBYTES_MAX(, 1024),
 	,
 	DEF_EQIIR_PRIV)
 

--- a/tools/topology/sof/pipe-eq-iir-volume-capture-16khz.m4
+++ b/tools/topology/sof/pipe-eq-iir-volume-capture-16khz.m4
@@ -59,7 +59,7 @@ C_CONTROLBYTES(DEF_EQIIR_COEF, PIPELINE_ID,
 		258 binds the mixer control to bytes get/put handlers,
 		258, 258),
 	, , ,
-	CONTROLBYTES_MAX(, 304),
+	CONTROLBYTES_MAX(, 1024),
 	,
 	DEF_EQIIR_PRIV)
 

--- a/tools/topology/sof/pipe-eq-iir-volume-capture.m4
+++ b/tools/topology/sof/pipe-eq-iir-volume-capture.m4
@@ -75,7 +75,7 @@ C_CONTROLBYTES(DEF_EQIIR_COEF, PIPELINE_ID,
 		258 binds the mixer control to bytes get/put handlers,
 		258, 258),
 	, , ,
-	CONTROLBYTES_MAX(, 304),
+	CONTROLBYTES_MAX(, 1024),
 	,
 	DEF_EQIIR_PRIV)
 

--- a/tools/topology/sof/pipe-eq-iir-volume-playback.m4
+++ b/tools/topology/sof/pipe-eq-iir-volume-playback.m4
@@ -55,7 +55,7 @@ C_CONTROLBYTES(DEF_EQIIR_COEF, PIPELINE_ID,
 	CONTROLBYTES_OPS(bytes, 258 binds the mixer control to bytes get/put handlers, 258, 258),
 	CONTROLBYTES_EXTOPS(258 binds the mixer control to bytes get/put handlers, 258, 258),
 	, , ,
-	CONTROLBYTES_MAX(, 304),
+	CONTROLBYTES_MAX(, 1024),
 	,
 	DEF_EQIIR_PRIV)
 

--- a/tools/topology/sof/pipe-highpass-capture.m4
+++ b/tools/topology/sof/pipe-highpass-capture.m4
@@ -62,7 +62,7 @@ C_CONTROLBYTES(DEF_EQIIR_COEF, PIPELINE_ID,
 		258 binds the mixer control to bytes get/put handlers,
 		258, 258),
 	, , ,
-	CONTROLBYTES_MAX(, 304),
+	CONTROLBYTES_MAX(, 1024),
 	,
 	DEF_EQIIR_PRIV)
 

--- a/tools/topology/sof/pipe-highpass-capture.m4
+++ b/tools/topology/sof/pipe-highpass-capture.m4
@@ -125,5 +125,5 @@ PCM_CAPABILITIES(Highpass Capture PCM_ID, `S32_LE,S24_LE,S16_LE',
 
 undefine(`DEF_PGA_TOKENS')
 undefine(`DEF_PGA_CONF')
-undefine(`DEF_EQFIR_COEF')
-undefine(`DEF_EQFIR_PRIV')
+undefine(`DEF_EQIIR_COEF')
+undefine(`DEF_EQIIR_PRIV')

--- a/tools/topology/sof/pipe-highpass-switch-capture.m4
+++ b/tools/topology/sof/pipe-highpass-switch-capture.m4
@@ -71,7 +71,7 @@ C_CONTROLBYTES(DEF_EQIIR_COEF, PIPELINE_ID,
 		258 binds the mixer control to bytes get/put handlers,
 		258, 258),
 	, , ,
-	CONTROLBYTES_MAX(, 304),
+	CONTROLBYTES_MAX(, 1024),
 	,
 	DEF_EQIIR_PRIV)
 


### PR DESCRIPTION
The main change in this pull request is to handle multi-part configuration IPC. The other changes are align of bytes control max. size in topologies to 1024 bytes to IIR and 4096 bytes to FIR. Also a mistake fix for macro name clear is included. It didn't seem cause any issues though.