### PR TITLE
scripts/testbench: add set -e

### DIFF
--- a/scripts/host-testbench.sh
+++ b/scripts/host-testbench.sh
@@ -11,6 +11,9 @@
 # ./scripts/host-testbench.sh
 #
 
+# stop on most errors
+set -e
+
 function filesize() {
   du -b "$1" | awk '{print $1}'
 }
@@ -46,7 +49,7 @@ SOF_DIR=$SCRIPTS_DIR/../
 TESTBENCH_DIR=${SOF_DIR}/tools/test/audio
 INPUT_FILE_SIZE=10240
 
-cd "$TESTBENCH_DIR" || exit 2
+cd "$TESTBENCH_DIR"
 rm -rf ./*.raw
 
 # create input zeros raw file

--- a/scripts/xtensa-build-all.sh
+++ b/scripts/xtensa-build-all.sh
@@ -2,6 +2,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright(c) 2018 Intel Corporation. All rights reserved.
 
+# stop on most errors
+set -e
+
 SUPPORTED_PLATFORMS=(byt cht bdw hsw apl skl kbl cnl sue icl jsl \
                     imx8 imx8x imx8m)
 BUILD_ROM=no
@@ -55,7 +58,7 @@ for arg in "$@"; do
 		if [ x"$i" = x"$arg" ]; then
 			PLATFORMS=("${PLATFORMS[@]}" "$i")
 			platform=$i
-			shift
+			shift || true
 			break
 		fi
 	done
@@ -83,9 +86,6 @@ then
 	fi
 	PRIVATE_KEY_OPTION="-DRIMAGE_PRIVATE_KEY=${RIMAGE_PRIVATE_KEY}"
 fi
-
-# fail on any errors
-set -e
 
 OLDPATH=$PATH
 WORKDIR="$pwd"

--- a/tools/test/audio/comp_run.sh
+++ b/tools/test/audio/comp_run.sh
@@ -2,6 +2,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright(c) 2018-2020 Intel Corporation. All rights reserved.
 
+# stop on most errors
+set -e
+
 COMP=$1
 DIRECTION=$2
 BITS_IN=$3

--- a/tools/test/audio/eqiir_run.sh
+++ b/tools/test/audio/eqiir_run.sh
@@ -2,6 +2,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright(c) 2020 Intel Corporation. All rights reserved.
 
+# stop on most errors
+set -e
+
 usage ()
 {
     echo "Usage:   $0 <bits in> <bits out> <rate> <input> <output>"
@@ -14,7 +17,7 @@ main ()
 
     if [ $# -ne 5 ]; then
 	usage "$0"
-	exit
+	exit 1
     fi
 
     COMP=eq-iir

--- a/tools/test/audio/src_run.sh
+++ b/tools/test/audio/src_run.sh
@@ -2,6 +2,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright(c) 2018-2020 Intel Corporation. All rights reserved.
 
+# stop on most errors
+set -e
+
 usage ()
 {
     echo "Usage:   $1 <bits in> <bits out> <rate in> <rate out> <input> <output>"
@@ -14,7 +17,7 @@ main()
 
     if [ $# -ne 6 ]; then
 	usage "$0"
-	exit
+	exit 1
     fi
 
     COMP=src

--- a/tools/test/audio/volume_run.sh
+++ b/tools/test/audio/volume_run.sh
@@ -2,6 +2,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright(c) 2020 Intel Corporation. All rights reserved.
 
+# stop on most errors
+set -e
+
 usage ()
 {
     echo "Usage:   $0 <bits in> <bits out> <rate> <input> <output>"
@@ -14,7 +17,7 @@ main ()
 
     if [ $# -ne 5 ]; then
 	usage "$0"
-	exit
+	exit 1
     fi
 
     COMP=volume


### PR DESCRIPTION
Let's stop ignoring build and test failures. Start gradually with the
scripts involved in testbench, more files later.

Follow-up to to bug #2752 "host-testbench.sh ignores errors" and commit
ab421466aff826 ("CI: Travis: enable host testbnech again") and
ab421466aff826~1

Signed-off-by: Marc Herbert <marc.herbert@intel.com>
