### PR TITLE
scripts/build-tools.sh: let user override NO_PROCESSORS

### DIFF
--- a/scripts/build-tools.sh
+++ b/scripts/build-tools.sh
@@ -42,11 +42,10 @@ build_fuzzer()
 
 main()
 {
-        local DO_BUILD_TEST DO_BUILD_FUZZER SCRIPT_DIR SOF_REPO NO_PROCESSORS
-
+        local DO_BUILD_TEST DO_BUILD_FUZZER SCRIPT_DIR SOF_REPO
         SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
         SOF_REPO=$(dirname "$SCRIPT_DIR")
-        NO_PROCESSORS=$(nproc)
+        : ${NO_PROCESSORS:=$(nproc)}
 
         DO_BUILD_TEST=false
         DO_BUILD_FUZZER=false


### PR DESCRIPTION
When there's a failure like for instance SOF issue #2543, fixed in
alsa-utils commit caf77a93cef5 ("topology: add back asrc to widget_map
in dapm.c"), it's finally possible to remove all the noise around the
failure and see the failed command:

   NO_PROCESSORS=1 VEBOSE=1 ./scripts/build-tools.sh

Signed-off-by: Marc Herbert <marc.herbert@intel.com>