### PR TITLE
zephyr: Change task_main_start() to not require sof argument

### DIFF
--- a/zephyr/include/sof/schedule/task.h
+++ b/zephyr/include/sof/schedule/task.h
@@ -101,6 +101,6 @@ void task_main_init(void);
 
 void task_main_free(void);
 
-int task_main_start(struct sof *sof);
+int task_main_start(void);
 
 #endif /* __SOF_SCHEDULE_TASK_H__ */

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -371,8 +371,10 @@ void sys_comp_asrc_init(void);
 void sys_comp_dcblock_init(void);
 void sys_comp_eq_iir_init(void);
 
-int task_main_start(struct sof *sof)
+int task_main_start(void)
 {
+	struct sof *sof = sof_get();
+
 	/* init default audio components */
 	sys_comp_init(sof);
 


### PR DESCRIPTION
This function would be called from Zephyr sample which does not need
to include SOF headers for sof_get(), etc.