### PR TITLE
Fix tool build without submodule setup

### DIFF
--- a/scripts/cmake/git-submodules.cmake
+++ b/scripts/cmake/git-submodules.cmake
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 find_package(Git)
-if(GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
+if(GIT_FOUND AND EXISTS "${SOF_ROOT_SOURCE_DIRECTORY}/.git")
 	# Update submodules by default
 	option(GIT_SUBMODULE "Check submodules during build" ON)
 
@@ -18,6 +18,6 @@ if(GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
 	endif()
 endif()
 
-if(NOT EXISTS "${PROJECT_SOURCE_DIR}/rimage/CMakeLists.txt")
+if(NOT EXISTS "${SOF_ROOT_SOURCE_DIRECTORY}/rimage/CMakeLists.txt")
 	message(FATAL_ERROR "The submodules were not downloaded! GIT_SUBMODULE was turned off or failed. Please update submodules and try again.")
 endif()

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -14,6 +14,9 @@ project(SOF_TOOLS C)
 
 set(SOF_ROOT_SOURCE_DIRECTORY "${PROJECT_SOURCE_DIR}/..")
 
+# checkout submodules
+include(${SOF_ROOT_SOURCE_DIRECTORY}/scripts/cmake/git-submodules.cmake)
+
 add_subdirectory(probes)
 add_subdirectory(logger)
 add_subdirectory(ctl)


### PR DESCRIPTION
Fix submodule missing issue in tools build by add submodule cmake function into tools build.