### PR TITLE
topology: remove sof-tgl-rt711-i2s-rt1308-nohdmi.conf

### DIFF
--- a/tools/topology/CMakeLists.txt
+++ b/tools/topology/CMakeLists.txt
@@ -119,7 +119,6 @@ set(TPLGS
 	"sof-tgl-nocodec\;sof-tgl-nocodec"
 	"sof-tgl-rt711-i2s-rt1308\;sof-tgl-rt711-i2s-rt1308-2ch\;-DHDMI=1\;-DCHANNELS=2"
 	"sof-tgl-rt711-i2s-rt1308\;sof-tgl-rt711-i2s-rt1308-4ch\;-DHDMI=1\;-DCHANNELS=4"
-	"sof-tgl-rt711-i2s-rt1308\;sof-tgl-rt711-i2s-rt1308-nohdmi"
 	"sof-tgl-rt711-rt1308\;sof-tgl-rt711-rt1308"
 	"sof-tgl-rt5682\;sof-tgl-rt5682\;-DHDMI=1"
 	"sof-tgl-nocodec\;sof-ehl-nocodec"


### PR DESCRIPTION
No one seems to be using this topology or they would have seen the
error below that DMICs are required on this platform.

[  8%] Generating sof-tgl-rt711-i2s-rt1308-nohdmi.conf

m4:tools/topology/sof/pipe-volume-capture-16khz.m4:54: bad expression
in eval (bad input): 2 * 2 * CHANNELS * 16
m4:tools/topology/sof/pipe-volume-capture-16khz.m4:57: bad expression
in eval (bad input): 2 * 2 * CHANNELS * 16

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>