### PR TITLE
topology: invoke with m4 --fatal-warnings

### DIFF
--- a/tools/topology/CMakeLists.txt
+++ b/tools/topology/CMakeLists.txt
@@ -154,7 +154,7 @@ foreach(tplg ${TPLGS})
 
 	add_custom_command(
 		OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${output}.conf
-		COMMAND m4
+		COMMAND m4 --fatal-warnings
 			${DEFINES}
 			-I ${CMAKE_CURRENT_SOURCE_DIR}/m4
 			-I ${CMAKE_CURRENT_SOURCE_DIR}/common


### PR DESCRIPTION
As seen in PR #2954, no one ever notices m4 warnings. As PR #2954 will
remove sof-tgl-rt711-i2s-rt1308-nohdmi.conf and the only m4 warning
currently, this is a great opportunity to upgrade m4 warnings to
errors.

Note neither Travis nor github have the concept of a "warning", they can
only report success or failure.

This fix can be considered part of the "green failures" family.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>