### PR TITLE
Generic process implementation

### DIFF
--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -65,9 +65,14 @@ struct comp_dev *comp_new(struct sof_ipc_comp *comp)
 	/* find the driver for our new component */
 	drv = get_drv(comp->type);
 	if (!drv) {
-		tr_err(&comp_tr, "comp_new(): driver not found, comp->type = %u",
-		       comp->type);
-		return NULL;
+		tr_info(&comp_tr, "comp_new(), no type %d, fallback to use subtype",
+			comp->type);
+		drv = get_drv(comp->subtype);
+		if (!drv) {
+			tr_err(&comp_tr, "comp_new(): driver not found, comp->type = %u",
+			       comp->type);
+			return NULL;
+		}
 	}
 
 	/* validate size of ipc config */

--- a/src/include/ipc/topology.h
+++ b/src/include/ipc/topology.h
@@ -47,6 +47,12 @@ enum sof_comp_type {
 	SOF_COMP_ASRC,		/**< Asynchronous sample rate converter */
 	SOF_COMP_DCBLOCK,
 	SOF_COMP_SMART_AMP,		/**< smart amplifier component */
+
+	/*
+	 * No more _COMP_ types to be added.
+	 * Use SOF_COMP_PROCESS from now on.
+	 */
+	SOF_COMP_PROCESS = 1000,        /**< generic process component */
 	/* keep FILEREAD/FILEWRITE as the last ones */
 	SOF_COMP_FILEREAD = 10000,	/**< host test based file IO */
 	SOF_COMP_FILEWRITE = 10001,	/**< host test based file IO */

--- a/src/include/ipc/topology.h
+++ b/src/include/ipc/topology.h
@@ -71,8 +71,7 @@ struct sof_ipc_comp {
 	uint32_t pipeline_id;
 	uint32_t core;
 
-	/* reserved for future use */
-	uint32_t reserved[1];
+	uint32_t subtype;       /**< flavour for generic component type */
 } __attribute__((packed));
 
 /*

--- a/src/include/kernel/abi.h
+++ b/src/include/kernel/abi.h
@@ -29,7 +29,7 @@
 
 /** \brief SOF ABI version major, minor and patch numbers */
 #define SOF_ABI_MAJOR 3
-#define SOF_ABI_MINOR 16
+#define SOF_ABI_MINOR 17
 #define SOF_ABI_PATCH 0
 
 /** \brief SOF ABI version number. Format within 32bit word is MMmmmppp */


### PR DESCRIPTION
This is a simple series to support generic process component as described in:
https://github.com/orgs/thesofproject/teams/sof-developers/discussions/32

UUID support is not added yet, but this is sufficient to unblock adding new process components like crossover, beamformer, ...

The kernel corresponding PR is: https://github.com/thesofproject/linux/pull/2129

After this series is applied, all existed process components including mux/demux/eq/kpb/detect_test/selector/smart_amp/dcblock will be switched to this generic process type automatically.

The ABI minor will be bumped to 17 with this change.
