### PR TITLE
ext_manifest: byt: fix .fw_metadata section alignment

### DIFF
--- a/src/platform/baytrail/baytrail.x.in
+++ b/src/platform/baytrail/baytrail.x.in
@@ -552,7 +552,8 @@ SECTIONS
 
   .fw_metadata (COPY) : ALIGN(1024)
   {
-    KEEP (*(.fw_metadata))
+    KEEP (*(.fw_metadata));
+    KEEP (*(.fw_metadata.align));
   } >fw_metadata_seg :metadata_entries_phdr
 
   .fw_ready : ALIGN(4)

--- a/src/platform/baytrail/platform.c
+++ b/src/platform/baytrail/platform.c
@@ -34,12 +34,23 @@
 #include <ipc/header.h>
 #include <ipc/info.h>
 #include <kernel/abi.h>
+#include <kernel/ext_manifest.h>
 #include <config.h>
 #include <version.h>
 #include <errno.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+
+/*
+ * following element is created to assure proper section size alignment, besides
+ * of build tools limitation - removing `READONLY` flag when updated `.` value
+ * with `ALIGN(.)` in linker script.
+ */
+const struct {
+	 char elem[0];
+} ext_manifest_align_element
+	__aligned(EXT_MAN_ALIGN) __section(".fw_metadata.align") = {};
 
 static const struct sof_ipc_fw_ready ready
 	__section(".fw_ready") = {


### PR DESCRIPTION
Section of this section should be aligned to EXT_MAN_ALIGN,
proper way of doing this with ALIGN() function inside linker
script didn't work, because of removing READONLY attribute
for this segment, what leads to error in rimage.
This solution introduce changes only for platforms, where problem
exists, so generic tools like rimage are kept clean of such a hacks.

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>