### PR TITLE
README: Add IRC badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ### Status
 [![Build Status](https://travis-ci.org/thesofproject/sof.svg?branch=master)](https://travis-ci.org/thesofproject/sof)
 [![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/thesofproject/community)
+[![IRC chat](https://img.shields.io/badge/IRC-%23sof-1e72ff.svg)](https://www.irccloud.com/invite?channel=%23sof&hostname=irc.freenode.net&port=6697&ssl=1)
 
 ### Documentation
 


### PR DESCRIPTION
This will help people reach #sof IRC channel easier.
Clicking on the badge will allow people to join IRC
chat via irccloud webclient or prompt for their local
IRC client.

Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>