### PR TITLE
tools: improve sof-ri-info parsing and add memory layout info

### DIFF
--- a/tools/sof_ri_info/sof_ri_info.py
+++ b/tools/sof_ri_info/sof_ri_info.py
@@ -171,6 +171,8 @@ def parse_params():
                         action='store_true')
     parser.add_argument('--no_colors', help='disable colors in output',
                         action='store_true')
+    parser.add_argument('--no_cse', help='disable cse manifest parsing',
+                        action='store_true')
     parser.add_argument('--no_headers', help='skip information about headers',
                         action='store_true')
     parser.add_argument('--no_modules', help='skip information about modules',
@@ -585,7 +587,7 @@ def parse_adsp_manifest(reader, name):
 
     return adsp_mft
 
-def parse_fw_bin(path, verbose):
+def parse_fw_bin(path, no_cse, verbose):
     """ Parses sof binary
     """
     reader = BinReader(path, verbose)
@@ -594,7 +596,8 @@ def parse_fw_bin(path, verbose):
     parsed_bin.add_a(Astring('file_name', reader.file_name))
     parsed_bin.add_a(Auint('file_size', reader.file_size))
     parsed_bin.add_comp(parse_extended_manifest(reader))
-    parsed_bin.add_comp(parse_cse_manifest(reader))
+    if not no_cse:
+        parsed_bin.add_comp(parse_cse_manifest(reader))
     reader.set_offset(reader.ext_mft_length + 0x2000)
     parsed_bin.add_comp(parse_adsp_manifest(reader, 'cavs0015'))
 
@@ -1217,7 +1220,7 @@ def main(args):
 
     Attribute.full_bytes = args.full_bytes
 
-    fw_bin = parse_fw_bin(args.sof_ri_path, args.verbose)
+    fw_bin = parse_fw_bin(args.sof_ri_path, args.no_cse, args.verbose)
 
     comp_filter = []
     if args.headers or args.no_modules:

--- a/tools/sof_ri_info/sof_ri_info.py
+++ b/tools/sof_ri_info/sof_ri_info.py
@@ -578,8 +578,7 @@ def parse_fw_bin(path, verbose, add_module_entries):
     parsed_bin.add_comp(parse_extended_manifest(reader))
     parsed_bin.add_comp(parse_cse_manifest(reader, add_module_entries))
 
-    if verbose:
-        print('Parsing finished')
+    reader.info('Parsing finished', show_offset = False)
     return parsed_bin
 
 class BinReader():
@@ -587,15 +586,13 @@ class BinReader():
     """
     def __init__(self, path, verbose):
         self.verbose = verbose
-        if self.verbose:
-            print('Reading SOF ri image ' + path)
+        self.cur_offset = 0
+        self.info('Reading SOF ri image ' + path)
         self.file_name = path
         # read the content
         self.data = open(path, 'rb').read()
         self.file_size = len(self.data)
-        if self.verbose:
-            print('File size ' + uint_to_string(self.file_size, True))
-        self.cur_offset = 0
+        self.info('File size ' + uint_to_string(self.file_size, True))
 
     def get_offset(self):
         """ Retrieve the offset, the reader is at
@@ -665,12 +662,15 @@ class BinReader():
         """
         return uint_to_string(self.cur_offset+delta)
 
-    def info(self, loginfo, off_delta=0, verb_info=True):
+    def info(self, loginfo, off_delta=0, verb_info=True, show_offset=True):
         """ Prints 'info' log to the output, respects verbose mode
         """
         if verb_info and not self.verbose:
             return
-        print(self.offset_to_string(off_delta) + '\t' + loginfo)
+        if show_offset:
+            print(self.offset_to_string(off_delta) + '\t' + loginfo)
+        else:
+            print(loginfo)
 
     def error(self, logerror, off_delta=0):
         """ Prints 'error' log to the output

--- a/tools/sof_ri_info/sof_ri_info.py
+++ b/tools/sof_ri_info/sof_ri_info.py
@@ -371,7 +371,8 @@ def parse_cse_manifest(reader):
                     entry_length))
 
         if '.man' in entry_name:
-            entry = CssManifest(entry_name, entry_offset)
+            entry = CssManifest(entry_name,
+                                reader.ext_mft_length + entry_offset)
             cur_off = reader.set_offset(reader.ext_mft_length + entry_offset)
             parse_css_manifest(entry, reader,
                                reader.ext_mft_length + entry_offset + entry_length)

--- a/tools/sof_ri_info/sof_ri_info.py
+++ b/tools/sof_ri_info/sof_ri_info.py
@@ -307,6 +307,7 @@ def parse_extended_manifest(reader):
     """ Parses extended manifest from sof binary
     """
 
+    reader.info('Looking for Extended Manifest')
     # Try to detect signature first
     sig = reader.read_string(4)
     reader.set_offset(0)
@@ -327,6 +328,7 @@ def parse_extended_manifest(reader):
 def parse_cse_manifest(reader):
     """ Parses CSE manifest form sof binary
     """
+    reader.info('Looking for CSE Manifest')
     cse_mft = CseManifest(reader.get_offset())
 
     # Try to detect signature first
@@ -342,6 +344,7 @@ def parse_cse_manifest(reader):
     hdr.add_a(Astring('sig', sig))
     # read number of entries
     nb_entries = reader.read_dw()
+    reader.info('# of entries {}'.format(nb_entries))
     hdr.add_a(Adec('nb_entries', nb_entries))
     # read version (1byte for header ver and 1 byte for entry ver)
     ver = reader.read_w()
@@ -355,6 +358,7 @@ def parse_cse_manifest(reader):
     # Read entries
     nb_index = 0
     while nb_index < nb_entries:
+        reader.info('Looking for CSE Manifest entry')
         entry_name = reader.read_string(12)
         entry_offset = reader.read_dw()
         entry_length = reader.read_dw()
@@ -394,6 +398,7 @@ def parse_cse_manifest(reader):
 def parse_css_manifest(css_mft, reader, limit):
     """ Parses CSS manifest from sof binary
     """
+    reader.info('Parsing CSS Manifest')
     ver, = struct.unpack('I', reader.get_data(0, 4))
     if ver == 4:
         reader.info('CSS Manifest type 4')
@@ -406,6 +411,7 @@ def parse_css_manifest_4(css_mft, reader, size_limit):
     """ Parses CSS manifest type 4 from sof binary
     """
 
+    reader.info('Parsing CSS Manifest type 4')
     # CSS Header
     hdr = Component('css_mft_hdr', 'Header', reader.get_offset())
     css_mft.add_comp(hdr)
@@ -444,9 +450,11 @@ def parse_css_manifest_4(css_mft, reader, size_limit):
     #   that could be parsed if extension type is recognized
     #
     #   or series of 0xffffffff that should be skipped
+    reader.info('Parsing CSS Manifest extensions end 0x{:x}'.format(size_limit))
     ext_idx = 0
     while reader.get_offset() < size_limit:
         ext_type = reader.read_dw()
+        reader.info('Reading extension type 0x{:x}'.format(ext_type))
         if ext_type == 0xffffffff:
             continue
         reader.set_offset(reader.get_offset() - 4)
@@ -600,12 +608,13 @@ class BinReader():
         self.verbose = verbose
         self.cur_offset = 0
         self.ext_mft_length = 0
-        self.info('Reading SOF ri image ' + path)
+        self.info('Reading SOF ri image ' + path, show_offset=False)
         self.file_name = path
         # read the content
         self.data = open(path, 'rb').read()
         self.file_size = len(self.data)
-        self.info('File size ' + uint_to_string(self.file_size, True))
+        self.info('File size ' + uint_to_string(self.file_size, True),
+                  show_offset=False)
 
     def get_offset(self):
         """ Retrieve the offset, the reader is at

--- a/tools/sof_ri_info/sof_ri_info.py
+++ b/tools/sof_ri_info/sof_ri_info.py
@@ -1013,7 +1013,11 @@ class FwBin(Component):
 def main(args):
     """ main function
     """
-    Attribute.no_colors = args.no_colors
+    if sys.stdout.isatty():
+        Attribute.no_colors = args.no_colors
+    else:
+        Attribute.no_colors = True
+
     Attribute.full_bytes = args.full_bytes
 
     fw_bin = parse_fw_bin(args.sof_ri_path, args.verbose, not args.headers)


### PR DESCRIPTION
There are a couple of improvements that handle more corner cases while parsing sof binaries (see individual commit messages).

One output improvement, more compact module information:
```
    BRNGUP    2b79e4f3-4675-f649-89df-3bc194a91aeb
      entry point 0xb0038000 type 0x21 ( loadable LL )
      cfg offset 0 count 0 affinity 0x3 instance max count 1 stack size 0x1
      .text   0xb0038000 file offset 0x8000 flags 0x1001f ( contents alloc load readonly code type=0 pages=1 )
      .rodata 0xb0039000 file offset 0x9000 flags 0x1012f ( contents alloc load readonly data type=1 pages=1 )
      .bss    0x0 file offset 0x0 flags 0xf00 ( type=15 pages=0 )

    BASEFW    0e398c32-5ade-ba4b-93b1-c50432280ee4
      entry point 0xbe00c400 type 0x21 ( loadable LL )
      cfg offset 0 count 0 affinity 0x3 instance max count 1 stack size 0x1
      .text   0xbe00c000 file offset 0xa000 flags 0x2b001f ( contents alloc load readonly code type=0 pages=43 )
      .rodata 0xbe037000 file offset 0x35000 flags 0x24012f ( contents alloc load readonly data type=1 pages=36 )
      .bss    0xbe05b000 file offset 0x0 flags 0xa50202 ( alloc type=2 pages=165 )

```

There is also a one new feature, memory layout info.
When run with .ri file only, the last segment of output in case of a known platform (detected by the .ri filename) may look like:
```
Intel Cannonlake
  imr                                 0xb0000000 (8192 + 136579200  0.01% used)
    BRNGUP.text                         0xb0038000 (4096)
    BRNGUP.rodata                       0xb0039000 (4096)
  l2 hpsram                           0xbe000000 (999424 + 2146304  31.77% used)
    BASEFW.text                         0xbe00c000 (176128)
    BASEFW.rodata                       0xbe037000 (147456)
    BASEFW.bss                          0xbe05b000 (675840)
  l2 lpsram                           0xbe800000 (65536)
```

If there is also corresponding .lmap file (sof-cnl.lmap in this case) available in the same location as .ri file (written to <build>/src/arch/xtensa), then the output is more detailed (and more precise if there are sections not included in the .ri manifest file but visible in the section list, `.wnd` for example):
```
Intel Cannonlake
  imr                                 0xb0000000 (8192 + 136579200  0.01% used)
    BRNGUP.text                         0xb0038000 (4096)
    BRNGUP.rodata                       0xb0039000 (4096)
  l2 hpsram                           0xbe000000 (1032192 + 2113536  32.81% used)
    BASEFW.text                         0xbe00c000 (173896 + 2232  98.73% used)
      .WindowVectors.text                 0xbe00c000 (362)
      .Level2InterruptVector.text         0xbe00c180 (6)
      .Level5InterruptVector.text         0xbe00c240 (6)
      .DebugExceptionVector.text          0xbe00c280 (6)
      .NMIExceptionVector.text            0xbe00c2c0 (3)
      .KernelExceptionVector.text         0xbe00c300 (6)
      .UserExceptionVector.literal        0xbe00c338 (4)
      .UserExceptionVector.text           0xbe00c340 (23)
      .DoubleExceptionVector.text         0xbe00c3c0 (6)
      .text                               0xbe00c400 (173474)
      .MainEntry.literal                  0xbe0369a4 (0)
    BASEFW.rodata                       0xbe037000 (144144 + 3312  97.75% used)
      .rodata                             0xbe037000 (114592)
      .module_init                        0xbe052fa0 (60)
      .shared_data                        0xbe053000 (22848)
      .data                               0xbe058940 (6216)
      .fw_ready                           0xbe05a188 (428)
    BASEFW.bss                          0xbe05b000 (675840 + 0  100.00% used)
      .bss                                0xbe05b000 (675840)
    .wnd0                               0xbe004000 (8192)
    .wnd1                               0xbe006000 (8192)
    .wnd2                               0xbe008000 (8192)
    .wnd3                               0xbe00a000 (8192)
  l2 lpsram                           0xbe800000 (65536)
```