### PR TITLE
drivers: sai: Fix watermark mask size

### DIFF
--- a/src/include/sof/drivers/sai.h
+++ b/src/include/sof/drivers/sai.h
@@ -127,7 +127,11 @@
 #define REG_SAI_CSR_FRDE	BIT(0)
 
 /* SAI Transmit and Receive Configuration 1 Register */
+#ifdef CONFIG_IMX8M
+#define REG_SAI_CR1_RFW_MASK	0x7f
+#else
 #define REG_SAI_CR1_RFW_MASK	0x3f
+#endif
 
 /* SAI Transmit and Receive Configuration 2 Register */
 #define REG_SAI_CR2_SYNC	SET_BITS(31, 30, 1)


### PR DESCRIPTION
On i.MX8M watermark can be up to 128 and we must adjust
the T/RFW mask register in order for values greater than 64 to be
correctly set.

Now capture works fine!

Fixes: 29414aa25e56a1 ("platform: imx8m: Fix FIFO depth for i.MX8M")
Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>