### PR TITLE
rimage: Update to version with changed headers location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ set(CMAKE_ASM_FLAGS -DASSEMBLY)
 add_library(sof_public_headers INTERFACE)
 
 target_include_directories(sof_public_headers INTERFACE ${PROJECT_SOURCE_DIR}/src/include)
-target_include_directories(sof_public_headers INTERFACE ${PROJECT_SOURCE_DIR}/rimage/src/include/sof)
+target_include_directories(sof_public_headers INTERFACE ${PROJECT_SOURCE_DIR}/rimage/src/include)
 
 # interface library that is used only as container for sof binary options
 # other targets can use it to build with the same options

--- a/smex/CMakeLists.txt
+++ b/smex/CMakeLists.txt
@@ -18,5 +18,5 @@ target_compile_options(smex PRIVATE
 
 target_include_directories(smex PRIVATE
 	"${SOF_ROOT_SOURCE_DIRECTORY}/src/include"
-	"${SOF_ROOT_SOURCE_DIRECTORY}/rimage/src/include/sof"
+	"${SOF_ROOT_SOURCE_DIRECTORY}/rimage/src/include"
 )

--- a/smex/ldc.h
+++ b/smex/ldc.h
@@ -12,7 +12,7 @@
 #define __INCLUDE_LDC_H__
 
 #include <ipc/info.h>
-#include <kernel/fw.h>
+#include <rimage/sof/kernel/fw.h>
 
 #define SND_SOF_LOGS_SIG_SIZE	4
 #define SND_SOF_LOGS_SIG	"Logs"

--- a/src/include/kernel/ext_manifest.h
+++ b/src/include/kernel/ext_manifest.h
@@ -29,42 +29,9 @@
 
 #include <ipc/info.h>
 #include <sof/compiler_attributes.h>
+#include <rimage/sof/kernel/ext_manifest.h>
 #include <stdint.h>
 
-/* In ASCII `XMan` */
-#define EXT_MAN_MAGIC_NUMBER	0x6e614d58
-
-/* Build u32 number in format MMmmmppp */
-#define EXT_MAN_BUILD_VERSION(MAJOR, MINOR, PATH) ( \
-	((uint32_t)(MAJOR) << 24) | \
-	((uint32_t)(MINOR) << 12) | \
-	(uint32_t)(PATH))
-
-/* check extended manifest version consistency */
-#define EXT_MAN_VERSION_INCOMPATIBLE(host_ver, cli_ver) ( \
-	((host_ver) & GENMASK(31, 24)) != \
-	((cli_ver) & GENMASK(31, 24)))
-
-/* used extended manifest header version */
-#define EXT_MAN_VERSION		EXT_MAN_BUILD_VERSION(1, 0, 0)
-
-/* struct size alignment for ext_man elements */
-#define EXT_MAN_ALIGN 16
-
-/* extended manifest header, deleting any field breaks backward compatibility */
-struct ext_man_header {
-	uint32_t magic;		/**< identification number, */
-				/**< EXT_MAN_MAGIC_NUMBER */
-	uint32_t full_size;	/**< [bytes] full size of ext_man, */
-				/**< (header + content + padding) */
-	uint32_t header_size;	/**< [bytes] makes header extensionable, */
-				/**< after append new field to ext_man header */
-				/**< then backward compatible won't be lost */
-	uint32_t header_version; /**< value of EXT_MAN_VERSION */
-				/**< not related with following content */
-
-	/* just after this header should be list of ext_man_elem_* elements */
-} __packed;
 
 /* Now define extended manifest elements */
 
@@ -74,14 +41,6 @@ enum ext_man_elem_type {
 	EXT_MAN_ELEM_CC_VERSION		= SOF_IPC_EXT_CC_INFO,
 	EXT_MAN_ELEM_PROBE_INFO		= SOF_IPC_EXT_PROBE_INFO,
 };
-
-/* extended manifest element header */
-struct ext_man_elem_header {
-	uint32_t type;		/**< EXT_MAN_ELEM_* */
-	uint32_t elem_size;	/**< in bytes, including header size */
-
-	/* just after this header should be type dependent content */
-} __packed;
 
 /* FW version */
 struct ext_man_fw_version {

--- a/src/platform/apollolake/base_module.c
+++ b/src/platform/apollolake/base_module.c
@@ -5,7 +5,7 @@
 // Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
 
 #include <sof/lib/memory.h>
-#include <user/manifest.h>
+#include <rimage/sof/user/manifest.h>
 
 /*
  * Each module has an entry in the FW manifest header. This is NOT part of

--- a/src/platform/apollolake/boot_module.c
+++ b/src/platform/apollolake/boot_module.c
@@ -5,7 +5,7 @@
 // Author: Marcin Maka <marcin.maka@linux.intel.com>
 
 #include <sof/lib/memory.h>
-#include <user/manifest.h>
+#include <rimage/sof/user/manifest.h>
 
 /*
  * Each module has an entry in the FW manifest header. This is NOT part of

--- a/src/platform/cannonlake/base_module.c
+++ b/src/platform/cannonlake/base_module.c
@@ -5,7 +5,7 @@
 // Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
 
 #include <sof/lib/memory.h>
-#include <user/manifest.h>
+#include <rimage/sof/user/manifest.h>
 
 /*
  * Each module has an entry in the FW manifest header. This is NOT part of

--- a/src/platform/cannonlake/boot_module.c
+++ b/src/platform/cannonlake/boot_module.c
@@ -5,7 +5,7 @@
 // Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
 
 #include <sof/lib/memory.h>
-#include <user/manifest.h>
+#include <rimage/sof/user/manifest.h>
 
 /*
  * Each module has an entry in the FW manifest header. This is NOT part of

--- a/src/platform/icelake/base_module.c
+++ b/src/platform/icelake/base_module.c
@@ -5,7 +5,7 @@
 // Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
 
 #include <sof/lib/memory.h>
-#include <user/manifest.h>
+#include <rimage/sof/user/manifest.h>
 
 /*
  * Each module has an entry in the FW manifest header. This is NOT part of

--- a/src/platform/icelake/boot_module.c
+++ b/src/platform/icelake/boot_module.c
@@ -5,7 +5,7 @@
 // Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
 
 #include <sof/lib/memory.h>
-#include <user/manifest.h>
+#include <rimage/sof/user/manifest.h>
 
 /*
  * Each module has an entry in the FW manifest header. This is NOT part of

--- a/src/platform/intel/cavs/boot_loader.c
+++ b/src/platform/intel/cavs/boot_loader.c
@@ -14,7 +14,7 @@
 #include <sof/platform.h>
 #include <sof/sof.h>
 #include <sof/trace/trace.h>
-#include <user/manifest.h>
+#include <rimage/sof/user/manifest.h>
 #include <config.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/src/platform/suecreek/base_module.c
+++ b/src/platform/suecreek/base_module.c
@@ -5,7 +5,7 @@
 // Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
 
 #include <sof/lib/memory.h>
-#include <user/manifest.h>
+#include <rimage/sof/user/manifest.h>
 #include <sof/common.h>
 
 /*

--- a/src/platform/suecreek/boot_module.c
+++ b/src/platform/suecreek/boot_module.c
@@ -5,7 +5,7 @@
 // Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
 
 #include <sof/lib/memory.h>
-#include <user/manifest.h>
+#include <rimage/sof/user/manifest.h>
 
 /*
  * Each module has an entry in the FW manifest header. This is NOT part of

--- a/src/platform/tigerlake/base_module.c
+++ b/src/platform/tigerlake/base_module.c
@@ -6,7 +6,7 @@
 //         Janusz Jankowski <janusz.jankowski@linux.intel.com>
 
 #include <sof/lib/memory.h>
-#include <user/manifest.h>
+#include <rimage/sof/user/manifest.h>
 
 /*
  * Each module has an entry in the FW manifest header. This is NOT part of

--- a/src/platform/tigerlake/boot_module.c
+++ b/src/platform/tigerlake/boot_module.c
@@ -6,7 +6,7 @@
 //         Janusz Jankowski <janusz.jankowski@linux.intel.com>
 
 #include <sof/lib/memory.h>
-#include <user/manifest.h>
+#include <rimage/sof/user/manifest.h>
 
 /*
  * Each module has an entry in the FW manifest header. This is NOT part of

--- a/tools/logger/CMakeLists.txt
+++ b/tools/logger/CMakeLists.txt
@@ -11,7 +11,7 @@ target_compile_options(sof-logger PRIVATE
 
 target_include_directories(sof-logger PRIVATE
 	"${SOF_ROOT_SOURCE_DIRECTORY}/src/include"
-	"${SOF_ROOT_SOURCE_DIRECTORY}/rimage/src/include/sof"
+	"${SOF_ROOT_SOURCE_DIRECTORY}/rimage/src/include"
 	"${SOF_ROOT_SOURCE_DIRECTORY}"
 )
 


### PR DESCRIPTION
In new version of rimage software, headers are located in
rimage/src/include/rimage directory to make it easily accessible
from another source code without include path collision.

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>