### PR TITLE
trace: buffer: Use trace context in buffer logs

### DIFF
--- a/src/audio/buffer.c
+++ b/src/audio/buffer.c
@@ -22,17 +22,18 @@
 /* 42544c92-8e92-4e41-b679-34519f1c1d28 */
 DECLARE_SOF_UUID("buffer", buffer_uuid, 0x42544c92, 0x8e92, 0x4e41,
 		 0xb6, 0x79, 0x34, 0x51, 0x9f, 0x1c, 0x1d, 0x28);
-uintptr_t buffer_uuid_ptr = SOF_UUID(buffer_uuid);
+DECLARE_TR_CTX(buffer_tr, SOF_UUID(buffer_uuid), LOG_LEVEL_INFO);
 
 struct comp_buffer *buffer_alloc(uint32_t size, uint32_t caps, uint32_t align)
 {
 	struct comp_buffer *buffer;
 
-	buf_cl_dbg("buffer_alloc()");
+	tr_dbg(&buffer_tr, "buffer_alloc()");
 
 	/* validate request */
 	if (size == 0 || size > HEAP_BUFFER_SIZE) {
-		buf_cl_err("buffer_alloc(): new size = %u is invalid", size);
+		tr_err(&buffer_tr, "buffer_alloc(): new size = %u is invalid",
+		       size);
 		return NULL;
 	}
 
@@ -40,7 +41,7 @@ struct comp_buffer *buffer_alloc(uint32_t size, uint32_t caps, uint32_t align)
 	buffer = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM,
 			 sizeof(*buffer));
 	if (!buffer) {
-		buf_cl_err("buffer_alloc(): could not alloc structure");
+		tr_err(&buffer_tr, "buffer_alloc(): could not alloc structure");
 		return NULL;
 	}
 
@@ -48,15 +49,15 @@ struct comp_buffer *buffer_alloc(uint32_t size, uint32_t caps, uint32_t align)
 			       SOF_MEM_CAPS_RAM, sizeof(*buffer->lock));
 	if (!buffer->lock) {
 		rfree(buffer);
-		buf_cl_err("buffer_alloc(): could not alloc lock");
+		tr_err(&buffer_tr, "buffer_alloc(): could not alloc lock");
 		return NULL;
 	}
 
 	buffer->stream.addr = rballoc_align(0, caps, size, align);
 	if (!buffer->stream.addr) {
 		rfree(buffer);
-		buf_cl_err("buffer_alloc(): could not alloc size = %u bytes of type = %u",
-			   size, caps);
+		tr_err(&buffer_tr, "buffer_alloc(): could not alloc size = %u bytes of type = %u",
+		       size, caps);
 		return NULL;
 	}
 
@@ -74,7 +75,7 @@ struct comp_buffer *buffer_new(struct sof_ipc_buffer *desc)
 {
 	struct comp_buffer *buffer;
 
-	buf_cl_info("buffer new size 0x%x id %d.%d", desc->size,
+	tr_info(&buffer_tr, "buffer new size 0x%x id %d.%d", desc->size,
 		    desc->comp.pipeline_id, desc->comp.id);
 
 	/* allocate buffer */

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -32,48 +32,43 @@
 
 struct comp_dev;
 
+/** \name Trace macros
+ *  @{
+ */
+
 /* buffer tracing */
-extern uintptr_t buffer_uuid_ptr;
+extern struct tr_ctx buffer_tr;
 
-#define buf_cl_err(__e, ...) \
-	trace_error_with_ids(TRACE_CLASS_DEPRECATED, buffer_uuid_ptr, \
-			     -1, -1, __e, ##__VA_ARGS__)
+/** \brief Retrieves trace context from the buffer */
+#define trace_buf_get_tr_ctx(buf_ptr) (&buffer_tr)
 
-#define buf_cl_err_a(__e, ...) \
-	trace_error_atomic_with_ids(TRACE_CLASS_DEPRECATED, buffer_uuid_ptr, \
-				    -1, -1, __e, ##__VA_ARGS__)
+/** \brief Retrieves id (pipe id) from the buffer */
+#define trace_buf_get_id(buf_ptr) ((buf_ptr)->pipeline_id)
 
-#define buf_cl_warn(__e, ...) \
-	trace_warn_with_ids(TRACE_CLASS_DEPRECATED, buffer_uuid_ptr, \
-			    -1, -1, __e, ##__VA_ARGS__)
+/** \brief Retrieves subid (comp id) from the buffer */
+#define trace_buf_get_subid(buf_ptr) ((buf_ptr)->id)
 
-#define buf_cl_info(__e, ...) \
-	trace_event_with_ids(TRACE_CLASS_DEPRECATED, buffer_uuid_ptr, \
-			     -1, -1, __e, ##__VA_ARGS__)
+/** \brief Trace error message from buffer */
+#define buf_err(buf_ptr, __e, ...)					\
+	trace_dev_err(trace_buf_get_tr_ctx, trace_buf_get_id,		\
+		      trace_buf_get_subid, buf_ptr, __e, ##__VA_ARGS__)
 
-#define buf_cl_dbg(__e, ...) \
-	tracev_event_with_ids(TRACE_CLASS_DEPRECATED, buffer_uuid_ptr, \
-			      -1, -1, __e, ##__VA_ARGS__)
+/** \brief Trace warning message from buffer */
+#define buf_warn(buf_ptr, __e, ...)					\
+	trace_dev_warn(trace_buf_get_tr_ctx, trace_buf_get_id,	\
+		       trace_buf_get_subid, buf_ptr, __e, ##__VA_ARGS__)
 
-#define buf_err(buf_ptr, __e, ...) \
-	trace_error_with_ids(TRACE_CLASS_DEPRECATED, buffer_uuid_ptr, \
-			     (buf_ptr)->pipeline_id, \
-			     (buf_ptr)->id, __e, ##__VA_ARGS__)
+/** \brief Trace info message from buffer */
+#define buf_info(buf_ptr, __e, ...)					\
+	trace_dev_info(trace_buf_get_tr_ctx, trace_buf_get_id,	\
+		       trace_buf_get_subid, buf_ptr, __e, ##__VA_ARGS__)
 
-#define buf_warn(buf_ptr, __e, ...) \
-	trace_warn_with_ids(TRACE_CLASS_DEPRECATED, buffer_uuid_ptr, \
-			    (buf_ptr)->pipeline_id, \
-			    (buf_ptr)->id, __e, ##__VA_ARGS__)
+/** \brief Trace debug message from buffer */
+#define buf_dbg(buf_ptr, __e, ...)					\
+	trace_dev_dbg(trace_buf_get_tr_ctx, trace_buf_get_id,		\
+		      trace_buf_get_subid, buf_ptr, __e, ##__VA_ARGS__)
 
-#define buf_info(buf_ptr, __e, ...) \
-	trace_event_with_ids(TRACE_CLASS_DEPRECATED, buffer_uuid_ptr, \
-			     (buf_ptr)->pipeline_id, \
-			     (buf_ptr)->id, __e, ##__VA_ARGS__)
-
-#define buf_dbg(buf_ptr, __e, ...) \
-	tracev_event_with_ids(TRACE_CLASS_DEPRECATED, buffer_uuid_ptr, \
-			      (buf_ptr)->pipeline_id, \
-			      (buf_ptr)->id, __e, ##__VA_ARGS__)
+/** @}*/
 
 /* buffer callback types */
 #define BUFF_CB_TYPE_PRODUCE	BIT(0)

--- a/test/cmocka/src/audio/component/mock.c
+++ b/test/cmocka/src/audio/component/mock.c
@@ -13,7 +13,7 @@
 
 static struct sof sof;
 
-uintptr_t buffer_uuid_ptr;
+struct tr_ctx buffer_tr;
 
 #if !CONFIG_LIBRARY
 

--- a/test/cmocka/src/audio/mux/mock.c
+++ b/test/cmocka/src/audio/mux/mock.c
@@ -16,7 +16,7 @@
 
 static struct sof sof;
 
-uintptr_t buffer_uuid_ptr;
+struct tr_ctx buffer_tr;
 
 void pipeline_xrun(struct pipeline *p, struct comp_dev *dev, int32_t bytes)
 {

--- a/test/cmocka/src/audio/pipeline/pipeline_mocks.c
+++ b/test/cmocka/src/audio/pipeline/pipeline_mocks.c
@@ -11,7 +11,7 @@ struct ipc *_ipc;
 struct timer *platform_timer;
 struct schedulers *schedulers;
 static struct sof sof;
-uintptr_t buffer_uuid_ptr;
+struct tr_ctx buffer_tr;
 
 struct sof *sof_get(void)
 {


### PR DESCRIPTION
Each trace function should refer to trace context, where are
stored information like uuid and runtime editable logs level,
to unify trace API and allow trace filtering in future.
Remove buf_cl_* functions, as no longer supported.

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>