### PR TITLE
logger: Move optstring from getopt function to separate variable

### DIFF
--- a/tools/logger/logger.c
+++ b/tools/logger/logger.c
@@ -139,6 +139,7 @@ static int configure_uart(const char *file, unsigned int baud)
 
 int main(int argc, char *argv[])
 {
+	static const char optstring[] = "ho:i:l:ps:c:u:tev:rdLf:";
 	struct convert_config config;
 	unsigned int baud = 0;
 	const char *snapshot_file = 0;
@@ -164,7 +165,7 @@ int main(int argc, char *argv[])
 	config.hide_location = 0;
 	config.float_precision = 6;
 
-	while ((opt = getopt(argc, argv, "ho:i:l:ps:c:u:tev:rdLf:")) != -1) {
+	while ((opt = getopt(argc, argv, optstring)) != -1) {
 		switch (opt) {
 		case 'o':
 			config.out_file = optarg;


### PR DESCRIPTION
Such a change is provoked by getting close to maximal line length
in line with getopt line call. Moving format string to separate
variable is more logical solution than splitting function arguments
on separate lines.

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>