### PR TITLE
logger: Fix help message consistency

### DIFF
--- a/tools/logger/logger.c
+++ b/tools/logger/logger.c
@@ -53,7 +53,7 @@ static void usage(void)
 		APP_NAME);
 	fprintf(stdout, "%s:\t -L\t\t\tHide log location in source code\n",
 		APP_NAME);
-	fprintf(stdout, "%s:\t -f precision\t\t\tset timestamp precision\n",
+	fprintf(stdout, "%s:\t -f precision\t\tSet timestamp precision\n",
 		APP_NAME);
 	fprintf(stdout, "%s:\t -d\t\t\tDump ldc information\n", APP_NAME);
 	exit(0);


### PR DESCRIPTION
Before this patch output message was misaligned and one flag
description start from small letter:
```
sof-logger:      -L                     Hide log location in source code
sof-logger:      -f precision                   set timestamp precision
sof-logger:      -d                     Dump ldc information
```

After change, it's fixed:
```
sof-logger:      -L                     Hide log location in source code
sof-logger:      -f precision           Set timestamp precision
sof-logger:      -d                     Dump ldc information
```

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>