### PR TITLE
idc: extract common protocol functions

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,3 +24,7 @@ endif()
 if (CONFIG_PROBE)
 	add_subdirectory(probe)
 endif()
+
+if (CONFIG_SMP)
+	add_subdirectory(idc)
+endif()

--- a/src/arch/xtensa/include/arch/drivers/idc.h
+++ b/src/arch/xtensa/include/arch/drivers/idc.h
@@ -1,0 +1,22 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2020 Intel Corporation. All rights reserved.
+ *
+ * Author: Tomasz Lauda <tomasz.lauda@linux.intel.com>
+ */
+
+#include <sof/lib/cpu.h>
+#include <xtos-structs.h>
+
+struct idc;
+
+/**
+ * \brief Returns IDC data.
+ * \return Pointer to pointer of IDC data.
+ */
+static inline struct idc **idc_get(void)
+{
+	struct core_context *ctx = (struct core_context *)cpu_read_threadptr();
+
+	return &ctx->idc;
+}

--- a/src/drivers/intel/cavs/idc.c
+++ b/src/drivers/intel/cavs/idc.c
@@ -4,64 +4,20 @@
 //
 // Author: Tomasz Lauda <tomasz.lauda@linux.intel.com>
 
-#include <sof/audio/component_ext.h>
-#include <sof/audio/pipeline.h>
 #include <sof/debug/panic.h>
 #include <sof/drivers/idc.h>
 #include <sof/drivers/interrupt.h>
-#include <sof/drivers/ipc.h>
-#include <sof/drivers/timer.h>
-#include <sof/lib/alloc.h>
-#include <sof/lib/cache.h>
-#include <sof/lib/clk.h>
 #include <sof/lib/cpu.h>
 #include <sof/lib/mailbox.h>
-#include <sof/lib/memory.h>
-#include <sof/lib/notifier.h>
 #include <sof/lib/shim.h>
-#include <sof/lib/uuid.h>
 #include <sof/platform.h>
-#include <sof/schedule/edf_schedule.h>
-#include <sof/schedule/ll_schedule.h>
 #include <sof/schedule/schedule.h>
 #include <sof/schedule/task.h>
+#include <sof/string.h>
 #include <sof/trace/trace.h>
-#include <ipc/control.h>
-#include <ipc/stream.h>
-#include <ipc/topology.h>
-#include <xtos-structs.h>
 #include <errno.h>
 #include <stdbool.h>
-#include <stddef.h>
 #include <stdint.h>
-
-/** \brief IDC message payload per core. */
-static SHARED_DATA struct idc_payload payload[PLATFORM_CORE_COUNT];
-
-/* 379a60ae-cedb-4777-aaf2-5659b0a85735 */
-DECLARE_SOF_UUID("idc", idc_uuid, 0x379a60ae, 0xcedb, 0x4777,
-		 0xaa, 0xf2, 0x56, 0x59, 0xb0, 0xa8, 0x57, 0x35);
-
-DECLARE_TR_CTX(idc_tr, SOF_UUID(idc_uuid), LOG_LEVEL_INFO);
-
-/* b90f5a4e-5537-4375-a1df-95485472ff9e */
-DECLARE_SOF_UUID("comp-task", idc_comp_task_uuid, 0xb90f5a4e, 0x5537, 0x4375,
-		 0xa1, 0xdf, 0x95, 0x48, 0x54, 0x72, 0xff, 0x9e);
-
-/* a5dacb0e-88dc-415c-a1b5-3e8df77f1976 */
-DECLARE_SOF_UUID("idc-cmd-task", idc_cmd_task_uuid, 0xa5dacb0e, 0x88dc, 0x415c,
-		 0xa1, 0xb5, 0x3e, 0x8d, 0xf7, 0x7f, 0x19, 0x76);
-
-/**
- * \brief Returns IDC data.
- * \return Pointer to pointer of IDC data.
- */
-static struct idc **idc_get(void)
-{
-	struct core_context *ctx = (struct core_context *)cpu_read_threadptr();
-
-	return &ctx->idc;
-}
 
 /**
  * \brief Enables IDC interrupts.
@@ -118,39 +74,6 @@ static void idc_irq_handler(void *arg)
 }
 
 /**
- * \brief Sets IDC command status after execution.
- * \param[in] status Status to be set.
- * \param[in] core Id of the core for this status.
- */
-static void idc_msg_status_set(int status, uint32_t core)
-{
-	struct idc *idc = *idc_get();
-	struct idc_payload *payload = idc_payload_get(idc, core);
-
-	*(uint32_t *)payload->data = status;
-
-	platform_shared_commit(payload, sizeof(*payload));
-}
-
-/**
- * \brief Retrieves IDC command status after sending message.
- * \param[in] core Id of the core for this status.
- * \return Last IDC message status.
- */
-static int idc_msg_status_get(uint32_t core)
-{
-	struct idc *idc = *idc_get();
-	struct idc_payload *payload = idc_payload_get(idc, core);
-	int status;
-
-	status = *(uint32_t *)payload->data;
-
-	platform_shared_commit(payload, sizeof(*payload));
-
-	return status;
-}
-
-/**
  * \brief Checks IDC registers whether message has been received.
  * \param[in] target_core Id of the core receiving the message.
  * \return True if message received, false otherwise.
@@ -170,37 +93,6 @@ static bool idc_is_powered_up(int target_core)
 {
 	return mailbox_sw_reg_read(PLATFORM_TRACEP_SLAVE_CORE(target_core)) ==
 		TRACE_BOOT_PLATFORM;
-}
-
-/**
- * \brief Waits until status condition is true.
- * \param[in] target_core Id of the core receiving the message.
- * \param[in] cond Pointer to condition function.
- * \return Error code.
- */
-static int idc_wait_in_blocking_mode(uint32_t target_core, bool (*cond)(int))
-{
-	struct timer *timer = timer_get();
-	uint64_t deadline;
-
-	deadline = platform_timer_get(timer) +
-		clock_ms_to_ticks(PLATFORM_DEFAULT_CLOCK, 1) *
-		IDC_TIMEOUT / 1000;
-
-	while (!cond(target_core)) {
-		if (deadline < platform_timer_get(timer)) {
-			/* safe check in case we've got preempted
-			 * after read
-			 */
-			if (cond(target_core))
-				break;
-
-			tr_err(&idc_tr, "idc_wait_in_blocking_mode() error: timeout");
-			return -ETIME;
-		}
-	}
-
-	return 0;
 }
 
 /**
@@ -257,212 +149,10 @@ int idc_send_msg(struct idc_msg *msg, uint32_t mode)
 }
 
 /**
- * \brief Executes IDC IPC processing message.
- */
-static void idc_ipc(void)
-{
-	struct ipc *ipc = ipc_get();
-	struct sof_ipc_cmd_hdr *hdr = ipc->comp_data;
-
-	ipc_cmd(hdr);
-}
-
-/**
- * \brief Executes IDC component params message.
- * \param[in] comp_id Component id to have params set.
- * \return Error code.
- */
-static int idc_params(uint32_t comp_id)
-{
-	struct ipc *ipc = ipc_get();
-	struct ipc_comp_dev *ipc_dev;
-	struct idc *idc = *idc_get();
-	struct idc_payload *payload = idc_payload_get(idc, cpu_get_id());
-	struct sof_ipc_stream_params *params =
-		(struct sof_ipc_stream_params *)payload;
-	int ret;
-
-	ipc_dev = ipc_get_comp_by_id(ipc, comp_id);
-	if (!ipc_dev)
-		return -ENODEV;
-
-	ret = comp_params(ipc_dev->cd, params);
-
-	platform_shared_commit(payload, sizeof(*payload));
-	platform_shared_commit(ipc_dev, sizeof(*ipc_dev));
-	platform_shared_commit(ipc, sizeof(*ipc));
-
-	return ret;
-}
-
-static enum task_state comp_task(void *data)
-{
-	if (comp_copy(data) < 0)
-		return SOF_TASK_STATE_COMPLETED;
-
-	return SOF_TASK_STATE_RESCHEDULE;
-}
-
-/**
- * \brief Executes IDC component prepare message.
- * \param[in] comp_id Component id to be prepared.
- * \return Error code.
- */
-static int idc_prepare(uint32_t comp_id)
-{
-	struct ipc *ipc = ipc_get();
-	struct ipc_comp_dev *ipc_dev;
-	struct comp_dev *dev;
-	int ret;
-
-	ipc_dev = ipc_get_comp_by_id(ipc, comp_id);
-	if (!ipc_dev)
-		return -ENODEV;
-
-	dev = ipc_dev->cd;
-
-	/* we're running on different core, so allocate our own task */
-	if (!dev->task) {
-		/* allocate task for shared component */
-		dev->task = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM,
-				    sizeof(*dev->task));
-		if (!dev->task) {
-			ret = -ENOMEM;
-			goto out;
-		}
-
-		ret = schedule_task_init_ll(dev->task,
-					    SOF_UUID(idc_comp_task_uuid),
-					    SOF_SCHEDULE_LL_TIMER,
-					    dev->priority, comp_task, dev,
-					    dev->comp.core, 0);
-		if (ret < 0) {
-			rfree(dev->task);
-			goto out;
-		}
-	}
-
-	ret = comp_prepare(ipc_dev->cd);
-
-out:
-	platform_shared_commit(dev, sizeof(*dev));
-	platform_shared_commit(ipc_dev, sizeof(*ipc_dev));
-	platform_shared_commit(ipc, sizeof(*ipc));
-
-	return ret;
-}
-
-/**
- * \brief Executes IDC component trigger message.
- * \param[in] comp_id Component id to be triggered.
- * \return Error code.
- */
-static int idc_trigger(uint32_t comp_id)
-{
-	struct ipc *ipc = ipc_get();
-	struct ipc_comp_dev *ipc_dev;
-	struct idc *idc = *idc_get();
-	struct idc_payload *payload = idc_payload_get(idc, cpu_get_id());
-	uint32_t cmd = *(uint32_t *)payload;
-	int ret;
-
-	ipc_dev = ipc_get_comp_by_id(ipc, comp_id);
-	if (!ipc_dev)
-		return -ENODEV;
-
-	ret = comp_trigger(ipc_dev->cd, cmd);
-	if (ret < 0)
-		goto out;
-
-	/* schedule or cancel task */
-	switch (cmd) {
-	case COMP_TRIGGER_START:
-	case COMP_TRIGGER_RELEASE:
-		schedule_task(ipc_dev->cd->task, 0, ipc_dev->cd->period);
-		break;
-	case COMP_TRIGGER_XRUN:
-	case COMP_TRIGGER_PAUSE:
-	case COMP_TRIGGER_STOP:
-		schedule_task_cancel(ipc_dev->cd->task);
-		break;
-	}
-
-out:
-	platform_shared_commit(payload, sizeof(*payload));
-	platform_shared_commit(ipc_dev->cd, sizeof(*ipc_dev->cd));
-	platform_shared_commit(ipc_dev, sizeof(*ipc_dev));
-	platform_shared_commit(ipc, sizeof(*ipc));
-
-	return ret;
-}
-
-/**
- * \brief Executes IDC component reset message.
- * \param[in] comp_id Component id to be reset.
- * \return Error code.
- */
-static int idc_reset(uint32_t comp_id)
-{
-	struct ipc *ipc = ipc_get();
-	struct ipc_comp_dev *ipc_dev;
-	int ret;
-
-	ipc_dev = ipc_get_comp_by_id(ipc, comp_id);
-	if (!ipc_dev)
-		return -ENODEV;
-
-	ret = comp_reset(ipc_dev->cd);
-
-	platform_shared_commit(ipc_dev, sizeof(*ipc_dev));
-	platform_shared_commit(ipc, sizeof(*ipc));
-
-	return ret;
-}
-
-/**
- * \brief Executes IDC message based on type.
- * \param[in,out] msg Pointer to IDC message.
- */
-static void idc_cmd(struct idc_msg *msg)
-{
-	uint32_t type = iTS(msg->header);
-	int ret = 0;
-
-	switch (type) {
-	case iTS(IDC_MSG_POWER_DOWN):
-		cpu_power_down_core();
-		break;
-	case iTS(IDC_MSG_NOTIFY):
-		notifier_notify_remote();
-		break;
-	case iTS(IDC_MSG_IPC):
-		idc_ipc();
-		break;
-	case iTS(IDC_MSG_PARAMS):
-		ret = idc_params(msg->extension);
-		break;
-	case iTS(IDC_MSG_PREPARE):
-		ret = idc_prepare(msg->extension);
-		break;
-	case iTS(IDC_MSG_TRIGGER):
-		ret = idc_trigger(msg->extension);
-		break;
-	case iTS(IDC_MSG_RESET):
-		ret = idc_reset(msg->extension);
-		break;
-	default:
-		tr_err(&idc_tr, "idc_cmd(): invalid msg->header = %u",
-		       msg->header);
-	}
-
-	idc_msg_status_set(ret, cpu_get_id());
-}
-
-/**
  * \brief Handles received IDC message.
  * \param[in,out] data Pointer to IDC data.
  */
-static enum task_state idc_do_cmd(void *data)
+enum task_state idc_do_cmd(void *data)
 {
 	struct idc *idc = data;
 	int core = cpu_get_id();
@@ -503,39 +193,27 @@ static uint32_t idc_get_busy_bit_mask(int core)
 /**
  * \brief Initializes IDC data and registers for interrupt.
  */
-int idc_init(void)
+int platform_idc_init(void)
 {
+	struct idc *idc = *idc_get();
 	int core = cpu_get_id();
 	int ret;
-	struct task_ops ops = {
-		.run = idc_do_cmd,
-		.get_deadline = ipc_task_deadline,
-	};
-
-	tr_info(&idc_tr, "arch_idc_init()");
 
 	/* initialize idc data */
-	struct idc **idc = idc_get();
-	*idc = rzalloc(SOF_MEM_ZONE_SYS, 0, SOF_MEM_CAPS_RAM, sizeof(**idc));
-	(*idc)->busy_bit_mask = idc_get_busy_bit_mask(core);
-	(*idc)->payload = cache_to_uncache((struct idc_payload *)payload);
-
-	/* process task */
-	schedule_task_init_edf(&(*idc)->idc_task, SOF_UUID(idc_cmd_task_uuid),
-			       &ops, *idc, core, 0);
+	idc->busy_bit_mask = idc_get_busy_bit_mask(core);
 
 	/* configure interrupt */
-	(*idc)->irq = interrupt_get_irq(PLATFORM_IDC_INTERRUPT,
-					PLATFORM_IDC_INTERRUPT_NAME);
-	if ((*idc)->irq < 0)
-		return (*idc)->irq;
-	ret = interrupt_register((*idc)->irq, idc_irq_handler, *idc);
+	idc->irq = interrupt_get_irq(PLATFORM_IDC_INTERRUPT,
+				     PLATFORM_IDC_INTERRUPT_NAME);
+	if (idc->irq < 0)
+		return idc->irq;
+	ret = interrupt_register(idc->irq, idc_irq_handler, idc);
 	if (ret < 0)
 		return ret;
-	interrupt_enable((*idc)->irq, *idc);
+	interrupt_enable(idc->irq, idc);
 
 	/* enable BUSY interrupt */
-	idc_write(IPC_IDCCTL, core, (*idc)->busy_bit_mask);
+	idc_write(IPC_IDCCTL, core, idc->busy_bit_mask);
 
 	return 0;
 }

--- a/src/idc/CMakeLists.txt
+++ b/src/idc/CMakeLists.txt
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+add_local_sources(sof idc.c )

--- a/src/idc/idc.c
+++ b/src/idc/idc.c
@@ -1,0 +1,332 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2020 Intel Corporation. All rights reserved.
+//
+// Author: Tomasz Lauda <tomasz.lauda@linux.intel.com>
+
+#include <sof/audio/component.h>
+#include <sof/audio/component_ext.h>
+#include <sof/drivers/idc.h>
+#include <sof/drivers/ipc.h>
+#include <sof/drivers/timer.h>
+#include <sof/lib/alloc.h>
+#include <sof/lib/clk.h>
+#include <sof/lib/cpu.h>
+#include <sof/lib/memory.h>
+#include <sof/lib/notifier.h>
+#include <sof/lib/uuid.h>
+#include <sof/platform.h>
+#include <sof/schedule/edf_schedule.h>
+#include <sof/schedule/ll_schedule.h>
+#include <sof/schedule/schedule.h>
+#include <sof/schedule/task.h>
+#include <sof/trace/trace.h>
+#include <ipc/header.h>
+#include <ipc/stream.h>
+#include <ipc/topology.h>
+#include <errno.h>
+#include <stdint.h>
+
+/** \brief IDC message payload per core. */
+static SHARED_DATA struct idc_payload payload[PLATFORM_CORE_COUNT];
+
+/* 379a60ae-cedb-4777-aaf2-5659b0a85735 */
+DECLARE_SOF_UUID("idc", idc_uuid, 0x379a60ae, 0xcedb, 0x4777,
+		 0xaa, 0xf2, 0x56, 0x59, 0xb0, 0xa8, 0x57, 0x35);
+
+DECLARE_TR_CTX(idc_tr, SOF_UUID(idc_uuid), LOG_LEVEL_INFO);
+
+/* b90f5a4e-5537-4375-a1df-95485472ff9e */
+DECLARE_SOF_UUID("comp-task", idc_comp_task_uuid, 0xb90f5a4e, 0x5537, 0x4375,
+		 0xa1, 0xdf, 0x95, 0x48, 0x54, 0x72, 0xff, 0x9e);
+
+/* a5dacb0e-88dc-415c-a1b5-3e8df77f1976 */
+DECLARE_SOF_UUID("idc-cmd-task", idc_cmd_task_uuid, 0xa5dacb0e, 0x88dc, 0x415c,
+		 0xa1, 0xb5, 0x3e, 0x8d, 0xf7, 0x7f, 0x19, 0x76);
+
+/**
+ * \brief Sets IDC command status after execution.
+ * \param[in] status Status to be set.
+ * \param[in] core Id of the core for this status.
+ */
+static void idc_msg_status_set(int status, uint32_t core)
+{
+	struct idc *idc = *idc_get();
+	struct idc_payload *payload = idc_payload_get(idc, core);
+
+	*(uint32_t *)payload->data = status;
+
+	platform_shared_commit(payload, sizeof(*payload));
+}
+
+/**
+ * \brief Retrieves IDC command status after sending message.
+ * \param[in] core Id of the core for this status.
+ * \return Last IDC message status.
+ */
+int idc_msg_status_get(uint32_t core)
+{
+	struct idc *idc = *idc_get();
+	struct idc_payload *payload = idc_payload_get(idc, core);
+	int status;
+
+	status = *(uint32_t *)payload->data;
+
+	platform_shared_commit(payload, sizeof(*payload));
+
+	return status;
+}
+
+/**
+ * \brief Waits until status condition is true.
+ * \param[in] target_core Id of the core receiving the message.
+ * \param[in] cond Pointer to condition function.
+ * \return Error code.
+ */
+int idc_wait_in_blocking_mode(uint32_t target_core, bool (*cond)(int))
+{
+	struct timer *timer = timer_get();
+	uint64_t deadline;
+
+	deadline = platform_timer_get(timer) +
+		clock_ms_to_ticks(PLATFORM_DEFAULT_CLOCK, 1) *
+		IDC_TIMEOUT / 1000;
+
+	while (!cond(target_core)) {
+		if (deadline < platform_timer_get(timer)) {
+			/* safe check in case we've got preempted
+			 * after read
+			 */
+			if (cond(target_core))
+				break;
+
+			tr_err(&idc_tr, "idc_wait_in_blocking_mode() error: timeout");
+			return -ETIME;
+		}
+	}
+
+	return 0;
+}
+
+/**
+ * \brief Executes IDC IPC processing message.
+ */
+static void idc_ipc(void)
+{
+	struct ipc *ipc = ipc_get();
+	struct sof_ipc_cmd_hdr *hdr = ipc->comp_data;
+
+	ipc_cmd(hdr);
+}
+
+/**
+ * \brief Executes IDC component params message.
+ * \param[in] comp_id Component id to have params set.
+ * \return Error code.
+ */
+static int idc_params(uint32_t comp_id)
+{
+	struct ipc *ipc = ipc_get();
+	struct ipc_comp_dev *ipc_dev;
+	struct idc *idc = *idc_get();
+	struct idc_payload *payload = idc_payload_get(idc, cpu_get_id());
+	struct sof_ipc_stream_params *params =
+		(struct sof_ipc_stream_params *)payload;
+	int ret;
+
+	ipc_dev = ipc_get_comp_by_id(ipc, comp_id);
+	if (!ipc_dev)
+		return -ENODEV;
+
+	ret = comp_params(ipc_dev->cd, params);
+
+	platform_shared_commit(payload, sizeof(*payload));
+	platform_shared_commit(ipc_dev, sizeof(*ipc_dev));
+	platform_shared_commit(ipc, sizeof(*ipc));
+
+	return ret;
+}
+
+static enum task_state comp_task(void *data)
+{
+	if (comp_copy(data) < 0)
+		return SOF_TASK_STATE_COMPLETED;
+
+	return SOF_TASK_STATE_RESCHEDULE;
+}
+
+/**
+ * \brief Executes IDC component prepare message.
+ * \param[in] comp_id Component id to be prepared.
+ * \return Error code.
+ */
+static int idc_prepare(uint32_t comp_id)
+{
+	struct ipc *ipc = ipc_get();
+	struct ipc_comp_dev *ipc_dev;
+	struct comp_dev *dev;
+	int ret;
+
+	ipc_dev = ipc_get_comp_by_id(ipc, comp_id);
+	if (!ipc_dev)
+		return -ENODEV;
+
+	dev = ipc_dev->cd;
+
+	/* we're running on different core, so allocate our own task */
+	if (!dev->task) {
+		/* allocate task for shared component */
+		dev->task = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM,
+				    sizeof(*dev->task));
+		if (!dev->task) {
+			ret = -ENOMEM;
+			goto out;
+		}
+
+		ret = schedule_task_init_ll(dev->task,
+					    SOF_UUID(idc_comp_task_uuid),
+					    SOF_SCHEDULE_LL_TIMER,
+					    dev->priority, comp_task, dev,
+					    dev->comp.core, 0);
+		if (ret < 0) {
+			rfree(dev->task);
+			goto out;
+		}
+	}
+
+	ret = comp_prepare(ipc_dev->cd);
+
+out:
+	platform_shared_commit(dev, sizeof(*dev));
+	platform_shared_commit(ipc_dev, sizeof(*ipc_dev));
+	platform_shared_commit(ipc, sizeof(*ipc));
+
+	return ret;
+}
+
+/**
+ * \brief Executes IDC component trigger message.
+ * \param[in] comp_id Component id to be triggered.
+ * \return Error code.
+ */
+static int idc_trigger(uint32_t comp_id)
+{
+	struct ipc *ipc = ipc_get();
+	struct ipc_comp_dev *ipc_dev;
+	struct idc *idc = *idc_get();
+	struct idc_payload *payload = idc_payload_get(idc, cpu_get_id());
+	uint32_t cmd = *(uint32_t *)payload;
+	int ret;
+
+	ipc_dev = ipc_get_comp_by_id(ipc, comp_id);
+	if (!ipc_dev)
+		return -ENODEV;
+
+	ret = comp_trigger(ipc_dev->cd, cmd);
+	if (ret < 0)
+		goto out;
+
+	/* schedule or cancel task */
+	switch (cmd) {
+	case COMP_TRIGGER_START:
+	case COMP_TRIGGER_RELEASE:
+		schedule_task(ipc_dev->cd->task, 0, ipc_dev->cd->period);
+		break;
+	case COMP_TRIGGER_XRUN:
+	case COMP_TRIGGER_PAUSE:
+	case COMP_TRIGGER_STOP:
+		schedule_task_cancel(ipc_dev->cd->task);
+		break;
+	}
+
+out:
+	platform_shared_commit(payload, sizeof(*payload));
+	platform_shared_commit(ipc_dev->cd, sizeof(*ipc_dev->cd));
+	platform_shared_commit(ipc_dev, sizeof(*ipc_dev));
+	platform_shared_commit(ipc, sizeof(*ipc));
+
+	return ret;
+}
+
+/**
+ * \brief Executes IDC component reset message.
+ * \param[in] comp_id Component id to be reset.
+ * \return Error code.
+ */
+static int idc_reset(uint32_t comp_id)
+{
+	struct ipc *ipc = ipc_get();
+	struct ipc_comp_dev *ipc_dev;
+	int ret;
+
+	ipc_dev = ipc_get_comp_by_id(ipc, comp_id);
+	if (!ipc_dev)
+		return -ENODEV;
+
+	ret = comp_reset(ipc_dev->cd);
+
+	platform_shared_commit(ipc_dev, sizeof(*ipc_dev));
+	platform_shared_commit(ipc, sizeof(*ipc));
+
+	return ret;
+}
+
+/**
+ * \brief Executes IDC message based on type.
+ * \param[in,out] msg Pointer to IDC message.
+ */
+void idc_cmd(struct idc_msg *msg)
+{
+	uint32_t type = iTS(msg->header);
+	int ret = 0;
+
+	switch (type) {
+	case iTS(IDC_MSG_POWER_DOWN):
+		cpu_power_down_core();
+		break;
+	case iTS(IDC_MSG_NOTIFY):
+		notifier_notify_remote();
+		break;
+	case iTS(IDC_MSG_IPC):
+		idc_ipc();
+		break;
+	case iTS(IDC_MSG_PARAMS):
+		ret = idc_params(msg->extension);
+		break;
+	case iTS(IDC_MSG_PREPARE):
+		ret = idc_prepare(msg->extension);
+		break;
+	case iTS(IDC_MSG_TRIGGER):
+		ret = idc_trigger(msg->extension);
+		break;
+	case iTS(IDC_MSG_RESET):
+		ret = idc_reset(msg->extension);
+		break;
+	default:
+		tr_err(&idc_tr, "idc_cmd(): invalid msg->header = %u",
+		       msg->header);
+	}
+
+	idc_msg_status_set(ret, cpu_get_id());
+}
+
+int idc_init(void)
+{
+	struct idc **idc = idc_get();
+	struct task_ops ops = {
+		.run = idc_do_cmd,
+		.get_deadline = ipc_task_deadline,
+	};
+
+	tr_info(&idc_tr, "idc_init()");
+
+	/* initialize idc data */
+	*idc = rzalloc(SOF_MEM_ZONE_SYS, 0, SOF_MEM_CAPS_RAM, sizeof(**idc));
+	(*idc)->payload = cache_to_uncache((struct idc_payload *)payload);
+
+	/* process task */
+	schedule_task_init_edf(&(*idc)->idc_task, SOF_UUID(idc_cmd_task_uuid),
+			       &ops, *idc, cpu_get_id(), 0);
+
+	return platform_idc_init();
+}

--- a/src/include/sof/drivers/idc.h
+++ b/src/include/sof/drivers/idc.h
@@ -14,6 +14,7 @@
 #ifndef __SOF_DRIVERS_IDC_H__
 #define __SOF_DRIVERS_IDC_H__
 
+#include <arch/drivers/idc.h>
 #include <platform/drivers/idc.h>
 #include <sof/schedule/task.h>
 #include <sof/trace/trace.h>
@@ -113,6 +114,9 @@ struct idc {
 	int irq;
 };
 
+/* idc trace context, used by multiple units */
+extern struct tr_ctx idc_tr;
+
 static inline struct idc_payload *idc_payload_get(struct idc *idc,
 						  uint32_t core)
 {
@@ -122,5 +126,15 @@ static inline struct idc_payload *idc_payload_get(struct idc *idc,
 void idc_enable_interrupts(int target_core, int source_core);
 
 void idc_free(void);
+
+int platform_idc_init(void);
+
+enum task_state idc_do_cmd(void *data);
+
+void idc_cmd(struct idc_msg *msg);
+
+int idc_wait_in_blocking_mode(uint32_t target_core, bool (*cond)(int));
+
+int idc_msg_status_get(uint32_t core);
 
 #endif /* __SOF_DRIVERS_IDC_H__ */


### PR DESCRIPTION
Extracts IDC protocol related code to common file.
Platform specific driver has just the implementations
for hardware specific operations.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>