### PR TITLE
zephyr: Enable IIR init also for CAVS 1.5

### DIFF
--- a/src/audio/mux/mux_generic.c
+++ b/src/audio/mux/mux_generic.c
@@ -26,8 +26,8 @@
  * \param[in] offset Offset in source buffer.
  * \param[in] mask Routing bitmask for calculating output sample.
  */
-UT_STATIC inline int32_t calc_sample_s16le(const struct audio_stream *source,
-					   uint32_t offset, uint8_t mask)
+UT_STATIC int32_t calc_sample_s16le(const struct audio_stream *source,
+				    uint32_t offset, uint8_t mask)
 {
 	int32_t sample = 0;
 	int16_t *src;
@@ -136,8 +136,8 @@ static void mux_s16le(struct audio_stream *sink,
  * \param[in] offset Offset in source buffer.
  * \param[in] mask Routing bitmask for calculating output sample.
  */
-UT_STATIC inline int32_t calc_sample_s24le(const struct audio_stream *source,
-					   uint32_t offset, uint8_t mask)
+UT_STATIC int32_t calc_sample_s24le(const struct audio_stream *source,
+				    uint32_t offset, uint8_t mask)
 {
 	int32_t sample = 0;
 	int32_t *src;
@@ -245,8 +245,8 @@ static void mux_s24le(struct audio_stream *sink,
  * \param[in] offset Offset in source buffer.
  * \param[in] mask Routing bitmask for calculating output sample.
  */
-UT_STATIC inline int64_t calc_sample_s32le(const struct audio_stream *source,
-					   uint32_t offset, uint8_t mask)
+UT_STATIC int64_t calc_sample_s32le(const struct audio_stream *source,
+				    uint32_t offset, uint8_t mask)
 {
 	int64_t sample = 0;
 	int32_t *src;

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -456,26 +456,22 @@ int task_main_start(void)
 
 	/* init self-registered modules */
 	sys_module_init();
+
 	sys_comp_volume_init();
 	sys_comp_host_init();
 	sys_comp_mixer_init();
 	sys_comp_dai_init();
 	sys_comp_src_init();
-	sys_comp_eq_iir_init();
 
-	/* only CAVS18+ have enough memory for these */
-#if defined CONFIG_SOC_SERIES_INTEL_CAVS_V18 ||\
-	defined CONFIG_SOC_SERIES_INTEL_CAVS_V20 ||\
-	defined CONFIG_SOC_SERIES_INTEL_CAVS_V25
-	//sys_comp_mux_init();   // needs more symbols.
 	sys_comp_selector_init();
 	sys_comp_switch_init();
 	sys_comp_tone_init();
 	sys_comp_eq_fir_init();
+	sys_comp_eq_iir_init();
 	sys_comp_keyword_init();
 	sys_comp_asrc_init();
 	sys_comp_dcblock_init();
-#endif
+	sys_comp_mux_init();
 
 	/* init pipeline position offsets */
 	pipeline_posn_init(sof);

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -461,6 +461,7 @@ int task_main_start(void)
 	sys_comp_mixer_init();
 	sys_comp_dai_init();
 	sys_comp_src_init();
+	sys_comp_eq_iir_init();
 
 	/* only CAVS18+ have enough memory for these */
 #if defined CONFIG_SOC_SERIES_INTEL_CAVS_V18 ||\
@@ -474,7 +475,6 @@ int task_main_start(void)
 	sys_comp_keyword_init();
 	sys_comp_asrc_init();
 	sys_comp_dcblock_init();
-	sys_comp_eq_iir_init();
 #endif
 
 	/* init pipeline position offsets */


### PR DESCRIPTION
Fixes errors when loading topology due to:
...
COMP comp_new(): driver not found, comp->type = 13
...