### PR TITLE
trace: Use trace context in each instance of topology components

### DIFF
--- a/src/audio/buffer.c
+++ b/src/audio/buffer.c
@@ -90,6 +90,9 @@ struct comp_buffer *buffer_new(struct sof_ipc_buffer *desc)
 		buffer->stream.overrun_permitted = desc->flags &
 						   SOF_BUF_OVERRUN_PERMITTED;
 
+		memcpy_s(&buffer->tctx, sizeof(struct tr_ctx),
+			 &buffer_tr, sizeof(struct tr_ctx));
+
 		dcache_writeback_invalidate_region(buffer, sizeof(*buffer));
 	}
 

--- a/src/audio/pipeline.c
+++ b/src/audio/pipeline.c
@@ -109,6 +109,9 @@ struct pipeline *pipeline_new(struct sof_ipc_pipe_new *pipe_desc,
 		return NULL;
 	}
 
+	memcpy_s(&p->tctx, sizeof(struct tr_ctx), &pipe_tr,
+		 sizeof(struct tr_ctx));
+
 	return p;
 }
 

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -40,7 +40,7 @@ struct comp_dev;
 extern struct tr_ctx buffer_tr;
 
 /** \brief Retrieves trace context from the buffer */
-#define trace_buf_get_tr_ctx(buf_ptr) (&buffer_tr)
+#define trace_buf_get_tr_ctx(buf_ptr) (&(buf_ptr)->tctx)
 
 /** \brief Retrieves id (pipe id) from the buffer */
 #define trace_buf_get_id(buf_ptr) ((buf_ptr)->pipeline_id)
@@ -96,6 +96,7 @@ struct comp_buffer {
 	uint32_t caps;
 	uint32_t core;
 	bool inter_core; /* true if connected to a comp from another core */
+	struct tr_ctx tctx;			/* trace settings */
 
 	/* connected components */
 	struct comp_dev *source;	/* source component */

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -130,7 +130,7 @@ struct dai_hw_params;
 #define trace_comp_drv_get_subid(drv_p) (-1)
 
 /** \brief Retrieves trace context from the component device */
-#define trace_comp_get_tr_ctx(comp_p) ((comp_p)->drv->tctx)
+#define trace_comp_get_tr_ctx(comp_p) (&(comp_p)->tctx)
 
 /** \brief Retrieves id (pipe id) from the component device */
 #define trace_comp_get_id(comp_p) ((comp_p)->comp.pipeline_id)
@@ -428,6 +428,7 @@ struct comp_dev {
 	bool is_shared;		/**< indicates whether component is shared
 				  *  across cores
 				  */
+	struct tr_ctx tctx;	/**< trace settings */
 
 	/* common runtime configuration for downstream/upstream */
 	uint32_t direction;	/**< enum sof_ipc_stream_direction */
@@ -545,6 +546,8 @@ static inline struct comp_dev *comp_alloc(const struct comp_driver *drv,
 		return NULL;
 	dev->size = bytes;
 	dev->drv = drv;
+	memcpy_s(&dev->tctx, sizeof(struct tr_ctx),
+		 trace_comp_drv_get_tr_ctx(dev->drv), sizeof(struct tr_ctx));
 
 	return dev;
 }

--- a/src/include/sof/audio/pipeline.h
+++ b/src/include/sof/audio/pipeline.h
@@ -40,7 +40,7 @@ struct task;
 /* pipeline tracing */
 extern struct tr_ctx pipe_tr;
 
-#define trace_pipe_get_tr_ctx(pipe_p) (&pipe_tr)
+#define trace_pipe_get_tr_ctx(pipe_p) (&pipe_p->tctx)
 #define trace_pipe_get_id(pipe_p) ((pipe_p)->ipc_pipe.pipeline_id)
 #define trace_pipe_get_subid(pipe_p) ((pipe_p)->ipc_pipe.comp_id)
 
@@ -98,6 +98,7 @@ struct pipeline {
 	/* runtime status */
 	int32_t xrun_bytes;		/* last xrun length */
 	uint32_t status;		/* pipeline status */
+	struct tr_ctx tctx;		/* trace settings */
 
 	/* scheduling */
 	struct task *pipe_task;		/* pipeline processing task */


### PR DESCRIPTION
To allow setting individual trace level per component, it's necessary to hold such and information in each component.

It's a part of https://github.com/thesofproject/sof/pull/2965