### PR TITLE
trace: Put global trace context entries to separate section

### DIFF
--- a/src/include/sof/trace/trace.h
+++ b/src/include/sof/trace/trace.h
@@ -297,7 +297,11 @@ struct tr_ctx {
 	uint32_t level;		/**< Default log level */
 };
 
-/* todo: put in a section to iterate over later while cfg log levels */
+#if defined(UNIT_TEST)
+#define TRACE_CONTEXT_SECTION
+#else
+#define TRACE_CONTEXT_SECTION __section(".trace_ctx")
+#endif
 
 /**
  * Declares trace context.
@@ -306,7 +310,7 @@ struct tr_ctx {
  * @param default_log_level Default log level.
  */
 #define DECLARE_TR_CTX(ctx_name, uuid, default_log_level) \
-	struct tr_ctx ctx_name = { \
+	struct tr_ctx ctx_name TRACE_CONTEXT_SECTION = { \
 			.uuid_p = uuid, \
 			.level = default_log_level, \
 	}

--- a/src/platform/apollolake/apollolake.x.in
+++ b/src/platform/apollolake/apollolake.x.in
@@ -446,6 +446,9 @@ SECTIONS
     *(.sdata2.*)
     *(.gnu.linkonce.s2.*)
     KEEP(*(.jcr))
+    _trace_ctx_start = ABSOLUTE(.);
+    *(.trace_ctx)
+    _trace_ctx_end = ABSOLUTE(.);
     _data_end = ABSOLUTE(.);
   } >sof_fw :sof_fw_phdr
 

--- a/src/platform/baytrail/baytrail.x.in
+++ b/src/platform/baytrail/baytrail.x.in
@@ -410,6 +410,9 @@ SECTIONS
     *(.sdata2.*)
     *(.gnu.linkonce.s2.*)
     KEEP(*(.jcr))
+    _trace_ctx_start = ABSOLUTE(.);
+    *(.trace_ctx)
+    _trace_ctx_end = ABSOLUTE(.);
     _data_end = ABSOLUTE(.);
   } >sof_data :sof_data_phdr
 

--- a/src/platform/cannonlake/cannonlake.x.in
+++ b/src/platform/cannonlake/cannonlake.x.in
@@ -411,6 +411,9 @@ SECTIONS
     *(.sdata2.*)
     *(.gnu.linkonce.s2.*)
     KEEP(*(.jcr))
+    _trace_ctx_start = ABSOLUTE(.);
+    *(.trace_ctx)
+    _trace_ctx_end = ABSOLUTE(.);
     _data_end = ABSOLUTE(.);
   } >sof_fw :sof_fw_phdr
 

--- a/src/platform/haswell/haswell.x.in
+++ b/src/platform/haswell/haswell.x.in
@@ -418,6 +418,9 @@ SECTIONS
     *(.gnu.linkonce.s2.*)
     KEEP(*(.jcr))
     _data_end = ABSOLUTE(.);
+    _trace_ctx_start = ABSOLUTE(.);
+    *(.trace_ctx)
+    _trace_ctx_end = ABSOLUTE(.);
   } >sof_data :sof_data_phdr
 
   .lit4 : ALIGN(4)

--- a/src/platform/icelake/icelake.x.in
+++ b/src/platform/icelake/icelake.x.in
@@ -415,6 +415,9 @@ SECTIONS
     *(.sdata2.*)
     *(.gnu.linkonce.s2.*)
     KEEP(*(.jcr))
+    _trace_ctx_start = ABSOLUTE(.);
+    *(.trace_ctx)
+    _trace_ctx_end = ABSOLUTE(.);
     _data_end = ABSOLUTE(.);
   } >sof_fw :sof_fw_phdr
 

--- a/src/platform/imx8/imx8.x.in
+++ b/src/platform/imx8/imx8.x.in
@@ -374,6 +374,9 @@ SECTIONS
     *(.sdata2.*)
     *(.gnu.linkonce.s2.*)
     KEEP(*(.jcr))
+    _trace_ctx_start = ABSOLUTE(.);
+    *(.trace_ctx)
+    _trace_ctx_end = ABSOLUTE(.);
     _data_end = ABSOLUTE(.);
   } >sof_sdram0 :sof_sdram0_phdr
 

--- a/src/platform/imx8m/imx8m.x.in
+++ b/src/platform/imx8m/imx8m.x.in
@@ -374,6 +374,9 @@ SECTIONS
     *(.sdata2.*)
     *(.gnu.linkonce.s2.*)
     KEEP(*(.jcr))
+    _trace_ctx_start = ABSOLUTE(.);
+    *(.trace_ctx)
+    _trace_ctx_end = ABSOLUTE(.);
     _data_end = ABSOLUTE(.);
   } >sof_sdram0 :sof_sdram0_phdr
 

--- a/src/platform/suecreek/suecreek.x.in
+++ b/src/platform/suecreek/suecreek.x.in
@@ -413,6 +413,9 @@ SECTIONS
     *(.sdata2.*)
     *(.gnu.linkonce.s2.*)
     KEEP(*(.jcr))
+    _trace_ctx_start = ABSOLUTE(.);
+    *(.trace_ctx)
+    _trace_ctx_end = ABSOLUTE(.);
     _data_end = ABSOLUTE(.);
   } >sof_fw :sof_fw_phdr
 

--- a/src/platform/tigerlake/tigerlake.x.in
+++ b/src/platform/tigerlake/tigerlake.x.in
@@ -465,6 +465,9 @@ SECTIONS
     *(.sdata2.*)
     *(.gnu.linkonce.s2.*)
     KEEP(*(.jcr))
+    _trace_ctx_start = ABSOLUTE(.);
+    *(.trace_ctx)
+    _trace_ctx_end = ABSOLUTE(.);
     _data_end = ABSOLUTE(.);
   } >sof_fw :sof_fw_phdr
 


### PR DESCRIPTION
It is the first step to allow iterating over the trace context
entries and of search for the right one.

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>

It's a part of https://github.com/thesofproject/sof/pull/2965