### PR TITLE
ipc: Extract pipeline id dereference from ipc_comp_dev structure

### DIFF
--- a/src/include/sof/audio/pipeline.h
+++ b/src/include/sof/audio/pipeline.h
@@ -8,7 +8,6 @@
 #ifndef __SOF_AUDIO_PIPELINE_H__
 #define __SOF_AUDIO_PIPELINE_H__
 
-#include <sof/drivers/ipc.h>
 #include <sof/lib/cpu.h>
 #include <sof/lib/mailbox.h>
 #include <sof/lib/memory.h>
@@ -26,6 +25,7 @@
 struct comp_buffer;
 struct comp_dev;
 struct ipc;
+struct ipc_msg;
 struct sof_ipc_buffer;
 struct sof_ipc_pcm_params;
 struct task;

--- a/src/include/sof/drivers/ipc.h
+++ b/src/include/sof/drivers/ipc.h
@@ -32,7 +32,6 @@
 struct dai_config;
 struct dma;
 struct dma_sg_elem_array;
-struct sof;
 struct sof_ipc_buffer;
 struct sof_ipc_comp;
 struct sof_ipc_comp_event;

--- a/src/include/sof/drivers/ipc.h
+++ b/src/include/sof/drivers/ipc.h
@@ -9,6 +9,9 @@
 #ifndef __SOF_DRIVERS_IPC_H__
 #define __SOF_DRIVERS_IPC_H__
 
+#include <sof/audio/buffer.h>
+#include <sof/audio/component.h>
+#include <sof/audio/pipeline.h>
 #include <sof/lib/alloc.h>
 #include <sof/lib/memory.h>
 #include <sof/list.h>
@@ -26,12 +29,9 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-struct comp_buffer;
-struct comp_dev;
 struct dai_config;
 struct dma;
 struct dma_sg_elem_array;
-struct pipeline;
 struct sof;
 struct sof_ipc_buffer;
 struct sof_ipc_comp;
@@ -122,6 +122,23 @@ static inline uint64_t ipc_task_deadline(void *data)
 	 * to finish processing. This will allow us to calculate task deadline.
 	 */
 	return SOF_TASK_DEADLINE_NOW;
+}
+
+static inline int32_t ipc_comp_pipe_id(const struct ipc_comp_dev *icd)
+{
+	extern struct tr_ctx ipc_tr;
+
+	switch (icd->type) {
+	case COMP_TYPE_COMPONENT:
+		return dev_comp_pipe_id(icd->cd);
+	case COMP_TYPE_BUFFER:
+		return icd->cb->pipeline_id;
+	case COMP_TYPE_PIPELINE:
+		return icd->pipeline->ipc_pipe.pipeline_id;
+	default:
+		tr_err(&ipc_tr, "Unknown ipc component type %u", icd->type);
+		return -EINVAL;
+	};
 }
 
 static inline void ipc_build_stream_posn(struct sof_ipc_stream_posn *posn,

--- a/src/ipc/ipc.c
+++ b/src/ipc/ipc.c
@@ -100,20 +100,8 @@ struct ipc_comp_dev *ipc_get_comp_by_ppl_id(struct ipc *ipc, uint16_t type,
 			continue;
 		}
 
-		switch (icd->type) {
-		case COMP_TYPE_COMPONENT:
-			if (dev_comp_pipe_id(icd->cd) == ppl_id)
-				return icd;
-			break;
-		case COMP_TYPE_BUFFER:
-			if (icd->cb->pipeline_id == ppl_id)
-				return icd;
-			break;
-		case COMP_TYPE_PIPELINE:
-			if (icd->pipeline->ipc_pipe.pipeline_id == ppl_id)
-				return icd;
-			break;
-		}
+		if (ipc_comp_pipe_id(icd) == ppl_id)
+			return icd;
 
 		platform_shared_commit(icd, sizeof(*icd));
 	}

--- a/test/cmocka/src/audio/pipeline/pipeline_mocks.h
+++ b/test/cmocka/src/audio/pipeline/pipeline_mocks.h
@@ -7,6 +7,7 @@
 
 #include <sof/audio/component.h>
 #include <sof/audio/pipeline.h>
+#include <sof/drivers/ipc.h>
 #include <sof/lib/clk.h>
 #include <sof/schedule/edf_schedule.h>
 #include <sof/schedule/ll_schedule.h>


### PR DESCRIPTION
Mechanism of comparison pipe_id from ipc_comp_dev will be used in
trace filtering, so this part should be moved to separate function
and allow code reusability.
Moreover function usage is compact and descriptive method to define
what given block of code should do, so after such a refactor code
readability is improved.

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>

This is part of https://github.com/thesofproject/sof/pull/2965