### PR TITLE
task: increase default stack size for EDF tasks

### DIFF
--- a/src/platform/intel/cavs/include/cavs/lib/memory.h
+++ b/src/platform/intel/cavs/include/cavs/lib/memory.h
@@ -65,7 +65,7 @@
 #define HEAP_BUF_ALIGNMENT		PLATFORM_DCACHE_ALIGN
 
 /** \brief EDF task's default stack size in bytes. */
-#define PLATFORM_TASK_DEFAULT_STACK_SIZE	3072
+#define PLATFORM_TASK_DEFAULT_STACK_SIZE	0x1000
 
 #if !defined(__ASSEMBLER__) && !defined(LINKER)
 


### PR DESCRIPTION
Increases default stack size for EDF tasks. Some of the
IPC operations are very stack heavy, so let's make sure
they won't exceed stack.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>

Fixes #2921 & #2693.