### PR TITLE
ipc: prevent SSP dai config double execution

### DIFF
--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -832,7 +832,7 @@ static int dai_config(struct comp_dev *dev, struct sof_ipc_dai_config *config)
 				  dai_dma_cb, 0);
 	}
 
-	return dai_set_config(dd->dai, config);
+	return 0;
 }
 
 static int dai_ts_config(struct comp_dev *dev)

--- a/src/drivers/intel/alh.c
+++ b/src/drivers/intel/alh.c
@@ -44,6 +44,8 @@ static int alh_set_config(struct dai *dai, struct sof_ipc_dai_config *config)
 
 	alh->params.stream_id = config->alh.stream_id;
 
+	platform_shared_commit(alh, sizeof(*alh));
+
 	return 0;
 }
 
@@ -61,6 +63,8 @@ static int alh_get_hw_params(struct dai *dai,
 
 	/* FIFO format is static */
 	params->frame_fmt = SOF_IPC_FRAME_S32_LE;
+
+	platform_shared_commit(alh, sizeof(*alh));
 
 	return 0;
 }
@@ -88,13 +92,15 @@ static int alh_probe(struct dai *dai)
 	if (dai_get_drvdata(dai))
 		return -EEXIST;
 
-	alh = rzalloc(SOF_MEM_ZONE_SYS_RUNTIME, 0, SOF_MEM_CAPS_RAM,
-		      sizeof(*alh));
+	alh = rzalloc(SOF_MEM_ZONE_SYS_RUNTIME, SOF_MEM_FLAG_SHARED,
+		      SOF_MEM_CAPS_RAM, sizeof(*alh));
 	if (!alh) {
 		dai_err(dai, "alh_probe() error: alloc failed");
 		return -ENOMEM;
 	}
 	dai_set_drvdata(dai, alh);
+
+	platform_shared_commit(alh, sizeof(*alh));
 
 	return 0;
 }

--- a/src/drivers/intel/hda/hda.c
+++ b/src/drivers/intel/hda/hda.c
@@ -35,6 +35,8 @@ static int hda_set_config(struct dai *dai,
 		hda->params.rate = config->hda.rate;
 	}
 
+	platform_shared_commit(hda, sizeof(*hda));
+
 	return 0;
 }
 
@@ -51,6 +53,8 @@ static int hda_get_hw_params(struct dai *dai,
 	params->buffer_fmt = 0;
 	params->frame_fmt = 0;
 
+	platform_shared_commit(hda, sizeof(*hda));
+
 	return 0;
 }
 
@@ -63,13 +67,15 @@ static int hda_probe(struct dai *dai)
 	if (dai_get_drvdata(dai))
 		return -EEXIST;
 
-	hda = rzalloc(SOF_MEM_ZONE_SYS_RUNTIME, 0, SOF_MEM_CAPS_RAM,
-		      sizeof(*hda));
+	hda = rzalloc(SOF_MEM_ZONE_SYS_RUNTIME, SOF_MEM_FLAG_SHARED,
+		      SOF_MEM_CAPS_RAM, sizeof(*hda));
 	if (!hda) {
 		dai_err(dai, "hda_probe() error: alloc failed");
 		return -ENOMEM;
 	}
 	dai_set_drvdata(dai, hda);
+
+	platform_shared_commit(hda, sizeof(*hda));
 
 	return 0;
 }

--- a/src/drivers/intel/ssp/mn.c
+++ b/src/drivers/intel/ssp/mn.c
@@ -193,7 +193,7 @@ static inline int set_mclk_divider(uint16_t mclk_id, uint32_t mdivr_val)
 		mdivr = 0x6; /* 1/8 */
 		break;
 	default:
-		tr_err(&mn_tr, "invalid mdivr_val %d", mdivr_val);
+		tr_err(&mn_tr, "invalid ssp_freq %d", ssp_freq[1].freq);
 		return -EINVAL;
 	}
 

--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -503,16 +503,50 @@ static int ipc_glb_stream_message(uint32_t header)
  * DAI IPC Operations.
  */
 
+static int ipc_dai_config_set(struct sof_ipc_dai_config *config)
+{
+	struct dai *dai;
+	int ret;
+
+	/* get DAI */
+	dai = dai_get(config->type, config->dai_index, 0 /* existing only */);
+	if (!dai) {
+		tr_err(&ipc_tr, "ipc: dai %d,%d not found", config->type,
+		       config->dai_index);
+		return -ENODEV;
+	}
+
+	/* configure DAI */
+	ret = dai_set_config(dai, config);
+	dai_put(dai); /* free ref immediately */
+	if (ret < 0) {
+		tr_err(&ipc_tr, "ipc: dai %d,%d config failed %d", config->type,
+		       config->dai_index, ret);
+		return ret;
+	}
+
+	return 0;
+}
+
 static int ipc_dai_config(uint32_t header)
 {
 	struct ipc *ipc = ipc_get();
 	struct sof_ipc_dai_config config;
+	int ret;
 
 	/* copy message with ABI safe method */
 	IPC_COPY_CMD(config, ipc->comp_data);
 
 	tr_dbg(&ipc_tr, "ipc: dai %d.%d -> config ", config.type,
 	       config.dai_index);
+
+	/* only master core configures dai */
+	if (cpu_get_id() == PLATFORM_MASTER_CORE_ID) {
+		ret = ipc_dai_config_set(
+			(struct sof_ipc_dai_config *)ipc->comp_data);
+		if (ret < 0)
+			return ret;
+	}
 
 	/* send params to all DAI components who use that physical DAI */
 	return ipc_comp_dai_config(ipc,


### PR DESCRIPTION
Prevents DAI config to be executed double for SSP.
Along with this change we need to share dai private data.
From now on master core will be always responsible for setting
dai config on dai and it may happen that private data is allocated
by slave core.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>