### PR TITLE
drivers: imx: Disable FIFO warning DMA flag

### DIFF
--- a/src/drivers/imx/sai.c
+++ b/src/drivers/imx/sai.c
@@ -32,11 +32,9 @@ static void sai_start(struct dai *dai, int direction)
 
 	uint32_t xcsr = 0U;
 
-	dai_update_bits(dai, REG_SAI_XCSR(direction),
-			REG_SAI_CSR_FRDE, REG_SAI_CSR_FRDE);
 	/* enable DMA requests */
 	dai_update_bits(dai, REG_SAI_XCSR(direction),
-			REG_SAI_CSR_FWDE, REG_SAI_CSR_FWDE);
+			REG_SAI_CSR_FRDE, REG_SAI_CSR_FRDE);
 #ifdef CONFIG_IMX8M
 	dai_update_bits(dai, REG_SAI_MCTL, REG_SAI_MCTL_MCLK_EN,
 			REG_SAI_MCTL_MCLK_EN);


### PR DESCRIPTION
FIFO warning flag signals if SAI FIFO is empty (for transmitter)
or full (for receiver) and it is cleared automatically if the condition
is removed.

We already use FIFO request flag to signal DMA for data availability
so there is no need to enable FIFO warning DMA flag.

This aligns SAI firmware driver with SAI Linux kernel driver.

Also, this mitigates a problem in the SDMA driver where multiple
starting and stopping aplay in a loop results in an I/O error
after some time.
Investigation should continue to fix the SDMA driver.

Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>