### PR TITLE
ext_manifest: Add sof_ipc_user_abi_version content

### DIFF
--- a/src/include/kernel/ext_manifest.h
+++ b/src/include/kernel/ext_manifest.h
@@ -50,6 +50,7 @@ enum ext_man_elem_type {
 	EXT_MAN_ELEM_WINDOW		= SOF_IPC_EXT_WINDOW,
 	EXT_MAN_ELEM_CC_VERSION		= SOF_IPC_EXT_CC_INFO,
 	EXT_MAN_ELEM_PROBE_INFO		= SOF_IPC_EXT_PROBE_INFO,
+	EXT_MAN_ELEM_DBG_ABI		= SOF_IPC_EXT_USER_ABI_INFO,
 };
 
 /* FW version */
@@ -78,6 +79,12 @@ struct ext_man_probe_support {
 	struct ext_man_elem_header hdr;
 	/* use sof_ipc struct because of code re-use */
 	struct sof_ipc_probe_support probe;
+} __packed;
+
+struct ext_man_dbg_abi {
+	struct ext_man_elem_header hdr;
+	/* use sof_ipc struct because of code re-use */
+	struct sof_ipc_user_abi_version dbg_abi;
 } __packed;
 
 #endif /* __KERNEL_EXT_MANIFEST_H__ */

--- a/src/init/ext_manifest.c
+++ b/src/init/ext_manifest.c
@@ -11,7 +11,7 @@
 #include <sof/debug/debug.h>
 #include <kernel/abi.h>
 #include <kernel/ext_manifest.h>
-
+#include <user/abi_dbg.h>
 #include <version.h>
 
 const struct ext_man_fw_version ext_man_fw_ver
@@ -68,5 +68,18 @@ const struct ext_man_probe_support ext_man_probe
 		.probe_points_max = CONFIG_PROBE_POINTS_MAX,
 		.injection_dmas_max = CONFIG_PROBE_DMA_MAX
 #endif
+	},
+};
+
+const struct ext_man_dbg_abi ext_man_dbg_info
+	__aligned(EXT_MAN_ALIGN) __section(".fw_metadata") = {
+	.hdr.type = EXT_MAN_ELEM_DBG_ABI,
+	.hdr.elem_size = ALIGN_UP(sizeof(struct ext_man_dbg_abi),
+				  EXT_MAN_ALIGN),
+	.dbg_abi = {
+		.ext_hdr.hdr.size = sizeof(struct sof_ipc_user_abi_version),
+		.ext_hdr.hdr.cmd = SOF_IPC_FW_READY,
+		.ext_hdr.type = SOF_IPC_EXT_USER_ABI_INFO,
+		.abi_dbg_version = SOF_ABI_DBG_VERSION,
 	},
 };


### PR DESCRIPTION
This information known at build time does not need to be
provided in a mailbox.

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>