### PR TITLE
sof: Define possible UUID entries usage in IPC during declaration

### DIFF
--- a/src/audio/asrc/asrc.c
+++ b/src/audio/asrc/asrc.c
@@ -47,7 +47,7 @@ typedef void (*asrc_proc_func)(struct comp_dev *dev,
 static const struct comp_driver comp_asrc;
 
 /* c8ec72f6-8526-4faf-9d39-a23d0b541de2 */
-DECLARE_SOF_UUID("asrc", asrc_uuid, 0xc8ec72f6, 0x8526, 0x4faf,
+DECLARE_SOF_RT_UUID("asrc", asrc_uuid, 0xc8ec72f6, 0x8526, 0x4faf,
 		 0x9d, 0x39, 0xa2, 0x3d, 0x0b, 0x54, 0x1d, 0xe2);
 
 DECLARE_TR_CTX(asrc_tr, SOF_UUID(asrc_uuid), LOG_LEVEL_INFO);

--- a/src/audio/asrc/asrc.c
+++ b/src/audio/asrc/asrc.c
@@ -898,7 +898,7 @@ static int asrc_reset(struct comp_dev *dev)
 
 static const struct comp_driver comp_asrc = {
 	.type = SOF_COMP_ASRC,
-	.uid = SOF_UUID(asrc_uuid),
+	.uid = SOF_RT_UUID(asrc_uuid),
 	.tctx = &asrc_tr,
 	.ops = {
 		.create = asrc_new,

--- a/src/audio/buffer.c
+++ b/src/audio/buffer.c
@@ -20,7 +20,7 @@
 #include <stdint.h>
 
 /* 42544c92-8e92-4e41-b679-34519f1c1d28 */
-DECLARE_SOF_UUID("buffer", buffer_uuid, 0x42544c92, 0x8e92, 0x4e41,
+DECLARE_SOF_RT_UUID("buffer", buffer_uuid, 0x42544c92, 0x8e92, 0x4e41,
 		 0xb6, 0x79, 0x34, 0x51, 0x9f, 0x1c, 0x1d, 0x28);
 DECLARE_TR_CTX(buffer_tr, SOF_UUID(buffer_uuid), LOG_LEVEL_INFO);
 

--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -77,7 +77,7 @@ struct comp_dev *comp_new(struct sof_ipc_comp *comp)
 	}
 
 	tr_info(&comp_tr, "comp new %s type %d id %d.%d",
-		drv->uid, comp->type, comp->pipeline_id, comp->id);
+		drv->tctx->uuid_p, comp->type, comp->pipeline_id, comp->id);
 
 	/* create the new component */
 	cdev = drv->ops.create(drv, comp);

--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -36,7 +36,7 @@
 static const struct comp_driver comp_dai;
 
 /* c2b00d27-ffbc-4150-a51a-245c79c5e54b */
-DECLARE_SOF_UUID("dai", dai_comp_uuid, 0xc2b00d27, 0xffbc, 0x4150,
+DECLARE_SOF_RT_UUID("dai", dai_comp_uuid, 0xc2b00d27, 0xffbc, 0x4150,
 		 0xa5, 0x1a, 0x24, 0x5c, 0x79, 0xc5, 0xe5, 0x4b);
 
 DECLARE_TR_CTX(dai_comp_tr, SOF_UUID(dai_comp_uuid), LOG_LEVEL_INFO);

--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -894,7 +894,7 @@ static int dai_ts_get(struct comp_dev *dev, struct timestamp_data *tsd)
 
 static const struct comp_driver comp_dai = {
 	.type	= SOF_COMP_DAI,
-	.uid	= SOF_UUID(dai_comp_uuid),
+	.uid	= SOF_RT_UUID(dai_comp_uuid),
 	.tctx	= &dai_comp_tr,
 	.ops	= {
 		.create			= dai_new,

--- a/src/audio/dcblock/dcblock.c
+++ b/src/audio/dcblock/dcblock.c
@@ -30,7 +30,7 @@
 static const struct comp_driver comp_dcblock;
 
 /* b809efaf-5681-42b1-9ed6-04bb012dd384 */
-DECLARE_SOF_UUID("dcblock", dcblock_uuid, 0xb809efaf, 0x5681, 0x42b1,
+DECLARE_SOF_RT_UUID("dcblock", dcblock_uuid, 0xb809efaf, 0x5681, 0x42b1,
 		 0x9e, 0xd6, 0x04, 0xbb, 0x01, 0x2d, 0xd3, 0x84);
 
 DECLARE_TR_CTX(dcblock_tr, SOF_UUID(dcblock_uuid), LOG_LEVEL_INFO);

--- a/src/audio/dcblock/dcblock.c
+++ b/src/audio/dcblock/dcblock.c
@@ -395,7 +395,7 @@ static int dcblock_reset(struct comp_dev *dev)
 /** \brief DC Blocking Filter component definition. */
 static const struct comp_driver comp_dcblock = {
 	.type = SOF_COMP_DCBLOCK,
-	.uid  = SOF_UUID(dcblock_uuid),
+	.uid  = SOF_RT_UUID(dcblock_uuid),
 	.tctx = &dcblock_tr,
 	.ops  = {
 		 .create	= dcblock_new,

--- a/src/audio/detect_test.c
+++ b/src/audio/detect_test.c
@@ -785,7 +785,7 @@ static int test_keyword_prepare(struct comp_dev *dev)
 
 static const struct comp_driver comp_keyword = {
 	.type	= SOF_COMP_KEYWORD_DETECT,
-	.uid	= SOF_UUID(keyword_uuid),
+	.uid	= SOF_RT_UUID(keyword_uuid),
 	.tctx	= &keyword_tr,
 	.ops	= {
 		.create		= test_keyword_new,

--- a/src/audio/detect_test.c
+++ b/src/audio/detect_test.c
@@ -51,7 +51,7 @@
 static const struct comp_driver comp_keyword;
 
 /* eba8d51f-7827-47b5-82ee-de6e7743af67 */
-DECLARE_SOF_UUID("kd-test", keyword_uuid, 0xeba8d51f, 0x7827, 0x47b5,
+DECLARE_SOF_RT_UUID("kd-test", keyword_uuid, 0xeba8d51f, 0x7827, 0x47b5,
 		 0x82, 0xee, 0xde, 0x6e, 0x77, 0x43, 0xaf, 0x67);
 
 DECLARE_TR_CTX(keyword_tr, SOF_UUID(keyword_uuid), LOG_LEVEL_INFO);

--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -806,7 +806,7 @@ static int eq_fir_reset(struct comp_dev *dev)
 
 static const struct comp_driver comp_eq_fir = {
 	.type = SOF_COMP_EQ_FIR,
-	.uid = SOF_UUID(eq_fir_uuid),
+	.uid = SOF_RT_UUID(eq_fir_uuid),
 	.tctx = &eq_fir_tr,
 	.ops = {
 		.create = eq_fir_new,

--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -45,7 +45,7 @@
 static const struct comp_driver comp_eq_fir;
 
 /* 43a90ce7-f3a5-41df-ac06-ba98651ae6a3 */
-DECLARE_SOF_UUID("eq-fir", eq_fir_uuid, 0x43a90ce7, 0xf3a5, 0x41df,
+DECLARE_SOF_RT_UUID("eq-fir", eq_fir_uuid, 0x43a90ce7, 0xf3a5, 0x41df,
 		 0xac, 0x06, 0xba, 0x98, 0x65, 0x1a, 0xe6, 0xa3);
 
 DECLARE_TR_CTX(eq_fir_tr, SOF_UUID(eq_fir_uuid), LOG_LEVEL_INFO);

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -34,7 +34,7 @@
 static const struct comp_driver comp_eq_iir;
 
 /* 5150c0e6-27f9-4ec8-8351-c705b642d12f */
-DECLARE_SOF_UUID("eq-iir", eq_iir_uuid, 0x5150c0e6, 0x27f9, 0x4ec8,
+DECLARE_SOF_RT_UUID("eq-iir", eq_iir_uuid, 0x5150c0e6, 0x27f9, 0x4ec8,
 		 0x83, 0x51, 0xc7, 0x05, 0xb6, 0x42, 0xd1, 0x2f);
 
 DECLARE_TR_CTX(eq_iir_tr, SOF_UUID(eq_iir_uuid), LOG_LEVEL_INFO);

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -985,7 +985,7 @@ static int eq_iir_reset(struct comp_dev *dev)
 
 static const struct comp_driver comp_eq_iir = {
 	.type = SOF_COMP_EQ_IIR,
-	.uid = SOF_UUID(eq_iir_uuid),
+	.uid = SOF_RT_UUID(eq_iir_uuid),
 	.tctx = &eq_iir_tr,
 	.ops = {
 		.create = eq_iir_new,

--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -33,7 +33,7 @@
 static const struct comp_driver comp_host;
 
 /* 8b9d100c-6d78-418f-90a3-e0e805d0852b */
-DECLARE_SOF_UUID("host", host_uuid, 0x8b9d100c, 0x6d78, 0x418f,
+DECLARE_SOF_RT_UUID("host", host_uuid, 0x8b9d100c, 0x6d78, 0x418f,
 		 0x90, 0xa3, 0xe0, 0xe8, 0x05, 0xd0, 0x85, 0x2b);
 
 DECLARE_TR_CTX(host_tr, SOF_UUID(host_uuid), LOG_LEVEL_INFO);

--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -896,7 +896,7 @@ static int host_set_attribute(struct comp_dev *dev, uint32_t type,
 
 static const struct comp_driver comp_host = {
 	.type	= SOF_COMP_HOST,
-	.uid	= SOF_UUID(host_uuid),
+	.uid	= SOF_RT_UUID(host_uuid),
 	.tctx	= &host_tr,
 	.ops	= {
 		.create		= host_new,

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -47,7 +47,7 @@
 static const struct comp_driver comp_kpb;
 
 /* d8218443-5ff3-4a4c-b388-6cfe07b9562e */
-DECLARE_SOF_UUID("kpb", kpb_uuid, 0xd8218443, 0x5ff3, 0x4a4c,
+DECLARE_SOF_RT_UUID("kpb", kpb_uuid, 0xd8218443, 0x5ff3, 0x4a4c,
 		 0xb3, 0x88, 0x6c, 0xfe, 0x07, 0xb9, 0x56, 0x2e);
 
 DECLARE_TR_CTX(kpb_tr, SOF_UUID(kpb_uuid), LOG_LEVEL_INFO);

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -1573,7 +1573,7 @@ static inline void kpb_change_state(struct comp_data *kpb,
 
 static const struct comp_driver comp_kpb = {
 	.type = SOF_COMP_KPB,
-	.uid = SOF_UUID(kpb_uuid),
+	.uid = SOF_RT_UUID(kpb_uuid),
 	.tctx = &kpb_tr,
 	.ops = {
 		.create = kpb_new,

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -31,7 +31,7 @@
 static const struct comp_driver comp_mixer;
 
 /* bc06c037-12aa-417c-9a97-89282e321a76 */
-DECLARE_SOF_UUID("mixer", mixer_uuid, 0xbc06c037, 0x12aa, 0x417c,
+DECLARE_SOF_RT_UUID("mixer", mixer_uuid, 0xbc06c037, 0x12aa, 0x417c,
 		 0x9a, 0x97, 0x89, 0x28, 0x2e, 0x32, 0x1a, 0x76);
 
 DECLARE_TR_CTX(mixer_tr, SOF_UUID(mixer_uuid), LOG_LEVEL_INFO);

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -439,7 +439,7 @@ static int mixer_prepare(struct comp_dev *dev)
 
 static const struct comp_driver comp_mixer = {
 	.type	= SOF_COMP_MIXER,
-	.uid	= SOF_UUID(mixer_uuid),
+	.uid	= SOF_RT_UUID(mixer_uuid),
 	.tctx	= &mixer_tr,
 	.ops	= {
 		.create		= mixer_new,

--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -33,13 +33,13 @@
 static const struct comp_driver comp_mux;
 
 /* c607ff4d-9cb6-49dc-b678-7da3c63ea557 */
-DECLARE_SOF_UUID("mux", mux_uuid, 0xc607ff4d, 0x9cb6, 0x49dc,
+DECLARE_SOF_RT_UUID("mux", mux_uuid, 0xc607ff4d, 0x9cb6, 0x49dc,
 		 0xb6, 0x78, 0x7d, 0xa3, 0xc6, 0x3e, 0xa5, 0x57);
 
 DECLARE_TR_CTX(mux_tr, SOF_UUID(mux_uuid), LOG_LEVEL_INFO);
 
 /* c4b26868-1430-470e-a089-15d1c77f851a */
-DECLARE_SOF_UUID("demux", demux_uuid, 0xc4b26868, 0x1430, 0x470e,
+DECLARE_SOF_RT_UUID("demux", demux_uuid, 0xc4b26868, 0x1430, 0x470e,
 		 0xa0, 0x89, 0x15, 0xd1, 0xc7, 0x7f, 0x85, 0x1a);
 
 DECLARE_TR_CTX(demux_tr, SOF_UUID(demux_uuid), LOG_LEVEL_INFO);

--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -504,7 +504,7 @@ static int mux_trigger(struct comp_dev *dev, int cmd)
 
 static const struct comp_driver comp_mux = {
 	.type	= SOF_COMP_MUX,
-	.uid	= SOF_UUID(mux_uuid),
+	.uid	= SOF_RT_UUID(mux_uuid),
 	.tctx	= &mux_tr,
 	.ops	= {
 		.create		= mux_new,
@@ -524,7 +524,7 @@ static SHARED_DATA struct comp_driver_info comp_mux_info = {
 
 static const struct comp_driver comp_demux = {
 	.type	= SOF_COMP_DEMUX,
-	.uid	= SOF_UUID(demux_uuid),
+	.uid	= SOF_RT_UUID(demux_uuid),
 	.tctx	= &demux_tr,
 	.ops	= {
 		.create		= mux_new,

--- a/src/audio/pipeline.c
+++ b/src/audio/pipeline.c
@@ -42,7 +42,7 @@ struct pipeline_data {
 };
 
 /* 4e934adb-b0ec-4d33-a086-c1022f921321 */
-DECLARE_SOF_UUID("pipe", pipe_uuid, 0x4e934adb, 0xb0ec, 0x4d33,
+DECLARE_SOF_RT_UUID("pipe", pipe_uuid, 0x4e934adb, 0xb0ec, 0x4d33,
 		 0xa0, 0x86, 0xc1, 0x02, 0x2f, 0x92, 0x13, 0x21);
 
 DECLARE_TR_CTX(pipe_tr, SOF_UUID(pipe_uuid), LOG_LEVEL_INFO);

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -519,7 +519,7 @@ static int selector_reset(struct comp_dev *dev)
 /** \brief Selector component definition. */
 static const struct comp_driver comp_selector = {
 	.type	= SOF_COMP_SELECTOR,
-	.uid	= SOF_UUID(selector_uuid),
+	.uid	= SOF_RT_UUID(selector_uuid),
 	.tctx	= &selector_tr,
 	.ops	= {
 		.create		= selector_new,

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -38,7 +38,7 @@
 static const struct comp_driver comp_selector;
 
 /* 55a88ed5-3d18-46ca-88f1-0ee6eae9930f */
-DECLARE_SOF_UUID("selector", selector_uuid, 0x55a88ed5, 0x3d18, 0x46ca,
+DECLARE_SOF_RT_UUID("selector", selector_uuid, 0x55a88ed5, 0x3d18, 0x46ca,
 		 0x88, 0xf1, 0x0e, 0xe6, 0xea, 0xe9, 0x93, 0x0f);
 
 DECLARE_TR_CTX(selector_tr, SOF_UUID(selector_uuid), LOG_LEVEL_INFO);

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -51,7 +51,7 @@
 static const struct comp_driver comp_src;
 
 /* c1c5326d-8390-46b4-aa47-95c3beca6550 */
-DECLARE_SOF_UUID("src", src_uuid, 0xc1c5326d, 0x8390, 0x46b4,
+DECLARE_SOF_RT_UUID("src", src_uuid, 0xc1c5326d, 0x8390, 0x46b4,
 		 0xaa, 0x47, 0x95, 0xc3, 0xbe, 0xca, 0x65, 0x50);
 
 DECLARE_TR_CTX(src_tr, SOF_UUID(src_uuid), LOG_LEVEL_INFO);

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -914,7 +914,7 @@ static int src_reset(struct comp_dev *dev)
 
 static const struct comp_driver comp_src = {
 	.type = SOF_COMP_SRC,
-	.uid = SOF_UUID(src_uuid),
+	.uid = SOF_RT_UUID(src_uuid),
 	.tctx = &src_tr,
 	.ops = {
 		.create = src_new,

--- a/src/audio/switch.c
+++ b/src/audio/switch.c
@@ -16,7 +16,7 @@
 static const struct comp_driver comp_switch;
 
 /* 385cc44b-f34e-4b9b-8be0-535c5f43a825 */
-DECLARE_SOF_UUID("switch", switch_uuid, 0x385cc44b, 0xf34e, 0x4b9b,
+DECLARE_SOF_RT_UUID("switch", switch_uuid, 0x385cc44b, 0xf34e, 0x4b9b,
 		 0x8b, 0xe0, 0x53, 0x5c, 0x5f, 0x43, 0xa8, 0x25);
 
 DECLARE_TR_CTX(switch_tr, SOF_UUID(switch_uuid), LOG_LEVEL_INFO);

--- a/src/audio/switch.c
+++ b/src/audio/switch.c
@@ -66,7 +66,7 @@ static int switch_prepare(struct comp_dev *dev)
 
 static const struct comp_driver comp_switch = {
 	.type	= SOF_COMP_SWITCH,
-	.uid	= SOF_UUID(switch_uuid),
+	.uid	= SOF_RT_UUID(switch_uuid),
 	.tctx	= &switch_tr,
 	.ops	= {
 		.create		= switch_new,

--- a/src/audio/tone.c
+++ b/src/audio/tone.c
@@ -45,7 +45,7 @@
 static const struct comp_driver comp_tone;
 
 /* 04e3f894-2c5c-4f2e-8dc1-694eeaab53fa */
-DECLARE_SOF_UUID("tone", tone_uuid, 0x04e3f894, 0x2c5c, 0x4f2e,
+DECLARE_SOF_RT_UUID("tone", tone_uuid, 0x04e3f894, 0x2c5c, 0x4f2e,
 		 0x8d, 0xc1, 0x69, 0x4e, 0xea, 0xab, 0x53, 0xfa);
 
 DECLARE_TR_CTX(tone_tr, SOF_UUID(tone_uuid), LOG_LEVEL_INFO);

--- a/src/audio/tone.c
+++ b/src/audio/tone.c
@@ -703,7 +703,7 @@ static int tone_reset(struct comp_dev *dev)
 
 static const struct comp_driver comp_tone = {
 	.type = SOF_COMP_TONE,
-	.uid = SOF_UUID(tone_uuid),
+	.uid = SOF_RT_UUID(tone_uuid),
 	.tctx = &tone_tr,
 	.ops = {
 		.create = tone_new,

--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -47,7 +47,7 @@
 static const struct comp_driver comp_volume;
 
 /* b77e677e-5ff4-4188-af14-fba8bdbf8682 */
-DECLARE_SOF_UUID("volume", volume_uuid, 0xb77e677e, 0x5ff4, 0x4188,
+DECLARE_SOF_RT_UUID("volume", volume_uuid, 0xb77e677e, 0x5ff4, 0x4188,
 		 0xaf, 0x14, 0xfb, 0xa8, 0xbd, 0xbf, 0x86, 0x82);
 
 DECLARE_TR_CTX(volume_tr, SOF_UUID(volume_uuid), LOG_LEVEL_INFO);

--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -860,7 +860,7 @@ static int volume_reset(struct comp_dev *dev)
 /** \brief Volume component definition. */
 static const struct comp_driver comp_volume = {
 	.type	= SOF_COMP_VOLUME,
-	.uid	= SOF_UUID(volume_uuid),
+	.uid	= SOF_RT_UUID(volume_uuid),
 	.tctx	= &volume_tr,
 	.ops	= {
 		.create		= volume_new,

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -385,10 +385,10 @@ struct comp_ops {
  * - used by all other component types.
  */
 struct comp_driver {
-	uint32_t type;		/**< SOF_COMP_ for driver */
+	uint32_t type;			/**< SOF_COMP_ for driver */
 	const struct sof_uuid *uid;	/**< Address to UUID value */
-	struct tr_ctx *tctx;	/**< Pointer to trace context */
-	struct comp_ops ops;	/**< component operations */
+	struct tr_ctx *tctx;		/**< Pointer to trace context */
+	struct comp_ops ops;		/**< component operations */
 };
 
 /** \brief Holds constant pointer to component driver */

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -386,7 +386,7 @@ struct comp_ops {
  */
 struct comp_driver {
 	uint32_t type;		/**< SOF_COMP_ for driver */
-	uint32_t uid;		/**< Address of uuid_entry */
+	const struct sof_uuid *uid;	/**< Address to UUID value */
 	struct tr_ctx *tctx;	/**< Pointer to trace context */
 	struct comp_ops ops;	/**< component operations */
 };

--- a/src/include/sof/lib/uuid.h
+++ b/src/include/sof/lib/uuid.h
@@ -59,12 +59,18 @@ struct sof_uuid_entry {
 #define DECLARE_SOF_UUID(entity_name, uuid_name,			\
 			 va, vb, vc,					\
 			 vd0, vd1, vd2, vd3, vd4, vd5, vd6, vd7)
+#define DECLARE_SOF_RT_UUID(entity_name, uuid_name,			\
+			 va, vb, vc,					\
+			 vd0, vd1, vd2, vd3, vd4, vd5, vd6, vd7)
 
 #define SOF_UUID(uuid_name) 0
 
 #else
 
 /** \brief Declares UUID (aaaaaaaa-bbbb-cccc-d0d1-d2d3d4d5d6d7) and name.
+ *
+ * UUID value from variables declared with this macro are unaccessible in
+ * runtime code - UUID dictionary from ldc file is needed get UUID value.
  *
  * \param entity_name Name of the object pinted by the software tools.
  * \param uuid_name Uuid symbol name used with SOF_UUID().
@@ -84,17 +90,48 @@ struct sof_uuid_entry {
 			 va, vb, vc,					\
 			 vd0, vd1, vd2, vd3, vd4, vd5, vd6, vd7)	\
 	__section(".static_uuids")					\
-	static const struct sof_uuid_entry uuid_name = {		\
+	static const struct sof_uuid_entry uuid_name ## _ldc = {	\
 		{.a = va, .b = vb, .c = vc,				\
 		 .d = {vd0, vd1, vd2, vd3, vd4, vd5, vd6, vd7}},	\
 		entity_name "\0"					\
 	}
 
+/** \brief Declares runtime UUID (aaaaaaaa-bbbb-cccc-d0d1-d2d3d4d5d6d7) and name.
+ *
+ * UUID value from variables declared with this macro are accessible in
+ * runtime code - to dereference use SOF_RT_UUID()
+ *
+ * \param entity_name Name of the object pinted by the software tools.
+ * \param uuid_name Uuid symbol name used with SOF_UUID() and SOF_RT_UUID().
+ * \param va aaaaaaaa value.
+ * \param vb bbbb value.
+ * \param vc cccc value.
+ * \param vd0 d0 value (note how d0 and d1 are grouped in formatted uuid)
+ * \param vd1 d1 value.
+ * \param vd2 d2 value.
+ * \param vd3 d3 value.
+ * \param vd4 d4 value.
+ * \param vd5 d5 value.
+ * \param vd6 d6 value.
+ * \param vd7 d7 value.
+ */
+#define DECLARE_SOF_RT_UUID(entity_name, uuid_name,			\
+			 va, vb, vc,					\
+			 vd0, vd1, vd2, vd3, vd4, vd5, vd6, vd7)	\
+	DECLARE_SOF_UUID(entity_name, uuid_name,			\
+			 va, vb, vc,					\
+			 vd0, vd1, vd2, vd3, vd4, vd5, vd6, vd7);	\
+	const struct sof_uuid uuid_name = {				\
+		.a = va, .b = vb, .c = vc,				\
+		.d = {vd0, vd1, vd2, vd3, vd4, vd5, vd6, vd7}		\
+	}
+
 /** \brief Creates local unique 32-bit representation of UUID structure.
  *
- * \param uuid_name UUID symbol name declared with DECLARE_SOF_UUID().
+ * \param uuid_name UUID symbol name declared with DECLARE_SOF_UUID() or
+ *		    DECLARE_SOF_RT_UUID().
  */
-#define SOF_UUID(uuid_name) ((uintptr_t)&(uuid_name))
+#define SOF_UUID(uuid_name) ((uintptr_t)&(uuid_name ## _ldc))
 #endif
 
 /** @}*/

--- a/src/include/sof/lib/uuid.h
+++ b/src/include/sof/lib/uuid.h
@@ -64,6 +64,7 @@ struct sof_uuid_entry {
 			 vd0, vd1, vd2, vd3, vd4, vd5, vd6, vd7)
 
 #define SOF_UUID(uuid_name) 0
+#define SOF_RT_UUID(uuid_name) NULL
 
 #else
 
@@ -132,6 +133,12 @@ struct sof_uuid_entry {
  *		    DECLARE_SOF_RT_UUID().
  */
 #define SOF_UUID(uuid_name) ((uintptr_t)&(uuid_name ## _ldc))
+
+/** \brief Dereference unique 32-bit representation of UUID structure in runtime.
+ *
+ * \param uuid_name UUID symbol name declared with DECLARE_SOF_RT_UUID().
+ */
+#define SOF_RT_UUID(uuid_name) (&(uuid_name))
 #endif
 
 /** @}*/

--- a/tools/testbench/file.c
+++ b/tools/testbench/file.c
@@ -21,6 +21,11 @@
 #include "testbench/common_test.h"
 #include "testbench/file.h"
 
+/* bfc7488c-75aa-4ce8-9bde-d8da08a698c2 */
+DECLARE_SOF_UUID("file", file_uuid, 0xbfc7488c, 0x75aa, 0x4ce8,
+		 0x9d, 0xbe, 0xd8, 0xda, 0x08, 0xa6, 0x98, 0xc2);
+DECLARE_TR_CTX(file_tr, SOF_UUID(file_uuid), LOG_LEVEL_INFO);
+
 static const struct comp_driver comp_file_dai;
 static const struct comp_driver comp_file_host;
 
@@ -759,6 +764,8 @@ static int file_get_hw_params(struct comp_dev *dev,
 
 static const struct comp_driver comp_file_host = {
 	.type = SOF_COMP_HOST,
+	.uid	= SOF_UUID(file_tr),
+	.tctx	= &file_tr,
 	.ops = {
 		.create = file_new,
 		.free = file_free,
@@ -769,10 +776,13 @@ static const struct comp_driver comp_file_host = {
 		.prepare = file_prepare,
 		.reset = file_reset,
 	},
+
 };
 
 static const struct comp_driver comp_file_dai = {
 	.type = SOF_COMP_DAI,
+	.uid	= SOF_UUID(file_tr),
+	.tctx	= &file_tr,
 	.ops = {
 		.create = file_new,
 		.free = file_free,


### PR DESCRIPTION
A few UUID entries, related with components from topology,
should be loaded into SRAM to allow runtime comparison with
value in IPC message during component creation. UUID of the
components whose are not created by IPC message are not needed
in runtime, so there should not be there to reduce memory
consumtion.

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>

It's a part of https://github.com/thesofproject/sof/pull/2920
@keyonjie please check if I choose 'RT` UUID for all needed components.