### PR TITLE
Kconfig: use relative 'rsource' paths so SOF can be a Zephyr module

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -163,7 +163,7 @@ config INTERRUPT_LEVEL_5
 	  Select if the platform supports any interrupts of level 5.
 	  Disabling this option allows for less memory consumption.
 
-source "src/Kconfig"
+rsource "src/Kconfig"
 
 choice
 	prompt "Optimization"

--- a/src/Kconfig
+++ b/src/Kconfig
@@ -1,13 +1,13 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-source "src/arch/Kconfig"
+rsource "arch/Kconfig"
 
-source "src/platform/Kconfig"
+rsource "platform/Kconfig"
 
-source "src/drivers/Kconfig"
+rsource "drivers/Kconfig"
 
-source "src/audio/Kconfig"
+rsource "audio/Kconfig"
 
-source "src/trace/Kconfig"
+rsource "trace/Kconfig"
 
-source "src/probe/Kconfig"
+rsource "probe/Kconfig"

--- a/src/arch/Kconfig
+++ b/src/arch/Kconfig
@@ -2,4 +2,4 @@
 
 # Generic architecture configs
 
-source "src/arch/$(ARCH)/Kconfig"
+rsource "$(ARCH)/Kconfig"

--- a/src/drivers/Kconfig
+++ b/src/drivers/Kconfig
@@ -2,9 +2,9 @@
 
 menu "Drivers"
 
-source "src/drivers/intel/Kconfig"
+rsource "intel/Kconfig"
 
-source "src/drivers/dw/Kconfig"
+rsource "dw/Kconfig"
 
 config DUMMY_DMA
 	bool "Dummy DMA (software DMA driver)"


### PR DESCRIPTION
As documented in https://docs.zephyrproject.org/2.2.0/guides/modules.html,
Zephyr and Kconfiglib support merging Kconfig menus across multiple git
repos. This requires relative inclusion paths.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>