### PR TITLE
.gitignore: don't ignore all .* hidden files in every subdirectory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,6 @@
 *.dis
 *.lst
 *.log
-.*
 *.html
 *.js
 *.png


### PR DESCRIPTION
That's too extreme and was probably accidental because the rest of
commit d721347ad945 ("gitignore: ignore boot loaders and binaries.")
seems not related at all.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>