### PR TITLE
alloc: Correct path for the memory.h

### DIFF
--- a/src/include/sof/lib/alloc.h
+++ b/src/include/sof/lib/alloc.h
@@ -25,7 +25,7 @@
 #include <stdint.h>
 
 #include <sof/lib/cache.h>
-#include <memory.h>
+#include <sof/lib/memory.h>
 
 /** \addtogroup alloc_api Memory Allocation API
  *  @{


### PR DESCRIPTION
Correct my mistake.