### PR TITLE
zephyr: use Zephyr's Kconfig and temporarily dummify sof-config.h …

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -163,7 +163,7 @@ config INTERRUPT_LEVEL_5
 	  Select if the platform supports any interrupts of level 5.
 	  Disabling this option allows for less memory consumption.
 
-source "src/Kconfig"
+rsource "src/Kconfig"
 
 choice
 	prompt "Optimization"

--- a/src/Kconfig
+++ b/src/Kconfig
@@ -1,13 +1,13 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-source "src/arch/Kconfig"
+rsource "arch/Kconfig"
 
-source "src/platform/Kconfig"
+rsource "platform/Kconfig"
 
-source "src/drivers/Kconfig"
+rsource "drivers/Kconfig"
 
-source "src/audio/Kconfig"
+rsource "audio/Kconfig"
 
-source "src/trace/Kconfig"
+rsource "trace/Kconfig"
 
-source "src/probe/Kconfig"
+rsource "probe/Kconfig"

--- a/src/arch/Kconfig
+++ b/src/arch/Kconfig
@@ -2,4 +2,4 @@
 
 # Generic architecture configs
 
-source "src/arch/$(ARCH)/Kconfig"
+rsource "$(ARCH)/Kconfig"

--- a/src/drivers/Kconfig
+++ b/src/drivers/Kconfig
@@ -2,9 +2,9 @@
 
 menu "Drivers"
 
-source "src/drivers/intel/cavs/Kconfig"
+rsource "intel/cavs/Kconfig"
 
-source "src/drivers/dw/Kconfig"
+rsource "dw/Kconfig"
 
 config DUMMY_DMA
 	bool "Dummy DMA (software DMA driver)"

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -334,47 +334,11 @@ else()
 	set(PYTHON3 "${Python3_EXECUTABLE}")
 endif()
 
-# Looks for defconfig files in arch directory
-set(DEFCONFIGS_DIRECTORY "${SOF_ROOT_SOURCE_DIRECTORY}/../src/arch/${ARCH}/configs")
-file(GLOB DEFCONFIG_PATHS "${DEFCONFIGS_DIRECTORY}/*_defconfig")
-
-# Adds dependency on defconfigs directory
-set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${DEFCONFIGS_DIRECTORY})
-
-# create a sof-config.h for target. 
-foreach(defconfig_path ${DEFCONFIG_PATHS})
-	get_filename_component(defconfig_name ${defconfig_path} NAME)
-	add_custom_target(
-		# Seed the .config with a _defconfig
-		${defconfig_name}
-		COMMAND ${CMAKE_COMMAND} -E copy
-			${defconfig_path}
-			${DOT_CONFIG_PATH}
-		# Expland and normalize the .config
-		COMMAND ${CMAKE_COMMAND} -E env
-			srctree=${SOF_ROOT_SOURCE_DIRECTORY}/../
-			ARCH=${ARCH}
-			KCONFIG_CONFIG=${DOT_CONFIG_PATH}
-			${PYTHON3} ${SOF_ROOT_SOURCE_DIRECTORY}/../scripts/kconfig/olddefconfig.py
-			${SOF_ROOT_SOURCE_DIRECTORY}/../Kconfig
-		# Generate sof-config.h from .config
-		COMMAND ${CMAKE_COMMAND} -E env
-			srctree=${SOF_ROOT_SOURCE_DIRECTORY}/../
-			CC_VERSION_TEXT="zephyr"
-			ARCH=${ARCH}
-			KCONFIG_CONFIG=${DOT_CONFIG_PATH}
-			${PYTHON3} ${SOF_ROOT_SOURCE_DIRECTORY}/../scripts/kconfig/genconfig.py
-			--header-path ${CONFIG_H_PATH}
-			${SOF_ROOT_SOURCE_DIRECTORY}/../Kconfig
-		WORKING_DIRECTORY ${GENERATED_DIRECTORY}
-		COMMENT "sof/zephyr/CMakeLists.txt using ${defconfig_name}"
-		VERBATIM
-		USES_TERMINAL
-	)
-endforeach()
-
-# TODO: detect GCC vs XCC builds and apply DEFCONFIG_PATCH= "_gcc"
-add_dependencies(modules_sof ${PLATFORM}${DEFCONFIG_PATCH}_defconfig)
+# FIXME: after some mileage revert 6d2f666fadd1 and rename sof-config.h
+# back to config.h Also move it out of the source directory.
+file(WRITE ${CONFIG_H_PATH}
+  "// Nothing here: Zephyr gives generated/autoconf.h for free with -imacros
+")
 
 # create version.h
 include(../scripts/cmake/version.cmake)

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,2 +1,3 @@
 build:
         cmake: ./zephyr
+        kconfig: Kconfig


### PR DESCRIPTION
[ this MUST be merged at the same time than https://github.com/thesofproject/zephyr/pull/50 ]

This is a small commit but with a very large ripple effect on the
entangled web of .h files, so it keeps a dummy sof-config.h file for
now to minimize the number of lines changed; so it can very easily be
reverted for testing purposes if needed. More below.

This commit also moves the creation of (the dummy) [sof-]config.h and
others entirely at cmake time instead of make time, which fixes the
issue where make -j1 used sof-config.h from the previous build and make
-j2 uses sof-config.h from the current build (please don't build
anything else in the source directory again)

Back to the main topic: I have compared the new, combined .config and
combined config.h files with their separate parts before this commit and
besides two de-duplicated values (CONFIG_SMP and CONFIG_DEBUG), the
combined files are exactly the same as the sum of the previously
separate parts.

HOWEVER, strictly identical configuration is unfortunately NOT enough to
build the same objects because of the complex nest of .h files including
each other _in semi-random order_ and the fact we don't use -Wundef. So
to verify this commit doesn't actually change anything I compared object
files. Good news: I found only one .obj before/after difference,
namely power_down.S Thanks to diffoscope I root-caused this to
sof-config.h (and CONFIG_LP_MEMORY_BANKS) being before this commit
included _too late_ in power_down.S and defaulting to zero. So this
commit "accidentally" fixes that thanks to Zephyr's -imacros magic and
may even save some power and help with climate change, who knows.

It may also fix other undefined macros but if any they don't matter in
the single, up_squared_adsp samples/audio/sof/prj.conf configuration I
tested this with.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>