### PR TITLE
mn: cleanup definitions

### DIFF
--- a/src/include/sof/drivers/mn.h
+++ b/src/include/sof/drivers/mn.h
@@ -8,24 +8,11 @@
 #ifndef __SOF_DRIVERS_MN_H__
 #define __SOF_DRIVERS_MN_H__
 
+#include <platform/drivers/mn.h>
 #include <sof/sof.h>
+#include <config.h>
 #include <stdbool.h>
 #include <stdint.h>
-
-/** \brief Offset of MCLK Divider Control Register. */
-#define MN_MDIVCTRL 0x0
-
-/** \brief Enables the output of MCLK Divider. */
-#define MN_MDIVCTRL_M_DIV_ENABLE BIT(0)
-
-/** \brief Offset of MCLK Divider x Ratio Register. */
-#define MN_MDIVR(x) (0x80 + (x) * 0x4)
-
-/** \brief Offset of BCLK x M/N Divider M Value Register. */
-#define MN_MDIV_M_VAL(x) (0x100 + (x) * 0x8 + 0x0)
-
-/** \brief Offset of BCLK x M/N Divider N Value Register. */
-#define MN_MDIV_N_VAL(x) (0x100 + (x) * 0x8 + 0x4)
 
 /**
  * \brief Initializes MN driver.
@@ -50,6 +37,7 @@ int mn_set_mclk(uint16_t mclk_id, uint32_t mclk_rate);
  */
 void mn_release_mclk(uint32_t mclk_id);
 
+#if CONFIG_INTEL_MN
 /**
  * \brief Finds and sets valid combination of BCLK source and M/N to
  *	  achieve requested BCLK rate.
@@ -77,6 +65,7 @@ void mn_release_bclk(uint32_t dai_index);
  * \param[in] dai_index DAI index (SSP port).
  */
 void mn_reset_bclk_divider(uint32_t dai_index);
+#endif
 
 /**
  * \brief Retrieves M/N dividers structure.

--- a/src/include/sof/drivers/ssp.h
+++ b/src/include/sof/drivers/ssp.h
@@ -209,11 +209,6 @@ extern const struct dai_driver ssp_driver;
 #endif
 
 #if CONFIG_CAVS
-#define MNDSS(x)	SET_BITS(21, 20, x)
-#define MCDSS(x)	SET_BITS(17, 16, x)
-#endif
-
-#if CONFIG_CAVS
 
 #include <sof/lib/clk.h>
 

--- a/src/platform/apollolake/include/platform/drivers/mn.h
+++ b/src/platform/apollolake/include/platform/drivers/mn.h
@@ -1,0 +1,21 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2020 Intel Corporation. All rights reserved.
+ *
+ * Author: Janusz Jankowski <janusz.jankowski@linux.intel.com>
+ */
+
+#ifdef __SOF_DRIVERS_MN_H__
+
+#ifndef __PLATFORM_DRIVERS_MN_H__
+#define __PLATFORM_DRIVERS_MN_H__
+
+#include <cavs/drivers/mn.h>
+
+#endif /* __PLATFORM_DRIVERS_MN_H__ */
+
+#else
+
+#error "This file shouldn't be included from outside of sof/drivers/mn.h"
+
+#endif /* __SOF_DRIVERS_MN_H__ */

--- a/src/platform/apollolake/include/platform/lib/shim.h
+++ b/src/platform/apollolake/include/platform/lib/shim.h
@@ -292,12 +292,12 @@ static inline void sw_reg_write(uint32_t reg, uint32_t val)
 		SRAM_ALIAS_OFFSET) + reg)) = val;
 }
 
-static inline uint32_t mn_reg_read(uint32_t reg)
+static inline uint32_t mn_reg_read(uint32_t reg, uint32_t id)
 {
 	return *((volatile uint32_t*)(MN_BASE + reg));
 }
 
-static inline void mn_reg_write(uint32_t reg, uint32_t val)
+static inline void mn_reg_write(uint32_t reg, uint32_t id, uint32_t val)
 {
 	*((volatile uint32_t*)(MN_BASE + reg)) = val;
 }

--- a/src/platform/cannonlake/include/platform/drivers/mn.h
+++ b/src/platform/cannonlake/include/platform/drivers/mn.h
@@ -1,0 +1,21 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2020 Intel Corporation. All rights reserved.
+ *
+ * Author: Janusz Jankowski <janusz.jankowski@linux.intel.com>
+ */
+
+#ifdef __SOF_DRIVERS_MN_H__
+
+#ifndef __PLATFORM_DRIVERS_MN_H__
+#define __PLATFORM_DRIVERS_MN_H__
+
+#include <cavs/drivers/mn.h>
+
+#endif /* __PLATFORM_DRIVERS_MN_H__ */
+
+#else
+
+#error "This file shouldn't be included from outside of sof/drivers/mn.h"
+
+#endif /* __SOF_DRIVERS_MN_H__ */

--- a/src/platform/cannonlake/include/platform/lib/shim.h
+++ b/src/platform/cannonlake/include/platform/lib/shim.h
@@ -321,12 +321,12 @@ static inline void sw_reg_write(uint32_t reg, uint32_t val)
 		SRAM_ALIAS_OFFSET) + reg)) = val;
 }
 
-static inline uint32_t mn_reg_read(uint32_t reg)
+static inline uint32_t mn_reg_read(uint32_t reg, uint32_t id)
 {
 	return *((volatile uint32_t*)(MN_BASE + reg));
 }
 
-static inline void mn_reg_write(uint32_t reg, uint32_t val)
+static inline void mn_reg_write(uint32_t reg, uint32_t id, uint32_t val)
 {
 	*((volatile uint32_t*)(MN_BASE + reg)) = val;
 }

--- a/src/platform/icelake/include/platform/drivers/mn.h
+++ b/src/platform/icelake/include/platform/drivers/mn.h
@@ -1,0 +1,21 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2020 Intel Corporation. All rights reserved.
+ *
+ * Author: Janusz Jankowski <janusz.jankowski@linux.intel.com>
+ */
+
+#ifdef __SOF_DRIVERS_MN_H__
+
+#ifndef __PLATFORM_DRIVERS_MN_H__
+#define __PLATFORM_DRIVERS_MN_H__
+
+#include <cavs/drivers/mn.h>
+
+#endif /* __PLATFORM_DRIVERS_MN_H__ */
+
+#else
+
+#error "This file shouldn't be included from outside of sof/drivers/mn.h"
+
+#endif /* __SOF_DRIVERS_MN_H__ */

--- a/src/platform/icelake/include/platform/lib/shim.h
+++ b/src/platform/icelake/include/platform/lib/shim.h
@@ -315,12 +315,12 @@ static inline void sw_reg_write(uint32_t reg, uint32_t val)
 		SRAM_ALIAS_OFFSET) + reg)) = val;
 }
 
-static inline uint32_t mn_reg_read(uint32_t reg)
+static inline uint32_t mn_reg_read(uint32_t reg, uint32_t id)
 {
 	return *((volatile uint32_t*)(MN_BASE + reg));
 }
 
-static inline void mn_reg_write(uint32_t reg, uint32_t val)
+static inline void mn_reg_write(uint32_t reg, uint32_t id, uint32_t val)
 {
 	*((volatile uint32_t*)(MN_BASE + reg)) = val;
 }

--- a/src/platform/intel/cavs/include/cavs/drivers/mn.h
+++ b/src/platform/intel/cavs/include/cavs/drivers/mn.h
@@ -1,0 +1,42 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2020 Intel Corporation. All rights reserved.
+ *
+ * Author: Janusz Jankowski <janusz.jankowski@linux.intel.com>
+ */
+
+#ifdef __PLATFORM_DRIVERS_MN_H__
+
+#ifndef __CAVS_DRIVERS_MN_H__
+#define __CAVS_DRIVERS_MN_H__
+
+#include <sof/bit.h>
+
+/** \brief Offset of MCLK Divider Control Register. */
+#define MN_MDIVCTRL 0x0
+
+/** \brief Enables the output of MCLK Divider. */
+#define MN_MDIVCTRL_M_DIV_ENABLE BIT(0)
+
+/** \brief Offset of MCLK Divider x Ratio Register. */
+#define MN_MDIVR(x) (0x80 + (x) * 0x4)
+
+/** \brief Bits for setting MCLK source clock. */
+#define MCDSS(x)	SET_BITS(17, 16, x)
+
+/** \brief Offset of BCLK x M/N Divider M Value Register. */
+#define MN_MDIV_M_VAL(x) (0x100 + (x) * 0x8 + 0x0)
+
+/** \brief Offset of BCLK x M/N Divider N Value Register. */
+#define MN_MDIV_N_VAL(x) (0x100 + (x) * 0x8 + 0x4)
+
+/** \brief Bits for setting M/N source clock. */
+#define MNDSS(x)	SET_BITS(21, 20, x)
+
+#endif /* __CAVS_DRIVERS_MN_H__ */
+
+#else
+
+#error "This file shouldn't be included from outside of platform/drivers/mn.h"
+
+#endif /* __PLATFORM_DRIVERS_MN_H__ */

--- a/src/platform/suecreek/include/platform/drivers/mn.h
+++ b/src/platform/suecreek/include/platform/drivers/mn.h
@@ -1,0 +1,21 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2020 Intel Corporation. All rights reserved.
+ *
+ * Author: Janusz Jankowski <janusz.jankowski@linux.intel.com>
+ */
+
+#ifdef __SOF_DRIVERS_MN_H__
+
+#ifndef __PLATFORM_DRIVERS_MN_H__
+#define __PLATFORM_DRIVERS_MN_H__
+
+#include <cavs/drivers/mn.h>
+
+#endif /* __PLATFORM_DRIVERS_MN_H__ */
+
+#else
+
+#error "This file shouldn't be included from outside of sof/drivers/mn.h"
+
+#endif /* __SOF_DRIVERS_MN_H__ */

--- a/src/platform/suecreek/include/platform/lib/shim.h
+++ b/src/platform/suecreek/include/platform/lib/shim.h
@@ -313,12 +313,12 @@ static inline void sw_reg_write(uint32_t reg, uint32_t val)
 }
 #endif
 
-static inline uint32_t mn_reg_read(uint32_t reg)
+static inline uint32_t mn_reg_read(uint32_t reg, uint32_t id)
 {
 	return *((volatile uint32_t*)(MN_BASE + reg));
 }
 
-static inline void mn_reg_write(uint32_t reg, uint32_t val)
+static inline void mn_reg_write(uint32_t reg, uint32_t id, uint32_t val)
 {
 	*((volatile uint32_t*)(MN_BASE + reg)) = val;
 }

--- a/src/platform/tigerlake/include/platform/drivers/mn.h
+++ b/src/platform/tigerlake/include/platform/drivers/mn.h
@@ -1,0 +1,21 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2020 Intel Corporation. All rights reserved.
+ *
+ * Author: Janusz Jankowski <janusz.jankowski@linux.intel.com>
+ */
+
+#ifdef __SOF_DRIVERS_MN_H__
+
+#ifndef __PLATFORM_DRIVERS_MN_H__
+#define __PLATFORM_DRIVERS_MN_H__
+
+#include <cavs/drivers/mn.h>
+
+#endif /* __PLATFORM_DRIVERS_MN_H__ */
+
+#else
+
+#error "This file shouldn't be included from outside of sof/drivers/mn.h"
+
+#endif /* __SOF_DRIVERS_MN_H__ */

--- a/src/platform/tigerlake/include/platform/lib/shim.h
+++ b/src/platform/tigerlake/include/platform/lib/shim.h
@@ -324,12 +324,12 @@ static inline void sw_reg_write(uint32_t reg, uint32_t val)
 		SRAM_ALIAS_OFFSET) + reg)) = val;
 }
 
-static inline uint32_t mn_reg_read(uint32_t reg)
+static inline uint32_t mn_reg_read(uint32_t reg, uint32_t id)
 {
 	return *((volatile uint32_t*)(MN_BASE + reg));
 }
 
-static inline void mn_reg_write(uint32_t reg, uint32_t val)
+static inline void mn_reg_write(uint32_t reg, uint32_t id, uint32_t val)
 {
 	*((volatile uint32_t*)(MN_BASE + reg)) = val;
 }


### PR DESCRIPTION
Cleanups MCLK and MN related functionality. Moves some defines
from ssp to mn header. Also hides some definitions in platform
specific headers.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>