### PR TITLE
init: add missing inclusion

### DIFF
--- a/src/init/init.c
+++ b/src/init/init.c
@@ -10,6 +10,7 @@
  */
 
 #include <sof/debug/panic.h>
+#include <sof/drivers/interrupt.h>
 #include <sof/init.h>
 #include <sof/lib/cpu.h>
 #include <sof/lib/memory.h>


### PR DESCRIPTION
Adds misssing inclusion of drivers\interrupt.h.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>