### PR TITLE
README.md: fix Travis badge not to show the random PR of the moment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Sound Open Firmware
 
 ### Status
-[![Build Status](https://travis-ci.org/thesofproject/sof.svg?branch=master)](https://travis-ci.org/thesofproject/sof)
+[![Build Status](https://travis-ci.org/thesofproject/sof.svg?branch=master)](https://travis-ci.org/thesofproject/sof/branches)
 [![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/thesofproject/community)
 [![IRC chat](https://img.shields.io/badge/IRC-%23sof-1e72ff.svg)](https://www.irccloud.com/invite?channel=%23sof&hostname=irc.freenode.net&port=6697&ssl=1)
 


### PR DESCRIPTION
As discussed in PR #2964, the Travis badge shows the status of the
master branch but it links to the random PR of the moment. Fix that link
to point to the more useful "branches" page which has the master branch
at the top.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>