### PR TITLE
pcm_converter: Fix first output sample pointer calculation

### DIFF
--- a/src/audio/pcm_converter/pcm_converter.c
+++ b/src/audio/pcm_converter/pcm_converter.c
@@ -23,7 +23,7 @@ void pcm_convert_as_linear(const struct audio_stream *source, uint32_t ioffset,
 	char *r_ptr = audio_stream_get_frag(source, source->r_ptr, ioffset,
 					    s_size_in);
 	char *w_ptr = audio_stream_get_frag(sink, sink->w_ptr, ooffset,
-					    s_size_in);
+					    s_size_out);
 	int i = 0;
 	int chunk;
 	int N1, N2;


### PR DESCRIPTION
Output sample size is unrelated wit input one. To calculate
write pointer address, correct value should be use.
Without this path, output data will be placed in wrong memory
area, what results in corrupted output stream when output offset
differ from zero.

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>