### PR TITLE
ipc: use macro instead of a magic number for timeout period

### DIFF
--- a/src/include/sof/drivers/ipc.h
+++ b/src/include/sof/drivers/ipc.h
@@ -47,6 +47,9 @@ struct ipc_msg;
 #define COMP_TYPE_BUFFER	2
 #define COMP_TYPE_PIPELINE	3
 
+/** \brief Scheduling period for IPC task in microseconds. */
+#define IPC_PERIOD_USEC	100
+
 /* validates internal non tail structures within IPC command structure */
 #define IPC_IS_SIZE_INVALID(object)					\
 	(object).hdr.size == sizeof(object) ? 0 : 1

--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -1385,7 +1385,7 @@ out:
 
 void ipc_schedule_process(struct ipc *ipc)
 {
-	schedule_task(&ipc->ipc_task, 0, 100);
+	schedule_task(&ipc->ipc_task, 0, IPC_PERIOD_USEC);
 
 	platform_shared_commit(ipc, sizeof(*ipc));
 }


### PR DESCRIPTION
Currently, in the ipc_schedule_process function, when we call
schedule_task to schedule an ipc task, we use magic number to
indicate the time kernel waits before calling timeout on an
IPC. This makes it difficult to search for the timeout period
using grep and other utilities. Replacing it with a macro makes
it easier to search and change only at one place.

Signed-off-by: Mohana Datta Yelugoti <ymdatta.work@gmail.com>