### PR TITLE
Audio: Fix error trace for build specific limitation for FIR EQ

### DIFF
--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -331,7 +331,7 @@ static int eq_fir_init_coef(struct sof_eq_fir_config *config,
 #if defined FIR_MAX_LENGTH_BUILD_SPECIFIC
 		if (fir[i].taps * nch > FIR_MAX_LENGTH_BUILD_SPECIFIC) {
 			comp_cl_err(&comp_eq_fir, "Filter length %d exceeds limitation for build.",
-				    fir[i].length);
+				    fir[i].taps);
 			return -EINVAL;
 		}
 #endif


### PR DESCRIPTION
This patch fixes from errors trace a message where the length
parameter is always shown as zero:

ERROR Filter length 0 exceeds limitation for build.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>