### PR TITLE
cavs: timer: set logical_irq for arch timers

### DIFF
--- a/src/drivers/intel/cavs/timer.c
+++ b/src/drivers/intel/cavs/timer.c
@@ -133,6 +133,8 @@ int timer_register(struct timer *timer, void (*handler)(void *arg), void *arg)
 	case TIMER0:
 	case TIMER1:
 	case TIMER2:
+		/* arch timers have no children, so HW IRQ is logical IRQ */
+		timer->logical_irq = timer->irq;
 		ret = arch_timer_register(timer, handler, arg);
 		break;
 	case TIMER3:


### PR DESCRIPTION
All timers should have logical_irq properly set up.
In case of arch timers logical_irq is equal to irq.

Signed-off-by: Janusz Jankowski <janusz.jankowski@linux.intel.com>