### PR TITLE
buffer: Don't lock buffers when only reading state or params.

### DIFF
--- a/src/audio/asrc/asrc.c
+++ b/src/audio/asrc/asrc.c
@@ -824,7 +824,6 @@ static int asrc_copy(struct comp_dev *dev)
 	int frames_src;
 	int frames_snk;
 	int ret;
-	uint32_t flags = 0;
 
 	comp_dbg(dev, "asrc_copy()");
 
@@ -838,14 +837,11 @@ static int asrc_copy(struct comp_dev *dev)
 	sink = list_first_item(&dev->bsink_list, struct comp_buffer,
 			       source_list);
 
-	buffer_lock(source, &flags);
-	buffer_lock(sink, &flags);
+	buffer_control_invalidate(source);
+	buffer_control_invalidate(sink);
 
 	frames_src = audio_stream_get_avail_frames(&source->stream);
 	frames_snk = audio_stream_get_free_frames(&sink->stream);
-
-	buffer_unlock(sink, flags);
-	buffer_unlock(source, flags);
 
 	if (cd->mode == ASRC_OM_PULL) {
 		/* Let ASRC access max number of source frames in pull mode.

--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -666,7 +666,6 @@ static int dai_copy(struct comp_dev *dev)
 	uint32_t src_samples;
 	uint32_t sink_samples;
 	int ret = 0;
-	uint32_t flags = 0;
 
 	comp_dbg(dev, "dai_copy()");
 
@@ -677,7 +676,7 @@ static int dai_copy(struct comp_dev *dev)
 		return ret;
 	}
 
-	buffer_lock(buf, &flags);
+	buffer_control_invalidate(buf);
 
 	/* calculate minimum size to copy */
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK) {
@@ -696,8 +695,6 @@ static int dai_copy(struct comp_dev *dev)
 				 MIN(src_samples, sink_samples) *
 				 get_sample_bytes(dd->frame_fmt));
 	}
-
-	buffer_unlock(buf, flags);
 
 	comp_dbg(dev, "dai_copy(), copy_bytes = 0x%x", copy_bytes);
 

--- a/src/audio/detect_test.c
+++ b/src/audio/detect_test.c
@@ -728,7 +728,6 @@ static int test_keyword_copy(struct comp_dev *dev)
 	struct comp_data *cd = comp_get_drvdata(dev);
 	struct comp_buffer *source;
 	uint32_t frames;
-	uint32_t flags = 0;
 
 	comp_dbg(dev, "test_keyword_copy()");
 
@@ -736,10 +735,9 @@ static int test_keyword_copy(struct comp_dev *dev)
 	source = list_first_item(&dev->bsource_list,
 				 struct comp_buffer, sink_list);
 
-	buffer_lock(source, &flags);
+	buffer_control_invalidate(source);
 	frames = source->stream.avail /
 		audio_stream_frame_bytes(&source->stream);
-	buffer_unlock(source, flags);
 
 	/* copy and perform detection */
 	buffer_invalidate(source, source->stream.avail);

--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -244,17 +244,14 @@ static uint32_t host_get_copy_bytes_one_shot(struct comp_dev *dev)
 	struct dma_sg_elem *local_elem = hd->config.elem_array.elems;
 	uint32_t copy_bytes = 0;
 	uint32_t split_value;
-	uint32_t flags = 0;
 
-	buffer_lock(hd->local_buffer, &flags);
+	buffer_control_invalidate(hd->local_buffer);
 
 	/* calculate minimum size to copy */
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK)
 		copy_bytes = hd->local_buffer->stream.free;
 	else
 		copy_bytes = hd->local_buffer->stream.avail;
-
-	buffer_unlock(hd->local_buffer, flags);
 
 	/* copy_bytes should be aligned to minimum possible chunk of
 	 * data to be copied by dma.
@@ -323,7 +320,6 @@ static uint32_t host_get_copy_bytes_normal(struct comp_dev *dev)
 	uint32_t avail_bytes = 0;
 	uint32_t free_bytes = 0;
 	uint32_t copy_bytes = 0;
-	uint32_t flags = 0;
 	int ret;
 
 	/* get data sizes from DMA */
@@ -335,7 +331,7 @@ static uint32_t host_get_copy_bytes_normal(struct comp_dev *dev)
 		return 0;
 	}
 
-	buffer_lock(hd->local_buffer, &flags);
+	buffer_control_invalidate(hd->local_buffer);
 
 	/* calculate minimum size to copy */
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK)
@@ -348,8 +344,6 @@ static uint32_t host_get_copy_bytes_normal(struct comp_dev *dev)
 	else
 		copy_bytes = MIN(hd->local_buffer->stream.avail,
 				 free_bytes);
-
-	buffer_unlock(hd->local_buffer, flags);
 
 	/* copy_bytes should be aligned to minimum possible chunk of
 	 * data to be copied by dma.

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -615,7 +615,6 @@ static int kpb_copy(struct comp_dev *dev)
 	struct comp_buffer *sink = NULL;
 	size_t copy_bytes = 0;
 	size_t sample_width = kpb->config.sampling_width;
-	uint32_t flags = 0;
 	struct draining_data *dd = &kpb->draining_task_data;
 
 	comp_dbg(dev, "kpb_copy()");
@@ -630,17 +629,14 @@ static int kpb_copy(struct comp_dev *dev)
 		goto out;
 	}
 
-	buffer_lock(source, &flags);
+	buffer_control_invalidate(source);
 
 	/* Validate source */
 	if (!source->stream.r_ptr) {
 		comp_err(dev, "kpb_copy(): invalid source pointers.");
 		ret = -EINVAL;
-		buffer_unlock(source, flags);
 		goto out;
 	}
-
-	buffer_unlock(source, flags);
 
 	switch (kpb->state) {
 	case KPB_STATE_RUN:
@@ -653,17 +649,14 @@ static int kpb_copy(struct comp_dev *dev)
 			goto out;
 		}
 
-		buffer_lock(sink, &flags);
+		buffer_control_invalidate(sink);
 
 		/* Validate sink */
 		if (!sink->stream.w_ptr) {
 			comp_err(dev, "kpb_copy(): invalid selector sink pointers.");
 			ret = -EINVAL;
-			buffer_unlock(sink, flags);
 			goto out;
 		}
-
-		buffer_unlock(sink, flags);
 
 		copy_bytes = MIN(sink->stream.free, source->stream.avail);
 		if (!copy_bytes) {
@@ -710,17 +703,14 @@ static int kpb_copy(struct comp_dev *dev)
 			goto out;
 		}
 
-		buffer_lock(sink, &flags);
+		buffer_control_invalidate(sink);
 
 		/* Validate sink */
 		if (!sink->stream.w_ptr) {
 			comp_err(dev, "kpb_copy(): invalid host sink pointers.");
 			ret = -EINVAL;
-			buffer_unlock(sink, flags);
 			goto out;
 		}
-
-		buffer_unlock(sink, flags);
 
 		copy_bytes = MIN(sink->stream.free, source->stream.avail);
 		if (!copy_bytes) {

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -281,7 +281,6 @@ static int mixer_copy(struct comp_dev *dev)
 	uint32_t frames = INT32_MAX;
 	uint32_t source_bytes;
 	uint32_t sink_bytes;
-	uint32_t flags = 0;
 
 	comp_dbg(dev, "mixer_copy()");
 
@@ -310,18 +309,15 @@ static int mixer_copy(struct comp_dev *dev)
 	if (num_mix_sources == 0)
 		return 0;
 
-	buffer_lock(sink, &flags);
+	buffer_control_invalidate(sink);
 
 	/* check for underruns */
 	for (i = 0; i < num_mix_sources; i++) {
-		buffer_lock(sources[i], &flags);
+		buffer_control_invalidate(sources[i]);
 		frames = MIN(frames,
 			     audio_stream_avail_frames(sources_stream[i],
 						       &sink->stream));
-		buffer_unlock(sources[i], flags);
 	}
-
-	buffer_unlock(sink, flags);
 
 	/* Every source has the same format, so calculate bytes based
 	 * on the first one.

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -381,7 +381,6 @@ static int selector_copy(struct comp_dev *dev)
 	uint32_t frames;
 	uint32_t source_bytes;
 	uint32_t sink_bytes;
-	uint32_t flags = 0;
 
 	comp_dbg(dev, "selector_copy()");
 
@@ -391,15 +390,12 @@ static int selector_copy(struct comp_dev *dev)
 	sink = list_first_item(&dev->bsink_list, struct comp_buffer,
 			       source_list);
 
-	buffer_lock(source, &flags);
-	buffer_lock(sink, &flags);
+	buffer_control_invalidate(source);
+	buffer_control_invalidate(sink);
 
 	frames = audio_stream_avail_frames(&source->stream, &sink->stream);
 	source_bytes = frames * audio_stream_frame_bytes(&source->stream);
 	sink_bytes = frames * audio_stream_frame_bytes(&sink->stream);
-
-	buffer_unlock(sink, flags);
-	buffer_unlock(source, flags);
 
 	comp_dbg(dev, "selector_copy(), source_bytes = 0x%x, sink_bytes = 0x%x",
 		 source_bytes, sink_bytes);

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -772,7 +772,6 @@ static int src_copy(struct comp_dev *dev)
 	struct comp_buffer *source;
 	struct comp_buffer *sink;
 	int ret;
-	uint32_t flags = 0;
 
 	comp_dbg(dev, "src_copy()");
 
@@ -782,17 +781,14 @@ static int src_copy(struct comp_dev *dev)
 	sink = list_first_item(&dev->bsink_list, struct comp_buffer,
 			       source_list);
 
-	buffer_lock(source, &flags);
-	buffer_lock(sink, &flags);
+	buffer_control_invalidate(source);
+	buffer_control_invalidate(sink);
 
 	/* Get from buffers and SRC conversion specific block constraints
 	 * how many frames can be processed. If sufficient number of samples
 	 * is not available the processing is omitted.
 	 */
 	ret = src_get_copy_limits(cd, source, sink);
-
-	buffer_unlock(sink, flags);
-	buffer_unlock(source, flags);
 
 	if (ret) {
 		comp_info(dev, "No data to process.");

--- a/src/audio/tone.c
+++ b/src/audio/tone.c
@@ -431,7 +431,6 @@ static int tone_params(struct comp_dev *dev,
 	struct sof_ipc_comp_config *config = dev_comp_config(dev);
 	struct comp_buffer *sourceb;
 	struct comp_buffer *sinkb;
-	uint32_t flags = 0;
 
 	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer,
 				  sink_list);
@@ -446,8 +445,8 @@ static int tone_params(struct comp_dev *dev,
 	if (config->frame_fmt != SOF_IPC_FRAME_S32_LE)
 		return -EINVAL;
 
-	buffer_lock(sourceb, &flags);
-	buffer_lock(sinkb, &flags);
+	buffer_control_invalidate(sourceb);
+	buffer_control_invalidate(sinkb);
 
 	sourceb->stream.frame_fmt = config->frame_fmt;
 	sinkb->stream.frame_fmt = config->frame_fmt;
@@ -455,9 +454,6 @@ static int tone_params(struct comp_dev *dev,
 	/* calculate period size based on config */
 	cd->period_bytes = dev->frames *
 			   audio_stream_frame_bytes(&sourceb->stream);
-
-	buffer_unlock(sinkb, flags);
-	buffer_unlock(sourceb, flags);
 
 	return 0;
 }
@@ -619,7 +615,6 @@ static int tone_copy(struct comp_dev *dev)
 	struct comp_buffer *sink;
 	struct comp_data *cd = comp_get_drvdata(dev);
 	uint32_t free;
-	uint32_t flags = 0;
 
 	comp_dbg(dev, "tone_copy()");
 
@@ -627,9 +622,8 @@ static int tone_copy(struct comp_dev *dev)
 	sink = list_first_item(&dev->bsink_list, struct comp_buffer,
 			       source_list);
 
-	buffer_lock(sink, &flags);
+	buffer_control_invalidate(sink);
 	free = audio_stream_get_free_bytes(&sink->stream);
-	buffer_unlock(sink, flags);
 
 	/* Test that sink has enough free frames. Then run once to maintain
 	 * low latency and steady load for tones.

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -164,6 +164,19 @@ void comp_update_buffer_produce(struct comp_buffer *buffer, uint32_t bytes);
 /* called by a component after consuming data from this buffer */
 void comp_update_buffer_consume(struct comp_buffer *buffer, uint32_t bytes);
 
+/**
+ * Invalidates control block of a buffer to ensure current state and params
+ * readout.
+ * @param buffer Buffer component to invalidate
+ */
+static inline void buffer_control_invalidate(struct comp_buffer *buffer)
+{
+	if (!buffer->inter_core)
+		return;
+
+	dcache_invalidate_region(buffer, sizeof(*buffer));
+}
+
 static inline void buffer_invalidate(struct comp_buffer *buffer, uint32_t bytes)
 {
 	if (!buffer->inter_core)


### PR DESCRIPTION
There was an overkill with components locking buffers each time they
read r/w pointers or free/avail, while simply invalidating the buffer's
control block would suffice.
By changing this behaviour we greatly reduce amount of needlessly
acquired locks.

Signed-off-by: Artur Kloniecki <arturx.kloniecki@linux.intel.com>