### PR TITLE
.travis.yml: add IRC notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,3 +92,10 @@ jobs:
         # any issue. This time doxygen stops on the first issue.
         - printf 'WARN_AS_ERROR = YES\n' >> doc/sof.doxygen.in
         - ninja -C doxybuild -v doc
+
+notifications:
+  irc:
+    channels:
+      - "chat.freenode.net#sof"
+    on_success: always
+    on_failure: always


### PR DESCRIPTION
SOF has #sof dedicated channel on irc.freenode.net server.
This will enable travis ci to send notifications to the IRC
channel each time a build is finished (either successful or not).

We will see how this works and refine it later if it is too spammy.

Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>