### PR TITLE
ipc: pipe: Fix pipe id value in log message

### DIFF
--- a/src/ipc/ipc.c
+++ b/src/ipc/ipc.c
@@ -542,9 +542,10 @@ int ipc_pipeline_complete(struct ipc *ipc, uint32_t comp_id)
 	if (!cpu_is_me(ipc_pipe->core))
 		return ipc_process_on_core(ipc_pipe->core);
 
-	tr_dbg(&ipc_tr, "ipc: pipe %d -> complete", comp_id);
-
 	pipeline_id = ipc_pipe->pipeline->ipc_pipe.pipeline_id;
+
+	tr_dbg(&ipc_tr, "ipc: pipe %d -> complete on comp %d", pipeline_id,
+	       comp_id);
 
 	/* get pipeline source component */
 	ipc_ppl_source = ipc_get_ppl_src_comp(ipc, pipeline_id);


### PR DESCRIPTION
`pipe` should refer to `pipeline_id`, using `comp_id` is misleading.

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>