### PR TITLE
cmake/git-submodules: don't throw away work in progress at build time

### DIFF
--- a/scripts/cmake/git-submodules.cmake
+++ b/scripts/cmake/git-submodules.cmake
@@ -1,14 +1,14 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 find_package(Git)
+set(RIMAGE_CMAKE "${SOF_ROOT_SOURCE_DIRECTORY}/rimage/CMakeLists.txt")
+
 if(GIT_FOUND AND EXISTS "${SOF_ROOT_SOURCE_DIRECTORY}/.git")
-	# Update submodules by default
-	option(GIT_SUBMODULE "Check submodules during build" ON)
 
-	if(GIT_SUBMODULE)
-		message(STATUS "Git submodule update")
+	if(NOT EXISTS "${RIMAGE_CMAKE}")
+		message(STATUS "Git submodules update")
 
-		execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive
+		execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --merge --recursive
 				WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 				RESULT_VARIABLE GIT_SUBMOD_RESULT)
 
@@ -18,6 +18,7 @@ if(GIT_FOUND AND EXISTS "${SOF_ROOT_SOURCE_DIRECTORY}/.git")
 	endif()
 endif()
 
-if(NOT EXISTS "${SOF_ROOT_SOURCE_DIRECTORY}/rimage/CMakeLists.txt")
-	message(FATAL_ERROR "The submodules were not downloaded! GIT_SUBMODULE was turned off or failed. Please update submodules and try again.")
+# rimage is not optional, see "git grep include.*rimage"
+if(NOT EXISTS "${RIMAGE_CMAKE}")
+	message(FATAL_ERROR "rimage not found! Please update git submodules and try again.")
 endif()


### PR DESCRIPTION
- Add a simple test in cmake to download submodules only when rimage is
  missing. This stops randomly changing the source code from one build
  to the next and overwriting any submodule work in progress.

- Remove the GIT_SUBMODULE option which is now useless because rimage is
  not optional for sof

- Add a --merge option for safety. It makes zero difference right now
  but could save work in progress if we ever add more
  submodules (hopefully not) and someone struggles with submodules and
  ends up in a partially initialized state.

Git submodules are rarely ever the answer; these few changes make them a
bit more usable.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>