### PR TITLE
arch: shared_vecbase cache fix

### DIFF
--- a/src/arch/xtensa/init.c
+++ b/src/arch/xtensa/init.c
@@ -37,7 +37,7 @@ uint32_t lock_dbg_atomic;
 uint32_t lock_dbg_user[DBG_LOCK_USERS] = {0};
 #endif
 #if CONFIG_NO_SLAVE_CORE_ROM
-SHARED_DATA void *shared_vecbase_ptr;
+void *shared_vecbase_ptr __aligned(PLATFORM_DCACHE_ALIGN);
 #endif
 /** \brief Core context for master core. */
 static struct core_context master_core_ctx;

--- a/src/arch/xtensa/lib/cpu.c
+++ b/src/arch/xtensa/lib/cpu.c
@@ -51,8 +51,8 @@ static void alloc_shared_slave_cores_objects(void)
 		panic(SOF_IPC_PANIC_MEM);
 
 	shared_vecbase_ptr = dynamic_vectors;
-	dcache_writeback_invalidate_region(shared_vecbase_ptr,
-					   SOF_DYNAMIC_VECTORS_SIZE);
+	dcache_writeback_region(&shared_vecbase_ptr,
+				sizeof(shared_vecbase_ptr));
 }
 
 /**


### PR DESCRIPTION
This will fix cache handling for shared_vecbase and allow to
boot slave cores in a proper way.