### PR TITLE
Smart amp tplg fixes

### DIFF
--- a/tools/topology/sof-smart-amplifier.m4
+++ b/tools/topology/sof-smart-amplifier.m4
@@ -42,6 +42,8 @@ ifdef(`SMART_SSP_NAME',`',`errprint(note: Need to define SSP BE dai_link name fo
 # define(`SMART_SSP_QUIRK', 0) define SSP quirk for special use, e.g. set SSP_QUIRK_LBM to verify
 # smart_amp nocodec mode. Set it to 0 by default for normal mode.
 ifdef(`SMART_SSP_QUIRK',`',`define(`SMART_SSP_QUIRK', 0)')
+# define(`SSP_MCLK', ) define SSP mclk if not done yet
+ifdef(`SSP_MCLK',`',`define(`SSP_MCLK', 19200000)')
 ')
 
 # define(`SMART_BE_ID', 7) define BE dai_link ID
@@ -219,7 +221,7 @@ DAI_CONFIG(ALH, eval(SMART_ALH_INDEX + 1), eval(SMART_BE_ID + 1), SMART_ALH_CAPT
 `
 #SSP SSP_INDEX (ID: SMART_BE_ID)
 DAI_CONFIG(SSP, SMART_SSP_INDEX, SMART_BE_ID, SMART_SSP_NAME,
-	SSP_CONFIG(DSP_B, SSP_CLOCK(mclk, 38400000, codec_mclk_in),
+	SSP_CONFIG(DSP_B, SSP_CLOCK(mclk, SSP_MCLK, codec_mclk_in),
 		      SSP_CLOCK(bclk, 9600000, codec_slave),
 		      SSP_CLOCK(fsync, 48000, codec_slave),
 		      SSP_TDM(8, 25, 15, 255),

--- a/tools/topology/sof-smart-amplifier.m4
+++ b/tools/topology/sof-smart-amplifier.m4
@@ -39,6 +39,9 @@ ifdef(`SMART_SSP_INDEX',`',`errprint(note: Need to define SSP index for sof-smar
 # define(`SMART_SSP_NAME', `SSP1-Codec') define SSP BE dai_link name
 ifdef(`SMART_SSP_NAME',`',`errprint(note: Need to define SSP BE dai_link name for sof-smart-amplifier
 )')
+# define(`SMART_SSP_QUIRK', 0) define SSP quirk for special use, e.g. set SSP_QUIRK_LBM to verify
+# smart_amp nocodec mode. Set it to 0 by default for normal mode.
+ifdef(`SMART_SSP_QUIRK',`',`define(`SMART_SSP_QUIRK', 0)')
 ')
 
 # define(`SMART_BE_ID', 7) define BE dai_link ID

--- a/tools/topology/sof-tgl-max98373-rt5682.m4
+++ b/tools/topology/sof-tgl-max98373-rt5682.m4
@@ -45,6 +45,8 @@ define(`SMART_SSP_INDEX', 1)
 define(`SMART_SSP_NAME', `SSP1-Codec')
 #define BE dai_link ID
 define(`SMART_BE_ID', 7)
+#define SSP mclk
+define(`SSP_MCLK', 19200000)
 # Playback related
 define(`SMART_PB_PPL_ID', 1)
 define(`SMART_PB_CH_NUM', 2)
@@ -199,7 +201,7 @@ dnl ssp1-maxmspk, ssp0-RTHeadset
 
 #SSP 0 (ID: 0)
 DAI_CONFIG(SSP, 0, 0, SSP0-Codec,
-        SSP_CONFIG(I2S, SSP_CLOCK(mclk, 19200000, codec_mclk_in),
+        SSP_CONFIG(I2S, SSP_CLOCK(mclk, SSP_MCLK, codec_mclk_in),
                       SSP_CLOCK(bclk, 2400000, codec_slave),
                       SSP_CLOCK(fsync, 48000, codec_slave),
                       SSP_TDM(2, 25, 3, 3),


### PR DESCRIPTION
make sure the SMART_SSP_QUIRK is configured, and use the unify mclk among SSPs.

This will fix https://github.com/thesofproject/linux/issues/2190