### PR TITLE
Use '-imacros config.h' instead of explicit #include <config.h>

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,7 @@ set(GENERATED_DIRECTORY ${PROJECT_BINARY_DIR}/generated)
 file(MAKE_DIRECTORY ${GENERATED_DIRECTORY}/include)
 
 set(DOT_CONFIG_PATH ${GENERATED_DIRECTORY}/.config)
-set(CONFIG_H_PATH ${GENERATED_DIRECTORY}/include/config.h CACHE
+set(CONFIG_H_PATH ${GENERATED_DIRECTORY}/include/autoconfig.h CACHE
   PATH "Path to kconfig's .h output file")
 set(VERSION_H_PATH ${GENERATED_DIRECTORY}/include/version.h)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,8 @@ set(GENERATED_DIRECTORY ${PROJECT_BINARY_DIR}/generated)
 file(MAKE_DIRECTORY ${GENERATED_DIRECTORY}/include)
 
 set(DOT_CONFIG_PATH ${GENERATED_DIRECTORY}/.config)
-set(CONFIG_H_PATH ${GENERATED_DIRECTORY}/include/config.h)
+set(CONFIG_H_PATH ${GENERATED_DIRECTORY}/include/config.h CACHE
+  PATH "Path to kconfig's .h output file")
 set(VERSION_H_PATH ${GENERATED_DIRECTORY}/include/version.h)
 
 include(scripts/cmake/version.cmake)

--- a/src/arch/host/CMakeLists.txt
+++ b/src/arch/host/CMakeLists.txt
@@ -5,6 +5,7 @@ target_include_directories(sof_public_headers INTERFACE ${PROJECT_SOURCE_DIR}/sr
 target_include_directories(sof_public_headers INTERFACE ${PROJECT_SOURCE_DIR}/src/platform/library/include)
 
 # C & ASM flags
-target_compile_options(sof_options INTERFACE -g -O3 -Wall -Werror -Wl,-EL -Wmissing-prototypes -Wimplicit-fallthrough=3 -Wpointer-arith -DCONFIG_LIBRARY)
+target_compile_options(sof_options INTERFACE -g -O3 -Wall -Werror -Wl,-EL -Wmissing-prototypes
+  -Wimplicit-fallthrough=3 -Wpointer-arith -DCONFIG_LIBRARY -imacros "${CONFIG_H_PATH}")
 
 add_subdirectory(lib)

--- a/src/arch/xtensa/CMakeLists.txt
+++ b/src/arch/xtensa/CMakeLists.txt
@@ -109,7 +109,7 @@ target_compile_options(sof_options INTERFACE ${stdlib_flag} -fno-inline-function
 #      better to have set of default flags and change it only for special cases
 #   3) custom function that is used instead of target_sources and sets flags
 #      for each added source based on file extension
-target_compile_options(sof_options INTERFACE $<$<COMPILE_LANGUAGE:C>: -${optimization_flag} -g -Wall -Werror -Wl,-EL -Wmissing-prototypes -Wpointer-arith ${XTENSA_C_FLAGS}>)
+target_compile_options(sof_options INTERFACE $<$<COMPILE_LANGUAGE:C>: -${optimization_flag} -g -Wall -Werror -Wl,-EL -Wmissing-prototypes -Wpointer-arith ${XTENSA_C_FLAGS}> -imacros ${CONFIG_H_PATH})
 
 if(BUILD_UNIT_TESTS)
 	# rest of this file is not needed for unit tests
@@ -154,6 +154,7 @@ function(sof_add_ld_script binary_name script_name)
 
 	add_custom_command(OUTPUT ${lds_out}
 		COMMAND ${CMAKE_C_COMPILER} -E -DLINKER -P ${iflags} -o ${lds_out} -x c ${lds_in}
+			-imacros ${CONFIG_H_PATH}
 		DEPENDS ${lds_in} ${LINK_DEPS} genconfig ${CONFIG_H_PATH} ${lds_headers}
 		WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
 		COMMENT "Generating linker script: ${lds_out}"

--- a/src/arch/xtensa/include/arch/drivers/interrupt.h
+++ b/src/arch/xtensa/include/arch/drivers/interrupt.h
@@ -14,7 +14,7 @@
 #include <xtensa/xtruntime.h>
 #include <stddef.h>
 #include <stdint.h>
-#include <config.h>
+
 
 static inline int arch_interrupt_register(int irq,
 	void (*handler)(void *arg), void *arg)

--- a/src/arch/xtensa/include/arch/init.h
+++ b/src/arch/xtensa/include/arch/init.h
@@ -18,7 +18,7 @@
 
 #include <sof/debug/panic.h>
 #include <ipc/trace.h>
-#include <config.h>
+
 #include <xtensa/corebits.h>
 #include <xtensa/xtruntime.h>
 #include <stddef.h>

--- a/src/arch/xtensa/include/arch/lib/cpu.h
+++ b/src/arch/xtensa/include/arch/lib/cpu.h
@@ -10,7 +10,7 @@
 #ifndef __ARCH_LIB_CPU_H__
 #define __ARCH_LIB_CPU_H__
 
-#include <config.h>
+
 #include <xtensa/config/core-isa.h>
 
 #if CONFIG_SMP

--- a/src/arch/xtensa/include/arch/lib/wait.h
+++ b/src/arch/xtensa/include/arch/lib/wait.h
@@ -12,7 +12,7 @@
 #include <sof/drivers/interrupt.h>
 #include <sof/lib/clk.h>
 #include <ipc/trace.h>
-#include <config.h>
+
 #include <xtensa/xtruntime.h>
 
 #if (CONFIG_WAITI_DELAY)

--- a/src/arch/xtensa/include/arch/spinlock.h
+++ b/src/arch/xtensa/include/arch/spinlock.h
@@ -10,7 +10,7 @@
 #ifndef __ARCH_SPINLOCK_H__
 #define __ARCH_SPINLOCK_H__
 
-#include <config.h>
+
 #include <stdint.h>
 
 typedef struct {

--- a/src/arch/xtensa/include/arch/string.h
+++ b/src/arch/xtensa/include/arch/string.h
@@ -10,7 +10,7 @@
 #ifndef __ARCH_STRING_H__
 #define __ARCH_STRING_H__
 
-#include <config.h>
+
 #include <xtensa/hal.h>
 #include <errno.h>
 #include <stddef.h>

--- a/src/arch/xtensa/init.c
+++ b/src/arch/xtensa/init.c
@@ -16,7 +16,7 @@
 #include <sof/lib/cpu.h>
 #include <sof/sof.h>
 #include <sof/spinlock.h>
-#include <config.h>
+
 #include <xtensa/xtruntime-frames.h>
 #include <xtos-structs.h>
 #include <stddef.h>

--- a/src/arch/xtensa/schedule/task.c
+++ b/src/arch/xtensa/schedule/task.c
@@ -21,7 +21,7 @@
 #include <sof/schedule/schedule.h>
 #include <sof/schedule/task.h>
 #include <ipc/topology.h>
-#include <config.h>
+
 #include <xtensa/corebits.h>
 #include <xtensa/xtruntime-frames.h>
 #include <xtos-structs.h>

--- a/src/arch/xtensa/xtos/core-restore.S
+++ b/src/arch/xtensa/xtos/core-restore.S
@@ -22,7 +22,7 @@
 // TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#include <config.h>
+
 #include <xtensa/coreasm.h>
 #include <xtensa/corebits.h>
 #include <xtensa/cacheasm.h>

--- a/src/arch/xtensa/xtos/core-save.S
+++ b/src/arch/xtensa/xtos/core-save.S
@@ -22,7 +22,7 @@
 // TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#include <config.h>
+
 #include <xtensa/coreasm.h>
 #include <xtensa/corebits.h>
 #include <xtensa/cacheasm.h>

--- a/src/arch/xtensa/xtos/crt1-boards-rom.S
+++ b/src/arch/xtensa/xtos/crt1-boards-rom.S
@@ -29,7 +29,7 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include <sof/lib/memory.h>
-#include <config.h>
+
 #include <xtensa/coreasm.h>
 
 // Exports

--- a/src/arch/xtensa/xtos/crt1-boards.S
+++ b/src/arch/xtensa/xtos/crt1-boards.S
@@ -28,7 +28,7 @@
 // TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#include <config.h>
+
 #if CONFIG_SMP
 #include <sof/lib/cpu.h>
 #include <sof/lib/memory.h>

--- a/src/arch/xtensa/xtos/debug-vector.S
+++ b/src/arch/xtensa/xtos/debug-vector.S
@@ -23,7 +23,7 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include <arch/debug/gdb/xtensa-defs.h>
-#include <config.h>
+
 #include <xtensa/xtensa-versions.h>
 #include <xtensa/coreasm.h>
 #include <xtensa/config/specreg.h>

--- a/src/arch/xtensa/xtos/int-highpri-dispatcher.S
+++ b/src/arch/xtensa/xtos/int-highpri-dispatcher.S
@@ -33,7 +33,7 @@
 // To use this template file, define a macro called _INTERRUPT_LEVEL
 // to be the interrupt priority level of the vector, then include this file.
 
-#include <config.h>
+
 #if CONFIG_SMP
 #include <sof/lib/cpu.h>
 #endif

--- a/src/arch/xtensa/xtos/int-medpri-dispatcher.S
+++ b/src/arch/xtensa/xtos/int-medpri-dispatcher.S
@@ -31,7 +31,7 @@
 // to be the interrupt priority level of the vector, then include this file.
 
 #include <sof/lib/memory.h>
-#include <config.h>
+
 #include <xtensa/coreasm.h>
 #include "xtos-internal.h"
 

--- a/src/arch/xtensa/xtos/int-sethandler.c
+++ b/src/arch/xtensa/xtos/int-sethandler.c
@@ -27,7 +27,7 @@
 #include "xtos-internal.h"
 #include "xtos-structs.h"
 #include <sof/lib/cpu.h>
-#include <config.h>
+
 
 #if XCHAL_HAVE_INTERRUPTS
 #if CONFIG_SMP

--- a/src/arch/xtensa/xtos/interrupt-table.S
+++ b/src/arch/xtensa/xtos/interrupt-table.S
@@ -21,7 +21,7 @@
 // TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#include <config.h>
+
 #include <xtensa/coreasm.h>
 #include "xtos-internal.h"
 

--- a/src/arch/xtensa/xtos/ints-off.S
+++ b/src/arch/xtensa/xtos/ints-off.S
@@ -21,7 +21,7 @@
 // TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#include <config.h>
+
 #include <xtensa/coreasm.h>
 #include "xtos-internal.h"
 

--- a/src/arch/xtensa/xtos/ints-on.S
+++ b/src/arch/xtensa/xtos/ints-on.S
@@ -21,7 +21,7 @@
 // TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#include <config.h>
+
 #include <xtensa/coreasm.h>
 #include "xtos-internal.h"
 

--- a/src/arch/xtensa/xtos/reset-vector.S
+++ b/src/arch/xtensa/xtos/reset-vector.S
@@ -22,7 +22,7 @@
 // TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#include <config.h>
+
 #include <sof/common.h>
 #if CONFIG_BOOT_LOADER && !CONFIG_VM_ROM
 #include <sof/lib/memory.h>

--- a/src/arch/xtensa/xtos/user-vector.S
+++ b/src/arch/xtensa/xtos/user-vector.S
@@ -22,7 +22,7 @@
 // TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#include <config.h>
+
 #include <xtensa/coreasm.h>
 #include <xtensa/config/system.h>
 #include "xtos-internal.h"

--- a/src/arch/xtensa/xtos/xea1/int-lowpri-dispatcher.S
+++ b/src/arch/xtensa/xtos/xea1/int-lowpri-dispatcher.S
@@ -22,7 +22,7 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include <sof/lib/memory.h>
-#include <config.h>
+
 #include <xtensa/coreasm.h>
 #include "../xtos-internal.h"
 

--- a/src/arch/xtensa/xtos/xea1/intlevel-restore.S
+++ b/src/arch/xtensa/xtos/xea1/intlevel-restore.S
@@ -21,7 +21,7 @@
 // TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#include <config.h>
+
 #include <xtensa/coreasm.h>
 #include <xtensa/config/specreg.h>
 #include "../xtos-internal.h"

--- a/src/arch/xtensa/xtos/xea1/intlevel-set.S
+++ b/src/arch/xtensa/xtos/xea1/intlevel-set.S
@@ -21,7 +21,7 @@
 // TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#include <config.h>
+
 #include <xtensa/coreasm.h>
 #include <xtensa/config/specreg.h>
 #include "../xtos-internal.h"

--- a/src/arch/xtensa/xtos/xea1/intlevel-setmin.S
+++ b/src/arch/xtensa/xtos/xea1/intlevel-setmin.S
@@ -21,7 +21,7 @@
 // TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#include <config.h>
+
 #include <xtensa/coreasm.h>
 #include <xtensa/config/specreg.h>
 #include "../xtos-internal.h"

--- a/src/arch/xtensa/xtos/xea2/int-lowpri-dispatcher.S
+++ b/src/arch/xtensa/xtos/xea2/int-lowpri-dispatcher.S
@@ -22,7 +22,7 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include <sof/lib/memory.h>
-#include <config.h>
+
 #include <xtensa/coreasm.h>
 #include "../xtos-internal.h"
 

--- a/src/arch/xtensa/xtos/xea2/intlevel-restore.S
+++ b/src/arch/xtensa/xtos/xea2/intlevel-restore.S
@@ -21,7 +21,7 @@
 // TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#include <config.h>
+
 #include <xtensa/coreasm.h>
 #include "../xtos-internal.h"
 

--- a/src/arch/xtensa/xtos/xtos-internal.h
+++ b/src/arch/xtensa/xtos/xtos-internal.h
@@ -27,7 +27,7 @@
 #ifndef XTOS_INTERNAL_H
 #define XTOS_INTERNAL_H
 
-#include <config.h>
+
 #if CONFIG_SMP
 #include <sof/lib/cpu.h>
 #endif

--- a/src/arch/xtensa/xtos/xtos-structs.h
+++ b/src/arch/xtensa/xtos/xtos-structs.h
@@ -11,7 +11,7 @@
 #include "xtos-internal.h"
 #include <sof/common.h>
 #include <sof/lib/memory.h>
-#include <config.h>
+
 #include <xtensa/xtruntime-frames.h>
 #include <stdint.h>
 

--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -5,7 +5,7 @@
 // Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
 //         Artur Kloniecki <arturx.kloniecki@linux.intel.com>
 
-#include <config.h>
+
 
 #if CONFIG_COMP_MUX
 

--- a/src/audio/mux/mux_generic.c
+++ b/src/audio/mux/mux_generic.c
@@ -4,7 +4,7 @@
 //
 // Author: Artur Kloniecki <arturx.kloniecki@linux.intel.com>
 
-#include <config.h>
+
 
 #if CONFIG_COMP_MUX
 

--- a/src/audio/pcm_converter/pcm_converter_generic.c
+++ b/src/audio/pcm_converter/pcm_converter_generic.c
@@ -20,7 +20,7 @@
 #include <sof/bit.h>
 #include <sof/common.h>
 #include <ipc/stream.h>
-#include <config.h>
+
 #include <stddef.h>
 #include <stdint.h>
 

--- a/src/audio/pcm_converter/pcm_converter_hifi3.c
+++ b/src/audio/pcm_converter/pcm_converter_hifi3.c
@@ -19,7 +19,7 @@
 #include <sof/common.h>
 #include <ipc/stream.h>
 #include <xtensa/tie/xt_hifi3.h>
-#include <config.h>
+
 #include <stddef.h>
 #include <stdint.h>
 

--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -35,7 +35,7 @@
 #include <ipc/stream.h>
 #include <ipc/topology.h>
 #include <user/trace.h>
-#include <config.h>
+
 #include <errno.h>
 #include <stdbool.h>
 #include <stddef.h>

--- a/src/debug/panic.c
+++ b/src/debug/panic.c
@@ -13,7 +13,7 @@
 #include <sof/string.h>
 #include <sof/trace/trace.h>
 #include <ipc/trace.h>
-#include <config.h>
+
 #include <stddef.h>
 #include <stdint.h>
 

--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -37,7 +37,7 @@
 #include <sof/platform.h>
 #include <sof/spinlock.h>
 #include <ipc/topology.h>
-#include <config.h>
+
 #include <errno.h>
 #include <stdbool.h>
 #include <stddef.h>

--- a/src/drivers/generic/dummy-dma.c
+++ b/src/drivers/generic/dummy-dma.c
@@ -40,7 +40,7 @@
 #include <sys/types.h>
 #include <ipc/topology.h>
 #include <user/trace.h>
-#include <config.h>
+
 #include <errno.h>
 #include <stdbool.h>
 #include <stddef.h>

--- a/src/drivers/imx/ipc.c
+++ b/src/drivers/imx/ipc.c
@@ -22,7 +22,7 @@
 #include <sof/spinlock.h>
 #include <ipc/header.h>
 #include <ipc/topology.h>
-#include <config.h>
+
 #include <errno.h>
 #include <stdbool.h>
 #include <stddef.h>

--- a/src/drivers/intel/baytrail/interrupt.c
+++ b/src/drivers/intel/baytrail/interrupt.c
@@ -8,7 +8,7 @@
 
 #include <sof/drivers/interrupt.h>
 #include <sof/lib/shim.h>
-#include <config.h>
+
 #include <stdint.h>
 
 void platform_interrupt_init(void) {}

--- a/src/drivers/intel/cavs/interrupt.c
+++ b/src/drivers/intel/cavs/interrupt.c
@@ -15,7 +15,7 @@
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
 #include <sof/spinlock.h>
-#include <config.h>
+
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/src/drivers/intel/cavs/ipc.c
+++ b/src/drivers/intel/cavs/ipc.c
@@ -25,7 +25,7 @@
 #include <ipc/header-intel-cavs.h>
 #include <ipc/pm.h>
 #endif
-#include <config.h>
+
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/src/drivers/intel/cavs/timestamp.c
+++ b/src/drivers/intel/cavs/timestamp.c
@@ -12,7 +12,7 @@
 #include <sof/lib/io.h>
 #include <ipc/dai.h>
 #include <ipc/stream.h>
-#include <config.h>
+
 #include <errno.h>
 #include <stdint.h>
 

--- a/src/drivers/intel/haswell/interrupt.c
+++ b/src/drivers/intel/haswell/interrupt.c
@@ -8,7 +8,7 @@
 
 #include <sof/drivers/interrupt.h>
 #include <sof/lib/shim.h>
-#include <config.h>
+
 #include <stdint.h>
 
 void platform_interrupt_init(void) {}

--- a/src/drivers/intel/ssp/mn.c
+++ b/src/drivers/intel/ssp/mn.c
@@ -13,7 +13,7 @@
 #include <sof/sof.h>
 #include <sof/spinlock.h>
 #include <sof/trace/trace.h>
-#include <config.h>
+
 #include <stdbool.h>
 #include <stdint.h>
 

--- a/src/drivers/intel/ssp/ssp.c
+++ b/src/drivers/intel/ssp/ssp.c
@@ -27,7 +27,7 @@
 #include <ipc/stream.h>
 #include <ipc/topology.h>
 #include <user/trace.h>
-#include <config.h>
+
 #include <errno.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/src/include/sof/audio/asrc/asrc_config.h
+++ b/src/include/sof/audio/asrc/asrc_config.h
@@ -6,7 +6,7 @@
 #ifndef __SOF_AUDIO_ASRC_ASRC_CONFIG_H__
 #define __SOF_AUDIO_ASRC_ASRC_CONFIG_H__
 
-#include <config.h>
+
 
 /* If next define is set to 1 the ASRC is configured automatically. Setting
  * to zero temporarily is useful is for testing needs.

--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -20,7 +20,7 @@
 #include <sof/lib/alloc.h>
 #include <sof/lib/cache.h>
 #include <ipc/stream.h>
-#include <config.h>
+
 #include <stdbool.h>
 #include <stdint.h>
 

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -25,7 +25,7 @@
 #include <ipc/topology.h>
 #include <user/trace.h>
 #include <sof/audio/format.h>
-#include <config.h>
+
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/src/include/sof/audio/coefficients/pdm_decim/pdm_decim_table.h
+++ b/src/include/sof/audio/coefficients/pdm_decim/pdm_decim_table.h
@@ -11,7 +11,7 @@
 #define __SOF_AUDIO_COEFFICIENTS_PDM_DECIM_PDM_DECIM_TABLE_H__
 
 #include "pdm_decim_fir.h"
-#include <config.h>
+
 #include <stddef.h>
 
 #if CONFIG_INTEL_DMIC_FIR_DECIMATE_BY_2

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -36,7 +36,7 @@
 #include <ipc/topology.h>
 #include <kernel/abi.h>
 #include <user/trace.h>
-#include <config.h>
+
 #include <errno.h>
 #include <stdbool.h>
 #include <stddef.h>

--- a/src/include/sof/audio/eq_iir/iir.h
+++ b/src/include/sof/audio/eq_iir/iir.h
@@ -16,7 +16,7 @@
 struct sof_eq_iir_header_df2t;
 
 /* Get platforms configuration */
-#include <config.h>
+
 
 /* If next defines are set to 1 the EQ is configured automatically. Setting
  * to zero temporarily is useful is for testing needs.

--- a/src/include/sof/audio/mux.h
+++ b/src/include/sof/audio/mux.h
@@ -14,7 +14,7 @@
 #ifndef __SOF_AUDIO_MUX_H__
 #define __SOF_AUDIO_MUX_H__
 
-#include <config.h>
+
 
 #if CONFIG_COMP_MUX
 

--- a/src/include/sof/audio/pcm_converter.h
+++ b/src/include/sof/audio/pcm_converter.h
@@ -15,7 +15,7 @@
 #define __SOF_AUDIO_PCM_CONVERTER_H__
 
 #include <ipc/stream.h>
-#include <config.h>
+
 #include <stddef.h>
 #include <stdint.h>
 

--- a/src/include/sof/audio/src/src_config.h
+++ b/src/include/sof/audio/src/src_config.h
@@ -8,7 +8,7 @@
 #ifndef __SOF_AUDIO_SRC_SRC_CONFIG_H__
 #define __SOF_AUDIO_SRC_SRC_CONFIG_H__
 
-#include <config.h>
+
 
 /* If next define is set to 1 the SRC is configured automatically. Setting
  * to zero temporarily is useful is for testing needs.

--- a/src/include/sof/debug/debug.h
+++ b/src/include/sof/debug/debug.h
@@ -17,7 +17,7 @@
 #include <sof/string.h>
 #include <ipc/info.h>
 #include <ipc/trace.h>
-#include <config.h>
+
 #include <stddef.h>
 #include <stdint.h>
 

--- a/src/include/sof/drivers/dmic.h
+++ b/src/include/sof/drivers/dmic.h
@@ -8,7 +8,7 @@
 #ifndef __SOF_DRIVERS_DMIC_H__
 #define __SOF_DRIVERS_DMIC_H__
 
-#include <config.h>
+
 
 #if CONFIG_INTEL_DMIC
 

--- a/src/include/sof/drivers/interrupt-map.h
+++ b/src/include/sof/drivers/interrupt-map.h
@@ -8,7 +8,7 @@
 #ifndef __SOF_DRIVERS_INTERRUPT_MAP_H__
 #define __SOF_DRIVERS_INTERRUPT_MAP_H__
 
-#include <config.h>
+
 
 #define SOF_IRQ_PASSIVE_LEVEL	0
 #define SOF_IRQ_ID_SHIFT	29

--- a/src/include/sof/drivers/mn.h
+++ b/src/include/sof/drivers/mn.h
@@ -10,7 +10,7 @@
 
 #include <platform/drivers/mn.h>
 #include <sof/sof.h>
-#include <config.h>
+
 #include <stdbool.h>
 #include <stdint.h>
 

--- a/src/include/sof/drivers/ssp.h
+++ b/src/include/sof/drivers/ssp.h
@@ -16,7 +16,7 @@
 #include <ipc/dai.h>
 #include <ipc/dai-intel.h>
 #include <user/trace.h>
-#include <config.h>
+
 #include <stdint.h>
 
 #define SSP_CLOCK_XTAL_OSCILLATOR	0x0

--- a/src/include/sof/lib/agent.h
+++ b/src/include/sof/lib/agent.h
@@ -13,7 +13,7 @@
 #include <sof/lib/perf_cnt.h>
 #include <sof/schedule/task.h>
 #include <sof/sof.h>
-#include <config.h>
+
 #include <stdbool.h>
 #include <stdint.h>
 

--- a/src/include/sof/lib/alloc.h
+++ b/src/include/sof/lib/alloc.h
@@ -20,7 +20,7 @@
 #include <sof/string.h>
 #include <sof/trace/trace.h>
 #include <user/trace.h>
-#include <config.h>
+
 #include <stddef.h>
 #include <stdint.h>
 

--- a/src/include/sof/lib/io.h
+++ b/src/include/sof/lib/io.h
@@ -8,7 +8,7 @@
 #ifndef __SOF_LIB_IO_H__
 #define __SOF_LIB_IO_H__
 
-#include <config.h>
+
 #include <stdint.h>
 
 #if CONFIG_LIBRARY

--- a/src/include/sof/lib/mm_heap.h
+++ b/src/include/sof/lib/mm_heap.h
@@ -15,7 +15,7 @@
 #include <sof/lib/memory.h>
 #include <sof/sof.h>
 #include <sof/spinlock.h>
-#include <config.h>
+
 #include <stddef.h>
 #include <stdint.h>
 

--- a/src/include/sof/lib/wait.h
+++ b/src/include/sof/lib/wait.h
@@ -21,7 +21,7 @@
 #include <sof/spinlock.h>
 #include <sof/trace/trace.h>
 #include <user/trace.h>
-#include <config.h>
+
 #include <stddef.h>
 #include <stdint.h>
 

--- a/src/include/sof/probe/probe.h
+++ b/src/include/sof/probe/probe.h
@@ -8,7 +8,7 @@
 #ifndef __SOF_PROBE_PROBE_H__
 #define __SOF_PROBE_PROBE_H__
 
-#include <config.h>
+
 
 #if CONFIG_PROBE
 

--- a/src/include/sof/spinlock.h
+++ b/src/include/sof/spinlock.h
@@ -15,7 +15,7 @@
 
 #include <arch/spinlock.h>
 #include <sof/lib/memory.h>
-#include <config.h>
+
 #include <stdint.h>
 
 /*

--- a/src/include/sof/trace/trace.h
+++ b/src/include/sof/trace/trace.h
@@ -21,7 +21,7 @@
 #include <sof/common.h>
 #include <sof/sof.h>
 #include <sof/trace/preproc.h>
-#include <config.h>
+
 #include <stdbool.h>
 #include <stdint.h>
 #if CONFIG_LIBRARY

--- a/src/init/ext_manifest.c
+++ b/src/init/ext_manifest.c
@@ -11,7 +11,7 @@
 #include <sof/debug/debug.h>
 #include <kernel/abi.h>
 #include <kernel/ext_manifest.h>
-#include <config.h>
+
 #include <version.h>
 
 const struct ext_man_fw_version ext_man_fw_ver

--- a/src/ipc/dma-copy.c
+++ b/src/ipc/dma-copy.c
@@ -12,7 +12,7 @@
 #include <sof/trace/dma-trace.h>
 #include <sof/trace/trace.h>
 #include <user/trace.h>
-#include <config.h>
+
 #include <errno.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -50,7 +50,7 @@
 #include <user/trace.h>
 #include <ipc/probe.h>
 #include <sof/probe/probe.h>
-#include <config.h>
+
 #include <errno.h>
 #include <stdbool.h>
 #include <stddef.h>

--- a/src/ipc/probe_support.c
+++ b/src/ipc/probe_support.c
@@ -7,7 +7,7 @@
 #include <ipc/info.h>
 #include <sof/fw-ready-metadata.h>
 #include <sof/compiler_attributes.h>
-#include <config.h>
+
 
 const struct sof_ipc_probe_support probe_support
 	__section(".fw_ready_metadata") = {

--- a/src/lib/alloc.c
+++ b/src/lib/alloc.c
@@ -18,7 +18,7 @@
 #include <sof/string.h>
 #include <ipc/topology.h>
 #include <ipc/trace.h>
-#include <config.h>
+
 #include <errno.h>
 #include <stdbool.h>
 #include <stddef.h>

--- a/src/lib/lib.c
+++ b/src/lib/lib.c
@@ -5,7 +5,7 @@
 // Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
 
 #include <sof/string.h>
-#include <config.h>
+
 #include <stddef.h>
 #include <stdint.h>
 

--- a/src/platform/apollolake/apollolake.x.in
+++ b/src/platform/apollolake/apollolake.x.in
@@ -7,7 +7,7 @@
  * Use spaces for formatting as cpp ignore tab sizes.
  */
 
-#include <config.h>
+
 #include <sof/lib/memory.h>
 #include <xtensa/config/core-isa.h>
 

--- a/src/platform/apollolake/boot_ldr.x.in
+++ b/src/platform/apollolake/boot_ldr.x.in
@@ -7,7 +7,7 @@
  * Use spaces for formatting as cpp ignore tab sizes.
  */
 
-#include <config.h>
+
 #include <sof/lib/memory.h>
 #include <xtensa/config/core-isa.h>
 

--- a/src/platform/apollolake/include/platform/drivers/interrupt.h
+++ b/src/platform/apollolake/include/platform/drivers/interrupt.h
@@ -13,7 +13,7 @@
 
 #include <cavs/drivers/interrupt.h>
 #include <sof/bit.h>
-#include <config.h>
+
 
 #define PLATFORM_IRQ_HW_NUM	XCHAL_NUM_INTERRUPTS
 #define PLATFORM_IRQ_FIRST_CHILD  PLATFORM_IRQ_HW_NUM

--- a/src/platform/apollolake/include/platform/lib/memory.h
+++ b/src/platform/apollolake/include/platform/lib/memory.h
@@ -13,7 +13,7 @@
 
 #include <cavs/lib/memory.h>
 #include <sof/lib/cpu.h>
-#include <config.h>
+
 
 /* physical DSP addresses */
 

--- a/src/platform/apollolake/rom.x.in
+++ b/src/platform/apollolake/rom.x.in
@@ -7,7 +7,7 @@
  * Use spaces for formatting as cpp ignore tab sizes.
  */
 
-#include <config.h>
+
 #include <sof/lib/memory.h>
 #include <xtensa/config/core-isa.h>
 

--- a/src/platform/baytrail/baytrail.x.in
+++ b/src/platform/baytrail/baytrail.x.in
@@ -7,7 +7,7 @@
  * Use spaces for formatting as cpp ignore tab sizes.
  */
 
-#include <config.h>
+
 #include <sof/lib/memory.h>
 #include <xtensa/config/core-isa.h>
 

--- a/src/platform/baytrail/include/platform/drivers/dw-dma.h
+++ b/src/platform/baytrail/include/platform/drivers/dw-dma.h
@@ -11,7 +11,7 @@
 #define __PLATFORM_DRIVERS_DW_DMA_H__
 
 #include <sof/bit.h>
-#include <config.h>
+
 #include <stdint.h>
 
 struct dma;

--- a/src/platform/baytrail/include/platform/drivers/interrupt.h
+++ b/src/platform/baytrail/include/platform/drivers/interrupt.h
@@ -11,7 +11,7 @@
 #define __PLATFORM_DRIVERS_INTERRUPT_H__
 
 #include <sof/bit.h>
-#include <config.h>
+
 
 /* IRQ numbers */
 #if CONFIG_INTERRUPT_LEVEL_1

--- a/src/platform/baytrail/include/platform/drivers/pmc.h
+++ b/src/platform/baytrail/include/platform/drivers/pmc.h
@@ -10,7 +10,7 @@
 #ifndef __PLATFORM_DRIVERS_PMC_H__
 #define __PLATFORM_DRIVERS_PMC_H__
 
-#include <config.h>
+
 #include <stdint.h>
 
 /* messages */

--- a/src/platform/baytrail/include/platform/lib/cpu.h
+++ b/src/platform/baytrail/include/platform/lib/cpu.h
@@ -15,7 +15,7 @@
 #ifndef __PLATFORM_LIB_CPU_H__
 #define __PLATFORM_LIB_CPU_H__
 
-#include <config.h>
+
 
 /** \brief Number of available DSP cores (conf. by kconfig) */
 #define PLATFORM_CORE_COUNT	CONFIG_CORE_COUNT

--- a/src/platform/baytrail/include/platform/lib/dma.h
+++ b/src/platform/baytrail/include/platform/lib/dma.h
@@ -11,7 +11,7 @@
 #ifndef __PLATFORM_LIB_DMA_H__
 #define __PLATFORM_LIB_DMA_H__
 
-#include <config.h>
+
 
 #if defined CONFIG_CHERRYTRAIL_EXTRA_DW_DMA
 #define PLATFORM_NUM_DMACS	3

--- a/src/platform/baytrail/include/platform/lib/mailbox.h
+++ b/src/platform/baytrail/include/platform/lib/mailbox.h
@@ -11,7 +11,7 @@
 #define __PLATFORM_LIB_MAILBOX_H__
 
 #include <sof/lib/memory.h>
-#include <config.h>
+
 #include <stddef.h>
 #include <stdint.h>
 

--- a/src/platform/baytrail/include/platform/lib/memory.h
+++ b/src/platform/baytrail/include/platform/lib/memory.h
@@ -10,7 +10,7 @@
 #ifndef __PLATFORM_LIB_MEMORY_H__
 #define __PLATFORM_LIB_MEMORY_H__
 
-#include <config.h>
+
 
 #if !defined(__ASSEMBLER__) && !defined(LINKER)
 

--- a/src/platform/baytrail/lib/clk.c
+++ b/src/platform/baytrail/lib/clk.c
@@ -12,7 +12,7 @@
 #include <sof/lib/notifier.h>
 #include <sof/sof.h>
 #include <sof/spinlock.h>
-#include <config.h>
+
 
 #if CONFIG_BAYTRAIL
 const struct freq_table platform_cpu_freq[] = {

--- a/src/platform/baytrail/lib/dai.c
+++ b/src/platform/baytrail/lib/dai.c
@@ -13,7 +13,7 @@
 #include <sof/sof.h>
 #include <ipc/dai.h>
 #include <ipc/stream.h>
-#include <config.h>
+
 
 static SHARED_DATA struct dai ssp[] = {
 {

--- a/src/platform/baytrail/lib/dma.c
+++ b/src/platform/baytrail/lib/dma.c
@@ -11,7 +11,7 @@
 #include <sof/lib/memory.h>
 #include <sof/sof.h>
 #include <sof/spinlock.h>
-#include <config.h>
+
 
 const struct dw_drv_plat_data dmac0 = {
 	.chan[0] = {

--- a/src/platform/baytrail/platform.c
+++ b/src/platform/baytrail/platform.c
@@ -35,7 +35,7 @@
 #include <ipc/info.h>
 #include <kernel/abi.h>
 #include <kernel/ext_manifest.h>
-#include <config.h>
+
 #include <version.h>
 #include <errno.h>
 #include <stdbool.h>

--- a/src/platform/cannonlake/boot_ldr.x.in
+++ b/src/platform/cannonlake/boot_ldr.x.in
@@ -7,7 +7,7 @@
  * Use spaces for formatting as cpp ignore tab sizes.
  */
 
-#include <config.h>
+
 #include <sof/lib/memory.h>
 #include <xtensa/config/core-isa.h>
 

--- a/src/platform/cannonlake/cannonlake.x.in
+++ b/src/platform/cannonlake/cannonlake.x.in
@@ -7,7 +7,7 @@
  * Use spaces for formatting as cpp ignore tab sizes.
  */
 
-#include <config.h>
+
 #include <sof/lib/memory.h>
 #include <xtensa/config/core-isa.h>
 

--- a/src/platform/cannonlake/include/platform/drivers/interrupt.h
+++ b/src/platform/cannonlake/include/platform/drivers/interrupt.h
@@ -14,7 +14,7 @@
 
 #include <cavs/drivers/interrupt.h>
 #include <sof/bit.h>
-#include <config.h>
+
 
 #define PLATFORM_IRQ_HW_NUM	XCHAL_NUM_INTERRUPTS
 #define PLATFORM_IRQ_FIRST_CHILD  PLATFORM_IRQ_HW_NUM

--- a/src/platform/cannonlake/include/platform/lib/memory.h
+++ b/src/platform/cannonlake/include/platform/lib/memory.h
@@ -14,7 +14,7 @@
 
 #include <cavs/lib/memory.h>
 #include <sof/lib/cpu.h>
-#include <config.h>
+
 
 /* physical DSP addresses */
 

--- a/src/platform/cannonlake/rom.x.in
+++ b/src/platform/cannonlake/rom.x.in
@@ -7,7 +7,7 @@
  * Use spaces for formatting as cpp ignore tab sizes.
  */
 
-#include <config.h>
+
 #include <sof/lib/memory.h>
 #include <xtensa/config/core-isa.h>
 

--- a/src/platform/haswell/haswell.x.in
+++ b/src/platform/haswell/haswell.x.in
@@ -7,7 +7,7 @@
  * Use spaces for formatting as cpp ignore tab sizes.
  */
 
-#include <config.h>
+
 #include <sof/lib/memory.h>
 #include <xtensa/config/core-isa.h>
 

--- a/src/platform/haswell/include/arch/xtensa/config/core-isa.h
+++ b/src/platform/haswell/include/arch/xtensa/config/core-isa.h
@@ -1,4 +1,4 @@
-#include <config.h>
+/* SPDX-License-Identifier: BSD-3-Clause */
 
 #if CONFIG_HASWELL
 #include <xtensa/config/core-isa-hsw.h>

--- a/src/platform/haswell/include/platform/drivers/interrupt.h
+++ b/src/platform/haswell/include/platform/drivers/interrupt.h
@@ -11,7 +11,7 @@
 #define __PLATFORM_DRIVERS_INTERRUPT_H__
 
 #include <sof/bit.h>
-#include <config.h>
+
 
 #define PLATFORM_IRQ_HW_NUM	XCHAL_NUM_INTERRUPTS
 #define PLATFORM_IRQ_FIRST_CHILD  PLATFORM_IRQ_HW_NUM

--- a/src/platform/haswell/include/platform/lib/cpu.h
+++ b/src/platform/haswell/include/platform/lib/cpu.h
@@ -15,7 +15,7 @@
 #ifndef __PLATFORM_LIB_CPU_H__
 #define __PLATFORM_LIB_CPU_H__
 
-#include <config.h>
+
 
 /** \brief Number of available DSP cores (conf. by kconfig) */
 #define PLATFORM_CORE_COUNT	CONFIG_CORE_COUNT

--- a/src/platform/haswell/include/platform/lib/mailbox.h
+++ b/src/platform/haswell/include/platform/lib/mailbox.h
@@ -11,7 +11,7 @@
 #define __PLATFORM_LIB_MAILBOX_H__
 
 #include <sof/lib/memory.h>
-#include <config.h>
+
 #include <stddef.h>
 #include <stdint.h>
 

--- a/src/platform/haswell/include/platform/lib/memory.h
+++ b/src/platform/haswell/include/platform/lib/memory.h
@@ -10,7 +10,7 @@
 #ifndef __PLATFORM_LIB_MEMORY_H__
 #define __PLATFORM_LIB_MEMORY_H__
 
-#include <config.h>
+
 
 #if !defined(__ASSEMBLER__) && !defined(LINKER)
 

--- a/src/platform/icelake/boot_ldr.x.in
+++ b/src/platform/icelake/boot_ldr.x.in
@@ -7,7 +7,7 @@
  * Use spaces for formatting as cpp ignore tab sizes.
  */
 
-#include <config.h>
+
 #include <sof/lib/memory.h>
 #include <xtensa/config/core-isa.h>
 

--- a/src/platform/icelake/icelake.x.in
+++ b/src/platform/icelake/icelake.x.in
@@ -7,7 +7,7 @@
  * Use spaces for formatting as cpp ignore tab sizes.
  */
 
-#include <config.h>
+
 #include <sof/lib/memory.h>
 #include <xtensa/config/core-isa.h>
 

--- a/src/platform/icelake/include/platform/drivers/interrupt.h
+++ b/src/platform/icelake/include/platform/drivers/interrupt.h
@@ -14,7 +14,7 @@
 
 #include <cavs/drivers/interrupt.h>
 #include <sof/bit.h>
-#include <config.h>
+
 
 #define PLATFORM_IRQ_HW_NUM	XCHAL_NUM_INTERRUPTS
 #define PLATFORM_IRQ_FIRST_CHILD  PLATFORM_IRQ_HW_NUM

--- a/src/platform/icelake/include/platform/lib/memory.h
+++ b/src/platform/icelake/include/platform/lib/memory.h
@@ -14,7 +14,7 @@
 
 #include <cavs/lib/memory.h>
 #include <sof/lib/cpu.h>
-#include <config.h>
+
 
 /* physical DSP addresses */
 

--- a/src/platform/icelake/rom.x.in
+++ b/src/platform/icelake/rom.x.in
@@ -7,7 +7,7 @@
  * Use spaces for formatting as cpp ignore tab sizes.
  */
 
-#include <config.h>
+
 #include <sof/lib/memory.h>
 #include <xtensa/config/core-isa.h>
 

--- a/src/platform/imx8/imx8.x.in
+++ b/src/platform/imx8/imx8.x.in
@@ -7,7 +7,7 @@
  * Use spaces for formatting as cpp ignore tab sizes.
  */
 
-#include <config.h>
+
 #include <sof/lib/memory.h>
 #include <xtensa/config/core-isa.h>
 

--- a/src/platform/imx8/include/platform/drivers/interrupt.h
+++ b/src/platform/imx8/include/platform/drivers/interrupt.h
@@ -11,7 +11,7 @@
 #define __PLATFORM_DRIVERS_INTERRUPT_H__
 
 #include <sof/bit.h>
-#include <config.h>
+
 
 /* IRQ numbers */
 #if CONFIG_INTERRUPT_LEVEL_1

--- a/src/platform/imx8/include/platform/lib/cpu.h
+++ b/src/platform/imx8/include/platform/lib/cpu.h
@@ -15,7 +15,7 @@
 #ifndef __PLATFORM_LIB_CPU_H__
 #define __PLATFORM_LIB_CPU_H__
 
-#include <config.h>
+
 
 /** \brief Number of available DSP cores (conf. by kconfig) */
 #define PLATFORM_CORE_COUNT	CONFIG_CORE_COUNT

--- a/src/platform/imx8/include/platform/lib/memory.h
+++ b/src/platform/imx8/include/platform/lib/memory.h
@@ -11,7 +11,7 @@
 #define __PLATFORM_LIB_MEMORY_H__
 
 #include <sof/lib/cache.h>
-#include <config.h>
+
 
 /* data cache line alignment */
 #define PLATFORM_DCACHE_ALIGN	DCACHE_LINE_SIZE

--- a/src/platform/imx8m/imx8m.x.in
+++ b/src/platform/imx8m/imx8m.x.in
@@ -7,7 +7,7 @@
  * Use spaces for formatting as cpp ignore tab sizes.
  */
 
-#include <config.h>
+
 #include <sof/lib/memory.h>
 #include <xtensa/config/core-isa.h>
 

--- a/src/platform/imx8m/include/platform/drivers/interrupt.h
+++ b/src/platform/imx8m/include/platform/drivers/interrupt.h
@@ -11,7 +11,7 @@
 #define __PLATFORM_DRIVERS_INTERRUPT_H__
 
 #include <sof/bit.h>
-#include <config.h>
+
 
 /* IRQ numbers */
 #if CONFIG_INTERRUPT_LEVEL_1

--- a/src/platform/imx8m/include/platform/lib/cpu.h
+++ b/src/platform/imx8m/include/platform/lib/cpu.h
@@ -15,7 +15,7 @@
 #ifndef __PLATFORM_LIB_CPU_H__
 #define __PLATFORM_LIB_CPU_H__
 
-#include <config.h>
+
 
 /** \brief Number of available DSP cores (conf. by kconfig) */
 #define PLATFORM_CORE_COUNT	CONFIG_CORE_COUNT

--- a/src/platform/imx8m/include/platform/lib/memory.h
+++ b/src/platform/imx8m/include/platform/lib/memory.h
@@ -11,7 +11,7 @@
 #define __PLATFORM_LIB_MEMORY_H__
 
 #include <sof/lib/cache.h>
-#include <config.h>
+
 
 /* data cache line alignment */
 #define PLATFORM_DCACHE_ALIGN	DCACHE_LINE_SIZE

--- a/src/platform/intel/cavs/alternate_reset_vector.S
+++ b/src/platform/intel/cavs/alternate_reset_vector.S
@@ -3,7 +3,7 @@
  * Copyright(c) 2019 Intel Corporation. All rights reserved.
  */
 
-#include <config.h>
+
 #include <sof/bit.h>
 #include <sof/common.h>
 #include <sof/drivers/interrupt.h>

--- a/src/platform/intel/cavs/boot_entry.S
+++ b/src/platform/intel/cavs/boot_entry.S
@@ -16,7 +16,7 @@
 #include <sof/lib/memory.h>
 #include <sof/lib/shim.h>
 #include <sof/platform.h>
-#include <config.h>
+
 #include <xtensa/config/core-isa.h>
 #include <xtensa/corebits.h>
 #include "xtos-internal.h"

--- a/src/platform/intel/cavs/boot_loader.c
+++ b/src/platform/intel/cavs/boot_loader.c
@@ -15,7 +15,7 @@
 #include <sof/sof.h>
 #include <sof/trace/trace.h>
 #include <rimage/sof/user/manifest.h>
-#include <config.h>
+
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/src/platform/intel/cavs/include/cavs/drivers/dw-dma.h
+++ b/src/platform/intel/cavs/include/cavs/drivers/dw-dma.h
@@ -13,7 +13,7 @@
 #include <sof/bit.h>
 #include <sof/lib/dma.h>
 #include <sof/lib/shim.h>
-#include <config.h>
+
 #include <stdint.h>
 
 /* number of supported DW-DMACs */

--- a/src/platform/intel/cavs/include/cavs/drivers/idc.h
+++ b/src/platform/intel/cavs/include/cavs/drivers/idc.h
@@ -10,7 +10,7 @@
 #ifndef __CAVS_DRIVERS_IDC_H__
 #define __CAVS_DRIVERS_IDC_H__
 
-#include <config.h>
+
 #include <stdint.h>
 
 struct idc_msg;

--- a/src/platform/intel/cavs/include/cavs/lib/cpu.h
+++ b/src/platform/intel/cavs/include/cavs/lib/cpu.h
@@ -15,7 +15,7 @@
 #ifndef __CAVS_LIB_CPU_H__
 #define __CAVS_LIB_CPU_H__
 
-#include <config.h>
+
 
 /** \brief Number of available DSP cores (conf. by kconfig) */
 #define PLATFORM_CORE_COUNT	CONFIG_CORE_COUNT

--- a/src/platform/intel/cavs/include/cavs/lib/memory.h
+++ b/src/platform/intel/cavs/include/cavs/lib/memory.h
@@ -14,7 +14,7 @@
 #if !defined(__ASSEMBLER__) && !defined(LINKER)
 #include <sof/lib/cpu.h>
 #endif
-#include <config.h>
+
 
 /* data cache line alignment */
 #define PLATFORM_DCACHE_ALIGN	DCACHE_LINE_SIZE

--- a/src/platform/intel/cavs/include/cavs/lib/pm_memory.h
+++ b/src/platform/intel/cavs/include/cavs/lib/pm_memory.h
@@ -21,7 +21,7 @@
 #include <sof/lib/shim.h>
 #include <sof/lib/wait.h>
 #include <sof/math/numbers.h>
-#include <config.h>
+
 #include <stdbool.h>
 #include <stdint.h>
 

--- a/src/platform/intel/cavs/include/cavs/version.h
+++ b/src/platform/intel/cavs/include/cavs/version.h
@@ -8,7 +8,7 @@
 #ifndef __CAVS_VERSION_H__
 #define __CAVS_VERSION_H__
 
-#include <config.h>
+
 
 #define CAVS_VERSION_1_5 0x10500
 #define CAVS_VERSION_1_8 0x10800

--- a/src/platform/intel/cavs/lib/dai.c
+++ b/src/platform/intel/cavs/lib/dai.c
@@ -18,7 +18,7 @@
 #include <sof/spinlock.h>
 #include <ipc/dai.h>
 #include <ipc/stream.h>
-#include <config.h>
+
 
 #if CONFIG_INTEL_SSP
 

--- a/src/platform/intel/cavs/lib/dma.c
+++ b/src/platform/intel/cavs/lib/dma.c
@@ -15,7 +15,7 @@
 #include <sof/lib/memory.h>
 #include <sof/sof.h>
 #include <sof/spinlock.h>
-#include <config.h>
+
 
 #if CONFIG_APOLLOLAKE
 #define DMAC0_CLASS 1

--- a/src/platform/intel/cavs/lib/pm_memory.c
+++ b/src/platform/intel/cavs/lib/pm_memory.c
@@ -12,7 +12,7 @@
 #include <sof/lib/uuid.h>
 #include <sof/trace/trace.h>
 #include <user/trace.h>
-#include <config.h>
+
 #include <stdbool.h>
 #include <stdint.h>
 

--- a/src/platform/intel/cavs/lib/pm_runtime.c
+++ b/src/platform/intel/cavs/lib/pm_runtime.c
@@ -28,7 +28,7 @@
 #include <sof/trace/trace.h>
 #include <ipc/topology.h>
 #include <user/trace.h>
-#include <config.h>
+
 #include <version.h>
 #include <stdint.h>
 

--- a/src/platform/intel/cavs/lps_wait.c
+++ b/src/platform/intel/cavs/lps_wait.c
@@ -14,7 +14,7 @@
 #include <sof/lib/pm_runtime.h>
 #include <sof/lib/shim.h>
 #include <sof/schedule/task.h>
-#include <config.h>
+
 #include <stdint.h>
 
 #define LPSRAM_MAGIC_VALUE 0x13579BDF

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -44,7 +44,7 @@
 #include <ipc/info.h>
 #include <kernel/abi.h>
 #include <kernel/ext_manifest.h>
-#include <config.h>
+
 #include <version.h>
 #include <errno.h>
 #include <stdint.h>

--- a/src/platform/suecreek/boot_ldr.x.in
+++ b/src/platform/suecreek/boot_ldr.x.in
@@ -7,7 +7,7 @@
  * Use spaces for formatting as cpp ignore tab sizes.
  */
 
-#include <config.h>
+
 #include <sof/lib/memory.h>
 #include <xtensa/config/core-isa.h>
 

--- a/src/platform/suecreek/include/platform/drivers/interrupt.h
+++ b/src/platform/suecreek/include/platform/drivers/interrupt.h
@@ -15,7 +15,7 @@
 #include <cavs/drivers/interrupt.h>
 #include <sof/bit.h>
 #include <sof/drivers/interrupt-map.h>
-#include <config.h>
+
 
 #define PLATFORM_IRQ_HW_NUM	XCHAL_NUM_INTERRUPTS
 #define PLATFORM_IRQ_FIRST_CHILD  PLATFORM_IRQ_HW_NUM

--- a/src/platform/suecreek/include/platform/lib/memory.h
+++ b/src/platform/suecreek/include/platform/lib/memory.h
@@ -14,7 +14,7 @@
 
 #include <cavs/lib/memory.h>
 #include <sof/lib/cpu.h>
-#include <config.h>
+
 
 /* physical DSP addresses */
 

--- a/src/platform/suecreek/rom.x.in
+++ b/src/platform/suecreek/rom.x.in
@@ -7,7 +7,7 @@
  * Use spaces for formatting as cpp ignore tab sizes.
  */
 
-#include <config.h>
+
 #include <sof/lib/memory.h>
 #include <xtensa/config/core-isa.h>
 

--- a/src/platform/suecreek/suecreek.x.in
+++ b/src/platform/suecreek/suecreek.x.in
@@ -7,7 +7,7 @@
  * Use spaces for formatting as cpp ignore tab sizes.
  */
 
-#include <config.h>
+
 #include <sof/lib/memory.h>
 #include <xtensa/config/core-isa.h>
 

--- a/src/platform/tigerlake/boot_ldr.x.in
+++ b/src/platform/tigerlake/boot_ldr.x.in
@@ -7,7 +7,7 @@
  * Use spaces for formatting as cpp ignore tab sizes.
  */
 
-#include <config.h>
+
 #include <sof/lib/memory.h>
 #include <xtensa/config/core-isa.h>
 

--- a/src/platform/tigerlake/include/platform/drivers/interrupt.h
+++ b/src/platform/tigerlake/include/platform/drivers/interrupt.h
@@ -15,7 +15,7 @@
 #if !defined(__ASSEMBLER__) && !defined(LINKER)
 #include <cavs/drivers/interrupt.h>
 #include <sof/bit.h>
-#include <config.h>
+
 #endif
 
 #define PLATFORM_IRQ_HW_NUM	XCHAL_NUM_INTERRUPTS

--- a/src/platform/tigerlake/include/platform/lib/memory.h
+++ b/src/platform/tigerlake/include/platform/lib/memory.h
@@ -14,7 +14,7 @@
 
 #include <cavs/lib/memory.h>
 #include <sof/lib/cpu.h>
-#include <config.h>
+
 
 /* physical DSP addresses */
 

--- a/src/platform/tigerlake/rom.x.in
+++ b/src/platform/tigerlake/rom.x.in
@@ -7,7 +7,7 @@
  * Use spaces for formatting as cpp ignore tab sizes.
  */
 
-#include <config.h>
+
 #include <sof/lib/memory.h>
 #include <xtensa/config/core-isa.h>
 

--- a/src/platform/tigerlake/tigerlake.x.in
+++ b/src/platform/tigerlake/tigerlake.x.in
@@ -7,7 +7,7 @@
  * Use spaces for formatting as cpp ignore tab sizes.
  */
 
-#include <config.h>
+
 #include <sof/lib/memory.h>
 #include <xtensa/config/core-isa.h>
 

--- a/src/probe/probe.c
+++ b/src/probe/probe.c
@@ -5,7 +5,7 @@
 // Author: Artur Kloniecki <arturx.kloniecki@linux.intel.com>
 // Author: Adrian Bonislawski <adrian.bonislawski@linux.intel.com>
 
-#include <config.h>
+
 #include <sof/audio/buffer.h>
 #include <sof/audio/component.h>
 #include <sof/probe/probe.h>

--- a/src/schedule/ll_schedule.c
+++ b/src/schedule/ll_schedule.c
@@ -25,7 +25,7 @@
 #include <sof/schedule/task.h>
 #include <sof/spinlock.h>
 #include <ipc/topology.h>
-#include <config.h>
+
 #include <errno.h>
 #include <stdbool.h>
 #include <stddef.h>

--- a/src/spinlock.c
+++ b/src/spinlock.c
@@ -9,7 +9,7 @@
 #include <sof/lib/uuid.h>
 #endif
 #include <sof/spinlock.h>
-#include <config.h>
+
 #include <stdint.h>
 
 #if CONFIG_DEBUG_LOCKS

--- a/src/trace/dma-trace.c
+++ b/src/trace/dma-trace.c
@@ -24,7 +24,7 @@
 #include <sof/trace/dma-trace.h>
 #include <ipc/topology.h>
 #include <ipc/trace.h>
-#include <config.h>
+
 #include <errno.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/tools/testbench/CMakeLists.txt
+++ b/tools/testbench/CMakeLists.txt
@@ -25,15 +25,19 @@ sof_append_relative_path_definitions(testbench)
 
 target_include_directories(testbench PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
-target_compile_options(testbench PRIVATE -g -O3 -Wall -Werror -Wl,-EL -Wmissing-prototypes -Wimplicit-fallthrough=3 -DCONFIG_LIBRARY)
+set(sof_source_directory "${PROJECT_SOURCE_DIR}/../..")
+set(sof_install_directory "${PROJECT_BINARY_DIR}/sof_ep/install")
+set(sof_binary_directory "${PROJECT_BINARY_DIR}/sof_ep/build")
+
+set(config_h ${sof_binary_directory}/library_autoconfig.h)
+
+target_compile_options(testbench PRIVATE -g -O3 -Wall -Werror -Wl,-EL -Wmissing-prototypes
+  -Wimplicit-fallthrough=3 -DCONFIG_LIBRARY -imacros ${config_h})
 
 target_link_libraries(testbench PRIVATE -ldl -lm)
 
 install(TARGETS testbench DESTINATION bin)
 
-set(sof_source_directory "${PROJECT_SOURCE_DIR}/../..")
-set(sof_install_directory "${PROJECT_BINARY_DIR}/sof_ep/install")
-set(sof_binary_directory "${PROJECT_BINARY_DIR}/sof_ep/build")
 
 include(ExternalProject)
 
@@ -45,6 +49,7 @@ ExternalProject_Add(sof_ep
 	CMAKE_ARGS -DCONFIG_LIBRARY=ON
 		-DCMAKE_INSTALL_PREFIX=${sof_install_directory}
 		-DCMAKE_VERBOSE_MAKEFILE=${CMAKE_VERBOSE_MAKEFILE}
+		-DCONFIG_H_PATH=${config_h}
 	BUILD_ALWAYS 1
 	BUILD_BYPRODUCTS "${sof_install_directory}/lib/libsof.so"
 )


### PR DESCRIPTION
3rd commit:
Rename config.h to kconfig.h to catch any remaining #include config.h
left in any other PR, branch or any other concurrent work in progress
unknown to this.

2nd commit:
Using -imacros on the compiler command line instead of explicitly
including config.h is not just less tedious in the future:
- it also makes sure configuration always comes first and is never
  accidentally missed by an earlier #include
- it makes sure all translation units get the (same) configuration
- it lets parent projects like Zephyr override the config.h name

To test this I ran `./scripts/xtensa-build-all.sh -a -r`, compared
binaries before and after this change and found no output difference.

Full disclosure: this required a few unrelated tricks not submitted here
like a .tarball-version file, commenting out `__DATE__` and `__TIME__` in a
few places, running strip-determinism on the .a files because our
crosstool-ng reference is not cutting-edge, etc.

As Tigerlake doesn't build by default it required a couple more hacks to
compile.

Blank lines are left instead of the former #include lines so even debug
objects are the same.

Only defconfigs were tested. On the other hand, this commit was _not_
performed by a script but by changing the name of the generated file and
clicking on and fixing every build failure. This proves that every
removed #include was actually required by one or more tested defconfigs
and that the added -imacros flag does affect the compilation of all the
modified files.

There is no #include config.h left: they were all in use in at least
one _defconfig.

I think comparing all binaries produced by ./scripts/xtensa-build-all.sh
-r -a provides extensive enough coverage but note this was tested only
with the crosstool-ng toolchain described in the SOF documentation.

The obsolete[*] xt-xcc front-end is gcc-based and the newer xt-clang
front-end is (surprise) clang-based. clang (copies many gcc options and)
does support -imacros so I don't expect any issue with either xt-xcc or
xt-clang. In the worst case, I do not expect any compiler front end to
_silently_ discard any unknown command line flag nor to ignore a missing
or misnamed config.h file.

[*] https://github.com/zephyrproject-rtos/zephyr/issues/3165