### PR TITLE
zephyr: Include MUX sources only when enabled

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -55,6 +55,15 @@ if (CONFIG_SOC_SERIES_INTEL_ADSP_BAYTRAIL)
 		 ../src/drivers/intel/pmc-ipc.c
 	)
 
+	# Platform includes
+	zephyr_library_sources(
+		../src/platform/baytrail/platform.c
+		../src/platform/baytrail/lib/dai.c
+		../src/platform/baytrail/lib/clk.c
+		../src/platform/baytrail/lib/dma.c
+		../src/schedule/dma_multi_chan_domain.c
+	)
+
 	set(PLATFORM "baytrail")
 endif()
 

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -301,8 +301,8 @@ zephyr_library_sources(
 	../src/audio/asrc/asrc_farrow_generic.c
 	../src/audio/dcblock/dcblock_generic.c
 	../src/audio/dcblock/dcblock.c
-	../src/audio/mux/mux.c
-	../src/audio/mux/mux_generic.c
+	#../src/audio/mux/mux.c
+	#../src/audio/mux/mux_generic.c
 	../src/audio/eq_iir/iir_generic.c
 	../src/audio/eq_iir/iir_hifi3.c
 	../src/audio/eq_iir/iir.c
@@ -320,6 +320,8 @@ zephyr_library_sources(
 )
 
 zephyr_library_sources_ifdef(CONFIG_HAVE_AGENT ../src/lib/agent.c)
+zephyr_library_sources_ifdef(CONFIG_COMP_MUX ../src/audio/mux/mux.c)
+zephyr_library_sources_ifdef(CONFIG_COMP_MUX ../src/audio/mux/mux_generic.c)
 
 zephyr_library_link_libraries(SOF)
 target_link_libraries(SOF INTERFACE zephyr_interface)

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -469,7 +469,10 @@ int task_main_start(void)
 	sys_comp_keyword_init();
 	sys_comp_asrc_init();
 	sys_comp_dcblock_init();
-	sys_comp_mux_init();
+
+	if (IS_ENABLED(CONFIG_COMP_MUX)) {
+		sys_comp_mux_init();
+	}
 
 	/* init pipeline position offsets */
 	pipeline_posn_init(sof);


### PR DESCRIPTION
Fixes build for boards with disabled MUX.
