### PR TITLE
debug: disable stack rewind in exception

### DIFF
--- a/src/arch/xtensa/include/arch/init.h
+++ b/src/arch/xtensa/include/arch/init.h
@@ -35,10 +35,9 @@ static inline void exception(void)
 
 	__asm__ __volatile__("rsr %0, EPC1" : "=a" (epc1) : : "memory");
 
-	/* now panic and rewind 8 stack frames. */
+	/* now save panic dump */
 	/* TODO: we could invoke a GDB stub here */
-	panic_rewind(SOF_IPC_PANIC_EXCEPTION, 8 * sizeof(uint32_t),
-		     NULL, &epc1);
+	panic_dump(SOF_IPC_PANIC_EXCEPTION, NULL, &epc1);
 }
 
 /**

--- a/src/debug/panic.c
+++ b/src/debug/panic.c
@@ -30,9 +30,8 @@ void dump_panicinfo(void *addr, struct sof_ipc_panic_info *panic_info)
 	dcache_writeback_region(addr, sizeof(struct sof_ipc_panic_info));
 }
 
-/* panic and rewind stack */
-void panic_rewind(uint32_t p, uint32_t stack_rewind_frames,
-		  struct sof_ipc_panic_info *panic_info, uintptr_t *data)
+void panic_dump(uint32_t p, struct sof_ipc_panic_info *panic_info,
+		uintptr_t *data)
 {
 	char *ext_offset;
 	size_t count;
@@ -56,7 +55,7 @@ void panic_rewind(uint32_t p, uint32_t stack_rewind_frames,
 #endif
 
 	/* dump stack frames */
-	p = dump_stack(p, ext_offset, stack_rewind_frames, count, &stack_ptr);
+	p = dump_stack(p, ext_offset, 0, count, &stack_ptr);
 
 	/* dump DSP core registers
 	 * after arch_dump_regs() use only inline funcs if needed
@@ -109,5 +108,5 @@ void __panic(uint32_t p, char *filename, uint32_t linenum)
 			     "a3", "memory");
 #endif
 
-	panic_rewind(p, 0, &panicinfo, NULL);
+	panic_dump(p, &panicinfo, NULL);
 }

--- a/src/include/sof/debug/panic.h
+++ b/src/include/sof/debug/panic.h
@@ -26,8 +26,8 @@
 #endif
 
 void dump_panicinfo(void *addr, struct sof_ipc_panic_info *panic_info);
-void panic_rewind(uint32_t p, uint32_t stack_rewind_frames,
-		  struct sof_ipc_panic_info *panic_info, uintptr_t *data)
+void panic_dump(uint32_t p, struct sof_ipc_panic_info *panic_info,
+		uintptr_t *data)
 	SOF_NORETURN;
 void __panic(uint32_t p, char *filename, uint32_t linenum) SOF_NORETURN;
 


### PR DESCRIPTION
this will restore functional backtrace for exception stack dump because stack rewind
is not implemented correctly

Example log from coredump (full backtrace):

```
$2 = "backtrace"
# 0  0xbe050480 in literals ()
# 1  0xbe04306b in memcpy_s (dest=0xbe00881c, dest_size=0, src=0x0, src_size=1)
# 2  0xbe04506e in panic_dump (p=233492486, panic_info=0x4d8, data=0xbe091440)
# 3  0xbe02da65 in exception () at /sof/src/arch/xtensa/include/arch/init.h:40
# 4  0xbe04f3d8 in _GeneralException ()
# 5  0xbe02dfdb in ipc_comp_free (ipc=0x1c, comp_id=4261601243) at /sof/src/ipc/ipc.c:242
# 6  0xbe0306a5 in ipc_glb_tplg_free (header=2651720960, free_func=0xbe02df54 <ipc_comp_free>)
# 7  0xbe0307a5 in ipc_glb_tplg_message (header=805437440) at /sof/src/ipc/handler.c:1239
# 8  0xbe030978 in ipc_cmd (hdr=0x9e0e0d80) at /sof/src/ipc/handler.c:1299
# 9  0xbe045e6a in ipc_platform_do_cmd (data=0x9e0e0d00)
# 10 0xbe04cff1 in schedule_edf_task_run (task=0x9e0e0d20, data=0xbe0e0940)
```

the idea of stack rewind was to hide first #0-4 entries but it was problematic and in most cases backtrace was not working at all.

In my opinion full backtrace is clear enough and there is no need to modify it.