### PR TITLE
comp: return warning instead of error in comp_get_model()

### DIFF
--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -341,10 +341,10 @@ void comp_free_model_data(struct comp_dev *dev, struct comp_model_data *model)
 int  comp_alloc_model_data(struct comp_dev *dev, struct comp_model_data *model,
 			   uint32_t size)
 {
+	comp_free_model_data(dev, model);
+
 	if (!size)
 		return 0;
-
-	comp_free_model_data(dev, model);
 
 	model->data = rballoc(0, SOF_MEM_CAPS_RAM, size);
 
@@ -376,7 +376,10 @@ int comp_set_model(struct comp_dev *dev, struct comp_model_data *model,
 	 */
 	if (!cdata->msg_index) {
 		ret = comp_alloc_model_data(dev, model, cdata->data->size);
-		if (ret < 0)
+		/* in case when required model size is equal to zero we do not
+		 * allocate memory and should just return 0
+		 */
+		if (ret < 0 || !cdata->data->size)
 			return ret;
 	}
 

--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -471,8 +471,9 @@ int comp_get_model(struct comp_dev *dev, struct comp_model_data *model,
 		model->data_pos += bs;
 
 	} else {
-		comp_err(dev, "comp_get_model(): !model->data");
-		ret = -EINVAL;
+		comp_warn(dev, "comp_get_model(): model->data not allocated yet.");
+		cdata->data->abi = SOF_ABI_VERSION;
+		cdata->data->size = 0;
 	}
 
 	return ret;


### PR DESCRIPTION
In comp_get_model() function we should return warning in
case not allocated model->data.

fixes #3068 

Signed-off-by: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>