### PR TITLE
add tgl with xtensa-cnl-elf. No rimage yet.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,9 @@ jobs:
     - <<: *build-platform
       env: PLATFORM='jsl'
 
+    - <<: *build-platform
+      env: PLATFORM='tgl'
+
     - name: "./scripts/build-tools.sh"
       before_install: *docker-pull-sof
       script: ./scripts/docker-run.sh ./scripts/build-tools.sh

--- a/src/arch/xtensa/lib/cpu.c
+++ b/src/arch/xtensa/lib/cpu.c
@@ -36,7 +36,7 @@ static int dsp_sref[PLATFORM_CORE_COUNT];	/**< simple ref counter */
 
 #if CONFIG_NO_SLAVE_CORE_ROM
 extern void *shared_vecbase_ptr;
-extern void _WindowOverflow4;
+extern uint8_t _WindowOverflow4[];
 
 /**
  * \brief This function will allocate memory for shared slave cores
@@ -62,7 +62,7 @@ static void alloc_shared_slave_cores_objects(void)
  */
 static void unpack_dynamic_vectors(void)
 {
-	void *dyn_vec_start_addr = (void *)(&_WindowOverflow4);
+	void *dyn_vec_start_addr = _WindowOverflow4;
 
 	memcpy_s(shared_vecbase_ptr, SOF_DYNAMIC_VECTORS_SIZE,
 		 dyn_vec_start_addr, SOF_DYNAMIC_VECTORS_SIZE);


### PR DESCRIPTION
See commit messages.

The build with this toolchain has NOT been tested, however the -g0 -Wno-err binaries produced by gcc are identical before and after this change. The purpose of is purely to add the gcc build to CI, avoid future gcc bitrot and catc  more warnings and bugs.