### PR TITLE
demux: Fix buffer lock in copy function

### DIFF
--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -296,11 +296,13 @@ static int demux_copy(struct comp_dev *dev)
 	// align sink streams with their respective configurations
 	list_for_item(clist, &dev->bsink_list) {
 		sink = container_of(clist, struct comp_buffer, source_list);
+		buffer_lock(sink, &flags);
 		if (sink->sink->state == dev->state) {
 			num_sinks++;
 			i = get_stream_index(cd, sink->pipeline_id);
 			sinks[i] = sink;
 		}
+		buffer_unlock(sink, flags);
 	}
 
 	/* if there are no sinks active */


### PR DESCRIPTION
Sink buffer should be locked and invalidated (inside lock function)
before reading, to acheve consistent data between multiple cores.
Otherwise readed data may be outdated.

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>