### PR TITLE
dai: Log number of frames in copy function

### DIFF
--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -738,7 +738,7 @@ static int dai_config(struct comp_dev *dev, struct sof_ipc_dai_config *config)
 	int channel = 0;
 	int handshake;
 
-	comp_info(dev, "dai_config() dai %d.%d",
+	comp_info(dev, "dai_config() dai type = %d index = %d",
 		  config->type, config->dai_index);
 
 	/* cannot configure DAI while active */


### PR DESCRIPTION
It easier to compare number of copied frames between dai and
process components than copied bytes.

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>