### PR TITLE
cmake: no space after -imacros to avoid de-duplication

### DIFF
--- a/src/arch/host/CMakeLists.txt
+++ b/src/arch/host/CMakeLists.txt
@@ -6,6 +6,6 @@ target_include_directories(sof_public_headers INTERFACE ${PROJECT_SOURCE_DIR}/sr
 
 # C & ASM flags
 target_compile_options(sof_options INTERFACE -g -O3 -Wall -Werror -Wl,-EL -Wmissing-prototypes
-  -Wimplicit-fallthrough=3 -Wpointer-arith -DCONFIG_LIBRARY -imacros "${CONFIG_H_PATH}")
+  -Wimplicit-fallthrough=3 -Wpointer-arith -DCONFIG_LIBRARY "-imacros${CONFIG_H_PATH}")
 
 add_subdirectory(lib)

--- a/src/arch/xtensa/CMakeLists.txt
+++ b/src/arch/xtensa/CMakeLists.txt
@@ -109,7 +109,10 @@ target_compile_options(sof_options INTERFACE ${stdlib_flag} -fno-inline-function
 #      better to have set of default flags and change it only for special cases
 #   3) custom function that is used instead of target_sources and sets flags
 #      for each added source based on file extension
-target_compile_options(sof_options INTERFACE $<$<COMPILE_LANGUAGE:C>: -${optimization_flag} -g -Wall -Werror -Wl,-EL -Wmissing-prototypes -Wpointer-arith ${XTENSA_C_FLAGS}> -imacros ${CONFIG_H_PATH})
+
+# No space between -imacros and its argument to avoid CMake
+# de-duplication "feature"
+target_compile_options(sof_options INTERFACE $<$<COMPILE_LANGUAGE:C>: -${optimization_flag} -g -Wall -Werror -Wl,-EL -Wmissing-prototypes -Wpointer-arith ${XTENSA_C_FLAGS}> -imacros${CONFIG_H_PATH})
 
 if(BUILD_UNIT_TESTS)
 	# rest of this file is not needed for unit tests
@@ -154,7 +157,7 @@ function(sof_add_ld_script binary_name script_name)
 
 	add_custom_command(OUTPUT ${lds_out}
 		COMMAND ${CMAKE_C_COMPILER} -E -DLINKER -P ${iflags} -o ${lds_out} -x c ${lds_in}
-			-imacros ${CONFIG_H_PATH}
+			-imacros${CONFIG_H_PATH}
 		DEPENDS ${lds_in} ${LINK_DEPS} genconfig ${CONFIG_H_PATH} ${lds_headers}
 		WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
 		COMMENT "Generating linker script: ${lds_out}"

--- a/tools/testbench/CMakeLists.txt
+++ b/tools/testbench/CMakeLists.txt
@@ -32,7 +32,7 @@ set(sof_binary_directory "${PROJECT_BINARY_DIR}/sof_ep/build")
 set(config_h ${sof_binary_directory}/library_autoconfig.h)
 
 target_compile_options(testbench PRIVATE -g -O3 -Wall -Werror -Wl,-EL -Wmissing-prototypes
-  -Wimplicit-fallthrough=3 -DCONFIG_LIBRARY -imacros ${config_h})
+  -Wimplicit-fallthrough=3 -DCONFIG_LIBRARY -imacros${config_h})
 
 target_link_libraries(testbench PRIVATE -ldl -lm)
 


### PR DESCRIPTION
This is not needed yet as we use only one -imacros at a time but could
save someone a lot of time in the future; including the author of this
patch who will have forgotten about it in a few weeks.

For more details see
https://github.com/zephyrproject-rtos/zephyr/commit/e53c0d0ec7640b
and links from there.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>