### PR TITLE
.travis.yml: build ROM for "buildonly" platforms too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
         &docker-pull-sof
         docker pull thesofproject/sof && docker tag thesofproject/sof sof
       script:
-        ./scripts/docker-run.sh ./scripts/xtensa-build-all.sh $PLATFORM
+        ./scripts/docker-run.sh ./scripts/xtensa-build-all.sh -r $PLATFORM
       env: PLATFORM='sue'
 
     - <<: *build-platform


### PR DESCRIPTION
No obvious reason not to build ROM for "buildonly" platforms too.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>