### PR TITLE
Smart amp: prepare for multi core processing

### DIFF
--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -197,6 +197,8 @@ int comp_set_state(struct comp_dev *dev, int cmd)
 		break;
 	}
 
+	comp_writeback(dev);
+
 	return ret;
 }
 

--- a/src/audio/pipeline.c
+++ b/src/audio/pipeline.c
@@ -128,6 +128,7 @@ int pipeline_connect(struct comp_dev *comp, struct comp_buffer *buffer,
 	list_item_prepend(buffer_comp_list(buffer, dir),
 			  comp_buffer_list(comp, dir));
 	buffer_set_comp(buffer, comp, dir);
+	comp_writeback(comp);
 	irq_local_enable(flags);
 
 	return 0;

--- a/src/audio/smart_amp_test.c
+++ b/src/audio/smart_amp_test.c
@@ -527,6 +527,7 @@ static int smart_amp_prepare(struct comp_dev *dev)
 	sad->out_channels = sad->sink_buf->stream.channels;
 
 	sad->feedback_buf->stream.channels = sad->config.feedback_channels;
+	sad->feedback_buf->stream.rate = sad->source_buf->stream.rate;
 
 	/* TODO:
 	 * ATM feedback buffer frame_fmt is hardcoded to s32_le. It should be

--- a/src/audio/smart_amp_test.c
+++ b/src/audio/smart_amp_test.c
@@ -458,6 +458,8 @@ static int smart_amp_copy(struct comp_dev *dev)
 			     sad->config.feedback_ch_map);
 
 		comp_update_buffer_consume(sad->feedback_buf, feedback_bytes);
+	} else {
+		buffer_unlock(sad->feedback_buf, feedback_flags);
 	}
 
 	/* bytes calculation */

--- a/src/audio/smart_amp_test.c
+++ b/src/audio/smart_amp_test.c
@@ -437,6 +437,7 @@ static int smart_amp_copy(struct comp_dev *dev)
 	avail_frames = avail_passthrough_frames;
 
 	buffer_lock(sad->feedback_buf, &feedback_flags);
+	comp_invalidate(sad->feedback_buf->source);
 	if (sad->feedback_buf->source->state == dev->state) {
 		/* feedback */
 		avail_feedback_frames = sad->feedback_buf->stream.avail /

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -736,6 +736,26 @@ void comp_get_copy_limits_with_lock(struct comp_buffer *source,
 }
 
 /**
+ * Invalidates component to ensure current state and params readout.
+ * @param dev Component to invalidate
+ */
+static inline void comp_invalidate(struct comp_dev *dev)
+{
+	if (!dev->is_shared)
+		dcache_invalidate_region(dev, sizeof(struct comp_dev));
+}
+
+/**
+ * Writeback component to ensure current state and params readout.
+ * @param dev Component to writeback
+ */
+static inline void comp_writeback(struct comp_dev *dev)
+{
+	if (!dev->is_shared)
+		dcache_writeback_region(dev, sizeof(struct comp_dev));
+}
+
+/**
  * Frees data for large component configurations.
  *
  * @param dev Component device


### PR DESCRIPTION
Smart amp is quite specific component because of feedback buffer between pipelines, so memory handling must be performed with care to use valid data. This PR have a series of fixes which allows smart amp to work on the another core. Feedback buffer from smart_amp must allow overrun to omit start-up race between pipelines.