### PR TITLE
smart_amp: Merge dbg logs from copy function

### DIFF
--- a/src/audio/smart_amp_test.c
+++ b/src/audio/smart_amp_test.c
@@ -436,9 +436,6 @@ static int smart_amp_copy(struct comp_dev *dev)
 
 	avail_frames = avail_passthrough_frames;
 
-	comp_dbg(dev, "smart_amp_copy(): avail_passthrough_frames: %d",
-		 avail_passthrough_frames);
-
 	buffer_lock(sad->feedback_buf, &feedback_flags);
 	if (sad->feedback_buf->source->state == dev->state) {
 		/* feedback */
@@ -453,8 +450,8 @@ static int smart_amp_copy(struct comp_dev *dev)
 
 		buffer_unlock(sad->feedback_buf, feedback_flags);
 
-		comp_dbg(dev, "smart_amp_copy(): processing %d feedback bytes",
-			 feedback_bytes);
+		comp_dbg(dev, "smart_amp_copy(): processing %d feedback frames (avail_passthrough_frames: %d)",
+			 avail_frames, avail_passthrough_frames);
 
 		sad->process(dev, &sad->feedback_buf->stream,
 			     &sad->sink_buf->stream, avail_frames,


### PR DESCRIPTION
Number of available frames from feedback and passthrough buffers
should be in the same format and close together for easily compare.
Moreover reducing number of logs, especially from copy function is
important in terms of logs readability and FW performance - adding
one more parameter have much less impact on FW than adding one more
log message.

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>