### PR TITLE
logger: Add possibility to hide timestamps

### DIFF
--- a/tools/logger/convert.c
+++ b/tools/logger/convert.c
@@ -212,13 +212,13 @@ static double to_usecs(uint64_t time, double clk)
 
 
 static inline void print_table_header(FILE *out_fd, int hide_location,
-				      int float_precision)
+				      int time_precision)
 {
 	char time_fmt[32];
 
-	if (float_precision >= 0) {
+	if (time_precision >= 0) {
 		snprintf(time_fmt, sizeof(time_fmt), "%%%ds %%%ds ",
-			 float_precision + 12, float_precision + 12);
+			 time_precision + 12, time_precision + 12);
 		fprintf(out_fd, time_fmt, "TIMESTAMP", "DELTA");
 	}
 	fprintf(out_fd, "%2s %-18s ", "C#", "COMPONENT");
@@ -305,7 +305,7 @@ static void print_entry_params(FILE *out_fd,
 	const struct snd_sof_uids_header *uids_dict,
 	const struct log_entry_header *dma_log, const struct ldc_entry *entry,
 	uint64_t last_timestamp, double clock, int use_colors, int raw_output,
-	int hide_location, int float_precision)
+	int hide_location, int time_precision)
 {
 	char ids[TRACE_MAX_IDS_STR];
 	float dt = to_usecs(dma_log->timestamp - last_timestamp, clock);
@@ -328,9 +328,9 @@ static void print_entry_params(FILE *out_fd,
 	if (raw_output) {
 		const char *entry_fmt = "%s%u %u %s%s%s ";
 
-		if (float_precision >= 0)
+		if (time_precision >= 0)
 			snprintf(time_fmt, sizeof(time_fmt), "%%.%df %%.%df ",
-				 float_precision, float_precision);
+				 time_precision, time_precision);
 
 		fprintf(out_fd, entry_fmt,
 			entry->header.level == use_colors ?
@@ -342,7 +342,7 @@ static void print_entry_params(FILE *out_fd,
 					   dma_log->uid),
 			raw_output && strlen(ids) ? "-" : "",
 			ids);
-		if (float_precision >= 0)
+		if (time_precision >= 0)
 			fprintf(out_fd, time_fmt,
 				to_usecs(dma_log->timestamp, clock),
 				dt);
@@ -352,11 +352,11 @@ static void print_entry_params(FILE *out_fd,
 				entry->header.line_idx);
 	} else {
 		/* timestamp */
-		if (float_precision >= 0) {
+		if (time_precision >= 0) {
 			snprintf(time_fmt, sizeof(time_fmt),
 				 "%%s[%%%d.%df] (%%%d.%df)%%s ",
-				 float_precision + 10, float_precision,
-				 float_precision + 10, float_precision);
+				 time_precision + 10, time_precision,
+				 time_precision + 10, time_precision);
 			fprintf(out_fd, time_fmt,
 				use_colors ? KGRN : "",
 				to_usecs(dma_log->timestamp, clock), dt,
@@ -532,7 +532,7 @@ static int fetch_entry(const struct convert_config *config,
 			   dma_log, &entry, *last_timestamp,
 			   config->clock, config->use_colors,
 			   config->raw_output, config->hide_location,
-			   config->float_precision);
+			   config->time_precision);
 	*last_timestamp = dma_log->timestamp;
 
 	/* set f_ldc file position to the beginning */
@@ -611,7 +611,7 @@ static int logger_read(const struct convert_config *config,
 
 	if (!config->raw_output)
 		print_table_header(config->out_fd, config->hide_location,
-				   config->float_precision);
+				   config->time_precision);
 
 	if (config->serial_fd >= 0)
 		/* Wait for CTRL-C */

--- a/tools/logger/convert.c
+++ b/tools/logger/convert.c
@@ -216,9 +216,11 @@ static inline void print_table_header(FILE *out_fd, int hide_location,
 {
 	char time_fmt[32];
 
-	snprintf(time_fmt, sizeof(time_fmt), "%%%ds %%%ds ",
-		 float_precision + 12, float_precision + 12);
-	fprintf(out_fd, time_fmt, "TIMESTAMP", "DELTA");
+	if (float_precision >= 0) {
+		snprintf(time_fmt, sizeof(time_fmt), "%%%ds %%%ds ",
+			 float_precision + 12, float_precision + 12);
+		fprintf(out_fd, time_fmt, "TIMESTAMP", "DELTA");
+	}
 	fprintf(out_fd, "%2s %-18s ", "C#", "COMPONENT");
 	if (!hide_location)
 		fprintf(out_fd, "%-29s ", "LOCATION");
@@ -326,8 +328,9 @@ static void print_entry_params(FILE *out_fd,
 	if (raw_output) {
 		const char *entry_fmt = "%s%u %u %s%s%s ";
 
-		snprintf(time_fmt, sizeof(time_fmt), "%%.%df %%.%df ",
-			 float_precision, float_precision);
+		if (float_precision >= 0)
+			snprintf(time_fmt, sizeof(time_fmt), "%%.%df %%.%df ",
+				 float_precision, float_precision);
 
 		fprintf(out_fd, entry_fmt,
 			entry->header.level == use_colors ?
@@ -339,22 +342,26 @@ static void print_entry_params(FILE *out_fd,
 					   dma_log->uid),
 			raw_output && strlen(ids) ? "-" : "",
 			ids);
-		fprintf(out_fd, time_fmt, to_usecs(dma_log->timestamp, clock),
-			dt);
+		if (float_precision >= 0)
+			fprintf(out_fd, time_fmt,
+				to_usecs(dma_log->timestamp, clock),
+				dt);
 		if (!hide_location)
 			fprintf(out_fd, "(%s:%u) ",
 				format_file_name(entry->file_name, raw_output),
 				entry->header.line_idx);
 	} else {
 		/* timestamp */
-		snprintf(time_fmt, sizeof(time_fmt),
-			 "%%s[%%%d.%df] (%%%d.%df)%%s ",
-			 float_precision + 10, float_precision,
-			 float_precision + 10, float_precision);
-		fprintf(out_fd, time_fmt,
-			use_colors ? KGRN : "",
-			to_usecs(dma_log->timestamp, clock), dt,
-			use_colors ? KNRM : "");
+		if (float_precision >= 0) {
+			snprintf(time_fmt, sizeof(time_fmt),
+				 "%%s[%%%d.%df] (%%%d.%df)%%s ",
+				 float_precision + 10, float_precision,
+				 float_precision + 10, float_precision);
+			fprintf(out_fd, time_fmt,
+				use_colors ? KGRN : "",
+				to_usecs(dma_log->timestamp, clock), dt,
+				use_colors ? KNRM : "");
+		}
 
 		/* core id */
 		fprintf(out_fd, "c%d ", dma_log->core_id);

--- a/tools/logger/convert.h
+++ b/tools/logger/convert.h
@@ -38,7 +38,7 @@ struct convert_config {
 	int raw_output;
 	int dump_ldc;
 	int hide_location;
-	int float_precision;
+	int time_precision;
 	struct snd_sof_uids_header *uids_dict;
 };
 

--- a/tools/logger/logger.c
+++ b/tools/logger/logger.c
@@ -55,6 +55,8 @@ static void usage(void)
 		APP_NAME);
 	fprintf(stdout, "%s:\t -f precision\t\tSet timestamp precision\n",
 		APP_NAME);
+	fprintf(stdout, "%s:\t -g\t\tHide timestamp\n",
+		APP_NAME);
 	fprintf(stdout, "%s:\t -d *.ldc_file \t\tDump ldc_file information\n",
 		APP_NAME);
 	exit(0);
@@ -140,7 +142,7 @@ static int configure_uart(const char *file, unsigned int baud)
 
 int main(int argc, char *argv[])
 {
-	static const char optstring[] = "ho:i:l:ps:c:u:tev:rd:Lf:";
+	static const char optstring[] = "ho:i:l:ps:c:u:tev:rd:Lf:g";
 	struct convert_config config;
 	unsigned int baud = 0;
 	const char *snapshot_file = 0;
@@ -220,6 +222,9 @@ int main(int argc, char *argv[])
 				usage();
 				return -EINVAL;
 			}
+			break;
+		case 'g':
+			config.float_precision = -1;
 			break;
 		case 'd':
 			if (config.ldc_file) {

--- a/tools/logger/logger.c
+++ b/tools/logger/logger.c
@@ -166,7 +166,7 @@ int main(int argc, char *argv[])
 	config.raw_output = 0;
 	config.dump_ldc = 0;
 	config.hide_location = 0;
-	config.float_precision = 6;
+	config.time_precision = 6;
 
 	while ((opt = getopt(argc, argv, optstring)) != -1) {
 		switch (opt) {
@@ -217,14 +217,14 @@ int main(int argc, char *argv[])
 			config.hide_location = 1;
 			break;
 		case 'f':
-			config.float_precision = atoi(optarg);
-			if (config.float_precision < 0) {
+			config.time_precision = atoi(optarg);
+			if (config.time_precision < 0) {
 				usage();
 				return -EINVAL;
 			}
 			break;
 		case 'g':
-			config.float_precision = -1;
+			config.time_precision = -1;
 			break;
 		case 'd':
 			if (config.ldc_file) {


### PR DESCRIPTION
After removing timestamps it is possible to compare output logs
with tools like diff or similar. Moreover then output logs are
in more compact form.

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>