### PR TITLE
buffer: Describe buffer flags in init log

### DIFF
--- a/src/audio/buffer.c
+++ b/src/audio/buffer.c
@@ -75,8 +75,8 @@ struct comp_buffer *buffer_new(struct sof_ipc_buffer *desc)
 {
 	struct comp_buffer *buffer;
 
-	tr_info(&buffer_tr, "buffer new size 0x%x id %d.%d", desc->size,
-		    desc->comp.pipeline_id, desc->comp.id);
+	tr_info(&buffer_tr, "buffer new size 0x%x id %d.%d flags 0x%X",
+		desc->size, desc->comp.pipeline_id, desc->comp.id, desc->flags);
 
 	/* allocate buffer */
 	buffer = buffer_alloc(desc->size, desc->caps, PLATFORM_DCACHE_ALIGN);


### PR DESCRIPTION
Buffer flags is important field and should be accessible in logs
output.

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>