### PR TITLE
gitignore: add Eclipse project metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,11 @@ doc/*.cmake
 doc/*.ninja
 doc/Makefile
 
+# Eclipse project metadata
+.settings
+.project
+.cproject
+
 /tags
 /TAGS
 


### PR DESCRIPTION
When sof source code is edited in Eclipse, the project
metadata files should be ignored by git.

Signed-off-by: Marcin Maka <marcin.maka@linux.intel.com>