### PR TITLE
kpb: add detailed info to error messages

### DIFF
--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -449,7 +449,6 @@ static int kpb_prepare(struct comp_dev *dev)
 
 	if (!validate_host_params(dev, kpb->host_period_size,
 				  kpb->host_buffer_size, hb_size_req)) {
-		comp_cl_err(&comp_kpb, "kpb_prepare(): wrong host params.");
 		return -EINVAL;
 	}
 
@@ -1530,12 +1529,16 @@ static inline bool validate_host_params(struct comp_dev *dev,
 
 	if (!host_period_size || !host_buffer_size) {
 		/* Wrong host params */
+		comp_err(dev, "kpb: host_period_size (%d) cannot be 0 and host_buffer_size (%d) cannot be 0",
+			 host_period_size, host_buffer_size);
 		return false;
 	} else if (HOST_BUFFER_MIN_SIZE(hb_size_req) >
 		   host_buffer_size) {
 		/* Host buffer size is too small - history data
 		 * may get overwritten.
 		 */
+		comp_err(dev, "kpb: host_buffer_size (%d) must be at least %d",
+			 host_buffer_size, HOST_BUFFER_MIN_SIZE(hb_size_req));
 		return false;
 	} else if (kpb->sync_draining_mode) {
 		/* Sync draining allowed. Check if we can perform draining
@@ -1548,8 +1551,13 @@ static inline bool validate_host_params(struct comp_dev *dev,
 		 * of buffered data.
 		 */
 		if ((host_period_size / KPB_DRAIN_NUM_OF_PPL_PERIODS_AT_ONCE) <
-		    pipeline_period_size)
+		    pipeline_period_size) {
+			comp_err(dev, "kpb: host_period_size (%d) must be at least %d * %d",
+				 host_period_size,
+				 KPB_DRAIN_NUM_OF_PPL_PERIODS_AT_ONCE,
+				 pipeline_period_size);
 			return false;
+		}
 	}
 
 	return true;


### PR DESCRIPTION
Parameter validation should give detailed information about wrong
settings to speed up the troubleshooting.

Signed-off-by: Marcin Maka <marcin.maka@linux.intel.com>