### PR TITLE
[RFC] Audio: Shorten volume playback ramp length to 20 ms including other improvements 

### DIFF
--- a/src/include/sof/audio/volume.h
+++ b/src/include/sof/audio/volume.h
@@ -47,9 +47,19 @@ struct sof_ipc_ctrl_value_chan;
 
 /**
  * \brief Volume ramp update rate in microseconds.
- * Update volume gain value every 1 ms.
+ * Update volume gain value every 125 to 1000 us. The faster gain ramps need
+ * higher update rate to avoid annoying zipper noise sound. The below
+ * values were tested subjectively for constraint of 125 microseconds
+ * multiple gain update rate.
  */
-#define VOL_RAMP_UPDATE_US 1000
+#define VOL_RAMP_UPDATE_SLOWEST_US	1000
+#define VOL_RAMP_UPDATE_SLOW_US		500
+#define VOL_RAMP_UPDATE_FAST_US		250
+#define VOL_RAMP_UPDATE_FASTEST_US	125
+
+#define VOL_RAMP_UPDATE_THRESHOLD_SLOW_MS	128
+#define VOL_RAMP_UPDATE_THRESHOLD_FAST_MS	64
+#define VOL_RAMP_UPDATE_THRESHOLD_FASTEST_MS	32
 
 /**
  * \brief Volume maximum value.

--- a/tools/topology/sof/pipe-asrc-volume-playback.m4
+++ b/tools/topology/sof/pipe-asrc-volume-playback.m4
@@ -57,8 +57,8 @@ W_ASRC(0, PIPELINE_FORMAT, 2, 2, MY_ASRC_CONF)
 define(MY_PGA_TOKENS, concat(`pga_tokens_', PIPELINE_ID))
 define(MY_PGA_CONF, concat(`pga_conf_', PIPELINE_ID))
 W_VENDORTUPLES(MY_PGA_TOKENS, sof_volume_tokens,
-LIST(`		', `SOF_TKN_VOLUME_RAMP_STEP_TYPE	"0"'
-     `		', `SOF_TKN_VOLUME_RAMP_STEP_MS		"250"'))
+LIST(`		', `SOF_TKN_VOLUME_RAMP_STEP_TYPE	"2"'
+     `		', `SOF_TKN_VOLUME_RAMP_STEP_MS		"20"'))
 W_DATA(MY_PGA_CONF, MY_PGA_TOKENS)
 
 # "Volume" has x sink and 2 source periods

--- a/tools/topology/sof/pipe-dcblock-volume-playback.m4
+++ b/tools/topology/sof/pipe-dcblock-volume-playback.m4
@@ -33,8 +33,8 @@ C_CONTROLMIXER(Master Playback Volume, PIPELINE_ID,
 define(MY_PGA_TOKENS, concat(`pga_tokens_', PIPELINE_ID))
 define(MY_PGA_CONF, concat(`pga_conf_', PIPELINE_ID))
 W_VENDORTUPLES(MY_PGA_TOKENS, sof_volume_tokens,
-LIST(`		', `SOF_TKN_VOLUME_RAMP_STEP_TYPE	"0"'
-     `		', `SOF_TKN_VOLUME_RAMP_STEP_MS		"250"'))
+LIST(`		', `SOF_TKN_VOLUME_RAMP_STEP_TYPE	"2"'
+     `		', `SOF_TKN_VOLUME_RAMP_STEP_MS		"20"'))
 
 W_DATA(MY_PGA_CONF, MY_PGA_TOKENS)
 

--- a/tools/topology/sof/pipe-eq-fir-volume-playback.m4
+++ b/tools/topology/sof/pipe-eq-fir-volume-playback.m4
@@ -35,8 +35,8 @@ define(DEF_PGA_TOKENS, concat(`pga_tokens_', PIPELINE_ID))
 define(DEF_PGA_CONF, concat(`pga_conf_', PIPELINE_ID))
 
 W_VENDORTUPLES(DEF_PGA_TOKENS, sof_volume_tokens,
-LIST(`		', `SOF_TKN_VOLUME_RAMP_STEP_TYPE	"0"'
-     `		', `SOF_TKN_VOLUME_RAMP_STEP_MS		"250"'))
+LIST(`		', `SOF_TKN_VOLUME_RAMP_STEP_TYPE	"2"'
+     `		', `SOF_TKN_VOLUME_RAMP_STEP_MS		"20"'))
 
 W_DATA(DEF_PGA_CONF, DEF_PGA_TOKENS)
 

--- a/tools/topology/sof/pipe-eq-iir-eq-fir-volume-playback.m4
+++ b/tools/topology/sof/pipe-eq-iir-eq-fir-volume-playback.m4
@@ -37,8 +37,8 @@ define(DEF_PGA_TOKENS, concat(`pga_tokens_', PIPELINE_ID))
 define(DEF_PGA_CONF, concat(`pga_conf_', PIPELINE_ID))
 
 W_VENDORTUPLES(DEF_PGA_TOKENS, sof_volume_tokens,
-LIST(`		', `SOF_TKN_VOLUME_RAMP_STEP_TYPE	"0"'
-     `		', `SOF_TKN_VOLUME_RAMP_STEP_MS		"250"'))
+LIST(`		', `SOF_TKN_VOLUME_RAMP_STEP_TYPE	"2"'
+     `		', `SOF_TKN_VOLUME_RAMP_STEP_MS		"20"'))
 
 W_DATA(DEF_PGA_CONF, DEF_PGA_TOKENS)
 

--- a/tools/topology/sof/pipe-eq-iir-volume-playback.m4
+++ b/tools/topology/sof/pipe-eq-iir-volume-playback.m4
@@ -35,8 +35,8 @@ define(DEF_PGA_TOKENS, concat(`pga_tokens_', PIPELINE_ID))
 define(DEF_PGA_CONF, concat(`pga_conf_', PIPELINE_ID))
 
 W_VENDORTUPLES(DEF_PGA_TOKENS, sof_volume_tokens,
-LIST(`		', `SOF_TKN_VOLUME_RAMP_STEP_TYPE	"0"'
-     `		', `SOF_TKN_VOLUME_RAMP_STEP_MS		"250"'))
+LIST(`		', `SOF_TKN_VOLUME_RAMP_STEP_TYPE	"2"'
+     `		', `SOF_TKN_VOLUME_RAMP_STEP_MS		"20"'))
 
 W_DATA(DEF_PGA_CONF, DEF_PGA_TOKENS)
 

--- a/tools/topology/sof/pipe-src-volume-playback.m4
+++ b/tools/topology/sof/pipe-src-volume-playback.m4
@@ -49,15 +49,17 @@ W_SRC(0, PIPELINE_FORMAT, 3, 3, media_src_conf)
 # Volume Configuration
 #
 
-W_VENDORTUPLES(playback_pga_tokens, sof_volume_tokens,
-LIST(`		', `SOF_TKN_VOLUME_RAMP_STEP_TYPE	"0"'
-     `		', `SOF_TKN_VOLUME_RAMP_STEP_MS		"250"'))
+define(DEF_PGA_TOKENS, concat(`pga_tokens_', PIPELINE_ID))
+define(DEF_PGA_CONF, concat(`pga_conf_', PIPELINE_ID))
 
+W_VENDORTUPLES(DEF_PGA_TOKENS, sof_volume_tokens,
+LIST(`		', `SOF_TKN_VOLUME_RAMP_STEP_TYPE	"2"'
+     `		', `SOF_TKN_VOLUME_RAMP_STEP_MS		"20"'))
 
-W_DATA(playback_pga_conf, playback_pga_tokens)
+W_DATA(DEF_PGA_CONF, DEF_PGA_TOKENS)
 
 # "Volume" has 3 source and x sink periods
-W_PGA(0, PIPELINE_FORMAT, DAI_PERIODS, 3, playback_pga_conf, SCHEDULE_CORE,
+W_PGA(0, PIPELINE_FORMAT, DAI_PERIODS, 3, DEF_PGA_CONF, SCHEDULE_CORE,
 	 LIST(`		', "PIPELINE_ID Master Playback Volume"))
 
 # Playback Buffers
@@ -96,3 +98,5 @@ indir(`define', concat(`PIPELINE_PCM_', PIPELINE_ID), SRC Playback PCM_ID)
 
 PCM_CAPABILITIES(SRC Playback PCM_ID, `S32_LE,S24_LE,S16_LE', 8000, 192000, 2, PIPELINE_CHANNELS, 2, 16, 192, 16384, 65536, 65536)
 
+undefine(`DEF_PGA_TOKENS')
+undefine(`DEF_PGA_CONF')

--- a/tools/topology/sof/pipe-volume-playback.m4
+++ b/tools/topology/sof/pipe-volume-playback.m4
@@ -29,11 +29,14 @@ C_CONTROLMIXER(Master Playback Volume, PIPELINE_ID,
 # Volume configuration
 #
 
-W_VENDORTUPLES(playback_pga_tokens, sof_volume_tokens,
-LIST(`		', `SOF_TKN_VOLUME_RAMP_STEP_TYPE	"0"'
-     `		', `SOF_TKN_VOLUME_RAMP_STEP_MS		"250"'))
+define(DEF_PGA_TOKENS, concat(`pga_tokens_', PIPELINE_ID))
+define(DEF_PGA_CONF, concat(`pga_conf_', PIPELINE_ID))
 
-W_DATA(playback_pga_conf, playback_pga_tokens)
+W_VENDORTUPLES(DEF_PGA_TOKENS, sof_volume_tokens,
+LIST(`		', `SOF_TKN_VOLUME_RAMP_STEP_TYPE	"2"'
+     `		', `SOF_TKN_VOLUME_RAMP_STEP_MS		"20"'))
+
+W_DATA(DEF_PGA_CONF, DEF_PGA_TOKENS)
 
 #
 # Components and Buffers
@@ -44,7 +47,7 @@ W_DATA(playback_pga_conf, playback_pga_tokens)
 W_PCM_PLAYBACK(PCM_ID, Passthrough Playback, 2, 0, SCHEDULE_CORE)
 
 # "Volume" has 2 source and x sink periods
-W_PGA(0, PIPELINE_FORMAT, DAI_PERIODS, 2, playback_pga_conf, SCHEDULE_CORE,
+W_PGA(0, PIPELINE_FORMAT, DAI_PERIODS, 2, DEF_PGA_CONF, SCHEDULE_CORE,
 	LIST(`		', "PIPELINE_ID Master Playback Volume"))
 
 # Playback Buffers
@@ -79,3 +82,5 @@ indir(`define', concat(`PIPELINE_PCM_', PIPELINE_ID), Passthrough Playback PCM_I
 #
 PCM_CAPABILITIES(Passthrough Playback PCM_ID, `S32_LE,S24_LE,S16_LE', PCM_MIN_RATE, PCM_MAX_RATE, 2, PIPELINE_CHANNELS, 2, 16, 192, 16384, 65536, 65536)
 
+undefine(`DEF_PGA_TOKENS')
+undefine(`DEF_PGA_CONF')


### PR DESCRIPTION
This pull request contains changes:

- Tools: Topology: Change playback volume ramp duration to 20 ms
- Audio: Improve volume ramp time calculation precision
- Audio: Make volume gain ramp update rate variable

The shortening from 250 ms to 20 ms was made to get short notification tones better audible. The long ramp suppresses quite a lot the beginning. The two other changes are are improvements to volume component to sound better with fast ramp and optimize ramp rate for needed ramp time. 