### PR TITLE
mixer: reset additional check is only needed for playback

### DIFF
--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -351,17 +351,21 @@ static int mixer_copy(struct comp_dev *dev)
 
 static int mixer_reset(struct comp_dev *dev)
 {
+	int dir = dev->pipeline->source_comp->direction;
 	struct list_item *blist;
 	struct comp_buffer *source;
 
 	comp_dbg(dev, "mixer_reset()");
 
-	list_for_item(blist, &dev->bsource_list) {
-		source = container_of(blist, struct comp_buffer, sink_list);
-		/* only mix the sources with the same state with mixer*/
-		if (source->source->state > COMP_STATE_READY)
-			/* should not reset the downstream components */
-			return 1;
+	if (dir == SOF_IPC_STREAM_PLAYBACK) {
+		list_for_item(blist, &dev->bsource_list) {
+			source = container_of(blist, struct comp_buffer,
+					      sink_list);
+			/* only mix the sources with the same state with mixer*/
+			if (source->source->state > COMP_STATE_READY)
+				/* should not reset the downstream components */
+				return 1;
+		}
 	}
 
 	comp_set_state(dev, COMP_TRIGGER_RESET);


### PR DESCRIPTION
Limits additional check in mixer_reset to playback streams only.
For mixer in capture streams the request will always come from downstream,
which means that source components will always be in state >
COMP_STATE_READY. Checking sink component also doesn't make,
because it's the source of the request. The logic is now similar
to the mixer_trigger, where for capture streams we also don't require
additional checks.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>