### PR TITLE
Restore qemu error messages

### DIFF
--- a/scripts/qemu-check.sh
+++ b/scripts/qemu-check.sh
@@ -162,9 +162,12 @@ do
 	SHM_IPC_REG_FILE=$(ls /dev/shm/ | grep -E $SHM_IPC_REG)
 
 	# check if ready ipc header is in the ipc regs
-	IPC_REG=$(hexdump -C /dev/shm/"$SHM_IPC_REG_FILE" | grep "$READY_IPC")
+	IPC_REG=$(hexdump -C /dev/shm/"$SHM_IPC_REG_FILE" |
+		      grep "$READY_IPC") || true
+
 	# check if ready ipc message is in the mbox
-	IPC_MSG=$(hexdump -C /dev/shm/$SHM_MBOX | grep -A 4 "$READY_MSG" | grep -A 4 "$OUTBOX_OFFSET")
+	IPC_MSG=$(hexdump -C /dev/shm/$SHM_MBOX | grep -A 4 "$READY_MSG" |
+		      grep -A 4 "$OUTBOX_OFFSET") || true
 
 	if [ "$IPC_REG" ]; then
 		echo "ipc reg dump:"

--- a/scripts/qemu-check.sh
+++ b/scripts/qemu-check.sh
@@ -15,6 +15,8 @@ rm -f dump-*.txt
 die()
 {
 	>&2 printf '%s ERROR: ' "$0"
+	# We want die() to be usable exactly like printf
+	# shellcheck disable=SC2059
 	>&2 printf "$@"
 	exit 1
 }
@@ -145,15 +147,14 @@ do
 	esac
 
 	if $has_rom; then
-		ROM="-r ${SOF_BUILDS}/build_${platform}_gcc"
-		ROM+="/src/arch/xtensa/rom-$platform.bin"
+		ROM=(-r "${SOF_BUILDS}/build_${platform}_gcc/src/arch/xtensa/rom-$platform.bin")
 	fi
 
         xtensa_host_sh=$(find_qemu_xtensa)
 
 	${xtensa_host_sh} "$PLATFORM" -k \
 	   "${SOF_BUILDS}"/build_"${platform}"_gcc/src/arch/xtensa/"$FWNAME" \
-                $ROM \
+                "${ROM[@]}" \
 		-o 2.0 "${SOF_BUILDS}"/dump-"$platform".txt || true # timeout
 	# dump log into sof.git incase running in docker
 


### PR DESCRIPTION
See commit messages

Fixes 428804e ("scripts/qemu-check.sh: add set -e") which failed to consider the case of an empty $IPC_REG or $IPC_MSG.

Address two shellcheck warnings