### PR TITLE
topology: tgl-sdw-max98373: change DMIC16k format to 32LE

### DIFF
--- a/tools/topology/sof-tgl-sdw-max98373-rt5682.m4
+++ b/tools/topology/sof-tgl-sdw-max98373-rt5682.m4
@@ -101,7 +101,7 @@ PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 # Passthrough capture pipeline 5 on PCM 4 using max 4 channels.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-volume-capture-16khz.m4,
-        6, 5, CHANNELS, s16le,
+        6, 5, CHANNELS, s32le,
         1000, 0, 0,
         16000, 16000, 16000)
 
@@ -164,10 +164,10 @@ DAI_ADD(sof/pipe-dai-capture.m4,
         1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is DMIC16k using 2 periods
-# Buffers use s16le format, with 16 frame per 1000us on core 0 with priority 0
+# Buffers use s32le format, with 16 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
         6, DMIC, 1, dmic16k,
-        PIPELINE_SINK_6, 2, s16le,
+        PIPELINE_SINK_6, 2, s32le,
         1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp1 using 2 periods
@@ -233,7 +233,7 @@ DAI_CONFIG(DMIC, 0, 4, dmic01,
 # dmic16k (ID: 5)
 DAI_CONFIG(DMIC, 1, 5, dmic16k,
            DMIC_CONFIG(1, 500000, 4800000, 40, 60, 16000,
-                DMIC_WORD_LENGTH(s16le), 400, DMIC, 1,
+                DMIC_WORD_LENGTH(s32le), 400, DMIC, 1,
                 PDM_CONFIG(DMIC, 1, DMIC_PDM_CONFIG)))
 
 # 4 HDMI/DP outputs (ID: 6,7,8,9)


### PR DESCRIPTION
For original DMIC16k only S16_LE is supported in pcm capability.
Now this patch enables S24_LE and S32_LE for applications like
DMIC01.

fixes https://github.com/thesofproject/sof/issues/3102