### PR TITLE
tgl: iccmax use pm_runtime core power up instead of full init

### DIFF
--- a/src/platform/intel/cavs/include/cavs/lib/pm_runtime.h
+++ b/src/platform/intel/cavs/include/cavs/lib/pm_runtime.h
@@ -16,6 +16,14 @@
 #ifndef __CAVS_LIB_PM_RUNTIME_H__
 #define __CAVS_LIB_PM_RUNTIME_H__
 
+/**
+ * \brief extra pwr flag to power up a core with a specific reason
+ * it can be powered down only with the same reason (flag)
+ */
+#define PWRD_MASK	MASK(31, 30)
+#define PWRD_BY_HPRO	BIT(31)		/**< requested by HPRO */
+#define PWRD_BY_TPLG	BIT(30)		/**< typical power up */
+
 struct pm_runtime_data;
 
 /** \brief cAVS specific runtime power management data. */
@@ -23,6 +31,7 @@ struct cavs_pm_runtime_data {
 	bool dsp_d0; /**< dsp target D0(true) or D0ix(false) */
 	int host_dma_l1_sref; /**< ref counter for Host DMA accesses */
 	uint32_t sleep_core_mask; /**< represents cores in waiti state */
+	int dsp_client_bitmap[PLATFORM_CORE_COUNT]; /**< simple pwr override */
 };
 
 /**

--- a/src/platform/intel/cavs/lib/clk.c
+++ b/src/platform/intel/cavs/lib/clk.c
@@ -32,8 +32,9 @@ static inline void select_cpu_clock_hw(int freq_idx, bool release_unused)
 	uint32_t status_mask = cpu_freq_status_mask[freq_idx];
 
 #if CONFIG_TIGERLAKE
+	/* TGL specific HW recommended flow */
 	if (freq_idx == CPU_HPRO_FREQ_IDX)
-		cpu_enable_core(PLATFORM_CORE_COUNT - 1);
+		pm_runtime_get(PM_RUNTIME_DSP, PWRD_BY_HPRO | (PLATFORM_CORE_COUNT - 1));
 #endif
 
 	/* request clock */
@@ -55,8 +56,9 @@ static inline void select_cpu_clock_hw(int freq_idx, bool release_unused)
 			     (io_reg_read(SHIM_BASE + SHIM_CLKCTL) &
 			      ~SHIM_CLKCTL_OSC_REQUEST_MASK) | enc);
 #if CONFIG_TIGERLAKE
+		/* TGL specific HW recommended flow */
 		if (freq_idx != CPU_HPRO_FREQ_IDX)
-			cpu_disable_core(PLATFORM_CORE_COUNT - 1);
+			pm_runtime_put(PM_RUNTIME_DSP, PWRD_BY_HPRO | (PLATFORM_CORE_COUNT - 1));
 #endif
 	}
 

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -295,7 +295,8 @@ int platform_boot_complete(uint32_t boot_message)
 	uint32_t mb_offset = 0;
 
 #if CONFIG_TIGERLAKE && !CONFIG_CAVS_LPRO_ONLY
-	cpu_enable_core(PLATFORM_CORE_COUNT - 1);
+	/* TGL specific HW recommended flow */
+	pm_runtime_get(PM_RUNTIME_DSP, PWRD_BY_HPRO | (PLATFORM_CORE_COUNT - 1));
 #endif
 
 	mailbox_dspbox_write(mb_offset, &ready, sizeof(ready));


### PR DESCRIPTION
This will will save a lot of time if quick changes are needed
