### PR TITLE
ipc: handler: clear the stale IPC data

### DIFF
--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -118,6 +118,9 @@ struct sof_ipc_cmd_hdr *mailbox_validate(void)
 {
 	struct sof_ipc_cmd_hdr *hdr = ipc_get()->comp_data;
 
+	/* reset and clear the stale IPC data */
+	bzero(hdr, SOF_IPC_MSG_MAX_SIZE);
+
 	/* read component values from the inbox */
 	mailbox_hostbox_read(hdr, SOF_IPC_MSG_MAX_SIZE, 0, sizeof(*hdr));
 


### PR DESCRIPTION
The global IPC comp_data is used to store the full IPC message/data from
the host mailbox, it should be cleaned before storing new IPC data to
it.

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>