### PR TITLE
component: not disable irq or sync shared data for get_drv()

### DIFF
--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -35,25 +35,17 @@ static const struct comp_driver *get_drv(uint32_t type)
 	struct list_item *clist;
 	const struct comp_driver *drv = NULL;
 	struct comp_driver_info *info;
-	uint32_t flags;
-
-	irq_local_disable(flags);
 
 	/* search driver list for driver type */
 	list_for_item(clist, &drivers->list) {
 		info = container_of(clist, struct comp_driver_info, list);
 		if (info->drv->type == type) {
 			drv = info->drv;
-			platform_shared_commit(info, sizeof(*info));
 			goto out;
 		}
-
-		platform_shared_commit(info, sizeof(*info));
 	}
 
 out:
-	platform_shared_commit(drivers, sizeof(*drivers));
-	irq_local_enable(flags);
 	return drv;
 }
 


### PR DESCRIPTION
For get_drv(), we are only reading the driver info, no writing is
involved, so no need to disable irq or to sync the shared data.

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>