### PR TITLE
Fix clock change in waiti for multicore access

### DIFF
--- a/src/arch/host/include/arch/lib/cpu.h
+++ b/src/arch/host/include/arch/lib/cpu.h
@@ -24,6 +24,11 @@ static inline int arch_cpu_is_core_enabled(int id)
 	return 0;
 }
 
+static inline int arch_cpu_enabled_cores(void)
+{
+	return 1;
+}
+
 static inline int arch_cpu_get_id(void)
 {
 	return 0;

--- a/src/arch/xtensa/include/arch/lib/cpu.h
+++ b/src/arch/xtensa/include/arch/lib/cpu.h
@@ -25,6 +25,8 @@ void arch_cpu_disable_core(int id);
 
 int arch_cpu_is_core_enabled(int id);
 
+int arch_cpu_enabled_cores(void);
+
 #else
 
 static inline int arch_cpu_enable_core(int id) { return 0; }
@@ -32,6 +34,8 @@ static inline int arch_cpu_enable_core(int id) { return 0; }
 static inline void arch_cpu_disable_core(int id) { }
 
 static inline int arch_cpu_is_core_enabled(int id) { return 1; }
+
+static inline int arch_cpu_enabled_cores(void) { return 1; }
 
 #endif
 

--- a/src/arch/xtensa/lib/cpu.c
+++ b/src/arch/xtensa/lib/cpu.c
@@ -31,7 +31,7 @@
 extern struct core_context *core_ctx_ptr[PLATFORM_CORE_COUNT];
 extern struct xtos_core_data *core_data_ptr[PLATFORM_CORE_COUNT];
 
-static uint32_t active_cores_mask;
+static uint32_t active_cores_mask = BIT(PLATFORM_MASTER_CORE_ID);
 static int dsp_sref[PLATFORM_CORE_COUNT];	/**< simple ref counter */
 
 #if CONFIG_NO_SLAVE_CORE_ROM
@@ -131,8 +131,7 @@ void arch_cpu_disable_core(int id)
 
 int arch_cpu_is_core_enabled(int id)
 {
-	return id == PLATFORM_MASTER_CORE_ID ||
-		active_cores_mask & (1 << id);
+	return active_cores_mask & BIT(id);
 }
 
 void cpu_alloc_core_context(int core)

--- a/src/arch/xtensa/lib/cpu.c
+++ b/src/arch/xtensa/lib/cpu.c
@@ -134,6 +134,11 @@ int arch_cpu_is_core_enabled(int id)
 	return active_cores_mask & BIT(id);
 }
 
+int arch_cpu_enabled_cores(void)
+{
+	return active_cores_mask;
+}
+
 void cpu_alloc_core_context(int core)
 {
 	struct core_context *core_ctx;

--- a/src/include/sof/lib/clk.h
+++ b/src/include/sof/lib/clk.h
@@ -12,6 +12,7 @@
 #include <platform/lib/clk.h>
 #include <sof/sof.h>
 #include <sof/spinlock.h>
+#include <stdbool.h>
 #include <stdint.h>
 
 struct timer;
@@ -40,12 +41,19 @@ struct clock_info {
 	uint32_t notification_id;
 	uint32_t notification_mask;
 	spinlock_t lock;
+
+	/* persistent change clock value in active state */
 	int (*set_freq)(int clock, int freq_idx);
+
+	/* temporary change clock - don't modify default clock settings */
+	void (*low_power_mode)(int clock, bool enable);
 };
 
 uint32_t clock_get_freq(int clock);
 
 void clock_set_freq(int clock, uint32_t hz);
+
+void clock_low_power_mode(int clock, bool enable);
 
 uint64_t clock_ms_to_ticks(int clock, uint64_t ms);
 

--- a/src/include/sof/lib/cpu.h
+++ b/src/include/sof/lib/cpu.h
@@ -55,6 +55,11 @@ static inline int cpu_is_core_enabled(int id)
 	return arch_cpu_is_core_enabled(id);
 }
 
+static inline int cpu_enabled_cores(void)
+{
+	return arch_cpu_enabled_cores();
+}
+
 #endif
 
 #endif /* __SOF_LIB_CPU_H__ */

--- a/src/include/sof/lib/pm_runtime.h
+++ b/src/include/sof/lib/pm_runtime.h
@@ -40,6 +40,7 @@ enum pm_runtime_context {
 	DMIC_POW,			/**< DMIC Power */
 	DW_DMAC_CLK,			/**< DW DMAC Clock */
 	CORE_MEMORY_POW,		/**< Core Memory power */
+	CORE_HP_CLK,			/**< High Performance Clock*/
 	PM_RUNTIME_DSP			/**< DSP */
 };
 

--- a/src/lib/clk.c
+++ b/src/lib/clk.c
@@ -85,6 +85,14 @@ void clock_set_freq(int clock, uint32_t hz)
 	spin_unlock_irq(&clk_info->lock, flags);
 }
 
+void clock_low_power_mode(int clock, bool enable)
+{
+	struct clock_info *clk_info = clocks_get() + clock;
+
+	if (clk_info->low_power_mode)
+		clk_info->low_power_mode(clock, enable);
+}
+
 uint64_t clock_ms_to_ticks(int clock, uint64_t ms)
 {
 	struct clock_info *clk_info = clocks_get() + clock;

--- a/src/platform/intel/cavs/include/cavs/lib/pm_runtime.h
+++ b/src/platform/intel/cavs/include/cavs/lib/pm_runtime.h
@@ -22,6 +22,7 @@ struct pm_runtime_data;
 struct cavs_pm_runtime_data {
 	int dsp_d0_sref; /**< simple ref counter, accessed by core 0 only */
 	int host_dma_l1_sref; /**< ref counter for Host DMA accesses */
+	uint32_t sleep_core_mask; /**< represents cores in waiti state */
 };
 
 #endif

--- a/src/platform/intel/cavs/lib/clk.c
+++ b/src/platform/intel/cavs/lib/clk.c
@@ -9,6 +9,7 @@
 #include <sof/lib/clk.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/notifier.h>
+#include <sof/lib/pm_runtime.h>
 #include <sof/sof.h>
 #include <sof/spinlock.h>
 
@@ -127,12 +128,12 @@ static void platform_clock_low_power_mode(int clock, bool enable)
 
 void platform_clock_on_wakeup(void)
 {
-	clock_low_power_mode(CLK_CPU(cpu_get_id()), false);
+	pm_runtime_get(CORE_HP_CLK, cpu_get_id());
 }
 
 void platform_clock_on_waiti(void)
 {
-	clock_low_power_mode(CLK_CPU(cpu_get_id()), true);
+	pm_runtime_put(CORE_HP_CLK, cpu_get_id());
 }
 
 #else


### PR DESCRIPTION
There was race condition in situation with multicore environment:
1. One core saves active `current_freq_idx`  to `active_freq_idx` (HPRO) and then change `current_freq_idx` to LPRO
1. Another core saves active `current_freq_idx`  to `active_freq_idx` (LPRO) and then change `current_freq_idx` to LPRO
1. After wake-up system restore  `active_freq_idx` - LPRO instead HPRO

Moreover `sleep_core_mask` must be introduced because in a case with multiple cores connected to single clock source, then clock rate may be reduced only when each of them is in wait state. 