### PR TITLE
zephyr: Use right SOF allocator API

### DIFF
--- a/zephyr/ll_schedule.c
+++ b/zephyr/ll_schedule.c
@@ -176,7 +176,8 @@ struct ll_schedule_domain *timer_domain_init(struct timer *timer, int clk,
 {
 	struct ll_schedule_domain *d;
 
-	d = k_malloc(sizeof(*d));
+	d = rzalloc(SOF_MEM_ZONE_SYS, SOF_MEM_FLAG_SHARED,
+		    SOF_MEM_CAPS_RAM, sizeof(*d));
 	d->type = SOF_SCHEDULE_LL_TIMER;
 
 	return d;
@@ -188,7 +189,8 @@ struct ll_schedule_domain *dma_single_chan_domain_init(struct dma *dma_array,
 {
 	struct ll_schedule_domain *d;
 
-	d = k_malloc(sizeof(*d));
+	d = rzalloc(SOF_MEM_ZONE_SYS, SOF_MEM_FLAG_SHARED,
+		    SOF_MEM_CAPS_RAM, sizeof(*d));
 	d->type = SOF_SCHEDULE_LL_DMA;
 
 	return d;

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -349,7 +349,8 @@ static struct notify *host_notify;
 struct notify **arch_notify_get(void)
 {
 	if (!host_notify)
-		host_notify = k_calloc(sizeof(*host_notify), 1);
+		host_notify = rzalloc(SOF_MEM_ZONE_SYS, 0, SOF_MEM_CAPS_RAM,
+				      sizeof(*host_notify));
 	return &host_notify;
 }
 


### PR DESCRIPTION
Since we change Zephyr allocation it is better to use SOF API which
would use the latest Zephyr allocator method.