### PR TITLE
volume: add details to sink size error message

### DIFF
--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -813,7 +813,8 @@ static int volume_prepare(struct comp_dev *dev)
 						      dev->frames);
 
 	if (sinkb->stream.size < config->periods_sink * sink_period_bytes) {
-		comp_err(dev, "volume_prepare(): sink buffer size is insufficient");
+		comp_err(dev, "volume_prepare(): sink buffer size %d is insufficient < %d * %d",
+			 sinkb->stream.size, config->periods_sink, sink_period_bytes);
 		ret = -ENOMEM;
 		goto err;
 	}


### PR DESCRIPTION
Required sink size and actual size should be available
in the log file.

Signed-off-by: Marcin Maka <marcin.maka@linux.intel.com>