### PR TITLE
sof/common.h: Disable ARRAY_SIZE() & IS_ENABLED() under Zephyr

### DIFF
--- a/src/include/sof/common.h
+++ b/src/include/sof/common.h
@@ -24,11 +24,9 @@
 #include <stddef.h>
 
 /* use same syntax as Linux for simplicity */
-/* Zephyr defines this - remove local copy once Zephyr integration complete */
-#ifdef ARRAY_SIZE
-#undef ARRAY_SIZE
+#ifndef __ZEPHYR__
+# define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
 #endif
-#define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
 #define container_of(ptr, type, member) \
 	({const typeof(((type *)0)->member)*__memberptr = (ptr); \
 	(type *)((char *)__memberptr - offsetof(type, member)); })
@@ -62,14 +60,13 @@
  * error for other types, except positive integers, but it shouldn't be
  * used with them.
  */
-#ifdef IS_ENABLED
-#undef IS_ENABLED
-#endif
+#ifndef __ZEPHYR__
 #define IS_ENABLED(config) IS_ENABLED_STEP_1(config)
 #define IS_ENABLED_DUMMY_1 0,
 #define IS_ENABLED_STEP_1(config) IS_ENABLED_STEP_2(IS_ENABLED_DUMMY_ ## config)
 #define IS_ENABLED_STEP_2(values) IS_ENABLED_STEP_3(values 1, 0)
 #define IS_ENABLED_STEP_3(ignore, value, ...) (!!(value))
+#endif
 
 #if defined __XCC__
 /* XCC does not currently check alignment for packed data so no need for any


### PR DESCRIPTION
This is effectively the same patch that the Zephyr integration branch has.  IMHO it's a little bit cleaner as we have a standard symbol to test for Zephyr compilation, and this way we don't have to unconditionally disable a macro inside of Zephyr's headers.

I've been carrying this locally while working on the andyross/zephyr/sof-upstreaming branch because I've removed that change there (for obvious reasons the existing change has no chance of merging).