### PR TITLE
cavs: shim: make register functions common

### DIFF
--- a/src/platform/apollolake/include/platform/lib/shim.h
+++ b/src/platform/apollolake/include/platform/lib/shim.h
@@ -11,12 +11,9 @@
 #ifndef __PLATFORM_LIB_SHIM_H__
 #define __PLATFORM_LIB_SHIM_H__
 
+#include <cavs/lib/shim.h>
 #include <sof/bit.h>
 #include <sof/lib/memory.h>
-
-#ifndef ASSEMBLY
-#include <stdint.h>
-#endif
 
 /* DSP IPC for Host Registers */
 #define IPC_DIPCT		0x00
@@ -257,81 +254,6 @@
 
 #define DMWBA_ENABLE		BIT(0)
 #define DMWBA_READONLY		BIT(1)
-
-#ifndef ASSEMBLY
-
-static inline uint32_t shim_read(uint32_t reg)
-{
-	return *((volatile uint32_t*)(SHIM_BASE + reg));
-}
-
-static inline void shim_write(uint32_t reg, uint32_t val)
-{
-	*((volatile uint32_t*)(SHIM_BASE + reg)) = val;
-}
-
-static inline uint64_t shim_read64(uint32_t reg)
-{
-	return *((volatile uint64_t*)(SHIM_BASE + reg));
-}
-
-static inline void shim_write64(uint32_t reg, uint64_t val)
-{
-	*((volatile uint64_t*)(SHIM_BASE + reg)) = val;
-}
-
-static inline uint32_t sw_reg_read(uint32_t reg)
-{
-	return *((volatile uint32_t*)((SRAM_SW_REG_BASE -
-		SRAM_ALIAS_OFFSET) + reg));
-}
-
-static inline void sw_reg_write(uint32_t reg, uint32_t val)
-{
-	*((volatile uint32_t*)((SRAM_SW_REG_BASE -
-		SRAM_ALIAS_OFFSET) + reg)) = val;
-}
-
-static inline uint32_t mn_reg_read(uint32_t reg, uint32_t id)
-{
-	return *((volatile uint32_t*)(MN_BASE + reg));
-}
-
-static inline void mn_reg_write(uint32_t reg, uint32_t id, uint32_t val)
-{
-	*((volatile uint32_t*)(MN_BASE + reg)) = val;
-}
-
-static inline uint32_t irq_read(uint32_t reg)
-{
-	return *((volatile uint32_t*)(IRQ_BASE + reg));
-}
-
-static inline void irq_write(uint32_t reg, uint32_t val)
-{
-	*((volatile uint32_t*)(IRQ_BASE + reg)) = val;
-}
-
-static inline uint32_t ipc_read(uint32_t reg)
-{
-	return *((volatile uint32_t*)(IPC_HOST_BASE + reg));
-}
-
-static inline void ipc_write(uint32_t reg, uint32_t val)
-{
-	*((volatile uint32_t*)(IPC_HOST_BASE + reg)) = val;
-}
-
-static inline uint32_t idc_read(uint32_t reg, uint32_t core_id)
-{
-	return *((volatile uint32_t*)(IPC_DSP_BASE(core_id) + reg));
-}
-
-static inline void idc_write(uint32_t reg, uint32_t core_id, uint32_t val)
-{
-	*((volatile uint32_t*)(IPC_DSP_BASE(core_id) + reg)) = val;
-}
-#endif
 
 #endif /* __PLATFORM_LIB_SHIM_H__ */
 

--- a/src/platform/cannonlake/include/platform/lib/shim.h
+++ b/src/platform/cannonlake/include/platform/lib/shim.h
@@ -13,12 +13,9 @@
 #define __PLATFORM_LIB_SHIM_H__
 
 #include <cavs/drivers/sideband-ipc.h>
+#include <cavs/lib/shim.h>
 #include <sof/bit.h>
 #include <sof/lib/memory.h>
-
-#ifndef ASSEMBLY
-#include <stdint.h>
-#endif
 
 /* DSP IPC for Host Registers */
 #define IPC_DIPCTDR		0x00
@@ -276,91 +273,6 @@
 
 /* DMIC disable clock gating */
 #define DMIC_DCGD	((uint32_t) BIT(30))
-
-#ifndef ASSEMBLY
-
-static inline uint16_t shim_read16(uint16_t reg)
-{
-	return *((volatile uint16_t*)(SHIM_BASE + reg));
-}
-
-static inline void shim_write16(uint16_t reg, uint16_t val)
-{
-	*((volatile uint16_t*)(SHIM_BASE + reg)) = val;
-}
-
-static inline uint32_t shim_read(uint32_t reg)
-{
-	return *((volatile uint32_t*)(SHIM_BASE + reg));
-}
-
-static inline void shim_write(uint32_t reg, uint32_t val)
-{
-	*((volatile uint32_t*)(SHIM_BASE + reg)) = val;
-}
-
-static inline uint64_t shim_read64(uint32_t reg)
-{
-	return *((volatile uint64_t*)(SHIM_BASE + reg));
-}
-
-static inline void shim_write64(uint32_t reg, uint64_t val)
-{
-	*((volatile uint64_t*)(SHIM_BASE + reg)) = val;
-}
-
-static inline uint32_t sw_reg_read(uint32_t reg)
-{
-	return *((volatile uint32_t*)((SRAM_SW_REG_BASE -
-		SRAM_ALIAS_OFFSET) + reg));
-}
-
-static inline void sw_reg_write(uint32_t reg, uint32_t val)
-{
-	*((volatile uint32_t*)((SRAM_SW_REG_BASE -
-		SRAM_ALIAS_OFFSET) + reg)) = val;
-}
-
-static inline uint32_t mn_reg_read(uint32_t reg, uint32_t id)
-{
-	return *((volatile uint32_t*)(MN_BASE + reg));
-}
-
-static inline void mn_reg_write(uint32_t reg, uint32_t id, uint32_t val)
-{
-	*((volatile uint32_t*)(MN_BASE + reg)) = val;
-}
-
-static inline uint32_t irq_read(uint32_t reg)
-{
-	return *((volatile uint32_t*)(IRQ_BASE + reg));
-}
-
-static inline void irq_write(uint32_t reg, uint32_t val)
-{
-	*((volatile uint32_t*)(IRQ_BASE + reg)) = val;
-}
-
-static inline uint32_t ipc_read(uint32_t reg)
-{
-	return *((volatile uint32_t*)(IPC_HOST_BASE + reg));
-}
-
-static inline void ipc_write(uint32_t reg, uint32_t val)
-{
-	*((volatile uint32_t*)(IPC_HOST_BASE + reg)) = val;
-}
-
-static inline uint32_t idc_read(uint32_t reg, uint32_t core_id)
-{
-	return *((volatile uint32_t*)(IPC_DSP_BASE(core_id) + reg));
-}
-
-static inline void idc_write(uint32_t reg, uint32_t core_id, uint32_t val)
-{
-	*((volatile uint32_t*)(IPC_DSP_BASE(core_id) + reg)) = val;
-}
-#endif
 
 #endif /* __PLATFORM_LIB_SHIM_H__ */
 

--- a/src/platform/icelake/include/platform/lib/shim.h
+++ b/src/platform/icelake/include/platform/lib/shim.h
@@ -13,12 +13,9 @@
 #define __PLATFORM_LIB_SHIM_H__
 
 #include <cavs/drivers/sideband-ipc.h>
+#include <cavs/lib/shim.h>
 #include <sof/bit.h>
 #include <sof/lib/memory.h>
-
-#ifndef ASSEMBLY
-#include <stdint.h>
-#endif
 
 /* DSP IPC for Host Registers */
 #define IPC_DIPCTDR		0x00
@@ -270,91 +267,6 @@
 
 /* DMIC disable clock gating */
 #define DMIC_DCGD	((uint32_t) BIT(30))
-
-#ifndef ASSEMBLY
-
-static inline uint16_t shim_read16(uint16_t reg)
-{
-	return *((volatile uint16_t*)(SHIM_BASE + reg));
-}
-
-static inline void shim_write16(uint16_t reg, uint16_t val)
-{
-	*((volatile uint16_t*)(SHIM_BASE + reg)) = val;
-}
-
-static inline uint32_t shim_read(uint32_t reg)
-{
-	return *((volatile uint32_t*)(SHIM_BASE + reg));
-}
-
-static inline void shim_write(uint32_t reg, uint32_t val)
-{
-	*((volatile uint32_t*)(SHIM_BASE + reg)) = val;
-}
-
-static inline uint64_t shim_read64(uint32_t reg)
-{
-	return *((volatile uint64_t*)(SHIM_BASE + reg));
-}
-
-static inline void shim_write64(uint32_t reg, uint64_t val)
-{
-	*((volatile uint64_t*)(SHIM_BASE + reg)) = val;
-}
-
-static inline uint32_t sw_reg_read(uint32_t reg)
-{
-	return *((volatile uint32_t*)((SRAM_SW_REG_BASE -
-		SRAM_ALIAS_OFFSET) + reg));
-}
-
-static inline void sw_reg_write(uint32_t reg, uint32_t val)
-{
-	*((volatile uint32_t*)((SRAM_SW_REG_BASE -
-		SRAM_ALIAS_OFFSET) + reg)) = val;
-}
-
-static inline uint32_t mn_reg_read(uint32_t reg, uint32_t id)
-{
-	return *((volatile uint32_t*)(MN_BASE + reg));
-}
-
-static inline void mn_reg_write(uint32_t reg, uint32_t id, uint32_t val)
-{
-	*((volatile uint32_t*)(MN_BASE + reg)) = val;
-}
-
-static inline uint32_t irq_read(uint32_t reg)
-{
-	return *((volatile uint32_t*)(IRQ_BASE + reg));
-}
-
-static inline void irq_write(uint32_t reg, uint32_t val)
-{
-	*((volatile uint32_t*)(IRQ_BASE + reg)) = val;
-}
-
-static inline uint32_t ipc_read(uint32_t reg)
-{
-	return *((volatile uint32_t*)(IPC_HOST_BASE + reg));
-}
-
-static inline void ipc_write(uint32_t reg, uint32_t val)
-{
-	*((volatile uint32_t*)(IPC_HOST_BASE + reg)) = val;
-}
-
-static inline uint32_t idc_read(uint32_t reg, uint32_t core_id)
-{
-	return *((volatile uint32_t*)(IPC_DSP_BASE(core_id) + reg));
-}
-
-static inline void idc_write(uint32_t reg, uint32_t core_id, uint32_t val)
-{
-	*((volatile uint32_t*)(IPC_DSP_BASE(core_id) + reg)) = val;
-}
-#endif
 
 #endif /* __PLATFORM_LIB_SHIM_H__ */
 

--- a/src/platform/intel/cavs/include/cavs/lib/shim.h
+++ b/src/platform/intel/cavs/include/cavs/lib/shim.h
@@ -1,0 +1,112 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2020 Intel Corporation. All rights reserved.
+ *
+ * Author: Tomasz Lauda <tomasz.lauda@linux.intel.com>
+ */
+
+#ifdef __PLATFORM_LIB_SHIM_H__
+
+#ifndef __CAVS_LIB_SHIM_H__
+#define __CAVS_LIB_SHIM_H__
+
+#ifndef ASSEMBLY
+
+#include <sof/lib/memory.h>
+#include <stdint.h>
+
+static inline uint16_t shim_read16(uint16_t reg)
+{
+	return *((volatile uint16_t*)(SHIM_BASE + reg));
+}
+
+static inline void shim_write16(uint16_t reg, uint16_t val)
+{
+	*((volatile uint16_t*)(SHIM_BASE + reg)) = val;
+}
+
+static inline uint32_t shim_read(uint32_t reg)
+{
+	return *((volatile uint32_t*)(SHIM_BASE + reg));
+}
+
+static inline void shim_write(uint32_t reg, uint32_t val)
+{
+	*((volatile uint32_t*)(SHIM_BASE + reg)) = val;
+}
+
+static inline uint64_t shim_read64(uint32_t reg)
+{
+	return *((volatile uint64_t*)(SHIM_BASE + reg));
+}
+
+static inline void shim_write64(uint32_t reg, uint64_t val)
+{
+	*((volatile uint64_t*)(SHIM_BASE + reg)) = val;
+}
+
+#if !CONFIG_SUECREEK
+
+static inline uint32_t sw_reg_read(uint32_t reg)
+{
+	return *((volatile uint32_t*)((SRAM_SW_REG_BASE -
+		SRAM_ALIAS_OFFSET) + reg));
+}
+
+static inline void sw_reg_write(uint32_t reg, uint32_t val)
+{
+	*((volatile uint32_t*)((SRAM_SW_REG_BASE -
+		SRAM_ALIAS_OFFSET) + reg)) = val;
+}
+
+#endif /* !CONFIG_SUECREEK */
+
+static inline uint32_t mn_reg_read(uint32_t reg, uint32_t id)
+{
+	return *((volatile uint32_t*)(MN_BASE + reg));
+}
+
+static inline void mn_reg_write(uint32_t reg, uint32_t id, uint32_t val)
+{
+	*((volatile uint32_t*)(MN_BASE + reg)) = val;
+}
+
+static inline uint32_t irq_read(uint32_t reg)
+{
+	return *((volatile uint32_t*)(IRQ_BASE + reg));
+}
+
+static inline void irq_write(uint32_t reg, uint32_t val)
+{
+	*((volatile uint32_t*)(IRQ_BASE + reg)) = val;
+}
+
+static inline uint32_t ipc_read(uint32_t reg)
+{
+	return *((volatile uint32_t*)(IPC_HOST_BASE + reg));
+}
+
+static inline void ipc_write(uint32_t reg, uint32_t val)
+{
+	*((volatile uint32_t*)(IPC_HOST_BASE + reg)) = val;
+}
+
+static inline uint32_t idc_read(uint32_t reg, uint32_t core_id)
+{
+	return *((volatile uint32_t*)(IPC_DSP_BASE(core_id) + reg));
+}
+
+static inline void idc_write(uint32_t reg, uint32_t core_id, uint32_t val)
+{
+	*((volatile uint32_t*)(IPC_DSP_BASE(core_id) + reg)) = val;
+}
+
+#endif /* !ASSEMBLY */
+
+#endif /* __CAVS_LIB_SHIM_H__ */
+
+#else
+
+#error "This file shouldn't be included from outside of platform/lib/shim.h"
+
+#endif /* __PLATFORM_LIB_SHIM_H__ */

--- a/src/platform/suecreek/include/platform/lib/shim.h
+++ b/src/platform/suecreek/include/platform/lib/shim.h
@@ -13,12 +13,9 @@
 #define __PLATFORM_LIB_SHIM_H__
 
 #include <cavs/drivers/sideband-ipc.h>
+#include <cavs/lib/shim.h>
 #include <sof/bit.h>
 #include <sof/lib/memory.h>
-
-#ifndef ASSEMBLY
-#include <stdint.h>
-#endif
 
 /* DSP IPC for Host Registers */
 #define IPC_DIPCTDR		0x00
@@ -265,94 +262,6 @@
 
 /* DMIC disable clock gating */
 #define DMIC_DCGD	((uint32_t) BIT(30))
-
-#ifndef ASSEMBLY
-
-static inline uint16_t shim_read16(uint16_t reg)
-{
-	return *((volatile uint16_t*)(SHIM_BASE + reg));
-}
-
-static inline void shim_write16(uint16_t reg, uint16_t val)
-{
-	*((volatile uint16_t*)(SHIM_BASE + reg)) = val;
-}
-
-static inline uint32_t shim_read(uint32_t reg)
-{
-	return *((volatile uint32_t*)(SHIM_BASE + reg));
-}
-
-static inline void shim_write(uint32_t reg, uint32_t val)
-{
-	*((volatile uint32_t*)(SHIM_BASE + reg)) = val;
-}
-
-static inline uint64_t shim_read64(uint32_t reg)
-{
-	return *((volatile uint64_t*)(SHIM_BASE + reg));
-}
-
-static inline void shim_write64(uint32_t reg, uint64_t val)
-{
-	*((volatile uint64_t*)(SHIM_BASE + reg)) = val;
-}
-
-// TODO: this should be BUILD_MAILBOX
-#if !defined CONFIG_SUECREEK
-static inline uint32_t sw_reg_read(uint32_t reg)
-{
-	return *((volatile uint32_t*)((SRAM_SW_REG_BASE -
-		SRAM_ALIAS_OFFSET) + reg));
-}
-
-static inline void sw_reg_write(uint32_t reg, uint32_t val)
-{
-	*((volatile uint32_t*)((SRAM_SW_REG_BASE -
-		SRAM_ALIAS_OFFSET) + reg)) = val;
-}
-#endif
-
-static inline uint32_t mn_reg_read(uint32_t reg, uint32_t id)
-{
-	return *((volatile uint32_t*)(MN_BASE + reg));
-}
-
-static inline void mn_reg_write(uint32_t reg, uint32_t id, uint32_t val)
-{
-	*((volatile uint32_t*)(MN_BASE + reg)) = val;
-}
-
-static inline uint32_t irq_read(uint32_t reg)
-{
-	return *((volatile uint32_t*)(IRQ_BASE + reg));
-}
-
-static inline void irq_write(uint32_t reg, uint32_t val)
-{
-	*((volatile uint32_t*)(IRQ_BASE + reg)) = val;
-}
-
-static inline uint32_t ipc_read(uint32_t reg)
-{
-	return *((volatile uint32_t*)(IPC_HOST_BASE + reg));
-}
-
-static inline void ipc_write(uint32_t reg, uint32_t val)
-{
-	*((volatile uint32_t*)(IPC_HOST_BASE + reg)) = val;
-}
-
-static inline uint32_t idc_read(uint32_t reg, uint32_t core_id)
-{
-	return *((volatile uint32_t*)(IPC_DSP_BASE(core_id) + reg));
-}
-
-static inline void idc_write(uint32_t reg, uint32_t core_id, uint32_t val)
-{
-	*((volatile uint32_t*)(IPC_DSP_BASE(core_id) + reg)) = val;
-}
-#endif
 
 #endif /* __PLATFORM_LIB_SHIM_H__ */
 

--- a/src/platform/tigerlake/include/platform/lib/shim.h
+++ b/src/platform/tigerlake/include/platform/lib/shim.h
@@ -13,12 +13,9 @@
 #define __PLATFORM_LIB_SHIM_H__
 
 #include <cavs/drivers/sideband-ipc.h>
+#include <cavs/lib/shim.h>
 #include <sof/bit.h>
 #include <sof/lib/memory.h>
-
-#ifndef ASSEMBLY
-#include <stdint.h>
-#endif
 
 /* DSP IPC for Host Registers */
 #define IPC_DIPCTDR		0x00
@@ -279,91 +276,6 @@
 
 /* DMIC disable clock gating */
 #define DMIC_DCGD	((uint32_t) BIT(30))
-
-#ifndef ASSEMBLY
-
-static inline uint16_t shim_read16(uint16_t reg)
-{
-	return *((volatile uint16_t*)(SHIM_BASE + reg));
-}
-
-static inline void shim_write16(uint16_t reg, uint16_t val)
-{
-	*((volatile uint16_t*)(SHIM_BASE + reg)) = val;
-}
-
-static inline uint32_t shim_read(uint32_t reg)
-{
-	return *((volatile uint32_t*)(SHIM_BASE + reg));
-}
-
-static inline void shim_write(uint32_t reg, uint32_t val)
-{
-	*((volatile uint32_t*)(SHIM_BASE + reg)) = val;
-}
-
-static inline uint64_t shim_read64(uint32_t reg)
-{
-	return *((volatile uint64_t*)(SHIM_BASE + reg));
-}
-
-static inline void shim_write64(uint32_t reg, uint64_t val)
-{
-	*((volatile uint64_t*)(SHIM_BASE + reg)) = val;
-}
-
-static inline uint32_t sw_reg_read(uint32_t reg)
-{
-	return *((volatile uint32_t*)((SRAM_SW_REG_BASE -
-		SRAM_ALIAS_OFFSET) + reg));
-}
-
-static inline void sw_reg_write(uint32_t reg, uint32_t val)
-{
-	*((volatile uint32_t*)((SRAM_SW_REG_BASE -
-		SRAM_ALIAS_OFFSET) + reg)) = val;
-}
-
-static inline uint32_t mn_reg_read(uint32_t reg, uint32_t id)
-{
-	return *((volatile uint32_t*)(MN_BASE + reg));
-}
-
-static inline void mn_reg_write(uint32_t reg, uint32_t id, uint32_t val)
-{
-	*((volatile uint32_t*)(MN_BASE + reg)) = val;
-}
-
-static inline uint32_t irq_read(uint32_t reg)
-{
-	return *((volatile uint32_t*)(IRQ_BASE + reg));
-}
-
-static inline void irq_write(uint32_t reg, uint32_t val)
-{
-	*((volatile uint32_t*)(IRQ_BASE + reg)) = val;
-}
-
-static inline uint32_t ipc_read(uint32_t reg)
-{
-	return *((volatile uint32_t*)(IPC_HOST_BASE + reg));
-}
-
-static inline void ipc_write(uint32_t reg, uint32_t val)
-{
-	*((volatile uint32_t*)(IPC_HOST_BASE + reg)) = val;
-}
-
-static inline uint32_t idc_read(uint32_t reg, uint32_t core_id)
-{
-	return *((volatile uint32_t*)(IPC_DSP_BASE(core_id) + reg));
-}
-
-static inline void idc_write(uint32_t reg, uint32_t core_id, uint32_t val)
-{
-	*((volatile uint32_t*)(IPC_DSP_BASE(core_id) + reg)) = val;
-}
-#endif
 
 #endif /* __PLATFORM_LIB_SHIM_H__ */
 


### PR DESCRIPTION
Moves register helper functions to common cavs header.

Signed-off-by: Tomasz Lauda <tomasz.lauda@linux.intel.com>