### PR TITLE
pcm_converter: Convert linear memory regions

### DIFF
--- a/src/audio/pcm_converter/pcm_converter_generic.c
+++ b/src/audio/pcm_converter/pcm_converter_generic.c
@@ -26,114 +26,126 @@
 
 #if CONFIG_FORMAT_S16LE && CONFIG_FORMAT_S24LE
 
+static void pcm_convert_s16_to_s24_lin(const void *psrc, void *pdst,
+				       uint32_t samples)
+{
+	const int16_t *src = psrc;
+	int32_t *dst = pdst;
+	uint32_t i;
+
+	for (i = 0; i < samples; i++)
+		dst[i] = src[i] << 8;
+}
+
+static void pcm_convert_s24_to_s16_lin(const void *psrc, void *pdst,
+				       uint32_t samples)
+{
+	const int32_t *src = psrc;
+	int16_t *dst = pdst;
+	uint32_t i;
+
+	for (i = 0; i < samples; i++)
+		dst[i] = sat_int16(Q_SHIFT_RND(sign_extend_s24(src[i]), 23, 15));
+}
+
 static void pcm_convert_s16_to_s24(const struct audio_stream *source,
 				   uint32_t ioffset, struct audio_stream *sink,
 				   uint32_t ooffset, uint32_t samples)
 {
-	uint32_t buff_frag = 0;
-	int16_t *src;
-	int32_t *dst;
-	uint32_t i;
-
-	for (i = 0; i < samples; i++) {
-		src = audio_stream_read_frag_s16(source, buff_frag + ioffset);
-		dst = audio_stream_write_frag_s32(sink, buff_frag + ooffset);
-		*dst = *src << 8;
-		buff_frag++;
-	}
+	pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
+			      pcm_convert_s16_to_s24_lin);
 }
 
 static void pcm_convert_s24_to_s16(const struct audio_stream *source,
 				   uint32_t ioffset, struct audio_stream *sink,
 				   uint32_t ooffset, uint32_t samples)
 {
-	uint32_t buff_frag = 0;
-	int32_t *src;
-	int16_t *dst;
-	uint32_t i;
-
-	for (i = 0; i < samples; i++) {
-		src = audio_stream_read_frag_s32(source, buff_frag + ioffset);
-		dst = audio_stream_write_frag_s16(sink, buff_frag + ooffset);
-		*dst = sat_int16(Q_SHIFT_RND(sign_extend_s24(*src), 23, 15));
-		buff_frag++;
-	}
+	pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
+			      pcm_convert_s24_to_s16_lin);
 }
 
 #endif /* CONFIG_FORMAT_S16LE && CONFIG_FORMAT_S24LE */
 
 #if CONFIG_FORMAT_S16LE && CONFIG_FORMAT_S32LE
 
+static void pcm_convert_s16_to_s32_lin(const void *psrc, void *pdst,
+				       uint32_t samples)
+{
+	const int32_t *src = psrc;
+	int32_t *dst = pdst;
+	uint32_t i;
+
+	for (i = 0; i < samples; i++)
+		dst[i] = src[i] << 16;
+}
+
+static void pcm_convert_s32_to_s16_lin(const void *psrc, void *pdst,
+				       uint32_t samples)
+{
+	const int32_t *src = psrc;
+	int32_t *dst = pdst;
+	uint32_t i;
+
+	for (i = 0; i < samples; i++)
+		dst[i] = sat_int16(Q_SHIFT_RND(src[i], 31, 15));
+}
+
 static void pcm_convert_s16_to_s32(const struct audio_stream *source,
 				   uint32_t ioffset, struct audio_stream *sink,
 				   uint32_t ooffset, uint32_t samples)
 {
-	uint32_t buff_frag = 0;
-	int16_t *src;
-	int32_t *dst;
-	uint32_t i;
-
-	for (i = 0; i < samples; i++) {
-		src = audio_stream_read_frag_s16(source, buff_frag + ioffset);
-		dst = audio_stream_write_frag_s32(sink, buff_frag + ooffset);
-		*dst = *src << 16;
-		buff_frag++;
-	}
+	pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
+			      pcm_convert_s16_to_s32_lin);
 }
 
 static void pcm_convert_s32_to_s16(const struct audio_stream *source,
 				   uint32_t ioffset, struct audio_stream *sink,
 				   uint32_t ooffset, uint32_t samples)
 {
-	uint32_t buff_frag = 0;
-	int32_t *src;
-	int16_t *dst;
-	uint32_t i;
-
-	for (i = 0; i < samples; i++) {
-		src = audio_stream_read_frag_s32(source, buff_frag + ioffset);
-		dst = audio_stream_write_frag_s16(sink, buff_frag + ooffset);
-		*dst = sat_int16(Q_SHIFT_RND(*src, 31, 15));
-		buff_frag++;
-	}
+	pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
+			      pcm_convert_s32_to_s16_lin);
 }
 
 #endif /* CONFIG_FORMAT_S16LE && CONFIG_FORMAT_S32LE */
 
 #if CONFIG_FORMAT_S24LE && CONFIG_FORMAT_S32LE
 
+static void pcm_convert_s24_to_s32_lin(const void *psrc, void *pdst,
+				       uint32_t samples)
+{
+	const int32_t *src = psrc;
+	int32_t *dst = pdst;
+	uint32_t i;
+
+	for (i = 0; i < samples; i++)
+		dst[i] = src[i] << 8;
+}
+
+static void pcm_convert_s32_to_s24_lin(const void *psrc, void *pdst,
+				       uint32_t samples)
+{
+	const int32_t *src = psrc;
+	int32_t *dst = pdst;
+	uint32_t i;
+
+	for (i = 0; i < samples; i++)
+		dst[i] = sat_int24(Q_SHIFT_RND(src[i], 31, 23));
+}
+
 static void pcm_convert_s24_to_s32(const struct audio_stream *source,
 				   uint32_t ioffset, struct audio_stream *sink,
 				   uint32_t ooffset, uint32_t samples)
 {
-	uint32_t buff_frag = 0;
-	int32_t *src;
-	int32_t *dst;
-	uint32_t i;
-
-	for (i = 0; i < samples; i++) {
-		src = audio_stream_read_frag_s32(source, buff_frag + ioffset);
-		dst = audio_stream_write_frag_s32(sink, buff_frag + ooffset);
-		*dst = *src << 8;
-		buff_frag++;
-	}
+	pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
+			      pcm_convert_s24_to_s32_lin);
 }
 
 static void pcm_convert_s32_to_s24(const struct audio_stream *source,
 				   uint32_t ioffset, struct audio_stream *sink,
 				   uint32_t ooffset, uint32_t samples)
 {
-	uint32_t buff_frag = 0;
-	int32_t *src;
-	int32_t *dst;
-	uint32_t i;
-
-	for (i = 0; i < samples; i++) {
-		src = audio_stream_read_frag_s32(source, buff_frag + ioffset);
-		dst = audio_stream_write_frag_s32(sink, buff_frag + ooffset);
-		*dst = sat_int24(Q_SHIFT_RND(*src, 31, 23));
-		buff_frag++;
-	}
+	pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
+			      pcm_convert_s32_to_s24_lin);
 }
 
 #endif /* CONFIG_FORMAT_S24LE && CONFIG_FORMAT_S32LE */


### PR DESCRIPTION
Usage of pcm_convert_as_linear() function speed up conversion
and make core convert function easier to implement.

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>