### PR TITLE
PLL input at 50fs is no longer supported

### DIFF
--- a/tools/topology/platform/intel/jsl-rt1015.m4
+++ b/tools/topology/platform/intel/jsl-rt1015.m4
@@ -12,7 +12,7 @@ define(`SPK_DATA_FORMAT', `s24le')
 
 define(`SET_SSP_CONFIG',
 				`SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24000000, codec_mclk_in),
-						SSP_CLOCK(bclk, 2400000, codec_slave),
+						SSP_CLOCK(bclk, 3072000, codec_slave),
 						SSP_CLOCK(fsync, 48000, codec_slave),
-						SSP_TDM(2, 25, 3, 3),
+						SSP_TDM(2, 32, 3, 3),
 						SSP_CONFIG_DATA(SSP, 1, 24))')


### PR DESCRIPTION
The new recommended settings at 48Khz rate are:

PLL input       SSP bclk
------------------------
64fs            3.073Mhz
100fs           4.8Mhz

Modifying topology to 100fs