### PR TITLE
dist.cmake: add --prefix to git archive to stop creating a "tarbomb"

### DIFF
--- a/scripts/cmake/dist.cmake
+++ b/scripts/cmake/dist.cmake
@@ -1,18 +1,30 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-# depends on version.cmake
-# Adds dist target
+# This creates a release tarball from a git checkout.
+#
+# Warning: a ".tarball-version" at the top of the source directory takes
+# precedence; even for git checkouts it does! This can be used to make
+# the build "more deterministic". See GIT_TAG in version.cmake.
 
-set(TARBALL_PATH_TMP "${PROJECT_BINARY_DIR}/sof-${GIT_TAG}.tar")
-set(TARBALL_PATH "${PROJECT_BINARY_DIR}/sof-${GIT_TAG}.tgz")
+set(TAR_BASENAME sof-${GIT_TAG})
+set(TARBALL_PATH_TMP "${PROJECT_BINARY_DIR}/${TAR_BASENAME}.tar")
+set(TARBALL_PATH "${PROJECT_BINARY_DIR}/${TAR_BASENAME}.tgz")
 set(TARBALL_VERSION_BINARY_PATH "${PROJECT_BINARY_DIR}/${TARBALL_VERSION_FILE_NAME}")
 
 add_custom_target(dist
-	COMMAND git archive -o "${TARBALL_PATH_TMP}" HEAD
+	COMMAND git archive --prefix=${TAR_BASENAME}/ -o "${TARBALL_PATH_TMP}" HEAD
+
+	# .tarball-version in the top build directory for git users' convenience
 	COMMAND ${CMAKE_COMMAND} -E echo "${GIT_TAG}" > "${TARBALL_VERSION_BINARY_PATH}"
 	COMMAND ${CMAKE_COMMAND} -E echo "${GIT_LOG_HASH}" >> "${TARBALL_VERSION_BINARY_PATH}"
-	COMMAND tar rf "${TARBALL_PATH_TMP}" -C "${PROJECT_BINARY_DIR}" "${TARBALL_VERSION_FILE_NAME}"
+
+	# ${TAR_BASENAME}/.tarball-version for the release tarball
+	COMMAND ${CMAKE_COMMAND} -E make_directory "${PROJECT_BINARY_DIR}/${TAR_BASENAME}"
+	COMMAND ${CMAKE_COMMAND} -E copy "${TARBALL_VERSION_BINARY_PATH}" "${PROJECT_BINARY_DIR}/${TAR_BASENAME}/${TARBALL_VERSION_FILE_NAME}"
+	COMMAND tar rf "${TARBALL_PATH_TMP}" -C "${PROJECT_BINARY_DIR}" "${TAR_BASENAME}/${TARBALL_VERSION_FILE_NAME}"
+
 	COMMAND gzip -9 < "${TARBALL_PATH_TMP}" > "${TARBALL_PATH}"
+
 	WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
 	COMMENT "Creating tarball: ${TARBALL_PATH}"
 	BYPRODUCTS "$TARBALL_VERSION_BINARY_PATH" "${TARBALL_PATH_TMP}" "${TARBALL_PATH}"


### PR DESCRIPTION
A "tarbomb" is an archive file that has more than one directory at the
top level, which is (fortunately) unusual for .tar files. By default,
tar extracts archive members "as is" in the current directory. If the
archive has many top level members then it becomes very hard to make the
difference between what was just extracted versus what was already
there. As extraction is recursive this gets much worse because the
problem can repeat itself in subdirectories. As the last but not least
nail in the coffin, tar silently overwrites existing files by default.

This commit is admittedly an "incompatible build API change" meaning any
higher level build or packaging script that was consuming source release
tarballs (as opposed to git cloning the source) will require a small
change. Consumers of release tarballs must be rare though because the
output of "make dist" has already been broken by commit
c00d39c ("Add rimage as a git submodule") anyway yet no one noticed
yet.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>