### PR TITLE
xtensa-build-all.sh: log the main cmake and defconfig commands

### DIFF
--- a/scripts/xtensa-build-all.sh
+++ b/scripts/xtensa-build-all.sh
@@ -284,12 +284,14 @@ do
 	mkdir $BUILD_DIR
 	cd $BUILD_DIR
 
+	( set -x # log the main commands and their parameters
 	cmake -DTOOLCHAIN=$TOOLCHAIN \
 		-DROOT_DIR=$ROOT \
 		${PRIVATE_KEY_OPTION} \
 		..
 
 	make ${PLATFORM}${DEFCONFIG_PATCH}_defconfig
+	)
 
 	if [[ "x$MAKE_MENUCONFIG" == "xyes" ]]
 	then


### PR DESCRIPTION
The main build script has a fairly verbose output by default but not the
most important things it does yet. These commands are useful to "peel"
the layer of indirection and debug cmake issues; either locally or when
wondering what CI does.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>