### PR TITLE
smart_amp: fix smart amplifier tplg

### DIFF
--- a/tools/topology/sof-smart-amplifier.m4
+++ b/tools/topology/sof-smart-amplifier.m4
@@ -222,9 +222,9 @@ DAI_CONFIG(ALH, eval(SMART_ALH_INDEX + 1), eval(SMART_BE_ID + 1), SMART_ALH_CAPT
 #SSP SSP_INDEX (ID: SMART_BE_ID)
 DAI_CONFIG(SSP, SMART_SSP_INDEX, SMART_BE_ID, SMART_SSP_NAME,
 	SSP_CONFIG(DSP_B, SSP_CLOCK(mclk, SSP_MCLK, codec_mclk_in),
-		      SSP_CLOCK(bclk, 9600000, codec_slave),
+		      SSP_CLOCK(bclk, 12288000, codec_slave),
 		      SSP_CLOCK(fsync, 48000, codec_slave),
-		      SSP_TDM(8, 25, 15, 255),
+		      SSP_TDM(8, 32, 15, 255),
 		      SSP_CONFIG_DATA(SSP, SMART_SSP_INDEX, 24, 0, SMART_SSP_QUIRK)))
 ')
 


### PR DESCRIPTION
This commit changes SSP bclk rate from 9600000 to
12288000 ind ssp container to 32 bits order to fix
glitch issue.

fixes #3092 

Signed-off-by: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>