### PR TITLE
atomic: ll_scheduler: Fix atomic implementation, return old value

### DIFF
--- a/src/arch/xtensa/include/arch/atomic.h
+++ b/src/arch/xtensa/include/arch/atomic.h
@@ -45,7 +45,7 @@ static inline int32_t arch_atomic_add(atomic_t *a, int32_t value)
 		: "a" (&a->value), "a" (value)
 		: "memory");
 
-	return (*(volatile int32_t *)&a->value);
+	return current;
 }
 
 static inline int32_t arch_atomic_sub(atomic_t *a, int32_t value)
@@ -62,7 +62,7 @@ static inline int32_t arch_atomic_sub(atomic_t *a, int32_t value)
 		: "a" (&a->value), "a" (value)
 		: "memory");
 
-	return (*(volatile int32_t *)&a->value);
+	return current;
 }
 
 #endif /* __ARCH_ATOMIC_H__ */


### PR DESCRIPTION
Return value should be aligned with compiler builtins implementations,
see https://gcc.gnu.org/onlinedocs/gcc-4.1.1/gcc/Atomic-Builtins.html

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>