### PR TITLE
kpb: update kpb HB free size during RT copies

### DIFF
--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -746,6 +746,7 @@ static int kpb_copy(struct comp_dev *dev)
 			buffer_invalidate(source, copy_bytes);
 			ret = kpb_buffer_data(dev, source, copy_bytes);
 			dd->buffered_while_draining += copy_bytes;
+			kpb->hd.free -= copy_bytes;
 
 			if (ret) {
 				comp_err(dev, "kpb_copy(): internal buffering failed.");


### PR DESCRIPTION
This patch decreases history buffer free size during
real time copies therefore we avoid history data overwrite
when draining is delayed.

Signed-off-by: Marcin Rajwa <marcin.rajwa@linux.intel.com>