### PR TITLE
[DO NOT MERGE] [DO NOT REVIEW] pcm_converter: Replace asserts with sample number check to if instruction

### DIFF
--- a/src/audio/pcm_converter/pcm_converter_generic.c
+++ b/src/audio/pcm_converter/pcm_converter_generic.c
@@ -26,126 +26,126 @@
 
 #if CONFIG_FORMAT_S16LE && CONFIG_FORMAT_S24LE
 
+static void pcm_convert_s16_to_s24_lin(const void *psrc, void *pdst,
+				       uint32_t samples)
+{
+	const int16_t *src = psrc;
+	int32_t *dst = pdst;
+	uint32_t i;
+
+	for (i = 0; i < samples; i++)
+		dst[i] = src[i] << 8;
+}
+
+static void pcm_convert_s24_to_s16_lin(const void *psrc, void *pdst,
+				       uint32_t samples)
+{
+	const int32_t *src = psrc;
+	int16_t *dst = pdst;
+	uint32_t i;
+
+	for (i = 0; i < samples; i++)
+		dst[i] = sat_int16(Q_SHIFT_RND(sign_extend_s24(src[i]), 23, 15));
+}
+
 static int pcm_convert_s16_to_s24(const struct audio_stream *source,
 				  uint32_t ioffset, struct audio_stream *sink,
 				  uint32_t ooffset, uint32_t samples)
 {
-	uint32_t buff_frag = 0;
-	int16_t *src;
-	int32_t *dst;
-	uint32_t i;
-
-	for (i = 0; i < samples; i++) {
-		src = audio_stream_read_frag_s16(source, buff_frag + ioffset);
-		dst = audio_stream_write_frag_s32(sink, buff_frag + ooffset);
-		*dst = *src << 8;
-		buff_frag++;
-	}
-
-	return samples;
+	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
+				    pcm_convert_s16_to_s24_lin);
 }
 
 static int pcm_convert_s24_to_s16(const struct audio_stream *source,
 				  uint32_t ioffset, struct audio_stream *sink,
 				  uint32_t ooffset, uint32_t samples)
 {
-	uint32_t buff_frag = 0;
-	int32_t *src;
-	int16_t *dst;
-	uint32_t i;
-
-	for (i = 0; i < samples; i++) {
-		src = audio_stream_read_frag_s32(source, buff_frag + ioffset);
-		dst = audio_stream_write_frag_s16(sink, buff_frag + ooffset);
-		*dst = sat_int16(Q_SHIFT_RND(sign_extend_s24(*src), 23, 15));
-		buff_frag++;
-	}
-
-	return samples;
+	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
+				     pcm_convert_s24_to_s16_lin);
 }
 
 #endif /* CONFIG_FORMAT_S16LE && CONFIG_FORMAT_S24LE */
 
 #if CONFIG_FORMAT_S16LE && CONFIG_FORMAT_S32LE
 
+static void pcm_convert_s16_to_s32_lin(const void *psrc, void *pdst,
+				       uint32_t samples)
+{
+	const int32_t *src = psrc;
+	int32_t *dst = pdst;
+	uint32_t i;
+
+	for (i = 0; i < samples; i++)
+		dst[i] = src[i] << 16;
+}
+
+static void pcm_convert_s32_to_s16_lin(const void *psrc, void *pdst,
+				       uint32_t samples)
+{
+	const int32_t *src = psrc;
+	int32_t *dst = pdst;
+	uint32_t i;
+
+	for (i = 0; i < samples; i++)
+		dst[i] = sat_int16(Q_SHIFT_RND(src[i], 31, 15));
+}
+
 static int pcm_convert_s16_to_s32(const struct audio_stream *source,
 				  uint32_t ioffset, struct audio_stream *sink,
 				  uint32_t ooffset, uint32_t samples)
 {
-	uint32_t buff_frag = 0;
-	int16_t *src;
-	int32_t *dst;
-	uint32_t i;
-
-	for (i = 0; i < samples; i++) {
-		src = audio_stream_read_frag_s16(source, buff_frag + ioffset);
-		dst = audio_stream_write_frag_s32(sink, buff_frag + ooffset);
-		*dst = *src << 16;
-		buff_frag++;
-	}
-
-	return samples;
+	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
+				     pcm_convert_s16_to_s32_lin);
 }
 
 static int pcm_convert_s32_to_s16(const struct audio_stream *source,
 				  uint32_t ioffset, struct audio_stream *sink,
 				  uint32_t ooffset, uint32_t samples)
 {
-	uint32_t buff_frag = 0;
-	int32_t *src;
-	int16_t *dst;
-	uint32_t i;
-
-	for (i = 0; i < samples; i++) {
-		src = audio_stream_read_frag_s32(source, buff_frag + ioffset);
-		dst = audio_stream_write_frag_s16(sink, buff_frag + ooffset);
-		*dst = sat_int16(Q_SHIFT_RND(*src, 31, 15));
-		buff_frag++;
-	}
-
-	return samples;
+	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
+				     pcm_convert_s32_to_s16_lin);
 }
 
 #endif /* CONFIG_FORMAT_S16LE && CONFIG_FORMAT_S32LE */
 
 #if CONFIG_FORMAT_S24LE && CONFIG_FORMAT_S32LE
 
+static void pcm_convert_s24_to_s32_lin(const void *psrc, void *pdst,
+				       uint32_t samples)
+{
+	const int32_t *src = psrc;
+	int32_t *dst = pdst;
+	uint32_t i;
+
+	for (i = 0; i < samples; i++)
+		dst[i] = src[i] << 8;
+}
+
+static void pcm_convert_s32_to_s24_lin(const void *psrc, void *pdst,
+				       uint32_t samples)
+{
+	const int32_t *src = psrc;
+	int32_t *dst = pdst;
+	uint32_t i;
+
+	for (i = 0; i < samples; i++)
+		dst[i] = sat_int24(Q_SHIFT_RND(src[i], 31, 23));
+}
+
 static int pcm_convert_s24_to_s32(const struct audio_stream *source,
 				  uint32_t ioffset, struct audio_stream *sink,
 				  uint32_t ooffset, uint32_t samples)
 {
-	uint32_t buff_frag = 0;
-	int32_t *src;
-	int32_t *dst;
-	uint32_t i;
-
-	for (i = 0; i < samples; i++) {
-		src = audio_stream_read_frag_s32(source, buff_frag + ioffset);
-		dst = audio_stream_write_frag_s32(sink, buff_frag + ooffset);
-		*dst = *src << 8;
-		buff_frag++;
-	}
-
-	return samples;
+	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
+				     pcm_convert_s24_to_s32_lin);
 }
 
 static int pcm_convert_s32_to_s24(const struct audio_stream *source,
 				  uint32_t ioffset, struct audio_stream *sink,
 				  uint32_t ooffset, uint32_t samples)
 {
-	uint32_t buff_frag = 0;
-	int32_t *src;
-	int32_t *dst;
-	uint32_t i;
-
-	for (i = 0; i < samples; i++) {
-		src = audio_stream_read_frag_s32(source, buff_frag + ioffset);
-		dst = audio_stream_write_frag_s32(sink, buff_frag + ooffset);
-		*dst = sat_int24(Q_SHIFT_RND(*src, 31, 23));
-		buff_frag++;
-	}
-
-	return samples;
+	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
+				     pcm_convert_s32_to_s24_lin);
 }
 
 #endif /* CONFIG_FORMAT_S24LE && CONFIG_FORMAT_S32LE */

--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -863,8 +863,8 @@ static int dw_dma_copy(struct dma_chan_data *channel, int bytes,
 	};
 	uint32_t irq_flags;
 
-	tr_dbg(&dwdma_tr, "dw_dma_copy(): dma %d channel %d copy",
-	       channel->dma->plat_data.id, channel->index);
+	tr_info(&dwdma_tr, "dw_dma_copy(): dma %d channel %d copy",
+		channel->dma->plat_data.id, channel->index);
 
 	notifier_event(channel, NOTIFIER_ID_DMA_COPY,
 		       NOTIFIER_TARGET_CORE_LOCAL, &next, sizeof(next));

--- a/src/drivers/intel/hda/hda-dma.c
+++ b/src/drivers/intel/hda/hda-dma.c
@@ -330,8 +330,8 @@ static void hda_dma_post_copy(struct dma_chan_data *chan, int bytes)
 
 static int hda_dma_link_copy_ch(struct dma_chan_data *chan, int bytes)
 {
-	tr_dbg(&hdma_tr, "hda-dmac: %d channel %d -> copy 0x%x bytes",
-	       chan->dma->plat_data.id, chan->index, bytes);
+	tr_info(&hdma_tr, "hda-dmac: %d channel %d -> copy 0x%x bytes",
+		chan->dma->plat_data.id, chan->index, bytes);
 
 	hda_dma_get_dbg_vals(chan, HDA_DBG_PRE, HDA_DBG_LINK);
 
@@ -436,7 +436,7 @@ static int hda_dma_host_copy(struct dma_chan_data *channel, int bytes,
 {
 	int ret;
 
-	tr_dbg(&hdma_tr, "hda-dmac: %d channel %d -> copy 0x%x bytes",
+	tr_info(&hdma_tr, "hda-dmac: %d channel %d -> copy 0x%x bytes",
 	       channel->dma->plat_data.id, channel->index, bytes);
 
 	hda_dma_get_dbg_vals(channel, HDA_DBG_PRE, HDA_DBG_HOST);


### PR DESCRIPTION
Using if with return instruction is not so fatal consequences
as assertion, so fw will keep running after such an error.

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>

Fix for https://github.com/thesofproject/sof/issues/3146