### PR TITLE
dist.cmake: add 'rebuild_cache' warning.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@
 *.rom
 *.man
 .version
-.tarball-version
 *.x
 .build
 *.dis

--- a/scripts/cmake/dist.cmake
+++ b/scripts/cmake/dist.cmake
@@ -26,7 +26,9 @@ add_custom_target(dist
 	COMMAND gzip -9 < "${TARBALL_PATH_TMP}" > "${TARBALL_PATH}"
 
 	WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
-	COMMENT "Creating tarball: ${TARBALL_PATH}"
+	COMMENT "Creating tarball: ${TARBALL_PATH}
+Warning: you must invoke make/ninja 'rebuild_cache' when the version changes, 'clean' is not enough.
+"
 	BYPRODUCTS "$TARBALL_VERSION_BINARY_PATH" "${TARBALL_PATH_TMP}" "${TARBALL_PATH}"
 	VERBATIM
 	USES_TERMINAL


### PR DESCRIPTION
dist.cmake is (for now) the only .cmake file that uses GIT_TAG at _cmake
configure time_. This means even "make clean" is not enough for
dist.cmake to take into account some git tag or version change. It's
very confusing because on the other hand "make check_version_h" and
everything else always shows up-to-date git information.

"make rebuild_cache" addresses this situation so mention it in a
warning.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>