### PR TITLE
check patch: ABI warning only once per file, not once per line

### DIFF
--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -2309,6 +2309,7 @@ sub process {
 	my $commit_log_has_diff = 0;
 	my $reported_maintainer_file = 0;
 	my $reported_abi_update = 0;
+	my $last_abi_file = '';
 	my $non_utf8_charset = 0;
 
 	my $last_blank_line = 0;
@@ -3321,10 +3322,11 @@ sub process {
 		}
 
 # UAPI ABI version
-		if ($SOF &&
+		if ($SOF && $realfile ne $last_abi_file &&
 		    $realfile =~ m@^(src/include/ipc/|src/include/kernel/|src/include/user/)@ &&
 		    $rawline =~ /^\+/ &&
 		    !$reported_abi_update) {
+			$last_abi_file = $realfile;
 			WARN("ABI update ??",
 			     "Please update ABI in accordance with http://semver.org\n" . $hereprev);
 		}


### PR DESCRIPTION
Stop drowning and missing other warnings.

Example:

 ./scripts/checkpatch.pl -g eaf49e26b4bb~0

- 40 "Please update ABI..." warnings
- 2 other warnings including a spelling mistake that were missed.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>