### PR TITLE
Revert "pcm_converter: Convert linear memory regions"

### DIFF
--- a/src/audio/pcm_converter/pcm_converter_generic.c
+++ b/src/audio/pcm_converter/pcm_converter_generic.c
@@ -26,126 +26,114 @@
 
 #if CONFIG_FORMAT_S16LE && CONFIG_FORMAT_S24LE
 
-static void pcm_convert_s16_to_s24_lin(const void *psrc, void *pdst,
-				       uint32_t samples)
-{
-	const int16_t *src = psrc;
-	int32_t *dst = pdst;
-	uint32_t i;
-
-	for (i = 0; i < samples; i++)
-		dst[i] = src[i] << 8;
-}
-
-static void pcm_convert_s24_to_s16_lin(const void *psrc, void *pdst,
-				       uint32_t samples)
-{
-	const int32_t *src = psrc;
-	int16_t *dst = pdst;
-	uint32_t i;
-
-	for (i = 0; i < samples; i++)
-		dst[i] = sat_int16(Q_SHIFT_RND(sign_extend_s24(src[i]), 23, 15));
-}
-
 static void pcm_convert_s16_to_s24(const struct audio_stream *source,
 				   uint32_t ioffset, struct audio_stream *sink,
 				   uint32_t ooffset, uint32_t samples)
 {
-	pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
-			      pcm_convert_s16_to_s24_lin);
+	uint32_t buff_frag = 0;
+	int16_t *src;
+	int32_t *dst;
+	uint32_t i;
+
+	for (i = 0; i < samples; i++) {
+		src = audio_stream_read_frag_s16(source, buff_frag + ioffset);
+		dst = audio_stream_write_frag_s32(sink, buff_frag + ooffset);
+		*dst = *src << 8;
+		buff_frag++;
+	}
 }
 
 static void pcm_convert_s24_to_s16(const struct audio_stream *source,
 				   uint32_t ioffset, struct audio_stream *sink,
 				   uint32_t ooffset, uint32_t samples)
 {
-	pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
-			      pcm_convert_s24_to_s16_lin);
+	uint32_t buff_frag = 0;
+	int32_t *src;
+	int16_t *dst;
+	uint32_t i;
+
+	for (i = 0; i < samples; i++) {
+		src = audio_stream_read_frag_s32(source, buff_frag + ioffset);
+		dst = audio_stream_write_frag_s16(sink, buff_frag + ooffset);
+		*dst = sat_int16(Q_SHIFT_RND(sign_extend_s24(*src), 23, 15));
+		buff_frag++;
+	}
 }
 
 #endif /* CONFIG_FORMAT_S16LE && CONFIG_FORMAT_S24LE */
 
 #if CONFIG_FORMAT_S16LE && CONFIG_FORMAT_S32LE
 
-static void pcm_convert_s16_to_s32_lin(const void *psrc, void *pdst,
-				       uint32_t samples)
-{
-	const int32_t *src = psrc;
-	int32_t *dst = pdst;
-	uint32_t i;
-
-	for (i = 0; i < samples; i++)
-		dst[i] = src[i] << 16;
-}
-
-static void pcm_convert_s32_to_s16_lin(const void *psrc, void *pdst,
-				       uint32_t samples)
-{
-	const int32_t *src = psrc;
-	int32_t *dst = pdst;
-	uint32_t i;
-
-	for (i = 0; i < samples; i++)
-		dst[i] = sat_int16(Q_SHIFT_RND(src[i], 31, 15));
-}
-
 static void pcm_convert_s16_to_s32(const struct audio_stream *source,
 				   uint32_t ioffset, struct audio_stream *sink,
 				   uint32_t ooffset, uint32_t samples)
 {
-	pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
-			      pcm_convert_s16_to_s32_lin);
+	uint32_t buff_frag = 0;
+	int16_t *src;
+	int32_t *dst;
+	uint32_t i;
+
+	for (i = 0; i < samples; i++) {
+		src = audio_stream_read_frag_s16(source, buff_frag + ioffset);
+		dst = audio_stream_write_frag_s32(sink, buff_frag + ooffset);
+		*dst = *src << 16;
+		buff_frag++;
+	}
 }
 
 static void pcm_convert_s32_to_s16(const struct audio_stream *source,
 				   uint32_t ioffset, struct audio_stream *sink,
 				   uint32_t ooffset, uint32_t samples)
 {
-	pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
-			      pcm_convert_s32_to_s16_lin);
+	uint32_t buff_frag = 0;
+	int32_t *src;
+	int16_t *dst;
+	uint32_t i;
+
+	for (i = 0; i < samples; i++) {
+		src = audio_stream_read_frag_s32(source, buff_frag + ioffset);
+		dst = audio_stream_write_frag_s16(sink, buff_frag + ooffset);
+		*dst = sat_int16(Q_SHIFT_RND(*src, 31, 15));
+		buff_frag++;
+	}
 }
 
 #endif /* CONFIG_FORMAT_S16LE && CONFIG_FORMAT_S32LE */
 
 #if CONFIG_FORMAT_S24LE && CONFIG_FORMAT_S32LE
 
-static void pcm_convert_s24_to_s32_lin(const void *psrc, void *pdst,
-				       uint32_t samples)
-{
-	const int32_t *src = psrc;
-	int32_t *dst = pdst;
-	uint32_t i;
-
-	for (i = 0; i < samples; i++)
-		dst[i] = src[i] << 8;
-}
-
-static void pcm_convert_s32_to_s24_lin(const void *psrc, void *pdst,
-				       uint32_t samples)
-{
-	const int32_t *src = psrc;
-	int32_t *dst = pdst;
-	uint32_t i;
-
-	for (i = 0; i < samples; i++)
-		dst[i] = sat_int24(Q_SHIFT_RND(src[i], 31, 23));
-}
-
 static void pcm_convert_s24_to_s32(const struct audio_stream *source,
 				   uint32_t ioffset, struct audio_stream *sink,
 				   uint32_t ooffset, uint32_t samples)
 {
-	pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
-			      pcm_convert_s24_to_s32_lin);
+	uint32_t buff_frag = 0;
+	int32_t *src;
+	int32_t *dst;
+	uint32_t i;
+
+	for (i = 0; i < samples; i++) {
+		src = audio_stream_read_frag_s32(source, buff_frag + ioffset);
+		dst = audio_stream_write_frag_s32(sink, buff_frag + ooffset);
+		*dst = *src << 8;
+		buff_frag++;
+	}
 }
 
 static void pcm_convert_s32_to_s24(const struct audio_stream *source,
 				   uint32_t ioffset, struct audio_stream *sink,
 				   uint32_t ooffset, uint32_t samples)
 {
-	pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
-			      pcm_convert_s32_to_s24_lin);
+	uint32_t buff_frag = 0;
+	int32_t *src;
+	int32_t *dst;
+	uint32_t i;
+
+	for (i = 0; i < samples; i++) {
+		src = audio_stream_read_frag_s32(source, buff_frag + ioffset);
+		dst = audio_stream_write_frag_s32(sink, buff_frag + ooffset);
+		*dst = sat_int24(Q_SHIFT_RND(*src, 31, 23));
+		buff_frag++;
+	}
 }
 
 #endif /* CONFIG_FORMAT_S24LE && CONFIG_FORMAT_S32LE */


### PR DESCRIPTION
https://github.com/thesofproject/sof/pull/3156 does not work, so if we can't get a quick fix let's revert and redo. Nothing personal, just that we can't break CI for a month and keep going this way.

This reverts commit 1f092df4012def1c541bf7c627ecffd51584093b.

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>