### PR TITLE
xtensa-build-all: Fix missed $j -> $platform renaming

### DIFF
--- a/scripts/xtensa-build-all.sh
+++ b/scripts/xtensa-build-all.sh
@@ -270,7 +270,7 @@ do
 		PATH=$pwd/../$HOST/bin:$OLDPATH
 		COMPILER="gcc"
 
-		case $j in
+		case "$platform" in
 			byt|cht|cnl|sue) DEFCONFIG_PATCH="_gcc";;
 			*)	     DEFCONFIG_PATCH="";;
 		esac


### PR DESCRIPTION
In renaming of $j -> $platform one instance of variable was missed which
has led to wrong configs being used.

Signed-off-by: Shreeya Patel <shreeya.patel23498@gmail.com>