### PR TITLE
edf_scheduler: cleanup

### DIFF
--- a/src/include/sof/schedule/schedule.h
+++ b/src/include/sof/schedule/schedule.h
@@ -294,20 +294,6 @@ static inline void schedule_free(void)
 	}
 }
 
-/** See scheduler_ops::scheduler_run */
-static inline void schedule(void)
-{
-	struct schedulers *schedulers = *arch_schedulers_get();
-	struct schedule_data *sch;
-	struct list_item *slist;
-
-	list_for_item(slist, &schedulers->list) {
-		sch = container_of(slist, struct schedule_data, list);
-		if (sch->ops->scheduler_run)
-			sch->ops->scheduler_run(sch->data);
-	}
-}
-
 /**
  * Initializes scheduling task.
  * @param task Task to be initialized.

--- a/src/include/sof/schedule/task.h
+++ b/src/include/sof/schedule/task.h
@@ -49,7 +49,7 @@ struct task_ops {
 
 /** \brief Task used by schedulers. */
 struct task {
-	uint64_t start;		/**< start time */
+	uint64_t start;		/**< start time in [ms] since now (LL only) */
 	uint32_t uid;		/**< Uuid */
 	uint16_t type;		/**< type of the task (LL or EDF) */
 	uint16_t priority;	/**< priority of the task (used by LL) */

--- a/src/schedule/edf_schedule.c
+++ b/src/schedule/edf_schedule.c
@@ -104,9 +104,9 @@ static int schedule_edf_task(void *data, struct task *task, uint64_t start,
 			     uint64_t period)
 {
 	struct edf_schedule_data *edf_sch = data;
-	uint64_t ticks_per_ms;
-	uint64_t current;
 	uint32_t flags;
+	(void) period; /* not used */
+	(void) start; /* not used */
 
 	irq_local_disable(flags);
 
@@ -118,15 +118,6 @@ static int schedule_edf_task(void *data, struct task *task, uint64_t start,
 		irq_local_enable(flags);
 		return -EALREADY;
 	}
-
-	/* get current time */
-	current = platform_timer_get(timer_get());
-
-	ticks_per_ms = clock_ms_to_ticks(edf_sch->clock, 1);
-
-	/* calculate start time */
-	task->start = start ? task->start + ticks_per_ms * start / 1000 :
-		current;
 
 	/* add task to the list */
 	list_item_append(&task->list, &edf_sch->list);


### PR DESCRIPTION
This patch removes not used code from edf_scheduler header
file and code which is setting edf scheduler tasks start
time while this is not supported by this scheduler.

Signed-off-by: Marcin Rajwa <marcin.rajwa@linux.intel.com>