### PR TITLE
[Do Not Merge] buffer: Remove buffer_fmt field

### DIFF
--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -219,7 +219,7 @@ void comp_get_copy_limits(struct comp_buffer *source, struct comp_buffer *sink,
 	cl->sink_bytes = cl->frames * cl->sink_frame_bytes;
 }
 
-/* Function overwrites PCM parameters (frame_fmt, buffer_fmt, channels, rate)
+/* Function overwrites PCM parameters (frame_fmt, channels, rate)
  * with buffer parameters when specific flag is set.
  */
 static void comp_update_params(uint32_t flag,
@@ -228,9 +228,6 @@ static void comp_update_params(uint32_t flag,
 {
 	if (flag & BUFF_PARAMS_FRAME_FMT)
 		params->frame_fmt = buffer->stream.frame_fmt;
-
-	if (flag & BUFF_PARAMS_BUFFER_FMT)
-		params->buffer_fmt = buffer->buffer_fmt;
 
 	if (flag & BUFF_PARAMS_CHANNELS)
 		params->channels = buffer->stream.channels;

--- a/src/audio/pipeline.c
+++ b/src/audio/pipeline.c
@@ -336,7 +336,6 @@ static void pipeline_update_buffer_pcm_params(struct comp_buffer *buffer,
 	struct sof_ipc_stream_params *params = data;
 	int i;
 
-	params->buffer_fmt = buffer->buffer_fmt;
 	params->frame_fmt = buffer->stream.frame_fmt;
 	params->rate = buffer->stream.rate;
 	params->channels = buffer->stream.channels;
@@ -461,9 +460,9 @@ int pipeline_params(struct pipeline *p, struct comp_dev *host,
 	int dir = params->params.direction;
 	int ret;
 
-	pipe_info(p, "pipe params dir %d frame_fmt %d buffer_fmt %d rate %d",
+	pipe_info(p, "pipe params dir %d frame_fmt %d rate %d",
 		  params->params.direction, params->params.frame_fmt,
-		  params->params.buffer_fmt, params->params.rate);
+		  params->params.rate);
 	pipe_info(p, "pipe params stream_tag %d channels %d sample_valid_bytes %d sample_container_bytes %d",
 		  params->params.stream_tag, params->params.channels,
 		  params->params.sample_valid_bytes,

--- a/src/drivers/imx/esai.c
+++ b/src/drivers/imx/esai.c
@@ -440,7 +440,6 @@ static int esai_get_hw_params(struct dai *dai,
 	/* ESAI only currently supports these parameters */
 	params->rate = 48000;
 	params->channels = 2;
-	params->buffer_fmt = 0;
 	params->frame_fmt = SOF_IPC_FRAME_S24_4LE;
 
 	return 0;

--- a/src/drivers/imx/sai.c
+++ b/src/drivers/imx/sai.c
@@ -344,7 +344,6 @@ static int sai_get_hw_params(struct dai *dai,
 	/* SAI only currently supports these parameters */
 	params->rate = 48000;
 	params->channels = 2;
-	params->buffer_fmt = 0;
 	params->frame_fmt = SOF_IPC_FRAME_S32_LE;
 
 	return 0;

--- a/src/drivers/intel/alh.c
+++ b/src/drivers/intel/alh.c
@@ -58,9 +58,6 @@ static int alh_get_hw_params(struct dai *dai,
 	params->rate = alh->params.rate;
 	params->channels = alh->params.channels;
 
-	/* 0 means variable */
-	params->buffer_fmt = 0;
-
 	/* FIFO format is static */
 	params->frame_fmt = SOF_IPC_FRAME_S32_LE;
 

--- a/src/drivers/intel/baytrail/ssp.c
+++ b/src/drivers/intel/baytrail/ssp.c
@@ -487,7 +487,6 @@ static int ssp_get_hw_params(struct dai *dai,
 	struct ssp_pdata *ssp = dai_get_drvdata(dai);
 
 	params->rate = ssp->params.fsync_rate;
-	params->buffer_fmt = 0;
 
 	if (dir == SOF_IPC_STREAM_PLAYBACK)
 		params->channels = popcount(ssp->params.tx_slots);

--- a/src/drivers/intel/dmic.c
+++ b/src/drivers/intel/dmic.c
@@ -1067,7 +1067,6 @@ static int dmic_get_hw_params(struct dai *dai,
 	int di = dai->index;
 
 	params->rate = dmic_prm[di]->fifo_fs;
-	params->buffer_fmt = 0;
 
 	switch (dmic_prm[di]->num_pdm_active) {
 	case 1:

--- a/src/drivers/intel/haswell/ssp.c
+++ b/src/drivers/intel/haswell/ssp.c
@@ -395,7 +395,6 @@ static int ssp_get_hw_params(struct dai *dai,
 	struct ssp_pdata *ssp = dai_get_drvdata(dai);
 
 	params->rate = ssp->params.fsync_rate;
-	params->buffer_fmt = 0;
 
 	if (dir == SOF_IPC_STREAM_PLAYBACK)
 		params->channels = popcount(ssp->params.tx_slots);

--- a/src/drivers/intel/hda/hda.c
+++ b/src/drivers/intel/hda/hda.c
@@ -50,7 +50,6 @@ static int hda_get_hw_params(struct dai *dai,
 	params->channels = hda->params.channels;
 
 	/* 0 means variable */
-	params->buffer_fmt = 0;
 	params->frame_fmt = 0;
 
 	platform_shared_commit(hda, sizeof(*hda));

--- a/src/drivers/intel/ssp/ssp.c
+++ b/src/drivers/intel/ssp/ssp.c
@@ -640,7 +640,6 @@ static int ssp_get_hw_params(struct dai *dai,
 	struct ssp_pdata *ssp = dai_get_drvdata(dai);
 
 	params->rate = ssp->params.fsync_rate;
-	params->buffer_fmt = 0;
 
 	if (dir == SOF_IPC_STREAM_PLAYBACK)
 		params->channels = popcount(ssp->params.tx_slots);

--- a/src/include/ipc/stream.h
+++ b/src/include/ipc/stream.h
@@ -57,13 +57,6 @@ enum sof_ipc_frame {
 	/* other formats here */
 };
 
-/* stream buffer format */
-enum sof_ipc_buffer_format {
-	SOF_IPC_BUFFER_INTERLEAVED,
-	SOF_IPC_BUFFER_NONINTERLEAVED,
-	/* other formats here */
-};
-
 /* stream direction */
 enum sof_ipc_stream_direction {
 	SOF_IPC_STREAM_PLAYBACK = 0,
@@ -84,7 +77,7 @@ struct sof_ipc_stream_params {
 	struct sof_ipc_host_buffer buffer;
 	uint32_t direction;	/**< enum sof_ipc_stream_direction */
 	uint32_t frame_fmt;	/**< enum sof_ipc_frame */
-	uint32_t buffer_fmt;	/**< enum sof_ipc_buffer_format */
+	uint32_t buffer_fmt_deprecated;	/**< deprecated since ABI 3.17 */
 	uint32_t rate;
 	uint16_t stream_tag;
 	uint16_t channels;

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -79,7 +79,6 @@ extern struct tr_ctx buffer_tr;
 
 /* buffer parameters */
 #define BUFF_PARAMS_FRAME_FMT	BIT(0)
-#define BUFF_PARAMS_BUFFER_FMT	BIT(1)
 #define BUFF_PARAMS_RATE	BIT(2)
 #define BUFF_PARAMS_CHANNELS	BIT(3)
 
@@ -107,7 +106,6 @@ struct comp_buffer {
 	struct list_item sink_list;	/* list in comp buffers */
 
 	/* runtime stream params */
-	uint32_t buffer_fmt;	/**< enum sof_ipc_buffer_format */
 	uint16_t chmap[SOF_IPC_MAX_CHANNELS];	/**< channel map - SOF_CHMAP_ */
 
 	bool hw_params_configured; /**< indicates whether hw params were set */
@@ -286,7 +284,6 @@ static inline int buffer_set_params(struct comp_buffer *buffer,
 		return -EINVAL;
 	}
 
-	buffer->buffer_fmt = params->buffer_fmt;
 	for (i = 0; i < SOF_IPC_MAX_CHANNELS; i++)
 		buffer->chmap[i] = params->chmap[i];
 

--- a/tools/testbench/common_test.c
+++ b/tools/testbench/common_test.c
@@ -109,7 +109,6 @@ int tb_pipeline_params(struct ipc *ipc, struct sof_ipc_pipe_new *ipc_pipe,
 
 	/* set pcm params */
 	params.comp_id = ipc_pipe->comp_id;
-	params.params.buffer_fmt = SOF_IPC_BUFFER_INTERLEAVED;
 	params.params.frame_fmt = tp->frame_fmt;
 	params.params.direction = SOF_IPC_STREAM_PLAYBACK;
 	params.params.rate = tp->fs_in;

--- a/tools/testbench/file.c
+++ b/tools/testbench/file.c
@@ -757,7 +757,6 @@ static int file_get_hw_params(struct comp_dev *dev,
 	params->direction = dir;
 	params->rate = cd->rate;
 	params->channels = cd->channels;
-	params->buffer_fmt = 0;
 	params->frame_fmt = cd->frame_fmt;
 	return 0;
 }


### PR DESCRIPTION
This value is unused in whole source code.

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>