### PR TITLE
probes: adjust probe points limit

### DIFF
--- a/src/probe/Kconfig
+++ b/src/probe/Kconfig
@@ -13,7 +13,7 @@ config PROBE
 config PROBE_POINTS_MAX
 	int "Maximum probe points"
 	depends on PROBE
-	default 16
+	default 4
 	help
 	  Define maximum number of probes, extraction and injection combined.
 


### PR DESCRIPTION
This patch will adjust probe points limit to value verified
in the worst and corner cases

Signed-off-by: Adrian Bonislawski <adrian.bonislawski@linux.intel.com>