### PR TITLE
detector: send comp type instead of id to host

### DIFF
--- a/src/audio/detect_test.c
+++ b/src/audio/detect_test.c
@@ -292,7 +292,7 @@ static struct comp_dev *test_keyword_new(const struct comp_driver *drv,
 	}
 
 	/* build component event */
-	ipc_build_comp_event(&cd->event, comp->type, comp->id);
+	ipc_build_comp_event(&cd->event, comp->type, comp->type);
 	cd->event.event_type = SOF_CTRL_EVENT_KD;
 	cd->event.num_elems = 0;
 


### PR DESCRIPTION
This patch changes the notification to host so it sends
a component type instead of id. This is needed due to host
new feature of component events.

Signed-off-by: Marcin Rajwa <marcin.rajwa@linux.intel.com>