### PR TITLE
testbench: add null pointer check for function argument

### DIFF
--- a/tools/testbench/common_test.c
+++ b/tools/testbench/common_test.c
@@ -99,8 +99,15 @@ int tb_pipeline_params(struct ipc *ipc, struct sof_ipc_pipe_new *ipc_pipe,
 	struct sof_ipc_pcm_params params;
 	char message[DEBUG_MSG_LEN];
 	int fs_period;
-	int period = ipc_pipe->period;
+	int period;
 	int ret = 0;
+
+	if (!ipc_pipe) {
+		fprintf(stderr, "error: ipc_pipe NULL\n");
+		return -EINVAL;
+	}
+
+	period = ipc_pipe->period;
 
 	/* Compute period from sample rates */
 	fs_period = (int)(0.9999 + tp->fs_in * period / 1e6);


### PR DESCRIPTION
tb_pipeline_params() function takes an argument called ipc_pipe,
which is a pointer and is derefernced in the function to access
a member of structure that pointer is pointing to.

If this pointer is NULL, this leads to Segmentation fault. A
null pointer check is added before the argument is dereferenced.

Signed-off-by: Mohana Datta Yelugoti <ymdatta.work@gmail.com>

This error was found when testbench was fuzzed with AFL fuzzer.