### PR TITLE
ipc: handler: Message trace data is hex not decimal.

### DIFF
--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -1306,7 +1306,7 @@ void ipc_cmd(struct sof_ipc_cmd_hdr *hdr)
 	platform_shared_commit(hdr, hdr->size);
 
 out:
-	tr_dbg(&ipc_tr, "ipc: last request %d returned %d", type, ret);
+	tr_dbg(&ipc_tr, "ipc: last request 0x%x returned %d", type, ret);
 
 	/* if ret > 0, reply created and copied by cmd() */
 	if (ret <= 0) {


### PR DESCRIPTION
Make sure we see hex message in the log.

Signed-off-by: Liam Girdwood <liam.r.girdwood@linux.intel.com>