### PR TITLE
zephyr: numbers:  MIN/MAX INT already defined in Zephyr

### DIFF
--- a/src/include/sof/math/numbers.h
+++ b/src/include/sof/math/numbers.h
@@ -92,6 +92,16 @@ uint32_t crc32(uint32_t base, const void *data, uint32_t bytes);
 #define merge_4b4b(high, low) (((uint8_t)(high) << 4) | \
 			       ((low) & 0xF))
 
+/* Zephyr defines this - remove local copy once Zephyr integration complete */
+#ifdef INT_MIN
+#undef INT_MIN
+#endif
+
+/* Zephyr defines this - remove local copy once Zephyr integration complete */
+#ifdef INT_MAX
+#undef INT_MAX
+#endif
+
 /* Get max and min signed integer values for N bits word length */
 #define INT_MAX(N)	((int64_t)((1ULL << ((N) - 1)) - 1))
 #define INT_MIN(N)	((int64_t)(-((1ULL << ((N) - 1)) - 1) - 1))


### PR DESCRIPTION
Some macros are duplicated between SOF and Zephyr meaning we need
to undefine them in the short term until Zephyr and SOF can align
fully.

Signed-off-by: Liam Girdwood <liam.r.girdwood@linux.intel.com>