### PR TITLE
components: ut: all components should be declared UT_STATIC

### DIFF
--- a/src/audio/asrc/asrc.c
+++ b/src/audio/asrc/asrc.c
@@ -18,6 +18,7 @@
 #include <sof/list.h>
 #include <sof/platform.h>
 #include <sof/string.h>
+#include <sof/ut.h>
 #include <ipc/control.h>
 #include <ipc/stream.h>
 #include <ipc/topology.h>
@@ -919,7 +920,7 @@ static SHARED_DATA struct comp_driver_info comp_asrc_info = {
 	.drv = &comp_asrc,
 };
 
-static void sys_comp_asrc_init(void)
+UT_STATIC void sys_comp_asrc_init(void)
 {
 	comp_register(platform_shared_get(&comp_asrc_info,
 					  sizeof(comp_asrc_info)));

--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -24,6 +24,7 @@
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
 #include <sof/string.h>
+#include <sof/ut.h>
 #include <sof/trace/trace.h>
 #include <ipc/dai.h>
 #include <ipc/stream.h>
@@ -921,7 +922,7 @@ static SHARED_DATA struct comp_driver_info comp_dai_info = {
 	.drv = &comp_dai,
 };
 
-static void sys_comp_dai_init(void)
+UT_STATIC void sys_comp_dai_init(void)
 {
 	comp_register(platform_shared_get(&comp_dai_info,
 					  sizeof(comp_dai_info)));

--- a/src/audio/dcblock/dcblock.c
+++ b/src/audio/dcblock/dcblock.c
@@ -18,6 +18,7 @@
 #include <sof/list.h>
 #include <sof/platform.h>
 #include <sof/string.h>
+#include <sof/ut.h>
 #include <sof/trace/trace.h>
 #include <ipc/control.h>
 #include <ipc/stream.h>
@@ -413,7 +414,7 @@ static SHARED_DATA struct comp_driver_info comp_dcblock_info = {
 	.drv = &comp_dcblock,
 };
 
-static void sys_comp_dcblock_init(void)
+UT_STATIC void sys_comp_dcblock_init(void)
 {
 	comp_register(platform_shared_get(&comp_dcblock_info,
 					  sizeof(comp_dcblock_info)));

--- a/src/audio/detect_test.c
+++ b/src/audio/detect_test.c
@@ -19,6 +19,7 @@
 #include <sof/list.h>
 #include <sof/math/numbers.h>
 #include <sof/string.h>
+#include <sof/ut.h>
 #include <sof/trace/trace.h>
 #include <ipc/control.h>
 #include <ipc/stream.h>
@@ -659,7 +660,7 @@ static SHARED_DATA struct comp_driver_info comp_keyword_info = {
 	.drv = &comp_keyword,
 };
 
-static void sys_comp_keyword_init(void)
+UT_STATIC void sys_comp_keyword_init(void)
 {
 	comp_register(platform_shared_get(&comp_keyword_info,
 					  sizeof(comp_keyword_info)));

--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -19,6 +19,7 @@
 #include <sof/list.h>
 #include <sof/platform.h>
 #include <sof/string.h>
+#include <sof/ut.h>
 #include <sof/trace/trace.h>
 #include <ipc/control.h>
 #include <ipc/stream.h>
@@ -823,7 +824,7 @@ static SHARED_DATA struct comp_driver_info comp_eq_fir_info = {
 	.drv = &comp_eq_fir,
 };
 
-static void sys_comp_eq_fir_init(void)
+UT_STATIC void sys_comp_eq_fir_init(void)
 {
 	comp_register(platform_shared_get(&comp_eq_fir_info,
 					  sizeof(comp_eq_fir_info)));

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -21,6 +21,7 @@
 #include <sof/list.h>
 #include <sof/platform.h>
 #include <sof/string.h>
+#include <sof/ut.h>
 #include <sof/trace/trace.h>
 #include <ipc/control.h>
 #include <ipc/stream.h>
@@ -1003,7 +1004,7 @@ static SHARED_DATA struct comp_driver_info comp_eq_iir_info = {
 	.drv = &comp_eq_iir,
 };
 
-static void sys_comp_eq_iir_init(void)
+UT_STATIC void sys_comp_eq_iir_init(void)
 {
 	comp_register(platform_shared_get(&comp_eq_iir_info,
 					  sizeof(comp_eq_iir_info)));

--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -21,6 +21,7 @@
 #include <sof/list.h>
 #include <sof/math/numbers.h>
 #include <sof/string.h>
+#include <sof/ut.h>
 #include <sof/trace/trace.h>
 #include <ipc/stream.h>
 #include <ipc/topology.h>
@@ -915,7 +916,7 @@ static SHARED_DATA struct comp_driver_info comp_host_info = {
 	.drv = &comp_host,
 };
 
-static void sys_comp_host_init(void)
+UT_STATIC void sys_comp_host_init(void)
 {
 	comp_register(platform_shared_get(&comp_host_info,
 					  sizeof(comp_host_info)));

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -21,6 +21,7 @@
 #include <sof/math/numbers.h>
 #include <sof/platform.h>
 #include <sof/string.h>
+#include <sof/ut.h>
 #include <sof/trace/trace.h>
 #include <ipc/control.h>
 #include <ipc/stream.h>
@@ -932,7 +933,7 @@ static SHARED_DATA struct comp_driver_info comp_src_info = {
 	.drv = &comp_src,
 };
 
-static void sys_comp_src_init(void)
+UT_STATIC void sys_comp_src_init(void)
 {
 	comp_register(platform_shared_get(&comp_src_info,
 					  sizeof(comp_src_info)));

--- a/src/audio/switch.c
+++ b/src/audio/switch.c
@@ -9,6 +9,7 @@
 #include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
 #include <sof/trace/trace.h>
+#include <sof/ut.h>
 #include <ipc/topology.h>
 #include <user/trace.h>
 #include <stddef.h>
@@ -83,7 +84,7 @@ static SHARED_DATA struct comp_driver_info comp_switch_info = {
 	.drv = &comp_switch,
 };
 
-static void sys_comp_switch_init(void)
+UT_STATIC void sys_comp_switch_init(void)
 {
 	comp_register(platform_shared_get(&comp_switch_info,
 					  sizeof(comp_switch_info)));

--- a/src/audio/tone.c
+++ b/src/audio/tone.c
@@ -21,6 +21,7 @@
 #include <sof/platform.h>
 #include <sof/string.h>
 #include <sof/trace/trace.h>
+#include <sof/ut.h>
 #include <ipc/control.h>
 #include <ipc/stream.h>
 #include <ipc/topology.h>
@@ -721,7 +722,7 @@ static SHARED_DATA struct comp_driver_info comp_tone_info = {
 	.drv = &comp_tone,
 };
 
-static void sys_comp_tone_init(void)
+UT_STATIC void sys_comp_tone_init(void)
 {
 	comp_register(platform_shared_get(&comp_tone_info,
 					  sizeof(comp_tone_info)));

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -588,7 +588,7 @@ static inline struct sof_ipc_comp_config *comp_config(struct sof_ipc_comp *comp)
 #define comp_get_drvdata(c) \
 	c->priv_data
 
-#ifdef UNIT_TEST
+#if defined UNIT_TEST || defined __ZEPHYR__
 #define DECLARE_MODULE(init)
 #elif CONFIG_LIBRARY
 /* In case of shared libs components are initialised in dlopen */

--- a/src/include/sof/ut.h
+++ b/src/include/sof/ut.h
@@ -10,7 +10,7 @@
 
 /* UT_STATIC makes function unit-testable (non-static) when built for unit tests
  */
-#ifdef UNIT_TEST
+#if defined UNIT_TEST || defined __ZEPHYR__
 #define UT_STATIC
 #else
 #define UT_STATIC static


### PR DESCRIPTION
Zephyr build fails without this atm, but also needed for testbench.

Signed-off-by: Liam Girdwood <liam.r.girdwood@linux.intel.com>