### PR TITLE
zephyr: kconfig: rename CONFIG_SMP -> CONFIG_MULTICORE

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -129,7 +129,7 @@ rsource "src/Kconfig"
 
 config IDC_TASK_BUDGET
 	int "Cycles budget for IDC task"
-	depends on SMP
+	depends on MULTICORE
 	default 8000
 	help
 	  Cycles budget for IDC task per systick (see config SYSTICK).

--- a/scripts/xtensa-build-all.sh
+++ b/scripts/xtensa-build-all.sh
@@ -314,7 +314,7 @@ do
 	if [ "x$BUILD_FORCE_UP" == "xyes" ]
 	then
 		echo "Force building UP(xtensa)..."
-		echo "CONFIG_SMP=n" >> override.config
+		echo "CONFIG_MULTICORE=n" >> override.config
 	fi
 
 	if [ -e override.config ]

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,6 +25,6 @@ if (CONFIG_PROBE)
 	add_subdirectory(probe)
 endif()
 
-if (CONFIG_SMP)
+if (CONFIG_MULTICORE)
 	add_subdirectory(idc)
 endif()

--- a/src/arch/xtensa/Kconfig
+++ b/src/arch/xtensa/Kconfig
@@ -11,7 +11,7 @@ config CORE_COUNT
 	  Number of used cores
 	  Lowering available core count could result in lower power consumption
 
-config SMP
+config MULTICORE
 	bool
 	default CORE_COUNT > 1
 	help

--- a/src/arch/xtensa/include/arch/init.h
+++ b/src/arch/xtensa/include/arch/init.h
@@ -128,7 +128,7 @@ static inline void register_exceptions(void)
  */
 static inline void __memmap_init(void) { }
 
-#if CONFIG_SMP
+#if CONFIG_MULTICORE
 
 int slave_core_init(struct sof *sof);
 
@@ -136,7 +136,7 @@ int slave_core_init(struct sof *sof);
 
 static inline int slave_core_init(struct sof *sof) { return 0; }
 
-#endif /* CONFIG_SMP */
+#endif /* CONFIG_MULTICORE */
 
 #endif /* __ARCH_INIT_H__ */
 

--- a/src/arch/xtensa/include/arch/lib/cpu.h
+++ b/src/arch/xtensa/include/arch/lib/cpu.h
@@ -13,7 +13,7 @@
 
 #include <xtensa/config/core-isa.h>
 
-#if CONFIG_SMP
+#if CONFIG_MULTICORE
 
 void cpu_power_down_core(void);
 

--- a/src/arch/xtensa/init.c
+++ b/src/arch/xtensa/init.c
@@ -88,7 +88,7 @@ static void initialize_pointers_per_core(void)
 #if CONFIG_INTERRUPT_LEVEL_5
 	p->xtos_stack_for_interrupt_5 = core_data->xtos_stack_for_interrupt_5;
 #endif
-#if CONFIG_SMP
+#if CONFIG_MULTICORE
 	p->xtos_enabled = &core_data->xtos_int_data.xtos_enabled;
 	p->xtos_intstruct = &core_data->xtos_int_data;
 	p->xtos_interrupt_table =
@@ -109,7 +109,7 @@ int arch_init(void)
 	return 0;
 }
 
-#if CONFIG_SMP
+#if CONFIG_MULTICORE
 
 #include <sof/debug/panic.h>
 #include <sof/drivers/idc.h>

--- a/src/arch/xtensa/lib/CMakeLists.txt
+++ b/src/arch/xtensa/lib/CMakeLists.txt
@@ -2,6 +2,6 @@
 
 add_local_sources(sof notifier.c)
 
-if (CONFIG_SMP)
+if (CONFIG_MULTICORE)
 	add_local_sources(sof cpu.c)
 endif()

--- a/src/arch/xtensa/schedule/task.c
+++ b/src/arch/xtensa/schedule/task.c
@@ -31,7 +31,7 @@
 
 enum task_state task_main_slave_core(void *data)
 {
-#if CONFIG_SMP
+#if CONFIG_MULTICORE
 	/* main audio processing loop */
 	while (1) {
 		/* sleep until next IDC or DMA */

--- a/src/arch/xtensa/xtos/crt1-boards.S
+++ b/src/arch/xtensa/xtos/crt1-boards.S
@@ -29,7 +29,7 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-#if CONFIG_SMP
+#if CONFIG_MULTICORE
 #include <sof/lib/cpu.h>
 #include <sof/lib/memory.h>
 #endif
@@ -73,7 +73,7 @@
 	.align 4
 
 _start:
-#if CONFIG_SMP
+#if CONFIG_MULTICORE
 	// each core unpacks xtos structures for itself
 	// nevertheless core 0 initializes shared xtosstruct
 	get_prid 	a5
@@ -108,7 +108,7 @@ _start:
 #include "reset-unneeded.S"
 #endif
 
-#if !CONFIG_SMP
+#if !CONFIG_MULTICORE
 	// Init xtos struct ptr
 	movi	a2, master_core_data
 	movi	a3, core_data_ptr
@@ -163,7 +163,7 @@ xtos_per_core:
 	writesr	excsave 5 a4
 #endif
 
-#if CONFIG_SMP
+#if CONFIG_MULTICORE
 	get_prid	a5
 	movi		a4, PLATFORM_MASTER_CORE_ID
 	beq		a5, a4, xtos_per_core_obtain_xtos_structs
@@ -250,7 +250,7 @@ xtos_per_core_init_interrupt_mask:
 	// Assign stack ptr before PS is initialized to avoid any debugger
 	// side effects and prevent from double exception.
 	xtos_stack_addr_percore sp, a3, _stack_sentry, _sof_core_s_start, SOF_STACK_SIZE
-#else	/* CONFIG_SMP */
+#else	/* CONFIG_MULTICORE */
 	movi	sp, __stack
 #endif
 

--- a/src/arch/xtensa/xtos/int-highpri-dispatcher.S
+++ b/src/arch/xtensa/xtos/int-highpri-dispatcher.S
@@ -34,7 +34,7 @@
 // to be the interrupt priority level of the vector, then include this file.
 
 
-#if CONFIG_SMP
+#if CONFIG_MULTICORE
 #include <sof/lib/cpu.h>
 #endif
 #include <xtensa/coreasm.h>
@@ -96,7 +96,7 @@ STRUCT_END(HighPriFrame)
 
 	//  Allocate save area and stack:
 	//  (must use .bss, not .comm, because the subsequent .set does not work otherwise)
-#if CONFIG_SMP
+#if CONFIG_MULTICORE
 	.macro generate_stack_for_int core_id
 		.if GREATERTHAN(PLATFORM_CORE_COUNT, \core_id)
 			.section .bss, "aw"
@@ -126,7 +126,7 @@ LABEL(_Pri_,_HandlerAddress):	.space 4
 	.align	4
 	.global	LABEL(_Level,FromVector)
 LABEL(_Level,FromVector):
-#if CONFIG_SMP
+#if CONFIG_MULTICORE
 	xtos_stack_addr_percore_add	a2, LABEL(_Pri_,_Stack), PRI_N_STACK_SIZE	// get ptr to save area
 #else
 	movi	a2, LABEL(_Pri_,_Stack) + PRI_N_STACK_SIZE
@@ -218,7 +218,7 @@ LABEL(_Level,FromVector):
 
 #endif /* __XTENSA_WINDOWED_ABI__ */
 
-#if CONFIG_SMP
+#if CONFIG_MULTICORE
 	xtos_stack_addr_percore_add	a1, LABEL(_Pri_,_Stack), PRI_N_STACK_SIZE	// get ptr to save area
 #else
 	movi	a1, LABEL(_Pri_,_Stack) + PRI_N_STACK_SIZE	// get ptr to save area
@@ -232,7 +232,7 @@ LABEL(_Level,FromVector):
 	//  at the appropriate level (ie. level 2 and below are disabled in this case).
 
 #if XCHAL_HAVE_XEA1
-#if CONFIG_SMP
+#if CONFIG_MULTICORE
 	xtos_addr_percore	a7, xtos_intstruct		// address of interrupt management globals
 #else
 	movi	a7, _xtos_intstruct		// address of interrupt management globals
@@ -298,7 +298,7 @@ LABEL(Pri_,_loop):				// handle all enabled & pending interrupts
 	//  Compute pointer to interrupt table entry, given mask a14 with single bit set:
 
 # if XCHAL_HAVE_NSA
-#if CONFIG_SMP
+#if CONFIG_MULTICORE
 	xtos_addr_percore_sub	a12, xtos_interrupt_table, (32-XCHAL_NUM_INTERRUPTS)*8
 #else
 	movi	a12, xtos_interrupt_table - (32-XCHAL_NUM_INTERRUPTS)*8
@@ -306,7 +306,7 @@ LABEL(Pri_,_loop):				// handle all enabled & pending interrupts
 	nsau	a14, a14		// get index of bit in a14, numbered from msbit
 	addx8	a12, a14, a12
 # else /* XCHAL_HAVE_NSA */
-#if CONFIG_SMP
+#if CONFIG_MULTICORE
 	xtos_addr_percore	a12, xtos_interrupt_table	// pointer to interrupt table
 #else
 	movi	a12, xtos_interrupt_table	// pointer to interrupt table
@@ -338,7 +338,7 @@ LABEL(Pri_,_loop):				// handle all enabled & pending interrupts
 # endif
 
 	movi	a13, INTLEVEL_N_MASK	// (if interrupt is s/w or edge-triggered or write/err only)
-#if CONFIG_SMP
+#if CONFIG_MULTICORE
 	xtos_addr_percore	a12, xtos_interrupt_table	// get pointer to its interrupt table entry
 #else
 	movi	a12, xtos_interrupt_table	// get pointer to its interrupt table entry
@@ -357,7 +357,7 @@ LABEL(Pri_,_loop):				// handle all enabled & pending interrupts
 #endif
 
 #if XCHAL_HAVE_XEA1
-#if CONFIG_SMP
+#if CONFIG_MULTICORE
 	xtos_addr_percore	a7, xtos_intstruct	// address of interrupt management globals
 #else
 	movi	a7, _xtos_intstruct	// address of interrupt management globals
@@ -436,7 +436,7 @@ LABEL(Pri_,_spurious):
 	//  Note:  register window has rotated, ie. a0..a15 clobbered.
 
 	//  Reload initial stack pointer:
-#if CONFIG_SMP
+#if CONFIG_MULTICORE
 	xtos_stack_addr_percore_add	a1, LABEL(_Pri_,_Stack), PRI_N_STACK_SIZE	// - 16
 #else
 	movi	a1, LABEL(_Pri_,_Stack) + PRI_N_STACK_SIZE	// - 16

--- a/src/arch/xtensa/xtos/int-medpri-dispatcher.S
+++ b/src/arch/xtensa/xtos/int-medpri-dispatcher.S
@@ -171,7 +171,7 @@ no_context:
 
 	xtos_on_wakeup
 
-#if CONFIG_SMP
+#if CONFIG_MULTICORE
 	xtos_addr_percore_add	a12, xtos_interrupt_table, MAPINT(SINGLE_INT_NUM)*XIE_SIZE
 #else
 	movi	a12, xtos_interrupt_table + (MAPINT(SINGLE_INT_NUM) * XIE_SIZE)
@@ -238,7 +238,7 @@ LABEL(.L1,_loop0):
 	neg	a12, a15
 	and	a12, a12, a15
 	wsr.intclear	a12	// clear if edge-trig or s/w or wr/err (else no effect)
-#if CONFIG_SMP
+#if CONFIG_MULTICORE
 	xtos_addr_percore	a13, xtos_interrupt_table
 #else
 	movi	a13, xtos_interrupt_table

--- a/src/arch/xtensa/xtos/int-sethandler.c
+++ b/src/arch/xtensa/xtos/int-sethandler.c
@@ -30,7 +30,7 @@
 
 
 #if XCHAL_HAVE_INTERRUPTS
-#if CONFIG_SMP
+#if CONFIG_MULTICORE
 extern struct xtos_core_data *core_data_ptr[PLATFORM_CORE_COUNT];
 #else
 /*
@@ -58,7 +58,7 @@ _xtos_handler _xtos_set_interrupt_handler_arg( int n, _xtos_handler f, void *arg
         ret = 0;     /* priority level too high to safely handle in C */
     }
     else {
-#if CONFIG_SMP
+#if CONFIG_MULTICORE
         entry = &(core_data_ptr[cpu_get_id()]->xtos_int_data.xtos_interrupt_table.array[MAPINT(n)]);
 #else
         entry = xtos_interrupt_table + MAPINT(n);

--- a/src/arch/xtensa/xtos/interrupt-table.S
+++ b/src/arch/xtensa/xtos/interrupt-table.S
@@ -25,7 +25,7 @@
 #include <xtensa/coreasm.h>
 #include "xtos-internal.h"
 
-#if !CONFIG_SMP
+#if !CONFIG_MULTICORE
 #if XCHAL_HAVE_INTERRUPTS
 
 	.data
@@ -93,7 +93,7 @@ xtos_interrupt_mask_table:
 #endif /* XCHAL_HAVE_INTERRUPTS */
 
 	.text
-#endif /* CONFIG_SMP */
+#endif /* CONFIG_MULTICORE */
 
 #if XCHAL_HAVE_INTERRUPTS
 

--- a/src/arch/xtensa/xtos/ints-off.S
+++ b/src/arch/xtensa/xtos/ints-off.S
@@ -47,7 +47,7 @@ _xtos_ints_off:
 	abi_entry
 #if XCHAL_HAVE_INTERRUPTS && (XCHAL_HAVE_XEA1 || XCHAL_HAVE_XEA2)
 # if XTOS_VIRTUAL_INTENABLE
-#if CONFIG_SMP
+#if CONFIG_MULTICORE
 	xtos_addr_percore	a4, xtos_intstruct
 #else
 	movi	a4, _xtos_intstruct

--- a/src/arch/xtensa/xtos/ints-on.S
+++ b/src/arch/xtensa/xtos/ints-on.S
@@ -50,7 +50,7 @@ _xtos_ints_on:
 	abi_entry
 #if XCHAL_HAVE_INTERRUPTS && (XCHAL_HAVE_XEA1 || XCHAL_HAVE_XEA2)
 # if XTOS_VIRTUAL_INTENABLE
-#if CONFIG_SMP
+#if CONFIG_MULTICORE
 	xtos_addr_percore	a4, xtos_intstruct
 #else
 	movi	a4, _xtos_intstruct

--- a/src/arch/xtensa/xtos/user-vector.S
+++ b/src/arch/xtensa/xtos/user-vector.S
@@ -94,13 +94,13 @@ _UserExceptionFromVector:
 	 *  entries that have no handler point to xtos_unhandled_exception.
 	 */
 	.data
-#if CONFIG_SMP
+#if CONFIG_MULTICORE
 	.global	xtos_exc_handler_table_r
 #else
 	.global	xtos_exc_handler_table
 #endif
 	.align 4
-#if CONFIG_SMP
+#if CONFIG_MULTICORE
 xtos_exc_handler_table_r:
 #else
 xtos_exc_handler_table:
@@ -152,7 +152,7 @@ xtos_exc_handler_table:
 	.rept	XCHAL_EXCCAUSE_NUM-40
 	.word	xtos_unhandled_exception	//40-63 (reserved for TIE)
 	.endr
-#if CONFIG_SMP
+#if CONFIG_MULTICORE
 	.section .bss
 	.global	xtos_exc_handler_table
 	.align 4

--- a/src/arch/xtensa/xtos/xea1/int-lowpri-dispatcher.S
+++ b/src/arch/xtensa/xtos/xea1/int-lowpri-dispatcher.S
@@ -167,7 +167,7 @@ LABEL(.L1,_loop0):
 	neg	a12, a15
 	and	a12, a12, a15
 	wsr.intclear	a12	// clear if edge-trig or s/w or wr/err (else no effect)
-#if CONFIG_SMP
+#if CONFIG_MULTICORE
 	xtos_addr_percore	a13, xtos_interrupt_table
 #else
 	movi	a13, xtos_interrupt_table

--- a/src/arch/xtensa/xtos/xea1/intlevel-restore.S
+++ b/src/arch/xtensa/xtos/xea1/intlevel-restore.S
@@ -55,7 +55,7 @@ _xtos_restore_intlevel:
 	abi_entry
 #if XCHAL_HAVE_INTERRUPTS && XTOS_VIRTUAL_INTENABLE
 	mov	a3, a2
-#if CONFIG_SMP
+#if CONFIG_MULTICORE
 	xtos_addr_percore	a4, xtos_intstruct
 #else
 	movi	a4, _xtos_intstruct

--- a/src/arch/xtensa/xtos/xea1/intlevel-set.S
+++ b/src/arch/xtensa/xtos/xea1/intlevel-set.S
@@ -54,7 +54,7 @@ _xtos_set_intlevel:
 	addx4	a5, a3, a4	// index mask to use
 	l32i	a3, a5, 0	// get mask of interrupts at requested intlevel and below
 	movi	a5, -1		// all 1's
-#if CONFIG_SMP
+#if CONFIG_MULTICORE
 	xtos_addr_percore	a4, xtos_intstruct
 #else
 	movi	a4, _xtos_intstruct

--- a/src/arch/xtensa/xtos/xea1/intlevel-setmin.S
+++ b/src/arch/xtensa/xtos/xea1/intlevel-setmin.S
@@ -56,7 +56,7 @@ _xtos_set_min_intlevel:
 	addx4	a5, a3, a4	// index mask to use
 	l32i	a3, a5, 0	// get mask of interrupts at requested intlevel and below
 	movi	a5, -1		// all 1's
-#if CONFIG_SMP
+#if CONFIG_MULTICORE
 	xtos_addr_percore	a4, xtos_intstruct
 #else
 	movi	a4, _xtos_intstruct

--- a/src/arch/xtensa/xtos/xea2/int-lowpri-dispatcher.S
+++ b/src/arch/xtensa/xtos/xea2/int-lowpri-dispatcher.S
@@ -167,7 +167,7 @@ LABEL(.L1,_loop0):
 	neg	a12, a15
 	and	a12, a12, a15
 	wsr.intclear	a12	// clear if edge-trig or s/w or wr/err (else no effect)
-#if CONFIG_SMP
+#if CONFIG_MULTICORE
 	xtos_addr_percore	a13, xtos_interrupt_table
 #else
 	movi	a13, xtos_interrupt_table

--- a/src/arch/xtensa/xtos/xea2/intlevel-restore.S
+++ b/src/arch/xtensa/xtos/xea2/intlevel-restore.S
@@ -71,7 +71,7 @@ _xtos_set_vpri:
 	abi_entry
 #if XCHAL_HAVE_INTERRUPTS && XTOS_VIRTUAL_INTENABLE
 	mov	a3, a2
-#if CONFIG_SMP
+#if CONFIG_MULTICORE
 	xtos_addr_percore	a4, xtos_intstruct
 #else
 	movi	a4, _xtos_intstruct

--- a/src/arch/xtensa/xtos/xtos-internal.h
+++ b/src/arch/xtensa/xtos/xtos-internal.h
@@ -28,7 +28,7 @@
 #define XTOS_INTERNAL_H
 
 
-#if CONFIG_SMP
+#if CONFIG_MULTICORE
 #include <sof/lib/cpu.h>
 #endif
 #include <sof/lib/memory.h>
@@ -327,7 +327,7 @@ XTOS_PENDING_OFS:	.space	4	/* _xtos_pending variable */
 #endif
 	.endm
 
-#if CONFIG_SMP
+#if CONFIG_MULTICORE
 	// xtos_stack_addr_percore ax, ay, stack_master, stack_slave, stack_size
 	// Retrieves address of end of stack buffer for certain core to register ax.
 	.macro	xtos_stack_addr_percore ax, ay, stack_master_addr, mem_blk_slave_addr, stack_size
@@ -386,7 +386,7 @@ exit:
 	xtos_addr_percore	\ax, \symbol
 	addi			\ax, \ax, -\offset
 	.endm
-#endif /* CONFIG_SMP */
+#endif /* CONFIG_MULTICORE */
 
 	// xtos_addr_percore ax, structure_name
 	// Pointer to structure per core.
@@ -510,7 +510,7 @@ typedef struct XtosIntMaskEntry {
 } XtosIntMaskEntry;
 # endif
 
-#if CONFIG_SMP
+#if CONFIG_MULTICORE
 struct XtosIntStruct
 {
 	unsigned xtos_enabled;
@@ -608,7 +608,7 @@ extern void xtos_unhandled_interrupt();
 #define GREATERTHAN(a, b)	(((b) - (a)) & ~0xFFF)
 #define EQUAL(a, b)		((1 << (a)) & (1 << (b)))
 
-#if CONFIG_SMP
+#if CONFIG_MULTICORE
 // sizeof(xtos_enabled)
 #define XTOS_ENABLED_SIZE_PER_CORE	(4)
 // sizeof(vpri_enabled)

--- a/src/arch/xtensa/xtos/xtos-structs.h
+++ b/src/arch/xtensa/xtos/xtos-structs.h
@@ -26,7 +26,7 @@ struct thread_data {
 };
 
 struct xtos_core_data {
-#if CONFIG_SMP
+#if CONFIG_MULTICORE
 	struct XtosInterruptStructure xtos_int_data;
 #endif
 #if CONFIG_INTERRUPT_LEVEL_1

--- a/src/drivers/intel/cavs/CMakeLists.txt
+++ b/src/drivers/intel/cavs/CMakeLists.txt
@@ -16,6 +16,6 @@ else()
 	add_local_sources(sof ipc.c)
 endif()
 
-if(CONFIG_SMP)
+if(CONFIG_MULTICORE)
 	add_local_sources(sof idc.c)
 endif()

--- a/src/platform/intel/cavs/include/cavs/drivers/idc.h
+++ b/src/platform/intel/cavs/include/cavs/drivers/idc.h
@@ -15,7 +15,7 @@
 
 struct idc_msg;
 
-#if CONFIG_SMP
+#if CONFIG_MULTICORE
 
 int idc_send_msg(struct idc_msg *msg, uint32_t mode);
 

--- a/src/platform/tigerlake/include/platform/lib/memory.h
+++ b/src/platform/tigerlake/include/platform/lib/memory.h
@@ -317,7 +317,7 @@
 /* LP SRAM */
 #define LP_SRAM_BASE			0xBE800000
 
-#if CONFIG_SMP
+#if CONFIG_MULTICORE
 /* alternate reset vector */
 #define LP_SRAM_ALT_RESET_VEC_BASE	LP_SRAM_BASE
 #define LP_SRAM_ALT_RESET_VEC_SIZE	0x180

--- a/test/cmocka/src/audio/mux/mock.c
+++ b/test/cmocka/src/audio/mux/mock.c
@@ -40,7 +40,7 @@ struct schedulers **arch_schedulers_get(void)
 	return NULL;
 }
 
-#if CONFIG_SMP
+#if CONFIG_MULTICORE
 
 int idc_send_msg(struct idc_msg *msg, uint32_t mode)
 {

--- a/test/cmocka/src/audio/pipeline/CMakeLists.txt
+++ b/test/cmocka/src/audio/pipeline/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-if(CONFIG_SMP)
+if(CONFIG_MULTICORE)
 	SET(arch_src ${PROJECT_SOURCE_DIR}/src/drivers/intel/cavs/idc.c)
 
 	# make small lib for stripping so we don't have to care


### PR DESCRIPTION
This kconfig collides with one of the same name in Zephyr.  Rename it
for clarity ("MULTICORE" was picked for symmetry with the existing
"CORE_COUNT", though it's admittedly a little long...).

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>