### PR TITLE
topology: add smart_amp support to sof-tgl-nocodec

### DIFF
--- a/tools/topology/CMakeLists.txt
+++ b/tools/topology/CMakeLists.txt
@@ -117,6 +117,7 @@ set(TPLGS
 	"sof-cml-rt1011-rt5682\;sof-cml-rt1011-rt5682\;-DPLATFORM=cml\;-DPPROC=volume"
 	"sof-cml-rt1011-rt5682\;sof-cml-eq-rt1011-rt5682\;-DPLATFORM=cml\;-DPPROC=eq-iir-eq-fir-volume"
 	"sof-tgl-nocodec\;sof-tgl-nocodec"
+	"sof-tgl-nocodec-ci\;sof-tgl-nocodec-ci"
 	"sof-tgl-rt711-i2s-rt1308\;sof-tgl-rt711-i2s-rt1308-2ch\;-DHDMI=1\;-DCHANNELS=2"
 	"sof-tgl-rt711-i2s-rt1308\;sof-tgl-rt711-i2s-rt1308-4ch\;-DHDMI=1\;-DCHANNELS=4"
 	"sof-tgl-rt711-rt1308\;sof-tgl-rt711-rt1308-2ch\;-DCHANNELS=2"

--- a/tools/topology/sof-tgl-nocodec-ci.m4
+++ b/tools/topology/sof-tgl-nocodec-ci.m4
@@ -1,0 +1,182 @@
+#
+# Topology for Tigerlake RVP board CI testing, with covering as more
+# features as possible running with no codec machine.
+#
+# TGL Host GW DMAC support max 6 playback and max 6 capture channels so some
+# pipelines/PCMs/DAIs are commented out to keep within HW bounds. If these
+# are needed then they can be used provided other PCMs/pipelines/SSPs are
+# commented out in their place.
+
+# Include topology builder
+include(`utils.m4')
+include(`dai.m4')
+include(`ssp.m4')
+include(`pipeline.m4')
+
+# Include TLV library
+include(`common/tlv.m4')
+
+# Include Token library
+include(`sof/tokens.m4')
+
+# Include Tigerlake DSP configuration
+include(`platform/intel/tgl.m4')
+include(`platform/intel/dmic.m4')
+
+#
+# Define the pipelines
+#
+# PCM0 <---> volume <----> SSP0
+# PCM1 <---> Volume <----> SSP1
+# PCM2 ----> smart_amp ----> SSP(SSP_INDEX)
+#             ^
+#             |
+#             |
+# PCM2 <---- demux <----- SSP(SSP_INDEX)
+# PCM6 <---- volume <----- DMIC6 (DMIC01)
+#
+
+# Smart amplifier related
+# SSP related
+#define smart amplifier SSP index
+define(`SMART_SSP_INDEX', 2)
+#define SSP BE dai_link name
+define(`SMART_SSP_NAME', `NoCodec-2')
+#define BE dai_link ID
+define(`SMART_BE_ID', 2)
+#define SSP QUIRK
+define(`SMART_SSP_QUIRK', `SSP_QUIRK_LBM')
+
+# Playback related
+define(`SMART_PB_PPL_ID', 10)
+define(`SMART_PB_CH_NUM', 2)
+define(`SMART_TX_CHANNELS', 4)
+define(`SMART_RX_CHANNELS', 8)
+define(`SMART_FB_CHANNELS', 8)
+# Ref capture related
+define(`SMART_REF_PPL_ID', 11)
+define(`SMART_REF_CH_NUM', 4)
+# PCM related
+define(`SMART_PCM_ID', 2)
+define(`SMART_PCM_NAME', `smart-nocodec')
+
+# Include Smart Amplifier support
+include(`sof-smart-amplifier.m4')
+
+dnl PIPELINE_PCM_ADD(pipeline,
+dnl     pipe id, pcm, max channels, format,
+dnl     period, priority, core,
+dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
+dnl     time_domain, sched_comp)
+
+# Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s16le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	1, 0, 2, s16le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s16le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
+	2, 0, 2, s16le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency playback pipeline 3 on PCM 1 using max 2 channels of s16le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	3, 1, 2, s16le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency capture pipeline 4 on PCM 1 using max 2 channels of s16le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
+	4, 1, 2, s16le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Passthrough capture pipeline 13 on PCM 6 using max 2 channels.
+# 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
+	13, 6, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+#
+# DAIs configuration
+#
+
+dnl DAI_ADD(pipeline,
+dnl     pipe id, dai type, dai_index, dai_be,
+dnl     buffer, periods, format,
+dnl     deadline, priority, core, time_domain)
+
+# playback DAI is SSP0 using 2 periods
+# Buffers use s16le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+	1, SSP, 0, NoCodec-0,
+	PIPELINE_SOURCE_1, 2, s16le,
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+
+# capture DAI is SSP0 using 2 periods
+# Buffers use s16le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-capture.m4,
+	2, SSP, 0, NoCodec-0,
+	PIPELINE_SINK_2, 2, s16le,
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+
+# playback DAI is SSP1 using 2 periods
+# Buffers use s16le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+	3, SSP, 1, NoCodec-1,
+	PIPELINE_SOURCE_3, 2, s16le,
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+
+# capture DAI is SSP1 using 2 periods
+# Buffers use s16le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-capture.m4,
+	4, SSP, 1, NoCodec-1,
+	PIPELINE_SINK_4, 2, s16le,
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+
+# capture DAI is DMIC 0 using 2 periods
+# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-capture.m4,
+	13, DMIC, 0, NoCodec-6,
+	PIPELINE_SINK_13, 2, s32le,
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+
+dnl PCM_DUPLEX_ADD(name, pcm_id, playback, capture)
+PCM_DUPLEX_ADD(Port0, 0, PIPELINE_PCM_1, PIPELINE_PCM_2)
+PCM_DUPLEX_ADD(Port1, 1, PIPELINE_PCM_3, PIPELINE_PCM_4)
+PCM_CAPTURE_ADD(DMIC, 6, PIPELINE_PCM_13)
+
+#
+# BE configurations - overrides config in ACPI if present
+#
+
+DAI_CONFIG(SSP, 0, 0, NoCodec-0,
+	   SSP_CONFIG(I2S, SSP_CLOCK(mclk, 38400000, codec_mclk_in),
+		      SSP_CLOCK(bclk, 2400000, codec_slave),
+		      SSP_CLOCK(fsync, 48000, codec_slave),
+		      SSP_TDM(2, 25, 3, 3),
+		      SSP_CONFIG_DATA(SSP, 0, 24, 0, SSP_QUIRK_LBM)))
+
+DAI_CONFIG(SSP, 1, 1, NoCodec-1,
+	   SSP_CONFIG(I2S, SSP_CLOCK(mclk, 38400000, codec_mclk_in),
+		      SSP_CLOCK(bclk, 2400000, codec_slave),
+		      SSP_CLOCK(fsync, 48000, codec_slave),
+		      SSP_TDM(2, 25, 3, 3),
+		      SSP_CONFIG_DATA(SSP, 1, 24, 0, SSP_QUIRK_LBM)))
+
+DAI_CONFIG(DMIC, 0, 6, NoCodec-6,
+	   dnl DMIC_CONFIG(driver_version, clk_min, clk_mac, duty_min, duty_max,
+	   dnl		   sample_rate, fifo word length, unmute time, type,
+	   dnl		   dai_index, pdm controller config)
+	   DMIC_CONFIG(1, 500000, 4800000, 40, 60, 48000,
+		DMIC_WORD_LENGTH(s32le), 400, DMIC, 0,
+		dnl PDM_CONFIG(type, dai_index, num pdm active, pdm tuples list)
+		dnl STEREO_PDM0 is a pre-defined pdm config for stereo capture
+		PDM_CONFIG(DMIC, 0, STEREO_PDM0)))
+


### PR DESCRIPTION
Add nocodec mode smart_amp support to sof-tgl-nocodec-ci, which will help
to verify smart_amp feature on nocodec platforms.

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>