### PR TITLE
topology: add tgl-rt711-rt1316-rt715 support

### DIFF
--- a/tools/topology/CMakeLists.txt
+++ b/tools/topology/CMakeLists.txt
@@ -95,6 +95,7 @@ set(TPLGS
 	"sof-icl-rt711-rt1308-rt715-hdmi\;sof-icl-rt711-rt1308-rt715\;-DPLATFORM=icl"
 	"sof-icl-rt711-rt1308-rt715-hdmi\;sof-tgl-rt711-rt1308-mono-rt715\;-DPLATFORM=tgl\;-DMONO"
 	"sof-icl-rt711-rt1308-rt715-hdmi\;sof-tgl-rt711-rt1308-rt715\;-DPLATFORM=tgl"
+	"sof-icl-rt711-rt1308-rt715-hdmi\;sof-tgl-rt711-rt1316-rt714\;-DPLATFORM=tgl"
 	"sof-cnl-rt5682-sdw2\;sof-cnl-rt5682-sdw2\;-DPLATFORM=cnl"
 	"sof-apl-asrc-wm8804\;sof-apl-asrc-wm8804"
 	"sof-apl-asrc-pcm512x\;sof-apl-asrc-pcm512x"


### PR DESCRIPTION
tgl-rt711-rt1316-rt715 is almost the same as tgl-rt711-rt1308-rt715 and
can use the same topology file.

Signed-off-by: Bard Liao <yung-chuan.liao@linux.intel.com>