### PR TITLE
docker GCC and ALSA updates

### DIFF
--- a/scripts/docker_build/sof_builder/Dockerfile
+++ b/scripts/docker_build/sof_builder/Dockerfile
@@ -73,12 +73,12 @@ USER sof
 RUN cd /home/sof && \
 	git clone $CLONE_DEFAULTS --branch sof-gcc8.1 $XT_OVERLAY_REPO && \
 	cd xtensa-overlay && cd ../ && \
-	git clone $CLONE_DEFAULTS --branch sof-gcc8.1 $CT_NG_REPO && \
+	git clone $CLONE_DEFAULTS --branch sof-gcc9x $CT_NG_REPO && \
 	mkdir -p /home/sof/work/ && \
 	cd crosstool-ng && \
 	./bootstrap && ./configure --prefix=`pwd` && make && make install && \
 	for arch in byt hsw apl cnl imx imx8m; do \
-		cp config-${arch}-gcc8.1-gdb8.1 .config && \
+		cp config-${arch}-gcc9.2-gdb8.3 .config && \
 # replace the build dist to save space
 		sed -i 's#${CT_TOP_DIR}\/builds#\/home\/sof\/work#g' .config && \
 # gl_cv_func_getcwd_path_max=yes is used to avoid too-long confdir3/confdir3/...

--- a/scripts/docker_build/sof_builder/Dockerfile
+++ b/scripts/docker_build/sof_builder/Dockerfile
@@ -50,20 +50,20 @@ RUN apt-get -y update && \
 		python3 \
 		libglib2.0-dev
 
-
 ARG CLONE_DEFAULTS="--depth 5"
-# Use ToT alsa utils for the latest topology patches.
-RUN mkdir -p /root/alsa-build && cd /root/alsa-build && \
-git clone $CLONE_DEFAULTS https://github.com/thesofproject/alsa-lib.git && \
-git clone $CLONE_DEFAULTS https://github.com/thesofproject/alsa-utils.git && \
-cd /root/alsa-build/alsa-lib && ./gitcompile &&  make install && \
-cd /root/alsa-build/alsa-utils && ./gitcompile &&  make install && \
-cd /root/ && rm -rf alsa-build
 
 # Set up sof user
 RUN useradd --create-home -d /home/sof -u $UID -G sudo sof && \
 echo "sof:test0000" | chpasswd && adduser sof sudo
 ENV HOME /home/sof
+
+# Use ToT alsa utils for the latest topology patches.
+RUN mkdir -p /home/sof/work/alsa && cd /home/sof/work/alsa && \
+git clone $CLONE_DEFAULTS https://github.com/thesofproject/alsa-lib.git && \
+git clone $CLONE_DEFAULTS https://github.com/thesofproject/alsa-utils.git && \
+cd /home/sof/work/alsa/alsa-lib && ./gitcompile &&  make install && \
+cd /home/sof/work/alsa/alsa-utils && ./gitcompile &&  make install &&\
+chown -R sof:sof /home/sof
 
 ARG GITHUB_SOF=https://github.com/thesofproject
 ARG XT_OVERLAY_REPO=$GITHUB_SOF/xtensa-overlay.git


### PR DESCRIPTION
Bump GCC to 9.3 and Keep ALSA source in the container to permit ALSA development.
@xiulipan I think I screwed up my container when testing this, I can build it manually but not with the build script (maybe I need to force clean it?) Can you check. Thanks.