### PR TITLE
tools: fix memory leaks or errors found when fuzzing using AFL

### DIFF
--- a/tools/testbench/testbench.c
+++ b/tools/testbench/testbench.c
@@ -228,10 +228,20 @@ int main(int argc, char **argv)
 		exit(EXIT_FAILURE);
 	}
 
-	/* Get pointers to fileread and filewrite */
+	/* Get pointer to filewrite */
 	pcm_dev = ipc_get_comp_by_id(sof.ipc, tp.fw_id);
+	if (!pcm_dev) {
+		fprintf(stderr, "error: failed to get pointers to filewrite\n");
+		exit(EXIT_FAILURE);
+	}
 	fwcd = comp_get_drvdata(pcm_dev->cd);
+
+	/* Get pointer to fileread */
 	pcm_dev = ipc_get_comp_by_id(sof.ipc, tp.fr_id);
+	if (!pcm_dev) {
+		fprintf(stderr, "error: failed to get pointers to fileread\n");
+		exit(EXIT_FAILURE);
+	}
 	frcd = comp_get_drvdata(pcm_dev->cd);
 
 	/* Run pipeline until EOF from fileread */

--- a/tools/testbench/topology.c
+++ b/tools/testbench/topology.c
@@ -734,6 +734,9 @@ int parse_topology(struct sof *sof, struct shared_lib_table *library_table,
 			temp_comp_list = (struct comp_info *)
 					 realloc(temp_comp_list, size);
 
+			for (i = (num_comps - hdr->count); i < num_comps; i++)
+				temp_comp_list[i].name = NULL;
+
 			for (i = (num_comps - hdr->count); i < num_comps; i++) {
 				ret = load_widget(sof, SOF_DEV,
 						  temp_comp_list,


### PR DESCRIPTION
First patch:

When we try to free a pointer which is not initialized, we are
using a value in the program which is undefined. So, initialize
the pointer variable, so that in future, when we free the pointer
it won't cause a problem.

Second patch:

When an error is occurred when loading the widget, the memory
allocated is not freed properly. This results in memory leaks.
Avoid these memory leaks by freeing the allocated memory before
exiting the function by returning error value.

Third patch:

When we are about to access a pointer for its contents, check if
the pointer is NULL before doing so. Else, it may lead to segmentation
faults.

Signed-off-by: Mohana Datta Yelugoti <ymdatta.work@gmail.com>

This error was found when testbench was fuzzed with AFL fuzzer.
