### PR TITLE
smart amp: fix alignment warning of data passesed in

### DIFF
--- a/src/audio/smart_amp_test.c
+++ b/src/audio/smart_amp_test.c
@@ -90,7 +90,8 @@ static int smart_amp_set_config(struct comp_dev *dev,
 	size_t bs;
 
 	/* Copy new config, find size from header */
-	cfg = (struct sof_smart_amp_config *)cdata->data->data;
+	cfg = (struct sof_smart_amp_config *)
+	       ASSUME_ALIGNED(cdata->data->data, sizeof(uint32_t));
 	bs = cfg->size;
 
 	comp_dbg(dev, "smart_amp_set_config(), actual blob size = %u, expected blob size = %u",


### PR DESCRIPTION
Fix GGC warning on aligned packed data.

Signed-off-by: Liam Girdwood <liam.r.girdwood@linux.intel.com>

Fixes #3244