### PR TITLE
arch: xtensa: idc: dont use xtos structs for zephyr.

### DIFF
--- a/src/arch/xtensa/include/arch/drivers/idc.h
+++ b/src/arch/xtensa/include/arch/drivers/idc.h
@@ -6,10 +6,13 @@
  */
 
 #include <sof/lib/cpu.h>
+#ifndef __ZEPHYR__
 #include <xtos-structs.h>
+#endif
 
 struct idc;
 
+#ifndef __ZEPHYR__
 /**
  * \brief Returns IDC data.
  * \return Pointer to pointer of IDC data.
@@ -20,3 +23,9 @@ static inline struct idc **idc_get(void)
 
 	return &ctx->idc;
 }
+
+#else
+
+struct idc **idc_get(void);
+
+#endif


### PR DESCRIPTION
Zephyr will provide it's own per core data in place of the xtos data. XTOS not used by Zephyr.

Signed-off-by: Liam Girdwood <liam.r.girdwood@linux.intel.com>