### PR TITLE
zephyr: intel: make sure we do not perform init twice in SOF and Zephyr

### DIFF
--- a/src/init/init.c
+++ b/src/init/init.c
@@ -71,6 +71,7 @@ int master_core_init(int argc, char *argv[], struct sof *sof)
 	sof->argc = argc;
 	sof->argv = argv;
 
+#ifndef __ZEPHYR__
 	/* init architecture */
 	trace_point(TRACE_BOOT_ARCH);
 	err = arch_init();
@@ -83,6 +84,7 @@ int master_core_init(int argc, char *argv[], struct sof *sof)
 	init_heap(sof);
 
 	interrupt_init(sof);
+#endif /* __ZEPHYR__ */
 
 #if CONFIG_TRACE
 	trace_point(TRACE_BOOT_SYS_TRACES);
@@ -112,7 +114,11 @@ int master_core_init(int argc, char *argv[], struct sof *sof)
 	return err;
 }
 
+#ifdef __ZEPHYR__
+int sof_main(int argc, char *argv[])
+#else
 int main(int argc, char *argv[])
+#endif
 {
 	int err;
 
@@ -123,7 +129,9 @@ int main(int argc, char *argv[])
 	else
 		err = slave_core_init(&sof);
 
+#ifndef __ZEPHYR__
 	/* should never get here */
 	panic(SOF_IPC_PANIC_TASK);
+#endif
 	return err;
 }

--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -707,7 +707,7 @@ static int ipc_dma_trace_config(uint32_t header)
 
 	platform_shared_commit(timer, sizeof(*timer));
 
-#if CONFIG_SUECREEK
+#if CONFIG_SUECREEK || defined __ZEPHYR__
 	return 0;
 #endif
 

--- a/src/platform/baytrail/platform.c
+++ b/src/platform/baytrail/platform.c
@@ -217,9 +217,11 @@ int platform_init(struct sof *sof)
 	trace_point(TRACE_BOOT_PLATFORM_PMC);
 	platform_ipc_pmc_init();
 
+#ifndef __ZEPHYR__
 	/* init timers, clocks and schedulers */
 	trace_point(TRACE_BOOT_PLATFORM_TIMER);
 	platform_timer_start(sof->platform_timer);
+#endif
 
 	trace_point(TRACE_BOOT_PLATFORM_CLOCK);
 	platform_clock_init(sof);
@@ -319,6 +321,7 @@ int platform_init(struct sof *sof)
 		return -ENODEV;
 #endif
 
+#ifndef __ZEPHYR__
 #if CONFIG_TRACE
 	/* Initialize DMA for Trace*/
 	trace_point(TRACE_BOOT_PLATFORM_DMA_TRACE);
@@ -327,6 +330,7 @@ int platform_init(struct sof *sof)
 
 	/* show heap status */
 	heap_trace_all(1);
+#endif /* __ZEPHYR__ */
 
 	return 0;
 }

--- a/src/platform/haswell/platform.c
+++ b/src/platform/haswell/platform.c
@@ -195,9 +195,11 @@ int platform_init(struct sof *sof)
 	trace_point(TRACE_BOOT_PLATFORM_SHIM);
 	platform_init_shim();
 
+#ifndef __ZEPHYR__
 	/* init timers, clocks and schedulers */
 	trace_point(TRACE_BOOT_PLATFORM_TIMER);
 	platform_timer_start(sof->platform_timer);
+#endif
 
 	trace_point(TRACE_BOOT_PLATFORM_CLOCK);
 	platform_clock_init(sof);
@@ -255,6 +257,7 @@ int platform_init(struct sof *sof)
 	if (!ssp1)
 		return -ENODEV;
 
+#ifndef __ZEPHYR__
 #if CONFIG_TRACE
 	/* Initialize DMA for Trace*/
 	trace_point(TRACE_BOOT_PLATFORM_DMA_TRACE);
@@ -263,6 +266,7 @@ int platform_init(struct sof *sof)
 
 	/* show heap status */
 	heap_trace_all(1);
+#endif /* __ZEPHYR__ */
 
 	return 0;
 }

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -391,9 +391,11 @@ int platform_init(struct sof *sof)
 	platform_memory_windows_init(MEM_WND_INIT_CLEAR);
 #endif
 
+#ifndef __ZEPHYR__
 	/* init timers, clocks and schedulers */
 	trace_point(TRACE_BOOT_PLATFORM_TIMER);
 	platform_timer_start(sof->platform_timer);
+#endif
 
 	trace_point(TRACE_BOOT_PLATFORM_CLOCK);
 	platform_clock_init(sof);
@@ -511,6 +513,7 @@ int platform_init(struct sof *sof)
 	if (ret < 0)
 		return ret;
 
+#ifndef __ZEPHYR__
 #if CONFIG_DW_SPI
 	/* initialize the SPI slave */
 	trace_point(TRACE_BOOT_PLATFORM_SPI);
@@ -535,10 +538,11 @@ int platform_init(struct sof *sof)
 
 	/* show heap status */
 	heap_trace_all(1);
-
+#endif /* __ZEPHYR__ */
 	return 0;
 }
 
+#ifndef __ZEPHYR__
 void platform_wait_for_interrupt(int level)
 {
 #if CONFIG_CAVS_USE_LPRO_IN_WAITI
@@ -553,3 +557,4 @@ void platform_wait_for_interrupt(int level)
 	arch_wait_for_interrupt(level);
 #endif
 }
+#endif


### PR DESCRIPTION
Modify the SOF init sequence to avoid the areas where Zephyr has performed initialisation. 
@dbaluta same will need done for IMX once Zephyr core is fully upstreamed.