### PR TITLE
Unify audio_stream_copy

### DIFF
--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -166,7 +166,7 @@ static inline int set_fir_func(struct comp_dev *dev)
 	return 0;
 }
 
-/* Pass-trough functions to replace FIR core while not configured for
+/* Pass-through function to replace FIR core while not configured for
  * response.
  */
 

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -209,25 +209,13 @@ static void eq_iir_s32_24_default(const struct comp_dev *dev,
 }
 #endif /* CONFIG_FORMAT_S32LE && CONFIG_FORMAT_S24LE */
 
-#if CONFIG_FORMAT_S16LE
-static void eq_iir_s16_pass(const struct comp_dev *dev,
-			    const struct audio_stream *source,
-			    struct audio_stream *sink,
-			    uint32_t frames)
+static void eq_iir_pass(const struct comp_dev *dev,
+			const struct audio_stream *source,
+			struct audio_stream *sink,
+			uint32_t frames)
 {
-	audio_stream_copy_s16(source, 0, sink, 0, frames * source->channels);
+	audio_stream_copy(source, 0, sink, 0, frames * source->channels);
 }
-#endif /* CONFIG_FORMAT_S16LE */
-
-#if CONFIG_FORMAT_S24LE || CONFIG_FORMAT_S32LE
-static void eq_iir_s32_pass(const struct comp_dev *dev,
-			    const struct audio_stream *source,
-			    struct audio_stream *sink,
-			    uint32_t frames)
-{
-	audio_stream_copy_s32(source, 0, sink, 0, frames * source->channels);
-}
-#endif /* CONFIG_FORMAT_S24LE || CONFIG_FORMAT_S32LE */
 
 #if CONFIG_FORMAT_S16LE && CONFIG_FORMAT_S32LE
 static void eq_iir_s32_s16_pass(const struct comp_dev *dev,
@@ -294,7 +282,7 @@ const struct eq_iir_func_map fm_configured[] = {
 
 const struct eq_iir_func_map fm_passthrough[] = {
 #if CONFIG_FORMAT_S16LE
-	{SOF_IPC_FRAME_S16_LE,  SOF_IPC_FRAME_S16_LE,  eq_iir_s16_pass},
+	{SOF_IPC_FRAME_S16_LE,  SOF_IPC_FRAME_S16_LE,  eq_iir_pass},
 #endif /* CONFIG_FORMAT_S16LE */
 #if CONFIG_FORMAT_S16LE && CONFIG_FORMAT_S24LE
 	{SOF_IPC_FRAME_S16_LE,  SOF_IPC_FRAME_S24_4LE, NULL},
@@ -306,14 +294,14 @@ const struct eq_iir_func_map fm_passthrough[] = {
 	{SOF_IPC_FRAME_S32_LE,  SOF_IPC_FRAME_S16_LE,  eq_iir_s32_s16_pass},
 #endif /* CONFIG_FORMAT_S16LE && CONFIG_FORMAT_S32LE*/
 #if CONFIG_FORMAT_S24LE
-	{SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S24_4LE, eq_iir_s32_pass},
+	{SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S24_4LE, eq_iir_pass},
 #endif /* CONFIG_FORMAT_S24LE */
 #if CONFIG_FORMAT_S24LE && CONFIG_FORMAT_S32LE
 	{SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S32_LE,  NULL},
 	{SOF_IPC_FRAME_S32_LE,  SOF_IPC_FRAME_S24_4LE, eq_iir_s32_s24_pass},
 #endif /* CONFIG_FORMAT_S24LE */
 #if CONFIG_FORMAT_S32LE
-	{SOF_IPC_FRAME_S32_LE,  SOF_IPC_FRAME_S32_LE,  eq_iir_s32_pass},
+	{SOF_IPC_FRAME_S32_LE,  SOF_IPC_FRAME_S32_LE,  eq_iir_pass},
 #endif /* CONFIG_FORMAT_S32LE */
 };
 

--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -721,6 +721,8 @@ static int host_params(struct comp_dev *dev,
 			comp_err(dev, "host_params(): failed to alloc dma buffer");
 			return -ENOMEM;
 		}
+
+		buffer_set_params(hd->dma_buffer, params, BUFFER_UPDATE_FORCE);
 	}
 
 	/* create SG DMA elems for local DMA buffer */

--- a/src/audio/pcm_converter/pcm_converter_generic.c
+++ b/src/audio/pcm_converter/pcm_converter_generic.c
@@ -379,17 +379,17 @@ static void pcm_convert_f_to_s32(const struct audio_stream *source,
 
 const struct pcm_func_map pcm_func_map[] = {
 #if CONFIG_FORMAT_S16LE
-	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S16_LE, audio_stream_copy_s16 },
+	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S16_LE, audio_stream_copy },
 #endif /* CONFIG_FORMAT_S16LE */
 #if CONFIG_FORMAT_S24LE
-	{ SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S24_4LE, audio_stream_copy_s32 },
+	{ SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S24_4LE, audio_stream_copy },
 #endif /* CONFIG_FORMAT_S24LE */
 #if  CONFIG_FORMAT_S24LE && CONFIG_FORMAT_S16LE
 	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S24_4LE, pcm_convert_s16_to_s24 },
 	{ SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S16_LE, pcm_convert_s24_to_s16 },
 #endif /* CONFIG_FORMAT_S24LE && CONFIG_FORMAT_S16LE */
 #if CONFIG_FORMAT_S32LE
-	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, audio_stream_copy_s32 },
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, audio_stream_copy },
 #endif /* CONFIG_FORMAT_S32LE */
 #if CONFIG_FORMAT_S32LE && CONFIG_FORMAT_S16LE
 	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S32_LE, pcm_convert_s16_to_s32 },
@@ -400,7 +400,7 @@ const struct pcm_func_map pcm_func_map[] = {
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, pcm_convert_s32_to_s24 },
 #endif /* CONFIG_FORMAT_S32LE && CONFIG_FORMAT_S24LE */
 #if CONFIG_FORMAT_FLOAT
-	{ SOF_IPC_FRAME_FLOAT, SOF_IPC_FRAME_FLOAT, audio_stream_copy_s32 },
+	{ SOF_IPC_FRAME_FLOAT, SOF_IPC_FRAME_FLOAT, audio_stream_copy },
 #endif /* CONFIG_FORMAT_FLOAT */
 #if CONFIG_FORMAT_FLOAT && CONFIG_FORMAT_S16LE
 	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_FLOAT, pcm_convert_s16_to_f },

--- a/src/audio/pcm_converter/pcm_converter_hifi3.c
+++ b/src/audio/pcm_converter/pcm_converter_hifi3.c
@@ -895,17 +895,17 @@ static void pcm_convert_f_to_s32(const struct audio_stream *source,
 
 const struct pcm_func_map pcm_func_map[] = {
 #if CONFIG_FORMAT_S16LE
-	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S16_LE, audio_stream_copy_s16 },
+	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S16_LE, audio_stream_copy },
 #endif /* CONFIG_FORMAT_S16LE */
 #if CONFIG_FORMAT_S24LE
-	{ SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S24_4LE, audio_stream_copy_s32 },
+	{ SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S24_4LE, audio_stream_copy },
 #endif /* CONFIG_FORMAT_S24LE */
 #if CONFIG_FORMAT_S24LE && CONFIG_FORMAT_S16LE
 	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S24_4LE, pcm_convert_s16_to_s24 },
 	{ SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S16_LE, pcm_convert_s24_to_s16 },
 #endif /* CONFIG_FORMAT_S24LE && CONFIG_FORMAT_S16LE */
 #if CONFIG_FORMAT_S32LE
-	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, audio_stream_copy_s32 },
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, audio_stream_copy },
 #endif /* CONFIG_FORMAT_S32LE */
 #if CONFIG_FORMAT_S32LE && CONFIG_FORMAT_S16LE
 	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S32_LE, pcm_convert_s16_to_s32 },
@@ -917,7 +917,7 @@ const struct pcm_func_map pcm_func_map[] = {
 #endif /* CONFIG_FORMAT_S32LE && CONFIG_FORMAT_S24LE */
 #if XCHAL_HAVE_FP
 #if CONFIG_FORMAT_FLOAT
-	{ SOF_IPC_FRAME_FLOAT, SOF_IPC_FRAME_FLOAT, audio_stream_copy_s32 },
+	{ SOF_IPC_FRAME_FLOAT, SOF_IPC_FRAME_FLOAT, audio_stream_copy },
 #endif /* CONFIG_FORMAT_FLOAT */
 #if CONFIG_FORMAT_FLOAT && CONFIG_FORMAT_S16LE
 	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_FLOAT, pcm_convert_s16_to_f },

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -435,23 +435,14 @@ static void src_copy_sxx(struct comp_dev *dev,
 	int frames = cd->param.blk_in;
 
 	switch (sink->frame_fmt) {
-#if CONFIG_FORMAT_S16LE
 	case SOF_IPC_FRAME_S16_LE:
-		audio_stream_copy_s16(source, 0, sink, 0,
-				      frames * source->channels);
-		*n_read = frames;
-		*n_written = frames;
-		break;
-#endif
-#if CONFIG_FORMAT_S24LE || CONFIG_FORMAT_S32LE
 	case SOF_IPC_FRAME_S24_4LE:
 	case SOF_IPC_FRAME_S32_LE:
-		audio_stream_copy_s32(source, 0, sink, 0,
-				      frames * source->channels);
+		audio_stream_copy(source, 0, sink, 0,
+				  frames * source->channels);
 		*n_read = frames;
 		*n_written = frames;
 		break;
-#endif
 	default:
 		*n_read = 0;
 		*n_written = 0;

--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -584,46 +584,6 @@ static inline void audio_stream_copy(const struct audio_stream *source,
 	}
 }
 
-#if CONFIG_FORMAT_S16LE
-
-/**
- * Copies signed 16-bit samples from source buffer to sink buffer.
- * @param source Source buffer.
- * @param ioffset Offset (in samples) in source buffer to start reading from.
- * @param sink Sink buffer.
- * @param ooffset Offset (in samples) in sink buffer to start writing to.
- * @param samples Number of samples to copy.
- */
-static inline void audio_stream_copy_s16(const struct audio_stream *source,
-					 uint32_t ioffset,
-					 struct audio_stream *sink,
-					 uint32_t ooffset, uint32_t samples)
-{
-	audio_stream_copy(source, ioffset, sink, ooffset, samples);
-}
-
-#endif /* CONFIG_FORMAT_S16LE */
-
-#if CONFIG_FORMAT_S24LE || CONFIG_FORMAT_S32LE || CONFIG_FORMAT_FLOAT
-
-/**
- * Copies signed 32-bit samples from source buffer to sink buffer.
- * @param source Source buffer.
- * @param ioffset Offset (in samples) in source buffer to start reading from.
- * @param sink Sink buffer.
- * @param ooffset Offset (in samples) in sink buffer to start writing to.
- * @param samples Number of samples to copy.
- */
-static inline void audio_stream_copy_s32(const struct audio_stream *source,
-					 uint32_t ioffset,
-					 struct audio_stream *sink,
-					 uint32_t ooffset, uint32_t samples)
-{
-	audio_stream_copy(source, ioffset, sink, ooffset, samples);
-}
-
-#endif /* CONFIG_FORMAT_S24LE || CONFIG_FORMAT_S32LE || CONFIG_FORMAT_FLOAT */
-
 /** @}*/
 
 #endif /* __SOF_AUDIO_AUDIO_STREAM_H__ */

--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -546,21 +546,22 @@ audio_stream_frames_without_wrap(const struct audio_stream *source,
 /**
  * Copies data from source buffer to sink buffer.
  * @param source Source buffer.
- * @param ioffset_bytes Offset (in bytes) in source buffer to start reading
- *	from.
+ * @param ioffset Offset (in samples) in source buffer to start reading from.
  * @param sink Sink buffer.
- * @param ooffset_bytes Offset (in bytes) in sink buffer to start writing to.
- * @param bytes Number of bytes to copy.
+ * @param ooffset Offset (in samples) in sink buffer to start writing to.
+ * @param samples Number of samples to copy.
  */
 static inline void audio_stream_copy(const struct audio_stream *source,
-				     uint32_t ioffset_bytes,
+				     uint32_t ioffset,
 				     struct audio_stream *sink,
-				     uint32_t ooffset_bytes, uint32_t bytes)
+				     uint32_t ooffset, uint32_t samples)
 {
+	int ssize = audio_stream_sample_bytes(source); /* src fmt == sink fmt */
 	void *src = audio_stream_wrap(source,
-				      (char *)source->r_ptr + ioffset_bytes);
+				      (char *)source->r_ptr + ioffset * ssize);
 	void *snk = audio_stream_wrap(sink,
-				      (char *)sink->w_ptr + ooffset_bytes);
+				      (char *)sink->w_ptr + ooffset * ssize);
+	uint32_t bytes = samples * ssize;
 	uint32_t bytes_src;
 	uint32_t bytes_snk;
 	uint32_t bytes_copied;
@@ -598,10 +599,7 @@ static inline void audio_stream_copy_s16(const struct audio_stream *source,
 					 struct audio_stream *sink,
 					 uint32_t ooffset, uint32_t samples)
 {
-	const int ssize = sizeof(int16_t);
-
-	audio_stream_copy(source, ioffset * ssize, sink, ooffset * ssize,
-			  samples * ssize);
+	audio_stream_copy(source, ioffset, sink, ooffset, samples);
 }
 
 #endif /* CONFIG_FORMAT_S16LE */
@@ -621,10 +619,7 @@ static inline void audio_stream_copy_s32(const struct audio_stream *source,
 					 struct audio_stream *sink,
 					 uint32_t ooffset, uint32_t samples)
 {
-	const int ssize = sizeof(int32_t);
-
-	audio_stream_copy(source, ioffset * ssize, sink, ooffset * ssize,
-			  samples * ssize);
+	audio_stream_copy(source, ioffset, sink, ooffset, samples);
 }
 
 #endif /* CONFIG_FORMAT_S24LE || CONFIG_FORMAT_S32LE || CONFIG_FORMAT_FLOAT */


### PR DESCRIPTION
    audio_stream: Calculate sample size inside audio_stream_copy function
    
    Sample size is related with frame format, which is saved inside
    audio_stream, so this value can be easily calculated inside
    audio_stream_copy function. This approach allows to delete
    functions like audio_stream_copy_s16/s32 and functions related
    to them, then code will be shorter and cleaner.
    
    Moreover in future, during compressed stream implementation, there
    won't be need to add new copy function implementation for compressed
    streams, it will be sufficient to return 1 in audio_stream_sample_bytes()
    for non-pcm formats, then sample calculation will be equal to number
    of bytes and generic function like copy shoudn't have any trouble to
    handle such a data type.