### PR TITLE
Revert scheduler changes  - restore BYT/CHT functionality

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -127,13 +127,6 @@ config INTERRUPT_LEVEL_5
 
 rsource "src/Kconfig"
 
-config IDC_TASK_BUDGET
-	int "Cycles budget for IDC task"
-	depends on MULTICORE
-	default 8000
-	help
-	  Cycles budget for IDC task per systick (see config SYSTICK).
-
 choice
 	prompt "Optimization"
 	default OPTIMIZE_FOR_PERFORMANCE

--- a/src/drivers/intel/Kconfig
+++ b/src/drivers/intel/Kconfig
@@ -47,13 +47,6 @@ config INTEL_DMIC
 	  Select this to enable Intel DMIC driver. The DMIC driver provides
 	  as DAI the SoC direct attach digital microphones interface.
 
-config INTEL_CAVS_IPC_TASK_BUDGET
-	int "Intel cycles budget for IPC task"
-	depends on CAVS
-	default 8000
-	help
-	  Cycles budget for IPC task per systick (see config SYSTICK).
-
 if INTEL_DMIC
 
 choice

--- a/src/drivers/intel/cavs/ipc.c
+++ b/src/drivers/intel/cavs/ipc.c
@@ -296,10 +296,8 @@ int platform_ipc_init(struct ipc *ipc)
 	ipc_set_drvdata(ipc, NULL);
 
 	/* schedule */
-	schedule_task_init_edf_with_budget(&ipc->ipc_task,
-					   SOF_UUID(ipc_task_uuid),
-					   &ipc_task_ops, ipc, 0, 0,
-					   CONFIG_INTEL_CAVS_IPC_TASK_BUDGET);
+	schedule_task_init_edf(&ipc->ipc_task, SOF_UUID(ipc_task_uuid),
+			       &ipc_task_ops, ipc, 0, 0);
 
 	/* configure interrupt */
 	irq = interrupt_get_irq(PLATFORM_IPC_INTERRUPT,

--- a/src/idc/idc.c
+++ b/src/idc/idc.c
@@ -325,10 +325,8 @@ int idc_init(void)
 	(*idc)->payload = cache_to_uncache((struct idc_payload *)payload);
 
 	/* process task */
-	schedule_task_init_edf_with_budget(&(*idc)->idc_task,
-					   SOF_UUID(idc_cmd_task_uuid),
-					   &ops, *idc, cpu_get_id(), 0,
-					   CONFIG_IDC_TASK_BUDGET);
+	schedule_task_init_edf(&(*idc)->idc_task, SOF_UUID(idc_cmd_task_uuid),
+			       &ops, *idc, cpu_get_id(), 0);
 
 	return platform_idc_init();
 }

--- a/src/include/sof/schedule/edf_schedule.h
+++ b/src/include/sof/schedule/edf_schedule.h
@@ -12,7 +12,6 @@
 #include <sof/trace/trace.h>
 #include <user/trace.h>
 #include <stdint.h>
-#include <stdbool.h>
 
 #define edf_sch_set_pdata(task, data) \
 	(task->priv_data = data)
@@ -21,10 +20,6 @@
 
 struct edf_task_pdata {
 	void *ctx;
-	uint32_t budget;	/**< cycles per systick */
-	uint64_t last_systick;	/**< last systick in which budget
-				  *  was granted to task
-				  */
 };
 
 int scheduler_init_edf(void);
@@ -32,10 +27,5 @@ int scheduler_init_edf(void);
 int schedule_task_init_edf(struct task *task, uint32_t uid,
 			   const struct task_ops *ops,
 			   void *data, uint16_t core, uint32_t flags);
-
-int schedule_task_init_edf_with_budget(struct task *task, uint32_t uid,
-				       const struct task_ops *ops,
-				       void *data, uint16_t core,
-				       uint32_t flags, uint32_t cycles_budget);
 
 #endif /* __SOF_SCHEDULE_EDF_SCHEDULE_H__ */


### PR DESCRIPTION
Baytrail + Cherrytrail have been plagued by instability issues for several weeks, and the trace is no longer functional.

By bisecting to restore the trace functionality, I came across this report pointing at e003afe582e41c / PR #3057 

````
e003afe582e41c4a8a52b21d45dbc83c166021a5 is the first bad commit
commit e003afe582e41c4a8a52b21d45dbc83c166021a5
Author: Janusz Jankowski <janusz.jankowski@linux.intel.com>
Date:   Fri Jun 5 20:33:47 2020 +0200

    schedule: edf: cycles budget
    
    Add possibility to set budget for EDF tasks.
    It's needed to ensure that some long running task will
    not stall other tasks.
    
    Signed-off-by: Janusz Jankowski <janusz.jankowski@linux.intel.com>

 src/include/sof/schedule/edf_schedule.h | 10 ++++++
 src/schedule/edf_schedule.c             | 56 ++++++++++++++++++++++++++++++++-
 2 files changed, 65 insertions(+), 1 deletion(-)
````

Reverting this series from @jajanusz restores the DMA trace on Baytrail/Cherrytrail, and in addition I cannot reproduce the stability issues with -EIO errors.

I won't pretend I know what these patches do but they certainly have an effect on these devices, so pushing these reverts to test my results with CI.