### PR TITLE
Pcm converter: return error code

### DIFF
--- a/src/audio/pcm_converter/pcm_converter_generic.c
+++ b/src/audio/pcm_converter/pcm_converter_generic.c
@@ -26,9 +26,9 @@
 
 #if CONFIG_FORMAT_S16LE && CONFIG_FORMAT_S24LE
 
-static void pcm_convert_s16_to_s24(const struct audio_stream *source,
-				   uint32_t ioffset, struct audio_stream *sink,
-				   uint32_t ooffset, uint32_t samples)
+static int pcm_convert_s16_to_s24(const struct audio_stream *source,
+				  uint32_t ioffset, struct audio_stream *sink,
+				  uint32_t ooffset, uint32_t samples)
 {
 	uint32_t buff_frag = 0;
 	int16_t *src;
@@ -41,11 +41,13 @@ static void pcm_convert_s16_to_s24(const struct audio_stream *source,
 		*dst = *src << 8;
 		buff_frag++;
 	}
+
+	return samples;
 }
 
-static void pcm_convert_s24_to_s16(const struct audio_stream *source,
-				   uint32_t ioffset, struct audio_stream *sink,
-				   uint32_t ooffset, uint32_t samples)
+static int pcm_convert_s24_to_s16(const struct audio_stream *source,
+				  uint32_t ioffset, struct audio_stream *sink,
+				  uint32_t ooffset, uint32_t samples)
 {
 	uint32_t buff_frag = 0;
 	int32_t *src;
@@ -58,15 +60,17 @@ static void pcm_convert_s24_to_s16(const struct audio_stream *source,
 		*dst = sat_int16(Q_SHIFT_RND(sign_extend_s24(*src), 23, 15));
 		buff_frag++;
 	}
+
+	return samples;
 }
 
 #endif /* CONFIG_FORMAT_S16LE && CONFIG_FORMAT_S24LE */
 
 #if CONFIG_FORMAT_S16LE && CONFIG_FORMAT_S32LE
 
-static void pcm_convert_s16_to_s32(const struct audio_stream *source,
-				   uint32_t ioffset, struct audio_stream *sink,
-				   uint32_t ooffset, uint32_t samples)
+static int pcm_convert_s16_to_s32(const struct audio_stream *source,
+				  uint32_t ioffset, struct audio_stream *sink,
+				  uint32_t ooffset, uint32_t samples)
 {
 	uint32_t buff_frag = 0;
 	int16_t *src;
@@ -79,11 +83,13 @@ static void pcm_convert_s16_to_s32(const struct audio_stream *source,
 		*dst = *src << 16;
 		buff_frag++;
 	}
+
+	return samples;
 }
 
-static void pcm_convert_s32_to_s16(const struct audio_stream *source,
-				   uint32_t ioffset, struct audio_stream *sink,
-				   uint32_t ooffset, uint32_t samples)
+static int pcm_convert_s32_to_s16(const struct audio_stream *source,
+				  uint32_t ioffset, struct audio_stream *sink,
+				  uint32_t ooffset, uint32_t samples)
 {
 	uint32_t buff_frag = 0;
 	int32_t *src;
@@ -96,15 +102,17 @@ static void pcm_convert_s32_to_s16(const struct audio_stream *source,
 		*dst = sat_int16(Q_SHIFT_RND(*src, 31, 15));
 		buff_frag++;
 	}
+
+	return samples;
 }
 
 #endif /* CONFIG_FORMAT_S16LE && CONFIG_FORMAT_S32LE */
 
 #if CONFIG_FORMAT_S24LE && CONFIG_FORMAT_S32LE
 
-static void pcm_convert_s24_to_s32(const struct audio_stream *source,
-				   uint32_t ioffset, struct audio_stream *sink,
-				   uint32_t ooffset, uint32_t samples)
+static int pcm_convert_s24_to_s32(const struct audio_stream *source,
+				  uint32_t ioffset, struct audio_stream *sink,
+				  uint32_t ooffset, uint32_t samples)
 {
 	uint32_t buff_frag = 0;
 	int32_t *src;
@@ -117,11 +125,13 @@ static void pcm_convert_s24_to_s32(const struct audio_stream *source,
 		*dst = *src << 8;
 		buff_frag++;
 	}
+
+	return samples;
 }
 
-static void pcm_convert_s32_to_s24(const struct audio_stream *source,
-				   uint32_t ioffset, struct audio_stream *sink,
-				   uint32_t ooffset, uint32_t samples)
+static int pcm_convert_s32_to_s24(const struct audio_stream *source,
+				  uint32_t ioffset, struct audio_stream *sink,
+				  uint32_t ooffset, uint32_t samples)
 {
 	uint32_t buff_frag = 0;
 	int32_t *src;
@@ -134,6 +144,8 @@ static void pcm_convert_s32_to_s24(const struct audio_stream *source,
 		*dst = sat_int24(Q_SHIFT_RND(*src, 31, 23));
 		buff_frag++;
 	}
+
+	return samples;
 }
 
 #endif /* CONFIG_FORMAT_S24LE && CONFIG_FORMAT_S32LE */
@@ -272,20 +284,20 @@ static void pcm_convert_f_to_s16_lin(const void *psrc, void *pdst,
 		dst[i] = sat_int16(_pcm_convert_f_to_i(src[i], 15));
 }
 
-static void pcm_convert_s16_to_f(const struct audio_stream *source,
-				 uint32_t ioffset, struct audio_stream *sink,
-				 uint32_t ooffset, uint32_t samples)
+static int pcm_convert_s16_to_f(const struct audio_stream *source,
+				uint32_t ioffset, struct audio_stream *sink,
+				uint32_t ooffset, uint32_t samples)
 {
-	pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
-			      pcm_convert_s16_to_f_lin);
+	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
+				     pcm_convert_s16_to_f_lin);
 }
 
-static void pcm_convert_f_to_s16(const struct audio_stream *source,
-				 uint32_t ioffset, struct audio_stream *sink,
-				 uint32_t ooffset, uint32_t samples)
+static int pcm_convert_f_to_s16(const struct audio_stream *source,
+				uint32_t ioffset, struct audio_stream *sink,
+				uint32_t ooffset, uint32_t samples)
 {
-	pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
-			      pcm_convert_f_to_s16_lin);
+	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
+				     pcm_convert_f_to_s16_lin);
 }
 #endif /* CONFIG_FORMAT_FLOAT && CONFIG_FORMAT_S16LE */
 
@@ -316,20 +328,20 @@ static void pcm_convert_f_to_s24_lin(const void *psrc, void *pdst,
 		dst[i] = sat_int24(_pcm_convert_f_to_i(src[i], 23));
 }
 
-static void pcm_convert_s24_to_f(const struct audio_stream *source,
-				 uint32_t ioffset, struct audio_stream *sink,
-				 uint32_t ooffset, uint32_t samples)
+static int pcm_convert_s24_to_f(const struct audio_stream *source,
+				uint32_t ioffset, struct audio_stream *sink,
+				uint32_t ooffset, uint32_t samples)
 {
-	pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
-			      pcm_convert_s24_to_f_lin);
+	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
+				     pcm_convert_s24_to_f_lin);
 }
 
-static void pcm_convert_f_to_s24(const struct audio_stream *source,
-				 uint32_t ioffset, struct audio_stream *sink,
-				 uint32_t ooffset, uint32_t samples)
+static int pcm_convert_f_to_s24(const struct audio_stream *source,
+				uint32_t ioffset, struct audio_stream *sink,
+				uint32_t ooffset, uint32_t samples)
 {
-	pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
-			      pcm_convert_f_to_s24_lin);
+	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
+				     pcm_convert_f_to_s24_lin);
 }
 #endif /* CONFIG_FORMAT_FLOAT && CONFIG_FORMAT_S24LE */
 
@@ -360,20 +372,20 @@ static void pcm_convert_f_to_s32_lin(const void *psrc, void *pdst,
 		dst[i] = _pcm_convert_f_to_i(src[i], 31);
 }
 
-static void pcm_convert_s32_to_f(const struct audio_stream *source,
-				 uint32_t ioffset, struct audio_stream *sink,
-				 uint32_t ooffset, uint32_t samples)
+static int pcm_convert_s32_to_f(const struct audio_stream *source,
+				uint32_t ioffset, struct audio_stream *sink,
+				uint32_t ooffset, uint32_t samples)
 {
-	pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
-			      pcm_convert_s32_to_f_lin);
+	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
+				     pcm_convert_s32_to_f_lin);
 }
 
-static void pcm_convert_f_to_s32(const struct audio_stream *source,
-				 uint32_t ioffset, struct audio_stream *sink,
-				 uint32_t ooffset, uint32_t samples)
+static int pcm_convert_f_to_s32(const struct audio_stream *source,
+				uint32_t ioffset, struct audio_stream *sink,
+				uint32_t ooffset, uint32_t samples)
 {
-	pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
-			      pcm_convert_f_to_s32_lin);
+	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
+				     pcm_convert_f_to_s32_lin);
 }
 #endif /* CONFIG_FORMAT_FLOAT && CONFIG_FORMAT_S32LE */
 

--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -550,8 +550,9 @@ audio_stream_frames_without_wrap(const struct audio_stream *source,
  * @param sink Sink buffer.
  * @param ooffset Offset (in samples) in sink buffer to start writing to.
  * @param samples Number of samples to copy.
+ * @return number of processed samples.
  */
-static inline void audio_stream_copy(const struct audio_stream *source,
+static inline int audio_stream_copy(const struct audio_stream *source,
 				     uint32_t ioffset,
 				     struct audio_stream *sink,
 				     uint32_t ooffset, uint32_t samples)
@@ -582,6 +583,8 @@ static inline void audio_stream_copy(const struct audio_stream *source,
 		src = audio_stream_wrap(source, src);
 		snk = audio_stream_wrap(sink, snk);
 	}
+
+	return samples;
 }
 
 /** @}*/

--- a/src/include/sof/audio/pcm_converter.h
+++ b/src/include/sof/audio/pcm_converter.h
@@ -41,10 +41,11 @@ struct audio_stream;
  * \param sink output buffer, write pointer is not modified
  * \param ooffset offset to first sample in sink stream
  * \param samples number of samples to convert
+ * \return error code or number of processed samples.
  */
-typedef void (*pcm_converter_func)(const struct audio_stream *source,
-				   uint32_t ioffset, struct audio_stream *sink,
-				   uint32_t ooffset, uint32_t samples);
+typedef int (*pcm_converter_func)(const struct audio_stream *source,
+				  uint32_t ioffset, struct audio_stream *sink,
+				  uint32_t ooffset, uint32_t samples);
 
 /**
  * \brief PCM conversion function interface for data in linear buffer
@@ -100,9 +101,10 @@ pcm_get_conversion_function(enum sof_ipc_frame in,
  * \param ooffset offset to first sample in sink stream
  * \param samples number of samples to convert
  * \param converter core conversion function working on linear memory regions
+ * \return error code or number of processed samples
  */
-void pcm_convert_as_linear(const struct audio_stream *source, uint32_t ioffset,
-			   struct audio_stream *sink, uint32_t ooffset,
-			   uint32_t samples, pcm_converter_lin_func converter);
+int pcm_convert_as_linear(const struct audio_stream *source, uint32_t ioffset,
+			  struct audio_stream *sink, uint32_t ooffset,
+			  uint32_t samples, pcm_converter_lin_func converter);
 
 #endif /* __SOF_AUDIO_PCM_CONVERTER_H__ */

--- a/src/include/sof/lib/dma.h
+++ b/src/include/sof/lib/dma.h
@@ -222,9 +222,9 @@ struct dma_info {
 };
 
 struct audio_stream;
-typedef void (*dma_process_func)(const struct audio_stream *source,
-				 uint32_t ioffset, struct audio_stream *sink,
-				 uint32_t ooffset, uint32_t frames);
+typedef int (*dma_process_func)(const struct audio_stream *source,
+				uint32_t ioffset, struct audio_stream *sink,
+				uint32_t ooffset, uint32_t frames);
 
 /**
  * \brief API to initialize a platform DMA controllers.

--- a/src/include/sof/lib/dma.h
+++ b/src/include/sof/lib/dma.h
@@ -607,12 +607,12 @@ typedef void (*dma_process)(const struct audio_stream *,
 			    struct audio_stream *, uint32_t);
 
 /* copies data from DMA buffer using provided processing function */
-void dma_buffer_copy_from(struct comp_buffer *source, struct comp_buffer *sink,
-			  dma_process_func process, uint32_t source_bytes);
+int dma_buffer_copy_from(struct comp_buffer *source, struct comp_buffer *sink,
+			 dma_process_func process, uint32_t source_bytes);
 
 /* copies data to DMA buffer using provided processing function */
-void dma_buffer_copy_to(struct comp_buffer *source, struct comp_buffer *sink,
-			dma_process_func process, uint32_t sink_bytes);
+int dma_buffer_copy_to(struct comp_buffer *source, struct comp_buffer *sink,
+		       dma_process_func process, uint32_t sink_bytes);
 
 /* generic DMA DSP <-> Host copier */
 


### PR DESCRIPTION
Assertion may be replaced with error code return, then error won't be so fatal and error log may be traced in client component context.