### PR TITLE
cAVS: pm_runtime: change to use bool flag to denote the DSP target state

### DIFF
--- a/src/platform/intel/cavs/include/cavs/lib/pm_runtime.h
+++ b/src/platform/intel/cavs/include/cavs/lib/pm_runtime.h
@@ -20,7 +20,7 @@ struct pm_runtime_data;
 
 /** \brief cAVS specific runtime power management data. */
 struct cavs_pm_runtime_data {
-	int dsp_d0_sref; /**< simple ref counter, accessed by core 0 only */
+	bool dsp_d0; /**< dsp target D0(true) or D0ix(false) */
 	int host_dma_l1_sref; /**< ref counter for Host DMA accesses */
 	uint32_t sleep_core_mask; /**< represents cores in waiti state */
 };

--- a/src/platform/intel/cavs/lib/pm_runtime.c
+++ b/src/platform/intel/cavs/lib/pm_runtime.c
@@ -97,14 +97,14 @@ static inline void cavs_pm_runtime_enable_dsp(bool enable)
 	 */
 	irq_local_disable(flags);
 
-	enable ? --pprd->dsp_d0_sref : ++pprd->dsp_d0_sref;
+	pprd->dsp_d0 = !enable;
 
 	platform_shared_commit(prd, sizeof(*prd));
 
 	irq_local_enable(flags);
 
 	tr_info(&power_tr, "pm_runtime_enable_dsp dsp_d0_sref %d",
-		pprd->dsp_d0_sref);
+		pprd->dsp_d0);
 
 	platform_shared_commit(pprd, sizeof(*pprd));
 
@@ -114,7 +114,7 @@ static inline void cavs_pm_runtime_enable_dsp(bool enable)
 	if (!clk_info)
 		return;
 
-	if (pprd->dsp_d0_sref > 0) {
+	if (pprd->dsp_d0) {
 		if (clk_info->current_freq_idx == CPU_LPRO_FREQ_IDX)
 			report_dsp_r_state(r1_r_state);
 		else
@@ -129,12 +129,11 @@ static inline bool cavs_pm_runtime_is_active_dsp(void)
 {
 	struct pm_runtime_data *prd = pm_runtime_data_get();
 	struct cavs_pm_runtime_data *pprd = prd->platform_data;
-	int is_active = pprd->dsp_d0_sref > 0;
 
 	platform_shared_commit(prd, sizeof(*prd));
 	platform_shared_commit(pprd, sizeof(*pprd));
 
-	return is_active;
+	return pprd->dsp_d0;
 }
 
 #if CONFIG_INTEL_SSP


### PR DESCRIPTION
Remove the usage of refcount dsp_d0_sref, and use bool flag dsp_d0 to
denote is the DSP target state is D0 or D0ix (Low power mode).

This will simplify the logic of use of LPS and clock switching.

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>