### PR TITLE
KConfig changes for i.MX platforms

### DIFF
--- a/src/drivers/Kconfig
+++ b/src/drivers/Kconfig
@@ -6,6 +6,8 @@ rsource "intel/Kconfig"
 
 rsource "dw/Kconfig"
 
+rsource "imx/Kconfig"
+
 config DUMMY_DMA
 	bool "Dummy DMA (software DMA driver)"
 	default n
@@ -18,13 +20,6 @@ config DUMMY_DMA
 
 	  If unsure, select "n".
 
-config IMX_EDMA
-	bool "i.MX EDMA driver"
-	default n
-	depends on IMX
-	help
-	  Select this to enable support for i.MX EDMA DMA controller.
-
 config IPC_POLLING
 	bool "Enable IPC Polling support"
 	default n
@@ -32,28 +27,6 @@ config IPC_POLLING
 	  Select this to enable support for simple IPC polling. This allows
 	  users like GDB and boot loader a simple IPC mechanism that does not
 	  depend on IRQ or a scheduler.
-
-	  If unsure, select "n".
-
-config IMX_IRQSTEER
-	bool "Enable i.MX IRQ_STEER driver support"
-	default n
-	depends on IMX8 || IMX8X || IMX8M
-	help
-	  Select this to enable the i.MX IRQ_STEER controller. Note that this
-	  should automatically be selected if you have picked one of the
-	  platforms that has this controller.
-
-	  If unsure, select "n".
-
-config IMX_SDMA
-	bool "Enable i.MX SDMA controller support"
-	default n
-	depends on IMX8M
-	help
-	  Select this if the platform has a SDMA (Smart DMA) controller for
-	  i.MX. Note that this should automatically be selected if you have
-	  picked one of the platforms that has this controller.
 
 	  If unsure, select "n".
 

--- a/src/drivers/Kconfig
+++ b/src/drivers/Kconfig
@@ -35,4 +35,15 @@ config IPC_POLLING
 
 	  If unsure, select "n".
 
+config IMX_IRQSTEER
+	bool "Enable i.MX IRQ_STEER driver support"
+	default n
+	depends on IMX8 || IMX8X || IMX8M
+	help
+	  Select this to enable the i.MX IRQ_STEER controller. Note that this
+	  should automatically be selected if you have picked one of the
+	  platforms that has this controller.
+
+	  If unsure, select "n".
+
 endmenu # "Drivers"

--- a/src/drivers/Kconfig
+++ b/src/drivers/Kconfig
@@ -46,4 +46,15 @@ config IMX_IRQSTEER
 
 	  If unsure, select "n".
 
+config IMX_SDMA
+	bool "Enable i.MX SDMA controller support"
+	default n
+	depends on IMX8M
+	help
+	  Select this if the platform has a SDMA (Smart DMA) controller for
+	  i.MX. Note that this should automatically be selected if you have
+	  picked one of the platforms that has this controller.
+
+	  If unsure, select "n".
+
 endmenu # "Drivers"

--- a/src/drivers/imx/CMakeLists.txt
+++ b/src/drivers/imx/CMakeLists.txt
@@ -5,7 +5,6 @@ add_local_sources(sof
 	sai.c
 	ipc.c
 	timer.c
-	sdma.c
 )
 
 if(CONFIG_IMX_IRQSTEER)
@@ -14,4 +13,8 @@ endif()
 
 if(CONFIG_IMX_EDMA)
 	add_local_sources(sof edma.c)
+endif()
+
+if(CONFIG_IMX_SDMA)
+	add_local_sources(sof sdma.c)
 endif()

--- a/src/drivers/imx/CMakeLists.txt
+++ b/src/drivers/imx/CMakeLists.txt
@@ -3,11 +3,14 @@
 add_local_sources(sof
 	esai.c
 	sai.c
-	interrupt.c
 	ipc.c
 	timer.c
 	sdma.c
 )
+
+if(CONFIG_IMX_IRQSTEER)
+	add_local_sources(sof interrupt.c)
+endif()
 
 if(CONFIG_IMX_EDMA)
 	add_local_sources(sof edma.c)

--- a/src/drivers/imx/Kconfig
+++ b/src/drivers/imx/Kconfig
@@ -1,0 +1,32 @@
+if IMX
+
+config IMX_EDMA
+	bool "i.MX EDMA driver"
+	default n
+	depends on IMX
+	help
+	  Select this to enable support for i.MX EDMA DMA controller.
+
+config IMX_IRQSTEER
+	bool "Enable i.MX IRQ_STEER driver support"
+	default n
+	depends on IMX8 || IMX8X || IMX8M
+	help
+	  Select this to enable the i.MX IRQ_STEER controller. Note that this
+	  should automatically be selected if you have picked one of the
+	  platforms that has this controller.
+
+	  If unsure, select "n".
+
+config IMX_SDMA
+	bool "Enable i.MX SDMA controller support"
+	default n
+	depends on IMX8M
+	help
+	  Select this if the platform has a SDMA (Smart DMA) controller for
+	  i.MX. Note that this should automatically be selected if you have
+	  picked one of the platforms that has this controller.
+
+	  If unsure, select "n".
+
+endif # IMX

--- a/src/platform/Kconfig
+++ b/src/platform/Kconfig
@@ -173,6 +173,7 @@ config IMX8
 	select WAITI_DELAY
 	select IMX
 	select IMX_EDMA
+	select IMX_IRQSTEER
 	help
 	  Select if your target platform is imx8-compatible
 
@@ -187,6 +188,7 @@ config IMX8X
 	select WAITI_DELAY
 	select IMX
 	select IMX_EDMA
+	select IMX_IRQSTEER
 	help
 	  Select if your target platform is imx8x-compatible
 
@@ -200,6 +202,7 @@ config IMX8M
 	select DUMMY_DMA
 	select WAITI_DELAY
 	select IMX
+	select IMX_IRQSTEER
 	help
 	  Select if your target platform is imx8m-compatible
 

--- a/src/platform/Kconfig
+++ b/src/platform/Kconfig
@@ -203,6 +203,7 @@ config IMX8M
 	select WAITI_DELAY
 	select IMX
 	select IMX_IRQSTEER
+	select IMX_SDMA
 	help
 	  Select if your target platform is imx8m-compatible
 


### PR DESCRIPTION
First commit adds a KConfig for the i.MX IRQ_STEER interrupt controller, as the i.MX8ULP platform doesn't have any.

Second commit adds a KConfig for the SDMA DMA controller, as iMX8/iMX8X platforms don't have it at all.

These two commits help limit the size of the firmware by removing what is essentially dead code from the builds.