### PR TITLE
topology: bytcht: reduce deep-buffer to 5ms

### DIFF
--- a/tools/topology/sof-byt-codec.m4
+++ b/tools/topology/sof-byt-codec.m4
@@ -62,7 +62,7 @@ PIPELINE_PCM_ADD(sof/pipe-host-volume-playback.m4,
 # this is connected to pipeline DAI 1
 PIPELINE_PCM_ADD(sof/pipe-host-volume-playback.m4,
 	4, 1, 2, s32le,
-	10000, 0, 0,
+	5000, 0, 0,
 	48000, 48000, 48000,
 	SCHEDULE_TIME_DOMAIN_DMA,
 	PIPELINE_PLAYBACK_SCHED_COMP_1)

--- a/tools/topology/sof-cht-nocodec.m4
+++ b/tools/topology/sof-cht-nocodec.m4
@@ -62,7 +62,7 @@ PIPELINE_PCM_ADD(sof/pipe-host-volume-playback.m4,
 # this is connected to pipeline DAI 1
 PIPELINE_PCM_ADD(sof/pipe-host-volume-playback.m4,
 	4, 1, 2, s32le,
-	10000, 0, 0,
+	5000, 0, 0,
 	48000, 48000, 48000,
 	SCHEDULE_TIME_DOMAIN_DMA,
 	PIPELINE_PLAYBACK_SCHED_COMP_1)


### PR DESCRIPTION
Somehow a 10ms buffer for the deep-buffer pipe generates write errors
on the kernel side with S24 and S32_LE.

Reducing the memory footprint seems to fix the problem.

This may hide a more fundamental problem with either scheduling or
memory allocation, but for now let's solve CI and daily tests.

BugLink: https://github.com/thesofproject/sof/issues/3171
Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>