### PR TITLE
Remove references to .free and .avail members of audio_stream.

### DIFF
--- a/src/audio/buffer.c
+++ b/src/audio/buffer.c
@@ -185,7 +185,8 @@ void comp_update_buffer_produce(struct comp_buffer *buffer, uint32_t bytes)
 	addr = buffer->stream.addr;
 
 	buf_dbg(buffer, "comp_update_buffer_produce(), ((buffer->avail << 16) | buffer->free) = %08x, ((buffer->id << 16) | buffer->size) = %08x",
-		(buffer->stream.avail << 16) | buffer->stream.free,
+		(audio_stream_get_avail_bytes(&buffer->stream) << 16) |
+		 audio_stream_get_free_bytes(&buffer->stream),
 		(buffer->id << 16) | buffer->stream.size);
 	buf_dbg(buffer, "comp_update_buffer_produce(), ((buffer->r_ptr - buffer->addr) << 16 | (buffer->w_ptr - buffer->addr)) = %08x",
 		((char *)buffer->stream.r_ptr - addr) << 16 |
@@ -224,7 +225,8 @@ void comp_update_buffer_consume(struct comp_buffer *buffer, uint32_t bytes)
 	addr = buffer->stream.addr;
 
 	buf_dbg(buffer, "comp_update_buffer_consume(), (buffer->avail << 16) | buffer->free = %08x, (buffer->id << 16) | buffer->size = %08x, (buffer->r_ptr - buffer->addr) << 16 | (buffer->w_ptr - buffer->addr)) = %08x",
-		(buffer->stream.avail << 16) | buffer->stream.free,
+		(audio_stream_get_avail_bytes(&buffer->stream) << 16) |
+		 audio_stream_get_free_bytes(&buffer->stream),
 		(buffer->id << 16) | buffer->stream.size,
 		((char *)buffer->stream.r_ptr - addr) << 16 |
 		((char *)buffer->stream.w_ptr - addr));

--- a/src/audio/detect_test.c
+++ b/src/audio/detect_test.c
@@ -594,16 +594,15 @@ static int test_keyword_copy(struct comp_dev *dev)
 				 struct comp_buffer, sink_list);
 
 	buffer_lock(source, &flags);
-	frames = source->stream.avail /
-		audio_stream_frame_bytes(&source->stream);
+	frames = audio_stream_get_avail_frames(&source->stream);
 	buffer_unlock(source, flags);
 
 	/* copy and perform detection */
-	buffer_invalidate(source, source->stream.avail);
+	buffer_invalidate(source, audio_stream_get_avail_bytes(&source->stream));
 	cd->detect_func(dev, &source->stream, frames);
 
 	/* calc new available */
-	comp_update_buffer_consume(source, source->stream.avail);
+	comp_update_buffer_consume(source, audio_stream_get_avail_bytes(&source->stream));
 
 	return 0;
 }

--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -246,9 +246,9 @@ static uint32_t host_get_copy_bytes_one_shot(struct comp_dev *dev)
 
 	/* calculate minimum size to copy */
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK)
-		copy_bytes = hd->local_buffer->stream.free;
+		copy_bytes = audio_stream_get_free_bytes(&hd->local_buffer->stream);
 	else
-		copy_bytes = hd->local_buffer->stream.avail;
+		copy_bytes = audio_stream_get_avail_bytes(&hd->local_buffer->stream);
 
 	buffer_unlock(hd->local_buffer, flags);
 
@@ -340,10 +340,10 @@ static uint32_t host_get_copy_bytes_normal(struct comp_dev *dev)
 		 */
 		copy_bytes = MIN(hd->period_bytes,
 				 MIN(avail_bytes,
-				     hd->local_buffer->stream.free));
+				     audio_stream_get_free_bytes(&hd->local_buffer->stream)));
 	else
-		copy_bytes = MIN(hd->local_buffer->stream.avail,
-				 free_bytes);
+		copy_bytes = MIN(
+			audio_stream_get_avail_bytes(&hd->local_buffer->stream), free_bytes);
 
 	buffer_unlock(hd->local_buffer, flags);
 

--- a/src/audio/smart_amp_test.c
+++ b/src/audio/smart_amp_test.c
@@ -440,8 +440,7 @@ static int smart_amp_copy(struct comp_dev *dev)
 	comp_invalidate(sad->feedback_buf->source);
 	if (sad->feedback_buf->source->state == dev->state) {
 		/* feedback */
-		avail_feedback_frames = sad->feedback_buf->stream.avail /
-			audio_stream_frame_bytes(&sad->feedback_buf->stream);
+		avail_feedback_frames = audio_stream_get_avail_frames(&sad->feedback_buf->stream);
 
 		avail_frames = MIN(avail_passthrough_frames,
 				   avail_feedback_frames);

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -325,8 +325,8 @@ static void src_2s(struct comp_dev *dev, const struct audio_stream *source,
 	size_t sbuf_size = cd->param.sbuf_length * sizeof(int32_t);
 	int nch = source->channels;
 	int sbuf_free = cd->param.sbuf_length - cd->sbuf_avail;
-	int avail_b = source->avail;
-	int free_b = sink->free;
+	int avail_b = audio_stream_get_avail_bytes(source);
+	int free_b = audio_stream_get_free_bytes(sink);
 	int sz = cd->sample_container_bytes;
 
 	*n_read = 0;

--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -393,7 +393,7 @@ static inline void audio_stream_produce(struct audio_stream *buffer,
 					  (char *)buffer->w_ptr + bytes);
 
 	/* "overwrite" old data in circular wrap case */
-	if (bytes > buffer->free)
+	if (bytes > audio_stream_get_free_bytes(buffer))
 		buffer->r_ptr = buffer->w_ptr;
 
 	/* calculate available bytes */

--- a/test/cmocka/src/audio/buffer/buffer_copy.c
+++ b/test/cmocka/src/audio/buffer/buffer_copy.c
@@ -36,7 +36,7 @@ static void test_audio_buffer_copy_underrun(void **state)
 	copy_bytes =
 		audio_stream_can_copy_bytes(&src->stream, &snk->stream, 16);
 
-	assert_int_equal(src->stream.avail, 10);
+	assert_int_equal(audio_stream_get_avail_bytes(&src->stream), 10);
 	assert_int_equal(copy_bytes, -1);
 
 	buffer_free(src);
@@ -64,8 +64,8 @@ static void test_audio_buffer_copy_overrun(void **state)
 	copy_bytes =
 		audio_stream_can_copy_bytes(&src->stream, &snk->stream, 16);
 
-	assert_int_equal(src->stream.avail, 16);
-	assert_int_equal(snk->stream.free, 10);
+	assert_int_equal(audio_stream_get_avail_bytes(&src->stream), 16);
+	assert_int_equal(audio_stream_get_free_bytes(&snk->stream), 10);
 	assert_int_equal(copy_bytes, 1);
 
 	buffer_free(src);
@@ -91,7 +91,7 @@ static void test_audio_buffer_copy_success(void **state)
 	comp_update_buffer_produce(src, 10);
 	copy_bytes = audio_stream_can_copy_bytes(&src->stream, &snk->stream, 0);
 
-	assert_int_equal(src->stream.avail, 10);
+	assert_int_equal(audio_stream_get_avail_bytes(&src->stream), 10);
 	assert_int_equal(copy_bytes, 0);
 
 	buffer_free(src);
@@ -118,8 +118,8 @@ static void test_audio_buffer_copy_fit_space_constraint(void **state)
 	comp_update_buffer_produce(snk, 246);
 	copy_bytes = audio_stream_get_copy_bytes(&src->stream, &snk->stream);
 
-	assert_int_equal(src->stream.avail, 16);
-	assert_int_equal(snk->stream.free, 10);
+	assert_int_equal(audio_stream_get_avail_bytes(&src->stream), 16);
+	assert_int_equal(audio_stream_get_free_bytes(&snk->stream), 10);
 	assert_int_equal(copy_bytes, 10);
 
 	buffer_free(src);
@@ -145,7 +145,7 @@ static void test_audio_buffer_copy_fit_no_space_constraint(void **state)
 	comp_update_buffer_produce(src, 16);
 	copy_bytes = audio_stream_get_copy_bytes(&src->stream, &snk->stream);
 
-	assert_int_equal(src->stream.avail, 16);
+	assert_int_equal(audio_stream_get_avail_bytes(&src->stream), 16);
 	assert_int_equal(copy_bytes, 16);
 
 	buffer_free(src);

--- a/test/cmocka/src/audio/buffer/buffer_new.c
+++ b/test/cmocka/src/audio/buffer/buffer_new.c
@@ -27,8 +27,8 @@ static void test_audio_buffer_new(void **state)
 	struct comp_buffer *buf = buffer_new(&test_buf_desc);
 
 	assert_non_null(buf);
-	assert_int_equal(buf->stream.avail, 0);
-	assert_int_equal(buf->stream.free, 256);
+	assert_int_equal(audio_stream_get_avail_bytes(&buf->stream), 0);
+	assert_int_equal(audio_stream_get_free_bytes(&buf->stream), 256);
 	assert_ptr_equal(buf->stream.w_ptr, buf->stream.r_ptr);
 
 	buffer_free(buf);

--- a/test/cmocka/src/audio/buffer/buffer_wrap.c
+++ b/test/cmocka/src/audio/buffer/buffer_wrap.c
@@ -27,8 +27,8 @@ static void test_audio_buffer_write_fill_10_bytes_and_write_5(void **state)
 	struct comp_buffer *buf = buffer_new(&test_buf_desc);
 
 	assert_non_null(buf);
-	assert_int_equal(buf->stream.avail, 0);
-	assert_int_equal(buf->stream.free, 10);
+	assert_int_equal(audio_stream_get_avail_bytes(&buf->stream), 0);
+	assert_int_equal(audio_stream_get_free_bytes(&buf->stream), 10);
 	assert_ptr_equal(buf->stream.w_ptr, buf->stream.r_ptr);
 
 	uint8_t bytes[10] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
@@ -36,8 +36,8 @@ static void test_audio_buffer_write_fill_10_bytes_and_write_5(void **state)
 	memcpy_s(buf->stream.w_ptr, test_buf_desc.size, &bytes, 10);
 	comp_update_buffer_produce(buf, 10);
 
-	assert_int_equal(buf->stream.avail, 10);
-	assert_int_equal(buf->stream.free, 0);
+	assert_int_equal(audio_stream_get_avail_bytes(&buf->stream), 10);
+	assert_int_equal(audio_stream_get_free_bytes(&buf->stream), 0);
 	assert_ptr_equal(buf->stream.w_ptr, buf->stream.r_ptr);
 
 	uint8_t more_bytes[5] = {10, 11, 12, 13, 14};
@@ -48,8 +48,8 @@ static void test_audio_buffer_write_fill_10_bytes_and_write_5(void **state)
 	uint8_t ref_1[5] = {5, 6, 7, 8, 9};
 	uint8_t ref_2[5] = {10, 11, 12, 13, 14};
 
-	assert_int_equal(buf->stream.avail, 10);
-	assert_int_equal(buf->stream.free, 0);
+	assert_int_equal(audio_stream_get_avail_bytes(&buf->stream), 10);
+	assert_int_equal(audio_stream_get_free_bytes(&buf->stream), 0);
 	assert_ptr_equal(buf->stream.w_ptr, buf->stream.r_ptr);
 	assert_int_equal(memcmp(buf->stream.r_ptr, &ref_1, 5), 0);
 	comp_update_buffer_consume(buf, 5);

--- a/test/cmocka/src/audio/buffer/buffer_write.c
+++ b/test/cmocka/src/audio/buffer/buffer_write.c
@@ -28,8 +28,8 @@ static void test_audio_buffer_write_10_bytes_out_of_256_and_read_back
 	struct comp_buffer *buf = buffer_new(&test_buf_desc);
 
 	assert_non_null(buf);
-	assert_int_equal(buf->stream.avail, 0);
-	assert_int_equal(buf->stream.free, 256);
+	assert_int_equal(audio_stream_get_avail_bytes(&buf->stream), 0);
+	assert_int_equal(audio_stream_get_free_bytes(&buf->stream), 256);
 	assert_ptr_equal(buf->stream.w_ptr, buf->stream.r_ptr);
 
 	uint8_t bytes[10] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
@@ -37,16 +37,16 @@ static void test_audio_buffer_write_10_bytes_out_of_256_and_read_back
 	memcpy_s(buf->stream.w_ptr, test_buf_desc.size, &bytes, 10);
 	comp_update_buffer_produce(buf, 10);
 
-	assert_int_equal(buf->stream.avail, 10);
-	assert_int_equal(buf->stream.free, 246);
+	assert_int_equal(audio_stream_get_avail_bytes(&buf->stream), 10);
+	assert_int_equal(audio_stream_get_free_bytes(&buf->stream), 246);
 	assert_ptr_equal(buf->stream.w_ptr, (char *)buf->stream.r_ptr + 10);
 
 	assert_int_equal(memcmp(buf->stream.r_ptr, &bytes, 10), 0);
 
 	comp_update_buffer_consume(buf, 10);
 
-	assert_int_equal(buf->stream.avail, 0);
-	assert_int_equal(buf->stream.free, 256);
+	assert_int_equal(audio_stream_get_avail_bytes(&buf->stream), 0);
+	assert_int_equal(audio_stream_get_free_bytes(&buf->stream), 256);
 	assert_ptr_equal(buf->stream.w_ptr, buf->stream.r_ptr);
 
 	buffer_free(buf);
@@ -63,8 +63,8 @@ static void test_audio_buffer_fill_10_bytes(void **state)
 	struct comp_buffer *buf = buffer_new(&test_buf_desc);
 
 	assert_non_null(buf);
-	assert_int_equal(buf->stream.avail, 0);
-	assert_int_equal(buf->stream.free, 10);
+	assert_int_equal(audio_stream_get_avail_bytes(&buf->stream), 0);
+	assert_int_equal(audio_stream_get_free_bytes(&buf->stream), 10);
 	assert_ptr_equal(buf->stream.w_ptr, buf->stream.r_ptr);
 
 	uint8_t bytes[10] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
@@ -72,8 +72,8 @@ static void test_audio_buffer_fill_10_bytes(void **state)
 	memcpy_s(buf->stream.w_ptr, test_buf_desc.size, &bytes, 10);
 	comp_update_buffer_produce(buf, 10);
 
-	assert_int_equal(buf->stream.avail, 10);
-	assert_int_equal(buf->stream.free, 0);
+	assert_int_equal(audio_stream_get_avail_bytes(&buf->stream), 10);
+	assert_int_equal(audio_stream_get_free_bytes(&buf->stream), 0);
 	assert_ptr_equal(buf->stream.w_ptr, buf->stream.r_ptr);
 
 	buffer_free(buf);

--- a/test/cmocka/src/audio/mixer/mixer_test.c
+++ b/test/cmocka/src/audio/mixer/mixer_test.c
@@ -271,8 +271,8 @@ static void test_audio_mixer_copy(void **state)
 			samples[smp] = ((sin(rad) + 1) / 2) * (0xFFFFFFFF / 2);
 		}
 
-		tc->sources[src_idx].buf->stream.avail =
-			tc->sources[src_idx].buf->stream.size;
+		audio_stream_produce(&tc->sources[src_idx].buf->stream,
+				     sizeof(uint32_t) * MIX_TEST_SAMPLES);
 	}
 
 	mixer_drv_mock.ops.copy(mixer_dev_mock);

--- a/test/cmocka/src/audio/mux/CMakeLists.txt
+++ b/test/cmocka/src/audio/mux/CMakeLists.txt
@@ -12,6 +12,8 @@ add_library(
 	${PROJECT_SOURCE_DIR}/src/audio/mux/mux.c
 	${PROJECT_SOURCE_DIR}/src/audio/mux/mux_generic.c
 	${PROJECT_SOURCE_DIR}/src/audio/component.c
+	${PROJECT_SOURCE_DIR}/src/audio/buffer.c
+	${PROJECT_SOURCE_DIR}/test/cmocka/src/notifier_mocks.c
 )
 sof_append_relative_path_definitions(audio_mux)
 

--- a/test/cmocka/src/audio/mux/mock.c
+++ b/test/cmocka/src/audio/mux/mock.c
@@ -16,17 +16,7 @@
 
 static struct sof sof;
 
-struct tr_ctx buffer_tr;
-
 void pipeline_xrun(struct pipeline *p, struct comp_dev *dev, int32_t bytes)
-{
-}
-
-void comp_update_buffer_produce(struct comp_buffer *buffer, uint32_t bytes)
-{
-}
-
-void comp_update_buffer_consume(struct comp_buffer *buffer, uint32_t bytes)
 {
 }
 

--- a/test/cmocka/src/audio/mux/mux_get_processing_function.c
+++ b/test/cmocka/src/audio/mux/mux_get_processing_function.c
@@ -54,7 +54,7 @@ static int setup_test_case(void **state)
 
 	td->cd = (struct comp_data *)td->dev->priv_data;
 
-	td->sink = create_test_sink(td->dev, 0, 0, 0);
+	td->sink = create_test_sink(td->dev, 0, 0, 0, 4);
 
 	*state = td;
 
@@ -65,8 +65,8 @@ static int teardown_test_case(void **state)
 {
 	struct test_data *td = *state;
 
+	free_test_sink(td->sink);
 	comp_free(td->dev);
-	free(td->sink);
 	free(td);
 
 	return 0;

--- a/test/cmocka/src/audio/mux/util.h
+++ b/test/cmocka/src/audio/mux/util.h
@@ -15,9 +15,18 @@
 static inline struct comp_buffer *create_test_sink(struct comp_dev *dev,
 						   uint32_t pipeline_id,
 						   uint32_t frame_fmt,
-						   uint16_t channels)
+						   uint16_t channels,
+						   uint16_t buffer_size)
 {
-	struct comp_buffer *buffer = calloc(1, sizeof(struct comp_buffer));
+	struct sof_ipc_buffer desc = {
+		.comp = {
+			.pipeline_id = pipeline_id,
+		},
+		.size = buffer_size,
+	};
+	struct comp_buffer *buffer = buffer_new(&desc);
+
+	memset(buffer->stream.addr, 0, buffer_size);
 
 	/* set bsink list */
 	list_item_append(&buffer->source_list, &dev->bsink_list);
@@ -27,9 +36,6 @@ static inline struct comp_buffer *create_test_sink(struct comp_dev *dev,
 	buffer->sink->state = COMP_STATE_PREPARE;
 	buffer->stream.frame_fmt = frame_fmt;
 	buffer->stream.channels = channels;
-	buffer->stream.free = 0;
-	buffer->stream.avail = 0;
-	buffer->pipeline_id = pipeline_id;
 
 	return buffer;
 }
@@ -37,15 +43,24 @@ static inline struct comp_buffer *create_test_sink(struct comp_dev *dev,
 static inline void free_test_sink(struct comp_buffer *buffer)
 {
 	free(buffer->sink);
-	free(buffer);
+	buffer_free(buffer);
 }
 
 static inline struct comp_buffer *create_test_source(struct comp_dev *dev,
 						     uint32_t pipeline_id,
 						     uint32_t frame_fmt,
-						     uint16_t channels)
+						     uint16_t channels,
+						     uint16_t buffer_size)
 {
-	struct comp_buffer *buffer = calloc(1, sizeof(struct comp_buffer));
+	struct sof_ipc_buffer desc = {
+		.comp = {
+			.pipeline_id = pipeline_id,
+		},
+		.size = buffer_size,
+	};
+	struct comp_buffer *buffer = buffer_new(&desc);
+
+	memset(buffer->stream.addr, 0, buffer_size);
 
 	/*set bsource list */
 	list_item_append(&buffer->sink_list, &dev->bsource_list);
@@ -55,9 +70,6 @@ static inline struct comp_buffer *create_test_source(struct comp_dev *dev,
 	buffer->source->state = COMP_STATE_PREPARE;
 	buffer->stream.frame_fmt = frame_fmt;
 	buffer->stream.channels = channels;
-	buffer->stream.free = 0;
-	buffer->stream.avail = 0;
-	buffer->pipeline_id = pipeline_id;
 
 	return buffer;
 }
@@ -65,5 +77,5 @@ static inline struct comp_buffer *create_test_source(struct comp_dev *dev,
 static inline void free_test_source(struct comp_buffer *buffer)
 {
 	free(buffer->source);
-	free(buffer);
+	buffer_free(buffer);
 }

--- a/tools/testbench/file.c
+++ b/tools/testbench/file.c
@@ -599,8 +599,7 @@ static int file_copy(struct comp_dev *dev)
 					 source_list);
 
 		/* test sink has enough free frames */
-		snk_frames = buffer->stream.free /
-			     audio_stream_frame_bytes(&buffer->stream);
+		snk_frames = audio_stream_get_free_frames(&buffer->stream);
 		if (snk_frames > 0 && !cd->fs.reached_eof) {
 			/* read PCM samples from file */
 			ret = cd->file_func(dev, &buffer->stream, NULL,
@@ -618,8 +617,7 @@ static int file_copy(struct comp_dev *dev)
 					 struct comp_buffer, sink_list);
 
 		/* test source has enough free frames */
-		src_frames = buffer->stream.avail /
-			     audio_stream_frame_bytes(&buffer->stream);
+		src_frames = audio_stream_get_avail_frames(&buffer->stream);
 		if (src_frames > 0) {
 			/* write PCM samples into file */
 			ret = cd->file_func(dev, NULL, &buffer->stream,


### PR DESCRIPTION
All audio_stream clients should use provided audio_stream_get_avail*/free*
API, instead of directly accessing .avail and .free member fields.

Signed-off-by: Artur Kloniecki <arturx.kloniecki@linux.intel.com>