### PR TITLE
tools: tplg_parser: check if parameter is valid before using it

### DIFF
--- a/tools/tplg_parser/tplg_parser.c
+++ b/tools/tplg_parser/tplg_parser.c
@@ -1114,6 +1114,11 @@ int load_widget(void *dev, int dev_type, struct comp_info *temp_comp_list,
 	size_t size;
 	int ret = 0;
 
+	if (!temp_comp_list) {
+		fprintf(stderr, "load_widget: temp_comp_list argument NULL\n");
+		return -EINVAL;
+	}
+
 	/* allocate memory for widget */
 	size = sizeof(struct snd_soc_tplg_dapm_widget);
 	widget = (struct snd_soc_tplg_dapm_widget *)malloc(size);


### PR DESCRIPTION
Before accessing the contents of the parameter pointer of the
function, check if the pointer is NULL. Else, it may lead to
segmentation fault.

This error was found when fuzzing testbench with AFL fuzzer.

Signed-off-by: Mohana Datta Yelugoti <ymdatta.work@gmail.com>