### PR TITLE
logger: Align g flag description in help message

### DIFF
--- a/tools/logger/logger.c
+++ b/tools/logger/logger.c
@@ -55,7 +55,7 @@ static void usage(void)
 		APP_NAME);
 	fprintf(stdout, "%s:\t -f precision\t\tSet timestamp precision\n",
 		APP_NAME);
-	fprintf(stdout, "%s:\t -g\t\tHide timestamp\n",
+	fprintf(stdout, "%s:\t -g\t\t\tHide timestamp\n",
 		APP_NAME);
 	fprintf(stdout, "%s:\t -d *.ldc_file \t\tDump ldc_file information\n",
 		APP_NAME);


### PR DESCRIPTION
Help message, near -g flags looks like:
```
sof-logger:      -f precision           Set timestamp precision
sof-logger:      -g             Hide timestamp
sof-logger:      -d *.ldc_file          Dump ldc_file information
```
before changes, and after apply this patch, descriptions are aligned.

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>