### PR TITLE
ll: set initial value for num_clients

### DIFF
--- a/src/schedule/ll_schedule.c
+++ b/src/schedule/ll_schedule.c
@@ -155,7 +155,7 @@ static void schedule_ll_clients_reschedule(struct ll_schedule_data *sch)
 static void schedule_ll_tasks_run(void *data)
 {
 	struct ll_schedule_data *sch = data;
-	uint32_t num_clients;
+	uint32_t num_clients = 0;
 	uint64_t last_tick;
 	uint32_t flags;
 


### PR DESCRIPTION
Value for 'num_clients' has to be set, otherwise it may
have undefined value in later ifs.

Issue reported by KW that `if (!num_clients)` may use uninitialized value.

Signed-off-by: Janusz Jankowski <janusz.jankowski@linux.intel.com>