### PR TITLE
topology: change dmic dai name in nocodec topologies

### DIFF
--- a/tools/topology/sof-apl-dmic-a96k-b16k.m4
+++ b/tools/topology/sof-apl-dmic-a96k-b16k.m4
@@ -63,14 +63,14 @@ dnl     deadline, priority, core, time_domain)
 # capture DAI is DMIC 0 using 3 periods
 # Buffers use s32le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
-	6, DMIC, 0, NoCodec-6,
+	6, DMIC, 0, dmic01,
 	PIPELINE_SINK_6, 3, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is DMIC 1 using 3 periods
 # Buffers use s32le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
-	7, DMIC, 1, NoCodec-7,
+	7, DMIC, 1, dmic16k,
 	PIPELINE_SINK_7, 3, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
@@ -85,7 +85,7 @@ PCM_CAPTURE_ADD(DMIC16k, 7, PIPELINE_PCM_7)
 
 dnl DAI_CONFIG(type, dai_index, link_id, name, ssp_config/dmic_config)
 
-DAI_CONFIG(DMIC, 0, 6, NoCodec-6,
+DAI_CONFIG(DMIC, 0, 6, dmic01,
 	   dnl DMIC_CONFIG(driver_version, clk_min, clk_mac, duty_min, duty_max,
 	   dnl		   sample_rate, fifo word length, unmute time, type,
 	   dnl              dai_index, pdm controller config)
@@ -93,7 +93,7 @@ DAI_CONFIG(DMIC, 0, 6, NoCodec-6,
 		DMIC_WORD_LENGTH(s32le), 400, DMIC, 0,
 		PDM_CONFIG(DMIC, 0, STEREO_PDM0)))
 
-DAI_CONFIG(DMIC, 1, 7, NoCodec-7,
+DAI_CONFIG(DMIC, 1, 7, dmic16k,
 	   dnl DMIC_CONFIG(driver_version, clk_min, clk_mac, duty_min, duty_max,
 	   dnl		   sample_rate, fifo word length, unmute time, type,
 	   dnl             dai_index, pdm controller config)

--- a/tools/topology/sof-apl-dmic-asymmetric.m4
+++ b/tools/topology/sof-apl-dmic-asymmetric.m4
@@ -63,14 +63,14 @@ dnl     deadline, priority, core, time_domain)
 # capture DAI is DMIC 0 using 2 periods
 `# Buffers use 'AFORMAT `format, 1000us deadline on core 0 with priority 0'
 DAI_ADD(sof/pipe-dai-capture.m4,
-	6, DMIC, 0, NoCodec-6,
+	6, DMIC, 0, dmic01,
 	PIPELINE_SINK_6, 2, AFORMAT,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is DMIC 1 using 2 periods
 `# Buffers use 'BFORMAT `format, 1000us deadline on core 0 with priority 0'
 DAI_ADD(sof/pipe-dai-capture.m4,
-	7, DMIC, 1, NoCodec-7,
+	7, DMIC, 1, dmic16k,
 	PIPELINE_SINK_7, 2, BFORMAT,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
@@ -86,7 +86,7 @@ PCM_CAPTURE_ADD(DMIC16kHz, 7, PIPELINE_PCM_7)
 
 dnl DAI_CONFIG(type, dai_index, link_id, name, ssp_config/dmic_config)
 
-DAI_CONFIG(DMIC, 0, 6, NoCodec-6,
+DAI_CONFIG(DMIC, 0, 6, dmic01,
 	   dnl DMIC_CONFIG(driver_version, clk_min, clk_mac, duty_min, duty_max,
 	   dnl		   sample_rate, fifo word length, unmute time, type,
 	   dnl 		   dai_index, pdm controller config)
@@ -94,7 +94,7 @@ DAI_CONFIG(DMIC, 0, 6, NoCodec-6,
 		DMIC_WORD_LENGTH(AFORMAT), 400, DMIC, 0,
 		PDM_CONFIG(DMIC, 0, APDM)))
 
-DAI_CONFIG(DMIC, 1, 7, NoCodec-7,
+DAI_CONFIG(DMIC, 1, 7, dmic16k,
 	   dnl DMIC_CONFIG(driver_version, clk_min, clk_mac, duty_min, duty_max,
 	   dnl		   sample_rate, fifo word length, unmute time, type,
 	   dnl             dai_index, pdm controller config)

--- a/tools/topology/sof-apl-dmic.m4
+++ b/tools/topology/sof-apl-dmic.m4
@@ -68,14 +68,14 @@ dnl     deadline, priority, core, time_domain)
 # capture DAI is DMIC 0 using 2 periods
 # Buffers use s32le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
-	6, DMIC, 0, NoCodec-6,
+	6, DMIC, 0, dmic01,
 	PIPELINE_SINK_6, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is DMIC 1 using 2 periods
 # Buffers use s16le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
-	7, DMIC, 1, NoCodec-7,
+	7, DMIC, 1, dmic16k,
 	PIPELINE_SINK_7, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
@@ -91,7 +91,7 @@ PCM_CAPTURE_ADD(DMIC16kHz, 7, PIPELINE_PCM_7)
 
 dnl DAI_CONFIG(type, dai_index, link_id, name, ssp_config/dmic_config)
 
-DAI_CONFIG(DMIC, 0, 6, NoCodec-6,
+DAI_CONFIG(DMIC, 0, 6, dmic01,
 	   dnl DMIC_CONFIG(driver_version, clk_min, clk_mac, duty_min, duty_max,
 	   dnl		   sample_rate, fifo word length, unmute time, type,
 	   dnl             dai_index, pdm controller config)
@@ -99,7 +99,7 @@ DAI_CONFIG(DMIC, 0, 6, NoCodec-6,
 		DMIC_WORD_LENGTH(s32le), 400, DMIC, 0,
 		PDM_CONFIG(DMIC, 0, DMIC_PDM_CONFIG)))
 
-DAI_CONFIG(DMIC, 1, 7, NoCodec-7,
+DAI_CONFIG(DMIC, 1, 7, dmic16k,
 	   dnl DMIC_CONFIG(driver_version, clk_min, clk_mac, duty_min, duty_max,
 	   dnl		   sample_rate, fifo word length, unmute time, type,
 	   dnl             dai_index, pdm controller config)

--- a/tools/topology/sof-apl-keyword-detect.m4
+++ b/tools/topology/sof-apl-keyword-detect.m4
@@ -53,7 +53,7 @@ dnl     deadline, priority, core, time_domain)
 # capture DAI is DMIC 0 using 2 periods
 # Buffers use s16le format, with 320 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
-	1, DMIC, 1, NoCodec-6,
+	1, DMIC, 1, dmic01,
 	PIPELINE_SINK_1, 2, s16le,
 	KWD_PIPE_SCH_DEADLINE_US,
 	0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
@@ -87,7 +87,7 @@ SectionGraph."pipe-sof-apl-keyword-detect" {
 #
 
 dnl DAI_CONFIG(type, dai_index, link_id, name, ssp_config/dmic_config)
-DAI_CONFIG(DMIC, 1, 6, NoCodec-6,
+DAI_CONFIG(DMIC, 1, 6, dmic01,
            dnl DMIC_CONFIG(driver_version, clk_min, clk_mac, duty_min, duty_max,
            dnl             sample_rate, fifo word length, unmute time, type,
            dnl             dai_index, pdm controller config)

--- a/tools/topology/sof-apl-nocodec.m4
+++ b/tools/topology/sof-apl-nocodec.m4
@@ -246,7 +246,7 @@ DAI_ADD(sof/pipe-dai-capture.m4,
 # capture DAI is DMIC 0 using 2 periods
 # Buffers use s32le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
-	13, DMIC, 0, NoCodec-6,
+	13, DMIC, 0, dmic01,
 	PIPELINE_SINK_13, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
@@ -309,7 +309,7 @@ DAI_CONFIG(SSP, 5, 5, NoCodec-5,
 		      SSP_TDM(2, 16, 3, 3),
 		      SSP_CONFIG_DATA(SSP, 5, 16, 0, SSP_QUIRK_LBM)))
 
-DAI_CONFIG(DMIC, 0, 6, NoCodec-6,
+DAI_CONFIG(DMIC, 0, 6, dmic01,
 	   dnl DMIC_CONFIG(driver_version, clk_min, clk_mac, duty_min, duty_max,
 	   dnl		   sample_rate, fifo word length, unmute time, type,
 	   dnl		   dai_index, pdm controller config)

--- a/tools/topology/sof-apl-src-dmic.m4
+++ b/tools/topology/sof-apl-src-dmic.m4
@@ -62,14 +62,14 @@ dnl     deadline, priority, core, time_domain)
 # capture DAI is DMIC 0 using 2 periods
 # Buffers use s32le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
-	6, DMIC, 0, NoCodec-6,
+	6, DMIC, 0, dmic01,
 	PIPELINE_SINK_6, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is DMIC 1 using 2 periods
 # Buffers use s32le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
-	7, DMIC, 1, NoCodec-7,
+	7, DMIC, 1, dmic16k,
 	PIPELINE_SINK_7, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
@@ -84,7 +84,7 @@ PCM_CAPTURE_ADD(DMIC16kHz, 7, PIPELINE_PCM_7)
 
 dnl DAI_CONFIG(type, dai_index, link_id, name, ssp_config/dmic_config)
 
-DAI_CONFIG(DMIC, 0, 6, NoCodec-6,
+DAI_CONFIG(DMIC, 0, 6, dmic01,
 	   dnl DMIC_CONFIG(driver_version, clk_min, clk_mac, duty_min, duty_max,
 	   dnl		   sample_rate, fifo word length, unmute time, type,
 	   dnl             dai_index, pdm controller config)
@@ -92,7 +92,7 @@ DAI_CONFIG(DMIC, 0, 6, NoCodec-6,
 		DMIC_WORD_LENGTH(s32le), 400, DMIC, 0,
 		PDM_CONFIG(DMIC, 0, STEREO_PDM0)))
 
-DAI_CONFIG(DMIC, 1, 7, NoCodec-7,
+DAI_CONFIG(DMIC, 1, 7, dmic16k,
 	   dnl DMIC_CONFIG(driver_version, clk_min, clk_mac, duty_min, duty_max,
 	   dnl		   sample_rate, fifo word length, unmute time, type,
 	   dnl             dai_index, pdm controller config)

--- a/tools/topology/sof-tgl-nocodec.m4
+++ b/tools/topology/sof-tgl-nocodec.m4
@@ -139,7 +139,7 @@ DAI_ADD(sof/pipe-dai-capture.m4,
 # capture DAI is DMIC 0 using 2 periods
 # Buffers use s32le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
-	13, DMIC, 0, NoCodec-6,
+	13, DMIC, 0, dmic01,
 	PIPELINE_SINK_13, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
@@ -174,7 +174,7 @@ DAI_CONFIG(SSP, 2, 2, NoCodec-2,
 		      SSP_TDM(2, 25, 3, 3),
 		      SSP_CONFIG_DATA(SSP, 2, 24, 0, SSP_QUIRK_LBM)))
 
-DAI_CONFIG(DMIC, 0, 6, NoCodec-6,
+DAI_CONFIG(DMIC, 0, 6, dmic01,
 	   dnl DMIC_CONFIG(driver_version, clk_min, clk_mac, duty_min, duty_max,
 	   dnl		   sample_rate, fifo word length, unmute time, type,
 	   dnl		   dai_index, pdm controller config)


### PR DESCRIPTION
Change DMIC dai name in nocodec:
NoCodec-6 => dmic01
NoCodec-7 => dmic16k

Signed-off-by: Pan Xiuli <xiuli.pan@linux.intel.com>

Work with https://github.com/thesofproject/linux/pull/2327