### PR TITLE
Audio: ASRC: Fix pull mode copy frames consume limit

### DIFF
--- a/src/audio/asrc/asrc.c
+++ b/src/audio/asrc/asrc.c
@@ -148,7 +148,7 @@ static void src_copy_s32(struct comp_dev *dev,
 		ret = asrc_process_pull32(dev, cd->asrc_obj,
 					  (int32_t **)cd->ibuf, &in_frames,
 					  (int32_t **)cd->obuf, &out_frames,
-					  out_frames, &idx);
+					  in_frames, &idx);
 
 	if (ret)
 		comp_err(dev, "src_copy_s32(), error %d", ret);
@@ -221,7 +221,7 @@ static void src_copy_s16(struct comp_dev *dev,
 		ret = asrc_process_pull16(dev, cd->asrc_obj,
 					  (int16_t **)cd->ibuf, &in_frames,
 					  (int16_t **)cd->obuf, &out_frames,
-					  out_frames, &idx);
+					  in_frames, &idx);
 
 	if (ret)
 		comp_err(dev, "src_copy_s16(), error %d", ret);


### PR DESCRIPTION
This patch fixes the regression that happened in a previous fix
for stress test gitches issue. Since the passed 7th argument
(write_index) was set to output frames limit the ASRC copy()
terminated too early when converting from higher to lower sample
rate. It has caused issues at least in sof-diagnostic-driver based
validation for capture direction.

Fixes: f63adb42d93521b0bb25c670fd457122857badef
Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>