### PR TITLE
mn: get mn struct pointer using platform_shared_get() function

### DIFF
--- a/src/drivers/intel/ssp/mn.c
+++ b/src/drivers/intel/ssp/mn.c
@@ -67,7 +67,7 @@ void mn_init(struct sof *sof)
 	int i;
 #endif
 
-	sof->mn = cache_to_uncache(&mn);
+	sof->mn = platform_shared_get(&mn, sizeof(mn));
 
 #if CONFIG_INTEL_MN
 	for (i = 0; i < ARRAY_SIZE(sof->mn->bclk_sources); i++)


### PR DESCRIPTION
In order to get SHARED_DATA we should not use cache_to_uncache
macro directly, but platform_shared_get() function. Otherwise,
it can lead to situation, in which in one section there will
be cached and uncached variables not aligned to cache line
(as a result cache invalidation and writebacks could lead to
unexpexted memory overwrite).

Signed-off-by: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>