### PR TITLE
scripts: Add a new script to rebuild testbench

### DIFF
--- a/scripts/rebuild-testbench.sh
+++ b/scripts/rebuild-testbench.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2020, Mohana Datta Yelugoti
+
+# fail on any errors
+set -e
+
+print_usage()
+{
+    cat <<EOFUSAGE
+usage: $0 [-f]
+       -f Build testbench with compiler provided by fuzzer
+          (default path: $HOME/sof/work/AFL/afl-gcc)
+EOFUSAGE
+}
+
+rebuild_testbench()
+{
+    cd "$BUILD_TESTBENCH_DIR"
+
+    rm -rf build_testbench
+
+    mkdir build_testbench
+    cd build_testbench
+
+    cmake -DCMAKE_INSTALL_PREFIX=install \
+	  -DCMAKE_VERBOSE_MAKEFILE=ON \
+	  ..
+
+    make -j"$(nproc --all)"
+    make install
+}
+
+export_CC_with_afl()
+{
+    printf 'export CC=%s\n' "${SOF_AFL}"
+    export CC=${SOF_AFL}
+}
+
+main()
+{
+    SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+    SOF_REPO=$(dirname "$SCRIPT_DIR")
+    BUILD_TESTBENCH_DIR="$SOF_REPO"/tools/testbench
+    : "${SOF_AFL:=$HOME/sof/work/AFL/afl-gcc}"
+
+    while getopts "fh" OPTION; do
+	case "$OPTION" in
+	    f) export_CC_with_afl;;
+	    h) print_usage; exit 1;;
+	    *) print_usage; exit 1;;
+	esac
+    done
+
+    rebuild_testbench
+}
+
+main "$@"


### PR DESCRIPTION
Currently, the testbench is built using the script named
'host-build-all.sh' under scripts directory. But the name of
the script, it's git history doesn't refer to what the script
is currently doing now.

The newly written script adds option to build the testbench.
This script was written in mind to remove the old script
used to build the testbench (i.e host-build-all.sh).

The script also adds an option to build the testbench with
AFL instrumentation. AFL fuzzer works well when the code
it's trying to fuzz is instrumented properly. The instrumentation
helps the fuzzer in generating unique inputs which cover
different paths in the code graph. When the option is set,
testbench is built using a compiler AFL provides, which does
the instrumentation work.

Signed-off-by: Mohana Datta Yelugoti <ymdatta.work@gmail.com>