### PR TITLE
CODEOWNERS: fix path to dmic.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -37,7 +37,7 @@ src/arch/xtensa/debug/gdb/*		@mrajwa
 src/platform/imx8/**			@dbaluta
 
 # drivers
-src/drivers/intel/cavs/dmic.c		@singalsu
+src/drivers/intel/dmic.c		@singalsu
 src/drivers/intel/cavs/sue-iomux.c	@lyakh
 src/drivers/intel/haswell/*		@randerwang
 src/drivers/imx/**			@dbaluta


### PR DESCRIPTION
Fixes commit f545e3e832ec ("dmic: move dmic driver out of the cavs
specific directory")'

Signed-off-by: Marc Herbert <marc.herbert@intel.com>