### PR TITLE
CODEOWNERS: really add marc-hb to scripts

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -53,6 +53,7 @@ src/schedule				@tlauda @mrajwa
 
 # other helpers
 test/**					@jajanusz
+# Mostly overridden by *.(ba)sh below
 scripts/*				@xiulipan @marc-hb
 
 # tools(old soft)
@@ -70,8 +71,8 @@ tools/tune/*				@singalsu
 scripts/cmake/**			@jajanusz
 scripts/kconfig/**			@jajanusz
 
-# related files
-*.sh					@jajanusz
+*.sh					@jajanusz @marc-hb
+*.bash					@jajanusz @marc-hb
 *trace.*				@xiulipan @akloniex
 
 # You can also use email addresses if you prefer.


### PR DESCRIPTION
Fixes commit 757b13c123b1 ("CODEOWNERS: scripts/ += marc-hb")

Also add *.bash which we don't use yet but should considering how
not portable is the vast majority of our scripts.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>