### PR TITLE
config: disable sa panic by default

### DIFF
--- a/src/lib/agent.c
+++ b/src/lib/agent.c
@@ -59,9 +59,11 @@ static enum task_state validate(void *data)
 
 	perf_cnt_stamp(&sa->pcd, perf_sa_trace, sa);
 
+#if CONFIG_AGENT_PANIC_ON_DELAY
 	/* panic timeout */
 	if (sa->panic_on_delay && delta > sa->panic_timeout)
 		panic(SOF_IPC_PANIC_IDLE);
+#endif
 
 	/* warning timeout */
 	if (delta > sa->warn_timeout)

--- a/src/platform/Kconfig
+++ b/src/platform/Kconfig
@@ -353,4 +353,13 @@ config HAVE_AGENT
 	  with DMA based scheduling, where asynchronous interrupts
 	  can potentially starve the agent.
 
+config AGENT_PANIC_ON_DELAY
+	bool "Enable system agent time verification panic"
+	default n
+	depends on HAVE_AGENT
+	help
+	  Enables system agent time verification panic.
+	  If scheduler timing verification fails, SA will
+	  call a DSP panic.
+
 endmenu


### PR DESCRIPTION
System agent as a debug feature has very strict timing verification,
if the timing is not met it will result in a panic.
Such drastic measures are not suitable for release builds,
as a single scheduling delay has the potential to render the DSP FW
completely dead until reboot, due to lack of a FW recovery mechanism.

Signed-off-by: Slawomir Blauciak <slawomir.blauciak@linux.intel.com>