### PR TITLE
topology: apl-pcm512x: fix scheduler domain

### DIFF
--- a/tools/topology/sof-apl-pcm512x.m4
+++ b/tools/topology/sof-apl-pcm512x.m4
@@ -19,9 +19,8 @@ include(`sof/tokens.m4')
 include(`platform/intel/bxt.m4')
 include(`platform/intel/dmic.m4')
 
-ifdef(`CODEC_MASTER',
-define(SSP_SCHEDULE_TIME_DOMAIN, SCHEDULE_TIME_DOMAIN_DMA),
-define(SSP_SCHEDULE_TIME_DOMAIN, SCHEDULE_TIME_DOMAIN_TIMER))
+define(`SSP_SCHEDULE_TIME_DOMAIN',
+	ifdef(`CODEC_MASTER', SCHEDULE_TIME_DOMAIN_DMA, SCHEDULE_TIME_DOMAIN_TIMER))
 
 DEBUG_START
 


### PR DESCRIPTION
The conditional definition in sof-apl-pcm512x.m4 is supposed to
select the DMA scheduler if the codec is the bclk source and the
timer scheduler otherwise, but the conditional definition is
broken which leads to the DMA scheduler being selected always.
Fix the definition.

This fixes https://github.com/thesofproject/sof/issues/3256 but only when the PCM512x codec is the bclk slave. More work is needed to also fix the codec-master configuration.