### PR TITLE
[RFC] dw-dma: remove redundant register reads

### DIFF
--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -911,9 +911,6 @@ static int dw_dma_setup(struct dma *dma)
 		return -EIO;
 	}
 
-	for (i = 0; i < dma->plat_data.channels; i++)
-		dma_reg_read(dma, DW_DMA_CHAN_EN);
-
 	/* enable the DMA controller */
 	dma_reg_write(dma, DW_DMA_CFG, 1);
 


### PR DESCRIPTION
This is more of a question than a PR: are these reads needed? The firmware doesn't need to deal with any PCI write posting, does it?