### PR TITLE
dma: dw: writeback LLI descriptors in cache

### DIFF
--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -827,6 +827,7 @@ static void dw_dma_verify_transfer(struct dma_chan_data *channel,
 #else
 		while (lli->ctrl_hi & DW_CTLH_DONE(1)) {
 			lli->ctrl_hi &= ~DW_CTLH_DONE(1);
+			dcache_writeback_region(lli, sizeof(struct dw_lli));
 			dw_chan->lli_current =
 				(struct dw_lli *)dw_chan->lli_current->llp;
 			lli = platform_dw_dma_lli_get(dw_chan->lli_current);


### PR DESCRIPTION
Make sure we manage cached LLI descriptors and writeback after clearing DONE.

Signed-off-by: Liam Girdwood <liam.r.girdwood@linux.intel.com>