### PR TITLE
cavs: lps_wait: zephyr: include memory.h

### DIFF
--- a/src/platform/intel/cavs/lps_wait.c
+++ b/src/platform/intel/cavs/lps_wait.c
@@ -8,6 +8,7 @@
 #include <cavs/lps_ctx.h>
 #include <cavs/lps_wait.h>
 #include <cavs/mem_window.h>
+#include <cavs/memory.h>
 #include <sof/common.h>
 #include <sof/platform.h>
 #include <sof/drivers/interrupt.h>


### PR DESCRIPTION
Fixes build on Zephyr.

Signed-off-by: Liam Girdwood <liam.r.girdwood@linux.intel.com>