### PR TITLE
Read only byte kcontrol with access type as read & volatile

### DIFF
--- a/src/include/kernel/tokens.h
+++ b/src/include/kernel/tokens.h
@@ -22,6 +22,9 @@
 #define SOF_TPLG_KCTL_ENUM_ID	257
 #define SOF_TPLG_KCTL_BYTES_ID	258
 #define SOF_TPLG_KCTL_SWITCH_ID	259
+#define SOF_TPLG_KCTL_BYTES_VOLATILE_RO 260
+#define SOF_TPLG_KCTL_BYTES_VOLATILE_RW 261
+#define SOF_TPLG_KCTL_BYTES_WO_ID 262
 
 /*
  * Tokens - must match values in topology configurations

--- a/tools/ctl/ctl.c
+++ b/tools/ctl/ctl.c
@@ -355,12 +355,9 @@ static int ctl_setup(struct ctl_data *ctl_data)
 	read = snd_ctl_elem_info_is_tlv_readable(ctl_data->info);
 	write = snd_ctl_elem_info_is_tlv_writable(ctl_data->info);
 	type = snd_ctl_elem_info_get_type(ctl_data->info);
-	if (!read) {
-		fprintf(stderr, "Error: No read capability.\n");
-		goto value_free;
-	}
-	if (!write) {
-		fprintf(stderr, "Error: No write capability.\n");
+
+	if (!read && !write) {
+		fprintf(stderr, "Error: Not a read/write control\n");
 		goto value_free;
 	}
 	if (type != SND_CTL_ELEM_TYPE_BYTES) {

--- a/tools/topology/get_abi.sh
+++ b/tools/topology/get_abi.sh
@@ -15,6 +15,8 @@ minor_val=$(($MINOR << $MINOR_SHIFT))
 abi_version_3_8=$((3<<$MAJOR_SHIFT | 8<<$MINOR_SHIFT))
 abi_version=$(($major_val | $minor_val))
 abi_version_3_9_or_greater=$(($abi_version > $abi_version_3_8))
+abi_version_3_17=$((3<<$MAJOR_SHIFT | 17<<$MINOR_SHIFT))
+abi_version_3_17_or_greater=$(($abi_version >= $abi_version_3_17))
 
 printf "define(\`SOF_ABI_MAJOR', \`0x%02x')\n" $MAJOR > abi.h
 printf "define(\`SOF_ABI_MINOR', \`0x%02x')\n" $MINOR >> abi.h
@@ -22,3 +24,5 @@ printf "define(\`SOF_ABI_PATCH', \`0x%02x')\n" $PATCH >> abi.h
 printf "define(\`SOF_ABI_VERSION', \`0x%x')\n" $abi_version >> abi.h
 printf "define(\`SOF_ABI_VERSION_3_9_OR_GRT', \`%d')\n"\
 	$abi_version_3_9_or_greater >> abi.h
+printf "define(\`SOF_ABI_VERSION_3_17_OR_GRT', \`%d')\n"\
+	$abi_version_3_17_or_greater >> abi.h

--- a/tools/topology/m4/bytecontrol.m4
+++ b/tools/topology/m4/bytecontrol.m4
@@ -27,6 +27,22 @@ define(`CONTROLBYTES_EXTOPS',
 `		put STR($3)'
 `	}')
 
+# Readonly byte control to read the actual value from DSP
+dnl CONTROLBYTES_EXTOPS_READONLY(info, comment, get)
+define(`CONTROLBYTES_EXTOPS_READONLY',
+`extops."extctl" {'
+`		#$1'
+`		get STR($2)'
+`	}')
+
+# Writeonly byte control
+dnl CONTROLBYTES_EXTOPS_WRITEONLY(info, comment, put)
+define(`CONTROLBYTES_EXTOPS_WRITEONLY',
+`extops."extctl" {'
+`		#$1'
+`		put STR($2)'
+`	}')
+
 define(`CONTROLBYTES_PRIV',
 `SectionData.STR($1) {'
 `	$2'
@@ -53,6 +69,90 @@ define(`C_CONTROLBYTES',
 `		tlv_write'
 `		tlv_read'
 `		tlv_callback'
+`	]'
+`	data ['
+`		$10'
+`	]'
+`}')
+
+# Readonly byte control to read the actual value from DSP
+dnl C_CONTROLBYTES_VOLATILE_READONLY(name, index, ops, base, num_regs, mask, max, tlv, priv)
+define(`C_CONTROLBYTES_VOLATILE_READONLY',
+`SectionControlBytes.STR($1) {'
+`'
+`	# control belongs to this index group'
+`	index STR($2)'
+`'
+`	# control uses bespoke driver get/put/info ID for io ops'
+`	$3'
+`	# control uses bespoke driver get/put/info ID for ext ops'
+`	$4'
+`'
+`	base STR($5)'
+`	num_regs STR($6)'
+`	mask STR($7)'
+`	$8'
+`	$9'
+`	access ['
+`		tlv_read'
+`		tlv_callback'
+`		volatile'
+`	]'
+`	data ['
+`		$10'
+`	]'
+`}')
+
+# Writeonly byte control
+dnl C_CONTROLBYTES_WRITEONLY(name, index, ops, base, num_regs, mask, max, tlv, priv)
+define(`C_CONTROLBYTES_WRITEONLY',
+`SectionControlBytes.STR($1) {'
+`'
+`	# control belongs to this index group'
+`	index STR($2)'
+`'
+`	# control uses bespoke driver get/put/info ID for io ops'
+`	$3'
+`	# control uses bespoke driver get/put/info ID for ext ops'
+`	$4'
+`'
+`	base STR($5)'
+`	num_regs STR($6)'
+`	mask STR($7)'
+`	$8'
+`	$9'
+`	access ['
+`		tlv_write'
+`		tlv_callback'
+`	]'
+`	data ['
+`		$10'
+`	]'
+`}')
+
+# Read-write volatile byte control
+dnl C_CONTROLBYTES_VOLATILE_RW(name, index, ops, base, num_regs, mask, max, tlv, priv)
+define(`C_CONTROLBYTES_VOLATILE_RW',
+`SectionControlBytes.STR($1) {'
+`'
+`	# control belongs to this index group'
+`	index STR($2)'
+`'
+`	# control uses bespoke driver get/put/info ID for io ops'
+`	$3'
+`	# control uses bespoke driver get/put/info ID for ext ops'
+`	$4'
+`'
+`	base STR($5)'
+`	num_regs STR($6)'
+`	mask STR($7)'
+`	$8'
+`	$9'
+`	access ['
+`		tlv_read'
+`		tlv_write'
+`		tlv_callback'
+`		volatile'
 `	]'
 `	data ['
 `		$10'

--- a/tools/topology/sof/pipe-smart-amplifier-playback.m4
+++ b/tools/topology/sof/pipe-smart-amplifier-playback.m4
@@ -69,6 +69,16 @@ C_CONTROLBYTES(Smart_amp Model, PIPELINE_ID,
         ,
         MODEL_priv)
 
+
+ifelse(SOF_ABI_VERSION_3_17_OR_GRT, `1',
+C_CONTROLBYTES_VOLATILE_READONLY(Smart_amp Model_Get_params, PIPELINE_ID,
+        CONTROLBYTES_OPS(bytes, 258 binds the mixer control to bytes get handlers, 258, 258),
+        CONTROLBYTES_EXTOPS_READONLY(260 binds the mixer control to bytes get handlers, 260),
+        , , ,
+        CONTROLBYTES_MAX(, 300000),
+        ,
+        MODEL_priv))
+
 #
 # Components and Buffers
 #
@@ -78,7 +88,8 @@ C_CONTROLBYTES(Smart_amp Model, PIPELINE_ID,
 W_PCM_PLAYBACK(PCM_ID, Smart Amplifier Playback, 2, 0)
 
 # Mux 0 has 2 sink and source periods.
-W_SMART_AMP(0, PIPELINE_FORMAT, 2, 2, LIST(`             ', "Smart_amp Config", "Smart_amp Model"))
+W_SMART_AMP(0, PIPELINE_FORMAT, 2, 2, LIST(`             ', "Smart_amp Config", "Smart_amp Model",
+	    ifelse(SOF_ABI_VERSION_3_17_OR_GRT, `1', "Smart_amp Model_Get_params")))
 
 # Low Latency Buffers
 W_BUFFER(0, COMP_BUFFER_SIZE(2,


### PR DESCRIPTION
This patch set creates a Read only byte kcontrol with access type as read & volatile. Reading values from DSM audio component is very important for speaker calibration & diagnosis.Temperature, DC resistance, Fc and Q of the speaker are always changing, and every speaker has its own unique value. DSM requires Rdc calibration for each speaker in the factory line to match speaker coil resistance with actual ambient temperature. Customer also monitors above speaker parameters to make sure if there is any temperature/excursion violation. This mandates the need for a kcontrol interface to read the "actual" data from DSP. Today we already have the read/write kcontrol, where read always returns the cached data, that was set during write, as the kcontrol read need not wake up DSP everytime. But the "actual" data is needed for tuning and hence the patch set.