### PR TITLE
topology: Allow set parameters at runtime in smart_amplifier component

### DIFF
--- a/src/audio/smart_amp_test.c
+++ b/src/audio/smart_amp_test.c
@@ -185,14 +185,8 @@ static int smart_amp_ctrl_set_bin_data(struct comp_dev *dev,
 
 	assert(sad);
 
-	if (dev->state != COMP_STATE_READY) {
-		/* It is a valid request but currently this is not
-		 * supported during playback/capture. The driver will
-		 * re-send data in next resume when idle and the new
-		 * configuration will be used when playback/capture
-		 * starts.
-		 */
-		comp_err(dev, "smart_amp_ctrl_set_bin_data(): driver is busy");
+	if (dev->state < COMP_STATE_READY) {
+		comp_err(dev, "smart_amp_ctrl_set_bin_data(): driver in init!");
 		return -EBUSY;
 	}
 


### PR DESCRIPTION
Kcontrol interface is needed to set the smart_amplifier algorithm
parameters at runtime for tuning purpose. This patch allows the
user to set parameters using byte kcontrol.

Signed-off-by: Dharageswari R <dharageswari.r@intel.com>