### PR TITLE
zephyr: wrapper: complete zephyr support for working audio

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -31,9 +31,22 @@ endfunction()
 # 4. RTOS logic - scheduler, allocator, notifier - as with 2 & 3.
 zephyr_interface_library_named(SOF)
 
+# SOF source paths.
+set(SOF_SRC_PATH "../src")
+set(SOF_PLATFORM_PATH "${SOF_SRC_PATH}/platform")
+set(SOF_AUDIO_PATH "${SOF_SRC_PATH}/audio")
+set(SOF_LIB_PATH "${SOF_SRC_PATH}/lib")
+set(SOF_DRIVERS_PATH "${SOF_SRC_PATH}/drivers")
+set(SOF_IPC_PATH "${SOF_SRC_PATH}/ipc")
+set(SOF_DEBUG_PATH "${SOF_SRC_PATH}/debug")
+set(SOF_MATH_PATH "${SOF_SRC_PATH}/math")
+set(SOF_TRACE_PATH "${SOF_SRC_PATH}/trace")
+
 # default SOF includes
-target_include_directories(SOF INTERFACE ../src/include)
-target_include_directories(SOF INTERFACE ../src/arch/xtensa/include)
+target_include_directories(SOF INTERFACE ../rimage/src/include)
+target_include_directories(SOF INTERFACE ../zephyr/include)
+target_include_directories(SOF INTERFACE ${SOF_SRC_PATH}/include)
+target_include_directories(SOF INTERFACE ${SOF_SRC_PATH}/arch/xtensa/include)
 
 # SOF module init
 zephyr_library_named(modules_sof)
@@ -44,195 +57,429 @@ zephyr_include_directories(
 # SOC level sources
 # Files that are commented may not be needed.
 
-# BYT, CHT, BSW
-if (CONFIG_SOC_SERIES_INTEL_BAYTRAIL)
+# Intel BYT, CHT, BSW platforms
+if (CONFIG_SOC_SERIES_INTEL_ADSP_BAYTRAIL)
+
+	# Driver sources
 	zephyr_library_sources(
-		../src/drivers/intel/baytrail/ipc.c
-		#../src/drivers/intel/baytrail/interrupt.c
-		../src/drivers/intel/baytrail/timer.c
-		../src/drivers/intel/baytrail/ssp.c
-		 ../src/drivers/intel/pmc-ipc.c
+		${SOF_DRIVERS_PATH}/intel/baytrail/ipc.c
+		${SOF_DRIVERS_PATH}/intel/baytrail/ssp.c
+		${SOF_DRIVERS_PATH}/intel/pmc-ipc.c
 	)
 
-	target_include_directories(SOF INTERFACE ../src/platform/baytrail/include)
-endif()
-
-# HSW, BDW
-if (CONFIG_SOC_SERIES_INTEL_BROADWELL)
+	# Platform sources
 	zephyr_library_sources(
-		../src/drivers/intel/haswell/ipc.c
-		#../src/drivers/intel/haswell/interrupt.c
-		../src/drivers/intel/haswell/timer.c
-		../src/drivers/intel/haswell/ssp.c
+		${SOF_PLATFORM_PATH}/baytrail/platform.c
+		${SOF_PLATFORM_PATH}/baytrail/lib/dai.c
+		${SOF_PLATFORM_PATH}/baytrail/lib/clk.c
+		${SOF_PLATFORM_PATH}/baytrail/lib/dma.c
+		${SOF_SRC_PATH}/schedule/dma_multi_chan_domain.c
 	)
 
-	target_include_directories(SOF INTERFACE ../src/platform/haswell/include)
+	set(PLATFORM "baytrail")
 endif()
 
-# APL, KBL, SKL
+# Intel HSW, BDW platforms
+if (CONFIG_SOC_SERIES_INTEL_ADSP_BROADWELL)
+	zephyr_library_sources(
+		${SOF_DRIVERS_PATH}/intel/haswell/ipc.c
+		${SOF_DRIVERS_PATH}/intel/haswell/ssp.c
+	)
+
+	set(PLATFORM "haswell")
+endif()
+
+# Intel APL, KBL, SKL CAVS 1.5 platforms
 if (CONFIG_SOC_SERIES_INTEL_CAVS_V15)
+
+	# Driver sources
 	zephyr_library_sources(
-		../src/drivers/intel/cavs/hda-dma.c
-		../src/drivers/intel/cavs/hda.c
-		../src/drivers/intel/cavs/ipc.c
-		../src/drivers/intel/cavs/dmic.c
-		#../src/drivers/intel/cavs/interrupt.c
-		#../src/drivers/intel/cavs/idc.c
-		../src/drivers/intel/cavs/timer.c
-		../src/drivers/intel/cavs/ssp.c
-		../src/drivers/intel/cavs/mn.c
+		${SOF_DRIVERS_PATH}/intel/cavs/ipc.c
+		${SOF_DRIVERS_PATH}/intel/cavs/timestamp.c
 	)
 
-	# CAVS15 include seems to be set in Zephyr. TODO also set common dir.
+	zephyr_library_sources_ifdef(CONFIG_MULTICORE
+		${SOF_DRIVERS_PATH}/intel/cavs/idc.c
+	)
+
+	zephyr_library_sources_ifdef(CONFIG_INTEL_HDA
+		${SOF_DRIVERS_PATH}/intel/hda/hda-dma.c
+		${SOF_DRIVERS_PATH}/intel/hda/hda.c
+	)
+
+	zephyr_library_sources_ifdef(CONFIG_INTEL_MN
+		${SOF_DRIVERS_PATH}/intel/ssp/mn.c
+	)
+
+	zephyr_library_sources_ifdef(CONFIG_INTEL_SSP
+		${SOF_DRIVERS_PATH}/intel/ssp/ssp.c
+	)
+
+	zephyr_library_sources_ifdef(CONFIG_INTEL_ALH
+		${SOF_DRIVERS_PATH}/intel/alh.c
+	)
+
+	zephyr_library_sources_ifdef(CONFIG_INTEL_DMIC
+		${SOF_DRIVERS_PATH}/intel/dmic.c
+	)
+
+	# Platform sources
+	zephyr_library_sources(
+		${SOF_PLATFORM_PATH}/intel/cavs/platform.c
+		${SOF_PLATFORM_PATH}/intel/cavs/lib/mem_window.c
+		${SOF_PLATFORM_PATH}/intel/cavs/lib/pm_runtime.c
+		${SOF_PLATFORM_PATH}/intel/cavs/lib/pm_memory.c
+		${SOF_PLATFORM_PATH}/intel/cavs/lib/clk.c
+		${SOF_PLATFORM_PATH}/intel/cavs/lib/dai.c
+		${SOF_PLATFORM_PATH}/intel/cavs/lib/dma.c
+		${SOF_PLATFORM_PATH}/apollolake/lib/power_down.S
+		${SOF_PLATFORM_PATH}/apollolake/lib/clk.c
+	)
+
+	set_source_files_properties(${SOF_PLATFORM_PATH}/apollolake/lib/power_down.S PROPERTIES COMPILE_FLAGS -DASSEMBLY)
+
+	set(PLATFORM "apollolake")
+	zephyr_include_directories(${SOF_PLATFORM_PATH}/intel/cavs/include)
+endif()
+
+# Intel CNL and CAVS 1.8 platfroms
+if (CONFIG_SOC_SERIES_INTEL_CAVS_V18)
+
+	# Driver sources
+	zephyr_library_sources(
+		${SOF_DRIVERS_PATH}/intel/cavs/ipc.c
+		${SOF_DRIVERS_PATH}/intel/cavs/timestamp.c
+	)
+
+	zephyr_library_sources_ifdef(CONFIG_MULTICORE
+		${SOF_DRIVERS_PATH}/intel/cavs/idc.c
+	)
+
+	# Sue Creek - S100 only - already in Zephyr.
+	#${SOF_DRIVERS_PATH}/intel/cavs/sue-ipc.c
+	#${SOF_DRIVERS_PATH}/intel/cavs/sue-iomux.c
+
+	zephyr_library_sources_ifdef(CONFIG_INTEL_HDA
+		${SOF_DRIVERS_PATH}/intel/hda/hda-dma.c
+		${SOF_DRIVERS_PATH}/intel/hda/hda.c
+	)
+
+	zephyr_library_sources_ifdef(CONFIG_INTEL_MN
+		${SOF_DRIVERS_PATH}/intel/ssp/mn.c
+	)
+
+	zephyr_library_sources_ifdef(CONFIG_INTEL_SSP
+		${SOF_DRIVERS_PATH}/intel/ssp/ssp.c
+	)
+
+	zephyr_library_sources_ifdef(CONFIG_INTEL_ALH
+		${SOF_DRIVERS_PATH}/intel/alh.c
+	)
+
+	zephyr_library_sources_ifdef(CONFIG_INTEL_DMIC
+		${SOF_DRIVERS_PATH}/intel/dmic.c
+	)
+
+	# Platform sources
+	zephyr_library_sources(
+		${SOF_PLATFORM_PATH}/intel/cavs/platform.c
+		${SOF_PLATFORM_PATH}/intel/cavs/lib/mem_window.c
+		${SOF_PLATFORM_PATH}/cannonlake/lib/clk.c
+		${SOF_PLATFORM_PATH}/intel/cavs/lib/power_down.S
+		${SOF_PLATFORM_PATH}/intel/cavs/lib/pm_runtime.c
+		${SOF_PLATFORM_PATH}/intel/cavs/lib/pm_memory.c
+		${SOF_PLATFORM_PATH}/intel/cavs/lib/clk.c
+		${SOF_PLATFORM_PATH}/intel/cavs/lib/dai.c
+		${SOF_PLATFORM_PATH}/intel/cavs/lib/dma.c
+		#${SOF_PLATFORM_PATH}/intel/cavs/lps_pic_restore_vector.S
+		${SOF_PLATFORM_PATH}/intel/cavs/lps_wait.c
+	)
+
+	set_source_files_properties(${SOF_PLATFORM_PATH}/intel/cavs/lib/power_down.S PROPERTIES COMPILE_FLAGS -DASSEMBLY)
+	set_source_files_properties(${SOF_PLATFORM_PATH}/intel/cavs/lps_pic_restore_vector.S PROPERTIES COMPILE_FLAGS -DASSEMBLY)
+
+	set(PLATFORM "cannonlake")
+	zephyr_include_directories(${SOF_PLATFORM_PATH}/intel/cavs/include)
+endif()
+
+# Intel ICL and CAVS 2.0 platforms
+if (CONFIG_SOC_SERIES_INTEL_CAVS_V20)
+
+	# Driver sources
+	zephyr_library_sources(
+		${SOF_DRIVERS_PATH}/intel/cavs/ipc.c
+		${SOF_DRIVERS_PATH}/intel/cavs/timestamp.c
+	)
+
+	zephyr_library_sources_ifdef(CONFIG_MULTICORE
+		${SOF_DRIVERS_PATH}/intel/cavs/idc.c
+	)
+
+	zephyr_library_sources_ifdef(CONFIG_INTEL_HDA
+		${SOF_DRIVERS_PATH}/intel/hda/hda-dma.c
+		${SOF_DRIVERS_PATH}/intel/hda/hda.c
+	)
+
+	zephyr_library_sources_ifdef(CONFIG_INTEL_MN
+		${SOF_DRIVERS_PATH}/intel/ssp/mn.c
+	)
+
+	zephyr_library_sources_ifdef(CONFIG_INTEL_SSP
+		${SOF_DRIVERS_PATH}/intel/ssp/ssp.c
+	)
+
+	zephyr_library_sources_ifdef(CONFIG_INTEL_ALH
+		${SOF_DRIVERS_PATH}/intel/alh.c
+	)
+
+	zephyr_library_sources_ifdef(CONFIG_INTEL_DMIC
+		${SOF_DRIVERS_PATH}/intel/dmic.c
+	)
+
+	# Platform sources
+	zephyr_library_sources(
+		${SOF_PLATFORM_PATH}/intel/cavs/platform.c
+		${SOF_PLATFORM_PATH}/intel/cavs/lib/mem_window.c
+		${SOF_PLATFORM_PATH}/icelake/lib/clk.c
+		${SOF_PLATFORM_PATH}/intel/cavs/lib/power_down.S
+		${SOF_PLATFORM_PATH}/intel/cavs/lib/pm_runtime.c
+		${SOF_PLATFORM_PATH}/intel/cavs/lib/pm_memory.c
+		${SOF_PLATFORM_PATH}/intel/cavs/lib/clk.c
+		${SOF_PLATFORM_PATH}/intel/cavs/lib/dai.c
+		${SOF_PLATFORM_PATH}/intel/cavs/lib/dma.c
+		#${SOF_PLATFORM_PATH}/intel/cavs/lps_pic_restore_vector.S
+		${SOF_PLATFORM_PATH}/intel/cavs/lps_wait.c
+	)
+
+	set_source_files_properties(${SOF_PLATFORM_PATH}/intel/cavs/lib/power_down.S PROPERTIES COMPILE_FLAGS -DASSEMBLY)
+	set_source_files_properties(${SOF_PLATFORM_PATH}/intel/cavs/lps_pic_restore_vector.S PROPERTIES COMPILE_FLAGS -DASSEMBLY)
+
+	set(PLATFORM "icelake")
+	target_include_directories(SOF INTERFACE ../zephyr/include/cavs20)
+	zephyr_include_directories(${SOF_PLATFORM_PATH}/intel/cavs/include)
 	zephyr_include_directories(../../../../zephyr/soc/xtensa/intel_adsp/common/include)
 endif()
 
-# CNL
-if (CONFIG_SOC_SERIES_INTEL_CAVS_V18)
-	zephyr_library_sources(
-		../src/drivers/intel/cavs/hda-dma.c
-		../src/drivers/intel/cavs/hda.c
-		../src/drivers/intel/cavs/ipc.c
-		#../src/drivers/intel/cavs/sue-ipc.c
-		../src/drivers/intel/cavs/dmic.c
-		# ../src/drivers/intel/cavs/interrupt.c
-		../src/drivers/intel/cavs/idc.c
-		../src/drivers/intel/cavs/timer.c
-		#../src/drivers/intel/cavs/sue-iomux.c
-		../src/drivers/intel/cavs/ssp.c
-		../src/drivers/intel/cavs/mn.c
-		../src/drivers/intel/cavs/alh.c
-	)
-
-endif()
-
-# ICL
-if (CONFIG_SOC_SERIES_INTEL_CAVS_V20)
-	zephyr_library_sources(
-		../src/drivers/intel/cavs/hda-dma.c
-		../src/drivers/intel/cavs/hda.c
-		../src/drivers/intel/cavs/ipc.c
-		../src/drivers/intel/cavs/dmic.c
-		#../src/drivers/intel/cavs/interrupt.c
-		../src/drivers/intel/cavs/idc.c
-		../src/drivers/intel/cavs/timer.c
-		../src/drivers/intel/cavs/ssp.c
-		../src/drivers/intel/cavs/mn.c
-		../src/drivers/intel/cavs/alh.c
-	)
-endif()
-
-# TGL
+# Intel TGL and CAVS 2.5 platforms
 if (CONFIG_SOC_SERIES_INTEL_CAVS_V25)
+
+	# Driver sources
 	zephyr_library_sources(
-		../src/drivers/intel/cavs/hda-dma.c
-		../src/drivers/intel/cavs/hda.c
-		../src/drivers/intel/cavs/ipc.c
-		../src/drivers/intel/cavs/dmic.c
-		#../src/drivers/intel/cavs/interrupt.c
-		../src/drivers/intel/cavs/idc.c
-		../src/drivers/intel/cavs/timer.c
-		../src/drivers/intel/cavs/ssp.c
-		../src/drivers/intel/cavs/mn.c
-		../src/drivers/intel/cavs/alh.c
+		${SOF_DRIVERS_PATH}/intel/cavs/ipc.c
+		${SOF_DRIVERS_PATH}/intel/cavs/timestamp.c
 	)
+
+	zephyr_library_sources_ifdef(CONFIG_MULTICORE
+		${SOF_DRIVERS_PATH}/intel/cavs/idc.c
+	)
+
+	zephyr_library_sources_ifdef(CONFIG_INTEL_HDA
+		${SOF_DRIVERS_PATH}/intel/hda/hda-dma.c
+		${SOF_DRIVERS_PATH}/intel/hda/hda.c
+	)
+
+	zephyr_library_sources_ifdef(CONFIG_INTEL_MN
+		${SOF_DRIVERS_PATH}/intel/ssp/mn.c
+	)
+
+	zephyr_library_sources_ifdef(CONFIG_INTEL_SSP
+		${SOF_DRIVERS_PATH}/intel/ssp/ssp.c
+	)
+
+	zephyr_library_sources_ifdef(CONFIG_INTEL_ALH
+		${SOF_DRIVERS_PATH}/intel/alh.c
+	)
+
+	zephyr_library_sources_ifdef(CONFIG_INTEL_DMIC
+		${SOF_DRIVERS_PATH}/intel/dmic.c
+	)
+
+	# Platform sources
+	zephyr_library_sources(
+		${SOF_PLATFORM_PATH}/intel/cavs/platform.c
+		${SOF_PLATFORM_PATH}/intel/cavs/lib/mem_window.c
+		${SOF_PLATFORM_PATH}/tigerlake/lib/clk.c
+		${SOF_PLATFORM_PATH}/intel/cavs/lib/power_down.S
+		${SOF_PLATFORM_PATH}/intel/cavs/lib/pm_runtime.c
+		${SOF_PLATFORM_PATH}/intel/cavs/lib/pm_memory.c
+		${SOF_PLATFORM_PATH}/intel/cavs/lib/clk.c
+		${SOF_PLATFORM_PATH}/intel/cavs/lib/dai.c
+		${SOF_PLATFORM_PATH}/intel/cavs/lib/dma.c
+		#${SOF_PLATFORM_PATH}/intel/cavs/lps_pic_restore_vector.S
+		${SOF_PLATFORM_PATH}/intel/cavs/lps_wait.c
+	)
+
+	set_source_files_properties(${SOF_PLATFORM_PATH}/intel/cavs/lib/power_down.S PROPERTIES COMPILE_FLAGS -DASSEMBLY)
+	set_source_files_properties(${SOF_PLATFORM_PATH}/intel/cavs/lps_pic_restore_vector.S PROPERTIES COMPILE_FLAGS -DASSEMBLY)
+
+	set(PLATFORM "tigerlake")
+	target_include_directories(SOF INTERFACE ../zephyr/include/cavs25)
+	zephyr_include_directories(${SOF_PLATFORM_PATH}/intel/cavs/include)
+	zephyr_include_directories(../../../../zephyr/soc/xtensa/intel_adsp/common/include)
 endif()
 
-# IMX8
+# NXP IMX8 platforms
 if (CONFIG_SOC_SERIES_NXP_IMX8)
 	zephyr_library_sources(
-		#../src/drivers/imx/sdma.c
-		#../src/drivers/imx/edma.c
-		#../src/drivers/imx/sai.c
-		#../src/drivers/imx/ipc.c
-		#../src/drivers/imx/esai.c
-		#../src/drivers/imx/interrupt.c
-		#../src/drivers/imx/timer.c
+		#${SOF_DRIVERS_PATH}/generic/dummy-dma.c
+		#${SOF_DRIVERS_PATH}/imx/sdma.c
+		#${SOF_DRIVERS_PATH}/imx/edma.c
+		#${SOF_DRIVERS_PATH}/imx/sai.c
+		#${SOF_DRIVERS_PATH}/imx/ipc.c
+		#${SOF_DRIVERS_PATH}/imx/esai.c
 	)
 endif()
 
-# Files used on all platforms.
+zephyr_include_directories(${SOF_PLATFORM_PATH}/${PLATFORM}/include)
+
+# Mandatory Files used on all platforms.
 # Commented files will be added/removed as integration dictates.
 zephyr_library_sources(
-	../src/trace/dma-trace.c
-	../src/trace/trace.c
-	#../src/drivers/dw/ssi-spi.c
-	#../src/drivers/dw/gpio.c
-	../src/drivers/dw/dma.c
-	#../src/drivers/interrupt.c
-	../src/drivers/generic/dummy-dma.c
-	../src/ipc/dma-copy.c
-	../src/ipc/ipc.c
-	../src/ipc/handler.c
-	../src/ipc/probe_support.c
-	../src/ipc/user_abi_version.c
-	../src/ipc/ipc-host-ptable.c
-	../src/ipc/cc_version.c
-	../src/debug/gdb/gdb.c
-	../src/debug/gdb/ringbuffer.c
-	../src/debug/panic.c
-	../src/spinlock.c
-	../src/math/decibels.c
-	../src/math/numbers.c
-	../src/math/trig.c
-	#../src/init/init.c
-	#../src/schedule/task.c
-	#../src/schedule/timer_domain.c
-	#../src/schedule/schedule.c
-	#../src/schedule/edf_schedule.c
-	#../src/schedule/dma_single_chan_domain.c
-	#../src/schedule/dma_multi_chan_domain.c
-	#../src/schedule/ll_schedule.c
-	../src/lib/clk.c
-	../src/lib/notifier.c
-	../src/lib/lib.c
-	../src/lib/pm_runtime.c
-	../src/lib/agent.c
-	#../src/lib/alloc.c
-	../src/lib/wait.c
-	../src/lib/dma.c
-	../src/lib/dai.c
-	../src/audio/kpb.c
-	../src/audio/pipeline_static.c
-	../src/audio/selector/selector_generic.c
-	../src/audio/selector/selector.c
-	../src/audio/channel_map.c
-	../src/audio/switch.c
-	../src/audio/src/src_hifi2ep.c
-	../src/audio/src/src_generic.c
-	../src/audio/src/src_hifi3.c
-	../src/audio/src/src.c
-	../src/audio/pcm_converter/pcm_converter_hifi3.c
-	../src/audio/pcm_converter/pcm_converter_generic.c
-	../src/audio/volume/volume_hifi3.c
-	../src/audio/volume/volume_generic.c
-	../src/audio/volume/volume.c
-	../src/audio/mixer.c
-	../src/audio/tone.c
-	../src/audio/eq_fir/fir_hifi3.c
-	../src/audio/eq_fir/fir_hifi2ep.c
-	../src/audio/eq_fir/eq_fir.c
-	../src/audio/eq_fir/fir.c
-	../src/audio/detect_test.c
-	../src/audio/host.c
-	../src/audio/asrc/asrc.c
-	../src/audio/asrc/asrc_farrow_hifi3.c
-	../src/audio/asrc/asrc_farrow.c
-	../src/audio/asrc/asrc_farrow_generic.c
-	../src/audio/dcblock/dcblock_generic.c
-	../src/audio/dcblock/dcblock.c
-	../src/audio/mux/mux.c
-	../src/audio/mux/mux_generic.c
-	../src/audio/eq_iir/iir_generic.c
-	../src/audio/eq_iir/iir_hifi3.c
-	../src/audio/eq_iir/iir.c
-	../src/audio/eq_iir/eq_iir.c
-	../src/audio/buffer.c
-	../src/audio/component.c
-	../src/audio/dai.c
-	../src/audio/pipeline.c
-	#../src/probe/probe.c
+	${SOF_SRC_PATH}/trace/dma-trace.c
+	${SOF_IPC_PATH}/dma-copy.c
+	${SOF_IPC_PATH}/ipc.c
+	${SOF_IPC_PATH}/handler.c
+	${SOF_IPC_PATH}/probe_support.c
+	${SOF_IPC_PATH}/user_abi_version.c
+	${SOF_IPC_PATH}/ipc-host-ptable.c
+	${SOF_IPC_PATH}/cc_version.c
+	${SOF_SRC_PATH}/spinlock.c
+
+	# SOF math utilities
+	${SOF_MATH_PATH}/decibels.c
+	${SOF_MATH_PATH}/numbers.c
+	${SOF_MATH_PATH}/trig.c
+
+	# SOF library - parts to transition to Zephyr over time
+	${SOF_LIB_PATH}/clk.c
+	${SOF_LIB_PATH}/notifier.c
+	${SOF_LIB_PATH}/lib.c
+	${SOF_LIB_PATH}/pm_runtime.c
+	${SOF_LIB_PATH}/wait.c
+	${SOF_LIB_PATH}/dma.c
+	${SOF_LIB_PATH}/dai.c
+
+	# SOF mandatory audio processing
+	${SOF_AUDIO_PATH}/pipeline_static.c
+	${SOF_AUDIO_PATH}/channel_map.c
+	${SOF_AUDIO_PATH}/pcm_converter/pcm_converter_hifi3.c
+	${SOF_AUDIO_PATH}/pcm_converter/pcm_converter.c
+	${SOF_AUDIO_PATH}/pcm_converter/pcm_converter_generic.c
+	${SOF_AUDIO_PATH}/buffer.c
+	${SOF_AUDIO_PATH}/component.c
+	${SOF_AUDIO_PATH}/pipeline.c
+	${SOF_AUDIO_PATH}/host.c
+
+	# SOF core infrastructure - runs on top of Zephyr
+	${SOF_SRC_PATH}/init/init.c
+	${SOF_SRC_PATH}/init/ext_manifest.c
+	${SOF_SRC_PATH}/schedule/timer_domain.c
+	${SOF_SRC_PATH}/schedule/schedule.c
+	${SOF_SRC_PATH}/schedule/dma_single_chan_domain.c
+	${SOF_SRC_PATH}/schedule/dma_multi_chan_domain.c
+	${SOF_SRC_PATH}/schedule/ll_schedule.c
+	${SOF_SRC_PATH}/trace/trace.c
+
+	# Bridge wrapper between SOF and Zephyr APIs - Will shrink over time.
 	wrapper.c
+	edf_schedule.c
+	schedule.c
+)
+
+# Optional SOF sources - depends on Kconfig - WIP
+
+zephyr_library_sources_ifdef(CONFIG_COMP_FIR
+	${SOF_AUDIO_PATH}/eq_fir/fir_hifi3.c
+	${SOF_AUDIO_PATH}/eq_fir/fir_hifi2ep.c
+	${SOF_AUDIO_PATH}/eq_fir/eq_fir.c
+	${SOF_AUDIO_PATH}/eq_fir/fir.c
+)
+
+zephyr_library_sources_ifdef(CONFIG_COMP_IIR
+	${SOF_AUDIO_PATH}/eq_iir/iir_generic.c
+	${SOF_AUDIO_PATH}/eq_iir/iir_hifi3.c
+	${SOF_AUDIO_PATH}/eq_iir/iir.c
+	${SOF_AUDIO_PATH}/eq_iir/eq_iir.c
+)
+
+zephyr_library_sources_ifdef(CONFIG_COMP_ASRC
+	${SOF_AUDIO_PATH}/asrc/asrc.c
+	${SOF_AUDIO_PATH}/asrc/asrc_farrow_hifi3.c
+	${SOF_AUDIO_PATH}/asrc/asrc_farrow.c
+	${SOF_AUDIO_PATH}/asrc/asrc_farrow_generic.c
+)
+
+zephyr_library_sources_ifdef(CONFIG_COMP_DCBLOCK
+	${SOF_AUDIO_PATH}/dcblock/dcblock_generic.c
+	${SOF_AUDIO_PATH}/dcblock/dcblock.c
+)
+
+zephyr_library_sources_ifdef(CONFIG_COMP_SEL
+	${SOF_AUDIO_PATH}/selector/selector_generic.c
+	${SOF_AUDIO_PATH}/selector/selector.c
+)
+
+zephyr_library_sources_ifdef(CONFIG_COMP_KPB
+	${SOF_AUDIO_PATH}/kpb.c
+)
+
+zephyr_library_sources_ifdef(CONFIG_COMP_SWITCH
+	${SOF_AUDIO_PATH}/switch.c
+)
+
+zephyr_library_sources_ifdef(CONFIG_COMP_MIXER
+	${SOF_AUDIO_PATH}/mixer.c
+)
+
+zephyr_library_sources_ifdef(CONFIG_COMP_TONE
+	${SOF_AUDIO_PATH}/tone.c
+)
+
+zephyr_library_sources_ifdef(CONFIG_COMP_DAI
+	${SOF_AUDIO_PATH}/dai.c
+)
+
+zephyr_library_sources_ifdef(CONFIG_COMP_TEST_KEYPHRASE
+	${SOF_AUDIO_PATH}/detect_test.c
+)
+
+zephyr_library_sources_ifdef(CONFIG_COMP_VOLUME
+	${SOF_AUDIO_PATH}/volume/volume_hifi3.c
+	${SOF_AUDIO_PATH}/volume/volume_generic.c
+	${SOF_AUDIO_PATH}/volume/volume.c
+)
+
+zephyr_library_sources_ifdef(CONFIG_COMP_SRC
+	${SOF_AUDIO_PATH}/src/src_hifi2ep.c
+	${SOF_AUDIO_PATH}/src/src_generic.c
+	${SOF_AUDIO_PATH}/src/src_hifi3.c
+	${SOF_AUDIO_PATH}/src/src.c
+)
+
+zephyr_library_sources_ifdef(CONFIG_COMP_MUX
+	${SOF_AUDIO_PATH}/mux/mux.c
+	${SOF_AUDIO_PATH}/mux/mux_generic.c
+)
+
+zephyr_library_sources_ifdef(CONFIG_PROBE
+	${SOF_SRC_PATH}/probe/probe.c
+)
+
+zephyr_library_sources_ifdef(CONFIG_MULTICORE
+	${SOF_SRC_PATH}/idc/idc.c
+)
+
+zephyr_library_sources_ifdef(CONFIG_HAVE_AGENT
+	${SOF_LIB_PATH}/agent.c
+)
+
+zephyr_library_sources_ifdef(CONFIG_GDB_DEBUG
+	${SOF_DEBUG_PATH}/gdb/gdb.c
+	${SOF_DEBUG_PATH}/gdb/ringbuffer.c
+)
+
+zephyr_library_sources_ifdef(CONFIG_DW_DMA
+	${SOF_DRIVERS_PATH}/dw/dma.c
 )
 
 zephyr_library_link_libraries(SOF)
@@ -247,16 +494,27 @@ file(MAKE_DIRECTORY ${GENERATED_DIRECTORY}/include)
 # generated files
 set(VERSION_H_PATH ${GENERATED_DIRECTORY}/include/version.h)
 set(DOT_CONFIG_PATH ${GENERATED_DIRECTORY}/.config)
-set(CONFIG_H_PATH ${GENERATED_DIRECTORY}/include/config.h)
 
-# create version.h
-include(../scripts/cmake/version.cmake)
+if(${CMAKE_VERSION} VERSION_LESS "3.12.0")
+	# FindPythonInterp is bugged and may sometimes be unable to find
+	# Python 3 when both Python 2 & 3 are in PATH,
+	# so it's always better to use CMake 3.12+
+	find_package(PythonInterp 3.0)
+	set(PYTHON3 "${PYTHON_EXECUTABLE}")
+else()
+	find_package(Python3 COMPONENTS Interpreter)
+	set(PYTHON3 "${Python3_EXECUTABLE}")
+endif()
 
 # SOF uses GNU C99 extensions. TODO other flags required ?
 target_compile_options(SOF INTERFACE -std=gnu99 -fno-inline-functions)
 
 # Toolchain info
 add_definitions(-DXCC_TOOLS_VERSION="${ZEPHYR_TOOLCHAIN_VARIANT}" -DCC_OPTIMIZE_FLAGS="${OPTIMIZATION_FLAG}")
+
+# create version information
+include(../scripts/cmake/version.cmake)
+add_definitions(-DSOF_MICRO=${SOF_MICRO} -DSOF_MINOR=${SOF_MINOR} -DSOF_MAJOR=${SOF_MAJOR} -DSOF_TAG="${SOF_TAG}")
 
 # Create Trace realtive file paths
 sof_append_relative_path_definitions(modules_sof)

--- a/zephyr/edf_schedule.c
+++ b/zephyr/edf_schedule.c
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2019 Intel Corporation. All rights reserved.
+//
+// Author: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>
+
+#include <sof/audio/component.h>
+#include <sof/schedule/task.h>
+#include <stdint.h>
+#include <sof/schedule/edf_schedule.h>
+#include <sof/lib/wait.h>
+
+#include <kernel.h>
+#include <sys_clock.h>
+
+struct k_work_q edf_workq;
+K_THREAD_STACK_DEFINE(edf_workq_stack, 8192);
+
+/*
+ * since only IPC is using the EDF scheduler - we schedule the work in the
+ * next timer_domain time slice
+ */
+#define EDF_SCHEDULE_DELAY	0
+
+static void edf_work_handler(struct k_work *work)
+{
+	struct task *task = CONTAINER_OF(work, struct task, z_delayed_work);
+
+	task->state = SOF_TASK_STATE_RUNNING;
+	task_run(task);
+
+	task_complete(task);
+	task->state = SOF_TASK_STATE_COMPLETED;
+}
+
+/* schedule task */
+static int schedule_edf_task(void *data, struct task *task, uint64_t start,
+			     uint64_t period)
+{
+	/* start time is microseconds from now */
+	k_timeout_t start_time = K_USEC(start + EDF_SCHEDULE_DELAY);
+
+	k_delayed_work_submit_to_queue(&edf_workq,
+				       &task->z_delayed_work,
+					   start_time);
+
+	task->state = SOF_TASK_STATE_QUEUED;
+	return 0;
+}
+
+static int schedule_edf_task_cancel(void *data, struct task *task)
+{
+	int ret = 0;
+
+	if (task->state == SOF_TASK_STATE_QUEUED) {
+		ret = k_delayed_work_cancel(&task->z_delayed_work);
+
+		/* delete task */
+		task->state = SOF_TASK_STATE_CANCEL;
+	}
+
+	return ret;
+}
+
+static int schedule_edf_task_complete(void *data, struct task *task)
+{
+	task_complete(task);
+	return 0;
+}
+
+static int schedule_edf_task_running(void *data, struct task *task)
+{
+	task->state = SOF_TASK_STATE_RUNNING;
+	return 0;
+}
+
+static int schedule_edf_task_free(void *data, struct task *task)
+{
+	task->state = SOF_TASK_STATE_FREE;
+	task->ops.run = NULL;
+	task->data = NULL;
+
+	return 0;
+}
+
+struct scheduler_ops schedule_edf_ops = {
+	.schedule_task		= schedule_edf_task,
+	.schedule_task_running	= schedule_edf_task_running,
+	.schedule_task_complete = schedule_edf_task_complete,
+	.schedule_task_cancel	= schedule_edf_task_cancel,
+	.schedule_task_free	= schedule_edf_task_free,
+};
+
+int scheduler_init_edf(void)
+{
+	scheduler_init(SOF_SCHEDULE_EDF, &schedule_edf_ops, NULL);
+
+	k_work_q_start(&edf_workq,
+		       edf_workq_stack,
+		       K_THREAD_STACK_SIZEOF(edf_workq_stack),
+		       1);
+	k_thread_name_set(&edf_workq.thread, "edf_workq");
+
+	return 0;
+}
+
+int schedule_task_init_edf(struct task *task, uint32_t uid,
+			   const struct task_ops *ops,
+			   void *data, uint16_t core, uint32_t flags)
+{
+	int ret = 0;
+
+	ret = schedule_task_init(task, uid, SOF_SCHEDULE_EDF, 0, ops->run, data,
+				 core, flags);
+	if (ret < 0)
+		return ret;
+
+	task->ops = *ops;
+
+	k_delayed_work_init(&task->z_delayed_work, edf_work_handler);
+
+	return 0;
+}
+
+int schedule_task_init_edf_with_budget(struct task *task, uint32_t uid,
+				       const struct task_ops *ops,
+				       void *data, uint16_t core,
+				       uint32_t flags, uint32_t cycles_budget)
+{
+	return schedule_task_init_edf(task, uid, ops, data, core, flags);
+}

--- a/zephyr/include/sof/atomic.h
+++ b/zephyr/include/sof/atomic.h
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2020 Intel Corporation. All rights reserved.
+//
+
+#ifndef __INCLUDE_ATOMIC_H_
+#define __INCLUDE_ATOMIC_H_
+
+#include <sys/atomic.h>
+
+#define atomic_read	atomic_get
+#define atomic_init	atomic_set
+
+#endif

--- a/zephyr/include/sof/trace/trace.h
+++ b/zephyr/include/sof/trace/trace.h
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2020 Intel Corporation. All rights reserved.
+//
+
+#ifndef __SOF_TRACE_TRACE1_H__
+#define __SOF_TRACE_TRACE1_H__
+
+#ifndef ZEPHYR_INCLUDE_LOGGING_LOG_H_
+#include <logging/log.h>
+
+/* Level of SOF trace on Zephyr */
+#define SOF_ZEPHYR_TRACE_LEVEL LOG_LEVEL_INF
+
+LOG_MODULE_DECLARE(sof, SOF_ZEPHYR_TRACE_LEVEL);
+#endif
+
+/* printk supports uint64_t so use it until LOG is ready */
+#define USE_PRINTK	1
+
+/* SOF trace header */
+#include "../../../../src/include/sof/trace/trace.h"
+
+struct timer;
+uint64_t platform_timer_get(struct timer *timer);
+
+/*
+ * Use SOF macros, but let Zephyr take care of the physical log IO.
+ */
+#undef _log_message
+
+#if USE_PRINTK
+#define _log_message(atomic, level, comp_class, ctx, id1, id2, format, ...)	\
+	do {								        \
+		if ((level) <= SOF_ZEPHYR_TRACE_LEVEL)                          \
+			printk("%llu: " format "\n", platform_timer_get(NULL),	\
+				##__VA_ARGS__);					\
+	} while (0)
+#else
+#define _log_message(atomic, level, comp_class, ctx, id1, id2, format, ...)	\
+	do {								        \
+		Z_LOG(level, "%u: " format, (uint32_t)platform_timer_get(NULL),	\
+		      ##__VA_ARGS__);					        \
+	} while (0)
+#endif
+
+#endif /* __INCLUDE_TRACE__ */

--- a/zephyr/schedule.c
+++ b/zephyr/schedule.c
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2019 Intel Corporation. All rights reserved.
+//
+// Author: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>
+
+/* Generic scheduler */
+#include <sof/schedule/schedule.h>
+#include <sof/schedule/edf_schedule.h>
+#include <sof/schedule/ll_schedule.h>
+#include <sof/lib/alloc.h>
+#include <ipc/topology.h>
+
+static struct schedulers *_schedulers;
+
+/**
+ * Retrieves registered schedulers.
+ * @return List of registered schedulers.
+ */
+struct schedulers **arch_schedulers_get(void)
+{
+	return &_schedulers;
+}

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -7,16 +7,119 @@
 
 #include <sof/lib/alloc.h>
 #include <sof/drivers/interrupt.h>
+#include <sof/drivers/interrupt-map.h>
 #include <sof/lib/dma.h>
 #include <sof/schedule/schedule.h>
+#include <platform/drivers/interrupt.h>
+#include <platform/lib/memory.h>
+#include <sof/platform.h>
+#include <sof/lib/notifier.h>
+#include <sof/audio/pipeline.h>
+#include <sof/audio/component_ext.h>
+#include <sof/trace/trace.h>
+
+/* Zephyr includes */
+#include <device.h>
+#include <soc.h>
+#include <kernel.h>
+
+/* Confirm Zephyr config settings - TODO: Use ASSERT */
+#if !defined(CONFIG_DYNAMIC_INTERRUPTS)
+#error Define CONFIG_DYNAMIC_INTERRUPTS
+#endif
+
+#if !defined(CONFIG_SYS_HEAP_ALIGNED_ALLOC)
+#error Define CONFIG_SYS_HEAP_ALIGNED_ALLOC
+#endif
 
 /*
- * Memory
+ * Memory - Create Zephyr HEAP for SOF.
+ *
+ * Currently functional but some items still WIP.
  */
+
+/* system size not declared on some platforms */
+#ifndef HEAP_SYSTEM_SIZE
+#define HEAP_SYSTEM_SIZE	0
+#endif
+
+/* The Zephyr heap - TODO: split heap */
+#define HEAP_SIZE	(HEAP_SYSTEM_SIZE + HEAP_RUNTIME_SIZE + HEAP_BUFFER_SIZE)
+uint8_t __aligned(64) heapmem[HEAP_SIZE];
+
+/* Use k_heap structure */
+static struct k_heap sof_heap;
+
+static int statics_init(struct device *unused)
+{
+	ARG_UNUSED(unused);
+
+	sys_heap_init(&sof_heap.heap, heapmem, HEAP_SIZE);
+
+	return 0;
+}
+
+SYS_INIT(statics_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_OBJECTS);
+
+static void *heap_alloc_aligned(struct k_heap *h, size_t align, size_t bytes)
+{
+	void *ret = NULL;
+
+	k_spinlock_key_t key = k_spin_lock(&h->lock);
+
+	ret = sys_heap_aligned_alloc(&h->heap, align, bytes);
+
+	k_spin_unlock(&h->lock, key);
+
+	return ret;
+}
+
+static void heap_free(struct k_heap *h, void *mem)
+{
+	k_spinlock_key_t key = k_spin_lock(&h->lock);
+
+	sys_heap_free(&h->heap, mem);
+
+	k_spin_unlock(&h->lock, key);
+}
+
 void *rmalloc(enum mem_zone zone, uint32_t flags, uint32_t caps, size_t bytes)
 {
-	// TODO: call Zephyr API
-	return NULL;
+	return heap_alloc_aligned(&sof_heap, 8, bytes);
+}
+
+/* Use SOF_MEM_ZONE_BUFFER at the moment */
+void *rbrealloc_align(void *ptr, uint32_t flags, uint32_t caps, size_t bytes,
+		      size_t old_bytes, uint32_t alignment)
+{
+	void *new_ptr;
+
+	if (!ptr) {
+		/* TODO: Use correct zone */
+		return rballoc_align(flags, caps, bytes, alignment);
+	}
+
+	/* Original version returns NULL without freeing this memory */
+	if (!bytes) {
+		/* TODO: Should we call rfree(ptr); */
+		LOG_ERR("realloc failed for %d bytes", bytes);
+		return NULL;
+	}
+
+	new_ptr = rballoc_align(flags, caps, bytes, alignment);
+	if (!new_ptr) {
+		return NULL;
+	}
+
+	if (!(flags & SOF_MEM_FLAG_NO_COPY)) {
+		memcpy(new_ptr, ptr, MIN(bytes, old_bytes));
+	}
+
+	rfree(ptr);
+
+	LOG_INF("rbealloc: new ptr %p", new_ptr);
+
+	return new_ptr;
 }
 
 /**
@@ -27,8 +130,11 @@ void *rmalloc(enum mem_zone zone, uint32_t flags, uint32_t caps, size_t bytes)
  */
 void *rzalloc(enum mem_zone zone, uint32_t flags, uint32_t caps, size_t bytes)
 {
-	// TODO: call Zephyr API
-	return NULL;
+	void *ptr = rmalloc(zone, flags, caps, bytes);
+
+	memset(ptr, 0, bytes);
+
+	return ptr;
 }
 
 /**
@@ -42,156 +148,172 @@ void *rzalloc(enum mem_zone zone, uint32_t flags, uint32_t caps, size_t bytes)
 void *rballoc_align(uint32_t flags, uint32_t caps, size_t bytes,
 		    uint32_t alignment)
 {
-	// TODO: call Zephyr API
-	return NULL;
+	return heap_alloc_aligned(&sof_heap, alignment, bytes);
 }
 
+/*
+ * Free's memory allocated by above alloc calls.
+ */
 void rfree(void *ptr)
 {
-	// TODO: call Zephyr API
+	if (!ptr)
+		return;
+
+	heap_free(&sof_heap, ptr);
 }
 
+/* debug only - only needed for linking */
 void heap_trace_all(int force)
 {
 }
 
 /*
- * Interrupts
+ * Interrupts.
+ *
+ * Mostly mapped. Still needs some linkage symbols that can be removed later.
  */
+
+/* needed for linkage only */
+const char irq_name_level2[] = "level2";
+const char irq_name_level5[] = "level5";
+
+/*
+ * CAVS IRQs are multilevel whereas BYT and BDW are DSP level only.
+ */
+int interrupt_get_irq(unsigned int irq, const char *cascade)
+{
+#if defined(CONFIG_SOC_SERIES_INTEL_ADSP_BAYTRAIL) ||\
+	defined(CONFIG_SOC_SERIES_INTEL_ADSP_BROADWELL)
+	return irq;
+#else
+	if (cascade == irq_name_level2)
+		return SOC_AGGREGATE_IRQ(irq, IRQ_NUM_EXT_LEVEL2);
+	if (cascade == irq_name_level5)
+		return SOC_AGGREGATE_IRQ(irq, IRQ_NUM_EXT_LEVEL5);
+
+	return SOC_AGGREGATE_IRQ(0, irq);
+#endif
+}
+
 int interrupt_register(uint32_t irq, void(*handler)(void *arg), void *arg)
 {
-	return 0;
+	return arch_irq_connect_dynamic(irq, 0, handler, arg, 0);
 }
 
+/* unregister an IRQ handler - matches on IRQ number and data ptr */
 void interrupt_unregister(uint32_t irq, const void *arg)
 {
+	/*
+	 * There is no "unregister" (or "disconnect") for
+	 * interrupts in Zephyr.
+	 */
+	z_soc_irq_disable(irq);
 }
 
+/* enable an interrupt source - IRQ needs mapped to Zephyr,
+ * arg is used to match.
+ */
 uint32_t interrupt_enable(uint32_t irq, void *arg)
 {
+	z_soc_irq_enable(irq);
+
 	return 0;
 }
 
+/* disable interrupt */
 uint32_t interrupt_disable(uint32_t irq, void *arg)
 {
-	return 0;
-}
+	z_soc_irq_disable(irq);
 
-void platform_interrupt_init(void)
-{
-}
-
-void platform_interrupt_set(uint32_t irq)
-{
-}
-
-void platform_interrupt_clear(uint32_t irq, uint32_t mask)
-{
-}
-
-uint32_t platform_interrupt_get_enabled(void)
-{
 	return 0;
 }
 
 void interrupt_mask(uint32_t irq, unsigned int cpu)
 {
+	/* TODO: how do we mask on other cores with Zephyr APIs */
 }
 
 void interrupt_unmask(uint32_t irq, unsigned int cpu)
 {
+	/* TODO: how do we unmask on other cores with Zephyr APIs */
 }
 
-void interrupt_init(struct sof *sof)
+void platform_interrupt_init(void)
 {
+	/* handled by zephyr - needed for linkage */
 }
 
-int interrupt_cascade_register(const struct irq_cascade_tmpl *tmpl)
+void platform_interrupt_set(uint32_t irq)
 {
-	return 0;
+	/* handled by zephyr - needed for linkage */
 }
 
-struct irq_cascade_desc *interrupt_get_parent(uint32_t irq)
+void platform_interrupt_clear(uint32_t irq, uint32_t mask)
 {
-	return NULL;
-}
-
-int interrupt_get_irq(unsigned int irq, const char *cascade)
-{
-	return 0;
-}
-
-const char irq_name_level2[] = "level2";
-const char irq_name_level5[] = "level5";
-
-/*
- * Scheduler
- */
-
-struct schedulers **arch_schedulers_get(void)
-{
-	return NULL;
-}
-
-int scheduler_init_ll(struct ll_schedule_domain *domain)
-{
-	return 0;
-}
-
-int schedule_task_init_ll(struct task *task,
-			  uint32_t uid, uint16_t type, uint16_t priority,
-			  enum task_state (*run)(void *data), void *data,
-			  uint16_t core, uint32_t flags)
-{
-	return 0;
-}
-
-int scheduler_init_edf(void)
-{
-	return 0;
-}
-
-int schedule_task_init_edf(struct task *task, uint32_t uid,
-			   const struct task_ops *ops,
-			   void *data, uint16_t core, uint32_t flags)
-{
-	return 0;
-}
-
-struct ll_schedule_domain *timer_domain_init(struct timer *timer, int clk,
-					     uint64_t timeout)
-{
-	return NULL;
-}
-
-struct ll_schedule_domain *dma_single_chan_domain_init(struct dma *dma_array,
-						       uint32_t num_dma,
-						       int clk)
-{
-	return NULL;
-}
-
-volatile void *task_context_get(void)
-{
-	return NULL;
+	/* handled by zephyr - needed for linkage */
 }
 
 /*
- * Timers
+ * Timers.
+ *
+ * Mostly mapped. TODO: align with 64bit Zephyr timers when they are upstream.
  */
 
-uint32_t arch_timer_get_system(struct timer *timer)
+uint64_t arch_timer_get_system(struct timer *timer)
 {
-	return 0;
+	return platform_timer_get(timer);
+}
+
+/* platform_timer_set() should not be called using Zephyr */
+int64_t platform_timer_set(struct timer *timer, uint64_t ticks)
+{
+#if defined(CONFIG_SOC_SERIES_INTEL_ADSP_BAYTRAIL)
+	return ticks;
+#else
+	/* TODO: needs BDW; should call Zephyr 64bit API ? */
+	return shim_read64(SHIM_DSPWCT0C);
+#endif
+}
+
+uint64_t platform_timer_get(struct timer *timer)
+{
+#if defined(CONFIG_SOC_SERIES_INTEL_ADSP_BAYTRAIL)
+	uint32_t low;
+	uint32_t high;
+	uint64_t time;
+
+	/* read low 32 bits */
+	low = shim_read(SHIM_EXT_TIMER_STAT);
+	/* TODO: check and see whether 32bit IRQ is pending for timer */
+	high = timer->hitime;
+
+	time = ((uint64_t)high << 32) | low;
+
+	return time;
+#elif defined(CONFIG_SOC_SERIES_INTEL_ADSP_BROADWELL)
+	return arch_timer_get_system(timer);
+#else
+	/* CAVS versions */
+	return shim_read64(SHIM_DSPWC);
+#endif
 }
 
 /*
- * Notifier
+ * Notifier.
+ *
+ * Use SOF inter component messaging today. Zephy has similar APIs that will
+ * need some minor feature updates prior to merge. i.e. FW to host messages.
+ * TODO: align with Zephyr API when ready.
  */
+
+static struct notify *host_notify;
 
 struct notify **arch_notify_get(void)
 {
-	return NULL;
+	if (!host_notify)
+		host_notify = rzalloc(SOF_MEM_ZONE_SYS, 0, SOF_MEM_CAPS_RAM,
+				      sizeof(*host_notify));
+	return &host_notify;
 }
 
 /*
@@ -199,22 +321,214 @@ struct notify **arch_notify_get(void)
  */
 void arch_dump_regs_a(void *dump_buf)
 {
-
+	/* needed for linkage only */
 }
 
 /*
- * Xtensa
+ * Xtensa. TODO: this needs removed and fixed in SOF.
  */
-
-unsigned int _xtos_ints_off( unsigned int mask )
+unsigned int _xtos_ints_off(unsigned int mask)
 {
+	/* turn all local IRQs OFF */
+	irq_lock();
 	return 0;
 }
 
 /*
- * entry
+ * Audio components.
+ *
+ * Integrated except for linkage so symbols are "used" here until linker
+ * support is ready in Zephyr. TODO: fix component linkage in Zephyr.
  */
+
+/* TODO: this is not yet working with Zephyr - section has been created but
+ *  no symbols are being loaded into ELF file.
+ */
+extern intptr_t _module_init_start;
+extern intptr_t _module_init_end;
+
+static void sys_module_init(void)
+{
+	intptr_t *module_init = (intptr_t *)(&_module_init_start);
+
+	for (; module_init < (intptr_t *)&_module_init_end; ++module_init)
+		((void(*)(void))(*module_init))();
+}
+
+/*
+ * TODO: all the audio processing components/modules constructor should be
+ * linked to the module_init section, but this is not happening. Just call
+ * constructors directly atm.
+ */
+
+void sys_comp_volume_init(void);
+void sys_comp_host_init(void);
+void sys_comp_mixer_init(void);
+void sys_comp_dai_init(void);
+void sys_comp_src_init(void);
+void sys_comp_mux_init(void);
+void sys_comp_selector_init(void);
+void sys_comp_switch_init(void);
+void sys_comp_tone_init(void);
+void sys_comp_eq_fir_init(void);
+void sys_comp_keyword_init(void);
+void sys_comp_asrc_init(void);
+void sys_comp_dcblock_init(void);
+void sys_comp_eq_iir_init(void);
+
 int task_main_start(struct sof *sof)
 {
+	int ret;
+
+	/* init default audio components */
+	sys_comp_init(sof);
+
+	/* init self-registered modules */
+	sys_module_init();
+
+	/* host is mandatory */
+	sys_comp_host_init();
+
+	if (IS_ENABLED(CONFIG_COMP_VOLUME)) {
+		sys_comp_volume_init();
+	}
+
+	if (IS_ENABLED(CONFIG_COMP_MIXER)) {
+		sys_comp_mixer_init();
+	}
+
+	if (IS_ENABLED(CONFIG_COMP_DAI)) {
+		sys_comp_dai_init();
+	}
+
+	if (IS_ENABLED(CONFIG_COMP_SRC)) {
+		sys_comp_src_init();
+	}
+
+	if (IS_ENABLED(CONFIG_COMP_SEL)) {
+		sys_comp_selector_init();
+	}
+
+	if (IS_ENABLED(CONFIG_COMP_SWITCH)) {
+		sys_comp_switch_init();
+	}
+
+	if (IS_ENABLED(CONFIG_COMP_TONE)) {
+		sys_comp_tone_init();
+	}
+
+	if (IS_ENABLED(CONFIG_COMP_FIR)) {
+		sys_comp_eq_fir_init();
+	}
+
+	if (IS_ENABLED(CONFIG_COMP_IIR)) {
+		sys_comp_eq_iir_init();
+	}
+
+	if (IS_ENABLED(CONFIG_COMP_KPB)) {
+		sys_comp_keyword_init();
+	}
+
+	if (IS_ENABLED(CONFIG_COMP_ASRC)) {
+		sys_comp_asrc_init();
+	}
+
+	if (IS_ENABLED(CONFIG_COMP_DCBLOCK)) {
+		sys_comp_dcblock_init();
+	}
+
+	if (IS_ENABLED(CONFIG_COMP_MUX)) {
+		sys_comp_mux_init();
+	}
+
+	/* init pipeline position offsets */
+	pipeline_posn_init(sof);
+
+	/* let host know DSP boot is complete */
+	ret = platform_boot_complete(0);
+
+	return ret;
+}
+
+/*
+ * Timestamps.
+ *
+ * TODO: move to generic code in SOF, currently platform code.
+ */
+
+/* get timestamp for host stream DMA position */
+void platform_host_timestamp(struct comp_dev *host,
+			     struct sof_ipc_stream_posn *posn)
+{
+	int err;
+
+	/* get host position */
+	err = comp_position(host, posn);
+	if (err == 0)
+		posn->flags |= SOF_TIME_HOST_VALID;
+}
+
+/* get timestamp for DAI stream DMA position */
+void platform_dai_timestamp(struct comp_dev *dai,
+			    struct sof_ipc_stream_posn *posn)
+{
+	int err;
+
+	/* get DAI position */
+	err = comp_position(dai, posn);
+	if (err == 0)
+		posn->flags |= SOF_TIME_DAI_VALID;
+
+	/* get SSP wallclock - DAI sets this to stream start value */
+	posn->wallclock = platform_timer_get(NULL) - posn->wallclock;
+	posn->wallclock_hz = clock_get_freq(PLATFORM_DEFAULT_CLOCK);
+	posn->flags |= SOF_TIME_WALL_VALID;
+}
+
+/* get current wallclock for componnent */
+void platform_dai_wallclock(struct comp_dev *dai, uint64_t *wallclock)
+{
+	*wallclock = platform_timer_get(NULL);
+}
+
+/*
+ * Multicore
+ *
+ * Mostly empty today waiting pending Zephyr CAVS SMP integration.
+ */
+#if CONFIG_MULTICORE
+int arch_cpu_enable_core(int id)
+{
+	/* TODO: call Zephyr API */
 	return 0;
 }
+
+void arch_cpu_disable_core(int id)
+{
+	/* TODO: call Zephyr API */
+}
+
+int arch_cpu_is_core_enabled(int id)
+{
+	/* TODO: call Zephyr API */
+	return 1;
+}
+
+void cpu_power_down_core(void)
+{
+	/* TODO: use Zephyr version */
+}
+
+int arch_cpu_enabled_cores(void)
+{
+	/* TODO: use zephyr version to get number of running cores */
+	return 1;
+}
+
+struct idc;
+struct idc **idc_get(void)
+{
+	/* TODO: this should return per core data */
+	return NULL;
+}
+#endif


### PR DESCRIPTION
This patch finalises the wrapper to allow LL scheduling of
timer domain audio, EDF sccheduling of IPC, trace re-direction
and kconfig build support.

There are still many items that are WIP and have been marked with
TODO: comments.

Signed-off-by: Liam Girdwood <liam.r.girdwood@linux.intel.com>