### PR TITLE
testbench: topology: check array size mismatch in various components

### DIFF
--- a/tools/testbench/topology.c
+++ b/tools/testbench/topology.c
@@ -184,6 +184,12 @@ static int tplg_load_fileread(int comp_id, int pipeline_id, int size,
 			return -EINVAL;
 		}
 
+		if (!is_valid_priv_size(total_array_size, size, array)) {
+			fprintf(stderr, "error: filewrite array size mismatch\n");
+			free(array);
+			return -EINVAL;
+		}
+
 		tplg_read_array(array, file);
 
 		/* parse comp tokens */

--- a/tools/testbench/topology.c
+++ b/tools/testbench/topology.c
@@ -240,6 +240,12 @@ static int tplg_load_filewrite(int comp_id, int pipeline_id, int size,
 			return -EINVAL;
 		}
 
+		if (!is_valid_priv_size(total_array_size, size, array)) {
+			fprintf(stderr, "error: filewrite array size mismatch\n");
+			free(array);
+			return -EINVAL;
+		}
+
 		tplg_read_array(array, file);
 
 		ret = sof_parse_tokens(&filewrite->config, comp_tokens,

--- a/tools/tplg_parser/include/tplg_parser/topology.h
+++ b/tools/tplg_parser/include/tplg_parser/topology.h
@@ -10,6 +10,7 @@
 #ifndef _COMMON_TPLG_H
 #define _COMMON_TPLG_H
 
+#include <stdbool.h>
 #include <sound/asoc.h>
 #include <ipc/dai.h>
 #include <kernel/tokens.h>

--- a/tools/tplg_parser/include/tplg_parser/topology.h
+++ b/tools/tplg_parser/include/tplg_parser/topology.h
@@ -269,5 +269,7 @@ int load_widget(void *dev, int dev_type, struct comp_info *temp_comp_list,
 
 void register_comp(int comp_type);
 int find_widget(struct comp_info *temp_comp_list, int count, char *name);
+bool is_valid_priv_size(size_t size_read, size_t priv_size,
+			struct snd_soc_tplg_vendor_array *array);
 
 #endif

--- a/tools/tplg_parser/tplg_parser.c
+++ b/tools/tplg_parser/tplg_parser.c
@@ -254,6 +254,13 @@ int tplg_load_pcm(int comp_id, int pipeline_id, int size, int dir,
 		if (ret != 1)
 			return -EINVAL;
 
+		/* check for array size mismatch */
+		if (!is_valid_priv_size(total_array_size, size, array)) {
+			fprintf(stderr, "error: load pcm array size mismatch\n");
+			free(array);
+			return -EINVAL;
+		}
+
 		ret = tplg_read_array(array, file);
 		if (ret) {
 			fprintf(stderr, "error: read array fail\n");
@@ -318,6 +325,13 @@ int tplg_load_dai(int comp_id, int pipeline_id, int size,
 		read_size = sizeof(struct snd_soc_tplg_vendor_array);
 		ret = fread(array, read_size, 1, file);
 		if (ret != 1) {
+			free(array);
+			return -EINVAL;
+		}
+
+		/* check for array size mismatch */
+		if (!is_valid_priv_size(total_array_size, size, array)) {
+			fprintf(stderr, "error: load dai array size mismatch\n");
 			free(array);
 			return -EINVAL;
 		}
@@ -458,14 +472,21 @@ int tplg_load_pipeline(int comp_id, int pipeline_id, int size,
 		read_size = sizeof(struct snd_soc_tplg_vendor_array);
 		ret = fread(array, read_size, 1, file);
 		if (ret != 1) {
-			free(array);
+			free((void *)array - total_array_size);
+			return -EINVAL;
+		}
+
+		/* check for array size mismatch */
+		if (!is_valid_priv_size(total_array_size, size, array)) {
+			fprintf(stderr, "error: load pipeline array size mismatch\n");
+			free((void *)array - total_array_size);
 			return -EINVAL;
 		}
 
 		ret = tplg_read_array(array, file);
 		if (ret) {
 			fprintf(stderr, "error: read array fail\n");
-			free(array);
+			free((void *)array - total_array_size);
 			return -EINVAL;
 		}
 
@@ -476,7 +497,7 @@ int tplg_load_pipeline(int comp_id, int pipeline_id, int size,
 		if (ret != 0) {
 			fprintf(stderr, "error: parse pipeline tokens %d\n",
 				size);
-			free(array);
+			free((void *)array - total_array_size);
 			return -EINVAL;
 		}
 
@@ -827,6 +848,13 @@ int tplg_load_src(int comp_id, int pipeline_id, int size,
 			return -EINVAL;
 		}
 
+		/* check for array size mismatch */
+		if (!is_valid_priv_size(total_array_size, size, array)) {
+			fprintf(stderr, "error: load src array size mismatch\n");
+			free(array);
+			return -EINVAL;
+		}
+
 		ret = tplg_read_array(array, file);
 		if (ret) {
 			fprintf(stderr, "error: read array fail\n");
@@ -895,6 +923,13 @@ int tplg_load_asrc(int comp_id, int pipeline_id, int size,
 		read_size = sizeof(struct snd_soc_tplg_vendor_array);
 		ret = fread(array, read_size, 1, file);
 		if (ret != 1) {
+			free(array);
+			return -EINVAL;
+		}
+
+		/* check for array size mismatch */
+		if (!is_valid_priv_size(total_array_size, size, array)) {
+			fprintf(stderr, "error: load asrc array size mismatch\n");
 			free(array);
 			return -EINVAL;
 		}
@@ -972,6 +1007,13 @@ int tplg_load_process(int comp_id, int pipeline_id, int size,
 			return -EINVAL;
 		}
 
+		/* check for array size mismatch */
+		if (!is_valid_priv_size(total_array_size, size, array)) {
+			fprintf(stderr, "error: load process array size mismatch\n");
+			free(array);
+			return -EINVAL;
+		}
+
 		ret = tplg_read_array(array, file);
 		if (ret) {
 			fprintf(stderr, "error: read array fail\n");
@@ -1041,6 +1083,13 @@ int tplg_load_mixer(int comp_id, int pipeline_id, int size,
 		read_size = sizeof(struct snd_soc_tplg_vendor_array);
 		ret = fread(array, read_size, 1, file);
 		if (ret != 1) {
+			free(array);
+			return -EINVAL;
+		}
+
+		/* check for array size mismatch */
+		if (!is_valid_priv_size(total_array_size, size, array)) {
+			fprintf(stderr, "error: load mixer array size mismatch\n");
 			free(array);
 			return -EINVAL;
 		}

--- a/tools/tplg_parser/tplg_parser.c
+++ b/tools/tplg_parser/tplg_parser.c
@@ -10,7 +10,6 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <stddef.h>
-#include <stdbool.h>
 #include <errno.h>
 #include <unistd.h>
 #include <string.h>
@@ -178,6 +177,13 @@ int tplg_load_buffer(int comp_id, int pipeline_id, int size,
 		if (ret != 1) {
 			fprintf(stderr,
 				"error: fread fail during load_buffer\n");
+			free(array);
+			return -EINVAL;
+		}
+
+		/* check for array size mismatch */
+		if (!is_valid_priv_size(parsed_size, size, array)) {
+			fprintf(stderr, "error: load buffer array size mismatch\n");
 			free(array);
 			return -EINVAL;
 		}

--- a/tools/tplg_parser/tplg_parser.c
+++ b/tools/tplg_parser/tplg_parser.c
@@ -61,7 +61,7 @@ static enum sof_comp_type find_process_comp_type(enum sof_ipc_process_type type)
 	return SOF_COMP_NONE;
 }
 
-static bool is_valid_priv_size(size_t size_read, size_t priv_size,
+bool is_valid_priv_size(size_t size_read, size_t priv_size,
 			      struct snd_soc_tplg_vendor_array *array)
 {
 	size_t arr_size, elem_size, arr_elems_size;


### PR DESCRIPTION
This patch uses the functionality added by the c9e090c commit
to check for array size mismatch in various components.

Not doing so may result in cases, where we try to write into the
space not allocated leading to segmentation fault.

Signed-off-by: Mohana Datta Yelugoti <ymdatta.work@gmail.com>