### PR TITLE
[PATCH RFC] host: Fix first period not being copied to/from host

### DIFF
--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -280,10 +280,6 @@ static int host_copy_one_shot(struct comp_dev *dev)
 
 	comp_dbg(dev, "host_copy_one_shot()");
 
-	/* update first transfer manually */
-	if (!dev->position)
-		host_one_shot_cb(dev, hd->dma_buffer->stream.size);
-
 	copy_bytes = host_get_copy_bytes_one_shot(dev);
 	if (!copy_bytes) {
 		comp_info(dev, "host_copy_one_shot(): no bytes to copy");


### PR DESCRIPTION
After commit 048145fe6006f8 ("pipeline: remove code related to preload")
buffers are no longer preloaded so we don't need to manually
update first period transfer.

Taking playback as an example, without this patch first period bytes
weren't copied downstream to DAIs removing typically first 0.1 seconds
from the input file.

With PCM streams this is not really noticeable. Anyhow, this becomes
a problem with compressed streams where we need every byte for
decompression.

Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>