### PR TITLE
test: Replace mockup buffer implementations with real ones.

### DIFF
--- a/test/cmocka/src/audio/buffer/buffer_wrap.c
+++ b/test/cmocka/src/audio/buffer/buffer_wrap.c
@@ -33,17 +33,26 @@ static void test_audio_buffer_write_fill_10_bytes_and_write_5(void **state)
 
 	uint8_t bytes[10] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-	memcpy_s(buf->stream.w_ptr, test_buf_desc.size, &bytes, 10);
-	comp_update_buffer_produce(buf, 10);
+	int i;
+	uint8_t *ptr;
 
-	assert_int_equal(audio_stream_get_avail_bytes(&buf->stream), 10);
+	for (i = 0; i < ARRAY_SIZE(bytes); i++) {
+		ptr = audio_stream_write_frag(&buf->stream, i, sizeof(uint8_t));
+		*ptr = bytes[i];
+	}
+	comp_update_buffer_produce(buf, sizeof(bytes));
+
+	assert_int_equal(audio_stream_get_avail_bytes(&buf->stream), sizeof(bytes));
 	assert_int_equal(audio_stream_get_free_bytes(&buf->stream), 0);
 	assert_ptr_equal(buf->stream.w_ptr, buf->stream.r_ptr);
 
 	uint8_t more_bytes[5] = {10, 11, 12, 13, 14};
 
-	memcpy_s(buf->stream.w_ptr, test_buf_desc.size, &more_bytes, 5);
-	comp_update_buffer_produce(buf, 5);
+	for (i = 0; i < ARRAY_SIZE(more_bytes); i++) {
+		ptr = audio_stream_write_frag(&buf->stream, i, sizeof(uint8_t));
+		*ptr = more_bytes[i];
+	}
+	comp_update_buffer_produce(buf, sizeof(more_bytes));
 
 	uint8_t ref_1[5] = {5, 6, 7, 8, 9};
 	uint8_t ref_2[5] = {10, 11, 12, 13, 14};
@@ -51,9 +60,15 @@ static void test_audio_buffer_write_fill_10_bytes_and_write_5(void **state)
 	assert_int_equal(audio_stream_get_avail_bytes(&buf->stream), 10);
 	assert_int_equal(audio_stream_get_free_bytes(&buf->stream), 0);
 	assert_ptr_equal(buf->stream.w_ptr, buf->stream.r_ptr);
-	assert_int_equal(memcmp(buf->stream.r_ptr, &ref_1, 5), 0);
-	comp_update_buffer_consume(buf, 5);
-	assert_int_equal(memcmp(buf->stream.r_ptr, &ref_2, 5), 0);
+	for (i = 0; i < ARRAY_SIZE(ref_1); i++) {
+		ptr = audio_stream_read_frag(&buf->stream, i, sizeof(uint8_t));
+		assert_int_equal(*ptr, ref_1[i]);
+	}
+	comp_update_buffer_consume(buf, sizeof(ref_1));
+	for (i = 0; i < ARRAY_SIZE(ref_2); i++) {
+		ptr = audio_stream_read_frag(&buf->stream, i, sizeof(uint8_t));
+		assert_int_equal(*ptr, ref_2[i]);
+	}
 
 	buffer_free(buf);
 }

--- a/test/cmocka/src/audio/mux/demux_copy.c
+++ b/test/cmocka/src/audio/mux/demux_copy.c
@@ -5,7 +5,7 @@
 // Author: Daniel Bogdzia <danielx.bogdzia@linux.intel.com>
 //         Janusz Jankowski <janusz.jankowski@linux.intel.com>
 
-#include "util.h"
+#include "../../util.h"
 
 #include <sof/audio/component_ext.h>
 #include <sof/audio/format.h>

--- a/test/cmocka/src/audio/mux/mux_copy.c
+++ b/test/cmocka/src/audio/mux/mux_copy.c
@@ -5,7 +5,7 @@
 // Author: Daniel Bogdzia <danielx.bogdzia@linux.intel.com>
 //         Janusz Jankowski <janusz.jankowski@linux.intel.com>
 
-#include "util.h"
+#include "../../util.h"
 
 #include <sof/audio/component_ext.h>
 #include <sof/audio/format.h>

--- a/test/cmocka/src/audio/mux/mux_get_processing_function.c
+++ b/test/cmocka/src/audio/mux/mux_get_processing_function.c
@@ -5,7 +5,7 @@
 // Author: Daniel Bogdzia <danielx.bogdzia@linux.intel.com>
 //         Janusz Jankowski <janusz.jankowski@linux.intel.com>
 
-#include "util.h"
+#include "../../util.h"
 
 #include <sof/audio/component_ext.h>
 #include <sof/audio/mux.h>

--- a/test/cmocka/src/audio/selector/CMakeLists.txt
+++ b/test/cmocka/src/audio/selector/CMakeLists.txt
@@ -14,6 +14,8 @@ add_compile_options(-DUNIT_TEST)
 add_library(audio_for_selector STATIC
 	${PROJECT_SOURCE_DIR}/src/audio/selector/selector.c
 	${PROJECT_SOURCE_DIR}/src/audio/selector/selector_generic.c
+	${PROJECT_SOURCE_DIR}/src/audio/buffer.c
+	${PROJECT_SOURCE_DIR}/test/cmocka/src/notifier_mocks.c
 )
 sof_append_relative_path_definitions(audio_for_selector)
 

--- a/test/cmocka/src/audio/volume/CMakeLists.txt
+++ b/test/cmocka/src/audio/volume/CMakeLists.txt
@@ -15,6 +15,8 @@ add_library(audio_for_volume STATIC
 	${PROJECT_SOURCE_DIR}/src/audio/volume/volume.c
 	${PROJECT_SOURCE_DIR}/src/audio/volume/volume_generic.c
 	${PROJECT_SOURCE_DIR}/src/audio/volume/volume_hifi3.c
+	${PROJECT_SOURCE_DIR}/src/audio/buffer.c
+	${PROJECT_SOURCE_DIR}/test/cmocka/src/notifier_mocks.c
 )
 sof_append_relative_path_definitions(audio_for_volume)
 

--- a/test/cmocka/src/util.h
+++ b/test/cmocka/src/util.h
@@ -7,7 +7,6 @@
 
 #include <sof/sof.h>
 #include <sof/audio/component.h>
-#include <sof/audio/mux.h>
 #include <sof/lib/alloc.h>
 
 #include <stdlib.h>


### PR DESCRIPTION
Currently unit tests utilize mock-up comp_buffer/audio_stream implementations, which would introduce overhead in upcoming buffer implementation changes, and are also obsolete in the tests themselves.
In this PR I've replaced mocked-up implementations in Volume and Selector unit tests with actual comp_buffer implementation.
Also Buffer UTs were modified to read/write byte by byte, to better imitate actual component behaviour.