### PR TITLE
cmake: set git hash to 8 digit

### DIFF
--- a/scripts/cmake/version.cmake
+++ b/scripts/cmake/version.cmake
@@ -83,7 +83,7 @@ if(EXISTS ${CMAKE_SOURCE_DIR}/.git/)
 	string(SUBSTRING ${SOF_SRC_HASH_LONG} 0 8 SOF_SRC_HASH)
 	message(STATUS "Source content hash: ${SOF_SRC_HASH}")
 else()
-	set(SOF_SRC_HASH ${GIT_LOG_HASH})
+	string(SUBSTRING ${GIT_LOG_HASH} 0 8 SOF_SRC_HASH)
 	message(WARNING "Source content hash can't be calculated, use GIT_LOG_HASH")
 endif()
 


### PR DESCRIPTION
GIT_LOG_HASH can be more than 8 digits. Limit hash value up to
first 8 digits.

fixes: #3322

Signed-off-by: Fred Oh <fred.oh@linux.intel.com>