### PR TITLE
zephyr: fix build for new sof git hashes.

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -514,7 +514,9 @@ add_definitions(-DXCC_TOOLS_VERSION="${ZEPHYR_TOOLCHAIN_VARIANT}" -DCC_OPTIMIZE_
 
 # create version information
 include(../scripts/cmake/version.cmake)
-add_definitions(-DSOF_MICRO=${SOF_MICRO} -DSOF_MINOR=${SOF_MINOR} -DSOF_MAJOR=${SOF_MAJOR} -DSOF_TAG="${SOF_TAG}")
+add_definitions(-DSOF_MICRO=${SOF_MICRO} -DSOF_MINOR=${SOF_MINOR})
+add_definitions(-DSOF_MAJOR=${SOF_MAJOR} -DSOF_TAG="${SOF_TAG}")
+add_definitions(-DSOF_SRC_HASH=0x${SOF_SRC_HASH} -DSOF_GIT_TAG="${SOF_GIT_TAG}")
 
 # Create Trace realtive file paths
 sof_append_relative_path_definitions(modules_sof)


### PR DESCRIPTION
Git hashes need exported for Zephyr build.

Signed-off-by: Liam Girdwood <liam.r.girdwood@linux.intel.com>