### PR TITLE
tools: testbench: initialize local variable before accessing it

### DIFF
--- a/tools/testbench/testbench.c
+++ b/tools/testbench/testbench.c
@@ -244,6 +244,7 @@ int main(int argc, char **argv)
 	tp.fs_out = 0;
 	tp.bits_in = 0;
 	tp.input_file = NULL;
+	tp.tplg_file = NULL;
 	for (i = 0; i < MAX_OUTPUT_FILE_NUM; i++)
 		tp.output_file[i] = NULL;
 	tp.output_file_num = 0;


### PR DESCRIPTION
If user fails to provide a topology file, the tplg_file member
of structure tp is left uninitialized. This member is used to
check again if the file was provided, which won't be possible
unless this has been initialized to NULL and checked for NULL
after parsing arguments.

Signed-off-by: Mohana Datta Yelugoti <ymdatta.work@gmail.com>