### PR TITLE
schedule: dma_multi_chan: fix a DMA channel interrupt race

### DIFF
--- a/src/include/sof/schedule/ll_schedule_domain.h
+++ b/src/include/sof/schedule/ll_schedule_domain.h
@@ -38,7 +38,7 @@ struct ll_schedule_domain_ops {
 	void (*domain_set)(struct ll_schedule_domain *domain, uint64_t start);
 	void (*domain_clear)(struct ll_schedule_domain *domain);
 	bool (*domain_is_pending)(struct ll_schedule_domain *domain,
-				  struct task *task);
+				  struct task *task, struct comp_dev **comp);
 };
 
 struct ll_schedule_domain {
@@ -151,13 +151,13 @@ static inline void domain_clear(struct ll_schedule_domain *domain)
 }
 
 static inline bool domain_is_pending(struct ll_schedule_domain *domain,
-				     struct task *task)
+				     struct task *task, struct comp_dev **comp)
 {
 	bool ret;
 
 	assert(domain->ops->domain_is_pending);
 
-	ret = domain->ops->domain_is_pending(domain, task);
+	ret = domain->ops->domain_is_pending(domain, task, comp);
 
 	platform_shared_commit(domain, sizeof(*domain));
 

--- a/src/schedule/dma_single_chan_domain.c
+++ b/src/schedule/dma_single_chan_domain.c
@@ -509,7 +509,7 @@ out:
  * \return True is task should be executed, false otherwise.
  */
 static bool dma_single_chan_domain_is_pending(struct ll_schedule_domain *domain,
-					      struct task *task)
+					      struct task *task, struct comp_dev **comp)
 {
 	return task->start <= platform_timer_get(timer_get());
 }

--- a/src/schedule/ll_schedule.c
+++ b/src/schedule/ll_schedule.c
@@ -59,16 +59,21 @@ static bool schedule_ll_is_pending(struct ll_schedule_data *sch)
 	struct list_item *tlist;
 	struct task *task;
 	uint32_t pending_count = 0;
+	struct comp_dev *sched_comp;
 
-	/* mark each valid task as pending */
-	list_for_item(tlist, &sch->tasks) {
-		task = container_of(tlist, struct task, list);
+	do {
+		sched_comp = NULL;
 
-		if (domain_is_pending(sch->domain, task)) {
-			task->state = SOF_TASK_STATE_PENDING;
-			pending_count++;
+		/* mark each valid task as pending */
+		list_for_item(tlist, &sch->tasks) {
+			task = container_of(tlist, struct task, list);
+
+			if (domain_is_pending(sch->domain, task, &sched_comp)) {
+				task->state = SOF_TASK_STATE_PENDING;
+				pending_count++;
+			}
 		}
-	}
+	} while (sched_comp);
 
 	return pending_count > 0;
 }

--- a/src/schedule/timer_domain.c
+++ b/src/schedule/timer_domain.c
@@ -269,7 +269,7 @@ static void timer_domain_clear(struct ll_schedule_domain *domain)
 }
 
 static bool timer_domain_is_pending(struct ll_schedule_domain *domain,
-				    struct task *task)
+				    struct task *task, struct comp_dev **comp)
 {
 	return task->start <= platform_timer_get(timer_get());
 }


### PR DESCRIPTION
When streaming audio data on multiple DMA channels simultaneously cases
with 3 tasks (A, B, and C), scheduled on 2 DMA channels (X and Y), have
been observed, when one of the tasks wasn't scheduled. Usually when
scanning tasks in schedule_ll_is_pending() the following sequence would
take place:
    channel    task    interrupt status
    X          A       1
    X          B       1
    Y          C       1
where the interrupt would be cleared in lines 2 and 3 above. However,
sometimes the following sequence takes place:
    channel    task    interrupt status
    X          A       0
    X          B       1
    Y          C       1
which then leaves task A not scheduled, because similar to the first case,
the interrupt on channel X will be cleared in line 2. To fix this modify
schedule_ll_is_pending() to handle DMA channels / scheduling components
one after another.

Fixes #3170 