### PR TITLE
[DON'T MERGE] topology: cht-max98090: set format S32_LE on SSP2.OUT

### DIFF
--- a/tools/topology/sof-cht-max98090.m4
+++ b/tools/topology/sof-cht-max98090.m4
@@ -38,12 +38,12 @@ PIPELINE_PCM_ADD(sof/pipe-low-latency-capture.m4,
 #
 
 # playback DAI is SSP2 using 2 periods
-# Buffers use s16le format, 1000us deadline on core 0 with priority 1
+# Buffers use s32le format, 1000us deadline on core 0 with priority 1
 # this defines pipeline 1. The 'NOT_USED_IGNORED' is due to dependencies
 # and is adjusted later with an explicit dapm line.
 DAI_ADD(sof/pipe-mixer-dai-playback.m4,
 	1, SSP, SSP_NUM, SSP2-Codec,
-	NOT_USED_IGNORED, 2, s16le,
+	NOT_USED_IGNORED, 2, s32le,
 	1000, 1, 0, SCHEDULE_TIME_DOMAIN_DMA,
 	2, 48000)
 


### PR DESCRIPTION
This is the fix for S32_LE/S24_LE format playback.

fixes: https://github.com/thesofproject/sof/issues/3340

Signed-off-by: Fred Oh <fred.oh@linux.intel.com>