### PR TITLE
BSW_MAX98090 (Cyan) temporary fix

### DIFF
--- a/src/audio/asrc/asrc.c
+++ b/src/audio/asrc/asrc.c
@@ -569,9 +569,8 @@ static int asrc_prepare(struct comp_dev *dev)
 						      cd->sink_frames);
 
 	if (sinkb->stream.size < config->periods_sink * sink_period_bytes) {
-		comp_err(dev, "asrc_prepare(), sink size=%d is insufficient, when periods=%d, period_bytes=%d",
-			 sinkb->stream.size, config->periods_sink,
-			 sink_period_bytes);
+		comp_err(dev, "asrc_prepare(): sink buffer size %d is insufficient < %d * %d",
+			 sinkb->stream.size, config->periods_sink, sink_period_bytes);
 		ret = -ENOMEM;
 		goto err;
 	}

--- a/src/audio/dcblock/dcblock.c
+++ b/src/audio/dcblock/dcblock.c
@@ -355,8 +355,8 @@ static int dcblock_prepare(struct comp_dev *dev)
 			audio_stream_period_bytes(&sinkb->stream, dev->frames);
 
 	if (sinkb->stream.size < config->periods_sink * sink_period_bytes) {
-		comp_err(dev, "dcblock_prepare(), sink buffer size %d is insufficient",
-			 sinkb->stream.size);
+		comp_err(dev, "dcblock_prepare(): sink buffer size %d is insufficient < %d * %d",
+			 sinkb->stream.size, config->periods_sink, sink_period_bytes);
 		ret = -ENOMEM;
 		goto err;
 	}

--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -720,7 +720,8 @@ static int eq_fir_prepare(struct comp_dev *dev)
 						      dev->frames);
 
 	if (sinkb->stream.size < config->periods_sink * sink_period_bytes) {
-		comp_err(dev, "eq_fir_prepare(): sink buffer size is insufficient");
+		comp_err(dev, "eq_fir_prepare(): sink buffer size %d is insufficient < %d * %d",
+			 sinkb->stream.size, config->periods_sink, sink_period_bytes);
 		ret = -ENOMEM;
 		goto err;
 	}

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -911,8 +911,8 @@ static int eq_iir_prepare(struct comp_dev *dev)
 						      dev->frames);
 
 	if (sinkb->stream.size < config->periods_sink * sink_period_bytes) {
-		comp_err(dev, "eq_iir_prepare(), sink buffer size %d is insufficient",
-			 sinkb->stream.size);
+		comp_err(dev, "eq_iir_prepare(): sink buffer size %d is insufficient < %d * %d",
+			 sinkb->stream.size, config->periods_sink, sink_period_bytes);
 		ret = -ENOMEM;
 		goto err;
 	}

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -192,7 +192,8 @@ static int mixer_params(struct comp_dev *dev,
 				source_list);
 
 	/* calculate period size based on config */
-	sink_period_bytes = dev->frames * audio_stream_frame_bytes(&sinkb->stream);
+	sink_period_bytes = audio_stream_period_bytes(&sinkb->stream,
+						      dev->frames);
 	if (sink_period_bytes == 0) {
 		comp_err(dev, "mixer_params(): period_bytes = 0");
 		return -EINVAL;

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -177,7 +177,7 @@ static int mixer_params(struct comp_dev *dev,
 {
 	struct sof_ipc_comp_config *config = dev_comp_config(dev);
 	struct comp_buffer *sinkb;
-	uint32_t period_bytes;
+	uint32_t sink_period_bytes;
 	int err;
 
 	comp_dbg(dev, "mixer_params()");
@@ -192,14 +192,15 @@ static int mixer_params(struct comp_dev *dev,
 				source_list);
 
 	/* calculate period size based on config */
-	period_bytes = dev->frames * audio_stream_frame_bytes(&sinkb->stream);
-	if (period_bytes == 0) {
+	sink_period_bytes = dev->frames * audio_stream_frame_bytes(&sinkb->stream);
+	if (sink_period_bytes == 0) {
 		comp_err(dev, "mixer_params(): period_bytes = 0");
 		return -EINVAL;
 	}
 
-	if (sinkb->stream.size < config->periods_sink * period_bytes) {
-		comp_err(dev, "mixer_params(): sink buffer size is insufficient");
+	if (sinkb->stream.size < config->periods_sink * sink_period_bytes) {
+		comp_err(dev, "mixer_params(): sink buffer size %d is insufficient < %d * %d",
+			 sinkb->stream.size, config->periods_sink, sink_period_bytes);
 		return -ENOMEM;
 	}
 

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -464,7 +464,8 @@ static int selector_prepare(struct comp_dev *dev)
 		  sinkb->stream.channels);
 
 	if (sinkb->stream.size < config->periods_sink * cd->sink_period_bytes) {
-		comp_err(dev, "selector_prepare(): sink buffer size is insufficient");
+		comp_err(dev, "selector_prepare(): sink buffer size %d is insufficient < %d * %d",
+			 sinkb->stream.size, config->periods_sink, cd->sink_period_bytes);
 		ret = -ENOMEM;
 		goto err;
 	}

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -833,7 +833,8 @@ static int src_prepare(struct comp_dev *dev)
 						      dev->frames);
 
 	if (sinkb->stream.size < config->periods_sink * sink_period_bytes) {
-		comp_err(dev, "src_prepare(): sink buffer size is insufficient");
+		comp_err(dev, "src_prepare(): sink buffer size %d is insufficient < %d * %d",
+			 sinkb->stream.size, config->periods_sink, sink_period_bytes);
 		ret = -ENOMEM;
 		goto err;
 	}

--- a/tools/topology/sof-cht-max98090.m4
+++ b/tools/topology/sof-cht-max98090.m4
@@ -24,10 +24,10 @@ include(`platform/intel/'PLATFORM`.m4')
 # PCM0 <---- Volume <---- SSP2
 #
 
-# Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s32le.
+# Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s16le.
 # 1000us deadline on core 0 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-low-latency-capture.m4,
-	2, 0, 2, s32le,
+	2, 0, 2, s16le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
@@ -47,21 +47,21 @@ DAI_ADD(sof/pipe-mixer-dai-playback.m4,
 	1000, 1, 0, SCHEDULE_TIME_DOMAIN_DMA,
 	2, 48000)
 
-# PCM Playback pipeline 3 on PCM 0 using max 2 channels of s32le.
+# PCM Playback pipeline 3 on PCM 0 using max 2 channels of s16le.
 # 1000us deadline on core 0 with priority 0
 # this is connected to pipeline DAI 1
 PIPELINE_PCM_ADD(sof/pipe-host-volume-playback.m4,
-	3, 0, 2, s32le,
+	3, 0, 2, s16le,
 	1000, 0, 0,
 	48000, 48000, 48000,
 	SCHEDULE_TIME_DOMAIN_DMA,
 	PIPELINE_PLAYBACK_SCHED_COMP_1)
 
-# PCM Playback pipeline 4 on PCM 1 using max 2 channels of s32le.
+# PCM Playback pipeline 4 on PCM 1 using max 2 channels of s16le.
 # 10ms deadline on core 0 with priority 0
 # this is connected to pipeline DAI 1
 PIPELINE_PCM_ADD(sof/pipe-host-volume-playback.m4,
-	4, 1, 2, s32le,
+	4, 1, 2, s16le,
 	10000, 0, 0,
 	48000, 48000, 48000,
 	SCHEDULE_TIME_DOMAIN_DMA,


### PR DESCRIPTION
Kernel CI reports issues with S24/S32_LE support [1], since we don't have a good solution for now limit the format to S16_LE. This error was always present but was only caught by a new test added a bit prematurely to the CI list.

We definitively want the code to support these two cases but if CI keeps complaining it makes the job of maintainers more complicated than it needs to be.

[1] https://sof-ci.01.org/softestpr/PR349/build106/devicetest/
