### PR TITLE
[WIP]audio: src: update component's value validation logic

### DIFF
--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -462,7 +462,7 @@ static struct comp_dev *src_new(const struct comp_driver *drv,
 	comp_cl_info(&comp_src, "src_new()");
 
 	/* validate init data - either SRC sink or source rate must be set */
-	if (ipc_src->source_rate == 0 && ipc_src->sink_rate == 0) {
+	if (ipc_src->source_rate == 0 || ipc_src->sink_rate == 0) {
 		comp_cl_err(&comp_src, "src_new(): SRC sink and source rate are not set");
 		return NULL;
 	}


### PR DESCRIPTION
In src component structure, for it to be valid, the source rate
and sink rate values aren't supposed to be zero.

The current logic check marks it as an error only if both
are zero, but even if one is zero, it's an error. The new
logic updates the check for the same.

Signed-off-by: Mohana Datta Yelugoti <ymdatta.work@gmail.com>