### PR TITLE
kconfig: select CAVS_USE_LPRO_IN_WAITI for TGL

### DIFF
--- a/src/platform/Kconfig
+++ b/src/platform/Kconfig
@@ -151,6 +151,7 @@ config TIGERLAKE
 	select CAVS_VERSION_2_5
 	select WAITI_DELAY
 	select NO_SLAVE_CORE_ROM
+	select CAVS_USE_LPRO_IN_WAITI
 	help
 	  Select if your target platform is Tigerlake-compatible
 


### PR DESCRIPTION
TGL have hardware requirement that DSP should use LPRO as clock source in waiti.