### PR TITLE
Audio: Volume: Avoid possible divide by zero trap

### DIFF
--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -866,7 +866,17 @@ static int volume_prepare(struct comp_dev *dev)
 	else
 		ramp_update_us = VOL_RAMP_UPDATE_SLOWEST_US;
 
-	cd->vol_ramp_frames = dev->frames / (dev->period / ramp_update_us);
+	/* The volume ramp is updated at least once per copy(). If the ramp update
+	 * period is larger than schedule period the frames count for update is set
+	 * to copy schedule equivalent number of frames. This also prevents a divide
+	 * by zero to happen with a combinations of topology parameters for the volume
+	 * component and the pipeline.
+	 */
+	if (ramp_update_us > dev->period)
+		cd->vol_ramp_frames = dev->frames;
+	else
+		cd->vol_ramp_frames = dev->frames / (dev->period / ramp_update_us);
+
 	return 0;
 
 err:


### PR DESCRIPTION
If in a topology the volume component ramp length (milliseconds) and
from it derived ramp update period is longer than pipeline copy()
schedule period the dev->frames (frames to process per per period) is
divided by zero. This error is not triggered by any of current
topologies.

The fix is to use dev->frames count as gain ramp update rate for
situations where the integer divider would round to zero. There is no
harm to update the gain at higher rate than suggested by topology.

Returning an error for such topologies also is not necessary since the
service is in such case done at better quality than requested. Finer
update grid results to less zipper noise.

Fixes commit 1b57609a1ef9 ("volume: do not schedule ramping as separate task")
Fixes #3334

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>