### PR TITLE
Tools: Fuzzer: Do not use illegal BUILD_COMMAND in CMakeLists.txt

### DIFF
--- a/tools/fuzzer/CMakeLists.txt
+++ b/tools/fuzzer/CMakeLists.txt
@@ -23,7 +23,6 @@ ExternalProject_Add(sof_parser_ep
 	BINARY_DIR "${PROJECT_BINARY_DIR}/sof_parser/build"
 	CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${parser_install_dir}
 		-DCMAKE_VERBOSE_MAKEFILE=${CMAKE_VERBOSE_MAKEFILE}
-	BUILD_COMMAND ${CMAKE_COMMAND}
 	BUILD_ALWAYS 1
 	BUILD_BYPRODUCTS "${parser_install_dir}/lib/libsof_tplg_parser.so"
 )


### PR DESCRIPTION
This patch removes the incorrect usage of BUILD_COMMAND. Having it set
to "cmake" caused the cmake usage help text output to be shown only and
caused the ExternalProject_Add command to believe the
libsof_tplg_parser.so was built. The build for the library happened only
because the next install step performed the compilation. With this fix
the default build command is used instead. There's no need to define
it here.

Fixes #2656

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
