### PR TITLE
comp: add comp_get_status() helper function

### DIFF
--- a/src/audio/smart_amp_test.c
+++ b/src/audio/smart_amp_test.c
@@ -438,8 +438,7 @@ static int smart_amp_copy(struct comp_dev *dev)
 	avail_frames = avail_passthrough_frames;
 
 	buffer_lock(sad->feedback_buf, &feedback_flags);
-	comp_invalidate(sad->feedback_buf->source);
-	if (sad->feedback_buf->source->state == dev->state) {
+	if (comp_get_state(dev, sad->feedback_buf->source) == dev->state) {
 		/* feedback */
 		avail_feedback_frames = audio_stream_get_avail_frames(&sad->feedback_buf->stream);
 

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -756,6 +756,23 @@ static inline void comp_writeback(struct comp_dev *dev)
 }
 
 /**
+ * Get component state.
+ *
+ * @param req_dev Requesting component
+ * @param dev Component from which user wants to read status.
+ */
+static inline int comp_get_state(struct comp_dev *req_dev, struct comp_dev *dev)
+{
+	/* we should not invalidate data when components are on the same
+	 * core, because we could invalidate data not previously writebacked
+	 */
+	if (req_dev->comp.core != dev->comp.core)
+		comp_invalidate(dev);
+
+	return dev->state;
+}
+
+/**
  * Frees data for large component configurations.
  *
  * @param dev Component device


### PR DESCRIPTION
This commit adds comp_get_status() helper function, which
takes two arguments: requesting component and component from
which user wants to read status. In case when both components
are on the different cores function additionally invokes
comp_invalidate().

This commit also fixes issue in smart_amp_copy() function, where
we always invoke comp_invalidate(sad->feedback_buf->source) whether
or not both components (smart amp and sad->feedback_buf->source)
are on different cores. In case when both components are on
the same core, we can invalidate data not previously writebacked.

Signed-off-by: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>