### PR TITLE
Trace throttling

### DIFF
--- a/src/init/init.c
+++ b/src/init/init.c
@@ -153,6 +153,8 @@ int master_core_init(int argc, char *argv[], struct sof *sof)
 	if (err < 0)
 		panic(SOF_IPC_PANIC_PLATFORM);
 
+	trace_ratelimit_init(sof);
+
 	trace_point(TRACE_BOOT_PLATFORM);
 
 #if CONFIG_NO_SLAVE_CORE_ROM

--- a/src/lib/agent.c
+++ b/src/lib/agent.c
@@ -67,8 +67,8 @@ static enum task_state validate(void *data)
 
 	/* warning timeout */
 	if (delta > sa->warn_timeout)
-		tr_warn(&sa_tr, "validate(), ll drift detected, delta = %u",
-			delta);
+		tr_info_t_ratelimit(&sa_tr, "validate(), ll drift detected, delta = %u",
+				    delta);
 
 	/* update last_check to current */
 	sa->last_check = current;

--- a/test/cmocka/src/common_mocks.c
+++ b/test/cmocka/src/common_mocks.c
@@ -11,6 +11,7 @@
 #include <sof/lib/mm_heap.h>
 #include <stdlib.h>
 #include <stdarg.h>
+#include <stdbool.h>
 #include <stddef.h>
 #include <setjmp.h>
 #include <stdint.h>
@@ -86,6 +87,13 @@ void WEAK trace_log(bool send_atomic, const void *log_entry,
 	(void) id_1;
 	(void) id_2;
 	(void) arg_count;
+}
+
+bool WEAK trace_ratelimit_time(struct trace_ratelimit *trtl)
+{
+	(void) trtl;
+
+	return true;
 }
 
 uint32_t WEAK _spin_lock_irq(spinlock_t *lock)


### PR DESCRIPTION
The first patch is mostly ready, constants can be tuned and made configurable, some other adjustments can be made, maybe the simple number-based throttling should be dropped completely. The second patch is just an example. From the first patch commit message:

trace: add trace throttling

Add two methods of trace message throttling: by time and by number. Throttling by time allows up to "burst" messages within a timeout, after that it blocks further messages from the same source. After the timeout expires, next time the same source sends a trace, the number of suppressed messages is printed and the throttling is reset.
Throttling by number is simpler: every time the trace count reaches the burst number, further messages from the same source are suppressed until the pre-configured number is reached. Then the same "suppressed" message is sent and throttling is reset.

Based in part on https://github.com/thesofproject/sof/commit/995da5a40fc8687f85d3d1ad039c996a78737ff4