### PR TITLE
rebuild-testbench.sh: remove CMAKE_VERBOSE_MAKEFILE

### DIFF
--- a/scripts/host-testbench.sh
+++ b/scripts/host-testbench.sh
@@ -73,6 +73,7 @@ else
   cat vol.log
   exit 1
 fi
+rm volume_out.raw vol.log
 
 # test with src
 echo "=========================================================="
@@ -92,6 +93,7 @@ else
   cat src.log
   exit 1
 fi
+rm src_out.raw src.log
 
 # test with eq
 echo "=========================================================="
@@ -112,3 +114,6 @@ else
   cat eqiir.log
   exit 1
 fi
+rm eqiir_out.raw eqiir.log
+
+rm zeros_in.raw

--- a/scripts/rebuild-testbench.sh
+++ b/scripts/rebuild-testbench.sh
@@ -23,11 +23,9 @@ rebuild_testbench()
     mkdir build_testbench
     cd build_testbench
 
-    cmake -DCMAKE_INSTALL_PREFIX=install \
-	  -DCMAKE_VERBOSE_MAKEFILE=ON \
-	  ..
+    cmake -DCMAKE_INSTALL_PREFIX=install  ..
 
-    make -j"$(nproc --all)"
+    make -j"$(nproc)"
     make install
 }
 


### PR DESCRIPTION
2 commits, see commit messages

Default is verbose enough. VERBOSE=1 can still be used later at make
time.

Also change nproc to nproc --all because we don't care about offline
processors.