### PR TITLE
Extract platform specific defines from the shared headers

### DIFF
--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -936,6 +936,7 @@ static int dai_config(struct comp_dev *dev, struct sof_ipc_dai_config *config)
 		dd->stream_id = config->alh.stream_id;
 		comp_info(dev, "dai_config(), channel = %d", channel);
 		break;
+#if IS_ENABLED(IMX)
 	case SOF_DAI_IMX_SAI:
 		handshake = dai_get_handshake(dd->dai, dai->direction,
 					      dd->stream_id);
@@ -952,6 +953,7 @@ static int dai_config(struct comp_dev *dev, struct sof_ipc_dai_config *config)
 		dd->config.burst_elems =
 			dd->dai->plat_data.fifo[dai->direction].depth;
 		break;
+#endif
 	default:
 		/* other types of DAIs not handled for now */
 		comp_err(dev, "dai_config(): Unknown dai type %d",

--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -869,7 +869,9 @@ static int dai_config(struct comp_dev *dev, struct sof_ipc_dai_config *config)
 	struct dai_data *dd = comp_get_drvdata(dev);
 	struct sof_ipc_comp_dai *dai = COMP_GET_IPC(dev, sof_ipc_comp_dai);
 	int channel = 0;
+#if IS_ENABLED(IMX)
 	int handshake;
+#endif
 	int ret = 0;
 
 	comp_info(dev, "dai_config() dai type = %d index = %d",

--- a/src/include/sof/drivers/edma.h
+++ b/src/include/sof/drivers/edma.h
@@ -8,6 +8,9 @@
 #ifndef __SOF_DRIVERS_EDMA_H__
 #define __SOF_DRIVERS_EDMA_H__
 
+#if IS_ENABLED(CONFIG_IMX_EDMA)
+
+#include <platform/drivers/edma.h>
 #include <sof/bit.h>
 #include <sof/trace/trace.h>
 #include <user/trace.h>
@@ -84,15 +87,6 @@
 #define EDMA_HANDSHAKE(irq, channel)\
 	(EDMA_HS_SET_CHAN(channel) | EDMA_HS_SET_IRQ(irq))
 
-#define EDMA0_ESAI_CHAN_RX	6
-#define EDMA0_ESAI_CHAN_TX	7
-#define EDMA0_SAI_CHAN_RX	14
-#define EDMA0_SAI_CHAN_TX	15
-#define EDMA0_CHAN_MAX		32
-
-#define EDMA0_ESAI_CHAN_RX_IRQ	442
-#define EDMA0_ESAI_CHAN_TX_IRQ	442
-#define EDMA0_SAI_CHAN_RX_IRQ	349
-#define EDMA0_SAI_CHAN_TX_IRQ	349
+#endif /* IS_ENABLED(CONFIG_IMX_EDMA) */
 
 #endif /* __SOF_DRIVERS_EDMA_H__ */

--- a/src/include/sof/drivers/esai.h
+++ b/src/include/sof/drivers/esai.h
@@ -8,6 +8,7 @@
 #ifndef __SOF_DRIVERS_ESAI_H__
 #define __SOF_DRIVERS_ESAI_H__
 
+#include <platform/drivers/esai.h>
 #include <sof/bit.h>
 #include <sof/lib/dai.h>
 #include <sof/trace/trace.h>
@@ -185,11 +186,6 @@
 #define ESAI_PCRC_PC(v)		SET_BITS(11, 0, v)
 
 #define ESAI_GPIO		MASK(11, 0)
-
-#define EDMA_ESAI_IRQ		442
-
-#define EDMA_ESAI_TX_CHAN	7
-#define EDMA_ESAI_RX_CHAN	6
 
 extern const struct dai_driver esai_driver;
 #endif /* __SOF_DRIVERS_ESAI_H__ */

--- a/src/include/sof/drivers/sdma.h
+++ b/src/include/sof/drivers/sdma.h
@@ -8,6 +8,10 @@
 #ifndef __SOF_DRIVERS_SDMA_H__
 #define __SOF_DRIVERS_SDMA_H__
 
+#if IS_ENABLED(IMX_SDMA)
+
+#include <platform/drivers/sdma.h>
+
 #define SDMA_MC0PTR		0x0000 /* platform 0 control block */
 #define SDMA_INTR		0x0004 /* Active interrupts, W1C */
 #define SDMA_STOP_STAT		0x0008 /* Channel stop/status, W1C */
@@ -144,11 +148,6 @@
 #define SDMA_CHAN_TYPE_SHP2MCU		3
 #define SDMA_CHAN_TYPE_MCU2SHP		4
 
-/* TODO check and move these to platform data */
-#define SDMA_SCRIPT_AP2AP_OFF		644
-#define SDMA_SCRIPT_AP2MCU_OFF		685
-#define SDMA_SCRIPT_MCU2AP_OFF		749
-#define SDMA_SCRIPT_SHP2MCU_OFF		893
-#define SDMA_SCRIPT_MCU2SHP_OFF		962
+#endif /* IS_ENABLED(IMX_SDMA) */
 
 #endif /* __SOF_DRIVERS_SDMA_H__ */

--- a/src/platform/imx8/include/platform/drivers/edma.h
+++ b/src/platform/imx8/include/platform/drivers/edma.h
@@ -1,0 +1,30 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright 2020 NXP
+ *
+ * Author: Paul Olaru <paul.olaru@nxp.com>
+ */
+
+#ifdef __SOF_DRIVERS_EDMA_H__
+
+#ifndef __PLATFORM_DRIVERS_EDMA_H__
+#define __PLATFORM_DRIVERS_EDMA_H__
+
+#define EDMA0_ESAI_CHAN_RX	6
+#define EDMA0_ESAI_CHAN_TX	7
+#define EDMA0_SAI_CHAN_RX	14
+#define EDMA0_SAI_CHAN_TX	15
+#define EDMA0_CHAN_MAX		32
+
+#define EDMA0_ESAI_CHAN_RX_IRQ	442
+#define EDMA0_ESAI_CHAN_TX_IRQ	442
+#define EDMA0_SAI_CHAN_RX_IRQ	349
+#define EDMA0_SAI_CHAN_TX_IRQ	349
+
+#endif /* __PLATFORM_DRIVERS_EDMA_H__ */
+
+#else /* __SOF_DRIVERS_EDMA_H__ */
+
+#error "This file shouldn't be included from outside of sof/drivers/edma.h"
+
+#endif /* __SOF_DRIVERS_EDMA_H__ */

--- a/src/platform/imx8/include/platform/drivers/esai.h
+++ b/src/platform/imx8/include/platform/drivers/esai.h
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright 2020 NXP
+ *
+ * Author: Paul Olaru <paul.olaru@nxp.com>
+ */
+
+#ifdef __SOF_DRIVERS_ESAI_H__
+
+#ifndef __PLATFORM_DRIVERS_ESAI_H__
+#define __PLATFORM_DRIVERS_ESAI_H__
+
+#define EDMA_ESAI_IRQ		442
+
+#define EDMA_ESAI_TX_CHAN	7
+#define EDMA_ESAI_RX_CHAN	6
+
+#endif /* __PLATFORM_DRIVERS_ESAI_H__ */
+
+#else /* __SOF_DRIVERS_ESAI_H__ */
+
+#error "This file shouldn't be included from outside of sof/drivers/esai.h"
+
+#endif /* __SOF_DRIVERS_ESAI_H__ */

--- a/src/platform/imx8m/include/platform/drivers/sdma.h
+++ b/src/platform/imx8m/include/platform/drivers/sdma.h
@@ -1,0 +1,25 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright 2020 NXP
+ *
+ * Author: Paul Olaru <paul.olaru@nxp.com>
+ */
+
+#ifdef __SOF_DRIVERS_SDMA_H__
+
+#ifndef __PLATFORM_DRIVERS_SDMA_H__
+#define __PLATFORM_DRIVERS_SDMA_H__
+
+#define SDMA_SCRIPT_AP2AP_OFF		644
+#define SDMA_SCRIPT_AP2MCU_OFF		685
+#define SDMA_SCRIPT_MCU2AP_OFF		749
+#define SDMA_SCRIPT_SHP2MCU_OFF		893
+#define SDMA_SCRIPT_MCU2SHP_OFF		962
+
+#endif /* __PLATFORM_DRIVERS_SDMA_H__ */
+
+#else /* __SOF_DRIVERS_SDMA_H__ */
+
+#error "This file shouldn't be included from outside of sof/drivers/sdma.h"
+
+#endif /* __SOF_DRIVERS_SDMA_H__ */


### PR DESCRIPTION
Some definitions in include/sof/drivers/*.h include highly platform specific defines that don't apply to all the platforms where these drivers exist.

This is just a cleanup PR.