### PR TITLE
logger: Create global convert_config variable to avoid spaghetti code.

### DIFF
--- a/tools/logger/convert.h
+++ b/tools/logger/convert.h
@@ -42,8 +42,8 @@ struct convert_config {
 	int hide_location;
 	int time_precision;
 	struct snd_sof_uids_header *uids_dict;
+	struct snd_sof_logs_header *logs_header;
 };
 
-uint32_t get_uuid_key(const struct snd_sof_uids_header *uids_dict,
-		      const struct sof_uuid_entry *entry);
+uint32_t get_uuid_key(const struct sof_uuid_entry *entry);
 int convert(struct convert_config *config);

--- a/tools/logger/filter.h
+++ b/tools/logger/filter.h
@@ -10,7 +10,6 @@
 
 #define FILTER_KERNEL_PATH "/sys/kernel/debug/sof/filter"
 
-int filter_update_firmware(const struct snd_sof_uids_header *uids_dict,
-			   char *input_str);
+int filter_update_firmware(void);
 
 #endif /* __LOGGER_FILTER_H__ */

--- a/tools/logger/misc.c
+++ b/tools/logger/misc.c
@@ -5,6 +5,7 @@
  * Author: Karol Trzcinski	<karolx.trzcinski@linux.intel.com>
  */
 
+#include "convert.h"
 #include <ctype.h>
 #include <stdarg.h>
 #include <stdio.h>
@@ -40,8 +41,11 @@ char *asprintf(const char *format, ...)
 	return result;
 }
 
-void log_err(FILE *out_fd, const char *fmt, ...)
+extern struct convert_config *global_config;
+
+void log_err(const char *fmt, ...)
 {
+	FILE *out_fd = global_config->out_fd;
 	static const char prefix[] = "error: ";
 	ssize_t needed_size;
 	va_list args, args_alloc;

--- a/tools/logger/misc.h
+++ b/tools/logger/misc.h
@@ -11,7 +11,7 @@
 char *vasprintf(const char *format, va_list args);
 char *asprintf(const char *format, ...);
 
-void log_err(FILE *out_fd, const char *fmt, ...);
+void log_err(const char *fmt, ...);
 
 /* trim whitespaces from string begin */
 char *ltrim(char *s);


### PR DESCRIPTION
Most functions in logger depend on values stored in conver_config struct
which are passed to almost all function calls. This patch moves pointer
to the config to global context and allows each function to derive
necessary values from there. This reduces needless parameters passed
to function calls and allows for more flexible access to data in nested
functions.

Signed-off-by: Artur Kloniecki <arturx.kloniecki@linux.intel.com>