### PR TITLE
 Pass uuid token to the smart_amp widget

### DIFF
--- a/tools/topology/m4/smart_amp.m4
+++ b/tools/topology/m4/smart_amp.m4
@@ -1,18 +1,16 @@
 divert(-1)
 
 dnl Define macro for smart_amp(Smart Amplifier) widget
-DECLARE_SOF_RT_UUID("smart_amp-test", smart_amp_comp_uuid, 0x167a961e, 0x8ae4,
-		 0x11ea, 0x89, 0xf1, 0x00, 0x0c, 0x29, 0xce, 0x16, 0x35)
 
 dnl SMART_AMP name)
 define(`N_SMART_AMP', `SMART_AMP'PIPELINE_ID`.'$1)
 
-dnl W_SMART_AMP(name, format, periods_sink, periods_source, kcontrols_list)
+dnl W_SMART_AMP(name, uuid, format, periods_sink, periods_source, kcontrols_list)
 define(`W_SMART_AMP',
 `SectionVendorTuples."'N_SMART_AMP($1)`_tuples_uuid" {'
 `	tokens "sof_comp_tokens"'
 `	tuples."uuid" {'
-`		SOF_TKN_COMP_UUID'		STR(smart_amp_comp_uuid)
+`		SOF_TKN_COMP_UUID'		STR($2)
 `	}'
 `}'
 `SectionData."'N_SMART_AMP($1)`_data_uuid" {'
@@ -21,8 +19,8 @@ define(`W_SMART_AMP',
 `SectionVendorTuples."'N_SMART_AMP($1)`_tuples_w" {'
 `	tokens "sof_comp_tokens"'
 `	tuples."word" {'
-`		SOF_TKN_COMP_PERIOD_SINK_COUNT'		STR($3)
-`		SOF_TKN_COMP_PERIOD_SOURCE_COUNT'	STR($4)
+`		SOF_TKN_COMP_PERIOD_SINK_COUNT'		STR($4)
+`		SOF_TKN_COMP_PERIOD_SOURCE_COUNT'	STR($5)
 `	}'
 `}'
 `SectionData."'N_SMART_AMP($1)`_data_w" {'
@@ -31,7 +29,7 @@ define(`W_SMART_AMP',
 `SectionVendorTuples."'N_SMART_AMP($1)`_tuples_str" {'
 `	tokens "sof_comp_tokens"'
 `	tuples."string" {'
-`		SOF_TKN_COMP_FORMAT'	STR($2)
+`		SOF_TKN_COMP_FORMAT'	STR($3)
 `	}'
 `}'
 `SectionVendorTuples."'N_SMART_AMP($1)`_process_tuples_str" {'
@@ -54,7 +52,7 @@ define(`W_SMART_AMP',
 `		"'N_SMART_AMP($1)`_data_str"'
 `	]'
 `	bytes ['
-		$5
+		$6
 `	]'
 `}')
 

--- a/tools/topology/sof-tgl-max98373-rt5682.m4
+++ b/tools/topology/sof-tgl-max98373-rt5682.m4
@@ -62,6 +62,10 @@ define(`SMART_REF_CH_NUM', 4)
 define(`SMART_PCM_ID', 0)
 define(`SMART_PCM_NAME', `smart373-spk')
 
+# UUID related
+DECLARE_SOF_RT_UUID("Maxim DSM", maxim_dsm_comp_uuid, 0x0cd84e80, 0xebd3,
+                    0x11ea, 0xad, 0xc1, 0x02, 0x42, 0xac, 0x12, 0x00, 0x02);
+define(`SMART_UUID', maxim_dsm_comp_uuid)
 # Include Smart Amplifier support
 include(`sof-smart-amplifier.m4')
 

--- a/tools/topology/sof/pipe-smart-amplifier-playback.m4
+++ b/tools/topology/sof/pipe-smart-amplifier-playback.m4
@@ -28,6 +28,9 @@ ifdef(`SMART_TX_CHANNELS',`',`errprint(note: Need to define DAI TX channel numbe
 ifdef(`SMART_FB_CHANNELS',`',`errprint(note: Need to define feedback channel number for sof-smart-amplifier
 )')
 
+DECLARE_SOF_RT_UUID("smart_amp-test", smart_amp_comp_uuid, 0x167a961e, 0x8ae4,
+		 0x11ea, 0x89, 0xf1, 0x00, 0x0c, 0x29, 0xce, 0x16, 0x35)
+ifdef(`SMART_UUID',`', `define(`SMART_UUID', smart_amp_comp_uuid)');
 #
 # Controls
 #
@@ -88,7 +91,7 @@ C_CONTROLBYTES_VOLATILE_READONLY(Smart_amp Model_Get_params, PIPELINE_ID,
 W_PCM_PLAYBACK(PCM_ID, Smart Amplifier Playback, 2, 0)
 
 # Mux 0 has 2 sink and source periods.
-W_SMART_AMP(0, PIPELINE_FORMAT, 2, 2, LIST(`             ', "Smart_amp Config", "Smart_amp Model",
+W_SMART_AMP(0, SMART_UUID, PIPELINE_FORMAT, 2, 2, LIST(`             ', "Smart_amp Config", "Smart_amp Model",
 	    ifelse(SOF_ABI_VERSION_3_17_OR_GRT, `1', "Smart_amp Model_Get_params")))
 
 # Low Latency Buffers


### PR DESCRIPTION
This patch set adds the uuid argument to smart_amp widget, uuid parameter can be configured by the topology files while integrating any new component. If not configured, uuid will be assigned with the UUID of the smart_amp_test component as default value.
It also includes the changes to sof-tgl-max98373-rt5682, to add the UUID of Maxim DSM component
