### PR TITLE
topology: use 16-bit data for MX98360A in I2S mode

### DIFF
--- a/tools/topology/platform/intel/jsl-dedede.m4
+++ b/tools/topology/platform/intel/jsl-dedede.m4
@@ -8,11 +8,11 @@ define(`SPK_INDEX', `1')
 define(`SPK_NAME', `SSP1-Codec')
 
 undefine(`SPK_DATA_FORMAT')
-define(`SPK_DATA_FORMAT', `s24le')
+define(`SPK_DATA_FORMAT', `s16le')
 
 define(`SET_SSP_CONFIG',
                 `SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24000000, codec_mclk_in),
-                        SSP_CLOCK(bclk, 2304000, codec_slave),
+                        SSP_CLOCK(bclk, 1536000, codec_slave),
                         SSP_CLOCK(fsync, 48000, codec_slave),
-                        SSP_TDM(2, 24, 3, 3),
-                        SSP_CONFIG_DATA(SSP, SPK_INDEX, 24, 0))')
+                        SSP_TDM(2, 16, 3, 3),
+                        SSP_CONFIG_DATA(SSP, SPK_INDEX, 16, 0))')


### PR DESCRIPTION
16 bits resolution is sufficient for spk playback.

Signed-off-by: Yong Zhi <yong.zhi@intel.com>