### PR TITLE
github: remove @tlauda from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,7 +2,7 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in the repo.
-*       @lgirdwood @plbossart @mmaka1 @lbetlej @dbaluta @tlauda @jajanusz
+*       @lgirdwood @plbossart @mmaka1 @lbetlej @dbaluta @jajanusz
 
 # Order is important. The last matching pattern has the most precedence.
 # So if a pull request only touches javascript files, only these owners
@@ -29,8 +29,6 @@ src/audio/dcblock*			@cujomalainey @dgreid
 src/audio/crossover*			@cujomalainey @dgreid
 
 # platforms
-src/arch/xtensa/*			@tlauda
-src/platform/*				@tlauda
 src/platform/baytrail/*			@xiulipan
 src/platform/haswell/*			@xiulipan @randerwang
 src/platform/suecreek/*			@lyakh
@@ -49,8 +47,8 @@ src/math/*				@singalsu
 src/ipc/*				@xiulipan @bardliao
 src/drivers/intel/cavs/sue-ipc.c	@lyakh
 src/lib/*				@libinyang
-src/debug/gdb/*			@mrajwa
-src/schedule				@tlauda @mrajwa
+src/debug/gdb/*				@mrajwa
+src/schedule				@mrajwa
 
 # other helpers
 test/**					@jajanusz


### PR DESCRIPTION
@tlauda is no longer a maintainer in SOF project.

Signed-off-by: Janusz Jankowski <janusz.jankowski@linux.intel.com>