### PR TITLE
uuid: use a pointer instead of casting it to an integer

### DIFF
--- a/src/include/sof/lib/dai.h
+++ b/src/include/sof/lib/dai.h
@@ -107,7 +107,7 @@ struct timestamp_ops {
 
 struct dai_driver {
 	uint32_t type;	/**< type, one of SOF_DAI_... */
-	uint32_t uid;
+	const struct sof_uuid_entry *uid;
 	struct tr_ctx *tctx;
 	uint32_t dma_caps;
 	uint32_t dma_dev;

--- a/src/include/sof/lib/uuid.h
+++ b/src/include/sof/lib/uuid.h
@@ -132,7 +132,7 @@ struct sof_uuid_entry {
  * \param uuid_name UUID symbol name declared with DECLARE_SOF_UUID() or
  *		    DECLARE_SOF_RT_UUID().
  */
-#define SOF_UUID(uuid_name) ((uintptr_t)&(uuid_name ## _ldc))
+#define SOF_UUID(uuid_name) (&(uuid_name ## _ldc))
 
 /** \brief Dereference unique 32-bit representation of UUID structure in runtime.
  *

--- a/src/include/sof/schedule/edf_schedule.h
+++ b/src/include/sof/schedule/edf_schedule.h
@@ -24,7 +24,7 @@ struct edf_task_pdata {
 
 int scheduler_init_edf(void);
 
-int schedule_task_init_edf(struct task *task, uint32_t uid,
+int schedule_task_init_edf(struct task *task, const struct sof_uuid_entry *uid,
 			   const struct task_ops *ops,
 			   void *data, uint16_t core, uint32_t flags);
 

--- a/src/include/sof/schedule/ll_schedule.h
+++ b/src/include/sof/schedule/ll_schedule.h
@@ -35,8 +35,8 @@ struct ll_task_pdata {
 int scheduler_init_ll(struct ll_schedule_domain *domain);
 
 int schedule_task_init_ll(struct task *task,
-			  uint32_t uid, uint16_t type, uint16_t priority,
-			  enum task_state (*run)(void *data), void *data,
-			  uint16_t core, uint32_t flags);
+			  const struct sof_uuid_entry *uid, uint16_t type,
+			  uint16_t priority, enum task_state (*run)(void *data),
+			  void *data, uint16_t core, uint32_t flags);
 
 #endif /* __SOF_SCHEDULE_LL_SCHEDULE_H__ */

--- a/src/include/sof/schedule/schedule.h
+++ b/src/include/sof/schedule/schedule.h
@@ -307,9 +307,9 @@ static inline void schedule_free(void)
  * @return 0 if succeeded, error code otherwise.
  */
 int schedule_task_init(struct task *task,
-		       uint32_t uid, uint16_t type, uint16_t priority,
-		       enum task_state (*run)(void *data), void *data,
-		       uint16_t core, uint32_t flags);
+		       const struct sof_uuid_entry *uid, uint16_t type,
+		       uint16_t priority, enum task_state (*run)(void *data),
+		       void *data, uint16_t core, uint32_t flags);
 
 /**
  * Initializes scheduler

--- a/src/include/sof/schedule/task.h
+++ b/src/include/sof/schedule/task.h
@@ -54,7 +54,7 @@ struct task_ops {
 /** \brief Task used by schedulers. */
 struct task {
 	uint64_t start;		/**< start time in [ms] since now (LL only) */
-	uint32_t uid;		/**< Uuid */
+	const struct sof_uuid_entry *uid; /**< Uuid */
 	uint16_t type;		/**< type of the task (LL or EDF) */
 	uint16_t priority;	/**< priority of the task (used by LL) */
 	uint16_t core;		/**< execution core */

--- a/src/include/sof/trace/trace.h
+++ b/src/include/sof/trace/trace.h
@@ -281,8 +281,8 @@ static inline void trace_init(struct sof *sof) { }
  * Trace context.
  */
 struct tr_ctx {
-	uintptr_t uuid_p;	/**< UUID pointer, use SOF_UUID() to init */
-	uint32_t level;		/**< Default log level */
+	const struct sof_uuid_entry *uuid_p;	/**< UUID pointer, use SOF_UUID() to init */
+	uint32_t level;				/**< Default log level */
 };
 
 #if defined(UNIT_TEST)

--- a/src/schedule/edf_schedule.c
+++ b/src/schedule/edf_schedule.c
@@ -131,7 +131,7 @@ static int schedule_edf_task(void *data, struct task *task, uint64_t start,
 	return 0;
 }
 
-int schedule_task_init_edf(struct task *task, uint32_t uid,
+int schedule_task_init_edf(struct task *task, const struct sof_uuid_entry *uid,
 			   const struct task_ops *ops,
 			   void *data, uint16_t core, uint32_t flags)
 {

--- a/src/schedule/ll_schedule.c
+++ b/src/schedule/ll_schedule.c
@@ -379,9 +379,9 @@ out:
 }
 
 int schedule_task_init_ll(struct task *task,
-			  uint32_t uid, uint16_t type, uint16_t priority,
-			  enum task_state (*run)(void *data), void *data,
-			  uint16_t core, uint32_t flags)
+			  const struct sof_uuid_entry *uid, uint16_t type,
+			  uint16_t priority, enum task_state (*run)(void *data),
+			  void *data, uint16_t core, uint32_t flags)
 {
 	struct ll_task_pdata *ll_pdata;
 	int ret = 0;

--- a/src/schedule/schedule.c
+++ b/src/schedule/schedule.c
@@ -22,9 +22,9 @@ DECLARE_SOF_UUID("schedule", sch_uuid, 0x3dee06de, 0xf25a, 0x4e10,
 DECLARE_TR_CTX(sch_tr, SOF_UUID(sch_uuid), LOG_LEVEL_INFO);
 
 int schedule_task_init(struct task *task,
-		       uint32_t uid, uint16_t type, uint16_t priority,
-		       enum task_state (*run)(void *data), void *data,
-		       uint16_t core, uint32_t flags)
+		       const struct sof_uuid_entry *uid, uint16_t type,
+		       uint16_t priority, enum task_state (*run)(void *data),
+		       void *data, uint16_t core, uint32_t flags)
 {
 	if (type >= SOF_SCHEDULE_COUNT) {
 		tr_err(&sch_tr, "schedule_task_init(): invalid task type");

--- a/src/trace/trace.c
+++ b/src/trace/trace.c
@@ -44,7 +44,7 @@ struct trace {
 
 #define TRACE_ID_MASK ((1 << TRACE_ID_LENGTH) - 1)
 
-static void put_header(uint32_t *dst, uint32_t id_0,
+static void put_header(uint32_t *dst, const struct sof_uuid_entry *uid,
 		       uint32_t id_1, uint32_t id_2,
 		       uint32_t entry, uint64_t timestamp)
 {
@@ -52,7 +52,7 @@ static void put_header(uint32_t *dst, uint32_t id_0,
 	struct log_entry_header header;
 	int ret;
 
-	header.uid = id_0;
+	header.uid = (uintptr_t)uid;
 	header.id_0 = id_1 & TRACE_ID_MASK;
 	header.id_1 = id_2 & TRACE_ID_MASK;
 	header.core_id = cpu_get_id();

--- a/test/cmocka/src/audio/pipeline/pipeline_mocks.c
+++ b/test/cmocka/src/audio/pipeline/pipeline_mocks.c
@@ -30,7 +30,8 @@ void platform_dai_timestamp(struct comp_dev *dai,
 	(void)posn;
 }
 
-int schedule_task_init(struct task *task, uint32_t uid, uint16_t type,
+int schedule_task_init(struct task *task,
+		       const struct sof_uuid_entry *uid, uint16_t type,
 		       uint16_t priority, enum task_state (*run)(void *data),
 		       void *data, uint16_t core, uint32_t flags)
 {
@@ -46,7 +47,8 @@ int schedule_task_init(struct task *task, uint32_t uid, uint16_t type,
 	return 0;
 }
 
-int schedule_task_init_ll(struct task *task, uint32_t uid, uint16_t type,
+int schedule_task_init_ll(struct task *task,
+			  const struct sof_uuid_entry *uid, uint16_t type,
 			  uint16_t priority, enum task_state (*run)(void *data),
 			  void *data, uint16_t core, uint32_t flags)
 {

--- a/tools/testbench/edf_schedule.c
+++ b/tools/testbench/edf_schedule.c
@@ -53,7 +53,7 @@ static int schedule_edf_task(void *data, struct task *task, uint64_t start,
 	return 0;
 }
 
-int schedule_task_init_edf(struct task *task, uint32_t uid,
+int schedule_task_init_edf(struct task *task, const struct sof_uuid_entry *uid,
 			   const struct task_ops *ops, void *data,
 			   uint16_t core, uint32_t flags)
 {

--- a/tools/testbench/ll_schedule.c
+++ b/tools/testbench/ll_schedule.c
@@ -7,10 +7,10 @@
 #include <sof/schedule/ll_schedule.h>
 #include <sof/schedule/schedule.h>
 
-int schedule_task_init_ll(struct task *task, uint32_t uid, uint16_t type,
-			  uint16_t priority,
-			  enum task_state (*run)(void *data), void *data,
-			  uint16_t core, uint32_t flags)
+int schedule_task_init_ll(struct task *task,
+			  const struct sof_uuid_entry *uid, uint16_t type,
+			  uint16_t priority, enum task_state (*run)(void *data),
+			  void *data, uint16_t core, uint32_t flags)
 {
 	return schedule_task_init(task, uid, type, priority, run, data, core,
 				  flags);

--- a/tools/testbench/schedule.c
+++ b/tools/testbench/schedule.c
@@ -20,7 +20,8 @@ struct schedulers **arch_schedulers_get(void)
 	return &testbench_schedulers_ptr;
 }
 
-int schedule_task_init(struct task *task, uint32_t uid, uint16_t type,
+int schedule_task_init(struct task *task,
+		       const struct sof_uuid_entry *uid, uint16_t type,
 		       uint16_t priority, enum task_state (*run)(void *data),
 		       void *data, uint16_t core, uint32_t flags)
 {

--- a/zephyr/edf_schedule.c
+++ b/zephyr/edf_schedule.c
@@ -104,7 +104,7 @@ int scheduler_init_edf(void)
 	return 0;
 }
 
-int schedule_task_init_edf(struct task *task, uint32_t uid,
+int schedule_task_init_edf(struct task *task, const struct sof_uuid_entry *uid,
 			   const struct task_ops *ops,
 			   void *data, uint16_t core, uint32_t flags)
 {
@@ -122,7 +122,8 @@ int schedule_task_init_edf(struct task *task, uint32_t uid,
 	return 0;
 }
 
-int schedule_task_init_edf_with_budget(struct task *task, uint32_t uid,
+int schedule_task_init_edf_with_budget(struct task *task,
+				       const struct sof_uuid_entry *uid,
 				       const struct task_ops *ops,
 				       void *data, uint16_t core,
 				       uint32_t flags, uint32_t cycles_budget)


### PR DESCRIPTION
UUID objects are represented by struct sof_uuid_entry instances in SOF. Instead of casting pointers to them to integers for passing around, carry them as pointers until they have to be cast to integers for packing into data structures. This also fixes printing UUID, using a "%pU" format.

with this patch, applied together with all other zephyr upstreaming patches, I can actually build zephyr+sof with no warnings