### PR TITLE
doc: annotate all ABI fields added/changed in 3.17 ABI

### DIFF
--- a/src/include/ipc/info.h
+++ b/src/include/ipc/info.h
@@ -54,7 +54,7 @@ struct sof_ipc_fw_version {
 	uint8_t time[10];
 	uint8_t tag[6];
 	uint32_t abi_version;
-	/* used to check FW and ldc file compatibility, reproducible value */
+	/** used to check FW and ldc file compatibility, reproducible value (ABI3.17) */
 	uint32_t src_hash;
 
 	/* reserved for future use */
@@ -109,7 +109,7 @@ struct sof_ipc_window_elem {
 struct sof_ipc_window {
 	struct sof_ipc_ext_data_hdr ext_hdr;
 	uint32_t num_windows;
-	struct sof_ipc_window_elem window[SOF_IPC_MAX_ELEMS];
+	struct sof_ipc_window_elem window[SOF_IPC_MAX_ELEMS]; /**< ABI3.17: Fixed size */
 } __attribute__((packed));
 
 /* extended data, compiler version */

--- a/src/include/ipc/topology.h
+++ b/src/include/ipc/topology.h
@@ -65,7 +65,7 @@ struct sof_ipc_comp {
 	uint32_t pipeline_id;
 	uint32_t core;
 
-	/* extended data length, 0 if no extended data */
+	/** extended data length, 0 if no extended data (ABI3.17) */
 	uint32_t ext_data_length;
 } __attribute__((packed));
 

--- a/src/include/kernel/ext_manifest.h
+++ b/src/include/kernel/ext_manifest.h
@@ -50,9 +50,9 @@ enum ext_man_elem_type {
 	EXT_MAN_ELEM_WINDOW		= SOF_IPC_EXT_WINDOW,
 	EXT_MAN_ELEM_CC_VERSION		= SOF_IPC_EXT_CC_INFO,
 	EXT_MAN_ELEM_PROBE_INFO		= SOF_IPC_EXT_PROBE_INFO,
-	EXT_MAN_ELEM_DBG_ABI		= SOF_IPC_EXT_USER_ABI_INFO,
-	EXT_MAN_ELEM_CONFIG_DATA	= 5,
-	EXT_MAN_ELEM_PLATFORM_CONFIG_DATA = 6,
+	EXT_MAN_ELEM_DBG_ABI		= SOF_IPC_EXT_USER_ABI_INFO, /**< ABI3.17 */
+	EXT_MAN_ELEM_CONFIG_DATA	= 5,    /**< ABI3.17 */
+	EXT_MAN_ELEM_PLATFORM_CONFIG_DATA = 6,  /**< ABI3.17 */
 };
 
 /* EXT_MAN_ELEM_CONFIG_DATA elements identificators */
@@ -100,7 +100,7 @@ struct ext_man_dbg_abi {
 	struct sof_ipc_user_abi_version dbg_abi;
 } __packed;
 
-/* EXT_MAN_ELEM_CONFIG_DATA elements */
+/** EXT_MAN_ELEM_CONFIG_DATA elements (ABI3.17) */
 struct ext_man_config_data {
 	struct ext_man_elem_header hdr;
 


### PR DESCRIPTION
Add a "ABImajor.minor" note to inline documentation of all
ABI interfaces that have been added or modified as part of
3.17 interface changes.

This is patch serves as an example for proposed new policy on this topic, making the annotations mandatory for any new change:
https://github.com/thesofproject/sof-docs/pull/283
