### PR TITLE
Fix playback issue on i.MX8MP

### DIFF
--- a/src/drivers/imx/sai.c
+++ b/src/drivers/imx/sai.c
@@ -31,6 +31,7 @@ static void sai_start(struct dai *dai, int direction)
 	dai_info(dai, "SAI: sai_start");
 
 	uint32_t xcsr = 0U;
+	int i;
 
 	/* enable DMA requests */
 	dai_update_bits(dai, REG_SAI_XCSR(direction),
@@ -41,10 +42,17 @@ static void sai_start(struct dai *dai, int direction)
 #endif
 
 	/* add one word to FIFO before TRCE is enabled */
-	if (direction == DAI_DIR_PLAYBACK)
+	if (direction == DAI_DIR_PLAYBACK) {
 		dai_write(dai, REG_SAI_TDR0, 0x0);
-	else
+		/* We could add quite a few more words; let's add
+		 * another 64, to fill the FIFO with a little bit of
+		 * silence...
+		 */
+		for (i = 0; i < 64; i++)
+			dai_write(dai, REG_SAI_TDR0, 0x0);
+	} else {
 		dai_write(dai, REG_SAI_RDR0, 0x0);
+	}
 
 	/* transmitter enable */
 	dai_update_bits(dai, REG_SAI_XCSR(direction),

--- a/src/drivers/imx/sdma.c
+++ b/src/drivers/imx/sdma.c
@@ -528,9 +528,8 @@ static int sdma_start(struct dma_chan_data *channel)
 		sdma_enable_event(channel);
 		dma_reg_update_bits(channel->dma, SDMA_HOSTOVR,
 				    BIT(channel->index), BIT(channel->index));
-	} else {
-		dma_reg_write(channel->dma, SDMA_HSTART, BIT(channel->index));
 	}
+	dma_reg_write(channel->dma, SDMA_HSTART, BIT(channel->index));
 
 	/* Set a runnable channel priority (channel 0 requires maximum priority)
 	 * so it remains usable even if others are schedulable.

--- a/src/drivers/imx/sdma.c
+++ b/src/drivers/imx/sdma.c
@@ -524,11 +524,13 @@ static int sdma_start(struct dma_chan_data *channel)
 	/* If channel is event driven, allow it to run by setting HOSTOVR.
 	 * If it's manually controlled, kickstart it by writing to SDMA_HSTART.
 	 */
-	if (pdata->hw_event != -1)
+	if (pdata->hw_event != -1) {
+		sdma_enable_event(channel);
 		dma_reg_update_bits(channel->dma, SDMA_HOSTOVR,
 				    BIT(channel->index), BIT(channel->index));
-	else
+	} else {
 		dma_reg_write(channel->dma, SDMA_HSTART, BIT(channel->index));
+	}
 
 	/* Set a runnable channel priority (channel 0 requires maximum priority)
 	 * so it remains usable even if others are schedulable.
@@ -555,6 +557,11 @@ static int sdma_stop(struct dma_chan_data *channel)
 
 	tr_dbg(&sdma_tr, "sdma_stop(%d)", channel->index);
 	if (pdata->hw_event != -1) {
+		/* Disable the event so no further requests are coming
+		 * XXX is this safe at this point or should I do it
+		 * after?
+		 */
+		sdma_disable_event(channel);
 		/* For event driven channels, disable them from running by
 		 * setting HOSTOVR to 0. Manually controlled channels need not
 		 * be stopped as they will finish their transfer and stop on
@@ -881,7 +888,6 @@ static int sdma_set_config(struct dma_chan_data *channel,
 	tr_dbg(&sdma_tr, "SDMA context uploaded");
 	/* Context uploaded, we can set up events now */
 	sdma_set_event(channel, pdata->hw_event);
-	sdma_enable_event(channel);
 
 	/* Finally set channel priority */
 	dma_reg_write(channel->dma, SDMA_CHNPRI(channel->index), SDMA_DEFPRI);

--- a/src/drivers/imx/sdma.c
+++ b/src/drivers/imx/sdma.c
@@ -797,9 +797,7 @@ static int sdma_prep_desc(struct dma_chan_data *channel,
 		if (!config->irq_disabled)
 			bd->config |= SDMA_BD_INT;
 
-		bd->config |= SDMA_BD_CONT;
-		if (pdata->next_bd == i)
-			bd->config |= SDMA_BD_DONE;
+		bd->config |= SDMA_BD_CONT | SDMA_BD_DONE;
 	}
 
 	/* Configure last BD to account for cyclic transfers */


### PR DESCRIPTION
Issue was that multiple consecutive playbacks would bring us in a weird state where the second/third/etc playback wouldn't actually consume data (no DMA interrupts)

These fixes both contribute to work around the state left after the first stop, so the second playback would start on a clean slate.

The root cause that was fixed by the patch "drivers: imx: sai: Add a small amount of silence on start trigger" was that the SAI would send no further DMA requests if it has already sent one and it isn't satisfied. The other patch improves the handling of hardware event triggers (DMA request based trigger) as well as that of SDMA buffer descriptors (now two descriptors ahead of the current one have the DONE bit set instead of just one, to counter for the fact that it is possible that the DMA might begin starting the descriptor two ahead before we had the time to set its DONE bit (that would cause the channel to stop completely)).

Base branch is i.MX release.