### PR TITLE
[WIP][RFC] add enum control to topology and test multiple controls with iir

### DIFF
--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -687,6 +687,9 @@ static int iir_cmd_get_data(struct comp_dev *dev,
 			ret = -EINVAL;
 		}
 		break;
+	case SOF_CTRL_CMD_ENUM:
+		comp_info(dev, "iir_cmd_get_data(), SOF_CTRL_CMD_ENUM");
+		break;
 	default:
 		comp_err(dev, "iir_cmd_get_data(), invalid command");
 		ret = -EINVAL;
@@ -777,6 +780,9 @@ static int iir_cmd_set_data(struct comp_dev *dev,
 			}
 		}
 		break;
+	case SOF_CTRL_CMD_ENUM:
+		comp_info(dev, "iir_cmd_set_data(), SOF_CTRL_CMD_ENUM");
+		break;
 	default:
 		comp_err(dev, "iir_cmd_set_data(), invalid command");
 		ret = -EINVAL;
@@ -800,6 +806,12 @@ static int eq_iir_cmd(struct comp_dev *dev, int cmd, void *data,
 		ret = iir_cmd_set_data(dev, cdata);
 		break;
 	case COMP_CMD_GET_DATA:
+		ret = iir_cmd_get_data(dev, cdata, max_data_size);
+		break;
+	case COMP_CMD_SET_VALUE:
+		ret = iir_cmd_set_data(dev, cdata);
+		break;
+	case COMP_CMD_GET_VALUE:
 		ret = iir_cmd_get_data(dev, cdata, max_data_size);
 		break;
 	default:

--- a/tools/topology/m4/enumcontrol.m4
+++ b/tools/topology/m4/enumcontrol.m4
@@ -1,0 +1,41 @@
+dnl ENUM_CHANNEL(name, reg, shift)
+define(`ENUM_CHANNEL',
+`channel.STR($1) {'
+`		reg STR($2)'
+`		shift STR($3)'
+`	}')
+
+
+dnl CONTROLENUM_OPS(info, comment, get, put)
+define(`CONTROLENUM_OPS',
+`ops."ctl" {'
+`		info STR($1)'
+`		#$2'
+`		get STR($3)'
+`		put STR($4)'
+`	}')
+
+dnl CONTROLENUM_LIST(name, enums_list)
+define(`CONTROLENUM_LIST',
+`SectionText.STR($1) {'
+`       values ['
+`           $2'
+`	    ]'
+`}')
+
+dnl C_CONTROLENUM(name, index, ops, ops, enums)
+define(`C_CONTROLENUM',
+`SectionControlEnum.STR($1) {'
+`'
+`	# control belongs to this index group'
+`	index STR($2)'
+`'
+`	# enum values as text'
+`	texts STR($3)'
+`'
+`	# channel register and shift for Front Left/Right'
+`	$4'
+`'
+`	# control uses bespoke driver get/put/info ID for io ops'
+`	$5'
+`}')

--- a/tools/topology/m4/eq_iir.m4
+++ b/tools/topology/m4/eq_iir.m4
@@ -60,6 +60,9 @@ define(`W_EQ_IIR',
 `	bytes ['
 		$6
 `	]'
+`	enum ['
+		$7
+`	]'
 `}')
 
 divert(0)dnl

--- a/tools/topology/sof/pipe-eq-iir-volume-capture.m4
+++ b/tools/topology/sof/pipe-eq-iir-volume-capture.m4
@@ -13,6 +13,7 @@ include(`dai.m4')
 include(`pipeline.m4')
 include(`bytecontrol.m4')
 include(`mixercontrol.m4')
+include(`enumcontrol.m4')
 include(`eq_iir.m4')
 
 define(`PGA_NAME', Dmic0)
@@ -61,6 +62,7 @@ W_DATA(DEF_PGA_CONF, DEF_PGA_TOKENS)
 define(DEF_EQIIR_COEF, concat(`eqiir_coef_', PIPELINE_ID))
 define(DEF_EQIIR_PRIV, concat(`eqiir_priv_', PIPELINE_ID))
 
+define(DEF_EQIIR_ENUM, concat(`eqiir_enum_', PIPELINE_ID))
 # By default, use 40 Hz highpass response with +0 dB gain for 48khz
 # TODO: need to implement middle level macro handler per pipeline
 ifdef(`DMICPROC_FILTER1', , `define(DMICPROC_FILTER1, eq_iir_coef_highpass_40hz_0db_48khz.m4)')
@@ -79,6 +81,17 @@ C_CONTROLBYTES(DEF_EQIIR_COEF, PIPELINE_ID,
 	,
 	DEF_EQIIR_PRIV)
 
+# EQ enum list
+CONTROLENUM_LIST(eq_preset, LIST(`	', `"preset1"', `"preset2"'))
+
+# EQ enum control
+C_CONTROLENUM(DEF_EQIIR_ENUM, PIPELINE_ID,
+	eq_preset,
+	LIST(`	', ENUM_CHANNEL(FL, 3, 0), ENUM_CHANNEL(FR, 3, 1)),
+	CONTROLENUM_OPS(enum,
+		257 binds the mixer control to enum get/put handlers,
+		257, 257))
+
 #
 # Components and Buffers
 #
@@ -94,7 +107,7 @@ W_PGA(0, PIPELINE_FORMAT, 2, 2, DEF_PGA_CONF, SCHEDULE_CORE,
 
 # "EQ 0" has 2 sink period and x source periods
 W_EQ_IIR(0, PIPELINE_FORMAT, 2, DAI_PERIODS, SCHEDULE_CORE,
-	LIST(`		', "DEF_EQIIR_COEF"))
+	LIST(`		', "DEF_EQIIR_COEF"), LIST(`		', "DEF_EQIIR_ENUM"))
 
 # Capture Buffers
 W_BUFFER(0, COMP_BUFFER_SIZE(2,


### PR DESCRIPTION
This PR is experimenting with having multiple different type controls 
in a single widget. So add enum control and test iir with simultaneous 
enum and byte control.