### PR TITLE
kpb: reduce buffer length on non-TGL platforms

### DIFF
--- a/src/include/sof/audio/kpb.h
+++ b/src/include/sof/audio/kpb.h
@@ -15,8 +15,16 @@
 struct comp_buffer;
 
 /* KPB internal defines */
+
+#ifdef CONFIG_TIGERLAKE
 #define KPB_MAX_BUFF_TIME 3000 /**< time of buffering in miliseconds */
 #define HOST_WAKEUP_TIME 1000 /* aprox. time of host DMA wakup from suspend [ms] */
+#else
+/** Due to memory constraints on non-TGL platforms, the buffers are smaller. */
+#define KPB_MAX_BUFF_TIME 2100 /**< time of buffering in miliseconds */
+#define HOST_WAKEUP_TIME 0 /* aprox. time of host DMA wakup from suspend [ms] */
+#endif
+
 #define KPB_MAX_DRAINING_REQ (KPB_MAX_BUFF_TIME - HOST_WAKEUP_TIME)
 #define KPB_MAX_SUPPORTED_CHANNELS 2 /**< number of supported channels */
 /**< number of samples taken each milisecond */


### PR DESCRIPTION
Due to memory constraints, the keyphrase buffer cannot be too long.
As a consequence of reducing the buffer,
platform wakeup margin check has to be removed as well,
otherwise the maximum draining request will be very short.

This is a temporary measure,
ultimately the buffer length and wakeup time settings
should be moved to the topology.

Signed-off-by: Slawomir Blauciak <slawomir.blauciak@linux.intel.com>