### PR TITLE
tools: support standard CMAKE_BUILD_TYPE and default to Debug

### DIFF
--- a/scripts/build-tools.sh
+++ b/scripts/build-tools.sh
@@ -27,11 +27,11 @@ reconfigure_build()
         mkdir "$BUILD_TOOLS_DIR"
 
         cd "$BUILD_TOOLS_DIR"
-        cmake ..
+        cmake -DCMAKE_BUILD_TYPE="$CMAKE_BUILD_TYPE" ..
 
         mkdir "$BUILD_TOOLS_DIR/fuzzer"
         cd "$BUILD_TOOLS_DIR/fuzzer"
-        cmake ../../fuzzer
+        cmake -DCMAKE_BUILD_TYPE="$CMAKE_BUILD_TYPE" ../../fuzzer
 }
 
 make_tool()

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -12,6 +12,11 @@ endif()
 
 project(SOF_TOOLS C)
 
+if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "No CMAKE_BUILD_TYPE, defaulting to Debug")
+  set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Build Type" FORCE)
+endif()
+
 set(SOF_ROOT_SOURCE_DIRECTORY "${PROJECT_SOURCE_DIR}/..")
 
 # checkout submodules


### PR DESCRIPTION
To produce the exact same binaries than before this commit:
```
  CMAKE_BUILD_TYPE='  ' ./scripts/build-tools.sh
```
To observe which CFLAGS are being used:
```
   CMAKE_BUILD_TYPE=Release VERBOSE=1 ./scripts/build-tools.sh
```
Off topic: the logger fails to build with: `-O3 -DNDEBUG -Wall -Werror`
(all other tools build fine with these flags)

Signed-off-by: Marc Herbert <marc.herbert@intel.com>