### PR TITLE
logger: add error message when reading sof/etrace instead of sof/trace

### DIFF
--- a/tools/logger/convert.c
+++ b/tools/logger/convert.c
@@ -630,8 +630,10 @@ static int logger_read(void)
 				freopen(NULL, "r", global_config->in_fd);
 				continue;
 			}
-
-			return -ferror(global_config->in_fd);
+			log_err("in %s(), fread(..., %s) failed: %s(%d)\n",
+				 __func__, global_config->in_file,
+				strerror(errno), errno);
+			return -errno;
 		}
 
 		/* checking if received trace address is located in

--- a/tools/logger/logger.c
+++ b/tools/logger/logger.c
@@ -150,7 +150,7 @@ static int append_filter_config(struct convert_config *config, const char *input
 
 	/* filer_config can't be NULL for following steps */
 	if (!old_config)
-		config->filter_config = asprintf("");
+		config->filter_config = asprintf("%s", "");
 
 	config->filter_config = asprintf("%s%s\n", config->filter_config, input);
 	free(old_config);

--- a/tools/logger/misc.h
+++ b/tools/logger/misc.h
@@ -9,8 +9,15 @@
 #include <stdlib.h>
 
 char *vasprintf(const char *format, va_list args);
+
+#ifdef __GNUC__
+__attribute__((format(printf, 1, 2)))
+#endif
 char *asprintf(const char *format, ...);
 
+#ifdef __GNUC__
+__attribute__((format(printf, 1, 2)))
+#endif
 void log_err(const char *fmt, ...);
 
 /* trim whitespaces from string begin */


### PR DESCRIPTION
2 commits. Main one:

Failing silently is not nice. Now prints instead:
```
  TIMESTAMP   DELTA C# COMPONENT   LOCATION   CONTENT
  error: in logger_read(), fread(..., /sys/kernel/debug/sof/etrace) \
    failed: Invalid argument(22)
```
Also make logger_read() and the process return [-]errno which can have
different values and some information instead of -ferror() which has
only one value (non-zero in theory, 1 in practice) hence no information.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>