### PR TITLE
test: pcm converter: Utilize comp_buffer implementation instead of mocking

### DIFF
--- a/test/cmocka/src/audio/pcm_converter/CMakeLists.txt
+++ b/test/cmocka/src/audio/pcm_converter/CMakeLists.txt
@@ -5,6 +5,8 @@ if(CONFIG_FORMAT_FLOAT)
 		pcm_float.c
 		${PROJECT_SOURCE_DIR}/src/audio/pcm_converter/pcm_converter.c
 		${PROJECT_SOURCE_DIR}/src/audio/pcm_converter/pcm_converter_generic.c
+		${PROJECT_SOURCE_DIR}/src/audio/buffer.c
+		${PROJECT_SOURCE_DIR}/test/cmocka/src/notifier_mocks.c
 	)
 	target_include_directories(pcm_float_generic PRIVATE ${PROJECT_SOURCE_DIR}/src/include)
 	target_compile_definitions(pcm_float_generic PRIVATE PCM_CONVERTER_GENERIC)

--- a/test/cmocka/src/util.h
+++ b/test/cmocka/src/util.h
@@ -28,7 +28,8 @@ static inline struct comp_buffer *create_test_sink(struct comp_dev *dev,
 	memset(buffer->stream.addr, 0, buffer_size);
 
 	/* set bsink list */
-	list_item_append(&buffer->source_list, &dev->bsink_list);
+	if (dev)
+		list_item_append(&buffer->source_list, &dev->bsink_list);
 
 	/* alloc sink and set default parameters */
 	buffer->sink = calloc(1, sizeof(struct comp_dev));
@@ -62,7 +63,8 @@ static inline struct comp_buffer *create_test_source(struct comp_dev *dev,
 	memset(buffer->stream.addr, 0, buffer_size);
 
 	/*set bsource list */
-	list_item_append(&buffer->sink_list, &dev->bsource_list);
+	if (dev)
+		list_item_append(&buffer->sink_list, &dev->bsource_list);
 
 	/* alloc source and set default parameters */
 	buffer->source = calloc(1, sizeof(struct comp_dev));


### PR DESCRIPTION
Currently pcm converter unit tests use mocked-up audio_stream
implementation which should be replaced with real FW implementation.

Signed-off-by: Artur Kloniecki <arturx.kloniecki@linux.intel.com>