### PR TITLE
smart_amp: remove hardcoded frame_fmt value

### DIFF
--- a/src/audio/smart_amp_test.c
+++ b/src/audio/smart_amp_test.c
@@ -535,12 +535,6 @@ static int smart_amp_prepare(struct comp_dev *dev)
 	buffer_lock(sad->feedback_buf, &flags);
 	sad->feedback_buf->stream.channels = sad->config.feedback_channels;
 	sad->feedback_buf->stream.rate = sad->source_buf->stream.rate;
-
-	/* TODO:
-	 * ATM feedback buffer frame_fmt is hardcoded to s32_le. It should be
-	 * removed when parameters negotiation between pipelines will prepared
-	 */
-	sad->feedback_buf->stream.frame_fmt = SOF_IPC_FRAME_S32_LE;
 	buffer_unlock(sad->feedback_buf, flags);
 
 	sad->process = get_smart_amp_process(dev);


### PR DESCRIPTION
In order to allow stream different audio formats,
the hardcodec frame fmt value should be removed.

Signed-off-by: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>