### PR TITLE
topology: Update tplg file name for tgl system with max98373-rt5682

### DIFF
--- a/tools/topology/CMakeLists.txt
+++ b/tools/topology/CMakeLists.txt
@@ -137,7 +137,7 @@ set(TPLGS
 	"sof-imx8qxp-wm8960\;sof-imx8qxp-wm8960"
 	"sof-tgl-max98357a-rt5682\;sof-tgl-max98357a-rt5682"
 	"sof-tgl-max98373-rt5682\;sof-tgl-max98373-rt5682\;-DAMP_SSP=1"
-	"sof-tgl-max98373-rt5682\;sof-tgl-max98373-rt5682-ssp2\;-DAMP_SSP=2"
+	"sof-tgl-max98373-rt5682\;sof-tgl-rt5682-ssp0-max98373-ssp2\;-DAMP_SSP=2"
 	"sof-tgl-sdw-max98373-rt5682\;sof-tgl-sdw-max98373-rt5682-2ch\;-DCHANNELS=2"
 	"sof-tgl-sdw-max98373-rt5682\;sof-tgl-sdw-max98373-rt5682-4ch\;-DCHANNELS=4"
 	"sof-jsl-da7219\;sof-jsl-da7219\;-DPLATFORM=jsl"


### PR DESCRIPTION
Changed the tplg file name in kernel driver according to Maintainers
feedback. So, topology file name here needs the corresponding change.

As part of the below PR, Pierre suggested us to change the name:
https://github.com/thesofproject/linux/pull/2345