### PR TITLE
travis: run build-tools.sh with CMAKE_BUILD_TYPE=Release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,9 +38,9 @@ jobs:
     - <<: *build-platform
       env: PLATFORM='tgl'
 
-    - name: "./scripts/build-tools.sh"
+    - name: "./scripts/build-tools.sh Release"
       before_install: *docker-pull-sof
-      script: ./scripts/docker-run.sh ./scripts/build-tools.sh
+      script: CMAKE_BUILD_TYPE=Release ./scripts/docker-run.sh ./scripts/build-tools.sh
 
     - name: "./scripts/host-build-all.sh"
       before_install: *docker-pull-sof

--- a/scripts/docker-run.sh
+++ b/scripts/docker-run.sh
@@ -10,5 +10,5 @@
 #  To build topology:
 #  ./scripts/docker-run.sh ./scripts/build-tools.sh
 
-docker run -i -t -v `pwd`:/home/sof/work/sof.git \
-	   --user `id -u` sof $@
+docker run -i -t -v "$(pwd)":/home/sof/work/sof.git \
+	   --user "$(id -u)" sof "$@"

--- a/scripts/docker-run.sh
+++ b/scripts/docker-run.sh
@@ -11,4 +11,5 @@
 #  ./scripts/docker-run.sh ./scripts/build-tools.sh
 
 docker run -i -t -v "$(pwd)":/home/sof/work/sof.git \
+	--env CMAKE_BUILD_TYPE \
 	   --user "$(id -u)" sof "$@"


### PR DESCRIPTION
For some reason gcc prints more warnings this way and of course CI is
meant to catch warnings as soon as possible.
