### PR TITLE
dai: Add warning about possible glitch

### DIFF
--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -837,6 +837,16 @@ static int dai_copy(struct comp_dev *dev)
 		 dev->direction, copy_bytes,
 		 samples / buf->stream.channels);
 
+	/* Check possibility of glitch occurrence */
+	if (dev->direction == SOF_IPC_STREAM_PLAYBACK &&
+	    copy_bytes + avail_bytes < dd->period_bytes)
+		comp_warn(dev, "dai_copy(): Copy_bytes %d + avail bytes %d < period bytes %d, possible glitch",
+			  copy_bytes, avail_bytes, dd->period_bytes);
+	else if (dev->direction == SOF_IPC_STREAM_CAPTURE &&
+		 copy_bytes + free_bytes < dd->period_bytes)
+		comp_warn(dev, "dai_copy(): Copy_bytes %d + free bytes %d < period bytes %d, possible glitch",
+			  copy_bytes, free_bytes, dd->period_bytes);
+
 	/* return if nothing to copy */
 	if (!copy_bytes) {
 		comp_warn(dev, "dai_copy(): nothing to copy");


### PR DESCRIPTION
DMA should be loaded at least with data for one period
otherwise glitches are supposed to appear. Such a kind of
problem is quite difficult to track, because it may be related
with scheduling in runtime, DSP load, or used buffers size,
so log message pointing possible source of glitch is useful.

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>