### PR TITLE
build-tools.sh: remove all the "Entering directory..." noise

### DIFF
--- a/scripts/build-tools.sh
+++ b/scripts/build-tools.sh
@@ -39,13 +39,21 @@ make_tool()
         # if no argument provided, all the tools will be built. Empty tool is
         # okay.
         tool=$1
-        # shellcheck disable=SC2086
-        make -C "$BUILD_TOOLS_DIR" -j "$NO_PROCESSORS" $tool
+
+        # 'cd' is unfortunately much less verbose than 'make -C'.
+        # 'MAKEFLAGS=--no-print-directory' works too but let's not
+        # interfere with the user's environment.
+        ( cd "$BUILD_TOOLS_DIR"
+         # shellcheck disable=SC2086
+          make -j "$NO_PROCESSORS" $tool
+        )
 }
 
 make_fuzzer()
 {
-        make -C "$BUILD_TOOLS_DIR/fuzzer" -j "$NO_PROCESSORS"
+        ( cd "$BUILD_TOOLS_DIR"/fuzzer
+          make -j "$NO_PROCESSORS"
+        )
 }
 
 print_build_info()


### PR DESCRIPTION
This gets rid of about 600 lines of noisy "Entering directory..."
messages which cuts the size of the output of the script in half leaving
only useful stuff on the screen. This (and other changes before it) may
finally avoid bugs like 'commit f430addec752 ("Tools: Fuzzer: Do not use
illegal BUILD_COMMAND in CMakeLists.txt") evading scrutiny for months.

After so many years enjoying the convenience of make's '-C' option, I
finally did some research and realized it is the cause of this very
serious noise issue with no other easy way out :-(

Signed-off-by: Marc Herbert <marc.herbert@intel.com>