### PR TITLE
travis: remove duplicate and deprecated host-build-all.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,11 +44,6 @@ jobs:
       before_install: *docker-pull-sof
       script: CMAKE_BUILD_TYPE=Release ./scripts/docker-run.sh ./scripts/build-tools.sh
 
-    - name: "./scripts/host-build-all.sh"
-      before_install: *docker-pull-sof
-      script: ./scripts/docker-run.sh ./scripts/host-build-all.sh -l
-
-
     # stage tests
 
     - &qemuboottest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
-sudo: required
+---
+# Suggested tools that can save round-trips to github and a lot of time:
+#
+# yamllint .travis.yml
+# ~/.gem/ruby/2.7.0/bin/travis lint .travis.yml
+# yaml merge-expand .travis.yml exp.yml && diff -b -u .travis.yml exp.yml
 
 language: c
 


### PR DESCRIPTION
2 commits. Main one:

travis: remove duplicate and deprecated host-build-all.sh

We already build _and_ run the testbench in the next stage, with the
newer script. No need to build the same thing twice.