### PR TITLE
[RFC] Use inclusive language for DAI

### DIFF
--- a/src/drivers/imx/esai.c
+++ b/src/drivers/imx/esai.c
@@ -162,21 +162,21 @@ static inline int esai_set_config(struct dai *dai,
 		return -EINVAL;
 	}
 
-	switch (config->format & SOF_DAI_FMT_MASTER_MASK) {
-	case SOF_DAI_FMT_CBM_CFM:
+	switch (config->format & SOF_DAI_FMT_CLOCK_PROVIDER_MASK) {
+	case SOF_DAI_FMT_CBP_CFP:
 		/* Nothing to do in the registers */
 		break;
-	case SOF_DAI_FMT_CBM_CFS:
+	case SOF_DAI_FMT_CBP_CFC:
 		xccr |= ESAI_xCCR_xFSD;
 		break;
-	case SOF_DAI_FMT_CBS_CFM:
+	case SOF_DAI_FMT_CBC_CFP:
 		xccr |= ESAI_xCCR_xCKD;
 		break;
-	case SOF_DAI_FMT_CBS_CFS:
+	case SOF_DAI_FMT_CBC_CFC:
 		xccr |= ESAI_xCCR_xFSD | ESAI_xCCR_xCKD;
 		break;
 	default:
-		dai_err(dai, "ESAI: Invalid clock master-slave configuration");
+		dai_err(dai, "ESAI: Invalid clock provider-consumer configuration");
 		return -EINVAL;
 	}
 
@@ -204,8 +204,8 @@ static inline int esai_set_config(struct dai *dai,
 
 	dai_update_bits(dai, REG_ESAI_TCCR, mask, xccr);
 	/* There is a hardware limitation which prevents tx and rx to be
-	 * simultaneously master or simultaneously slave. As a workaround,
-	 * we will leave tx as master and set rx as slave.
+	 * simultaneously provider or simultaneously consumer. As a workaround,
+	 * we will leave tx as provider and set rx as consumer.
 	 */
 	xccr &= ~(ESAI_xCCR_xCKD | ESAI_xCCR_xFSD);
 	dai_update_bits(dai, REG_ESAI_RCCR, mask, xccr);

--- a/src/drivers/imx/sai.c
+++ b/src/drivers/imx/sai.c
@@ -198,27 +198,27 @@ static inline int sai_set_config(struct dai *dai,
 		return -EINVAL;
 	}
 
-	/* DAI clock master masks */
-	switch (config->format & SOF_DAI_FMT_MASTER_MASK) {
-	case SOF_DAI_FMT_CBS_CFS:
-		dai_info(dai, "SAI: codec is slave");
+	/* DAI clock provider masks */
+	switch (config->format & SOF_DAI_FMT_CLOCK_PROVIDER_MASK) {
+	case SOF_DAI_FMT_CBC_CFC:
+		dai_info(dai, "SAI: codec is consumer");
 		val_cr2 |= REG_SAI_CR2_MSEL_MCLK1;
 		val_cr2 |= REG_SAI_CR2_BCD_MSTR;
 		val_cr2 |= SAI_CLOCK_DIV; /* TODO: determine dynamically.*/
 		val_cr4 |= REG_SAI_CR4_FSD_MSTR;
 		break;
-	case SOF_DAI_FMT_CBM_CFM:
-		dai_info(dai, "SAI: codec is master");
+	case SOF_DAI_FMT_CBP_CFP:
+		dai_info(dai, "SAI: codec is provider");
 		/*
-		 * fields CR2_DIV and CR2_MSEL not relevant in slave mode.
+		 * fields CR2_DIV and CR2_MSEL not relevant in consumer mode.
 		 * fields CR2_BCD and CR4_MFSD already at 0
 		 */
 		break;
-	case SOF_DAI_FMT_CBS_CFM:
+	case SOF_DAI_FMT_CBC_CFP:
 		val_cr2 |= REG_SAI_CR2_BCD_MSTR;
 		val_cr2 |= SAI_CLOCK_DIV; /* TODO: determine dynamically.*/
 		break;
-	case SOF_DAI_FMT_CBM_CFS:
+	case SOF_DAI_FMT_CBP_CFC:
 		val_cr4 |= REG_SAI_CR4_FSD_MSTR;
 		val_cr2 |= SAI_CLOCK_DIV; /* TODO: determine dynamically.*/
 		break;

--- a/src/drivers/intel/baytrail/ssp.c
+++ b/src/drivers/intel/baytrail/ssp.c
@@ -166,24 +166,24 @@ static int ssp_set_config(struct dai *dai,
 	ssp->config = *config;
 	ssp->params = config->ssp;
 
-	/* clock masters */
+	/* clock providers */
 	/*
-	 * On TNG/BYT/CHT, the SSP wrapper generates the fs even in master mode,
-	 * the master/slave choice depends on the clock type
+	 * On TNG/BYT/CHT, the SSP wrapper generates the fs even in provider mode,
+	 * the provider/consumer choice depends on the clock type
 	 */
 	sscr1 |= SSCR1_SFRMDIR;
 
-	switch (config->format & SOF_DAI_FMT_MASTER_MASK) {
-	case SOF_DAI_FMT_CBM_CFM:
+	switch (config->format & SOF_DAI_FMT_CLOCK_PROVIDER_MASK) {
+	case SOF_DAI_FMT_CBP_CFP:
 		sscr0 |= SSCR0_ECS; /* external clock used */
 		sscr1 |= SSCR1_SCLKDIR;
 		/*
 		 * FIXME: does SSRC1.SCFR need to be set
-		 * when codec is master ?
+		 * when codec is provider ?
 		 */
 		sscr2 |= SSCR2_SLV_EXT_CLK_RUN_EN;
 		break;
-	case SOF_DAI_FMT_CBS_CFS:
+	case SOF_DAI_FMT_CBC_CFC:
 #ifdef ENABLE_SSRCR1_SCFR /* FIXME: is this needed ? */
 		sscr1 |= SSCR1_SCFR;
 #endif
@@ -191,19 +191,19 @@ static int ssp_set_config(struct dai *dai,
 		cfs = true;
 		cbs = true;
 		break;
-	case SOF_DAI_FMT_CBM_CFS:
+	case SOF_DAI_FMT_CBP_CFC:
 		sscr0 |= SSCR0_ECS; /* external clock used */
 		sscr1 |= SSCR1_SCLKDIR;
 		/*
 		 * FIXME: does SSRC1.SCFR need to be set
-		 * when codec is master ?
+		 * when codec is provider ?
 		 */
 		sscr2 |= SSCR2_SLV_EXT_CLK_RUN_EN;
 		sscr3 |= SSCR3_FRM_MST_EN;
 		cfs = true;
 		/* FIXME: this mode has not been tested */
 		break;
-	case SOF_DAI_FMT_CBS_CFM:
+	case SOF_DAI_FMT_CBC_CFP:
 #ifdef ENABLE_SSRCR1_SCFR /* FIXME: is this needed ? */
 		sscr1 |= SSCR1_SCFR;
 #endif
@@ -211,7 +211,7 @@ static int ssp_set_config(struct dai *dai,
 		cbs = true;
 		break;
 	default:
-		dai_err(dai, "ssp_set_config(): format & MASTER_MASK EINVAL");
+		dai_err(dai, "ssp_set_config(): format & PROVIDER_MASK EINVAL");
 		ret = -EINVAL;
 		goto out;
 	}
@@ -337,7 +337,7 @@ static int ssp_set_config(struct dai *dai,
 		if (cbs) {
 			/*
 			 * keep RX functioning on a TX underflow
-			 * (I2S/LEFT_J master only)
+			 * (I2S/LEFT_J provider only)
 			 */
 			sscr3 |= SSCR3_MST_CLK_EN;
 
@@ -367,7 +367,7 @@ static int ssp_set_config(struct dai *dai,
 		if (cbs) {
 			/*
 			 * keep RX functioning on a TX underflow
-			 * (I2S/LEFT_J master only)
+			 * (I2S/LEFT_J provider only)
 			 */
 			sscr3 |= SSCR3_MST_CLK_EN;
 
@@ -391,7 +391,7 @@ static int ssp_set_config(struct dai *dai,
 		/* handle frame polarity, DSP_A default is rising/active high */
 		sspsp |= SSPSP_SFRMP(!inverted_frame);
 		if (cfs) {
-			/* set sscr frame polarity in DSP/master mode only */
+			/* set sscr frame polarity in DSP/provider mode only */
 			sscr5 |= SSCR5_FRM_POLARITY(inverted_frame);
 		}
 
@@ -419,7 +419,7 @@ static int ssp_set_config(struct dai *dai,
 		/* handle frame polarity, DSP_A default is rising/active high */
 		sspsp |= SSPSP_SFRMP(!inverted_frame);
 		if (cfs) {
-			/* set sscr frame polarity in DSP/master mode only */
+			/* set sscr frame polarity in DSP/provider mode only */
 			sscr5 |= SSCR5_FRM_POLARITY(inverted_frame);
 		}
 

--- a/src/drivers/intel/haswell/ssp.c
+++ b/src/drivers/intel/haswell/ssp.c
@@ -109,26 +109,26 @@ static int ssp_set_config(struct dai *dai,
 	ssp->config = *config;
 	ssp->params = config->ssp;
 
-	switch (config->format & SOF_DAI_FMT_MASTER_MASK) {
-	case SOF_DAI_FMT_CBM_CFM:
+	switch (config->format & SOF_DAI_FMT_CLOCK_PROVIDER_MASK) {
+	case SOF_DAI_FMT_CBP_CFP:
 		sscr1 |= SSCR1_SCLKDIR | SSCR1_SFRMDIR;
 #ifdef ENABLE_SSRCR1_SCFR
 		sscr1 |= SSCR1_SCFR;
 #endif
 		break;
-	case SOF_DAI_FMT_CBS_CFS:
+	case SOF_DAI_FMT_CBC_CFC:
 		break;
-	case SOF_DAI_FMT_CBM_CFS:
+	case SOF_DAI_FMT_CBP_CFC:
 		sscr1 |= SSCR1_SCLKDIR;
 #ifdef ENABLE_SSRCR1_SCFR
 		sscr1 |= SSCR1_SCFR;
 #endif
 		break;
-	case SOF_DAI_FMT_CBS_CFM:
+	case SOF_DAI_FMT_CBC_CFP:
 		sscr1 |= SSCR1_SFRMDIR;
 		break;
 	default:
-		dai_err(dai, "ssp_set_config(): format & MASTER_MASK EINVAL");
+		dai_err(dai, "ssp_set_config(): format & PROVIDER_MASK EINVAL");
 		ret = -EINVAL;
 		goto out;
 	}
@@ -181,13 +181,13 @@ static int ssp_set_config(struct dai *dai,
 	sscr2 |= (ssp->params.quirks & SOF_DAI_INTEL_SSP_QUIRK_MMRATF) ?
 		SSCR2_MMRATF : 0;
 
-	/* Enable/disable the fix for PSP slave mode TXD wait for frame
+	/* Enable/disable the fix for PSP consumer mode TXD wait for frame
 	 * de-assertion before starting the second channel
 	 */
 	sscr2 |= (ssp->params.quirks & SOF_DAI_INTEL_SSP_QUIRK_PSPSTWFDFD) ?
 		SSCR2_PSPSTWFDFD : 0;
 
-	/* Enable/disable the fix for PSP master mode FSRT with dummy stop &
+	/* Enable/disable the fix for PSP provider mode FSRT with dummy stop &
 	 * frame end padding capability
 	 */
 	sscr2 |= (ssp->params.quirks & SOF_DAI_INTEL_SSP_QUIRK_PSPSRWFDFD) ?

--- a/src/drivers/intel/ssp/mn.c
+++ b/src/drivers/intel/ssp/mn.c
@@ -106,7 +106,7 @@ static inline bool is_mclk_source_in_use(void)
  * \brief Configures source clock for MCLK.
  *	  All MCLKs share the same source, so it should be changed
  *	  only if there are no other ports using it already.
- * \param[in] mclk_rate master clock frequency.
+ * \param[in] mclk_rate main clock frequency.
  * \return 0 on success, error code otherwise.
  */
 static inline int setup_initial_mclk_source(uint32_t mclk_id,
@@ -156,7 +156,7 @@ out:
 
 /**
  * \brief Checks if requested MCLK can be achieved with current source.
- * \param[in] mclk_rate master clock frequency.
+ * \param[in] mclk_rate main clock frequency.
  * \return 0 on success, error code otherwise.
  */
 static inline int check_current_mclk_source(uint32_t mclk_rate)

--- a/src/drivers/intel/ssp/ssp.c
+++ b/src/drivers/intel/ssp/ssp.c
@@ -199,26 +199,26 @@ static int ssp_set_config(struct dai *dai,
 	/* ssrsa dynamic setting is RTSA, default 2 slots */
 	ssrsa = SSRSA_SSRSA(config->ssp.rx_slots);
 
-	switch (config->format & SOF_DAI_FMT_MASTER_MASK) {
-	case SOF_DAI_FMT_CBM_CFM:
+	switch (config->format & SOF_DAI_FMT_CLOCK_PROVIDER_MASK) {
+	case SOF_DAI_FMT_CBP_CFP:
 		sscr1 |= SSCR1_SCLKDIR | SSCR1_SFRMDIR;
 		break;
-	case SOF_DAI_FMT_CBS_CFS:
+	case SOF_DAI_FMT_CBC_CFC:
 		sscr1 |= SSCR1_SCFR;
 		cfs = true;
 		break;
-	case SOF_DAI_FMT_CBM_CFS:
+	case SOF_DAI_FMT_CBP_CFC:
 		sscr1 |= SSCR1_SCLKDIR;
 		/* FIXME: this mode has not been tested */
 
 		cfs = true;
 		break;
-	case SOF_DAI_FMT_CBS_CFM:
+	case SOF_DAI_FMT_CBC_CFP:
 		sscr1 |= SSCR1_SCFR | SSCR1_SFRMDIR;
 		/* FIXME: this mode has not been tested */
 		break;
 	default:
-		dai_err(dai, "ssp_set_config(): format & MASTER_MASK EINVAL");
+		dai_err(dai, "ssp_set_config(): format & PROVIDER_MASK EINVAL");
 		ret = -EINVAL;
 		goto out;
 	}
@@ -283,13 +283,13 @@ static int ssp_set_config(struct dai *dai,
 	sscr2 |= (ssp->params.quirks & SOF_DAI_INTEL_SSP_QUIRK_MMRATF) ?
 		SSCR2_MMRATF : 0;
 
-	/* Enable/disable the fix for PSP slave mode TXD wait for frame
+	/* Enable/disable the fix for PSP consumer mode TXD wait for frame
 	 * de-assertion before starting the second channel
 	 */
 	sscr2 |= (ssp->params.quirks & SOF_DAI_INTEL_SSP_QUIRK_PSPSTWFDFD) ?
 		SSCR2_PSPSTWFDFD : 0;
 
-	/* Enable/disable the fix for PSP master mode FSRT with dummy stop &
+	/* Enable/disable the fix for PSP provider mode FSRT with dummy stop &
 	 * frame end padding capability
 	 */
 	sscr2 |= (ssp->params.quirks & SOF_DAI_INTEL_SSP_QUIRK_PSPSRWFDFD) ?

--- a/src/include/ipc/dai.h
+++ b/src/include/ipc/dai.h
@@ -42,15 +42,15 @@
 #define SOF_DAI_FMT_IB_NF	(3 << 8) /**< invert BCLK + nor FRM */
 #define SOF_DAI_FMT_IB_IF	(4 << 8) /**< invert BCLK + FRM */
 
-#define SOF_DAI_FMT_CBM_CFM	(0 << 12) /**< codec clk & FRM master */
-#define SOF_DAI_FMT_CBS_CFM	(2 << 12) /**< codec clk slave & FRM master */
-#define SOF_DAI_FMT_CBM_CFS	(3 << 12) /**< codec clk master & frame slave */
-#define SOF_DAI_FMT_CBS_CFS	(4 << 12) /**< codec clk & FRM slave */
+#define SOF_DAI_FMT_CBP_CFP	(0 << 12) /**< codec bclk provider & frame provider */
+#define SOF_DAI_FMT_CBC_CFP	(2 << 12) /**< codec bclk consumer & frame provider */
+#define SOF_DAI_FMT_CBP_CFC	(3 << 12) /**< codec bclk provider & frame consumer */
+#define SOF_DAI_FMT_CBC_CFC	(4 << 12) /**< codec bclk consumer & frame consumer */
 
 #define SOF_DAI_FMT_FORMAT_MASK		0x000f
 #define SOF_DAI_FMT_CLOCK_MASK		0x00f0
 #define SOF_DAI_FMT_INV_MASK		0x0f00
-#define SOF_DAI_FMT_MASTER_MASK		0xf000
+#define SOF_DAI_FMT_CLOCK_PROVIDER_MASK	0xf000
 
 /** \brief Types of DAI */
 enum sof_ipc_dai_type {

--- a/src/include/sof/drivers/mn.h
+++ b/src/include/sof/drivers/mn.h
@@ -25,15 +25,15 @@ void mn_init(struct sof *sof);
  *	  User should release clock when it is no longer needed to allow
  *	  driver to change MCLK M/N source when user count drops to 0.
  *	  M value of M/N is not supported for MCLK, only divider can be used.
- * \param[in] mclk_id id of master clock for which rate should be set.
- * \param[in] mclk_rate master clock frequency.
+ * \param[in] mclk_id id of main clock for which rate should be set.
+ * \param[in] mclk_rate main clock frequency.
  * \return 0 on success otherwise a negative error code.
  */
 int mn_set_mclk(uint16_t mclk_id, uint32_t mclk_rate);
 
 /**
  * \brief Release previously requested MCLK for given MCLK ID.
- * \param[in] mclk_id id of master clock.
+ * \param[in] mclk_id id of main clock.
  */
 void mn_release_mclk(uint32_t mclk_id);
 

--- a/src/include/sof/drivers/sai.h
+++ b/src/include/sof/drivers/sai.h
@@ -241,7 +241,7 @@
 #define SAI_FIFO_WORD_SIZE	64
 #endif
 
-/* Divides down the audio master clock to generate the bit clock when
+/* Divides down the audio main clock to generate the bit clock when
  * configured for an internal bit clock.
  * The division value is (DIV + 1) * 2.
  */


### PR DESCRIPTION
The consensus in Linux/ALSA circles is to use clock provider/consumer, instead of the legacy master/slave.

This PR mirrors this consensus and follows the work already done for DSP cores in https://github.com/thesofproject/sof/pull/3381

There should be no functional changes, if there is one it's an error.