### PR TITLE
dai: add warning when we skip .copy

### DIFF
--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -837,9 +837,11 @@ static int dai_copy(struct comp_dev *dev)
 		 dev->direction, copy_bytes,
 		 samples / buf->stream.channels);
 
-	/* return if it's not stream start */
-	if (!copy_bytes && dd->start_position != dev->position)
+	/* return if nothing to copy */
+	if (!copy_bytes) {
+		comp_warn(dev, "dai_copy(): nothing to copy");
 		return 0;
+	}
 
 	ret = dma_copy(dd->chan, copy_bytes, 0);
 	if (ret < 0) {


### PR DESCRIPTION
This patch logs warning message when we skip dai .copy() method.
Also the condition has been changed, there is no need to compare
positions - if there is nothing to copy we should terminate this
procedure regardless of positions.

Signed-off-by: Marcin Rajwa <marcin.rajwa@linux.intel.com>