### PR TITLE
travis: build host tools in travis, not in our docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,9 @@ jobs:
       env: PLATFORM='tgl'
 
     - name: "./scripts/build-tools.sh Release"
-      before_install: *docker-pull-sof
-      script: CMAKE_BUILD_TYPE=Release ./scripts/docker-run.sh ./scripts/build-tools.sh
+      before_install:
+        - &apt-alsa sudo apt-get -y install libasound2-dev alsa-utils
+      script: CMAKE_BUILD_TYPE=Release ./scripts/build-tools.sh
 
     # stage tests
 
@@ -73,11 +74,13 @@ jobs:
 
 
     - name: testbench
-      before_install: *docker-pull-sof
+      before_install:
+        - *apt-alsa
+
       script:
         # testbench needs some topologies
-        - ./scripts/docker-run.sh ./scripts/build-tools.sh -t
-        - ./scripts/docker-run.sh ./scripts/rebuild-testbench.sh
+        - ./scripts/build-tools.sh -t
+        - ./scripts/rebuild-testbench.sh
         - ./scripts/host-testbench.sh
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@
 # yaml merge-expand .travis.yml exp.yml && diff -b -u .travis.yml exp.yml
 
 language: c
+# Ubuntu 20.04 LTS
+dist: focal
 
 git:
   depth: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,13 +52,15 @@ jobs:
     - &qemuboottest
       stage: tests
       script:
-        - sed -i $(($(grep "config HAVE_AGENT" -n src/platform/Kconfig | cut -f1 -d:)+2))"s/default y/default n/" src/platform/Kconfig
+        - sed -i $(($(grep "config HAVE_AGENT" -n src/platform/Kconfig |
+             cut -f1 -d:)+2))"s/default y/default n/" src/platform/Kconfig
         - ./scripts/docker-run.sh ./scripts/xtensa-build-all.sh -r $PLATFORM
         - ./scripts/docker-qemu.sh ../sof.git/scripts/qemu-check.sh $PLATFORM
       env: PLATFORM='byt cht'
       before_install:
         - *docker-pull-sof
-        - docker pull thesofproject/sofqemu && docker tag thesofproject/sofqemu sofqemu
+        - docker pull thesofproject/sofqemu &&
+            docker tag thesofproject/sofqemu sofqemu
 
     - <<: *qemuboottest
       env: PLATFORM='bdw hsw'
@@ -91,7 +93,8 @@ jobs:
       script:
 
         # Show ALL warnings. Warnings don't cause doxygen to fail (yet).
-        - mkdir -p doxybuild && pushd doxybuild && cmake -GNinja -S ../doc && ninja -v doc
+        - mkdir -p doxybuild && pushd doxybuild && cmake -GNinja -S ../doc &&
+             ninja -v doc
         - popd
 
         # Build again (it's very quick) and report a failure in Travis if


### PR DESCRIPTION
3 travis commits. Main one:

The docker image is useful because it saves users the somewhat tedious
and error-prone build of a toolchain.

On the other hand, we don't want to force a layer of indirection to
build the host tools. This commit makes sure the host tools will never
have any hidden dependency on the docker image.
