### PR TITLE
travis: upgrade distribution to Ubuntu 20.04 …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@
 # yaml merge-expand .travis.yml exp.yml && diff -b -u .travis.yml exp.yml
 
 language: c
+# Ubuntu 20.04 LTS
+dist: focal
 
 git:
   depth: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,13 +49,15 @@ jobs:
     - &qemuboottest
       stage: tests
       script:
-        - sed -i $(($(grep "config HAVE_AGENT" -n src/platform/Kconfig | cut -f1 -d:)+2))"s/default y/default n/" src/platform/Kconfig
+        - sed -i $(($(grep "config HAVE_AGENT" -n src/platform/Kconfig |
+             cut -f1 -d:)+2))"s/default y/default n/" src/platform/Kconfig
         - ./scripts/docker-run.sh ./scripts/xtensa-build-all.sh -r $PLATFORM
         - ./scripts/docker-qemu.sh ../sof.git/scripts/qemu-check.sh $PLATFORM
       env: PLATFORM='byt cht'
       before_install:
         - *docker-pull-sof
-        - docker pull thesofproject/sofqemu && docker tag thesofproject/sofqemu sofqemu
+        - docker pull thesofproject/sofqemu &&
+            docker tag thesofproject/sofqemu sofqemu
 
     - <<: *qemuboottest
       env: PLATFORM='bdw hsw'
@@ -86,7 +88,8 @@ jobs:
       script:
 
         # Show ALL warnings. Warnings don't cause doxygen to fail (yet).
-        - mkdir -p doxybuild && pushd doxybuild && cmake -GNinja -S ../doc && ninja -v doc
+        - mkdir -p doxybuild && pushd doxybuild && cmake -GNinja -S ../doc &&
+             ninja -v doc
         - popd
 
         # Build again (it's very quick) and report a failure in Travis if


### PR DESCRIPTION
The current default Travis default is 16.04 which is obsolete.

From thesofproject/linux#2402

> Everyone uses 20.04, period. SOF CI also uses 20.04.

Everything used Docker anyway.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>