### PR TITLE
Audio: Continue volume ramp until all channels are complete

### DIFF
--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -216,6 +216,7 @@ static void volume_ramp(struct comp_dev *dev)
 	int32_t vol;
 	int32_t ramp_time;
 	int i;
+	bool ramp_finished = true;
 
 	/* No need to ramp in idle state, jump volume to request. */
 	if (dev->state == COMP_STATE_READY) {
@@ -257,9 +258,8 @@ static void volume_ramp(struct comp_dev *dev)
 			if (vol >= cd->tvolume[i] || vol >= cd->vol_max) {
 				cd->ramp_coef[i] = 0;
 				cd->volume[i] = cd->tvolume[i];
-				cd->ramp_finished = true;
-				cd->vol_ramp_active = false;
 			} else {
+				ramp_finished = false;
 				cd->volume[i] = vol;
 			}
 		} else {
@@ -274,14 +274,18 @@ static void volume_ramp(struct comp_dev *dev)
 				    vol <= cd->vol_min) {
 					cd->ramp_coef[i] = 0;
 					cd->volume[i] = cd->tvolume[i];
-					cd->ramp_finished = true;
-					cd->vol_ramp_active = false;
 				} else {
+					ramp_finished = false;
 					cd->volume[i] = vol;
 				}
 			}
 		}
 
+	}
+
+	if (ramp_finished) {
+		cd->ramp_finished = true;
+		cd->vol_ramp_active = false;
 	}
 
 	/* sync host with new value */


### PR DESCRIPTION
The volume component works correct when all channels receive the same
gain value in volume set command.

This patch fixes a bug that is triggered by applying different
gain values for the channels. The logic with setting cd->ramp_finished
to true caused the check in volume copy() to no more call volume_ramp()
when one of the channel reached their target volume. When the ramp
updating was stopped all other channels remain in intermediate gain
value.

In the fix the logic is set to opposite. Whenever a channel needs a ramp
update it sets a temporary flag. The ramp finish is set only when
no channels needed gain update.

Fixes #3455

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>