### PR TITLE
topology: fix playback & capture pipelines to be timer driven

### DIFF
--- a/tools/topology/sof-jsl-rt5682.m4
+++ b/tools/topology/sof-jsl-rt5682.m4
@@ -110,21 +110,21 @@ dnl     frames, deadline, priority, core)
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, SPK_INDEX, SPK_NAME,
 	PIPELINE_SOURCE_1, 2, SPK_DATA_FORMAT,
-	1000, 0, 0)
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is SSP0 using 2 periods
 # Buffers use s24le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	2, SSP, 0, SSP0-Codec,
 	PIPELINE_SOURCE_2, 2, s24le,
-	1000, 0, 0)
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is SSP0 using 2 periods
 # Buffers use s24le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	3, SSP, 0, SSP0-Codec,
 	PIPELINE_SINK_3, 2, s24le,
-	1000, 0, 0)
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp1 using 2 periods
 # Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0


### PR DESCRIPTION
The patch fixes two SSP pipelines to be scheduled in timer domain.

Signed-off-by: Yong Zhi <yong.zhi@intel.com>