### PR TITLE
cmake: allow testbench to build with clang

### DIFF
--- a/src/arch/host/CMakeLists.txt
+++ b/src/arch/host/CMakeLists.txt
@@ -6,6 +6,6 @@ target_include_directories(sof_public_headers INTERFACE ${PROJECT_SOURCE_DIR}/sr
 
 # C & ASM flags
 target_compile_options(sof_options INTERFACE -g -O3 -Wall -Werror -Wl,-EL -Wmissing-prototypes
-  -Wimplicit-fallthrough=3 -Wpointer-arith -DCONFIG_LIBRARY "-imacros${CONFIG_H_PATH}")
+  -Wimplicit-fallthrough -Wpointer-arith -DCONFIG_LIBRARY "-imacros${CONFIG_H_PATH}")
 
 add_subdirectory(lib)

--- a/src/audio/CMakeLists.txt
+++ b/src/audio/CMakeLists.txt
@@ -110,7 +110,7 @@ macro(check_optimization opt_name flag extra_define)
 	check_c_compiler_flag(${flag} compiles_flag_${opt_name})
 	if(compiles_flag_${opt_name})
 		list(APPEND available_optimizations ${opt_name})
-		set(${opt_name}_flags ${flag} ${extra_define} -ffast-math -ftree-vectorizer-verbose=0)
+		set(${opt_name}_flags ${flag} ${extra_define} -ffast-math)
 	endif()
 endmacro()
 

--- a/tools/testbench/CMakeLists.txt
+++ b/tools/testbench/CMakeLists.txt
@@ -32,7 +32,7 @@ set(sof_binary_directory "${PROJECT_BINARY_DIR}/sof_ep/build")
 set(config_h ${sof_binary_directory}/library_autoconfig.h)
 
 target_compile_options(testbench PRIVATE -g -O3 -Wall -Werror -Wl,-EL -Wmissing-prototypes
-  -Wimplicit-fallthrough=3 -DCONFIG_LIBRARY -imacros${config_h})
+  -Wimplicit-fallthrough -DCONFIG_LIBRARY -imacros${config_h})
 
 target_link_libraries(testbench PRIVATE -ldl -lm)
 

--- a/tools/tplg_parser/CMakeLists.txt
+++ b/tools/tplg_parser/CMakeLists.txt
@@ -9,7 +9,7 @@ set(sof_source_directory "${PROJECT_SOURCE_DIR}/../..")
 add_library(sof_tplg_parser SHARED tplg_parser.c)
 target_include_directories(sof_tplg_parser PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_include_directories(sof_tplg_parser PRIVATE ${sof_source_directory}/src/include)
-target_compile_options(sof_tplg_parser PRIVATE -g -O -Wall -Werror -Wl,-EL -Wmissing-prototypes -Wimplicit-fallthrough=3)
+target_compile_options(sof_tplg_parser PRIVATE -g -O -Wall -Werror -Wl,-EL -Wmissing-prototypes -Wimplicit-fallthrough)
 
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/tplg_parser
 	DESTINATION include


### PR DESCRIPTION
We need clang support for the testbench therefore the following changes
are needed

remove -ftree-vectorizer-verbose when building with clang

remove =3 from -Wimplicit-fallthrough=3 since 3 is the default level
anyways

Signed-off-by: Curtis Malainey <cujomalainey@chromium.org>