### PR TITLE
logger: Log fread error only when it happened

### DIFF
--- a/tools/logger/convert.c
+++ b/tools/logger/convert.c
@@ -640,7 +640,7 @@ static int logger_read(void)
 		ret = fread(&dma_log, sizeof(dma_log), 1, global_config->in_fd);
 		if (!ret) {
 			if (global_config->trace && !ferror(global_config->in_fd)) {
-				if (freopen(NULL, "r", global_config->in_fd)) {
+				if (freopen(NULL, "rb", global_config->in_fd)) {
 					continue;
 				} else {
 					log_err("in %s(), freopen(..., %s) failed: %s(%d)\n",

--- a/tools/logger/convert.c
+++ b/tools/logger/convert.c
@@ -640,10 +640,12 @@ static int logger_read(void)
 					return -errno;
 				}
 			}
-			log_err("in %s(), fread(..., %s) failed: %s(%d)\n",
-				 __func__, global_config->in_file,
-				strerror(errno), errno);
-			return -errno;
+			ret = -ferror(global_config->in_fd);
+			if (ret)
+				log_err("in %s(), fread(..., %s) failed: %s(%d)\n",
+					__func__, global_config->in_file,
+					strerror(-ret), ret);
+			return ret;
 		}
 
 		/* checking if received trace address is located in


### PR DESCRIPTION
    fread may return 0 when some error occurred or nothig has been reded.

    Fixes: 337afc4f3809: ("logger: add error message when reading sof/etrace instead of sof/trace")

    Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>