### PR TITLE
ext_manifest: fix config name to LPRO_ONLY for cavs

### DIFF
--- a/src/platform/intel/cavs/ext_manifest.c
+++ b/src/platform/intel/cavs/ext_manifest.c
@@ -16,8 +16,8 @@ const struct ext_man_cavs_config_data ext_man_cavs_config
 	.hdr.elem_size = ALIGN_UP(sizeof(struct ext_man_cavs_config_data),
 				  EXT_MAN_ALIGN),
 	.elems = {
-#if CONFIG_CAVS_LPRO
-		{EXT_MAN_CAVS_CONFIG_LPRO,  CONFIG_CAVS_LPRO},
+#if CONFIG_CAVS_LPRO_ONLY
+		{EXT_MAN_CAVS_CONFIG_LPRO,  CONFIG_CAVS_LPRO_ONLY},
 #endif
 		{EXT_MAN_CAVS_CONFIG_OUTBOX_SIZE, SRAM_OUTBOX_SIZE},
 		{EXT_MAN_CAVS_CONFIG_INBOX_SIZE, SRAM_INBOX_SIZE},


### PR DESCRIPTION
Config name is CONFIG_CAVS_LPRO_ONLY.

Signed-off-by: Fred Oh <fred.oh@linux.intel.com>

There was a problem, CONFIG_LPRO information is not read from linux driver.