### PR TITLE
docker-run.sh: pass-through PRIVATE_KEY_OPTION

### DIFF
--- a/scripts/docker-run.sh
+++ b/scripts/docker-run.sh
@@ -12,4 +12,5 @@
 
 docker run -i -t -v "$(pwd)":/home/sof/work/sof.git \
 	--env CMAKE_BUILD_TYPE \
+	--env PRIVATE_KEY_OPTION \
 	   --user "$(id -u)" sof "$@"


### PR DESCRIPTION
Pass PRIVATE_KEY_OPTION environment variable to docker to be able to
define external key for signing.

Suggested-by: Marc Herbert <marc.herbert@intel.com>
Signed-off-by: Jaska Uimonen <jaska.uimonen@intel.com>