### PR TITLE
ssp: fix the RX FIFO flushing logic

### DIFF
--- a/src/include/sof/drivers/ssp.h
+++ b/src/include/sof/drivers/ssp.h
@@ -220,6 +220,9 @@ extern const struct dai_driver ssp_driver;
 /* For 8000 Hz rate one sample is transmitted within 125us */
 #define SSP_MAX_SEND_TIME_PER_SAMPLE 125
 
+/* SSP flush timeout in microseconds */
+#define SSP_RX_FLUSH_TIMEOUT	200
+
 #define ssp_irq(ssp) \
 	ssp->plat_data.irq
 


### PR DESCRIPTION
To make sure all the RX FIFO entries are read out for the flushing, we
need wait until the SSSR_RNE is cleared after the SSP is disabled (the
SSSR_BSY is cleared, otherwise, there might be obsoleted entry remained
in the FIFO which will impact the next run with the SSP RX and lead to
sample mismatched issue.

BugLink: https://github.com/thesofproject/sof/issues/3428
Cc: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>
Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>