### PR TITLE
smart amp: Update smart amp test changes to maxim dsm component.

### DIFF
--- a/src/audio/smart_amp/smart_amp.c
+++ b/src/audio/smart_amp/smart_amp.c
@@ -599,7 +599,7 @@ static int smart_amp_copy(struct comp_dev *dev)
 	avail_frames = avail_passthrough_frames;
 
 	buffer_lock(sad->feedback_buf, &feedback_flags);
-	if (sad->feedback_buf->source->state == dev->state) {
+	if (comp_get_state(dev, sad->feedback_buf->source) == dev->state) {
 		/* feedback */
 		avail_feedback_frames = audio_stream_get_avail_frames(&sad->feedback_buf->stream);
 

--- a/src/audio/smart_amp/smart_amp.c
+++ b/src/audio/smart_amp/smart_amp.c
@@ -601,8 +601,7 @@ static int smart_amp_copy(struct comp_dev *dev)
 	buffer_lock(sad->feedback_buf, &feedback_flags);
 	if (sad->feedback_buf->source->state == dev->state) {
 		/* feedback */
-		avail_feedback_frames = sad->feedback_buf->stream.avail /
-			audio_stream_frame_bytes(&sad->feedback_buf->stream);
+		avail_feedback_frames = audio_stream_get_avail_frames(&sad->feedback_buf->stream);
 
 		avail_frames = MIN(avail_passthrough_frames,
 				   avail_feedback_frames);

--- a/src/audio/smart_amp/smart_amp.c
+++ b/src/audio/smart_amp/smart_amp.c
@@ -390,14 +390,8 @@ static int smart_amp_ctrl_set_bin_data(struct comp_dev *dev,
 
 	assert(sad);
 
-	if (dev->state != COMP_STATE_READY) {
-		/* It is a valid request but currently this is not
-		 * supported during playback/capture. The driver will
-		 * re-send data in next resume when idle and the new
-		 * configuration will be used when playback/capture
-		 * starts.
-		 */
-		comp_err(dev, "smart_amp_ctrl_set_bin_data(): driver is busy");
+	if (dev->state < COMP_STATE_READY) {
+		comp_err(dev, "smart_amp_ctrl_set_bin_data(): driver in init!");
 		return -EBUSY;
 	}
 

--- a/src/audio/smart_amp/smart_amp.c
+++ b/src/audio/smart_amp/smart_amp.c
@@ -692,15 +692,6 @@ static int smart_amp_prepare(struct comp_dev *dev)
 		return -EINVAL;
 	}
 
-	/* TODO:
-	 * ATM feedback buffer frame_fmt is hardcoded to s32_le. It should be
-	 * removed when parameters negotiation between pipelines will prepared
-	 */
-	if (sad->feedback_buf->stream.frame_fmt != SOF_IPC_FRAME_S32_LE) {
-		sad->feedback_buf->stream.frame_fmt = SOF_IPC_FRAME_S32_LE;
-		comp_err(dev, "smart_amp_prepare(): S32_LE format is hardcoded as workaround");
-	}
-
 	sad->process = get_smart_amp_process(dev);
 	if (!sad->process) {
 		comp_err(dev, "smart_amp_prepare(): get_smart_amp_process failed");

--- a/src/audio/smart_amp/smart_amp.c
+++ b/src/audio/smart_amp/smart_amp.c
@@ -683,6 +683,7 @@ static int smart_amp_prepare(struct comp_dev *dev)
 	sad->out_channels = sad->sink_buf->stream.channels;
 
 	sad->feedback_buf->stream.channels = sad->config.feedback_channels;
+	sad->feedback_buf->stream.rate = sad->source_buf->stream.rate;
 
 	if (smart_amp_check_audio_fmt(sad->source_buf->stream.rate,
 				      sad->source_buf->stream.channels)) {

--- a/src/audio/smart_amp/smart_amp_maxim_dsm.c
+++ b/src/audio/smart_amp/smart_amp_maxim_dsm.c
@@ -106,7 +106,7 @@ static int maxim_dsm_get_volatile_param(struct smart_amp_mod_struct_t *hspk,
 	int x;
 
 	/* Update all volatile parameter values */
-	for (x = DSM_API_ADAPTIVE_PARAM_START ; x < DSM_API_ADAPTIVE_PARAM_END ;  x++) {
+	for (x = DSM_API_ADAPTIVE_PARAM_START ; x <= DSM_API_ADAPTIVE_PARAM_END ;  x++) {
 		cmdblock[0] = DSM_SET_CMD_ID(x);
 		retcode = dsm_api_get_params(hspk->dsmhandle, 1, (void *)cmdblock);
 		if (retcode != DSM_API_OK)


### PR DESCRIPTION
There have been several patches applied to [smart_amp_test.c](https://github.com/thesofproject/sof/blob/master/src/audio/smart_amp_test.c) which is smart amp reference code.

Applied same changes to smart_amp.c[](https://github.com/thesofproject/sof/blob/master/src/audio/smart_amp/smart_amp.c)
which is for Maxim DSM(Dynamic Speaker Management) component.

