### PR TITLE
Tools: Test: Fix for sine vector orientations mismatch

### DIFF
--- a/tools/test/audio/test_utils/multitone.m
+++ b/tools/test/audio/test_utils/multitone.m
@@ -14,48 +14,23 @@ function x = multitone( fs, f, amp, tlength )
 % x = multitone(48000, [997 1997], 10.^([-26 -46]/20), 1.0);
 %
 
-%%
-% Copyright (c) 2017, Intel Corporation
-% All rights reserved.
-%
-% Redistribution and use in source and binary forms, with or without
-% modification, are permitted provided that the following conditions are met:
-%   * Redistributions of source code must retain the above copyright
-%     notice, this list of conditions and the following disclaimer.
-%   * Redistributions in binary form must reproduce the above copyright
-%     notice, this list of conditions and the following disclaimer in the
-%     documentation and/or other materials provided with the distribution.
-%   * Neither the name of the Intel Corporation nor the
-%     names of its contributors may be used to endorse or promote products
-%     derived from this software without specific prior written permission.
-%
-% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
-% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-% POSSIBILITY OF SUCH DAMAGE.
-%
+% SPDX-License-Identifier: BSD-3-Clause
+% Copyright(c) 2017 Intel Corporation. All rights reserved.
 % Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
-%
 
 n = round(fs*tlength);
 t = (0:n-1)/fs;
 nf = length(f);
 if nf > 1
-        ph = rand(nf, 1)*2*pi;
+	ph = rand(nf, 1)*2*pi;
 else
-        ph = 0;
+	ph = 0;
 end
 
-x = amp(1)*sin(2*pi*f(1)*t');
+x = zeros(n, 1);
+x(:,1) = amp(1)*sin(2*pi*f(1)*t);
 for i=2:length(f)
-        x = x + amp(i)*sin(2*pi*f(i)*t+ph(i));
+	x(:,1) = x(:,1) + amp(i)*sin(2*pi*f(i)*t+ph(i))';
 end
 
 end


### PR DESCRIPTION
The generation of multiple tone frequencies failed due accidental
square matrix generation when mixed row and column vectors were added.
The new version uses only vectors in first dimension and avoids the
problem.

The license text format also is changed to current.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>