### PR TITLE
Tools: Test: Fix for dBFS level measure for muted audio

### DIFF
--- a/tools/test/audio/std_utils/level_dbfs.m
+++ b/tools/test/audio/std_utils/level_dbfs.m
@@ -9,38 +9,12 @@ function dbfs = level_dbfs(x)
 % dbfs - sigmal level in dBFS
 %
 
-%%
-% Copyright (c) 2017, Intel Corporation
-% All rights reserved.
-%
-% Redistribution and use in source and binary forms, with or without
-% modification, are permitted provided that the following conditions are met:
-%   * Redistributions of source code must retain the above copyright
-%     notice, this list of conditions and the following disclaimer.
-%   * Redistributions in binary form must reproduce the above copyright
-%     notice, this list of conditions and the following disclaimer in the
-%     documentation and/or other materials provided with the distribution.
-%   * Neither the name of the Intel Corporation nor the
-%     names of its contributors may be used to endorse or promote products
-%     derived from this software without specific prior written permission.
-%
-% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
-% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-% POSSIBILITY OF SUCH DAMAGE.
-%
+% SPDX-License-Identifier: BSD-3-Clause
+% Copyright(c) 2017 Intel Corporation. All rights reserved.
 % Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
-%
 
 %% Reference AES 17 3.12.3
 level_ms = mean(x.^2);
-dbfs = 10*log10(level_ms) + 20*log10(sqrt(2));
+dbfs = 10*log10(level_ms + 1e-20) + 20*log10(sqrt(2));
 
 end


### PR DESCRIPTION
The log() function returns -Inf for level measure for stream of
digital zeros. It is correct but requires extra handling in the
upper level functions to avoid unnecessary tests fails. Adding of
offset 1e-20 results to -196.99 dBFS be the smallest possible
reported value. The function remains sufficient for all audio
measurements with 16 - 32 bit formats.

The license text is also updated to current version.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>