### PR TITLE
logger: Fix uuid formatting

### DIFF
--- a/tools/logger/convert.c
+++ b/tools/logger/convert.c
@@ -207,7 +207,7 @@ static void process_params(struct proc_ldc_entry *pe,
 			pe->subst_mask |= 1 << i;
 			++i;
 			p += 2;
-		} else if (p + 2 >= t_end && p[1] == 'p' && p[2] == 'U') {
+		} else if (p + 2 < t_end && p[1] == 'p' && p[2] == 'U') {
 			/* substitute UUID entry address with formatted string pointer from heap */
 			pe->params[i] = (uintptr_t)asprintf_uuid(p, e->params[i], use_colors,
 								 &uuid_fmt_len);
@@ -215,7 +215,7 @@ static void process_params(struct proc_ldc_entry *pe,
 			++i;
 			/* replace uuid formatter with %s */
 			p[1] = 's';
-			memmove(&p[2], &p[uuid_fmt_len], (int)(t_end - &p[uuid_fmt_len]));
+			memmove(&p[2], &p[uuid_fmt_len], (int)(t_end - &p[uuid_fmt_len]) + 1);
 			p += uuid_fmt_len - 2;
 			t_end -= uuid_fmt_len - 2;
 		} else {


### PR DESCRIPTION
'p + 2' should be smaller than end pointer, bigger value may leads
to undefined memory region read.
Memmove should include last '\0' char.
Without this fix output looks like:
   `task add 0xbe070600 pipe-task 0x1fffa0f0U`
After changes:
    `task add 0xbe070600 pipe-task <f11818eb-e92e-4082-82a3-dc54c604ebb3>`

Fixes: 12f2d9b2c822 logger: Refactor UUID parsing

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>

Related with #3472 