### PR TITLE
timer: check whether handler is set before its invocation

### DIFF
--- a/src/arch/xtensa/drivers/timer.c
+++ b/src/arch/xtensa/drivers/timer.c
@@ -30,7 +30,8 @@ void timer_64_handler(void *arg)
 		arch_timer_clear(timer);
 	} else {
 		/* no roll over, run the handler */
-		timer->handler(timer->data);
+		if (timer->handler)
+			timer->handler(timer->data);
 	}
 
 	/* get next timeout value */


### PR DESCRIPTION
This commit adds check whether timer handler is set
in order to avoid unexpected errors.

Signed-off-by: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>