### PR TITLE
compile: fix reporting compiler version when built with gcc

### DIFF
--- a/src/arch/xtensa/include/arch/compiler_info.h
+++ b/src/arch/xtensa/include/arch/compiler_info.h
@@ -19,10 +19,18 @@
 /* read used compilator name and version */
 /* CC_NAME must consist of 3 characters with null termination */
 /* See declaration of sof_ipc_cc_version. */
+#ifndef __GNUC__
 #define CC_MAJOR (XTHAL_RELEASE_MAJOR / 1000)
 #define CC_MINOR ((XTHAL_RELEASE_MAJOR % 1000) / 10)
 #define CC_MICRO XTHAL_RELEASE_MINOR
 #define CC_NAME "XCC"
+#else
+#define CC_MAJOR __GNUC__
+#define CC_MINOR __GNUC_MINOR__
+#define CC_MICRO __GNUC_PATCHLEVEL__
+#define CC_NAME "GCC"
+#endif
+
 #define CC_DESC " " XCC_TOOLS_VERSION
 
 #endif /* __ARCH_COMPILER_INFO_H__ */

--- a/src/init/CMakeLists.txt
+++ b/src/init/CMakeLists.txt
@@ -13,7 +13,7 @@ set_property(TARGET ext_manifest APPEND
 get_optimization_flag(optimization_flag)
 set_property(TARGET ext_manifest APPEND
 	PROPERTY COMPILE_DEFINITIONS
-	CC_OPTIMIZE_FLAGS="${optimization_flag}")
+	CC_OPTIMIZE_FLAGS="-${optimization_flag}")
 
 add_local_sources(ext_manifest
 	ext_manifest.c)

--- a/src/ipc/CMakeLists.txt
+++ b/src/ipc/CMakeLists.txt
@@ -33,7 +33,7 @@ set_property(TARGET data_structs APPEND
 get_optimization_flag(optimization_flag)
 set_property(TARGET data_structs APPEND
 	     PROPERTY COMPILE_DEFINITIONS
-	     CC_OPTIMIZE_FLAGS="${optimization_flag}")
+	     CC_OPTIMIZE_FLAGS="-${optimization_flag}")
 
 add_local_sources(data_structs
 	cc_version.c


### PR DESCRIPTION
Properly retrieve gcc version values and unify the optimisation flag with Zephyr to always include a '-' in the string. Before this patch the kernel reports the firmware, built with gcc as 

Firmware info: used compiler XCC 12:0:8 xtensa-cnl-elf used optimization flags O2

With this patch it reports

Firmware info: used compiler GCC 8:1:0 xtensa-cnl-elf used optimization flags -O2
