### PR TITLE
Fixup missing headers

### DIFF
--- a/src/include/sof/lib/dai.h
+++ b/src/include/sof/lib/dai.h
@@ -18,6 +18,7 @@
 
 #include <platform/lib/dai.h>
 #include <sof/bit.h>
+#include <sof/list.h>
 #include <sof/lib/io.h>
 #include <sof/lib/memory.h>
 #include <sof/sof.h>

--- a/src/platform/haswell/include/platform/lib/pm_runtime.h
+++ b/src/platform/haswell/include/platform/lib/pm_runtime.h
@@ -17,6 +17,7 @@
 #define __PLATFORM_LIB_PM_RUNTIME_H__
 
 #include <stdint.h>
+#include <stdbool.h>
 
 struct pm_runtime_data;
 


### PR DESCRIPTION
In prepping for fuzzing I noticed some missing headers that would cause builds to fail randomly, adding them so this can be fixed.