### PR TITLE
Zephyr cavs18

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -183,7 +183,7 @@ config DEBUG_HEAP
 
 config DEBUG_MEMORY_USAGE_SCAN
 	bool "Memory usage scan"
-	default y
+	default y if KERNEL_BIN_NAME != "zephyr"
 	help
 	  It enables memory usage scan at demand in runtime.
 	  This feature does not affect standard memory operations,

--- a/smex/ldc.c
+++ b/smex/ldc.c
@@ -5,7 +5,6 @@
 // Author: Karol Trzcinski <karolx.trzcinski@linux.intel.com>
 
 #include <kernel/abi.h>
-#include <kernel/ext_manifest.h>
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -17,7 +16,7 @@
 static int fw_version_copy(const struct elf_module *src,
 			   struct snd_sof_logs_header *header)
 {
-	struct ext_man_elem_header *ext_hdr = NULL;
+	struct sof_ipc_ext_data_hdr *ext_hdr = NULL;
 	void *buffer = NULL;
 	int section_size;
 
@@ -29,7 +28,6 @@ static int fw_version_copy(const struct elf_module *src,
 	memcpy(&header->version,
 	       &((struct sof_ipc_fw_ready *)buffer)->version,
 	       sizeof(header->version));
-	free(buffer);
 
 	/* fw_ready structure contains main (primarily kernel)
 	 * ABI version.
@@ -44,30 +42,25 @@ static int fw_version_copy(const struct elf_module *src,
 	 *
 	 * skip the base fw-ready record and begin from the first extension.
 	 */
-	section_size = elf_read_section(src, ".fw_metadata", NULL, &buffer);
-
-	if (section_size < 0)
-		return section_size;
-
-	ext_hdr = (struct ext_man_elem_header *)buffer;
+	ext_hdr = buffer + ((struct sof_ipc_fw_ready *)buffer)->hdr.size;
 	while ((uintptr_t)ext_hdr < (uintptr_t)buffer + section_size) {
-		if (ext_hdr->type == EXT_MAN_ELEM_DBG_ABI) {
+		if (ext_hdr->type == SOF_IPC_EXT_USER_ABI_INFO) {
 			header->version.abi_version =
-				((struct ext_man_dbg_abi *)
-						ext_hdr)->dbg_abi.abi_dbg_version;
+				((struct sof_ipc_user_abi_version *)
+						ext_hdr)->abi_dbg_version;
 			break;
 		}
 		//move to the next entry
-		ext_hdr = (struct ext_man_elem_header *)
-				((uint8_t *)ext_hdr + ext_hdr->elem_size);
+		ext_hdr = (struct sof_ipc_ext_data_hdr *)
+				((uint8_t *)ext_hdr + ext_hdr->hdr.size);
 	}
-	free(buffer);
 
 	fprintf(stdout, "fw abi dbg version:\t%d:%d:%d\n",
 		SOF_ABI_VERSION_MAJOR(header->version.abi_version),
 		SOF_ABI_VERSION_MINOR(header->version.abi_version),
 		SOF_ABI_VERSION_PATCH(header->version.abi_version));
 
+	free(buffer);
 
 	return 0;
 }

--- a/src/drivers/intel/ssp/mn.c
+++ b/src/drivers/intel/ssp/mn.c
@@ -14,6 +14,8 @@
 #include <sof/spinlock.h>
 #include <sof/trace/trace.h>
 
+#include <cavs/version.h>
+
 #include <stdbool.h>
 #include <stdint.h>
 

--- a/src/include/kernel/ext_manifest.h
+++ b/src/include/kernel/ext_manifest.h
@@ -32,6 +32,16 @@
 #include <rimage/sof/kernel/ext_manifest.h>
 #include <stdint.h>
 
+/* Macro used to creeate copy of some structure in extended manifest */
+#define EXT_MAN_PORT(XENUM, XSIZE, IPC_ELEM, XNAME, IPC_NAME, CONTENT)	\
+	XNAME __aligned(EXT_MAN_ALIGN) __section(".fw_metadata")	\
+		__attribute__ ((unused)) = {				\
+		.hdr.type = XENUM,					\
+		.hdr.elem_size = ALIGN_UP(XSIZE, EXT_MAN_ALIGN),	\
+		.IPC_ELEM = { CONTENT }					\
+	};								\
+	IPC_NAME = { CONTENT }
+
 /* Now define extended manifest elements */
 
 /* Extended manifest elements identificators */

--- a/src/include/sof/compiler_attributes.h
+++ b/src/include/sof/compiler_attributes.h
@@ -14,5 +14,3 @@
 #define __aligned(x) __attribute__((__aligned__(x)))
 
 #define __section(x) __attribute__((section(x)))
-
-#define __unused __attribute__((unused))

--- a/src/include/sof/fw-ready-metadata.h
+++ b/src/include/sof/fw-ready-metadata.h
@@ -10,4 +10,6 @@
 
 #include <ipc/info.h>
 
+extern const struct sof_ipc_user_abi_version user_abi_version;
+
 #endif /* __IPC_FW_READY_METADATA_H__ */

--- a/src/include/sof/fw-ready-metadata.h
+++ b/src/include/sof/fw-ready-metadata.h
@@ -10,6 +10,7 @@
 
 #include <ipc/info.h>
 
+extern const struct sof_ipc_cc_version cc_version;
 extern const struct sof_ipc_probe_support probe_support;
 extern const struct sof_ipc_user_abi_version user_abi_version;
 

--- a/src/include/sof/fw-ready-metadata.h
+++ b/src/include/sof/fw-ready-metadata.h
@@ -10,6 +10,7 @@
 
 #include <ipc/info.h>
 
+extern const struct sof_ipc_probe_support probe_support;
 extern const struct sof_ipc_user_abi_version user_abi_version;
 
 #endif /* __IPC_FW_READY_METADATA_H__ */

--- a/src/ipc/CMakeLists.txt
+++ b/src/ipc/CMakeLists.txt
@@ -36,6 +36,7 @@ set_property(TARGET data_structs APPEND
 	     CC_OPTIMIZE_FLAGS="-${optimization_flag}")
 
 add_local_sources(data_structs
+	cc_version.c
 	probe_support.c
 	user_abi_version.c)
 

--- a/src/ipc/CMakeLists.txt
+++ b/src/ipc/CMakeLists.txt
@@ -36,6 +36,7 @@ set_property(TARGET data_structs APPEND
 	     CC_OPTIMIZE_FLAGS="-${optimization_flag}")
 
 add_local_sources(data_structs
+	probe_support.c
 	user_abi_version.c)
 
 target_link_libraries(data_structs sof_options)

--- a/src/ipc/CMakeLists.txt
+++ b/src/ipc/CMakeLists.txt
@@ -21,3 +21,22 @@ if (CONFIG_HOST_PTABLE)
 	add_local_sources(sof
 		ipc-host-ptable.c)
 endif()
+
+add_library(data_structs STATIC "")
+
+# define compiler version
+set_property(TARGET data_structs APPEND
+	     PROPERTY COMPILE_DEFINITIONS
+	     XCC_TOOLS_VERSION="${XCC_TOOLS_VERSION}")
+
+# and optimization settings
+get_optimization_flag(optimization_flag)
+set_property(TARGET data_structs APPEND
+	     PROPERTY COMPILE_DEFINITIONS
+	     CC_OPTIMIZE_FLAGS="-${optimization_flag}")
+
+add_local_sources(data_structs
+	user_abi_version.c)
+
+target_link_libraries(data_structs sof_options)
+target_link_libraries(sof_static_libraries INTERFACE data_structs)

--- a/src/ipc/cc_version.c
+++ b/src/ipc/cc_version.c
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2019 Intel Corporation. All rights reserved.
+//
+// Author: Karol Trzcinski <karolx.trzcinski@linux.intel.com>
+
+#include <ipc/info.h>
+#include <sof/fw-ready-metadata.h>
+#include <sof/common.h>
+#include <sof/compiler_info.h>
+
+/* copy CC_NAME to const arrays during compilation time */
+#define CC_NAME_COPY(field) \
+	field = CC_NAME "\0"
+
+/* copy CC_OPTIM to const arrays during compilation time */
+#define CC_OPTIM_COPY(field) \
+	field = CC_OPTIMIZE_FLAGS "\0"
+
+/* copy CC_DESC to arrays during compilation time */
+#define CC_DESC_COPY(field) \
+	field = CC_DESC "\0"
+
+const struct sof_ipc_cc_version cc_version
+	__section(".fw_ready_metadata") = {
+	.ext_hdr = {
+		.hdr.cmd = SOF_IPC_FW_READY,
+		.hdr.size = sizeof(struct sof_ipc_cc_version),
+		.type = SOF_IPC_EXT_CC_INFO,
+	},
+	.micro = CC_MICRO,
+	.minor = CC_MINOR,
+	.major = CC_MAJOR,
+	CC_NAME_COPY(.name),
+	CC_OPTIM_COPY(.optim),
+	CC_DESC_COPY(.desc),
+};

--- a/src/ipc/probe_support.c
+++ b/src/ipc/probe_support.c
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2020 Intel Corporation. All rights reserved.
+//
+// Author: Artur Kloniecki <arturx.kloniecki@linux.intel.com>
+
+#include <ipc/info.h>
+#include <sof/fw-ready-metadata.h>
+#include <sof/compiler_attributes.h>
+
+
+const struct sof_ipc_probe_support probe_support
+	__section(".fw_ready_metadata") = {
+	.ext_hdr = {
+		.hdr.cmd = SOF_IPC_FW_READY,
+		.hdr.size = sizeof(struct sof_ipc_probe_support),
+		.type = SOF_IPC_EXT_PROBE_INFO,
+	},
+#if CONFIG_PROBE
+	.probe_points_max = CONFIG_PROBE_POINTS_MAX,
+	.injection_dmas_max = CONFIG_PROBE_DMA_MAX
+#endif
+};

--- a/src/ipc/user_abi_version.c
+++ b/src/ipc/user_abi_version.c
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2020 Intel Corporation. All rights reserved.
+//
+// Author: Marcin Maka <marcin.maka@linux.intel.com>
+
+#include <ipc/info.h>
+#include <user/abi_dbg.h>
+
+const struct sof_ipc_user_abi_version user_abi_version
+	__attribute__((section(".fw_ready_metadata"))) = {
+	.ext_hdr = {
+		.hdr.cmd = SOF_IPC_FW_READY,
+		.hdr.size = sizeof(struct sof_ipc_user_abi_version),
+		.type = SOF_IPC_EXT_USER_ABI_INFO,
+	},
+	.abi_dbg_version = SOF_ABI_DBG_VERSION,
+};

--- a/src/platform/baytrail/platform.c
+++ b/src/platform/baytrail/platform.c
@@ -161,6 +161,11 @@ int platform_boot_complete(uint32_t boot_message)
 			     sram_window.ext_hdr.hdr.size);
 	mb_offset = mb_offset + sram_window.ext_hdr.hdr.size;
 
+	/* variable length compiler description is a last field of cc_version */
+	mailbox_dspbox_write(mb_offset, &cc_version,
+			     cc_version.ext_hdr.hdr.size);
+	mb_offset = mb_offset + cc_version.ext_hdr.hdr.size;
+
 	mailbox_dspbox_write(mb_offset, &probe_support,
 			     probe_support.ext_hdr.hdr.size);
 	mb_offset = mb_offset + probe_support.ext_hdr.hdr.size;

--- a/src/platform/baytrail/platform.c
+++ b/src/platform/baytrail/platform.c
@@ -161,6 +161,10 @@ int platform_boot_complete(uint32_t boot_message)
 			     sram_window.ext_hdr.hdr.size);
 	mb_offset = mb_offset + sram_window.ext_hdr.hdr.size;
 
+	mailbox_dspbox_write(mb_offset, &probe_support,
+			     probe_support.ext_hdr.hdr.size);
+	mb_offset = mb_offset + probe_support.ext_hdr.hdr.size;
+
 	mailbox_dspbox_write(mb_offset, &user_abi_version,
 			     user_abi_version.ext_hdr.hdr.size);
 

--- a/src/platform/baytrail/platform.c
+++ b/src/platform/baytrail/platform.c
@@ -151,9 +151,14 @@ static SHARED_DATA struct timer arch_timer = {
 
 int platform_boot_complete(uint32_t boot_message)
 {
+	uint32_t mb_offset = 0;
 	uint64_t outbox = MAILBOX_HOST_OFFSET >> 3;
 
-	mailbox_dspbox_write(0, &ready, sizeof(ready));
+	mailbox_dspbox_write(mb_offset, &ready, sizeof(ready));
+	mb_offset = mb_offset + sizeof(ready);
+
+	mailbox_dspbox_write(mb_offset, &user_abi_version,
+			     user_abi_version.ext_hdr.hdr.size);
 
 	/* now interrupt host to tell it we are done booting */
 	shim_write(SHIM_IPCDL, SOF_IPC_FW_READY | outbox);

--- a/src/platform/baytrail/platform.c
+++ b/src/platform/baytrail/platform.c
@@ -79,65 +79,65 @@ static const struct sof_ipc_fw_ready ready
 
 #define NUM_BYT_WINDOWS		6
 
-const struct ext_man_windows xsram_window
-		__aligned(EXT_MAN_ALIGN) __section(".fw_metadata") __unused = {
-	.hdr = {
-		.type = EXT_MAN_ELEM_WINDOW,
-		.elem_size = ALIGN_UP(sizeof(struct ext_man_windows), EXT_MAN_ALIGN),
+EXT_MAN_PORT(
+	EXT_MAN_ELEM_WINDOW,
+	sizeof(struct ext_man_windows),
+	window,
+	static const struct ext_man_windows xsram_window,
+	static const struct sof_ipc_window sram_window
+		__section(".fw_ready_metadata"),
+	_META_EXPAND(
+	.ext_hdr	= {
+		.hdr.cmd = SOF_IPC_FW_READY,
+		.hdr.size = sizeof(struct sof_ipc_window),
+		.type	= SOF_IPC_EXT_WINDOW,
 	},
-	.window = {
-		.ext_hdr	= {
-			.hdr.cmd = SOF_IPC_FW_READY,
-			.hdr.size = sizeof(struct sof_ipc_window),
-			.type	= SOF_IPC_EXT_WINDOW,
+	.num_windows	= NUM_BYT_WINDOWS,
+	.window	= {
+		{
+			.type	= SOF_IPC_REGION_UPBOX,
+			.id	= 0,	/* map to host window 0 */
+			.flags	= 0, // TODO: set later
+			.size	= MAILBOX_DSPBOX_SIZE,
+			.offset	= MAILBOX_DSPBOX_OFFSET,
 		},
-		.num_windows	= NUM_BYT_WINDOWS,
-		.window	= {
-			{
-				.type	= SOF_IPC_REGION_UPBOX,
-				.id	= 0,	/* map to host window 0 */
-				.flags	= 0, // TODO: set later
-				.size	= MAILBOX_DSPBOX_SIZE,
-				.offset	= MAILBOX_DSPBOX_OFFSET,
-			},
-			{
-				.type	= SOF_IPC_REGION_DOWNBOX,
-				.id	= 0,	/* map to host window 0 */
-				.flags	= 0, // TODO: set later
-				.size	= MAILBOX_HOSTBOX_SIZE,
-				.offset	= MAILBOX_HOSTBOX_OFFSET,
-			},
-			{
-				.type	= SOF_IPC_REGION_DEBUG,
-				.id	= 0,	/* map to host window 0 */
-				.flags	= 0, // TODO: set later
-				.size	= MAILBOX_DEBUG_SIZE,
-				.offset	= MAILBOX_DEBUG_OFFSET,
-			},
-			{
-				.type	= SOF_IPC_REGION_TRACE,
-				.id	= 0,	/* map to host window 0 */
-				.flags	= 0, // TODO: set later
-				.size	= MAILBOX_TRACE_SIZE,
-				.offset	= MAILBOX_TRACE_OFFSET,
-			},
-			{
-				.type	= SOF_IPC_REGION_STREAM,
-				.id	= 0,	/* map to host window 0 */
-				.flags	= 0, // TODO: set later
-				.size	= MAILBOX_STREAM_SIZE,
-				.offset	= MAILBOX_STREAM_OFFSET,
-			},
-			{
-				.type	= SOF_IPC_REGION_EXCEPTION,
-				.id	= 0,	/* map to host window 0 */
-				.flags	= 0, // TODO: set later
-				.size	= MAILBOX_EXCEPTION_SIZE,
-				.offset	= MAILBOX_EXCEPTION_OFFSET,
-			},
+		{
+			.type	= SOF_IPC_REGION_DOWNBOX,
+			.id	= 0,	/* map to host window 0 */
+			.flags	= 0, // TODO: set later
+			.size	= MAILBOX_HOSTBOX_SIZE,
+			.offset	= MAILBOX_HOSTBOX_OFFSET,
+		},
+		{
+			.type	= SOF_IPC_REGION_DEBUG,
+			.id	= 0,	/* map to host window 0 */
+			.flags	= 0, // TODO: set later
+			.size	= MAILBOX_DEBUG_SIZE,
+			.offset	= MAILBOX_DEBUG_OFFSET,
+		},
+		{
+			.type	= SOF_IPC_REGION_TRACE,
+			.id	= 0,	/* map to host window 0 */
+			.flags	= 0, // TODO: set later
+			.size	= MAILBOX_TRACE_SIZE,
+			.offset	= MAILBOX_TRACE_OFFSET,
+		},
+		{
+			.type	= SOF_IPC_REGION_STREAM,
+			.id	= 0,	/* map to host window 0 */
+			.flags	= 0, // TODO: set later
+			.size	= MAILBOX_STREAM_SIZE,
+			.offset	= MAILBOX_STREAM_OFFSET,
+		},
+		{
+			.type	= SOF_IPC_REGION_EXCEPTION,
+			.id	= 0,	/* map to host window 0 */
+			.flags	= 0, // TODO: set later
+			.size	= MAILBOX_EXCEPTION_SIZE,
+			.offset	= MAILBOX_EXCEPTION_OFFSET,
 		},
 	},
-};
+));
 
 static SHARED_DATA struct timer timer = {
 	.id = TIMER3, /* external timer */
@@ -156,6 +156,10 @@ int platform_boot_complete(uint32_t boot_message)
 
 	mailbox_dspbox_write(mb_offset, &ready, sizeof(ready));
 	mb_offset = mb_offset + sizeof(ready);
+
+	mailbox_dspbox_write(mb_offset, &sram_window,
+			     sram_window.ext_hdr.hdr.size);
+	mb_offset = mb_offset + sram_window.ext_hdr.hdr.size;
 
 	mailbox_dspbox_write(mb_offset, &user_abi_version,
 			     user_abi_version.ext_hdr.hdr.size);

--- a/src/platform/haswell/platform.c
+++ b/src/platform/haswell/platform.c
@@ -142,6 +142,11 @@ int platform_boot_complete(uint32_t boot_message)
 			     sram_window.ext_hdr.hdr.size);
 	mb_offset = mb_offset + sram_window.ext_hdr.hdr.size;
 
+	/* variable length compiler description is a last field of cc_version */
+	mailbox_dspbox_write(mb_offset, &cc_version,
+			     cc_version.ext_hdr.hdr.size);
+	mb_offset = mb_offset + cc_version.ext_hdr.hdr.size;
+
 	mailbox_dspbox_write(mb_offset, &probe_support,
 			     probe_support.ext_hdr.hdr.size);
 	mb_offset = mb_offset + probe_support.ext_hdr.hdr.size;

--- a/src/platform/haswell/platform.c
+++ b/src/platform/haswell/platform.c
@@ -65,65 +65,65 @@ static const struct sof_ipc_fw_ready ready
 
 #define NUM_HSW_WINDOWS		6
 
-const struct ext_man_windows xsram_window
-		__aligned(EXT_MAN_ALIGN) __section(".fw_metadata") __unused = {
-	.hdr = {
-		.type = EXT_MAN_ELEM_WINDOW,
-		.elem_size = ALIGN_UP(sizeof(struct ext_man_windows), EXT_MAN_ALIGN),
+EXT_MAN_PORT(
+	EXT_MAN_ELEM_WINDOW,
+	sizeof(struct ext_man_windows),
+	window,
+	static const struct ext_man_windows xsram_window,
+	static const struct sof_ipc_window sram_window
+		__section(".fw_ready_metadata"),
+	_META_EXPAND(
+	.ext_hdr	= {
+		.hdr.cmd = SOF_IPC_FW_READY,
+		.hdr.size = sizeof(struct sof_ipc_window),
+		.type	= SOF_IPC_EXT_WINDOW,
 	},
-	.window = {
-		.ext_hdr	= {
-			.hdr.cmd = SOF_IPC_FW_READY,
-			.hdr.size = sizeof(struct sof_ipc_window),
-			.type	= SOF_IPC_EXT_WINDOW,
+	.num_windows	= NUM_HSW_WINDOWS,
+	.window	= {
+		{
+			.type	= SOF_IPC_REGION_UPBOX,
+			.id	= 0,	/* map to host window 0 */
+			.flags	= 0, // TODO: set later
+			.size	= MAILBOX_DSPBOX_SIZE,
+			.offset	= MAILBOX_DSPBOX_OFFSET,
 		},
-		.num_windows	= NUM_HSW_WINDOWS,
-		.window	= {
-			{
-				.type	= SOF_IPC_REGION_UPBOX,
-				.id	= 0,	/* map to host window 0 */
-				.flags	= 0, // TODO: set later
-				.size	= MAILBOX_DSPBOX_SIZE,
-				.offset	= MAILBOX_DSPBOX_OFFSET,
-			},
-			{
-				.type	= SOF_IPC_REGION_DOWNBOX,
-				.id	= 0,	/* map to host window 0 */
-				.flags	= 0, // TODO: set later
-				.size	= MAILBOX_HOSTBOX_SIZE,
-				.offset	= MAILBOX_HOSTBOX_OFFSET,
-			},
-			{
-				.type	= SOF_IPC_REGION_DEBUG,
-				.id	= 0,	/* map to host window 0 */
-				.flags	= 0, // TODO: set later
-				.size	= MAILBOX_DEBUG_SIZE,
-				.offset	= MAILBOX_DEBUG_OFFSET,
-			},
-			{
-				.type	= SOF_IPC_REGION_TRACE,
-				.id	= 0,	/* map to host window 0 */
-				.flags	= 0, // TODO: set later
-				.size	= MAILBOX_TRACE_SIZE,
-				.offset	= MAILBOX_TRACE_OFFSET,
-			},
-			{
-				.type	= SOF_IPC_REGION_STREAM,
-				.id	= 0,	/* map to host window 0 */
-				.flags	= 0, // TODO: set later
-				.size	= MAILBOX_STREAM_SIZE,
-				.offset	= MAILBOX_STREAM_OFFSET,
-			},
-			{
-				.type	= SOF_IPC_REGION_EXCEPTION,
-				.id	= 0,	/* map to host window 0 */
-				.flags	= 0, // TODO: set later
-				.size	= MAILBOX_EXCEPTION_SIZE,
-				.offset	= MAILBOX_EXCEPTION_OFFSET,
-			},
+		{
+			.type	= SOF_IPC_REGION_DOWNBOX,
+			.id	= 0,	/* map to host window 0 */
+			.flags	= 0, // TODO: set later
+			.size	= MAILBOX_HOSTBOX_SIZE,
+			.offset	= MAILBOX_HOSTBOX_OFFSET,
+		},
+		{
+			.type	= SOF_IPC_REGION_DEBUG,
+			.id	= 0,	/* map to host window 0 */
+			.flags	= 0, // TODO: set later
+			.size	= MAILBOX_DEBUG_SIZE,
+			.offset	= MAILBOX_DEBUG_OFFSET,
+		},
+		{
+			.type	= SOF_IPC_REGION_TRACE,
+			.id	= 0,	/* map to host window 0 */
+			.flags	= 0, // TODO: set later
+			.size	= MAILBOX_TRACE_SIZE,
+			.offset	= MAILBOX_TRACE_OFFSET,
+		},
+		{
+			.type	= SOF_IPC_REGION_STREAM,
+			.id	= 0,	/* map to host window 0 */
+			.flags	= 0, // TODO: set later
+			.size	= MAILBOX_STREAM_SIZE,
+			.offset	= MAILBOX_STREAM_OFFSET,
+		},
+		{
+			.type	= SOF_IPC_REGION_EXCEPTION,
+			.id	= 0,	/* map to host window 0 */
+			.flags	= 0, // TODO: set later
+			.size	= MAILBOX_EXCEPTION_SIZE,
+			.offset	= MAILBOX_EXCEPTION_OFFSET,
 		},
 	},
-};
+));
 
 SHARED_DATA struct timer timer = {
 	.id = TIMER1, /* internal timer */
@@ -137,6 +137,10 @@ int platform_boot_complete(uint32_t boot_message)
 
 	mailbox_dspbox_write(mb_offset, &ready, sizeof(ready));
 	mb_offset = mb_offset + sizeof(ready);
+
+	mailbox_dspbox_write(mb_offset, &sram_window,
+			     sram_window.ext_hdr.hdr.size);
+	mb_offset = mb_offset + sram_window.ext_hdr.hdr.size;
 
 	mailbox_dspbox_write(mb_offset, &user_abi_version,
 			     user_abi_version.ext_hdr.hdr.size);

--- a/src/platform/haswell/platform.c
+++ b/src/platform/haswell/platform.c
@@ -142,6 +142,10 @@ int platform_boot_complete(uint32_t boot_message)
 			     sram_window.ext_hdr.hdr.size);
 	mb_offset = mb_offset + sram_window.ext_hdr.hdr.size;
 
+	mailbox_dspbox_write(mb_offset, &probe_support,
+			     probe_support.ext_hdr.hdr.size);
+	mb_offset = mb_offset + probe_support.ext_hdr.hdr.size;
+
 	mailbox_dspbox_write(mb_offset, &user_abi_version,
 			     user_abi_version.ext_hdr.hdr.size);
 

--- a/src/platform/haswell/platform.c
+++ b/src/platform/haswell/platform.c
@@ -132,9 +132,14 @@ SHARED_DATA struct timer timer = {
 
 int platform_boot_complete(uint32_t boot_message)
 {
+	uint32_t mb_offset = 0;
 	uint32_t outbox = MAILBOX_HOST_OFFSET >> 3;
 
-	mailbox_dspbox_write(0, &ready, sizeof(ready));
+	mailbox_dspbox_write(mb_offset, &ready, sizeof(ready));
+	mb_offset = mb_offset + sizeof(ready);
+
+	mailbox_dspbox_write(mb_offset, &user_abi_version,
+			     user_abi_version.ext_hdr.hdr.size);
 
 	/* now interrupt host to tell it we are done booting */
 	shim_write(SHIM_IPCD, outbox | SHIM_IPCD_BUSY);

--- a/src/platform/imx8/platform.c
+++ b/src/platform/imx8/platform.c
@@ -140,6 +140,10 @@ int platform_boot_complete(uint32_t boot_message)
 			     sram_window.ext_hdr.hdr.size);
 	mb_offset = mb_offset + sram_window.ext_hdr.hdr.size;
 
+	mailbox_dspbox_write(mb_offset, &probe_support,
+			     probe_support.ext_hdr.hdr.size);
+	mb_offset = mb_offset + probe_support.ext_hdr.hdr.size;
+
 	mailbox_dspbox_write(mb_offset, &user_abi_version,
 			     user_abi_version.ext_hdr.hdr.size);
 

--- a/src/platform/imx8/platform.c
+++ b/src/platform/imx8/platform.c
@@ -140,6 +140,11 @@ int platform_boot_complete(uint32_t boot_message)
 			     sram_window.ext_hdr.hdr.size);
 	mb_offset = mb_offset + sram_window.ext_hdr.hdr.size;
 
+	/* variable length compiler description is a last field of cc_version */
+	mailbox_dspbox_write(mb_offset, &cc_version,
+			     cc_version.ext_hdr.hdr.size);
+	mb_offset = mb_offset + cc_version.ext_hdr.hdr.size;
+
 	mailbox_dspbox_write(mb_offset, &probe_support,
 			     probe_support.ext_hdr.hdr.size);
 	mb_offset = mb_offset + probe_support.ext_hdr.hdr.size;

--- a/src/platform/imx8/platform.c
+++ b/src/platform/imx8/platform.c
@@ -64,65 +64,65 @@ static const struct sof_ipc_fw_ready ready
 
 #define NUM_IMX_WINDOWS		6
 
-const struct ext_man_windows xsram_window
-		__aligned(EXT_MAN_ALIGN) __section(".fw_metadata") __unused = {
-	.hdr = {
-		.type = EXT_MAN_ELEM_WINDOW,
-		.elem_size = ALIGN_UP(sizeof(struct ext_man_windows), EXT_MAN_ALIGN),
+EXT_MAN_PORT(
+	EXT_MAN_ELEM_WINDOW,
+	sizeof(struct ext_man_windows),
+	window,
+	static const struct ext_man_windows xsram_window,
+	static const struct sof_ipc_window sram_window
+		__section(".fw_ready_metadata"),
+	_META_EXPAND(
+	.ext_hdr	= {
+		.hdr.cmd = SOF_IPC_FW_READY,
+		.hdr.size = sizeof(struct sof_ipc_window),
+		.type	= SOF_IPC_EXT_WINDOW,
 	},
-	.window = {
-		.ext_hdr	= {
-			.hdr.cmd = SOF_IPC_FW_READY,
-			.hdr.size = sizeof(struct sof_ipc_window),
-			.type	= SOF_IPC_EXT_WINDOW,
+	.num_windows	= NUM_IMX_WINDOWS,
+	.window	= {
+		{
+			.type	= SOF_IPC_REGION_UPBOX,
+			.id	= 0,	/* map to host window 0 */
+			.flags	= 0, // TODO: set later
+			.size	= MAILBOX_DSPBOX_SIZE,
+			.offset	= MAILBOX_DSPBOX_OFFSET,
 		},
-		.num_windows	= NUM_IMX_WINDOWS,
-		.window	= {
-			{
-				.type	= SOF_IPC_REGION_UPBOX,
-				.id	= 0,	/* map to host window 0 */
-				.flags	= 0, // TODO: set later
-				.size	= MAILBOX_DSPBOX_SIZE,
-				.offset	= MAILBOX_DSPBOX_OFFSET,
-			},
-			{
-				.type	= SOF_IPC_REGION_DOWNBOX,
-				.id	= 0,	/* map to host window 0 */
-				.flags	= 0, // TODO: set later
-				.size	= MAILBOX_HOSTBOX_SIZE,
-				.offset	= MAILBOX_HOSTBOX_OFFSET,
-			},
-			{
-				.type	= SOF_IPC_REGION_DEBUG,
-				.id	= 0,	/* map to host window 0 */
-				.flags	= 0, // TODO: set later
-				.size	= MAILBOX_DEBUG_SIZE,
-				.offset	= MAILBOX_DEBUG_OFFSET,
-			},
-			{
-				.type	= SOF_IPC_REGION_TRACE,
-				.id	= 0,	/* map to host window 0 */
-				.flags	= 0, // TODO: set later
-				.size	= MAILBOX_TRACE_SIZE,
-				.offset	= MAILBOX_TRACE_OFFSET,
-			},
-			{
-				.type	= SOF_IPC_REGION_STREAM,
-				.id	= 0,	/* map to host window 0 */
-				.flags	= 0, // TODO: set later
-				.size	= MAILBOX_STREAM_SIZE,
-				.offset	= MAILBOX_STREAM_OFFSET,
-			},
-			{
-				.type	= SOF_IPC_REGION_EXCEPTION,
-				.id	= 0,	/* map to host window 0 */
-				.flags	= 0, // TODO: set later
-				.size	= MAILBOX_EXCEPTION_SIZE,
-				.offset	= MAILBOX_EXCEPTION_OFFSET,
-			},
+		{
+			.type	= SOF_IPC_REGION_DOWNBOX,
+			.id	= 0,	/* map to host window 0 */
+			.flags	= 0, // TODO: set later
+			.size	= MAILBOX_HOSTBOX_SIZE,
+			.offset	= MAILBOX_HOSTBOX_OFFSET,
 		},
-	}
-};
+		{
+			.type	= SOF_IPC_REGION_DEBUG,
+			.id	= 0,	/* map to host window 0 */
+			.flags	= 0, // TODO: set later
+			.size	= MAILBOX_DEBUG_SIZE,
+			.offset	= MAILBOX_DEBUG_OFFSET,
+		},
+		{
+			.type	= SOF_IPC_REGION_TRACE,
+			.id	= 0,	/* map to host window 0 */
+			.flags	= 0, // TODO: set later
+			.size	= MAILBOX_TRACE_SIZE,
+			.offset	= MAILBOX_TRACE_OFFSET,
+		},
+		{
+			.type	= SOF_IPC_REGION_STREAM,
+			.id	= 0,	/* map to host window 0 */
+			.flags	= 0, // TODO: set later
+			.size	= MAILBOX_STREAM_SIZE,
+			.offset	= MAILBOX_STREAM_OFFSET,
+		},
+		{
+			.type	= SOF_IPC_REGION_EXCEPTION,
+			.id	= 0,	/* map to host window 0 */
+			.flags	= 0, // TODO: set later
+			.size	= MAILBOX_EXCEPTION_SIZE,
+			.offset	= MAILBOX_EXCEPTION_OFFSET,
+		},
+	},
+));
 
 SHARED_DATA struct timer timer = {
 	.id = TIMER0, /* internal timer */
@@ -135,6 +135,10 @@ int platform_boot_complete(uint32_t boot_message)
 
 	mailbox_dspbox_write(mb_offset, &ready, sizeof(ready));
 	mb_offset = mb_offset + sizeof(ready);
+
+	mailbox_dspbox_write(mb_offset, &sram_window,
+			     sram_window.ext_hdr.hdr.size);
+	mb_offset = mb_offset + sram_window.ext_hdr.hdr.size;
 
 	mailbox_dspbox_write(mb_offset, &user_abi_version,
 			     user_abi_version.ext_hdr.hdr.size);

--- a/src/platform/imx8/platform.c
+++ b/src/platform/imx8/platform.c
@@ -131,7 +131,13 @@ SHARED_DATA struct timer timer = {
 
 int platform_boot_complete(uint32_t boot_message)
 {
-	mailbox_dspbox_write(0, &ready, sizeof(ready));
+	uint32_t mb_offset = 0;
+
+	mailbox_dspbox_write(mb_offset, &ready, sizeof(ready));
+	mb_offset = mb_offset + sizeof(ready);
+
+	mailbox_dspbox_write(mb_offset, &user_abi_version,
+			     user_abi_version.ext_hdr.hdr.size);
 
 	/* now interrupt host to tell it we are done booting */
 	imx_mu_xcr_rmw(IMX_MU_xCR_GIRn(1), 0);

--- a/src/platform/imx8m/platform.c
+++ b/src/platform/imx8m/platform.c
@@ -63,65 +63,65 @@ static const struct sof_ipc_fw_ready ready
 
 #define NUM_IMX_WINDOWS		6
 
-const struct ext_man_windows xsram_window
-		__aligned(EXT_MAN_ALIGN) __section(".fw_metadata") __unused = {
-	.hdr = {
-		.type = EXT_MAN_ELEM_WINDOW,
-		.elem_size = ALIGN_UP(sizeof(struct ext_man_windows), EXT_MAN_ALIGN),
+EXT_MAN_PORT(
+	EXT_MAN_ELEM_WINDOW,
+	sizeof(struct ext_man_windows),
+	window,
+	static const struct ext_man_windows xsram_window,
+	static const struct sof_ipc_window sram_window
+		__section(".fw_ready_metadata"),
+	_META_EXPAND(
+	.ext_hdr	= {
+		.hdr.cmd = SOF_IPC_FW_READY,
+		.hdr.size = sizeof(struct sof_ipc_window),
+		.type	= SOF_IPC_EXT_WINDOW,
 	},
-	.window = {
-		.ext_hdr	= {
-			.hdr.cmd = SOF_IPC_FW_READY,
-			.hdr.size = sizeof(struct sof_ipc_window),
-			.type	= SOF_IPC_EXT_WINDOW,
+	.num_windows	= NUM_IMX_WINDOWS,
+	.window	= {
+		{
+			.type	= SOF_IPC_REGION_UPBOX,
+			.id	= 0,	/* map to host window 0 */
+			.flags	= 0, // TODO: set later
+			.size	= MAILBOX_DSPBOX_SIZE,
+			.offset	= MAILBOX_DSPBOX_OFFSET,
 		},
-		.num_windows	= NUM_IMX_WINDOWS,
-		.window	= {
-			{
-				.type	= SOF_IPC_REGION_UPBOX,
-				.id	= 0,	/* map to host window 0 */
-				.flags	= 0, // TODO: set later
-				.size	= MAILBOX_DSPBOX_SIZE,
-				.offset	= MAILBOX_DSPBOX_OFFSET,
-			},
-			{
-				.type	= SOF_IPC_REGION_DOWNBOX,
-				.id	= 0,	/* map to host window 0 */
-				.flags	= 0, // TODO: set later
-				.size	= MAILBOX_HOSTBOX_SIZE,
-				.offset	= MAILBOX_HOSTBOX_OFFSET,
-			},
-			{
-				.type	= SOF_IPC_REGION_DEBUG,
-				.id	= 0,	/* map to host window 0 */
-				.flags	= 0, // TODO: set later
-				.size	= MAILBOX_DEBUG_SIZE,
-				.offset	= MAILBOX_DEBUG_OFFSET,
-			},
-			{
-				.type	= SOF_IPC_REGION_TRACE,
-				.id	= 0,	/* map to host window 0 */
-				.flags	= 0, // TODO: set later
-				.size	= MAILBOX_TRACE_SIZE,
-				.offset	= MAILBOX_TRACE_OFFSET,
-			},
-			{
-				.type	= SOF_IPC_REGION_STREAM,
-				.id	= 0,	/* map to host window 0 */
-				.flags	= 0, // TODO: set later
-				.size	= MAILBOX_STREAM_SIZE,
-				.offset	= MAILBOX_STREAM_OFFSET,
-			},
-			{
-				.type	= SOF_IPC_REGION_EXCEPTION,
-				.id	= 0,	/* map to host window 0 */
-				.flags	= 0, // TODO: set later
-				.size	= MAILBOX_EXCEPTION_SIZE,
-				.offset	= MAILBOX_EXCEPTION_OFFSET,
-			},
+		{
+			.type	= SOF_IPC_REGION_DOWNBOX,
+			.id	= 0,	/* map to host window 0 */
+			.flags	= 0, // TODO: set later
+			.size	= MAILBOX_HOSTBOX_SIZE,
+			.offset	= MAILBOX_HOSTBOX_OFFSET,
+		},
+		{
+			.type	= SOF_IPC_REGION_DEBUG,
+			.id	= 0,	/* map to host window 0 */
+			.flags	= 0, // TODO: set later
+			.size	= MAILBOX_DEBUG_SIZE,
+			.offset	= MAILBOX_DEBUG_OFFSET,
+		},
+		{
+			.type	= SOF_IPC_REGION_TRACE,
+			.id	= 0,	/* map to host window 0 */
+			.flags	= 0, // TODO: set later
+			.size	= MAILBOX_TRACE_SIZE,
+			.offset	= MAILBOX_TRACE_OFFSET,
+		},
+		{
+			.type	= SOF_IPC_REGION_STREAM,
+			.id	= 0,	/* map to host window 0 */
+			.flags	= 0, // TODO: set later
+			.size	= MAILBOX_STREAM_SIZE,
+			.offset	= MAILBOX_STREAM_OFFSET,
+		},
+		{
+			.type	= SOF_IPC_REGION_EXCEPTION,
+			.id	= 0,	/* map to host window 0 */
+			.flags	= 0, // TODO: set later
+			.size	= MAILBOX_EXCEPTION_SIZE,
+			.offset	= MAILBOX_EXCEPTION_OFFSET,
 		},
 	},
-};
+));
 
 SHARED_DATA struct timer timer = {
 	.id = TIMER0, /* internal timer */
@@ -134,6 +134,10 @@ int platform_boot_complete(uint32_t boot_message)
 
 	mailbox_dspbox_write(mb_offset, &ready, sizeof(ready));
 	mb_offset = mb_offset + sizeof(ready);
+
+	mailbox_dspbox_write(mb_offset, &sram_window,
+			     sram_window.ext_hdr.hdr.size);
+	mb_offset = mb_offset + sram_window.ext_hdr.hdr.size;
 
 	mailbox_dspbox_write(mb_offset, &user_abi_version,
 			     user_abi_version.ext_hdr.hdr.size);

--- a/src/platform/imx8m/platform.c
+++ b/src/platform/imx8m/platform.c
@@ -139,6 +139,11 @@ int platform_boot_complete(uint32_t boot_message)
 			     sram_window.ext_hdr.hdr.size);
 	mb_offset = mb_offset + sram_window.ext_hdr.hdr.size;
 
+	/* variable length compiler description is a last field of cc_version */
+	mailbox_dspbox_write(mb_offset, &cc_version,
+			     cc_version.ext_hdr.hdr.size);
+	mb_offset = mb_offset + cc_version.ext_hdr.hdr.size;
+
 	mailbox_dspbox_write(mb_offset, &probe_support,
 			     probe_support.ext_hdr.hdr.size);
 	mb_offset = mb_offset + probe_support.ext_hdr.hdr.size;

--- a/src/platform/imx8m/platform.c
+++ b/src/platform/imx8m/platform.c
@@ -139,6 +139,10 @@ int platform_boot_complete(uint32_t boot_message)
 			     sram_window.ext_hdr.hdr.size);
 	mb_offset = mb_offset + sram_window.ext_hdr.hdr.size;
 
+	mailbox_dspbox_write(mb_offset, &probe_support,
+			     probe_support.ext_hdr.hdr.size);
+	mb_offset = mb_offset + probe_support.ext_hdr.hdr.size;
+
 	mailbox_dspbox_write(mb_offset, &user_abi_version,
 			     user_abi_version.ext_hdr.hdr.size);
 

--- a/src/platform/imx8m/platform.c
+++ b/src/platform/imx8m/platform.c
@@ -130,7 +130,13 @@ SHARED_DATA struct timer timer = {
 
 int platform_boot_complete(uint32_t boot_message)
 {
-	mailbox_dspbox_write(0, &ready, sizeof(ready));
+	uint32_t mb_offset = 0;
+
+	mailbox_dspbox_write(mb_offset, &ready, sizeof(ready));
+	mb_offset = mb_offset + sizeof(ready);
+
+	mailbox_dspbox_write(mb_offset, &user_abi_version,
+			     user_abi_version.ext_hdr.hdr.size);
 
 	/* now interrupt host to tell it we are done booting */
 	imx_mu_xcr_rmw(IMX_MU_xCR_GIRn(1), 0);

--- a/src/platform/intel/cavs/include/cavs/lib/asm_memory_management.h
+++ b/src/platform/intel/cavs/include/cavs/lib/asm_memory_management.h
@@ -20,6 +20,8 @@
 #warning "The file is intended to be included in assembly files only."
 #endif
 
+#include <cavs/version.h>
+
 #include <sof/lib/memory.h>
 #include <sof/lib/shim.h>
 

--- a/src/platform/intel/cavs/include/cavs/version.h
+++ b/src/platform/intel/cavs/include/cavs/version.h
@@ -8,8 +8,6 @@
 #ifndef __CAVS_VERSION_H__
 #define __CAVS_VERSION_H__
 
-
-
 #define CAVS_VERSION_1_5 0x10500
 #define CAVS_VERSION_1_8 0x10800
 #define CAVS_VERSION_2_0 0x20000

--- a/src/platform/intel/cavs/lib/clk.c
+++ b/src/platform/intel/cavs/lib/clk.c
@@ -13,6 +13,8 @@
 #include <sof/sof.h>
 #include <sof/spinlock.h>
 
+#include <cavs/version.h>
+
 static SHARED_DATA struct clock_info platform_clocks_info[NUM_CLOCKS];
 
 #if CAVS_VERSION == CAVS_VERSION_1_5

--- a/src/platform/intel/cavs/lib/pm_runtime.c
+++ b/src/platform/intel/cavs/lib/pm_runtime.c
@@ -13,6 +13,7 @@
  */
 
 #include <cavs/lib/pm_memory.h>
+#include <cavs/version.h>
 #include <sof/debug/panic.h>
 #include <sof/drivers/interrupt.h>
 #include <sof/lib/alloc.h>

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -308,6 +308,10 @@ int platform_boot_complete(uint32_t boot_message)
 	mb_offset = mb_offset + sram_window.ext_hdr.hdr.size;
 #endif
 
+	mailbox_dspbox_write(mb_offset, &probe_support,
+			     probe_support.ext_hdr.hdr.size);
+	mb_offset = mb_offset + probe_support.ext_hdr.hdr.size;
+
 	mailbox_dspbox_write(mb_offset, &user_abi_version,
 			     user_abi_version.ext_hdr.hdr.size);
 

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -78,72 +78,72 @@ static const struct sof_ipc_fw_ready ready
 
 #define NUM_WINDOWS 7
 
-const struct ext_man_windows xsram_window
-		__aligned(EXT_MAN_ALIGN) __section(".fw_metadata") __unused = {
-	.hdr = {
-		.type = EXT_MAN_ELEM_WINDOW,
-		.elem_size = ALIGN_UP(sizeof(struct ext_man_windows), EXT_MAN_ALIGN),
+EXT_MAN_PORT(
+	EXT_MAN_ELEM_WINDOW,
+	sizeof(struct ext_man_windows),
+	window,
+	static const struct ext_man_windows xsram_window,
+	static const struct sof_ipc_window sram_window
+		__section(".fw_ready_metadata"),
+	_META_EXPAND(
+	.ext_hdr	= {
+		.hdr.cmd = SOF_IPC_FW_READY,
+		.hdr.size = sizeof(struct sof_ipc_window),
+		.type	= SOF_IPC_EXT_WINDOW,
 	},
-	.window = {
-		.ext_hdr	= {
-			.hdr.cmd = SOF_IPC_FW_READY,
-			.hdr.size = sizeof(struct sof_ipc_window),
-			.type	= SOF_IPC_EXT_WINDOW,
+	.num_windows	= NUM_WINDOWS,
+	.window	= {
+		{
+			.type	= SOF_IPC_REGION_REGS,
+			.id	= 0,	/* map to host window 0 */
+			.flags	= 0, // TODO: set later
+			.size	= MAILBOX_SW_REG_SIZE,
+			.offset	= 0,
 		},
-		.num_windows	= NUM_WINDOWS,
-		.window	= {
-			{
-				.type	= SOF_IPC_REGION_REGS,
-				.id	= 0,	/* map to host window 0 */
-				.flags	= 0, // TODO: set later
-				.size	= MAILBOX_SW_REG_SIZE,
-				.offset	= 0,
-			},
-			{
-				.type	= SOF_IPC_REGION_UPBOX,
-				.id	= 0,	/* map to host window 0 */
-				.flags	= 0, // TODO: set later
-				.size	= MAILBOX_DSPBOX_SIZE,
-				.offset	= MAILBOX_SW_REG_SIZE,
-			},
-			{
-				.type	= SOF_IPC_REGION_DOWNBOX,
-				.id	= 1,	/* map to host window 1 */
-				.flags	= 0, // TODO: set later
-				.size	= MAILBOX_HOSTBOX_SIZE,
-				.offset	= 0,
-			},
-			{
-				.type	= SOF_IPC_REGION_DEBUG,
-				.id	= 2,	/* map to host window 2 */
-				.flags	= 0, // TODO: set later
-				.size	= MAILBOX_DEBUG_SIZE,
-				.offset	= 0,
-			},
-			{
-				.type	= SOF_IPC_REGION_EXCEPTION,
-				.id	= 2,	/* map to host window 2 */
-				.flags	= 0, // TODO: set later
-				.size	= MAILBOX_EXCEPTION_SIZE,
-				.offset	= MAILBOX_EXCEPTION_OFFSET,
-			},
-			{
-				.type	= SOF_IPC_REGION_STREAM,
-				.id	= 2,	/* map to host window 2 */
-				.flags	= 0, // TODO: set later
-				.size	= MAILBOX_STREAM_SIZE,
-				.offset	= MAILBOX_STREAM_OFFSET,
-			},
-			{
-				.type	= SOF_IPC_REGION_TRACE,
-				.id	= 3,	/* map to host window 3 */
-				.flags	= 0, // TODO: set later
-				.size	= MAILBOX_TRACE_SIZE,
-				.offset	= 0,
-			},
+		{
+			.type	= SOF_IPC_REGION_UPBOX,
+			.id	= 0,	/* map to host window 0 */
+			.flags	= 0, // TODO: set later
+			.size	= MAILBOX_DSPBOX_SIZE,
+			.offset	= MAILBOX_SW_REG_SIZE,
+		},
+		{
+			.type	= SOF_IPC_REGION_DOWNBOX,
+			.id	= 1,	/* map to host window 1 */
+			.flags	= 0, // TODO: set later
+			.size	= MAILBOX_HOSTBOX_SIZE,
+			.offset	= 0,
+		},
+		{
+			.type	= SOF_IPC_REGION_DEBUG,
+			.id	= 2,	/* map to host window 2 */
+			.flags	= 0, // TODO: set later
+			.size	= MAILBOX_DEBUG_SIZE,
+			.offset	= 0,
+		},
+		{
+			.type	= SOF_IPC_REGION_EXCEPTION,
+			.id	= 2,	/* map to host window 2 */
+			.flags	= 0, // TODO: set later
+			.size	= MAILBOX_EXCEPTION_SIZE,
+			.offset	= MAILBOX_EXCEPTION_OFFSET,
+		},
+		{
+			.type	= SOF_IPC_REGION_STREAM,
+			.id	= 2,	/* map to host window 2 */
+			.flags	= 0, // TODO: set later
+			.size	= MAILBOX_STREAM_SIZE,
+			.offset	= MAILBOX_STREAM_OFFSET,
+		},
+		{
+			.type	= SOF_IPC_REGION_TRACE,
+			.id	= 3,	/* map to host window 3 */
+			.flags	= 0, // TODO: set later
+			.size	= MAILBOX_TRACE_SIZE,
+			.offset	= 0,
 		},
 	},
-};
+));
 #endif
 
 #if CONFIG_CANNONLAKE || CONFIG_ICELAKE || CONFIG_TIGERLAKE
@@ -301,6 +301,12 @@ int platform_boot_complete(uint32_t boot_message)
 
 	mailbox_dspbox_write(mb_offset, &ready, sizeof(ready));
 	mb_offset = mb_offset + sizeof(ready);
+
+#if CONFIG_MEM_WND
+	mailbox_dspbox_write(mb_offset, &sram_window,
+			     sram_window.ext_hdr.hdr.size);
+	mb_offset = mb_offset + sram_window.ext_hdr.hdr.size;
+#endif
 
 	mailbox_dspbox_write(mb_offset, &user_abi_version,
 			     user_abi_version.ext_hdr.hdr.size);

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -292,12 +292,18 @@ int platform_boot_complete(uint32_t boot_message)
 
 int platform_boot_complete(uint32_t boot_message)
 {
+	uint32_t mb_offset = 0;
+
 #if CONFIG_TIGERLAKE && !CONFIG_CAVS_LPRO_ONLY
 	/* TGL specific HW recommended flow */
 	pm_runtime_get(PM_RUNTIME_DSP, PWRD_BY_HPRO | (CONFIG_CORE_COUNT - 1));
 #endif
 
-	mailbox_dspbox_write(0, &ready, sizeof(ready));
+	mailbox_dspbox_write(mb_offset, &ready, sizeof(ready));
+	mb_offset = mb_offset + sizeof(ready);
+
+	mailbox_dspbox_write(mb_offset, &user_abi_version,
+			     user_abi_version.ext_hdr.hdr.size);
 
 	/* tell host we are ready */
 #if CAVS_VERSION == CAVS_VERSION_1_5

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -308,6 +308,11 @@ int platform_boot_complete(uint32_t boot_message)
 	mb_offset = mb_offset + sram_window.ext_hdr.hdr.size;
 #endif
 
+	/* variable length compiler description is a last field of cc_version */
+	mailbox_dspbox_write(mb_offset, &cc_version,
+			     cc_version.ext_hdr.hdr.size);
+	mb_offset = mb_offset + cc_version.ext_hdr.hdr.size;
+
 	mailbox_dspbox_write(mb_offset, &probe_support,
 			     probe_support.ext_hdr.hdr.size);
 	mb_offset = mb_offset + probe_support.ext_hdr.hdr.size;

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -341,7 +341,9 @@ zephyr_library_sources(
 	${SOF_IPC_PATH}/ipc.c
 	${SOF_IPC_PATH}/handler.c
 	${SOF_IPC_PATH}/probe_support.c
+	${SOF_IPC_PATH}/user_abi_version.c
 	${SOF_IPC_PATH}/ipc-host-ptable.c
+	${SOF_IPC_PATH}/cc_version.c
 	${SOF_SRC_PATH}/spinlock.c
 
 	# SOF math utilities

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -340,6 +340,7 @@ zephyr_library_sources(
 	${SOF_IPC_PATH}/dma-copy.c
 	${SOF_IPC_PATH}/ipc.c
 	${SOF_IPC_PATH}/handler.c
+	${SOF_IPC_PATH}/probe_support.c
 	${SOF_IPC_PATH}/ipc-host-ptable.c
 	${SOF_SRC_PATH}/spinlock.c
 

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -35,6 +35,7 @@ zephyr_interface_library_named(SOF)
 set(SOF_SRC_PATH "../src")
 set(SOF_PLATFORM_PATH "${SOF_SRC_PATH}/platform")
 set(SOF_AUDIO_PATH "${SOF_SRC_PATH}/audio")
+set(SOF_SAMPLES_PATH "${SOF_SRC_PATH}/samples")
 set(SOF_LIB_PATH "${SOF_SRC_PATH}/lib")
 set(SOF_DRIVERS_PATH "${SOF_SRC_PATH}/drivers")
 set(SOF_IPC_PATH "${SOF_SRC_PATH}/ipc")
@@ -439,8 +440,8 @@ zephyr_library_sources_ifdef(CONFIG_COMP_DAI
 	${SOF_AUDIO_PATH}/dai.c
 )
 
-zephyr_library_sources_ifdef(CONFIG_COMP_TEST_KEYPHRASE
-	${SOF_AUDIO_PATH}/detect_test.c
+zephyr_library_sources_ifdef(CONFIG_SAMPLE_KEYPHRASE
+	${SOF_SAMPLES_PATH}/audio/detect_test.c
 )
 
 zephyr_library_sources_ifdef(CONFIG_COMP_VOLUME

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -28,10 +28,6 @@
 #error Define CONFIG_DYNAMIC_INTERRUPTS
 #endif
 
-#if !defined(CONFIG_SYS_HEAP_ALIGNED_ALLOC)
-#error Define CONFIG_SYS_HEAP_ALIGNED_ALLOC
-#endif
-
 /*
  * Memory - Create Zephyr HEAP for SOF.
  *

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -50,7 +50,7 @@ uint8_t __aligned(64) heapmem[HEAP_SIZE];
 /* Use k_heap structure */
 static struct k_heap sof_heap;
 
-static int statics_init(struct device *unused)
+static int statics_init(const struct device *unused)
 {
 	ARG_UNUSED(unused);
 
@@ -197,7 +197,8 @@ int interrupt_get_irq(unsigned int irq, const char *cascade)
 
 int interrupt_register(uint32_t irq, void(*handler)(void *arg), void *arg)
 {
-	return arch_irq_connect_dynamic(irq, 0, handler, arg, 0);
+	return arch_irq_connect_dynamic(irq, 0, (void (*)(const void *))handler,
+					arg, 0);
 }
 
 /* unregister an IRQ handler - matches on IRQ number and data ptr */

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -415,7 +415,7 @@ int task_main_start(struct sof *sof)
 		sys_comp_eq_iir_init();
 	}
 
-	if (IS_ENABLED(CONFIG_COMP_KPB)) {
+	if (IS_ENABLED(CONFIG_SAMPLE_KEYPHRASE)) {
 		sys_comp_keyword_init();
 	}
 


### PR DESCRIPTION
Zephyr fixes for cAVS 1.8+. Note, that the first commit has already been merged, the last one is actually a temporary "fix," but probably we'll have to apply it for now or find a different way to limit the number of cores to 1