### PR TITLE
Topology: Use pipe-volume-switch-capture in nocodec topologies

### DIFF
--- a/tools/topology/sof-apl-nocodec.m4
+++ b/tools/topology/sof-apl-nocodec.m4
@@ -47,9 +47,9 @@ PIPELINE_PCM_ADD(sof/pipe-low-latency-playback.m4,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
-# Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s16le.
+# Volume switch capture pipeline 2 on PCM 0 using max 2 channels of s16le.
 # 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-switch-capture.m4,
 	2, 0, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
@@ -61,9 +61,9 @@ PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
-# Low Latency capture pipeline 4 on PCM 1 using max 2 channels of s16le.
+# Volume switch capture pipeline 4 on PCM 1 using max 2 channels of s16le.
 # 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-switch-capture.m4,
 	4, 1, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
@@ -75,9 +75,9 @@ PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 #	1000, 0, 0,
 #	48000, 48000, 48000)
 
-# Low Latency capture pipeline 6 on PCM 2 using max 2 channels of s16le.
+# Volume switch capture pipeline 6 on PCM 2 using max 2 channels of s16le.
 # 1000us deadline on core 0 with priority 0
-#PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
+#PIPELINE_PCM_ADD(sof/pipe-volume-switch-capture.m4,
 #	6, 2, 2, s32le,
 #	1000, 0, 0,
 #	48000, 48000, 48000)
@@ -89,9 +89,9 @@ PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
-# Low Latency capture pipeline 8 on PCM 3 using max 2 channels of s16le.
+# Volume switch capture pipeline 8 on PCM 3 using max 2 channels of s16le.
 # 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-switch-capture.m4,
 	8, 3, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
@@ -103,9 +103,9 @@ PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 #	1000, 0, 0,
 #	48000, 48000, 48000)
 
-# Low Latency capture pipeline 10 on PCM 4 using max 2 channels of s16le.
+# Volume switch capture pipeline 10 on PCM 4 using max 2 channels of s16le.
 # 1000us deadline on core 0 with priority 0
-#PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
+#PIPELINE_PCM_ADD(sof/pipe-volume-switch-capture.m4,
 #	10, 4, 2, s32le,
 #	1000, 0, 0,
 #	48000, 48000, 48000)
@@ -117,9 +117,9 @@ PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
-# Low Latency capture pipeline 12 on PCM 5 using max 2 channels of s16le.
+# Volume switch capture pipeline 12 on PCM 5 using max 2 channels of s16le.
 # 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-switch-capture.m4,
 	12, 5, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)

--- a/tools/topology/sof-bdw-nocodec.m4
+++ b/tools/topology/sof-bdw-nocodec.m4
@@ -34,9 +34,9 @@ PIPELINE_PCM_ADD(sof/pipe-low-latency-playback.m4,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
-# Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s32le.
+# Volume switch capture pipeline 2 on PCM 0 using max 2 channels of s32le.
 # 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_ADD(sof/pipe-low-latency-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-switch-capture.m4,
 	2, 0, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)

--- a/tools/topology/sof-cht-nocodec.m4
+++ b/tools/topology/sof-cht-nocodec.m4
@@ -24,9 +24,9 @@ include(`platform/intel/'PLATFORM`.m4')
 # PCM0 <---- Volume <---- SSP2
 #
 
-# Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s32le.
+# Volume switch capture pipeline 2 on PCM 0 using max 2 channels of s32le.
 # 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_ADD(sof/pipe-low-latency-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-switch-capture.m4,
 	2, 0, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)

--- a/tools/topology/sof-cnl-nocodec.m4
+++ b/tools/topology/sof-cnl-nocodec.m4
@@ -40,9 +40,9 @@ PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
-# Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s24le.
+# Volume switch capture pipeline 2 on PCM 0 using max 2 channels of s24le.
 # Set 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-switch-capture.m4,
 	2, 0, 2, s24le,
 	1000, 0, 0,
 	48000, 48000, 48000)
@@ -54,9 +54,9 @@ PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
-# Low Latency capture pipeline 4 on PCM 1 using max 2 channels of s24le.
+# Volume switch capture pipeline 4 on PCM 1 using max 2 channels of s24le.
 # Set 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-switch-capture.m4,
 	4, 1, 2, s24le,
 	1000, 0, 0,
 	48000, 48000, 48000)
@@ -68,9 +68,9 @@ PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
-# Low Latency capture pipeline 6 on PCM 2 using max 2 channels of s24le.
+# Volume switch capture pipeline 6 on PCM 2 using max 2 channels of s24le.
 # Set 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-switch-capture.m4,
 	6, 2, 2, s24le,
 	1000, 0, 0,
 	48000, 48000, 48000)

--- a/tools/topology/sof-icl-nocodec.m4
+++ b/tools/topology/sof-icl-nocodec.m4
@@ -36,9 +36,9 @@ PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
-# Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s24le.
+# Volume switch capture pipeline 2 on PCM 0 using max 2 channels of s24le.
 # 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-switch-capture.m4,
 	2, 0, 2, s24le,
 	1000, 0, 0,
 	48000, 48000, 48000)

--- a/tools/topology/sof-tgl-nocodec.m4
+++ b/tools/topology/sof-tgl-nocodec.m4
@@ -44,9 +44,9 @@ PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
-# Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s16le.
+# Volume switch capture pipeline 2 on PCM 0 using max 2 channels of s16le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-switch-capture.m4,
 	2, 0, 2, s16le,
 	1000, 0, 0,
 	48000, 48000, 48000)
@@ -58,9 +58,9 @@ PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
-# Low Latency capture pipeline 4 on PCM 1 using max 2 channels of s16le.
+# Volume switch capture pipeline 4 on PCM 1 using max 2 channels of s16le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-switch-capture.m4,
 	4, 1, 2, s16le,
 	1000, 0, 0,
 	48000, 48000, 48000)
@@ -72,9 +72,9 @@ PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
-# Low Latency capture pipeline 6 on PCM 2 using max 2 channels of s16le.
+# Volume switch capture pipeline 6 on PCM 2 using max 2 channels of s16le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-switch-capture.m4,
 	6, 2, 2, s16le,
 	1000, 0, 0,
 	48000, 48000, 48000)


### PR DESCRIPTION
This patch replaces use of pipe-volume-capture macro to
pipe-volume-switch-capture in nocodec topologies for APL, CNL, ICL,
and TGL based platforms. It allows to test of volume component
mute switch control in SSP loopback that is used by default in
nocodec topologies. The testing of mute switch feature is simplest
to do with loopback topologies. Nocodec topologies are not in
mainstream usage so this is the safest option to enable testing.

The mute switch add should be possible to all capture topologies but
it can be done later once it is confirmed it is safe to do (avoid
accidental muted audio or problems with UCM).

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>