### PR TITLE
xtensa-build-all: document PRIVATE_KEY_OPTION and deprecate -k

### DIFF
--- a/scripts/xtensa-build-all.sh
+++ b/scripts/xtensa-build-all.sh
@@ -33,7 +33,8 @@ print_usage()
 Re-configures and re-builds SOF using the corresponding compiler and
 platform's _defconfig file.
 
-usage: xtensa-build.sh [options] platform(s)
+usage: $0 [options] platform(s)
+
        -r Build rom if available (gcc only)
        -a Build all platforms
        -u Force UP ARCH
@@ -41,12 +42,23 @@ usage: xtensa-build.sh [options] platform(s)
        -c Interactive menuconfig
        -o copies the file argument from src/arch/xtensa/configs/override/$arg.config
 	  to the build directory after invoking CMake and before Make.
-       -k Use private key
+       -k Configure rimage to use a non-default \${RIMAGE_PRIVATE_KEY}
+           DEPRECATED: use the more flexible \${PRIVATE_KEY_OPTION} below.
        -v Verbose Makefile log
        -j n Set number of make build jobs. Jobs=#cores when no flag. \
 Infinte when not specified.
 	-m path to MEU tool. Switches signing step to use MEU instead of rimage.
-       Supported platforms ${SUPPORTED_PLATFORMS[*]}
+           To use a non-default key define PRIVATE_KEY_OPTION, see below.
+
+To use a non-default key you must define the right CMake parameter in the
+following environment variable:
+
+     PRIVATE_KEY_OPTION='-DMEU_PRIVATE_KEY=path/to/key'  $0  -m /path/to/meu ...
+or:
+     PRIVATE_KEY_OPTION='-DRIMAGE_PRIVATE_KEY=path/to/key'  $0 ...
+
+Supported platforms ${SUPPORTED_PLATFORMS[*]}
+
 EOF
 }
 
@@ -113,6 +125,8 @@ fi
 
 if [ "x$USE_PRIVATE_KEY" == "xyes" ]
 then
+	>&2 printf \
+	    'WARNING: -k and RIMAGE_PRIVATE_KEY are deprecated, see usage.\n'
 	if [ -z ${RIMAGE_PRIVATE_KEY+x} ]
 	then
 		echo "Error: No variable specified for RIMAGE_PRIVATE_KEY"


### PR DESCRIPTION
Following commit 88b69cc2e5ca ("scripts: xtensa-build-all: Add support
for building TGL and signing with MEU") we now have an unified and
flexible PRIVATE_KEY_OPTION that can do anything with very little code.

The -k option was never a good idea in the first place because it
already required an environment variable anyway (RIMAGE_PRIVATE_KEY)
instead of a command line argument so the code should have just checked
whether RIMAGE_PRIVATE_KEY was defined, that would have been
enough. Requiring the user to "double-confirm" with -k has been adding
extra complication for both the user interface and the implementation.

xtensa-build-all is effectively a "CMake configuration convenience"
script, however it shouldn't become an additional layer of indirection
and complexity and its interface should expose CMake (which is already a
layer of indirection!) as directly as possible.

See longer discussion in PR #3187

Signed-off-by: Marc Herbert <marc.herbert@intel.com>