### PR TITLE
perf_cnt: cast timer value to uint32_t type

### DIFF
--- a/src/include/sof/lib/perf_cnt.h
+++ b/src/include/sof/lib/perf_cnt.h
@@ -17,12 +17,12 @@
 #include <sof/drivers/timer.h>
 
 struct perf_cnt_data {
-	uint64_t plat_ts;
-	uint64_t cpu_ts;
-	uint64_t plat_delta_last;
-	uint64_t plat_delta_peak;
-	uint64_t cpu_delta_last;
-	uint64_t cpu_delta_peak;
+	uint32_t plat_ts;
+	uint32_t cpu_ts;
+	uint32_t plat_delta_last;
+	uint32_t plat_delta_peak;
+	uint32_t cpu_delta_last;
+	uint32_t cpu_delta_peak;
 };
 
 #if CONFIG_PERFORMANCE_COUNTERS
@@ -66,8 +66,10 @@ struct perf_cnt_data {
  *  \param arg Argument passed to trace_m as arg.
  */
 #define perf_cnt_stamp(pcd, trace_m, arg) do {				  \
-		uint64_t plat_ts = platform_timer_get(timer_get());	  \
-		uint64_t cpu_ts = arch_timer_get_system(cpu_timer_get()); \
+		uint32_t plat_ts =					  \
+			(uint32_t) platform_timer_get(timer_get());	  \
+		uint32_t cpu_ts =					  \
+			(uint32_t) arch_timer_get_system(cpu_timer_get());\
 		if ((pcd)->plat_ts) {					  \
 			(pcd)->plat_delta_last = plat_ts - (pcd)->plat_ts;\
 			(pcd)->cpu_delta_last = cpu_ts - (pcd)->cpu_ts;   \


### PR DESCRIPTION
In order to get proper perf counters peaks values
we should cast arch timer value to uint32_t.

Arch timers API allows user to get uint64_t value.
In fact arch timer consits two parts. 32 bits (MSB)
software part and 32 bits (LSB) hardware timer.
The 32 bits (MSB) software part is incremented only
during hardware timer rollover when timer interrupts
are enabled. If interrupts are not enabled (perf_cnt
case), incrementation will never appear.

Signed-off-by: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>