### PR TITLE
component: initialize new devices to INIT state

### DIFF
--- a/src/audio/drc/drc.c
+++ b/src/audio/drc/drc.c
@@ -167,8 +167,6 @@ static struct comp_dev *drc_new(const struct comp_driver *drv,
 		       sizeof(struct sof_ipc_comp_process));
 	assert(!ret);
 
-	dev->state = COMP_STATE_INIT;
-
 	cd = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM, sizeof(*cd));
 	if (!cd) {
 		rfree(dev);

--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -136,8 +136,6 @@ static struct comp_dev *mux_new(const struct comp_driver *drv,
 	if (!dev)
 		return NULL;
 
-	dev->state = COMP_STATE_INIT;
-
 	memcpy_s(COMP_GET_IPC(dev, sof_ipc_comp_process),
 		 sizeof(struct sof_ipc_comp_process),
 		 comp, sizeof(struct sof_ipc_comp_process));

--- a/src/audio/tdfb/tdfb.c
+++ b/src/audio/tdfb/tdfb.c
@@ -269,8 +269,6 @@ static struct comp_dev *tdfb_new(const struct comp_driver *drv,
 		 sizeof(struct sof_ipc_comp_process), ipc_tdfb,
 		 sizeof(struct sof_ipc_comp_process));
 
-	dev->state = COMP_STATE_INIT;
-
 	cd = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM, sizeof(*cd));
 	if (!cd) {
 		rfree(dev);

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -546,6 +546,7 @@ static inline struct comp_dev *comp_alloc(const struct comp_driver *drv,
 		return NULL;
 	dev->size = bytes;
 	dev->drv = drv;
+	dev->state = COMP_STATE_INIT;
 	memcpy_s(&dev->tctx, sizeof(struct tr_ctx),
 		 trace_comp_drv_get_tr_ctx(dev->drv), sizeof(struct tr_ctx));
 


### PR DESCRIPTION
As per component graph we start devices in INIT state. Since most
components don't use this state anyways lets just init the struct to
this state and remove it where it is used correctly.

Signed-off-by: Curtis Malainey <cujomalainey@chromium.org>