### PR TITLE
ssp: disable SSP port during ssp_start()

### DIFF
--- a/src/drivers/intel/ssp/ssp.c
+++ b/src/drivers/intel/ssp/ssp.c
@@ -688,12 +688,11 @@ static int ssp_get_hw_params(struct dai *dai,
 static void ssp_start(struct dai *dai, int direction)
 {
 	struct ssp_pdata *ssp = dai_get_drvdata(dai);
+	uint32_t sscr0 = ssp_read(dai, SSCR0);
+	uint32_t sspsp = ssp_read(dai, SSPSP);
+	uint32_t sssr = ssp_read(dai, SSSR);
 
 	spin_lock(&dai->lock);
-
-	/* enable port */
-	ssp_update_bits(dai, SSCR0, SSCR0_SSE, SSCR0_SSE);
-	ssp->state[direction] = COMP_STATE_ACTIVE;
 
 	dai_info(dai, "ssp_start()");
 
@@ -705,6 +704,10 @@ static void ssp_start(struct dai *dai, int direction)
 					     ssp->params.bclk_delay));
 	}
 
+	if (sscr0 & SSCR0_SSE)
+		/* disable SSP to load new configuration */
+		ssp_update_bits(dai, SSCR0, SSCR0_SSE, 0);
+
 	/* enable DMA */
 	if (direction == DAI_DIR_PLAYBACK) {
 		ssp_update_bits(dai, SSCR1, SSCR1_TSRE, SSCR1_TSRE);
@@ -713,6 +716,14 @@ static void ssp_start(struct dai *dai, int direction)
 		ssp_update_bits(dai, SSCR1, SSCR1_RSRE, SSCR1_RSRE);
 		ssp_update_bits(dai, SSRSA, SSRSA_RXEN, SSRSA_RXEN);
 	}
+
+	/* restore ssp status */
+	ssp_write(dai, SSSR, sssr);
+	ssp_write(dai, SSPSP, sspsp);
+
+	/* enable port */
+	ssp_write(dai, SSCR0, sscr0 | SSCR0_SSE);
+	ssp->state[direction] = COMP_STATE_ACTIVE;
 
 	/* wait to get valid fifo status */
 	wait_delay(PLATFORM_SSP_DELAY);


### PR DESCRIPTION
We should make sure the SSP port is disabled when trying to start new
transmission or reception, to avoid any potential race between
transmission and the reception on the same SSP port.

Fixes #3520 #3525

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>