### PR TITLE
logger: Check for unused arguments

### DIFF
--- a/tools/logger/logger.c
+++ b/tools/logger/logger.c
@@ -261,6 +261,11 @@ int main(int argc, char *argv[])
 		}
 	}
 
+	if (argc != optind) {
+		fprintf(stderr, "error: Unused parameter '%s'\n", argv[optind]);
+		usage();
+	}
+
 	if (snapshot_file)
 		return baud ? EINVAL : -snapshot(snapshot_file);
 


### PR DESCRIPTION
There is no place for unused arguments, their are consequence of invalid
argument list as usual.
Such an situation is highly possible especially during defining trace
filters, eg `-Fv=mux 4.1` instead `-F"v=mux 4.1"` or `-Fv=mux4.1`.

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>