### PR TITLE
git: Remove temporary checkpatch file from repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ test-driver
 *.trs
 
 __pycache__
+.checkpatch-camelcase.git.*
 
 build*/
 CMakeCache.txt


### PR DESCRIPTION
This file is generate by checkpatch run, any temporary file shouldn't
be tracked by git. It was added to git by:
538eb6a: ("host: stub about required functions")

Moreover file is problematic for developers working on Windows,
now try to pull changes from remote repository ends up with:
```
  $ git pull
  error: invalid path '.checkpatch-camelcase.git.'
  Updating 6e85152..7709924`
```

cloning repository ends up with:
```
   $ git clone https://github.com/thesofproject/sof.git
   Cloning into 'sof'...
   remote: Enumerating objects: 97, done.
   remote: Counting objects: 100% (97/97), done.
   remote: Compressing objects: 100% (96/96), done.
   remote: Total 67251 (delta 49), reused 4 (delta 1), pack-reused 67154
   Receiving objects: 100% (67251/67251), 13.41 MiB | 2.62 MiB/s, done.
   Resolving deltas: 100% (49768/49768), done.
   error: invalid path '.checkpatch-camelcase.git.'
   fatal: unable to checkout working tree
   You can inspect what was checked out with 'git status'
   and retry with 'git restore --source=HEAD :/'
```

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>