### PR TITLE
abi: fix macro size overflow

### DIFF
--- a/src/include/ipc/header.h
+++ b/src/include/ipc/header.h
@@ -154,7 +154,7 @@
 
 /** Shift-left bits to extract the global cmd type */
 #define SOF_GLB_TYPE_SHIFT			28
-#define SOF_GLB_TYPE_MASK			(0xf << SOF_GLB_TYPE_SHIFT)
+#define SOF_GLB_TYPE_MASK			(0xfL << SOF_GLB_TYPE_SHIFT)
 #define SOF_GLB_TYPE(x)				((x) << SOF_GLB_TYPE_SHIFT)
 
 /** @} */
@@ -165,7 +165,7 @@
 
 /** Shift-left bits to extract the command type */
 #define SOF_CMD_TYPE_SHIFT			16
-#define SOF_CMD_TYPE_MASK			(0xfff << SOF_CMD_TYPE_SHIFT)
+#define SOF_CMD_TYPE_MASK			(0xfffL << SOF_CMD_TYPE_SHIFT)
 #define SOF_CMD_TYPE(x)				((x) << SOF_CMD_TYPE_SHIFT)
 
 /** @} */

--- a/src/include/kernel/abi.h
+++ b/src/include/kernel/abi.h
@@ -30,7 +30,7 @@
 /** \brief SOF ABI version major, minor and patch numbers */
 #define SOF_ABI_MAJOR 3
 #define SOF_ABI_MINOR 18
-#define SOF_ABI_PATCH 0
+#define SOF_ABI_PATCH 1
 
 /** \brief SOF ABI version number. Format within 32bit word is MMmmmppp */
 #define SOF_ABI_MAJOR_SHIFT	24


### PR DESCRIPTION
ubsan found the following bug via oss-fuzz

/src/sof/src/ipc/handler.c:1385:9: runtime error: left shift of 15 by 28 places cannot be represented in type 'int'

This is caused by SOF_GLB_TYPE_MASK which has an implicit length of 15
(int16_t)

Signed-off-by: Curtis Malainey <cujomalainey@chromium.org>