### PR TITLE
zephyr/wrapper: Disable check for CONFIG_SYS_HEAP_ALIGNED_ALLOC

### DIFF
--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -28,10 +28,6 @@
 #error Define CONFIG_DYNAMIC_INTERRUPTS
 #endif
 
-#if !defined(CONFIG_SYS_HEAP_ALIGNED_ALLOC)
-#error Define CONFIG_SYS_HEAP_ALIGNED_ALLOC
-#endif
-
 /*
  * Memory - Create Zephyr HEAP for SOF.
  *


### PR DESCRIPTION
[Not sure if submitting to stable-v1.6 is correct or not?  Should I be submitting to master and then backporting instead?]

This kconfig variable no longer exists in upstream Zephyr (the feature
it used to control is now zero-overhead and always enabled).

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>