### PR TITLE
Ssp rx flush

### DIFF
--- a/src/include/sof/drivers/ssp.h
+++ b/src/include/sof/drivers/ssp.h
@@ -220,8 +220,8 @@ extern const struct dai_driver ssp_driver;
 /* For 8000 Hz rate one sample is transmitted within 125us */
 #define SSP_MAX_SEND_TIME_PER_SAMPLE 125
 
-/* SSP flush timeout in microseconds */
-#define SSP_RX_FLUSH_TIMEOUT	200
+/* SSP flush retry counts maximum */
+#define SSP_RX_FLUSH_RETRY_MAX	16
 
 #define ssp_irq(ssp) \
 	ssp->plat_data.irq

--- a/src/include/sof/lib/clk.h
+++ b/src/include/sof/lib/clk.h
@@ -57,6 +57,8 @@ void clock_low_power_mode(int clock, bool enable);
 
 uint64_t clock_ms_to_ticks(int clock, uint64_t ms);
 
+uint64_t clock_ticks_per_sample(int clock, uint32_t sample_rate);
+
 void platform_timer_set_delta(struct timer *timer, uint64_t ns);
 
 static inline struct clock_info *clocks_get(void)

--- a/src/lib/clk.c
+++ b/src/lib/clk.c
@@ -115,6 +115,19 @@ uint64_t clock_ms_to_ticks(int clock, uint64_t ms)
 	return ticks;
 }
 
+uint64_t clock_ticks_per_sample(int clock, uint32_t sample_rate)
+{
+	struct clock_info *clk_info = clocks_get() + clock;
+	uint32_t ticks_per_msec;
+	uint64_t ticks_per_sample;
+
+	platform_shared_get(clk_info, sizeof(*clk_info));
+	ticks_per_msec = clk_info->freqs[clk_info->current_freq_idx].ticks_per_msec;
+	ticks_per_sample = sample_rate ? ticks_per_msec * 1000 / sample_rate : 0;
+
+	return ticks_per_sample;
+}
+
 void platform_timer_set_delta(struct timer *timer, uint64_t ns)
 {
 	struct clock_info *clk_info = clocks_get() + PLATFORM_DEFAULT_CLOCK;


### PR DESCRIPTION
    ssp: refine the RX FIFO flushing logic
    
    The SSSR_BSY is not necessary for flushing, we need to read out entries
    every time the FIFO is not empty. This flushing may need take place
    several rounds, and we need to wait 1 sample time between 2 flushing
    rounds.
    
    Fixes #3525
    
    Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>
