### PR TITLE
Refactor and fix SDMA driver

### DIFF
--- a/src/drivers/imx/sdma.c
+++ b/src/drivers/imx/sdma.c
@@ -773,7 +773,7 @@ static int sdma_prep_desc(struct dma_chan_data *channel,
 		return -EINVAL;
 	}
 
-	watermark = config->burst_elems;
+	watermark = (config->burst_elems * width) / 8;
 
 	memset(pdata->ctx, 0, sizeof(*pdata->ctx));
 	pdata->ctx->pc = sdma_script_addr;

--- a/src/drivers/imx/sdma.c
+++ b/src/drivers/imx/sdma.c
@@ -713,6 +713,8 @@ static int sdma_prep_desc(struct dma_chan_data *channel,
 		return -EINVAL;
 	}
 
+	pdata->next_bd = 0;
+
 	for (i = 0; i < config->elem_array.count; i++) {
 		bd = &pdata->desc[i];
 		/* For MEM2DEV and DEV2MEM, buf_addr holds the RAM address and

--- a/src/drivers/imx/sdma.c
+++ b/src/drivers/imx/sdma.c
@@ -437,6 +437,7 @@ static struct dma_chan_data *sdma_channel_get(struct dma *dma,
 		cdata->hw_event = -1;
 
 		channel->status = COMP_STATE_READY;
+		channel->index = i;
 		dma_chan_set_data(channel, cdata);
 
 		/* Allow events, allow manual */

--- a/src/drivers/imx/sdma.c
+++ b/src/drivers/imx/sdma.c
@@ -582,6 +582,8 @@ static int sdma_copy(struct dma_chan_data *channel, int bytes, uint32_t flags)
 	notifier_event(channel, NOTIFIER_ID_DMA_COPY,
 		       NOTIFIER_TARGET_CORE_LOCAL, &next, sizeof(next));
 
+	sdma_enable_channel(channel->dma, channel->index);
+
 	return 0;
 }
 

--- a/src/drivers/imx/sdma.c
+++ b/src/drivers/imx/sdma.c
@@ -510,15 +510,6 @@ static int sdma_start(struct dma_chan_data *channel)
 	else
 		dma_reg_write(channel->dma, SDMA_HSTART, BIT(channel->index));
 
-	/* Set a runnable channel priority (channel 0 requires maximum priority)
-	 * so it remains usable even if others are schedulable.
-	 */
-	if (channel->index)
-		dma_reg_write(channel->dma, SDMA_CHNPRI(channel->index),
-			      SDMA_DEFPRI);
-	else
-		dma_reg_write(channel->dma, SDMA_CHNPRI(0), SDMA_MAXPRI);
-
 	return 0;
 }
 

--- a/src/drivers/imx/sdma.c
+++ b/src/drivers/imx/sdma.c
@@ -491,8 +491,6 @@ static void sdma_channel_put(struct dma_chan_data *channel)
 
 static int sdma_start(struct dma_chan_data *channel)
 {
-	struct sdma_chan *pdata = dma_chan_get_data(channel);
-
 	tr_dbg(&sdma_tr, "sdma_start(%d)", channel->index);
 
 	if (channel->status != COMP_STATE_PREPARE &&
@@ -501,14 +499,7 @@ static int sdma_start(struct dma_chan_data *channel)
 
 	channel->status = COMP_STATE_ACTIVE;
 
-	/* If channel is event driven, allow it to run by setting HOSTOVR.
-	 * If it's manually controlled, kickstart it by writing to SDMA_HSTART.
-	 */
-	if (pdata->hw_event != -1)
-		dma_reg_update_bits(channel->dma, SDMA_HOSTOVR,
-				    BIT(channel->index), BIT(channel->index));
-	else
-		dma_reg_write(channel->dma, SDMA_HSTART, BIT(channel->index));
+	sdma_enable_channel(channel->dma, channel->index);
 
 	return 0;
 }

--- a/src/drivers/imx/sdma.c
+++ b/src/drivers/imx/sdma.c
@@ -441,7 +441,7 @@ static struct dma_chan_data *sdma_channel_get(struct dma *dma,
 		dma_chan_set_data(channel, cdata);
 
 		/* Allow events, allow manual */
-		sdma_set_overrides(channel, true, false);
+		sdma_set_overrides(channel, false, false);
 		return channel;
 	}
 	tr_err(&sdma_tr, "sdma no channel free");


### PR DESCRIPTION
Our SDMA drivers has problems when running stress tests. What happens is that channels are not scheduled when running subsequent aplay/arecord commands.

This patch series aims to simplify to code and take a new approach on scheduling the channels. RM says that a condition for a channel to be runnable is      (HE[i] or HO[i]) and (EP[i] or EO[i])

So, foar we have overriden the manual starting of the channel by setting HO[i] = 0, but this creates problems. In order to have a better control on scheduling the channels we use both conditions to schedule the channel:
* make HO[i] =  0
* make EO[i] =  0

With this patchseires and also changing sdma_watermark to half is current value stress test work fine for 1000 iterations.

This means that a channel will run when both the channel was manually started and a DMA request event arrived for the corresponding channel.
