### PR TITLE
compile: check for __XCC__ flag when defining FW build info

### DIFF
--- a/src/arch/xtensa/include/arch/compiler_info.h
+++ b/src/arch/xtensa/include/arch/compiler_info.h
@@ -19,7 +19,7 @@
 /* read used compilator name and version */
 /* CC_NAME must consist of 3 characters with null termination */
 /* See declaration of sof_ipc_cc_version. */
-#ifndef __GNUC__
+#ifdef __XCC__
 #define CC_MAJOR (XTHAL_RELEASE_MAJOR / 1000)
 #define CC_MINOR ((XTHAL_RELEASE_MAJOR % 1000) / 10)
 #define CC_MICRO XTHAL_RELEASE_MINOR


### PR DESCRIPTION
Previously, the __GNUC__ flag was used to differentiate between GCC and XCC.
However, that flag is defined by XCC as well,
as a result, __XCC__ flag should be checked instead.

Fixes: https://github.com/thesofproject/sof/issues/3551

Signed-off-by: Slawomir Blauciak <slawomir.blauciak@linux.intel.com>