### PR TITLE
trace: enforce mailbox size

### DIFF
--- a/src/trace/dma-trace.c
+++ b/src/trace/dma-trace.c
@@ -385,6 +385,8 @@ void dma_trace_flush(void *t)
 				(char *)buffer->addr;
 	}
 
+	size = MIN(size, MAILBOX_TRACE_SIZE);
+
 	/* invalidate trace data */
 	dcache_invalidate_region((void *)t, size);
 


### PR DESCRIPTION
If we are fuzzing we can get the trace system into a state where it
tries flush dma and overshoot the mailbox boundary.

Signed-off-by: Curtis Malainey <cujomalainey@chromium.org>