### PR TITLE
fuzz_ipc: use calloc instead of malloc for ipc region

### DIFF
--- a/tools/oss-fuzz/fuzz_ipc.c
+++ b/tools/oss-fuzz/fuzz_ipc.c
@@ -19,7 +19,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 {
 	// since we can always assume the mailbox is allocated
 	// copy the buffer to pre allocated buffer
-	struct sof_ipc_cmd_hdr *hdr = malloc(SOF_IPC_MSG_MAX_SIZE);
+	struct sof_ipc_cmd_hdr *hdr = calloc(SOF_IPC_MSG_MAX_SIZE, 1);
 
 	memcpy_s(hdr, SOF_IPC_MSG_MAX_SIZE, Data, MIN(Size, SOF_IPC_MSG_MAX_SIZE));
 


### PR DESCRIPTION
The memory sanitzer catches uninitialized value errors on the size check
for small data sizes. Therefore lets us calloc so we can assume the
whole region exists without having the sanitizer get upset.

Signed-off-by: Curtis Malainey <cujomalainey@chromium.org>