### PR TITLE
oss-fuzz: add code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -65,6 +65,7 @@ tools/test/*				@xiulipan
 tools/test/audio/*			@singalsu
 tools/ctl/*				@singalsu
 tools/tune/*				@singalsu
+tools/oss-fuzz/*			@cujomalainey
 
 # build system
 **/CMakeLists.txt			@jajanusz


### PR DESCRIPTION
Add myself as the code owner for the fuzzer

Signed-off-by: Curtis Malainey <cujomalainey@chromium.org>