### PR TITLE
host: don't alloc notifier

### DIFF
--- a/src/arch/host/lib/notifier.c
+++ b/src/arch/host/lib/notifier.c
@@ -18,8 +18,5 @@ static struct notify *host_notify;
 
 struct notify **arch_notify_get(void)
 {
-	if (!host_notify)
-		host_notify = rzalloc(SOF_MEM_ZONE_SYS, 0, SOF_MEM_CAPS_RAM,
-				      sizeof(*host_notify));
 	return &host_notify;
 }


### PR DESCRIPTION
Both the fuzzer and the testbench call init_system_notifier which
initializes the struct so there is no need for this check (which causes
a double alloc) in the get function.

Signed-off-by: Curtis Malainey <cujomalainey@chromium.org>