### PR TITLE
buffer: Move code with tracing/assertions from headers to .c files

### DIFF
--- a/src/audio/buffer.c
+++ b/src/audio/buffer.c
@@ -131,6 +131,26 @@ int buffer_set_size(struct comp_buffer *buffer, uint32_t size)
 	return 0;
 }
 
+bool buffer_params_match(struct comp_buffer *buffer, struct sof_ipc_stream_params *params,
+			 uint32_t flag)
+{
+	assert(params && buffer);
+
+	if ((flag & BUFF_PARAMS_FRAME_FMT) &&
+	    buffer->stream.frame_fmt != params->frame_fmt)
+		return false;
+
+	if ((flag & BUFF_PARAMS_RATE) &&
+	    buffer->stream.rate != params->rate)
+		return false;
+
+	if ((flag & BUFF_PARAMS_CHANNELS) &&
+	    buffer->stream.channels != params->channels)
+		return false;
+
+	return true;
+}
+
 /* free component in the pipeline */
 void buffer_free(struct comp_buffer *buffer)
 {

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -165,6 +165,9 @@ void comp_update_buffer_produce(struct comp_buffer *buffer, uint32_t bytes);
 /* called by a component after consuming data from this buffer */
 void comp_update_buffer_consume(struct comp_buffer *buffer, uint32_t bytes);
 
+bool buffer_params_match(struct comp_buffer *buffer, struct sof_ipc_stream_params *params,
+			 uint32_t flag);
+
 static inline void buffer_invalidate(struct comp_buffer *buffer, uint32_t bytes)
 {
 	if (!buffer->inter_core)
@@ -294,27 +297,6 @@ static inline int buffer_set_params(struct comp_buffer *buffer,
 	buffer->hw_params_configured = true;
 
 	return 0;
-}
-
-static inline bool buffer_params_match(struct comp_buffer *buffer,
-				       struct sof_ipc_stream_params *params,
-				       uint32_t flag)
-{
-	assert(params && buffer);
-
-	if ((flag & BUFF_PARAMS_FRAME_FMT) &&
-	    buffer->stream.frame_fmt != params->frame_fmt)
-		return false;
-
-	if ((flag & BUFF_PARAMS_RATE) &&
-	    buffer->stream.rate != params->rate)
-		return false;
-
-	if ((flag & BUFF_PARAMS_CHANNELS) &&
-	    buffer->stream.channels != params->channels)
-		return false;
-
-	return true;
 }
 
 #endif /* __SOF_AUDIO_BUFFER_H__ */

--- a/test/cmocka/src/audio/component/mock.c
+++ b/test/cmocka/src/audio/component/mock.c
@@ -48,4 +48,10 @@ struct sof *sof_get(void)
 	return &sof;
 }
 
+int buffer_set_params(struct comp_buffer *buffer, struct sof_ipc_stream_params *params,
+		      bool force_update)
+{
+	return 0;
+}
+
 #endif

--- a/test/cmocka/src/audio/pipeline/pipeline_mocks.c
+++ b/test/cmocka/src/audio/pipeline/pipeline_mocks.c
@@ -131,6 +131,20 @@ int comp_verify_params(struct comp_dev *dev, uint32_t flag,
 	return 0;
 }
 
+void buffer_zero(struct comp_buffer *buffer)
+{
+	(void)buffer;
+}
+
+int buffer_set_params(struct comp_buffer *buffer, struct sof_ipc_stream_params *params,
+		      bool force_update)
+{
+	(void)buffer;
+	(void)params;
+	(void)force_update;
+	return 0;
+}
+
 bool buffer_params_match(struct comp_buffer *buffer, struct sof_ipc_stream_params *params,
 			 uint32_t flag)
 {

--- a/test/cmocka/src/audio/pipeline/pipeline_mocks.c
+++ b/test/cmocka/src/audio/pipeline/pipeline_mocks.c
@@ -130,3 +130,12 @@ int comp_verify_params(struct comp_dev *dev, uint32_t flag,
 	(void)params;
 	return 0;
 }
+
+bool buffer_params_match(struct comp_buffer *buffer, struct sof_ipc_stream_params *params,
+			 uint32_t flag)
+{
+	(void)buffer;
+	(void)params;
+	(void)flag;
+	return 0;
+}


### PR DESCRIPTION
After change there is proper location in assert and trace message. 