### PR TITLE
testbench: fix a bug, leading to a build failure

### DIFF
--- a/tools/testbench/topology.c
+++ b/tools/testbench/topology.c
@@ -21,7 +21,7 @@
 
 FILE *file;
 char pipeline_string[DEBUG_MSG_LEN];
-struct shared_lib_table *lib_table;
+static struct shared_lib_table *lib_table;
 int output_file_index;
 
 const struct sof_dai_types sof_dais[] = {


### PR DESCRIPTION
Building testbench is broken, due to a missing "extern." Please also cherry-pick to 1.6