### PR TITLE
rebuild-testbench.sh: don't build twice with combined "make install"

### DIFF
--- a/scripts/rebuild-testbench.sh
+++ b/scripts/rebuild-testbench.sh
@@ -25,8 +25,7 @@ rebuild_testbench()
 
     cmake -DCMAKE_INSTALL_PREFIX=install  ..
 
-    make -j"$(nproc)"
-    make install
+    make -j"$(nproc)" install
 }
 
 export_CC_with_afl()


### PR DESCRIPTION
"make + make install" duplicates many steps, probably because of the
fatal combination of build timestamps + source hash, see PR #3353 for a
similar example.

A single, combined "make install" generates the exact same binary
outputs 30% faster and prints 30% shorter build logs.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>