### PR TITLE
testbench: make lib_table actually global and stop passing it around

### DIFF
--- a/tools/testbench/include/testbench/common_test.h
+++ b/tools/testbench/include/testbench/common_test.h
@@ -56,6 +56,8 @@ struct shared_lib_table {
 	void *handle;
 };
 
+extern struct shared_lib_table lib_table[];
+
 extern int debug;
 
 int edf_scheduler_init(void);
@@ -83,6 +85,6 @@ int get_index_by_type(uint32_t comp_type,
 int get_index_by_uuid(struct sof_ipc_comp_ext *comp_ext,
 		      struct shared_lib_table *lib_table);
 
-int parse_topology(struct sof *sof, struct shared_lib_table *library_table,
+int parse_topology(struct sof *sof,
 		   struct testbench_prm *tp, char *pipeline_msg);
 #endif

--- a/tools/testbench/testbench.c
+++ b/tools/testbench/testbench.c
@@ -282,7 +282,7 @@ int main(int argc, char **argv)
 	}
 
 	/* parse topology file and create pipeline */
-	if (parse_topology(sof_get(), lib_table, &tp, pipeline) < 0) {
+	if (parse_topology(sof_get(), &tp, pipeline) < 0) {
 		fprintf(stderr, "error: parsing topology\n");
 		exit(EXIT_FAILURE);
 	}

--- a/tools/testbench/topology.c
+++ b/tools/testbench/topology.c
@@ -21,7 +21,6 @@
 
 FILE *file;
 char pipeline_string[DEBUG_MSG_LEN];
-struct shared_lib_table *lib_table;
 int output_file_index;
 
 const struct sof_dai_types sof_dais[] = {
@@ -691,7 +690,7 @@ int load_mixer(void *dev, int comp_id, int pipeline_id,
 }
 
 /* parse topology file and set up pipeline */
-int parse_topology(struct sof *sof, struct shared_lib_table *library_table,
+int parse_topology(struct sof *sof,
 		   struct testbench_prm *tp, char *pipeline_msg)
 {
 	struct snd_soc_tplg_hdr *hdr;
@@ -714,8 +713,6 @@ int parse_topology(struct sof *sof, struct shared_lib_table *library_table,
 		fprintf(stderr, "error: opening file %s\n", tp->tplg_file);
 		return -EINVAL;
 	}
-
-	lib_table = library_table;
 
 	/* file size */
 	if (fseek(file, 0, SEEK_END)) {


### PR DESCRIPTION
This fixes compilation with:
```shell
  CFLAGS=-fno-common ./scripts/rebuild-testbench.sh

  sof/tools/testbench/topology.c:24: multiple definition of `lib_table';
  sof/tools/testbench/testbench.c:39: first defined here
```
This was detected by Gentoo 10 which uses -fno-common by default, thanks
Guennadi for the report and investigation.

Commit 03067c6c7709 ("host: set up shared library table") introduced a
strange "lib_table" symbol that was apparently meant to be global but
was not really because of some confusion between arrays and pointers and
needed to be passed around and "initialized to itself" (!) at run time
as seen in the sample trace below:
```C
topology.c

struct shared_lib_table *lib_table;

parse_topology(..., library_table,...)
{

        printf("DEBUG1 ----- %p, %p, %p\n",
                  &lib_table,     lib_table,      library_table);

        lib_table = library_table;

        printf("DEBUG2 ----- %p, %p, %p\n",
                 &lib_table,      lib_table,      library_table);

}
```
Log:
```
    DEBUG1 ----- 0x56298c954040, 0x56298c951183, 0x56298c954040

    DEBUG2 ----- 0x56298c954040, 0x56298c954040, 0x56298c954040
```
Signed-off-by: Marc Herbert <marc.herbert@intel.com>