### PR TITLE
ssp: dma: Move pause action from dma to ssp implementation

### DIFF
--- a/src/drivers/intel/ssp/ssp.c
+++ b/src/drivers/intel/ssp/ssp.c
@@ -764,12 +764,27 @@ static void ssp_pause(struct dai *dai, int direction)
 {
 	struct ssp_pdata *ssp = dai_get_drvdata(dai);
 
-	if (direction == SOF_IPC_STREAM_CAPTURE)
-		dai_info(dai, "ssp_pause(), RX");
-	else
-		dai_info(dai, "ssp_pause(), TX");
+	spin_lock(&dai->lock);
 
-	ssp->state[direction] = COMP_STATE_PAUSED;
+	/* stop Rx if needed */
+	if (direction == DAI_DIR_CAPTURE &&
+	    ssp->state[SOF_IPC_STREAM_CAPTURE] != COMP_STATE_PAUSED) {
+		ssp_update_bits(dai, SSCR1, SSCR1_RSRE, 0);
+		ssp_update_bits(dai, SSRSA, SSRSA_RXEN, 0);
+		ssp->state[SOF_IPC_STREAM_CAPTURE] = COMP_STATE_PAUSED;
+		dai_info(dai, "ssp_pause(), RX stop");
+	}
+
+	/* stop Tx if needed */
+	if (direction == DAI_DIR_PLAYBACK &&
+	    ssp->state[SOF_IPC_STREAM_PLAYBACK] != COMP_STATE_PAUSED) {
+		ssp_update_bits(dai, SSCR1, SSCR1_TSRE, 0);
+		ssp_update_bits(dai, SSTSA, SSTSA_TXEN, 0);
+		ssp->state[SOF_IPC_STREAM_PLAYBACK] = COMP_STATE_PAUSED;
+		dai_info(dai, "ssp_pause(), TX stop");
+	}
+
+	spin_unlock(&dai->lock);
 }
 
 static int ssp_trigger(struct dai *dai, int cmd, int direction)


### PR DESCRIPTION
Dma pause-resume cycle leads to invalid data after resume -
some data overlaps. The root cause was double sending
a few LLI regions. After moving pause-resume logic to
SSP problem is solved, here pause-resume logic works as
expected.

SSP is even better place to perform pause-resume action,
because of time scheduling instead of dma which one takes
action after FIFO level drop, so is event scheduler.

After changes dw_dma_release moves dma to active state,
so following dw_dma_start is no longer needed in this
pause-resume scenarious for dw_dma (but still neededd eg.
for hda-hda).

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>

Solves https://github.com/thesofproject/sof/issues/2891