### PR TITLE
Pipeline 3 periods

### DIFF
--- a/tools/topology/m4/pipeline.m4
+++ b/tools/topology/m4/pipeline.m4
@@ -72,7 +72,7 @@ define(`PIPELINE_PCM_ADD',
 `define(`SCHEDULE_TIME_DOMAIN', $12)'
 `define(`DAI_FORMAT', $5)'
 `define(`SCHED_COMP', $13)'
-`define(`DAI_PERIODS', DAI_DEFAULT_PERIODS)'
+`define(`DAI_PERIODS', ifelse(`$14', `', `DAI_DEFAULT_PERIODS', `$14'))'
 `include($1)'
 `DEBUG_PCM_ADD($1, $3)'
 ,`fatal_error(`Invalid parameters ($#) to PIPELINE_PCM_ADD')')'

--- a/tools/topology/sof-icl-rt711-rt1308-rt715-hdmi.m4
+++ b/tools/topology/sof-icl-rt711-rt1308-rt715-hdmi.m4
@@ -103,7 +103,7 @@ PIPELINE_PCM_ADD(ifdef(`NO_AGGREGATION',`sof/pipe-volume-playback.m4',
 	`sof/pipe-volume-demux-playback.m4'),
 	3, 2, 2, s32le,
 	1000, 0, 0,
-	48000, 48000, 48000)
+	48000, 48000, 48000,,,3)
 
 # Low Latency playback pipeline 4 on PCM 3 using max 2 channels of s32le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
@@ -111,7 +111,7 @@ PIPELINE_PCM_ADD(ifdef(`NO_AGGREGATION', `sof/pipe-volume-playback.m4',
 	`sof/pipe-dai-endpoint.m4'),
 	4, 3, 2, s32le,
 	1000, 0, 0,
-	48000, 48000, 48000)
+	48000, 48000, 48000,,,3)
 ')
 
 # Low Latency capture pipeline 5 on PCM 4 using max 2 channels of s32le.


### PR DESCRIPTION
This patch set supports to set 3 period buffers in the pipeline. And sof-icl-rt711-rt1308-rt715 uses 3 period buffers in muxdemux pipelines. With 3 period buffers, FW can have more buffer to process the mux/demux.