### PR TITLE
power_down: move IPC_HOST_BASE literal into register

### DIFF
--- a/src/platform/apollolake/lib/power_down.S
+++ b/src/platform/apollolake/lib/power_down.S
@@ -37,6 +37,7 @@ literals:
 #define temp_reg1                    a7
 #define temp_reg2                    a8
 #define temp_reg3                    a9
+#define host_base                    a10
 #define pfl_reg                      a15
 
     .align 64
@@ -66,6 +67,8 @@ power_down:
     beqz b_enable_lpsram, _PD_DISABLE_HPSRAM
 
 _PD_DISABLE_LPSRAM:
+    movi host_base, IPC_HOST_BASE
+
     movi temp_reg0, SHIM_LDOCTL_LPSRAM_LDO_ON
     m_cavs_set_lpldo_state temp_reg0, temp_reg1, temp_reg2
 
@@ -125,11 +128,10 @@ _PD_RELEASE_VNN:
 _PD_SEND_IPC:
 	// Send IPC to host informing of PD completion - Clear BUSY bit by
 	// writting IPC_DIPCT_BUSY to IPC_DIPCT
-	movi temp_reg0, IPC_HOST_BASE
-	l32i temp_reg1, temp_reg0, IPC_DIPCT
+	l32i temp_reg1, host_base, IPC_DIPCT
 	movi temp_reg2, IPC_DIPCT_BUSY
 	or temp_reg1, temp_reg1, temp_reg2
-	s32i temp_reg1, temp_reg0, IPC_DIPCT
+	s32i temp_reg1, host_base, IPC_DIPCT
 
 _PD_SLEEP:
     // effecfively executes:

--- a/src/platform/intel/cavs/lib/power_down.S
+++ b/src/platform/intel/cavs/lib/power_down.S
@@ -51,6 +51,7 @@ sram_dis_loop_cnt:
 #define temp_reg1                    a7
 #define temp_reg2                    a8
 #define temp_reg3                    a9
+#define host_base		     a10
 #define pfl_reg                      a15
 
 power_down:
@@ -78,6 +79,8 @@ _PD_DISABLE_LPSRAM:
  *  cavs_lpsram_power_down_entire();
  * }
  */
+	movi host_base, IPC_HOST_BASE
+
 	beqz b_enable_lpsram, _PD_DISABLE_HPSRAM
 	m_cavs_lpsram_power_down_entire temp_reg0, temp_reg1, temp_reg2,\
 					sram_dis_loop_cnt
@@ -138,16 +141,15 @@ _PD_SEND_IPC:
  * bit by writing IPC_DIPCTDR_BUSY to IPC_DIPCTDR
  * and writing IPC_DIPCTDA_DONE to IPC_DIPCTDA
  */
-	movi temp_reg0, IPC_HOST_BASE
-	l32i temp_reg1, temp_reg0, IPC_DIPCTDR
+	l32i temp_reg1, host_base, IPC_DIPCTDR
 	movi temp_reg2, ipc_flag
 	l32i temp_reg2, temp_reg2, 0
 	or temp_reg1, temp_reg1, temp_reg2
-	s32i temp_reg1, temp_reg0, IPC_DIPCTDR
+	s32i temp_reg1, host_base, IPC_DIPCTDR
 
-	l32i temp_reg1, temp_reg0, IPC_DIPCTDA
+	l32i temp_reg1, host_base, IPC_DIPCTDA
 	or temp_reg1, temp_reg1, temp_reg2
-	s32i temp_reg1, temp_reg0, IPC_DIPCTDA
+	s32i temp_reg1, host_base, IPC_DIPCTDA
 
 _PD_SLEEP:
 /* effecfively executes:


### PR DESCRIPTION
Before switching off memory, IPC_HOST_BASE literal value should
be moved to register, in order to avoid accessing to disabled
memory.

fixes #3538 

Signed-off-by: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>