### PR TITLE
mux: add channels checking in *_prepare_active_look_up() functions

### DIFF
--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -336,6 +336,12 @@ static void mux_prepare_active_look_up(struct comp_dev *dev,
 		if (!source)
 			continue;
 
+		if ((cd->lookup[0].copy_elem[elem].in_ch >
+		    (source->channels - 1)) ||
+		    (cd->lookup[0].copy_elem[elem].out_ch >
+		    (sink->channels - 1)))
+			continue;
+
 		cd->active_lookup.copy_elem[active_elem] =
 			cd->lookup[0].copy_elem[elem];
 		active_elem++;

--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -349,6 +349,34 @@ static void mux_prepare_active_look_up(struct comp_dev *dev,
 	}
 }
 
+static void demux_prepare_active_look_up(struct comp_dev *dev,
+					 struct audio_stream *sink,
+					 const struct audio_stream *source,
+					 struct mux_look_up *look_up)
+{
+	struct comp_data *cd = comp_get_drvdata(dev);
+	uint8_t active_elem;
+	uint8_t elem;
+
+	cd->active_lookup.num_elems = 0;
+
+	active_elem = 0;
+
+	/* init pointers */
+	for (elem = 0; elem < look_up->num_elems; elem++) {
+		if ((look_up->copy_elem[elem].in_ch >
+		    (source->channels - 1)) ||
+		    (look_up->copy_elem[elem].out_ch >
+		    (sink->channels - 1)))
+			continue;
+
+		cd->active_lookup.copy_elem[active_elem] =
+			look_up->copy_elem[elem];
+		active_elem++;
+		cd->active_lookup.num_elems = active_elem;
+	}
+}
+
 /* process and copy stream data from source to sink buffers */
 static int demux_copy(struct comp_dev *dev)
 {
@@ -429,9 +457,11 @@ static int demux_copy(struct comp_dev *dev)
 		if (!sinks[i])
 			continue;
 
+		demux_prepare_active_look_up(dev, &sinks[i]->stream,
+					     &source->stream, look_ups[i]);
 		buffer_invalidate(source, source_bytes);
 		cd->demux(dev, &sinks[i]->stream, &source->stream, frames,
-			  look_ups[i]);
+			  &cd->active_lookup);
 		buffer_writeback(sinks[i], sinks_bytes[i]);
 	}
 

--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -317,9 +317,9 @@ static int mux_cmd(struct comp_dev *dev, int cmd, void *data,
 	}
 }
 
-static void prepare_active_look_up(struct comp_dev *dev,
-				   struct audio_stream *sink,
-				   const struct audio_stream **sources)
+static void mux_prepare_active_look_up(struct comp_dev *dev,
+				       struct audio_stream *sink,
+				       const struct audio_stream **sources)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 	const struct audio_stream *source;
@@ -519,7 +519,7 @@ static int mux_copy(struct comp_dev *dev)
 	}
 	sink_bytes = frames * audio_stream_frame_bytes(&sink->stream);
 
-	prepare_active_look_up(dev, &sink->stream, &sources_stream[0]);
+	mux_prepare_active_look_up(dev, &sink->stream, &sources_stream[0]);
 
 	/* produce output */
 	cd->mux(dev, &sink->stream, &sources_stream[0], frames,


### PR DESCRIPTION
This commit adds channel parameter checking in demux/mux_prepare_active_look_up() functions.
Look up table should not include elements referring to channels higher than those actually set in
source/sink buffers. 

fixes #3499 