### PR TITLE
ipc: fix logic for buffer free

### DIFF
--- a/src/audio/pipeline.c
+++ b/src/audio/pipeline.c
@@ -136,6 +136,21 @@ int pipeline_connect(struct comp_dev *comp, struct comp_buffer *buffer,
 	return 0;
 }
 
+void pipeline_disconnect(struct comp_dev *comp, struct comp_buffer *buffer, int dir)
+{
+	uint32_t flags;
+
+	if (dir == PPL_CONN_DIR_COMP_TO_BUFFER)
+		comp_info(comp, "disconnect buffer %d as sink", buffer->id);
+	else
+		comp_info(comp, "disconnect buffer %d as source", buffer->id);
+
+	irq_local_disable(flags);
+	list_item_del(buffer_comp_list(buffer, dir));
+	comp_writeback(comp);
+	irq_local_enable(flags);
+}
+
 struct pipeline_walk_context {
 	int (*comp_func)(struct comp_dev *, struct comp_buffer *,
 			 struct pipeline_walk_context *, int);

--- a/src/include/sof/audio/pipeline.h
+++ b/src/include/sof/audio/pipeline.h
@@ -221,9 +221,10 @@ struct pipeline *pipeline_new(struct sof_ipc_pipe_new *pipe_desc,
 	struct comp_dev *cd);
 int pipeline_free(struct pipeline *p);
 
-/* insert component in pipeline */
+/* insert/remove component in pipeline */
 int pipeline_connect(struct comp_dev *comp, struct comp_buffer *buffer,
 		     int dir);
+void pipeline_disconnect(struct comp_dev *comp, struct comp_buffer *buffer, int dir);
 
 /* complete the pipeline */
 int pipeline_complete(struct pipeline *p, struct comp_dev *source,


### PR DESCRIPTION
A buffer should be prevented from being freed only
if both the sink and the source widgets are active.
In the case of dynamic pipeline loading, a buffer
belonging to a pipeline will need to freed when that
pipeline is no longer active but the other end of the
buffer might still be active. So, change the logic
to check if both the sink and source widget states
are invalid to prevent the buffer from being freed.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>