### PR TITLE
host-testbench.sh: update comment for testbench building

### DIFF
--- a/scripts/host-testbench.sh
+++ b/scripts/host-testbench.sh
@@ -6,7 +6,7 @@
 # Usage:
 # please run following scrits for the test tplg and host build
 # ./scripts/build-tools.sh -t
-# ./scripts/host-build-all.sh
+# ./scripts/rebuild-testbench.sh
 # Run test
 # ./scripts/host-testbench.sh
 #


### PR DESCRIPTION
The host-build-all.sh is deprecated, update to the recommended
'rebuild-testbench.sh'.

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>