### PR TITLE
SOF build on arbitrary architectures

### DIFF
--- a/src/arch/xtensa/Kconfig
+++ b/src/arch/xtensa/Kconfig
@@ -2,29 +2,6 @@
 
 # Xtensa-specific architecture configs
 
-menu "Xtensa Architecture"
-
-config MAX_CORE_COUNT
-	int
-	default 1 if KERNEL_BIN_NAME = "zephyr"
-	default 2 if APOLLOLAKE
-	default 4 if ICELAKE || CANNONLAKE || SUECREEK || TIGERLAKE
-	default 1
-
-config CORE_COUNT
-	int "Number of cores"
-	default MAX_CORE_COUNT
-	range 1 MAX_CORE_COUNT
-	help
-	  Number of used cores
-	  Lowering available core count could result in lower power consumption
-
-config MULTICORE
-	bool
-	default CORE_COUNT > 1
-	help
-	  Indicates that architecture uses multiple cores
-
 config NO_SECONDARY_CORE_ROM
 	bool
 	default n
@@ -40,5 +17,3 @@ config WAKEUP_HOOK
 	  This config should be selected by other platform-level configs.
 	  Platforms that use it, have to implement hook function
 	  platform_interrupt_on_wakeup.
-
-endmenu

--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -13,6 +13,7 @@
 #include <sof/common.h>
 #include <sof/debug/panic.h>
 #include <sof/drivers/edma.h>
+#include <sof/drivers/interrupt.h>
 #include <sof/drivers/ipc.h>
 #include <sof/drivers/interrupt.h>
 #include <sof/drivers/timer.h>

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -850,7 +850,7 @@ static int kpb_buffer_data(struct comp_dev *dev,
 		}
 
 		/* Check how much space there is in current write buffer */
-		space_avail = (uint32_t)buff->end_addr - (uint32_t)buff->w_ptr;
+		space_avail = (uintptr_t)buff->end_addr - (uintptr_t)buff->w_ptr;
 
 		if (size_to_copy > space_avail) {
 			/* We have more data to copy than available space
@@ -1052,12 +1052,12 @@ static void kpb_init_draining(struct comp_dev *dev, struct kpb_client *cli)
 			 */
 			buff->r_ptr = buff->start_addr;
 			if (buff->state == KPB_BUFFER_FREE) {
-				local_buffered = (uint32_t)buff->w_ptr -
-						 (uint32_t)buff->start_addr;
+				local_buffered = (uintptr_t)buff->w_ptr -
+						 (uintptr_t)buff->start_addr;
 				buffered += local_buffered;
 			} else if (buff->state == KPB_BUFFER_FULL) {
-				local_buffered = (uint32_t)buff->end_addr -
-						 (uint32_t)buff->start_addr;
+				local_buffered = (uintptr_t)buff->end_addr -
+						 (uintptr_t)buff->start_addr;
 				buffered += local_buffered;
 			} else {
 				comp_err(dev, "kpb_init_draining(): incorrect buffer label");
@@ -1076,8 +1076,8 @@ static void kpb_init_draining(struct comp_dev *dev, struct kpb_client *cli)
 					 * and buffer's end address.
 					 */
 					buff = buff->prev;
-					buffered += (uint32_t)buff->end_addr -
-						    (uint32_t)buff->w_ptr;
+					buffered += (uintptr_t)buff->end_addr -
+						    (uintptr_t)buff->w_ptr;
 					buff->r_ptr = (char *)buff->w_ptr +
 						      (buffered - drain_req);
 					break;
@@ -1206,7 +1206,7 @@ static enum task_state kpb_draining_task(void *arg)
 			period_copy_start = platform_timer_get(timer);
 		}
 
-		size_to_read = (uint32_t)buff->end_addr - (uint32_t)buff->r_ptr;
+		size_to_read = (uintptr_t)buff->end_addr - (uintptr_t)buff->r_ptr;
 
 		if (size_to_read > audio_stream_get_free_bytes(&sink->stream)) {
 			if (audio_stream_get_free_bytes(&sink->stream) >= drain_req)
@@ -1414,7 +1414,7 @@ static void kpb_clear_history_buffer(struct history_buffer *buff)
 
 	do {
 		start_addr = buff->start_addr;
-		size = (uint32_t)buff->end_addr - (uint32_t)start_addr;
+		size = (uintptr_t)buff->end_addr - (uintptr_t)start_addr;
 
 		bzero(start_addr, size);
 

--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -25,6 +25,7 @@
 #include <sof/bit.h>
 #include <sof/common.h>
 #include <sof/drivers/dw-dma.h>
+#include <sof/drivers/interrupt.h>
 #include <sof/drivers/timer.h>
 #include <sof/lib/alloc.h>
 #include <sof/lib/cache.h>

--- a/src/include/sof/lib/dai.h
+++ b/src/include/sof/lib/dai.h
@@ -21,6 +21,7 @@
 #include <sof/list.h>
 #include <sof/lib/io.h>
 #include <sof/lib/memory.h>
+#include <sof/list.h>
 #include <sof/sof.h>
 #include <sof/spinlock.h>
 #include <sof/trace/trace.h>

--- a/src/ipc/dma-copy.c
+++ b/src/ipc/dma-copy.c
@@ -103,7 +103,7 @@ int dma_copy_to_host_nowait(struct dma_copy *dc, struct dma_sg_config *host_sg,
 
 	/* configure local DMA elem */
 	local_sg_elem.dest = host_sg_elem->dest + offset;
-	local_sg_elem.src = (uint32_t)local_ptr;
+	local_sg_elem.src = (uintptr_t)local_ptr;
 	if (size >= HOST_PAGE_SIZE - offset)
 		local_sg_elem.size = HOST_PAGE_SIZE - offset;
 	else

--- a/src/ipc/ipc-host-ptable.c
+++ b/src/ipc/ipc-host-ptable.c
@@ -105,7 +105,7 @@ static int ipc_get_page_descriptors(struct dma *dmac, uint8_t *page_table,
 	dma_sg_init(&config.elem_array);
 
 	/* set up DMA descriptor */
-	elem.dest = (uint32_t)page_table;
+	elem.dest = (uintptr_t)page_table;
 	elem.src = ring->phy_addr;
 
 	/* source buffer size is always PAGE_SIZE bytes */

--- a/src/platform/Kconfig
+++ b/src/platform/Kconfig
@@ -206,6 +206,29 @@ config IMX8M
 
 endchoice
 
+config MAX_CORE_COUNT
+	int
+	default 1 if KERNEL_BIN_NAME = "zephyr"
+	default 2 if APOLLOLAKE
+	default 4 if ICELAKE || CANNONLAKE || SUECREEK || TIGERLAKE
+	default 1
+	help
+	  Maximum number of cores per configuration
+
+config CORE_COUNT
+	int "Number of cores"
+	default MAX_CORE_COUNT
+	range 1 MAX_CORE_COUNT
+	help
+	  Number of used cores
+	  Lowering available core count could result in lower power consumption
+
+config MULTICORE
+	bool
+	default CORE_COUNT > 1
+	help
+	  Indicates that architecture uses multiple cores
+
 config INTEL
 	bool
 	default n

--- a/src/trace/trace.c
+++ b/src/trace/trace.c
@@ -27,7 +27,7 @@
 #include <stdint.h>
 
 struct trace {
-	uint32_t pos ;	/* trace position */
+	uintptr_t pos ;	/* trace position */
 	uint32_t enable;
 	spinlock_t lock; /* locking mechanism */
 };
@@ -129,7 +129,7 @@ void trace_log(bool send_atomic, const void *log_entry,
 	}
 
 	/* fill log content */
-	put_header(data, ctx->uuid_p, id_1, id_2, (uint32_t)log_entry,
+	put_header(data, ctx->uuid_p, id_1, id_2, (uintptr_t)log_entry,
 		   platform_timer_get(timer_get()));
 	va_start(vl, arg_count);
 	for (i = 0; i < arg_count; ++i)
@@ -223,7 +223,7 @@ static int trace_filter_update_global(int32_t log_level, uint32_t uuid_id)
 		 * when looking for specific uuid element,
 		 * then find, update and stop searching
 		 */
-		if ((uint32_t)ptr->uuid_p == uuid_id) {
+		if ((uintptr_t)ptr->uuid_p == uuid_id) {
 			ptr->level = log_level;
 			return 1;
 		}
@@ -274,7 +274,7 @@ static int trace_filter_update_instances(int32_t log_level, uint32_t uuid_id,
 		if (!ctx)
 			return -EINVAL;
 		correct_comp = comp_id == -1 || icd->id == comp_id; /* todo: icd->topo_id */
-		correct_comp &= uuid_id == 0 || (uint32_t)ctx->uuid_p == uuid_id;
+		correct_comp &= uuid_id == 0 || (uintptr_t)ctx->uuid_p == uuid_id;
 		correct_comp &= pipe_id == -1 || ipc_comp_pipe_id(icd) == pipe_id;
 		if (correct_comp) {
 			ctx->level = log_level;

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -336,7 +336,6 @@ zephyr_include_directories(${SOF_PLATFORM_PATH}/${PLATFORM}/include)
 # Mandatory Files used on all platforms.
 # Commented files will be added/removed as integration dictates.
 zephyr_library_sources(
-	${SOF_SRC_PATH}/trace/dma-trace.c
 	${SOF_IPC_PATH}/dma-copy.c
 	${SOF_IPC_PATH}/ipc.c
 	${SOF_IPC_PATH}/handler.c
@@ -376,12 +375,16 @@ zephyr_library_sources(
 	${SOF_SRC_PATH}/schedule/dma_single_chan_domain.c
 	${SOF_SRC_PATH}/schedule/dma_multi_chan_domain.c
 	${SOF_SRC_PATH}/schedule/ll_schedule.c
-	${SOF_SRC_PATH}/trace/trace.c
 
 	# Bridge wrapper between SOF and Zephyr APIs - Will shrink over time.
 	wrapper.c
 	edf_schedule.c
 	schedule.c
+)
+
+zephyr_library_sources_ifdef(CONFIG_TRACE
+	${SOF_SRC_PATH}/trace/dma-trace.c
+	${SOF_SRC_PATH}/trace/trace.c
 )
 
 # Optional SOF sources - depends on Kconfig - WIP

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -281,7 +281,8 @@ uint64_t platform_timer_get(struct timer *timer)
 
 	return time;
 #elif defined(CONFIG_SOC_SERIES_INTEL_ADSP_BROADWELL)
-	return arch_timer_get_system(timer);
+	// FIXME!
+	return 0;
 #else
 	/* CAVS versions */
 	return shim_read64(SHIM_DSPWC);


### PR DESCRIPTION
This overrides #3578 upon request from @lgirdwood 
This enables building SOF for arbitrary non-xtensa architectures. It uses CONFIG_LIBRARY for that purpose.