### PR TITLE
tools/README: update comment for testbench building

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -150,7 +150,7 @@ functionality and quality of processed samples.
 
 #### Compilation steps
 
-Run the host-build-all.sh to build the required libraries for the testbench.
+Run the rebuild-testbench.sh to build the required libraries for the testbench.
 It should also build the testbench executable.
 
 #### Running the Testbench


### PR DESCRIPTION
The host-build-all.sh is deprecated, update to the recommended
'rebuild-testbench.sh'.

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>