### PR TITLE
topology: smart_amp: restrict channel number of PCM capabilities

### DIFF
--- a/tools/topology/sof/pipe-amp-ref-capture.m4
+++ b/tools/topology/sof/pipe-amp-ref-capture.m4
@@ -115,5 +115,11 @@ indir(`define', concat(`PIPELINE_PCM_', PIPELINE_ID), Echo Reference Capture PCM
 
 
 # PCM capabilities supported by FW
-PCM_CAPABILITIES(Echo Reference Capture PCM_ID, CAPABILITY_FORMAT_NAME(PIPELINE_FORMAT), 48000, 48000, 2, PIPELINE_CHANNELS, 2, 16, 192, 16384, 65536, 65536)
+PCM_CAPABILITIES(Echo Reference Capture PCM_ID,
+	CAPABILITY_FORMAT_NAME(PIPELINE_FORMAT),
+	48000, 48000, dnl rate_min, rate_max
+	SMART_REF_CH_NUM, SMART_REF_CH_NUM, dnl channels_min, channels_max
+	2, 16, dnl periods_min, periods_max
+	192, 16384, dnl period_size_min, period_size_max
+	65536, 65536)
 

--- a/tools/topology/sof/pipe-smart-amplifier-playback.m4
+++ b/tools/topology/sof/pipe-smart-amplifier-playback.m4
@@ -137,5 +137,11 @@ indir(`define', concat(`PIPELINE_PCM_', PIPELINE_ID), Smart Amplifier Playback P
 #
 
 # PCM capabilities supported by FW
-PCM_CAPABILITIES(Smart Amplifier Playback PCM_ID, CAPABILITY_FORMAT_NAME(PIPELINE_FORMAT), 48000, 48000, 2, PIPELINE_CHANNELS, 2, 16, 192, 16384, 65536, 65536)
+PCM_CAPABILITIES(Smart Amplifier Playback PCM_ID,
+	CAPABILITY_FORMAT_NAME(PIPELINE_FORMAT),
+	48000, 48000, dnl rate_min, rate_max
+	SMART_PB_CH_NUM, SMART_PB_CH_NUM, dnl channels_min, channels_max
+	2, 16, dnl periods_min, periods_max
+	192, 16384, dnl period_size_min, period_size_max
+	65536, 65536)
 


### PR DESCRIPTION
Both the playback and capture PCMs should be restricted to the
corresponding SMART_PB_CH_NUM and SMART_REF_CH_NUM, as running them with
other channel numbers will not work correctly.

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>