### PR TITLE
sof: multiband_drc: Add Multiband DRC component

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -29,6 +29,7 @@ src/audio/dcblock*			@cujomalainey @dgreid
 src/audio/crossover*			@cujomalainey @dgreid
 src/audio/tdfb*                         @singalsu
 src/audio/drc/*				@johnylin76 @cujomalainey @dgreid
+src/audio/multiband_drc/*		@johnylin76 @cujomalainey @dgreid
 
 # platforms
 src/platform/baytrail/*			@xiulipan

--- a/src/audio/CMakeLists.txt
+++ b/src/audio/CMakeLists.txt
@@ -33,6 +33,9 @@ if(NOT CONFIG_LIBRARY)
 	if(CONFIG_COMP_DRC)
 		add_subdirectory(drc)
 	endif()
+	if(CONFIG_COMP_MULTIBAND_DRC)
+		add_subdirectory(multiband_drc)
+	endif()
 	if(CONFIG_COMP_TONE)
 		add_local_sources(sof
 			tone.c
@@ -118,7 +121,7 @@ check_optimization(fma -mfma -DOPS_FMA)
 check_optimization(hifi2ep -mhifi2ep -DOPS_HIFI2EP)
 check_optimization(hifi3 -mhifi3 -DOPS_HIFI3)
 
-set(sof_audio_modules volume src asrc eq-fir eq-iir dcblock crossover tdfb drc)
+set(sof_audio_modules volume src asrc eq-fir eq-iir dcblock crossover tdfb drc multiband_drc)
 
 # sources for each module
 set(volume_sources volume/volume.c volume/volume_generic.c)
@@ -130,6 +133,7 @@ set(dcblock_sources dcblock/dcblock.c dcblock/dcblock_generic.c)
 set(crossover_sources crossover/crossover.c crossover/crossover_generic.c)
 set(tdfb_sources tdfb/tdfb.c tdfb/tdfb_generic.c)
 set(drc_sources drc/drc.c drc/drc_generic.c drc/drc_math_generic.c)
+set(multiband_drc_sources multiband_drc/multiband_drc.c crossover/crossover.c drc/drc.c)
 
 foreach(audio_module ${sof_audio_modules})
 	# first compile with no optimizations

--- a/src/audio/Kconfig
+++ b/src/audio/Kconfig
@@ -142,6 +142,15 @@ config COMP_DRC
 	  to reduce the volume of loud sounds and amplify silent sounds thus
 	  compressing an audio signal's dynamic range.
 
+config COMP_MULTIBAND_DRC
+	depends on COMP_IIR && COMP_CROSSOVER && COMP_DRC
+	bool "Multiband Dynamic Range Compressor component"
+	default n
+	help
+	  Select for Multiband Dynamic Range Compressor (DRC) component. It
+	  consists of Emphasis Equalizer, n-way Crossover Filter, per-band DRC,
+	  and Deemphasis Equalizer.
+
 config COMP_DCBLOCK
 	bool "DC Blocking Filter component"
 	default y

--- a/src/audio/crossover/crossover.c
+++ b/src/audio/crossover/crossover.c
@@ -9,6 +9,7 @@
 #include <sof/audio/format.h>
 #include <sof/audio/pipeline.h>
 #include <sof/audio/crossover/crossover.h>
+#include <sof/audio/crossover/crossover_algorithm.h>
 #include <sof/audio/eq_iir/iir.h>
 #include <sof/common.h>
 #include <sof/debug/panic.h>
@@ -61,7 +62,7 @@ static inline void crossover_reset_state_lr4(struct iir_state_df2t *lr4)
  * \brief Reset the state (coefficients and delay) of the crossover filter
  *	  of a single channel.
  */
-static inline void crossover_reset_state_ch(struct crossover_state *ch_state)
+inline void crossover_reset_state_ch(struct crossover_state *ch_state)
 {
 	int i;
 
@@ -215,9 +216,9 @@ static int crossover_init_coef_lr4(struct sof_eq_iir_biquad_df2t *coef,
 /**
  * \brief Initializes the crossover coefficients for one channel
  */
-static int crossover_init_coef_ch(struct sof_eq_iir_biquad_df2t *coef,
-				  struct crossover_state *ch_state,
-				  int32_t num_sinks)
+int crossover_init_coef_ch(struct sof_eq_iir_biquad_df2t *coef,
+			   struct crossover_state *ch_state,
+			   int32_t num_sinks)
 {
 	int32_t i;
 	int32_t j = 0;

--- a/src/audio/drc/drc.c
+++ b/src/audio/drc/drc.c
@@ -7,6 +7,7 @@
 #include <sof/audio/component.h>
 #include <sof/audio/buffer.h>
 #include <sof/audio/drc/drc.h>
+#include <sof/audio/drc/drc_algorithm.h>
 #include <sof/audio/format.h>
 #include <sof/audio/pipeline.h>
 #include <sof/common.h>
@@ -38,7 +39,7 @@ DECLARE_SOF_RT_UUID("drc", drc_uuid, 0xb36ee4da, 0x006f, 0x47f9,
 
 DECLARE_TR_CTX(drc_tr, SOF_UUID(drc_uuid), LOG_LEVEL_INFO);
 
-static inline void drc_reset_state(struct drc_state *state)
+inline void drc_reset_state(struct drc_state *state)
 {
 	int i;
 
@@ -62,9 +63,9 @@ static inline void drc_reset_state(struct drc_state *state)
 	state->max_attack_compression_diff_db = INT32_MIN;
 }
 
-static inline int drc_init_pre_delay_buffers(struct drc_state *state,
-					     size_t sample_bytes,
-					     int channels)
+inline int drc_init_pre_delay_buffers(struct drc_state *state,
+				      size_t sample_bytes,
+				      int channels)
 {
 	size_t bytes_per_channel = sample_bytes * DRC_MAX_PRE_DELAY_FRAMES;
 	size_t bytes_total = bytes_per_channel * channels;
@@ -86,9 +87,9 @@ static inline int drc_init_pre_delay_buffers(struct drc_state *state,
 	return 0;
 }
 
-static inline int drc_set_pre_delay_time(struct drc_state *state,
-					 int32_t pre_delay_time,
-					 int32_t rate)
+inline int drc_set_pre_delay_time(struct drc_state *state,
+				  int32_t pre_delay_time,
+				  int32_t rate)
 {
 	int32_t pre_delay_frames;
 

--- a/src/audio/drc/drc_generic.c
+++ b/src/audio/drc/drc_generic.c
@@ -6,6 +6,7 @@
 
 #include <sof/audio/component.h>
 #include <sof/audio/drc/drc.h>
+#include <sof/audio/drc/drc_algorithm.h>
 #include <sof/audio/drc/drc_math.h>
 #include <sof/audio/format.h>
 #include <sof/math/decibels.h>
@@ -69,10 +70,10 @@ static int32_t volume_gain(const struct sof_drc_params *p, int32_t x)
 }
 
 /* Update detector_average from the last input division. */
-static void drc_update_detector_average(struct drc_state *state,
-					const struct sof_drc_params *p,
-					int nbyte,
-					int nch)
+void drc_update_detector_average(struct drc_state *state,
+				 const struct sof_drc_params *p,
+				 int nbyte,
+				 int nch)
 {
 	int32_t detector_average = state->detector_average; /* Q2.30 */
 	int32_t abs_input_array[DRC_DIVISION_FRAMES]; /* Q1.31 */
@@ -158,7 +159,7 @@ static void drc_update_detector_average(struct drc_state *state,
 }
 
 /* Updates the envelope_rate used for the next division */
-static void drc_update_envelope(struct drc_state *state, const struct sof_drc_params *p)
+void drc_update_envelope(struct drc_state *state, const struct sof_drc_params *p)
 {
 	/* Calculate desired gain */
 
@@ -251,10 +252,10 @@ static void drc_update_envelope(struct drc_state *state, const struct sof_drc_pa
 
 /* Calculate compress_gain from the envelope and apply total_gain to compress
  * the next output division. */
-static void drc_compress_output(struct drc_state *state,
-				const struct sof_drc_params *p,
-				int nbyte,
-				int nch)
+void drc_compress_output(struct drc_state *state,
+			 const struct sof_drc_params *p,
+			 int nbyte,
+			 int nch)
 {
 	const int div_start = state->pre_delay_read_index;
 	int count = DRC_DIVISION_FRAMES >> 2;

--- a/src/audio/multiband_drc/CMakeLists.txt
+++ b/src/audio/multiband_drc/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_local_sources(sof multiband_drc.c)

--- a/src/audio/multiband_drc/multiband_drc.c
+++ b/src/audio/multiband_drc/multiband_drc.c
@@ -1,0 +1,577 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2020 Google LLC. All rights reserved.
+//
+// Author: Pin-chih Lin <johnylin@google.com>
+
+#include <sof/audio/buffer.h>
+#include <sof/audio/crossover/crossover_algorithm.h>
+#include <sof/audio/drc/drc_algorithm.h>
+#include <sof/audio/multiband_drc/multiband_drc.h>
+#include <sof/audio/format.h>
+#include <sof/audio/pipeline.h>
+#include <sof/common.h>
+#include <sof/debug/panic.h>
+#include <sof/drivers/ipc.h>
+#include <sof/lib/alloc.h>
+#include <sof/lib/memory.h>
+#include <sof/lib/uuid.h>
+#include <sof/list.h>
+#include <sof/math/numbers.h>
+#include <sof/platform.h>
+#include <sof/string.h>
+#include <sof/ut.h>
+#include <sof/trace/trace.h>
+#include <ipc/control.h>
+#include <ipc/stream.h>
+#include <ipc/topology.h>
+#include <user/eq.h>
+#include <user/trace.h>
+#include <errno.h>
+#include <stddef.h>
+#include <stdint.h>
+
+static const struct comp_driver comp_multiband_drc;
+
+/* 0d9f2256-8e4f-47b3-8448-239a334f1191 */
+DECLARE_SOF_RT_UUID("multiband_drc", multiband_drc_uuid, 0x0d9f2256, 0x8e4f, 0x47b3,
+		    0x84, 0x48, 0x23, 0x9a, 0x33, 0x4f, 0x11, 0x91);
+
+DECLARE_TR_CTX(multiband_drc_tr, SOF_UUID(multiband_drc_uuid), LOG_LEVEL_INFO);
+
+static inline void multiband_drc_iir_reset_state_ch(struct iir_state_df2t *iir)
+{
+	rfree(iir->coef);
+	rfree(iir->delay);
+
+	iir->coef = NULL;
+	iir->delay = NULL;
+}
+
+static inline void multiband_drc_reset_state(struct multiband_drc_state *state)
+{
+	int i;
+
+	/* Reset emphasis eq-iir state */
+	for (i = 0; i < PLATFORM_MAX_CHANNELS; i++)
+		multiband_drc_iir_reset_state_ch(&state->emphasis[i]);
+
+	/* Reset crossover state */
+	for (i = 0; i < PLATFORM_MAX_CHANNELS; i++)
+		crossover_reset_state_ch(&state->crossover[i]);
+
+	/* Reset drc kernel state */
+	for (i = 0; i < SOF_MULTIBAND_DRC_MAX_BANDS; i++)
+		drc_reset_state(&state->drc[i]);
+
+	/* Reset deemphasis eq-iir state */
+	for (i = 0; i < PLATFORM_MAX_CHANNELS; i++)
+		multiband_drc_iir_reset_state_ch(&state->deemphasis[i]);
+}
+
+static int multiband_drc_eq_init_coef_ch(struct sof_eq_iir_biquad_df2t *coef,
+					 struct iir_state_df2t *eq)
+{
+	int ret;
+
+	eq->coef = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM,
+			   sizeof(struct sof_eq_iir_biquad_df2t) * SOF_EMP_DEEMP_BIQUADS);
+	if (!eq->coef)
+		return -ENOMEM;
+
+	/* Coefficients of the first biquad and second biquad */
+	ret = memcpy_s(eq->coef, sizeof(struct sof_eq_iir_biquad_df2t) * SOF_EMP_DEEMP_BIQUADS,
+		       coef, sizeof(struct sof_eq_iir_biquad_df2t) * SOF_EMP_DEEMP_BIQUADS);
+	assert(!ret);
+
+	/* EQ filters are two 2nd order filters, so only need 4 delay slots
+	 * delay[0..1] -> state for first biquad
+	 * delay[2..3] -> state for second biquad
+	 */
+	eq->delay = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM,
+			    sizeof(uint64_t) * CROSSOVER_NUM_DELAYS_LR4);
+	if (!eq->delay)
+		return -ENOMEM;
+
+	eq->biquads = SOF_EMP_DEEMP_BIQUADS;
+	eq->biquads_in_series = SOF_EMP_DEEMP_BIQUADS;
+
+	return 0;
+}
+
+static int multiband_drc_init_coef(struct multiband_drc_comp_data *cd, int16_t nch, uint32_t rate)
+{
+	struct sof_eq_iir_biquad_df2t *crossover;
+	struct sof_eq_iir_biquad_df2t *emphasis;
+	struct sof_eq_iir_biquad_df2t *deemphasis;
+	struct sof_multiband_drc_config *config = cd->config;
+	struct multiband_drc_state *state = &cd->state;
+	uint32_t sample_bytes = get_sample_bytes(cd->source_format);
+	int num_bands = cd->config->num_bands;
+	int i, ch, ret;
+
+	if (!config) {
+		comp_cl_err(&comp_multiband_drc, "multiband_drc_init_coef(), no config is set");
+		return -EINVAL;
+	}
+
+	/* Sanity checks */
+	if (nch > PLATFORM_MAX_CHANNELS) {
+		comp_cl_err(&comp_multiband_drc,
+			    "multiband_drc_init_coef(), invalid channels count(%i)",
+			    nch);
+		return -EINVAL;
+	}
+	if (config->num_bands > SOF_MULTIBAND_DRC_MAX_BANDS) {
+		comp_cl_err(&comp_multiband_drc,
+			    "multiband_drc_init_coef(), invalid bands count(%i)",
+			    config->num_bands);
+		return -EINVAL;
+	}
+
+	comp_cl_info(&comp_multiband_drc,
+		     "multiband_drc_init_coef(), initiliazing %i-way crossover",
+		     config->num_bands);
+
+	/* Crossover: collect the coef array and assign it to every channel */
+	crossover = config->crossover_coef;
+	for (ch = 0; ch < nch; ch++) {
+		ret = crossover_init_coef_ch(crossover, &state->crossover[ch],
+					     config->num_bands);
+		/* Free all previously allocated blocks in case of an error */
+		if (ret < 0) {
+			comp_cl_err(&comp_multiband_drc,
+				    "multiband_drc_init_coef(), could not assign coeffs to ch %d",
+				    ch);
+			goto err;
+		}
+	}
+
+	comp_cl_info(&comp_multiband_drc, "multiband_drc_init_coef(), initiliazing emphasis_eq");
+
+	/* Emphasis: collect the coef array and assign it to every channel */
+	emphasis = config->emp_coef;
+	for (ch = 0; ch < nch; ch++) {
+		ret = multiband_drc_eq_init_coef_ch(emphasis, &state->emphasis[ch]);
+		/* Free all previously allocated blocks in case of an error */
+		if (ret < 0) {
+			comp_cl_err(&comp_multiband_drc,
+				    "multiband_drc_init_coef(), could not assign coeffs to ch %d",
+				    ch);
+			goto err;
+		}
+	}
+
+	comp_cl_info(&comp_multiband_drc, "multiband_drc_init_coef(), initiliazing deemphasis_eq");
+
+	/* Deemphasis: collect the coef array and assign it to every channel */
+	deemphasis = config->deemp_coef;
+	for (ch = 0; ch < nch; ch++) {
+		ret = multiband_drc_eq_init_coef_ch(deemphasis, &state->deemphasis[ch]);
+		/* Free all previously allocated blocks in case of an error */
+		if (ret < 0) {
+			comp_cl_err(&comp_multiband_drc,
+				    "multiband_drc_init_coef(), could not assign coeffs to ch %d",
+				    ch);
+			goto err;
+		}
+	}
+
+	/* Allocate all DRC pre-delay buffers and set delay time with band number */
+	for (i = 0; i < num_bands; i++) {
+		comp_cl_info(&comp_multiband_drc,
+			     "multiband_drc_init_coef(), initiliazing drc band %d", i);
+
+		ret = drc_init_pre_delay_buffers(&state->drc[i], (size_t)sample_bytes, (int)nch);
+		if (ret < 0) {
+			comp_cl_err(&comp_multiband_drc,
+				    "multiband_drc_init_coef(), could not init pre delay buffers");
+			goto err;
+		}
+
+		ret = drc_set_pre_delay_time(&state->drc[i],
+					     cd->config->drc_coef[i].pre_delay_time, rate);
+		if (ret < 0) {
+			comp_cl_err(&comp_multiband_drc,
+				    "multiband_drc_init_coef(), could not set pre delay time");
+			goto err;
+		}
+	}
+
+	return 0;
+
+err:
+	multiband_drc_reset_state(state);
+	return ret;
+}
+
+static int multiband_drc_setup(struct multiband_drc_comp_data *cd, int16_t channels, uint32_t rate)
+{
+	int ret;
+
+	/* Reset any previous state */
+	multiband_drc_reset_state(&cd->state);
+
+	/* Setup Crossover, Emphasis EQ, Deemphasis EQ, and DRC */
+	ret = multiband_drc_init_coef(cd, channels, rate);
+	if (ret < 0)
+		return ret;
+
+	return 0;
+}
+
+/*
+ * End of Multiband DRC setup code. Next the standard component methods.
+ */
+
+static struct comp_dev *multiband_drc_new(const struct comp_driver *drv,
+					  struct sof_ipc_comp *comp)
+{
+	struct comp_dev *dev;
+	struct multiband_drc_comp_data *cd;
+	struct sof_ipc_comp_process *ipc_multiband_drc =
+		(struct sof_ipc_comp_process *)comp;
+	size_t bs = ipc_multiband_drc->size;
+	int ret;
+
+	comp_cl_info(&comp_multiband_drc, "multiband_drc_new()");
+
+	/* Check first before proceeding with dev and cd that coefficients
+	 * blob size is sane.
+	 */
+	if (bs > SOF_MULTIBAND_DRC_MAX_BLOB_SIZE) {
+		comp_cl_err(&comp_multiband_drc,
+			    "multiband_drc_new(), error: configuration blob size = %u > %d",
+			    bs, SOF_MULTIBAND_DRC_MAX_BLOB_SIZE);
+		return NULL;
+	}
+
+	dev = comp_alloc(drv, COMP_SIZE(struct sof_ipc_comp_process));
+	if (!dev)
+		return NULL;
+
+	ret = memcpy_s(COMP_GET_IPC(dev, sof_ipc_comp_process),
+		       sizeof(struct sof_ipc_comp_process), ipc_multiband_drc,
+		       sizeof(struct sof_ipc_comp_process));
+	assert(!ret);
+
+	cd = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM, sizeof(*cd));
+	if (!cd) {
+		rfree(dev);
+		return NULL;
+	}
+
+	comp_set_drvdata(dev, cd);
+
+	cd->multiband_drc_func = NULL;
+	cd->crossover_split = NULL;
+
+	/* Handler for configuration data */
+	cd->model_handler = comp_data_blob_handler_new(dev);
+	if (!cd->model_handler) {
+		comp_cl_err(&comp_multiband_drc,
+			    "multiband_drc_new(): comp_data_blob_handler_new() failed.");
+		rfree(dev);
+		rfree(cd);
+		return NULL;
+	}
+
+	/* Get configuration data and reset DRC state */
+	ret = comp_init_data_blob(cd->model_handler, bs, ipc_multiband_drc->data);
+	if (ret < 0) {
+		comp_cl_err(&comp_multiband_drc,
+			    "multiband_drc_new(): comp_init_data_blob() failed.");
+		rfree(dev);
+		rfree(cd);
+		return NULL;
+	}
+	multiband_drc_reset_state(&cd->state);
+
+	dev->state = COMP_STATE_READY;
+	return dev;
+}
+
+static void multiband_drc_free(struct comp_dev *dev)
+{
+	struct multiband_drc_comp_data *cd = comp_get_drvdata(dev);
+
+	comp_info(dev, "multiband_drc_free()");
+
+	comp_data_blob_handler_free(cd->model_handler);
+
+	rfree(cd);
+	rfree(dev);
+}
+
+static int multiband_drc_params(struct comp_dev *dev, struct sof_ipc_stream_params *params)
+{
+	int ret;
+
+	comp_dbg(dev, "multiband_drc_params()");
+
+	comp_dbg(dev, "multiband_drc_verify_params()");
+	ret = comp_verify_params(dev, 0, params);
+	if (ret < 0) {
+		comp_err(dev, "multiband_drc_params(): comp_verify_params() failed.");
+		return -EINVAL;
+	}
+
+	/* All configuration work is postponed to prepare(). */
+	return 0;
+}
+
+static int multiband_drc_cmd_get_data(struct comp_dev *dev,
+				      struct sof_ipc_ctrl_data *cdata,
+				      int max_size)
+{
+	struct multiband_drc_comp_data *cd = comp_get_drvdata(dev);
+	int ret = 0;
+
+	switch (cdata->cmd) {
+	case SOF_CTRL_CMD_BINARY:
+		comp_dbg(dev, "multiband_drc_cmd_get_data(), SOF_CTRL_CMD_BINARY");
+		ret = comp_data_blob_get_cmd(cd->model_handler, cdata, max_size);
+		break;
+	default:
+		comp_err(dev, "multiband_drc_cmd_get_data() error: invalid cdata->cmd");
+		ret = -EINVAL;
+		break;
+	}
+	return ret;
+}
+
+static int multiband_drc_cmd_set_data(struct comp_dev *dev,
+				      struct sof_ipc_ctrl_data *cdata)
+{
+	struct multiband_drc_comp_data *cd = comp_get_drvdata(dev);
+	int ret = 0;
+
+	switch (cdata->cmd) {
+	case SOF_CTRL_CMD_BINARY:
+		comp_dbg(dev, "multiband_drc_cmd_set_data(), SOF_CTRL_CMD_BINARY");
+		ret = comp_data_blob_set_cmd(cd->model_handler, cdata);
+		break;
+	default:
+		comp_err(dev, "multiband_drc_cmd_set_data() error: invalid cdata->cmd");
+		ret = -EINVAL;
+		break;
+	}
+
+	return ret;
+}
+
+static int multiband_drc_cmd(struct comp_dev *dev, int cmd, void *data, int max_data_size)
+{
+	struct sof_ipc_ctrl_data *cdata = data;
+	int ret = 0;
+
+	comp_dbg(dev, "multiband_drc_cmd()");
+
+	switch (cmd) {
+	case COMP_CMD_SET_DATA:
+		ret = multiband_drc_cmd_set_data(dev, cdata);
+		break;
+	case COMP_CMD_GET_DATA:
+		ret = multiband_drc_cmd_get_data(dev, cdata, max_data_size);
+		break;
+	default:
+		comp_err(dev, "multiband_drc_cmd(), invalid command");
+		ret = -EINVAL;
+	}
+
+	return ret;
+}
+
+static int multiband_drc_trigger(struct comp_dev *dev, int cmd)
+{
+	int ret;
+
+	comp_dbg(dev, "multiband_drc_trigger()");
+
+	ret = comp_set_state(dev, cmd);
+	if (ret == COMP_STATUS_STATE_ALREADY_SET)
+		ret = PPL_STATUS_PATH_STOP;
+
+	return ret;
+}
+
+static void multiband_drc_process(struct comp_dev *dev, struct comp_buffer *source,
+				  struct comp_buffer *sink, int frames,
+				  uint32_t source_bytes, uint32_t sink_bytes)
+{
+	struct multiband_drc_comp_data *cd = comp_get_drvdata(dev);
+
+	buffer_invalidate(source, source_bytes);
+
+	cd->multiband_drc_func(dev, &source->stream, &sink->stream, frames);
+
+	buffer_writeback(sink, sink_bytes);
+
+	/* calc new free and available */
+	comp_update_buffer_consume(source, source_bytes);
+	comp_update_buffer_produce(sink, sink_bytes);
+}
+
+static int multiband_drc_copy(struct comp_dev *dev)
+{
+	struct comp_copy_limits cl;
+	struct multiband_drc_comp_data *cd = comp_get_drvdata(dev);
+	struct comp_buffer *sourceb;
+	struct comp_buffer *sinkb;
+	int ret;
+
+	comp_dbg(dev, "multiband_drc_copy()");
+
+	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer,
+				  sink_list);
+	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer,
+				source_list);
+
+	/* Check for changed configuration */
+	if (comp_is_new_data_blob_available(cd->model_handler)) {
+		cd->config = comp_get_data_blob(cd->model_handler, NULL, NULL);
+		ret = multiband_drc_setup(cd, (int16_t)sourceb->stream.channels,
+					  sourceb->stream.rate);
+		if (ret < 0) {
+			comp_err(dev, "multiband_drc_copy(), failed DRC setup");
+			return ret;
+		}
+	}
+
+	/* Get source, sink, number of frames etc. to process. */
+	comp_get_copy_limits_with_lock(sourceb, sinkb, &cl);
+
+	/* Run Multiband DRC function */
+	multiband_drc_process(dev, sourceb, sinkb, cl.frames, cl.source_bytes, cl.sink_bytes);
+
+	return 0;
+}
+
+static int multiband_drc_prepare(struct comp_dev *dev)
+{
+	struct multiband_drc_comp_data *cd = comp_get_drvdata(dev);
+	struct sof_ipc_comp_config *config = dev_comp_config(dev);
+	struct comp_buffer *sourceb;
+	struct comp_buffer *sinkb;
+	uint32_t sink_period_bytes;
+	int ret;
+
+	comp_info(dev, "multiband_drc_prepare()");
+
+	ret = comp_set_state(dev, COMP_TRIGGER_PREPARE);
+	if (ret < 0)
+		return ret;
+
+	if (ret == COMP_STATUS_STATE_ALREADY_SET)
+		return PPL_STATUS_PATH_STOP;
+
+	/* DRC component will only ever have 1 source and 1 sink buffer */
+	sourceb = list_first_item(&dev->bsource_list,
+				  struct comp_buffer, sink_list);
+	sinkb = list_first_item(&dev->bsink_list,
+				struct comp_buffer, source_list);
+
+	/* get source data format */
+	cd->source_format = sourceb->stream.frame_fmt;
+
+	/* Initialize DRC */
+	comp_dbg(dev, "multiband_drc_prepare(), source_format=%d, sink_format=%d",
+		 cd->source_format, cd->source_format);
+	cd->config = comp_get_data_blob(cd->model_handler, NULL, NULL);
+	if (cd->config) {
+		ret = multiband_drc_setup(cd, sourceb->stream.channels, sourceb->stream.rate);
+		if (ret < 0) {
+			comp_err(dev, "multiband_drc_prepare() error: multiband_drc_setup failed.");
+			goto err;
+		}
+
+		cd->multiband_drc_func = multiband_drc_find_proc_func(cd->source_format);
+		if (!cd->multiband_drc_func) {
+			comp_err(dev, "multiband_drc_prepare(), No proc func");
+			ret = -EINVAL;
+			goto err;
+		}
+
+		cd->crossover_split = crossover_find_split_func(cd->config->num_bands);
+		if (!cd->crossover_split) {
+			comp_err(dev, "multiband_drc_prepare(), No crossover_split for band num %i",
+				 cd->config->num_bands);
+			ret = -EINVAL;
+			goto err;
+		}
+	} else {
+		cd->multiband_drc_func = multiband_drc_find_proc_func_pass(cd->source_format);
+		if (!cd->multiband_drc_func) {
+			comp_err(dev, "multiband_drc_prepare(), No proc func passthrough");
+			ret = -EINVAL;
+			goto err;
+		}
+	}
+
+	/* validate sink data format and period bytes */
+	if (cd->source_format != sinkb->stream.frame_fmt) {
+		comp_err(dev,
+			 "multiband_drc_prepare(): Source fmt %d and sink fmt %d are different.",
+			 cd->source_format, sinkb->stream.frame_fmt);
+		ret = -EINVAL;
+		goto err;
+	}
+
+	sink_period_bytes = audio_stream_period_bytes(&sinkb->stream,
+						      dev->frames);
+
+	if (sinkb->stream.size < config->periods_sink * sink_period_bytes) {
+		comp_err(dev, "multiband_drc_prepare(), sink buffer size %d is insufficient",
+			 sinkb->stream.size);
+		ret = -ENOMEM;
+		goto err;
+	}
+
+	return 0;
+
+err:
+	comp_set_state(dev, COMP_TRIGGER_RESET);
+	return ret;
+}
+
+static int multiband_drc_reset(struct comp_dev *dev)
+{
+	struct multiband_drc_comp_data *cd = comp_get_drvdata(dev);
+
+	comp_info(dev, "multiband_drc_reset()");
+
+	multiband_drc_reset_state(&cd->state);
+
+	cd->multiband_drc_func = NULL;
+	cd->crossover_split = NULL;
+
+	comp_set_state(dev, COMP_TRIGGER_RESET);
+	return 0;
+}
+
+static const struct comp_driver comp_multiband_drc = {
+	.uid = SOF_RT_UUID(multiband_drc_uuid),
+	.tctx = &multiband_drc_tr,
+	.ops = {
+		.create  = multiband_drc_new,
+		.free    = multiband_drc_free,
+		.params  = multiband_drc_params,
+		.cmd     = multiband_drc_cmd,
+		.trigger = multiband_drc_trigger,
+		.copy    = multiband_drc_copy,
+		.prepare = multiband_drc_prepare,
+		.reset   = multiband_drc_reset,
+	},
+};
+
+static SHARED_DATA struct comp_driver_info comp_multiband_drc_info = {
+	.drv = &comp_multiband_drc,
+};
+
+UT_STATIC void sys_comp_multiband_drc_init(void)
+{
+	comp_register(platform_shared_get(&comp_multiband_drc_info,
+					  sizeof(comp_multiband_drc_info)));
+}
+
+DECLARE_MODULE(sys_comp_multiband_drc_init);

--- a/src/include/sof/audio/crossover/crossover_algorithm.h
+++ b/src/include/sof/audio/crossover/crossover_algorithm.h
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2020 Google LLC. All rights reserved.
+ *
+ * Author: Pin-chih Lin <johnylin@google.com>
+ */
+#ifndef __SOF_AUDIO_CROSSOVER_CROSSOVER_ALGORITHM_H__
+#define __SOF_AUDIO_CROSSOVER_CROSSOVER_ALGORITHM_H__
+
+#include <stdint.h>
+#include <sof/audio/crossover/crossover.h>
+#include <sof/platform.h>
+#include <sof/math/iir_df2t.h>
+#include <user/crossover.h>
+
+/* crossover reset function */
+void crossover_reset_state_ch(struct crossover_state *ch_state);
+
+/* crossover init function */
+int crossover_init_coef_ch(struct sof_eq_iir_biquad_df2t *coef,
+			   struct crossover_state *ch_state,
+			   int32_t num_sinks);
+
+#endif //  __SOF_AUDIO_CROSSOVER_CROSSOVER_ALGORITHM_H__

--- a/src/include/sof/audio/drc/drc_algorithm.h
+++ b/src/include/sof/audio/drc/drc_algorithm.h
@@ -1,0 +1,37 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2020 Google LLC. All rights reserved.
+ *
+ * Author: Pin-chih Lin <johnylin@google.com>
+ */
+#ifndef __SOF_AUDIO_DRC_DRC_ALGORITHM_H__
+#define __SOF_AUDIO_DRC_DRC_ALGORITHM_H__
+
+#include <stdint.h>
+#include <sof/audio/drc/drc.h>
+#include <sof/platform.h>
+#include <user/drc.h>
+
+/* drc reset function */
+void drc_reset_state(struct drc_state *state);
+
+/* drc init functions */
+int drc_init_pre_delay_buffers(struct drc_state *state,
+			       size_t sample_bytes,
+			       int channels);
+int drc_set_pre_delay_time(struct drc_state *state,
+			   int32_t pre_delay_time,
+			   int32_t rate);
+
+/* drc process functions */
+void drc_update_detector_average(struct drc_state *state,
+				 const struct sof_drc_params *p,
+				 int nbyte,
+				 int nch);
+void drc_update_envelope(struct drc_state *state, const struct sof_drc_params *p);
+void drc_compress_output(struct drc_state *state,
+			 const struct sof_drc_params *p,
+			 int nbyte,
+			 int nch);
+
+#endif //  __SOF_AUDIO_DRC_DRC_ALGORITHM_H__

--- a/src/include/sof/audio/multiband_drc/multiband_drc.h
+++ b/src/include/sof/audio/multiband_drc/multiband_drc.h
@@ -1,0 +1,83 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2020 Google LLC. All rights reserved.
+ *
+ * Author: Pin-chih Lin <johnylin@google.com>
+ */
+#ifndef __SOF_AUDIO_MULTIBAND_DRC_MULTIBAND_DRC_H__
+#define __SOF_AUDIO_MULTIBAND_DRC_MULTIBAND_DRC_H__
+
+#include <stdint.h>
+#include <sof/audio/component.h>
+#include <sof/audio/crossover/crossover.h>
+#include <sof/audio/drc/drc.h>
+#include <sof/platform.h>
+#include <sof/math/iir_df2t.h>
+#include <user/multiband_drc.h>
+
+/**
+ * Stores the state of the sub-components in Multiband DRC
+ */
+struct multiband_drc_state {
+	struct iir_state_df2t emphasis[PLATFORM_MAX_CHANNELS];
+	struct crossover_state crossover[PLATFORM_MAX_CHANNELS];
+	struct drc_state drc[SOF_MULTIBAND_DRC_MAX_BANDS];
+	struct iir_state_df2t deemphasis[PLATFORM_MAX_CHANNELS];
+};
+
+typedef void (*multiband_drc_func)(const struct comp_dev *dev,
+				   const struct audio_stream *source,
+				   struct audio_stream *sink,
+				   uint32_t frames);
+
+/* Multiband DRC component private data */
+struct multiband_drc_comp_data {
+	struct multiband_drc_state state;        /**< compressor state */
+	struct comp_data_blob_handler *model_handler;
+	struct sof_multiband_drc_config *config; /**< pointer to setup blob */
+	bool config_ready;                       /**< set when fully received */
+	enum sof_ipc_frame source_format;        /**< source frame format */
+	multiband_drc_func multiband_drc_func;   /**< processing function */
+	crossover_split crossover_split;         /**< crossover n-way split func */
+};
+
+struct multiband_drc_proc_fnmap {
+	enum sof_ipc_frame frame_fmt;
+	multiband_drc_func multiband_drc_proc_func;
+};
+
+extern const struct multiband_drc_proc_fnmap multiband_drc_proc_fnmap[];
+extern const struct multiband_drc_proc_fnmap multiband_drc_proc_fnmap_pass[];
+extern const size_t multiband_drc_proc_fncount;
+
+/**
+ * \brief Returns Multiband DRC processing function.
+ */
+static multiband_drc_func multiband_drc_find_proc_func(enum sof_ipc_frame src_fmt)
+{
+	int i;
+
+	/* Find suitable processing function from map */
+	for (i = 0; i < multiband_drc_proc_fncount; i++)
+		if (src_fmt == multiband_drc_proc_fnmap[i].frame_fmt)
+			return multiband_drc_proc_fnmap[i].multiband_drc_proc_func;
+
+	return NULL;
+}
+
+/**
+ * \brief Returns Multiband DRC passthrough functions.
+ */
+static multiband_drc_func multiband_drc_find_proc_func_pass(enum sof_ipc_frame src_fmt)
+{
+	int i;
+
+	/* Find suitable processing function from map */
+	for (i = 0; i < drc_proc_fncount; i++)
+		if (src_fmt == multiband_drc_proc_fnmap_pass[i].frame_fmt)
+			return multiband_drc_proc_fnmap_pass[i].multiband_drc_proc_func;
+
+	return NULL;
+}
+
+#endif //  __SOF_AUDIO_MULTIBAND_DRC_MULTIBAND_DRC_H__

--- a/src/include/user/multiband_drc.h
+++ b/src/include/user/multiband_drc.h
@@ -1,0 +1,85 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2020 Google LLC. All rights reserved.
+ *
+ * Author: Pin-chih Lin <johnylin@google.com>
+ */
+
+#ifndef __USER_MULTIBAND_DRC_H__
+#define __USER_MULTIBAND_DRC_H__
+
+#include <stdint.h>
+#include <user/crossover.h>
+#include <user/drc.h>
+#include <user/eq.h>
+
+/* Maximum number of frequency band for Multiband DRC */
+#define SOF_MULTIBAND_DRC_MAX_BANDS SOF_CROSSOVER_MAX_STREAMS
+
+/* Maximum number of Crossover LR4 highpass and lowpass filters */
+#define SOF_CROSSOVER_MAX_LR4 ((SOF_CROSSOVER_MAX_STREAMS - 1) * 2)
+
+/* The number of biquads (and biquads in series) of (De)Emphasis Equalizer */
+#define SOF_EMP_DEEMP_BIQUADS 2
+
+/* Maximum number allowed of IPC configuration blob size */
+#define SOF_MULTIBAND_DRC_MAX_BLOB_SIZE 1024
+
+ /* multiband_drc configuration
+  *     Multiband DRC is a single-source-single-sink compound component which
+  *     consists of 4 stages: Emphasis Equalizer, Crossover Filter (from 1-band
+  *     to 4-band), DRC (per band), and Deemphasis Equalizer of summed stream.
+  *
+  *     The following graph illustrates a 3-band Multiband DRC component:
+  *
+  *                                      low
+  *                                     o----> DRC0 ----o
+  *                                     |               |
+  *                           3-WAY     |mid            |
+  *     x(n) --> EQ EMP --> CROSSOVER --o----> DRC1 ---(+)--> EQ DEEMP --> y(n)
+  *                                     |               |
+  *                                     |high           |
+  *                                     o----> DRC2 ----o
+  *
+  *     uint32_t num_bands <= 4
+  *         Determines the number of frequency bands, the choice of n-way
+  *         Crossover, and the number of DRC components.
+  *     uint32_t enable_emp_deemp
+  *         1=enable Emphasis and Deemphasis Equalizer; 0=disable (passthrough)
+  *     struct sof_eq_iir_biquad_df2t emp_coef[2]
+  *         The coefficient data for Emphasis Equalizer, which is a cascade of 2
+  *         biquad filters.
+  *     struct sof_eq_iir_biquad_df2t deemp_coef[2]
+  *         The coefficient data for Deemphasis Equalizer, which is a cascade of
+  *         2 biquad filters.
+  *     struct sof_eq_iir_biquad_df2t crossover_coef[6]
+  *         The coefficient data for Crossover LR4 filters. Please refer
+  *         src/include/user/crossover.h for details. Zeros will be filled if
+  *         the entries are useless. For example, when 2-way crossover is used:
+  *     struct sof_drc_params drc_coef[num_bands]
+  *         The parameter data for DRC per band, the number entries of this may
+  *         vary. Please refer src/include/user/drc.h for details.
+  *
+  */
+struct sof_multiband_drc_config {
+	uint32_t size;
+	uint32_t num_bands;
+	uint32_t enable_emp_deemp;
+
+	/* reserved */
+	uint32_t reserved[8];
+
+	/* config of emphasis eq-iir */
+	struct sof_eq_iir_biquad_df2t emp_coef[SOF_EMP_DEEMP_BIQUADS];
+
+	/* config of deemphasis eq-iir */
+	struct sof_eq_iir_biquad_df2t deemp_coef[SOF_EMP_DEEMP_BIQUADS];
+
+	/* config of crossover */
+	struct sof_eq_iir_biquad_df2t crossover_coef[SOF_CROSSOVER_MAX_LR4];
+
+	/* config of multi-band drc */
+	struct sof_drc_params drc_coef[];
+};
+
+#endif // __USER_MULTIBAND_DRC_H__


### PR DESCRIPTION
Multiband DRC is a single-source-single-sink compound component which consists of 4 stages: Emphasis Equalizer, Crossover Filter (from 1-band to 4-band), DRC (per band), and Deemphasis Equalizer of summed stream.

The following graph illustrates a 3-band Multiband DRC component:
 
```
                                       low
                                      o----> DRC0 ----o
                                      |               |
                            3-WAY     |mid            |
      x(n) --> EQ EMP --> CROSSOVER --o----> DRC1 ---(+)--> EQ DEEMP --> y(n)
                                      |               |
                                      |high           |
                                      o----> DRC2 ----o
```
