### PR TITLE
platform: imx: Fix PLATFORM_DCACHE_ALIGN

### DIFF
--- a/src/platform/imx8/include/platform/lib/memory.h
+++ b/src/platform/imx8/include/platform/lib/memory.h
@@ -14,7 +14,7 @@
 
 
 /* data cache line alignment */
-#define PLATFORM_DCACHE_ALIGN	DCACHE_LINE_SIZE
+#define PLATFORM_DCACHE_ALIGN	sizeof(void *)
 
 /* physical DSP addresses */
 
@@ -171,7 +171,7 @@
 
 #define SOF_MEM_RO_SIZE			0x8
 
-#define HEAP_BUF_ALIGNMENT		PLATFORM_DCACHE_ALIGN
+#define HEAP_BUF_ALIGNMENT		DCACHE_LINE_SIZE
 
 /** \brief EDF task's default stack size in bytes. */
 #define PLATFORM_TASK_DEFAULT_STACK_SIZE	3072

--- a/src/platform/imx8m/include/platform/lib/memory.h
+++ b/src/platform/imx8m/include/platform/lib/memory.h
@@ -14,7 +14,7 @@
 
 
 /* data cache line alignment */
-#define PLATFORM_DCACHE_ALIGN	DCACHE_LINE_SIZE
+#define PLATFORM_DCACHE_ALIGN	sizeof(void *)
 
 /* physical DSP addresses */
 
@@ -172,7 +172,7 @@
 
 #define SOF_MEM_RO_SIZE			0x8
 
-#define HEAP_BUF_ALIGNMENT		PLATFORM_DCACHE_ALIGN
+#define HEAP_BUF_ALIGNMENT		DCACHE_LINE_SIZE
 
 /** \brief EDF task's default stack size in bytes. */
 #define PLATFORM_TASK_DEFAULT_STACK_SIZE	3072


### PR DESCRIPTION
At this point PLATFORM_DCACHE_ALIGN is equal with DCACHE_LINE_SIZE
which on i.MX boards is 128.

Functions like rmalloc and rzalloc are allocating memory aligned at
PLATFORM_DCACHE_ALIGN bytes. This means that blocks under 128 bytes
are not really used and blocks sized > 128 are preffered for small
allocations.

This seems to be an unnecessary overhead which results in SOF not
being abel to allocate memory for simple pipelines (e.g simple
pipeline with a mixer).

For this reason, we set PLATFORM_DCACHE_ALIGN to a smaller value
(sizeof(void*)) but keep HEAP_BUF_ALIGNMENT unchanged.

Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>