### PR TITLE
Tools: Tune: Add tool for DMIC FIR filters setup

### DIFF
--- a/tools/tune/dmic/dmic_batch.m
+++ b/tools/tune/dmic/dmic_batch.m
@@ -1,0 +1,51 @@
+%% Create DMIC FIR configuration files
+
+% SPDX-License-Identifier: BSD-3-Clause
+%
+% Copyright (c) 2019, Intel Corporation. All rights reserved.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+
+%% Generic parameters
+prm.driver_abi_version = 1;
+prm.duty_min = 40;
+prm.duty_max = 60;
+prm.fifo_a_fs = 0;
+prm.fifo_a_bits = 24;
+prm.fifo_b_fs = 0;
+prm.fifo_b_bits = 24;
+prm.number_of_pdm_controllers = 2;
+prm.pdm(1).enable_mic_a = 1;
+prm.pdm(1).enable_mic_b = 1;
+prm.pdm(1).polarity_mic_a = 0;
+prm.pdm(1).polarity_mic_b = 0;
+prm.pdm(1).clk_edge = 0;
+prm.pdm(1).skew = 0;
+prm.pdm(2).enable_mic_a = 1;
+prm.pdm(2).enable_mic_b = 1;
+prm.pdm(2).polarity_mic_a = 0;
+prm.pdm(2).polarity_mic_b = 0;
+prm.pdm(2).clk_edge = 0;
+prm.pdm(2).skew = 0;
+
+%% Design
+prm.pdmclk_min = 2.4e6;
+prm.pdmclk_max = 4.8e6;
+
+% clkdiv, mcic, mfira, mfirb
+prm.fifo_a_fs =  8e3; prm.fifo_b_fs = 16e3; dmic_init(prm); %  8, 30, 10, 5
+prm.fifo_a_fs =  8e3; prm.fifo_b_fs = 32e3; dmic_init(prm); %  8, 25, 12, 3
+prm.fifo_a_fs =  8e3; prm.fifo_b_fs = 48e3; dmic_init(prm); %  8, 25, 12, 2
+prm.fifo_a_fs = 24e3; prm.fifo_b_fs = 96e3; dmic_init(prm); %  5, 20,  8, 2
+prm.fifo_a_fs = 32e3; prm.fifo_b_fs = 96e3; dmic_init(prm); %  5, 20,  6, 2
+prm.fifo_a_fs = 48e3; prm.fifo_b_fs = 96e3; dmic_init(prm); %  5, 20,  4, 2
+prm.fifo_a_fs = 48e3; prm.fifo_b_fs = 16e3; dmic_init(prm); %  8, 25,  2, 6
+
+%% No need to run due to duplicated FIR coefficients
+%prm.fifo_a_fs =  8e3; prm.fifo_b_fs = 24e3; dmic_init(prm); %  8, 25, 12, 4
+%prm.fifo_a_fs = 16e3; prm.fifo_b_fs = 32e3; dmic_init(prm); %  8, 25,  6, 3
+%prm.fifo_a_fs = 16e3; prm.fifo_b_fs = 24e3; dmic_init(prm); %  8, 25,  6, 4
+%prm.fifo_a_fs = 16e3; prm.fifo_b_fs = 96e3; dmic_init(prm); %  5, 20, 12, 2
+%prm.fifo_a_fs = 24e3; prm.fifo_b_fs = 32e3; dmic_init(prm); %  8, 25,  4, 3
+%prm.fifo_a_fs = 24e3; prm.fifo_b_fs = 48e3; dmic_init(prm); %  8, 25,  4, 2
+%prm.fifo_a_fs = 32e3; prm.fifo_b_fs = 48e3; dmic_init(prm); %  5, 20,  6, 4

--- a/tools/tune/dmic/dmic_fir.m
+++ b/tools/tune/dmic/dmic_fir.m
@@ -1,0 +1,271 @@
+% PDM_DECIM_FIRPM
+%
+% [ coef, shift, used_passhz, used_stophz, used_rs, pb_ripple, sb_ripple, pass] = ...
+%        pdm_decim_firpm( rp, rs, passhz, stophz, fs_cic, fs_fir, max_length, linph)
+%
+
+% SPDX-License-Identifier: BSD-3-Clause
+%
+% Copyright (c) 2019, Intel Corporation. All rights reserved.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+
+function [ coef, shift, used_passhz, used_stophz, used_rs, pb_ripple, sb_ripple, pass] = ...
+        dmic_fir( rp, rs, passhz, stophz, fs_cic, fs_fir, max_length, linph)
+
+
+if exist('OCTAVE_VERSION', 'builtin')
+	error('This function runs only in Matlab');
+end
+
+%% Suppress iteration prints
+verbose = 0;
+do_plots = 0;
+
+%% cic5 response
+f = linspace(1, fs_fir/2, 5000);
+w = 2*pi*f/fs_cic;
+j = sqrt(-1);
+z = exp(j.*w);
+m_cic = fs_cic / fs_fir;
+g_cic = m_cic^5;
+g_cic_db = 20*log10(g_cic);
+z_cic_hi = z;
+z_cic_lo = z.^(m_cic);
+
+hd = (1 - z_cic_lo.^(-1)).^5;
+hi = (1 ./ (1 - z_cic_hi.^(-1))).^5;
+h_cic = (1/g_cic) .* hi .* hd;
+
+%% Get firpm design spec
+
+[n, fv, mv, w] = filter_spec(rp, rs, passhz, stophz, fs_fir, f, h_cic, linph);
+if linph
+        n = min(n, max_length-1);
+end
+
+%% Iterate order and passband width
+iterate = 1;
+lo_ind = find(f < passhz/20);
+pb_ind = find(f < passhz);
+sb_ind = find(f > stophz);
+pb_ripple_min = 1000;
+sb_ripple_min = 1000;
+pb_ripple_prev = 1000;
+sb_ripple_prev = 1000;
+pb_worse = 0;
+sb_worse = 0;
+
+pass = 0;
+nstep = 2;
+cpb = 1.0;
+csb = 1.0;
+cpb_min = 0.95;
+cpb_dec = 0.0005;
+csb_inc = 0.0005;
+rs_dec = 1;
+passhz0 = passhz;
+stophz0 = stophz;
+used_passhz = passhz;
+used_stophz = stophz;
+used_rs = rs;
+ni_max = 200;
+rs_min = 90;
+
+ni = 0;
+while (iterate > 0)
+        ni = ni + 1;
+	if verbose
+		fprintf(1, 'N=%3d, max=%3d, order=%3d, bw=%5.2f kHz, sb=%5.2f kHz, rp=%4.1f dB', ...
+			ni, max_length-1, n, passhz/1e3, stophz/1e3, rs);
+	end
+        b = firpm(n, fv, mv, w);
+        if linph == 0
+		error('not supported');
+        end
+
+        % Set low frequency gain to max 0 dB
+        h_lo = freqz(b, 1, f(lo_ind), fs_fir);
+        g = 1/max(abs(h_lo));
+        b = b * g;
+        n_taps = length(b);
+        n_fir = n_taps-1;
+
+        %% Scale FIR coefficient to be close to 1.0
+        max_abs_coef = max(abs(b));
+        scale = 0.9999/max_abs_coef;
+
+        % Check for amount of left shifts for coefficients / right shifts
+        % for data.
+        shift = floor(log(scale)/log(2));
+        c = 2^shift;
+        coef = b * c;
+
+
+        %% Compute FIR response as H(z^M)
+        z_fir = z.^m_cic;
+        h_fir = b(1);
+        for i=2:(n_fir+1)
+                h_fir = h_fir + b(i).*z_fir.^(-i+1);
+        end
+
+        %% Combine CIC5 and FIR response
+        h_decim = h_cic .* h_fir;
+
+        %% Check passband
+        % If PB is met then SB should be OK as well due to weights
+        h_passband_db = 20*log10(abs(h_decim(pb_ind)));
+        h_stopband_db = 20*log10(abs(h_decim(sb_ind)));
+        pb_ripple = (max(h_passband_db)-min(h_passband_db))/2;
+        sb_ripple = max(h_stopband_db);
+	if verbose
+		fprintf(1,', rp=%4.2f, rs=%5.1f', pb_ripple, sb_ripple);
+	end
+
+        if (sb_ripple < -rs) && (pb_ripple < rp)
+                iterate = 0;
+                pass = 1;
+        else
+                % Check if length can be increased or generic filter spec relaxed
+                if (sb_ripple < sb_ripple_min) && (pb_ripple < pb_ripple_min)
+                        sb_ripple_min = sb_ripple;
+                        pb_ripple_min = pb_ripple;
+                        n_min = n;
+                        fv_min = fv;
+                        mv_min = mv;
+                        w_min = w;
+			if verbose
+				fprintf(' +');
+			end
+                end
+                if (n_taps + nstep < max_length + 1) && (pb_worse < 10) && (sb_worse < 10)
+                        n = n + nstep;
+                else
+                        cpb = cpb - cpb_dec;
+                        if cpb < cpb_min
+                                if passhz < 24e3
+                                        cpb = cpb_min;
+                                        rs = rs - rs_dec;
+                                        if rs < rs_min
+                                                rs = rs_min;
+                                                csb = csb + csb_inc;
+                                        end
+                                end
+                        end
+                        passhz = passhz0 * cpb;
+                        used_passhz = passhz;
+                        stophz = stophz0 * csb;
+                        used_stophz = stophz;
+                        used_rs = rs;
+                        [n, fv, mv, w] = filter_spec(rp, rs, passhz, stophz, fs_fir, f, h_cic, linph);
+                        if linph
+                                n = min(n, max_length-1);
+                        end
+                        pb_ind = find(f < passhz);
+                        sb_ind = find(f > stophz);
+                        pb_worse = 0;
+                        sb_worse = 0;
+			if verbose
+				fprintf(1, ' *');
+			end
+                end
+                if pb_ripple > pb_ripple_prev
+                        pb_worse = pb_worse + 1;
+                else
+                        pb_worse = 0;
+                end
+                if sb_ripple > sb_ripple_prev
+                        sb_worse = sb_worse + 1;
+                else
+                        sb_worse = 0;
+                end
+                if ni > ni_max
+                        n = n_min;
+                        fv = fv_min;
+                        mv = mv_min;
+                        w = w_min;
+                        iterate = 0;
+			if verbose
+				fprintf(1, ', Iterate stop, restore n=%d', n);
+			end
+                end
+                pb_ripple_prev = pb_ripple;
+                sb_ripple_prev = sb_ripple;
+	end
+	if verbose
+		fprintf(1, '\n');
+	end
+
+end
+
+if do_plots
+	figure;
+	plot(f, 20*log10(abs(h_decim)), ...
+		f, 20*log10(abs(h_fir)), '--', f, 20*log10(abs(h_cic)), '--');
+	grid on;
+	xlabel('Frequency (Hz)');
+	ylabel('Magniture (dB)');
+	legend('Combined', 'FIR', 'CIC', 'Location', 'SouthWest');
+end
+
+end
+
+function [n, fv, mv, w] = filter_spec(rp, rs, passhz, stophz, fs_fir, f, h_cic, linph)
+
+% Prepare for normal firpm filter design
+dp0 = (10^(rp/20)-1)/(10^(rp/20)+1);
+ds0 = 10^(-rs/20);
+if linph
+        dp = dp0;
+        ds = ds0;
+else
+        % See https://www.cs.tut.fi/~ts/FIR_minimumphase.pdf
+        den = 1 + dp0^2 - 0.5 * ds0^2;
+        dp = 2 * dp0 / den;
+        ds = 0.5 * ds0^2 / den;
+end
+
+n_pb = 16; % Number of tilted line slopes for passband
+% Make the start of equalized region high enough to have a flat band
+% from DC to some kHz. It's the 1st band for firpmord().
+f_pb = linspace(passhz/20, passhz, n_pb);
+% Interpolate complex CIC^5 response to this grid
+h_cic_pb = interp1(f, h_cic, f_pb, 'linear');
+% Inverse response
+h_seq = abs(h_cic_pb(1))./abs(h_cic_pb);
+if linph == 0
+        h_seq = h_seq .^2;
+end
+
+% Specify response in bands for firpm() / remez()
+% First band is from DC to 1st point (1 kHz)
+f_fir_cic = [ 0 0.9999*f_pb(1) ];
+a_fir_cic = [ 1 h_seq(1) ]; % Firpm/Remez supports slopes with two points for gain
+dev_cic = [ dp ];
+for n = 2:n_pb;
+        f_fir_cic = [ f_fir_cic f_pb(n-1) 0.9999*f_pb(n) ];
+        a_fir_cic = [ a_fir_cic h_seq(n-1) h_seq(n) ];
+        dev_cic(n) = dp * h_seq(n)^2; % Ripple spec relax as square of eq
+end
+
+f_fir = f_fir_cic;
+a_fir = a_fir_cic;
+dev = dev_cic;
+
+% Append transition/stop band
+f_fir = [ f_fir stophz 0.5*fs_fir];
+a_fir = [ a_fir 0 0 ];
+dev   = [ dev ds ];
+
+fv = 2*f_fir/fs_fir;
+mv = a_fir;
+a_fir_bands = 0.5*(a_fir(1:2:end)+a_fir(2:2:end));
+sb = (a_fir_bands == 0); % Find stopband
+devr = dev ./ (sb + a_fir_bands); % Get relative deviation
+w = max(devr)./devr; % Invert and normalize
+
+% Get FIR order estimate with firpmord()
+[n, ~,  ~, ~] = firpmord([passhz stophz], [1 0], [dp ds], fs_fir );
+n = round(0.95*n/2)*2;
+
+end

--- a/tools/tune/dmic/dmic_fir_export.m
+++ b/tools/tune/dmic/dmic_fir_export.m
@@ -1,0 +1,62 @@
+% dmic_fir_export - Export FIR coefficients
+%
+% success=pdm_export_coef(fir, hdir)
+%
+% fir     - fir definition struct
+% hdir    - directory for header files
+
+% SPDX-License-Identifier: BSD-3-Clause
+%
+% Copyright (c) 2019, Intel Corporation. All rights reserved.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+
+function success = dmic_fir_export(fir, hdir)
+
+if ~exist(hdir, 'dir')
+	mkdir(hdir);
+end
+
+pbi = round(fir.cp*1e4);
+sbi = round(fir.cs*1e4);
+rpi = round(fir.rp*1e2);
+rsi = round(fir.rs);
+
+hfn = sprintf('%s/pdm_decim_int32_%02d_%04d_%04d_%03d_%03d.h', hdir, fir.m, pbi, sbi, rpi, rsi);
+vfn = sprintf('fir_int32_%02d_%04d_%04d_%03d_%03d', fir.m, pbi, sbi, rpi, rsi);
+sfn = sprintf('pdm_decim_int32_%02d_%04d_%04d_%03d_%03d', fir.m, pbi, sbi, rpi, rsi);
+
+fprintf('Exporting %s ...\n', hfn);
+fh = fopen(hfn, 'w');
+
+fprintf(fh, '/* SPDX-License-Identifier: BSD-3-Clause\n');
+fprintf(fh, ' *\n');
+fprintf(fh, ' * Copyright(c) 2019 Intel Corporation. All rights reserved.\n');
+fprintf(fh, ' */\n');
+fprintf(fh, '\n');
+fprintf(fh, '#include <stdint.h>\n');
+fprintf(fh, '\n');
+
+print_int_coef(fir, fh, 'int32_t', vfn);
+
+fprintf(fh, '\n\n');
+fprintf(fh, 'struct pdm_decim %s = {\n', sfn);
+fprintf(fh, '\t%d, %d, %d, %d, %d, %d, %d, %s\n};\n', ...
+        fir.m, fir.length, fir.shift, pbi, sbi, rpi, rsi, vfn);
+fclose(fh);
+success = 1;
+
+end
+
+function print_int_coef(fir, fh, vtype, vfn)
+        fprintf(fh, 'const %s %s[%d] = {\n', ...
+                vtype, vfn, fir.length);
+
+        fprintf(fh,'\t%d', fir.coef(1));
+        for n=2:fir.length
+                fprintf(fh, ',\n');
+                fprintf(fh,'\t%d', fir.coef(n));
+        end
+        fprintf(fh,'\n\n};');
+end
+

--- a/tools/tune/dmic/dmic_init.m
+++ b/tools/tune/dmic/dmic_init.m
@@ -1,0 +1,332 @@
+% success = dmic_init(prm)
+%
+% Create PDM microphones interface configuration
+
+% SPDX-License-Identifier: BSD-3-Clause
+%
+% Copyright (c) 2019, Intel Corporation. All rights reserved.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+
+function success = dmic_init(prm)
+
+hw.controllers = 4;
+hw.bits_cic = 26;
+hw.bits_fir_coef = 20;
+hw.bits_fir_gain = 20;
+hw.bits_fir_input = 22;
+hw.bits_fir_output = 24;
+hw.bits_fir_internal = 26;
+hw.bits_gain_output = 22;
+hw.fir_length_max = 250;
+hw.cic_shift_right_range = [-8 4];
+hw.fir_shift_right_range  = [0 8];
+hw.fir_max_length = 250;
+hw.version = 1;
+hw.number_of_pdm_controllers = 2;
+hw.ioclk = 19.2e6;
+spec.scale = 0.95;
+spec.linear_phase = 1;
+spec.rp = 0.1;
+spec.cp = 0.4375;
+spec.cs = 0.5100;
+spec.rs = 95;
+success = 0;
+
+if (prm.fifo_a_fs == 0) && (prm.fifo_b_fs == 0)
+        fprintf(1,'Error: At least one FIFO needs non-zero Fs!\n');
+        return;
+end
+
+%% Match modes
+[a_clkdiv, a_mcic, a_mfir] = find_modes(prm, hw, prm.fifo_a_fs);
+[b_clkdiv, b_mcic, b_mfir] = find_modes(prm, hw, prm.fifo_b_fs);
+[common_clkdiv_list,common_mcic_list,a_mfir_list,b_mfir_list] = ...
+        match_modes(a_clkdiv, a_mcic, a_mfir, b_clkdiv, b_mcic, b_mfir);
+
+if isempty(common_clkdiv_list)
+        error('No compatible settings were found!\n');
+end
+
+%% Set basic configuration data
+cfg = get_cfg(prm, hw);
+
+%% Done, print 1st modes combination
+fprintf('Selected fifo_a_fs=%d, fifo_b_fs=%d: ', prm.fifo_a_fs, prm.fifo_b_fs);
+cfg = select_mode(common_mcic_list, a_mfir_list, b_mfir_list, common_clkdiv_list, cfg);
+cfg = get_cic_config(prm, cfg, hw);
+cfg = get_fir_config(prm, cfg, hw, spec);
+
+end
+
+%% Functions
+
+%% Get FIR filters
+function cfg = get_fir_config(prm, cfg, hw, spec)
+
+if prm.fifo_a_fs > 0
+        [coef, shift] = get_fir(cfg.mfir_a, prm, cfg, hw, spec);
+
+        [cfg.fir_coef_a, cfg.fir_shift_a, cfg.fir_length_a] = ...
+                scale_fir_coef(coef, shift, spec.scale, cfg.remain_gain_to_fir, hw.bits_fir_coef);
+        cfg.fir_gain_a = 1;
+else
+        cfg.fir_gain_a = 0;
+        cfg.fir_coef_a = 0;
+        cfg.fir_shift_a = 0;
+        cfg.fir_length_a = 1;
+end
+
+if prm.fifo_b_fs > 0
+        [coef, shift] = get_fir(cfg.mfir_b, prm, cfg, hw, spec);
+
+        [cfg.fir_coef_b, cfg.fir_shift_b, cfg.fir_length_b] = ...
+		scale_fir_coef(coef, shift, spec.scale, cfg.remain_gain_to_fir, hw.bits_fir_coef);
+        cfg.fir_gain_b = 1;
+else
+        cfg.fir_gain_b = 0;
+        cfg.fir_coef_b = 0;
+        cfg.fir_shift_b = 0;
+        cfg.fir_length_b = 1;
+end
+
+end
+
+function [coefq, shiftq, len] = scale_fir_coef(coef32, shift32, hw_sens, add_gain, bits)
+
+out_scale = 2^(bits-1);
+q31_scale = 2^31;
+coef = coef32/q31_scale * 2^(-shift32) * hw_sens * add_gain;
+max_abs_coef = max(abs(coef));
+scale = 0.9999/max_abs_coef;
+shiftq = floor(log(scale)/log(2));
+c = 2^shiftq;
+coefq = round(out_scale * coef * c);
+len = length(coefq);
+
+end
+
+% This function becomes table lookup in C
+function [coef32, shift] = get_fir(mfir, prm, cfg, hw, spec)
+
+fs_fir = cfg.mic_clk/cfg.mcic;
+fs = fs_fir/mfir;
+passhz = spec.cp * fs;
+stophz = spec.cs * fs;
+max_length = min(hw.fir_max_length, floor(hw.ioclk/fs/2-5));
+
+[ coef, shift, bw, sb, rs, got_pb, got_sb, passed] = ...
+	dmic_fir(spec.rp, spec.rs, passhz, stophz, cfg.mic_clk, fs_fir, max_length, spec.linear_phase);
+
+if passed == 0
+        fprintf(1, 'Warning: Filter specification was reduced.\n');
+        if (got_pb > 1) || (got_sb > -60)
+                error('The design is erroneous.');
+        end
+end
+
+coef32 = round(2^31 * coef);
+fir.length = length(coef32);
+fir.coef = coef32;
+fir.shift = shift;
+cp = bw/fs;
+cs = sb/fs;
+fir.cp = cp;
+fir.cs = cs;
+fir.rp = spec.rp;
+fir.rs = rs;
+fir.m = mfir;
+dmic_fir_export(fir, 'include');
+
+end
+
+%% Select one mode from possible combinations
+function cfg = select_mode(common_mcic_list, a_mfir_list, b_mfir_list, common_clkdiv_list, cfg)
+
+cfg.mcic = 0;
+cfg.mfir_a = 0;
+cfg.mfir_b = 0;
+cfg.clk_div = 0;
+
+% Order of preference for FIR decimation factors, prime numbers
+% even if low value, are less preferable due to incompatibility
+% with other FIR decimation factor.
+mpref = [2 4 6 8 3 5 7 9 10 11 12 13 14 15];
+
+% Find common mode with lowest FIR decimation ratio. If there are many
+% select one with lowest mic clock rate. Lowest rates or highest dividers
+% are in the end of list.
+if length(common_mcic_list) > 0
+	for mtry = mpref
+		idx = find(a_mfir_list == mtry);
+		if ~isempty(idx)
+			n = idx(end);
+			break;
+		end
+	end
+        cfg.mcic = common_mcic_list(n);
+        cfg.clk_div = common_clkdiv_list(n);
+        if a_mfir_list(1) > 0
+                cfg.mfir_a = a_mfir_list(n);
+        end
+        if b_mfir_list(1) > 0
+                cfg.mfir_b = b_mfir_list(n);
+        end
+        fprintf(1, 'clk_div=%d, cic=%d, fir_a=%d, fir_b=%d\n', ...
+		cfg.clk_div, cfg.mcic, cfg.mfir_a, cfg.mfir_b);
+end
+
+end
+
+%% Compute CIC filter settings
+function cfg = get_cic_config(prm, cfg, hw)
+
+cfg.mic_clk = hw.ioclk/cfg.clk_div;
+g_cic = cfg.mcic^5;
+bitsneeded = floor(log(g_cic)/log(2)+1)+1;
+cfg.cic_shift = bitsneeded - hw.bits_fir_input;
+
+if hw.bits_cic < bitsneeded
+        fprintf(1,'Error: Needed CIC word length is exceeded %d\n', bitsneeded);
+end
+
+if cfg.cic_shift < hw.cic_shift_right_range(1);
+        fprintf(1,'Warning: Limited CIC shift right from %d', cfg.cic_shift);
+        cfg.cic_shift = hw.cic_shift_right_range(1);
+end
+
+if cfg.cic_shift > hw.cic_shift_right_range(2);
+        fprintf(1,'Error: Limited CIC shift right from %d', cfg.cic_shift);
+        cfg.cic_shift = hw.cic_shift_right_range(2);
+end
+
+% Compute how much gain is left for FIR from scaling to full scale
+cfg.remain_gain_to_fir = 2^(hw.bits_fir_input-1)/(g_cic/2^cfg.cic_shift);
+
+end
+
+%% Find modes those are possible and exist in setup database
+function [clkdiv, mcic, mfir] = find_modes(prm, hw, pcm_fs)
+
+if pcm_fs < 1
+        clkdiv = 0;
+        mcic = 0;
+        mfir = 0;
+        return;
+end
+osr_min = 50;
+if pcm_fs > 48e3
+        osr_min = floor(3.0e6 / pcm_fs);
+end
+mcic_min = 5;
+mcic_max = 31; % 8 bits reg but CIC gain and 26 bits implementation limits this
+mfir_min = 2;
+mfir_max = 15;
+clkdiv_min = ceil(hw.ioclk/prm.pdmclk_max);
+clkdiv_max = floor(hw.ioclk/prm.pdmclk_min);
+n = 1;
+clkdiv = [];
+mcic = [];
+mfir = [];
+% Highest to lowest PDM clock, prefer best quality in range
+for clkdiv_test = clkdiv_min:clkdiv_max
+        if clkdiv_test > 4 % Limitation in cAVS1.5-2.0
+                c1 = floor(clkdiv_test/2);
+                c2 = clkdiv_test - c1;
+                du_min = 100*c1/clkdiv_test;
+                du_max = 100*c2/clkdiv_test;
+                pdmclk = hw.ioclk/clkdiv_test;
+                osr = round(pdmclk/pcm_fs);
+                % Lowest FIR decimation to highest, prefer low FIR
+                % decimation ratios
+                for mfir_test = mfir_min:osr
+                        mcic_test = floor(osr/mfir_test);
+                        if (abs(pcm_fs*mfir_test*mcic_test -pdmclk) < 1)  ...
+                                        && (osr >= osr_min) ...
+                                        && (mcic_test >= mcic_min) ...
+                                        && (mcic_test <= mcic_max) ...
+                                        && (mfir_test <= mfir_max) ...
+                                        && (du_min >= prm.duty_min) ...
+                                        && (du_max <= prm.duty_max)
+                                sfir = sprintf('FIR %d x %d x %dHz', ...
+                                        mcic_test, mfir_test, round(pcm_fs));
+                                %fprintf('Found: %s\n',sfir);
+                                clkdiv(n) = clkdiv_test;
+                                mcic(n) = mcic_test;
+                                mfir(n) = mfir_test;
+                                n=n+1;
+                        end
+                end
+        end
+end
+end
+
+
+%% Match found modes for common clkdiv and mcic, a DMIC hardware constraint
+function [common_clkdiv_list,common_mcic_list,a_mfir_list,b_mfir_list] = ...
+        match_modes(a_clkdiv, a_mcic, a_mfir, b_clkdiv, b_mcic, b_mfir)
+
+if b_clkdiv == 0
+        common_clkdiv_list = a_clkdiv;
+        common_mcic_list = a_mcic;
+        a_mfir_list = a_mfir;
+        b_mfir_list = 0;
+        return;
+end
+common_clkdiv_list = [];
+common_mcic_list = [];
+a_mfir_list = [];
+b_mfir_list = [];
+n_list = 1;
+for n=1:length(a_clkdiv)
+        idx = find(b_clkdiv == a_clkdiv(n));
+        for m=1:length(idx)
+                if b_mcic(idx(m)) == a_mcic(n)
+                        common_clkdiv = a_clkdiv(n);
+                        common_mcic = a_mcic(n);
+                        common_clkdiv_list(n_list) = common_clkdiv;
+                        common_mcic_list(n_list) = common_mcic;
+                        a_mfir_list(n_list) = a_mfir(n);
+                        b_mfir_list(n_list) = b_mfir(idx(m));
+                        fprintf('Option %d: div=%d, mcic=%d, mfira=%d, mfirb=%d\n', ...
+                                n_list, common_clkdiv, common_mcic, ...
+                                a_mfir_list(n_list), b_mfir_list(n_list));
+                        n_list = n_list+1;
+                end
+        end
+end
+end
+
+%% Misc blob details needed
+function cfg = get_cfg(prm, hw)
+
+% if FIFO A or B is disabled, append a dummy blob to keep modes matching
+% code happy with identical A and B request
+if (prm.fifo_a_fs == 0) && (prm.fifo_b_fs == 0)
+        fprintf('Error: FIFO A or B need to be assigned a nonzero samplerate\n');
+        return;
+end
+
+cfg.hw_version = hw.version;
+
+cfg.fifo_a_fs = prm.fifo_a_fs;
+cfg.fifo_b_fs = prm.fifo_b_fs;
+
+cfg.pdm01_provided = (prm.pdm(1).enable_mic_a | prm.pdm(1).enable_mic_b) ...
+        + (prm.pdm(2).enable_mic_a | prm.pdm(2).enable_mic_b)*2;
+cfg.ch01_provided = (prm.fifo_a_fs > 0) + (prm.fifo_b_fs > 0)*2;
+
+if prm.fifo_a_fs > 0
+        cfg.a_nchannels = prm.pdm(1).enable_mic_a + prm.pdm(1).enable_mic_b ...
+                + prm.pdm(2).enable_mic_a + prm.pdm(2).enable_mic_b;
+else
+        cfg.a_nchannels = 0;
+end
+if prm.fifo_b_fs > 0
+        cfg.b_nchannels = prm.pdm(1).enable_mic_a + prm.pdm(1).enable_mic_b ...
+                + prm.pdm(2).enable_mic_a + prm.pdm(2).enable_mic_b;
+else
+        cfg.b_nchannels = 0;
+end
+
+end


### PR DESCRIPTION
This patch adds the the Matlab script dmic_init() that simulates
initialization of the Intel PDM digital microphones decimation
block. The tool computes the needed FIR filters and exports
them as C header files. The script dmic_batch computes all the
currently used decimation settings.

The generated header files from subdirectory include need to be
manually copied to src/include/sof/audio/coefficients/pdm_decim/
and the header file pdm_decim_table.h edited manually if the
header file names were changed due to different filter characteristic
(band frequencies, stop-band attenuation).

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>