### PR TITLE
allocator: make aligned allocations precise

### DIFF
--- a/src/include/sof/common.h
+++ b/src/include/sof/common.h
@@ -12,7 +12,7 @@
 /* Align the number to the nearest alignment value */
 #define IS_ALIGNED(size, alignment) ((size) % (alignment) == 0)
 #define ALIGN_UP(size, alignment) \
-	((size) + (((alignment) - ((size) % (alignment))) % (alignment)))
+	((size) + (alignment) - 1 - ((size) + (alignment) - 1) % (alignment))
 #define ALIGN_DOWN(size, alignment) \
 	((size) - ((size) % (alignment)))
 #define ALIGN ALIGN_UP

--- a/src/lib/alloc.c
+++ b/src/lib/alloc.c
@@ -201,18 +201,21 @@ static void *align_ptr(struct mm_heap *heap, uint32_t alignment,
 }
 
 /* allocate single block */
-static void *alloc_block(struct mm_heap *heap, int level,
-			 uint32_t alignment)
+static void *alloc_block_index(struct mm_heap *heap, int level,
+			       uint32_t alignment, int index)
 {
 	struct block_map *map = &heap->map[level];
 	struct block_hdr *hdr;
 	void *ptr;
 	int i;
 
-	hdr = &map->block[map->first_free];
+	if (index < 0)
+		index = map->first_free;
 
 	map->free_count--;
-	ptr = (void *)(map->base + map->first_free * map->block_size);
+
+	hdr = &map->block[index];
+	ptr = (void *)(map->base + index * map->block_size);
 	ptr = align_ptr(heap, alignment, ptr, hdr);
 
 	hdr->size = 1;
@@ -221,21 +224,28 @@ static void *alloc_block(struct mm_heap *heap, int level,
 	heap->info.used += map->block_size;
 	heap->info.free -= map->block_size;
 
-	/* find next free */
-	for (i = map->first_free; i < map->count; ++i) {
-		hdr = &map->block[i];
+	if (index == map->first_free)
+		/* find next free */
+		for (i = map->first_free; i < map->count; ++i) {
+			hdr = &map->block[i];
 
-		if (hdr->used == 0) {
-			map->first_free = i;
-			break;
+			if (hdr->used == 0) {
+				map->first_free = i;
+				break;
+			}
 		}
-	}
 
 	platform_shared_commit(map->block, sizeof(*map->block) * map->count);
 	platform_shared_commit(map, sizeof(*map));
 	platform_shared_commit(heap, sizeof(*heap));
 
 	return ptr;
+}
+
+static void *alloc_block(struct mm_heap *heap, int level,
+			 uint32_t alignment)
+{
+	return alloc_block_index(heap, level, alignment, -1);
 }
 
 /* allocates continuous blocks */
@@ -777,45 +787,79 @@ static void *alloc_heap_buffer(struct mm_heap *heap, uint32_t flags,
 			       uint32_t caps, size_t bytes, uint32_t alignment)
 {
 	struct block_map *map;
-	int i, temp_bytes = bytes;
+	unsigned int i, j, temp_bytes = bytes;
 	void *ptr = NULL;
 
 	/* Only allow alignment as a power of 2 */
 	if ((alignment & (alignment - 1)) != 0)
 		panic(SOF_IPC_PANIC_MEM);
 
+	/*
+	 * There are several cases when a memory allocation request can be
+	 * satisfied with one buffer:
+	 * 1. allocate 30 bytes 256-byte aligned from 32 byte buffers. 1 buffer
+	 * is enough but you have to find a suitable one.
+	 * 2. allocate 20 bytes 256-byte aligned from 0x180 byte buffers. 1
+	 * buffer is always enough.
+	 * 3. allocate 200 bytes 256-byte aligned from 0x180 byte buffers. 1
+	 * buffer is enough, but not every buffer is suitable.
+	 */
+
 	/* will request fit in single block */
-	for (i = 0; i < heap->blocks; i++) {
-		map = &heap->map[i];
+	for (i = 0, map = heap->map; i < heap->blocks; i++, map++) {
+		struct block_hdr *hdr;
+		uintptr_t free_start;
 
-		/* size of requested buffer is adjusted for alignment purposes
-		 * we check if first free block is already aligned if not
-		 * we need to allocate bigger size for alignment
-		 */
-		if ((map->base + (map->block_size * map->first_free))
-		    % alignment)
-			temp_bytes += alignment;
+		if (map->block_size < bytes || !map->free_count)
+			continue;
 
-		/* Check if blocks are big enough and at least one is free */
-		if (map->block_size >= temp_bytes && map->free_count) {
+		if (!alignment) {
 			platform_shared_commit(map, sizeof(*map));
 
 			/* found: grab a block */
 			ptr = alloc_block(heap, i, alignment);
 			break;
 		}
-		temp_bytes = bytes;
 
-		platform_shared_commit(map, sizeof(*map));
+		/*
+		 * Usually block sizes are a power of 2 and all blocks are
+		 * respectively aligned. But it's also possible to have
+		 * non-power of 2 sized blocks, e.g. to optimize for typical
+		 * ALSA allocations a map with 0x180 byte buffers can be used.
+		 * For performance reasons we could first check the power-of-2
+		 * case. This can be added as an optimization later.
+		 */
+		for (j = map->first_free, hdr = map->block + j,
+		     free_start = map->base + map->block_size * j;
+		     j < map->count;
+		     j++, hdr++, free_start += map->block_size) {
+			uintptr_t aligned;
+
+			if (hdr->used)
+				continue;
+
+			aligned = ALIGN(free_start, alignment);
+
+			if (aligned + bytes > free_start + map->block_size)
+				continue;
+
+			/* Found, alloc_block_index() cannot fail */
+			ptr = alloc_block_index(heap, i, alignment, j);
+			temp_bytes += aligned - free_start;
+			break;
+		}
+
+		if (ptr)
+			break;
 	}
-
-	/* size of requested buffer is adjusted for alignment purposes
-	 * since we span more blocks we have to assume worst case scenario
-	 */
-	bytes += alignment;
 
 	/* request spans > 1 block */
 	if (!ptr) {
+		/* size of requested buffer is adjusted for alignment purposes
+		 * since we span more blocks we have to assume worst case scenario
+		 */
+		bytes += alignment;
+
 		/*
 		 * Find the best block size for request. We know, that we failed
 		 * to find a single large enough block, so, skip those.

--- a/src/lib/alloc.c
+++ b/src/lib/alloc.c
@@ -202,7 +202,7 @@ static void *align_ptr(struct mm_heap *heap, uint32_t alignment,
 
 /* allocate single block */
 static void *alloc_block(struct mm_heap *heap, int level,
-			 uint32_t caps, uint32_t alignment)
+			 uint32_t alignment)
 {
 	struct block_map *map = &heap->map[level];
 	struct block_hdr *hdr;
@@ -240,7 +240,7 @@ static void *alloc_block(struct mm_heap *heap, int level,
 
 /* allocates continuous blocks */
 static void *alloc_cont_blocks(struct mm_heap *heap, int level,
-			       uint32_t caps, size_t bytes, uint32_t alignment)
+			       size_t bytes, uint32_t alignment)
 {
 	struct block_map *map = &heap->map[level];
 	struct block_hdr *hdr;
@@ -416,7 +416,7 @@ static void *get_ptr_from_heap(struct mm_heap *heap, uint32_t flags,
 		}
 
 		/* free block space exists */
-		ptr = alloc_block(heap, i, caps, alignment);
+		ptr = alloc_block(heap, i, alignment);
 
 		platform_shared_commit(map, sizeof(*map));
 
@@ -801,7 +801,7 @@ static void *alloc_heap_buffer(struct mm_heap *heap, uint32_t flags,
 			platform_shared_commit(map, sizeof(*map));
 
 			/* found: grab a block */
-			ptr = alloc_block(heap, i, caps, alignment);
+			ptr = alloc_block(heap, i, alignment);
 			break;
 		}
 		temp_bytes = bytes;
@@ -825,7 +825,7 @@ static void *alloc_heap_buffer(struct mm_heap *heap, uint32_t flags,
 
 			/* allocate if block size is smaller than request */
 			if (heap->size >= bytes	&& map->block_size < bytes) {
-				ptr = alloc_cont_blocks(heap, i, caps,
+				ptr = alloc_cont_blocks(heap, i,
 							bytes, alignment);
 				if (ptr) {
 					platform_shared_commit(map,

--- a/src/lib/alloc.c
+++ b/src/lib/alloc.c
@@ -190,17 +190,14 @@ static void *rmalloc_sys(struct mm_heap *heap, uint32_t flags, int caps, size_t 
 static void *align_ptr(struct mm_heap *heap, uint32_t alignment,
 		       void *ptr, struct block_hdr *hdr)
 {
-	int mod_align = 0;
-
 	/* Save unaligned ptr to block hdr */
 	hdr->unaligned_ptr = ptr;
 
 	/* If ptr is not already aligned we calculate alignment shift */
-	if (alignment && (uintptr_t)ptr % alignment)
-		mod_align = alignment - ((uintptr_t)ptr % alignment);
+	if (!alignment)
+		return ptr;
 
-	/* Calculate aligned pointer */
-	return (char *)ptr + mod_align;
+	return (void *)ALIGN((uintptr_t)ptr, alignment);
 }
 
 /* allocate single block */


### PR DESCRIPTION
Currently when the allocator tries to allocate aligned buffers, if it detects, that the current alignment isn't suitable, it adds alignment to the requested size and tries to allocate that. This is too imprecise and counterintuitive. In the very worst theoretical case alignment - 1 bytes might be needed additionally. Also no need to begin grabbing buffers for continuous allocations, which don't contain an address with required alignment. Simplify the alignment macro too to only perform division once.
