### PR TITLE
dai: add fall through markers for clang

### DIFF
--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -692,7 +692,7 @@ static int dai_comp_trigger_internal(struct comp_dev *dev, int cmd)
 		comp_info(dev, "dai_comp_trigger_internal(), XRUN");
 		dd->xrun = 1;
 
-		/* fallthrough */
+		COMPILER_FALLTHROUGH;
 	case COMP_TRIGGER_STOP:
 		comp_dbg(dev, "dai_comp_trigger_internal(), STOP");
 		ret = dma_stop(dd->chan);
@@ -702,6 +702,7 @@ static int dai_comp_trigger_internal(struct comp_dev *dev, int cmd)
 		comp_dbg(dev, "dai_comp_trigger_internal(), PAUSE");
 		ret = dma_pause(dd->chan);
 		dai_trigger(dd->dai, cmd, dev->direction);
+		break;
 	default:
 		break;
 	}

--- a/src/include/sof/compiler_attributes.h
+++ b/src/include/sof/compiler_attributes.h
@@ -17,3 +17,12 @@
 
 #define __section(x) __attribute__((section(x)))
 
+#ifdef __clang__
+
+#define COMPILER_FALLTHROUGH __attribute__((fallthrough))
+
+#else
+
+#define COMPILER_FALLTHROUGH  /* fallthrough */
+
+#endif


### PR DESCRIPTION
for some reason the clang version with oss-fuzz doesn't recognize the
comments so lets add this attributes in the meantime. xtensa-gcc doesn't
seem to mind them.

Signed-off-by: Curtis Malainey <cujomalainey@chromium.org>