### PR TITLE
Tools:tune:src scripts does not execute with Matlab

### DIFF
--- a/tools/test/audio/std_utils/stdnotch_get.m
+++ b/tools/test/audio/std_utils/stdnotch_get.m
@@ -43,7 +43,7 @@ function [b, a] = stdnotch_get(fn, fs)
 
 target_q = 2.1;
 bw = (2*fn/fs)/target_q;
-if exist('iirnotch.m') == 2
+if exist(fullfile('.', 'iirnotch.m'),'file') == 2
         [b, a] = iirnotch(2*fn/fs, bw);
 else
         [b, a] = pei_tseng_notch(2*fn/fs, bw);

--- a/tools/test/audio/test_utils/delete_check.m
+++ b/tools/test/audio/test_utils/delete_check.m
@@ -29,7 +29,7 @@
 %
 
 function delete_check(really, f)
-if really && exist(f) == 2
+if really && exist(fullfile('.', f),'file') == 2
         delete(f);
 end
 end

--- a/tools/test/audio/test_utils/load_test_output.m
+++ b/tools/test/audio/test_utils/load_test_output.m
@@ -31,7 +31,7 @@ switch test.bits_out
 end
 
 %% Check that output file exists
-if exist(test.fn_out)
+if exist(fullfile('.', test.fn_out),'file') == 2
 	fprintf('Reading output data file %s...\n', test.fn_out);
 	switch lower(test.fmt)
 		case 'txt'

--- a/tools/test/audio/test_utils/mkdir_check.m
+++ b/tools/test/audio/test_utils/mkdir_check.m
@@ -29,7 +29,7 @@
 %
 
 function d = mkdir_check(d)
-if exist(d) ~= 7
+if ~exist(fullfile('.', d),'dir')
         mkdir(d);
 end
 end

--- a/tools/test/audio/test_utils/test_run.m
+++ b/tools/test/audio/test_utils/test_run.m
@@ -30,7 +30,7 @@
 
 function test = test_run(test)
 
-if exist(test.ex) == 2
+if exist(fullfile('./', test.ex),'file') == 2
 	%fcmd = sprintf('file %s', test.ex);
 	%[status, output]=system(fcmd);
 	%if findstr(output, "Tensilica Xtensa")

--- a/tools/tune/eq/mls_freq_resp.m
+++ b/tools/tune/eq/mls_freq_resp.m
@@ -273,7 +273,7 @@ function rec = meas_remote_rec_config(fs, fmt)
 	fprintf('Channels         : %d\n', rec.nch);
 	fprintf('Calibration Data : %s\n', rec.cal);
 
-	if length(rec.cal) > 0
+	if ~isempty(rec.cal)
 		if exist(rec.cal, 'file')
 			[rec.cf, rec.cm, rec.sens, rec.cs] = get_calibration(rec.cal);
 		else

--- a/tools/tune/src/src_generate.m
+++ b/tools/tune/src/src_generate.m
@@ -242,7 +242,7 @@ type(fn);
 end
 
 function d = mkdir_check(d)
-if exist(d) ~= 7
+if ~exist(fullfile('.', d),'dir')
         mkdir(d);
 end
 end


### PR DESCRIPTION
Running the  matlab script from 
```
\tool\tune\src\src_std_int32.m
\tool\tune\src\src_tiny_int16.m
\tool\tune\src\src_small_int32.m

```
is showing error in the command window
```
Error message 
Error using fprintf
Invalid file identifier. Use fopen to generate a valid file identifier.
Error in src_generate (line 171)
fprintf(fh,'\n');

Error in src_std_int32 (line 55)
src_generate(fs1, fs2, fs_matrix, cfg);
```

`Line fh = fopen(fn,'w')  - This is not executing , fh is -1`

