### PR TITLE
codec_adepter: fix for memory list initialization

### DIFF
--- a/src/audio/codec_adapter/codec/generic.c
+++ b/src/audio/codec_adapter/codec/generic.c
@@ -119,6 +119,9 @@ int codec_init(struct comp_dev *dev)
 	}
 	/* Assign interface */
 	codec->ops = interface;
+	/* Init memory list */
+	list_init(&codec->memory.mem_list);
+
 	/* Now we can proceed with codec specific initialization */
 	ret = codec->ops->init(dev);
 	if (ret) {
@@ -232,7 +235,6 @@ int codec_prepare(struct comp_dev *dev)
 	codec->s_cfg.avail = false;
 	codec->r_cfg.avail = false;
 	codec->r_cfg.data = NULL;
-	list_init(&codec->memory.mem_list);
 
 	/* After prepare is done we no longer need runtime configuration
 	 * as it has been applied during the procedure - it is safe to


### PR DESCRIPTION
This patch moves memory list initialization from .prepare() to .init()
as we need that memory list be already initialized on codec
initialization otherwise we will lose track of memory allocated
prior to .prepare()

Signed-off-by: Marcin Rajwa <marcin.rajwa@linux.intel.com>