### PR TITLE
SSP bclk refining series

### DIFF
--- a/src/drivers/intel/ssp/mn.c
+++ b/src/drivers/intel/ssp/mn.c
@@ -422,6 +422,35 @@ static inline int setup_initial_bclk_mn_source(uint32_t bclk, uint32_t *scr_div,
 }
 
 /**
+ * \brief Reset M/N source clock for BCLK.
+ *	  If no port is using bclk, reset to use SSP_CLOCK_XTAL_OSCILLATOR
+ *	  as the default clock source.
+ */
+static inline void reset_bclk_mn_source(void)
+{
+	struct mn *mn = mn_get();
+	uint32_t mdivc;
+	int clk_index = find_clk_ssp_index(SSP_CLOCK_XTAL_OSCILLATOR);
+
+	if (clk_index < 0) {
+		tr_err(&mn_tr, "BCLK reset failed, no SSP_CLOCK_XTAL_OSCILLATOR source!");
+		return;
+	}
+
+	mdivc = mn_reg_read(MN_MDIVCTRL, 0);
+
+	/* reset to use XTAL Oscillator */
+	mdivc &= ~MNDSS(MN_SOURCE_CLKS_MASK);
+	mdivc |= MNDSS(SSP_CLOCK_XTAL_OSCILLATOR);
+
+	mn_reg_write(MN_MDIVCTRL, 0, mdivc);
+
+	mn->bclk_source_mn_clock = clk_index;
+
+	platform_shared_commit(mn, sizeof(*mn));
+}
+
+/**
  * \brief Finds valid M/(N * SCR) values for source clock that is already locked
  *	  because other ports use it.
  * \param[in] bclk Bit clock frequency.

--- a/src/drivers/intel/ssp/mn.c
+++ b/src/drivers/intel/ssp/mn.c
@@ -578,10 +578,16 @@ out:
 void mn_release_bclk(uint32_t dai_index)
 {
 	struct mn *mn = mn_get();
+	bool mn_in_use;
 
 	spin_lock(&mn->lock);
 	mn->bclk_sources[dai_index] = MN_BCLK_SOURCE_NONE;
 	platform_shared_commit(mn, sizeof(*mn));
+
+	mn_in_use = is_bclk_source_in_use(MN_BCLK_SOURCE_MN);
+	/* release the M/N clock source if not used */
+	if (!mn_in_use)
+		reset_bclk_mn_source();
 	spin_unlock(&mn->lock);
 }
 

--- a/src/drivers/intel/ssp/mn.c
+++ b/src/drivers/intel/ssp/mn.c
@@ -344,6 +344,22 @@ static int find_bclk_source(uint32_t bclk,
 }
 
 /**
+ * \brief Finds index of SSP clock with the given clock source encoded index.
+ * \return the index in ssp_freq if could find it, -EINVAL otherwise.
+ */
+static int find_clk_ssp_index(uint32_t src_enc)
+{
+	int i;
+
+	/* searching for the encode value matched bclk source */
+	for (i = 0; i <= MAX_SSP_FREQ_INDEX; i++)
+		if (ssp_freq_sources[i] == src_enc)
+			return i;
+
+	return -EINVAL;
+}
+
+/**
  * \brief Checks if given clock is used as source for any BCLK.
  * \param[in] clk_src Bit clock source.
  * \return true if any port use given clock source, false otherwise.

--- a/src/drivers/intel/ssp/ssp.c
+++ b/src/drivers/intel/ssp/ssp.c
@@ -140,7 +140,6 @@ static int ssp_set_config(struct dai *dai,
 	uint32_t ssrsa;
 	uint32_t ssto;
 	uint32_t ssioc;
-	uint32_t mdiv;
 	uint32_t bdiv;
 	uint32_t data_size;
 	uint32_t frame_end_padding;
@@ -157,7 +156,6 @@ static int ssp_set_config(struct dai *dai,
 	bool inverted_frame = false;
 	bool cfs = false;
 	bool start_delay = false;
-	bool need_ecs = false;
 
 	int ret = 0;
 
@@ -331,42 +329,6 @@ static int ssp_set_config(struct dai *dai,
 			config->ssp.mclk_rate, config->ssp.mclk_id);
 		goto out;
 	}
-
-#if CONFIG_INTEL_MN
-	/* BCLK config */
-	ret = mn_set_bclk(config->dai_index, config->ssp.bclk_rate,
-			  &mdiv, &need_ecs);
-	if (ret < 0) {
-		dai_err(dai, "invalid bclk_rate = %d for dai_index = %d",
-			config->ssp.bclk_rate, config->dai_index);
-		goto out;
-	}
-#else
-	if (ssp_freq[SSP_DEFAULT_IDX].freq % config->ssp.bclk_rate != 0) {
-		dai_err(dai, "invalid bclk_rate = %d for dai_index = %d",
-			config->ssp.bclk_rate, config->dai_index);
-		goto out;
-	}
-
-	mdiv = ssp_freq[SSP_DEFAULT_IDX].freq / config->ssp.bclk_rate;
-#endif
-
-	if (need_ecs)
-		sscr0 |= SSCR0_ECS;
-
-	/* clock divisor is SCR + 1 */
-	mdiv -= 1;
-
-	/* divisor must be within SCR range */
-	if (mdiv > (SSCR0_SCR_MASK >> 8)) {
-		dai_err(dai, "ssp_set_config(): divisor %d is not within SCR range",
-			mdiv);
-		ret = -EINVAL;
-		goto out;
-	}
-
-	/* set the SCR divisor */
-	sscr0 |= SSCR0_SCR(mdiv);
 
 	/* calc frame width based on BCLK and rate - must be divisable */
 	if (config->ssp.bclk_rate % config->ssp.fsync_rate) {
@@ -785,6 +747,9 @@ static void ssp_start(struct dai *dai, int direction)
 
 	spin_lock(&dai->lock);
 
+	/* request mclk/bclk */
+	ssp_pre_start(dai);
+
 	/* enable port */
 	ssp_update_bits(dai, SSCR0, SSCR0_SSE, SSCR0_SSE);
 	ssp->state[direction] = COMP_STATE_ACTIVE;
@@ -850,6 +815,8 @@ static void ssp_stop(struct dai *dai, int direction)
 		ssp_update_bits(dai, SSCR0, SSCR0_SSE, 0);
 		dai_info(dai, "ssp_stop(), SSP port disabled");
 	}
+
+	ssp_post_stop(dai);
 
 	spin_unlock(&dai->lock);
 }

--- a/src/drivers/intel/ssp/ssp.c
+++ b/src/drivers/intel/ssp/ssp.c
@@ -659,6 +659,93 @@ out:
 	return ret;
 }
 
+/*
+ * Portion of the SSP configuration should be applied just before the
+ * SSP dai is activated, for either power saving or params runtime
+ * configurable flexibility.
+ */
+static int ssp_pre_start(struct dai *dai)
+{
+	struct ssp_pdata *ssp = dai_get_drvdata(dai);
+	struct sof_ipc_dai_config *config = &ssp->config;
+	uint32_t sscr0;
+	uint32_t mdiv;
+	bool need_ecs = false;
+
+	int ret = 0;
+
+	dai_info(dai, "ssp_pre_start()");
+
+	/* SSP active means bclk already configured. */
+	if (ssp->state[SOF_IPC_STREAM_PLAYBACK] == COMP_STATE_ACTIVE ||
+	    ssp->state[SOF_IPC_STREAM_CAPTURE] == COMP_STATE_ACTIVE)
+		return 0;
+
+	sscr0 = ssp_read(dai, SSCR0);
+
+#if CONFIG_INTEL_MN
+	/* BCLK config */
+	ret = mn_set_bclk(config->dai_index, config->ssp.bclk_rate,
+			  &mdiv, &need_ecs);
+	if (ret < 0) {
+		dai_err(dai, "invalid bclk_rate = %d for dai_index = %d",
+			config->ssp.bclk_rate, config->dai_index);
+		goto out;
+	}
+#else
+	if (ssp_freq[SSP_DEFAULT_IDX].freq % config->ssp.bclk_rate != 0) {
+		dai_err(dai, "invalid bclk_rate = %d for dai_index = %d",
+			config->ssp.bclk_rate, config->dai_index);
+		goto out;
+	}
+
+	mdiv = ssp_freq[SSP_DEFAULT_IDX].freq / config->ssp.bclk_rate;
+#endif
+
+	if (need_ecs)
+		sscr0 |= SSCR0_ECS;
+
+	/* clock divisor is SCR + 1 */
+	mdiv -= 1;
+
+	/* divisor must be within SCR range */
+	if (mdiv > (SSCR0_SCR_MASK >> 8)) {
+		dai_err(dai, "ssp_pre_start(): divisor %d is not within SCR range",
+			mdiv);
+		ret = -EINVAL;
+		goto out;
+	}
+
+	/* set the SCR divisor */
+	sscr0 &= ~SSCR0_SCR_MASK;
+	sscr0 |= SSCR0_SCR(mdiv);
+
+	ssp_write(dai, SSCR0, sscr0);
+
+	dai_info(dai, "ssp_set_config(), sscr0 = 0x%08x", sscr0);
+out:
+	platform_shared_commit(ssp, sizeof(*ssp));
+
+	return ret;
+}
+
+/*
+ * For power saving, we should do kinds of power release when the SSP
+ * dai is changed to inactive, though the runtime param configuration
+ * don't have to be reset.
+ */
+static void ssp_post_stop(struct dai *dai)
+{
+#if CONFIG_INTEL_MN
+	struct ssp_pdata *ssp = dai_get_drvdata(dai);
+
+	/* release bclk if SSP is inactive */
+	if (ssp->state[SOF_IPC_STREAM_PLAYBACK] != COMP_STATE_ACTIVE &&
+	    ssp->state[SOF_IPC_STREAM_CAPTURE] != COMP_STATE_ACTIVE)
+		mn_release_bclk(dai->index);
+#endif
+}
+
 /* get SSP hw params */
 static int ssp_get_hw_params(struct dai *dai,
 			     struct sof_ipc_stream_params  *params, int dir)


### PR DESCRIPTION
This is a small series to refine the SSP bclk request/release sequence,
to reduce the power consumption when SSP is inactive.

To reduce the power consumption, we should request the clock source for
bclk only when SSP is active. This means we need to postpone the clock
request from ssp_set_config() to ssp_start() and release it at
ssp_stop().

Create ssp_pre_start/stop() helpers to do this kind of runtime
configuration, and do the bclk request/release inside them.