### PR TITLE
topology: imx8: Add memory caps for i.MX8 platforms

### DIFF
--- a/tools/topology/platform/imx/imx8qxp.m4
+++ b/tools/topology/platform/imx/imx8qxp.m4
@@ -4,6 +4,12 @@
 
 include(`memory.m4')
 
+dnl Memory capabilities for different buffer types on i.MX8
+define(`PLATFORM_DAI_MEM_CAP', MEMCAPS(MEM_CAP_RAM, MEM_CAP_DMA, MEM_CAP_CACHE))
+define(`PLATFORM_HOST_MEM_CAP', MEMCAPS(MEM_CAP_RAM, MEM_CAP_DMA, MEM_CAP_CACHE))
+define(`PLATFORM_PASS_MEM_CAP', MEMCAPS(MEM_CAP_RAM, MEM_CAP_DMA, MEM_CAP_CACHE))
+define(`PLATFORM_COMP_MEM_CAP', MEMCAPS(MEM_CAP_RAM, MEM_CAP_CACHE))
+
 # Low Latency PCM Configuration
 W_VENDORTUPLES(pipe_ll_schedule_plat_tokens, sof_sched_tokens, LIST(`		', `SOF_TKN_SCHED_MIPS	"50000"'))
 W_DATA(pipe_ll_schedule_plat, pipe_ll_schedule_plat_tokens)


### PR DESCRIPTION
This adds memory capabilities macros for different buffer
types on i.MX8.

Once we started to enable more complex pipelines
on i.MX8 we found out that we need these caps defined.

Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>