### PR TITLE
cavs: clk: correct the WOVCRO attempting logic

### DIFF
--- a/src/platform/intel/cavs/lib/clk.c
+++ b/src/platform/intel/cavs/lib/clk.c
@@ -306,14 +306,14 @@ void platform_clock_init(struct sof *sof)
 #if CAVS_VERSION == CAVS_VERSION_2_5
 	/*
 	 * Check HW version clock capabilities
-	 * Try to request WOV_CRO clock, if it fails use LPRO clock
+	 * Try to request WOV_CRO clock, if it fails fallback to use LPRO clock.
 	 */
-
 	shim_write(SHIM_CLKCTL, shim_read(SHIM_CLKCTL) | SHIM_CLKCTL_WOV_CRO_REQUEST);
-	if (shim_read(SHIM_CLKCTL) & SHIM_CLKCTL_WOV_CRO_REQUEST)
+	idelay(PLATFORM_DEFAULT_DELAY);
+	if (!(shim_read(SHIM_CLKSTS) & SHIM_CLKCTL_WOV_CRO_REQUEST)) {
 		shim_write(SHIM_CLKCTL, shim_read(SHIM_CLKCTL) & ~SHIM_CLKCTL_WOV_CRO_REQUEST);
-	else
 		platform_waiti_clock = CPU_LPRO_FREQ_IDX;
+	}
 #endif
 
 	for (i = 0; i < CONFIG_CORE_COUNT; i++) {


### PR DESCRIPTION
Set CLKCTL_WOV_CRO_REQUEST to request WOVCRO, and fallback to use LPRO
if it is not available, correct the attempting logic here, to address
the random boot fail issue.

Fixes #3633

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>