### PR TITLE
hal: remove unused files

### DIFF
--- a/src/arch/xtensa/hal/CMakeLists.txt
+++ b/src/arch/xtensa/hal/CMakeLists.txt
@@ -133,27 +133,10 @@ target_compile_definitions(hal PRIVATE
 )
 
 add_local_sources(hal
-	attribute.c
-	cache.c
 	cache_asm.S
 	clock.S
-	coherence.c
-	debug.c
-	debug_hndlr.S
-	disass.c
 	int_asm.S
 	interrupts.c
 	memcopy.S
-	mem_ecc_parity.S
-	misc.c
-	miscellaneous.S
-	mmu.c
-	mp_asm.S
-	mpu_asm.S
-	mpu.c
-	set_region_translate.c
-	state_asm.S
-	state.c
-	syscache_asm.S
 	windowspill_asm.S
 )


### PR DESCRIPTION
Prevent unused Xtensa XTOS files from building but keep them in the tree until migration to Zephyr completes. This is a replacement of #3557 which I damaged beyond repair, sorry about that