### PR TITLE
Fix sai params

### DIFF
--- a/src/drivers/imx/sai.c
+++ b/src/drivers/imx/sai.c
@@ -121,8 +121,12 @@ static inline int sai_set_config(struct dai *dai,
 	dai_info(dai, "SAI: sai_set_config");
 	uint32_t val_cr2 = 0, val_cr4 = 0, val_cr5 = 0;
 	uint32_t mask_cr2 = 0, mask_cr4 = 0, mask_cr5 = 0;
+	struct sai_pdata *sai = dai_get_drvdata(dai);
 	/* TODO: this value will be provided by config */
 	uint32_t sywd = 32;
+
+	sai->config = *config;
+	sai->params = config->sai;
 
 	switch (config->format & SOF_DAI_FMT_FORMAT_MASK) {
 	case SOF_DAI_FMT_I2S:
@@ -299,7 +303,17 @@ static int sai_trigger(struct dai *dai, int cmd, int direction)
 
 static int sai_probe(struct dai *dai)
 {
+	struct sai_pdata *sai;
+
 	dai_info(dai, "SAI: sai_probe");
+
+	/* allocate private data */
+	sai = rzalloc(SOF_MEM_ZONE_RUNTIME_SHARED, 0, SOF_MEM_CAPS_RAM, sizeof(*sai));
+	if (!sai) {
+		dai_err(dai, "sai_probe(): alloc failed");
+		return -ENOMEM;
+	}
+	dai_set_drvdata(dai, sai);
 
 	/* Software Reset for both Tx and Rx */
 	dai_update_bits(dai, REG_SAI_TCSR, REG_SAI_CSR_SR, REG_SAI_CSR_SR);

--- a/src/drivers/imx/sai.c
+++ b/src/drivers/imx/sai.c
@@ -361,8 +361,10 @@ static int sai_get_hw_params(struct dai *dai,
 			     struct sof_ipc_stream_params *params,
 			     int dir)
 {
+	struct sai_pdata *sai = dai_get_drvdata(dai);
+
 	/* SAI only currently supports these parameters */
-	params->rate = 48000;
+	params->rate = sai->params.fsync_rate;
 	params->channels = 2;
 	params->buffer_fmt = 0;
 	params->frame_fmt = SOF_IPC_FRAME_S32_LE;

--- a/src/include/ipc/dai-imx.h
+++ b/src/include/ipc/dai-imx.h
@@ -37,8 +37,11 @@ struct sof_ipc_dai_sai_params {
 	/* MCLK */
 	uint16_t reserved1;
 	uint16_t mclk_id;
-	uint32_t mclk_rate; /* MCLK frequency in Hz */
 	uint32_t mclk_direction;
+
+	uint32_t mclk_rate; /* MCLK frequency in Hz */
+	uint32_t fsync_rate;
+	uint32_t bclk_rate;
 
 	/* TDM */
 	uint32_t tdm_slots;

--- a/src/include/sof/drivers/sai.h
+++ b/src/include/sof/drivers/sai.h
@@ -9,6 +9,8 @@
 #ifndef __SOF_DRIVERS_SAI_H__
 #define __SOF_DRIVERS_SAI_H__
 
+#include <ipc/dai.h>
+#include <ipc/dai-imx.h>
 #include <sof/bit.h>
 #include <sof/lib/dai.h>
 #include <sof/trace/trace.h>
@@ -249,4 +251,11 @@
 #define SAI_TDM_SLOTS		2
 
 extern const struct dai_driver sai_driver;
+
+/* SAI private data */
+struct sai_pdata {
+	struct sof_ipc_dai_config config;
+	struct sof_ipc_dai_sai_params params;
+};
+
 #endif /*__SOF_DRIVERS_SAI_H__ */


### PR DESCRIPTION
This patch series helps reading the SAI parmeters from topology. So far we didn't care about this for two reasons:
- SAI is always used in provider mode
- all our pipelines used 48000 constant rate.

This prepares our KWD pipelines. 