### PR TITLE
alloc: fix the general one-buffer memory allocation case

### DIFF
--- a/src/lib/alloc.c
+++ b/src/lib/alloc.c
@@ -827,7 +827,10 @@ static void *alloc_heap_buffer(struct mm_heap *heap, uint32_t flags,
 			       uint32_t caps, size_t bytes, uint32_t alignment)
 {
 	struct block_map *map;
-	unsigned int j, temp_bytes = bytes;
+#if CONFIG_DEBUG_BLOCK_FREE
+	unsigned int temp_bytes = bytes;
+#endif
+	unsigned int j;
 	int i;
 	void *ptr = NULL;
 
@@ -887,7 +890,9 @@ static void *alloc_heap_buffer(struct mm_heap *heap, uint32_t flags,
 
 			/* Found, alloc_block_index() cannot fail */
 			ptr = alloc_block_index(heap, i, alignment, j);
+#if CONFIG_DEBUG_BLOCK_FREE
 			temp_bytes += aligned - free_start;
+#endif
 			break;
 		}
 

--- a/src/lib/alloc.c
+++ b/src/lib/alloc.c
@@ -859,8 +859,6 @@ static void *alloc_heap_buffer(struct mm_heap *heap, uint32_t flags,
 			continue;
 
 		if (alignment <= 1) {
-			platform_shared_commit(map, sizeof(*map));
-
 			/* found: grab a block */
 			ptr = alloc_block(heap, i, caps, alignment);
 			break;


### PR DESCRIPTION
**Note** this has to wait for #3642 to be merged first to then get rebased on top of it.
The condition "size + alignment <= block_size" for allocating memory from a signle buffer is sufficient but not precise enough. For example if we want to allocate 20 bytes with 64-byte alignment, a 32-byte buffer *might* be sufficient if it's suitably aligned. Fix the algorithm to account for such cases.
