### PR TITLE
zephyr: fix a path to a header, build LPS conditionally

### DIFF
--- a/src/platform/intel/cavs/lps_wait.c
+++ b/src/platform/intel/cavs/lps_wait.c
@@ -18,7 +18,8 @@
 #include <stdint.h>
 
 #ifdef __ZEPHYR__
-#include <cavs/memory.h>
+#include <cavs/lib/memory.h>
+#include <platform/lib/memory.h>
 /* TODO: declare local copy to avoid naming collisions with Zephyr and SOF */
 /* headers until common functions can be separated out */
 int memcpy_s(void *dest, size_t dest_size, const void *src, size_t src_size);

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -201,6 +201,9 @@ if (CONFIG_SOC_SERIES_INTEL_CAVS_V18)
 		${SOF_PLATFORM_PATH}/intel/cavs/lib/dai.c
 		${SOF_PLATFORM_PATH}/intel/cavs/lib/dma.c
 		#${SOF_PLATFORM_PATH}/intel/cavs/lps_pic_restore_vector.S
+	)
+
+	zephyr_library_sources_ifdef(CONFIG_CAVS_LPS
 		${SOF_PLATFORM_PATH}/intel/cavs/lps_wait.c
 	)
 
@@ -257,6 +260,9 @@ if (CONFIG_SOC_SERIES_INTEL_CAVS_V20)
 		${SOF_PLATFORM_PATH}/intel/cavs/lib/dai.c
 		${SOF_PLATFORM_PATH}/intel/cavs/lib/dma.c
 		#${SOF_PLATFORM_PATH}/intel/cavs/lps_pic_restore_vector.S
+	)
+
+	zephyr_library_sources_ifdef(CONFIG_CAVS_LPS
 		${SOF_PLATFORM_PATH}/intel/cavs/lps_wait.c
 	)
 
@@ -315,6 +321,9 @@ if (CONFIG_SOC_SERIES_INTEL_CAVS_V25)
 		${SOF_PLATFORM_PATH}/intel/cavs/lib/dai.c
 		${SOF_PLATFORM_PATH}/intel/cavs/lib/dma.c
 		#${SOF_PLATFORM_PATH}/intel/cavs/lps_pic_restore_vector.S
+	)
+
+	zephyr_library_sources_ifdef(CONFIG_CAVS_LPS
 		${SOF_PLATFORM_PATH}/intel/cavs/lps_wait.c
 	)
 


### PR DESCRIPTION
Use a correct path to the cAVS memory.h header, build cAVS LPS only when the respective Kconfig option is selected.
