### PR TITLE
zephyr: fix breakage after a recent logging extention

### DIFF
--- a/zephyr/include/sof/trace/trace.h
+++ b/zephyr/include/sof/trace/trace.h
@@ -30,14 +30,14 @@ uint64_t platform_timer_get(struct timer *timer);
 #undef _log_message
 
 #if USE_PRINTK
-#define _log_message(atomic, level, comp_class, ctx, id1, id2, format, ...)	\
+#define _log_message(log_func, atomic, level, comp_class, ctx, id1, id2, format, ...)	\
 	do {								        \
 		if ((level) <= SOF_ZEPHYR_TRACE_LEVEL)                          \
 			printk("%llu: " format "\n", platform_timer_get(NULL),	\
 				##__VA_ARGS__);					\
 	} while (0)
 #else
-#define _log_message(atomic, level, comp_class, ctx, id1, id2, format, ...)	\
+#define _log_message(log_func, atomic, level, comp_class, ctx, id1, id2, format, ...)	\
 	do {								        \
 		Z_LOG(level, "%u: " format, (uint32_t)platform_timer_get(NULL),	\
 		      ##__VA_ARGS__);					        \


### PR DESCRIPTION
Commit fee7d9c66026 ("trace: Introduce adaptive rate-limiting/suppression of repeated messages") broke Zephyr build. Add the missing parameter.
