### PR TITLE
[RFC] scripts: docker build changes to support enum control

### DIFF
--- a/scripts/docker_build/sof_builder/Dockerfile
+++ b/scripts/docker_build/sof_builder/Dockerfile
@@ -59,8 +59,8 @@ ENV HOME /home/sof
 
 # Use ToT alsa utils for the latest topology patches.
 RUN mkdir -p /home/sof/work/alsa && cd /home/sof/work/alsa && \
-git clone $CLONE_DEFAULTS https://github.com/thesofproject/alsa-lib.git && \
-git clone $CLONE_DEFAULTS https://github.com/thesofproject/alsa-utils.git && \
+git clone $CLONE_DEFAULTS https://github.com/alsa-project/alsa-lib.git && \
+git clone $CLONE_DEFAULTS https://github.com/alsa-project/alsa-utils.git && \
 cd /home/sof/work/alsa/alsa-lib && ./gitcompile &&  make install && \
 cd /home/sof/work/alsa/alsa-utils && ./gitcompile &&  make install &&\
 chown -R sof:sof /home/sof

--- a/scripts/docker_build/sof_builder/docker-build.sh
+++ b/scripts/docker_build/sof_builder/docker-build.sh
@@ -7,4 +7,4 @@ if [ -f "/etc/apt/apt.conf" ]; then
 else
 	touch apt.conf
 fi
-docker build --build-arg UID=$(id -u) --build-arg host_http_proxy=$http_proxy --build-arg host_https_proxy=$https_proxy -t sof .
+docker build --ulimit nofile=65536:65536 --build-arg UID=$(id -u) --build-arg host_http_proxy=$http_proxy --build-arg host_https_proxy=$https_proxy -t sof .


### PR DESCRIPTION
Update docker build description to use alsa-lib and alsa-utils upstream
rather than sofproject versions. Also update ulimit for docker build to
support crosstools-ng.

Signed-off-by: Jaska Uimonen <jaska.uimonen@intel.com>