### PR TITLE
codec_adapter: improvements

### DIFF
--- a/src/audio/codec_adapter/codec/generic.c
+++ b/src/audio/codec_adapter/codec/generic.c
@@ -217,9 +217,6 @@ int codec_prepare(struct comp_dev *dev)
 
 	comp_dbg(dev, "codec_prepare() start");
 
-	/* After reset the codec should remain prepared, hence there
-	 * is no need to re-prepare it again.
-	 */
 	if (cd->codec.state == CODEC_PREPARED)
 		return 0;
 	if (cd->codec.state < CODEC_INITIALIZED)
@@ -328,7 +325,7 @@ int codec_reset(struct comp_dev *dev)
 	/* Codec reset itself to the initial condition after prepare()
 	 * so let's change its state to reflect that.
 	 */
-	codec->state = CODEC_PREPARED;
+	codec->state = CODEC_INITIALIZED;
 
 	return 0;
 }

--- a/src/audio/codec_adapter/codec/generic.c
+++ b/src/audio/codec_adapter/codec/generic.c
@@ -333,7 +333,7 @@ int codec_reset(struct comp_dev *dev)
 	return 0;
 }
 
-static void codec_free_all_memory(struct comp_dev *dev)
+void codec_free_all_memory(struct comp_dev *dev)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 	struct codec_memory *mem;

--- a/src/audio/codec_adapter/codec/generic.c
+++ b/src/audio/codec_adapter/codec/generic.c
@@ -369,8 +369,8 @@ int codec_free(struct comp_dev *dev)
 	codec->r_cfg.size = 0;
 	rfree(codec->r_cfg.data);
 	rfree(codec->s_cfg.data);
-	if (cd->runtime_params)
-		rfree(cd->runtime_params);
+	if (codec->runtime_params)
+		rfree(codec->runtime_params);
 
 	codec->state = CODEC_DISABLED;
 

--- a/src/audio/codec_adapter/codec_adapter.c
+++ b/src/audio/codec_adapter/codec_adapter.c
@@ -225,8 +225,21 @@ static int codec_adapter_prepare(struct comp_dev *dev)
 static int codec_adapter_params(struct comp_dev *dev,
 				    struct sof_ipc_stream_params *params)
 {
-	comp_dbg(dev, "codec_adapter_params(): codec_adapter doesn't support .params() method.");
+	int ret;
+	struct comp_data *cd = comp_get_drvdata(dev);
 
+	ret = comp_verify_params(dev, 0, params);
+	if (ret < 0) {
+		comp_err(dev, "codec_adapter_params(): comp_verify_params() failed.");
+		return ret;
+	}
+
+	ret = memcpy_s(&cd->stream_params, sizeof(struct sof_ipc_stream_params),
+		       params, sizeof(struct sof_ipc_stream_params));
+	assert(!ret);
+
+	cd->period_bytes = params->sample_container_bytes *
+			   params->channels * params->rate / 1000;
 	return 0;
 }
 

--- a/src/audio/codec_adapter/codec_adapter.c
+++ b/src/audio/codec_adapter/codec_adapter.c
@@ -358,6 +358,7 @@ static int codec_adapter_set_params(struct comp_dev *dev, struct sof_ipc_ctrl_da
 	static uint32_t size;
 	uint32_t offset;
 	struct comp_data *cd = comp_get_drvdata(dev);
+	struct codec_data *codec = &cd->codec;
 
 	comp_dbg(dev, "codec_adapter_set_params(): start: num_of_elem %d, elem remain %d msg_index %u",
 		 cdata->num_elems, cdata->elems_remaining, cdata->msg_index);
@@ -366,7 +367,7 @@ static int codec_adapter_set_params(struct comp_dev *dev, struct sof_ipc_ctrl_da
 	if (cdata->msg_index == 0) {
 		size = cdata->num_elems + cdata->elems_remaining;
 		/* Check that there is no work-in-progress on previous request */
-		if (cd->runtime_params) {
+		if (codec->runtime_params) {
 			comp_err(dev, "codec_adapter_set_params() error: busy with previous request");
 			ret = -EBUSY;
 			goto end;
@@ -388,22 +389,22 @@ static int codec_adapter_set_params(struct comp_dev *dev, struct sof_ipc_ctrl_da
 		}
 
 		/* Allocate buffer for new params */
-		cd->runtime_params = rballoc(0, SOF_MEM_CAPS_RAM, size);
-		if (!cd->runtime_params) {
+		codec->runtime_params = rballoc(0, SOF_MEM_CAPS_RAM, size);
+		if (!codec->runtime_params) {
 			comp_err(dev, "codec_adapter_set_params(): space allocation for new params failed");
 			ret = -ENOMEM;
 			goto end;
 		}
 
-		memset(cd->runtime_params, 0, size);
-	} else if (!cd->runtime_params) {
+		memset(codec->runtime_params, 0, size);
+	} else if (!codec->runtime_params) {
 		comp_err(dev, "codec_adapter_set_params() error: no memory available for runtime params in consecutive load");
 		ret = -EIO;
 		goto end;
 	}
 
 	offset = size - (cdata->num_elems + cdata->elems_remaining);
-	dst = (char *)cd->runtime_params + offset;
+	dst = (char *)codec->runtime_params + offset;
 	src = (char *)cdata->data->data;
 
 	ret = memcpy_s(dst, size - offset, src, cdata->num_elems);
@@ -415,7 +416,7 @@ static int codec_adapter_set_params(struct comp_dev *dev, struct sof_ipc_ctrl_da
 	if (!cdata->elems_remaining) {
 		switch (type) {
 		case CODEC_CFG_SETUP:
-			ret = load_setup_config(dev, cd->runtime_params, size);
+			ret = load_setup_config(dev, codec->runtime_params, size);
 			if (ret) {
 				comp_err(dev, "codec_adapter_set_params(): error %d: load of setup config failed.",
 					 ret);
@@ -425,7 +426,7 @@ static int codec_adapter_set_params(struct comp_dev *dev, struct sof_ipc_ctrl_da
 
 			break;
 		case CODEC_CFG_RUNTIME:
-			ret = codec_load_config(dev, cd->runtime_params, size,
+			ret = codec_load_config(dev, codec->runtime_params, size,
 						CODEC_CFG_RUNTIME);
 			if (ret) {
 				comp_err(dev, "codec_adapter_set_params() error %d: load of runtime config failed.",
@@ -458,9 +459,9 @@ static int codec_adapter_set_params(struct comp_dev *dev, struct sof_ipc_ctrl_da
 		}
 	}
 done:
-	if (cd->runtime_params)
-		rfree(cd->runtime_params);
-	cd->runtime_params = NULL;
+	if (codec->runtime_params)
+		rfree(codec->runtime_params);
+	codec->runtime_params = NULL;
 	return ret;
 end:
 	return ret;

--- a/src/audio/codec_adapter/codec_adapter.c
+++ b/src/audio/codec_adapter/codec_adapter.c
@@ -181,7 +181,10 @@ static int codec_adapter_prepare(struct comp_dev *dev)
 	int ret;
 	struct comp_data *cd = comp_get_drvdata(dev);
 	struct codec_data *codec = &cd->codec;
-	uint32_t buff_periods; /* number of deep buffering periods */
+	uint32_t buff_periods = 2; /* default periods of local buffer,
+				    * may change if case of deep buffering
+				    */
+	uint32_t buff_size; /* size of local buffer */
 
 	comp_info(dev, "codec_adapter_prepare() start");
 
@@ -241,8 +244,30 @@ static int codec_adapter_prepare(struct comp_dev *dev)
 		cd->deep_buff_bytes = 0;
 	}
 
-	comp_info(dev, "codec_adapter_prepare() done");
+	/* Allocate local buffer */
+	buff_size = MAX(cd->period_bytes, codec->cpd.in_buff_size) * buff_periods;
+	if (cd->local_buff) {
+		ret = buffer_set_size(cd->local_buff, buff_size);
+		if (ret < 0) {
+			comp_err(dev, "codec_adapter_prepare(): buffer_set_size() failed, buff_size = %u",
+				 buff_size);
+			return ret;
+		}
+	} else {
+		cd->local_buff = buffer_alloc(buff_size, SOF_MEM_CAPS_RAM,
+					      PLATFORM_DCACHE_ALIGN);
+		if (!cd->local_buff) {
+			comp_err(dev, "codec_adapter_prepare(): failed to allocate local buffer");
+			return -ENOMEM;
+		}
+
+		buffer_set_params(cd->local_buff, &cd->stream_params,
+				  BUFFER_UPDATE_FORCE);
+	}
+	buffer_reset_pos(cd->local_buff, NULL);
+
 	cd->state = PP_STATE_PREPARED;
+	comp_info(dev, "codec_adapter_prepare() done");
 
 	return 0;
 }
@@ -593,7 +618,7 @@ static int codec_adapter_reset(struct comp_dev *dev)
 		comp_cl_info(&comp_codec_adapter, "codec_adapter_reset(): error %d, codec reset has failed",
 			     ret);
 	}
-
+	buffer_zero(cd->local_buff);
 	cd->state = PP_STATE_CREATED;
 
 	comp_cl_info(&comp_codec_adapter, "codec_adapter_reset(): done");
@@ -613,6 +638,7 @@ static void codec_adapter_free(struct comp_dev *dev)
 		comp_cl_info(&comp_codec_adapter, "codec_adapter_reset(): error %d, codec reset has failed",
 			     ret);
 	}
+	buffer_free(cd->local_buff);
 	rfree(cd);
 	rfree(dev);
 

--- a/src/include/sof/audio/codec_adapter/codec/generic.h
+++ b/src/include/sof/audio/codec_adapter/codec/generic.h
@@ -167,10 +167,11 @@ struct codec_processing_data {
 struct codec_data {
 	uint32_t id;
 	enum codec_state state;
+	void *private; /**< self object, memory tables etc here */
+	void *runtime_params;
 	struct codec_config s_cfg; /**< setup config */
 	struct codec_config r_cfg; /**< runtime config */
 	struct codec_interface *ops; /**< codec specific operations */
-	void *private; /**< self object, memory tables etc here */
 	struct codec_memory memory; /**< memory allocated by codec */
 	struct codec_processing_data cpd; /**< shared data comp <-> codec */
 };
@@ -182,7 +183,6 @@ struct comp_data {
 	struct codec_data codec; /**< codec private data */
 	struct comp_buffer *ca_sink;
 	struct comp_buffer *ca_source;
-	void *runtime_params;
 	struct sof_ipc_stream_params stream_params;
 	uint32_t period_bytes; /** pipeline period bytes */
 };

--- a/src/include/sof/audio/codec_adapter/codec/generic.h
+++ b/src/include/sof/audio/codec_adapter/codec/generic.h
@@ -185,6 +185,7 @@ struct comp_data {
 	struct comp_buffer *ca_source;
 	struct sof_ipc_stream_params stream_params;
 	uint32_t period_bytes; /** pipeline period bytes */
+	uint32_t deep_buff_bytes; /**< copy start threshold */
 };
 
 /*****************************************************************************/

--- a/src/include/sof/audio/codec_adapter/codec/generic.h
+++ b/src/include/sof/audio/codec_adapter/codec/generic.h
@@ -183,6 +183,8 @@ struct comp_data {
 	struct comp_buffer *ca_sink;
 	struct comp_buffer *ca_source;
 	void *runtime_params;
+	struct sof_ipc_stream_params stream_params;
+	uint32_t period_bytes; /** pipeline period bytes */
 };
 
 /*****************************************************************************/

--- a/src/include/sof/audio/codec_adapter/codec/generic.h
+++ b/src/include/sof/audio/codec_adapter/codec/generic.h
@@ -183,6 +183,7 @@ struct comp_data {
 	struct codec_data codec; /**< codec private data */
 	struct comp_buffer *ca_sink;
 	struct comp_buffer *ca_source;
+	struct comp_buffer *local_buff;
 	struct sof_ipc_stream_params stream_params;
 	uint32_t period_bytes; /** pipeline period bytes */
 	uint32_t deep_buff_bytes; /**< copy start threshold */

--- a/src/include/sof/audio/codec_adapter/codec/generic.h
+++ b/src/include/sof/audio/codec_adapter/codec/generic.h
@@ -198,6 +198,7 @@ int codec_init(struct comp_dev *dev);
 void *codec_allocate_memory(struct comp_dev *dev, uint32_t size,
 			    uint32_t alignment);
 int codec_free_memory(struct comp_dev *dev, void *ptr);
+void codec_free_all_memory(struct comp_dev *dev);
 int codec_prepare(struct comp_dev *dev);
 int codec_process(struct comp_dev *dev);
 int codec_apply_runtime_config(struct comp_dev *dev);

--- a/tools/topology/sof/pipe-processing-playback.m4
+++ b/tools/topology/sof/pipe-processing-playback.m4
@@ -14,6 +14,8 @@ include(`codec_adapter.m4')
 include(`bytecontrol.m4')
 
 ifdef(`PP_CORE',`', `define(`PP_CORE', 1)')
+undefine(`DAI_PERIODS')
+define(`DAI_PERIODS', 8)
 
 #
 # Controls

--- a/tools/topology/sof/pipe-processing-playback.m4
+++ b/tools/topology/sof/pipe-processing-playback.m4
@@ -57,6 +57,15 @@ CONTROLBYTES_PRIV(PP_RUNTIME_PARAMS,
 `	0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00"'
 )
 
+# Post process Bytes control for runtime config
+C_CONTROLBYTES(Post Process Runtime Params, PIPELINE_ID,
+        CONTROLBYTES_OPS(bytes),
+        CONTROLBYTES_EXTOPS(void, 258, 258),
+        , , ,
+        CONTROLBYTES_MAX(void, 157),
+        ,
+        PP_RUNTIME_PARAMS)
+
 #
 # Components and Buffers
 #


### PR DESCRIPTION
This patch sets improves codec_adapter in several ways:
- introduces additional local buffer -  we can store several periods internally in CA before we actually start producing samples out.
- introduces deep buffering - this feature is needed in cases when the codec buffer is different (in terms of size) than the pipeline sink&source buffers. In such cases we need to gather enough samples so after certain periods we will be able to produce output constantly 
- add missing CONRTROL bytes structure for real time parameters in the topology
- increase buffer sizes of all component on CA pipeline
- slight code refactor 