### PR TITLE
topology: sof-smart-amplifier: update speaker amp ssp DAI configuration

### DIFF
--- a/tools/topology/sof-smart-amplifier.m4
+++ b/tools/topology/sof-smart-amplifier.m4
@@ -168,14 +168,14 @@ DAI_ADD(sof/pipe-dai-capture.m4,
 # Buffers use s32le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	SMART_PB_PPL_ID, SSP, SMART_SSP_INDEX, SMART_SSP_NAME,
-	SMART_PIPE_SOURCE, 2, s24le,
+	SMART_PIPE_SOURCE, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is SSP(SSP_INDEX) using 2 periods
 # Buffers use s32le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	SMART_REF_PPL_ID, SSP, SMART_SSP_INDEX, SMART_SSP_NAME,
-	SMART_PIPE_SINK, 2, s24le,
+	SMART_PIPE_SINK, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 ')
 
@@ -225,7 +225,7 @@ DAI_CONFIG(SSP, SMART_SSP_INDEX, SMART_BE_ID, SMART_SSP_NAME,
 		      SSP_CLOCK(bclk, 12288000, codec_slave),
 		      SSP_CLOCK(fsync, 48000, codec_slave),
 		      SSP_TDM(8, 32, 15, 255),
-		      SSP_CONFIG_DATA(SSP, SMART_SSP_INDEX, 24, 0, SMART_SSP_QUIRK)))
+		      SSP_CONFIG_DATA(SSP, SMART_SSP_INDEX, 32, 0, SMART_SSP_QUIRK)))
 ')
 
 DEBUG_END


### PR DESCRIPTION
[TGL] [THD] Speaker amp THD issue

DUT: TGL chrome DUT with Max98373-**I2S**
Kernel: Chrome 5.4
SOF topology: branch-tgl-010-hot-fix-1

Issue:  ODM observed high THD during speaker playback. 

**Fixes for this are spread in:**
a) kernel fix to update tdm/slot_width (https://github.com/thesofproject/linux/pull/2590)
b) topology: update DAI config to s32_le (this PR)
c) Maxim DSM tuning blob - will be submitted to private branch
