### PR TITLE
Tools: Test: Fix Matlab compatibility in process_test.m

### DIFF
--- a/tools/test/audio/process_test.m
+++ b/tools/test/audio/process_test.m
@@ -396,7 +396,8 @@ for i = 1:length(test.ph)
 end
 
 for i = 1:length(test.fh)
-	figure(test.fh(i), 'visible', test.plot_visible);
+	figure(test.fh(i));
+	set(test.fh(i), 'visible', test.plot_visible);
 	pfn = sprintf('plots/%s_%s_%d_%d_%d_%d.png', ...
 		      testacronym, t.comp, ...
 		      t.bits_in, t.bits_out, t.fs, i);


### PR DESCRIPTION
The set of figure property in figure() command is not supported
in Matlab. The separate set() property works for both Octave and
Matlab.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>