### PR TITLE
ipc: Fix page table DMA transfer size

### DIFF
--- a/src/ipc/ipc-host-ptable.c
+++ b/src/ipc/ipc-host-ptable.c
@@ -110,7 +110,7 @@ static int ipc_get_page_descriptors(struct dma *dmac, uint8_t *page_table,
 
 	/* source buffer size is always PAGE_SIZE bytes */
 	/* 20 bits for each page, round up to 32 */
-	elem.size = (ring->pages * 5 * 16 + 31) / 32;
+	elem.size = 4 * ((ring->pages * 20 + 31) / 32);
 	config.elem_array.elems = &elem;
 	config.elem_array.count = 1;
 

--- a/src/ipc/ipc-host-ptable.c
+++ b/src/ipc/ipc-host-ptable.c
@@ -87,6 +87,7 @@ static int ipc_get_page_descriptors(struct dma *dmac, uint8_t *page_table,
 	struct dma_sg_config config;
 	struct dma_sg_elem elem;
 	struct dma_chan_data *chan;
+	uint32_t dma_copy_align;
 	int ret = 0;
 
 	/* get DMA channel from DMAC */
@@ -109,8 +110,14 @@ static int ipc_get_page_descriptors(struct dma *dmac, uint8_t *page_table,
 	elem.src = ring->phy_addr;
 
 	/* source buffer size is always PAGE_SIZE bytes */
-	/* 20 bits for each page, round up to 32 */
-	elem.size = 4 * ((ring->pages * 20 + 31) / 32);
+	/* 20 bits for each page, round up to minimum DMA copy size */
+	ret = dma_get_attribute(dmac, DMA_ATTR_COPY_ALIGNMENT, &dma_copy_align);
+	if (ret < 0) {
+		tr_err(&ipc_tr, "ipc_get_page_descriptors(): dma_get_attribute() failed");
+		goto out;
+	}
+	elem.size = (ring->pages * 20 + 7) / 8;
+	elem.size = ALIGN_UP(elem.size, dma_copy_align);
 	config.elem_array.elems = &elem;
 	config.elem_array.count = 1;
 


### PR DESCRIPTION
This corrects the minimum transfer size calculation for the ptable and uses the relevant DMA attribute.

Fixes #3492, fixes  #3503