### PR TITLE
core: optimise ALIGN_UP() to only use 1 division

### DIFF
--- a/src/include/sof/common.h
+++ b/src/include/sof/common.h
@@ -12,7 +12,7 @@
 /* Align the number to the nearest alignment value */
 #define IS_ALIGNED(size, alignment) ((size) % (alignment) == 0)
 #define ALIGN_UP(size, alignment) \
-	((size) + (((alignment) - ((size) % (alignment))) % (alignment)))
+	((size) + (alignment) - 1 - ((size) + (alignment) - 1) % (alignment))
 #define ALIGN_DOWN(size, alignment) \
 	((size) - ((size) % (alignment)))
 #define ALIGN ALIGN_UP


### PR DESCRIPTION
No need for two divisions for an alignment macro, one is enough.
