### PR TITLE
[RFC] core: assure alignment is only done on power of 2 values

### DIFF
--- a/src/init/ext_manifest.c
+++ b/src/init/ext_manifest.c
@@ -17,8 +17,8 @@
 const struct ext_man_fw_version ext_man_fw_ver
 	__aligned(EXT_MAN_ALIGN) __section(".fw_metadata") = {
 	.hdr.type = EXT_MAN_ELEM_FW_VERSION,
-	.hdr.elem_size = ALIGN_UP(sizeof(struct ext_man_fw_version),
-				  EXT_MAN_ALIGN),
+	.hdr.elem_size = ALIGN_UP_COMPILE(sizeof(struct ext_man_fw_version),
+					  EXT_MAN_ALIGN),
 	.version = {
 		.hdr.size = sizeof(struct sof_ipc_fw_version),
 		.micro = SOF_MICRO,
@@ -40,8 +40,8 @@ const struct ext_man_fw_version ext_man_fw_ver
 const struct ext_man_cc_version ext_man_cc_ver
 	__aligned(EXT_MAN_ALIGN) __section(".fw_metadata") = {
 	.hdr.type = EXT_MAN_ELEM_CC_VERSION,
-	.hdr.elem_size = ALIGN_UP(sizeof(struct ext_man_cc_version),
-				  EXT_MAN_ALIGN),
+	.hdr.elem_size = ALIGN_UP_COMPILE(sizeof(struct ext_man_cc_version),
+					  EXT_MAN_ALIGN),
 	.cc_version = {
 		.ext_hdr.hdr.size = sizeof(struct sof_ipc_cc_version),
 		.ext_hdr.hdr.cmd = SOF_IPC_FW_READY,
@@ -59,8 +59,8 @@ const struct ext_man_cc_version ext_man_cc_ver
 const struct ext_man_probe_support ext_man_probe
 	__aligned(EXT_MAN_ALIGN) __section(".fw_metadata") = {
 	.hdr.type = EXT_MAN_ELEM_PROBE_INFO,
-	.hdr.elem_size = ALIGN_UP(sizeof(struct ext_man_probe_support),
-				  EXT_MAN_ALIGN),
+	.hdr.elem_size = ALIGN_UP_COMPILE(sizeof(struct ext_man_probe_support),
+					  EXT_MAN_ALIGN),
 	.probe = {
 		.ext_hdr.hdr.size = sizeof(struct sof_ipc_probe_support),
 		.ext_hdr.hdr.cmd = SOF_IPC_FW_READY,
@@ -75,8 +75,8 @@ const struct ext_man_probe_support ext_man_probe
 const struct ext_man_dbg_abi ext_man_dbg_info
 	__aligned(EXT_MAN_ALIGN) __section(".fw_metadata") = {
 	.hdr.type = EXT_MAN_ELEM_DBG_ABI,
-	.hdr.elem_size = ALIGN_UP(sizeof(struct ext_man_dbg_abi),
-				  EXT_MAN_ALIGN),
+	.hdr.elem_size = ALIGN_UP_COMPILE(sizeof(struct ext_man_dbg_abi),
+					  EXT_MAN_ALIGN),
 	.dbg_abi = {
 		.ext_hdr.hdr.size = sizeof(struct sof_ipc_user_abi_version),
 		.ext_hdr.hdr.cmd = SOF_IPC_FW_READY,
@@ -91,9 +91,9 @@ const struct ext_man_dbg_abi ext_man_dbg_info
 const struct ext_man_config_data ext_man_config
 	__aligned(EXT_MAN_ALIGN) __section(".fw_metadata") = {
 	.hdr.type = EXT_MAN_ELEM_CONFIG_DATA,
-	.hdr.elem_size = ALIGN_UP(sizeof(struct ext_man_config_data) +
-				  sizeof(struct config_elem) * CONFIG_ELEM_CNT,
-				  EXT_MAN_ALIGN),
+	.hdr.elem_size = ALIGN_UP_COMPILE(sizeof(struct ext_man_config_data) +
+					  sizeof(struct config_elem) * CONFIG_ELEM_CNT,
+					  EXT_MAN_ALIGN),
 	.elems = {
 		{EXT_MAN_CONFIG_IPC_MSG_SIZE, SOF_IPC_MSG_MAX_SIZE},
 		{EXT_MAN_CONFIG_MEMORY_USAGE_SCAN, IS_ENABLED(CONFIG_DEBUG_MEMORY_USAGE_SCAN)},

--- a/src/platform/baytrail/platform.c
+++ b/src/platform/baytrail/platform.c
@@ -83,7 +83,7 @@ const struct ext_man_windows xsram_window
 		__aligned(EXT_MAN_ALIGN) __section(".fw_metadata") __unused = {
 	.hdr = {
 		.type = EXT_MAN_ELEM_WINDOW,
-		.elem_size = ALIGN_UP(sizeof(struct ext_man_windows), EXT_MAN_ALIGN),
+		.elem_size = ALIGN_UP_COMPILE(sizeof(struct ext_man_windows), EXT_MAN_ALIGN),
 	},
 	.window = {
 		.ext_hdr	= {

--- a/src/platform/haswell/platform.c
+++ b/src/platform/haswell/platform.c
@@ -69,7 +69,7 @@ const struct ext_man_windows xsram_window
 		__aligned(EXT_MAN_ALIGN) __section(".fw_metadata") __unused = {
 	.hdr = {
 		.type = EXT_MAN_ELEM_WINDOW,
-		.elem_size = ALIGN_UP(sizeof(struct ext_man_windows), EXT_MAN_ALIGN),
+		.elem_size = ALIGN_UP_COMPILE(sizeof(struct ext_man_windows), EXT_MAN_ALIGN),
 	},
 	.window = {
 		.ext_hdr	= {

--- a/src/platform/imx8/platform.c
+++ b/src/platform/imx8/platform.c
@@ -68,7 +68,7 @@ const struct ext_man_windows xsram_window
 		__aligned(EXT_MAN_ALIGN) __section(".fw_metadata") __unused = {
 	.hdr = {
 		.type = EXT_MAN_ELEM_WINDOW,
-		.elem_size = ALIGN_UP(sizeof(struct ext_man_windows), EXT_MAN_ALIGN),
+		.elem_size = ALIGN_UP_COMPILE(sizeof(struct ext_man_windows), EXT_MAN_ALIGN),
 	},
 	.window = {
 		.ext_hdr	= {

--- a/src/platform/imx8m/platform.c
+++ b/src/platform/imx8m/platform.c
@@ -67,7 +67,7 @@ const struct ext_man_windows xsram_window
 		__aligned(EXT_MAN_ALIGN) __section(".fw_metadata") __unused = {
 	.hdr = {
 		.type = EXT_MAN_ELEM_WINDOW,
-		.elem_size = ALIGN_UP(sizeof(struct ext_man_windows), EXT_MAN_ALIGN),
+		.elem_size = ALIGN_UP_COMPILE(sizeof(struct ext_man_windows), EXT_MAN_ALIGN),
 	},
 	.window = {
 		.ext_hdr	= {

--- a/src/platform/intel/cavs/ext_manifest.c
+++ b/src/platform/intel/cavs/ext_manifest.c
@@ -16,9 +16,9 @@
 const struct ext_man_cavs_config_data ext_man_cavs_config
 	__aligned(EXT_MAN_ALIGN) __section(".fw_metadata") = {
 	.hdr.type = EXT_MAN_ELEM_PLATFORM_CONFIG_DATA,
-	.hdr.elem_size = ALIGN_UP(sizeof(struct ext_man_cavs_config_data) +
-				  sizeof(struct config_elem) * CAVS_CONFIG_ELEM_CNT,
-				  EXT_MAN_ALIGN),
+	.hdr.elem_size = ALIGN_UP_COMPILE(sizeof(struct ext_man_cavs_config_data) +
+					  sizeof(struct config_elem) * CAVS_CONFIG_ELEM_CNT,
+					  EXT_MAN_ALIGN),
 	.elems = {
 		{EXT_MAN_CAVS_CONFIG_LPRO,  IS_ENABLED(CONFIG_CAVS_LPRO_ONLY)},
 		{EXT_MAN_CAVS_CONFIG_OUTBOX_SIZE, SRAM_OUTBOX_SIZE},

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -82,7 +82,7 @@ const struct ext_man_windows xsram_window
 		__aligned(EXT_MAN_ALIGN) __section(".fw_metadata") __unused = {
 	.hdr = {
 		.type = EXT_MAN_ELEM_WINDOW,
-		.elem_size = ALIGN_UP(sizeof(struct ext_man_windows), EXT_MAN_ALIGN),
+		.elem_size = ALIGN_UP_COMPILE(sizeof(struct ext_man_windows), EXT_MAN_ALIGN),
 	},
 	.window = {
 		.ext_hdr	= {


### PR DESCRIPTION
Alignment should always be done on powers of 2. Enforcing this rule also allows the use of binary AND for alignment instead of much slower division. Also add compile-time checks where possible.
