### PR TITLE
mux: fix input and output channel setting

### DIFF
--- a/src/audio/mux/mux_generic.c
+++ b/src/audio/mux/mux_generic.c
@@ -499,8 +499,8 @@ void mux_prepare_look_up_table(struct comp_dev *dev)
 			for (k = 0; k < PLATFORM_MAX_CHANNELS; k++) {
 				if (cd->config.streams[i].mask[j] & BIT(k)) {
 					/* MUX component has only one sink */
-					cd->lookup[0].copy_elem[idx].in_ch = k;
-					cd->lookup[0].copy_elem[idx].out_ch = j;
+					cd->lookup[0].copy_elem[idx].in_ch = j;
+					cd->lookup[0].copy_elem[idx].out_ch = k;
 					cd->lookup[0].copy_elem[idx].stream_id =
 						i;
 					cd->lookup[0].num_elems = ++idx;
@@ -525,8 +525,8 @@ void demux_prepare_look_up_table(struct comp_dev *dev)
 			for (k = 0; k < PLATFORM_MAX_CHANNELS; k++) {
 				if (cd->config.streams[i].mask[j] & BIT(k)) {
 					/* MUX component has only one sink */
-					cd->lookup[i].copy_elem[idx].in_ch = k;
-					cd->lookup[i].copy_elem[idx].out_ch = j;
+					cd->lookup[i].copy_elem[idx].in_ch = j;
+					cd->lookup[i].copy_elem[idx].out_ch = k;
 					cd->lookup[i].copy_elem[idx].stream_id =
 						i;
 					cd->lookup[i].num_elems = ++idx;

--- a/test/cmocka/src/audio/mux/demux_copy.c
+++ b/test/cmocka/src/audio/mux/demux_copy.c
@@ -197,7 +197,7 @@ static void test_demux_copy_proc_16(void **state)
 			int64_t sample = 0;
 
 			for (k = 0; k < PLATFORM_MAX_CHANNELS; ++k)
-				if (td->mask[i][j] & BIT(k))
+				if (td->mask[i][k] & BIT(j))
 					sample = input_16b[k];
 
 			expected_results[i][j] = sample;
@@ -222,7 +222,7 @@ static void test_demux_copy_proc_24(void **state)
 			int32_t sample = 0;
 
 			for (k = 0; k < PLATFORM_MAX_CHANNELS; ++k)
-				if (td->mask[i][j] & BIT(k))
+				if (td->mask[i][k] & BIT(j))
 					sample = input_24b[k];
 
 			expected_results[i][j] = sample;
@@ -247,7 +247,7 @@ static void test_demux_copy_proc_32(void **state)
 			int32_t sample = 0;
 
 			for (k = 0; k < PLATFORM_MAX_CHANNELS; ++k)
-				if (td->mask[i][j] & BIT(k))
+				if (td->mask[i][k] & BIT(j))
 					sample = input_32b[k];
 
 			expected_results[i][j] = sample;

--- a/test/cmocka/src/audio/mux/mux_copy.c
+++ b/test/cmocka/src/audio/mux/mux_copy.c
@@ -219,7 +219,7 @@ static void test_mux_copy_proc_16(void **state)
 
 		for (j = 0; j < MUX_MAX_STREAMS; ++j) {
 			for (k = 0; k < PLATFORM_MAX_CHANNELS; ++k) {
-				if (td->mask[j][i] & BIT(k))
+				if (td->mask[j][k] & BIT(i))
 					sample = input_16b[j][k];
 			}
 		}
@@ -243,7 +243,7 @@ static void test_mux_copy_proc_24(void **state)
 
 		for (j = 0; j < MUX_MAX_STREAMS; ++j) {
 			for (k = 0; k < PLATFORM_MAX_CHANNELS; ++k) {
-				if (td->mask[j][i] & BIT(k))
+				if (td->mask[j][k] & BIT(i))
 					sample = input_24b[j][k];
 			}
 		}
@@ -267,7 +267,7 @@ static void test_mux_copy_proc_32(void **state)
 
 		for (j = 0; j < MUX_MAX_STREAMS; ++j) {
 			for (k = 0; k < PLATFORM_MAX_CHANNELS; ++k) {
-				if (td->mask[j][i] & BIT(k))
+				if (td->mask[j][k] & BIT(i))
 					sample = input_32b[j][k];
 			}
 		}


### PR DESCRIPTION
Input and output channel settings from matrix row and column
are in reverse order, so they should be swapped.

Signed-off-by: Jaska Uimonen <jaska.uimonen@intel.com>