### PR TITLE
Tools: Tune: Add variable initialize to EQ blobs plotter

### DIFF
--- a/tools/tune/eq/eq_blob_plot.m
+++ b/tools/tune/eq/eq_blob_plot.m
@@ -33,6 +33,7 @@ end
 
 if nargin < 4 || isempty(f)
 	eq.f = logspace(log10(10),log10(fs/2), 1000);
+	f_single = [];
 else
 	% Freqz() needs two frequency points or more
 	if length(f) < 2


### PR DESCRIPTION
This fix adds initialization and declaration of variable f_single
to avoid a previously overlooked error when accessing it in the
end of script. It produces the plot but with a warning print.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>