### PR TITLE
topology: fix setting mux uuid in m4

### DIFF
--- a/tools/topology/m4/muxdemux.m4
+++ b/tools/topology/m4/muxdemux.m4
@@ -43,9 +43,7 @@ define(`W_MUXDEMUX',
 `SectionVendorTuples."'N_MUXDEMUX($1)`_tuples_uuid" {'
 `	tokens "sof_comp_tokens"'
 `	tuples."uuid" {'
-ifelse(`$2', `0',
-`		SOF_TKN_COMP_UUID'	STR(mux_uuid),
-`		SOF_TKN_COMP_UUID'	STR(demux_uuid))
+`ifelse(`$2', `0',`		SOF_TKN_COMP_UUID'	STR(mux_uuid),`		SOF_TKN_COMP_UUID'	STR(demux_uuid))'
 `	}'
 `}'
 `SectionData."'N_MUXDEMUX($1)`_data_uuid" {'


### PR DESCRIPTION
Currently the mux/demux uuid setting doesn't work and uuid is always set
to "demux". Fix this by quoting the ifelse in 1 line.

Signed-off-by: Jaska Uimonen <jaska.uimonen@intel.com>