### PR TITLE
Pretend unused slots presence in dictionaries from extended manifest

### DIFF
--- a/src/include/kernel/ext_manifest.h
+++ b/src/include/kernel/ext_manifest.h
@@ -95,7 +95,7 @@ struct ext_man_dbg_abi {
 struct ext_man_config_data {
 	struct ext_man_elem_header hdr;
 
-	struct config_elem elems[EXT_MAN_CONFIG_LAST_ELEM];
+	struct config_elem elems[];
 } __packed;
 
 #endif /* __KERNEL_EXT_MANIFEST_H__ */

--- a/src/init/ext_manifest.c
+++ b/src/init/ext_manifest.c
@@ -85,10 +85,14 @@ const struct ext_man_dbg_abi ext_man_dbg_info
 	},
 };
 
+/* increment this value after adding any element to ext_man_config dictionary */
+#define CONFIG_ELEM_CNT (EXT_MAN_CONFIG_LAST_ELEM - 1)
+
 const struct ext_man_config_data ext_man_config
 	__aligned(EXT_MAN_ALIGN) __section(".fw_metadata") = {
 	.hdr.type = EXT_MAN_ELEM_CONFIG_DATA,
-	.hdr.elem_size = ALIGN_UP(sizeof(struct ext_man_config_data),
+	.hdr.elem_size = ALIGN_UP(sizeof(struct ext_man_config_data) +
+				  sizeof(struct config_elem) * CONFIG_ELEM_CNT,
 				  EXT_MAN_ALIGN),
 	.elems = {
 		{EXT_MAN_CONFIG_IPC_MSG_SIZE, SOF_IPC_MSG_MAX_SIZE},

--- a/src/platform/intel/cavs/ext_manifest.c
+++ b/src/platform/intel/cavs/ext_manifest.c
@@ -10,10 +10,14 @@
 #include <sof/common.h>
 #include <sof/lib/memory.h>
 
+/* Describes elements counter from ext_man_cavs_config dictionary */
+#define CAVS_CONFIG_ELEM_CNT (EXT_MAN_CAVS_CONFIG_LAST_ELEM - 1)
+
 const struct ext_man_cavs_config_data ext_man_cavs_config
 	__aligned(EXT_MAN_ALIGN) __section(".fw_metadata") = {
 	.hdr.type = EXT_MAN_ELEM_PLATFORM_CONFIG_DATA,
-	.hdr.elem_size = ALIGN_UP(sizeof(struct ext_man_cavs_config_data),
+	.hdr.elem_size = ALIGN_UP(sizeof(struct ext_man_cavs_config_data) +
+				  sizeof(struct config_elem) * CAVS_CONFIG_ELEM_CNT,
 				  EXT_MAN_ALIGN),
 	.elems = {
 		{EXT_MAN_CAVS_CONFIG_LPRO,  IS_ENABLED(CONFIG_CAVS_LPRO_ONLY)},

--- a/src/platform/intel/cavs/ext_manifest.c
+++ b/src/platform/intel/cavs/ext_manifest.c
@@ -16,9 +16,7 @@ const struct ext_man_cavs_config_data ext_man_cavs_config
 	.hdr.elem_size = ALIGN_UP(sizeof(struct ext_man_cavs_config_data),
 				  EXT_MAN_ALIGN),
 	.elems = {
-#if CONFIG_CAVS_LPRO_ONLY
-		{EXT_MAN_CAVS_CONFIG_LPRO,  CONFIG_CAVS_LPRO_ONLY},
-#endif
+		{EXT_MAN_CAVS_CONFIG_LPRO,  IS_ENABLED(CONFIG_CAVS_LPRO_ONLY)},
 		{EXT_MAN_CAVS_CONFIG_OUTBOX_SIZE, SRAM_OUTBOX_SIZE},
 		{EXT_MAN_CAVS_CONFIG_INBOX_SIZE, SRAM_INBOX_SIZE},
 	},

--- a/src/platform/intel/cavs/include/cavs/ext_manifest.h
+++ b/src/platform/intel/cavs/include/cavs/ext_manifest.h
@@ -22,7 +22,7 @@ enum cavs_config_elem_type {
 struct ext_man_cavs_config_data {
 	struct ext_man_elem_header hdr;
 
-	struct config_elem elems[EXT_MAN_CAVS_CONFIG_LAST_ELEM];
+	struct config_elem elems[];
 } __packed;
 
 #endif /* __KERNEL_EXT_MANIFEST_H__ */


### PR DESCRIPTION


Solution extracted from discussion from https://github.com/thesofproject/sof/pull/3527