### PR TITLE
codec_adapter: fix premature free of memory

### DIFF
--- a/src/audio/codec_adapter/codec_adapter.c
+++ b/src/audio/codec_adapter/codec_adapter.c
@@ -430,7 +430,6 @@ static int codec_adapter_set_params(struct comp_dev *dev, struct sof_ipc_ctrl_da
 				if (ret) {
 					comp_err(dev, "codec_adapter_set_params() error %x: codec runtime config apply failed",
 						 ret);
-					goto done;
 				}  else {
 					comp_dbg(dev, "codec_adapter_set_params() apply of runtime config done.");
 				}
@@ -443,7 +442,9 @@ static int codec_adapter_set_params(struct comp_dev *dev, struct sof_ipc_ctrl_da
 			comp_err(dev, "codec_adapter_set_params(): error: unknown config type.");
 			break;
 		}
-	}
+	} else
+		goto end;
+
 done:
 	if (cd->runtime_params)
 		rfree(cd->runtime_params);


### PR DESCRIPTION
This patch fixes the issue with premature free of runtime
parameters memory. Such situation occurs when runtime
params are send in few parts, then after the first packet
has been copied the memory is freed so the consecutive one
no longer has a copy destination.

Signed-off-by: Marcin Rajwa <marcin.rajwa@linux.intel.com>