### PR TITLE
schedule: dma_multi_chan: fix null pointer when scanning for tasks

### DIFF
--- a/src/schedule/dma_multi_chan_domain.c
+++ b/src/schedule/dma_multi_chan_domain.c
@@ -293,7 +293,8 @@ static bool dma_multi_chan_domain_is_pending(struct ll_schedule_domain *domain,
 					continue;
 
 				*comp = dma_domain->data[i][j].task->sched_comp;
-			} else if (dma_domain->data[i][j].task->sched_comp != *comp) {
+			} else if (!dma_domain->data[i][j].task ||
+				   dma_domain->data[i][j].task->sched_comp != *comp) {
 				continue;
 			}
 


### PR DESCRIPTION
When scanning all channels for a certain task we end up comparing
with a null task.
That's because we have multiple channels (e.g. 32 for i.MX) but only
some of them are used in certain scenarios. For example, for simultaneous
playback/capture we use only 2 DMA channels.
To fix this, validate task before using it.

Fixes #3690
Fixes: 647390f75 ("schedule: dma_multi_chan: fix a DMA channel interrupt race")

Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>
Signed-off-by: Iuliana Prodan <iuliana.prodan@nxp.com>