### PR TITLE
topology: Add sof-cht-nau8824 topology file

### DIFF
--- a/tools/topology/CMakeLists.txt
+++ b/tools/topology/CMakeLists.txt
@@ -63,6 +63,7 @@ set(TPLGS
 	"sof-byt-codec\;sof-cht-da7213\;-DCODEC=DA7213\;-DPLATFORM=cht-codec\;-DSSP_NUM=2"
 	"sof-byt-codec\;sof-cht-cx2072x\;-DCODEC=CX2072X\;-DPLATFORM=cht-codec\;-DSSP_NUM=2"
 	"sof-byt-codec\;sof-cht-es8316\;-DCODEC=ES8316\;-DPLATFORM=cht-codec\;-DSSP_NUM=2"
+	"sof-byt-codec\;sof-cht-nau8824\;-DCODEC=NAU8824\;-DPLATFORM=cht-codec\;-DSSP_NUM=2"
 	"sof-cht-max98090\;sof-cht-max98090\;-DCODEC=MAX98090\;-DPLATFORM=cht-codec\;-DSSP_NUM=2"
 	"sof-cnl-rt274\;sof-cnl-rt274"
 	"sof-apl-tdf8532\;sof-apl-tdf8532"


### PR DESCRIPTION
Add a topology file for Cherry Trail boards with a NAU8824 codec.
These setups work with the standard settings from sof-byt-codec.m4.

This has been tested on the following devices:

Medion E2215T:   stereo speakers, analog mic
Medion E2228T:   stereo speakers, stereo digital mics
Cube iWork8 Air: mono speaker, analog mic

Signed-off-by: Hans de Goede <hdegoede@redhat.com>