### PR TITLE
Tools: Topology: Change volume demux playback ramp length to 20 ms

### DIFF
--- a/tools/topology/sof/pipe-volume-demux-playback.m4
+++ b/tools/topology/sof/pipe-volume-demux-playback.m4
@@ -43,11 +43,14 @@ C_CONTROLMIXER(Master Playback Volume, PIPELINE_ID,
 # Volume configuration
 #
 
-W_VENDORTUPLES(playback_pga_tokens, sof_volume_tokens,
-LIST(`		', `SOF_TKN_VOLUME_RAMP_STEP_TYPE	"0"'
-     `		', `SOF_TKN_VOLUME_RAMP_STEP_MS		"250"'))
+define(DEF_PGA_TOKENS, concat(`pga_tokens_', PIPELINE_ID))
+define(DEF_PGA_CONF, concat(`pga_conf_', PIPELINE_ID))
 
-W_DATA(playback_pga_conf, playback_pga_tokens)
+W_VENDORTUPLES(DEF_PGA_TOKENS, sof_volume_tokens,
+LIST(`		', `SOF_TKN_VOLUME_RAMP_STEP_TYPE	"2"'
+     `		', `SOF_TKN_VOLUME_RAMP_STEP_MS		"20"'))
+
+W_DATA(DEF_PGA_CONF, DEF_PGA_TOKENS)
 
 #
 # Components and Buffers
@@ -58,7 +61,7 @@ W_DATA(playback_pga_conf, playback_pga_tokens)
 W_PCM_PLAYBACK(PCM_ID, Low Latency Playback, 2, 0, SCHEDULE_CORE)
 
 # "Master Playback Volume" has 2 source and x sink periods for DAI ping-pong
-W_PGA(1, PIPELINE_FORMAT, DAI_PERIODS, 2, playback_pga_conf, SCHEDULE_CORE,
+W_PGA(1, PIPELINE_FORMAT, DAI_PERIODS, 2, DEF_PGA_CONF, SCHEDULE_CORE,
 	LIST(`		', "PIPELINE_ID Master Playback Volume"))
 
 # Mux 0 has 2 sink and source periods.
@@ -103,3 +106,5 @@ indir(`define', concat(`PIPELINE_PCM_', PIPELINE_ID), Low Latency Playback PCM_I
 # PCM capabilities supported by FW
 PCM_CAPABILITIES(Low Latency Playback PCM_ID, CAPABILITY_FORMAT_NAME(PIPELINE_FORMAT), 48000, 48000, 2, PIPELINE_CHANNELS, 2, 16, 192, 16384, 65536, 65536)
 
+undefine(`DEF_PGA_TOKENS')
+undefine(`DEF_PGA_CONF')


### PR DESCRIPTION
The earlier length 250 ms is quite long and makes very short UI
tones etc. quite silent. The 20 ms long ramp with zero crossings
detect is used in rest of this topology for playback so this is
changed to similar.

The topologies those use the changed macro are: sof-icl-rt711-rt1308-rt715-hdmi.m4, sof-apl-demux-pcm512x.m4, sof-tgl-max98357a-rt5682.m4, sof-cml-demux-rt5682.m4, and sof-tgl-nocodec-ci.m4.

Fixes: #3707

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>