### PR TITLE
smart_amp_maxim_dsm: log warning for zero frame copy

### DIFF
--- a/src/audio/smart_amp/smart_amp_maxim_dsm.c
+++ b/src/audio/smart_amp/smart_amp_maxim_dsm.c
@@ -689,7 +689,7 @@ int smart_amp_ff_copy(struct comp_dev *dev, uint32_t frames,
 	int ret;
 
 	if (frames == 0) {
-		comp_dbg(dev, "[DSM] feed forward frame size zero warning.");
+		comp_warn(dev, "[DSM] feed forward frame size zero warning.");
 		return 0;
 	}
 
@@ -749,7 +749,7 @@ int smart_amp_fb_copy(struct comp_dev *dev, uint32_t frames,
 	int ret;
 
 	if (frames == 0) {
-		comp_dbg(dev, "[DSM] feedback frame size zero warning.");
+		comp_warn(dev, "[DSM] feedback frame size zero warning.");
 		return 0;
 	}
 


### PR DESCRIPTION
Change to comp_warn() when zero fram is copied, which really requires
attention on.

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>