### PR TITLE
tools: Add cmake toolchain file for cross compilation on arm64

### DIFF
--- a/tools/scripts/cross-arch64.cmake
+++ b/tools/scripts/cross-arch64.cmake
@@ -1,0 +1,23 @@
+#
+# CMake Toolchain file for crosscompiling on arm64
+#
+# This can be used when running cmake in the following way:
+#  cd build/
+#  cmake .. -DCMAKE_TOOLCHAIN_FILE=../scripts/cross-arch64.cmake
+#
+
+# Target operating system name.
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR aarch64)
+
+# Name of C compiler.
+set(CMAKE_C_COMPILER "aarch64-linux-gnu-gcc")
+set(CMAKE_CXX_COMPILER "aarch64-linux-gnu-g++")
+
+# Adjust the default behavior of the FIND_XXX() commands:
+# search programs in the host environment only.
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+
+# Search headers and libraries in the target environment only.
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)


### PR DESCRIPTION
We need this to cross-compile sof-logger for arm64.

Steps:
	* download and install cross-compiler
	* (e.g on Ubuntu: sudo apt-get install gcc-aarch64-linux-gnu)
	* mkdir tools/build/
	* cd tools/build/
	* cmake .. -DCMAKE_TOOLCHAIN_FILE=../scripts//cross-arch64.cmake
	* make sof-logger

Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>