### PR TITLE
codec: Add dummy codec implementation

### DIFF
--- a/src/audio/Kconfig
+++ b/src/audio/Kconfig
@@ -336,6 +336,14 @@ config CADENCE_CODEC
 		Select for codecs which conforms to the Cadence API.
 		This will cause codec adapter component to include header
 		files specific to CADENCE base codecs.
+
+config DUMMY_CODEC
+	bool "Dummy codec"
+	default n
+	help
+	  Select for a dummy API codec implementation.
+	  This will cause codec adapter component to include header
+	  files specific to DUMMY base codecs.
 endif
 endmenu # "Audio components"
 

--- a/src/audio/codec_adapter/CMakeLists.txt
+++ b/src/audio/codec_adapter/CMakeLists.txt
@@ -4,3 +4,7 @@ add_local_sources(sof codec_adapter.c codec/generic.c)
 if(CONFIG_CADENCE_CODEC)
 add_local_sources(sof codec/cadence.c)
 endif()
+
+if(CONFIG_DUMMY_CODEC)
+add_local_sources(sof codec/dummy.c)
+endif()

--- a/src/audio/codec_adapter/codec/dummy.c
+++ b/src/audio/codec_adapter/codec/dummy.c
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright 2020 NXP
+//
+// Author: Daniel Baluta <daniel.baluta@nxp.com>
+//
+// Dummy codec implementation to demonstrate Codec Adapter API
+
+#include <sof/audio/codec_adapter/codec/generic.h>
+#include <sof/audio/codec_adapter/codec/dummy.h>
+
+int dummy_codec_init(struct comp_dev *dev)
+{
+	comp_info(dev, "dummy_codec_init() start");
+	return 0;
+}
+
+int dummy_codec_prepare(struct comp_dev *dev)
+{
+	struct codec_data *codec = comp_get_codec(dev);
+	struct comp_data *cd = comp_get_drvdata(dev);
+
+	comp_info(dev, "dummy_codec_process()");
+
+	codec->cpd.in_buff = rballoc(0, SOF_MEM_CAPS_RAM, cd->period_bytes);
+	if (!codec->cpd.in_buff) {
+		comp_err(dev, "dummy_codec_prepare(): Failed to alloc in_buff");
+		return -ENOMEM;
+	}
+	codec->cpd.in_buff_size = cd->period_bytes;
+
+	codec->cpd.out_buff = rballoc(0, SOF_MEM_CAPS_RAM, cd->period_bytes);
+	if (!codec->cpd.out_buff) {
+		comp_err(dev, "dummy_codec_prepare(): Failed to alloc out_buff");
+		rfree(codec->cpd.in_buff);
+		return -ENOMEM;
+	}
+	codec->cpd.out_buff_size = cd->period_bytes;
+
+	return 0;
+}
+
+int dummy_codec_process(struct comp_dev *dev)
+{
+	struct codec_data *codec = comp_get_codec(dev);
+	struct comp_data *cd = comp_get_drvdata(dev);
+
+	comp_dbg(dev, "dummy_codec_process()");
+
+	memcpy_s(codec->cpd.out_buff, codec->cpd.out_buff_size,
+		 codec->cpd.in_buff, codec->cpd.in_buff_size);
+	codec->cpd.produced = cd->period_bytes;
+
+	return 0;
+}
+
+int dummy_codec_apply_config(struct comp_dev *dev)
+{
+	comp_info(dev, "dummy_codec_apply_config()");
+
+	/* nothing to do */
+	return 0;
+}
+
+int dummy_codec_reset(struct comp_dev *dev)
+{
+	comp_info(dev, "dummy_codec_reset()");
+
+	/* nothing to do */
+	return 0;
+}
+
+int dummy_codec_free(struct comp_dev *dev)
+{
+	struct codec_data *codec = comp_get_codec(dev);
+
+	comp_info(dev, "dummy_codec_free()");
+
+	rfree(codec->cpd.in_buff);
+	rfree(codec->cpd.out_buff);
+
+	return 0;
+}

--- a/src/include/sof/audio/codec_adapter/codec/dummy.h
+++ b/src/include/sof/audio/codec_adapter/codec/dummy.h
@@ -1,0 +1,18 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright 2020 NXP
+ *
+ * Author: Daniel Baluta <daniel.baluta@nxp.com>
+ */
+
+#ifndef __SOF_AUDIO_DUMMY_CODEC__
+#define __SOF_AUDIO_DUMMY_CODEC__
+
+int dummy_codec_init(struct comp_dev *dev);
+int dummy_codec_prepare(struct comp_dev *dev);
+int dummy_codec_process(struct comp_dev *dev);
+int dummy_codec_apply_config(struct comp_dev *dev);
+int dummy_codec_reset(struct comp_dev *dev);
+int dummy_codec_free(struct comp_dev *dev);
+
+#endif /* __SOF_AUDIO_DUMMY_CODEC__ */

--- a/src/include/sof/audio/codec_adapter/interfaces.h
+++ b/src/include/sof/audio/codec_adapter/interfaces.h
@@ -15,7 +15,12 @@
 #include <sof/audio/codec_adapter/codec/cadence.h>
 #endif /* CONFIG_CADENCE_CODEC */
 
+#if CONFIG_DUMMY_CODEC
+#include <sof/audio/codec_adapter/codec/dummy.h>
+#endif
+
 #define CADENCE_ID 0xCADE01
+#define DUMMY_ID   0xD03311
 
 /*****************************************************************************/
 /* Linked codecs interfaces						     */
@@ -32,6 +37,18 @@ static struct codec_interface interfaces[] = {
 		.free = cadence_codec_free
 	},
 #endif /* CONFIG_CADENCE_CODEC */
+
+#ifdef CONFIG_DUMMY_CODEC
+	{
+		.id = DUMMY_ID, /** dummy interface */
+		.init  = dummy_codec_init,
+		.prepare = dummy_codec_prepare,
+		.process = dummy_codec_process,
+		.apply_config = dummy_codec_apply_config,
+		.reset = dummy_codec_reset,
+		.free = dummy_codec_free
+	},
+#endif /* CONFIG_DUMMY_CODEC */
 };
 
 #endif /* __SOF_AUDIO_CODEC_INTERFACES__ */


### PR DESCRIPTION
This is useful to test codec adapter component and generic codec code.

Also, this is useful for testing compress API patches without the need to compile in the Cadence proprietary binaries.