### PR TITLE
zephyr: add a cache variable with a rimage configuration path

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -51,6 +51,12 @@ set(SOF_DEBUG_PATH "${SOF_SRC_PATH}/debug")
 set(SOF_MATH_PATH "${SOF_SRC_PATH}/math")
 set(SOF_TRACE_PATH "${SOF_SRC_PATH}/trace")
 
+# Save path to rimage configuration files in cmake cache for later use by
+# rimage during the "west sign" stage
+get_filename_component(RIMAGE_CONFIG "../rimage/config" ABSOLUTE)
+set(RIMAGE_CONFIG_PATH ${RIMAGE_CONFIG} CACHE PATH
+    " Path to rimage board configuration files")
+
 # default SOF includes
 target_include_directories(SOF INTERFACE ../rimage/src/include)
 target_include_directories(SOF INTERFACE ../zephyr/include)


### PR DESCRIPTION
zephyr needs a path to rimage configuration files, add it to cmake cache. As suggested by @mbolivar-nordic in https://github.com/zephyrproject-rtos/zephyr/pull/31127#discussion_r552916260