### PR TITLE
Codec adapter fixups

### DIFF
--- a/src/include/sof/audio/codec_adapter/codec/generic.h
+++ b/src/include/sof/audio/codec_adapter/codec/generic.h
@@ -57,7 +57,8 @@ struct codec_interface {
 	int (*process)(struct comp_dev *dev);
 	/**
 	 * Codec specific apply config procedure, called by codec_adapter every time
-	 * new configuration has been loaded.
+	 * a new RUNTIME configuration has been sent if the adapter has been
+	 * prepared. This will not be called for SETUP cfg.
 	 */
 	int (*apply_config)(struct comp_dev *dev);
 	/**


### PR DESCRIPTION
For the documentation fix I personally don't agree with the design but the documentation needs to match the code. **Begin rant** I think the adapter should **never** reject a config push to a valid adapter. This makes it hard for things like audio servers to push config's on boot as its past init so too late for setup but too early for runtime. The library should be allowed to make the choice when it wants to use the config but it should always be notified of when it is loaded. Also I don't think we should be limiting the types, why not make the id generic and let the adapter decide what types of configs it wants and pass that as an argument in the callback? Right now the cadence adapter uses the same function for both setup and runtime config which suggests that we should be something similar to the command workflow in components rather than creating a diamond code path unnecessarily. **end rant**

I am hesitant to change this API as I know it needs to be stable but these issues worry me as they appear to already be causing confusion. I am happy to fork this into a issue and continue this discussion if need be there.