### PR TITLE
zephyr: update for unsupported arch builds

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -348,6 +348,12 @@ if (CONFIG_SOC_SERIES_NXP_IMX8)
 	)
 endif()
 
+zephyr_library_sources_ifdef(CONFIG_LIBRARY
+	${SOF_PLATFORM_PATH}/library/platform.c
+	${SOF_PLATFORM_PATH}/library/lib/dai.c
+	${SOF_DRIVERS_PATH}/host/ipc.c
+)
+
 zephyr_include_directories(${SOF_PLATFORM_PATH}/${PLATFORM}/include)
 
 # Mandatory Files used on all platforms.

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -535,11 +535,6 @@ struct idc **idc_get(void)
 /* Dummies for unsupported architectures */
 
 /* Platform */
-int platform_init(struct sof *sof)
-{
-	return 0;
-}
-
 int platform_boot_complete(uint32_t boot_message)
 {
 	return 0;


### PR DESCRIPTION
Add some files from src/platform/library/ to generic arch builds with Zephyr.