### PR TITLE
[RFC] align: make power-of-2 alignment verification a debug option

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -228,6 +228,13 @@ config DEBUG_IPC_COUNTERS
 	help
 	  Select for enabling tracing IPC counter in SRAM_REG mailbox
 
+config DEBUG_ALIGNMENT
+	bool "Power of 2 alignment"
+	default n
+	help
+	  Select to enable compile- and run-time power-of-2 alignment checks
+	  in macros ALIGN(), ALIGN_UP() etc.
+
 config PERFORMANCE_COUNTERS
 	bool "Performance counters"
 	default n

--- a/src/include/sof/common.h
+++ b/src/include/sof/common.h
@@ -21,8 +21,7 @@
 
 #define ALIGN_UP_INTERNAL(val, align) (((val) + (align) - 1) & ~((align) - 1))
 
-#define VERIFY_ALIGN
-#ifdef VERIFY_ALIGN
+#if CONFIG_DEBUG_ALIGNMENT
 
 /* For data initializers etc. */
 #define ALIGN_UP_COMPILE(size, alignment)					\


### PR DESCRIPTION
Power-of-2 verification is needed during an initial testing phase. It adds a slight run-time overhead. After the initial testing period is over it can be converted to a debug option, disabled by default.
@lgirdwood this **should not be merged immediately**, but we probably want it before the next release?