### PR TITLE
sof: drc: fix drc_sin_fixed function

### DIFF
--- a/src/audio/drc/drc_math_generic.c
+++ b/src/audio/drc/drc_math_generic.c
@@ -112,7 +112,9 @@ inline int32_t drc_sin_fixed(int32_t x)
 {
 	const int32_t PI_OVER_TWO = Q_CONVERT_FLOAT(1.57079632679489661923f, 30);
 
-	return sin_fixed(q_mult(x, PI_OVER_TWO, 30, 30, 28));
+	/* input range of sin_fixed() is non-negative */
+	int32_t abs_sin_val = sin_fixed(q_mult(ABS(x), PI_OVER_TWO, 30, 30, 28));
+	return SGN(x) < 0 ? -abs_sin_val : abs_sin_val;
 }
 
 /*


### PR DESCRIPTION
drc_sin_fixed() utilized sin_fixed() while its input range is
non-negative. This commit fixes drc_siz_fixed() for negative input by
using ABS(input) to sin_fixed() and then inverting the output sign.