### PR TITLE
codec_adapter: Used nested Kconfig of codec adapter codecs

### DIFF
--- a/src/audio/Kconfig
+++ b/src/audio/Kconfig
@@ -328,23 +328,8 @@ config COMP_CODEC_ADAPTER
 	  "src\include\sof\audio\codec_adapter\interfaces.h". It is possible to link several
 	  different codecs and use them in parallel.
 
-if COMP_CODEC_ADAPTER
-config CADENCE_CODEC
-	bool "Cadence codec"
-	default n
-	help
-		Select for codecs which conforms to the Cadence API.
-		This will cause codec adapter component to include header
-		files specific to CADENCE base codecs.
+rsource "codec_adapter/Kconfig"
 
-config DUMMY_CODEC
-	bool "Dummy codec"
-	default n
-	help
-	  Select for a dummy API codec implementation.
-	  This will cause codec adapter component to include header
-	  files specific to DUMMY base codecs.
-endif
 endmenu # "Audio components"
 
 menu "Data formats"

--- a/src/audio/codec_adapter/Kconfig
+++ b/src/audio/codec_adapter/Kconfig
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+menu "Codec Adapter codecs"
+	visible if COMP_CODEC_ADAPTER
+
+	config CADENCE_CODEC
+		bool "Cadence codec"
+		default n
+		help
+		  Select for codecs which conforms to the Cadence API.
+		  This will cause codec adapter component to include header
+		  files specific to CADENCE base codecs.
+
+	config DUMMY_CODEC
+		bool "Dummy codec"
+		default n
+		help
+		  Select for a dummy API codec implementation.
+		  This will cause codec adapter component to include header
+		  files specific to DUMMY base codecs.
+endmenu


### PR DESCRIPTION
The codec config of codec adapter should be placed under
src/audio/codec_adapter since we may have more and more codecs in the
future.

Any thought?