### PR TITLE
dmic: stop dmic at xrun to avoid interrupt flooding

### DIFF
--- a/src/drivers/intel/dmic.c
+++ b/src/drivers/intel/dmic.c
@@ -1536,11 +1536,13 @@ static void dmic_irq_handler(void *data)
 	if (val0 & OUTSTAT0_ROR_BIT) {
 		dai_err(dai, "dmic_irq_handler(): full fifo A or PDM overrun");
 		dai_write(dai, OUTSTAT0, val0);
+		dmic_stop(dai);
 	}
 
 	if (val1 & OUTSTAT1_ROR_BIT) {
 		dai_err(dai, "dmic_irq_handler(): full fifo B or PDM overrun");
 		dai_write(dai, OUTSTAT1, val1);
+		dmic_stop(dai);
 	}
 }
 


### PR DESCRIPTION
Once an Xrun happens, only clearing the interrupt can't recover it, stop
the dmic to avoid interrupt flooding.

This will lead to subsequent pipeline Xrun and eventually the pipeline
will be stopped.

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>