### PR TITLE
common.h: restore basic ALIGN() macro compatible with assembly

### DIFF
--- a/src/include/sof/common.h
+++ b/src/include/sof/common.h
@@ -77,7 +77,12 @@
 
 #endif
 
-#define ALIGN ALIGN_UP
+/* This most basic ALIGN() must be used in header files that are
+ * included in both C and assembly code. memory.h files require this
+ * exact spelling matching the linker function because memory.h values
+ * are _also_ copied unprocessed to the .x[.in] linker script
+ */
+#define ALIGN(val, align) ALIGN_UP_INTERNAL(val, align)
 #define DIV_ROUND_UP(val, div) (((val) + (div) - 1) / (div))
 
 #if !defined(__ASSEMBLER__)

--- a/src/lib/alloc.c
+++ b/src/lib/alloc.c
@@ -197,7 +197,7 @@ static void *align_ptr(struct mm_heap *heap, uint32_t alignment,
 	if (alignment <= 1)
 		return ptr;
 
-	return (void *)ALIGN((uintptr_t)ptr, alignment);
+	return (void *)ALIGN_UP((uintptr_t)ptr, alignment);
 }
 
 /* allocate single block */
@@ -290,7 +290,7 @@ static void *alloc_cont_blocks(struct mm_heap *heap, int level,
 
 			/* Check if we can start a sequence here */
 			if (alignment) {
-				aligned = ALIGN(blk_start, alignment);
+				aligned = ALIGN_UP(blk_start, alignment);
 
 				if (blk_start & (alignment - 1) &&
 				    aligned >= blk_start + map->block_size)
@@ -881,7 +881,7 @@ static void *alloc_heap_buffer(struct mm_heap *heap, uint32_t flags,
 			if (hdr->used)
 				continue;
 
-			aligned = ALIGN(free_start, alignment);
+			aligned = ALIGN_UP(free_start, alignment);
 
 			if (aligned + bytes > free_start + map->block_size)
 				continue;

--- a/src/platform/intel/cavs/lib/pm_memory.c
+++ b/src/platform/intel/cavs/lib/pm_memory.c
@@ -38,7 +38,7 @@ static void memory_banks_get(void *start, void *end, uint32_t base,
 	 * or end for end address
 	 */
 	if ((uintptr_t)start % SRAM_BANK_SIZE)
-		start = (void *)ALIGN((uintptr_t)start, SRAM_BANK_SIZE);
+		start = (void *)ALIGN_UP((uintptr_t)start, SRAM_BANK_SIZE);
 
 	if ((uintptr_t)end % SRAM_BANK_SIZE)
 		end = (void *)ALIGN_DOWN((uintptr_t)end, SRAM_BANK_SIZE);


### PR DESCRIPTION
commit 39266cac81f4 ("core: assure alignment is only done on power of 2
values") changed the alignment macros, they now use C code to perform a
sanity check. This broke ALIGN() usage in
platform/suecreek/include/platform/lib/memory.h in two different ways:

1. it broke static initializers in platform/suecreek/base_module.c
because these can't use statement-expressions. This could have been
fixed by simply switching to ALIGN_UP_COMPILE(), BUT:

2. memory.h files are also included in assembly.

Also note memory.h values are copied unprocessed to linker scripts that
require the ALIGN() spelling.

For these reasons ALIGN() needs to be switched back to a "dumb" macro.

Preserve the sanity checks just added in alloc.c and pm_memory.c by
switching them to the new and smarter ALIGN_UP() macro.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>