### PR TITLE
.travis.yml: build Sue Creek

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,9 @@ jobs:
       env: PLATFORM='jsl'
 
     - <<: *build-platform
+      env: PLATFORM='sue'
+
+    - <<: *build-platform
       env: PLATFORM='tgl'
 
     - <<: *build-platform


### PR DESCRIPTION
Sue Creek is the only platform using the ALIGN() macro in assembly. If
it had been built in CI then we would have avoided the ALIGN()
regression in commit 39266cac81f4 ("core: assure alignment is only done
on power of 2 values"). Building Sue Creek is practically free and finds
bugs so let's build it.

I'm aware Travis isn't the future but it's still running for now and
this is a tiny and totally trivial change that took 1/100 of the time
spent writing this commit message. It's also a reminder not to forget
Sue Creek in whatever will replace Travis.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>