### PR TITLE
clk: do not release clock only for LPRO->HPRO transition

### DIFF
--- a/src/platform/intel/cavs/lib/clk.c
+++ b/src/platform/intel/cavs/lib/clk.c
@@ -167,7 +167,12 @@ static void platform_clock_low_power_mode(int clock, bool enable)
 	int freq_idx = *cache_to_uncache(&active_freq_idx);
 
 	if (enable && current_freq_idx > CPU_LPRO_FREQ_IDX)
-		select_cpu_clock(CPU_LPRO_FREQ_IDX, true);
+		/* LPRO requests are fast, but requests for other ROs
+		 * can take a lot of time. That's why it's better to
+		 * not release active clock just for waiti,
+		 * so they can be switched without delay on wake up.
+		 */
+		select_cpu_clock(CPU_LPRO_FREQ_IDX, false);
 	else if (!enable && current_freq_idx != freq_idx)
 		select_cpu_clock(freq_idx, true);
 }


### PR DESCRIPTION
Bringing back HPRO active for waiti. It was disabled for both transitions (waiti enter and wakeup) in recent commits but actually one of them is very important in tight timing scenarios.