### PR TITLE
Pipeline fixes

### DIFF
--- a/src/audio/pipeline.c
+++ b/src/audio/pipeline.c
@@ -689,8 +689,9 @@ static void pipeline_comp_trigger_sched_comp(struct pipeline *p,
 	/* only required by the scheduling component or sink component
 	 * on pipeline without one
 	 */
-	if (p->sched_comp != comp &&
-	    (p == p->sched_comp->pipeline || p->sink_comp != comp))
+	if (dev_comp_id(p->sched_comp) != dev_comp_id(comp) &&
+	    (pipeline_id(p) == pipeline_id(p->sched_comp->pipeline) ||
+	     dev_comp_id(p->sink_comp) != dev_comp_id(comp)))
 		return;
 
 	/* add for later schedule */

--- a/src/include/sof/audio/pipeline.h
+++ b/src/include/sof/audio/pipeline.h
@@ -206,6 +206,16 @@ static inline bool pipeline_is_this_cpu(struct pipeline *p)
 	return p->ipc_pipe.core == cpu_get_id();
 }
 
+/**
+ * Retrieves pipeline id from pipeline.
+ * @param p pipeline.
+ * @return pipeline id.
+ */
+static inline uint32_t pipeline_id(struct pipeline *p)
+{
+	return p->ipc_pipe.pipeline_id;
+}
+
 /* pipeline creation and destruction */
 struct pipeline *pipeline_new(struct sof_ipc_pipe_new *pipe_desc,
 	struct comp_dev *cd);


### PR DESCRIPTION
Minor fixes for component/pipeline comparison, we should use the unique IDs, not the pointers.