### PR TITLE
ll_schedule: refining the scheduling policy to on demand

### DIFF
--- a/src/include/sof/schedule/ll_schedule_domain.h
+++ b/src/include/sof/schedule/ll_schedule_domain.h
@@ -42,7 +42,7 @@ struct ll_schedule_domain_ops {
 };
 
 struct ll_schedule_domain {
-	uint64_t last_tick;		/**< timestamp of last run */
+	uint64_t next_tick;		/**< ticks just set for next run */
 	spinlock_t lock;		/**< standard lock */
 	atomic_t total_num_tasks;	/**< total number of registered tasks */
 	atomic_t num_clients;		/**< number of registered cores */

--- a/src/include/sof/schedule/ll_schedule_domain.h
+++ b/src/include/sof/schedule/ll_schedule_domain.h
@@ -84,6 +84,8 @@ static inline struct ll_schedule_domain *domain_init
 	domain->full_sync = false;
 	domain->ticks_per_ms = clock_ms_to_ticks(clk, 1);
 	domain->ops = ops;
+	/* maximum value means no tick has been set to timer */
+	domain->next_tick = UINT64_MAX;
 
 	spinlock_init(&domain->lock);
 	atomic_init(&domain->total_num_tasks, 0);
@@ -135,18 +137,25 @@ static inline void domain_disable(struct ll_schedule_domain *domain, int core)
 	platform_shared_commit(domain, sizeof(*domain));
 }
 
+/* configure the next interrupt for domain */
 static inline void domain_set(struct ll_schedule_domain *domain, uint64_t start)
 {
 	if (domain->ops->domain_set)
 		domain->ops->domain_set(domain, start);
+	else
+		domain->next_tick = start;
 
 	platform_shared_commit(domain, sizeof(*domain));
 }
 
+/* clear the interrupt for domain */
 static inline void domain_clear(struct ll_schedule_domain *domain)
 {
 	if (domain->ops->domain_clear)
 		domain->ops->domain_clear(domain);
+
+	/* reset to denote no tick/interrupt is set */
+	domain->next_tick = UINT64_MAX;
 
 	platform_shared_commit(domain, sizeof(*domain));
 }

--- a/src/include/sof/schedule/ll_schedule_domain.h
+++ b/src/include/sof/schedule/ll_schedule_domain.h
@@ -165,8 +165,7 @@ static inline bool domain_is_pending(struct ll_schedule_domain *domain,
 	return ret;
 }
 
-struct ll_schedule_domain *timer_domain_init(struct timer *timer, int clk,
-					     uint64_t timeout);
+struct ll_schedule_domain *timer_domain_init(struct timer *timer, int clk);
 
 struct ll_schedule_domain *dma_multi_chan_domain_init(struct dma *dma_array,
 						      uint32_t num_dma, int clk,

--- a/src/platform/Kconfig
+++ b/src/platform/Kconfig
@@ -375,8 +375,7 @@ config SYSTICK_PERIOD
 	int "System tick period in microseconds"
 	default 1000
 	help
-	  Defines platform system tick period. It is used to
-	  drive timer based low latency scheduler and also
+	  Defines platform system tick period. It is used
 	  as a timeout check value for system agent.
 	  Value should be provided in microseconds.
 

--- a/src/platform/baytrail/platform.c
+++ b/src/platform/baytrail/platform.c
@@ -219,8 +219,7 @@ int platform_init(struct sof *sof)
 
 	/* init low latency timer domain and scheduler */
 	sof->platform_timer_domain =
-		timer_domain_init(sof->platform_timer, PLATFORM_DEFAULT_CLOCK,
-				  CONFIG_SYSTICK_PERIOD);
+		timer_domain_init(sof->platform_timer, PLATFORM_DEFAULT_CLOCK);
 	scheduler_init_ll(sof->platform_timer_domain);
 
 	/* init the system agent */

--- a/src/platform/haswell/platform.c
+++ b/src/platform/haswell/platform.c
@@ -192,8 +192,7 @@ int platform_init(struct sof *sof)
 
 	/* init low latency timer domain and scheduler */
 	sof->platform_timer_domain =
-		timer_domain_init(sof->platform_timer, PLATFORM_DEFAULT_CLOCK,
-				  CONFIG_SYSTICK_PERIOD);
+		timer_domain_init(sof->platform_timer, PLATFORM_DEFAULT_CLOCK);
 	scheduler_init_ll(sof->platform_timer_domain);
 
 	/* init the system agent */

--- a/src/platform/imx8/platform.c
+++ b/src/platform/imx8/platform.c
@@ -158,8 +158,7 @@ int platform_init(struct sof *sof)
 
 	/* init low latency domains and schedulers */
 	sof->platform_timer_domain =
-		timer_domain_init(sof->platform_timer, PLATFORM_DEFAULT_CLOCK,
-				  CONFIG_SYSTICK_PERIOD);
+		timer_domain_init(sof->platform_timer, PLATFORM_DEFAULT_CLOCK);
 	scheduler_init_ll(sof->platform_timer_domain);
 
 	platform_timer_start(sof->platform_timer);

--- a/src/platform/imx8m/platform.c
+++ b/src/platform/imx8m/platform.c
@@ -157,8 +157,7 @@ int platform_init(struct sof *sof)
 
 	/* init low latency domains and schedulers */
 	sof->platform_timer_domain =
-		timer_domain_init(sof->platform_timer, PLATFORM_DEFAULT_CLOCK,
-				  CONFIG_SYSTICK_PERIOD);
+		timer_domain_init(sof->platform_timer, PLATFORM_DEFAULT_CLOCK);
 	scheduler_init_ll(sof->platform_timer_domain);
 
 	platform_timer_start(sof->platform_timer);

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -386,8 +386,7 @@ int platform_init(struct sof *sof)
 
 	/* init low latency timer domain and scheduler */
 	sof->platform_timer_domain =
-		timer_domain_init(sof->platform_timer, PLATFORM_DEFAULT_CLOCK,
-				  CONFIG_SYSTICK_PERIOD);
+		timer_domain_init(sof->platform_timer, PLATFORM_DEFAULT_CLOCK);
 	scheduler_init_ll(sof->platform_timer_domain);
 
 	/* init the system agent */

--- a/src/schedule/dma_single_chan_domain.c
+++ b/src/schedule/dma_single_chan_domain.c
@@ -482,7 +482,8 @@ static void dma_single_chan_domain_set(struct ll_schedule_domain *domain,
 		ticks = domain->ticks_per_ms * data->channel->period / 1000 +
 			start;
 
-		domain->next_tick = domain->next_tick ? ticks : start;
+		domain->next_tick = domain->next_tick != UINT64_MAX ?
+				    ticks : start;
 	}
 
 out:

--- a/src/schedule/dma_single_chan_domain.c
+++ b/src/schedule/dma_single_chan_domain.c
@@ -459,7 +459,7 @@ out:
 }
 
 /**
- * \brief Calculates domain's last tick.
+ * \brief Calculates domain's next tick.
  * \param[in,out] domain Pointer to schedule domain.
  * \param[in] start Offset of last calculated tick.
  */
@@ -475,14 +475,14 @@ static void dma_single_chan_domain_set(struct ll_schedule_domain *domain,
 		goto out;
 
 	if (dma_domain->channel_changed) {
-		domain->last_tick = platform_timer_get_atomic(timer_get());
+		domain->next_tick = platform_timer_get_atomic(timer_get());
 
 		dma_domain->channel_changed = false;
 	} else {
 		ticks = domain->ticks_per_ms * data->channel->period / 1000 +
 			start;
 
-		domain->last_tick = domain->last_tick ? ticks : start;
+		domain->next_tick = domain->next_tick ? ticks : start;
 	}
 
 out:

--- a/src/schedule/ll_schedule.c
+++ b/src/schedule/ll_schedule.c
@@ -213,10 +213,15 @@ static void schedule_ll_tasks_run(void *data)
 }
 
 static int schedule_ll_domain_set(struct ll_schedule_data *sch,
-				  struct task *task, uint64_t period)
+				  struct task *task, uint64_t start,
+				  uint64_t period)
 {
 	int core = cpu_get_id();
 	unsigned int total;
+	uint64_t task_start_us;
+	uint64_t task_start_ticks;
+	uint64_t task_start;
+	uint64_t offset;
 	bool registered;
 	int ret;
 
@@ -230,16 +235,41 @@ static int schedule_ll_domain_set(struct ll_schedule_data *sch,
 
 	spin_lock(&sch->domain->lock);
 
+	tr_dbg(&ll_tr, "task->start %u next_tick %u",
+	       (unsigned int)task->start,
+	       (unsigned int)sch->domain->next_tick);
+
+	task_start_us = period ? period : start;
+	task_start_ticks = sch->domain->ticks_per_ms * task_start_us / 1000;
+	task_start = task_start_ticks + platform_timer_get_atomic(timer_get());
+
+	if (sch->domain->next_tick == UINT64_MAX) {
+		/* first task, set domain */
+		domain_set(sch->domain, task_start);
+		task->start = sch->domain->next_tick;
+	} else if (!period) {
+		/* one shot task, set domain if it is earlier */
+		task->start = task_start;
+		if (task->start < sch->domain->next_tick)
+			domain_set(sch->domain, task_start);
+	} else if (task_start < sch->domain->next_tick) {
+		/* earlier periodic task, try to make it cadence-aligned with the existed task */
+		offset = (sch->domain->next_tick - task_start) %
+			 (sch->domain->ticks_per_ms * period / 1000);
+		task_start = task_start - task_start_ticks + offset;
+		domain_set(sch->domain, task_start);
+		task->start = sch->domain->next_tick;
+	} else {
+		/* later periodic task, simplify and cover it by the coming interrupt */
+		task->start = sch->domain->next_tick;
+	}
+
 	registered = sch->domain->registered[core];
 	total = atomic_add(&sch->num_tasks, 1);
 	if (total == 0)
 		sch->domain->registered[core] = true;
 
 	total = atomic_add(&sch->domain->total_num_tasks, 1);
-	if (total == 0)
-		/* First task in domain over all cores: actiivate it */
-		domain_set(sch->domain, platform_timer_get_atomic(timer_get()));
-
 	if (total == 0 || !registered) {
 		/* First task on core: count and enable it */
 		atomic_add(&sch->domain->num_clients, 1);
@@ -247,6 +277,7 @@ static int schedule_ll_domain_set(struct ll_schedule_data *sch,
 		sch->domain->enabled[core] = true;
 	}
 
+	tr_info(&ll_tr, "new added task->start %u", (unsigned int)task->start);
 	tr_info(&ll_tr, "num_tasks %d total_num_tasks %d",
 		atomic_read(&sch->num_tasks),
 		atomic_read(&sch->domain->total_num_tasks));
@@ -265,24 +296,15 @@ static void schedule_ll_domain_clear(struct ll_schedule_data *sch,
 
 	spin_lock(&sch->domain->lock);
 
-	count = atomic_sub(&sch->domain->total_num_tasks, 1);
-	if (count == 1) {
-		domain_clear(sch->domain);
-		sch->domain->next_tick = 0;
-	}
+	atomic_sub(&sch->domain->total_num_tasks, 1);
 
 	count = atomic_sub(&sch->num_tasks, 1);
 	if (count == 1) {
 		sch->domain->registered[cpu_get_id()] = false;
 
-		/* reschedule if we are the last client */
-		if (atomic_read(&sch->domain->num_clients)) {
-			count = atomic_sub(&sch->domain->num_clients, 1);
-			if (count == 1) {
-				domain_clear(sch->domain);
-				schedule_ll_clients_reschedule(sch);
-			}
-		}
+		count = atomic_sub(&sch->domain->num_clients, 1);
+		if (count == 1)
+			domain_clear(sch->domain);
 	}
 
 	tr_info(&ll_tr, "num_tasks %d total_num_tasks %d",
@@ -401,18 +423,11 @@ static int schedule_ll_task(void *data, struct task *task, uint64_t start,
 	schedule_ll_task_insert(task, &sch->tasks);
 
 	/* set schedule domain */
-	ret = schedule_ll_domain_set(sch, task, period);
+	ret = schedule_ll_domain_set(sch, task, start, period);
 	if (ret < 0) {
 		list_item_del(&task->list);
 		goto out;
 	}
-
-	task->start = sch->domain->ticks_per_ms * start / 1000;
-
-	if (sch->domain->synchronous)
-		task->start += platform_timer_get_atomic(timer_get());
-	else
-		task->start += sch->domain->next_tick;
 
 	platform_shared_commit(sch->domain, sizeof(*sch->domain));
 

--- a/src/schedule/ll_schedule.c
+++ b/src/schedule/ll_schedule.c
@@ -80,7 +80,7 @@ static bool schedule_ll_is_pending(struct ll_schedule_data *sch)
 }
 
 static void schedule_ll_task_update_start(struct ll_schedule_data *sch,
-					  struct task *task, uint64_t last_tick)
+					  struct task *task, uint64_t next_tick)
 {
 	struct ll_task_pdata *pdata = ll_sch_get_pdata(task);
 	uint64_t next;
@@ -90,11 +90,11 @@ static void schedule_ll_task_update_start(struct ll_schedule_data *sch,
 	if (sch->domain->synchronous)
 		task->start += next;
 	else
-		task->start = next + last_tick;
+		task->start = next + next_tick;
 }
 
 static void schedule_ll_tasks_execute(struct ll_schedule_data *sch,
-				      uint64_t last_tick)
+				      uint64_t next_tick)
 {
 	struct list_item *wlist;
 	struct list_item *tlist;
@@ -127,7 +127,7 @@ static void schedule_ll_tasks_execute(struct ll_schedule_data *sch,
 				atomic_read(&sch->domain->total_num_tasks));
 		} else {
 			/* update task's start time */
-			schedule_ll_task_update_start(sch, task, last_tick);
+			schedule_ll_task_update_start(sch, task, next_tick);
 		}
 	}
 
@@ -151,7 +151,7 @@ static void schedule_ll_clients_reschedule(struct ll_schedule_data *sch)
 {
 	/* rearm only if there is work to do */
 	if (atomic_read(&sch->domain->total_num_tasks)) {
-		domain_set(sch->domain, sch->domain->last_tick);
+		domain_set(sch->domain, sch->domain->next_tick);
 		schedule_ll_clients_enable(sch);
 	}
 
@@ -162,7 +162,7 @@ static void schedule_ll_tasks_run(void *data)
 {
 	struct ll_schedule_data *sch = data;
 	uint32_t num_clients = 0;
-	uint64_t last_tick;
+	uint64_t next_tick;
 	uint32_t flags;
 
 	domain_disable(sch->domain, cpu_get_id());
@@ -173,7 +173,7 @@ static void schedule_ll_tasks_run(void *data)
 
 	sch->domain->enabled[cpu_get_id()] = false;
 
-	last_tick = sch->domain->last_tick;
+	next_tick = sch->domain->next_tick;
 
 	/* clear domain only if all clients are done */
 	/* TODO: no need for atomic operations,
@@ -194,7 +194,7 @@ static void schedule_ll_tasks_run(void *data)
 
 	/* run tasks if there are any pending */
 	if (schedule_ll_is_pending(sch))
-		schedule_ll_tasks_execute(sch, last_tick);
+		schedule_ll_tasks_execute(sch, next_tick);
 
 	notifier_event(sch, NOTIFIER_ID_LL_POST_RUN,
 		       NOTIFIER_TARGET_CORE_LOCAL, NULL, 0);
@@ -268,7 +268,7 @@ static void schedule_ll_domain_clear(struct ll_schedule_data *sch,
 	count = atomic_sub(&sch->domain->total_num_tasks, 1);
 	if (count == 1) {
 		domain_clear(sch->domain);
-		sch->domain->last_tick = 0;
+		sch->domain->next_tick = 0;
 	}
 
 	count = atomic_sub(&sch->num_tasks, 1);
@@ -412,7 +412,7 @@ static int schedule_ll_task(void *data, struct task *task, uint64_t start,
 	if (sch->domain->synchronous)
 		task->start += platform_timer_get_atomic(timer_get());
 	else
-		task->start += sch->domain->last_tick;
+		task->start += sch->domain->next_tick;
 
 	platform_shared_commit(sch->domain, sizeof(*sch->domain));
 
@@ -513,7 +513,7 @@ static int reschedule_ll_task(void *data, struct task *task, uint64_t start)
 	if (sch->domain->synchronous)
 		time += platform_timer_get_atomic(timer_get());
 	else
-		time += sch->domain->last_tick;
+		time += sch->domain->next_tick;
 
 	irq_local_disable(flags);
 

--- a/src/schedule/timer_domain.c
+++ b/src/schedule/timer_domain.c
@@ -238,7 +238,7 @@ static void timer_domain_set(struct ll_schedule_domain *domain, uint64_t start)
 #else
 	uint64_t current = platform_timer_get_atomic(timer_domain->timer);
 	uint64_t earliest_next = current + 1 + ZEPHYR_SCHED_COST;
-	uint64_t ticks_req = domain->last_tick ? start + ticks_tout :
+	uint64_t ticks_req = domain->next_tick ? start + ticks_tout :
 		MAX(start, earliest_next);
 	int ret, core = cpu_get_id();
 	uint64_t ticks_delta;
@@ -283,7 +283,7 @@ static void timer_domain_set(struct ll_schedule_domain *domain, uint64_t start)
 		timer_report_delay(timer_domain->timer->id,
 				   ticks_set - ticks_req);
 
-	domain->last_tick = ticks_set;
+	domain->next_tick = ticks_set;
 
 	platform_shared_commit(timer_domain, sizeof(*timer_domain));
 }

--- a/src/schedule/timer_domain.c
+++ b/src/schedule/timer_domain.c
@@ -8,6 +8,7 @@
 #include <sof/lib/alloc.h>
 #include <sof/lib/cpu.h>
 #include <sof/lib/memory.h>
+#include <sof/math/numbers.h>
 #include <sof/platform.h>
 #include <sof/schedule/ll_schedule.h>
 #include <sof/schedule/ll_schedule_domain.h>
@@ -53,6 +54,8 @@ K_THREAD_STACK_DEFINE(ll_workq_stack3, ZEPHYR_LL_WORKQ_SIZE);
 #endif
 #endif
 
+#define LL_TIMER_SET_OVERHEAD_TICKS  1000 /* overhead/delay to set the tick, in ticks */
+
 struct timer_domain {
 #ifdef __ZEPHYR__
 	struct k_work_q ll_workq[CONFIG_CORE_COUNT];
@@ -60,7 +63,7 @@ struct timer_domain {
 #endif
 	struct timer *timer;
 	void *arg[CONFIG_CORE_COUNT];
-	uint64_t timeout; /* in microseconds */
+	uint64_t timeout; /* in ticks */
 };
 
 #ifdef __ZEPHYR__
@@ -228,11 +231,13 @@ static void timer_domain_disable(struct ll_schedule_domain *domain, int core)
 static void timer_domain_set(struct ll_schedule_domain *domain, uint64_t start)
 {
 	struct timer_domain *timer_domain = ll_sch_domain_get_pdata(domain);
-	uint64_t ticks_tout = domain->ticks_per_ms * timer_domain->timeout /
-			     1000;
+	uint64_t ticks_tout = timer_domain->timeout;
 	uint64_t ticks_set;
 #ifndef __ZEPHYR__
-	uint64_t ticks_req = start + ticks_tout;
+	uint64_t ticks_req;
+
+	/* make sure to require for ticks later than tout from now */
+	ticks_req = MAX(start, platform_timer_get_atomic(timer_domain->timer) + ticks_tout);
 
 	ticks_set = platform_timer_set(timer_domain->timer, ticks_req);
 #else
@@ -276,6 +281,10 @@ static void timer_domain_set(struct ll_schedule_domain *domain, uint64_t start)
 		current - current % CYC_PER_TICK;
 #endif
 
+	tr_dbg(&ll_tr, "timer_domain_set(): ticks_set %u ticks_req %u current %u",
+	       (unsigned int)ticks_set, (unsigned int)ticks_req,
+	       (unsigned int)platform_timer_get_atomic(timer_get()));
+
 	/* Was timer set to the value we requested? If no it means some
 	 * delay occurred and we should report that in error log.
 	 */
@@ -305,24 +314,17 @@ static bool timer_domain_is_pending(struct ll_schedule_domain *domain,
 	return task->start <= platform_timer_get_atomic(timer_get());
 }
 
-struct ll_schedule_domain *timer_domain_init(struct timer *timer, int clk,
-					     uint64_t timeout)
+struct ll_schedule_domain *timer_domain_init(struct timer *timer, int clk)
 {
 	struct ll_schedule_domain *domain;
 	struct timer_domain *timer_domain;
-
-	if (timeout <= UINT_MAX)
-		tr_info(&ll_tr, "timer_domain_init clk %d timeout %u", clk,
-			(unsigned int)timeout);
-	else
-		tr_info(&ll_tr, "timer_domain_init clk %d timeout > %u", clk, UINT_MAX);
 
 	domain = domain_init(SOF_SCHEDULE_LL_TIMER, clk, false,
 			     &timer_domain_ops);
 
 	timer_domain = rzalloc(SOF_MEM_ZONE_SYS_SHARED, 0, SOF_MEM_CAPS_RAM, sizeof(*timer_domain));
 	timer_domain->timer = timer;
-	timer_domain->timeout = timeout;
+	timer_domain->timeout = LL_TIMER_SET_OVERHEAD_TICKS;
 
 	ll_sch_domain_set_pdata(domain, timer_domain);
 

--- a/src/schedule/timer_domain.c
+++ b/src/schedule/timer_domain.c
@@ -283,7 +283,7 @@ static void timer_domain_set(struct ll_schedule_domain *domain, uint64_t start)
 		timer_report_delay(timer_domain->timer->id,
 				   ticks_set - ticks_req);
 
-	domain->last_tick = ticks_req;
+	domain->last_tick = ticks_set;
 
 	platform_shared_commit(timer_domain, sizeof(*timer_domain));
 }


### PR DESCRIPTION
ll_schedule: refining the scheduling policy to optimize it

For low latency scheduler, we should schedule a task at the as accurate
as possible point, and set timer interrupt only at needed point.

Also, if we schedule a periodic task at a delayed point, it will be good
to catch up it in the next period, to avoid accumulated delay which will
eventually lead to Xrun.

Here is what the commit does for the LL scheduler refining:

1. at the point of domain_set():
previously: set when the first task over all cores being added, set tick
to the current point (ASAP).
new: set when needed. e.g. the first task over all cores being added, or
a task asking for earlier timer being added.

2. at interrupt handling & tasks_run(): run each pending task of the core,
e.g. for period tasks:
previously: update task->start based on last_tick(asynchronized), if the
last_tick was delayed, the delay will be accumulated to the subsequent
periods!
new: update task->start based on last task->start, to try to make the
task's running follow the backend's requirement as more as possible.

3. reschedule once interrupt is handled by all cores(clients):
previously: if there is still task in the list, set timer to be the
last_tick, and enable interrupt on cores that have tasks to run.
new: if there is still task in the list, traverse to set timer according
to the earlist task, and enable interrupt on cores that have tasks to run.

4. timer_domain refining:
previously: add 1ms(overhead) for each timer set unconditionally.
new: change to use overhead which has max value 50us, and don't add any
if no needed(e.g. if the start > current + 50us).
This will help to schedule the task ASAP, and make the catching up (of
the previous delay) possible.

5. rename the last_tick to next_tick, which means the one already set
to the timer, for more easy to understand.

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>