### PR TITLE
topology: smart_amp: make the DSP core configurable

### DIFF
--- a/tools/topology/m4/smart_amp.m4
+++ b/tools/topology/m4/smart_amp.m4
@@ -5,7 +5,7 @@ dnl Define macro for smart_amp(Smart Amplifier) widget
 dnl SMART_AMP name)
 define(`N_SMART_AMP', `SMART_AMP'PIPELINE_ID`.'$1)
 
-dnl W_SMART_AMP(name, uuid, format, periods_sink, periods_source, kcontrols_list)
+dnl W_SMART_AMP(name, uuid, format, periods_sink, periods_source, core, kcontrols_list)
 define(`W_SMART_AMP',
 `SectionVendorTuples."'N_SMART_AMP($1)`_tuples_uuid" {'
 `	tokens "sof_comp_tokens"'
@@ -21,6 +21,7 @@ define(`W_SMART_AMP',
 `	tuples."word" {'
 `		SOF_TKN_COMP_PERIOD_SINK_COUNT'		STR($4)
 `		SOF_TKN_COMP_PERIOD_SOURCE_COUNT'	STR($5)
+`               SOF_TKN_COMP_CORE_ID'                   STR($6)
 `	}'
 `}'
 `SectionData."'N_SMART_AMP($1)`_data_w" {'
@@ -52,7 +53,7 @@ define(`W_SMART_AMP',
 `		"'N_SMART_AMP($1)`_data_str"'
 `	]'
 `	bytes ['
-		$6
+		$7
 `	]'
 `}')
 

--- a/tools/topology/sof-smart-amplifier.m4
+++ b/tools/topology/sof-smart-amplifier.m4
@@ -19,6 +19,10 @@ DEBUG_START
 # define the default macros.
 # define them in your specific platform .m4 if needed.
 
+# define(`SMART_AMP_CORE', 1) define the DSP core that the DSM pipeline will be run on, if not done yet
+ifdef(`SMART_AMP_CORE',`',`define(`SMART_AMP_CORE', 0)')
+
+dnl define smart amplifier ALH index
 
 ifelse(SDW, `1',
 `
@@ -119,7 +123,7 @@ dnl     time_domain, sched_comp)
 # Set 1000us deadline on core 0 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-smart-amplifier-playback.m4,
 	SMART_PB_PPL_ID, SMART_PCM_ID, SMART_PB_CH_NUM, s32le,
-	1000, 0, 0,
+	1000, 0, SMART_AMP_CORE,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s32le.
@@ -134,7 +138,7 @@ PIPELINE_PCM_ADD(sof/pipe-amp-ref-capture.m4,
 `
 PIPELINE_PCM_ADD(sof/pipe-amp-ref-capture.m4,
 	SMART_REF_PPL_ID, SMART_PCM_ID, SMART_REF_CH_NUM, s32le,
-	1000, 0, 0,
+	1000, 0, SMART_AMP_CORE,
 	48000, 48000, 48000)
 ')
 
@@ -169,14 +173,14 @@ DAI_ADD(sof/pipe-dai-capture.m4,
 DAI_ADD(sof/pipe-dai-playback.m4,
 	SMART_PB_PPL_ID, SSP, SMART_SSP_INDEX, SMART_SSP_NAME,
 	SMART_PIPE_SOURCE, 2, s32le,
-	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+	1000, 0, SMART_AMP_CORE, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is SSP(SSP_INDEX) using 2 periods
 # Buffers use s32le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	SMART_REF_PPL_ID, SSP, SMART_SSP_INDEX, SMART_SSP_NAME,
 	SMART_PIPE_SINK, 2, s32le,
-	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+	1000, 0, SMART_AMP_CORE, SCHEDULE_TIME_DOMAIN_TIMER)
 ')
 
 # Connect demux to smart_amp

--- a/tools/topology/sof/pipe-amp-ref-capture.m4
+++ b/tools/topology/sof/pipe-amp-ref-capture.m4
@@ -74,7 +74,7 @@ C_CONTROLBYTES(DEMUX, PIPELINE_ID,
 
 # Host "Echo Reference Capture" PCM
 # with 0 sink and 2 source periods
-W_PCM_CAPTURE(PCM_ID, Echo Reference Capture, 0, 2)
+W_PCM_CAPTURE(PCM_ID, Echo Reference Capture, 0, 2, SCHEDULE_CORE)
 
 # Mux 0 has 2 sink and source periods.
 W_MUXDEMUX(0, 1, PIPELINE_FORMAT, 2, 2, SCHEDULE_CORE, LIST(`         ', "DEMUX"))

--- a/tools/topology/sof/pipe-smart-amplifier-playback.m4
+++ b/tools/topology/sof/pipe-smart-amplifier-playback.m4
@@ -92,10 +92,11 @@ C_CONTROLBYTES_VOLATILE_READONLY(Smart_amp Model_Get_params, PIPELINE_ID,
 
 # Host "Low latency Playback" PCM
 # with 2 sink and 0 source periods
-W_PCM_PLAYBACK(PCM_ID, Smart Amplifier Playback, 2, 0)
+W_PCM_PLAYBACK(PCM_ID, Smart Amplifier Playback, 2, 0, SCHEDULE_CORE)
 
 # Mux 0 has 2 sink and source periods.
-W_SMART_AMP(0, SMART_UUID, PIPELINE_FORMAT, 2, 2, LIST(`             ', "Smart_amp Config", "Smart_amp Model",
+W_SMART_AMP(0, SMART_UUID, PIPELINE_FORMAT, 2, 2, SCHEDULE_CORE,
+	    LIST(`             ', "Smart_amp Config", "Smart_amp Model",
 	    ifelse(SOF_ABI_VERSION_3_17_OR_GRT, `1', "Smart_amp Model_Get_params")))
 
 # Low Latency Buffers


### PR DESCRIPTION
Define SMART_AMP_CORE configurable, configure to run DSM pipelines on
DSP core0 if it is not set.

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>