### PR TITLE
DSP clock switching refining

### DIFF
--- a/src/include/sof/lib/clk.h
+++ b/src/include/sof/lib/clk.h
@@ -21,6 +21,7 @@ struct timer;
 #define CLOCK_NOTIFY_POST	1
 
 struct clock_notify_data {
+	uint32_t clk_id;
 	uint32_t old_freq;
 	uint32_t old_ticks_per_msec;
 	uint32_t freq;

--- a/src/include/sof/lib/clk.h
+++ b/src/include/sof/lib/clk.h
@@ -54,6 +54,7 @@ struct clock_info {
 uint32_t clock_get_freq(int clock);
 
 void clock_set_freq(int clock, uint32_t hz);
+void clock_set_idx(int clock, int freq_idx);
 
 void clock_low_power_mode(int clock, bool enable);
 

--- a/src/lib/clk.c
+++ b/src/lib/clk.c
@@ -97,6 +97,41 @@ void clock_set_freq(int clock, uint32_t hz)
 	spin_unlock_irq(&clk_info->lock, flags);
 }
 
+void clock_set_idx(int clock, int freq_idx)
+{
+	struct clock_info *clk_info = clocks_get() + clock;
+
+	clk_notify_data.clk_id = clock;
+
+	clk_notify_data.old_freq =
+		clk_info->freqs[clk_info->current_freq_idx].freq;
+	clk_notify_data.old_ticks_per_msec =
+		clk_info->freqs[clk_info->current_freq_idx].ticks_per_msec;
+
+	clk_notify_data.freq = clk_info->freqs[freq_idx].freq;
+
+	tr_info(&clock_tr, "clock %d set freq_idx %d", clock, freq_idx);
+
+	/* tell anyone interested we are about to change freq */
+	clk_notify_data.message = CLOCK_NOTIFY_PRE;
+	notifier_event(clk_info, clk_info->notification_id,
+		       clk_info->notification_mask, &clk_notify_data,
+		       sizeof(clk_notify_data));
+
+	if (!clk_info->set_freq ||
+	    clk_info->set_freq(clock, freq_idx) == 0)
+		/* update clock frequency */
+		clk_info->current_freq_idx = freq_idx;
+
+	/* tell anyone interested we have now changed freq */
+	clk_notify_data.message = CLOCK_NOTIFY_POST;
+	notifier_event(clk_info, clk_info->notification_id,
+		       clk_info->notification_mask, &clk_notify_data,
+		       sizeof(clk_notify_data));
+
+	platform_shared_commit(clk_info, sizeof(*clk_info));
+}
+
 void clock_low_power_mode(int clock, bool enable)
 {
 	struct clock_info *clk_info = clocks_get() + clock;

--- a/src/lib/clk.c
+++ b/src/lib/clk.c
@@ -57,6 +57,8 @@ void clock_set_freq(int clock, uint32_t hz)
 	uint32_t idx;
 	uint32_t flags;
 
+	clk_notify_data.clk_id = clock;
+
 	clk_notify_data.old_freq =
 		clk_info->freqs[clk_info->current_freq_idx].freq;
 	clk_notify_data.old_ticks_per_msec =

--- a/src/platform/intel/cavs/lib/clk.c
+++ b/src/platform/intel/cavs/lib/clk.c
@@ -190,11 +190,11 @@ void platform_clock_on_waiti(void)
 	if (pm_is_active) {
 		/* set HPRO clock if not already enabled */
 		if (freq_idx != CPU_HPRO_FREQ_IDX)
-			set_cpu_current_freq_idx(CPU_HPRO_FREQ_IDX, true);
+			clock_set_idx(CLK_CPU(cpu_get_id()), CPU_HPRO_FREQ_IDX);
 	} else {
 		/* set lowest clock if not already enabled */
 		if (freq_idx != lowest_freq_idx)
-			set_cpu_current_freq_idx(lowest_freq_idx, true);
+			clock_set_idx(CLK_CPU(cpu_get_id()), lowest_freq_idx);
 	}
 
 	spin_unlock_irq(&prd->lock, flags);
@@ -265,11 +265,11 @@ void platform_clock_on_waiti(void)
 	if (pm_is_active) {
 		/* set HPRO clock if not already enabled */
 		if (freq_idx != CPU_HPRO_FREQ_IDX)
-			set_cpu_current_freq_idx(CPU_HPRO_FREQ_IDX, true);
+			clock_set_idx(CLK_CPU(cpu_get_id()), CPU_HPRO_FREQ_IDX);
 	} else {
 		/* set lowest clock if not already enabled */
 		if (freq_idx != lowest_freq_idx)
-			set_cpu_current_freq_idx(lowest_freq_idx, true);
+			clock_set_idx(CLK_CPU(cpu_get_id()), lowest_freq_idx);
 	}
 
 	spin_unlock_irq(&prd->lock, flags);
@@ -290,7 +290,7 @@ void platform_clock_on_wakeup(void)
 
 	/* restore the active cpu freq_idx manually */
 	if (current_idx != target_idx)
-		set_cpu_current_freq_idx(target_idx, true);
+		clock_set_idx(CLK_CPU(cpu_get_id()), target_idx);
 
 	spin_unlock_irq(&prd->lock, flags);
 }

--- a/src/schedule/ll_schedule.c
+++ b/src/schedule/ll_schedule.c
@@ -536,6 +536,9 @@ static void ll_scheduler_notify(void *arg, enum notify_id type, void *data)
 	struct clock_notify_data *clk_data = data;
 	uint32_t flags;
 
+	if (clk_data->clk_id != sch->domain->clk)
+		return;
+
 	irq_local_disable(flags);
 
 	/* we need to recalculate tasks when clock frequency changes */


### PR DESCRIPTION
1. add notification event for the clock switching.
2. use the event to notify KPB to start draining.