### PR TITLE
topology: add a development topology for HDA without HDMI

### DIFF
--- a/tools/topology/development/CMakeLists.txt
+++ b/tools/topology/development/CMakeLists.txt
@@ -2,6 +2,11 @@
 
 set(TPLGS
 	"sof-tgl-nocodec-ci\;sof-tgl-nocodec-ci"
+		"sof-hda-generic-nohdmi\;sof-hda-generic-nohdmi\;-DCHANNELS=0\;-DPPROC=volume"
+		"sof-hda-generic-nohdmi\;sof-hda-generic-nohdmi-1ch\;-DCHANNELS=2\;-DPPROC=volume\;-DDMICPROC_FILTER1=eq_iir_coef_highpass_40hz_20db_48khz.m4\;-DDMIC16KPROC_FILTER1=eq_iir_coef_highpass_40hz_20db_16khz.m4"
+		"sof-hda-generic-nohdmi\;sof-hda-generic-nohdmi-2ch\;-DCHANNELS=2\;-DPPROC=volume\;-DDMICPROC_FILTER1=eq_iir_coef_highpass_40hz_20db_48khz.m4\;-DDMIC16KPROC_FILTER1=eq_iir_coef_highpass_40hz_20db_16khz.m4"
+		"sof-hda-generic-nohdmi\;sof-hda-generic-nohdmi-3ch\;-DCHANNELS=4\;-DPPROC=volume\;-DDMICPROC_FILTER1=eq_iir_coef_highpass_40hz_20db_48khz.m4\;-DDMIC16KPROC_FILTER1=eq_iir_coef_highpass_40hz_20db_16khz.m4"
+		"sof-hda-generic-nohdmi\;sof-hda-generic-nohdmi-4ch\;-DCHANNELS=4\;-DPPROC=volume\;-DDMICPROC_FILTER1=eq_iir_coef_highpass_40hz_20db_48khz.m4\;-DDMIC16KPROC_FILTER1=eq_iir_coef_highpass_40hz_20db_16khz.m4"
 )
 
 add_custom_target(dev_topologies ALL)

--- a/tools/topology/development/sof-hda-generic-nohdmi.m4
+++ b/tools/topology/development/sof-hda-generic-nohdmi.m4
@@ -1,0 +1,144 @@
+# Topology for SKL+ HDA Generic machine
+#
+
+# if XPROC is not defined, define with default pipe
+ifdef(`DMICPROC', , `define(DMICPROC, eq-iir-volume)')
+ifdef(`DMIC16KPROC', , `define(DMIC16KPROC, eq-iir-volume)')
+
+# Include topology builder
+include(`utils.m4')
+include(`dai.m4')
+include(`pipeline.m4')
+include(`hda.m4')
+
+# Include TLV library
+include(`common/tlv.m4')
+
+# Include Token library
+include(`sof/tokens.m4')
+
+# Include bxt DSP configuration
+include(`platform/intel/bxt.m4')
+
+# Define pipeline id for intel-generic-dmic.m4
+# to generate dmic setting
+
+ifelse(CHANNELS, `0', ,
+`
+define(DMIC_PIPELINE_48k_ID, `10')
+define(DMIC_PIPELINE_16k_ID, `11')
+
+include(`platform/intel/intel-generic-dmic.m4')
+'
+)
+
+# The pipeline naming notation is pipe-PROCESSING-DIRECTION.m4
+# PPROC is set by makefile
+define(PIPE_HEADSET_PLAYBACK, `sof/pipe-`PPROC'-playback.m4')
+
+#
+# Define the pipelines
+#
+# PCM0P --> volume     (pipe 1) --> HDA Analog (HDA Analog playback)
+# PCM0C <-- volume, EQ (pipe 2) <-- HDA Analog (HDA Analog capture)
+# PCM1P --> volume     (pipe 3) --> HDA Digital (HDA Digital playback)
+# PCM1C <-- volume, EQ (pipe 4) <-- HDA Digital (HDA Digital capture)
+#
+
+# Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s24le.
+# 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(PIPE_HEADSET_PLAYBACK,
+	1, 0, 2, s24le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s24le.
+# 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-highpass-capture.m4,
+	2, 0, 2, s24le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency playback pipeline 3 on PCM 1 using max 2 channels of s24le.
+# 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	3, 1, 2, s24le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency capture pipeline 4 on PCM 1 using max 2 channels of s24le.
+# 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-highpass-capture.m4,
+	4, 1, 2, s24le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+#
+# DAIs configuration
+#
+
+# playback DAI is HDA Analog using 2 periods
+# Dai buffers use s32le format, 1000us deadline on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+        1, HDA, 0, Analog Playback and Capture,
+        PIPELINE_SOURCE_1, 2, s32le,
+        1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+
+# capture DAI is HDA Analog using 2 periods
+# Dai buffers use s32le format, 1000us deadline on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-capture.m4,
+        2, HDA, 1, Analog Playback and Capture,
+	PIPELINE_SINK_2, 2, s32le,
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+
+# playback DAI is HDA Digital using 2 periods
+# Dai buffers use s32le format, 1000us deadline on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+        3, HDA, 2, Digital Playback and Capture,
+        PIPELINE_SOURCE_3, 2, s32le,
+        1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+
+# capture DAI is HDA Digital using 2 periods
+# Dai buffers use s32le format, 1000us deadline on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-capture.m4,
+        4, HDA, 3, Digital Playback and Capture,
+	PIPELINE_SINK_4, 2, s32le,
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+
+PCM_DUPLEX_ADD(HDA Analog, 0, PIPELINE_PCM_1, PIPELINE_PCM_2)
+PCM_DUPLEX_ADD(HDA Digital, 1, PIPELINE_PCM_3, PIPELINE_PCM_4)
+
+#
+# BE configurations - overrides config in ACPI if present
+#
+
+# HDA outputs
+DAI_CONFIG(HDA, 0, 4, Analog Playback and Capture,
+	HDA_CONFIG(HDA_CONFIG_DATA(HDA, 0, 48000, 2)))
+DAI_CONFIG(HDA, 1, 5, Digital Playback and Capture,
+	HDA_CONFIG(HDA_CONFIG_DATA(HDA, 1, 48000, 2)))
+
+VIRTUAL_DAPM_ROUTE_IN(codec0_in, HDA, 1, IN, 1)
+VIRTUAL_DAPM_ROUTE_IN(codec1_in, HDA, 3, IN, 2)
+VIRTUAL_DAPM_ROUTE_OUT(codec0_out, HDA, 0, OUT, 3)
+VIRTUAL_DAPM_ROUTE_OUT(codec1_out, HDA, 2, OUT, 4)
+
+# codec2 is not supported in dai links but it exists
+# in dapm routes, so hack this one to HDA1
+VIRTUAL_DAPM_ROUTE_IN(codec2_in, HDA, 3, IN, 5)
+VIRTUAL_DAPM_ROUTE_OUT(codec2_out, HDA, 2, OUT, 6)
+
+VIRTUAL_WIDGET(iDisp3_out, out_drv, 9)
+VIRTUAL_WIDGET(iDisp2_out, out_drv, 10)
+VIRTUAL_WIDGET(iDisp1_out, out_drv, 11)
+
+VIRTUAL_WIDGET(iDisp3 Tx, out_drv, 0)
+VIRTUAL_WIDGET(iDisp2 Tx, out_drv, 1)
+VIRTUAL_WIDGET(iDisp1 Tx, out_drv, 2)
+
+VIRTUAL_WIDGET(Analog CPU Playback, out_drv, 3)
+VIRTUAL_WIDGET(Digital CPU Playback, out_drv, 4)
+VIRTUAL_WIDGET(Alt Analog CPU Playback, out_drv, 5)
+VIRTUAL_WIDGET(Analog CPU Capture, input, 6)
+VIRTUAL_WIDGET(Digital CPU Capture, input, 7)
+VIRTUAL_WIDGET(Alt Analog CPU Capture, input, 8)


### PR DESCRIPTION
some platform do not have HDMI codec support, need to fallback to use
HDA without HDMI codec.

Signed-off-by: Pan Xiuli <xiuli.pan@linux.intel.com>