### PR TITLE
[skip ci] sof.doxygen.in: change ../test to @top_srcdir@/test

### DIFF
--- a/doc/sof.doxygen.in
+++ b/doc/sof.doxygen.in
@@ -13,7 +13,7 @@ INPUT            = @top_srcdir@/src/include/ipc \
 EXCLUDE		 =
 RECURSIVE	 = YES
 FILE_PATTERNS    = *.c *.h
-EXAMPLE_PATH     = ../test
+EXAMPLE_PATH     = @top_srcdir@/test
 IMAGE_PATH	 =
 QUIET            = YES
 


### PR DESCRIPTION
Makes it possible to place the build directory anywhere.

This directory does not seem in use any more; fixing it does not change
the doxygen output. However this does silence a doxygen error message
when the build directory is not in the usual place.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>