### PR TITLE
[RFC] polling for DSP to HOST IPC free before power off hpsram

### DIFF
--- a/src/drivers/intel/cavs/ipc.c
+++ b/src/drivers/intel/cavs/ipc.c
@@ -278,7 +278,7 @@ int ipc_platform_send_msg(struct ipc_msg *msg)
 	ipc_write(IPC_DIPCI, IPC_DIPCI_BUSY | msg->header);
 #else
 	ipc_write(IPC_DIPCIDD, 0);
-	ipc_write(IPC_DIPCIDR, 0x80000000 | msg->header);
+	ipc_write(IPC_DIPCIDR, IPC_DIPCIDR_BUSY | msg->header);
 #endif
 
 	platform_shared_commit(msg, sizeof(*msg));
@@ -446,7 +446,7 @@ int ipc_platform_poll_tx_host_msg(struct ipc_msg *msg)
 	ipc_write(IPC_DIPCI, IPC_DIPCI_BUSY | msg->header);
 #else
 	ipc_write(IPC_DIPCIDD, 0);
-	ipc_write(IPC_DIPCIDR, 0x80000000 | msg->header);
+	ipc_write(IPC_DIPCIDR, IPC_DIPCIDR_BUSY | msg->header);
 #endif
 
 	/* message sent */

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -302,10 +302,10 @@ int platform_boot_complete(uint32_t boot_message)
 	/* tell host we are ready */
 #if CAVS_VERSION == CAVS_VERSION_1_5
 	ipc_write(IPC_DIPCIE, SRAM_WINDOW_HOST_OFFSET(0) >> 12);
-	ipc_write(IPC_DIPCI, 0x80000000 | SOF_IPC_FW_READY);
+	ipc_write(IPC_DIPCI, IPC_DIPCI_BUSY | SOF_IPC_FW_READY);
 #else
 	ipc_write(IPC_DIPCIDD, SRAM_WINDOW_HOST_OFFSET(0) >> 12);
-	ipc_write(IPC_DIPCIDR, 0x80000000 | SOF_IPC_FW_READY);
+	ipc_write(IPC_DIPCIDR, IPC_DIPCIDR_BUSY | SOF_IPC_FW_READY);
 #endif
 	return 0;
 }


### PR DESCRIPTION
polling the IPC_DIPCIDR_BUSY to be cleared to show no IPC is sending to HOST before power off hpsram.

RFC created from discussion in https://github.com/thesofproject/linux/pull/2663