### PR TITLE
topology: sof-tgl-rt711-rt1308: align DMIC support with HDaudio

### DIFF
--- a/tools/topology/CMakeLists.txt
+++ b/tools/topology/CMakeLists.txt
@@ -94,8 +94,14 @@ set(TPLGS
 	"sof-apl-dmic\;sof-apl-dmic-2ch\;-DCHANNELS=2\;-DCPROC=volume"
 	"sof-apl-src-50khz-pcm512x\;sof-apl-src-50khz-pcm512x"
 	"sof-icl-dmic-4ch\;sof-icl-dmic-4ch"
-	"sof-icl-rt700\;sof-icl-rt700\;-DPLATFORM=icl"
-	"sof-cml-rt700\;sof-cml-rt700\;-DPLATFORM=cml"
+	# sof-icl-r700 is kept for compatibility with CI and previous versions of the kernel.
+	"sof-icl-rt700\;sof-icl-rt700\;-DCHANNELS=4\;-DPLATFORM=icl"
+	"sof-icl-rt700\;sof-icl-rt700-4ch\;-DCHANNELS=4\;-DPLATFORM=icl"
+	"sof-icl-rt700\;sof-icl-rt700-2ch\;-DCHANNELS=2\;-DPLATFORM=icl"
+	# sof-cml-r700 is kept for compatibility with CI and previous versions of the kernel.
+	"sof-cml-rt700\;sof-cml-rt700\;-DCHANNELS=4\;-DPLATFORM=cml"
+	"sof-cml-rt700\;sof-cml-rt700-4ch\;-DCHANNELS=4\;-DPLATFORM=cml"
+	"sof-cml-rt700\;sof-cml-rt700-2ch\;-DCHANNELS=2\;-DPLATFORM=cml"
 	"sof-icl-rt711-rt1308-rt715-hdmi\;sof-cml-rt711-rt1308-mono-rt715\;-DPLATFORM=cml\;-DMONO"
 	"sof-icl-rt711-rt1308-rt715-hdmi\;sof-cml-rt711-rt1308-rt715\;-DPLATFORM=cml"
 	"sof-icl-rt711-rt1308-rt715-hdmi\;sof-icl-rt711-rt1308-rt715\;-DPLATFORM=icl"

--- a/tools/topology/sof-cml-rt700.m4
+++ b/tools/topology/sof-cml-rt700.m4
@@ -2,12 +2,17 @@
 # Topology for Cometlake with rt700 codec.
 #
 
+# if XPROC is not defined, define with default pipe
+ifdef(`DMICPROC', , `define(DMICPROC, eq-iir-volume)')
+ifdef(`DMIC16KPROC', , `define(DMIC16KPROC, eq-iir-volume)')
+
 # Include topology builder
 include(`utils.m4')
 include(`dai.m4')
 include(`pipeline.m4')
 include(`alh.m4')
 include(`hda.m4')
+include(`platform/intel/dmic.m4')
 
 # Include TLV library
 include(`common/tlv.m4')
@@ -17,6 +22,23 @@ include(`sof/tokens.m4')
 
 # Include CML DSP configuration
 include(`platform/intel/cml.m4')
+
+# Define pipeline id for intel-generic-dmic.m4
+# to generate dmic setting
+
+ifelse(CHANNELS, `0', ,
+`
+define(DMIC_PCM_48k_ID, `2')
+define(DMIC_PIPELINE_48k_ID, `3')
+define(DMIC_DAI_LINK_48k_ID, `2')
+
+define(DMIC_PCM_16k_ID, `3')
+define(DMIC_PIPELINE_16k_ID, `4')
+define(DMIC_DAI_LINK_16k_ID, `3')
+
+include(`platform/intel/intel-generic-dmic.m4')
+'
+)
 
 DEBUG_START
 
@@ -51,20 +73,6 @@ PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	2, 1, 2, s24le,
 	1000, 0, 0,
 	48000, 48000, 48000)
-
-# Passthrough capture pipeline 3 on PCM 2 using max 4 channels.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
-	3, 2, 4, s32le,
-	1000, 0, 0,
-	48000, 48000, 48000)
-
-# Passthrough capture pipeline 4 on PCM 3 using max 2 channels.
-# Schedule 16 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
-	4, 3, 2, s16le,
-	1000, 0, 0,
-	16000, 16000, 16000)
 
 # Low Latency playback pipeline 5 on PCM 4 using max 2 channels of s32le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
@@ -110,20 +118,6 @@ DAI_ADD(sof/pipe-dai-capture.m4,
 	PIPELINE_SINK_2, 2, s24le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is DMIC01 using 2 periods
-# Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
-DAI_ADD(sof/pipe-dai-capture.m4,
-	3, DMIC, 0, dmic01,
-	PIPELINE_SINK_3, 2, s32le,
-	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
-
-# capture DAI is DMIC16k using 2 periods
-# Buffers use s16le format, with 16 frame per 1000us on core 0 with priority 0
-DAI_ADD(sof/pipe-dai-capture.m4,
-	4, DMIC, 1, dmic16k,
-	PIPELINE_SINK_4, 2, s16le,
-	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
-
 # playback DAI is iDisp1 using 2 periods
 # Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
@@ -149,8 +143,6 @@ DAI_ADD(sof/pipe-dai-playback.m4,
 dnl PCM_PLAYBACK_ADD(name, pcm_id, playback)
 PCM_PLAYBACK_ADD(SDW1-speakers, 0, PIPELINE_PCM_1)
 PCM_CAPTURE_ADD(SDW1-mics, 1, PIPELINE_PCM_2)
-PCM_CAPTURE_ADD(DMIC, 2, PIPELINE_PCM_3)
-PCM_CAPTURE_ADD(DMIC16kHz, 3, PIPELINE_PCM_4)
 PCM_PLAYBACK_ADD(HDMI1, 4, PIPELINE_PCM_5)
 PCM_PLAYBACK_ADD(HDMI2, 5, PIPELINE_PCM_6)
 PCM_PLAYBACK_ADD(HDMI3, 6, PIPELINE_PCM_7)
@@ -167,18 +159,6 @@ DAI_CONFIG(ALH, 0x102, 0, SDW1-Playback,
 #ALH SDW1 Pin3 (ID: 1)
 DAI_CONFIG(ALH, 0x103, 1, SDW1-Capture,
 	ALH_CONFIG(ALH_CONFIG_DATA(ALH, 0x103, 48000, 2)))
-
-# dmic01 (ID: 1)
-DAI_CONFIG(DMIC, 0, 2, dmic01,
-	   DMIC_CONFIG(1, 500000, 4800000, 40, 60, 48000,
-		DMIC_WORD_LENGTH(s32le), 400, DMIC, 0,
-		PDM_CONFIG(DMIC, 0, FOUR_CH_PDM0_PDM1)))
-
-# dmic16k (ID: 2)
-DAI_CONFIG(DMIC, 1, 3, dmic16k,
-	   DMIC_CONFIG(1, 500000, 4800000, 40, 60, 16000,
-		DMIC_WORD_LENGTH(s16le), 400, DMIC, 1,
-		PDM_CONFIG(DMIC, 1, STEREO_PDM0)))
 
 # 3 HDMI/DP outputs (ID: 4,5,6)
 DAI_CONFIG(HDA, 0, 4, iDisp1,

--- a/tools/topology/sof-icl-rt700.m4
+++ b/tools/topology/sof-icl-rt700.m4
@@ -2,12 +2,17 @@
 # Topology for Icelake with rt700 codec.
 #
 
+# if XPROC is not defined, define with default pipe
+ifdef(`DMICPROC', , `define(DMICPROC, eq-iir-volume)')
+ifdef(`DMIC16KPROC', , `define(DMIC16KPROC, eq-iir-volume)')
+
 # Include topology builder
 include(`utils.m4')
 include(`dai.m4')
 include(`pipeline.m4')
 include(`alh.m4')
 include(`hda.m4')
+include(`platform/intel/dmic.m4')
 
 # Include TLV library
 include(`common/tlv.m4')
@@ -17,6 +22,23 @@ include(`sof/tokens.m4')
 
 # Include Icelake DSP configuration
 include(`platform/intel/icl.m4')
+
+# Define pipeline id for intel-generic-dmic.m4
+# to generate dmic setting
+
+ifelse(CHANNELS, `0', ,
+`
+define(DMIC_PCM_48k_ID, `2')
+define(DMIC_PIPELINE_48k_ID, `3')
+define(DMIC_DAI_LINK_48k_ID, `2')
+
+define(DMIC_PCM_16k_ID, `3')
+define(DMIC_PIPELINE_16k_ID, `4')
+define(DMIC_DAI_LINK_16k_ID, `3')
+
+include(`platform/intel/intel-generic-dmic.m4')
+'
+)
 
 DEBUG_START
 
@@ -51,20 +73,6 @@ PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	2, 1, 2, s24le,
 	1000, 0, 0,
 	48000, 48000, 48000)
-
-# Passthrough capture pipeline 3 on PCM 2 using max 4 channels.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
-	3, 2, 4, s32le,
-	1000, 0, 0,
-	48000, 48000, 48000)
-
-# Passthrough capture pipeline 4 on PCM 3 using max 2 channels.
-# Schedule 16 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
-	4, 3, 2, s16le,
-	1000, 0, 0,
-	16000, 16000, 16000)
 
 # Low Latency playback pipeline 5 on PCM 4 using max 2 channels of s32le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
@@ -110,20 +118,6 @@ DAI_ADD(sof/pipe-dai-capture.m4,
 	PIPELINE_SINK_2, 2, s24le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# capture DAI is DMIC01 using 2 periods
-# Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
-DAI_ADD(sof/pipe-dai-capture.m4,
-	3, DMIC, 0, dmic01,
-	PIPELINE_SINK_3, 2, s32le,
-	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
-
-# capture DAI is DMIC16k using 2 periods
-# Buffers use s16le format, with 16 frame per 1000us on core 0 with priority 0
-DAI_ADD(sof/pipe-dai-capture.m4,
-	4, DMIC, 1, dmic16k,
-	PIPELINE_SINK_4, 2, s16le,
-	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
-
 # playback DAI is iDisp1 using 2 periods
 # Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
@@ -149,8 +143,6 @@ DAI_ADD(sof/pipe-dai-playback.m4,
 dnl PCM_PLAYBACK_ADD(name, pcm_id, playback)
 PCM_PLAYBACK_ADD(SDW0-speakers, 0, PIPELINE_PCM_1)
 PCM_CAPTURE_ADD(SDW0-mics, 1, PIPELINE_PCM_2)
-PCM_CAPTURE_ADD(DMIC, 2, PIPELINE_PCM_3)
-PCM_CAPTURE_ADD(DMIC16kHz, 3, PIPELINE_PCM_4)
 PCM_PLAYBACK_ADD(HDMI1, 4, PIPELINE_PCM_5)
 PCM_PLAYBACK_ADD(HDMI2, 5, PIPELINE_PCM_6)
 PCM_PLAYBACK_ADD(HDMI3, 6, PIPELINE_PCM_7)
@@ -167,18 +159,6 @@ DAI_CONFIG(ALH, 2, 0, SDW0-Playback,
 #ALH SDW0 Pin3 (ID: 1)
 DAI_CONFIG(ALH, 3, 1, SDW0-Capture,
 	ALH_CONFIG(ALH_CONFIG_DATA(ALH, 3, 48000, 2)))
-
-# dmic01 (ID: 1)
-DAI_CONFIG(DMIC, 0, 2, dmic01,
-	   DMIC_CONFIG(1, 500000, 4800000, 40, 60, 48000,
-		DMIC_WORD_LENGTH(s32le), 400, DMIC, 0,
-		PDM_CONFIG(DMIC, 0, FOUR_CH_PDM0_PDM1)))
-
-# dmic16k (ID: 2)
-DAI_CONFIG(DMIC, 1, 3, dmic16k,
-	   DMIC_CONFIG(1, 500000, 4800000, 40, 60, 16000,
-		DMIC_WORD_LENGTH(s16le), 400, DMIC, 1,
-		PDM_CONFIG(DMIC, 1, STEREO_PDM0)))
 
 # 3 HDMI/DP outputs (ID: 4,5,6)
 DAI_CONFIG(HDA, 0, 4, iDisp1,


### PR DESCRIPTION
Somehow we use different configurations for the DMIC, remove
everything in this file and rely on the same macros.

The only difference with HDaudio is the pipeline and PCM device numbers

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>