### PR TITLE
[skip ci] CODEOWNERS += /.github/

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -80,5 +80,7 @@ tools/oss-fuzz/*			@cujomalainey
 *.bash					@marc-hb
 *trace.*				@xiulipan @akloniex
 
+/.github/				@dbaluta @cujomalainey @xiulipan @lgirdwood @marc-hb
+
 # You can also use email addresses if you prefer.
 #docs/*  docs@example.com


### PR DESCRIPTION
Add CODEOWNERS for /.github/

Signed-off-by: Marc Herbert <marc.herbert@intel.com>