### PR TITLE
[skip ci] .github: rename workflow from "Github Action CI" to "Github Actions"

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -9,7 +9,10 @@
 # github.com also has a powerful web editor that can be used without
 # committing.
 
-name: GitHub Action CI
+# This is the name of this workflow and should technically be called
+# something like "Main Workflow" but the place where most people see
+# this name is the Checks window next to other, non-github checks.
+name: GitHub Actions
 
 # yamllint disable-line rule:truthy
 on:
@@ -139,7 +142,8 @@ jobs:
         run: ./scripts/docker-qemu.sh
           ../sof.git/scripts/qemu-check.sh ${PLATFORM}
 
-  yamllint-actions:
+  yamllint-gh:
+    name: yamllint /.github/workflows/
     runs-on: ubuntu-20.04
 
     steps:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Sound Open Firmware
 
 ### Status
-[![GitHub Action CI](https://github.com/thesofproject/sof/workflows/GitHub%20Action%20CI/badge.svg)](https://github.com/thesofproject/sof/actions)
+[![GitHub Actions](https://github.com/thesofproject/sof/workflows/GitHub%20Actions/badge.svg)](https://github.com/thesofproject/sof/actions)
 [![Build Status](https://travis-ci.org/thesofproject/sof.svg?branch=master)](https://travis-ci.org/thesofproject/sof/branches)
 [![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/thesofproject/community)
 [![IRC chat](https://img.shields.io/badge/IRC-%23sof-1e72ff.svg)](https://www.irccloud.com/invite?channel=%23sof&hostname=irc.freenode.net&port=6697&ssl=1)


### PR DESCRIPTION
The singular "Action" makes it look like our workflow is an action. The
plural "Github Actions" is at least the name of the product; so it's
vague enough.

A technically acccurate name would be "Main workflow" but we have only
one so it would be useless plus we're next to "Jenkins" and others and
want to stay consistent with them.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>