### PR TITLE
fix wrong usage of poll_for_register_delay in CTX_SAVE power down hpsram

### DIFF
--- a/src/platform/intel/cavs/lib/pm_runtime.c
+++ b/src/platform/intel/cavs/lib/pm_runtime.c
@@ -612,10 +612,10 @@ void platform_pm_runtime_power_off(void)
 #if CAVS_VERSION >= CAVS_VERSION_1_8
 	int ret;
 
-	/* check if DSP is busy sending IPC for 10ms */
+	/* check if DSP is busy sending IPC for 100us */
 	ret = poll_for_register_delay(IPC_HOST_BASE + IPC_DIPCIDR,
 				      IPC_DIPCIDR_BUSY, 0,
-				      10000);
+				      100);
 	/* did command succeed */
 	if (ret < 0)
 		tr_err(&power_tr, "failed to wait for DSP sent IPC handled.");

--- a/src/platform/intel/cavs/lib/pm_runtime.c
+++ b/src/platform/intel/cavs/lib/pm_runtime.c
@@ -614,7 +614,7 @@ void platform_pm_runtime_power_off(void)
 
 	/* check if DSP is busy sending IPC for 10ms */
 	ret = poll_for_register_delay(IPC_HOST_BASE + IPC_DIPCIDR,
-				      IPC_DIPCIDR_MSG_MASK, ~IPC_DIPCIDR_BUSY,
+				      IPC_DIPCIDR_BUSY, 0,
 				      10000);
 	/* did command succeed */
 	if (ret < 0)


### PR DESCRIPTION
In current kernel logs the CTX_SAVE IPC will always take more than 10ms,
but before 0b2876b2794 it only need less than 1ms. This patch fix the
wrong usage of always timeout for poll_for_register_delay.

IPC_DIPCIDR_MSG_MASK is the mask for msg from BIT 0 to 30 while
we want to check if BIT 31 is 0. now change the MASK and VAL to correct
values to make the poll and delay will return when there is no DSP sent
IPC.

Also make some optimization to timeout value:

After checking the kernel log the HOST will always handle
and replay DSP sent IPC GLB_TRACE_MSG in about 40us.

set the FW side wait timeout to 100us to improve the performance
of DSP power switch by a proper poll period.

fix some issues find in tests with https://github.com/thesofproject/sof/pull/3786

@lgirdwood Please help to check if the patch is needed for 1.7 release.