### PR TITLE
cavs: pm: change the timeout value to 2ms for HOST IPC handler

### DIFF
--- a/src/platform/intel/cavs/lib/pm_runtime.c
+++ b/src/platform/intel/cavs/lib/pm_runtime.c
@@ -612,10 +612,10 @@ void platform_pm_runtime_power_off(void)
 #if CAVS_VERSION >= CAVS_VERSION_1_8
 	int ret;
 
-	/* check if DSP is busy sending IPC for 100us */
+	/* check if DSP is busy sending IPC for 2ms */
 	ret = poll_for_register_delay(IPC_HOST_BASE + IPC_DIPCIDR,
 				      IPC_DIPCIDR_BUSY, 0,
-				      100);
+				      2000);
 	/* did command succeed */
 	if (ret < 0)
 		tr_err(&power_tr, "failed to wait for DSP sent IPC handled.");


### PR DESCRIPTION
With a recent test result:

[ 9435.941365] sof-audio-pci 0000:00:1f.3: ipc rx: 0x90020000: GLB_TRACE_MSG
[ 9435.941392] sof-audio-pci 0000:00:1f.3: ipc tx: 0x40010000: GLB_PM_MSG: CTX_SAVE
[ 9435.942023] sof-audio-pci 0000:00:1f.3: error: DSP trace buffer overflow 4294967295 bytes. Total messages -1
[ 9435.942030] sof-audio-pci 0000:00:1f.3: ipc rx done: 0x90020000: GLB_TRACE_MSG
[ 9435.942118] sof-audio-pci 0000:00:1f.3: ipc tx succeeded: 0x40010000: GLB_PM_MSG: CTX_SAVE

IF a DSP sent IPC just arrived before IPC CTX_SAVE sent, the HOST IPC
handler may be delayed anda use about 1ms. Change the timeout value
to 2ms will be safer

Signed-off-by: Pan Xiuli <xiuli.pan@linux.intel.com>