### PR TITLE
schedule: dma_multi_chan: do not skip tasks for dma_domain scheduler

### DIFF
--- a/src/include/sof/schedule/ll_schedule.h
+++ b/src/include/sof/schedule/ll_schedule.h
@@ -30,6 +30,8 @@ extern struct tr_ctx ll_tr;
 
 struct ll_task_pdata {
 	uint64_t period;
+	uint16_t ratio;		/**< ratio of periods compared to the registrable task */
+	uint16_t skip_cnt;	/**< how many times the task was skipped for execution */
 };
 
 int scheduler_init_ll(struct ll_schedule_domain *domain);

--- a/src/include/sof/schedule/ll_schedule_domain.h
+++ b/src/include/sof/schedule/ll_schedule_domain.h
@@ -50,6 +50,7 @@ struct ll_schedule_domain {
 	int type;			/**< domain type */
 	int clk;			/**< source clock */
 	bool synchronous;		/**< are tasks should be synchronous */
+	bool full_sync;			/**< tasks should be full synchronous, no time dependent */
 	void *priv_data;		/**< pointer to private data */
 	bool registered[CONFIG_CORE_COUNT];		/**< registered cores */
 	bool enabled[CONFIG_CORE_COUNT];		/**< enabled cores */
@@ -80,6 +81,7 @@ static inline struct ll_schedule_domain *domain_init
 	domain->type = type;
 	domain->clk = clk;
 	domain->synchronous = synchronous;
+	domain->full_sync = false;
 	domain->ticks_per_ms = clock_ms_to_ticks(clk, 1);
 	domain->ops = ops;
 

--- a/src/include/sof/schedule/task.h
+++ b/src/include/sof/schedule/task.h
@@ -31,6 +31,9 @@ struct sof;
 #define SOF_TASK_DEADLINE_ALMOST_IDLE	(SOF_TASK_DEADLINE_IDLE - 1)
 #define SOF_TASK_DEADLINE_NOW		0
 
+/** \brief Task counter initial value. */
+#define SOF_TASK_SKIP_COUNT		0xFFFFu
+
 /** \brief Task states. */
 enum task_state {
 	SOF_TASK_STATE_INIT = 0,

--- a/src/platform/imx8/platform.c
+++ b/src/platform/imx8/platform.c
@@ -176,6 +176,9 @@ int platform_init(struct sof *sof)
 	sof->platform_dma_domain = dma_multi_chan_domain_init
 			(&sof->dma_info->dma_array[0], 1,
 			 PLATFORM_DEFAULT_CLOCK, false);
+
+	/* i.MX platform DMA domain will be full synchronous, no time dependent */
+	sof->platform_dma_domain->full_sync = true;
 	scheduler_init_ll(sof->platform_dma_domain);
 
 	/* initialize the host IPC mechanims */

--- a/src/platform/imx8m/platform.c
+++ b/src/platform/imx8m/platform.c
@@ -175,6 +175,9 @@ int platform_init(struct sof *sof)
 	sof->platform_dma_domain =
 		dma_multi_chan_domain_init(&sof->dma_info->dma_array[1],
 					   1, PLATFORM_DEFAULT_CLOCK, true);
+
+	/* i.MX platform DMA domain will be full synchronous, no time dependent */
+	sof->platform_dma_domain->full_sync = true;
 	scheduler_init_ll(sof->platform_dma_domain);
 
 	/* initialize the host IPC mechanims */

--- a/src/schedule/dma_multi_chan_domain.c
+++ b/src/schedule/dma_multi_chan_domain.c
@@ -280,6 +280,7 @@ static bool dma_multi_chan_domain_is_pending(struct ll_schedule_domain *domain,
 	struct dma_domain *dma_domain = ll_sch_domain_get_pdata(domain);
 	struct pipeline_task *pipe_task = pipeline_task_get(task);
 	struct dma *dmas = dma_domain->dma_array;
+	struct ll_task_pdata *pdata;
 	uint32_t status;
 	int i;
 	int j;
@@ -303,11 +304,29 @@ static bool dma_multi_chan_domain_is_pending(struct ll_schedule_domain *domain,
 			    pipe_task->sched_comp)
 				continue;
 
-			/* it's too soon for this task */
-			if (!pipe_task->registrable &&
-			    pipe_task->task.start >
-			    platform_timer_get_atomic(timer_get()))
-				continue;
+			/* Schedule task based on the frequency they
+			 * were configured with, not time (task.start)
+			 *
+			 * There are cases when a DMA transfer from a DAI
+			 * is finished earlier than task.start and,
+			 * without full_sync mode, this task will not
+			 * be scheduled
+			 */
+			if (domain->full_sync) {
+				pdata = ll_sch_get_pdata(&pipe_task->task);
+				pdata->skip_cnt++;
+				if (pdata->skip_cnt == pdata->ratio)
+					pdata->skip_cnt = 0;
+
+				if (pdata->skip_cnt != 0)
+					continue;
+			} else {
+				/* it's too soon for this task */
+				if (!pipe_task->registrable &&
+				    pipe_task->task.start >
+				    platform_timer_get_atomic(timer_get()))
+					continue;
+			}
 
 			notifier_event(&dmas[i].chan[j], NOTIFIER_ID_DMA_IRQ,
 				       NOTIFIER_TARGET_CORE_LOCAL,

--- a/src/schedule/ll_schedule.c
+++ b/src/schedule/ll_schedule.c
@@ -324,8 +324,11 @@ static int schedule_ll_task(void *data, struct task *task, uint64_t start,
 {
 	struct ll_schedule_data *sch = data;
 	struct ll_task_pdata *pdata;
+	struct ll_task_pdata *reg_pdata;
 	struct list_item *tlist;
 	struct task *curr_task;
+	struct task *registrable_task = NULL;
+	struct pipeline_task *pipe_task;
 	uint32_t flags;
 	int ret = 0;
 
@@ -352,6 +355,47 @@ static int schedule_ll_task(void *data, struct task *task, uint64_t start,
 			task->priority, task->flags, UINT_MAX);
 
 	pdata->period = period;
+
+	/* for full synchronous domain, calculate ratio and initialize skip_cnt for task */
+	if (sch->domain->full_sync) {
+		pdata->ratio = 1;
+		pdata->skip_cnt = (uint16_t)SOF_TASK_SKIP_COUNT;
+
+		/* get the registrable task */
+		list_for_item(tlist, &sch->tasks) {
+			curr_task = container_of(tlist, struct task, list);
+			pipe_task = pipeline_task_get(curr_task);
+
+			/* registrable task found */
+			if (pipe_task->registrable) {
+				registrable_task = curr_task;
+				break;
+			}
+		}
+
+		/* we found a registrable task */
+		if (registrable_task) {
+			reg_pdata = ll_sch_get_pdata(registrable_task);
+
+			/* update ratio for all tasks */
+			list_for_item(tlist, &sch->tasks) {
+				curr_task = container_of(tlist, struct task, list);
+				pdata = ll_sch_get_pdata(curr_task);
+
+				/* the assumption is that the registrable
+				 * task has the smallest period
+				 */
+				if (pdata->period >= reg_pdata->period) {
+					pdata->ratio = period / reg_pdata->period;
+				} else {
+					tr_err(&ll_tr,
+					       "schedule_ll_task(): registrable task has a period longer than current task");
+					ret = -EINVAL;
+					goto out;
+				}
+			}
+		}
+	}
 
 	/* insert task into the list */
 	schedule_ll_task_insert(task, &sch->tasks);


### PR DESCRIPTION
Add a full_sync attribute to ll_schdule domain.
This is set to true, for a full synchronous dma_domain
scheduler, which is not time dependent.
By default, it is false.

In full_sync case we use the ratio between the task period
and the registrable task period to do the scheduling, not
the task.start time.

We do this because for the DMA_DOMAIN there are no guarantees
for the accuracy of the period of the registrable task
which drives the entire scheduling.

The second commit sets the full_sync attribute to true for imx platforms.

Fixes: #3802