### PR TITLE
lib: Add __vec_memcpy / __vec_memset

### DIFF
--- a/src/arch/host/include/arch/string.h
+++ b/src/arch/host/include/arch/string.h
@@ -28,6 +28,9 @@ int memset_s(void *dest, size_t dest_size,
 int memcpy_s(void *dest, size_t dest_size,
 	     const void *src, size_t src_size);
 
+void *__vec_memcpy(void *dst, const void *src, size_t len);
+void *__vec_memset(void *dest, int data, size_t src_size);
+
 static inline int arch_memcpy_s(void *dest, size_t dest_size,
 				const void *src, size_t src_size)
 {

--- a/src/arch/xtensa/include/arch/string.h
+++ b/src/arch/xtensa/include/arch/string.h
@@ -36,10 +36,8 @@ int memset_s(void *dest, size_t dest_size,
 int memcpy_s(void *dest, size_t dest_size,
 	     const void *src, size_t src_size);
 
-#if __XCC__ && XCHAL_HAVE_HIFI3 && !CONFIG_LIBRARY
 void *__vec_memcpy(void *dst, const void *src, size_t len);
 void *__vec_memset(void *dest, int data, size_t src_size);
-#endif
 
 static inline int arch_memcpy_s(void *dest, size_t dest_size,
 				const void *src, size_t src_size)

--- a/src/lib/lib.c
+++ b/src/lib/lib.c
@@ -43,6 +43,18 @@ int memset_s(void *dest, size_t dest_size, int data, size_t count)
 	return arch_memset_s(dest, dest_size, data, count);
 }
 
+#if !__XCC || !XCHAL_HAVE_HIFI3 || !CONFIG_LIBRARY
+void *__vec_memcpy(void *dst, const void *src, size_t len)
+{
+	return memcpy(dst, src, len);
+}
+
+void *__vec_memset(void *dest, int data, size_t src_size)
+{
+	return memset(dest, data, src_size);
+}
+#endif
+
 #if !CONFIG_LIBRARY && !__ZEPHYR__
 int memcmp(const void *p, const void *q, size_t count)
 {


### PR DESCRIPTION
3rd party libraries need __vec_memcpy / __vec_memset
which are not provided by xtensa gcc.

Add open coded versions of these functions by using
memcpy and memset.

Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>