### PR TITLE
RFC: codec: cadence: Add codec API functions symbols

### DIFF
--- a/src/audio/codec_adapter/Kconfig
+++ b/src/audio/codec_adapter/Kconfig
@@ -11,6 +11,16 @@ menu "Codec Adapter codecs"
 		  This will cause codec adapter component to include header
 		  files specific to CADENCE base codecs.
 
+if CADENCE_CODEC
+	config CADENCE_CODEC_WRAPPER
+		bool 'Cadence codec wrapper'
+		default n
+		help
+		  Select for cadence_codec_api wrapper function that will allow
+		  users to call into codecs which conforms to the Cadence API without
+		  explicitly knowing/using the entry function symbol name.
+endif
+
 	config DUMMY_CODEC
 		bool "Dummy codec"
 		default n

--- a/src/audio/codec_adapter/Kconfig
+++ b/src/audio/codec_adapter/Kconfig
@@ -19,6 +19,48 @@ if CADENCE_CODEC
 		  Select for cadence_codec_api wrapper function that will allow
 		  users to call into codecs which conforms to the Cadence API without
 		  explicitly knowing/using the entry function symbol name.
+	config CADENCE_CODEC_AAC_DEC
+		bool "Cadence AAC decoder"
+		default n
+		help
+		  Select for Cadence AAC decoder support.
+		  This will cause Cadence codec to include Cadence AAC library
+		  api symbol.
+	config CADENCE_CODEC_BSAC_DEC
+		bool "Cadence BSAC decoder"
+		default n
+		help
+		  Select for Cadence BSAC decoder support.
+		  This will cause Cadence codec to include Cadence BSAC library
+		  api symbol.
+	config CADENCE_CODEC_DAB_DEC
+		bool "Cadence DAB decoder"
+		default n
+		help
+		  Select for Cadence DAB decoder support.
+		  This will cause Cadence codec to include Cadence DAB library
+		  api symbol.
+	config CADENCE_CODEC_DRM_DEC
+		bool "Cadence DRM decoder"
+		default n
+		help
+		  Select for Cadence DRM decoder support.
+		  This will cause Cadence codec to include Cadence DRM library
+		  api symbol.
+	config CADENCE_CODEC_MP3_DEC
+		bool "Cadence MP3 decoder"
+		default n
+		help
+		  Select for Cadence MP3 decoder support.
+		  This will cause Cadence codec to include Cadence MP3 library
+		  api symbol.
+	config CADENCE_CODEC_SBC_DEC
+		bool "Cadence SBC decoder"
+		default n
+		help
+		  Select for Cadence SBC decoder support.
+		  This will cause Cadence codec to include Cadence SBC library
+		  api symbol.
 endif
 
 	config DUMMY_CODEC

--- a/src/audio/codec_adapter/codec/cadence.c
+++ b/src/audio/codec_adapter/codec/cadence.c
@@ -24,6 +24,42 @@ static struct cadence_api cadence_api_table[] = {
 		.api = cadence_api_function
 	},
 #endif
+#ifdef CONFIG_CADENCE_CODEC_AAC_DEC
+	{
+		.id = 0x02,
+		.api = xa_aac_dec,
+	},
+#endif
+#ifdef CONFIG_CADENCE_CODEC_BSAC_DEC
+	{
+		.id = 0x03,
+		.api = xa_bsac_dec,
+	},
+#endif
+#ifdef CONFIG_CADENCE_CODEC_DAB_DEC
+	{
+		.id = 0x04,
+		.api = xa_dabplus_dec,
+	},
+#endif
+#ifdef CONFIG_CADENCE_CODEC_DRM_DEC
+	{
+		.id = 0x05,
+		.api = xa_drm_dec,
+	},
+#endif
+#ifdef CONFIG_CADENCE_CODEC_MP3_DEC
+	{
+		.id = 0x06,
+		.api = xa_mp3_dec,
+	},
+#endif
+#ifdef CONFIG_CADENCE_CODEC_SBC_DEC
+	{
+		.id = 0x07,
+		.api = xa_sbc_dec,
+	},
+#endif
 };
 
 int cadence_codec_init(struct comp_dev *dev)

--- a/src/audio/codec_adapter/codec/cadence.c
+++ b/src/audio/codec_adapter/codec/cadence.c
@@ -18,10 +18,12 @@
 /* Cadence API functions array						     */
 /*****************************************************************************/
 static struct cadence_api cadence_api_table[] = {
+#ifdef CONFIG_CADENCE_CODEC_WRAPPER
 	{
 		.id = 0x01,
 		.api = cadence_api_function
 	},
+#endif
 };
 
 int cadence_codec_init(struct comp_dev *dev)

--- a/src/include/sof/audio/codec_adapter/codec/cadence.h
+++ b/src/include/sof/audio/codec_adapter/codec/cadence.h
@@ -20,6 +20,12 @@
 /* Cadence API functions							     */
 /*****************************************************************************/
 extern xa_codec_func_t cadence_api_function;
+extern xa_codec_func_t xa_aac_dec;
+extern xa_codec_func_t xa_bsac_dec;
+extern xa_codec_func_t xa_dabplus_dec;
+extern xa_codec_func_t xa_drm_dec;
+extern xa_codec_func_t xa_mp3_dec;
+extern xa_codec_func_t xa_sbc_dec;
 
 /*****************************************************************************/
 /* Cadence private data types						     */


### PR DESCRIPTION
Cadence library comes with various codecs. In order to support one
codec we need to initialize the API member of cadence_api with exported
library function.

This patch adds Cadence exported functions for aac, bsac, dabplus, drm
and mp3 codecs.

Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>