### PR TITLE
topology: tgl-sdw-max98373: Add UUID for Maxim DSM component

### DIFF
--- a/tools/topology/sof-tgl-sdw-max98373-rt5682.m4
+++ b/tools/topology/sof-tgl-sdw-max98373-rt5682.m4
@@ -70,6 +70,13 @@ define(`SMART_REF_CH_NUM', 2)
 define(`SMART_PCM_ID', 2)
 define(`SMART_PCM_NAME', `smart373-spk')
 
+# Maxim DSM UUID
+DECLARE_SOF_RT_UUID("Maxim DSM", maxim_dsm_comp_uuid, 0x0cd84e80, 0xebd3,
+                    0x11ea, 0xad, 0xc1, 0x02, 0x42, 0xac, 0x12, 0x00, 0x02);
+
+# comment out the following to fallback on smart_amp-test
+define(`SMART_UUID', maxim_dsm_comp_uuid)
+
 # Include Smart Amplifier support
 include(`sof-smart-amplifier.m4')
 


### PR DESCRIPTION
Add UUID for Maxim DSM component, define SMART_UUID to use MAXIM_DSM.

Signed-off-by: Yong Zhi <yong.zhi@intel.com>