### PR TITLE
smart_amp_test: check if feedback_buf exists before accessing it

### DIFF
--- a/src/samples/audio/smart_amp_test.c
+++ b/src/samples/audio/smart_amp_test.c
@@ -315,7 +315,8 @@ static int smart_amp_trigger(struct comp_dev *dev, int cmd)
 	switch (cmd) {
 	case COMP_TRIGGER_START:
 	case COMP_TRIGGER_RELEASE:
-		buffer_zero(sad->feedback_buf);
+		if (sad->feedback_buf)
+			buffer_zero(sad->feedback_buf);
 		break;
 	case COMP_TRIGGER_PAUSE:
 	case COMP_TRIGGER_STOP:
@@ -437,31 +438,34 @@ static int smart_amp_copy(struct comp_dev *dev)
 
 	avail_frames = avail_passthrough_frames;
 
-	buffer_lock(sad->feedback_buf, &feedback_flags);
-	if (comp_get_state(dev, sad->feedback_buf->source) == dev->state) {
-		/* feedback */
-		avail_feedback_frames = audio_stream_get_avail_frames(&sad->feedback_buf->stream);
+	if (sad->feedback_buf) {
+		buffer_lock(sad->feedback_buf, &feedback_flags);
+		if (comp_get_state(dev, sad->feedback_buf->source) == dev->state) {
+			/* feedback */
+			avail_feedback_frames =
+				audio_stream_get_avail_frames(&sad->feedback_buf->stream);
 
-		avail_frames = MIN(avail_passthrough_frames,
-				   avail_feedback_frames);
+			avail_frames = MIN(avail_passthrough_frames,
+					   avail_feedback_frames);
 
-		feedback_bytes = avail_frames *
-			audio_stream_frame_bytes(&sad->feedback_buf->stream);
+			feedback_bytes = avail_frames *
+				audio_stream_frame_bytes(&sad->feedback_buf->stream);
 
-		buffer_unlock(sad->feedback_buf, feedback_flags);
+			buffer_unlock(sad->feedback_buf, feedback_flags);
 
-		comp_dbg(dev, "smart_amp_copy(): processing %d feedback frames (avail_passthrough_frames: %d)",
-			 avail_frames, avail_passthrough_frames);
+			comp_dbg(dev, "smart_amp_copy(): processing %d feedback frames (avail_passthrough_frames: %d)",
+				 avail_frames, avail_passthrough_frames);
 
-		/* perform buffer writeback after source_buf process */
-		buffer_invalidate(sad->feedback_buf, feedback_bytes);
-		sad->process(dev, &sad->feedback_buf->stream,
-			     &sad->sink_buf->stream, avail_frames,
-			     sad->config.feedback_ch_map);
+			/* perform buffer writeback after source_buf process */
+			buffer_invalidate(sad->feedback_buf, feedback_bytes);
+			sad->process(dev, &sad->feedback_buf->stream,
+				     &sad->sink_buf->stream, avail_frames,
+				     sad->config.feedback_ch_map);
 
-		comp_update_buffer_consume(sad->feedback_buf, feedback_bytes);
-	} else {
-		buffer_unlock(sad->feedback_buf, feedback_flags);
+			comp_update_buffer_consume(sad->feedback_buf, feedback_bytes);
+		} else {
+			buffer_unlock(sad->feedback_buf, feedback_flags);
+		}
 	}
 
 	/* bytes calculation */
@@ -532,10 +536,12 @@ static int smart_amp_prepare(struct comp_dev *dev)
 	sad->in_channels = sad->source_buf->stream.channels;
 	sad->out_channels = sad->sink_buf->stream.channels;
 
-	buffer_lock(sad->feedback_buf, &flags);
-	sad->feedback_buf->stream.channels = sad->config.feedback_channels;
-	sad->feedback_buf->stream.rate = sad->source_buf->stream.rate;
-	buffer_unlock(sad->feedback_buf, flags);
+	if (sad->feedback_buf) {
+		buffer_lock(sad->feedback_buf, &flags);
+		sad->feedback_buf->stream.channels = sad->config.feedback_channels;
+		sad->feedback_buf->stream.rate = sad->source_buf->stream.rate;
+		buffer_unlock(sad->feedback_buf, flags);
+	}
 
 	sad->process = get_smart_amp_process(dev);
 	if (!sad->process) {


### PR DESCRIPTION
With dynamic pipelines, the widgets in the feedback path are set
up only when the capture PCM is opened. Check if the
feedback_buf exists before accessing it to prevent DSP panic
when only the playback pipeline is open.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>