### PR TITLE
topology: sof-tgl-nocodec-ci: use 38.4MHz MCLK

### DIFF
--- a/tools/topology/development/sof-tgl-nocodec-ci.m4
+++ b/tools/topology/development/sof-tgl-nocodec-ci.m4
@@ -84,6 +84,8 @@ define(`SMART_SSP_NAME', `NoCodec-2')
 define(`SMART_BE_ID', 2)
 #define SSP QUIRK
 define(`SMART_SSP_QUIRK', `SSP_QUIRK_LBM')
+#define SSP_MCLK
+define(`SSP_MCLK', 38400000)
 
 # Playback related
 define(`SMART_PB_PPL_ID', 5)


### PR DESCRIPTION
Define to use 38.4MHz MCLK for DSM, to align with other SSP ports.

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>