### PR TITLE
[skip ci] oss-fuzz/cmake: provide an error message when $ENV{OUT} is missing

### DIFF
--- a/tools/oss-fuzz/CMakeLists.txt
+++ b/tools/oss-fuzz/CMakeLists.txt
@@ -57,6 +57,11 @@ add_dependencies(sof_library sof_ep)
 target_link_libraries(fuzz_ipc PRIVATE sof_library)
 target_include_directories(fuzz_ipc PRIVATE ${sof_install_directory}/include)
 target_link_options(fuzz_ipc PUBLIC $ENV{LIB_FUZZING_ENGINE})
+if(NOT DEFINED ENV{OUT})
+message(FATAL_ERROR
+	"Missing $OUT environment variable, try: OUT=... cmake ..."
+)
+endif()
 set_target_properties(fuzz_ipc PROPERTIES RUNTIME_OUTPUT_DIRECTORY $ENV{OUT})
 
 set_target_properties(fuzz_ipc


### PR DESCRIPTION
... instead of:
```
  set_target_properties called with incorrect number of arguments
```
A little bit of user-friendliness goes a long way.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>