### PR TITLE
timer_domain: set last_tick to ticks_req in order to avoid drift

### DIFF
--- a/src/schedule/timer_domain.c
+++ b/src/schedule/timer_domain.c
@@ -283,7 +283,7 @@ static void timer_domain_set(struct ll_schedule_domain *domain, uint64_t start)
 		timer_report_delay(timer_domain->timer->id,
 				   ticks_set - ticks_req);
 
-	domain->last_tick = ticks_set;
+	domain->last_tick = ticks_req;
 
 	platform_shared_commit(timer_domain, sizeof(*timer_domain));
 }


### PR DESCRIPTION
In the case of scheduling irregularities the drift may accumulate in the
scheduling reference value. By ensuring we always refer to the previous
requested time the drift can be prevented.

Signed-off-by: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>
Signed-off-by: Slawomir Blauciak <slawomir.blauciak@linux.intel.com>