### PR TITLE
xtensa-build-all.sh: add PATH to build log

### DIFF
--- a/scripts/xtensa-build-all.sh
+++ b/scripts/xtensa-build-all.sh
@@ -40,7 +40,7 @@ usage: $0 [options] platform(s)
        -u Force UP ARCH
        -d Enable debug build
        -c Interactive menuconfig
-       -o copies the file argument from src/arch/xtensa/configs/override/$arg.config
+       -o arg, copies src/arch/xtensa/configs/override/<arg>.config
 	  to the build directory after invoking CMake and before Make.
        -k Configure rimage to use a non-default \${RIMAGE_PRIVATE_KEY}
            DEPRECATED: use the more flexible \${PRIVATE_KEY_OPTION} below.
@@ -347,6 +347,7 @@ do
 	mkdir "$BUILD_DIR"
 	cd "$BUILD_DIR"
 
+	printf 'PATH=%s\n' "$PATH"
 	( set -x # log the main commands and their parameters
 	cmake -DTOOLCHAIN="$TOOLCHAIN" \
 		-DROOT_DIR="$ROOT" \


### PR DESCRIPTION
The script already logs the full CMake command that is re-usable outside
this script... except for the PATH change. Expose that sneaky PATH
change.

Debugging every build issue starts with peeling the too many layers of
indirection.

Also fix some minor issue in the help message.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>