### PR TITLE
oss-fuzz: add error for incorrect build env and readme

### DIFF
--- a/tools/oss-fuzz/CMakeLists.txt
+++ b/tools/oss-fuzz/CMakeLists.txt
@@ -25,6 +25,10 @@ target_link_libraries(fuzz_ipc PRIVATE -ldl -lm)
 
 install(TARGETS fuzz_ipc DESTINATION bin)
 
+if(NOT DEFINED ENV{OUT})
+	message(FATAL_ERROR
+		"Missing key env vars, please only build with oss-fuzz, see README in tools/oss-fuzz")
+endif()
 
 include(ExternalProject)
 

--- a/tools/oss-fuzz/README.md
+++ b/tools/oss-fuzz/README.md
@@ -1,0 +1,7 @@
+# SOF OSS-Fuzz Shim
+
+## Build Steps
+See https://google.github.io/oss-fuzz/getting-started/new-project-guide/#testing-locally
+
+## TODOs
+Add all components to build to be part of fuzzing space, currently components are not part of library build


### PR DESCRIPTION
add proper build instructions

Signed-off-by: Curtis Malainey <cujomalainey@chromium.org>