### PR TITLE
topology: Add sof-byt-wm5102-ssp0 topology file

### DIFF
--- a/tools/topology/CMakeLists.txt
+++ b/tools/topology/CMakeLists.txt
@@ -56,6 +56,7 @@ set(TPLGS
 	"sof-byt-codec\;sof-byt-da7213-ssp0\;-DCODEC=DA7213\;-DPLATFORM=byt-codec\;-DSSP_NUM=0"
 	"sof-byt-codec\;sof-byt-cx2072x-ssp0\;-DCODEC=CX2072X\;-DPLATFORM=byt-codec\;-DSSP_NUM=0"
 	"sof-byt-codec\;sof-byt-es8316-ssp0\;-DCODEC=ES8316\;-DPLATFORM=byt-codec\;-DSSP_NUM=0"
+	"sof-byt-codec\;sof-byt-wm5102-ssp0\;-DCODEC=WM5102\;-DPLATFORM=byt-codec\;-DSSP_NUM=0"
 	"sof-byt-codec\;sof-cht-rt5640\;-DCODEC=RT5640\;-DPLATFORM=cht-codec\;-DSSP_NUM=2"
 	"sof-byt-codec\;sof-cht-rt5645\;-DCODEC=RT5645\;-DPLATFORM=cht-codec\;-DSSP_NUM=2"
 	"sof-byt-codec\;sof-cht-rt5651\;-DCODEC=RT5651\;-DPLATFORM=cht-codec\;-DSSP_NUM=2"


### PR DESCRIPTION
Add a topology file for Bay Trail boards with a WM5102 codec
connected to SSP0.

These setups works with the standard settings from sof-byt-codec.m4.

This has been tested on a Lenovo Yoga Tablet 2 1015L.

Signed-off-by: Hans de Goede <hdegoede@redhat.com>

Note this also should be chery-picked as a fix into the stable-v1.7 branch.