### PR TITLE
Zephyr integration changes

### DIFF
--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -521,8 +521,8 @@ static int kpb_prepare(struct comp_dev *dev)
 	}
 
 	if (!kpb->sel_sink || !kpb->host_sink) {
-		comp_info(dev, "kpb_prepare(): could not find sinks: sel_sink %d host_sink %d",
-			  (uintptr_t)kpb->sel_sink, (uintptr_t)kpb->host_sink);
+		comp_info(dev, "kpb_prepare(): could not find sinks: sel_sink %p host_sink %p",
+			  kpb->sel_sink, kpb->host_sink);
 		ret = -EIO;
 	}
 

--- a/src/include/sof/trace/trace.h
+++ b/src/include/sof/trace/trace.h
@@ -296,7 +296,7 @@ struct tr_ctx {
 	uint32_t level;				/**< Default log level */
 };
 
-#if defined(UNIT_TEST)
+#if defined(UNIT_TEST) || defined(__ZEPHYR__)
 #define TRACE_CONTEXT_SECTION
 #else
 #define TRACE_CONTEXT_SECTION __section(".trace_ctx")

--- a/src/trace/trace.c
+++ b/src/trace/trace.c
@@ -139,7 +139,7 @@ static void emit_recent_entry(struct recent_log_entry *entry)
 	_log_message(trace_log_unfiltered, false, LOG_LEVEL_INFO, _TRACE_INV_CLASS, &dt_tr,
 		     _TRACE_INV_ID, _TRACE_INV_ID, "Suppressed %u similar messages: %pQ",
 		     entry->trigger_count - CONFIG_TRACE_BURST_COUNT,
-		     entry->entry_id);
+		     (void *)entry->entry_id);
 
 	memset(entry, 0, sizeof(*entry));
 }

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -53,7 +53,7 @@ set(SOF_TRACE_PATH "${SOF_SRC_PATH}/trace")
 
 # Save path to rimage configuration files in cmake cache for later use by
 # rimage during the "west sign" stage
-get_filename_component(RIMAGE_CONFIG "ext/rimage/config" ABSOLUTE)
+get_filename_component(RIMAGE_CONFIG "../rimage/config" ABSOLUTE)
 set(RIMAGE_CONFIG_PATH ${RIMAGE_CONFIG} CACHE PATH
     " Path to rimage board configuration files")
 

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -1,0 +1,3 @@
+if SOF
+rsource "../Kconfig"
+endif

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,2 +1,3 @@
 build:
-        cmake: ./zephyr
+  cmake: ./zephyr
+  kconfig: ./zephyr/Kconfig


### PR DESCRIPTION
- Reference local Kconfig to avoid inclusion of SOF Kconfig when SOF is not enabled from Zephyr
- Fix few formatting issues resulting in warning
- Revert reference to local copy of rimage which is now removed.