### PR TITLE
Topology: Get PGA_NAME from pipeline caller macro

### DIFF
--- a/tools/topology/platform/intel/intel-generic-dmic-kwd.m4
+++ b/tools/topology/platform/intel/intel-generic-dmic-kwd.m4
@@ -57,9 +57,17 @@ dnl     time_domain, sched_comp)
 # Passthrough capture pipeline using max channels defined by CHANNELS.
 
 # Set 1000us deadline on core 0 with priority 0
+ifdef(`DMICPROC_FILTER1', `define(PIPELINE_FILTER1, DMICPROC_FILTER1)', `undefine(`PIPELINE_FILTER1')')
+ifdef(`DMICPROC_FILTER2', `define(PIPELINE_FILTER2, DMICPROC_FILTER2)', `undefine(`PIPELINE_FILTER2')')
+define(`PGA_NAME', Dmic0)
+
 PIPELINE_PCM_ADD(sof/pipe-`DMICPROC'-capture.m4,
         DMIC_PIPELINE_48k_ID, DMIC_PCM_48k_ID, CHANNELS, s32le,
         1000, 0, 0, 48000, 48000, 48000)
+
+undefine(`PGA_NAME')
+undefine(`PIPELINE_FILTER1')
+undefine(`PIPELINE_FILTER2')
 
 #
 # KWD configuration

--- a/tools/topology/platform/intel/intel-generic-dmic.m4
+++ b/tools/topology/platform/intel/intel-generic-dmic.m4
@@ -75,11 +75,13 @@ dnl     time_domain, sched_comp)
 # Set 1000us deadline on core 0 with priority 0
 ifdef(`DMICPROC_FILTER1', `define(PIPELINE_FILTER1, DMICPROC_FILTER1)', `undefine(`PIPELINE_FILTER1')')
 ifdef(`DMICPROC_FILTER2', `define(PIPELINE_FILTER2, DMICPROC_FILTER2)', `undefine(`PIPELINE_FILTER2')')
+define(`PGA_NAME', Dmic0)
 
 PIPELINE_PCM_ADD(sof/pipe-DMICPROC-capture.m4,
 	DMIC_PIPELINE_48k_ID, DMIC_PCM_48k_ID, DMIC_PCM_CHANNELS, s32le,
 	1000, 0, 0, 48000, 48000, 48000)
 
+undefine(`PGA_NAME')
 undefine(`PIPELINE_FILTER1')
 undefine(`PIPELINE_FILTER2')
 
@@ -88,11 +90,13 @@ undefine(`PIPELINE_FILTER2')
 # Schedule with 1000us deadline on core 0 with priority 0
 ifdef(`DMIC16KPROC_FILTER1', `define(PIPELINE_FILTER1, DMIC16KPROC_FILTER1)', `undefine(`PIPELINE_FILTER1')')
 ifdef(`DMIC16KPROC_FILTER2', `define(PIPELINE_FILTER2, DMIC16KPROC_FILTER2)', `undefine(`PIPELINE_FILTER2')')
+define(`PGA_NAME', Dmic1)
 
 PIPELINE_PCM_ADD(sof/pipe-DMIC16KPROC-capture-16khz.m4,
 	DMIC_PIPELINE_16k_ID, DMIC_PCM_16k_ID, DMIC16K_PCM_CHANNELS, s32le,
 	1000, 0, 0, 16000, 16000, 16000)
 
+undefine(`PGA_NAME')
 undefine(`PIPELINE_FILTER1')
 undefine(`PIPELINE_FILTER2')
 

--- a/tools/topology/sof-cml-rt5682.m4
+++ b/tools/topology/sof-cml-rt5682.m4
@@ -60,10 +60,18 @@ PIPELINE_PCM_ADD(sof/pipe-`HSMICPROC'-capture.m4,
 
 # Passthrough capture pipeline 3 on PCM 1 using max 4 channels.
 # 1000us deadline on core 0 with priority 0
+ifdef(`DMICPROC_FILTER1', `define(PIPELINE_FILTER1, DMICPROC_FILTER1)', `undefine(`PIPELINE_FILTER1')')
+ifdef(`DMICPROC_FILTER2', `define(PIPELINE_FILTER2, DMICPROC_FILTER2)', `undefine(`PIPELINE_FILTER2')')
+define(`PGA_NAME', Dmic0)
+
 PIPELINE_PCM_ADD(sof/pipe-`DMICPROC'-capture.m4,
 	3, 1, 4, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
+
+undefine(`PGA_NAME')
+undefine(`PIPELINE_FILTER1')
+undefine(`PIPELINE_FILTER2')
 
 # Low Latency playback pipeline 4 on PCM 2 using max 2 channels of s32le.
 # 1000us deadline on core 0 with priority 0
@@ -88,10 +96,18 @@ PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 
 # Passthrough capture pipeline 7 on PCM 5 using max 2 channels.
 # Schedule 1000us deadline on core 0 with priority 0
+ifdef(`DMIC16KPROC_FILTER1', `define(PIPELINE_FILTER1, DMIC16KPROC_FILTER1)', `undefine(`PIPELINE_FILTER1')')
+ifdef(`DMIC16KPROC_FILTER2', `define(PIPELINE_FILTER2, DMIC16KPROC_FILTER2)', `undefine(`PIPELINE_FILTER2')')
+define(`PGA_NAME', Dmic1)
+
 PIPELINE_PCM_ADD(sof/pipe-`DMIC16KPROC'-capture-16khz.m4,
 	8, 8, 2, s24le,
 	1000, 0, 0,
 	16000, 16000, 16000)
+
+undefine(`PGA_NAME')
+undefine(`PIPELINE_FILTER1')
+undefine(`PIPELINE_FILTER2')
 
 #
 # DAIs configuration

--- a/tools/topology/sof/pipe-eq-iir-volume-capture-16khz.m4
+++ b/tools/topology/sof/pipe-eq-iir-volume-capture-16khz.m4
@@ -15,7 +15,7 @@ include(`bytecontrol.m4')
 include(`eq_iir.m4')
 
 define(`CONTROL_NAME', 2nd Capture Volume)
-define(`PGA_NAME', Dmic1)
+ifdef(`PGA_NAME', `', `define(PGA_NAME, N_PGA(0))')
 
 #
 # Controls

--- a/tools/topology/sof/pipe-eq-iir-volume-capture.m4
+++ b/tools/topology/sof/pipe-eq-iir-volume-capture.m4
@@ -15,7 +15,7 @@ include(`bytecontrol.m4')
 include(`mixercontrol.m4')
 include(`eq_iir.m4')
 
-define(`PGA_NAME', Dmic0)
+ifdef(`PGA_NAME', `', `define(PGA_NAME, N_PGA(0))')
 define(`CONTROL_NAME_VOLUME', Capture Volume)
 define(`CONTROL_NAME_SWITCH', Capture Switch)
 define(`CONTROL_NAME', `CONTROL_NAME_VOLUME')

--- a/tools/topology/sof/pipe-tdfb-eq-iir-volume-capture-16khz.m4
+++ b/tools/topology/sof/pipe-tdfb-eq-iir-volume-capture-16khz.m4
@@ -16,7 +16,7 @@ include(`mixercontrol.m4')
 include(`tdfb.m4')
 include(`eq_iir.m4')
 
-define(`PGA_NAME', Dmic1)
+ifdef(`PGA_NAME', `', `define(PGA_NAME, N_PGA(0))')
 define(`CONTROL_NAME_VOLUME', 2nd Capture Volume)
 define(`CONTROL_NAME_SWITCH', 2nd Capture Switch)
 define(`CONTROL_NAME', `CONTROL_NAME_VOLUME')

--- a/tools/topology/sof/pipe-tdfb-eq-iir-volume-capture.m4
+++ b/tools/topology/sof/pipe-tdfb-eq-iir-volume-capture.m4
@@ -16,7 +16,7 @@ include(`mixercontrol.m4')
 include(`tdfb.m4')
 include(`eq_iir.m4')
 
-define(`PGA_NAME', Dmic0)
+ifdef(`PGA_NAME', `', `define(PGA_NAME, N_PGA(0))')
 define(`CONTROL_NAME_VOLUME', Capture Volume)
 define(`CONTROL_NAME_SWITCH', Capture Switch)
 define(`CONTROL_NAME', `CONTROL_NAME_VOLUME')

--- a/tools/topology/sof/pipe-tdfb-volume-capture-16khz.m4
+++ b/tools/topology/sof/pipe-tdfb-volume-capture-16khz.m4
@@ -15,7 +15,7 @@ include(`bytecontrol.m4')
 include(`mixercontrol.m4')
 include(`tdfb.m4')
 
-define(`PGA_NAME', Dmic1)
+ifdef(`PGA_NAME', `', `define(PGA_NAME, N_PGA(0))')
 define(`CONTROL_NAME_VOLUME', 2nd Capture Volume)
 define(`CONTROL_NAME_SWITCH', 2nd Capture Switch)
 define(`CONTROL_NAME', `CONTROL_NAME_VOLUME')

--- a/tools/topology/sof/pipe-tdfb-volume-capture.m4
+++ b/tools/topology/sof/pipe-tdfb-volume-capture.m4
@@ -15,7 +15,7 @@ include(`bytecontrol.m4')
 include(`mixercontrol.m4')
 include(`tdfb.m4')
 
-define(`PGA_NAME', Dmic0)
+ifdef(`PGA_NAME', `', `define(PGA_NAME, N_PGA(0))')
 define(`CONTROL_NAME_VOLUME', Capture Volume)
 define(`CONTROL_NAME_SWITCH', Capture Switch)
 define(`CONTROL_NAME', `CONTROL_NAME_VOLUME')


### PR DESCRIPTION
This patch fixes the error that happens with the hard-coded PGA
names Dmic0 and Dmic1 in pipelines pipe-eq-iir-volume-capture.m4
and pipe-eq-iir-volume-capture-16khz.m4. Pipelines for beamformer
TDFB have the same hard-coded PGA names and are fixed too.

If impacted pipelines are used for any other purpose than DMIC endpoints
the topology graph gets messed up. With this change the caller macro,
e.g. intel-generic-dmic.m4 needs to set the PGA_NAME macro when the
respective pipeline is instantiated. If it is not set the default
name via N_PGA() macro is used.

The macro intel-generic-dmic-kwd.m4 is updated to set the Dmic0
PGA name as well as the earlier missed PIPELINE_FILTER1 and
PIPELINE_FILTER2 definitions for passing filter coefficients.

Fixes: #3378

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
