### PR TITLE
New installer/GNUmakefile to gradually replace scripts in sof-bin.git - take 2

### DIFF
--- a/installer/.gitignore
+++ b/installer/.gitignore
@@ -1,0 +1,1 @@
+/staging/sof*

--- a/installer/GNUmakefile
+++ b/installer/GNUmakefile
@@ -1,0 +1,204 @@
+
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2021 Intel Corporation
+
+
+.DEFAULT_GOAL := stage
+.PHONY: clean stage rsync
+.PHONY: signed unsigned ldicts topologies
+.PHONY: compare signed_dummies
+
+# Override ?= variables in config.mk
+-include config.mk
+
+UNSIGNED_list ?= bdw byt cht
+SIGNED_list  ?= apl cnl icl jsl tgl
+# older SOF versions
+# SIGNED_list += hsw kbl skl sue
+ALIAS_list ?= glk cfl cml ehl
+
+$(info UNSIGNED_list = ${UNSIGNED_list} )
+$(info SIGNED_list   = ${SIGNED_list}   )
+$(info ALIAS_list    = ${ALIAS_list}    )
+
+# Same code, same Intel key
+target_of_glk := apl
+target_of_cfl := cnl
+target_of_cml := cnl
+
+# Same code, different Intel key
+target_of_ehl := tgl
+
+TOOLCHAIN ?= gcc
+
+TREE_OPTS ?= --sort=size --dirsfirst
+INSTALL_OPTS ?= -D -p -m 0664
+
+# Keep SOF_VERSION optional
+
+SOF_VERSION ?= $(shell git describe --dirty)
+ifneq (${SOF_VERSION},)
+VERSION_DIR := ${SOF_VERSION}/
+VERSION_SUFFIX := -${SOF_VERSION}
+endif
+
+
+
+      ################################
+      ###  Top-level directories  ####
+      ################################
+
+# Our input:  build_*_?cc/ directories
+BUILDS_ROOT ?= ../
+
+STAGING_SOF ?= staging/sof
+STAGING_SOF_VERSION := ${STAGING_SOF}${VERSION_SUFFIX}
+
+STAGING_SOF_TPLG ?= staging/sof-tplg
+
+stage: signed unsigned ldicts aliases topologies
+ifneq (${STAGING_SOF_VERSION},${STAGING_SOF})
+	ln -sfT sof${VERSION_SUFFIX} ${STAGING_SOF}
+	test -e ${STAGING_SOF}
+endif
+	@file ${STAGING_SOF}
+	@tree ${TREE_OPTS} ${STAGING_SOF_VERSION}
+
+COMMUNITY	:= ${STAGING_SOF_VERSION}/community
+INTEL_SIGNED	:= ${STAGING_SOF_VERSION}/intel-signed
+${COMMUNITY} ${INTEL_SIGNED}:
+	mkdir -p $@
+
+
+      #####################################
+      ###    rsync to local or remote  ####
+      #####################################
+
+# Default value
+FW_DESTDIR ?= /lib/firmware/intel/
+# We don't depend on any other target so:
+# - it's possible to deploy a staging _subset_,
+# - sudo never builds by accident
+rsync:
+	rsync -a --info=progress2 staging/sof* "${FW_DESTDIR}"
+ifneq (${USER_DESTDIR},)
+	# TODO: add more user space binaries: sof-ctl, probes,...
+	# absorbe scripts/sof-target-install.sh
+	# Requires ./scripts/build-tools.sh -l ...
+	rsync -a ${BUILDS_ROOT}/tools/build_tools/logger/sof-logger ${USER_DESTDIR}
+endif
+
+clean:
+	${RM} -r staging/sof*
+
+
+   ##########################################################
+   ###  Stage sof-*.ri firmware files and symbolic links ####
+   ##########################################################
+
+#
+# 1. Stages all *.ri files
+#
+# 2. Create symbolic links, including (broken) intel-signed symbolic
+#    links that must be fixed in a final release, otherwise the release
+#    is incomplete. To check all symlinks: file $(find -type l)
+#
+
+# '%' is the platform name
+SIGNED_FWS := ${SIGNED_list:%=${COMMUNITY}/sof-%.ri}
+# $(info SIGNED_FWS = ${SIGNED_FWS})
+signed: ${SIGNED_FWS}
+${SIGNED_FWS}: ${COMMUNITY}/sof-%.ri:    \
+               ${BUILDS_ROOT}/build_%_${TOOLCHAIN}/sof.ri     \
+	     | ${COMMUNITY} ${INTEL_SIGNED}
+	install ${INSTALL_OPTS} $< $@
+	ln -sfT     intel-signed/sof-$*.ri ${STAGING_SOF_VERSION}/sof-$*.ri
+
+# '%' is the platform name
+UNSIGNED_FWS := ${UNSIGNED_list:%=${STAGING_SOF_VERSION}/sof-%.ri}
+# $(info UNSIGNED_FWS = ${UNSIGNED_FWS})
+unsigned: ${UNSIGNED_FWS}
+${UNSIGNED_FWS}: ${STAGING_SOF_VERSION}/sof-%.ri:   \
+                 ${BUILDS_ROOT}/build_%_${TOOLCHAIN}/sof.ri
+	install ${INSTALL_OPTS} $< $@
+
+
+       ########################################
+       ###  Stage *.ldc logger dictionaries ###
+       ########################################
+
+# '%' is the platform name
+LDICTS := ${UNSIGNED_list:%=${STAGING_SOF_VERSION}/sof-%.ldc} \
+            ${SIGNED_list:%=${STAGING_SOF_VERSION}/sof-%.ldc}
+# $(info LDICTS = ${LDICTS})
+ldicts: ${LDICTS}
+${LDICTS}: ${STAGING_SOF_VERSION}/sof-%.ldc:  \
+             ${BUILDS_ROOT}/build_%_${TOOLCHAIN}/sof.ldc
+	install ${INSTALL_OPTS} $< $@
+
+
+        #######################################
+        ###  Platform -> platform aliases  ####
+        #######################################
+
+# '%' is the platform name
+COMM_ALIASES   := ${ALIAS_list:%=${STAGING_SOF_VERSION}/community/sof-%.ri}
+DICT_ALIASES   := ${ALIAS_list:%=${STAGING_SOF_VERSION}/sof-%.ldc}
+SIGNED_ALIASES := ${ALIAS_list:%=${STAGING_SOF_VERSION}/sof-%.ri}
+aliases: ${SIGNED_ALIASES} ${COMM_ALIASES} ${DICT_ALIASES}
+
+${COMM_ALIASES}: ${STAGING_SOF_VERSION}/community/sof-%.ri:
+	ln -sfT sof-${target_of_$*}.ri $@
+
+${DICT_ALIASES}: ${STAGING_SOF_VERSION}/sof-%.ldc:
+	ln -sfT sof-${target_of_$*}.ldc $@
+
+# Some have the same key, others just the code. We don't make any
+# difference here and let the intel-signed/ directory handle this.
+${SIGNED_ALIASES}: ${STAGING_SOF_VERSION}/sof-%.ri:
+	ln -sfT intel-signed/sof-$*.ri $@
+
+
+            ##################################
+            ### Stage sof-tplg/ topologies ###
+            ##################################
+
+topologies:
+	# This requires ./scripts/build-tools.sh -T ...
+	install ${INSTALL_OPTS}  -t ${STAGING_SOF_TPLG}${VERSION_SUFFIX}/ \
+               ${BUILDS_ROOT}/tools/build_tools/topology/sof-*.tplg
+ifneq (,${VERSION_SUFFIX})
+	ln -sfT sof-tplg${VERSION_SUFFIX} ${STAGING_SOF_TPLG}
+	test -e ${STAGING_SOF_TPLG}
+endif
+	@file ${STAGING_SOF_TPLG}
+	@tree ${TREE_OPTS} ${STAGING_SOF_TPLG}${VERSION_SUFFIX} | \
+            head -n 10; printf '├── ...\n..\n'
+
+
+             ####################
+             ### Self-Testing ###
+             ####################
+
+COMPARE_REFS ?= /lib/firmware/intel
+
+# Useful for testing this Makefile. Can be used against /lib/firmware,
+# sof-bin, a previous version of this Makefile,...
+# As the first arguments maybe symbolic links, their trailing slash is
+# critical.
+compare: stage
+	! diff -qr --no-dereference ${COMPARE_REFS}/sof/ \
+             ${STAGING_SOF_VERSION}/ \
+             | grep -v ' differ$$' # || true
+	! diff -qr --no-dereference ${COMPARE_REFS}/sof-tplg/ \
+             ${STAGING_SOF_TPLG}${VERSION_SUFFIX}/ \
+             | grep -v ' differ$$'
+
+# Invoke this manually to check symbolic links are correct
+SIGNED_DUMMIES := ${SIGNED_list:%=${INTEL_SIGNED}/sof-%.ri} \
+                   ${ALIAS_list:%=${INTEL_SIGNED}/sof-%.ri}
+signed_dummies: ${SIGNED_DUMMIES}
+	! file $$(find . -type l) | grep -i broken
+
+${SIGNED_DUMMIES}: | ${INTEL_SIGNED}
+	touch $@

--- a/installer/README.md
+++ b/installer/README.md
@@ -1,0 +1,78 @@
+The GNUmakefile in this directory prepares ``/lib/firmware/intel/sof/`` and
+``/lib/firmware/intel/sof-tplg/`` directories.
+
+It extracts what's needed from the output of the scripts
+``./scripts/xtensa-build-all.sh -a`` and ``./scripts/build-tools.sh
+-T -l``; running these scripts is a pre-requisite.
+
+It does not copy anything to ``/lib/firmware/`` directly but to local,
+"staging" subdirectory first. The staging area can then be installed with
+rsync to a local or remote ``/lib/firmware/intel/`` or to a release
+location. This gives an opportunity to inspect the staging area and
+avoids running everything as root.
+
+The default target (re-)generates the staging area:
+
+    make -C installer/
+
+Then, to install the staging area:
+
+    sudo make -C installer/ rsync
+
+By default, the "rsync" target installs to the local
+``/lib/firmware/intel/`` directory. To install to a different host or
+different directory, copy the ``sample-config.mk`` file to ``config.mk``
+and follow the instructions inside the file. ``config.mk`` can also be
+used to change the list of platforms installed and a number of other
+Make variables. As usual with Make, many parameters can also be
+overridden on the command line.
+
+To stage and install in one go:
+
+    make -C installer/ stage rsync
+
+"stage" is the default target and it tries to stage everything:
+firmware, dictionaries and topologies. As usual with Make, it's possible
+to invoke individual targets. Find a list of targets at the top of
+GNUMakefile.
+
+Sample output:
+
+    staging/sof: symbolic link to sof-v1.6.1
+    staging/sof-v1.6.1/
+    ├── community/
+    │   ├── sof-tgl.ri
+    │   ├── sof-cnl.ri
+    │   ├── sof-icl.ri
+    │   ├── sof-jsl.ri
+    │   ├── sof-apl.ri
+    │   ├── sof-cfl.ri -> sof-cnl.ri
+    │   ├── sof-cml.ri -> sof-cnl.ri
+    │   ├── sof-ehl.ri -> sof-tgl.ri
+    │   └── sof-glk.ri -> sof-apl.ri
+    ├── intel-signed/
+    ├── sof-bdw.ri
+    ├── sof-cht.ri
+    ├── sof-byt.ri
+    ├── sof-cnl.ldc
+    ├── sof-tgl.ldc
+    ├── sof-icl.ldc
+    ├── sof-jsl.ldc
+    ├── sof-apl.ldc
+    ├── sof-bdw.ldc
+    ├── sof-byt.ldc
+    ├── sof-cht.ldc
+    ├── sof-apl.ri -> intel-signed/sof-apl.ri
+    ├── sof-cfl.ri -> intel-signed/sof-cfl.ri
+    ├── sof-cml.ri -> intel-signed/sof-cml.ri
+    ├── sof-cnl.ri -> intel-signed/sof-cnl.ri
+    ├── sof-ehl.ri -> intel-signed/sof-ehl.ri
+    ├── sof-glk.ri -> intel-signed/sof-glk.ri
+    ├── sof-icl.ri -> intel-signed/sof-icl.ri
+    ├── sof-jsl.ri -> intel-signed/sof-jsl.ri
+    ├── sof-tgl.ri -> intel-signed/sof-tgl.ri
+    ├── sof-cfl.ldc -> sof-cnl.ldc
+    ├── sof-cml.ldc -> sof-cnl.ldc
+    ├── sof-ehl.ldc -> sof-tgl.ldc
+    └── sof-glk.ldc -> sof-apl.ldc
+

--- a/installer/sample-config.mk
+++ b/installer/sample-config.mk
@@ -1,0 +1,23 @@
+# To customize the installation, copy this file to config.mk and edit
+# it. Leave undefined to use default values.
+
+# As usual with Make, all these can also be passed as either CLI
+# arguments or environment variables.  Warning: undefined is NOT the
+# same as blank!
+
+# Everything is installed by default. To install and deploy fewer
+# patforms override the default lists like this:
+# UNSIGNED_list :=
+# SIGNED_list := apl tgl
+
+# The default FW_DESTDIR is the local /lib/firmware/intel directory
+# _remote := test-system.local
+# FW_DESTDIR     := root@${_remote}:/lib/firmware/intel
+# USER_DESTDIR   := ${_remote}:bin/
+
+# Define this empty for a plain sof/ directory and no sof -> sof-v1.2.3
+# symbolic links.
+# SOF_VERSION :=
+#
+# SOF_VERSION := $(shell git describe --tags )
+# SOF_VERSION := v1.6.14

--- a/src/arch/xtensa/CMakeLists.txt
+++ b/src/arch/xtensa/CMakeLists.txt
@@ -504,7 +504,9 @@ else()
 	add_custom_target(
 		bin ALL
 		COMMAND ${CMAKE_COMMAND} -E copy sof-${fw_name}.ri ${PROJECT_BINARY_DIR}/sof-${fw_output_name}.ri
+		COMMAND ${CMAKE_COMMAND} -E copy sof-${fw_name}.ri ${PROJECT_BINARY_DIR}/sof.ri
 		COMMAND ${CMAKE_COMMAND} -E copy sof-${fw_name}.ldc ${PROJECT_BINARY_DIR}/sof-${fw_output_name}.ldc
+		COMMAND ${CMAKE_COMMAND} -E copy sof-${fw_name}.ldc ${PROJECT_BINARY_DIR}/sof.ldc
 		DEPENDS run_meu bin_extras glue_binary_files
 		VERBATIM
 		USES_TERMINAL


### PR DESCRIPTION
_[To see the README.md file with rendered markdown go to Files changed->README.md->three dots in the upper right corner-> View File]_

More specifically replacing sof-bin/go.sh and sof-bin/publish.sh and
also sof/scripts/sof-target-install.sh eventually.

"make install" code has always belonged to source repositories because
developers need to install too and we want everyone to use the same
installers. It's also easier to have all the information in a single
place.

Once the layout in sof-bin mirrors the /lib/firmware/intel layout
exactly, sof-bin does not need any installation code any more.

Mixing source and binaries in the same repo is also a "code smell",
notably because it forces branching them together.

Using a higher level build tool for installation instead of plain
scripts has a few benefits:

- Multiple entry points: easy to invoke (and test) any part of the
  installer individually
- ... while invoking dependencies automatically.
- Other features "for free" like:
  - errexit
  - error messages like "dunno how to build file x"
  - commands are logged by default

- Also gets rid of most of the large code duplication in go.sh and
  publish.sh, so:
  - Enabling or disabling a platform is a 3-character change
  - Allows platform selection in local config file (even just one platform)
  - Much harder to add inconsistencies
  - Much easier to review correctness, for instance no need to
    scrutinize every line to see which platforms are aliased.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>