### PR TITLE
demux: fix demux look up table preparation

### DIFF
--- a/src/audio/mux/mux_generic.c
+++ b/src/audio/mux/mux_generic.c
@@ -524,9 +524,9 @@ void demux_prepare_look_up_table(struct comp_dev *dev)
 		for (j = 0; j < PLATFORM_MAX_CHANNELS; j++) {
 			for (k = 0; k < PLATFORM_MAX_CHANNELS; k++) {
 				if (cd->config.streams[i].mask[j] & BIT(k)) {
-					/* MUX component has only one sink */
-					cd->lookup[i].copy_elem[idx].in_ch = j;
-					cd->lookup[i].copy_elem[idx].out_ch = k;
+					/* DEMUX component has only one source */
+					cd->lookup[i].copy_elem[idx].in_ch = k;
+					cd->lookup[i].copy_elem[idx].out_ch = j;
 					cd->lookup[i].copy_elem[idx].stream_id =
 						i;
 					cd->lookup[i].num_elems = ++idx;

--- a/test/cmocka/src/audio/mux/demux_copy.c
+++ b/test/cmocka/src/audio/mux/demux_copy.c
@@ -197,7 +197,7 @@ static void test_demux_copy_proc_16(void **state)
 			int64_t sample = 0;
 
 			for (k = 0; k < PLATFORM_MAX_CHANNELS; ++k)
-				if (td->mask[i][k] & BIT(j))
+				if (td->mask[i][j] & BIT(k))
 					sample = input_16b[k];
 
 			expected_results[i][j] = sample;
@@ -222,7 +222,7 @@ static void test_demux_copy_proc_24(void **state)
 			int32_t sample = 0;
 
 			for (k = 0; k < PLATFORM_MAX_CHANNELS; ++k)
-				if (td->mask[i][k] & BIT(j))
+				if (td->mask[i][j] & BIT(k))
 					sample = input_24b[k];
 
 			expected_results[i][j] = sample;
@@ -247,7 +247,7 @@ static void test_demux_copy_proc_32(void **state)
 			int32_t sample = 0;
 
 			for (k = 0; k < PLATFORM_MAX_CHANNELS; ++k)
-				if (td->mask[i][k] & BIT(j))
+				if (td->mask[i][j] & BIT(k))
 					sample = input_32b[k];
 
 			expected_results[i][j] = sample;


### PR DESCRIPTION
Array streams represents streams on "many" side i.e. input
for MUX and output for DEMUX.
For DEMUX each stream has masks array - 1 mask per output
channel. Each mask shows, from which input channel data
should be taken.

This commit reverts "demux" part of commit:
b1b31e7154a5c159d81459634eabd8013b434181

Signed-off-by: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>