### PR TITLE
Topology: Build sof-hda-generic-2ch-pdm1.tplg for PDM1 connected DMIC

### DIFF
--- a/tools/topology/development/CMakeLists.txt
+++ b/tools/topology/development/CMakeLists.txt
@@ -25,6 +25,8 @@ set(TPLGS_UP
 	"sof-cml-rt5682\;sof-cml-eq-fir-rt5682\;-DPLATFORM=cml\;-DHSMICPROC=eq-fir-volume\;-DDMICPROC=eq-iir-volume\;-DDMIC16KPROC=eq-iir-volume"
 	"sof-cml-rt5682\;sof-cml-eq-iir-rt5682\;-DPLATFORM=cml\;-DHSEARPROC=eq-iir-volume\;-DDMICPROC=eq-iir-volume\;-DDMIC16KPROC=eq-iir-volume"
 	"sof-glk-da7219\;sof-glk-eq-da7219\;-DDMICPROC=eq-iir-volume"
+	"sof-hda-generic\;sof-hda-generic-1ch-pdm1\;-DCHANNELS=2\;-DHSPROC=volume\;-DDMICPROC_FILTER1=eq_iir_coef_highpass_40hz_20db_48khz.m4\;-DDMIC16KPROC_FILTER1=eq_iir_coef_highpass_40hz_20db_16khz.m4\;-DDMICPDM=PDM1"
+	"sof-hda-generic\;sof-hda-generic-2ch-pdm1\;-DCHANNELS=2\;-DHSPROC=volume\;-DDMICPROC_FILTER1=eq_iir_coef_highpass_40hz_20db_48khz.m4\;-DDMIC16KPROC_FILTER1=eq_iir_coef_highpass_40hz_20db_16khz.m4\;-DDMICPDM=PDM1"
 	"sof-hda-generic\;sof-hda-generic-tdfb_50mm-2ch\;-DCHANNELS=2\;-DHSPROC=volume\;-DDMIC16KPROC=tdfb-eq-iir-volume\;-DDMIC16KPROC_FILTER1=tdfb/coef_line2_50mm_pm10deg_16khz.m4\;-DDMICPROC=tdfb-eq-iir-volume\;-DDMICPROC_FILTER1=tdfb/coef_line2_50mm_pm10deg_48khz.m4\;-DDMICPROC_FILTER2=eq_iir_coef_highpass_40hz_20db_48khz.m4\;-DDMIC16KPROC_FILTER2=eq_iir_coef_highpass_40hz_20db_16khz.m4"
 )
 

--- a/tools/topology/platform/intel/intel-generic-dmic.m4
+++ b/tools/topology/platform/intel/intel-generic-dmic.m4
@@ -132,6 +132,12 @@ PCM_CAPTURE_ADD(DMIC_16k_PCM_NAME, DMIC_PCM_16k_ID, concat(`PIPELINE_PCM_', DMIC
 # BE configurations - overrides config in ACPI if present
 #
 
+# Address case where two microphones are connected to PDM1 controller, default is PDM0
+ifdef(`DMICPDM', `', `define(`DMICPDM', `PDM0')')
+ifelse(DMICPDM, `PDM1',
+`define(`DEF_STEREO_PDMX', `STEREO_PDM1')',
+`define(`DEF_STEREO_PDMX', `STEREO_PDM0')')
+
 dnl DAI_CONFIG(type, dai_index, link_id, name, ssp_config/dmic_config)
 ifelse(DMIC_DAI_CHANNELS, 4,
 `DAI_CONFIG(DMIC, 0, DMIC_DAI_LINK_48k_ID, DMIC_DAI_LINK_48k_NAME,
@@ -141,7 +147,7 @@ ifelse(DMIC_DAI_CHANNELS, 4,
 `DAI_CONFIG(DMIC, 0, DMIC_DAI_LINK_48k_ID, DMIC_DAI_LINK_48k_NAME,
            DMIC_CONFIG(1, 500000, 4800000, 40, 60, 48000,
                 DMIC_WORD_LENGTH(s32le), 200, DMIC, 0,
-                PDM_CONFIG(DMIC, 0, STEREO_PDM0)))')
+                PDM_CONFIG(DMIC, 0, DEF_STEREO_PDMX)))')
 
 ifelse(DMIC16K_DAI_CHANNELS, 4,
 `DAI_CONFIG(DMIC, 1, DMIC_DAI_LINK_16k_ID, DMIC_DAI_LINK_16k_NAME,
@@ -151,4 +157,6 @@ ifelse(DMIC16K_DAI_CHANNELS, 4,
 `DAI_CONFIG(DMIC, 1, DMIC_DAI_LINK_16k_ID, DMIC_DAI_LINK_16k_NAME,
            DMIC_CONFIG(1, 500000, 4800000, 40, 60, 16000,
                 DMIC_WORD_LENGTH(s32le), 400, DMIC, 1,
-                PDM_CONFIG(DMIC, 1, STEREO_PDM0)))')
+                PDM_CONFIG(DMIC, 1, DEF_STEREO_PDMX)))')
+
+undefine(`DEF_STEREO_PDMX')


### PR DESCRIPTION
This patch addresses issue with device where BIOS reported 2ch DMIC
is not connected to default PDM0 pins but PDM1 pins instead.

Currently there is no known indication of such connection in BIOS so
the created topology needs to be manually copied over
sof-hda-generic-2ch.tplg on the impacted devices.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>