### PR TITLE
codec_adapter: don't error on free(NULL)

### DIFF
--- a/src/audio/codec_adapter/codec/generic.c
+++ b/src/audio/codec_adapter/codec/generic.c
@@ -182,8 +182,7 @@ int codec_free_memory(struct comp_dev *dev, void *ptr)
 	struct list_item *_mem_list;
 
 	if (!ptr) {
-		comp_err(dev, "codec_free_memory: error: NULL pointer passed.");
-		return -EINVAL;
+		return 0;
 	}
 	/* Find which container keeps this memory */
 	list_for_item_safe(mem_list, _mem_list, &cd->codec.memory.mem_list) {


### PR DESCRIPTION
libc doesn't return a type, so it just no-ops silently on null, lets to
the same having this error makes walk back patterns more annoying

Signed-off-by: Curtis Malainey <cujomalainey@chromium.org>