### PR TITLE
math: fix norm_int32

### DIFF
--- a/src/math/numbers.c
+++ b/src/math/numbers.c
@@ -130,26 +130,15 @@ int32_t find_max_abs_int32(int32_t vec[], int vec_length)
  */
 int norm_int32(int32_t val)
 {
-	int s;
-	int32_t n;
+	int s = 0;
+	uint32_t n = ((uint32_t)val) << 1;
 
 	if (!val)
 		return 31;
 
-	if (val > 0) {
-		n = val << 1;
-		s = 0;
-		while (n > 0) {
-			n = n << 1;
-			s++;
-		}
-	} else {
-		n = val << 1;
-		s = 0;
-		while (n < 0) {
-			n = n << 1;
-			s++;
-		}
+	while (n > 0) {
+		n = n << 1;
+		s++;
 	}
 	return s;
 }


### PR DESCRIPTION
The original implementation relied on undefined behaviour (left shifting
a signed integer) and also had duplicate code. The solution is to
convert to a unsigned int and conduct the test. Note this change when
tested on x86 does not return the same results.

AT 80000070: (old)0 != (new)27
AT fffffff2: (old)27 != (new)30
AT 6: (old)28 != (new)30
AT 7fffff6f: (old)0 != (new)31
AT 7fffffff: (old)0 != (new)31

Signed-off-by: Curtis Malainey <cujomalainey@chromium.org>