### PR TITLE
xtensa-build-all.sh: Bump IMX xtensa toolchain version

### DIFF
--- a/scripts/xtensa-build-all.sh
+++ b/scripts/xtensa-build-all.sh
@@ -281,21 +281,21 @@ do
 			ARCH="xtensa"
 			XTENSA_CORE="hifi4_nxp_v3_3_1_2_dev"
 			HOST="xtensa-imx-elf"
-			XTENSA_TOOLS_VERSION="RF-2016.4-linux"
+			XTENSA_TOOLS_VERSION="RF-2017.8-linux"
 			;;
 		imx8x)
 			PLATFORM="imx8x"
 			ARCH="xtensa"
 			XTENSA_CORE="hifi4_nxp_v3_3_1_2_dev"
 			HOST="xtensa-imx-elf"
-			XTENSA_TOOLS_VERSION="RF-2016.4-linux"
+			XTENSA_TOOLS_VERSION="RF-2017.8-linux"
 			;;
 		imx8m)
 			PLATFORM="imx8m"
 			ARCH="xtensa"
 			XTENSA_CORE="hifi4_mscale_v0_0_2_prod"
 			HOST="xtensa-imx8m-elf"
-			XTENSA_TOOLS_VERSION="RF-2016.4-linux"
+			XTENSA_TOOLS_VERSION="RF-2017.8-linux"
 			;;
 
 	esac


### PR DESCRIPTION
Lets use the same version of Xtensa toolchain as Intel in order
to avoid compilation problems.

It is difficult to support multiple toolchain versions because specific
headers needs to be updated, so lets have the same version supported
between IMX and Intel.

Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>