### PR TITLE
cavs: clk: do TGL specific HW recommended flow unconditionally

### DIFF
--- a/src/platform/intel/cavs/lib/clk.c
+++ b/src/platform/intel/cavs/lib/clk.c
@@ -57,12 +57,13 @@ static inline void select_cpu_clock_hw(int freq_idx, bool release_unused)
 		io_reg_write(SHIM_BASE + SHIM_CLKCTL,
 			     (io_reg_read(SHIM_BASE + SHIM_CLKCTL) &
 			      ~SHIM_CLKCTL_OSC_REQUEST_MASK) | enc);
-#if CONFIG_TIGERLAKE
-		/* TGL specific HW recommended flow */
-		if (freq_idx != CPU_HPRO_FREQ_IDX)
-			pm_runtime_put(PM_RUNTIME_DSP, PWRD_BY_HPRO | (PLATFORM_CORE_COUNT - 1));
-#endif
 	}
+
+#if CONFIG_TIGERLAKE
+	/* TGL specific HW recommended flow */
+	if (freq_idx != CPU_HPRO_FREQ_IDX)
+		pm_runtime_put(PM_RUNTIME_DSP, PWRD_BY_HPRO | (PLATFORM_CORE_COUNT - 1));
+#endif
 
 #if CONFIG_DSP_RESIDENCY_COUNTERS
 	if (get_dsp_r_state() != r2_r_state) {


### PR DESCRIPTION
We need to follow TGL specific HW recommended flow to get/put
PM_RUNTIME_DSP, even for not release_unused clocks requirement.

This will address the PM_GATE IPC failure issue:
https://github.com/thesofproject/sof/issues/3823

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>