### PR TITLE
Fix playback and capture multiple runs which occasionally fails with Input/output error

### DIFF
--- a/src/drivers/imx/sai.c
+++ b/src/drivers/imx/sai.c
@@ -50,9 +50,7 @@ static void sai_start(struct dai *dai, int direction)
 	/* transmitter enable */
 	dai_update_bits(dai, REG_SAI_XCSR(direction),
 			REG_SAI_CSR_TERE, REG_SAI_CSR_TERE);
-	/* TODO: for the time being use half FIFO size as watermark */
-	dai_update_bits(dai, REG_SAI_XCR1(direction),
-			REG_SAI_CR1_RFW_MASK, SAI_FIFO_WORD_SIZE / 2);
+
 	dai_update_bits(dai, REG_SAI_XCR3(direction),
 			REG_SAI_CR3_TRCE_MASK, REG_SAI_CR3_TRCE(1));
 
@@ -255,6 +253,9 @@ static inline int sai_set_config(struct dai *dai,
 	mask_cr5  = REG_SAI_CR5_WNW_MASK | REG_SAI_CR5_W0W_MASK |
 			REG_SAI_CR5_FBT_MASK;
 
+	/* TODO: for the time being use half FIFO size as watermark */
+	dai_update_bits(dai, REG_SAI_XCR1(REG_TX_DIR),
+			REG_SAI_CR1_RFW_MASK, SAI_FIFO_WORD_SIZE / 2);
 	dai_update_bits(dai, REG_SAI_XCR2(REG_TX_DIR), mask_cr2, val_cr2);
 	dai_update_bits(dai, REG_SAI_XCR4(REG_TX_DIR), mask_cr4, val_cr4);
 	dai_update_bits(dai, REG_SAI_XCR5(REG_TX_DIR), mask_cr5, val_cr5);
@@ -264,6 +265,10 @@ static inline int sai_set_config(struct dai *dai,
 
 	val_cr2 |= REG_SAI_CR2_SYNC;
 	mask_cr2 |= REG_SAI_CR2_SYNC_MASK;
+
+	/* TODO: for the time being use half FIFO size as watermark */
+	dai_update_bits(dai, REG_SAI_XCR1(REG_RX_DIR),
+			REG_SAI_CR1_RFW_MASK, SAI_FIFO_WORD_SIZE / 2);
 	dai_update_bits(dai, REG_SAI_XCR2(REG_RX_DIR), mask_cr2, val_cr2);
 	dai_update_bits(dai, REG_SAI_XCR4(REG_RX_DIR), mask_cr4, val_cr4);
 	dai_update_bits(dai, REG_SAI_XCR5(REG_RX_DIR), mask_cr5, val_cr5);

--- a/src/drivers/imx/sai.c
+++ b/src/drivers/imx/sai.c
@@ -66,6 +66,14 @@ static void sai_start(struct dai *dai, int direction)
 		}
 	}
 
+	/* W1C */
+	dai_update_bits(dai, REG_SAI_XCSR(direction),
+			REG_SAI_CSR_FEF, 1);
+	dai_update_bits(dai, REG_SAI_XCSR(direction),
+			REG_SAI_CSR_SEF, 1);
+	dai_update_bits(dai, REG_SAI_XCSR(direction),
+			REG_SAI_CSR_WSF, 1);
+
 	/* add one word to FIFO before TRCE is enabled */
 	if (direction == DAI_DIR_PLAYBACK)
 		dai_write(dai, REG_SAI_TDR0, 0x0);


### PR DESCRIPTION
This pull request fixes #3809.

The first commit updates the correct order for DAI and DMA start/stop.
Before this update, on multiple start/stop runs for playback or record or combined,
we get an underrun/overflow.
That's because the DAI makes a DMA request, before the DMA channel is
enabled.

The second commit updates the start/stop operations for SAI.
Please see a more detailed explanation in the commit message.

After the first 3 commits, after multiple playback/capture runs (~700, ~1000)
everything seems ok. 
But, sometimes, when running a second/third time, the same 700 loop I get an "ipc timed out for 0x60050000 size 12".
Here's a log:
```
Playing raw data '16/j16.wav' : Signed 16 bit Little Endian, Rate 48000 Hz, Stereo
Playing raw data '16/j16.wav' : Signed 16 bit Little Endian, Rate 48000 Hz, Stereo
Recording WAVE 'test_record.pcm' : Signed 16 bit Little Endian, Rate 48000 Hz, Stereo
[  582.814139] sof-audio-of 556e8000.dsp: error: ipc timed out for 0x60050000 size 12
[  582.821802] sof-audio-of 556e8000.dsp: info: preventing DSP entering D3 state to preserve context
[  582.830906] sof-audio-of 556e8000.dsp: invalid header size 0x2000200. FW oops is bogus
[  582.838989] sof-audio-of 556e8000.dsp: error: unexpected fault 0x00000000 trace 0x00000000
[  582.847530] sof-audio-of 556e8000.dsp: error: waking up any trace sleepers
[  582.854601] sof-audio-of 556e8000.dsp: error: trace IO error
[  582.861198] sof-audio-of 556e8000.dsp: ASoC: error at snd_soc_pcm_component_trigger on 556e8000.dsp: -110
[  582.871466]  Port0: ASoC: trigger FE cmd: 0 failed: -110
Playing raw data '16/j16.wav' : Signed 16 bit Little Endian, Rate 48000 Hz, Stereo
Recording WAVE 'test_record.pcm' : Signed 16 bit Little Endian, Rate 48000 Hz, Stereo
aplay: pcm_write:2061: write error: Input/output error
(null)      1  TFAIL  :  ltpapicmd.c:188: Test 420 Playback failed
Recording WAVE 'test_record.pcm' : Signed 16 bit Little Endian, Rate 48000 Hz, Stereo
Recording WAVE 'test_record.pcm' : Signed 16 bit Little Endian, Rate 48000 Hz, Stereo
```
By looking in the trace I saw that the stop cmd is not triggered in DSP
and in SAI we get two start operations one after another.
Therefore, in the 3rd commit, we check in SAI, on start, if a start was already
triggered, disable just the DMA request and the data channel.

