### PR TITLE
drivers: imx: esai: use rate from topology

### DIFF
--- a/src/include/ipc/dai-imx.h
+++ b/src/include/ipc/dai-imx.h
@@ -18,8 +18,11 @@ struct sof_ipc_dai_esai_params {
 	/* MCLK */
 	uint16_t reserved1;
 	uint16_t mclk_id;
-	uint32_t mclk_rate; /* MCLK frequency in Hz */
 	uint32_t mclk_direction;
+
+	uint32_t mclk_rate; /* MCLK frequency in Hz */
+	uint32_t fsync_rate;
+	uint32_t bclk_rate;
 
 	/* TDM */
 	uint32_t tdm_slots;


### PR DESCRIPTION
So far we only used topologies with rate set
to 48000Hz. This might change in the future.
So use rate from parameters passed from kernel.

While here, align sof_ipc_dai_esai_params struct
with the one from kernel.

Signed-off-by: Iuliana Prodan <iuliana.prodan@nxp.com>