### PR TITLE
topology: enable setting multiple configs for dai

### DIFF
--- a/tools/topology/m4/dai.m4
+++ b/tools/topology/m4/dai.m4
@@ -192,6 +192,50 @@ define(`DAI_CONFIG',
 `ifelse(`$#', `5', `DO_DAI_CONFIG($1, $2, $3, $4, $5)', `$#', `4', `DO_DAI_CONFIG($1, $2, $3, $4)', `fatal_error(`Invalid parameters ($#) to DAI_CONFIG')')'
 )
 
+define(`HW_CONFIG_NAMES',
+`	hw_configs ['
+`	$1'
+`	]')
+
+define(`DAI_DATA_NAMES',
+`	data ['
+`	$1'
+`		"N_DAI_CONFIG_data_common"')
+
+dnl DO_MULTI_DAI_CONFIG(type, idx, link_id, name, sai_config/esai_config/ssp_config/dmic_config)
+define(`DO_MULTI_DAI_CONFIG',
+`$5'
+`SectionVendorTuples."N_DAI_CONFIG_tuples_common" {'
+`	tokens "sof_dai_tokens"'
+`	tuples."string" {'
+`		SOF_TKN_DAI_TYPE'		STR($1)
+`	}'
+`	tuples."word" {'
+`		SOF_TKN_DAI_INDEX'		STR($2)
+`	}'
+`}'
+`SectionData."N_DAI_CONFIG_data_common" {'
+`	tuples "N_DAI_CONFIG_tuples_common"'
+`}'
+`'
+`SectionBE."'$4`" {'
+`	id "'$3`"'
+`	index "0"'
+`	default_hw_conf_id	"'$3`"'
+`'
+`	$6'
+`	$7'
+`ifelse($1, `DMIC',`		"'N_DAI_CONFIG($1$2)`_pdm_data"', `')'
+`	]'
+`}'
+`DEBUG_DAI_CONFIG($1, $3)'
+)
+
+dnl MULTI_DAI_CONFIG(type, idx, link_id, name, ssp_config/dmic_config times n)
+ define(`MULTI_DAI_CONFIG',
+`ifelse(`eval($# < 5)', `1', `fatal_error(`Invalid parameters ($#) to MULTI_DAI_CONFIG')', `DO_MULTI_DAI_CONFIG($@)')'
+)
+
 dnl DAI_ADD(pipeline,
 dnl     pipe id, dai type, dai_index, dai_be,
 dnl     buffer, periods, format,

--- a/tools/topology/platform/common/ssp.m4
+++ b/tools/topology/platform/common/ssp.m4
@@ -49,4 +49,40 @@ define(`SSP_CONFIG_DATA',
 `}'
 )
 
+define(`MULTI_SSP_CONFIG',
+`SectionHWConfig."'$1`" {'
+`'
+`	id		"'$2`"'
+`'
+`	format		"'$3`"'
+`	'$4
+`	'$5
+`	'$6
+`	'$7
+`}'
+$8
+)
+
+define(`SSP_MULTI_CONFIG_DATA',
+`SectionVendorTuples."'$1`_tuples" {'
+`	tokens "sof_ssp_tokens"'
+`	tuples."word" {'
+`		SOF_TKN_INTEL_SSP_SAMPLE_BITS'	STR($2)
+`		SOF_TKN_INTEL_SSP_QUIRKS'	ifelse(defn(`$4'), `', "0", STR($4))
+`		SOF_TKN_INTEL_SSP_BCLK_DELAY'	ifelse(defn(`$5'), `', "0", STR($5))
+`		SOF_TKN_INTEL_SSP_CLKS_CONTROL' ifelse(defn(`$6'), `', "0", STR($6))
+`	}'
+`	tuples."short" {'
+`		SOF_TKN_INTEL_SSP_MCLK_ID'	ifelse(defn(`$3'), `', "0", STR($3))
+`		SOF_TKN_INTEL_SSP_FRAME_PULSE_WIDTH' ifelse(defn(`$7'), `', "0", STR($7))
+`	}'
+`	tuples."bool" {'
+`		SOF_TKN_INTEL_SSP_TDM_PADDING_PER_SLOT' ifelse(defn(`$8'), `', "false", STR($8))
+`	}'
+`}'
+`SectionData."'$1`" {'
+`	tuples "'$1`_tuples"'
+`}'
+)
+
 divert(0)dnl


### PR DESCRIPTION
In some cases we need to change dai configuration in firmware. ASoC
supports already setting multiple hw_configs, but sof M4 scripts lack
the mechanism to do this. Thus enable defining multiple config items in
the dai. Enable now support only for SSP by defining new
SSP_MULTI_CONFIG macros that should not clash with the single dai config.

Signed-off-by: Jaska Uimonen <jaska.uimonen@intel.com>