### PR TITLE
codec_adapter: cadence: Fix API func search

### DIFF
--- a/src/audio/codec_adapter/codec/cadence.c
+++ b/src/audio/codec_adapter/codec/cadence.c
@@ -50,7 +50,7 @@ int cadence_codec_init(struct comp_dev *dev)
 	/* Find and assign API function */
 	for (i = 0; i < no_of_api; i++) {
 		if (cadence_api_table[i].id == api_id) {
-			cd->api = cadence_api_table[0].api;
+			cd->api = cadence_api_table[i].api;
 			break;
 		}
 	}


### PR DESCRIPTION
Existing code returns everytimethe API function at index 0, which works
now because we support only a single API function. But, this will break
when patches adding multiple Cadence codec types will be merged.

Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>