### PR TITLE
RFC: codec_adapter: Bail out only on fatal errors

### DIFF
--- a/src/audio/codec_adapter/codec/cadence.c
+++ b/src/audio/codec_adapter/codec/cadence.c
@@ -97,7 +97,7 @@ out:
 
 static int apply_config(struct comp_dev *dev, enum codec_cfg_type type)
 {
-	int ret;
+	int ret = 0;
 	int size;
 	struct codec_config *cfg;
 	void *data;
@@ -133,7 +133,8 @@ static int apply_config(struct comp_dev *dev, enum codec_cfg_type type)
 		if (ret != LIB_NO_ERROR) {
 			comp_err(dev, "apply_config() error %x: failed to apply parameter %d value %d",
 				 ret, param->id, *(int32_t *)param->data);
-			goto ret;
+			if (LIB_IS_FATAL_ERROR(ret))
+				goto ret;
 		}
 		/* Obtain next parameter, it starts right after the preceding one */
 		data = (char *)data + param->size;
@@ -141,6 +142,7 @@ static int apply_config(struct comp_dev *dev, enum codec_cfg_type type)
 	}
 
 	comp_dbg(dev, "apply_config() done");
+	ret  = 0;
 ret:
 	return ret;
 }

--- a/src/include/sof/audio/codec_adapter/codec/cadence.h
+++ b/src/include/sof/audio/codec_adapter/codec/cadence.h
@@ -15,6 +15,7 @@
 
 #define LIB_NAME_MAX_LEN 30
 #define LIB_NO_ERROR XA_NO_ERROR
+#define LIB_IS_FATAL_ERROR(e) ((e) & XA_FATAL_ERROR)
 
 /*****************************************************************************/
 /* Cadence API functions							     */


### PR DESCRIPTION
When setting parameters some API calls might not be fatal, so there
is no need to fail the apply config phase in this case.

For example, in case of Cadence MP3 codec the only supported PCM
output word size is 16 and 24. Trying to set a PCM word size of 32
will result in a non-fatal error and the word size would be adjusted to
24.

Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>