### PR TITLE
Topology: Fix two mistakes with HSPROC/DMICPROC and IIR pipeline include

### DIFF
--- a/tools/topology/sof-hda-generic.m4
+++ b/tools/topology/sof-hda-generic.m4
@@ -4,7 +4,7 @@
 # if XPROC is not defined, define with default pipe
 ifdef(`DMICPROC', , `define(DMICPROC, eq-iir-volume)')
 ifdef(`DMIC16KPROC', , `define(DMIC16KPROC, eq-iir-volume)')
-ifdef(`HSPROC', , `define(DMICPROC, volume)')
+ifdef(`HSPROC', , `define(HSPROC, volume)')
 
 # Include topology builder
 include(`utils.m4')

--- a/tools/topology/sof/pipe-eq-iir-volume-capture-16khz.m4
+++ b/tools/topology/sof/pipe-eq-iir-volume-capture-16khz.m4
@@ -12,6 +12,7 @@ include(`pga.m4')
 include(`dai.m4')
 include(`pipeline.m4')
 include(`bytecontrol.m4')
+include(`mixercontrol.m4')
 include(`eq_iir.m4')
 
 define(`CONTROL_NAME', 2nd Capture Volume)


### PR DESCRIPTION
This set of two patches fixes two potentially severe bugs. The first potentially can cause undesired processing for DMIC capture pipeline and the second causes topologies build fail if triggered.

Based on before and after diff of topology .conf files the bugs did not cause issues because there's only white space changes with this patch.