### PR TITLE
Prepare for Cadence decoder support

### DIFF
--- a/src/audio/codec_adapter/codec/cadence.c
+++ b/src/audio/codec_adapter/codec/cadence.c
@@ -383,6 +383,13 @@ int cadence_codec_process(struct comp_dev *dev)
 		goto err;
 	}
 
+	API_CALL(cd, XA_API_CMD_GET_CURIDX_INPUT_BUF, 0, &codec->cpd.consumed, ret);
+	if (ret != LIB_NO_ERROR) {
+		comp_err(dev, "cadence_codec_process() error %x: could not get consumed bytes",
+			 ret);
+		goto err;
+	}
+
 	comp_dbg(dev, "cadence_codec_process() done");
 
 	return 0;

--- a/src/audio/codec_adapter/codec/cadence.c
+++ b/src/audio/codec_adapter/codec/cadence.c
@@ -256,7 +256,7 @@ err:
 
 int cadence_codec_init_process(struct comp_dev *dev)
 {
-	int ret, lib_init_status;
+	int ret;
 	struct codec_data *codec = comp_get_codec(dev);
 	struct cadence_codec_data *cd = codec->private;
 
@@ -275,7 +275,7 @@ int cadence_codec_init_process(struct comp_dev *dev)
 	}
 
 	API_CALL(cd, XA_API_CMD_INIT, XA_CMD_TYPE_INIT_DONE_QUERY,
-		 &lib_init_status, ret);
+		 &codec->cpd.init_done, ret);
 	if (ret != LIB_NO_ERROR) {
 		comp_err(dev, "cadence_codec_init_process() error %x: failed to get lib init status",
 			 ret);

--- a/src/audio/codec_adapter/codec/cadence.c
+++ b/src/audio/codec_adapter/codec/cadence.c
@@ -260,6 +260,13 @@ int cadence_codec_init_process(struct comp_dev *dev)
 	struct codec_data *codec = comp_get_codec(dev);
 	struct cadence_codec_data *cd = codec->private;
 
+	API_CALL(cd, XA_API_CMD_SET_INPUT_BYTES, 0, &codec->cpd.avail, ret);
+	if (ret != LIB_NO_ERROR) {
+		comp_err(dev, "cadence_codec_init_process() error %x: failed to set size of input data",
+			 ret);
+		return ret;
+	}
+
 	API_CALL(cd, XA_API_CMD_INIT, XA_CMD_TYPE_INIT_PROCESS, NULL, ret);
 	if (ret != LIB_NO_ERROR) {
 		comp_err(dev, "cadence_codec_init_process() error %x: failed to initialize codec",
@@ -273,12 +280,13 @@ int cadence_codec_init_process(struct comp_dev *dev)
 		comp_err(dev, "cadence_codec_init_process() error %x: failed to get lib init status",
 			 ret);
 		return ret;
-	} else if (!lib_init_status) {
-		comp_err(dev, "cadence_codec_init_process() error: lib has not been initiated properly");
-		ret = -EINVAL;
+	}
+
+	API_CALL(cd, XA_API_CMD_GET_CURIDX_INPUT_BUF, 0, &codec->cpd.consumed, ret);
+	if (ret != LIB_NO_ERROR) {
+		comp_err(dev, "cadence_codec_init_process() error %x: could not get consumed bytes",
+			 ret);
 		return ret;
-	} else {
-		comp_dbg(dev, "cadence_codec_init_process(): lib has been initialized properly");
 	}
 
 	return 0;

--- a/src/audio/codec_adapter/codec/cadence.c
+++ b/src/audio/codec_adapter/codec/cadence.c
@@ -254,9 +254,38 @@ err:
 	return ret;
 }
 
+int cadence_codec_init_process(struct comp_dev *dev)
+{
+	int ret, lib_init_status;
+	struct codec_data *codec = comp_get_codec(dev);
+	struct cadence_codec_data *cd = codec->private;
+
+	API_CALL(cd, XA_API_CMD_INIT, XA_CMD_TYPE_INIT_PROCESS, NULL, ret);
+	if (ret != LIB_NO_ERROR) {
+		comp_err(dev, "cadence_codec_init_process() error %x: failed to initialize codec",
+			 ret);
+		return ret;
+	}
+
+	API_CALL(cd, XA_API_CMD_INIT, XA_CMD_TYPE_INIT_DONE_QUERY,
+		 &lib_init_status, ret);
+	if (ret != LIB_NO_ERROR) {
+		comp_err(dev, "cadence_codec_init_process() error %x: failed to get lib init status",
+			 ret);
+		return ret;
+	} else if (!lib_init_status) {
+		comp_err(dev, "cadence_codec_init_process() error: lib has not been initiated properly");
+		ret = -EINVAL;
+		return ret;
+	} else {
+		comp_dbg(dev, "cadence_codec_init_process(): lib has been initialized properly");
+	}
+
+	return 0;
+}
 int cadence_codec_prepare(struct comp_dev *dev)
 {
-	int ret = 0, mem_tabs_size, lib_init_status;
+	int ret = 0, mem_tabs_size;
 	struct codec_data *codec = comp_get_codec(dev);
 	struct cadence_codec_data *cd = codec->private;
 
@@ -324,26 +353,9 @@ int cadence_codec_prepare(struct comp_dev *dev)
 		goto free;
 	}
 
-	API_CALL(cd, XA_API_CMD_INIT, XA_CMD_TYPE_INIT_PROCESS, NULL, ret);
-	if (ret != LIB_NO_ERROR) {
-		comp_err(dev, "cadence_codec_prepare() error %x: failed to initialize codec",
-			 ret);
+	ret = cadence_codec_init_process(dev);
+	if (ret)
 		goto free;
-	}
-
-	API_CALL(cd, XA_API_CMD_INIT, XA_CMD_TYPE_INIT_DONE_QUERY,
-		 &lib_init_status, ret);
-	if (ret != LIB_NO_ERROR) {
-		comp_err(dev, "cadence_codec_prepare() error %x: failed to get lib init status",
-			 ret);
-		goto free;
-	} else if (!lib_init_status) {
-		comp_err(dev, "cadence_codec_prepare() error: lib has not been initiated properly");
-		ret = -EINVAL;
-		goto free;
-	} else {
-		comp_dbg(dev, "cadence_codec_prepare(): lib has been initialized properly");
-	}
 
 	comp_dbg(dev, "cadence_codec_prepare() done");
 	return 0;

--- a/src/audio/codec_adapter/codec/generic.c
+++ b/src/audio/codec_adapter/codec/generic.c
@@ -245,6 +245,25 @@ end:
 	return ret;
 }
 
+int codec_init_process(struct comp_dev *dev)
+{
+	int ret;
+	struct comp_data *cd = comp_get_drvdata(dev);
+	struct codec_data *codec = &cd->codec;
+
+	comp_dbg(dev, "codec_init_process() start");
+
+	ret = codec->ops->init_process(dev);
+	if (ret) {
+		comp_err(dev, "codec_init_process() error %x", ret);
+		goto out;
+	}
+
+	comp_dbg(dev, "codec_init_process() done");
+out:
+	return ret;
+}
+
 int codec_process(struct comp_dev *dev)
 {
 	int ret;

--- a/src/include/sof/audio/codec_adapter/codec/cadence.h
+++ b/src/include/sof/audio/codec_adapter/codec/cadence.h
@@ -42,6 +42,7 @@ struct cadence_codec_data {
 /*****************************************************************************/
 int cadence_codec_init(struct comp_dev *dev);
 int cadence_codec_prepare(struct comp_dev *dev);
+int cadence_codec_init_process(struct comp_dev *dev);
 int cadence_codec_process(struct comp_dev *dev);
 int cadence_codec_apply_config(struct comp_dev *dev);
 int cadence_codec_reset(struct comp_dev *dev);

--- a/src/include/sof/audio/codec_adapter/codec/generic.h
+++ b/src/include/sof/audio/codec_adapter/codec/generic.h
@@ -159,7 +159,8 @@ struct codec_processing_data {
 	uint32_t in_buff_size; /**< Specifies the size of codec input buffer. */
 	uint32_t out_buff_size; /**< Specifies the size of codec output buffer.*/
 	uint32_t avail; /**< Specifies how much data is available for codec to process.*/
-	uint32_t produced; /**< Specifies how much data the codec processed in its last task.*/
+	uint32_t produced; /**< Specifies how much data the codec produced in its last task.*/
+	uint32_t consumed; /**< Specified how much data the codec consumed in its last task */
 	void *in_buff; /**< A pointer to codec input buffer. */
 	void *out_buff; /**< A pointer to codec output buffer. */
 };

--- a/src/include/sof/audio/codec_adapter/codec/generic.h
+++ b/src/include/sof/audio/codec_adapter/codec/generic.h
@@ -49,6 +49,14 @@ struct codec_interface {
 	 */
 	int (*prepare)(struct comp_dev *dev);
 	/**
+	 * Codec specific init processing procedure, called as a part of
+	 * codec_adapter component copy in .copy(). Typically in this
+	 * phase a processing algorithm searches for the valid header,
+	 * does header decoding to get the parameters and initializes
+	 * state and configuration structures.
+	 */
+	int (*init_process)(struct comp_dev *dev);
+	/**
 	 * Codec specific processing procedure, called as part of codec_adapter
 	 * component copy in .copy(). This procedure is responsible to consume
 	 * samples provided by the codec_adapter and produce/output the processed
@@ -203,6 +211,7 @@ void *codec_allocate_memory(struct comp_dev *dev, uint32_t size,
 int codec_free_memory(struct comp_dev *dev, void *ptr);
 void codec_free_all_memory(struct comp_dev *dev);
 int codec_prepare(struct comp_dev *dev);
+int codec_init_process(struct comp_dev *dev);
 int codec_process(struct comp_dev *dev);
 int codec_apply_runtime_config(struct comp_dev *dev);
 int codec_reset(struct comp_dev *dev);

--- a/src/include/sof/audio/codec_adapter/codec/generic.h
+++ b/src/include/sof/audio/codec_adapter/codec/generic.h
@@ -161,6 +161,7 @@ struct codec_processing_data {
 	uint32_t avail; /**< Specifies how much data is available for codec to process.*/
 	uint32_t produced; /**< Specifies how much data the codec produced in its last task.*/
 	uint32_t consumed; /**< Specified how much data the codec consumed in its last task */
+	uint32_t init_done; /**< Specifies if the codec initialization is finished */
 	void *in_buff; /**< A pointer to codec input buffer. */
 	void *out_buff; /**< A pointer to codec output buffer. */
 };


### PR DESCRIPTION
This is the first PR in the series of preparing support for compressed streams decoding. Mainly, this takes care of adding the codec initialization phase during copy() function.

Initializaton phase for decoders needs to process input frames in order to get a valid header, parse it and figure out the codec parameters. It then also initalizes codec internal state and data structures. 