### PR TITLE
hda-dma: change host dma alignment

### DIFF
--- a/src/drivers/intel/hda/hda-dma.c
+++ b/src/drivers/intel/hda/hda-dma.c
@@ -67,8 +67,8 @@ DECLARE_TR_CTX(hdma_tr, SOF_UUID(hda_dma_uuid), LOG_LEVEL_INFO);
 #define HDA_STATE_RELEASE	BIT(0)
 
 /* DGMBS align value */
-#define HDA_DMA_BUFFER_ALIGNMENT	0x20
-#define HDA_DMA_COPY_ALIGNMENT		0x20
+#define HDA_DMA_BUFFER_ALIGNMENT	0x8
+#define HDA_DMA_COPY_ALIGNMENT		0x8
 #define HDA_DMA_BUFFER_ADDRESS_ALIGNMENT 0x80
 
 /* DMA host transfer timeout in microseconds */


### PR DESCRIPTION
Currently the hda dma alignment is set to 32 bytes, but the programming
manual says it can be either 32 or 64 bits. 32 bytes is actually causing
issues with 8kHz 16 bit mono pipeline as the transfer size goes under 32
bytes and is aligned up causing mismatch in period size calculation and
stopping the processing. Thus change the alignment to 64 bits to cover
both 32 and 64 bit cases.

Signed-off-by: Jaska Uimonen <jaska.uimonen@intel.com>