### PR TITLE
host: fix buffer size alignment

### DIFF
--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -721,7 +721,7 @@ static int host_params(struct comp_dev *dev,
 	}
 
 	/* calculate DMA buffer size */
-	buffer_size = ALIGN_UP(period_count * period_bytes, align);
+	buffer_size = ALIGN_UP(period_bytes, align) * period_count;
 
 	/* alloc DMA buffer or change its size if exists */
 	if (hd->dma_buffer) {


### PR DESCRIPTION
In buffer_size calculation period_bytes should be aligned with dma
before multiplying with period_count. This is an issue for example when
period_bytes could be smaller than the dma alignment size like with 8khz
16 bit mono stream.

Signed-off-by: Jaska Uimonen <jaska.uimonen@intel.com>