### PR TITLE
installer: TOOLCHAIN default value depends on XTENSA_TOOLS_ROOT

### DIFF
--- a/installer/GNUmakefile
+++ b/installer/GNUmakefile
@@ -29,7 +29,13 @@ target_of_cml := cnl
 # Same code, different Intel key
 target_of_ehl := tgl
 
-TOOLCHAIN ?= gcc
+ifeq (,${TOOLCHAIN})
+  ifeq (,${XTENSA_TOOLS_ROOT})
+    TOOLCHAIN := gcc
+  else
+    TOOLCHAIN := xcc
+  endif
+endif
 
 TREE_OPTS ?= --sort=size --dirsfirst
 INSTALL_OPTS ?= -D -p -m 0664


### PR DESCRIPTION
XTENSA_TOOLS_ROOT is required by xtensa-build-all.sh anyway, so don't
force the user to say twice that they want xcc.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>