### PR TITLE
topology: add new token for dynamic pipelines

### DIFF
--- a/tools/topology/m4/dai.m4
+++ b/tools/topology/m4/dai.m4
@@ -196,7 +196,7 @@ dnl DAI_ADD(pipeline,
 dnl     pipe id, dai type, dai_index, dai_be,
 dnl     buffer, periods, format,
 dnl     period , priority, core, time_domain,
-dnl     channels, rate)
+dnl     channels, rate, dynamic_pipe)
 define(`DAI_ADD',
 `undefine(`PIPELINE_ID')'
 `undefine(`DAI_TYPE')'
@@ -211,6 +211,7 @@ define(`DAI_ADD',
 `undefine(`SCHEDULE_TIME_DOMAIN')'
 `undefine(`DAI_CHANNELS')'
 `undefine(`DAI_RATE')'
+`undefine(`DYNAMIC_PIPE')'
 `define(`PIPELINE_ID', $2)'
 `define(`DAI_TYPE', STR($3))'
 `define(`DAI_INDEX', STR($4))'
@@ -225,6 +226,7 @@ define(`DAI_ADD',
 `define(`SCHEDULE_TIME_DOMAIN', $12)'
 `define(`DAI_CHANNELS', $13)'
 `define(`DAI_RATE', $14)'
+`define(`DYNAMIC_PIPE', $15)'
 `include($1)'
 `DEBUG_DAI($3, $4)'
 )

--- a/tools/topology/m4/pipeline.m4
+++ b/tools/topology/m4/pipeline.m4
@@ -22,6 +22,7 @@ define(`W_PIPELINE',
 `		SOF_TKN_SCHED_CORE'		STR($4)
 `		SOF_TKN_SCHED_FRAMES'		"0"
 `		SOF_TKN_SCHED_TIME_DOMAIN'	STR($5)
+`		SOF_TKN_SCHED_DYNAMIC'		ifdef(`DYNAMIC', "1", ifelse(DYNAMIC_PIPE, `1', "1", "0"))
 `	}'
 `}'
 `SectionData."'N_PIPELINE($1)`_data" {'
@@ -42,7 +43,7 @@ dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,
 dnl     period, priority, core,
 dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
-dnl     time_domain, sched_comp)
+dnl     time_domain, sched_comp, dynamic)
 define(`PIPELINE_PCM_ADD',
 `ifelse(eval(`$# > 10'), `1',
 `undefine(`PCM_ID')'
@@ -59,6 +60,7 @@ define(`PIPELINE_PCM_ADD',
 `undefine(`DAI_FORMAT')'
 `undefine(`SCHED_COMP')'
 `undefine(`DAI_PERIODS')'
+`undefine(`DYNAMIC_PIPE')'
 `define(`PIPELINE_ID', $2)'
 `define(`PCM_ID', $3)'
 `define(`PIPELINE_CHANNELS', $4)'
@@ -72,6 +74,7 @@ define(`PIPELINE_PCM_ADD',
 `define(`SCHEDULE_TIME_DOMAIN', $12)'
 `define(`DAI_FORMAT', $5)'
 `define(`SCHED_COMP', $13)'
+`define(`DYNAMIC_PIPE', $14)'
 `define(`DAI_PERIODS', DAI_DEFAULT_PERIODS)'
 `include($1)'
 `DEBUG_PCM_ADD($1, $3)'
@@ -124,7 +127,7 @@ dnl PIPELINE_ADD(pipeline,
 dnl     pipe id, max channels, format,
 dnl     period, priority, core,
 dnl     sched_comp, time_domain,
-dnl     pcm_min_rate, pcm_max_rate, pipeline_rate)
+dnl     pcm_min_rate, pcm_max_rate, pipeline_rate, dynamic)
 define(`PIPELINE_ADD',
 `ifelse(`$#', `12',
 `undefine(`PIPELINE_ID')'
@@ -137,6 +140,7 @@ define(`PIPELINE_ADD',
 `undefine(`PCM_MIN_RATE')'
 `undefine(`PCM_MAX_RATE')'
 `undefine(`PIPELINE_RATE')'
+`undefine(`DYNAMIC_PIPE')'
 `define(`PIPELINE_ID', $2)'
 `define(`PIPELINE_CHANNELS', $3)'
 `define(`PIPELINE_FORMAT', $4)'
@@ -148,6 +152,7 @@ define(`PIPELINE_ADD',
 `define(`PCM_MIN_RATE', $10)'
 `define(`PCM_MAX_RATE', $11)'
 `define(`PIPELINE_RATE', $12)'
+`define(`DYNAMIC_PIPE', $13)'
 `include($1)'
 ,`fatal_error(`Invalid parameters ($#) to PIPELINE_ADD')')'
 )

--- a/tools/topology/sof/tokens.m4
+++ b/tools/topology/sof/tokens.m4
@@ -29,6 +29,7 @@ SectionVendorTokens."sof_sched_tokens" {
 	SOF_TKN_SCHED_CORE			"203"
 	SOF_TKN_SCHED_FRAMES			"204"
 	SOF_TKN_SCHED_TIME_DOMAIN		"205"
+	SOF_TKN_SCHED_DYNAMIC			"206"
 }
 
 SectionVendorTokens."sof_volume_tokens" {


### PR DESCRIPTION
Add a new token in scheduler tokens to flag a pipeline
as dynamic. Modify the DAI_ADD ans PIPLINE_PCM_ADD macros
to indicate if the pipeline should be dynamic or now. It is
also possible to make all pipelines in a topology dynamic
by defining the macro DYNAMIC during build.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>