### PR TITLE
 buffer.h: silences warning "flags may be used uninitialized"

### DIFF
--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -197,9 +197,15 @@ static inline void buffer_writeback(struct comp_buffer *buffer, uint32_t bytes)
  */
 static inline void buffer_lock(struct comp_buffer *buffer, uint32_t *flags)
 {
-	if (!buffer->inter_core)
+	if (!buffer->inter_core) {
+		/* Ignored by buffer_unlock() below, silences "may be
+		 * used uninitialized" warning.
+		 */
+		*flags = 0xffffffff;
 		return;
+	}
 
+	/* Expands to: *flags = ... */
 	spin_lock_irq(buffer->lock, *flags);
 
 	/* invalidate in case something has changed during our wait */

--- a/src/include/sof/spinlock.h
+++ b/src/include/sof/spinlock.h
@@ -124,13 +124,13 @@ extern struct tr_ctx sl_tr;
 		tr_info(&sl_tr, "line: %d", line); \
 	} while (0)
 
-#else
+#else  /* CONFIG_DEBUG_LOCKS_VERBOSE */
 #define spin_lock_log(lock, line) do {} while (0)
 #define spin_lock_dbg(line) do {} while (0)
 #define spin_unlock_dbg(line) do {} while (0)
-#endif
+#endif /* CONFIG_DEBUG_LOCKS_VERBOSE */
 
-#else
+#else  /* CONFIG_DEBUG_LOCKS */
 
 #define trace_lock(__e) do {} while (0)
 #define tracev_lock(__e) do {} while (0)
@@ -138,7 +138,7 @@ extern struct tr_ctx sl_tr;
 #define spin_lock_dbg(line) do {} while (0)
 #define spin_unlock_dbg(line) do {} while (0)
 
-#endif
+#endif /* CONFIG_DEBUG_LOCKS */
 
 static inline int _spin_try_lock(spinlock_t *lock, int line)
 {


### PR DESCRIPTION
buffer_unlock() does not use flags.