### PR TITLE
installer: add missing mkdir staging/* dep. for symlinks

### DIFF
--- a/installer/GNUmakefile
+++ b/installer/GNUmakefile
@@ -67,7 +67,7 @@ endif
 
 COMMUNITY	:= ${STAGING_SOF_VERSION}/community
 INTEL_SIGNED	:= ${STAGING_SOF_VERSION}/intel-signed
-${COMMUNITY} ${INTEL_SIGNED} ${BUILDS_ROOT}:
+${COMMUNITY} ${INTEL_SIGNED} ${BUILDS_ROOT} ${STAGING_SOF_VERSION}:
 	mkdir -p $@
 
 
@@ -173,15 +173,15 @@ DICT_ALIASES   := ${ALIAS_list:%=${STAGING_SOF_VERSION}/sof-%.ldc}
 SIGNED_ALIASES := ${ALIAS_list:%=${STAGING_SOF_VERSION}/sof-%.ri}
 aliases: ${SIGNED_ALIASES} ${COMM_ALIASES} ${DICT_ALIASES}
 
-${COMM_ALIASES}: ${STAGING_SOF_VERSION}/community/sof-%.ri:
+${COMM_ALIASES}: ${STAGING_SOF_VERSION}/community/sof-%.ri: | ${COMMUNITY}
 	ln -sfT sof-${target_of_$*}.ri $@
 
-${DICT_ALIASES}: ${STAGING_SOF_VERSION}/sof-%.ldc:
+${DICT_ALIASES}: ${STAGING_SOF_VERSION}/sof-%.ldc: | ${STAGING_SOF_VERSION}
 	ln -sfT sof-${target_of_$*}.ldc $@
 
 # Some have the same key, others just the code. We don't make any
 # difference here and let the intel-signed/ directory handle this.
-${SIGNED_ALIASES}: ${STAGING_SOF_VERSION}/sof-%.ri:
+${SIGNED_ALIASES}: ${STAGING_SOF_VERSION}/sof-%.ri: | ${STAGING_SOF_VERSION}
 	ln -sfT intel-signed/sof-$*.ri $@
 
 


### PR DESCRIPTION
Fixes:
```
 rm -rf staging ; make aliases
 ln: failed to create symbolic link 'staging/sof/sof-glk.ri': No such
 file or directory
```
This also happens on a brand new checkout when building in parallel with
`make -j` because symbolic links don't have any dependency. Example at:

  https://github.com/marc-hb/sof/runs/2036288013

Signed-off-by: Marc Herbert <marc.herbert@intel.com>