### PR TITLE
xtensa-buid-all.sh: prepends $OVERRIDE_CONFIG with $SOF_TOP

### DIFF
--- a/scripts/xtensa-build-all.sh
+++ b/scripts/xtensa-build-all.sh
@@ -83,7 +83,7 @@ SIGNING_TOOL=RIMAGE
 
 if [ -n "${OVERRIDE_CONFIG}" ]
 then
-	OVERRIDE_CONFIG="src/arch/xtensa/configs/override/$OVERRIDE_CONFIG.config"
+	OVERRIDE_CONFIG="${SOF_TOP}/src/arch/xtensa/configs/override/$OVERRIDE_CONFIG.config"
 	[ -f "${OVERRIDE_CONFIG}" ] || die 'Invalid override config file %s\n' "${OVERRIDE_CONFIG}"
 fi
 
@@ -358,7 +358,7 @@ do
 
 	if [ -n "$OVERRIDE_CONFIG" ]
 	then
-		cp "../$OVERRIDE_CONFIG" override.config
+		cp "$OVERRIDE_CONFIG" override.config
 	fi
 
 	if [[ "x$MAKE_MENUCONFIG" == "xyes" ]]


### PR DESCRIPTION
commit e31afb36519f ("xtensa-build-all.sh: make it runnable from
anywhere") missed this.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>