### PR TITLE
kpb: pass the draining task deadline from detect component

### DIFF
--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -110,7 +110,9 @@ static inline void kpb_change_state(struct comp_data *kpb,
 
 static uint64_t kpb_task_deadline(void *data)
 {
-	return SOF_TASK_DEADLINE_ALMOST_IDLE;
+	struct draining_data *draining_data = (struct draining_data *)data;
+
+	return draining_data->task_deadline;
 }
 
 /**
@@ -1135,6 +1137,7 @@ static void kpb_init_draining(struct comp_dev *dev, struct kpb_client *cli)
 		kpb->draining_task_data.pb_limit = period_bytes_limit;
 		kpb->draining_task_data.dev = dev;
 		kpb->draining_task_data.sync_mode_on = kpb->sync_draining_mode;
+		kpb->draining_task_data.task_deadline = cli->task_deadline;
 
 		/* save current sink copy type */
 		comp_get_attribute(kpb->host_sink->sink, COMP_ATTR_COPY_TYPE,

--- a/src/include/sof/audio/kpb.h
+++ b/src/include/sof/audio/kpb.h
@@ -94,6 +94,7 @@ struct kpb_client {
 	enum kpb_client_state state; /**< current state of a client */
 	void *r_ptr; /**< current read position */
 	struct comp_buffer *sink; /**< client's sink */
+	uint64_t task_deadline;
 };
 
 enum buffer_state {
@@ -130,6 +131,7 @@ struct draining_data {
 	struct comp_dev *dev;
 	bool sync_mode_on;
 	enum comp_copy_type copy_type;
+	uint64_t task_deadline;
 };
 
 struct history_data {

--- a/src/samples/audio/detect_test.c
+++ b/src/samples/audio/detect_test.c
@@ -124,6 +124,7 @@ static void notify_kpb(const struct comp_dev *dev)
 	cd->client_data.r_ptr = NULL;
 	cd->client_data.sink = NULL;
 	cd->client_data.id = 0; /**< TODO: acquire proper id from kpb */
+	cd->client_data.task_deadline = SOF_TASK_DEADLINE_ALMOST_IDLE;
 	/* time in milliseconds */
 	cd->client_data.drain_req = (cd->drain_req != 0) ?
 					 cd->drain_req :


### PR DESCRIPTION
Allow draining task deadline to be specified from
detect component.

Signed-off-by: Viorel Suman <viorel.suman@nxp.com>