### PR TITLE
Enabled KWD demo on iMX8M arch

### DIFF
--- a/src/samples/audio/Kconfig
+++ b/src/samples/audio/Kconfig
@@ -11,7 +11,7 @@ menu "Audio component samples"
 	                Select for test smart amplifier component
 
         config SAMPLE_KEYPHRASE
-		depends on CAVS
+		depends on CAVS || IMX
 	        bool "Keyphrase test component"
 	        default y
 	        help

--- a/tools/topology/CMakeLists.txt
+++ b/tools/topology/CMakeLists.txt
@@ -119,6 +119,7 @@ set(TPLGS
 	"sof-imx8-wm8960-mixer\;sof-imx8-wm8960-mixer"
 	"sof-imx8-cs42888-mixer\;sof-imx8-cs42888-mixer"
 	"sof-imx8mp-wm8960-mixer\;sof-imx8mp-wm8960-mixer"
+	"sof-imx8mp-wm8960-kwd\;sof-imx8mp-wm8960-kwd"
 	"sof-tgl-max98357a-rt5682\;sof-tgl-max98357a-rt5682\;-DCODEC=MAX98357A\;-DFMT=s16le"
 	"sof-tgl-max98357a-rt5682\;sof-tgl-rt1011-rt5682\;-DCODEC=RT1011\;-DFMT=s24le"
 	"sof-tgl-max98373-rt5682\;sof-tgl-max98373-rt5682\;-DAMP_SSP=1"

--- a/tools/topology/sof-imx8mp-wm8960-kwd.m4
+++ b/tools/topology/sof-imx8mp-wm8960-kwd.m4
@@ -1,0 +1,96 @@
+#
+# Topology for i.MX8 with wm8960 codec for
+# keyword detection and triggering use case.
+#
+
+# Include topology builder
+include(`utils.m4')
+include(`dai.m4')
+include(`pipeline.m4')
+
+# Include TLV library
+include(`common/tlv.m4')
+
+# Include Token library
+include(`sof/tokens.m4')
+
+include(`sai.m4')
+# Include i.MX8 DSP configuration
+include(`platform/imx/imx8qxp.m4')
+
+define(KWD_PIPE_SCH_DEADLINE_US, 20000)
+
+define(DMIC_16k_PCM_NAME, `SAI3')
+
+# This is for iMX8M PLUS
+#
+# PCM 0 <-------+- KPBM 0 <-- B0 <-- SAI3 (wm8960)
+#               |
+# Keyword <-----+
+dnl PIPELINE_PCM_ADD(pipeline,
+dnl     pipe id, pcm, max channels, format,
+dnl     period, priority, core,
+dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
+dnl     time_domain, sched_comp)
+
+# Passthrough capture pipeline 1 on PCM 0 using max 2 channels.
+# Schedule 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-kfbm-no-lp-capture.m4,
+	1, 0, 2, s16le,
+	KWD_PIPE_SCH_DEADLINE_US, 0, 0,
+	16000, 16000, 16000)
+
+#
+# DAIs configuration
+#
+
+dnl DAI_ADD(pipeline,
+dnl     pipe id, dai type, dai_index, dai_be,
+dnl     buffer, periods, format,
+dnl     deadline, priority, core, time_domain)
+
+# This is for iMX8M PLUS
+# capture DAI is SAI3 using 2 periods
+# Buffers use s16le format, with 320 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-capture.m4,
+        1, SAI, 3, sai3-wm8960-hifi,
+        PIPELINE_SINK_1, 2, s16le,
+        KWD_PIPE_SCH_DEADLINE_US,
+        0, 0, SCHEDULE_TIME_DOMAIN_DMA)
+
+# keyword detector pipe
+dnl PIPELINE_ADD(pipeline,
+dnl     pipe id, max channels, format,
+dnl     period, priority, core,
+dnl     sched_comp, time_domain,
+dnl     pcm_min_rate, pcm_max_rate, pipeline_rate)
+PIPELINE_ADD(sof/pipe-detect.m4,
+	2, 2, s16le,
+	KWD_PIPE_SCH_DEADLINE_US, 1, 0,
+	PIPELINE_SCHED_COMP_1,
+	SCHEDULE_TIME_DOMAIN_TIMER,
+	16000, 16000, 16000)
+
+# Connect pipelines together
+SectionGraph."pipe-sof-apl-keyword-detect" {
+        index "0"
+
+        lines [
+		# keyword detect
+                dapm(PIPELINE_SINK_2, PIPELINE_SOURCE_1)
+		dapm(PIPELINE_PCM_1, PIPELINE_DETECT_2)
+        ]
+}
+
+# This is for iMX8M PLUS
+#
+# BE configurations - overrides config in ACPI if present
+#
+
+dnl DAI_CONFIG(type, dai_index, link_id, name, sai_config/ssp_config/dmic_config)
+DAI_CONFIG(SAI, 3, 0, sai3-wm8960-hifi,
+           SAI_CONFIG(I2S, SAI_CLOCK(mclk, 12288000, codec_mclk_in),
+                SAI_CLOCK(bclk, 3072000, codec_master),
+                SAI_CLOCK(fsync, 16000, codec_master),
+                SAI_TDM(2, 32, 3, 3),
+                SAI_CONFIG_DATA(SAI, 3, 0)))

--- a/tools/topology/sof/pipe-kfbm-no-lp-capture.m4
+++ b/tools/topology/sof/pipe-kfbm-no-lp-capture.m4
@@ -1,0 +1,95 @@
+# Passthrough Capture Pipeline with KPBM and PCM
+#
+# Pipeline Endpoints for connection are :-
+#
+#  host PCM_C <-- B1 <--+- KPBM 0 <-- B0 <-- source DAI0
+#               |
+#  Others    <--+
+
+# Include topology builder
+include(`utils.m4')
+include(`buffer.m4')
+include(`pcm.m4')
+include(`pga.m4')
+include(`dai.m4')
+include(`kpbm.m4')
+include(`mixercontrol.m4')
+include(`bytecontrol.m4')
+include(`pipeline.m4')
+
+dnl Soun Trigger Stream Name)
+define(`N_STS', `Sound Trigger Capture '$1)
+
+#
+# Controls
+#
+
+# kpbm initial parameters, aligned with struct sof_kpb_config
+CONTROLBYTES_PRIV(KPB_priv,
+`       bytes "0x53,0x4f,0x46,0x00,0x00,0x00,0x00,0x00,'
+`       0x18,0x00,0x00,0x00,0x00,0x10,0x00,0x03,'
+`       0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,'
+`       0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,'
+`       0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,'
+`       0x02,0x00,0x00,0x00,0x00,0x00,0x00,0x00,'
+`       0x80,0x3e,0x00,0x00,0x10,0x00,0x00,0x00"'
+)
+
+# KPB Bytes control with max value of 255
+C_CONTROLBYTES(KPB, PIPELINE_ID,
+	CONTROLBYTES_OPS(bytes, 258 binds the mixer control to bytes get/put handlers, 258, 258),
+	CONTROLBYTES_EXTOPS(258 binds the mixer control to bytes get/put handlers, 258, 258),
+	, , ,
+	CONTROLBYTES_MAX(, 304),
+	,
+	KPB_priv)
+
+#
+# Components and Buffers
+#
+
+# Host "Passthrough Capture" PCM
+# with 0 sink and 2 source periods
+W_PCM_CAPTURE(PCM_ID, Sound Trigger Capture, 0, 2, SCHEDULE_CORE)
+
+# "KPBM" has 2 source and 2 sink periods
+W_KPBM(0, PIPELINE_FORMAT, 2, 2, PIPELINE_ID, SCHEDULE_CORE,
+	LIST(`             ', "KPB"))
+
+# Capture Buffers
+W_BUFFER(0, COMP_BUFFER_SIZE(DAI_PERIODS,
+	COMP_SAMPLE_SIZE(PIPELINE_FORMAT), PIPELINE_CHANNELS, COMP_PERIOD_FRAMES(PCM_MAX_RATE, SCHEDULE_PERIOD)),
+	PLATFORM_DAI_MEM_CAP)
+# Capture Buffers
+W_BUFFER(1, COMP_BUFFER_SIZE(2,
+	COMP_SAMPLE_SIZE(PIPELINE_FORMAT), PIPELINE_CHANNELS, COMP_PERIOD_FRAMES(PCM_MAX_RATE, SCHEDULE_PERIOD)),
+	PLATFORM_HOST_MEM_CAP)
+
+#
+# Pipeline Graph
+#
+#  host PCM_C <-- B1 <--+- KPBM 0 <-- B0 <-- source DAI0
+#                	|
+#            Others  <--
+
+P_GRAPH(pipe-kpbm-capture-PIPELINE_ID, PIPELINE_ID,
+	LIST(`		',
+	`dapm(N_PCMC(PCM_ID), N_BUFFER(1))',
+	`dapm(N_BUFFER(1), N_KPBM(0, PIPELINE_ID))',
+	`dapm(N_KPBM(0, PIPELINE_ID), N_BUFFER(0))'))
+
+#
+# Pipeline Source and Sinks
+#
+indir(`define', concat(`PIPELINE_SINK_', PIPELINE_ID), N_BUFFER(0))
+indir(`define', concat(`PIPELINE_SOURCE_', PIPELINE_ID), N_KPBM(0, PIPELINE_ID))
+indir(`define', concat(`PIPELINE_PCM_', PIPELINE_ID), N_PCMC(PCM_ID))
+
+#
+# PCM Configuration
+#
+dnl PCM_CAPTURE_ADD(name, pipeline, capture)
+PCM_CAPTURE_ADD(DMIC_16k_PCM_NAME, PCM_ID, N_STS(PCM_ID))
+
+PCM_CAPABILITIES(N_STS(PCM_ID), CAPABILITY_FORMAT_NAME(PIPELINE_FORMAT), 16000, 16000, 2, PIPELINE_CHANNELS, 2, 160, 192, 256000, 537600, 1280000)
+


### PR DESCRIPTION
- Created KWD topology for iMX8M (adapting the KWD topology from APL arch)

- Enabled detect_test component default compilation for iMX arch (by enabling CONFIG_SAMPLE_KEYPHRASE in defconfig file)