### PR TITLE
FIX gcc10 linker errors

### DIFF
--- a/src/arch/xtensa/include/arch/string.h
+++ b/src/arch/xtensa/include/arch/string.h
@@ -30,6 +30,7 @@
 void *memcpy(void *dest, const void *src, size_t length);
 void *memset(void *dest, int data, size_t count);
 void *xthal_memcpy(void *dst, const void *src, size_t len);
+void *memmove(void *dest, const void *src, size_t n);
 
 int memset_s(void *dest, size_t dest_size,
 	     int data, size_t count);

--- a/src/lib/lib.c
+++ b/src/lib/lib.c
@@ -30,6 +30,26 @@ void *memset(void *s, int c, size_t n)
 
 	return s;
 }
+
+/* generic memmove */
+void *memmove(void *dest, const void *src, size_t n)
+{
+	char *d = dest;
+	const char *s = src;
+
+	if (d < s) {
+		/* same as memcpy */
+		arch_memcpy_s(d, n, s, n);
+	} else {
+		char *lasts = (char *)s + (n - 1);
+		char *lastd = d + (n - 1);
+
+		for (; n > 0; n--)
+			*lastd-- = *lasts--;
+	}
+
+	return dest;
+}
 #endif
 
 int memcpy_s(void *dest, size_t dest_size,

--- a/src/platform/intel/cavs/boot_loader.c
+++ b/src/platform/intel/cavs/boot_loader.c
@@ -29,6 +29,20 @@
 
 #define MANIFEST_SEGMENT_COUNT 3
 
+/* GCC10: memset linker error */
+/* generic memset */
+void *memset(void *s, int c, size_t n)
+{
+	uint8_t *d8 = s;
+	uint8_t v = c;
+	int i;
+
+	for (i = 0; i < n; i++)
+		d8[i] = v;
+
+	return s;
+}
+
 /* generic string compare cloned into the bootloader to
  * compact code and make it more readable
  */


### PR DESCRIPTION
fixes: https://github.com/thesofproject/sof/issues/3880

WIthout this fix, error snippet is like this.

```
Scanning dependencies of target sof
-- The C compiler identification is GNU 7.5.0
-- The C compiler identification is GNU 7.5.0
-- Check for working C compiler: /usr/bin/cc
/home/sof/work/xtensa-apl-elf/lib/gcc/xtensa-apl-elf/10.2.0/../../../../xtensa-apl-elf/bin/ld: CMakeFiles/bootloader.dir/__/__/platform/intel/cavs/boot_loader.c.o: in function `strcmp':
/home/sof/work/sof.git/src/platform/intel/cavs/boot_loader.c:206: undefined reference to `memset'
/home/sof/work/xtensa-apl-elf/lib/gcc/xtensa-apl-elf/10.2.0/../../../../xtensa-apl-elf/bin/ld: CMakeFiles/bootloader.dir/__/__/platform/intel/cavs/boot_loader.c.o: in function `bbzero':
/home/sof/work/sof.git/src/platform/intel/cavs/boot_loader.c:79: undefined reference to `memset'
collect2: error: ld returned 1 exit status
-- Check for working C compiler: /usr/bin/cc
src/arch/xtensa/CMakeFiles/bootloader.dir/build.make:136: recipe for target 'src/arch/xtensa/bootloader' failed
make[3]: *** [src/arch/xtensa/bootloader] Error 1
CMakeFiles/Makefile2:1502: recipe for target 'src/arch/xtensa/CMakeFiles/bootloader.dir/all' failed
make[2]: *** [src/arch/xtensa/CMakeFiles/bootloader.dir/all] Error 2
---------------------
[100%] Linking C executable sof
/home/sof/work/xtensa-apl-elf/lib/gcc/xtensa-apl-elf/10.2.0/../../../../xtensa-apl-elf/bin/ld: CMakeFiles/sof.dir/src/audio/mux/mux.c.o: in function `mux_prepare':
/home/sof/work/sof.git/src/audio/mux/mux.c:657: undefined reference to `memmove'
/home/sof/work/xtensa-apl-elf/lib/gcc/xtensa-apl-elf/10.2.0/../../../../xtensa-apl-elf/bin/ld: CMakeFiles/sof.dir/src/audio/mux/mux.c.o: in function `mux_mix_check':
/home/sof/work/sof.git/src/audio/mux/mux.c:62: undefined reference to `memmove'
collect2: error: ld returned 1 exit status
CMakeFiles/sof.dir/build.make:2740: recipe for target 'sof' failed
make[3]: *** [sof] Error 1
CMakeFiles/Makefile2:428: recipe for target 'CMakeFiles/sof.dir/all' failed
make[2]: *** [CMakeFiles/sof.dir/all] Error 2
CMakeFiles/Makefile2:1587: recipe for target 'src/arch/xtensa/CMakeFiles/bin.dir/rule' failed
make[1]: *** [src/arch/xtensa/CMakeFiles/bin.dir/rule] Error 2
Makefile:658: recipe for target 'bin' failed
make: *** [bin] Error 2
```