### PR TITLE
cmake: add some MEU-related comments

### DIFF
--- a/scripts/xtensa-build-all.sh
+++ b/scripts/xtensa-build-all.sh
@@ -45,8 +45,9 @@ usage: $0 [options] platform(s)
        -v Verbose Makefile log
        -j n Set number of make build jobs. Jobs=#cores when no flag. \
 Infinte when not specified.
-	-m path to MEU tool. Switches signing step to use MEU instead of rimage.
-           To use a non-default key define PRIVATE_KEY_OPTION, see below.
+       -m path to MEU tool. CMake disables rimage signing which produces a
+          .uns[igned] file signed by MEU. For a non-default key use the
+          PRIVATE_KEY_OPTION, see below.
 
 To use a non-default key you must define the right CMake parameter in the
 following environment variable:

--- a/src/arch/xtensa/CMakeLists.txt
+++ b/src/arch/xtensa/CMakeLists.txt
@@ -372,13 +372,18 @@ endif()
 # what they build in the moment.
 set(silenceUnusedWarning "${MEU_OPENSSL}")
 
-if(MEU_PATH OR DEFINED MEU_NO_SIGN)
+if(MEU_PATH OR DEFINED MEU_NO_SIGN) # Don't sign with rimage
 	if(NOT DEFINED MEU_OFFSET)
 		execute_process(
 			COMMAND ${MEU_PATH}/meu -ver
 			OUTPUT_VARIABLE MEU_VERSION_FULL_TEXT
 			OUTPUT_STRIP_TRAILING_WHITESPACE
+			RESULT_VARIABLE meu_ver_res
 		)
+		if(NOT ${meu_ver_res} EQUAL 0)
+			message(WARNING "${MEU_PATH}/meu -ver"
+			  " failed with: ${meu_ver_res}")
+		endif()
 
 		string(REGEX MATCH "Version:[\t\n ]*([^\t\n ]+)" ignored "${MEU_VERSION_FULL_TEXT}")
 		set(MEU_VERSION ${CMAKE_MATCH_1})
@@ -391,7 +396,10 @@ if(MEU_PATH OR DEFINED MEU_NO_SIGN)
 			set(MEU_OFFSET 1344)
 		endif()
 	endif()
+	message(STATUS MEU_OFFSET=${MEU_OFFSET})
 
+	# Passing -s ${MEU_OFFSET} disables rimage signing and produces
+	# one .uns file and one .met file instead of a .ri file.
 	add_custom_target(
 		run_rimage
 		COMMAND ${PROJECT_BINARY_DIR}/rimage_ep/build/rimage
@@ -438,7 +446,7 @@ if(MEU_PATH OR DEFINED MEU_NO_SIGN)
 			USES_TERMINAL
 		)
 	endif()
-else()
+else() # sign with rimage
 	add_custom_target(
 		run_rimage
 		COMMAND ${PROJECT_BINARY_DIR}/rimage_ep/build/rimage
@@ -462,7 +470,7 @@ else()
 	endif()
 
 	add_custom_target(run_meu DEPENDS run_rimage)
-endif()
+endif() # sign with MEU / nothing / rimage
 
 if(NOT DEFINED FIRMWARE_NAME)
 	set(fw_output_name "${fw_name}")


### PR DESCRIPTION
Notably:
- Log error and default MEU_OFFSET when meu -ver is not found.
- Explain rimage -s option

Signed-off-by: Marc Herbert <marc.herbert@intel.com>