### PR TITLE
xtensa-build-all.sh: 3 times more xcc threads than gcc threads

### DIFF
--- a/scripts/xtensa-build-all.sh
+++ b/scripts/xtensa-build-all.sh
@@ -16,6 +16,21 @@ PLATFORMS=()
 
 SOF_TOP=$(cd "$(dirname "$0")/.." && pwd)
 
+# As CMake forks one compiler process for each source file, the XTensa
+# compiler spends much more time idle waiting for the license server
+# over the network than actually using CPU or disk. A factor 3 has been
+# found optimal for 16 nproc 25ms away from the server; your mileage may
+# vary.
+#
+# The entire, purely local gcc build is so fast (~ 1s) that observing
+# any difference between -j nproc and -j nproc*N is practically
+# impossible so let's not waste RAM when building with gcc.
+
+if [ -n "$XTENSA_TOOLS_ROOT" ]; then
+    BUILD_JOBS=$((BUILD_JOBS * 3))
+fi
+
+
 die()
 {
 	>&2 printf '%s ERROR: ' "$0"
@@ -29,7 +44,7 @@ print_usage()
 {
     cat <<EOF
 Re-configures and re-builds SOF using the corresponding compiler and
-platform's _defconfig file.
+the <platform>_defconfig file.
 
 usage: $0 [options] platform(s)
 
@@ -347,6 +362,7 @@ do
 		TOOLCHAIN=xt
 		ROOT="$XTENSA_BUILDS_DIR/$XTENSA_CORE/xtensa-elf"
 		export XTENSA_SYSTEM=$XTENSA_BUILDS_DIR/$XTENSA_CORE/config
+		printf 'XTENSA_SYSTEM=%s\n' "${XTENSA_SYSTEM}"
 		PATH=$XTENSA_TOOLS_DIR/XtensaTools/bin:$OLDPATH
 		COMPILER="xcc"
 	else


### PR DESCRIPTION
As CMake forks one compiler process for each source file, the XTensa
compiler spends much more time idle waiting for the license server over
the network than actually using CPU or disk.

On my VM with 16 virtual cores, rebuilding one platform from scratch
with this commit goes down from 12s to less than 9s: more than 25%
faster. With Ninja it goes down from 11s to less than 8s. My license
server is 25ms away: a closer server does not need as many threads while
a more distant server would obviously benefit for even more
threads... while already getting an even better improvement than 25%
from just 3 times more threads! It's complicated and we probably don't
want to start the build by measuring latency to the license server.

The entire, purely local _gcc_ build is so fast (~ 1s) that observing any
the difference between -j nproc and -j nproc*N is practically impossible
so let's not waste RAM when building with gcc.

Also: log the $XTENSA_SYSTEM variable as it is required for incremental
builds; remove one apostrophe in the here-doc usage as it breaks the
parser of some editor (jed).

Signed-off-by: Marc Herbert <marc.herbert@intel.com>