### PR TITLE
installer: fix incremental builds

### DIFF
--- a/installer/GNUmakefile
+++ b/installer/GNUmakefile
@@ -79,6 +79,9 @@ INTEL_SIGNED	:= ${STAGING_SOF_VERSION}/intel-signed
 ${COMMUNITY} ${INTEL_SIGNED} ${BUILDS_ROOT} ${STAGING_SOF_VERSION}:
 	mkdir -p $@
 
+# The noise for incremental, do-nothing builds is incredible otherwise,
+# especially for build_tools
+GNUMAKEFLAGS = --no-print-directory
 
       #####################################
       ###    rsync to local or remote  ####

--- a/installer/GNUmakefile
+++ b/installer/GNUmakefile
@@ -157,7 +157,7 @@ endif
 ${BUILD_SOF_RIS}: ${BUILDS_ROOT}/build_%_${TOOLCHAIN}/sof.ri: | ${BUILDS_ROOT}
 	cd ${BUILDS_ROOT} && bdir="$$(dirname $@)" &&  \
       if [ -d $${bdir} ] && [ xcc != "${TOOLCHAIN}" ] ; then \
-        cmake --build $${bdir} -- sof; else \
+        cmake --build $${bdir} -- bin; else \
       $(CURDIR)/../scripts/xtensa-build-all.sh $*; fi
 
 


### PR DESCRIPTION
2 commits

Building "sof" does not rebuild the .ri firmware file. Switch to the
"bin" target which is what ./scripts/xtensa-build-all.sh builds.

Fixes: 4798096 ("installer: (re)build firmware, topologies and user
space tools)