### PR TITLE
xtensa-build-all: remove unused $ARCH, $XTOBJCPY and $XTOBJDUMP

### DIFF
--- a/.github/workflows/shallow_checkpatch.yml
+++ b/.github/workflows/shallow_checkpatch.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       PR_NUM: ${{github.event.number}}
-      CHK_CMD_OPTS: --codespell --codespellfile
+      CHK_CMD_OPTS: --ignore UNKNOWN_COMMIT_ID --codespell --codespellfile
           /usr/lib/python3/dist-packages/codespell_lib/data/dictionary.txt
     steps:
       # depth 2 so:

--- a/scripts/xtensa-build-all.sh
+++ b/scripts/xtensa-build-all.sh
@@ -311,12 +311,8 @@ do
 		if [ -d "$XTENSA_TOOLS_DIR" ]
 			then
 				XCC="xt-xcc"
-				XTOBJCOPY="xt-objcopy"
-				XTOBJDUMP="xt-objdump"
 			else
 				XCC="none"
-				XTOBJCOPY="none"
-				XTOBJDUMP="none"
 				>&2 printf 'WARNING: %s
 \t is not a directory, reverting to gcc\n' "$XTENSA_TOOLS_DIR"
 		fi

--- a/scripts/xtensa-build-all.sh
+++ b/scripts/xtensa-build-all.sh
@@ -165,35 +165,30 @@ do
 	case $platform in
 		byt)
 			PLATFORM="baytrail"
-			ARCH="xtensa"
 			XTENSA_CORE="Intel_HiFiEP"
 			HOST="xtensa-byt-elf"
 			XTENSA_TOOLS_VERSION="RD-2012.5-linux"
 			;;
 		cht)
 			PLATFORM="cherrytrail"
-			ARCH="xtensa"
 			XTENSA_CORE="CHT_audio_hifiep"
 			HOST="xtensa-byt-elf"
 			XTENSA_TOOLS_VERSION="RD-2012.5-linux"
 			;;
 		bdw)
 			PLATFORM="broadwell"
-			ARCH="xtensa"
 			XTENSA_CORE="LX4_langwell_audio_17_8"
 			HOST="xtensa-hsw-elf"
 			XTENSA_TOOLS_VERSION="RG-2017.8-linux"
 			;;
 		hsw)
 			PLATFORM="haswell"
-			ARCH="xtensa"
 			XTENSA_CORE="LX4_langwell_audio_17_8"
 			HOST="xtensa-hsw-elf"
 			XTENSA_TOOLS_VERSION="RG-2017.8-linux"
 			;;
 		apl)
 			PLATFORM="apollolake"
-			ARCH="xtensa-smp"
 			XTENSA_CORE="X4H3I16w2D48w3a_2017_8"
 
 			# test APL compiler aliases and ignore set -e here
@@ -208,7 +203,6 @@ do
 			;;
 		skl)
 			PLATFORM="skylake"
-			ARCH="xtensa"
 			XTENSA_CORE="X4H3I16w2D48w3a_2017_8"
 
 			# test APL compiler aliases and ignore set -e here
@@ -223,7 +217,6 @@ do
 			;;
 		kbl)
 			PLATFORM="kabylake"
-			ARCH="xtensa"
 			XTENSA_CORE="X4H3I16w2D48w3a_2017_8"
 
 			# test APL compiler aliases and ignore set -e here
@@ -238,7 +231,6 @@ do
 			;;
 		cnl)
 			PLATFORM="cannonlake"
-			ARCH="xtensa-smp"
 			XTENSA_CORE="X6H3CNL_2017_8"
 			HOST="xtensa-cnl-elf"
 			XTENSA_TOOLS_VERSION="RG-2017.8-linux"
@@ -246,7 +238,6 @@ do
 			;;
 		sue)
 			PLATFORM="suecreek"
-			ARCH="xtensa"
 			XTENSA_CORE="X6H3CNL_2017_8"
 			HOST="xtensa-cnl-elf"
 			XTENSA_TOOLS_VERSION="RG-2017.8-linux"
@@ -254,7 +245,6 @@ do
 			;;
 		icl)
 			PLATFORM="icelake"
-			ARCH="xtensa-smp"
 			XTENSA_CORE="X6H3CNL_2017_8"
 			HOST="xtensa-cnl-elf"
 			XTENSA_TOOLS_VERSION="RG-2017.8-linux"
@@ -262,7 +252,6 @@ do
 			;;
 		tgl)
 			PLATFORM="tgplp"
-			ARCH="xtensa-smp"
 			XTENSA_CORE="cavs2x_LX6HiFi3_2017_8"
 			HOST="xtensa-cnl-elf"
 			XTENSA_TOOLS_VERSION="RG-2017.8-linux"
@@ -275,7 +264,6 @@ do
 			;;
 		tgl-h)
 			PLATFORM="tgph"
-			ARCH="xtensa-smp"
 			XTENSA_CORE="cavs2x_LX6HiFi3_2017_8"
 			HOST="xtensa-cnl-elf"
 			XTENSA_TOOLS_VERSION="RG-2017.8-linux"
@@ -288,7 +276,6 @@ do
 			;;
 		jsl)
 			PLATFORM="jasperlake"
-			ARCH="xtensa-smp"
 			XTENSA_CORE="X6H3CNL_2017_8"
 			HOST="xtensa-cnl-elf"
 			XTENSA_TOOLS_VERSION="RG-2017.8-linux"
@@ -296,21 +283,18 @@ do
 			;;
 		imx8)
 			PLATFORM="imx8"
-			ARCH="xtensa"
 			XTENSA_CORE="hifi4_nxp_v3_3_1_2_dev"
 			HOST="xtensa-imx-elf"
 			XTENSA_TOOLS_VERSION="RG-2017.8-linux"
 			;;
 		imx8x)
 			PLATFORM="imx8x"
-			ARCH="xtensa"
 			XTENSA_CORE="hifi4_nxp_v3_3_1_2_dev"
 			HOST="xtensa-imx-elf"
 			XTENSA_TOOLS_VERSION="RG-2017.8-linux"
 			;;
 		imx8m)
 			PLATFORM="imx8m"
-			ARCH="xtensa"
 			XTENSA_CORE="hifi4_mscale_v0_0_2_prod"
 			HOST="xtensa-imx8m-elf"
 			XTENSA_TOOLS_VERSION="RG-2017.8-linux"


### PR DESCRIPTION
2 commit messages with plenty of git archeology.

I got tired of seeing these warnings every time I ran shellcheck, xtensa-build-all.sh is now shellcheck-clean.
