### PR TITLE
kpb: fix type for force_copy_type

### DIFF
--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -190,7 +190,7 @@ static struct comp_dev *kpb_new(const struct comp_driver *drv,
 #ifdef CONFIG_KPB_FORCE_COPY_TYPE_NORMAL
 	kpb->force_copy_type = COMP_COPY_NORMAL;
 #else
-	kpb->force_copy_type = -1; /* do not change kpb sink copy type */
+	kpb->force_copy_type = COMP_COPY_INVALID; /* do not change kpb sink copy type */
 #endif
 
 	/* Kpb has been created successfully */
@@ -1140,7 +1140,7 @@ static void kpb_init_draining(struct comp_dev *dev, struct kpb_client *cli)
 		comp_get_attribute(kpb->host_sink->sink, COMP_ATTR_COPY_TYPE,
 				   &kpb->draining_task_data.copy_type);
 
-		if (kpb->force_copy_type >= 0)
+		if (kpb->force_copy_type != COMP_COPY_INVALID)
 			comp_set_attribute(kpb->host_sink->sink, COMP_ATTR_COPY_TYPE,
 					   &kpb->force_copy_type);
 

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -215,6 +215,7 @@ enum comp_endpoint_type {
  * to comp_set_attribute().
  */
 enum comp_copy_type {
+	COMP_COPY_INVALID = -1,	/**< Invalid */
 	COMP_COPY_NORMAL = 0,	/**< Normal */
 	COMP_COPY_BLOCKING,	/**< Blocking */
 	COMP_COPY_ONE_SHOT,	/**< One-shot */


### PR DESCRIPTION
In kpb force_copy_type is declared as enum comp_copy_type,
but later on is initialized and compared with an integer
constant.

We should use everywhere only enum comp_copy_type.
Therefore add an invalid copy_type, COMP_COPY_INVALID in
enum comp_copy_type.
Use this one to initialize and compare force_copy_type.

Fixes: 7e46996c967e ("kpb: Introduce force_copy_type")

Signed-off-by: Iuliana Prodan <iuliana.prodan@nxp.com>