### PR TITLE
[skip ci] Dockerfile: apt-get install tree

### DIFF
--- a/scripts/docker_build/sof_builder/Dockerfile
+++ b/scripts/docker_build/sof_builder/Dockerfile
@@ -43,6 +43,7 @@ RUN apt-get -y update && \
 		software-properties-common \
 		sudo \
 		texinfo \
+		tree \
 		udev \
 		wget \
 		unzip \


### PR DESCRIPTION
Required to remove the copy hack introduced in
commit eb4373cb6143 (".github: new installer.yml")

Signed-off-by: Marc Herbert <marc.herbert@intel.com>