### PR TITLE
Extend kwd functionality by using a neural network for detection

### DIFF
--- a/src/include/sof/samples/audio/detect_test.h
+++ b/src/include/sof/samples/audio/detect_test.h
@@ -39,6 +39,14 @@ struct sof_detect_test_config {
 	uint32_t reserved[1];
 } __attribute__((packed));
 
+uint16_t test_keyword_get_sample_valid_bytes(struct comp_dev *dev);
+
+uint32_t test_keyword_get_detected(struct comp_dev *dev);
+void test_keyword_set_detected(struct comp_dev *dev, uint32_t detected);
+
+uint32_t test_keyword_get_drain_req(struct comp_dev *dev);
+void test_keyword_set_drain_req(struct comp_dev *dev, uint32_t drain_req);
+
 void detect_test_notify(const struct comp_dev *dev);
 
 /** used for binary blob size sanity checks */

--- a/src/include/sof/samples/audio/detect_test.h
+++ b/src/include/sof/samples/audio/detect_test.h
@@ -44,6 +44,7 @@ uint16_t test_keyword_get_sample_valid_bytes(struct comp_dev *dev);
 uint32_t test_keyword_get_detected(struct comp_dev *dev);
 void test_keyword_set_detected(struct comp_dev *dev, uint32_t detected);
 
+#if CONFIG_KWD_NN_SAMPLE_KEYPHRASE
 const int16_t *test_keyword_get_input(struct comp_dev *dev);
 
 int16_t test_keyword_get_input_byte(struct comp_dev *dev, uint32_t index);
@@ -52,6 +53,7 @@ int test_keyword_set_input_elem(struct comp_dev *dev, uint32_t index, int16_t va
 
 size_t test_keyword_get_input_size(struct comp_dev *dev);
 void test_keyword_set_input_size(struct comp_dev *dev, size_t input_size);
+#endif
 
 uint32_t test_keyword_get_drain_req(struct comp_dev *dev);
 void test_keyword_set_drain_req(struct comp_dev *dev, uint32_t drain_req);

--- a/src/include/sof/samples/audio/detect_test.h
+++ b/src/include/sof/samples/audio/detect_test.h
@@ -44,6 +44,15 @@ uint16_t test_keyword_get_sample_valid_bytes(struct comp_dev *dev);
 uint32_t test_keyword_get_detected(struct comp_dev *dev);
 void test_keyword_set_detected(struct comp_dev *dev, uint32_t detected);
 
+const int16_t *test_keyword_get_input(struct comp_dev *dev);
+
+int16_t test_keyword_get_input_byte(struct comp_dev *dev, uint32_t index);
+int16_t test_keyword_get_input_elem(struct comp_dev *dev, uint32_t index);
+int test_keyword_set_input_elem(struct comp_dev *dev, uint32_t index, int16_t val);
+
+size_t test_keyword_get_input_size(struct comp_dev *dev);
+void test_keyword_set_input_size(struct comp_dev *dev, size_t input_size);
+
 uint32_t test_keyword_get_drain_req(struct comp_dev *dev);
 void test_keyword_set_drain_req(struct comp_dev *dev, uint32_t drain_req);
 

--- a/src/include/sof/samples/audio/detect_test.h
+++ b/src/include/sof/samples/audio/detect_test.h
@@ -39,6 +39,8 @@ struct sof_detect_test_config {
 	uint32_t reserved[1];
 } __attribute__((packed));
 
+void detect_test_notify(const struct comp_dev *dev);
+
 /** used for binary blob size sanity checks */
 #define SOF_DETECT_TEST_MAX_CFG_SIZE sizeof(struct sof_detect_test_config)
 

--- a/src/include/sof/samples/audio/kwd_nn/kwd_nn_config.h
+++ b/src/include/sof/samples/audio/kwd_nn/kwd_nn_config.h
@@ -45,6 +45,6 @@
  * this threshold, the probability to be a
  * false-positive is high
  */
-#define KWD_NN_MAX_CONFIDENCE_THRESHOLD        128
+#define KWD_NN_MIN_ACCEPTABLE_CONFIDENCE	128
 
 #endif /* __KWD_NN_CONFIG_H__ */

--- a/src/include/sof/samples/audio/kwd_nn/kwd_nn_config.h
+++ b/src/include/sof/samples/audio/kwd_nn/kwd_nn_config.h
@@ -1,0 +1,50 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright 2021 NXP
+ *
+ * Author: Mihai Despotovici <mihai.despotovici@nxp.com>
+ */
+
+#ifndef __KWD_NN_CONFIG_H__
+#define __KWD_NN_CONFIG_H__
+
+/* RAW AUDIO DATA CONFIGURATION */
+#define KWD_NN_MS_TO_SAMPLES(samplerate, time) ((samplerate) * (time) / 1000)
+#define KWD_NN_SIZE_FROM_STRIDE_SIZE(stride, size, no_windows) \
+		(((no_windows) - 1) * (stride) + (size))
+
+#define KWD_NN_CONFIG_SAMPLERATE 16000
+#define KWD_NN_CONFIG_NO_CHANNELS 1
+
+#define KWD_NN_CONFIG_WINDOW_STRIDE KWD_NN_MS_TO_SAMPLES(KWD_NN_CONFIG_SAMPLERATE, 20)
+#define KWD_NN_CONFIG_WINDOW_SIZE KWD_NN_MS_TO_SAMPLES(KWD_NN_CONFIG_SAMPLERATE, 30)
+#define KWD_NN_CONFIG_NO_WINDOWS 49
+
+#define KWD_NN_CONFIG_RAW_SIZE (KWD_NN_CONFIG_NO_CHANNELS * \
+		KWD_NN_SIZE_FROM_STRIDE_SIZE( \
+			KWD_NN_CONFIG_WINDOW_STRIDE, \
+			KWD_NN_CONFIG_WINDOW_SIZE, \
+			KWD_NN_CONFIG_NO_WINDOWS))
+
+/* PREPROCESSED DATA CONFIGURATION */
+#define KWD_NN_CONFIG_PREPROCESSED_HEIGHT KWD_NN_CONFIG_NO_WINDOWS
+#define KWD_NN_CONFIG_SPECTROGRAM_SIZE 256
+#define KWD_NN_CONFIG_PREPROCESSED_AVGPOOL_WIDTH 6
+#define KWD_NN_CONFIG_PREPROCESSED_WIDTH 43
+#define KWD_NN_CONFIG_PREPROCESSED_SIZE (KWD_NN_CONFIG_PREPROCESSED_HEIGHT * \
+		KWD_NN_CONFIG_PREPROCESSED_WIDTH)
+
+/* NN can report one of the following 4 answers
+ * after applying inference: YES, NO, UNKNOWN or
+ * SILENCE. The function computes confidence
+ * value for each possible answer
+ */
+#define KWD_NN_CONFIDENCES_SIZE        4
+
+/* if confidence of the NN result is lower than
+ * this threshold, the probability to be a
+ * false-positive is high
+ */
+#define KWD_NN_MAX_CONFIDENCE_THRESHOLD        128
+
+#endif /* __KWD_NN_CONFIG_H__ */

--- a/src/include/sof/samples/audio/kwd_nn/kwd_nn_preprocess.h
+++ b/src/include/sof/samples/audio/kwd_nn/kwd_nn_preprocess.h
@@ -1,0 +1,17 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright 2021 NXP
+ *
+ * Author: Mihai Despotovici <mihai.despotovici@nxp.com>
+ */
+
+#ifndef __KWD_NN_PREPROCESS_H__
+#define __KWD_NN_PREPROCESS_H__
+
+#include <stdint.h>
+
+int kwd_nn_preprocess(const int16_t *input, uint8_t *output);
+
+void kwd_nn_preprocess_1s(const int16_t *raw_data, uint8_t *preprocessed_data);
+
+#endif /* __KWD_NN_PREPROCESS_H__ */

--- a/src/include/sof/samples/audio/kwd_nn/kwd_nn_process.h
+++ b/src/include/sof/samples/audio/kwd_nn/kwd_nn_process.h
@@ -1,0 +1,17 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright 2021 NXP
+ *
+ * Author: Mihai Despotovici <mihai.despotovici@nxp.com>
+ */
+
+#ifndef __KWD_NN_PROCESS_H__
+#define __KWD_NN_PROCESS_H__
+
+#include "kwd_nn_config.h"
+
+void kwd_nn_process_data
+	(uint8_t preprocessed_data[KWD_NN_CONFIG_PREPROCESSED_SIZE],
+	uint8_t confidences[KWD_NN_CONFIDENCES_SIZE]);
+
+#endif /* __KWD_NN_PROCESS_H__ */

--- a/src/include/sof/samples/audio/kwd_nn_detect_test.h
+++ b/src/include/sof/samples/audio/kwd_nn_detect_test.h
@@ -1,0 +1,30 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright 2021 NXP
+ *
+ * Author: Cristina Feies <cristina.ilie@nxp.com>
+ * Author: Viorel Suman <viorel.suman@nxp.com>
+ */
+
+#ifndef __USER_KWD_NN_DETECT_TEST_H__
+#define __USER_KWD_NN_DETECT_TEST_H__
+
+#include <sof/samples/audio/kwd_nn/kwd_nn_config.h>
+
+#define KWD_NN_SILENCE         0
+#define KWD_NN_UNKNOWN         1
+#define KWD_NN_YES_KEYWORD     2
+#define KWD_NN_NO_KEYWORD      3
+
+/* 990 ms of data considering frame rate 16KHz */
+#define KWD_NN_KEY_LEN         (990 * 16 * 1)
+#define KWD_NN_NUM_OF_CHANNELS 1
+/* ~2 seconds of samples */
+#define KWD_NN_IN_BUFF_SIZE    (2 * KWD_NN_KEY_LEN * KWD_NN_NUM_OF_CHANNELS)
+
+int kwd_nn_postprocess(uint8_t confidences[KWD_NN_CONFIDENCES_SIZE]);
+void kwd_nn_detect_test(struct comp_dev *dev,
+			const struct audio_stream *source,
+			uint32_t frames);
+
+#endif /* __USER_KWD_NN_DETECT_TEST_H__ */

--- a/src/include/sof/samples/audio/kwd_nn_detect_test.h
+++ b/src/include/sof/samples/audio/kwd_nn_detect_test.h
@@ -9,7 +9,8 @@
 #ifndef __USER_KWD_NN_DETECT_TEST_H__
 #define __USER_KWD_NN_DETECT_TEST_H__
 
-#include <sof/samples/audio/kwd_nn/kwd_nn_config.h>
+#include "kwd_nn/kwd_nn_config.h"
+#include <sof/audio/component.h>
 
 #define KWD_NN_SILENCE         0
 #define KWD_NN_UNKNOWN         1

--- a/src/samples/audio/CMakeLists.txt
+++ b/src/samples/audio/CMakeLists.txt
@@ -11,3 +11,7 @@ if(CONFIG_SAMPLE_KEYPHRASE)
 		detect_test.c
 	)
 endif()
+
+if(CONFIG_KWD_NN_SAMPLE_KEYPHRASE)
+	add_local_sources(sof kwd_nn_detect_test.c)
+endif()

--- a/src/samples/audio/Kconfig
+++ b/src/samples/audio/Kconfig
@@ -18,4 +18,13 @@ menu "Audio component samples"
 	                Select for Keyphrase test component.
 	                Provides basic functionality for use in testing of keyphrase detection pipelines.
 
+	config KWD_NN_SAMPLE_KEYPHRASE
+                depends on IMX
+                bool "KWD NN Keyphrase test component"
+                default n
+                help
+			Select for KWD NN Keyphrase test component based on neural network.
+			Provides ML functionality for use in testing of keyphrase detection pipelines.
+			Use KWD based on NN as alternative to the default KWD component.
+			Provides neural network as a library.
 endmenu

--- a/src/samples/audio/detect_test.c
+++ b/src/samples/audio/detect_test.c
@@ -136,7 +136,7 @@ static void notify_kpb(const struct comp_dev *dev)
 		       sizeof(cd->event_data));
 }
 
-static void detect_test_notify(const struct comp_dev *dev)
+void detect_test_notify(const struct comp_dev *dev)
 {
 	notify_host(dev);
 	notify_kpb(dev);

--- a/src/samples/audio/detect_test.c
+++ b/src/samples/audio/detect_test.c
@@ -653,6 +653,41 @@ static int test_keyword_prepare(struct comp_dev *dev)
 	return comp_set_state(dev, COMP_TRIGGER_PREPARE);
 }
 
+uint16_t test_keyword_get_sample_valid_bytes(struct comp_dev *dev)
+{
+	struct comp_data *cd = comp_get_drvdata(dev);
+
+	return cd->sample_valid_bytes;
+}
+
+uint32_t test_keyword_get_detected(struct comp_dev *dev)
+{
+	struct comp_data *cd = comp_get_drvdata(dev);
+
+	return cd->detected;
+}
+
+void test_keyword_set_detected(struct comp_dev *dev, uint32_t detected)
+{
+	struct comp_data *cd = comp_get_drvdata(dev);
+
+	cd->detected = detected;
+}
+
+uint32_t test_keyword_get_drain_req(struct comp_dev *dev)
+{
+	struct comp_data *cd = comp_get_drvdata(dev);
+
+	return cd->drain_req;
+}
+
+void test_keyword_set_drain_req(struct comp_dev *dev, uint32_t drain_req)
+{
+	struct comp_data *cd = comp_get_drvdata(dev);
+
+	cd->drain_req = drain_req;
+}
+
 static const struct comp_driver comp_keyword = {
 	.type	= SOF_COMP_KEYWORD_DETECT,
 	.uid	= SOF_RT_UUID(keyword_uuid),

--- a/src/samples/audio/kwd_nn_detect_test.c
+++ b/src/samples/audio/kwd_nn_detect_test.c
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright 2021 NXP
+//
+// Author: Cristina Feies <cristina.ilie@nxp.com>
+// Author: Viorel Suman <viorel.suman@nxp.com>
+
+#include <sof/samples/audio/kwd_nn_detect_test.h>
+#include <sof/samples/audio/kwd_nn/kwd_nn_preprocess.h>
+#include <sof/samples/audio/kwd_nn/kwd_nn_process.h>
+#include <sof/samples/audio/detect_test.h>
+#include <sof/audio/component.h>
+#include <sof/lib/wait.h>
+#include <stdint.h>
+
+static __aligned(64) uint8_t preprocessed_data[KWD_NN_CONFIG_PREPROCESSED_SIZE];
+static __aligned(8) uint8_t confidences[KWD_NN_CONFIDENCES_SIZE];
+
+static int kwd_nn_detect_postprocess(uint8_t confidences[KWD_NN_CONFIDENCES_SIZE])
+{
+	int i;
+	uint8_t max_confidence = confidences[0];
+	int max_idx = 0;
+
+	for (i = 1; i < KWD_NN_CONFIDENCES_SIZE; i++) {
+		if (max_confidence < confidences[i]) {
+			max_confidence = confidences[i];
+			max_idx = i;
+		}
+	}
+	if (max_confidence < KWD_NN_MIN_ACCEPTABLE_CONFIDENCE)
+		max_idx = KWD_NN_UNKNOWN;
+	return max_idx;
+}
+
+void kwd_nn_detect_test(struct comp_dev *dev,
+			const struct audio_stream *source,
+			uint32_t frames)
+{
+	void *src;
+	uint32_t count = frames; /**< Assuming single channel */
+	uint32_t sample;
+	uint32_t one_sec_samples = KWD_NN_KEY_LEN;
+	uint32_t half_sec_samples = one_sec_samples / 2;
+
+	/* perform detection within current period */
+	for (sample = 0; sample < count && !test_keyword_get_detected(dev); ++sample) {
+		src = (test_keyword_get_sample_valid_bytes(dev) * 8 == 16U) ?
+			audio_stream_read_frag_s16(source, sample) :
+			audio_stream_read_frag_s32(source, sample);
+		if (test_keyword_get_input_size(dev) < KWD_NN_IN_BUFF_SIZE) {
+			if (test_keyword_get_sample_valid_bytes(dev) == 16U)
+				test_keyword_set_input_elem(dev,
+							    test_keyword_get_input_size(dev),
+							    *((int16_t *)src));
+			else
+				test_keyword_set_input_elem(dev,
+							    test_keyword_get_input_size(dev),
+							    *((int32_t *)src));
+			test_keyword_set_input_size(dev, test_keyword_get_input_size(dev) + 1);
+		}
+		if (test_keyword_get_input_size(dev) > one_sec_samples) {
+			uint64_t time_start;
+			uint64_t time_stop;
+			struct timer *timer = timer_get();
+			int result;
+			int i, j;
+
+			comp_dbg(dev, "Drain values (0-3): 0x%x, 0x%x, 0x%x, 0x%x\n",
+				 test_keyword_get_input_byte(dev, 0),
+				 test_keyword_get_input_byte(dev, 1),
+				 test_keyword_get_input_byte(dev, 2),
+				 test_keyword_get_input_byte(dev, 3)
+			);
+			comp_dbg(dev, "Drain values (4-7): 0x%x, 0x%x, 0x%x, 0x%x\n",
+				 test_keyword_get_input_byte(dev, 4),
+				 test_keyword_get_input_byte(dev, 5),
+				 test_keyword_get_input_byte(dev, 6),
+				 test_keyword_get_input_byte(dev, 7)
+			);
+			time_start = platform_timer_get(timer);
+			kwd_nn_preprocess_1s(test_keyword_get_input(dev), preprocessed_data);
+			kwd_nn_process_data(preprocessed_data, confidences);
+			result = kwd_nn_detect_postprocess(confidences);
+			time_stop = platform_timer_get(timer);
+			comp_dbg(dev,
+				 "KWD: kwd_nn_detect_test_copy() inference done in %u ms",
+				 (unsigned int)((time_stop - time_start)
+				 / clock_ms_to_ticks(PLATFORM_DEFAULT_CLOCK, 1)));
+			switch (result) {
+			case KWD_NN_YES_KEYWORD:
+			case KWD_NN_NO_KEYWORD:
+				if (result == KWD_NN_NO_KEYWORD)
+					comp_info(dev,
+						  "kwd_nn_detect_test_copy(): keyword NO detected confidence %d",
+						  confidences[3]);
+				else
+					comp_info(dev,
+						  "kwd_nn_detect_test_copy(): keyword YES detected confidences %d",
+						  confidences[2]);
+				/* The algorithm shall use cd->drain_req
+				 * to specify its draining size request.
+				 * Zero value means default config value
+				 * will be used.
+				 */
+				test_keyword_set_drain_req(dev, 0);
+				detect_test_notify(dev);
+				test_keyword_set_detected(dev, 1);
+				break;
+			default:
+				if (result == KWD_NN_SILENCE)
+					comp_dbg(dev,
+						 "detect_test_copy(): SILENCE detected conf %d",
+						 confidences[0]);
+				else if (result == KWD_NN_UNKNOWN)
+					comp_dbg(dev,
+						 "detect_test_copy(): UNKNOWN detected conf %d",
+						 confidences[1]);
+				/* now shift input buffer half second left */
+				for (i = half_sec_samples, j = 0;
+						i < test_keyword_get_input_size(dev); i++, j++)
+					/* input[j] = input[i] */
+					test_keyword_set_input_elem(dev, j,
+								    test_keyword_get_input_elem
+								    (dev, i));
+				test_keyword_set_input_size(dev,
+							    test_keyword_get_input_size(dev) -
+							    half_sec_samples);
+				break;
+			}
+		}
+	}
+}


### PR DESCRIPTION
Extend kwd functionality by using a neural network for detection. 

Implemented a kwd detection functionality able to recognize some keywords by using a neural network (neural network is implemented in a lib linked with sof; this lib provide the preprocess & inference functions necessary in recognizing the keywords). Kwd functionality based on neural network is implemented in separate file (nxp_detect_test.c) and represents an alternative to the default kwd functionality (default_detect_test function). At this moment switch will be done by using the DEFAULT_DETECT macro found in detect_test.c source file.
