### PR TITLE
platform: imx8: Fix clock frequency for i.MX8X

### DIFF
--- a/src/platform/imx8/include/platform/lib/clk.h
+++ b/src/platform/imx8/include/platform/lib/clk.h
@@ -18,8 +18,13 @@ struct sof;
 
 #define CPU_DEFAULT_IDX		0
 
+#ifdef CONFIG_IMX8
 #define CLK_DEFAULT_CPU_HZ	666000000
 #define CLK_MAX_CPU_HZ		666000000
+#else /* CONFIG_IMX8X */
+#define CLK_DEFAULT_CPU_HZ	640000000
+#define CLK_MAX_CPU_HZ		640000000
+#endif
 
 #define NUM_CLOCKS	1
 

--- a/src/platform/imx8/lib/clk.c
+++ b/src/platform/imx8/lib/clk.c
@@ -14,7 +14,11 @@
 #include <sof/spinlock.h>
 
 const struct freq_table platform_cpu_freq[] = {
+#ifdef CONFIG_IMX8
 	{ 666000000, 666000 },
+#else /* CONFIG_IMX8X */
+	{ 640000000, 640000 },
+#endif
 };
 
 STATIC_ASSERT(NUM_CPU_FREQ == ARRAY_SIZE(platform_cpu_freq),


### PR DESCRIPTION
Looking at the timestamps from sof-logger it looks like
the DSP core frequency on i.MX8X is wrong.

Documentation confirms this. It should be 640Mhz.

Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>