### PR TITLE
compiler: use libc versions of memset, memcpy for GCC10 onwards

### DIFF
--- a/src/arch/xtensa/CMakeLists.txt
+++ b/src/arch/xtensa/CMakeLists.txt
@@ -93,8 +93,12 @@ else()
 	set(XTENSA_C_FLAGS -mtext-section-literals)
 endif()
 
-# linker flags
-target_link_libraries(sof_options INTERFACE ${stdlib_flag} -lgcc -Wl,--no-check-sections -ucall_user_start -Wl,-static)
+# linker flags - GCC >= 10.x uses libc
+if (CMAKE_COMPILER_IS_GNUCC AND CMAKE_C_COMPILER_VERSION VERSION_GREATER 10.0)
+	target_link_libraries(sof_options INTERFACE ${stdlib_flag} -lgcc -lc -Wl,--no-check-sections -ucall_user_start -Wl,-static)
+else()
+	target_link_libraries(sof_options INTERFACE ${stdlib_flag} -lgcc -Wl,--no-check-sections -ucall_user_start -Wl,-static)
+endif()
 
 # C & ASM flags
 target_compile_options(sof_options INTERFACE ${stdlib_flag} -fno-inline-functions ${XTENSA_C_ASM_FLAGS})

--- a/src/arch/xtensa/include/arch/compiler_info.h
+++ b/src/arch/xtensa/include/arch/compiler_info.h
@@ -29,6 +29,11 @@
 #define CC_MINOR __GNUC_MINOR__
 #define CC_MICRO __GNUC_PATCHLEVEL__
 #define CC_NAME "GCC"
+
+#if CC_MAJOR >= 10
+#define CC_USE_LIBC
+#endif
+
 #endif
 
 #define CC_DESC " " XCC_TOOLS_VERSION

--- a/src/lib/lib.c
+++ b/src/lib/lib.c
@@ -5,12 +5,14 @@
 // Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
 
 #include <sof/string.h>
+#include <sof/compiler_info.h>
 
 #include <stddef.h>
 #include <stdint.h>
 
-/* Not needed for host or Zephyr */
-#if !CONFIG_LIBRARY && !__ZEPHYR__
+/* Not needed for host or Zephyr or CC uses LIBC */
+#if !CONFIG_LIBRARY && !__ZEPHYR__ && !defined(CC_USE_LIBC)
+
 /* used by gcc - but uses arch_memcpy internally */
 void *memcpy(void *dest, const void *src, size_t n)
 {
@@ -30,6 +32,22 @@ void *memset(void *s, int c, size_t n)
 
 	return s;
 }
+
+int memcmp(const void *p, const void *q, size_t count)
+{
+	uint8_t *s1 = (uint8_t *)p;
+	uint8_t *s2 = (uint8_t *)q;
+
+	while (count) {
+		if (*s1 != *s2)
+			return *s1 < *s2 ? -1 : 1;
+		s1++;
+		s2++;
+		count--;
+	}
+	return 0;
+}
+
 #endif
 
 int memcpy_s(void *dest, size_t dest_size,
@@ -52,23 +70,6 @@ void *__vec_memcpy(void *dst, const void *src, size_t len)
 void *__vec_memset(void *dest, int data, size_t src_size)
 {
 	return memset(dest, data, src_size);
-}
-#endif
-
-#if !CONFIG_LIBRARY && !__ZEPHYR__
-int memcmp(const void *p, const void *q, size_t count)
-{
-	uint8_t *s1 = (uint8_t *)p;
-	uint8_t *s2 = (uint8_t *)q;
-
-	while (count) {
-		if (*s1 != *s2)
-			return *s1 < *s2 ? -1 : 1;
-		s1++;
-		s2++;
-		count--;
-	}
-	return 0;
 }
 #endif
 


### PR DESCRIPTION
GCC configuration for ct-NG uses newlibc libc versions of common
memcpy() and memset(). Check this in makefile and lib.c so we can use
the correct versions.

Signed-off-by: Liam Girdwood <liam.r.girdwood@linux.intel.com>