### PR TITLE
drivers: imx: esai: set private data after allocation

### DIFF
--- a/src/drivers/imx/esai.c
+++ b/src/drivers/imx/esai.c
@@ -398,6 +398,8 @@ static int esai_probe(struct dai *dai)
 		dai_err(dai, "ESAI probe failure, out of memory");
 		return -ENOMEM;
 	}
+	dai_set_drvdata(dai, pdata);
+
 	/* ESAI core reset */
 	dai_write(dai, REG_ESAI_ECR, ESAI_ECR_ERST | ESAI_ECR_ESAIEN);
 	dai_write(dai, REG_ESAI_ECR, ESAI_ECR_ESAIEN);


### PR DESCRIPTION
ESAI allocates private data and retrieves this data using
dai_get_drvdata().
But this is never set using dai_set_drvdata() and sometimes
dai_get_drvdata() returns NULL.
So, after private data is allocated, set it using dai_set_drvdata().

Without this fix, on i.MX8QM, on playback we get:
root@imx8qmmek:~# aplay -Dhw:1,0 -f S16_LE -c 2 -r 48000 -d 5 -t raw /dev/urandom
Playing raw data '/dev/urandom' : Signed 16 bit Little Endian, Rate 48000 Hz, Stereo
[  197.478128] sof-audio-of 556e8000.dsp: error : DSP panic!
[  197.483547] sof-audio-of 556e8000.dsp: error: runtime exception
[  197.489473] sof-audio-of 556e8000.dsp: error: trace point 0dead006
[  197.495658] sof-audio-of 556e8000.dsp: error: panic at :0
[  197.501064] sof-audio-of 556e8000.dsp: error: DSP Firmware Oops
[...]

Fixes: f40222a1eaae ("drivers: imx: esai: use rate from topology")
Signed-off-by: Iuliana Prodan <iuliana.prodan@nxp.com>