### PR TITLE
version.cmake: add --dirty to git describe command

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -117,20 +117,18 @@ jobs:
       - uses: actions/checkout@v2
         with: {fetch-depth: 0, submodules: recursive}
 
-      # FIXME: could/should probably use ./scripts/xtensa-build-all.sh
-      # -o agent.config instead of hiding this here.
       - name: turn off HAVE_AGENT
-        run: sed -i $(($(grep "config HAVE_AGENT" -n src/platform/Kconfig |
-          cut -f1 -d:)+2))"s/default y/default n/" src/platform/Kconfig
+        run: echo CONFIG_HAVE_AGENT=n >
+          src/arch/xtensa/configs/override/no-agent.config
 
       - name: docker SOF
         run: docker pull thesofproject/sof && docker tag thesofproject/sof sof
 
-      - name: xtensa-build-all
+      - name: xtensa-build-all -o no-agent
         env:
           PLATFORM: ${{ matrix.platform }}
         run: ./scripts/docker-run.sh
-          ./scripts/xtensa-build-all.sh -r ${PLATFORM}
+          ./scripts/xtensa-build-all.sh -o no-agent -r ${PLATFORM}
 
       - name: docker QEMU
         run: docker pull thesofproject/sofqemu &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,9 +57,8 @@ jobs:
     - &qemuboottest
       stage: tests
       script:
-        - sed -i $(($(grep "config HAVE_AGENT" -n src/platform/Kconfig |
-             cut -f1 -d:)+2))"s/default y/default n/" src/platform/Kconfig
-        - ./scripts/docker-run.sh ./scripts/xtensa-build-all.sh -r $PLATFORM
+        - echo CONFIG_HAVE_AGENT=n > src/arch/xtensa/configs/override/no-agent.config
+        - ./scripts/docker-run.sh ./scripts/xtensa-build-all.sh -o no-agent -r $PLATFORM
         - ./scripts/docker-qemu.sh ../sof.git/scripts/qemu-check.sh $PLATFORM
       env: PLATFORM='byt cht'
       before_install:

--- a/scripts/cmake/version.cmake
+++ b/scripts/cmake/version.cmake
@@ -23,7 +23,8 @@ if(EXISTS ${TARBALL_VERSION_SOURCE_PATH})
 	list(GET lines 1 GIT_LOG_HASH)
 	message(STATUS "Found ${TARBALL_VERSION_FILE_NAME}")
 else()
-	execute_process(COMMAND git describe --tags --abbrev=12 --match v*
+	execute_process(
+	        COMMAND git describe --tags --abbrev=12 --match v* --dirty
 		WORKING_DIRECTORY ${SOF_ROOT_SOURCE_DIRECTORY}
 		OUTPUT_VARIABLE GIT_TAG
 		OUTPUT_STRIP_TRAILING_WHITESPACE


### PR DESCRIPTION
For at least two reasons:
  - exposes sneaky change(s) performed by automation if/when any
  - solves the mystery of the Source content hash (printed on the next line)
    changing while the git version does not.

Example, at https://sof-ci.01.org/sofpr/PR3941/build8429/build/bdw_gcc.txt

 -- Found Git: /usr/bin/git (found version "2.17.1")
 -- GIT_TAG / GIT_LOG_HASH : v1.7-rc1-151-g023c4abacde1 / 023c4abac
 -- Source content hash: 91f261ea

whereas at https://github.com/thesofproject/sof/runs/2166298087, xtensa-build-all

 -- Found Git: /usr/bin/git (found version "2.17.1")
 -- GIT_TAG / GIT_LOG_HASH : v1.7-rc1-151-g023c4abacde1 / 023c4abac
 -- Source content hash: 67f31697


> solves the mystery of the Source content hash (printed on the next line)  changing while the git version does not.

Little -dirty mystery solved by the other commit that removes a KConfig hack and replaces it by an untracked `no-agent.config` file. The Source content hash is now the same all across the board:

https://github.com/thesofproject/sof/pull/3943/checks?check_run_id=2171612562
https://sof-ci.01.org/sofpr/PR3943/build8442/build/tgl_gcc.txt
https://travis-ci.org/github/thesofproject/sof/jobs/764032498

None of these is "-dirty"
