### PR TITLE
ll_schedule.c: fix "uninitialized task_take" warning in CONFIG_TRACEV

### DIFF
--- a/src/include/sof/trace/trace.h
+++ b/src/include/sof/trace/trace.h
@@ -84,6 +84,7 @@ static inline struct trace *trace_get(void)
 	return sof_get()->trace;
 }
 
+/* Silences compiler warnings about unused variables */
 #define trace_unused(class, ctx, id_1, id_2, format, ...) \
 	UNUSED(ctx, id_1, id_2, ##__VA_ARGS__)
 
@@ -377,6 +378,7 @@ struct tr_ctx {
 				    _TRACE_INV_ID, _TRACE_INV_ID, \
 				    fmt, ##__VA_ARGS__)
 
+/* tracev_ output depends on CONFIG_TRACEV=y */
 #define tr_dbg(ctx, fmt, ...) \
 	tracev_event_with_ids(_TRACE_INV_CLASS, ctx, \
 			      _TRACE_INV_ID, _TRACE_INV_ID, fmt, ##__VA_ARGS__)

--- a/src/schedule/ll_schedule.c
+++ b/src/schedule/ll_schedule.c
@@ -159,11 +159,12 @@ static void schedule_ll_clients_reschedule(struct ll_schedule_data *sch)
 {
 	struct list_item *wlist;
 	struct list_item *tlist;
-	struct task *task, *task_take;
+	struct task *task;
 	uint64_t next_tick = UINT64_MAX;
 
 	/* rearm only if there is work to do */
 	if (atomic_read(&sch->domain->total_num_tasks)) {
+		struct task *task_take_dbg = NULL;
 		/* traverse to set timer according to the earliest task */
 		list_for_item_safe(wlist, tlist, &sch->tasks) {
 			task = container_of(wlist, struct task, list);
@@ -171,12 +172,13 @@ static void schedule_ll_clients_reschedule(struct ll_schedule_data *sch)
 			/* update to use the earlier tick */
 			if (task->start < next_tick) {
 				next_tick = task->start;
-				task_take = task;
+				task_take_dbg = task;
 			}
 		}
 
-		tr_dbg(&ll_tr, "schedule_ll_clients_reschedule next_tick %u task_take %p",
-		       (unsigned int)next_tick, task_take);
+		tr_dbg(&ll_tr,
+		       "schedule_ll_clients_reschedule next_tick %u task_take %p",
+		       (unsigned int)next_tick, task_take_dbg);
 		domain_set(sch->domain, next_tick);
 	}
 

--- a/src/trace/Kconfig
+++ b/src/trace/Kconfig
@@ -15,7 +15,8 @@ config TRACEV
 	depends on TRACE
 	default n
 	help
-	  Enabling verbose traces.
+	  Enabling verbose traces. tr_dbg() statements depend on this at
+	  compile-time and on run-time filtering below too.
 
 config TRACEE
 	bool "Trace error"


### PR DESCRIPTION
Looks like no one ever uses tr_dbg()?

Signed-off-by: Marc Herbert <marc.herbert@intel.com>