### PR TITLE
topology/cmake: add missing .m4 dependency, fixes incremental build

### DIFF
--- a/scripts/build-tools.sh
+++ b/scripts/build-tools.sh
@@ -60,8 +60,8 @@ Build commands for respective tools:
         ctl:        make -C "$BUILD_TOOLS_DIR" sof-ctl
         logger:     make -C "$BUILD_TOOLS_DIR" sof-logger
         probes:     make -C "$BUILD_TOOLS_DIR" sof-probes
-        tests:      make -C "$BUILD_TOOLS_DIR" tests
         topologies: make -C "$BUILD_TOOLS_DIR" topologies
+        test tplgs: make -C "$BUILD_TOOLS_DIR" tests
         fuzzer:     make -C "$BUILD_TOOLS_DIR/fuzzer"
 EOFUSAGE
 }

--- a/tools/topology/CMakeLists.txt
+++ b/tools/topology/CMakeLists.txt
@@ -150,7 +150,7 @@ foreach(tplg ${TPLGS})
 	endif()
 
 	add_custom_command(
-		OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${output}.conf
+		OUTPUT ${output}.conf
 		COMMAND m4 --fatal-warnings
 			${DEFINES}
 			-I ${CMAKE_CURRENT_SOURCE_DIR}/m4
@@ -161,6 +161,7 @@ foreach(tplg ${TPLGS})
 			${CMAKE_CURRENT_SOURCE_DIR}/common/abi.m4
 			${CMAKE_CURRENT_SOURCE_DIR}/${input}.m4
 			> ${output}.conf
+		MAIN_DEPENDENCY ${CMAKE_CURRENT_SOURCE_DIR}/${input}.m4
 		DEPENDS abi
 		VERBATIM
 		USES_TERMINAL
@@ -184,7 +185,7 @@ foreach(tplg ${TPLGS})
 	add_custom_command(
 		OUTPUT ${output}.tplg
 		COMMAND alsatplg \$\${VERBOSE:+-v 1} -c ${output}.conf -o ${output}.tplg
-		DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${output}.conf
+		MAIN_DEPENDENCY ${output}.conf
 		USES_TERMINAL
 	)
 

--- a/tools/topology/get_abi.sh
+++ b/tools/topology/get_abi.sh
@@ -2,6 +2,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright(c) 2019 Intel Corporation. All rights reserved.
 
+
+set -e
+
 MAJOR=`grep '#define SOF_ABI_MAJOR ' $1/src/include/kernel/abi.h | grep -E ".[[:digit:]]$" -o`
 MINOR=`grep '#define SOF_ABI_MINOR ' $1/src/include/kernel/abi.h | grep -E ".[[:digit:]]$" -o`
 PATCH=`grep '#define SOF_ABI_PATCH ' $1/src/include/kernel/abi.h | grep -E ".[[:digit:]]$" -o`


### PR DESCRIPTION
There was no [MAIN_]DEPENDS on the .m4 source file, so changes were not
triggering any rebuild.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>