### PR TITLE
logger: new relative timestamps option, relative to first entry seen

### DIFF
--- a/tools/logger/convert.h
+++ b/tools/logger/convert.h
@@ -40,6 +40,7 @@ struct convert_config {
 	int raw_output;
 	int dump_ldc;
 	int hide_location;
+	int relative_timestamps;
 	int time_precision;
 	struct snd_sof_uids_header *uids_dict;
 	struct snd_sof_logs_header *logs_header;

--- a/tools/logger/logger.c
+++ b/tools/logger/logger.c
@@ -286,7 +286,8 @@ int main(int argc, char *argv[])
 	if (config.version_fw) {
 		config.version_fd = fopen(config.version_file, "rb");
 		if (!config.version_fd) {
-			fprintf(stderr, "error: Unable to open version file %s\n",
+			fprintf(stderr,
+				"error: Unable to open version file %s, check permissions\n",
 				config.version_file);
 			ret = errno;
 			goto out;
@@ -324,7 +325,8 @@ int main(int argc, char *argv[])
 	} else if (config.in_file) {
 		config.in_fd = fopen(config.in_file, "rb");
 		if (!config.in_fd) {
-			fprintf(stderr, "error: Unable to open in file %s\n",
+			fprintf(stderr,
+				"error: Unable to open in file %s, check permissions\n",
 				config.in_file);
 			ret = errno;
 			goto out;


### PR DESCRIPTION
2 commits. The only big and main one:


Add a new sof-logger -e 0/1 relative timestamps option where the
TIMESTAMP column is relative to the first entry seen.

Removes many digits and makes the TIMESTAMP column much more readable in
short logs.

Also stop showing "NaN" as the first DELTA like something went
wrong. Show zero instead.

The new option is off by default when using -r(aw) and on otherwise.

The first entry is kept always absolute.

Before:
```
         TIMESTAMP              DELTA C# COMPONENT     LOCATION                      CONTENT
[6653843012.343750] (             NaN) c0 dma-trace    src/trace/dma-trace.c:339     ERROR FW ...
[6653843111.510417] (       99.166664) c0 ll-schedule  ./schedule/ll_schedule.c:229  perf ll_work
[6653843309.010417] (      197.500000) c0 ll-schedule  ./schedule/ll_schedule.c:399  task add
[6653843314.166667] (        5.156250) c0 ll-schedule  ./schedule/ll_schedule.c:403  task params
[6653843322.031250] (        7.864583) c0 ll-schedule  ./schedule/ll_schedule.c:309  new added
[6653843327.031250] (        5.000000) c0 ll-schedule  ./schedule/ll_schedule.c:312  num_tasks 2
[6653844109.531250] (      782.500000) c0 sa                    src/lib/agent.c:65   perf sys_load
[6653844155.156250] (       45.625000) c0 ll-schedule  ./schedule/ll_schedule.c:229  perf ll_work
[6653844384.218750] (      229.062500) c0 component       src/audio/component.c:130  comp new host
```
After:
```
         TIMESTAMP              DELTA C# COMPONENT     LOCATION                      CONTENT
[686125142.395834] (        0.000000) c0 dma-trace    src/trace/dma-trace.c:339     ERROR FW ...
[       94.270833] (       94.270836) c0 ll-schedule   ./schedule/ll_schedule.c:229  perf ll_work
[      296.770833] (      202.500000) c0 ll-schedule   ./schedule/ll_schedule.c:399  task add
[      301.979167] (        5.208333) c0 ll-schedule   ./schedule/ll_schedule.c:403  task params
[      309.843750] (        7.864583) c0 ll-schedule   ./schedule/ll_schedule.c:309  new added
[      314.843750] (        5.000000) c0 ll-schedule   ./schedule/ll_schedule.c:312  num_tasks 2
[     1092.395833] (      777.552063) c0 sa                     src/lib/agent.c:65   perf sys_load
[     1137.968750] (       45.572918) c0 ll-schedule   ./schedule/ll_schedule.c:229  perf ll_work
[     1850.208333] (      712.239563) c0 component        src/audio/component.c:130  comp new host
```