### PR TITLE
memcpy: remove duplicate memcpy and meset definitions in local string.h

### DIFF
--- a/src/arch/xtensa/include/arch/string.h
+++ b/src/arch/xtensa/include/arch/string.h
@@ -27,8 +27,6 @@
 	memset(ptr, 0, size)
 #endif
 
-void *memcpy(void *dest, const void *src, size_t length);
-void *memset(void *dest, int data, size_t count);
 void *xthal_memcpy(void *dst, const void *src, size_t len);
 
 int memset_s(void *dest, size_t dest_size,


### PR DESCRIPTION
Local string.h already includes C library string.h.

Signed-off-by: Liam Girdwood <liam.r.girdwood@linux.intel.com>