### PR TITLE
codec_adapter: fix local buffer prepare

### DIFF
--- a/src/audio/codec_adapter/codec_adapter.c
+++ b/src/audio/codec_adapter/codec_adapter.c
@@ -263,9 +263,9 @@ static int codec_adapter_prepare(struct comp_dev *dev)
 			return -ENOMEM;
 		}
 
-		buffer_set_params(cd->local_buff, &cd->stream_params,
-				  BUFFER_UPDATE_FORCE);
 	}
+	buffer_set_params(cd->local_buff, &cd->stream_params,
+			  BUFFER_UPDATE_FORCE);
 	buffer_reset_pos(cd->local_buff, NULL);
 
 	cd->state = PP_STATE_PREPARED;


### PR DESCRIPTION
We are only setting the parameters on the allocation of the local buffer
which means if the params change on the next run it will not change and
break things.

Signed-off-by: Curtis Malainey <cujomalainey@chromium.org>