### PR TITLE
owners: add cujomalainey as owner of codec adapter

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -16,6 +16,7 @@ src/include/user/**			@thesofproject/steering-committee
 src/include/sof/debug/gdb/*		@mrajwa
 src/include/sof/audio/kpb.h		@mrajwa
 src/include/sof/audio/mux.h		@akloniex
+src/include/sof/audio/codec_adapter/* @cujomalainey
 
 # audio component
 src/audio/src*				@singalsu
@@ -30,6 +31,7 @@ src/audio/crossover*			@cujomalainey @dgreid
 src/audio/tdfb*                         @singalsu
 src/audio/drc/*				@johnylin76 @cujomalainey @dgreid
 src/audio/multiband_drc/*		@johnylin76 @cujomalainey @dgreid
+src/audio/codec_adapter/*    @cujomalainey
 
 # platforms
 src/platform/haswell/*			@randerwang


### PR DESCRIPTION
Request for owner has gone unacknowledged, ToT adapter is broken
suggesting we likely need additional reviewers given we have no existing
code owner.

Signed-off-by: Curtis Malainey <cujomalainey@chromium.org>