### PR TITLE
cmake: new DETERMINISTIC_BUILD option to turn off build counters/time…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,8 @@ endif()
 
 option(BUILD_UNIT_TESTS "Build unit tests" OFF)
 option(BUILD_CLANG_SCAN "Build for clang's scan-build" OFF)
+option(BUILD_DETERMINISTIC "Disables build counter(s), build timestamps
+and other non-deterministic features" OFF)
 
 if(CONFIG_LIBRARY)
 	set(ARCH host)
@@ -64,6 +66,12 @@ target_include_directories(sof_public_headers INTERFACE ${PROJECT_SOURCE_DIR}/ri
 add_library(sof_options INTERFACE)
 
 target_link_libraries(sof_options INTERFACE sof_public_headers)
+
+if(BUILD_DETERMINISTIC)
+target_compile_definitions(sof_options INTERFACE DETERMINISTIC_BLD=1)
+else()
+target_compile_definitions(sof_options INTERFACE DETERMINISTIC_BLD=0)
+endif()
 
 # interface library that is used only as container for sof statically
 # linked libraries
@@ -182,7 +190,9 @@ target_link_libraries(sof PRIVATE sof_ld_scripts)
 target_link_libraries(sof PRIVATE sof_ld_flags)
 target_link_libraries(sof PRIVATE sof_static_libraries)
 
+if (NOT BUILD_DETERMINISTIC)
 sof_add_build_counter_rule()
+endif()
 
 add_subdirectory(src)
 

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -60,11 +60,15 @@ static const struct sof_ipc_fw_ready ready
 		.micro = SOF_MICRO,
 		.minor = SOF_MINOR,
 		.major = SOF_MAJOR,
-#if CONFIG_DEBUG
+#if CONFIG_DEBUG && !DETERMINISTIC_BLD
 		/* only added in debug for reproducability in releases */
-		.build = SOF_BUILD,
+		.build = SOF_BUILD, // build counter
 		.date = __DATE__,
 		.time = __TIME__,
+#else
+		.build = -1,
+		.date = "dtermin.\0",
+		.time = "build\0",
 #endif
 		.tag = SOF_TAG,
 		.abi_version = SOF_ABI_VERSION,


### PR DESCRIPTION
[transferred from `master` PR #3353]

…stamps

Makes DEBUG builds (locally) deterministic: (re)building twice produces
the same binaries. Also, re-running make now recompiles only C files
actually modified.

Also makes sure non-debug builds can't use uninitialized strings in some
future security accident.

In the future this flag can be extended for other purposes like for
instance -fmacro-prefix-map.

Fun fact:

 ./scripts/checkpatch.pl -g aa85e2c0e956c

ERROR: Use of the '__DATE__' macro makes the build non-deterministic
+		.date = __DATE__,
ERROR: Use of the '__TIME__' macro makes the build non-deterministic
+		.time = __TIME__,

Signed-off-by: Marc Herbert <marc.herbert@intel.com>