### PR TITLE
[skip ci] docker: apt-get install python3-elftools

### DIFF
--- a/scripts/docker_build/sof_builder/Dockerfile
+++ b/scripts/docker_build/sof_builder/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get -y update && \
 	    	autoconf \
 		bison \
 		build-essential \
+		python3-pyelftools \
 		flex \
 		gawk \
 		gettext \


### PR DESCRIPTION
Required by #3459 / #3975 "elfsize" proof of concept and probably by
other things too in the future - we use both ELF and Python
everywhere; it's surprising they haven't met each other yet.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>