### PR TITLE
logger: new relative timestamps option, relative to first entry seen

### DIFF
--- a/tools/logger/convert.c
+++ b/tools/logger/convert.c
@@ -5,6 +5,7 @@
 // Author: Bartosz Kokoszko	<bartoszx.kokoszko@linux.intel.com>
 //	   Artur Kloniecki	<arturx.kloniecki@linux.intel.com>
 
+#include <assert.h>
 #include <endian.h>
 #include <stdbool.h>
 #include <stdlib.h>
@@ -372,6 +373,9 @@ static char *format_file_name(char *file_name_raw, int full_name)
 static void print_entry_params(const struct log_entry_header *dma_log,
 			       const struct ldc_entry *entry, uint64_t last_timestamp)
 {
+	static int entry_number = 1;
+	static uint64_t timestamp_origin;
+
 	FILE *out_fd = global_config->out_fd;
 	int use_colors = global_config->use_colors;
 	int raw_output = global_config->raw_output;
@@ -387,8 +391,26 @@ static void print_entry_params(const struct log_entry_header *dma_log,
 	if (raw_output)
 		use_colors = 0;
 
+	/* Something somewhere went wrong */
 	if (dt < 0 || dt > 1000.0 * 1000.0 * 1000.0)
 		dt = NAN;
+
+	/* The first entry:
+	 *  - is never shown with a relative TIMESTAMP (to itself!?)
+	 *  - shows a zero DELTA
+	 */
+	if (entry_number == 1) {
+		entry_number++;
+		assert(last_timestamp == 0);
+		/* Display absolute (and random) timestamps */
+		timestamp_origin = 0;
+		dt = 0;
+	} else if (entry_number == 2) {
+		entry_number++;
+		if (global_config->relative_timestamps == 1)
+			/* Switch to relative timestamps from now on. */
+			timestamp_origin = last_timestamp;
+	} /* We don't need the exact entry_number after 3 */
 
 	if (dma_log->id_0 != INVALID_TRACE_ID &&
 	    dma_log->id_1 != INVALID_TRACE_ID)
@@ -413,7 +435,8 @@ static void print_entry_params(const struct log_entry_header *dma_log,
 			raw_output && strlen(ids) ? "-" : "",
 			ids);
 		if (time_precision >= 0)
-			fprintf(out_fd, time_fmt, to_usecs(dma_log->timestamp), dt);
+			fprintf(out_fd, time_fmt,
+				to_usecs(dma_log->timestamp - timestamp_origin), dt);
 		if (!hide_location)
 			fprintf(out_fd, "(%s:%u) ",
 				format_file_name(entry->file_name, raw_output),
@@ -431,7 +454,7 @@ static void print_entry_params(const struct log_entry_header *dma_log,
 				 time_precision + 10, time_precision);
 			fprintf(out_fd, time_fmt,
 				use_colors ? KGRN : "",
-				to_usecs(dma_log->timestamp), dt,
+				to_usecs(dma_log->timestamp - timestamp_origin), dt,
 				use_colors ? KNRM : "");
 		}
 

--- a/tools/logger/convert.h
+++ b/tools/logger/convert.h
@@ -40,6 +40,7 @@ struct convert_config {
 	int raw_output;
 	int dump_ldc;
 	int hide_location;
+	int relative_timestamps;
 	int time_precision;
 	struct snd_sof_uids_header *uids_dict;
 	struct snd_sof_logs_header *logs_header;

--- a/tools/logger/logger.c
+++ b/tools/logger/logger.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <stdint.h>
+#include <limits.h>
 #include <errno.h>
 #include <string.h>
 #include <ctype.h>
@@ -53,6 +54,11 @@ static void usage(void)
 		"chained log processors\n",
 		APP_NAME);
 	fprintf(stdout, "%s:\t -L\t\t\tHide log location in source code\n",
+		APP_NAME);
+	fprintf(stdout,
+		"%s:\t -e 0/1\t\t\tTimestamps relative to first entry seen. Defaults to\n",
+		APP_NAME);
+	fprintf(stdout, "%s:\t\t\t\tabsolute when -r(aw), relative otherwise.\n",
 		APP_NAME);
 	fprintf(stdout, "%s:\t -f precision\t\tSet timestamp precision\n",
 		APP_NAME);
@@ -162,7 +168,7 @@ static int append_filter_config(struct convert_config *config, const char *input
 
 int main(int argc, char *argv[])
 {
-	static const char optstring[] = "ho:i:l:ps:c:u:tv:rd:Lf:gF:n";
+	static const char optstring[] = "ho:i:l:ps:c:u:tv:rd:Le:f:gF:n";
 	struct convert_config config;
 	unsigned int baud = 0;
 	const char *snapshot_file = 0;
@@ -187,6 +193,7 @@ int main(int argc, char *argv[])
 	config.dump_ldc = 0;
 	config.hide_location = 0;
 	config.time_precision = 6;
+	config.relative_timestamps = INT_MAX; /* unspecified */
 	config.filter_config = NULL;
 
 	while ((opt = getopt(argc, argv, optstring)) != -1) {
@@ -232,6 +239,16 @@ int main(int argc, char *argv[])
 		case 'L':
 			config.hide_location = 1;
 			break;
+		case 'e': {
+			int i = atoi(optarg);
+
+			if (i < 0 || 1 < i) {
+				fprintf(stderr, "%s: invalid option: -e %s\n",
+					APP_NAME, optarg);
+				return -EINVAL;
+			}
+			config.relative_timestamps = i;
+		}
 		case 'f':
 			config.time_precision = atoi(optarg);
 			if (config.time_precision < 0) {
@@ -308,6 +325,10 @@ int main(int argc, char *argv[])
 	/* trace requested ? */
 	if (config.trace)
 		config.in_file = "/sys/kernel/debug/sof/trace";
+
+	/* Default value when -e is not specified */
+	if (config.relative_timestamps == INT_MAX)
+		config.relative_timestamps = config.raw_output ? 0 : 1;
 
 	/* default option with no infile is to dump errors/debug data */
 	if (!config.in_file && !config.dump_ldc)


### PR DESCRIPTION
Add a new sof-logger -e 0/1 relative timestamps option where the
TIMESTAMP column is relative to the first entry seen.

Removes many digits and makes the TIMESTAMP column much more readable in
short logs.

Also stop showing "NaN" as the first DELTA like something went
wrong. Show zero instead.

The new option is off by default when using -r(aw) and on otherwise.

The first entry is kept always absolute.

Before:
```
         TIMESTAMP              DELTA C# COMPONENT     LOCATION                      CONTENT
[6653843012.343750] (             NaN) c0 dma-trace    src/trace/dma-trace.c:339     ERROR FW ...
[6653843111.510417] (       99.166664) c0 ll-schedule  ./schedule/ll_schedule.c:229  perf ll_work
[6653843309.010417] (      197.500000) c0 ll-schedule  ./schedule/ll_schedule.c:399  task add
[6653843314.166667] (        5.156250) c0 ll-schedule  ./schedule/ll_schedule.c:403  task params
[6653843322.031250] (        7.864583) c0 ll-schedule  ./schedule/ll_schedule.c:309  new added
[6653843327.031250] (        5.000000) c0 ll-schedule  ./schedule/ll_schedule.c:312  num_tasks 2
[6653844109.531250] (      782.500000) c0 sa                    src/lib/agent.c:65   perf sys_load
[6653844155.156250] (       45.625000) c0 ll-schedule  ./schedule/ll_schedule.c:229  perf ll_work
[6653844384.218750] (      229.062500) c0 component       src/audio/component.c:130  comp new host
```
After:
```
         TIMESTAMP              DELTA C# COMPONENT     LOCATION                      CONTENT
[686125142.395834] (        0.000000) c0 dma-trace    src/trace/dma-trace.c:339     ERROR FW ...
[       94.270833] (       94.270836) c0 ll-schedule   ./schedule/ll_schedule.c:229  perf ll_work
[      296.770833] (      202.500000) c0 ll-schedule   ./schedule/ll_schedule.c:399  task add
[      301.979167] (        5.208333) c0 ll-schedule   ./schedule/ll_schedule.c:403  task params
[      309.843750] (        7.864583) c0 ll-schedule   ./schedule/ll_schedule.c:309  new added
[      314.843750] (        5.000000) c0 ll-schedule   ./schedule/ll_schedule.c:312  num_tasks 2
[     1092.395833] (      777.552063) c0 sa                     src/lib/agent.c:65   perf sys_load
[     1137.968750] (       45.572918) c0 ll-schedule   ./schedule/ll_schedule.c:229  perf ll_work
[     1850.208333] (      712.239563) c0 component        src/audio/component.c:130  comp new host
```

For more output examples check https://sof-ci.01.org/sofpr/PR3985/build8535/devicetest/

Signed-off-by: Marc Herbert <marc.herbert@intel.com>