### PR TITLE
.github/pull-request.yml: watch "main" branch instead of master

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -18,12 +18,12 @@ name: GitHub Actions
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
       - 'stable-**'
       - '**-stable'
   pull_request:
     branches:
-      - 'master'
+      - 'main'
       - 'stable-**'
       - '**-stable'
 


### PR DESCRIPTION
Will hopefully fix mysterious CI hangs.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>