### PR TITLE
Fix -Werror=declaration-after-statement and add flag

### DIFF
--- a/src/arch/xtensa/CMakeLists.txt
+++ b/src/arch/xtensa/CMakeLists.txt
@@ -122,6 +122,7 @@ target_compile_options(sof_options INTERFACE
 		-Wall -Werror
 		-Wl,-EL
 		-Wmissing-prototypes
+		-Wdeclaration-after-statement
 		-Wpointer-arith
 		${XTENSA_C_FLAGS}
 	>

--- a/src/arch/xtensa/CMakeLists.txt
+++ b/src/arch/xtensa/CMakeLists.txt
@@ -116,7 +116,17 @@ target_compile_options(sof_options INTERFACE ${stdlib_flag} -fno-inline-function
 
 # No space between -imacros and its argument to avoid CMake
 # de-duplication "feature"
-target_compile_options(sof_options INTERFACE $<$<COMPILE_LANGUAGE:C>: -${optimization_flag} -g -Wall -Werror -Wl,-EL -Wmissing-prototypes -Wpointer-arith ${XTENSA_C_FLAGS}> -imacros${CONFIG_H_PATH})
+target_compile_options(sof_options INTERFACE
+	$<$<COMPILE_LANGUAGE:C>:
+		-${optimization_flag} -g
+		-Wall -Werror
+		-Wl,-EL
+		-Wmissing-prototypes
+		-Wpointer-arith
+		${XTENSA_C_FLAGS}
+	>
+	-imacros${CONFIG_H_PATH}
+	)
 
 if(BUILD_UNIT_TESTS)
 	# rest of this file is not needed for unit tests

--- a/src/audio/asrc/asrc_farrow.c
+++ b/src/audio/asrc/asrc_farrow.c
@@ -418,6 +418,8 @@ enum asrc_error_code asrc_set_fs_ratio(struct comp_dev *dev,
 				       struct asrc_farrow *src_obj,
 				       int32_t fs_prim, int32_t fs_sec)
 {
+	enum asrc_error_code error_code;
+
 	/* Check for parameter errors */
 	if (!src_obj) {
 		comp_err(dev, "asrc_set_fs_ratio(), null src_obj");
@@ -466,7 +468,7 @@ enum asrc_error_code asrc_set_fs_ratio(struct comp_dev *dev,
 	/* See initialise_asrc(...) for further information
 	 * Update the filters accordingly
 	 */
-	enum asrc_error_code error_code = initialise_filter(dev, src_obj);
+	error_code = initialise_filter(dev, src_obj);
 	/* check for errors */
 	if (error_code != ASRC_EC_OK) {
 		comp_err(dev, "asrc_set_fs_ratio(), failed filter initialise");

--- a/src/audio/asrc/asrc_farrow_hifi3.c
+++ b/src/audio/asrc/asrc_farrow_hifi3.c
@@ -16,8 +16,6 @@ void asrc_fir_filter16(struct asrc_farrow *src_obj, int16_t **output_buffers,
 	ae_f32x2 filter01 = AE_ZERO32(); /* Note: Init is not needed */
 	ae_f32x2 filter23 = AE_ZERO32(); /* Note: Init is not needed */
 	ae_f16x4 buffer0123 = AE_ZERO16(); /* Note: Init is not needed */
-	ae_f32x2 *filter_p;
-	ae_f16x4 *buffer_p;
 	int n_limit;
 	int ch;
 	int n;
@@ -37,10 +35,10 @@ void asrc_fir_filter16(struct asrc_farrow *src_obj, int16_t **output_buffers,
 	/* Iterate over each channel */
 	for (ch = 0; ch < src_obj->num_channels; ch++) {
 		/* Pointer to the beginning of the impulse response */
-		filter_p = (ae_f32x2 *)&src_obj->impulse_response[0];
+		ae_f32x2 *filter_p = (ae_f32x2 *)&src_obj->impulse_response[0];
 
 		/* Pointer to the buffered input data */
-		buffer_p =
+		ae_f16x4 *buffer_p =
 			(ae_f16x4 *)&src_obj->ring_buffers16[ch]
 			[src_obj->buffer_write_position];
 
@@ -101,8 +99,6 @@ void asrc_fir_filter32(struct asrc_farrow *src_obj, int32_t **output_buffers,
 	ae_f32x2 prod;
 	ae_f32x2 buffer01 = AE_ZERO32(); /* Note: Init is not needed */
 	ae_f32x2 filter01 = AE_ZERO32(); /* Note: Init is not needed */
-	ae_f32x2 *filter_p;
-	ae_f32x2 *buffer_p;
 	int n_limit;
 	int ch;
 	int n;
@@ -122,10 +118,10 @@ void asrc_fir_filter32(struct asrc_farrow *src_obj, int32_t **output_buffers,
 	/* Iterate over each channel */
 	for (ch = 0; ch < src_obj->num_channels; ch++) {
 		/* Pointer to the beginning of the impulse response */
-		filter_p = (ae_f32x2 *)&src_obj->impulse_response[0];
+		ae_f32x2 *filter_p = (ae_f32x2 *)&src_obj->impulse_response[0];
 
 		/* Pointer to the buffered input data */
-		buffer_p =
+		ae_f32x2 *buffer_p =
 			(ae_f32x2 *)&src_obj->ring_buffers32[ch]
 			[src_obj->buffer_write_position];
 

--- a/src/audio/dcblock/dcblock.c
+++ b/src/audio/dcblock/dcblock.c
@@ -44,8 +44,9 @@ DECLARE_TR_CTX(dcblock_tr, SOF_UUID(dcblock_uuid), LOG_LEVEL_INFO);
  */
 static void dcblock_set_passthrough(struct comp_data *cd)
 {
-	comp_cl_info(&comp_dcblock, "dcblock_set_passthrough()");
 	int i;
+
+	comp_cl_info(&comp_dcblock, "dcblock_set_passthrough()");
 
 	for (i = 0; i < PLATFORM_MAX_CHANNELS; i++)
 		cd->R_coeffs[i] = ONE_Q2_30;

--- a/src/audio/pipeline.c
+++ b/src/audio/pipeline.c
@@ -202,11 +202,13 @@ static int pipeline_for_each_comp(struct comp_dev *current,
 
 		/* continue further */
 		if (ctx->comp_func) {
+			int err;
+
 			buffer_lock(buffer, &flags);
 			buffer->walking = true;
 			buffer_unlock(buffer, flags);
 
-			int err = ctx->comp_func(buffer_comp, buffer,
+			err = ctx->comp_func(buffer_comp, buffer,
 						 ctx, dir);
 			buffer_lock(buffer, &flags);
 			buffer->walking = false;

--- a/src/drivers/imx/sai.c
+++ b/src/drivers/imx/sai.c
@@ -29,9 +29,9 @@ DECLARE_TR_CTX(sai_tr, SOF_UUID(sai_uuid), LOG_LEVEL_INFO);
 
 static void sai_start(struct dai *dai, int direction)
 {
-	dai_info(dai, "SAI: sai_start");
-
 	uint32_t xcsr = 0U;
+
+	dai_info(dai, "SAI: sai_start");
 
 	if (direction == DAI_DIR_CAPTURE) {
 		/* Software Reset */
@@ -99,9 +99,9 @@ static void sai_start(struct dai *dai, int direction)
 
 static void sai_stop(struct dai *dai, int direction)
 {
-	dai_info(dai, "SAI: sai_stop");
-
 	uint32_t xcsr = 0U;
+
+	dai_info(dai, "SAI: sai_stop");
 
 	/* Disable DMA request */
 	dai_update_bits(dai, REG_SAI_XCSR(direction),
@@ -152,12 +152,13 @@ static int sai_context_restore(struct dai *dai)
 static inline int sai_set_config(struct dai *dai,
 				 struct sof_ipc_dai_config *config)
 {
-	dai_info(dai, "SAI: sai_set_config");
 	uint32_t val_cr2 = 0, val_cr4 = 0, val_cr5 = 0;
 	uint32_t mask_cr2 = 0, mask_cr4 = 0, mask_cr5 = 0;
 	struct sai_pdata *sai = dai_get_drvdata(dai);
 	/* TODO: this value will be provided by config */
 	uint32_t sywd = 32;
+
+	dai_info(dai, "SAI: sai_set_config");
 
 	sai->config = *config;
 	sai->params = config->sai;

--- a/src/drivers/intel/dmic.c
+++ b/src/drivers/intel/dmic.c
@@ -778,6 +778,9 @@ static int stereo_helper(int stereo[], int swap[])
 static int configure_registers(struct dai *dai,
 			       struct dmic_configuration *cfg)
 {
+#if (DMIC_HW_VERSION == 2 && DMIC_HW_CONTROLLERS > 2) || DMIC_HW_VERSION == 3
+	int source[OUTCONTROLX_IPM_NUMSOURCES];
+#endif
 	int stereo[DMIC_HW_CONTROLLERS];
 	int swap[DMIC_HW_CONTROLLERS];
 	uint32_t val;
@@ -809,10 +812,6 @@ static int configure_registers(struct dai *dai,
 	soft_reset = 1;
 	cic_mute = 1;
 	fir_mute = 1;
-
-#if (DMIC_HW_VERSION == 2 && DMIC_HW_CONTROLLERS > 2) || DMIC_HW_VERSION == 3
-	int source[OUTCONTROLX_IPM_NUMSOURCES];
-#endif
 
 	/* pdata is set by dmic_probe(), error if it has not been set */
 	if (!pdata) {

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -222,11 +222,11 @@ static inline void buffer_lock(struct comp_buffer *buffer, uint32_t *flags)
  */
 static inline void buffer_unlock(struct comp_buffer *buffer, uint32_t flags)
 {
-	if (!buffer->inter_core)
-		return;
-
 	/* save lock pointer to avoid memory access after cache flushing */
 	spinlock_t *lock = buffer->lock;
+
+	if (!buffer->inter_core)
+		return;
 
 	/* wtb and inv to avoid buffer locking in read only situations */
 	dcache_writeback_invalidate_region(buffer, sizeof(*buffer));

--- a/src/include/sof/drivers/ipc.h
+++ b/src/include/sof/drivers/ipc.h
@@ -191,11 +191,11 @@ static inline struct ipc_msg *ipc_msg_init(uint32_t header, uint32_t size)
 
 static inline void ipc_msg_free(struct ipc_msg *msg)
 {
-	if (!msg)
-		return;
-
 	struct ipc *ipc = ipc_get();
 	uint32_t flags;
+
+	if (!msg)
+		return;
 
 	spin_lock_irq(&ipc->lock, flags);
 

--- a/src/include/sof/trace/trace.h
+++ b/src/include/sof/trace/trace.h
@@ -194,11 +194,11 @@ _thrown_from_macro_BASE_LOG_in_trace_h
 do {											\
 	_DECLARE_LOG_ENTRY(lvl, format, comp_class,					\
 			   META_COUNT_VARAGS_BEFORE_COMPILE(__VA_ARGS__));		\
-	STATIC_ASSERT_ARG_SIZE(__VA_ARGS__);						\
 	STATIC_ASSERT(_TRACE_EVENT_MAX_ARGUMENT_COUNT >=				\
 			META_COUNT_VARAGS_BEFORE_COMPILE(__VA_ARGS__),			\
 		BASE_LOG_ASSERT_FAIL_MSG						\
 	);										\
+	STATIC_ASSERT_ARG_SIZE(__VA_ARGS__);						\
 	log_func(atomic, &log_entry, ctx, lvl, id_1, id_2,				\
 		 META_COUNT_VARAGS_BEFORE_COMPILE(__VA_ARGS__), ##__VA_ARGS__);		\
 } while (0)

--- a/src/math/numbers.c
+++ b/src/math/numbers.c
@@ -22,6 +22,9 @@
 
 int gcd(int a, int b)
 {
+	int aux;
+	int k;
+
 	if (a == 0)
 		return b;
 
@@ -37,9 +40,6 @@ int gcd(int a, int b)
 
 	if (b < 0)
 		b = -b;
-
-	int aux;
-	int k;
 
 	/* Find the greatest power of 2 that devides both a and b */
 	for (k = 0; ((a | b) & 1) == 0; k++) {

--- a/src/platform/intel/cavs/lib/pm_runtime.c
+++ b/src/platform/intel/cavs/lib/pm_runtime.c
@@ -216,8 +216,8 @@ static inline void cavs_pm_runtime_dis_ssp_power(uint32_t index)
 static inline void cavs_pm_runtime_dis_dmic_clk_gating(uint32_t index)
 {
 #if CONFIG_APOLLOLAKE || CONFIG_CANNONLAKE
-	(void)index;
 	uint32_t shim_reg;
+	(void)index;
 
 	shim_reg = shim_read(SHIM_CLKCTL) | SHIM_CLKCTL_DMICFDCGB;
 
@@ -236,8 +236,8 @@ static inline void cavs_pm_runtime_dis_dmic_clk_gating(uint32_t index)
 static inline void cavs_pm_runtime_en_dmic_clk_gating(uint32_t index)
 {
 #if CONFIG_APOLLOLAKE || CONFIG_CANNONLAKE
-	(void)index;
 	uint32_t shim_reg;
+	(void)index;
 
 	shim_reg = shim_read(SHIM_CLKCTL) & ~SHIM_CLKCTL_DMICFDCGB;
 

--- a/tools/logger/CMakeLists.txt
+++ b/tools/logger/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(sof-logger
 
 target_compile_options(sof-logger PRIVATE
 	-Wall -Werror
+	-Wdeclaration-after-statement
 )
 
 target_include_directories(sof-logger PRIVATE


### PR DESCRIPTION
Automate current (and unwritten?) coding guidelines. Let's not waste
considerable time in code reviews discussing problems computers can
catch automatically.

Note this goes against CERT-C recommendations DCL00-C, DCL19-C and many
others but it's the current policy so let's apply and automate it. Can
be changed later.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>