### PR TITLE
cmake: don't trust CI to record time and versions and log ourselves

### DIFF
--- a/scripts/cmake/version.cmake
+++ b/scripts/cmake/version.cmake
@@ -11,6 +11,29 @@ cmake_minimum_required(VERSION 3.10)
 
 set(VERSION_CMAKE_PATH ${CMAKE_CURRENT_LIST_DIR}/version.cmake)
 
+
+# In an ideal world, every CI engine records the most basic and most
+# important information:
+# - current date and time
+# - git version of the pull request
+# - git version of the moving branch it's being merged with
+#
+# In the real world, some CI results use a random timezone without
+# telling which one or don't provide any time at all.
+string(TIMESTAMP build_start_time UTC)
+message(STATUS "version.cmake starting SOF build at ${build_start_time} UTC")
+
+# Most CI engines test a temporary merge of the pull request with a
+# moving target: the latest target branch. In that case the SHA version
+# gathered by git describe is disposable hence useless. Only the
+# --parents SHA are useful.
+message(STATUS "Building git commit with parent(s):")
+# Note execute_process() failures are ignored by default (missing git...)
+execute_process(
+	COMMAND git log --parents --oneline --decorate -n 1 HEAD
+	)
+
+
 # Don't confuse this manual _input_ file with the other, output file of
 # the same name auto-generated in the top _build_ directory by "make
 # dist", see dist.cmake

--- a/scripts/cmake/version.cmake
+++ b/scripts/cmake/version.cmake
@@ -23,24 +23,24 @@ if(EXISTS ${TARBALL_VERSION_SOURCE_PATH})
 	list(GET lines 1 GIT_LOG_HASH)
 	message(STATUS "Found ${TARBALL_VERSION_FILE_NAME}")
 else()
+	# execute_process() errors are not fatal by default!
 	execute_process(
 	        COMMAND git describe --tags --abbrev=12 --match v* --dirty
 		WORKING_DIRECTORY ${SOF_ROOT_SOURCE_DIRECTORY}
 		OUTPUT_VARIABLE GIT_TAG
 		OUTPUT_STRIP_TRAILING_WHITESPACE
-		ERROR_QUIET
 	)
 
 	execute_process(COMMAND git log --pretty=format:%h -1
 		WORKING_DIRECTORY ${SOF_ROOT_SOURCE_DIRECTORY}
 		OUTPUT_VARIABLE GIT_LOG_HASH
 		OUTPUT_STRIP_TRAILING_WHITESPACE
-		ERROR_QUIET
 	)
 endif()
 
-# We have ERROR_QUIET above so git issues are not fatal
 if(NOT GIT_TAG MATCHES "^v")
+	message(WARNING
+	  "git describe found ${GIT_TAG} / nothing starting with 'v'. Shallow clone?")
 	set(GIT_TAG "v0.0-0-g0000")
 endif()
 


### PR DESCRIPTION
In an ideal world, every CI engine records and shares the most important
CI information:
- current date and time in a well identified timezone
- git version of the pull request
- git version of the moving branch the PR is being merged with

In the real world we have multiple CI solutions and they unfortunately
cannot not all be trusted to perform their most basic job
correctly. Fortunately, they all make at least build logs available so
these very few lines of code adding very few lines of output cost near
zero extra build time and solve the problem once for all. I feel stupid
I didn't do this sooner, this would have saved me hours and hours in
vain requests and discussions and in trying to puzzle that information
together.

Sample outputs
```
-- Preparing Xtensa toolchain
version.cmake starting SOF build at 2021-03-31T18:09:46Z UTC
Building git commit with parent(s):
150fd1e4c968 4249bdb1b305 [2nd parent if merge] (HEAD -> main) cmake: ...
-- GIT_TAG / GIT_LOG_HASH : v1.7-rc1-174-g150fd1e4c968-dirty / 150fd1e4c968
```

From https://github.com/thesofproject/sof/pull/3996/checks?check_run_id=2239525672, xtensa-build-all.sh
```
-- version.cmake starting SOF build at 2021-03-31T20:01:47Z UTC
-- Building git commit with parent(s):
5ad5c7d0c eb459078f 83d425817 (HEAD, pull/3996/merge) Merge 83d42581779c4da872e9d635962436ab1752c853 into eb459078f3023f6762428f38976547576eeae59f
-- GIT_TAG / GIT_LOG_HASH : v1.7-rc1-166-g5ad5c7d0c573 / 5ad5c7d0c
-- Source content hash: 55ed85fe
```
Other examples at https://sof-ci.01.org/sofpr/PR3996/build8556/build/

Signed-off-by: Marc Herbert <marc.herbert@intel.com>