### PR TITLE
codec_adapter: add mrajwa & dbaluta as code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -16,7 +16,7 @@ src/include/user/**			@thesofproject/steering-committee
 src/include/sof/debug/gdb/*		@mrajwa
 src/include/sof/audio/kpb.h		@mrajwa
 src/include/sof/audio/mux.h		@akloniex
-src/include/sof/audio/codec_adapter/* @cujomalainey
+src/include/sof/audio/codec_adapter/* @cujomalainey @mrajwa @dbaluta
 
 # audio component
 src/audio/src*				@singalsu
@@ -31,7 +31,7 @@ src/audio/crossover*			@cujomalainey @dgreid
 src/audio/tdfb*                         @singalsu
 src/audio/drc/*				@johnylin76 @cujomalainey @dgreid
 src/audio/multiband_drc/*		@johnylin76 @cujomalainey @dgreid
-src/audio/codec_adapter/*    @cujomalainey
+src/audio/codec_adapter/*    @cujomalainey @mrajwa @dbaluta
 
 # platforms
 src/platform/haswell/*			@randerwang


### PR DESCRIPTION
This patch adds two more code owners of codec_adapter.

Signed-off-by: Marcin Rajwa <marcin.rajwa@linux.intel.com>
Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>