### PR TITLE
zephyr/cmake: stop trying to build removed pipeline_static.c

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -386,7 +386,6 @@ zephyr_library_sources(
 	${SOF_LIB_PATH}/dai.c
 
 	# SOF mandatory audio processing
-	${SOF_AUDIO_PATH}/pipeline_static.c
 	${SOF_AUDIO_PATH}/channel_map.c
 	${SOF_AUDIO_PATH}/pcm_converter/pcm_converter_hifi3.c
 	${SOF_AUDIO_PATH}/pcm_converter/pcm_converter.c


### PR DESCRIPTION
Fixes commit 093589899a2e ("pipeline: remove legacy static pipeline
support") that broke zephyr compilation.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>