### PR TITLE
Rename MIN and MAX to Z_MIN and Z_MAX for Zephyr compatibility

### DIFF
--- a/src/audio/asrc/asrc.c
+++ b/src/audio/asrc/asrc.c
@@ -419,7 +419,7 @@ static int asrc_params(struct comp_dev *dev,
 	 */
 	cd->source_frames_max = cd->source_frames + 10;
 	cd->sink_frames_max = cd->sink_frames + 10;
-	cd->frames = MAX(cd->source_frames_max, cd->sink_frames_max);
+	cd->frames = Z_MAX(cd->source_frames_max, cd->sink_frames_max);
 
 	comp_info(dev, "asrc_params(), source_rate=%u, sink_rate=%u, source_frames_max=%d, sink_frames_max=%d",
 		  cd->source_rate, cd->sink_rate,
@@ -785,8 +785,8 @@ static int asrc_control_loop(struct comp_dev *dev, struct comp_data *cd)
 	/* Track skew variation, it helps to analyze possible problems
 	 * with slave DAI frame clock stability.
 	 */
-	cd->skew_min = MIN(cd->skew, cd->skew_min);
-	cd->skew_max = MAX(cd->skew, cd->skew_max);
+	cd->skew_min = Z_MIN(cd->skew, cd->skew_min);
+	cd->skew_max = Z_MAX(cd->skew, cd->skew_max);
 	comp_cl_dbg(&comp_asrc, "skew %d %d %d %d", delta_sample, delta_ts,
 		    skew, cd->skew);
 	return 0;
@@ -852,22 +852,22 @@ static int asrc_copy(struct comp_dev *dev)
 		 * The amount cd->sink_frames will be produced while
 		 * consumption varies.
 		 */
-		cd->source_frames = MIN(frames_src, cd->source_frames_max);
+		cd->source_frames = Z_MIN(frames_src, cd->source_frames_max);
 		cd->sink_frames = cd->source_frames * cd->sink_rate /
 			cd->source_rate;
-		cd->sink_frames = MIN(cd->sink_frames, cd->sink_frames_max);
-		cd->sink_frames = MIN(cd->sink_frames, frames_snk);
+		cd->sink_frames = Z_MIN(cd->sink_frames, cd->sink_frames_max);
+		cd->sink_frames = Z_MIN(cd->sink_frames, frames_snk);
 	} else {
 		/* In push mode maximize the sink buffer write potential.
 		 * ASRC will consume from source cd->source_frames while
 		 * production varies.
 		 */
-		cd->sink_frames = MIN(frames_snk, cd->sink_frames_max);
+		cd->sink_frames = Z_MIN(frames_snk, cd->sink_frames_max);
 		cd->source_frames = cd->sink_frames * cd->source_rate /
 			cd->sink_rate;
-		cd->source_frames = MIN(cd->source_frames,
-					cd->source_frames_max);
-		cd->source_frames = MIN(cd->source_frames, frames_src);
+		cd->source_frames = Z_MIN(cd->source_frames,
+					  cd->source_frames_max);
+		cd->source_frames = Z_MIN(cd->source_frames, frames_src);
 	}
 
 	if (cd->source_frames && cd->sink_frames)

--- a/src/audio/codec_adapter/codec_adapter.c
+++ b/src/audio/codec_adapter/codec_adapter.c
@@ -243,7 +243,7 @@ int codec_adapter_prepare(struct comp_dev *dev)
 	}
 
 	/* Allocate local buffer */
-	buff_size = MAX(cd->period_bytes, codec->cpd.out_buff_size) * buff_periods;
+	buff_size = Z_MAX(cd->period_bytes, codec->cpd.out_buff_size) * buff_periods;
 	if (cd->local_buff) {
 		ret = buffer_set_size(cd->local_buff, buff_size);
 		if (ret < 0) {
@@ -297,7 +297,7 @@ codec_adapter_copy_from_source_to_lib(const struct audio_stream *source,
 				      size_t bytes)
 {
 	/* head_size - available data until end of local buffer */
-	uint32_t head_size = MIN(bytes, audio_stream_bytes_without_wrap(source,
+	uint32_t head_size = Z_MIN(bytes, audio_stream_bytes_without_wrap(source,
 				 source->r_ptr));
 	/* tail_size - residue data to be copied starting from the beginning
 	 * of the buffer
@@ -319,7 +319,7 @@ codec_adapter_copy_from_lib_to_sink(const struct codec_processing_data *cpd,
 				    size_t bytes)
 {
 	/* head_size - free space until end of local buffer */
-	uint32_t head_size = MIN(bytes, audio_stream_bytes_without_wrap(sink,
+	uint32_t head_size = Z_MIN(bytes, audio_stream_bytes_without_wrap(sink,
 				 sink->w_ptr));
 	/* tail_size - rest of the bytes that needs to be written
 	 * starting from the beginning of the buffer
@@ -352,7 +352,7 @@ static void generate_zeroes(struct comp_buffer *sink, uint32_t bytes)
 		ptr = audio_stream_wrap(&sink->stream, sink->stream.w_ptr);
 		tmp = audio_stream_bytes_without_wrap(&sink->stream,
 						      ptr);
-		tmp = MIN(tmp, copy_bytes);
+		tmp = Z_MIN(tmp, copy_bytes);
 		ptr = (char *)ptr + tmp;
 		copy_bytes -= tmp;
 	}

--- a/src/audio/crossover/crossover.c
+++ b/src/audio/crossover/crossover.c
@@ -692,7 +692,7 @@ static int crossover_copy(struct comp_dev *dev)
 		buffer_lock(sinks[i], &flags);
 		avail = audio_stream_avail_frames(&source->stream,
 						  &sinks[i]->stream);
-		frames = MIN(frames, avail);
+		frames = Z_MIN(frames, avail);
 		buffer_unlock(sinks[i], flags);
 	}
 

--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -833,16 +833,16 @@ static int dai_copy(struct comp_dev *dev)
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK) {
 		src_samples = audio_stream_get_avail_samples(&buf->stream);
 		sink_samples = free_bytes / get_sample_bytes(dma_fmt);
-		samples = MIN(src_samples, sink_samples);
+		samples = Z_MIN(src_samples, sink_samples);
 	} else {
 		src_samples = avail_bytes / get_sample_bytes(dma_fmt);
 		sink_samples = audio_stream_get_free_samples(&buf->stream);
-		samples = MIN(src_samples, sink_samples);
+		samples = Z_MIN(src_samples, sink_samples);
 
 		/* limit bytes per copy to one period for the whole pipeline
 		 * in order to avoid high load spike
 		 */
-		samples = MIN(samples, dd->period_bytes /
+		samples = Z_MIN(samples, dd->period_bytes /
 			      get_sample_bytes(dma_fmt));
 	}
 	copy_bytes = samples * get_sample_bytes(dma_fmt);

--- a/src/audio/drc/drc.c
+++ b/src/audio/drc/drc.c
@@ -97,7 +97,7 @@ inline int drc_set_pre_delay_time(struct drc_state *state,
 	pre_delay_frames = Q_MULTSR_32X32((int64_t)pre_delay_time, rate, 30, 0, 0);
 	if (pre_delay_frames < 0)
 		return -EINVAL;
-	pre_delay_frames = MIN(pre_delay_frames, DRC_MAX_PRE_DELAY_FRAMES - 1);
+	pre_delay_frames = Z_MIN(pre_delay_frames, DRC_MAX_PRE_DELAY_FRAMES - 1);
 
 	/* Make pre_delay_frames multiplies of DIVISION_FRAMES. This way we
 	 * won't split a division of samples into two blocks of memory, so it is
@@ -107,7 +107,7 @@ inline int drc_set_pre_delay_time(struct drc_state *state,
 
 	/* We need at least one division buffer, so the incoming data won't
 	 * overwrite the output data */
-	pre_delay_frames = MAX(pre_delay_frames, DRC_DIVISION_FRAMES);
+	pre_delay_frames = Z_MAX(pre_delay_frames, DRC_DIVISION_FRAMES);
 
 	if (state->last_pre_delay_frames != pre_delay_frames) {
 		state->last_pre_delay_frames = pre_delay_frames;

--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -124,7 +124,7 @@ static uint32_t host_dma_get_split(struct host_data *hd, uint32_t bytes)
 			(hd->sink->current_end - local_elem->dest);
 
 	/* get max split, so the current copy will be minimum */
-	return MAX(split_src, split_dst);
+	return Z_MAX(split_src, split_dst);
 }
 
 static void host_update_position(struct comp_dev *dev, uint32_t bytes)
@@ -351,12 +351,12 @@ static uint32_t host_get_copy_bytes_normal(struct comp_dev *dev)
 		/* limit bytes per copy to one period for the whole pipeline
 		 * in order to avoid high load spike
 		 */
-		copy_bytes = MIN(hd->period_bytes,
-				 MIN(avail_bytes,
-				     audio_stream_get_free_bytes(&hd->local_buffer->stream)));
+		copy_bytes = Z_MIN(hd->period_bytes,
+				   Z_MIN(avail_bytes,
+					 audio_stream_get_free_bytes(&hd->local_buffer->stream)));
 	else
-		copy_bytes = MIN(
-			audio_stream_get_avail_bytes(&hd->local_buffer->stream), free_bytes);
+		copy_bytes = Z_MIN(audio_stream_get_avail_bytes(&hd->local_buffer->stream),
+				   free_bytes);
 
 	buffer_unlock(hd->local_buffer, flags);
 

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -699,7 +699,7 @@ static int kpb_copy(struct comp_dev *dev)
 			/* Update buffered size. NOTE! We only record buffered
 			 * data up to the size of history buffer.
 			 */
-			kpb->hd.buffered += MIN(kpb->hd.buffer_size -
+			kpb->hd.buffered += Z_MIN(kpb->hd.buffer_size -
 						kpb->hd.buffered,
 						copy_bytes);
 		} else {
@@ -756,7 +756,7 @@ static int kpb_copy(struct comp_dev *dev)
 		/* In draining and init draining we only buffer data in
 		 * the internal history buffer.
 		 */
-		copy_bytes = MIN(audio_stream_get_avail_bytes(&source->stream), kpb->hd.free);
+		copy_bytes = Z_MIN(audio_stream_get_avail_bytes(&source->stream), kpb->hd.free);
 		ret = PPL_STATUS_PATH_STOP;
 		if (copy_bytes) {
 			buffer_invalidate(source, copy_bytes);
@@ -1242,7 +1242,7 @@ static enum task_state kpb_draining_task(void *arg)
 		drain_req -= size_to_copy;
 		drained += size_to_copy;
 		period_bytes += size_to_copy;
-		kpb->hd.free += MIN(kpb->hd.buffer_size -
+		kpb->hd.free += Z_MIN(kpb->hd.buffer_size -
 				    kpb->hd.free, size_to_copy);
 
 		if (move_buffer) {

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -299,7 +299,7 @@ static int mixer_copy(struct comp_dev *dev)
 	/* write zeros if all sources are inactive */
 	if (num_mix_sources == 0) {
 		buffer_lock(sink, &flags);
-		frames = MIN(frames, audio_stream_get_free_frames(&sink->stream));
+		frames = Z_MIN(frames, audio_stream_get_free_frames(&sink->stream));
 		sink_bytes = frames * audio_stream_frame_bytes(&sink->stream);
 		buffer_unlock(sink, flags);
 
@@ -316,9 +316,9 @@ static int mixer_copy(struct comp_dev *dev)
 	/* check for underruns */
 	for (i = 0; i < num_mix_sources; i++) {
 		buffer_lock(sources[i], &flags);
-		frames = MIN(frames,
-			     audio_stream_avail_frames(sources_stream[i],
-						       &sink->stream));
+		frames = Z_MIN(frames,
+			       audio_stream_avail_frames(sources_stream[i],
+							 &sink->stream));
 		buffer_unlock(sources[i], flags);
 	}
 

--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -473,7 +473,7 @@ static int demux_copy(struct comp_dev *dev)
 		buffer_lock(sinks[i], &flags);
 		avail = audio_stream_avail_frames(&source->stream,
 						  &sinks[i]->stream);
-		frames = MIN(frames, avail);
+		frames = Z_MIN(frames, avail);
 		buffer_unlock(sinks[i], flags);
 	}
 
@@ -573,9 +573,9 @@ static int mux_copy(struct comp_dev *dev)
 	for (i = 0; i < MUX_MAX_STREAMS; i++) {
 		if (!sources[i])
 			continue;
-		frames = MIN(frames,
-			     audio_stream_avail_frames(sources_stream[i],
-						       &sink->stream));
+		frames = Z_MIN(frames,
+			       audio_stream_avail_frames(sources_stream[i],
+							 &sink->stream));
 		buffer_unlock(sources[i], flags);
 	}
 

--- a/src/audio/mux/mux_generic.c
+++ b/src/audio/mux/mux_generic.c
@@ -287,7 +287,7 @@ static void demux_s16le(struct comp_dev *dev, struct audio_stream *sink,
 			demux_calc_frames_without_wrap_s16(dev, sink, source,
 							   lookup);
 
-		frames_without_wrap = MIN(frames, frames_without_wrap);
+		frames_without_wrap = Z_MIN(frames, frames_without_wrap);
 
 		for (i = 0; i < frames_without_wrap; i++) {
 			for (elem = 0; elem < lookup->num_elems; elem++) {
@@ -341,7 +341,7 @@ static void mux_s16le(struct comp_dev *dev, struct audio_stream *sink,
 			mux_calc_frames_without_wrap_s16(dev, sink, sources,
 							 lookup);
 
-		frames_without_wrap = MIN(frames, frames_without_wrap);
+		frames_without_wrap = Z_MIN(frames, frames_without_wrap);
 
 		for (i = 0; i < frames_without_wrap; i++) {
 			for (elem = 0; elem < lookup->num_elems; elem++) {
@@ -397,7 +397,7 @@ static void demux_s32le(struct comp_dev *dev, struct audio_stream *sink,
 			demux_calc_frames_without_wrap_s32(dev, sink, source,
 							   lookup);
 
-		frames_without_wrap = MIN(frames, frames_without_wrap);
+		frames_without_wrap = Z_MIN(frames, frames_without_wrap);
 
 		for (i = 0; i < frames_without_wrap; i++) {
 			for (elem = 0; elem < lookup->num_elems; elem++) {
@@ -451,7 +451,7 @@ static void mux_s32le(struct comp_dev *dev, struct audio_stream *sink,
 			mux_calc_frames_without_wrap_s32(dev, sink, sources,
 							 lookup);
 
-		frames_without_wrap = MIN(frames, frames_without_wrap);
+		frames_without_wrap = Z_MIN(frames, frames_without_wrap);
 
 		for (i = 0; i < frames_without_wrap; i++) {
 			for (elem = 0; elem < lookup->num_elems; elem++) {

--- a/src/audio/pcm_converter/pcm_converter.c
+++ b/src/audio/pcm_converter/pcm_converter.c
@@ -43,8 +43,8 @@ int pcm_convert_as_linear(const struct audio_stream *source, uint32_t ioffset,
 			log2_s_size_in;
 		N2 = audio_stream_bytes_without_wrap(sink, w_ptr) >>
 			log2_s_size_out;
-		chunk = MIN(N1, N2);
-		chunk = MIN(chunk, samples - i);
+		chunk = Z_MIN(N1, N2);
+		chunk = Z_MIN(chunk, samples - i);
 
 		/* run conversion on linear memory region */
 		converter(r_ptr, w_ptr, chunk);

--- a/src/audio/smart_amp/smart_amp.c
+++ b/src/audio/smart_amp/smart_amp.c
@@ -607,8 +607,8 @@ static int smart_amp_copy(struct comp_dev *dev)
 			avail_feedback_frames =
 				audio_stream_get_avail_frames(&sad->feedback_buf->stream);
 
-			avail_frames = MIN(avail_passthrough_frames,
-					   avail_feedback_frames);
+			avail_frames = Z_MIN(avail_passthrough_frames,
+					     avail_feedback_frames);
 
 			feedback_bytes = avail_frames *
 				audio_stream_frame_bytes(&sad->feedback_buf->stream);

--- a/src/audio/smart_amp/smart_amp_maxim_dsm.c
+++ b/src/audio/smart_amp/smart_amp_maxim_dsm.c
@@ -544,7 +544,7 @@ int smart_amp_get_num_param(struct smart_amp_mod_struct_t *hspk,
 	if (retcode != DSM_API_OK)
 		return 0;
 
-	return MIN(DSM_DEFAULT_MAX_NUM_PARAM, cmdblock[DSM_GET_CH1_IDX]);
+	return Z_MIN(DSM_DEFAULT_MAX_NUM_PARAM, cmdblock[DSM_GET_CH1_IDX]);
 }
 
 int smart_amp_get_memory_size(struct smart_amp_mod_struct_t *hspk,
@@ -699,8 +699,8 @@ int smart_amp_ff_copy(struct comp_dev *dev, uint32_t frames,
 		return -EINVAL;
 	}
 
-	num_ch_in = MIN(num_ch_in, SMART_AMP_FF_MAX_CH_NUM);
-	num_ch_out = MIN(num_ch_out, SMART_AMP_FF_OUT_MAX_CH_NUM);
+	num_ch_in = Z_MIN(num_ch_in, SMART_AMP_FF_MAX_CH_NUM);
+	num_ch_out = Z_MIN(num_ch_out, SMART_AMP_FF_OUT_MAX_CH_NUM);
 
 	ret = smart_amp_get_buffer(hspk->buf.frame_in,
 				   frames, &source->stream, chan_map,
@@ -729,8 +729,8 @@ int smart_amp_ff_copy(struct comp_dev *dev, uint32_t frames,
 
 	ret = smart_amp_put_buffer(hspk->buf.frame_out,
 				   frames, &sink->stream, chan_map,
-				   MIN(num_ch_in, SMART_AMP_FF_MAX_CH_NUM),
-				   MIN(num_ch_out, SMART_AMP_FF_OUT_MAX_CH_NUM));
+				   Z_MIN(num_ch_in, SMART_AMP_FF_MAX_CH_NUM),
+				   Z_MIN(num_ch_out, SMART_AMP_FF_OUT_MAX_CH_NUM));
 	if (ret)
 		goto err;
 
@@ -759,7 +759,7 @@ int smart_amp_fb_copy(struct comp_dev *dev, uint32_t frames,
 		return -EINVAL;
 	}
 
-	num_ch = MIN(num_ch, SMART_AMP_FB_MAX_CH_NUM);
+	num_ch = Z_MIN(num_ch, SMART_AMP_FB_MAX_CH_NUM);
 
 	ret = smart_amp_get_buffer(hspk->buf.frame_iv,
 				   frames, &source->stream,

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -710,21 +710,21 @@ static int src_get_copy_limits(struct comp_data *cd,
 	if (s2->filter_length > 1) {
 		/* Two polyphase filters case */
 		frames_snk = audio_stream_get_free_frames(&sink->stream);
-		frames_snk = MIN(frames_snk, cd->sink_frames + s2->blk_out);
+		frames_snk = Z_MIN(frames_snk, cd->sink_frames + s2->blk_out);
 		sp->stage2_times = frames_snk / s2->blk_out;
 		frames_src = audio_stream_get_avail_frames(&source->stream);
-		frames_src = MIN(frames_src, cd->source_frames + s1->blk_in);
+		frames_src = Z_MIN(frames_src, cd->source_frames + s1->blk_in);
 		sp->stage1_times = frames_src / s1->blk_in;
 		sp->blk_in = sp->stage1_times * s1->blk_in;
 		sp->blk_out = sp->stage2_times * s2->blk_out;
 	} else {
 		/* Single polyphase filter case */
 		frames_snk = audio_stream_get_free_frames(&sink->stream);
-		frames_snk = MIN(frames_snk, cd->sink_frames + s1->blk_out);
+		frames_snk = Z_MIN(frames_snk, cd->sink_frames + s1->blk_out);
 		sp->stage1_times = frames_snk / s1->blk_out;
 		frames_src = audio_stream_get_avail_frames(&source->stream);
-		sp->stage1_times = MIN(sp->stage1_times,
-				       frames_src / s1->blk_in);
+		sp->stage1_times = Z_MIN(sp->stage1_times,
+					 frames_src / s1->blk_in);
 		sp->blk_in = sp->stage1_times * s1->blk_in;
 		sp->blk_out = sp->stage1_times * s1->blk_out;
 	}

--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -364,8 +364,8 @@ static struct comp_dev *volume_new(const struct comp_driver *drv,
 	}
 
 	for (i = 0; i < PLATFORM_MAX_CHANNELS; i++) {
-		cd->volume[i]  =  MAX(MIN(cd->vol_max, VOL_ZERO_DB),
-				      cd->vol_min);
+		cd->volume[i]  =  Z_MAX(Z_MIN(cd->vol_max, VOL_ZERO_DB),
+					cd->vol_min);
 		cd->tvolume[i] = cd->volume[i];
 		cd->mvolume[i] = cd->volume[i];
 		cd->muted[i] = false;
@@ -477,7 +477,7 @@ static inline int volume_set_chan(struct comp_dev *dev, int chan,
 		/* Ensure ramp coefficient is at least min. non-zero
 		 * fractional value.
 		 */
-		coef = MAX(coef, 1);
+		coef = Z_MAX(coef, 1);
 
 		/* Invert sign for volume down ramp step */
 		if (delta < 0)

--- a/src/drivers/generic/dummy-dma.c
+++ b/src/drivers/generic/dummy-dma.c
@@ -96,7 +96,7 @@ static ssize_t dummy_dma_copy_crt_elem(struct dma_chan_pdata *pdata,
 	wptr = pdata->elems->elems[pdata->sg_elem_curr_idx].dest;
 	orig_size = pdata->elems->elems[pdata->sg_elem_curr_idx].size;
 	remaining_size = orig_size - pdata->elem_progress;
-	copy_size = MIN(remaining_size, bytes);
+	copy_size = Z_MIN(remaining_size, bytes);
 
 	/* On playback, invalidate host buffer (it may lie in a cached area).
 	 * Otherwise we could be playing stale data.

--- a/src/drivers/imx/edma.c
+++ b/src/drivers/imx/edma.c
@@ -313,7 +313,7 @@ static int edma_setup_tcd(struct dma_chan_data *channel, int16_t soff,
 	 */
 	burst_elems = burst_elems * 4U / 2U;
 
-	size = MIN(elem_size, burst_elems);
+	size = Z_MIN(elem_size, burst_elems);
 	while (size >= 4U) {
 		if ((elem_size % size) == 0UL)
 			break;

--- a/src/drivers/intel/dmic.c
+++ b/src/drivers/intel/dmic.c
@@ -288,7 +288,7 @@ static void find_modes(struct dai *dai,
 
 	/* Min and max clock dividers */
 	clkdiv_min = ceil_divide(DMIC_HW_IOCLK, dmic_prm[di]->pdmclk_max);
-	clkdiv_min = MAX(clkdiv_min, DMIC_HW_CIC_DECIM_MIN);
+	clkdiv_min = Z_MAX(clkdiv_min, DMIC_HW_CIC_DECIM_MIN);
 	clkdiv_max = DMIC_HW_IOCLK / dmic_prm[di]->pdmclk_min;
 
 	/* Loop possible clock dividers and check based on resulting
@@ -436,9 +436,9 @@ static struct pdm_decim *get_fir(struct dai *dai,
 	 * length. Exceeding this length sets HW overrun status and
 	 * overwrite of other register.
 	 */
-	fir_max_length = MIN(DMIC_HW_FIR_LENGTH_MAX,
-			     DMIC_HW_IOCLK / fs / 2 -
-			     DMIC_FIR_PIPELINE_OVERHEAD);
+	fir_max_length = Z_MIN(DMIC_HW_FIR_LENGTH_MAX,
+			       DMIC_HW_IOCLK / fs / 2 -
+			       DMIC_FIR_PIPELINE_OVERHEAD);
 
 	i = 0;
 	/* Loop until NULL */
@@ -968,8 +968,8 @@ static int configure_registers(struct dai *dai,
 
 		if (di == 0) {
 			/* FIR A */
-			fir_decim = MAX(cfg->mfir_a - 1, 0);
-			fir_length = MAX(cfg->fir_a_length - 1, 0);
+			fir_decim = Z_MAX(cfg->mfir_a - 1, 0);
+			fir_length = Z_MAX(cfg->fir_a_length - 1, 0);
 			val = FIR_CONTROL_A_START(0) |
 				FIR_CONTROL_A_ARRAY_START_EN(array_a) |
 				FIR_CONTROL_A_DCCOMP(dccomp) |
@@ -1013,8 +1013,8 @@ static int configure_registers(struct dai *dai,
 
 		if (di == 1) {
 			/* FIR B */
-			fir_decim = MAX(cfg->mfir_b - 1, 0);
-			fir_length = MAX(cfg->fir_b_length - 1, 0);
+			fir_decim = Z_MAX(cfg->mfir_b - 1, 0);
+			fir_length = Z_MAX(cfg->fir_b_length - 1, 0);
 			val = FIR_CONTROL_B_START(0) |
 				FIR_CONTROL_B_ARRAY_START_EN(array_b) |
 				FIR_CONTROL_B_DCCOMP(dccomp) |

--- a/src/drivers/intel/ssp/mn.c
+++ b/src/drivers/intel/ssp/mn.c
@@ -344,7 +344,7 @@ static bool find_mn(uint32_t freq, uint32_t bclk,
 		--scr_div;
 
 	/* clamp to valid SCR range */
-	scr_div = MIN(scr_div, (SSCR0_SCR_MASK >> 8) + 1);
+	scr_div = Z_MIN(scr_div, (SSCR0_SCR_MASK >> 8) + 1);
 
 	/* find highest even divisor */
 	while (scr_div > 1 && freq % scr_div != 0)

--- a/src/drivers/intel/ssp/ssp.c
+++ b/src/drivers/intel/ssp/ssp.c
@@ -577,10 +577,10 @@ static int ssp_set_config(struct dai *dai,
 			goto out;
 	}
 
-	tft = MIN(SSP_FIFO_DEPTH - SSP_FIFO_WATERMARK,
-		  sample_width * active_tx_slots);
-	rft = MIN(SSP_FIFO_DEPTH - SSP_FIFO_WATERMARK,
-		  sample_width * active_rx_slots);
+	tft = Z_MIN(SSP_FIFO_DEPTH - SSP_FIFO_WATERMARK,
+		    sample_width * active_tx_slots);
+	rft = Z_MIN(SSP_FIFO_DEPTH - SSP_FIFO_WATERMARK,
+		    sample_width * active_rx_slots);
 
 	sscr3 |= SSCR3_TX(tft) | SSCR3_RX(rft);
 

--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -378,7 +378,7 @@ audio_stream_avail_frames(const struct audio_stream *source,
 	uint32_t src_frames = audio_stream_get_avail_frames(source);
 	uint32_t sink_frames = audio_stream_get_free_frames(sink);
 
-	return MIN(src_frames, sink_frames);
+	return Z_MIN(src_frames, sink_frames);
 }
 
 /**
@@ -571,7 +571,7 @@ static inline int audio_stream_copy(const struct audio_stream *source,
 	while (bytes) {
 		bytes_src = audio_stream_bytes_without_wrap(source, src);
 		bytes_snk = audio_stream_bytes_without_wrap(sink, snk);
-		bytes_copied = MIN(bytes, MIN(bytes_src, bytes_snk));
+		bytes_copied = Z_MIN(bytes, Z_MIN(bytes_src, bytes_snk));
 
 		ret = memcpy_s(snk, bytes_snk, src, bytes_copied);
 		assert(!ret);

--- a/src/include/sof/math/numbers.h
+++ b/src/include/sof/math/numbers.h
@@ -12,23 +12,32 @@
 
 #include <stdint.h>
 
+/* These macros evaluate their arguments only once. This comes at a
+ * price:
+ * 1. They require a compiler that supports statement-expressions
+ *    (gcc, clang,...)
+ * 2. They cannot be used at compile time, only at run time.
+ *
+ * Z_MIN and Z_MAX are named like the equivalent Zephyr macros.
+ */
+
 /* Zephyr defines this - remove local copy once Zephyr integration complete */
-#ifdef MIN
-#undef MIN
+#ifdef Z_MIN
+#undef Z_MIN
 #endif
 
-#define MIN(a, b) ({		\
+#define Z_MIN(a, b) ({		\
 	typeof(a) __a = (a);	\
 	typeof(b) __b = (b);	\
 	__a > __b ? __b : __a;	\
 })
 
 /* Zephyr defines this - remove local copy once Zephyr integration complete */
-#ifdef MAX
-#undef MAX
+#ifdef Z_MAX
+#undef Z_MAX
 #endif
 
-#define MAX(a, b) ({		\
+#define Z_MAX(a, b) ({		\
 	typeof(a) __a = (a);	\
 	typeof(b) __b = (b);	\
 	__a < __b ? __b : __a;	\

--- a/src/ipc/handler.c
+++ b/src/ipc/handler.c
@@ -993,7 +993,7 @@ static int ipc_probe_info(uint32_t header)
 	} else {
 		tr_err(&ipc_tr, "ipc_probe_get_data(): probes module returned too much payload for cmd %u - returned %d bytes, max %d",
 		       cmd, params->rhdr.hdr.size,
-		       MIN(MAILBOX_HOSTBOX_SIZE, SOF_IPC_MSG_MAX_SIZE));
+		       Z_MIN(MAILBOX_HOSTBOX_SIZE, SOF_IPC_MSG_MAX_SIZE));
 		ret = -EINVAL;
 	}
 
@@ -1079,7 +1079,7 @@ static int ipc_comp_value(uint32_t header, uint32_t cmd)
 	} else {
 		tr_err(&ipc_tr, "ipc: comp %d cmd %u returned %d bytes max %d",
 		       data->comp_id, data->cmd, data->rhdr.hdr.size,
-		       MIN(MAILBOX_HOSTBOX_SIZE, SOF_IPC_MSG_MAX_SIZE));
+		       Z_MIN(MAILBOX_HOSTBOX_SIZE, SOF_IPC_MSG_MAX_SIZE));
 		ret = -EINVAL;
 	}
 

--- a/src/lib/alloc.c
+++ b/src/lib/alloc.c
@@ -1039,7 +1039,7 @@ void *rbrealloc_align(void *ptr, uint32_t flags, uint32_t caps, size_t bytes,
 	struct mm *memmap = memmap_get();
 	void *new_ptr = NULL;
 	uint32_t lock_flags;
-	size_t copy_bytes = MIN(bytes, old_bytes);
+	size_t copy_bytes = Z_MIN(bytes, old_bytes);
 
 	if (!bytes)
 		return new_ptr;

--- a/src/samples/audio/smart_amp_test.c
+++ b/src/samples/audio/smart_amp_test.c
@@ -443,8 +443,8 @@ static int smart_amp_copy(struct comp_dev *dev)
 			avail_feedback_frames =
 				audio_stream_get_avail_frames(&sad->feedback_buf->stream);
 
-			avail_frames = MIN(avail_passthrough_frames,
-					   avail_feedback_frames);
+			avail_frames = Z_MIN(avail_passthrough_frames,
+					     avail_feedback_frames);
 
 			feedback_bytes = avail_frames *
 				audio_stream_frame_bytes(&sad->feedback_buf->stream);

--- a/src/schedule/timer_domain.c
+++ b/src/schedule/timer_domain.c
@@ -237,14 +237,14 @@ static void timer_domain_set(struct ll_schedule_domain *domain, uint64_t start)
 	uint64_t ticks_req;
 
 	/* make sure to require for ticks later than tout from now */
-	ticks_req = MAX(start, platform_timer_get_atomic(timer_domain->timer) + ticks_tout);
+	ticks_req = Z_MAX(start, platform_timer_get_atomic(timer_domain->timer) + ticks_tout);
 
 	ticks_set = platform_timer_set(timer_domain->timer, ticks_req);
 #else
 	uint64_t current = platform_timer_get_atomic(timer_domain->timer);
 	uint64_t earliest_next = current + 1 + ZEPHYR_SCHED_COST;
 	uint64_t ticks_req = domain->next_tick ? start + ticks_tout :
-		MAX(start, earliest_next);
+		Z_MAX(start, earliest_next);
 	int ret, core = cpu_get_id();
 	uint64_t ticks_delta;
 

--- a/src/trace/dma-trace.c
+++ b/src/trace/dma-trace.c
@@ -401,7 +401,7 @@ void dma_trace_flush(void *t)
 				(char *)buffer->addr;
 	}
 
-	size = MIN(size, MAILBOX_TRACE_SIZE);
+	size = Z_MIN(size, MAILBOX_TRACE_SIZE);
 
 	/* invalidate trace data */
 	dcache_invalidate_region((void *)t, size);

--- a/tools/oss-fuzz/fuzz_ipc.c
+++ b/tools/oss-fuzz/fuzz_ipc.c
@@ -19,7 +19,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 	// copy the buffer to pre allocated buffer
 	struct sof_ipc_cmd_hdr *hdr = calloc(SOF_IPC_MSG_MAX_SIZE, 1);
 
-	memcpy_s(hdr, SOF_IPC_MSG_MAX_SIZE, Data, MIN(Size, SOF_IPC_MSG_MAX_SIZE));
+	memcpy_s(hdr, SOF_IPC_MSG_MAX_SIZE, Data, Z_MIN(Size, SOF_IPC_MSG_MAX_SIZE));
 
 	// sanity check performed typically by platform dependent code
 	if (hdr->size < sizeof(*hdr) || hdr->size > SOF_IPC_MSG_MAX_SIZE)

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -112,7 +112,7 @@ void *rbrealloc_align(void *ptr, uint32_t flags, uint32_t caps, size_t bytes,
 	}
 
 	if (!(flags & SOF_MEM_FLAG_NO_COPY)) {
-		memcpy(new_ptr, ptr, MIN(bytes, old_bytes));
+		memcpy(new_ptr, ptr, Z_MIN(bytes, old_bytes));
 	}
 
 	rfree(ptr);


### PR DESCRIPTION
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/33567

No functional change, compiler output is identical.

Note a number of some source files modified are not compiled in the
default configurations and were not even compile-tested locally:
```
src/ipc/handler.c
src/schedule/timer_domain.c
zephyr/wrapper.c
src/audio/codec_adapter/codec_adapter.c
src/audio/drc/drc.c
src/audio/drc/drc_generic.c
src/audio/crossover/crossover.c
src/audio/smart_amp/smart_amp.c
src/audio/smart_amp/smart_amp_maxim_dsm.c
```
Signed-off-by: Marc Herbert <marc.herbert@intel.com>