### PR TITLE
[skip ci] Run checkpatch --strict even when non-strict fails

### DIFF
--- a/.github/workflows/shallow_checkpatch.yml
+++ b/.github/workflows/shallow_checkpatch.yml
@@ -45,9 +45,10 @@ jobs:
            # show what we got
            git --no-pager log --oneline --graph --decorate --max-count=50
 
-      - name: normal checkpatch
-        run: .github/workflows/checkpatch_list.sh ${CHK_CMD_OPTS} < PR_SHAs.txt
-
-      - name: checkpatch --strict
+      - name: checkpatch --strict (status always white even on failure)
+        continue-on-error: true
         run: .github/workflows/checkpatch_list.sh ${CHK_CMD_OPTS}
                  --strict < PR_SHAs.txt
+
+      - name: normal checkpatch
+        run: .github/workflows/checkpatch_list.sh ${CHK_CMD_OPTS} < PR_SHAs.txt

--- a/src/audio/tone.c
+++ b/src/audio/tone.c
@@ -45,6 +45,7 @@
 
 static const struct comp_driver comp_tone;
 
+
 /* 04e3f894-2c5c-4f2e-8dc1-694eeaab53fa */
 DECLARE_SOF_RT_UUID("tone", tone_uuid, 0x04e3f894, 0x2c5c, 0x4f2e,
 		 0x8d, 0xc1, 0x69, 0x4e, 0xea, 0xab, 0x53, 0xfa);


### PR DESCRIPTION
We want both results even when the first one fails and provide all the
information right away to help avoid one additional round-trip to
github.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>