### PR TITLE
ipc: structures should all be aligned on 4 bytes

### DIFF
--- a/src/audio/asrc/asrc.c
+++ b/src/audio/asrc/asrc.c
@@ -323,7 +323,7 @@ static int asrc_ctrl_cmd(struct comp_dev *dev, struct sof_ipc_ctrl_data *cdata)
 static int asrc_cmd(struct comp_dev *dev, int cmd, void *data,
 		    int max_data_size)
 {
-	struct sof_ipc_ctrl_data *cdata = data;
+	struct sof_ipc_ctrl_data *cdata = ASSUME_ALIGNED(data, 4);
 	int ret = 0;
 
 	comp_info(dev, "asrc_cmd()");

--- a/src/audio/codec_adapter/codec_adapter.c
+++ b/src/audio/codec_adapter/codec_adapter.c
@@ -645,7 +645,7 @@ int codec_adapter_cmd(struct comp_dev *dev, int cmd, void *data,
 		      int max_data_size)
 {
 	int ret;
-	struct sof_ipc_ctrl_data *cdata = data;
+	struct sof_ipc_ctrl_data *cdata = ASSUME_ALIGNED(data, 4);
 
 	comp_dbg(dev, "codec_adapter_cmd() %d start", cmd);
 

--- a/src/audio/crossover/crossover.c
+++ b/src/audio/crossover/crossover.c
@@ -590,7 +590,7 @@ static int crossover_cmd_get_data(struct comp_dev *dev,
 static int crossover_cmd(struct comp_dev *dev, int cmd, void *data,
 			 int max_data_size)
 {
-	struct sof_ipc_ctrl_data *cdata = data;
+	struct sof_ipc_ctrl_data *cdata = ASSUME_ALIGNED(data, 4);
 	int ret = 0;
 
 	comp_info(dev, "crossover_cmd()");

--- a/src/audio/dcblock/dcblock.c
+++ b/src/audio/dcblock/dcblock.c
@@ -235,7 +235,7 @@ static int dcblock_cmd_set_data(struct comp_dev *dev,
 static int dcblock_cmd(struct comp_dev *dev, int cmd, void *data,
 		       int max_data_size)
 {
-	struct sof_ipc_ctrl_data *cdata = data;
+	struct sof_ipc_ctrl_data *cdata = ASSUME_ALIGNED(data, 4);
 	int ret = 0;
 
 	comp_info(dev, "dcblock_cmd()");

--- a/src/audio/drc/drc.c
+++ b/src/audio/drc/drc.c
@@ -273,7 +273,7 @@ static int drc_cmd_set_data(struct comp_dev *dev,
 static int drc_cmd(struct comp_dev *dev, int cmd, void *data,
 		   int max_data_size)
 {
-	struct sof_ipc_ctrl_data *cdata = data;
+	struct sof_ipc_ctrl_data *cdata = ASSUME_ALIGNED(data, 4);
 	int ret = 0;
 
 	comp_info(dev, "drc_cmd()");

--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -441,7 +441,7 @@ static int fir_cmd_set_data(struct comp_dev *dev,
 static int eq_fir_cmd(struct comp_dev *dev, int cmd, void *data,
 		      int max_data_size)
 {
-	struct sof_ipc_ctrl_data *cdata = data;
+	struct sof_ipc_ctrl_data *cdata = ASSUME_ALIGNED(data, 4);
 	int ret = 0;
 
 	comp_info(dev, "eq_fir_cmd()");

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -667,7 +667,7 @@ static int iir_cmd_set_data(struct comp_dev *dev,
 static int eq_iir_cmd(struct comp_dev *dev, int cmd, void *data,
 		      int max_data_size)
 {
-	struct sof_ipc_ctrl_data *cdata = data;
+	struct sof_ipc_ctrl_data *cdata = ASSUME_ALIGNED(data, 4);
 	int ret = 0;
 
 	comp_info(dev, "eq_iir_cmd()");

--- a/src/audio/multiband_drc/multiband_drc.c
+++ b/src/audio/multiband_drc/multiband_drc.c
@@ -362,7 +362,7 @@ static int multiband_drc_cmd_set_data(struct comp_dev *dev,
 
 static int multiband_drc_cmd(struct comp_dev *dev, int cmd, void *data, int max_data_size)
 {
-	struct sof_ipc_ctrl_data *cdata = data;
+	struct sof_ipc_ctrl_data *cdata = ASSUME_ALIGNED(data, 4);
 	int ret = 0;
 
 	comp_dbg(dev, "multiband_drc_cmd()");

--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -338,7 +338,7 @@ static int mux_ctrl_get_cmd(struct comp_dev *dev,
 static int mux_cmd(struct comp_dev *dev, int cmd, void *data,
 		   int max_data_size)
 {
-	struct sof_ipc_ctrl_data *cdata = data;
+	struct sof_ipc_ctrl_data *cdata = ASSUME_ALIGNED(data, 4);
 
 	comp_info(dev, "mux_cmd() cmd = 0x%08x", cmd);
 

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -316,7 +316,7 @@ static int selector_ctrl_get_data(struct comp_dev *dev,
 static int selector_cmd(struct comp_dev *dev, int cmd, void *data,
 			int max_data_size)
 {
-	struct sof_ipc_ctrl_data *cdata = data;
+	struct sof_ipc_ctrl_data *cdata = ASSUME_ALIGNED(data, 4);
 	int ret = 0;
 
 	comp_info(dev, "selector_cmd()");

--- a/src/audio/smart_amp/smart_amp.c
+++ b/src/audio/smart_amp/smart_amp.c
@@ -450,7 +450,7 @@ static int smart_amp_ctrl_set_data(struct comp_dev *dev,
 static int smart_amp_cmd(struct comp_dev *dev, int cmd, void *data,
 			 int max_data_size)
 {
-	struct sof_ipc_ctrl_data *cdata = data;
+	struct sof_ipc_ctrl_data *cdata = ASSUME_ALIGNED(data, 4);
 
 	comp_dbg(dev, "smart_amp_cmd(): cmd: %d", cmd);
 

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -666,7 +666,7 @@ static int src_ctrl_cmd(struct comp_dev *dev, struct sof_ipc_ctrl_data *cdata)
 static int src_cmd(struct comp_dev *dev, int cmd, void *data,
 		   int max_data_size)
 {
-	struct sof_ipc_ctrl_data *cdata = data;
+	struct sof_ipc_ctrl_data *cdata = ASSUME_ALIGNED(data, 4);
 	int ret = 0;
 
 	comp_info(dev, "src_cmd()");

--- a/src/audio/tdfb/tdfb.c
+++ b/src/audio/tdfb/tdfb.c
@@ -362,7 +362,7 @@ static int tdfb_cmd_set_data(struct comp_dev *dev,
 static int tdfb_cmd(struct comp_dev *dev, int cmd, void *data,
 		    int max_data_size)
 {
-	struct sof_ipc_ctrl_data *cdata = data;
+	struct sof_ipc_ctrl_data *cdata = ASSUME_ALIGNED(data, 4);
 	int ret = 0;
 
 	comp_info(dev, "tdfb_cmd()");

--- a/src/audio/tone.c
+++ b/src/audio/tone.c
@@ -530,7 +530,8 @@ static int tone_cmd_set_data(struct comp_dev *dev,
 	case SOF_CTRL_CMD_ENUM:
 		comp_info(dev, "tone_cmd_set_data(), SOF_CTRL_CMD_ENUM, cdata->index = %u",
 			  cdata->index);
-		compv = (struct sof_ipc_ctrl_value_comp *)cdata->data->data;
+		compv = (struct sof_ipc_ctrl_value_comp *)ASSUME_ALIGNED(cdata->data->data, 4);
+
 		for (i = 0; i < (int)cdata->num_elems; i++) {
 			ch = compv[i].index;
 			val = compv[i].svalue;
@@ -587,7 +588,7 @@ static int tone_cmd_set_data(struct comp_dev *dev,
 static int tone_cmd(struct comp_dev *dev, int cmd, void *data,
 		    int max_data_size)
 {
-	struct sof_ipc_ctrl_data *cdata = data;
+	struct sof_ipc_ctrl_data *cdata = ASSUME_ALIGNED(data, 4);
 	int ret = 0;
 
 	comp_info(dev, "tone_cmd()");

--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -669,7 +669,7 @@ static int volume_ctrl_get_cmd(struct comp_dev *dev,
 static int volume_cmd(struct comp_dev *dev, int cmd, void *data,
 		      int max_data_size)
 {
-	struct sof_ipc_ctrl_data *cdata = data;
+	struct sof_ipc_ctrl_data *cdata = ASSUME_ALIGNED(data, 4);
 
 	comp_dbg(dev, "volume_cmd()");
 

--- a/src/include/ipc/channel_map.h
+++ b/src/include/ipc/channel_map.h
@@ -41,7 +41,7 @@ struct sof_ipc_channel_map {
 	uint32_t ch_mask;
 	uint32_t reserved;
 	int32_t ch_coeffs[0];
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /**
  * \brief Complete map for each channel of a multichannel stream.
@@ -57,6 +57,6 @@ struct sof_ipc_stream_map {
 	uint32_t num_ch_map;
 	uint32_t reserved[3];
 	struct sof_ipc_channel_map ch_map[0];
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 #endif /* __IPC_CHANNEL_MAP_H__ */

--- a/src/include/ipc/control.h
+++ b/src/include/ipc/control.h
@@ -101,7 +101,7 @@ enum sof_ipc_ctrl_cmd {
 struct sof_ipc_ctrl_value_chan {
 	uint32_t channel;	/**< channel map - enum sof_ipc_chmap */
 	uint32_t value;
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /**
  * Generic component mapped value data.
@@ -112,7 +112,7 @@ struct sof_ipc_ctrl_value_comp {
 		uint32_t uvalue;
 		int32_t svalue;
 	};
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /**
  * Generic control data.
@@ -145,7 +145,7 @@ struct sof_ipc_ctrl_data {
 		/* data can be used by binary controls */
 		struct sof_abi_hdr data[0];
 	};
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /** Event type */
 enum sof_ipc_ctrl_event_type {
@@ -175,7 +175,7 @@ struct sof_ipc_comp_event {
 		/* event specific values */
 		uint32_t event_value;
 	};
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /** @}*/
 

--- a/src/include/ipc/dai-imx.h
+++ b/src/include/ipc/dai-imx.h
@@ -31,7 +31,7 @@ struct sof_ipc_dai_esai_params {
 	uint16_t tdm_slot_width;
 	uint16_t reserved2;	/* alignment */
 
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /* SAI Configuration Request - SOF_IPC_DAI_SAI_CONFIG */
 struct sof_ipc_dai_sai_params {
@@ -53,5 +53,5 @@ struct sof_ipc_dai_sai_params {
 	uint16_t tdm_slot_width;
 	uint16_t reserved2;	/* alignment */
 
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 #endif /* __IPC_DAI_IMX_H__ */

--- a/src/include/ipc/dai-intel.h
+++ b/src/include/ipc/dai-intel.h
@@ -90,7 +90,7 @@ struct sof_ipc_dai_ssp_params {
 	uint32_t bclk_delay;	/* guaranteed time (ms) for which BCLK
 				 * will be driven, before sending data
 				 */
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /* HDA Configuration Request - SOF_IPC_DAI_HDA_CONFIG */
 struct sof_ipc_dai_hda_params {
@@ -98,7 +98,7 @@ struct sof_ipc_dai_hda_params {
 	uint32_t link_dma_ch;
 	uint32_t rate;
 	uint32_t channels;
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /* ALH Configuration Request - SOF_IPC_DAI_ALH_CONFIG */
 struct sof_ipc_dai_alh_params {
@@ -109,7 +109,7 @@ struct sof_ipc_dai_alh_params {
 
 	/* reserved for future use */
 	uint32_t reserved[13];
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /* DMIC Configuration Request - SOF_IPC_DAI_DMIC_CONFIG */
 
@@ -144,7 +144,7 @@ struct sof_ipc_dai_dmic_pdm_ctrl {
 	uint16_t skew;		/**< Adjust PDM data sampling vs. clock (0..15) */
 
 	uint16_t reserved[3];	/**< Make sure the total size is 4 bytes aligned */
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /* This struct contains the global settings for all 2ch PDM controllers. The
  * version number used in configuration data is checked vs. version used by
@@ -203,6 +203,6 @@ struct sof_ipc_dai_dmic_params {
 
 	/**< PDM controllers configuration */
 	struct sof_ipc_dai_dmic_pdm_ctrl pdm[SOF_DAI_INTEL_DMIC_NUM_CTRL];
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 #endif /* __IPC_DAI_INTEL_H__ */

--- a/src/include/ipc/dai.h
+++ b/src/include/ipc/dai.h
@@ -86,6 +86,6 @@ struct sof_ipc_dai_config {
 		struct sof_ipc_dai_esai_params esai;
 		struct sof_ipc_dai_sai_params sai;
 	};
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 #endif /* __IPC_DAI_H__ */

--- a/src/include/ipc/debug.h
+++ b/src/include/ipc/debug.h
@@ -28,7 +28,7 @@ struct sof_ipc_dbg_mem_usage_elem {
 	uint32_t used;		/**< number of bytes used in zone */
 	uint32_t free;		/**< number of bytes free to use within zone */
 	uint32_t reserved;	/**< reserved for future use */
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /** ABI3.18 */
 struct sof_ipc_dbg_mem_usage {
@@ -36,6 +36,6 @@ struct sof_ipc_dbg_mem_usage {
 	uint32_t reserved[4];				/**< reserved for future use */
 	uint32_t num_elems;				/**< elems[] counter */
 	struct sof_ipc_dbg_mem_usage_elem elems[];	/**< memory usage information */
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 #endif /* __IPC_DEBUG_H__ */

--- a/src/include/ipc/header.h
+++ b/src/include/ipc/header.h
@@ -322,7 +322,7 @@
  */
 struct sof_ipc_hdr {
 	uint32_t size;			/**< size of structure */
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /**
  * Command Header - Header for all IPC commands. Identifies IPC message.
@@ -333,7 +333,7 @@ struct sof_ipc_hdr {
 struct sof_ipc_cmd_hdr {
 	uint32_t size;			/**< size of structure */
 	uint32_t cmd;			/**< SOF_IPC_GLB_ + cmd */
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /**
  * Generic reply message. Some commands override this with their own reply
@@ -342,7 +342,7 @@ struct sof_ipc_cmd_hdr {
 struct sof_ipc_reply {
 	struct sof_ipc_cmd_hdr hdr;
 	int32_t error;			/**< negative error numbers */
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /**
  * Compound commands - SOF_IPC_GLB_COMPOUND.
@@ -355,7 +355,7 @@ struct sof_ipc_reply {
 struct sof_ipc_compound_hdr {
 	struct sof_ipc_cmd_hdr hdr;
 	uint32_t count;		/**< count of 0 means end of compound sequence */
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /**
  * OOPS header architecture specific data.
@@ -363,7 +363,7 @@ struct sof_ipc_compound_hdr {
 struct sof_ipc_dsp_oops_arch_hdr {
 	uint32_t arch;		/* Identifier of architecture */
 	uint32_t totalsize;	/* Total size of oops message */
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /**
  * OOPS header platform specific data.
@@ -376,7 +376,7 @@ struct sof_ipc_dsp_oops_plat_hdr {
 				 * oops message
 				 */
 	uint32_t stackptr;	/* Stack ptr */
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /** @}*/
 

--- a/src/include/ipc/info.h
+++ b/src/include/ipc/info.h
@@ -59,7 +59,7 @@ struct sof_ipc_fw_version {
 
 	/* reserved for future use */
 	uint32_t reserved[3];
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /* FW ready Message - sent by firmware when boot has completed */
 struct sof_ipc_fw_ready {
@@ -75,7 +75,7 @@ struct sof_ipc_fw_ready {
 
 	/* reserved for future use */
 	uint32_t reserved[4];
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /*
  * Extended Firmware data. All optional, depends on platform/arch.
@@ -93,7 +93,7 @@ enum sof_ipc_region {
 struct sof_ipc_ext_data_hdr {
 	struct sof_ipc_cmd_hdr hdr;
 	uint32_t type;		/**< SOF_IPC_EXT_ */
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 struct sof_ipc_window_elem {
 	struct sof_ipc_hdr hdr;
@@ -103,14 +103,14 @@ struct sof_ipc_window_elem {
 	uint32_t size;		/**< size of region in bytes */
 	/* offset in window region as windows can be partitioned */
 	uint32_t offset;
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /* extended data memory windows for IPC, trace and debug */
 struct sof_ipc_window {
 	struct sof_ipc_ext_data_hdr ext_hdr;
 	uint32_t num_windows;
 	struct sof_ipc_window_elem window[SOF_IPC_MAX_ELEMS]; /**< ABI3.17: Fixed size */
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /* extended data, compiler version */
 struct sof_ipc_cc_version {
@@ -125,7 +125,7 @@ struct sof_ipc_cc_version {
 	uint8_t name[16]; /* null terminated compiler name */
 	uint8_t optim[4]; /* null terminated compiler -O flag value */
 	uint8_t desc[32]; /* null terminated compiler description */
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /* extended data: Probe setup */
 struct sof_ipc_probe_support {
@@ -136,13 +136,13 @@ struct sof_ipc_probe_support {
 
 	/* reserved for future use */
 	uint32_t reserved[2];
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /* extended data: user abi version(s) */
 struct sof_ipc_user_abi_version {
 	struct sof_ipc_ext_data_hdr ext_hdr;
 
 	uint32_t abi_dbg_version;
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 #endif /* __IPC_INFO_H__ */

--- a/src/include/ipc/pm.h
+++ b/src/include/ipc/pm.h
@@ -30,7 +30,7 @@ struct sof_ipc_pm_ctx_elem {
 	uint32_t type;
 	uint32_t size;
 	uint64_t addr;
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /*
  * PM context - SOF_IPC_PM_CTX_SAVE, SOF_IPC_PM_CTX_RESTORE,
@@ -46,13 +46,13 @@ struct sof_ipc_pm_ctx {
 	uint32_t reserved[8];
 
 	struct sof_ipc_pm_ctx_elem elems[];
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /* enable or disable cores - SOF_IPC_PM_CORE_ENABLE */
 struct sof_ipc_pm_core_config {
 	struct sof_ipc_cmd_hdr hdr;
 	uint32_t enable_mask;
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 struct sof_ipc_pm_gate {
 	struct sof_ipc_cmd_hdr hdr;
@@ -60,7 +60,7 @@ struct sof_ipc_pm_gate {
 
 	/* reserved for future use */
 	uint32_t reserved[5];
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 #define SOF_PM_PG_RSVD		BIT(0)
 

--- a/src/include/ipc/probe.h
+++ b/src/include/ipc/probe.h
@@ -102,7 +102,7 @@ struct probe_data_packet {
 struct probe_dma {
 	uint32_t stream_tag;		/**< Stream tag associated with this DMA */
 	uint32_t dma_buffer_size;	/**< Size of buffer associated with this DMA */
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /**
  * Description of probe point
@@ -114,7 +114,7 @@ struct probe_point {
 				 *   For extraction purposes, stream tag is ignored when received,
 				 *   but returned actual extraction stream tag via INFO function.
 				 */
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /**
  * \brief DMA ADD for probes.
@@ -125,7 +125,7 @@ struct sof_ipc_probe_dma_add_params {
 	struct sof_ipc_cmd_hdr hdr;	/**< Header */
 	uint32_t num_elems;		/**< Count of DMAs specified in array */
 	struct probe_dma probe_dma[];	/**< Array of DMAs to be added */
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /**
  * \brief Reply to INFO functions.
@@ -139,7 +139,7 @@ struct sof_ipc_probe_info_params {
 		struct probe_dma probe_dma[0];		/**< DMA info */
 		struct probe_point probe_point[0];	/**< Probe Point info */
 	};
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /**
  * \brief Probe DMA remove.
@@ -150,7 +150,7 @@ struct sof_ipc_probe_dma_remove_params {
 	struct sof_ipc_cmd_hdr hdr;	/**< Header */
 	uint32_t num_elems;		/**< Count of stream tags specified in array */
 	uint32_t stream_tag[];		/**< Array of stream tags associated with DMAs to remove */
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /**
  * \brief Add probe points.
@@ -161,7 +161,7 @@ struct sof_ipc_probe_point_add_params {
 	struct sof_ipc_cmd_hdr hdr;		/**< Header */
 	uint32_t num_elems;			/**< Count of Probe Points specified in array */
 	struct probe_point probe_point[];	/**< Array of Probe Points to add */
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /**
  * \brief Remove probe point.
@@ -172,6 +172,6 @@ struct sof_ipc_probe_point_remove_params {
 	struct sof_ipc_cmd_hdr hdr;	/**< Header */
 	uint32_t num_elems;		/**< Count of buffer IDs specified in array */
 	uint32_t buffer_id[];		/**< Array of buffer IDs from which Probe Points should be removed */
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 #endif /* __IPC_PROBE_H__ */

--- a/src/include/ipc/stream.h
+++ b/src/include/ipc/stream.h
@@ -77,7 +77,7 @@ struct sof_ipc_host_buffer {
 	uint32_t pages;
 	uint32_t size;
 	uint32_t reserved[3];
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 struct sof_ipc_stream_params {
 	struct sof_ipc_hdr hdr;
@@ -96,7 +96,7 @@ struct sof_ipc_stream_params {
 
 	uint16_t reserved[3];
 	uint16_t chmap[SOF_IPC_MAX_CHANNELS];	/**< channel map - SOF_CHMAP_ */
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /* PCM params info - SOF_IPC_STREAM_PCM_PARAMS */
 struct sof_ipc_pcm_params {
@@ -105,20 +105,20 @@ struct sof_ipc_pcm_params {
 	uint32_t flags;		/**< generic PCM flags - SOF_PCM_FLAG_ */
 	uint32_t reserved[2];
 	struct sof_ipc_stream_params params;
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /* PCM params info reply - SOF_IPC_STREAM_PCM_PARAMS_REPLY */
 struct sof_ipc_pcm_params_reply {
 	struct sof_ipc_reply rhdr;
 	uint32_t comp_id;
 	uint32_t posn_offset;
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /* free stream - SOF_IPC_STREAM_PCM_PARAMS */
 struct sof_ipc_stream {
 	struct sof_ipc_cmd_hdr hdr;
 	uint32_t comp_id;
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /* flags indicating which time stamps are in sync with each other */
 #define	SOF_TIME_HOST_SYNC	(1 << 0)
@@ -151,6 +151,6 @@ struct sof_ipc_stream_posn {
 	uint64_t timestamp;	/**< system time stamp */
 	uint32_t xrun_comp_id;	/**< comp ID of XRUN component */
 	int32_t xrun_size;	/**< XRUN size in bytes */
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 #endif /* __IPC_STREAM_H__ */

--- a/src/include/ipc/topology.h
+++ b/src/include/ipc/topology.h
@@ -67,7 +67,7 @@ struct sof_ipc_comp {
 
 	/** extended data length, 0 if no extended data (ABI3.17) */
 	uint32_t ext_data_length;
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /*
  * Component Buffers
@@ -104,7 +104,7 @@ struct sof_ipc_buffer {
 	uint32_t caps;		/**< SOF_MEM_CAPS_ */
 	uint32_t flags;		/**< SOF_BUF_ flags defined above */
 	uint32_t reserved;	/**< reserved for future use */
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /* generic component config data - must always be after struct sof_ipc_comp */
 struct sof_ipc_comp_config {
@@ -117,7 +117,7 @@ struct sof_ipc_comp_config {
 
 	/* reserved for future use */
 	uint32_t reserved[2];
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /* generic host component */
 struct sof_ipc_comp_host {
@@ -126,7 +126,7 @@ struct sof_ipc_comp_host {
 	uint32_t direction;	/**< SOF_IPC_STREAM_ */
 	uint32_t no_irq;	/**< don't send periodic IRQ to host/DSP */
 	uint32_t dmac_config; /**< DMA engine specific */
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /* generic DAI component */
 struct sof_ipc_comp_dai {
@@ -136,13 +136,13 @@ struct sof_ipc_comp_dai {
 	uint32_t dai_index;	/**< index of this type dai */
 	uint32_t type;		/**< DAI type - SOF_DAI_ */
 	uint32_t reserved;	/**< reserved */
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /* generic mixer component */
 struct sof_ipc_comp_mixer {
 	struct sof_ipc_comp comp;
 	struct sof_ipc_comp_config config;
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /* volume ramping types */
 enum sof_volume_ramp {
@@ -161,7 +161,7 @@ struct sof_ipc_comp_volume {
 	uint32_t max_value;
 	uint32_t ramp;		/**< SOF_VOLUME_ */
 	uint32_t initial_ramp;	/**< ramp space in ms */
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /* generic SRC component */
 struct sof_ipc_comp_src {
@@ -171,7 +171,7 @@ struct sof_ipc_comp_src {
 	uint32_t source_rate;	/**< source rate or 0 for variable */
 	uint32_t sink_rate;	/**< sink rate or 0 for variable */
 	uint32_t rate_mask;	/**< SOF_RATE_ supported rates */
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /* generic ASRC component */
 struct sof_ipc_comp_asrc {
@@ -197,13 +197,13 @@ struct sof_ipc_comp_asrc {
 
 	/* reserved for future use */
 	uint32_t reserved[4];
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /* generic MUX component */
 struct sof_ipc_comp_mux {
 	struct sof_ipc_comp comp;
 	struct sof_ipc_comp_config config;
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /* generic tone generator component */
 struct sof_ipc_comp_tone {
@@ -218,7 +218,7 @@ struct sof_ipc_comp_tone {
 	int32_t period;
 	int32_t repeats;
 	int32_t ramp_step;
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /* generic "effect", "codec" or proprietary processing component */
 struct sof_ipc_comp_process {
@@ -231,7 +231,7 @@ struct sof_ipc_comp_process {
 	uint32_t reserved[7];
 
 	unsigned char data[0];
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /* frees components, buffers and pipelines
  * SOF_IPC_TPLG_COMP_FREE, SOF_IPC_TPLG_PIPE_FREE, SOF_IPC_TPLG_BUFFER_FREE
@@ -239,13 +239,13 @@ struct sof_ipc_comp_process {
 struct sof_ipc_free {
 	struct sof_ipc_cmd_hdr hdr;
 	uint32_t id;
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 struct sof_ipc_comp_reply {
 	struct sof_ipc_reply rhdr;
 	uint32_t id;
 	uint32_t offset;
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /*
  * Pipeline
@@ -270,29 +270,29 @@ struct sof_ipc_pipe_new {
 	uint32_t frames_per_sched;/**< output frames of pipeline, 0 is variable */
 	uint32_t xrun_limit_usecs; /**< report xruns greater than limit */
 	uint32_t time_domain;	/**< scheduling time domain */
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /* pipeline construction complete - SOF_IPC_TPLG_PIPE_COMPLETE */
 struct sof_ipc_pipe_ready {
 	struct sof_ipc_cmd_hdr hdr;
 	uint32_t comp_id;
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 struct sof_ipc_pipe_free {
 	struct sof_ipc_cmd_hdr hdr;
 	uint32_t comp_id;
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /* connect two components in pipeline - SOF_IPC_TPLG_COMP_CONNECT */
 struct sof_ipc_pipe_comp_connect {
 	struct sof_ipc_cmd_hdr hdr;
 	uint32_t source_id;
 	uint32_t sink_id;
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /* extended data struct for UUID components */
 struct sof_ipc_comp_ext {
 	uint8_t uuid[SOF_UUID_SIZE];
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 #endif /* __IPC_TOPOLOGY_H__ */

--- a/src/include/ipc/trace.h
+++ b/src/include/ipc/trace.h
@@ -33,7 +33,7 @@ struct sof_ipc_dma_trace_params {
 	struct sof_ipc_cmd_hdr hdr;
 	struct sof_ipc_host_buffer buffer;
 	uint32_t stream_tag;
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /* DMA for Trace params info - SOF_IPC_DEBUG_DMA_PARAMS_EXT */
 struct sof_ipc_dma_trace_params_ext {
@@ -42,7 +42,7 @@ struct sof_ipc_dma_trace_params_ext {
 	uint32_t stream_tag;
 	uint64_t timestamp_ns; /* in nanosecnd */
 	uint32_t reserved[8];
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /* DMA for Trace params info - SOF_IPC_DEBUG_DMA_PARAMS */
 struct sof_ipc_dma_trace_posn {
@@ -50,7 +50,7 @@ struct sof_ipc_dma_trace_posn {
 	uint32_t host_offset;	/* Offset of DMA host buffer */
 	uint32_t overflow;	/* overflow bytes if any */
 	uint32_t messages;	/* total trace messages */
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /* Values used in sof_ipc_trace_filter_elem */
 
@@ -70,7 +70,7 @@ struct sof_ipc_dma_trace_posn {
 struct sof_ipc_trace_filter_elem {
 	int32_t key;		/**< SOF_IPC_TRACE_FILTER_ELEM_ {LEVEL, UUID, COMP, PIPE} */
 	int32_t value;		/**< element value */
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /** Runtime tracing filtration data - SOF_IPC_TRACE_FILTER_UPDATE, ABI3.17 */
 struct sof_ipc_trace_filter {
@@ -79,7 +79,7 @@ struct sof_ipc_trace_filter {
 	uint32_t reserved[8];		/**< reserved for future usage */
 	/** variable size array with new filtering settings */
 	struct sof_ipc_trace_filter_elem elems[];
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 /*
  * Commom debug
@@ -112,6 +112,6 @@ struct sof_ipc_panic_info {
 	uint32_t code;			/* SOF_IPC_PANIC_ */
 	char filename[SOF_TRACE_FILENAME_SIZE];
 	uint32_t linenum;
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 #endif /* __IPC_TRACE_H__ */

--- a/src/include/ipc/xtensa.h
+++ b/src/include/ipc/xtensa.h
@@ -54,6 +54,6 @@ struct sof_ipc_dsp_oops_xtensa {
 	uint32_t windowstart;
 	uint32_t excsave1;
 	uint32_t ar[];
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 #endif /* __IPC_XTENSA_H__ */

--- a/src/include/kernel/ext_manifest.h
+++ b/src/include/kernel/ext_manifest.h
@@ -55,7 +55,7 @@ enum config_elem_type {
 struct config_elem {
 	uint32_t token;
 	uint32_t value;
-} __packed;
+} __attribute__((packed, aligned(4)));
 
 /* FW version */
 struct ext_man_fw_version {
@@ -63,39 +63,39 @@ struct ext_man_fw_version {
 	/* use sof_ipc struct because of code re-use */
 	struct sof_ipc_fw_version version;
 	uint32_t flags;
-} __packed;
+} __attribute__((packed, aligned(4)));
 
 /* windows info */
 struct ext_man_windows {
 	struct ext_man_elem_header hdr;
 	/* use sof_ipc struct because of code re-use */
 	struct sof_ipc_window window;
-} __packed;
+} __attribute__((packed, aligned(4)));
 
 /* Used C compiler description */
 struct ext_man_cc_version {
 	struct ext_man_elem_header hdr;
 	/* use sof_ipc struct because of code re-use */
 	struct sof_ipc_cc_version cc_version;
-} __packed;
+} __attribute__((packed, aligned(4)));
 
 struct ext_man_probe_support {
 	struct ext_man_elem_header hdr;
 	/* use sof_ipc struct because of code re-use */
 	struct sof_ipc_probe_support probe;
-} __packed;
+} __attribute__((packed, aligned(4)));
 
 struct ext_man_dbg_abi {
 	struct ext_man_elem_header hdr;
 	/* use sof_ipc struct because of code re-use */
 	struct sof_ipc_user_abi_version dbg_abi;
-} __packed;
+} __attribute__((packed, aligned(4)));
 
 /** EXT_MAN_ELEM_CONFIG_DATA elements (ABI3.17) */
 struct ext_man_config_data {
 	struct ext_man_elem_header hdr;
 
 	struct config_elem elems[];
-} __packed;
+} __attribute__((packed, aligned(4)));
 
 #endif /* __KERNEL_EXT_MANIFEST_H__ */

--- a/src/include/sof/audio/component_ext.h
+++ b/src/include/sof/audio/component_ext.h
@@ -120,7 +120,7 @@ static inline int comp_dai_get_hw_params(struct comp_dev *dev,
 static inline int comp_cmd(struct comp_dev *dev, int cmd, void *data,
 			   int max_data_size)
 {
-	struct sof_ipc_ctrl_data *cdata = data;
+	struct sof_ipc_ctrl_data *cdata = ASSUME_ALIGNED(data, 4);
 	int ret = -EINVAL;
 
 	if (cmd == COMP_CMD_SET_DATA &&

--- a/src/samples/audio/detect_test.c
+++ b/src/samples/audio/detect_test.c
@@ -574,7 +574,7 @@ static int test_keyword_ctrl_get_data(struct comp_dev *dev,
 static int test_keyword_cmd(struct comp_dev *dev, int cmd, void *data,
 			    int max_data_size)
 {
-	struct sof_ipc_ctrl_data *cdata = data;
+	struct sof_ipc_ctrl_data *cdata = ASSUME_ALIGNED(data, 4);
 
 	comp_info(dev, "test_keyword_cmd()");
 

--- a/src/samples/audio/smart_amp_test.c
+++ b/src/samples/audio/smart_amp_test.c
@@ -240,7 +240,7 @@ static int smart_amp_ctrl_set_data(struct comp_dev *dev,
 static int smart_amp_cmd(struct comp_dev *dev, int cmd, void *data,
 			 int max_data_size)
 {
-	struct sof_ipc_ctrl_data *cdata = data;
+	struct sof_ipc_ctrl_data *cdata = ASSUME_ALIGNED(data, 4);
 
 	comp_info(dev, "smart_amp_cmd(): cmd: %d", cmd);
 

--- a/tools/testbench/file.c
+++ b/tools/testbench/file.c
@@ -565,7 +565,7 @@ static int file_trigger(struct comp_dev *dev, int cmd)
 static int file_cmd(struct comp_dev *dev, int cmd, void *data,
 		    int max_data_size)
 {
-	struct sof_ipc_ctrl_data *cdata = data;
+	struct sof_ipc_ctrl_data *cdata = ASSUME_ALIGNED(data, 4);
 	int ret = 0;
 
 	comp_info(dev, "file_cmd()");


### PR DESCRIPTION
Give the compiler a chance to further optimise IPC data access since it's
all on a 4 byte alignment.

Signed-off-by: Liam Girdwood <liam.r.girdwood@linux.intel.com>