### PR TITLE
[DNM (for v1.8-rc2) ] CA: cadence: update stream params during config apply

### DIFF
--- a/src/audio/codec_adapter/codec/cadence.c
+++ b/src/audio/codec_adapter/codec/cadence.c
@@ -144,6 +144,29 @@ int cadence_codec_init(struct comp_dev *dev)
 			 obj_size);
 	}
 
+	/* Assign stream params IDs */
+	switch (api_id) {
+#ifdef CONFIG_CADENCE_CODEC_AAC_DEC
+	case CADENCE_CODEC_AAC_DEC_ID:
+		cd->sample_rate_id = XA_AACDEC_CONFIG_PARAM_AAC_SAMPLERATE;
+		cd->sample_width_id = XA_AACDEC_CONFIG_PARAM_PCM_WDSZ;
+		cd->channels_id = XA_AACDEC_CONFIG_PARAM_NUM_CHANNELS;
+		break;
+#endif
+#ifdef CONFIG_CADENCE_CODEC_MP3_DEC
+	case CADENCE_CODEC_MP3_DEC_ID:
+		cd->sample_rate_id = XA_MP3DEC_CONFIG_PARAM_SAMP_FREQ;
+		cd->sample_width_id = XA_MP3DEC_CONFIG_PARAM_PCM_WDSZ;
+		cd->channels_id = XA_MP3DEC_CONFIG_PARAM_NUM_CHANNELS;
+		break;
+#endif
+	default:
+		cd->sample_rate_id = CADENCE_SAMPLE_RATE_ID;
+		cd->sample_width_id = CADENCE_SAMPLE_WIDTH_ID;
+		cd->channels_id = CADENCE_CHANNELS_COUNT_ID;
+		break;
+	}
+
 	comp_dbg(dev, "cadence_codec_init() done");
 out:
 	return ret;

--- a/src/include/sof/audio/codec_adapter/codec/cadence.h
+++ b/src/include/sof/audio/codec_adapter/codec/cadence.h
@@ -36,12 +36,23 @@ struct cadence_api {
 	xa_codec_func_t *api;
 };
 
+enum default_stream_params_ids {
+	CADENCE_SAMPLE_RATE_ID = 0x01,
+	CADENCE_SAMPLE_WIDTH_ID = 0x02,
+	CADENCE_CHANNELS_COUNT_ID = 0x04
+}
+
 struct cadence_codec_data {
 	char name[LIB_NAME_MAX_LEN];
 	void *self;
 	xa_codec_func_t *api;
 	void *mem_tabs;
+	uint32_t sample_width_id;
+	uint32_t sample_rate_id;
+	uint32_t channels_id;
 };
+
+
 
 /*****************************************************************************/
 /* Cadence interfaces							     */


### PR DESCRIPTION
This patch updates configuration parameters read from the topology
or during runtime with the stream parameters. Hence settings like
sampling rate or sample width are aligned with stream parameters.
The mismatch in those parameters may result in audio glitches or
stream stalls, just to name a few potential issues.

Signed-off-by: Marcin Rajwa <marcin.rajwa@linux.intel.com>