### PR TITLE
doxygen: codecs: exclude 3rd part codec headers from Doxygen

### DIFF
--- a/doc/sof.doxygen.in
+++ b/doc/sof.doxygen.in
@@ -10,7 +10,8 @@ INPUT            = @top_srcdir@/src/include/ipc \
                    @top_srcdir@/src/include/kernel \
 		   @top_srcdir@/src/include/user \
                    @top_srcdir@/src/include/sof
-EXCLUDE		 =
+# Exlude some 3rd party codec headers with external references
+EXCLUDE		 = @top_srcdir@/src/include/sof/audio/MaxxEffect
 RECURSIVE	 = YES
 FILE_PATTERNS    = *.c *.h
 EXAMPLE_PATH     = @top_srcdir@/test


### PR DESCRIPTION
Lets try and keep 3rd party codec headers as-is without any modifications.
This include doxygen as some references may be in closed headers.

Signed-off-by: Liam R Girdwood <liam.r.girdwood@intel.com>