### PR TITLE
drivers: Create imx drivers Kconfig file

### DIFF
--- a/src/drivers/Kconfig
+++ b/src/drivers/Kconfig
@@ -6,6 +6,8 @@ rsource "intel/Kconfig"
 
 rsource "dw/Kconfig"
 
+rsource "imx/Kconfig"
+
 config DUMMY_DMA
 	bool "Dummy DMA (software DMA driver)"
 	default n
@@ -17,13 +19,6 @@ config DUMMY_DMA
 	  host memory.
 
 	  If unsure, select "n".
-
-config IMX_EDMA
-	bool "i.MX EDMA driver"
-	default n
-	depends on IMX
-	help
-	  Select this to enable support for i.MX EDMA DMA controller.
 
 config IPC_POLLING
 	bool "Enable IPC Polling support"

--- a/src/drivers/imx/Kconfig
+++ b/src/drivers/imx/Kconfig
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+config IMX_EDMA
+	bool "i.MX EDMA driver"
+	default n
+	depends on IMX
+	help
+	  Select this to enable support for i.MX EDMA DMA controller.


### PR DESCRIPTION
This will be the home of IMX drivers config option
definitions.

This moves IMX_DMA config option to imx/Kconfig.

Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>