### PR TITLE
Codec adapter processing fixes

### DIFF
--- a/src/audio/codec_adapter/codec_adapter.c
+++ b/src/audio/codec_adapter/codec_adapter.c
@@ -425,6 +425,9 @@ int codec_adapter_copy(struct comp_dev *dev)
 		bytes_to_process -= codec->cpd.consumed;
 		processed += codec->cpd.consumed;
 		produced += codec->cpd.produced;
+
+		audio_stream_produce(&local_buff->stream, codec->cpd.produced);
+		comp_update_buffer_consume(source, codec->cpd.consumed);
 	}
 
 	if (!produced && !cd->deep_buff_bytes) {
@@ -436,12 +439,7 @@ int codec_adapter_copy(struct comp_dev *dev)
 			goto copy_period;
 		else
 			goto end;
-	} else if (!produced && cd->deep_buff_bytes) {
-		goto db_verify;
 	}
-
-	audio_stream_produce(&local_buff->stream, produced);
-	comp_update_buffer_consume(source, processed);
 
 db_verify:
 	if (cd->deep_buff_bytes) {


### PR DESCRIPTION
First, fixes for compress audio when even there hasn't been anything produced local buffer still has some valid data which needs to be sent to the sink.
Second, fixes processing loop were we need to update source/local_buffer bytes inside the loop. Otherwise, there are problems when the loop takes more than 1 iteration.