### PR TITLE
installer: change default destination to /lib/firmware/updates

### DIFF
--- a/installer/GNUmakefile
+++ b/installer/GNUmakefile
@@ -88,11 +88,16 @@ GNUMAKEFLAGS = --no-print-directory
       #####################################
 
 # Default value
-FW_DESTDIR ?= /lib/firmware/intel/
-# We don't depend on any other target so:
-# - it's possible to deploy a staging _subset_,
+FW_DESTDIR ?= /lib/firmware/updates/intel/
+
+# The rsync target does not depend on any other target so:
+# - it's possible to deploy a staging _subset_, e.g.: only topologies
+#   only,...
 # - sudo never builds by accident
 rsync:
+# The --mkpath option is too recent, dealing with both remote and local
+# would be complicated and this is also a safety against typos.
+	# The destination directory must already exist
 	rsync -a --info=progress2 staging/sof* "${FW_DESTDIR}"
 ifneq (${USER_DESTDIR},)
 	# TODO: add more user space binaries: sof-ctl, probes,...

--- a/installer/sample-config.mk
+++ b/installer/sample-config.mk
@@ -10,9 +10,9 @@
 # UNSIGNED_list :=
 # SIGNED_list := apl tgl
 
-# The default FW_DESTDIR is the local /lib/firmware/intel directory
+# The default FW_DESTDIR is the local /lib/firmware/updates/intel directory
 # _remote := test-system.local
-# FW_DESTDIR     := root@${_remote}:/lib/firmware/intel
+# FW_DESTDIR     := root@${_remote}:/lib/firmware/updates/intel
 # USER_DESTDIR   := ${_remote}:bin/
 
 # Define this empty for a plain sof/ directory and no sof -> sof-v1.2.3


### PR DESCRIPTION
Kudos to Pierre-Louis for advertising this cool feature

Signed-off-by: Marc Herbert <marc.herbert@intel.com>