### PR TITLE
fuzzer: fix build as with header order and ARRAY_SIZE redefinition

### DIFF
--- a/tools/fuzzer/fuzzer.h
+++ b/tools/fuzzer/fuzzer.h
@@ -30,7 +30,9 @@
 #define IRQ_WAKE_THREAD	1
 #define IRQ_HANDLED	2
 
+#ifndef ARRAY_SIZE
 #define ARRAY_SIZE(x) (sizeof(x) / sizeof(x[0]))
+#endif
 
 struct fuzz;
 struct fuzz_platform;

--- a/tools/fuzzer/topology.c
+++ b/tools/fuzzer/topology.c
@@ -13,11 +13,12 @@
 #include <errno.h>
 #include <unistd.h>
 #include <string.h>
-#include "../fuzzer/fuzzer.h"
 #include <ipc/topology.h>
 #include <ipc/stream.h>
 #include <sof/common.h>
 #include <tplg_parser/topology.h>
+
+#include "../fuzzer/fuzzer.h"
 
 const struct sof_dai_types sof_dais[] = {
 	{"SSP", SOF_DAI_INTEL_SSP},


### PR DESCRIPTION
ARRAY_SIZE was being redefined, simplest option is to remove, but I think
this code has to additionally be compiled with external Fuzzer. Fix build.

Signed-off-by: Liam Girdwood <liam.r.girdwood@linux.intel.com>