### PR TITLE
codec_adapter: Remove braces around single statement

### DIFF
--- a/src/audio/codec_adapter/codec/generic.c
+++ b/src/audio/codec_adapter/codec/generic.c
@@ -169,9 +169,9 @@ int codec_free_memory(struct comp_dev *dev, void *ptr)
 	struct list_item *mem_list;
 	struct list_item *_mem_list;
 
-	if (!ptr) {
+	if (!ptr)
 		return 0;
-	}
+
 	/* Find which container keeps this memory */
 	list_for_item_safe(mem_list, _mem_list, &cd->codec.memory.mem_list) {
 		mem = container_of(mem_list, struct codec_memory, mem_list);


### PR DESCRIPTION
This fixes the following checkpatch.pl warning:

WARNING: braces {} are not necessary for single statement blocks
172: FILE: src/audio/codec_adapter/codec/generic.c:172: