### PR TITLE
topology: sof-tgl-nocodec-ci: change to run smart_amp on core 1

### DIFF
--- a/tools/topology/development/sof-tgl-nocodec-ci.m4
+++ b/tools/topology/development/sof-tgl-nocodec-ci.m4
@@ -100,6 +100,9 @@ define(`SMART_REF_CH_NUM', 4)
 define(`SMART_PCM_ID', 2)
 define(`SMART_PCM_NAME', `smart-nocodec')
 
+# run smart amp pipelines on DSP core 1
+define(`SMART_AMP_CORE', 1)
+
 # Include Smart Amplifier support
 include(`sof-smart-amplifier.m4')
 


### PR DESCRIPTION
Change to run smart_amp pipelines on DSP core 1, this will help reduce
the core 0 usage and add multi-core to the CI coverage.

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>