### PR TITLE
dai: add DAI driver "hw_params" callback

### DIFF
--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -290,6 +290,25 @@ static int dai_comp_get_hw_params(struct comp_dev *dev,
 	return 0;
 }
 
+static int dai_comp_hw_params(struct comp_dev *dev,
+			      struct sof_ipc_stream_params *params)
+{
+	struct dai_data *dd = comp_get_drvdata(dev);
+	int ret;
+
+	comp_dbg(dev, "dai_comp_hw_params()");
+
+	/* configure hw dai stream params */
+	ret = dai_hw_params(dd->dai, params);
+	if (ret < 0) {
+		comp_err(dev, "dai_comp_hw_params(): dai_hw_params failed ret %d",
+			 ret);
+		return ret;
+	}
+
+	return 0;
+}
+
 static int dai_verify_params(struct comp_dev *dev,
 			     struct sof_ipc_stream_params *params)
 {
@@ -453,6 +472,13 @@ static int dai_params(struct comp_dev *dev,
 	if (err < 0) {
 		comp_err(dev, "dai_params(): pcm params verification failed.");
 		return -EINVAL;
+	}
+
+	/* params verification passed, so now configure hw dai stream params */
+	err = dai_comp_hw_params(dev, params);
+	if (err < 0) {
+		comp_err(dev, "dai_params(): dai_comp_hw_params failed err %d", err);
+		return err;
 	}
 
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK)

--- a/src/include/sof/lib/dai.h
+++ b/src/include/sof/lib/dai.h
@@ -77,6 +77,7 @@ struct dai_ops {
 	int (*pm_context_store)(struct dai *dai);
 	int (*get_hw_params)(struct dai *dai,
 			     struct sof_ipc_stream_params *params, int dir);
+	int (*hw_params)(struct dai *dai, struct sof_ipc_stream_params *params);
 	int (*get_handshake)(struct dai *dai, int direction, int stream_id);
 	int (*get_fifo)(struct dai *dai, int direction, int stream_id);
 	int (*probe)(struct dai *dai);
@@ -374,6 +375,20 @@ static inline int dai_get_hw_params(struct dai *dai,
 {
 	int ret = dai->drv->ops.get_hw_params(dai, params, dir);
 
+
+	return ret;
+}
+
+/**
+ * \brief Configure Digital Audio interface stream parameters
+ */
+static inline int dai_hw_params(struct dai *dai,
+				struct sof_ipc_stream_params *params)
+{
+	int ret = 0;
+
+	if (dai->drv->ops.hw_params)
+		ret = dai->drv->ops.hw_params(dai, params);
 
 	return ret;
 }


### PR DESCRIPTION
Add "hw_params" callback in order to provide the
stream information like stream rate, number of channels
and format to DAI IP driver.

Signed-off-by: Viorel Suman <viorel.suman@nxp.com>