### PR TITLE
testbench: align IPC structures on 4 bytes.

### DIFF
--- a/tools/testbench/include/testbench/file.h
+++ b/tools/testbench/include/testbench/file.h
@@ -56,5 +56,5 @@ struct sof_ipc_comp_file {
 	char *fn;
 	enum file_mode mode;
 	enum sof_ipc_frame frame_fmt;
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 #endif


### PR DESCRIPTION
IPC is aligned on at least 4 bytes, removes compiler warning about packed
data being aligned on 1 bytes.

In file included from /home/lrg/work/sof/sof/tools/testbench/file.c:23:
/home/lrg/work/sof/sof/tools/testbench/include/testbench/file.h:59:1: error: alignment 1 of ‘struct sof_ipc_comp_file’ is less than 4 [-Werror=packed-not-aligned]
   59 | } __attribute__((packed));
      | ^

Signed-off-by: Liam Girdwood <liam.r.girdwood@linux.intel.com>