### PR TITLE
smex: log versions with a dot (3.18.1) instead of a colon (3:18:1)

### DIFF
--- a/smex/ldc.c
+++ b/smex/ldc.c
@@ -34,7 +34,7 @@ static int fw_version_copy(const struct elf_module *src,
 	/* fw_ready structure contains main (primarily kernel)
 	 * ABI version.
 	 */
-	fprintf(stdout, "fw abi main version:\t%d:%d:%d\n",
+	fprintf(stdout, "fw abi main version:\t%d.%d.%d\n",
 		SOF_ABI_VERSION_MAJOR(header->version.abi_version),
 		SOF_ABI_VERSION_MINOR(header->version.abi_version),
 		SOF_ABI_VERSION_PATCH(header->version.abi_version));
@@ -63,7 +63,7 @@ static int fw_version_copy(const struct elf_module *src,
 	}
 	free(buffer);
 
-	fprintf(stdout, "fw abi dbg version:\t%d:%d:%d\n",
+	fprintf(stdout, "fw abi dbg version:\t%d.%d.%d\n",
 		SOF_ABI_VERSION_MAJOR(header->version.abi_version),
 		SOF_ABI_VERSION_MINOR(header->version.abi_version),
 		SOF_ABI_VERSION_PATCH(header->version.abi_version));


### PR DESCRIPTION
Logging versions like "3:18:1" deceive Emacs (and maybe others) because
they look like an error location produced by a compiler. When compiling
Emacs wrongly believes this an error location and offers to jump to it.

The colon ':' is also a reserved character in most filesystems and an
unusual version separator.

Before:

fw abi main version:	3:18:1
fw abi main version:	3:18:1

After:

fw abi main version:	3.18.1
fw abi main version:	3.18.1

Signed-off-by: Marc Herbert <marc.herbert@intel.com>