### PR TITLE
Revert "installer: change default destination to /lib/firmware/updates"

### DIFF
--- a/installer/GNUmakefile
+++ b/installer/GNUmakefile
@@ -88,7 +88,7 @@ GNUMAKEFLAGS = --no-print-directory
       #####################################
 
 # Default value
-FW_DESTDIR ?= /lib/firmware/updates/intel/
+FW_DESTDIR ?= /lib/firmware/intel/
 
 # The rsync target does not depend on any other target so:
 # - it's possible to deploy a staging _subset_, e.g.: only topologies

--- a/installer/sample-config.mk
+++ b/installer/sample-config.mk
@@ -10,9 +10,9 @@
 # UNSIGNED_list :=
 # SIGNED_list := apl tgl
 
-# The default FW_DESTDIR is the local /lib/firmware/updates/intel directory
+# The default FW_DESTDIR is the local /lib/firmware/intel directory
 # _remote := test-system.local
-# FW_DESTDIR     := root@${_remote}:/lib/firmware/updates/intel
+# FW_DESTDIR     := root@${_remote}:/lib/firmware/intel
 # USER_DESTDIR   := ${_remote}:bin/
 
 # Define this empty for a plain sof/ directory and no sof -> sof-v1.2.3


### PR DESCRIPTION
This reverts the main change in commit
65ade5a4f973f021918955fefb16e95943e7a66f.

There are too many test changes required first, see a tentative list in
https://github.com/thesofproject/sof-test/pull/645

Signed-off-by: Marc Herbert <marc.herbert@intel.com>