### PR TITLE
topology: ssp: fix a bug in passing SSP_CONFIG_DATA args

### DIFF
--- a/tools/topology/platform/common/ssp.m4
+++ b/tools/topology/platform/common/ssp.m4
@@ -37,11 +37,11 @@ define(`SSP_CONFIG_DATA',
 `	tokens "sof_ssp_tokens"'
 `	tuples."word" {'
 `		SOF_TKN_INTEL_SSP_SAMPLE_BITS'	STR($3)
-`		SOF_TKN_INTEL_SSP_QUIRKS'	ifelse($5, `', "0", STR($5))
-`		SOF_TKN_INTEL_SSP_BCLK_DELAY'	ifelse($6, `', "0", STR($6))
+`		SOF_TKN_INTEL_SSP_QUIRKS'	`ifelse(`$5', `', "0", STR($5))'
+`		SOF_TKN_INTEL_SSP_BCLK_DELAY'	`ifelse(`$6', `', "0", STR($6))'
 `	}'
 `	tuples."short" {'
-`		SOF_TKN_INTEL_SSP_MCLK_ID'	ifelse($4, `', "0", STR($4))
+`		SOF_TKN_INTEL_SSP_MCLK_ID'	`ifelse(`$4', `', "0", STR($4))'
 `	}'
 `}'
 `SectionData."'N_DAI_CONFIG($1$2)`_data" {'


### PR DESCRIPTION
The m4 ifelse check on macro parameters is not working as expected.
If optional parameters are not passed, an empty string is written
to output conf file, instead of the "0" string specified in
the ifelse statement.

This has not caused functional errors as the empty string has
been interpreted as zero. Fix the logic despite this so that this
is not copied to other macros.

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>