### PR TITLE
logger: fix precision bug introduced by new -e option

### DIFF
--- a/tools/logger/logger.c
+++ b/tools/logger/logger.c
@@ -248,6 +248,7 @@ int main(int argc, char *argv[])
 				return -EINVAL;
 			}
 			config.relative_timestamps = i;
+			break;
 		}
 		case 'f':
 			config.time_precision = atoi(optarg);


### PR DESCRIPTION
Add missing "break" so the -e option stops spilling on the -f precision
option. Fixes commit 53ce8b9d9f82 ("logger: new relative timestamps
option, relative to first entry seen"). Since that commit the -e option
was wrongly assigned to the precision too.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>