### PR TITLE
cmocka updates for host tests and GCC xtensa

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ endif()
 
 option(BUILD_UNIT_TESTS "Build unit tests" OFF)
 option(BUILD_UNIT_TESTS_HOST "Build unit tests for host" OFF)
+option(BUILD_UNIT_TESTS_XTENSA_GCC "Build xtensa unit test using GCC" OFF)
 option(BUILD_CLANG_SCAN "Build for clang's scan-build" OFF)
 
 if(CONFIG_LIBRARY OR BUILD_UNIT_TESTS_HOST)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,9 +29,10 @@ else()
 endif()
 
 option(BUILD_UNIT_TESTS "Build unit tests" OFF)
+option(BUILD_UNIT_TESTS_HOST "Build unit tests for host" OFF)
 option(BUILD_CLANG_SCAN "Build for clang's scan-build" OFF)
 
-if(CONFIG_LIBRARY)
+if(CONFIG_LIBRARY OR BUILD_UNIT_TESTS_HOST)
 	set(ARCH host)
 else()
 	# firmware build supports only xtensa arch for now

--- a/scripts/run-mocks.sh
+++ b/scripts/run-mocks.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2021 Intel Corporation. All rights reserved.
+
+# fail on any errors
+set -e
+
+rm -rf build_ut
+
+mkdir build_ut
+cd build_ut
+
+cmake -DBUILD_UNIT_TESTS=ON -DBUILD_UNIT_TESTS_HOST=ON ..
+
+make -j$(nproc --all)
+
+TESTS=`find test -type f -executable -print`
+echo test are ${TESTS}
+for test in ${TESTS}
+do
+	echo got ${test}
+	./${test}
+done

--- a/src/arch/host/CMakeLists.txt
+++ b/src/arch/host/CMakeLists.txt
@@ -8,4 +8,6 @@ target_include_directories(sof_public_headers INTERFACE ${PROJECT_SOURCE_DIR}/sr
 target_compile_options(sof_options INTERFACE -g -O3 -Wall -Werror -Wmissing-prototypes
   -Wimplicit-fallthrough -Wno-pointer-to-int-cast -Wno-int-to-pointer-cast -Wpointer-arith -DCONFIG_LIBRARY "-imacros${CONFIG_H_PATH}")
 
-add_subdirectory(lib)
+if(NOT BUILD_UNIT_TESTS_HOST)
+	add_subdirectory(lib)
+endif()

--- a/src/platform/library/include/platform/lib/memory.h
+++ b/src/platform/library/include/platform/lib/memory.h
@@ -11,6 +11,7 @@
 #define __PLATFORM_LIB_MEMORY_H__
 
 #include <inttypes.h>
+#include <stddef.h>
 
 struct sof;
 

--- a/src/platform/library/include/platform/lib/memory.h
+++ b/src/platform/library/include/platform/lib/memory.h
@@ -12,6 +12,8 @@
 
 #include <inttypes.h>
 
+struct sof;
+
 #define PLATFORM_DCACHE_ALIGN	sizeof(void *)
 
 #define HEAP_BUFFER_SIZE	(1024 * 128)
@@ -21,10 +23,12 @@ uint8_t *get_library_mailbox(void);
 
 #define MAILBOX_BASE	get_library_mailbox()
 
-#define PLATFORM_HEAP_SYSTEM		1
+#define PLATFORM_HEAP_SYSTEM		2
 #define PLATFORM_HEAP_SYSTEM_RUNTIME	1
 #define PLATFORM_HEAP_RUNTIME		1
 #define PLATFORM_HEAP_BUFFER		3
+#define PLATFORM_HEAP_SYSTEM_SHARED	1
+#define PLATFORM_HEAP_RUNTIME_SHARED	1
 
 #define SHARED_DATA
 
@@ -32,6 +36,137 @@ static inline void *platform_shared_get(void *ptr, int bytes)
 {
 	return ptr;
 }
+
+void platform_init_memmap(struct sof *sof);
+
+static inline void *platform_rfree_prepare(void *ptr)
+{
+	return ptr;
+}
+
+#define uncache_to_cache(address)	address
+#define cache_to_uncache(address)	address
+#define is_uncached(address)		1
+
+#define ARCH_OOPS_SIZE	0
+
+static inline void *arch_get_stack_entry(void)
+{
+	return NULL;
+}
+
+static inline uint32_t arch_get_stack_size(void)
+{
+	return 0;
+}
+
+/* NOTE - FAKE Memory configurations are used by UT's to test allocator */
+
+#define SRAM_BANK_SIZE	0x10000
+#define LP_SRAM_SIZE SRAM_BANK_SIZE
+#define HP_SRAM_SIZE SRAM_BANK_SIZE
+
+#define HP_SRAM_BASE	0
+#define LP_SRAM_BASE	0
+
+/* Heap section sizes for system runtime heap for primary core */
+#define HEAP_SYS_RT_0_COUNT64		128
+#define HEAP_SYS_RT_0_COUNT512		16
+#define HEAP_SYS_RT_0_COUNT1024		4
+
+/* Heap section sizes for system runtime heap for secondary core */
+#define HEAP_SYS_RT_X_COUNT64		64
+#define HEAP_SYS_RT_X_COUNT512		8
+#define HEAP_SYS_RT_X_COUNT1024		4
+
+/* Heap section sizes for module pool */
+#define HEAP_RT_COUNT64		128
+#define HEAP_RT_COUNT128	64
+#define HEAP_RT_COUNT256	128
+#define HEAP_RT_COUNT512	8
+#define HEAP_RT_COUNT1024	4
+#define HEAP_RT_COUNT2048	1
+#define HEAP_RT_COUNT4096	1
+
+/* Heap configuration */
+#define HEAP_RUNTIME_SIZE \
+	(HEAP_RT_COUNT64 * 64 + HEAP_RT_COUNT128 * 128 + \
+	HEAP_RT_COUNT256 * 256 + HEAP_RT_COUNT512 * 512 + \
+	HEAP_RT_COUNT1024 * 1024 + HEAP_RT_COUNT2048 * 2048 + \
+	HEAP_RT_COUNT4096 * 4096)
+
+/* Heap section sizes for runtime shared heap */
+#define HEAP_RUNTIME_SHARED_COUNT64	(64 + 32 * CONFIG_CORE_COUNT)
+#define HEAP_RUNTIME_SHARED_COUNT128	64
+#define HEAP_RUNTIME_SHARED_COUNT256	4
+#define HEAP_RUNTIME_SHARED_COUNT512	16
+#define HEAP_RUNTIME_SHARED_COUNT1024	4
+
+#define HEAP_RUNTIME_SHARED_SIZE \
+	(HEAP_RUNTIME_SHARED_COUNT64 * 64 + HEAP_RUNTIME_SHARED_COUNT128 * 128 + \
+	HEAP_RUNTIME_SHARED_COUNT256 * 256 + HEAP_RUNTIME_SHARED_COUNT512 * 512 + \
+	HEAP_RUNTIME_SHARED_COUNT1024 * 1024)
+
+/* Heap section sizes for system shared heap */
+#define HEAP_SYSTEM_SHARED_SIZE		0x1500
+
+#define HEAP_BUFFER_BLOCK_SIZE		0x100
+#define HEAP_BUFFER_COUNT	(HEAP_BUFFER_SIZE / HEAP_BUFFER_BLOCK_SIZE)
+
+#define HEAP_SYSTEM_M_SIZE		0x8000 /* heap primary core size */
+#define HEAP_SYSTEM_S_SIZE		0x6000 /* heap secondary core size */
+
+#define HEAP_SYSTEM_T_SIZE \
+	(HEAP_SYSTEM_M_SIZE + ((CONFIG_CORE_COUNT - 1) * HEAP_SYSTEM_S_SIZE))
+
+#define HEAP_SYS_RUNTIME_M_SIZE \
+	(HEAP_SYS_RT_0_COUNT64 * 64 + HEAP_SYS_RT_0_COUNT512 * 512 + \
+	HEAP_SYS_RT_0_COUNT1024 * 1024)
+
+#define HEAP_SYS_RUNTIME_S_SIZE \
+	(HEAP_SYS_RT_X_COUNT64 * 64 + HEAP_SYS_RT_X_COUNT512 * 512 + \
+	HEAP_SYS_RT_X_COUNT1024 * 1024)
+
+#define HEAP_SYS_RUNTIME_T_SIZE \
+	(HEAP_SYS_RUNTIME_M_SIZE + ((CONFIG_CORE_COUNT - 1) * \
+	HEAP_SYS_RUNTIME_S_SIZE))
+
+/* Heap section sizes for module pool */
+#define HEAP_RT_LP_COUNT8			0
+#define HEAP_RT_LP_COUNT16			256
+#define HEAP_RT_LP_COUNT32			128
+#define HEAP_RT_LP_COUNT64			64
+#define HEAP_RT_LP_COUNT128			64
+#define HEAP_RT_LP_COUNT256			96
+#define HEAP_RT_LP_COUNT512			8
+#define HEAP_RT_LP_COUNT1024			4
+
+/* Heap configuration */
+#define SOF_LP_DATA_SIZE			0x4000
+
+#define HEAP_LP_SYSTEM_BASE		(LP_SRAM_BASE + SOF_LP_DATA_SIZE)
+#define HEAP_LP_SYSTEM_SIZE		0x1000
+
+#define HEAP_LP_RUNTIME_BASE \
+	(HEAP_LP_SYSTEM_BASE + HEAP_LP_SYSTEM_SIZE)
+#define HEAP_LP_RUNTIME_SIZE \
+	(HEAP_RT_LP_COUNT8 * 8 + HEAP_RT_LP_COUNT16 * 16 + \
+	HEAP_RT_LP_COUNT32 * 32 + HEAP_RT_LP_COUNT64 * 64 + \
+	HEAP_RT_LP_COUNT128 * 128 + HEAP_RT_LP_COUNT256 * 256 + \
+	HEAP_RT_LP_COUNT512 * 512 + HEAP_RT_LP_COUNT1024 * 1024)
+
+#define HEAP_LP_BUFFER_BLOCK_SIZE		0x180
+#define HEAP_LP_BUFFER_COUNT \
+	(HEAP_LP_BUFFER_SIZE / HEAP_LP_BUFFER_BLOCK_SIZE)
+
+#define HEAP_LP_BUFFER_BASE LP_SRAM_BASE
+#define HEAP_LP_BUFFER_SIZE LP_SRAM_SIZE
+
+/* SOF Core S configuration */
+#define SOF_CORE_S_SIZE \
+	ALIGN((HEAP_SYSTEM_S_SIZE + HEAP_SYS_RUNTIME_S_SIZE + SOF_STACK_SIZE),\
+	SRAM_BANK_SIZE)
+#define SOF_CORE_S_T_SIZE ((CONFIG_CORE_COUNT - 1) * SOF_CORE_S_SIZE)
 
 #endif /* __PLATFORM_LIB_MEMORY_H__ */
 

--- a/test/cmocka/CMakeLists.txt
+++ b/test/cmocka/CMakeLists.txt
@@ -7,8 +7,15 @@ add_library(cmocka STATIC IMPORTED)
 # Default use XCC unless user asks for GCC
 if(BUILD_UNIT_TESTS_HOST)
 	set(UT_CC_CONFIG ${CMAKE_CURRENT_SOURCE_DIR}/cmocka-host-gcc-toolchain.cmake)
+	set(UT_TOOLCHAIN "")
+elseif(BUILD_UNIT_TESTS_XTENSA_GCC)
+	# GCC xtensa build for future Qemu.
+	set(UT_CC_CONFIG ${CMAKE_CURRENT_SOURCE_DIR}/cmocka-xtensa-gcc-toolchain.cmake)
+	set(UT_TOOLCHAIN "-DTOOLCHAIN=${TOOLCHAIN}")
 else()
+	# xtensa XCC build for xt-run.
 	set(UT_CC_CONFIG ${CMAKE_CURRENT_SOURCE_DIR}/cmocka-xtensa-xt-toolchain.cmake)
+	set(UT_TOOLCHAIN "")
 endif()
 
 if(DEFINED CMOCKA_DIRECTORY)
@@ -32,6 +39,7 @@ else()
 			-DWITH_EXAMPLES=OFF
 			-DWITH_POSITION_INDEPENDENT_CODE=OFF
 			-DWITH_TINY_CONFIG=ON
+			${UT_TOOLCHAIN}
 		BUILD_BYPRODUCTS "${cmocka_binary_directory}/src/libcmocka-static.a"
 		INSTALL_COMMAND ""
 	)
@@ -68,6 +76,13 @@ add_dependencies(common_mock cmocka)
 target_include_directories(common_mock PRIVATE ${CMOCKA_INCLUDE_DIR})
 target_link_libraries(common_mock PRIVATE sof_options)
 target_link_libraries(common_mock PRIVATE m)
+
+# xtensa GCC require some extra options to link
+if(BUILD_UNIT_TESTS_XTENSA_GCC)
+	target_link_libraries(common_mock PRIVATE gcc)
+	target_link_libraries(common_mock PRIVATE c)
+	target_link_libraries(common_mock PRIVATE -nostdlib)
+endif()
 link_libraries(common_mock)
 sof_append_relative_path_definitions(common_mock)
 

--- a/test/cmocka/CMakeLists.txt
+++ b/test/cmocka/CMakeLists.txt
@@ -4,6 +4,13 @@ include(ExternalProject)
 
 add_library(cmocka STATIC IMPORTED)
 
+# Default use XCC unless user asks for GCC
+if(BUILD_UNIT_TESTS_HOST)
+	set(UT_CC_CONFIG ${CMAKE_CURRENT_SOURCE_DIR}/cmocka-host-gcc-toolchain.cmake)
+else()
+	set(UT_CC_CONFIG ${CMAKE_CURRENT_SOURCE_DIR}/cmocka-xtensa-xt-toolchain.cmake)
+endif()
+
 if(DEFINED CMOCKA_DIRECTORY)
 	# Prebuilt Cmocka lib
 	set_property(TARGET cmocka PROPERTY IMPORTED_LOCATION "${CMOCKA_DIRECTORY}/lib/libcmocka-static.a")
@@ -19,7 +26,7 @@ else()
 		PREFIX "${PROJECT_BINARY_DIR}/cmocka_git"
 		BINARY_DIR ${cmocka_binary_directory}
 		CMAKE_ARGS -DCMAKE_BUILD_TYPE=Release
-			-DCMAKE_TOOLCHAIN_FILE=${CMAKE_CURRENT_SOURCE_DIR}/cmocka-xtensa-xt-toolchain.cmake
+			-DCMAKE_TOOLCHAIN_FILE=${UT_CC_CONFIG}
 			-DWITH_SHARED_LIB=OFF
 			-DWITH_STATIC_LIB=ON
 			-DWITH_EXAMPLES=OFF

--- a/test/cmocka/cmocka-host-gcc-toolchain.cmake
+++ b/test/cmocka/cmocka-host-gcc-toolchain.cmake
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+message(STATUS "Preparing Host GCC toolchain")
+
+set(CMAKE_SYSTEM_NAME Generic)
+set(CMAKE_SYSTEM_VERSION 1)
+
+set(CMAKE_ASM_COMPILER_FORCED 1)
+set(CMAKE_C_COMPILER_FORCED 1)
+
+set(CMAKE_ASM_COMPILER_ID GNU)
+set(CMAKE_C_COMPILER_ID GNU)
+
+set(CMAKE_C_COMPILER gcc)
+
+find_program(CMAKE_LD NAMES "$ld" PATHS ENV PATH NO_DEFAULT_PATH)
+find_program(CMAKE_AR NAMES "$ar" PATHS ENV PATH NO_DEFAULT_PATH)
+find_program(CMAKE_OBJCOPY NAMES "objcopy" PATHS ENV PATH NO_DEFAULT_PATH)
+find_program(CMAKE_OBJDUMP NAMES "objdump" PATHS ENV PATH NO_DEFAULT_PATH)
+
+set(CMAKE_FIND_ROOT_PATH  ".")
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+
+# Cmocka is written in C99, but for some reason it sets this flag, only on Posix
+# We set up it here, because our system is Generic
+add_definitions("-std=gnu99")

--- a/test/cmocka/cmocka-xtensa-gcc-toolchain.cmake
+++ b/test/cmocka/cmocka-xtensa-gcc-toolchain.cmake
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+message(STATUS "Preparing Xtensa GCC toolchain using ${TOOLCHAIN}")
+
+set(CROSS_COMPILE "${TOOLCHAIN}-")
+
+set(CMAKE_SYSTEM_NAME Generic)
+set(CMAKE_SYSTEM_VERSION 1)
+
+set(CMAKE_ASM_COMPILER_FORCED 1)
+set(CMAKE_C_COMPILER_FORCED 1)
+
+set(CMAKE_ASM_COMPILER_ID GNU)
+set(CMAKE_C_COMPILER_ID GNU)
+
+set(CMAKE_C_COMPILER 	${CROSS_COMPILE}gcc)
+
+# required for checking flags
+set(CMAKE_REQUIRED_FLAGS "-nostdlib")
+
+find_program(CMAKE_LD NAMES "${CROSS_COMPILE}ld" PATHS ENV PATH NO_DEFAULT_PATH)
+find_program(CMAKE_AR NAMES "${CROSS_COMPILE}ar" PATHS ENV PATH NO_DEFAULT_PATH)
+find_program(CMAKE_OBJCOPY NAMES "${CROSS_COMPILE}objcopy" PATHS ENV PATH NO_DEFAULT_PATH)
+find_program(CMAKE_OBJDUMP NAMES "${CROSS_COMPILE}objdump" PATHS ENV PATH NO_DEFAULT_PATH)
+
+set(CMAKE_FIND_ROOT_PATH  ".")
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+
+# Cmocka is written in C99, but for some reason it sets this flag, only on Posix
+# We set up it here, because our system is Generic
+add_definitions("-std=gnu99")

--- a/test/cmocka/src/CMakeLists.txt
+++ b/test/cmocka/src/CMakeLists.txt
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 add_subdirectory(audio)
-add_subdirectory(debugability)
+if(NOT BUILD_UNIT_TESTS_HOST)
+	add_subdirectory(debugability)
+endif()
 add_subdirectory(lib)
 add_subdirectory(list)
 add_subdirectory(math)

--- a/test/cmocka/src/audio/pcm_converter/pcm_float.c
+++ b/test/cmocka/src/audio/pcm_converter/pcm_float.c
@@ -537,7 +537,7 @@ int main(void)
 	cmocka_set_message_output(CM_OUTPUT_TAP);
 
 	/* log number of converting functions for current configuration */
-	print_message("%s start tests, count(pcm_func_map)=%d\n",
+	print_message("%s start tests, count(pcm_func_map)=%zu\n",
 		      __FILE__, pcm_func_count);
 
 	return cmocka_run_group_tests(tests, NULL, NULL);

--- a/test/cmocka/src/audio/pipeline/CMakeLists.txt
+++ b/test/cmocka/src/audio/pipeline/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-if(CONFIG_MULTICORE)
+if(CONFIG_MULTICORE AND NOT BUILD_UNIT_TESTS_HOST)
 	SET(arch_src ${PROJECT_SOURCE_DIR}/src/drivers/intel/cavs/idc.c)
 
 	# make small lib for stripping so we don't have to care

--- a/test/cmocka/src/common_mocks.c
+++ b/test/cmocka/src/common_mocks.c
@@ -115,6 +115,9 @@ void WEAK trace_flush(void)
 {
 }
 
+#if CONFIG_LIBRARY
+volatile void *task_context_get(void);
+#endif
 volatile void * WEAK task_context_get(void)
 {
 	return NULL;
@@ -141,13 +144,18 @@ uint64_t WEAK platform_timer_get(struct timer *timer)
 	return 0;
 }
 
+#if !CONFIG_LIBRARY
 uint64_t WEAK arch_timer_get_system(struct timer *timer)
 {
 	(void)timer;
 
 	return 0;
 }
+#endif
 
+#if CONFIG_LIBRARY
+void WEAK arch_dump_regs_a(void *dump_buf);
+#endif
 void WEAK arch_dump_regs_a(void *dump_buf)
 {
 	(void)dump_buf;
@@ -184,11 +192,11 @@ void WEAK ipc_platform_complete_cmd(void *data)
 {
 }
 
+#if !CONFIG_LIBRARY
 int WEAK ipc_platform_send_msg(struct ipc_msg *msg)
 {
 	return 0;
 }
-
 void WEAK xthal_icache_region_invalidate(void *addr, unsigned size)
 {
 }
@@ -204,6 +212,7 @@ void WEAK xthal_dcache_region_writeback(void *addr, unsigned size)
 void WEAK xthal_dcache_region_writeback_inv(void *addr, unsigned size)
 {
 }
+#endif
 
 struct sof * WEAK sof_get(void)
 {
@@ -290,7 +299,7 @@ uint64_t WEAK clock_ms_to_ticks(int clock, uint64_t ms)
 	return 0;
 }
 
-#if CONFIG_MULTICORE
+#if CONFIG_MULTICORE && !CONFIG_LIBRARY
 
 int WEAK idc_send_msg(struct idc_msg *msg, uint32_t mode)
 {
@@ -305,5 +314,26 @@ int WEAK arch_cpu_is_core_enabled(int id)
 	return 0;
 }
 
+#endif
+
+#if CONFIG_LIBRARY
+/* enable trace by default in testbench */
+int WEAK test_bench_trace = 1;
+int WEAK debug;
+
+/* look up subsystem class name from table */
+char * WEAK get_trace_class(uint32_t trace_class)
+{
+	(void)trace_class;
+	/* todo: trace class is deprecated,
+	 * uuid should be used only
+	 */
+	return "unknown";
+}
+
+uint8_t * WEAK get_library_mailbox(void)
+{
+	return NULL;
+}
 #endif
 

--- a/test/cmocka/src/common_mocks.c
+++ b/test/cmocka/src/common_mocks.c
@@ -337,3 +337,110 @@ uint8_t * WEAK get_library_mailbox(void)
 }
 #endif
 
+/*
+ * GCC xtensa requires us to fake some of the standard C library calls
+ * as this is "bare metal" support (i.e. with no host OS implementation
+ * methods for these calls).
+ *
+ * None of these IO calls are used in the Mocks for testing.
+ */
+#if !CONFIG_LIBRARY && !__XCC__
+void _exit(int status);
+unsigned int _getpid_r(void);
+int _kill_r(int id, int sig);
+void _sbrk_r(int id);
+int _fstat_r(int fd, void *buf);
+int _open_r(const char *pathname, int flags);
+int _write_r(int fd, char *buf, int count);
+int _read_r(int fd, char *buf, int count);
+int _lseek_r(int fd, int count);
+int _close_r(int fd);
+int _isatty(int fd);
+
+void _exit(int status)
+{
+	while (1);
+}
+
+unsigned int _getpid_r(void)
+{
+	return 0;
+}
+
+int _kill_r(int id, int sig)
+{
+	return 0;
+}
+
+void _sbrk_r(int id)
+{
+}
+
+int _fstat_r(int fd, void *buf)
+{
+	return 0;
+}
+
+int _open_r(const char *pathname, int flags)
+{
+	return 0;
+}
+
+int _write_r(int fd, char *buf, int count)
+{
+	return 0;
+}
+
+int _read_r(int fd, char *buf, int count)
+{
+	return 0;
+}
+
+int _lseek_r(int fd, int count)
+{
+	return 0;
+}
+
+int _close_r(int fd)
+{
+	return 0;
+}
+
+int _isatty(int fd)
+{
+	return 0;
+}
+
+/* TODO: work around some linker warnings. Both will need fixed for qemu. */
+int _start = 0;
+int *__errno _PARAMS ((void));
+
+/*
+ * TODO: Math support for GCC xtensa requires a little more work to use the
+ * newlib versions. This is just to build test only today !
+ */
+double __floatsidf(int i);
+double __divdf3(double a, double b);
+int __ledf2(double a, double b);
+int __eqdf2(double a, double b);
+
+double __floatsidf(int i)
+{
+	return i;
+}
+
+double __divdf3(double a, double b)
+{
+	return a / b;
+}
+
+int WEAK __ledf2(double a, double b)
+{
+	return a <= b ? 0 : 1;
+}
+
+int WEAK __eqdf2(double a, double b)
+{
+	return a == b ? 0 : 1;
+}
+#endif

--- a/test/cmocka/src/lib/CMakeLists.txt
+++ b/test/cmocka/src/lib/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-add_subdirectory(alloc)
+if(NOT BUILD_UNIT_TESTS_HOST)
+	add_subdirectory(alloc)
+endif()
 add_subdirectory(lib)
 add_subdirectory(preproc)

--- a/test/cmocka/src/math/CMakeLists.txt
+++ b/test/cmocka/src/math/CMakeLists.txt
@@ -2,4 +2,8 @@
 
 add_subdirectory(numbers)
 add_subdirectory(trig)
-add_subdirectory(fft)
+
+# FFT needs maths is WIP for xtensa GCC
+if(XCC AND NOT BUILD_UNIT_TESTS_HOST)
+	add_subdirectory(fft)
+endif()


### PR DESCRIPTION
This PR allows the tests to be run on the host (i.e. build all mocks as local command line tests) and also to build on xtensa GCC. The xtensa GCC support is build only, as there require more work to run on qemu.