### PR TITLE
topology: adding optional support for IIR component on jsl-rt015 topology

### DIFF
--- a/tools/topology/CMakeLists.txt
+++ b/tools/topology/CMakeLists.txt
@@ -137,6 +137,7 @@ set(TPLGS
 	"sof-imx8mp-wm8960\;sof-imx8mp-wm8960"
 	"sof-smart-amplifier-nocodec\;sof-smart-amplifier-nocodec"
 	"sof-jsl-rt5682\;sof-jsl-rt5682-rt1015\;-DPLATFORM=jsl-rt1015"
+	"sof-jsl-rt5682\;sof-jsl-rt5682-rt1015-xperi\;-DPLATFORM=jsl-rt1015\;-DINCLUDE_IIR_EQ=1"
 	"sof-jsl-rt5682\;sof-jsl-rt5682-mx98360a\;-DPLATFORM=jsl-dedede"
 )
 

--- a/tools/topology/sof-jsl-rt5682.m4
+++ b/tools/topology/sof-jsl-rt5682.m4
@@ -62,12 +62,24 @@ PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
+ifdef(`INCLUDE_IIR_EQ',
+`
 # Low Latency playback pipeline 2 on PCM 1 using max 2 channels of s24le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+PIPELINE_PCM_ADD(sof/pipe-eq-iir-volume-playback.m4,
 	2, 1, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
+'
+,
+`
+# Low Latency playback pipeline 2 on PCM 1 using max 2 channels of s24le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+        2, 1, 2, s32le,
+        1000, 0, 0,
+        48000, 48000, 48000)
+')
 
 # Low Latency capture pipeline 3 on PCM 1 using max 2 channels of s24le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0

--- a/tools/topology/sof-jsl-rt5682.m4
+++ b/tools/topology/sof-jsl-rt5682.m4
@@ -55,7 +55,7 @@ dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,
 dnl     frames, deadline, priority, core)
 
-# Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s24le.
+# Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	1, 0, 2, s32le,
@@ -64,7 +64,7 @@ PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 
 ifdef(`INCLUDE_IIR_EQ',
 `
-# Low Latency playback pipeline 2 on PCM 1 using max 2 channels of s24le.
+# Low Latency playback pipeline 2 on PCM 1 using max 2 channels of s32le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-eq-iir-volume-playback.m4,
 	2, 1, 2, s32le,
@@ -73,15 +73,15 @@ PIPELINE_PCM_ADD(sof/pipe-eq-iir-volume-playback.m4,
 '
 ,
 `
-# Low Latency playback pipeline 2 on PCM 1 using max 2 channels of s24le.
+# Low Latency playback pipeline 2 on PCM 1 using max 2 channels of s32le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
-        2, 1, 2, s32le,
-        1000, 0, 0,
-        48000, 48000, 48000)
+	2, 1, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
 ')
 
-# Low Latency capture pipeline 3 on PCM 1 using max 2 channels of s24le.
+# Low Latency capture pipeline 3 on PCM 1 using max 2 channels of s32le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	3, 1, 2, s32le,


### PR DESCRIPTION
Allows the IIR component to be added to the jsl-rt015 topology allowing tuning

Signed-off-by: Ross Chisholm <ross.chisholm@xperi.com>