### PR TITLE
zephyr: CONFIG_CAVS_TIMER is only required on cAVS platforms

### DIFF
--- a/src/schedule/timer_domain.c
+++ b/src/schedule/timer_domain.c
@@ -30,7 +30,7 @@
  * SOF on Intel CAVS platforms currently only aligns with Zephyr when both
  * use the CAVS 19.2 MHz SSP clock. TODO - needs runtime alignment.
  */
-#if CONFIG_XTENSA && !CONFIG_CAVS_TIMER
+#if CONFIG_XTENSA && CONFIG_CAVS && !CONFIG_CAVS_TIMER
 #error "Zephyr uses 19.2MHz clock derived from SSP which must be enabled."
 #endif
 


### PR DESCRIPTION
Allow building SOF with Zephyr with Xtensa platforms other than cAVS.

BugLink: https://github.com/thesofproject/sof/issues/4046