### PR TITLE
probe: fix compilation error

### DIFF
--- a/src/probe/probe.c
+++ b/src/probe/probe.c
@@ -14,7 +14,7 @@
 #include <sof/lib/dma.h>
 #include <sof/lib/notifier.h>
 #include <sof/lib/uuid.h>
-#include <ipc/topology.h>
+#include <sof/ipc/topology.h>
 #include <sof/ipc/driver.h>
 #include <sof/drivers/timer.h>
 #include <sof/schedule/ll_schedule.h>


### PR DESCRIPTION
Use the right header file to fix the compilation
error when building with probes enabled.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>