### PR TITLE
platform: apollolake: increase runtime heap 256B count

### DIFF
--- a/src/platform/apollolake/include/platform/lib/memory.h
+++ b/src/platform/apollolake/include/platform/lib/memory.h
@@ -261,7 +261,7 @@
 /* Heap section sizes for module pool */
 #define HEAP_RT_COUNT64			128
 #define HEAP_RT_COUNT128		64
-#define HEAP_RT_COUNT256		96
+#define HEAP_RT_COUNT256		128
 #define HEAP_RT_COUNT512		8
 #define HEAP_RT_COUNT1024		4
 #define HEAP_RT_COUNT2048		1


### PR DESCRIPTION
Increase the count of the runtime heap 256 Bytes block on apollolake to
satisfy the buffer requirement of the new implemented dynamic DAI config
feature.

Fixes: 6c2cdffd0239 ("dai: dai_config refinement")
Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>

This should fix issue https://github.com/thesofproject/sof/issues/4069