### PR TITLE
Revert "topology: sof-tgl-nocodec-ci: change to run smart_amp on core 1"

### DIFF
--- a/tools/topology/development/sof-tgl-nocodec-ci.m4
+++ b/tools/topology/development/sof-tgl-nocodec-ci.m4
@@ -100,9 +100,6 @@ define(`SMART_REF_CH_NUM', 4)
 define(`SMART_PCM_ID', 2)
 define(`SMART_PCM_NAME', `smart-nocodec')
 
-# run smart amp pipelines on DSP core 1
-define(`SMART_AMP_CORE', 1)
-
 # Include Smart Amplifier support
 include(`sof-smart-amplifier.m4')
 


### PR DESCRIPTION
This reverts commit cd2444adbf8821d33e098b071b40dab2931d6a8e.

Reverting this to unblock the CI runningon tgl-nocodec-ci platform, multi-core support
is not ready yet in the Linux side.

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>