### PR TITLE
zephyr: fix build: add a missing IPC file

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -369,6 +369,7 @@ zephyr_library_sources(
 	${SOF_IPC_PATH}/dma-copy.c
 	${SOF_IPC_PATH}/ipc-common.c
 	${SOF_IPC_PATH}/handler-ipc3.c
+	${SOF_IPC_PATH}/helper-ipc3.c
 	${SOF_IPC_PATH}/ipc-host-ptable.c
 	${SOF_SRC_PATH}/spinlock.c
 


### PR DESCRIPTION
Commit b3f195e92a71 ("zephyr: fix build with recent file name changes.") partially fixed a regression, caused by 4e436f8570be ("ipc: split out ipc functions into separate files.") partially. This patch completes the fix.
