### PR TITLE
topology: tgl-nocodec-ci: add multicore support

### DIFF
--- a/tools/topology/development/CMakeLists.txt
+++ b/tools/topology/development/CMakeLists.txt
@@ -14,6 +14,7 @@ set(TPLGS
 	"sof-cml-src-rt5682\;sof-cml-src-rt5682"
 	"sof-hda-asrc\;sof-hda-asrc-2ch\;-DCHANNELS=2"
 	"sof-tgl-nocodec-ci\;sof-tgl-nocodec-ci"
+	"sof-tgl-nocodec-ci\;sof-tgl-nocodec-ci-multicore\;-DSMART_AMP_CORE=1"
 	"sof-cml-rt1011-rt5682-nokwd\;sof-cml-rt1011-rt5682-nokwd\;-DCHANNELS=2\;-DDMICPROC_FILTER1=eq_iir_coef_highpass_40hz_20db_48khz.m4\;-DDMIC16KPROC_FILTER1=eq_iir_coef_highpass_40hz_20db_16khz.m4"
 	"sof-cml-rt1011-rt5682-nokwd\;sof-cml-rt1011-rt5682-eq\;-DCHANNELS=2\;-DDMICPROC_FILTER1=eq_iir_coef_highpass_40hz_20db_48khz.m4\;-DDMIC16KPROC_FILTER1=eq_iir_coef_highpass_40hz_20db_16khz.m4\;-DHSEARPROC=eq-iir-eq-fir-volume\;-DHSMICPROC=eq-fir-volume\;-DSPKPROC=eq-iir-eq-fir-volume"
 	"sof-imx8mp-src-wm8960\;sof-imx8mp-src-wm8960"


### PR DESCRIPTION
Generate sof-tgl-nocodec-ci-multicore.tplg for multicore validation
coverage.

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>