### PR TITLE
scheduler: guard against subdivision underflow on domain clear

### DIFF
--- a/src/schedule/ll_schedule.c
+++ b/src/schedule/ll_schedule.c
@@ -331,9 +331,11 @@ static void schedule_ll_domain_clear(struct ll_schedule_data *sch,
 	if (count == 1) {
 		sch->domain->registered[cpu_get_id()] = false;
 
-		count = atomic_sub(&sch->domain->num_clients, 1);
-		if (count == 1)
-			domain_clear(sch->domain);
+		if (atomic_read(&sch->domain->num_clients)) {
+			count = atomic_sub(&sch->domain->num_clients, 1);
+			if (count == 1)
+				domain_clear(sch->domain);
+		}
 	}
 
 	tr_info(&ll_tr, "num_tasks %d total_num_tasks %d",


### PR DESCRIPTION
In some situations the domain clear routine might encounter
a case, when the number of clients is decremented and 0,
as such, a subsequent subdivision will result in an integer underflow.

Signed-off-by: Slawomir Blauciak <slawomir.blauciak@linux.intel.com>

Fixes #3950 
Fixes #3949 
Fixes #3947 