### PR TITLE
LL scheduler domain refinement

### DIFF
--- a/src/drivers/intel/cavs/timer.c
+++ b/src/drivers/intel/cavs/timer.c
@@ -165,9 +165,6 @@ static int platform_timer_register(struct timer *timer,
 	/* enable timer interrupt */
 	interrupt_enable(timer->logical_irq, arg);
 
-	/* disable timer interrupt on core level */
-	timer_disable(timer, arg, cpu_get_id());
-
 	return err;
 }
 

--- a/src/include/sof/schedule/ll_schedule_domain.h
+++ b/src/include/sof/schedule/ll_schedule_domain.h
@@ -46,6 +46,7 @@ struct ll_schedule_domain {
 	spinlock_t lock;		/**< standard lock */
 	atomic_t total_num_tasks;	/**< total number of registered tasks */
 	atomic_t registered_cores;	/**< number of registered cores */
+	atomic_t enabled_cores;		/**< number of enabled cores */
 	uint32_t ticks_per_ms;		/**< number of clock ticks per ms */
 	int type;			/**< domain type */
 	int clk;			/**< source clock */
@@ -90,6 +91,7 @@ static inline struct ll_schedule_domain *domain_init
 	spinlock_init(&domain->lock);
 	atomic_init(&domain->total_num_tasks, 0);
 	atomic_init(&domain->registered_cores, 0);
+	atomic_init(&domain->enabled_cores, 0);
 
 	return domain;
 }

--- a/src/include/sof/schedule/ll_schedule_domain.h
+++ b/src/include/sof/schedule/ll_schedule_domain.h
@@ -31,8 +31,8 @@ struct ll_schedule_domain_ops {
 	int (*domain_register)(struct ll_schedule_domain *domain,
 			       uint64_t period, struct task *task,
 			       void (*handler)(void *arg), void *arg);
-	void (*domain_unregister)(struct ll_schedule_domain *domain,
-				  struct task *task, uint32_t num_tasks);
+	int (*domain_unregister)(struct ll_schedule_domain *domain,
+				 struct task *task, uint32_t num_tasks);
 	void (*domain_enable)(struct ll_schedule_domain *domain, int core);
 	void (*domain_disable)(struct ll_schedule_domain *domain, int core);
 	void (*domain_set)(struct ll_schedule_domain *domain, uint64_t start);

--- a/src/include/sof/schedule/ll_schedule_domain.h
+++ b/src/include/sof/schedule/ll_schedule_domain.h
@@ -45,7 +45,7 @@ struct ll_schedule_domain {
 	uint64_t next_tick;		/**< ticks just set for next run */
 	spinlock_t lock;		/**< standard lock */
 	atomic_t total_num_tasks;	/**< total number of registered tasks */
-	atomic_t num_clients;		/**< number of registered cores */
+	atomic_t registered_cores;	/**< number of registered cores */
 	uint32_t ticks_per_ms;		/**< number of clock ticks per ms */
 	int type;			/**< domain type */
 	int clk;			/**< source clock */
@@ -89,7 +89,7 @@ static inline struct ll_schedule_domain *domain_init
 
 	spinlock_init(&domain->lock);
 	atomic_init(&domain->total_num_tasks, 0);
-	atomic_init(&domain->num_clients, 0);
+	atomic_init(&domain->registered_cores, 0);
 
 	return domain;
 }

--- a/src/include/sof/schedule/ll_schedule_domain.h
+++ b/src/include/sof/schedule/ll_schedule_domain.h
@@ -43,6 +43,7 @@ struct ll_schedule_domain_ops {
 
 struct ll_schedule_domain {
 	uint64_t next_tick;		/**< ticks just set for next run */
+	uint64_t new_target_tick;	/**< for the next set, used during the reschedule stage */
 	spinlock_t lock;		/**< standard lock */
 	atomic_t total_num_tasks;	/**< total number of registered tasks */
 	atomic_t registered_cores;	/**< number of registered cores */
@@ -87,6 +88,7 @@ static inline struct ll_schedule_domain *domain_init
 	domain->ops = ops;
 	/* maximum value means no tick has been set to timer */
 	domain->next_tick = UINT64_MAX;
+	domain->new_target_tick = UINT64_MAX;
 
 	spinlock_init(&domain->lock);
 	atomic_init(&domain->total_num_tasks, 0);

--- a/src/include/sof/schedule/schedule.h
+++ b/src/include/sof/schedule/schedule.h
@@ -10,6 +10,7 @@
 #define __SOF_SCHEDULE_SCHEDULE_H__
 
 #include <sof/common.h>
+#include <sof/lib/cpu.h>
 #include <sof/list.h>
 #include <sof/schedule/task.h>
 #include <sof/trace/trace.h>
@@ -122,6 +123,7 @@ struct scheduler_ops {
 struct schedule_data {
 	struct list_item list;			/**< list of schedulers */
 	int type;				/**< SOF_SCHEDULE_ type */
+	uint32_t core;				/**< the index of the core the scheduler run on */
 	const struct scheduler_ops *ops;	/**< scheduler operations */
 	void *data;				/**< pointer to private data */
 };
@@ -210,7 +212,8 @@ static inline int schedule_task(struct task *task, uint64_t start,
 
 	list_for_item(slist, &schedulers->list) {
 		sch = container_of(slist, struct schedule_data, list);
-		if (task->type == sch->type && sch->ops->schedule_task)
+		if (task->type == sch->type && sch->core == cpu_get_id() &&
+		    sch->ops->schedule_task)
 			return sch->ops->schedule_task(sch->data, task, start,
 						       period);
 	}
@@ -249,7 +252,8 @@ static inline int schedule_task_cancel(struct task *task)
 
 	list_for_item(slist, &schedulers->list) {
 		sch = container_of(slist, struct schedule_data, list);
-		if (task->type == sch->type && sch->ops->schedule_task_cancel)
+		if (task->type == sch->type && sch->core == cpu_get_id() &&
+		    sch->ops->schedule_task_cancel)
 			return sch->ops->schedule_task_cancel(sch->data, task);
 	}
 

--- a/src/schedule/schedule.c
+++ b/src/schedule/schedule.c
@@ -7,6 +7,7 @@
 /* Generic scheduler */
 
 #include <sof/lib/alloc.h>
+#include <sof/lib/cpu.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
 #include <sof/schedule/schedule.h>
@@ -66,6 +67,7 @@ void scheduler_init(int type, const struct scheduler_ops *ops, void *data)
 	sch->type = type;
 	sch->ops = ops;
 	sch->data = data;
+	sch->core = cpu_get_id();
 
 	scheduler_register(sch);
 }

--- a/src/schedule/timer_domain.c
+++ b/src/schedule/timer_domain.c
@@ -194,8 +194,8 @@ out:
 	return ret;
 }
 
-static void timer_domain_unregister(struct ll_schedule_domain *domain,
-				    struct task *task, uint32_t num_tasks)
+static int timer_domain_unregister(struct ll_schedule_domain *domain,
+				   struct task *task, uint32_t num_tasks)
 {
 	struct timer_domain *timer_domain = ll_sch_domain_get_pdata(domain);
 	int core = cpu_get_id();
@@ -204,7 +204,7 @@ static void timer_domain_unregister(struct ll_schedule_domain *domain,
 
 	/* tasks still registered on this core */
 	if (!timer_domain->arg[core] || num_tasks)
-		return;
+		return 0;
 
 	tr_info(&ll_tr, "timer_domain_unregister domain->type %d domain->clk %d",
 		domain->type, domain->clk);
@@ -212,6 +212,8 @@ static void timer_domain_unregister(struct ll_schedule_domain *domain,
 	timer_unregister(timer_domain->timer, timer_domain->arg[core]);
 #endif
 	timer_domain->arg[core] = NULL;
+
+	return 0;
 }
 
 static void timer_domain_enable(struct ll_schedule_domain *domain, int core)


### PR DESCRIPTION
clean up of the ll_scheduler domain clients/tasks management.

    ll_schedule: domain client/task refinement
    
    Refinement to make the domain client/task management more clear:
    
    a. update the total_num_tasks and num_clients in the helper pair
    domain_register/unregister().
    
    b. update the enabled[core] and enabled_clients in the helper pair
    domain_enable/disable().
    
    c. for the completed task, do the domain client/task update in the new
    created helper schedule_ll_task_done().
    
    d. cleanup and remove the client/task management from the ll_schedule
    helpers schedule_ll_clients_enable(), schedule_ll_tasks_run(),
    schedule_ll_domain_set() and schedule_ll_domain_clear().
    
    Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>

    This is aim to fix #3947 #3949 #3950.

    Without those refinement, the num_clients was not used correctly, we wanted to use it for both num_registered_cores and 
    num_enabled_cores, with that @slawblauciak observed it may be changed to '-1' when component/pipeline is asked for 
    running on a slave core. That's why we are seeing issues #3947 #3949 #3950.

    This reverts changes in 'commit b500999477ca ("scheduler: guard against
    subdivision underflow on domain clear")' as it is not needed anymore.
