### PR TITLE
imx8m: remove SDMA2

### DIFF
--- a/src/platform/imx8m/include/platform/lib/dma.h
+++ b/src/platform/imx8m/include/platform/lib/dma.h
@@ -10,7 +10,7 @@
 #ifndef __PLATFORM_LIB_DMA_H__
 #define __PLATFORM_LIB_DMA_H__
 
-#define PLATFORM_NUM_DMACS	3
+#define PLATFORM_NUM_DMACS	2
 
 /* max number of supported DMA channels */
 #define PLATFORM_MAX_DMA_CHAN	32

--- a/src/platform/imx8m/lib/dma.c
+++ b/src/platform/imx8m/lib/dma.c
@@ -26,21 +26,6 @@ SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
 },
 {
 	.plat_data = {
-		.id		= DMA_ID_SDMA2,
-		/* Note: support is available for MEM_TO_MEM but not
-		 * enabled as it is unneeded
-		 */
-		.dir		= DMA_DIR_MEM_TO_DEV | DMA_DIR_DEV_TO_MEM,
-		.devs		= DMA_DEV_SAI,
-		.base		= SDMA2_BASE,
-		.channels	= 32,
-		.irq		= SDMA2_IRQ,
-		.irq_name	= SDMA2_IRQ_NAME,
-	},
-	.ops	= &sdma_ops,
-},
-{
-	.plat_data = {
 		.id		= DMA_ID_SDMA3,
 		/* Note: support is available for MEM_TO_MEM but not
 		 * enabled as it is unneeded


### PR DESCRIPTION
With SDMA2 in place now it is shared by both A and HiFi cores
- this breaks 8MP EVK + WM8960 topology. Remove SDMA2 so that
SDMA2 remains assigned to A core and SDMA3 assigned to HiFi core
as it was initially planned.

Suggested-by: Paul Olaru <paul.olaru@nxp.com>
Signed-off-by: Viorel Suman <viorel.suman@nxp.com>