### PR TITLE
codec_adapter: allow apply config earlier + state machine rework 

### DIFF
--- a/src/audio/codec_adapter/codec/cadence.c
+++ b/src/audio/codec_adapter/codec/cadence.c
@@ -386,6 +386,7 @@ int cadence_codec_prepare(struct comp_dev *dev)
 	if (codec->state == CODEC_PREPARED)
 		goto done;
 
+	/* Setup config */
 	if (!codec->s_cfg.avail && !codec->s_cfg.size) {
 		comp_err(dev, "cadence_codec_prepare() no setup configuration available!");
 		ret = -EIO;
@@ -404,6 +405,16 @@ int cadence_codec_prepare(struct comp_dev *dev)
 	 * later on in case there is no new one upon reset.
 	 */
 	codec->s_cfg.avail = false;
+
+	/* Runtime config */
+	if (codec->r_cfg.avail) {
+		ret = apply_config(dev, CODEC_CFG_RUNTIME);
+		if (ret) {
+			comp_err(dev, "cadence_codec_prepare() error %x: failed to applay runtime config",
+				 ret);
+			goto err;
+		}
+	}
 
 	/* Allocate memory for the codec */
 	API_CALL(cd, XA_API_CMD_GET_MEMTABS_SIZE, 0, &mem_tabs_size, ret);

--- a/src/audio/codec_adapter/codec/cadence.c
+++ b/src/audio/codec_adapter/codec/cadence.c
@@ -383,9 +383,6 @@ int cadence_codec_prepare(struct comp_dev *dev)
 
 	comp_dbg(dev, "cadence_codec_prepare() start");
 
-	if (codec->state == CODEC_PREPARED)
-		goto done;
-
 	/* Setup config */
 	if (!codec->s_cfg.avail && !codec->s_cfg.size) {
 		comp_err(dev, "cadence_codec_prepare() no setup configuration available!");
@@ -453,7 +450,6 @@ int cadence_codec_prepare(struct comp_dev *dev)
 free:
 	codec_free_memory(dev, cd->mem_tabs);
 err:
-done:
 	return ret;
 }
 

--- a/src/audio/codec_adapter/codec/cadence.c
+++ b/src/audio/codec_adapter/codec/cadence.c
@@ -143,6 +143,14 @@ int cadence_codec_init(struct comp_dev *dev)
 		comp_dbg(dev, "cadence_codec_init(): allocated %d bytes for lib object",
 			 obj_size);
 	}
+	/* Set all params to their default values */
+	API_CALL(cd, XA_API_CMD_INIT, XA_CMD_TYPE_INIT_API_PRE_CONFIG_PARAMS,
+		 NULL, ret);
+	if (ret != LIB_NO_ERROR) {
+		comp_err(dev, "cadence_codec_init(): error %x: failed to set default config",
+			 ret);
+		goto out;
+	}
 
 	comp_dbg(dev, "cadence_codec_init() done");
 out:
@@ -377,14 +385,6 @@ int cadence_codec_prepare(struct comp_dev *dev)
 
 	if (codec->state == CODEC_PREPARED)
 		goto done;
-
-	API_CALL(cd, XA_API_CMD_INIT, XA_CMD_TYPE_INIT_API_PRE_CONFIG_PARAMS,
-		 NULL, ret);
-	if (ret != LIB_NO_ERROR) {
-		comp_err(dev, "cadence_codec_prepare(): error %x: failed to set default config",
-			 ret);
-		goto err;
-	}
 
 	if (!codec->s_cfg.avail && !codec->s_cfg.size) {
 		comp_err(dev, "cadence_codec_prepare() no setup configuration available!");

--- a/src/audio/codec_adapter/codec/generic.c
+++ b/src/audio/codec_adapter/codec/generic.c
@@ -204,7 +204,7 @@ int codec_prepare(struct comp_dev *dev)
 
 	comp_dbg(dev, "codec_prepare() start");
 
-	if (cd->codec.state == CODEC_PREPARED)
+	if (cd->codec.state == CODEC_IDLE)
 		return 0;
 	if (cd->codec.state < CODEC_INITIALIZED)
 		return -EPERM;
@@ -227,7 +227,7 @@ int codec_prepare(struct comp_dev *dev)
 	codec->r_cfg.avail = false;
 	codec->r_cfg.data = NULL;
 
-	codec->state = CODEC_PREPARED;
+	codec->state = CODEC_IDLE;
 	comp_dbg(dev, "codec_prepare() done");
 end:
 	return ret;
@@ -261,7 +261,7 @@ int codec_process(struct comp_dev *dev)
 
 	comp_dbg(dev, "codec_process() start");
 
-	if (cd->codec.state < CODEC_PREPARED) {
+	if (cd->codec.state != CODEC_IDLE) {
 		comp_err(dev, "codec_prepare(): wrong state of codec %x, state %d",
 			 cd->ca_config.codec_id, codec->state);
 		return -EPERM;
@@ -276,6 +276,7 @@ int codec_process(struct comp_dev *dev)
 
 	comp_dbg(dev, "codec_process() done");
 out:
+	codec->state = CODEC_IDLE;
 	return ret;
 }
 

--- a/src/audio/codec_adapter/codec/generic.c
+++ b/src/audio/codec_adapter/codec/generic.c
@@ -301,12 +301,6 @@ int codec_apply_runtime_config(struct comp_dev *dev)
 
 	comp_dbg(dev, "codec_apply_config() start");
 
-	if (cd->codec.state < CODEC_PREPARED) {
-		comp_err(dev, "codec_prepare() wrong state of codec %x, state %d",
-			 cd->ca_config.codec_id, codec->state);
-		return -EPERM;
-	}
-
 	ret = codec->ops->apply_config(dev);
 	if (ret) {
 		comp_err(dev, "codec_apply_config() error %d: codec process failed for codec_id %x",

--- a/src/audio/codec_adapter/codec_adapter.c
+++ b/src/audio/codec_adapter/codec_adapter.c
@@ -570,7 +570,7 @@ static int codec_adapter_set_params(struct comp_dev *dev, struct sof_ipc_ctrl_da
 				comp_dbg(dev, "codec_adapter_set_params() load of runtime config done.");
 			}
 
-			if (cd->state >= PP_STATE_PREPARED) {
+			if (cd->state >= PP_STATE_CREATED) {
 				/* We are already prepared so we can apply runtime
 				 * config right away.
 				 */

--- a/src/audio/codec_adapter/codec_adapter.c
+++ b/src/audio/codec_adapter/codec_adapter.c
@@ -86,7 +86,6 @@ struct comp_dev *codec_adapter_new(const struct comp_driver *drv,
 	}
 
 	dev->state = COMP_STATE_READY;
-	cd->state = PP_STATE_CREATED;
 
 	comp_dbg(dev, "codec_adapter_new() done");
 	return dev;
@@ -264,7 +263,6 @@ int codec_adapter_prepare(struct comp_dev *dev)
 			  BUFFER_UPDATE_FORCE);
 	buffer_reset_pos(cd->local_buff, NULL);
 
-	cd->state = PP_STATE_PREPARED;
 	comp_dbg(dev, "codec_adapter_prepare() done");
 
 	return 0;
@@ -570,7 +568,7 @@ static int codec_adapter_set_params(struct comp_dev *dev, struct sof_ipc_ctrl_da
 				comp_dbg(dev, "codec_adapter_set_params() load of runtime config done.");
 			}
 
-			if (cd->state >= PP_STATE_CREATED) {
+			if (codec->state >= CODEC_INITIALIZED) {
 				/* We are already prepared so we can apply runtime
 				 * config right away.
 				 */
@@ -630,7 +628,7 @@ static int codec_adapter_ctrl_set_data(struct comp_dev *dev,
 	struct comp_data *cd = comp_get_drvdata(dev);
 
 	comp_dbg(dev, "codec_adapter_ctrl_set_data() start, state %d, cmd %d",
-		 cd->state, cdata->cmd);
+		 cd->codec.state, cdata->cmd);
 
 	/* Check version from ABI header */
 	if (SOF_ABI_VERSION_INCOMPATIBLE(SOF_ABI_VERSION, cdata->data->abi)) {
@@ -702,7 +700,6 @@ int codec_adapter_reset(struct comp_dev *dev)
 			 ret);
 	}
 	buffer_zero(cd->local_buff);
-	cd->state = PP_STATE_CREATED;
 
 	comp_dbg(dev, "codec_adapter_reset(): done");
 

--- a/src/include/sof/audio/codec_adapter/codec/generic.h
+++ b/src/include/sof/audio/codec_adapter/codec/generic.h
@@ -135,25 +135,14 @@ enum codec_cfg_type {
 };
 
 /**
- * \enum ca_state
- * \brief States of codec_adapter
- */
-enum ca_state {
-	PP_STATE_DISABLED = 0, /**< Codec adapter isn't initialized yet or has just been freed. */
-	PP_STATE_CREATED, /**< Codec adapter created or reset.*/
-	PP_STATE_PREPARED, /**< Codec adapter prepared. */
-	PP_STATE_RUN, /**< Codec adapter is running now. */
-};
-
-/**
  * \enum codec_state
  * \brief Codec specific states
  */
 enum codec_state {
 	CODEC_DISABLED, /**< Codec isn't initialized yet or has been freed.*/
 	CODEC_INITIALIZED, /**< Codec initialized or reset. */
-	CODEC_PREPARED, /**< Codec prepared. */
-	CODEC_RUNNING, /**< Codec is running now. */
+	CODEC_IDLE, /**< Codec is idle now. */
+	CODEC_PROCESSING, /**< Codec is processing samples now. */
 };
 
 /** codec adapter setup config parameters */
@@ -232,7 +221,6 @@ struct codec_data {
 
 /* codec_adapter private, runtime data */
 struct comp_data {
-	enum ca_state state; /**< current state of codec_adapter */
 	struct ca_config ca_config;
 	struct codec_data codec; /**< codec private data */
 	struct comp_buffer *ca_sink;


### PR DESCRIPTION
This patchset includes:
- state machine rework (simplify + add additional states IDLE + PROCESSING + RESETTING)
- improve resetting procedure (don't reset codec right away while in PROCESSING state)
- allow runtime config to be applied earlier

Signed-off-by: Marcin Rajwa <marcin.rajwa@linux.intel.com>