### PR TITLE
pipeline: set scheduling comp during complete

### DIFF
--- a/src/audio/pipeline/pipeline-graph.c
+++ b/src/audio/pipeline/pipeline-graph.c
@@ -103,8 +103,7 @@ void pipeline_posn_init(struct sof *sof)
 }
 
 /* create new pipeline - returns pipeline id or negative error */
-struct pipeline *pipeline_new(struct comp_dev *cd, uint32_t pipeline_id,
-			      uint32_t priority, uint32_t comp_id)
+struct pipeline *pipeline_new(uint32_t pipeline_id, uint32_t priority, uint32_t comp_id)
 {
 	struct sof_ipc_stream_posn posn;
 	struct pipeline *p;
@@ -121,7 +120,6 @@ struct pipeline *pipeline_new(struct comp_dev *cd, uint32_t pipeline_id,
 	}
 
 	/* init pipeline */
-	p->sched_comp = cd;
 	p->comp_id = comp_id;
 	p->priority = priority;
 	p->pipeline_id = pipeline_id;

--- a/src/include/sof/audio/pipeline.h
+++ b/src/include/sof/audio/pipeline.h
@@ -110,14 +110,12 @@ struct pipeline_data {
 
 /**
  * \brief Creates a new pipeline.
- * \param[in,out] cd Pipeline component device.
  * \param[in] pipeline_id Pipeline ID number.
  * \param[in] priority Pipeline scheduling priority.
  * \param[in] comp_id Pipeline component ID number.
  * \return New pipeline pointer or NULL.
  */
-struct pipeline *pipeline_new(struct comp_dev *cd, uint32_t pipeline_id,
-			      uint32_t priority, uint32_t comp_id);
+struct pipeline *pipeline_new(uint32_t pipeline_id, uint32_t priority, uint32_t comp_id);
 
 /**
  * \brief Free's a pipeline.

--- a/test/cmocka/src/audio/pipeline/pipeline_new.c
+++ b/test/cmocka/src/audio/pipeline/pipeline_new.c
@@ -44,8 +44,7 @@ static void test_audio_pipeline_pipeline_new_creation(void **state)
 	struct pipeline_new_setup_data *test_data = *state;
 
 	/*Testing component*/
-	struct pipeline *result = pipeline_new(test_data->comp_data,
-					       test_data->pipe_id,
+	struct pipeline *result = pipeline_new(test_data->pipe_id,
 					       test_data->priority,
 					       test_data->comp_id);
 


### PR DESCRIPTION
Move the code that sets the scheduling comp for
a pipeline to ipc_pipeline_complete(). This removes the
restriction that the scheduling comp must be set up
before the pipeline widget and provides the
flexibility in the kernel to set up the widgets
in any order while parsing topology.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>