### PR TITLE
[SKIP CI] .github: add zephyr build

### DIFF
--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -1,0 +1,24 @@
+---
+
+name: Zephyr
+
+# 'workflow_dispatch' allows running this workflow manually from the
+# 'Actions' tab
+# yamllint disable-line rule:truthy
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  zephyr-build:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        # From time to time this will catch a git tag and change SOF_VERSION
+        with: {fetch-depth: 10, submodules: recursive}
+
+      - name: yamllint ourselves
+        run: yamllint .github/workflows/zephyr.yml
+
+      - name: build
+        run: docker run -v "$(pwd)":/workdir
+             docker.io/zephyrprojectrtos/zephyr-build:latest
+             ./zephyr/docker-build.sh

--- a/scripts/xtensa-build-zephyr.sh
+++ b/scripts/xtensa-build-zephyr.sh
@@ -17,7 +17,8 @@ die()
 	>&2 printf '%s ERROR: ' "$0"
 	# We want die() to be usable exactly like printf
 	# shellcheck disable=SC2059
-	>&2 printf "$@\n"
+	>&2 printf "$@"
+	>&2 printf '\n'
 	exit 1
 }
 

--- a/scripts/xtensa-build-zephyr.sh
+++ b/scripts/xtensa-build-zephyr.sh
@@ -5,9 +5,11 @@
 # stop on most errors
 set -e
 
+SOF_TOP=$(cd "$(dirname "$0")" && cd .. && pwd)
+
 SUPPORTED_PLATFORMS=(apl cnl icl tgl-h)
-# By default use "zephyr" in the current directory
-ZEPHYR_ROOT=zephyr
+# Default value, can be overridden on the command line
+WEST_TOP="${SOF_TOP}"/zephyrproject
 BUILD_JOBS=$(nproc --all)
 RIMAGE_KEY=modules/audio/sof/keys/otc_private_key.pem
 PLATFORMS=()
@@ -31,41 +33,43 @@ platform's _defconfig file.
 usage: $0 [options] platform(s)
 
        -a Build all platforms.
-       -c Clone the complete Zephyr and SOF trees before building.
        -j n Set number of make build jobs. Jobs=#cores by default.
            Infinite when not specified.
        -k Path to a non-default rimage signing key.
-       -p Zephyr root directory.
+       -c recursively clones Zephyr inside sof before building.
+          Incompatible with -p.
+       -p Existing Zephyr project directory. Incompatible with -c.
+          If modules/audio/sof is missing there then a symbolic
+          link pointing to ${SOF_TOP} will be added.
 
 Supported platforms ${SUPPORTED_PLATFORMS[*]}
 
 EOF
 }
 
+# Downloads zephyrproject inside sof/ and create a ../../.. symbolic
+# link back to sof/
 clone()
 {
-	# Check out Zephyr + SOF
-
 	type -p west || die "Install west and a west toolchain following https://docs.zephyrproject.org/latest/getting_started/index.html"
 	type -p git || die "Install git"
 
-	[ -e "$ZEPHYR_ROOT" ] && die "$ZEPHYR_ROOT already exists"
-	mkdir -p "$ZEPHYR_ROOT"
-	cd "$ZEPHYR_ROOT"
-	west init
-	west update
-	cd modules/audio/sof
-	git remote add sof https://github.com/thesofproject/sof.git
-	git remote update sof
-	git checkout sof/main
-	git clone --recurse-submodules https://github.com/thesofproject/rimage.git
-	cd -
+	[ -e "$WEST_TOP" ] && die "$WEST_TOP already exists"
+	mkdir -p "$WEST_TOP"
+	git clone --depth=5 https://github.com/zephyrproject-rtos/zephyr \
+	    "$WEST_TOP"/zephyr
+	west init -l "${WEST_TOP}"/zephyr
+	( cd "${WEST_TOP}"
+	  mkdir -p modules/audio
+	  ln -s ../../.. modules/audio/sof
+	  # Do NOT "west update sof"!!
+	  west update zephyr hal_xtensa
+	)
 }
 
 build()
 {
-	[ -d "$ZEPHYR_ROOT" ] || die "$ZEPHYR_ROOT doesn't exists"
-	cd "$ZEPHYR_ROOT"
+	cd "$WEST_TOP"
 
 	# Build rimage
 	RIMAGE_DIR=build-rimage
@@ -107,6 +111,8 @@ build()
 
 main()
 {
+	local zeproj
+
 	# parse the args
 	while getopts "acj:k:p:" OPTION; do
 		case "$OPTION" in
@@ -114,11 +120,27 @@ main()
 			c) DO_CLONE=yes ;;
 			j) BUILD_JOBS="$OPTARG" ;;
 			k) RIMAGE_KEY="$OPTARG" ;;
-			p) ZEPHYR_ROOT="$OPTARG" ;;
+			p) zeproj="$OPTARG" ;;
 			*) print_usage; exit 1 ;;
 		esac
 	done
 	shift $((OPTIND-1))
+
+	if [ -n "$zeproj" ] && [ x"$DO_CLONE" = xyes ]; then
+	    die 'Cannot use -p with -c, -c supports %s only' "${WEST_TOP}"
+	fi
+
+	if [ -n "$zeproj" ]; then
+
+	    [ -d "$zeproj" ] ||
+		die "$zeproj is not a directory, try -c instead of -p?"
+
+	    ( cd "$zeproj"
+	      test "$(realpath "$(west topdir)")" = "$(/bin/pwd)"
+	    ) || die '%s is not a zephyrproject' "$WEST_TOP"
+
+	    WEST_TOP="$zeproj"
+	fi
 
 	# parse platform args
 	for arg in "$@"; do
@@ -148,6 +170,17 @@ main()
 
 	if [ "x$DO_CLONE" == "xyes" ]; then
 		clone
+	else
+		# Link to ourselves if no sof module yet
+		test -e "${WEST_TOP}"/modules/audio/sof ||
+		    ln -s "$SOF_TOP" "${WEST_TOP}"/modules/audio/sof
+
+		# Support for submodules in west is too recent, cannot
+		# rely on it
+		test -d "${WEST_TOP}"/modules/audio/sof/rimage/CMakeLists.txt || (
+		    cd "${WEST_TOP}"/modules/audio/sof
+		    git submodule update --init --recursive
+		)
 	fi
 
 	build

--- a/zephyr/docker-build.sh
+++ b/zephyr/docker-build.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2021 Intel Corporation. All rights reserved.
+
+# "All problems can be solved by another level of indirection"
+# Ideally, this script would not be needed.
+
+set -e
+set -x
+
+# export http_proxy=...
+# export https_proxy=...
+
+unset ZEPHYR_BASE
+
+sudo --preserve-env=http_proxy,https_proxy apt-get update
+sudo --preserve-env=http_proxy,https_proxy apt-get -y install libssl-dev
+
+# Make sure we're in the right place; chgrp -R below.
+test -e ./scripts/xtensa-build-zephyr.sh
+
+if test -e zephyrproject; then
+    ./scripts/xtensa-build-zephyr.sh -a
+else
+    # Matches docker.io/zephyrprojectrtos/zephyr-build:latest gid
+    ls -ln | head
+    stat .
+    sudo chgrp -R 1000 .
+    sudo chmod -R g+rwX .
+    ./scripts/xtensa-build-zephyr.sh -a -c
+fi


### PR DESCRIPTION
3 commits, see messages, especially: `xtensa-build-zephyr: do not clone a second version of sof.git`

Related rimage.h background info: https://github.com/zephyrproject-rtos/sof/pull/7#issuecomment-814539846