### PR TITLE
installer: Fix installer test

### DIFF
--- a/installer/GNUmakefile
+++ b/installer/GNUmakefile
@@ -246,7 +246,7 @@ checktree:
 	diff -u tests/staging_sof_ref.txt ${BUILDS_ROOT}/staging_sof_tree.txt
 	# Check two random topologies are there
 	test -f ${STAGING_SOF_TPLG}/sof-apl-nocodec.tplg
-	test -f ${STAGING_SOF_TPLG}/sof-imx8qxp-nocodec.tplg
+	test -f ${STAGING_SOF_TPLG}/sof-imx8-wm8960.tplg
 
 # Useful for testing this Makefile. COMPARE_REFS can be /lib/firmware,
 # sof-bin, a previous version of this Makefile,...


### PR DESCRIPTION
After commit 5ca0e9bba3e6d ("topology: Use generic name for 8qxp/8qm")
installer test is broken as we also need to update the check tree
topologies to the new naming.

So, fix this by replacing imx8qxp naming with imx8. But while we are at
it choose a better random topology, sof-imx8-wm8960.tplg instead of
sof-imx8-nodec.tplg

Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>