### PR TITLE
ipc4: add basic module init support

### DIFF
--- a/src/include/ipc4/error_status.h
+++ b/src/include/ipc4/error_status.h
@@ -1,0 +1,158 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2021 Intel Corporation. All rights reserved.
+ */
+
+/*
+ * This file contains structures that are exact copies of an existing ABI used
+ * by IOT middleware. They are Intel specific and will be used by one middleware.
+ *
+ * Some of the structures may contain programming implementations that makes them
+ * unsuitable for generic use and general usage.
+ */
+
+/**
+ * \file include/ipc4/error_status.h
+ * \brief IPC4 global definitions.
+ * NOTE: This ABI uses bit fields and is non portable.
+ */
+
+#ifndef __SOF_IPC4_ERROR_STATUS_H__
+#define __SOF_IPC4_ERROR_STATUS_H__
+
+enum ipc4_status {
+	//! The operation was successful.
+	IPC4_SUCCESS = 0,
+
+	//! Invalid parameter specified.
+	IPC4_ERROR_INVALID_PARAM = 1,
+	//! Unknown message type specified.
+	IPC4_UNKNOWN_MESSAGE_TYPE = 2,
+	//! Not enough space in the IPC reply buffer to complete the request.
+	IPC4_OUT_OF_MEMORY = 3,
+
+	//! The system or resource is busy.
+	IPC4_BUSY = 4,
+	//! Replaced ADSP IPC PENDING (unused) - according to cAVS v0.5.
+	IPC4_BAD_STATE = 5,
+	//! Unknown error while processing the request.
+	IPC4_FAILURE = 6,
+	//! Unsupported operation requested.
+	IPC4_INVALID_REQUEST = 7,
+	//! Reserved (ADSP_STAGE_UNINITIALIZED removed).
+	IPC4_RSVD_8 = 8,
+
+	//! Specified resource not found.
+	IPC4_INVALID_RESOURCE_ID = 9,
+	//! A resource's ID requested to be created is already assigned.
+	IPC4_RESOURCE_ID_EXISTS = 10,
+
+	//! Reserved (IPC4_OUT_OF_MIPS removed).
+	IPC4_RSVD_11 = 11,
+
+	//! Required resource is in invalid state.
+	IPC4_INVALID_RESOURCE_STATE = 12,
+
+	//! Requested power transition failed to complete.
+	IPC4_POWER_TRANSITION_FAILED = 13,
+
+	//! Manifest of the library being loaded is invalid.
+	IPC4_INVALID_MANIFEST = 14,
+
+	//! Requested service or data is unavailable on the target platform.
+	IPC4_UNAVAILABLE = 15,
+
+	/* Load/unload library specific codes */
+
+	//! Library target address is out of storage memory range.
+	IPC4_LOAD_ADDRESS_OUT_OF_RANGE = 42,
+
+	//! Reserved
+	IPC4_RSVD_43 = 43,
+
+	//! Image verification by CSE failed.
+	IPC4_CSE_VALIDATION_FAILED = 44,
+
+	//! General module management error.
+	IPC4_MOD_MGMT_ERROR = 100,
+	//! Module loading failed.
+	IPC4_MOD_LOAD_CL_FAILED = 101,
+	//! Integrity check of the loaded module content failed.
+	IPC4_MOD_LOAD_INVALID_HASH = 102,
+
+	//! Attempt to unload code of the module in use.
+	ADSP_MOD_INSTANCE_EXISTS = 103,
+	//! Other failure of module instance initialization request.
+	IPC4_MOD_NOT_INITIALIZED = 104,
+	//! Reserved (IPC4_OUT_OF_MIPS removed).
+	IPC4_RSVD_105 = 105,
+	//! Reserved (IPC4_CONFIG_GET_ERROR removed).
+	IPC4_RSVD_106 = 106,
+	//! Reserved (IPC4_CONFIG_SET_ERROR removed).
+	IPC4_RSVD_107 = 107,
+	//! Reserved (IPC4_LARGE_CONFIG_GET_ERROR removed).
+	IPC4_RSVD_108 = 108,
+	//! Reserved (IPC4_LARGE_CONFIG_SET_ERROR removed).
+	IPC4_RSVD_109 = 109,
+
+	//! Invalid (out of range) module ID provided.
+	IPC4_MOD_INVALID_ID  = 110,
+	//! Invalid module instance ID provided.
+	IPC4_MOD_INST_INVALID_ID  = 111,
+	//! Invalid queue (pin) ID provided.
+	IPC4_QUEUE_INVALID_ID = 112,
+	//! Invalid destination queue (pin) ID provided.
+	IPC4_QUEUE_DST_INVALID_ID = 113,
+	//! Reserved (IPC4_BIND_UNBIND_DST_SINK_UNSUPPORTED removed).
+	IPC4_RSVD_114 = 114,
+	//! Reserved (IPC4_UNLOAD_INST_EXISTS removed).
+	IPC4_RSVD_115 = 115,
+	//! Invalid target code ID provided.
+	IPC4_INVALID_CORE_ID = 116,
+
+	//! Injection DMA buffer is too small for probing the input pin.
+	IPC4_PROBE_DMA_INJECTION_BUFFER_TOO_SMALL = 117,
+	//! Extraction DMA buffer is too small for probing the output pin.
+	IPC4_PROBE_DMA_EXTRACTION_BUFFER_TOO_SMALL = 118,
+
+	//! Invalid ID of configuration item provided in TLV list.
+	IPC4_INVALID_CONFIG_PARAM_ID = 120,
+	//! Invalid length of configuration item provided in TLV list.
+	IPC4_INVALID_CONFIG_DATA_LEN = 121,
+	//! Invalid structure of configuration item provided.
+	IPC4_INVALID_CONFIG_DATA_STRUCT = 122,
+
+	//! Initialization of DMA Gateway failed.
+	IPC4_GATEWAY_NOT_INITIALIZED = 140,
+	//! Invalid ID of gateway provided.
+	IPC4_GATEWAY_NOT_EXIST = 141,
+	//! Setting state of DMA Gateway failed.
+	IPC4_GATEWAY_STATE_NOT_SET = 142,
+	//! DMA_CONTROL message targeting gateway not allocated yet.
+	IPC4_GATEWAY_NOT_ALLOCATED = 143,
+
+	//! Attempt to configure SCLK while I2S port is running.
+	IPC4_SCLK_ALREADY_RUNNING = 150,
+	//! Attempt to configure MCLK while I2S port is running.
+	IPC4_MCLK_ALREADY_RUNNING = 151,
+	//! Attempt to stop SCLK that is not running.
+	IPC4_NO_RUNNING_SCLK = 152,
+	//! Attempt to stop MCLK that is not running.
+	IPC4_NO_RUNNING_MCLK = 153,
+
+	//! Reserved (IPC4_PIPELINE_NOT_INITIALIZED removed).
+	IPC4_RSVD_160 = 160,
+	//! Reserved (IPC4_PIPELINE_NOT_EXIST removed).
+	IPC4_RSVD_161 = 161,
+	//! Reserved (IPC4_PIPELINE_SAVE_FAILED removed).
+	IPC4_RSVD_162 = 162,
+	//! Reserved (IPC4_PIPELINE_RESTORE_FAILED removed).
+	IPC4_RSVD_163 = 163,
+	//! Reverted for ULP purposes.
+	IPC4_PIPELINE_STATE_NOT_SET = 164,
+	//! Reserved (IPC4_PIPELINE_ALREADY_EXISTS removed).
+	IPC4_RSVD_165 = 165,
+
+	IPC4_MAX_STATUS = ((1<<IXC_STATUS_BITS)-1)
+};
+#endif

--- a/src/include/ipc4/module.h
+++ b/src/include/ipc4/module.h
@@ -186,5 +186,46 @@ struct ipc4_module_bind_unbind {
 	} data;
 } __attribute__((packed, aligned(4)));
 
+struct ipc4_module_large_config {
+	union {
+		uint32_t dat;
+
+		struct {
+			//! module id
+			uint32_t module_id		: 16;
+			//! instance id
+			uint32_t instance_id	: 8;
+			//! ModuleMsg::LARGE_CONFIG_GET / LARGE_CONFIG_SET
+			uint32_t type			: 5;
+			//! Msg::MSG_REQUEST
+			uint32_t rsp			: 1;
+			//! Msg::MODULE_MSG
+			uint32_t msg_tgt		: 1;
+			uint32_t _reserved_0	: 1;
+			} r;
+		} header;
+
+	union {
+		uint32_t dat;
+
+		struct {
+			//! data size/offset
+			uint32_t data_off_size	: 20;
+			//! param type : VENDOR_CONFIG_PARAM / GENERIC_CONFIG_PARAM
+			uint32_t large_param_id : 8;
+			//! 1 if final block
+			uint32_t final_block	: 1;
+			//! 1 if first block
+			uint32_t init_block	: 1;
+			uint32_t _reserved_2	: 2;
+		} r;
+	} data;
+};
+
+#define IPC4_COMP_ID(x, y) ((x) << 16 | (y))
+const struct comp_driver *ipc4_get_comp_drv(int module_id);
+struct comp_dev *ipc4_get_comp_dev(int comp_id);
+void ipc4_add_comp_dev(struct comp_dev *dev);
+
 #endif
 

--- a/src/ipc/handler-ipc4.c
+++ b/src/ipc/handler-ipc4.c
@@ -46,6 +46,7 @@
 #include <ipc/control.h>
 #include <ipc/dai.h>
 #include <ipc/debug.h>
+#include <ipc4/error_status.h>
 #include <ipc4/header.h>
 #include <ipc4/module.h>
 #include <ipc4/pipeline.h>
@@ -149,6 +150,34 @@ static int ipc4_process_glb_message(union ipc4_message_header *ipc4)
 
 static int ipc4_init_module(union ipc4_message_header *ipc4)
 {
+	struct ipc4_module_init_instance module;
+	const struct comp_driver *drv;
+	struct sof_ipc_comp comp;
+	struct comp_dev *dev;
+
+	module.header.dat = *ipc_to_hdr(ipc4);
+	module.data.dat = *(ipc_to_hdr(ipc4) + 1);
+
+	drv = ipc4_get_comp_drv(module.header.r.module_id);
+	if (!drv)
+		return IPC4_MOD_INVALID_ID;
+
+	memset(&comp, 0, sizeof(comp));
+	comp.id = IPC4_COMP_ID(module.header.r.module_id, module.header.r.instance_id);
+	comp.pipeline_id = module.data.r.ppl_instance_id;
+	comp.core = module.data.r.core_id;
+
+	/*
+	 * todo: rework interface to pass module config in host box
+	 * another solution is to read host box in component directly
+	 */
+	dev = drv->ops.create(drv, &comp);
+
+	if (!dev)
+		return IPC4_MOD_NOT_INITIALIZED;
+
+	ipc4_add_comp_dev(dev);
+
 	return 0;
 }
 
@@ -164,7 +193,24 @@ static int ipc4_unbind_module(union ipc4_message_header *ipc4)
 
 static int ipc4_set_large_config_module(union ipc4_message_header *ipc4)
 {
-	return 0;
+	struct ipc4_module_large_config config;
+	const struct comp_driver *drv;
+	struct comp_dev *dev;
+	int comp_id;
+	int ret;
+
+	config.header.dat = *ipc_to_hdr(ipc4);
+	config.data.dat = *(ipc_to_hdr(ipc4) + 1);
+	drv = ipc4_get_comp_drv(config.header.r.module_id);
+	if (!drv)
+		return IPC4_MOD_INVALID_ID;
+
+	comp_id = IPC4_COMP_ID(config.header.r.module_id, config.header.r.instance_id);
+	dev = ipc4_get_comp_dev(comp_id);
+	ret = drv->ops.cmd(dev, config.data.r.large_param_id, (void *)MAILBOX_HOSTBOX_BASE,
+				config.data.dat);
+
+	return ret;
 }
 
 static int ipc4_process_module_message(union ipc4_message_header *ipc4)
@@ -279,7 +325,7 @@ void ipc_cmd(ipc_cmd_hdr *_hdr)
 	default:
 		/* should not reach here as we only have 2 message tyes */
 		tr_err(&ipc_tr, "ipc4: invalid target %d", target);
-		err = -EINVAL;
+		err = IPC4_UNKNOWN_MESSAGE_TYPE;
 	}
 
 	if (err) {

--- a/src/ipc/helper-ipc4.c
+++ b/src/ipc/helper-ipc4.c
@@ -24,6 +24,8 @@
 #include <sof/platform.h>
 #include <sof/sof.h>
 #include <sof/spinlock.h>
+#include <rimage/cavs/cavs_ext_manifest.h>
+#include <rimage/sof/user/manifest.h>
 
 #include <ipc4/header.h>
 #include <ipc4/pipeline.h>
@@ -221,3 +223,66 @@ struct comp_buffer *buffer_new(struct sof_ipc_buffer *desc)
 {
 	return NULL;
 }
+
+static const struct comp_driver *module_driver[FW_MAX_EXT_MODULE_NUM] = {0};
+
+static const struct comp_driver *ipc4_get_drv(uint8_t *uuid)
+{
+	struct comp_driver_list *drivers = comp_drivers_get();
+	struct list_item *clist;
+	const struct comp_driver *drv = NULL;
+	struct comp_driver_info *info;
+	uint32_t flags;
+
+	irq_local_disable(flags);
+
+	/* search driver list with UUID */
+	list_for_item(clist, &drivers->list) {
+		info = container_of(clist, struct comp_driver_info,
+				    list);
+		if (!memcmp(info->drv->uid, uuid, UUID_SIZE)) {
+			tr_dbg(&comp_tr,
+			       "get_drv_from_uuid(), found driver type %d, uuid %pU",
+			       info->drv->type,
+			       info->drv->tctx->uuid_p);
+			drv = info->drv;
+			goto out;
+		}
+	}
+
+	tr_err(&comp_tr, "get_drv(): the provided UUID (%8x%8x%8x%8x) doesn't match to any driver!",
+	       *(uint32_t *)(&uuid[0]),
+	       *(uint32_t *)(&uuid[4]),
+	       *(uint32_t *)(&uuid[8]),
+	       *(uint32_t *)(&uuid[12]));
+
+out:
+	irq_local_enable(flags);
+	return drv;
+}
+
+const struct comp_driver *ipc4_get_comp_drv(int module_id)
+{
+	struct sof_man_fw_desc *desc = (struct sof_man_fw_desc *)IMR_BOOT_LDR_MANIFEST_BASE;
+	struct sof_man_module *mod;
+	const struct comp_driver *drv;
+
+	if (module_driver[module_id])
+		return module_driver[module_id];
+
+	/* skip basefw of module 0 in manifest */
+	mod = (struct sof_man_module *)((char *)desc + SOF_MAN_MODULE_OFFSET(module_id + 1));
+	drv = ipc4_get_drv(mod->uuid);
+	module_driver[module_id] = drv;
+
+	return drv;
+}
+
+struct comp_dev *ipc4_get_comp_dev(int comp_id)
+{
+	return NULL;
+}
+
+void ipc4_add_comp_dev(struct comp_dev *dev)
+{
+};


### PR DESCRIPTION
Translate module initialization to component new. Current
problem is the interface of create can't pass module
config in host box. Another solution is to read host box in
component directly so we don't need to change current interface.

Also add error code for IPC4. All IPC4 functions should
use these error code.

Signed-off-by: Rander Wang <rander.wang@intel.com>