### PR TITLE
xtensa-build-all.sh: replace "type xtensa-bxt-elf-gcc" with "command -v"

### DIFF
--- a/scripts/xtensa-build-all.sh
+++ b/scripts/xtensa-build-all.sh
@@ -206,8 +206,8 @@ do
 			PLATFORM="apollolake"
 			XTENSA_CORE="X4H3I16w2D48w3a_2017_8"
 
-			# test APL compiler aliases and ignore set -e here
-			if type xtensa-bxt-elf-gcc; then
+			# test APL compiler aliases
+			if command -v xtensa-bxt-elf-gcc; then
 				HOST="xtensa-bxt-elf"
 			else
 				HOST="xtensa-apl-elf"
@@ -220,8 +220,8 @@ do
 			PLATFORM="skylake"
 			XTENSA_CORE="X4H3I16w2D48w3a_2017_8"
 
-			# test APL compiler aliases and ignore set -e here
-			if type xtensa-bxt-elf-gcc; then
+			# test APL compiler aliases
+			if command -v xtensa-bxt-elf-gcc; then
 				HOST="xtensa-bxt-elf"
 			else
 				HOST="xtensa-apl-elf"
@@ -234,8 +234,8 @@ do
 			PLATFORM="kabylake"
 			XTENSA_CORE="X4H3I16w2D48w3a_2017_8"
 
-			# test APL compiler aliases and ignore set -e here
-			if type xtensa-bxt-elf-gcc; then
+			# test APL compiler aliases
+			if command -v xtensa-bxt-elf-gcc; then
 				HOST="xtensa-bxt-elf"
 			else
 				HOST="xtensa-apl-elf"


### PR DESCRIPTION
... because the latter does not print on stderr when not found; so IDEs
and CIs don't display this as a warning.

Also remove the "... and ignore set -e" comment that made sense at the
time of commit cad86dc ("scripts: xtensa-build: fix alias detection
for bxt/apl gcc") but not anymore.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>