### PR TITLE
Zephyr multicore batch 1

### DIFF
--- a/src/include/sof/drivers/idc.h
+++ b/src/include/sof/drivers/idc.h
@@ -137,4 +137,6 @@ int idc_wait_in_blocking_mode(uint32_t target_core, bool (*cond)(int));
 
 int idc_msg_status_get(uint32_t core);
 
+void idc_init_thread(void);
+
 #endif /* __SOF_DRIVERS_IDC_H__ */

--- a/src/init/init.c
+++ b/src/init/init.c
@@ -172,11 +172,8 @@ int primary_core_init(int argc, char *argv[], struct sof *sof)
 	return err;
 }
 
-#ifdef __ZEPHYR__
-int sof_main(int argc, char *argv[])
-#else
+#ifndef __ZEPHYR__
 int main(int argc, char *argv[])
-#endif
 {
 	int err;
 
@@ -187,9 +184,17 @@ int main(int argc, char *argv[])
 	else
 		err = secondary_core_init(&sof);
 
-#ifndef __ZEPHYR__
 	/* should never get here */
 	panic(SOF_IPC_PANIC_TASK);
-#endif
 	return err;
 }
+
+#else
+
+int sof_main(int argc, char *argv[])
+{
+	trace_point(TRACE_BOOT_START);
+
+	return primary_core_init(argc, argv, &sof);
+}
+#endif

--- a/src/init/init.c
+++ b/src/init/init.c
@@ -89,10 +89,10 @@ int secondary_core_init(struct sof *sof)
 	/* interrupts need to be initialized before any usage */
 	trace_point(TRACE_BOOT_PLATFORM_IRQ);
 	platform_interrupt_init();
-#endif
 
-	trace_point(TRACE_BOOT_PLATFORM_SCHED);
 	scheduler_init_edf();
+#endif
+	trace_point(TRACE_BOOT_PLATFORM_SCHED);
 	scheduler_init_ll(timer_domain_get());
 	scheduler_init_ll(dma_domain_get());
 

--- a/src/platform/Kconfig
+++ b/src/platform/Kconfig
@@ -218,7 +218,6 @@ endchoice
 
 config MAX_CORE_COUNT
 	int
-	default 1 if KERNEL_BIN_NAME = "zephyr"
 	default 2 if APOLLOLAKE
 	default 4 if ICELAKE || CANNONLAKE || SUECREEK || TIGERLAKE
 	default 1
@@ -227,6 +226,7 @@ config MAX_CORE_COUNT
 
 config CORE_COUNT
 	int "Number of cores"
+	default MP_NUM_CPUS if KERNEL_BIN_NAME = "zephyr"
 	default MAX_CORE_COUNT
 	range 1 MAX_CORE_COUNT
 	help

--- a/src/schedule/zephyr.c
+++ b/src/schedule/zephyr.c
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2021 Intel Corporation. All rights reserved.
+
+/*
+ * Use P4WQ to implement IDC for SOF. We create a P4 work queue per core and
+ * when the primary core sends a message to a secondary core, a work item from
+ * a static per-core array is queued accordingly. The secondary core is then
+ * woken up, it executes irc_handler(), which eventually calls idc_cmd() just
+ * like in the native SOF case. One work item per secondary core is enough
+ * because IDC on SOF is always synchronous, the primary core always waits for
+ * secondary cores to complete operation, so no races can occur.
+ *
+ * Design:
+ * - use K_P4WQ_ARRAY_DEFINE() to statically create one queue with one thread
+ *	per DSP core.
+ * - k_p4wq_submit()
+ *	runs on primary CPU
+ *	send tasks to other CPUs.
+ */
+
+#include <kernel.h>
+
+#include <sys/p4wq.h>
+#include <sof/drivers/idc.h>
+#include <sof/init.h>
+#include <sof/lib/alloc.h>
+#include <ipc/topology.h>
+
+/*
+ * Inter-CPU communication is only used in
+ * - IPC
+ * - Notifier
+ * - Power management (IDC_MSG_POWER_UP, IDC_MSG_POWER_DOWN)
+ */
+
+#if !CONFIG_MULTICORE || !defined(CONFIG_SMP)
+
+void idc_init_thread(void)
+{
+}
+
+#else
+
+K_P4WQ_ARRAY_DEFINE(q_zephyr_idc, CONFIG_CORE_COUNT, SOF_STACK_SIZE,
+		    K_P4WQ_USER_CPU_MASK);
+
+struct zephyr_idc_msg {
+	struct k_p4wq_work work;
+	struct idc_msg msg;
+};
+
+static void idc_handler(struct k_p4wq_work *work)
+{
+	struct zephyr_idc_msg *zmsg = container_of(work, struct zephyr_idc_msg, work);
+	struct idc *idc = *idc_get();
+	struct idc_msg *msg = &zmsg->msg;
+	int payload = -1;
+
+	SOC_DCACHE_INVALIDATE(msg, sizeof(*msg));
+
+	if (msg->size == sizeof(int))
+		assert(!memcpy_s(&payload, sizeof(payload), msg->payload, msg->size));
+
+	idc->received_msg.core = msg->core;
+	idc->received_msg.header = msg->header;
+	idc->received_msg.extension = msg->extension;
+
+	switch (msg->header) {
+	case IDC_MSG_POWER_UP:
+		/* Run the core initialisation? */
+		secondary_core_init(sof_get());
+		break;
+	default:
+		idc_cmd(&idc->received_msg);
+	}
+}
+
+/*
+ * Used for *target* CPUs, since the initiator (usually core 0) can launch
+ * several IDC messages at once
+ */
+static struct zephyr_idc_msg idc_work[CONFIG_CORE_COUNT];
+
+int idc_send_msg(struct idc_msg *msg, uint32_t mode)
+{
+	struct idc *idc = *idc_get();
+	struct idc_payload *payload = idc_payload_get(idc, msg->core);
+	unsigned int target_cpu = msg->core;
+	struct zephyr_idc_msg *zmsg = idc_work + target_cpu;
+	struct idc_msg *msg_cp = &zmsg->msg;
+	struct k_p4wq_work *work = &zmsg->work;
+	int ret;
+
+	assert(!memcpy_s(msg_cp, sizeof(*msg_cp), msg, sizeof(*msg)));
+	/* TODO: verify .priority and .deadline */
+	work->priority = K_HIGHEST_THREAD_PRIO + 1;
+	work->deadline = 0;
+	work->handler = idc_handler;
+	work->sync = mode == IDC_BLOCKING;
+
+	if (msg->payload) {
+		assert(!memcpy_s(payload->data, sizeof(payload->data),
+				 msg->payload, msg->size));
+		SOC_DCACHE_FLUSH(payload->data, MIN(sizeof(payload->data), msg->size));
+	}
+
+	/* Temporarily store sender core ID */
+	msg_cp->core = cpu_get_id();
+
+	SOC_DCACHE_FLUSH(msg_cp, sizeof(*msg_cp));
+	k_p4wq_submit(q_zephyr_idc + target_cpu, work);
+
+	switch (mode) {
+	case IDC_BLOCKING:
+		ret = k_p4wq_wait(work, K_FOREVER);
+		break;
+	case IDC_POWER_UP:
+	case IDC_NON_BLOCKING:
+	default:
+		ret = 0;
+	}
+
+	return ret;
+}
+
+void idc_init_thread(void)
+{
+	int cpu = cpu_get_id();
+
+	k_p4wq_enable_static_thread(q_zephyr_idc + cpu,
+				    _p4threads_q_zephyr_idc + cpu, BIT(cpu));
+}
+
+#endif /* CONFIG_MULTICORE */

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -114,10 +114,6 @@ if (CONFIG_SOC_SERIES_INTEL_CAVS_V15)
 		${SOF_DRIVERS_PATH}/intel/cavs/timestamp.c
 	)
 
-	zephyr_library_sources_ifdef(CONFIG_MULTICORE
-		${SOF_DRIVERS_PATH}/intel/cavs/idc.c
-	)
-
 	zephyr_library_sources_ifdef(CONFIG_INTEL_HDA
 		${SOF_DRIVERS_PATH}/intel/hda/hda-dma.c
 		${SOF_DRIVERS_PATH}/intel/hda/hda.c
@@ -165,10 +161,6 @@ if (CONFIG_SOC_SERIES_INTEL_CAVS_V18)
 	zephyr_library_sources(
 		${SOF_DRIVERS_PATH}/intel/cavs/ipc.c
 		${SOF_DRIVERS_PATH}/intel/cavs/timestamp.c
-	)
-
-	zephyr_library_sources_ifdef(CONFIG_MULTICORE
-		${SOF_DRIVERS_PATH}/intel/cavs/idc.c
 	)
 
 	# Sue Creek - S100 only - already in Zephyr.
@@ -230,10 +222,6 @@ if (CONFIG_SOC_SERIES_INTEL_CAVS_V20)
 		${SOF_DRIVERS_PATH}/intel/cavs/timestamp.c
 	)
 
-	zephyr_library_sources_ifdef(CONFIG_MULTICORE
-		${SOF_DRIVERS_PATH}/intel/cavs/idc.c
-	)
-
 	zephyr_library_sources_ifdef(CONFIG_INTEL_HDA
 		${SOF_DRIVERS_PATH}/intel/hda/hda-dma.c
 		${SOF_DRIVERS_PATH}/intel/hda/hda.c
@@ -289,10 +277,6 @@ if (CONFIG_SOC_SERIES_INTEL_CAVS_V25)
 	zephyr_library_sources(
 		${SOF_DRIVERS_PATH}/intel/cavs/ipc.c
 		${SOF_DRIVERS_PATH}/intel/cavs/timestamp.c
-	)
-
-	zephyr_library_sources_ifdef(CONFIG_MULTICORE
-		${SOF_DRIVERS_PATH}/intel/cavs/idc.c
 	)
 
 	zephyr_library_sources_ifdef(CONFIG_INTEL_HDA
@@ -409,6 +393,7 @@ zephyr_library_sources(
 	${SOF_SRC_PATH}/schedule/dma_single_chan_domain.c
 	${SOF_SRC_PATH}/schedule/dma_multi_chan_domain.c
 	${SOF_SRC_PATH}/schedule/ll_schedule.c
+	${SOF_SRC_PATH}/schedule/zephyr.c
 
 	# Bridge wrapper between SOF and Zephyr APIs - Will shrink over time.
 	wrapper.c

--- a/zephyr/schedule.c
+++ b/zephyr/schedule.c
@@ -9,9 +9,10 @@
 #include <sof/schedule/edf_schedule.h>
 #include <sof/schedule/ll_schedule.h>
 #include <sof/lib/alloc.h>
+#include <sof/lib/cpu.h>
 #include <ipc/topology.h>
 
-static struct schedulers *_schedulers;
+static struct schedulers *_schedulers[CONFIG_CORE_COUNT];
 
 /**
  * Retrieves registered schedulers.
@@ -19,5 +20,5 @@ static struct schedulers *_schedulers;
  */
 struct schedulers **arch_schedulers_get(void)
 {
-	return &_schedulers;
+	return _schedulers + cpu_get_id();
 }

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -6,6 +6,7 @@
  */
 
 #include <sof/lib/alloc.h>
+#include <sof/drivers/idc.h>
 #include <sof/drivers/interrupt.h>
 #include <sof/drivers/interrupt-map.h>
 #include <sof/lib/dma.h>
@@ -544,11 +545,16 @@ int arch_cpu_enabled_cores(void)
 	return 1;
 }
 
-struct idc;
+static struct idc idc[CONFIG_MP_NUM_CPUS];
+static struct idc *p_idc[CONFIG_MP_NUM_CPUS];
+
 struct idc **idc_get(void)
 {
-	/* TODO: this should return per core data */
-	return NULL;
+	int cpu = cpu_get_id();
+
+	p_idc[cpu] = idc + cpu;
+
+	return p_idc + cpu;
 }
 #endif
 

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -324,19 +324,16 @@ uint64_t platform_timer_get_atomic(struct timer *timer)
 /*
  * Notifier.
  *
- * Use SOF inter component messaging today. Zephy has similar APIs that will
+ * Use SOF inter component messaging today. Zephyr has similar APIs that will
  * need some minor feature updates prior to merge. i.e. FW to host messages.
  * TODO: align with Zephyr API when ready.
  */
 
-static struct notify *host_notify;
+static struct notify *host_notify[CONFIG_CORE_COUNT];
 
 struct notify **arch_notify_get(void)
 {
-	if (!host_notify)
-		host_notify = rzalloc(SOF_MEM_ZONE_SYS, 0, SOF_MEM_CAPS_RAM,
-				      sizeof(*host_notify));
-	return &host_notify;
+	return host_notify + cpu_get_id();
 }
 
 /*


### PR DESCRIPTION
The first (IIRC) batch of SOF Zephyr multicore patches. Limited functionality: on APL and CNL booting, secondary core can be powered on and initialised, topology can be loaded, but DMIC isn't working even on core 0, actual audio streaming on core 1, e.g. to HDMI isn't working yet either.