### PR TITLE
ipc: component: abstract the component creation API

### DIFF
--- a/src/audio/crossover/crossover.c
+++ b/src/audio/crossover/crossover.c
@@ -8,6 +8,7 @@
 #include <sof/audio/component.h>
 #include <sof/audio/format.h>
 #include <sof/audio/pipeline.h>
+#include <sof/audio/ipc-config.h>
 #include <sof/audio/crossover/crossover.h>
 #include <sof/audio/crossover/crossover_algorithm.h>
 #include <sof/audio/eq_iir/iir.h>
@@ -309,13 +310,12 @@ static int crossover_setup(struct comp_data *cd, int nch)
  * \return Pointer to Crossover Filter component device.
  */
 static struct comp_dev *crossover_new(const struct comp_driver *drv,
-				      struct sof_ipc_comp *comp)
+				      struct comp_ipc_config *config,
+				      void *spec)
 {
 	struct comp_dev *dev;
 	struct comp_data *cd;
-	struct sof_ipc_comp_process *crossover;
-	struct sof_ipc_comp_process *ipc_crossover =
-			(struct sof_ipc_comp_process *)comp;
+	struct ipc_config_process *ipc_crossover = spec;;
 	size_t bs = ipc_crossover->size;
 	int ret;
 
@@ -328,14 +328,10 @@ static struct comp_dev *crossover_new(const struct comp_driver *drv,
 		return NULL;
 	}
 
-	dev = comp_alloc(drv, COMP_SIZE(struct sof_ipc_comp_process));
+	dev = comp_alloc(drv, sizeof(*dev));
 	if (!dev)
 		return NULL;
-
-	crossover = COMP_GET_IPC(dev, sof_ipc_comp_process);
-	ret = memcpy_s(crossover, sizeof(*crossover), ipc_crossover,
-		       sizeof(struct sof_ipc_comp_process));
-	assert(!ret);
+	dev->ipc_config = *config;
 
 	cd = rzalloc(SOF_MEM_ZONE_RUNTIME, 0,
 		     SOF_MEM_CAPS_RAM, sizeof(*cd));
@@ -730,7 +726,6 @@ static int crossover_copy(struct comp_dev *dev)
 static int crossover_prepare(struct comp_dev *dev)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
-	struct sof_ipc_comp_config *config = dev_comp_config(dev);
 	struct comp_buffer *source, *sink;
 	struct list_item *sink_list;
 	int32_t sink_period_bytes;
@@ -766,7 +761,7 @@ static int crossover_prepare(struct comp_dev *dev)
 		sink_period_bytes = audio_stream_period_bytes(&sink->stream,
 							      dev->frames);
 		if (sink->stream.size <
-				config->periods_sink * sink_period_bytes) {
+				dev->ipc_config.periods_sink * sink_period_bytes) {
 			comp_err(dev, "crossover_prepare(), sink %d buffer size %d is insufficient",
 				 sink->pipeline_id, sink->stream.size);
 			ret = -ENOMEM;

--- a/src/audio/drc/drc.c
+++ b/src/audio/drc/drc.c
@@ -10,6 +10,7 @@
 #include <sof/audio/drc/drc_algorithm.h>
 #include <sof/audio/format.h>
 #include <sof/audio/pipeline.h>
+#include <sof/audio/ipc-config.h>
 #include <sof/common.h>
 #include <sof/debug/panic.h>
 #include <sof/ipc/msg.h>
@@ -139,12 +140,12 @@ static int drc_setup(struct drc_comp_data *cd, uint16_t channels, uint32_t rate)
  */
 
 static struct comp_dev *drc_new(const struct comp_driver *drv,
-				struct sof_ipc_comp *comp)
+				struct comp_ipc_config *config,
+				void *spec)
 {
 	struct comp_dev *dev;
 	struct drc_comp_data *cd;
-	struct sof_ipc_comp_process *ipc_drc =
-		(struct sof_ipc_comp_process *)comp;
+	struct ipc_config_process *ipc_drc = spec;
 	size_t bs = ipc_drc->size;
 	int ret;
 
@@ -159,14 +160,10 @@ static struct comp_dev *drc_new(const struct comp_driver *drv,
 		return NULL;
 	}
 
-	dev = comp_alloc(drv, COMP_SIZE(struct sof_ipc_comp_process));
+	dev = comp_alloc(drv, sizeof(*dev));
 	if (!dev)
 		return NULL;
-
-	ret = memcpy_s(COMP_GET_IPC(dev, sof_ipc_comp_process),
-		       sizeof(struct sof_ipc_comp_process), ipc_drc,
-		       sizeof(struct sof_ipc_comp_process));
-	assert(!ret);
+	dev->ipc_config = *config;
 
 	cd = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM, sizeof(*cd));
 	if (!cd) {
@@ -362,7 +359,6 @@ static int drc_copy(struct comp_dev *dev)
 static int drc_prepare(struct comp_dev *dev)
 {
 	struct drc_comp_data *cd = comp_get_drvdata(dev);
-	struct sof_ipc_comp_config *config = dev_comp_config(dev);
 	struct comp_buffer *sourceb;
 	struct comp_buffer *sinkb;
 	uint32_t sink_period_bytes;
@@ -424,7 +420,7 @@ static int drc_prepare(struct comp_dev *dev)
 	sink_period_bytes = audio_stream_period_bytes(&sinkb->stream,
 						      dev->frames);
 
-	if (sinkb->stream.size < config->periods_sink * sink_period_bytes) {
+	if (sinkb->stream.size < dev->ipc_config.periods_sink * sink_period_bytes) {
 		comp_err(dev, "drc_prepare(), sink buffer size %d is insufficient",
 			 sinkb->stream.size);
 		ret = -ENOMEM;

--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -10,6 +10,7 @@
 #include <sof/audio/buffer.h>
 #include <sof/audio/component.h>
 #include <sof/audio/pipeline.h>
+#include <sof/audio/ipc-config.h>
 #include <sof/common.h>
 #include <sof/debug/panic.h>
 #include <sof/ipc/msg.h>
@@ -314,13 +315,12 @@ static int eq_fir_setup(struct comp_data *cd, int nch)
  */
 
 static struct comp_dev *eq_fir_new(const struct comp_driver *drv,
-				   struct sof_ipc_comp *comp)
+				   struct comp_ipc_config *config,
+				   void *spec)
 {
 	struct comp_dev *dev;
 	struct comp_data *cd;
-	struct sof_ipc_comp_process *fir;
-	struct sof_ipc_comp_process *ipc_fir
-		= (struct sof_ipc_comp_process *)comp;
+	struct ipc_config_process *ipc_fir = spec;
 	size_t bs = ipc_fir->size;
 	int i;
 	int ret;
@@ -336,14 +336,10 @@ static struct comp_dev *eq_fir_new(const struct comp_driver *drv,
 		return NULL;
 	}
 
-	dev = comp_alloc(drv, COMP_SIZE(struct sof_ipc_comp_process));
+	dev = comp_alloc(drv, sizeof(*dev));
 	if (!dev)
 		return NULL;
-
-	fir = COMP_GET_IPC(dev, sof_ipc_comp_process);
-	ret = memcpy_s(fir, sizeof(*fir), ipc_fir,
-		       sizeof(struct sof_ipc_comp_process));
-	assert(!ret);
+	dev->ipc_config = *config;
 
 	cd = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM, sizeof(*cd));
 	if (!cd) {
@@ -545,7 +541,6 @@ static int eq_fir_copy(struct comp_dev *dev)
 static int eq_fir_prepare(struct comp_dev *dev)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
-	struct sof_ipc_comp_config *config = dev_comp_config(dev);
 	struct comp_buffer *sourceb;
 	struct comp_buffer *sinkb;
 	uint32_t sink_period_bytes;
@@ -574,9 +569,9 @@ static int eq_fir_prepare(struct comp_dev *dev)
 	sink_period_bytes = audio_stream_period_bytes(&sinkb->stream,
 						      dev->frames);
 
-	if (sinkb->stream.size < config->periods_sink * sink_period_bytes) {
+	if (sinkb->stream.size < dev->ipc_config.periods_sink * sink_period_bytes) {
 		comp_err(dev, "eq_fir_prepare(): sink buffer size %d is insufficient < %d * %d",
-			 sinkb->stream.size, config->periods_sink, sink_period_bytes);
+			 sinkb->stream.size, dev->ipc_config.periods_sink, sink_period_bytes);
 		ret = -ENOMEM;
 		goto err;
 	}

--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -904,6 +904,9 @@ static int host_get_attribute(struct comp_dev *dev, uint32_t type,
 	case COMP_ATTR_COPY_TYPE:
 		*(enum comp_copy_type *)value = hd->copy_type;
 		break;
+	case COMP_ATTR_COPY_DIR:
+		*(uint32_t *)value = hd->ipc_host.direction;
+		break;
 	default:
 		return -EINVAL;
 	}

--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -9,6 +9,7 @@
 #include <sof/audio/component_ext.h>
 #include <sof/audio/pcm_converter.h>
 #include <sof/audio/pipeline.h>
+#include <sof/audio/ipc-config.h>
 #include <sof/common.h>
 #include <sof/debug/panic.h>
 #include <sof/ipc/msg.h>
@@ -94,6 +95,9 @@ struct host_data {
 
 	host_copy_func copy;	/**< host copy function */
 	pcm_converter_func process;	/**< processing function */
+
+	/* IPC host init info */
+	struct ipc_config_host ipc_host;
 
 	/* stream info */
 	struct sof_ipc_stream_posn posn; /* TODO: update this */
@@ -507,25 +511,20 @@ static int host_trigger(struct comp_dev *dev, int cmd)
 }
 
 static struct comp_dev *host_new(const struct comp_driver *drv,
-				 struct sof_ipc_comp *comp)
+				 struct comp_ipc_config *config,
+				 void *spec)
 {
-	struct sof_ipc_comp_host *ipc_host = (struct sof_ipc_comp_host *)comp;
-	struct sof_ipc_comp_host *host;
 	struct comp_dev *dev;
 	struct host_data *hd;
+	struct ipc_config_host *ipc_host = spec;
 	uint32_t dir;
-	int ret;
 
 	comp_cl_dbg(&comp_host, "host_new()");
 
-	dev = comp_alloc(drv, COMP_SIZE(struct sof_ipc_comp_host));
+	dev = comp_alloc(drv, sizeof(*dev));
 	if (!dev)
 		return NULL;
-
-	host = COMP_GET_IPC(dev, sof_ipc_comp_host);
-	ret = memcpy_s(host, sizeof(*host),
-		       ipc_host, sizeof(struct sof_ipc_comp_host));
-	assert(!ret);
+	dev->ipc_config = *config;
 
 	hd = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM, sizeof(*hd));
 	if (!hd) {
@@ -534,9 +533,10 @@ static struct comp_dev *host_new(const struct comp_driver *drv,
 	}
 
 	comp_set_drvdata(dev, hd);
+	hd->ipc_host = *ipc_host;
 
 	/* request HDA DMA with shared access privilege */
-	dir = ipc_host->direction == SOF_IPC_STREAM_PLAYBACK ?
+	dir = hd->ipc_host.direction == SOF_IPC_STREAM_PLAYBACK ?
 		DMA_DIR_HMEM_TO_LMEM : DMA_DIR_LMEM_TO_HMEM;
 
 	hd->dma = dma_get(dir, 0, DMA_DEV_HOST, DMA_ACCESS_SHARED);
@@ -552,7 +552,7 @@ static struct comp_dev *host_new(const struct comp_driver *drv,
 	dma_sg_init(&hd->host.elem_array);
 	dma_sg_init(&hd->local.elem_array);
 
-	ipc_build_stream_posn(&hd->posn, SOF_IPC_STREAM_POSITION, comp->id);
+	ipc_build_stream_posn(&hd->posn, SOF_IPC_STREAM_POSITION, dev->ipc_config.id);
 
 	hd->msg = ipc_msg_init(hd->posn.rhdr.hdr.cmd, sizeof(hd->posn));
 	if (!hd->msg) {

--- a/src/audio/smart_amp/smart_amp_maxim_dsm.c
+++ b/src/audio/smart_amp/smart_amp_maxim_dsm.c
@@ -212,7 +212,7 @@ int maxim_dsm_set_param(struct smart_amp_mod_struct_t *hspk,
 	/* Model database */
 	int32_t *db = (int32_t *)caldata->data;
 	/* Payload buffer */
-	int *wparam = (int *)cdata->data->data;
+	int *wparam = ASSUME_ALIGNED(cdata->data->data, 4);
 	/* number of parameters to read */
 	int num_param = (cdata->num_elems >> 2);
 	int idx, id, ch;

--- a/src/audio/switch.c
+++ b/src/audio/switch.c
@@ -23,7 +23,8 @@ DECLARE_SOF_RT_UUID("switch", switch_uuid, 0x385cc44b, 0xf34e, 0x4b9b,
 DECLARE_TR_CTX(switch_tr, SOF_UUID(switch_uuid), LOG_LEVEL_INFO);
 
 static struct comp_dev *switch_new(const struct comp_driver *drv,
-				   struct sof_ipc_comp *comp)
+				   struct comp_ipc_config *config,
+				   void *spec)
 {
 	comp_cl_info(&comp_switch, "switch_new()");
 

--- a/src/audio/tdfb/tdfb.c
+++ b/src/audio/tdfb/tdfb.c
@@ -21,6 +21,7 @@
 #include <sof/audio/buffer.h>
 #include <sof/audio/component.h>
 #include <sof/audio/pipeline.h>
+#include <sof/audio/ipc-config.h>
 #include <sof/audio/tdfb/tdfb_comp.h>
 #include <sof/math/fir_generic.h>
 #include <sof/math/fir_hifi2ep.h>
@@ -242,10 +243,10 @@ static int tdfb_setup(struct tdfb_comp_data *cd, int source_nch, int sink_nch)
  */
 
 static struct comp_dev *tdfb_new(const struct comp_driver *drv,
-				 struct sof_ipc_comp *comp)
+				 struct comp_ipc_config *config,
+				 void *spec)
 {
-	struct sof_ipc_comp_process *ipc_tdfb =
-		(struct sof_ipc_comp_process *)comp;
+	struct ipc_config_process *ipc_tdfb = spec;
 	struct comp_dev *dev;
 	struct tdfb_comp_data *cd;
 	size_t bs = ipc_tdfb->size;
@@ -261,13 +262,10 @@ static struct comp_dev *tdfb_new(const struct comp_driver *drv,
 		return NULL;
 	}
 
-	dev = comp_alloc(drv, COMP_SIZE(struct sof_ipc_comp_process));
+	dev = comp_alloc(drv, sizeof(*dev));
 	if (!dev)
 		return NULL;
-
-	memcpy_s(COMP_GET_IPC(dev, sof_ipc_comp_process),
-		 sizeof(struct sof_ipc_comp_process), ipc_tdfb,
-		 sizeof(struct sof_ipc_comp_process));
+	dev->ipc_config = *config;
 
 	cd = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM, sizeof(*cd));
 	if (!cd) {

--- a/src/audio/volume/volume_generic.c
+++ b/src/audio/volume/volume_generic.c
@@ -54,7 +54,7 @@ static inline int32_t vol_mult_s24_to_s24(int32_t x, int32_t vol)
 static void vol_s24_to_s24(struct comp_dev *dev, struct audio_stream *sink,
 			   const struct audio_stream *source, uint32_t frames)
 {
-	struct comp_data *cd = comp_get_drvdata(dev);
+	struct vol_data *cd = comp_get_drvdata(dev);
 	int32_t *src;
 	int32_t *dest;
 	int32_t i;
@@ -89,7 +89,7 @@ static void vol_s24_to_s24(struct comp_dev *dev, struct audio_stream *sink,
 static void vol_s32_to_s32(struct comp_dev *dev, struct audio_stream *sink,
 			   const struct audio_stream *source, uint32_t frames)
 {
-	struct comp_data *cd = comp_get_drvdata(dev);
+	struct vol_data *cd = comp_get_drvdata(dev);
 	int32_t *src;
 	int32_t *dest;
 	int32_t i;
@@ -126,7 +126,7 @@ static void vol_s32_to_s32(struct comp_dev *dev, struct audio_stream *sink,
 static void vol_s16_to_s16(struct comp_dev *dev, struct audio_stream *sink,
 			   const struct audio_stream *source, uint32_t frames)
 {
-	struct comp_data *cd = comp_get_drvdata(dev);
+	struct vol_data *cd = comp_get_drvdata(dev);
 	int16_t *src;
 	int16_t *dest;
 	int32_t i;

--- a/src/audio/volume/volume_hifi3.c
+++ b/src/audio/volume/volume_hifi3.c
@@ -44,7 +44,7 @@ static void vol_s24_to_s24_s32(struct comp_dev *dev, struct audio_stream *sink,
 			       const struct audio_stream *source,
 			       uint32_t frames)
 {
-	struct comp_data *cd = comp_get_drvdata(dev);
+	struct vol_data *cd = comp_get_drvdata(dev);
 	ae_f64 mult;
 	ae_f32x2 in_sample = AE_ZERO32();
 	ae_f32x2 out_sample;
@@ -105,7 +105,7 @@ static void vol_s32_to_s24_s32(struct comp_dev *dev, struct audio_stream *sink,
 			       const struct audio_stream *source,
 			       uint32_t frames)
 {
-	struct comp_data *cd = comp_get_drvdata(dev);
+	struct vol_data *cd = comp_get_drvdata(dev);
 	ae_f64 mult;
 	ae_f32x2 in_sample = AE_ZERO32();
 	ae_f32x2 out_sample;
@@ -165,7 +165,7 @@ static void vol_s32_to_s24_s32(struct comp_dev *dev, struct audio_stream *sink,
 static void vol_s16_to_s16(struct comp_dev *dev, struct audio_stream *sink,
 			   const struct audio_stream *source, uint32_t frames)
 {
-	struct comp_data *cd = comp_get_drvdata(dev);
+	struct vol_data *cd = comp_get_drvdata(dev);
 	ae_f64 mult;
 	ae_f32x2 volume;
 	ae_f32x2 out_sample;

--- a/src/idc/idc.c
+++ b/src/idc/idc.c
@@ -190,7 +190,7 @@ static int idc_prepare(uint32_t comp_id)
 					    SOF_UUID(idc_comp_task_uuid),
 					    SOF_SCHEDULE_LL_TIMER,
 					    dev->priority, comp_task, dev,
-					    dev->comp.core, 0);
+					    dev->ipc_config.core, 0);
 		if (ret < 0) {
 			rfree(dev->task);
 			goto out;

--- a/src/include/ipc/topology.h
+++ b/src/include/ipc/topology.h
@@ -47,6 +47,7 @@ enum sof_comp_type {
 	SOF_COMP_ASRC,		/**< Asynchronous sample rate converter */
 	SOF_COMP_DCBLOCK,
 	SOF_COMP_SMART_AMP,		/**< smart amplifier component */
+	SOF_COMP_CODEC_ADAPTOR,		/**< codec adaptor */
 	/* keep FILEREAD/FILEWRITE as the last ones */
 	SOF_COMP_FILEREAD = 10000,	/**< host test based file IO */
 	SOF_COMP_FILEWRITE = 10001,	/**< host test based file IO */

--- a/src/include/ipc/topology.h
+++ b/src/include/ipc/topology.h
@@ -233,6 +233,17 @@ struct sof_ipc_comp_process {
 	unsigned char data[0];
 } __attribute__((packed, aligned(4)));
 
+/* IPC file component used by testbench only */
+struct sof_ipc_comp_file {
+	struct sof_ipc_comp comp;
+	struct sof_ipc_comp_config config;
+	uint32_t rate;
+	uint32_t channels;
+	char *fn;
+	uint32_t mode;
+	uint32_t frame_fmt;
+} __attribute__((packed, aligned(4)));
+
 /* frees components, buffers and pipelines
  * SOF_IPC_TPLG_COMP_FREE, SOF_IPC_TPLG_PIPE_FREE, SOF_IPC_TPLG_BUFFER_FREE
  */

--- a/src/include/sof/audio/codec_adapter/codec/generic.h
+++ b/src/include/sof/audio/codec_adapter/codec/generic.h
@@ -29,9 +29,10 @@
 
 #define DECLARE_CODEC_ADAPTER(adapter, uuid, tr) \
 static struct comp_dev *adapter_shim_new(const struct comp_driver *drv, \
-					 struct sof_ipc_comp *comp)\
+					 struct comp_ipc_config *config, \
+					 void *spec) \
 { \
-	return codec_adapter_new(drv, comp, &(adapter));\
+	return codec_adapter_new(drv, config, &(adapter), spec);\
 } \
 \
 static const struct comp_driver comp_codec_adapter = { \
@@ -250,8 +251,9 @@ int codec_reset(struct comp_dev *dev);
 int codec_free(struct comp_dev *dev);
 
 struct comp_dev *codec_adapter_new(const struct comp_driver *drv,
-				   struct sof_ipc_comp *comp,
-				   struct codec_interface *interface);
+				   struct comp_ipc_config *config,
+				   struct codec_interface *interface,
+				   void *spec);
 int codec_adapter_prepare(struct comp_dev *dev);
 int codec_adapter_params(struct comp_dev *dev, struct sof_ipc_stream_params *params);
 int codec_adapter_copy(struct comp_dev *dev);

--- a/src/include/sof/audio/codec_adapter/codec/generic.h
+++ b/src/include/sof/audio/codec_adapter/codec/generic.h
@@ -36,7 +36,7 @@ static struct comp_dev *adapter_shim_new(const struct comp_driver *drv, \
 } \
 \
 static const struct comp_driver comp_codec_adapter = { \
-	.type = SOF_COMP_NONE, \
+	.type = SOF_COMP_CODEC_ADAPTOR, \
 	.uid = SOF_RT_UUID(uuid), \
 	.tctx = &(tr), \
 	.ops = { \

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -114,6 +114,7 @@ struct dai_hw_params;
  */
 #define COMP_ATTR_COPY_TYPE	0	/**< Comp copy type attribute */
 #define COMP_ATTR_HOST_BUFFER	1	/**< Comp host buffer attribute */
+#define COMP_ATTR_COPY_DIR	2	/**< Comp copy direction */
 /** @}*/
 
 /** \name Trace macros

--- a/src/include/sof/audio/component_ext.h
+++ b/src/include/sof/audio/component_ext.h
@@ -71,8 +71,8 @@ static inline void comp_shared_commit(struct comp_dev *dev)
 static inline int comp_params_remote(struct comp_dev *dev,
 				     struct sof_ipc_stream_params *params)
 {
-	struct idc_msg msg = { IDC_MSG_PARAMS, IDC_MSG_PARAMS_EXT(dev->comp.id),
-		dev->comp.core, sizeof(*params), params, };
+	struct idc_msg msg = { IDC_MSG_PARAMS, IDC_MSG_PARAMS_EXT(dev->ipc_config.id),
+		dev->ipc_config.core, sizeof(*params), params, };
 
 	return idc_send_msg(&msg, IDC_BLOCKING);
 }
@@ -83,7 +83,7 @@ static inline int comp_params(struct comp_dev *dev,
 {
 	int ret = 0;
 
-	if (dev->is_shared && !cpu_is_me(dev->comp.core)) {
+	if (dev->is_shared && !cpu_is_me(dev->ipc_config.core)) {
 		ret = comp_params_remote(dev, params);
 	} else {
 		if (dev->drv->ops.params) {
@@ -146,7 +146,7 @@ out:
 static inline int comp_trigger_remote(struct comp_dev *dev, int cmd)
 {
 	struct idc_msg msg = { IDC_MSG_TRIGGER,
-		IDC_MSG_TRIGGER_EXT(dev->comp.id), dev->comp.core, sizeof(cmd),
+		IDC_MSG_TRIGGER_EXT(dev->ipc_config.id), dev->ipc_config.core, sizeof(cmd),
 		&cmd, };
 
 	return idc_send_msg(&msg, IDC_BLOCKING);
@@ -159,7 +159,7 @@ static inline int comp_trigger(struct comp_dev *dev, int cmd)
 
 	assert(dev->drv->ops.trigger);
 
-	ret = (dev->is_shared && !cpu_is_me(dev->comp.core)) ?
+	ret = (dev->is_shared && !cpu_is_me(dev->ipc_config.core)) ?
 		comp_trigger_remote(dev, cmd) : dev->drv->ops.trigger(dev, cmd);
 
 	comp_shared_commit(dev);
@@ -171,7 +171,7 @@ static inline int comp_trigger(struct comp_dev *dev, int cmd)
 static inline int comp_prepare_remote(struct comp_dev *dev)
 {
 	struct idc_msg msg = { IDC_MSG_PREPARE,
-		IDC_MSG_PREPARE_EXT(dev->comp.id), dev->comp.core, };
+		IDC_MSG_PREPARE_EXT(dev->ipc_config.id), dev->ipc_config.core, };
 
 	return idc_send_msg(&msg, IDC_BLOCKING);
 }
@@ -182,7 +182,7 @@ static inline int comp_prepare(struct comp_dev *dev)
 	int ret = 0;
 
 	if (dev->drv->ops.prepare)
-		ret = (dev->is_shared && !cpu_is_me(dev->comp.core)) ?
+		ret = (dev->is_shared && !cpu_is_me(dev->ipc_config.core)) ?
 			comp_prepare_remote(dev) : dev->drv->ops.prepare(dev);
 
 	comp_shared_commit(dev);
@@ -198,7 +198,7 @@ static inline int comp_copy(struct comp_dev *dev)
 	assert(dev->drv->ops.copy);
 
 	/* copy only if we are the owner of the component */
-	if (cpu_is_me(dev->comp.core)) {
+	if (cpu_is_me(dev->ipc_config.core)) {
 		perf_cnt_init(&dev->pcd);
 		ret = dev->drv->ops.copy(dev);
 		perf_cnt_stamp(&dev->pcd, comp_perf_info, dev);
@@ -240,7 +240,7 @@ static inline int comp_set_attribute(struct comp_dev *dev, uint32_t type,
 static inline int comp_reset_remote(struct comp_dev *dev)
 {
 	struct idc_msg msg = { IDC_MSG_RESET,
-		IDC_MSG_RESET_EXT(dev->comp.id), dev->comp.core, };
+		IDC_MSG_RESET_EXT(dev->ipc_config.id), dev->ipc_config.core, };
 
 	return idc_send_msg(&msg, IDC_BLOCKING);
 }
@@ -255,7 +255,7 @@ static inline int comp_reset(struct comp_dev *dev)
 	int ret = 0;
 
 	if (dev->drv->ops.reset)
-		ret = (dev->is_shared && !cpu_is_me(dev->comp.core)) ?
+		ret = (dev->is_shared && !cpu_is_me(dev->ipc_config.core)) ?
 			comp_reset_remote(dev) : dev->drv->ops.reset(dev);
 
 	comp_shared_commit(dev);

--- a/src/include/sof/audio/ipc-config.h
+++ b/src/include/sof/audio/ipc-config.h
@@ -1,0 +1,98 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2021 Intel Corporation. All rights reserved.
+ */
+
+#ifndef __SOF_AUDIO_IPC_CONFIG_H__
+#define __SOF_AUDIO_IPC_CONFIG_H__
+
+#include <stdint.h>
+
+/*
+ * Generic IPC information for base components. Fields can be added here with NO impact on
+ * IPC ABI version.
+ */
+
+/* generic host component */
+struct ipc_config_host {
+	uint32_t direction;	/**< SOF_IPC_STREAM_ */
+	uint32_t no_irq;	/**< don't send periodic IRQ to host/DSP */
+	uint32_t dmac_config; /**< DMA engine specific */
+};
+
+/* generic DAI component */
+struct ipc_config_dai {
+	uint32_t direction;	/**< SOF_IPC_STREAM_ */
+	uint32_t dai_index;	/**< index of this type dai */
+	uint32_t type;		/**< DAI type - SOF_DAI_ */
+};
+
+/* generic volume component */
+struct ipc_config_volume {
+	uint32_t channels;
+	uint32_t min_value;
+	uint32_t max_value;
+	uint32_t ramp;		/**< SOF_VOLUME_ */
+	uint32_t initial_ramp;	/**< ramp space in ms */
+};
+
+/* generic SRC component */
+struct ipc_config_src {
+	/* either source or sink rate must be non zero */
+	uint32_t source_rate;	/**< source rate or 0 for variable */
+	uint32_t sink_rate;	/**< sink rate or 0 for variable */
+	uint32_t rate_mask;	/**< SOF_RATE_ supported rates */
+};
+
+/* generic ASRC component */
+struct ipc_config_asrc {
+	/* either source or sink rate must be non zero */
+	uint32_t source_rate;           /**< Define fixed source rate or */
+					/**< use 0 to indicate need to get */
+					/**< the rate from stream */
+	uint32_t sink_rate;             /**< Define fixed sink rate or */
+					/**< use 0 to indicate need to get */
+					/**< the rate from stream */
+	uint32_t asynchronous_mode;     /**< synchronous 0, asynchronous 1 */
+					/**< When 1 the ASRC tracks and */
+					/**< compensates for drift. */
+	uint32_t operation_mode;        /**< push 0, pull 1, In push mode the */
+					/**< ASRC consumes a defined number */
+					/**< of frames at input, with varying */
+					/**< number of frames at output. */
+					/**< In pull mode the ASRC outputs */
+					/**< a defined number of frames while */
+					/**< number of input frames varies. */
+};
+
+/* generic tone generator component */
+struct ipc_config_tone {
+	int32_t sample_rate;
+	int32_t frequency;
+	int32_t amplitude;
+	int32_t freq_mult;
+	int32_t ampl_mult;
+	int32_t length;
+	int32_t period;
+	int32_t repeats;
+	int32_t ramp_step;
+};
+
+/* generic "effect", "codec" or proprietary processing component */
+struct ipc_config_process {
+	uint32_t size;	/**< size of bespoke data section in bytes */
+	uint32_t type;	/**< sof_ipc_process_type */
+
+	unsigned char *data;
+};
+
+/* file IO ipc comp */
+struct ipc_comp_file {
+	uint32_t rate;
+	uint32_t channels;
+	char *fn;
+	uint32_t mode;
+	uint32_t frame_fmt;
+} __attribute__((packed, aligned(4)));
+
+#endif

--- a/src/include/sof/audio/volume.h
+++ b/src/include/sof/audio/volume.h
@@ -17,6 +17,7 @@
 #define __SOF_AUDIO_VOLUME_H__
 
 #include <sof/audio/component.h>
+#include <sof/audio/ipc-config.h>
 #include <sof/bit.h>
 #include <sof/common.h>
 #include <sof/trace/trace.h>
@@ -92,13 +93,14 @@ typedef uint32_t (*vol_zc_func)(const struct audio_stream *source,
  *
  * Gain amplitude value is between 0 (mute) ... 2^16 (0dB) ... 2^24 (~+48dB).
  */
-struct comp_data {
+struct vol_data {
 	struct sof_ipc_ctrl_value_chan *hvol;	/**< host volume readback */
 	int32_t volume[SOF_IPC_MAX_CHANNELS];	/**< current volume */
 	int32_t tvolume[SOF_IPC_MAX_CHANNELS];	/**< target volume */
 	int32_t mvolume[SOF_IPC_MAX_CHANNELS];	/**< mute volume */
 	int32_t rvolume[SOF_IPC_MAX_CHANNELS];	/**< ramp start volume */
 	int32_t ramp_coef[SOF_IPC_MAX_CHANNELS]; /**< parameter for slope */
+	struct ipc_config_volume ipc_config;
 	int32_t vol_min;			/**< minimum volume */
 	int32_t vol_max;			/**< maximum volume */
 	int32_t	vol_ramp_range;			/**< max ramp transition */

--- a/src/ipc/handler-ipc3.c
+++ b/src/ipc/handler-ipc3.c
@@ -192,11 +192,11 @@ static bool is_hostless_upstream(struct comp_dev *current)
 static int ipc_stream_pcm_params(uint32_t stream)
 {
 #if CONFIG_HOST_PTABLE
-	struct sof_ipc_comp_host *host = NULL;
 	struct dma_sg_elem_array elem_array;
 	uint32_t ring_size;
 	enum comp_copy_type copy_type = COMP_COPY_ONE_SHOT;
 	struct comp_dev *cd;
+	uint32_t direction;
 #endif
 	struct ipc *ipc = ipc_get();
 	struct sof_ipc_pcm_params pcm_params;
@@ -242,16 +242,12 @@ static int ipc_stream_pcm_params(uint32_t stream)
 	if (is_hostless_downstream(cd) && is_hostless_upstream(cd))
 		goto pipe_params;
 
-	/* Parse host tables */
-	host = (struct sof_ipc_comp_host *)&cd->comp;
-	if (IPC_IS_SIZE_INVALID(host->config)) {
-		IPC_SIZE_ERROR_TRACE(&ipc_tr, host->config);
-		err = -EINVAL;
+	err = comp_get_attribute(cd, COMP_ATTR_COPY_DIR, &direction);
+	if (err < 0)
 		goto error;
-	}
 
 	err = ipc_process_host_buffer(ipc, &pcm_params.params.buffer,
-				      host->direction,
+				      direction,
 				      &elem_array,
 				      &ring_size);
 	if (err < 0)

--- a/src/ipc/handler-ipc3.c
+++ b/src/ipc/handler-ipc3.c
@@ -128,8 +128,8 @@ static bool is_hostless_downstream(struct comp_dev *current)
 	struct list_item *clist;
 
 	/* check if current is a HOST comp */
-	if (current->comp.type == SOF_COMP_HOST ||
-	    current->comp.type == SOF_COMP_SG_HOST)
+	if (current->ipc_config.type == SOF_COMP_HOST ||
+	    current->ipc_config.type == SOF_COMP_SG_HOST)
 		return false;
 
 	/* check if the pipeline has a HOST comp downstream */
@@ -143,7 +143,8 @@ static bool is_hostless_downstream(struct comp_dev *current)
 			continue;
 
 		/* dont go downstream if this comp belongs to another pipe */
-		if (buffer->sink->comp.pipeline_id != current->comp.pipeline_id)
+		if (buffer->sink->ipc_config.pipeline_id !=
+			current->ipc_config.pipeline_id)
 			continue;
 
 		/* return if there's a host comp downstream */
@@ -160,8 +161,8 @@ static bool is_hostless_upstream(struct comp_dev *current)
 	struct list_item *clist;
 
 	/* check if current is a HOST comp */
-	if (current->comp.type == SOF_COMP_HOST ||
-	    current->comp.type == SOF_COMP_SG_HOST)
+	if (current->ipc_config.type == SOF_COMP_HOST ||
+	    current->ipc_config.type == SOF_COMP_SG_HOST)
 		return false;
 
 	/* check if the pipeline has a HOST comp upstream */
@@ -175,8 +176,8 @@ static bool is_hostless_upstream(struct comp_dev *current)
 			continue;
 
 		/* dont go upstream if this comp belongs to another pipeline */
-		if (buffer->source->comp.pipeline_id !=
-		    current->comp.pipeline_id)
+		if (buffer->source->ipc_config.pipeline_id !=
+		    current->ipc_config.pipeline_id)
 			continue;
 
 		/* return if there is a host comp upstream */

--- a/src/ipc/helper-ipc3.c
+++ b/src/ipc/helper-ipc3.c
@@ -8,6 +8,7 @@
 #include <sof/audio/buffer.h>
 #include <sof/audio/component_ext.h>
 #include <sof/audio/pipeline.h>
+#include <sof/audio/ipc-config.h>
 #include <sof/common.h>
 #include <sof/drivers/idc.h>
 #include <sof/drivers/interrupt.h>
@@ -34,6 +35,16 @@
 #include <stdint.h>
 
 extern struct tr_ctx comp_tr;
+
+/**
+ * Retrieves component config data from component ipc.
+ * @param comp Component ipc data.
+ * @return Pointer to the component config data.
+ */
+static inline struct sof_ipc_comp_config *comp_config(struct sof_ipc_comp *comp)
+{
+	return (struct sof_ipc_comp_config *)(comp + 1);
+}
 
 void ipc_build_stream_posn(struct sof_ipc_stream_posn *posn, uint32_t type,
 			   uint32_t id)
@@ -241,8 +252,133 @@ out:
 	return drv;
 }
 
+/* build generic IPC data for all components */
+static void comp_common_builder(struct sof_ipc_comp *comp,
+				struct comp_ipc_config *config)
+{
+	struct sof_ipc_comp_config *ipc_config;
+
+	/* create the new component */
+	memset(config, 0, sizeof(*config));
+	config->core = comp->core;
+	config->id = comp->id;
+	config->pipeline_id = comp->pipeline_id;
+	config->type = comp->type;
+
+	/* buffers dont have the following data */
+	if (comp->type != SOF_COMP_BUFFER) {
+		/* ipc common config is always after sof_ipc_comp */
+		ipc_config = (struct sof_ipc_comp_config *)(comp + 1);
+		config->frame_fmt = ipc_config->frame_fmt;
+		config->periods_sink = ipc_config->periods_sink;
+		config->periods_source = ipc_config->periods_source;
+		config->xrun_action = ipc_config->xrun_action;
+	}
+}
+/*
+ * Stores all the "legacy" init IPC data locally.
+ */
+union ipc_config_specific {
+	struct ipc_config_host host;
+	struct ipc_config_dai dai;
+	struct ipc_config_volume volume;
+	struct ipc_config_src src;
+	struct ipc_config_asrc asrc;
+	struct ipc_config_tone tone;
+	struct ipc_config_process process;
+	struct ipc_comp_file file;
+} __attribute__((packed, aligned(4)));
+
+/* build component specific data */
+static void comp_specific_builder(struct sof_ipc_comp *comp,
+				  union ipc_config_specific *config)
+{
+#if CONFIG_LIBRARY
+	struct sof_ipc_comp_file *file = (struct sof_ipc_comp_file *)comp;
+#else
+	struct sof_ipc_comp_host *host = (struct sof_ipc_comp_host *)comp;
+	struct sof_ipc_comp_dai *dai = (struct sof_ipc_comp_dai *)comp;
+#endif
+	struct sof_ipc_comp_volume *vol = (struct sof_ipc_comp_volume *)comp;
+	struct sof_ipc_comp_process *proc = (struct sof_ipc_comp_process *)comp;
+	struct sof_ipc_comp_src *src = (struct sof_ipc_comp_src *)comp;
+	struct sof_ipc_comp_tone *tone = (struct sof_ipc_comp_tone *)comp;
+
+	memset(config, 0, sizeof(*config));
+
+	switch (comp->type) {
+#if CONFIG_LIBRARY
+	/* test bench maps host and DAIs to a file */
+	case SOF_COMP_HOST:
+	case SOF_COMP_SG_HOST:
+	case SOF_COMP_DAI:
+	case SOF_COMP_SG_DAI:
+		config->file.channels = file->channels;
+		config->file.fn = file->fn;
+		config->file.frame_fmt = file->frame_fmt;
+		config->file.mode = file->mode;
+		config->file.rate = file->rate;
+		break;
+#else
+	case SOF_COMP_HOST:
+	case SOF_COMP_SG_HOST:
+		config->host.direction = host->direction;
+		config->host.no_irq = host->no_irq;
+		config->host.dmac_config = host->dmac_config;
+		break;
+	case SOF_COMP_DAI:
+	case SOF_COMP_SG_DAI:
+		config->dai.dai_index = dai->dai_index;
+		config->dai.direction = dai->direction;
+		config->dai.type = dai->type;
+		break;
+#endif
+	case SOF_COMP_VOLUME:
+		config->volume.channels = vol->channels;
+		config->volume.initial_ramp = vol->initial_ramp;
+		config->volume.max_value = vol->max_value;
+		config->volume.min_value = vol->min_value;
+		config->volume.ramp = vol->ramp;
+		break;
+	case SOF_COMP_SRC:
+		config->src.rate_mask = src->rate_mask;
+		config->src.sink_rate = src->sink_rate;
+		config->src.source_rate = src->source_rate;
+		break;
+	case SOF_COMP_TONE:
+		config->tone.ampl_mult = tone->ampl_mult;
+		config->tone.amplitude = tone->amplitude;
+		config->tone.freq_mult = tone->freq_mult;
+		config->tone.frequency = tone->frequency;
+		config->tone.length = tone->length;
+		config->tone.period = tone->period;
+		config->tone.ramp_step = tone->ramp_step;
+		config->tone.repeats = tone->repeats;
+		config->tone.sample_rate = tone->sample_rate;
+		break;
+	case SOF_COMP_EQ_IIR:
+	case SOF_COMP_EQ_FIR:
+	case SOF_COMP_KEYWORD_DETECT:
+	case SOF_COMP_KPB:
+	case SOF_COMP_SELECTOR:
+	case SOF_COMP_DEMUX:
+	case SOF_COMP_MUX:
+	case SOF_COMP_ASRC:
+	case SOF_COMP_DCBLOCK:
+	case SOF_COMP_SMART_AMP:
+		config->process.type = proc->type;
+		config->process.size = proc->size;
+		config->process.data = proc->data;
+		break;
+	default:
+		break;
+	}
+}
+
 struct comp_dev *comp_new(struct sof_ipc_comp *comp)
 {
+	struct comp_ipc_config config;
+	union ipc_config_specific spec;
 	struct comp_dev *cdev;
 	const struct comp_driver *drv;
 
@@ -263,8 +399,10 @@ struct comp_dev *comp_new(struct sof_ipc_comp *comp)
 	tr_info(&comp_tr, "comp new %pU type %d id %d.%d",
 		drv->tctx->uuid_p, comp->type, comp->pipeline_id, comp->id);
 
-	/* create the new component */
-	cdev = drv->ops.create(drv, comp);
+	/* build the component */
+	comp_common_builder(comp, &config);
+	comp_specific_builder(comp, &spec);
+	cdev = drv->ops.create(drv, &config, &spec);
 	if (!cdev) {
 		comp_cl_err(drv, "comp_new(): unable to create the new component");
 		return NULL;
@@ -441,12 +579,14 @@ int ipc_pipeline_complete(struct ipc *ipc, uint32_t comp_id)
 int ipc_comp_dai_config(struct ipc *ipc, struct sof_ipc_dai_config *config)
 {
 	bool comp_on_core[CONFIG_CORE_COUNT] = { false };
-	struct sof_ipc_comp_dai *dai;
 	struct sof_ipc_reply reply;
 	struct ipc_comp_dev *icd;
 	struct list_item *clist;
 	int ret = -ENODEV;
 	int i;
+
+	tr_info(&ipc_tr, "ipc_comp_dai_config() dai type = %d index = %d",
+		config->type, config->dai_index);
 
 	/* for each component */
 	list_for_item(clist, &ipc->comp_list) {
@@ -464,17 +604,10 @@ int ipc_comp_dai_config(struct ipc *ipc, struct sof_ipc_dai_config *config)
 
 		if (dev_comp_type(icd->cd) == SOF_COMP_DAI ||
 		    dev_comp_type(icd->cd) == SOF_COMP_SG_DAI) {
-			dai = COMP_GET_IPC(icd->cd, sof_ipc_comp_dai);
-			/*
-			 * set config if comp dai_index matches
-			 * config dai_index.
-			 */
-			if (dai->dai_index == config->dai_index &&
-			    dai->type == config->type) {
-				ret = comp_dai_config(icd->cd, config);
-				if (ret < 0)
-					break;
-			}
+
+			ret = comp_dai_config(icd->cd, config);
+			if (ret < 0)
+				break;
 		}
 	}
 

--- a/src/ipc/helper-ipc3.c
+++ b/src/ipc/helper-ipc3.c
@@ -366,6 +366,7 @@ static void comp_specific_builder(struct sof_ipc_comp *comp,
 	case SOF_COMP_ASRC:
 	case SOF_COMP_DCBLOCK:
 	case SOF_COMP_SMART_AMP:
+	case SOF_COMP_CODEC_ADAPTOR:
 		config->process.type = proc->type;
 		config->process.size = proc->size;
 		config->process.data = proc->data;

--- a/test/cmocka/src/audio/mixer/comp_mock.c
+++ b/test/cmocka/src/audio/mixer/comp_mock.c
@@ -14,7 +14,8 @@
 #include "comp_mock.h"
 
 static struct comp_dev *mock_comp_new(const struct comp_driver *drv,
-				      struct sof_ipc_comp *comp)
+				      struct comp_ipc_config *config,
+				      void *spec)
 {
 	struct comp_dev *dev = calloc(1, sizeof(struct comp_dev));
 

--- a/test/cmocka/src/audio/pipeline/pipeline_connect_upstream.c
+++ b/test/cmocka/src/audio/pipeline/pipeline_connect_upstream.c
@@ -7,6 +7,7 @@
 #include <stdint.h>
 #include <sof/audio/component.h>
 #include <sof/audio/pipeline.h>
+#include <sof/audio/ipc-config.h>
 #include <sof/schedule/edf_schedule.h>
 #include "pipeline_mocks.h"
 #include "pipeline_connection_mocks.h"
@@ -148,12 +149,12 @@ static void test_audio_pipeline_complete_connect_downstream_full(void **state)
 {
 	struct pipeline_connect_data *test_data = *state;
 	struct pipeline result = test_data->p;
-	struct sof_ipc_comp *comp;
+	struct comp_ipc_config *comp;
 
 	cleanup_test_data(test_data);
 
 	/*Connecting first comp to second*/
-	comp = dev_comp(test_data->second);
+	comp = &test_data->second->ipc_config;
 	comp->pipeline_id = PIPELINE_ID_SAME;
 	list_item_append(&result.sched_comp->bsink_list,
 					 &test_data->b1->source_list);
@@ -179,12 +180,12 @@ static void test_audio_pipeline_complete_connect_upstream_full(void **state)
 {
 	struct pipeline_connect_data *test_data = *state;
 	struct pipeline result = test_data->p;
-	struct sof_ipc_comp *comp;
+	struct comp_ipc_config *comp;
 
 	cleanup_test_data(test_data);
 
 	/*Connecting first comp to second*/
-	comp = dev_comp(test_data->second);
+	comp = &test_data->second->ipc_config;
 	comp->pipeline_id = PIPELINE_ID_SAME;
 	list_item_append(&result.sched_comp->bsource_list,
 					 &test_data->b1->sink_list);
@@ -204,12 +205,12 @@ static void test_audio_pipeline_complete_connect_upstream_other_pipeline
 {
 	struct pipeline_connect_data *test_data = *state;
 	struct pipeline result = test_data->p;
-	struct sof_ipc_comp *comp;
+	struct comp_ipc_config *comp;
 
 	cleanup_test_data(test_data);
 
 	/*Connecting first comp to second*/
-	comp = dev_comp(test_data->second);
+	comp = &test_data->second->ipc_config;
 	comp->pipeline_id = PIPELINE_ID_DIFFERENT;
 	list_item_append(&result.sched_comp->bsource_list,
 					 &test_data->b1->sink_list);

--- a/test/cmocka/src/audio/pipeline/pipeline_connection_mocks.c
+++ b/test/cmocka/src/audio/pipeline/pipeline_connection_mocks.c
@@ -4,6 +4,7 @@
 //
 // Author: Jakub Dabek <jakub.dabek@linux.intel.com>
 
+#include <sof/audio/ipc-config.h>
 #include "pipeline_connection_mocks.h"
 
 extern struct schedulers *schedulers;
@@ -49,7 +50,7 @@ struct pipeline_connect_data *get_standard_connect_objects(void)
 	list_item_append(&sch->list, &schedulers->list);
 
 	struct comp_dev *first = calloc(sizeof(struct comp_dev), 1);
-	struct sof_ipc_comp *first_comp = dev_comp(first);
+	struct comp_ipc_config *first_comp = &first->ipc_config;
 
 	first_comp->id = 3;
 	first_comp->pipeline_id = PIPELINE_ID_SAME;
@@ -59,7 +60,7 @@ struct pipeline_connect_data *get_standard_connect_objects(void)
 	pipe->sched_comp = first;
 
 	struct comp_dev *second = calloc(sizeof(struct comp_dev), 1);
-	struct sof_ipc_comp *second_comp = dev_comp(second);
+	struct comp_ipc_config *second_comp = &second->ipc_config;
 
 	second_comp->id = 4;
 	second_comp->pipeline_id = PIPELINE_ID_DIFFERENT;

--- a/test/cmocka/src/audio/pipeline/pipeline_free.c
+++ b/test/cmocka/src/audio/pipeline/pipeline_free.c
@@ -7,6 +7,7 @@
 #include <stdint.h>
 #include <sof/audio/component.h>
 #include <sof/audio/pipeline.h>
+#include <sof/audio/ipc-config.h>
 #include <sof/schedule/edf_schedule.h>
 #include <sof/schedule/task.h>
 #include "pipeline_connection_mocks.h"
@@ -87,8 +88,8 @@ static void test_audio_pipeline_free_disconnect_full(void **state)
 {
 	struct pipeline_connect_data *test_data = *state;
 	struct pipeline result = test_data->p;
-	struct sof_ipc_comp *first_comp;
-	struct sof_ipc_comp *second_comp;
+	struct comp_ipc_config *first_comp;
+	struct comp_ipc_config *second_comp;
 
 	cleanup_test_data(test_data);
 
@@ -96,8 +97,8 @@ static void test_audio_pipeline_free_disconnect_full(void **state)
 	result.source_comp = test_data->first;
 	test_data->first->pipeline = &result;
 	test_data->second->pipeline = &result;
-	first_comp = dev_comp(test_data->first);
-	second_comp = dev_comp(test_data->second);
+	first_comp = &test_data->first->ipc_config;
+	second_comp = &test_data->second->ipc_config;
 	second_comp->pipeline_id = PIPELINE_ID_SAME;
 	first_comp->pipeline_id = PIPELINE_ID_SAME;
 	test_data->b1->source = test_data->first;

--- a/test/cmocka/src/audio/selector/selector_test.c
+++ b/test/cmocka/src/audio/selector/selector_test.c
@@ -46,7 +46,7 @@ static int setup(void **state)
 	sel_state = test_malloc(sizeof(*sel_state));
 
 	/* allocate and set new device */
-	sel_state->dev = test_malloc(COMP_SIZE(struct sof_ipc_comp_volume));
+	sel_state->dev = test_malloc(sizeof(struct comp_dev));
 	sel_state->dev->frames = parameters->frames;
 
 	list_init(&sel_state->dev->bsink_list);

--- a/test/cmocka/src/audio/volume/volume_process.c
+++ b/test/cmocka/src/audio/volume/volume_process.c
@@ -58,14 +58,14 @@ static int setup(void **state)
 {
 	struct vol_test_parameters *parameters = *state;
 	struct vol_test_state *vol_state;
-	struct comp_data *cd;
+	struct vol_data *cd;
 	uint32_t size = 0;
 
 	/* allocate new state */
 	vol_state = test_malloc(sizeof(*vol_state));
 
 	/* allocate and set new device */
-	vol_state->dev = test_malloc(COMP_SIZE(struct sof_ipc_comp_volume));
+	vol_state->dev = test_malloc(sizeof(struct comp_dev));
 	vol_state->dev->frames = parameters->frames;
 
 	/* allocate and set new data */
@@ -105,7 +105,7 @@ static int setup(void **state)
 static int teardown(void **state)
 {
 	struct vol_test_state *vol_state = *state;
-	struct comp_data *cd = comp_get_drvdata(vol_state->dev);
+	struct vol_data *cd = comp_get_drvdata(vol_state->dev);
 
 	/* free everything */
 	test_free(cd);
@@ -136,7 +136,7 @@ static void fill_source_s16(struct vol_test_state *vol_state)
 static void verify_s16_to_s16(struct comp_dev *dev, struct comp_buffer *sink,
 			      struct comp_buffer *source)
 {
-	struct comp_data *cd = comp_get_drvdata(dev);
+	struct vol_data *cd = comp_get_drvdata(dev);
 	const int16_t *src = (int16_t *)source->stream.r_ptr;
 	const int16_t *dst = (int16_t *)sink->stream.w_ptr;
 	double processed;
@@ -186,7 +186,7 @@ static void verify_s24_to_s24_s32(struct comp_dev *dev,
 				  struct comp_buffer *sink,
 				  struct comp_buffer *source)
 {
-	struct comp_data *cd = comp_get_drvdata(dev);
+	struct vol_data *cd = comp_get_drvdata(dev);
 	const int32_t *src = (int32_t *)source->stream.r_ptr;
 	const int32_t *dst = (int32_t *)sink->stream.w_ptr;
 	double processed;
@@ -243,7 +243,7 @@ static void verify_s32_to_s24_s32(struct comp_dev *dev,
 				  struct comp_buffer *sink,
 				  struct comp_buffer *source)
 {
-	struct comp_data *cd = comp_get_drvdata(dev);
+	struct vol_data *cd = comp_get_drvdata(dev);
 	double processed;
 	const int32_t *src = (int32_t *)source->stream.r_ptr;
 	const int32_t *dst = (int32_t *)sink->stream.w_ptr;
@@ -286,7 +286,7 @@ static void verify_s32_to_s24_s32(struct comp_dev *dev,
 static void verify_s16_to_sX(struct comp_dev *dev, struct comp_buffer *sink,
 			     struct comp_buffer *source)
 {
-	struct comp_data *cd = comp_get_drvdata(dev);
+	struct vol_data *cd = comp_get_drvdata(dev);
 	const int16_t *src = (int16_t *)source->r_ptr;
 	const int32_t *dst = (int32_t *)sink->w_ptr;
 	double processed;
@@ -331,7 +331,7 @@ static void verify_s16_to_sX(struct comp_dev *dev, struct comp_buffer *sink,
 static void verify_sX_to_s16(struct comp_dev *dev, struct comp_buffer *sink,
 			     struct comp_buffer *source)
 {
-	struct comp_data *cd = comp_get_drvdata(dev);
+	struct vol_data *cd = comp_get_drvdata(dev);
 	const int32_t *src = (int32_t *)source->r_ptr;
 	const int16_t *dst = (int16_t *)sink->w_ptr;
 	double processed;
@@ -372,7 +372,7 @@ static void verify_sX_to_s16(struct comp_dev *dev, struct comp_buffer *sink,
 static void test_audio_vol(void **state)
 {
 	struct vol_test_state *vol_state = *state;
-	struct comp_data *cd = comp_get_drvdata(vol_state->dev);
+	struct vol_data *cd = comp_get_drvdata(vol_state->dev);
 
 	switch (vol_state->sink->stream.frame_fmt) {
 	case SOF_IPC_FRAME_S16_LE:

--- a/tools/testbench/include/testbench/file.h
+++ b/tools/testbench/include/testbench/file.h
@@ -47,14 +47,4 @@ struct file_comp_data {
 
 };
 
-/* file IO ipc comp */
-struct sof_ipc_comp_file {
-	struct sof_ipc_comp comp;
-	struct sof_ipc_comp_config config;
-	uint32_t rate;
-	uint32_t channels;
-	char *fn;
-	enum file_mode mode;
-	enum sof_ipc_frame frame_fmt;
-} __attribute__((packed, aligned(4)));
 #endif


### PR DESCRIPTION
Make sure component creation is not tightly coupled to a particular IPC
version. This is mostly a mechanical change of structures being passed
to the comp creation APIs away from IPC specific to general structures.
    
High level changes
      
1) Pass a common component data object and a component
specific data object during create().
    
2) Mark the component IPC derived data as "ipc_config" within the
component device to help developers track the data source origin.
    
3) Pass component specific data during creation so that componets
can allocate and copy to thier private data.
    
4) Comp_dev no longer has component specific data appended to it.
Instead we can store all in the comp private data (and hence use the
compiler to access it rather than by developer access methods).
    
Signed-off-by: Liam Girdwood <liam.r.girdwood@linux.intel.com>
