### PR TITLE
numbers.h: simplify #ifndef ZEPHYR for MIN and MAX

### DIFF
--- a/src/include/sof/math/numbers.h
+++ b/src/include/sof/math/numbers.h
@@ -12,20 +12,13 @@
 
 #include <stdint.h>
 
-/* Zephyr defines this - remove local copy once Zephyr integration complete */
-#ifdef MIN
-#undef MIN
-#endif
+#ifndef __ZEPHYR__
 /* Unsafe and portable macros for consistency with Zephyr.
  * See SEI CERT-C PRE31-C
  */
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
-
-/* Zephyr defines this - remove local copy once Zephyr integration complete */
-#ifdef MAX
-#undef MAX
-#endif
 #define MAX(a, b) ((a) < (b) ? (b) : (a))
+#endif /* ! __ZEPHYR__ */
 
 #define ABS(a) ({		\
 	typeof(a) __a = (a);	\


### PR DESCRIPTION
Undefining and re-defining MIN/MAX when already defined is
convoluted. Simply define them if not `__ZEPHYR__` instead.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>