### PR TITLE
[SKIP CI] build-zephyr.sh: don't update rimage every time we run

### DIFF
--- a/scripts/xtensa-build-zephyr.sh
+++ b/scripts/xtensa-build-zephyr.sh
@@ -177,7 +177,7 @@ main()
 
 		# Support for submodules in west is too recent, cannot
 		# rely on it
-		test -d "${WEST_TOP}"/modules/audio/sof/rimage/CMakeLists.txt || (
+		test -e "${WEST_TOP}"/modules/audio/sof/rimage/CMakeLists.txt || (
 		    cd "${WEST_TOP}"/modules/audio/sof
 		    git submodule update --init --recursive
 		)


### PR DESCRIPTION
Fixes 33c5f5d38e ("xtensa-build-zephyr: do not clone a second version of
sof.git")

The very first version of this test was checking whether the rimage/
directory exists, which proves nothing. So I switched to
rimage/CMakelists.txt but forgot change the `test` flag.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>