### PR TITLE
xtensa-build-zephyr.sh: show zephyr short git log / version after clone

### DIFF
--- a/scripts/xtensa-build-zephyr.sh
+++ b/scripts/xtensa-build-zephyr.sh
@@ -58,6 +58,8 @@ clone()
 	mkdir -p "$WEST_TOP"
 	git clone --depth=5 https://github.com/zephyrproject-rtos/zephyr \
 	    "$WEST_TOP"/zephyr
+	git -C "$WEST_TOP"/zephyr --no-pager log --oneline --graph \
+	    --decorate --max-count=20
 	west init -l "${WEST_TOP}"/zephyr
 	( cd "${WEST_TOP}"
 	  mkdir -p modules/audio


### PR DESCRIPTION
By default, the Zephyr build does not log its version. The fix has
already been submitted at
https://github.com/zephyrproject-rtos/zephyr/pull/34842 however:

- 34842 may take some time. Zephyr reviewers are even busier than the
  SOF reviewer.
- 34842 could even be rejected
- 34842 will at best log the SHA1 and no context. This is more verbose
  and future-proof because it supports more complex situations like
  testing a pull/12345/merge

As seen in (unrelated) PR #4123, we need Zephyr git versions NOW.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>