### PR TITLE
cadence codecs: update stream params

### DIFF
--- a/src/include/sof/audio/codec_adapter/codec/cadence.h
+++ b/src/include/sof/audio/codec_adapter/codec/cadence.h
@@ -36,6 +36,12 @@ struct cadence_api {
 	xa_codec_func_t *api;
 };
 
+enum default_stream_params_ids {
+	CADENCE_SAMPLE_RATE_ID		= 1,
+	CADENCE_SAMPLE_WIDTH_ID		= 2,
+	CADENCE_CHANNELS_COUNT_ID	= 4,
+};
+
 struct cadence_codec_data {
 	char name[LIB_NAME_MAX_LEN];
 	void *self;


### PR DESCRIPTION
This patch takes care of the update of stream
parameters during runtime. It is important to
start stream base on its runtime params and not
those read from the topology which may not match
those of stream.

For now we only take care of sample rate, sample width and number of
channels.

Notice that Cadence API has the following particularities:
	* each codec has its own set of parameters IDs (e.g sample rate
	  ID for AAC might be different for sample rate ID for MP3).
	* setting parameters is not always valid and can return a fatal
	  error.

This patch only takes care of updating the parameters for wildcard codec
id (which is used by Intel).

Signed-off-by: Marcin Rajwa <marcin.rajwa@linux.intel.com>
Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>