### PR TITLE
zephyr: fixes to kpb and sample-smart-amp components

### DIFF
--- a/src/samples/audio/smart_amp_test.c
+++ b/src/samples/audio/smart_amp_test.c
@@ -570,7 +570,7 @@ static SHARED_DATA struct comp_driver_info comp_smart_amp_info = {
 	.drv = &comp_smart_amp,
 };
 
-static void sys_comp_smart_amp_init(void)
+UT_STATIC void sys_comp_smart_amp_init(void)
 {
 	comp_register(platform_shared_get(&comp_smart_amp_info,
 					  sizeof(comp_smart_amp_info)));

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -479,6 +479,10 @@ zephyr_library_sources_ifdef(CONFIG_COMP_SRC
 	${SOF_AUDIO_PATH}/src/src.c
 )
 
+zephyr_library_sources_ifdef(CONFIG_SAMPLE_SMART_AMP
+	${SOF_SAMPLES_PATH}/audio/smart_amp_test.c
+)
+
 zephyr_library_sources_ifdef(CONFIG_COMP_MUX
 	${SOF_AUDIO_PATH}/mux/mux.c
 	${SOF_AUDIO_PATH}/mux/mux_generic.c

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -397,6 +397,7 @@ void sys_comp_keyword_init(void);
 void sys_comp_asrc_init(void);
 void sys_comp_dcblock_init(void);
 void sys_comp_eq_iir_init(void);
+void sys_comp_kpb_init(void);
 void sys_comp_smart_amp_init(void);
 
 int task_main_start(struct sof *sof)
@@ -450,6 +451,10 @@ int task_main_start(struct sof *sof)
 
 	if (IS_ENABLED(CONFIG_SAMPLE_KEYPHRASE)) {
 		sys_comp_keyword_init();
+	}
+
+	if (IS_ENABLED(CONFIG_COMP_KPB)) {
+		sys_comp_kpb_init();
 	}
 
 	if (IS_ENABLED(CONFIG_SAMPLE_SMART_AMP)) {

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -397,6 +397,7 @@ void sys_comp_keyword_init(void);
 void sys_comp_asrc_init(void);
 void sys_comp_dcblock_init(void);
 void sys_comp_eq_iir_init(void);
+void sys_comp_smart_amp_init(void);
 
 int task_main_start(struct sof *sof)
 {
@@ -449,6 +450,10 @@ int task_main_start(struct sof *sof)
 
 	if (IS_ENABLED(CONFIG_SAMPLE_KEYPHRASE)) {
 		sys_comp_keyword_init();
+	}
+
+	if (IS_ENABLED(CONFIG_SAMPLE_SMART_AMP)) {
+		sys_comp_smart_amp_init();
 	}
 
 	if (IS_ENABLED(CONFIG_COMP_ASRC)) {


### PR DESCRIPTION
Properly include these components in Zephyr based builds (if enabled in kconfig).