### PR TITLE
[SKIP CI] xtensa-build-zephyr: add mkdir -p modules/audio

### DIFF
--- a/scripts/xtensa-build-zephyr.sh
+++ b/scripts/xtensa-build-zephyr.sh
@@ -28,7 +28,7 @@ print_usage()
 {
     cat <<EOF
 Re-configures and re-builds SOF with Zephyr using a pre-installed Zephyr toolchain and
-platform's _defconfig file.
+the _defconfig file for that platform.
 
 usage: $0 [options] platform(s)
 
@@ -174,8 +174,10 @@ main()
 		clone
 	else
 		# Link to ourselves if no sof module yet
-		test -e "${WEST_TOP}"/modules/audio/sof ||
+		test -e "${WEST_TOP}"/modules/audio/sof || {
+		    mkdir -p "${WEST_TOP}"/modules/audio
 		    ln -s "$SOF_TOP" "${WEST_TOP}"/modules/audio/sof
+		}
 
 		# Support for submodules in west is too recent, cannot
 		# rely on it


### PR DESCRIPTION
More robust support for "manual" installations.

Also rephrase usage string to remove a single quote breaking
the shell parser in one editor I use (sorry).

Signed-off-by: Marc Herbert <marc.herbert@intel.com>