### PR TITLE
topology: adding IIR component on max98373-rt5682 topology

### DIFF
--- a/tools/topology/CMakeLists.txt
+++ b/tools/topology/CMakeLists.txt
@@ -131,6 +131,7 @@ set(TPLGS
 	"sof-tgl-max98373-rt5682\;sof-tgl-max98373-rt5682\;-DAMP_SSP=1"
 	"sof-tgl-max98373-rt5682\;sof-tgl-max98373-rt5682-xperi\;-DAMP_SSP=1\;-DINCLUDE_IIR_EQ=1"
 	"sof-tgl-max98373-rt5682\;sof-tgl-rt5682-ssp0-max98373-ssp2\;-DAMP_SSP=2"
+	"sof-tgl-max98373-rt5682\;sof-tgl-rt5682-ssp0-max98373-ssp2-xperi\;-DAMP_SSP=2\;-DINCLUDE_IIR_EQ=1"
 	"sof-tgl-sdw-max98373-rt5682\;sof-tgl-sdw-max98373-rt5682-2ch\;-DCHANNELS=2"
 	"sof-tgl-sdw-max98373-rt5682\;sof-tgl-sdw-max98373-rt5682-4ch\;-DCHANNELS=4"
 	"sof-jsl-da7219\;sof-jsl-da7219\;-DPLATFORM=jsl"


### PR DESCRIPTION
Builds a configuration of the max98373-rt5682 topology with AMP_SSP=2
defined and includes the IIR component

Signed-off-by: Ross Chisholm <ross.chisholm@xperi.com>