### PR TITLE
audio: add UT_STATIC to crossover and smart_amp

### DIFF
--- a/src/audio/crossover/crossover.c
+++ b/src/audio/crossover/crossover.c
@@ -21,6 +21,7 @@
 #include <sof/platform.h>
 #include <sof/string.h>
 #include <sof/trace/trace.h>
+#include <sof/ut.h>
 #include <ipc/control.h>
 #include <ipc/stream.h>
 #include <ipc/topology.h>
@@ -868,7 +869,7 @@ static SHARED_DATA struct comp_driver_info comp_crossover_info = {
 	.drv = &comp_crossover,
 };
 
-static void sys_comp_crossover_init(void)
+UT_STATIC void sys_comp_crossover_init(void)
 {
 	comp_register(platform_shared_get(&comp_crossover_info,
 					  sizeof(comp_crossover_info)));

--- a/src/audio/smart_amp/smart_amp.c
+++ b/src/audio/smart_amp/smart_amp.c
@@ -775,7 +775,7 @@ static SHARED_DATA struct comp_driver_info comp_smart_amp_info = {
 	.drv = &comp_smart_amp,
 };
 
-static void sys_comp_smart_amp_init(void)
+UT_STATIC void sys_comp_smart_amp_init(void)
 {
 	comp_register(platform_shared_get(&comp_smart_amp_info,
 					  sizeof(comp_smart_amp_info)));


### PR DESCRIPTION
Still a few component in main without UT_STATIC.