### PR TITLE
Zephyr scheduling fixes

### DIFF
--- a/src/arch/xtensa/include/arch/lib/cache.h
+++ b/src/arch/xtensa/include/arch/lib/cache.h
@@ -20,10 +20,15 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#define SRAM_UNCACHED_ALIAS	0x20000000
+
+#define is_cached(address) (!!((uintptr_t)(address) & SRAM_UNCACHED_ALIAS))
+
 static inline void dcache_writeback_region(void *addr, size_t size)
 {
 #if XCHAL_DCACHE_SIZE > 0
-	xthal_dcache_region_writeback(addr, size);
+	if (is_cached(addr))
+		xthal_dcache_region_writeback(addr, size);
 #endif
 }
 
@@ -37,7 +42,8 @@ static inline void dcache_writeback_all(void)
 static inline void dcache_invalidate_region(void *addr, size_t size)
 {
 #if XCHAL_DCACHE_SIZE > 0
-	xthal_dcache_region_invalidate(addr, size);
+	if (is_cached(addr))
+		xthal_dcache_region_invalidate(addr, size);
 #endif
 }
 
@@ -65,7 +71,8 @@ static inline void icache_invalidate_all(void)
 static inline void dcache_writeback_invalidate_region(void *addr, size_t size)
 {
 #if XCHAL_DCACHE_SIZE > 0
-	xthal_dcache_region_writeback_inv(addr, size);
+	if (is_cached(addr))
+		xthal_dcache_region_writeback_inv(addr, size);
 #endif
 }
 

--- a/src/platform/intel/cavs/include/cavs/lib/memory.h
+++ b/src/platform/intel/cavs/include/cavs/lib/memory.h
@@ -77,7 +77,7 @@ struct sof;
  * uncached memory region. SMP platforms without uncache can simply
  * align to cache line size instead.
  */
-#if CONFIG_CORE_COUNT > 1 && !defined(UNIT_TEST)
+#if CONFIG_CORE_COUNT > 1 && !defined(UNIT_TEST) && !defined __ZEPHYR__
 #define SHARED_DATA	__section(".shared_data")
 #else
 #define SHARED_DATA
@@ -112,7 +112,7 @@ struct sof;
  */
 static inline void *platform_shared_get(void *ptr, int bytes)
 {
-#if CONFIG_CORE_COUNT > 1
+#if CONFIG_CORE_COUNT > 1 && !defined __ZEPHYR__
 	dcache_invalidate_region(ptr, bytes);
 	return cache_to_uncache(ptr);
 #else

--- a/src/platform/intel/cavs/include/cavs/lib/memory.h
+++ b/src/platform/intel/cavs/include/cavs/lib/memory.h
@@ -85,7 +85,7 @@ struct sof;
 
 #define SRAM_ALIAS_BASE		0x9E000000
 #define SRAM_ALIAS_MASK		0xFF000000
-#define SRAM_ALIAS_OFFSET	0x20000000
+#define SRAM_ALIAS_OFFSET	SRAM_UNCACHED_ALIAS
 
 #if !defined UNIT_TEST && !defined __ZEPHYR__
 #define uncache_to_cache(address) \

--- a/src/schedule/timer_domain.c
+++ b/src/schedule/timer_domain.c
@@ -273,7 +273,7 @@ static void timer_domain_set(struct ll_schedule_domain *domain, uint64_t start)
 	/* using K_CYC(ticks_delta - 885) brings "requested - set" to about 180-700
 	 * cycles, audio sounds very slow and distorted.
 	 */
-	ret = k_delayed_work_submit_to_queue(&timer_domain[core].ll_workq[core],
+	ret = k_delayed_work_submit_to_queue(&timer_domain->ll_workq[core],
 					     &zdata[core].work,
 					     K_CYC(ticks_delta - ZEPHYR_SCHED_COST));
 	if (ret < 0) {


### PR DESCRIPTION
This set of patches allows execution of audio pipelines on secondary cores. A modified pipeline was used to test HDMI playback on core 1 on UP-squared, playback worked correctly.