### PR TITLE
audio: fix igo_nr wrapper code issues.

### DIFF
--- a/src/audio/igo_nr/LICENSE
+++ b/src/audio/igo_nr/LICENSE
@@ -1,0 +1,1 @@
+The AI Noise Reduction Software contained herein is the proprietary intellectual property of British Cayman Islands Intelligo Technology, Inc. All rights reserved. Customer who desires to obtain more information or the license to incorporate this Software into their systems and/or devices may contact Intelligo at support@intelli-go.ai.

--- a/src/audio/igo_nr/igo_nr.c
+++ b/src/audio/igo_nr/igo_nr.c
@@ -220,7 +220,7 @@ static struct comp_dev *igo_nr_new(const struct comp_driver *drv,
 	struct sof_ipc_comp_process *ipc_igo_nr =
 		(struct sof_ipc_comp_process *)comp;
 	struct comp_dev *dev;
-	struct comp_data *cd = NULL;
+	struct comp_data *cd;
 	size_t bs = ipc_igo_nr->size;
 	int32_t ret;
 

--- a/src/audio/igo_nr/igo_nr.c
+++ b/src/audio/igo_nr/igo_nr.c
@@ -29,25 +29,6 @@
 
 #define SOF_IGO_NR_MAX_SIZE 4096		/* Max size for coef data in bytes */
 
-struct IGO_PARAMS {
-	uint32_t igo_params_ver;
-	uint32_t dump_data;
-	uint32_t nr_bypass;
-	uint32_t nr_mode1_en;
-	uint32_t nr_mode3_en;
-	uint32_t nr_ul_enable;
-	uint32_t agc_gain;
-	uint32_t nr_voice_str;
-	uint32_t nr_level;
-	uint32_t nr_mode1_floor;
-	uint32_t nr_mode1_od;
-	uint32_t nr_mode1_pp_param7;
-	uint32_t nr_mode1_pp_param8;
-	uint32_t nr_mode1_pp_param10;
-	uint32_t nr_mode3_floor;
-	uint32_t nr_mode1_pp_param53;
-} __attribute__((packed));
-
 enum IGO_NR_ENUM {
 	IGO_NR_ONOFF_SWITCH = 0,
 	IGO_NR_ENUM_LAST,

--- a/src/audio/igo_nr/igo_nr.c
+++ b/src/audio/igo_nr/igo_nr.c
@@ -551,10 +551,9 @@ static void igo_nr_process(struct comp_dev *dev,
 static void igo_nr_get_igo_params(struct comp_dev *dev)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
-
 	struct sof_igo_nr_config *p_config = comp_get_data_blob(cd->model_handler, NULL, NULL);
-	comp_info(dev, "igo_nr_get_igo_params()");
 
+	comp_info(dev, "igo_nr_get_igo_params()");
 	if (p_config) {
 		cd->config = *p_config;
 

--- a/src/audio/igo_nr/igo_nr.c
+++ b/src/audio/igo_nr/igo_nr.c
@@ -421,20 +421,6 @@ static int32_t igo_nr_cmd_get_value(struct comp_dev *dev, struct sof_ipc_ctrl_da
 	int32_t ret = 0;
 
 	switch (cdata->cmd) {
-	case SOF_CTRL_CMD_ENUM:
-		comp_info(dev, "igo_nr_cmd_get_value(), SOF_CTRL_CMD_ENUM index=%d", cdata->index);
-		switch (cdata->index) {
-		case IGO_NR_ONOFF_SWITCH:
-			for (j = 0; j < cdata->num_elems; j++)
-				cdata->chanv[j].value = cd->process_enable[j];
-			break;
-		default:
-			comp_err(dev, "igo_nr_cmd_get_value() error: invalid cdata->index %d",
-				 cdata->index);
-			ret = -EINVAL;
-			break;
-		}
-		break;
 	case SOF_CTRL_CMD_SWITCH:
 		for (j = 0; j < cdata->num_elems; j++) {
 			cdata->chanv[j].channel = j;
@@ -501,19 +487,6 @@ static int32_t igo_nr_cmd_set_value(struct comp_dev *dev, struct sof_ipc_ctrl_da
 	int32_t ret;
 
 	switch (cdata->cmd) {
-	case SOF_CTRL_CMD_ENUM:
-		comp_dbg(dev, "igo_nr_cmd_set_value(), SOF_CTRL_CMD_ENUM index=%d", cdata->index);
-		switch (cdata->index) {
-		case IGO_NR_ONOFF_SWITCH:
-			ret = igo_nr_set_chan(dev, cdata);
-			break;
-		default:
-			comp_err(dev, "igo_nr_cmd_set_value() error: invalid cdata->index %d",
-				 cdata->index);
-			ret = -EINVAL;
-			break;
-		}
-		break;
 	case SOF_CTRL_CMD_SWITCH:
 		comp_dbg(dev, "igo_nr_cmd_set_value(), SOF_CTRL_CMD_SWITCH, cdata->comp_id = %u",
 			 cdata->comp_id);

--- a/src/include/user/igo_nr.h
+++ b/src/include/user/igo_nr.h
@@ -10,6 +10,25 @@
 
 #include <stdint.h>
 
+struct IGO_PARAMS {
+	uint32_t igo_params_ver;
+	uint32_t dump_data;
+	uint32_t nr_bypass;
+	uint32_t nr_mode1_en;
+	uint32_t nr_mode3_en;
+	uint32_t nr_ul_enable;
+	uint32_t agc_gain;
+	uint32_t nr_voice_str;
+	uint32_t nr_level;
+	uint32_t nr_mode1_floor;
+	uint32_t nr_mode1_od;
+	uint32_t nr_mode1_pp_param7;
+	uint32_t nr_mode1_pp_param8;
+	uint32_t nr_mode1_pp_param10;
+	uint32_t nr_mode3_floor;
+	uint32_t nr_mode1_pp_param53;
+} __attribute__((packed));
+
 struct sof_igo_nr_config {
 	/* reserved */
 	struct IGO_PARAMS igo_params;


### PR DESCRIPTION
This PR resolved the issues in #4017 and added license file.
1. Removed NULL assignment of cd `(L223: igo_nr.c)`
2. Removed ENUM in `igo_nr_cmd_get_value` and `igo_nr_cmd_set_value`
3. Added new line in L556:igo_nr.c
4. Moved `struct IGO_PARAMS` from `igo_nr.c` to `igo_nr.h` since `sof_igo_nr_config` needs it.
5. Added license file.

Signed-off-by: fy.tsuo <fy.tsuo@intelli-go.com>