### PR TITLE
topology: add missing configuration for byt-max98080

### DIFF
--- a/tools/topology/CMakeLists.txt
+++ b/tools/topology/CMakeLists.txt
@@ -61,6 +61,7 @@ set(TPLGS
 	"sof-byt-codec\;sof-cht-cx2072x\;-DCODEC=CX2072X\;-DPLATFORM=cht-codec\;-DSSP_NUM=2"
 	"sof-byt-codec\;sof-cht-es8316\;-DCODEC=ES8316\;-DPLATFORM=cht-codec\;-DSSP_NUM=2"
 	"sof-byt-codec\;sof-cht-nau8824\;-DCODEC=NAU8824\;-DPLATFORM=cht-codec\;-DSSP_NUM=2"
+	"sof-cht-max98090\;sof-byt-max98090\;-DCODEC=MAX98090\;-DPLATFORM=byt-codec\;-DSSP_NUM=2"
 	"sof-cht-max98090\;sof-cht-max98090\;-DCODEC=MAX98090\;-DPLATFORM=cht-codec\;-DSSP_NUM=2"
 	"sof-cnl-rt274\;sof-cnl-rt274"
 	"sof-apl-tdf8532\;sof-apl-tdf8532"


### PR DESCRIPTION
Somehow we only support this configuration for BYT, but there are
Baytrail devices using the same codec.

BugLink: https://github.com/thesofproject/sof/issues/4160
Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>