### PR TITLE
[WIP] codec_adapter: cadence: rework of reset & free procedures

### DIFF
--- a/src/audio/codec_adapter/codec/cadence.c
+++ b/src/audio/codec_adapter/codec/cadence.c
@@ -504,14 +504,13 @@ int cadence_codec_apply_config(struct comp_dev *dev)
 int cadence_codec_reset(struct comp_dev *dev)
 {
 	int ret;
-	/* Current CADENCE API doesn't support reset of codec's
-	 * runtime parameters therefore we need to free all the resources
-	 * and start over.
-	 */
-	codec_free_all_memory(dev);
-	ret = cadence_codec_init(dev);
-	if (ret) {
-		comp_err(dev, "cadence_codec_reset() error %x: could not reinitialize codec after reset",
+	struct codec_data *codec = comp_get_codec(dev);
+	struct cadence_codec_data *cd = codec->private;
+
+	API_CALL(cd, XA_API_CMD_INIT, XA_CMD_TYPE_INIT_API_PRE_CONFIG_PARAMS,
+		 NULL, ret);
+	if (ret != LIB_NO_ERROR) {
+		comp_err(dev, "cadence_codec_init(): error %x: failed to reset to default values.",
 			 ret);
 	}
 
@@ -520,7 +519,7 @@ int cadence_codec_reset(struct comp_dev *dev)
 
 int cadence_codec_free(struct comp_dev *dev)
 {
-	/* Nothing to do */
+	codec_free_all_memory(dev);
 	return 0;
 }
 


### PR DESCRIPTION
This patch fixes the reset procedure of cadence codecs.

Potential fix for https://github.com/thesofproject/sof/issues/4104, not tested.

Signed-off-by: Marcin Rajwa <marcin.rajwa@linux.intel.com>