### PR TITLE
audio: Fix codec adapter submenu display

### DIFF
--- a/src/audio/Kconfig
+++ b/src/audio/Kconfig
@@ -344,6 +344,8 @@ config COMP_CODEC_ADAPTER
 	  "src\include\sof\audio\codec_adapter\interfaces.h". It is possible to link several
 	  different codecs and use them in parallel.
 
+rsource "codec_adapter/Kconfig"
+
 config COMP_IGO_NR
 	bool "IGO NR component"
 	default n
@@ -351,8 +353,6 @@ config COMP_IGO_NR
 	  This option enables Intelligo non-speech noise reduction. The feature links to a proprietary
 	  binary libigonr.a that currently is supported on different Xtensa DSP platforms. Please email
 	  support@intelli-go.ai for any questions about the binary.
-
-rsource "codec_adapter/Kconfig"
 
 endmenu # "Audio components"
 


### PR DESCRIPTION
Without this patch codec adapter submenu is displayed after IGO NR
component resulting in something like this:

    [*] Codec adapter
    [*] IGO NR components
      Codec adapter codecs

After this patch is applied the display will be as expected:

    [*] Codec adapter
      Codec adapter codecs
    [*] IGO NR components

Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>