### PR TITLE
imx: invalidate cache for specific address range only

### DIFF
--- a/src/platform/imx8/imx8.x.in
+++ b/src/platform/imx8/imx8.x.in
@@ -156,6 +156,13 @@ _memmap_cacheattr_bp_strict = 0x22F22FFF;
 _memmap_cacheattr_wb_allvalid = 0x44224222;
 _memmap_cacheattr_wt_allvalid = 0x11221222;
 _memmap_cacheattr_bp_allvalid = 0x22222222;
+/*
+ * Every 512M in 4GB space has dedicate cache attribute.
+ * 1: write through
+ * 2: cache bypass
+ * 4: write back
+ * F: invalid access
+ */
 _memmap_cacheattr_imx8_wt_allvalid = 0x22212222;
 PROVIDE(_memmap_cacheattr_reset = _memmap_cacheattr_imx8_wt_allvalid);
 

--- a/src/platform/imx8m/imx8m.x.in
+++ b/src/platform/imx8m/imx8m.x.in
@@ -156,6 +156,13 @@ _memmap_cacheattr_bp_strict = 0x22F22FFF;
 _memmap_cacheattr_wb_allvalid = 0x44224222;
 _memmap_cacheattr_wt_allvalid = 0x11221222;
 _memmap_cacheattr_bp_allvalid = 0x22222222;
+/*
+ * Every 512M in 4GB space has dedicate cache attribute.
+ * 1: write through
+ * 2: cache bypass
+ * 4: write back
+ * F: invalid access
+ */
 _memmap_cacheattr_imx8_wt_allvalid = 0x22212222;
 PROVIDE(_memmap_cacheattr_reset = _memmap_cacheattr_imx8_wt_allvalid);
 


### PR DESCRIPTION
The _memmap_cacheattr_reset linker script variable has
dedicate cache attribute for every 512M in 4GB space
1: write through
2: cache bypass
4: write back
F: invalid access

For imx, implement is_cached() based on
_memmap_cacheattr_reset.

Without this fix, when loading a topology we get:
sof-audio-of 556e8000.dsp: error: reply expected 20 got 12 bytes
sof-audio-of 556e8000.dsp: error: ipc error for 0x30010000 size 20
sof-audio-of 556e8000.dsp: error: DSP failed to add widget id 0 type 23 name : PCM0P stream Passthrough Playback 0 reply 0
sof-audio-of 556e8000.dsp: ASoC: failed to load widget PCM0P
sof-audio-of 556e8000.dsp: ASoC: topology: could not load header: -22
sof-audio-of 556e8000.dsp: error: tplg component load failed -22
sof-audio-of 556e8000.dsp: error: failed to load DSP topology -22
sof-audio-of 556e8000.dsp: ASoC: error at snd_soc_component_probe on 556e8000.dsp: -22
sof-audio-of 556e8000.dsp: ASoC: failed to probe component -22
asoc-simple-card sof-sound-wm8960: ASoC: failed to instantiate card -22
asoc-simple-card: probe of sof-sound-wm8960 failed with error -22

That's because, on mailbox_hostbox_read() we don't invalidate cache
before reading the address.

Fixes: bfe7707f37de ("cavs: disable data cache operations on uncached addresses")
Signed-off-by: Iuliana Prodan <iuliana.prodan@nxp.com>