### PR TITLE
[SKIP CI] zephyr/docker-build.sh: remove apt update / install libssl-dev

### DIFF
--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -20,5 +20,5 @@ jobs:
 
       - name: build
         run: docker run -v "$(pwd)":/workdir
-             docker.io/zephyrprojectrtos/zephyr-build:latest
+             docker.io/zephyrprojectrtos/zephyr-build:v0.17.3
              ./zephyr/docker-build.sh

--- a/zephyr/docker-build.sh
+++ b/zephyr/docker-build.sh
@@ -8,13 +8,7 @@
 set -e
 set -x
 
-# export http_proxy=...
-# export https_proxy=...
-
 unset ZEPHYR_BASE
-
-sudo --preserve-env=http_proxy,https_proxy apt-get update
-sudo --preserve-env=http_proxy,https_proxy apt-get -y install libssl-dev
 
 # Make sure we're in the right place; chgrp -R below.
 test -e ./scripts/xtensa-build-zephyr.sh


### PR DESCRIPTION
2 commits. Main one:


zephyr/docker-build.sh: remove apt update / install libssl-dev

The Zephyr image has been updated in
zephyrproject-rtos/docker-image#58

This will save some time and even better avoid llvm.org
glitches like this one:

https://github.com/thesofproject/sof/pull/4089/checks?check_run_id=2554961695