### PR TITLE
ssp/dai: Dont treat dai_config during active audio as an error

### DIFF
--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -737,8 +737,8 @@ static int dai_config(struct comp_dev *dev, struct sof_ipc_dai_config *config)
 
 	/* cannot configure DAI while active */
 	if (dev->state == COMP_STATE_ACTIVE) {
-		comp_err(dev, "dai_config(): Component is in active state.");
-		return -EINVAL;
+		comp_info(dev, "dai_config(): Component is in active state. Ignore config");
+		return 0;
 	}
 
 	switch (config->type) {

--- a/src/drivers/intel/baytrail/ssp.c
+++ b/src/drivers/intel/baytrail/ssp.c
@@ -100,8 +100,7 @@ static int ssp_set_config(struct dai *dai,
 	/* is playback/capture already running */
 	if (ssp->state[DAI_DIR_PLAYBACK] == COMP_STATE_ACTIVE ||
 	    ssp->state[DAI_DIR_CAPTURE] == COMP_STATE_ACTIVE) {
-		dai_err(dai, "ssp_set_config(): playback/capture already running");
-		ret = -EINVAL;
+		dai_info(dai, "ssp_set_config(): playback/capture active. Ignore config");
 		goto out;
 	}
 

--- a/src/drivers/intel/haswell/ssp.c
+++ b/src/drivers/intel/haswell/ssp.c
@@ -76,8 +76,7 @@ static int ssp_set_config(struct dai *dai,
 	/* is playback/capture already running */
 	if (ssp->state[DAI_DIR_PLAYBACK] == COMP_STATE_ACTIVE ||
 	    ssp->state[DAI_DIR_CAPTURE] == COMP_STATE_ACTIVE) {
-		dai_err(dai, "ssp_set_config(): playback/capture already running");
-		ret = -EINVAL;
+		dai_info(dai, "ssp_set_config(): playback/capture active. Ignore config");
 		goto out;
 	}
 

--- a/src/drivers/intel/ssp/ssp.c
+++ b/src/drivers/intel/ssp/ssp.c
@@ -139,8 +139,7 @@ static int ssp_set_config(struct dai *dai,
 	/* is playback/capture already running */
 	if (ssp->state[DAI_DIR_PLAYBACK] == COMP_STATE_ACTIVE ||
 	    ssp->state[DAI_DIR_CAPTURE] == COMP_STATE_ACTIVE) {
-		dai_info(dai, "ssp_set_config(): playback/capture already running");
-		ret = -EINVAL;
+		dai_info(dai, "ssp_set_config(): playback/capture active. Ignore config");
 		goto out;
 	}
 


### PR DESCRIPTION
When a DAI_CONFIG IPC is sent from the driver for a particular
DAI type and index, all DAI components that match the type and index
are configured. When all components are set up during topology
loading, this isn't really much of a problem as all DAI_CONFIG
IPCs will be sent at that time as well ie there is no active
playback/capture. But with dynamic pipeline loading, the playback
and capture DAIs will be individually configured whenever the
respective pipeline is started. This will end up with errors both
when configuring the SSP and when configuring the DAI comp itself.

So, ignore the request to configure the SSP and the DAI comp
that is already active so that the other DAI comp can be
configured successfully when its pipeline is set up.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>