### PR TITLE
dai: limit number of bytes copied to one period for all directions

### DIFF
--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -1122,12 +1122,13 @@ static int dai_copy(struct comp_dev *dev)
 		src_samples = avail_bytes / sampling;
 		sink_samples = audio_stream_get_free_samples(&buf->stream);
 		samples = MIN(src_samples, sink_samples);
-
-		/* limit bytes per copy to one period for the whole pipeline
-		 * in order to avoid high load spike
-		 */
-		samples = MIN(samples, dd->period_bytes / sampling);
 	}
+
+	/* limit bytes per copy to one period for the whole pipeline
+	 * in order to avoid high load spike
+	 */
+	samples = MIN(samples, dd->period_bytes / sampling);
+
 	copy_bytes = samples * sampling;
 
 	buffer_unlock(buf, flags);


### PR DESCRIPTION
This is similar with:
commit 761bbac5aca6 ("host: dai: limit number of bytes copied to one
period") which limits the number of copied bytes for CAPTURE direction.

This patch does the same thing for PLAYBACK direction.

We need this with codec adapter component that most of the time
will produce more than period_bytes in a period.

DAI will copy more than on period_bytes at a time and this
affects sound quality.

Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>