### PR TITLE
[WIP][RFC] pipeline: move generic mem alloc to pipeline

### DIFF
--- a/src/audio/codec_adapter/codec/waves.c
+++ b/src/audio/codec_adapter/codec/waves.c
@@ -199,7 +199,7 @@ static int waves_effect_allocate(struct comp_dev *dev)
 		return -EINVAL;
 	}
 
-	waves_codec->effect = (MaxxEffect_t *)codec_allocate_memory(dev,
+	waves_codec->effect = (MaxxEffect_t *)pipeline_devm_alloc(dev->pipeline,
 		waves_codec->effect_size, 16);
 
 	if (!waves_codec->effect) {
@@ -375,7 +375,7 @@ static int waves_effect_buffers(struct comp_dev *dev)
 		goto err;
 	}
 
-	response = codec_allocate_memory(dev, waves_codec->response_max_bytes, 16);
+	response = pipeline_devm_alloc(dev->pipeline, waves_codec->response_max_bytes, 16);
 	if (!response) {
 		comp_err(dev, "waves_effect_buffers() failed to allocate %d bytes for response",
 			 waves_codec->response_max_bytes);
@@ -383,7 +383,7 @@ static int waves_effect_buffers(struct comp_dev *dev)
 		goto err;
 	}
 
-	i_buffer = codec_allocate_memory(dev, waves_codec->buffer_bytes, 16);
+	i_buffer = pipeline_devm_alloc(dev->pipeline, waves_codec->buffer_bytes, 16);
 	if (!i_buffer) {
 		comp_err(dev, "waves_effect_buffers() failed to allocate %d bytes for i_buffer",
 			 waves_codec->buffer_bytes);
@@ -391,7 +391,7 @@ static int waves_effect_buffers(struct comp_dev *dev)
 		goto err;
 	}
 
-	o_buffer = codec_allocate_memory(dev, waves_codec->buffer_bytes, 16);
+	o_buffer = pipeline_devm_alloc(dev->pipeline, waves_codec->buffer_bytes, 16);
 	if (!o_buffer) {
 		comp_err(dev, "waves_effect_buffers() failed to allocate %d bytes for o_buffer",
 			 waves_codec->buffer_bytes);
@@ -415,12 +415,6 @@ static int waves_effect_buffers(struct comp_dev *dev)
 	return 0;
 
 err:
-	if (i_buffer)
-		codec_free_memory(dev, i_buffer);
-	if (o_buffer)
-		codec_free_memory(dev, o_buffer);
-	if (response)
-		codec_free_memory(dev, response);
 	return ret;
 }
 
@@ -606,7 +600,7 @@ int waves_codec_init(struct comp_dev *dev)
 
 	comp_dbg(dev, "waves_codec_init() start");
 
-	waves_codec = codec_allocate_memory(dev, sizeof(struct waves_codec_data), 16);
+	waves_codec = pipeline_devm_alloc(dev->pipeline, sizeof(struct waves_codec_data), 16);
 	if (!waves_codec) {
 		comp_err(dev, "waves_codec_init() failed to allocate %d bytes for waves_codec_data",
 			 sizeof(struct waves_codec_data));
@@ -617,7 +611,6 @@ int waves_codec_init(struct comp_dev *dev)
 
 		ret = waves_effect_allocate(dev);
 		if (ret) {
-			codec_free_memory(dev, waves_codec);
 			codec->private = NULL;
 		}
 	}
@@ -756,7 +749,7 @@ int waves_codec_reset(struct comp_dev *dev)
 
 int waves_codec_free(struct comp_dev *dev)
 {
-	/* codec is using codec_adapter method codec_allocate_memory for all allocations
+	/* codec is using codec_adapter method pipeline_devm_alloc for all allocations
 	 * codec_adapter will free it all on component free call
 	 * nothing to do here
 	 */

--- a/src/include/sof/audio/codec_adapter/codec/generic.h
+++ b/src/include/sof/audio/codec_adapter/codec/generic.h
@@ -184,15 +184,6 @@ struct codec_config {
 };
 
 /**
- * \struct codec_memory
- * \brief codec memory block - used for every memory allocated by codec
- */
-struct codec_memory {
-	void *ptr; /**< A pointr to particular memory block */
-	struct list_item mem_list; /**< list of memory allocated by codec */
-};
-
-/**
  * \struct codec_processing_data
  * \brief Processing data shared between particular codec & codec_adapter
  */
@@ -216,7 +207,6 @@ struct codec_data {
 	struct codec_config s_cfg; /**< setup config */
 	struct codec_config r_cfg; /**< runtime config */
 	struct codec_interface *ops; /**< codec specific operations */
-	struct codec_memory memory; /**< memory allocated by codec */
 	struct codec_processing_data cpd; /**< shared data comp <-> codec */
 };
 
@@ -238,10 +228,6 @@ struct comp_data {
 int codec_load_config(struct comp_dev *dev, void *cfg, size_t size,
 		      enum codec_cfg_type type);
 int codec_init(struct comp_dev *dev, struct codec_interface *interface);
-void *codec_allocate_memory(struct comp_dev *dev, uint32_t size,
-			    uint32_t alignment);
-int codec_free_memory(struct comp_dev *dev, void *ptr);
-void codec_free_all_memory(struct comp_dev *dev);
 int codec_prepare(struct comp_dev *dev);
 int codec_get_samples(struct comp_dev *dev);
 int codec_init_process(struct comp_dev *dev);

--- a/src/include/sof/audio/pipeline.h
+++ b/src/include/sof/audio/pipeline.h
@@ -38,6 +38,15 @@ struct task;
 #define PPL_DIR_DOWNSTREAM	0
 #define PPL_DIR_UPSTREAM	1
 
+/**
+ * \struct pipe_dev_mem - used in pipeline_devm_alloc
+ * \brief pipe memory block - used for memory allocated by comp
+ */
+struct pipe_dev_mem {
+	void *ptr; /**< A pointr to particular memory block */
+	struct list_item mem_list; /**< list of memory allocated by codec */
+};
+
 /*
  * Audio pipeline.
  */
@@ -73,6 +82,8 @@ struct pipeline {
 	/* position update */
 	uint32_t posn_offset;		/* position update array offset*/
 	struct ipc_msg *msg;
+
+	struct pipe_dev_mem mem;
 };
 
 struct pipeline_walk_context {
@@ -364,5 +375,9 @@ void pipeline_xrun(struct pipeline *p, struct comp_dev *dev, int32_t bytes);
  * \param[in] xrun_limit_usecs Limit in micro secs that pipeline will tolerate.
  */
 int pipeline_xrun_set_limit(struct pipeline *p, uint32_t xrun_limit_usecs);
+
+void *pipeline_devm_alloc(struct pipeline *pipe, uint32_t size, uint32_t alignment);
+
+int pipeline_devm_free(struct pipeline *pipe, void *ptr);
 
 #endif /* __SOF_AUDIO_PIPELINE_H__ */


### PR DESCRIPTION
Codec adapter has a devm_kzalloc type memory allocator to allocate
multiple chunks of memory into a list, which can be then freed without
explicit pointers in codec deletion. Move this generic mechanism to
pipeline class. This is possible as recent changes in driver create the
pipeline before its components.

Signed-off-by: Jaska Uimonen <jaska.uimonen@intel.com>