### PR TITLE
kconfig: clean up DMA related entries at top-level

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -42,11 +42,11 @@ config INTEL_IOMUX
 	bool
 	default n
 
-config HW_LLI
+config DMA_HW_LLI
 	bool
 	default n
 	help
-	  Hardware linked list is the DW-DMA feature, which allows
+	  Hardware linked list is DMA feature, which allows
 	  to automatically reload the next programmed linked list
 	  item from memory without stopping the transfer. Without
 	  it the transfer stops after every lli read and FW needs

--- a/Kconfig
+++ b/Kconfig
@@ -55,18 +55,6 @@ config DMA_HW_LLI
 	  Any platforms with hardware linked list support
 	  should set this.
 
-config DW_DMA_AGGREGATED_IRQ
-	bool
-	default n
-	help
-	  Some platforms cannot register interrupt per DW-DMA channel
-	  and have the possibility only to register interrupts per
-	  DMA controller, which require manual handling of aggregated
-	  irq.
-
-	  Any platforms with DW-DMA aggregated interrupts support
-	  should set this.
-
 config DMA_SUSPEND_DRAIN
 	bool
 	default n

--- a/src/drivers/dw/Kconfig
+++ b/src/drivers/dw/Kconfig
@@ -14,6 +14,18 @@ config DW_DMA
 	help
 	  Select this to enable support for the Designware DMA controller.
 
+config DW_DMA_AGGREGATED_IRQ
+	bool
+	default n
+	help
+	  Some platforms cannot register interrupt per DW-DMA channel
+	  and have the possibility only to register interrupts per
+	  DMA controller, which require manual handling of aggregated
+	  irq.
+
+	  Any platforms with DW-DMA aggregated interrupts support
+	  should set this.
+
 config DW_SPI
 	bool
 	default n

--- a/src/platform/Kconfig
+++ b/src/platform/Kconfig
@@ -78,7 +78,7 @@ config APOLLOLAKE
 	select DW
 	select DW_DMA
 	select MEM_WND
-	select HW_LLI
+	select DMA_HW_LLI
 	select DMA_FIFO_PARTITION
 	select CAVS
 	select CAVS_VERSION_1_5
@@ -93,7 +93,7 @@ config CANNONLAKE
 	select DW
 	select DW_DMA
 	select MEM_WND
-	select HW_LLI
+	select DMA_HW_LLI
 	select DW_DMA_AGGREGATED_IRQ
 	select DMA_FIFO_PARTITION
 	select CAVS
@@ -112,7 +112,7 @@ config SUECREEK
 	select DW_SPI
 	select INTEL_IOMUX
 	select DW_GPIO
-	select HW_LLI
+	select DMA_HW_LLI
 	select DW_DMA_AGGREGATED_IRQ
 	select DMA_FIFO_PARTITION
 	select CAVS
@@ -130,7 +130,7 @@ config ICELAKE
 	select DW
 	select DW_DMA
 	select MEM_WND
-	select HW_LLI
+	select DMA_HW_LLI
 	select DW_DMA_AGGREGATED_IRQ
 	select DMA_FIFO_PARTITION
 	select CAVS
@@ -148,7 +148,7 @@ config TIGERLAKE
 	select DW
 	select DW_DMA
 	select MEM_WND
-	select HW_LLI
+	select DMA_HW_LLI
 	select DW_DMA_AGGREGATED_IRQ
 	select DMA_FIFO_PARTITION
 	select CAVS


### PR DESCRIPTION
Add namespace to DMA related Kconfig options at the top-level Kconfig and move (one) driver-specific options into a more appropriate driver-specific Kconfig.