### PR TITLE
audio: igo_nr: max98373-rt5682: roll back SSP clock setting

### DIFF
--- a/src/audio/igo_nr/igo_nr.c
+++ b/src/audio/igo_nr/igo_nr.c
@@ -359,10 +359,10 @@ static int32_t igo_nr_params(struct comp_dev *dev,
 		 cd->source_rate, cd->sink_rate,
 		 cd->source_frames_max, cd->sink_frames_max);
 
-	/* The igo_nr supports sample rate 16000 only. */
+	/* The igo_nr supports sample rate 48000 only. */
 	switch (sourceb->stream.rate) {
-	case 16000:
-		comp_info(dev, "igo_nr_params(), sample rate = 16000");
+	case 48000:
+		comp_info(dev, "igo_nr_params(), sample rate = 48000");
 		cd->invalid_param = false;
 		break;
 	default:
@@ -663,7 +663,7 @@ static void igo_nr_lib_init(struct comp_dev *dev)
 	cd->igo_stream_data_in.data = cd->in;
 	cd->igo_stream_data_in.data_width = IGO_DATA_16BIT;
 	cd->igo_stream_data_in.sample_num = IGO_FRAME_SIZE;
-	cd->igo_stream_data_in.sampling_rate = 16000;
+	cd->igo_stream_data_in.sampling_rate = 48000;
 
 	cd->igo_stream_data_ref.data = NULL;
 	cd->igo_stream_data_ref.data_width = 0;
@@ -673,7 +673,7 @@ static void igo_nr_lib_init(struct comp_dev *dev)
 	cd->igo_stream_data_out.data = cd->out;
 	cd->igo_stream_data_out.data_width = IGO_DATA_16BIT;
 	cd->igo_stream_data_out.sample_num = IGO_FRAME_SIZE;
-	cd->igo_stream_data_out.sampling_rate = 16000;
+	cd->igo_stream_data_out.sampling_rate = 48000;
 }
 
 static int32_t igo_nr_prepare(struct comp_dev *dev)

--- a/src/include/sof/audio/igo_nr/igo_nr_comp.h
+++ b/src/include/sof/audio/igo_nr/igo_nr_comp.h
@@ -12,7 +12,7 @@
 #include <sof/audio/audio_stream.h>
 #include <sof/audio/igo_nr/igo_lib.h>
 
-#define IGO_FRAME_SIZE (256)
+#define IGO_FRAME_SIZE (768)
 #define IGO_NR_IN_BUF_LENGTH (IGO_FRAME_SIZE)
 #define IGO_NR_OUT_BUF_LENGTH (IGO_FRAME_SIZE)
 

--- a/tools/topology/platform/intel/intel-generic-dmic-kwd.m4
+++ b/tools/topology/platform/intel/intel-generic-dmic-kwd.m4
@@ -49,14 +49,6 @@ ifdef(`IGO',
 # Prolong period to 16ms for igo_nr process
 ifdef(`IGO', `define(`INTEL_GENERIC_DMIC_KWD_PERIOD', 16000)', `define(`INTEL_GENERIC_DMIC_KWD_PERIOD', 1000)')
 
-# PCM is fix 16k for igo_nr
-ifdef(`IGO', `define(`PCM_RATE', 16000)', `define(`PCM_RATE', 48000)')
-
-# DMIC setting for igo_nr
-ifdef(`IGO', `define(`DMIC_CONFIG_CLK_MIN', 500000)', `define(`DMIC_CONFIG_CLK_MIN', 2400000)')
-ifdef(`IGO', `define(`DMIC_CONFIG_CLK_MAX', 1600000)', `define(`DMIC_CONFIG_CLK_MAX', 4800000)')
-ifdef(`IGO', `define(`DMIC_CONFIG_SAMPLE_RATE', 16000)', `define(`DMIC_CONFIG_SAMPLE_RATE', 48000)')
-
 #
 # Define the pipelines
 #
@@ -76,7 +68,7 @@ define(`PGA_NAME', Dmic0)
 
 PIPELINE_PCM_ADD(sof/pipe-`DMICPROC'-capture.m4,
         DMIC_PIPELINE_48k_ID, DMIC_PCM_48k_ID, CHANNELS, s32le,
-        INTEL_GENERIC_DMIC_KWD_PERIOD, 0, 0, PCM_RATE, PCM_RATE, PCM_RATE)
+        INTEL_GENERIC_DMIC_KWD_PERIOD, 0, 0, 48000, 48000, 48000)
 
 undefine(`PGA_NAME')
 undefine(`PIPELINE_FILTER1')
@@ -154,16 +146,16 @@ SectionGraph."pipe-sof-generic-keyword-detect" {
 dnl DAI_CONFIG(type, dai_index, link_id, name, ssp_config/dmic_config)
 ifelse(CHANNELS, 4,
 `DAI_CONFIG(DMIC, 0, DMIC_DAI_LINK_48k_ID, DMIC_DAI_LINK_48k_NAME,
-                DMIC_CONFIG(1, DMIC_CONFIG_CLK_MIN, DMIC_CONFIG_CLK_MAX, 40, 60, DMIC_CONFIG_SAMPLE_RATE,
+                DMIC_CONFIG(1, 2400000, 4800000, 40, 60, 48000,
                 DMIC_WORD_LENGTH(s32le), 200, DMIC, 0,
                 PDM_CONFIG(DMIC, 0, FOUR_CH_PDM0_PDM1)))',
 `DAI_CONFIG(DMIC, 0, DMIC_DAI_LINK_48k_ID, DMIC_DAI_LINK_48k_NAME,
-                DMIC_CONFIG(1, DMIC_CONFIG_CLK_MIN, DMIC_CONFIG_CLK_MAX, 40, 60, DMIC_CONFIG_SAMPLE_RATE,
+                DMIC_CONFIG(1, 2400000, 4800000, 40, 60, 48000,
                 DMIC_WORD_LENGTH(s32le), 200, DMIC, 0,
                 PDM_CONFIG(DMIC, 0, STEREO_PDM0)))')
 
 # dmic16k (ID: 2)
 DAI_CONFIG(DMIC, 1, DMIC_DAI_LINK_16k_ID, DMIC_DAI_LINK_16k_NAME,
-                DMIC_CONFIG(1, DMIC_CONFIG_CLK_MIN, DMIC_CONFIG_CLK_MAX, 40, 60, 16000,
+                DMIC_CONFIG(1, 2400000, 4800000, 40, 60, 16000,
                 DMIC_WORD_LENGTH(s32le), 400, DMIC, 1,
                 PDM_CONFIG(DMIC, 1, STEREO_PDM0)))

--- a/tools/topology/platform/intel/intel-generic-dmic-kwd.m4
+++ b/tools/topology/platform/intel/intel-generic-dmic-kwd.m4
@@ -68,7 +68,7 @@ define(`PGA_NAME', Dmic0)
 
 PIPELINE_PCM_ADD(sof/pipe-`DMICPROC'-capture.m4,
         DMIC_PIPELINE_48k_ID, DMIC_PCM_48k_ID, CHANNELS, s32le,
-        INTEL_GENERIC_DMIC_KWD_PERIOD, 0, 0, 48000, 48000, 48000)
+        INTEL_GENERIC_DMIC_KWD_PERIOD, 0, 1, 48000, 48000, 48000)
 
 undefine(`PGA_NAME')
 undefine(`PIPELINE_FILTER1')
@@ -102,7 +102,7 @@ dnl     deadline, priority, core, time_domain)
 DAI_ADD(sof/pipe-dai-capture.m4,
         DMIC_PIPELINE_48k_ID, DMIC, 0, DMIC_DAI_LINK_48k_NAME,
         concat(`PIPELINE_SINK_', DMIC_PIPELINE_48k_ID), 2, s32le,
-        INTEL_GENERIC_DMIC_KWD_PERIOD, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+        INTEL_GENERIC_DMIC_KWD_PERIOD, 0, 1, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is DMIC 1 using 3 periods
 # Buffers use s32le format, with 320 frame per 20000us on core 0 with priority 0

--- a/tools/topology/sof-tgl-max98373-rt5682.m4
+++ b/tools/topology/sof-tgl-max98373-rt5682.m4
@@ -49,13 +49,7 @@ define(`SMART_SSP_NAME', concat(concat(`SSP', AMP_SSP),`-Codec'))
 #define BE dai_link ID
 define(`SMART_BE_ID', 7)
 #define SSP mclk
-ifdef(`IGO', `define(`SSP_MCLK', 19200000)', `define(`SSP_MCLK', 24576000)')
-#define SSP bclk
-ifdef(`IGO', `define(`SSP_BCLK', 2400000)', `define(`SSP_BCLK', 3072000)')
-#define SSP_TDM_WIDTH
-ifdef(`IGO', `define(`SSP_TDM_WIDTH', 25)', `define(`SSP_TDM_WIDTH', 32)')
-#define SSP_CONFIG_DATA_VALID_BITS
-ifdef(`IGO', `define(`SSP_CONFIG_DATA_VALID_BITS', 24)', `define(`SSP_CONFIG_DATA_VALID_BITS', 32)')
+define(`SSP_MCLK', 24576000)
 # Playback related
 define(`SMART_PB_PPL_ID', 1)
 define(`SMART_PB_CH_NUM', 2)
@@ -236,10 +230,10 @@ dnl ssp1-maxmspk, ssp0-RTHeadset
 #SSP 0 (ID: 0)
 DAI_CONFIG(SSP, 0, 0, SSP0-Codec,
         SSP_CONFIG(I2S, SSP_CLOCK(mclk, SSP_MCLK, codec_mclk_in),
-                      SSP_CLOCK(bclk, SSP_BCLK, codec_slave),
+                      SSP_CLOCK(bclk, 3072000, codec_slave),
                       SSP_CLOCK(fsync, 48000, codec_slave),
-                      SSP_TDM(2, SSP_TDM_WIDTH, 3, 3),
-                      SSP_CONFIG_DATA(SSP, 0, SSP_CONFIG_DATA_VALID_BITS)))
+                      SSP_TDM(2, 32, 3, 3),
+                      SSP_CONFIG_DATA(SSP, 0, 32)))
 
 # 4 HDMI/DP outputs (ID: 3,4,5,6)
 DAI_CONFIG(HDA, 0, 3, iDisp1,


### PR DESCRIPTION
1. Roll back SSP setting from 16K sampling rate to 48K. Meanwhile igo_nr supports 48K-in-48K-out now.
2. Offload igo_nr to core 1.