### PR TITLE
kconfig: move more XTOS-only options out from top-level Kconfig

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -145,12 +145,6 @@ config GDB_DEBUG
 	help
 	  Select for GDB debugging
 
-config DEBUG_HEAP
-	bool "Heap debug"
-	default n
-	help
-	  Select for enable heap alloc debugging
-
 config DEBUG_MEMORY_USAGE_SCAN
 	bool "Memory usage scan"
 	default y
@@ -158,15 +152,6 @@ config DEBUG_MEMORY_USAGE_SCAN
 	  It enables memory usage scan at demand in runtime.
 	  This feature does not affect standard memory operations,
 	  especially allocation and deallocation.
-
-config DEBUG_BLOCK_FREE
-	bool "Blocks freeing debug"
-	default n
-	help
-	  It enables checking if free was called multiple times on
-	  already freed block of memory. Enabling this feature increases
-	  number of memory writes and reads, due to checks for memory patterns
-	  that may be performed on allocation and deallocation.
 
 config DEBUG_LOCKS
 	bool "Spinlock debug"
@@ -217,5 +202,9 @@ config DSP_RESIDENCY_COUNTERS
 	  Enables simple DSP residency counters in SRAM_REG mailbox.
 	  R0, R1, R2 are abstract states which can be used differently
 	  based on platform implementation.
+
+if !ZEPHYR_SOF_MODULE
+	rsource "Kconfig.xtos-dbg"
+endif
 
 endmenu

--- a/Kconfig
+++ b/Kconfig
@@ -169,12 +169,6 @@ config DEBUG_LOCKS_VERBOSE
 	  In addition to DEBUG_LOCKS it also adds spinlock traces
 	  every time the lock is acquired.
 
-config BUILD_VM_ROM
-	bool "Build VM ROM"
-	default n
-	help
-	  Select if you want to build VM ROM
-
 config DEBUG_IPC_COUNTERS
 	bool "IPC counters"
 	depends on CAVS

--- a/Kconfig
+++ b/Kconfig
@@ -127,39 +127,9 @@ config XT_INTERRUPT_LEVEL_5
 
 rsource "src/Kconfig"
 
-choice
-	prompt "Optimization"
-	default OPTIMIZE_FOR_PERFORMANCE
-	help
-	  Controls how compiler should optimize binary.
-	  This config should affect only compiler settings and is
-	  not meant to be used for conditional compilation of code.
-
-config OPTIMIZE_FOR_PERFORMANCE
-	bool "Optimize for performance"
-	help
-	  Apply compiler optimizations prioritizing performance.
-	  It means -O2 for GCC or equivalent for other compilers.
-
-config OPTIMIZE_FOR_SIZE
-	bool "Optimize for size"
-	help
-	  Apply compiler optimizations prioritizing binary size.
-	  It means -Os for GCC or equivalent for other compilers.
-
-config OPTIMIZE_FOR_DEBUG
-	bool "Optimize for debug"
-	help
-	  Apply compiler optimizations prioritizing debugging experience.
-	  It means -Og for GCC or equivalent for other compilers.
-
-config OPTIMIZE_FOR_NONE
-	bool "Don't optimize"
-	help
-	  Apply no compiler optimizations.
-	  It means -O0 for GCC or equivalent for other compilers.
-
-endchoice
+if !ZEPHYR_SOF_MODULE
+	rsource "Kconfig.xtos-build"
+endif
 
 menu "Debug"
 

--- a/Kconfig.xtos-build
+++ b/Kconfig.xtos-build
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+comment "XTOS options / compiler"
+
+choice
+	prompt "Optimization"
+	default OPTIMIZE_FOR_PERFORMANCE
+	help
+	  Controls how compiler should optimize binary.
+	  This config should affect only compiler settings and is
+	  not meant to be used for conditional compilation of code.
+
+config OPTIMIZE_FOR_PERFORMANCE
+	bool "Optimize for performance"
+	help
+	  Apply compiler optimizations prioritizing performance.
+	  It means -O2 for GCC or equivalent for other compilers.
+
+config OPTIMIZE_FOR_SIZE
+	bool "Optimize for size"
+	help
+	  Apply compiler optimizations prioritizing binary size.
+	  It means -Os for GCC or equivalent for other compilers.
+
+config OPTIMIZE_FOR_DEBUG
+	bool "Optimize for debug"
+	help
+	  Apply compiler optimizations prioritizing debugging experience.
+	  It means -Og for GCC or equivalent for other compilers.
+
+config OPTIMIZE_FOR_NONE
+	bool "Don't optimize"
+	help
+	  Apply no compiler optimizations.
+	  It means -O0 for GCC or equivalent for other compilers.
+
+endchoice

--- a/Kconfig.xtos-build
+++ b/Kconfig.xtos-build
@@ -35,3 +35,9 @@ config OPTIMIZE_FOR_NONE
 	  It means -O0 for GCC or equivalent for other compilers.
 
 endchoice
+
+config BUILD_VM_ROM
+	bool "Build VM ROM"
+	default n
+	help
+	  Select if you want to build VM ROM

--- a/Kconfig.xtos-dbg
+++ b/Kconfig.xtos-dbg
@@ -1,0 +1,14 @@
+config DEBUG_HEAP
+	bool "Heap debug"
+	default n
+	help
+	  Select for enable heap alloc debugging
+
+config DEBUG_BLOCK_FREE
+	bool "Blocks freeing debug"
+	default n
+	help
+	  It enables checking if free was called multiple times on
+	  already freed block of memory. Enabling this feature increases
+	  number of memory writes and reads, due to checks for memory patterns
+	  that may be performed on allocation and deallocation.


### PR DESCRIPTION
Some of the top-level Kconfig options are not used at all when SOF is built with another RTOS like the SOF Zephyr module build. 

To make this more explicit at Kconfig level, move these options out from the top-level Kconfig file and exclude when needed.
