### PR TITLE
Abstraction of IPC DAI configuration

### DIFF
--- a/src/drivers/imx/esai.c
+++ b/src/drivers/imx/esai.c
@@ -96,9 +96,10 @@ static int esai_context_restore(struct dai *dai)
 	return 0;
 }
 
-static inline int esai_set_config(struct dai *dai,
-				 struct sof_ipc_dai_config *config)
+static inline int esai_set_config(struct dai *dai, struct ipc_config_dai *common_config,
+				  void *spec_config)
 {
+	struct sof_ipc_dai_config *config = spec_config;
 	uint32_t xcr = 0, xccr = 0, mask;
 	struct esai_pdata *esai = dai_get_drvdata(dai);
 

--- a/src/drivers/imx/sai.c
+++ b/src/drivers/imx/sai.c
@@ -149,10 +149,11 @@ static int sai_context_restore(struct dai *dai)
 	return 0;
 }
 
-static inline int sai_set_config(struct dai *dai,
-				 struct sof_ipc_dai_config *config)
+static inline int sai_set_config(struct dai *dai, struct ipc_config_dai *common_config,
+				 void *spec_config)
 {
 	dai_info(dai, "SAI: sai_set_config");
+	struct sof_ipc_dai_config *config = spec_config;
 	uint32_t val_cr2 = 0, val_cr4 = 0, val_cr5 = 0;
 	uint32_t mask_cr2 = 0, mask_cr4 = 0, mask_cr5 = 0;
 	struct sai_pdata *sai = dai_get_drvdata(dai);

--- a/src/drivers/intel/alh.c
+++ b/src/drivers/intel/alh.c
@@ -30,9 +30,11 @@ static int alh_trigger(struct dai *dai, int cmd, int direction)
 	return 0;
 }
 
-static int alh_set_config(struct dai *dai, struct sof_ipc_dai_config *config)
+static int alh_set_config(struct dai *dai, struct ipc_config_dai *common_config,
+			  void *spec_config)
 {
 	struct alh_pdata *alh = dai_get_drvdata(dai);
+	struct sof_ipc_dai_config *config = spec_config;
 
 	dai_info(dai, "alh_set_config() config->format = 0x%4x",
 		  config->format);

--- a/src/drivers/intel/baytrail/ssp.c
+++ b/src/drivers/intel/baytrail/ssp.c
@@ -71,9 +71,10 @@ static int ssp_context_restore(struct dai *dai)
 }
 
 /* Digital Audio interface formatting */
-static int ssp_set_config(struct dai *dai,
-			  struct sof_ipc_dai_config *config)
+static int ssp_set_config(struct dai *dai, struct ipc_config_dai *common_config,
+			  void *spec_config)
 {
+	struct sof_ipc_dai_config *config = spec_config;
 	struct ssp_pdata *ssp = dai_get_drvdata(dai);
 	uint32_t sscr0;
 	uint32_t sscr1;

--- a/src/drivers/intel/dmic.c
+++ b/src/drivers/intel/dmic.c
@@ -1104,10 +1104,12 @@ static int dmic_get_hw_params(struct dai *dai,
 	return 0;
 }
 
-static int dmic_set_config(struct dai *dai, struct sof_ipc_dai_config *config)
+static int dmic_set_config(struct dai *dai, struct ipc_config_dai *common_config,
+			   void *spec_config)
 {
 	struct sof_ipc_dai_dmic_params **uncached_dmic_prm = cache_to_uncache(&dmic_prm[0]);
 	struct dmic_pdata *dmic = dai_get_drvdata(dai);
+	struct sof_ipc_dai_config *config = spec_config;
 	struct matched_modes modes_ab;
 	struct dmic_configuration cfg;
 	struct decim_modes modes_a;

--- a/src/drivers/intel/haswell/ssp.c
+++ b/src/drivers/intel/haswell/ssp.c
@@ -50,9 +50,10 @@ static int ssp_context_restore(struct dai *dai)
 }
 
 /* Digital Audio interface formatting */
-static int ssp_set_config(struct dai *dai,
-			  struct sof_ipc_dai_config *config)
+static int ssp_set_config(struct dai *dai, struct ipc_config_dai *common_config,
+			  void *spec_config)
 {
+	struct sof_ipc_dai_config *config = spec_config;
 	struct ssp_pdata *ssp = dai_get_drvdata(dai);
 	uint32_t sscr0;
 	uint32_t sscr1;

--- a/src/drivers/intel/hda/hda.c
+++ b/src/drivers/intel/hda/hda.c
@@ -25,16 +25,20 @@ static int hda_trigger(struct dai *dai, int cmd, int direction)
 	return 0;
 }
 
-static int hda_set_config(struct dai *dai,
-			  struct sof_ipc_dai_config *config)
+static int hda_set_config(struct dai *dai,  struct ipc_config_dai *common_config,
+			  void *spec_config)
 {
 	struct hda_pdata *hda = dai_get_drvdata(dai);
+	struct sof_ipc_dai_config *dai_config = spec_config;
+	struct sof_ipc_dai_hda_params *params = &dai_config->hda;
 
-	if (config->hda.channels || config->hda.rate) {
-		hda->params.channels = config->hda.channels;
-		hda->params.rate = config->hda.rate;
-	}
+	dai_info(dai, "hda_set_config(): channels %u rate %u", params->channels,
+		 params->rate);
 
+	if (params->channels)
+		hda->params.channels = params->channels;
+	if (params->rate)
+		hda->params.rate = params->rate;
 
 	return 0;
 }
@@ -45,13 +49,15 @@ static int hda_get_hw_params(struct dai *dai,
 {
 	struct hda_pdata *hda = dai_get_drvdata(dai);
 
+	dai_info(dai, "hda_get_hw_params(): channels %u rate %u", hda->params.channels,
+		 hda->params.rate);
+
 	params->rate = hda->params.rate;
 	params->channels = hda->params.channels;
 
 	/* 0 means variable */
 	params->buffer_fmt = 0;
 	params->frame_fmt = 0;
-
 
 	return 0;
 }
@@ -71,7 +77,6 @@ static int hda_probe(struct dai *dai)
 		return -ENOMEM;
 	}
 	dai_set_drvdata(dai, hda);
-
 
 	return 0;
 }

--- a/src/drivers/intel/ssp/ssp.c
+++ b/src/drivers/intel/ssp/ssp.c
@@ -126,10 +126,11 @@ static int ssp_context_restore(struct dai *dai)
 }
 
 /* Digital Audio interface formatting */
-static int ssp_set_config(struct dai *dai,
-			  struct sof_ipc_dai_config *config)
+static int ssp_set_config(struct dai *dai, struct ipc_config_dai *common_config,
+			  void *spec_config)
 {
 	struct ssp_pdata *ssp = dai_get_drvdata(dai);
+	struct sof_ipc_dai_config *config = spec_config;
 	uint32_t sscr0;
 	uint32_t sscr1;
 	uint32_t sscr2;
@@ -169,7 +170,7 @@ static int ssp_set_config(struct dai *dai,
 	}
 
 	dai_info(dai, "ssp_set_config(), config->format = 0x%4x",
-		 config->format);
+		 common_config->format);
 
 	/* reset SSP settings */
 	/* sscr0 dynamic settings are DSS, EDSS, SCR, FRDC, ECS */

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -33,7 +33,7 @@
 #include <sof/trace/trace.h>
 #include <ipc/control.h>
 #include <ipc/stream.h>
-#include <ipc/topology.h>
+#include <sof/ipc/topology.h>
 #include <kernel/abi.h>
 #include <user/trace.h>
 
@@ -43,9 +43,9 @@
 #include <stdint.h>
 
 struct comp_dev;
-struct sof_ipc_dai_config;
 struct sof_ipc_stream_posn;
 struct dai_hw_params;
+struct timestamp_data;
 
 /** \addtogroup component_api Component API
  *  @{
@@ -292,8 +292,8 @@ struct comp_ops {
 	 *
 	 * Mandatory for components that allocate DAI.
 	 */
-	int (*dai_config)(struct comp_dev *dev,
-			  struct sof_ipc_dai_config *dai_config);
+	int (*dai_config)(struct comp_dev *dev, struct ipc_config_dai *dai_config,
+			  void *dai_spec_config);
 
 	/**
 	 * Used to pass standard and bespoke commands (with optional data).

--- a/src/include/sof/audio/component_ext.h
+++ b/src/include/sof/audio/component_ext.h
@@ -264,13 +264,13 @@ static inline int comp_reset(struct comp_dev *dev)
 }
 
 /** See comp_ops::dai_config */
-static inline int comp_dai_config(struct comp_dev *dev,
-				  struct sof_ipc_dai_config *config)
+static inline int comp_dai_config(struct comp_dev *dev, struct ipc_config_dai *config,
+				  void *spec_config)
 {
 	int ret = 0;
 
 	if (dev->drv->ops.dai_config)
-		ret = dev->drv->ops.dai_config(dev, config);
+		ret = dev->drv->ops.dai_config(dev, config, spec_config);
 
 	comp_shared_commit(dev);
 

--- a/src/include/sof/audio/ipc-config.h
+++ b/src/include/sof/audio/ipc-config.h
@@ -7,6 +7,7 @@
 #define __SOF_AUDIO_IPC_CONFIG_H__
 
 #include <stdint.h>
+#include <stdbool.h>
 
 /*
  * Generic IPC information for base components. Fields can be added here with NO impact on
@@ -25,6 +26,10 @@ struct ipc_config_dai {
 	uint32_t direction;	/**< SOF_IPC_STREAM_ */
 	uint32_t dai_index;	/**< index of this type dai */
 	uint32_t type;		/**< DAI type - SOF_DAI_ */
+	/* physical protocol and clocking */
+	uint16_t format;	/**< SOF_DAI_FMT_ */
+	uint16_t group_id;	/**< group ID, 0 means no group (ABI 3.17) */
+	bool is_config_blob;	/**< DAI specific configuration is a blob */
 };
 
 /* generic volume component */

--- a/src/include/sof/ipc/common.h
+++ b/src/include/sof/ipc/common.h
@@ -140,6 +140,19 @@ int ipc_process_host_buffer(struct ipc *ipc,
 int ipc_dma_trace_send_position(void);
 
 /**
+ * \brief Configure DAI.
+ * @return 0 on success.
+ */
+int ipc_dai_data_config(struct comp_dev *dev);
+
+/**
+ * \brief create a IPC boot complete message.
+ * @param[in] header header.
+ * @param[in] data data.
+ */
+void ipc_boot_complete_msg(ipc_cmd_hdr *header, uint32_t *data);
+
+/**
  * \brief Read a compact IPC message or return NULL for normal message.
  * @return Pointer to the compact message data.
  */
@@ -151,6 +164,13 @@ ipc_cmd_hdr *ipc_compact_read_msg(void);
  * @return Number of words written.
  */
 int ipc_compact_write_msg(ipc_cmd_hdr *hdr);
+
+/**
+ * \brief process a dsp IPC message.
+ * @param[in] msg The ipc msg.
+ * @return Number of words written.
+ */
+ipc_cmd_hdr *ipc_process_msg(struct ipc_msg *msg);
 
 /**
  * \brief Validate mailbox contents for valid IPC header.

--- a/src/include/sof/lib/dai.h
+++ b/src/include/sof/lib/dai.h
@@ -340,7 +340,6 @@ static inline int dai_trigger(struct dai *dai, int cmd, int direction)
 {
 	int ret = dai->drv->ops.trigger(dai, cmd, direction);
 
-
 	return ret;
 }
 
@@ -351,7 +350,6 @@ static inline int dai_pm_context_store(struct dai *dai)
 {
 	int ret = dai->drv->ops.pm_context_store(dai);
 
-
 	return ret;
 }
 
@@ -361,7 +359,6 @@ static inline int dai_pm_context_store(struct dai *dai)
 static inline int dai_pm_context_restore(struct dai *dai)
 {
 	int ret = dai->drv->ops.pm_context_restore(dai);
-
 
 	return ret;
 }
@@ -374,7 +371,6 @@ static inline int dai_get_hw_params(struct dai *dai,
 				    int dir)
 {
 	int ret = dai->drv->ops.get_hw_params(dai, params, dir);
-
 
 	return ret;
 }
@@ -401,7 +397,6 @@ static inline int dai_get_handshake(struct dai *dai, int direction,
 {
 	int ret = dai->drv->ops.get_handshake(dai, direction, stream_id);
 
-
 	return ret;
 }
 
@@ -413,7 +408,6 @@ static inline int dai_get_fifo(struct dai *dai, int direction,
 {
 	int ret = dai->drv->ops.get_fifo(dai, direction, stream_id);
 
-
 	return ret;
 }
 
@@ -424,7 +418,6 @@ static inline int dai_probe(struct dai *dai)
 {
 	int ret = dai->drv->ops.probe(dai);
 
-
 	return ret;
 }
 
@@ -434,7 +427,6 @@ static inline int dai_probe(struct dai *dai)
 static inline int dai_remove(struct dai *dai)
 {
 	int ret = dai->drv->ops.remove(dai);
-
 
 	return ret;
 }
@@ -461,20 +453,17 @@ static inline int dai_get_info(struct dai *dai, int info)
 		break;
 	}
 
-
 	return ret;
 }
 
 static inline void dai_write(struct dai *dai, uint32_t reg, uint32_t value)
 {
 	io_reg_write(dai_base(dai) + reg, value);
-
 }
 
 static inline uint32_t dai_read(struct dai *dai, uint32_t reg)
 {
 	uint32_t val = io_reg_read(dai_base(dai) + reg);
-
 
 	return val;
 }
@@ -483,7 +472,6 @@ static inline void dai_update_bits(struct dai *dai, uint32_t reg,
 				   uint32_t mask, uint32_t value)
 {
 	io_reg_update_bits(dai_base(dai) + reg, mask, value);
-
 }
 
 static inline const struct dai_info *dai_info_get(void)

--- a/src/ipc/CMakeLists.txt
+++ b/src/ipc/CMakeLists.txt
@@ -4,6 +4,7 @@ if (CONFIG_IPC_MAJOR_3)
 	add_local_sources(sof
 		handler-ipc3.c
 		helper-ipc3.c
+		dai-ipc3.c
 	)
 endif()
 

--- a/src/ipc/dai-ipc3.c
+++ b/src/ipc/dai-ipc3.c
@@ -1,0 +1,266 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2016 Intel Corporation. All rights reserved.
+//
+// Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
+//         Keyon Jie <yang.jie@linux.intel.com>
+
+#include <sof/audio/component_ext.h>
+#include <sof/audio/ipc-config.h>
+#include <sof/drivers/idc.h>
+#include <sof/ipc/topology.h>
+#include <sof/ipc/common.h>
+#include <sof/ipc/msg.h>
+#include <sof/ipc/driver.h>
+#include <sof/lib/dai.h>
+#include <sof/drivers/edma.h>
+#include <errno.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/* IPC3 headers */
+#include <ipc/dai.h>
+#include <ipc/header.h>
+#include <ipc/stream.h>
+#include <ipc/topology.h>
+
+int dai_config_dma_channel(struct comp_dev *dev, void *spec_config)
+{
+	struct dai_data *dd = comp_get_drvdata(dev);
+	struct sof_ipc_dai_config *config = spec_config;
+	struct ipc_config_dai *dai = &dd->ipc_config;
+	int channel;
+	int handshake;
+
+	assert(config);
+
+	switch (config->type) {
+	case SOF_DAI_INTEL_SSP:
+		COMPILER_FALLTHROUGH;
+	case SOF_DAI_INTEL_DMIC:
+		channel = 0;
+		break;
+	case SOF_DAI_INTEL_HDA:
+		channel = config->hda.link_dma_ch;
+		break;
+	case SOF_DAI_INTEL_ALH:
+		/* As with HDA, the DMA channel is assigned in runtime,
+		 * not during topology parsing.
+		 */
+		channel = config->alh.stream_id;
+		break;
+	case SOF_DAI_IMX_SAI:
+		COMPILER_FALLTHROUGH;
+	case SOF_DAI_IMX_ESAI:
+		handshake = dai_get_handshake(dd->dai, dai->direction,
+					      dd->stream_id);
+		channel = EDMA_HS_GET_CHAN(handshake);
+		break;
+	default:
+		/* other types of DAIs not handled for now */
+		comp_err(dev, "dai_config_dma_channel(): Unknown dai type %d",
+			 config->type);
+		channel = DMA_CHAN_INVALID;
+		break;
+	}
+
+	return channel;
+}
+
+int ipc_dai_data_config(struct comp_dev *dev)
+{
+	struct dai_data *dd = comp_get_drvdata(dev);
+	struct ipc_config_dai *dai = &dd->ipc_config;
+	struct sof_ipc_dai_config *dai_config = ipc_from_dai_config(dd->dai_spec_config);
+
+	if (!dai_config) {
+		comp_err(dev, "dai_data_config(): no config set for dai %d type %d",
+			 dai->dai_index, dai->type);
+		return -EINVAL;
+	}
+
+	comp_info(dev, "dai_data_config() dai type = %d index = %d dd %p",
+		  dai->type, dai->dai_index, dd);
+
+	/* cannot configure DAI while active */
+	if (dev->state == COMP_STATE_ACTIVE) {
+		comp_info(dev, "dai_data_config(): Component is in active state.");
+		return 0;
+	}
+
+	/* validate direction */
+	if (dai->direction != SOF_IPC_STREAM_PLAYBACK &&
+	    dai->direction != SOF_IPC_STREAM_CAPTURE) {
+		comp_err(dev, "dai_data_config(): no direction set for dai %d type %d",
+			 dai->dai_index, dai->type);
+		return -EINVAL;
+	}
+
+	switch (dai_config->type) {
+	case SOF_DAI_INTEL_SSP:
+		/* set dma burst elems to slot number */
+		dd->config.burst_elems = dai_config->ssp.tdm_slots;
+		break;
+	case SOF_DAI_INTEL_DMIC:
+		/* We can use always the largest burst length. */
+		dd->config.burst_elems = 8;
+
+		comp_info(dev, "config->dmic.fifo_bits = %u config->dmic.num_pdm_active = %u",
+			  dai_config->dmic.fifo_bits,
+			  dai_config->dmic.num_pdm_active);
+		break;
+	case SOF_DAI_INTEL_HDA:
+		break;
+	case SOF_DAI_INTEL_ALH:
+		/* SDW HW FIFO always requires 32bit MSB aligned sample data for
+		 * all formats, such as 8/16/24/32 bits.
+		 */
+		dev->ipc_config.frame_fmt = SOF_IPC_FRAME_S32_LE;
+		dd->dma_buffer->stream.frame_fmt = dev->ipc_config.frame_fmt;
+
+		dd->config.burst_elems =
+			dd->dai->plat_data.fifo[dai->direction].depth;
+
+		/* As with HDA, the DMA channel is assigned in runtime,
+		 * not during topology parsing.
+		 */
+		dd->stream_id = dai_config->alh.stream_id;
+		break;
+	case SOF_DAI_IMX_SAI:
+		COMPILER_FALLTHROUGH;
+	case SOF_DAI_IMX_ESAI:
+		dd->config.burst_elems =
+			dd->dai->plat_data.fifo[dai->direction].depth;
+		break;
+	default:
+		/* other types of DAIs not handled for now */
+		comp_warn(dev, "dai_data_config(): Unknown dai type %d",
+			  dai_config->type);
+		break;
+	}
+
+	/* some DAIs may not need extra config */
+	return 0;
+}
+
+int ipc_comp_dai_config(struct ipc *ipc, struct ipc_config_dai *common_config,
+			void *spec_config)
+{
+	struct sof_ipc_dai_config *config = spec_config;
+	bool comp_on_core[CONFIG_CORE_COUNT] = { false };
+	struct sof_ipc_reply reply;
+	struct ipc_comp_dev *icd;
+	struct list_item *clist;
+	int ret = -ENODEV;
+	int i;
+
+	tr_info(&ipc_tr, "ipc_comp_dai_config() dai type = %d index = %d",
+		config->type, config->dai_index);
+
+	/* for each component */
+	list_for_item(clist, &ipc->comp_list) {
+		icd = container_of(clist, struct ipc_comp_dev, list);
+		/* make sure we only config DAI comps */
+		if (icd->type != COMP_TYPE_COMPONENT)
+			continue;
+
+		if (!cpu_is_me(icd->core)) {
+			comp_on_core[icd->core] = true;
+			ret = 0;
+			continue;
+		}
+
+		if (dev_comp_type(icd->cd) == SOF_COMP_DAI ||
+		    dev_comp_type(icd->cd) == SOF_COMP_SG_DAI) {
+
+			ret = comp_dai_config(icd->cd, common_config, spec_config);
+			if (ret < 0)
+				break;
+		}
+	}
+
+	if (ret < 0) {
+		tr_err(&ipc_tr, "ipc_comp_dai_config(): comp_dai_config() failed");
+		return ret;
+	}
+
+	/* message forwarded only by primary core */
+	if (!cpu_is_secondary(cpu_get_id())) {
+		for (i = 0; i < CONFIG_CORE_COUNT; ++i) {
+			if (!comp_on_core[i])
+				continue;
+
+			ret = ipc_process_on_core(i);
+			if (ret < 0)
+				return ret;
+
+			/* check whether IPC failed on secondary core */
+			mailbox_hostbox_read(&reply, sizeof(reply), 0,
+					     sizeof(reply));
+			if (reply.error < 0)
+				/* error reply already written */
+				return 1;
+		}
+	}
+
+	return ret;
+}
+
+int dai_config(struct comp_dev *dev, struct ipc_config_dai *common_config,
+	       void *spec_config)
+{
+	struct sof_ipc_dai_config *config = spec_config;
+	struct dai_data *dd = comp_get_drvdata(dev);
+	int ret;
+
+	/* ignore if message not for this DAI id/type */
+	if (dd->ipc_config.dai_index != config->dai_index ||
+	    dd->ipc_config.type != config->type)
+		return 0;
+
+	comp_info(dev, "dai_config() dai type = %d index = %d dd %p",
+		  config->type, config->dai_index, dd);
+
+	/* cannot configure DAI while active */
+	if (dev->state == COMP_STATE_ACTIVE) {
+		comp_info(dev, "dai_config(): Component is in active state. Ignore config");
+		return 0;
+	}
+
+	if (dd->chan) {
+		comp_info(dev, "dai_config(): Configured. dma channel index %d, ignore...",
+			  dd->chan->index);
+		return 0;
+	}
+
+	if (config->group_id) {
+		ret = dai_assign_group(dev, config->group_id);
+
+		if (ret)
+			return ret;
+	}
+
+	/* do nothing for asking for channel free, for compatibility. */
+	if (dai_config_dma_channel(dev, spec_config) == DMA_CHAN_INVALID)
+		return 0;
+
+	/* allocated dai_config if not yet */
+	if (!dd->dai_spec_config) {
+		dd->dai_spec_config = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM,
+					      sizeof(struct sof_ipc_dai_config));
+		if (!dd->dai_spec_config) {
+			comp_err(dev, "dai_config(): No memory for dai_config.");
+			return -ENOMEM;
+		}
+	}
+
+	ret = memcpy_s(dd->dai_spec_config, sizeof(struct sof_ipc_dai_config), config,
+		       sizeof(struct sof_ipc_dai_config));
+	if (ret < 0) {
+		rfree(dd->dai_spec_config);
+		dd->dai_spec_config = NULL;
+	}
+
+	return ret;
+}

--- a/src/ipc/helper-ipc3.c
+++ b/src/ipc/helper-ipc3.c
@@ -71,6 +71,21 @@ void ipc_build_trace_posn(struct sof_ipc_dma_trace_posn *posn)
 	posn->rhdr.hdr.size = sizeof(*posn);
 }
 
+int32_t ipc_comp_pipe_id(const struct ipc_comp_dev *icd)
+{
+	switch (icd->type) {
+	case COMP_TYPE_COMPONENT:
+		return dev_comp_pipe_id(icd->cd);
+	case COMP_TYPE_BUFFER:
+		return icd->cb->pipeline_id;
+	case COMP_TYPE_PIPELINE:
+		return icd->pipeline->pipeline_id;
+	default:
+		tr_err(&ipc_tr, "Unknown ipc component type %u", icd->type);
+		return -EINVAL;
+	};
+}
+
 /* Function overwrites PCM parameters (frame_fmt, buffer_fmt, channels, rate)
  * with buffer parameters when specific flag is set.
  */
@@ -584,68 +599,6 @@ int ipc_pipeline_complete(struct ipc *ipc, uint32_t comp_id)
 
 	ret = pipeline_complete(ipc_pipe->pipeline, ipc_ppl_source->cd,
 				ipc_ppl_sink->cd);
-
-	return ret;
-}
-
-int ipc_comp_dai_config(struct ipc *ipc, struct sof_ipc_dai_config *config)
-{
-	bool comp_on_core[CONFIG_CORE_COUNT] = { false };
-	struct sof_ipc_reply reply;
-	struct ipc_comp_dev *icd;
-	struct list_item *clist;
-	int ret = -ENODEV;
-	int i;
-
-	tr_info(&ipc_tr, "ipc_comp_dai_config() dai type = %d index = %d",
-		config->type, config->dai_index);
-
-	/* for each component */
-	list_for_item(clist, &ipc->comp_list) {
-		icd = container_of(clist, struct ipc_comp_dev, list);
-		/* make sure we only config DAI comps */
-		if (icd->type != COMP_TYPE_COMPONENT) {
-			continue;
-		}
-
-		if (!cpu_is_me(icd->core)) {
-			comp_on_core[icd->core] = true;
-			ret = 0;
-			continue;
-		}
-
-		if (dev_comp_type(icd->cd) == SOF_COMP_DAI ||
-		    dev_comp_type(icd->cd) == SOF_COMP_SG_DAI) {
-
-			ret = comp_dai_config(icd->cd, config);
-			if (ret < 0)
-				break;
-		}
-	}
-
-	if (ret < 0) {
-		tr_err(&ipc_tr, "ipc_comp_dai_config(): comp_dai_config() failed");
-		return ret;
-	}
-
-	/* message forwarded only by primary core */
-	if (!cpu_is_secondary(cpu_get_id())) {
-		for (i = 0; i < CONFIG_CORE_COUNT; ++i) {
-			if (!comp_on_core[i])
-				continue;
-
-			ret = ipc_process_on_core(i);
-			if (ret < 0)
-				return ret;
-
-			/* check whether IPC failed on secondary core */
-			mailbox_hostbox_read(&reply, sizeof(reply), 0,
-					     sizeof(reply));
-			if (reply.error < 0)
-				/* error reply already written */
-				return 1;
-		}
-	}
 
 	return ret;
 }

--- a/src/platform/library/lib/dai.c
+++ b/src/platform/library/lib/dai.c
@@ -15,6 +15,11 @@ const struct dai_info lib_dai = {
 	.num_dai_types = ARRAY_SIZE(dti)
 };
 
+int dai_assign_group(struct comp_dev *dev, uint32_t group_id)
+{
+	return 0;
+}
+
 int dai_init(struct sof *sof)
 {
 	sof->dai_info = &lib_dai;

--- a/src/platform/library/platform.c
+++ b/src/platform/library/platform.c
@@ -29,7 +29,7 @@ uint8_t *get_library_mailbox()
 
 static void platform_clock_init(struct sof *sof) {}
 
-static int dmac_init(struct sof *sof)
+int dmac_init(struct sof *sof)
 {
 	return 0;
 }

--- a/tools/testbench/common_test.c
+++ b/tools/testbench/common_test.c
@@ -246,6 +246,11 @@ void pipeline_xrun(struct pipeline *p, struct comp_dev *dev, int32_t bytes)
 {
 }
 
+int dai_assign_group(struct comp_dev *dev, uint32_t group_id)
+{
+	return 0;
+}
+
 /* print debug messages */
 void debug_print(char *message)
 {

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -354,6 +354,7 @@ zephyr_library_sources(
 	${SOF_IPC_PATH}/ipc-common.c
 	${SOF_IPC_PATH}/handler-ipc3.c
 	${SOF_IPC_PATH}/helper-ipc3.c
+	${SOF_IPC_PATH}/dai-ipc3.c
 	${SOF_IPC_PATH}/ipc-host-ptable.c
 	${SOF_SRC_PATH}/spinlock.c
 


### PR DESCRIPTION
Currently the IPC DAI configuration is tightly bound to the IPC major version. This PR abstracts this interface so that other IPC majors can be used to configure DAIs. The DAI drivers themselves still use IPC major 3, but this opens up the ability to send NHLT configuration blobs.