### PR TITLE
[skip-ci] docker_build: add bison and flex to apt install list

### DIFF
--- a/scripts/docker_build/sof_qemu/Dockerfile
+++ b/scripts/docker_build/sof_qemu/Dockerfile
@@ -38,7 +38,9 @@ RUN apt-get -y update && \
 		libpixman-1-dev \
 		pkg-config \
 		sudo \
-		bsdmainutils
+		bsdmainutils \
+		bison \
+		flex
 
 # Set up sof user
 RUN useradd --create-home -d /home/sof -u $UID -G sudo sof && \


### PR DESCRIPTION
There are warnings about bison and flex not available.
Interestingly these were not fatal errors but time to fix them.

Signed-off-by: Fred Oh <fred.oh@linux.intel.com>

related issues: https://github.com/thesofproject/sof/issues/4186
This is NOT the fix for https://github.com/thesofproject/sof/issues/4186, When the fix is available, I will re-build the docker image for QEMU.