### PR TITLE
zephyr: fix a power-down exception

### DIFF
--- a/src/include/sof/lib/agent.h
+++ b/src/include/sof/lib/agent.h
@@ -53,10 +53,12 @@ static inline void sa_set_panic_on_delay(bool enabled)
 }
 
 void sa_init(struct sof *sof, uint64_t timeout);
+void sa_exit(struct sof *sof);
 
 #else
 
 static inline void sa_init(struct sof *sof, uint64_t timeout) { }
+static inline void sa_exit(struct sof *sof) { }
 static inline void sa_set_panic_on_delay(bool enabled) { }
 
 #endif

--- a/src/ipc/handler-ipc3.c
+++ b/src/ipc/handler-ipc3.c
@@ -26,6 +26,7 @@
 #include <sof/ipc/driver.h>
 #include <sof/ipc/schedule.h>
 #include <sof/drivers/timer.h>
+#include <sof/lib/agent.h>
 #include <sof/lib/alloc.h>
 #include <sof/lib/clk.h>
 #include <sof/lib/cache.h>
@@ -562,6 +563,8 @@ static int ipc_pm_context_save(uint32_t header)
 	//struct sof_ipc_pm_ctx *pm_ctx = _ipc->comp_data;
 
 	tr_info(&ipc_tr, "ipc: pm -> save");
+
+	sa_exit(sof_get());
 
 	/* TODO use Zephyr calls for shutdown */
 #ifndef __ZEPHYR__

--- a/src/lib/agent.c
+++ b/src/lib/agent.c
@@ -130,3 +130,8 @@ void sa_init(struct sof *sof, uint64_t timeout)
 	sof->sa->last_check = platform_timer_get(timer_get());
 
 }
+
+void sa_exit(struct sof *sof)
+{
+	schedule_task_cancel(&sof->sa->work);
+}

--- a/src/platform/intel/cavs/include/cavs/lib/memory.h
+++ b/src/platform/intel/cavs/include/cavs/lib/memory.h
@@ -87,17 +87,24 @@ struct sof;
 #define SRAM_ALIAS_MASK		0xFF000000
 #define SRAM_ALIAS_OFFSET	SRAM_UNCACHED_ALIAS
 
-#if !defined UNIT_TEST && !defined __ZEPHYR__
+#if !defined UNIT_TEST
 #define uncache_to_cache(address) \
-	((__typeof__((address)))((uint32_t)((address)) + SRAM_ALIAS_OFFSET))
+	((__typeof__(address))((uint32_t)(address) | SRAM_ALIAS_OFFSET))
 #define cache_to_uncache(address) \
-	((__typeof__((address)))((uint32_t)((address)) - SRAM_ALIAS_OFFSET))
+	((__typeof__(address))((uint32_t)(address) & ~SRAM_ALIAS_OFFSET))
 #define is_uncached(address) \
 	(((uint32_t)(address) & SRAM_ALIAS_MASK) == SRAM_ALIAS_BASE)
 #else
 #define uncache_to_cache(address)	address
 #define cache_to_uncache(address)	address
 #define is_uncached(address)		0
+#endif
+
+#if !defined UNIT_TEST && !defined __ZEPHYR__
+#define cache_to_uncache_init(address) \
+	((__typeof__((address)))((uint32_t)((address)) - SRAM_ALIAS_OFFSET))
+#else
+#define cache_to_uncache_init(address)	address
 #endif
 
 /**

--- a/src/platform/intel/cavs/lib/dai.c
+++ b/src/platform/intel/cavs/lib/dai.c
@@ -91,26 +91,26 @@ const struct dai_type_info dti[] = {
 #if CONFIG_INTEL_SSP
 	{
 		.type = SOF_DAI_INTEL_SSP,
-		.dai_array = cache_to_uncache((struct dai *)ssp),
+		.dai_array = cache_to_uncache_init((struct dai *)ssp),
 		.num_dais = ARRAY_SIZE(ssp)
 	},
 #endif
 #if CONFIG_INTEL_DMIC
 	{
 		.type = SOF_DAI_INTEL_DMIC,
-		.dai_array = cache_to_uncache((struct dai *)dmic),
+		.dai_array = cache_to_uncache_init((struct dai *)dmic),
 		.num_dais = ARRAY_SIZE(dmic)
 	},
 #endif
 	{
 		.type = SOF_DAI_INTEL_HDA,
-		.dai_array = cache_to_uncache((struct dai *)hda),
+		.dai_array = cache_to_uncache_init((struct dai *)hda),
 		.num_dais = ARRAY_SIZE(hda)
 	},
 #if CONFIG_INTEL_ALH
 	{
 		.type = SOF_DAI_INTEL_ALH,
-		.dai_array = cache_to_uncache((struct dai *)alh),
+		.dai_array = cache_to_uncache_init((struct dai *)alh),
 		.num_dais = ARRAY_SIZE(alh)
 	}
 #endif

--- a/src/platform/intel/cavs/lib/dma.c
+++ b/src/platform/intel/cavs/lib/dma.c
@@ -237,7 +237,7 @@ SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
 #endif
 
 const struct dma_info lib_dma = {
-	.dma_array = cache_to_uncache((struct dma *)dma),
+	.dma_array = cache_to_uncache_init((struct dma *)dma),
 	.num_dmas = ARRAY_SIZE(dma)
 };
 

--- a/src/platform/intel/cavs/lib/memory.c
+++ b/src/platform/intel/cavs/lib/memory.c
@@ -15,7 +15,7 @@
 #include <ipc/topology.h>
 #include <stdint.h>
 
-#define uncached_block_hdr(hdr)	cache_to_uncache((struct block_hdr *)(hdr))
+#define uncached_block_hdr(hdr)	cache_to_uncache_init((struct block_hdr *)(hdr))
 #define uncached_block_map(map)	cache_to_uncache((struct block_map *)(map))
 
 extern uintptr_t _system_heap, _system_runtime_heap, _module_heap;

--- a/src/platform/intel/cavs/lib/pm_runtime.c
+++ b/src/platform/intel/cavs/lib/pm_runtime.c
@@ -605,6 +605,6 @@ void platform_pm_runtime_power_off(void)
 	for (i = 0; i < PLATFORM_HPSRAM_SEGMENTS; i++)
 		hpsram_mask[i] = HPSRAM_MASK(i);
 
-	power_down(true, hpsram_mask);
+	power_down(true, uncache_to_cache(&hpsram_mask[0]));
 }
 #endif


### PR DESCRIPTION
this addresses one of the reasons of https://github.com/zephyrproject-rtos/zephyr/issues/35299 but doesn't fix it completely.