### PR TITLE
[SKIP CI] .github/ipc_fuzzer: add back local compilation hack as a comment

### DIFF
--- a/.github/workflows/ipc_fuzzer.yml
+++ b/.github/workflows/ipc_fuzzer.yml
@@ -7,6 +7,16 @@
 # Build and run fuzzer for 5s just to check that it runs properly. If it
 # consistently fails in under 5s you probably did something wrong
 
+# If you came here to quickly copy/paste the invocation of some build
+# script in order to reproduce a failure reported by github then you
+# will be disappointed by the Github Action below: it's magical. For a
+# thorough reproduction you must follow the links above. For a quick,
+# dirty and incomplete reproduction hack you can try the following two
+# lines. Don't do this at home.
+#
+#   OUT=unused_dir  cmake -B oss-fuzz-build/ -S tools/oss-fuzz/
+#   make -j -C oss-fuzz-build sof_ep fuzz_ipc.o
+
 name: IPC fuzzer compile test
 
 # 'workflow_dispatch' allows running this workflow manually from the


### PR DESCRIPTION
... because it has definitely helped reproduce compilation issues in the
past in just two lines without going through the whole setup process,
see a list of examples in #4126.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>