### PR TITLE
Build SOF with Zephyr on i.MX

### DIFF
--- a/src/platform/imx8/lib/clk.c
+++ b/src/platform/imx8/lib/clk.c
@@ -7,11 +7,14 @@
 
 #include <sof/common.h>
 #include <sof/lib/clk.h>
-#include <sof/lib/cpu.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/notifier.h>
 #include <sof/sof.h>
 #include <sof/spinlock.h>
+
+#ifdef __ZEPHYR__
+#include <sys/util.h>
+#endif
 
 const struct freq_table platform_cpu_freq[] = {
 #ifdef CONFIG_IMX8

--- a/src/platform/imx8/platform.c
+++ b/src/platform/imx8/platform.c
@@ -165,7 +165,10 @@ int platform_init(struct sof *sof)
 		timer_domain_init(sof->platform_timer, PLATFORM_DEFAULT_CLOCK);
 	scheduler_init_ll(sof->platform_timer_domain);
 
+#ifndef __ZEPHYR__
 	platform_timer_start(sof->platform_timer);
+#endif
+
 	sa_init(sof, CONFIG_SYSTICK_PERIOD);
 
 	clock_set_freq(CLK_CPU(cpu_get_id()), CLK_MAX_CPU_HZ);
@@ -191,6 +194,7 @@ int platform_init(struct sof *sof)
 	if (ret < 0)
 		return -ENODEV;
 
+#ifndef __ZEPHYR__
 #if CONFIG_TRACE
 	/* Initialize DMA for Trace*/
 	trace_point(TRACE_BOOT_PLATFORM_DMA_TRACE);
@@ -199,6 +203,7 @@ int platform_init(struct sof *sof)
 
 	/* show heap status */
 	heap_trace_all(1);
+#endif /* __ZEPHYR__ */
 
 	return 0;
 }

--- a/src/platform/imx8m/platform.c
+++ b/src/platform/imx8m/platform.c
@@ -164,7 +164,10 @@ int platform_init(struct sof *sof)
 		timer_domain_init(sof->platform_timer, PLATFORM_DEFAULT_CLOCK);
 	scheduler_init_ll(sof->platform_timer_domain);
 
+#ifndef __ZEPHYR__
 	platform_timer_start(sof->platform_timer);
+#endif
+
 	sa_init(sof, CONFIG_SYSTICK_PERIOD);
 
 	clock_set_freq(CLK_CPU(cpu_get_id()), CLK_MAX_CPU_HZ);
@@ -191,6 +194,7 @@ int platform_init(struct sof *sof)
 	if (ret < 0)
 		return -ENODEV;
 
+#ifndef __ZEPHYR__
 #if CONFIG_TRACE
 	/* Initialize DMA for Trace*/
 	trace_point(TRACE_BOOT_PLATFORM_DMA_TRACE);
@@ -199,6 +203,7 @@ int platform_init(struct sof *sof)
 
 	/* show heap status */
 	heap_trace_all(1);
+#endif /* __ZEPHYR__ */
 
 	return 0;
 }

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -330,13 +330,45 @@ endif()
 # NXP IMX8 platforms
 if (CONFIG_SOC_SERIES_NXP_IMX8)
 	zephyr_library_sources(
-		#${SOF_DRIVERS_PATH}/generic/dummy-dma.c
-		#${SOF_DRIVERS_PATH}/imx/sdma.c
-		#${SOF_DRIVERS_PATH}/imx/edma.c
-		#${SOF_DRIVERS_PATH}/imx/sai.c
-		#${SOF_DRIVERS_PATH}/imx/ipc.c
-		#${SOF_DRIVERS_PATH}/imx/esai.c
+		${SOF_DRIVERS_PATH}/generic/dummy-dma.c
+		${SOF_DRIVERS_PATH}/imx/edma.c
+		${SOF_DRIVERS_PATH}/imx/sai.c
+		${SOF_DRIVERS_PATH}/imx/ipc.c
+		${SOF_DRIVERS_PATH}/imx/esai.c
 	)
+
+	# Platform sources
+	zephyr_library_sources(
+		${SOF_PLATFORM_PATH}/imx8/platform.c
+		${SOF_PLATFORM_PATH}/imx8/lib/clk.c
+		${SOF_PLATFORM_PATH}/imx8/lib/dai.c
+		${SOF_PLATFORM_PATH}/imx8/lib/dma.c
+		${SOF_PLATFORM_PATH}/imx8/lib/memory.c
+	)
+
+	set(PLATFORM "imx8")
+endif()
+
+if (CONFIG_SOC_SERIES_NXP_IMX8M)
+	zephyr_library_sources(
+		${SOF_DRIVERS_PATH}/generic/dummy-dma.c
+		${SOF_DRIVERS_PATH}/imx/sdma.c
+		${SOF_DRIVERS_PATH}/imx/edma.c
+		${SOF_DRIVERS_PATH}/imx/sai.c
+		${SOF_DRIVERS_PATH}/imx/ipc.c
+		${SOF_DRIVERS_PATH}/imx/esai.c
+	)
+
+	# Platform sources
+	zephyr_library_sources(
+		${SOF_PLATFORM_PATH}/imx8m/platform.c
+		${SOF_PLATFORM_PATH}/imx8m/lib/clk.c
+		${SOF_PLATFORM_PATH}/imx8m/lib/memory.c
+		${SOF_PLATFORM_PATH}/imx8m/lib/dai.c
+		${SOF_PLATFORM_PATH}/imx8m/lib/dma.c
+	)
+
+	set(PLATFORM "imx8m")
 endif()
 
 zephyr_library_sources_ifdef(CONFIG_LIBRARY

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -26,6 +26,10 @@
 #include <soc.h>
 #include <kernel.h>
 
+#ifndef CONFIG_KERNEL_COHERENCE
+#include <arch/xtensa/cache.h>
+#endif
+
 extern K_KERNEL_STACK_ARRAY_DEFINE(z_interrupt_stacks, CONFIG_MP_NUM_CPUS,
 				   CONFIG_ISR_STACK_SIZE);
 


### PR DESCRIPTION
Add support for i.MX to build Sound Open Firmware with Zephyr OS.

Please check each commit message.

With these commits I have a successful build. 
I obtain the zephyr.ri image which boots the DSP and loads the topology.

```
root@imx8qmmek:~# ./loadSof.sh 
[  166.405965] sof-audio-of 556e8000.dsp: DT DSP detected
[  166.416971] imx-dsp imx-dsp: NXP i.MX DSP IPC initialized
[  166.430784] sof-audio-of 556e8000.dsp: warning: unknown sof_ext_man header type 5 size 0x20
[  166.439213] sof-audio-of 556e8000.dsp: warning: unknown sof_ext_man header type 3 size 0x30
[  166.447885] sof-audio-of 556e8000.dsp: Firmware info: version 1:8:0-cf919
[  166.454703] sof-audio-of 556e8000.dsp: Firmware: ABI 3:19:0 Kernel ABI 3:17:0
[  166.461862] sof-audio-of 556e8000.dsp: warn: FW ABI is more recent than kernel
[  166.469453] sof-audio-of 556e8000.dsp: Firmware info: version 1:8:0-cf919
[  166.476264] sof-audio-of 556e8000.dsp: Firmware: ABI 3:19:0 Kernel ABI 3:17:0
[  166.483406] sof-audio-of 556e8000.dsp: warn: FW ABI is more recent than kernel
[  166.506546] sof-audio-of 556e8000.dsp: Topology: ABI 3:18:1 Kernel ABI 3:17:0
[  166.515821] sof-audio-of 556e8000.dsp: warn: topology ABI is more recent than kernel
[  166.526795] sof-audio-of 556e8000.dsp: tplg: config SAI1 fmt 0x1 mclk 12288000 width 32 slots 2 mclk id 0
[  166.537294] sof-audio-of 556e8000.dsp: ASoC: Parent card not yet available, widget card binding deferred
root@imx8qmmek:~# 
root@imx8qmmek:~# aplay -l
**** List of PLAYBACK Hardware Devices ****
card 0: btscoaudio [bt-sco-audio], device 0: 59040000.sai-bt-sco-pcm-wb bt-sco-pcm-wb-0 [59040000.sai-bt-sco-pcm-wb bt-sco-pcm-wb-0]
  Subdevices: 1/1
  Subdevice #0: subdevice #0
card 1: sofwm8960audio [sof-wm8960-audio], device 0: Port0 (*) []
  Subdevices: 1/1
  Subdevice #0: subdevice #0
root@imx8qmmek:~# arecord -l
**** List of CAPTURE Hardware Devices ****
card 0: btscoaudio [bt-sco-audio], device 0: 59040000.sai-bt-sco-pcm-wb bt-sco-pcm-wb-0 [59040000.sai-bt-sco-pcm-wb bt-sco-pcm-wb-0]
  Subdevices: 1/1
  Subdevice #0: subdevice #0
card 1: sofwm8960audio [sof-wm8960-audio], device 0: Port0 (*) []
  Subdevices: 1/1
  Subdevice #0: subdevice #0
```
Pull requests were also opened on:
- zephyr repo - see [#35467](https://github.com/zephyrproject-rtos/zephyr/pull/35467) 
- xtensa_hal - see [#12](https://github.com/zephyrproject-rtos/hal_xtensa/pull/12)