### PR TITLE
cavs: memory: fix panic on tplg load for zephyr on cavs20/25

### DIFF
--- a/src/platform/intel/cavs/include/cavs/lib/memory.h
+++ b/src/platform/intel/cavs/include/cavs/lib/memory.h
@@ -87,7 +87,7 @@ struct sof;
 #define SRAM_ALIAS_MASK		0xFF000000
 #define SRAM_ALIAS_OFFSET	SRAM_UNCACHED_ALIAS
 
-#if !defined UNIT_TEST
+#if !defined UNIT_TEST && (CAVS_VERSION <= CAVS_VERSION_1_8 || !defined __ZEPHYR__)
 #define uncache_to_cache(address) \
 	((__typeof__(address))((uint32_t)(address) | SRAM_ALIAS_OFFSET))
 #define cache_to_uncache(address) \


### PR DESCRIPTION
The Zephyr linker scripts for cavs20/25 do not map sections
on uncached RAM, so the memory accesses to uncached memory will
fail. This shows up as a DSP panic while loading initial topology.

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>