### PR TITLE
Multi core series -- cache & consistency

### DIFF
--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -164,7 +164,7 @@ static struct comp_dev *dai_new(const struct comp_driver *drv,
 		return NULL;
 	dev->ipc_config = *config;
 
-	dd = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM, sizeof(*dd));
+	dd = rzalloc(SOF_MEM_ZONE_RUNTIME_SHARED, 0, SOF_MEM_CAPS_RAM, sizeof(*dd));
 	if (!dd) {
 		rfree(dev);
 		return NULL;

--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -985,7 +985,7 @@ static int dw_dma_probe(struct dma *dma)
 		chan->index = i;
 		chan->core = DMA_CORE_INVALID;
 
-		dw_chan = rzalloc(SOF_MEM_ZONE_SYS_RUNTIME, 0, SOF_MEM_CAPS_RAM,
+		dw_chan = rzalloc(SOF_MEM_ZONE_RUNTIME_SHARED, 0, SOF_MEM_CAPS_RAM,
 				  sizeof(*dw_chan));
 
 		if (!dw_chan) {

--- a/src/ipc/dai-ipc3.c
+++ b/src/ipc/dai-ipc3.c
@@ -247,7 +247,7 @@ int dai_config(struct comp_dev *dev, struct ipc_config_dai *common_config,
 
 	/* allocated dai_config if not yet */
 	if (!dd->dai_spec_config) {
-		dd->dai_spec_config = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM,
+		dd->dai_spec_config = rzalloc(SOF_MEM_ZONE_RUNTIME_SHARED, 0, SOF_MEM_CAPS_RAM,
 					      sizeof(struct sof_ipc_dai_config));
 		if (!dd->dai_spec_config) {
 			comp_err(dev, "dai_config(): No memory for dai_config.");


### PR DESCRIPTION
For dw dma controllers and channels, they are shared to multiple pipelines and cores.
For dai config and ssp config, the configuration may happen on different core with the one on the active time.

Add cache invalidate and writeback to ensure the consistency, to address issue https://github.com/thesofproject/sof/issues/3953