### PR TITLE
converged: add aca converged module example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,6 @@ ncscope.*
 
 # zephyr files
 zephyr/include/version.h
+
+# converged sound open fw
+!converged_sound_open_fw_modules_development/*

--- a/converged_sound_open_fw_modules_development/FW/intel_common/module_binmaps/aca_module.binmap
+++ b/converged_sound_open_fw_modules_development/FW/intel_common/module_binmaps/aca_module.binmap
@@ -1,0 +1,35 @@
+module o ACA
+uuid 88881111-2222-3333-4444-555566667777
+name Aca module example
+version_major 0x1
+version_minor 0x0
+version_hotfix 0x0
+version_build 0x0
+affinity_mask MASTER_CORE_AFFINITY
+instance_count +1
+domain_types DP
+type AudClassModule
+stack_size 1000
+
+group text
+section .aca_module.text
+section ep .aca_module.cmi.text
+group rodata
+section .aca_module.rodata
+group bss
+section .aca_module.noload
+
+sched_caps 1 all
+
+mod_cfg 0 0 0 0 4096 500000 180 180 0 5000 0
+
+
+pin in
+stream_type pcm
+sample_rates 16k
+sample_sizes sample_16b
+sample_containers container_16b
+channel_cfg ch_mono
+
+
+

--- a/converged_sound_open_fw_modules_development/modules/aca_module/aca_config.h
+++ b/converged_sound_open_fw_modules_development/modules/aca_module/aca_config.h
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2021 Intel Corporation. All rights reserved.
+
+
+#ifndef ACA_CONFIG_H_
+#define ACA_CONFIG_H_
+
+#define ACA_MODULE_NOTIFICATION_SUPPORT
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#pragma pack(4)
+
+#ifdef ACA_MODULE_NOTIFICATION_SUPPORT
+/*!
+ * \brief Defines the structure of the notification message which can be sent
+ * from the Aca module to driver.
+ */
+#define ACA_ENVIRONMENT_NOTIFICATION_ID 0
+/*! Value in ms, indicating how often Environment notification is send */
+#define ACA_ENVIRONMENT_NOTIFICATION_PERIOD 2000
+
+struct ACA_EnvironmentNotificationParams
+{
+    uint16_t AcaEnvironmentType_;
+    uint32_t score_;
+};
+#define ACA_SOUND_NOTIFICATION_ID 1
+struct ACA_SoundNotificationParams
+{
+    uint16_t AcaEventType_;
+    uint32_t score_;
+};
+
+//! Example types of sound events.
+typedef enum e_AcaEventType{
+    kEventBabyCry = 0,
+    kEventGlassBreak = 1,
+    kEventAlarm = 2,
+    kEventScream = 3,
+    kEventSpeech = 4,
+    kEventGunshot = 5,
+    kUnknownEvent = 0xFFFFFFFF
+} AcaEventType;
+
+//! Example types of environments.
+typedef enum e_AcaEnvironmentType{
+    kNormalEnv = 0,
+    kUnknownEnv = 0xFFFFFFFF
+} AcaEnvironmentType;
+
+//! State of the detector
+typedef enum e_AcaDetectionState{
+    kEventLowState = 0, //!< set when there's no detection
+    kEventBegin = 1, //!< set when the state changes from low to high
+    kEventHighState = 2, //!< set in the middle of an event
+    kEventEnd = 3 //!< set when the state changes from high to low
+} AcaDetectionState;
+
+//! Information about the event specified in Event Type
+typedef struct AcaResult_
+{
+    AcaResult_(): event_type(kUnknownEvent), score(0), detected(false), state(kEventLowState)
+    {}
+    AcaEventType event_type; //!< selected type of event
+    int32_t score; //!< current highest score for selected event in Q23
+    bool detected; //!< true if the score is currently over threshold, can remain true for multiple frames
+    AcaDetectionState state; //!< state of the detector - detection/no detection or rising/falling edge of event
+} AcaResult;
+
+//! Information about the environment specified in environment Type
+typedef struct AcaEnvironment_
+{
+
+    AcaEnvironment_(): environment_type(kNormalEnv), score(0)
+    {}
+    AcaEnvironmentType environment_type; //!< selected type of event
+    int32_t score; //!< current highest score for selected event in Q23
+} AcaEnvironment;
+
+
+
+#endif //#ifdef ACA_MODULE_NOTIFICATION_SUPPORT
+
+/*!
+ * \brief Defines the structure of the configuration message which can be sent/received
+ * to/from the Aca module through SetConfiguration/GetConfiguration.
+ */
+struct AcaConfig
+{
+    /* Custom module configuration to be set
+     * .... */
+};
+
+typedef struct AcaBss
+{
+    AcaConfig aca_config_;
+    AcaEnvironment aca_environment_params_;
+    AcaResult aca_detection_result_;
+} AcaBss;
+
+#pragma pack()
+
+#endif // ACA_CONFIG_H_

--- a/converged_sound_open_fw_modules_development/modules/aca_module/aca_module.cc
+++ b/converged_sound_open_fw_modules_development/modules/aca_module/aca_module.cc
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2021 Intel Corporation. All rights reserved.
+
+#if defined(XTENSA_TOOLSCHAIN) || defined(__XCC__)
+#include <xtensa/tie/xt_hifi2.h>
+#endif
+
+#include "aca_module.h"
+
+#include <logger.h>
+
+using namespace intel_adsp;
+
+DECLARE_LOADABLE_MODULE(AcaModule,
+                        AcaModuleFactory)
+
+
+ErrorCode::Type AcaModuleFactory::Create(
+    SystemAgentInterface &system_agent,
+    ModulePlaceholder *module_placeholder,
+    ModuleInitialSettings initial_settings
+    )
+{
+    // count of input pins formats retrieved from the ModuleInitialSettings container
+    const size_t in_pins_format_count = initial_settings.GetItem<IN_PINS_FORMAT>().GetLength();
+    // count of output pins formats retrieved from the ModuleInitialSettings container
+    const size_t out_pins_format_count = initial_settings.GetItem<OUT_PINS_FORMAT>().GetLength();
+
+    LOG_MESSAGE(    LOW, "Create(in_pins_format_count = %d, out_pins_format_count=%d)",
+                    LOG_ENTRY, in_pins_format_count, out_pins_format_count);
+
+    // check that one audio format is available for the input pin
+    if (in_pins_format_count < 1 || out_pins_format_count != 1)
+    {
+        LOG_MESSAGE(    CRITICAL, "Invalid count of input pin formats received (%d)",
+                        LOG_ENTRY, in_pins_format_count);
+        return ErrorCode::INVALID_SETTINGS;
+    }
+
+    InputPinFormat const& input_pin_format = initial_settings.GetItem<IN_PINS_FORMAT>()[0];
+    OutputPinFormat const& output_pin_format = initial_settings.GetItem<OUT_PINS_FORMAT>()[0];
+    // check that audio format retrieved for input is assigned to an existing module pin.
+    if (input_pin_format.pin_index != 0 || output_pin_format.pin_index != 0 || input_pin_format.ibs != output_pin_format.obs )
+    {
+        LOG_MESSAGE(    CRITICAL, "Retrieved audio format is associated to an invalid input pin index (%d)",
+                        LOG_ENTRY, input_pin_format.pin_index);
+        return ErrorCode::INVALID_SETTINGS;
+    }
+
+    // check that ibs can be divided by the bytes size of "samples group"
+    if ((input_pin_format.ibs * 8) % (input_pin_format.audio_fmt.bit_depth * input_pin_format.audio_fmt.number_of_channels))
+    {
+        LOG_MESSAGE(    CRITICAL, "ibs*8 shall be a multiple of samples group value: "
+                        "ibs = %d, input_bit_depth = %d.",
+                        LOG_ENTRY, input_pin_format.ibs, input_pin_format.audio_fmt.bit_depth);
+         return ErrorCode::INVALID_SETTINGS;
+    }
+
+    // Initializes AcaModule instance using the
+    // "placement syntax" of operator new
+    new (module_placeholder)AcaModule(
+        input_pin_format.audio_fmt.number_of_channels,
+        input_pin_format.audio_fmt.bit_depth,
+        input_pin_format.audio_fmt.sampling_frequency,
+        input_pin_format.ibs,
+        system_agent);
+
+    return ErrorCode::NO_ERROR;
+}
+
+// Note that purpose of the source code presented below is to demonstrate usage
+// of the ADSP System API.
+// It might not be optimized enough for efficient computation.
+uint32_t AcaModule::Process(
+    InputStreamBuffer* input_stream_buffers,
+    OutputStreamBuffer* output_stream_buffers)
+{
+    InternalError ec = PROCESS_SUCCEED;
+    uint8_t* input_buffer = input_stream_buffers[0].data;
+    size_t data_size = input_stream_buffers[0].size;
+
+    if (input_buffer != NULL)
+    {
+        ec = CheckEnvironment(input_buffer, data_size);
+        if(ec != PROCESS_SUCCEED) return ec;
+
+        ec = CheckResult(input_buffer, data_size);
+    }
+    return (uint32_t)ec;
+}
+
+AcaModule::InternalError AcaModule::CheckEnvironment(uint8_t* input_buffer, size_t data_size)
+{
+    InternalError ec = PROCESS_SUCCEED;
+
+    // ec = ACA_InternalEnvironmentProcess(&bss_, input_buffer, data_size) /* to implement */
+    // if (ec != PROCESS_SUCCEED) return ec;
+
+    ACA_Environment_notification_counter_++;
+#ifdef ACA_MODULE_NOTIFICATION_SUPPORT
+    if( ACA_Environment_notification_counter_ == (ACA_ENVIRONMENT_NOTIFICATION_PERIOD / ms_per_frame_))
+    {
+        // NOTE: 2 second reached, send environment notification, set notification_counter to 0.
+        ACA_Environment_notification_counter_ = 0;
+
+        bss_.aca_environment_params_.score = bss_.aca_environment_params_.score;
+        bss_.aca_environment_params_.environment_type = kNormalEnv;
+
+        LOG_MESSAGE(MEDIUM, "Environment (%d) notify score (%d):", LOG_ENTRY, bss_.aca_environment_params_.environment_type, bss_.aca_environment_params_.score);
+        ec = Send_ACA_Environment_Notification();
+    }
+#endif
+    return ec;
+}
+
+AcaModule::InternalError AcaModule::CheckResult(uint8_t* input_buffer, size_t data_size)
+{
+    InternalError ec = PROCESS_SUCCEED;
+    // ec = ACA_InternalSoundProcess(&bss_, input_buffer, data_size) /* to implement */
+    // if (ec != PROCESS_SUCCEED) return ec;
+    if(bss_.aca_detection_result_.detected)
+    {
+        bss_.aca_detection_result_.score = bss_.aca_detection_result_.score + 1;
+        bss_.aca_detection_result_.event_type = kEventScream;
+        bss_.aca_detection_result_.state = kEventHighState;
+        LOG_MESSAGE(HIGH, "Event (%d) notify score (%d):", LOG_ENTRY, bss_.aca_detection_result_.event_type, bss_.aca_detection_result_.score);
+        ec = Send_ACA_Sound_Notification();
+    }
+    return ec;
+}
+#ifdef ACA_MODULE_NOTIFICATION_SUPPORT
+AcaModule::InternalError AcaModule::Send_ACA_Environment_Notification()
+{
+    InternalError ec = PROCESS_SUCCEED;
+    ACA_EnvironmentNotificationParams* notification_data =
+        notification_environment_message_.GetNotification<ACA_EnvironmentNotificationParams>
+                                                         (ACA_ENVIRONMENT_NOTIFICATION_ID, GetSystemService()/* system_service reference */);
+    if (notification_data != NULL)
+    {
+        notification_data->AcaEnvironmentType_ = bss_.aca_environment_params_.environment_type;
+        notification_data->score_ = bss_.aca_environment_params_.score;
+        notification_environment_message_.Send(GetSystemService());
+        ec = PROCESS_SUCCEED;
+    }
+    else
+    {
+        ec = PROCESS_NOTIFICATION_ERROR;
+    }
+
+    return ec;
+}
+AcaModule::InternalError AcaModule::Send_ACA_Sound_Notification()
+{
+    InternalError ec = PROCESS_SUCCEED;
+    ACA_SoundNotificationParams* notification_data =
+        notification_event_message_.GetNotification<ACA_SoundNotificationParams>
+                                                   (ACA_SOUND_NOTIFICATION_ID, GetSystemService()/* system_service reference */);
+    if (notification_data != NULL)
+    {
+        notification_data->AcaEventType_ = bss_.aca_detection_result_.event_type;
+        notification_data->score_ = bss_.aca_detection_result_.score;
+        notification_event_message_.Send(GetSystemService());
+        ec = PROCESS_SUCCEED;
+    }
+    else
+    {
+        ec = PROCESS_NOTIFICATION_ERROR;
+    }
+
+    return ec;
+}
+#endif //#ifdef ACA_MODULE_NOTIFICATION_SUPPORT
+ErrorCode::Type AcaModule::SetConfiguration(
+    uint32_t config_id,
+    ConfigurationFragmentPosition fragment_position,
+    uint32_t data_offset_size,
+    const uint8_t *fragment_block,
+    size_t fragment_size,
+    uint8_t *response,
+    size_t &response_size)
+{
+    const AcaConfig *cfg =
+        reinterpret_cast<const AcaConfig *>(fragment_block);
+    // TODO parse configuration here
+    LOG_MESSAGE(LOW, "SetConfiguration()", LOG_ENTRY);
+    return ErrorCode::NO_ERROR;
+}
+
+ErrorCode::Type AcaModule::GetConfiguration(
+    uint32_t config_id,
+    ConfigurationFragmentPosition fragment_position,
+    uint32_t &data_offset_size,
+    uint8_t *fragment_buffer,
+    size_t &fragment_size)
+{
+    LOG_MESSAGE(LOW, "GetConfiguration()", LOG_ENTRY);
+    return ErrorCode::NO_ERROR;
+}
+
+void AcaModule::SetProcessingMode(ProcessingMode mode)
+{
+    LOG_MESSAGE(LOW, "SetProcessingMode()", LOG_ENTRY);
+
+    // Store module mode
+    processing_mode_ = mode;
+}
+
+ProcessingMode AcaModule::GetProcessingMode()
+{
+    LOG_MESSAGE(LOW, "GetProcessingMode()", LOG_ENTRY);
+
+    return processing_mode_;
+}
+
+void AcaModule::Reset()
+{
+    LOG_MESSAGE(LOW, "Reset", LOG_ENTRY);
+    processing_mode_ = ProcessingMode::NORMAL;
+
+    // Leave config_ parameters unchanged.
+}

--- a/converged_sound_open_fw_modules_development/modules/aca_module/aca_module.h
+++ b/converged_sound_open_fw_modules_development/modules/aca_module/aca_module.h
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2021 Intel Corporation. All rights reserved.
+
+
+#ifndef ACA_MODULE_H_
+#define ACA_MODULE_H_
+
+
+#include "loadable_processing_module.h"
+#include "build/module_design_config.h"
+#include "aca_config.h"
+
+#ifdef ACA_MODULE_NOTIFICATION_SUPPORT
+#include <notification_message.h>
+#endif
+
+/*!
+ * \brief The AcaModule class is an implementation example
+ * of ProcessingModuleInterface which simply amplifies the input stream
+ * by a constant gain value.
+ *
+ * The AcaModule is a single input-single output module.
+ * It can take any size of the input frame as long as it is suitable with the length of sample word.
+ */
+class AcaModule : public intel_adsp::ProcessingModule<DESIGN_CONFIG>
+{
+public:
+    /*! \brief Set of error codes value specific to this module
+     */
+    enum InternalError
+    {
+        PROCESS_SUCCEED = 0,
+#ifdef ACA_MODULE_NOTIFICATION_SUPPORT
+        PROCESS_NOTIFICATION_ERROR = 1,
+#endif
+    };
+
+    /*! Defines alias for the base class */
+    typedef intel_adsp::ProcessingModule<DESIGN_CONFIG> ProcessingModule;
+
+    /*! \brief Initializes a new instance of AcaModule
+     *
+     * \param [in] num_channels             number of channels.
+     * \param [in] bits_per_sample          bits per input and output audio sample.
+     * \param [in] sampling_frequency       sampling frequency.
+     * \param [in] ibs                      input buffer size.
+     * \param [in] system_agent             system_agent to check in the instance which is initializing.
+     */
+    AcaModule(
+        uint32_t num_channels,
+        size_t bits_per_sample,
+        uint32_t sampling_frequency,
+        uint32_t ibs,
+        intel_adsp::SystemAgentInterface &system_agent):
+        ProcessingModule(system_agent),
+        ms_per_frame_(ibs / ((bits_per_sample / 8) * num_channels * ( sampling_frequency / 1000 )))
+    {
+        processing_mode_ = intel_adsp::ProcessingMode::NORMAL;
+        ACA_Environment_notification_counter_ = 0;
+    }
+
+    virtual uint32_t Process(intel_adsp::InputStreamBuffer *input_stream_buffers,
+                             intel_adsp::OutputStreamBuffer *output_stream_buffers) /*override*/;
+
+    virtual ErrorCode::Type SetConfiguration(
+        uint32_t config_id,
+        intel_adsp::ConfigurationFragmentPosition fragment_position,
+        uint32_t data_offset_size,
+        const uint8_t *fragment_buffer,
+        size_t fragment_size,
+        uint8_t *response,
+        size_t &response_size
+        );                                     /*override*/
+
+    virtual ErrorCode::Type GetConfiguration(
+        uint32_t config_id,
+        intel_adsp::ConfigurationFragmentPosition fragment_position,
+        uint32_t &data_offset_size,
+        uint8_t *fragment_buffer,
+        size_t &fragment_size
+        );                                     /*override*/
+
+    virtual void SetProcessingMode(intel_adsp::ProcessingMode mode);     /*override*/
+
+    virtual intel_adsp::ProcessingMode GetProcessingMode();     /*override*/
+
+    virtual void Reset();     /*override*/
+
+private:
+    InternalError CheckEnvironment(uint8_t* input_buffer, size_t data_size);
+
+    InternalError CheckResult(uint8_t* input_buffer, size_t data_size);
+#ifdef ACA_MODULE_NOTIFICATION_SUPPORT
+    // function used to send notification
+    InternalError Send_ACA_Environment_Notification();
+
+    InternalError Send_ACA_Sound_Notification();
+#endif //#ifdef ACA_MODULE_NOTIFICATION_SUPPORT
+
+    const uint16_t ms_per_frame_;
+
+    uint16_t ACA_Environment_notification_counter_;
+    // current processing mode
+    intel_adsp::ProcessingMode processing_mode_;
+    // reserves space for module instances' bss
+    AcaBss bss_;
+
+#ifdef ACA_MODULE_NOTIFICATION_SUPPORT
+    // Notification object used to send message to host
+    // NOTE: Template<> is expected to contain max size of the Aca notification messages (if several)
+    intel_adsp::ModuleNotificationMessage<sizeof(ACA_SoundNotificationParams)> notification_event_message_;
+    intel_adsp::ModuleNotificationMessage<sizeof(ACA_EnvironmentNotificationParams)> notification_environment_message_;
+#endif //#ifdef ACA_MODULE_NOTIFICATION_SUPPORT
+
+};     // class AcaModule
+
+class AcaModuleFactory
+    : public intel_adsp::ProcessingModuleFactory<AcaModuleFactory,
+                                     AcaModule>
+{
+public:
+    AcaModuleFactory(
+        intel_adsp::SystemAgentInterface &system_agent)
+        :   intel_adsp::ProcessingModuleFactory<AcaModuleFactory,
+                                    AcaModule>(
+            system_agent)
+    {}
+
+    ErrorCode::Type Create(
+        intel_adsp::SystemAgentInterface &system_agent,
+        intel_adsp::ModulePlaceholder *module_placeholder,
+        intel_adsp::ModuleInitialSettings initial_settings
+        );
+};     // class AcaModuleFactory
+
+#endif // ACA_MODULE_H_

--- a/converged_sound_open_fw_modules_development/modules/aca_module/build/makefile
+++ b/converged_sound_open_fw_modules_development/modules/aca_module/build/makefile
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright(c) 2021 Intel Corporation. All rights reserved.
+
+
+# _CURRENT_MAKEFILE indicates the relative path to this current file
+override _CURRENT_MAKEFILE := $(lastword $(MAKEFILE_LIST))
+# _AMPLIFIER_DIR indicates the relative path to directory of the this current file
+override _ACA_DIR := $(dir $(_CURRENT_MAKEFILE))
+# INTEL_ADSP_DIR indicates the path to the directory of the intel_adsp installation
+INTEL_ADSP_DIR := $(_ACA_DIR)../../../FW/src/intel_adsp/
+
+
+# define MANDATORY VARIABLES for generation of a module package
+#<--
+# path to this makefile file
+TOP_MAKEFILE ?= $(_CURRENT_MAKEFILE)
+# name of the binary file to generate
+MODULE_FILENAME := aca_module
+# SRC_DIRS indicates the list of directories to look for source files
+# Requirements on source directory path:
+# * shall be absolute path or UNC path
+# * can be relative path if all paths are below same drive letter (windows specific) (otherwise some possible name clash can happen)
+# * shall not contain spaces
+# * shall end with '/'
+SRC_DIRS := $(_ACA_DIR)../
+#-->
+
+# define OPTIONAL VARIABLES for generation of a module package
+#<--
+# CXX_INCLUDES indicates the list of include directories for c++  files
+CXX_INCLUDES := $(_ACA_DIR)../
+
+# other possible variables are indicated at beginning of file module_package.mk
+#
+# ROOT_OUT_DIR define the output directory where intermediate and target files will be generated
+# by default ROOT_OUT_DIR is set to generate files in some "out" directory right below the current execution directory.
+# ROOT_OUT_DIR := my_out/
+#-->
+
+# following parameter shall be set to 1 for FDK module
+IS_SELF_CONTAINED := 1
+
+MODULE_PACKAGE_MK?=$(INTEL_ADSP_DIR)build_framework/module_package.mk
+include $(MODULE_PACKAGE_MK)

--- a/converged_sound_open_fw_modules_development/modules/aca_module/build/module_design_config.h
+++ b/converged_sound_open_fw_modules_development/modules/aca_module/build/module_design_config.h
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2021 Intel Corporation. All rights reserved.
+
+/*  (this file was generated -- do not edit)  */
+#ifndef MODULE_DESIGN_CONFIG_H_
+#define MODULE_DESIGN_CONFIG_H_
+
+#define INPUT_NUMBER 1
+#define OUTPUT_NUMBER 0
+
+#include <stdint.h>
+
+/*
+ *  sizeof(queue_buf) for a reference pin (INPUT_NUMBER > 1) equals:
+ *  RoundUp(Max(src_mod_output_chunk_size, designed_mod_input_chunk_size), 64) * 3 + sizeof(queue_object)
+ *  chunk_size = max_sample_group * max_channels_num * max_sample_size / sizeof(uint8_t)
+ */
+#pragma pack(4)
+struct ReferenceQueueBuffers
+{
+};
+#pragma pack()
+
+#define DESIGN_CONFIG  INPUT_NUMBER, OUTPUT_NUMBER, sizeof(ReferenceQueueBuffers)
+
+#endif // MODULE_DESIGN_CONFIG_H_
+/*  (this file was generated -- do not edit)  */


### PR DESCRIPTION
This commit contains converged aca_module example. Aca module
is an implementation example of post-processing module which
simply amplifies the input stream by a constant gain value.
The aca_module is a signle input - single output module.

This PR requires:
- #4222 

to be merged before.

Signed-off-by: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>