### PR TITLE
converged: add downmixer converged module example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,6 @@ ncscope.*
 
 # zephyr files
 zephyr/include/version.h
+
+# converged sound open fw
+!converged_sound_open_fw_modules_development/*

--- a/converged_sound_open_fw_modules_development/FW/intel_common/module_binmaps/downmixer_module.binmap
+++ b/converged_sound_open_fw_modules_development/FW/intel_common/module_binmaps/downmixer_module.binmap
@@ -1,0 +1,45 @@
+module o DOWNMIX
+uuid 1234f1f1-1234-1a34-8c08-884be5d14faa
+name Downmixer module example
+version_major 0x1
+version_minor 0x0
+version_hotfix 0x0
+version_build 0x0
+affinity_mask MASTER_CORE_AFFINITY
+instance_count +2
+domain_types DP
+type FxModule
+stack_size 1000
+
+group text
+section .downmixer_module.text
+section ep .downmixer_module.cmi.text
+group rodata
+section .downmixer_module.rodata
+group bss
+section .downmixer_module.noload
+
+sched_caps 1 all
+
+mod_cfg 0 0 0 0 4096 1000000 512 256 0 0 0
+
+pin in
+stream_type pcm
+sample_rates 16k 44.1k 48k
+sample_sizes sample_16b sample_24b sample_32b
+sample_containers container_16b container_32b
+channel_cfg ch_mono ch_dual_mono ch_stereo ch_2_1 ch_3_0 ch_quad
+
+pin in
+stream_type pcm
+sample_rates 16k 44.1k 48k
+sample_sizes sample_16b sample_24b sample_32b
+sample_containers container_16b container_32b
+channel_cfg ch_mono ch_dual_mono ch_stereo
+
+pin out
+stream_type pcm
+sample_rates 16k 44.1k 48k
+sample_sizes sample_16b sample_24b sample_32b
+sample_containers container_16b container_32b
+channel_cfg ch_mono ch_dual_mono

--- a/converged_sound_open_fw_modules_development/modules/downmixer_module/build/makefile
+++ b/converged_sound_open_fw_modules_development/modules/downmixer_module/build/makefile
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright(c) 2021 Intel Corporation. All rights reserved.
+
+
+# _CURRENT_MAKEFILE indicates the relative path to this current file
+override _CURRENT_MAKEFILE := $(lastword $(MAKEFILE_LIST))
+# _DOWNMIXER_DIR indicates the relative path to directory of the this current file
+override _DOWNMIXER_DIR := $(dir $(_CURRENT_MAKEFILE))
+# INTEL_ADSP_DIR indicates the path to the directory of the intel_adsp installation
+INTEL_ADSP_DIR := $(_DOWNMIXER_DIR)../../../FW/src/intel_adsp/
+
+
+# define MANDATORY VARIABLES for generation of a module package
+#<--
+# path to this makefile file
+TOP_MAKEFILE ?= $(_CURRENT_MAKEFILE)
+# name of the binary file to generate
+MODULE_FILENAME := downmixer_module
+# SRC_DIRS indicates the list of directories to look for source files
+# Requirements on source directory path:
+# * shall be absolute path or UNC path
+# * can be relative path if all paths are below same drive letter (windows specific) (otherwise some possible name clash can happen)
+# * shall not contain spaces
+# * shall end with '/'
+SRC_DIRS := $(_DOWNMIXER_DIR)../
+#-->
+
+# define OPTIONAL VARIABLES for generation of a module package
+#<--
+# CXX_INCLUDES indicates the list of include directories for c++  files
+CXX_INCLUDES := $(_DOWNMIXER_DIR)../
+# other possible variables are indicated at beginning of file module_package.mk
+#
+# ROOT_OUT_DIR define the output directory where intermediate and target files will be generated
+# by default ROOT_OUT_DIR is set to generate files in some "out" directory right below the current execution directory.
+# ROOT_OUT_DIR := my_out/
+#-->
+
+# following parameter shall be set to 1 for FDK module
+IS_SELF_CONTAINED := 1
+ifeq (xtensa,$(TOOLSCHAIN))
+  STATIC_LIBRARIES = $(_XTENSA_CONFIG)/xtensa-elf/lib/xcc/libgcc.a
+else
+  STATIC_LIBRARIES = $(OVERLAY_TOOLS_DIR)/../lib/gcc/xtensa-lx7hifi4-elf/10.2.0/libgcc.a
+  STATIC_LIBRARIES += $(OVERLAY_TOOLS_DIR)/../xtensa-lx7hifi4-elf/lib/libc.a
+endif
+
+include $(INTEL_ADSP_DIR)build_framework/module_package.mk

--- a/converged_sound_open_fw_modules_development/modules/downmixer_module/build/module_design_config.h
+++ b/converged_sound_open_fw_modules_development/modules/downmixer_module/build/module_design_config.h
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2021 Intel Corporation. All rights reserved.
+
+/*  (this file was generated -- do not edit)  */
+#ifndef MODULE_DESIGN_CONFIG_H_
+#define MODULE_DESIGN_CONFIG_H_
+
+#define INPUT_NUMBER 2
+#define OUTPUT_NUMBER 1
+
+#include <stdint.h>
+
+/*
+ *  sizeof(queue_buf) for a reference pin (INPUT_NUMBER > 1) equals:
+ *  RoundUp(Max(src_mod_output_chunk_size, designed_mod_input_chunk_size), 64) * 3 + sizeof(queue_object)
+ *  chunk_size = max_sample_group * max_channels_num * max_sample_size / sizeof(uint8_t)
+ */
+#pragma pack(4)
+struct RefQueueBuffers
+{
+    uint8_t queue1_buf[1360];
+};
+#pragma pack()
+
+#define DESIGN_CONFIG  INPUT_NUMBER, OUTPUT_NUMBER, sizeof(RefQueueBuffers)
+
+#endif // MODULE_DESIGN_CONFIG_H_
+/*  (this file was generated -- do not edit)  */

--- a/converged_sound_open_fw_modules_development/modules/downmixer_module/downmixer_config.h
+++ b/converged_sound_open_fw_modules_development/modules/downmixer_module/downmixer_config.h
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2021 Intel Corporation. All rights reserved.
+
+
+#ifndef DOWNMIXER_CONFIG_H_
+#define DOWNMIXER_CONFIG_H_
+
+#include <stdint.h>
+
+#pragma pack(4)
+
+/*!
+ * \brief Defines the structure of the configuration message which can be sent/received
+ * to/from the Downmixer module through SetConfiguration/GetConfiguration.
+ */
+struct DownmixerConfig
+{
+    /*! \brief Downmixer attenuation for each input */
+    uint32_t divider_input_0;
+    uint32_t divider_input_1;
+};
+
+#pragma pack()
+
+#endif // DOWNMIXER_CONFIG_H_

--- a/converged_sound_open_fw_modules_development/modules/downmixer_module/downmixer_module.cc
+++ b/converged_sound_open_fw_modules_development/modules/downmixer_module/downmixer_module.cc
@@ -1,0 +1,348 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2021 Intel Corporation. All rights reserved.
+
+#include "downmixer_module.h"
+
+#include <logger.h>
+
+using namespace intel_adsp;
+
+DECLARE_LOADABLE_MODULE(DownmixerModule,
+                        DownmixerModuleFactory)
+
+
+ErrorCode::Type DownmixerModuleFactory::Create(
+        SystemAgentInterface &system_agent,
+        ModulePlaceholder *module_placeholder,
+        ModuleInitialSettings initial_settings)
+{
+    // count of input pins formats retrieved from the ModuleInitialSettings container
+    const size_t in_pins_format_count   = initial_settings.GetItem<IN_PINS_FORMAT>().GetLength();
+    // count of output pins formats retrieved from the ModuleInitialSettings container
+    const size_t out_pins_format_count  = initial_settings.GetItem<OUT_PINS_FORMAT>().GetLength();
+
+    // check that at least 1 audio format has been retrieved for 1 input pin
+    // and there are no more audio formats than the module input pins count.
+    if ((in_pins_format_count < 1) || (in_pins_format_count > DownmixerModule::kInputCount))
+    {
+        LOG_MESSAGE(    CRITICAL, "Invalid count of input pin formats received (%d)",
+                        LOG_ENTRY, in_pins_format_count);
+        return ErrorCode::INVALID_SETTINGS;
+    }
+
+    // check that one audio format is available for the output pin
+    if (out_pins_format_count != 1)
+    {
+        LOG_MESSAGE(    CRITICAL, "Invalid count of output pin formats received (%d)",
+                        LOG_ENTRY, out_pins_format_count);
+        return ErrorCode::INVALID_SETTINGS;
+    }
+
+    OutputPinFormat const& output_pin_format    = initial_settings.GetItem<OUT_PINS_FORMAT>()[0];
+    // check that output audio format is for output pin0
+    if (output_pin_format.pin_index != 0)
+    {
+        LOG_MESSAGE(    CRITICAL, "Retrieved audio format is associated to an invalid output pin index (%d)",
+                        LOG_ENTRY, out_pins_format_count);
+        return ErrorCode::INVALID_SETTINGS;
+    }
+
+    // array of input audio format indexed by the input pin index.
+    InputPinFormat input_pin_format[DownmixerModule::kInputCount];
+
+    // initialize each ibs to 0 to indicate that pin format has not yet been configured.
+    for (int i = 0 ; i < DownmixerModule::kInputCount ; i++)
+        input_pin_format[i].ibs = 0;
+
+    for (int i = 0 ; i < in_pins_format_count ; i++)
+    {
+        InputPinFormat const& pin_format = initial_settings.GetItem<IN_PINS_FORMAT>()[i];
+
+        // check that audio format retrieved for input is assigned to an existing module pin.
+        if (pin_format.pin_index >= DownmixerModule::kInputCount)
+        {
+            LOG_MESSAGE(    CRITICAL, "Retrieved audio format is associated to an invalid input pin index (%d)",
+                            LOG_ENTRY, pin_format.pin_index);
+            return ErrorCode::INVALID_SETTINGS;
+        }
+
+        input_pin_format[pin_format.pin_index] = pin_format;
+    }
+
+    // check that at least input pin0 has an audio format
+    if (!input_pin_format[0].ibs)
+    {
+            LOG_MESSAGE(    CRITICAL, "Input pin 0 is not configured", LOG_ENTRY);
+            return ErrorCode::INVALID_SETTINGS;
+    }
+
+    // check that input pin 0 and output pin 0 have compatible audio format
+    if (    (input_pin_format[0].audio_fmt.sampling_frequency != output_pin_format.audio_fmt.sampling_frequency) ||
+            (input_pin_format[0].audio_fmt.bit_depth != output_pin_format.audio_fmt.bit_depth))
+    {
+        LOG_MESSAGE(    CRITICAL, "Input pin0 and output pin0 formats have incompatible audio format: "
+                        "input_freq = %d, output_freq = %d, input_bit_depth = %d, output_bit_depth = %d.",
+                        LOG_ENTRY, input_pin_format[0].audio_fmt.sampling_frequency, output_pin_format.audio_fmt.sampling_frequency,
+                        input_pin_format[0].audio_fmt.bit_depth, output_pin_format.audio_fmt.bit_depth);
+        return ErrorCode::INVALID_SETTINGS;
+    }
+
+    // check that input pin 0 has a supported channels count
+    if (    (input_pin_format[0].audio_fmt.number_of_channels != 1)
+         && (input_pin_format[0].audio_fmt.number_of_channels != 2)
+         && (input_pin_format[0].audio_fmt.number_of_channels != 3)
+         && (input_pin_format[0].audio_fmt.number_of_channels != 4))
+    {
+        LOG_MESSAGE(    CRITICAL, "Input pin0 format has unsupported channels count (%d)",
+                        LOG_ENTRY, input_pin_format[0].audio_fmt.number_of_channels);
+        return ErrorCode::INVALID_SETTINGS;
+    }
+
+    // check that bit_depth value is supported
+    if (    (output_pin_format.audio_fmt.bit_depth != DEPTH_16BIT) &&
+            (output_pin_format.audio_fmt.bit_depth != DEPTH_32BIT))
+    {
+        LOG_MESSAGE(    CRITICAL, " bit depth in audio format is not supported (%d)",
+                        LOG_ENTRY, output_pin_format.audio_fmt.bit_depth);
+        return ErrorCode::INVALID_SETTINGS;
+    }
+
+    // check that output pin has a supported channels count
+    if (   (output_pin_format.audio_fmt.number_of_channels != 1)
+        && (output_pin_format.audio_fmt.number_of_channels != 2) )
+    {
+        LOG_MESSAGE(    CRITICAL, "Output pin format has unsupported channels count (%d)",
+                        LOG_ENTRY, output_pin_format.audio_fmt.number_of_channels);
+        return ErrorCode::INVALID_SETTINGS;
+    }
+
+    // check that pin 0 ibs can be divided by the bytes size of "samples group"
+    if ((input_pin_format[0].ibs * 8) % (input_pin_format[0].audio_fmt.bit_depth * input_pin_format[0].audio_fmt.number_of_channels))
+    {
+        LOG_MESSAGE(    CRITICAL, "ibs0*8 shall be a multiple of samples group value: "
+                        "ibs = %d, input_bit_depth = %d.",
+                        LOG_ENTRY, input_pin_format[0].ibs, input_pin_format[0].audio_fmt.bit_depth);
+        return ErrorCode::INVALID_SETTINGS;
+    }
+
+    // check that obs can be divided by the "bit_depth" settings value
+    if ((output_pin_format.obs * 8) % (output_pin_format.audio_fmt.bit_depth * output_pin_format.audio_fmt.number_of_channels))
+    {
+        LOG_MESSAGE(    CRITICAL, "obs0*8 shall be a multiple of samples group value"
+                        "obs = %d, output_bit_depth = %d.",
+                        LOG_ENTRY, output_pin_format.obs, output_pin_format.audio_fmt.bit_depth);
+        return ErrorCode::INVALID_SETTINGS;
+    }
+
+    if (input_pin_format[1].ibs)
+    {
+        // if some audio format is available to configure the input pin 1
+        // check that input pin 0 and pin 1 have compatible audio format
+        if (    (input_pin_format[0].audio_fmt.sampling_frequency != input_pin_format[1].audio_fmt.sampling_frequency)
+            ||  (input_pin_format[0].audio_fmt.bit_depth != input_pin_format[1].audio_fmt.bit_depth))
+        {
+            LOG_MESSAGE(    CRITICAL, "Input pin0 and input pin1 formats have incompatible audio format: "
+                            "input_freq[0] = %d, input_freq[1] = %d, input_bit_depth[0] = %d, input_bit_depth[1] = %d.",
+                            LOG_ENTRY, input_pin_format[0].audio_fmt.sampling_frequency, input_pin_format[1].audio_fmt.sampling_frequency,
+                            input_pin_format[0].audio_fmt.bit_depth, input_pin_format[1].audio_fmt.bit_depth);
+            return ErrorCode::INVALID_SETTINGS;
+        }
+
+        // check that input pin 1 has a supported channels count
+        if (   (input_pin_format[1].audio_fmt.number_of_channels != 1)
+            && (input_pin_format[1].audio_fmt.number_of_channels != 2) )
+        {
+            LOG_MESSAGE(    CRITICAL, "Input pin1 format has unsupported channels count (%d)",
+                            LOG_ENTRY, input_pin_format[1].audio_fmt.number_of_channels);
+            return ErrorCode::INVALID_SETTINGS;
+        }
+
+        // check that pin 1 ibs can be divided by the bytes size of "samples group"
+        if ((input_pin_format[1].ibs * 8) % (input_pin_format[1].audio_fmt.bit_depth * input_pin_format[1].audio_fmt.number_of_channels))
+        {
+            LOG_MESSAGE(    CRITICAL, "ibs1*8 shall be a multiple of samples group value: "
+                            "ibs = %d, input_bit_depth = %d.",
+                            LOG_ENTRY, input_pin_format[1].ibs, input_pin_format[1].audio_fmt.bit_depth);
+            return ErrorCode::INVALID_SETTINGS;
+        }
+    }
+
+    const size_t input1_channels_count = (input_pin_format[1].ibs) ? input_pin_format[1].audio_fmt.number_of_channels : 0;
+
+    // Log BaseModuleCfgExt
+    LOG_MESSAGE(VERBOSE, "Create, in_pins_format_count = %d, out_pins_format_count = %d", LOG_ENTRY, in_pins_format_count, out_pins_format_count);
+    LOG_MESSAGE(VERBOSE, "Create, input_pin_format[0]: pin_index = %d, ibs = %d", LOG_ENTRY, input_pin_format[0].pin_index, input_pin_format[0].ibs);
+    LOG_MESSAGE(VERBOSE, "Create, input_pin_format[0]: freq = %d, bit_depth = %d, channel_map = %d, channel_config = %d", LOG_ENTRY, input_pin_format[0].audio_fmt.sampling_frequency, input_pin_format[0].audio_fmt.bit_depth, input_pin_format[0].audio_fmt.channel_map, input_pin_format[0].audio_fmt.channel_config);
+    LOG_MESSAGE(VERBOSE, "Create, input_pin_format[0]: interleaving_style = %d, number_of_channels = %d, audio_fmt.valid_bit_depth = %d, sample_type = %d", LOG_ENTRY, input_pin_format[0].audio_fmt.interleaving_style, input_pin_format[0].audio_fmt.number_of_channels, input_pin_format[0].audio_fmt.valid_bit_depth, input_pin_format[0].audio_fmt.sample_type);
+    LOG_MESSAGE(VERBOSE, "Create, input_pin_format[1]: pin_index = %d, ibs = %d", LOG_ENTRY, input_pin_format[1].pin_index, input_pin_format[1].ibs);
+    LOG_MESSAGE(VERBOSE, "Create, input_pin_format[1]: freq = %d, bit_depth = %d, channel_map = %d, channel_config = %d", LOG_ENTRY, input_pin_format[1].audio_fmt.sampling_frequency, input_pin_format[1].audio_fmt.bit_depth, input_pin_format[1].audio_fmt.channel_map, input_pin_format[1].audio_fmt.channel_config);
+    LOG_MESSAGE(VERBOSE, "Create, input_pin_format[1]: interleaving_style = %d, number_of_channels = %d, audio_fmt.valid_bit_depth = %d, sample_type = %d", LOG_ENTRY, input_pin_format[1].audio_fmt.interleaving_style, input_pin_format[1].audio_fmt.number_of_channels, input_pin_format[1].audio_fmt.valid_bit_depth, input_pin_format[1].audio_fmt.sample_type);
+    LOG_MESSAGE(VERBOSE, "Create, output_pin_format: pin_index = %d, 0bs = %d", LOG_ENTRY, output_pin_format.pin_index, output_pin_format.obs);
+    LOG_MESSAGE(VERBOSE, "Create, output_pin_format: freq = %d, bit_depth = %d, channel_map = %d, channel_config = %d", LOG_ENTRY, output_pin_format.audio_fmt.sampling_frequency, output_pin_format.audio_fmt.bit_depth, output_pin_format.audio_fmt.channel_map, output_pin_format.audio_fmt.channel_config);
+    LOG_MESSAGE(VERBOSE, "Create, output_pin_format: interleaving_style = %d, number_of_channels = %d, audio_fmt.valid_bit_depth = %d, sample_type = %d", LOG_ENTRY, output_pin_format.audio_fmt.interleaving_style, output_pin_format.audio_fmt.number_of_channels, output_pin_format.audio_fmt.valid_bit_depth, output_pin_format.audio_fmt.sample_type);
+
+    // Initializes DownmixerModule instance using the "placement syntax" of operator new
+    new (module_placeholder) DownmixerModule(
+            output_pin_format.audio_fmt.bit_depth,
+            input_pin_format[0].audio_fmt.number_of_channels,
+            input1_channels_count,
+            output_pin_format.audio_fmt.number_of_channels,
+            system_agent);
+
+    return ErrorCode::NO_ERROR;
+}
+
+
+// Note that purpose of the source code presented below is to demonstrate usage
+// of the ADSP System API.
+// It might not be optimized enough for efficient computation.
+// Processed output = (Pin0Ch1/Div0 + Pin0Ch2/Div0 + Pin0Ch3/Div0 + Pin0Ch4/Div0) + (Pin1Ch1/Div1 + Pin0Ch2/Div1)
+// If module output is configured in 2 channel, output is dual mono
+uint32_t DownmixerModule::Process(
+        InputStreamBuffer *input_stream_buffers,
+        OutputStreamBuffer *output_stream_buffers)
+{
+    uint8_t const* input_buffer_0 = input_stream_buffers[0].data;
+    // if input1_channels_count_ is worth 0, the pin 1 has not been configured and shall be discarded
+    uint8_t const* input_buffer_1 = (input1_channels_count_) ? input_stream_buffers[1].data : NULL;
+    uint8_t* output_buffer = output_stream_buffers[0].data;
+    size_t data_size_0 = input_stream_buffers[0].size;
+    size_t data_size_1 = input_stream_buffers[1].size;
+    size_t data_size_per_channel = ( (output_stream_buffers[0].size/output_channels_count_) <= (data_size_0/input0_channels_count_)) ?
+            output_stream_buffers[0].size/output_channels_count_ : data_size_0/input0_channels_count_;
+    size_t output_data_size = output_channels_count_*data_size_per_channel;
+    // ref_pin_active value indicates whether ref pin is connected and has been configured
+    bool const ref_pin_active = ((input_buffer_1 == NULL) || ((data_size_1/input1_channels_count_) < data_size_per_channel))  ? false : true;
+
+    // If reference pin is not connected or module is in bypass mode,
+    // set local_input1_channel_count to 0.
+    // This allows to skip reference pin content in the processing loop
+    size_t local_input1_channel_count = (ref_pin_active && (processing_mode_ == ProcessingMode::NORMAL) ) ? input1_channels_count_ : 0;
+
+    // Input not connected.
+    if (input_buffer_0 == NULL) {
+        output_stream_buffers[0].size = 0;
+        return PROCESS_SUCCEED;
+    }
+
+    // Apply processing of the input chunks and generate the output chunk
+    int32_t divider_input_0 = config_.divider_input_0;
+    int32_t divider_input_1 = config_.divider_input_1;
+
+    if (processing_mode_ == ProcessingMode::BYPASS) {
+        divider_input_0 = input0_channels_count_;
+        // local_input1_channel_count is already set to 0 in BYPASS mode
+    }
+
+    if (bits_per_sample_ == DEPTH_16BIT)
+    {
+        int16_t const* input_buffer16_0 = reinterpret_cast<int16_t const*>(input_buffer_0);
+        int16_t const* input_buffer16_1 = reinterpret_cast<int16_t const*>(input_buffer_1);
+        int16_t* output_buffer16 = reinterpret_cast<int16_t*>(output_buffer);
+
+        for (size_t i = 0 ; i < output_data_size / output_channels_count_ / sizeof(int16_t) ; i++)
+        {
+            int32_t mixed_sample = 0;
+            for (size_t k = 0; k < input0_channels_count_; k++)
+                mixed_sample += ((int32_t) input_buffer16_0[input0_channels_count_*i + k]/divider_input_0);
+            for (size_t k = 0; k < local_input1_channel_count; k++)
+                mixed_sample += ((int32_t) input_buffer16_1[local_input1_channel_count*i + k]/divider_input_1);
+            for (size_t k = 0; k < output_channels_count_; k++)
+                output_buffer16[output_channels_count_*i + k] = (int16_t) mixed_sample;
+        }
+    }
+
+    if (bits_per_sample_ == DEPTH_32BIT)
+    {
+        int32_t const* input_buffer32_0 = reinterpret_cast<int32_t const*>(input_buffer_0);
+        int32_t const* input_buffer32_1 = reinterpret_cast<int32_t const*>(input_buffer_1);
+        int32_t* output_buffer32 = reinterpret_cast<int32_t*>(output_buffer);
+
+        for (size_t i = 0 ; i < output_data_size / output_channels_count_ / sizeof(int32_t) ; i++)
+        {
+            int64_t mixed_sample = 0;
+            for (size_t k = 0; k < input0_channels_count_; k++)
+                mixed_sample += ((int64_t) input_buffer32_0[input0_channels_count_*i + k]/divider_input_0);
+            for (size_t k = 0; k < local_input1_channel_count; k++)
+                mixed_sample += ((int64_t) input_buffer32_1[local_input1_channel_count*i + k]/divider_input_1);
+            for (size_t k = 0; k < output_channels_count_; k++)
+                output_buffer32[output_channels_count_*i + k] = (int32_t) mixed_sample;
+        }
+    }
+
+    // Update output buffer data size
+    output_stream_buffers[0].size = output_data_size;
+
+    return PROCESS_SUCCEED;
+}
+
+ErrorCode::Type DownmixerModule::SetConfiguration(
+        uint32_t config_id,
+        ConfigurationFragmentPosition fragment_position,
+        uint32_t data_offset_size,
+        const uint8_t *fragment_block,
+        size_t fragment_size,
+        uint8_t *response,
+        size_t &response_size)
+{
+    const DownmixerConfig *cfg =
+        reinterpret_cast<const DownmixerConfig *>(fragment_block);
+
+    LOG_MESSAGE(LOW, "SetConfiguration: "
+                "config_id = %d, data_offset_size = %d, fragment_size = %d",
+                LOG_ENTRY, config_id, data_offset_size, fragment_size);
+
+    if ( (cfg->divider_input_0 == 0) || (cfg->divider_input_1 == 0) )
+    {
+        return ErrorCode::INVALID_CONFIGURATION;
+    }
+    else
+    {
+        config_.divider_input_0 = cfg->divider_input_0;
+        config_.divider_input_1 = cfg->divider_input_1;
+        LOG_MESSAGE(LOW, "SetConfiguration: divider_input_0 = %d, divider_input_1 = %d", LOG_ENTRY, config_.divider_input_0, config_.divider_input_1);
+        return ErrorCode::NO_ERROR;
+    }
+}
+
+ErrorCode::Type DownmixerModule::GetConfiguration(
+        uint32_t config_id,
+        ConfigurationFragmentPosition fragment_position,
+        uint32_t &data_offset_size,
+        uint8_t *fragment_buffer,
+        size_t &fragment_size)
+{
+
+    DownmixerConfig *cfg =
+        reinterpret_cast<DownmixerConfig *>(fragment_buffer);
+
+    LOG_MESSAGE(LOW, "GetConfiguration: config_id(%d)", LOG_ENTRY, config_id);
+
+    cfg->divider_input_0 = config_.divider_input_0;
+    cfg->divider_input_1 = config_.divider_input_1;
+    data_offset_size = sizeof(DownmixerConfig);
+    return ErrorCode::NO_ERROR;
+
+}
+
+void DownmixerModule::SetProcessingMode(ProcessingMode mode)
+{
+    LOG_MESSAGE(LOW, "SetProcessingMode", LOG_ENTRY);
+
+    // Store module mode
+    processing_mode_ = mode;
+}
+
+ProcessingMode DownmixerModule::GetProcessingMode()
+{
+    LOG_MESSAGE(LOW, "GetProcessingMode", LOG_ENTRY);
+
+    return processing_mode_;
+}
+
+void DownmixerModule::Reset()
+{
+    LOG_MESSAGE(LOW, "Reset", LOG_ENTRY);
+    processing_mode_ = ProcessingMode::NORMAL;
+}

--- a/converged_sound_open_fw_modules_development/modules/downmixer_module/downmixer_module.h
+++ b/converged_sound_open_fw_modules_development/modules/downmixer_module/downmixer_module.h
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2021 Intel Corporation. All rights reserved.
+
+
+#ifndef DOWNMIXER_MODULE_H_
+#define DOWNMIXER_MODULE_H_
+
+
+#include "loadable_processing_module.h"
+#include "build/module_design_config.h"
+#include "downmixer_config.h"
+
+
+/*!
+ * \brief The DownmixerModule class is an implementation example of the ProcessingModuleInterface
+ *  which performs a weighted average of 2 input audio streams.
+ *
+ * The DownmixerModule is a 2 inputs/single output module. It is also a "sampled-based" module i.e.
+ * it can process any size of input buffer as long as it is suitable with (divisible by) the size of a sample group.
+ * A sample group corresponds to a frame of samples containing 1 sample per available channel in an input or an output stream.
+ *
+ * Supported audio settings:
+ * * 1 or 2 inputs can be connected. "Master" input settings for pin with index 0 is mandatory.
+ * * If only "master" input is connected, reference pin format shall be supplied anyway in case of dynamic connection.
+ * * The audio input and output samples can have 16 bits or 32 bits depth
+ * (however all inputs and outputs shall be configured with the same bit depth).
+ * * Sampling frequency shall be configured identically for all inputs and output.
+ * * The input pin 0 can be fed with 1 to 4 channels.
+ * * The input pin 1 can be fed with 1 or 2 channels.
+ * * The output pin can be fed with 1 or 2 channels independently from input configurations.
+ * * The output signal is the sum of all the signals (channels) on Master pin plus all the signals (channels) on reference pin
+ * weighted with divider factor meant to avoid saturations. If 2 channels format is required for output, the channel 0 is
+ * duplicated into channel 1.
+ */
+
+class DownmixerModule : public intel_adsp::ProcessingModule<DESIGN_CONFIG>
+{
+public:
+    /*! \brief Set of error codes value specific to this module
+     */
+    enum InternalError
+    {
+        PROCESS_SUCCEED = 0,
+        INVALID_IN_BUFFERS_SIZE = 1,
+        INVALID_CONFIGURATION = 2
+    };
+
+    /*! Defines alias for the base class */
+    typedef intel_adsp::ProcessingModule<DESIGN_CONFIG> ProcessingModule;
+
+    /*! \brief Initializes a new instance of DownmixerModule
+     *
+     * \param [in] bits_per_sample          number of bits per sample for the inputs and output audio samples.
+     * \param [in] input0_channels_count    count of channels for the input pin 0.
+     * \param [in] input1_channels_count    count of channels for the input pin 1.
+     * \param [in] output_channels_count    count of channels for the output pin.
+     * \param [in] system_agent             to check in the instance which is initializing.
+     */
+    DownmixerModule(
+            intel_adsp::BitDepth bits_per_sample,
+            size_t input0_channels_count,
+            size_t input1_channels_count,
+            size_t output_channels_count,
+            intel_adsp::SystemAgentInterface &system_agent) :
+        ProcessingModule(system_agent),
+        bits_per_sample_(bits_per_sample),
+        input0_channels_count_(input0_channels_count),
+        input1_channels_count_(input1_channels_count),
+        output_channels_count_(output_channels_count)
+    {
+        processing_mode_ = intel_adsp::ProcessingMode::NORMAL;
+        config_.divider_input_0 = input0_channels_count_ + input1_channels_count_;
+        config_.divider_input_1 = config_.divider_input_0;
+    }
+
+    virtual uint32_t Process(
+        intel_adsp::InputStreamBuffer *input_stream_buffers,
+        intel_adsp::OutputStreamBuffer *output_stream_buffers) /*override*/;
+
+    virtual ErrorCode::Type SetConfiguration(
+        uint32_t config_id,
+        intel_adsp::ConfigurationFragmentPosition fragment_position,
+        uint32_t data_offset_size,
+        const uint8_t *fragment_buffer,
+        size_t fragment_size,
+        uint8_t *response,
+        size_t &response_size) /*override*/;
+
+    virtual ErrorCode::Type GetConfiguration(
+        uint32_t config_id,
+        intel_adsp::ConfigurationFragmentPosition fragment_position,
+        uint32_t &data_offset_size,
+        uint8_t *fragment_buffer,
+        size_t &fragment_size) /*override*/;
+
+    /*! \brief SetProcessingMode
+     *  BY_PASS mode averages the 2 inputs. (Input_1 + Input_2) / 2.
+     *  NORMAL  mode applies the divider values to each input passed by the SetConfiguration() call.
+     *  Default mode is BY_PASS mode.
+     */
+    virtual void SetProcessingMode(intel_adsp::ProcessingMode mode); /*override*/
+
+    virtual intel_adsp::ProcessingMode GetProcessingMode(); /*override*/
+
+    virtual void Reset(); /*override*/
+
+private:
+
+    // Indicates the bits per audio sample in the input streams and to produce in the output stream
+    const size_t bits_per_sample_;
+    // Indicates the count of channels on the input pin 0.
+    const size_t input0_channels_count_;
+    // Indicates the count of channels on the input pin 1. It can be worth 0 if the input pin 1 has not been configued.
+    // If so, any audio samples reaching the input pin 1 will be discarded.
+    const size_t input1_channels_count_;
+    // Indicates the count of channels on the output pin.
+    const size_t output_channels_count_;
+    // Indicates tCurrent active configuration
+    DownmixerConfig config_;
+    // current processing mode
+    intel_adsp::ProcessingMode processing_mode_;
+
+}; // class DownmixerModule
+
+class DownmixerModuleFactory
+    : public intel_adsp::ProcessingModuleFactory<DownmixerModuleFactory,
+                                     DownmixerModule>
+{
+public:
+    DownmixerModuleFactory(intel_adsp::SystemAgentInterface &system_agent)
+        : intel_adsp::ProcessingModuleFactory<DownmixerModuleFactory,
+                                  DownmixerModule>(system_agent)
+    {}
+
+    ErrorCode::Type Create(
+        intel_adsp::SystemAgentInterface &system_agent,
+        intel_adsp::ModulePlaceholder *module_placeholder,
+        intel_adsp::ModuleInitialSettings initial_settings);
+}; // class DownmixerModuleFactory
+
+#endif // DOWNMIXER_MODULE_H_


### PR DESCRIPTION
This commit contains converged amplifier_module example.
Downmixer_module is a pre-processing module (it should
be used on the capture path). This is a more advanced
module implementation as it supports two pins in the input.
The second input pin is used for the reference signal: when
performing a playback and a record at the same time, the
playback signal is sent on the second input pin as a
reference, as needed for an echo canceller for example.
As for the amplifier, the parameters set is basic and
defined on one configuration ID. The output is the result
of a mix between input and reference signal balanced with
"main_div" and "ref_div" parameter values:
output_signal = input_signal/main_div + reference_signal/ref_div

This PR requires:
- #4222 

to be merged before.

Signed-off-by: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>