### PR TITLE
zephyr: trace: use zephyr utilities when enabled

### DIFF
--- a/zephyr/include/sof/trace/trace.h
+++ b/zephyr/include/sof/trace/trace.h
@@ -9,6 +9,10 @@
 #ifndef ZEPHYR_INCLUDE_LOGGING_LOG_H_
 #include <logging/log.h>
 
+#ifdef __ZEPHYR__
+#include <sys/printk.h>
+#endif
+
 /* Level of SOF trace on Zephyr */
 #define SOF_ZEPHYR_TRACE_LEVEL LOG_LEVEL_INF
 


### PR DESCRIPTION
Use the Zephyr sys/printk.h when Zephyr RTOS is used.

Suggested-by: Guennadi Liakhovetski <guennadi.liakhovetski@linux.intel.com>
Signed-off-by: Iuliana Prodan <iuliana.prodan@nxp.com>