### PR TITLE
topology: remove obsolete s24_4le from COMP_SAMPLE_SIZE

### DIFF
--- a/tools/topology/m4/utils.m4
+++ b/tools/topology/m4/utils.m4
@@ -35,7 +35,7 @@ dnl COMP_SAMPLE_SIZE(FMT)
 define(`COMP_SAMPLE_SIZE',
 `ifelse(
 	$1, `s16le', `2',
-	$1, `s24_4le', `4',
+	$1, `s24le', `4',
 	$1, `s32le', `4',
 	$1, `float', `4',
 	`4')')


### PR DESCRIPTION
Remove definition of s24_4le from COMP_SAMPLE_SIZE macro as it is not
used anywhere. Instead all pipelines are using s24le definition and the
COMP_SAMPLE_SIZE macro works only because it defaults to 4 bytes.

Signed-off-by: Jaska Uimonen <jaska.uimonen@intel.com>