### PR TITLE
zephyr: trace: remove useless #ifdef __ZEPHYR__ macro

### DIFF
--- a/zephyr/include/sof/trace/trace.h
+++ b/zephyr/include/sof/trace/trace.h
@@ -8,10 +8,7 @@
 
 #ifndef ZEPHYR_INCLUDE_LOGGING_LOG_H_
 #include <logging/log.h>
-
-#ifdef __ZEPHYR__
 #include <sys/printk.h>
-#endif
 
 /* Level of SOF trace on Zephyr */
 #define SOF_ZEPHYR_TRACE_LEVEL LOG_LEVEL_INF


### PR DESCRIPTION
Commit 8357dcf793f4 ("zephyr: trace: use zephyr utilities when enabled")
added Zephyr's sys/printk.h in order to fix:
warning: implicit declaration of function 'printk'.

Remove #ifdef __ZEPHYR__ macro since this is not needed, because
the whole file is for Zephyr only.

Fixes: 8357dcf793f4 ("zephyr: trace: use zephyr utilities when enabled")
Signed-off-by: Iuliana Prodan <iuliana.prodan@nxp.com>