### PR TITLE
alloc: add handle to free a buffer with uncached pointer

### DIFF
--- a/src/platform/baytrail/include/platform/lib/memory.h
+++ b/src/platform/baytrail/include/platform/lib/memory.h
@@ -22,6 +22,10 @@ struct sof;
 
 void platform_init_memmap(struct sof *sof);
 
+#define uncache_to_cache(address)	address
+#define cache_to_uncache(address)	address
+#define is_uncached(address)		0
+
 static inline void *platform_shared_get(void *ptr, int bytes)
 {
 	return ptr;

--- a/src/platform/haswell/include/platform/lib/memory.h
+++ b/src/platform/haswell/include/platform/lib/memory.h
@@ -22,6 +22,10 @@ struct sof;
 
 void platform_init_memmap(struct sof *sof);
 
+#define uncache_to_cache(address)	address
+#define cache_to_uncache(address)	address
+#define is_uncached(address)		0
+
 static inline void *platform_shared_get(void *ptr, int bytes)
 {
 	return ptr;

--- a/src/platform/imx8/include/platform/lib/memory.h
+++ b/src/platform/imx8/include/platform/lib/memory.h
@@ -192,6 +192,10 @@ static inline void *platform_shared_get(void *ptr, int bytes)
 	return ptr;
 }
 
+#define uncache_to_cache(address)	address
+#define cache_to_uncache(address)	address
+#define is_uncached(address)		0
+
 /**
  * \brief Function for keeping shared data synchronized.
  * It's used after usage of data shared by different cores.

--- a/src/platform/imx8m/include/platform/lib/memory.h
+++ b/src/platform/imx8m/include/platform/lib/memory.h
@@ -191,6 +191,10 @@ struct sof;
 
 void platform_init_memmap(struct sof *sof);
 
+#define uncache_to_cache(address)	address
+#define cache_to_uncache(address)	address
+#define is_uncached(address)		0
+
 static inline void *platform_shared_get(void *ptr, int bytes)
 {
 	return ptr;


### PR DESCRIPTION
This is aim to fix https://github.com/thesofproject/sof/issues/4237

For shared comp_dev, the address is modified to the uncached one, when
trying to free it, we need to change it back to the allocated cached one,
otherwise, we will free a wrong address with error log like below:

src/lib/alloc.c:462  ERROR free_block(): invalid heap = 0x9e062080, cpu = 1

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>