### PR TITLE
codec_adapter: Fix audio for compress streams

### DIFF
--- a/src/audio/codec_adapter/codec_adapter.c
+++ b/src/audio/codec_adapter/codec_adapter.c
@@ -428,6 +428,7 @@ int codec_adapter_copy(struct comp_dev *dev)
 		/* skipping as lib has not produced anything */
 		comp_err(dev, "codec_adapter_copy() error %x: lib hasn't processed anything",
 			 ret);
+		comp_update_buffer_consume(source, codec->cpd.consumed);
 		goto db_verify;
 	}
 	codec_adapter_copy_from_lib_to_sink(&codec->cpd, &local_buff->stream,


### PR DESCRIPTION
It looks like that Cadence audio codec for some mp3 streams returns that
it hasn't produced any output byte although it consumed the frame.

In this case we need to remove the frame from the input buffer otherwise
the playback will get stuck trying to decode the same frame over and
over.

Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>