### PR TITLE
init: define secondary_core_init() only on MULTICORE

### DIFF
--- a/src/init/init.c
+++ b/src/init/init.c
@@ -112,13 +112,6 @@ int secondary_core_init(struct sof *sof)
 	return err;
 }
 
-#else
-
-static int secondary_core_init(struct sof *sof)
-{
-	return 0;
-}
-
 #endif
 
 static int primary_core_init(int argc, char *argv[], struct sof *sof)
@@ -175,8 +168,10 @@ int main(int argc, char *argv[])
 
 	if (cpu_get_id() == PLATFORM_PRIMARY_CORE_ID)
 		err = primary_core_init(argc, argv, &sof);
+#if CONFIG_MULTICORE
 	else
 		err = secondary_core_init(&sof);
+#endif
 
 	/* should never get here */
 	panic(SOF_IPC_PANIC_TASK);


### PR DESCRIPTION
Define function secondary_core_init() only on MULTICORE.
This fixes:
warning: 'secondary_core_init' defined but not used
while building SOF with Zephyr for i.MX which has only one
DSP core.

Signed-off-by: Iuliana Prodan <iuliana.prodan@nxp.com>