### PR TITLE
ipc4: fix XRUN in capture path

### DIFF
--- a/src/audio/copier.c
+++ b/src/audio/copier.c
@@ -298,6 +298,7 @@ static struct comp_dev *copier_new(const struct comp_driver *drv,
 			goto error_cd;
 	}
 
+	dev->direction = cd->direction;
 	dev->state = COMP_STATE_READY;
 	return dev;
 
@@ -480,6 +481,7 @@ static void update_internal_comp(struct comp_dev *parent, struct comp_dev *child
 	child->period = parent->period;
 	child->pipeline = parent->pipeline;
 	child->priority = parent->priority;
+	child->direction = parent->direction;
 }
 
 /* configure the DMA params */
@@ -533,9 +535,9 @@ static int copier_params(struct comp_dev *dev, struct sof_ipc_stream_params *par
 	if (cd->host) {
 		update_internal_comp(dev, cd->host);
 
-		connect_comp_to_buffer(cd->host, cd->buf, dir);
+		connect_comp_to_buffer(cd->host, buffer, dir);
 		ret = cd->host->drv->ops.params(cd->host, params);
-		connect_comp_to_buffer(dev, cd->buf, dir);
+		connect_comp_to_buffer(dev, buffer, dir);
 	} else if (cd->dai) {
 		update_internal_comp(dev, cd->dai);
 

--- a/src/ipc/handler-ipc4.c
+++ b/src/ipc/handler-ipc4.c
@@ -102,7 +102,7 @@ static int ipc4_comp_params(struct comp_dev *current,
 	if (err < 0 || err == PPL_STATUS_PATH_STOP)
 		return err;
 
-	return pipeline_for_each_comp(current, ctx, current->direction);
+	return pipeline_for_each_comp(current, ctx, dir);
 
 }
 
@@ -121,7 +121,7 @@ static int ipc4_pipeline_params(struct pipeline *p, struct comp_dev *host,
 		.skip_incomplete = true,
 	};
 
-	return param_ctx.comp_func(host, NULL, &param_ctx, PPL_DIR_DOWNSTREAM);
+	return param_ctx.comp_func(host, NULL, &param_ctx, host->direction);
 }
 
 static int ipc4_pcm_params(struct ipc_comp_dev *pcm_dev)
@@ -190,7 +190,11 @@ static int ipc4_set_pipeline_state(union ipc4_message_header *ipc4)
 		return IPC4_INVALID_RESOURCE_ID;
 	}
 
-	host = ipc_get_comp_by_id(ipc, pcm_dev->pipeline->source_comp->ipc_config.id);
+	if (pcm_dev->pipeline->source_comp->direction == SOF_IPC_STREAM_PLAYBACK)
+		host = ipc_get_comp_by_id(ipc, pcm_dev->pipeline->source_comp->ipc_config.id);
+	else
+		host = ipc_get_comp_by_id(ipc, pcm_dev->pipeline->sink_comp->ipc_config.id);
+
 	if (!host) {
 		tr_err(&ipc_tr, "ipc: comp host not found", 
 			pcm_dev->pipeline->source_comp->ipc_config.id);


### PR DESCRIPTION
In current IPC3 path, we always first create host and dai last,
and our pipeline trigger, param, prepare are also designed to
follow this sequence. But for IPC4, source component is always
created first and sink component is last. For capture case dai
is source component and will be created first which is different
from IPC3.

This patch refine IPC4 path to make it compatible with current
pipeline design

Signed-off-by: Rander Wang <rander.wang@intel.com>