### PR TITLE
Restore original, 2018 mtrace_event(atomic) spin lock logic

### DIFF
--- a/src/trace/trace.c
+++ b/src/trace/trace.c
@@ -250,11 +250,11 @@ static void vatrace_log(bool send_atomic, uint32_t log_entry, const struct tr_ct
 #if CONFIG_TRACEM
 	/* send event by mail box too. */
 	if (send_atomic) {
+		mtrace_event((const char *)data, MESSAGE_SIZE(arg_count));
+	} else {
 		spin_lock_irq(&trace->lock, flags);
 		mtrace_event((const char *)data, MESSAGE_SIZE(arg_count));
 		spin_unlock_irq(&trace->lock, flags);
-	} else {
-		mtrace_event((const char *)data, MESSAGE_SIZE(arg_count));
 	}
 #else
 	/* send event by mail box if level is LOG_LEVEL_CRITICAL. */

--- a/tools/logger/convert.c
+++ b/tools/logger/convert.c
@@ -457,7 +457,8 @@ static void print_entry_params(const struct log_entry_header *dma_log,
 
 	if (dma_log->timestamp < last_timestamp) {
 		fprintf(out_fd,
-			"\n\t\t --- negative DELTA: wrap, IPC_TRACE, other? ---\n\n");
+			"\n\t\t --- negative DELTA = %.3f us: wrap, IPC_TRACE, other? ---\n\n",
+			-to_usecs(last_timestamp - dma_log->timestamp));
 		entry_number = 1;
 	}
 

--- a/tools/logger/convert.c
+++ b/tools/logger/convert.c
@@ -836,7 +836,7 @@ static int logger_read(void)
 				log_err("in %s(), fread(..., %s) failed: %s(%d)\n",
 					__func__, global_config->in_file,
 					strerror(-ret), ret);
-				return ret;
+				break;
 			}
 			/* for trace mode, try to reopen */
 			if (global_config->trace) {
@@ -851,7 +851,8 @@ static int logger_read(void)
 					log_err("in %s(), freopen(..., %s) failed: %s(%d)\n",
 						__func__, global_config->in_file,
 						strerror(errno), errno);
-					return -errno;
+					ret = -errno;
+					break;
 				}
 			} else {
 				/* EOF */


### PR DESCRIPTION
2 cosmetic commits + this "atomic" one:

Fixes bad commit b284ac3 ("debugability: Macro Metaprogramming
Refactor") that accidentally swapped mtrace_event() and
mtrace_event_atomic()

Before that accidental inversion, _trace_event_mboxN() functions invoked
spin_lock_irq() whereas _trace_even_mbox_atomicN() did NOT take
locks. That was consistent with the non-mbox, DMA variants of these
functions. As explained in the message of commit 3dca7b7 ("trace:
dma: Add atomic and nowait DMA tracing support."), functions with the
`_atomic()` suffix,, are meant to be used in atomic contexts where the
lock is _already_ taken.

Searching for spin_lock_irq() in the code after the bad commit shows
that the logic was inverted for the _mbox variants: the lock became used
for the _atomic() variants.

The reasons why I can't reproduce any actual issue are likely the same
reasons why this inversion was never noticed:

- no multicore
- very little use of trace_.*_atomic variants
- spin_lock_irq() is re-entrant?

I merely noticed the inconsistency with DMA tracing while trying to
solve unrelated issues in the same places.

The non-mbox, DMA variants were not affected by the bad commit because
for DMA the lock was and is managed in a different file: dma-trace.c.

Searching "spin_lock_irq" in later commit b12a662 ("trace:
Remove metaprogramming from trace implementation") shows that it
preserved this inversion across this second refactor; it left the bug
untouched.