### PR TITLE
wait: print register values if poll_for_register_delay fails

### DIFF
--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -888,8 +888,10 @@ static int dw_dma_copy(struct dma_chan_data *channel, int bytes,
 					      DW_DMA_CHAN_EN,
 					      DW_CHAN(channel->index), 0,
 					      DW_DMA_TIMEOUT);
-		if (ret < 0)
+		if (ret < 0) {
+			tr_dbg(&dwdma_tr, "dw_dma_copy(): poll_for_register_delay timeout");
 			return ret;
+		}
 	}
 
 	dw_dma_verify_transfer(channel, &next);

--- a/src/lib/wait.c
+++ b/src/lib/wait.c
@@ -43,7 +43,8 @@ int poll_for_register_delay(uint32_t reg, uint32_t mask,
 
 	while ((io_reg_read(reg) & mask) != val) {
 		if (!tries--) {
-			tr_err(&wait_tr, "ewt");
+			tr_err(&wait_tr, "poll timeout reg %u mask %u val %u us %u",
+			       reg, mask, val, (uint32_t)us);
 			return -EIO;
 		}
 		wait_delay(delta);


### PR DESCRIPTION
Print register and its values if poll_for_register_delay fails. Also
check the return value and print warning in sai.c

Signed-off-by: Jaska Uimonen <jaska.uimonen@intel.com>