### PR TITLE
Add GET_BIT() and GET_BITS() macros to bit.h

### DIFF
--- a/src/include/sof/bit.h
+++ b/src/include/sof/bit.h
@@ -24,5 +24,9 @@
 #define SET_BIT(b, x)		(((x) & 1) << (b))
 #define SET_BITS(b_hi, b_lo, x)	\
 	(((x) & ((1ULL << ((b_hi) - (b_lo) + 1ULL)) - 1ULL)) << (b_lo))
+#define GET_BIT(b, x) \
+	(((x) & (1ULL << (b))) >> (b))
+#define GET_BITS(b_hi, b_lo, x) \
+	(((x) & MASK(b_hi, b_lo)) >> (b_lo))
 
 #endif /* __SOF_BIT_H__ */


### PR DESCRIPTION
These macros are useful for decoding bit fields.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>