### PR TITLE
codec_adapter: cadence: fix reset procedure + improve prepare

### DIFF
--- a/src/audio/codec_adapter/codec/cadence.c
+++ b/src/audio/codec_adapter/codec/cadence.c
@@ -504,14 +504,22 @@ int cadence_codec_apply_config(struct comp_dev *dev)
 int cadence_codec_reset(struct comp_dev *dev)
 {
 	int ret;
-	struct codec_data *codec = comp_get_codec(dev);
-	struct cadence_codec_data *cd = codec->private;
 
-	API_CALL(cd, XA_API_CMD_INIT, XA_CMD_TYPE_INIT_API_PRE_CONFIG_PARAMS,
-		 NULL, ret);
-	if (ret != LIB_NO_ERROR) {
-		comp_err(dev, "cadence_codec_init(): error %x: failed to reset to default values.",
-			 ret);
+	/* Current CADENCE API doesn't support reset of codec's
+	 * runtime parameters therefore we need to free all the resources
+	 * and start over.
+	 */
+	codec_free_all_memory(dev);
+	ret = cadence_codec_init(dev);
+	if (ret) {
+		comp_err(dev, "cadence_codec_reset() error %x: could not re-initialize codec after reset",
+			ret);
+	}
+
+	ret = cadence_codec_prepare(dev);
+	if (ret) {
+		comp_err(dev, "cadence_codec_reset() error %x: could not re-prepare codec after reset",
+			ret);
 	}
 
 	return ret;

--- a/src/audio/codec_adapter/codec/cadence.c
+++ b/src/audio/codec_adapter/codec/cadence.c
@@ -444,7 +444,26 @@ int cadence_codec_prepare(struct comp_dev *dev)
 			 ret);
 		goto free;
 	}
-
+	/* Check init done status. Note, it may happen that init_done flag will return
+	 * false value, this is normal since some codec variants needs input in order to
+	 * fully finish initialization. That's why at codec_adapter_copy() we call
+	 * codec_init_process() base on result obtained below.
+	 */
+#ifdef CONFIG_CADENCE_CODEC_WRAPPER
+	/* TODO: remove the "#ifdef CONFIG_CADENCE_CODEC_WRAPPER" once cadence fixes the bug
+	 * in the init/prepare sequence. Basically below API_CALL shall return 1 for
+	 * PCM streams and 0 for compress ones. As it turns out currently it returns 1
+	 * in both cases so in turn compress stream won't finish its prepare during first copy
+	 * in codec_adapter_copy().
+	 */
+	API_CALL(cd, XA_API_CMD_INIT, XA_CMD_TYPE_INIT_DONE_QUERY,
+		 &codec->cpd.init_done, ret);
+	if (ret != LIB_NO_ERROR) {
+		comp_err(dev, "cadence_codec_init_process() error %x: failed to get lib init status",
+			 ret);
+		return ret;
+	}
+#endif
 	comp_dbg(dev, "cadence_codec_prepare() done");
 	return 0;
 free:

--- a/src/audio/codec_adapter/codec/generic.c
+++ b/src/audio/codec_adapter/codec/generic.c
@@ -262,14 +262,14 @@ int codec_process(struct comp_dev *dev)
 	comp_dbg(dev, "codec_process() start");
 
 	if (cd->codec.state != CODEC_IDLE) {
-		comp_err(dev, "codec_prepare(): wrong state of codec %x, state %d",
+		comp_err(dev, "codec_process(): wrong state of codec %x, state %d",
 			 cd->ca_config.codec_id, codec->state);
 		return -EPERM;
 	}
 
 	ret = codec->ops->process(dev);
 	if (ret) {
-		comp_err(dev, "codec_prepare() error %d: codec process failed for codec_id %x",
+		comp_err(dev, "codec_process() error %d: codec process failed for codec_id %x",
 			 ret, codec_id);
 		goto out;
 	}

--- a/src/audio/codec_adapter/codec/generic.c
+++ b/src/audio/codec_adapter/codec/generic.c
@@ -339,7 +339,7 @@ int codec_reset(struct comp_dev *dev)
 	/* Codec reset itself to the initial condition after prepare()
 	 * so let's change its state to reflect that.
 	 */
-	codec->state = CODEC_INITIALIZED;
+	codec->state = CODEC_IDLE;
 
 	return 0;
 }


### PR DESCRIPTION
This patch set:
- improves prepare procedure by adding INIT_PROCESS and INIT_DONE API calls
- fixes the reset procedure to address https://github.com/thesofproject/sof/issues/4104
   Cadence documentation doesn't document reset procedure at all so for a long time we were just freeing all the memory codec allocated and start over. However this is very inefficient way of performing simple reset of parameters. Hence this patch  https://github.com/thesofproject/sof/pull/4162/files tried to simplify it and while it does reset parameters it also breaks the flow since XA_CMD_TYPE_INIT_API_PRE_CONFIG_PARAMS is only allowed during INIT phase. After code inspection of the codec library XA_CMD_TYPE_INIT_PROCESS seems to do what we need to perform the reset and hence this patch relies on that API call.
- minor cleanup of wrong comments