### PR TITLE
topology: revert apl-nocodec to static pipelines for now

### DIFF
--- a/tools/topology/CMakeLists.txt
+++ b/tools/topology/CMakeLists.txt
@@ -30,7 +30,7 @@ set(TPLGS
 	"sof-hda-generic-idisp\;sof-hda-generic-idisp\;-DCHANNELS=0\;-DDYNAMIC=1"
 	"sof-hda-generic-idisp\;sof-hda-generic-idisp-2ch\;-DCHANNELS=2\;-DDMICPROC_FILTER1=eq_iir_coef_highpass_40hz_20db_48khz.m4\;-DDMIC16KPROC_FILTER1=eq_iir_coef_highpass_40hz_20db_16khz.m4\;-DDYNAMIC=1"
 	"sof-hda-generic-idisp\;sof-hda-generic-idisp-4ch\;-DCHANNELS=4\;-DDMICPROC_FILTER1=eq_iir_coef_highpass_40hz_20db_48khz.m4\;-DDMIC16KPROC_FILTER1=eq_iir_coef_highpass_40hz_20db_16khz.m4\;-DDYNAMIC=1"
-	"sof-apl-nocodec\;sof-apl-nocodec\;-DDYNAMIC=1"
+	"sof-apl-nocodec\;sof-apl-nocodec"
 	"sof-apl-keyword-detect\;sof-apl-keyword-detect"
 	"sof-bdw-codec\;sof-bdw-rt286\;-DCODEC=RT286"
 	"sof-bdw-codec\;sof-bdw-rt5640\;-DCODEC=RT5640"


### PR DESCRIPTION
This partial, apl-nocodec only revert of commit 426d7816e265 ("topology:
nocodec: switch to dynamic pipelines") solves the `aplay:
set_params:1432: Unable to install hw params:` failure described below.

According to Xiaoyun, it also fixes #4199. This regression has been
opened for more than 2 weeks now.

Note `-DDYNAMIC=0` produces the same output as `-DDYNAMIC=1`. Bug or
feature? EDIT: apparently an `m4` "feature". In that case I recommend `-DDYNAMIC=some_thing`

Reproduction steps:

- Unload the drivers with `sof-test/tools/kmod/sof_remove.sh`

- Insert the drivers and REQUIRED: turn off Power Management [as described in sof-docs](https://thesofproject.github.io/latest/developer_guides/debugability/logger/index.html)

```
sof-test/tools/kmod/sof_insert.sh && echo on |   sudo tee /sys/devices/pci0000:00/0000:00:0e.0/power/control > /dev/null
```

EDIT+ WARNING: all the above must be on the same line NOT to give the DSP time to be suspended which happens after a couple seconds. Tip: `journalctl -f -p 7 -g 'DSP'`

In other words this bug reproduces only on the very first DSP boot.

- sof-test/test-case/check-playback.sh -d 1 -l 1
```
  aplay   -Dhw:0,1 -r 48000 -c 2 -f S16_LE -d 1 /dev/zero -v -q
  aplay: set_params:1432: Unable to install hw params:
```
Trace shows `ERROR ipc: comp X pipeline not found`

Notes:

- aplay seems to fail only once per pipeline. After failing the first
  time, each pipeline seems to be working fine.

- Turning off power management seems required.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>