### PR TITLE
memory: apollolake: enlarge the heap runtime size

### DIFF
--- a/src/platform/apollolake/include/platform/lib/memory.h
+++ b/src/platform/apollolake/include/platform/lib/memory.h
@@ -259,7 +259,7 @@
 #define HEAP_SYS_RT_X_COUNT1024		4
 
 /* Heap section sizes for module pool */
-#define HEAP_RT_COUNT64			128
+#define HEAP_RT_COUNT64			160
 #define HEAP_RT_COUNT128		64
 #define HEAP_RT_COUNT256		128
 #define HEAP_RT_COUNT512		8


### PR DESCRIPTION
This fixes https://github.com/thesofproject/sof/issues/4274

Increase the count of the 64 Bytes block to 160 to address the heap
runtime memory used up issue.

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>