### PR TITLE
add a missing domain unregister call

### DIFF
--- a/src/include/sof/schedule/ll_schedule_domain.h
+++ b/src/include/sof/schedule/ll_schedule_domain.h
@@ -119,6 +119,7 @@ static inline int domain_register(struct ll_schedule_domain *domain,
 				  uint64_t period, struct task *task,
 				  void (*handler)(void *arg), void *arg)
 {
+	int core = cpu_get_id();
 	int ret;
 
 	assert(domain->ops->domain_register);
@@ -129,9 +130,9 @@ static inline int domain_register(struct ll_schedule_domain *domain,
 		/* registered one more task, increase the count */
 		atomic_add(&domain->total_num_tasks, 1);
 
-		if (!domain->registered[cpu_get_id()])
+		if (!domain->registered[core])
 			/* first task of the core, new client registered */
-			domain->registered[cpu_get_id()] = true;
+			domain->registered[core] = true;
 	}
 
 	return ret;
@@ -140,6 +141,7 @@ static inline int domain_register(struct ll_schedule_domain *domain,
 static inline void domain_unregister(struct ll_schedule_domain *domain,
 				     struct task *task, uint32_t num_tasks)
 {
+	int core = cpu_get_id();
 	int ret;
 
 	assert(domain->ops->domain_unregister);
@@ -151,8 +153,8 @@ static inline void domain_unregister(struct ll_schedule_domain *domain,
 		atomic_sub(&domain->total_num_tasks, 1);
 
 		/* the last task of the core, unregister the client/core */
-		if (!num_tasks && domain->registered[cpu_get_id()])
-			domain->registered[cpu_get_id()] = false;
+		if (!num_tasks && domain->registered[core])
+			domain->registered[core] = false;
 	}
 }
 

--- a/src/schedule/ll_schedule.c
+++ b/src/schedule/ll_schedule.c
@@ -109,10 +109,8 @@ static void schedule_ll_task_done(struct ll_schedule_data *sch,
 	 * If this was the last task of the core, unregister the client/core
 	 */
 	if (atomic_sub(&sch->num_tasks, 1) == 1 &&
-	    sch->domain->registered[cpu_get_id()]) {
+	    sch->domain->registered[cpu_get_id()])
 		sch->domain->registered[cpu_get_id()] = false;
-		atomic_sub(&sch->domain->registered_cores, 1);
-	}
 
 	tr_info(&ll_tr, "task complete %p %pU", task, task->uid);
 	tr_info(&ll_tr, "num_tasks %d total_num_tasks %d",


### PR DESCRIPTION
When the last LL task in a domain completes, the domain should be unregistered. This is currently missing.