### PR TITLE
ipc4: introduce initial IPC4 interface

### DIFF
--- a/src/include/ipc4/gateway.h
+++ b/src/include/ipc4/gateway.h
@@ -1,0 +1,189 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2021 Intel Corporation. All rights reserved.
+ */
+
+/*
+ * This file contains structures that are exact copies of an existing ABI used
+ * by IOT middleware. They are Intel specific and will be used by one middleware.
+ *
+ * Some of the structures may contain programming implementations that makes them
+ * unsuitable for generic use and general usage.
+ *
+ * This code is mostly copied "as-is" from existing C++ interface files hence the use of
+ * different style in places. The intention is to keep the interface as close as possible to
+ * original so it's easier to track changes with IPC host code.
+ */
+
+/**
+ * \file include/ipc4/header.h
+ * \brief IPC4 global definitions.
+ * NOTE: This ABI uses bit fields and is non portable.
+ */
+
+#ifndef __SOF_IPC4_GATEWAY_H__
+#define __SOF_IPC4_GATEWAY_H__
+
+#include <stdint.h>
+
+/**< Type of the gateway. */
+enum ipc4_connector_node_id_type {
+	/**< HD/A host output (-> DSP). */
+	ipc4_hda_host_output_class = 0,
+	/**< HD/A host input (<- DSP). */
+	ipc4_hda_host_input_class = 1,
+	/**< HD/A host input/output (rsvd for future use). */
+	ipc4_hda_host_inout_class = 2,
+
+	/**< HD/A link output (DSP ->). */
+	ipc4_hda_link_output_class = 8,
+	/**< HD/A link input (DSP <-). */
+	ipc4_hda_link_input_class = 9,
+	/**< HD/A link input/output (rsvd for future use). */
+	ipc4_hda_link_inout_class = 10,
+
+	/**< DMIC link input (DSP <-). */
+	ipc4_dmic_link_input_class = 11,
+
+	/**< I2S link output (DSP ->). */
+	ipc4_i2s_link_output_class = 12,
+	/**< I2S link input (DSP <-). */
+	ipc4_i2s_link_input_class = 13,
+
+	/**< ALH link output, legacy for SNDW (DSP ->). */
+	ipc4_alh_link_output_class = 16,
+	/**< ALH link input, legacy for SNDW (DSP <-). */
+	ipc4_alh_link_input_class = 17,
+
+	/**< SNDW link output (DSP ->). */
+	ipc4_alh_snd_wire_stream_link_output_class = 16,
+	/**< SNDW link input (DSP <-). */
+	ipc4_alh_snd_wire_stream_link_input_class = 17,
+
+	/**< UAOL link output (DSP ->). */
+	ipc4_alh_uaol_stream_link_output_class = 18,
+	/**< UAOL link input (DSP <-). */
+	ipc4_alh_uaol_stream_link_input_class = 19,
+
+	/**< IPC output (DSP ->). */
+	ipc4_ipc_output_class = 20,
+	/**< IPC input (DSP <-). */
+	ipc4_ipc_input_class = 21,
+
+	/**< I2S Multi gtw output (DSP ->). */
+	ipc4_i2s_multi_link_output_class = 22,
+	/**< I2S Multi gtw input (DSP <-). */
+	ipc4_i2s_multi_link_input_class = 23,
+	/**< GPIO */
+	ipc4_gpio_class = 24,
+	/**< SPI */
+	ipc4_spi_output_class = 25,
+	ipc4_spi_input_class = 26,
+	ipc4_max_connector_node_id_type
+};
+
+/**< Invalid raw node id (to indicate uninitialized node id). */
+#define IPC4_INVALID_NODE_ID	0xffffffff
+
+/**< Base top-level structure of an address of a gateway. */
+/*!
+ * The virtual index value, presented on the top level as raw 8 bits,
+ * is expected to be encoded in a gateway specific way depending on
+ * the actual type of gateway.
+ */
+union ipc4_connector_node_id {
+
+	/**< Raw 32-bit value of node id. */
+	uint32_t dw;
+
+	/**< Bit fields */
+	struct {
+		/**< Index of the virtual DMA at the gateway. */
+		uint32_t v_index : 8;
+
+		/**< Type of the gateway, one of ConnectorNodeId::Type values. */
+		uint32_t dma_type : 5;
+
+		/**< Rsvd field. */
+		uint32_t _rsvd : 19;
+	} f; /**<< Bits */
+} __attribute__((packed, aligned(4)));
+
+#define IPC4_HW_HOST_OUTPUT_NODE_ID_BASE	0x00
+#define IPC4_HW_CODE_LOADER_NODE_ID		0x0F
+#define IPC4_HW_LINK_INPUT_NODE_ID_BASE		0x10
+
+/*!
+ * Attributes are usually provided along with the gateway configuration
+ * BLOB when the FW is requested to instantiate that gateway.
+ *
+ * There are flags which requests FW to allocate gateway related data
+ * (buffers and other items used while transferring data, like linked list)
+ *  to be allocated from a special memory area, e.g low power memory.
+ */
+union ipc4_gateway_attributes {
+
+	/**< Raw value */
+	uint32_t dw;
+
+	/**< Access to the fields */
+	struct {
+		/**< Gateway data requested in low power memory. */
+		uint32_t lp_buffer_alloc : 1;
+
+		/**< Gateway data requested in register file memory. */
+		uint32_t alloc_from_reg_file : 1;
+
+		/**< Reserved field */
+		uint32_t _rsvd : 30;
+	} bits; /**<< Bits */
+} __attribute__((packed, aligned(4)));
+
+/**< Configuration for the IPC Gateway */
+struct ipc4_gateway_config_blob {
+
+	/**< Size of the gateway buffer, specified in bytes */
+	uint32_t buffer_size;
+
+	/**< Flags */
+	union flags {
+		struct bits {
+			/**< Activates high threshold notification */
+			/*!
+			 * Indicates whether notification should be sent to the host
+			 * when the size of data in the buffer reaches the high threshold
+			 * specified by threshold_high parameter.
+			 */
+			uint32_t notif_high : 1;
+
+			/**< Activates low threshold notification */
+			/*!
+			 * Indicates whether notification should be sent to the host
+			 * when the size of data in the buffer reaches the low threshold
+			 * specified by threshold_low parameter.
+			 */
+			uint32_t notif_low : 1;
+
+			/**< Reserved field */
+			uint32_t rsvd : 30;
+		} f; /**<< Bits */
+		/**< Raw value of flags */
+		uint32_t flags_raw;
+	} u; /**<< Flags */
+
+	/**< High threshold */
+	/*!
+	 * Specifies the high threshold (in bytes) for notifying the host
+	 * about the buffered data level.
+	 */
+	uint32_t threshold_high;
+
+	/**< Low threshold */
+	/*!
+	 * Specifies the low threshold (in bytes) for notifying the host
+	 * about the buffered data level.
+	 */
+	uint32_t threshold_low;
+} __attribute__((packed, aligned(4)));
+
+#endif

--- a/src/include/ipc4/header.h
+++ b/src/include/ipc4/header.h
@@ -9,6 +9,10 @@
  *
  * Some of the structures may contain programming implementations that makes them
  * unsuitable for generic use and general usage.
+ *
+ * This code is mostly copied "as-is" from existing C++ interface files hence the use of
+ * different style in places. The intention is to keep the interface as close as possible to
+ * original so it's easier to track changes with IPC host code.
  */
 
 /**
@@ -22,19 +26,19 @@
 
 #include <stdint.h>
 
-//! Message target, value of msg_tgt field.
+/**< Message target, value of msg_tgt field. */
 enum ipc4_message_target {
-	//! Global FW message
+	/**< Global FW message */
 	SOF_IPC4_MESSAGE_TARGET_FW_GEN_MSG = 0,
-	//! Module message
+	/**< Module message */
 	SOF_IPC4_MESSAGE_TARGET_MODULE_MSG = 1
 };
 
-//! Message direction, value of rsp field.
+/**< Message direction, value of rsp field. */
 enum ipc4_message_direction {
-	//! Request, Notification
+	/**< Request, Notification */
 	SOF_IPC4_MESSAGE_DIR_MSG_REQUEST = 0,
-	//! Reply
+	/**< Reply */
 	SOF_IPC4_MESSAGE_DIR_MSG_REPLY = 1,
 };
 
@@ -42,46 +46,46 @@ enum ipc4_message_direction {
  * Global IPC4 message types - must fit into 5 bits.
  */
 enum ipc4_message_type {
-	//! Boot Config.
+	/**< Boot Config. */
 	SOF_IPC4_GLB_BOOT_CONFIG = 0,
-	//! ROM Control (directed to ROM).
+	/**< ROM Control (directed to ROM). */
 	SOF_IPC4_GLB_ROM_CONTROL = 1,
-	//! Execute IPC gateway command
+	/**< Execute IPC gateway command */
 	SOF_IPC4_GLB_IPCGATEWAY_CMD = 2,
 
 	/* GAP HERE- DO NOT USE - size 10 (3 .. 12)  */
 
-	//! Execute performance measurements command.
+	/**< Execute performance measurements command. */
 	SOF_IPC4_GLB_PERF_MEASUREMENTS_CMD = 13,
-	//! DMA Chain command.
+	/**< DMA Chain command. */
 	SOF_IPC4_GLB_CHAIN_DMA = 14,
-	//! Load multiple modules
+	/**< Load multiple modules */
 	SOF_IPC4_GLB_LOAD_MULTIPLE_MODULES = 15,
-	//! Unload multiple modules
+	/**< Unload multiple modules */
 	SOF_IPC4_GLB_UNLOAD_MULTIPLE_MODULES = 16,
-	//! Create pipeline
+	/**< Create pipeline */
 	SOF_IPC4_GLB_CREATE_PIPELINE = 17,
-	//! Delete pipeline
+	/**< Delete pipeline */
 	SOF_IPC4_GLB_DELETE_PIPELINE = 18,
-	//! Set pipeline state
+	/**< Set pipeline state */
 	SOF_IPC4_GLB_SET_PIPELINE_STATE = 19,
-	//! Get pipeline state
+	/**< Get pipeline state */
 	SOF_IPC4_GLB_GET_PIPELINE_STATE = 20,
-	//! Get pipeline context size
+	/**< Get pipeline context size */
 	SOF_IPC4_GLB_GET_PIPELINE_CONTEXT_SIZE = 21,
-	//! Save pipeline
+	/**< Save pipeline */
 	SOF_IPC4_GLB_SAVE_PIPELINE = 22,
-	//! Restore pipeline
+	/**< Restore pipeline */
 	SOF_IPC4_GLB_RESTORE_PIPELINE = 23,
-	//! Loads library
+	/**< Loads library */
 	SOF_IPC4_GLB_LOAD_LIBRARY = 24,
-	//! Internal FW message
+	/**< Internal FW message */
 	SOF_IPC4_GLB_INTERNAL_MESSAGE = 26,
-	//! Notification (FW to SW driver)
+	/**< Notification (FW to SW driver) */
 	SOF_IPC4_GLB_NOTIFICATION = 27,
 	/* GAP HERE- DO NOT USE - size 3 (28 .. 30)  */
 
-	//! Maximum message number
+	/**< Maximum message number */
 	SOF_IPC4_GLB_MAX_IXC_MESSAGE_TYPE = 31
 };
 
@@ -94,19 +98,54 @@ union ipc4_message_header {
 	uint32_t dat;
 
 	struct {
-		uint32_t rsvd0		: 24;
+		uint32_t rsvd0 : 24;
 
-		//! One of Global::Type
-		uint32_t type		: 5;
+		/**< One of Global::Type */
+		uint32_t type : 5;
 
-		//! Msg::MSG_REQUEST
-		uint32_t rsp		: 1;
+		/**< Msg::MSG_REQUEST */
+		uint32_t rsp : 1;
 
-		//! Msg::FW_GEN_MSG
-		uint32_t msg_tgt	: 1;
+		/**< Msg::FW_GEN_MSG */
+		uint32_t msg_tgt : 1;
 
-		uint32_t _reserved_0: 1;
+		uint32_t _reserved_0 : 1;
 	} r;
 } __attribute__((packed, aligned(4)));
+
+struct ipc4_message_reply {
+	union {
+		uint32_t dat;
+
+		struct {
+			/**< Processing status, one of IxcStatus values */
+			uint32_t status	: 24;
+
+			/**< Type, symmetric to Msg */
+			uint32_t type : 5;
+
+			/**< MSG_REPLY */
+			uint32_t rsp : 1;
+
+			/**< same as request, one of FW_GEN_MSG, MODULE_MSG */
+			uint32_t msg_tgt : 1;
+
+			/**< Reserved field (HW ctrl bits) */
+			uint32_t _reserved_0 : 1;
+		} r;
+	} header;
+
+	union {
+		uint32_t dat;
+
+		struct {
+			/**< Reserved field */
+			uint32_t rsvd1 : 30;
+
+			/**< Reserved field (HW ctrl bits) */
+			uint32_t _reserved_2 : 2;
+		} r;
+	} data;
+} __attribute((packed, aligned(4)));
 
 #endif

--- a/src/include/ipc4/module.h
+++ b/src/include/ipc4/module.h
@@ -1,0 +1,231 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2021 Intel Corporation. All rights reserved.
+ */
+
+/*
+ * This file contains structures that are exact copies of an existing ABI used
+ * by IOT middleware. They are Intel specific and will be used by one middleware.
+ *
+ * Some of the structures may contain programming implementations that makes them
+ * unsuitable for generic use and general usage.
+ *
+ * This code is mostly copied "as-is" from existing C++ interface files hence the use of
+ * different style in places. The intention is to keep the interface as close as possible to
+ * original so it's easier to track changes with IPC host code.
+ */
+
+/**
+ * \file include/ipc4/module.h
+ * \brief IPC4 module definitions
+ * NOTE: This ABI uses bit fields and is non portable.
+ */
+
+#ifndef __IPC4_MODULE_H__
+#define __IPC4_MODULE_H__
+
+#include <stdint.h>
+
+#define SOF_IPC4_DST_QUEUE_ID_BITFIELD_SIZE	3
+#define SOF_IPC4_SRC_QUEUE_ID_BITFIELD_SIZE	3
+
+enum sof_ipc4_module_type {
+	SOF_IPC4_MOD_INIT_INSTANCE		= 0,
+	SOF_IPC4_MOD_CONFIG_GET			= 1,
+	SOF_IPC4_MOD_CONFIG_SET			= 2,
+	SOF_IPC4_MOD_LARGE_CONFIG_GET		= 3,
+	SOF_IPC4_MOD_LARGE_CONFIG_SET		= 4,
+	SOF_IPC4_MOD_BIND			= 5,
+	SOF_IPC4_MOD_UNBIND			= 6,
+	SOF_IPC4_MOD_SET_DX			= 7,
+	SOF_IPC4_MOD_SET_D0IX			= 8,
+	SOF_IPC4_MOD_ENTER_MODULE_RESTORE	= 9,
+	SOF_IPC4_MOD_EXIT_MODULE_RESTORE	= 10,
+	SOF_IPC4_MOD_DELETE_INSTANCE		= 11,
+};
+
+/*
+ * Host Driver sends this message to create a new module instance.
+ */
+struct ipc4_module_init_ext_init {
+	/**< if it is set to 1, proc_domain should be ignored and processing */
+	/* domain is RTOS scheduling */
+	uint32_t rtos_domain : 1;
+	/**< Indicates that GNA is used by a module and additional information */
+	/* (gna_config) is passed after ExtendedData. */
+	uint32_t gna_used    : 1;
+	uint32_t rsvd_0      : 30;
+	uint32_t rsvd_1[2];
+} __attribute__((packed, aligned(4)));
+
+struct ipc4_module_init_ext_data {
+	struct ipc4_module_init_ext_init extended_init;
+
+	/**< Data (actual size set to param_block_size) */
+	uint32_t param_data[0];
+} __attribute__((packed, aligned(4)));
+
+struct ipc4_module_init_gna_config {
+	/**< Number of GNA cycles required to process one input frame. */
+	/* This information is used by DP scheduler to correctly schedule
+	 * a DP module.
+	 */
+	uint32_t gna_cpc;
+	uint32_t rsvd;
+} __attribute__((packed, aligned(4)));
+
+struct ipc4_module_init_data {
+	/**< Data (actual size set to param_block_size) */
+	uint32_t param_data[0];
+} __attribute__((packed, aligned(4)));
+
+/*!
+  Created instance is a child element of pipeline identified by the ppl_id
+  specified by the driver.
+
+  The module_id should be set to an index of the module entry in the FW Image
+  Manifest.
+
+  The instance_id assigned by the driver should be in the
+  0..ModuleEntry.max_instance_count range defined in the FW Image Manifest.
+
+  Initial configuration of the module instance is provided by the driver in
+  the param_data array. Size of the array is specified in param_block_size
+  field of the message header.
+
+  Refer to Module Configuration section of FW I/F Specification for details on
+  module specific initial configuration parameters.
+
+  \remark hide_methods
+*/
+struct ipc4_module_init_instance {
+
+	union {
+		uint32_t dat;
+
+		struct {
+			/**< module id */
+			uint32_t module_id          : 16;
+			/**< instance id */
+			uint32_t instance_id        : 8;
+			/**< ModuleMsg::INIT_INSTANCE */
+			uint32_t type               : 5;
+			/**< Msg::MSG_REQUEST */
+			uint32_t rsp                : 1;
+			/**< Msg::MODULE_MSG */
+			uint32_t msg_tgt            : 1;
+			uint32_t _reserved_0        : 1;
+		} r;
+	} header;
+
+	union {
+		uint32_t dat;
+
+		struct {
+			/**< Size of Data::param_data[] (in dwords) */
+			uint32_t param_block_size   : 16;
+			/**< ID of module instance's parent pipeline */
+			uint32_t ppl_instance_id    : 8;
+			/**< ID of core that instance will run on */
+			uint32_t core_id            : 4;
+			/**< Processing domain, 0-LL, 1-DP */
+			uint32_t proc_domain        : 1;
+			/* reserved in cAVS  */
+			uint32_t extended_init      : 1;
+			uint32_t _hw_reserved_2     : 2;
+		} r;
+	} data;
+
+	struct ipc4_module_init_ext_init ext_init;
+	struct ipc4_module_init_ext_data ext_data;
+	struct ipc4_module_init_gna_config gna_config;
+	struct ipc4_module_init_data init_data;
+} __attribute__((packed, aligned(4)));
+
+/*!
+  SW Driver sends Bind IPC message to connect two module instances together
+  creating data processing path between them.
+
+  Unbind IPC message is sent to destroy a connection between two module instances
+  (belonging to different pipelines) previously created with Bind call.
+
+  NOTE: when both module instances are parts of the same pipeline Unbind IPC would
+  be ignored by FW since FW does not support changing internal topology of pipeline
+  during run-time. The only way to change pipeline topology is to delete the whole
+  pipeline and create it in modified form.
+
+  \remark hide_methods
+ */
+struct ipc4_module_bind_unbind {
+	union {
+		uint32_t dat;
+
+		struct {
+			/**< module id */
+			uint32_t module_id : 16;
+			/**< instance id */
+			uint32_t instance_id : 8;
+			/**< ModuleMsg::BIND / UNBIND. */
+			uint32_t type : 5;
+			/**< Msg::MSG_REQUEST */
+			uint32_t rsp : 1;
+			/**< Msg::MODULE_MSG */
+			uint32_t msg_tgt : 1;
+			uint32_t _reserved_0 : 1;
+		} r;
+	} header;
+
+	union {
+		uint32_t dat;
+
+		struct {
+			/**< destination module id */
+			uint32_t dst_module_id : 16;
+			/**< destination instance id */
+			uint32_t dst_instance_id : 8;
+			/**< destination queue (pin) id */
+			uint32_t dst_queue : SOF_IPC4_DST_QUEUE_ID_BITFIELD_SIZE;
+			/**< source queue (pin) id */
+			uint32_t src_queue : SOF_IPC4_SRC_QUEUE_ID_BITFIELD_SIZE;
+			uint32_t _reserved_2 : 2;
+		} r;
+	} data;
+} __attribute__((packed, aligned(4)));
+
+struct ipc4_module_large_config {
+	union {
+		uint32_t dat;
+
+		struct {
+			/**< module id */
+			uint32_t module_id : 16;
+			/**< instance id */
+			uint32_t instance_id : 8;
+			/**< ModuleMsg::LARGE_CONFIG_GET / LARGE_CONFIG_SET */
+			uint32_t type : 5;
+			/**< Msg::MSG_REQUEST */
+			uint32_t rsp : 1;
+			/**< Msg::MODULE_MSG */
+			uint32_t msg_tgt : 1;
+			uint32_t _reserved_0 : 1;
+			} r;
+		} header;
+
+	union {
+		uint32_t dat;
+
+		struct {
+			/**< data size/offset */
+			uint32_t data_off_size : 20;
+			/**< param type : VENDOR_CONFIG_PARAM / GENERIC_CONFIG_PARAM */
+			uint32_t large_param_id : 8;
+			/**< 1 if final block */
+			uint32_t final_block : 1;
+			/**< 1 if first block */
+			uint32_t init_block : 1;
+			uint32_t _reserved_2 : 2;
+		} r;
+	} data;
+};
+
+#endif

--- a/src/include/ipc4/pipeline.h
+++ b/src/include/ipc4/pipeline.h
@@ -1,0 +1,383 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2021 Intel Corporation. All rights reserved.
+ */
+
+/*
+ * This file contains structures that are exact copies of an existing ABI used
+ * by IOT middleware. They are Intel specific and will be used by one middleware.
+ *
+ * Some of the structures may contain programming implementations that makes them
+ * unsuitable for generic use and general usage.
+ *
+ * This code is mostly copied "as-is" from existing C++ interface files hence the use of
+ * different style in places. The intention is to keep the interface as close as possible to
+ * original so it's easier to track changes with IPC host code.
+ */
+
+/**
+ * \file include/ipc4/pipeline.h
+ * \brief IPC4 pipeline definitions
+ * NOTE: This ABI uses bit fields and is non portable.
+ */
+
+#ifndef __SOF_IPC4_PIPELINE_H__
+#define __SOF_IPC4_PIPELINE_H__
+
+#include <stdint.h>
+
+#define IPC4_IXC_STATUS_BITS		24
+
+/**< Pipeline priority */
+enum ipc4_pipeline_priority {
+	/**< Priority 0 (run first) */
+	SOF_IPC4_PIPELINE_PRIORITY_0 = 0,
+	/**< Priority 1 */
+	SOF_IPC4_PIPELINE_PRIORITY_1,
+	/**< Priority 2 */
+	SOF_IPC4_PIPELINE_PRIORITY_2,
+	/**< Priority 3 */
+	SOF_IPC4_PIPELINE_PRIORITY_3,
+	/**< Priority 4 */
+	SOF_IPC4_PIPELINE_PRIORITY_4,
+	/**< Priority 5 */
+	SOF_IPC4_PIPELINE_PRIORITY_5,
+	/**< Priority 6 */
+	SOF_IPC4_PIPELINE_PRIORITY_6,
+	/**< Priority 7 */
+	SOF_IPC4_PIPELINE_PRIORITY_7,
+	/**< Max (and lowest) priority */
+	SOF_IPC4_MAX_PIPELINE_PRIORITY = SOF_IPC4_PIPELINE_PRIORITY_7
+};
+
+/**< Pipeline State */
+enum ipc4_pipeline_state {
+	/**< Invalid value */
+	SOF_IPC4_PIPELINE_STATE_INVALID = 0,
+	/**< Created but initialization incomplete */
+	SOF_IPC4_PIPELINE_STATE_UNINITIALIZED = 1,
+	/**< Resets pipeline */
+	SOF_IPC4_PIPELINE_STATE_RESET = 2,
+	/**< Pauses pipeline */
+	SOF_IPC4_PIPELINE_STATE_PAUSED = 3,
+	/**< Starts pipeline */
+	SOF_IPC4_PIPELINE_STATE_RUNNING = 4,
+	/**< Marks pipeline as expecting End Of Stream */
+	SOF_IPC4_PIPELINE_STATE_EOS = 5,
+	/**< Stopped on error */
+	SOF_IPC4_PIPELINE_STATE_ERROR_STOP,
+	/**< Saved to the host memory */
+	SOF_IPC4_PIPELINE_STATE_SAVED
+};
+
+/*!
+ * lp - indicates whether the pipeline should be kept on running in low power
+ * mode. On BXT the driver should set this flag to 1 for WoV pipeline.
+ *
+ * \remark hide_methods
+ */
+struct ipc4_pipeline_create {
+
+	union {
+		uint32_t dat;
+
+		struct {
+			/**< # pages for pipeline */
+			uint32_t ppl_mem_size   : 11;
+			/**< priority - uses enum ipc4_pipeline_priority */
+			uint32_t ppl_priority   : 5;
+			/**< pipeline id */
+			uint32_t instance_id    : 8;
+			/**< Global::CREATE_PIPELINE */
+			uint32_t type           : 5;
+			/**< Msg::MSG_REQUEST */
+			uint32_t rsp            : 1;
+			/**< Msg::FW_GEN_MSG */
+			uint32_t msg_tgt        : 1;
+			uint32_t _reserved_0    : 1;
+		} r;
+	} header;
+
+	union{
+		uint32_t dat;
+
+		struct {
+			/**< 1 - is low power */
+			uint32_t lp             : 1;
+			uint32_t rsvd1          : 3;
+			uint32_t attributes     : 16;
+			uint32_t rsvd2          : 10;
+			uint32_t _reserved_2    : 2;
+		} r;
+	} data;
+} __attribute__((packed, aligned(4)));
+
+/*!
+ * SW Driver sends this IPC message to delete a pipeline from ADSP memory.
+ *
+ * All module instances and tasks that are associated with the pipeline are
+ * deleted too.
+ *
+ * There must be no existing binding from any pipeline's module instance
+ * to another pipeline to complete the command successfully.
+ *
+ * \remark hide_methods
+ */
+struct ipc4_pipeline_delete {
+	union {
+		uint32_t dat;
+
+		struct {
+			uint32_t rsvd0          : 16;
+			/**< Ppl instance id */
+			uint32_t instance_id    : 8;
+			/**< Global::DELETE_PIPELINE */
+			uint32_t type           : 5;
+			/**< Msg::MSG_REQUEST */
+			uint32_t rsp            : 1;
+			/**< Msg::FW_GEN_MSG */
+			uint32_t msg_tgt        : 1;
+			uint32_t _reserved_0    : 1;
+		} r;
+	} header;
+
+	union{
+		uint32_t dat;
+
+		struct {
+			uint32_t rsvd1          : 30;
+			uint32_t _reserved_2    : 2;
+		} r;
+	} data;
+} __attribute__((packed, aligned(4)));
+
+/*!
+ * Host SW sends this message to set a pipeline to the specified state.
+ *
+ * If there are multiple pipelines, from FW input to FW output, connected
+ * in a data processing stream, the driver should start them in reverse order,
+ * beginning with pipeline connected to the output gateway, in order to avoid
+ * overruns (FW protects the output gateway against underruns in this scenario).
+ *
+ * If driver starts multiple pipelines using a single Set Pipeline State
+ * command, it should take care of the pipeline ID order in the command payload
+ * to follow the above rule.
+ *
+ * sync_stop_start indicates whether all specified pipelines' gateways should
+ * be started with a minimal delay possible. If this flag is set to 0 while
+ * multiple pipelines are specified, the target pipelines' state is adjusted
+ * pipeline by pipeline meaning that internal propagation to all child modules
+ * may take more time between reaching state of attached gateways. Output and
+ * input gateways are grouped separately, and started/stopped separately.
+ *
+ * NOTE: Task Creation/Registration is part of the first state transition.
+ * There is no other dedicated call for this.
+ *
+ * \remark hide_methods
+ */
+struct ipc4_pipeline_set_state_data {
+	/**< Number of items in ppl_id[] */
+	uint32_t pipelines_count;
+	/**< Pipeline ids */
+	uint32_t ppl_id[0];
+} __attribute__((packed, aligned(4)));
+
+struct ipc4_pipeline_set_state {
+	union {
+		uint32_t dat;
+
+		struct {
+			/**< new state, one of enum ipc4_pipeline_state */
+			uint32_t ppl_state  : 16;
+			/**< pipeline instance id (ignored if multi_ppl =1) */
+			uint32_t ppl_id     : 8;
+			/**< Global::SET_PIPELINE_STATE */
+			uint32_t type       : 5;
+			/**< Msg::MSG_REQUEST */
+			uint32_t rsp        : 1;
+
+			/**< Msg::FW_GEN_MSG */
+			uint32_t msg_tgt    : 1;
+			uint32_t _reserved_0: 1;
+		} r;
+	} header;
+
+	union{
+		uint32_t dat;
+
+		struct {
+			/**< = 1 if there are more pipeline ids in payload */
+			uint32_t multi_ppl  : 1;
+			/**< = 1 if FW should sync state change across multiple ppls */
+			uint32_t sync_stop_start : 1;
+			uint32_t rsvd1      : 28;
+			uint32_t _reserved_2: 2;
+		} r;
+	} data;
+
+	/* multiple pipeline states */
+	struct ipc4_pipeline_set_state_data s_data;
+} __attribute__((packed, aligned(4)));
+
+/**< Reply to Set Pipeline State */
+/*!
+ * In case of error, there is failed pipeline id reported back.
+ *
+  \remark hide_methods
+*/
+struct ipc4_pipeline_set_state_reply {
+	union {
+		uint32_t dat;
+
+		struct {
+			/**< status */
+			uint32_t status     : IPC4_IXC_STATUS_BITS;
+			/**< Global::SET_PIPELINE_STATE */
+			uint32_t type       : 5;
+			/**< Msg::MSG_REPLY */
+			uint32_t rsp        : 1;
+			/**< Msg::FW_GEN_MSG */
+			uint32_t msg_tgt    : 1;
+			uint32_t _reserved_0: 1;
+		} r;
+	} header;
+
+	union{
+		uint32_t dat;
+
+		struct {
+			/**< id of failed pipeline on error */
+			uint32_t ppl_id     : 30;
+			uint32_t _reserved_2: 2;
+		} r;
+	} data;
+} __attribute__((packed, aligned(4)));
+
+/**< This IPC message is sent to the FW in order to retrieve a pipeline state. */
+/*! \remark hide_methods */
+struct ipc4_pipeline_get_state {
+	union {
+		uint32_t dat;
+
+		struct {
+			/**< pipeline id */
+			uint32_t ppl_id     : 8;
+			uint32_t rsvd       : 16;
+			/**< Global::GET_PIPELINE_STATE */
+			uint32_t type       : 5;
+			/**< Msg::MSG_REQUEST */
+			uint32_t rsp        : 1;
+			/**< Msg::FW_GEN_MSG */
+			uint32_t msg_tgt    : 1;
+			uint32_t _reserved_0: 1;
+			} r;
+	} header;
+
+	union{
+		uint32_t dat;
+
+		struct {
+			uint32_t rsvd1      : 30;
+			uint32_t _reserved_2: 2;
+		} r;
+	} data;
+} __attribute__((packed, aligned(4)));
+
+/**< Sent by the FW in response to GetPipelineState. */
+/*! \remark hide_methods */
+struct ipc4_pipeline_get_state_reply {
+	union {
+		uint32_t dat;
+
+		struct {
+			/**< status */
+			uint32_t status      :IPC4_IXC_STATUS_BITS;
+			/**< Global::GET_PIPELINE_STATE */
+			uint32_t type       : 5;
+			/**< Msg::MSG_REPLY */
+			uint32_t rsp        : 1;
+			/**< Msg::FW_GEN_MSG */
+			uint32_t msg_tgt    : 1;
+			uint32_t _reserved_0: 1;
+		} r;
+	} header;
+
+	union{
+		uint32_t dat;
+
+		struct {
+			/**< one of PipelineState */
+			uint32_t state      : 5;
+			uint32_t rsvd1      : 25;
+			uint32_t _reserved_2: 2;
+		} r;
+	} data;
+} __attribute__((packed, aligned(4)));
+
+/*!
+ * The size is expressed in number of pages. It is a total number of memory pages
+ * allocated for pipeline memory buffer and all separately allocated child
+ * module instances.
+ *
+ *  \remark hide_methods
+ */
+struct ipc4_pipeline_get_context_size {
+	union {
+		uint32_t dat;
+
+		struct {
+			uint32_t rsvd0          : 16;
+			/**< pipeline id */
+			uint32_t instance_id    : 8;
+			/**< Global::GET_PIPELINE_CONTEXT_SIZE */
+			uint32_t type           : 5;
+			/**< Msg::MSG_REQUEST */
+			uint32_t rsp            : 1;
+			/**< Msg::FW_GEN_MSG */
+			uint32_t msg_tgt        : 1;
+			uint32_t _reserved_0    : 1;
+		} r;
+	} header;
+
+	union{
+		uint32_t dat;
+
+		struct {
+			uint32_t rsvd1          : 30;
+			uint32_t _reserved_2    : 2;
+		} r;
+	} data;
+} __attribute__((packed, aligned(4)));
+
+/**< Reply to Get Pipeline Context Size. */
+/*! \remark hide_methods */
+struct ipc4_pipeline_get_context_size_reply {
+	union {
+		uint32_t dat;
+
+		struct {
+			/**< status */
+			uint32_t status :IPC4_IXC_STATUS_BITS;
+			/**< Global::GET_PIPELINE_CONTEXT_SIZE */
+			uint32_t type       : 5;
+			/**< Msg::MSG_REPLY */
+			uint32_t rsp        : 1;
+			/**< Msg::FW_GEN_MSG */
+			uint32_t msg_tgt    : 1;
+			uint32_t _reserved_0: 1;
+		} r;
+	} header;
+
+	union{
+		uint32_t dat;
+
+		struct {
+			/**< size of pipeline context (in number of pages) */
+			uint32_t ctx_size   : 16;
+			uint32_t rsvd1      : 14;
+			uint32_t _reserved_2: 2;
+		} r;
+	} data;
+} __attribute__((packed, aligned(4)));
+
+#endif

--- a/src/include/sof/ipc/topology.h
+++ b/src/include/sof/ipc/topology.h
@@ -26,7 +26,6 @@
 #include <stdint.h>
 
 /* generic IPC pipeline regardless of ABI MAJOR type that is always 4 byte aligned */
-typedef uint32_t ipc_config_dai_spec;
 #include <ipc/topology.h>
 #define ipc_from_dai_config(x) ((struct sof_ipc_dai_config *)x)
 

--- a/src/ipc/ipc3/handler.c
+++ b/src/ipc/ipc3/handler.c
@@ -1165,7 +1165,7 @@ static int ipc_glb_tplg_comp_new(uint32_t header)
 	       comp->pipeline_id, comp->id, comp->type);
 
 	/* register component */
-	ret = ipc_comp_new(ipc, comp);
+	ret = ipc_comp_new(ipc, ipc_to_comp_new(comp));
 	if (ret < 0) {
 		tr_err(&ipc_tr, "ipc: pipe %d comp %d creation failed %d",
 		       comp->pipeline_id, comp->id, ret);

--- a/src/ipc/ipc3/helper.c
+++ b/src/ipc/ipc3/helper.c
@@ -436,9 +436,9 @@ struct comp_dev *comp_new(struct sof_ipc_comp *comp)
 	return cdev;
 }
 
-int ipc_pipeline_new(struct ipc *ipc,
-	struct sof_ipc_pipe_new *pipe_desc)
+int ipc_pipeline_new(struct ipc *ipc, ipc_pipe_new *_pipe_desc)
 {
+	struct sof_ipc_pipe_new *pipe_desc = ipc_from_pipe_new(_pipe_desc);
 	struct ipc_comp_dev *ipc_pipe;
 	struct pipeline *pipe;
 	int ret;
@@ -769,9 +769,9 @@ static int ipc_buffer_to_comp_connect(struct ipc_comp_dev *buffer,
 	return ret;
 }
 
-int ipc_comp_connect(struct ipc *ipc,
-	struct sof_ipc_pipe_comp_connect *connect)
+int ipc_comp_connect(struct ipc *ipc, ipc_pipe_comp_connect *_connect)
 {
+	struct sof_ipc_pipe_comp_connect *connect = ipc_from_pipe_connect(_connect);
 	struct ipc_comp_dev *icd_source;
 	struct ipc_comp_dev *icd_sink;
 
@@ -804,8 +804,9 @@ int ipc_comp_connect(struct ipc *ipc,
 	}
 }
 
-int ipc_comp_new(struct ipc *ipc, struct sof_ipc_comp *comp)
+int ipc_comp_new(struct ipc *ipc, ipc_comp *_comp)
 {
+	struct sof_ipc_comp *comp = ipc_from_comp_new(_comp);
 	struct comp_dev *cd;
 	struct ipc_comp_dev *icd;
 

--- a/tools/testbench/topology.c
+++ b/tools/testbench/topology.c
@@ -116,7 +116,7 @@ static int load_graph(void *dev, struct comp_info *temp_comp_list,
 			return ret;
 
 		/* connect source and sink */
-		if (ipc_comp_connect(sof->ipc, &connection) < 0) {
+		if (ipc_comp_connect(sof->ipc, ipc_to_pipe_connect(&connection)) < 0) {
 			fprintf(stderr, "error: comp connect\n");
 			return -EINVAL;
 		}
@@ -320,7 +320,7 @@ static int load_fileread(void *dev, int comp_id, int pipeline_id,
 
 	/* create fileread component */
 	register_comp(fileread.comp.type, NULL);
-	if (ipc_comp_new(sof->ipc, (struct sof_ipc_comp *)&fileread) < 0) {
+	if (ipc_comp_new(sof->ipc, ipc_to_comp_new(&fileread)) < 0) {
 		fprintf(stderr, "error: comp register\n");
 		return -EINVAL;
 	}
@@ -369,7 +369,7 @@ static int load_filewrite(struct sof *sof, int comp_id, int pipeline_id,
 
 	/* create filewrite component */
 	register_comp(filewrite.comp.type, NULL);
-	if (ipc_comp_new(sof->ipc, (struct sof_ipc_comp *)&filewrite) < 0) {
+	if (ipc_comp_new(sof->ipc, ipc_to_comp_new(&filewrite)) < 0) {
 		fprintf(stderr, "error: comp register\n");
 		return -EINVAL;
 	}
@@ -455,7 +455,7 @@ int load_pga(void *dev, int comp_id, int pipeline_id,
 
 	/* load volume component */
 	register_comp(volume.comp.type, NULL);
-	if (ipc_comp_new(sof->ipc, (struct sof_ipc_comp *)&volume) < 0) {
+	if (ipc_comp_new(sof->ipc, ipc_to_comp_new(&volume)) < 0) {
 		fprintf(stderr, "error: comp register\n");
 		return -EINVAL;
 	}
@@ -484,7 +484,7 @@ int load_pipeline(void *dev, int comp_id, int pipeline_id,
 	pipeline.sched_id = sched_id;
 
 	/* Create pipeline */
-	if (ipc_pipeline_new(sof->ipc, &pipeline) < 0) {
+	if (ipc_pipeline_new(sof->ipc, (ipc_pipe_new *)&pipeline) < 0) {
 		fprintf(stderr, "error: pipeline new\n");
 		return -EINVAL;
 	}
@@ -526,7 +526,7 @@ int load_src(void *dev, int comp_id, int pipeline_id,
 
 	/* load src component */
 	register_comp(src.comp.type, NULL);
-	if (ipc_comp_new(sof->ipc, (struct sof_ipc_comp *)&src) < 0) {
+	if (ipc_comp_new(sof->ipc, ipc_to_comp_new(&src)) < 0) {
 		fprintf(stderr, "error: new src comp\n");
 		return -EINVAL;
 	}
@@ -568,7 +568,7 @@ int load_asrc(void *dev, int comp_id, int pipeline_id,
 
 	/* load asrc component */
 	register_comp(asrc.comp.type, NULL);
-	if (ipc_comp_new(sof->ipc, (struct sof_ipc_comp *)&asrc) < 0) {
+	if (ipc_comp_new(sof->ipc, ipc_to_comp_new(&asrc)) < 0) {
 		fprintf(stderr, "error: new asrc comp\n");
 		return -EINVAL;
 	}
@@ -660,7 +660,7 @@ int load_process(void *dev, int comp_id, int pipeline_id,
 	register_comp(process_ipc->comp.type, &comp_ext);
 
 	/* Instantiate */
-	ret = ipc_comp_new(sof->ipc, (struct sof_ipc_comp *)process_ipc);
+	ret = ipc_comp_new(sof->ipc, ipc_to_comp_new(process_ipc));
 	free(process_ipc);
 
 	if (ret < 0)


### PR DESCRIPTION
This PR introduces the IPC4 interface that is used today on some devices. The IPC4 ABI cant be changed since it's not possible to change the middleware on devices that use the IPC4 ABI. This PR introduces the interfaces used to load topology.

This PR also further adds abstraction around the IPC based client APIs so that any IPC ABI major can be used to construct pipelines. Further PRs will follow that add logic around the interface.
 