### PR TITLE
ipc: ipc3: Do not reset pipeline components during comp_free

### DIFF
--- a/src/ipc/ipc3/helper.c
+++ b/src/ipc/ipc3/helper.c
@@ -865,16 +865,6 @@ int ipc_comp_free(struct ipc *ipc, uint32_t comp_id)
 	if (icd->cd->state != COMP_STATE_READY)
 		return -EINVAL;
 
-	/* set pipeline sink/source/sched pointers to NULL if needed */
-	if (icd->cd->pipeline) {
-		if (icd->cd == icd->cd->pipeline->source_comp)
-			icd->cd->pipeline->source_comp = NULL;
-		if (icd->cd == icd->cd->pipeline->sink_comp)
-			icd->cd->pipeline->sink_comp = NULL;
-		if (icd->cd == icd->cd->pipeline->sched_comp)
-			icd->cd->pipeline->sched_comp = NULL;
-	}
-
 	/* free component and remove from list */
 	comp_free(icd->cd);
 


### PR DESCRIPTION
Pipelines can be shared between multiple PCM's. For example,
in the case of the sof-apl-nocodec, a part of pipeline 1
(mixer1.0 ->BUF1.2 ->PGA1.1-> BUF1.3 -> SSP0.OUT)
is shared between PCM0 and PCM7. Setting the source_comp for
pipeline 1 to NULL when PCM0 is stopped results in a panic.
So, hold off resetting the pipeline until the scheduler widget
is freed.

Fixes #4199