### PR TITLE
dmic: fix pause/release error leading to invalid dmic_active_fifos

### DIFF
--- a/src/drivers/intel/dmic.c
+++ b/src/drivers/intel/dmic.c
@@ -1529,7 +1529,7 @@ static int dmic_trigger(struct dai *dai, int cmd, int direction)
 		break;
 	case COMP_TRIGGER_PAUSE:
 		dmic->state = COMP_STATE_PAUSED;
-		dmic_stop(dai, true);
+		dmic_stop(dai, false);
 		break;
 	case COMP_TRIGGER_RESUME:
 		dmic_context_restore(dai);


### PR DESCRIPTION
The 'in_active' parameter of dmic_stop() is used to control whether
the fifo should be released or not. In case of COMP_TRIGGER_PAUSE,
this should be false and the 'dmic_active_fifos' count should not
be modified.

Without this fix:

  PAUSED -> RELEASE -> dmic_start() -> no change on dmic_active_fifos

  ACTIVE -> PAUSE   -> dmic_stop()  -> dmic_active_fifos--

If a test case repeatedly pauses and releases, 'dmic_active_fifos'
will go out-of-sync.

Fix the issue that dmic_stop for PAUSE does not release the fifo
reference.

Fixes: 22731744cb04 ("dmic: don't decrement active FIFO count below 0")
Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>