### PR TITLE
SSP BLCK and MCLK early start - take3

### DIFF
--- a/src/drivers/intel/ssp/ssp.c
+++ b/src/drivers/intel/ssp/ssp.c
@@ -658,6 +658,7 @@ static int ssp_pre_start(struct dai *dai)
 	if (ssp_freq[SSP_DEFAULT_IDX].freq % config->ssp.bclk_rate != 0) {
 		dai_err(dai, "invalid bclk_rate = %d for dai_index = %d",
 			config->ssp.bclk_rate, config->dai_index);
+		ret = -EINVAL;
 		goto out;
 	}
 

--- a/src/drivers/intel/ssp/ssp.c
+++ b/src/drivers/intel/ssp/ssp.c
@@ -125,6 +125,112 @@ static int ssp_context_restore(struct dai *dai)
 	return 0;
 }
 
+static int ssp_mclk_prepare_enable(struct dai *dai)
+{
+	struct ssp_pdata *ssp = dai_get_drvdata(dai);
+	struct sof_ipc_dai_config *config = &ssp->config;
+	int ret;
+
+	if (ssp->clk_active & SSP_CLK_MCLK_ACTIVE)
+		return 0;
+
+	/* MCLK config */
+	ret = mn_set_mclk(config->ssp.mclk_id, config->ssp.mclk_rate);
+	if (ret < 0)
+		dai_err(dai, "ssp_mclk_prepare_enable(): invalid mclk_rate = %d for mclk_id = %d",
+			config->ssp.mclk_rate, config->ssp.mclk_id);
+	else
+		ssp->clk_active |= SSP_CLK_MCLK_ACTIVE;
+
+	return ret;
+}
+
+static void ssp_mclk_disable_unprepare(struct dai *dai)
+{
+	struct ssp_pdata *ssp = dai_get_drvdata(dai);
+
+	if (!(ssp->clk_active & SSP_CLK_MCLK_ACTIVE))
+		return;
+
+	mn_release_mclk(ssp->config.ssp.mclk_id);
+
+	ssp->clk_active &= ~SSP_CLK_MCLK_ACTIVE;
+}
+
+static int ssp_bclk_prepare_enable(struct dai *dai)
+{
+	struct ssp_pdata *ssp = dai_get_drvdata(dai);
+	struct sof_ipc_dai_config *config = &ssp->config;
+	uint32_t sscr0;
+	uint32_t mdiv;
+	bool need_ecs = false;
+	int ret = 0;
+
+	if (ssp->clk_active & SSP_CLK_BCLK_ACTIVE)
+		return 0;
+
+	sscr0 = ssp_read(dai, SSCR0);
+
+#if CONFIG_INTEL_MN
+	/* BCLK config */
+	ret = mn_set_bclk(config->dai_index, config->ssp.bclk_rate,
+			  &mdiv, &need_ecs);
+	if (ret < 0) {
+		dai_err(dai, "ssp_bclk_prepare_enable(): invalid bclk_rate = %d for dai_index = %d",
+			config->ssp.bclk_rate, config->dai_index);
+		goto out;
+	}
+#else
+	if (ssp_freq[SSP_DEFAULT_IDX].freq % config->ssp.bclk_rate != 0) {
+		dai_err(dai, "ssp_bclk_prepare_enable(): invalid bclk_rate = %d for dai_index = %d",
+			config->ssp.bclk_rate, config->dai_index);
+		ret = -EINVAL;
+		goto out;
+	}
+
+	mdiv = ssp_freq[SSP_DEFAULT_IDX].freq / config->ssp.bclk_rate;
+#endif
+
+	if (need_ecs)
+		sscr0 |= SSCR0_ECS;
+
+	/* clock divisor is SCR + 1 */
+	mdiv -= 1;
+
+	/* divisor must be within SCR range */
+	if (mdiv > (SSCR0_SCR_MASK >> 8)) {
+		dai_err(dai, "ssp_bclk_prepare_enable(): divisor %d is not within SCR range",
+			mdiv);
+		ret = -EINVAL;
+		goto out;
+	}
+
+	/* set the SCR divisor */
+	sscr0 &= ~SSCR0_SCR_MASK;
+	sscr0 |= SSCR0_SCR(mdiv);
+
+	ssp_write(dai, SSCR0, sscr0);
+
+	dai_info(dai, "ssp_bclk_prepare_enable(): sscr0 = 0x%08x", sscr0);
+out:
+	if (!ret)
+		ssp->clk_active |= SSP_CLK_BCLK_ACTIVE;
+
+	return ret;
+}
+
+static void ssp_bclk_disable_unprepare(struct dai *dai)
+{
+	struct ssp_pdata *ssp = dai_get_drvdata(dai);
+
+	if (!(ssp->clk_active & SSP_CLK_BCLK_ACTIVE))
+		return;
+#if CONFIG_INTEL_MN
+	mn_release_bclk(dai->index);
+#endif
+	ssp->clk_active &= ~SSP_CLK_BCLK_ACTIVE;
+}
+
 /* Digital Audio interface formatting */
 static int ssp_set_config(struct dai *dai, struct ipc_config_dai *common_config,
 			  void *spec_config)
@@ -620,75 +726,21 @@ out:
  */
 static int ssp_pre_start(struct dai *dai)
 {
-	struct ssp_pdata *ssp = dai_get_drvdata(dai);
-	struct sof_ipc_dai_config *config = &ssp->config;
-	uint32_t sscr0;
-	uint32_t mdiv;
-	bool need_ecs = false;
-
-	int ret = 0;
+	int ret;
 
 	dai_info(dai, "ssp_pre_start()");
 
-	/* SSP active means bclk already configured. */
-	if (ssp->state[SOF_IPC_STREAM_PLAYBACK] == COMP_STATE_ACTIVE ||
-	    ssp->state[SOF_IPC_STREAM_CAPTURE] == COMP_STATE_ACTIVE)
-		return 0;
+	/*
+	 * We will test if mclk/bclk is configured in
+	 * ssp_mclk/bclk_prepare_enable/disable functions
+	 */
 
 	/* MCLK config */
-	ret = mn_set_mclk(config->ssp.mclk_id, config->ssp.mclk_rate);
-	if (ret < 0) {
-		dai_err(dai, "invalid mclk_rate = %d for mclk_id = %d",
-			config->ssp.mclk_rate, config->ssp.mclk_id);
-		goto out;
-	}
+	ret = ssp_mclk_prepare_enable(dai);
+	if (ret < 0)
+		return ret;
 
-	sscr0 = ssp_read(dai, SSCR0);
-
-#if CONFIG_INTEL_MN
-	/* BCLK config */
-	ret = mn_set_bclk(config->dai_index, config->ssp.bclk_rate,
-			  &mdiv, &need_ecs);
-	if (ret < 0) {
-		dai_err(dai, "invalid bclk_rate = %d for dai_index = %d",
-			config->ssp.bclk_rate, config->dai_index);
-		goto out;
-	}
-#else
-	if (ssp_freq[SSP_DEFAULT_IDX].freq % config->ssp.bclk_rate != 0) {
-		dai_err(dai, "invalid bclk_rate = %d for dai_index = %d",
-			config->ssp.bclk_rate, config->dai_index);
-		ret = -EINVAL;
-		goto out;
-	}
-
-	mdiv = ssp_freq[SSP_DEFAULT_IDX].freq / config->ssp.bclk_rate;
-#endif
-
-	if (need_ecs)
-		sscr0 |= SSCR0_ECS;
-
-	/* clock divisor is SCR + 1 */
-	mdiv -= 1;
-
-	/* divisor must be within SCR range */
-	if (mdiv > (SSCR0_SCR_MASK >> 8)) {
-		dai_err(dai, "ssp_pre_start(): divisor %d is not within SCR range",
-			mdiv);
-		ret = -EINVAL;
-		goto out;
-	}
-
-	/* set the SCR divisor */
-	sscr0 &= ~SSCR0_SCR_MASK;
-	sscr0 |= SSCR0_SCR(mdiv);
-
-	ssp_write(dai, SSCR0, sscr0);
-
-	dai_info(dai, "ssp_set_config(), sscr0 = 0x%08x", sscr0);
-out:
-
-	return ret;
+	return ssp_bclk_prepare_enable(dai);
 }
 
 /*
@@ -704,10 +756,8 @@ static void ssp_post_stop(struct dai *dai)
 	if (ssp->state[SOF_IPC_STREAM_PLAYBACK] != COMP_STATE_ACTIVE &&
 	    ssp->state[SOF_IPC_STREAM_CAPTURE] != COMP_STATE_ACTIVE) {
 		dai_info(dai, "releasing BCLK/MCLK clocks for SSP%d...", dai->index);
-#if CONFIG_INTEL_MN
-		mn_release_bclk(dai->index);
-#endif
-		mn_release_mclk(ssp->config.ssp.mclk_id);
+		ssp_bclk_disable_unprepare(dai);
+		ssp_mclk_disable_unprepare(dai);
 	}
 }
 
@@ -908,14 +958,10 @@ static int ssp_probe(struct dai *dai)
 
 static int ssp_remove(struct dai *dai)
 {
-	struct ssp_pdata *ssp = dai_get_drvdata(dai);
-
 	pm_runtime_put_sync(SSP_CLK, dai->index);
 
-	mn_release_mclk(ssp->config.ssp.mclk_id);
-#if CONFIG_INTEL_MN
-	mn_release_bclk(dai->index);
-#endif
+	ssp_mclk_disable_unprepare(dai);
+	ssp_bclk_disable_unprepare(dai);
 
 	/* Disable SSP power */
 	pm_runtime_put_sync(SSP_POW, dai->index);

--- a/src/include/ipc/dai-intel.h
+++ b/src/include/ipc/dai-intel.h
@@ -56,6 +56,10 @@
 #define SOF_DAI_INTEL_SSP_CLKCTRL_FS_KA			BIT(4)
 /* bclk idle */
 #define SOF_DAI_INTEL_SSP_CLKCTRL_BCLK_IDLE_HIGH	BIT(5)
+/* mclk early start */
+#define SOF_DAI_INTEL_SSP_CLKCTRL_MCLK_ES		BIT(6)
+/* bclk early start */
+#define SOF_DAI_INTEL_SSP_CLKCTRL_BCLK_ES		BIT(7)
 
 /* DMIC max. four controllers for eight microphone channels */
 #define SOF_DAI_INTEL_DMIC_NUM_CTRL			4

--- a/src/include/ipc/dai.h
+++ b/src/include/ipc/dai.h
@@ -52,6 +52,13 @@
 #define SOF_DAI_FMT_INV_MASK		0x0f00
 #define SOF_DAI_FMT_CLOCK_PROVIDER_MASK	0xf000
 
+/* DAI_CONFIG flags */
+#define SOF_DAI_CONFIG_FLAGS_MASK	0x3
+#define SOF_DAI_CONFIG_FLAGS_NONE	(0 << 0) /**< DAI_CONFIG sent without stage information */
+#define SOF_DAI_CONFIG_FLAGS_HW_PARAMS	(1 << 0) /**< DAI_CONFIG sent during hw_params stage */
+#define SOF_DAI_CONFIG_FLAGS_HW_FREE	(2 << 0) /**< DAI_CONFIG sent during hw_free stage */
+#define SOF_DAI_CONFIG_FLAGS_RFU	(3 << 0) /**< not used, reserved for future use */
+
 /** \brief Types of DAI */
 enum sof_ipc_dai_type {
 	SOF_DAI_INTEL_NONE = 0,		/**< None */
@@ -72,7 +79,7 @@ struct sof_ipc_dai_config {
 	/* physical protocol and clocking */
 	uint16_t format;	/**< SOF_DAI_FMT_ */
 	uint8_t group_id;	/**< group ID, 0 means no group (ABI 3.17) */
-	uint8_t reserved8;	/**< alignment */
+	uint8_t flags;		/**< SOF_DAI_CONFIG_FLAGS_ (ABI 3.19) */
 
 	/* reserved for future use */
 	uint32_t reserved[8];

--- a/src/include/kernel/abi.h
+++ b/src/include/kernel/abi.h
@@ -29,8 +29,8 @@
 
 /** \brief SOF ABI version major, minor and patch numbers */
 #define SOF_ABI_MAJOR 3
-#define SOF_ABI_MINOR 18
-#define SOF_ABI_PATCH 1
+#define SOF_ABI_MINOR 19
+#define SOF_ABI_PATCH 0
 
 /** \brief SOF ABI version number. Format within 32bit word is MMmmmppp */
 #define SOF_ABI_MAJOR_SHIFT	24

--- a/src/include/sof/drivers/ssp.h
+++ b/src/include/sof/drivers/ssp.h
@@ -224,8 +224,10 @@ extern const struct dai_driver ssp_driver;
 #define ssp_irq(ssp) \
 	ssp->plat_data.irq
 
-#define SSP_CLK_MCLK_ACTIVE	BIT(0)
-#define SSP_CLK_BCLK_ACTIVE	BIT(1)
+#define SSP_CLK_MCLK_ES_REQ	BIT(0)
+#define SSP_CLK_MCLK_ACTIVE	BIT(1)
+#define SSP_CLK_BCLK_ES_REQ	BIT(2)
+#define SSP_CLK_BCLK_ACTIVE	BIT(3)
 
 /* SSP private data */
 struct ssp_pdata {

--- a/src/include/sof/drivers/ssp.h
+++ b/src/include/sof/drivers/ssp.h
@@ -224,12 +224,16 @@ extern const struct dai_driver ssp_driver;
 #define ssp_irq(ssp) \
 	ssp->plat_data.irq
 
+#define SSP_CLK_MCLK_ACTIVE	BIT(0)
+#define SSP_CLK_BCLK_ACTIVE	BIT(1)
+
 /* SSP private data */
 struct ssp_pdata {
 	uint32_t sscr0;
 	uint32_t sscr1;
 	uint32_t psp;
 	uint32_t state[2];		/* SSP_STATE_ for each direction */
+	uint32_t clk_active;
 	struct sof_ipc_dai_config config;
 	struct sof_ipc_dai_ssp_params params;
 };

--- a/tools/topology/platform/common/ssp.m4
+++ b/tools/topology/platform/common/ssp.m4
@@ -30,6 +30,11 @@ $6
 dnl SSP_QUIRK_LBM 64 = (1 << 6)
 define(`SSP_QUIRK_LBM', 64)
 
+dnl SSP_CC_MCLK_ES 64 = (1 << 6)
+define(`SSP_CC_MCLK_ES', 64)
+dnl SSP_CC_BCLK_ES 128 = (1 << 7)
+define(`SSP_CC_BCLK_ES', 128)
+
 dnl SSP_CONFIG_DATA(type, idx, valid bits, mclk_id, quirks, bclk_delay,
 dnl clks_control, pulse_width, padding)
 dnl mclk_id, quirks, bclk_delay clks_control, pulse_width and padding are optional

--- a/tools/topology/sof-apl-nocodec.m4
+++ b/tools/topology/sof-apl-nocodec.m4
@@ -272,42 +272,48 @@ DAI_CONFIG(SSP, 0, 0, NoCodec-0,
 		      SSP_CLOCK(fsync, 48000, codec_slave),
 		      SSP_TDM(2, 16, 3, 3),
 		      dnl SSP_CONFIG_DATA(type, dai_index, valid bits, mclk_id, quirks)
-		      SSP_CONFIG_DATA(SSP, 0, 16, 0, SSP_QUIRK_LBM)))
+		      SSP_CONFIG_DATA(SSP, 0, 16, 0, SSP_QUIRK_LBM, 0,
+				      eval(SSP_CC_MCLK_ES | SSP_CC_BCLK_ES))))
 
 DAI_CONFIG(SSP, 1, 1, NoCodec-1,
 	   SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24576000, codec_mclk_in),
 		      SSP_CLOCK(bclk, 1536000, codec_slave),
 		      SSP_CLOCK(fsync, 48000, codec_slave),
 		      SSP_TDM(2, 16, 3, 3),
-		      SSP_CONFIG_DATA(SSP, 1, 16, 0, SSP_QUIRK_LBM)))
+		      SSP_CONFIG_DATA(SSP, 1, 16, 0, SSP_QUIRK_LBM, 0,
+				      eval(SSP_CC_MCLK_ES | SSP_CC_BCLK_ES))))
 
 #DAI_CONFIG(SSP, 2, 2, NoCodec-2,
 #	   SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24576000, codec_mclk_in),
 #		      SSP_CLOCK(bclk, 1536000, codec_slave),
 #		      SSP_CLOCK(fsync, 48000, codec_slave),
 #		      SSP_TDM(2, 16, 3, 3),
-#		      SSP_CONFIG_DATA(SSP, 2, 16, 0, SSP_QUIRK_LBM)))
+#		      SSP_CONFIG_DATA(SSP, 2, 16, 0, SSP_QUIRK_LBM, 0,
+#				      eval(SSP_CC_MCLK_ES | SSP_CC_BCLK_ES))))
 
 DAI_CONFIG(SSP, 3, 3, NoCodec-3,
 	   SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24576000, codec_mclk_in),
 		      SSP_CLOCK(bclk, 1536000, codec_slave),
 		      SSP_CLOCK(fsync, 48000, codec_slave),
 		      SSP_TDM(2, 16, 3, 3),
-		      SSP_CONFIG_DATA(SSP, 3, 16, 0, SSP_QUIRK_LBM)))
+		      SSP_CONFIG_DATA(SSP, 3, 16, 0, SSP_QUIRK_LBM, 0,
+				      eval(SSP_CC_MCLK_ES | SSP_CC_BCLK_ES))))
 
 #DAI_CONFIG(SSP, 4, 4, NoCodec-4,
 #	   SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24576000, codec_mclk_in),
 #		      SSP_CLOCK(bclk, 1536000, codec_slave),
 #		      SSP_CLOCK(fsync, 48000, codec_slave),
 #		      SSP_TDM(2, 16, 3, 3),
-#		      SSP_CONFIG_DATA(SSP, 4, 16, 0, SSP_QUIRK_LBM)))
+#		      SSP_CONFIG_DATA(SSP, 4, 16, 0, SSP_QUIRK_LBM, 0,
+#				      eval(SSP_CC_MCLK_ES | SSP_CC_BCLK_ES))))
 
 DAI_CONFIG(SSP, 5, 5, NoCodec-5,
 	   SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24576000, codec_mclk_in),
 		      SSP_CLOCK(bclk, 1536000, codec_slave),
 		      SSP_CLOCK(fsync, 48000, codec_slave),
 		      SSP_TDM(2, 16, 3, 3),
-		      SSP_CONFIG_DATA(SSP, 5, 16, 0, SSP_QUIRK_LBM)))
+		      SSP_CONFIG_DATA(SSP, 5, 16, 0, SSP_QUIRK_LBM, 0,
+				      eval(SSP_CC_MCLK_ES | SSP_CC_BCLK_ES))))
 
 DAI_CONFIG(DMIC, 0, 6, NoCodec-6,
 	   dnl DMIC_CONFIG(driver_version, clk_min, clk_mac, duty_min, duty_max,

--- a/tools/topology/sof-cnl-nocodec.m4
+++ b/tools/topology/sof-cnl-nocodec.m4
@@ -159,21 +159,24 @@ DAI_CONFIG(SSP, 0, 0, NoCodec-0,
 		      SSP_CLOCK(fsync, 48000, codec_slave),
 		      SSP_TDM(2, 25, 3, 3),
 		      dnl SSP_CONFIG_DATA(type, dai_index, valid bits, mclk_id, quirks)
-		      SSP_CONFIG_DATA(SSP, 0, 24, 0, SSP_QUIRK_LBM)))
+		      SSP_CONFIG_DATA(SSP, 0, 24, 0, SSP_QUIRK_LBM, 0,
+				      eval(SSP_CC_MCLK_ES | SSP_CC_BCLK_ES))))
 
 DAI_CONFIG(SSP, 1, 1, NoCodec-1,
 	   SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24000000, codec_mclk_in),
 		      SSP_CLOCK(bclk, 4800000, codec_slave),
 		      SSP_CLOCK(fsync, 48000, codec_slave),
 		      SSP_TDM(2, 25, 3, 3),
-		      SSP_CONFIG_DATA(SSP, 1, 24, 0, SSP_QUIRK_LBM)))
+		      SSP_CONFIG_DATA(SSP, 1, 24, 0, SSP_QUIRK_LBM, 0,
+				      eval(SSP_CC_MCLK_ES | SSP_CC_BCLK_ES))))
 
 DAI_CONFIG(SSP, 2, 2, NoCodec-2,
 	   SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24000000, codec_mclk_in),
 		      SSP_CLOCK(bclk, 4800000, codec_slave),
 		      SSP_CLOCK(fsync, 48000, codec_slave),
 		      SSP_TDM(2, 25, 3, 3),
-		      SSP_CONFIG_DATA(SSP, 2, 24, 0, SSP_QUIRK_LBM)))
+		      SSP_CONFIG_DATA(SSP, 2, 24, 0, SSP_QUIRK_LBM, 0,
+				      eval(SSP_CC_MCLK_ES | SSP_CC_BCLK_ES))))
 
 DAI_CONFIG(DMIC, 0, 3, NoCodec-3,
 	   DMIC_CONFIG(1, 2400000, 4800000, 40, 60, 48000,

--- a/tools/topology/sof-glk-da7219.m4
+++ b/tools/topology/sof-glk-da7219.m4
@@ -185,7 +185,7 @@ DAI_CONFIG(SSP, 2, 1, SSP2-Codec,
 		SSP_CLOCK(bclk, 2400000, codec_slave),
 		SSP_CLOCK(fsync, 48000, codec_slave),
 		SSP_TDM(2, 25, 3, 3),
-		SSP_CONFIG_DATA(SSP, 2, 16, 1, 0, 10)))
+		SSP_CONFIG_DATA(SSP, 2, 16, 1, 0, 0, SSP_CC_BCLK_ES)))
 ', )
 
 # dmic01 (id: 2)

--- a/tools/topology/sof-tgl-nocodec.m4
+++ b/tools/topology/sof-tgl-nocodec.m4
@@ -158,21 +158,24 @@ DAI_CONFIG(SSP, 0, 0, NoCodec-0,
 		      SSP_CLOCK(bclk, 2400000, codec_slave),
 		      SSP_CLOCK(fsync, 48000, codec_slave),
 		      SSP_TDM(2, 25, 3, 3),
-		      SSP_CONFIG_DATA(SSP, 0, 24, 0, SSP_QUIRK_LBM)))
+		      SSP_CONFIG_DATA(SSP, 0, 24, 0, SSP_QUIRK_LBM, 0,
+				eval(SSP_CC_MCLK_ES | SSP_CC_BCLK_ES))))
 
 DAI_CONFIG(SSP, 1, 1, NoCodec-1,
 	   SSP_CONFIG(I2S, SSP_CLOCK(mclk, 38400000, codec_mclk_in),
 		      SSP_CLOCK(bclk, 2400000, codec_slave),
 		      SSP_CLOCK(fsync, 48000, codec_slave),
 		      SSP_TDM(2, 25, 3, 3),
-		      SSP_CONFIG_DATA(SSP, 1, 24, 0, SSP_QUIRK_LBM)))
+		      SSP_CONFIG_DATA(SSP, 1, 24, 0, SSP_QUIRK_LBM, 0,
+				eval(SSP_CC_MCLK_ES | SSP_CC_BCLK_ES))))
 
 DAI_CONFIG(SSP, 2, 2, NoCodec-2,
 	   SSP_CONFIG(I2S, SSP_CLOCK(mclk, 38400000, codec_mclk_in),
 		      SSP_CLOCK(bclk, 2400000, codec_slave),
 		      SSP_CLOCK(fsync, 48000, codec_slave),
 		      SSP_TDM(2, 25, 3, 3),
-		      SSP_CONFIG_DATA(SSP, 2, 24, 0, SSP_QUIRK_LBM)))
+		      SSP_CONFIG_DATA(SSP, 2, 24, 0, SSP_QUIRK_LBM, 0,
+				eval(SSP_CC_MCLK_ES | SSP_CC_BCLK_ES))))
 
 DAI_CONFIG(DMIC, 0, 6, NoCodec-6,
 	   dnl DMIC_CONFIG(driver_version, clk_min, clk_mac, duty_min, duty_max,


### PR DESCRIPTION
This PR is the companion of kernel PR https://github.com/thesofproject/linux/pull/2965

This builds on previous PRs from @bardliao (PR #https://github.com/thesofproject/sof/pull/4219) and @brentlu (PR https://github.com/thesofproject/sof/pull/4262)

We also build on previous work from @juimonen for the multi-ssp config where we send a DAI_CONFIG IPC in the hw_params and hw_free stages. Currently we send the same information in the two cases, so the firmware cannot take any action wrt. early clock enablement. Adding a flag is enough to provide the firmware with the information missing.

This is tagged as an ABI 3.18 change.

Results with a 50ms delay added in the kernel shows the bclock starting early and stopping late. The FSYNC starts with the data but that's explained (see commit messages).

![start](https://user-images.githubusercontent.com/1149035/120679428-c4a43d80-c45e-11eb-85f2-f14b493441ba.png)
![stop1](https://user-images.githubusercontent.com/1149035/120679441-cb32b500-c45e-11eb-81b2-01f427719d71.png)
