### PR TITLE
ipc4: refine pipeline for I2S

### DIFF
--- a/src/audio/copier.c
+++ b/src/audio/copier.c
@@ -239,9 +239,7 @@ static struct comp_dev *copier_new(const struct comp_driver *drv,
 	list_init(&dev->bsource_list);
 	list_init(&dev->bsink_list);
 
-	if (IPC4_INVALID_NODE_ID == copier->gtw_cfg.node_id) {
-		//nothing to do for converter
-	} else {
+	if (copier->gtw_cfg.node_id != IPC4_INVALID_NODE_ID) {
 		struct ipc_comp_dev *ipc_pipe;
 
 		node_id.dw = copier->gtw_cfg.node_id;

--- a/src/drivers/intel/ssp/ssp.c
+++ b/src/drivers/intel/ssp/ssp.c
@@ -621,6 +621,10 @@ static int ssp_set_config_blob(struct dai *dai, struct ipc_config_dai *common_co
 	struct ssp_pdata *ssp = dai_get_drvdata(dai);
 	uint32_t ssc0, sstsa, ssrsa;
 
+	/* set config only once for playback or capture */
+	if (dai->sref > 1)
+		return 0;
+
 	ssc0 = blob->i2s_driver_config.i2s_config.ssc0;
 	sstsa = blob->i2s_driver_config.i2s_config.sstsa;
 	ssrsa = blob->i2s_driver_config.i2s_config.ssrsa;

--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -221,10 +221,11 @@ static int ipc4_set_pipeline_state(union ipc4_message_header *ipc4)
 		ret = pipeline_trigger(host->cd->pipeline, host->cd, COMP_TRIGGER_STOP);
 		if (ret < 0) {
 			tr_err(&ipc_tr, "ipc: comp %d trigger 0x%x failed %d", id, cmd, ret);
-			ret = IPC4_PIPELINE_STATE_NOT_SET;
+			return IPC4_PIPELINE_STATE_NOT_SET;
 		}
 
-		cmd = COMP_TRIGGER_RESET;
+		/* resource is not released by triggering reset which is used by current FW */
+		return pipeline_reset(host->cd->pipeline, host->cd);
 		break;
 	case SOF_IPC4_PIPELINE_STATE_PAUSED:
 		if (pcm_dev->pipeline->status == COMP_STATE_INIT)


### PR DESCRIPTION
Sof FW doesn't use reset cmd in pipeline_trigger function now,
and resource is also not released by this cmd. Call pipeline_reset to
free resource.

Signed-off-by: Rander Wang <rander.wang@intel.com>