### PR TITLE
Disable __TIME__ and the non-reproducible build counter by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,8 @@ option(BUILD_UNIT_TESTS "Build unit tests" OFF)
 option(BUILD_UNIT_TESTS_HOST "Build unit tests for host" OFF)
 option(BUILD_UNIT_TESTS_XTENSA_GCC "Build xtensa unit test using GCC" OFF)
 option(BUILD_CLANG_SCAN "Build for clang's scan-build" OFF)
+option(BUILD_COUNTERS "Enable build counter(s), timestamps and any other
+non-deterministic build features" OFF)
 
 if(CONFIG_LIBRARY OR BUILD_UNIT_TESTS_HOST)
 	set(ARCH host)
@@ -77,6 +79,12 @@ target_include_directories(sof_public_headers INTERFACE ${PROJECT_SOURCE_DIR}/ri
 add_library(sof_options INTERFACE)
 
 target_link_libraries(sof_options INTERFACE sof_public_headers)
+
+if(BUILD_COUNTERS)
+target_compile_definitions(sof_options INTERFACE BLD_COUNTERS=1)
+else()
+target_compile_definitions(sof_options INTERFACE BLD_COUNTERS=0)
+endif()
 
 # interface library that is used only as container for sof statically
 # linked libraries
@@ -183,7 +191,9 @@ target_link_libraries(sof PRIVATE sof_ld_scripts)
 target_link_libraries(sof PRIVATE sof_ld_flags)
 target_link_libraries(sof PRIVATE sof_static_libraries)
 
+if (BUILD_COUNTERS)
 sof_add_build_counter_rule()
+endif()
 
 add_subdirectory(src)
 

--- a/installer/GNUmakefile
+++ b/installer/GNUmakefile
@@ -147,7 +147,7 @@ BUILD_SOF_RIS := \
       ${UNSIGNED_list:%=${BUILDS_ROOT}/build_%_${TOOLCHAIN}/sof.ri} \
         ${SIGNED_list:%=${BUILDS_ROOT}/build_%_${TOOLCHAIN}/sof.ri}
 
-# The build is not deterministic; use this to reduce noise when testing
+# When the build is not deterministic use this to reduce noise when testing
 # this Makefile.
 # Also very useful with XCC, see next comment.
 ifneq (true,${BUILD_ONLY_ONCE})

--- a/installer/sample-config.mk
+++ b/installer/sample-config.mk
@@ -16,7 +16,8 @@
 # USER_DESTDIR   := ${_remote}:bin/
 
 # Define this empty for a plain sof/ directory and no sof -> sof-v1.2.3
-# symbolic links.
+# symbolic links. This is _only_ to override the top-level directory
+# name; for version.h see version.cmake and try sof/.tarball-version
 # SOF_VERSION :=
 #
 # SOF_VERSION := $(shell git describe --tags )

--- a/src/init/ext_manifest.c
+++ b/src/init/ext_manifest.c
@@ -24,11 +24,15 @@ const struct ext_man_fw_version ext_man_fw_ver
 		.micro = SOF_MICRO,
 		.minor = SOF_MINOR,
 		.major = SOF_MAJOR,
-#if CONFIG_DEBUG
-		/* only added in debug for reproducibility in releases */
+/* opt-in; reproducible build by default */
+#if BLD_COUNTERS
 		.build = SOF_BUILD,
 		.date = __DATE__,
 		.time = __TIME__,
+#else
+		.build = -1,
+		.date = "dtermin.\0",
+		.time = "extman\0",
 #endif
 		.tag = SOF_TAG,
 		.abi_version = SOF_ABI_VERSION,

--- a/src/platform/baytrail/platform.c
+++ b/src/platform/baytrail/platform.c
@@ -64,11 +64,15 @@ static const struct sof_ipc_fw_ready ready
 		.micro = SOF_MICRO,
 		.minor = SOF_MINOR,
 		.major = SOF_MAJOR,
-#if CONFIG_DEBUG
-		/* only added in debug for reproducability in releases */
-		.build = SOF_BUILD,
+/* opt-in; reproducible build by default */
+#if BLD_COUNTERS
+		.build = SOF_BUILD, /* See version-build-counter.cmake */
 		.date = __DATE__,
 		.time = __TIME__,
+#else
+		.build = -1,
+		.date = "dtermin.\0",
+		.time = "fwready.\0",
 #endif
 		.tag = SOF_TAG,
 		.abi_version = SOF_ABI_VERSION,

--- a/src/platform/haswell/platform.c
+++ b/src/platform/haswell/platform.c
@@ -50,11 +50,15 @@ static const struct sof_ipc_fw_ready ready
 		.micro = SOF_MICRO,
 		.minor = SOF_MINOR,
 		.major = SOF_MAJOR,
-#if CONFIG_DEBUG
-		/* only added in debug for reproducability in releases */
-		.build = SOF_BUILD,
+/* opt-in; reproducible build by default */
+#if BLD_COUNTERS
+		.build = SOF_BUILD, /* See version-build-counter.cmake */
 		.date = __DATE__,
 		.time = __TIME__,
+#else
+		.build = -1,
+		.date = "dtermin.\0",
+		.time = "fwready.\0",
 #endif
 		.tag = SOF_TAG,
 		.abi_version = SOF_ABI_VERSION,

--- a/src/platform/imx8/platform.c
+++ b/src/platform/imx8/platform.c
@@ -49,11 +49,15 @@ static const struct sof_ipc_fw_ready ready
 		.micro = SOF_MICRO,
 		.minor = SOF_MINOR,
 		.major = SOF_MAJOR,
-#ifdef DEBUG_BUILD
-		/* only added in debug for reproducability in releases */
-		.build = SOF_BUILD,
+/* opt-in; reproducible build by default */
+#if BLD_COUNTERS
+		.build = SOF_BUILD, /* See version-build-counter.cmake */
 		.date = __DATE__,
 		.time = __TIME__,
+#else
+		.build = -1,
+		.date = "dtermin.\0",
+		.time = "fwready.\0",
 #endif
 		.tag = SOF_TAG,
 		.abi_version = SOF_ABI_VERSION,

--- a/src/platform/imx8m/platform.c
+++ b/src/platform/imx8m/platform.c
@@ -48,11 +48,15 @@ static const struct sof_ipc_fw_ready ready
 		.micro = SOF_MICRO,
 		.minor = SOF_MINOR,
 		.major = SOF_MAJOR,
-#ifdef DEBUG_BUILD
-		/* only added in debug for reproducability in releases */
-		.build = SOF_BUILD,
+/* opt-in; reproducible build by default */
+#if BLD_COUNTERS
+		.build = SOF_BUILD, /* See version-build-counter.cmake */
 		.date = __DATE__,
 		.time = __TIME__,
+#else
+		.build = -1,
+		.date = "dtermin.\0",
+		.time = "fwready.\0",
 #endif
 		.tag = SOF_TAG,
 		.abi_version = SOF_ABI_VERSION,

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -60,11 +60,15 @@ static const struct sof_ipc_fw_ready ready
 		.micro = SOF_MICRO,
 		.minor = SOF_MINOR,
 		.major = SOF_MAJOR,
-#if CONFIG_DEBUG
-		/* only added in debug for reproducability in releases */
-		.build = SOF_BUILD,
+/* opt-in; reproducible build by default */
+#if BLD_COUNTERS
+		.build = SOF_BUILD, /* See version-build-counter.cmake */
 		.date = __DATE__,
 		.time = __TIME__,
+#else
+		.build = -1,
+		.date = "dtermin.\0",
+		.time = "fwready.\0",
 #endif
 		.tag = SOF_TAG,
 		.abi_version = SOF_ABI_VERSION,


### PR DESCRIPTION
Makes even CONFIG_DEBUG builds (locally) deterministic by
default: (re)building twice produces the same binaries. Also a partial
fix for incremental builds: running "make" twice in a row now recompiles
fewer files because version.h does not keep changing.

Also makes sure non-debug builds can't use uninitialized strings in some
future security accident.

Fixes:

 ./scripts/checkpatch.pl -g aa85e2c0e956c
```
ERROR: Use of the '__DATE__' macro makes the build non-deterministic
+		.date = __DATE__,
ERROR: Use of the '__TIME__' macro makes the build non-deterministic
+		.time = __TIME__,
```
The previous behavior can be restored using any standard CMake
configuration method, example:
```
  ./scripts/xtensa-build-all.sh apl
  cmake -B build_apl_gcc/ -DBUILD_COUNTERS=1
  make -C build_apl_gcc
```
https://reproducible-builds.org/

Signed-off-by: Marc Herbert <marc.herbert@intel.com>