### PR TITLE
Drivers: Intel: DMIC: Re-arrange DMIC DAI component data

### DIFF
--- a/src/drivers/intel/dmic.c
+++ b/src/drivers/intel/dmic.c
@@ -1603,7 +1603,7 @@ static int dmic_probe(struct dai *dai)
 	/* Initialize start sequence handler */
 	schedule_task_init_ll(&dmic->dmicwork, SOF_UUID(dmic_work_task_uuid),
 			      SOF_SCHEDULE_LL_TIMER,
-			      SOF_TASK_PRI_MED, dmic_work, dai, 0, 0);
+			      SOF_TASK_PRI_MED, dmic_work, dai, cpu_get_id(), 0);
 
 	/* Enable DMIC power */
 	pm_runtime_get_sync(DMIC_POW, dai->index);

--- a/src/drivers/intel/dmic.c
+++ b/src/drivers/intel/dmic.c
@@ -159,8 +159,7 @@ static enum task_state dmic_work(void *data)
 	 * Gain is Q2.30 and gain modifier is Q12.20.
 	 */
 	dmic->startcount++;
-	dmic->gain = q_multsr_sat_32x32(dmic->gain, dmic->gain_coef,
-					Q_SHIFT_GAIN_X_GAIN_COEF);
+	dmic->gain = q_multsr_sat_32x32(dmic->gain, dmic->gain_coef, Q_SHIFT_GAIN_X_GAIN_COEF);
 
 	/* Gain is stored as Q2.30, while HW register is Q1.19 so shift
 	 * the value right by 11.
@@ -1609,10 +1608,7 @@ static int dmic_probe(struct dai *dai)
 	pm_runtime_get_sync(DMIC_POW, dai->index);
 	/* Disable dynamic clock gating for dmic before touching any reg */
 	pm_runtime_get_sync(DMIC_CLK, dai->index);
-
 	interrupt_enable(dmic->irq, dai);
-
-
 	return 0;
 }
 

--- a/src/include/sof/drivers/dmic.h
+++ b/src/include/sof/drivers/dmic.h
@@ -50,6 +50,7 @@
 
 #if DMIC_HW_VERSION
 
+#include <ipc/dai-intel.h>
 #include <sof/audio/format.h>
 #include <sof/bit.h>
 #include <sof/lib/dai.h>
@@ -315,15 +316,23 @@
 #define dmic_irq(dmic) dmic->plat_data.irq
 #define dmic_irq_name(dmic) dmic->plat_data.irq_name
 
+struct dmic_global_shared {
+	struct sof_ipc_dai_dmic_params prm[DMIC_HW_FIFOS];  /* Configuration requests */
+	uint32_t active_fifos_mask;	/* Bits (dai->index) are set to indicate active FIFO */
+	uint32_t pause_mask;		/* Bits (dai->index) are set to indicate driver pause */
+};
+
 /* DMIC private data */
 struct dmic_pdata {
-	uint16_t enable[DMIC_HW_CONTROLLERS];
-	uint32_t state;
-	struct task dmicwork;
-	int32_t startcount;
-	int32_t gain;
-	int32_t gain_coef;
-	int irq;
+	struct dmic_global_shared *global;	/* Common data for all DMIC DAI instances */
+	struct task dmicwork;			/* HW gain ramp update task */
+	uint16_t enable[DMIC_HW_CONTROLLERS];	/* Mic 0 and 1 enable bits array for PDMx */
+	uint32_t state;				/* Driver component state */
+	int32_t startcount;			/* Counter in dmicwork that controls HW unmute */
+	int32_t gain_coef;			/* Gain update constant */
+	int32_t gain;				/* Gain value to be applied to HW */
+	int irq;				/* Interrupt number used */
+
 };
 
 extern const struct dai_driver dmic_driver;


### PR DESCRIPTION
This patch separates the component data to private and global
parts and cleans up the explicit un-cache code from previous
version.

Since the dmic_prm[] struct is fixed length it does not need to
be allocated dynamically. It simplifies a lot the parameters
handling and sharing.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>