### PR TITLE
topology: sof-glk-cs42l42: using 2.4MHz bclk

### DIFF
--- a/tools/topology/sof-glk-da7219.m4
+++ b/tools/topology/sof-glk-da7219.m4
@@ -182,9 +182,9 @@ DAI_CONFIG(SSP, 2, 1, SSP2-Codec,
 #SSP 2 (ID: 1) with 19.2 MHz mclk with MCLK_ID 1 (unused), 3.072 MHz bclk, no quirk, 10 ms BCLK delay
 DAI_CONFIG(SSP, 2, 1, SSP2-Codec,
 	SSP_CONFIG(I2S, SSP_CLOCK(mclk, 19200000, codec_mclk_in),
-		SSP_CLOCK(bclk, 3072000, codec_slave),
+		SSP_CLOCK(bclk, 2400000, codec_slave),
 		SSP_CLOCK(fsync, 48000, codec_slave),
-		SSP_TDM(2, 32, 3, 3),
+		SSP_TDM(2, 25, 3, 3),
 		SSP_CONFIG_DATA(SSP, 2, 16, 1, 0, 10)))
 ', )
 


### PR DESCRIPTION
By changing bclk to 2.4MHz, we can use XTAL as clock source and reduce
power consumption.

Signed-off-by: Brent Lu <brent.lu@intel.com>

The codec driver does not support bclk running at 2.4MHz when we implemented the machine driver. Since the setting is ready now, we change the bclk to 2.4MHz for power optimization.
