### PR TITLE
cavs: memory: unify access macros on Zephyr

### DIFF
--- a/src/platform/intel/cavs/include/cavs/lib/memory.h
+++ b/src/platform/intel/cavs/include/cavs/lib/memory.h
@@ -87,7 +87,7 @@ struct sof;
 #define SRAM_ALIAS_MASK		0xFF000000
 #define SRAM_ALIAS_OFFSET	SRAM_UNCACHED_ALIAS
 
-#if !defined UNIT_TEST && (CAVS_VERSION <= CAVS_VERSION_1_8 || !defined __ZEPHYR__)
+#if !defined UNIT_TEST
 #define uncache_to_cache(address) \
 	((__typeof__(address))((uint32_t)(address) | SRAM_ALIAS_OFFSET))
 #define cache_to_uncache(address) \


### PR DESCRIPTION
Once following Zephyr PRs are merged, this can proceed:
- https://github.com/zephyrproject-rtos/zephyr/pull/36055
- https://github.com/zephyrproject-rtos/zephyr/pull/35490

Marking as draft until dependencies met.

With Zephyr linker scripts updated on all cAVS platforms, we can now
unify uncache_to_cache() and cached_to_uncache() implementation in
Zephyr builds.

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>