### PR TITLE
Tracing fixes

### DIFF
--- a/src/debug/panic.c
+++ b/src/debug/panic.c
@@ -81,9 +81,8 @@ void panic_dump(uint32_t p, struct sof_ipc_panic_info *panic_info,
 	count = MAILBOX_EXCEPTION_SIZE -
 		(size_t)(ext_offset - (char *)mailbox_get_exception_base());
 
-	/* flush last trace messages */
 #if CONFIG_TRACE
-	trace_flush();
+	trace_flush_dma_to_mbox();
 #endif
 
 	/* dump stack frames */

--- a/src/include/sof/trace/dma-trace.h
+++ b/src/include/sof/trace/dma-trace.h
@@ -52,7 +52,7 @@ int dma_trace_host_buffer(struct dma_trace_data *d,
 			  struct dma_sg_elem_array *elem_array,
 			  uint32_t host_size);
 int dma_trace_enable(struct dma_trace_data *d);
-void dma_trace_flush(void *t);
+void dma_trace_flush(void *destination);
 void dma_trace_on(void);
 void dma_trace_off(void);
 

--- a/src/include/sof/trace/dma-trace.h
+++ b/src/include/sof/trace/dma-trace.h
@@ -59,6 +59,11 @@ void dma_trace_off(void);
 void dtrace_event(const char *e, uint32_t size);
 void dtrace_event_atomic(const char *e, uint32_t length);
 
+static inline bool dma_trace_initialized(const struct dma_trace_data *d)
+{
+	return d && d->dmatb.addr;
+}
+
 static inline struct dma_trace_data *dma_trace_data_get(void)
 {
 	return sof_get()->dmat;

--- a/src/include/sof/trace/trace.h
+++ b/src/include/sof/trace/trace.h
@@ -137,7 +137,7 @@ struct trace_filter {
 				     ctx, id_1, id_2,			\
 				     format, ##__VA_ARGS__)
 
-void trace_flush(void);
+void trace_flush_dma_to_mbox(void);
 void trace_on(void);
 void trace_off(void);
 void trace_init(struct sof *sof);
@@ -253,7 +253,7 @@ do {											\
 
 #define trace_point(x)  do {} while (0)
 
-static inline void trace_flush(void) { }
+static inline void trace_flush_dma_to_mbox(void) { }
 static inline void trace_on(void) { }
 static inline void trace_off(void) { }
 static inline void trace_init(struct sof *sof) { }

--- a/src/include/sof/trace/trace.h
+++ b/src/include/sof/trace/trace.h
@@ -161,7 +161,7 @@ int trace_filter_update(const struct trace_filter *elem);
 /** The start of this linker output MUST match the 'ldc_entry_header'
  *  struct defined in the logger program running in user space.
  */
-#define _DECLARE_LOG_ENTRY(lvl, format, comp_class, params)	\
+#define _DECLARE_LOG_ENTRY(lvl, format, comp_class, n_params)	\
 	__section(".static_log." #lvl)				\
 	static const struct {					\
 		uint32_t level;					\
@@ -175,7 +175,7 @@ int trace_filter_update(const struct trace_filter *elem);
 	} log_entry = {						\
 		lvl,						\
 		comp_class,					\
-		params,						\
+		n_params,						\
 		__LINE__,					\
 		sizeof(RELATIVE_FILE),				\
 		sizeof(format),					\
@@ -306,9 +306,13 @@ static inline int trace_filter_update(const struct trace_filter *filter)
 
 #endif /* CONFIG_TRACEE, CONFIG_TRACE */
 
-
-#define _TRACE_INV_CLASS	TRACE_CLASS_DEPRECATED
+/** Default value when there is no specific pipeline, dev, dai, etc. */
 #define _TRACE_INV_ID		-1
+
+/** This has been replaced in commits 6ce635aa82 and earlier by the
+ * DECLARE_TR_CTX, tr_ctx and component UUID system below
+ */
+#define _TRACE_INV_CLASS	TRACE_CLASS_DEPRECATED
 
 /**
  * Trace context.

--- a/src/trace/dma-trace.c
+++ b/src/trace/dma-trace.c
@@ -120,6 +120,10 @@ out:
 	return SOF_TASK_STATE_RESCHEDULE;
 }
 
+/** Do this early so we can log at initialization time even before the
+ * DMA runs. The rest happens later in dma_trace_init_complete() and
+ * dma_trace_enable()
+ */
 int dma_trace_init_early(struct sof *sof)
 {
 	sof->dmat = rzalloc(SOF_MEM_ZONE_SYS_SHARED, 0, SOF_MEM_CAPS_RAM, sizeof(*sof->dmat));
@@ -135,6 +139,7 @@ int dma_trace_init_early(struct sof *sof)
 	return 0;
 }
 
+/** Run after dma_trace_init_early() and before dma_trace_enable() */
 int dma_trace_init_complete(struct dma_trace_data *d)
 {
 	int ret = 0;
@@ -317,6 +322,9 @@ static int dma_trace_get_avail_data(struct dma_trace_data *d,
 
 #endif  /* CONFIG_DMA_GW */
 
+/** Invoked remotely by SOF_IPC_TRACE_DMA_PARAMS* Depends on
+ * dma_trace_init_complete()
+ */
 int dma_trace_enable(struct dma_trace_data *d)
 {
 	int err;

--- a/src/trace/dma-trace.c
+++ b/src/trace/dma-trace.c
@@ -379,9 +379,8 @@ void dma_trace_flush(void *t)
 	int32_t wrap_count;
 	int ret;
 
-	if (!trace_data || !trace_data->dmatb.addr) {
+	if (!dma_trace_initialized(trace_data))
 		return;
-	}
 
 	buffer = &trace_data->dmatb;
 	avail = buffer->avail;
@@ -553,7 +552,7 @@ void dtrace_event(const char *e, uint32_t length)
 	struct dma_trace_buf *buffer = NULL;
 	unsigned long flags;
 
-	if (!trace_data || !trace_data->dmatb.addr ||
+	if (!dma_trace_initialized(trace_data) ||
 	    length > DMA_TRACE_LOCAL_SIZE / 8 || length == 0) {
 		return;
 	}
@@ -591,7 +590,7 @@ void dtrace_event_atomic(const char *e, uint32_t length)
 {
 	struct dma_trace_data *trace_data = dma_trace_data_get();
 
-	if (!trace_data || !trace_data->dmatb.addr ||
+	if (!dma_trace_initialized(trace_data) ||
 	    length > DMA_TRACE_LOCAL_SIZE / 8 || length == 0) {
 		return;
 	}

--- a/src/trace/dma-trace.c
+++ b/src/trace/dma-trace.c
@@ -352,9 +352,6 @@ int dma_trace_enable(struct dma_trace_data *d)
 		goto out;
 #endif
 
-	/* flush fw description message */
-	trace_flush();
-
 	/* validate DMA context */
 	if (!d->dc.dmac || !d->dc.chan) {
 		tr_err_atomic(&dt_tr, "dma_trace_enable(): not valid");

--- a/src/trace/trace.c
+++ b/src/trace/trace.c
@@ -75,6 +75,8 @@ static void put_header(uint32_t *dst, const struct sof_uuid_entry *uid,
 		       uint32_t entry, uint64_t timestamp)
 {
 	struct timer *timer = timer_get();
+	/* Support very early tracing */
+	uint64_t delta = timer ? timer->delta : 0;
 	struct log_entry_header header;
 	int ret;
 
@@ -82,7 +84,7 @@ static void put_header(uint32_t *dst, const struct sof_uuid_entry *uid,
 	header.id_0 = id_1 & TRACE_ID_MASK;
 	header.id_1 = id_2 & TRACE_ID_MASK;
 	header.core_id = cpu_get_id();
-	header.timestamp = timestamp + timer->delta;
+	header.timestamp = timestamp + delta;
 	header.log_entry_address = entry;
 
 	ret = memcpy_s(dst, sizeof(header), &header, sizeof(header));

--- a/src/trace/trace.c
+++ b/src/trace/trace.c
@@ -508,8 +508,6 @@ void trace_off(void)
 
 void trace_init(struct sof *sof)
 {
-	dma_trace_init_early(sof);
-
 	sof->trace = rzalloc(SOF_MEM_ZONE_SYS_SHARED, 0, SOF_MEM_CAPS_RAM, sizeof(*sof->trace));
 	sof->trace->enable = 1;
 	sof->trace->pos = 0;
@@ -521,4 +519,6 @@ void trace_init(struct sof *sof)
 	bzero((void *)MAILBOX_TRACE_BASE, MAILBOX_TRACE_SIZE);
 	dcache_writeback_invalidate_region((void *)MAILBOX_TRACE_BASE,
 					   MAILBOX_TRACE_SIZE);
+
+	dma_trace_init_early(sof);
 }

--- a/src/trace/trace.c
+++ b/src/trace/trace.c
@@ -463,7 +463,7 @@ int trace_filter_update(const struct trace_filter *filter)
 }
 
 /** Sends all pending DMA messages to mailbox (for emergencies) */
-void trace_flush(void)
+void trace_flush_dma_to_mbox(void)
 {
 	struct trace *trace = trace_get();
 	volatile uint64_t *t;

--- a/test/cmocka/src/common_mocks.c
+++ b/test/cmocka/src/common_mocks.c
@@ -111,7 +111,7 @@ void WEAK trace_log_filtered(bool send_atomic, const void *log_entry, const stru
 	(void) arg_count;
 }
 
-void WEAK trace_flush(void)
+void WEAK trace_flush_dma_to_mbox(void)
 {
 }
 

--- a/tools/logger/convert.c
+++ b/tools/logger/convert.c
@@ -386,8 +386,12 @@ static const char *get_level_name(uint32_t level)
 		return "ERROR ";
 	case LOG_LEVEL_WARNING:
 		return "WARN ";
+	case LOG_LEVEL_INFO:
+		return "INFO ";
+	case LOG_LEVEL_DEBUG:
+		return "DEBUG ";
 	default:
-		return ""; /* info is usual, do not print anything */
+		return "UNKNOWN ";
 	}
 }
 

--- a/tools/logger/convert.c
+++ b/tools/logger/convert.c
@@ -60,7 +60,7 @@ struct proc_ldc_entry {
 	uintptr_t params[TRACE_MAX_PARAMS_COUNT];
 };
 
-static const char *BAD_PTR_STR = "<bad uid ptr %x>";
+static const char *BAD_PTR_STR = "<bad uid ptr 0x%.8x>";
 
 #define UUID_LOWER "%s%s%s<%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x>%s%s%s"
 #define UUID_UPPER "%s%s%s<%08X-%04X-%04X-%02X%02X-%02X%02X%02X%02X%02X%02X>%s%s%s"


### PR DESCRIPTION
Various fixes and some comments. Main changes:

`dma-trace.c: remove misunderstood trace_flush() after FW ABI banner`
`trace: initialize DMA trace _after_ mailbox`
