### PR TITLE
buffer: demote info messages to dbg

### DIFF
--- a/src/audio/buffer.c
+++ b/src/audio/buffer.c
@@ -195,11 +195,11 @@ void comp_update_buffer_produce(struct comp_buffer *buffer, uint32_t bytes)
 
 	/* return if no bytes */
 	if (!bytes) {
-		buf_info(buffer, "comp_update_buffer_produce(), no bytes to produce, source->comp.id = %u, source->comp.type = %u, sink->comp.id = %u, sink->comp.type = %u",
-			 dev_comp_id(buffer->source),
-			 dev_comp_type(buffer->source),
-			 dev_comp_id(buffer->sink),
-			 dev_comp_type(buffer->sink));
+		buf_dbg(buffer, "comp_update_buffer_produce(), no bytes to produce, source->comp.id = %u, source->comp.type = %u, sink->comp.id = %u, sink->comp.type = %u",
+			dev_comp_id(buffer->source),
+			dev_comp_type(buffer->source),
+			dev_comp_id(buffer->sink),
+			dev_comp_type(buffer->sink));
 		return;
 	}
 
@@ -235,11 +235,11 @@ void comp_update_buffer_consume(struct comp_buffer *buffer, uint32_t bytes)
 
 	/* return if no bytes */
 	if (!bytes) {
-		buf_info(buffer, "comp_update_buffer_consume(), no bytes to consume, source->comp.id = %u, source->comp.type = %u, sink->comp.id = %u, sink->comp.type = %u",
-			 dev_comp_id(buffer->source),
-			 dev_comp_type(buffer->source),
-			 dev_comp_id(buffer->sink),
-			 dev_comp_type(buffer->sink));
+		buf_dbg(buffer, "comp_update_buffer_consume(), no bytes to consume, source->comp.id = %u, source->comp.type = %u, sink->comp.id = %u, sink->comp.type = %u",
+			dev_comp_id(buffer->source),
+			dev_comp_type(buffer->source),
+			dev_comp_id(buffer->sink),
+			dev_comp_type(buffer->sink));
 		return;
 	}
 


### PR DESCRIPTION
Move to dbg since having zero bytes to produce/consume is not
necessarily a problem.

Fixes: https://github.com/thesofproject/sof/issues/3308
Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>