### PR TITLE
zephyr: trace: disable DMA trace and unused filtered trace

### DIFF
--- a/src/include/sof/trace/trace.h
+++ b/src/include/sof/trace/trace.h
@@ -185,7 +185,7 @@ int trace_filter_update(const struct trace_filter *elem);
 
 /* _log_message() */
 
-#ifdef CONFIG_LIBRARY
+#if CONFIG_LIBRARY
 
 extern int test_bench_trace;
 char *get_trace_class(uint32_t trace_class);

--- a/src/platform/Kconfig
+++ b/src/platform/Kconfig
@@ -119,6 +119,7 @@ config SUECREEK
 	select CAVS_VERSION_2_0
 	select XT_WAITI_DELAY
 	select CAVS_USE_LPRO_IN_WAITI
+	select TRACE_DMA_DISABLE
 	help
 	  Select if your target platform is Suecreek-compatible
 

--- a/src/trace/Kconfig
+++ b/src/trace/Kconfig
@@ -88,4 +88,11 @@ config TRACE_BURST_COUNT
 		Amount of messages that will pass through the filter even if sent in rapid succession.
 		Allowed message burst size before filter suppresses the message.
 
+config TRACE_DMA_DISABLE
+	bool
+	default y if KERNEL_BIN_NAME = "zephyr"
+	default n
+	help
+		Most platforms support DMA trace, to disable it select this option.
+
 endmenu

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -403,9 +403,14 @@ zephyr_library_sources(
 )
 
 zephyr_library_sources_ifdef(CONFIG_TRACE
-	${SOF_SRC_PATH}/trace/dma-trace.c
 	${SOF_SRC_PATH}/trace/trace.c
 )
+
+if (NOT CONFIG_TRACE_DMA_DISABLE)
+zephyr_library_sources_ifdef(CONFIG_TRACE
+	${SOF_SRC_PATH}/trace/dma-trace.c
+)
+endif ()
 
 # Optional SOF sources - depends on Kconfig - WIP
 


### PR DESCRIPTION
DMA trace isn't available on Sue Creek for obvious reasons and it isn't yet available under Zephyr. Disable it for those configurations. Additionally under Zephyr filtered traces aren't used, disable them as well.

I know we actually do want DMA trace for Zephyr, but as long as it isn't working, it's better not to include respective code in Zephyr builds.