### PR TITLE
Introduction and preparation for Topology2.0 - Part 1

### DIFF
--- a/tools/topology2/include/common/tokens.conf
+++ b/tools/topology2/include/common/tokens.conf
@@ -1,0 +1,15 @@
+#
+# Vendor token objects with token values used for adding tuple pairs to an object's private data
+#
+
+Object.Base.VendorToken {
+	"sof_tkn_comp" {
+		period_sink_count	400
+		period_source_count	401
+		format			402
+		# Token retired with ABI 3.2, do not use for new capabilities
+		preload_count		403
+		core_id		404
+		uuid			405
+	}
+}

--- a/tools/topology2/include/common/tokens.conf
+++ b/tools/topology2/include/common/tokens.conf
@@ -25,4 +25,9 @@ Object.Base.VendorToken {
 		size			100
 		caps			101
 	}
+
+	"sof_tkn_volume" {
+		ramp_step_type		250
+		ramp_step_ms		251
+	}
 }

--- a/tools/topology2/include/common/tokens.conf
+++ b/tools/topology2/include/common/tokens.conf
@@ -12,4 +12,12 @@ Object.Base.VendorToken {
 		core_id		404
 		uuid			405
 	}
+
+	"sof_tkn_dai" {
+		# Token retired with ABI 3.2, do not use for new capabilities
+		dmac_config			153
+		dai_type			154
+		dai_index			155
+		direction			156
+	}
 }

--- a/tools/topology2/include/common/tokens.conf
+++ b/tools/topology2/include/common/tokens.conf
@@ -20,4 +20,9 @@ Object.Base.VendorToken {
 		dai_index			155
 		direction			156
 	}
+
+	"sof_tkn_buffer" {
+		size			100
+		caps			101
+	}
 }

--- a/tools/topology2/include/common/vendor-token.conf
+++ b/tools/topology2/include/common/vendor-token.conf
@@ -1,0 +1,39 @@
+#
+# vendortoken class definition component. All attributes defined herein are namespaced
+# by alsatplg to "Object.Base.VendorTokem.name.token_name"
+#
+# Usage: this component can be used by instantiating it in the parent object. i.e.
+#
+#	Object.Base.VendorToken. "sof_tkn_comp" {
+#		period_sink_count	400
+#		period_source_count	401
+#		# Token retired with ABI 3.2, do not use for new capabilities
+#		preload_count		403
+#		core_id		404
+#		uuid			405
+#	}
+#
+
+Class.Base.VendorToken {
+	#
+	# name for the vendortoken object
+	#
+	DefineAttribute."name" {
+		type	"string"
+	}
+
+	attributes {
+		#
+		# VendorToken object names are constructed as VendorToken.<name>
+		#
+		!constructor [
+			"name"
+		]
+
+		#
+		# name attribute values for VendorToken objects must be unique in the same alsaconf
+		# node
+		#
+		unique	"name"
+	}
+}

--- a/tools/topology2/include/components/buffer.conf
+++ b/tools/topology2/include/components/buffer.conf
@@ -1,0 +1,136 @@
+# Common pipeline buffer
+#
+# A generic buffer component. All attributes defined herein are namespaced
+# by alsatplg to "Object.Widget.buffer.N.attribute_name"
+#
+# Usage: this component can be used by instantiating it in the parent object. i.e.
+#
+# 	Object.Widget.buffer."N" {
+#		index	1
+#		caps	"host"
+#		periods 2
+#	}
+#
+# Where N is the unique instance number for the buffer object within the same alsaconf node.
+
+Class.Widget."buffer" {
+	#
+	# Pipeline ID for the buffer object
+	#
+	DefineAttribute."index" {}
+
+	#
+	# Buffer object instance
+	#
+	DefineAttribute."instance" {}
+
+	#include common component definition
+	<include/components/widget-common.conf>
+
+	#
+	# Buffer component UUID
+	#
+	DefineAttribute."uuid" {
+		# Token set reference name and type
+		token_ref	"sof_tkn_comp.uuid"
+	}
+
+	#
+	# Bespoke Attribute Definitions for Buffers
+	#
+
+	#
+	# Buffer size in bytes. Will be calculated based on pipeline parameters in which the
+	# buffer object belongs
+	#
+	DefineAttribute."size" {
+		# Token reference and type
+		token_ref	"sof_tkn_buffer.word"
+	}
+
+	# Number of periods
+	DefineAttribute."periods" {}
+
+	# Number of channels
+	DefineAttribute."channels" {}
+
+	#
+	# Buffer memory capabilities. The values provided will be translated to integer values
+	# specified in the tuple_values array
+	# For example: "dai" will be translated to 113 and added to the buffer widget's private data.
+	DefineAttribute."caps" {
+		type	"string"
+		# Token reference and type
+		token_ref	"sof_tkn_buffer.word"
+		constraints {
+			!valid_values [
+				"dai"
+				"host"
+				"pass"
+				"comp"
+			]
+			!tuple_values [
+				113
+				113
+				113
+				65
+			]
+		}
+	}
+
+	# Attribute categories
+	attributes {
+		#
+		# The buffer widget name would be constructed using the index and instance attributes.
+		# For ex: "buffer.1.1" or "buffer.10.2" etc.
+		#
+		!constructor [
+			"index"
+			"instance"
+		]
+
+		#
+		# mandatory attributes that must be provided when the buffer class is instantiated
+		#
+		!mandatory [
+			"periods"
+			"caps"
+			"channels"
+		]
+
+		#
+		# immutable attributes cannot be modified in the object instance
+		#
+		!immutable [
+			"uuid"
+			"type"
+		]
+
+		#
+		# size attribute value for buffer objects is computed in the compiler
+		#
+		!automatic [
+			"size"
+		]
+
+		#
+		# deprecated attributes should not be added in the object instance
+		#
+		!deprecated [
+			"preload_count"
+		]
+
+		#
+		# buffer widget objects instantiated within the same alsaconf node must have unique
+		# instance attribute
+		#
+		unique	"instance"
+	}
+
+	#
+	# Default attribute values for buffer objects
+	#
+	type 		"buffer"
+	uuid 		"92:4c:54:42:92:8e:41:4e:b6:79:34:51:9f:1c:1d:28"
+	no_pm 		"true"
+}

--- a/tools/topology2/include/components/dai.conf
+++ b/tools/topology2/include/components/dai.conf
@@ -1,0 +1,137 @@
+#
+# A generic dai widget. All attributes defined herein are namespaced
+# by alsatplg to "Object.Widget.dai.N.attribute_name"
+#
+# For playback
+# 	Object.Widget.dai."playback" {
+#		dai_type		SSP
+#		index			1
+#		period_sink_count	2
+#		period_source_count	0
+#		type			dai_in
+#	}
+#
+# For Capture
+# 	Object.Widget.dai."capture" {
+#		dai_type		SSP
+#		index			2
+#		period_sink_count	0
+#		period_source_count	2
+#		type			dai_out
+#	}
+#
+
+Class.Widget."dai" {
+	# Type of DAI
+	DefineAttribute."dai_type" {
+		type	"string"
+		token_ref	"sof_tkn_dai.string"
+		constraints {
+			!valid_values [
+				"SSP"
+				"DMIC"
+				"HDA"
+				"ALH"
+				"ESAI"
+			]
+		}
+	}
+
+	DefineAttribute."instance" {}
+
+	# DAI Index in the firmware
+	DefineAttribute."dai_index" {
+		# Token reference and type
+		token_ref	"sof_tkn_dai.word"
+	}
+
+	#
+	# DAI direction. The string values will be converted to 0/1 and added as tuple data
+	#
+	DefineAttribute."direction" {
+		type	"string"
+		token_ref	"sof_tkn_dai.word"
+		constraints {
+			!valid_values [
+				"playback"
+				"capture"
+			]
+			!tuple_values [
+				0
+				1
+			]
+		}
+	}
+
+	# include common widget attribute definitions
+	<include/components/widget-common.conf>
+
+	#
+	# Pipeline ID that the dai widget belongs to
+	#
+	DefineAttribute."index" {}
+
+	DefineAttribute.uuid {
+		type	"string"
+		# Token set reference name and type
+		token_ref	"sof_tkn_comp.uuid"
+	}
+
+	# Bespoke attributes for DAI
+	DefineAttribute."format" {
+		type	"string"
+		# Token reference and type
+		token_ref	"sof_tkn_comp.string"
+	}
+
+	# Attribute categories
+	attributes {
+		#
+		# The DAI widget name would be constructed using the dai_type, index and direction
+		# attributes. For ex: "dai.SSP.1.capture" or "dai.ALH.2.playback" etc.
+		#
+		!constructor [
+			"dai_type"
+			"dai_index"
+			"direction"
+		]
+
+		#
+		# mandatory attributes that must be provided when the dai widget class is instantiated
+		#
+		!mandatory [
+			"type"
+			"stream_name"
+			"format"
+			"index"
+			"period_sink_count"
+			"period_source_count"
+			"format"
+		]
+
+		#
+		# immutable attributes cannot be modified in the object instance
+		#
+		!immutable [
+			"uuid"
+		]
+
+		#
+		# deprecated attributes should not be added in the object instance
+		#
+		!deprecated [
+			"preload_count"
+		]
+
+		#
+		# dai widget objects instantiated within the same alsaconf node must have unique
+		# direction attribute
+		#
+		unique	"instance"
+	}
+
+	# Default attribute values for DAI widget
+	uuid "27:0d:b0:c2:bc:ff:50:41:a5:1a:24:5c:79:c5:e5:4b"
+	no_pm		"true"
+	core_id 	0
+}

--- a/tools/topology2/include/components/host.conf
+++ b/tools/topology2/include/components/host.conf
@@ -1,0 +1,117 @@
+# A generic AIF_IN/AIF_OUT widget. All attributes defined herein are namespaced
+# by alsatplg to "Object.host.direction.attribute_name" in the parent object
+#
+# Usage: host widget can be instantiated by declaring in a parent object as:
+#
+# For playback:
+# 	Object.Widget.host."playback" {
+#		index			3
+#		period_sink_count	2
+#		period_source_count	0
+#		type		 	aif_in
+#	}
+#
+# For Capture:
+# 	Object.Widget.host."capture" {
+#		index			4
+#		period_sink_count	0
+#		period_source_count	2
+#		type			aif_out
+#	}
+
+#
+# "host" class belongs to the "Widget" group of classes.
+#
+Class.Widget."host" {
+	#
+	# Attributes for host widget
+	#
+
+	#
+	# Pipeline ID that the host widget belongs to
+	#
+	DefineAttribute."index" {}
+
+	#
+	# Host direction
+	#
+	DefineAttribute."direction" {
+		type	"string"
+		constraints {
+			!valid_values [
+				"playback"
+				"capture"
+			]
+
+		}
+	}
+
+	#
+	# Host widget type
+	#
+	DefineAttribute."type" {
+		type	"string"
+		constraints {
+			!valid_values [
+				"aif_in"
+				"aif_out"
+			]
+
+		}
+	}
+
+	#include common widget attributes
+	<include/components/widget-common.conf>
+
+	DefineAttribute.uuid {
+		type	"string"
+		# Token set reference name and type
+		token_ref	"sof_tkn_comp.uuid"
+	}
+
+	# Attribute categories
+	attributes {
+		#
+		# host objects instantiated within the same alsaconf node must have unique value for
+		# direction attribute
+		#
+		unique	"direction"
+
+		#
+		# The host object name is constructed using the index and direction arguments.
+		# E.g. "host.0.capture" or "host.2.playback" etc
+		#
+		!constructor [
+			"index"
+			"direction"
+		]
+
+		#
+		# mandatory attributes that must be provided when the host class is instantiated
+		#
+		!mandatory [
+			"type"
+			"stream_name"
+		]
+		#
+		# immutable attributes cannot be modified in the object instance
+		#
+		!immutable [
+			"uuid"
+		]
+		#
+		# deprecated attributes should not be added in the object instance
+		#
+		!deprecated [
+			"preload_count"
+		]
+	}
+
+	#
+	# Default attribute values for host
+	#
+	uuid 		"0c:10:9d:8b:78:6d:8f:41:90:a3:e0:e8:05:d0:85:2b"
+	no_pm		"true"
+	period_sink_count	0
+	period_source_count	2
+}

--- a/tools/topology2/include/components/volume.conf
+++ b/tools/topology2/include/components/volume.conf
@@ -1,0 +1,118 @@
+#
+# Common pipeline volume
+#
+# A generic volume widget. All attributes defined herein are namespaced
+# by alsatplg to "Object.Widget.pga.N.attribute_name"
+#
+# Usage: this component can be used by declaring int a parent object. i.e.
+#
+# 	Object.Widget.pga."N" {
+#		index	1
+#		format	s24le
+#		no_pm	"true"
+#	}
+#
+# Where N is the unique instance number for pga widget in the same alsaconf node.
+
+Class.Widget."pga" {
+	#
+	# Pipeline ID for the pga widget object
+	#
+	DefineAttribute."index" {}
+
+	#
+	# pga object instance
+	#
+	DefineAttribute."instance" {}
+
+	#include common component definition
+	<include/components/widget-common.conf>
+
+	#
+	# pga widget UUID
+	#
+	DefineAttribute."uuid" {
+		type	"string"
+		# Token set reference name and type
+		token_ref	"sof_tkn_comp.uuid"
+	}
+
+	#
+	# Bespoke attributes for PGA
+	#
+
+	#
+	# Volume ramp step type. The values provided will be translated to integer values
+	# as specified in the tuple_values array.
+	# For example: "linear" is translated to 0, "log" to 1 etc.
+	#
+	DefineAttribute."ramp_step_type" {
+		type	"string"
+		# Token set reference name
+		token_ref	"sof_tkn_volume.word"
+		constraints {
+			!valid_values [
+				"linear"
+				"log"
+				"linear_zc"
+				"log_zc"
+			]
+			!tuple_values [
+				0
+				1
+				2
+				3
+			]
+		}
+	}
+
+	#
+	# Volume ramp step in milliseconds
+	#
+	DefineAttribute."ramp_step_ms" {
+		# Token set reference name
+		token_ref	"sof_tkn_volume.word"
+	}
+
+	# Attribute categories
+	attributes {
+		#
+		# The PGA widget name would be constructed using the index and instance attributes.
+		# For ex: "pga.1.1" or "pga.10.2" etc.
+		#
+		!constructor [
+			"index"
+			"instance"
+		]
+
+		#
+		# immutable attributes cannot be modified in the object instance
+		#
+		!immutable [
+			"uuid"
+			"type"
+		]
+
+		#
+		# deprecated attributes should not be added in the object instance
+		#
+		!deprecated [
+			"preload_count"
+		]
+
+		#
+		# pga widget objects instantiated within the same alsaconf node must have unique
+		# instance attribute
+		#
+		unique	"instance"
+	}
+
+	# Default attribute values for pga widget
+	type 			"pga"
+	uuid 			"7e:67:7e:b7:f4:5f:88:41:af:14:fb:a8:bd:bf:86:82"
+	no_pm			"true"
+	period_sink_count	2
+	period_source_count	2
+	ramp_step_type		"linear"
+	ramp_step_ms		400
+}

--- a/tools/topology2/include/components/widget-common.conf
+++ b/tools/topology2/include/components/widget-common.conf
@@ -1,0 +1,84 @@
+#
+# Common widget attribute definitions
+#
+
+#
+# no_pm - maps to the DAPM widget's reg field
+# "false" value indicates that there is no direct DAPM for this widget
+#
+DefineAttribute."no_pm" {
+	type	"string"
+	constraints {
+		!valid_values [
+			"true"
+			"false"
+		]
+	}
+}
+
+#
+# Widget Type - maps to the widget ID with values of type enum SND_SOC_TPLG_DAPM_*
+#
+DefineAttribute."type" {
+	type	"string"
+}
+
+#
+# Stream name - maps to the DAPM widget's stream name
+#
+DefineAttribute."stream_name" {
+	type	"string"
+}
+
+#
+# Event type widget binds to
+#
+DefineAttribute.event_type {}
+
+#
+# Widget event flags
+#
+DefineAttribute.event_flags {}
+
+#
+# Attributes with a "token_ref" value will be added to widget's private data
+#
+
+# number of sink periods
+DefineAttribute."period_sink_count" {
+	# Token set reference name and type
+	token_ref	"sof_tkn_comp.word"
+}
+
+# number of source periods
+DefineAttribute."period_source_count" {
+	# Token set reference name and type
+	token_ref	"sof_tkn_comp.word"
+}
+
+# widget format
+DefineAttribute."format" {
+	type	"string"
+	# Token set reference name and type
+	token_ref	"sof_tkn_comp.string"
+	constraints {
+		!valid_values [
+			"s16le"
+			"s24le"
+			"s32le"
+			"float"
+		]
+	}
+}
+
+# ID of the core this widget should be scheduled on
+DefineAttribute."core_id" {
+	# Token set reference name and type
+	token_ref	"sof_tkn_comp.word"
+}
+
+# number of periods to preload
+DefineAttribute."preload_count" {
+	# Token set reference name and type
+	token_ref	"sof_tkn_comp.word"
+}


### PR DESCRIPTION
This PR introduces Topology2.0 and adds the preparatory commits for a few widget classes that will form the basis for creating simple topologies with the 2.0 compiler.

There are no machine topologies included yet.