### PR TITLE
topology: eq pipelines: remove duplicate SectionData

### DIFF
--- a/tools/topology/sof/pipe-eq-iir-volume-capture-16khz.m4
+++ b/tools/topology/sof/pipe-eq-iir-volume-capture-16khz.m4
@@ -43,13 +43,14 @@ LIST(`		', `SOF_TKN_VOLUME_RAMP_STEP_TYPE	"0"'
 
 W_DATA(DEF_PGA_CONF, DEF_PGA_TOKENS)
 
-define(DEF_EQIIR_COEF, concat(`eqiir_coef_', PIPELINE_ID))
-define(DEF_EQIIR_PRIV, concat(`eqiir_priv_', PIPELINE_ID))
-
 # By default, use 40 Hz highpass response with +0 dB gain for 16khz
 # TODO: need to implement middle level macro handler per pipeline
 ifdef(`DMIC16KPROC_FILTER1', , `define(DMIC16KPROC_FILTER1, eq_iir_coef_highpass_40hz_0db_16khz.m4)')
+define(DEF_EQIIR_PRIV, DMIC16KPROC_FILTER1)
 include(DMIC16KPROC_FILTER1)
+
+define(DEF_EQIIR_COEF, concat(`eqiir_coef_', PIPELINE_ID))
+
 
 # EQ Bytes control with max value of 255
 C_CONTROLBYTES(DEF_EQIIR_COEF, PIPELINE_ID,

--- a/tools/topology/sof/pipe-eq-iir-volume-capture.m4
+++ b/tools/topology/sof/pipe-eq-iir-volume-capture.m4
@@ -58,13 +58,13 @@ LIST(`		', `SOF_TKN_VOLUME_RAMP_STEP_TYPE	"0"'
 
 W_DATA(DEF_PGA_CONF, DEF_PGA_TOKENS)
 
-define(DEF_EQIIR_COEF, concat(`eqiir_coef_', PIPELINE_ID))
-define(DEF_EQIIR_PRIV, concat(`eqiir_priv_', PIPELINE_ID))
-
 # By default, use 40 Hz highpass response with +0 dB gain for 48khz
 # TODO: need to implement middle level macro handler per pipeline
 ifdef(`DMICPROC_FILTER1', , `define(DMICPROC_FILTER1, eq_iir_coef_highpass_40hz_0db_48khz.m4)')
+define(DEF_EQIIR_PRIV, DMICPROC_FILTER1)
 include(DMICPROC_FILTER1)
+
+define(DEF_EQIIR_COEF, concat(`eqiir_coef_', PIPELINE_ID))
 
 # EQ Bytes control with max value of 255
 C_CONTROLBYTES(DEF_EQIIR_COEF, PIPELINE_ID,

--- a/tools/topology/sof/pipe-highpass-capture.m4
+++ b/tools/topology/sof/pipe-highpass-capture.m4
@@ -45,11 +45,9 @@ W_DATA(DEF_PGA_CONF, DEF_PGA_TOKENS)
 # IIR configuration
 #
 
-define(DEF_EQIIR_COEF, concat(`eqiir_coef_', PIPELINE_ID))
-define(DEF_EQIIR_PRIV, concat(`eqiir_priv_', PIPELINE_ID))
-
 # By default, use 40 Hz highpass response with 0 dB gain
 ifdef(`PIPELINE_FILTER1', , `define(PIPELINE_FILTER1, eq_iir_coef_highpass_40hz_0db_48khz.m4)')
+define(DEF_EQIIR_PRIV, PIPELINE_FILTER1)
 include(PIPELINE_FILTER1)
 
 # EQ Bytes control with max value of 255

--- a/tools/topology/sof/pipe-highpass-switch-capture.m4
+++ b/tools/topology/sof/pipe-highpass-switch-capture.m4
@@ -55,12 +55,13 @@ W_DATA(DEF_PGA_CONF, DEF_PGA_TOKENS)
 # IIR configuration
 #
 
-define(DEF_EQIIR_COEF, concat(`eqiir_coef_', PIPELINE_ID))
-define(DEF_EQIIR_PRIV, concat(`eqiir_priv_', PIPELINE_ID))
 
 # By default, use 40 Hz highpass response with 0 dB gain
 ifdef(`PIPELINE_FILTER1', , `define(PIPELINE_FILTER1, eq_iir_coef_highpass_40hz_0db_48khz.m4)')
+define(DEF_EQIIR_PRIV, PIPELINE_FILTER1)
 include(PIPELINE_FILTER1)
+
+define(DEF_EQIIR_COEF, concat(`eqiir_coef_', PIPELINE_ID))
 
 # EQ Bytes control with max value of 255
 C_CONTROLBYTES(DEF_EQIIR_COEF, PIPELINE_ID,


### PR DESCRIPTION
Remove the duplicate SectionData when multiple EQ's use the
same filter coefficients. There is no change in the topology
binary generated with just one SectionData instead of multiple
ones.

But this will help clean up the conf file so that converting to
topology2.0 will become easier as the name tells me which
coefficients to include.