### PR TITLE
pipeline: dont disable IRQs around pipeline scheduling.

### DIFF
--- a/src/audio/pipeline/pipeline-schedule.c
+++ b/src/audio/pipeline/pipeline-schedule.c
@@ -113,9 +113,6 @@ void pipeline_schedule_triggered(struct pipeline_walk_context *ctx,
 {
 	struct list_item *tlist;
 	struct pipeline *p;
-	uint32_t flags;
-
-	irq_local_disable(flags);
 
 	list_for_item(tlist, &ctx->pipelines) {
 		p = container_of(tlist, struct pipeline, list);
@@ -138,8 +135,6 @@ void pipeline_schedule_triggered(struct pipeline_walk_context *ctx,
 			break;
 		}
 	}
-
-	irq_local_enable(flags);
 }
 
 int pipeline_comp_task_init(struct pipeline *p)


### PR DESCRIPTION
The walk context is passed in by the caller and not shared. The pipeline
states are locked by IPC.

Signed-off-by: Liam Girdwood <liam.r.girdwood@linux.intel.com>