### PR TITLE
notifier: no need to disable IRQs during registration

### DIFF
--- a/src/include/sof/lib/notifier.h
+++ b/src/include/sof/lib/notifier.h
@@ -10,6 +10,7 @@
 
 #include <sof/bit.h>
 #include <sof/list.h>
+#include <sof/spinlock.h>
 #include <sof/sof.h>
 #include <stdint.h>
 
@@ -39,6 +40,7 @@ enum notify_id {
 
 struct notify {
 	struct list_item list[NOTIFIER_ID_COUNT]; /* list of callback handles */
+	spinlock_t lock;	/* list lock */
 };
 
 struct notify_data {


### PR DESCRIPTION
Use a spinlock for locking the list instead.

Signed-off-by: Liam Girdwood <liam.r.girdwood@linux.intel.com>