### PR TITLE
pm: cavs: no need to switch IRQs when setting PM state variable.

### DIFF
--- a/src/platform/intel/cavs/lib/pm_runtime.c
+++ b/src/platform/intel/cavs/lib/pm_runtime.c
@@ -88,16 +88,8 @@ static inline void cavs_pm_runtime_enable_dsp(bool enable)
 {
 	struct pm_runtime_data *prd = pm_runtime_data_get();
 	struct cavs_pm_runtime_data *pprd = prd->platform_data;
-	uint32_t flags;
-
-	/* request is always run on dsp0 and applies to dsp0,
-	 * so no global lock is required.
-	 */
-	irq_local_disable(flags);
 
 	pprd->dsp_d0 = !enable;
-
-	irq_local_enable(flags);
 
 	tr_info(&power_tr, "pm_runtime_enable_dsp dsp_d0_sref %d",
 		pprd->dsp_d0);


### PR DESCRIPTION
This variable is only used to enable and disable the CPU residency
counters. No need to  switch IRQs OFF when setting it's value.

Signed-off-by: Liam Girdwood <liam.r.girdwood@linux.intel.com>