### PR TITLE
topology: remove default google hotword

### DIFF
--- a/tools/topology/sof-tgl-max98357a-rt5682.m4
+++ b/tools/topology/sof-tgl-max98357a-rt5682.m4
@@ -85,8 +85,6 @@ define(DMIC_PIPELINE_KWD_ID, `12')
 define(DMIC_DAI_LINK_16k_ID, `2')
 # define pcm, pipeline and dai id
 define(KWD_PIPE_SCH_DEADLINE_US, 5000)
-# Use the google hotword detector
-define(DETECTOR_TYPE, `google-hotword-detect')
 # include the generic dmic with kwd
 include(`platform/intel/intel-generic-dmic-kwd.m4')
 

--- a/tools/topology/sof-tgl-max98373-rt5682.m4
+++ b/tools/topology/sof-tgl-max98373-rt5682.m4
@@ -88,8 +88,6 @@ define(DMIC_DAI_LINK_16k_ID, `2')
 define(DMIC_PIPELINE_48k_CORE_ID, 1)
 # define pcm, pipeline and dai id
 define(KWD_PIPE_SCH_DEADLINE_US, 20000)
-# Use the google hotword detector
-define(DETECTOR_TYPE, `google-hotword-detect')
 # include the generic dmic with kwd
 include(`platform/intel/intel-generic-dmic-kwd.m4')
 

--- a/tools/topology/sof-tgl-sdw-max98373-rt5682.m4
+++ b/tools/topology/sof-tgl-sdw-max98373-rt5682.m4
@@ -126,8 +126,6 @@ define(DMIC_DAI_LINK_16k_ID, `5')
 define(DMIC_16k_PCM_NAME, `BufferedMic')
 # define pcm, pipeline and dai id
 define(KWD_PIPE_SCH_DEADLINE_US, 5000)
-# Use the google hotword detector
-define(DETECTOR_TYPE, `google-hotword-detect')
 # include the generic dmic with kwd
 include(`platform/intel/intel-generic-dmic-kwd.m4')
 


### PR DESCRIPTION
hotword is not public and therefore should not be on by default

Signed-off-by: Curtis Malainey <curtis@malainey.com>