### PR TITLE
topology: Add DRC_EQ def for adopting DRC/EQ pipeline

### DIFF
--- a/tools/topology/CMakeLists.txt
+++ b/tools/topology/CMakeLists.txt
@@ -132,6 +132,7 @@ set(TPLGS
 	"sof-imx8mp-wm8960-kwd\;sof-imx8mp-wm8960-kwd"
 	"sof-tgl-max98357a-rt5682\;sof-tgl-max98357a-rt5682\;-DCODEC=MAX98357A\;-DFMT=s16le"
 	"sof-tgl-max98357a-rt5682\;sof-tgl-max98357a-rt5682-pdm1\;-DCODEC=MAX98357A\;-DFMT=s16le\;-DDMIC_DAI_LINK_16k_PDM=STEREO_PDM1"
+	"sof-tgl-max98357a-rt5682\;sof-tgl-max98357a-rt5682-pdm1-drceq\;-DCODEC=MAX98357A\;-DFMT=s16le\;-DDMIC_DAI_LINK_16k_PDM=STEREO_PDM1\;-DDRC_EQ"
 	"sof-tgl-max98357a-rt5682\;sof-tgl-rt1011-rt5682\;-DCODEC=RT1011\;-DFMT=s24le"
 	"sof-tgl-max98373-rt5682\;sof-tgl-max98373-rt5682\;-DAMP_SSP=1"
 	"sof-tgl-max98373-rt5682\;sof-tgl-max98373-rt5682-igonr\;-DAMP_SSP=1\;-DIGO"

--- a/tools/topology/sof-tgl-max98357a-rt5682.m4
+++ b/tools/topology/sof-tgl-max98357a-rt5682.m4
@@ -98,7 +98,9 @@ dnl     frames, deadline, priority, core)
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
 define(ENDPOINT_NAME, `Speakers')
 PIPELINE_PCM_ADD(
-	ifdef(`WAVES', sof/pipe-waves-codec-demux-playback.m4, sof/pipe-volume-demux-playback.m4),
+	ifdef(`WAVES', sof/pipe-waves-codec-demux-playback.m4,
+	      ifdef(`DRC_EQ', sof/pipe-drc-eq-volume-demux-playback.m4,
+		    sof/pipe-volume-demux-playback.m4)),
 	1, 0, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)


### PR DESCRIPTION
For speaker pipeline, we want to deploy DRC/EQ for partial TGL device
like Eldrid. The definition flag DRC_EQ is added to make the choice of
adopting the playback pipeline with DRC/EQ.