### PR TITLE
topology: sof-cnl-nocodec: use different core for each DAI

### DIFF
--- a/tools/topology/topology1/sof-cnl-nocodec.m4
+++ b/tools/topology/topology1/sof-cnl-nocodec.m4
@@ -34,31 +34,31 @@ dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s24le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline on core 2 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	1, 0, 2, s24le,
-	1000, 0, 0,
+	1000, 0, 2,
 	48000, 48000, 48000)
 
 # Volume switch capture pipeline 2 on PCM 0 using max 2 channels of s24le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline on core 2 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-volume-switch-capture.m4,
 	2, 0, 2, s24le,
-	1000, 0, 0,
+	1000, 0, 2,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 3 on PCM 1 using max 2 channels of s24le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline on core 1 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	3, 1, 2, s24le,
-	1000, 0, 0,
+	1000, 0, 1,
 	48000, 48000, 48000)
 
 # Volume switch capture pipeline 4 on PCM 1 using max 2 channels of s24le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline on core 1 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-volume-switch-capture.m4,
 	4, 1, 2, s24le,
-	1000, 0, 0,
+	1000, 0, 1,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 5 on PCM 2 using max 2 channels of s24le.
@@ -76,10 +76,10 @@ PIPELINE_PCM_ADD(sof/pipe-volume-switch-capture.m4,
 	48000, 48000, 48000)
 
 # Passthrough capture pipeline 7 on PCM 3 using max 4 channels.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline on core 3 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
 	7, 3, 4, s32le,
-	1000, 0, 0,
+	1000, 0, 3,
 	48000, 48000, 48000)
 
 #
@@ -96,28 +96,28 @@ dnl     deadline, priority, core, time_domain)
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, 0, NoCodec-0,
 	PIPELINE_SOURCE_1, 2, s24le,
-	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+	1000, 0, 2, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is SSP0 using 2 periods
 # Buffers use s24le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	2, SSP, 0, NoCodec-0,
 	PIPELINE_SINK_2, 2, s24le,
-	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+	1000, 0, 2, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is SSP1 using 2 periods
 # Buffers use s24le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	3, SSP, 1, NoCodec-1,
 	PIPELINE_SOURCE_3, 2, s24le,
-	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+	1000, 0, 1, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is SSP1 using 2 periods
 # Buffers use s24le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	4, SSP, 1, NoCodec-1,
 	PIPELINE_SINK_4, 2, s24le,
-	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+	1000, 0, 1, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is SSP2 using 2 periods
 # Buffers use s24le format, 1000us deadline on core 0 with priority 0
@@ -134,11 +134,11 @@ DAI_ADD(sof/pipe-dai-capture.m4,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is DMIC 0 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline on core 3 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	7, DMIC, 0, NoCodec-3,
 	PIPELINE_SINK_7, 2, s32le,
-	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+	1000, 0, 3, SCHEDULE_TIME_DOMAIN_TIMER)
 
 dnl PCM_DUPLEX_ADD(name, pcm_id, playback, capture)
 PCM_DUPLEX_ADD(Port0, 0, PIPELINE_PCM_1, PIPELINE_PCM_2)


### PR DESCRIPTION
The UpExtreme HAT connector with the SoundWire,
I2S, DMIC mixed mode exposes the following pins

DMIC_DATA0: input: HAT PIN 8
DMIC_CLK: output: HAT PIN 26

IS2_MCLK: output: HAT PIN 16

I2S1_SCLK: output: HAT PIN 32
I2S1_SFRM: output: HAT PIN 10
I2S1_TXD: output: HAT PIN 24
I2S1_RXD: input: HAT PIN 18

Let's use core3 for DMIC, core2 for SSP0, core1 for SSP1 and core0 for
SSP2.

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>