### PR TITLE
topology2: Add pipeline classes

### DIFF
--- a/tools/topology/topology2/include/pipelines/eq-iir-volume-capture.conf
+++ b/tools/topology/topology2/include/pipelines/eq-iir-volume-capture.conf
@@ -1,0 +1,117 @@
+#
+# Volume capture pipeline with Highpass EQ IIR
+#
+# Capture pipeline with a EQ IIR filter. All attributes defined herein are namespaced by alsatplg to
+# "Object.Pipeline.eq-iir-volume--capture.attribute_name"
+#
+# Usage: this component can be used by declaring in the top-level topology conf file as follows:
+#
+# 	Object.Pipeline.eq-iir-volume--capture."N" {
+#		format		"s16le"
+#		period		1000
+#		time_domain	"timer"
+#		channels	2
+#		rate		48000
+#	}
+#
+# Where N is a unique integer for pipeline ID in the same alsaconf node.
+#
+
+#
+# (source) host.N.capture <- buffer.N.1 <- volume.N.1 <- buffer.N.2 <- eqiir.N.1 <- buffer.N.3 (source endpoint)
+#
+Class.Pipeline."eq-iir-volume-capture" {
+	# Include common pipeline attribute definitions
+	<include/pipelines/pipeline-common.conf>
+
+	attributes {
+		!constructor [
+			"index"
+		]
+		!mandatory [
+			"format"
+		]
+		!immutable [
+			"direction"
+		]
+		unique	"index"
+	}
+
+	Object.Widget {
+		pipeline."1" {}
+
+		host."capture" {
+			type		"aif_out"
+		}
+
+		buffer."1" {
+			periods	2
+			caps		"host"
+		}
+
+		pga."1" {
+			# set TLV scale for volume control mixer
+			Object.Control.mixer."1" {
+				Object.Base.tlv."vtlv_m50s1" {
+					Object.Base.scale."m50s1" {
+						min	-5000
+						step	100
+					}
+				}
+			}
+		}
+
+		buffer."2" {
+			periods	2
+			caps		"host"
+		}
+
+		eqiir."1" {
+			# byte control for EQ IIR
+			Object.Control.bytes."1" {}
+		}
+
+		buffer."3" {
+			periods	2
+			caps		"dai"
+		}
+	}
+
+	# Pipeline connections
+	Object.Base {
+		route."1" {
+			source	buffer..1
+			sink host..capture
+		}
+
+		route."2" {
+			source	pga..1
+			sink	buffer..1
+		}
+
+		route."3" {
+			source	buffer..2
+			sink	pga..1
+		}
+
+		route."4" {
+			source	eqiir..1
+			sink	buffer..2
+		}
+
+		route."5" {
+			source	buffer..3
+			sink	eqiir..1
+		}
+	}
+
+	direction 	"capture"
+	time_domain	"timer"
+	period		1000
+	channels	2
+	rate		48000
+	priority	0
+	core 		0
+	frames		0
+	mips		5000
+}

--- a/tools/topology/topology2/include/pipelines/passthrough-capture.conf
+++ b/tools/topology/topology2/include/pipelines/passthrough-capture.conf
@@ -1,0 +1,72 @@
+#
+# Volume capture pipeline
+#
+# A simple pipeline. All attributes defined herein are namespaced by alsatplg to
+# "Object.Pipeline.passthrough-capture.N.attribute_name"
+#
+# Usage: this component can be used by declaring in the top-level topology conf file as follows:
+#
+# 	Object.passthrough-capture."N" {
+#		format		"s16le"
+#		period		1000
+#		time_domain	"timer"
+#		channels	2
+#		rate		48000
+#	}
+#
+# and N is the unique pipeline_id for this pipeline object within the same alsaconf node.
+#
+#
+# (sink) host.N.capture <- buffer.N.1 (source endpoint)
+#
+Class.Pipeline."passthrough-capture" {
+	# Include common pipeline attribute definitions
+	<include/pipelines/pipeline-common.conf>
+
+	attributes {
+		!constructor [
+			"index"
+		]
+		!immutable [
+			"direction"
+		]
+		#
+		# passthrough-capture pipeline objects instantiated within the same alsaconf node must have
+		# unique index attribute
+		#
+		unique	"index"
+	}
+
+	Object.Widget {
+		pipeline."1" {}
+
+		host."capture" {
+			type			"aif_out"
+		}
+
+		buffer."1" {
+			periods	2
+			caps		"pass"
+		}
+	}
+
+	# Pipeline connections
+	Object.Base {
+		route."1" {
+			source	"buffer..1"
+			sink	"host..capture"
+		}
+	}
+
+	# Default attribute values
+	format		"s32le"
+	direction 	"capture"
+	time_domain	"timer"
+	period		1000
+	channels	2
+	rate		48000
+	priority	0
+	core 		0
+	frames		0
+	mips		5000
+}

--- a/tools/topology/topology2/include/pipelines/pipeline-common.conf
+++ b/tools/topology/topology2/include/pipelines/pipeline-common.conf
@@ -1,0 +1,78 @@
+#
+# Common pipeline definitions. To be included in Class.Pipeline definitions
+#
+
+# pipeline ID
+DefineAttribute."index" {}
+
+# Number of channels
+DefineAttribute."channels" {
+	constraints {
+		min	2
+		max	8
+	}
+}
+
+# Pipeline format
+DefineAttribute."format" {
+	type	"string"
+	constraints {
+		!valid_values [
+			"s32le"
+			"s24le"
+			"s16le"
+			"float"
+		]
+	}
+}
+
+# Sampling rate
+DefineAttribute."rate" {
+	constraints {
+		min	16000
+		max	196000
+	}
+}
+
+# Pipeline direction
+DefineAttribute."direction" {
+	type	"string"
+	constraints {
+		!valid_values [
+			"playback"
+			"capture"
+		]
+	}
+}
+
+# Scheduling period
+DefineAttribute."period" {
+	# Token reference and type
+	token_ref	"sof_tkn_scheduler.word"
+	constraints {
+		min	333
+		max	1000
+	}
+}
+
+# Scheduler time domain. The value provided will be translated to 0/1 based on
+# sof_tkn_scheduler_time_domain. For example: value "timer" will be converted to 1.
+DefineAttribute."time_domain" {
+	# Token reference and type
+	type	"string"
+	token_ref	"sof_tkn_scheduler.word"
+	constraints {
+		# Acceptable values for time_domain
+		!valid_values [
+			"dma"
+			"timer"
+		]
+		!tuple_values [
+			0
+			1
+		]
+	}
+}
+
+# flag to indicate if the pipeline is dynamic
+DefineAttribute."dynamic_pipeline" {}

--- a/tools/topology/topology2/include/pipelines/volume-capture.conf
+++ b/tools/topology/topology2/include/pipelines/volume-capture.conf
@@ -1,0 +1,103 @@
+#
+# Volume capture pipeline
+#
+# A simple pipeline. All attributes defined herein are namespaced by alsatplg to
+# "Object.Pipeline.volume-capture.N.attribute_name"
+#
+# Usage: this component can be used by declaring in the top-level topology conf file as follows:
+#
+# 	Object.Pipeline.volume-capture."N" {
+#		format		"s16le"
+#		period		1000
+#		time_domain	"timer"
+#		channels	2
+#		rate		48000
+#	}
+#
+# and N is the unique pipeline_id for this pipeline object within the same alsaconf node.
+#
+#
+# (sink) host.N.capture <- buffer.N.1 <- volume.N.1 <- buffer.N.2 (source endpoint)
+#
+Class.Pipeline."volume-capture" {
+	# include common pipeline attribute definitions
+	<include/pipelines/pipeline-common.conf>
+
+	attributes {
+		# pipeline name is constructed as "volume-capture.1"
+		!constructor [
+			"index"
+		]
+		!mandatory [
+			"format"
+		]
+		!immutable [
+			"direction"
+		]
+		#
+		# volume-capture objects instantiated within the same alsaconf node must have
+		# unique index attribute
+		#
+		unique	"index"
+	}
+
+	Object.Widget {
+		pipeline."1" {}
+
+		host."capture" {
+			type			"aif_out"
+		}
+
+		buffer."1" {
+			periods	2
+			caps		"host"
+		}
+
+		pga."1" {
+			ramp_step_ms	250
+
+			Object.Control.mixer.1 {
+				Object.Base.tlv."vtlv_m50s1" {
+					Object.Base.scale."m50s1" {
+						min	-5000
+						step	100
+					}
+				}
+			}
+		}
+
+		buffer."2" {
+			periods	2
+			caps		"dai"
+		}
+	}
+
+	# Pipeline connections
+	Object.Base {
+		route."1" {
+			source	"buffer..1"
+			sink	"host..capture"
+		}
+
+		route."2" {
+			source	"pga..1"
+			sink	"buffer..1"
+		}
+
+		route."3" {
+			source	"buffer..2"
+			sink	"pga..1"
+		}
+	}
+
+	# Default attribute values
+	direction 	"capture"
+	time_domain	"timer"
+	period		1000
+	channels	2
+	rate		48000
+	priority	0
+	core 		0
+	frames		0
+	mips		5000
+}

--- a/tools/topology/topology2/include/pipelines/volume-demux-playback.conf
+++ b/tools/topology/topology2/include/pipelines/volume-demux-playback.conf
@@ -1,0 +1,117 @@
+#
+# Low Latency playback pipeline with demux and volume.
+#
+# All attributes defined herein are namespaced by alsatplg to
+# "Object.Pipeline.volume-demux-playback.N.attribute_name"
+#
+# Usage: this component can be used by declaring in the top-level topology conf file as follows:
+#
+# 	Object.Pipeline.volume-demux-playback."N" {
+#		format		"s16le"
+#		period		1000
+#		time_domain	"timer"
+#		channels	2
+#		rate		48000
+#	}
+#
+# Where N is a unique integer for pipeline ID in the same alsaconf node.
+#
+
+#
+# (source) host.N.playback -> buffer.N.1 -> volume.N.1 -> buffer.N.2 -> muxdemux.N.1 -> buffer.N.3 (sink endpoint)
+#
+Class.Pipeline."volume-demux-playback" {
+	# Include common pipeline attribute definitions
+	<include/pipelines/pipeline-common.conf>
+
+	attributes {
+		!constructor [
+			"index"
+		]
+		!mandatory [
+			"channels"
+		]
+		!immutable [
+			"direction"
+		]
+		unique	"index"
+	}
+
+	Object.Widget {
+		pipeline."1" {}
+
+		host."playback" {
+			type		"aif_in"
+		}
+
+		buffer."1" {
+			periods	2
+			caps		"host"
+		}
+
+		pga."1" {
+			# set TLV scale for volume control mixer
+			Object.Control.mixer."1" {
+				Object.Base.tlv."vtlv_m64s2" {
+					Object.Base.scale."m64s2" {}
+				}
+			}
+		}
+
+		buffer."2" {
+			periods	2
+			caps		"comp"
+		}
+
+		muxdemux."1" {
+			# byte control for muxemux widget
+			Object.Control.bytes."0" {
+				max	304
+			}
+		}
+
+		buffer."3" {
+			periods	2
+			caps		"comp"
+		}
+	}
+
+	# Pipeline connections
+	Object.Base {
+		route."1" {
+			sink	buffer..1
+			source  host..playback
+		}
+
+		route."2" {
+			sink	pga..1
+			source	buffer..1
+		}
+
+		route."3" {
+			sink	buffer..2
+			source	pga..1
+		}
+
+		route."4" {
+			sink	muxdemux..1
+			source	buffer..2
+		}
+
+		route."5" {
+			sink	buffer..3
+			source	muxdemux..1
+		}
+	}
+
+	# default attribute values for volume-demux-playback pipeline
+	direction 	"playback"
+	time_domain	"timer"
+	period		1000
+	channels	2
+	rate		48000
+	priority	0
+	core 		0
+	frames		0
+	mips		5000
+}

--- a/tools/topology/topology2/include/pipelines/volume-playback.conf
+++ b/tools/topology/topology2/include/pipelines/volume-playback.conf
@@ -1,0 +1,100 @@
+#
+# Volume playback pipeline
+#
+# A simple pipeline. All attributes defined herein are namespaced by alsatplg to
+# "Object.Pipeline.volume-playback.N.attribute_name"
+#
+# Usage: this component can be used by declaring in the top-level topology conf file as follows:
+#
+# 	Object.Pipeline.volume-playback."N" {
+#		format		"s16le"
+#		period		1000
+#		time_domain	"timer"
+#		channels	2
+#		rate		48000
+#	}
+#
+# where N is the unique pipeline_id for this pipeline object within the same alsaconf node.
+#
+#
+# (source) host.N.playback -> buffer.N.1 -> volume.N.1 -> buffer.N.2 (sink endpoint)
+#
+Class.Pipeline."volume-playback" {
+	# include common pipeline attribute definitions
+	<include/pipelines/pipeline-common.conf>
+
+	attributes {
+		# pipeline name is constructed as "volume-playback.1"
+		!constructor [
+			"index"
+		]
+		!mandatory [
+			"format"
+		]
+		!immutable [
+			"direction"
+		]
+		#
+		# volume-playback objects instantiated within the same alsaconf node must have
+		# unique index attribute
+		#
+		unique	"index"
+	}
+
+	Object.Widget {
+		pipeline."1" {}
+
+		host."playback" {
+			type			"aif_in"
+		}
+
+		buffer."1" {
+			periods	2
+			caps		"host"
+		}
+
+		pga."1" {
+			Object.Control.mixer.1 {
+				Object.Base.tlv."vtlv_m64s2" {
+					Object.Base.scale."m64s2" {}
+				}
+			}
+		}
+
+		buffer."2" {
+			periods	2
+			caps		"dai"
+		}
+	}
+
+	# Pipeline connections
+	# The index attribute values for the source/sink widgets will be populated
+	# when the route objects are built
+	Object.Base {
+		route."1" {
+			source	"host..playback"
+			sink	"buffer..1"
+		}
+
+		route."2" {
+			source	"buffer..1"
+			sink	"pga..1"
+		}
+
+		route."3" {
+			source	"pga..1"
+			sink	"buffer..2"
+		}
+	}
+
+	# Default attribute values
+	direction 	"playback"
+	time_domain	"timer"
+	period		1000
+	channels	2
+	rate		48000
+	priority	0
+	core 		0
+	frames		0
+	mips		5000
+}


### PR DESCRIPTION
Add some pipeline classes for volume playback/capture, passthrough
capture and eq capture.
Each of these classes include the pipeline widget objects, connections
between pipeline widgets and pipeline attribute definitions

For ex: A volume playback pipeline can be instanted as follows:
Object.Pipeline.pipeline-volume-playback."2" {
	channels	2
	rate		48000
	index		5
	format		"s32le"
}

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>