### PR TITLE
topology: tgl-max98357a-rt5682: conditionally build BT offload

### DIFF
--- a/tools/topology/topology1/sof-tgl-max98373-rt5682.m4
+++ b/tools/topology/topology1/sof-tgl-max98373-rt5682.m4
@@ -92,12 +92,15 @@ define(KWD_PIPE_SCH_DEADLINE_US, 20000)
 include(`platform/intel/intel-generic-dmic-kwd.m4')
 
 # BT offload support
+ifdef(`INCLUDE_BT_OFFLOAD',
+`
 define(`BT_PIPELINE_PB_ID', eval(SMART_REF_PPL_ID + 1))
 define(`BT_PIPELINE_CP_ID', eval(SMART_REF_PPL_ID + 2))
 define(`BT_DAI_LINK_ID', eval(SMART_BE_ID + 1))
 define(`BT_PCM_ID', `6')
 define(`HW_CONFIG_ID', `8')
 include(`platform/intel/intel-generic-bt.m4')
+')
 
 dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,


### PR DESCRIPTION
With both INCLUDE_IIR_EQ and BT offload enabled, observe tplg load failed for:

[    7.449626] sof-audio-pci 0000:00:1f.3: error: ipc error for 0x80010000 size 12
[    7.449629] sof-audio-pci 0000:00:1f.3: error: failed to set DAI config for SSP0-Codec index 0
[    7.449630] sof-audio-pci 0000:00:1f.3: error: failed to save DAI config for SSP0
[    7.449631] sof-audio-pci 0000:00:1f.3: ASoC: physical link loading failed
[    7.449633] sof-audio-pci 0000:00:1f.3: ASoC: topology: could not load header: -12

So conditionally compile BT as the feature is optional on tgl.

Signed-off-by: Yong Zhi <yong.zhi@intel.com>