### PR TITLE
Add new mtrace_printf() and use it for DMA init error handling and demoting banner to INFO level

### DIFF
--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -4129,6 +4129,8 @@ sub process {
 			     "LINUX_VERSION_CODE should be avoided, code should be for the version to which it is merged\n" . $herecurr);
 		}
 
+		if(!$SOF) {
+
 # check for uses of printk_ratelimit
 		if ($line =~ /\bprintk_ratelimit\s*\(/) {
 			WARN("PRINTK_RATELIMITED",
@@ -4168,6 +4170,8 @@ sub process {
 			WARN("PREFER_DEV_LEVEL",
 			     "Prefer dev_$level(... to dev_printk(KERN_$orig, ...\n" . $herecurr);
 		}
+
+		} # !$SOF
 
 # ENOSYS means "bad syscall nr" and nothing else.  This will have a small
 # number of false positives, but assembly files are not checked, so at

--- a/src/include/sof/drivers/timer.h
+++ b/src/include/sof/drivers/timer.h
@@ -62,6 +62,17 @@ int64_t platform_timer_set(struct timer *timer, uint64_t ticks);
 void platform_timer_clear(struct timer *timer);
 uint64_t platform_timer_get(struct timer *timer);
 uint64_t platform_timer_get_atomic(struct timer *timer);
+
+static inline uint64_t platform_safe_get_time(struct timer *timer)
+{
+	/* Default to something small but at least 1.0 microsecond so it
+	 * does not look like an uninitialized zero; not even when the
+	 * user does not request any microseconds decimals. See
+	 * DEFAULT_CLOCK constant in logger.c
+	 */
+	return timer ? platform_timer_get(timer) : 50;
+}
+
 void platform_timer_start(struct timer *timer);
 void platform_timer_stop(struct timer *timer);
 

--- a/src/ipc/ipc3/handler.c
+++ b/src/ipc/ipc3/handler.c
@@ -742,6 +742,12 @@ static int ipc_dma_trace_config(uint32_t header)
 	struct timer *timer = timer_get();
 	int err;
 
+	if (!dmat) {
+		mtrace_printf(LOG_LEVEL_ERROR,
+			      "ipc_dma_trace_config failed: dmat not initialized");
+		return -ENOMEM;
+	}
+
 	/* copy message with ABI safe method */
 	IPC_COPY_CMD(params, ipc->comp_data);
 

--- a/src/trace/dma-trace.c
+++ b/src/trace/dma-trace.c
@@ -370,13 +370,17 @@ int dma_trace_enable(struct dma_trace_data *d)
 		goto out;
 	}
 
-	/*
-	 * It should be the very first sent log for easily identification.
-	 * Use tr_err to have this initial message also in error logs and assert
-	 * traces works well.
-	 */
-	tr_err(&dt_tr, "FW ABI 0x%x DBG ABI 0x%x tag " SOF_GIT_TAG " src hash 0x%08x (ldc hash " META_QUOTE(SOF_SRC_HASH) ")",
-	       SOF_ABI_VERSION, SOF_ABI_DBG_VERSION, SOF_SRC_HASH);
+	/* It should be the very first sent log for easy identification. */
+	mtrace_printf(LOG_LEVEL_INFO,
+		      "SHM: FW ABI 0x%x DBG ABI 0x%x tag " SOF_GIT_TAG " src hash 0x%08x (ldc hash "
+		      META_QUOTE(SOF_SRC_HASH) ")",
+		      SOF_ABI_VERSION, SOF_ABI_DBG_VERSION, SOF_SRC_HASH);
+
+	/* Use a different, DMA: prefix to ease identification of log files */
+	tr_info(&dt_tr,
+		"DMA: FW ABI 0x%x DBG ABI 0x%x tag " SOF_GIT_TAG " src hash 0x%08x (ldc hash "
+		META_QUOTE(SOF_SRC_HASH) ")",
+		SOF_ABI_VERSION, SOF_ABI_DBG_VERSION, SOF_SRC_HASH);
 
 #if CONFIG_DMA_GW
 	/*

--- a/src/trace/trace.c
+++ b/src/trace/trace.c
@@ -105,7 +105,7 @@ static inline void mtrace_event(const char *data, uint32_t length)
 		trace->pos = 0;
 	}
 
-	memcpy_s(t + trace->pos, MAILBOX_TRACE_SIZE,
+	memcpy_s(t + trace->pos, MAILBOX_TRACE_SIZE - trace->pos,
 		 data, length);
 	dcache_writeback_region(t + trace->pos, length);
 	trace->pos += length;

--- a/src/trace/trace.c
+++ b/src/trace/trace.c
@@ -238,7 +238,8 @@ static void vatrace_log(bool send_atomic, uint32_t log_entry, const struct tr_ct
 #endif /* CONFIG TRACEM */
 
 	/* fill log content. arg_count is in the dictionary. */
-	put_header(data, ctx->uuid_p, id_1, id_2, log_entry, platform_timer_get(timer_get()));
+	put_header(data, ctx->uuid_p, id_1, id_2, log_entry,
+		   platform_safe_get_time(timer_get()));
 
 	for (i = 0; i < arg_count; ++i)
 		data[PAYLOAD_OFFSET(i)] = va_arg(vargs, uint32_t);
@@ -300,7 +301,7 @@ void trace_log_filtered(bool send_atomic, const void *log_entry, const struct tr
 
 #if CONFIG_TRACE_FILTERING_ADAPTIVE
 	if (!trace->user_filter_override) {
-		current_ts = platform_timer_get(timer_get());
+		current_ts = platform_safe_get_time(timer_get());
 
 		emit_recent_entries(current_ts);
 

--- a/zephyr/include/sof/trace/trace.h
+++ b/zephyr/include/sof/trace/trace.h
@@ -25,18 +25,26 @@ struct timer;
 uint64_t platform_timer_get(struct timer *timer);
 
 /*
- * Use SOF macros, but let Zephyr take care of the physical log IO.
+ * Override SOF dictionary macros for now and let Zephyr take care of
+ * the physical log IO.
  */
 #undef _log_message
+#undef mtrace_printf
 
 #if USE_PRINTK
+#define mtrace_printf(level, format, ...)				\
+	do {								        \
+		if ((level) <= SOF_ZEPHYR_TRACE_LEVEL)                          \
+			printk("%llu: " format "\n", platform_timer_get(NULL),	\
+				##__VA_ARGS__);					\
+	} while (0)
 #define _log_message(log_func, atomic, level, comp_class, ctx, id1, id2, format, ...)	\
 	do {								        \
 		if ((level) <= SOF_ZEPHYR_TRACE_LEVEL)                          \
 			printk("%llu: " format "\n", platform_timer_get(NULL),	\
 				##__VA_ARGS__);					\
 	} while (0)
-#else
+#else /* not tested */
 #define _log_message(log_func, atomic, level, comp_class, ctx, id1, id2, format, ...)	\
 	do {								        \
 		Z_LOG(level, "%u: " format, (uint32_t)platform_timer_get(NULL),	\


### PR DESCRIPTION
5 commits, per-commit review is recommended.

This is a re-submission/recycling of 85% of the earlier "restore early tracing" PR previously reviewed in #4334: everything except the actual and final restoration of early tracing which is currently failing on BDW and BYT which I have no time to debug right now. Maybe later.