### PR TITLE
codec_adapter: cadence: Reset init_done at init time

### DIFF
--- a/src/audio/codec_adapter/codec/cadence.c
+++ b/src/audio/codec_adapter/codec/cadence.c
@@ -97,6 +97,7 @@ int cadence_codec_init(struct comp_dev *dev)
 	}
 
 	codec->private = cd;
+	codec->cpd.init_done = 0;
 	cd->self = NULL;
 	cd->mem_tabs = NULL;
 	cd->api = NULL;


### PR DESCRIPTION
After first compress play run init_done is initialized with 1 and it
keeps this value as no one resets it.

This causes subsequent compress play to miss codec process init phase
and this causes decoding to fail.

With this change multiple cplay runs work fine!

Notice that cadence_codec_reset calls cadence_codec_init and thus resets
init_done flag.

Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>