### PR TITLE
ipc4: hda: enable blob support for hda

### DIFF
--- a/src/audio/copier.c
+++ b/src/audio/copier.c
@@ -174,7 +174,7 @@ static struct comp_dev *create_dai(struct comp_ipc_config *config, struct ipc4_c
 	case ipc4_hda_link_input_class:
 		dai.type = SOF_DAI_INTEL_HDA;
 		dai.link_dma_ch = node_id->f.v_index;
-		dai.is_config_blob = false;
+		dai.is_config_blob = true;
 		break;
 	case ipc4_i2s_link_output_class:
 	case ipc4_i2s_link_input_class:

--- a/src/drivers/intel/hda/hda.c
+++ b/src/drivers/intel/hda/hda.c
@@ -32,13 +32,24 @@ static int hda_set_config(struct dai *dai,  struct ipc_config_dai *common_config
 	struct sof_ipc_dai_config *dai_config = spec_config;
 	struct sof_ipc_dai_hda_params *params = &dai_config->hda;
 
-	dai_info(dai, "hda_set_config(): channels %u rate %u", params->channels,
-		 params->rate);
+	if (!common_config->is_config_blob) {
+		dai_info(dai, "hda_set_config(): channels %u rate %u", params->channels,
+			 params->rate);
 
-	if (params->channels)
-		hda->params.channels = params->channels;
-	if (params->rate)
-		hda->params.rate = params->rate;
+		if (params->channels)
+			hda->params.channels = params->channels;
+		if (params->rate)
+			hda->params.rate = params->rate;
+	} else {
+		union ipc4_gateway_attributes *attr;
+
+		attr = spec_config;
+		if (attr->bits.lp_buffer_alloc)
+			dai_info(dai, "create dma buffer in lp memory");
+
+		hda->params.channels = common_config->channels;
+		hda->params.rate = common_config->rate;
+	}
 
 	return 0;
 }


### PR DESCRIPTION
Blob data only includes lp memory support for hda

Signed-off-by: Rander Wang <rander.wang@intel.com>