### PR TITLE
debug: add support for valgrind in the mocks

### DIFF
--- a/scripts/run-mocks.sh
+++ b/scripts/run-mocks.sh
@@ -5,9 +5,27 @@
 # fail on any errors
 set -e
 
-rm -rf build_ut
+# default config of none supplied
+CONFIG="tgph_defconfig"
+VALGRIND_CMD=""
 
+while getopts "vc:" flag; do
+    case "${flag}" in
+        c) CONFIG=${OPTARG};;
+        v) VALGRIND_CMD="valgrind --tool=memcheck --track-origins=yes --leak-check=full --show-leak-kinds=all";;
+        ?) echo "Usage: -v -c defconfig"
+           exit 1;;
+    esac
+done
+
+
+
+# clean build area
+rm -rf build_ut
 mkdir build_ut
+
+# copy initial defconfig
+cp src/arch/xtensa/configs/${CONFIG} initial.config
 cd build_ut
 
 cmake -DBUILD_UNIT_TESTS=ON -DBUILD_UNIT_TESTS_HOST=ON ..
@@ -19,5 +37,5 @@ echo test are ${TESTS}
 for test in ${TESTS}
 do
 	echo got ${test}
-	./${test}
+	${VALGRIND_CMD} ./${test}
 done

--- a/src/audio/pipeline/pipeline-graph.c
+++ b/src/audio/pipeline/pipeline-graph.c
@@ -112,6 +112,9 @@ struct pipeline *pipeline_new(uint32_t pipeline_id, uint32_t priority, uint32_t 
 	pipe_cl_info("pipeline new pipe_id %d priority %d",
 		     pipeline_id, priority);
 
+	/* show heap status */
+	heap_trace_all(0);
+
 	/* allocate new pipeline */
 	p = rzalloc(SOF_MEM_ZONE_RUNTIME_SHARED, 0, SOF_MEM_CAPS_RAM, sizeof(*p));
 	if (!p) {

--- a/src/include/sof/lib/mm_heap.h
+++ b/src/include/sof/lib/mm_heap.h
@@ -49,7 +49,11 @@ struct block_map {
 struct mm_heap {
 	uint32_t blocks;
 	struct block_map *map;
+#if CONFIG_LIBRARY
+	unsigned long heap;
+#else
 	uint32_t heap;
+#endif
 	uint32_t size;
 	uint32_t caps;
 	struct mm_info info;

--- a/src/lib/alloc.c
+++ b/src/lib/alloc.c
@@ -1116,11 +1116,14 @@ void heap_trace(struct mm_heap *heap, int size) { }
 void init_heap(struct sof *sof)
 {
 	struct mm *memmap = sof->memory_map;
+
+#if !CONFIG_LIBRARY
 	extern uintptr_t _system_heap_start;
 
 	/* sanity check for malformed images or loader issues */
 	if (memmap->system[0].heap != (uintptr_t)&_system_heap_start)
 		panic(SOF_IPC_PANIC_MEM);
+#endif
 
 	init_heap_map(memmap->system_runtime, PLATFORM_HEAP_SYSTEM_RUNTIME);
 

--- a/src/platform/library/include/platform/lib/memory.h
+++ b/src/platform/library/include/platform/lib/memory.h
@@ -25,9 +25,9 @@ uint8_t *get_library_mailbox(void);
 #define MAILBOX_BASE	get_library_mailbox()
 
 #define PLATFORM_HEAP_SYSTEM		2
-#define PLATFORM_HEAP_SYSTEM_RUNTIME	1
+#define PLATFORM_HEAP_SYSTEM_RUNTIME	CONFIG_CORE_COUNT
 #define PLATFORM_HEAP_RUNTIME		1
-#define PLATFORM_HEAP_BUFFER		3
+#define PLATFORM_HEAP_BUFFER		2
 #define PLATFORM_HEAP_SYSTEM_SHARED	1
 #define PLATFORM_HEAP_RUNTIME_SHARED	1
 
@@ -48,6 +48,7 @@ static inline void *platform_rfree_prepare(void *ptr)
 #define uncache_to_cache(address)	address
 #define cache_to_uncache(address)	address
 #define is_uncached(address)		1
+#define cache_to_uncache_init(address)	address
 
 #define ARCH_OOPS_SIZE	0
 

--- a/src/platform/library/lib/CMakeLists.txt
+++ b/src/platform/library/lib/CMakeLists.txt
@@ -5,6 +5,7 @@ add_local_sources(sof
 	clk.c
 	dai.c
 	pm_runtime.c
+	memory.c
 )
 
 if (CONFIG_TRACE)

--- a/src/platform/library/lib/memory.c
+++ b/src/platform/library/lib/memory.c
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2018 Intel Corporation. All rights reserved.
+//
+// Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
+//         Janusz Jankowski <janusz.jankowski@linux.intel.com>
+
+#include <sof/common.h>
+#include <sof/lib/mm_heap.h>
+#include <sof/lib/cache.h>
+#include <sof/lib/cpu.h>
+#include <sof/lib/memory.h>
+#include <sof/platform.h>
+#include <sof/sof.h>
+#include <ipc/topology.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define uncached_block_hdr(hdr)	cache_to_uncache_init((struct block_hdr *)(hdr))
+#define uncached_block_map(map)	cache_to_uncache((struct block_map *)(map))
+
+/* Heap blocks for system runtime for primary core */
+static SHARED_DATA struct block_hdr sys_rt_0_block64[HEAP_SYS_RT_0_COUNT64];
+static SHARED_DATA struct block_hdr sys_rt_0_block512[HEAP_SYS_RT_0_COUNT512];
+static SHARED_DATA struct block_hdr sys_rt_0_block1024[HEAP_SYS_RT_0_COUNT1024];
+
+/* Heap blocks for system runtime for secondary core */
+#if CONFIG_CORE_COUNT > 1
+static SHARED_DATA struct block_hdr
+	sys_rt_x_block64[CONFIG_CORE_COUNT - 1][HEAP_SYS_RT_X_COUNT64];
+static SHARED_DATA struct block_hdr
+	sys_rt_x_block512[CONFIG_CORE_COUNT - 1][HEAP_SYS_RT_X_COUNT512];
+static SHARED_DATA struct block_hdr
+	sys_rt_x_block1024[CONFIG_CORE_COUNT - 1][HEAP_SYS_RT_X_COUNT1024];
+#endif
+
+/* Heap memory for system runtime */
+static SHARED_DATA struct block_map sys_rt_heap_map[CONFIG_CORE_COUNT][3] = {
+	{ BLOCK_DEF(64, HEAP_SYS_RT_0_COUNT64,
+		    uncached_block_hdr(sys_rt_0_block64)),
+	  BLOCK_DEF(512, HEAP_SYS_RT_0_COUNT512,
+		    uncached_block_hdr(sys_rt_0_block512)),
+	  BLOCK_DEF(1024, HEAP_SYS_RT_0_COUNT1024,
+		    uncached_block_hdr(sys_rt_0_block1024)), },
+#if CONFIG_CORE_COUNT > 1
+	{ BLOCK_DEF(64, HEAP_SYS_RT_X_COUNT64,
+		    uncached_block_hdr(sys_rt_x_block64[0])),
+	  BLOCK_DEF(512, HEAP_SYS_RT_X_COUNT512,
+		    uncached_block_hdr(sys_rt_x_block512[0])),
+	  BLOCK_DEF(1024, HEAP_SYS_RT_X_COUNT1024,
+		    uncached_block_hdr(sys_rt_x_block1024[0])), },
+#endif
+#if CONFIG_CORE_COUNT > 2
+	{ BLOCK_DEF(64, HEAP_SYS_RT_X_COUNT64,
+		    uncached_block_hdr(sys_rt_x_block64[1])),
+	  BLOCK_DEF(512, HEAP_SYS_RT_X_COUNT512,
+		    uncached_block_hdr(sys_rt_x_block512[1])),
+	  BLOCK_DEF(1024, HEAP_SYS_RT_X_COUNT1024,
+		    uncached_block_hdr(sys_rt_x_block1024[1])), },
+#endif
+#if CONFIG_CORE_COUNT > 3
+	{ BLOCK_DEF(64, HEAP_SYS_RT_X_COUNT64,
+		    uncached_block_hdr(sys_rt_x_block64[2])),
+	  BLOCK_DEF(512, HEAP_SYS_RT_X_COUNT512,
+		    uncached_block_hdr(sys_rt_x_block512[2])),
+	  BLOCK_DEF(1024, HEAP_SYS_RT_X_COUNT1024,
+		    uncached_block_hdr(sys_rt_x_block1024[2])), },
+#endif
+};
+
+/* Heap blocks for modules */
+static SHARED_DATA struct block_hdr mod_block64[HEAP_RT_COUNT64];
+static SHARED_DATA struct block_hdr mod_block128[HEAP_RT_COUNT128];
+static SHARED_DATA struct block_hdr mod_block256[HEAP_RT_COUNT256];
+static SHARED_DATA struct block_hdr mod_block512[HEAP_RT_COUNT512];
+static SHARED_DATA struct block_hdr mod_block1024[HEAP_RT_COUNT1024];
+static SHARED_DATA struct block_hdr mod_block2048[HEAP_RT_COUNT2048];
+static SHARED_DATA struct block_hdr mod_block4096[HEAP_RT_COUNT4096];
+
+/* Heap memory map for modules */
+static SHARED_DATA struct block_map rt_heap_map[] = {
+	BLOCK_DEF(64, HEAP_RT_COUNT64, uncached_block_hdr(mod_block64)),
+	BLOCK_DEF(128, HEAP_RT_COUNT128, uncached_block_hdr(mod_block128)),
+	BLOCK_DEF(256, HEAP_RT_COUNT256, uncached_block_hdr(mod_block256)),
+	BLOCK_DEF(512, HEAP_RT_COUNT512, uncached_block_hdr(mod_block512)),
+	BLOCK_DEF(1024, HEAP_RT_COUNT1024, uncached_block_hdr(mod_block1024)),
+	BLOCK_DEF(2048, HEAP_RT_COUNT2048, uncached_block_hdr(mod_block2048)),
+	BLOCK_DEF(4096, HEAP_RT_COUNT4096, uncached_block_hdr(mod_block4096)),
+};
+
+#if CONFIG_CORE_COUNT > 1
+/* Heap blocks for runtime shared */
+static SHARED_DATA struct block_hdr rt_shared_block64[HEAP_RUNTIME_SHARED_COUNT64];
+static SHARED_DATA struct block_hdr rt_shared_block128[HEAP_RUNTIME_SHARED_COUNT128];
+static SHARED_DATA struct block_hdr rt_shared_block256[HEAP_RUNTIME_SHARED_COUNT256];
+static SHARED_DATA struct block_hdr rt_shared_block512[HEAP_RUNTIME_SHARED_COUNT512];
+static SHARED_DATA struct block_hdr rt_shared_block1024[HEAP_RUNTIME_SHARED_COUNT1024];
+
+/* Heap memory map for runtime shared */
+static SHARED_DATA struct block_map rt_shared_heap_map[] = {
+	BLOCK_DEF(64, HEAP_RUNTIME_SHARED_COUNT64, uncached_block_hdr(rt_shared_block64)),
+	BLOCK_DEF(128, HEAP_RUNTIME_SHARED_COUNT128, uncached_block_hdr(rt_shared_block128)),
+	BLOCK_DEF(256, HEAP_RUNTIME_SHARED_COUNT256, uncached_block_hdr(rt_shared_block256)),
+	BLOCK_DEF(512, HEAP_RUNTIME_SHARED_COUNT512, uncached_block_hdr(rt_shared_block512)),
+	BLOCK_DEF(1024, HEAP_RUNTIME_SHARED_COUNT1024, uncached_block_hdr(rt_shared_block1024)),
+};
+#endif
+
+/* Heap blocks for buffers */
+static SHARED_DATA struct block_hdr buf_block[HEAP_BUFFER_COUNT];
+static SHARED_DATA struct block_hdr lp_buf_block[HEAP_LP_BUFFER_COUNT];
+
+/* Heap memory map for buffers */
+static SHARED_DATA struct block_map buf_heap_map[] = {
+	BLOCK_DEF(HEAP_BUFFER_BLOCK_SIZE, HEAP_BUFFER_COUNT,
+		  uncached_block_hdr(buf_block)),
+};
+
+static SHARED_DATA struct block_map lp_buf_heap_map[] = {
+	BLOCK_DEF(HEAP_LP_BUFFER_BLOCK_SIZE, HEAP_LP_BUFFER_COUNT,
+		  uncached_block_hdr(lp_buf_block)),
+};
+
+static SHARED_DATA struct mm memmap;
+
+void platform_init_memmap(struct sof *sof)
+{
+	int i;
+
+	/* access memory map through uncached region */
+	sof->memory_map = cache_to_uncache(&memmap);
+
+	/* .system primary core initialization */
+	sof->memory_map->system[0].heap = (unsigned long)malloc(HEAP_SYSTEM_M_SIZE);
+	sof->memory_map->system[0].size = HEAP_SYSTEM_M_SIZE;
+	sof->memory_map->system[0].info.free = HEAP_SYSTEM_M_SIZE;
+	sof->memory_map->system[0].caps = SOF_MEM_CAPS_RAM | SOF_MEM_CAPS_EXT |
+		SOF_MEM_CAPS_CACHE;
+
+	/* .system_runtime primary core initialization */
+	sof->memory_map->system_runtime[0].blocks =
+		ARRAY_SIZE(sys_rt_heap_map[0]);
+	sof->memory_map->system_runtime[0].map =
+		uncached_block_map(sys_rt_heap_map[0]);
+	sof->memory_map->system_runtime[0].heap =
+		(unsigned long)malloc(HEAP_SYS_RUNTIME_M_SIZE);
+	sof->memory_map->system_runtime[0].size = HEAP_SYS_RUNTIME_M_SIZE;
+	sof->memory_map->system_runtime[0].info.free = HEAP_SYS_RUNTIME_M_SIZE;
+	sof->memory_map->system_runtime[0].caps = SOF_MEM_CAPS_RAM |
+		SOF_MEM_CAPS_EXT | SOF_MEM_CAPS_CACHE |
+		SOF_MEM_CAPS_DMA;
+
+	/* .system and .system_runtime secondary core initialization */
+	for (i = 1; i < CONFIG_CORE_COUNT; i++) {
+		/* .system init */
+		sof->memory_map->system[i].heap =
+				(unsigned long)malloc(HEAP_SYSTEM_S_SIZE) +
+			((i - 1) * SOF_CORE_S_SIZE);
+		sof->memory_map->system[i].size = HEAP_SYSTEM_S_SIZE;
+		sof->memory_map->system[i].info.free = HEAP_SYSTEM_S_SIZE;
+		sof->memory_map->system[i].caps = SOF_MEM_CAPS_RAM |
+			SOF_MEM_CAPS_EXT | SOF_MEM_CAPS_CACHE;
+
+		/* .system_runtime init */
+		sof->memory_map->system_runtime[i].blocks =
+			ARRAY_SIZE(sys_rt_heap_map[i]);
+		sof->memory_map->system_runtime[i].map =
+			uncached_block_map(sys_rt_heap_map[i]);
+		sof->memory_map->system_runtime[i].heap =
+			(unsigned long)malloc(HEAP_SYS_RUNTIME_S_SIZE) +
+			((i - 1) * SOF_CORE_S_SIZE) + HEAP_SYSTEM_S_SIZE;
+		sof->memory_map->system_runtime[i].size =
+			HEAP_SYS_RUNTIME_S_SIZE;
+		sof->memory_map->system_runtime[i].info.free =
+			HEAP_SYS_RUNTIME_S_SIZE;
+		sof->memory_map->system_runtime[i].caps = SOF_MEM_CAPS_RAM |
+			SOF_MEM_CAPS_EXT | SOF_MEM_CAPS_CACHE |
+			SOF_MEM_CAPS_DMA;
+	}
+
+#if CONFIG_CORE_COUNT > 1
+	/* .runtime_shared init */
+	sof->memory_map->runtime_shared[0].blocks = ARRAY_SIZE(rt_shared_heap_map);
+	sof->memory_map->runtime_shared[0].map = uncached_block_map(rt_shared_heap_map);
+	sof->memory_map->runtime_shared[0].heap =
+			(unsigned long)cache_to_uncache(malloc(HEAP_RUNTIME_SHARED_SIZE));
+	sof->memory_map->runtime_shared[0].size = HEAP_RUNTIME_SHARED_SIZE;
+	sof->memory_map->runtime_shared[0].info.free = HEAP_RUNTIME_SHARED_SIZE;
+	sof->memory_map->runtime_shared[0].caps = SOF_MEM_CAPS_RAM | SOF_MEM_CAPS_EXT |
+		SOF_MEM_CAPS_CACHE;
+
+	/* .system_shared init */
+	sof->memory_map->system_shared[0].heap =
+		(unsigned long)cache_to_uncache(malloc(HEAP_SYSTEM_SHARED_SIZE));
+	sof->memory_map->system_shared[0].size = HEAP_SYSTEM_SHARED_SIZE;
+	sof->memory_map->system_shared[0].info.free = HEAP_SYSTEM_SHARED_SIZE;
+	sof->memory_map->system_shared[0].caps = SOF_MEM_CAPS_RAM | SOF_MEM_CAPS_EXT |
+		SOF_MEM_CAPS_CACHE;
+
+#endif
+
+	/* .runtime init*/
+	sof->memory_map->runtime[0].blocks = ARRAY_SIZE(rt_heap_map);
+	sof->memory_map->runtime[0].map = uncached_block_map(rt_heap_map);
+	sof->memory_map->runtime[0].heap = (unsigned long)malloc(HEAP_RUNTIME_SIZE);
+	sof->memory_map->runtime[0].size = HEAP_RUNTIME_SIZE;
+	sof->memory_map->runtime[0].info.free = HEAP_RUNTIME_SIZE;
+	sof->memory_map->runtime[0].caps = SOF_MEM_CAPS_RAM | SOF_MEM_CAPS_EXT |
+		SOF_MEM_CAPS_CACHE;
+
+	/* heap buffer init */
+	sof->memory_map->buffer[0].blocks = ARRAY_SIZE(buf_heap_map);
+	sof->memory_map->buffer[0].map = uncached_block_map(buf_heap_map);
+	sof->memory_map->buffer[0].heap = (unsigned long)malloc(HEAP_BUFFER_SIZE);
+	sof->memory_map->buffer[0].size = HEAP_BUFFER_SIZE;
+	sof->memory_map->buffer[0].info.free = HEAP_BUFFER_SIZE;
+	sof->memory_map->buffer[0].caps = SOF_MEM_CAPS_RAM | SOF_MEM_CAPS_HP |
+		SOF_MEM_CAPS_CACHE | SOF_MEM_CAPS_DMA;
+
+	/* heap lp buffer init */
+	sof->memory_map->buffer[1].blocks = ARRAY_SIZE(lp_buf_heap_map);
+	sof->memory_map->buffer[1].map = uncached_block_map(lp_buf_heap_map);
+	sof->memory_map->buffer[1].heap = (unsigned long)malloc(HEAP_LP_BUFFER_SIZE);
+	sof->memory_map->buffer[1].size = HEAP_LP_BUFFER_SIZE;
+	sof->memory_map->buffer[1].info.free = HEAP_LP_BUFFER_SIZE;
+	sof->memory_map->buffer[1].caps = SOF_MEM_CAPS_RAM | SOF_MEM_CAPS_LP |
+		SOF_MEM_CAPS_CACHE | SOF_MEM_CAPS_DMA;
+
+	/* .total init */
+	sof->memory_map->total.free = HEAP_SYSTEM_T_SIZE +
+		HEAP_SYS_RUNTIME_T_SIZE + HEAP_RUNTIME_SIZE + HEAP_BUFFER_SIZE +
+		HEAP_LP_BUFFER_SIZE;
+
+}

--- a/test/cmocka/src/lib/CMakeLists.txt
+++ b/test/cmocka/src/lib/CMakeLists.txt
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-if(NOT BUILD_UNIT_TESTS_HOST)
-	add_subdirectory(alloc)
-endif()
+add_subdirectory(alloc)
 add_subdirectory(lib)
 add_subdirectory(preproc)

--- a/test/cmocka/src/lib/alloc/CMakeLists.txt
+++ b/test/cmocka/src/lib/alloc/CMakeLists.txt
@@ -1,5 +1,13 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
+if(BUILD_UNIT_TESTS_HOST)
+cmocka_test(alloc
+	alloc.c
+	${PROJECT_SOURCE_DIR}/src/lib/alloc.c
+	${PROJECT_SOURCE_DIR}/src/platform/library/lib/memory.c
+	${PROJECT_SOURCE_DIR}/src/spinlock.c
+)
+else()
 cmocka_test(alloc
 	alloc.c
 	${PROJECT_SOURCE_DIR}/src/lib/alloc.c
@@ -7,5 +15,6 @@ cmocka_test(alloc
 	${PROJECT_SOURCE_DIR}/src/platform/intel/cavs/lib/memory.c
 	${PROJECT_SOURCE_DIR}/src/spinlock.c
 )
+endif()
 
 target_include_directories(sof_options INTERFACE ${PROJECT_SOURCE_DIR}/src/platform/intel/cavs/include)

--- a/test/cmocka/src/lib/alloc/alloc.c
+++ b/test/cmocka/src/lib/alloc/alloc.c
@@ -14,6 +14,7 @@
 #include <sof/sof.h>
 #include <sof/lib/alloc.h>
 #include <sof/lib/mm_heap.h>
+#include <sof/lib/memory.h>
 #include <ipc/header.h>
 #include <ipc/topology.h>
 


### PR DESCRIPTION
Add support for valgrind to run on the mocks to detect memory errors.

Reported memory errors still have to be fixed, most are leaks in the mock code.