### PR TITLE
trace: Don't initialize trace buffer under Zephyr

### DIFF
--- a/src/trace/trace.c
+++ b/src/trace/trace.c
@@ -518,9 +518,15 @@ void trace_init(struct sof *sof)
 #endif /* CONFIG_TRACE_FILTERING_ADAPTIVE */
 	spinlock_init(&sof->trace->lock);
 
+#ifndef __ZEPHYR__
+	/* Zephyr owns and has already initialized this buffer (and
+	 * likely has already logged to it by the time we get here).
+	 * Don't touch.
+	 */
 	bzero((void *)MAILBOX_TRACE_BASE, MAILBOX_TRACE_SIZE);
 	dcache_writeback_invalidate_region((void *)MAILBOX_TRACE_BASE,
 					   MAILBOX_TRACE_SIZE);
+#endif
 
 	dma_trace_init_early(sof);
 }


### PR DESCRIPTION
This memory is already owned and initialized by the OS under Zephyr
(and in many cases already holds live output!), don't touch it.

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>