### PR TITLE
zephyr: switch to use 3k private key for tgl-h

### DIFF
--- a/scripts/xtensa-build-zephyr.sh
+++ b/scripts/xtensa-build-zephyr.sh
@@ -94,6 +94,7 @@ build()
 				;;
 			tgl-h)
 				PLAT_CONFIG='intel_adsp_cavs25'
+				RIMAGE_KEY=modules/audio/sof/keys/otc_private_key_3k.pem
 				;;
 			*)
 				echo "Unsupported platform: $platform"


### PR DESCRIPTION
TGL-H should be used the 3k otc private key for build.

Signed-off-by: Zhang Keqiao <keqiao.zhang@intel.com>