### PR TITLE
topology: sof-tgl-max98373-rt5682: move DMIC to core 1 for IGO only

### DIFF
--- a/tools/topology/sof-tgl-max98373-rt5682.m4
+++ b/tools/topology/sof-tgl-max98373-rt5682.m4
@@ -84,8 +84,8 @@ define(DMIC_PCM_16k_ID, `100')
 define(DMIC_PIPELINE_16k_ID, `9')
 define(DMIC_PIPELINE_KWD_ID, `10')
 define(DMIC_DAI_LINK_16k_ID, `2')
-# Offload DMIC_PIPELINE_48K to secondary core of TGL.
-define(DMIC_PIPELINE_48k_CORE_ID, 1)
+# Offload DMIC_PIPELINE_48K to secondary core for IGO.
+ifdef(`IGO', `define(`DMIC_PIPELINE_48k_CORE_ID', 1)')
 # define pcm, pipeline and dai id
 define(KWD_PIPE_SCH_DEADLINE_US, 20000)
 # include the generic dmic with kwd


### PR DESCRIPTION
Optimal load-balancing depends on multiple factors, so let's condition
it for igo_nr only based on its high MCPS needs and benchmark score.

Signed-off-by: Yong Zhi <yong.zhi@intel.com>