### PR TITLE
buffer: fix double list deletion detected by valgrind.

### DIFF
--- a/src/audio/buffer.c
+++ b/src/audio/buffer.c
@@ -176,8 +176,6 @@ void buffer_free(struct comp_buffer *buffer)
 	/* In case some listeners didn't unregister from buffer's callbacks */
 	notifier_unregister_all(NULL, buffer);
 
-	list_item_del(&buffer->source_list);
-	list_item_del(&buffer->sink_list);
 	rfree(buffer->stream.addr);
 	rfree(buffer->lock);
 	rfree(buffer);


### PR DESCRIPTION
Buffer lists were being deleted twice, at first by the
pipeline_disconnect() (the correct place) and then by buffer_free().

Fix this so buffer_free() only frees the buffer.

==426365== Invalid write of size 8
==426365==    at 0x49CB47B: list_item_del (list.h:57)
==426365==    by 0x49CB47B: buffer_free (buffer.c:179)
==426365==    by 0x49C8C7B: ipc_buffer_free (helper.c:697)
==426365==    by 0x10C1E6: free_comps (testbench.c:165)
==426365==    by 0x10C1E6: main (testbench.c:415)
==426365==  Address 0x4bdce48 is 152 bytes inside a block of size 168 free'd
==426365==    at 0x484521F: free (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==426365==    by 0x49C9163: comp_free (component_ext.h:55)
==426365==    by 0x49C9163: ipc_comp_free (helper.c:866)
==426365==    by 0x10C200: free_comps (testbench.c:162)
==426365==    by 0x10C200: main (testbench.c:415)
==426365==  Block was alloc'd at
==426365==    at 0x4847A25: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==426365==    by 0x10D4E8: comp_alloc (component.h:548)
==426365==    by 0x10D4E8: file_new (file.c:430)
==426365==    by 0x49C81E7: comp_new (helper.c:423)
==426365==    by 0x49C8F0F: ipc_comp_new (helper.c:823)
==426365==    by 0x10E642: load_fileread (topology.c:323)
==426365==    by 0x49E13A0: load_widget (tplg_parser.c:1281)
==426365==    by 0x10F796: parse_topology (topology.c:779)
==426365==    by 0x10BE76: main (testbench.c:310)

Signed-off-by: Liam Girdwood <liam.r.girdwood@linux.intel.com>