### PR TITLE
Revert "dai: only process DAI config for comps on cores that enabled"

### DIFF
--- a/src/ipc/ipc3/dai.c
+++ b/src/ipc/ipc3/dai.c
@@ -165,7 +165,7 @@ int ipc_comp_dai_config(struct ipc *ipc, struct ipc_config_dai *common_config,
 		if (icd->type != COMP_TYPE_COMPONENT)
 			continue;
 
-		if (!cpu_is_me(icd->core) && cpu_is_core_enabled(icd->core)) {
+		if (!cpu_is_me(icd->core)) {
 			comp_on_core[icd->core] = true;
 			ret = 0;
 			continue;


### PR DESCRIPTION
If the core is not up, the comp exist in the comp_list.
So no need to check if the core is up.
This reverts commit bccecb1a8eed84a0737fdf2878204adfb6cf845d.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>