### PR TITLE
trace: make trace contect constant

### DIFF
--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -37,7 +37,7 @@ struct comp_dev;
  */
 
 /* buffer tracing */
-extern struct tr_ctx buffer_tr;
+extern const struct tr_ctx buffer_tr;
 
 /** \brief Retrieves trace context from the buffer */
 #define trace_buf_get_tr_ctx(buf_ptr) (&(buf_ptr)->tctx)

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -410,7 +410,7 @@ struct comp_ops {
 struct comp_driver {
 	uint32_t type;			/**< SOF_COMP_ for driver */
 	const struct sof_uuid *uid;	/**< Address to UUID value */
-	struct tr_ctx *tctx;		/**< Pointer to trace context */
+	const struct tr_ctx *tctx;	/**< Pointer to trace context */
 	struct comp_ops ops;		/**< component operations */
 };
 

--- a/src/include/sof/audio/pipeline-trace.h
+++ b/src/include/sof/audio/pipeline-trace.h
@@ -16,7 +16,7 @@
 #include <stdint.h>
 
 /* pipeline tracing */
-extern struct tr_ctx pipe_tr;
+extern const struct tr_ctx pipe_tr;
 
 #define trace_pipe_get_tr_ctx(pipe_p) (&(pipe_p)->tctx)
 #define trace_pipe_get_id(pipe_p) ((pipe_p)->pipeline_id)

--- a/src/include/sof/drivers/idc.h
+++ b/src/include/sof/drivers/idc.h
@@ -115,7 +115,7 @@ struct idc {
 };
 
 /* idc trace context, used by multiple units */
-extern struct tr_ctx idc_tr;
+extern const struct tr_ctx idc_tr;
 
 static inline struct idc_payload *idc_payload_get(struct idc *idc,
 						  uint32_t core)

--- a/src/include/sof/ipc/common.h
+++ b/src/include/sof/ipc/common.h
@@ -44,7 +44,7 @@ typedef uint32_t ipc_cmd_hdr;
 	(object).hdr.size == sizeof(object) ? 0 : 1
 
 /* ipc trace context, used by multiple units */
-extern struct tr_ctx ipc_tr;
+extern const struct tr_ctx ipc_tr;
 
 /* convenience error trace for mismatched internal structures */
 #define IPC_SIZE_ERROR_TRACE(ctx, object)		\

--- a/src/include/sof/lib/dai.h
+++ b/src/include/sof/lib/dai.h
@@ -115,7 +115,7 @@ struct timestamp_ops {
 struct dai_driver {
 	uint32_t type;	/**< type, one of SOF_DAI_... */
 	const struct sof_uuid_entry *uid;
-	struct tr_ctx *tctx;
+	const struct tr_ctx *tctx;
 	uint32_t dma_caps;
 	uint32_t dma_dev;
 	struct dai_ops ops;

--- a/src/include/sof/lib/wait.h
+++ b/src/include/sof/lib/wait.h
@@ -25,7 +25,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-extern struct tr_ctx wait_tr;
+extern const struct tr_ctx wait_tr;
 
 static inline void wait_for_interrupt(int level)
 {

--- a/src/include/sof/schedule/ll_schedule.h
+++ b/src/include/sof/schedule/ll_schedule.h
@@ -21,7 +21,7 @@
 struct ll_schedule_domain;
 
 /* ll tracing */
-extern struct tr_ctx ll_tr;
+extern const struct tr_ctx ll_tr;
 
 #define ll_sch_set_pdata(task, data) \
 	do { (task)->priv_data = (data); } while (0)

--- a/src/include/sof/trace/trace.h
+++ b/src/include/sof/trace/trace.h
@@ -335,7 +335,7 @@ struct tr_ctx {
  * @param default_log_level Default log level.
  */
 #define DECLARE_TR_CTX(ctx_name, uuid, default_log_level)	\
-	struct tr_ctx ctx_name TRACE_CONTEXT_SECTION = {	\
+	const struct tr_ctx ctx_name TRACE_CONTEXT_SECTION = {	\
 		.uuid_p = uuid,					\
 		.level = default_log_level,			\
 	}


### PR DESCRIPTION
Trace context objects, declared with DECLARE_TR_CTX() are constant, add the missing attribute.
