### PR TITLE
cavs: pm: improve PM_RUNTIME_HOST_DMA_L1 documentation

### DIFF
--- a/src/include/sof/lib/pm_runtime.h
+++ b/src/include/sof/lib/pm_runtime.h
@@ -33,7 +33,7 @@
 
 /** \brief Runtime power management context */
 enum pm_runtime_context {
-	PM_RUNTIME_HOST_DMA_L1 = 0,	/**< Host DMA L1 Exit */
+	PM_RUNTIME_HOST_DMA_L1 = 0,	/**< Host DMA L1 */
 	SSP_CLK,			/**< SSP Clock */
 	SSP_POW,			/**< SSP Power */
 	DMIC_CLK,			/**< DMIC Clock */


### PR DESCRIPTION
Reword doxygen comments and change the private helper function
names to better reflect the actual implementation. No functional
change.

The PM_RUNTIME_HOST_DMA_L1 resource is used to coordinate host DMA
users, so that DMI link is kept in L1 until all users are ready to
activate the link. This is a bit unusual usage of runtime-pm interface
in that a 'put on a resource' triggers transition to higher power state,
so this deserves some more documentation.

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>