### PR TITLE
comp: make all comp_dev and host data shared

### DIFF
--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -526,7 +526,7 @@ static struct comp_dev *host_new(const struct comp_driver *drv,
 		return NULL;
 	dev->ipc_config = *config;
 
-	hd = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM, sizeof(*hd));
+	hd = rzalloc(SOF_MEM_ZONE_RUNTIME_SHARED, 0, SOF_MEM_CAPS_RAM, sizeof(*hd));
 	if (!hd) {
 		rfree(dev);
 		return NULL;

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -545,7 +545,7 @@ static inline struct comp_dev *comp_alloc(const struct comp_driver *drv,
 {
 	struct comp_dev *dev = NULL;
 
-	dev = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM, bytes);
+	dev = rzalloc(SOF_MEM_ZONE_RUNTIME_SHARED, 0, SOF_MEM_CAPS_RAM, bytes);
 	if (!dev)
 		return NULL;
 	dev->size = bytes;


### PR DESCRIPTION
comp dev is shared by pipelines and host data contains the DMA channel that is shared. So make both of them shared too.

This is the last of the fixes needed to make dynamic pipelines + multi-core work on TGL(At least in my local tests).
This affects performance but provides a stable baseline for passing tests.

