### PR TITLE
LL refinement to remove dependency among COREs

### DIFF
--- a/src/schedule/ll_schedule.c
+++ b/src/schedule/ll_schedule.c
@@ -72,6 +72,14 @@ static bool schedule_ll_is_pending(struct ll_schedule_data *sch)
 		list_for_item(tlist, &sch->tasks) {
 			task = container_of(tlist, struct task, list);
 
+			/*
+			 * only tasks queued or waiting for reschedule are
+			 * pending for scheduling
+			 */
+			if (task->state != SOF_TASK_STATE_QUEUED &&
+			    task->state != SOF_TASK_STATE_RESCHEDULE)
+				continue;
+
 			if (domain_is_pending(domain, task, &sched_comp)) {
 				task->state = SOF_TASK_STATE_PENDING;
 				pending_count++;
@@ -125,6 +133,8 @@ static void schedule_ll_tasks_execute(struct ll_schedule_data *sch)
 			continue;
 
 		tr_dbg(&ll_tr, "task %p %pU being started...", task, task->uid);
+
+		task->state = SOF_TASK_STATE_RUNNING;
 
 		task->state = task_run(task);
 
@@ -443,6 +453,7 @@ static int schedule_ll_task(void *data, struct task *task, uint64_t start,
 
 	/* insert task into the list */
 	schedule_ll_task_insert(task, &sch->tasks);
+	task->state = SOF_TASK_STATE_QUEUED;
 
 	/* set schedule domain */
 	ret = schedule_ll_domain_set(sch, task, start, period);


### PR DESCRIPTION
ll_schedule: refine to remove the dependency among DSP COREs
We don't need to wait until tasks on all DSP COREs finished, before we
can configure the next interrupt to trigger the next scheduling. Imagine
scenarios that one of the CORE is taking long time to finish a high MCPS
task, we should keep tasks on other COREs freed to be scheduled during
that period.

Calculate and re-configure the interrupt at finish of each CORE, and
re-enable domain on each CORE separately.