### PR TITLE
topology: cavs-nocodec: temporarily fix jsl-nocodec issues with s24le

### DIFF
--- a/tools/topology/topology1/sof-cavs-nocodec.m4
+++ b/tools/topology/topology1/sof-cavs-nocodec.m4
@@ -88,6 +88,17 @@ define(SSP1_IDX, `1')
 define(SSP2_IDX, `2')
 ')
 
+ifelse(PLATFORM, `jsl',
+`
+define(PIPE_BITS, `s32le')
+define(DAI_BITS, `s24le')
+',
+`
+define(PIPE_BITS, `s32le')
+define(DAI_BITS, `s32le')
+'
+)
+
 #
 # Define the pipelines
 #
@@ -102,45 +113,45 @@ dnl     period, priority, core,
 dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
 
-# Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
+# Low Latency playback pipeline 1 on PCM 0 using max 2 channels of PIPE_BITS.
 # Set 1000us deadline on core 2 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
-	1, 0, 2, s32le,
+	1, 0, 2, PIPE_BITS,
 	1000, 0, SSP0_CORE_ID,
 	48000, 48000, 48000)
 
-# Volume switch capture pipeline 2 on PCM 0 using max 2 channels of s32le.
+# Volume switch capture pipeline 2 on PCM 0 using max 2 channels of PIPE_BITS.
 # Set 1000us deadline on core 2 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-volume-switch-capture.m4,
-	2, 0, 2, s32le,
+	2, 0, 2, PIPE_BITS,
 	1000, 0, SSP0_CORE_ID,
 	48000, 48000, 48000)
 
-# Low Latency playback pipeline 3 on PCM 1 using max 2 channels of s32le.
+# Low Latency playback pipeline 3 on PCM 1 using max 2 channels of PIPE_BITS.
 # Set 1000us deadline on core 1 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
-	3, 1, 2, s32le,
+	3, 1, 2, PIPE_BITS,
 	1000, 0, SSP1_CORE_ID,
 	48000, 48000, 48000)
 
-# Volume switch capture pipeline 4 on PCM 1 using max 2 channels of s32le.
+# Volume switch capture pipeline 4 on PCM 1 using max 2 channels of PIPE_BITS.
 # Set 1000us deadline on core 1 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-volume-switch-capture.m4,
-	4, 1, 2, s32le,
+	4, 1, 2, PIPE_BITS,
 	1000, 0, SSP1_CORE_ID,
 	48000, 48000, 48000)
 
-# Low Latency playback pipeline 5 on PCM 2 using max 2 channels of s32le.
+# Low Latency playback pipeline 5 on PCM 2 using max 2 channels of PIPE_BITS.
 # Set 1000us deadline on core 0 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
-	5, 2, 2, s32le,
+	5, 2, 2, PIPE_BITS,
 	1000, 0, SSP2_CORE_ID,
 	48000, 48000, 48000)
 
-# Volume switch capture pipeline 6 on PCM 2 using max 2 channels of s32le.
+# Volume switch capture pipeline 6 on PCM 2 using max 2 channels of PIPE_BITS.
 # Set 1000us deadline on core 0 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-volume-switch-capture.m4,
-	6, 2, 2, s32le,
+	6, 2, 2, PIPE_BITS,
 	1000, 0, SSP2_CORE_ID,
 	48000, 48000, 48000)
 
@@ -154,45 +165,45 @@ dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
 # playback DAI is SSP0 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use DAI_BITS format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, SSP0_IDX, NoCodec-0,
-	PIPELINE_SOURCE_1, 2, s32le,
+	PIPELINE_SOURCE_1, 2, DAI_BITS,
 	1000, 0, SSP0_CORE_ID, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is SSP0 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use DAI_BITS format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	2, SSP, SSP0_IDX, NoCodec-0,
-	PIPELINE_SINK_2, 2, s32le,
+	PIPELINE_SINK_2, 2, DAI_BITS,
 	1000, 0, SSP0_CORE_ID, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is SSP1 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use DAI_BITS format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	3, SSP, SSP1_IDX, NoCodec-1,
-	PIPELINE_SOURCE_3, 2, s32le,
+	PIPELINE_SOURCE_3, 2, DAI_BITS,
 	1000, 0, SSP1_CORE_ID, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is SSP1 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use DAI_BITS format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	4, SSP, SSP1_IDX, NoCodec-1,
-	PIPELINE_SINK_4, 2, s32le,
+	PIPELINE_SINK_4, 2, DAI_BITS,
 	1000, 0, SSP1_CORE_ID, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is SSP2 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use DAI_BITS format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	5, SSP, SSP2_IDX, NoCodec-2,
-	PIPELINE_SOURCE_5, 2, s32le,
+	PIPELINE_SOURCE_5, 2, DAI_BITS,
 	1000, 0, SSP2_CORE_ID, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is SSP2 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use DAI_BITS format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	6, SSP, SSP2_IDX, NoCodec-2,
-	PIPELINE_SINK_6, 2, s32le,
+	PIPELINE_SINK_6, 2, DAI_BITS,
 	1000, 0, SSP2_CORE_ID, SCHEDULE_TIME_DOMAIN_TIMER)
 
 dnl PCM_DUPLEX_ADD(name, pcm_id, playback, capture)


### PR DESCRIPTION
For some reason s32le does not work on JSL-NOCODEC platforms. alsa-bat
tests fail, but they work fine on APL, CNL, TGL. This is likely to be
an ICL platform issue. The root cause is still TBD

Use s24le for now to unlock Intel daily tests.

BugLink: https://github.com/thesofproject/sof/issues/4427
Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>