### PR TITLE
Revert "pipeline/buffer: alloc them in the runtime shared zone"

### DIFF
--- a/src/audio/buffer.c
+++ b/src/audio/buffer.c
@@ -38,7 +38,7 @@ struct comp_buffer *buffer_alloc(uint32_t size, uint32_t caps, uint32_t align)
 	}
 
 	/* allocate new buffer */
-	buffer = rzalloc(SOF_MEM_ZONE_RUNTIME_SHARED, 0, SOF_MEM_CAPS_RAM,
+	buffer = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM,
 			 sizeof(*buffer));
 	if (!buffer) {
 		tr_err(&buffer_tr, "buffer_alloc(): could not alloc structure");

--- a/src/audio/pipeline/pipeline-graph.c
+++ b/src/audio/pipeline/pipeline-graph.c
@@ -116,7 +116,7 @@ struct pipeline *pipeline_new(uint32_t pipeline_id, uint32_t priority, uint32_t 
 	heap_trace_all(0);
 
 	/* allocate new pipeline */
-	p = rzalloc(SOF_MEM_ZONE_RUNTIME_SHARED, 0, SOF_MEM_CAPS_RAM, sizeof(*p));
+	p = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM, sizeof(*p));
 	if (!p) {
 		pipe_cl_err("pipeline_new(): Out of Memory");
 		return NULL;


### PR DESCRIPTION
Revert these for now. Will be fixed with other multi-core fixes.

This reverts commit 928dba0853efa4cd0d79aa66b1e9c221b8813a8f.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>