### PR TITLE
imx/sdma.c: silence "may be uninitialized" warnings with gcc10.2 -O1

### DIFF
--- a/src/drivers/imx/sdma.c
+++ b/src/drivers/imx/sdma.c
@@ -713,6 +713,13 @@ static int sdma_prep_desc(struct dma_chan_data *channel,
 
 	pdata->next_bd = 0;
 
+	/* Silence "may be used uninitialized" warnings with gcc10 -O1
+	 * and maybe other compilers/levels that don't know that
+	 * config->elem_array.count > 0
+	 */
+	bd = &pdata->desc[0];
+	width = 0;
+
 	for (i = 0; i < config->elem_array.count; i++) {
 		bd = &pdata->desc[i];
 		/* For MEM2DEV and DEV2MEM, buf_addr holds the RAM address and


### PR DESCRIPTION
gcc10.2 does not see that config->elem_array.count is greater than zero
and complains. This happens only at the -O1 optimization level that is
rarely tested.

```
error: 'bd' may be used uninitialized in this function
                                  [-Werror=maybe-uninitialized]
  758 |  bd->config &= ~SDMA_BD_CONT;

error: 'width' may be used uninitialized in this function
                                  [-Werror=maybe-uninitialized]
  786 |  watermark = (config->burst_elems * width) / 8;
      |              ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~
```

This is preferred over initialization at the top of the function
that hides _all_ warnings including valid ones.

Of course the even better fix would to BOTH declare and initialization
just before the loop, as late as possible just like in any other modern
and safer programming language. However C99 declarations are not allowed
yet; I've added this to the next TSC agenda:
github.com/orgs/thesofproject/teams/steering-committee/discussions/24

```diff
 -693,11 +698,9 @@ static int sdma_prep_desc(struct dma_chan_data *channel,
                          struct dma_sg_config *config)
 {
        int i;
-       int width;
        int watermark;
        uint32_t sdma_script_addr;
        struct sdma_chan *pdata = dma_chan_get_data(channel);
-       struct sdma_bd *bd;

        /* Validate requested configuration */
        if (config->elem_array.count > SDMA_MAX_BDS) {
 -713,6 +716,9 @@ static int sdma_prep_desc(struct dma_chan_data *channel,

        pdata->next_bd = 0;

+       struct sdma_bd *bd = &pdata->desc[0]; // or NULL
+       int width = 0;
+
        for (i = 0; i < config->elem_array.count; i++) {
                bd = &pdata->desc[i];
                /* For MEM2DEV and DEV2MEM, buf_addr holds the RAM address
```

Signed-off-by: Marc Herbert <marc.herbert@intel.com>