### PR TITLE
smex: fix crash in elf_free_module() when input file not found

### DIFF
--- a/smex/CMakeLists.txt
+++ b/smex/CMakeLists.txt
@@ -4,6 +4,11 @@ cmake_minimum_required(VERSION 3.10)
 
 project(SOF_SMEX C)
 
+if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "No CMAKE_BUILD_TYPE, defaulting to Debug")
+  set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Build Type" FORCE)
+endif()
+
 set(SOF_ROOT_SOURCE_DIRECTORY "${PROJECT_SOURCE_DIR}/..")
 
 add_executable(smex
@@ -12,8 +17,9 @@ add_executable(smex
 	smex.c
 )
 
+# In addition to the usual flags from CMAKE_BUILD_TYPE
 target_compile_options(smex PRIVATE
-	-O2 -g -Wall -Werror -Wl,-EL -Wmissing-prototypes -Wimplicit-fallthrough=3
+	-Wall -Werror -Wl,-EL -Wmissing-prototypes -Wimplicit-fallthrough=3
 )
 
 target_include_directories(smex PRIVATE

--- a/smex/elf.c
+++ b/smex/elf.c
@@ -536,5 +536,6 @@ void elf_free_module(struct elf_module *module)
 	free(module->prg);
 	free(module->section);
 	free(module->strings);
-	fclose(module->fd);
+	if (module->fd)
+		fclose(module->fd);
 }

--- a/smex/elf.c
+++ b/smex/elf.c
@@ -471,8 +471,8 @@ int elf_read_module(struct elf_module *module, const char *name, bool verbose)
 	/* open the elf input file */
 	module->fd = fopen(name, "rb");
 	if (!module->fd) {
-		fprintf(stderr, "error: unable to open %s for reading %d\n",
-			name, errno);
+		fprintf(stderr, "error: unable to open %s for reading: %s\n",
+			name, strerror(errno));
 		return -EINVAL;
 	}
 	module->elf_file = name;


### PR DESCRIPTION
3 commits, main one:

smex: fix crash in elf_free_module() when input file not found

fclose() seems to require a valid argument.