### PR TITLE
Re-enable DMA trace initialization in Zephyr

### DIFF
--- a/src/ipc/ipc3/handler.c
+++ b/src/ipc/ipc3/handler.c
@@ -729,7 +729,7 @@ static int ipc_glb_pm_message(uint32_t header)
 /*
  * Debug IPC Operations.
  */
-#if CONFIG_SUECREEK || defined __ZEPHYR__
+#if CONFIG_SUECREEK
 static int ipc_dma_trace_config(uint32_t header)
 {
 	return 0;
@@ -799,7 +799,7 @@ static int ipc_dma_trace_config(uint32_t header)
 error:
 	return err;
 }
-#endif /* CONFIG_SUECREEK || defined __ZEPHYR__ */
+#endif /* CONFIG_SUECREEK */
 
 static int ipc_trace_filter_update(uint32_t header)
 {

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -505,7 +505,6 @@ int platform_init(struct sof *sof)
 	if (ret < 0)
 		return ret;
 
-#ifndef __ZEPHYR__
 #if CONFIG_DW_SPI
 	/* initialize the SPI slave */
 	trace_point(TRACE_BOOT_PLATFORM_SPI);
@@ -530,7 +529,7 @@ int platform_init(struct sof *sof)
 
 	/* show heap status */
 	heap_trace_all(1);
-#endif /* __ZEPHYR__ */
+
 	return 0;
 }
 

--- a/src/schedule/zephyr_ll.c
+++ b/src/schedule/zephyr_ll.c
@@ -15,6 +15,12 @@
 
 #include <kernel.h>
 
+/* 1547fe68-de0c-11eb-8461-3158a1294853 */
+DECLARE_SOF_UUID("zll-schedule", zll_sched_uuid, 0x1547fe68, 0xde0c, 0x11eb,
+		 0x84, 0x61, 0x31, 0x58, 0xa1, 0x29, 0x48, 0x53);
+
+DECLARE_TR_CTX(ll_tr, SOF_UUID(zll_sched_uuid), LOG_LEVEL_INFO);
+
 /* per-scheduler data */
 struct zephyr_ll {
 	struct list_item tasks;			/* list of ll tasks */


### PR DESCRIPTION
Just a first part. The DMA trace with the SOF dictionary works in my workspace but I'm still cleaning up the rest.

