### PR TITLE
zephyr: ll-scheduler: switch to the native time-keeping API

### DIFF
--- a/src/audio/pipeline/pipeline-schedule.c
+++ b/src/audio/pipeline/pipeline-schedule.c
@@ -113,6 +113,14 @@ void pipeline_schedule_triggered(struct pipeline_walk_context *ctx,
 {
 	struct list_item *tlist;
 	struct pipeline *p;
+	uint32_t flags;
+
+	/*
+	 * Interrupts have to be disabled while adding tasks to or removing them
+	 * from the scheduler list. Without that scheduling can begin
+	 * immediately before all pipelines achieved a consistent state.
+	 */
+	irq_local_disable(flags);
 
 	list_for_item(tlist, &ctx->pipelines) {
 		p = container_of(tlist, struct pipeline, list);
@@ -135,6 +143,8 @@ void pipeline_schedule_triggered(struct pipeline_walk_context *ctx,
 			break;
 		}
 	}
+
+	irq_local_enable(flags);
 }
 
 int pipeline_comp_task_init(struct pipeline *p)

--- a/src/schedule/ll_schedule.c
+++ b/src/schedule/ll_schedule.c
@@ -286,14 +286,6 @@ static int schedule_ll_domain_set(struct ll_schedule_data *sch,
 		task->start = domain->next_tick;
 	} else {
 		/* later periodic task, simplify and cover it by the coming interrupt */
-#ifdef __ZEPHYR__
-		/*
-		 * Under Zephyr domain_set() must be called for each client, if the next
-		 * tick is already set by a different client in the same domain, this
-		 * will just set the new client to the same tick time
-		 */
-		domain_set(domain, domain->next_tick);
-#endif
 		task->start = domain->next_tick;
 	}
 

--- a/src/schedule/zephyr_ll.c
+++ b/src/schedule/zephyr_ll.c
@@ -30,9 +30,6 @@ struct zephyr_ll_pdata {
 	struct k_sem sem;
 };
 
-/* FIXME: would be good to use the timer, configured in the underlying domain */
-#define domain_time(sch) platform_timer_get_atomic(timer_get())
-
 /* Locking: caller should hold the domain lock */
 static void zephyr_ll_task_done(struct zephyr_ll *sch,
 				struct task *task)
@@ -292,7 +289,7 @@ static int zephyr_ll_task_schedule(void *data, struct task *task, uint64_t start
 		}
 	}
 
-	task->start = domain_time(sch) + delay;
+	task->start = k_uptime_ticks() + k_cyc_to_ticks_floor64(delay);
 	if (sch->ll_domain->next_tick != UINT64_MAX &&
 	    sch->ll_domain->next_tick > task->start)
 		task->start = sch->ll_domain->next_tick;


### PR DESCRIPTION
The series fixes a recent regression by reverting commit af6655e7fac3c56847251553699f354df74bf6a9 and then switches the SOF Zephyr-based LL scheduler implementation to using the native Zephyr time-keeping API.