### PR TITLE
topology: cavs-nocodec: use s24le for DAIs for all platforms

### DIFF
--- a/tools/topology/topology1/sof-cavs-nocodec.m4
+++ b/tools/topology/topology1/sof-cavs-nocodec.m4
@@ -88,16 +88,8 @@ define(SSP1_IDX, `1')
 define(SSP2_IDX, `2')
 ')
 
-ifelse(PLATFORM, `jsl',
-`
 define(PIPE_BITS, `s32le')
 define(DAI_BITS, `s24le')
-',
-`
-define(PIPE_BITS, `s32le')
-define(DAI_BITS, `s32le')
-'
-)
 
 #
 # Define the pipelines


### PR DESCRIPTION
The use of s32le did not expose any problems on APL, but alsa-bat was
previously reported as failing on JSL. Now that this test was extended
to CML_NOCODEC, we see the same issue. Manual tests with s24le show no
issues.

Let's just use s24le across the board and move on.

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>