### PR TITLE
drivers: Intel: SSP: ignore config when SSP is already configured

### DIFF
--- a/src/drivers/intel/ssp/ssp.c
+++ b/src/drivers/intel/ssp/ssp.c
@@ -268,10 +268,10 @@ static int ssp_set_config(struct dai *dai, struct ipc_config_dai *common_config,
 
 	spin_lock(&dai->lock);
 
-	/* is playback/capture already running */
-	if (ssp->state[DAI_DIR_PLAYBACK] == COMP_STATE_ACTIVE ||
-	    ssp->state[DAI_DIR_CAPTURE] == COMP_STATE_ACTIVE) {
-		dai_info(dai, "ssp_set_config(): playback/capture active. Ignore config");
+	/* ignore config if SSP is already configured */
+	if (ssp->state[DAI_DIR_PLAYBACK] > COMP_STATE_READY ||
+	    ssp->state[DAI_DIR_CAPTURE] > COMP_STATE_READY) {
+		dai_info(dai, "ssp_set_config(): Already configured. Ignore config");
 		goto out;
 	}
 


### PR DESCRIPTION
When two streams are started one after the other, 2 DAI_CONFIG
IPC's will be sent before the START trigger. This ends up
configuring the SSP when the first one has already just
configured it and ends up with xruns. Avoid this by checking
if the current state is > COMP_STATE_READY before configuring the
SSP.

Fixes https://github.com/thesofproject/sof/issues/4457