### PR TITLE
topology1: sof-tgl-nocodec-ci: use volume capture for PCM0

### DIFF
--- a/tools/topology/topology1/development/sof-tgl-nocodec-ci.m4
+++ b/tools/topology/topology1/development/sof-tgl-nocodec-ci.m4
@@ -120,9 +120,9 @@ PIPELINE_PCM_ADD(sof/pipe-volume-demux-playback.m4,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
-# Passthrough capture pipeline 2 on PCM 0 using max 2 channels of s16le.
+# Volume-switch capture pipeline 2 on PCM 0 using max 2 channels of s32le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-switch-capture.m4,
 	2, 0, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)


### PR DESCRIPTION
Fixes #4461

S32_LE without PGA is not supported in alsabat, switch to use
pipe-volume-capture and unblock the CI alsabat test case.

Signed-off-by: Iris Wu <xiaoyun.wu@intel.com>