### PR TITLE
dma: add some NULL pointer checks

### DIFF
--- a/src/include/sof/lib/dma.h
+++ b/src/include/sof/lib/dma.h
@@ -284,6 +284,9 @@ void dma_put(struct dma *dma);
 static inline struct dma_chan_data *dma_channel_get(struct dma *dma,
 						    int req_channel)
 {
+	if (!dma || !dma->ops || !dma->ops->channel_get)
+		return NULL;
+
 	struct dma_chan_data *chan = dma->ops->channel_get(dma, req_channel);
 
 	return chan;

--- a/src/trace/dma-trace.c
+++ b/src/trace/dma-trace.c
@@ -269,6 +269,13 @@ static int dma_trace_start(struct dma_trace_data *d)
 	uint32_t elem_size, elem_addr, elem_num;
 	int err = 0;
 
+	/* DMA Controller initialization is platform-specific */
+	if (!d || !d->dc.dmac) {
+		mtrace_printf(LOG_LEVEL_ERROR,
+			      "dma_trace_start failed: no DMAC!");
+		return -ENODEV;
+	}
+
 	err = dma_copy_set_stream_tag(&d->dc, d->stream_tag);
 	if (err < 0)
 		return err;
@@ -294,8 +301,10 @@ static int dma_trace_start(struct dma_trace_data *d)
 		return err;
 
 	err = dma_set_config(d->dc.chan, &config);
-	if (err < 0)
+	if (err < 0) {
+		mtrace_printf(LOG_LEVEL_ERROR, "dma_set_config() failed: %d", err);
 		return err;
+	}
 
 	err = dma_start(d->dc.chan);
 


### PR DESCRIPTION
These proved useful when debugging Zephyr but they're not Zephyr specific.

Use mtrace_printf() because if we're having DMA issues we probably want
to avoid the DMA trace

Signed-off-by: Marc Herbert <marc.herbert@intel.com>