### PR TITLE
pm_runtime: longer hp sram power gating delay

### DIFF
--- a/src/platform/intel/cavs/include/cavs/lib/pm_memory.h
+++ b/src/platform/intel/cavs/include/cavs/lib/pm_memory.h
@@ -25,7 +25,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#define MEMORY_POWER_DOWN_DELAY 256
+#define MEMORY_POWER_DOWN_DELAY 512
 
 #if CAVS_VERSION >= CAVS_VERSION_1_8
 


### PR DESCRIPTION
Signed-off-by: Slawomir Blauciak <slawomir.blauciak@linux.intel.com>