### PR TITLE
topology2: Add cavs-nocodec topology

### DIFF
--- a/tools/topology/topology2/cavs-nocodec.conf
+++ b/tools/topology/topology2/cavs-nocodec.conf
@@ -1,0 +1,113 @@
+<include/common/vendor-token.conf>
+<include/common/tokens.conf>
+<include/common/manifest.conf>
+<include/common/pcm.conf>
+<include/common/pcm_caps.conf>
+<include/common/fe_dai.conf>
+<include/common/route.conf>
+<include/components/host.conf>
+<include/components/dai.conf>
+<include/components/pipeline.conf>
+<include/components/copier.conf>
+<include/dais/ssp.conf>
+<include/dais/hw_config.conf>
+<include/pipelines/cavs/passthrough-playback.conf>
+<include/pipelines/cavs/passthrough-capture.conf>
+
+#
+# List of all DAIs
+#
+#SSP Index: 0, Direction: duplex
+Object.Dai {
+	SSP."0" {
+		id 		0
+		direction	"duplex"
+		name		NoCodec-0
+		default_hw_conf_id	0
+		sample_bits		16
+		quirks			"lbm_mode"
+
+		Object.Base.hw_config."SSP0" {
+			id	0
+			mclk_freq	24000000
+			bclk_freq	4800000
+			tdm_slot_width	32
+		}
+
+		# include DAI copier components
+		Object.Widget.copier."0" {
+			index 1
+			type "dai_in"
+			copier_type	"SSP"
+			direction "playback"
+			stream_name "NoCodec-0"
+			period_sink_count 0
+			period_source_count 2
+			format s16le
+		}
+
+		Object.Widget.copier."1" {
+			index 2
+			type	"dai_out"
+			copier_type "SSP"
+			direction "capture"
+			stream_name "NoCodec-0"
+			period_sink_count 2
+			period_source_count 0
+			format s16le
+		}
+	}
+}
+
+#
+# Pipeline definitions
+#
+
+# Pipeline ID:1 PCM ID: 0
+Object.Pipeline {
+	passthrough-playback."1" {
+		format "s16le"
+
+		Object.Widget.pipeline.1.stream_name	"copier.SSP.1.0"
+
+		Object.Widget.copier.1.stream_name	"Passthrough Playback 0"
+	}
+
+	passthrough-capture."2" {
+		format		"s16le"
+
+		Object.Widget.pipeline.1.stream_name	"copier.SSP.2.1"
+
+		Object.Widget.copier.1.stream_name	"Passthrough Capture 0"
+	}
+}
+
+Object.PCM {
+	pcm."0" {
+		name	"Port0"
+		direction	"duplex"
+		Object.Base.fe_dai."Port0" {}
+
+		Object.PCM.pcm_caps."playback" {
+			name "Passthrough Playback 0"
+			formats 'S16_LE'
+		}
+
+		Object.PCM.pcm_caps."capture" {
+			name "Passthrough Capture 0"
+			formats 'S16_LE'
+		}
+	}
+}
+
+Object.Base {
+	route."0" {
+		source	"copier.host.1.1"
+		sink	"copier.SSP.1.0"
+	}
+
+	route."1" {
+		source	"copier.SSP.2.1"
+		sink	"copier.host.2.1"
+	}
+}

--- a/tools/topology/topology2/include/common/fe_dai.conf
+++ b/tools/topology/topology2/include/common/fe_dai.conf
@@ -1,0 +1,36 @@
+#
+# FE DAI Class definition. All attributes defined herein are namespaced
+# by alsatplg to "Object.Base.fe_dai.NAME.attribute_name".
+#
+# Usage: FE DAI objects can be instantiated as
+#
+#	Object.Base.fe_dai."NAME" {
+#		id	0
+#	}
+#
+# where NAME is the unique instance name for the FE DAI object within the
+# same alsaconf node.
+
+Class.Base."fe_dai" {
+
+	DefineAttribute."name" {
+		type	"string"
+	}
+
+	DefineAttribute."id" {}
+
+	attributes {
+		constructor [
+			"name"
+		]
+
+		mandatory [
+			"id"
+		]
+		#
+		# name attribute values for fe_dai objects must be unique in the
+		# same alsaconf node
+		#
+		unique	"name"
+	}
+}

--- a/tools/topology/topology2/include/common/manifest.conf
+++ b/tools/topology/topology2/include/common/manifest.conf
@@ -1,0 +1,20 @@
+#
+# Manifest Class definition.
+#
+
+Class.Base."manifest" {
+	DefineAttribute."name" {
+		type	"string"
+	}
+
+	attributes {
+		constructor [
+			"name"
+		]
+		#
+		# name attribute values for manifest objects must be unique
+		# in the same alsaconf node
+		#
+		unique	"name"
+	}
+}

--- a/tools/topology/topology2/include/common/pcm.conf
+++ b/tools/topology/topology2/include/common/pcm.conf
@@ -1,0 +1,61 @@
+#
+# PCM Class definition. All attributes defined herein are namespaced
+# by alsatplg to "Object.PCM.pcm.N.attribute_name".
+#
+# Usage: PCM object can be instantiated as:
+#
+#	Object.PCM.pcm."N" {
+#		id		2
+#		pcm_name	"Headset"
+#		direction	"playback"
+#	}
+#
+# where N is the unique instance number for the PCM object within the same alsaconf node.
+
+Class.PCM."pcm" {
+
+	# PCM name
+	DefineAttribute."name" {}
+
+	# PCM id
+	DefineAttribute."id" {}
+
+	DefineAttribute."direction" {
+		constraints {
+			valid_values [
+				playback
+				capture
+				duplex
+			]
+		}
+	}
+
+	DefineAttribute."compress" {}
+
+	DefineAttribute."playback_compatible_d0i3" {
+		# Token reference and type
+		token_ref	"sof_tkn_stream.bool"
+	}
+
+	DefineAttribute."capture_compatible_d0i3" {
+		# Token reference and type
+		token_ref	"sof_tkn_stream.bool"
+	}
+
+	attributes {
+		!constructor [
+			"name"
+			"id"
+			"direction"
+		]
+
+		#
+		# pcm objects instantiated within the same alsaconf node must have unique
+		# id attribute
+		#
+		unique	"id"
+	}
+
+	# Default values for PCM attributes
+	compress	"false"
+}

--- a/tools/topology/topology2/include/common/pcm_caps.conf
+++ b/tools/topology/topology2/include/common/pcm_caps.conf
@@ -1,0 +1,92 @@
+#
+# PCM Capabilities Class definition. All attributes defined herein are
+# namespaced by alsatplg to "Object.PCM.pcm_caps.DIRECTION.attribute_name".
+#
+# Usage: PCM object can be instantiated as:
+#
+#	Object.PCM.pcm_caps."DIRECTION" {
+#		name			"Headset"
+#		direction		"playback"
+#		formats			"S32_LE,S24_LE,S16_LE"
+#		rate_min		48000
+#		rate_max		48000
+#		channels_min		2
+#		channels_max		2
+#		periods_min		2
+#	}
+#
+# where DIRECTION is the unique stream direction for the pcm_caps object within
+# the same alsaconf node (normally, pcm object).
+
+Class.PCM."pcm_caps" {
+	#
+	# Argument used to construct PCM Capabilities
+	#
+	DefineAttribute."name" {
+		type	"string"
+	}
+
+	DefineAttribute."direction" {
+		type	"string"
+		!valid_values [
+			playback
+			capture
+		]
+	}
+
+	DefineAttribute."formats" {
+		type	"string"
+	}
+
+	DefineAttribute."rates" {
+		type	"string"
+	}
+
+	DefineAttribute."sigbits" {}
+
+	DefineAttribute."rate_min" {}
+
+	DefineAttribute."rate_max" {}
+
+	DefineAttribute."channels_min" {}
+
+	DefineAttribute."channels_max" {}
+
+	DefineAttribute."periods_min" {}
+
+	DefineAttribute."periods_max" {}
+
+	DefineAttribute."period_size_min" {}
+
+	DefineAttribute."period_size_max" {}
+
+	DefineAttribute."buffer_size_min" {}
+
+	DefineAttribute."buffer_size_max" {}
+
+	attributes {
+		!constructor [
+			"name"
+			"direction"
+		]
+
+		#
+		# pcm_caps objects instantiated within the same alsaconf node must have unique
+		# direction attribute
+		#
+		unique	"direction"
+	}
+
+	# Default attribute values for PCM capabilities
+	formats		"S32_LE,S24_LE,S16_LE"
+	rate_min		48000
+	rate_max		48000
+	periods_min		2
+	periods_max		16
+	channels_min		2
+	channels_max		2
+	period_size_min		192
+	period_size_max		16384
+	buffer_size_min		65536
+	buffer_size_max		65536
+}

--- a/tools/topology/topology2/include/common/tokens.conf
+++ b/tools/topology/topology2/include/common/tokens.conf
@@ -52,4 +52,8 @@ Object.Base.VendorToken {
 		time_domain		205
 		dynamic_pipeline	206
 	}
+
+	"sof_tkn_copier" {
+		cpc		1600
+	}
 }

--- a/tools/topology/topology2/include/common/tokens.conf
+++ b/tools/topology/topology2/include/common/tokens.conf
@@ -56,4 +56,14 @@ Object.Base.VendorToken {
 	"sof_tkn_copier" {
 		cpc		1600
 	}
+
+	"sof_tkn_intel_ssp" {
+		clks_control		500
+		mclk_id			501
+		sample_bits		502
+		frame_pulse_width 	503
+		quirks			504
+		tdm_padding_per_slot	505
+		bclk_delay		506
+	}
 }

--- a/tools/topology/topology2/include/components/copier.conf
+++ b/tools/topology/topology2/include/components/copier.conf
@@ -1,0 +1,116 @@
+#
+# Common pipeline copier
+#
+# A generic copier widget. All attributes defined herein are namespaced
+# by alsatplg to "Object.Widget.copier.N.attribute_name"
+#
+# Usage: this component can be used by instantiating it in the parent object. i.e.
+#
+# 	Object.Widget.copier."N" {
+#		copier_type	"host"
+#		cpc	100000
+#	}
+#
+# Where N is the unique instance number for the copier object within the same alsaconf node.
+
+Class.Widget."copier" {
+	#
+	# Pipeline ID for the copier object
+	#
+	DefineAttribute."index" {}
+
+	#
+	# Copier object instance
+	#
+	DefineAttribute."instance" {}
+
+	#include common component definition
+	<include/components/widget-common.conf>
+
+	#
+	# Copier component UUID
+	#
+	DefineAttribute."uuid" {
+		type "string"
+		# Token set reference name and type
+		token_ref	"sof_tkn_comp.uuid"
+	}
+
+	#
+	# Bespoke Attribute Definitions for Copiers
+	#
+
+	#
+	# copier type in pipeline.
+	#
+	DefineAttribute."copier_type" {
+		constraints {
+			!values [
+				"host"
+				"SSP" # TODO: add more DAIs
+				"module"
+			]
+		}
+	}
+
+	DefineAttribute."direction" {
+		constraints {
+			!values [
+				"playback"
+				"capture"
+			]
+		}
+	}
+
+	DefineAttribute."cpc" {
+		# Token set reference name and type
+		token_ref	"sof_tkn_copier.word"
+	}
+
+	attributes {
+		#
+		# The copier widget name would be constructed using the copier type, index and
+		# instance attributes. For ex: "copier.SSP.0.1".
+		#
+		!constructor [
+			"copier_type"
+			"index"
+			"instance"
+		]
+
+		#
+		# mandatory attributes that must be provided when the buffer class is instantiated
+		#
+		!mandatory [
+			"no_pm"
+			"uuid"
+			"copier_type"
+			"cpc"
+		]
+
+		#
+		# immutable attributes cannot be modified in the object instance
+		#
+		!immutable [
+			"uuid"
+		]
+
+		#
+		# deprecated attributes should not be added in the object instance
+		#
+		!deprecated [
+			"preload_count"
+		]
+
+		unique	"instance"
+	}
+
+	#
+	# Default attributes for Copier
+	#
+	#UUID: 9BA00C83-CA12-4A83-943C-1FA2E82F9DDA
+	uuid 		"83:0c:a0:9b:12:CA:83:4a:94:3c:1f:a2:e8:2f:9d:da"
+	no_pm 		"true"
+	core_id	0
+	cpc		100000
+}

--- a/tools/topology/topology2/include/dais/hw_config.conf
+++ b/tools/topology/topology2/include/dais/hw_config.conf
@@ -1,0 +1,83 @@
+# Hardware config class definition DAIs. All attributes defined herein
+# are namespaced by alsatplg to "Object.Base.hw_config.NAME.attribute_name"
+#
+# Object.Base.hw_config."NAME" {
+# 		id		0
+# 		mclk_freq	24000000
+# 		bclk_freq	4800000
+# 		tdm_slot_width	25
+# 	}
+#
+# where NAME is the unique instance name for the hw_config object
+# within the same alsaconf node.
+
+Class.Base."hw_config" {
+	#
+	# Argument used to construct hw config (hw config ID)
+	#
+	DefineAttribute."id" {}
+
+	DefineAttribute."name" {
+		type	"string"
+	}
+
+	# All attributes are only used for SSP.
+	DefineAttribute."format" {
+		type	"string"
+		constraints {
+			valid_values [
+				"I2S"
+				"DSP_A"
+				"DSP_B"
+			]
+		}
+	}
+
+	DefineAttribute."mclk" {
+		type	"string"
+	}
+
+	DefineAttribute."mclk_freq" {}
+
+	DefineAttribute."bclk" {
+		type	"string"
+	}
+
+	DefineAttribute."bclk_freq" {}
+
+	DefineAttribute."fsync" {
+		type	"string"
+	}
+
+	DefineAttribute."fsync_freq" {}
+
+	DefineAttribute."tdm_slots" {}
+
+	DefineAttribute."tdm_slot_width" {}
+
+	DefineAttribute."tx_slots" {}
+
+	DefineAttribute."rx_slots" {}
+
+	attributes {
+		constructor [
+			"id"
+		]
+		#
+		# hw_cfg objects instantiated within the same alsaconf node must have unique
+		# 'name' attribute
+		#
+		unique	"name"
+	}
+
+	#TODO: Add link flags
+
+	format		"I2S"
+	mclk		"codec_mclk_in"
+	bclk		"codec_consumer"
+	fsync		"codec_consumer"
+	fsync_freq	48000
+	tdm_slots	2
+	tx_slots	3
+	rx_slots	3
+}

--- a/tools/topology/topology2/include/dais/ssp.conf
+++ b/tools/topology/topology2/include/dais/ssp.conf
@@ -1,0 +1,136 @@
+#
+# SSP DAI class definition. All attributes defined herein are namespaced
+# by alsatplg to "Object.Dai.SSP.N.attribute_name"
+#
+# Usage: SSP DAI objects can be instantiated as:
+#
+# Object.Dai.SSP."N" {
+# 	direction		"duplex" # playback, capture or duplex
+# 	dai_name		"NoCodec-0"
+# 	id 			0
+# 	quirks			"lbm_mode"
+# 	sample_bits		24
+# 	Object.hw_config."0" {
+# 		mclk_freq	24000000
+# 		bclk_freq	4800000
+# 		tdm_slot_width	25
+# 	}
+# 	Object.dai."playback" {
+# 		period_source_count	2
+# 		period_sink_count	0
+# 	}
+# 	Object.dai."capture" {
+# 		period_source_count	0
+# 		period_sink_count	2
+# 	}
+# }
+#
+# where N is the unique instance number for the SSP object within the same alsaconf node.
+
+# SSP port definition
+Class.Dai."SSP" {
+
+	#
+	# Argument used to construct DAI widget
+	#
+	# Playback DAI Index
+	DefineAttribute."dai_index" {
+		token_ref	"sof_tkn_dai.word"
+	}
+
+	DefineAttribute."direction" {
+		type "string"
+		constraints {
+			!valid_values [
+				"playback"
+				"capture"
+				"duplex"
+			]
+		}
+	}
+
+	DefineAttribute."dai_type" {
+		type	"string"
+		token_ref	"sof_tkn_dai.string"
+	}
+
+	DefineAttribute."default_hw_config_id" {}
+
+	DefineAttribute."name" {
+		type	"string"
+	}
+
+	# Backend DAI Link ID matching with the machine driver
+	DefineAttribute."id" {}
+
+	DefineAttribute."sample_bits" {
+		# Token reference and type
+		token_ref	"sof_tkn_intel_ssp.word"
+	}
+
+	DefineAttribute."bclk_delay" {
+		# Token reference and type
+		token_ref	"sof_tkn_intel_ssp.word"
+	}
+
+	DefineAttribute."tdm_padding_per_slot" {
+		type	"string"
+		# Token reference and type
+		token_ref	"sof_tkn_intel_ssp.bool"
+		constraints {
+			!valid_values [
+				"true"
+				"false"
+			]
+		}
+	}
+
+	# SSP quirks. Value will translated based on sof_tkn_ssp_quirks. For ex: lb_mode will
+	# be converted to 64.
+	DefineAttribute."quirks" {
+		# Token reference and type
+		token_ref	"sof_tkn_intel_ssp.word"
+		constraints {
+			!valid_values [
+				"lbm_mode"
+			]
+			!tuple_values [
+				64
+			]
+
+		}
+	}
+
+	DefineAttribute."mclk_id" {
+		# Token reference and type
+		token_ref	"sof_tkn_intel_ssp.short"
+	}
+
+	attributes {
+		constructor [
+			"name"
+		]
+
+		mandatory [
+			"id"
+			"sample_bits"
+		]
+
+		immutable [
+			"dai_type"
+		]
+		#
+		# SSP DAI objects instantiated within the same alsaconf node must have unique
+		# dai_index attribute
+		#
+		unique	"dai_index"
+	}
+
+	dai_type		"SSP"
+	bclk_delay		0
+	mclk_id 		0
+	default_hw_config_id	0
+	clks_control 		0
+	frame_pulse_width	0
+	tdm_padding_per_slot	false
+}

--- a/tools/topology/topology2/include/pipelines/cavs/passthrough-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/passthrough-capture.conf
@@ -1,0 +1,66 @@
+#
+# CAVS passthrough capture pipeline
+#
+# A simple passthrough pipeline. All attributes defined herein are namespaced
+# by alsatplg to "Object.Pipeline.passthrough-capture.N.attribute_name".
+#
+# Usage: passthrough-capture pipeline object can be instantiated as:
+#
+# Object.Pipeline.passthrough-capture."N" {
+# 	format		"s16le"
+# 	period		1000
+# 	time_domain	"timer"
+# 	channels	2
+# 	rate		48000
+# }
+#
+# Where N is the unique pipeline ID within the same alsaconf node.
+#
+
+Class.Pipeline."passthrough-capture" {
+
+	DefineAttribute."index" {}
+
+	<include/pipelines/pipeline-common.conf>
+
+	attributes {
+		!constructor [
+			"index"
+		]
+
+		!mandatory [
+			"format"
+		]
+
+		!immutable [
+			"direction"
+		]
+
+		#
+		# passthrough-capture objects instantiated within the same alsaconf node must have
+		# unique pipeline_id attribute
+		#
+		unique	"index"
+	}
+
+	Object.Widget {
+		copier."1" {
+			copier_type	"host"
+			type	"aif_out"
+		}
+
+		pipeline."1" {
+			priority	0
+			lp_mode		0
+		}
+	}
+
+	direction	"capture"
+	time_domain	"timer"
+	channels	2
+	channels_min	2
+	channels_max	2
+	rate		48000
+	rate_min	48000
+	rate_max	48000
+}

--- a/tools/topology/topology2/include/pipelines/cavs/passthrough-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/passthrough-playback.conf
@@ -1,0 +1,66 @@
+#
+# CAVS passthrough playback pipeline
+#
+# A simple passthrough pipeline. All attributes defined herein are namespaced
+# by alsatplg to "Object.Pipeline.passthrough-playback.N.attribute_name"
+#
+# Usage: passthrough-playback pipeline object can be instantiated as:
+#
+# Object.Pipeline.passthrough-playback."N" {
+# 	format		"s16le"
+# 	period		1000
+# 	time_domain	"timer"
+# 	channels	2
+# 	rate		48000
+# }
+#
+# Where N is the unique pipeline ID within the same alsaconf node.
+#
+
+Class.Pipeline."passthrough-playback" {
+
+	DefineAttribute."index" {}
+
+	<include/pipelines/pipeline-common.conf>
+
+	attributes {
+		!constructor [
+			"index"
+		]
+
+		!mandatory [
+			"format"
+		]
+
+		!immutable [
+			"direction"
+		]
+
+		#
+		# passthrough-playback objects instantiated within the same alsaconf node must have
+		# unique pipeline_id attribute
+		#
+		unique	"index"
+	}
+
+	Object.Widget {
+		copier."1" {
+			copier_type	"host"
+			type	"aif_in"
+		}
+
+		pipeline."1" {
+			priority	0
+			lp_mode		0
+		}
+	}
+
+	direction	"playback"
+	time_domain	"timer"
+	channels	2
+	channels_min	2
+	channels_max	2
+	rate		48000
+	rate_min	48000
+	rate_max	48000
+}


### PR DESCRIPTION
This patch adds cavs-nocodec topology, and classes used by this topology.
Note that, only a playback and a capture pipelines on SSP0 are added.

This topology is verified with CAVS firmware on a TGLU nocodec device. 
special thanks to @RanderWang for topology verification and integration debug.

To compile this topology, take the upstream alsa-utils and Ranjani's PR https://github.com/alsa-project/alsa-utils/pull/97. run command 
```
export ALSA_CONFIG_DIR=path-to-topology2 # E.g. export ALSA_CONFIG_DIR=~/sof/tools/topology/topology2
alsatplg -p -c tools/topology/topology2/cavs-nocodec.conf -o cavs-nocodec.tplg
```