### PR TITLE
Multicore IPC

### DIFF
--- a/src/drivers/intel/cavs/ipc.c
+++ b/src/drivers/intel/cavs/ipc.c
@@ -172,7 +172,11 @@ int ipc_platform_compact_read_msg(ipc_cmd_hdr *hdr, int words)
 
 enum task_state ipc_platform_do_cmd(void *data)
 {
+	struct ipc *ipc = data;
 	ipc_cmd_hdr *hdr;
+
+	/* Reset after the previous IPC */
+	ipc->core = PLATFORM_PRIMARY_CORE_ID;
 
 #if CAVS_VERSION >= CAVS_VERSION_1_8
 	hdr = ipc_compact_read_msg();
@@ -188,6 +192,9 @@ enum task_state ipc_platform_do_cmd(void *data)
 void ipc_platform_complete_cmd(void *data)
 {
 	struct ipc *ipc = data;
+
+	if (!cpu_is_me(ipc->core))
+		return;
 
 	/* write 1 to clear busy, and trigger interrupt to host*/
 #if CAVS_VERSION == CAVS_VERSION_1_5

--- a/src/idc/idc.c
+++ b/src/idc/idc.c
@@ -7,6 +7,7 @@
 #include <sof/audio/component.h>
 #include <sof/audio/component_ext.h>
 #include <sof/drivers/idc.h>
+#include <sof/ipc/driver.h>
 #include <sof/ipc/msg.h>
 #include <sof/ipc/topology.h>
 #include <sof/ipc/schedule.h>
@@ -120,9 +121,18 @@ int idc_wait_in_blocking_mode(uint32_t target_core, bool (*cond)(int))
 static void idc_ipc(void)
 {
 	struct ipc *ipc = ipc_get();
-	ipc_cmd_hdr *hdr = ipc->comp_data;
 
-	ipc_cmd(hdr);
+	/*
+	 * In principle we could just do
+	 * ipc->core = cpu_get_id();
+	 * because currently that's the only field that is modified at run-time,
+	 * but flushing the complete cache is more future-proof.
+	 */
+	dcache_invalidate_region(ipc, sizeof(*ipc));
+	ipc_cmd(ipc->comp_data);
+
+	/* Signal the host */
+	ipc_platform_complete_cmd(ipc);
 }
 
 /**

--- a/src/include/sof/ipc/common.h
+++ b/src/include/sof/ipc/common.h
@@ -68,6 +68,7 @@ struct ipc {
 
 	struct list_item msg_list;	/* queue of messages to be sent */
 	bool is_notification_pending;	/* notification is being sent to host */
+	unsigned int core;		/* core, processing the IPC */
 
 	struct list_item comp_list;	/* list of component devices */
 

--- a/src/ipc/ipc-common.c
+++ b/src/ipc/ipc-common.c
@@ -40,6 +40,7 @@ DECLARE_TR_CTX(ipc_tr, SOF_UUID(ipc_uuid), LOG_LEVEL_INFO);
 
 int ipc_process_on_core(uint32_t core)
 {
+	struct ipc *ipc = ipc_get();
 	struct idc_msg msg = { .header = IDC_MSG_IPC, .core = core, };
 	int ret;
 
@@ -49,8 +50,15 @@ int ipc_process_on_core(uint32_t core)
 		return -EACCES;
 	}
 
+	/* The other core will write there its response */
+	dcache_invalidate_region((void *)MAILBOX_HOSTBOX_BASE,
+				 ((struct sof_ipc_cmd_hdr *)ipc->comp_data)->size);
+
+	ipc->core = core;
+	dcache_writeback_region(ipc, sizeof(*ipc));
+
 	/* send IDC message */
-	ret = idc_send_msg(&msg, IDC_BLOCKING);
+	ret = idc_send_msg(&msg, IDC_NON_BLOCKING);
 	if (ret < 0)
 		return ret;
 


### PR DESCRIPTION
Currently when an IPC message arrives, the primary core receives the interrupt, schedules a task and begins processing the message. If it identifies, that the message is for another core, it sends an IDC message to it and waits in a busy loop until the other core completes processing the message and writes a response into the mailbox. After that the primary core notifies the host about completing the processing. This patch lets the processing secondary core notify the host directly, which also frees the primary core to handle other tasks instead of waiting in a busy loop.