### PR TITLE
One-line revert of zephyr: wrapper: build SOF with Zephyr for imx

### DIFF
--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -151,8 +151,6 @@ void *rmalloc(enum mem_zone zone, uint32_t flags, uint32_t caps, size_t bytes)
 {
 	if (zone_is_cached(zone))
 		return heap_alloc_aligned_cached(&sof_heap, 0, bytes);
-	else
-		return heap_alloc_aligned(&sof_heap, 8, bytes);
 
 	return heap_alloc_aligned(&sof_heap_shared, 8, bytes);
 }


### PR DESCRIPTION
This reverts the only line in commit 34bb9b728268 / PR #4217 that is not
under some `#ifdef IMX`

This avoids the following crash always happening on my Up Squared board
on the second aplay command:
```
[00022612] <err> os:  ** FATAL EXCEPTION
[00022612] <err> os:  ** CPU 0 EXCCAUSE 13 (load/store PIF d{slot 33, seq=34} ata error)
[00022612] <err> os:  **  PC 0xbe00b7ed VADDR 0x9e08bbc4
[00022612] <err> os:  **  PS 0x60a20
[00022612] <err> os:  **    (INTLEVEL:0 EXCM: 0 UM:1 RING:0 {slot 37, seq=38} WOE:1 OWB:10 CALLINC:2)
[00022612] <err> os:  **  A0 0xbe00ba7e  SP 0xbe0498e0  A2 0{slot 39, seq=40} x1fff  A3 0x9e08bbc4
[00022612] <err> os:  **  A4 0x4  A5 0xc1  A6 0x1b20  A7 0xb{slot 41, seq=42} e049b64
[00022612] <err> os:  **  A8 0x7fff  A9 0x7fff A10 0xe A11 0{slot 43, seq=44} x9e0732c2
[00022612] <err> os:  ** A12 0x2 A13 0x182 A14 0x180 A15 0x6{slot 45, seq=46} 0
[00022612] <err> os:  ** LBEG 0xbe01739c LEND 0xbe0173a6 LCO{slot 47, seq=48} UNT (nil)
[00022612] <err> os:  ** SAR 0x19
[00022612] <err> os: >>> ZEPHYR FATAL ERROR 0: CPU exception{slot 50, seq=51}  on CPU 0
[00022612] <err> os: Current thread: 0x9e075ca8 (unknown)
[00022614] <err> os: Halting system
```

I don't think it matters but for completeness this crash and the corresponding fix were reproduced with the following Zephyr commits: 882600834e80 and db9756045e1a