### PR TITLE
zephyr: build and run smex. New staging area for easy deployment

### DIFF
--- a/smex/smex.c
+++ b/smex/smex.c
@@ -20,7 +20,7 @@ static void usage(char *name)
 	fprintf(stdout, "\t -l log dictionary outfile\n");
 	fprintf(stdout, "\t -v enable verbose output\n");
 	fprintf(stdout, "\t -h this help message\n");
-	exit(0);
+	exit(1);
 }
 
 int main(int argc, char *argv[])

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -1,5 +1,7 @@
 # This is still WIP - Not fully validated on any platform.
 
+# When west is installed, Zephyr's CMake invokes west to list and try to
+# compile every Zephyr module that can be found.
 if(CONFIG_SOF)
 
 if(CONFIG_LIBRARY)
@@ -580,5 +582,5 @@ add_definitions(-DSOF_SRC_HASH=0x${SOF_SRC_HASH} -DSOF_GIT_TAG="${SOF_GIT_TAG}")
 
 # Create Trace realtive file paths
 sof_append_relative_path_definitions(modules_sof)
-endif()
 
+endif() # CONFIG_SOF

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -60,6 +60,25 @@ get_filename_component(RIMAGE_CONFIG "../rimage/config" ABSOLUTE)
 set(RIMAGE_CONFIG_PATH ${RIMAGE_CONFIG} CACHE PATH
     " Path to rimage board configuration files")
 
+include(ExternalProject)
+
+ExternalProject_Add(smex_ep
+	SOURCE_DIR "${ZEPHYR_SOF_MODULE_DIR}/smex/"
+	# The default paths are very "deep"
+	PREFIX     "${PROJECT_BINARY_DIR}/smex_ep"
+	BINARY_DIR "${PROJECT_BINARY_DIR}/smex_ep/build"
+	INSTALL_COMMAND "" # need smex only at build time
+)
+
+ExternalProject_Add(sof_logger_ep
+	SOURCE_DIR "${ZEPHYR_SOF_MODULE_DIR}/tools/"
+	# The default paths are very "deep"
+	PREFIX     "${PROJECT_BINARY_DIR}/sof-logger_ep"
+	BINARY_DIR "${PROJECT_BINARY_DIR}/sof-logger_ep/build"
+	BUILD_COMMAND cmake --build . --target sof-logger
+	INSTALL_COMMAND ""
+)
+
 # default SOF includes
 target_include_directories(SOF INTERFACE ../rimage/src/include)
 target_include_directories(SOF INTERFACE ../zephyr/include)

--- a/zephyr/docker-build.sh
+++ b/zephyr/docker-build.sh
@@ -4,6 +4,8 @@
 
 # "All problems can be solved by another level of indirection"
 # Ideally, this script would not be needed.
+#
+# Minor adjustments to the docker image provided by the Zephyr project.
 
 set -e
 set -x
@@ -12,6 +14,9 @@ unset ZEPHYR_BASE
 
 # Make sure we're in the right place; chgrp -R below.
 test -e ./scripts/xtensa-build-zephyr.sh
+
+sudo apt-get update
+sudo apt-get -y install tree
 
 if test -e zephyrproject; then
     ./scripts/xtensa-build-zephyr.sh -a

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,3 +1,7 @@
-build:
-  cmake: ./zephyr
-  kconfig: ./zephyr/Kconfig
+# https://docs.zephyrproject.org/latest/guides/modules.html
+name: sof
+
+# Default values:
+# build:
+#  cmake: ./zephyr
+#  kconfig: ./zephyr/Kconfig

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -510,8 +510,29 @@ void sys_comp_eq_iir_init(void);
 void sys_comp_kpb_init(void);
 void sys_comp_smart_amp_init(void);
 
+/* Zephyr redefines log_message() and mtrace_printf() which leaves
+ * totally empty the .static_log_entries ELF sections for the
+ * sof-logger. This makes smex fail. Define at least one such section to
+ * fix the build when sof-logger is not used.
+ */
+static inline const void *smex_placeholder_f(void)
+{
+	_DECLARE_LOG_ENTRY(LOG_LEVEL_DEBUG,
+			   "placeholder so .static_log.X are not all empty",
+			   _TRACE_INV_CLASS, 0);
+
+	return &log_entry;
+}
+
+/* Need to actually use the function and export something otherwise the
+ * compiler optimizes everything away.
+ */
+const void *_smex_placeholder;
+
 int task_main_start(struct sof *sof)
 {
+	_smex_placeholder = smex_placeholder_f();
+
 	int ret;
 
 	/* init default audio components */


### PR DESCRIPTION
See commit messages.  This is temporary until the switch to Zephyr logging.

Sample output from https://github.com/thesofproject/sof/pull/4474/checks?check_run_id=3043998310
```
zephyr-project/build-sof-staging
├── sof
│   ├── community
│   │   ├── sof-apl.ri
│   │   ├── sof-cnl.ri
│   │   ├── sof-icl.ri
│   │   └── sof-tgl-h.ri
│   ├── sof-apl.ldc
│   ├── sof-cnl.ldc
│   ├── sof-icl.ldc
│   └── sof-tgl-h.ldc
└── tools
    └── sof-logger
```