### PR TITLE
[SKIP CI] docker: add valgrind package for more advanced testing

### DIFF
--- a/scripts/docker_build/sof_builder/Dockerfile
+++ b/scripts/docker_build/sof_builder/Dockerfile
@@ -55,7 +55,8 @@ RUN apt-get -y update && \
 		unzip \
 		cmake \
 		python3 \
-		libglib2.0-dev
+		libglib2.0-dev \
+		valgrind
 
 ARG CLONE_DEFAULTS="--depth 5"
 


### PR DESCRIPTION
The Valgrind tool suite provides a number of debugging and profiling tools
that we could used for debugging/testing.

Signed-off-by: Fred Oh <fred.oh@linux.intel.com>