### PR TITLE
codec_adapter: passthrough: fix typo

### DIFF
--- a/src/audio/codec_adapter/codec/passthrough.c
+++ b/src/audio/codec_adapter/codec/passthrough.c
@@ -24,7 +24,7 @@ static int passthrough_codec_prepare(struct comp_dev *dev)
 	struct codec_data *codec = comp_get_codec(dev);
 	struct comp_data *cd = comp_get_drvdata(dev);
 
-	comp_info(dev, "passthrough_codec_process()");
+	comp_info(dev, "passthrough_codec_prepare()");
 
 	codec->cpd.in_buff = rballoc(0, SOF_MEM_CAPS_RAM, cd->period_bytes);
 	if (!codec->cpd.in_buff) {

--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -807,7 +807,6 @@ static int host_params(struct comp_dev *dev,
 
 static int host_prepare(struct comp_dev *dev)
 {
-	struct host_data *hd = comp_get_drvdata(dev);
 	int ret;
 
 	comp_dbg(dev, "host_prepare()");
@@ -818,10 +817,6 @@ static int host_prepare(struct comp_dev *dev)
 
 	if (ret == COMP_STATUS_STATE_ALREADY_SET)
 		return PPL_STATUS_PATH_STOP;
-
-	hd->local_pos = 0;
-	hd->report_pos = 0;
-	dev->position = 0;
 
 	return 0;
 }


### PR DESCRIPTION
logging as process in prepare step