### PR TITLE
topology2: add dai token support in copier

### DIFF
--- a/tools/topology/topology2/cavs-nocodec.conf
+++ b/tools/topology/topology2/cavs-nocodec.conf
@@ -37,8 +37,10 @@ Object.Dai {
 		# include DAI copier components
 		Object.Widget.copier."0" {
 			index 1
+			dai_index 1
 			type "dai_in"
-			copier_type	"SSP"
+			dai_type "SSP"
+			copier_type "SSP"
 			direction "playback"
 			stream_name "NoCodec-0"
 			period_sink_count 0
@@ -48,7 +50,9 @@ Object.Dai {
 
 		Object.Widget.copier."1" {
 			index 2
-			type	"dai_out"
+			dai_index 2
+			type "dai_out"
+			dai_type "SSP"
 			copier_type "SSP"
 			direction "capture"
 			stream_name "NoCodec-0"

--- a/tools/topology/topology2/include/components/copier.conf
+++ b/tools/topology/topology2/include/components/copier.conf
@@ -19,6 +19,10 @@ Class.Widget."copier" {
 	#
 	DefineAttribute."index" {}
 
+	DefineAttribute."dai_index" {
+		token_ref	"sof_tkn_dai.word"
+	}
+
 	#
 	# Copier object instance
 	#
@@ -53,11 +57,30 @@ Class.Widget."copier" {
 		}
 	}
 
+        DefineAttribute."dai_type" {
+                type    "string"
+                token_ref       "sof_tkn_dai.string"
+                constraints {
+                        !valid_values [
+                                "SSP"
+                                "DMIC"
+                                "HDA"
+                                "ALH"
+                        ]
+                }
+        }
+
 	DefineAttribute."direction" {
+		type "string"
+		token_ref	"sof_tkn_dai.word"
 		constraints {
-			!values [
+			!valid_values [
 				"playback"
 				"capture"
+			]
+			!tuple_values [
+				0
+				1
 			]
 		}
 	}

--- a/tools/topology/topology2/include/components/copier.conf
+++ b/tools/topology/topology2/include/components/copier.conf
@@ -49,7 +49,7 @@ Class.Widget."copier" {
 	#
 	DefineAttribute."copier_type" {
 		constraints {
-			!values [
+			!valid_values [
 				"host"
 				"SSP" # TODO: add more DAIs
 				"module"


### PR DESCRIPTION
Copier widget may be used as a dai component in ipc4 path,
so we need to add dai token in copier, including dai_index,
dai_type and direction. They are optional attributes and can
be set only for dai type.