### PR TITLE
test: cmocka: Add exit to function __panic()

### DIFF
--- a/test/cmocka/src/common_mocks.c
+++ b/test/cmocka/src/common_mocks.c
@@ -97,6 +97,7 @@ int WEAK rstrlen(const char *s)
 void WEAK __panic(uint32_t p, char *filename, uint32_t linenum)
 {
 	fail_msg("panic: %s:%d (code 0x%x)\n", filename, linenum, p);
+	exit(EXIT_FAILURE);
 }
 
 void WEAK trace_log_filtered(bool send_atomic, const void *log_entry, const struct tr_ctx *ctx,


### PR DESCRIPTION
This change avoids build error:

```
cc1: warnings being treated as errors
sof/test/cmocka/src/common_mocks.c: In function ‘__panic’:
sof/test/cmocka/src/common_mocks.c:100: warning: ‘noreturn’ function does return
```

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>