### PR TITLE
Add basic ipc4 headers

### DIFF
--- a/src/include/ipc4/base-config.h
+++ b/src/include/ipc4/base-config.h
@@ -1,0 +1,134 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2021 Intel Corporation. All rights reserved.
+ */
+
+/*
+ * This file contains structures that are exact copies of an existing ABI used
+ * by IOT middleware. They are Intel specific and will be used by one middleware.
+ *
+ * Some of the structures may contain programming implementations that makes them
+ * unsuitable for generic use and general usage.
+ *
+ * This code is mostly copied "as-is" from existing C++ interface files hence the use of
+ * different style in places. The intention is to keep the interface as close as possible to
+ * original so it's easier to track changes with IPC host code.
+ */
+
+/**
+ * \file include/ipc4/base-config.h
+ * \brief IPC4 global definitions.
+ * NOTE: This ABI uses bit fields and is non portable.
+ */
+
+#ifndef __SOF_IPC4_BASE_CONFIG_H__
+#define __SOF_IPC4_BASE_CONFIG_H__
+
+#include <stdint.h>
+
+enum ipc4_sampling_frequency {
+	IPC4_FS_8000HZ = 8000,
+	IPC4_FS_11025HZ = 11025,
+	IPC4_FS_12000HZ = 12000, /**< Mp3, AAC, SRC only */
+	IPC4_FS_16000HZ = 16000,
+	IPC4_FS_18900HZ = 18900, /**< SRC only for 44100 */
+	IPC4_FS_22050HZ = 22050,
+	IPC4_FS_24000HZ = 24000, /**< Mp3, AAC, SRC only */
+	IPC4_FS_32000HZ = 32000,
+	IPC4_FS_37800HZ = 37800, /**< SRC only for 44100 */
+	IPC4_FS_44100HZ = 44100,
+	IPC4_FS_48000HZ = 48000, /**< Default */
+	IPC4_FS_64000HZ = 64000, /**< AAC, SRC only */
+	IPC4_FS_88200HZ = 88200, /**< AAC, SRC only */
+	IPC4_FS_96000HZ = 96000, /**< AAC, SRC only */
+	IPC4_FS_176400HZ = 176400, /**< SRC only */
+	IPC4_FS_192000HZ = 192000, /**< SRC only */
+	IPC4_FS_INVALID
+};
+
+enum ipc4_bit_depth {
+	IPC4_DEPTH_8BIT	= 8, /**< 8 bits depth */
+	IPC4_DEPTH_16BIT = 16, /**< 16 bits depth */
+	IPC4_DEPTH_24BIT = 24, /**< 24 bits depth - Default */
+	IPC4_DEPTH_32BIT = 32, /**< 32 bits depth */
+	IPC4_DEPTH_64BIT = 64, /**< 64 bits depth */
+	IPC4_DEPTH_INVALID
+};
+
+enum ipc4_channel_config {
+	IPC4_CHANNEL_CONFIG_MONO = 0,		/**< one channel only */
+	IPC4_CHANNEL_CONFIG_STEREO = 1,		/**< L & R */
+	IPC4_CHANNEL_CONFIG_2_POINT_1 = 2,	/**< L, R & LFE; PCM only */
+	IPC4_CHANNEL_CONFIG_3_POINT_0 = 3,	/**< L, C & R; MP3 & AAC only */
+	IPC4_CHANNEL_CONFIG_3_POINT_1 = 4,	/**< L, C, R & LFE; PCM only */
+	IPC4_CHANNEL_CONFIG_QUATRO = 5,		/**< L, R, Ls & Rs; PCM only */
+	IPC4_CHANNEL_CONFIG_4_POINT_0 = 6,	/**< L, C, R & Cs; MP3 & AAC only */
+	IPC4_CHANNEL_CONFIG_5_POINT_0 = 7,	/**< L, C, R, Ls & Rs */
+	IPC4_CHANNEL_CONFIG_5_POINT_1 = 8,	/**< L, C, R, Ls, Rs & LFE */
+	IPC4_CHANNEL_CONFIG_DUAL_MONO = 9,	/**< one channel replicated in two */
+	/**< Stereo (L,R) in 4 slots, 1st stream: [ L, R, -, - ] */
+	IPC4_CHANNEL_CONFIG_I2S_DUAL_STEREO_0 = 10,
+	/**< Stereo (L,R) in 4 slots, 2nd stream: [ -, -, L, R ] */
+	IPC4_CHANNEL_CONFIG_I2S_DUAL_STEREO_1 = 11,
+	IPC4_CHANNEL_CONFIG_7_POINT_1 = 12,	/**< L, C, R, Ls, Rs & LFE., LS, RS */
+	IPC4_CHANNEL_CONFIG_INVALID
+};
+
+enum ipc4_interleaved_style {
+	IPC4_CHANNELS_INTERLEAVED = 0,
+	IPC4_CHANNELS_NONINTERLEAVED = 1,
+};
+
+enum ipc4_sample_type {
+	IPC4_TYPE_MSB_INTEGER = 0,	/**< integer with Most Significant Byte first */
+	IPC4_TYPE_LSB_INTEGER = 1,	/**< integer with Least Significant Byte first */
+	IPC4_TYPE_SIGNED_INTEGER = 2,
+	IPC4_TYPE_UNSIGNED_INTEGER = 3,
+	IPC4_TYPE_FLOAT = 4
+};
+
+enum ipc4_stream_type {
+	IPC4_STREAM_PCM = 0,	/**< PCM stream */
+	IPC4_STREAM_MP3 = 1,	/**< MP3 encoded stream */
+	IPC4_STREAM_AAC = 2,	/**< AAC encoded stream */
+	/* TODO: revisit max stream type count. Currently
+	 * it aligns with windows audio driver and we will
+	 * update all when more types are supported
+	 */
+	IPC4_STREAM_COUNT = 3,
+	IPC4_STREAM_INVALID = 0xFF
+};
+
+struct ipc4_audio_format {
+	enum ipc4_sampling_frequency sampling_frequency;
+	enum ipc4_bit_depth depth;
+	uint32_t ch_map;
+	enum ipc4_channel_config ch_cfg;
+	uint32_t interleaving_style;
+	uint32_t channels_count : 8;
+	uint32_t valid_bit_depth : 8;
+	enum ipc4_sample_type s_type : 8;
+	uint32_t reserved : 8;
+} __attribute__((packed, aligned(4)));
+
+struct ipc4_base_module_cfg {
+	uint32_t cpc;		/**< the max count of Cycles Per Chunk processing */
+	uint32_t ibs;		/**< input Buffer Size (in bytes)  */
+	uint32_t obs;		/**< output Buffer Size (in bytes) */
+	uint32_t is_pages;	/**< number of physical pages used */
+	struct ipc4_audio_format audio_fmt;
+} __attribute__((packed, aligned(4)));
+
+struct ipc4_input_pin_format {
+	uint32_t pin_index;	/**< index of the pin */
+	uint32_t ibs;		/**< specifies input frame size (in bytes) */
+	struct ipc4_audio_format audio_fmt; /**< format of the input data */
+} __attribute__((packed, aligned(4)));
+
+struct ipc4_output_pin_format {
+	uint32_t pin_index;	/**< index of the pin */
+	uint32_t obs;		/**< specifies output frame size (in bytes) */
+	struct ipc4_audio_format audio_fmt; /**< format of the output data */
+} __attribute__((packed, aligned(4)));
+
+#endif

--- a/src/include/ipc4/error_status.h
+++ b/src/include/ipc4/error_status.h
@@ -1,0 +1,129 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2021 Intel Corporation. All rights reserved.
+ */
+
+/*
+ * This file contains structures that are exact copies of an existing ABI used
+ * by IOT middleware. They are Intel specific and will be used by one middleware.
+ *
+ * Some of the structures may contain programming implementations that makes them
+ * unsuitable for generic use and general usage.
+ */
+
+/**
+ * \file include/ipc4/error_status.h
+ * \brief IPC4 global definitions.
+ * NOTE: This ABI uses bit fields and is non portable.
+ */
+
+#ifndef __SOF_IPC4_ERROR_STATUS_H__
+#define __SOF_IPC4_ERROR_STATUS_H__
+
+#define IPC4_IXC_STATUS_BITS	24
+
+enum ipc4_status {
+	/**< The operation was successful */
+	IPC4_SUCCESS = 0,
+
+	/**< Invalid parameter specified */
+	IPC4_ERROR_INVALID_PARAM = 1,
+	/**< Unknown message type specified */
+	IPC4_UNKNOWN_MESSAGE_TYPE = 2,
+	/**< Not enough space in the IPC reply buffer to complete the request */
+	IPC4_OUT_OF_MEMORY = 3,
+
+	/**< The system or resource is busy */
+	IPC4_BUSY = 4,
+	/**< Replaced ADSP IPC PENDING (unused) - according to cAVS v0.5 */
+	IPC4_BAD_STATE = 5,
+	/**< Unknown error while processing the request */
+	IPC4_FAILURE = 6,
+	/**< Unsupported operation requested */
+	IPC4_INVALID_REQUEST = 7,
+
+	/**< Specified resource not found */
+	IPC4_INVALID_RESOURCE_ID = 9,
+	/**< A resource's ID requested to be created is already assigned */
+	IPC4_RESOURCE_ID_EXISTS = 10,
+
+	/**< Required resource is in invalid state */
+	IPC4_INVALID_RESOURCE_STATE = 12,
+
+	/**< Requested power transition failed to complete */
+	IPC4_POWER_TRANSITION_FAILED = 13,
+
+	/**< Manifest of the library being loaded is invalid */
+	IPC4_INVALID_MANIFEST = 14,
+
+	/**< Requested service or data is unavailable on the target platform */
+	IPC4_UNAVAILABLE = 15,
+
+	/* Load/unload library specific codes */
+
+	/**< Library target address is out of storage memory range */
+	IPC4_LOAD_ADDRESS_OUT_OF_RANGE = 42,
+
+	/**< Image verification by CSE failed */
+	IPC4_CSE_VALIDATION_FAILED = 44,
+
+	/**< General module management error */
+	IPC4_MOD_MGMT_ERROR = 100,
+	/**< Module loading failed */
+	IPC4_MOD_LOAD_CL_FAILED = 101,
+	/**< Integrity check of the loaded module content failed */
+	IPC4_MOD_LOAD_INVALID_HASH = 102,
+
+	/**< Attempt to unload code of the module in use */
+	IPC4_MOD_INSTANCE_EXISTS = 103,
+	/**< Other failure of module instance initialization request */
+	IPC4_MOD_NOT_INITIALIZED = 104,
+
+	/**< Invalid (out of range) module ID provided */
+	IPC4_MOD_INVALID_ID  = 110,
+	/**< Invalid module instance ID provided */
+	IPC4_MOD_INST_INVALID_ID  = 111,
+	/**< Invalid queue (pin) ID provided */
+	IPC4_QUEUE_INVALID_ID = 112,
+	/**< Invalid destination queue (pin) ID provided */
+	IPC4_QUEUE_DST_INVALID_ID = 113,
+
+	/**< Invalid target code ID provided */
+	IPC4_INVALID_CORE_ID = 116,
+
+	/**< Injection DMA buffer is too small for probing the input pin */
+	IPC4_PROBE_DMA_INJECTION_BUFFER_TOO_SMALL = 117,
+	/**< Extraction DMA buffer is too small for probing the output pin */
+	IPC4_PROBE_DMA_EXTRACTION_BUFFER_TOO_SMALL = 118,
+
+	/**< Invalid ID of configuration item provided in TLV list */
+	IPC4_INVALID_CONFIG_PARAM_ID = 120,
+	/**< Invalid length of configuration item provided in TLV list */
+	IPC4_INVALID_CONFIG_DATA_LEN = 121,
+	/**< Invalid structure of configuration item provided */
+	IPC4_INVALID_CONFIG_DATA_STRUCT = 122,
+
+	/**< Initialization of DMA Gateway failed */
+	IPC4_GATEWAY_NOT_INITIALIZED = 140,
+	/**< Invalid ID of gateway provided */
+	IPC4_GATEWAY_NOT_EXIST = 141,
+	/**< Setting state of DMA Gateway failed */
+	IPC4_GATEWAY_STATE_NOT_SET = 142,
+	/**< DMA_CONTROL message targeting gateway not allocated yet */
+	IPC4_GATEWAY_NOT_ALLOCATED = 143,
+
+	/**< Attempt to configure SCLK while I2S port is running */
+	IPC4_SCLK_ALREADY_RUNNING = 150,
+	/**< Attempt to configure MCLK while I2S port is running */
+	IPC4_MCLK_ALREADY_RUNNING = 151,
+	/**< Attempt to stop SCLK that is not running */
+	IPC4_NO_RUNNING_SCLK = 152,
+	/**< Attempt to stop MCLK that is not running */
+	IPC4_NO_RUNNING_MCLK = 153,
+
+	/**< Reverted for ULP purposes */
+	IPC4_PIPELINE_STATE_NOT_SET = 164,
+
+	IPC4_MAX_STATUS = ((1 << IPC4_IXC_STATUS_BITS) - 1)
+};
+#endif

--- a/src/include/ipc4/fw_reg.h
+++ b/src/include/ipc4/fw_reg.h
@@ -1,0 +1,132 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2021 Intel Corporation. All rights reserved.
+ */
+
+/*
+ * This file contains structures that are exact copies of an existing ABI used
+ * by IOT middleware. They are Intel specific and will be used by one middleware.
+ *
+ * Some of the structures may contain programming implementations that makes them
+ * unsuitable for generic use and general usage.
+ *
+ * This code is mostly copied "as-is" from existing C++ interface files hence the use of
+ * different style in places. The intention is to keep the interface as close as possible to
+ * original so it's easier to track changes with IPC host code.
+ */
+
+/**
+ * \file include/ipc4/fw_reg.h
+ * \brief IPC4 fw registers in mailbox for host
+ * NOTE: This ABI uses bit fields and is non portable.
+ */
+
+#ifndef __IPC4_FW_REG_H__
+#define __IPC4_FW_REG_H__
+
+#include <stdint.h>
+#include <ipc4/module.h>
+#include <platform/lib/cpu.h>
+#include <platform/lib/dma.h>
+
+struct ipc4_fw_status_reg {
+	uint32_t state      : 28;
+	/* Last module ID updated FSR */
+	uint32_t module     : 3;
+	/* State of DSP core */
+	uint32_t running    : 1;
+} __attribute__((packed, aligned(4)));
+
+typedef uint32_t ipc4_last_error;
+
+struct ipc4_fw_pwr_status {
+	/* currently set astate */
+	uint32_t curr_astate : 4;
+	/* cached IMR usage status for previous D0i3 */
+	uint32_t cached_imr_usage_status  : 1;
+	uint32_t curr_fstate : 3;
+	uint32_t wake_tick_period : 5;
+	uint32_t active_pipelines_count : 6;
+	uint32_t rsvd0 : 13;
+} __attribute__((packed, aligned(4)));
+
+struct ipc4_pipeline_registers {
+	/**
+	 * Stream start offset (LPIB) reported by mixin module allocated on pipeline attached
+	 * to Host Output Gateway when first data is being mixed to mixout module. When data
+	 * is not mixed (right after creation/after reset) value "(uint64_t)-1" is reported.
+	 * In number of bytes.
+	 * */
+	uint64_t stream_start_offset;
+	/**
+	 * Stream end offset (LPIB) reported by mixin module allocated on pipeline attached
+	 * to Host Output Gateway during transition from RUNNING to PAUSED. When data
+	 * is not mixed (right after creation/after reset) value "(uint64_t)-1" is reported. When
+	 * first data is mixed then value "0"is reported.
+	 * In number of bytes.
+	 * */
+	uint64_t stream_end_offset;
+} __attribute__((packed, aligned(8)));
+
+#define IPC4_PV_MAX_SUPPORTED_CHANNELS 8
+struct ipc4_peak_volume_regs {
+	uint32_t peak_meter_[IPC4_PV_MAX_SUPPORTED_CHANNELS];
+	uint32_t current_volume_[IPC4_PV_MAX_SUPPORTED_CHANNELS];
+	uint32_t target_volume_[IPC4_PV_MAX_SUPPORTED_CHANNELS];
+} __attribute__((packed, aligned(4)));
+
+struct ipc4_llp_reading {
+	/* lower part of 64-bit LLP */
+	uint32_t llp_l;
+	/* upper part of 64-bit LLP */
+	uint32_t llp_u;
+	/* lower part of 64-bit Wallclock */
+	uint32_t wclk_l;
+	/* upper part of 64-bit Wallclock */
+	uint32_t wclk_u;
+} __attribute__((packed, aligned(4)));
+
+struct ipc4_llp_reading_slot {
+	uint32_t node_id;
+	struct ipc4_llp_reading reading;
+} __attribute__((packed, aligned(4)));
+
+union ipc4_rom_info {
+	struct {
+		uint32_t fuse_values: 8;
+		uint32_t load_method: 1;
+		uint32_t downlink_IPC_use_DMA: 1;
+		uint32_t load_method_reserved: 2;
+		uint32_t implementation_revision_min: 4;
+		uint32_t implementation_revision_maj: 4;
+		uint32_t implementation_version_min: 4;
+		uint32_t implementation_version_maj: 4;
+		uint32_t reserved : 4;
+	} bits;
+	struct {
+		uint32_t rsvd1: 16;
+		uint32_t type: 12;
+		uint32_t rsvd2: 4;
+	} platform;
+} __attribute__((packed, aligned(4)));
+
+struct ipc4_fw_registers {
+	struct ipc4_fw_status_reg fsr;
+	ipc4_last_error lec;
+	struct ipc4_fw_pwr_status fps;
+	uint32_t mem_status;
+	uint32_t ltr;
+	uint32_t rsvd0;
+	union ipc4_rom_info rom_info;
+	uint32_t rsvd1[5];
+	uint32_t dbg_log_wp[MAX_CORE_COUNT];
+	uint32_t rsvd2[4 - MAX_CORE_COUNT];
+
+	struct ipc4_pipeline_registers pipeline_regs[PLATFORM_MAX_DMA_CHAN];
+	struct ipc4_peak_volume_regs peak_vol_regs[10];
+	struct ipc4_llp_reading_slot llp_gpdma_reading_slots[MAX_GPDMA_COUNT * 8];
+	struct ipc4_llp_reading_slot llp_sndw_reading_slots[MAX_GPDMA_COUNT * 8];
+	uint32_t memory_window_2_slot_desc[IPC4_MAX_SUPPORTED_LIBRARIES];
+} __attribute__((packed, aligned(4)));
+
+#endif

--- a/src/include/ipc4/module.h
+++ b/src/include/ipc4/module.h
@@ -226,7 +226,7 @@ struct ipc4_module_large_config {
 			uint32_t _reserved_2 : 2;
 		} r;
 	} data;
-};
+} __attribute__((packed, aligned(4)));
 
 struct ipc4_module_delete_instance {
 	union {

--- a/src/include/ipc4/module.h
+++ b/src/include/ipc4/module.h
@@ -228,4 +228,31 @@ struct ipc4_module_large_config {
 	} data;
 };
 
+struct ipc4_module_delete_instance {
+	union {
+		uint32_t dat;
+
+		struct {
+			uint32_t module_id : 16;
+			uint32_t instance_id : 8;
+			/**< ModuleMsg::DELETE_INSTANCE */
+			uint32_t type : 5;
+			/**< Msg::MSG_REQUEST */
+			uint32_t rsp : 1;
+			/**< Msg::MODULE_MSG */
+			uint32_t msg_tgt : 1;
+			uint32_t _reserved_0 : 1;
+		} r;
+	} header;
+
+	union {
+		uint32_t dat;
+
+		struct {
+			uint32_t rsvd : 30;
+			uint32_t _reserved_1 : 2;
+		} r;
+	} data;
+} __attribute__((packed, aligned(4)));
+
 #endif

--- a/src/include/ipc4/module.h
+++ b/src/include/ipc4/module.h
@@ -26,6 +26,12 @@
 
 #include <stdint.h>
 
+/* TODO: revisit it. Now it aligns with audio sdk
+ * and we will update this value and sdk when more
+ * libraries are supported
+ */
+#define IPC4_MAX_SUPPORTED_LIBRARIES 16
+
 #define SOF_IPC4_DST_QUEUE_ID_BITFIELD_SIZE	3
 #define SOF_IPC4_SRC_QUEUE_ID_BITFIELD_SIZE	3
 

--- a/src/include/ipc4/notification.h
+++ b/src/include/ipc4/notification.h
@@ -1,0 +1,53 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2021 Intel Corporation. All rights reserved.
+ */
+
+/*
+ * This file contains structures that are exact copies of an existing ABI used
+ * by IOT middleware. They are Intel specific and will be used by one middleware.
+ *
+ * Some of the structures may contain programming implementations that makes them
+ * unsuitable for generic use and general usage.
+ *
+ * This code is mostly copied "as-is" from existing C++ interface files hence the use of
+ * different style in places. The intention is to keep the interface as close as possible to
+ * original so it's easier to track changes with IPC host code.
+ */
+
+/**
+ * \file include/ipc4/notification.h
+ * \brief IPC4 notification definitions
+ */
+
+#ifndef __IPC4_NOTIFICATION_H__
+#define __IPC4_NOTIFICATION_H__
+
+#include <stdint.h>
+#include <ipc4/header.h>
+
+/* ipc4 notification msg */
+enum sof_ipc4_notification_type {
+	SOF_IPC4_NOTIFY_PHRASE_DETECTED		= 4,
+	SOF_IPC4_NOTIFY_RESOURCE_EVENT		= 5,
+	SOF_IPC4_NOTIFY_LOG_BUFFER_STATUS	= 6,
+	SOF_IPC4_NOTIFY_TIMESTAMP_CAPTURED	= 7,
+	SOF_IPC4_NOTIFY_FW_READY		= 8,
+	SOF_IPC4_FW_AUD_CLASS_RESULT		= 9,
+	SOF_IPC4_EXCEPTION_CAUGHT		= 10,
+	SOF_IPC4_MODULE_NOTIFICATION		= 12,
+	SOF_IPC4_UAOL_RSVD_		= 13,
+	SOF_IPC4_PROBE_DATA_AVAILABLE		= 14,
+	SOF_IPC4_WATCHDOG_TIMEOUT		= 15,
+	SOF_IPC4_MANAGEMENT_SERVICE		= 16,
+};
+
+#define SOF_IPC4_GLB_NOTIFY_DIR_MASK		BIT(29)
+#define SOF_IPC4_REPLY_STATUS_MASK		0xFFFFFF
+#define SOF_IPC4_GLB_NOTIFY_TYPE_SHIFT		16
+#define SOF_IPC4_GLB_NOTIFY_MSG_TYPE_SHIFT		24
+
+#define SOF_IPC4_FW_READY \
+		(((SOF_IPC4_NOTIFY_FW_READY) << (SOF_IPC4_GLB_NOTIFY_TYPE_SHIFT)) |\
+		((SOF_IPC4_GLB_NOTIFICATION) << (SOF_IPC4_GLB_NOTIFY_MSG_TYPE_SHIFT)))
+#endif

--- a/src/include/ipc4/pipeline.h
+++ b/src/include/ipc4/pipeline.h
@@ -25,8 +25,7 @@
 #define __SOF_IPC4_PIPELINE_H__
 
 #include <stdint.h>
-
-#define IPC4_IXC_STATUS_BITS		24
+#include <ipc4/error_status.h>
 
 /**< Pipeline priority */
 enum ipc4_pipeline_priority {


### PR DESCRIPTION
IPC4 is another ipc version for intel next platforms. Compared to current ipc3,  the key difference are:
(1) pipeline is composed of module, not component. And also pipeline will manage memory allocation including buffer
(2) there is no buffer defined in topology and FW will create buffer on demand

The pipeline in ipc4 has different operations and states but it can be converted to current ipc3 straight forward. Module interface can also be supported by current component interface.

This patch adds support of ipc4 message and basic pass-though pipeline support on HDA, I2S and ALH.