### PR TITLE
pcm_converter: add ipc4 converter support

### DIFF
--- a/src/audio/Kconfig
+++ b/src/audio/Kconfig
@@ -446,6 +446,27 @@ config PCM_CONVERTER_FORMAT_FLOAT
 	help
 	  Support floating point processing data format
 
+config PCM_CONVERTER_FORMAT_S16_C16_AND_S16_C32
+	bool "Support S16C16 <-> S16C32"
+	default n
+	help
+	  Support conversion between 16 bit valid sample size in 16 bit container
+	  and 16 bit valid sample size in 32 bit container
+
+config PCM_CONVERTER_FORMAT_S16_C32_AND_S32_C32
+	bool "Support S16C32 <-> S32C32"
+	default n
+	help
+	  Support conversion between 16 bit valid sample size in 32 bit container
+	  and 32 bit valid sample size in 32 bit container
+
+config PCM_CONVERTER_FORMAT_S16_C32_AND_S24_C32
+	bool "Support S16C32 <-> S24C32"
+	default n
+	help
+	  Support conversion between 16 bit valid sample size in 32 bit container
+	  and 24 bit valid sample size in 32 bit container
+
 config PCM_CONVERTER_FORMAT_CONVERT_HIFI3
 	bool "HIFI3 optimized conversion"
 	default y

--- a/src/audio/pcm_converter/pcm_converter_generic.c
+++ b/src/audio/pcm_converter/pcm_converter_generic.c
@@ -12,6 +12,7 @@
  */
 
 #include <sof/audio/pcm_converter.h>
+#include <sof/audio/audio_stream.h>
 
 #ifdef PCM_CONVERTER_GENERIC
 
@@ -431,3 +432,139 @@ const struct pcm_func_map pcm_func_map[] = {
 const size_t pcm_func_count = ARRAY_SIZE(pcm_func_map);
 
 #endif
+
+#if CONFIG_PCM_CONVERTER_FORMAT_S16_C16_AND_S16_C32
+static int pcm_convert_s16_c16_to_s16_c32(const struct audio_stream *source,
+					  uint32_t ioffset, struct audio_stream *sink,
+					  uint32_t ooffset, uint32_t samples)
+{
+	uint32_t buff_frag = 0;
+	int16_t *src;
+	int32_t *dst;
+	uint32_t i;
+
+	for (i = 0; i < samples; i++) {
+		src = audio_stream_read_frag_s16(source, buff_frag + ioffset);
+		dst = audio_stream_write_frag_s32(sink, buff_frag + ooffset);
+		*dst = *src;
+		buff_frag++;
+	}
+
+	return samples;
+}
+
+static int pcm_convert_s16_c32_to_s16_c16(const struct audio_stream *source,
+					  uint32_t ioffset, struct audio_stream *sink,
+					  uint32_t ooffset, uint32_t samples)
+{
+	uint32_t buff_frag = 0;
+	int32_t *src;
+	int16_t *dst;
+	uint32_t i;
+
+	for (i = 0; i < samples; i++) {
+		src = audio_stream_read_frag_s32(source, buff_frag + ioffset);
+		dst = audio_stream_write_frag_s16(sink, buff_frag + ooffset);
+		*dst = *src & 0xffff;
+		buff_frag++;
+	}
+
+	return samples;
+}
+#endif
+#if CONFIG_PCM_CONVERTER_FORMAT_S16_C32_AND_S32_C32
+static int pcm_convert_s16_c32_to_s32_c32(const struct audio_stream *source,
+					  uint32_t ioffset, struct audio_stream *sink,
+					  uint32_t ooffset, uint32_t samples)
+{
+	uint32_t buff_frag = 0;
+	int32_t *src, *dst;
+	uint32_t i;
+
+	for (i = 0; i < samples; i++) {
+		src = audio_stream_read_frag_s32(source, buff_frag + ioffset);
+		dst = audio_stream_write_frag_s32(sink, buff_frag + ooffset);
+		*dst = *src << 16;
+		buff_frag++;
+	}
+
+	return samples;
+}
+
+static int pcm_convert_s32_c32_to_s16_c32(const struct audio_stream *source,
+					  uint32_t ioffset, struct audio_stream *sink,
+					  uint32_t ooffset, uint32_t samples)
+{
+	uint32_t buff_frag = 0;
+	int32_t *src, *dst;
+	uint32_t i;
+
+	for (i = 0; i < samples; i++) {
+		src = audio_stream_read_frag_s32(source, buff_frag + ioffset);
+		dst = audio_stream_write_frag_s32(sink, buff_frag + ooffset);
+		*dst = sat_int16(Q_SHIFT_RND(*src, 31, 15));
+		buff_frag++;
+	}
+
+	return samples;
+}
+#endif
+#if CONFIG_PCM_CONVERTER_FORMAT_S16_C32_AND_S24_C32
+static int pcm_convert_s16_c32_to_s24_c32(const struct audio_stream *source,
+					  uint32_t ioffset, struct audio_stream *sink,
+					  uint32_t ooffset, uint32_t samples)
+{
+	uint32_t buff_frag = 0;
+	int32_t *src, *dst;
+	uint32_t i;
+
+	for (i = 0; i < samples; i++) {
+		src = audio_stream_read_frag_s32(source, buff_frag + ioffset);
+		dst = audio_stream_write_frag_s32(sink, buff_frag + ooffset);
+		*dst = *src << 8;
+		buff_frag++;
+	}
+
+	return samples;
+}
+
+static int pcm_convert_s24_c32_to_s16_c32(const struct audio_stream *source,
+					  uint32_t ioffset, struct audio_stream *sink,
+					  uint32_t ooffset, uint32_t samples)
+{
+	uint32_t buff_frag = 0;
+	int32_t *src, *dst;
+	uint32_t i;
+
+	for (i = 0; i < samples; i++) {
+		src = audio_stream_read_frag_s32(source, buff_frag + ioffset);
+		dst = audio_stream_write_frag_s32(sink, buff_frag + ooffset);
+		*dst = sat_int16(Q_SHIFT_RND(sign_extend_s24(*src & 0xffffff), 23, 15));
+		buff_frag++;
+	}
+
+	return samples;
+}
+#endif
+const struct pcm_func_vc_map pcm_func_vc_map[] = {
+#if CONFIG_PCM_CONVERTER_FORMAT_S16_C16_AND_S16_C32
+	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE,
+		pcm_convert_s16_c16_to_s16_c32 },
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S16_LE,
+		pcm_convert_s16_c32_to_s16_c16 },
+#endif
+#if CONFIG_PCM_CONVERTER_FORMAT_S16_C32_AND_S32_C32
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE,
+		pcm_convert_s16_c32_to_s32_c32 },
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE,
+		pcm_convert_s32_c32_to_s16_c32 },
+#endif
+#if CONFIG_PCM_CONVERTER_FORMAT_S16_C32_AND_S24_C32
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE,
+		pcm_convert_s16_c32_to_s24_c32 },
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE,
+		pcm_convert_s24_c32_to_s16_c32 },
+#endif
+};
+
+const size_t pcm_func_vc_count = ARRAY_SIZE(pcm_func_vc_map);

--- a/src/include/sof/audio/pcm_converter.h
+++ b/src/include/sof/audio/pcm_converter.h
@@ -91,6 +91,52 @@ pcm_get_conversion_function(enum sof_ipc_frame in,
 	return NULL;
 }
 
+/** \brief PCM conversion functions mapfor different size of valid bit and container. */
+struct pcm_func_vc_map {
+	enum sof_ipc_frame source;	/**< source frame container format */
+	enum sof_ipc_frame valid_src_bits;	/**< source frame format */
+	enum sof_ipc_frame sink;	/**< sink frame container format */
+	enum sof_ipc_frame valid_sink_bits;	/**< sink frame format */
+	pcm_converter_func func; /**< PCM conversion function */
+};
+
+/** \brief Map of formats with dedicated conversion functions. */
+extern const struct pcm_func_vc_map pcm_func_vc_map[];
+
+/** \brief Number of conversion functions. */
+extern const size_t pcm_func_vc_count;
+
+/**
+ * \brief Retrieves PCM conversion function for different container size.
+ * \param in_bits is source container format.
+ * \param valid_in_bits is source valid sample format.
+ * \param out_bits is sink container format.
+ * \param valid_out_bits is sink valid sample format.
+ */
+static inline pcm_converter_func
+pcm_get_conversion_vc_function(enum sof_ipc_frame in_bits,
+			       enum sof_ipc_frame valid_in_bits,
+			       enum sof_ipc_frame out_bits,
+			       enum sof_ipc_frame valid_out_bits)
+{
+	uint32_t i;
+
+	for (i = 0; i < pcm_func_vc_count; i++) {
+		if (in_bits != pcm_func_vc_map[i].source)
+			continue;
+		if (valid_in_bits != pcm_func_vc_map[i].valid_src_bits)
+			continue;
+		if (out_bits != pcm_func_vc_map[i].sink)
+			continue;
+		if (valid_out_bits != pcm_func_vc_map[i].valid_sink_bits)
+			continue;
+
+		return pcm_func_vc_map[i].func;
+	}
+
+	return NULL;
+}
+
 /**
  * \brief Convert data from circular buffer using converter working on linear
  *	  memory space


### PR DESCRIPTION
Ipc4 pcm converter will check container size and valid sample
size to do format conversion. This patch add general support for
valid sample / container size s16c16 <-> s16c32, s32c32 <-> s16c32
s16c32 <-> s24c32 s24c32 <->s16c32, which are not supported
by sof now.

Signed-off-by: Rander Wang <rander.wang@intel.com>