### PR TITLE
ipc4: add bind & unbind ops for ipc4 module

### DIFF
--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -401,6 +401,20 @@ struct comp_ops {
 	 */
 	int (*dai_ts_get)(struct comp_dev *dev,
 			  struct timestamp_data *tsd);
+
+	/**
+	 * Bind, atomic - used to notify component of bind event.
+	 * @param dev Component device.
+	 * @param data Bind info
+	 */
+	int (*bind)(struct comp_dev *dev, void *data);
+
+	/**
+	 * Unbind, atomic - used to notify component of unbind event.
+	 * @param dev Component device.
+	 * @param data unBind info
+	 */
+	int (*unbind)(struct comp_dev *dev, void *data);
 };
 
 /**

--- a/src/include/sof/audio/component_ext.h
+++ b/src/include/sof/audio/component_ext.h
@@ -391,6 +391,30 @@ static inline struct comp_driver_list *comp_drivers_get(void)
 	return sof_get()->comp_drivers;
 }
 
+static inline int comp_bind(struct comp_dev *dev, void *data)
+{
+	int ret = 0;
+
+	if (dev->drv->ops.bind)
+		ret = dev->drv->ops.bind(dev, data);
+
+	comp_shared_commit(dev);
+
+	return ret;
+}
+
+static inline int comp_unbind(struct comp_dev *dev, void *data)
+{
+	int ret = 0;
+
+	if (dev->drv->ops.unbind)
+		ret = dev->drv->ops.unbind(dev, data);
+
+	comp_shared_commit(dev);
+
+	return ret;
+}
+
 /** @}*/
 
 #endif /* __SOF_AUDIO_COMPONENT_INT_H__ */


### PR DESCRIPTION
In ipc4 each module will be bound to its sink module by pipeline.
This patch add new ops bind & unbind to dispatch these events to
related modules.

Signed-off-by: Rander Wang <rander.wang@intel.com>