### PR TITLE
Reset handler cleanup fixes for audio processing components

### DIFF
--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -47,8 +47,6 @@ struct comp_data {
 	struct fir_state_32x16 fir[PLATFORM_MAX_CHANNELS]; /**< filters state */
 	struct comp_data_blob_handler *model_handler;
 	struct sof_eq_fir_config *config;
-	enum sof_ipc_frame source_format;	/**< source frame format */
-	enum sof_ipc_frame sink_format;		/**< sink frame format */
 	int32_t *fir_delay;			/**< pointer to allocated RAM */
 	size_t fir_delay_size;			/**< allocated size */
 	void (*eq_fir_func)(struct fir_state_32x16 fir[],
@@ -562,11 +560,6 @@ static int eq_fir_prepare(struct comp_dev *dev)
 	sinkb = list_first_item(&dev->bsink_list,
 				struct comp_buffer, source_list);
 
-	/* get source data format */
-	cd->source_format = sourceb->stream.frame_fmt;
-
-	/* get sink data format and period bytes */
-	cd->sink_format = sinkb->stream.frame_fmt;
 	sink_period_bytes = audio_stream_period_bytes(&sinkb->stream,
 						      dev->frames);
 

--- a/src/audio/tdfb/tdfb.c
+++ b/src/audio/tdfb/tdfb.c
@@ -794,6 +794,10 @@ static int tdfb_reset(struct comp_dev *dev)
 	for (i = 0; i < PLATFORM_MAX_CHANNELS; i++)
 		fir_reset(&cd->fir[i]);
 
+	/* Clear in/out buffers */
+	memset(cd->in, 0, TDFB_IN_BUF_LENGTH * sizeof(int32_t));
+	memset(cd->out, 0, TDFB_IN_BUF_LENGTH * sizeof(int32_t));
+
 	comp_set_state(dev, COMP_TRIGGER_RESET);
 	return 0;
 }


### PR DESCRIPTION
The components FIR, IIR, SRC, TDFB, and volume have some state variables those were not treated as required in reset operation description in component.h. This pull request removes some unnecessary state variables from component by converting them to local or adds reset code.

This contributes to issue #4488 .

Edit: I've removed volume component from this PR. The volume state can't be reset in reset() comp op without causing volume levels test to fail.
