### PR TITLE
Tools: Fix topology1 path in Matlab language scripts

### DIFF
--- a/tools/test/audio/process_test.m
+++ b/tools/test/audio/process_test.m
@@ -26,7 +26,7 @@ if nargin < 4
 end
 
 %% Paths
-t.blobpath = '../../topology/m4';
+t.blobpath = '../../topology/topology1/m4';
 plots = 'plots';
 reports = 'reports';
 

--- a/tools/tune/crossover/example_crossover.m
+++ b/tools/tune/crossover/example_crossover.m
@@ -1,7 +1,7 @@
 function example_crossover();
 
 % Set the parameters here
-tplg_fn = "../../topology/m4/crossover_coef_default.m4" % Control Bytes File
+tplg_fn = "../../topology/topology1/m4/crossover_coef_default.m4" % Control Bytes File
 % Use those files with sof-ctl to update the component's configuration
 blob_fn = "../../ctl/crossover_coef.blob" % Blob binary file
 alsa_fn = "../../ctl/crossover_coef.txt" % ALSA CSV format file

--- a/tools/tune/dcblock/example_dcblock.m
+++ b/tools/tune/dcblock/example_dcblock.m
@@ -1,7 +1,7 @@
 function example_dcblock();
 
 % Set the parameters here
-tplg_fn = "../../topology/m4/dcblock_coef_default.m4" % Control Bytes File
+tplg_fn = "../../topology/topology1/m4/dcblock_coef_default.m4" % Control Bytes File
 % Use those files with sof-ctl to update the component's configuration
 blob_fn = "../../ctl/dcblock_coef.blob" % Blob binary file
 alsa_fn = "../../ctl/dcblock_coef.txt" % ALSA CSV format file

--- a/tools/tune/drc/example_drc.m
+++ b/tools/tune/drc/example_drc.m
@@ -1,7 +1,7 @@
 function example_drc();
 
 % Set the parameters here
-tplg_fn = "../../topology/m4/drc_coef_default.m4"; % Control Bytes File
+tplg_fn = "../../topology/topology1/m4/drc_coef_default.m4"; % Control Bytes File
 % Use those files with sof-ctl to update the component's configuration
 blob_fn = "../../ctl/drc_coef.blob"; % Blob binary file
 alsa_fn = "../../ctl/drc_coef.txt"; % ALSA CSV format file

--- a/tools/tune/eq/example_fir_eq.m
+++ b/tools/tune/eq/example_fir_eq.m
@@ -10,7 +10,7 @@ function example_fir_eq()
 
 %% Common definitions
 fs = 48e3;
-tpath =  '../../topology/m4';
+tpath =  '../../topology/topology1/m4';
 cpath = '../../ctl';
 priv = 'DEF_EQFIR_PRIV';
 

--- a/tools/tune/eq/example_iir_eq.m
+++ b/tools/tune/eq/example_iir_eq.m
@@ -10,7 +10,7 @@ function example_iir_eq()
 
 %% Common definitions
 fs = 48e3;
-tpath =  '../../topology/m4';
+tpath =  '../../topology/topology1/m4';
 cpath = '../../ctl';
 priv = 'DEF_EQIIR_PRIV';
 

--- a/tools/tune/eq/example_spk_eq.m
+++ b/tools/tune/eq/example_spk_eq.m
@@ -15,7 +15,7 @@ function example_spk_eq()
 
 %% Defaults
 fs = 48e3;
-tpath =  '../../topology/m4';
+tpath =  '../../topology/topology1/m4';
 cpath = '../../ctl';
 iir_priv = 'DEF_EQIIR_PRIV';
 fir_priv = 'DEF_EQFIR_PRIV';

--- a/tools/tune/multiband_drc/example_multiband_drc.m
+++ b/tools/tune/multiband_drc/example_multiband_drc.m
@@ -1,7 +1,7 @@
 function example_multiband_drc();
 
 % Set the parameters here
-tplg_fn = "../../topology/m4/multiband_drc_coef_default.m4"; % Control Bytes File
+tplg_fn = "../../topology/topology1/m4/multiband_drc_coef_default.m4"; % Control Bytes File
 % Use those files with sof-ctl to update the component's configuration
 blob_fn = "../../ctl/multiband_drc_coef.blob"; % Blob binary file
 alsa_fn = "../../ctl/multiband_drc_coef.txt"; % ALSA CSV format file


### PR DESCRIPTION
The change for topology1 was missing from various tuning
and testing scripts those access binary blob data from
topology m4 directories.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>