### PR TITLE
Ipc4 : add alh & i2s blob support

### DIFF
--- a/src/drivers/intel/alh.c
+++ b/src/drivers/intel/alh.c
@@ -16,6 +16,7 @@
 #include <ipc/topology.h>
 #include <user/trace.h>
 #include <stdint.h>
+#include <ipc4/alh.h>
 
 /* a8e4218c-e863-4c93-84e7-5c27d2504501 */
 DECLARE_SOF_UUID("alh-dai", alh_uuid, 0xa8e4218c, 0xe863, 0x4c93,
@@ -30,23 +31,49 @@ static int alh_trigger(struct dai *dai, int cmd, int direction)
 	return 0;
 }
 
-static int alh_set_config(struct dai *dai, struct ipc_config_dai *common_config,
-			  void *spec_config)
+static int alh_set_config_tplg(struct dai *dai, struct ipc_config_dai *common_config,
+			       void *spec_config)
 {
 	struct alh_pdata *alh = dai_get_drvdata(dai);
 	struct sof_ipc_dai_config *config = spec_config;
 
-	dai_info(dai, "alh_set_config() config->format = 0x%4x",
-		  config->format);
+	dai_info(dai, "alh_set_config_tplg() config->format = 0x%4x", config->format);
 
 	if (config->alh.channels || config->alh.rate) {
 		alh->params.channels = config->alh.channels;
 		alh->params.rate = config->alh.rate;
+		dai_info(dai, "alh_set_config() channels %d rate %d",
+			 config->alh.channels, config->alh.rate);
 	}
 
 	alh->params.stream_id = config->alh.stream_id;
 
 	return 0;
+}
+
+static int alh_set_config_blob(struct dai *dai, struct ipc_config_dai *common_config,
+			       void *spec_config)
+{
+	struct alh_pdata *alh = dai_get_drvdata(dai);
+	struct sof_alh_configuration_blob *blob = spec_config;
+	struct ipc4_alh_multi_gtw_cfg *alh_cfg = &blob->alh_cfg;
+
+	dai_info(dai, "alh_set_config_blob()");
+
+	alh->params.channels = 2;
+	alh->params.rate = 48000;
+	alh->params.stream_id = alh_cfg->mapping[0].alh_id & 0xf;
+
+	return 0;
+}
+
+static int alh_set_config(struct dai *dai, struct ipc_config_dai *common_config,
+			  void *spec_config)
+{
+	if (!common_config->is_config_blob)
+		return alh_set_config_tplg(dai, common_config, spec_config);
+	else
+		return alh_set_config_blob(dai, common_config, spec_config);
 }
 
 /* get ALH hw params */

--- a/src/drivers/intel/ssp/mn.c
+++ b/src/drivers/intel/ssp/mn.c
@@ -270,6 +270,14 @@ out:
 	return ret;
 }
 
+int mn_set_mclk_blob(uint32_t mdivc, uint32_t mdivr)
+{
+	mn_reg_write(MN_MDIVCTRL, 0, mdivc);
+	mn_reg_write(MN_MDIVR(0), 0, mdivr);
+
+	return 0;
+}
+
 void mn_release_mclk(uint32_t mclk_id)
 {
 	struct mn *mn = mn_get();

--- a/src/drivers/intel/ssp/ssp.c
+++ b/src/drivers/intel/ssp/ssp.c
@@ -26,6 +26,7 @@
 #include <ipc/dai-intel.h>
 #include <ipc/stream.h>
 #include <ipc/topology.h>
+#include <ipc4/ssp.h>
 #include <user/trace.h>
 
 #include <errno.h>
@@ -232,8 +233,8 @@ static void ssp_bclk_disable_unprepare(struct dai *dai)
 }
 
 /* Digital Audio interface formatting */
-static int ssp_set_config(struct dai *dai, struct ipc_config_dai *common_config,
-			  void *spec_config)
+static int ssp_set_config_tplg(struct dai *dai, struct ipc_config_dai *common_config,
+			       void *spec_config)
 {
 	struct ssp_pdata *ssp = dai_get_drvdata(dai);
 	struct sof_ipc_dai_config *config = spec_config;
@@ -785,6 +786,81 @@ out:
 	spin_unlock(&dai->lock);
 
 	return ret;
+}
+
+static int ssp_set_config_blob(struct dai *dai, struct ipc_config_dai *common_config,
+			       void *spec_config)
+{
+	struct ipc4_ssp_configuration_blob *blob = spec_config;
+	struct ssp_pdata *ssp = dai_get_drvdata(dai);
+	uint32_t ssc0, sstsa, ssrsa;
+
+	/* set config only once for playback or capture */
+	if (dai->sref > 1)
+		return 0;
+
+	ssc0 = blob->i2s_driver_config.i2s_config.ssc0;
+	sstsa = blob->i2s_driver_config.i2s_config.sstsa;
+	ssrsa = blob->i2s_driver_config.i2s_config.ssrsa;
+
+	ssp_write(dai, SSCR0, ssc0);
+	ssp_write(dai, SSCR1, blob->i2s_driver_config.i2s_config.ssc1);
+	ssp_write(dai, SSCR2, blob->i2s_driver_config.i2s_config.ssc2);
+	ssp_write(dai, SSCR3, blob->i2s_driver_config.i2s_config.ssc3);
+	ssp_write(dai, SSPSP, blob->i2s_driver_config.i2s_config.sspsp);
+	ssp_write(dai, SSPSP2, blob->i2s_driver_config.i2s_config.sspsp2);
+	ssp_write(dai, SSIOC, blob->i2s_driver_config.i2s_config.ssioc);
+	ssp_write(dai, SSTO, blob->i2s_driver_config.i2s_config.sscto);
+	ssp_write(dai, SSTSA, sstsa);
+	ssp_write(dai, SSRSA, ssrsa);
+
+	dai_info(dai, "ssp_set_config(), sscr0 = 0x%08x, sscr1 = 0x%08x, ssto = 0x%08x, sspsp = 0x%0x",
+		 ssc0, blob->i2s_driver_config.i2s_config.ssc1,
+		 blob->i2s_driver_config.i2s_config.sscto,
+		 blob->i2s_driver_config.i2s_config.sspsp);
+	dai_info(dai, "ssp_set_config(), sscr2 = 0x%08x, sspsp2 = 0x%08x, sscr3 = 0x%08x",
+		 blob->i2s_driver_config.i2s_config.ssc2, blob->i2s_driver_config.i2s_config.sspsp2,
+		 blob->i2s_driver_config.i2s_config.ssc3);
+	dai_err(dai, "ssp_set_config(), ssioc = 0x%08x, ssrsa = 0x%08x, sstsa = 0x%08x",
+		blob->i2s_driver_config.i2s_config.ssioc, ssrsa, sstsa);
+
+	ssp->config.ssp.sample_valid_bits = SSCR0_DSIZE_GET(ssc0);
+	if (ssc0 & SSCR0_EDSS)
+		ssp->config.ssp.sample_valid_bits += 16;
+
+	ssp->config.ssp.tdm_slots = SSCR0_FRDC_GET(ssc0);
+	ssp->config.ssp.tx_slots = SSTSA_GET(sstsa);
+	ssp->config.ssp.rx_slots = SSRSA_GET(ssrsa);
+	ssp->config.ssp.fsync_rate = 48000;
+	ssp->params = ssp->config.ssp;
+
+	ssp->state[DAI_DIR_PLAYBACK] = COMP_STATE_PREPARE;
+	ssp->state[DAI_DIR_CAPTURE] = COMP_STATE_PREPARE;
+
+	/* ssp blob is set by pcm_hw_params for ipc4 stream, so enable
+	 * mclk and bclk at this time.
+	 */
+	mn_set_mclk_blob(blob->i2s_driver_config.mclk_config.mdivc,
+			 blob->i2s_driver_config.mclk_config.mdivr);
+	ssp->clk_active |= SSP_CLK_MCLK_ES_REQ;
+
+	/* enable TRSE/RSRE before SSE */
+	ssp_update_bits(dai, SSCR1, SSCR1_TSRE | SSCR1_RSRE, SSCR1_TSRE | SSCR1_RSRE);
+
+	/* enable port */
+	ssp_update_bits(dai, SSCR0, SSCR0_SSE, SSCR0_SSE);
+	ssp->clk_active |= SSP_CLK_BCLK_ES_REQ;
+
+	return 0;
+}
+
+static int ssp_set_config(struct dai *dai, struct ipc_config_dai *common_config,
+			  void *spec_config)
+{
+	if (!common_config->is_config_blob)
+		return ssp_set_config_tplg(dai, common_config, spec_config);
+	else
+		return ssp_set_config_blob(dai, common_config, spec_config);
 }
 
 /*

--- a/src/include/ipc4/alh.h
+++ b/src/include/ipc4/alh.h
@@ -1,0 +1,50 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2021 Intel Corporation. All rights reserved.
+ */
+
+/*
+ * This file contains structures that are exact copies of an existing ABI used
+ * by IOT middleware. They are Intel specific and will be used by one middleware.
+ *
+ * Some of the structures may contain programming implementations that makes them
+ * unsuitable for generic use and general usage.
+ *
+ * This code is mostly copied "as-is" from existing C++ interface files hence the use of
+ * different style in places. The intention is to keep the interface as close as possible to
+ * original so it's easier to track changes with IPC host code.
+ */
+
+/**
+ * \file include/ipc4/alh.h
+ * \brief IPC4 global definitions.
+ * NOTE: This ABI uses bit fields and is non portable.
+ */
+
+#ifndef __SOF_IPC4_ALH_H__
+#define __SOF_IPC4_ALH_H__
+
+#include <stdint.h>
+#include <ipc4/gateway.h>
+
+#define IPC4_ALH_MAX_NUMBER_OF_GTW 16
+#define IPC4_ALH_DAI_INDEX_OFFSET 7
+
+struct ipc4_alh_multi_gtw_cfg {
+	/* Number of single channels (valid items in mapping array). */
+	uint32_t count;
+	/* Single to multi aggregation mapping item. */
+	struct {
+		/* Vindex of a single ALH channel aggregated. */
+		uint32_t alh_id;
+		/* Channel mask */
+		uint32_t channel_mask;
+	} mapping[IPC4_ALH_MAX_NUMBER_OF_GTW]; /* < Mapping items */
+} __attribute__((packed, aligned(4)));
+
+struct sof_alh_configuration_blob {
+	union ipc4_gateway_attributes gtw_attributes;
+	struct ipc4_alh_multi_gtw_cfg alh_cfg;
+} __attribute__((packed, aligned(4)));
+
+#endif

--- a/src/include/ipc4/ssp.h
+++ b/src/include/ipc4/ssp.h
@@ -1,0 +1,118 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2021 Intel Corporation. All rights reserved.
+ */
+
+/*
+ * This file contains structures that are exact copies of an existing ABI used
+ * by IOT middleware. They are Intel specific and will be used by one middleware.
+ *
+ * Some of the structures may contain programming implementations that makes them
+ * unsuitable for generic use and general usage.
+ */
+
+/**
+ * \file include/ipc4/ssp.h
+ * \brief IPC4 global definitions.
+ * NOTE: This ABI uses bit fields and is non portable.
+ */
+
+#ifndef __SOF_IPC4_SSP_H__
+#define __SOF_IPC4_SSP_H__
+
+#include <stdint.h>
+#include <ipc4/gateway.h>
+
+#define I2S_TDM_INVALID_SLOT_MAP1 0xF
+#define I2S_TDM_MAX_CHANNEL_COUNT 8
+#define I2S_TDM_MAX_SLOT_MAP_COUNT 8
+
+/* i2s Configuration BLOB building blocks */
+
+/* i2s registers for i2s Configuration */
+struct ipc4_ssp_config {
+	uint32_t ssc0;
+	uint32_t ssc1;
+	uint32_t sscto;
+	uint32_t sspsp;
+	uint32_t sstsa;
+	uint32_t ssrsa;
+	uint32_t ssc2;
+	uint32_t sspsp2;
+	uint32_t ssc3;
+	uint32_t ssioc;
+} __attribute__((packed, aligned(4)));
+
+struct ipc4_ssp_mclk_config {
+	/* master clock divider control register */
+	uint32_t mdivc;
+
+	/* master clock divider ratio register */
+	uint32_t mdivr;
+} __attribute__((packed, aligned(4)));
+
+struct ipc4_ssp_driver_config {
+	struct ipc4_ssp_config i2s_config;
+	struct ipc4_ssp_mclk_config mclk_config;
+} __attribute__((packed, aligned(4)));
+
+struct ipc4_ssp_start_control {
+	/* delay in msec between enabling interface (moment when
+	 * Copier instance is being attached to the interface) and actual
+	 * interface start. Value of 0 means no delay.
+	 */
+	uint32_t clock_warm_up    : 16;
+
+	/* specifies if parameters target MCLK (1) or SCLK (0) */
+	uint32_t mclk             : 1;
+
+	/* value of 1 means that clock should be started immediately
+	 * even if no Copier instance is currently attached to the interface.
+	 */
+	uint32_t warm_up_ovr      : 1;
+	uint32_t rsvd0            : 14;
+} __attribute__((packed, aligned(4)));
+
+struct ipc4_ssp_stop_control {
+	/* delay in msec between stopping the interface
+	 * (moment when Copier instance is being detached from the interface)
+	 * and interface clock stop. Value of 0 means no delay.
+	 */
+	uint32_t clock_stop_delay : 16;
+
+	/* value of 1 means that clock should be kept running (infinite
+	 * stop delay) after Copier instance detaches from the interface.
+	 */
+	uint32_t keep_running     : 1;
+
+	/* value of 1 means that clock should be stopped immediately */
+	uint32_t clock_stop_ovr   : 1;
+	uint32_t rsvd1            : 14;
+} __attribute__((packed, aligned(4)));
+
+union ipc4_ssp_dma_control {
+	struct ipc4_ssp_control {
+		struct ipc4_ssp_start_control start_control;
+		struct ipc4_ssp_stop_control stop_control;
+	} control_data;
+
+	struct ipc4_mn_div_config {
+		uint32_t mval;
+		uint32_t nval;
+	} mndiv_control_data;
+} __attribute__((packed, aligned(4)));
+
+struct ipc4_ssp_configuration_blob {
+	union ipc4_gateway_attributes gw_attr;
+
+	/* TDM time slot mappings */
+	uint32_t tdm_ts_group[I2S_TDM_MAX_SLOT_MAP_COUNT];
+
+	/* i2s port configuration */
+	struct ipc4_ssp_driver_config i2s_driver_config;
+
+	/* optional configuration parameters */
+	union ipc4_ssp_dma_control i2s_dma_control[0];
+} __attribute__((packed, aligned(4)));
+
+#endif

--- a/src/include/sof/drivers/mn.h
+++ b/src/include/sof/drivers/mn.h
@@ -32,6 +32,14 @@ void mn_init(struct sof *sof);
 int mn_set_mclk(uint16_t mclk_id, uint32_t mclk_rate);
 
 /**
+ * \brief set mclk according to blob setting
+ * \param[in] mdivc mclk control setting.
+ * \param[in] mdivr mclk divider setting.
+ * \return 0 on success otherwise a negative error code.
+ */
+int mn_set_mclk_blob(uint32_t mdivc, uint32_t mdivr);
+
+/**
  * \brief Release previously requested MCLK for given MCLK ID.
  * \param[in] mclk_id id of main clock.
  */

--- a/src/include/sof/drivers/ssp.h
+++ b/src/include/sof/drivers/ssp.h
@@ -51,6 +51,7 @@ extern const struct dai_driver ssp_driver;
 
 /* SSCR0 bits */
 #define SSCR0_DSIZE(x)	SET_BITS(3, 0, (x) - 1)
+#define SSCR0_DSIZE_GET(x)	(((x) & MASK(3, 0)) + 1)
 #define SSCR0_FRF	MASK(5, 4)
 #define SSCR0_MOT	SET_BITS(5, 4, 0)
 #define SSCR0_TI	SET_BITS(5, 4, 1)
@@ -65,6 +66,7 @@ extern const struct dai_driver ssp_driver;
 #define SSCR0_RIM	BIT(22)
 #define SSCR0_TIM	BIT(23)
 #define SSCR0_FRDC(x)	SET_BITS(26, 24, (x) - 1)
+#define SSCR0_FRDC_GET(x) ((((x) & MASK(26, 24)) >> 24) + 1)
 #define SSCR0_ACS	BIT(30)
 #define SSCR0_MOD	BIT(31)
 
@@ -155,10 +157,12 @@ extern const struct dai_driver ssp_driver;
 
 /* SSTSA bits */
 #define SSTSA_SSTSA(x)		SET_BITS(7, 0, x)
+#define SSTSA_GET(x)		((x) & MASK(7, 0))
 #define SSTSA_TXEN		BIT(8)
 
 /* SSRSA bits */
 #define SSRSA_SSRSA(x)		SET_BITS(7, 0, x)
+#define SSRSA_GET(x)		((x) & MASK(7, 0))
 #define SSRSA_RXEN		BIT(8)
 
 /* SSCR3 bits */

--- a/src/ipc/CMakeLists.txt
+++ b/src/ipc/CMakeLists.txt
@@ -2,6 +2,8 @@
 
 if (CONFIG_IPC_MAJOR_3)
 	add_subdirectory(ipc3)
+elseif (CONFIG_IPC_MAJOR_4)
+        add_subdirectory(ipc4)
 endif()
 
 add_local_sources(sof

--- a/src/ipc/ipc4/CMakeLists.txt
+++ b/src/ipc/ipc4/CMakeLists.txt
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+add_local_sources(sof
+	dai.c
+)

--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2021 Intel Corporation. All rights reserved.
+//
+// Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
+// Author: Rander Wang <rander.wang@linux.intel.com>
+
+#include <sof/audio/buffer.h>
+#include <sof/audio/component_ext.h>
+#include <sof/audio/ipc-config.h>
+#include <sof/common.h>
+#include <sof/drivers/alh.h>
+#include <sof/drivers/idc.h>
+#include <sof/lib/alloc.h>
+#include <sof/lib/dai.h>
+#include <sof/platform.h>
+#include <sof/sof.h>
+#include <ipc4/gateway.h>
+#include <ipc4/header.h>
+#include <ipc4/alh.h>
+#include <ipc4/ssp.h>
+#include <ipc4/copier.h>
+#include <ipc/dai.h>
+#include <errno.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+int dai_config_dma_channel(struct comp_dev *dev, void *spec_config)
+{
+	struct ipc4_copier_module_cfg *copier_cfg = spec_config;
+	union ipc4_connector_node_id node;
+	struct dai_data *dd = comp_get_drvdata(dev);
+	struct ipc_config_dai *dai = &dd->ipc_config;
+	int channel;
+
+	switch (dai->type) {
+	case SOF_DAI_INTEL_SSP:
+		COMPILER_FALLTHROUGH;
+	case SOF_DAI_INTEL_DMIC:
+		channel = 0;
+		break;
+	case SOF_DAI_INTEL_HDA:
+		node.dw = copier_cfg->gtw_cfg.node_id;
+		channel = node.f.v_index;
+		break;
+	case SOF_DAI_INTEL_ALH:
+		/* As with HDA, the DMA channel is assigned in runtime,
+		 * not during topology parsing.
+		 */
+		channel = 0;
+		break;
+	default:
+		/* other types of DAIs not handled for now */
+		comp_err(dev, "dai_config_dma_channel(): Unknown dai type %d", dai->type);
+		channel = DMA_CHAN_INVALID;
+		break;
+	}
+
+	return channel;
+}
+
+int ipc_dai_data_config(struct comp_dev *dev)
+{
+	struct dai_data *dd = comp_get_drvdata(dev);
+	struct ipc_config_dai *dai = &dd->ipc_config;
+	struct ipc4_copier_module_cfg *copier_cfg;
+	struct dai *dai_p = dd->dai;
+	struct alh_pdata *alh;
+
+	if (!dai) {
+		comp_err(dev, "dai_data_config(): no config set for dai %d type %d",
+			 dai->dai_index, dai->type);
+		return -EINVAL;
+	}
+
+	comp_info(dev, "dai_data_config() dai type = %d index = %d dd %p",
+		  dai->type, dai->dai_index, dd);
+
+	/* cannot configure DAI while active */
+	if (dev->state == COMP_STATE_ACTIVE) {
+		comp_info(dev, "dai_data_config(): Component is in active state.");
+		return 0;
+	}
+
+	switch (dai->type) {
+	case SOF_DAI_INTEL_SSP:
+		copier_cfg = dd->dai_spec_config;
+		/* set dma burst elems to slot number */
+		dd->config.burst_elems = copier_cfg->base.audio_fmt.channels_count;
+		break;
+	case SOF_DAI_INTEL_DMIC:
+		/* We can use always the largest burst length. */
+		dd->config.burst_elems = 8;
+		break;
+	case SOF_DAI_INTEL_HDA:
+		break;
+	case SOF_DAI_INTEL_ALH:
+		alh = dai_get_drvdata(dai_p);
+		/* SDW HW FIFO always requires 32bit MSB aligned sample data for
+		 * all formats, such as 8/16/24/32 bits.
+		 */
+		dev->ipc_config.frame_fmt = SOF_IPC_FRAME_S32_LE;
+		dd->dma_buffer->stream.frame_fmt = dev->ipc_config.frame_fmt;
+
+		dd->config.burst_elems =
+			dd->dai->plat_data.fifo[dai->direction].depth;
+
+		/* As with HDA, the DMA channel is assigned in runtime,
+		 * not during topology parsing.
+		 */
+		dd->stream_id = alh->params.stream_id;
+
+		comp_dbg(dev, "dai_data_config() SOF_DAI_INTEL_ALH dd->dma_buffer->stream.frame_fmt %#x stream_id %d",
+			 dd->dma_buffer->stream.frame_fmt, dd->stream_id);
+		break;
+	default:
+		/* other types of DAIs not handled for now */
+		comp_warn(dev, "dai_data_config(): Unknown dai type %d", dai->type);
+		return -EINVAL;
+	}
+
+	/* some DAIs may not need extra config */
+	return 0;
+}
+
+/* dai config is not sent by ipc message */
+int ipc_comp_dai_config(struct ipc *ipc, struct ipc_config_dai *common_config,
+			void *spec_config)
+{
+	return 0;
+}
+
+int dai_config(struct comp_dev *dev, struct ipc_config_dai *common_config,
+	       void *spec_config)
+{
+	struct ipc4_copier_module_cfg *copier_cfg = spec_config;
+	struct dai_data *dd = comp_get_drvdata(dev);
+	int size;
+	int ret = 0;
+
+	/* ignore if message not for this DAI id/type */
+	if (dd->ipc_config.dai_index != common_config->dai_index ||
+	    dd->ipc_config.type != common_config->type)
+		return 0;
+
+	comp_info(dev, "dai_config() dai type = %d index = %d dd %p",
+		  common_config->type, common_config->dai_index, dd);
+
+	/* cannot configure DAI while active */
+	if (dev->state == COMP_STATE_ACTIVE) {
+		comp_info(dev, "dai_config(): Component is in active state. Ignore config");
+		return 0;
+	}
+
+	if (dd->chan) {
+		comp_info(dev, "dai_config(): Configured. dma channel index %d, ignore...",
+			  dd->chan->index);
+		return 0;
+	}
+
+	if (common_config->group_id) {
+		ret = dai_assign_group(dev, common_config->group_id);
+
+		if (ret)
+			return ret;
+	}
+
+	/* do nothing for asking for channel free, for compatibility. */
+	if (dai_config_dma_channel(dev, spec_config) == DMA_CHAN_INVALID)
+		return 0;
+
+	/* allocated dai_config if not yet */
+	if (!dd->dai_spec_config) {
+		size = sizeof(*copier_cfg);
+		dd->dai_spec_config = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM, size);
+		if (!dd->dai_spec_config) {
+			comp_err(dev, "dai_config(): No memory for dai_config size %d", size);
+			return -ENOMEM;
+		}
+
+		ret = memcpy_s(dd->dai_spec_config, size, copier_cfg, size);
+		if (ret < 0) {
+			rfree(dd->dai_spec_config);
+			dd->dai_spec_config = NULL;
+		}
+	}
+
+	return dai_set_config(dd->dai, common_config, copier_cfg->gtw_cfg.config_data);
+}


### PR DESCRIPTION
This PR adds support of alh & i2s blob support for IPC4.  IPC4 is a next ipc version of intel platforms.