### PR TITLE
Fixes for SOF with Zephyr on i.MX

### DIFF
--- a/scripts/xtensa-build-zephyr.sh
+++ b/scripts/xtensa-build-zephyr.sh
@@ -114,6 +114,10 @@ build()
 				PLAT_CONFIG='intel_adsp_cavs25'
 				RIMAGE_KEY=modules/audio/sof/keys/otc_private_key_3k.pem
 				;;
+			imx8)
+				PLAT_CONFIG='nxp_adsp_imx8'
+				RIMAGE_KEY='' # no key needed for imx8
+				;;
 			*)
 				echo "Unsupported platform: $platform"
 				exit 1

--- a/src/drivers/imx/interrupt-irqsteer.c
+++ b/src/drivers/imx/interrupt-irqsteer.c
@@ -95,6 +95,10 @@ DECLARE_TR_CTX(irq_i_tr, SOF_UUID(irq_imx_uuid), LOG_LEVEL_INFO);
 #define IRQSTR_INT_BIT(irq)		((irq) % 32)
 #define IRQSTR_INT_MASK(irq)		(1 << IRQSTR_INT_BIT(irq))
 
+#if defined(__ZEPHYR__)
+#define interrupt_get_irq mux_interrupt_get_irq
+#endif
+
 /* HW register access helper methods */
 
 static inline void irqstr_write(uint32_t reg, uint32_t value)

--- a/src/include/sof/drivers/interrupt.h
+++ b/src/include/sof/drivers/interrupt.h
@@ -119,6 +119,17 @@ static inline struct cascade_root *cascade_root_get(void)
 	return sof_get()->cascade_root;
 }
 
+/* For i.MX, while building SOF with Zephyr use the interrupt_*
+ * functions from second level interrupt handling and IRQ_STEER.
+ */
+#if defined(__ZEPHYR__) && defined(CONFIG_IMX)
+int mux_interrupt_get_irq(unsigned int irq, const char *cascade);
+int mux_interrupt_register(uint32_t irq, void(*handler)(void *arg), void *arg);
+void mux_interrupt_unregister(uint32_t irq, const void *arg);
+uint32_t mux_interrupt_enable(uint32_t irq, void *arg);
+uint32_t mux_interrupt_disable(uint32_t irq, void *arg);
+#endif
+
 int interrupt_register(uint32_t irq, void(*handler)(void *arg), void *arg);
 void interrupt_unregister(uint32_t irq, const void *arg);
 uint32_t interrupt_enable(uint32_t irq, void *arg);

--- a/src/include/sof/schedule/ll_schedule.h
+++ b/src/include/sof/schedule/ll_schedule.h
@@ -34,7 +34,7 @@ struct ll_task_pdata {
 	uint16_t skip_cnt;	/**< how many times the task was skipped for execution */
 };
 
-#ifndef __ZEPHYR__
+#if !defined(__ZEPHYR__) || defined(CONFIG_IMX)
 int scheduler_init_ll(struct ll_schedule_domain *domain);
 
 int schedule_task_init_ll(struct task *task,

--- a/src/platform/imx8/platform.c
+++ b/src/platform/imx8/platform.c
@@ -156,6 +156,11 @@ int platform_init(struct sof *sof)
 	sof->platform_timer = &timer;
 	sof->cpu_timers = &timer;
 
+#ifdef __ZEPHYR__
+	/* initialize cascade interrupts before any usage */
+	interrupt_init(sof);
+#endif
+
 	platform_interrupt_init();
 	platform_clock_init(sof);
 	scheduler_init_edf();

--- a/src/schedule/dma_multi_chan_domain.c
+++ b/src/schedule/dma_multi_chan_domain.c
@@ -23,6 +23,21 @@
 #include <stddef.h>
 #include <stdint.h>
 
+/* For i.MX, when building SOF with Zephyr, we use wrapper.c,
+ * interrupt.c and interrupt-irqsteer.c which causes name
+ * collisions.
+ * In order to avoid this and make any second level interrupt
+ * handling go through interrupt-irqsteer.c define macros to
+ * rename the duplicated functions.
+ */
+#if defined(__ZEPHYR__) && defined(CONFIG_IMX)
+#define interrupt_get_irq mux_interrupt_get_irq
+#define interrupt_register mux_interrupt_register
+#define interrupt_unregister mux_interrupt_unregister
+#define interrupt_enable mux_interrupt_enable
+#define interrupt_disable mux_interrupt_disable
+#endif
+
 struct dma_domain_data {
 	int irq;
 	struct pipeline_task *task;

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -430,6 +430,11 @@ if (CONFIG_SOC_SERIES_NXP_IMX8)
 		${SOF_PLATFORM_PATH}/imx8/lib/memory.c
 	)
 
+	# SOF core infrastructure - runs on top of Zephyr
+	zephyr_library_sources(
+		${SOF_SRC_PATH}/schedule/ll_schedule.c
+	)
+
 	set(PLATFORM "imx8")
 endif()
 

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -419,6 +419,7 @@ if (CONFIG_SOC_SERIES_NXP_IMX8)
 		${SOF_DRIVERS_PATH}/imx/sai.c
 		${SOF_DRIVERS_PATH}/imx/ipc.c
 		${SOF_DRIVERS_PATH}/imx/esai.c
+		${SOF_DRIVERS_PATH}/imx/interrupt-irqsteer.c
 	)
 
 	# Platform sources
@@ -433,6 +434,7 @@ if (CONFIG_SOC_SERIES_NXP_IMX8)
 	# SOF core infrastructure - runs on top of Zephyr
 	zephyr_library_sources(
 		${SOF_SRC_PATH}/schedule/ll_schedule.c
+		${SOF_SRC_PATH}/drivers/interrupt.c
 	)
 
 	set(PLATFORM "imx8")

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -113,6 +113,11 @@ if (CONFIG_SOC_SERIES_INTEL_ADSP_BAYTRAIL)
 		${SOF_SRC_PATH}/schedule/dma_multi_chan_domain.c
 	)
 
+	# SOF core infrastructure - runs on top of Zephyr
+	zephyr_library_sources(
+		${SOF_SRC_PATH}/schedule/ll_schedule.c
+	)
+
 	set(PLATFORM "baytrail")
 endif()
 
@@ -121,6 +126,11 @@ if (CONFIG_SOC_SERIES_INTEL_ADSP_BROADWELL)
 	zephyr_library_sources(
 		${SOF_DRIVERS_PATH}/intel/haswell/ipc.c
 		${SOF_DRIVERS_PATH}/intel/haswell/ssp.c
+	)
+
+	# SOF core infrastructure - runs on top of Zephyr
+	zephyr_library_sources(
+		${SOF_SRC_PATH}/schedule/ll_schedule.c
 	)
 
 	set(PLATFORM "haswell")
@@ -175,6 +185,11 @@ if (CONFIG_SOC_SERIES_INTEL_CAVS_V15)
 		${SOF_PLATFORM_PATH}/intel/cavs/lib/dma.c
 		${SOF_PLATFORM_PATH}/apollolake/lib/power_down.S
 		${SOF_PLATFORM_PATH}/apollolake/lib/clk.c
+	)
+
+	# SOF core infrastructure - runs on top of Zephyr
+	zephyr_library_sources(
+		${SOF_SRC_PATH}/schedule/zephyr_ll.c
 	)
 
 	set_source_files_properties(${SOF_PLATFORM_PATH}/apollolake/lib/power_down.S PROPERTIES COMPILE_FLAGS -DASSEMBLY)
@@ -239,6 +254,11 @@ if (CONFIG_SOC_SERIES_INTEL_CAVS_V18)
 		#${SOF_PLATFORM_PATH}/intel/cavs/lps_pic_restore_vector.S
 	)
 
+	# SOF core infrastructure - runs on top of Zephyr
+	zephyr_library_sources(
+		${SOF_SRC_PATH}/schedule/zephyr_ll.c
+	)
+
 	zephyr_library_sources_ifdef(CONFIG_CAVS_LPS
 		${SOF_PLATFORM_PATH}/intel/cavs/lps_wait.c
 	)
@@ -300,6 +320,11 @@ if (CONFIG_SOC_SERIES_INTEL_CAVS_V20)
 		${SOF_PLATFORM_PATH}/intel/cavs/lib/dai.c
 		${SOF_PLATFORM_PATH}/intel/cavs/lib/dma.c
 		#${SOF_PLATFORM_PATH}/intel/cavs/lps_pic_restore_vector.S
+	)
+
+	# SOF core infrastructure - runs on top of Zephyr
+	zephyr_library_sources(
+		${SOF_SRC_PATH}/schedule/zephyr_ll.c
 	)
 
 	zephyr_library_sources_ifdef(CONFIG_CAVS_LPS
@@ -366,6 +391,11 @@ if (CONFIG_SOC_SERIES_INTEL_CAVS_V25)
 		${SOF_PLATFORM_PATH}/intel/cavs/lib/dai.c
 		${SOF_PLATFORM_PATH}/intel/cavs/lib/dma.c
 		#${SOF_PLATFORM_PATH}/intel/cavs/lps_pic_restore_vector.S
+	)
+
+	# SOF core infrastructure - runs on top of Zephyr
+	zephyr_library_sources(
+		${SOF_SRC_PATH}/schedule/zephyr_ll.c
 	)
 
 	zephyr_library_sources_ifdef(CONFIG_CAVS_LPS
@@ -479,7 +509,6 @@ zephyr_library_sources(
 	${SOF_SRC_PATH}/schedule/schedule.c
 	${SOF_SRC_PATH}/schedule/dma_single_chan_domain.c
 	${SOF_SRC_PATH}/schedule/dma_multi_chan_domain.c
-	${SOF_SRC_PATH}/schedule/zephyr_ll.c
 	${SOF_SRC_PATH}/schedule/zephyr.c
 
 	# Bridge wrapper between SOF and Zephyr APIs - Will shrink over time.

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -611,8 +611,14 @@ int task_main_start(struct sof *sof)
 	/* init pipeline position offsets */
 	pipeline_posn_init(sof);
 
+#if defined(CONFIG_IMX)
+#define SOF_IPC_QUEUED_DOMAIN SOF_SCHEDULE_LL_DMA
+#else
+#define SOF_IPC_QUEUED_DOMAIN SOF_SCHEDULE_LL_TIMER
+#endif
+
 	/* Temporary fix for issue #4356 */
-	(void)notifier_register(NULL, scheduler_get_data(SOF_SCHEDULE_LL_TIMER),
+	(void)notifier_register(NULL, scheduler_get_data(SOF_IPC_QUEUED_DOMAIN),
 				NOTIFIER_ID_LL_POST_RUN,
 				ipc_send_queued_callback, 0);
 


### PR DESCRIPTION
This pull request fixes some issues we have on i.MX.
Please check each commit, but here's a summary of these fixes:
- i.MX uses dma_domain, so keep the ll_schedule from SOF, until we extend the zephyr_ll for DMA_IRQ
- on i.MX the DMA interrupts are routed via IRQ_STEER.  In order for this to work we need to make any second level interrupts handling go through interrupt-irqsteer.c
- for i.MX we need to use [this ](https://github.com/iuliana-prodan/sof/commit/c194125b83c21d82243bc9eaa18701d87deba468) temporary fix for SOF_SCHEDULE_LL_DMA

With this pull request we can now run successfully, on i.MX, playback and record scenarios with Zephyr.