### PR TITLE
topology2: copier: add ALH type

### DIFF
--- a/tools/topology/topology2/include/components/copier.conf
+++ b/tools/topology/topology2/include/components/copier.conf
@@ -52,6 +52,7 @@ Class.Widget."copier" {
 			!valid_values [
 				"host"
 				"SSP" # TODO: add more DAIs
+				"ALH"
 				"module"
 			]
 		}


### PR DESCRIPTION
ALH is a valid type of copier.

Signed-off-by: Bard Liao <yung-chuan.liao@linux.intel.com>