### PR TITLE
tools: ctl: Fix getopt() stop condition

### DIFF
--- a/tools/ctl/ctl.c
+++ b/tools/ctl/ctl.c
@@ -507,7 +507,7 @@ int main(int argc, char *argv[])
 	int read;
 	int write;
 	int type;
-	char opt;
+	int opt;
 	struct sof_abi_hdr *hdr;
 
 	ctl_data = calloc(1, sizeof(struct ctl_data));


### PR DESCRIPTION
getopt() returns an int, which in our implementation is assigned to a
char type var.

On some platforms char is unsigned thus making getopt() return value
always > 0.

Use int instead of char here to fix the stop condition for parameter
parsing.

This makes sof-ctl work on ARM platforms.

Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>