### PR TITLE
zephyr: add per-ll-task tracking of execution time

### DIFF
--- a/src/include/sof/schedule/task.h
+++ b/src/include/sof/schedule/task.h
@@ -69,6 +69,9 @@ struct task {
 	struct task_ops ops;	/**< task operations */
 #ifdef __ZEPHYR__
 	struct k_work_delayable z_delayed_work;
+	uint32_t cycles_sum;
+	uint32_t cycles_max;
+	uint32_t cycles_cnt;
 #endif
 };
 


### PR DESCRIPTION
Add a lightweight layer to track execution time of ll tasks to the
zephyr-ll scheduler. Use k_cycle_get_32() timestamps for minimal
overhead. A trace is printed with a period size of 2^10 task executions
(roughly once per second in typical configuration with 1ms timer tick).
Average and maximum observed execution time is printed out for each
task.

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>