### PR TITLE
Audio: clean up source_format in component data of drc and multiband_drc

### DIFF
--- a/src/audio/drc/drc.c
+++ b/src/audio/drc/drc.c
@@ -442,6 +442,7 @@ static int drc_reset(struct comp_dev *dev)
 
 	drc_reset_state(&cd->state);
 
+	cd->source_format = 0;
 	cd->drc_func = NULL;
 
 	comp_set_state(dev, COMP_TRIGGER_RESET);

--- a/src/audio/multiband_drc/multiband_drc.c
+++ b/src/audio/multiband_drc/multiband_drc.c
@@ -539,6 +539,7 @@ static int multiband_drc_reset(struct comp_dev *dev)
 
 	multiband_drc_reset_state(&cd->state);
 
+	cd->source_format = 0;
 	cd->multiband_drc_func = NULL;
 	cd->crossover_split = NULL;
 


### PR DESCRIPTION
To make sure we have cleaned up all contents in component data on reset().

This PR contributes to issue #4488 fixes.