### PR TITLE
ipc: let secondary cores acknowledge IPC messages

### DIFF
--- a/src/drivers/intel/cavs/ipc.c
+++ b/src/drivers/intel/cavs/ipc.c
@@ -200,9 +200,10 @@ enum task_state ipc_platform_do_cmd(void *data)
 
 void ipc_platform_complete_cmd(void *data)
 {
-#if CONFIG_SUECREEK
 	struct ipc *ipc = data;
-#endif
+
+	if (!cpu_is_me(ipc->core))
+		return;
 
 	/* write 1 to clear busy, and trigger interrupt to host*/
 #if CAVS_VERSION == CAVS_VERSION_1_5

--- a/src/idc/idc.c
+++ b/src/idc/idc.c
@@ -7,6 +7,7 @@
 #include <sof/audio/component.h>
 #include <sof/audio/component_ext.h>
 #include <sof/drivers/idc.h>
+#include <sof/ipc/driver.h>
 #include <sof/ipc/msg.h>
 #include <sof/ipc/topology.h>
 #include <sof/ipc/schedule.h>
@@ -120,9 +121,11 @@ int idc_wait_in_blocking_mode(uint32_t target_core, bool (*cond)(int))
 static void idc_ipc(void)
 {
 	struct ipc *ipc = ipc_get();
-	ipc_cmd_hdr *hdr = ipc->comp_data;
 
-	ipc_cmd(hdr);
+	ipc_cmd(ipc->comp_data);
+
+	/* Signal the host */
+	ipc_platform_complete_cmd(ipc);
 }
 
 /**

--- a/src/include/sof/ipc/common.h
+++ b/src/include/sof/ipc/common.h
@@ -68,6 +68,7 @@ struct ipc {
 
 	struct list_item msg_list;	/* queue of messages to be sent */
 	bool is_notification_pending;	/* notification is being sent to host */
+	unsigned int core;		/* core, processing the IPC */
 
 	struct list_item comp_list;	/* list of component devices */
 
@@ -190,8 +191,9 @@ void ipc_cmd(ipc_cmd_hdr *hdr);
 /**
  * \brief IPC message to be processed on other core.
  * @param[in] core Core id for IPC to be processed on.
+ * @param[in] blocking Process in blocking mode: wait for completion.
  * @return 1 if successful (reply sent by other core), error code otherwise.
  */
-int ipc_process_on_core(uint32_t core);
+int ipc_process_on_core(uint32_t core, bool blocking);
 
 #endif /* __SOF_DRIVERS_IPC_H__ */

--- a/src/ipc/ipc3/helper.c
+++ b/src/ipc/ipc3/helper.c
@@ -513,7 +513,7 @@ int ipc_pipeline_free(struct ipc *ipc, uint32_t comp_id)
 
 	/* check core */
 	if (!cpu_is_me(ipc_pipe->core))
-		return ipc_process_on_core(ipc_pipe->core);
+		return ipc_process_on_core(ipc_pipe->core, false);
 
 	/* free buffer and remove from list */
 	ret = pipeline_free(ipc_pipe->pipeline);
@@ -548,7 +548,7 @@ int ipc_pipeline_complete(struct ipc *ipc, uint32_t comp_id)
 
 	/* check core */
 	if (!cpu_is_me(ipc_pipe->core))
-		return ipc_process_on_core(ipc_pipe->core);
+		return ipc_process_on_core(ipc_pipe->core, false);
 
 	p = ipc_pipe->pipeline;
 
@@ -653,7 +653,7 @@ int ipc_buffer_free(struct ipc *ipc, uint32_t buffer_id)
 
 	/* check core */
 	if (!cpu_is_me(ibd->core))
-		return ipc_process_on_core(ibd->core);
+		return ipc_process_on_core(ibd->core, false);
 
 	/* try to find sink/source components to check if they still exists */
 	list_for_item(clist, &ipc->comp_list) {
@@ -707,7 +707,7 @@ static int ipc_comp_to_buffer_connect(struct ipc_comp_dev *comp,
 	int ret;
 
 	if (!cpu_is_me(comp->core))
-		return ipc_process_on_core(comp->core);
+		return ipc_process_on_core(comp->core, false);
 
 	tr_dbg(&ipc_tr, "ipc: comp sink %d, source %d  -> connect", buffer->id,
 	       comp->id);
@@ -739,7 +739,7 @@ static int ipc_buffer_to_comp_connect(struct ipc_comp_dev *buffer,
 	int ret;
 
 	if (!cpu_is_me(comp->core))
-		return ipc_process_on_core(comp->core);
+		return ipc_process_on_core(comp->core, false);
 
 	tr_dbg(&ipc_tr, "ipc: comp sink %d, source %d  -> connect", comp->id,
 	       buffer->id);
@@ -856,7 +856,7 @@ int ipc_comp_free(struct ipc *ipc, uint32_t comp_id)
 
 	/* check core */
 	if (!cpu_is_me(icd->core))
-		return ipc_process_on_core(icd->core);
+		return ipc_process_on_core(icd->core, false);
 
 	/* check state */
 	if (icd->cd->state != COMP_STATE_READY)


### PR DESCRIPTION
Currently when an IPC message arrives, the primary core receives the interrupt, schedules a task and begins processing the message. If it identifies, that the message is for another core, it sends an IDC message to it and waits in a busy loop until the other core completes processing the message and writes a response into the mailbox. After that the primary core notifies the host about completing the processing. This patch lets the processing secondary core notify the host directly, which also frees the primary core to handle other tasks instead of waiting in a busy loop.

@lgirdwood This is a prerequisite for the "trigger from thread" #4471