### PR TITLE
zephyr: ll-domain: set .next_tick into the future

### DIFF
--- a/src/schedule/zephyr_domain.c
+++ b/src/schedule/zephyr_domain.c
@@ -112,7 +112,7 @@ static void zephyr_domain_timer_fn(struct k_timer *timer)
 	 * struct task::start for a strictly periodic Zephyr-based LL scheduler
 	 * implementation, they will be removed after a short grace period.
 	 */
-	while (zephyr_domain->ll_domain->next_tick < now)
+	while (zephyr_domain->ll_domain->next_tick <= now)
 		zephyr_domain->ll_domain->next_tick += LL_TIMER_PERIOD_TICKS;
 
 	for (core = 0; core < CONFIG_CORE_COUNT; core++) {


### PR DESCRIPTION
.next_tick is updated on each timer run to the time of the next run. Instead the current version sometimes only updates it to the current time. Fix the update condition.
