### PR TITLE
topology: Add Waves codec to JSL topology

### DIFF
--- a/tools/topology/sof-jsl-rt5682.m4
+++ b/tools/topology/sof-jsl-rt5682.m4
@@ -57,17 +57,23 @@ dnl     frames, deadline, priority, core)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s24le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+define(ENDPOINT_NAME, `Speakers')
+PIPELINE_PCM_ADD(
+	ifdef(`WAVES', sof/pipe-waves-codec-playback.m4, sof/pipe-volume-playback.m4),
 	1, 0, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
+undefine(ENDPOINT_NAME)
 
 # Low Latency playback pipeline 2 on PCM 1 using max 2 channels of s24le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+define(ENDPOINT_NAME, `Headphones')
+PIPELINE_PCM_ADD(
+	ifdef(`WAVES', sof/pipe-waves-codec-playback.m4, sof/pipe-volume-playback.m4),
 	2, 1, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
+undefine(ENDPOINT_NAME)
 
 # Low Latency capture pipeline 3 on PCM 1 using max 2 channels of s24le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0

--- a/tools/topology/sof/pipe-waves-codec-playback.m4
+++ b/tools/topology/sof/pipe-waves-codec-playback.m4
@@ -1,0 +1,44 @@
+# Low Latency Passthrough with Waves codec Pipeline and PCM
+#
+# Pipeline Endpoints for connection are :-
+#
+# host PCM_P --> B0 --> Waves codec --> B1 --> sink DAI0
+
+ifdef(`ENDPOINT_NAME',`',`fatal_error(`Pipe requires ENDPOINT_NAME to be defined: Speakers, Headphones, etc.')')
+
+# Waves codec setup config. For more details see pipe-codec-adapter-playback.m4
+define(`CA_SETUP_CONTROLBYTES',
+``      bytes "0x53,0x4f,0x46,0x00,'
+`       0x00,0x00,0x00,0x00,'
+`       0x20,0x00,0x00,0x00,'
+`       0x00,0x10,0x00,0x03,'
+`       0x00,0x00,0x00,0x00,'
+`       0x00,0x00,0x00,0x00,'
+`       0x00,0x00,0x00,0x00,'
+`       0x00,0x00,0x00,0x00,'
+
+`       0x00,0x01,0x41,0x57,'
+`       0x00,0x00,0x00,0x00,'
+`       0x80,0xBB,0x00,0x00,'
+`       0x20,0x00,0x00,0x00,'
+`       0x02,0x00,0x00,0x00,'
+
+`       0x00,0x00,0x00,0x00,'
+`       0x0c,0x00,0x00,0x00,'
+`       0x00,0x00,0x00,0x00"''
+)
+define(`CA_SETUP_CONTROLBYTES_MAX', 8192)
+define(`CA_SETUP_CONTROLBYTES_NAME', `Waves' `ENDPOINT_NAME' `Setup ')
+
+# use default runtime config but change max size
+define(`CA_RUNTIME_CONTROLBYTES_MAX', 8192)
+define(`CA_RUNTIME_CONTROLBYTES_NAME', `Waves' `ENDPOINT_NAME' `Runtime ')
+
+define(`CA_SCHEDULE_CORE', 0)
+
+DECLARE_SOF_RT_UUID("Waves codec", waves_codec_uuid, 0xd944281a, 0xafe9,
+		    0x4695, 0xa0, 0x43, 0xd7, 0xf6, 0x2b, 0x89, 0x53, 0x8e);
+define(`CA_UUID', waves_codec_uuid)
+
+# Include codec adapter playback topology
+include(`sof/pipe-codec-adapter-playback.m4')


### PR DESCRIPTION
Add pipe for Waves codec playback
Modify sof-jsl-rt5682 topology so Waves codec can be added
to playback in case 'WAVES' is defined