### PR TITLE
clock: (cosmetic) make frequency tables and sources const

### DIFF
--- a/src/platform/apollolake/lib/clk.c
+++ b/src/platform/apollolake/lib/clk.c
@@ -9,7 +9,7 @@
 #include <sof/drivers/ssp.h>
 #include <sof/lib/clk.h>
 
-const struct freq_table platform_cpu_freq[] = {
+static const struct freq_table platform_cpu_freq[] = {
 	{ 100000000, 100000 },
 	{ 200000000, 200000 },
 	{ CLK_MAX_CPU_HZ, 400000 },
@@ -29,13 +29,13 @@ const struct freq_table *cpu_freq = platform_cpu_freq;
 /* IMPORTANT: array should be filled in increasing order
  * (regarding to .freq field)
  */
-const struct freq_table platform_ssp_freq[] = {
+static const struct freq_table platform_ssp_freq[] = {
 	{ 19200000, 19200 },
 	{ 24576000, 24576 },
 	{ 96000000, 96000 },
 };
 
-const uint32_t platform_ssp_freq_sources[] = {
+static const uint32_t platform_ssp_freq_sources[] = {
 	SSP_CLOCK_XTAL_OSCILLATOR,
 	SSP_CLOCK_AUDIO_CARDINAL,
 	SSP_CLOCK_PLL_FIXED,

--- a/src/platform/baytrail/lib/clk.c
+++ b/src/platform/baytrail/lib/clk.c
@@ -14,7 +14,7 @@
 #include <sof/spinlock.h>
 
 #if CONFIG_BAYTRAIL
-const struct freq_table platform_cpu_freq[] = {
+static const struct freq_table platform_cpu_freq[] = {
 	{ 25000000, 25000 },
 	{ 25000000, 25000 },
 	{ 50000000, 50000 },
@@ -25,7 +25,7 @@ const struct freq_table platform_cpu_freq[] = {
 	{ 343000000, 343000 },
 };
 #elif CONFIG_CHERRYTRAIL
-const struct freq_table platform_cpu_freq[] = {
+static const struct freq_table platform_cpu_freq[] = {
 	{ 19200000, 19200 },
 	{ 19200000, 19200 },
 	{ 38400000, 38400 },
@@ -53,12 +53,12 @@ STATIC_ASSERT(NUM_CPU_FREQ == ARRAY_SIZE(platform_cpu_freq),
 
 const struct freq_table *cpu_freq = platform_cpu_freq;
 
-const struct freq_table platform_ssp_freq[] = {
+static const struct freq_table platform_ssp_freq[] = {
 	{ 19200000, 19200 }, /* default */
 	{ 25000000, 25000 },
 };
 
-const uint32_t platform_ssp_freq_sources[] = {
+static const uint32_t platform_ssp_freq_sources[] = {
 	PMC_SET_SSP_19M2,
 	PMC_SET_SSP_25M,
 };

--- a/src/platform/cannonlake/lib/clk.c
+++ b/src/platform/cannonlake/lib/clk.c
@@ -9,7 +9,7 @@
 #include <sof/drivers/ssp.h>
 #include <sof/lib/clk.h>
 
-const struct freq_table platform_cpu_freq[] = {
+static const struct freq_table platform_cpu_freq[] = {
 	{ 120000000, 120000 },
 	{ CLK_MAX_CPU_HZ, 400000 },
 };
@@ -34,12 +34,12 @@ const struct freq_table *cpu_freq = platform_cpu_freq;
 /* IMPORTANT: array should be filled in increasing order
  * (regarding to .freq field)
  */
-const static struct freq_table platform_ssp_freq[] = {
+static const struct freq_table platform_ssp_freq[] = {
 	{ 24000000, 24000 },
 	{ 96000000, 96000 },
 };
 
-const static uint32_t platform_ssp_freq_sources[] = {
+static const uint32_t platform_ssp_freq_sources[] = {
 	SSP_CLOCK_XTAL_OSCILLATOR,
 	SSP_CLOCK_PLL_FIXED,
 };

--- a/src/platform/haswell/lib/clk.c
+++ b/src/platform/haswell/lib/clk.c
@@ -13,7 +13,7 @@
 #include <sof/sof.h>
 #include <sof/spinlock.h>
 
-const struct freq_table platform_cpu_freq[] = {
+static const struct freq_table platform_cpu_freq[] = {
 	{ 32000000, 32000 },
 	{ 80000000, 80000 },
 	{ 160000000, 160000 },
@@ -34,11 +34,11 @@ const uint32_t cpu_freq_enc[] = {
 STATIC_ASSERT(NUM_CPU_FREQ == ARRAY_SIZE(platform_cpu_freq),
 	      invalid_number_of_cpu_frequencies);
 
-const struct freq_table platform_ssp_freq[] = {
+static const struct freq_table platform_ssp_freq[] = {
 	{ 24000000, 24000 },
 };
 
-const uint32_t platform_ssp_freq_sources[] = {
+static const uint32_t platform_ssp_freq_sources[] = {
 	0,
 };
 

--- a/src/platform/icelake/lib/clk.c
+++ b/src/platform/icelake/lib/clk.c
@@ -9,7 +9,7 @@
 #include <sof/drivers/ssp.h>
 #include <sof/lib/clk.h>
 
-const struct freq_table platform_cpu_freq[] = {
+static const struct freq_table platform_cpu_freq[] = {
 	{ 120000000, 120000 },
 	{ CLK_MAX_CPU_HZ, 400000 },
 };
@@ -34,13 +34,13 @@ const struct freq_table *cpu_freq = platform_cpu_freq;
 /* IMPORTANT: array should be filled in increasing order
  * (regarding to .freq field)
  */
-const struct freq_table platform_ssp_freq[] = {
+static const struct freq_table platform_ssp_freq[] = {
 	{ 24576000, 24576 },
 	{ 38400000, 38400 },
 	{ 96000000, 96000 },
 };
 
-const uint32_t platform_ssp_freq_sources[] = {
+static const uint32_t platform_ssp_freq_sources[] = {
 	SSP_CLOCK_AUDIO_CARDINAL,
 	SSP_CLOCK_XTAL_OSCILLATOR,
 	SSP_CLOCK_PLL_FIXED,

--- a/src/platform/suecreek/lib/clk.c
+++ b/src/platform/suecreek/lib/clk.c
@@ -9,7 +9,7 @@
 #include <sof/drivers/ssp.h>
 #include <sof/lib/clk.h>
 
-const struct freq_table platform_cpu_freq[] = {
+static const struct freq_table platform_cpu_freq[] = {
 	{ 120000000, 120000 },
 	{ CLK_MAX_CPU_HZ, 400000 },
 };
@@ -34,12 +34,12 @@ const struct freq_table *cpu_freq = platform_cpu_freq;
 /* IMPORTANT: array should be filled in increasing order
  * (regarding to .freq field)
  */
-const struct freq_table platform_ssp_freq[] = {
+static const struct freq_table platform_ssp_freq[] = {
 	{ 19200000, 19200 },
 	{ 24000000, 24000 },
 };
 
-const uint32_t platform_ssp_freq_sources[] = {
+static const uint32_t platform_ssp_freq_sources[] = {
 	SSP_CLOCK_XTAL_OSCILLATOR,
 	SSP_CLOCK_PLL_FIXED,
 };

--- a/src/platform/tigerlake/lib/clk.c
+++ b/src/platform/tigerlake/lib/clk.c
@@ -9,7 +9,7 @@
 #include <sof/drivers/ssp.h>
 #include <sof/lib/clk.h>
 
-const struct freq_table platform_cpu_freq[] = {
+static const struct freq_table platform_cpu_freq[] = {
 	{ 38400000, 38400 },
 	{ 120000000, 120000 },
 	{ CLK_MAX_CPU_HZ, 400000 },
@@ -38,13 +38,13 @@ const struct freq_table *cpu_freq = platform_cpu_freq;
 /* IMPORTANT: array should be filled in increasing order
  * (regarding to .freq field)
  */
-const struct freq_table platform_ssp_freq[] = {
+static const struct freq_table platform_ssp_freq[] = {
 	{ 24576000, 24576 },
 	{ 38400000, 38400 },
 	{ 96000000, 96000 },
 };
 
-const uint32_t platform_ssp_freq_sources[] = {
+static const uint32_t platform_ssp_freq_sources[] = {
 	SSP_CLOCK_AUDIO_CARDINAL,
 	SSP_CLOCK_XTAL_OSCILLATOR,
 	SSP_CLOCK_PLL_FIXED,


### PR DESCRIPTION
Make platform_cpu_freq[], platform_ssp_freq[] and platform_ssp_freq_sources[] arrays constant on multiple platforms.
