### PR TITLE
topology1: imx8ulp: Set min_channels to 1

### DIFF
--- a/tools/topology/topology1/sof-imx8ulp-btsco.m4
+++ b/tools/topology/topology1/sof-imx8ulp-btsco.m4
@@ -25,6 +25,8 @@ include(`platform/imx/imx8.m4')
 # PCM0 <----> volume <-----> SAI5 (connect to BT)
 #
 
+define(`CHANNELS_MIN', 1)
+
 dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,
 dnl     period, priority, core,
@@ -37,6 +39,8 @@ PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	1, 0, 1, s16le,
 	1000, 0, 0,
 	16000, 16000, 16000)
+
+undefine(`CHANNELS_MIN')
 
 # Low Latency capture pipeline 2 on PCM 0 using max 1 channels of s16le.
 # Set 1000us deadline on core 0 with priority 0


### PR DESCRIPTION
On i.MX8ULP SAI5 is connected to BT interface that only supports 1
channel.

Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>