### PR TITLE
compile: use __attribute__((fallthrough)) with GCC

### DIFF
--- a/src/include/sof/compiler_attributes.h
+++ b/src/include/sof/compiler_attributes.h
@@ -17,7 +17,7 @@
 
 #define __section(x) __attribute__((section(x)))
 
-#ifdef __clang__
+#if defined(__clang__) || !defined(__XCC__)
 
 #define COMPILER_FALLTHROUGH __attribute__((fallthrough))
 


### PR DESCRIPTION
2 my PRs need this: #4559 and #4562 - would be good to merge this ASAP...

Fix compiler warning by using the "fallthrough" attribute with GCC as well.
