### PR TITLE
ssp and idc minor updates.

### DIFF
--- a/src/drivers/intel/cavs/idc.c
+++ b/src/drivers/intel/cavs/idc.c
@@ -129,8 +129,11 @@ int idc_send_msg(struct idc_msg *msg, uint32_t mode)
 	switch (mode) {
 	case IDC_BLOCKING:
 		ret = idc_wait_in_blocking_mode(msg->core, idc_is_received);
-		if (ret < 0)
+		if (ret < 0) {
+			tr_err(&idc_tr, "idc_send_msg(), blocking msg 0x%x failed for core %d",
+			       msg->header, msg->core);
 			return ret;
+		}
 
 		idc_write(IPC_IDCIETC(msg->core), core,
 			  idc_read(IPC_IDCIETC(msg->core), core) |

--- a/src/drivers/intel/ssp/ssp.c
+++ b/src/drivers/intel/ssp/ssp.c
@@ -987,8 +987,19 @@ static void ssp_start(struct dai *dai, int direction)
 	else
 		ssp_update_bits(dai, SSRSA, SSRSA_RXEN, SSRSA_RXEN);
 
-	/* wait to get valid fifo status */
-	wait_delay(PLATFORM_SSP_DELAY);
+	/*
+	 * Wait to get valid fifo status in clock consumer mode. TODO it's
+	 * uncertain which SSP clock consumer modes need the delay atm, but
+	 * these can be added here when confirmed.
+	 */
+	switch (ssp->config.format & SOF_DAI_FMT_CLOCK_PROVIDER_MASK) {
+	case SOF_DAI_FMT_CBC_CFC:
+		break;
+	default:
+		/* delay for all SSP consumed clocks atm - see above */
+		wait_delay(PLATFORM_SSP_DELAY);
+		break;
+	}
 
 	spin_unlock(&dai->lock);
 }
@@ -1000,8 +1011,19 @@ static void ssp_stop(struct dai *dai, int direction)
 
 	spin_lock(&dai->lock);
 
-	/* wait to get valid fifo status */
-	wait_delay(PLATFORM_SSP_DELAY);
+	/*
+	 * Wait to get valid fifo status in clock consumer mode. TODO it's
+	 * uncertain which SSP clock consumer modes need the delay atm, but
+	 * these can be added here when confirmed.
+	 */
+	switch (ssp->config.format & SOF_DAI_FMT_CLOCK_PROVIDER_MASK) {
+	case SOF_DAI_FMT_CBC_CFC:
+		break;
+	default:
+		/* delay for all SSP consumed clocks atm - see above */
+		wait_delay(PLATFORM_SSP_DELAY);
+		break;
+	}
 
 	/* stop Rx if neeed */
 	if (direction == DAI_DIR_CAPTURE &&


### PR DESCRIPTION
Tell users which IDC is failing and only delay in SSP clock consumer modes.