### PR TITLE
cache: make sure all shared data is cache line size aligned.

### DIFF
--- a/src/platform/intel/cavs/include/cavs/lib/memory.h
+++ b/src/platform/intel/cavs/include/cavs/lib/memory.h
@@ -78,7 +78,7 @@ struct sof;
  * align to cache line size instead.
  */
 #if CONFIG_CORE_COUNT > 1 && !defined(UNIT_TEST) && !defined __ZEPHYR__
-#define SHARED_DATA	__section(".shared_data")
+#define SHARED_DATA	__section(".shared_data") __attribute__((aligned(PLATFORM_DCACHE_ALIGN)))
 #else
 #define SHARED_DATA
 #endif


### PR DESCRIPTION
Aligns all SHARED data on cache line size to ensure we dont clobber
data.

Signed-off-by: Liam Girdwood <liam.r.girdwood@linux.intel.com>