### PR TITLE
zephyr: unify CTX_SAVE handling for Zephyr

### DIFF
--- a/src/ipc/ipc3/handler.c
+++ b/src/ipc/ipc3/handler.c
@@ -595,8 +595,7 @@ static int ipc_pm_context_save(uint32_t header)
 	/* do platform specific suspending */
 	platform_context_save(sof_get());
 
-	/* TODO use Zephyr calls for shutdown */
-#if !defined(__ZEPHYR__) && !defined(CONFIG_LIBRARY)
+#if !defined(CONFIG_LIBRARY)
 	/* TODO: check we are inactive - all streams are suspended */
 
 	/* TODO: mask ALL platform interrupts except DMA */

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -414,6 +414,10 @@ out:
 #endif
 }
 
+void platform_timer_stop(struct timer *timer)
+{
+}
+
 uint64_t platform_timer_get_atomic(struct timer *timer)
 {
 	uint32_t flags;


### PR DESCRIPTION
Clean up the ifdefs for ipc_pm_context_save(). By implementing
platform_timer_stop() in the Zephyr wrapper, the original context
save sequence can be used also for Zephyr builds.

By doing this, we can fix issues with IPC timeout on CTX_SAVE.
Disabling all interrupts before the IPC reply is needed also on
Zephyr.

BugLink: https://github.com/thesofproject/sof/issues/4507
Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>