### PR TITLE
[SKIP CI] github actions: update zephyr docker image to 0.18.1

### DIFF
--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -17,5 +17,6 @@ jobs:
 
       - name: build
         run: docker run -v "$(pwd)":/workdir
-             docker.io/zephyrprojectrtos/zephyr-build:v0.17.3
+             -e ZEPHYR_SDK_INSTALL_DIR='/opt/toolchains/zephyr-sdk-0.13.0'
+             docker.io/zephyrprojectrtos/zephyr-build:v0.18.1
              ./zephyr/docker-build.sh


### PR DESCRIPTION
The recent zephyr code add restriction to the SDK,
and requires the SDK version >= 0.13, we have to
update the docker image for zephyr SOF building.

As the default SDK version in docker image 0.18.1
is still 0.12.4, and the alternative SDK is 0.13.0,
we need to specify the SDK location with env.

Signed-off-by: Chao Song <chao.song@linux.intel.com>