### PR TITLE
topology1: fix error in LOCAL_CHANNELS_MIN definition

### DIFF
--- a/tools/topology/topology1/sof/pipe-passthrough-capture.m4
+++ b/tools/topology/topology1/sof/pipe-passthrough-capture.m4
@@ -40,7 +40,7 @@ indir(`define', concat(`PIPELINE_SINK_', PIPELINE_ID), N_BUFFER(0))
 indir(`define', concat(`PIPELINE_PCM_', PIPELINE_ID), Passthrough Capture PCM_ID)
 
 ifdef(`CHANNELS_MIN',`define(`LOCAL_CHANNELS_MIN', `CHANNELS_MIN')',
-`define(`LOCAL_CHANNELS_MIN' `PIPELINE_CHANNELS')')
+`define(`LOCAL_CHANNELS_MIN', `PIPELINE_CHANNELS')')
 
 #
 # PCM Configuration


### PR DESCRIPTION
The patch to fix CHANNELS_MIN side effects had a bug in which caused
LOCAL_CHANNELS_MIN to slip into conf output. Example from
sof-adl-sdw-max98373-rt5682:

---cut--
SectionPCMCapabilities."Passthrough Capture 14" {
»       formats "S16_LE"
»       rate_min "8000"
»       rate_max "16000"
»       channels_min "LOCAL_CHANNELS_MIN"
--cut--

Fixes: 659266685b43 ("topology: remove side effects from macro definitions")
BugLink: https://github.com/thesofproject/sof/issues/4621
Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>