### PR TITLE
trace: enable trace after it is ready

### DIFF
--- a/src/init/init.c
+++ b/src/init/init.c
@@ -134,10 +134,8 @@ static int primary_core_init(int argc, char *argv[], struct sof *sof)
 	interrupt_init(sof);
 #endif /* __ZEPHYR__ */
 
-#if CONFIG_TRACE
 	trace_point(TRACE_BOOT_SYS_TRACES);
 	trace_init(sof);
-#endif
 
 	trace_point(TRACE_BOOT_SYS_NOTIFIER);
 	init_system_notify(sof);
@@ -150,6 +148,9 @@ static int primary_core_init(int argc, char *argv[], struct sof *sof)
 		panic(SOF_IPC_PANIC_PLATFORM);
 
 	trace_point(TRACE_BOOT_PLATFORM);
+
+	/* now start the trace */
+	trace_on();
 
 #if CONFIG_NO_SECONDARY_CORE_ROM
 	lp_sram_unpack();

--- a/src/trace/dma-trace.c
+++ b/src/trace/dma-trace.c
@@ -200,7 +200,6 @@ int dma_trace_init_complete(struct dma_trace_data *d)
 			      SOF_TASK_PRI_MED, trace_work, d, 0, 0);
 
 out:
-
 	return ret;
 }
 

--- a/src/trace/trace.c
+++ b/src/trace/trace.c
@@ -290,9 +290,8 @@ void trace_log_filtered(bool send_atomic, const void *log_entry, const struct tr
 	uint64_t current_ts;
 #endif /* CONFIG_TRACE_FILTERING_ADAPTIVE */
 
-	if (!trace->enable) {
+	if (!trace || !trace->enable)
 		return;
-	}
 
 #if CONFIG_TRACE_FILTERING_VERBOSITY
 	if (!trace_filter_verbosity(lvl, ctx))
@@ -512,7 +511,6 @@ void trace_off(void)
 void trace_init(struct sof *sof)
 {
 	sof->trace = rzalloc(SOF_MEM_ZONE_SYS_SHARED, 0, SOF_MEM_CAPS_RAM, sizeof(*sof->trace));
-	sof->trace->enable = 1;
 	sof->trace->pos = 0;
 #if CONFIG_TRACE_FILTERING_ADAPTIVE
 	sof->trace->user_filter_override = false;


### PR DESCRIPTION
If the log tracing (e.g. tr_err()) is called before the trace itself is
available, the FW will crash and FW boot fail happen.

Enable the trace after it is ready, and don't try to perform tracing
when it is unavailable.

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>