### PR TITLE
sof-tgl-sdw-max98373-rt5682: remove 3rd party smart amp dependency

### DIFF
--- a/tools/topology/topology1/sof-tgl-max98373-rt5682.m4
+++ b/tools/topology/topology1/sof-tgl-max98373-rt5682.m4
@@ -63,10 +63,6 @@ define(`SMART_REF_CH_NUM', 2)
 define(`SMART_PCM_ID', 0)
 define(`SMART_PCM_NAME', `smart373-spk')
 
-# UUID related
-DECLARE_SOF_RT_UUID("Maxim DSM", maxim_dsm_comp_uuid, 0x0cd84e80, 0xebd3,
-                    0x11ea, 0xad, 0xc1, 0x02, 0x42, 0xac, 0x12, 0x00, 0x02);
-define(`SMART_UUID', maxim_dsm_comp_uuid)
 # Include Smart Amplifier support
 include(`sof-smart-amplifier.m4')
 


### PR DESCRIPTION
1st commit to use a mockup of the smart amp

for 2nd commit, BT offload is not working on TGL Voxel I2S. I don't think BT offload is ready for TGL.

sof-tgl-sdw-max98373-rt5682.m4 uses BT offload when platform is ADL.
https://github.com/thesofproject/sof/blob/6713cace3586115c82dd18a111b63d6f4cd4b435/tools/topology/topology1/sof-tgl-sdw-max98373-rt5682.m4#L57

This is error message when I tested on TGL Voxel.
```
# for playback
2021-08-13 20:08:39 UTC [COMMAND] aplay   -Dhw:0,6 -r 8000 -c 1 -f S16_LE -d 5 /dev/zero -v -q
aplay: set_params:1432: Unable to install hw params:

[  116.834656] sof-audio-pci-intel-tgl 0000:00:1f.3: ipc tx: 0x60010000: GLB_STREAM_MSG: PCM_PARAMS
[  116.835013] sof-audio-pci-intel-tgl 0000:00:1f.3: error: ipc error for 0x60010000 size 20
[  116.835115] sof-audio-pci-intel-tgl 0000:00:1f.3: error: hw params ipc failed for stream 1
[  116.835121] sof-audio-pci-intel-tgl 0000:00:1f.3: ASoC: error at snd_soc_pcm_component_hw_params on 0000:00:1f.3: -22
[  116.835130]  Bluetooth: ASoC: soc_pcm_hw_params() failed (-22)
[  116.835152] sof-audio-pci-intel-tgl 0000:00:1f.3: ipc tx: 0x80010000: GLB_DAI_MSG: CONFIG
[  116.835679] sof-audio-pci-intel-tgl 0000:00:1f.3: ipc tx succeeded: 0x80010000: GLB_DAI_MSG: CONFIG
[  116.835689]  Bluetooth: ASoC: dpcm_fe_dai_hw_params failed (-22)


# for capture
2021-08-13 20:09:56 UTC [COMMAND] arecord   -Dhw:0,6 -r 8000 -c 1 -f S16_LE -d 5 /dev/null -v -q
Hardware PCM card 0 'sof-rt5682' device 6 subdevice 0
...
arecord: pcm_read:2178: read error: Input/output error
```