### PR TITLE
tools: tune: add eq_iir_drceq coefficient scripts

### DIFF
--- a/tools/tune/multiband_drc/biquad_gen_df2t_coefs.m
+++ b/tools/tune/multiband_drc/biquad_gen_df2t_coefs.m
@@ -1,0 +1,304 @@
+function biquad_coefs = biquad_gen_df2t_coefs(params);
+
+switch (params.type)
+	case 0  % NONE
+		biquad_coefs = [0.0 0.0 0.0 0.0 1.0 0 1.0];
+	case 1  % LOWPASS
+		biquad_coefs = lowpass_coefs(params.freq, params.Q);
+	case 2  % HIGHPASS
+		biquad_coefs = highpass_coefs(params.freq, params.Q);
+	case 3  % BANDPASS
+		biquad_coefs = bandpass_coefs(params.freq, params.Q);
+	case 4  % LOWSHELF
+		biquad_coefs = lowshelf_coefs(params.freq, params.gain);
+	case 5  % HIGHSHELF
+		biquad_coefs = highshelf_coefs(params.freq, params.gain);
+	case 6  % PEAKING
+		biquad_coefs = peaking_coefs(params.freq, params.Q, params.gain);
+	case 7  % NOTCH
+		biquad_coefs = lowshelf_coefs(params.freq, params.Q);
+	case 8  % ALLPASS
+		biquad_coefs = allpass_coefs(params.freq, params.Q);
+	otherwise
+		error ("invalid type: %d (available: 0~8)", params.type);
+endswitch
+
+endfunction
+
+function biquad_coefs = lowpass_coefs(freq, Q);
+
+% Limit cutoff to 0 to 1.
+cutoff = max(0.0, min(freq, 1.0));
+
+if (cutoff == 1.0 || cutoff == 0.0)
+	% When cutoff is 1, the z-transform is 1.
+	% When cutoff is zero, nothing gets through the filter, so set
+	% coefficients up correctly.
+	biquad_coefs = [0.0 0.0 0.0 0.0 cutoff 0 1.0];
+	return;
+endif
+
+% Compute biquad coefficients for lowpass filter
+resonance = max(0.0, Q); % can't go negative
+g = 10.0 ** (0.05 * resonance);
+d = sqrt((4 - sqrt(16 - 16 / (g * g))) / 2);
+
+theta = pi * cutoff;
+sn = 0.5 * d * sin(theta);
+beta = 0.5 * (1 - sn) / (1 + sn);
+gamma = (0.5 + beta) * cos(theta);
+alpha = 0.25 * (0.5 + beta - gamma);
+
+b0 = 2 * alpha;
+b1 = 2 * 2 * alpha;
+b2 = 2 * alpha;
+a1 = 2 * -gamma;
+a2 = 2 * beta;
+
+biquad_coefs = [-a2 -a1 b2 b1 b0 0 1.0];
+
+endfunction
+
+function biquad_coefs = highpass_coefs(freq, Q);
+
+% Limit cutoff to 0 to 1.
+cutoff = max(0.0, min(freq, 1.0));
+
+if (cutoff == 1.0 || cutoff == 0.0)
+	% When cutoff is one, the z-transform is 0.
+	% When cutoff is zero, we need to be careful because the above
+	% gives a quadratic divided by the same quadratic, with poles
+	% and zeros on the unit circle in the same place. When cutoff
+	% is zero, the z-transform is 1.
+	biquad_coefs = [0.0 0.0 0.0 0.0 (1.0 - cutoff) 0 1.0];
+	return;
+endif
+
+% Compute biquad coefficients for highpass filter
+resonance = max(0.0, Q);  % can't go negative
+g = 10.0 ** (0.05 * resonance);
+d = sqrt((4 - sqrt(16 - 16 / (g * g))) / 2);
+
+theta = pi * cutoff;
+sn = 0.5 * d * sin(theta);
+beta = 0.5 * (1 - sn) / (1 + sn);
+gamma = (0.5 + beta) * cos(theta);
+alpha = 0.25 * (0.5 + beta + gamma);
+
+b0 = 2 * alpha;
+b1 = 2 * -2 * alpha;
+b2 = 2 * alpha;
+a1 = 2 * -gamma;
+a2 = 2 * beta;
+
+biquad_coefs = [-a2 -a1 b2 b1 b0 0 1.0];
+
+endfunction
+
+function biquad_coefs = bandpass_coefs(freq, Q);
+
+% No negative frequencies allowed.
+if (freq <= 0.0 || freq >= 1.0)
+	% When the cutoff is zero, the z-transform approaches 0, if Q
+	% > 0. When both Q and cutoff are zero, the z-transform is
+	% pretty much undefined. What should we do in this case?
+	% For now, just make the filter 0. When the cutoff is 1, the
+	% z-transform also approaches 0.
+	biquad_coefs = [0.0 0.0 0.0 0.0 0.0 0 1.0];
+	return;
+endif
+
+% Don't let Q go negative, which causes an unstable filter.
+if (Q <= 0.0)
+	% When Q = 0, the above formulas have problems. If we
+	% look at the z-transform, we can see that the limit
+	% as Q->0 is 1, so set the filter that way.
+	biquad_coefs = [0.0 0.0 0.0 0.0 1.0 0 1.0];
+	return;
+endif
+
+w0 = pi * freq;
+alpha = sin(w0) / (2 * Q);
+k = cos(w0);
+
+b0 = alpha;
+b1 = 0;
+b2 = -alpha;
+a0 = 1 + alpha;
+a1 = -2 * k;
+a2 = 1 - alpha;
+
+biquad_coefs = [-(a2 / a0) -(a1 / a0) (b2 / a0) (b1 / a0) (b0 / a0) 0 1.0];
+
+endfunction
+
+function biquad_coefs = lowshelf_coefs(freq, gain);
+
+% Clip frequencies to between 0 and 1, inclusive.
+if (freq <= 0.0)
+	% When frequency is 0, the z-transform is 1.
+	biquad_coefs = [0.0 0.0 0.0 0.0 1.0 0 1.0];
+	return;
+endif
+if (freq >= 1.0)
+	% The z-transform is a constant gain.
+	biquad_coefs = [0.0 0.0 0.0 0.0 (A * A) 0 1.0];
+	return;
+endif
+
+A = 10.0 ** (gain / 40);
+
+w0 = pi * freq;
+S = 1; % filter slope (1 is max value)
+alpha = 0.5 * sin(w0) * sqrt((A + 1 / A) * (1 / S - 1) + 2);
+k = cos(w0);
+k2 = 2 * sqrt(A) * alpha;
+a_plus_one = A + 1;
+a_minus_one = A - 1;
+
+b0 = A * (a_plus_one - a_minus_one * k + k2);
+b1 = 2 * A * (a_minus_one - a_plus_one * k);
+b2 = A * (a_plus_one - a_minus_one * k - k2);
+a0 = a_plus_one + a_minus_one * k + k2;
+a1 = -2 * (a_minus_one + a_plus_one * k);
+a2 = a_plus_one + a_minus_one * k - k2;
+
+biquad_coefs = [-(a2 / a0) -(a1 / a0) (b2 / a0) (b1 / a0) (b0 / a0) 0 1.0];
+
+endfunction
+
+function biquad_coefs = highshelf_coefs(freq, gain);
+
+% Clip frequencies to between 0 and 1, inclusive.
+if (freq <= 0.0)
+	% When frequency = 0, the filter is just a gain, A^2.
+	biquad_coefs = [0.0 0.0 0.0 0.0 (A * A) 0 1.0];
+	return;
+endif
+if (freq >= 1.0)
+	% The z-transform is 1.
+	biquad_coefs = [0.0 0.0 0.0 0.0 1.0 0 1.0];
+	return;
+endif
+
+A = 10.0 ** (gain / 40);
+
+w0 = pi * freq;
+S = 1; % filter slope (1 is max value)
+alpha = 0.5 * sin(w0) * sqrt((A + 1 / A) * (1 / S - 1) + 2);
+k = cos(w0);
+k2 = 2 * sqrt(A) * alpha;
+a_plus_one = A + 1;
+a_minus_one = A - 1;
+
+b0 = A * (a_plus_one + a_minus_one * k + k2);
+b1 = -2 * A * (a_minus_one + a_plus_one * k);
+b2 = A * (a_plus_one + a_minus_one * k - k2);
+a0 = a_plus_one - a_minus_one * k + k2;
+a1 = 2 * (a_minus_one - a_plus_one * k);
+a2 = a_plus_one - a_minus_one * k - k2;
+
+biquad_coefs = [-(a2 / a0) -(a1 / a0) (b2 / a0) (b1 / a0) (b0 / a0) 0 1.0];
+
+endfunction
+
+function biquad_coefs = peaking_coefs(freq, Q, gain);
+
+% Clip frequencies to between 0 and 1, inclusive.
+if (freq <= 0.0 || freq >= 1.0)
+	% When frequency is 0 or 1, the z-transform is 1.
+	biquad_coefs = [0.0 0.0 0.0 0.0 1.0 0 1.0];
+	return;
+endif
+
+A = 10.0 ** (gain / 40);
+
+% Don't let Q go negative, which causes an unstable filter.
+if (Q <= 0.0)
+	% When Q <= 0, the above formulas have problems. If we
+	% look at the z-transform, we can see that the limit
+	% as Q->0 is A^2, so set the filter that way.
+	biquad_coefs = [0.0 0.0 0.0 0.0 (A * A) 0 1.0];
+        return;
+endif
+
+w0 = pi * freq;
+alpha = sin(w0) / (2 * Q);
+k = cos(w0);
+
+b0 = 1 + alpha * A;
+b1 = -2 * k;
+b2 = 1 - alpha * A;
+a0 = 1 + alpha / A;
+a1 = -2 * k;
+a2 = 1 - alpha / A;
+
+biquad_coefs = [-(a2 / a0) -(a1 / a0) (b2 / a0) (b1 / a0) (b0 / a0) 0 1.0];
+
+endfunction
+
+function biquad_coefs = notch_coefs(freq, Q);
+
+% Clip frequencies to between 0 and 1, inclusive.
+if (freq <= 0.0 || freq >= 1.0)
+	% When frequency is 0 or 1, the z-transform is 1.
+	biquad_coefs = [0.0 0.0 0.0 0.0 1.0 0 1.0];
+	return;
+endif
+
+% Don't let Q go negative, which causes an unstable filter.
+if (Q <= 0.0)
+	% When Q = 0, the above formulas have problems. If we
+	% look at the z-transform, we can see that the limit
+	% as Q->0 is 0, so set the filter that way.
+	biquad_coefs = [0.0 0.0 0.0 0.0 0.0 0 1.0];
+	return;
+endif
+
+w0 = pi * freq;
+alpha = sin(w0) / (2 * Q);
+k = cos(w0);
+
+b0 = 1;
+b1 = -2 * k;
+b2 = 1;
+a0 = 1 + alpha;
+a1 = -2 * k;
+a2 = 1 - alpha;
+
+biquad_coefs = [-(a2 / a0) -(a1 / a0) (b2 / a0) (b1 / a0) (b0 / a0) 0 1.0];
+
+endfunction
+
+function biquad_coefs = allpass_coefs(freq, Q);
+
+% Clip frequencies to between 0 and 1, inclusive.
+if (freq <= 0.0 || freq >= 1.0)
+	% When frequency is 0 or 1, the z-transform is 1.
+	biquad_coefs = [0.0 0.0 0.0 0.0 1.0 0 1.0];
+	return;
+endif
+
+% Don't let Q go negative, which causes an unstable filter.
+if (Q <= 0.0)
+	% When Q = 0, the above formulas have problems. If we
+	% look at the z-transform, we can see that the limit
+	% as Q->0 is -1, so set the filter that way.
+	biquad_coefs = [0.0 0.0 0.0 0.0 -1.0 0 1.0];
+	return;
+endif
+
+w0 = pi * frequency;
+alpha = sin(w0) / (2 * Q);
+k = cos(w0);
+
+b0 = 1 - alpha;
+b1 = -2 * k;
+b2 = 1 + alpha;
+a0 = 1 + alpha;
+a1 = -2 * k;
+a2 = 1 - alpha;
+
+biquad_coefs = [-(a2 / a0) -(a1 / a0) (b2 / a0) (b1 / a0) (b0 / a0) 0 1.0];
+
+endfunction

--- a/tools/tune/multiband_drc/eq_adjust_shift_gain.m
+++ b/tools/tune/multiband_drc/eq_adjust_shift_gain.m
@@ -1,0 +1,48 @@
+function eq_biquad_adj_coefs = eq_adjust_shift_gain(eq_biquad_coefs);
+
+eq_biquad_adj_coefs = cell(1, length(eq_biquad_coefs));
+total_shift = 0;
+total_gain = 1.0;
+for i = 1:length(eq_biquad_coefs)
+	coef = cell2mat(eq_biquad_coefs(i));
+
+	% Biquad coefficients are Q2.30 (range:(-2,2))
+	% If a2(coef(1)) and a1(coef(2)) are out of range, there is no way to
+	% adjust. Make an assertion then.
+	if (abs(coef(1)) >= 2.0 || abs(coef(2)) >= 2.0)
+		error("Invalid biquad coef: a2=%f a1=%f", coef(1), coef(2));
+	endif
+
+	% Adjust the absolute values of b2,b1,b0(coef(3:5)) to not greater than
+        % 1.0, and restore the intensity by gain(coef(7))
+	max_b = max(max(abs(coef(3)), abs(coef(4))), abs(coef(5)));
+	if (max_b > 1.0)
+		coef(3) /= max_b;
+		coef(4) /= max_b;
+		coef(5) /= max_b;
+		coef(7) *= max_b;
+	endif
+
+	% Postpone shifts and gains of all former biquad stages to the last
+	% stage, in order to keep inner responses un-saturated.
+	total_shift += coef(6);
+	total_gain *= coef(7);
+	if (i == length(eq_biquad_coefs))
+		% total_gain is Q2.14 (range:(-2,2)). Use total_shift to adjust
+		% total_gain until it is within range.
+		while (abs(total_gain) >= 2.0)
+			total_gain /= 2;
+			total_shift--;
+		endwhile
+
+		coef(6) = total_shift;
+		coef(7) = total_gain;
+	else
+		coef(6) = 0;
+		coef(7) = 1.0;
+	endif
+
+	eq_biquad_adj_coefs(i) = coef;
+endfor
+
+endfunction

--- a/tools/tune/multiband_drc/eq_gen_header_quant.m
+++ b/tools/tune/multiband_drc/eq_gen_header_quant.m
@@ -1,0 +1,37 @@
+function eq_header_quant = eq_gen_header_quant(eq_biquad_coefs);
+
+n_header = 6;
+n_biquad = 7;
+num_sections = length(eq_biquad_coefs);
+eq_header_quant = int32(zeros(1, n_header + n_biquad * num_sections));
+eq_header_quant(1) = num_sections;
+eq_header_quant(2) = num_sections;  % num_sections_in_series
+% eq_header_quant(3:6) are reserved zeros
+
+m = n_header + 1;
+for i = 1:num_sections
+	eq_header_quant(m:m+n_biquad-1) = biquad_coef_quant(eq_biquad_coefs(i));
+	m += n_biquad;
+endfor
+
+endfunction
+
+function coef_quant = biquad_coef_quant(coef);
+
+bits_bq = 32;  % Q2.30
+qf_bq = 30;
+
+bits_gain = 16;  % Q2.14
+qf_gain = 14;
+
+addpath ../eq
+
+coef = cell2mat(coef);
+
+quant_ab = eq_coef_quant(coef(1:5), bits_bq, qf_bq);
+quant_gain = eq_coef_quant(coef(7), bits_gain, qf_gain);
+coef_quant = [quant_ab coef(6) quant_gain];
+
+rmpath ../eq
+
+endfunction

--- a/tools/tune/multiband_drc/example_eq_iir_drceq.m
+++ b/tools/tune/multiband_drc/example_eq_iir_drceq.m
@@ -1,0 +1,136 @@
+function example_eq_iir_drceq();
+
+tplg_fn = "../../topology/m4/eq_iir_coef_drceq.m4"; % Control Bytes File
+% Use those files with sof-ctl to update the component's configuration
+blob_fn = "../../ctl/eq_iir_coef_drceq.blob"; % Blob binary file
+alsa_fn = "../../ctl/eq_iir_coef_drceq.txt"; % ALSA CSV format file
+
+endian = "little";
+
+sample_rate = 48000;
+nyquist = sample_rate / 2;
+
+%% Input parameters
+% 1-st channel 1-st biquad parameter
+eq_2ch_params(1).type = 2;
+eq_2ch_params(1).freq = 195;
+eq_2ch_params(1).Q = 0;
+eq_2ch_params(1).gain = 0;
+% 2-nd channel 1-st biquad parameter
+eq_2ch_params(2).type = 2;
+eq_2ch_params(2).freq = 195;
+eq_2ch_params(2).Q = 0;
+eq_2ch_params(2).gain = 0;
+% 1-st channel 2-nd biquad parameter
+eq_2ch_params(3).type = 6;
+eq_2ch_params(3).freq = 520;
+eq_2ch_params(3).Q = 1.8;
+eq_2ch_params(3).gain = -10;
+% 2-nd channel 2-nd biquad parameter
+eq_2ch_params(4).type = 6;
+eq_2ch_params(4).freq = 520;
+eq_2ch_params(4).Q = 1.8;
+eq_2ch_params(4).gain = -10;
+% 1-st channel 3-rd biquad parameter
+eq_2ch_params(5).type = 6;
+eq_2ch_params(5).freq = 2900;
+eq_2ch_params(5).Q = 0.5;
+eq_2ch_params(5).gain = -9;
+% 2-nd channel 3-rd biquad parameter
+eq_2ch_params(6).type = 6;
+eq_2ch_params(6).freq = 2900;
+eq_2ch_params(6).Q = 0.5;
+eq_2ch_params(6).gain = -9;
+% 1-st channel 4-th biquad parameter
+eq_2ch_params(7).type = 6;
+eq_2ch_params(7).freq = 12000;
+eq_2ch_params(7).Q = 0.8;
+eq_2ch_params(7).gain = 6;
+% 2-nd channel 4-th biquad parameter
+eq_2ch_params(8).type = 6;
+eq_2ch_params(8).freq = 12000;
+eq_2ch_params(8).Q = 0.8;
+eq_2ch_params(8).gain = 6;
+% 1-st channel 5-th biquad parameter
+eq_2ch_params(9).type = 6;
+eq_2ch_params(9).freq = 4000;
+eq_2ch_params(9).Q = 3.5;
+eq_2ch_params(9).gain = -4.5;
+% 2-nd channel 5-th biquad parameter
+eq_2ch_params(10).type = 6;
+eq_2ch_params(10).freq = 4000;
+eq_2ch_params(10).Q = 3.5;
+eq_2ch_params(10).gain = -4.5;
+% 1-st channel 6-th biquad parameter
+eq_2ch_params(11).type = 6;
+eq_2ch_params(11).freq = 1100;
+eq_2ch_params(11).Q = 2;
+eq_2ch_params(11).gain = -5.5;
+% 2-nd channel 6-th biquad parameter
+eq_2ch_params(12).type = 6;
+eq_2ch_params(12).freq = 1100;
+eq_2ch_params(12).Q = 2;
+eq_2ch_params(12).gain = -5.5;
+% 1-st channel 7-th biquad parameter
+eq_2ch_params(13).type = 6;
+eq_2ch_params(13).freq = 3100;
+eq_2ch_params(13).Q = 4;
+eq_2ch_params(13).gain = -2;
+% 2-nd channel 7-th biquad parameter
+eq_2ch_params(14).type = 6;
+eq_2ch_params(14).freq = 3100;
+eq_2ch_params(14).Q = 4;
+eq_2ch_params(14).gain = -2;
+% 1-st channel 8-th biquad parameter
+eq_2ch_params(15).type = 6;
+eq_2ch_params(15).freq = 220;
+eq_2ch_params(15).Q = 2;
+eq_2ch_params(15).gain = -3.5;
+% 2-nd channel 8-th biquad parameter
+eq_2ch_params(16).type = 6;
+eq_2ch_params(16).freq = 220;
+eq_2ch_params(16).Q = 2;
+eq_2ch_params(16).gain = -3.5;
+
+%% Calculate biquad coefficients
+eq1_biquad_coefs = cell(1, length(eq_2ch_params)/2);
+eq2_biquad_coefs = cell(1, length(eq_2ch_params)/2);
+for i = 1:length(eq_2ch_params)/2
+	eq_2ch_params(i*2-1).freq /= nyquist;
+	eq1_biquad_coefs(i) = biquad_gen_df2t_coefs(eq_2ch_params(i*2-1));
+	eq_2ch_params(i*2).freq /= nyquist;
+	eq2_biquad_coefs(i) = biquad_gen_df2t_coefs(eq_2ch_params(i*2));
+endfor
+
+eq1_biquad_coefs = eq_adjust_shift_gain(eq1_biquad_coefs)
+eq2_biquad_coefs = eq_adjust_shift_gain(eq2_biquad_coefs)
+
+%% Generate quantized EQ headers
+eq1_header_quant = eq_gen_header_quant(eq1_biquad_coefs);
+eq2_header_quant = eq_gen_header_quant(eq2_biquad_coefs);
+
+%% Build config blob
+addpath ../eq
+
+channels_in_config = 2;
+num_responses = 2;
+assign_response = [0 1];
+bm = eq_iir_blob_merge(channels_in_config, ...
+		       num_responses, ...
+		       assign_response, ...
+		       [eq1_header_quant eq2_header_quant]);
+
+bp = eq_iir_blob_pack(bm, endian);
+
+rmpath ../eq
+
+%% Generate output files
+addpath ../common
+
+tplg_write(tplg_fn, bp, "EQIIR");
+blob_write(blob_fn, bp);
+alsactl_write(alsa_fn, bp);
+
+rmpath ../common
+
+endfunction


### PR DESCRIPTION
This is the temporary script to convert ChromeOS EQ parameters into
the config blob of EQIIR on SOF. ChromeOS EQ parameters are tuned by
OEM on board manufacturing stage and recorded in the file dsp.ini.

The final goal is to establish the conversion logic on ChromeOS user
space side to automatically generate the config blob from dsp.ini and
write into the corresponding EQIIR on SOF.