### PR TITLE
dw-dma: fix the lli corruption issue

### DIFF
--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -437,9 +437,6 @@ static int dw_dma_stop(struct dma_chan_data *channel)
 		lli->ctrl_hi &= ~DW_CTLH_DONE(1);
 		lli++;
 	}
-
-	dcache_writeback_region(dw_chan->lli,
-				sizeof(struct dw_lli) * channel->desc_count);
 #endif
 
 	/* disable linear link position */
@@ -557,9 +554,9 @@ static int dw_dma_set_config(struct dma_chan_data *channel,
 		if (dw_chan->lli)
 			rfree(dw_chan->lli);
 
-		dw_chan->lli = rballoc_align(0, SOF_MEM_CAPS_RAM | SOF_MEM_CAPS_DMA,
-					sizeof(struct dw_lli) * channel->desc_count,
-					PLATFORM_DCACHE_ALIGN);
+		dw_chan->lli = rzalloc(SOF_MEM_ZONE_RUNTIME_SHARED, 0,
+				       SOF_MEM_CAPS_RAM | SOF_MEM_CAPS_DMA,
+				       sizeof(struct dw_lli) * channel->desc_count);
 		if (!dw_chan->lli) {
 			tr_err(&dwdma_tr, "dw_dma_set_config(): dma %d channel %d lli alloc failed",
 			       channel->dma->plat_data.id,
@@ -767,10 +764,6 @@ static int dw_dma_set_config(struct dma_chan_data *channel,
 #endif
 	}
 
-	/* write back descriptors so DMA engine can read them directly */
-	dcache_writeback_region(dw_chan->lli,
-				sizeof(struct dw_lli) * channel->desc_count);
-
 	channel->status = COMP_STATE_PREPARE;
 	dw_chan->lli_current = dw_chan->lli;
 
@@ -810,7 +803,7 @@ static void dw_dma_verify_transfer(struct dma_chan_data *channel,
 #if defined __ZEPHYR__
 	int i;
 #else
-	struct dw_lli *lli = platform_dw_dma_lli_get(dw_chan->lli_current);
+	struct dw_lli *lli = dw_chan->lli_current;
 #endif
 	switch (next->status) {
 	case DMA_CB_STATUS_END:
@@ -823,20 +816,14 @@ static void dw_dma_verify_transfer(struct dma_chan_data *channel,
 	 * sure the cache is coherent between DSP and DMAC.
 	 */
 #if defined __ZEPHYR__
-		dcache_invalidate_region(dw_chan->lli,
-					 sizeof(struct dw_lli) * channel->desc_count);
-
 		for (i = 0; i < channel->desc_count; i++)
 			dw_chan->lli[i].ctrl_hi &= ~DW_CTLH_DONE(1);
-
-		dcache_writeback_region(dw_chan->lli,
-					sizeof(struct dw_lli) * channel->desc_count);
 #else
 		while (lli->ctrl_hi & DW_CTLH_DONE(1)) {
 			lli->ctrl_hi &= ~DW_CTLH_DONE(1);
 			dw_chan->lli_current =
 				(struct dw_lli *)dw_chan->lli_current->llp;
-			lli = platform_dw_dma_lli_get(dw_chan->lli_current);
+			lli = dw_chan->lli_current;
 		}
 #endif
 		break;

--- a/src/include/sof/drivers/dw-dma.h
+++ b/src/include/sof/drivers/dw-dma.h
@@ -130,11 +130,6 @@
 #define DW_DMA_BUFFER_ALIGNMENT 0x4
 #define DW_DMA_COPY_ALIGNMENT	0x4
 
-/* LLI address alignment, in Bytes */
-#ifndef DW_DMA_LLI_ALIGN
-#define DW_DMA_LLI_ALIGN	32
-#endif
-
 /* TODO: add FIFO sizes */
 struct dw_chan_data {
 	uint16_t class;
@@ -155,10 +150,10 @@ struct dw_lli {
 	uint32_t sstat;
 	uint32_t dstat;
 
-	/* align to required bytes to make sure every item
-	 * is aligned in case of more than two items
+	/* align to 32 bytes to not cross cache line
+	 * in case of more than two items
 	 */
-	uint8_t reserved[DW_DMA_LLI_ALIGN - sizeof(uint32_t) * 7];
+	uint32_t reserved;
 } __packed;
 
 extern const struct dma_ops dw_dma_ops;

--- a/src/platform/intel/cavs/include/cavs/drivers/dw-dma.h
+++ b/src/platform/intel/cavs/include/cavs/drivers/dw-dma.h
@@ -85,11 +85,6 @@ static inline void platform_dw_dma_llp_disable(struct dma *dma,
 		   shim_read(DW_CHLLPC(dma, chan)) & ~SHIM_GPDMA_CHLLPC_EN);
 }
 
-static inline struct dw_lli *platform_dw_dma_lli_get(struct dw_lli *lli)
-{
-	return cache_to_uncache(lli);
-}
-
 #endif /* __CAVS_LIB_DW_DMA_H__ */
 
 #else

--- a/src/platform/intel/cavs/lib/memory.c
+++ b/src/platform/intel/cavs/lib/memory.c
@@ -192,7 +192,7 @@ void platform_init_memmap(struct sof *sof)
 	sof->memory_map->runtime_shared[0].size = HEAP_RUNTIME_SHARED_SIZE;
 	sof->memory_map->runtime_shared[0].info.free = HEAP_RUNTIME_SHARED_SIZE;
 	sof->memory_map->runtime_shared[0].caps = SOF_MEM_CAPS_RAM | SOF_MEM_CAPS_EXT |
-		SOF_MEM_CAPS_CACHE;
+		SOF_MEM_CAPS_CACHE | SOF_MEM_CAPS_DMA;
 
 	/* .system_shared init */
 	sof->memory_map->system_shared[0].heap = cache_to_uncache((uintptr_t)&_system_shared_heap);

--- a/src/platform/tigerlake/include/platform/drivers/dw-dma.h
+++ b/src/platform/tigerlake/include/platform/drivers/dw-dma.h
@@ -12,9 +12,6 @@
 
 #include <cavs/drivers/dw-dma.h>
 
-/* LLI address alignment, in Bytes */
-#define DW_DMA_LLI_ALIGN	128
-
 #endif /* __PLATFORM_DRIVERS_DW_DMA_H__ */
 
 #else


### PR DESCRIPTION
dw-dma: change to use runtime_shared heap for lli buffer

The lli structs are used by both DSP and DMAC, allocate them from the
runtime_shared heap to avoid being corrupted by cache writing back.

This helps to fix a lot of DMA xrun issue according to the validation.

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>