### PR TITLE
dw-dma: set LLI alignment to platform specific

### DIFF
--- a/src/include/sof/drivers/dw-dma.h
+++ b/src/include/sof/drivers/dw-dma.h
@@ -130,6 +130,11 @@
 #define DW_DMA_BUFFER_ALIGNMENT 0x4
 #define DW_DMA_COPY_ALIGNMENT	0x4
 
+/* LLI address alignment, in Bytes */
+#ifndef DW_DMA_LLI_ALIGN
+#define DW_DMA_LLI_ALIGN	32
+#endif
+
 /* TODO: add FIFO sizes */
 struct dw_chan_data {
 	uint16_t class;
@@ -150,10 +155,10 @@ struct dw_lli {
 	uint32_t sstat;
 	uint32_t dstat;
 
-	/* align to 32 bytes to not cross cache line
-	 * in case of more than two items
+	/* align to required bytes to make sure every item
+	 * is aligned in case of more than two items
 	 */
-	uint32_t reserved;
+	uint8_t reserved[DW_DMA_LLI_ALIGN - sizeof(uint32_t) * 7];
 } __packed;
 
 extern const struct dma_ops dw_dma_ops;

--- a/src/platform/tigerlake/include/platform/drivers/dw-dma.h
+++ b/src/platform/tigerlake/include/platform/drivers/dw-dma.h
@@ -12,6 +12,9 @@
 
 #include <cavs/drivers/dw-dma.h>
 
+/* LLI address alignment, in Bytes */
+#define DW_DMA_LLI_ALIGN	128
+
 #endif /* __PLATFORM_DRIVERS_DW_DMA_H__ */
 
 #else


### PR DESCRIPTION
It is observed that on different platforms, the LLI need to be aligned
different, e.g. it is 128 Bytes on TGL, otherwise, the LLI struct might
be clobbered and the DMA channel might get unexpected stopped, which
will eventually lead to Xrun.

Here make the LLI alignment to platform specific and use 128 Bytes for
TGL.

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>