### PR TITLE
ssp: bclk/mclk control is ignored

### DIFF
--- a/src/drivers/intel/ssp/ssp.c
+++ b/src/drivers/intel/ssp/ssp.c
@@ -757,6 +757,14 @@ clk:
 		}
 		break;
 	case SOF_DAI_CONFIG_FLAGS_HW_FREE:
+		/* disable SSP port if no users */
+		if (ssp->state[SOF_IPC_STREAM_CAPTURE] != COMP_STATE_PREPARE ||
+		    ssp->state[SOF_IPC_STREAM_PLAYBACK] != COMP_STATE_PREPARE) {
+			dai_info(dai, "ssp_set_config(): hw_free stage: ignore since there is still user",
+				 dai->index);
+			break;
+		}
+
 		if (ssp->params.clks_control & SOF_DAI_INTEL_SSP_CLKCTRL_BCLK_ES) {
 			dai_info(dai, "ssp_set_config(): hw_free stage: releasing BCLK clocks for SSP%d...",
 				 dai->index);

--- a/src/drivers/intel/ssp/ssp.c
+++ b/src/drivers/intel/ssp/ssp.c
@@ -273,7 +273,7 @@ static int ssp_set_config_tplg(struct dai *dai, struct ipc_config_dai *common_co
 	if (ssp->state[DAI_DIR_PLAYBACK] > COMP_STATE_READY ||
 	    ssp->state[DAI_DIR_CAPTURE] > COMP_STATE_READY) {
 		dai_info(dai, "ssp_set_config(): Already configured. Ignore config");
-		goto out;
+		goto clk;
 	}
 
 	dai_info(dai, "ssp_set_config(), config->format = 0x%4x",
@@ -713,6 +713,7 @@ static int ssp_set_config_tplg(struct dai *dai, struct ipc_config_dai *common_co
 	ssp->state[DAI_DIR_PLAYBACK] = COMP_STATE_PREPARE;
 	ssp->state[DAI_DIR_CAPTURE] = COMP_STATE_PREPARE;
 
+clk:
 	switch (config->flags & SOF_DAI_CONFIG_FLAGS_MASK) {
 	case SOF_DAI_CONFIG_FLAGS_HW_PARAMS:
 		if (ssp->params.clks_control & SOF_DAI_INTEL_SSP_CLKCTRL_MCLK_ES) {


### PR DESCRIPTION
Two issues ware identified when we test early bclk feature on JSL Chromebooks.

1. bclk/mclk control is ignored
2. mdivctrl corruption