### PR TITLE
xtensa-build-zephyr: disable XCC build for Intel APL

### DIFF
--- a/scripts/xtensa-build-zephyr.sh
+++ b/scripts/xtensa-build-zephyr.sh
@@ -122,8 +122,11 @@ build()
 		case "$platform" in
 			apl)
 				PLAT_CONFIG='intel_adsp_cavs15'
-				XTENSA_CORE="X4H3I16w2D48w3a_2017_8"
-				XTENSA_TOOLS_VERSION="RG-2017.8-linux"
+				# XCC build runs out of memory, tracked as
+				# https://github.com/thesofproject/sof/issues/4645
+				unset XTENSA_TOOLS_ROOT
+				#XTENSA_CORE="X4H3I16w2D48w3a_2017_8"
+				#XTENSA_TOOLS_VERSION="RG-2017.8-linux"
 				;;
 			cnl)
 				PLAT_CONFIG='intel_adsp_cavs18'


### PR DESCRIPTION
The BSS usage exceeds available memory when building for
APL/cavs15 hardware with XCC, so disable it for now. Issue
tracked as https://github.com/thesofproject/sof/issues/4645

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>