### PR TITLE
Integrate RTNR into sof-tgl-max98357a-rt5682.m4

### DIFF
--- a/tools/topology/topology1/CMakeLists.txt
+++ b/tools/topology/topology1/CMakeLists.txt
@@ -145,6 +145,7 @@ set(TPLGS
 	"sof-tgl-max98357a-rt5682\;sof-adl-max98357a-rt5682\;-DCODEC=MAX98357A\;-DFMT=s16le\;-DPLATFORM=adl\;-DAMP_SSP=2"
 	"sof-tgl-max98357a-rt5682\;sof-tgl-max98357a-rt5682-pdm1\;-DCODEC=MAX98357A\;-DFMT=s16le\;-DDMIC_DAI_LINK_16k_PDM=STEREO_PDM1\;-DPLATFORM=tgl\;-DAMP_SSP=1"
 	"sof-tgl-max98357a-rt5682\;sof-tgl-rt1011-rt5682\;-DCODEC=RT1011\;-DFMT=s24le\;-DPLATFORM=tgl\;-DAMP_SSP=1"
+	"sof-tgl-max98357a-rt5682\;sof-tgl-max98357a-rt5682-rtnr\;-DCODEC=MAX98357A\;-DFMT=s16le\;-DPLATFORM=tgl\;-DAMP_SSP=1\;-DCHANNELS=2\;-DDMICPROC=eq-iir-volume\;-DRTNR"
 	"sof-tgl-max98357a-rt5682-rtnr-16kHz\;sof-tgl-max98357a-rt5682-rtnr-16kHz\;-DCODEC=MAX98357A\;-DFMT=s16le\;-DCHANNELS=2\;-DDMICPROC=eq-iir-volume\;-DRTNR"
 	"sof-tgl-max98373-rt5682\;sof-tgl-max98373-rt5682\;-DAMP_SSP=1"
 	"sof-tgl-max98373-rt5682\;sof-tgl-max98373-rt5682-igonr\;-DAMP_SSP=1\;-DIGO"

--- a/tools/topology/topology1/sof-tgl-max98357a-rt5682.m4
+++ b/tools/topology/topology1/sof-tgl-max98357a-rt5682.m4
@@ -97,8 +97,12 @@ define(DMIC_PIPELINE_KWD_ID, `12')
 define(DMIC_DAI_LINK_16k_ID, `2')
 # define pcm, pipeline and dai id
 define(KWD_PIPE_SCH_DEADLINE_US, 5000)
-# include the generic dmic with kwd
-include(`platform/intel/intel-generic-dmic-kwd.m4')
+
+# if RTNR is defined, define DMIC16KPROC as rtnr
+ifdef(`RTNR',`', define(DMIC16KPROC, rtnr))
+
+# include the generic dmic if RTNR is defined, else include generic dmic with kwd
+include(ifdef(`RTNR', platform/intel/intel-generic-dmic.m4, platform/intel/intel-generic-dmic-kwd.m4))
 
 dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,


### PR DESCRIPTION
This Pull Request integrates RTNR component into sof-tgl-max98357a-rt5682.m4. DMIC16KPROC will be defined as rtnr if RTNR is defined. Both sink and source need to be 2 channels for RTNR.

Signed-off-by: Ming Jen Tai <mingjen_tai@realtek.com>