### PR TITLE
Audio: Fix sink buffer size check in several processing components

### DIFF
--- a/src/audio/crossover/crossover.c
+++ b/src/audio/crossover/crossover.c
@@ -759,8 +759,7 @@ static int crossover_prepare(struct comp_dev *dev)
 
 		sink_period_bytes = audio_stream_period_bytes(&sink->stream,
 							      dev->frames);
-		if (sink->stream.size <
-				dev->ipc_config.periods_sink * sink_period_bytes) {
+		if (sink->stream.size < sink_period_bytes) {
 			comp_err(dev, "crossover_prepare(), sink %d buffer size %d is insufficient",
 				 sink->pipeline_id, sink->stream.size);
 			ret = -ENOMEM;

--- a/src/audio/dcblock/dcblock.c
+++ b/src/audio/dcblock/dcblock.c
@@ -344,9 +344,9 @@ static int dcblock_prepare(struct comp_dev *dev)
 	sink_period_bytes =
 			audio_stream_period_bytes(&sinkb->stream, dev->frames);
 
-	if (sinkb->stream.size < dev->ipc_config.periods_sink * sink_period_bytes) {
-		comp_err(dev, "dcblock_prepare(): sink buffer size %d is insufficient < %d * %d",
-			 sinkb->stream.size, dev->ipc_config.periods_sink, sink_period_bytes);
+	if (sinkb->stream.size < sink_period_bytes) {
+		comp_err(dev, "dcblock_prepare(): sink buffer size %d is insufficient < %d",
+			 sinkb->stream.size, sink_period_bytes);
 		ret = -ENOMEM;
 		goto err;
 	}

--- a/src/audio/drc/drc.c
+++ b/src/audio/drc/drc.c
@@ -420,7 +420,7 @@ static int drc_prepare(struct comp_dev *dev)
 	sink_period_bytes = audio_stream_period_bytes(&sinkb->stream,
 						      dev->frames);
 
-	if (sinkb->stream.size < dev->ipc_config.periods_sink * sink_period_bytes) {
+	if (sinkb->stream.size < sink_period_bytes) {
 		comp_err(dev, "drc_prepare(), sink buffer size %d is insufficient",
 			 sinkb->stream.size);
 		ret = -ENOMEM;

--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -563,9 +563,9 @@ static int eq_fir_prepare(struct comp_dev *dev)
 	sink_period_bytes = audio_stream_period_bytes(&sinkb->stream,
 						      dev->frames);
 
-	if (sinkb->stream.size < dev->ipc_config.periods_sink * sink_period_bytes) {
-		comp_err(dev, "eq_fir_prepare(): sink buffer size %d is insufficient < %d * %d",
-			 sinkb->stream.size, dev->ipc_config.periods_sink, sink_period_bytes);
+	if (sinkb->stream.size < sink_period_bytes) {
+		comp_err(dev, "eq_fir_prepare(): sink buffer size %d is insufficient < %d",
+			 sinkb->stream.size, sink_period_bytes);
 		ret = -ENOMEM;
 		goto err;
 	}

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -781,9 +781,9 @@ static int eq_iir_prepare(struct comp_dev *dev)
 	sink_period_bytes = audio_stream_period_bytes(&sinkb->stream,
 						      dev->frames);
 
-	if (sinkb->stream.size < dev->ipc_config.periods_sink * sink_period_bytes) {
-		comp_err(dev, "eq_iir_prepare(): sink buffer size %d is insufficient < %d * %d",
-			 sinkb->stream.size, dev->ipc_config.periods_sink, sink_period_bytes);
+	if (sinkb->stream.size < sink_period_bytes) {
+		comp_err(dev, "eq_iir_prepare(): sink buffer size %d is insufficient < %d",
+			 sinkb->stream.size, sink_period_bytes);
 		ret = -ENOMEM;
 		goto err;
 	}

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -191,9 +191,9 @@ static int mixer_params(struct comp_dev *dev,
 		return -EINVAL;
 	}
 
-	if (sinkb->stream.size < dev->ipc_config.periods_sink * sink_period_bytes) {
-		comp_err(dev, "mixer_params(): sink buffer size %d is insufficient < %d * %d",
-			 sinkb->stream.size, dev->ipc_config.periods_sink, sink_period_bytes);
+	if (sinkb->stream.size < sink_period_bytes) {
+		comp_err(dev, "mixer_params(): sink buffer size %d is insufficient < %d",
+			 sinkb->stream.size, sink_period_bytes);
 		return -ENOMEM;
 	}
 

--- a/src/audio/multiband_drc/multiband_drc.c
+++ b/src/audio/multiband_drc/multiband_drc.c
@@ -517,7 +517,7 @@ static int multiband_drc_prepare(struct comp_dev *dev)
 	sink_period_bytes = audio_stream_period_bytes(&sinkb->stream,
 						      dev->frames);
 
-	if (sinkb->stream.size < dev->ipc_config.periods_sink * sink_period_bytes) {
+	if (sinkb->stream.size < sink_period_bytes) {
 		comp_err(dev, "multiband_drc_prepare(), sink buffer size %d is insufficient",
 			 sinkb->stream.size);
 		ret = -ENOMEM;

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -462,9 +462,9 @@ static int selector_prepare(struct comp_dev *dev)
 	comp_info(dev, "selector_prepare(): sinkb->channels = %u",
 		  sinkb->stream.channels);
 
-	if (sinkb->stream.size < dev->ipc_config.periods_sink * cd->sink_period_bytes) {
-		comp_err(dev, "selector_prepare(): sink buffer size %d is insufficient < %d * %d",
-			 sinkb->stream.size, dev->ipc_config.periods_sink, cd->sink_period_bytes);
+	if (sinkb->stream.size < cd->sink_period_bytes) {
+		comp_err(dev, "selector_prepare(): sink buffer size %d is insufficient < %d",
+			 sinkb->stream.size, cd->sink_period_bytes);
 		ret = -ENOMEM;
 		goto err;
 	}

--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -831,9 +831,9 @@ static int volume_prepare(struct comp_dev *dev)
 	sink_period_bytes = audio_stream_period_bytes(&sinkb->stream,
 						      dev->frames);
 
-	if (sinkb->stream.size < dev->ipc_config.periods_sink * sink_period_bytes) {
-		comp_err(dev, "volume_prepare(): sink buffer size %d is insufficient < %d * %d",
-			 sinkb->stream.size, dev->ipc_config.periods_sink, sink_period_bytes);
+	if (sinkb->stream.size < sink_period_bytes) {
+		comp_err(dev, "volume_prepare(): sink buffer size %d is insufficient < %d",
+			 sinkb->stream.size, sink_period_bytes);
 		ret = -ENOMEM;
 		goto err;
 	}


### PR DESCRIPTION
This patch fixes the check in crossover, dcblock, drc, eq, mixer,
multiband drc, selector, and volume components. The check should
be for 1 period of data.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>