### PR TITLE
Heap refinement Part2 -- Dw dma fixes

### DIFF
--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -557,9 +557,8 @@ static int dw_dma_set_config(struct dma_chan_data *channel,
 		if (dw_chan->lli)
 			rfree(dw_chan->lli);
 
-		dw_chan->lli = rballoc_align(0, SOF_MEM_CAPS_RAM | SOF_MEM_CAPS_DMA,
-					sizeof(struct dw_lli) * channel->desc_count,
-					PLATFORM_DCACHE_ALIGN);
+		dw_chan->lli = rmalloc(SOF_MEM_ZONE_RUNTIME_SHARED, 0, SOF_MEM_CAPS_RAM,
+				       sizeof(struct dw_lli) * channel->desc_count);
 		if (!dw_chan->lli) {
 			tr_err(&dwdma_tr, "dw_dma_set_config(): dma %d channel %d lli alloc failed",
 			       channel->dma->plat_data.id,

--- a/src/include/sof/drivers/dw-dma.h
+++ b/src/include/sof/drivers/dw-dma.h
@@ -130,11 +130,6 @@
 #define DW_DMA_BUFFER_ALIGNMENT 0x4
 #define DW_DMA_COPY_ALIGNMENT	0x4
 
-/* LLI address alignment, in Bytes */
-#ifndef DW_DMA_LLI_ALIGN
-#define DW_DMA_LLI_ALIGN	32
-#endif
-
 /* TODO: add FIFO sizes */
 struct dw_chan_data {
 	uint16_t class;
@@ -155,10 +150,10 @@ struct dw_lli {
 	uint32_t sstat;
 	uint32_t dstat;
 
-	/* align to required bytes to make sure every item
-	 * is aligned in case of more than two items
+	/* align to 32 bytes to not cross cache line
+	 * in case of more than two items
 	 */
-	uint8_t reserved[DW_DMA_LLI_ALIGN - sizeof(uint32_t) * 7];
+	uint32_t reserved;
 } __packed;
 
 extern const struct dma_ops dw_dma_ops;

--- a/src/platform/tigerlake/include/platform/drivers/dw-dma.h
+++ b/src/platform/tigerlake/include/platform/drivers/dw-dma.h
@@ -12,9 +12,6 @@
 
 #include <cavs/drivers/dw-dma.h>
 
-/* LLI address alignment, in Bytes */
-#define DW_DMA_LLI_ALIGN	128
-
 #endif /* __PLATFORM_DRIVERS_DW_DMA_H__ */
 
 #else


### PR DESCRIPTION
    dw-dma: change to use runtime_shared heap for lli buffer
    
    The lli structs are used by both DSP and DMAC, allocate them from the
    runtime_shared heap to avoid being corrupted by cache writing back.
    
    This helps to fix a lot of DMA xrun issue according to the validation.

after this fix, the previous merged commit that enlarging the lli struct size is not needed any more. @lgirdwood FYI.
