### PR TITLE
.github/zephyr.yml: update docker for cmake requirement

### DIFF
--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -18,5 +18,5 @@ jobs:
       - name: build
         run: docker run -v "$(pwd)":/workdir
              -e ZEPHYR_SDK_INSTALL_DIR='/opt/toolchains/zephyr-sdk-0.13.0'
-             docker.io/zephyrprojectrtos/zephyr-build:v0.18.1
+             docker.io/zephyrprojectrtos/zephyr-build:v0.18.3
              ./zephyr/docker-build.sh


### PR DESCRIPTION
The latest zephyr requires CMake version >= 3.20,
we have to update the docker image to meet the
requirement.

Signed-off-by: Chao Song <chao.song@linux.intel.com>