### PR TITLE
drc: Optimize with cordic sine function

### DIFF
--- a/src/audio/drc/drc_math_generic.c
+++ b/src/audio/drc/drc_math_generic.c
@@ -106,6 +106,7 @@ inline int32_t drc_log_fixed(int32_t x)
 	return q_mult(LOG10, log10_x, 29, 26, 26);
 }
 
+#ifndef DRC_USE_CORDIC_ASIN
 /*
  * Input is Q2.30; valid range: [-1.0, 1.0]
  * Output range: [-1.0, 1.0]; regulated to Q2.30: (-2.0, 2.0)
@@ -164,6 +165,7 @@ inline int32_t drc_asin_fixed(int32_t x)
 #undef qch
 #undef qcl
 }
+#endif /* !DRC_USE_CORDIC_ASIN */
 
 /*
  * Input depends on precision_x
@@ -218,19 +220,6 @@ inline int32_t drc_inv_fixed(int32_t x, int32_t precision_x, int32_t precision_y
 }
 
 #endif /* DRC_GENERIC */
-
-/*
- * Input is Q2.30: (-2.0, 2.0)
- * Output range: (-1.0, 1.0); regulated to Q1.31: (-1.0, 1.0)
- */
-inline int32_t drc_sin_fixed(int32_t x)
-{
-	const int32_t PI_OVER_TWO = Q_CONVERT_FLOAT(1.57079632679489661923, 30);
-	/* input range of sin_fixed_16b() is non-negative */
-	int32_t abs_sin_val = sin_fixed_16b(q_mult(ABS(x), PI_OVER_TWO, 30, 30, 28));
-
-	return x < 0 ? -abs_sin_val << 16 : abs_sin_val << 16;
-}
 
 /*
  * Input x is Q6.26; valid range: (0.0, 32.0); x <= 0 is not supported

--- a/src/audio/drc/drc_math_hifi3.c
+++ b/src/audio/drc/drc_math_hifi3.c
@@ -23,7 +23,6 @@
 #define NEG_1K_Q21 -2097151999 /* Q_CONVERT_FLOAT(-1000.0f, 21) */
 #define LOG_10_Q29 1236190976 /* Q_CONVERT_FLOAT(2.3025850929940457f, 29) */
 #define NEG_30_Q26 -2013265919 /* Q_CONVERT_FLOAT(-30.0f, 26) */
-#define TWO_OVER_PI_Q30 683565248 /* Q_CONVERT_FLOAT(0.63661977236758134f, 30); 2/pi */
 #define ASIN_FUNC_A7L_Q30 126897672 /* Q_CONVERT_FLOAT(0.1181826665997505187988281f, 30) */
 #define ASIN_FUNC_A5L_Q30 43190596 /* Q_CONVERT_FLOAT(4.0224377065896987915039062e-2f, 30) */
 #define ASIN_FUNC_A3L_Q30 184887136 /* Q_CONVERT_FLOAT(0.1721895635128021240234375f, 30) */
@@ -129,6 +128,7 @@ inline int32_t drc_log_fixed(int32_t x)
 	return drc_mult_lshift(LOG_10_Q29, log10_x, drc_get_lshift(29, 26, 26));
 }
 
+#ifndef DRC_USE_CORDIC_ASIN
 /*
  * Input is Q2.30; valid range: [-1.0, 1.0]
  * Output range: [-1.0, 1.0]; regulated to Q2.30: (-2.0, 2.0)
@@ -178,6 +178,7 @@ inline int32_t drc_asin_fixed(int32_t x)
 	lshift = drc_get_lshift(qc, 30, 30);
 	return drc_mult_lshift(acc, TWO_OVER_PI_Q30, lshift);
 }
+#endif /* !DRC_USE_CORDIC_ASIN */
 
 /*
  * Input depends on precision_x


### PR DESCRIPTION
This patch optimizes for speed of DRC with cordic sine function usage in both HiFi3 and generic manners.