### PR TITLE
dma-trace: add check to avoid dereference from NULL

### DIFF
--- a/src/ipc/dma-copy.c
+++ b/src/ipc/dma-copy.c
@@ -64,6 +64,10 @@ int dma_copy_to_host_nowait(struct dma_copy *dc, struct dma_sg_config *host_sg,
 {
 	int ret;
 
+	/* return if DMA channel is not get yet */
+	if (!dc->chan)
+		return -EINVAL;
+
 	/* tell gateway to copy */
 	ret = dma_copy(dc->chan, size, 0);
 	if (ret < 0)
@@ -84,6 +88,10 @@ int dma_copy_to_host_nowait(struct dma_copy *dc, struct dma_sg_config *host_sg,
 	struct dma_sg_elem local_sg_elem;
 	int32_t err;
 	int32_t offset = host_offset;
+
+	/* return if DMA channel is not get yet */
+	if (!dc->chan)
+		return -EINVAL;
 
 	if (size <= 0)
 		return 0;

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -524,7 +524,9 @@ int platform_init(struct sof *sof)
 #elif CONFIG_TRACE
 	/* Initialize DMA for Trace*/
 	trace_point(TRACE_BOOT_PLATFORM_DMA_TRACE);
-	dma_trace_init_complete(sof->dmat);
+	ret = dma_trace_init_complete(sof->dmat);
+	if (ret < 0)
+		return ret;
 #endif
 
 	/* show heap status */

--- a/src/trace/dma-trace.c
+++ b/src/trace/dma-trace.c
@@ -476,9 +476,8 @@ void dma_trace_on(void)
 {
 	struct dma_trace_data *trace_data = dma_trace_data_get();
 
-	if (trace_data->enabled) {
+	if (!trace_data || trace_data->enabled)
 		return;
-	}
 
 	trace_data->enabled = 1;
 	schedule_task(&trace_data->dmat_work, DMA_TRACE_PERIOD,
@@ -490,9 +489,8 @@ void dma_trace_off(void)
 {
 	struct dma_trace_data *trace_data = dma_trace_data_get();
 
-	if (!trace_data->enabled) {
+	if (!trace_data || !trace_data->enabled)
 		return;
-	}
 
 	schedule_task_cancel(&trace_data->dmat_work);
 	trace_data->enabled = 0;

--- a/src/trace/trace.c
+++ b/src/trace/trace.c
@@ -272,9 +272,8 @@ void trace_log_unfiltered(bool send_atomic, const void *log_entry, const struct 
 	struct trace *trace = trace_get();
 	va_list vl;
 
-	if (!trace->enable) {
+	if (!trace || !trace->enable)
 		return;
-	}
 
 	va_start(vl, arg_count);
 	vatrace_log(send_atomic, (uint32_t)log_entry, ctx, lvl, id_1, id_2, arg_count, vl);


### PR DESCRIPTION
The DMA trace is not necessary enabled so the trace_data could be NULL,
add check to avoid dereference from NULL pointer and panics.

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>