### PR TITLE
ssp: mn: mdivctrl corruption in mn_release_mclk()

### DIFF
--- a/src/drivers/intel/ssp/mn.c
+++ b/src/drivers/intel/ssp/mn.c
@@ -291,7 +291,7 @@ void mn_release_mclk(uint32_t mclk_id)
 	if (!mn->mclk_sources_ref[mclk_id]) {
 		mdivc = mn_reg_read(MN_MDIVCTRL, mclk_id);
 
-		mdivc |= ~MN_MDIVCTRL_M_DIV_ENABLE(mclk_id);
+		mdivc &= ~MN_MDIVCTRL_M_DIV_ENABLE(mclk_id);
 		mn_reg_write(MN_MDIVCTRL, mclk_id, mdivc);
 	}
 


### PR DESCRIPTION
The mdivctrl register is corrupted when disabling MCLK divider in
mn_release_mclk() function. It could overwrite bclk's source clock and
stop the clock running.

Signed-off-by: Brent Lu <brent.lu@intel.com>