### PR TITLE
xtensa-build-zephyr: add imx8 as supported platform

### DIFF
--- a/scripts/xtensa-build-zephyr.sh
+++ b/scripts/xtensa-build-zephyr.sh
@@ -7,7 +7,7 @@ set -e
 
 SOF_TOP=$(cd "$(dirname "$0")" && cd .. && pwd)
 
-SUPPORTED_PLATFORMS=(apl cnl icl tgl-h)
+SUPPORTED_PLATFORMS=(apl cnl icl tgl-h imx8)
 # Default value, can (and sometimes must) be overridden with -p
 WEST_TOP="${SOF_TOP}"/zephyrproject
 BUILD_JOBS=$(nproc --all)


### PR DESCRIPTION
Add imx8 platform to be tested with Zephyr.

Signed-off-by: Iuliana Prodan <iuliana.prodan@nxp.com>