### PR TITLE
buffer: alloc main buffer struct in the runtime shared zone

### DIFF
--- a/src/audio/buffer.c
+++ b/src/audio/buffer.c
@@ -38,7 +38,7 @@ struct comp_buffer *buffer_alloc(uint32_t size, uint32_t caps, uint32_t align)
 	}
 
 	/* allocate new buffer */
-	buffer = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM,
+	buffer = rzalloc(SOF_MEM_ZONE_RUNTIME_SHARED, 0, SOF_MEM_CAPS_RAM,
 			 sizeof(*buffer));
 	if (!buffer) {
 		tr_err(&buffer_tr, "buffer_alloc(): could not alloc structure");


### PR DESCRIPTION
Buffers can be shared between cores and it is crucial to have access
to not only proper buffer data but also description data of this buffer

Fixes #4648 

Signed-off-by: Adrian Bonislawski <adrian.bonislawski@intel.com>