### PR TITLE
platform: (cosmetic) make all timer objects static

### DIFF
--- a/src/platform/amd/renoir/platform.c
+++ b/src/platform/amd/renoir/platform.c
@@ -61,7 +61,7 @@ static const struct sof_ipc_fw_ready ready
 	.flags = DEBUG_SET_FW_READY_FLAGS,
 };
 
-SHARED_DATA struct timer timer = {
+static SHARED_DATA struct timer timer = {
 	.id = TIMER0,
 	.irq = IRQ_NUM_TIMER0,
 };

--- a/src/platform/haswell/platform.c
+++ b/src/platform/haswell/platform.c
@@ -129,7 +129,7 @@ const struct ext_man_windows xsram_window
 	},
 };
 
-SHARED_DATA struct timer timer = {
+static SHARED_DATA struct timer timer = {
 	.id = TIMER1, /* internal timer */
 	.irq = IRQ_NUM_TIMER2,
 };

--- a/src/platform/imx8/platform.c
+++ b/src/platform/imx8/platform.c
@@ -128,7 +128,7 @@ const struct ext_man_windows xsram_window
 	}
 };
 
-SHARED_DATA struct timer timer = {
+static SHARED_DATA struct timer timer = {
 	.id = TIMER0, /* internal timer */
 	.irq = IRQ_NUM_TIMER0,
 };

--- a/src/platform/imx8m/platform.c
+++ b/src/platform/imx8m/platform.c
@@ -127,7 +127,7 @@ const struct ext_man_windows xsram_window
 	},
 };
 
-SHARED_DATA struct timer timer = {
+static SHARED_DATA struct timer timer = {
 	.id = TIMER0, /* internal timer */
 	.irq = IRQ_NUM_TIMER0,
 };

--- a/src/platform/imx8ulp/platform.c
+++ b/src/platform/imx8ulp/platform.c
@@ -124,7 +124,7 @@ const struct ext_man_windows xsram_window
 	}
 };
 
-SHARED_DATA struct timer timer = {
+static SHARED_DATA struct timer timer = {
 	.id = TIMER0, /* internal timer */
 	.irq = IRQ_NUM_TIMER0,
 };

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -264,13 +264,13 @@ const int n_iomux = ARRAY_SIZE(iomux_data);
 
 #endif
 
-SHARED_DATA struct timer timer = {
+static SHARED_DATA struct timer timer = {
 	.id = TIMER3, /* external timer */
 	.irq = IRQ_EXT_TSTAMP0_LVL2,
 	.irq_name = irq_name_level2,
 };
 
-SHARED_DATA struct timer arch_timers[CONFIG_CORE_COUNT];
+static SHARED_DATA struct timer arch_timers[CONFIG_CORE_COUNT];
 
 #if CONFIG_DW_SPI
 

--- a/src/platform/library/platform.c
+++ b/src/platform/library/platform.c
@@ -13,7 +13,7 @@
 #include <sof/lib/mailbox.h>
 #include <sof/lib/dai.h>
 
-SHARED_DATA struct timer timer = {};
+static SHARED_DATA struct timer timer = {};
 
 static uint8_t mailbox[MAILBOX_DSPBOX_SIZE +
 		       MAILBOX_HOSTBOX_SIZE +


### PR DESCRIPTION
All platform.c files contain timer objects, and some also arch_timers and most platforms define those objects as global. Make them static.
