### PR TITLE
xtensa-build-zephyr: disable XCC build for Intel ICL

### DIFF
--- a/scripts/xtensa-build-zephyr.sh
+++ b/scripts/xtensa-build-zephyr.sh
@@ -127,8 +127,11 @@ build()
 				;;
 			icl)
 				PLAT_CONFIG='intel_adsp_cavs20'
-				XTENSA_CORE="X6H3CNL_2017_8"
-				XTENSA_TOOLS_VERSION="RG-2017.8-linux"
+				# XCC build fails to linker script error, tracked as
+				# https://github.com/thesofproject/sof/issues/4703
+				unset XTENSA_TOOLS_ROOT
+				#XTENSA_CORE="X6H3CNL_2017_8"
+				#XTENSA_TOOLS_VERSION="RG-2017.8-linux"
 				;;
 			tgl-h)
 				PLAT_CONFIG='intel_adsp_cavs25'


### PR DESCRIPTION
There is a linker script failure with ICL/cavs20 hardware with XCC, so
disable the XCC build and force a build with gcc. Issue tracked
as https://github.com/thesofproject/sof/issues/4703

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>