### PR TITLE
IPC4: pipeline:  apply new pipeline status change to IPC4

### DIFF
--- a/src/ipc/ipc-common.c
+++ b/src/ipc/ipc-common.c
@@ -220,14 +220,6 @@ out:
 	spin_unlock_irq(&ipc->lock, flags);
 }
 
-void ipc_msg_reply(struct sof_ipc_reply *reply)
-{
-	struct ipc *ipc = ipc_get();
-
-	mailbox_hostbox_write(0, reply, reply->hdr.size);
-	ipc_complete_cmd(ipc);
-}
-
 void ipc_schedule_process(struct ipc *ipc)
 {
 	schedule_task(&ipc->ipc_task, 0, IPC_PERIOD_USEC);

--- a/src/ipc/ipc3/helper.c
+++ b/src/ipc/ipc3/helper.c
@@ -651,3 +651,11 @@ int ipc_comp_new(struct ipc *ipc, ipc_comp *_comp)
 
 	return 0;
 }
+
+void ipc_msg_reply(struct sof_ipc_reply *reply)
+{
+	struct ipc *ipc = ipc_get();
+
+	mailbox_hostbox_write(0, reply, reply->hdr.size);
+	ipc_complete_cmd(ipc);
+}

--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -88,6 +88,8 @@ int ipc_dai_data_config(struct comp_dev *dev)
 		copier_cfg = dd->dai_spec_config;
 		/* set dma burst elems to slot number */
 		dd->config.burst_elems = copier_cfg->base.audio_fmt.channels_count;
+		/* DMA buffer size is in fixed format of 32bit in IPC4 case */
+		dev->ipc_config.frame_fmt = SOF_IPC_FRAME_S32_LE;
 		break;
 	case SOF_DAI_INTEL_DMIC:
 		/* We can use always the largest burst length. */


### PR DESCRIPTION
Recently new pipeline status PRE_START and PRE_RELEASE are introduced to SOF and also msg reply method change. This patch apply it to ipc4.

And also enable multiple pipeline for mixin & mixout.