### PR TITLE
topology2: enable nocodec on tgl

### DIFF
--- a/tools/topology/topology2/cavs-nocodec.conf
+++ b/tools/topology/topology2/cavs-nocodec.conf
@@ -32,7 +32,7 @@ Object.Dai {
 
 		Object.Base.hw_config."SSP0" {
 			id	0
-			mclk_freq	24000000
+			mclk_freq	38400000
 			bclk_freq	4800000
 			tdm_slot_width	32
 		}
@@ -40,7 +40,7 @@ Object.Dai {
 		# include DAI copier components
 		Object.Widget.copier."0" {
 			index 1
-			dai_index 1
+			dai_index 0
 			type "dai_in"
 			dai_type "SSP"
 			copier_type "SSP"
@@ -53,7 +53,7 @@ Object.Dai {
 
 		Object.Widget.copier."1" {
 			index 2
-			dai_index 2
+			dai_index 0
 			type "dai_out"
 			dai_type "SSP"
 			copier_type "SSP"


### PR DESCRIPTION
Currently one SSP0 is supported by tgl and mclk is 38.4MHZ

Signed-off-by: Rander Wang <rander.wang@intel.com>