### PR TITLE
xtensa-build-zephyr: disable XCC build for Intel cAVS hw

### DIFF
--- a/scripts/xtensa-build-zephyr.sh
+++ b/scripts/xtensa-build-zephyr.sh
@@ -129,18 +129,28 @@ build()
 				;;
 			cnl)
 				PLAT_CONFIG='intel_adsp_cavs18'
-				XTENSA_CORE="X6H3CNL_2017_8"
-				XTENSA_TOOLS_VERSION="RG-2017.8-linux"
+				# issues, tracked as
+				# https://github.com/zephyrproject-rtos/zephyr/issues/38349
+				unset XTENSA_TOOLS_ROOT
+				#XTENSA_CORE="X6H3CNL_2017_8"
+				#XTENSA_TOOLS_VERSION="RG-2017.8-linux"
+				# XCC build fails to a linker script compatibility
 				;;
 			icl)
 				PLAT_CONFIG='intel_adsp_cavs20'
-				XTENSA_CORE="X6H3CNL_2017_8"
-				XTENSA_TOOLS_VERSION="RG-2017.8-linux"
+				# issues, tracked as
+				# https://github.com/zephyrproject-rtos/zephyr/issues/38349
+				unset XTENSA_TOOLS_ROOT
+				#XTENSA_CORE="X6H3CNL_2017_8"
+				#XTENSA_TOOLS_VERSION="RG-2017.8-linux"
 				;;
 			tgl-h|tgl)
 				PLAT_CONFIG='intel_adsp_cavs25'
-				XTENSA_CORE="cavs2x_LX6HiFi3_2017_8"
-				XTENSA_TOOLS_VERSION="RG-2017.8-linux"
+				# issues, tracked as
+				# https://github.com/zephyrproject-rtos/zephyr/issues/38349
+				unset XTENSA_TOOLS_ROOT
+				#XTENSA_CORE="cavs2x_LX6HiFi3_2017_8"
+				#XTENSA_TOOLS_VERSION="RG-2017.8-linux"
 				RIMAGE_KEY=modules/audio/sof/keys/otc_private_key_3k.pem
 				;;
 			imx8)


### PR DESCRIPTION
Recently merged rework of multicore support in Zephyr has
broken builds with XCC. Disable XCC based builds in CI until
issue is resolved in Zephyr mainline. Issue tracked as:
https://github.com/zephyrproject-rtos/zephyr/issues/38349

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>