### PR TITLE
[TEST CI, DO NOT MERGE] Revert "xtensa-build-zephyr: disable XCC build for Intel cAVS hw for"

### DIFF
--- a/scripts/xtensa-build-zephyr.sh
+++ b/scripts/xtensa-build-zephyr.sh
@@ -129,28 +129,18 @@ build()
 				;;
 			cnl)
 				PLAT_CONFIG='intel_adsp_cavs18'
-				# issues, tracked as
-				# https://github.com/zephyrproject-rtos/zephyr/issues/38349
-				unset XTENSA_TOOLS_ROOT
-				#XTENSA_CORE="X6H3CNL_2017_8"
-				#XTENSA_TOOLS_VERSION="RG-2017.8-linux"
-				# XCC build fails to a linker script compatibility
+				XTENSA_CORE="X6H3CNL_2017_8"
+				XTENSA_TOOLS_VERSION="RG-2017.8-linux"
 				;;
 			icl)
 				PLAT_CONFIG='intel_adsp_cavs20'
-				# issues, tracked as
-				# https://github.com/zephyrproject-rtos/zephyr/issues/38349
-				unset XTENSA_TOOLS_ROOT
-				#XTENSA_CORE="X6H3CNL_2017_8"
-				#XTENSA_TOOLS_VERSION="RG-2017.8-linux"
+				XTENSA_CORE="X6H3CNL_2017_8"
+				XTENSA_TOOLS_VERSION="RG-2017.8-linux"
 				;;
 			tgl-h|tgl)
 				PLAT_CONFIG='intel_adsp_cavs25'
-				# issues, tracked as
-				# https://github.com/zephyrproject-rtos/zephyr/issues/38349
-				unset XTENSA_TOOLS_ROOT
-				#XTENSA_CORE="cavs2x_LX6HiFi3_2017_8"
-				#XTENSA_TOOLS_VERSION="RG-2017.8-linux"
+				XTENSA_CORE="cavs2x_LX6HiFi3_2017_8"
+				XTENSA_TOOLS_VERSION="RG-2017.8-linux"
 				RIMAGE_KEY=modules/audio/sof/keys/otc_private_key_3k.pem
 				;;
 			imx8)


### PR DESCRIPTION
This PR revert the e963aa0e to let sof build failed, thus can be used
to test CI patches.

The CI patches will continue test successfully build firmware on device
while leaving those failed built platform untested.

This reverts commit e963aa0e4aad6972e74192351eeefe401a52f159.