### PR TITLE
mux: handle PRE_RELEASE in .trigger operation

### DIFF
--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -704,6 +704,7 @@ static int mux_trigger(struct comp_dev *dev, int cmd)
 
 	switch (cmd) {
 	case COMP_TRIGGER_PRE_START:
+	case COMP_TRIGGER_PRE_RELEASE:
 		if (mux_source_status_count(dev, COMP_STATE_ACTIVE) ||
 		    mux_source_status_count(dev, COMP_STATE_PAUSED))
 			return PPL_STATUS_PATH_STOP;


### PR DESCRIPTION
PRE_RELEASE in mux_trigger() should be handled the same way as PRE_START.
