### PR TITLE
ssp.c: fix recent arg count regression in dai_info()

### DIFF
--- a/src/drivers/intel/ssp/ssp.c
+++ b/src/drivers/intel/ssp/ssp.c
@@ -760,7 +760,7 @@ clk:
 		/* disable SSP port if no users */
 		if (ssp->state[SOF_IPC_STREAM_CAPTURE] != COMP_STATE_PREPARE ||
 		    ssp->state[SOF_IPC_STREAM_PLAYBACK] != COMP_STATE_PREPARE) {
-			dai_info(dai, "ssp_set_config(): hw_free stage: ignore since there is still user",
+			dai_info(dai, "ssp_set_config(): hw_free stage: ignore since SSP%d still in use",
 				 dai->index);
 			break;
 		}


### PR DESCRIPTION
~2 commits~ 1 commit

- ssp.c: fix recent arg count regression in dai_info()
- ~xtensa-build-zephyr: add ~-DCMAKE_C_FLAGS='-Werror'~ -DEXTRA_CFLAGS='-Werror'~

Because we can. fixes regression from
commit 287a5f9 ("ssp: mclk/bclk turned off unexpectedly")

```
sof/src/drivers/intel/ssp/ssp.c: In function 'ssp_set_config_tplg':
sof/zephyr/include/sof/trace/trace.h:44:11: warning:
                   too many arguments for format [-Wformat-extra-args]
   44 |    printk("%llu: " format "\n", platform_timer_get(NULL), \
      |           ^~~~~~~~
  ...
sof/src/drivers/intel/ssp/ssp.c:763:4: note: in expansion of macro 'dai_info'
  763 |    dai_info(dai, "ssp_set_config(): hw_free stage:
                     ignore since there is still user", dai->index);
```

Signed-off-by: Marc Herbert <marc.herbert@intel.com>