### PR TITLE
alloc: fix a wrong index calculation in heap buffer

### DIFF
--- a/src/lib/alloc.c
+++ b/src/lib/alloc.c
@@ -931,9 +931,7 @@ static void *_balloc_unlocked(uint32_t flags, uint32_t caps, size_t bytes,
 	void *ptr = NULL;
 
 	for (i = 0, n = PLATFORM_HEAP_BUFFER, heap = memmap->buffer;
-	     i < PLATFORM_HEAP_BUFFER;
-	     i = heap - memmap->buffer + 1, n = PLATFORM_HEAP_BUFFER - i,
-	     heap++) {
+	     i < PLATFORM_HEAP_BUFFER;) {
 		heap = get_heap_from_caps(heap, n, caps);
 		if (!heap)
 			break;
@@ -943,6 +941,9 @@ static void *_balloc_unlocked(uint32_t flags, uint32_t caps, size_t bytes,
 			break;
 
 		/* Continue from the next heap */
+		heap++;
+		i = (heap - memmap->buffer) / sizeof(struct mm_heap);
+		n = PLATFORM_HEAP_BUFFER - i;
 	}
 
 	return ptr;


### PR DESCRIPTION
The calculation 'heap - memmap->buffer + 1' is wrong and may lead to
index overflow when we have multiple buffer mm_heap, it should be
'(heap - memmap->buffer) / sizeof(struct mm_heap) + 1'.

Move the calculation to the end of the brace and make the logic simpler.

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>