### PR TITLE
xtensa-build-zephyr: re-enable XCC build for Intel cAVS hw

### DIFF
--- a/scripts/xtensa-build-zephyr.sh
+++ b/scripts/xtensa-build-zephyr.sh
@@ -132,28 +132,18 @@ build()
 				;;
 			cnl)
 				PLAT_CONFIG='intel_adsp_cavs18'
-				# issues, tracked as
-				# https://github.com/zephyrproject-rtos/zephyr/issues/38349
-				unset XTENSA_TOOLS_ROOT
-				#XTENSA_CORE="X6H3CNL_2017_8"
-				#XTENSA_TOOLS_VERSION="RG-2017.8-linux"
-				# XCC build fails to a linker script compatibility
+				XTENSA_CORE="X6H3CNL_2017_8"
+				XTENSA_TOOLS_VERSION="RG-2017.8-linux"
 				;;
 			icl)
 				PLAT_CONFIG='intel_adsp_cavs20'
-				# issues, tracked as
-				# https://github.com/zephyrproject-rtos/zephyr/issues/38349
-				unset XTENSA_TOOLS_ROOT
-				#XTENSA_CORE="X6H3CNL_2017_8"
-				#XTENSA_TOOLS_VERSION="RG-2017.8-linux"
+				XTENSA_CORE="X6H3CNL_2017_8"
+				XTENSA_TOOLS_VERSION="RG-2017.8-linux"
 				;;
 			tgl-h|tgl)
 				PLAT_CONFIG='intel_adsp_cavs25'
-				# issues, tracked as
-				# https://github.com/zephyrproject-rtos/zephyr/issues/38349
-				unset XTENSA_TOOLS_ROOT
-				#XTENSA_CORE="cavs2x_LX6HiFi3_2017_8"
-				#XTENSA_TOOLS_VERSION="RG-2017.8-linux"
+				XTENSA_CORE="cavs2x_LX6HiFi3_2017_8"
+				XTENSA_TOOLS_VERSION="RG-2017.8-linux"
 				RIMAGE_KEY=modules/audio/sof/keys/otc_private_key_3k.pem
 				;;
 			imx8)


### PR DESCRIPTION
The regression in Zephyr mainline is fixed with
https://github.com/zephyrproject-rtos/zephyr/pull/38374 , so
the XCC build can be renabled for cAVS targets.

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>