### PR TITLE
Revert "alloc: fix a wrong index calculation in heap buffer"

### DIFF
--- a/src/lib/alloc.c
+++ b/src/lib/alloc.c
@@ -931,7 +931,9 @@ static void *_balloc_unlocked(uint32_t flags, uint32_t caps, size_t bytes,
 	void *ptr = NULL;
 
 	for (i = 0, n = PLATFORM_HEAP_BUFFER, heap = memmap->buffer;
-	     i < PLATFORM_HEAP_BUFFER;) {
+	     i < PLATFORM_HEAP_BUFFER;
+	     i = heap - memmap->buffer + 1, n = PLATFORM_HEAP_BUFFER - i,
+	     heap++) {
 		heap = get_heap_from_caps(heap, n, caps);
 		if (!heap)
 			break;
@@ -941,9 +943,6 @@ static void *_balloc_unlocked(uint32_t flags, uint32_t caps, size_t bytes,
 			break;
 
 		/* Continue from the next heap */
-		heap++;
-		i = (heap - memmap->buffer) / sizeof(struct mm_heap);
-		n = PLATFORM_HEAP_BUFFER - i;
 	}
 
 	return ptr;


### PR DESCRIPTION
This reverts commit ffff0b061019d3ac02cf038bcc5c746cbb0e83d8. Both heap and memmap->buffer are of type struct mm_heap so their difference is already a number of struct mm_heap sized elements between them. Dividing by sizeof(struct mm_heap) again is wrong.
