### PR TITLE
Drivers: Intel: DMIC: Blob configuration related fixes

### DIFF
--- a/src/drivers/intel/dmic/dmic_computed.c
+++ b/src/drivers/intel/dmic/dmic_computed.c
@@ -632,6 +632,11 @@ static int configure_registers(struct dai *dai,
 		return -EINVAL;
 	}
 
+	/* Pass 2^BFTH to plat_data fifo depth. It will be used later in DMA
+	 * configuration
+	 */
+	dai->plat_data.fifo->depth = 1 << bfth;
+
 	dai_info(dai, "configuring registers");
 
 	/* OUTCONTROL0 and OUTCONTROL1 */

--- a/src/drivers/intel/dmic/dmic_nhlt.c
+++ b/src/drivers/intel/dmic/dmic_nhlt.c
@@ -310,7 +310,7 @@ int dmic_set_config_nhlt(struct dai *dai, void *spec_config)
 		clk_div = MIC_CONTROL_PDM_CLKDIV_GET(pdm_cfg[n]->mic_control);
 		p_clkdiv = clk_div + 2;
 		if (dmic->global->active_fifos_mask == 0) {
-			val = pdm_cfg[0]->cic_control;
+			val = pdm_cfg[n]->cic_control;
 			bf1 = CIC_CONTROL_SOFT_RESET_GET(val);
 			bf2 = CIC_CONTROL_CIC_START_B_GET(val);
 			bf3 = CIC_CONTROL_CIC_START_A_GET(val);

--- a/src/drivers/intel/dmic/dmic_nhlt.c
+++ b/src/drivers/intel/dmic/dmic_nhlt.c
@@ -246,9 +246,14 @@ int dmic_set_config_nhlt(struct dai *dai, void *spec_config)
 		bf6 = OUTCONTROL0_OF_GET(val);
 		bf7 = OUTCONTROL0_IPM_GET(val);
 		bf8 = OUTCONTROL0_TH_GET(val);
-		dai_dbg(dai, "dmic_set_config_nhlt(): OUTCONTROL%d = %08x", n, out_control[n]);
-		dai_dbg(dai, "  tie=%d, sip=%d, finit=%d, fci=%d", bf1, bf2, bf3, bf4);
-		dai_dbg(dai, "  bfth=%d, of=%d, ipm=%d, th=%d", bf5, bf6, bf7, bf8);
+		dai_info(dai, "dmic_set_config_nhlt(): OUTCONTROL%d = %08x", n, out_control[n]);
+		dai_info(dai, "  tie=%d, sip=%d, finit=%d, fci=%d", bf1, bf2, bf3, bf4);
+		dai_info(dai, "  bfth=%d, of=%d, ipm=%d, th=%d", bf5, bf6, bf7, bf8);
+		if (bf5 > OUTCONTROL0_BFTH_MAX) {
+			dai_err(dai, "dmic_set_config_nhlt(): illegal BFTH value");
+			return -EINVAL;
+		}
+
 #if defined DMIC_IPM_VER1
 		ref = OUTCONTROL0_TIE(bf1) | OUTCONTROL0_SIP(bf2) | OUTCONTROL0_FINIT(bf3) |
 			OUTCONTROL0_FCI(bf4) | OUTCONTROL0_BFTH(bf5) | OUTCONTROL0_OF(bf6) |
@@ -258,8 +263,7 @@ int dmic_set_config_nhlt(struct dai *dai, void *spec_config)
 		bf10 = OUTCONTROL0_IPM_SOURCE_2_GET(val);
 		bf11 = OUTCONTROL0_IPM_SOURCE_3_GET(val);
 		bf12 = OUTCONTROL0_IPM_SOURCE_4_GET(val);
-		dai_dbg(dai, "  ipms1=%d, ipms2=%d, ipms3=%d, ipms4=%d",
-			bf9, bf10, bf11, bf12);
+		dai_info(dai, "  ipms1=%d, ipms2=%d, ipms3=%d, ipms4=%d", bf9, bf10, bf11, bf12);
 		ref = OUTCONTROL0_TIE(bf1) | OUTCONTROL0_SIP(bf2) | OUTCONTROL0_FINIT(bf3) |
 			OUTCONTROL0_FCI(bf4) | OUTCONTROL0_BFTH(bf5) | OUTCONTROL0_OF(bf6) |
 			OUTCONTROL0_IPM(bf7) | OUTCONTROL0_IPM_SOURCE_1(bf9) |

--- a/src/include/sof/drivers/dmic.h
+++ b/src/include/sof/drivers/dmic.h
@@ -153,6 +153,8 @@
 #error Not supported HW version
 #endif
 
+#define OUTCONTROL0_BFTH_MAX	4 /* Max depth 16 */
+
 #if defined DMIC_IPM_VER1
 /* OUTCONTROL0 bits */
 #define OUTCONTROL0_TIE_BIT	BIT(27)

--- a/src/ipc/ipc3/dai.c
+++ b/src/ipc/ipc3/dai.c
@@ -122,12 +122,9 @@ int ipc_dai_data_config(struct comp_dev *dev)
 		dd->config.burst_elems = config->ssp.tdm_slots;
 		break;
 	case SOF_DAI_INTEL_DMIC:
-		/* We can use always the largest burst length. */
-		dd->config.burst_elems = 8;
-
-		comp_info(dev, "config->dmic.fifo_bits = %u config->dmic.num_pdm_active = %u",
-			  config->dmic.fifo_bits,
-			  config->dmic.num_pdm_active);
+		/* Depth is passed by DMIC driver that retrieves it from blob */
+		dd->config.burst_elems = dd->dai->plat_data.fifo->depth;
+		comp_info(dev, "dai_data_config() burst_elems = %d", dd->config.burst_elems);
 		break;
 	case SOF_DAI_INTEL_HDA:
 		break;

--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -92,8 +92,9 @@ int ipc_dai_data_config(struct comp_dev *dev)
 		dev->ipc_config.frame_fmt = SOF_IPC_FRAME_S32_LE;
 		break;
 	case SOF_DAI_INTEL_DMIC:
-		/* We can use always the largest burst length. */
-		dd->config.burst_elems = 8;
+		/* Depth is passed by DMIC driver that retrieves it from blob */
+		dd->config.burst_elems = dd->dai->plat_data.fifo->depth;
+		comp_info(dev, "dai_data_config() burst_elems = %d", dd->config.burst_elems);
 		break;
 	case SOF_DAI_INTEL_HDA:
 		break;


### PR DESCRIPTION
- Fixes error in check of cic_control register
- Fixes xrun errors when BFTH in blob is not 3 that is the hard-coded burst_elems size in dai
- Add check for too large non-supported BFTH value
- Fixes handling of more unusual blobs with single FIFO or single PDM defined