### PR TITLE
 Heap refinement Part 3 -- Buffer coherent support

### DIFF
--- a/Kconfig.xtos-dbg
+++ b/Kconfig.xtos-dbg
@@ -12,3 +12,12 @@ config DEBUG_BLOCK_FREE
 	  already freed block of memory. Enabling this feature increases
 	  number of memory writes and reads, due to checks for memory patterns
 	  that may be performed on allocation and deallocation.
+
+config DEBUG_FORCE_COHERENT_BUFFER
+	bool "Force the allocator to allocate coherent buffer only"
+	default n
+	help
+	  Select if we want to force the allocator to return coherent/uncached
+	  buffer only.
+	  This should be selected for debug purpose only, as accessing buffer
+	  without caching it will reduce the read/write performance.

--- a/src/include/sof/lib/alloc.h
+++ b/src/include/sof/lib/alloc.h
@@ -67,6 +67,8 @@ enum mem_zone {
 
 /** \brief Indicates that original content should not be copied by realloc. */
 #define SOF_MEM_FLAG_NO_COPY	BIT(1)
+/** \brief Indicates that if we should return uncached address. */
+#define SOF_MEM_FLAG_COHERENT  BIT(2)
 
 /** @} */
 

--- a/src/lib/alloc.c
+++ b/src/lib/alloc.c
@@ -921,8 +921,12 @@ static void *_balloc_unlocked(uint32_t flags, uint32_t caps, size_t bytes,
 	if (!ptr)
 		return ptr;
 
+#ifdef	CONFIG_DEBUG_FORCE_COHERENT_BUFFER
+	return cache_to_uncache(ptr);
+#else
 	return (flags & SOF_MEM_FLAG_COHERENT) && (CONFIG_CORE_COUNT > 1) ?
 		cache_to_uncache(ptr) : uncache_to_cache(ptr);
+#endif
 }
 
 /* allocates continuous buffers - not for direct use, clients use rballoc() */

--- a/src/platform/intel/cavs/lib/memory.c
+++ b/src/platform/intel/cavs/lib/memory.c
@@ -228,7 +228,7 @@ void platform_init_memmap(struct sof *sof)
 	/* heap buffer init */
 	sof->memory_map->buffer[0].blocks = ARRAY_SIZE(buf_heap_map);
 	sof->memory_map->buffer[0].map = uncached_block_map(buf_heap_map);
-	sof->memory_map->buffer[0].heap = (uintptr_t)&_buffer_heap;
+	sof->memory_map->buffer[0].heap = cache_to_uncache((uintptr_t)&_buffer_heap);
 	sof->memory_map->buffer[0].size = heap_buffer_size;
 	sof->memory_map->buffer[0].info.free = heap_buffer_size;
 	sof->memory_map->buffer[0].caps = SOF_MEM_CAPS_RAM | SOF_MEM_CAPS_HP |


### PR DESCRIPTION
    alloc: add support of coherent buffer allocation

    Ask for coherent/uncached pointer while allocating buffer from the
    buffer zone with flag SOF_MEM_FLAG_COHERENT specified.

    When freeing buffer blocks, try both cached and uncached address if
    needed, to make sure the freeing will succeed.
