### PR TITLE
xtensa-build-zephyr: add option to stop after cloning Zephyr

### DIFF
--- a/scripts/xtensa-build-zephyr.sh
+++ b/scripts/xtensa-build-zephyr.sh
@@ -36,14 +36,15 @@ print_usage()
 Re-configures and re-builds SOF with Zephyr using a pre-installed Zephyr toolchain and
 the _defconfig file for that platform.
 
-usage: $0 [options] platform(s) [ -- cmake arguments ]
+usage: $0 [options] [ platform(s) ] [ -- cmake arguments ]
 
        -a Build all platforms.
        -j n Set number of make build jobs for rimage. Jobs=#cores by default.
            Ignored by "west build".
        -k Path to a non-default rimage signing key.
        -c recursively clones Zephyr inside sof before building.
-          Incompatible with -p.
+          Incompatible with -p. To stop after cloning Zephyr, don't
+          pass any platform or cmake argument.
        -p Existing Zephyr project directory. Incompatible with -c.  If
           zephyr-project/modules/audio/sof is missing then a
           symbolic link pointing to ${SOF_TOP} will automatically be
@@ -282,14 +283,11 @@ parse_args()
 	# Check some target platform(s) have been passed in one way or
 	# the other
 	if [ "${#PLATFORMS[@]}" -eq 0 ]; then
-		echo "Error: No platforms specified. Supported are: " \
-		     "${SUPPORTED_PLATFORMS[*]}"
-		print_usage
-		exit 1
+		printf 'No platform build requested\n'
+	else
+		printf 'Building platforms:'
+		printf ' %s' "${PLATFORMS[@]}"; printf '\n'
 	fi
-
-	printf 'Building platforms:'
-	printf ' %s' "${PLATFORMS[@]}"; printf '\n'
 
 	CMAKE_ARGS=("$@")
 	# For debugging quoting and whitespace
@@ -318,7 +316,7 @@ main()
 		)
 	fi
 
-	build_all
+	test "${#PLATFORMS[@]}" -eq 0 || build_all
 }
 
 main "$@"

--- a/scripts/xtensa-build-zephyr.sh
+++ b/scripts/xtensa-build-zephyr.sh
@@ -77,6 +77,15 @@ Supported platforms ${SUPPORTED_PLATFORMS[*]}
 EOF
 }
 
+zephyr_fetch_and_switch()
+{
+	( cd "$WEST_TOP"/zephyr
+	  set -x
+	  git fetch --depth=5 "$1" "$2"
+	  git checkout FETCH_HEAD
+	)
+}
+
 # Downloads zephyrproject inside sof/ and create a ../../.. symbolic
 # link back to sof/
 clone()
@@ -88,6 +97,17 @@ clone()
 	mkdir -p "$WEST_TOP"
 	git clone --depth=5 https://github.com/zephyrproject-rtos/zephyr \
 	    "$WEST_TOP"/zephyr
+
+	# This shows how to point SOF CI to and run all SOF tests on any
+	# Zephyr work in progress or any other Zephyr commit from
+	# anywhere. Simply edit remote and reference, uncomment this
+	# line and submit as an SOF Pull Request.
+
+	# zephyr_fetch_and_switch    origin   pull/38374/head
+
+	# SECURITY WARNING for reviewers: never allow unknown code from
+	# unknown submitters on any CI system.
+
 	git -C "$WEST_TOP"/zephyr --no-pager log --oneline --graph \
 	    --decorate --max-count=20
 	west init -l "${WEST_TOP}"/zephyr


### PR DESCRIPTION
2 commits, main one:

xtensa-build-zephyr: add option to stop after cloning Zephyr

This is needed by CI to clone only once and then take control of the
iteration over platform builds. CI already does all that but by
copy/paste/diverge of this clone() function.

Once cloning Zephyr in CI code is de-duplicated and uses this new
clone-only feature instead, it will be possible to submit any Zephyr
commit to SOF testing.  In other words it will make failed attempt
#4728 possible