### PR TITLE
pipeline: remove heap status dumps from pipeline code

### DIFF
--- a/src/audio/pipeline/pipeline-graph.c
+++ b/src/audio/pipeline/pipeline-graph.c
@@ -112,9 +112,6 @@ struct pipeline *pipeline_new(uint32_t pipeline_id, uint32_t priority, uint32_t 
 	pipe_cl_info("pipeline new pipe_id %d priority %d",
 		     pipeline_id, priority);
 
-	/* show heap status */
-	heap_trace_all(0);
-
 	/* allocate new pipeline */
 	p = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM, sizeof(*p));
 	if (!p) {
@@ -211,9 +208,6 @@ int pipeline_free(struct pipeline *p)
 	/* now free the pipeline */
 	rfree(p);
 
-	/* show heap status */
-	heap_trace_all(0);
-
 	return 0;
 }
 
@@ -275,9 +269,6 @@ int pipeline_complete(struct pipeline *p, struct comp_dev *source,
 	p->source_comp = source;
 	p->sink_comp = sink;
 	p->status = COMP_STATE_READY;
-
-	/* show heap status */
-	heap_trace_all(0);
 
 	return 0;
 }


### PR DESCRIPTION
With dynamic pipelines, pipelines can be created and destroyed often enough at runtime, which makes dumping heap statue for each such action too noisy.
