### PR TITLE
buffer: remove buffer core argument in comp_buffer_connect

### DIFF
--- a/src/audio/copier.c
+++ b/src/audio/copier.c
@@ -531,11 +531,10 @@ static int copier_params(struct comp_dev *dev, struct sof_ipc_stream_params *par
 		update_internal_comp(dev, cd->endpoint);
 
 		/* attach buffer to endpoint */
-		comp_buffer_connect(cd->endpoint, cd->endpoint->ipc_config.core, buffer,
-				    buffer->core, dir);
+		comp_buffer_connect(cd->endpoint, cd->endpoint->ipc_config.core, buffer, dir);
 		ret = cd->endpoint->drv->ops.params(cd->endpoint, params);
 		/* restore buffer to copier */
-		comp_buffer_connect(dev, dev->ipc_config.core, buffer, buffer->core, dir);
+		comp_buffer_connect(dev, dev->ipc_config.core, buffer, dir);
 	}
 
 	return ret;

--- a/src/include/sof/ipc/topology.h
+++ b/src/include/sof/ipc/topology.h
@@ -212,10 +212,9 @@ int comp_verify_params(struct comp_dev *dev, uint32_t flag,
  * @param comp Component dev
  * @param comp_core comp core id
  * @param buffer Component buffer
- * @param buffer_core buffer core id
  * @param dir connection direction
  * @return connection status
  */
 int comp_buffer_connect(struct comp_dev *comp, uint32_t comp_core,
-			struct comp_buffer *buffer, uint32_t buffer_core, uint32_t dir);
+			struct comp_buffer *buffer, uint32_t dir);
 #endif

--- a/src/ipc/ipc-helper.c
+++ b/src/ipc/ipc-helper.c
@@ -178,12 +178,12 @@ int comp_verify_params(struct comp_dev *dev, uint32_t flag,
 }
 
 int comp_buffer_connect(struct comp_dev *comp, uint32_t comp_core,
-			struct comp_buffer *buffer, uint32_t buffer_core, uint32_t dir)
+			struct comp_buffer *buffer, uint32_t dir)
 {
 	int ret;
 
 	/* check if it's a connection between cores */
-	if (buffer_core != comp_core) {
+	if (buffer->core != comp_core) {
 		dcache_invalidate_region(buffer, sizeof(*buffer));
 
 		buffer->inter_core = true;

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -235,14 +235,14 @@ int ipc_comp_connect(struct ipc *ipc, ipc_pipe_comp_connect *_connect)
 		return IPC4_OUT_OF_MEMORY;
 	}
 
-	ret = comp_buffer_connect(source, source->ipc_config.core, buffer, buffer->core,
+	ret = comp_buffer_connect(source, source->ipc_config.core, buffer,
 				  PPL_CONN_DIR_COMP_TO_BUFFER);
 	if (ret < 0) {
 		tr_err(&ipc_tr, "failed to connect src %d to internal buffer", src_id);
 		goto err;
 	}
 
-	ret = comp_buffer_connect(sink, sink->ipc_config.core, buffer, buffer->core,
+	ret = comp_buffer_connect(sink, sink->ipc_config.core, buffer,
 				  PPL_CONN_DIR_BUFFER_TO_COMP);
 	if (ret < 0) {
 		tr_err(&ipc_tr, "failed to connect internal buffer to sink %d", sink_id);


### PR DESCRIPTION
It can be accessed with the buffer argument.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>