### PR TITLE
docker: add renoir to docker build

### DIFF
--- a/scripts/docker_build/sof_builder/Dockerfile
+++ b/scripts/docker_build/sof_builder/Dockerfile
@@ -88,7 +88,7 @@ RUN cd /home/sof && \
 	mkdir -p /home/sof/work/ && \
 	cd crosstool-ng && \
 	./bootstrap && ./configure --prefix=`pwd` && make && make install && \
-	for arch in byt hsw apl cnl imx imx8m imx8ulp; do \
+	for arch in byt hsw apl cnl imx imx8m imx8ulp rn; do \
 		cp config-${arch}-gcc10.2-gdb9 .config && \
 # replace the build dist to save space
 		sed -i 's#${CT_TOP_DIR}\/builds#\/home\/sof\/work#g' .config && \
@@ -102,6 +102,7 @@ ENV PATH="/home/sof/work/xtensa-byt-elf/bin:${PATH}"
 ENV PATH="/home/sof/work/xtensa-hsw-elf/bin:${PATH}"
 ENV PATH="/home/sof/work/xtensa-apl-elf/bin:${PATH}"
 ENV PATH="/home/sof/work/xtensa-cnl-elf/bin:${PATH}"
+ENV PATH="/home/sof/work/xtensa-rn-elf/bin:${PATH}"
 ENV PATH="/home/sof/work/xtensa-imx-elf/bin:${PATH}"
 ENV PATH="/home/sof/work/xtensa-imx8m-elf/bin:${PATH}"
 ENV PATH="/home/sof/work/xtensa-imx8ulp-elf/bin:${PATH}"
@@ -110,7 +111,7 @@ ARG NEWLIB_REPO=https://github.com/jcmvbkbc/newlib-xtensa.git
 RUN cd /home/sof && \
 	git clone $CLONE_DEFAULTS --branch xtensa $NEWLIB_REPO && \
 	cd newlib-xtensa && \
-	for arch in byt hsw apl cnl imx imx8m imx8ulp; do \
+	for arch in byt hsw apl cnl imx imx8m imx8ulp rn; do \
 		./configure --target=xtensa-${arch}-elf \
 		--prefix=/home/sof/work/xtensa-root && \
 		make && \


### PR DESCRIPTION
In order to support AMD as part of the docker image and CI we need to
include it in the build list as the overlays are already added to the
overlay repo.

Signed-off-by: Curtis Malainey <cujomalainey@chromium.org>