### PR TITLE
kconfig: select XTENSA_EXCLUSIVE for mt8195

### DIFF
--- a/src/platform/Kconfig
+++ b/src/platform/Kconfig
@@ -254,7 +254,8 @@ config MT8195
 	select HOST_PTABLE
 	select XT_WAITI_DELAY
 	select MEDIATEK
-        select SCHEDULE_DMA_MULTI_CHANNEL
+	select XTENSA_EXCLUSIVE
+	select SCHEDULE_DMA_MULTI_CHANNEL
 	help
 	  Select if your target platform is mt8195-compatible
 


### PR DESCRIPTION
there is no s32c1i instructions in mt8195.

it will use exclusive instructions.
(XCHAL_HAVE_EXCLUSIVE is defined in core-isa.h)

Select CONFIG_XTENSA_EXCLUSIVE  by default.

Signed-off-by: YC Hung <yc.hung@mediatek.com>
Signed-off-by: Allen-KH Cheng <allen-kh.cheng@mediatek.com>