### PR TITLE
host: add dma buffer clear

### DIFF
--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -809,6 +809,7 @@ static int host_params(struct comp_dev *dev,
 
 static int host_prepare(struct comp_dev *dev)
 {
+	struct host_data *hd = comp_get_drvdata(dev);
 	int ret;
 
 	comp_dbg(dev, "host_prepare()");
@@ -820,6 +821,7 @@ static int host_prepare(struct comp_dev *dev)
 	if (ret == COMP_STATUS_STATE_ALREADY_SET)
 		return PPL_STATUS_PATH_STOP;
 
+	buffer_zero(hd->dma_buffer);
 	return 0;
 }
 


### PR DESCRIPTION
Sometime, we could hear some noise after recording.

In host_prepare, reset dma buffer would be good
in general case to prevent reading uninitialized memory.

Add reset dma buffer zero to avoid unexpected noise

Signed-off-by: YC Hung yc.hung@mediatek.com
Signed-off-by: Allen-KH Cheng allen-kh.cheng@mediatek.com