### PR TITLE
Revert trace enable commits, fix DEBUG_TRACE_PTR() macro so it can be used early

### DIFF
--- a/src/init/init.c
+++ b/src/init/init.c
@@ -134,8 +134,10 @@ static int primary_core_init(int argc, char *argv[], struct sof *sof)
 	interrupt_init(sof);
 #endif /* __ZEPHYR__ */
 
+#if CONFIG_TRACE
 	trace_point(TRACE_BOOT_SYS_TRACES);
 	trace_init(sof);
+#endif
 
 	trace_point(TRACE_BOOT_SYS_NOTIFIER);
 	init_system_notify(sof);
@@ -148,9 +150,6 @@ static int primary_core_init(int argc, char *argv[], struct sof *sof)
 		panic(SOF_IPC_PANIC_PLATFORM);
 
 	trace_point(TRACE_BOOT_PLATFORM);
-
-	/* now start the trace */
-	trace_on();
 
 #if CONFIG_NO_SECONDARY_CORE_ROM
 	lp_sram_unpack();

--- a/src/ipc/dma-copy.c
+++ b/src/ipc/dma-copy.c
@@ -64,10 +64,6 @@ int dma_copy_to_host_nowait(struct dma_copy *dc, struct dma_sg_config *host_sg,
 {
 	int ret;
 
-	/* return if DMA channel is not get yet */
-	if (!dc->chan)
-		return -EINVAL;
-
 	/* tell gateway to copy */
 	ret = dma_copy(dc->chan, size, 0);
 	if (ret < 0)
@@ -88,10 +84,6 @@ int dma_copy_to_host_nowait(struct dma_copy *dc, struct dma_sg_config *host_sg,
 	struct dma_sg_elem local_sg_elem;
 	int32_t err;
 	int32_t offset = host_offset;
-
-	/* return if DMA channel is not get yet */
-	if (!dc->chan)
-		return -EINVAL;
 
 	if (size <= 0)
 		return 0;

--- a/src/lib/alloc.c
+++ b/src/lib/alloc.c
@@ -646,13 +646,13 @@ out:
 }
 
 #define DEBUG_TRACE_PTR(ptr, bytes, zone, caps, flags) \
-	do { \
+	if (trace_get()) { \
 		if (!ptr) { \
 			tr_err(&mem_tr, "failed to alloc 0x%x bytes zone 0x%x caps 0x%x flags 0x%x", \
 			       bytes, zone, caps, flags); \
 			alloc_trace_heap(zone, caps, bytes); \
-		} \
-	} while (0)
+	}
+
 #else
 #define DEBUG_TRACE_PTR(ptr, bytes, zone, caps, flags)
 #endif

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -524,9 +524,7 @@ int platform_init(struct sof *sof)
 #elif CONFIG_TRACE
 	/* Initialize DMA for Trace*/
 	trace_point(TRACE_BOOT_PLATFORM_DMA_TRACE);
-	ret = dma_trace_init_complete(sof->dmat);
-	if (ret < 0)
-		return ret;
+	dma_trace_init_complete(sof->dmat);
 #endif
 
 	/* show heap status */

--- a/src/trace/dma-trace.c
+++ b/src/trace/dma-trace.c
@@ -200,6 +200,7 @@ int dma_trace_init_complete(struct dma_trace_data *d)
 			      SOF_TASK_PRI_MED, trace_work, d, 0, 0);
 
 out:
+
 	return ret;
 }
 

--- a/src/trace/dma-trace.c
+++ b/src/trace/dma-trace.c
@@ -477,8 +477,9 @@ void dma_trace_on(void)
 {
 	struct dma_trace_data *trace_data = dma_trace_data_get();
 
-	if (!trace_data || trace_data->enabled)
+	if (trace_data->enabled) {
 		return;
+	}
 
 	trace_data->enabled = 1;
 	schedule_task(&trace_data->dmat_work, DMA_TRACE_PERIOD,
@@ -490,8 +491,9 @@ void dma_trace_off(void)
 {
 	struct dma_trace_data *trace_data = dma_trace_data_get();
 
-	if (!trace_data || !trace_data->enabled)
+	if (!trace_data->enabled) {
 		return;
+	}
 
 	schedule_task_cancel(&trace_data->dmat_work);
 	trace_data->enabled = 0;

--- a/src/trace/trace.c
+++ b/src/trace/trace.c
@@ -289,8 +289,9 @@ void trace_log_filtered(bool send_atomic, const void *log_entry, const struct tr
 	uint64_t current_ts;
 #endif /* CONFIG_TRACE_FILTERING_ADAPTIVE */
 
-	if (!trace || !trace->enable)
+	if (!trace->enable) {
 		return;
+	}
 
 #if CONFIG_TRACE_FILTERING_VERBOSITY
 	if (!trace_filter_verbosity(lvl, ctx))
@@ -510,6 +511,7 @@ void trace_off(void)
 void trace_init(struct sof *sof)
 {
 	sof->trace = rzalloc(SOF_MEM_ZONE_SYS_SHARED, 0, SOF_MEM_CAPS_RAM, sizeof(*sof->trace));
+	sof->trace->enable = 1;
 	sof->trace->pos = 0;
 #if CONFIG_TRACE_FILTERING_ADAPTIVE
 	sof->trace->user_filter_override = false;

--- a/src/trace/trace.c
+++ b/src/trace/trace.c
@@ -272,8 +272,9 @@ void trace_log_unfiltered(bool send_atomic, const void *log_entry, const struct 
 	struct trace *trace = trace_get();
 	va_list vl;
 
-	if (!trace || !trace->enable)
+	if (!trace->enable) {
 		return;
+	}
 
 	va_start(vl, arg_count);
 	vatrace_log(send_atomic, (uint32_t)log_entry, ctx, lvl, id_1, id_2, arg_count, vl);


### PR DESCRIPTION
This reverts commit 7df3674 + reverts its followup commit + 1 line fix  for DEBUG_TRACE_PTR()

It has been successfully tested in TEST PR #4758 

See commit messages, the main one copied here:

This restores the ability to use CONFIG_TRACEM (copy everything to
mailbox) without crashing, in other words it fixes #4699

This also fixes the other DSP panic #4676 and removes the need for
logical changes in #4678, which can be reverted too.

commit 7df3674 ("trace: enable trace after it is ready") was meant
to fix a crash when tr_xxx() was used early. However I've used very
early tracing for months and it never caused any crash (see #4334)

I tried adding a tr_err() statement immediately after trace_init(sof) in
primary_core_init() and it works just fine. primary_core_init() runs
extremely early so I don't think it's too demanding not to use an
tr_XXX() before the trace even exists.

The reverted commits confused initializing and enabling.

Reproduction #4683 did not seem to demonstrate anything obvious,
there's not even a link to a failed test run. I don't understand how
playing with spin locks is relevant to this.

Later, reproduction #4759 finally demonstrated the real issue: through
DEBUG_TRACE_PTR(), some tr_XXX() can indeed be called (in very unusal
debug circumstances specific to the original author) before the trace is
initialized. The previous commit in this series fixes that by simply
guarding it with if(trace_get())

     --------

I am _not_ pretending that these reverts make the tracing code bug-free
and perfect again, absolutely not and very far from it. I'm merely
saying that:

- The first reverted commit caused at least two regressions: #4676 and
  #4699

- These two commits added yet another variable (time) in an already
  complex situation with an already existing combinatorial "explosion":
  compile-time Kconfigs, run-time settings, platform-specific bugs
  (#4333, #4573, ...), various races, mbox + DMA, different DMA engines,
  Zephyr vs XTOS, etc.

- Last but not least, we don't want to invest in making the exist trace
  implementation better. We want to switch to the Zephyr implementation
  instead

So let's go back to a previous known good state, I mean _relatively_
good and stay there if we can.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>