### PR TITLE
dma-trace: send ipc msg after update host pointer

### DIFF
--- a/src/ipc/dma-copy.c
+++ b/src/ipc/dma-copy.c
@@ -82,7 +82,6 @@ int dma_copy_to_host_nowait(struct dma_copy *dc, struct dma_sg_config *host_sg,
 int dma_copy_to_host_nowait(struct dma_copy *dc, struct dma_sg_config *host_sg,
 			    int32_t host_offset, void *local_ptr, int32_t size)
 {
-	struct dma_trace_data *dmat = dma_trace_data_get();
 	struct dma_sg_config config;
 	struct dma_sg_elem *host_sg_elem;
 	struct dma_sg_elem local_sg_elem;
@@ -129,8 +128,6 @@ int dma_copy_to_host_nowait(struct dma_copy *dc, struct dma_sg_config *host_sg,
 		       DMA_COPY_ONE_SHOT | DMA_COPY_BLOCKING);
 	if (err < 0)
 		return err;
-
-	ipc_msg_send(dmat->msg, &dmat->posn, false);
 
 	/* bytes copied */
 	return local_sg_elem.size;

--- a/src/trace/dma-trace.c
+++ b/src/trace/dma-trace.c
@@ -100,6 +100,8 @@ static enum task_state trace_work(void *data)
 	if (buffer->r_ptr >= buffer->end_addr)
 		buffer->r_ptr = (char *)buffer->r_ptr - DMA_TRACE_LOCAL_SIZE;
 
+	ipc_msg_send(d->msg, &d->posn, false);
+
 out:
 	spin_lock_irq(&d->lock, flags);
 


### PR DESCRIPTION
When I use logger to trace the sof message, there some left data in dma buffer.

I find trace_work updates host pointer after dma_copy_to_host_nowait.

but dma_copy_to_host_nowait will send ipc msg before updating the new host offset.


I think the ipc_msg_send (send the host_offset information) should be after update host pointer.


If there is anything I don't well considered, please let me know.

Thanks.
