### PR TITLE
ipc: check type before freeing

### DIFF
--- a/src/ipc/ipc-helper.c
+++ b/src/ipc/ipc-helper.c
@@ -281,6 +281,13 @@ int ipc_comp_free(struct ipc *ipc, uint32_t comp_id)
 	if (!icd)
 		return -ENODEV;
 
+	/* check type */
+	if (icd->type != COMP_TYPE_COMPONENT) {
+		tr_err(&ipc_tr, "ipc_comp_free(): comp id: %d is not a COMPONENT",
+		       comp_id);
+		return -EINVAL;
+	}
+
 	/* check core */
 	if (!cpu_is_me(icd->core))
 		return ipc_process_on_core(icd->core, false);

--- a/src/ipc/ipc3/helper.c
+++ b/src/ipc/ipc3/helper.c
@@ -389,6 +389,13 @@ int ipc_pipeline_free(struct ipc *ipc, uint32_t comp_id)
 	if (!ipc_pipe)
 		return -ENODEV;
 
+	/* check type */
+	if (ipc_pipe->type != COMP_TYPE_PIPELINE) {
+		tr_err(&ipc_tr, "ipc_pipeline_free(): comp id: %d is not a PIPELINE",
+		       comp_id);
+		return -EINVAL;
+	}
+
 	/* check core */
 	if (!cpu_is_me(ipc_pipe->core))
 		return ipc_process_on_core(ipc_pipe->core, false);
@@ -457,6 +464,13 @@ int ipc_buffer_free(struct ipc *ipc, uint32_t buffer_id)
 	ibd = ipc_get_comp_by_id(ipc, buffer_id);
 	if (!ibd)
 		return -ENODEV;
+
+	/* check type */
+	if (ibd->type != COMP_TYPE_BUFFER) {
+		tr_err(&ipc_tr, "ipc_buffer_free(): comp id: %d is not a BUFFER",
+		       buffer_id);
+		return -EINVAL;
+	}
 
 	/* check core */
 	if (!cpu_is_me(ibd->core))


### PR DESCRIPTION
When freeing we currently implicitly are trusting the ID to match the
type specified in the message. From a security standpoint this is wrong,
never trust the other side. This is the likely cause of how the fuzzer
is leaking memory in pipelines since they have additional allocations
that are not freed when they are treated as a buffer or a component.

Signed-off-by: Curtis Malainey <cujomalainey@chromium.org>