### PR TITLE
Add panic dump debug support for renoir

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -17,6 +17,7 @@ src/include/sof/debug/gdb/*		@mrajwa
 src/include/sof/audio/kpb.h		@mrajwa
 src/include/sof/audio/mux.h		@akloniex
 src/include/sof/audio/codec_adapter/*	@cujomalainey @mrajwa @dbaluta
+src/include/sof/drivers/acp_dai_dma.h	@bhiregoudar @sunilkumardommati
 
 # audio component
 src/audio/src*				@singalsu
@@ -39,6 +40,7 @@ src/platform/haswell/*			@randerwang
 src/platform/suecreek/*			@lyakh
 src/arch/xtensa/debug/gdb/*		@mrajwa
 src/platform/imx8/**			@dbaluta
+src/platform/amd/**			@bhiregoudar @sunilkumardommati
 
 # drivers
 src/drivers/intel/dmic.c		@singalsu
@@ -46,6 +48,7 @@ src/drivers/intel/cavs/sue-iomux.c	@lyakh
 src/drivers/intel/haswell/*		@randerwang
 src/drivers/imx/**			@dbaluta
 src/drivers/dw/*			@lyakh
+src/drivers/amd/*			@bhiregoudar @sunilkumardommati
 
 # other libs
 src/math/*				@singalsu

--- a/src/drivers/amd/renoir/ipc.c
+++ b/src/drivers/amd/renoir/ipc.c
@@ -132,10 +132,8 @@ enum task_state ipc_platform_do_cmd(void *data)
 void ipc_platform_complete_cmd(void *data)
 {
 	struct ipc *ipc = data;
-	uint32_t flags;
 	acp_sw_intr_trig_t  sw_intr_trig;
 
-	spin_lock_irq(&ipc->lock, flags);
 	/* Set Dsp Ack for msg from host */
 	sof_ipc_dsp_ack_set();
 	/* Configures the trigger bit in ACP_DSP_SW_INTR_TRIG register */
@@ -146,7 +144,6 @@ void ipc_platform_complete_cmd(void *data)
 	io_reg_write((PU_REGISTER_BASE + ACP_SW_INTR_TRIG), sw_intr_trig.u32all);
 	/* now interrupt host to tell it we have sent a message */
 	acp_dsp_to_host_Intr_trig();
-	spin_unlock_irq(&ipc->lock, flags);
 	if (ipc->pm_prepare_D3) {
 		while (1)
 			wait_for_interrupt(0);

--- a/src/platform/amd/renoir/include/platform/lib/mailbox.h
+++ b/src/platform/amd/renoir/include/platform/lib/mailbox.h
@@ -38,6 +38,14 @@
 #define MAILBOX_STREAM_BASE		SRAM_STREAM_BASE
 #define MAILBOX_STREAM_OFFSET		SRAM_STREAM_OFFSET
 
+static inline void mailbox_sw_reg_write(size_t offset, uint32_t src)
+{
+	volatile uint32_t *ptr;
+
+	ptr = (volatile uint32_t *)(MAILBOX_DEBUG_BASE + offset);
+	*ptr = src;
+}
+
 #endif /* __PLATFORM_LIB_MAILBOX_H__ */
 
 #else


### PR DESCRIPTION
This pull request enables the support to dump panic info during any firmware exceptions on renoir platform.
Fix for IPC timeouts during firmware boot up time.
Add code owners for AMD platforms.