### PR TITLE
topology1: correct misleading comments for priority/core 

### DIFF
--- a/tools/topology/topology1/development/sof-apl-asrc-pcm512x.m4
+++ b/tools/topology/topology1/development/sof-apl-asrc-pcm512x.m4
@@ -34,21 +34,21 @@ dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl	time_domain, sched_comp)
 
 # Playback pipeline 1 on PCM 0 using max 2 channels of s32le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-asrc-volume-playback.m4,
 	1, 0, 2, s32le,
 	1000, 0, 0,
 	8000, 192000, 48000)
 
 # DMIC capture pipeline 2 on PCM 5 using max 2 channels.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-asrc-volume-capture.m4,
         2, 5, 2, s32le,
         1000, 0, 0,
         8000, 192000, 48000)
 
 # DMIC16kHz capture pipeline 2 on PCM 6 using max 2 channels.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-asrc-volume-capture.m4,
         3, 6, 2, s32le,
         1000, 0, 0,
@@ -64,21 +64,21 @@ dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
 # playback DAI is SSP5 using 2 periods
-# Buffers use s24le format, 1000us deadline on core 0 with priority 0
+# Buffers use s24le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, 5, SSP5-Codec,
 	PIPELINE_SOURCE_1, 2, s24le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is DMIC using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
         2, DMIC, 0, dmic01,
         PIPELINE_SINK_2, 2, s32le,
         1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is DMIC16kHz using 2 periods
-# Buffers use s16le format, 1000us deadline on core 0 with priority 0
+# Buffers use s16le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
         3, DMIC, 1, dmic16k,
         PIPELINE_SINK_3, 2, s32le,

--- a/tools/topology/topology1/development/sof-apl-asrc-wm8804.m4
+++ b/tools/topology/topology1/development/sof-apl-asrc-wm8804.m4
@@ -33,14 +33,14 @@ dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-asrc-volume-playback.m4,
 	1, 0, 2, s32le,
 	1000, 0, 0,
 	8000, 48000, 48000)
 
 # Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-asrc-capture.m4,
 	2, 0, 2, s32le,
 	1000, 0, 0,
@@ -56,14 +56,14 @@ dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
 # playback DAI is SSP5 using 2 periods
-# Buffers use s24le format, 1000us deadline on core 0 with priority 0
+# Buffers use s24le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, 5, SSP5-Codec,
 	PIPELINE_SOURCE_1, 2, s24le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is SSP5 using 2 periods
-# Buffers use s24le format, 1000us deadline on core 0 with priority 0
+# Buffers use s24le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	2, SSP, 5, SSP5-Codec,
 	PIPELINE_SINK_2, 2, s24le,

--- a/tools/topology/topology1/development/sof-apl-dmic-a96k-b16k.m4
+++ b/tools/topology/topology1/development/sof-apl-dmic-a96k-b16k.m4
@@ -38,14 +38,14 @@ dnl     dai periods, pcm_min_rate, pcm_max_rate,
 dnl     pipeline_rate, time_domain)
 
 # Passthrough capture pipeline 6 on PCM 6 using max channels 2.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
 	6, 6, 2, s32le,
 	1000, 0, 0, DMIC, 0, s32le, 3,
 	96000, 96000, 96000)
 
 # Passthrough capture pipeline 7 on PCM 7 using max channels 2.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
 	7, 7, 2, s32le,
 	1000, 0, 0, DMIC, 1, s32le, 3,
@@ -61,14 +61,14 @@ dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
 # capture DAI is DMIC 0 using 3 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	6, DMIC, 0, NoCodec-6,
 	PIPELINE_SINK_6, 3, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is DMIC 1 using 3 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	7, DMIC, 1, NoCodec-7,
 	PIPELINE_SINK_7, 3, s32le,

--- a/tools/topology/topology1/development/sof-apl-dmic-asymmetric.m4
+++ b/tools/topology/topology1/development/sof-apl-dmic-asymmetric.m4
@@ -38,14 +38,14 @@ dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
 
 `# Passthrough capture pipeline 6 on PCM 6 using max channels 'ACHANNEL
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	6, 6, ACHANNEL, AFORMAT,
 	1000, 0, 0,
 	ARATE, ARATE, ARATE)
 
 `# Passthrough capture pipeline 7 on PCM 7 using max channels 'BCHANNEL
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-capture-16khz.m4,
 	7, 7, BCHANNEL, BFORMAT,
 	1000, 0, 0,
@@ -61,14 +61,14 @@ dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
 # capture DAI is DMIC 0 using 2 periods
-`# Buffers use 'AFORMAT `format, 1000us deadline on core 0 with priority 0'
+`# Buffers use 'AFORMAT `format, 1000us deadline with priority 0 on core 0'
 DAI_ADD(sof/pipe-dai-capture.m4,
 	6, DMIC, 0, NoCodec-6,
 	PIPELINE_SINK_6, 2, AFORMAT,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is DMIC 1 using 2 periods
-`# Buffers use 'BFORMAT `format, 1000us deadline on core 0 with priority 0'
+`# Buffers use 'BFORMAT `format, 1000us deadline with priority 0 on core 0'
 DAI_ADD(sof/pipe-dai-capture.m4,
 	7, DMIC, 1, NoCodec-7,
 	PIPELINE_SINK_7, 2, BFORMAT,

--- a/tools/topology/topology1/development/sof-apl-dmic.m4
+++ b/tools/topology/topology1/development/sof-apl-dmic.m4
@@ -43,14 +43,14 @@ dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
 
 # Passthrough capture pipeline 6 on PCM 6 using max channels defined by CHANNELS.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(PIPE_PROC_CAPTURE,
 	6, 6, CHANNELS, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Passthrough capture pipeline 7 on PCM 7 using max channels defined by CHANNELS.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	7, 7, CHANNELS, s32le,
 	1000, 0, 0,
@@ -66,14 +66,14 @@ dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
 # capture DAI is DMIC 0 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	6, DMIC, 0, NoCodec-6,
 	PIPELINE_SINK_6, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is DMIC 1 using 2 periods
-# Buffers use s16le format, 1000us deadline on core 0 with priority 0
+# Buffers use s16le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	7, DMIC, 1, NoCodec-7,
 	PIPELINE_SINK_7, 2, s16le,

--- a/tools/topology/topology1/development/sof-apl-nocodec-ci.m4
+++ b/tools/topology/topology1/development/sof-apl-nocodec-ci.m4
@@ -41,91 +41,91 @@ dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s16le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-low-latency-playback.m4,
 	1, 0, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Volume switch capture pipeline 2 on PCM 0 using max 2 channels of s16le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-switch-capture.m4,
 	2, 0, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 3 on PCM 1 using max 2 channels of s16le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	3, 1, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Volume switch capture pipeline 4 on PCM 1 using max 2 channels of s16le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-switch-capture.m4,
 	4, 1, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 5 on PCM 2 using max 2 channels of s16le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 #PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 #	5, 2, 2, s32le,
 #	1000, 0, 0,
 #	48000, 48000, 48000)
 
 # Volume switch capture pipeline 6 on PCM 2 using max 2 channels of s16le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 #PIPELINE_PCM_ADD(sof/pipe-volume-switch-capture.m4,
 #	6, 2, 2, s32le,
 #	1000, 0, 0,
 #	48000, 48000, 48000)
 
 # Low Latency playback pipeline 7 on PCM 3 using max 2 channels of s16le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	7, 3, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Volume switch capture pipeline 8 on PCM 3 using max 2 channels of s16le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-switch-capture.m4,
 	8, 3, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 9 on PCM 4 using max 2 channels of s16le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 #PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 #	9, 4, 2, s32le,
 #	1000, 0, 0,
 #	48000, 48000, 48000)
 
 # Volume switch capture pipeline 10 on PCM 4 using max 2 channels of s16le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 #PIPELINE_PCM_ADD(sof/pipe-volume-switch-capture.m4,
 #	10, 4, 2, s32le,
 #	1000, 0, 0,
 #	48000, 48000, 48000)
 
 # Low Latency playback pipeline 11 on PCM 5 using max 2 channels of s16le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	11, 5, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Volume switch capture pipeline 12 on PCM 5 using max 2 channels of s16le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-switch-capture.m4,
 	12, 5, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Passthrough capture pipeline 13 on PCM 6 using max 2 channels.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
 	13, 6, 2, s32le,
 	1000, 0, 0,
@@ -141,14 +141,14 @@ dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
 # playback DAI is SSP0 using 2 periods
-# Buffers use s16le format, 1000us deadline on core 0 with priority 0
+# Buffers use s16le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, 0, NoCodec-0,
 	PIPELINE_SOURCE_1, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # Media playback pipeline 14 on PCM 7 using max 2 channels of s16le.
-# Set 4000us deadline on core 0 with priority 0
+# Set 4000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-pcm-media.m4,
 	14, 7, 2, s16le,
 	4000, 0, 0,
@@ -167,84 +167,84 @@ SectionGraph."media-pipeline" {
 }
 
 # capture DAI is SSP0 using 2 periods
-# Buffers use s16le format, 1000us deadline on core 0 with priority 0
+# Buffers use s16le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	2, SSP, 0, NoCodec-0,
 	PIPELINE_SINK_2, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is SSP1 using 2 periods
-# Buffers use s16le format, 1000us deadline on core 0 with priority 0
+# Buffers use s16le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	3, SSP, 1, NoCodec-1,
 	PIPELINE_SOURCE_3, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is SSP1 using 2 periods
-# Buffers use s16le format, 1000us deadline on core 0 with priority 0
+# Buffers use s16le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	4, SSP, 1, NoCodec-1,
 	PIPELINE_SINK_4, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is SSP2 using 2 periods
-# Buffers use s16le format, 1000us deadline on core 0 with priority 0
+# Buffers use s16le format, 1000us deadline with priority 0 on core 0
 #DAI_ADD(sof/pipe-dai-playback.m4,
 #	5, SSP, 2, NoCodec-2,
 #	PIPELINE_SOURCE_5, 2, s16le,
 #	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is SSP2 using 2 periods
-# Buffers use s16le format, 1000us deadline on core 0 with priority 0
+# Buffers use s16le format, 1000us deadline with priority 0 on core 0
 #DAI_ADD(sof/pipe-dai-capture.m4,
 #	6, SSP, 2, NoCodec-2,
 #	PIPELINE_SINK_6, 2, s16le,
 #	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is SSP3 using 2 periods
-# Buffers use s16le format, 1000us deadline on core 0 with priority 0
+# Buffers use s16le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	7, SSP, 3, NoCodec-3,
 	PIPELINE_SOURCE_7, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is SSP3 using 2 periods
-# Buffers use s16le format, 1000us deadline on core 0 with priority 0
+# Buffers use s16le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	8, SSP, 3, NoCodec-3,
 	PIPELINE_SINK_8, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is SSP4 using 2 periods
-# Buffers use s16le format, 1000us deadline on core 0 with priority 0
+# Buffers use s16le format, 1000us deadline with priority 0 on core 0
 #DAI_ADD(sof/pipe-dai-playback.m4,
 #	9, SSP, 4, NoCodec-4,
 #	PIPELINE_SOURCE_9, 2, s16le,
 #	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is SSP4 using 2 periods
-# Buffers use s16le format, 1000us deadline on core 0 with priority 0
+# Buffers use s16le format, 1000us deadline with priority 0 on core 0
 #DAI_ADD(sof/pipe-dai-capture.m4,
 #	10, SSP, 4, NoCodec-4,
 #	PIPELINE_SINK_10, 2, s16le,
 #	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is SSP5 using 2 periods
-# Buffers use s16le format, 1000us deadline on core 0 with priority 0
+# Buffers use s16le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	11, SSP, 5, NoCodec-5,
 	PIPELINE_SOURCE_11, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is SSP5 using 2 periods
-# Buffers use s16le format, 1000us deadline on core 0 with priority 0
+# Buffers use s16le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	12, SSP, 5, NoCodec-5,
 	PIPELINE_SINK_12, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is DMIC 0 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	13, DMIC, 0, NoCodec-6,
 	PIPELINE_SINK_13, 2, s32le,

--- a/tools/topology/topology1/development/sof-apl-nocodec-demux-eq-2ch4ch.m4
+++ b/tools/topology/topology1/development/sof-apl-nocodec-demux-eq-2ch4ch.m4
@@ -35,14 +35,14 @@ dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-demux-eq-iir-playback.m4,
 	1, 0, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Volume switch capture pipeline 2 on PCM 0 using max 4 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
 	2, 0, 4, s32le,
 	1000, 0, 0,
@@ -59,7 +59,7 @@ dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
 # playback DAI is SSP0 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, 0, NoCodec-0,
 	PIPELINE_SOURCE_1, 4, s32le,
@@ -67,7 +67,7 @@ DAI_ADD(sof/pipe-dai-playback.m4,
 
 
 # capture DAI is SSP0 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	2, SSP, 0, NoCodec-0,
 	PIPELINE_SINK_2, 4, s32le,

--- a/tools/topology/topology1/development/sof-apl-nocodec-demux-eq-4ch4ch.m4
+++ b/tools/topology/topology1/development/sof-apl-nocodec-demux-eq-4ch4ch.m4
@@ -35,14 +35,14 @@ dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 4 channels of s32le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-demux-eq-iir-playback.m4,
 	1, 0, 4, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Volume switch capture pipeline 2 on PCM 0 using max 4 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
 	2, 0, 4, s32le,
 	1000, 0, 0,
@@ -59,7 +59,7 @@ dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
 # playback DAI is SSP0 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, 0, NoCodec-0,
 	PIPELINE_SOURCE_1, 4, s32le,
@@ -67,7 +67,7 @@ DAI_ADD(sof/pipe-dai-playback.m4,
 
 
 # capture DAI is SSP0 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	2, SSP, 0, NoCodec-0,
 	PIPELINE_SINK_2, 4, s32le,

--- a/tools/topology/topology1/development/sof-apl-pcm512x-nohdmi.m4
+++ b/tools/topology/topology1/development/sof-apl-pcm512x-nohdmi.m4
@@ -41,7 +41,7 @@ dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(PIPE_PROC_PLAYBACK,
 	1, 0, 2, s32le,
 	1000, 0, 0,
@@ -57,7 +57,7 @@ dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
 # playback DAI is SSP5 using 2 periods
-# Buffers use s24le format, 1000us deadline on core 0 with priority 0
+# Buffers use s24le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, 5, SSP5-Codec,
 	PIPELINE_SOURCE_1, 2, s24le,

--- a/tools/topology/topology1/development/sof-apl-src-50khz-pcm512x.m4
+++ b/tools/topology/topology1/development/sof-apl-src-50khz-pcm512x.m4
@@ -33,7 +33,7 @@ dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
 
 # Playback pipeline 1 on PCM 0 using max 2 channels of s24le.
-# Schedule 1000us deadline on core 0 with priority 0
+# Schedule 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-src-volume-playback.m4,
 	1, 0, 2, s24le,
 	1000, 0, 0,

--- a/tools/topology/topology1/development/sof-cml-rt1011-rt5682-nokwd.m4
+++ b/tools/topology/topology1/development/sof-cml-rt1011-rt5682-nokwd.m4
@@ -61,7 +61,7 @@ dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s24le.
-# Schedule 1000us deadline on core 0 with priority 0
+# Schedule 1000us deadline with priority 0 on core 0
 ifdef(`HSEARPROC_FILTER1', `define(PIPELINE_FILTER1, HSEARPROC_FILTER1)', `undefine(`PIPELINE_FILTER1')')
 ifdef(`HSEARPROC_FILTER2', `define(PIPELINE_FILTER2, HSEARPROC_FILTER2)', `undefine(`PIPELINE_FILTER2')')
 PIPELINE_PCM_ADD(sof/pipe-HSEARPROC-playback.m4,
@@ -72,7 +72,7 @@ undefine(`PIPELINE_FILTER1')
 undefine(`PIPELINE_FILTER2')
 
 # Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s24le.
-# Schedule 1000us deadline on core 0 with priority 0
+# Schedule 1000us deadline with priority 0 on core 0
 ifdef(`HSMICPROC_FILTER1', `define(PIPELINE_FILTER1, HSMICPROC_FILTER1)', `undefine(`PIPELINE_FILTER1')')
 ifdef(`HSMICPROC_FILTER2', `define(PIPELINE_FILTER2, HSMICPROC_FILTER2)', `undefine(`PIPELINE_FILTER2')')
 PIPELINE_PCM_ADD(sof/pipe-HSMICPROC-capture.m4,
@@ -83,28 +83,28 @@ undefine(`PIPELINE_FILTER1')
 undefine(`PIPELINE_FILTER2')
 
 # Low Latency playback pipeline 4 on PCM 2 using max 2 channels of s32le.
-# Schedule 1000us deadline on core 0 with priority 0
+# Schedule 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	4, 2, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 5 on PCM 3 using max 2 channels of s32le.
-# Schedule 1000us deadline on core 0 with priority 0
+# Schedule 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	5, 3, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 6 on PCM 4 using max 2 channels of s32le.
-# Schedule 1000us deadline on core 0 with priority 0
+# Schedule 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	6, 4, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 7 on PCM 5 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 ifdef(`SPKPROC_FILTER1', `define(PIPELINE_FILTER1, SPKPROC_FILTER1)', `undefine(`PIPELINE_FILTER1')')
 ifdef(`SPKPROC_FILTER2', `define(PIPELINE_FILTER2, SPKPROC_FILTER2)', `undefine(`PIPELINE_FILTER2')')
 PIPELINE_PCM_ADD(sof/pipe-SPKPROC-playback.m4,

--- a/tools/topology/topology1/development/sof-cml-src-rt5682.m4
+++ b/tools/topology/topology1/development/sof-cml-src-rt5682.m4
@@ -38,42 +38,42 @@ dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s24le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-src-volume-playback.m4,
 	1, 0, 2, s24le,
 	1000, 0, 0,
 	8000, 96000, 48000)
 
 # Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s24le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	2, 0, 2, s24le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Passthrough capture pipeline 3 on PCM 1 using max 4 channels.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
 	3, 1, 4, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 4 on PCM 2 using max 2 channels of s32le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	4, 2, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 5 on PCM 3 using max 2 channels of s32le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	5, 3, 2, s32le,
 	1000, 0, 0,
 	48000 ,48000 ,48000)
 
 # Low Latency playback pipeline 6 on PCM 4 using max 2 channels of s32le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	6, 4, 2, s32le,
 	1000, 0, 0,
@@ -89,42 +89,42 @@ dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
 # playback DAI is SSP1 using 2 periods
-# Buffers use s24le format, 1000us deadline on core 0 with priority 0
+# Buffers use s24le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, 1, SSP1-Codec,
 	PIPELINE_SOURCE_1, 2, s24le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is SSP1 using 2 periods
-# Buffers use s24le format, 1000us deadline on core 0 with priority 0
+# Buffers use s24le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	2, SSP, 1, SSP1-Codec,
 	PIPELINE_SINK_2, 2, s24le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is DMIC01 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	3, DMIC, 0, dmic01,
 	PIPELINE_SINK_3, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp1 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	4, HDA, 0, iDisp1,
 	PIPELINE_SOURCE_4, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp2 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	5, HDA, 1, iDisp2,
 	PIPELINE_SOURCE_5, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp3 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	6, HDA, 2, iDisp3,
 	PIPELINE_SOURCE_6, 2, s32le,

--- a/tools/topology/topology1/development/sof-hda-asrc.m4
+++ b/tools/topology/topology1/development/sof-hda-asrc.m4
@@ -50,49 +50,49 @@ include(`platform/intel/intel-generic-dmic.m4')
 #
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s24le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-asrc-volume-playback.m4,
 	1, 0, 2, s24le,
 	1000, 0, 0,
 	8000, 48000, 48000)
 
 # Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s24le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-asrc-volume-capture.m4,
 	2, 0, 2, s24le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 3 on PCM 1 using max 2 channels of s24le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	3, 1, 2, s24le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 4 on PCM 1 using max 2 channels of s24le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	4, 1, 2, s24le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 7 on PCM 3 using max 2 channels of s24le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
         7, 3, 2, s24le,
         1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 8 on PCM 4 using max 2 channels of s24le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
         8, 4, 2, s24le,
         1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 9 on PCM 5 using max 2 channels of s24le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
         9, 5, 2, s24le,
         1000, 0, 0,
@@ -103,49 +103,49 @@ PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 #
 
 # playback DAI is HDA Analog using 2 periods
-# Dai buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Dai buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
         1, HDA, 0, Analog Playback and Capture,
         PIPELINE_SOURCE_1, 2, s32le,
         1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is HDA Analog using 2 periods
-# Dai buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Dai buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
         2, HDA, 1, Analog Playback and Capture,
 	PIPELINE_SINK_2, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is HDA Digital using 2 periods
-# Dai buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Dai buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
         3, HDA, 2, Digital Playback and Capture,
         PIPELINE_SOURCE_3, 2, s32le,
         1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is HDA Digital using 2 periods
-# Dai buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Dai buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
         4, HDA, 3, Digital Playback and Capture,
 	PIPELINE_SINK_4, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp1 using 2 periods
-# Dai buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Dai buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
         7, HDA, 4, iDisp1,
         PIPELINE_SOURCE_7, 2, s32le,
         1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp2 using 2 periods
-# Dai buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Dai buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
         8, HDA, 5, iDisp2,
         PIPELINE_SOURCE_8, 2, s32le,
         1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp3 using 2 periods
-# Dai buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Dai buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
         9, HDA, 6, iDisp3,
         PIPELINE_SOURCE_9, 2, s32le,

--- a/tools/topology/topology1/development/sof-imx8-compr-aac-wm8960.m4
+++ b/tools/topology/topology1/development/sof-imx8-compr-aac-wm8960.m4
@@ -61,7 +61,7 @@ dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-codec-adapter-playback.m4,
 	1, 0, 2, s32le,
 	1000, 0, 0,

--- a/tools/topology/topology1/development/sof-imx8-compr-mp3-wm8960.m4
+++ b/tools/topology/topology1/development/sof-imx8-compr-mp3-wm8960.m4
@@ -59,7 +59,7 @@ dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-codec-adapter-playback.m4,
 	1, 0, 2, s32le,
 	1000, 0, 0,

--- a/tools/topology/topology1/development/sof-imx8-src-cs42888.m4
+++ b/tools/topology/topology1/development/sof-imx8-src-cs42888.m4
@@ -32,14 +32,14 @@ dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s24le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-src-volume-playback.m4,
 	1, 0, 2, s24le,
 	1000, 0, 0,
 	8000, 96000, 48000)
 
 # Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s24le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-src-volume-capture.m4,
 	2, 0, 2, s24le,
 	1000, 0, 0,

--- a/tools/topology/topology1/development/sof-imx8-src-wm8960.m4
+++ b/tools/topology/topology1/development/sof-imx8-src-wm8960.m4
@@ -32,14 +32,14 @@ dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-src-volume-playback.m4,
 	1, 0, 2, s32le,
 	1000, 0, 0,
 	8000, 96000, 48000)
 
 # Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s32le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-src-volume-capture.m4,
 	2, 0, 2, s32le,
 	1000, 0, 0,

--- a/tools/topology/topology1/development/sof-imx8mp-compr-aac-wm8960.m4
+++ b/tools/topology/topology1/development/sof-imx8mp-compr-aac-wm8960.m4
@@ -61,7 +61,7 @@ dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-codec-adapter-playback.m4,
 	1, 0, 2, s32le,
 	1000, 0, 0,

--- a/tools/topology/topology1/development/sof-imx8mp-compr-mp3-wm8960.m4
+++ b/tools/topology/topology1/development/sof-imx8mp-compr-mp3-wm8960.m4
@@ -59,7 +59,7 @@ dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-codec-adapter-playback.m4,
 	1, 0, 2, s32le,
 	1000, 0, 0,

--- a/tools/topology/topology1/development/sof-imx8mp-src-wm8960.m4
+++ b/tools/topology/topology1/development/sof-imx8mp-src-wm8960.m4
@@ -32,14 +32,14 @@ dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-src-volume-playback.m4,
 	1, 0, 2, s32le,
 	1000, 0, 0,
 	8000, 96000, 48000)
 
 # Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s32le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-src-volume-capture.m4,
 	2, 0, 2, s32le,
 	1000, 0, 0,

--- a/tools/topology/topology1/development/sof-tgl-nocodec-ci.m4
+++ b/tools/topology/topology1/development/sof-tgl-nocodec-ci.m4
@@ -114,21 +114,21 @@ dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s16le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-demux-playback.m4,
 	1, 0, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Volume-switch capture pipeline 2 on PCM 0 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-switch-capture.m4,
 	2, 0, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 3 on PCM 1 using max 2 channels of s16le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	3, 1, 2, s16le,
 	1000, 0, 3,
@@ -157,7 +157,7 @@ PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
 	48000, 48000, 48000)
 
 # Passthrough capture pipeline 9 on PCM 5 using max 2 channels.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
 	9, 5, 2, s32le,
 	1000, 0, 0,
@@ -228,7 +228,7 @@ DAI_ADD(sof/pipe-dai-capture.m4,
 	1000, 0, 2, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is DMIC 1 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	9, DMIC, 1, NoCodec-7,
 	PIPELINE_SINK_9, 2, s32le,

--- a/tools/topology/topology1/platform/intel/cml.m4
+++ b/tools/topology/topology1/platform/intel/cml.m4
@@ -21,7 +21,7 @@ ifelse(SOF_ABI_VERSION_3_9_OR_GRT, `1',
 `
 # --- ABI VERSION is 3.9 or higher case ----
 # Low Latency playback pipeline 8 on PCM 6 using max 2 channels of s32le.
-# Schedule 1000us deadline on core 0 with priority 0
+# Schedule 1000us deadline with priority 0 on core 0
 # pipe-src pipeline is needed for older SSP config
 define(`PIPE_VOLUME_PLAYBACK', `sof/pipe-volume-playback.m4')
 define(`SSP1_VALID_BITS', `24')
@@ -44,7 +44,7 @@ define(`SET_SSP1_CONFIG_DATA', `SSP, 1, 24, 0, 0, 10')',
 `
 # --- ABI VERSION is below 3.9 case ----
 # Low Latency playback pipeline 8 on PCM 6 using max 2 channels of s32le.
-# Schedule 1000us deadline on core 0 with priority 0
+# Schedule 1000us deadline with priority 0 on core 0
 # pipe-src pipeline is needed for older SSP config
 define(`PIPE_VOLUME_PLAYBACK', `sof/pipe-src-volume-playback.m4')
 define(`SSP1_VALID_BITS', `16')

--- a/tools/topology/topology1/platform/intel/intel-generic-dmic-kwd.m4
+++ b/tools/topology/topology1/platform/intel/intel-generic-dmic-kwd.m4
@@ -70,7 +70,7 @@ dnl     time_domain, sched_comp)
 
 # Passthrough capture pipeline using max channels defined by CHANNELS.
 
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 ifdef(`DMICPROC_FILTER1', `define(PIPELINE_FILTER1, DMICPROC_FILTER1)', `undefine(`PIPELINE_FILTER1')')
 ifdef(`DMICPROC_FILTER2', `define(PIPELINE_FILTER2, DMICPROC_FILTER2)', `undefine(`PIPELINE_FILTER2')')
 define(`PGA_NAME', Dmic0)
@@ -89,7 +89,7 @@ undefine(`DMICPROC')
 #
 
 # Passthrough capture pipeline 7 on PCM 7 using max 2 channels.
-# Schedule 20000us deadline on core 0 with priority 0
+# Schedule 20000us deadline with priority 0 on core 0
 PIPELINE_PCM_DAI_ADD(sof/pipe-KFBM_TYPE-capture.m4,
         DMIC_PIPELINE_16k_ID, DMIC_PCM_16k_ID, 2, s32le,
         KWD_PIPE_SCH_DEADLINE_US, 0, 0, DMIC, 1, s32le, 3,
@@ -107,7 +107,7 @@ dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
 # capture DAI is DMIC 0 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
         DMIC_PIPELINE_48k_ID, DMIC, 0, DMIC_DAI_LINK_48k_NAME,
         concat(`PIPELINE_SINK_', DMIC_PIPELINE_48k_ID), 2, s32le,

--- a/tools/topology/topology1/platform/intel/intel-generic-dmic.m4
+++ b/tools/topology/topology1/platform/intel/intel-generic-dmic.m4
@@ -79,7 +79,7 @@ dnl     time_domain, sched_comp)
 
 # Passthrough capture pipeline using max channels defined by DMIC_PCM_CHANNELS.
 
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 ifdef(`DMICPROC_FILTER1', `define(PIPELINE_FILTER1, DMICPROC_FILTER1)', `undefine(`PIPELINE_FILTER1')')
 ifdef(`DMICPROC_FILTER2', `define(PIPELINE_FILTER2, DMICPROC_FILTER2)', `undefine(`PIPELINE_FILTER2')')
 define(`PGA_NAME', Dmic0)
@@ -94,7 +94,7 @@ undefine(`PIPELINE_FILTER2')
 
 # Passthrough capture pipeline using max channels defined by CHANNELS.
 
-# Schedule with 1000us deadline on core 0 with priority 0
+# Schedule with 1000us deadline with priority 0 on core 0
 ifdef(`DMIC16KPROC_FILTER1', `define(PIPELINE_FILTER1, DMIC16KPROC_FILTER1)', `undefine(`PIPELINE_FILTER1')')
 ifdef(`DMIC16KPROC_FILTER2', `define(PIPELINE_FILTER2, DMIC16KPROC_FILTER2)', `undefine(`PIPELINE_FILTER2')')
 define(`PGA_NAME', Dmic1)
@@ -119,7 +119,7 @@ dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
 # capture DAI is DMIC 0 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	DMIC_PIPELINE_48k_ID, DMIC, 0, DMIC_DAI_LINK_48k_NAME,
 	concat(`PIPELINE_SINK_', DMIC_PIPELINE_48k_ID), 2, s32le,

--- a/tools/topology/topology1/sof-apl-da7219.m4
+++ b/tools/topology/topology1/sof-apl-da7219.m4
@@ -37,35 +37,35 @@ dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	1, 0, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 2 on PCM 1 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	2, 1, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 3 on PCM 1 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	3, 1, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 4 on PCM 99 using max 4 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
 	4, 99, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 5 on PCM 5 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 # PIPELINE_PCM_ADD(sof/pipe-passthrough-playback.m4,
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
         5, 5, 2, s32le,
@@ -73,7 +73,7 @@ PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 6 on PCM 6 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 # PIPELINE_PCM_ADD(sof/pipe-passthrough-playback.m4,
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
         6, 6, 2, s32le,
@@ -81,7 +81,7 @@ PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 7 on PCM 7 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 # PIPELINE_PCM_ADD(sof/pipe-passthrough-playback.m4,
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
         7, 7, 2, s32le,
@@ -98,49 +98,49 @@ dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
 # playback DAI is SSP5 using 2 periods
-# Buffers use s16le format, 1000us deadline on core 0 with priority 0
+# Buffers use s16le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, 5, SSP5-Codec,
 	PIPELINE_SOURCE_1, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is SSP1 using 2 periods
-# Buffers use s16le format, 1000us deadline on core 0 with priority 0
+# Buffers use s16le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	2, SSP, 1, SSP1-Codec,
 	PIPELINE_SOURCE_2, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is SSP1 using 2 periods
-# Buffers use s16le format, 1000us deadline on core 0 with priority 0
+# Buffers use s16le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	3, SSP, 1, SSP1-Codec,
 	PIPELINE_SINK_3, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is DMIC0 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	4, DMIC, 0, dmic01,
 	PIPELINE_SINK_4, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp1 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
         5, HDA, 3, iDisp1,
         PIPELINE_SOURCE_5, 2, s32le,
         1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp2 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
         6, HDA, 4, iDisp2,
         PIPELINE_SOURCE_6, 2, s32le,
         1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp3 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
         7, HDA, 5, iDisp3,
         PIPELINE_SOURCE_7, 2, s32le,

--- a/tools/topology/topology1/sof-apl-demux-pcm512x.m4
+++ b/tools/topology/topology1/sof-apl-demux-pcm512x.m4
@@ -70,28 +70,28 @@ dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
 
 # Demux pipeline 1 on PCM 0 using max 2 channels of s32le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-demux-playback.m4,
 	1, 0, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 2 on PCM 1 using max 2 channels of s32le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	2, 1, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 3 on PCM 2 using max 2 channels of s32le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	3, 2, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 4 on PCM 3 using max 2 channels of s32le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	4, 3, 2, s32le,
 	1000, 0, 0,
@@ -107,7 +107,7 @@ dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
 # playback DAI is SSP5 using 2 periods
-# Buffers use s24le format, 1000us deadline on core 0 with priority 0
+# Buffers use s24le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, 5, SSP5-Codec,
 	PIPELINE_SOURCE_1, 2, s24le,
@@ -145,21 +145,21 @@ SectionGraph."PIPE_CAP_VIRT" {
 }
 
 # playback DAI is iDisp1 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	2, HDA, 0, iDisp1,
 	PIPELINE_SOURCE_2, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp2 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	3, HDA, 1, iDisp2,
 	PIPELINE_SOURCE_3, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp3 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	4, HDA, 2, iDisp3,
 	PIPELINE_SOURCE_4, 2, s32le,

--- a/tools/topology/topology1/sof-apl-keyword-detect.m4
+++ b/tools/topology/topology1/sof-apl-keyword-detect.m4
@@ -36,7 +36,7 @@ dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
 
 # Passthrough capture pipeline 1 on PCM 0 using max 2 channels.
-# Schedule 1000us deadline on core 0 with priority 0
+# Schedule 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-kfbm-capture.m4,
 	1, 0, 2, s16le,
 	KWD_PIPE_SCH_DEADLINE_US, 0, 0,

--- a/tools/topology/topology1/sof-apl-pcm512x.m4
+++ b/tools/topology/topology1/sof-apl-pcm512x.m4
@@ -51,35 +51,35 @@ dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-low-latency-playback.m4,
 	1, 0, 2, s32le,
 	1000, 0, 0,
 	FSYNC, FSYNC, FSYNC)
 
 # Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	6, 0, 2, s32le,
 	1000, 0, 0,
 	FSYNC, FSYNC, FSYNC)
 
 # Low Latency playback pipeline 2 on PCM 5 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	2, 5, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 3 on PCM 6 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	3, 6, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 4 on PCM 7 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	4, 7, 2, s32le,
 	1000, 0, 0,
@@ -110,21 +110,21 @@ dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
 # playback DAI is SSP5 using 2 periods
-# Buffers use s24le format, 1000us deadline on core 0 with priority 0
+# Buffers use s24le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, 5, SSP5-Codec,
 	PIPELINE_SOURCE_1, 2, s24le,
 	1000, 0, 0, SSP_SCHEDULE_TIME_DOMAIN)
 
 # capture DAI is SSP5 using 2 periods
-# Buffers use s16le format, 1000us deadline on core 0 with priority 0
+# Buffers use s16le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	6, SSP, 5, SSP5-Codec,
 	PIPELINE_SINK_6, 2, s24le,
 	1000, 0, 0, SSP_SCHEDULE_TIME_DOMAIN)
 
 # Media playback pipeline 5 on PCM 4 using max 2 channels of s16le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-pcm-media.m4,
 	5, 4, 2, s16le,
 	1000, 0, 0,
@@ -142,21 +142,21 @@ SectionGraph."media-pipeline" {
 }
 
 # playback DAI is iDisp1 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	2, HDA, 0, iDisp1,
 	PIPELINE_SOURCE_2, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp2 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	3, HDA, 1, iDisp2,
 	PIPELINE_SOURCE_3, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp3 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	4, HDA, 2, iDisp3,
 	PIPELINE_SOURCE_4, 2, s32le,

--- a/tools/topology/topology1/sof-apl-rt298.m4
+++ b/tools/topology/topology1/sof-apl-rt298.m4
@@ -34,28 +34,28 @@ dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	1, 0, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 5 on PCM 5 using max 2 channels of s16le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
         5, 5, 2, s16le,
         1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 6 on PCM 6 using max 2 channels of s16le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
         6, 6, 2, s16le,
         1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 7 on PCM 7 using max 2 channels of s16le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
         7, 7, 2, s16le,
         1000, 0, 0,
@@ -70,28 +70,28 @@ dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
 # playback DAI is SSP5 using 2 periods
-# Buffers use s24le format, 1000us deadline on core 0 with priority 0
+# Buffers use s24le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, 5, SSP5-Codec,
 	PIPELINE_SOURCE_1, 2, s24le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp1 using 2 periods
-# Buffers use s16le format, 1000us deadline on core 0 with priority 0
+# Buffers use s16le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
         5, HDA, 3, iDisp1,
         PIPELINE_SOURCE_5, 2, s32le,
         1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp2 using 2 periods
-# Buffers use s16le format, 1000us deadline on core 0 with priority 0
+# Buffers use s16le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
         6, HDA, 4, iDisp2,
         PIPELINE_SOURCE_6, 2, s32le,
         1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp3 using 2 periods
-# Buffers use s16le format, 1000us deadline on core 0 with priority 0
+# Buffers use s16le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
         7, HDA, 5, iDisp3,
         PIPELINE_SOURCE_7, 2, s32le,

--- a/tools/topology/topology1/sof-apl-tdf8532.m4
+++ b/tools/topology/topology1/sof-apl-tdf8532.m4
@@ -35,70 +35,70 @@ dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 4 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	1, 0, 4, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 2 on PCM 1 using max 8 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	2, 1, 8, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 3 on PCM 1 using max 8 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	3, 1, 8, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 4 on PCM 2 using max 2 channels of s16le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	4, 2, 2, s16le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 5 on PCM 2 using max 2 channels of s16le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	5, 2, 2, s16le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 6 on PCM 3 using max 2 channels of s16le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	6, 3, 2, s16le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 7 on PCM 4 using max 2 channels of s16le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	7, 4, 2, s16le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 8 on PCM 4 using max 2 channels of s16le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	8, 4, 2, s16le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 9 on PCM 5 using max 2 channels of s16le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	9, 5, 2, s16le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 10 on PCM 5 using max 2 channels of s16le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	10, 5, 2, s16le,
 	1000, 0, 0,
@@ -115,70 +115,70 @@ dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
 # playback DAI is SSP0 using 2 periods
-# Buffers use s16le format, 1000us deadline on core 0 with priority 0
+# Buffers use s16le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	4, SSP, 0, SSP0-Codec,
 	PIPELINE_SOURCE_4, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is SSP0 using 2 periods
-# Buffers use s16le format, 1000us deadline on core 0 with priority 0
+# Buffers use s16le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	5, SSP, 0, SSP0-Codec,
 	PIPELINE_SINK_5, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is SSP1 using 2 periods
-# Buffers use s16le format, 1000us deadline on core 0 with priority 0
+# Buffers use s16le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	6, SSP, 1, SSP1-Codec,
 	PIPELINE_SINK_6, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is SSP2 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	2, SSP, 2, SSP2-Codec,
 	PIPELINE_SOURCE_2, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is SSP2 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	3, SSP, 2, SSP2-Codec,
 	PIPELINE_SINK_3, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is SSP3 using 2 periods
-# Buffers use s16le format, 1000us deadline on core 0 with priority 0
+# Buffers use s16le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	7, SSP, 3, SSP3-Codec,
 	PIPELINE_SOURCE_7, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is SSP3 using 2 periods
-# Buffers use s16le format, 1000us deadline on core 0 with priority 0
+# Buffers use s16le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	8, SSP, 3, SSP3-Codec,
 	PIPELINE_SINK_8, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is SSP4 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, 4, SSP4-Codec,
 	PIPELINE_SOURCE_1, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is SSP5 using 2 periods
-# Buffers use s16le format, 1000us deadline on core 0 with priority 0
+# Buffers use s16le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	9, SSP, 5, SSP5-Codec,
 	PIPELINE_SOURCE_9, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is SSP5 using 2 periods
-# Buffers use s16le format, 1000us deadline on core 0 with priority 0
+# Buffers use s16le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	10, SSP, 5, SSP5-Codec,
 	PIPELINE_SINK_10, 2, s16le,

--- a/tools/topology/topology1/sof-apl-wm8804.m4
+++ b/tools/topology/topology1/sof-apl-wm8804.m4
@@ -30,14 +30,14 @@ dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	1, 0, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-low-latency-capture.m4,
 	2, 0, 2, s32le,
 	1000, 0, 0,
@@ -53,14 +53,14 @@ dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
 # playback DAI is SSP5 using 2 periods
-# Buffers use s24le format, 1000us deadline on core 0 with priority 0
+# Buffers use s24le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, 5, SSP5-Codec,
 	PIPELINE_SOURCE_1, 2, s24le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_DMA)
 
 # capture DAI is SSP5 using 2 periods
-# Buffers use s24le format, 1000us deadline on core 0 with priority 0
+# Buffers use s24le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	2, SSP, 5, SSP5-Codec,
 	PIPELINE_SINK_2, 2, s24le,

--- a/tools/topology/topology1/sof-bdw-codec.m4
+++ b/tools/topology/topology1/sof-bdw-codec.m4
@@ -38,7 +38,7 @@ PIPELINE_PCM_ADD(sof/pipe-low-latency-playback.m4,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-low-latency-capture.m4,
 	2, 0, 2, s32le,
 	1000, 0, 0,
@@ -51,14 +51,14 @@ PIPELINE_PCM_ADD(sof/pipe-low-latency-capture.m4,
 #
 
 # playback DAI is SSP0 using 2 periods
-# Buffers use s24le format, 1000us deadline on core 0 with priority 0
+# Buffers use s24le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, 0, Codec,
 	PIPELINE_SOURCE_1, 2, s24le,
 	1000, 1, 0, SCHEDULE_TIME_DOMAIN_DMA)
 
 # PCM Media Playback pipeline 3 on PCM 1 using max 2 channels of s32le.
-# 2000us deadline on core 0 with priority 0
+# 2000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-pcm-media.m4,
 	3, 1, 2, s32le,
 	2000, 0, 0,
@@ -77,7 +77,7 @@ SectionGraph."PIPE_NAME" {
 }
 
 # capture DAI is SSP0 using 2 periods
-# Buffers use s24le format, 1000us deadline on core 0 with priority 0
+# Buffers use s24le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	2, SSP, 0, Codec,
 	PIPELINE_SINK_2, 2, s24le,

--- a/tools/topology/topology1/sof-bdw-nocodec.m4
+++ b/tools/topology/topology1/sof-bdw-nocodec.m4
@@ -28,14 +28,14 @@ include(`platform/intel/bdw.m4')
 #
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-low-latency-playback.m4,
 	1, 0, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Volume switch capture pipeline 2 on PCM 0 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-switch-capture.m4,
 	2, 0, 2, s32le,
 	1000, 0, 0,
@@ -48,7 +48,7 @@ PIPELINE_PCM_ADD(sof/pipe-volume-switch-capture.m4,
 #
 
 # playback DAI is SSP0 using 2 periods
-# Buffers use s24le format, 1000us deadline on core 0 with priority 0
+# Buffers use s24le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, 0, NoCodec-0,
 	PIPELINE_SOURCE_1, 2, s24le,
@@ -73,7 +73,7 @@ SectionGraph."media-pipe" {
 }
 
 # capture DAI is SSP0 using 2 periods
-# Buffers use s24le format, 1000us deadline on core 0 with priority 0
+# Buffers use s24le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	2, SSP, 0, NoCodec-0,
 	PIPELINE_SINK_2, 2, s24le,

--- a/tools/topology/topology1/sof-byt-codec.m4
+++ b/tools/topology/topology1/sof-byt-codec.m4
@@ -25,7 +25,7 @@ include(`platform/intel/'PLATFORM`.m4')
 #
 
 # Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-low-latency-capture.m4,
 	2, 0, 2, s32le,
 	1000, 0, 0,
@@ -48,7 +48,7 @@ DAI_ADD(sof/pipe-mixer-dai-playback.m4,
 	2, 48000)
 
 # PCM Playback pipeline 3 on PCM 0 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 # this is connected to pipeline DAI 1
 PIPELINE_PCM_ADD(sof/pipe-host-volume-playback.m4,
 	3, 0, 2, s32le,
@@ -58,7 +58,7 @@ PIPELINE_PCM_ADD(sof/pipe-host-volume-playback.m4,
 	PIPELINE_PLAYBACK_SCHED_COMP_1)
 
 # PCM Playback pipeline 4 on PCM 1 using max 2 channels of s32le.
-# 10ms deadline on core 0 with priority 0
+# 10ms deadline with priority 0 on core 0
 # this is connected to pipeline DAI 1
 PIPELINE_PCM_ADD(sof/pipe-host-volume-playback.m4,
 	4, 1, 2, s32le,
@@ -81,7 +81,7 @@ SectionGraph."PIPE_NAME" {
 }
 
 # capture DAI is SSP2 using 2 periods
-# Buffers use s24le format, 1000us deadline on core 0 with priority 0
+# Buffers use s24le format, 1000us deadline with priority 0 on core 0
 # this is part of pipeline 2
 DAI_ADD(sof/pipe-dai-capture.m4,
 	2, SSP, SSP_NUM, SSP2-Codec,

--- a/tools/topology/topology1/sof-cavs-nocodec.m4
+++ b/tools/topology/topology1/sof-cavs-nocodec.m4
@@ -120,7 +120,7 @@ PIPELINE_PCM_ADD(sof/pipe-volume-switch-capture.m4,
 	48000, 48000, 48000)
 
 # Volume switch capture pipeline 6 on PCM 2 using max 2 channels of PIPE_BITS.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-switch-capture.m4,
 	6, 2, 2, PIPE_BITS,
 	1000, 0, SSP2_CORE_ID,
@@ -136,7 +136,7 @@ dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
 # playback DAI is SSP0 using 2 periods
-# Buffers use DAI_BITS format, 1000us deadline on core 0 with priority 0
+# Buffers use DAI_BITS format, 1000us deadline with priority 0 on core 0
 # The 'NOT_USED_IGNORED' is due to dependencies and is adjusted later with an explicit dapm line.
 DAI_ADD(sof/pipe-mixer-dai-playback.m4,
 	1, SSP, SSP0_IDX, NoCodec-0,
@@ -164,14 +164,14 @@ ifelse(PLATFORM, `bxt', `',
 	PIPELINE_PLAYBACK_SCHED_COMP_1)')
 
 # capture DAI is SSP0 using 2 periods
-# Buffers use DAI_BITS format, 1000us deadline on core 0 with priority 0
+# Buffers use DAI_BITS format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	2, SSP, SSP0_IDX, NoCodec-0,
 	PIPELINE_SINK_2, 2, DAI_BITS,
 	1000, 0, SSP0_CORE_ID, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is SSP1 using 2 periods
-# Buffers use DAI_BITS format, 1000us deadline on core 0 with priority 0
+# Buffers use DAI_BITS format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-mixer-dai-playback.m4,
 	3, SSP, SSP1_IDX, NoCodec-1,
 	NOT_USED_IGNORED, 2, DAI_BITS,
@@ -187,14 +187,14 @@ PIPELINE_PCM_ADD(sof/pipe-host-volume-playback.m4,
 	PIPELINE_PLAYBACK_SCHED_COMP_3)
 
 # capture DAI is SSP1 using 2 periods
-# Buffers use DAI_BITS format, 1000us deadline on core 0 with priority 0
+# Buffers use DAI_BITS format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	4, SSP, SSP1_IDX, NoCodec-1,
 	PIPELINE_SINK_4, 2, DAI_BITS,
 	1000, 0, SSP1_CORE_ID, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is SSP2 using 2 periods
-# Buffers use DAI_BITS format, 1000us deadline on core 0 with priority 0
+# Buffers use DAI_BITS format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-mixer-dai-playback.m4,
 	5, SSP, SSP2_IDX, NoCodec-2,
 	NOT_USED_IGNORED, 2, DAI_BITS,
@@ -221,7 +221,7 @@ ifelse(PLATFORM, `bxt',
 	PIPELINE_PLAYBACK_SCHED_COMP_5)')
 
 # capture DAI is SSP2 using 2 periods
-# Buffers use DAI_BITS format, 1000us deadline on core 0 with priority 0
+# Buffers use DAI_BITS format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	6, SSP, SSP2_IDX, NoCodec-2,
 	PIPELINE_SINK_6, 2, DAI_BITS,

--- a/tools/topology/topology1/sof-cht-max98090.m4
+++ b/tools/topology/topology1/sof-cht-max98090.m4
@@ -25,7 +25,7 @@ include(`platform/intel/'PLATFORM`.m4')
 #
 
 # Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s16le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-low-latency-capture.m4,
 	2, 0, 2, s16le,
 	1000, 0, 0,
@@ -48,7 +48,7 @@ DAI_ADD(sof/pipe-mixer-dai-playback.m4,
 	2, 48000)
 
 # PCM Playback pipeline 3 on PCM 0 using max 2 channels of s16le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 # this is connected to pipeline DAI 1
 PIPELINE_PCM_ADD(sof/pipe-host-volume-playback.m4,
 	3, 0, 2, s16le,
@@ -58,7 +58,7 @@ PIPELINE_PCM_ADD(sof/pipe-host-volume-playback.m4,
 	PIPELINE_PLAYBACK_SCHED_COMP_1)
 
 # PCM Playback pipeline 4 on PCM 1 using max 2 channels of s16le.
-# 10ms deadline on core 0 with priority 0
+# 10ms deadline with priority 0 on core 0
 # this is connected to pipeline DAI 1
 PIPELINE_PCM_ADD(sof/pipe-host-volume-playback.m4,
 	4, 1, 2, s16le,
@@ -81,7 +81,7 @@ SectionGraph."PIPE_NAME" {
 }
 
 # capture DAI is SSP2 using 2 periods
-# Buffers use s16le format, 1000us deadline on core 0 with priority 0
+# Buffers use s16le format, 1000us deadline with priority 0 on core 0
 # this is part of pipeline 2
 DAI_ADD(sof/pipe-dai-capture.m4,
 	2, SSP, SSP_NUM, SSP2-Codec,

--- a/tools/topology/topology1/sof-cht-nocodec.m4
+++ b/tools/topology/topology1/sof-cht-nocodec.m4
@@ -25,7 +25,7 @@ include(`platform/intel/'PLATFORM`.m4')
 #
 
 # Volume switch capture pipeline 2 on PCM 0 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-switch-capture.m4,
 	2, 0, 2, s32le,
 	1000, 0, 0,
@@ -48,7 +48,7 @@ DAI_ADD(sof/pipe-mixer-dai-playback.m4,
 	2, 48000)
 
 # PCM Playback pipeline 3 on PCM 0 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 # this is connected to pipeline DAI 1
 PIPELINE_PCM_ADD(sof/pipe-host-volume-playback.m4,
 	3, 0, 2, s32le,
@@ -58,7 +58,7 @@ PIPELINE_PCM_ADD(sof/pipe-host-volume-playback.m4,
 	PIPELINE_PLAYBACK_SCHED_COMP_1)
 
 # PCM Playback pipeline 4 on PCM 1 using max 2 channels of s32le.
-# 10ms deadline on core 0 with priority 0
+# 10ms deadline with priority 0 on core 0
 # this is connected to pipeline DAI 1
 PIPELINE_PCM_ADD(sof/pipe-host-volume-playback.m4,
 	4, 1, 2, s32le,
@@ -81,7 +81,7 @@ SectionGraph."PIPE_NAME" {
 }
 
 # capture DAI is SSP2 using 2 periods
-# Buffers use s24le format, 1000us deadline on core 0 with priority 0
+# Buffers use s24le format, 1000us deadline with priority 0 on core 0
 # this is part of pipeline 2
 DAI_ADD(sof/pipe-dai-capture.m4,
 	2, SSP, SSP_NUM, NoCodec-2,

--- a/tools/topology/topology1/sof-cml-demux-rt5682.m4
+++ b/tools/topology/topology1/sof-cml-demux-rt5682.m4
@@ -70,42 +70,42 @@ dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
 
 # Demux pipeline 1 on PCM 0 using max 2 channels of s24le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-demux-playback.m4,
 	1, 0, 2, s24le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s24le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	2, 0, 2, s24le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Passthrough capture pipeline 3 on PCM 1 using max 4 channels.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
 	3, 1, 4, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 4 on PCM 2 using max 2 channels of s32le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	4, 2, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 5 on PCM 3 using max 2 channels of s32le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	7, 3, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 6 on PCM 4 using max 2 channels of s32le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	6, 4, 2, s32le,
 	1000, 0, 0,
@@ -121,14 +121,14 @@ dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
 # playback DAI is SSP(SPP_INDEX) using 2 periods
-# Buffers use s24le format, 1000us deadline on core 0 with priority 0
+# Buffers use s24le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, SSP_INDEX, SSP_NAME,
 	PIPELINE_SOURCE_1, 2, s24le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is SSP(SSP_INDEX) using 2 periods
-# Buffers use s24le format, 1000us deadline on core 0 with priority 0
+# Buffers use s24le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	2, SSP,SSP_INDEX, SSP_NAME,
 	PIPELINE_SINK_2, 2, s24le,
@@ -162,28 +162,28 @@ SectionGraph."PIPE_CAP_VIRT" {
 }
 
 # capture DAI is DMIC01 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	3, DMIC, 0, dmic01,
 	PIPELINE_SINK_3, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp1 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	4, HDA, 0, iDisp1,
 	PIPELINE_SOURCE_4, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp2 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	7, HDA, 1, iDisp2,
 	PIPELINE_SOURCE_7, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp3 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	6, HDA, 2, iDisp3,
 	PIPELINE_SOURCE_6, 2, s32le,

--- a/tools/topology/topology1/sof-cml-rt1011-rt5682.m4
+++ b/tools/topology/topology1/sof-cml-rt1011-rt5682.m4
@@ -31,7 +31,7 @@ dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 7 on PCM 5 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(PIPE_PROC_PLAYBACK,
 	7, 5, 2, s32le,
 	1000, 0, 0,

--- a/tools/topology/topology1/sof-cml-rt5682-kwd.m4
+++ b/tools/topology/topology1/sof-cml-rt5682-kwd.m4
@@ -52,21 +52,21 @@ dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s24le.
-# Schedule 1000us deadline on core 0 with priority 0
+# Schedule 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	1, 0, 2, s24le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s24le.
-# Schedule 1000us deadline on core 0 with priority 0
+# Schedule 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	2, 0, 2, s24le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # DMICPROC capture pipeline 3 on PCM 1 using max 4 channels.
-# Schedule 1000us deadline on core 0 with priority 0
+# Schedule 1000us deadline with priority 0 on core 0
 ifdef(`DMICPROC_FILTER1', `define(PIPELINE_FILTER1, DMICPROC_FILTER1)')
 ifdef(`DMICPROC_FILTER2', `define(PIPELINE_FILTER2, DMICPROC_FILTER2)')
 
@@ -79,21 +79,21 @@ undefine(`PIPELINE_FILTER1')
 undefine(`PIPELINE_FILTER2')
 
 # Low Latency playback pipeline 4 on PCM 2 using max 2 channels of s32le.
-# Schedule 1000us deadline on core 0 with priority 0
+# Schedule 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	4, 2, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 5 on PCM 3 using max 2 channels of s32le.
-# Schedule 1000us deadline on core 0 with priority 0
+# Schedule 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	5, 3, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 6 on PCM 4 using max 2 channels of s32le.
-# Schedule 1000us deadline on core 0 with priority 0
+# Schedule 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	6, 4, 2, s32le,
 	1000, 0, 0,
@@ -155,7 +155,7 @@ DAI_ADD(sof/pipe-dai-playback.m4,
 #
 
 # Passthrough capture pipeline 7 on PCM 7 using max 2 channels.
-# Schedule 20000us deadline on core 0 with priority 0
+# Schedule 20000us deadline with priority 0 on core 0
 PIPELINE_PCM_DAI_ADD(sof/pipe-kfbm-capture.m4,
 	8, 8, 2, s24le,
 	KWD_PIPE_SCH_DEADLINE_US, 0, 0, DMIC, 1, s32le, 3,

--- a/tools/topology/topology1/sof-cml-rt5682.m4
+++ b/tools/topology/topology1/sof-cml-rt5682.m4
@@ -45,21 +45,21 @@ dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s24le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-`HSEARPROC'-playback.m4,
 	1, 0, 2, s24le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s24le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-`HSMICPROC'-capture.m4,
 	2, 0, 2, s24le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Passthrough capture pipeline 3 on PCM 1 using max 4 channels.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 ifdef(`DMICPROC_FILTER1', `define(PIPELINE_FILTER1, DMICPROC_FILTER1)', `undefine(`PIPELINE_FILTER1')')
 ifdef(`DMICPROC_FILTER2', `define(PIPELINE_FILTER2, DMICPROC_FILTER2)', `undefine(`PIPELINE_FILTER2')')
 define(`PGA_NAME', Dmic0)
@@ -74,28 +74,28 @@ undefine(`PIPELINE_FILTER1')
 undefine(`PIPELINE_FILTER2')
 
 # Low Latency playback pipeline 4 on PCM 2 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	4, 2, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 5 on PCM 3 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	5, 3, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 6 on PCM 4 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	6, 4, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Passthrough capture pipeline 7 on PCM 5 using max 2 channels.
-# Schedule 1000us deadline on core 0 with priority 0
+# Schedule 1000us deadline with priority 0 on core 0
 ifdef(`DMIC16KPROC_FILTER1', `define(PIPELINE_FILTER1, DMIC16KPROC_FILTER1)', `undefine(`PIPELINE_FILTER1')')
 ifdef(`DMIC16KPROC_FILTER2', `define(PIPELINE_FILTER2, DMIC16KPROC_FILTER2)', `undefine(`PIPELINE_FILTER2')')
 define(`PGA_NAME', Dmic1)
@@ -119,42 +119,42 @@ dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
 # playback DAI is SSP(SPP_INDEX) using 2 periods
-# Buffers use s24le format, 1000us deadline on core 0 with priority 0
+# Buffers use s24le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, SSP_INDEX, SSP_NAME,
 	PIPELINE_SOURCE_1, 2, s24le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is SSP(SSP_INDEX) using 2 periods
-# Buffers use s24le format, 1000us deadline on core 0 with priority 0
+# Buffers use s24le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	2, SSP,SSP_INDEX, SSP_NAME,
 	PIPELINE_SINK_2, 2, s24le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is DMIC01 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	3, DMIC, 0, dmic01,
 	PIPELINE_SINK_3, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp1 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	4, HDA, 0, iDisp1,
 	PIPELINE_SOURCE_4, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp2 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	5, HDA, 1, iDisp2,
 	PIPELINE_SOURCE_5, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp3 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	6, HDA, 2, iDisp3,
 	PIPELINE_SOURCE_6, 2, s32le,

--- a/tools/topology/topology1/sof-cml-rt700.m4
+++ b/tools/topology/topology1/sof-cml-rt700.m4
@@ -61,35 +61,35 @@ dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	1, 0, 2, s24le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 2 on PCM 1 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	2, 1, 2, s24le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 6 on PCM 5 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	6, 5, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 7 on PCM 6 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	7, 6, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 8 on PCM 7 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	8, 7, 2, s32le,
 	1000, 0, 0,

--- a/tools/topology/topology1/sof-cnl-rt274.m4
+++ b/tools/topology/topology1/sof-cnl-rt274.m4
@@ -31,14 +31,14 @@ dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s24le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	1, 0, 2, s24le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s24le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	2, 0, 2, s24le,
 	1000, 0, 0,
@@ -56,14 +56,14 @@ dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
 # playback DAI is SSP0 using 2 periods
-# Buffers use s24le format, 1000us deadline on core 0 with priority 0
+# Buffers use s24le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, 0, SSP0-Codec,
 	PIPELINE_SOURCE_1, 2, s24le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is SSP0 using 2 periods
-# Buffers use s24le format, 1000us deadline on core 0 with priority 0
+# Buffers use s24le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	2, SSP, 0, SSP0-Codec,
 	PIPELINE_SINK_2, 2, s24le,

--- a/tools/topology/topology1/sof-cnl-rt5682-sdw2.m4
+++ b/tools/topology/topology1/sof-cnl-rt5682-sdw2.m4
@@ -36,35 +36,35 @@ dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	1, 0, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 2 on PCM 1 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-switch-capture.m4,
 	2, 1, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 3 on PCM 2 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	3, 5, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 4 on PCM 3 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	4, 6, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 5 on PCM 4 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	5, 7, 2, s32le,
 	1000, 0, 0,
@@ -94,21 +94,21 @@ DAI_ADD(sof/pipe-dai-capture.m4,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp1 using 2 periods
-# # Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# # Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	3, HDA, 0, iDisp1,
 	PIPELINE_SOURCE_3, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp2 using 2 periods
-# # Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# # Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	4, HDA, 1, iDisp2,
 	PIPELINE_SOURCE_4, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp3 using 2 periods
-# # Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# # Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	5, HDA, 2, iDisp3,
 	PIPELINE_SOURCE_5, 2, s32le,

--- a/tools/topology/topology1/sof-ehl-rt5660.m4
+++ b/tools/topology/topology1/sof-ehl-rt5660.m4
@@ -44,28 +44,28 @@ dnl     time_domain, sched_comp)
 # which is not applicable in ehl-rt5660.
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	1, 0, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	2, 0, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 3 on PCM 1 using max 4 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	3, 1, 4, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Passthrough capture pipeline 4 on PCM 3 using max 2 channels.
-# Schedule 16 frames per 1000us deadline on core 0 with priority 0
+# Schedule 16 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	4, 3, 2, s16le,
 	1000, 0, 0,
@@ -74,28 +74,28 @@ PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 ifelse(HDMI, `1',
 `
 # Low Latency playback pipeline 4 on PCM 2 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	5, 2, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 5 on PCM 3 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	6, 3, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 6 on PCM 4 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	7, 4, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 7 on PCM 5 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	8, 5, 2, s32le,
 	1000, 0, 0,

--- a/tools/topology/topology1/sof-glk-da7219-kwd.m4
+++ b/tools/topology/topology1/sof-glk-da7219-kwd.m4
@@ -51,28 +51,28 @@ dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(PIPE_VOLUME_PLAYBACK,
 	1, 0, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 2 on PCM 1 using max 2 channels of s32le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	2, 1, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 3 on PCM 1 using max 2 channels of s32le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	3, 1, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 4 on PCM 99 using max 4 channels of s32le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 
 PIPELINE_PCM_ADD(DMIC_PIPE_CAPTURE,
 	4, DMIC_PCM_NUM, 4, DMIC01_FMT,
@@ -80,21 +80,21 @@ PIPELINE_PCM_ADD(DMIC_PIPE_CAPTURE,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 5 on PCM 5 using max 2 channels of s32le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
         5, 5, 2, s32le,
         1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 6 on PCM 6 using max 2 channels of s32le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
         6, 6, 2, s32le,
         1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 7 on PCM 7 using max 2 channels of s32le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
         7, 7, 2, s32le,
         1000, 0, 0,
@@ -117,7 +117,7 @@ dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
 # playback DAI is SSP1 using 2 periods
-# Buffers use s16le format, 1000us deadline on core 0 with priority 0
+# Buffers use s16le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, 1, SSP1-Codec,
 	PIPELINE_SOURCE_1, 2, SSP1_VALID_BITS_STR,
@@ -132,42 +132,42 @@ DAI_ADD(sof/pipe-dai-capture.m4,
         1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)')
 
 # playback DAI is SSP(SSP_INDEX) using 2 periods
-# Buffers use s16le format, 1000us deadline on core 0 with priority 0
+# Buffers use s16le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	2, SSP, SSP_INDEX, SSP_NAME,
 	PIPELINE_SOURCE_2, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is SSP(SSP_INDEX) using 2 periods
-# Buffers use s16le format, 1000us deadline on core 0 with priority 0
+# Buffers use s16le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	3, SSP, SSP_INDEX, SSP_NAME,
 	PIPELINE_SINK_3, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is DMIC0 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	4, DMIC, 0, dmic01,
 	PIPELINE_SINK_4, 2, DMIC01_FMT,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp1 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
         5, HDA, HDMI0_INDEX, iDisp1,
         PIPELINE_SOURCE_5, 2, s32le,
         1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp2 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
         6, HDA, HDMI1_INDEX, iDisp2,
         PIPELINE_SOURCE_6, 2, s32le,
         1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp3 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
         7, HDA, HDMI2_INDEX, iDisp3,
         PIPELINE_SOURCE_7, 2, s32le,
@@ -178,7 +178,7 @@ DAI_ADD(sof/pipe-dai-playback.m4,
 #
 
 # Passthrough capture pipeline 8 on PCM 8 using max 2 channels.
-# Schedule 20000us deadline on core 0 with priority 0
+# Schedule 20000us deadline with priority 0 on core 0
 PIPELINE_PCM_DAI_ADD(sof/pipe-kfbm-capture.m4,
 	8, 8, 2, DMIC1_FMT,
 	KWD_PIPE_SCH_DEADLINE_US, 0, 0, DMIC, 1, DMIC01_FMT, 3,

--- a/tools/topology/topology1/sof-glk-da7219.m4
+++ b/tools/topology/topology1/sof-glk-da7219.m4
@@ -38,21 +38,21 @@ dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	1, 0, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 2 on PCM 1 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	2, 1, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 3 on PCM 1 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	3, 1, 2, s32le,
 	1000, 0, 0,
@@ -63,14 +63,14 @@ ifdef(`DMICPROC', , `define(DMICPROC, volume)')
 define(DEF_PIPE_DMIC_CAPTURE, sof/pipe-DMICPROC-capture.m4)
 
 # Low Latency capture pipeline 4 on PCM 99 using max 4 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(DEF_PIPE_DMIC_CAPTURE,
 	4, 99, 4, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 5 on PCM 5 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 # PIPELINE_PCM_ADD(sof/pipe-passthrough-playback.m4,
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
         5, 5, 2, s32le,
@@ -78,7 +78,7 @@ PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 6 on PCM 6 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 # PIPELINE_PCM_ADD(sof/pipe-passthrough-playback.m4,
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
         6, 6, 2, s32le,
@@ -86,7 +86,7 @@ PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 7 on PCM 7 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 # PIPELINE_PCM_ADD(sof/pipe-passthrough-playback.m4,
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
         7, 7, 2, s32le,
@@ -103,7 +103,7 @@ dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
 # playback DAI is SSP1 using 2 periods
-# Buffers use s16le format, 1000us deadline on core 0 with priority 0
+# Buffers use s16le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, 1, SSP1-Codec,
 	PIPELINE_SOURCE_1, 2, s16le,
@@ -111,28 +111,28 @@ DAI_ADD(sof/pipe-dai-playback.m4,
 
 ifelse(HEADPHONE, `da7219', `
 # playback DAI is SSP2 using 2 periods
-# Buffers use s16le format, 1000us deadline on core 0 with priority 0
+# Buffers use s16le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	2, SSP, 2, SSP2-Codec,
 	PIPELINE_SOURCE_2, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is SSP2 using 2 periods
-# Buffers use s16le format, 1000us deadline on core 0 with priority 0
+# Buffers use s16le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	3, SSP, 2, SSP2-Codec,
 	PIPELINE_SINK_3, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 ', HEADPHONE, `cs42l42', `
 # playback DAI is SSP2 using 2 periods
-# Buffers use s24le format, 1000us deadline on core 0 with priority 0
+# Buffers use s24le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	2, SSP, 2, SSP2-Codec,
 	PIPELINE_SOURCE_2, 2, s24le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is SSP2 using 2 periods
-# Buffers use s24le format, 1000us deadline on core 0 with priority 0
+# Buffers use s24le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	3, SSP, 2, SSP2-Codec,
 	PIPELINE_SINK_3, 2, s24le,
@@ -140,28 +140,28 @@ DAI_ADD(sof/pipe-dai-capture.m4,
 ', )
 
 # capture DAI is DMIC0 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	4, DMIC, 0, dmic01,
 	PIPELINE_SINK_4, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp1 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
         5, HDA, 3, iDisp1,
         PIPELINE_SOURCE_5, 2, s32le,
         1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp2 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
         6, HDA, 4, iDisp2,
         PIPELINE_SOURCE_6, 2, s32le,
         1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp3 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
         7, HDA, 5, iDisp3,
         PIPELINE_SOURCE_7, 2, s32le,

--- a/tools/topology/topology1/sof-glk-es8336.m4
+++ b/tools/topology/topology1/sof-glk-es8336.m4
@@ -67,35 +67,35 @@ ifelse(CHANNELS, `0',
 # PCM7  ----> volume (pipe 7)   -----> iDisp3 (HDMI/DP playback, BE link 7)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	1, 0, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-low-latency-capture.m4,
 	2, 0, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 5 on PCM 5 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
         5, 5, 2, s32le,
         1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 6 on PCM 6 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
         6, 6, 2, s32le,
         1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 7 on PCM 7 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
         7, 7, 2, s32le,
         1000, 0, 0,
@@ -111,35 +111,35 @@ dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
 # playback DAI is SSP2 using 2 periods
-# Buffers use s24le format, 1000us deadline on core 0 with priority 0
+# Buffers use s24le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, SSP_NUM, `SSP'SSP_NUM`-Codec',
 	PIPELINE_SOURCE_1, 2, s24le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_DMA)
 
 # capture DAI is SSP2 using 2 periods
-# Buffers use s24le format, 1000us deadline on core 0 with priority 0
+# Buffers use s24le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	2, SSP, SSP_NUM, `SSP'SSP_NUM`-Codec',
 	PIPELINE_SINK_2, 2, s24le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_DMA)
 
 # playback DAI is iDisp1 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
         5, HDA, 3, iDisp1,
         PIPELINE_SOURCE_5, 2, s32le,
         1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp2 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
         6, HDA, 4, iDisp2,
         PIPELINE_SOURCE_6, 2, s32le,
         1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp3 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
         7, HDA, 5, iDisp3,
         PIPELINE_SOURCE_7, 2, s32le,

--- a/tools/topology/topology1/sof-glk-rt5682.m4
+++ b/tools/topology/topology1/sof-glk-rt5682.m4
@@ -40,28 +40,28 @@ dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	1, 0, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 2 on PCM 1 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	2, 1, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 3 on PCM 1 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	3, 1, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 4 on PCM 99 using max 4 channels of s16le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 #PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
 	4, 99, 4, s16le,
@@ -69,7 +69,7 @@ PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 5 on PCM 5 using max 2 channels of s16le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 # PIPELINE_PCM_ADD(sof/pipe-passthrough-playback.m4,
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
         5, 5, 2, s16le,
@@ -77,7 +77,7 @@ PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 6 on PCM 6 using max 2 channels of s16le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 # PIPELINE_PCM_ADD(sof/pipe-passthrough-playback.m4,
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
         6, 6, 2, s16le,
@@ -85,7 +85,7 @@ PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 7 on PCM 7 using max 2 channels of s16le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 # PIPELINE_PCM_ADD(sof/pipe-passthrough-playback.m4,
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
         7, 7, 2, s16le,
@@ -102,49 +102,49 @@ dnl     buffer, periods, format,
 dnl     deadline, priority, core, time_domain)
 
 # playback DAI is SSP1 using 2 periods
-# Buffers use s16le format, 1000us deadline on core 0 with priority 0
+# Buffers use s16le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, 1, SSP1-Codec,
 	PIPELINE_SOURCE_1, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is SSP1 using 2 periods
-# Buffers use s16le format, 1000us deadline on core 0 with priority 0
+# Buffers use s16le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	2, SSP, 2, SSP2-Codec,
 	PIPELINE_SOURCE_2, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is SSP1 using 2 periods
-# Buffers use s16le format, 1000us deadline on core 0 with priority 0
+# Buffers use s16le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	3, SSP, 2, SSP2-Codec,
 	PIPELINE_SINK_3, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is DMIC0 using 2 periods
-# Buffers use s16le format, 1000us deadline on core 0 with priority 0
+# Buffers use s16le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	4, DMIC, 0, dmic01,
 	PIPELINE_SINK_4, 2, s16le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp1 using 2 periods
-# Buffers use s16le format, 1000us deadline on core 0 with priority 0
+# Buffers use s16le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
         5, HDA, 3, iDisp1,
         PIPELINE_SOURCE_5, 2, s16le,
         1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp2 using 2 periods
-# Buffers use s16le format, 1000us deadline on core 0 with priority 0
+# Buffers use s16le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
         6, HDA, 4, iDisp2,
         PIPELINE_SOURCE_6, 2, s16le,
         1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp3 using 2 periods
-# Buffers use s16le format, 1000us deadline on core 0 with priority 0
+# Buffers use s16le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
         7, HDA, 5, iDisp3,
         PIPELINE_SOURCE_7, 2, s16le,

--- a/tools/topology/topology1/sof-hda-generic-idisp.m4
+++ b/tools/topology/topology1/sof-hda-generic-idisp.m4
@@ -52,21 +52,21 @@ dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 2 on PCM 1 using max 2 channels of s32le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	2, 1, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 3 on PCM 2 using max 2 channels of s32le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	3, 2, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 4 on PCM 3 using max 2 channels of s32le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	4, 3, 2, s32le,
 	1000, 0, 0,
@@ -82,21 +82,21 @@ dnl     buffer, periods, format,
 dnl     deadline, priority, core)
 
 # playback DAI is iDisp1 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	2, HDA, 0, iDisp1,
 	PIPELINE_SOURCE_2, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp2 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	3, HDA, 1, iDisp2,
 	PIPELINE_SOURCE_3, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp3 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	4, HDA, 2, iDisp3,
 	PIPELINE_SOURCE_4, 2, s32le,

--- a/tools/topology/topology1/sof-hda-generic-kwd.m4
+++ b/tools/topology/topology1/sof-hda-generic-kwd.m4
@@ -53,49 +53,49 @@ include(`platform/intel/intel-generic-dmic-kwd.m4')
 )
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s24le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	1, 0, 2, s24le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s24le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	2, 0, 2, s24le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 3 on PCM 1 using max 2 channels of s24le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	3, 1, 2, s24le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 4 on PCM 1 using max 2 channels of s24le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	4, 1, 2, s24le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 7 on PCM 3 using max 2 channels of s24le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
         7, 3, 2, s24le,
         1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 8 on PCM 4 using max 2 channels of s24le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
         8, 4, 2, s24le,
         1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 9 on PCM 5 using max 2 channels of s24le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
         9, 5, 2, s24le,
         1000, 0, 0,
@@ -106,49 +106,49 @@ PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 #
 
 # playback DAI is HDA Analog using 2 periods
-# Dai buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Dai buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
         1, HDA, 0, Analog Playback and Capture,
         PIPELINE_SOURCE_1, 2, s32le,
         1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is HDA Analog using 2 periods
-# Dai buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Dai buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
         2, HDA, 1, Analog Playback and Capture,
 	PIPELINE_SINK_2, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is HDA Digital using 2 periods
-# Dai buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Dai buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
         3, HDA, 2, Digital Playback and Capture,
         PIPELINE_SOURCE_3, 2, s32le,
         1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is HDA Digital using 2 periods
-# Dai buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Dai buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
         4, HDA, 3, Digital Playback and Capture,
 	PIPELINE_SINK_4, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp1 using 2 periods
-# Dai buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Dai buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
         7, HDA, 4, iDisp1,
         PIPELINE_SOURCE_7, 2, s32le,
         1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp2 using 2 periods
-# Dai buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Dai buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
         8, HDA, 5, iDisp2,
         PIPELINE_SOURCE_8, 2, s32le,
         1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp3 using 2 periods
-# Dai buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Dai buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
         9, HDA, 6, iDisp3,
         PIPELINE_SOURCE_9, 2, s32le,

--- a/tools/topology/topology1/sof-hda-generic.m4
+++ b/tools/topology/topology1/sof-hda-generic.m4
@@ -58,7 +58,7 @@ ifdef(`HSPROC_FILTER1', `define(PIPELINE_FILTER1, HSPROC_FILTER1)', `undefine(`P
 ifdef(`HSPROC_FILTER2', `define(PIPELINE_FILTER2, HSPROC_FILTER2)', `undefine(`PIPELINE_FILTER2')')
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s24le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(PIPE_HEADSET_PLAYBACK,
 	1, 0, 2, s24le,
 	1000, 0, 0,
@@ -70,42 +70,42 @@ undefine(`PIPELINE_FILTER1')
 undefine(`PIPELINE_FILTER2')
 
 # Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s24le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-highpass-capture.m4,
 	2, 0, 2, s24le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 3 on PCM 1 using max 2 channels of s24le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	3, 1, 2, s24le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 4 on PCM 1 using max 2 channels of s24le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-highpass-capture.m4,
 	4, 1, 2, s24le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 7 on PCM 3 using max 2 channels of s24le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
         7, 3, 2, s24le,
         1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 8 on PCM 4 using max 2 channels of s24le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
         8, 4, 2, s24le,
         1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 9 on PCM 5 using max 2 channels of s24le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
         9, 5, 2, s24le,
         1000, 0, 0,
@@ -116,49 +116,49 @@ PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 #
 
 # playback DAI is HDA Analog using 2 periods
-# Dai buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Dai buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
         1, HDA, 0, Analog Playback and Capture,
         PIPELINE_SOURCE_1, 2, s32le,
         1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is HDA Analog using 2 periods
-# Dai buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Dai buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
         2, HDA, 1, Analog Playback and Capture,
 	PIPELINE_SINK_2, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is HDA Digital using 2 periods
-# Dai buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Dai buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
         3, HDA, 2, Digital Playback and Capture,
         PIPELINE_SOURCE_3, 2, s32le,
         1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is HDA Digital using 2 periods
-# Dai buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Dai buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
         4, HDA, 3, Digital Playback and Capture,
 	PIPELINE_SINK_4, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp1 using 2 periods
-# Dai buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Dai buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
         7, HDA, 4, iDisp1,
         PIPELINE_SOURCE_7, 2, s32le,
         1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp2 using 2 periods
-# Dai buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Dai buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
         8, HDA, 5, iDisp2,
         PIPELINE_SOURCE_8, 2, s32le,
         1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp3 using 2 periods
-# Dai buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Dai buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
         9, HDA, 6, iDisp3,
         PIPELINE_SOURCE_9, 2, s32le,

--- a/tools/topology/topology1/sof-icl-dmic-4ch.m4
+++ b/tools/topology/topology1/sof-icl-dmic-4ch.m4
@@ -29,7 +29,7 @@ dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
 
 # Passthrough capture pipeline 1 on PCM 1 using max 4 channels.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
 	1, 1, 4, s32le,
 	1000, 0, 0,
@@ -46,7 +46,7 @@ dnl     deadline, priority, core, time_domain)
 
 
 # capture DAI is DMIC 0 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	1, DMIC, 0, dmic01,
 	PIPELINE_SINK_1, 2, s32le,

--- a/tools/topology/topology1/sof-icl-rt700.m4
+++ b/tools/topology/topology1/sof-icl-rt700.m4
@@ -61,35 +61,35 @@ dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	1, 0, 2, s24le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 2 on PCM 1 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	2, 1, 2, s24le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 6 on PCM 5 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	6, 5, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 7 on PCM 6 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	7, 6, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 8 on PCM 7 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	8, 7, 2, s32le,
 	1000, 0, 0,

--- a/tools/topology/topology1/sof-icl-rt711-rt1308-rt715-hdmi.m4
+++ b/tools/topology/topology1/sof-icl-rt711-rt1308-rt715-hdmi.m4
@@ -91,14 +91,14 @@ dnl     time_domain, sched_comp)
 ifdef(`NOJACK', `',
 `
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	1, 0, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 2 on PCM 1 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-switch-capture.m4,
 	2, 1, 2, s32le,
 	1000, 0, 0,
@@ -108,7 +108,7 @@ PIPELINE_PCM_ADD(sof/pipe-volume-switch-capture.m4,
 ifdef(`MONO',
 `
 # Low Latency playback pipeline 3 on PCM 2 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	3, 2, 2, s32le,
 	1000, 0, 0,
@@ -116,7 +116,7 @@ PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 ',
 `
 # Low Latency playback pipeline 3 on PCM 2 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(ifdef(`NO_AGGREGATION',`sof/pipe-volume-playback.m4',
 	`sof/pipe-volume-demux-playback.m4'),
 	3, 2, 2, s32le,
@@ -124,7 +124,7 @@ PIPELINE_PCM_ADD(ifdef(`NO_AGGREGATION',`sof/pipe-volume-playback.m4',
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 4 on PCM 40 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(ifdef(`NO_AGGREGATION', `sof/pipe-volume-playback.m4',
 	`sof/pipe-dai-endpoint.m4'),
 	4, 40, 2, s32le,
@@ -133,28 +133,28 @@ PIPELINE_PCM_ADD(ifdef(`NO_AGGREGATION', `sof/pipe-volume-playback.m4',
 ')
 
 # Low Latency capture pipeline 5 on PCM 4 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-highpass-switch-capture.m4,
 	5, 4, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 6 on PCM 5 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	6, 5, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 7 on PCM 6 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	7, 6, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 8 on PCM 7 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	8, 7, 2, s32le,
 	1000, 0, 0,
@@ -226,21 +226,21 @@ DAI_ADD(sof/pipe-dai-capture.m4,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp1 using 2 periods
-# # Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# # Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	6, HDA, 0, iDisp1,
 	PIPELINE_SOURCE_6, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp2 using 2 periods
-# # Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# # Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	7, HDA, 1, iDisp2,
 	PIPELINE_SOURCE_7, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp3 using 2 periods
-# # Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# # Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	8, HDA, 2, iDisp3,
 	PIPELINE_SOURCE_8, 2, s32le,

--- a/tools/topology/topology1/sof-imx8-cs42888-mixer.m4
+++ b/tools/topology/topology1/sof-imx8-cs42888-mixer.m4
@@ -27,7 +27,7 @@ include(`platform/imx/imx8.m4')
 #
 
 # Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s24le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-low-latency-capture.m4,
 	2, 0, 2, s24le,
 	1000, 0, 0,
@@ -50,7 +50,7 @@ DAI_ADD(sof/pipe-mixer-dai-playback.m4,
 	2, 48000)
 
 # PCM Playback pipeline 3 on PCM 0 using max 2 channels of s24le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 # this is connected to pipeline DAI 1
 PIPELINE_PCM_ADD(sof/pipe-host-volume-playback.m4,
 	3, 0, 2, s24le,
@@ -60,7 +60,7 @@ PIPELINE_PCM_ADD(sof/pipe-host-volume-playback.m4,
 	PIPELINE_PLAYBACK_SCHED_COMP_1)
 
 # PCM Playback pipeline 4 on PCM 1 using max 2 channels of s24le.
-# 5ms deadline on core 0 with priority 0
+# 5ms deadline with priority 0 on core 0
 # this is connected to pipeline DAI 1
 PIPELINE_PCM_ADD(sof/pipe-host-volume-playback.m4,
 	4, 1, 2, s24le,
@@ -83,7 +83,7 @@ SectionGraph."PIPE_NAME" {
 }
 
 # capture DAI is ESAI0 using 2 periods
-# Buffers use s24le format, 1000us deadline on core 0 with priority 0
+# Buffers use s24le format, 1000us deadline with priority 0 on core 0
 # this is part of pipeline 2
 DAI_ADD(sof/pipe-dai-capture.m4,
 	2, ESAI, 0, esai0-cs42888,

--- a/tools/topology/topology1/sof-imx8-cs42888.m4
+++ b/tools/topology/topology1/sof-imx8-cs42888.m4
@@ -32,14 +32,14 @@ dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s24le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	1, 0, 2, s24le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s24le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	2, 0, 2, s24le,
 	1000, 0, 0,

--- a/tools/topology/topology1/sof-imx8-nocodec-sai.m4
+++ b/tools/topology/topology1/sof-imx8-nocodec-sai.m4
@@ -32,7 +32,7 @@ dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s24le
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	1, 0, 2, s24le,
 	1000, 0, 0,

--- a/tools/topology/topology1/sof-imx8-nocodec.m4
+++ b/tools/topology/topology1/sof-imx8-nocodec.m4
@@ -32,7 +32,7 @@ dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s24le
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	1, 0, 2, s24le,
 	1000, 0, 0,

--- a/tools/topology/topology1/sof-imx8-wm8960-kwd.m4
+++ b/tools/topology/topology1/sof-imx8-wm8960-kwd.m4
@@ -34,7 +34,7 @@ dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
 
 # Passthrough capture pipeline 1 on PCM 0 using max 2 channels.
-# Schedule 1000us deadline on core 0 with priority 0
+# Schedule 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-kfbm-no-lp-capture.m4,
 	1, 0, 2, s32le,
 	KWD_PIPE_SCH_DEADLINE_US, 0, 0,

--- a/tools/topology/topology1/sof-imx8-wm8960-mixer.m4
+++ b/tools/topology/topology1/sof-imx8-wm8960-mixer.m4
@@ -27,7 +27,7 @@ include(`platform/imx/imx8.m4')
 #
 
 # Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-low-latency-capture.m4,
 	2, 0, 2, s32le,
 	1000, 0, 0,
@@ -50,7 +50,7 @@ DAI_ADD(sof/pipe-mixer-dai-playback.m4,
 	2, 48000)
 
 # PCM Playback pipeline 3 on PCM 0 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 # this is connected to pipeline DAI 1
 PIPELINE_PCM_ADD(sof/pipe-host-volume-playback.m4,
 	3, 0, 2, s32le,
@@ -60,7 +60,7 @@ PIPELINE_PCM_ADD(sof/pipe-host-volume-playback.m4,
 	PIPELINE_PLAYBACK_SCHED_COMP_1)
 
 # PCM Playback pipeline 4 on PCM 1 using max 2 channels of s32le.
-# 5ms deadline on core 0 with priority 0
+# 5ms deadline with priority 0 on core 0
 # this is connected to pipeline DAI 1
 PIPELINE_PCM_ADD(sof/pipe-host-volume-playback.m4,
 	4, 1, 2, s32le,
@@ -83,7 +83,7 @@ SectionGraph."PIPE_NAME" {
 }
 
 # capture DAI is SAI1 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 # this is part of pipeline 2
 DAI_ADD(sof/pipe-dai-capture.m4,
 	2, SAI, 1, sai1-wm8960-hifi,

--- a/tools/topology/topology1/sof-imx8-wm8960.m4
+++ b/tools/topology/topology1/sof-imx8-wm8960.m4
@@ -32,14 +32,14 @@ dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-`PPROC'-playback.m4,
 	1, 0, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s32le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	2, 0, 2, s32le,
 	1000, 0, 0,

--- a/tools/topology/topology1/sof-imx8mp-wm8960-kwd.m4
+++ b/tools/topology/topology1/sof-imx8mp-wm8960-kwd.m4
@@ -34,7 +34,7 @@ dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
 
 # Passthrough capture pipeline 1 on PCM 0 using max 2 channels.
-# Schedule 1000us deadline on core 0 with priority 0
+# Schedule 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-kfbm-no-lp-capture.m4,
 	1, 0, 2, s16le,
 	KWD_PIPE_SCH_DEADLINE_US, 0, 0,

--- a/tools/topology/topology1/sof-imx8mp-wm8960-mixer.m4
+++ b/tools/topology/topology1/sof-imx8mp-wm8960-mixer.m4
@@ -27,7 +27,7 @@ include(`platform/imx/imx8.m4')
 #
 
 # Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-low-latency-capture.m4,
 	2, 0, 2, s32le,
 	1000, 0, 0,
@@ -50,7 +50,7 @@ DAI_ADD(sof/pipe-mixer-dai-playback.m4,
 	2, 48000)
 
 # PCM Playback pipeline 3 on PCM 0 using max 2 channels of s32le.
-# 1000us deadline on core 0 with priority 0
+# 1000us deadline with priority 0 on core 0
 # this is connected to pipeline DAI 1
 PIPELINE_PCM_ADD(sof/pipe-host-volume-playback.m4,
 	3, 0, 2, s32le,
@@ -60,7 +60,7 @@ PIPELINE_PCM_ADD(sof/pipe-host-volume-playback.m4,
 	PIPELINE_PLAYBACK_SCHED_COMP_1)
 
 # PCM Playback pipeline 4 on PCM 1 using max 2 channels of s32le.
-# 5ms deadline on core 0 with priority 0
+# 5ms deadline with priority 0 on core 0
 # this is connected to pipeline DAI 1
 PIPELINE_PCM_ADD(sof/pipe-host-volume-playback.m4,
 	4, 1, 2, s32le,
@@ -83,7 +83,7 @@ SectionGraph."PIPE_NAME" {
 }
 
 # capture DAI is SAI3 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 # this is part of pipeline 2
 DAI_ADD(sof/pipe-dai-capture.m4,
 	2, SAI, 3, sai3-wm8960-hifi,

--- a/tools/topology/topology1/sof-imx8mp-wm8960.m4
+++ b/tools/topology/topology1/sof-imx8mp-wm8960.m4
@@ -32,14 +32,14 @@ dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-`PPROC'-playback.m4,
 	1, 0, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s32le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	2, 0, 2, s32le,
 	1000, 0, 0,

--- a/tools/topology/topology1/sof-imx8ulp-btsco.m4
+++ b/tools/topology/topology1/sof-imx8ulp-btsco.m4
@@ -34,7 +34,7 @@ dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 1 channels of s16le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	1, 0, 1, s16le,
 	1000, 0, 0,
@@ -43,7 +43,7 @@ PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 undefine(`CHANNELS_MIN')
 
 # Low Latency capture pipeline 2 on PCM 0 using max 1 channels of s16le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	2, 0, 1, s16le,
 	1000, 0, 0,

--- a/tools/topology/topology1/sof-jsl-da7219.m4
+++ b/tools/topology/topology1/sof-jsl-da7219.m4
@@ -57,14 +57,14 @@ dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 1 on PCM 1 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	1, 1, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 2 on PCM 1 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	2, 1, 2, s32le,
 	1000, 0, 0,
@@ -77,21 +77,21 @@ PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 5 on PCM 2 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	5, 2, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 6 on PCM 3 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	6, 3, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 7 on PCM 4 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	7, 4, 2, s32le,
 	1000, 0, 0,

--- a/tools/topology/topology1/sof-jsl-rt5682.m4
+++ b/tools/topology/topology1/sof-jsl-rt5682.m4
@@ -56,7 +56,7 @@ dnl     pipe id, pcm, max channels, format,
 dnl     frames, deadline, priority, core)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 define(ENDPOINT_NAME, `Speakers')
 PIPELINE_PCM_ADD(
     ifdef(`WAVES', sof/pipe-waves-codec-playback.m4, sof/pipe-volume-playback.m4),
@@ -66,7 +66,7 @@ PIPELINE_PCM_ADD(
 undefine(ENDPOINT_NAME)
 
 # Low Latency playback pipeline 2 on PCM 1 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 define(ENDPOINT_NAME, `Headphones')
 PIPELINE_PCM_ADD(
     ifdef(`WAVES', sof/pipe-waves-codec-playback.m4,
@@ -78,28 +78,28 @@ PIPELINE_PCM_ADD(
 undefine(ENDPOINT_NAME)
 
 # Low Latency capture pipeline 3 on PCM 1 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	3, 1, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 2 on PCM 2 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	5, 2, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 3 on PCM 3 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	6, 3, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 4 on PCM 4 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	7, 4, 2, s32le,
 	1000, 0, 0,

--- a/tools/topology/topology1/sof-mt8195-mt6359-rt1019-rt5682.m4
+++ b/tools/topology/topology1/sof-mt8195-mt6359-rt1019-rt5682.m4
@@ -35,28 +35,28 @@ dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
 
 # Low Latency capture pipeline 1 on PCM 16 using max 2 channels of s16le
-# Set 10000us deadline on core 0 with priority 0
+# Set 10000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-passthrough-playback.m4,
 	1, 16, 2, s16le,
 	10000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 2 on PCM 16 using max 2 channels of s16le
-# Set 10000us deadline on core 0 with priority 0
+# Set 10000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-passthrough-playback.m4,
 	2, 17, 2, s16le,
 	10000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 3 on PCM 16 using max 2 channels of s16le
-# Set 10000us deadline on core 0 with priority 0
+# Set 10000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
 	3, 18, 2, s16le,
 	10000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 4 on PCM 16 using max 2 channels of s16le
-# Set 10000us deadline on core 0 with priority 0
+# Set 10000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
 	4, 19, 2, s16le,
 	10000, 0, 0,

--- a/tools/topology/topology1/sof-smart-amplifier.m4
+++ b/tools/topology/topology1/sof-smart-amplifier.m4
@@ -124,14 +124,14 @@ dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
 
 # Demux pipeline 1 on PCM 0 using max 2 channels of s32le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-smart-amplifier-playback.m4,
 	SMART_PB_PPL_ID, SMART_PCM_ID, SMART_PB_CH_NUM, s32le,
 	SMART_AMP_PERIOD, 0, SMART_AMP_CORE,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s32le.
-# Set 1000us deadline on core 0 with priority 0
+# Set 1000us deadline with priority 0 on core 0
 ifelse(SDW, `1',
 `
 PIPELINE_PCM_ADD(sof/pipe-amp-ref-capture.m4,
@@ -158,14 +158,14 @@ dnl     deadline, priority, core, time_domain)
 ifelse(SDW, `1',
 `
 # playback DAI is ALH(ALH_INDEX) using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
         SMART_PB_PPL_ID, ALH, SMART_ALH_INDEX, SMART_ALH_PLAYBACK_NAME,
         SMART_PIPE_SOURCE, 2, s24le,
         SMART_AMP_PERIOD, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is ALH(ALH_INDEX) using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
         SMART_REF_PPL_ID, ALH, eval(SMART_ALH_INDEX + 1), SMART_ALH_CAPTURE_NAME,
         SMART_PIPE_SINK, 2, s24le,
@@ -173,14 +173,14 @@ DAI_ADD(sof/pipe-dai-capture.m4,
 ',
 `
 # playback DAI is SSP(SPP_INDEX) using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	SMART_PB_PPL_ID, SSP, SMART_SSP_INDEX, SMART_SSP_NAME,
 	SMART_PIPE_SOURCE, 2, s32le,
 	SMART_AMP_PERIOD, 0, SMART_AMP_CORE, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is SSP(SSP_INDEX) using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	SMART_REF_PPL_ID, SSP, SMART_SSP_INDEX, SMART_SSP_NAME,
 	SMART_PIPE_SINK, 2, s32le,

--- a/tools/topology/topology1/sof-tgl-max98357a-rt5682-rtnr-16kHz.m4
+++ b/tools/topology/topology1/sof-tgl-max98357a-rt5682-rtnr-16kHz.m4
@@ -59,49 +59,49 @@ dnl     pipe id, pcm, max channels, format,
 dnl     frames, deadline, priority, core)
 
 # Low Latency playback pipeline 2 on PCM 1 using max 2 channels of s24le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	1, 0, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 3 on PCM 1 using max 2 channels of s24le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	2, 0, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 2 on PCM 2 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	5, 3, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 3 on PCM 3 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	6, 4, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 4 on PCM 4 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	7, 5, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 5 on PCM 5 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	8, 6, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s24le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 ifdef(`SPKPROC_FILTER1', `define(PIPELINE_FILTER1, SPKPROC_FILTER1)', `undefine(`PIPELINE_FILTER1')')
 ifdef(`SPKPROC_FILTER2', `define(PIPELINE_FILTER2, SPKPROC_FILTER2)', `undefine(`PIPELINE_FILTER2')')
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,

--- a/tools/topology/topology1/sof-tgl-max98357a-rt5682.m4
+++ b/tools/topology/topology1/sof-tgl-max98357a-rt5682.m4
@@ -109,7 +109,7 @@ dnl     pipe id, pcm, max channels, format,
 dnl     frames, deadline, priority, core)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s24le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 define(`ENDPOINT_NAME', `Speakers')
 PIPELINE_PCM_ADD(
 	ifdef(`WAVES', sof/pipe-waves-codec-demux-playback.m4,
@@ -121,7 +121,7 @@ PIPELINE_PCM_ADD(
 undefine(`ENDPOINT_NAME')
 
 # Low Latency playback pipeline 2 on PCM 1 using max 2 channels of s24le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 define(`ENDPOINT_NAME', `Headphones')
 PIPELINE_PCM_ADD(
 	ifdef(`WAVES', sof/pipe-waves-codec-playback.m4, sof/pipe-volume-playback.m4),
@@ -131,35 +131,35 @@ PIPELINE_PCM_ADD(
 undefine(`ENDPOINT_NAME')
 
 # Low Latency capture pipeline 3 on PCM 1 using max 2 channels of s24le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	3, 1, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 2 on PCM 2 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	5, 2, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 3 on PCM 3 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	6, 3, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 4 on PCM 4 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	7, 4, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 5 on PCM 5 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	8, 5, 2, s32le,
 	1000, 0, 0,

--- a/tools/topology/topology1/sof-tgl-max98373-rt5682.m4
+++ b/tools/topology/topology1/sof-tgl-max98373-rt5682.m4
@@ -102,7 +102,7 @@ dnl     frames, deadline, priority, core)
 ifdef(`INCLUDE_IIR_EQ',
 `
 # Low Latency playback pipeline 2 on PCM 1 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-eq-iir-volume-playback.m4,
 	2, 1, 2, s32le,
 	1000, 0, 0,
@@ -111,7 +111,7 @@ PIPELINE_PCM_ADD(sof/pipe-eq-iir-volume-playback.m4,
 ,
 `
 # Low Latency playback pipeline 2 on PCM 1 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	2, 1, 2, s32le,
 	1000, 0, 0,
@@ -120,35 +120,35 @@ PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 
 
 # Low Latency capture pipeline 3 on PCM 1 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	3, 1, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 5 on PCM 2 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	5, 2, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 6 on PCM 3 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	6, 3, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 7 on PCM 4 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	7, 4, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 8 on PCM 5 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	8, 5, 2, s32le,
 	1000, 0, 0,

--- a/tools/topology/topology1/sof-tgl-rt711-rt1308.m4
+++ b/tools/topology/topology1/sof-tgl-rt711-rt1308.m4
@@ -118,14 +118,14 @@ dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	1, 0, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 2 on PCM 1 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	2, 1, 2, s32le,
 	1000, 0, 0,
@@ -134,35 +134,35 @@ PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 ifdef(`EXT_AMP',
 `
 # Low Latency playback pipeline 3 on PCM 2 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	3, 2, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 ')
 # Low Latency playback pipeline 6 on PCM 5 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	6, 5, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 7 on PCM 6 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	7, 6, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 8 on PCM 7 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	8, 7, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 9 on PCM 8 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
         9, 8, 2, s32le,
         1000, 0, 0,
@@ -202,21 +202,21 @@ DAI_ADD(sof/pipe-dai-playback.m4,
 ')
 
 # playback DAI is iDisp1 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	6, HDA, 0, iDisp1,
 	PIPELINE_SOURCE_6, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp2 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	7, HDA, 1, iDisp2,
 	PIPELINE_SOURCE_7, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is iDisp3 using 2 periods
-# Buffers use s32le format, 1000us deadline on core 0 with priority 0
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	8, HDA, 2, iDisp3,
 	PIPELINE_SOURCE_8, 2, s32le,

--- a/tools/topology/topology1/sof-tgl-sdw-max98373-rt5682.m4
+++ b/tools/topology/topology1/sof-tgl-sdw-max98373-rt5682.m4
@@ -96,14 +96,14 @@ dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
 dnl     time_domain, sched_comp)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
         1, 0, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 2 on PCM 1 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
         2, 1, 2, s32le,
 	1000, 0, 0,
@@ -131,28 +131,28 @@ include(`platform/intel/intel-generic-dmic-kwd.m4')
 
 
 # Low Latency playback pipeline 6 on PCM 5 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	6, 5, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 7 on PCM 6 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	7, 6, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 8 on PCM 7 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	8, 7, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency playback pipeline 9 on PCM 8 using max 2 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+# Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	9, 8, 2, s32le,
 	1000, 0, 0,


### PR DESCRIPTION
Comments for PIPELINE_PCM_ADD and DAI_ADD mention "priority"
and "core" in wrong order. Given both values are 0 currently,
this is very misleading.

dnl DAI_ADD(pipeline,
dnl     pipe id, dai type, dai_index, dai_be,
dnl     buffer, periods, format,
dnl     period , priority, core, time_domain,
dnl     channels, rate, dynamic_pipe)
define(`DAI_ADD',


dnl PIPELINE_PCM_ADD(pipeline,
dnl     pipe id, pcm, max channels, format,
dnl     period, priority, core,
dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
dnl     time_domain, sched_comp, dynamic)

