### PR TITLE
Update logic for sharing buffers and components

### DIFF
--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -131,8 +131,6 @@ int comp_set_state(struct comp_dev *dev, int cmd)
 
 	dev->state = requested_state;
 
-	comp_writeback(dev);
-
 	return 0;
 }
 

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -256,8 +256,6 @@ static int mixer_trigger_common(struct comp_dev *dev, int cmd)
 		default:
 			break;
 		}
-
-		comp_writeback(dev);
 	}
 
 	ret = comp_set_state(dev, cmd);
@@ -277,7 +275,6 @@ static int mixer_trigger_common(struct comp_dev *dev, int cmd)
 	     (mixer_source_status_count(dev, COMP_STATE_ACTIVE) ||
 	     mixer_source_status_count(dev, COMP_STATE_PAUSED)))) {
 		dev->state = COMP_STATE_ACTIVE;
-		comp_writeback(dev);
 		ret = PPL_STATUS_PATH_STOP;
 	}
 

--- a/src/audio/pipeline/pipeline-graph.c
+++ b/src/audio/pipeline/pipeline-graph.c
@@ -167,7 +167,6 @@ int pipeline_connect(struct comp_dev *comp, struct comp_buffer *buffer,
 	list_item_prepend(buffer_comp_list(buffer, dir),
 			  comp_buffer_list(comp, dir));
 	buffer_set_comp(buffer, comp, dir);
-	comp_writeback(comp);
 	irq_local_enable(flags);
 
 	return 0;
@@ -184,7 +183,6 @@ void pipeline_disconnect(struct comp_dev *comp, struct comp_buffer *buffer, int 
 
 	irq_local_disable(flags);
 	list_item_del(buffer_comp_list(buffer, dir));
-	comp_writeback(comp);
 	irq_local_enable(flags);
 }
 

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -94,7 +94,6 @@ struct comp_buffer {
 	uint32_t id;
 	uint32_t pipeline_id;
 	uint32_t caps;
-	uint32_t core;
 	bool inter_core; /* true if connected to a comp from another core */
 	struct tr_ctx tctx;			/* trace settings */
 

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -747,26 +747,6 @@ void comp_get_copy_limits_with_lock(struct comp_buffer *source,
 }
 
 /**
- * Invalidates component to ensure current state and params readout.
- * @param dev Component to invalidate
- */
-static inline void comp_invalidate(struct comp_dev *dev)
-{
-	if (!dev->is_shared)
-		dcache_invalidate_region(dev, sizeof(struct comp_dev));
-}
-
-/**
- * Writeback component to ensure current state and params readout.
- * @param dev Component to writeback
- */
-static inline void comp_writeback(struct comp_dev *dev)
-{
-	if (!dev->is_shared)
-		dcache_writeback_region(dev, sizeof(struct comp_dev));
-}
-
-/**
  * Get component state.
  *
  * @param req_dev Requesting component
@@ -774,12 +754,6 @@ static inline void comp_writeback(struct comp_dev *dev)
  */
 static inline int comp_get_state(struct comp_dev *req_dev, struct comp_dev *dev)
 {
-	/* we should not invalidate data when components are on the same
-	 * core, because we could invalidate data not previously writebacked
-	 */
-	if (req_dev->ipc_config.core != dev->ipc_config.core)
-		comp_invalidate(dev);
-
 	return dev->state;
 }
 

--- a/src/ipc/ipc-helper.c
+++ b/src/ipc/ipc-helper.c
@@ -45,7 +45,6 @@ struct comp_buffer *buffer_new(const struct sof_ipc_buffer *desc)
 	if (buffer) {
 		buffer->id = desc->comp.id;
 		buffer->pipeline_id = desc->comp.pipeline_id;
-		buffer->core = desc->comp.core;
 
 		buffer->stream.underrun_permitted = desc->flags &
 						    SOF_BUF_UNDERRUN_PERMITTED;
@@ -180,12 +179,12 @@ int comp_verify_params(struct comp_dev *dev, uint32_t flag,
 int comp_buffer_connect(struct comp_dev *comp, uint32_t comp_core,
 			struct comp_buffer *buffer, uint32_t dir)
 {
+	struct comp_dev *cd = buffer_get_comp(buffer, dir);
 	int ret;
 
 	/* check if it's a connection between cores */
-	if (buffer->core != comp_core) {
+	if (cd && cd->ipc_config.core != comp_core) {
 		dcache_invalidate_region(buffer, sizeof(*buffer));
-
 		buffer->inter_core = true;
 
 		if (!comp->is_shared) {

--- a/src/ipc/ipc3/helper.c
+++ b/src/ipc/ipc3/helper.c
@@ -528,6 +528,18 @@ static int ipc_comp_to_buffer_connect(struct ipc_comp_dev *comp,
 			if (!comp->cd)
 				return -ENOMEM;
 		}
+
+		if (!sink->is_shared) {
+			sink = comp_make_shared(sink);
+			buffer_set_comp(buf, sink, PPL_CONN_DIR_BUFFER_TO_COMP);
+		}
+	} else {
+		/*
+		 * even if the the current 2 components are on the same core, comp->cd should be
+		 * made shared if the component it is connected to is shared.
+		 */
+		if (sink && sink->is_shared && !comp->cd->is_shared)
+			comp->cd = comp_make_shared(comp->cd);
 	}
 
 	ret = pipeline_connect(comp->cd, buf, PPL_CONN_DIR_COMP_TO_BUFFER);
@@ -560,6 +572,18 @@ static int ipc_buffer_to_comp_connect(struct ipc_comp_dev *buffer,
 			if (!comp->cd)
 				return -ENOMEM;
 		}
+
+		if (!source->is_shared) {
+			source = comp_make_shared(source);
+			buffer_set_comp(buf, source, PPL_CONN_DIR_COMP_TO_BUFFER);
+		}
+	} else {
+		/*
+		 * even if the the current 2 components are on the same core, comp->cd should be
+		 * made shared if the component it is connected to is shared.
+		 */
+		if (source && source->is_shared && !comp->cd->is_shared)
+			comp->cd = comp_make_shared(comp->cd);
 	}
 
 	ret = pipeline_connect(comp->cd, buf, PPL_CONN_DIR_BUFFER_TO_COMP);

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -309,8 +309,6 @@ int ipc_comp_disconnect(struct ipc *ipc, ipc_pipe_comp_connect *_connect)
 	irq_local_disable(flags);
 	list_item_del(buffer_comp_list(buffer, PPL_CONN_DIR_COMP_TO_BUFFER));
 	list_item_del(buffer_comp_list(buffer, PPL_CONN_DIR_BUFFER_TO_COMP));
-	comp_writeback(src);
-	comp_writeback(sink);
 	irq_local_enable(flags);
 
 	buffer_free(buffer);


### PR DESCRIPTION
If a comp is not shared, it is not necessary to invalidate/writeback
at all.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>