### PR TITLE
byt: align DMA mapping with closed source FW

### DIFF
--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -997,6 +997,18 @@ static int dw_dma_probe(struct dma *dma)
 		}
 
 		dma_chan_set_data(chan, dw_chan);
+
+#if CONFIG_BAYTRAIL || CONFIG_CHERRYTRAIL
+		/*
+		 * Disable DMAC1 channels 1 & 2 by hard coding them as active.
+		 * This is to align with mapping used by legacy closed source
+		 * BYT FW and may be required for stable audio without trace.
+		 */
+		if (dma->plat_data.id == DMA_ID_DMAC1) {
+			dma->chan[0].status = COMP_STATE_ACTIVE;
+			dma->chan[1].status = COMP_STATE_ACTIVE;
+		}
+#endif
 	}
 
 	/* init number of channels draining */

--- a/src/platform/baytrail/lib/dma.c
+++ b/src/platform/baytrail/lib/dma.c
@@ -127,7 +127,7 @@ SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
 				  DMA_DIR_DEV_TO_MEM | DMA_DIR_DEV_TO_DEV |
 				  DMA_DIR_HMEM_TO_LMEM | DMA_DIR_LMEM_TO_HMEM,
 		.caps		= DMA_CAP_GP_HP,
-		.devs		= DMA_DEV_SSP | DMA_DEV_DMIC | DMA_DEV_HOST,
+		.devs		= DMA_DEV_SSP | DMA_DEV_HOST,
 		.base		= DMA0_BASE,
 		.channels	= 8,
 		.irq		= IRQ_NUM_EXT_DMAC0,
@@ -142,7 +142,7 @@ SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
 				  DMA_DIR_DEV_TO_MEM | DMA_DIR_DEV_TO_DEV |
 				  DMA_DIR_HMEM_TO_LMEM | DMA_DIR_LMEM_TO_HMEM,
 		.caps		= DMA_CAP_GP_HP,
-		.devs		= DMA_DEV_SSP | DMA_DEV_DMIC | DMA_DEV_HOST,
+		.devs		= DMA_DEV_SSP | DMA_DEV_HOST,
 		.base		= DMA1_BASE,
 		.channels	= 8,
 		.irq		= IRQ_NUM_EXT_DMAC1,

--- a/src/platform/baytrail/lib/dma.c
+++ b/src/platform/baytrail/lib/dma.c
@@ -119,32 +119,48 @@ const struct dw_drv_plat_data dmac2 = {
 };
 #endif
 
+/*
+ * Baytrail and Cherrytrail should use the following DMA mappings.
+ *
+ * Init DMAC0 for Mem2Phe and Phe2Mem Transfers
+ *
+ *    Channel 0 - SSP2 to Mem - Src_Id  = 0
+ *    Channel 1 - Mem to SSP2 - Dest_Id = 5
+ *    Channels 2-7 - Unused
+ *
+ * Init DMAC1 for Mem2Mem Transfers
+ *
+ *    Channel 0 - Unused
+ *    Channel 1 - Unused
+ *    Channels 2-7 - Mem to Mem
+ *
+ */
 SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
 {
+	/* DMAC 0 Mem2Phe and Phe2Mem Transfers */
 	.plat_data = {
 		.id		= DMA_ID_DMAC0,
-		.dir		= DMA_DIR_MEM_TO_MEM | DMA_DIR_MEM_TO_DEV |
-				  DMA_DIR_DEV_TO_MEM | DMA_DIR_DEV_TO_DEV |
-				  DMA_DIR_HMEM_TO_LMEM | DMA_DIR_LMEM_TO_HMEM,
+		.dir		= DMA_DIR_MEM_TO_DEV |
+				  DMA_DIR_DEV_TO_MEM | DMA_DIR_DEV_TO_DEV,
 		.caps		= DMA_CAP_GP_HP,
-		.devs		= DMA_DEV_SSP | DMA_DEV_HOST,
+		.devs		= DMA_DEV_SSP,
 		.base		= DMA0_BASE,
-		.channels	= 8,
+		.channels	= 2, /* Channels 2-7 - Unused */
 		.irq		= IRQ_NUM_EXT_DMAC0,
 		.drv_plat_data	= &dmac0,
 	},
 	.ops		= &dw_dma_ops,
 },
 {
+	/*  DMAC1 for Mem2Mem Transfers */
 	.plat_data = {
 		.id		= DMA_ID_DMAC1,
-		.dir		= DMA_DIR_MEM_TO_MEM | DMA_DIR_MEM_TO_DEV |
-				  DMA_DIR_DEV_TO_MEM | DMA_DIR_DEV_TO_DEV |
+		.dir		= DMA_DIR_MEM_TO_MEM |
 				  DMA_DIR_HMEM_TO_LMEM | DMA_DIR_LMEM_TO_HMEM,
 		.caps		= DMA_CAP_GP_HP,
-		.devs		= DMA_DEV_SSP | DMA_DEV_HOST,
+		.devs		= DMA_DEV_HOST,
 		.base		= DMA1_BASE,
-		.channels	= 8,
+		.channels	= 8, /* Channels 0-1 - Unused in DMA driver */
 		.irq		= IRQ_NUM_EXT_DMAC1,
 		.drv_plat_data	= &dmac1,
 	},

--- a/src/platform/haswell/lib/dma.c
+++ b/src/platform/haswell/lib/dma.c
@@ -91,7 +91,7 @@ SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
 		.base		= DMA0_BASE,
 		.dir		= DMA_DIR_MEM_TO_MEM,
 		.caps		= DMA_CAP_GP_HP | DMA_CAP_GP_LP,
-		.devs		= DMA_DEV_SSP | DMA_DEV_DMIC | DMA_DEV_HOST,
+		.devs		= DMA_DEV_HOST,
 		.irq		= IRQ_NUM_EXT_DMAC0,
 		.drv_plat_data	= &dmac0,
 		.channels	= 8,
@@ -106,7 +106,7 @@ SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
 				  DMA_DIR_DEV_TO_MEM | DMA_DIR_DEV_TO_DEV |
 				  DMA_DIR_HMEM_TO_LMEM | DMA_DIR_LMEM_TO_HMEM,
 		.caps		= DMA_CAP_GP_HP | DMA_CAP_GP_LP,
-		.devs		= DMA_DEV_SSP | DMA_DEV_DMIC | DMA_DEV_HOST,
+		.devs		= DMA_DEV_SSP | DMA_DEV_HOST,
 		.irq		= IRQ_NUM_EXT_DMAC1,
 		.drv_plat_data	= &dmac1,
 		.channels	= 8,


### PR DESCRIPTION
Align the DMAC usage and channel mappings with the closed source firmware.
This may help with DMA stability when trace is disabled.

Compile tested only as I have no working BYT/CHT HW.

Signed-off-by: Liam Girdwood <liam.r.girdwood@linux.intel.com>