### PR TITLE
cmake: do not download submodules when BUILD_UNIT_TESTS or CONFIG_LIBRARY

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -59,7 +59,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-        with: {fetch-depth: 0, submodules: recursive}
+        with: {fetch-depth: 5}
 
       - name: docker
         run: docker pull thesofproject/sof && docker tag thesofproject/sof sof

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,6 @@ set(CMAKE_ASM_FLAGS -DASSEMBLY)
 add_library(sof_public_headers INTERFACE)
 
 target_include_directories(sof_public_headers INTERFACE ${PROJECT_SOURCE_DIR}/src/include)
-target_include_directories(sof_public_headers INTERFACE ${PROJECT_SOURCE_DIR}/rimage/src/include)
 
 # interface library that is used only as container for sof binary options
 # other targets can use it to build with the same options

--- a/scripts/cmake/git-submodules.cmake
+++ b/scripts/cmake/git-submodules.cmake
@@ -32,7 +32,8 @@ if(GIT_FOUND AND EXISTS "${SOF_ROOT_SOURCE_DIRECTORY}/.git")
 "There are submodule changes, check git status and git diff\n${stdout}")
 		endif()
 
-	elseif(NOT BUILD_UNIT_TESTS)
+	elseif(NOT BUILD_UNIT_TESTS AND
+	    NOT CONFIG_LIBRARY)
 	# Automated initialization for convenience. You can defeat it by
 	# manually initializing rimage and _not_ some other
 	# submodule. In that case you get the warning above.

--- a/scripts/cmake/git-submodules.cmake
+++ b/scripts/cmake/git-submodules.cmake
@@ -32,7 +32,7 @@ if(GIT_FOUND AND EXISTS "${SOF_ROOT_SOURCE_DIRECTORY}/.git")
 "There are submodule changes, check git status and git diff\n${stdout}")
 		endif()
 
-	else()
+	elseif(NOT BUILD_UNIT_TESTS)
 	# Automated initialization for convenience. You can defeat it by
 	# manually initializing rimage and _not_ some other
 	# submodule. In that case you get the warning above.

--- a/src/arch/xtensa/CMakeLists.txt
+++ b/src/arch/xtensa/CMakeLists.txt
@@ -266,6 +266,11 @@ if(build_bootloader)
 	add_dependencies(boot_module rimage_ep)
 	add_dependencies(base_module rimage_ep)
 
+	target_include_directories(bootloader   PRIVATE ${PROJECT_SOURCE_DIR}/rimage/src/include)
+	target_include_directories(boot_module  PRIVATE ${PROJECT_SOURCE_DIR}/rimage/src/include)
+	target_include_directories(base_module  PRIVATE ${PROJECT_SOURCE_DIR}/rimage/src/include)
+
+
 	target_link_libraries(bootloader PRIVATE sof_options)
 	add_local_sources(bootloader xtos/_vectors.S ${PROJECT_SOURCE_DIR}/src/platform/${family_path}/boot_entry.S ${PROJECT_SOURCE_DIR}/src/platform/${family_path}/boot_loader.c)
 	target_link_libraries(bootloader PRIVATE reset)


### PR DESCRIPTION
Faster CI, no dependency accidentally sneaking in

Signed-off-by: Marc Herbert <marc.herbert@intel.com>