### PR TITLE
Revert "trace: Kconfig: disable filtering by default"

### DIFF
--- a/src/trace/Kconfig
+++ b/src/trace/Kconfig
@@ -35,14 +35,14 @@ config TRACEM
 config TRACE_FILTERING
 	bool "Trace filtering"
 	depends on TRACE
-	default n
+	default y
 	help
 		Filtering of trace messages based on their verbosity level and frequency.
 
 config TRACE_FILTERING_VERBOSITY
 	bool "Filter by verbosity"
 	depends on TRACE_FILTERING
-	default n
+	default y
 	help
 		Filtering by log verbosity level, where maximum verbosity allowed is specified for each
 		context and may be adjusted in runtime.
@@ -50,7 +50,7 @@ config TRACE_FILTERING_VERBOSITY
 config TRACE_FILTERING_ADAPTIVE
 	bool "Adaptive rate limiting"
 	depends on TRACE_FILTERING
-	default n
+	default y
 	help
 		Adaptive filtering of trace messages, tracking up to CONFIG_TRACE_RECENT_ENTRIES_COUNT,
 		suppressing all repeated messages for up to CONFIG_TRACE_RECENT_TIME_THRESHOLD cycles.


### PR DESCRIPTION
This reverts commit 9fadef789e80b586c64cb963dad24f909d579afd.

After multiple trials on a CometLake SoundWire device, this revert to
bring the trace back to what it was seems to be the only solution, the
suggested PR https://github.com/thesofproject/linux/pull/3166 does not
help on this SoundWire device.

We had similar issues with SD offset timeouts and a similar revert
with https://github.com/thesofproject/sof/pull/4578 at the end of
July, there's something that we are missing on what the trace does and
how it impacts the DMA handling.

BugLink: https://github.com/thesofproject/sof/issues/4779
Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>