### PR TITLE
Re-enable trace filtering and implement DMA reset op

### DIFF
--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -683,8 +683,17 @@ static int dai_reset(struct comp_dev *dev)
 {
 	struct dai_data *dd = comp_get_drvdata(dev);
 	struct dma_sg_config *config = &dd->config;
+	int ret;
 
 	comp_info(dev, "dai_reset()");
+
+	if (dd->chan) {
+		ret = dma_reset(dd->chan);
+		if (ret < 0) {
+			comp_err(dev, "dai_reset(): failed to reset DMA chan");
+			return ret;
+		}
+	}
 
 	dai_config_reset(dev);
 

--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -855,6 +855,13 @@ static int host_reset(struct comp_dev *dev)
 	comp_dbg(dev, "host_reset()");
 
 	if (hd->chan) {
+		int ret = dma_reset(hd->chan);
+
+		if (ret < 0) {
+			comp_err(dev, "host_reset(): failed to reset DMA chan");
+			return ret;
+		}
+
 		/* remove callback */
 		notifier_unregister(dev, hd->chan, NOTIFIER_ID_DMA_COPY);
 		dma_channel_put(hd->chan);

--- a/src/include/sof/lib/dma.h
+++ b/src/include/sof/lib/dma.h
@@ -160,6 +160,7 @@ struct dma_ops {
 
 	int (*start)(struct dma_chan_data *channel);
 	int (*stop)(struct dma_chan_data *channel);
+	int (*reset)(struct dma_chan_data *channel);
 	int (*copy)(struct dma_chan_data *channel, int bytes, uint32_t flags);
 	int (*pause)(struct dma_chan_data *channel);
 	int (*release)(struct dma_chan_data *channel);
@@ -316,6 +317,14 @@ static inline int dma_stop(struct dma_chan_data *channel)
 	int ret = channel->dma->ops->stop(channel);
 
 	return ret;
+}
+
+static inline int dma_reset(struct dma_chan_data *channel)
+{
+	if (channel->dma->ops->reset)
+		return channel->dma->ops->reset(channel);
+
+	return 0;
 }
 
 /** \defgroup sof_dma_copy_func static int dma_copy (struct dma_chan_data * channel, int bytes, uint32_t flags)

--- a/src/include/sof/trace/dma-trace.h
+++ b/src/include/sof/trace/dma-trace.h
@@ -52,6 +52,7 @@ int dma_trace_host_buffer(struct dma_trace_data *d,
 			  struct dma_sg_elem_array *elem_array,
 			  uint32_t host_size);
 int dma_trace_enable(struct dma_trace_data *d);
+void dma_trace_disable(struct dma_trace_data *d);
 void dma_trace_flush(void *destination);
 void dma_trace_on(void);
 void dma_trace_off(void);

--- a/src/ipc/ipc3/handler.c
+++ b/src/ipc/ipc3/handler.c
@@ -602,6 +602,11 @@ static int ipc_pm_context_save(uint32_t header)
 	//struct sof_ipc_pm_ctx *pm_ctx = _ipc->comp_data;
 
 	tr_info(&ipc_tr, "ipc: pm -> save");
+#if CONFIG_TRACE
+	struct dma_trace_data *dmat = dma_trace_data_get();
+
+	dma_trace_disable(dmat);
+#endif
 
 	sa_exit(sof_get());
 

--- a/src/trace/Kconfig
+++ b/src/trace/Kconfig
@@ -35,14 +35,14 @@ config TRACEM
 config TRACE_FILTERING
 	bool "Trace filtering"
 	depends on TRACE
-	default y
+	default n
 	help
 		Filtering of trace messages based on their verbosity level and frequency.
 
 config TRACE_FILTERING_VERBOSITY
 	bool "Filter by verbosity"
 	depends on TRACE_FILTERING
-	default y
+	default n
 	help
 		Filtering by log verbosity level, where maximum verbosity allowed is specified for each
 		context and may be adjusted in runtime.
@@ -50,7 +50,7 @@ config TRACE_FILTERING_VERBOSITY
 config TRACE_FILTERING_ADAPTIVE
 	bool "Adaptive rate limiting"
 	depends on TRACE_FILTERING
-	default y
+	default n
 	help
 		Adaptive filtering of trace messages, tracking up to CONFIG_TRACE_RECENT_ENTRIES_COUNT,
 		suppressing all repeated messages for up to CONFIG_TRACE_RECENT_TIME_THRESHOLD cycles.

--- a/src/trace/dma-trace.c
+++ b/src/trace/dma-trace.c
@@ -420,6 +420,13 @@ out:
 	return err;
 }
 
+void dma_trace_disable(struct dma_trace_data *d)
+{
+	schedule_task_cancel(&d->dmat_work);
+	dma_reset(d->dc.chan);
+	dma_trace_buffer_free(d);
+}
+
 /** Sends all pending DMA messages to mailbox (for emergencies) */
 void dma_trace_flush(void *t)
 {


### PR DESCRIPTION
This reverts commit d8a19a4d2062cde129f2a18e414b07ce9ab31c73 to re-enable trace filtering.

And introduces the reset op in DMA ops to perform actions that must be preceded by DMA stop on the host-side.

This along with Linux PR https://github.com/thesofproject/linux/pull/3167 fixes #4479 and #4558