### PR TITLE
timer: mtk: use mtk systimer for mt8195

### DIFF
--- a/src/drivers/mediatek/mt8195/timer.c
+++ b/src/drivers/mediatek/mt8195/timer.c
@@ -3,45 +3,121 @@
 // Copyright(c) 2021 Mediatek
 //
 // Author:Fengquan Chen <fengquan.chen@mediatek.com>
+//        Allen-KH Cheng <allen-kh.cheng@mediatek.com>
 
 #include <sof/audio/component_ext.h>
 #include <sof/drivers/interrupt.h>
 #include <sof/lib/memory.h>
 #include <sof/platform.h>
-#include <sof/drivers/timer.h>
+#include <platform/drivers/timer.h>
+#include <platform/drivers/interrupt.h>
 #include <ipc/stream.h>
 #include <errno.h>
 #include <stdint.h>
 
 void platform_timer_start(struct timer *timer)
 {
-	/* nothing to do for cpu timer */
+	/*set 13M clksrc*/
+	io_reg_update_bits(CNTCR, CLKSRC_BIT, 0x0);
+	io_reg_update_bits(CNTCR, CLKSRC_13M_BIT, CLKSRC_13M_BIT);
+
+	/*enable timer*/
+	io_reg_update_bits(CNTCR, CNT_EN_BIT, CNT_EN_BIT);
 }
 
 void platform_timer_stop(struct timer *timer)
 {
-	arch_timer_disable(timer);
-}
+	if (timer->id > NR_TMRS)
+		return;
 
-int64_t platform_timer_set(struct timer *timer, uint64_t ticks)
-{
-	return arch_timer_set(timer, ticks);
-}
-
-void platform_timer_clear(struct timer *timer)
-{
-	arch_timer_clear(timer);
-}
-
-uint64_t platform_timer_get(struct timer *timer)
-{
-	return arch_timer_get_system(timer);
+	io_reg_update_bits(TIMER_CON(timer->id), TIMER_ENABLE_BIT, 0x0);
+	io_reg_update_bits(TIMER_IRQ_ACK(timer->id), TIMER_IRQ_ENABLE, 0x0);
 }
 
 /* IRQs off in arch_timer_get_system() */
 uint64_t platform_timer_get_atomic(struct timer *timer)
 {
-	return arch_timer_get_system(timer);
+	return platform_timer_get(timer);
+}
+
+int64_t platform_timer_set(struct timer *timer, uint64_t ticks)
+{
+	uint64_t time;
+	uint32_t hitimeout = ticks >> 32;
+	uint32_t lowtimeout = ticks & 0xFFFFFFFF;
+	uint32_t flags;
+	uint32_t low, high;
+	uint32_t ticks_set;
+
+	if (timer->id > NR_TMRS)
+		return -EINVAL;
+
+	flags = arch_interrupt_global_disable();
+
+	low = io_reg_read(OSTIMER_CUR_L);
+	high = io_reg_read(OSTIMER_CUR_H);
+
+	/*ostimer 13M counter to 26M interrupt */
+	time = (((uint64_t)high << 32) | low) << 1;
+
+	if (ticks > time)
+		ticks_set = (uint32_t)(ticks - time);
+	else
+		ticks_set = 1; /*set 1 to trigger interrupt*/
+
+	lowtimeout = ticks_set;
+	timer->hitimeout = hitimeout;
+	timer->lowtimeout = ticks_set;
+
+	/*selsect 26M clksrc*/
+	io_reg_update_bits(TIMER_CON(timer->id), TIMER_CLKSRC_BIT, 0x0);
+	io_reg_update_bits(TIMER_CON(timer->id),
+			   TIMER_CLK_SRC_CLK_26M << TIMER_CLK_SRC_SHIFT,
+			   TIMER_CLK_SRC_CLK_26M << TIMER_CLK_SRC_SHIFT);
+
+	io_reg_write(TIMER_RST_VAL(timer->id), lowtimeout);
+	io_reg_update_bits(TIMER_IRQ_ACK(timer->id), TIMER_IRQ_CLEAR, TIMER_IRQ_CLEAR);
+	io_reg_update_bits(TIMER_IRQ_ACK(timer->id), TIMER_IRQ_ENABLE, TIMER_IRQ_ENABLE);
+	io_reg_update_bits(TIMER_CON(timer->id), TIMER_ENABLE_BIT, TIMER_ENABLE_BIT);
+
+	arch_interrupt_global_enable(flags);
+
+	return ticks;
+}
+
+void platform_timer_clear(struct timer *timer)
+{
+	if (timer->id > NR_TMRS)
+		return;
+
+	io_reg_update_bits(TIMER_IRQ_ACK(timer->id), TIMER_IRQ_CLEAR, TIMER_IRQ_CLEAR);
+}
+
+uint64_t platform_timer_get(struct timer *timer)
+{
+	uint64_t time;
+	uint32_t low;
+	uint32_t high0;
+	uint32_t high1;
+
+	if (timer->id > NR_TMRS)
+		return -EINVAL;
+
+	/* 64bit reads are non atomic on xtensa so we must
+	 * read a stable value where there is no bit 32 flipping.
+	 */
+	do {
+		high0 = io_reg_read(OSTIMER_CUR_H);
+		low = io_reg_read(OSTIMER_CUR_L);
+		high1 = io_reg_read(OSTIMER_CUR_H);
+
+		/* worst case is we perform this twice so 6 * 32b clock reads */
+	} while (high0 != high1);
+
+	/*ostimer 13M counter to 26M interrupt */
+	time = (((uint64_t)high0 << 32) | low) << 1;
+
+	return time;
 }
 
 /* get timestamp for host stream DMA position */
@@ -74,15 +150,48 @@ void platform_dai_timestamp(struct comp_dev *dai,
 /* get current wallclock for componnent */
 void platform_dai_wallclock(struct comp_dev *dai, uint64_t *wallclock)
 {
-	*wallclock = timer_get_system(timer_get());
+	*wallclock = platform_timer_get(timer_get());
+}
+
+static void platform_timer_handler(void *arg)
+{
+	struct timer *timer = arg;
+
+	io_reg_update_bits(TIMER_IRQ_ACK(timer->id), TIMER_IRQ_CLEAR, TIMER_IRQ_CLEAR);
+	io_reg_update_bits(TIMER_CON(timer->id), TIMER_ENABLE_BIT, 0x0);
+	io_reg_update_bits(TIMER_IRQ_ACK(timer->id), TIMER_IRQ_ENABLE, 0x0);
+	timer->handler(timer->data);
+}
+
+static int platform_timer_register(struct timer *timer, void (*handler)(void *arg), void *arg)
+{
+	uint32_t timer_irq0;
+	int err;
+
+	timer->handler = handler;
+	timer->data = arg;
+	timer->hitime = 0;
+	timer->hitimeout = 0;
+
+	timer_irq0 = mtk_get_irq_domain_id(timer->irq);
+	err = interrupt_register(timer_irq0, platform_timer_handler, timer);
+	if (err < 0)
+		return err;
+
+	/* enable timer interrupt */
+	interrupt_enable(timer_irq0, timer);
+
+	return err;
 }
 
 int timer_register(struct timer *timer, void(*handler)(void *arg), void *arg)
 {
 	switch (timer->id) {
-	case TIMER0:
-	case TIMER1:
-		return arch_timer_register(timer, handler, arg);
+	case OSTIMER0:
+	case OSTIMER1:
+	case OSTIMER2:
+	case OSTIMER3:
+		return platform_timer_register(timer, handler, arg);
 	default:
 		return -EINVAL;
 	}

--- a/src/platform/mt8195/include/platform/drivers/interrupt.h
+++ b/src/platform/mt8195/include/platform/drivers/interrupt.h
@@ -19,7 +19,7 @@
 
 /* IRQ numbers - wrt Tensilica DSP */
 #if CONFIG_XT_INTERRUPT_LEVEL_1
-#define IRQ_NUM_TIMER0 16
+#define IRQ_NUM_TIMER0 0
 #define IRQ_NUM_SOFTWARE0 21
 #define IRQ_NUM_EXT_LEVEL01 1
 #define IRQ_NUM_EXT_LEVEL23 23

--- a/src/platform/mt8195/include/platform/drivers/timer.h
+++ b/src/platform/mt8195/include/platform/drivers/timer.h
@@ -1,0 +1,63 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2021 Mediatek
+ *
+ * Author: Author: Fengquan Chen <fengquan.chen@mediatek.com>
+ */
+
+#ifndef __PLATFORM_DRIVERS_TIMER_H__
+#define __PLATFORM_DRIVERS_TIMER_H__
+
+#include <sof/bit.h>
+#include <platform/drivers/mt_reg_base.h>
+
+/*-------timer:ostimer0-------*/
+enum ostimer {
+	OSTIMER0 = 0,
+	OSTIMER1,
+	OSTIMER2,
+	OSTIMER3,
+	NR_TMRS
+};
+
+#define TIMER_CON(n) (MTK_DSP_OSTIMER_BASE + 0x0 + 0x10 * (n))
+#define TIMER_RST_VAL(n) (MTK_DSP_OSTIMER_BASE + 0x4 + 0x10 * (n))
+#define TIMER_CUR_VAL(n) (MTK_DSP_OSTIMER_BASE + 0x8 + 0x10 * (n))
+#define TIMER_IRQ_ACK(n) (MTK_DSP_OSTIMER_BASE + 0xC + 0x10 * (n))
+
+#define TIMER_ENABLE_BIT (0x1 << 0)
+#define TIMER_IRQ_ENABLE (0x1 << 0)
+#define TIMER_IRQ_STA (0x1 << 4)
+#define TIMER_IRQ_CLEAR (0x1 << 5)
+#define TIMER_CLKSRC_BIT (0x3 << 4)
+
+#define TIMER_CLK_SRC_CLK_32K 0x00
+#define TIMER_CLK_SRC_CLK_26M 0x01
+#define TIMER_CLK_SRC_BCLK 0x02
+#define TIMER_CLK_SRC_PCLK 0x03
+
+#define TIMER_CLK_SRC_SHIFT 4
+
+#define OSTIMER_CON (MTK_DSP_OSTIMER_BASE + 0x80)
+#define OSTIMER_INIT_L (MTK_DSP_OSTIMER_BASE + 0x84)
+#define OSTIMER_INIT_H (MTK_DSP_OSTIMER_BASE + 0x88)
+#define OSTIMER_CUR_L (MTK_DSP_OSTIMER_BASE + 0x8C)
+#define OSTIMER_CUR_H (MTK_DSP_OSTIMER_BASE + 0x90)
+#define OSTIMER_TVAL (MTK_DSP_OSTIMER_BASE + 0x94)
+#define OSTIMER_IRQ_ACK (MTK_DSP_OSTIMER_BASE + 0x98)
+
+/*-------platform_timer: 64 bit systimer-------*/
+#define CNTCR (MTK_DSP_TIMER_BASE + 0x00)
+#define CNTSR (MTK_DSP_TIMER_BASE + 0x04)
+#define CNTCV_L (MTK_DSP_TIMER_BASE + 0x08)
+#define CNTCV_H (MTK_DSP_TIMER_BASE + 0x0c)
+#define CNTWACR (MTK_DSP_TIMER_BASE + 0x10)
+#define CNTRACR (MTK_DSP_TIMER_BASE + 0x14)
+
+#define CNT_EN_BIT BIT(0)
+#define CLKSRC_BIT (BIT(8) | BIT(9))
+#define CLKSRC_13M_BIT BIT(8)
+#define COMP_BIT (BIT(10) | BIT(11) | BIT(12))
+#define COMP_20_25_EN_BIT (BIT(11) | BIT(12))
+
+#endif /* __PLATFORM_DRIVERS_TIMER_H__ */

--- a/src/platform/mt8195/lib/clk.c
+++ b/src/platform/mt8195/lib/clk.c
@@ -12,13 +12,13 @@
 #include <sof/sof.h>
 #include <sof/spinlock.h>
 
-/*Use  DSP Internal timer*/
+/*Use external Ostimer*/
 const struct freq_table platform_cpu_freq[] = {
-	{ 13000000, 13000},
+	{ 13000000, 26000},
 	{ 26000000, 26000},
-	{ 370000000, 370000},
-	{ 540000000, 540000},
-	{ 720000000, 720000}, //default : CPU_DEFAULT_IDX
+	{ 370000000, 26000},
+	{ 540000000, 26000},
+	{ 720000000, 26000},
 };
 
 STATIC_ASSERT(ARRAY_SIZE(platform_cpu_freq) == NUM_CPU_FREQ,

--- a/src/platform/mt8195/platform.c
+++ b/src/platform/mt8195/platform.c
@@ -26,6 +26,7 @@
 #include <sof/schedule/ll_schedule_domain.h>
 #include <sof/sof.h>
 #include <sof/trace/dma-trace.h>
+#include <platform/drivers/timer.h>
 #include <ipc/dai.h>
 #include <ipc/header.h>
 #include <ipc/info.h>
@@ -120,8 +121,8 @@ const struct ext_man_windows xsram_window
 };
 
 static SHARED_DATA struct timer timer = {
-	.id = TIMER0,
-	.irq = IRQ_NUM_TIMER0,
+	.id = OSTIMER0,
+	.irq = LX_ADSP_TIMTER_IRQ0_B,
 };
 
 /* Override the default MPU setup. This table matches the memory map


### PR DESCRIPTION
For driver timer,
use mtk systimer instead of xtensa internal timer.
(xtensa timer clk will affect by dsp clock rate.)

In some test case, we need to sync time in ap and dsp for some debug tools of mtk. 

In our hw design, the architecture of mtk systimer in dsp is the same with AP.
