### PR TITLE
debug: panic: fix log file name error

### DIFF
--- a/src/debug/panic.c
+++ b/src/debug/panic.c
@@ -115,27 +115,27 @@ void panic_dump(uint32_t p, struct sof_ipc_panic_info *panic_info,
 void __panic(uint32_t panic_code, char *filename, uint32_t linenum)
 {
 	struct sof_ipc_panic_info panicinfo = { .linenum = linenum };
-	int strlen;
+	const unsigned int length_max = sizeof(panicinfo.filename);
+	int mem_len;
 	int ret;
 
-	strlen = rstrlen(filename);
+	/* including the ending '\0' */
+	mem_len = rstrlen(filename) + 1;
 
-	if (strlen >= SOF_TRACE_FILENAME_SIZE) {
+	if (mem_len > length_max) {
+		/* copy those last bytes only */
 		ret = memcpy_s(panicinfo.filename,
-			       sizeof(panicinfo.filename),
-			       filename + strlen - SOF_TRACE_FILENAME_SIZE,
-			       SOF_TRACE_FILENAME_SIZE);
+			       length_max,
+			       filename + mem_len - length_max,
+			       length_max);
 		/* TODO are asserts safe in this context? */
 		assert(!ret);
 
-		ret = memcpy_s(panicinfo.filename,
-			       sizeof(panicinfo.filename),
-			       "...", 3);
+		/* prefixing with "..." */
+		ret = memcpy_s(panicinfo.filename, length_max, "...", 3);
 		assert(!ret);
 	} else {
-		ret = memcpy_s(panicinfo.filename,
-			       sizeof(panicinfo.filename),
-			       filename, strlen + 1);
+		ret = memcpy_s(panicinfo.filename, length_max, filename, mem_len);
 		assert(!ret);
 	}
 


### PR DESCRIPTION
When the length of the path/file name surpass 32, there is no '\0'
anymore in the panicinfo.filename[] array, which will lead to file name
printing errors on the host side like this:
	.../include/cavs/lib/pm_memory.h\xd8:472

Here keep the last character in the array as '\0' to fix the issue and
eventually got correct output like this:
	.../include/cavs/lib/pm_memory.h:472

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>