### PR TITLE
ipc4: adjust max ipc size for ipc4

### DIFF
--- a/src/include/ipc/header.h
+++ b/src/include/ipc/header.h
@@ -309,9 +309,6 @@
 /** Get message component id */
 #define SOF_IPC_MESSAGE_ID(x)			((x) & 0xffff)
 
-/** Maximum message size for mailbox Tx/Rx */
-#define SOF_IPC_MSG_MAX_SIZE			384
-
 /** @} */
 
 /**

--- a/src/include/sof/ipc/topology.h
+++ b/src/include/sof/ipc/topology.h
@@ -39,12 +39,19 @@ typedef uint32_t ipc_comp;
 #define ipc_from_pipe_connect(x) ((struct sof_ipc_pipe_comp_connect *)x)
 #define ipc_from_comp_new(x) ((struct sof_ipc_comp *)x)
 #define ipc_from_dai_config(x) ((struct sof_ipc_dai_config *)x)
+
+/* Maximum message size for mailbox Tx/Rx */
+#define SOF_IPC_MSG_MAX_SIZE                    384
+
 #elif CONFIG_IPC_MAJOR_4
 #include <ipc4/pipeline.h>
 #include <ipc4/module.h>
 #include <ipc4/gateway.h>
 #define ipc_from_pipe_new(x) ((struct ipc4_pipeline_create *)x)
 #define ipc_from_pipe_connect(x) ((struct ipc4_module_bind_unbind *)x)
+
+/* Maximum message size for mailbox Tx/Rx based on mailbox size */
+#define SOF_IPC_MSG_MAX_SIZE                  0x1000
 
 const struct comp_driver *ipc4_get_comp_drv(int module_id);
 struct comp_dev *ipc4_get_comp_dev(uint32_t comp_id);

--- a/src/init/ext_manifest.c
+++ b/src/init/ext_manifest.c
@@ -9,6 +9,7 @@
 #include <sof/common.h>
 #include <sof/compiler_info.h>
 #include <sof/debug/debug.h>
+#include <sof/ipc/topology.h>
 #include <kernel/abi.h>
 #include <kernel/ext_manifest.h>
 #include <user/abi_dbg.h>


### PR DESCRIPTION
The max ipc size of 384 is a legacy issue. We first wanted
to send ipc message in multiple-thread style, but later
we have to serialize ipc message and we didn't change max
ipc size to fully utilize memory window. Now for ipc4,
we have to set it to min(dspbox, hostbox) to align with
host driver.

Signed-off-by: Rander Wang <rander.wang@intel.com>