### PR TITLE
.github/zephyr: point at the latest zephyr container again

### DIFF
--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -17,6 +17,5 @@ jobs:
 
       - name: build
         run: docker run -v "$(pwd)":/workdir
-             -e ZEPHYR_SDK_INSTALL_DIR='/opt/toolchains/zephyr-sdk-0.13.0'
-             docker.io/zephyrprojectrtos/zephyr-build:v0.18.3
+             docker.io/zephyrprojectrtos/zephyr-build:latest
              ./zephyr/docker-build.sh -- -DEXTRA_CFLAGS='-Werror'

--- a/zephyr/docker-build.sh
+++ b/zephyr/docker-build.sh
@@ -18,6 +18,10 @@ test -e ./scripts/xtensa-build-zephyr.sh
 sudo apt-get update
 sudo apt-get -y install tree
 
+ls -ld /opt/toolchains/zephyr-sdk-*
+# Zephyr's CMake does not look in /opt
+ln -s  /opt/toolchains/zephyr-sdk-0.13.*  ~/
+
 if test -e zephyrproject; then
     ./scripts/xtensa-build-zephyr.sh -a "$@"
 else


### PR DESCRIPTION
Also stop hardcoding the SDK version number: Zephyr's CMake can
automatically find the latest SDK in the home directory but not in
/opt/toolchains so add some symbolic links.

Fixes the build broken since
https://github.com/zephyrproject-rtos/zephyr/pull/38733

Signed-off-by: Marc Herbert <marc.herbert@intel.com>