### PR TITLE
component: reorder the switch case in comp_get_requested_state()

### DIFF
--- a/src/include/sof/audio/component_ext.h
+++ b/src/include/sof/audio/component_ext.h
@@ -281,6 +281,10 @@ static inline int comp_get_requested_state(int cmd)
 	int state = COMP_STATE_INIT;
 
 	switch (cmd) {
+	case COMP_TRIGGER_PRE_START:
+	case COMP_TRIGGER_PRE_RELEASE:
+		state = COMP_STATE_PRE_ACTIVE;
+		break;
 	case COMP_TRIGGER_START:
 	case COMP_TRIGGER_RELEASE:
 		state = COMP_STATE_ACTIVE;
@@ -295,10 +299,6 @@ static inline int comp_get_requested_state(int cmd)
 	case COMP_TRIGGER_XRUN:
 	case COMP_TRIGGER_RESET:
 		state = COMP_STATE_READY;
-		break;
-	case COMP_TRIGGER_PRE_START:
-	case COMP_TRIGGER_PRE_RELEASE:
-		state = COMP_STATE_PRE_ACTIVE;
 		break;
 	}
 


### PR DESCRIPTION
Pipeline trigger is now handled as part of the pipeline
task. Keeping the PRE_START/PRE_RELEASE as the last options
in the switch case to get the current component state results
in task taking taking too long during PRE_START leading to an
xrun with the first copy in the pipeline task. Move the
PRE_START/PRE_RELEASE options as the first cases to fix this.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>