### PR TITLE
topology1: codec_adapter: Add 'codec_adapter' pipeline configuration

### DIFF
--- a/tools/topology/topology1/sof/pipe-codec-adapter-playback.m4
+++ b/tools/topology/topology1/sof/pipe-codec-adapter-playback.m4
@@ -139,6 +139,8 @@ P_GRAPH(pipe-codec-adapter-playback, PIPELINE_ID,
 indir(`define', concat(`PIPELINE_SOURCE_', PIPELINE_ID), N_BUFFER(1))
 indir(`define', concat(`PIPELINE_PCM_', PIPELINE_ID), Passthrough Playback PCM_ID)
 
+W_PIPELINE(SCHED_COMP, SCHEDULE_PERIOD, SCHEDULE_PRIORITY, SCHEDULE_CORE, SCHEDULE_TIME_DOMAIN, pipe_media_schedule_plat)
+
 #
 # PCM Configuration
 #


### PR DESCRIPTION
This adds 'codec_adapter' pipeline configuration  allowing this
pipeline to be part of a more complex topology.

Important configuration here is the 'scheduler' widget. Without this,
'codec_adapter' would work in a more complex topology. This is because
each individual pipeline needs to have a 'scheduling' component.

Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>