### PR TITLE
Build SOF with Zephyr for imx8x

### DIFF
--- a/scripts/xtensa-build-zephyr.sh
+++ b/scripts/xtensa-build-zephyr.sh
@@ -13,7 +13,7 @@ SUPPORTED_PLATFORMS=()
 SUPPORTED_PLATFORMS+=(apl cnl icl tgl-h tgl)
 
 # NXP
-SUPPORTED_PLATFORMS+=(imx8)
+SUPPORTED_PLATFORMS+=(imx8 imx8x)
 
 # Default value, can (and sometimes must) be overridden with -p
 WEST_TOP="${SOF_TOP}"/zephyrproject
@@ -172,6 +172,10 @@ build_all()
 			imx8)
 				PLAT_CONFIG='nxp_adsp_imx8'
 				RIMAGE_KEY='' # no key needed for imx8
+				;;
+			imx8x)
+				PLAT_CONFIG='nxp_adsp_imx8x'
+				RIMAGE_KEY='ignored for imx8x'
 				;;
 			*)
 				echo "Unsupported platform: $platform"


### PR DESCRIPTION
Add imx8x platform to be tested with Zephyr.
This refers to i.MX8QXP target.

The support in Zephyr was merged: https://github.com/zephyrproject-rtos/zephyr/pull/38684