### PR TITLE
Backport cs42l42 support to jsl-005-drop-stable

### DIFF
--- a/src/drivers/intel/ssp/mn.c
+++ b/src/drivers/intel/ssp/mn.c
@@ -283,7 +283,7 @@ void mn_release_mclk(uint32_t mclk_id)
 	if (!mn->mclk_sources_ref[mclk_id]) {
 		mdivc = mn_reg_read(MN_MDIVCTRL, mclk_id);
 
-		mdivc |= ~MN_MDIVCTRL_M_DIV_ENABLE(mclk_id);
+		mdivc &= ~MN_MDIVCTRL_M_DIV_ENABLE(mclk_id);
 		mn_reg_write(MN_MDIVCTRL, mclk_id, mdivc);
 	}
 

--- a/src/drivers/intel/ssp/ssp.c
+++ b/src/drivers/intel/ssp/ssp.c
@@ -267,10 +267,10 @@ static int ssp_set_config(struct dai *dai,
 
 	spin_lock(&dai->lock);
 
-	/* is playback/capture already running */
-	if (ssp->state[DAI_DIR_PLAYBACK] == COMP_STATE_ACTIVE ||
-	    ssp->state[DAI_DIR_CAPTURE] == COMP_STATE_ACTIVE) {
-		dai_info(dai, "ssp_set_config(): playback/capture active. Ignore config");
+	/* ignore config if SSP is already configured */
+	if (ssp->state[DAI_DIR_PLAYBACK] > COMP_STATE_READY ||
+	    ssp->state[DAI_DIR_CAPTURE] > COMP_STATE_READY) {
+		dai_info(dai, "ssp_set_config(): Already configured. Ignore config");
 		goto out;
 	}
 

--- a/src/drivers/intel/ssp/ssp.c
+++ b/src/drivers/intel/ssp/ssp.c
@@ -657,6 +657,7 @@ static int ssp_pre_start(struct dai *dai)
 	if (ssp_freq[SSP_DEFAULT_IDX].freq % config->ssp.bclk_rate != 0) {
 		dai_err(dai, "invalid bclk_rate = %d for dai_index = %d",
 			config->ssp.bclk_rate, config->dai_index);
+		ret = -EINVAL;
 		goto out;
 	}
 

--- a/src/drivers/intel/ssp/ssp.c
+++ b/src/drivers/intel/ssp/ssp.c
@@ -758,7 +758,7 @@ clk:
 		/* disable SSP port if no users */
 		if (ssp->state[SOF_IPC_STREAM_CAPTURE] != COMP_STATE_PREPARE ||
 		    ssp->state[SOF_IPC_STREAM_PLAYBACK] != COMP_STATE_PREPARE) {
-			dai_info(dai, "ssp_set_config(): hw_free stage: ignore since there is still user",
+			dai_info(dai, "ssp_set_config(): hw_free stage: ignore since SSP%d still in use",
 				 dai->index);
 			break;
 		}

--- a/src/drivers/intel/ssp/ssp.c
+++ b/src/drivers/intel/ssp/ssp.c
@@ -711,6 +711,63 @@ static int ssp_set_config(struct dai *dai,
 	ssp->state[DAI_DIR_PLAYBACK] = COMP_STATE_PREPARE;
 	ssp->state[DAI_DIR_CAPTURE] = COMP_STATE_PREPARE;
 
+	switch (config->flags & SOF_DAI_CONFIG_FLAGS_MASK) {
+	case SOF_DAI_CONFIG_FLAGS_HW_PARAMS:
+		if (ssp->params.clks_control & SOF_DAI_INTEL_SSP_CLKCTRL_MCLK_ES) {
+			ret = ssp_mclk_prepare_enable(dai);
+			if (ret < 0)
+				goto out;
+
+			ssp->clk_active |= SSP_CLK_MCLK_ES_REQ;
+
+			dai_info(dai, "ssp_set_config(): hw_params stage: enabled MCLK clocks for SSP%d...",
+				 dai->index);
+		}
+
+		if (ssp->params.clks_control & SOF_DAI_INTEL_SSP_CLKCTRL_BCLK_ES) {
+			bool enable_sse = false;
+
+			if (!(ssp->clk_active & SSP_CLK_BCLK_ACTIVE))
+				enable_sse = true;
+
+			ret = ssp_bclk_prepare_enable(dai);
+			if (ret < 0)
+				goto out;
+
+			ssp->clk_active |= SSP_CLK_BCLK_ES_REQ;
+
+			if (enable_sse) {
+				/* enable port */
+				ssp_update_bits(dai, SSCR0, SSCR0_SSE, SSCR0_SSE);
+
+				dai_info(dai, "ssp_set_config(): SSE set for SSP%d", dai->index);
+			}
+
+			dai_info(dai, "ssp_set_config(): hw_params stage: enabled BCLK clocks for SSP%d...",
+				 dai->index);
+		}
+		break;
+	case SOF_DAI_CONFIG_FLAGS_HW_FREE:
+		if (ssp->params.clks_control & SOF_DAI_INTEL_SSP_CLKCTRL_BCLK_ES) {
+			dai_info(dai, "ssp_set_config(): hw_free stage: releasing BCLK clocks for SSP%d...",
+				 dai->index);
+			if (ssp->clk_active & SSP_CLK_BCLK_ACTIVE) {
+				ssp_update_bits(dai, SSCR0, SSCR0_SSE, 0);
+				dai_info(dai, "ssp_set_config(): SSE clear for SSP%d", dai->index);
+			}
+			ssp_bclk_disable_unprepare(dai);
+			ssp->clk_active &= ~SSP_CLK_BCLK_ES_REQ;
+		}
+		if (ssp->params.clks_control & SOF_DAI_INTEL_SSP_CLKCTRL_MCLK_ES) {
+			dai_info(dai, "ssp_set_config: hw_free stage: releasing MCLK clocks for SSP%d...",
+				 dai->index);
+			ssp_mclk_disable_unprepare(dai);
+			ssp->clk_active &= ~SSP_CLK_MCLK_ES_REQ;
+		}
+		break;
+	default:
+		break;
+	}
 out:
 
 	spin_unlock(&dai->lock);
@@ -725,7 +782,8 @@ out:
  */
 static int ssp_pre_start(struct dai *dai)
 {
-	int ret;
+	struct ssp_pdata *ssp = dai_get_drvdata(dai);
+	int ret = 0;
 
 	dai_info(dai, "ssp_pre_start()");
 
@@ -733,13 +791,17 @@ static int ssp_pre_start(struct dai *dai)
 	 * We will test if mclk/bclk is configured in
 	 * ssp_mclk/bclk_prepare_enable/disable functions
 	 */
+	if (!(ssp->clk_active & SSP_CLK_MCLK_ES_REQ)) {
+		/* MCLK config */
+		ret = ssp_mclk_prepare_enable(dai);
+		if (ret < 0)
+			return ret;
+	}
 
-	/* MCLK config */
-	ret = ssp_mclk_prepare_enable(dai);
-	if (ret < 0)
-		return ret;
+	if (!(ssp->clk_active & SSP_CLK_BCLK_ES_REQ))
+		ret = ssp_bclk_prepare_enable(dai);
 
-	return ssp_bclk_prepare_enable(dai);
+	return ret;
 }
 
 /*
@@ -754,9 +816,16 @@ static void ssp_post_stop(struct dai *dai)
 	/* release clocks if SSP is inactive */
 	if (ssp->state[SOF_IPC_STREAM_PLAYBACK] != COMP_STATE_ACTIVE &&
 	    ssp->state[SOF_IPC_STREAM_CAPTURE] != COMP_STATE_ACTIVE) {
-		dai_info(dai, "releasing BCLK/MCLK clocks for SSP%d...", dai->index);
-		ssp_bclk_disable_unprepare(dai);
-		ssp_mclk_disable_unprepare(dai);
+		if (!(ssp->clk_active & SSP_CLK_BCLK_ES_REQ)) {
+			dai_info(dai, "ssp_post_stop releasing BCLK clocks for SSP%d...",
+				 dai->index);
+			ssp_bclk_disable_unprepare(dai);
+		}
+		if (!(ssp->clk_active & SSP_CLK_MCLK_ES_REQ)) {
+			dai_info(dai, "ssp_post_stop releasing MCLK clocks for SSP%d...",
+				 dai->index);
+			ssp_mclk_disable_unprepare(dai);
+		}
 	}
 }
 
@@ -802,8 +871,11 @@ static void ssp_start(struct dai *dai, int direction)
 	/* request mclk/bclk */
 	ssp_pre_start(dai);
 
-	/* enable port */
-	ssp_update_bits(dai, SSCR0, SSCR0_SSE, SSCR0_SSE);
+	if (!(ssp->clk_active & SSP_CLK_BCLK_ES_REQ)) {
+		/* enable port */
+		ssp_update_bits(dai, SSCR0, SSCR0_SSE, SSCR0_SSE);
+		dai_info(dai, "ssp_start(): SSE set for SSP%d", dai->index);
+	}
 	ssp->state[direction] = COMP_STATE_ACTIVE;
 
 	dai_info(dai, "ssp_start()");
@@ -864,8 +936,10 @@ static void ssp_stop(struct dai *dai, int direction)
 	/* disable SSP port if no users */
 	if (ssp->state[SOF_IPC_STREAM_CAPTURE] == COMP_STATE_PREPARE &&
 	    ssp->state[SOF_IPC_STREAM_PLAYBACK] == COMP_STATE_PREPARE) {
-		ssp_update_bits(dai, SSCR0, SSCR0_SSE, 0);
-		dai_info(dai, "ssp_stop(), SSP port disabled");
+		if (!(ssp->clk_active & SSP_CLK_BCLK_ES_REQ)) {
+			ssp_update_bits(dai, SSCR0, SSCR0_SSE, 0);
+			dai_info(dai, "ssp_stop(): SSE clear SSP%d", dai->index);
+		}
 	}
 
 	ssp_post_stop(dai);

--- a/src/drivers/intel/ssp/ssp.c
+++ b/src/drivers/intel/ssp/ssp.c
@@ -271,7 +271,7 @@ static int ssp_set_config(struct dai *dai,
 	if (ssp->state[DAI_DIR_PLAYBACK] > COMP_STATE_READY ||
 	    ssp->state[DAI_DIR_CAPTURE] > COMP_STATE_READY) {
 		dai_info(dai, "ssp_set_config(): Already configured. Ignore config");
-		goto out;
+		goto clk;
 	}
 
 	dai_info(dai, "ssp_set_config(), config->format = 0x%4x",
@@ -711,6 +711,7 @@ static int ssp_set_config(struct dai *dai,
 	ssp->state[DAI_DIR_PLAYBACK] = COMP_STATE_PREPARE;
 	ssp->state[DAI_DIR_CAPTURE] = COMP_STATE_PREPARE;
 
+clk:
 	switch (config->flags & SOF_DAI_CONFIG_FLAGS_MASK) {
 	case SOF_DAI_CONFIG_FLAGS_HW_PARAMS:
 		if (ssp->params.clks_control & SOF_DAI_INTEL_SSP_CLKCTRL_MCLK_ES) {

--- a/src/drivers/intel/ssp/ssp.c
+++ b/src/drivers/intel/ssp/ssp.c
@@ -755,6 +755,14 @@ clk:
 		}
 		break;
 	case SOF_DAI_CONFIG_FLAGS_HW_FREE:
+		/* disable SSP port if no users */
+		if (ssp->state[SOF_IPC_STREAM_CAPTURE] != COMP_STATE_PREPARE ||
+		    ssp->state[SOF_IPC_STREAM_PLAYBACK] != COMP_STATE_PREPARE) {
+			dai_info(dai, "ssp_set_config(): hw_free stage: ignore since there is still user",
+				 dai->index);
+			break;
+		}
+
 		if (ssp->params.clks_control & SOF_DAI_INTEL_SSP_CLKCTRL_BCLK_ES) {
 			dai_info(dai, "ssp_set_config(): hw_free stage: releasing BCLK clocks for SSP%d...",
 				 dai->index);

--- a/src/include/ipc/dai-intel.h
+++ b/src/include/ipc/dai-intel.h
@@ -56,6 +56,10 @@
 #define SOF_DAI_INTEL_SSP_CLKCTRL_FS_KA			BIT(4)
 /* bclk idle */
 #define SOF_DAI_INTEL_SSP_CLKCTRL_BCLK_IDLE_HIGH	BIT(5)
+/* mclk early start */
+#define SOF_DAI_INTEL_SSP_CLKCTRL_MCLK_ES		BIT(6)
+/* bclk early start */
+#define SOF_DAI_INTEL_SSP_CLKCTRL_BCLK_ES		BIT(7)
 
 /* DMIC max. four controllers for eight microphone channels */
 #define SOF_DAI_INTEL_DMIC_NUM_CTRL			4

--- a/src/include/ipc/dai.h
+++ b/src/include/ipc/dai.h
@@ -52,6 +52,13 @@
 #define SOF_DAI_FMT_INV_MASK		0x0f00
 #define SOF_DAI_FMT_CLOCK_PROVIDER_MASK	0xf000
 
+/* DAI_CONFIG flags */
+#define SOF_DAI_CONFIG_FLAGS_MASK	0x3
+#define SOF_DAI_CONFIG_FLAGS_NONE	(0 << 0) /**< DAI_CONFIG sent without stage information */
+#define SOF_DAI_CONFIG_FLAGS_HW_PARAMS	(1 << 0) /**< DAI_CONFIG sent during hw_params stage */
+#define SOF_DAI_CONFIG_FLAGS_HW_FREE	(2 << 0) /**< DAI_CONFIG sent during hw_free stage */
+#define SOF_DAI_CONFIG_FLAGS_RFU	(3 << 0) /**< not used, reserved for future use */
+
 /** \brief Types of DAI */
 enum sof_ipc_dai_type {
 	SOF_DAI_INTEL_NONE = 0,		/**< None */
@@ -72,7 +79,7 @@ struct sof_ipc_dai_config {
 	/* physical protocol and clocking */
 	uint16_t format;	/**< SOF_DAI_FMT_ */
 	uint8_t group_id;	/**< group ID, 0 means no group (ABI 3.17) */
-	uint8_t reserved8;	/**< alignment */
+	uint8_t flags;		/**< SOF_DAI_CONFIG_FLAGS_ (ABI 3.19) */
 
 	/* reserved for future use */
 	uint32_t reserved[8];

--- a/src/include/sof/drivers/ssp.h
+++ b/src/include/sof/drivers/ssp.h
@@ -224,8 +224,10 @@ extern const struct dai_driver ssp_driver;
 #define ssp_irq(ssp) \
 	ssp->plat_data.irq
 
-#define SSP_CLK_MCLK_ACTIVE	BIT(0)
-#define SSP_CLK_BCLK_ACTIVE	BIT(1)
+#define SSP_CLK_MCLK_ES_REQ	BIT(0)
+#define SSP_CLK_MCLK_ACTIVE	BIT(1)
+#define SSP_CLK_BCLK_ES_REQ	BIT(2)
+#define SSP_CLK_BCLK_ACTIVE	BIT(3)
 
 /* SSP private data */
 struct ssp_pdata {

--- a/src/include/sof/drivers/ssp.h
+++ b/src/include/sof/drivers/ssp.h
@@ -224,12 +224,16 @@ extern const struct dai_driver ssp_driver;
 #define ssp_irq(ssp) \
 	ssp->plat_data.irq
 
+#define SSP_CLK_MCLK_ACTIVE	BIT(0)
+#define SSP_CLK_BCLK_ACTIVE	BIT(1)
+
 /* SSP private data */
 struct ssp_pdata {
 	uint32_t sscr0;
 	uint32_t sscr1;
 	uint32_t psp;
 	uint32_t state[2];		/* SSP_STATE_ for each direction */
+	uint32_t clk_active;
 	struct sof_ipc_dai_config config;
 	struct sof_ipc_dai_ssp_params params;
 };

--- a/tools/topology/CMakeLists.txt
+++ b/tools/topology/CMakeLists.txt
@@ -143,9 +143,10 @@ set(TPLGS
 	"sof-jsl-da7219\;sof-jsl-da7219-mx98360a\;-DPLATFORM=jsl-dedede"
 	"sof-imx8mp-wm8960\;sof-imx8mp-wm8960"
 	"sof-smart-amplifier-nocodec\;sof-smart-amplifier-nocodec"
-	"sof-jsl-rt5682\;sof-jsl-rt5682-rt1015\;-DPLATFORM=jsl-rt1015"
-	"sof-jsl-rt5682\;sof-jsl-rt5682-rt1015-xperi\;-DPLATFORM=jsl-rt1015\;-DINCLUDE_IIR_EQ=1"
-	"sof-jsl-rt5682\;sof-jsl-rt5682-mx98360a\;-DPLATFORM=jsl-dedede"
+	"sof-jsl-rt5682\;sof-jsl-rt5682-rt1015\;-DHEADPHONE=rt5682\;-DPLATFORM=jsl-rt1015"
+	"sof-jsl-rt5682\;sof-jsl-rt5682-rt1015-xperi\;-DHEADPHONE=rt5682\;-DPLATFORM=jsl-rt1015\;-DINCLUDE_IIR_EQ=1"
+	"sof-jsl-rt5682\;sof-jsl-rt5682-mx98360a\;-DHEADPHONE=rt5682\;-DPLATFORM=jsl-dedede"
+	"sof-jsl-rt5682\;sof-jsl-cs42l42-mx98360a\;-DHEADPHONE=cs42l42\;-DPLATFORM=jsl-dedede"
 )
 
 add_custom_target(topologies ALL)

--- a/tools/topology/platform/common/ssp.m4
+++ b/tools/topology/platform/common/ssp.m4
@@ -30,6 +30,11 @@ $6
 dnl SSP_QUIRK_LBM 64 = (1 << 6)
 define(`SSP_QUIRK_LBM', 64)
 
+dnl SSP_CC_MCLK_ES 64 = (1 << 6)
+define(`SSP_CC_MCLK_ES', 64)
+dnl SSP_CC_BCLK_ES 128 = (1 << 7)
+define(`SSP_CC_BCLK_ES', 128)
+
 dnl SSP_CONFIG_DATA(type, idx, valid bits, mclk_id, quirks, bclk_delay,
 dnl clks_control, pulse_width, padding)
 dnl mclk_id, quirks, bclk_delay clks_control, pulse_width and padding are optional

--- a/tools/topology/sof-jsl-rt5682.m4
+++ b/tools/topology/sof-jsl-rt5682.m4
@@ -1,5 +1,8 @@
 #
-# Topology for JasperLake with rt5682 codec + DMIC + 3 HDMI + Speaker amp
+# Topology for JasperLake with rt5682 or cs42l42 codec +
+#                              DMIC +
+#                              3 HDMI +
+#                              speaker amp
 #
 
 # Include topology builder
@@ -24,7 +27,7 @@ DEBUG_START
 # Define the pipelines
 #
 # PCM0 ----> volume -----> SSP1  (Speaker - ALC1015)
-# PCM1 <---> volume <----> SSP0  (Headset - ALC5682)
+`# PCM1 <---> volume <----> SSP0  (Headset - 'HEADPHONE`)'
 # PCM2 ----> volume -----> iDisp1
 # PCM3 ----> volume -----> iDisp2
 # PCM4 ----> volume -----> iDisp3
@@ -176,6 +179,7 @@ dnl SSP_CONFIG(format, mclk, bclk, fsync, tdm, ssp_config_data)
 dnl SSP_CLOCK(clock, freq, codec_master, polarity)
 dnl SSP_CONFIG_DATA(type, idx, valid bits, mclk_id)
 
+ifelse(HEADPHONE, `rt5682', `
 # SSP 0 (ID: 0) ALC5682
 DAI_CONFIG(SSP, 0, 0, SSP0-Codec,
 	SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24000000, codec_mclk_in),
@@ -183,6 +187,15 @@ DAI_CONFIG(SSP, 0, 0, SSP0-Codec,
 		SSP_CLOCK(fsync, 48000, codec_slave),
 		SSP_TDM(2, 25, 3, 3),
 		SSP_CONFIG_DATA(SSP, 0, 24)))
+', HEADPHONE, `cs42l42', `
+# SSP 0 (ID: 0) CS42L42
+DAI_CONFIG(SSP, 0, 0, SSP0-Codec,
+	SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24000000, codec_mclk_in),
+		SSP_CLOCK(bclk, 2400000, codec_slave),
+		SSP_CLOCK(fsync, 48000, codec_slave),
+		SSP_TDM(2, 25, 3, 3),
+		SSP_CONFIG_DATA(SSP, 0, 24, 0, 0, 0, SSP_CC_BCLK_ES)))
+', )
 
 # SSP 1 (ID: 6)
 DAI_CONFIG(SSP, SPK_INDEX, 6, SPK_NAME,


### PR DESCRIPTION
1. PR4391 for mclk/bclk control
4c2492a50 intel: ssp: fix missing return code on bclk configuration issue
0295d7b7d ipc: dai: add flags for DAI_CONFIG IPC
d4392b7ac ipc: dai-intel: add SOF_DAI_INTEL_SSP_CLKCTRL_MCLK/BCLK_ES bits
2106a7fc1 intel: ssp: introduce ssp_set/release_mclk/bclk helpers to set/release mclk/bclk
455eccab2 intel: ssp: handle MCLK/BCLK early start
f0c81d487 intel: ssp: handle TSRE and RSRE along with SSE
4b4235966 topology: ssp: mclk/bclk clock control

2. topology for  cs42l42
f678c88f9 topology: sof-jsl-rt5682: add support for cs42l42 with max98360a

3. fixes for the clock control feature
b06f7e5f0 drivers: Intel: SSP: ignore config when SSP is already configured
0c57c2602 ssp: mn: mdivctrl corruption in mn_release_mclk()
3e68d2fcf ssp: bclk/mclk control is ignored
b7395e883 ssp: mclk/bclk turned off unexpectedly
696cc7718 ssp.c: fix recent arg count regression in dai_info()

Tested on two Chromebooks with rt5682 and cs42l42 headphone codec.