### PR TITLE
drivers: amd: renoir: Fix 16K sample rate for dmic

### DIFF
--- a/src/drivers/amd/renoir/acp_dmic_dai.c
+++ b/src/drivers/amd/renoir/acp_dmic_dai.c
@@ -73,7 +73,7 @@ static int acp_dmic_dai_get_hw_params(struct dai *dai,
 			      int dir)
 {
 	/* ACP only currently supports these parameters */
-	params->rate = ACP_DEFAULT_SAMPLE_RATE;
+	params->rate = ACP_SAMPLE_RATE_16K;/* 16000 sample rate only for dmic */
 	params->channels = ACP_DEFAULT_NUM_CHANNELS;
 	params->buffer_fmt = SOF_IPC_BUFFER_INTERLEAVED;
 	params->frame_fmt = SOF_IPC_FRAME_S32_LE;

--- a/src/drivers/amd/renoir/acp_dmic_dma.c
+++ b/src/drivers/amd/renoir/acp_dmic_dma.c
@@ -96,8 +96,8 @@ static int acp_dmic_dma_start(struct dma_chan_data *channel)
 		deci_fctr.u32all = 2;
 		io_reg_write(PU_REGISTER_BASE + ACP_WOV_PDM_DECIMATION_FACTOR,
 							deci_fctr.u32all);
-		/* DMIC Clock */
-		clk_ctrl.bits.brm_clk_ctrl = 7;
+		/* DMIC Clock for 16K sample rate */
+		clk_ctrl.bits.brm_clk_ctrl = 1;
 		io_reg_write(PU_REGISTER_BASE + ACP_WOV_CLK_CTRL,
 						clk_ctrl.u32all);
 		/* PDM Control */

--- a/src/include/sof/drivers/acp_dai_dma.h
+++ b/src/include/sof/drivers/acp_dai_dma.h
@@ -27,6 +27,8 @@ int acp_dma_init(struct sof *sof);
 /* default sample rate */
 #define ACP_DEFAULT_SAMPLE_RATE     48000
 
+#define ACP_SAMPLE_RATE_16K	16000
+
 #define ACP_DMA_BUFFER_ALIGN	64
 #define ACP_DMA_TRANS_SIZE	64
 #define ACP_DAI_DMA_BUFFER_PERIOD_COUNT		2


### PR DESCRIPTION
Fix dmic sample rate to 16000 as default sample rate.

Signed-off-by: balapati <balakishore.pati@amd.com>