### PR TITLE
topology: topology1: Add initial topology for AMD Renoir platform

### DIFF
--- a/tools/topology/topology1/CMakeLists.txt
+++ b/tools/topology/topology1/CMakeLists.txt
@@ -173,6 +173,8 @@ set(TPLGS
 	"sof-imx8mp-wm8960\;sof-imx8mp-drc-wm8960\;-DPPROC=drc"
 
 	"sof-mt8195-mt6359-rt1019-rt5682\;sof-mt8195-mt6359-rt1019-rt5682"
+
+	"sof-acp-renoir\;sof-acp"
 )
 
 add_custom_target(topologies1 ALL

--- a/tools/topology/topology1/m4/dai.m4
+++ b/tools/topology/topology1/m4/dai.m4
@@ -155,7 +155,7 @@ define(`DO_DAI_CONFIG',
 `'
 `	id		"'$3`"'
 `'
-`	ifelse($1, `SSP', $5, $1, `HDA', $5, $1, `ALH', $5, $1, `ESAI', $5, $1, `SAI', $5, $1, `AFE', $5, `}')'
+`	ifelse($1, `SSP', $5, $1, `HDA', $5, $1, `ALH', $5, $1, `ESAI', $5, $1, `SAI', $5, $1, `AFE', $5, $1, `ACP', $5, $1, `ACPSP', $5, $1, `ACPDMIC', $5, `}')'
 `ifelse($1, `DMIC', $5, `')'
 `SectionVendorTuples."'N_DAI_CONFIG($1$2)`_tuples_common" {'
 `	tokens "sof_dai_tokens"'

--- a/tools/topology/topology1/platform/amd/acp.m4
+++ b/tools/topology/topology1/platform/amd/acp.m4
@@ -1,0 +1,13 @@
+#
+# ACPX differentiation for pipelines and components
+#
+
+include(`memory.m4')
+
+# PCM Configuration
+W_VENDORTUPLES(pipe_ll_schedule_plat_tokens, sof_sched_tokens, LIST(`		', `SOF_TKN_SCHED_MIPS	"50000"'))
+W_DATA(pipe_ll_schedule_plat, pipe_ll_schedule_plat_tokens)
+
+# DAI schedule Configuration - scheduled by IRQ
+W_VENDORTUPLES(pipe_dai_schedule_plat_tokens, sof_sched_tokens, LIST(`		', `SOF_TKN_SCHED_MIPS	"5000"'))
+W_DATA(pipe_dai_schedule_plat, pipe_dai_schedule_plat_tokens)

--- a/tools/topology/topology1/platform/common/acp-dmic.m4
+++ b/tools/topology/topology1/platform/common/acp-dmic.m4
@@ -1,0 +1,24 @@
+divert(-1)
+
+dnl ACPDMIC related macros
+
+define(`ACPDMIC_CONFIG',
+`}'
+$1
+)
+dnl ACPDMIC_CONFIG_DATA(type, idx, rate, channel)
+define(`ACPDMIC_CONFIG_DATA',
+`SectionVendorTuples."'N_DAI_CONFIG($1$2)`_tuples" {'
+`       tokens "sof_acpdmic_tokens"'
+`       tuples."word" {'
+`               SOF_TKN_AMD_ACPDMIC_RATE'	STR($3)
+`		SOF_TKN_AMD_ACPDMIC_CH'		STR($4)
+`       }'
+`}'
+`SectionData."'N_DAI_CONFIG($1$2)`_data" {'
+`       tuples "'N_DAI_CONFIG($1$2)`_tuples"'
+`}'
+)
+
+divert(0)dnl
+

--- a/tools/topology/topology1/platform/common/acp-sp.m4
+++ b/tools/topology/topology1/platform/common/acp-sp.m4
@@ -1,0 +1,46 @@
+divert(-1)
+
+dnl ACPSP related macros
+
+dnl ACP_CLOCK(clock, freq, codec_master, polarity)
+dnl polarity is optional
+define(`ACP_CLOCK',
+        $1              STR($3)
+        $1_freq         STR($2))
+        `ifelse($4, `inverted', `$1_invert      "true"',`')')
+
+dnl ACP_TDM(slots, width, tx_mask, rx_mask)
+define(`ACP_TDM',
+`       tdm_slots       'STR($1)
+`       tdm_slot_width  'STR($2)
+`       tx_slots        'STR($3)
+`       rx_slots        'STR($4)
+)
+
+dnl ACP_CONFIG(format, mclk, bclk, fsync, tdm, esai_config_data)
+define(`ACPSP_CONFIG',
+`       format          "'$1`"'
+`       '$2
+`       '$3
+`       '$4
+`       '$5
+`}'
+$6
+)
+
+dnl ACPSP_CONFIG_DATA(type, idx, rate, channel)
+define(`ACPSP_CONFIG_DATA',
+`SectionVendorTuples."'N_DAI_CONFIG($1$2)`_tuples" {'
+`       tokens "sof_acpsp_tokens"'
+`       tuples."word" {'
+`               SOF_TKN_AMD_ACPSP_RATE'		STR($3)
+`		SOF_TKN_AMD_ACPSP_CH'		STR($4)
+`       }'
+`}'
+`SectionData."'N_DAI_CONFIG($1$2)`_data" {'
+`       tuples "'N_DAI_CONFIG($1$2)`_tuples"'
+`}'
+)
+
+divert(0)dnl
+

--- a/tools/topology/topology1/sof-acp-renoir.m4
+++ b/tools/topology/topology1/sof-acp-renoir.m4
@@ -1,0 +1,65 @@
+#
+# Topology for Renoir with I2S SP and DMIC.
+#
+
+# Include topology builder
+include(`utils.m4')
+include(`dai.m4')
+include(`pipeline.m4')
+include(`acp-sp.m4')
+include(`acp-dmic.m4')
+
+# Include TLV library
+include(`common/tlv.m4')
+
+# Include Token library
+include(`sof/tokens.m4')
+
+# Include ACP DSP configuration
+include(`platform/amd/acp.m4')
+
+# Playback pipeline 1 on PCM 0 using max 2 channels of s16le.
+# Schedule 96 frames per 2000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-passthrough-playback.m4,
+        1, 0, 2, s16le,
+        2000, 0, 0,
+        48000, 48000, 48000)
+
+# playback DAI is ACPSP using 2 periods
+DAI_ADD(sof/pipe-dai-playback.m4, 1, ACPSP, 0, acp-headset-codec,
+PIPELINE_SOURCE_1, 2, s16le, 2000, 0, 0, SCHEDULE_TIME_DOMAIN_DMA)
+
+DAI_CONFIG(ACPSP, 0, 0, acp-headset-codec,
+	   ACPSP_CONFIG(I2S, ACP_CLOCK(mclk, 49152000, codec_mclk_in),
+                ACP_CLOCK(bclk, 3072000, codec_slave),
+                ACP_CLOCK(fsync, 48000, codec_slave),
+                ACP_TDM(2, 32, 3, 3),ACPSP_CONFIG_DATA(ACPSP, 0, 48000, 2)))
+
+# Capture pipeline 2 on PCM 0 using max 2 channels of s16le.
+PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
+        2, 0, 2, s16le,
+        2000, 0, 0,
+        48000, 48000, 48000)
+
+# Capture DAI is ACPSP using 2 periods
+DAI_ADD(sof/pipe-dai-capture.m4, 2, ACPSP, 0, acp-headset-codec,
+PIPELINE_SINK_2, 2, s16le, 2000, 0, 0, SCHEDULE_TIME_DOMAIN_DMA)
+
+# PCM  id 0
+PCM_DUPLEX_ADD(I2SSP, 0, PIPELINE_PCM_1, PIPELINE_PCM_2)
+
+# Capture pipeline 3 on PCM 1 using max 2 channels of s32le.
+PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
+        3, 1, 2, s32le,
+        2000, 0, 0,
+        16000, 16000, 16000)
+
+DAI_ADD(sof/pipe-dai-capture.m4, 3, ACPDMIC, 0, acp-dmic-codec,
+PIPELINE_SINK_3, 2, s32le, 2000, 0, 0, SCHEDULE_TIME_DOMAIN_DMA)
+
+dnl DAI_CONFIG(type, dai_index, link_id, name, acpdmic_config)
+DAI_CONFIG(ACPDMIC, 3, 2, acp-dmic-codec,
+	   ACPDMIC_CONFIG(ACPDMIC_CONFIG_DATA(ACPDMIC, 3, 16000, 2)))
+
+# PCM id 1
+PCM_CAPTURE_ADD(DMIC, 1, PIPELINE_PCM_3)

--- a/tools/topology/topology1/sof/tokens.m4
+++ b/tools/topology/topology1/sof/tokens.m4
@@ -136,3 +136,13 @@ SectionVendorTokens."sof_afe_tokens" {
 	SOF_TKN_MEDIATEK_AFE_CH				"1601"
 	SOF_TKN_MEDIATEK_AFE_FORMAT			"1602"
 }
+
+SectionVendorTokens."sof_acpsp_tokens" {
+	SOF_TKN_AMD_ACPSP_RATE			"1700"
+	SOF_TKN_AMD_ACPSP_CH			"1701"
+}
+
+SectionVendorTokens."sof_acpdmic_tokens" {
+        SOF_TKN_AMD_ACPDMIC_RATE                  "1800"
+        SOF_TKN_AMD_ACPDMIC_CH                    "1801"
+}


### PR DESCRIPTION
This PR adds m4 and headers to support basic topology with passthrough
pipeline for ACPSP and DMIC use case support on renoir platform.

