### PR TITLE
Build SOF with Zephyr on i.MX8MP

### DIFF
--- a/src/platform/imx8m/lib/clk.c
+++ b/src/platform/imx8m/lib/clk.c
@@ -6,11 +6,14 @@
 
 #include <sof/common.h>
 #include <sof/lib/clk.h>
-#include <sof/lib/cpu.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/notifier.h>
 #include <sof/sof.h>
 #include <sof/spinlock.h>
+
+#ifdef __ZEPHYR__
+#include <sys/util.h>
+#endif
 
 const struct freq_table platform_cpu_freq[] = {
 	{ 800000000, 800000 },

--- a/src/platform/imx8m/platform.c
+++ b/src/platform/imx8m/platform.c
@@ -155,6 +155,11 @@ int platform_init(struct sof *sof)
 	sof->platform_timer = &timer;
 	sof->cpu_timers = &timer;
 
+#ifdef __ZEPHYR__
+	/* initialize cascade interrupts before any usage */
+	interrupt_init(sof);
+#endif
+
 	platform_interrupt_init();
 	platform_clock_init(sof);
 	scheduler_init_edf();

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -444,10 +444,9 @@ if (CONFIG_SOC_SERIES_NXP_IMX8M)
 	zephyr_library_sources(
 		${SOF_DRIVERS_PATH}/generic/dummy-dma.c
 		${SOF_DRIVERS_PATH}/imx/sdma.c
-		${SOF_DRIVERS_PATH}/imx/edma.c
 		${SOF_DRIVERS_PATH}/imx/sai.c
 		${SOF_DRIVERS_PATH}/imx/ipc.c
-		${SOF_DRIVERS_PATH}/imx/esai.c
+		${SOF_DRIVERS_PATH}/imx/interrupt-irqsteer.c
 	)
 
 	# Platform sources
@@ -457,6 +456,12 @@ if (CONFIG_SOC_SERIES_NXP_IMX8M)
 		${SOF_PLATFORM_PATH}/imx8m/lib/memory.c
 		${SOF_PLATFORM_PATH}/imx8m/lib/dai.c
 		${SOF_PLATFORM_PATH}/imx8m/lib/dma.c
+	)
+
+	# SOF core infrastructure - runs on top of Zephyr
+	zephyr_library_sources(
+		${SOF_SRC_PATH}/schedule/ll_schedule.c
+		${SOF_SRC_PATH}/drivers/interrupt.c
 	)
 
 	set(PLATFORM "imx8m")


### PR DESCRIPTION
Add support for i.MX8MP to build Sound Open Firmware with Zephyr OS.

Pull requests were also opened on:
- Zephyr repo - see [#39050](https://github.com/zephyrproject-rtos/zephyr/pull/39050)
- xtensa_hal - see [#13](https://github.com/zephyrproject-rtos/hal_xtensa/pull/13)