### PR TITLE
lps: restore secondary cores on wake up

### DIFF
--- a/src/arch/host/include/arch/lib/cpu.h
+++ b/src/arch/host/include/arch/lib/cpu.h
@@ -39,6 +39,11 @@ static inline int arch_cpu_restore_secondary_cores(void)
 	return 0;
 }
 
+static inline int arch_cpu_secondary_cores_prepare_d0ix(void)
+{
+	return 0;
+}
+
 static inline void cpu_write_threadptr(int threadptr)
 {
 }

--- a/src/arch/host/include/arch/lib/cpu.h
+++ b/src/arch/host/include/arch/lib/cpu.h
@@ -34,6 +34,11 @@ static inline int arch_cpu_get_id(void)
 	return 0;
 }
 
+static inline int arch_cpu_restore_secondary_cores(void)
+{
+	return 0;
+}
+
 static inline void cpu_write_threadptr(int threadptr)
 {
 }

--- a/src/arch/xtensa/include/arch/lib/cpu.h
+++ b/src/arch/xtensa/include/arch/lib/cpu.h
@@ -26,6 +26,8 @@ int arch_cpu_is_core_enabled(int id);
 
 int arch_cpu_enabled_cores(void);
 
+int arch_cpu_restore_secondary_cores(void);
+
 #else
 
 static inline int arch_cpu_enable_core(int id) { return 0; }
@@ -35,6 +37,8 @@ static inline void arch_cpu_disable_core(int id) { }
 static inline int arch_cpu_is_core_enabled(int id) { return 1; }
 
 static inline int arch_cpu_enabled_cores(void) { return 1; }
+
+static inline int arch_cpu_restore_secondary_cores(void) {return 0; }
 
 #endif
 

--- a/src/arch/xtensa/include/arch/lib/cpu.h
+++ b/src/arch/xtensa/include/arch/lib/cpu.h
@@ -11,10 +11,17 @@
 #define __ARCH_LIB_CPU_H__
 
 #include <xtensa/config/core-isa.h>
+#include <stdint.h>
 
 #if CONFIG_MULTICORE
 
-void cpu_power_down_core(void);
+/** \brief CPU power down available flags */
+#define CPU_POWER_DOWN_MEMORY_ON	BIT(0) /**< Power down core with memory
+						 *  enabled (required in d0ix
+						 *  flow)
+						 */
+
+void cpu_power_down_core(uint32_t flags);
 
 void cpu_alloc_core_context(int id);
 
@@ -28,6 +35,8 @@ int arch_cpu_enabled_cores(void);
 
 int arch_cpu_restore_secondary_cores(void);
 
+int arch_cpu_secondary_cores_prepare_d0ix(void);
+
 #else
 
 static inline int arch_cpu_enable_core(int id) { return 0; }
@@ -39,6 +48,8 @@ static inline int arch_cpu_is_core_enabled(int id) { return 1; }
 static inline int arch_cpu_enabled_cores(void) { return 1; }
 
 static inline int arch_cpu_restore_secondary_cores(void) {return 0; }
+
+static inline int arch_cpu_secondary_cores_prepare_d0ix(void) {return 0; }
 
 #endif
 

--- a/src/arch/xtensa/lib/cpu.c
+++ b/src/arch/xtensa/lib/cpu.c
@@ -164,7 +164,7 @@ void cpu_power_down_core(void)
 {
 	arch_interrupt_global_disable();
 
-	idc_free();
+	idc_free(0);
 
 	schedule_free();
 

--- a/src/arch/xtensa/lib/cpu.c
+++ b/src/arch/xtensa/lib/cpu.c
@@ -166,7 +166,7 @@ void cpu_power_down_core(void)
 
 	idc_free(0);
 
-	schedule_free();
+	schedule_free(0);
 
 	free_system_notify();
 

--- a/src/drivers/intel/cavs/idc.c
+++ b/src/drivers/intel/cavs/idc.c
@@ -279,7 +279,7 @@ int platform_idc_restore(void)
 /**
  * \brief Frees IDC data and unregisters interrupt.
  */
-void idc_free(void)
+void idc_free(uint32_t flags)
 {
 	struct idc *idc = *idc_get();
 	int core = cpu_get_id();
@@ -298,6 +298,9 @@ void idc_free(void)
 		if (idctfc & IPC_IDCTFC_BUSY)
 			idc_write(IPC_IDCTFC(i), core, idctfc);
 	}
+
+	if (flags & IDC_FREE_IRQ_ONLY)
+		return;
 
 	schedule_task_free(&idc->idc_task);
 }

--- a/src/idc/idc.c
+++ b/src/idc/idc.c
@@ -336,3 +336,23 @@ int idc_init(void)
 	return 0;
 #endif
 }
+
+int idc_restore(void)
+{
+	struct idc **idc = idc_get();
+
+	tr_info(&idc_tr, "idc_restore()");
+
+	/* idc_restore() is invoked during D0->D0ix/D0ix->D0 flow. In that
+	 * case basic core structures e.g. idc struct should be already
+	 * allocated (in D0->D0ix primary core disables all secondary cores, but
+	 * memory has not been powered off).
+	 */
+	assert(*idc);
+
+#ifndef __ZEPHYR__
+	return platform_idc_restore();
+#endif
+
+	return 0;
+}

--- a/src/include/sof/drivers/idc.h
+++ b/src/include/sof/drivers/idc.h
@@ -132,6 +132,8 @@ void idc_free(void);
 
 int platform_idc_init(void);
 
+int platform_idc_restore(void);
+
 enum task_state idc_do_cmd(void *data);
 
 void idc_cmd(struct idc_msg *msg);

--- a/src/include/sof/drivers/idc.h
+++ b/src/include/sof/drivers/idc.h
@@ -88,6 +88,10 @@
 #define IDC_MSG_RESET		IDC_TYPE(0x8)
 #define IDC_MSG_RESET_EXT(x)	IDC_EXTENSION(x)
 
+/** \brief IDC prepare D0ix message. */
+#define IDC_MSG_PREPARE_D0ix		IDC_TYPE(0x9)
+#define IDC_MSG_PREPARE_D0ix_EXT	IDC_EXTENSION(0x0)
+
 /** \brief Decodes IDC message type. */
 #define iTS(x)	(((x) >> IDC_TYPE_SHIFT) & IDC_TYPE_MASK)
 

--- a/src/include/sof/drivers/idc.h
+++ b/src/include/sof/drivers/idc.h
@@ -94,6 +94,9 @@
 /** \brief Max IDC message payload size in bytes. */
 #define IDC_MAX_PAYLOAD_SIZE	96
 
+/** \brief IDC free function flags */
+#define IDC_FREE_IRQ_ONLY	BIT(0)	/**< disable only irqs */
+
 /** \brief IDC message payload. */
 struct idc_payload {
 	uint8_t data[IDC_MAX_PAYLOAD_SIZE];
@@ -128,7 +131,7 @@ static inline struct idc_payload *idc_payload_get(struct idc *idc,
 
 void idc_enable_interrupts(int target_core, int source_core);
 
-void idc_free(void);
+void idc_free(uint32_t flags);
 
 int platform_idc_init(void);
 

--- a/src/include/sof/lib/cpu.h
+++ b/src/include/sof/lib/cpu.h
@@ -56,6 +56,11 @@ static inline int cpu_enabled_cores(void)
 	return arch_cpu_enabled_cores();
 }
 
+static inline int cpu_restore_secondary_cores(void)
+{
+	return arch_cpu_restore_secondary_cores();
+}
+
 #endif
 
 #endif /* __SOF_LIB_CPU_H__ */

--- a/src/include/sof/lib/cpu.h
+++ b/src/include/sof/lib/cpu.h
@@ -61,6 +61,11 @@ static inline int cpu_restore_secondary_cores(void)
 	return arch_cpu_restore_secondary_cores();
 }
 
+static inline int cpu_secondary_cores_prepare_d0ix(void)
+{
+	return arch_cpu_secondary_cores_prepare_d0ix();
+}
+
 #endif
 
 #endif /* __SOF_LIB_CPU_H__ */

--- a/src/include/sof/schedule/schedule.h
+++ b/src/include/sof/schedule/schedule.h
@@ -117,6 +117,15 @@ struct scheduler_ops {
 	 * This operation is optional.
 	 */
 	void (*scheduler_free)(void *data);
+
+	/**
+	 * Restores scheduler's resources.
+	 * @param data Private data of selected scheduler.
+	 * @return 0 if succeeded, error code otherwise.
+	 *
+	 * This operation is optional.
+	 */
+	int (*scheduler_restore)(void *data);
 };
 
 /** \brief Holds information about scheduler. */
@@ -288,6 +297,24 @@ static inline void schedule_free(void)
 		if (sch->ops->scheduler_free)
 			sch->ops->scheduler_free(sch->data);
 	}
+}
+
+/** See scheduler_ops::scheduler_restore */
+static inline int schedulers_restore(void)
+{
+	struct schedulers *schedulers = *arch_schedulers_get();
+	struct schedule_data *sch;
+	struct list_item *slist;
+
+	assert(schedulers);
+
+	list_for_item(slist, &schedulers->list) {
+		sch = container_of(slist, struct schedule_data, list);
+		if (sch->ops->scheduler_restore)
+			return sch->ops->scheduler_restore(sch->data);
+	}
+
+	return 0;
 }
 
 /**

--- a/src/include/sof/schedule/schedule.h
+++ b/src/include/sof/schedule/schedule.h
@@ -35,6 +35,11 @@ enum {
 	SOF_SCHEDULE_COUNT	/**< indicates number of scheduler types */
 };
 
+/** \brief Scheduler free available flags */
+#define SOF_SCHEDULER_FREE_IRQ_ONLY	BIT(0) /**< Free function disables only
+						 *  interrupts
+						 */
+
 /**
  * Scheduler operations.
  *
@@ -112,11 +117,12 @@ struct scheduler_ops {
 	/**
 	 * Frees scheduler's resources.
 	 * @param data Private data of selected scheduler.
+	 * @param flags Function specific flags.
 	 * @return 0 if succeeded, error code otherwise.
 	 *
 	 * This operation is optional.
 	 */
-	void (*scheduler_free)(void *data);
+	void (*scheduler_free)(void *data, uint32_t flags);
 
 	/**
 	 * Restores scheduler's resources.
@@ -286,7 +292,7 @@ static inline int schedule_task_free(struct task *task)
 }
 
 /** See scheduler_ops::scheduler_free */
-static inline void schedule_free(void)
+static inline void schedule_free(uint32_t flags)
 {
 	struct schedulers *schedulers = *arch_schedulers_get();
 	struct schedule_data *sch;
@@ -295,7 +301,7 @@ static inline void schedule_free(void)
 	list_for_item(slist, &schedulers->list) {
 		sch = container_of(slist, struct schedule_data, list);
 		if (sch->ops->scheduler_free)
-			sch->ops->scheduler_free(sch->data);
+			sch->ops->scheduler_free(sch->data, flags);
 	}
 }
 

--- a/src/ipc/ipc3/handler.c
+++ b/src/ipc/ipc3/handler.c
@@ -707,6 +707,15 @@ static int ipc_pm_gate(uint32_t header)
 		cpu_restore_secondary_cores();
 #endif
 	} else {
+		/* before we enable pm runtime and perform D0->D0ix flow
+		 * (primary core powers off secondary cores in
+		 * platform_pg_int_handler) we have to prepare all secondary
+		 * cores data for powering off (disable interrupt, perform
+		 * cache writeback).
+		 */
+#if (CONFIG_CAVS_LPS)
+		cpu_secondary_cores_prepare_d0ix();
+#endif
 		pm_runtime_enable(PM_RUNTIME_DSP, PLATFORM_PRIMARY_CORE_ID);
 	}
 

--- a/src/ipc/ipc3/handler.c
+++ b/src/ipc/ipc3/handler.c
@@ -701,10 +701,14 @@ static int ipc_pm_gate(uint32_t header)
 	if (pm_gate.flags & SOF_PM_NO_TRACE)
 		trace_off();
 
-	if (pm_gate.flags & SOF_PM_PPG)
+	if (pm_gate.flags & SOF_PM_PPG) {
 		pm_runtime_disable(PM_RUNTIME_DSP, PLATFORM_PRIMARY_CORE_ID);
-	else
+#if (CONFIG_CAVS_LPS)
+		cpu_restore_secondary_cores();
+#endif
+	} else {
 		pm_runtime_enable(PM_RUNTIME_DSP, PLATFORM_PRIMARY_CORE_ID);
+	}
 
 	/* resume dma trace if needed */
 	if (!(pm_gate.flags & SOF_PM_NO_TRACE))

--- a/src/platform/apollolake/include/platform/lib/pm_runtime.h
+++ b/src/platform/apollolake/include/platform/lib/pm_runtime.h
@@ -48,6 +48,12 @@ void platform_pm_runtime_enable(uint32_t context, uint32_t index);
 
 void platform_pm_runtime_disable(uint32_t context, uint32_t index);
 
+void platform_pm_runtime_prepare_d0ix_en(uint32_t index);
+
+void platform_pm_runtime_prepare_d0ix_dis(uint32_t index);
+
+int platform_pm_runtime_prepare_d0ix_is_req(uint32_t index);
+
 bool platform_pm_runtime_is_active(uint32_t context, uint32_t index);
 
 /**

--- a/src/platform/cannonlake/include/platform/lib/pm_runtime.h
+++ b/src/platform/cannonlake/include/platform/lib/pm_runtime.h
@@ -47,6 +47,12 @@ void platform_pm_runtime_enable(uint32_t context, uint32_t index);
 
 void platform_pm_runtime_disable(uint32_t context, uint32_t index);
 
+void platform_pm_runtime_prepare_d0ix_en(uint32_t index);
+
+void platform_pm_runtime_prepare_d0ix_dis(uint32_t index);
+
+int platform_pm_runtime_prepare_d0ix_is_req(uint32_t index);
+
 bool platform_pm_runtime_is_active(uint32_t context, uint32_t index);
 
 /**

--- a/src/platform/icelake/include/platform/lib/pm_runtime.h
+++ b/src/platform/icelake/include/platform/lib/pm_runtime.h
@@ -47,6 +47,12 @@ void platform_pm_runtime_enable(uint32_t context, uint32_t index);
 
 void platform_pm_runtime_disable(uint32_t context, uint32_t index);
 
+void platform_pm_runtime_prepare_d0ix_en(uint32_t index);
+
+void platform_pm_runtime_prepare_d0ix_dis(uint32_t index);
+
+int platform_pm_runtime_prepare_d0ix_is_req(uint32_t index);
+
 bool platform_pm_runtime_is_active(uint32_t context, uint32_t index);
 
 /**

--- a/src/platform/intel/cavs/include/cavs/drivers/idc.h
+++ b/src/platform/intel/cavs/include/cavs/drivers/idc.h
@@ -20,6 +20,8 @@ int idc_send_msg(struct idc_msg *msg, uint32_t mode);
 
 int idc_init(void);
 
+int idc_restore(void);
+
 #else
 
 static inline int idc_send_msg(struct idc_msg *msg, uint32_t mode) { return 0; }

--- a/src/platform/intel/cavs/include/cavs/lib/pm_runtime.h
+++ b/src/platform/intel/cavs/include/cavs/lib/pm_runtime.h
@@ -31,6 +31,9 @@ struct cavs_pm_runtime_data {
 	bool dsp_d0; /**< dsp target D0(true) or D0ix(false) */
 	int host_dma_l1_sref; /**< ref counter for Host DMA accesses */
 	uint32_t sleep_core_mask; /**< represents cores in waiti state */
+	uint32_t prepare_d0ix_core_mask; /**< indicates whether core needs */
+					   /**< to prepare to d0ix power down */
+					   /**<	before next waiti */
 	int dsp_client_bitmap[CONFIG_CORE_COUNT]; /**< simple pwr override */
 };
 

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -538,6 +538,18 @@ void platform_wait_for_interrupt(int level)
 {
 	platform_clock_on_waiti();
 
+#ifdef CONFIG_MULTICORE
+	int cpu_id = cpu_get_id();
+
+	/* for secondary cores, if prepare_d0ix_core_mask flag is set for
+	 * specific core, we should prepare for power down before going to wait
+	 * - it is required by D0->D0ix flow.
+	 */
+	if (cpu_id != PLATFORM_PRIMARY_CORE_ID &&
+	    platform_pm_runtime_prepare_d0ix_is_req(cpu_id))
+		cpu_power_down_core(CPU_POWER_DOWN_MEMORY_ON);
+#endif
+
 #if (CONFIG_CAVS_LPS)
 	if (pm_runtime_is_active(PM_RUNTIME_DSP, PLATFORM_PRIMARY_CORE_ID) ||
 	    cpu_get_id() != PLATFORM_PRIMARY_CORE_ID)

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -539,7 +539,8 @@ void platform_wait_for_interrupt(int level)
 	platform_clock_on_waiti();
 
 #if (CONFIG_CAVS_LPS)
-	if (pm_runtime_is_active(PM_RUNTIME_DSP, PLATFORM_PRIMARY_CORE_ID))
+	if (pm_runtime_is_active(PM_RUNTIME_DSP, PLATFORM_PRIMARY_CORE_ID) ||
+	    cpu_get_id() != PLATFORM_PRIMARY_CORE_ID)
 		arch_wait_for_interrupt(level);
 	else
 		lps_wait_for_interrupt(level);

--- a/src/platform/library/include/platform/drivers/idc.h
+++ b/src/platform/library/include/platform/drivers/idc.h
@@ -28,6 +28,11 @@ static inline int idc_init(void)
 	return 0;
 }
 
+static inline int idc_restore(void)
+{
+	return 0;
+}
+
 #endif /* __PLATFORM_DRIVERS_IDC_H__ */
 
 #else

--- a/src/platform/library/schedule/edf_schedule.c
+++ b/src/platform/library/schedule/edf_schedule.c
@@ -85,7 +85,7 @@ int scheduler_init_edf(void)
 	return 0;
 }
 
-static void edf_scheduler_free(void *data)
+static void edf_scheduler_free(void *data, uint32_t flags)
 {
 	free(data);
 }

--- a/src/platform/suecreek/include/platform/lib/pm_runtime.h
+++ b/src/platform/suecreek/include/platform/lib/pm_runtime.h
@@ -49,6 +49,12 @@ void platform_pm_runtime_disable(uint32_t context, uint32_t index);
 
 bool platform_pm_runtime_is_active(uint32_t context, uint32_t index);
 
+void platform_pm_runtime_prepare_d0ix_en(uint32_t index);
+
+void platform_pm_runtime_prepare_d0ix_dis(uint32_t index);
+
+int platform_pm_runtime_prepare_d0ix_is_req(uint32_t index);
+
 #endif /* __PLATFORM_LIB_PM_RUNTIME_H__ */
 
 #else

--- a/src/platform/tigerlake/include/platform/lib/pm_runtime.h
+++ b/src/platform/tigerlake/include/platform/lib/pm_runtime.h
@@ -47,6 +47,12 @@ void platform_pm_runtime_enable(uint32_t context, uint32_t index);
 
 void platform_pm_runtime_disable(uint32_t context, uint32_t index);
 
+void platform_pm_runtime_prepare_d0ix_en(uint32_t index);
+
+void platform_pm_runtime_prepare_d0ix_dis(uint32_t index);
+
+int platform_pm_runtime_prepare_d0ix_is_req(uint32_t index);
+
 bool platform_pm_runtime_is_active(uint32_t context, uint32_t index);
 
 /**

--- a/src/schedule/edf_schedule.c
+++ b/src/schedule/edf_schedule.c
@@ -298,6 +298,29 @@ static void scheduler_free_edf(void *data)
 	irq_local_enable(flags);
 }
 
+static int scheduler_restore_edf(void *data)
+{
+	struct edf_schedule_data *edf_sch = data;
+	uint32_t flags;
+
+	irq_local_disable(flags);
+
+	edf_sch->irq = interrupt_get_irq(PLATFORM_SCHEDULE_IRQ,
+					 PLATFORM_SCHEDULE_IRQ_NAME);
+
+	if (edf_sch->irq < 0) {
+		tr_err(&edf_tr, "scheduler_restore_edf(): getting irq failed.");
+		return edf_sch->irq;
+	}
+
+	interrupt_register(edf_sch->irq, edf_scheduler_run, edf_sch);
+	interrupt_enable(edf_sch->irq, edf_sch);
+
+	irq_local_enable(flags);
+
+	return 0;
+}
+
 static void schedule_edf(struct edf_schedule_data *edf_sch)
 {
 	interrupt_set(edf_sch->irq);
@@ -311,4 +334,5 @@ static const struct scheduler_ops schedule_edf_ops = {
 	.schedule_task_cancel	= schedule_edf_task_cancel,
 	.schedule_task_free	= schedule_edf_task_free,
 	.scheduler_free		= scheduler_free_edf,
+	.scheduler_restore	= scheduler_restore_edf,
 };

--- a/src/schedule/edf_schedule.c
+++ b/src/schedule/edf_schedule.c
@@ -281,21 +281,22 @@ int scheduler_init_edf(void)
 	return 0;
 }
 
-static void scheduler_free_edf(void *data)
+static void scheduler_free_edf(void *data, uint32_t flags)
 {
 	struct edf_schedule_data *edf_sch = data;
-	uint32_t flags;
+	uint32_t irq_flags;
 
-	irq_local_disable(flags);
+	irq_local_disable(irq_flags);
 
 	/* disable and unregister EDF scheduler interrupt */
 	interrupt_disable(edf_sch->irq, edf_sch);
 	interrupt_unregister(edf_sch->irq, edf_sch);
 
-	/* free main task context */
-	task_main_free();
+	if (!(flags & SOF_SCHEDULER_FREE_IRQ_ONLY))
+		/* free main task context */
+		task_main_free();
 
-	irq_local_enable(flags);
+	irq_local_enable(irq_flags);
 }
 
 static int scheduler_restore_edf(void *data)

--- a/src/schedule/ll_schedule.c
+++ b/src/schedule/ll_schedule.c
@@ -646,6 +646,7 @@ static const struct scheduler_ops schedule_ll_ops = {
 	.schedule_task_cancel	= schedule_ll_task_cancel,
 	.reschedule_task	= reschedule_ll_task,
 	.scheduler_free		= scheduler_free_ll,
+	.scheduler_restore	= NULL,
 	.schedule_task_running	= NULL,
 	.schedule_task_complete	= NULL,
 };

--- a/src/schedule/ll_schedule.c
+++ b/src/schedule/ll_schedule.c
@@ -570,17 +570,20 @@ out:
 	return 0;
 }
 
-static void scheduler_free_ll(void *data)
+static void scheduler_free_ll(void *data, uint32_t flags)
 {
 	struct ll_schedule_data *sch = data;
-	uint32_t flags;
+	uint32_t irq_flags;
 
-	irq_local_disable(flags);
+	if (flags & SOF_SCHEDULER_FREE_IRQ_ONLY)
+		return;
+
+	irq_local_disable(irq_flags);
 
 	notifier_unregister(sch, NULL,
 			    NOTIFIER_CLK_CHANGE_ID(sch->domain->clk));
 
-	irq_local_enable(flags);
+	irq_local_enable(irq_flags);
 }
 
 static void ll_scheduler_recalculate_tasks(struct ll_schedule_data *sch,

--- a/src/schedule/zephyr_ll.c
+++ b/src/schedule/zephyr_ll.c
@@ -434,7 +434,7 @@ static int zephyr_ll_task_cancel(void *data, struct task *task)
  * be active, but other schedulers ignore them too... And we don't need to free
  * the scheduler data - it's allocated in the SYS zone.
  */
-static void zephyr_ll_scheduler_free(void *data)
+static void zephyr_ll_scheduler_free(void *data, uint32_t flags)
 {
 	struct zephyr_ll *sch = data;
 

--- a/tools/testbench/common_test.c
+++ b/tools/testbench/common_test.c
@@ -72,7 +72,7 @@ void tb_pipeline_free(struct sof *sof)
 	free(*notify);
 
 	/* free all scheduler data */
-	schedule_free();
+	schedule_free(0);
 	schedulers = arch_schedulers_get();
 	list_for_item_safe(slist, _slist, &(*schedulers)->list) {
 		sch = container_of(slist, struct schedule_data, list);

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -764,6 +764,12 @@ int arch_cpu_restore_secondary_cores(void)
 	return 0;
 }
 
+int arch_cpu_secondary_cores_prepare_d0ix(void)
+{
+	/* TODO: use Zephyr version */
+	return 0;
+}
+
 void arch_cpu_disable_core(int id)
 {
 	/* TODO: call Zephyr API */
@@ -774,7 +780,7 @@ int arch_cpu_is_core_enabled(int id)
 	return arch_cpu_active(id);
 }
 
-void cpu_power_down_core(void)
+void cpu_power_down_core(uint32_t flags)
 {
 	/* TODO: use Zephyr version */
 }

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -758,6 +758,12 @@ int arch_cpu_enable_core(int id)
 	return 0;
 }
 
+int arch_cpu_restore_secondary_cores(void)
+{
+	/* TODO: use Zephyr version */
+	return 0;
+}
+
 void arch_cpu_disable_core(int id)
 {
 	/* TODO: call Zephyr API */


### PR DESCRIPTION
Primary core disables all secondary cores in platform_pg_int_handler() function when going to D0ix state. During coming out from D0ix state (D0ix -> D0), we are not able to restore secondary cores properly. This PR add commits that allow us to enable LPS flow to be used in multicore scenario properly. This PR:
- adds secondary cores data writeback before disabling them;
- adds secondary cores restore during D0->D0ix transition (pm_runtime_get, enable idc interrupt and send power up idc message);
- adds separate booting path in secondary_core_init() function i.e. in case when we have basic firmware structures already allocated (i.e. schedulers, notifier  etc.), which means we are not during cold boot process (memory has not been powered off), we just register and enable required interrupts.