### PR TITLE
Cherry-pick installer updates  to stable-v1.9, especially ADL links and new tarball target

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -30,7 +30,7 @@ jobs:
       # concurrently. It makes the build log unreadable but that's OK
       # because we have other, slower actions with readable logs.
       - name: build all and stage
-        run: ./scripts/docker-run.sh make -j3 -C installer/ stage
+        run: ./scripts/docker-run.sh make -j3 -C installer/ tarball
 
       - name: check staging tree
         run: make -C installer/ checktree

--- a/installer/GNUmakefile
+++ b/installer/GNUmakefile
@@ -22,7 +22,7 @@ SIGNED_list  ?= apl cnl icl jsl tgl tgl-h
 
 
 ALIAS_SAME_KEY_list  := glk cfl cml
-ALIAS_OTHER_KEY_list := ehl
+ALIAS_OTHER_KEY_list := ehl adl adl-s
 ALIAS_list ?= ${ALIAS_SAME_KEY_list} ${ALIAS_OTHER_KEY_list}
 
 $(info UNSIGNED_list = ${UNSIGNED_list} )
@@ -34,6 +34,8 @@ target_of_cfl := cnl
 target_of_cml := cnl
 
 target_of_ehl := tgl
+target_of_adl   := tgl
+target_of_adl-s := tgl-h
 
 ifeq (,${TOOLCHAIN})
   ifeq (,${XTENSA_TOOLS_ROOT})

--- a/installer/GNUmakefile
+++ b/installer/GNUmakefile
@@ -4,8 +4,8 @@
 
 
 .DEFAULT_GOAL := stage
-.PHONY: clean stage rsync
-.PHONY: signed unsigned ldicts topologies build_tools
+.PHONY: clean stage rsync tarball
+.PHONY: signed unsigned ldicts topologies tools build_tools
 .PHONY: compare signed_dummies
 
 # Override ?= variables in config.mk
@@ -69,7 +69,9 @@ STAGING_SOF_VERSION := ${STAGING_SOF}${VERSION_SUFFIX}
 
 STAGING_SOF_TPLG ?= staging/sof-tplg
 
-stage: signed unsigned ldicts aliases topologies
+STAGING_TOOLS ?= staging/tools
+
+stage: signed unsigned ldicts aliases topologies tools
 ifneq (${STAGING_SOF_VERSION},${STAGING_SOF})
 	ln -sfT sof${VERSION_SUFFIX} ${STAGING_SOF}
 	test -e ${STAGING_SOF}
@@ -96,7 +98,7 @@ FW_DESTDIR ?= /lib/firmware/intel/
 # The rsync target does not depend on any other target so:
 # - it's possible to deploy a staging _subset_, e.g.: only topologies
 #   only,...
-# - sudo never builds by accident
+# - "sudo make rsync" never builds as root by accident
 rsync:
 # The --mkpath option is too recent, dealing with both remote and local
 # would be complicated and this is also a safety against typos.
@@ -109,11 +111,32 @@ ifneq (${USER_DESTDIR},)
 endif
 
 clean:
-	${RM} -r staging/sof*
+	${RM} -r ${STAGING_SOF}* ${STAGING_SOF_TPLG}* ${STAGING_TOOLS}*
 	${RM} ${BUILDS_ROOT}/staging_sof_tree.txt
 
 cleanall: clean
 	${RM} -r "${BUILD_TOOLS}/" "${BUILDS_ROOT}"/build_*_?cc/
+
+
+      #####################################
+      ###           tarball            ####
+      #####################################
+
+tarball: stage
+	cd staging && tar cfz sof-build${VERSION_SUFFIX}.tgz \
+	  sof${VERSION_SUFFIX} sof-tplg${VERSION_SUFFIX} \
+	  tools${VERSION_SUFFIX}
+
+
+      #####################################
+      ###           Stage tools        ####
+      #####################################
+
+# This is only for the tarball, rsync takes the RELPATHS shortcut
+tools: build_tools
+	mkdir -p ${STAGING_TOOLS}${VERSION_SUFFIX}
+	cd ${BUILD_TOOLS} && \
+	  cp -p ${TOOLS_RELPATHS} ${CURDIR}/${STAGING_TOOLS}${VERSION_SUFFIX}
 
    ##########################################################
    ###  Stage sof-*.ri firmware files and symbolic links ####
@@ -276,6 +299,8 @@ checktree:
 	# Check two random topologies are there
 	test -f ${STAGING_SOF_TPLG}/sof-apl-nocodec.tplg
 	test -f ${STAGING_SOF_TPLG}/sof-imx8-wm8960.tplg
+	for t in sof-ctl sof-logger sof-probes; do \
+	   test -f ${STAGING_TOOLS}${VERSION_SUFFIX}/$${t}; done
 
 # Useful for testing this Makefile. COMPARE_REFS can be /lib/firmware,
 # sof-bin, a previous version of this Makefile,...

--- a/installer/GNUmakefile
+++ b/installer/GNUmakefile
@@ -5,7 +5,7 @@
 
 .DEFAULT_GOAL := stage
 .PHONY: clean stage rsync
-.PHONY: signed unsigned ldicts topologies
+.PHONY: signed unsigned ldicts topologies build_tools
 .PHONY: compare signed_dummies
 
 # Override ?= variables in config.mk
@@ -105,7 +105,7 @@ rsync:
 ifneq (${USER_DESTDIR},)
 	# TODO: add more user space binaries: sof-ctl, probes,...
 	# absorbe scripts/sof-target-install.sh
-	rsync -a ${BUILD_TOOLS}/logger/sof-logger ${USER_DESTDIR}
+	cd ${BUILD_TOOLS} && rsync -a ${TOOLS_RELPATHS} ${USER_DESTDIR}
 endif
 
 clean:
@@ -240,13 +240,25 @@ endif
 	@tree ${TREE_OPTS} ${STAGING_SOF_TPLG}${VERSION_SUFFIX} | \
             head -n 10; printf '├── ...\n..\n'
 
-# We should use more targets rather than set -e and a multi-lines script
-# but that would be verbose.
+
+             ######################
+             ### build-tools.sh ###
+             ######################
+
+TOOLS_RELPATHS  := ctl/sof-ctl  logger/sof-logger  probes/sof-probes
+TOOLS_TARGETS   := sof-ctl      sof-logger         sof-probes
+TOOLS_FLAGS     := -c           -l                 -p
+
+.PHONY: build_tools
+build_tools: ${BUILD_TOOLS}
+
+# We could use more targets rather than "set -e" with a multi-lines "for" loop.
+# That would be more flexible but also quite verbose.
 ${BUILD_TOOLS}:
 	set -e; if test -d ${BUILD_TOOLS}; then \
-        for i in topologies sof-logger; do \
+        for i in topologies ${TOOLS_TARGETS}; do \
           cmake --build ${BUILD_TOOLS} -- $$i; done; else         \
-          BUILD_TOOLS_DIR=${BUILD_TOOLS} ../scripts/build-tools.sh -T -l ; \
+          BUILD_TOOLS_DIR=${BUILD_TOOLS} ../scripts/build-tools.sh -T ${TOOLS_FLAGS} ; \
         fi
 
 

--- a/installer/GNUmakefile
+++ b/installer/GNUmakefile
@@ -293,7 +293,7 @@ COMPARE_REFS ?= /lib/firmware/intel
 
 checktree:
 	cd ${STAGING_SOF_VERSION} && \
-             tree -a --dirsfirst . >  ${BUILDS_ROOT}/staging_sof_tree.txt
+             tree -a -v --dirsfirst . >  ${BUILDS_ROOT}/staging_sof_tree.txt
 	# Update sof-apl-nocodec.tplg when adding or removing a default platform
 	diff -u tests/staging_sof_ref.txt ${BUILDS_ROOT}/staging_sof_tree.txt
 	# Check two random topologies are there

--- a/installer/tests/staging_sof_ref.txt
+++ b/installer/tests/staging_sof_ref.txt
@@ -1,5 +1,7 @@
 .
 ├── community
+│   ├── sof-adl-s.ri -> sof-tgl-h.ri
+│   ├── sof-adl.ri -> sof-tgl.ri
 │   ├── sof-apl.ri
 │   ├── sof-cfl.ri -> sof-cnl.ri
 │   ├── sof-cml.ri -> sof-cnl.ri
@@ -14,6 +16,10 @@
 │   ├── sof-cfl.ri -> sof-cnl.ri
 │   ├── sof-cml.ri -> sof-cnl.ri
 │   └── sof-glk.ri -> sof-apl.ri
+├── sof-adl-s.ldc -> sof-tgl-h.ldc
+├── sof-adl-s.ri -> intel-signed/sof-adl-s.ri
+├── sof-adl.ldc -> sof-tgl.ldc
+├── sof-adl.ri -> intel-signed/sof-adl.ri
 ├── sof-apl.ldc
 ├── sof-apl.ri -> intel-signed/sof-apl.ri
 ├── sof-bdw.ldc
@@ -41,4 +47,4 @@
 ├── sof-tgl.ldc
 └── sof-tgl.ri -> intel-signed/sof-tgl.ri
 
-2 directories, 39 files
+2 directories, 45 files


### PR DESCRIPTION
Clean cherry-picks, zero conflict