### PR TITLE
CODEOWNERS: add code owners for mt8195

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -18,6 +18,7 @@ src/include/sof/audio/kpb.h		@mrajwa
 src/include/sof/audio/mux.h		@akloniex
 src/include/sof/audio/codec_adapter/*	@cujomalainey @mrajwa @dbaluta
 src/include/sof/drivers/acp_dai_dma.h	@bhiregoudar @sunilkumardommati
+src/include/sof/drivers/afe*		@yaochunhung
 
 # audio component
 src/audio/src*				@singalsu
@@ -41,6 +42,7 @@ src/platform/suecreek/*			@lyakh
 src/arch/xtensa/debug/gdb/*		@mrajwa
 src/platform/imx8/**			@dbaluta
 src/platform/amd/**			@bhiregoudar @sunilkumardommati
+src/platform/mt8195/**		@yaochunhung @kuanhsuncheng
 
 # drivers
 src/drivers/intel/dmic.c		@singalsu
@@ -49,6 +51,7 @@ src/drivers/intel/haswell/*		@randerwang
 src/drivers/imx/**			@dbaluta
 src/drivers/dw/*			@lyakh
 src/drivers/amd/*			@bhiregoudar @sunilkumardommati
+src/drivers/mediatek/mt8195/*		@yaochunhung @kuanhsuncheng
 
 # other libs
 src/math/*				@singalsu


### PR DESCRIPTION
Add code owners of mt8195 for mediatek platform.

Signed-off-by: YC Hung <yc.hung@mediatek.com>
Signed-off-by: Allen-KH Cheng <allen-kh.cheng@mediatek.com>