### PR TITLE
drivers: imx: sdma: use %p to print dma_base(dma)

### DIFF
--- a/src/drivers/imx/sdma.c
+++ b/src/drivers/imx/sdma.c
@@ -163,8 +163,8 @@ static int sdma_register_init(struct dma *dma)
 	/* Wait for 10us */
 	ret = poll_for_register_delay(dma_base(dma) + SDMA_RESET, 1, 0, 1000);
 	if (ret < 0) {
-		tr_err(&sdma_tr, "SDMA reset error, base address 0x%08x",
-		       (uint32_t)dma_base(dma));
+		tr_err(&sdma_tr, "SDMA reset error, base address %p",
+		       (void *)dma_base(dma));
 		return ret;
 	}
 


### PR DESCRIPTION
Use %p so the higher 32 bits are not quietly lost if dma_base ever
becomes 64 bits.

Fixes commit be69f41befae ("drivers: imx: sdma: fix warning")

Issue found by chance in unrelated PR #4837

Signed-off-by: Marc Herbert <marc.herbert@intel.com>