### PR TITLE
Minor fixes

### DIFF
--- a/src/ipc/ipc-common.c
+++ b/src/ipc/ipc-common.c
@@ -231,8 +231,13 @@ int ipc_init(struct sof *sof)
 
 	/* init ipc data */
 	sof->ipc = rzalloc(SOF_MEM_ZONE_SYS_SHARED, 0, SOF_MEM_CAPS_RAM, sizeof(*sof->ipc));
+	if (!sof->ipc)
+		return -ENOMEM;
+
 	sof->ipc->comp_data = rzalloc(SOF_MEM_ZONE_SYS_SHARED, 0,
 				      SOF_MEM_CAPS_RAM, SOF_IPC_MSG_MAX_SIZE);
+	if (!sof->ipc->comp_data)
+		return -ENOMEM;
 
 	spinlock_init(&sof->ipc->lock);
 	list_init(&sof->ipc->msg_list);

--- a/src/platform/amd/renoir/platform.c
+++ b/src/platform/amd/renoir/platform.c
@@ -94,7 +94,10 @@ int platform_init(struct sof *sof)
 			sizeof(sof->dma_info->dma_array), PLATFORM_DEFAULT_CLOCK, true);
 	scheduler_init_ll(sof->platform_dma_domain);
 	/* initialize the host IPC mechanisms */
-	ipc_init(sof);
+	ret = ipc_init(sof);
+	if (ret < 0)
+		return ret;
+
 	/* initialize the DAI mechanisms */
 	ret = dai_init(sof);
 	if (ret < 0)

--- a/src/platform/baytrail/platform.c
+++ b/src/platform/baytrail/platform.c
@@ -253,7 +253,9 @@ int platform_init(struct sof *sof)
 
 	/* initialise the host IPC mechanisms */
 	trace_point(TRACE_BOOT_PLATFORM_IPC);
-	ipc_init(sof);
+	ret = ipc_init(sof);
+	if (ret < 0)
+		return ret;
 
 	trace_point(TRACE_BOOT_PLATFORM_DAI);
 	ret = dai_init(sof);

--- a/src/platform/haswell/platform.c
+++ b/src/platform/haswell/platform.c
@@ -226,7 +226,9 @@ int platform_init(struct sof *sof)
 
 	/* initialise the host IPC mechanisms */
 	trace_point(TRACE_BOOT_PLATFORM_IPC);
-	ipc_init(sof);
+	ret = ipc_init(sof);
+	if (ret < 0)
+		return ret;
 
 	trace_point(TRACE_BOOT_PLATFORM_DAI);
 	ret = dai_init(sof);

--- a/src/platform/imx8/platform.c
+++ b/src/platform/imx8/platform.c
@@ -193,7 +193,9 @@ int platform_init(struct sof *sof)
 	scheduler_init_ll(sof->platform_dma_domain);
 
 	/* initialize the host IPC mechanims */
-	ipc_init(sof);
+	ret = ipc_init(sof);
+	if (ret < 0)
+		return ret;
 
 	ret = dai_init(sof);
 	if (ret < 0)

--- a/src/platform/imx8m/platform.c
+++ b/src/platform/imx8m/platform.c
@@ -193,7 +193,9 @@ int platform_init(struct sof *sof)
 	scheduler_init_ll(sof->platform_dma_domain);
 
 	/* initialize the host IPC mechanims */
-	ipc_init(sof);
+	ret = ipc_init(sof);
+	if (ret < 0)
+		return ret;
 
 	ret = dai_init(sof);
 	if (ret < 0)

--- a/src/platform/imx8ulp/platform.c
+++ b/src/platform/imx8ulp/platform.c
@@ -181,7 +181,9 @@ int platform_init(struct sof *sof)
 	scheduler_init_ll(sof->platform_dma_domain);
 
 	/* initialize the host IPC mechanims */
-	ipc_init(sof);
+	ret = ipc_init(sof);
+	if (ret < 0)
+		return ret;
 
 	ret = dai_init(sof);
 	if (ret < 0)

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -491,7 +491,9 @@ int platform_init(struct sof *sof)
 
 	/* initialize the host IPC mechanisms */
 	trace_point(TRACE_BOOT_PLATFORM_IPC);
-	ipc_init(sof);
+	ret = ipc_init(sof);
+	if (ret < 0)
+		return ret;
 
 	/* initialize IDC mechanism */
 	trace_point(TRACE_BOOT_PLATFORM_IDC);

--- a/src/platform/mt8195/platform.c
+++ b/src/platform/mt8195/platform.c
@@ -206,7 +206,9 @@ int platform_init(struct sof *sof)
 	scheduler_init_ll(sof->platform_dma_domain);
 
 	/* initialize the host IPC mechanims */
-	ipc_init(sof);
+	ret = ipc_init(sof);
+	if (ret < 0)
+		return ret;
 
 	ret = dai_init(sof);
 	if (ret < 0)

--- a/src/trace/dma-trace.c
+++ b/src/trace/dma-trace.c
@@ -407,6 +407,10 @@ int dma_trace_enable(struct dma_trace_data *d)
 {
 	int err;
 
+	/* the existence of the trace buffer means the dma trace already initialized */
+	if (d->dmatb.addr)
+		return 0;
+
 	/* initialize dma trace buffer */
 	err = dma_trace_buffer_init(d);
 


### PR DESCRIPTION
The series includes 2 fixes:
1. return failure in case ipc_init() fails.
2. dma-trace: avoid multiple allocations to fix fuzzy IPC.