### PR TITLE
[TEST ONLY][DO NOT REVIEW] ll_schedule: don't re-enable the domain if no tasks are active

### DIFF
--- a/src/schedule/ll_schedule.c
+++ b/src/schedule/ll_schedule.c
@@ -238,7 +238,8 @@ static void schedule_ll_tasks_run(void *data)
 	}
 
 	/* tasks on current core finished, re-enable domain on it */
-	domain_enable(domain, core);
+	if (atomic_read(&sch->num_tasks))
+		domain_enable(domain, core);
 
 	spin_unlock(&domain->lock);
 


### PR DESCRIPTION
If the last task completes in a domain, don't re-enable it. It will be re-enabled when a new task is submitted.
