### PR TITLE
edf_schedule: don't assert if there is no extra task to run

### DIFF
--- a/src/schedule/edf_schedule.c
+++ b/src/schedule/edf_schedule.c
@@ -94,10 +94,9 @@ static void edf_scheduler_run(void *data)
 
 	irq_local_enable(flags);
 
-	/* having next task is mandatory */
-	assert(task_next);
-
-	schedule_edf_task_running(data, task_next);
+	/* schedule next pending task */
+	if (task_next)
+		schedule_edf_task_running(data, task_next);
 }
 
 static int schedule_edf_task(void *data, struct task *task, uint64_t start,


### PR DESCRIPTION
There could be no more EDF task to be run if the last one in the list is
finished, we don't need to assert in this case.

If the next EDF task gonna be scheduled, interrupt will be generated
again by calling to schedule_edf() in schedule_edf_task(), so it should
be safe to remove the schedule_edf_task_running() in no pending task
scenarios.

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>