### PR TITLE
dma-trace: Fixes aimed to make the re-configuration robust and cleaner

### DIFF
--- a/src/trace/dma-trace.c
+++ b/src/trace/dma-trace.c
@@ -307,6 +307,7 @@ static int dma_trace_start(struct dma_trace_data *d)
 			      "dma_trace_start(): DMA reconfiguration (active stream_tag: %u)",
 			      d->active_stream_tag);
 
+		schedule_task_cancel(&d->dmat_work);
 		err = dma_stop(d->dc.chan);
 		if (err < 0) {
 			mtrace_printf(LOG_LEVEL_ERROR,

--- a/src/trace/dma-trace.c
+++ b/src/trace/dma-trace.c
@@ -412,7 +412,7 @@ int dma_trace_enable(struct dma_trace_data *d)
 
 	if (err < 0) {
 		mtrace_printf(LOG_LEVEL_ERROR, "dma_trace_enable: buffer_init failed");
-		goto out;
+		return err;
 	}
 
 	/* It should be the very first sent log for easy identification. */


### PR DESCRIPTION
Within https://github.com/thesofproject/sof/pull/4860 from @keyonjie there were a fix for memory leak in dtrace which would have broke the SOF client support - we need to be able to remove and insert the dtrace, re-configuration is normal.

The problem is valid, but it has to be handled in a different way, this PR is providing that with a cleaner (I hope) implementation and a the same time makes the dtrace reconfiguration a bit more nicer.

I have tested it with the SOF client support (https://github.com/thesofproject/linux/pull/3136):
run `aplay -Dplughw:1,0 -fdat /dev/urandom` to keep the DSP on and run in loop:
```
sudo rmmod snd_sof_dma_trace
sleep 1
sudo modprobe snd_sof_dma_trace
sleep 1
```
