### PR TITLE
pipeline: always check pipeline_for_each_comp() return value

### DIFF
--- a/src/audio/pipeline/pipeline-graph.c
+++ b/src/audio/pipeline/pipeline-graph.c
@@ -236,9 +236,7 @@ static int pipeline_comp_complete(struct comp_dev *current,
 	current->period = ppl_data->p->period;
 	current->priority = ppl_data->p->priority;
 
-	pipeline_for_each_comp(current, ctx, dir);
-
-	return 0;
+	return pipeline_for_each_comp(current, ctx, dir);
 }
 
 int pipeline_complete(struct pipeline *p, struct comp_dev *source,
@@ -255,6 +253,7 @@ int pipeline_complete(struct pipeline *p, struct comp_dev *source,
 #else
 	int freq = 0;
 #endif
+	int ret;
 
 	pipe_info(p, "pipeline complete, clock freq %dHz", freq);
 
@@ -270,7 +269,7 @@ int pipeline_complete(struct pipeline *p, struct comp_dev *source,
 	/* now walk downstream from source component and
 	 * complete component task and pipeline initialization
 	 */
-	walk_ctx.comp_func(source, NULL, &walk_ctx, PPL_DIR_DOWNSTREAM);
+	ret = walk_ctx.comp_func(source, NULL, &walk_ctx, PPL_DIR_DOWNSTREAM);
 
 	p->source_comp = source;
 	p->sink_comp = sink;
@@ -279,7 +278,7 @@ int pipeline_complete(struct pipeline *p, struct comp_dev *source,
 	/* show heap status */
 	heap_trace_all(0);
 
-	return 0;
+	return ret;
 }
 
 static int pipeline_comp_reset(struct comp_dev *current,

--- a/src/audio/pipeline/pipeline-stream.c
+++ b/src/audio/pipeline/pipeline-stream.c
@@ -431,7 +431,7 @@ static int pipeline_comp_timestamp(struct comp_dev *current,
 	    (dev_comp_type(current) == SOF_COMP_DAI ||
 	    dev_comp_type(current) == SOF_COMP_SG_DAI)) {
 		platform_dai_timestamp(current, ppl_data->posn);
-		return -1;
+		return PPL_STATUS_PATH_STOP;
 	}
 
 	return pipeline_for_each_comp(current, ctx, dir);
@@ -453,7 +453,9 @@ void pipeline_get_timestamp(struct pipeline *p, struct comp_dev *host,
 	data.start = host;
 	data.posn = posn;
 
-	walk_ctx.comp_func(host, NULL, &walk_ctx, host->direction);
+	if (walk_ctx.comp_func(host, NULL, &walk_ctx, host->direction) !=
+	    PPL_STATUS_PATH_STOP)
+		pipe_warn(p, "pipeline_get_timestamp(): DAI position update failed");
 
 	/* set timestamp resolution */
 	posn->timestamp_ns = p->period * 1000;

--- a/src/audio/pipeline/pipeline-xrun.c
+++ b/src/audio/pipeline/pipeline-xrun.c
@@ -27,6 +27,7 @@
  */
 #define NO_XRUN_RECOVERY 1
 
+/* This function always returns success */
 static int pipeline_comp_xrun(struct comp_dev *current,
 			      struct comp_buffer *calling_buf,
 			      struct pipeline_walk_context *ctx, int dir)

--- a/src/ipc/ipc-helper.c
+++ b/src/ipc/ipc-helper.c
@@ -206,7 +206,6 @@ int ipc_pipeline_complete(struct ipc *ipc, uint32_t comp_id)
 	uint32_t pipeline_id;
 	struct ipc_comp_dev *ipc_ppl_source;
 	struct ipc_comp_dev *ipc_ppl_sink;
-	int ret;
 
 	/* check whether pipeline exists */
 	ipc_pipe = ipc_get_comp_by_id(ipc, comp_id);
@@ -264,10 +263,8 @@ int ipc_pipeline_complete(struct ipc *ipc, uint32_t comp_id)
 	tr_dbg(&ipc_tr, "ipc: pipe %d -> complete on comp %d", pipeline_id,
 	       comp_id);
 
-	ret = pipeline_complete(ipc_pipe->pipeline, ipc_ppl_source->cd,
-				ipc_ppl_sink->cd);
-
-	return ret;
+	return pipeline_complete(ipc_pipe->pipeline, ipc_ppl_source->cd,
+				 ipc_ppl_sink->cd);
 }
 
 int ipc_comp_free(struct ipc *ipc, uint32_t comp_id)


### PR DESCRIPTION
Make sure all pipeline_for_each_comp() return values are consistently checked.
