### PR TITLE
zephyr: apl: further reduce heap size

### DIFF
--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -76,7 +76,7 @@ __section(".heap_mem") static uint8_t __aligned(64) heapmem[HEAPMEM_SIZE];
 #if (CONFIG_HP_MEMORY_BANKS < 16)
 /* e.g. APL */
 #if defined __XCC__
-#define	HEAPMEM_SIZE	0x28000
+#define	HEAPMEM_SIZE	0x20000
 #else
 #define	HEAPMEM_SIZE	0x30000
 #endif


### PR DESCRIPTION
Recent changes increased the size of various sections, breaking linkage again. We need to make the linker calculate the heap size automatically but until that is ready, reduce the heap size further to fix the current breakage.
