### PR TITLE
topology: add max98390 2/4 codecs and bt_offload support

### DIFF
--- a/tools/topology/topology1/CMakeLists.txt
+++ b/tools/topology/topology1/CMakeLists.txt
@@ -137,6 +137,8 @@ set(TPLGS
 	"sof-tgl-max98357a-rt5682\;sof-tgl-rt1011-rt5682\;-DCODEC=RT1011\;-DFMT=s24le\;-DPLATFORM=tgl\;-DAMP_SSP=1"
 	"sof-tgl-max98357a-rt5682\;sof-tgl-max98357a-rt5682-rtnr\;-DCODEC=MAX98357A\;-DFMT=s16le\;-DPLATFORM=tgl\;-DAMP_SSP=1\;-DCHANNELS=2\;-DDMICPROC=eq-iir-volume\;-DRTNR"
 	"sof-tgl-max98357a-rt5682-rtnr-16kHz\;sof-tgl-max98357a-rt5682-rtnr-16kHz\;-DCODEC=MAX98357A\;-DFMT=s16le\;-DCHANNELS=2\;-DDMICPROC=eq-iir-volume\;-DRTNR"
+	"sof-tgl-max98357a-rt5682\;sof-adl-max98390-rt5682\;-DCODEC=MAX98390\;-DFMT=s32le\;-DPLATFORM=adl\;-DAMP_SSP=1\;-DBT_OFFLOAD"
+	"sof-tgl-max98357a-rt5682\;sof-adl-max98390-ssp2-rt5682-ssp0\;-DCODEC=MAX98390\;-DFMT=s32le\;-DPLATFORM=adl\;-DAMP_SSP=2"
 	"sof-tgl-max98373-rt5682\;sof-tgl-max98373-rt5682\;-DAMP_SSP=1"
 	"sof-tgl-max98373-rt5682\;sof-tgl-max98373-rt5682-igonr\;-DAMP_SSP=1\;-DIGO"
 	"sof-tgl-max98373-rt5682\;sof-tgl-max98373-rt5682-xperi\;-DAMP_SSP=1\;-DINCLUDE_IIR_EQ=1"

--- a/tools/topology/topology1/sof-tgl-max98357a-rt5682.m4
+++ b/tools/topology/topology1/sof-tgl-max98357a-rt5682.m4
@@ -104,6 +104,15 @@ ifdef(`RTNR',`', define(DMIC16KPROC, rtnr))
 # include the generic dmic if RTNR is defined, else include generic dmic with kwd
 include(ifdef(`RTNR', platform/intel/intel-generic-dmic.m4, platform/intel/intel-generic-dmic-kwd.m4))
 
+ifdef(`BT_OFFLOAD', `
+# BT offload support
+define(`BT_PIPELINE_PB_ID', `13')
+define(`BT_PIPELINE_CP_ID', `14')
+define(`BT_DAI_LINK_ID', `8')
+define(`BT_PCM_ID', `7')
+define(`HW_CONFIG_ID', `8')
+include(`platform/intel/intel-generic-bt.m4')')
+
 dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,
 dnl     frames, deadline, priority, core)
@@ -180,6 +189,22 @@ DAI_ADD(sof/pipe-dai-playback.m4,
 	PIPELINE_SOURCE_1, 2, FMT,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
+ifelse(CODEC, `MAX98390', `
+# Low Latency capture pipeline 9 on PCM 6 using max 4 channels of s32le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
+	9, 6, 4, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# capture DAI is SSP1 using 2 periods
+# Buffers use FMT format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-capture.m4,
+	9, SSP, SPK_SSP_INDEX, SPK_SSP_NAME,
+	PIPELINE_SINK_9, 2, FMT,
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+',
+`
 # currently this dai is here as "virtual" capture backend
 W_DAI_IN(SSP, SPK_SSP_INDEX, SPK_SSP_NAME, FMT, 3, 0)
 
@@ -210,6 +235,7 @@ SectionGraph."PIPE_CAP_VIRT" {
 		dapm(ECHO REF 9, SPK_REF_DAI_NAME)
 	]
 }
+')
 
 # playback DAI is SSP0 using 2 periods
 # Buffers use s24le format, with 48 frame per 1000us on core 0 with priority 0
@@ -288,6 +314,12 @@ ifelse(
 		SSP_CLOCK(fsync, 48000, codec_slave),
 		SSP_TDM(4, 25, 3, 15),
 		SSP_CONFIG_DATA(SSP, SPK_SSP_INDEX, 24)))',
+	CODEC, `MAX98390', `
+	SSP_CONFIG(DSP_B, SSP_CLOCK(mclk, 19200000, codec_mclk_in),
+		SSP_CLOCK(bclk, 6144000, codec_slave),
+		SSP_CLOCK(fsync, 48000, codec_slave),
+		SSP_TDM(4, 32, 3, 15),
+	SSP_CONFIG_DATA(SSP, SPK_SSP_INDEX, 32)))',
 	)
 
 # SSP 0 (ID: 0)


### PR DESCRIPTION
This patch adds support for three configurations:

SSP1 connects max98390 2/4 speakers
SSP2 connects max98390 2 speakers

The SSP TDM configuration uses 4 slots for playback and
4 slots for the echo reference capture - regardless of the number of speakers.

UCM files in userspace specify which channels needs to be used on the specific platform.
There is no information reported by the topology/firmware related to valid channels.

Max98390 uses following channels mapping for playback and EchoRef capture
Chan 0 = Left
Chan 1 = Right
Chan 2 = Tweeter Left
Chan 3 = Tweeter Right
(Chan 0 and 1 with regular speakers;Chan 2 and 3 with tweeter speakers)

Adds SSP2 BT_OFFLOAD support in sof-adl-max98390-rt5682.tplg
sof-adl-max98390-ssp2-rt5682-ssp0.tplg doesn't due to ssp2 be used for speakers.
The BT_OFFLOAD feature required adl-003-drop-stable above. Because the dynamic pipeline has enabled when multiple SSPs creation.

Signed-off-by: Mac Chiang <mac.chiang@intel.com>