### PR TITLE
hda-dma: don't use AGGREGATE notifier for L1 exit

### DIFF
--- a/src/drivers/intel/hda/hda-dma.c
+++ b/src/drivers/intel/hda/hda-dma.c
@@ -437,8 +437,7 @@ static int hda_dma_host_start(struct dma_chan_data *channel)
 
 	/* Register common L1 exit for all channels */
 	ret = notifier_register(hda_chan, scheduler_get_data(SOF_SCHEDULE_LL_TIMER),
-				NOTIFIER_ID_LL_POST_RUN, hda_dma_l1_exit_notify,
-				NOTIFIER_FLAG_AGGREGATE);
+				NOTIFIER_ID_LL_POST_RUN, hda_dma_l1_exit_notify, 0);
 	if (ret < 0)
 		tr_err(&hdma_tr, "hda-dmac: %d channel %d, cannot register notification %d",
 		       channel->dma->plat_data.id, channel->index,
@@ -455,7 +454,7 @@ static void hda_dma_host_stop(struct dma_chan_data *channel)
 		return;
 
 	/* Unregister L1 exit */
-	notifier_unregister(NULL, scheduler_get_data(SOF_SCHEDULE_LL_TIMER),
+	notifier_unregister(hda_chan, scheduler_get_data(SOF_SCHEDULE_LL_TIMER),
 			    NOTIFIER_ID_LL_POST_RUN);
 }
 

--- a/src/platform/intel/cavs/include/cavs/lib/pm_runtime.h
+++ b/src/platform/intel/cavs/include/cavs/lib/pm_runtime.h
@@ -29,7 +29,7 @@ struct pm_runtime_data;
 /** \brief cAVS specific runtime power management data. */
 struct cavs_pm_runtime_data {
 	bool dsp_d0; /**< dsp target D0(true) or D0ix(false) */
-	int host_dma_l1_sref; /**< ref counter for Host DMA accesses */
+	int host_dma_l1_sref[CONFIG_CORE_COUNT]; /**< ref counter for Host DMA accesses */
 	uint32_t sleep_core_mask; /**< represents cores in waiti state */
 	int dsp_client_bitmap[CONFIG_CORE_COUNT]; /**< simple pwr override */
 };

--- a/src/platform/intel/cavs/lib/pm_runtime.c
+++ b/src/platform/intel/cavs/lib/pm_runtime.c
@@ -54,11 +54,12 @@ static void cavs_pm_runtime_host_dma_l1_get(void)
 {
 	struct pm_runtime_data *prd = pm_runtime_data_get();
 	struct cavs_pm_runtime_data *pprd = prd->platform_data;
+	int core = cpu_get_id();
 	uint32_t flags;
 
 	spin_lock_irq(&prd->lock, flags);
 
-	pprd->host_dma_l1_sref++;
+	pprd->host_dma_l1_sref[core]++;
 
 	spin_unlock_irq(&prd->lock, flags);
 }
@@ -71,11 +72,12 @@ static inline void cavs_pm_runtime_host_dma_l1_put(void)
 {
 	struct pm_runtime_data *prd = pm_runtime_data_get();
 	struct cavs_pm_runtime_data *pprd = prd->platform_data;
+	int core = cpu_get_id();
 	uint32_t flags;
 
 	spin_lock_irq(&prd->lock, flags);
 
-	if (!--pprd->host_dma_l1_sref) {
+	if (!--pprd->host_dma_l1_sref[core]) {
 		shim_write(SHIM_SVCFG,
 			   shim_read(SHIM_SVCFG) | SHIM_SVCFG_FORCE_L1_EXIT);
 


### PR DESCRIPTION
The notifier aggregate mode should be used for receivers who have no
receiver and caller difference, so that they can share the same handler
with a unified receiver, caller, and cb.

The hda_dma_l1_exit_notify() callbacks are registered for each hda_chan
as a separated receiver, and each hda_chan has its separated
l1_exit_needed flag, so we can't use the AGGREGATE notifier mode.

With this change, we need to specify the receiver for notifier
unregistering.

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>