### PR TITLE
topology: add max98390 2/4 codecs support

### DIFF
--- a/tools/topology/CMakeLists.txt
+++ b/tools/topology/CMakeLists.txt
@@ -132,6 +132,8 @@ set(TPLGS
 	"sof-tgl-max98357a-rt5682\;sof-tgl-max98357a-rt5682\;-DCODEC=MAX98357A\;-DFMT=s16le\;-DPLATFORM=tgl\;-DAMP_SSP=1"
 	"sof-tgl-max98357a-rt5682\;sof-adl-max98357a-rt5682\;-DCODEC=MAX98357A\;-DFMT=s16le\;-DPLATFORM=adl\;-DAMP_SSP=2"
 	"sof-tgl-max98357a-rt5682\;sof-tgl-max98357a-rt5682-pdm1\;-DCODEC=MAX98357A\;-DFMT=s16le\;-DDMIC_DAI_LINK_16k_PDM=STEREO_PDM1\;\;-DPLATFORM=tgl\;-DAMP_SSP=1"
+	"sof-tgl-max98357a-rt5682\;sof-adl-max98390-rt5682\;-DCODEC=MAX98390\;-DFMT=s32le\;-DPLATFORM=adl\;-DAMP_SSP=1\;-DBT_OFFLOAD"
+	"sof-tgl-max98357a-rt5682\;sof-adl-max98390-ssp2-rt5682-ssp0\;-DCODEC=MAX98390\;-DFMT=s32le\;-DPLATFORM=adl\;-DAMP_SSP=2"
 	"sof-tgl-max98357a-rt5682\;sof-tgl-rt1011-rt5682\;-DCODEC=RT1011\;-DFMT=s24le\;\;-DPLATFORM=tgl\;-DAMP_SSP=1"
 	"sof-tgl-max98373-rt5682\;sof-tgl-max98373-rt5682\;-DAMP_SSP=1"
 	"sof-tgl-max98373-rt5682\;sof-tgl-max98373-rt5682-igonr\;-DAMP_SSP=1\;-DIGO"


### PR DESCRIPTION
This patch adds support for three configurations:
SSP1 connects max98390 2/4 speakers
SSP2 connects max98390 2 speakers

The SSP TDM configuration uses 4 slots for playback and
4 slots for the echo reference capture - regardless of the number of speakers.

UCM files in userspace specify which channels needs to be used on the specific platform.
There is no information reported by the topology/firmware related to valid channels.

Max98390 uses following channels mapping for playback and EchoRef capture
Chan 0 = Left
Chan 1 = Right
Chan 2 = Tweeter Left
Chan 3 = Tweeter Right
(Chan 0 and 1 with regular speakers;Chan 2 and 3 with tweeter speakers)

Adds SSP2 BT_OFFLOAD support in sof-adl-max98390-rt5682.tplg
sof-adl-max98390-ssp2-rt5682-ssp0.tplg doesn't due to ssp2 be used for speakers.
The BT_OFFLOAD feature required adl-003-drop-stable above. Because the dynamic pipeline has enabled when multiple SSPs creation.

Signed-off-by: Mac Chiang <mac.chiang@intel.com>