### PR TITLE
lib: wait: Fix poll_for_register_delay() if delay is less then 8 ticks

### DIFF
--- a/src/lib/wait.c
+++ b/src/lib/wait.c
@@ -36,8 +36,13 @@ int poll_for_register_delay(uint32_t reg, uint32_t mask,
 	uint64_t delta = tick / tries;
 
 	if (!delta) {
-		delta = us;
-		tries = 1;
+		/*
+		 * If we want to wait for less than DEFAULT_TRY_TIMES ticks then
+		 * delta has to be set to 1 and number of tries to that of number
+		 * of ticks.
+		 */
+		delta = 1;
+		tries = tick;
 	}
 
 	while ((io_reg_read(reg) & mask) != val) {


### PR DESCRIPTION
The parameter for wait_delay() is in ticks, not in usec.
If the calculated delta (in ticks) is 0 then we should set the delta to the
number of tick the requested usec is translated and not the usec value
itself.

Signed-off-by: Peter Ujfalusi <peter.ujfalusi@linux.intel.com>