### PR TITLE
Audio: Optimize IIR performance

### DIFF
--- a/src/include/sof/math/iir_df2t.h
+++ b/src/include/sof/math/iir_df2t.h
@@ -60,4 +60,11 @@ struct iir_state_df2t {
 
 int32_t iir_df2t(struct iir_state_df2t *iir, int32_t x);
 
+/* Inline functions with or without HiFi3 intrinsics */
+#if IIR_HIFI3
+#include "iir_df2t_hifi3.h"
+#else
+#include "iir_df2t_generic.h"
+#endif
+
 #endif /* __SOF_MATH_IIR_DF2T_H__ */

--- a/src/include/sof/math/iir_df2t_generic.h
+++ b/src/include/sof/math/iir_df2t_generic.h
@@ -1,0 +1,34 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2021 Intel Corporation. All rights reserved.
+ *
+ * Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+ */
+
+#ifndef __IIR_DF2T_GENERIC_H__
+#define __IIR_DF2T_GENERIC_H__
+
+#include <stdint.h>
+
+static inline int16_t iir_df2t_s16(struct iir_state_df2t *iir, int16_t x)
+{
+	return sat_int16(Q_SHIFT_RND(iir_df2t(iir, ((int32_t)x) << 16), 31, 15));
+}
+
+static inline int32_t iir_df2t_s24(struct iir_state_df2t *iir, int32_t x)
+{
+	return sat_int24(Q_SHIFT_RND(iir_df2t(iir, x << 8), 31, 23));
+}
+
+static inline int16_t iir_df2t_s32_s16(struct iir_state_df2t *iir, int32_t x)
+{
+	return sat_int16(Q_SHIFT_RND(iir_df2t(iir, x), 31, 15));
+}
+
+static inline int32_t iir_df2t_s32_s24(struct iir_state_df2t *iir, int32_t x)
+{
+	return sat_int24(Q_SHIFT_RND(iir_df2t(iir, x), 31, 23));
+}
+
+#endif /* __IIR_DF2T_GENERIC_H__ */
+

--- a/src/include/sof/math/iir_df2t_hifi3.h
+++ b/src/include/sof/math/iir_df2t_hifi3.h
@@ -1,0 +1,43 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2021 Intel Corporation. All rights reserved.
+ *
+ * Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+ */
+
+#ifndef __IIR_DF2T_HIFI3_H__
+#define __IIR_DF2T_HIFI3_H__
+
+#include <xtensa/tie/xt_hifi3.h>
+#include <stdint.h>
+
+static inline int16_t iir_df2t_s16(struct iir_state_df2t *iir, int16_t x)
+{
+	ae_f32x2 y = iir_df2t(iir, ((int32_t)x) << 16);
+
+	return AE_ROUND16X4F32SSYM(y, y);
+}
+
+static inline int32_t iir_df2t_s24(struct iir_state_df2t *iir, int32_t x)
+{
+	ae_f32x2 y = iir_df2t(iir, x << 8);
+
+	return AE_SRAI32(AE_SLAI32S(AE_SRAI32R(y, 8), 8), 8);
+}
+
+static inline int16_t iir_df2t_s32_s16(struct iir_state_df2t *iir, int32_t x)
+{
+	ae_f32x2 y = iir_df2t(iir, x);
+
+	return AE_ROUND16X4F32SSYM(y, y);
+}
+
+static inline int32_t iir_df2t_s32_s24(struct iir_state_df2t *iir, int32_t x)
+{
+	ae_f32x2 y = iir_df2t(iir, x);
+
+	return AE_SRAI32(AE_SLAI32S(AE_SRAI32R(y, 8), 8), 8);
+}
+
+#endif /* __IIR_DF2T_HIFI3_H__ */
+


### PR DESCRIPTION
This patch optimizes the buffer copying and output scaling to
other format than int32_t. The main saving is from not using
read/write frag buffer access functions for every sample.

The saving of processing cycles consumption varies per platform
but a second order IIR stereo EQ on TGL shows 43% improvement for
average copy() duration.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>