### PR TITLE
[RFC] topology2: add mic extension and vendor mic config classes

### DIFF
--- a/tools/topology/topology2/include/dais/mic_config.conf
+++ b/tools/topology/topology2/include/dais/mic_config.conf
@@ -1,0 +1,111 @@
+# mic vendor config for nhlt type mic config
+#
+#	Object.Base.vendor_mic_config."0" {
+#		mic_type			0
+#		location			4
+#		speaker_position_distance	0
+#		horizontal_offset		0
+#		vertical_offset			0
+#		frequency_low_band		0
+#		frequency_high_band		0
+#		direction_angle			0
+#		elevation_angle			0
+#		vertical_angle_begin		0
+#		vertical_angle_end		0
+#		horizontal_angle_begin		0
+#		horizontal_angle_end		0
+#	}
+#
+#	Object.Base.vendor_mic_config."1" {
+#		mic_type			0
+#		location			4
+#		speaker_position_distance	0
+#		horizontal_offset		0
+#		vertical_offset			0
+#		frequency_low_band		0
+#		frequency_high_band		0
+#		direction_angle			0
+#		elevation_angle			0
+#		vertical_angle_begin		0
+#		vertical_angle_end		0
+#		horizontal_angle_begin		0
+#		horizontal_angle_end		0
+#	}
+#
+Class.Base."vendor_mic_config" {
+
+	DefineAttribute."mic_id" {}
+
+	# 0 Omnidirectional
+	# 1 Subcardioid
+	# 2 Cardioid
+	# 3 Supercardioid
+	# 4 Hypercardioid
+	# 5 Figure-8
+	# 6 Reserved
+	# 7 Vendordefined
+	DefineAttribute."mic_type" {}
+
+	# 0 Top
+	# 1 Bottom
+	# 2 Left
+	# 3 Right
+	# 4 Front (default)
+	# 5 Rear
+	DefineAttribute."location" {}
+
+	# in mm
+	DefineAttribute."speaker_position_distance" {}
+
+	# in mm
+	DefineAttribute."horizontal_offset" {}
+
+	# in mm
+	DefineAttribute."vertical_offset" {}
+
+	# 5 x Hz
+	DefineAttribute."frequency_low_band" {}
+
+	# 500 x Hz
+	DefineAttribute."frequency_low_band" {}
+
+	# -180 - + 180
+	DefineAttribute."direction_angle" {}
+
+	# -180 - + 180
+	DefineAttribute."elevation_angle" {}
+
+	# -180 - + 180 with 2 deg step
+	DefineAttribute."vertical_angle_begin" {}
+
+	# -180 - + 180 with 2 deg step
+	DefineAttribute."vertical_angle_end" {}
+
+	# -180 - + 180 with 2 deg step
+	DefineAttribute."horizontal_angle_begin" {}
+
+	# -180 - + 180 with 2 deg step
+	DefineAttribute."horizontal_angle_end" {}
+
+	attributes {
+		!constructor [
+			"mic_id"
+		]
+		!mandatory [
+			"mic_type"
+			"location"
+			"speaker_position_distance"
+			"horizontal_offset"
+			"vertical_offset"
+			"frequency_low_band"
+			"frequency_high_band"
+			"direction_angle"
+			"elevation_angle"
+			"vertical_angle_begin"
+			"vertical_angle_end"
+			"horizontal_angle_begin"
+			"horizontal_angle_end"
+		]
+		unique "mic_id"
+	}
+}

--- a/tools/topology/topology2/include/dais/mic_extension.conf
+++ b/tools/topology/topology2/include/dais/mic_extension.conf
@@ -1,0 +1,21 @@
+Class.Base."mic_extension" {
+
+	DefineAttribute."id" {}
+
+	# 16.16 fixed point value
+	DefineAttribute."snr" {}
+
+	# 16.16 fixed point value
+	DefineAttribute."sensitivity" {}
+
+	attributes {
+		!constructor [
+			"id"
+		]
+		!mandatory [
+			"snr"
+			"sensitivity"
+		]
+		unique "id"
+	}
+}


### PR DESCRIPTION
Add two classes to be used with dmic for nhlt conformance. Mic extension
includes snr and sensitivity values. Mic vendor config has multiple
values for defining the mic array geometry and mic positions.

Do not add tokens as these values are used currently only with nhlt
generation. Defining these classes in dmic is optional.

Signed-off-by: Jaska Uimonen <jaska.uimonen@intel.com>