### PR TITLE
topology2: nocodec: remove index initialization from DMIC instance

### DIFF
--- a/tools/topology/topology2/cavs-nocodec.conf
+++ b/tools/topology/topology2/cavs-nocodec.conf
@@ -67,7 +67,6 @@ Object.Dai {
 	DMIC."0" {
 		name NoCodec-6
 		id 6
-		index 0
 		driver_version		1
 		clk_min			500000
 		clk_max			4800000


### PR DESCRIPTION
The DMIC DAI does not have index attribute, so remove it.

Signed-off-by: Yong Zhi <yong.zhi@intel.com>