### PR TITLE
zephyr: ll_schedule: tasks in INIT state aren't on the task queue

### DIFF
--- a/src/schedule/zephyr_ll.c
+++ b/src/schedule/zephyr_ll.c
@@ -389,10 +389,10 @@ static int zephyr_ll_task_free(void *data, struct task *task)
 	 * one an additional flag must be used.
 	 */
 	switch (task->state) {
+	case SOF_TASK_STATE_INIT:
 	case SOF_TASK_STATE_FREE:
 		on_list = false;
 		/* fall through */
-	case SOF_TASK_STATE_INIT:
 	case SOF_TASK_STATE_QUEUED:
 		must_wait = false;
 		break;


### PR DESCRIPTION
Tasks in the INIT state aren't on the queue, calling schedule_task_free() for them causes a panic due to the task counter underrun. Don't try to dequeue such tasks.
