### PR TITLE
topology2: pcm/pipeline: add instance attribute

### DIFF
--- a/tools/topology/topology2/cavs-gain-hda.conf
+++ b/tools/topology/topology2/cavs-gain-hda.conf
@@ -167,6 +167,7 @@ Object.Pipeline {
 		}
 
 		format s16le
+		index 1
 	}
 	gain-playback.3 {
 		Object.Widget.pipeline.1 {
@@ -182,6 +183,7 @@ Object.Pipeline {
                 }
 
 		format s16le
+		index 3
 	}
 	gain-playback.5 {
 		Object.Widget.pipeline.1 {
@@ -197,6 +199,7 @@ Object.Pipeline {
                 }
 
 		format s16le
+		index 5
 	}
 	gain-playback.6 {
 		Object.Widget.pipeline.1 {
@@ -212,6 +215,7 @@ Object.Pipeline {
                 }
 
 		format s16le
+		index 6
 	}
 	gain-playback.7 {
 		Object.Widget.pipeline.1 {
@@ -227,6 +231,7 @@ Object.Pipeline {
                 }
 
 		format s16le
+		index 7
 	}
 	gain-capture.2 {
 		Object.Widget.pipeline.1 {
@@ -242,6 +247,7 @@ Object.Pipeline {
                 }
 
 		format s16le
+		index 2
 	}
 	gain-capture.4 {
 		Object.Widget.pipeline.1 {
@@ -257,11 +263,13 @@ Object.Pipeline {
                 }
 
 		format s16le
+		index 4
 	}
 }
 Object.PCM {
 	pcm.0 {
 		name 'HDA Analog'
+		id 0
 		Object.Base.fe_dai.'HDA Analog' [
 		]
 		Object.PCM.pcm_caps.playback {
@@ -276,6 +284,7 @@ Object.PCM {
 	}
 	pcm.1 {
 		name 'HDA Digital'
+		id 1
 		Object.Base.fe_dai.'HDA Digital' [
 		]
 		Object.PCM.pcm_caps.playback {
@@ -290,6 +299,7 @@ Object.PCM {
 	}
 	pcm.3 {
 		name HDMI1
+		id 3
 		Object.Base.fe_dai.HDMI1 [
 		]
 		Object.PCM.pcm_caps.playback {
@@ -300,6 +310,7 @@ Object.PCM {
 	}
 	pcm.4 {
 		name HDMI2
+		id 4
 		Object.Base.fe_dai.HDMI2 [
 		]
 		Object.PCM.pcm_caps.playback {
@@ -310,6 +321,7 @@ Object.PCM {
 	}
 	pcm.5 {
 		name HDMI3
+		id 5
 		Object.Base.fe_dai.HDMI3 [
 		]
 		Object.PCM.pcm_caps.playback {

--- a/tools/topology/topology2/cavs-nocodec.conf
+++ b/tools/topology/topology2/cavs-nocodec.conf
@@ -122,6 +122,7 @@ Object.Dai {
 Object.Pipeline {
 	passthrough-playback."1" {
 		format "s16le"
+		index 1
 
 		Object.Widget.pipeline.1.stream_name	"copier.SSP.1.0"
 
@@ -130,6 +131,7 @@ Object.Pipeline {
 
 	passthrough-capture."2" {
 		format		"s16le"
+		index 2
 
 		Object.Widget.pipeline.1.stream_name	"copier.SSP.2.1"
 
@@ -140,6 +142,7 @@ Object.Pipeline {
 Object.PCM {
 	pcm."0" {
 		name	"Port0"
+		id 0
 		direction	"duplex"
 		Object.Base.fe_dai."Port0" {}
 

--- a/tools/topology/topology2/cavs-sdw.conf
+++ b/tools/topology/topology2/cavs-sdw.conf
@@ -80,6 +80,7 @@ Object.Dai {
 Object.Pipeline {
 	passthrough-playback."2" {
 		format "s16le"
+		index 2
 
 		Object.Widget.pipeline.1.stream_name	"copier.ALH.2.0"
 
@@ -88,7 +89,7 @@ Object.Pipeline {
 
 	passthrough-capture."3" {
 		format	"s16le"
-
+		index 3
 		Object.Widget.pipeline.1.stream_name	"copier.ALH.3.0"
 
 		Object.Widget.copier.1.stream_name	"Passthrough Capture 0"
@@ -98,6 +99,7 @@ Object.Pipeline {
 Object.PCM {
 	pcm."0" {
 		name	"Jack out"
+		id 0
 		direction	"playback"
 		Object.Base.fe_dai."Jack out" {}
 
@@ -108,6 +110,7 @@ Object.PCM {
 	}
 	pcm."1" {
 		name	"Jack in"
+		id 1
 		direction	"capture"
 		Object.Base.fe_dai."Jack in" {}
 

--- a/tools/topology/topology2/cavs-windows-simple-pipeline.conf
+++ b/tools/topology/topology2/cavs-windows-simple-pipeline.conf
@@ -78,6 +78,7 @@ Object.Pipeline {
 		}
 
 		format s16le
+		index 1
 	}
 
 	gain-capture.2 {
@@ -94,6 +95,7 @@ Object.Pipeline {
                 }
 
 		format s16le
+		index 2
 	}
 }
 
@@ -112,12 +114,14 @@ Object.Pipeline {
                }
 
                 format s16le
+		index 3
         }
 }
 
 Object.PCM {
 	pcm.0 {
 		name 'HDA Analog'
+		id 0
 		Object.Base.fe_dai.'HDA Analog' [
 		]
 		Object.PCM.pcm_caps.playback {

--- a/tools/topology/topology2/include/common/pcm.conf
+++ b/tools/topology/topology2/include/common/pcm.conf
@@ -17,6 +17,8 @@ Class.PCM."pcm" {
 	# PCM name
 	DefineAttribute."name" {}
 
+	DefineAttribute."instance" {}
+
 	# PCM id
 	DefineAttribute."id" {}
 
@@ -53,7 +55,7 @@ Class.PCM."pcm" {
 		# pcm objects instantiated within the same alsaconf node must have unique
 		# id attribute
 		#
-		unique	"id"
+		unique	"instance"
 	}
 
 	# Default values for PCM attributes

--- a/tools/topology/topology2/include/pipelines/cavs/gain-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/gain-capture.conf
@@ -44,7 +44,7 @@ Class.Pipeline."gain-capture" {
 		# gain-capture objects instantiated within the same alsaconf node must have
 		# unique pipeline_id attribute
 		#
-		unique	"index"
+		unique	"instance"
 	}
 
 	Object.Widget {

--- a/tools/topology/topology2/include/pipelines/cavs/gain-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/gain-playback.conf
@@ -44,7 +44,7 @@ Class.Pipeline."gain-playback" {
 		# gain-playback objects instantiated within the same alsaconf node must have
 		# unique pipeline_id attribute
 		#
-		unique	"index"
+		unique	"instance"
 	}
 
 	Object.Widget {

--- a/tools/topology/topology2/include/pipelines/cavs/mixin-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixin-playback.conf
@@ -44,7 +44,7 @@ Class.Pipeline."mixin-playback" {
 		# mixin-playback objects instantiated within the same alsaconf node must have
 		# unique pipeline_id attribute
 		#
-		unique	"index"
+		unique	"instance"
 	}
 
 	Object.Widget {

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-gain-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-gain-playback.conf
@@ -44,7 +44,7 @@ Class.Pipeline."mixout-gain-playback" {
 		# mixout-gain-playback objects instantiated within the same alsaconf node must have
 		# unique pipeline_id attribute
 		#
-		unique	"index"
+		unique	"instance"
 	}
 
 	Object.Widget {

--- a/tools/topology/topology2/include/pipelines/cavs/passthrough-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/passthrough-capture.conf
@@ -43,7 +43,7 @@ Class.Pipeline."passthrough-capture" {
 		# passthrough-capture objects instantiated within the same alsaconf node must have
 		# unique pipeline_id attribute
 		#
-		unique	"index"
+		unique	"instance"
 	}
 
 	Object.Widget {

--- a/tools/topology/topology2/include/pipelines/cavs/passthrough-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/passthrough-playback.conf
@@ -43,7 +43,7 @@ Class.Pipeline."passthrough-playback" {
 		# passthrough-playback objects instantiated within the same alsaconf node must have
 		# unique pipeline_id attribute
 		#
-		unique	"index"
+		unique	"instance"
 	}
 
 	Object.Widget {

--- a/tools/topology/topology2/include/pipelines/eq-iir-volume-capture.conf
+++ b/tools/topology/topology2/include/pipelines/eq-iir-volume-capture.conf
@@ -43,7 +43,7 @@ Class.Pipeline."eq-iir-volume-capture" {
 		!immutable [
 			"direction"
 		]
-		unique	"index"
+		unique	"instance"
 	}
 
 	Object.Widget {

--- a/tools/topology/topology2/include/pipelines/passthrough-capture.conf
+++ b/tools/topology/topology2/include/pipelines/passthrough-capture.conf
@@ -40,7 +40,7 @@ Class.Pipeline."passthrough-capture" {
 		# passthrough-capture pipeline objects instantiated within the same alsaconf node must have
 		# unique index attribute
 		#
-		unique	"index"
+		unique	"instance"
 	}
 
 	Object.Widget {

--- a/tools/topology/topology2/include/pipelines/pipeline-common.conf
+++ b/tools/topology/topology2/include/pipelines/pipeline-common.conf
@@ -2,6 +2,9 @@
 # Common pipeline definitions. To be included in Class.Pipeline definitions
 #
 
+# pipeline instance of same pipeline class
+DefineAttribute."instance" {}
+
 # pipeline ID
 DefineAttribute."index" {}
 

--- a/tools/topology/topology2/include/pipelines/volume-capture.conf
+++ b/tools/topology/topology2/include/pipelines/volume-capture.conf
@@ -45,7 +45,7 @@ Class.Pipeline."volume-capture" {
 		# volume-capture objects instantiated within the same alsaconf node must have
 		# unique index attribute
 		#
-		unique	"index"
+		unique	"instance"
 	}
 
 	Object.Widget {

--- a/tools/topology/topology2/include/pipelines/volume-demux-playback.conf
+++ b/tools/topology/topology2/include/pipelines/volume-demux-playback.conf
@@ -43,7 +43,7 @@ Class.Pipeline."volume-demux-playback" {
 		!immutable [
 			"direction"
 		]
-		unique	"index"
+		unique	"instance"
 	}
 
 	Object.Widget {

--- a/tools/topology/topology2/include/pipelines/volume-playback.conf
+++ b/tools/topology/topology2/include/pipelines/volume-playback.conf
@@ -45,7 +45,7 @@ Class.Pipeline."volume-playback" {
 		# volume-playback objects instantiated within the same alsaconf node must have
 		# unique index attribute
 		#
-		unique	"index"
+		unique	"instance"
 	}
 
 	Object.Widget {


### PR DESCRIPTION
Add an instance attribute for all pipeline class definitions and the pcm
class. This will be used to instantiate unquir PCM/pipeline instances.

The ID attribute for PCM and the index attribute for pipeline may be the
same as the instance attribute in most cases. But in some cases, the
pipeline ID or the PCM index will be passed from the CMakeLists.txt file
as pre-processor definitions and they will be replaced as needed.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>