### PR TITLE
ll_schedule: only check tasks asked for rescheduling

### DIFF
--- a/src/schedule/ll_schedule.c
+++ b/src/schedule/ll_schedule.c
@@ -38,6 +38,31 @@ DECLARE_SOF_UUID("ll-schedule", ll_sched_uuid, 0x4f9c3ec7, 0x7b55, 0x400c,
 
 DECLARE_TR_CTX(ll_tr, SOF_UUID(ll_sched_uuid), LOG_LEVEL_INFO);
 
+/*
+ *        LL Scheduler Task State Transition Diagram
+ *
+ *         schedule_task() +---------+
+ *      +------------------|  INIT   |
+ *      |                  +---------+
+ *      |
+ *      v
+ * +--------+ is_pending() +---------+ is_pending() +----------+
+ * | QUEUED |------------->| PENDING |<-------------|RESCHEDULE|
+ * +--------+              +---------+              +----------+
+ *                              |                         ^
+ *                     execute()|                         |
+ *                              v                         |
+ *                         +---------+     task_run()     |
+ *                         | RUNNING |--------------------+
+ *                         +---------+     reschedule
+ *                              |
+ *                    task_run()|
+ *                    completed v
+ *                         +---------+
+ *                         |COMPLETED|
+ *                         +---------+
+ */
+
 /* one instance of data allocated per core */
 struct ll_schedule_data {
 	struct list_item tasks;			/* list of ll tasks */


### PR DESCRIPTION
In schedule_ll_client_reschedule(), we only need to check those tasks
who ask for rescheduling, for others (e.g. _COMPLETED ones), we should
not take them into account for next_tick calculation.

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>