### PR TITLE
tools: ctl: CMakeLists: Add -Wall and -Werror flags 

### DIFF
--- a/tools/ctl/CMakeLists.txt
+++ b/tools/ctl/CMakeLists.txt
@@ -8,6 +8,10 @@ target_link_libraries(sof-ctl PRIVATE
 	"-lasound"
 )
 
+target_compile_options(sof-ctl PRIVATE
+	-Wall -Werror
+)
+
 target_include_directories(sof-ctl PRIVATE
 	"${SOF_ROOT_SOURCE_DIRECTORY}/src/include"
 	"${SOF_ROOT_SOURCE_DIRECTORY}"

--- a/tools/ctl/ctl.c
+++ b/tools/ctl/ctl.c
@@ -287,11 +287,9 @@ static int ctl_setup(struct ctl_data *ctl_data)
 {
 	int mode = SND_CTL_NONBLOCK;
 	int ctrl_size;
-	int buffer_size;
 	int read;
 	int write;
 	int type;
-	char opt;
 	int ret;
 
 	/* Open the device, mixer control and get read/write/type properties.
@@ -376,8 +374,6 @@ static int ctl_setup(struct ctl_data *ctl_data)
 	}
 
 	return ret;
-buff_free:
-	buffer_free(ctl_data);
 
 value_free:
 	snd_ctl_elem_value_free(ctl_data->value);
@@ -494,6 +490,8 @@ static int ctl_set_get(struct ctl_data *ctl_data)
 		}
 		fprintf(stdout, "Success.\n");
 	}
+
+	return 0;
 }
 
 int main(int argc, char *argv[])
@@ -503,10 +501,6 @@ int main(int argc, char *argv[])
 	struct ctl_data *ctl_data;
 	char nname[256];
 	int ret = 0;
-	int n = 0;
-	int read;
-	int write;
-	int type;
 	int opt;
 	struct sof_abi_hdr *hdr;
 


### PR DESCRIPTION
These flags are required in order to ensure that ctl doesn't have any obvious bugs, for example undefined behaviour related bugs.

Also fix some of the things pointed out by these flags. One of them, the lack of a return value on a non-void function, had been reported as an actual internal bug due to a confusing error message showing up because of it.