### PR TITLE
zephyr: update print messages for 64-bit atomics

### DIFF
--- a/src/lib/dma.c
+++ b/src/lib/dma.c
@@ -85,7 +85,7 @@ struct dma *dma_get(uint32_t dir, uint32_t cap, uint32_t dev, uint32_t flags)
 		for (d = info->dma_array;
 		     d < info->dma_array + info->num_dmas;
 		     d++) {
-			tr_err(&dma_tr, " DMAC ID %d users %d busy channels %d",
+			tr_err(&dma_tr, " DMAC ID %d users %d busy channels %ld",
 			       d->plat_data.id, d->sref,
 			       atomic_read(&d->num_channels_busy));
 			tr_err(&dma_tr, "  caps 0x%x dev 0x%x",
@@ -116,7 +116,7 @@ struct dma *dma_get(uint32_t dir, uint32_t cap, uint32_t dev, uint32_t flags)
 	if (!ret)
 		dmin->sref++;
 
-	tr_info(&dma_tr, "dma_get() ID %d sref = %d busy channels %d",
+	tr_info(&dma_tr, "dma_get() ID %d sref = %d busy channels %ld",
 		dmin->plat_data.id, dmin->sref,
 		atomic_read(&dmin->num_channels_busy));
 

--- a/src/schedule/ll_schedule.c
+++ b/src/schedule/ll_schedule.c
@@ -108,7 +108,7 @@ static void schedule_ll_task_done(struct ll_schedule_data *sch,
 				  struct task *task)
 {
 	tr_info(&ll_tr, "task complete %p %pU", task, task->uid);
-	tr_info(&ll_tr, "num_tasks %d total_num_tasks %d",
+	tr_info(&ll_tr, "num_tasks %ld total_num_tasks %ld",
 		atomic_read(&sch->num_tasks),
 		atomic_read(&sch->domain->total_num_tasks));
 }
@@ -304,7 +304,7 @@ static int schedule_ll_domain_set(struct ll_schedule_data *sch,
 	tr_info(&ll_tr, "new added task->start %u at %u",
 		(unsigned int)task->start,
 		(unsigned int)platform_timer_get_atomic(timer_get()));
-	tr_info(&ll_tr, "num_tasks %d total_num_tasks %d",
+	tr_info(&ll_tr, "num_tasks %ld total_num_tasks %ld",
 		atomic_read(&sch->num_tasks),
 		atomic_read(&domain->total_num_tasks));
 
@@ -331,7 +331,7 @@ static void schedule_ll_domain_clear(struct ll_schedule_data *sch,
 	/* unregister the task */
 	domain_unregister(domain, task, atomic_read(&sch->num_tasks));
 
-	tr_info(&ll_tr, "num_tasks %d total_num_tasks %d",
+	tr_info(&ll_tr, "num_tasks %ld total_num_tasks %ld",
 		atomic_read(&sch->num_tasks),
 		atomic_read(&domain->total_num_tasks));
 

--- a/src/schedule/zephyr_ll.c
+++ b/src/schedule/zephyr_ll.c
@@ -50,7 +50,7 @@ static void zephyr_ll_task_done(struct zephyr_ll *sch,
 	task->state = SOF_TASK_STATE_FREE;
 
 	tr_info(&ll_tr, "task complete %p %pU", task, task->uid);
-	tr_info(&ll_tr, "num_tasks %d total_num_tasks %d",
+	tr_info(&ll_tr, "num_tasks %d total_num_tasks %ld",
 		sch->n_tasks, atomic_read(&sch->ll_domain->total_num_tasks));
 
 	/*


### PR DESCRIPTION
Atomics will use `long` rather than `int` so that they are 64-bit on 64-bit builds and 32-bit on 32-bit builds.

Required by zephyrproject-rtos/zephyr#39531
Originally at zephyrproject-rtos/sof#14

cc @lgirdwood @lyakh @kv2019i 