### PR TITLE
topology2: add dmic pipeline to nocodec topology

### DIFF
--- a/tools/topology/topology2/cavs-nocodec.conf
+++ b/tools/topology/topology2/cavs-nocodec.conf
@@ -94,7 +94,7 @@ Object.Dai {
 
 		Object.Widget.copier."1" {
 			index 3
-			dai_index 3
+			dai_index 0
 			type "dai_out"
 			dai_type "DMIC"
 			copier_type "DMIC"
@@ -110,7 +110,7 @@ Object.Dai {
 		Object.Base.pdm_config."0" {
 			ctrl_id	0
 		}
-        }
+	}
 }
 
 #
@@ -134,6 +134,14 @@ Object.Pipeline {
 
 		Object.Widget.copier.1.stream_name	"Passthrough Capture 0"
 	}
+
+	passthrough-capture."3" {
+		format	"s16le"
+
+		Object.Widget.pipeline.1.stream_name	"copier.DMIC.3.1"
+
+		Object.Widget.copier.1.stream_name	"Passthrough Capture 1"
+	}
 }
 
 Object.PCM {
@@ -152,6 +160,16 @@ Object.PCM {
 			formats 'S16_LE'
 		}
 	}
+	pcm."1" {
+		name	"DMIC"
+		direction	"capture"
+		Object.Base.fe_dai."DMIC" {}
+
+		Object.PCM.pcm_caps."capture" {
+			name "Passthrough Capture 1"
+			formats 'S16_LE'
+		}
+	}
 }
 
 Object.Base {
@@ -163,5 +181,11 @@ Object.Base {
 	route."1" {
 		source	"copier.SSP.2.1"
 		sink	"copier.host.2.1"
+	}
+
+	# bind pcm with host comp
+	route."2" {
+		source	"copier.DMIC.3.1"
+		sink	"copier.host.3.1"
 	}
 }


### PR DESCRIPTION
With dmic definition already in, add pipeline to make use of the pcm.

Signed-off-by: Yong Zhi <yong.zhi@intel.com>