### PR TITLE
Audio: Optimize saturation inline functions in format.h

### DIFF
--- a/src/include/sof/audio/format_generic.h
+++ b/src/include/sof/audio/format_generic.h
@@ -1,0 +1,43 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2021 Intel Corporation. All rights reserved.
+ */
+
+#ifndef __SOF_AUDIO_FORMAT_GENERIC_H__
+#define __SOF_AUDIO_FORMAT_GENERIC_H__
+
+#include <stdint.h>
+
+/* Saturation inline functions */
+
+static inline int32_t sat_int32(int64_t x)
+{
+	if (x > INT32_MAX)
+		return INT32_MAX;
+	else if (x < INT32_MIN)
+		return INT32_MIN;
+	else
+		return (int32_t)x;
+}
+
+static inline int32_t sat_int24(int32_t x)
+{
+	if (x > INT24_MAXVALUE)
+		return INT24_MAXVALUE;
+	else if (x < INT24_MINVALUE)
+		return INT24_MINVALUE;
+	else
+		return x;
+}
+
+static inline int16_t sat_int16(int32_t x)
+{
+	if (x > INT16_MAX)
+		return INT16_MAX;
+	else if (x < INT16_MIN)
+		return INT16_MIN;
+	else
+		return (int16_t)x;
+}
+
+#endif /* __SOF_AUDIO_FORMAT_GENERIC_H__ */

--- a/src/include/sof/audio/format_hifi3.h
+++ b/src/include/sof/audio/format_hifi3.h
@@ -1,0 +1,30 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2021 Intel Corporation. All rights reserved.
+ */
+
+#ifndef __SOF_AUDIO_FORMAT_HIFI3_H__
+#define __SOF_AUDIO_FORMAT_HIFI3_H__
+
+#include <xtensa/config/defs.h>
+#include <xtensa/tie/xt_hifi3.h>
+#include <stdint.h>
+
+/* Saturation inline functions */
+
+static inline int32_t sat_int32(int64_t x)
+{
+	return (ae_int32)AE_ROUND32F48SSYM(AE_SLAI64(x, 16));
+}
+
+static inline int32_t sat_int24(int32_t x)
+{
+	return AE_SRAI32(AE_SLAI32S(x, 8), 8);
+}
+
+static inline int16_t sat_int16(int32_t x)
+{
+	return AE_SAT16X4(x, x);
+}
+
+#endif /* __SOF_AUDIO_FORMAT_HIFI3_H__ */


### PR DESCRIPTION
This patch adds two included header files format_generic.h and
format_hifi3.h. The latter contains intrinsics operations
optimized versions of 16, 24, and 32 bit saturations. Generic
header contains the previous C versions those will be used
for anything else but xt-xcc HiFi3 compatible build.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>