### PR TITLE
component: allocate comp_dev on runtime_shared zone

### DIFF
--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -611,7 +611,12 @@ static inline struct comp_dev *comp_alloc(const struct comp_driver *drv,
 {
 	struct comp_dev *dev = NULL;
 
-	dev = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM, bytes);
+	/*
+	 * use uncached address at the moment to rule out multi-core failures,
+	 * may need to switch to the latest coherence API for performance
+	 * improvement later.
+	 */
+	dev = rzalloc(SOF_MEM_ZONE_RUNTIME_SHARED, 0, SOF_MEM_CAPS_RAM, bytes);
 	if (!dev)
 		return NULL;
 	dev->size = bytes;


### PR DESCRIPTION
Allocate comp_dev on runtime_shared zone to use uncached address to fix
cache coherency issue, this should not impact performance too much as it
is not frequently used buffer.

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>