### PR TITLE
Add multi-core coverage to CI

### DIFF
--- a/tools/topology/topology1/CMakeLists.txt
+++ b/tools/topology/topology1/CMakeLists.txt
@@ -83,7 +83,7 @@ set(TPLGS
 	"sof-cavs-nocodec\;sof-cml-nocodec\;-DPLATFORM=cml\;-DDYNAMIC=1"
 	"sof-cavs-nocodec\;sof-icl-nocodec\;-DPLATFORM=icl\;-DDYNAMIC=1"
 	"sof-cavs-nocodec\;sof-jsl-nocodec\;-DPLATFORM=jsl\;-DDYNAMIC=1"
-	"sof-cavs-nocodec\;sof-tgl-nocodec\;-DPLATFORM=tgl\;-DDYNAMIC=1"
+	"sof-cavs-nocodec\;sof-tgl-nocodec\;-DPLATFORM=tgl\;-DDMIC_48k_CORE_ID=1\;-DSSP0_CORE_ID=2\;-DSSP1_CORE_ID=3\;-DDYNAMIC=1"
 	"sof-cavs-nocodec\;sof-tgl-h-nocodec\;-DPLATFORM=tgl\;-DNCORES=2\;-DDYNAMIC=1"
 	"sof-cavs-nocodec\;sof-ehl-nocodec\;-DPLATFORM=ehl\;-DDYNAMIC=1"
 	"sof-cavs-nocodec\;sof-adl-nocodec\;-DPLATFORM=adl\;-DDMIC_48k_CORE_ID=1\;-DSSP0_CORE_ID=2\;-DSSP1_CORE_ID=3\;-DDYNAMIC=1"

--- a/tools/topology/topology1/CMakeLists.txt
+++ b/tools/topology/topology1/CMakeLists.txt
@@ -86,7 +86,7 @@ set(TPLGS
 	"sof-cavs-nocodec\;sof-tgl-nocodec\;-DPLATFORM=tgl\;-DDYNAMIC=1"
 	"sof-cavs-nocodec\;sof-tgl-h-nocodec\;-DPLATFORM=tgl\;-DNCORES=2\;-DDYNAMIC=1"
 	"sof-cavs-nocodec\;sof-ehl-nocodec\;-DPLATFORM=ehl\;-DDYNAMIC=1"
-	"sof-cavs-nocodec\;sof-adl-nocodec\;-DPLATFORM=adl\;-DDYNAMIC=1"
+	"sof-cavs-nocodec\;sof-adl-nocodec\;-DPLATFORM=adl\;-DDMIC_48k_CORE_ID=1\;-DSSP0_CORE_ID=2\;-DSSP1_CORE_ID=3\;-DDYNAMIC=1"
 	"sof-icl-dmic-4ch\;sof-icl-dmic-4ch"
 	# sof-icl-r700 is kept for compatibility with CI and previous versions of the kernel.
 	"sof-icl-rt700\;sof-icl-rt700\;-DCHANNELS=4\;-DPLATFORM=icl\;-DDMICPROC_FILTER1=eq_iir_coef_highpass_40hz_20db_48khz.m4\;-DDMIC16KPROC_FILTER1=eq_iir_coef_highpass_40hz_20db_16khz.m4"


### PR DESCRIPTION
1. change the sof-adl-nocodec.m4 to assign pipelines on all 4 DSP cores, this will enable "PR multi-core + dynamic pipeline" validation coverage.
2. change the sof-tgl-nocodec.m4 to assign pipelines on all DSP cores for tgl-nocodec, which will be run on daily test as comparison with ADL one. 