### PR TITLE
zephyr: fix secondary core IPC completion

### DIFF
--- a/src/include/sof/ipc/common.h
+++ b/src/include/sof/ipc/common.h
@@ -13,6 +13,7 @@
 #include <sof/lib/alloc.h>
 #include <sof/list.h>
 #include <sof/schedule/task.h>
+#include <sof/spinlock.h>
 #include <sof/sof.h>
 #include <user/trace.h>
 #include <stdbool.h>


### PR DESCRIPTION
Recently SOF IPC processing has been modified on multicore systems to let secondary cores reply to IPCs if the primary core has already left the IPC forwarding context. This hasn't been implemented for Zephyr which led to unanswered IPCs and IPC timeouts on the host. This patch lets secondary cores reply to IPCs under Zephyr.
