### PR TITLE
topology2: cavs-nocodec: fix dmic compile failure

### DIFF
--- a/tools/topology/topology2/cavs-nocodec.conf
+++ b/tools/topology/topology2/cavs-nocodec.conf
@@ -139,6 +139,7 @@ Object.Pipeline {
 
 	passthrough-capture."3" {
 		format	"s16le"
+		index 3
 
 		Object.Widget.pipeline.1.stream_name	"copier.DMIC.3.1"
 
@@ -165,6 +166,7 @@ Object.PCM {
 	}
 	pcm."1" {
 		name	"DMIC"
+		id 1
 		direction	"capture"
 		Object.Base.fe_dai."DMIC" {}
 


### PR DESCRIPTION
The current topology2 requires to set id in PCM.pcm and to set index in Pipeline.

Signed-off-by: Libin Yang <libin.yang@intel.com>