### PR TITLE
IPC4: add llp reading support

### DIFF
--- a/src/audio/copier.c
+++ b/src/audio/copier.c
@@ -269,12 +269,12 @@ static struct comp_dev *copier_new(const struct comp_driver *drv,
 				goto error_cd;
 			}
 
-			if (cd->direction == SOF_IPC_STREAM_PLAYBACK)
+			if (cd->direction == SOF_IPC_STREAM_PLAYBACK) {
 				ipc_pipe->pipeline->source_comp = dev;
-			else
+				init_pipeline_reg(cd);
+			} else {
 				ipc_pipe->pipeline->sink_comp = dev;
-
-			init_pipeline_reg(cd);
+			}
 
 			break;
 		case ipc4_hda_link_output_class:

--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -959,19 +959,6 @@ static int dai_copy(struct comp_dev *dev)
 	return ret;
 }
 
-static int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn)
-{
-	struct dai_data *dd = comp_get_drvdata(dev);
-
-	/* TODO: improve accuracy by adding current DMA position */
-	posn->dai_posn = dev->position;
-
-	/* set stream start wallclock */
-	posn->wallclock = dd->wallclock;
-
-	return 0;
-}
-
 /**
  * \brief Get DAI parameters and configure timestamping
  * \param[in, out] dev DAI device.

--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -463,6 +463,12 @@ static int dw_dma_status(struct dma_chan_data *channel,
 	status->w_pos = dma_reg_read(channel->dma, DW_DAR(channel->index));
 	status->timestamp = timer_get_system(timer_get());
 
+	if (status->ipc_posn_data) {
+		uint32_t *llp = (uint32_t *)status->ipc_posn_data;
+
+		platform_dw_dma_llp_read(channel->dma, channel, llp, llp + 1);
+	}
+
 	return 0;
 }
 

--- a/src/include/ipc4/copier.h
+++ b/src/include/ipc4/copier.h
@@ -37,25 +37,6 @@
  * be provided as an input to the FW Image Builder).
  */
 
-struct ipc4_llp_reading {
-	/* lower part of 64-bit LLP */
-	uint32_t llp_l;
-	/* upper part of 64-bit LLP */
-	uint32_t llp_u;
-	/* lower part of 64-bit Wallclock */
-	uint32_t wclk_l;
-	/* upper part of 64-bit Wallclock */
-	uint32_t wclk_u;
-} __attribute__((packed, aligned(4)));
-
-struct ipc4_llp_reading_extended {
-	struct ipc4_llp_reading llp_reading;
-	/* total processed data (low part) */
-	uint32_t tpd_low;
-	/* total processed data (high part) */
-	uint32_t tpd_high;
-} __attribute__((packed, aligned(4)));
-
 struct ipc4_base_module_cfg_ext {
 	/* specifies number of items in input_pins array. Maximum size is 8 */
 	uint16_t nb_input_pins;

--- a/src/include/ipc4/fw_reg.h
+++ b/src/include/ipc4/fw_reg.h
@@ -86,6 +86,14 @@ struct ipc4_llp_reading {
 	uint32_t wclk_u;
 } __attribute__((packed, aligned(4)));
 
+struct ipc4_llp_reading_extended {
+	struct ipc4_llp_reading llp_reading;
+	/* total processed data (low part) */
+	uint32_t tpd_low;
+	/* total processed data (high part) */
+	uint32_t tpd_high;
+} __attribute__((packed, aligned(4)));
+
 struct ipc4_llp_reading_slot {
 	uint32_t node_id;
 	struct ipc4_llp_reading reading;

--- a/src/include/sof/lib/dai.h
+++ b/src/include/sof/lib/dai.h
@@ -533,6 +533,11 @@ int dai_config(struct comp_dev *dev,  struct ipc_config_dai *common_config,
  */
 int dai_assign_group(struct comp_dev *dev, uint32_t group_id);
 
+/**
+ * \brief dai position for host driver.
+ */
+int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn);
+
 /** @}*/
 
 #endif /* __SOF_LIB_DAI_H__ */

--- a/src/include/sof/lib/dma.h
+++ b/src/include/sof/lib/dma.h
@@ -149,6 +149,9 @@ struct dma_chan_status {
 	uint32_t w_pos;
 	uint32_t r_pos;
 	uint32_t timestamp;
+
+	/* dma position info for ipc4 */
+	void *ipc_posn_data;
 };
 
 /* DMA operations */

--- a/src/ipc/ipc3/dai.c
+++ b/src/ipc/ipc3/dai.c
@@ -351,3 +351,16 @@ int dai_config(struct comp_dev *dev, struct ipc_config_dai *common_config,
 
 	return ret;
 }
+
+int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn)
+{
+	struct dai_data *dd = comp_get_drvdata(dev);
+
+	/* TODO: improve accuracy by adding current DMA position */
+	posn->dai_posn = dev->position;
+
+	/* set stream start wallclock */
+	posn->wallclock = dd->wallclock;
+
+	return 0;
+}

--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -601,6 +601,9 @@ static int ipc4_process_module_message(union ipc4_message_header *ipc4)
 		break;
 	case SOF_IPC4_MOD_CONFIG_GET:
 	case SOF_IPC4_MOD_CONFIG_SET:
+		ret = IPC4_UNAVAILABLE;
+		tr_info(&ipc_tr, "unsupported module CONFIG_GET");
+		break;
 	case SOF_IPC4_MOD_LARGE_CONFIG_GET:
 		ret = ipc4_get_large_config_module_instance(ipc4);
 		break;

--- a/src/platform/apollolake/include/platform/lib/shim.h
+++ b/src/platform/apollolake/include/platform/lib/shim.h
@@ -209,6 +209,9 @@
 #define SHIM_GPDMA_CHLLPC_EN		BIT(5)
 #define SHIM_GPDMA_CHLLPC_DHRS(x)	SET_BITS(4, 0, x)
 
+#define SHIM_GPDMA_CHLLPL(x, y)                (SHIM_GPDMA_BASE(x) + 0x18 + (y) * 0x10)
+#define SHIM_GPDMA_CHLLPU(x, y)                (SHIM_GPDMA_BASE(x) + 0x1c + (y) * 0x10)
+
 /** \brief LDO Control */
 #define SHIM_LDOCTL		0xA4
 #define SHIM_LDOCTL_HPSRAM_MASK	(3 << 0)

--- a/src/platform/baytrail/include/platform/drivers/dw-dma.h
+++ b/src/platform/baytrail/include/platform/drivers/dw-dma.h
@@ -62,6 +62,10 @@ static inline void platform_dw_dma_llp_enable(struct dma *dma,
 static inline void platform_dw_dma_llp_disable(struct dma *dma,
 					       struct dma_chan_data *chan) { }
 
+static inline void platform_dw_dma_llp_read(struct dma *dma,
+					    struct dma_chan_data *chan,
+					    uint32_t *llp_l,
+					    uint32_t *llp_u) { }
 #endif /* __PLATFORM_DRIVERS_DW_DMA_H__ */
 
 #else

--- a/src/platform/cannonlake/include/platform/lib/shim.h
+++ b/src/platform/cannonlake/include/platform/lib/shim.h
@@ -211,6 +211,9 @@
 #define SHIM_GPDMA_CHLLPC_EN		BIT(7)
 #define SHIM_GPDMA_CHLLPC_DHRS(x)	SET_BITS(6, 0, x)
 
+#define SHIM_GPDMA_CHLLPL(x, y)                (SHIM_GPDMA_BASE(x) + 0x18 + (y) * 0x10)
+#define SHIM_GPDMA_CHLLPU(x, y)                (SHIM_GPDMA_BASE(x) + 0x1c + (y) * 0x10)
+
 #define L2LMCAP			0x71D00
 #define L2MPAT			0x71D04
 

--- a/src/platform/haswell/include/platform/drivers/dw-dma.h
+++ b/src/platform/haswell/include/platform/drivers/dw-dma.h
@@ -60,6 +60,11 @@ static inline void platform_dw_dma_llp_enable(struct dma *dma,
 static inline void platform_dw_dma_llp_disable(struct dma *dma,
 					       struct dma_chan_data *chan) { }
 
+static inline void platform_dw_dma_llp_read(struct dma *dma,
+					    struct dma_chan_data *chan,
+					    uint32_t *llp_l,
+					    uint32_t *llp_u) { }
+
 #endif /* __PLATFORM_DRIVERS_DW_DMA_H__ */
 
 #else

--- a/src/platform/icelake/include/platform/lib/shim.h
+++ b/src/platform/icelake/include/platform/lib/shim.h
@@ -205,6 +205,9 @@
 #define SHIM_GPDMA_CHLLPC_EN		BIT(7)
 #define SHIM_GPDMA_CHLLPC_DHRS(x)	SET_BITS(6, 0, x)
 
+#define SHIM_GPDMA_CHLLPL(x, y)                (SHIM_GPDMA_BASE(x) + 0x18 + (y) * 0x10)
+#define SHIM_GPDMA_CHLLPU(x, y)                (SHIM_GPDMA_BASE(x) + 0x1c + (y) * 0x10)
+
 #define L2LMCAP			0x71D00
 #define L2MPAT			0x71D04
 

--- a/src/platform/intel/cavs/include/cavs/drivers/dw-dma.h
+++ b/src/platform/intel/cavs/include/cavs/drivers/dw-dma.h
@@ -58,6 +58,12 @@
 #define DW_CHLLPC(dma, chan) \
 	SHIM_GPDMA_CHLLPC((dma)->plat_data.id, (chan)->index)
 
+#define DW_CHLLPL(dma, chan) \
+	SHIM_GPDMA_CHLLPL((dma)->plat_data.id, (chan)->index)
+
+#define DW_CHLLPU(dma, chan) \
+	SHIM_GPDMA_CHLLPU((dma)->plat_data.id, (chan)->index)
+
 #define platform_dw_dma_set_class(chan, lli, class) \
 	(lli->ctrl_hi |= DW_CTLH_CLASS(class))
 
@@ -83,6 +89,15 @@ static inline void platform_dw_dma_llp_disable(struct dma *dma,
 {
 	shim_write(DW_CHLLPC(dma, chan),
 		   shim_read(DW_CHLLPC(dma, chan)) & ~SHIM_GPDMA_CHLLPC_EN);
+}
+
+static inline void platform_dw_dma_llp_read(struct dma *dma,
+					    struct dma_chan_data *chan,
+					    uint32_t *llp_l,
+					    uint32_t *llp_u)
+{
+	*llp_l = shim_read(DW_CHLLPL(dma, chan));
+	*llp_u = shim_read(DW_CHLLPU(dma, chan));
 }
 
 static inline struct dw_lli *platform_dw_dma_lli_get(struct dw_lli *lli)

--- a/src/platform/suecreek/include/platform/lib/shim.h
+++ b/src/platform/suecreek/include/platform/lib/shim.h
@@ -200,6 +200,9 @@
 #define SHIM_GPDMA_CHLLPC_EN		BIT(7)
 #define SHIM_GPDMA_CHLLPC_DHRS(x)	SET_BITS(6, 0, x)
 
+#define SHIM_GPDMA_CHLLPL(x, y)                (SHIM_GPDMA_BASE(x) + 0x18 + (y) * 0x10)
+#define SHIM_GPDMA_CHLLPU(x, y)                (SHIM_GPDMA_BASE(x) + 0x1c + (y) * 0x10)
+
 #define L2LMCAP			0x71D00
 #define L2MPAT			0x71D04
 

--- a/src/platform/tigerlake/include/platform/lib/shim.h
+++ b/src/platform/tigerlake/include/platform/lib/shim.h
@@ -212,6 +212,9 @@
 #define SHIM_GPDMA_CHLLPC_EN		BIT(7)
 #define SHIM_GPDMA_CHLLPC_DHRS(x)	SET_BITS(6, 0, x)
 
+#define SHIM_GPDMA_CHLLPL(x, y)		(SHIM_GPDMA_BASE(x) + 0x18 + (y) * 0x10)
+#define SHIM_GPDMA_CHLLPU(x, y)		(SHIM_GPDMA_BASE(x) + 0x1c + (y) * 0x10)
+
 /* I2S SHIM Registers */
 #define I2SLCTL			0x71C04
 


### PR DESCRIPTION
Linear link position (llp) is updated in llp register by GP-DMA hardware. Now it is enabled by SOF FW but not used.
This patch set up a path to read it and update it to host driver.