### PR TITLE
Ipc fix for multi-core scenarios

### DIFF
--- a/src/drivers/intel/cavs/ipc.c
+++ b/src/drivers/intel/cavs/ipc.c
@@ -46,9 +46,10 @@ static inline void increment_ipc_received_counter(void)
 static inline void increment_ipc_processed_counter(void)
 {
 	static uint32_t ipc_processed_counter;
+	uint32_t *uncache_counter = cache_to_uncache(&ipc_processed_counter);
 
 	mailbox_sw_reg_write(SRAM_REG_FW_IPC_PROCESSED_COUNT,
-			     ipc_processed_counter++);
+			     (*uncache_counter)++);
 }
 #endif
 

--- a/src/drivers/intel/cavs/ipc.c
+++ b/src/drivers/intel/cavs/ipc.c
@@ -123,9 +123,6 @@ static void ipc_irq_handler(void *arg)
 		/* unmask Done interrupt */
 		ipc_write(IPC_DIPCCTL,
 			  ipc_read(IPC_DIPCCTL) | IPC_DIPCCTL_IPCIDIE);
-
-		/* send next message to host */
-		ipc_send_queued_msg();
 	}
 }
 

--- a/src/drivers/intel/cavs/ipc.c
+++ b/src/drivers/intel/cavs/ipc.c
@@ -58,6 +58,9 @@ static void ipc_irq_handler(void *arg)
 {
 	struct ipc *ipc = arg;
 	uint32_t dipcctl;
+	uint32_t flags;
+
+	spin_lock_irq(&ipc->lock, flags);
 
 #if CAVS_VERSION == CAVS_VERSION_1_5
 	uint32_t dipct;
@@ -124,6 +127,8 @@ static void ipc_irq_handler(void *arg)
 		ipc_write(IPC_DIPCCTL,
 			  ipc_read(IPC_DIPCCTL) | IPC_DIPCCTL_IPCIDIE);
 	}
+
+	spin_unlock_irq(&ipc->lock, flags);
 }
 
 #if CAVS_VERSION >= CAVS_VERSION_1_8


### PR DESCRIPTION
    cavs-ipc: hold ipc->lock in ipc handler to avoid race
    
    For secondary core target IPC, the IPC handling could be completed on a
    secondary DSP core, while the primary core may be in handling an reply
    message from the host and touching the IPC_DIPCCTL at the same time, so
    there is race condition from different DSP cores in this scenario, and
    that actually lead to kinds of IPC timeout as setting of bit
    IPC_DIPCCTL_IPCTBIE could be ignore and busy interrupt will be disabled
    after that.
    
    Simply holding of ipc-lock in the irq handler fixes the issue, according
    to stress test with multi-core scenarios.
