### PR TITLE
pipeline: always begin scheduling from the source

### DIFF
--- a/src/audio/pipeline/pipeline-schedule.c
+++ b/src/audio/pipeline/pipeline-schedule.c
@@ -340,5 +340,12 @@ void pipeline_schedule_copy(struct pipeline *p, uint64_t start)
 	if (!pipeline_is_timer_driven(p))
 		sa_set_panic_on_delay(false);
 
-	schedule_task(p->pipe_task, start, p->period);
+	if (p->sched_next && task_is_active(p->sched_next->pipe_task))
+		schedule_task_before(p->pipe_task, start, p->period,
+				     p->sched_next->pipe_task);
+	else if (p->sched_prev && task_is_active(p->sched_prev->pipe_task))
+		schedule_task_after(p->pipe_task, start, p->period,
+				    p->sched_prev->pipe_task);
+	else
+		schedule_task(p->pipe_task, start, p->period);
 }

--- a/src/audio/pipeline/pipeline-schedule.c
+++ b/src/audio/pipeline/pipeline-schedule.c
@@ -211,7 +211,6 @@ void pipeline_schedule_triggered(struct pipeline_walk_context *ctx,
 	struct list_item *tlist;
 	struct pipeline *p;
 	uint32_t flags;
-	bool first_pipe = true;
 
 	/*
 	 * Interrupts have to be disabled while adding tasks to or removing them
@@ -246,7 +245,7 @@ void pipeline_schedule_triggered(struct pipeline_walk_context *ctx,
 		list_for_item(tlist, &ctx->pipelines) {
 			p = container_of(tlist, struct pipeline, list);
 			p->xrun_bytes = 0;
-			if (pipeline_is_timer_driven(p) && first_pipe) {
+			if (pipeline_is_timer_driven(p)) {
 				/*
 				 * Use the first of connected pipelines to
 				 * trigger, mark all other connected pipelines
@@ -254,7 +253,7 @@ void pipeline_schedule_triggered(struct pipeline_walk_context *ctx,
 				 */
 				p->trigger.cmd = cmd;
 				p->trigger.host = ppl_data->start;
-				first_pipe = false;
+				ppl_data->start = NULL;
 			} else {
 				p->status = COMP_STATE_ACTIVE;
 			}

--- a/src/include/sof/audio/pipeline.h
+++ b/src/include/sof/audio/pipeline.h
@@ -60,6 +60,8 @@ struct pipeline {
 
 	/* scheduling */
 	struct task *pipe_task;		/* pipeline processing task */
+	struct pipeline *sched_next;	/* pipeline scheduled after this */
+	struct pipeline *sched_prev;	/* pipeline scheduled before this */
 
 	/* component that drives scheduling in this pipe */
 	struct comp_dev *sched_comp;

--- a/src/include/sof/audio/pipeline.h
+++ b/src/include/sof/audio/pipeline.h
@@ -12,6 +12,7 @@
 #include <sof/lib/mailbox.h>
 #include <sof/lib/memory.h>
 #include <sof/list.h>
+#include <sof/schedule/task.h>
 #include <sof/sof.h>
 #include <sof/spinlock.h>
 #include <sof/audio/pipeline-trace.h>
@@ -25,7 +26,6 @@ struct comp_buffer;
 struct comp_dev;
 struct ipc;
 struct ipc_msg;
-struct task;
 
 /* Pipeline status to stop execution of current path */
 #define PPL_STATUS_PATH_STOP	1
@@ -107,6 +107,15 @@ struct pipeline_data {
 	int cmd;
 	uint32_t delay_ms;		/* between PRE_{START,RELEASE} and {START,RELEASE} */
 };
+
+/** \brief Task type registered by pipelines. */
+struct pipeline_task {
+	struct task task;		/**< parent structure */
+	bool registrable;		/**< should task be registered on irq */
+	struct comp_dev *sched_comp;	/**< pipeline scheduling component */
+};
+
+#define pipeline_task_get(t) container_of(t, struct pipeline_task, task)
 
 /*
  * Pipeline Graph APIs

--- a/src/include/sof/schedule/schedule.h
+++ b/src/include/sof/schedule/schedule.h
@@ -223,9 +223,12 @@ static inline int schedule_task(struct task *task, uint64_t start,
 	struct schedule_data *sch;
 	struct list_item *slist;
 
+	if (!task)
+		return -EINVAL;
+
 	list_for_item(slist, &schedulers->list) {
 		sch = container_of(slist, struct schedule_data, list);
-		if (task->type == sch->type && sch->ops->schedule_task)
+		if (task->type == sch->type)
 			return sch->ops->schedule_task(sch->data, task, start,
 						       period);
 	}
@@ -264,7 +267,7 @@ static inline int schedule_task_cancel(struct task *task)
 
 	list_for_item(slist, &schedulers->list) {
 		sch = container_of(slist, struct schedule_data, list);
-		if (task->type == sch->type && sch->ops->schedule_task_cancel)
+		if (task->type == sch->type)
 			return sch->ops->schedule_task_cancel(sch->data, task);
 	}
 
@@ -280,7 +283,7 @@ static inline int schedule_task_free(struct task *task)
 
 	list_for_item(slist, &schedulers->list) {
 		sch = container_of(slist, struct schedule_data, list);
-		if (task->type == sch->type && sch->ops->schedule_task_free)
+		if (task->type == sch->type)
 			return sch->ops->schedule_task_free(sch->data, task);
 	}
 

--- a/src/include/sof/schedule/task.h
+++ b/src/include/sof/schedule/task.h
@@ -75,14 +75,6 @@ struct task {
 #endif
 };
 
-/** \brief Task type registered by pipelines. */
-struct pipeline_task {
-	struct task task;		/**< parent structure */
-	bool registrable;		/**< should task be registered on irq */
-	struct comp_dev *sched_comp;	/**< pipeline scheduling component */
-};
-
-#define pipeline_task_get(t) container_of(t, struct pipeline_task, task)
 
 static inline enum task_state task_run(struct task *task)
 {

--- a/src/include/sof/schedule/task.h
+++ b/src/include/sof/schedule/task.h
@@ -75,6 +75,19 @@ struct task {
 #endif
 };
 
+static inline bool task_is_active(struct task *task)
+{
+	switch (task->state) {
+	case SOF_TASK_STATE_QUEUED:
+	case SOF_TASK_STATE_PENDING:
+	case SOF_TASK_STATE_RUNNING:
+	case SOF_TASK_STATE_PREEMPTED:
+	case SOF_TASK_STATE_RESCHEDULE:
+		return true;
+	default:
+		return false;
+	}
+}
 
 static inline enum task_state task_run(struct task *task)
 {

--- a/src/schedule/ll_schedule.c
+++ b/src/schedule/ll_schedule.c
@@ -7,6 +7,7 @@
 //         Tomasz Lauda <tomasz.lauda@linux.intel.com>
 
 #include <sof/atomic.h>
+#include <sof/audio/pipeline.h>
 #include <sof/common.h>
 #include <sof/drivers/interrupt.h>
 #include <sof/drivers/timer.h>

--- a/src/schedule/ll_schedule.c
+++ b/src/schedule/ll_schedule.c
@@ -330,11 +330,13 @@ static int schedule_ll_domain_set(struct ll_schedule_data *sch,
 		task->start = task_start;
 		if (task->start < domain->next_tick)
 			domain_set(domain, task_start);
-	} else if (task_start < domain->next_tick) {
-		/* earlier periodic task, try to make it cadence-aligned with the existed task */
-		offset = (domain->next_tick - task_start) %
-			 (domain->ticks_per_ms * period / 1000);
-		task_start = task_start - task_start_ticks + offset;
+	} else if (task_start + task_start_ticks < domain->next_tick) {
+		/*
+		 * Earlier periodic task, try to make it cadence-aligned with the existed task.
+		 * In this case task_start_ticks is the number of ticks per period.
+		 */
+		offset = (domain->next_tick - task_start) % task_start_ticks;
+		task_start += offset;
 		domain_set(domain, task_start);
 		task->start = domain->next_tick;
 	} else {

--- a/src/schedule/schedule.c
+++ b/src/schedule/schedule.c
@@ -61,6 +61,10 @@ void scheduler_init(int type, const struct scheduler_ops *ops, void *data)
 {
 	struct schedule_data *sch;
 
+	if (!ops || !ops->schedule_task || !ops->schedule_task_cancel ||
+	    !ops->schedule_task_free)
+		return;
+
 	sch = rzalloc(SOF_MEM_ZONE_SYS, 0, SOF_MEM_CAPS_RAM, sizeof(*sch));
 	list_init(&sch->list);
 	sch->type = type;


### PR DESCRIPTION
Pipeline tasks are scheduled in the order in which they're submitted to the scheduler. When audio streams cross several pipelines it makes sense to begin scheduling from the data source. I.e. for playback pipelines from the host pipeline, for capture pipelines from the DAI pipeline. Currently the DAI pipeline gets scheduled first for both playback and captuure, which for playback always results in a
```
WARN dai_copy(): nothing to copy
```
warning being printed for the first copy attempt. Also, this results in delayed scheduling: the first cycle will then only copy data from the host, so the first real DAI copying will only happen on the second tick.
On the contrary, when stopping to stream, the sink should be stopped first.
This patch takes the streaming direction and the command into account when scheduling tasks.
