### PR TITLE
Host component DMA copy the whole copy_bytes.

### DIFF
--- a/src/platform/Kconfig
+++ b/src/platform/Kconfig
@@ -499,4 +499,13 @@ config XTENSA_EXCLUSIVE
 	  This has to be selected for xtensa exclusive instructions.
 	  There is a definition for EXCLUSIVE option in xtensa-config.h
 
+config FORCE_DMA_COPY_WHOLE_BLOCK
+	bool
+	default y if MT8195
+	default n
+	depends on HOST_PTABLE
+	help
+	  The host component forces DMA to copy the block size to avoid
+	  copying byte jitter between the components of the same pipeline.
+
 endmenu


### PR DESCRIPTION
Host component stops copying bytes at element's end and resumes
copying the remaining bytes in the next round. This leads to jitter
between components of the same pipeline. Such jitter might cause
buffer overwrite for component which processes block by block.

Triggering extra DMA copy until all the copy_bytes are copied can
eliminate the jitter and hence no more buffer overwrite occurs.

Signed-off-by: fy.tsuo <fy.tsuo@intelli-go.com>