### PR TITLE
xtensa-build-zephyr: fix incremental build, pass CMAKE_ARGS only once

### DIFF
--- a/scripts/xtensa-build-zephyr.sh
+++ b/scripts/xtensa-build-zephyr.sh
@@ -209,10 +209,21 @@ build_all()
 			 # west can get lost in symbolic links and then
 			 # show a confusing error.
 			/bin/pwd
-			set -x
-			west build --build-dir "$bdir" --board "$PLAT_CONFIG" \
+			if test -d "$bdir"; then
+			    test -z "${CMAKE_ARGS+defined}" ||
+				die 'Cannot re-define CMAKE_ARGS, you must delete %s first\n' \
+				    "$(pwd)/$bdir"
+			    # --board is cached and not required again either but unlike
+			    # CMAKE_ARGS this _not_ does force CMake to re-run and passing
+			    # a different board by mistake is very nicely caught by west.
+			    set -x
+			    west build --build-dir "$bdir" --board "$PLAT_CONFIG"
+			else
+			    set -x
+			    west build --build-dir "$bdir" --board "$PLAT_CONFIG" \
 				zephyr/samples/subsys/audio/sof \
 				-- "${CMAKE_ARGS[@]}"
+			fi
 
 			# This should ideally be part of
 			# sof/zephyr/CMakeLists.txt but due to the way


### PR DESCRIPTION
As documented in
https://docs.zephyrproject.org/latest/guides/west/build-flash-debug.html#one-time-cmake-arguments
and accidentally found when testing rimage cleanup
https://github.com/zephyrproject-rtos/zephyr/pull/40431

Fixes commit 88327f618c7e ("xtensa-build-zephyr: support passing through
CMake arguments"); ccache is too good and hid this regression from me.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>