### PR TITLE
zephyr/atomic.h: add a no-op cast: (long)atomic_read()

### DIFF
--- a/zephyr/include/sof/atomic.h
+++ b/zephyr/include/sof/atomic.h
@@ -8,7 +8,13 @@
 
 #include <sys/atomic.h>
 
-#define atomic_read	atomic_get
-#define atomic_init	atomic_set
+/* Zephyr commit 174cb7f9f183 switched 'atomic_t' from 'int' to
+ * 'long'. As we don't support 64 bits, this should have made no
+ * difference but in reality it broke printk("%d / %ld",...)  The no-op
+ * cast to 'long' below provides a transition by making it possible to
+ * compile SOF both before _and_ after the Zephyr switch.
+ */
+#define atomic_read(p)		((long)atomic_get(p))
+#define atomic_init(p, v)	atomic_set(p, v)
 
 #endif


### PR DESCRIPTION
Zephyr commit 174cb7f9f183 switched 'atomic_t' from 'int' to
'long' and broke SOF compilation as shown below.

Recent SOF commit 970d7d61ece9 ("zephyr: update print messages for
64-bit atomics") switched all atomic_read() logs to "%ld" instead of
"%d" which fixed compilation with Zephyr after the switch but broke it
with Zephyr _before_ the switch.

This no-op (long) cast makes SOF compatible with Zephyr both before and
after the switch.

Note the sof-logger does not make any difference between %ld and %d and
does not care.

Sample failure:
```
src/lib/dma.c: In function 'dma_get': sof/src/include/sof/trace/trace.h:290
 error: format '%d' expects argument of type 'int', but
 argument 5 has type 'atomic_val_t' {aka 'long int'} [-Werror=format=]

 290 |   printk("%llu " format "\n", platform_timer_get(NULL), \
     |                 ^~~~~~~

sof/src/lib/dma.c:119:2: note: in expansion of macro 'tr_info'

 119 |  tr_info(&dma_tr, "..., busy channels = %d", atomic_read(...))
```
Signed-off-by: Marc Herbert <marc.herbert@intel.com>