### PR TITLE
xtensa-build-zephyr: temporarily exclude ICL 

### DIFF
--- a/scripts/xtensa-build-zephyr.sh
+++ b/scripts/xtensa-build-zephyr.sh
@@ -18,6 +18,11 @@ SUPPORTED_PLATFORMS+=(imx8 imx8x imx8m)
 # -a
 DEFAULT_PLATFORMS=("${SUPPORTED_PLATFORMS[@]}")
 
+# REVERTME: temporarily exclude ICL because of .noinit/.cached section
+# overlap and build failure
+# https://github.com/zephyrproject-rtos/zephyr/pull/40319
+unset DEFAULT_PLATFORMS[2]
+
 BUILD_JOBS=$(nproc --all)
 PLATFORMS=()
 

--- a/scripts/xtensa-build-zephyr.sh
+++ b/scripts/xtensa-build-zephyr.sh
@@ -15,6 +15,9 @@ SUPPORTED_PLATFORMS+=(apl cnl icl tgl-h tgl)
 # NXP
 SUPPORTED_PLATFORMS+=(imx8 imx8x imx8m)
 
+# -a
+DEFAULT_PLATFORMS=("${SUPPORTED_PLATFORMS[@]}")
+
 BUILD_JOBS=$(nproc --all)
 PLATFORMS=()
 
@@ -281,7 +284,7 @@ parse_args()
 	# Parse -options
 	while getopts "acz:j:k:p:" OPTION; do
 		case "$OPTION" in
-			a) PLATFORMS=("${SUPPORTED_PLATFORMS[@]}") ;;
+			a) PLATFORMS=("${DEFAULT_PLATFORMS[@]}") ;;
 			c) DO_CLONE=yes ;;
 			z) zephyr_ref="$OPTARG" ;;
 			j) BUILD_JOBS="$OPTARG" ;;


### PR DESCRIPTION
Because ICL fails to build, .noinit/.cached section overlap since
revert zephyrproject-rtos/zephyr#40319

Signed-off-by: Marc Herbert <marc.herbert@intel.com>