### PR TITLE
audio: host: call dma_stop during host reset

### DIFF
--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -494,10 +494,6 @@ static int host_trigger(struct comp_dev *dev, int cmd)
 		break;
 	case COMP_TRIGGER_STOP:
 	case COMP_TRIGGER_XRUN:
-		ret = dma_stop(hd->chan);
-		if (ret < 0)
-			comp_err(dev, "host_trigger(): dma stop failed: %d",
-				 ret);
 		break;
 	default:
 		break;
@@ -852,10 +848,17 @@ static int host_position(struct comp_dev *dev,
 static int host_reset(struct comp_dev *dev)
 {
 	struct host_data *hd = comp_get_drvdata(dev);
+	int ret;
 
 	comp_dbg(dev, "host_reset()");
 
 	if (hd->chan) {
+		ret = dma_stop(hd->chan);
+		if (ret < 0) {
+			comp_err(dev, "host_reset(): dma stop failed: %d",
+				 ret);
+			return ret;
+		}
 		/* remove callback */
 		notifier_unregister(dev, hd->chan, NOTIFIER_ID_DMA_COPY);
 		dma_channel_put(hd->chan);


### PR DESCRIPTION
Some DMA's like the HD-Audio DMA need to be stopped ater the pipeline
has been reset. So call dma_stop op in host reset so that the DMA
can be stopped during the PCM_FREE IPC when the host gets reset.

sof main brnach addresses this issue in this PR:
	https://github.com/thesofproject/sof/pull/4922

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>
Signed-off-by: Sathyanarayana Nujella <sathyanarayana.nujella@intel.com>