### PR TITLE
ipc4: update llp register in memory window 0

### DIFF
--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -605,6 +605,8 @@ static int dai_config_prepare(struct comp_dev *dev)
 	comp_info(dev, "dai_config_prepare(): new configured dma channel index %d",
 		  dd->chan->index);
 
+	dai_dma_position_init(dd);
+
 	/* setup callback */
 	notifier_register(dev, dd->chan, NOTIFIER_ID_DMA_COPY,
 			  dai_dma_cb, 0);
@@ -955,6 +957,8 @@ static int dai_copy(struct comp_dev *dev)
 		dai_report_xrun(dev, copy_bytes);
 		return ret;
 	}
+
+	dai_dma_position_update(dev);
 
 	return ret;
 }

--- a/src/include/sof/lib/dai.h
+++ b/src/include/sof/lib/dai.h
@@ -538,6 +538,15 @@ int dai_assign_group(struct comp_dev *dev, uint32_t group_id);
  */
 int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn);
 
+/**
+ * \brief init dai dma position for host driver.
+ */
+void dai_dma_position_init(struct dai_data *dd);
+
+/**
+ * \brief update dai dma position for host driver.
+ */
+void dai_dma_position_update(struct comp_dev *dev);
 /** @}*/
 
 #endif /* __SOF_LIB_DAI_H__ */

--- a/src/ipc/ipc3/dai.c
+++ b/src/ipc/ipc3/dai.c
@@ -364,3 +364,7 @@ int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn)
 
 	return 0;
 }
+
+void dai_dma_position_init(struct dai_data *dd) { }
+
+void dai_dma_position_update(struct comp_dev *dev) { }


### PR DESCRIPTION
Host driver checks llp register data in memory window 0
to update stream position to audio framework.
This patch update this memory location when dma channel
is allocated and dma copy is done.

Signed-off-by: Rander Wang <rander.wang@intel.com>