### PR TITLE
Math: Build library functions if enabled from Kconfig

### DIFF
--- a/src/Kconfig
+++ b/src/Kconfig
@@ -17,3 +17,5 @@ rsource "samples/Kconfig"
 rsource "schedule/Kconfig"
 
 rsource "ipc/Kconfig"
+
+rsource "math/Kconfig"

--- a/src/audio/Kconfig
+++ b/src/audio/Kconfig
@@ -88,22 +88,6 @@ endchoice
 
 endif # SRC
 
-config MATH_FIR
-	bool "FIR filter library"
-	default n
-	help
-	  This option builds FIR (Finite Impulse Response) filter library. It
-	  is selected by components for their digital signal processing. A FIR
-	  filter calculates a convolution of input PCM sample and a configurable
-	  impulse response.
-
-config MATH_FFT
-	bool "FFT library"
-	default n
-	help
-	  Enable Fast Fourier Transform library, this should not be selected
-	  directly, please select it from other audio components where need it.
-
 config COMP_FIR
 	bool "FIR component"
 	select MATH_FIR
@@ -119,24 +103,13 @@ config COMP_FIR
 config COMP_IIR
 	bool "IIR component"
 	default y
+	select MATH_IIR_DF2T
 	help
 	  Select for IIR component
 
-config CORDIC_FIXED
-       bool "Sine Cosine library function"
-       default n
-       help
-          This option builds the 32 and 16 bit sin_fixed() library function.
-	  The input is Q4.28 format and the output is Q1.31. The cordic sine
-	  cos algorithm converges, when the angle is in the range [-pi/2, pi/2).
-	  If an angle is outside of this range, then a multiple of pi/2 is added
-	  or subtracted from the angle until it is within the range [-pi/2,pi/2).
-	  Start with the angle in the range [-2*pi, 2*pi) and output has range in
-	  [-1.0 to 1.0]
-
 config COMP_TONE
 	bool "Tone component"
-	default y
+	default n
 	select CORDIC_FIXED
 	help
 	  Select for Tone component

--- a/src/drivers/intel/Kconfig
+++ b/src/drivers/intel/Kconfig
@@ -11,6 +11,7 @@ config INTEL_HDA
 config INTEL_MN
 	bool
 	depends on CAVS
+	select NUMBERS_GCD
 	default n
 	help
 	  Select this if the platform supports M/N dividers.
@@ -42,6 +43,10 @@ config INTEL_ALH
 config INTEL_DMIC
 	bool "Intel DMIC driver"
 	depends on CAVS
+	select NUMBERS_GCD
+	select NUMBERS_NORM
+	select NUMBERS_VECTOR_FIND
+	select MATH_DECIBELS
 	default n
 	help
 	  Select this to enable Intel DMIC driver. The DMIC driver provides

--- a/src/include/sof/math/trig.h
+++ b/src/include/sof/math/trig.h
@@ -13,10 +13,6 @@
 
 #include <stdint.h>
 
-#ifndef UNIT_CORDIC_TEST
-#define CONFIG_CORDIC_TRIGONOMETRY_FIXED
-#endif
-
 #define PI_DIV2_Q4_28 421657428
 #define PI_DIV2_Q3_29 843314856
 #define PI_Q4_28      843314857

--- a/src/math/CMakeLists.txt
+++ b/src/math/CMakeLists.txt
@@ -4,7 +4,15 @@ if(BUILD_LIBRARY)
 	return()
 endif()
 
-add_local_sources(sof numbers.c trig.c decibels.c iir_df2t_generic.c iir_df2t_hifi3.c)
+add_local_sources(sof numbers.c)
+
+if(CONFIG_CORDIC_FIXED)
+        add_local_sources(sof trig.c)
+endif()
+
+if(CONFIG_MATH_DECIBELS)
+        add_local_sources(sof decibels.c)
+endif()
 
 if(CONFIG_MATH_FIR)
         add_local_sources(sof fir_generic.c fir_hifi2ep.c fir_hifi3.c)
@@ -12,4 +20,8 @@ endif()
 
 if(CONFIG_MATH_FFT)
 	add_subdirectory(fft)
+endif()
+
+if(CONFIG_MATH_IIR_DF2T)
+        add_local_sources(sof iir_df2t_generic.c iir_df2t_hifi3.c)
 endif()

--- a/src/math/Kconfig
+++ b/src/math/Kconfig
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+menu "Math functions"
+
+config CORDIC_FIXED
+	bool "Trigonometric functions"
+	default n
+	help
+	  Select this to enable sin(), cos(), asin(), acos(),
+	  and cexp() functions as 16 bit and 32 bit versions.
+
+config NUMBERS_GCD
+	bool "Greatest common divisor"
+	default n
+	help
+	  Returns greatest common divisor for two parameters.
+
+config NUMBERS_NORM
+	bool "Norm function"
+	default n
+	help
+	  Norm function counts the left shifts needed to
+	  normalize integer value.
+
+config NUMBERS_VECTOR_FIND
+	bool "Find operations for numbers vecter"
+	default n
+	help
+	  This option provides functions func_equal_int16(),
+	  find_min_int16(), and find_max_abs32().
+
+config MATH_DECIBELS
+	bool "Convert decibels to linear"
+	default n
+	help
+	  Select this to enable db2lin_fixed() and exp_fixed()
+	  functions.
+
+config MATH_FFT
+	bool "FFT library"
+	default n
+	help
+	  Enable Fast Fourier Transform library, this should not be selected
+	  directly, please select it from other audio components where need it.
+
+config MATH_FIR
+	bool "FIR filter library"
+	default n
+	help
+	  This option builds FIR (Finite Impulse Response) filter library. It
+	  is selected by components for their digital signal processing. A FIR
+	  filter calculates a convolution of input PCM sample and a configurable
+	  impulse response.
+
+config MATH_IIR_DF2T
+	bool "IIR filter library"
+	default n
+	help
+	  Select this to build IIR (Infinite Impulse Response) filter
+	  or type 2-transposed library.
+
+endmenu

--- a/src/math/numbers.c
+++ b/src/math/numbers.c
@@ -14,6 +14,8 @@
 #include <sof/math/numbers.h>
 #include <stdint.h>
 
+#if CONFIG_NUMBERS_GCD
+
 /* This function returns the greatest common divisor of two numbers
  * If both parameters are 0, gcd(0, 0) returns 0
  * If first parameters is 0 or second parameter is 0, gcd(0, b) returns b
@@ -73,6 +75,10 @@ int gcd(int a, int b)
 	return a << k;
 }
 
+#endif /* CONFIG_NUMBERS_GCD */
+
+#if CONFIG_NUMBERS_VECTOR_FIND
+
 /* This function searches from vec[] (of length vec_length) integer values
  * of n. The indexes to equal values is returned in idx[]. The function
  * returns the number of found matches. The max_results should be set to
@@ -125,6 +131,10 @@ int32_t find_max_abs_int32(int32_t vec[], int vec_length)
 	return SATP_INT32(amax); /* Amax is always a positive value */
 }
 
+#endif /* CONFIG_VECTOR_FIND */
+
+#if CONFIG_NUMBERS_NORM
+
 /* Count the left shift amount to normalize a 32 bit signed integer value
  * without causing overflow. Input value 0 will result to 31.
  */
@@ -141,6 +151,8 @@ int norm_int32(int32_t val)
 
 	return 31 - c;
 }
+
+#endif /* CONFIG_NORM */
 
 /**
  * Basic CRC-32 implementation, based on pseudo-code from

--- a/src/math/trig.c
+++ b/src/math/trig.c
@@ -12,7 +12,6 @@
 #include <sof/math/cordic.h>
 #include <stdint.h>
 
-#ifdef CONFIG_CORDIC_TRIGONOMETRY_FIXED
 /* Use a local definition to avoid adding a dependency on <math.h> */
 #define _M_PI		3.14159265358979323846	/* pi */
 
@@ -280,5 +279,3 @@ void cmpx_cexp(int32_t sign, int32_t b_yn, int32_t xn, cordic_cfg type, struct c
 		cexp->im = sat_int16(Q_SHIFT_RND((cexp->im), 30, 15));
 	}
 }
-
-#endif

--- a/test/cmocka/CMakeLists.txt
+++ b/test/cmocka/CMakeLists.txt
@@ -107,6 +107,9 @@ function(cmocka_test test_name)
 	# Cmocka requires this define for stdint.h that defines uintptr
 	target_compile_definitions(${test_name} PRIVATE -D_UINTPTR_T_DEFINED)
 
+        # Enable features those would be disabled in some platforms
+	target_compile_definitions(${test_name} PRIVATE -DCONFIG_NUMBERS_GCD -DCONFIG_NUMBERS_NORM -DCONFIG_NUMBERS_VECTOR_FIND)
+
 	# Skip running alloc test on HOST until it's fixed (it passes and is run
 	# with xt-run)
 	if( "alloc" STREQUAL "${test_name}" AND BUILD_UNIT_TESTS_HOST)


### PR DESCRIPTION
This patch adds src/math/Kconfig with items CORDIC_TRIGONOMETRY_FIXED,
NUMBERS_GCD, NUMBERS_NORM, NUMBERS_VECTOR_FIND, MATH_DECIBELS, MATH_FFT,
MATH_FIR, and MATH_IIR_DF2T.

Configuration FIR and FFT were previously in src/audio/Kconfig but they
were moved to new math location for simplicity.

The CORDIRC_FIXED was removed and replaced by CORDIC_TRINONOMETRY_FIXED
that was used in the actual trig.c module.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>