### PR TITLE
xtensa-build-zephyr: guess CMake successes and failures better

### DIFF
--- a/scripts/xtensa-build-zephyr.sh
+++ b/scripts/xtensa-build-zephyr.sh
@@ -241,7 +241,8 @@ build_platforms()
 			 # west can get lost in symbolic links and then
 			 # show a confusing error.
 			/bin/pwd
-			if test -d "$bdir"; then
+
+			if test -e  "$bdir/build.ninja" || test -e  "$bdir/Makefile"; then
 			    test -z "${CMAKE_ARGS+defined}" ||
 				die 'Cannot re-define CMAKE_ARGS, you must delete %s first\n' \
 				    "$(pwd)/$bdir"


### PR DESCRIPTION
Recent commit b9fcc4156e5e ("xtensa-build-zephyr: fix incremental build,
pass CMAKE_ARGS only once") fixed incremental builds. For this it first
needs to guess whether the most recent CMake configuration step failed
or succeeded so it knows what is the current "checkpoint" and what is
the next west command to run. Merely testing whether the build directory
already exists is a very bad guess because that directory could have
been created by some other person or script, or - much worse - it could
have been created by a failed CMake configuration step!

The latter situation makes debugging CMake failures very tedious because
it requires manually deleting the build directory after each CMake
configuration failure.

Fix this by not merely looking for a build directory but by looking
whether there is either a build.ninja or a Makefile is found in that
directory. This is a much better indication that the CMake configuration
succeeded.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>