### PR TITLE
pipeline: remove a wrong warning

### DIFF
--- a/src/audio/pipeline/pipeline-schedule.c
+++ b/src/audio/pipeline/pipeline-schedule.c
@@ -70,7 +70,7 @@ static enum task_state pipeline_task_cmd(struct pipeline *p,
 		}
 
 		if (err == PPL_STATUS_PATH_STOP) {
-			pipe_warn(p, "pipeline_task_cmd(): stopping for xrun");
+			/* comp_trigger() interrupted trigger propagation or an xrun occurred */
 			err = SOF_TASK_STATE_COMPLETED;
 		} else if (p->trigger.cmd != cmd) {
 			/* PRE stage completed */


### PR DESCRIPTION
PPL_STATUS_PATH_STOP is not necessarily an indication of an xrun, it can also be returned by pipeline_trigger_run() in other perfectly normal cases. Remove the misleading left-over warning.
