### PR TITLE
edf_schedule: clear interrupt before enabling

### DIFF
--- a/src/schedule/edf_schedule.c
+++ b/src/schedule/edf_schedule.c
@@ -275,6 +275,9 @@ int scheduler_init_edf(void)
 	if (edf_sch->irq < 0)
 		return edf_sch->irq;
 
+	interrupt_mask(edf_sch->irq, cpu_get_id());
+	interrupt_unmask(edf_sch->irq, cpu_get_id());
+
 	interrupt_register(edf_sch->irq, edf_scheduler_run, edf_sch);
 	interrupt_enable(edf_sch->irq, edf_sch);
 


### PR DESCRIPTION
When resuming after a suspend, sometimes a spurious EDF interrupt arrives, causing panic in assert() in edf_scheduler_run(). Clear the interrupt before enabling it to avoid that.
