### PR TITLE
xtensa-build-zephyr: build ICL by default again

### DIFF
--- a/scripts/xtensa-build-zephyr.sh
+++ b/scripts/xtensa-build-zephyr.sh
@@ -331,7 +331,7 @@ parse_args()
 
 	    ( cd "$zeproj"
 	      test "$(realpath "$(west topdir)")" = "$(/bin/pwd)"
-	    ) || die '%s is not a zephyrproject' "$WEST_TOP"
+	    ) || die '%s is not the top of a zephyr project' "$zeproj"
 
 	    WEST_TOP="$zeproj"
 	fi

--- a/scripts/xtensa-build-zephyr.sh
+++ b/scripts/xtensa-build-zephyr.sh
@@ -18,10 +18,9 @@ SUPPORTED_PLATFORMS+=(imx8 imx8x imx8m)
 # -a
 DEFAULT_PLATFORMS=("${SUPPORTED_PLATFORMS[@]}")
 
-# REVERTME: temporarily exclude ICL because of .noinit/.cached section
-# overlap and build failure
-# https://github.com/zephyrproject-rtos/zephyr/pull/40319
-unset DEFAULT_PLATFORMS[2]
+# How to exclude one platform from the default builds while leaving it
+# possible to build individually:
+# unset DEFAULT_PLATFORMS[2]
 
 BUILD_JOBS=$(nproc --all)
 PLATFORMS=()


### PR DESCRIPTION
ICL linking overlap issue has been fixed by
zephyrproject-rtos/zephyr#39603

This is a logical revert of commit d4b8a01 ("xtensa-build-zephyr:
temporarily exclude ICL")

Signed-off-by: Marc Herbert <marc.herbert@intel.com>