### PR TITLE
Add RTNR support in intel-generic-dmic-kwd.m4 for adl-003-drop-stable branch

### DIFF
--- a/tools/topology/platform/intel/intel-generic-dmic-kwd.m4
+++ b/tools/topology/platform/intel/intel-generic-dmic-kwd.m4
@@ -47,7 +47,9 @@ ifdef(`DMIC_DAI_LINK_16k_NAME',`',define(DMIC_DAI_LINK_16k_NAME, `dmic16k'))
 # DMICPROC is set by makefile, available type: passthrough/eq-iir-volume
 ifdef(`IGO',
 `define(DMICPROC, igonr)',
-`ifdef(`DMICPROC', , `define(DMICPROC, passthrough)')')
+`ifdef(`RTNR',
+`define(DMICPROC, rtnr)',
+`define(DMICPROC, passthrough)')')
 
 # Prolong period to 16ms for igo_nr process
 ifdef(`IGO', `define(`INTEL_GENERIC_DMIC_KWD_PERIOD', 16000)', `define(`INTEL_GENERIC_DMIC_KWD_PERIOD', 1000)')


### PR DESCRIPTION
This PR is to cherry-pick commit that adds RTNR support in intel-generic-dmic-kwd.m4 for adl-003-drop-stable branch.