### PR TITLE
pipeline: set status to ACTIVE on all connected triggered pipelines

### DIFF
--- a/src/audio/pipeline/pipeline-schedule.c
+++ b/src/audio/pipeline/pipeline-schedule.c
@@ -51,6 +51,9 @@ static enum task_state pipeline_task_cmd(struct pipeline *p,
 		case COMP_TRIGGER_PAUSE:
 			return p->trigger.aborted ? SOF_TASK_STATE_RUNNING :
 				SOF_TASK_STATE_COMPLETED;
+		case COMP_TRIGGER_PRE_START:
+		case COMP_TRIGGER_PRE_RELEASE:
+			p->status = COMP_STATE_ACTIVE;
 		}
 
 		return SOF_TASK_STATE_RESCHEDULE;


### PR DESCRIPTION
This fixes a problem with pipelines, connected over a demultiplexer. In such cases one of pipelines keeps an inactive status and terminates during the next scheduler run after a START or a RELEASE.
