### PR TITLE
logger: rename asprintf and vasprintf

### DIFF
--- a/tools/logger/convert.c
+++ b/tools/logger/convert.c
@@ -79,17 +79,17 @@ char *format_uid_raw(const struct sof_uuid_entry *uid_entry, int use_colors, int
 	uint16_t c = be ? htobe16(uid_val->c) : uid_val->c;
 	char *str;
 
-	str = asprintf(upper ? UUID_UPPER : UUID_LOWER,
-		use_colors ? KBLU : "",
-		name_first ? uid_entry->name : "",
-		name_first ? " " : "",
-		a, b, c,
-		uid_val->d[0], uid_val->d[1], uid_val->d[2],
-		uid_val->d[3], uid_val->d[4], uid_val->d[5],
-		uid_val->d[6], uid_val->d[7],
-		name_first ? "" : " ",
-		name_first ? "" : uid_entry->name,
-		use_colors ? KNRM : "");
+	str = log_asprintf(upper ? UUID_UPPER : UUID_LOWER,
+			   use_colors ? KBLU : "",
+			   name_first ? uid_entry->name : "",
+			   name_first ? " " : "",
+			   a, b, c,
+			   uid_val->d[0], uid_val->d[1], uid_val->d[2],
+			   uid_val->d[3], uid_val->d[4], uid_val->d[5],
+			   uid_val->d[6], uid_val->d[7],
+			   name_first ? "" : " ",
+			   name_first ? "" : uid_entry->name,
+			   use_colors ? KNRM : "");
 	return str;
 }
 
@@ -247,7 +247,7 @@ static void process_params(struct proc_ldc_entry *pe,
 			/* %s format specifier */
 			/* check for string printing, because it leads to logger crash */
 			log_err("String printing is not supported\n");
-			pe->params[i] = (uintptr_t)asprintf("<String @ 0x%08x>", raw_param);
+			pe->params[i] = (uintptr_t)log_asprintf("<String @ 0x%08x>", raw_param);
 			pe->subst_mask |= 1 << i;
 			++i;
 			p += 2;

--- a/tools/logger/logger.c
+++ b/tools/logger/logger.c
@@ -161,9 +161,9 @@ static int append_filter_config(struct convert_config *config, const char *input
 
 	/* filer_config can't be NULL for following steps */
 	if (!old_config)
-		old_config = asprintf("%s", "");
+		old_config = log_asprintf("%s", "");
 
-	config->filter_config = asprintf("%s%s\n", old_config, input);
+	config->filter_config = log_asprintf("%s%s\n", old_config, input);
 	free(old_config);
 	if (!config->filter_config)
 		return -ENOMEM;

--- a/tools/logger/misc.c
+++ b/tools/logger/misc.c
@@ -12,7 +12,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-char *vasprintf(const char *format, va_list args)
+char *log_vasprintf(const char *format, va_list args)
 {
 	va_list args_copy;
 	int size;
@@ -29,13 +29,13 @@ char *vasprintf(const char *format, va_list args)
 	return result;
 }
 
-char *asprintf(const char *format, ...)
+char *log_asprintf(const char *format, ...)
 {
 	va_list args;
 	char *result;
 
 	va_start(args, format);
-	result = vasprintf(format, args);
+	result = log_vasprintf(format, args);
 	va_end(args);
 
 	return result;

--- a/tools/logger/misc.h
+++ b/tools/logger/misc.h
@@ -8,12 +8,12 @@
 #include <stdarg.h>
 #include <stdlib.h>
 
-char *vasprintf(const char *format, va_list args);
+char *log_vasprintf(const char *format, va_list args);
 
 #ifdef __GNUC__
 __attribute__((format(printf, 1, 2)))
 #endif
-char *asprintf(const char *format, ...);
+char *log_asprintf(const char *format, ...);
 
 #ifdef __GNUC__
 __attribute__((format(printf, 1, 2)))


### PR DESCRIPTION
Rename asprintf and vasprintf into log_asprintf and log_vasprintf as the
names could clash with the standard libc ones. These functions are there
originally done because of windows compatibility, but the naming was not
thought through carefully.

Signed-off-by: Jaska Uimonen <jaska.uimonen@intel.com>