### PR TITLE
check patch: allow C99 comments

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -22,7 +22,7 @@ jobs:
       # TODO: reduce duplication with scripts/sof-*-commit-hook.sh
       # thanks to either some .conf file or some wrapper script
       CHK_CMD_OPTS: --ignore UNKNOWN_COMMIT_ID --codespell
-         --ignore C99_COMMENT_TOLERANCE
+
     steps:
       # depth 2 so:
       # ^1. we can show the Subject of the current target branch tip

--- a/scripts/sof-post-commit-hook.sh
+++ b/scripts/sof-post-commit-hook.sh
@@ -7,4 +7,4 @@ set -e
 # and with .github/workflows/ with either some .conf file
 # or some wrapper script
 exec git show --format=email HEAD |
-  ./scripts/checkpatch.pl --no-tree --strict --codespell --ignore C99_COMMENT_TOLERANCE
+  ./scripts/checkpatch.pl --no-tree --strict --codespell


### PR DESCRIPTION
This is a logical revert of eb45907

Based on recently merged #4941, C99 comments are now OK. I never found
any rationale or even written down coding style for excluding them in
the first place.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>