### PR TITLE
Ipc4: container size support in format conversion

### DIFF
--- a/src/audio/copier.c
+++ b/src/audio/copier.c
@@ -431,17 +431,12 @@ static bool use_no_container_convert_function(enum sof_ipc_frame in,
 					      enum sof_ipc_frame valid_out_bits)
 {
 	/* valid sample size is equal to container size, go normal path */
-	if (in == out && valid_in_bits == valid_out_bits)
-		return true;
+	if (in == valid_in_bits && out == valid_out_bits) {
+		if (in == SOF_IPC_FRAME_S24_3LE || out == SOF_IPC_FRAME_S24_3LE)
+			return false;
 
-	/* go normal path for S24_4LE case since container is always 32 bits */
-	if (valid_in_bits == SOF_IPC_FRAME_S24_4LE && in == SOF_IPC_FRAME_S32_LE &&
-	    valid_out_bits == SOF_IPC_FRAME_S32_LE && out == SOF_IPC_FRAME_S32_LE)
 		return true;
-
-	if (valid_in_bits == SOF_IPC_FRAME_S32_LE && in == SOF_IPC_FRAME_S32_LE &&
-	    valid_out_bits == SOF_IPC_FRAME_S24_4LE && out == SOF_IPC_FRAME_S32_LE)
-		return true;
+	}
 
 	return false;
 }

--- a/src/include/ipc/stream.h
+++ b/src/include/ipc/stream.h
@@ -55,6 +55,7 @@ enum sof_ipc_frame {
 	SOF_IPC_FRAME_S32_LE,
 	SOF_IPC_FRAME_FLOAT,
 	/* other formats here */
+	SOF_IPC_FRAME_S24_3LE,
 };
 
 /* stream buffer format */

--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -54,6 +54,8 @@ struct audio_stream {
 
 	/* runtime stream params */
 	enum sof_ipc_frame frame_fmt;	/**< Sample data format */
+	enum sof_ipc_frame valid_sample_fmt;
+
 	uint32_t rate;		/**< Number of data frames per second [Hz] */
 	uint16_t channels;	/**< Number of samples in each frame */
 

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -201,7 +201,8 @@ static struct comp_buffer *ipc4_create_buffer(struct comp_dev *src, struct comp_
 	src_cfg = (struct ipc4_base_module_cfg *)comp_get_drvdata(src);
 	sink_cfg = (struct ipc4_base_module_cfg *)comp_get_drvdata(sink);
 
-	buf_size = MAX(src_cfg->obs, sink_cfg->ibs);
+	/* double it since obs is single buffer size */
+	buf_size = src_cfg->obs * 2;
 	memset(&ipc_buf, 0, sizeof(ipc_buf));
 	ipc_buf.size = buf_size;
 	ipc_buf.comp.id = IPC4_COMP_ID(src_queue, dst_queue);

--- a/test/cmocka/src/audio/eq_iir/eq_iir_process.c
+++ b/test/cmocka/src/audio/eq_iir/eq_iir_process.c
@@ -383,6 +383,8 @@ static void test_audio_eq_iir(void **state)
 		case SOF_IPC_FRAME_S32_LE:
 			fill_source_s32(td, frames);
 			break;
+		case SOF_IPC_FRAME_S24_3LE:
+			break;
 		default:
 			assert(0);
 			break;

--- a/test/cmocka/src/audio/mux/demux_copy.c
+++ b/test/cmocka/src/audio/mux/demux_copy.c
@@ -305,6 +305,10 @@ int main(void)
 				tests[ti].test_func = test_demux_copy_proc_32;
 				break;
 #endif /* CONFIG_FORMAT_S32LE */
+#if CONFIG_FORMAT_S24_3LE
+			case SOF_IPC_FRAME_S24_3LE:
+				break;
+#endif /* CONFIG_FORMAT_S24_3LE */
 			default:
 				return -EINVAL;
 			}

--- a/test/cmocka/src/audio/mux/mux_copy.c
+++ b/test/cmocka/src/audio/mux/mux_copy.c
@@ -324,6 +324,10 @@ int main(void)
 				tests[ti].test_func = test_mux_copy_proc_32;
 				break;
 #endif /* CONFIG_FORMAT_S32LE */
+#if CONFIG_FORMAT_S24_3LE
+			case SOF_IPC_FRAME_S24_3LE:
+				break;
+#endif /* CONFIG_FORMAT_S24_3LE */
 			default:
 				return -EINVAL;
 			}

--- a/test/cmocka/src/audio/selector/selector_test.c
+++ b/test/cmocka/src/audio/selector/selector_test.c
@@ -280,8 +280,10 @@ static void test_audio_sel(void **state)
 		fill_source_s32(sel_state);
 		break;
 #endif /* CONFIG_FORMAT_S24LE || CONFIG_FORMAT_S32LE */
+/* TODO: add S24_3LE support */
+	case SOF_IPC_FRAME_S24_3LE:
+		break;
 	}
-
 	cd->sel_func(sel_state->dev, &sel_state->sink->stream, &sel_state->source->stream,
 		     sel_state->dev->frames);
 

--- a/test/cmocka/src/audio/volume/volume_process.c
+++ b/test/cmocka/src/audio/volume/volume_process.c
@@ -385,6 +385,9 @@ static void test_audio_vol(void **state)
 	case SOF_IPC_FRAME_FLOAT:
 		fill_source_s32(vol_state);
 		break;
+	case SOF_IPC_FRAME_S24_3LE:
+		/* TODO: add 3LE support */
+		break;
 	}
 
 	cd->scale_vol(vol_state->dev, &vol_state->sink->stream,


### PR DESCRIPTION
    Ipc4 stream have container size and valid sample size.
    In windows system, container size is normally 32bit
    and valid sample size is 16bit or 24bit rely on system
    setting. Currently host and dai component are included
    by copier module to manage gateway. These two components
    doesn't support container size and all the code is designed
    for the case that container size is always equal to valid
    sample size.


With this patch HDA playback works with default windows audio player in format of 16bit/48000HZ/2CH.  24bit will be added later and it is a little tricky since it is really S24_3LE