### PR TITLE
Audio: KPB: Optimize drain, buffer and copy functions

### DIFF
--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -471,3 +471,68 @@ struct comp_dev *comp_make_shared(struct comp_dev *dev)
 
 	return dev;
 }
+
+int audio_stream_copy(const struct audio_stream *source, uint32_t ioffset,
+		      struct audio_stream *sink, uint32_t ooffset, uint32_t samples)
+{
+	int ssize = audio_stream_sample_bytes(source); /* src fmt == sink fmt */
+	uint8_t *src = audio_stream_wrap(source, (uint8_t *)source->r_ptr + ioffset * ssize);
+	uint8_t *snk = audio_stream_wrap(sink, (uint8_t *)sink->w_ptr + ooffset * ssize);
+	size_t bytes = samples * ssize;
+	size_t bytes_src;
+	size_t bytes_snk;
+	size_t bytes_copied;
+
+	while (bytes) {
+		bytes_src = audio_stream_bytes_without_wrap(source, src);
+		bytes_snk = audio_stream_bytes_without_wrap(sink, snk);
+		bytes_copied = MIN(bytes_src, bytes_snk);
+		bytes_copied = MIN(bytes, bytes_copied);
+		memcpy(snk, src, bytes_copied);
+		bytes -= bytes_copied;
+		src = audio_stream_wrap(source, src + bytes_copied);
+		snk = audio_stream_wrap(sink, snk + bytes_copied);
+	}
+
+	return samples;
+}
+
+void audio_stream_copy_from_linear(void *linear_source, int ioffset,
+				   struct audio_stream *sink, int ooffset, unsigned int samples)
+{
+	int ssize = audio_stream_sample_bytes(sink); /* src fmt == sink fmt */
+	uint8_t *src = (uint8_t *)linear_source + ioffset * ssize;
+	uint8_t *snk = audio_stream_wrap(sink, (uint8_t *)sink->w_ptr + ooffset * ssize);
+	size_t bytes = samples * ssize;
+	size_t bytes_snk;
+	size_t bytes_copied;
+
+	while (bytes) {
+		bytes_snk = audio_stream_bytes_without_wrap(sink, snk);
+		bytes_copied = MIN(bytes, bytes_snk);
+		memcpy(snk, src, bytes_copied);
+		bytes -= bytes_copied;
+		src += bytes_copied;
+		snk = audio_stream_wrap(sink, snk + bytes_copied);
+	}
+}
+
+void audio_stream_copy_to_linear(struct audio_stream *source, int ioffset,
+				 void *linear_sink, int ooffset, unsigned int samples)
+{
+	int ssize = audio_stream_sample_bytes(source); /* src fmt == sink fmt */
+	uint8_t *src = audio_stream_wrap(source, (uint8_t *)source->r_ptr + ioffset * ssize);
+	uint8_t *snk = (uint8_t *)linear_sink + ooffset * ssize;
+	size_t bytes = samples * ssize;
+	size_t bytes_src;
+	size_t bytes_copied;
+
+	while (bytes) {
+		bytes_src = audio_stream_bytes_without_wrap(source, src);
+		bytes_copied = MIN(bytes, bytes_src);
+		memcpy(snk, src, bytes_copied);
+		bytes -= bytes_copied;
+		src = audio_stream_wrap(source, src + bytes_copied);
+		snk += bytes_copied;
+	}
+}

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -1327,39 +1327,20 @@ out:
 static void kpb_drain_samples(void *source, struct audio_stream *sink,
 			      size_t size, size_t sample_width)
 {
-#if CONFIG_FORMAT_S16LE || CONFIG_FORMAT_S24LE || CONFIG_FORMAT_S32LE
-	void *dst;
-	void *src = source;
-	size_t i;
-	size_t j = 0;
-	size_t channel;
-	size_t frames = KPB_BYTES_TO_FRAMES(size, sample_width);
-#endif
+	unsigned int samples;
 
 	switch (sample_width) {
 #if CONFIG_FORMAT_S16LE
 	case 16:
-		for (i = 0; i < frames; i++) {
-			for (channel = 0; channel < KPB_NUM_OF_CHANNELS; channel++) {
-				dst = audio_stream_write_frag_s16(sink, j);
-				*((int16_t *)dst) = *((int16_t *)src);
-				src = ((int16_t *)src) + 1;
-				j++;
-			}
-		}
+		samples = KPB_BYTES_TO_S16_SAMPLES(size);
+		audio_stream_copy_from_linear(source, 0, sink, 0, samples);
 		break;
 #endif /* CONFIG_FORMAT_S16LE */
 #if CONFIG_FORMAT_S24LE || CONFIG_FORMAT_S32LE
 	case 24:
 	case 32:
-		for (i = 0; i < frames; i++) {
-			for (channel = 0; channel < KPB_NUM_OF_CHANNELS; channel++) {
-				dst = audio_stream_write_frag_s32(sink, j);
-				*((int32_t *)dst) = *((int32_t *)src);
-				src = ((int32_t *)src) + 1;
-				j++;
-			}
-		}
+		samples = KPB_BYTES_TO_S32_SAMPLES(size);
+		audio_stream_copy_from_linear(source, 0, sink, 0, samples);
 		break;
 #endif /* CONFIG_FORMAT_S24LE || CONFIG_FORMAT_S32LE */
 	default:

--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -555,32 +555,8 @@ audio_stream_frames_without_wrap(const struct audio_stream *source,
  * @param samples Number of samples to copy.
  * @return number of processed samples.
  */
-static inline int audio_stream_copy(const struct audio_stream *source,
-				     uint32_t ioffset,
-				     struct audio_stream *sink,
-				     uint32_t ooffset, uint32_t samples)
-{
-	int ssize = audio_stream_sample_bytes(source); /* src fmt == sink fmt */
-	uint8_t *src = audio_stream_wrap(source, (uint8_t *)source->r_ptr + ioffset * ssize);
-	uint8_t *snk = audio_stream_wrap(sink, (uint8_t *)sink->w_ptr + ooffset * ssize);
-	size_t bytes = samples * ssize;
-	size_t bytes_src;
-	size_t bytes_snk;
-	size_t bytes_copied;
-
-	while (bytes) {
-		bytes_src = audio_stream_bytes_without_wrap(source, src);
-		bytes_snk = audio_stream_bytes_without_wrap(sink, snk);
-		bytes_copied = MIN(bytes_src, bytes_snk);
-		bytes_copied = MIN(bytes, bytes_copied);
-		memcpy(snk, src, bytes_copied);
-		bytes -= bytes_copied;
-		src = audio_stream_wrap(source, src + bytes_copied);
-		snk = audio_stream_wrap(sink, snk + bytes_copied);
-	}
-
-	return samples;
-}
+int audio_stream_copy(const struct audio_stream *source, uint32_t ioffset,
+		      struct audio_stream *sink, uint32_t ooffset, uint32_t samples);
 
 /**
  * Copies data from linear source buffer to circular sink buffer.
@@ -590,26 +566,8 @@ static inline int audio_stream_copy(const struct audio_stream *source,
  * @param ooffset Offset (in samples) in sink buffer to start writing to.
  * @param samples Number of samples to copy.
  */
-static inline void audio_stream_copy_from_linear(void *linear_source, int ioffset,
-						 struct audio_stream *sink, int ooffset,
-						 unsigned int samples)
-{
-	int ssize = audio_stream_sample_bytes(sink); /* src fmt == sink fmt */
-	uint8_t *src = (uint8_t *)linear_source + ioffset * ssize;
-	uint8_t *snk = audio_stream_wrap(sink, (uint8_t *)sink->w_ptr + ooffset * ssize);
-	size_t bytes = samples * ssize;
-	size_t bytes_snk;
-	size_t bytes_copied;
-
-	while (bytes) {
-		bytes_snk = audio_stream_bytes_without_wrap(sink, snk);
-		bytes_copied = MIN(bytes, bytes_snk);
-		memcpy(snk, src, bytes_copied);
-		bytes -= bytes_copied;
-		src += bytes_copied;
-		snk = audio_stream_wrap(sink, snk + bytes_copied);
-	}
-}
+void audio_stream_copy_from_linear(void *linear_source, int ioffset,
+				   struct audio_stream *sink, int ooffset, unsigned int samples);
 
 /**
  * Copies data from circular source buffer to linear sink buffer.
@@ -619,26 +577,8 @@ static inline void audio_stream_copy_from_linear(void *linear_source, int ioffse
  * @param ooffset Offset (in samples) in sink buffer to start writing to.
  * @param samples Number of samples to copy.
  */
-static inline void audio_stream_copy_to_linear(struct audio_stream *source, int ioffset,
-					       void *linear_sink, int ooffset,
-					       unsigned int samples)
-{
-	int ssize = audio_stream_sample_bytes(source); /* src fmt == sink fmt */
-	uint8_t *src = audio_stream_wrap(source, (uint8_t *)source->r_ptr + ioffset * ssize);
-	uint8_t *snk = (uint8_t *)linear_sink + ooffset * ssize;
-	size_t bytes = samples * ssize;
-	size_t bytes_src;
-	size_t bytes_copied;
-
-	while (bytes) {
-		bytes_src = audio_stream_bytes_without_wrap(source, src);
-		bytes_copied = MIN(bytes, bytes_src);
-		memcpy(snk, src, bytes_copied);
-		bytes -= bytes_copied;
-		src = audio_stream_wrap(source, src + bytes_copied);
-		snk += bytes_copied;
-	}
-}
+void audio_stream_copy_to_linear(struct audio_stream *source, int ioffset,
+				 void *linear_sink, int ooffset, unsigned int samples);
 
 /**
  * Writes zeros in range [w_ptr, w_ptr+bytes], with rollover if necessary.

--- a/src/include/sof/audio/kpb.h
+++ b/src/include/sof/audio/kpb.h
@@ -47,6 +47,10 @@ struct comp_buffer;
 /**< Host buffer shall be at least two times bigger than history buffer. */
 #define HOST_BUFFER_MIN_SIZE(hb) (hb * 2)
 
+/**< Convert with right shift a bytes count to samples count */
+#define KPB_BYTES_TO_S16_SAMPLES(s)	((s) >> 1)
+#define KPB_BYTES_TO_S32_SAMPLES(s)	((s) >> 2)
+
 /** All states below as well as relations between them are documented in
  * the sof-dosc in [kpbm-state-diagram]
  * Therefore any addition of new states or modification of existing ones

--- a/test/cmocka/src/audio/pcm_converter/CMakeLists.txt
+++ b/test/cmocka/src/audio/pcm_converter/CMakeLists.txt
@@ -6,6 +6,7 @@ if(CONFIG_FORMAT_FLOAT)
 		${PROJECT_SOURCE_DIR}/src/audio/pcm_converter/pcm_converter.c
 		${PROJECT_SOURCE_DIR}/src/audio/pcm_converter/pcm_converter_generic.c
 		${PROJECT_SOURCE_DIR}/src/audio/buffer.c
+		${PROJECT_SOURCE_DIR}/src/audio/component.c
 		${PROJECT_SOURCE_DIR}/src/ipc/ipc3/helper.c
 		${PROJECT_SOURCE_DIR}/test/cmocka/src/notifier_mocks.c
 		${PROJECT_SOURCE_DIR}/src/ipc/ipc-common.c


### PR DESCRIPTION
The three commits contain the optimizations for the three copy functions. The optimizations are the same for the slightly different functions.