### PR TITLE
zephyr/cmake: BUILD_ALWAYS for smex and sof-logger

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -67,6 +67,7 @@ ExternalProject_Add(smex_ep
 	# The default paths are very "deep"
 	PREFIX     "${PROJECT_BINARY_DIR}/smex_ep"
 	BINARY_DIR "${PROJECT_BINARY_DIR}/smex_ep/build"
+	BUILD_ALWAYS 1
 	INSTALL_COMMAND "" # need smex only at build time
 )
 
@@ -76,6 +77,7 @@ ExternalProject_Add(sof_logger_ep
 	PREFIX     "${PROJECT_BINARY_DIR}/sof-logger_ep"
 	BINARY_DIR "${PROJECT_BINARY_DIR}/sof-logger_ep/build"
 	BUILD_COMMAND cmake --build . --target sof-logger
+	BUILD_ALWAYS 1
 	INSTALL_COMMAND ""
 )
 


### PR DESCRIPTION
Discovered the hard way that the Zephyr build assumes sof-logger is
always up to date when present. It's not clear from cmake's
ExternalProject documentation why that is the case. In any case
BUILD_ALWAYS fixes the issue and takes very little time because it does
not rebuild sof-logger from scratch. BUILD_ALWAYS is already used for
XTOS.

Fixes commit f6c71c21d03b8 ("zephyr/CMakeLists.txt: build smex and
sof-logger")

Signed-off-by: Marc Herbert <marc.herbert@intel.com>