### PR TITLE
Audio: Select: Optimize data copy operations

### DIFF
--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -197,7 +197,7 @@ static int selector_verify_params(struct comp_dev *dev,
 		return -EINVAL;
 	}
 
-	if (cd->config.sel_channel > (SEL_SOURCE_4CH - 1)) {
+	if (cd->config.sel_channel > (params->channels - 1)) {
 		comp_err(dev, "selector_verify_params(): ch_idx = %u"
 			 , cd->config.sel_channel);
 		return -EINVAL;


### PR DESCRIPTION
This patch replaces the per sample done circular copies with
audio_stream_read/write_frag_s16/32() functions calls with
max. length linear copies.

The original copy function for >1ch sink is just 1:1 copy
from source to sink without controllable channel select. This
patch preserves the functionality and implements the copy with
memcpy().

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>