### PR TITLE
xtensa-build-zephyr: use rev2 board TGL-H build of cavs25

### DIFF
--- a/scripts/xtensa-build-zephyr.sh
+++ b/scripts/xtensa-build-zephyr.sh
@@ -195,7 +195,11 @@ build_platforms()
 				XTENSA_TOOLS_VERSION="RG-2017.8-linux"
 				;;
 			tgl-h|tgl)
-				PLAT_CONFIG='intel_adsp_cavs25'
+				# zephyr syntax 'board_name@revision'
+				PLAT_CONFIG='intel_adsp_cavs25@4'
+				if test $platform = tgl-h ; then
+				    PLAT_CONFIG="intel_adsp_cavs25@2"
+				fi
 				XTENSA_CORE="cavs2x_LX6HiFi3_2017_8"
 				XTENSA_TOOLS_VERSION="RG-2017.8-linux"
 				RIMAGE_KEY=modules/audio/sof/keys/otc_private_key_3k.pem


### PR DESCRIPTION
Depends Zephyr commit: https://github.com/zephyrproject-rtos/zephyr/pull/40960

When building for TGL-H (2 DSP cores), we must use revision 2
of the Zephyr cavs25 board definition. Otherwise the core count
is incorrect and resulting firmware image will not boot.

BugLink: https://github.com/thesofproject/sof/issues/5055
Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>