### PR TITLE
audio: drc: Select DRC dependencies

### DIFF
--- a/src/audio/Kconfig
+++ b/src/audio/Kconfig
@@ -174,6 +174,8 @@ config COMP_CROSSOVER
 config COMP_DRC
 	bool "Dynamic Range Compressor component"
 	select CORDIC_FIXED
+	select NUMBERS_NORM
+	select MATH_DECIBELS
 	default n
 	help
 	  Select for Dynamic Range Compressor (DRC) component. A DRC can be used


### PR DESCRIPTION
DRC needs some math functions brought in by CONFIG_NUMBERS_NORM and
CONFIG_MATH_DECIBELS.

Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>