### PR TITLE
topology2: cavs-*-hdmi: replace the use of @args with Define

### DIFF
--- a/tools/topology/topology2/cavs-gain-hdmi.conf
+++ b/tools/topology/topology2/cavs-gain-hdmi.conf
@@ -18,10 +18,9 @@
 <manifest.conf>
 <route.conf>
 
-# arguments
-@args.HDA_CONFIG {
-       type string
-       default ""
+# variables
+Define {
+	HDA_CONFIG "gain"
 }
 
 # include HDA config if needed

--- a/tools/topology/topology2/cavs-passthrough-hdmi.conf
+++ b/tools/topology/topology2/cavs-passthrough-hdmi.conf
@@ -22,10 +22,9 @@
 <manifest.conf>
 <route.conf>
 
-# arguments
-@args.HDA_CONFIG {
-       type string
-       default ""
+# variables
+Define {
+	HDA_CONFIG "passthrough"
 }
 
 # include HDA config if needed.


### PR DESCRIPTION
The Define block replaces the use of @args for topology2 in the alsatplg
compiler. So replace all users.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>