### PR TITLE
IMX8ULP: Change default sample rate support

### DIFF
--- a/src/include/sof/drivers/sai.h
+++ b/src/include/sof/drivers/sai.h
@@ -251,7 +251,7 @@
  */
 #ifdef CONFIG_IMX8ULP
 /* frame clk is 16kHz on 8ulp */
-#define SAI_CLOCK_DIV		0xB
+#define SAI_CLOCK_DIV		0x17
 #define SAI_TDM_SLOTS		2
 #else
 #define SAI_CLOCK_DIV		0x7

--- a/tools/topology/topology1/sof-imx8ulp-btsco.m4
+++ b/tools/topology/topology1/sof-imx8ulp-btsco.m4
@@ -38,7 +38,7 @@ dnl     time_domain, sched_comp)
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	1, 0, 1, s16le,
 	1000, 0, 0,
-	16000, 16000, 16000)
+	8000, 8000, 8000)
 
 undefine(`CHANNELS_MIN')
 
@@ -47,7 +47,7 @@ undefine(`CHANNELS_MIN')
 PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	2, 0, 1, s16le,
 	1000, 0, 0,
-	16000, 16000, 16000)
+	8000, 8000, 8000)
 #
 # DAIs configuration
 #
@@ -80,6 +80,6 @@ dnl DAI_CONFIG(type, idx, link_id, name, sai_config)
 DAI_CONFIG(SAI, 5, 0, sai5-bt-sco-pcm-wb,
 	SAI_CONFIG(I2S, SAI_CLOCK(mclk, 12288000, codec_mclk_out),
 		SAI_CLOCK(bclk, 256000, codec_slave),
-		SAI_CLOCK(fsync, 16000, codec_slave),
+		SAI_CLOCK(fsync, 8000, codec_slave),
 		SAI_TDM(1, 16, 1, 1),
 		SAI_CONFIG_DATA(SAI, 5, 0)))


### PR DESCRIPTION
Cause BT is not supporting the 16Khz sample rate anymore, we need to match this.