### PR TITLE
sof_ri_info: assert Python version is 3.6 or above.

### DIFF
--- a/tools/sof_ri_info/sof_ri_info.py
+++ b/tools/sof_ri_info/sof_ri_info.py
@@ -22,6 +22,8 @@ import io
 import pathlib
 import hashlib
 
+# Required for open(pathlib)
+assert sys.version_info >= (3, 6)
 
 # To extend the DSP memory layout list scroll down to DSP_MEM_SPACE_EXT
 


### PR DESCRIPTION
As reported by @bkokoszx , Python 3.5.2 fails with the relatively cryptic
TypeError: invalid file: PosixPath('sof-tgl.ri'). Make this failure much
less cryptic.

As of December 2021 Python 3.5 is completely out of support and 3.6 will
be soon https://www.python.org/downloads/

Signed-off-by: Marc Herbert <marc.herbert@intel.com>