### PR TITLE
xtensa-build-zephyr: add deterministic sha256sum of final .ri file

### DIFF
--- a/scripts/xtensa-build-zephyr.sh
+++ b/scripts/xtensa-build-zephyr.sh
@@ -280,6 +280,14 @@ build_platforms()
 				--tool rimage --tool-path "$RIMAGE_DIR"/rimage \
 				--tool-data modules/audio/sof/rimage/config -- -k "$RIMAGE_KEY"
 		)
+
+		# A bit of a hack but it's very simple and saves a lot of duplication
+		grep -q "UNSIGNED_RI.*${platform}" "${SOF_TOP}"/src/arch/xtensa/CMakeLists.txt ||
+		    # This could use a -q(uiet) option...
+		    ${SOF_TOP}/tools/sof_ri_info/sof_ri_info.py \
+			--no_headers --no_modules --no_memory \
+			--erase_vars "$bdir"/zephyr/reproducible.ri "$bdir"/zephyr/zephyr.ri
+
 		install_opts -m 0644 "$bdir"/zephyr/zephyr.ri \
 			     "$STAGING"/sof/community/sof-"$platform".ri
 	done


### PR DESCRIPTION
Checksumming the final binary is useful to compare before/after some
configuration change or to compare builds across different people /
systems.

Because rimage is not deterministic, ask sof_ri_info to do this.

Sample output below or at https://github.com/thesofproject/sof/runs/4455053202
```
Firmware file size 0x55000 page count 79
 pkcs_v1_5_sign_man_v1_8: signing with key
               'modules/audio/sof/keys/otc_private_key.pem'
 pkcs: RSA private key is valid.
 pkcs: digest for manifest is 5b52ac0b8809503c817a96dac7c5124dba5a90d...
Firmware manifest and signing completed !
Extended manifest found module, type: 0x0001 size: 0x01A0 ( 416) offset:
Extended manifest found module, type: 0x0005 size: 0x0020 (  32) offset:
Extended manifest found module, type: 0x0004 size: 0x0020 (  32) offset:
Extended manifest found module, type: 0x0003 size: 0x0030 (  48) offset:
Extended manifest found module, type: 0x0002 size: 0x0070 ( 112) offset:
Extended manifest found module, type: 0x0000 size: 0x0050 (  80) offset:
Extended manifest saved zephyr/zephyr.ri.xman size 0x02E0 (736) bytes

SOF Binary build-apl/zephyr/zephyr.ri size 0x4f2e0

  Extended Manifest ver 1.0.0 length 736

  cavs0015 (ADSP Manifest) file offset 0x22e0 name ADSPFW build ver
             0.0.0.0 feature mask 0xffff image flags 0x0
    HW buffers base address 0x0 length 0x0
    Load offset 0x2000

sha256sum build-apl/zephyr/reproducible.ri
46f3404e3b674ed....120c2173d6050bde35b build-apl/zephyr/reproducible.ri
```
Signed-off-by: Marc Herbert <marc.herbert@intel.com>