### PR TITLE
Zephyr: fix log filtering

### DIFF
--- a/src/include/sof/trace/trace.h
+++ b/src/include/sof/trace/trace.h
@@ -379,7 +379,7 @@ struct tr_ctx {
 	uint32_t level;				/**< Default log level */
 };
 
-#if defined(UNIT_TEST) || defined(__ZEPHYR__)
+#if defined(UNIT_TEST)
 #define TRACE_CONTEXT_SECTION
 #else
 #define TRACE_CONTEXT_SECTION __section(".trace_ctx")

--- a/src/trace/trace.c
+++ b/src/trace/trace.c
@@ -342,7 +342,7 @@ struct sof_ipc_trace_filter_elem *trace_filter_fill(struct sof_ipc_trace_filter_
 static int trace_filter_update_global(int32_t log_level, uint32_t uuid_id)
 {
 	int cnt = 0;
-#if !defined(__ZEPHYR__) && !defined(CONFIG_LIBRARY)
+#if !defined(CONFIG_LIBRARY)
 	extern void *_trace_ctx_start;
 	extern void *_trace_ctx_end;
 	struct tr_ctx *ptr = (struct tr_ctx *)&_trace_ctx_start;


### PR DESCRIPTION
Fixes #5032.

Hard-dependency on zephyrproject-rtos/zephyr/pull/40975, Zephyr will fail to build until then.