### PR TITLE
topology1: build the production topologies one level down

### DIFF
--- a/tools/topology/topology1/CMakeLists.txt
+++ b/tools/topology/topology1/CMakeLists.txt
@@ -191,8 +191,18 @@ set(TPLGS
 	"sof-acp-renoir\;sof-acp"
 )
 
+# This empty 'production/' source subdirectory exists only to create the
+# corresponding 'production/' subdirectory in the build directory and
+# solve race https://github.com/thesofproject/sof/issues/5067 without
+# the disruption of actually moving all *.m4 sources one directory level
+# down.
+add_subdirectory(production)
+
+# "Install" all v1 production topologies two directory levels up. In the
+# future, v2 topologies will be "installed" instead in the same place so
+# users get upgraded without doing anything.
 add_custom_target(topologies1 ALL
-    COMMAND ${CMAKE_COMMAND} -E copy_directory . ${SOF_TOPOLOGY_BINARY_DIRECTORY}
+    COMMAND ${CMAKE_COMMAND} -E copy_directory production ${SOF_TOPOLOGY_BINARY_DIRECTORY}
 )
 
 foreach(tplg ${TPLGS})
@@ -209,7 +219,7 @@ foreach(tplg ${TPLGS})
 	endif()
 
 	add_custom_command(
-		OUTPUT ${output}.conf
+		OUTPUT production/${output}.conf
 		COMMAND m4 --fatal-warnings
 			${DEFINES}
 			-I ${CMAKE_CURRENT_SOURCE_DIR}/m4
@@ -219,7 +229,7 @@ foreach(tplg ${TPLGS})
 			-I ${CMAKE_CURRENT_BINARY_DIR}
 			${CMAKE_CURRENT_SOURCE_DIR}/common/abi.m4
 			${CMAKE_CURRENT_SOURCE_DIR}/${input}.m4
-			> ${output}.conf
+			> production/${output}.conf
 		MAIN_DEPENDENCY ${CMAKE_CURRENT_SOURCE_DIR}/${input}.m4
 		DEPENDS abi_v1
 		VERBATIM
@@ -242,13 +252,13 @@ foreach(tplg ${TPLGS})
 # (accidentally?) started ignoring the verbosity level, now it's just
 # verbose or not.
 	add_custom_command(
-		OUTPUT ${output}.tplg
-		COMMAND alsatplg \$\${VERBOSE:+-v 1} -c ${CMAKE_CURRENT_BINARY_DIR}/${output}.conf -o ${output}.tplg
-		MAIN_DEPENDENCY ${output}.conf
+		OUTPUT production/${output}.tplg
+		COMMAND alsatplg \$\${VERBOSE:+-v 1} -c production/${output}.conf -o production/${output}.tplg
+		MAIN_DEPENDENCY production/${output}.conf
 		USES_TERMINAL
 	)
 
-	add_custom_target(topology1_${output} DEPENDS ${output}.tplg)
+	add_custom_target(topology1_${output} DEPENDS production/${output}.tplg)
 	add_dependencies(topologies1 topology1_${output})
 endforeach()
 

--- a/tools/topology/topology1/production/CMakeLists.txt
+++ b/tools/topology/topology1/production/CMakeLists.txt
@@ -1,0 +1,4 @@
+# Empty source directory, exists only to create the corresponding
+# 'production' subdirectory in the build directory and solve race
+# https://github.com/thesofproject/sof/issues/5067 without actually
+# moving all *.m4 sources one level down.


### PR DESCRIPTION
Move generated *.conf and *.tplg v1 files down from:
```
  build_tools/topology/topology1/*.{conf,tplg}
```
_to:
```
  build_tools/topology/topology1/production/*.{conf,tplg}
```
... then copy/"install" the production/* subdirectory two levels up.

This fixes the race condition #5067 that also copied a random number of
development/ and dsp_enhancement/ topologies, sometimes even truncating
these.

In other words, this commit REMOVES the following two copies:
```
build_tools/topology/development/       # randomly corrupted copy, removed
build_tools/topology/dsp_enhancement/   # randomly corrupted copy, removed

build_tools/topology/topology1/development/    # real build dir, unchanged
build_tools/topology/topology1/dsp_enhancement # real build dir, unchanged
```
Production topologies are copied only to help with the v1->v2
transition. That duplication makes the build directory confusing enough,
no need to extend that copy to development topologies. A single instance
of development topologies in the build directory is enough.

This removal may break some CI script(s): this is perfect because such
CI script(s) were copying randomly corrupted data.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>