### PR TITLE
Add audio formats and other attributes for cavs modules

### DIFF
--- a/tools/topology/topology2/cavs-gain-hda.conf
+++ b/tools/topology/topology2/cavs-gain-hda.conf
@@ -4,12 +4,10 @@ Object.Dai {
 		id 4
 		index 0
 		default_hw_conf_id 4
-		Object.Base.hw_config.HDA0 [
-		]
+		Object.Base.hw_config.HDA0 {}
 		Object.Widget.copier.0 {
 			direction playback
 			index 1
-			dai_index 1
 			type dai_in
 			dai_type "HDA"
 			copier_type "HDA"
@@ -17,19 +15,45 @@ Object.Dai {
 			period_sink_count 0
 			period_source_count 2
 			format s32le
+			node_type $HDA_LINK_OUTPUT_CLASS
+			num_audio_formats 2
+			# 16-bit 48KHz 2ch
+			Object.Base.audio_format.1 {
+				dma_buffer_size "$[$obs * 2]"
+			}
+			# 32-bit 48KHz 2ch
+			Object.Base.audio_format.2 {
+				in_bit_depth		32
+				in_valid_bit_depth	32
+				out_bit_depth		32
+				out_valid_bit_depth	32
+				dma_buffer_size "$[$obs * 2]"
+			}
 		}
 		Object.Widget.copier.1 {
 			direction capture
 			index 2
-			dai_index 2
 			type dai_out
 			dai_type "HDA"
-                        copier_type "HDA"
+			copier_type "HDA"
 			stream_name 'Analog Playback and Capture'
-			dai_index 1
 			period_sink_count 2
 			period_source_count 0
 			format s32le
+			node_type $HDA_LINK_INPUT_CLASS
+			num_audio_formats 2
+			# 16-bit 48KHz 2ch
+			Object.Base.audio_format.1 {
+				dma_buffer_size "$[$ibs * 2]"
+			}
+			# 32-bit 48KHz 2ch
+			Object.Base.audio_format.2 {
+				in_bit_depth		32
+				in_valid_bit_depth	32
+				out_bit_depth		32
+				out_valid_bit_depth	32
+				dma_buffer_size "$[$ibs * 2]"
+			}
 		}
 		direction duplex
 	}
@@ -38,33 +62,56 @@ Object.Dai {
 		id 5
 		index 0
 		default_hw_conf_id 5
-		Object.Base.hw_config.HDA1 [
-		]
+		Object.Base.hw_config.HDA1 {}
 		Object.Widget.copier.0 {
 			direction playback
 			index 3
-			dai_index 3
 			type dai_in
 			dai_type "HDA"
-                        copier_type "HDA"
+			copier_type "HDA"
 			stream_name 'Digital Playback and Capture'
-			dai_index 2
 			period_sink_count 0
 			period_source_count 2
 			format s32le
+			node_type $HDA_LINK_OUTPUT_CLASS
+			num_audio_formats 2
+			# 16-bit 48KHz 2ch
+			Object.Base.audio_format.1 {
+				dma_buffer_size "$[$obs * 2]"
+			}
+			# 32-bit 48KHz 2ch
+			Object.Base.audio_format.2 {
+				in_bit_depth		32
+				in_valid_bit_depth	32
+				out_bit_depth		32
+				out_valid_bit_depth	32
+				dma_buffer_size "$[$obs * 2]"
+			}
 		}
 		Object.Widget.copier.1 {
 			direction capture
 			index 4
-			dai_index 4
 			type dai_out
 			dai_type "HDA"
-                        copier_type "HDA"
+			copier_type "HDA"
 			stream_name 'Digital Playback and Capture'
-			dai_index 3
 			period_sink_count 2
 			period_source_count 0
 			format s32le
+			node_type $HDA_LINK_INPUT_CLASS
+			num_audio_formats 2
+			# 16-bit 48KHz 2ch
+			Object.Base.audio_format.1 {
+				dma_buffer_size "$[$ibs * 2]"
+			}
+			# 32-bit 48KHz 2ch
+			Object.Base.audio_format.2 {
+				in_bit_depth		32
+				in_valid_bit_depth	32
+				out_bit_depth		32
+				out_valid_bit_depth	32
+				dma_buffer_size "$[$ibs * 2]"
+			}
 		}
 		direction duplex
 	}
@@ -140,8 +187,7 @@ Object.PCM {
 	pcm.0 {
 		name 'HDA Analog'
 		id 0
-		Object.Base.fe_dai.'HDA Analog' [
-		]
+		Object.Base.fe_dai.'HDA Analog' {}
 		Object.PCM.pcm_caps.playback {
 			name 'Gain Playback 0'
 			formats 'S24_LE,S16_LE'
@@ -155,8 +201,7 @@ Object.PCM {
 	pcm.1 {
 		name 'HDA Digital'
 		id 1
-		Object.Base.fe_dai.'HDA Digital' [
-		]
+		Object.Base.fe_dai.'HDA Digital' {}
 		Object.PCM.pcm_caps.playback {
 			name 'Gain Playback 1'
 			formats 'S24_LE,S16_LE'

--- a/tools/topology/topology2/cavs-gain-hdmi.conf
+++ b/tools/topology/topology2/cavs-gain-hdmi.conf
@@ -1,3 +1,4 @@
+<searchdir:cavs>
 <searchdir:include>
 <searchdir:include/common>
 <searchdir:include/components>
@@ -17,10 +18,10 @@
 <hw_config.conf>
 <manifest.conf>
 <route.conf>
+<cavs/common_definitions.conf>
 
-# variables
 Define {
-	HDA_CONFIG "gain"
+	HDA_CONFIG "none"
 }
 
 # include HDA config if needed
@@ -44,6 +45,20 @@ Object.Dai {
 			period_sink_count 0
 			period_source_count 2
 			format s32le
+			node_type $HDA_LINK_OUTPUT_CLASS
+			num_audio_formats 2
+			# 16-bit 48KHz 2ch
+			Object.Base.audio_format.1 {
+				dma_buffer_size "$[$obs * 2]"
+			}
+			# 32-bit 48KHz 2ch
+			Object.Base.audio_format.2 {
+				in_bit_depth		32
+				in_valid_bit_depth	32
+				out_bit_depth		32
+				out_valid_bit_depth	32
+				dma_buffer_size "$[$obs * 2]"
+			}
 		}
 		direction playback
 	}
@@ -62,6 +77,20 @@ Object.Dai {
 			period_sink_count 0
 			period_source_count 2
 			format s32le
+			node_type $HDA_LINK_OUTPUT_CLASS
+			num_audio_formats 2
+			# 16-bit 48KHz 2ch
+			Object.Base.audio_format.1 {
+				dma_buffer_size "$[$obs * 2]"
+			}
+			# 32-bit 48KHz 2ch
+			Object.Base.audio_format.2 {
+				in_bit_depth		32
+				in_valid_bit_depth	32
+				out_bit_depth		32
+				out_valid_bit_depth	32
+				dma_buffer_size "$[$obs * 2]"
+			}
 		}
 		direction playback
 	}
@@ -80,6 +109,20 @@ Object.Dai {
 			period_sink_count 0
 			period_source_count 2
 			format s32le
+			node_type $HDA_LINK_OUTPUT_CLASS
+			num_audio_formats 2
+			# 16-bit 48KHz 2ch
+			Object.Base.audio_format.1 {
+				dma_buffer_size "$[$obs * 2]"
+			}
+			# 32-bit 48KHz 2ch
+			Object.Base.audio_format.2 {
+				in_bit_depth		32
+				in_valid_bit_depth	32
+				out_bit_depth		32
+				out_valid_bit_depth	32
+				dma_buffer_size "$[$obs * 2]"
+			}
 		}
 		direction playback
 	}

--- a/tools/topology/topology2/cavs-passthrough-hda.conf
+++ b/tools/topology/topology2/cavs-passthrough-hda.conf
@@ -19,6 +19,18 @@ Object.Dai {
 			format s32le
 			event_flags	127 # trapping PRE/POST_PMU/PMD events
 			event_type	2 # 1 for COPIER event for copier component
+			node_type $HDA_LINK_OUTPUT_CLASS
+			num_audio_formats 2
+			Object.Base.audio_format.1 {
+				dma_buffer_size "$[$obs * 2]"
+			}
+			Object.Base.audio_format.2 {
+				in_bit_depth		32
+				in_valid_bit_depth	32
+				out_bit_depth		32
+				out_valid_bit_depth	32
+				dma_buffer_size "$[$obs * 2]"
+			}
 		}
 
 		Object.Widget.copier.1 {
@@ -27,12 +39,24 @@ Object.Dai {
 			dai_index 2
 			type dai_out
 			dai_type "HDA"
-                        copier_type "HDA"
+			copier_type "HDA"
+			node_type $HDA_LINK_INPUT_CLASS
 			stream_name 'Analog Playback and Capture'
 			dai_index 1
 			period_sink_count 2
 			period_source_count 0
 			format s32le
+			num_audio_formats 2
+			Object.Base.audio_format.1 {
+				dma_buffer_size "$[$ibs * 2]"
+			}
+			Object.Base.audio_format.2 {
+				in_bit_depth		32
+				in_valid_bit_depth	32
+				out_bit_depth		32
+				out_valid_bit_depth	32
+				dma_buffer_size "$[$ibs * 2]"
+			}
 		}
 	}
 }

--- a/tools/topology/topology2/cavs-passthrough-hdmi.conf
+++ b/tools/topology/topology2/cavs-passthrough-hdmi.conf
@@ -21,10 +21,10 @@
 <hw_config.conf>
 <manifest.conf>
 <route.conf>
+<cavs/common_definitions.conf>
 
-# variables
 Define {
-	HDA_CONFIG "passthrough"
+	HDA_CONFIG  "none"
 }
 
 # include HDA config if needed.
@@ -48,6 +48,20 @@ Object.Dai {
 			period_sink_count 0
 			period_source_count 2
 			format s32le
+			node_type $HDA_LINK_OUTPUT_CLASS
+			num_audio_formats 2
+			# 16-bit 48KHz 2ch
+			Object.Base.audio_format.1 {
+				dma_buffer_size "$[$obs * 2]"
+			}
+			# 32-bit 48KHz 2ch
+			Object.Base.audio_format.2 {
+				in_bit_depth		32
+				in_valid_bit_depth	32
+				out_bit_depth		32
+				out_valid_bit_depth	32
+				dma_buffer_size "$[$obs * 2]"
+			}
 		}
 		direction playback
 	}
@@ -65,6 +79,20 @@ Object.Dai {
 			period_sink_count 0
 			period_source_count 2
 			format s32le
+			node_type $HDA_LINK_OUTPUT_CLASS
+			num_audio_formats 2
+			# 16-bit 48KHz 2ch
+			Object.Base.audio_format.1 {
+				dma_buffer_size "$[$obs * 2]"
+			}
+			# 32-bit 48KHz 2ch
+			Object.Base.audio_format.2 {
+				in_bit_depth		32
+				in_valid_bit_depth	32
+				out_bit_depth		32
+				out_valid_bit_depth	32
+				dma_buffer_size "$[$obs * 2]"
+			}
 		}
 		direction playback
 	}
@@ -82,6 +110,20 @@ Object.Dai {
 			period_sink_count 0
 			period_source_count 2
 			format s32le
+			node_type $HDA_LINK_OUTPUT_CLASS
+			num_audio_formats 2
+			# 16-bit 48KHz 2ch
+			Object.Base.audio_format.0 {
+				dma_buffer_size "$[$obs * 2]"
+			}
+			# 32-bit 48KHz 2ch
+			Object.Base.audio_format.1 {
+				in_bit_depth		32
+				in_valid_bit_depth	32
+				out_bit_depth		32
+				out_valid_bit_depth	32
+				dma_buffer_size "$[$obs * 2]"
+			}
 		}
 		direction playback
 	}

--- a/tools/topology/topology2/cavs/common_definitions.conf
+++ b/tools/topology/topology2/cavs/common_definitions.conf
@@ -1,0 +1,59 @@
+# Commonly used definitions in cavs topologies
+Define {
+	# Channel configuration
+	CHANNEL_CONFIG_MONO			0 # one channel only
+	CHANNEL_CONFIG_STEREO			1 # L & R.
+	CHANNEL_CONFIG_2_POINT_1 		2 # L, R & LFE; PCM only.
+	CHANNEL_CONFIG_3_POINT_0		3 # L, C & R; MP3 & AAC only.
+	CHANNEL_CONFIG_3_POINT_1		4 # L, C, R & LFE; PCM only.
+	CHANNEL_CONFIG_QUATRO			5 # L, R, Ls & Rs; PCM only.
+	CHANNEL_CONFIG_4_POINT_0		6 # L, C, R & Cs; MP3 & AAC only.
+	CHANNEL_CONFIG_5_POINT_0		7 # L, C, R, Ls & Rs.
+	CHANNEL_CONFIG_5_POINT_1		8 # L, C, R, Ls, Rs & LFE.
+	CHANNEL_CONFIG_DUAL_MONO		9 # one channel replicated in two.
+	CHANNEL_CONFIG_I2S_DUAL_STEREO_0	10 # Stereo (L,R) in 4 slots, 1st stream: [ L, R, -, - ]
+	CHANNEL_CONFIG_I2S_DUAL_STEREO_1	11 # Stereo (L,R) in 4 slots, 2nd stream: [ -, -, L, R ]
+	CHANNEL_CONFIG_7_POINT_1		12 # L, C, R, Ls, Rs & LFE, LS, RS
+	CHANNEL_CONFIG_INVALID			13 # invalid
+
+	# Channel map
+	CHANNEL_MAP_MONO			0xFFFFFFF0
+	CHANNEL_MAP_STEREO			0xFFFFFF10
+	CHANNEL_MAP_2_POINT_1			0xFFFFF210
+	CHANNEL_MAP_3_POINT_1			0xFFFF3210
+	CHANNEL_MAP_5_POINT_0			0xFFF43210
+	CHANNEL_MAP_5_POINT_1			0xFF543210
+	CHANNEL_MAP_7_POINT_1			0x76543210
+	CHANNEL_MAP_INVALID			0xFFFFFFFF
+
+	# Sample types
+	SAMPLE_TYPE_MSB_INTEGER			0 # integer with Most Significant Byte first
+	SAMPLE_TYPE_LSB_INTEGER			1 # integer with Most Significant Byte first
+	SAMPLE_TYPE_SIGNED_INTEGER		2 # Signed Integer
+	SAMPLE_TYPE_UNSIGNED_INTEGER		3 # Unsigned Integer
+	SAMPLE_TYPE_FLOAT			4 # Float
+
+	# Copier type
+	HDA_HOST_OUTPUT_CLASS			0 # HD/A host output (-> DSP)
+	HDA_HOST_INPUT_CLASS			1 # HD/A host input (<- DSP)
+	HDA_HOST_INOUT_CLASS			2 # HD/A host input/output (rsvd for future use)
+	HDA_LINK_OUTPUT_CLASS			8 # HD/A link output (DSP ->)
+	HDA_LINK_INPUT_CLASS			9 # HD/A link input (DSP <-)
+	HDA_LINK_INOUT_CLASS			10 # HD/A link input/output (rsvd for future use)
+	DMIC_LINK_INPUT_CLASS			11 # DMIC link input (DSP <-)
+	I2S_LINK_OUTPUT_CLASS			12 # I2S link output (DSP ->)
+	I2S_LINK_INPUT_CLASS			13 # I2S link input (DSP <-)
+	ALH_LINK_OUTPUT_CLASS			16 # ALH link output, legacy for SNDW (DSP ->)
+	ALH_LINK_INPUT_CLASS			17 # ALH link input, legacy for SNDW (DSP <-)
+	ALH_SNDWIRE_STREAM_LINK_OUTPUT_CLASS	16 # SNDW link output (DSP ->)
+	ALH_SNDWIRE_STREAM_LINK_INPUT_CLASS	17 # SNDW link input (DSP <-)
+	ALH_UAOL_STREAM_LINK_OUTPUT_CLASS	18 # UAOL link output (DSP ->)
+	ALH_UAOL_STREAM_LINK_INPUT_CLASS	19 # UAOL link input (DSP <-)
+	IPC_OUTPUT_CLASS			20 # IPC output (DSP ->)
+	IPC_INPUT_CLASS				21 # IPC input (DSP <-)
+	I2S_MULTILINK_OUTPUT_CLASS		22 # I2S Multi gtw output (DSP ->)
+	I2S_MULTILINKI_NPUT_CLASS		23 # I2S Multi gtw input (DSP <-)
+	GPIO_CLASS				24 # GPIO
+	SPI_OUTPUT_CLASS			25 # SPI Output (DSP ->)
+	SPI_INPUT_CLASS				26 # SPI Input (DSP <-)
+}

--- a/tools/topology/topology2/include/common/audio_format.conf
+++ b/tools/topology/topology2/include/common/audio_format.conf
@@ -1,0 +1,237 @@
+# Class definition for audio format object
+# audio_format objects can be instantiated as:
+#
+# Object.Base.audio_format."0" {
+#	in_rate			48000
+#	in_sample_container_size	16
+#	in_valid_bit_depth		16
+#	in_interleaving_style		"interleaved"
+#	out_rate			48000
+#	out_sample_container_size	16
+#	out_valid_bit_depth		16
+#	out_interleaving_style		"interleaved"
+
+# }
+#
+
+Class.Base."audio_format" {
+
+	DefineAttribute."instance" {
+	}
+
+	# input sampling rate
+	DefineAttribute."in_rate" {
+		# Token set reference name
+		token_ref	"sof_tkn_cavs_audio_format.word"
+	}
+
+	# input bit depth
+	DefineAttribute."in_bit_depth" {
+		# Token set reference name
+		token_ref	"sof_tkn_cavs_audio_format.word"
+	}
+
+	# input valid bit depth
+	DefineAttribute."in_valid_bit_depth" {
+		# Token set reference name
+		token_ref	"sof_tkn_cavs_audio_format.word"
+	}
+
+	# input channel count
+	DefineAttribute."in_channels" {
+		# Token set reference name
+		token_ref	"sof_tkn_cavs_audio_format.word"
+		constraints {
+			min 1
+			max 8
+		}
+	}
+
+	# input channel map
+	DefineAttribute."in_ch_map" {
+		# Token set reference name
+		token_ref	"sof_tkn_cavs_audio_format.word"
+	}
+
+	# input channel config
+	DefineAttribute."in_ch_cfg" {
+		# Token set reference name
+		token_ref	"sof_tkn_cavs_audio_format.word"
+	}
+
+	# input interleaving style
+	DefineAttribute."in_interleaving_style" {
+		type	"string"
+		# Token set reference name
+		token_ref	"sof_tkn_cavs_audio_format.word"
+		constraints {
+			!valid_values [
+				"interleaved"
+				"non-interleaved"
+			]
+			!tuple_values [
+				0
+				1
+			]
+		}
+	}
+
+	# input format config
+	DefineAttribute."in_fmt_cfg" {
+		# Token set reference name
+		token_ref	"sof_tkn_cavs_audio_format.word"
+	}
+
+	# output sampling rate
+	DefineAttribute."out_rate" {
+		# Token set reference name
+		token_ref	"sof_tkn_cavs_audio_format.word"
+	}
+
+	# input sample_type
+	DefineAttribute."in_sample_type" {
+		type string
+		# Token set reference name
+		token_ref	"sof_tkn_cavs_audio_format.word"
+		constraints {
+			!valid_values [
+				$SAMPLE_TYPE_MSB_INTEGER
+				SAMPLE_TYPE_LSB_INTEGER
+				$SAMPLE_TYPE_SIGNED_INTEGER
+				$SAMPLE_TYPE_UNSIGNED_INTEGER
+				$SAMPLE_TYPE_FLOAT
+			]
+		}
+	}
+
+	# output bit depth
+	DefineAttribute."out_bit_depth" {
+		# Token set reference name
+		token_ref	"sof_tkn_cavs_audio_format.word"
+	}
+
+	# output valid bit depth
+	DefineAttribute."out_valid_bit_depth" {
+		# Token set reference name
+		token_ref	"sof_tkn_cavs_audio_format.word"
+	}
+
+	# output channel count
+	DefineAttribute."out_channels" {
+		# Token set reference name
+		token_ref	"sof_tkn_cavs_audio_format.word"
+		constraints {
+			min 1
+			max 8
+		}
+	}
+
+	# output channel map
+	DefineAttribute."out_ch_map" {
+		# Token set reference name
+		token_ref	"sof_tkn_cavs_audio_format.word"
+	}
+
+	# output channel config
+	DefineAttribute."out_ch_cfg" {
+		# Token set reference name
+		token_ref	"sof_tkn_cavs_audio_format.word"
+	}
+
+	# output interleaving style
+	DefineAttribute."out_interleaving_style" {
+		type	"string"
+		# Token set reference name
+		token_ref	"sof_tkn_cavs_audio_format.word"
+		constraints {
+			!valid_values [
+				"interleaved"
+				"non-interleaved"
+			]
+			!tuple_values [
+				0
+				1
+			]
+		}
+	}
+
+	# output format config
+	DefineAttribute."out_fmt_cfg" {
+		# Token set reference name
+		token_ref	"sof_tkn_cavs_audio_format.word"
+	}
+
+	#
+	# input buffer size
+	#
+	DefineAttribute."ibs" {
+		# Token set reference name and type
+		token_ref	"sof_tkn_cavs_audio_format.word"
+	}
+
+	#
+	# output buffer size
+	#
+	DefineAttribute."obs" {
+		# Token set reference name and type
+		token_ref	"sof_tkn_cavs_audio_format.word"
+	}
+
+	#output sample_type
+	DefineAttribute."out_sample_type" {
+		type string
+		# Token set reference name
+		token_ref	"sof_tkn_cavs_audio_format.word"
+		constraints {
+			!valid_values [
+				$SAMPLE_TYPE_MSB_INTEGER
+				SAMPLE_TYPE_LSB_INTEGER
+				$SAMPLE_TYPE_SIGNED_INTEGER
+				$SAMPLE_TYPE_UNSIGNED_INTEGER
+				$SAMPLE_TYPE_FLOAT
+			]
+		}
+	}
+
+	DefineAttribute."dma_buffer_size" {
+		# Token set reference name and type
+		token_ref	"sof_tkn_cavs_audio_format.word"
+	}
+
+	attributes {
+		!constructor [
+			"instance"
+		]
+
+		#
+		# audio_format objects instantiated within the same alsaconf node must have unique
+		# instance attribute values
+		#
+		unique	"instance"
+	}
+
+	in_rate		48000
+	in_bit_depth		16
+	in_valid_bit_depth	16
+	in_channels		2
+	in_interleaving_style	"interleaved"
+	in_sample_type		$SAMPLE_TYPE_MSB_INTEGER
+	out_rate		48000
+	out_bit_depth		16
+	out_valid_bit_depth	16
+	out_channels		2
+	out_interleaving_style	"interleaved"
+	out_sample_type	$SAMPLE_TYPE_MSB_INTEGER
+	in_ch_cfg	$CHANNEL_CONFIG_STEREO
+	in_ch_map	$CHANNEL_MAP_STEREO
+	out_ch_cfg	$CHANNEL_CONFIG_STEREO
+	out_ch_map	$CHANNEL_MAP_STEREO
+
+	# math expression for computing input/output fmt_cfg
+	in_fmt_cfg	"$[($in_channels | ($in_valid_bit_depth * 256)) | ($in_sample_type * 65536)]"
+	out_fmt_cfg	"$[($out_channels | ($out_valid_bit_depth * 256)) | ($out_sample_type * 65536)]"
+
+	# math expression for computing input/put buffer sizes
+	ibs "$[($in_channels * ($in_rate / 1000)) * ($in_bit_depth / 8)]"
+	obs "$[($out_channels * ($out_rate / 1000)) * ($out_bit_depth / 8)]"
+}

--- a/tools/topology/topology2/include/common/tokens.conf
+++ b/tools/topology/topology2/include/common/tokens.conf
@@ -11,6 +11,10 @@ Object.Base.VendorToken {
 		preload_count		403
 		core_id		404
 		uuid			405
+		# Tokens added with ABI 4.0
+		cpc			406
+		is_pages		409
+		num_audio_formats	410
 	}
 
 	"sof_tkn_dai" {
@@ -57,11 +61,8 @@ Object.Base.VendorToken {
 		frames			204
 		time_domain		205
 		dynamic_pipeline	206
-		lp_mode			207
-	}
-
-	"sof_tkn_copier" {
-		cpc		1800
+		# ABI 4.0 onwards
+		lp_mode		207
 	}
 
 	"sof_tkn_intel_ssp" {
@@ -111,5 +112,37 @@ Object.Base.VendorToken {
 
 	"sof_tkn_mixinout" {
 		mix_type	1700
+	}
+
+	# ABI 4.0 onwards
+	"sof_tkn_cavs_audio_format" {
+		in_rate		1900
+		in_bit_depth		1901
+		in_valid_bit_depth	1902
+		in_channels		1903
+		in_ch_map		1904
+		in_ch_cfg		1905
+		in_interleaving_style	1906
+		in_fmt_cfg		1907
+		in_sample_type		1908
+		# tokens up to 1929 reserved for future use
+		out_rate		1930
+		out_bit_depth		1931
+		out_valid_bit_depth	1932
+		out_channels		1933
+		out_ch_map		1934
+		out_ch_cfg		1935
+		out_interleaving_style	1936
+		out_fmt_cfg		1937
+		out_sample_type		1917
+		# tokens up to 1969 reserved for future use
+		ibs			1970
+		obs			1971
+		dma_buffer_size		1972
+	}
+
+	# ABI 4.0 onwards
+	"sof_tkn_copier" {
+		node_type		1980
 	}
 }

--- a/tools/topology/topology2/include/components/copier.conf
+++ b/tools/topology/topology2/include/components/copier.conf
@@ -52,7 +52,7 @@ Class.Widget."copier" {
 			!valid_values [
 				"HDA"
 				"host"
-				"SSP" # TODO: add more DAIs
+				"SSP"
 				"ALH"
 				"DMIC"
 				"module"

--- a/tools/topology/topology2/include/components/copier.conf
+++ b/tools/topology/topology2/include/components/copier.conf
@@ -88,9 +88,55 @@ Class.Widget."copier" {
 		}
 	}
 
+	#
+	# cycles per chunk processed
+	#
 	DefineAttribute."cpc" {
 		# Token set reference name and type
+		token_ref	"sof_tkn_comp.word"
+	}
+
+	DefineAttribute."num_audio_formats" {
+		# Token set reference name and type
+		token_ref	"sof_tkn_comp.word"
+	}
+
+	DefineAttribute."bss_size" {}
+
+	DefineAttribute."is_pages" {
+		# Token set reference name and type
+		token_ref	"sof_tkn_comp.word"
+	}
+
+	DefineAttribute."node_type" {
+		# Token set reference name and type
 		token_ref	"sof_tkn_copier.word"
+		constraints {
+			!valid_values [
+				$HDA_HOST_OUTPUT_CLASS # HD/A host output (-> DSP)
+				$HDA_HOST_INPUT_CLASS # HD/A host input (<- DSP)
+				$HDA_HOST_INOUT_CLASS # HD/A host input/output (rsvd for future use)
+				$HDA_LINK_OUTPUT_CLASS # HD/A link output (DSP ->)
+				$HDA_LINK_INPUT_CLASS # HD/A link input (DSP <-)
+				$HDA_LINK_INOUT_CLASS # HD/A link input/output (rsvd for future use)
+				$DMIC_LINK_INPUT_CLASS # DMIC link input (DSP <-)
+				$I2S_LINK_OUTPUT_CLASS # I2S link output (DSP ->)
+				$I2S_LINK_INPUT_CLASS # I2S link input (DSP <-)
+				$ALH_LINK_OUTPUT_CLASS # ALH link output, legacy for SNDW (DSP ->)
+				$ALH_LINK_INPUT_CLASS # ALH link input, legacy for SNDW (DSP <-)
+				$ALH_SNDWIRE_STREAM_LINK_OUTPUT_CLASS # SNDW link output (DSP ->)
+				$ALH_SNDWIRE_STREAM_LINK_INPUT_CLASS # SNDW link input (DSP <-)
+				$ALH_UAOL_STREAM_LINK_OUTPUT_CLASS # UAOL link output (DSP ->)
+				$ALH_UAOL_STREAM_LINK_INPUT_CLASS # UAOL link input (DSP <-)
+				$IPC_OUTPUT_CLASS # IPC output (DSP ->)
+				$IPC_INPUT_CLASS # IPC input (DSP <-)
+				$I2S_MULTILINK_OUTPUT_CLASS # I2S Multi gtw output (DSP ->)
+				$I2S_MULTILINKI_NPUT_CLASS # I2S Multi gtw input (DSP <-)
+				$GPIO_CLASS # GPIO
+				$SPI_OUTPUT_CLASS # SPI Output (DSP ->)
+				$SPI_INPUT_CLASS # SPI Input (DSP <-)
+			]
+		}
 	}
 
 	attributes {
@@ -111,7 +157,6 @@ Class.Widget."copier" {
 			"no_pm"
 			"uuid"
 			"copier_type"
-			"cpc"
 		]
 
 		#
@@ -139,4 +184,8 @@ Class.Widget."copier" {
 	no_pm 		"true"
 	core_id	0
 	cpc		1647
+	bss_size	280
+
+	# math expression for computing is_pages
+	is_pages "$[(($bss_size + 4095) & -4095) / 4096]"
 }

--- a/tools/topology/topology2/include/components/gain.conf
+++ b/tools/topology/topology2/include/components/gain.conf
@@ -77,6 +77,11 @@ Class.Widget."gain" {
                 token_ref       "sof_tkn_gain.word"
 	}
 
+	DefineAttribute."num_audio_formats" {
+		# Token set reference name and type
+		token_ref	"sof_tkn_comp.word"
+	}
+
 	# Attribute categories
 	attributes {
 		#
@@ -138,6 +143,18 @@ Class.Widget."gain" {
 					}
                                 }
 		}
+	}
+
+	# gain audio formats
+	num_audio_formats 2
+	# 16-bit 48KHz 2ch
+	Object.Base.audio_format.0 {}
+	# 32-bit 48KHz 2ch
+	Object.Base.audio_format.1 {
+		in_bit_depth		32
+		in_valid_bit_depth	32
+		out_bit_depth		32
+		out_valid_bit_depth	32
 	}
 
 	# Default attribute values for gain widget

--- a/tools/topology/topology2/include/components/mixin.conf
+++ b/tools/topology/topology2/include/components/mixin.conf
@@ -41,7 +41,12 @@ Class.Widget."mixin" {
 
 	DefineAttribute."cpc" {
 		# Token set reference name and type
-		token_ref	"sof_tkn_copier.word"
+		token_ref	"sof_tkn_comp.word"
+	}
+
+	DefineAttribute."num_audio_formats" {
+		# Token set reference name and type
+		token_ref	"sof_tkn_comp.word"
 	}
 
 	#include common component definition
@@ -90,6 +95,16 @@ Class.Widget."mixin" {
 		]
 
 		unique	"instance"
+	}
+
+	# Only 32-bit format is supported by mixin
+	num_audio_formats 1
+	# 32-bit 48KHz 2ch
+	Object.Base.audio_format.1 {
+		in_bit_depth		32
+		in_valid_bit_depth	32
+		out_bit_depth		32
+		out_valid_bit_depth	32
 	}
 
 	#

--- a/tools/topology/topology2/include/components/mixout.conf
+++ b/tools/topology/topology2/include/components/mixout.conf
@@ -41,7 +41,12 @@ Class.Widget."mixout" {
 
 	DefineAttribute."cpc" {
 		# Token set reference name and type
-		token_ref	"sof_tkn_copier.word"
+		token_ref	"sof_tkn_comp.word"
+	}
+
+	DefineAttribute."num_audio_formats" {
+		# Token set reference name and type
+		token_ref	"sof_tkn_comp.word"
 	}
 
 	#include common component definition
@@ -58,8 +63,8 @@ Class.Widget."mixout" {
 
 	attributes {
 		#
-		# The mixout widget name would be constructed using the index and
-		# instance attributes. For ex: "mixout.0.1".
+		# The mixout widget name is constructed using the index and instance attributes.
+		# For ex: "mixout.0.1".
 		#
 		!constructor [
 			"index"
@@ -92,6 +97,16 @@ Class.Widget."mixout" {
 		unique	"instance"
 	}
 
+	# Only 32-bit format is supported by mixout
+	num_audio_formats 1
+	# 32-bit 48KHz 2ch
+	Object.Base.audio_format.1 {
+		in_bit_depth		32
+		in_valid_bit_depth	32
+		out_bit_depth		32
+		out_valid_bit_depth	32
+	}
+
 	#
 	# Default attributes for mixout
 	#
@@ -102,5 +117,5 @@ Class.Widget."mixout" {
 	uuid 		"5a:50:56:3c:d7:24:8f:41:bd:dc:c1:f5:a3:ac:2a:e0"
 	no_pm 		"true"
 	core_id	0
-	cpc 1164
+	cpc 		5000
 }

--- a/tools/topology/topology2/include/pipelines/cavs/gain-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/gain-capture.conf
@@ -17,6 +17,7 @@
 # Where N is the unique pipeline ID within the same alsaconf node.
 #
 
+<include/common/audio_format.conf>
 <include/components/copier.conf>
 <include/components/gain.conf>
 <include/components/pipeline.conf>
@@ -51,10 +52,23 @@ Class.Pipeline."gain-capture" {
 		copier."1" {
 			copier_type	"host"
 			type	"aif_out"
+			num_audio_formats 2
+			# 16-bit 48KHz 2ch
+			Object.Base.audio_format.1 {
+				dma_buffer_size "$[$obs * 2]"
+			}
+			# 32-bit 48KHz 2ch
+			Object.Base.audio_format.2 {
+				in_bit_depth		32
+				in_valid_bit_depth	32
+				out_bit_depth		32
+				out_valid_bit_depth	32
+				dma_buffer_size "$[$obs * 2]"
+			}
+			node_type $HDA_HOST_INPUT_CLASS
 		}
 
-		gain."1" {
-		}
+		gain."1" {}
 
 		pipeline."1" {
 			priority	0

--- a/tools/topology/topology2/include/pipelines/cavs/gain-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/gain-playback.conf
@@ -17,6 +17,7 @@
 # Where N is the unique pipeline ID within the same alsaconf node.
 #
 
+<include/common/audio_format.conf>
 <include/components/copier.conf>
 <include/components/gain.conf>
 <include/components/pipeline.conf>
@@ -51,6 +52,20 @@ Class.Pipeline."gain-playback" {
 		copier."1" {
 			copier_type	"host"
 			type	"aif_in"
+			num_audio_formats 2
+			# 16-bit 48KHz 2ch
+			Object.Base.audio_format.1 {
+				dma_buffer_size "$[$ibs * 2]"
+			}
+			# 32-bit 48KHz 2ch
+			Object.Base.audio_format.2 {
+				in_bit_depth		32
+				in_valid_bit_depth	32
+				out_bit_depth		32
+				out_valid_bit_depth	32
+				dma_buffer_size "$[$ibs * 2]"
+			}
+			node_type $HDA_HOST_OUTPUT_CLASS
 		}
 
 		gain."1" {

--- a/tools/topology/topology2/include/pipelines/cavs/mixin-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixin-capture.conf
@@ -17,6 +17,7 @@
 # Where N is the unique pipeline ID within the same alsaconf node.
 #
 
+<include/common/audio_format.conf>
 <include/components/copier.conf>
 <include/components/mixin.conf>
 <include/components/pipeline.conf>
@@ -52,10 +53,25 @@ Class.Pipeline."mixin-capture" {
 			type dai_out
 			period_sink_count 2
 			period_source_count 0
+			node_type $HDA_LINK_INPUT_CLASS
+			num_audio_formats 2
+			# 16-bit 48KHz 2ch
+			Object.Base.audio_format.1 {
+				out_bit_depth		32
+				out_valid_bit_depth	32
+				dma_buffer_size "$[$ibs * 2]"
+			}
+			# 32-bit 48KHz 2ch
+			Object.Base.audio_format.2 {
+				in_bit_depth		32
+				in_valid_bit_depth	32
+				out_bit_depth		32
+				out_valid_bit_depth	32
+				dma_buffer_size "$[$ibs * 2]"
+			}
 		}
 
-		mixin."1" {
-		}
+		mixin."1" {}
 
 		pipeline."1" {
 			priority	0

--- a/tools/topology/topology2/include/pipelines/cavs/mixin-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixin-playback.conf
@@ -17,6 +17,7 @@
 # Where N is the unique pipeline ID within the same alsaconf node.
 #
 
+<include/common/audio_format.conf>
 <include/components/copier.conf>
 <include/components/mixin.conf>
 <include/components/pipeline.conf>
@@ -51,10 +52,25 @@ Class.Pipeline."mixin-playback" {
 		copier."1" {
 			copier_type	"host"
 			type	"aif_in"
+			node_type $HDA_HOST_OUTPUT_CLASS
+			num_audio_formats 2
+			# 16-bit 48KHz 2ch
+			Object.Base.audio_format.1 {
+				out_bit_depth		32
+				out_valid_bit_depth	32
+				dma_buffer_size "$[$ibs * 2]"
+			}
+			# 32-bit 48KHz 2ch
+			Object.Base.audio_format.2 {
+				in_bit_depth		32
+				in_valid_bit_depth	32
+				out_bit_depth		32
+				out_valid_bit_depth	32
+				dma_buffer_size "$[$ibs * 2]"
+			}
 		}
 
-		mixin."1" {
-		}
+		mixin."1" {}
 
 		pipeline."1" {
 			priority	0

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-capture.conf
@@ -17,6 +17,7 @@
 # Where N is the unique pipeline ID within the same alsaconf node.
 #
 
+<include/common/audio_format.conf>
 <include/components/copier.conf>
 <include/components/mixout.conf>
 <include/components/pipeline.conf>
@@ -53,6 +54,22 @@ Class.Pipeline."mixout-capture" {
 		copier."1" {
 			copier_type "host"
 			type	"aif_out"
+			node_type $HDA_HOST_INPUT_CLASS
+			num_audio_formats 2
+			# 16-bit 48KHz 2ch
+			Object.Base.audio_format.1 {
+				in_bit_depth		32
+				in_valid_bit_depth	32
+				dma_buffer_size "$[$obs * 2]"
+			}
+			# 32-bit 48KHz 2ch
+			Object.Base.audio_format.2 {
+				in_bit_depth		32
+				in_valid_bit_depth	32
+				out_bit_depth		32
+				out_valid_bit_depth	32
+				dma_buffer_size "$[$obs * 2]"
+			}
 		}
 
 		pipeline."1" {

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-playback.conf
@@ -17,6 +17,7 @@
 # Where N is the unique pipeline ID within the same alsaconf node.
 #
 
+<include/common/audio_format.conf>
 <include/components/copier.conf>
 <include/components/mixout.conf>
 <include/components/pipeline.conf>
@@ -51,8 +52,24 @@ Class.Pipeline."mixout-playback" {
 		mixout."1" {}
 		copier."1" {
 			type dai_in
+			node_type $HDA_LINK_OUTPUT_CLASS
 			period_sink_count 0
 			period_source_count 2
+			num_audio_formats 2
+			# 16-bit 48KHz 2ch
+			Object.Base.audio_format.1 {
+				in_bit_depth		32
+				in_valid_bit_depth	32
+				dma_buffer_size "$[$obs * 2]"
+			}
+			# 32-bit 48KHz 2ch
+			Object.Base.audio_format.2 {
+				in_bit_depth		32
+				in_valid_bit_depth	32
+				out_bit_depth		32
+				out_valid_bit_depth	32
+				dma_buffer_size "$[$obs * 2]"
+			}
 		}
 
 		pipeline."1" {

--- a/tools/topology/topology2/include/pipelines/cavs/passthrough-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/passthrough-capture.conf
@@ -17,6 +17,7 @@
 # Where N is the unique pipeline ID within the same alsaconf node.
 #
 
+<include/common/audio_format.conf>
 <include/components/copier.conf>
 <include/components/pipeline.conf>
 
@@ -50,6 +51,20 @@ Class.Pipeline."passthrough-capture" {
 		copier."1" {
 			copier_type	"host"
 			type	"aif_out"
+			node_type $HDA_HOST_INPUT_CLASS
+			num_audio_formats 2
+			# 16-bit 48KHz 2ch
+			Object.Base.audio_format.1 {
+				dma_buffer_size "$[$obs * 2]"
+			}
+			# 32-bit 48KHz 2ch
+			Object.Base.audio_format.2 {
+				in_bit_depth		32
+				in_valid_bit_depth	32
+				out_bit_depth		32
+				out_valid_bit_depth	32
+				dma_buffer_size "$[$obs * 2]"
+			}
 		}
 
 		pipeline."1" {

--- a/tools/topology/topology2/include/pipelines/cavs/passthrough-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/passthrough-playback.conf
@@ -19,6 +19,7 @@
 
 <include/components/copier.conf>
 <include/components/pipeline.conf>
+<include/common/audio_format.conf>
 
 Class.Pipeline."passthrough-playback" {
 
@@ -49,7 +50,21 @@ Class.Pipeline."passthrough-playback" {
 	Object.Widget {
 		copier."1" {
 			copier_type	"host"
+			node_type $HDA_HOST_OUTPUT_CLASS
 			type	"aif_in"
+			num_audio_formats 2
+			# 16-bit 48KHz 2ch
+			Object.Base.audio_format.1 {
+				dma_buffer_size "$[$ibs * 2]"
+			}
+			# 32-bit 48KHz 2ch
+			Object.Base.audio_format.2 {
+				in_bit_depth		32
+				in_valid_bit_depth	32
+				out_bit_depth		32
+				out_valid_bit_depth	32
+				dma_buffer_size "$[$ibs * 2]"
+			}
 		}
 
 		pipeline."1" {


### PR DESCRIPTION
Requires https://github.com/alsa-project/alsa-utils/pull/127 for compiling.