### PR TITLE
Preparation for introducing a generic module interface API

### DIFF
--- a/src/audio/codec_adapter/codec/cadence.c
+++ b/src/audio/codec_adapter/codec/cadence.c
@@ -353,7 +353,7 @@ static int cadence_codec_get_samples(struct comp_dev *dev)
 	return 0;
 }
 
-int cadence_codec_init_process(struct comp_dev *dev)
+static int cadence_codec_init_process(struct comp_dev *dev)
 {
 	int ret;
 	struct codec_data *codec = comp_get_codec(dev);
@@ -503,6 +503,8 @@ int cadence_codec_process(struct comp_dev *dev)
 
 		if (local_buff->stream.free < output_bytes)
 			return -ENOSPC;
+	} else {
+		return cadence_codec_init_process(dev);
 	}
 
 	comp_dbg(dev, "cadence_codec_process() start");
@@ -580,7 +582,6 @@ int cadence_codec_free(struct comp_dev *dev)
 static struct codec_interface cadence_interface = {
 	.init  = cadence_codec_init,
 	.prepare = cadence_codec_prepare,
-	.init_process = cadence_codec_init_process,
 	.process = cadence_codec_process,
 	.apply_config = cadence_codec_apply_config,
 	.reset = cadence_codec_reset,

--- a/src/audio/codec_adapter/codec/dts.c
+++ b/src/audio/codec_adapter/codec/dts.c
@@ -189,7 +189,7 @@ int dts_codec_prepare(struct comp_dev *dev)
 	return ret;
 }
 
-int dts_codec_init_process(struct comp_dev *dev)
+static int dts_codec_init_process(struct comp_dev *dev)
 {
 	int ret;
 	struct codec_data *codec = comp_get_codec(dev);
@@ -218,6 +218,9 @@ int dts_codec_process(struct comp_dev *dev)
 	struct codec_data *codec = comp_get_codec(dev);
 	DtsSofInterfaceResult dts_result;
 	unsigned int bytes_processed = 0;
+
+	if (!codec->cpd.init_done)
+		return dts_codec_init_process(dev);
 
 	comp_dbg(dev, "dts_codec_process() start");
 
@@ -353,7 +356,6 @@ int dts_codec_free(struct comp_dev *dev)
 static struct codec_interface dts_interface = {
 	.init  = dts_codec_init,
 	.prepare = dts_codec_prepare,
-	.init_process = dts_codec_init_process,
 	.process = dts_codec_process,
 	.apply_config = dts_codec_apply_config,
 	.reset = dts_codec_reset,

--- a/src/audio/codec_adapter/codec/generic.c
+++ b/src/audio/codec_adapter/codec/generic.c
@@ -280,19 +280,6 @@ out:
 	return ret;
 }
 
-int codec_get_samples(struct comp_dev *dev)
-{
-	struct comp_data *cd = comp_get_drvdata(dev);
-	struct codec_data *codec = &cd->codec;
-
-	comp_dbg(dev, "codec_get_samples()");
-
-	if (codec->ops->get_samples)
-		return codec->ops->get_samples(dev);
-
-	return 0;
-}
-
 int codec_apply_runtime_config(struct comp_dev *dev)
 {
 	int ret;

--- a/src/audio/codec_adapter/codec/generic.c
+++ b/src/audio/codec_adapter/codec/generic.c
@@ -97,7 +97,7 @@ int codec_init(struct comp_dev *dev, struct codec_interface *interface)
 			 codec_id);
 		ret = -EIO;
 		goto out;
-	} else if (!interface->init || !interface->prepare || !interface->init_process ||
+	} else if (!interface->init || !interface->prepare ||
 		   !interface->process || !interface->apply_config ||
 		   !interface->reset || !interface->free) {
 		comp_err(dev, "codec_init(): codec %x is missing mandatory interfaces",
@@ -230,25 +230,6 @@ int codec_prepare(struct comp_dev *dev)
 	codec->state = CODEC_IDLE;
 	comp_dbg(dev, "codec_prepare() done");
 end:
-	return ret;
-}
-
-int codec_init_process(struct comp_dev *dev)
-{
-	int ret;
-	struct comp_data *cd = comp_get_drvdata(dev);
-	struct codec_data *codec = &cd->codec;
-
-	comp_dbg(dev, "codec_init_process() start");
-
-	ret = codec->ops->init_process(dev);
-	if (ret) {
-		comp_err(dev, "codec_init_process() error %x", ret);
-		goto out;
-	}
-
-	comp_dbg(dev, "codec_init_process() done");
-out:
 	return ret;
 }
 

--- a/src/audio/codec_adapter/codec/passthrough.c
+++ b/src/audio/codec_adapter/codec/passthrough.c
@@ -62,6 +62,9 @@ static int passthrough_codec_process(struct comp_dev *dev)
 	struct codec_data *codec = comp_get_codec(dev);
 	struct comp_data *cd = comp_get_drvdata(dev);
 
+	if (!codec->cpd.init_done)
+		return passthrough_codec_init_process(dev);
+
 	comp_dbg(dev, "passthrough_codec_process()");
 
 	memcpy_s(codec->cpd.out_buff, codec->cpd.out_buff_size,
@@ -103,7 +106,6 @@ static int passthrough_codec_free(struct comp_dev *dev)
 static struct codec_interface passthrough_interface = {
 	.init  = passthrough_codec_init,
 	.prepare = passthrough_codec_prepare,
-	.init_process = passthrough_codec_init_process,
 	.process = passthrough_codec_process,
 	.apply_config = passthrough_codec_apply_config,
 	.reset = passthrough_codec_reset,

--- a/src/audio/codec_adapter/codec/waves.c
+++ b/src/audio/codec_adapter/codec/waves.c
@@ -653,7 +653,7 @@ int waves_codec_prepare(struct comp_dev *dev)
 	return ret;
 }
 
-int waves_codec_init_process(struct comp_dev *dev)
+static int waves_codec_init_process(struct comp_dev *dev)
 {
 	struct codec_data *codec = comp_get_codec(dev);
 
@@ -671,6 +671,9 @@ int waves_codec_process(struct comp_dev *dev)
 	int ret;
 	struct codec_data *codec = comp_get_codec(dev);
 	struct waves_codec_data *waves_codec = codec->private;
+
+	if (!codec->cpd.init_done)
+		return waves_codec_init_process(dev);
 
 	comp_dbg(dev, "waves_codec_process() start");
 
@@ -767,7 +770,6 @@ int waves_codec_free(struct comp_dev *dev)
 static struct codec_interface waves_interface = {
 	.init  = waves_codec_init,
 	.prepare = waves_codec_prepare,
-	.init_process = waves_codec_init_process,
 	.process = waves_codec_process,
 	.apply_config = waves_codec_apply_config,
 	.reset = waves_codec_reset,

--- a/src/audio/codec_adapter/codec_adapter.c
+++ b/src/audio/codec_adapter/codec_adapter.c
@@ -352,14 +352,6 @@ static void generate_zeroes(struct comp_buffer *sink, uint32_t bytes)
 	comp_update_buffer_produce(sink, bytes);
 }
 
-static int get_output_bytes(struct comp_dev *dev)
-{
-	struct comp_data *cd = comp_get_drvdata(dev);
-
-	return codec_get_samples(dev) * cd->stream_params.sample_container_bytes *
-		cd->stream_params.channels;
-}
-
 int codec_adapter_copy(struct comp_dev *dev)
 {
 	int ret = 0;
@@ -404,19 +396,17 @@ int codec_adapter_copy(struct comp_dev *dev)
 		goto db_verify;
 	}
 
-	/* Process only we have enough free data in the local
-	 * buffer. If we don't have enough free space process()
-	 * will override the data in the local buffer
-	 */
-	if (local_buff->stream.free < get_output_bytes(dev))
-		goto db_verify;
-
 	buffer_stream_invalidate(source, codec_buff_size);
 	codec_adapter_copy_from_source_to_lib(&source->stream, &codec->cpd,
 					      codec_buff_size);
 	codec->cpd.avail = codec_buff_size;
 	ret = codec_process(dev);
 	if (ret) {
+		if (ret == -ENOSPC) {
+			ret = 0;
+			goto db_verify;
+		}
+
 		comp_err(dev, "codec_adapter_copy() error %x: lib processing failed",
 			 ret);
 		goto db_verify;

--- a/src/include/sof/audio/codec_adapter/codec/cadence.h
+++ b/src/include/sof/audio/codec_adapter/codec/cadence.h
@@ -50,7 +50,6 @@ struct cadence_codec_data {
 /*****************************************************************************/
 int cadence_codec_init(struct comp_dev *dev);
 int cadence_codec_prepare(struct comp_dev *dev);
-int cadence_codec_get_samples(struct comp_dev *dev);
 int cadence_codec_init_process(struct comp_dev *dev);
 int cadence_codec_process(struct comp_dev *dev);
 int cadence_codec_apply_config(struct comp_dev *dev);

--- a/src/include/sof/audio/codec_adapter/codec/cadence.h
+++ b/src/include/sof/audio/codec_adapter/codec/cadence.h
@@ -50,7 +50,6 @@ struct cadence_codec_data {
 /*****************************************************************************/
 int cadence_codec_init(struct comp_dev *dev);
 int cadence_codec_prepare(struct comp_dev *dev);
-int cadence_codec_init_process(struct comp_dev *dev);
 int cadence_codec_process(struct comp_dev *dev);
 int cadence_codec_apply_config(struct comp_dev *dev);
 int cadence_codec_reset(struct comp_dev *dev);

--- a/src/include/sof/audio/codec_adapter/codec/dts.h
+++ b/src/include/sof/audio/codec_adapter/codec/dts.h
@@ -10,7 +10,6 @@
 
 int dts_codec_init(struct comp_dev *dev);
 int dts_codec_prepare(struct comp_dev *dev);
-int dts_codec_init_process(struct comp_dev *dev);
 int dts_codec_process(struct comp_dev *dev);
 int dts_codec_apply_config(struct comp_dev *dev);
 int dts_codec_reset(struct comp_dev *dev);

--- a/src/include/sof/audio/codec_adapter/codec/generic.h
+++ b/src/include/sof/audio/codec_adapter/codec/generic.h
@@ -87,12 +87,6 @@ struct codec_interface {
 	 */
 	int (*prepare)(struct comp_dev *dev);
 	/**
-	 * Codec specific. Returns the number of PCM output
-	 * samples after decoding one input compressed frame.
-	 * Codecs will return 0 for don't care.
-	 */
-	int (*get_samples)(struct comp_dev *dev);
-	/**
 	 * Codec specific init processing procedure, called as a part of
 	 * codec_adapter component copy in .copy(). Typically in this
 	 * phase a processing algorithm searches for the valid header,
@@ -243,7 +237,6 @@ void *codec_allocate_memory(struct comp_dev *dev, uint32_t size,
 int codec_free_memory(struct comp_dev *dev, void *ptr);
 void codec_free_all_memory(struct comp_dev *dev);
 int codec_prepare(struct comp_dev *dev);
-int codec_get_samples(struct comp_dev *dev);
 int codec_init_process(struct comp_dev *dev);
 int codec_process(struct comp_dev *dev);
 int codec_apply_runtime_config(struct comp_dev *dev);

--- a/src/include/sof/audio/codec_adapter/codec/generic.h
+++ b/src/include/sof/audio/codec_adapter/codec/generic.h
@@ -87,14 +87,6 @@ struct codec_interface {
 	 */
 	int (*prepare)(struct comp_dev *dev);
 	/**
-	 * Codec specific init processing procedure, called as a part of
-	 * codec_adapter component copy in .copy(). Typically in this
-	 * phase a processing algorithm searches for the valid header,
-	 * does header decoding to get the parameters and initializes
-	 * state and configuration structures.
-	 */
-	int (*init_process)(struct comp_dev *dev);
-	/**
 	 * Codec specific processing procedure, called as part of codec_adapter
 	 * component copy in .copy(). This procedure is responsible to consume
 	 * samples provided by the codec_adapter and produce/output the processed
@@ -237,7 +229,6 @@ void *codec_allocate_memory(struct comp_dev *dev, uint32_t size,
 int codec_free_memory(struct comp_dev *dev, void *ptr);
 void codec_free_all_memory(struct comp_dev *dev);
 int codec_prepare(struct comp_dev *dev);
-int codec_init_process(struct comp_dev *dev);
 int codec_process(struct comp_dev *dev);
 int codec_apply_runtime_config(struct comp_dev *dev);
 int codec_reset(struct comp_dev *dev);

--- a/src/include/sof/audio/codec_adapter/codec/passthrough.h
+++ b/src/include/sof/audio/codec_adapter/codec/passthrough.h
@@ -10,7 +10,6 @@
 
 int passthrough_codec_init(struct comp_dev *dev);
 int passthrough_codec_prepare(struct comp_dev *dev);
-int passthrough_codec_init_process(struct comp_dev *dev);
 int passthrough_codec_process(struct comp_dev *dev);
 int passthrough_codec_apply_config(struct comp_dev *dev);
 int passthrough_codec_reset(struct comp_dev *dev);

--- a/src/include/sof/audio/codec_adapter/codec/waves.h
+++ b/src/include/sof/audio/codec_adapter/codec/waves.h
@@ -10,7 +10,6 @@
 int waves_codec_init(struct comp_dev *dev);
 int waves_codec_prepare(struct comp_dev *dev);
 int waves_codec_process(struct comp_dev *dev);
-int waves_codec_init_process(struct comp_dev *dev);
 int waves_codec_apply_config(struct comp_dev *dev);
 int waves_codec_reset(struct comp_dev *dev);
 int waves_codec_free(struct comp_dev *dev);


### PR DESCRIPTION
In preparation for introducing a generic module interface API for 3rd party module interface, clean up the codec_adapter interface to remove the get_samples and init_process API's. The new API is still WIP but the idea is shown here: 
https://github.com/thesofproject/sof/commit/8cddb8f51cbfd5bfe691c571c2298c164b91f986