### PR TITLE
Audio: Volume: Drop unused hvol support (host mmap volume)

### DIFF
--- a/src/include/sof/audio/volume.h
+++ b/src/include/sof/audio/volume.h
@@ -100,7 +100,6 @@ typedef int32_t (*vol_ramp_func)(struct comp_dev *dev, int32_t ramp_time, int ch
  * Gain amplitude value is between 0 (mute) ... 2^16 (0dB) ... 2^24 (~+48dB).
  */
 struct vol_data {
-	struct sof_ipc_ctrl_value_chan *hvol;	/**< host volume readback */
 	int32_t volume[SOF_IPC_MAX_CHANNELS];	/**< current volume */
 	int32_t tvolume[SOF_IPC_MAX_CHANNELS];	/**< target volume */
 	int32_t mvolume[SOF_IPC_MAX_CHANNELS];	/**< mute volume */


### PR DESCRIPTION
The cd->hvol always remain NULL, there is no code path which would
configure it which makes the mapped volume unusable and unused.

The kernel does not use this feature either.

Remove all related code to this non supported feature.

Signed-off-by: Peter Ujfalusi <peter.ujfalusi@linux.intel.com>