### PR TITLE
topology: Ensure buffers get allocated on core 0

### DIFF
--- a/tools/topology/topology1/m4/buffer.m4
+++ b/tools/topology/topology1/m4/buffer.m4
@@ -5,7 +5,7 @@ dnl Define the macro for buffer widget
 dnl N_BUFFER(name)
 define(`N_BUFFER', `BUF'PIPELINE_ID`.'$1)
 
-dnl W_BUFFER(name, size, capabilities, core)
+dnl W_BUFFER(name, size, capabilities)
 define(`W_BUFFER',
 `SectionVendorTuples."'N_BUFFER($1)`_tuples" {'
 `	tokens "sof_buffer_tokens"'
@@ -21,7 +21,7 @@ define(`W_BUFFER',
 `SectionVendorTuples."'N_BUFFER($1)`_comp_tuples" {'
 `	tokens "sof_comp_tokens"'
 `	tuples."word" {'
-`		SOF_TKN_COMP_CORE_ID'	STR($4)
+`		SOF_TKN_COMP_CORE_ID'	0
 `	}'
 `}'
 `SectionData."'N_BUFFER($1)`_comp" {'


### PR DESCRIPTION
Pass the core number to the buffer instanciation so buffers can be
allocated on the same core the pipeline is scheduled.

Signed-off-by: Lionel Koenig <lionelk@google.com>