### PR TITLE
alloc: don't initialise rballoc() memory

### DIFF
--- a/src/lib/alloc.c
+++ b/src/lib/alloc.c
@@ -950,9 +950,6 @@ void *rballoc_align(uint32_t flags, uint32_t caps, size_t bytes,
 
 	ptr = _balloc_unlocked(flags, caps, bytes, alignment);
 
-	if (ptr)
-		bzero(ptr, bytes);
-
 	spin_unlock_irq(&memmap->lock, lock_flags);
 
 	DEBUG_TRACE_PTR(ptr, bytes, SOF_MEM_ZONE_BUFFER, caps, flags);


### PR DESCRIPTION
rballoc() doesn't guarantee zero-initialised memory, besides it's often enough called at run-time and for relatively large buffers, so performance losses aren't negligible. Remove the bzero() call.
