### PR TITLE
Platform: eliminate common code from trace.h and cpu.h

### DIFF
--- a/src/include/ipc4/fw_reg.h
+++ b/src/include/ipc4/fw_reg.h
@@ -127,8 +127,8 @@ struct ipc4_fw_registers {
 	uint32_t rsvd0;
 	union ipc4_rom_info rom_info;
 	uint32_t rsvd1[5];
-	uint32_t dbg_log_wp[MAX_CORE_COUNT];
-	uint32_t rsvd2[4 - MAX_CORE_COUNT];
+	uint32_t dbg_log_wp[CONFIG_MAX_CORE_COUNT];
+	uint32_t rsvd2[4 - CONFIG_MAX_CORE_COUNT];
 
 	struct ipc4_pipeline_registers pipeline_regs[PLATFORM_MAX_DMA_CHAN];
 	struct ipc4_peak_volume_regs peak_vol_regs[10];

--- a/src/platform/amd/renoir/include/platform/lib/cpu.h
+++ b/src/platform/amd/renoir/include/platform/lib/cpu.h
@@ -19,9 +19,6 @@
 /* brief Number of available DSP cores (conf. by kconfig) */
 #define PLATFORM_CORE_COUNT	CONFIG_CORE_COUNT
 
-/* brief Maximum allowed number of DSP cores */
-#define MAX_CORE_COUNT		1
-
 /* brief Id of master DSP core */
 #define PLATFORM_MASTER_CORE_ID	0
 

--- a/src/platform/apollolake/include/platform/lib/cpu.h
+++ b/src/platform/apollolake/include/platform/lib/cpu.h
@@ -17,9 +17,6 @@
 
 #include <cavs/lib/cpu.h>
 
-/** \brief Maximum allowed number of DSP cores */
-#define MAX_CORE_COUNT	2
-
 #endif /* __PLATFORM_LIB_CPU_H__ */
 
 #else

--- a/src/platform/apollolake/include/platform/trace/trace.h
+++ b/src/platform/apollolake/include/platform/trace/trace.h
@@ -10,27 +10,7 @@
 #ifndef __PLATFORM_TRACE_TRACE_H__
 #define __PLATFORM_TRACE_TRACE_H__
 
-#include <sof/lib/cpu.h>
-#include <sof/lib/mailbox.h>
-#include <sof/lib/memory.h>
-#include <stdint.h>
-
-#define PLATFORM_TRACEP_SECONDARY_CORE(x) \
-	(SRAM_REG_FW_TRACEP_SECONDARY_CORE_BASE + ((x) - 1) * 0x4)
-
-/* Platform defined trace code */
-static inline void platform_trace_point(uint32_t x)
-{
-	int cpu = cpu_get_id();
-	uint32_t offset;
-
-	if (cpu == PLATFORM_PRIMARY_CORE_ID)
-		offset = SRAM_REG_FW_TRACEP;
-	else
-		offset = PLATFORM_TRACEP_SECONDARY_CORE(cpu);
-
-	mailbox_sw_reg_write(offset, x);
-}
+#include <cavs/trace/trace.h>
 
 #endif /* __PLATFORM_TRACE_TRACE_H__ */
 

--- a/src/platform/cannonlake/include/platform/lib/cpu.h
+++ b/src/platform/cannonlake/include/platform/lib/cpu.h
@@ -17,9 +17,6 @@
 
 #include <cavs/lib/cpu.h>
 
-/** \brief Maximum allowed number of DSP cores */
-#define MAX_CORE_COUNT	4
-
 #endif /* __PLATFORM_LIB_CPU_H__ */
 
 #else

--- a/src/platform/cannonlake/include/platform/trace/trace.h
+++ b/src/platform/cannonlake/include/platform/trace/trace.h
@@ -10,27 +10,7 @@
 #ifndef __PLATFORM_TRACE_TRACE_H__
 #define __PLATFORM_TRACE_TRACE_H__
 
-#include <sof/lib/cpu.h>
-#include <sof/lib/mailbox.h>
-#include <sof/lib/memory.h>
-#include <stdint.h>
-
-#define PLATFORM_TRACEP_SECONDARY_CORE(x) \
-	(SRAM_REG_FW_TRACEP_SECONDARY_CORE_BASE + ((x) - 1) * 0x4)
-
-/* Platform defined trace code */
-static inline void platform_trace_point(uint32_t x)
-{
-	int cpu = cpu_get_id();
-	uint32_t offset;
-
-	if (cpu == PLATFORM_PRIMARY_CORE_ID)
-		offset = SRAM_REG_FW_TRACEP;
-	else
-		offset = PLATFORM_TRACEP_SECONDARY_CORE(cpu);
-
-	mailbox_sw_reg_write(offset, x);
-}
+#include <cavs/trace/trace.h>
 
 #endif /* __PLATFORM_TRACE_TRACE_H__ */
 

--- a/src/platform/icelake/include/platform/lib/cpu.h
+++ b/src/platform/icelake/include/platform/lib/cpu.h
@@ -17,9 +17,6 @@
 
 #include <cavs/lib/cpu.h>
 
-/** \brief Maximum allowed number of DSP cores */
-#define MAX_CORE_COUNT	4
-
 #endif /* __PLATFORM_LIB_CPU_H__ */
 
 #else

--- a/src/platform/icelake/include/platform/trace/trace.h
+++ b/src/platform/icelake/include/platform/trace/trace.h
@@ -10,27 +10,7 @@
 #ifndef __PLATFORM_TRACE_TRACE_H__
 #define __PLATFORM_TRACE_TRACE_H__
 
-#include <sof/lib/cpu.h>
-#include <sof/lib/mailbox.h>
-#include <sof/lib/memory.h>
-#include <stdint.h>
-
-#define PLATFORM_TRACEP_SECONDARY_CORE(x) \
-	(SRAM_REG_FW_TRACEP_SECONDARY_CORE_BASE + ((x) - 1) * 0x4)
-
-/* Platform defined trace code */
-static inline void platform_trace_point(uint32_t x)
-{
-	int cpu = cpu_get_id();
-	uint32_t offset;
-
-	if (cpu == PLATFORM_PRIMARY_CORE_ID)
-		offset = SRAM_REG_FW_TRACEP;
-	else
-		offset = PLATFORM_TRACEP_SECONDARY_CORE(cpu);
-
-	mailbox_sw_reg_write(offset, x);
-}
+#include <cavs/trace/trace.h>
 
 #endif /* __PLATFORM_TRACE_TRACE_H__ */
 

--- a/src/platform/intel/cavs/include/cavs/trace/trace.h
+++ b/src/platform/intel/cavs/include/cavs/trace/trace.h
@@ -1,0 +1,41 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2019 Intel Corporation. All rights reserved.
+ *
+ * Author: Tomasz Lauda <tomasz.lauda@linux.intel.com>
+ */
+
+#ifdef __PLATFORM_TRACE_TRACE_H__
+
+#ifndef __CAVS_TRACE_TRACE_H__
+#define __CAVS_TRACE_TRACE_H__
+
+#include <sof/lib/cpu.h>
+#include <sof/lib/mailbox.h>
+#include <sof/lib/memory.h>
+#include <stdint.h>
+
+#define PLATFORM_TRACEP_SECONDARY_CORE(x) \
+	(SRAM_REG_FW_TRACEP_SECONDARY_CORE_BASE + ((x) - 1) * 0x4)
+
+/* Platform defined trace code */
+static inline void platform_trace_point(uint32_t x)
+{
+	int cpu = cpu_get_id();
+	uint32_t offset;
+
+	if (cpu == PLATFORM_PRIMARY_CORE_ID)
+		offset = SRAM_REG_FW_TRACEP;
+	else
+		offset = PLATFORM_TRACEP_SECONDARY_CORE(cpu);
+
+	mailbox_sw_reg_write(offset, x);
+}
+
+#endif /* __CAVS_TRACE_TRACE_H__ */
+
+#else
+
+#error "This file shouldn't be included from outside of platform/trace/trace.h"
+
+#endif /* __PLATFORM_TRACE_H__ */

--- a/src/platform/suecreek/include/platform/lib/cpu.h
+++ b/src/platform/suecreek/include/platform/lib/cpu.h
@@ -17,9 +17,6 @@
 
 #include <cavs/lib/cpu.h>
 
-/** \brief Maximum allowed number of DSP cores */
-#define MAX_CORE_COUNT	4
-
 #endif /* __PLATFORM_LIB_CPU_H__ */
 
 #else

--- a/src/platform/tigerlake/include/platform/lib/cpu.h
+++ b/src/platform/tigerlake/include/platform/lib/cpu.h
@@ -17,9 +17,6 @@
 
 #include <cavs/lib/cpu.h>
 
-/** \brief Maximum allowed number of DSP cores */
-#define MAX_CORE_COUNT	4
-
 #endif /* __PLATFORM_LIB_CPU_H__ */
 
 #else

--- a/src/platform/tigerlake/include/platform/trace/trace.h
+++ b/src/platform/tigerlake/include/platform/trace/trace.h
@@ -10,27 +10,7 @@
 #ifndef __PLATFORM_TRACE_TRACE_H__
 #define __PLATFORM_TRACE_TRACE_H__
 
-#include <sof/lib/cpu.h>
-#include <sof/lib/mailbox.h>
-#include <sof/lib/memory.h>
-#include <stdint.h>
-
-#define PLATFORM_TRACEP_SECONDARY_CORE(x) \
-	(SRAM_REG_FW_TRACEP_SECONDARY_CORE_BASE + ((x) - 1) * 0x4)
-
-/* Platform defined trace code */
-static inline void platform_trace_point(uint32_t x)
-{
-	int cpu = cpu_get_id();
-	uint32_t offset;
-
-	if (cpu == PLATFORM_PRIMARY_CORE_ID)
-		offset = SRAM_REG_FW_TRACEP;
-	else
-		offset = PLATFORM_TRACEP_SECONDARY_CORE(cpu);
-
-	mailbox_sw_reg_write(offset, x);
-}
+#include <cavs/trace/trace.h>
 
 #endif /* __PLATFORM_TRACE_TRACE_H__ */
 


### PR DESCRIPTION
contents of trace.h and cpu.h on all cAVS platforms (except trace.h on Sue Creek) is identical, unify them.