### PR TITLE
cmocka: make test-all-defconfigs.h runnable from anywhere 

### DIFF
--- a/test/test-all-defconfigs.sh
+++ b/test/test-all-defconfigs.sh
@@ -2,8 +2,10 @@
 
 set -e
 
+# Absolute
 SOFTOP=$(cd "$(dirname "$0")"/.. && pwd)
 
+# Relative
 BUILDTOP=build_ut_defs
 
 rebuild_config()
@@ -11,8 +13,9 @@ rebuild_config()
     local conf="$1"
     mkdir -p "$BUILDTOP"
     ( set -x
-     cmake  -DINIT_CONFIG="$conf" -B "$BUILDTOP"/"$conf" -DBUILD_UNIT_TESTS=ON \
-           -DBUILD_UNIT_TESTS_HOST=ON
+     cmake  -DINIT_CONFIG="$conf" -S "$SOFTOP" -B "$BUILDTOP"/"$conf" \
+            -DBUILD_UNIT_TESTS=ON           \
+            -DBUILD_UNIT_TESTS_HOST=ON
 
      cmake --build "$BUILDTOP"/"$conf" -- -j"$(nproc)"
     )

--- a/test/test-all-defconfigs.sh
+++ b/test/test-all-defconfigs.sh
@@ -12,6 +12,8 @@ rebuild_config()
 {
     local conf="$1"
     mkdir -p "$BUILDTOP"
+    printf '\n    =========  Building native cmocka tests for %s ======\n\n' "$conf"
+
     ( set -x
      cmake  -DINIT_CONFIG="$conf" -S "$SOFTOP" -B "$BUILDTOP"/"$conf" \
             -DBUILD_UNIT_TESTS=ON           \
@@ -33,6 +35,7 @@ main()
 
     # Now run all the tests
     for d in "$BUILDTOP"/*_defconfig; do
+        printf '\n\n    =========  Running native cmocka tests in %s ======\n\n' "$d"
         ( set -x
          cmake --build "$d" -- test
         )


### PR DESCRIPTION
Make test-all-defconfigs.h runnable from anywhere by merely adding a
cmake -S option.