### PR TITLE
ipc4: refine frame size calculation for 44.1khz

### DIFF
--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -306,7 +306,7 @@ static int dai_verify_params(struct comp_dev *dev,
 	}
 
 	/* set component period frames */
-	component_set_period_frames(dev, params->rate);
+	component_set_nearest_period_frames(dev, params->rate);
 
 	return 0;
 }

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -163,7 +163,7 @@ static int selector_verify_params(struct comp_dev *dev,
 	buffer_set_params(buffer, params, BUFFER_UPDATE_FORCE);
 
 	/* set component period frames */
-	component_set_period_frames(dev, sinkb->stream.rate);
+	component_set_nearest_period_frames(dev, sinkb->stream.rate);
 
 	buffer_release_irq(buffer);
 

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -699,14 +699,30 @@ void comp_unregister(struct comp_driver_info *drv);
 int comp_set_state(struct comp_dev *dev, int cmd);
 
 /* \brief Set component period frames */
-static inline void component_set_period_frames(struct comp_dev *current,
-					       uint32_t rate)
+static inline void component_set_nearest_period_frames(struct comp_dev *current,
+						       uint32_t rate)
 {
-	/* Samplerate is in Hz and period in microseconds.
+	/* Sample rate is in Hz and period in microseconds.
 	 * As we don't have floats use scale divider 1000000.
 	 * Also integer round up the result.
+	 * dma buffer size should align with 32bytes which can't be
+	 * compatible with current 45K adjustment. 48K is a suitable
+	 * adjustment.
 	 */
-	current->frames = ceil_divide(rate * current->period, 1000000);
+	switch (rate) {
+	case 44100:
+		current->frames = 48000 * current->period / 1000000;
+		break;
+	case 88200:
+		current->frames = 96000 * current->period / 1000000;
+		break;
+	case 176400:
+		current->frames = 192000 * current->period / 1000000;
+		break;
+	default:
+		current->frames = ceil_divide(rate * current->period, 1000000);
+		break;
+	}
 }
 
 /** \name XRUN handling.

--- a/src/ipc/ipc-helper.c
+++ b/src/ipc/ipc-helper.c
@@ -144,7 +144,7 @@ int comp_verify_params(struct comp_dev *dev, uint32_t flag,
 		buffer_set_params(buf, params, BUFFER_UPDATE_FORCE);
 
 		/* set component period frames */
-		component_set_period_frames(dev, buf->stream.rate);
+		component_set_nearest_period_frames(dev, buf->stream.rate);
 
 		buf = buffer_release_irq(buf);
 	} else {
@@ -169,7 +169,7 @@ int comp_verify_params(struct comp_dev *dev, uint32_t flag,
 					source_list);
 
 		sinkb = buffer_acquire_irq(sinkb);
-		component_set_period_frames(dev, sinkb->stream.rate);
+		component_set_nearest_period_frames(dev, sinkb->stream.rate);
 		sinkb = buffer_release_irq(sinkb);
 	}
 


### PR DESCRIPTION
Dma buffer size should align with 32bytes which can't be compatible
with current 45K adjustment. 48K is a suitable adjustment.

Tested 44.1khz music on both Linux & windows