### PR TITLE
dma-trace: Full support for re-configuration and make dmatb persistent from the time it is allocated

### DIFF
--- a/src/include/sof/trace/dma-trace.h
+++ b/src/include/sof/trace/dma-trace.h
@@ -30,6 +30,9 @@ struct dma_trace_buf {
 struct dma_trace_data {
 	struct dma_sg_config config;
 	struct dma_trace_buf dmatb;
+#if CONFIG_DMA_GW
+	struct dma_sg_config gw_config;
+#endif
 	struct dma_copy dc;
 	struct sof_ipc_dma_trace_posn posn;
 	struct ipc_msg *msg;

--- a/src/ipc/ipc3/handler.c
+++ b/src/ipc/ipc3/handler.c
@@ -824,7 +824,7 @@ static int ipc_dma_trace_config(uint32_t header)
 				      &elem_array,
 				      &ring_size);
 	if (err < 0)
-		goto error;
+		goto processing_error;
 
 	err = dma_trace_host_buffer(dmat, &elem_array, ring_size);
 	if (err < 0) {
@@ -849,6 +849,12 @@ static int ipc_dma_trace_config(uint32_t header)
 	return 0;
 
 error:
+#if CONFIG_HOST_PTABLE
+	dma_sg_free(&elem_array);
+
+processing_error:
+#endif
+
 	return err;
 }
 #endif /* CONFIG_SUECREEK */

--- a/src/trace/dma-trace.c
+++ b/src/trace/dma-trace.c
@@ -322,6 +322,7 @@ static int dma_trace_start(struct dma_trace_data *d)
 			      "dma_trace_start(): DMA reconfiguration (active stream_tag: %u)",
 			      d->active_stream_tag);
 
+		schedule_task_cancel(&d->dmat_work);
 		err = dma_stop(d->dc.chan);
 		if (err < 0) {
 			mtrace_printf(LOG_LEVEL_ERROR,

--- a/src/trace/dma-trace.c
+++ b/src/trace/dma-trace.c
@@ -425,7 +425,7 @@ int dma_trace_enable(struct dma_trace_data *d)
 
 	if (err < 0) {
 		mtrace_printf(LOG_LEVEL_ERROR, "dma_trace_enable: buffer_init failed");
-		goto out;
+		return err;
 	}
 
 #ifdef __ZEPHYR__

--- a/src/trace/dma-trace.c
+++ b/src/trace/dma-trace.c
@@ -379,22 +379,19 @@ static int dma_trace_start(struct dma_trace_data *d)
 			   config.direction,
 			   elem_num, elem_size, elem_addr, 0);
 	if (err < 0)
-		goto err_alloc;
+		goto error;
 
 	err = dma_set_config(d->dc.chan, &config);
 	if (err < 0) {
 		mtrace_printf(LOG_LEVEL_ERROR, "dma_set_config() failed: %d", err);
-		goto err_config;
+		goto error;
 	}
 
 	err = dma_start(d->dc.chan);
 	if (err == 0)
 		return 0;
 
-err_config:
-	dma_sg_free(&config.elem_array);
-
-err_alloc:
+error:
 	dma_channel_put(d->dc.chan);
 	d->dc.chan = NULL;
 

--- a/src/trace/dma-trace.c
+++ b/src/trace/dma-trace.c
@@ -506,6 +506,14 @@ void dma_trace_disable(struct dma_trace_data *d)
 
 	/* free trace buffer */
 	dma_trace_buffer_free(d);
+
+#if (CONFIG_HOST_PTABLE)
+	/* Free up the host SG if it is set */
+	if (d->host_size) {
+		dma_sg_free(&d->config.elem_array);
+		d->host_size = 0;
+	}
+#endif
 }
 
 /** Sends all pending DMA messages to mailbox (for emergencies) */

--- a/src/trace/dma-trace.c
+++ b/src/trace/dma-trace.c
@@ -241,7 +241,7 @@ static int dma_trace_buffer_init(struct dma_trace_data *d)
 	buf = rballoc_align(0, SOF_MEM_CAPS_RAM | SOF_MEM_CAPS_DMA,
 			    DMA_TRACE_LOCAL_SIZE, addr_align);
 	if (!buf) {
-		tr_err(&dt_tr, "dma_trace_buffer_init(): alloc failed");
+		mtrace_printf(LOG_LEVEL_ERROR, "dma_trace_buffer_init(): alloc failed");
 		return -ENOMEM;
 	}
 


### PR DESCRIPTION
Hi,

This PR is replacing #4879.

Since last time I have noticed another path for a memory leak which was a hard one to crack:
Within dma_trace_start() when CONFIG_DMA_GW is set we were allocating a dma_sg (to SOF_MEM_ZONE_SYS) and we would do that for every start. The config is only used in that function to configure the DMA channel, but the dma_sg can not be freed up as it is allocated to SOF_MEM_ZONE_SYS. Other zone allocation failed on my tgl-h laptop.

The solution is to make dmatb and this dma_sg persistent from the point they are allocated.
This comes with a bonus that we can still collect dtrace logs to SOF firmware for some extent (if the would be dtrace client is removed we would still have some memory of the events).

The other change compared to #4879 is that I don't reset the firmware dmatb, only the host pointers as when the re-configuration happens it is indicating that  we are going to have a new host destination along with 0 offsets.
