### PR TITLE
pm_runtime: unify function prototypes for cAVS platforms

### DIFF
--- a/src/platform/apollolake/include/platform/lib/pm_runtime.h
+++ b/src/platform/apollolake/include/platform/lib/pm_runtime.h
@@ -17,50 +17,6 @@
 #define __PLATFORM_LIB_PM_RUNTIME_H__
 
 #include <cavs/lib/pm_runtime.h>
-#include <stdint.h>
-
-/**
- * \brief Initializes platform specific runtime power management.
- *
- * \param[in,out] prd Runtime power management data.
- */
-void platform_pm_runtime_init(struct pm_runtime_data *prd);
-
-/**
- * \brief Retrieves platform specific power management resource.
- *
- * \param[in] context Type of power management context.
- * \param[in] index Index of the device.
- * \param[in] flags Flags, set of RPM_...
- */
-void platform_pm_runtime_get(uint32_t context, uint32_t index, uint32_t flags);
-
-/**
- * \brief Releases platform specific power management resource.
- *
- * \param[in] context Type of power management context.
- * \param[in] index Index of the device.
- * \param[in] flags Flags, set of RPM_...
- */
-void platform_pm_runtime_put(uint32_t context, uint32_t index, uint32_t flags);
-
-void platform_pm_runtime_enable(uint32_t context, uint32_t index);
-
-void platform_pm_runtime_disable(uint32_t context, uint32_t index);
-
-void platform_pm_runtime_prepare_d0ix_en(uint32_t index);
-
-void platform_pm_runtime_prepare_d0ix_dis(uint32_t index);
-
-int platform_pm_runtime_prepare_d0ix_is_req(uint32_t index);
-
-bool platform_pm_runtime_is_active(uint32_t context, uint32_t index);
-
-/**
- * \brief Power gates platform specific hardware resources.
- * \param[in] context Type of power management context.
- */
-void platform_pm_runtime_power_off(void);
 
 #endif /* __PLATFORM_LIB_PM_RUNTIME_H__ */
 

--- a/src/platform/cannonlake/include/platform/lib/pm_runtime.h
+++ b/src/platform/cannonlake/include/platform/lib/pm_runtime.h
@@ -17,48 +17,6 @@
 #define __PLATFORM_LIB_PM_RUNTIME_H__
 
 #include <cavs/lib/pm_runtime.h>
-#include <stdint.h>
-
-/**
- * \brief Initializes platform specific runtime power management.
- * \param[in,out] prd Runtime power management data.
- */
-void platform_pm_runtime_init(struct pm_runtime_data *prd);
-
-/**
- * \brief Retrieves platform specific power management resource.
- *
- * \param[in] context Type of power management context.
- * \param[in] index Index of the device.
- * \param[in] flags Flags, set of RPM_...
- */
-void platform_pm_runtime_get(uint32_t context, uint32_t index, uint32_t flags);
-
-/**
- * \brief Releases platform specific power management resource.
- *
- * \param[in] context Type of power management context.
- * \param[in] index Index of the device.
- * \param[in] flags Flags, set of RPM_...
- */
-void platform_pm_runtime_put(uint32_t context, uint32_t index, uint32_t flags);
-
-void platform_pm_runtime_enable(uint32_t context, uint32_t index);
-
-void platform_pm_runtime_disable(uint32_t context, uint32_t index);
-
-void platform_pm_runtime_prepare_d0ix_en(uint32_t index);
-
-void platform_pm_runtime_prepare_d0ix_dis(uint32_t index);
-
-int platform_pm_runtime_prepare_d0ix_is_req(uint32_t index);
-
-bool platform_pm_runtime_is_active(uint32_t context, uint32_t index);
-
-/**
- * \brief Power gates platform specific hardware resources.
- */
-void platform_pm_runtime_power_off(void);
 
 #endif /* __PLATFORM_LIB_PM_RUNTIME_H__ */
 

--- a/src/platform/icelake/include/platform/lib/pm_runtime.h
+++ b/src/platform/icelake/include/platform/lib/pm_runtime.h
@@ -17,48 +17,6 @@
 #define __PLATFORM_LIB_PM_RUNTIME_H__
 
 #include <cavs/lib/pm_runtime.h>
-#include <stdint.h>
-
-/**
- * \brief Initializes platform specific runtime power management.
- * \param[in,out] prd Runtime power management data.
- */
-void platform_pm_runtime_init(struct pm_runtime_data *prd);
-
-/**
- * \brief Retrieves platform specific power management resource.
- *
- * \param[in] context Type of power management context.
- * \param[in] index Index of the device.
- * \param[in] flags Flags, set of RPM_...
- */
-void platform_pm_runtime_get(uint32_t context, uint32_t index, uint32_t flags);
-
-/**
- * \brief Releases platform specific power management resource.
- *
- * \param[in] context Type of power management context.
- * \param[in] index Index of the device.
- * \param[in] flags Flags, set of RPM_...
- */
-void platform_pm_runtime_put(uint32_t context, uint32_t index, uint32_t flags);
-
-void platform_pm_runtime_enable(uint32_t context, uint32_t index);
-
-void platform_pm_runtime_disable(uint32_t context, uint32_t index);
-
-void platform_pm_runtime_prepare_d0ix_en(uint32_t index);
-
-void platform_pm_runtime_prepare_d0ix_dis(uint32_t index);
-
-int platform_pm_runtime_prepare_d0ix_is_req(uint32_t index);
-
-bool platform_pm_runtime_is_active(uint32_t context, uint32_t index);
-
-/**
- * \brief Power gates platform specific hardware resources.
- */
-void platform_pm_runtime_power_off(void);
 
 #endif /* __PLATFORM_LIB_PM_RUNTIME_H__ */
 

--- a/src/platform/intel/cavs/include/cavs/lib/pm_runtime.h
+++ b/src/platform/intel/cavs/include/cavs/lib/pm_runtime.h
@@ -16,6 +16,8 @@
 #ifndef __CAVS_LIB_PM_RUNTIME_H__
 #define __CAVS_LIB_PM_RUNTIME_H__
 
+#include <stdint.h>
+
 /**
  * \brief extra pwr flag to power up a core with a specific reason
  * it can be powered down only with the same reason (flag)
@@ -36,6 +38,47 @@ struct cavs_pm_runtime_data {
 					   /**<	before next waiti */
 	int dsp_client_bitmap[CONFIG_CORE_COUNT]; /**< simple pwr override */
 };
+
+/**
+ * \brief Initializes platform specific runtime power management.
+ * \param[in,out] prd Runtime power management data.
+ */
+void platform_pm_runtime_init(struct pm_runtime_data *prd);
+
+/**
+ * \brief Retrieves platform specific power management resource.
+ *
+ * \param[in] context Type of power management context.
+ * \param[in] index Index of the device.
+ * \param[in] flags Flags, set of RPM_...
+ */
+void platform_pm_runtime_get(uint32_t context, uint32_t index, uint32_t flags);
+
+/**
+ * \brief Releases platform specific power management resource.
+ *
+ * \param[in] context Type of power management context.
+ * \param[in] index Index of the device.
+ * \param[in] flags Flags, set of RPM_...
+ */
+void platform_pm_runtime_put(uint32_t context, uint32_t index, uint32_t flags);
+
+void platform_pm_runtime_enable(uint32_t context, uint32_t index);
+
+void platform_pm_runtime_disable(uint32_t context, uint32_t index);
+
+void platform_pm_runtime_prepare_d0ix_en(uint32_t index);
+
+void platform_pm_runtime_prepare_d0ix_dis(uint32_t index);
+
+int platform_pm_runtime_prepare_d0ix_is_req(uint32_t index);
+
+bool platform_pm_runtime_is_active(uint32_t context, uint32_t index);
+
+/**
+ * \brief Power gates platform specific hardware resources.
+ */
+void platform_pm_runtime_power_off(void);
 
 /**
  * \brief CAVS DSP residency counters

--- a/src/platform/suecreek/include/platform/lib/pm_runtime.h
+++ b/src/platform/suecreek/include/platform/lib/pm_runtime.h
@@ -17,43 +17,6 @@
 #define __PLATFORM_LIB_PM_RUNTIME_H__
 
 #include <cavs/lib/pm_runtime.h>
-#include <stdint.h>
-
-/**
- * \brief Initializes platform specific runtime power management.
- * \param[in,out] prd Runtime power management data.
- */
-void platform_pm_runtime_init(struct pm_runtime_data *prd);
-
-/**
- * \brief Retrieves platform specific power management resource.
- *
- * \param[in] context Type of power management context.
- * \param[in] index Index of the device.
- * \param[in] flags Flags, set of RPM_...
- */
-void platform_pm_runtime_get(uint32_t context, uint32_t index, uint32_t flags);
-
-/**
- * \brief Releases platform specific power management resource.
- *
- * \param[in] context Type of power management context.
- * \param[in] index Index of the device.
- * \param[in] flags Flags, set of RPM_...
- */
-void platform_pm_runtime_put(uint32_t context, uint32_t index, uint32_t flags);
-
-void platform_pm_runtime_enable(uint32_t context, uint32_t index);
-
-void platform_pm_runtime_disable(uint32_t context, uint32_t index);
-
-bool platform_pm_runtime_is_active(uint32_t context, uint32_t index);
-
-void platform_pm_runtime_prepare_d0ix_en(uint32_t index);
-
-void platform_pm_runtime_prepare_d0ix_dis(uint32_t index);
-
-int platform_pm_runtime_prepare_d0ix_is_req(uint32_t index);
 
 #endif /* __PLATFORM_LIB_PM_RUNTIME_H__ */
 

--- a/src/platform/tigerlake/include/platform/lib/pm_runtime.h
+++ b/src/platform/tigerlake/include/platform/lib/pm_runtime.h
@@ -17,48 +17,6 @@
 #define __PLATFORM_LIB_PM_RUNTIME_H__
 
 #include <cavs/lib/pm_runtime.h>
-#include <stdint.h>
-
-/**
- * \brief Initializes platform specific runtime power management.
- * \param[in,out] prd Runtime power management data.
- */
-void platform_pm_runtime_init(struct pm_runtime_data *prd);
-
-/**
- * \brief Retrieves platform specific power management resource.
- *
- * \param[in] context Type of power management context.
- * \param[in] index Index of the device.
- * \param[in] flags Flags, set of RPM_...
- */
-void platform_pm_runtime_get(uint32_t context, uint32_t index, uint32_t flags);
-
-/**
- * \brief Releases platform specific power management resource.
- *
- * \param[in] context Type of power management context.
- * \param[in] index Index of the device.
- * \param[in] flags Flags, set of RPM_...
- */
-void platform_pm_runtime_put(uint32_t context, uint32_t index, uint32_t flags);
-
-void platform_pm_runtime_enable(uint32_t context, uint32_t index);
-
-void platform_pm_runtime_disable(uint32_t context, uint32_t index);
-
-void platform_pm_runtime_prepare_d0ix_en(uint32_t index);
-
-void platform_pm_runtime_prepare_d0ix_dis(uint32_t index);
-
-int platform_pm_runtime_prepare_d0ix_is_req(uint32_t index);
-
-bool platform_pm_runtime_is_active(uint32_t context, uint32_t index);
-
-/**
- * \brief Power gates platform specific hardware resources.
- */
-void platform_pm_runtime_power_off(void);
 
 #endif /* __PLATFORM_LIB_PM_RUNTIME_H__ */
 


### PR DESCRIPTION
All cAVS platforms use the same pm_runtime.c implementation, no need for separate headers, repeating the same function declarations.
