### PR TITLE
platform: cavs: make IMR restore feature default - except APL

### DIFF
--- a/src/platform/Kconfig
+++ b/src/platform/Kconfig
@@ -455,8 +455,8 @@ config CAVS_USE_LPRO_IN_WAITI
 
 config CAVS_IMR_D3_PERSISTENT
 	bool "Intel IMR content persistent on DSP in D3"
-	depends on CAVS
-	default n
+	depends on CAVS && !CAVS_VERSION_1_5
+	default y
 	help
 	  Select this if the Intel cAVS platform can keep the
 	  IMR (Isolated Memory Region) content persistent when


### PR DESCRIPTION
Let's enable this capability, with ApolloLake left out for now since there
are known issues with suspend-resume on Up2 board that were never
root-caused.

Enabling this at the firmware level is not enough, this capability
need to be enabled by kernel patches in
https://github.com/thesofproject/linux/pull/3340

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>