### PR TITLE
topology2: gain: fix dB scale min and step values

### DIFF
--- a/tools/topology/topology2/include/components/gain.conf
+++ b/tools/topology/topology2/include/components/gain.conf
@@ -133,12 +133,12 @@ Class.Widget."gain" {
 				get 	256
 				put 	256
 			}
-			max 66
+			max 45
 
-			Object.Base.tlv."vtlv_m64s1" {
-                                        Object.Base.scale."m64s1" {
-						min     1354970
-						step    1
+			Object.Base.tlv."vtlv_m90s2" {
+                                        Object.Base.scale."m90s2" {
+						min     -9000
+						step    200
 						mute    1
 					}
                                 }


### PR DESCRIPTION
It is not intuitive for the end-ser to set linear values for
minimum gain. Set the dB gain min value to -90dB and steps to 2dB.
Also, modify the max to 45 to allow the volume gain range -90dB to 0dB.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>