### PR TITLE
ll_schedule: unregister domain in free function with IRQ_ONLY_FLAG

### DIFF
--- a/src/schedule/ll_schedule.c
+++ b/src/schedule/ll_schedule.c
@@ -665,15 +665,13 @@ static void scheduler_free_ll(void *data, uint32_t flags)
 	struct ll_schedule_data *sch = data;
 	uint32_t irq_flags;
 
-	if (flags & SOF_SCHEDULER_FREE_IRQ_ONLY)
-		return;
-
 	irq_local_disable(irq_flags);
 
 	domain_unregister(sch->domain, NULL, 0);
 
-	notifier_unregister(sch, NULL,
-			    NOTIFIER_CLK_CHANGE_ID(sch->domain->clk));
+	if (!(flags & SOF_SCHEDULER_FREE_IRQ_ONLY))
+		notifier_unregister(sch, NULL,
+				    NOTIFIER_CLK_CHANGE_ID(sch->domain->clk));
 
 	irq_local_enable(irq_flags);
 }


### PR DESCRIPTION
scheduler_free_ll() function should invoke domain_unregister()
in case when SOF_SCHEDULER_FREE_IRQ_ONLY flag is used, beacause
in timer domain case, timer_domain_unregister() function
unregisters timer interrupts.

fixes #5114 

Signed-off-by: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>