### PR TITLE
test: improve compatibility for malloc.h

### DIFF
--- a/test/cmocka/src/audio/mixer/comp_mock.c
+++ b/test/cmocka/src/audio/mixer/comp_mock.c
@@ -6,10 +6,15 @@
 
 #include <stdint.h>
 #include <stddef.h>
-#include <malloc.h>
 #include <sof/list.h>
 #include <sof/audio/stream.h>
 #include <sof/audio/component.h>
+
+#ifdef HAVE_MALLOC_H
+#include <malloc.h>
+#else
+#include <stdlib.h>
+#endif
 
 #include "comp_mock.h"
 

--- a/test/cmocka/src/audio/mixer/mixer_test.c
+++ b/test/cmocka/src/audio/mixer/mixer_test.c
@@ -9,7 +9,6 @@
 #include <math.h>
 #include <setjmp.h>
 #include <stdint.h>
-#include <malloc.h>
 #include <cmocka.h>
 #include <sof/list.h>
 #include <sof/ipc/driver.h>
@@ -20,6 +19,12 @@
 #include <sof/audio/component.h>
 #include <sof/audio/format.h>
 #include <sof/audio/mixer.h>
+
+#ifdef HAVE_MALLOC_H
+#include <malloc.h>
+#else
+#include <stdlib.h>
+#endif
 
 #include "comp_mock.h"
 

--- a/test/cmocka/src/audio/pcm_converter/pcm_float.c
+++ b/test/cmocka/src/audio/pcm_converter/pcm_float.c
@@ -16,9 +16,14 @@
 #include <stddef.h>
 #include <setjmp.h>
 #include <math.h>
-#include <malloc.h>
 #include <stdint.h>
 #include <cmocka.h>
+
+#ifdef HAVE_MALLOC_H
+#include <malloc.h>
+#else
+#include <stdlib.h>
+#endif
 
 #include "../../util.h"
 

--- a/test/cmocka/src/audio/pipeline/pipeline_connection_mocks.h
+++ b/test/cmocka/src/audio/pipeline/pipeline_connection_mocks.h
@@ -12,8 +12,13 @@
 #include <stddef.h>
 #include <setjmp.h>
 #include <stdint.h>
-#include <malloc.h>
 #include <cmocka.h>
+
+#ifdef HAVE_MALLOC_H
+#include <malloc.h>
+#else
+#include <stdlib.h>
+#endif
 
 #define PIPELINE_ID_SAME 3
 #define PIPELINE_ID_DIFFERENT 4

--- a/test/cmocka/src/audio/pipeline/pipeline_free.c
+++ b/test/cmocka/src/audio/pipeline/pipeline_free.c
@@ -14,8 +14,13 @@
 #include <stdarg.h>
 #include <stddef.h>
 #include <setjmp.h>
-#include <malloc.h>
 #include <cmocka.h>
+
+#ifdef HAVE_MALLOC_H
+#include <malloc.h>
+#else
+#include <stdlib.h>
+#endif
 
 /* mock free() - dont free as we inspect contents */
 void rfree(void *ptr)

--- a/test/cmocka/src/audio/pipeline/pipeline_new.c
+++ b/test/cmocka/src/audio/pipeline/pipeline_new.c
@@ -12,8 +12,13 @@
 #include <stdarg.h>
 #include <stddef.h>
 #include <setjmp.h>
-#include <malloc.h>
 #include <cmocka.h>
+
+#ifdef HAVE_MALLOC_H
+#include <malloc.h>
+#else
+#include <stdlib.h>
+#endif
 
 static int setup(void **state)
 {

--- a/test/cmocka/src/debugability/macros.c
+++ b/test/cmocka/src/debugability/macros.c
@@ -10,8 +10,13 @@
 #include <stdarg.h>
 #include <setjmp.h>
 #include <stdint.h>
-#include <malloc.h>
 #include <cmocka.h>
+
+#ifdef HAVE_MALLOC_H
+#include <malloc.h>
+#else
+#include <stdlib.h>
+#endif
 
 #include <sof/trace/preproc.h>
 #include <sof/sof.h>
@@ -46,7 +51,7 @@ static void test_debugability_macros_declare_log_entry(void **state)
 			"1"
 			"0"
 			"1"
-			"31"
+			"36"
 			"sizeof(\"" RELATIVE_FILE "\")"
 			"sizeof(\"Message\")"
 			"\"" RELATIVE_FILE "\""

--- a/test/cmocka/src/lib/lib/strcheck.c
+++ b/test/cmocka/src/lib/lib/strcheck.c
@@ -11,8 +11,13 @@
 #include <setjmp.h>
 #include <stdint.h>
 #include <stdlib.h>
-#include <malloc.h>
 #include <cmocka.h>
+
+#ifdef HAVE_MALLOC_H
+#include <malloc.h>
+#else
+#include <stdlib.h>
+#endif
 
 #include <test_group_generator.h>
 


### PR DESCRIPTION
The C header file malloc.h does not exist on
some Xtensa processor configurations or host OSes,
include stdlib.h instead because they both provide
the prototype for 'malloc' function.

Fixes: #5102

Signed-off-by: Chao Song <chao.song@linux.intel.com>