### PR TITLE
logger: move "log_entry_address x not in dictionary range" to stderr

### DIFF
--- a/tools/logger/convert.c
+++ b/tools/logger/convert.c
@@ -891,9 +891,7 @@ static int logger_read(void)
 			 * report errors only for the DMA trace.
 			 */
 			if (global_config->trace && ldc_address_OK) {
-				/* FIXME: make this a log_err() */
-				fprintf(global_config->out_fd,
-					"warn: log_entry_address %#8x is not in dictionary range!\n",
+				log_err("log_entry_address %#10x is not in dictionary range!\n",
 					dma_log.log_entry_address);
 				fprintf(global_config->out_fd,
 					"warn: Seeking forward 4 bytes at a time until re-synchronize.\n");


### PR DESCRIPTION
Make DMA trace corruption #5120 a bit more visible in the logs.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>