### PR TITLE
cmake: fix .ldc chksum fallback when no SOURCE_DIRECTORY/.git

### DIFF
--- a/scripts/cmake/version.cmake
+++ b/scripts/cmake/version.cmake
@@ -110,13 +110,14 @@ if(EXISTS ${SOF_ROOT_SOURCE_DIRECTORY}/.git/)
 	message(STATUS "Source content hash: ${SOF_SRC_HASH}. \
 Note: by design, source hash is broken by config changes. See #3890.")
 else() # Zephyr, tarball,...
-	if("${GIT_LOG_HASH}")
+	if(NOT "${GIT_LOG_HASH}" STREQUAL "")
 		string(SUBSTRING "${GIT_LOG_HASH}" 0 8 SOF_SRC_HASH)
 	else()
-		set(SOF_SRC_HASH "0")
+		set(SOF_SRC_HASH "baadf00d")
 	endif()
 	message(WARNING "${SOF_ROOT_SOURCE_DIRECTORY}/.git not found, \
-source content hash cannot computed. Using GIT_LOG_HASH for .ldc instead.")
+source content hash cannot computed for the .ldc. Using SOF_SRC_HASH=${SOF_SRC_HASH} \
+from GIT_LOG_HASH instead")
 endif()
 
 # for SOF_BUILD


### PR DESCRIPTION
Fixes old (Aug 2020) and untested commit b2a325a3b7e66 ("cmake: Handle
empty SOF_SRC_HASH_LONG") which tried to use GIT_LOG_HASH as a fallback
for the SOF_SRC_HASH .ldc checksum but always fell back on "0" instead
because of a misunderstanding of cmake's surprisingly complex "if"
operator.

Before Zephyr this was not an issue in practice because GIT_LOG_HASH was
empty anyway when SOURCE_DIRECTORY/.git was missing, so there was
nothing to lose.

For the Zephyr builds this will now use the SOF SHA1 as the .ldc checksum
for now. Probably not ideal yet but far better than the current constant
"0" which means no check at all.

Also log the SOF_SRC_HASH fallback value now and change the second
fallback (when GIT_LOG_HASH is also missing) from "0" to the
searchable hexspeak "baadf00d".

Signed-off-by: Marc Herbert <marc.herbert@intel.com>