### PR TITLE
Revert "topology: redirection to workaround hardcoded alsatplg permissions"

### DIFF
--- a/tools/topology/CMakeLists.txt
+++ b/tools/topology/CMakeLists.txt
@@ -19,9 +19,11 @@ macro(add_alsatplg_command)
 	add_custom_command(
 		MAIN_DEPENDENCY ${ARGV0}
 		OUTPUT ${ARGV1}
-		# Use a redirection to work around hardcoded alsatplg permissions,
-		# see bug https://github.com/alsa-project/alsa-utils/issues/126
-		COMMAND alsatplg \$\${VERBOSE:+-v 1} -c ${ARGV0} -o - > ${ARGV1}
+		# Warning: before alsa-utils fix 8e71fba810b87c,
+		# permissions are hardcoded and only the user can read
+		# the -o(utput) file.
+		# See bug https://github.com/alsa-project/alsa-utils/issues/126
+		COMMAND alsatplg \$\${VERBOSE:+-v 1} -c ${ARGV0} -o ${ARGV1}
 		USES_TERMINAL
 	)
 endmacro()


### PR DESCRIPTION


This reverts commit eb344375228b15529838d6e4992bc7572650ab5e.

Fixes #5113

The `alsatplg -o -` feature is incompatible with `-v` and basically
buggy because it happily sends .tplg output and debug statements to
the same place without a care. To reproduce the bug, simply run:
```
   VERBOSE=1 ./scripts/build-tools.sh -T
```
... then observe .tplg output files like this:
```
B0x003d3b/015675 - pcm 'DMIC': write 912 bytes
B0x0040cb/016587 - pcm 'HDMI1': write 912 bytes
B0x00445b/017499 - pcm 'HDMI2': write 912 bytes
B0x0047eb/018411 - pcm 'HDMI3': write 912 bytes
B0x004b7b/019323 - pcm 'DMIC16kHz': write 912 bytes
B0x004f0b/020235 - block size for type be (11:10) is 0x2ad4/10964
B0x004f0b/020235 - header index 0CoSA^E^@^@^@^@^@^@^@^H^@^@^@$^@^@
^@^@^@^@^@s^@^@^@^@^@^@^@^A^@^@^@p^@^@^@ ^@^@^@.^@^@^@ ^@^@^@^F^@^
@^@^F^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^
@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^
@^@^@^@^@^@^@^@^@^...
```
Signed-off-by: Marc Herbert <marc.herbert@intel.com>