### PR TITLE
xtensa-build-all: only list rom if it is built

### DIFF
--- a/scripts/xtensa-build-all.sh
+++ b/scripts/xtensa-build-all.sh
@@ -435,5 +435,9 @@ do
 done # for platform in ...
 
 # list all the images
-ls -l build_*/*.ri build_*/src/arch/xtensa/rom*.bin || true
-ls -l build_*/sof
+if [[ "x$BUILD_ROM" == "xyes" ]]
+then
+	ls -l build_*/src/arch/xtensa/rom*.bin || true
+fi
+
+ls -l build_*/*.ri build_*/sof


### PR DESCRIPTION
This patch helps to remove the misleading "ls:
cannot access 'build_*/src/arch/xtensa/rom*.bin':
No such file or directory" warning.

Signed-off-by: Chao Song <chao.song@linux.intel.com>