### PR TITLE
Update host position value in every period to improve precision

### DIFF
--- a/src/include/ipc/stream.h
+++ b/src/include/ipc/stream.h
@@ -94,8 +94,9 @@ struct sof_ipc_stream_params {
 
 	uint32_t host_period_bytes;
 	uint16_t no_stream_position; /**< 1 means don't send stream position */
+	uint8_t cont_update_posn; /**< 1 means continuous update stream position */
 
-	uint16_t reserved[3];
+	uint8_t reserved[5];
 	uint16_t chmap[SOF_IPC_MAX_CHANNELS];	/**< channel map - SOF_CHMAP_ */
 } __attribute__((packed, aligned(4)));
 

--- a/src/include/kernel/abi.h
+++ b/src/include/kernel/abi.h
@@ -29,8 +29,8 @@
 
 /** \brief SOF ABI version major, minor and patch numbers */
 #define SOF_ABI_MAJOR 3
-#define SOF_ABI_MINOR 20
-#define SOF_ABI_PATCH 1
+#define SOF_ABI_MINOR 21
+#define SOF_ABI_PATCH 0
 
 /** \brief SOF ABI version number. Format within 32bit word is MMmmmppp */
 #define SOF_ABI_MAJOR_SHIFT	24

--- a/src/ipc/ipc3/handler.c
+++ b/src/ipc/ipc3/handler.c
@@ -193,6 +193,7 @@ static int ipc_stream_pcm_params(uint32_t stream)
 	struct sof_ipc_pcm_params pcm_params;
 	struct sof_ipc_pcm_params_reply reply;
 	struct ipc_comp_dev *pcm_dev;
+	struct sof_ipc_stream_posn posn;
 	int err, reset_err;
 
 	/* copy message with ABI safe method */
@@ -299,6 +300,11 @@ pipe_params:
 	reply.rhdr.error = 0;
 	reply.comp_id = pcm_params.comp_id;
 	reply.posn_offset = pcm_dev->cd->pipeline->posn_offset;
+
+	/* reset position value before send ipc */
+	memset(&posn, 0, sizeof(posn));
+	mailbox_stream_write(reply.posn_offset, &posn, sizeof(posn));
+
 	mailbox_hostbox_write(0, &reply, sizeof(reply));
 	return 1;
 


### PR DESCRIPTION
Hi,

I modify host position in every period not only larger than host period bytes. Host position will be updated more precisely. When linux side use pcm pointer callback to get host position data then the position will be updated based on pipeline period.
I also reset host position value as zero before replay ipc_stream_pcm_params to avoid unexpected value. I saw this invalid value when I run alsa conformance test and I implement PCM pointer function to get host position value but see invalid value at the beginning. After I provide this code, the invalid value will be replaced with zero.  Please help to review this PR and any feedback are welcome. Thanks. 