### PR TITLE
topology1: mt8195: support 1ms pipeline playback period

### DIFF
--- a/tools/topology/topology1/sof-mt8195-mt6359-rt1019-rt5682.m4
+++ b/tools/topology/topology1/sof-mt8195-mt6359-rt1019-rt5682.m4
@@ -39,25 +39,25 @@ dnl     time_domain, sched_comp)
 PIPELINE_PCM_ADD(
 	ifdef(`DTS', sof/pipe-eq-iir-dts-codec-playback.m4, sof/pipe-passthrough-playback.m4),
 	1, 16, 2, s16le,
-	10000, 0, 0,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
-# Low Latency playback pipeline 2 on PCM 16 using max 2 channels of s16le
+# Low Latency playback pipeline 2 on PCM 17 using max 2 channels of s16le
 # Set 10000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(
 	ifdef(`DTS', sof/pipe-eq-iir-dts-codec-playback.m4, sof/pipe-passthrough-playback.m4),
 	2, 17, 2, s16le,
-	10000, 0, 0,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
-# Low Latency capture pipeline 3 on PCM 16 using max 2 channels of s16le
+# Low Latency capture pipeline 3 on PCM 18 using max 2 channels of s16le
 # Set 10000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
 	3, 18, 2, s16le,
 	10000, 0, 0,
 	48000, 48000, 48000)
 
-# Low Latency playback pipeline 4 on PCM 16 using max 2 channels of s16le
+# Low Latency playback pipeline 4 on PCM 19 using max 2 channels of s16le
 # Set 10000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
 	4, 19, 2, s16le,
@@ -79,24 +79,24 @@ dnl     deadline, priority, core)
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, AFE, 0, AFE_SOF_DL2,
 	PIPELINE_SOURCE_1, 2, s16le,
-	10000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # playback DAI is AFE using 2 periods
 # Buffers use s16le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	2, AFE, 1, AFE_SOF_DL3,
 	PIPELINE_SOURCE_2, 2, s16le,
-	10000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is AFE using 2 periods
-# Buffers use s16le format, with 48 frame per 1000us on core 0 with priority 0
+# Buffers use s16le format, with 48 frame per 10000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	3, AFE, 2, AFE_SOF_UL4,
 	PIPELINE_SINK_3, 2, s16le,
 	10000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is AFE using 2 periods
-# Buffers use s16le format, with 48 frame per 1000us on core 0 with priority 0
+# Buffers use s16le format, with 48 frame per 10000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	4, AFE, 3, AFE_SOF_UL5,
 	PIPELINE_SINK_4, 2, s16le,


### PR DESCRIPTION
Default support 1ms period playback pipeline to update host position
more precisely.

Signed-off-by: YC Hung <yc.hung@mediatek.com>