### PR TITLE
coredump-reader: do not hardcode reset vector address

### DIFF
--- a/tools/coredumper/sof-coredump-reader.py
+++ b/tools/coredumper/sof-coredump-reader.py
@@ -718,7 +718,13 @@ class CoreDumpReader(object):
 			.format(stack_base, stack_dw_num))
 
 		stdoutOpen()
-		stdoutPrint("break *0xbefe0000\nrun\n")
+
+		# for XTOS SOF build
+		stdoutPrint("break _MemErrorVector\n")
+		# for Zephyr SOF build
+		stdoutPrint("break _MemoryExceptionVector_text_start\n")
+
+		stdoutPrint("run\n")
 		stdoutPrint(self.core_dump.to_string(1))
 
 		#TODO: make this elegant


### PR DESCRIPTION
The gdb script created by coredump-reader has a fixed reset
vector address. This address only works on a subset of supported
SOF platforms and for other platforms, user has to manually fix
the reset address in the gdb script before use.

Modify the script to emit breakpoint for "_MemErrorVector"
symbol. This is not the reset vector, but the simulation will
still be trapped early. The symbol is part of the firmware
binary, so its address can be looked up at runtime.

Also add a second breakpoint for "_MemoryExceptionVector_text_start".
This will cover SOF binaries built with Zephyr as the RTOS.

BugLink: https://github.com/thesofproject/sof/issues/5125
Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>