### PR TITLE
[SKIP CI] Docker: sof: add ninja-build

### DIFF
--- a/scripts/docker_build/sof_builder/Dockerfile
+++ b/scripts/docker_build/sof_builder/Dockerfile
@@ -34,6 +34,7 @@ RUN apt-get -y update && \
 		autoconf \
 		bison \
 		build-essential \
+		ninja-build \
 		python3-pyelftools \
 		flex \
 		gawk \


### PR DESCRIPTION
We should gradually switch to ninja as a default.

ninja-build is apparently missing from build-essential

Signed-off-by: Marc Herbert <marc.herbert@intel.com>