### PR TITLE
codeowner: add rander to review ipc changes

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,6 +11,7 @@
 # include files
 src/include/sof/drivers/dmic.h		@singalsu
 src/include/ipc/**			@thesofproject/steering-committee
+src/include/ipc/**			@randerwang
 src/include/kernel/**			@thesofproject/steering-committee
 src/include/user/**			@thesofproject/steering-committee
 src/include/sof/debug/gdb/*		@mrajwa


### PR DESCRIPTION
I am working on ipc interface for IPC4 and will
focus on ipc interface for both IPC3 & IPC4.

Signed-off-by: Rander Wang <rander.wang@intel.com>