### PR TITLE
replace PAUSE / RELEASE with STOP / START

### DIFF
--- a/src/ipc/Kconfig
+++ b/src/ipc/Kconfig
@@ -23,4 +23,12 @@ config IPC_MAJOR_4
 
 endchoice
 
+config STOP_FOR_PAUSE
+	bool
+	default y
+	help
+	  When selected, this option handles PAUSE and RELEASE streaming
+	  triggers just like STOP and START.
+	  If unsure say N.
+
 endmenu

--- a/src/ipc/ipc3/handler.c
+++ b/src/ipc/ipc3/handler.c
@@ -515,10 +515,14 @@ static int ipc_glb_stream_message(uint32_t header)
 		return ipc_stream_pcm_params(header);
 	case SOF_IPC_STREAM_PCM_FREE:
 		return ipc_stream_pcm_free(header);
-	case SOF_IPC_STREAM_TRIG_START:
-	case SOF_IPC_STREAM_TRIG_STOP:
 	case SOF_IPC_STREAM_TRIG_PAUSE:
 	case SOF_IPC_STREAM_TRIG_RELEASE:
+#if CONFIG_BAYTRAIL || CONFIG_CHERRYTRAIL || CONFIG_HASWELL || CONFIG_BROADWELL
+		tr_err(&ipc_tr, "ipc: stream cmd 0x%x is unsupported on this platform", cmd);
+		return -EOPNOTSUPP;
+#endif
+	case SOF_IPC_STREAM_TRIG_START:
+	case SOF_IPC_STREAM_TRIG_STOP:
 	case SOF_IPC_STREAM_TRIG_DRAIN:
 	case SOF_IPC_STREAM_TRIG_XRUN:
 		return ipc_stream_trigger(header);

--- a/src/ipc/ipc3/handler.c
+++ b/src/ipc/ipc3/handler.c
@@ -456,10 +456,18 @@ static int ipc_stream_trigger(uint32_t header)
 		cmd = COMP_TRIGGER_STOP;
 		break;
 	case SOF_IPC_STREAM_TRIG_PAUSE:
+#if CONFIG_STOP_FOR_PAUSE
+		cmd = COMP_TRIGGER_STOP;
+#else
 		cmd = COMP_TRIGGER_PAUSE;
+#endif
 		break;
 	case SOF_IPC_STREAM_TRIG_RELEASE:
+#if CONFIG_STOP_FOR_PAUSE
+		cmd = COMP_TRIGGER_PRE_START;
+#else
 		cmd = COMP_TRIGGER_PRE_RELEASE;
+#endif
 		break;
 	/* XRUN is special case- TODO */
 	case SOF_IPC_STREAM_TRIG_XRUN:


### PR DESCRIPTION
Currently many components, e.g. DAIs handle STOP and PAUSE differently. Also the mixer component blocks PAUSE while obviously accepting and propagating STOP. This creates a lot of complexity in forking pipelines. With START, STOP, PAUSE and RELEASE now handled in the pipeline task context, it should be possible to handle PAUSE and RELEASE exactly like STOP and START.