### PR TITLE
SOF TEST for zephyr PR #41661 Yet more ongoing cAVS cleanup & futureproofing

### DIFF
--- a/scripts/xtensa-build-zephyr.sh
+++ b/scripts/xtensa-build-zephyr.sh
@@ -133,7 +133,7 @@ west_init_update()
 	# fetching of (full 40-digits) SHAs; even SHAs not in origin but
 	# in forks!
 
-	# zephyr_fetch_and_switch    origin   pull/38374/head
+	zephyr_fetch_and_switch    origin   pull/41661/head
 	# zephyr_fetch_and_switch    origin   19d5448ec117fde8076bec4d0e61da53147f3315
 
 	# SECURITY WARNING for reviewers: never allow unknown code from


### PR DESCRIPTION
Test for
https://github.com/zephyrproject-rtos/zephyr/pull/41661 currently at
https://github.com/zephyrproject-rtos/zephyr/commit/62336a8f8c82094c as
I'm writing this.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>