### PR TITLE
hal: Add compare_exchange atomics for xtensa. (tgl-013-drop-stable)

### DIFF
--- a/src/arch/xtensa/hal/CMakeLists.txt
+++ b/src/arch/xtensa/hal/CMakeLists.txt
@@ -139,4 +139,5 @@ add_local_sources(hal
 	interrupts.c
 	memcopy.S
 	windowspill_asm.S
+	atomics.c
 )

--- a/src/arch/xtensa/hal/atomics.c
+++ b/src/arch/xtensa/hal/atomics.c
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <stdint.h>
+#include <xtensa/hal.h>
+
+int _xt_atomic_compare_exchange_4(int32_t *address, int32_t test_value, int32_t set_value);
+
+int _xt_atomic_compare_exchange_4(int32_t *address, int32_t test_value, int32_t set_value)
+{
+	return xthal_compare_and_set(address, test_value, set_value);
+}


### PR DESCRIPTION
Backport PR #5089 to tgl-013-drop-stable

Add compare_exchange atomic for better support of std::atomic when using
c++.

Signed-off-by: Lionel Koenig <lionelk@google.com>