### PR TITLE
lib: use 32-bit assignments for memset()

### DIFF
--- a/src/include/sof/common.h
+++ b/src/include/sof/common.h
@@ -25,7 +25,14 @@
 
 #define ALIGN_UP_INTERNAL(val, align) (((val) + (align) - 1) & ~((align) - 1))
 
+#if !defined(__ASSEMBLER__) && defined(__XTENSA__)
+
+#include <ipc/trace.h>
+#include <sof/debug/panic.h>
 #define VERIFY_ALIGN
+
+#endif
+
 #ifdef VERIFY_ALIGN
 
 /* Using this when 'alignment' is a constant and when compiling with gcc
@@ -78,7 +85,7 @@
 
 #endif /* not __XCC__ */
 
-#else /* not RUNTIME_ALIGN_CHECK */
+#else /* not VERIFY_ALIGN */
 
 #define ALIGN_UP(size, alignment) ALIGN_UP_INTERNAL(size, alignment)
 #define ALIGN_UP_COMPILE ALIGN_UP

--- a/src/platform/apollolake/CMakeLists.txt
+++ b/src/platform/apollolake/CMakeLists.txt
@@ -7,3 +7,6 @@ add_executable(base_module base_module.c)
 
 target_link_libraries(boot_module sof_options)
 target_link_libraries(base_module sof_options)
+
+sof_append_relative_path_definitions(boot_module)
+sof_append_relative_path_definitions(base_module)

--- a/src/platform/cannonlake/CMakeLists.txt
+++ b/src/platform/cannonlake/CMakeLists.txt
@@ -7,3 +7,6 @@ add_executable(base_module base_module.c)
 
 target_link_libraries(boot_module sof_options)
 target_link_libraries(base_module sof_options)
+
+sof_append_relative_path_definitions(boot_module)
+sof_append_relative_path_definitions(base_module)

--- a/src/platform/icelake/CMakeLists.txt
+++ b/src/platform/icelake/CMakeLists.txt
@@ -7,3 +7,6 @@ add_executable(base_module base_module.c)
 
 target_link_libraries(boot_module sof_options)
 target_link_libraries(base_module sof_options)
+
+sof_append_relative_path_definitions(boot_module)
+sof_append_relative_path_definitions(base_module)

--- a/src/platform/suecreek/CMakeLists.txt
+++ b/src/platform/suecreek/CMakeLists.txt
@@ -7,3 +7,6 @@ add_executable(base_module base_module.c)
 
 target_link_libraries(boot_module sof_options)
 target_link_libraries(base_module sof_options)
+
+sof_append_relative_path_definitions(boot_module)
+sof_append_relative_path_definitions(base_module)

--- a/src/platform/tigerlake/CMakeLists.txt
+++ b/src/platform/tigerlake/CMakeLists.txt
@@ -7,3 +7,6 @@ add_executable(base_module base_module.c)
 
 target_link_libraries(boot_module sof_options)
 target_link_libraries(base_module sof_options)
+
+sof_append_relative_path_definitions(boot_module)
+sof_append_relative_path_definitions(base_module)


### PR DESCRIPTION
SOF loves `memset()`. It takes great care to 0-initialise buffers and objects. And its `memset()` routine only sets one byte at a time. Optimise it to use 32-bit assignments where possible.

In fact it's weird. We have a SIMD-optimised version of `memset()`, accessible via `bzero()` and `memset_s()`, but that's only available to XCC builds (this is logical, gcc doesn't support Xtensa SIMD) **and** there are still a lot of locations, where the plain `memset()` is called. Since the plain `memset()` is anyway all, that's available to gcc, it's good to optimise it anyway. And we should move all plain `memset()` calls to `memset_s()` or `bzero()`. What about `memcmp()`, `memcpy()` etc.?