### PR TITLE
ipc4: add Aria module support for ipc4

### DIFF
--- a/src/audio/CMakeLists.txt
+++ b/src/audio/CMakeLists.txt
@@ -122,7 +122,9 @@ if(NOT CONFIG_LIBRARY)
                         base_fw.c
                 )
         endif()
-
+	if(CONFIG_COMP_ARIA)
+		add_subdirectory(aria)
+	endif()
 	subdirs(pipeline)
 
 	return()

--- a/src/audio/Kconfig
+++ b/src/audio/Kconfig
@@ -20,6 +20,17 @@ config COMP_DAI
 	help
 	  Select for DAI component
 
+config COMP_ARIA
+        bool "ARIA component"
+        default n
+        depends on IPC_MAJOR_4
+        help
+          Select for Automatic Regressive Input Amplifier Module component
+	  ARIA applies variable gain into incoming signal.
+	  Applied gain is in range <1, 2 power attenuation>
+	  Currently ARIA introduces gain transition and algorithmic
+	  latency equal to 1 ms.
+
 config COMP_VOLUME
 	bool "Volume component"
 	default y

--- a/src/audio/aria/CMakeLists.txt
+++ b/src/audio/aria/CMakeLists.txt
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+add_local_sources(sof aria.c aria_hifi3.c)

--- a/src/audio/aria/aria.c
+++ b/src/audio/aria/aria.c
@@ -1,0 +1,352 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2022 Intel Corporation. All rights reserved.
+//
+// Author: Adrian Bonislawski <adrian.bonislawski@intel.com>
+
+#include <sof/audio/aria/aria.h>
+#include <sof/audio/buffer.h>
+#include <sof/audio/format.h>
+#include <sof/audio/pipeline.h>
+#include <sof/debug/panic.h>
+#include <sof/ipc/msg.h>
+#include <sof/lib/alloc.h>
+#include <sof/lib/cache.h>
+#include <sof/lib/memory.h>
+#include <sof/lib/notifier.h>
+#include <sof/lib/uuid.h>
+#include <sof/list.h>
+#include <sof/string.h>
+#include <sof/ut.h>
+#include <sof/trace/trace.h>
+#include <ipc4/aria.h>
+#include <ipc4/fw_reg.h>
+#include <ipc/dai.h>
+#include <user/trace.h>
+#include <errno.h>
+#include <stddef.h>
+#include <stdint.h>
+
+static const struct comp_driver comp_aria;
+
+/* these ids aligns windows driver requirement to support windows driver */
+/* 99f7166d-372c-43ef-81f6-22007aa15f03 */
+DECLARE_SOF_RT_UUID("aria", aria_comp_uuid, 0x99f7166d, 0x372c, 0x43ef,
+		    0x81, 0xf6, 0x22, 0x00, 0x7a, 0xa1, 0x5f, 0x03);
+
+DECLARE_TR_CTX(aria_comp_tr, SOF_UUID(aria_comp_uuid), LOG_LEVEL_INFO);
+
+static size_t get_required_emory(size_t chan_cnt, size_t smpl_group_cnt)
+{
+	/* Current implementation is able to apply 1 ms transition */
+	/* internal circular buffer aligned to 8 bytes */
+	const size_t num_of_ms = 1;
+
+	return ALIGN_UP(num_of_ms * chan_cnt * smpl_group_cnt, 2) * sizeof(int32_t);
+}
+
+static int aria_algo_init(struct comp_dev *dev, void *buffer_desc, void *buf_in,
+			  void *buf_out, size_t att, size_t chan_cnt, size_t smpl_group_cnt)
+{
+	struct aria_data *cd = comp_get_drvdata(dev);
+	size_t idx;
+
+	cd->chan_cnt = chan_cnt;
+	cd->smpl_group_cnt = smpl_group_cnt;
+	/* ensures buffer size is aligned to 8 bytes */
+	cd->buff_size = ALIGN_UP(cd->chan_cnt * cd->smpl_group_cnt, 2);
+	cd->offset = (cd->chan_cnt * cd->smpl_group_cnt) % 2;
+	cd->att = att;
+	cd->data = buffer_desc;
+	cd->buf_in = buf_in;
+	cd->buf_out = buf_out;
+	cd->buff_pos = 0;
+
+	for (idx = 0; idx < ARIA_MAX_GAIN_STATES; ++idx)
+		cd->gains[idx] = (1ULL << (32 - cd->att - 1)) - 1;
+
+	memset((void *)cd->data, 0, sizeof(int32_t) * cd->buff_size);
+	memset((void *)cd->buf_in, 0, sizeof(int32_t) * cd->buff_size);
+	memset((void *)cd->buf_out, 0, sizeof(int32_t) * cd->buff_size);
+	cd->gain_state = 0;
+
+	return 0;
+}
+
+int aria_algo_buffer_data(struct comp_dev *dev, int32_t *__restrict data, size_t size)
+{
+	struct aria_data *cd = comp_get_drvdata(dev);
+	size_t min_buff = MIN(cd->buff_size - cd->buff_pos - cd->offset, size);
+	int ret;
+
+	ret = memcpy_s(&cd->data[cd->buff_pos], cd->buff_size * sizeof(int32_t),
+		       data, min_buff * sizeof(int32_t));
+	if (ret < 0)
+		return ret;
+	ret = memcpy_s(cd->data, cd->buff_size * sizeof(int32_t),
+		       &data[min_buff], (size - min_buff) * sizeof(int32_t));
+	if (ret < 0)
+		return ret;
+	cd->buff_pos = (cd->buff_pos + size) % cd->buff_size;
+
+	return 0;
+}
+
+int aria_process_data(struct comp_dev *dev,
+		      int32_t *__restrict dst, size_t dst_size,
+		      int32_t *__restrict src, size_t src_size)
+{
+	struct aria_data *cd = comp_get_drvdata(dev);
+	size_t min_buff;
+	int ret;
+
+	if (cd->att) {
+		aria_algo_calc_gain(dev, (cd->gain_state + 1) % ARIA_MAX_GAIN_STATES,
+				    src, src_size);
+		aria_algo_get_data(dev, dst, dst_size);
+	} else {
+		/* bypass processing gets unprocessed data from buffer */
+		min_buff = MIN(cd->buff_size - cd->buff_pos - cd->offset, dst_size);
+		ret = memcpy_s(dst, cd->buff_size * sizeof(int32_t),
+			       &cd->data[cd->buff_pos + cd->offset],
+			       min_buff * sizeof(int32_t));
+		if (ret < 0)
+			return ret;
+		ret = memcpy_s(&dst[min_buff], cd->buff_size * sizeof(int32_t),
+			       cd->data, (dst_size - min_buff) * sizeof(int32_t));
+		if (ret < 0)
+			return ret;
+	}
+	return aria_algo_buffer_data(dev, src, src_size);
+}
+
+static int init_aria(struct comp_dev *dev, struct comp_ipc_config *config,
+		     void *spec)
+{
+	struct ipc4_aria_module_cfg *aria = spec;
+	struct aria_data *cd;
+	size_t ibs, chc, sgs, sgc, req_mem, att;
+	void *buf, *buf_in, *buf_out;
+	int ret;
+
+	dev->ipc_config = *config;
+	list_init(&dev->bsource_list);
+	list_init(&dev->bsink_list);
+
+	dcache_invalidate_region(spec, sizeof(*aria));
+	cd = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM, sizeof(*cd));
+	if (!cd) {
+		comp_free(dev);
+		return -ENOMEM;
+	}
+
+	/* Copy received data format to local structures */
+	ret = memcpy_s(&cd->base, sizeof(struct ipc4_base_module_cfg),
+		       &aria->base_cfg, sizeof(struct ipc4_base_module_cfg));
+	if (ret < 0)
+		return ret;
+
+	ibs = cd->base.ibs;
+	chc = cd->base.audio_fmt.channels_count;
+	sgs = (cd->base.audio_fmt.valid_bit_depth >> 3) * chc;
+	sgc = ibs / sgs;
+	req_mem = get_required_emory(chc, sgc);
+	att = aria->attenuation;
+
+	if (aria->attenuation > ARIA_MAX_ATT) {
+		comp_warn(dev, "init_aria(): Attenuation value %d must not be greater than %d",
+			  att, ARIA_MAX_ATT);
+		att = ARIA_MAX_ATT;
+	}
+
+	comp_set_drvdata(dev, cd);
+
+	buf = rballoc(0, SOF_MEM_CAPS_RAM, req_mem);
+	buf_in = rballoc(0, SOF_MEM_CAPS_RAM, req_mem);
+	buf_out = rballoc(0, SOF_MEM_CAPS_RAM, req_mem);
+
+	if (!buf || !buf_in || !buf_out) {
+		rfree(buf);
+		rfree(buf_in);
+		rfree(buf_out);
+		rfree(cd);
+		comp_free(dev);
+		comp_err(dev, "init_aria(): allocation failed for size %d", req_mem);
+		return -ENOMEM;
+	}
+
+	return aria_algo_init(dev, buf, buf_in, buf_out, att, chc, sgc);
+}
+
+static struct comp_dev *aria_new(const struct comp_driver *drv,
+				 struct comp_ipc_config *config, void *spec)
+{
+	struct comp_dev *dev;
+	int ret;
+
+	comp_cl_info(&comp_aria, "aria_new()");
+
+	dev = comp_alloc(drv, sizeof(*dev));
+	if (!dev)
+		return NULL;
+
+	ret = init_aria(dev, config, spec);
+	if (ret < 0) {
+		comp_free(dev);
+		return NULL;
+	}
+	dev->state = COMP_STATE_READY;
+
+	return dev;
+}
+
+static void aria_free(struct comp_dev *dev)
+{
+	struct aria_data *cd = comp_get_drvdata(dev);
+
+	rfree(cd->data);
+	rfree(cd->buf_in);
+	rfree(cd->buf_out);
+	rfree(cd);
+	rfree(dev);
+}
+
+static int aria_prepare(struct comp_dev *dev)
+{
+	int ret;
+
+	comp_info(dev, "aria_prepare()");
+
+	if (dev->state == COMP_STATE_ACTIVE) {
+		comp_info(dev, "aria_prepare(): Component is in active state.");
+		return 0;
+	}
+
+	ret = comp_set_state(dev, COMP_TRIGGER_PREPARE);
+	if (ret < 0)
+		return ret;
+
+	if (ret == COMP_STATUS_STATE_ALREADY_SET)
+		return PPL_STATUS_PATH_STOP;
+
+	return 0;
+}
+
+static int aria_reset(struct comp_dev *dev)
+{
+	struct aria_data *cd = comp_get_drvdata(dev);
+	int idx;
+
+	comp_info(dev, "aria_reset()");
+
+	if (dev->state == COMP_STATE_ACTIVE) {
+		comp_info(dev, "aria module is in active state. Ignore resetting");
+		return 0;
+	}
+
+	for (idx = 0; idx < ARIA_MAX_GAIN_STATES; ++idx)
+		cd->gains[idx] = (1ULL << (32 - cd->att - 1)) - 1;
+
+	memset(cd->data, 0, sizeof(int32_t) * cd->buff_size);
+	memset(cd->buf_in, 0, sizeof(int32_t) * cd->buff_size);
+	memset(cd->buf_out, 0, sizeof(int32_t) * cd->buff_size);
+	cd->gain_state = 0;
+
+	comp_set_state(dev, COMP_TRIGGER_RESET);
+
+	return 0;
+}
+
+static int aria_trigger(struct comp_dev *dev, int cmd)
+{
+	comp_info(dev, "aria_trigger()");
+
+	return comp_set_state(dev, cmd);
+}
+
+static int aria_copy(struct comp_dev *dev)
+{
+	struct comp_copy_limits c;
+	struct comp_buffer *source;
+	struct comp_buffer *sink;
+	struct aria_data *cd;
+	uint32_t source_bytes;
+	uint32_t sink_bytes;
+	uint32_t frag = 0;
+	int32_t *destp;
+	int32_t i, channel;
+
+	cd = comp_get_drvdata(dev);
+
+	comp_dbg(dev, "aria_copy()");
+
+	source = list_first_item(&dev->bsource_list, struct comp_buffer,
+				 sink_list);
+	sink = list_first_item(&dev->bsink_list, struct comp_buffer,
+			       source_list);
+
+	comp_get_copy_limits_with_lock(source, sink, &c);
+	source_bytes = c.frames * c.source_frame_bytes;
+	sink_bytes = c.frames * c.sink_frame_bytes;
+
+	if (source_bytes == 0)
+		return 0;
+
+	buffer_stream_invalidate(source, source_bytes);
+
+	for (i = 0; i < c.frames; i++) {
+		for (channel = 0; channel < sink->stream.channels; channel++) {
+			cd->buf_in[frag] = *(int32_t *)audio_stream_read_frag_s32(&source->stream,
+										  frag);
+
+			frag++;
+		}
+	}
+	dcache_writeback_region(cd->buf_in, c.frames * sink->stream.channels * sizeof(int32_t));
+
+	aria_process_data(dev, cd->buf_out, sink_bytes / sizeof(uint32_t),
+			  cd->buf_in, source_bytes / sizeof(uint32_t));
+
+	dcache_writeback_region(cd->buf_out, c.frames * sink->stream.channels * sizeof(int32_t));
+	frag = 0;
+	for (i = 0; i < c.frames; i++) {
+		for (channel = 0; channel < sink->stream.channels; channel++) {
+			destp = audio_stream_write_frag_s32(&sink->stream, frag);
+			*destp = cd->buf_out[frag];
+
+			frag++;
+		}
+	}
+
+	buffer_stream_writeback(sink, sink_bytes);
+
+	comp_update_buffer_produce(sink, sink_bytes);
+	comp_update_buffer_consume(source, source_bytes);
+
+	return 0;
+}
+
+static const struct comp_driver comp_aria = {
+	.uid	= SOF_RT_UUID(aria_comp_uuid),
+	.tctx	= &aria_comp_tr,
+	.ops	= {
+		.create			= aria_new,
+		.free			= aria_free,
+		.trigger		= aria_trigger,
+		.copy			= aria_copy,
+		.prepare		= aria_prepare,
+		.reset			= aria_reset,
+	},
+};
+
+static SHARED_DATA struct comp_driver_info comp_aria_info = {
+	.drv = &comp_aria,
+};
+
+UT_STATIC void sys_comp_aria_init(void)
+{
+	comp_register(platform_shared_get(&comp_aria_info,
+					  sizeof(comp_aria_info)));
+}
+
+DECLARE_MODULE(sys_comp_aria_init);

--- a/src/audio/aria/aria_hifi3.c
+++ b/src/audio/aria/aria_hifi3.c
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2021 Intel Corporation. All rights reserved.
+
+#include <sof/audio/aria/aria.h>
+#include <xtensa/config/defs.h>
+#include <xtensa/tie/xt_hifi3.h>
+
+inline void aria_algo_calc_gain(struct comp_dev *dev, size_t gain_idx,
+				int32_t *__restrict data, const size_t src_size)
+{
+	struct aria_data *cd = comp_get_drvdata(dev);
+	/* detecting maximum value in data chunk */
+	size_t pairs_size = src_size;
+	size_t i;
+	ae_f32x2 d1;
+	ae_int32x2 *ptr_in = (ae_int32x2 *)data;
+	ae_f32x2 d0 = AE_ZERO32();
+
+	__aligned(8) uint32_t max_data[2];
+
+	ae_int32x2 *ptr_out = (ae_int32x2 *)&max_data[0];
+	/* below condition maintains buffer alignment to 8 bytes */
+	if (!IS_ALIGNED((uintptr_t)ptr_in, 8)) {
+		AE_L32_XC(d1, (ae_int32 *)ptr_in, 4);
+		d0 = AE_MAXABS32S(d0, d1);
+		pairs_size--;
+	}
+	for (i = 0; i < src_size >> 1; ++i) {
+		AE_L32X2_XP(d1, ptr_in, 8);
+		d0 = AE_MAXABS32S(d0, d1);
+	}
+	/* maintains odd sample if any left */
+	if (pairs_size % 2) {
+		AE_L32_XC(d1, (ae_int32 *)ptr_in, 0);
+		d0 = AE_MAXABS32S(d0, d1);
+	}
+	AE_S32X2_XP(d0, ptr_out, 0);
+	max_data[0] = MAX(max_data[0], max_data[1]);
+
+	uint64_t gain = (1ULL << (cd->att + 32)) - 1;
+	/* currently att_ value is checked on initialization and is in range <0;3>
+	 * so eventual zero check for max_data[0] is not needed (prevention from division by 0)
+	 */
+	if (max_data[0] > (0x7fffffffUL >> cd->att))
+		gain = (0x7fffffffULL << 32) / max_data[0];
+
+	/* normalization by attenuation factor to obtain fractional range <1 / (2 pow att), 1> */
+	cd->gains[gain_idx] = (int32_t)(gain >> (cd->att + 1));
+}
+
+void aria_algo_get_data(struct comp_dev *dev, int32_t *__restrict  data, size_t size)
+{
+	struct aria_data *cd = comp_get_drvdata(dev);
+	/* do linear approximation between points gain_begin and gain_end */
+	int32_t gain_begin = cd->gains[(cd->gain_state + 2) % ARIA_MAX_GAIN_STATES];
+	int32_t gain_end = cd->gains[(cd->gain_state + 3) % ARIA_MAX_GAIN_STATES];
+	size_t idx, ch;
+
+	for (idx = 1; idx < ARIA_MAX_GAIN_STATES - 1; ++idx) {
+		gain_begin = MIN(gain_begin, cd->gains[(cd->gain_state + idx + 2) %
+						ARIA_MAX_GAIN_STATES]);
+		gain_end = MIN(gain_end, cd->gains[(cd->gain_state + idx + 3) %
+						ARIA_MAX_GAIN_STATES]);
+	}
+
+	ae_f32x2 d1, d2, d3;
+	const size_t smpl_groups = size / cd->chan_cnt;
+	const int32_t step = (gain_end - gain_begin) / (int32_t)smpl_groups;
+	/* ensure index is always positive */
+	ae_int32x2 *ptr_in = (ae_int32x2 *)&cd->data[(cd->buff_pos + cd->offset) % cd->buff_size];
+	ae_int32x2 *ptr_out = (ae_int32x2 *)data;
+
+	d1 = (ae_f32x2)gain_begin;
+
+	int32_t next_gain;
+	int32_t prev_gain = gain_begin;
+
+	AE_SETCBEGIN0(cd->data);
+	AE_SETCEND0(cd->data + cd->buff_size);
+	ae_valign align_out = AE_ZALIGN64();
+	/* variable for odd sample detection, detection when exceeded */
+	size_t odd_detect = ALIGN_DOWN(size, 2);
+	/* variable accumulates samples being processed, helps to identify odd sample */
+	size_t acc = 0;
+
+	/* below condition maintains buffer alignment to 8 bytes */
+	if (!IS_ALIGNED((uintptr_t)ptr_in, 8)) {
+		AE_L32_XC(d2, (ae_int32 *)(ptr_in), 4);
+		d3 = AE_MULFP32X2RS(d1, d2);
+		d3 = AE_SLAA32S(d3, cd->att);
+		AE_S32_L_XP(d3, (ae_int32 *)(ptr_out), 4);
+		/* acc overflow expected and used as a condition later in loop */
+		acc = (size_t)(-cd->chan_cnt);
+		odd_detect = ALIGN_DOWN(size - 1, 2);
+	}
+	const size_t chan_pairs = cd->chan_cnt >> 1;
+
+	for (idx = 0; idx < smpl_groups; ++idx) {
+		/* below condition process channel pairs from current sample group
+		 * to be amplified with the same gain
+		 */
+		for (ch = 0; ch < chan_pairs; ++ch) {
+			AE_L32X2_XC(d2, ptr_in, 8);
+			/* d1 - Normalized gain of signal in range <1 / (2 pow att), 1>*/
+			d3 = AE_MULFP32X2RS(d1, d2);
+			/* denormalization */
+			d3 = AE_SLAA32S(d3, cd->att);
+			AE_SA32X2_IP(d3, align_out, ptr_out);
+		}
+		acc += cd->chan_cnt;
+		next_gain = (gain_begin + (idx + 1) * step);
+		/* below condition process odd channel from current sample group and next
+		 * sample group when channels count is odd, it process current
+		 * and next sample group corresponding to (idx) and (idx+1)
+		 */
+		if ((acc % 2) && !(acc > odd_detect)) {
+			d1 = AE_MOVDA32X2(prev_gain, next_gain);
+			AE_L32X2_XC(d2, ptr_in, 8);
+			/* d1 - Normalized gain of signal in range <1 / (2 pow att), 1>*/
+			d3 = AE_MULFP32X2RS(d1, d2);
+			/* denormalization */
+			d3 = AE_SLAA32S(d3, cd->att);
+			AE_SA32X2_IP(d3, align_out, ptr_out);
+		}
+		d1 = (ae_f32x2)next_gain;
+		prev_gain = next_gain;
+	}
+	AE_SA64POS_FP(align_out, ptr_out);
+	/* maintains odd sample if any left */
+	if (acc > odd_detect) {
+		AE_L32_XC(d2, (ae_int32 *)(ptr_in), 0);
+		d3 = AE_MULFP32X2RS(d1, d2);
+		d3 = AE_SLAA32S(d3, cd->att);
+		AE_S32_L_XP(d3, (ae_int32 *)(ptr_out), 0);
+	}
+	cd->gain_state = (cd->gain_state + 1) % ARIA_MAX_GAIN_STATES;
+}

--- a/src/include/ipc4/aria.h
+++ b/src/include/ipc4/aria.h
@@ -1,0 +1,34 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2022 Intel Corporation. All rights reserved.
+ */
+
+/*
+ * This file contains structures that are exact copies of an existing ABI used
+ * by IOT middleware. They are Intel specific and will be used by one middleware.
+ *
+ * Some of the structures may contain programming implementations that makes them
+ * unsuitable for generic use and general usage.
+ *
+ * This code is mostly copied "as-is" from existing C++ interface files hence the use of
+ * different style in places. The intention is to keep the interface as close as possible to
+ * original so it's easier to track changes with IPC host code.
+ */
+
+/*
+ * \file include/ipc4/aria.h
+ * \brief aria definitions.
+ * NOTE: This ABI uses bit fields and is non portable.
+ */
+
+#ifndef __SOF_IPC4_ARIA_H__
+#define __SOF_IPC4_ARIA_H__
+
+#include <sof/compiler_attributes.h>
+#include "base-config.h"
+
+struct ipc4_aria_module_cfg {
+	struct ipc4_base_module_cfg base_cfg;
+	uint32_t attenuation;
+} __packed __aligned(8);
+#endif

--- a/src/include/sof/audio/aria/aria.h
+++ b/src/include/sof/audio/aria/aria.h
@@ -1,0 +1,82 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2022 Intel Corporation. All rights reserved.
+ *
+ * Author: Adrian Bonislawski <adrian.bonislawski@intel.com>
+ */
+
+/**
+ * \file audio/aria/aria.h
+ * \brief Aria component header file
+ * \authors Adrian Bonislawski <adrian.bonislawski@intel.com>
+ */
+
+#ifndef __SOF_AUDIO_ARIA_H__
+#define __SOF_AUDIO_ARIA_H__
+
+#include <sof/audio/component_ext.h>
+#include <sof/audio/ipc-config.h>
+#include <sof/bit.h>
+#include <sof/common.h>
+#include <sof/trace/trace.h>
+#include <ipc/stream.h>
+#include <ipc4/module.h>
+#include <ipc4/base-config.h>
+#include <user/trace.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/** \brief Aria max gain states */
+#define ARIA_MAX_GAIN_STATES 10
+
+/** \brief Aria max att value */
+#define ARIA_MAX_ATT 3
+
+/**
+ * \brief Aria gain processing function
+ */
+void aria_algo_calc_gain(struct comp_dev *dev, size_t gain_idx,
+			 int32_t *__restrict data, const size_t src_size);
+
+/**
+ * \brief Aria data processing function
+ */
+void aria_algo_get_data(struct comp_dev *dev, int32_t *__restrict  data,
+			size_t size);
+
+int aria_algo_buffer_data(struct comp_dev *dev, int32_t *__restrict data,
+			  size_t size);
+int aria_process_data(struct comp_dev *dev, int32_t *__restrict dst,
+		      size_t dst_size, int32_t *__restrict src, size_t src_size);
+
+/**
+ * \brief Aria component private data.
+ */
+struct aria_data {
+	struct ipc4_base_module_cfg base;
+
+	/* channels count */
+	size_t chan_cnt;
+	/* sample groups to process count */
+	size_t smpl_group_cnt;
+	/* Size of chunk (1ms) in samples */
+	size_t buff_size;
+	/* Current gain state */
+	size_t gain_state;
+	/* current data position in circular buffer */
+	size_t buff_pos;
+	/* Attenuation parameter */
+	size_t att;
+	/* Gain states */
+	int32_t gains[ARIA_MAX_GAIN_STATES];
+	/* cyclic buffer for data */
+	int32_t *data;
+	/* buffer for data in */
+	int32_t *buf_in;
+	/* buffer for data out */
+	int32_t *buf_out;
+	/* internal buffer offset helps to keep algorithmic delay constant */
+	size_t offset;
+};
+
+#endif /* __SOF_AUDIO_ARIA_H__ */


### PR DESCRIPTION
Automatic Regressive Input Amplifier Module
At initial release only hifi3 version is supported