### PR TITLE
topology: define PIPELINE_FORMAT from DAI_ADD

### DIFF
--- a/tools/topology/topology1/m4/dai.m4
+++ b/tools/topology/topology1/m4/dai.m4
@@ -271,6 +271,7 @@ define(`DAI_ADD',
 `define(`DAI_CHANNELS', $13)'
 `define(`DAI_RATE', $14)'
 `define(`DYNAMIC_PIPE', $15)'
+`define(`PIPELINE_FORMAT', $8)'
 `include($1)'
 `DEBUG_DAI($3, $4)'
 `undefine(`PIPELINE_ID')'
@@ -287,6 +288,7 @@ define(`DAI_ADD',
 `undefine(`DAI_CHANNELS')'
 `undefine(`DAI_RATE')'
 `undefine(`DYNAMIC_PIPE')'
+`undefine(`PIPELINE_FORMAT')'
 )
 
 # DAI_ADD_SCHED can be used for adding a DAI with sched_comp

--- a/tools/topology/topology1/platform/intel/intel-generic-dmic-kwd.m4
+++ b/tools/topology/topology1/platform/intel/intel-generic-dmic-kwd.m4
@@ -127,17 +127,17 @@ dnl PCM_CAPTURE_ADD(name, pipeline, capture)
 PCM_CAPTURE_ADD(DMIC_48k_PCM_NAME, DMIC_PCM_48k_ID, concat(`PIPELINE_PCM_', DMIC_PIPELINE_48k_ID))
 
 # keyword detector pipe
-dnl PIPELINE_ADD(pipeline,
-dnl     pipe id, max channels, format,
+dnl PIPELINE_PCM_ADD(pipeline,
+dnl     pipe id, pcm, max channels, format,
 dnl     period, priority, core,
-dnl     sched_comp, time_domain,
-dnl     pcm_min_rate, pcm_max_rate, pipeline_rate)
-PIPELINE_ADD(sof/pipe-DETECTOR_TYPE.m4,
-        DMIC_PIPELINE_KWD_ID, 2, s24le,
+dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
+dnl     time_domain, sched_comp, dynamic)
+PIPELINE_PCM_ADD(sof/pipe-DETECTOR_TYPE.m4,
+        DMIC_PIPELINE_KWD_ID, DMIC_PCM_16k_ID, 2, s24le,
         KWD_PIPE_SCH_DEADLINE_US, 1, 0,
-        `PIPELINE_SCHED_COMP_'DMIC_PIPELINE_16k_ID,
-        SCHEDULE_TIME_DOMAIN_TIMER,
-        16000, 16000, 16000)
+        16000, 16000, 16000,
+		SCHEDULE_TIME_DOMAIN_TIMER,
+		`PIPELINE_SCHED_COMP_'DMIC_PIPELINE_16k_ID)
 
 # Connect pipelines together
 SectionGraph."pipe-sof-generic-keyword-detect" {

--- a/tools/topology/topology1/sof-apl-keyword-detect.m4
+++ b/tools/topology/topology1/sof-apl-keyword-detect.m4
@@ -66,12 +66,12 @@ dnl     pipe id, max channels, format,
 dnl     period, priority, core,
 dnl     sched_comp, time_domain,
 dnl     pcm_min_rate, pcm_max_rate, pipeline_rate)
-PIPELINE_ADD(sof/pipe-detect.m4,
-	2, 2, s16le,
+PIPELINE_PCM_ADD(sof/pipe-detect.m4,
+	2, 0, 2, s16le,
 	KWD_PIPE_SCH_DEADLINE_US, 1, 0,
+	16000, 16000, 16000,
 	PIPELINE_SCHED_COMP_1,
-	SCHEDULE_TIME_DOMAIN_TIMER,
-	16000, 16000, 16000)
+	SCHEDULE_TIME_DOMAIN_TIMER)
 
 # Connect pipelines together
 SectionGraph."pipe-sof-apl-keyword-detect" {

--- a/tools/topology/topology1/sof-cml-rt5682-kwd.m4
+++ b/tools/topology/topology1/sof-cml-rt5682-kwd.m4
@@ -177,17 +177,17 @@ PCM_PLAYBACK_ADD(HDMI2, 3, PIPELINE_PCM_5)
 PCM_PLAYBACK_ADD(HDMI3, 4, PIPELINE_PCM_6)
 
 # keyword detector pipe
-dnl PIPELINE_ADD(pipeline,
-dnl     pipe id, max channels, format,
+dnl PIPELINE_PCM_ADD(pipeline,
+dnl     pipe id, pcm, max channels, format,
 dnl     period, priority, core,
-dnl     sched_comp, time_domain,
-dnl     pcm_min_rate, pcm_max_rate, pipeline_rate)
-PIPELINE_ADD(sof/pipe-detect.m4,
-	9, 2, s24le,
+dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
+dnl     time_domain, sched_comp, dynamic)
+PIPELINE_PCM_ADD(sof/pipe-detect.m4,
+	9, 1, 2, s24le,
 	KWD_PIPE_SCH_DEADLINE_US, 1, 0,
-	PIPELINE_SCHED_COMP_8,
+	16000, 16000, 16000,
 	SCHEDULE_TIME_DOMAIN_TIMER,
-	16000, 16000, 16000)
+	PIPELINE_SCHED_COMP_8)
 
 # Connect pipelines together
 SectionGraph."pipe-sof-cml-keyword-detect" {

--- a/tools/topology/topology1/sof-glk-da7219-kwd.m4
+++ b/tools/topology/topology1/sof-glk-da7219-kwd.m4
@@ -203,16 +203,16 @@ ifelse(CODEC, `MAX98390',`
 PCM_CAPTURE_ADD(EchoRef, 4, PIPELINE_PCM_10)')
 
 # keyword detector pipe
-dnl PIPELINE_ADD(pipeline,
-dnl     pipe id, max channels, format,
+dnl PIPELINE_PCM_ADD(pipeline,
+dnl     pipe id, pcm, max channels, format,
 dnl     period, priority, core,
-dnl     sched_comp, time_domain,
-dnl     pcm_min_rate, pcm_max_rate, pipeline_rate)
-PIPELINE_ADD(sof/pipe-detect.m4,
-	     9, 2, DMIC1_FMT,
+dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
+dnl     time_domain, sched_comp, dynamic)
+PIPELINE_PCM_ADD(sof/pipe-detect.m4,
+	     9, 0, DMIC_PCM_NUM, DMIC1_FMT,
 	     KWD_PIPE_SCH_DEADLINE_US, 1, 0,
-	     PIPELINE_SCHED_COMP_8, SCHEDULE_TIME_DOMAIN_TIMER,
-	     16000, 16000, 16000)
+	     16000, 16000, 16000,
+		 SCHEDULE_TIME_DOMAIN_TIMER, PIPELINE_SCHED_COMP_8)
 
 # Connect pipelines together
 SectionGraph."pipe-sof-PLATFORM-keyword-detect" {

--- a/tools/topology/topology1/sof-imx8-wm8960-kwd.m4
+++ b/tools/topology/topology1/sof-imx8-wm8960-kwd.m4
@@ -59,17 +59,17 @@ DAI_ADD(sof/pipe-dai-capture.m4,
 	0, 0, SCHEDULE_TIME_DOMAIN_DMA)
 
 # keyword detector pipe
-dnl PIPELINE_ADD(pipeline,
-dnl     pipe id, max channels, format,
+dnl PIPELINE_PCM_ADD(pipeline,
+dnl     pipe id, pcm, max channels, format,
 dnl     period, priority, core,
-dnl     sched_comp, time_domain,
-dnl     pcm_min_rate, pcm_max_rate, pipeline_rate)
-PIPELINE_ADD(sof/pipe-detect.m4,
-	2, 2, s32le,
+dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
+dnl     time_domain, sched_comp, dynamic)
+PIPELINE_PCM_ADD(sof/pipe-detect.m4,
+	2, 0, 2, s32le,
 	KWD_PIPE_SCH_DEADLINE_US, 1, 0,
-	PIPELINE_SCHED_COMP_1,
+	16000, 16000, 16000,
 	SCHEDULE_TIME_DOMAIN_TIMER,
-	16000, 16000, 16000)
+	PIPELINE_SCHED_COMP_1)
 
 # Connect pipelines together
 SectionGraph."pipe-sof-imx8-keyword-detect" {

--- a/tools/topology/topology1/sof-imx8mp-wm8960-kwd.m4
+++ b/tools/topology/topology1/sof-imx8mp-wm8960-kwd.m4
@@ -59,17 +59,17 @@ DAI_ADD(sof/pipe-dai-capture.m4,
         0, 0, SCHEDULE_TIME_DOMAIN_DMA)
 
 # keyword detector pipe
-dnl PIPELINE_ADD(pipeline,
-dnl     pipe id, max channels, format,
+dnl PIPELINE_PCM_ADD(pipeline,
+dnl     pipe id, pcm, max channels, format,
 dnl     period, priority, core,
-dnl     sched_comp, time_domain,
-dnl     pcm_min_rate, pcm_max_rate, pipeline_rate)
-PIPELINE_ADD(sof/pipe-detect.m4,
-	2, 2, s16le,
+dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
+dnl     time_domain, sched_comp, dynamic)
+PIPELINE_PCM_ADD(sof/pipe-detect.m4,
+	2, 0, 2, s16le,
 	KWD_PIPE_SCH_DEADLINE_US, 1, 0,
-	PIPELINE_SCHED_COMP_1,
+	16000, 16000, 16000,
 	SCHEDULE_TIME_DOMAIN_TIMER,
-	16000, 16000, 16000)
+	PIPELINE_SCHED_COMP_1)
 
 # Connect pipelines together
 SectionGraph."pipe-sof-apl-keyword-detect" {


### PR DESCRIPTION
Pipeline extects PIPELINE_FORMAT to be defined. When including a
pipeline using DAI_ADD, DAI_FORMAT is defined but no PIPELINE_FORMAT.
Prior c687815, the last previously defined PIPELINE_FORMAT was used.
This change ensure the requested DAI_FORMAT is used in the pipeline.

This resolve #5193.

Signed-off-by: Lionel Koenig <lionelk@google.com>