### PR TITLE
ipc4: add S24_3LE for ipc4

### DIFF
--- a/src/audio/Kconfig
+++ b/src/audio/Kconfig
@@ -467,6 +467,12 @@ config PCM_CONVERTER_FORMAT_S24LE
 	help
 	  Support 24 bit processing data format with sign and in little endian format
 
+config PCM_CONVERTER_FORMAT_S24_3LE
+	bool "Support S24_3LE"
+	default n
+	help
+	  Support packed 24 bit processing data format with sign and in little endian format
+
 config PCM_CONVERTER_FORMAT_S32LE
 	bool "Support S32LE"
 	default y
@@ -499,6 +505,20 @@ config PCM_CONVERTER_FORMAT_S16_C32_AND_S24_C32
 	help
 	  Support conversion between 16 bit valid sample size in 32 bit container
 	  and 24 bit valid sample size in 32 bit container
+
+config PCM_CONVERTER_FORMAT_S24_C24_AND_S24_C32
+	bool "Support S24C24 <-> S24C32"
+	default n
+	help
+	  Support conversion between 24 bit valid sample size in 24 bit container
+	  and 24 bit valid sample size in 32 bit container
+
+config PCM_CONVERTER_FORMAT_S24_C32_AND_S24_C24
+	bool "Support S24C32 <-> S24C24"
+	default n
+	help
+	  Support conversion between 24 bit valid sample size in 32 bit container
+	  and 24 bit valid sample size in 24 bit container
 
 config PCM_CONVERTER_FORMAT_CONVERT_HIFI3
 	bool "HIFI3 optimized conversion"

--- a/src/audio/copier.c
+++ b/src/audio/copier.c
@@ -584,18 +584,15 @@ static int do_conversion_copy(struct comp_dev *dev,
 			      uint32_t *src_copy_bytes)
 {
 	struct comp_copy_limits c;
-	uint32_t sink_bytes;
-	uint32_t src_bytes;
 	int i;
 	int ret;
 
 	comp_get_copy_limits_with_lock(src, sink, &c);
-	src_bytes = c.frames * c.source_frame_bytes;
-	*src_copy_bytes = src_bytes;
-	sink_bytes = c.frames * c.sink_frame_bytes;
+	*src_copy_bytes = c.source_bytes;
 
 	i = IPC4_SINK_QUEUE_ID(sink->id);
-	buffer_stream_invalidate(src, src_bytes);
+	buffer_stream_invalidate(src, c.source_bytes);
+
 	cd->converter[i](&src->stream, 0, &sink->stream, 0, c.frames * sink->stream.channels);
 	if (cd->attenuation) {
 		ret = apply_attenuation(dev, cd, sink, c.frames);
@@ -603,8 +600,8 @@ static int do_conversion_copy(struct comp_dev *dev,
 			return ret;
 	}
 
-	buffer_stream_writeback(sink, sink_bytes);
-	comp_update_buffer_produce(sink, sink_bytes);
+	buffer_stream_writeback(sink, c.sink_bytes);
+	comp_update_buffer_produce(sink, c.sink_bytes);
 
 	return 0;
 }

--- a/src/audio/pcm_converter/pcm_converter_generic.c
+++ b/src/audio/pcm_converter/pcm_converter_generic.c
@@ -494,8 +494,6 @@ const struct pcm_func_map pcm_func_map[] = {
 
 const size_t pcm_func_count = ARRAY_SIZE(pcm_func_map);
 
-#endif
-
 #if CONFIG_PCM_CONVERTER_FORMAT_S16_C16_AND_S16_C32
 static int pcm_convert_s16_c16_to_s16_c32(const struct audio_stream *source,
 					  uint32_t ioffset, struct audio_stream *sink,
@@ -695,3 +693,5 @@ const struct pcm_func_vc_map pcm_func_vc_map[] = {
 };
 
 const size_t pcm_func_vc_count = ARRAY_SIZE(pcm_func_vc_map);
+
+#endif

--- a/src/audio/pcm_converter/pcm_converter_generic.c
+++ b/src/audio/pcm_converter/pcm_converter_generic.c
@@ -690,6 +690,23 @@ const struct pcm_func_vc_map pcm_func_vc_map[] = {
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE,
 		ipc4_gtw_all, pcm_convert_s24_c32_to_s16_c32 },
 #endif
+#if CONFIG_PCM_CONVERTER_FORMAT_S32LE && CONFIG_PCM_CONVERTER_FORMAT_S24LE
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE,
+		ipc4_gtw_all & ~(ipc4_gtw_link | ipc4_gtw_alh | ipc4_gtw_host), audio_stream_copy },
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE,
+		ipc4_gtw_link | ipc4_gtw_alh, pcm_convert_s24_to_s32 },
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE,
+		ipc4_gtw_host, pcm_convert_s32_to_s24 },
+#endif
+#if CONFIG_PCM_CONVERTER_FORMAT_S24LE && CONFIG_PCM_CONVERTER_FORMAT_S16LE
+	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S32_LE,
+		SOF_IPC_FRAME_S24_4LE, ipc4_gtw_all & ~(ipc4_gtw_link | ipc4_gtw_alh),
+		pcm_convert_s16_to_s24 },
+	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S32_LE,
+		SOF_IPC_FRAME_S24_4LE, ipc4_gtw_link | ipc4_gtw_alh, pcm_convert_s16_to_s32 },
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S16_LE,
+		SOF_IPC_FRAME_S16_LE, ipc4_gtw_all, pcm_convert_s24_to_s16 },
+#endif
 };
 
 const size_t pcm_func_vc_count = ARRAY_SIZE(pcm_func_vc_map);

--- a/src/audio/pcm_converter/pcm_converter_generic.c
+++ b/src/audio/pcm_converter/pcm_converter_generic.c
@@ -674,21 +674,21 @@ static int pcm_convert_s24_c32_to_s16_c32(const struct audio_stream *source,
 const struct pcm_func_vc_map pcm_func_vc_map[] = {
 #if CONFIG_PCM_CONVERTER_FORMAT_S16_C16_AND_S16_C32
 	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE,
-		pcm_convert_s16_c16_to_s16_c32 },
+		ipc4_gtw_all, pcm_convert_s16_c16_to_s16_c32 },
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S16_LE,
-		pcm_convert_s16_c32_to_s16_c16 },
+		ipc4_gtw_all, pcm_convert_s16_c32_to_s16_c16 },
 #endif
 #if CONFIG_PCM_CONVERTER_FORMAT_S16_C32_AND_S32_C32
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE,
-		pcm_convert_s16_c32_to_s32_c32 },
+		ipc4_gtw_all, pcm_convert_s16_c32_to_s32_c32 },
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE,
-		pcm_convert_s32_c32_to_s16_c32 },
+		ipc4_gtw_all, pcm_convert_s32_c32_to_s16_c32 },
 #endif
 #if CONFIG_PCM_CONVERTER_FORMAT_S16_C32_AND_S24_C32
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE,
-		pcm_convert_s16_c32_to_s24_c32 },
+		ipc4_gtw_all, pcm_convert_s16_c32_to_s24_c32 },
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE,
-		pcm_convert_s24_c32_to_s16_c32 },
+		ipc4_gtw_all, pcm_convert_s24_c32_to_s16_c32 },
 #endif
 };
 

--- a/src/drivers/intel/hda/hda-dma.c
+++ b/src/drivers/intel/hda/hda-dma.c
@@ -842,11 +842,14 @@ static int hda_dma_set_config(struct dma_chan_data *channel,
 	/* firmware control buffer */
 	dgcs = DGCS_FWCB;
 
-	/* set DGCS.SCS bit to 1 for 16bit(2B) container */
+	/* set DGCS.SCS bit to 1 for 16bit(2B) container
+	 * S24_3LE stream is treated as 16bit or 8bit
+	 * stream in host side
+	 */
 	if ((config->direction & (DMA_DIR_HMEM_TO_LMEM | DMA_DIR_DEV_TO_MEM) &&
-	     config->dest_width <= 2) ||
+	     config->dest_width <= 3) ||
 	    (config->direction & (DMA_DIR_LMEM_TO_HMEM | DMA_DIR_MEM_TO_DEV) &&
-	     config->src_width <= 2))
+	     config->src_width <= 3))
 		dgcs |= DGCS_SCS;
 
 	/* set DGCS.FIFORDY for input/output host DMA only. It is not relevant for link DMA's */

--- a/src/include/ipc4/gateway.h
+++ b/src/include/ipc4/gateway.h
@@ -25,6 +25,7 @@
 #define __SOF_IPC4_GATEWAY_H__
 
 #include <stdint.h>
+#include <sof/bit.h>
 
 /**< Type of the gateway. */
 enum ipc4_connector_node_id_type {
@@ -185,5 +186,15 @@ struct ipc4_gateway_config_blob {
 	 */
 	uint32_t threshold_low;
 } __attribute__((packed, aligned(4)));
+
+enum ipc4_gateway_type {
+	ipc4_gtw_none	= BIT(0),
+	ipc4_gtw_host	= BIT(1),
+	ipc4_gtw_dmic	= BIT(2),
+	ipc4_gtw_link	= BIT(3),
+	ipc4_gtw_alh	= BIT(4),
+	ipc4_gtw_ssp	= BIT(5),
+	ipc4_gtw_all	= BIT(6) - 1
+};
 
 #endif

--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -624,13 +624,9 @@ static inline void audio_stream_fmt_conversion(enum ipc4_bit_depth depth,
 	*valid_fmt = (valid >> 3) - 2;
 
 	/* really 24_3LE */
-	if (valid == 24) {
-		if (depth == 24) {
-			*frame_fmt = SOF_IPC_FRAME_S24_3LE;
-			*valid_fmt = SOF_IPC_FRAME_S24_3LE;
-		} else {
-			*frame_fmt = SOF_IPC_FRAME_S24_4LE;
-		}
+	if (valid == 24 && depth == 24) {
+		*frame_fmt = SOF_IPC_FRAME_S24_3LE;
+		*valid_fmt = SOF_IPC_FRAME_S24_3LE;
 	}
 
 	if (type == IPC4_TYPE_FLOAT && depth == 32) {

--- a/src/include/sof/audio/format.h
+++ b/src/include/sof/audio/format.h
@@ -155,7 +155,14 @@ static inline int32_t sign_extend_s24(int32_t x)
 
 static inline uint32_t get_sample_bytes(enum sof_ipc_frame fmt)
 {
-	return fmt == SOF_IPC_FRAME_S16_LE ? 2 : 4;
+	switch (fmt) {
+	case SOF_IPC_FRAME_S16_LE:
+		return 2;
+	case SOF_IPC_FRAME_S24_3LE:
+		return 3;
+	default:
+		return 4;
+	}
 }
 
 static inline uint32_t get_frame_bytes(enum sof_ipc_frame fmt,

--- a/src/include/sof/audio/pcm_converter.h
+++ b/src/include/sof/audio/pcm_converter.h
@@ -15,6 +15,7 @@
 #define __SOF_AUDIO_PCM_CONVERTER_H__
 
 #include <ipc/stream.h>
+#include <ipc4/gateway.h>
 
 #include <stddef.h>
 #include <stdint.h>
@@ -97,6 +98,7 @@ struct pcm_func_vc_map {
 	enum sof_ipc_frame valid_src_bits;	/**< source frame format */
 	enum sof_ipc_frame sink;	/**< sink frame container format */
 	enum sof_ipc_frame valid_sink_bits;	/**< sink frame format */
+	uint32_t type;	/**< gateway type */
 	pcm_converter_func func; /**< PCM conversion function */
 };
 
@@ -112,12 +114,14 @@ extern const size_t pcm_func_vc_count;
  * \param valid_in_bits is source valid sample format.
  * \param out_bits is sink container format.
  * \param valid_out_bits is sink valid sample format.
+ * \param type is gateway type
  */
 static inline pcm_converter_func
 pcm_get_conversion_vc_function(enum sof_ipc_frame in_bits,
 			       enum sof_ipc_frame valid_in_bits,
 			       enum sof_ipc_frame out_bits,
-			       enum sof_ipc_frame valid_out_bits)
+			       enum sof_ipc_frame valid_out_bits,
+			       enum ipc4_gateway_type type)
 {
 	uint32_t i;
 
@@ -129,6 +133,9 @@ pcm_get_conversion_vc_function(enum sof_ipc_frame in_bits,
 		if (out_bits != pcm_func_vc_map[i].sink)
 			continue;
 		if (valid_out_bits != pcm_func_vc_map[i].valid_sink_bits)
+			continue;
+
+		if (!(type & pcm_func_vc_map[i].type))
 			continue;
 
 		return pcm_func_vc_map[i].func;


### PR DESCRIPTION
S24_3LE is not a native supported format for hda dma. Driver
    treats it as 16bit stream or 8bit stream, .e.g. 24bit 3LE
    2ch stream will be set as 16bit 3ch stream. In FW side,
    24bit stream will be converted to S24LE.
    
    Currently HIFI3 optimization is not supported now and also
    S24_LE unit test is not implemented. These will be supported
    later.
    
    Tested on windows platform.
