### PR TITLE
Introducing the new 3rd Party Module API - Part 1

### DIFF
--- a/src/audio/codec_adapter/codec/cadence.c
+++ b/src/audio/codec_adapter/codec/cadence.c
@@ -564,7 +564,7 @@ static int cadence_codec_reset(struct processing_module *mod)
 	 * So, free all memory associated with runtime params. These will be reallocated during
 	 * prepare.
 	 */
-	module_free_all_memory(dev);
+	module_free_all_memory(mod);
 
 	/* reset to default params */
 	API_CALL(cd, XA_API_CMD_INIT, XA_CMD_TYPE_INIT_API_PRE_CONFIG_PARAMS, NULL, ret);
@@ -582,13 +582,13 @@ static int cadence_codec_reset(struct processing_module *mod)
 	return ret;
 }
 
-static int cadence_codec_free(struct comp_dev *dev)
+static int cadence_codec_free(struct processing_module *mod)
 {
-	struct module_data *codec = comp_get_module_data(dev);
+	struct module_data *codec = comp_get_module_data(mod->dev);
 	struct cadence_codec_data *cd = codec->private;
 
 	rfree(cd->setup_cfg.data);
-	module_free_all_memory(dev);
+	module_free_all_memory(mod);
 	rfree(cd->self);
 	rfree(cd);
 	return 0;

--- a/src/audio/codec_adapter/codec/cadence.c
+++ b/src/audio/codec_adapter/codec/cadence.c
@@ -94,9 +94,10 @@ static struct cadence_api cadence_api_table[] = {
 #endif
 };
 
-static int cadence_codec_init(struct comp_dev *dev)
+static int cadence_codec_init(struct processing_module *mod)
 {
 	int ret;
+	struct comp_dev *dev = mod->dev;
 	struct module_data *codec = comp_get_module_data(dev);
 	struct cadence_codec_data *cd = NULL;
 	uint32_t obj_size;

--- a/src/audio/codec_adapter/codec/cadence.c
+++ b/src/audio/codec_adapter/codec/cadence.c
@@ -425,9 +425,10 @@ static int cadence_codec_init_process(struct comp_dev *dev)
 	return 0;
 }
 
-static int cadence_codec_prepare(struct comp_dev *dev)
+static int cadence_codec_prepare(struct processing_module *mod)
 {
 	int ret = 0, mem_tabs_size;
+	struct comp_dev *dev = mod->dev;
 	struct module_data *codec = comp_get_module_data(dev);
 	struct cadence_codec_data *cd = codec->private;
 

--- a/src/audio/codec_adapter/codec/cadence.c
+++ b/src/audio/codec_adapter/codec/cadence.c
@@ -356,13 +356,13 @@ static int init_memory_tables(struct processing_module *mod)
 	return 0;
 err:
 	if (scratch)
-		module_free_memory(dev, scratch);
+		module_free_memory(mod, scratch);
 	if (persistent)
-		module_free_memory(dev, persistent);
+		module_free_memory(mod, persistent);
 	if (codec->mpd.in_buff)
-		module_free_memory(dev, codec->mpd.in_buff);
+		module_free_memory(mod, codec->mpd.in_buff);
 	if (codec->mpd.out_buff)
-		module_free_memory(dev, codec->mpd.out_buff);
+		module_free_memory(mod, codec->mpd.out_buff);
 	return ret;
 }
 
@@ -494,7 +494,7 @@ static int cadence_codec_prepare(struct processing_module *mod)
 	comp_dbg(dev, "cadence_codec_prepare() done");
 	return 0;
 free:
-	module_free_memory(dev, cd->mem_tabs);
+	module_free_memory(mod, cd->mem_tabs);
 	return ret;
 }
 

--- a/src/audio/codec_adapter/codec/cadence.c
+++ b/src/audio/codec_adapter/codec/cadence.c
@@ -258,10 +258,11 @@ static int cadence_codec_apply_config(struct comp_dev *dev)
 	return 0;
 }
 
-static int init_memory_tables(struct comp_dev *dev)
+static int init_memory_tables(struct processing_module *mod)
 {
 	int ret, no_mem_tables, i, mem_type, mem_size, mem_alignment;
 	void *ptr, *scratch, *persistent;
+	struct comp_dev *dev = mod->dev;
 	struct module_data *codec = comp_get_module_data(dev);
 	struct cadence_codec_data *cd = codec->private;
 
@@ -464,7 +465,7 @@ static int cadence_codec_prepare(struct processing_module *mod)
 		goto free;
 	}
 
-	ret = init_memory_tables(dev);
+	ret = init_memory_tables(mod);
 	if (ret != LIB_NO_ERROR) {
 		comp_err(dev, "cadence_codec_prepare() error %x: failed to init memory tables",
 			 ret);

--- a/src/audio/codec_adapter/codec/cadence.c
+++ b/src/audio/codec_adapter/codec/cadence.c
@@ -552,8 +552,9 @@ static int cadence_codec_process(struct comp_dev *dev)
 	return 0;
 }
 
-static int cadence_codec_reset(struct comp_dev *dev)
+static int cadence_codec_reset(struct processing_module *mod)
 {
+	struct comp_dev *dev = mod->dev;
 	struct module_data *codec = comp_get_module_data(dev);
 	struct cadence_codec_data *cd = codec->private;
 	int ret;
@@ -572,7 +573,7 @@ static int cadence_codec_reset(struct comp_dev *dev)
 
 	codec->mpd.init_done = 0;
 
-	ret = cadence_codec_prepare(dev);
+	ret = cadence_codec_prepare(mod);
 	if (ret) {
 		comp_err(dev, "cadence_codec_reset() error %x: could not re-prepare codec after reset",
 			ret);

--- a/src/audio/codec_adapter/codec/cadence.c
+++ b/src/audio/codec_adapter/codec/cadence.c
@@ -632,7 +632,6 @@ static struct module_interface cadence_interface = {
 	.init  = cadence_codec_init,
 	.prepare = cadence_codec_prepare,
 	.process = cadence_codec_process,
-	.apply_config = cadence_codec_apply_config,
 	.set_configuration = cadence_codec_set_configuration,
 	.reset = cadence_codec_reset,
 	.free = cadence_codec_free

--- a/src/audio/codec_adapter/codec/cadence.c
+++ b/src/audio/codec_adapter/codec/cadence.c
@@ -595,11 +595,45 @@ static int cadence_codec_free(struct processing_module *mod)
 	return 0;
 }
 
+static int
+cadence_codec_set_configuration(struct processing_module *mod, uint32_t config_id,
+				enum module_cfg_fragment_position pos, uint32_t data_offset_size,
+				const uint8_t *fragment, size_t fragment_size, uint8_t *response,
+				size_t response_size)
+{
+	struct module_data *md = &mod->priv;
+	struct comp_dev *dev = mod->dev;
+	int ret;
+
+	ret = module_set_configuration(mod, config_id, pos, data_offset_size, fragment,
+				       fragment_size, response, response_size);
+	if (ret < 0)
+		return ret;
+
+	/* return if more fragments are expected or if the module is not prepared */
+	if ((pos != MODULE_CFG_FRAGMENT_LAST && pos != MODULE_CFG_FRAGMENT_SINGLE) ||
+	    md->state < MODULE_INITIALIZED)
+		return 0;
+
+	/* whole configuration received, apply it now */
+	ret = cadence_codec_apply_config(dev);
+	if (ret) {
+		comp_err(dev, "cadence_codec_set_configuration(): error %x: runtime config apply failed",
+			 ret);
+		return ret;
+	}
+
+	comp_dbg(dev, "cadence_codec_set_configuration(): config applied");
+
+	return 0;
+}
+
 static struct module_interface cadence_interface = {
 	.init  = cadence_codec_init,
 	.prepare = cadence_codec_prepare,
 	.process = cadence_codec_process,
 	.apply_config = cadence_codec_apply_config,
+	.set_configuration = cadence_codec_set_configuration,
 	.reset = cadence_codec_reset,
 	.free = cadence_codec_free
 };

--- a/src/audio/codec_adapter/codec/cadence.c
+++ b/src/audio/codec_adapter/codec/cadence.c
@@ -312,7 +312,7 @@ static int init_memory_tables(struct processing_module *mod)
 			goto err;
 		}
 		/* Allocate memory for this type, taking alignment into account */
-		ptr = module_allocate_memory(dev, mem_size, mem_alignment);
+		ptr = module_allocate_memory(mod, mem_size, mem_alignment);
 		if (!ptr) {
 			comp_err(dev, "init_memory_tables() error %x: failed to allocate memory for %d",
 				 ret, mem_type);
@@ -450,7 +450,7 @@ static int cadence_codec_prepare(struct processing_module *mod)
 		return ret;
 	}
 
-	cd->mem_tabs = module_allocate_memory(dev, mem_tabs_size, 4);
+	cd->mem_tabs = module_allocate_memory(mod, mem_tabs_size, 4);
 	if (!cd->mem_tabs) {
 		comp_err(dev, "cadence_codec_prepare() error: failed to allocate space for memtabs");
 		return -ENOMEM;

--- a/src/audio/codec_adapter/codec/dts.c
+++ b/src/audio/codec_adapter/codec/dts.c
@@ -24,7 +24,7 @@ static void *dts_effect_allocate_codec_memory(void *mod_void, unsigned int lengt
 
 	comp_dbg(dev, "dts_effect_allocate_codec_memory() start");
 
-	pMem = module_allocate_memory(dev, (uint32_t)length, (uint32_t)alignment);
+	pMem = module_allocate_memory(mod, (uint32_t)length, (uint32_t)alignment);
 
 	if (pMem == NULL)
 		comp_err(dev,

--- a/src/audio/codec_adapter/codec/dts.c
+++ b/src/audio/codec_adapter/codec/dts.c
@@ -338,9 +338,10 @@ static int dts_codec_reset(struct processing_module *mod)
 	return ret;
 }
 
-static int dts_codec_free(struct comp_dev *dev)
+static int dts_codec_free(struct processing_module *mod)
 {
 	int ret;
+	struct comp_dev *dev = mod->dev;
 	struct module_data *codec = comp_get_module_data(dev);
 	DtsSofInterfaceResult dts_result;
 

--- a/src/audio/codec_adapter/codec/dts.c
+++ b/src/audio/codec_adapter/codec/dts.c
@@ -112,9 +112,10 @@ static int dts_effect_populate_buffer_configuration(struct comp_dev *dev,
 	return 0;
 }
 
-static int dts_codec_init(struct comp_dev *dev)
+static int dts_codec_init(struct processing_module *mod)
 {
 	int ret;
+	struct comp_dev *dev = mod->dev;
 	struct module_data *codec = comp_get_module_data(dev);
 	DtsSofInterfaceResult dts_result;
 	DtsSofInterfaceVersionInfo interface_version;

--- a/src/audio/codec_adapter/codec/dts.c
+++ b/src/audio/codec_adapter/codec/dts.c
@@ -15,10 +15,11 @@ DECLARE_TR_CTX(dts_tr, SOF_UUID(dts_uuid), LOG_LEVEL_INFO);
 
 #define MAX_EXPECTED_DTS_CONFIG_DATA_SIZE 8192
 
-static void *dts_effect_allocate_codec_memory(void *dev_void, unsigned int length,
-	unsigned int alignment)
+static void *dts_effect_allocate_codec_memory(void *mod_void, unsigned int length,
+					      unsigned int alignment)
 {
-	struct comp_dev *dev = dev_void;
+	struct processing_module *mod = mod_void;
+	struct comp_dev *dev = mod->dev;
 	void *pMem;
 
 	comp_dbg(dev, "dts_effect_allocate_codec_memory() start");
@@ -124,7 +125,7 @@ static int dts_codec_init(struct processing_module *mod)
 	comp_dbg(dev, "dts_codec_init() start");
 
 	dts_result = dtsSofInterfaceInit((DtsSofInterfaceInst **)&(codec->private),
-		dts_effect_allocate_codec_memory, dev);
+		dts_effect_allocate_codec_memory, mod);
 	ret = dts_effect_convert_sof_interface_result(dev, dts_result);
 
 	if (ret)

--- a/src/audio/codec_adapter/codec/dts.c
+++ b/src/audio/codec_adapter/codec/dts.c
@@ -157,9 +157,10 @@ static int dts_codec_init(struct processing_module *mod)
 	return ret;
 }
 
-static int dts_codec_prepare(struct comp_dev *dev)
+static int dts_codec_prepare(struct processing_module *mod)
 {
 	int ret;
+	struct comp_dev *dev = mod->dev;
 	struct module_data *codec = comp_get_module_data(dev);
 	DtsSofInterfaceBufferConfiguration buffer_configuration;
 	DtsSofInterfaceResult dts_result;

--- a/src/audio/codec_adapter/codec/dts.c
+++ b/src/audio/codec_adapter/codec/dts.c
@@ -318,9 +318,10 @@ static int dts_codec_apply_config(struct comp_dev *dev)
 	return ret;
 }
 
-static int dts_codec_reset(struct comp_dev *dev)
+static int dts_codec_reset(struct processing_module *mod)
 {
 	int ret;
+	struct comp_dev *dev = mod->dev;
 	struct module_data *codec = comp_get_module_data(dev);
 	DtsSofInterfaceResult dts_result;
 

--- a/src/audio/codec_adapter/codec/dts.c
+++ b/src/audio/codec_adapter/codec/dts.c
@@ -396,7 +396,6 @@ static struct module_interface dts_interface = {
 	.init  = dts_codec_init,
 	.prepare = dts_codec_prepare,
 	.process = dts_codec_process,
-	.apply_config = dts_codec_apply_config,
 	.set_configuration = dts_codec_set_configuration,
 	.reset = dts_codec_reset,
 	.free = dts_codec_free

--- a/src/audio/codec_adapter/codec/generic.c
+++ b/src/audio/codec_adapter/codec/generic.c
@@ -73,11 +73,11 @@ err:
 	return ret;
 }
 
-int module_init(struct comp_dev *dev, struct module_interface *interface)
+int module_init(struct processing_module *mod, struct module_interface *interface)
 {
 	int ret;
-	struct processing_module *mod = comp_get_drvdata(dev);
 	struct module_data *md = &mod->priv;
+	struct comp_dev *dev = mod->dev;
 
 	comp_info(dev, "module_init() start");
 
@@ -87,7 +87,7 @@ int module_init(struct comp_dev *dev, struct module_interface *interface)
 		return -EPERM;
 
 	if (!interface) {
-		comp_err(dev, "module_init(): could not find module interface for comp %d",
+		comp_err(dev, "module_init(): could not find module interface for comp id %d",
 			 dev_comp_id(dev));
 		return -EIO;
 	}
@@ -105,9 +105,9 @@ int module_init(struct comp_dev *dev, struct module_interface *interface)
 	list_init(&md->memory.mem_list);
 
 	/* Now we can proceed with module specific initialization */
-	ret = md->ops->init(dev);
+	ret = md->ops->init(mod);
 	if (ret) {
-		comp_err(dev, "module_init() error %d: module specific init failed, comp %d",
+		comp_err(dev, "module_init() error %d: module specific init failed, comp id %d",
 			 ret, dev_comp_id(dev));
 		return ret;
 	}

--- a/src/audio/codec_adapter/codec/generic.c
+++ b/src/audio/codec_adapter/codec/generic.c
@@ -188,11 +188,11 @@ static int validate_config(struct module_config *cfg)
 	return 0;
 }
 
-int module_prepare(struct comp_dev *dev)
+int module_prepare(struct processing_module *mod)
 {
 	int ret;
-	struct processing_module *mod = comp_get_drvdata(dev);
 	struct module_data *md = &mod->priv;
+	struct comp_dev *dev = mod->dev;
 
 	comp_dbg(dev, "module_prepare() start");
 
@@ -201,7 +201,7 @@ int module_prepare(struct comp_dev *dev)
 	if (mod->priv.state < MODULE_INITIALIZED)
 		return -EPERM;
 
-	ret = md->ops->prepare(dev);
+	ret = md->ops->prepare(mod);
 	if (ret) {
 		comp_err(dev, "module_prepare() error %d: module specific prepare failed, comp_id %d",
 			 ret, dev_comp_id(dev));

--- a/src/audio/codec_adapter/codec/generic.c
+++ b/src/audio/codec_adapter/codec/generic.c
@@ -155,9 +155,8 @@ void *module_allocate_memory(struct processing_module *mod, uint32_t size, uint3
 	return ptr;
 }
 
-int module_free_memory(struct comp_dev *dev, void *ptr)
+int module_free_memory(struct processing_module *mod, void *ptr)
 {
-	struct processing_module *mod = comp_get_drvdata(dev);
 	struct module_memory *mem;
 	struct list_item *mem_list;
 	struct list_item *_mem_list;
@@ -176,7 +175,7 @@ int module_free_memory(struct comp_dev *dev, void *ptr)
 		}
 	}
 
-	comp_err(dev, "module_free_memory: error: could not find memory pointed by %p",
+	comp_err(mod->dev, "module_free_memory: error: could not find memory pointed by %p",
 		 (uint32_t)ptr);
 
 	return -EINVAL;

--- a/src/audio/codec_adapter/codec/generic.c
+++ b/src/audio/codec_adapter/codec/generic.c
@@ -11,7 +11,7 @@
  *
  */
 
-#include <sof/audio/codec_adapter/codec/generic.h>
+#include <sof/audio/codec_adapter/codec_adapter.h>
 
 /*****************************************************************************/
 /* Local helper functions						     */
@@ -343,6 +343,105 @@ int module_free(struct processing_module *mod)
 		rfree(md->runtime_params);
 
 	md->state = MODULE_DISABLED;
+
+	return ret;
+}
+
+/**
+ * \brief Set module configuration - Common method to assemble large configuration message
+ * \param[in] mod - struct processing_module pointer
+ * \param[in] config_id - Configuration ID
+ * \param[in] pos - position of the fragment in the large message
+ * \param[in] data_offset_size: size of the whole configuration if it is the first fragment or the
+ *				 only fragment. Otherwise, it is the offset of the fragment in the
+ *				 whole configuration.
+ * \param[in] fragment: configuration fragment buffer
+ * \param[in] fragment_size: size of @fragment
+ * \params[in] response: optional response buffer to fill
+ * \params[in] response_size: size of @response
+ *
+ * \return: 0 upon success or error upon failure
+ */
+int module_set_configuration(struct processing_module *mod,
+			     uint32_t config_id,
+			     enum module_cfg_fragment_position pos, size_t data_offset_size,
+			     const uint8_t *fragment, size_t fragment_size, uint8_t *response,
+			     size_t response_size)
+{
+	struct module_data *md = &mod->priv;
+	struct comp_dev *dev = mod->dev;
+	static size_t size;
+	size_t offset = 0;
+	uint8_t *dst;
+	int ret;
+
+	switch (pos) {
+	case MODULE_CFG_FRAGMENT_FIRST:
+	case MODULE_CFG_FRAGMENT_SINGLE:
+		/*
+		 * verify input params & allocate memory for the config blob when the first
+		 * fragment arrives
+		 */
+		size = data_offset_size;
+
+		/* Check that there is no previous request in progress */
+		if (md->runtime_params) {
+			comp_err(dev, "module_set_configuration(): error: busy with previous request");
+			return -EBUSY;
+		}
+
+		if (!size)
+			return 0;
+
+		if (size > MAX_BLOB_SIZE) {
+			comp_err(dev, "module_set_configuration(): error: blob size is too big cfg size %d, allowed %d",
+				 size, MAX_BLOB_SIZE);
+			return -EINVAL;
+		}
+
+		/* Allocate buffer for new params */
+		md->runtime_params = rballoc(0, SOF_MEM_CAPS_RAM, size);
+		if (!md->runtime_params) {
+			comp_err(dev, "module_set_configuration(): space allocation for new params failed");
+			return -ENOMEM;
+		}
+
+		memset(md->runtime_params, 0, size);
+		break;
+	default:
+		if (!md->runtime_params) {
+			comp_err(dev, "module_set_configuration(): error: no memory available for runtime params in consecutive load");
+			return -EIO;
+		}
+
+		/* set offset for intermediate and last fragments */
+		offset = data_offset_size;
+		break;
+	}
+
+	dst = (uint8_t *)md->runtime_params + offset;
+
+	ret = memcpy_s(dst, size - offset, fragment, fragment_size);
+	if (ret < 0) {
+		comp_err(dev, "module_set_configuration(): error: failed to copy fragment",
+			 ret);
+		return ret;
+	}
+
+	/* return as more fragments of config data expected */
+	if (pos == MODULE_CFG_FRAGMENT_MIDDLE || pos == MODULE_CFG_FRAGMENT_FIRST)
+		return 0;
+
+	/* config fully copied, now load it */
+	ret = module_load_config(dev, md->runtime_params, size);
+	if (ret)
+		comp_err(dev, "module_set_configuration(): error %d: config failed", ret);
+	else
+		comp_dbg(dev, "module_set_configuration(): config load successful");
+
+	if (md->runtime_params)
+		rfree(md->runtime_params);
+	md->runtime_params = NULL;
 
 	return ret;
 }

--- a/src/audio/codec_adapter/codec/generic.c
+++ b/src/audio/codec_adapter/codec/generic.c
@@ -309,9 +309,8 @@ int module_reset(struct processing_module *mod)
 	return 0;
 }
 
-void module_free_all_memory(struct comp_dev *dev)
+void module_free_all_memory(struct processing_module *mod)
 {
-	struct processing_module *mod = comp_get_drvdata(dev);
 	struct module_memory *mem;
 	struct list_item *mem_list;
 	struct list_item *_mem_list;
@@ -325,19 +324,18 @@ void module_free_all_memory(struct comp_dev *dev)
 	}
 }
 
-int module_free(struct comp_dev *dev)
+int module_free(struct processing_module *mod)
 {
 	int ret;
-	struct processing_module *mod = comp_get_drvdata(dev);
 	struct module_data *md = &mod->priv;
 
-	ret = md->ops->free(dev);
+	ret = md->ops->free(mod);
 	if (ret)
-		comp_warn(dev, "module_free(): error: %d for %d",
-			  ret, dev_comp_id(dev));
+		comp_warn(mod->dev, "module_free(): error: %d for %d",
+			  ret, dev_comp_id(mod->dev));
 
 	/* Free all memory requested by module */
-	module_free_all_memory(dev);
+	module_free_all_memory(mod);
 	/* Free all memory shared by codec_adapter & module */
 	md->cfg.avail = false;
 	md->cfg.size = 0;

--- a/src/audio/codec_adapter/codec/generic.c
+++ b/src/audio/codec_adapter/codec/generic.c
@@ -93,7 +93,7 @@ int module_init(struct processing_module *mod, struct module_interface *interfac
 	}
 
 	if (!interface->init || !interface->prepare || !interface->process ||
-	    !interface->apply_config || !interface->reset || !interface->free) {
+	    !interface->reset || !interface->free) {
 		comp_err(dev, "module_init(): comp %d is missing mandatory interfaces",
 			 dev_comp_id(dev));
 		return -EIO;
@@ -252,31 +252,6 @@ int module_process(struct comp_dev *dev)
 
 	/* reset state to idle */
 	md->state = MODULE_IDLE;
-	return ret;
-}
-
-int module_apply_runtime_config(struct comp_dev *dev)
-{
-	int ret;
-	struct processing_module *mod = comp_get_drvdata(dev);
-	struct module_data *md = &mod->priv;
-
-	comp_dbg(dev, "module_apply_config() start");
-
-	ret = md->ops->apply_config(dev);
-	if (ret) {
-		comp_err(dev, "module_apply_config() error %d: for comp %x",
-			 ret, dev_comp_id(dev));
-		return ret;
-	}
-
-	md->cfg.avail = false;
-	/* Configuration had been applied, we can free it now. */
-	rfree(md->cfg.data);
-	md->cfg.data = NULL;
-
-	comp_dbg(dev, "module_apply_config() end");
-
 	return ret;
 }
 

--- a/src/audio/codec_adapter/codec/generic.c
+++ b/src/audio/codec_adapter/codec/generic.c
@@ -281,20 +281,19 @@ int module_apply_runtime_config(struct comp_dev *dev)
 	return ret;
 }
 
-int module_reset(struct comp_dev *dev)
+int module_reset(struct processing_module *mod)
 {
 	int ret;
-	struct processing_module *mod = comp_get_drvdata(dev);
 	struct module_data *md = &mod->priv;
 
 	/* if the module was never prepared, no need to reset */
 	if (md->state < MODULE_IDLE)
 		return 0;
 
-	ret = md->ops->reset(dev);
+	ret = md->ops->reset(mod);
 	if (ret) {
-		comp_err(dev, "module_reset() error %d: module specific reset() failed for comp %d",
-			 ret, dev_comp_id(dev));
+		comp_err(mod->dev, "module_reset() error %d: module specific reset() failed for comp %d",
+			 ret, dev_comp_id(mod->dev));
 		return ret;
 	}
 

--- a/src/audio/codec_adapter/codec/generic.c
+++ b/src/audio/codec_adapter/codec/generic.c
@@ -118,11 +118,11 @@ int module_init(struct processing_module *mod, struct module_interface *interfac
 	return ret;
 }
 
-void *module_allocate_memory(struct comp_dev *dev, uint32_t size, uint32_t alignment)
+void *module_allocate_memory(struct processing_module *mod, uint32_t size, uint32_t alignment)
 {
+	struct comp_dev *dev = mod->dev;
 	struct module_memory *container;
 	void *ptr;
-	struct processing_module *mod = comp_get_drvdata(dev);
 
 	if (!size) {
 		comp_err(dev, "module_allocate_memory: requested allocation of 0 bytes.");

--- a/src/audio/codec_adapter/codec/passthrough.c
+++ b/src/audio/codec_adapter/codec/passthrough.c
@@ -83,9 +83,9 @@ static int passthrough_codec_apply_config(struct comp_dev *dev)
 	return 0;
 }
 
-static int passthrough_codec_reset(struct comp_dev *dev)
+static int passthrough_codec_reset(struct processing_module *mod)
 {
-	comp_info(dev, "passthrough_codec_reset()");
+	comp_info(mod->dev, "passthrough_codec_reset()");
 
 	/* nothing to do */
 	return 0;

--- a/src/audio/codec_adapter/codec/passthrough.c
+++ b/src/audio/codec_adapter/codec/passthrough.c
@@ -19,10 +19,10 @@ static int passthrough_codec_init(struct processing_module *mod)
 	return 0;
 }
 
-static int passthrough_codec_prepare(struct comp_dev *dev)
+static int passthrough_codec_prepare(struct processing_module *mod)
 {
+	struct comp_dev *dev = mod->dev;
 	struct module_data *codec = comp_get_module_data(dev);
-	struct processing_module *mod = comp_get_drvdata(dev);
 
 	comp_info(dev, "passthrough_codec_prepare()");
 

--- a/src/audio/codec_adapter/codec/passthrough.c
+++ b/src/audio/codec_adapter/codec/passthrough.c
@@ -13,9 +13,9 @@ DECLARE_SOF_RT_UUID("passthrough_codec", passthrough_uuid, 0x376b5e44, 0x9c82, 0
 		    0xbc, 0x83, 0x10, 0xea, 0x10, 0x1a, 0xf8, 0x8f);
 DECLARE_TR_CTX(passthrough_tr, SOF_UUID(passthrough_uuid), LOG_LEVEL_INFO);
 
-static int passthrough_codec_init(struct comp_dev *dev)
+static int passthrough_codec_init(struct processing_module *mod)
 {
-	comp_info(dev, "passthrough_codec_init() start");
+	comp_info(mod->dev, "passthrough_codec_init() start");
 	return 0;
 }
 

--- a/src/audio/codec_adapter/codec/passthrough.c
+++ b/src/audio/codec_adapter/codec/passthrough.c
@@ -91,8 +91,9 @@ static int passthrough_codec_reset(struct processing_module *mod)
 	return 0;
 }
 
-static int passthrough_codec_free(struct comp_dev *dev)
+static int passthrough_codec_free(struct processing_module *mod)
 {
+	struct comp_dev *dev = mod->dev;
 	struct module_data *codec = comp_get_module_data(dev);
 
 	comp_info(dev, "passthrough_codec_free()");

--- a/src/audio/codec_adapter/codec/passthrough.c
+++ b/src/audio/codec_adapter/codec/passthrough.c
@@ -75,14 +75,6 @@ static int passthrough_codec_process(struct comp_dev *dev)
 	return 0;
 }
 
-static int passthrough_codec_apply_config(struct comp_dev *dev)
-{
-	comp_info(dev, "passthrough_codec_apply_config()");
-
-	/* nothing to do */
-	return 0;
-}
-
 static int passthrough_codec_reset(struct processing_module *mod)
 {
 	comp_info(mod->dev, "passthrough_codec_reset()");
@@ -108,7 +100,6 @@ static struct module_interface passthrough_interface = {
 	.init  = passthrough_codec_init,
 	.prepare = passthrough_codec_prepare,
 	.process = passthrough_codec_process,
-	.apply_config = passthrough_codec_apply_config,
 	.reset = passthrough_codec_reset,
 	.free = passthrough_codec_free
 };

--- a/src/audio/codec_adapter/codec/waves.c
+++ b/src/audio/codec_adapter/codec/waves.c
@@ -832,7 +832,6 @@ static struct module_interface waves_interface = {
 	.init  = waves_codec_init,
 	.prepare = waves_codec_prepare,
 	.process = waves_codec_process,
-	.apply_config = waves_codec_apply_config,
 	.set_configuration = waves_codec_set_configuration,
 	.reset = waves_codec_reset,
 	.free = waves_codec_free

--- a/src/audio/codec_adapter/codec/waves.c
+++ b/src/audio/codec_adapter/codec/waves.c
@@ -418,11 +418,11 @@ static int waves_effect_buffers(struct processing_module *mod)
 
 err:
 	if (i_buffer)
-		module_free_memory(dev, i_buffer);
+		module_free_memory(mod, i_buffer);
 	if (o_buffer)
-		module_free_memory(dev, o_buffer);
+		module_free_memory(mod, o_buffer);
 	if (response)
-		module_free_memory(dev, response);
+		module_free_memory(mod, response);
 	return ret;
 }
 
@@ -618,7 +618,7 @@ static int waves_codec_init(struct processing_module *mod)
 
 		ret = waves_effect_allocate(mod);
 		if (ret) {
-			module_free_memory(dev, waves_codec);
+			module_free_memory(mod, waves_codec);
 			codec->private = NULL;
 		}
 	}
@@ -636,7 +636,7 @@ static int waves_codec_init(struct processing_module *mod)
 		setup_cfg->data = rballoc(0, SOF_MEM_CAPS_RAM, codec->cfg.size);
 		if (!setup_cfg->data) {
 			comp_err(dev, "cadence_codec_init(): failed to alloc setup config");
-			module_free_memory(dev, waves_codec);
+			module_free_memory(mod, waves_codec);
 			return -ENOMEM;
 		}
 
@@ -645,7 +645,7 @@ static int waves_codec_init(struct processing_module *mod)
 		ret = memcpy_s(setup_cfg->data, setup_cfg->size, codec->cfg.data, setup_cfg->size);
 		if (ret) {
 			comp_err(dev, "cadence_codec_init(): failed to copy setup config %d", ret);
-			module_free_memory(dev, waves_codec);
+			module_free_memory(mod, waves_codec);
 			return ret;
 		}
 		setup_cfg->avail = true;

--- a/src/audio/codec_adapter/codec/waves.c
+++ b/src/audio/codec_adapter/codec/waves.c
@@ -596,8 +596,9 @@ static int waves_effect_setup_config(struct comp_dev *dev)
 	return 0;
 }
 
-static int waves_codec_init(struct comp_dev *dev)
+static int waves_codec_init(struct processing_module *mod)
 {
+	struct comp_dev *dev = mod->dev;
 	struct module_data *codec = comp_get_module_data(dev);
 	struct waves_codec_data *waves_codec;
 	int ret = 0;

--- a/src/audio/codec_adapter/codec/waves.c
+++ b/src/audio/codec_adapter/codec/waves.c
@@ -184,8 +184,9 @@ static bool rate_is_supported(uint32_t rate)
 }
 
 /* allocate memory for MaxxEffect object */
-static int waves_effect_allocate(struct comp_dev *dev)
+static int waves_effect_allocate(struct processing_module *mod)
 {
+	struct comp_dev *dev = mod->dev;
 	struct module_data *codec = comp_get_module_data(dev);
 	struct waves_codec_data *waves_codec = codec->private;
 	MaxxStatus_t status;
@@ -355,8 +356,9 @@ static int waves_effect_init(struct comp_dev *dev)
 }
 
 /* allocate additional buffers for MaxxEffect */
-static int waves_effect_buffers(struct comp_dev *dev)
+static int waves_effect_buffers(struct processing_module *mod)
 {
+	struct comp_dev *dev = mod->dev;
 	struct module_data *codec = comp_get_module_data(dev);
 	struct waves_codec_data *waves_codec = codec->private;
 	MaxxStatus_t status;
@@ -614,7 +616,7 @@ static int waves_codec_init(struct processing_module *mod)
 		memset(waves_codec, 0, sizeof(struct waves_codec_data));
 		codec->private = waves_codec;
 
-		ret = waves_effect_allocate(dev);
+		ret = waves_effect_allocate(mod);
 		if (ret) {
 			module_free_memory(dev, waves_codec);
 			codec->private = NULL;
@@ -666,7 +668,7 @@ static int waves_codec_prepare(struct processing_module *mod)
 		ret = waves_effect_init(dev);
 
 	if (!ret)
-		ret = waves_effect_buffers(dev);
+		ret = waves_effect_buffers(mod);
 
 	if (!ret)
 		ret = waves_effect_setup_config(dev);

--- a/src/audio/codec_adapter/codec/waves.c
+++ b/src/audio/codec_adapter/codec/waves.c
@@ -200,7 +200,7 @@ static int waves_effect_allocate(struct processing_module *mod)
 		return -EINVAL;
 	}
 
-	waves_codec->effect = (MaxxEffect_t *)module_allocate_memory(dev,
+	waves_codec->effect = (MaxxEffect_t *)module_allocate_memory(mod,
 		waves_codec->effect_size, 16);
 
 	if (!waves_codec->effect) {
@@ -377,7 +377,7 @@ static int waves_effect_buffers(struct processing_module *mod)
 		goto err;
 	}
 
-	response = module_allocate_memory(dev, waves_codec->response_max_bytes, 16);
+	response = module_allocate_memory(mod, waves_codec->response_max_bytes, 16);
 	if (!response) {
 		comp_err(dev, "waves_effect_buffers() failed to allocate %d bytes for response",
 			 waves_codec->response_max_bytes);
@@ -385,7 +385,7 @@ static int waves_effect_buffers(struct processing_module *mod)
 		goto err;
 	}
 
-	i_buffer = module_allocate_memory(dev, waves_codec->buffer_bytes, 16);
+	i_buffer = module_allocate_memory(mod, waves_codec->buffer_bytes, 16);
 	if (!i_buffer) {
 		comp_err(dev, "waves_effect_buffers() failed to allocate %d bytes for i_buffer",
 			 waves_codec->buffer_bytes);
@@ -393,7 +393,7 @@ static int waves_effect_buffers(struct processing_module *mod)
 		goto err;
 	}
 
-	o_buffer = module_allocate_memory(dev, waves_codec->buffer_bytes, 16);
+	o_buffer = module_allocate_memory(mod, waves_codec->buffer_bytes, 16);
 	if (!o_buffer) {
 		comp_err(dev, "waves_effect_buffers() failed to allocate %d bytes for o_buffer",
 			 waves_codec->buffer_bytes);
@@ -607,7 +607,7 @@ static int waves_codec_init(struct processing_module *mod)
 
 	comp_dbg(dev, "waves_codec_init() start");
 
-	waves_codec = module_allocate_memory(dev, sizeof(struct waves_codec_data), 16);
+	waves_codec = module_allocate_memory(mod, sizeof(struct waves_codec_data), 16);
 	if (!waves_codec) {
 		comp_err(dev, "waves_codec_init() failed to allocate %d bytes for waves_codec_data",
 			 sizeof(struct waves_codec_data));

--- a/src/audio/codec_adapter/codec/waves.c
+++ b/src/audio/codec_adapter/codec/waves.c
@@ -783,13 +783,13 @@ static int waves_codec_reset(struct processing_module *mod)
 	return ret;
 }
 
-static int waves_codec_free(struct comp_dev *dev)
+static int waves_codec_free(struct processing_module *mod)
 {
 	/* codec is using codec_adapter method module_allocate_memory for all allocations
 	 * codec_adapter will free it all on component free call
 	 * nothing to do here
 	 */
-	comp_dbg(dev, "waves_codec_free()");
+	comp_dbg(mod->dev, "waves_codec_free()");
 	return 0;
 }
 

--- a/src/audio/codec_adapter/codec/waves.c
+++ b/src/audio/codec_adapter/codec/waves.c
@@ -760,10 +760,11 @@ static int waves_codec_apply_config(struct comp_dev *dev)
 	return ret;
 }
 
-static int waves_codec_reset(struct comp_dev *dev)
+static int waves_codec_reset(struct processing_module *mod)
 {
 	MaxxStatus_t status;
 	int ret = 0;
+	struct comp_dev *dev = mod->dev;
 	struct module_data *codec = comp_get_module_data(dev);
 	struct waves_codec_data *waves_codec = codec->private;
 

--- a/src/audio/codec_adapter/codec/waves.c
+++ b/src/audio/codec_adapter/codec/waves.c
@@ -653,8 +653,9 @@ static int waves_codec_init(struct processing_module *mod)
 	return ret;
 }
 
-static int waves_codec_prepare(struct comp_dev *dev)
+static int waves_codec_prepare(struct processing_module *mod)
 {
+	struct comp_dev *dev = mod->dev;
 	int ret;
 
 	comp_dbg(dev, "waves_codec_prepare() start");

--- a/src/audio/codec_adapter/codec_adapter.c
+++ b/src/audio/codec_adapter/codec_adapter.c
@@ -572,7 +572,7 @@ void codec_adapter_free(struct comp_dev *dev)
 
 	comp_dbg(dev, "codec_adapter_free(): start");
 
-	ret = module_free(dev);
+	ret = module_free(mod);
 	if (ret)
 		comp_err(dev, "codec_adapter_free(): error %d, codec free failed", ret);
 

--- a/src/audio/codec_adapter/codec_adapter.c
+++ b/src/audio/codec_adapter/codec_adapter.c
@@ -401,80 +401,40 @@ end:
 
 static int codec_adapter_set_params(struct comp_dev *dev, struct sof_ipc_ctrl_data *cdata)
 {
-	int ret;
-	char *dst, *src;
-	static uint32_t size;
-	uint32_t offset;
 	struct processing_module *mod = comp_get_drvdata(dev);
 	struct module_data *md = &mod->priv;
+	enum module_cfg_fragment_position pos;
+	uint32_t data_offset_size;
+	static uint32_t size;
 
-	comp_dbg(dev, "codec_adapter_set_params(): start: num_of_elem %d, elem remain %d msg_index %u",
+	comp_dbg(dev, "codec_adapter_set_params(): num_of_elem %d, elem remain %d msg_index %u",
 		 cdata->num_elems, cdata->elems_remaining, cdata->msg_index);
 
-	/* Stage 1 verify input params & allocate memory for the config blob */
-	if (cdata->msg_index == 0) {
+	/* set the fragment position, data offset and config data size */
+	if (!cdata->msg_index) {
 		size = cdata->num_elems + cdata->elems_remaining;
-		if (!size)
-			return 0;
-
-		if (size > MAX_BLOB_SIZE) {
-			comp_err(dev, "codec_adapter_set_params() error: blob size is too big cfg size %d, allowed %d",
-				 size, MAX_BLOB_SIZE);
-			return -EINVAL;
-		}
-
-		/* Check that there is no work-in-progress on previous request */
-		if (md->runtime_params) {
-			comp_err(dev, "codec_adapter_set_params() error: busy with previous request");
-			return -EBUSY;
-		}
-
-		/* Allocate buffer for new params */
-		md->runtime_params = rballoc(0, SOF_MEM_CAPS_RAM, size);
-		if (!md->runtime_params) {
-			comp_err(dev, "codec_adapter_set_params(): space allocation for new params failed");
-			return -ENOMEM;
-		}
-
-		memset(md->runtime_params, 0, size);
-	} else if (!md->runtime_params) {
-		comp_err(dev, "codec_adapter_set_params() error: no memory available for runtime params in consecutive load");
-		return -EIO;
-	}
-
-	offset = size - (cdata->num_elems + cdata->elems_remaining);
-	dst = (char *)md->runtime_params + offset;
-	src = (char *)cdata->data->data;
-
-	ret = memcpy_s(dst, size - offset, src, cdata->num_elems);
-	assert(!ret);
-
-	/* return as more fragments of config data expected */
-	if (cdata->elems_remaining)
-		return 0;
-
-	/* config fully copied, now load it */
-	ret = module_load_config(dev, md->runtime_params, size);
-	if (ret)
-		goto end;
-
-	comp_dbg(dev, "codec_adapter_set_params(): config load successful");
-
-	/* And apply runtime config right away if codec is already prepared */
-	if (md->state >= MODULE_INITIALIZED) {
-		ret = module_apply_runtime_config(dev);
-		if (ret)
-			comp_err(dev, "codec_adapter_set_params() error %x: codec runtime config apply failed",
-				 ret);
+		data_offset_size = size;
+		if (cdata->elems_remaining)
+			pos = MODULE_CFG_FRAGMENT_FIRST;
 		else
-			comp_dbg(dev, "codec_adapter_set_params() apply of runtime config done.");
+			pos = MODULE_CFG_FRAGMENT_SINGLE;
+	} else {
+		data_offset_size = size - (cdata->num_elems + cdata->elems_remaining);
+		if (cdata->elems_remaining)
+			pos = MODULE_CFG_FRAGMENT_MIDDLE;
+		else
+			pos = MODULE_CFG_FRAGMENT_LAST;
 	}
 
-end:
-	if (md->runtime_params)
-		rfree(md->runtime_params);
-	md->runtime_params = NULL;
-	return ret;
+	/* IPC3 does not use config_id, so pass 0 for config ID as it will be ignored anyway */
+	if (md->ops->set_configuration)
+		return md->ops->set_configuration(mod, 0, pos, data_offset_size,
+						  (const uint8_t *)cdata->data->data,
+						  cdata->num_elems, NULL, 0);
+
+	comp_warn(dev, "codec_adapter_set_params(): no set_configuration op set for %d",
+		  dev_comp_id(dev));
+	return 0;
 }
 
 static int codec_adapter_ctrl_set_data(struct comp_dev *dev,

--- a/src/audio/codec_adapter/codec_adapter.c
+++ b/src/audio/codec_adapter/codec_adapter.c
@@ -140,7 +140,7 @@ int codec_adapter_prepare(struct comp_dev *dev)
 	}
 
 	/* Prepare codec */
-	ret = module_prepare(dev);
+	ret = module_prepare(mod);
 	if (ret) {
 		comp_err(dev, "codec_adapter_prepare() error %x: codec prepare failed",
 			 ret);

--- a/src/audio/codec_adapter/codec_adapter.c
+++ b/src/audio/codec_adapter/codec_adapter.c
@@ -78,7 +78,7 @@ struct comp_dev *codec_adapter_new(const struct comp_driver *drv,
 	}
 
 	/* Init processing codec */
-	ret = module_init(dev, interface);
+	ret = module_init(mod, interface);
 	if (ret) {
 		comp_err(dev, "codec_adapter_new() %d: codec initialization failed",
 			 ret);

--- a/src/audio/codec_adapter/codec_adapter.c
+++ b/src/audio/codec_adapter/codec_adapter.c
@@ -550,7 +550,7 @@ int codec_adapter_reset(struct comp_dev *dev)
 
 	comp_dbg(dev, "codec_adapter_reset(): resetting");
 
-	ret = module_reset(dev);
+	ret = module_reset(mod);
 	if (ret) {
 		comp_err(dev, "codec_adapter_reset(): error %d, codec reset has failed",
 			 ret);

--- a/src/audio/codec_adapter/codec_adapter.c
+++ b/src/audio/codec_adapter/codec_adapter.c
@@ -63,6 +63,8 @@ struct comp_dev *codec_adapter_new(const struct comp_driver *drv,
 		return NULL;
 	}
 
+	mod->dev = dev;
+
 	comp_set_drvdata(dev, mod);
 
 	/* Copy initial config */

--- a/src/include/sof/audio/codec_adapter/codec/generic.h
+++ b/src/include/sof/audio/codec_adapter/codec/generic.h
@@ -105,7 +105,7 @@ struct module_interface {
 	 * Module specific free procedure, called as part of codec_adapter component
 	 * free in .free(). This should free all memory allocated by module.
 	 */
-	int (*free)(struct comp_dev *dev);
+	int (*free)(struct processing_module *mod);
 };
 
 /**
@@ -205,12 +205,12 @@ int module_load_config(struct comp_dev *dev, void *cfg, size_t size);
 int module_init(struct processing_module *mod, struct module_interface *interface);
 void *module_allocate_memory(struct comp_dev *dev, uint32_t size, uint32_t alignment);
 int module_free_memory(struct comp_dev *dev, void *ptr);
-void module_free_all_memory(struct comp_dev *dev);
+void module_free_all_memory(struct processing_module *mod);
 int module_prepare(struct processing_module *mod);
 int module_process(struct comp_dev *dev);
 int module_apply_runtime_config(struct comp_dev *dev);
 int module_reset(struct processing_module *mod);
-int module_free(struct comp_dev *dev);
+int module_free(struct processing_module *mod);
 
 struct comp_dev *codec_adapter_new(const struct comp_driver *drv,
 				   struct comp_ipc_config *config,

--- a/src/include/sof/audio/codec_adapter/codec/generic.h
+++ b/src/include/sof/audio/codec_adapter/codec/generic.h
@@ -257,6 +257,11 @@ int module_process(struct comp_dev *dev);
 int module_apply_runtime_config(struct comp_dev *dev);
 int module_reset(struct processing_module *mod);
 int module_free(struct processing_module *mod);
+int module_set_configuration(struct processing_module *mod,
+			     uint32_t config_id,
+			     enum module_cfg_fragment_position pos, size_t data_offset_size,
+			     const uint8_t *fragment, size_t fragment_size, uint8_t *response,
+			     size_t response_size);
 
 struct comp_dev *codec_adapter_new(const struct comp_driver *drv,
 				   struct comp_ipc_config *config,

--- a/src/include/sof/audio/codec_adapter/codec/generic.h
+++ b/src/include/sof/audio/codec_adapter/codec/generic.h
@@ -79,6 +79,19 @@ enum module_cfg_fragment_position {
 	MODULE_CFG_FRAGMENT_SINGLE,
 };
 
+/**
+ * \enum module_processing_mode
+ * MODULE_PROCESSING_NORMAL: Indicates that module is expected to apply its custom processing on
+ *			      the input signal
+ * MODULE_PROCESSING_BYPASS: Indicates that module is expected to skip custom processing on
+ *			      the input signal and act as a passthrough component
+ */
+
+enum module_processing_mode {
+	MODULE_PROCESSING_NORMAL,
+	MODULE_PROCESSING_BYPASS,
+};
+
 /*****************************************************************************/
 /* Module generic data types						     */
 /*****************************************************************************/

--- a/src/include/sof/audio/codec_adapter/codec/generic.h
+++ b/src/include/sof/audio/codec_adapter/codec/generic.h
@@ -204,7 +204,7 @@ struct processing_module {
 int module_load_config(struct comp_dev *dev, void *cfg, size_t size);
 int module_init(struct processing_module *mod, struct module_interface *interface);
 void *module_allocate_memory(struct processing_module *mod, uint32_t size, uint32_t alignment);
-int module_free_memory(struct comp_dev *dev, void *ptr);
+int module_free_memory(struct processing_module *mod, void *ptr);
 void module_free_all_memory(struct processing_module *mod);
 int module_prepare(struct processing_module *mod);
 int module_process(struct comp_dev *dev);

--- a/src/include/sof/audio/codec_adapter/codec/generic.h
+++ b/src/include/sof/audio/codec_adapter/codec/generic.h
@@ -81,7 +81,7 @@ struct module_interface {
 	 * Module specific prepare procedure, called as part of codec_adapter
 	 * component preparation in .prepare()
 	 */
-	int (*prepare)(struct comp_dev *dev);
+	int (*prepare)(struct processing_module *mod);
 	/**
 	 * Module specific processing procedure, called as part of codec_adapter
 	 * component copy in .copy(). This procedure is responsible to consume
@@ -206,7 +206,7 @@ int module_init(struct processing_module *mod, struct module_interface *interfac
 void *module_allocate_memory(struct comp_dev *dev, uint32_t size, uint32_t alignment);
 int module_free_memory(struct comp_dev *dev, void *ptr);
 void module_free_all_memory(struct comp_dev *dev);
-int module_prepare(struct comp_dev *dev);
+int module_prepare(struct processing_module *mod);
 int module_process(struct comp_dev *dev);
 int module_apply_runtime_config(struct comp_dev *dev);
 int module_reset(struct comp_dev *dev);

--- a/src/include/sof/audio/codec_adapter/codec/generic.h
+++ b/src/include/sof/audio/codec_adapter/codec/generic.h
@@ -100,7 +100,7 @@ struct module_interface {
 	 * reset in .reset(). This should reset all parameters to their initial stage
 	 * but leave allocated memory intact.
 	 */
-	int (*reset)(struct comp_dev *dev);
+	int (*reset)(struct processing_module *mod);
 	/**
 	 * Module specific free procedure, called as part of codec_adapter component
 	 * free in .free(). This should free all memory allocated by module.
@@ -209,7 +209,7 @@ void module_free_all_memory(struct comp_dev *dev);
 int module_prepare(struct processing_module *mod);
 int module_process(struct comp_dev *dev);
 int module_apply_runtime_config(struct comp_dev *dev);
-int module_reset(struct comp_dev *dev);
+int module_reset(struct processing_module *mod);
 int module_free(struct comp_dev *dev);
 
 struct comp_dev *codec_adapter_new(const struct comp_driver *drv,

--- a/src/include/sof/audio/codec_adapter/codec/generic.h
+++ b/src/include/sof/audio/codec_adapter/codec/generic.h
@@ -62,6 +62,8 @@ UT_STATIC void sys_comp_codec_##adapter_init(void) \
 \
 DECLARE_MODULE(sys_comp_codec_##adapter_init)
 
+struct processing_module;
+
 /*****************************************************************************/
 /* Module generic data types						     */
 /*****************************************************************************/
@@ -74,7 +76,7 @@ struct module_interface {
 	 * Module specific initialization procedure, called as part of
 	 * codec_adapter component creation in .new()
 	 */
-	int (*init)(struct comp_dev *dev);
+	int (*init)(struct processing_module *mod);
 	/**
 	 * Module specific prepare procedure, called as part of codec_adapter
 	 * component preparation in .prepare()
@@ -200,7 +202,7 @@ struct processing_module {
 /* Module generic interfaces						     */
 /*****************************************************************************/
 int module_load_config(struct comp_dev *dev, void *cfg, size_t size);
-int module_init(struct comp_dev *dev, struct module_interface *interface);
+int module_init(struct processing_module *mod, struct module_interface *interface);
 void *module_allocate_memory(struct comp_dev *dev, uint32_t size, uint32_t alignment);
 int module_free_memory(struct comp_dev *dev, void *ptr);
 void module_free_all_memory(struct comp_dev *dev);

--- a/src/include/sof/audio/codec_adapter/codec/generic.h
+++ b/src/include/sof/audio/codec_adapter/codec/generic.h
@@ -64,6 +64,21 @@ DECLARE_MODULE(sys_comp_codec_##adapter_init)
 
 struct processing_module;
 
+/**
+ * \enum module_cfg_fragment_position
+ * \brief Fragment position in config
+ * MODULE_CFG_FRAGMENT_FIRST: first fragment of the large configuration
+ * MODULE_CFG_FRAGMENT_SINGLE: only fragment of the configuration
+ * MODULE_CFG_FRAGMENT_LAST: last fragment of the configuration
+ * MODULE_CFG_FRAGMENT_MIDDLE: intermediate fragment of the large configuration
+ */
+enum module_cfg_fragment_position {
+	MODULE_CFG_FRAGMENT_MIDDLE,
+	MODULE_CFG_FRAGMENT_FIRST,
+	MODULE_CFG_FRAGMENT_LAST,
+	MODULE_CFG_FRAGMENT_SINGLE,
+};
+
 /*****************************************************************************/
 /* Module generic data types						     */
 /*****************************************************************************/

--- a/src/include/sof/audio/codec_adapter/codec/generic.h
+++ b/src/include/sof/audio/codec_adapter/codec/generic.h
@@ -149,6 +149,17 @@ struct module_interface {
 				 const uint8_t *fragment, size_t fragment_size);
 
 	/**
+	 * Set processing mode for the module
+	 */
+	int (*set_processing_mode)(struct processing_module *mod,
+				   enum module_processing_mode mode);
+
+	/**
+	 * Get the current processing mode for the module
+	 */
+	enum module_processing_mode (*get_processing_mode)(struct processing_module *mod);
+
+	/**
 	 * Module specific reset procedure, called as part of codec_adapter component
 	 * reset in .reset(). This should reset all parameters to their initial stage
 	 * but leave allocated memory intact.

--- a/src/include/sof/audio/codec_adapter/codec/generic.h
+++ b/src/include/sof/audio/codec_adapter/codec/generic.h
@@ -187,6 +187,11 @@ struct processing_module {
 	struct comp_buffer *ca_source;
 	struct comp_buffer *local_buff;
 	struct sof_ipc_stream_params stream_params;
+	/*
+	 * This is a temporary change in order to support the trace messages in the modules. This
+	 * will be removed once the trace API is updated.
+	 */
+	struct comp_dev *dev;
 	uint32_t period_bytes; /** pipeline period bytes */
 	uint32_t deep_buff_bytes; /**< copy start threshold */
 };

--- a/src/include/sof/audio/codec_adapter/codec/generic.h
+++ b/src/include/sof/audio/codec_adapter/codec/generic.h
@@ -203,7 +203,7 @@ struct processing_module {
 /*****************************************************************************/
 int module_load_config(struct comp_dev *dev, void *cfg, size_t size);
 int module_init(struct processing_module *mod, struct module_interface *interface);
-void *module_allocate_memory(struct comp_dev *dev, uint32_t size, uint32_t alignment);
+void *module_allocate_memory(struct processing_module *mod, uint32_t size, uint32_t alignment);
 int module_free_memory(struct comp_dev *dev, void *ptr);
 void module_free_all_memory(struct processing_module *mod);
 int module_prepare(struct processing_module *mod);

--- a/src/include/sof/audio/codec_adapter/codec/generic.h
+++ b/src/include/sof/audio/codec_adapter/codec/generic.h
@@ -110,6 +110,37 @@ struct module_interface {
 	 * prepared. This will not be called for SETUP cfg.
 	 */
 	int (*apply_config)(struct comp_dev *dev);
+
+	/**
+	 * Set module configuration for the given configuration ID
+	 *
+	 * If the complete configuration message is greater than MAX_BLOB_SIZE bytes, the
+	 * transmission will be split into several smaller fragments.
+	 * In this case the ADSP System will perform multiple calls to SetConfiguration() until
+	 * completion of the configuration message sending.
+	 * \note config_id indicates ID of the configuration message only on the first fragment
+	 * sending, otherwise it is set to 0.
+	 */
+	int (*set_configuration)(struct processing_module *mod,
+				 uint32_t config_id,
+				 enum module_cfg_fragment_position pos, uint32_t data_offset_size,
+				 const uint8_t *fragment, size_t fragment_size, uint8_t *response,
+				 size_t response_size);
+
+	/**
+	 * Get module runtime configuration for the given configuration ID
+	 *
+	 * If the complete configuration message is greater than MAX_BLOB_SIZE bytes, the
+	 * transmission will be split into several smaller fragments.
+	 * In this case the ADSP System will perform multiple calls to GetConfiguration() until
+	 * completion of the configuration message retrieval.
+	 * \note config_id indicates ID of the configuration message only on the first fragment
+	 * retrieval, otherwise it is set to 0.
+	 */
+	int (*get_configuration)(struct processing_module *mod,
+				 uint32_t config_id, uint32_t data_offset_size,
+				 const uint8_t *fragment, size_t fragment_size);
+
 	/**
 	 * Module specific reset procedure, called as part of codec_adapter component
 	 * reset in .reset(). This should reset all parameters to their initial stage

--- a/src/include/sof/audio/codec_adapter/codec/generic.h
+++ b/src/include/sof/audio/codec_adapter/codec/generic.h
@@ -104,12 +104,6 @@ struct module_interface {
 	 * ones back to codec_adapter.
 	 */
 	int (*process)(struct comp_dev *dev);
-	/**
-	 * Module specific apply config procedure, called by codec_adapter every time
-	 * a new RUNTIME configuration has been sent if the adapter has been
-	 * prepared. This will not be called for SETUP cfg.
-	 */
-	int (*apply_config)(struct comp_dev *dev);
 
 	/**
 	 * Set module configuration for the given configuration ID
@@ -254,7 +248,6 @@ int module_free_memory(struct processing_module *mod, void *ptr);
 void module_free_all_memory(struct processing_module *mod);
 int module_prepare(struct processing_module *mod);
 int module_process(struct comp_dev *dev);
-int module_apply_runtime_config(struct comp_dev *dev);
 int module_reset(struct processing_module *mod);
 int module_free(struct processing_module *mod);
 int module_set_configuration(struct processing_module *mod,


### PR DESCRIPTION
This PR is Part 1 of the proposal to update then module_interface to add new API's and modify existing API's.

**The process() API will be modified in a follow up PR as it requires the codec_adapter to be modified to handle more than just 1 input/output buffer**

```
struct module_interface {
	/**
	 * Module specific initialization procedure, called as part of
	 * codec_adapter component creation in .new()
	 */
	int (*init)(struct processing_module *mod);
	/**
	 * Module specific prepare procedure, called as part of codec_adapter
	 * component preparation in .prepare()
	 */
	int (*prepare)(struct processing_module *mod);
	/**
	 * Module specific processing procedure, called as part of codec_adapter
	 * component copy in .copy(). This procedure is responsible to consume
	 * samples provided by the codec_adapter and produce/output the processed
	 * ones back to codec_adapter.
	 */
       **To be modified in th next PR**
	int (*process)(struct comp_dev *dev);

	/**
	 * Set module configuration for the given configuration ID
	 *
	 * If the complete configuration message is greater than MAX_BLOB_SIZE bytes, the
	 * transmission will be split into several smaller fragments.
	 * In this case the ADSP System will perform multiple calls to SetConfiguration() until
	 * completion of the configuration message sending.
	 * \note config_id indicates ID of the configuration message only on the first fragment
	 * sending, otherwise it is set to 0.
	 */
	int (*set_configuration)(struct processing_module *mod,
				 uint32_t config_id,
				 enum module_cfg_fragment_position pos, uint32_t data_offset_size,
				 const uint8_t *fragment, size_t fragment_size, uint8_t *response,
				 size_t response_size);

	/**
	 * Get module runtime configuration for the given configuration ID
	 *
	 * If the complete configuration message is greater than MAX_BLOB_SIZE bytes, the
	 * transmission will be split into several smaller fragments.
	 * In this case the ADSP System will perform multiple calls to GetConfiguration() until
	 * completion of the configuration message retrieval.
	 * \note config_id indicates ID of the configuration message only on the first fragment
	 * retrieval, otherwise it is set to 0.
	 */
	int (*get_configuration)(struct processing_module *mod,
				 uint32_t config_id, uint32_t data_offset_size,
				 const uint8_t *fragment, size_t fragment_size);

	/**
	 * Set processing mode for the module
	 */
	int (*set_processing_mode)(struct processing_module *mod,
				   enum module_processing_mode mode);

	/**
	 * Get the current processing mode for the module
	 */
	enum module_processing_mode (*get_processing_mode)(struct processing_module *mod);

	/**
	 * Module specific reset procedure, called as part of codec_adapter component
	 * reset in .reset(). This should reset all parameters to their initial stage
	 * but leave allocated memory intact.
	 */
	int (*reset)(struct processing_module *mod);
	/**
	 * Module specific free procedure, called as part of codec_adapter component
	 * free in .free(). This should free all memory allocated by module.
	 */
	int (*free)(struct processing_module *mod);
};
```