### PR TITLE
xtensa-build-all.sh: distinguish default/working platform and WIP. Fix toolchain coverage

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -86,7 +86,10 @@ jobs:
 
     strategy:
       matrix:
-        platform: [sue jsl tgl]
+        platform: [imx8ulp,
+                   sue jsl tgl,
+                   rn,
+        ]
 
     steps:
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -114,11 +114,13 @@ jobs:
 
     strategy:
       matrix:
-        # Compiler-based grouping, see HOST= in xtensa-build-all.sh The
-        # only reason for grouping is to avoid the matrix swarming the
-        # user interface and burying other checks.
+        # Compiler-based groups, see HOST= compilers in
+        # xtensa-build-all.sh.  Pay attention to commas and whitespace.
+        # The main reason for these groups is to avoid the matrix
+        # swarming the Github web interface and burying other checks.
         platform: [imx8 imx8x imx8m,
-                   byt cht, bdw hsw, apl skl kbl, cnl icl]
+                   byt cht, bdw hsw, apl skl kbl, cnl icl,
+        ]
 
     steps:
 

--- a/scripts/xtensa-build-all.sh
+++ b/scripts/xtensa-build-all.sh
@@ -5,8 +5,15 @@
 # stop on most errors
 set -e
 
-SUPPORTED_PLATFORMS=(byt cht bdw hsw apl skl kbl cnl sue icl jsl \
-                    imx8 imx8x imx8m imx8ulp tgl tgl-h rn mt8195)
+# Platforms with a toolchain available in the latest Docker image and
+# built by the -a option.
+DEFAULT_PLATFORMS=(  byt cht bdw hsw apl skl kbl cnl sue icl jsl \
+                    imx8 imx8x imx8m imx8ulp tgl tgl-h rn mt8195 )
+
+# Work in progress can be added to this "staging area" without breaking
+# the -a option for everyone.
+SUPPORTED_PLATFORMS=( "${DEFAULT_PLATFORMS[@]}" )
+
 BUILD_ROM=no
 BUILD_DEBUG=no
 BUILD_FORCE_UP=no
@@ -51,8 +58,8 @@ https://thesofproject.github.io/latest/developer_guides/firmware/cmake.html
 usage: $0 [options] platform(s)
 
        -r Build rom if available (gcc only)
-       -a Build all platforms
-       -u Force UP ARCH
+       -a Build all platforms which have a toolchain in the latest Docker image
+       -u Force CONFIG_MULTICORE=n
        -d Enable debug build
        -c Interactive menuconfig
        -o arg, copies src/arch/xtensa/configs/override/<arg>.config
@@ -108,7 +115,7 @@ while getopts "rudj:ckvao:m:" OPTION; do
 		k) USE_PRIVATE_KEY=yes ;;
 		o) OVERRIDE_CONFIG=$OPTARG ;;
 		v) BUILD_VERBOSE='VERBOSE=1' ;;
-		a) PLATFORMS=("${SUPPORTED_PLATFORMS[@]}") ;;
+		a) PLATFORMS=("${DEFAULT_PLATFORMS[@]}") ;;
 		m) MEU_TOOL_PATH=$OPTARG ;;
 		*) print_usage; exit 1 ;;
         esac
@@ -416,7 +423,6 @@ do
 		echo "CONFIG_BUILD_VM_ROM=y" >> override.config
 	fi
 
-	# override default ARCH if BUILD_FORCE_UP is set
 	if [ "x$BUILD_FORCE_UP" == "xyes" ]
 	then
 		echo "Force building UP(xtensa)..."

--- a/scripts/xtensa-build-all.sh
+++ b/scripts/xtensa-build-all.sh
@@ -324,7 +324,6 @@ do
 			;;
 		rn)
 			PLATFORM="renoir"
-			ARCH="xtensa"
 			XTENSA_CORE="ACP_3_1_001_PROD"
 			HOST="xtensa-rn-elf"
 			XTENSA_TOOLS_VERSION="RF-2016.4-linux"


### PR DESCRIPTION
4 commits. Main one below. Also: fix toolchain coverage in CI

The -a option has been broken by the addition of platform(s) that don't
have a toolchain available in the Docker image. Every platform can be
built by someone but no one can built -a(ll) platforms right now.

Fix the -a option by changing its definition: make it build what
everyone can build using the public Docker image.
