### PR TITLE
SDMA suspend/resume fixes

### DIFF
--- a/src/drivers/imx/sai.c
+++ b/src/drivers/imx/sai.c
@@ -329,13 +329,13 @@ static int sai_trigger(struct dai *dai, int cmd, int direction)
 
 	switch (cmd) {
 	case COMP_TRIGGER_START:
+	case COMP_TRIGGER_RELEASE:
 		sai_start(dai, direction);
 		break;
 	case COMP_TRIGGER_STOP:
 	case COMP_TRIGGER_PAUSE:
 		sai_stop(dai, direction);
 		break;
-	case COMP_TRIGGER_RELEASE:
 	case COMP_TRIGGER_PRE_START:
 	case COMP_TRIGGER_PRE_RELEASE:
 		break;

--- a/src/drivers/imx/sdma.c
+++ b/src/drivers/imx/sdma.c
@@ -504,7 +504,7 @@ static int sdma_release(struct dma_chan_data *channel)
 	if (channel->status != COMP_STATE_PAUSED)
 		return -EINVAL;
 
-	channel->status = COMP_STATE_ACTIVE;
+	channel->status = COMP_STATE_PREPARE;
 
 	/* No pointer realignment is necessary for release, context points
 	 * correctly to beginning of the following BD.


### PR DESCRIPTION
This PR contains two small fixes related to pause/resume for SAI  + SDMA related to wrong state handling and not calling sai_start() on release.

pause/resume feature still needs to be reviewed.