### PR TITLE
topology2: cavs-sdw: add audio format tokens

### DIFF
--- a/tools/topology/topology2/cavs/CMakeLists.txt
+++ b/tools/topology/topology2/cavs/CMakeLists.txt
@@ -12,6 +12,8 @@ set(TPLGS
 "cavs-gain-hdmi\;cavs-gain-hda\;HDA_CONFIG=gain"
 # CAVS HDA topology with mixer-based pipelines
 "cavs-passthrough-hdmi\;cavs-mixin-mixout-hda\;HDA_CONFIG=mix"
+# CAVS SDW topology with passthrough pipelines
+"cavs-sdw\;cavs-sdw"
 )
 
 # This will override the topology1 binaries with topology2 binaries

--- a/tools/topology/topology2/cavs/cavs-sdw.conf
+++ b/tools/topology/topology2/cavs/cavs-sdw.conf
@@ -1,18 +1,29 @@
-<include/common/vendor-token.conf>
-<include/common/tokens.conf>
-<include/common/manifest.conf>
-<include/common/pcm.conf>
-<include/common/pcm_caps.conf>
-<include/common/fe_dai.conf>
-<include/common/route.conf>
-<include/components/host.conf>
-<include/components/dai.conf>
-<include/components/pipeline.conf>
-<include/components/copier.conf>
-<include/dais/alh.conf>
-<include/dais/hw_config.conf>
-<include/pipelines/cavs/passthrough-playback.conf>
-<include/pipelines/cavs/passthrough-capture.conf>
+<searchdir:cavs>
+<searchdir:include>
+<searchdir:include/common>
+<searchdir:include/components>
+<searchdir:include/dais>
+<searchdir:include/pipelines/cavs>
+
+<vendor-token.conf>
+<tokens.conf>
+<virtual.conf>
+<passthrough-playback.conf>
+<passthrough-capture.conf>
+<data.conf>
+<pcm.conf>
+<pcm_caps.conf>
+<fe_dai.conf>
+<alh.conf>
+<hw_config.conf>
+<manifest.conf>
+<route.conf>
+<cavs/common_definitions.conf>
+<copier.conf>
+<pipeline.conf>
+<dai.conf>
+<host.conf>
+
 
 #
 # List of all DAIs
@@ -43,6 +54,24 @@ Object.Dai {
 			period_sink_count 0
 			period_source_count 2
 			format s16le
+			node_type $ALH_LINK_OUTPUT_CLASS
+			num_audio_formats 2
+			# 16-bit 48KHz 2ch
+			Object.Base.audio_format.1 {
+				# 16 -> 32 bits conversion will be done in the copier,
+				# therefore the out_bit_depth is 32
+				out_bit_depth		32
+				# dma_buffer_size should be 2 * obs for playback
+				dma_buffer_size "$[$obs * 2]"
+			}
+			# 32-bit 48KHz 2ch
+			Object.Base.audio_format.2 {
+				in_bit_depth		32
+				in_valid_bit_depth	32
+				out_bit_depth		32
+				out_valid_bit_depth	32
+				dma_buffer_size "$[$obs * 2]"
+			}
 		}
 	}
 	ALH."3" {
@@ -68,6 +97,25 @@ Object.Dai {
 			period_sink_count 2
 			period_source_count 0
 			format s16le
+			node_type $ALH_LINK_INPUT_CLASS
+			num_audio_formats 2
+			# 16-bit 48KHz 2ch
+			Object.Base.audio_format.1 {
+				# 32 -> 16 bits conversion will be done in pipeline,
+				# so both in_bit_depth and out_bit_depth are still 32 here.
+				in_bit_depth		32
+				out_bit_depth		32
+				# dma_buffer_size should be 2 * ibs for capture
+				dma_buffer_size "$[$ibs * 2]"
+			}
+			# 32-bit 48KHz 2ch
+			Object.Base.audio_format.2 {
+				in_bit_depth		32
+				in_valid_bit_depth	32
+				out_bit_depth		32
+				out_valid_bit_depth	32
+				dma_buffer_size "$[$ibs * 2]"
+			}
 		}
 	}
 }
@@ -93,6 +141,11 @@ Object.Pipeline {
 		Object.Widget.pipeline.1.stream_name	"copier.ALH.3.0"
 
 		Object.Widget.copier.1.stream_name	"Passthrough Capture 0"
+		Object.Widget.copier.1.Object.Base.audio_format.1 {
+			# 32 -> 16 bits conversion is done here,
+			# so in_bit_depth is 32 (and out_bit_depth is 16).
+			in_bit_depth	32
+		}
 	}
 }
 


### PR DESCRIPTION
Add audio format tokens for cavs-sdw.conf

Signed-off-by: Bard Liao <yung-chuan.liao@linux.intel.com>