### PR TITLE
ipc4: Move the 'dai_index' 4 bits to the right

### DIFF
--- a/src/audio/copier.c
+++ b/src/audio/copier.c
@@ -232,6 +232,7 @@ static struct comp_dev *create_dai(struct comp_dev *parent_dev, struct copier_da
 		break;
 	case ipc4_i2s_link_output_class:
 	case ipc4_i2s_link_input_class:
+		dai.dai_index = (dai.dai_index >> 4) & 0xF;
 		dai.type = SOF_DAI_INTEL_SSP;
 		dai.is_config_blob = true;
 		break;


### PR DESCRIPTION
I2S Node ID virtual index structure:
-first 4 bits are index of the time slot group (uint8_t time_slot_group_index : 4)
-next 4 bits are index instance (uint8_t i2s_instance : 4)
Therefore dai.dai_index should be moved 4 bits to the right.

Signed-off-by: Arsen Eloglian <ArsenX.Eloglian@intel.com>