### PR TITLE
ipc4: Correction of component id printed in tr_err

### DIFF
--- a/src/audio/copier.c
+++ b/src/audio/copier.c
@@ -46,6 +46,9 @@ DECLARE_SOF_RT_UUID("copier", copier_comp_uuid, 0x9ba00c83, 0xca12, 0x4a83,
 DECLARE_TR_CTX(copier_comp_tr, SOF_UUID(copier_comp_uuid), LOG_LEVEL_INFO);
 
 struct copier_data {
+	/* Must be the 1st field, function ipc4_create_buffer casts components private data
+	 * as ipc4_base_module_cfg!
+	 */
 	struct ipc4_copier_module_cfg config;
 	struct comp_dev *endpoint;
 	struct comp_buffer *endpoint_buffer;

--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -228,6 +228,8 @@ static inline void *audio_stream_wrap(const struct audio_stream *buffer,
 		ptr = (char *)buffer->addr +
 			((char *)ptr - (char *)buffer->end_addr);
 
+	assert((intptr_t)ptr <= (intptr_t)buffer->end_addr);
+
 	return ptr;
 }
 
@@ -525,6 +527,7 @@ static inline int
 audio_stream_bytes_without_wrap(const struct audio_stream *source,
 				const void *ptr)
 {
+	assert((intptr_t)source->end_addr >= (intptr_t)ptr);
 	int to_end = (intptr_t)source->end_addr - (intptr_t)ptr;
 	return to_end;
 }


### PR DESCRIPTION
Corrected component id printed in tr_err.
Added some important comments.
Added asserts witch helped me debug the code.