### PR TITLE
ipc4: invalidate HOSTBOX for comp_new

### DIFF
--- a/src/audio/copier.c
+++ b/src/audio/copier.c
@@ -318,8 +318,6 @@ static struct comp_dev *copier_new(const struct comp_driver *drv,
 	if (!dev)
 		return NULL;
 
-	dcache_invalidate_region(spec, sizeof(*copier));
-
 	dev->ipc_config = *config;
 
 	config_size = copier->gtw_cfg.config_length * sizeof(uint32_t);

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -630,7 +630,6 @@ static struct comp_dev *mixinout_new(const struct comp_driver *drv,
 		return NULL;
 	}
 
-	dcache_invalidate_region(spec, sizeof(md->base_cfg));
 	memcpy_s(&md->base_cfg, sizeof(md->base_cfg), spec, sizeof(md->base_cfg));
 	comp_set_drvdata(dev, md);
 

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -77,6 +77,9 @@ struct comp_dev *comp_new(struct sof_ipc_comp *comp)
 	ipc_config.pipeline_id = comp->pipeline_id;
 	ipc_config.core = comp->core;
 
+	dcache_invalidate_region((void *)(MAILBOX_HOSTBOX_BASE),
+				 MAILBOX_HOSTBOX_SIZE);
+
 	dev = drv->ops.create(drv, &ipc_config, (void *)MAILBOX_HOSTBOX_BASE);
 	if (!dev)
 		return NULL;


### PR DESCRIPTION
This will allow to remove invalidate calls for each component init