### PR TITLE
Audio: Buffer: Remove too verbose buffer debug traces for CONFIG_LIBRARY

### DIFF
--- a/src/audio/buffer.c
+++ b/src/audio/buffer.c
@@ -179,7 +179,6 @@ void comp_update_buffer_produce(struct comp_buffer *buffer, uint32_t bytes)
 		.transaction_amount = bytes,
 		.transaction_begin_address = buffer->stream.w_ptr,
 	};
-	char *addr;
 
 	/* return if no bytes */
 	if (!bytes) {
@@ -198,15 +197,13 @@ void comp_update_buffer_produce(struct comp_buffer *buffer, uint32_t bytes)
 	notifier_event(buffer, NOTIFIER_ID_BUFFER_PRODUCE,
 		       NOTIFIER_TARGET_CORE_LOCAL, &cb_data, sizeof(cb_data));
 
-	addr = buffer->stream.addr;
-
 	buf_dbg(buffer, "comp_update_buffer_produce(), ((buffer->avail << 16) | buffer->free) = %08x, ((buffer->id << 16) | buffer->size) = %08x",
 		(audio_stream_get_avail_bytes(&buffer->stream) << 16) |
 		 audio_stream_get_free_bytes(&buffer->stream),
 		(buffer->id << 16) | buffer->stream.size);
 	buf_dbg(buffer, "comp_update_buffer_produce(), ((buffer->r_ptr - buffer->addr) << 16 | (buffer->w_ptr - buffer->addr)) = %08x",
-		((char *)buffer->stream.r_ptr - addr) << 16 |
-		((char *)buffer->stream.w_ptr - addr));
+		((char *)buffer->stream.r_ptr - (char *)buffer->stream.addr) << 16 |
+		((char *)buffer->stream.w_ptr - (char *)buffer->stream.addr));
 
 	buffer = buffer_release_irq(buffer);
 }
@@ -218,7 +215,6 @@ void comp_update_buffer_consume(struct comp_buffer *buffer, uint32_t bytes)
 		.transaction_amount = bytes,
 		.transaction_begin_address = buffer->stream.r_ptr,
 	};
-	char *addr;
 
 	/* return if no bytes */
 	if (!bytes) {
@@ -237,14 +233,12 @@ void comp_update_buffer_consume(struct comp_buffer *buffer, uint32_t bytes)
 	notifier_event(buffer, NOTIFIER_ID_BUFFER_CONSUME,
 		       NOTIFIER_TARGET_CORE_LOCAL, &cb_data, sizeof(cb_data));
 
-	addr = buffer->stream.addr;
-
 	buf_dbg(buffer, "comp_update_buffer_consume(), (buffer->avail << 16) | buffer->free = %08x, (buffer->id << 16) | buffer->size = %08x, (buffer->r_ptr - buffer->addr) << 16 | (buffer->w_ptr - buffer->addr)) = %08x",
 		(audio_stream_get_avail_bytes(&buffer->stream) << 16) |
 		 audio_stream_get_free_bytes(&buffer->stream),
 		(buffer->id << 16) | buffer->stream.size,
-		((char *)buffer->stream.r_ptr - addr) << 16 |
-		((char *)buffer->stream.w_ptr - addr));
+		((char *)buffer->stream.r_ptr - (char *)buffer->stream.addr) << 16 |
+		((char *)buffer->stream.w_ptr - (char *)buffer->stream.addr));
 
 	buffer = buffer_release_irq(buffer);
 }

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -65,9 +65,13 @@ extern struct tr_ctx buffer_tr;
 		       trace_buf_get_subid, buf_ptr, __e, ##__VA_ARGS__)
 
 /** \brief Trace debug message from buffer */
+#if defined(CONFIG_LIBRARY)
+#define buf_dbg(buf_ptr, __e, ...)
+#else
 #define buf_dbg(buf_ptr, __e, ...)					\
 	trace_dev_dbg(trace_buf_get_tr_ctx, trace_buf_get_id,		\
 		      trace_buf_get_subid, buf_ptr, __e, ##__VA_ARGS__)
+#endif
 
 /** @}*/
 


### PR DESCRIPTION
This patch leaves out low value debug traces with CONFIG_LIBRARY for
comp_update_buffer_produce() and comp_update_buffer_consume(). They
are too far too verbose and slow down testbench runs, and cause
massive size data files if traces are captured to files.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>