### PR TITLE
Tools: Test: Audio: Add sound direction test for TDFB

### DIFF
--- a/tools/test/topology/test-capture.m4
+++ b/tools/test/topology/test-capture.m4
@@ -20,11 +20,8 @@ include(`platform/intel/bxt.m4')
 
 DEBUG_START
 
-# Apply a non-trivial filter blob IIR and FIR tests. TODO: Note that the
-# PIPELINE_FILTERx notation will be updated in future for better flexibility.
-ifelse(TEST_PIPE_NAME, `eq-iir', `define(PIPELINE_FILTER1, `eq_iir_coef_loudness.m4')')
-ifelse(TEST_PIPE_NAME, `eq-fir', `define(PIPELINE_FILTER2, `eq_fir_coef_loudness.m4')')
-ifelse(TEST_PIPE_NAME, `tdfb',  `define(PIPELINE_FILTER1, `tdfb/coef_line2_50mm_pm90deg_48khz.m4')')
+# Define the algorithm configurations blobs to apply such as filter coefficients
+include(`test_pipeline_filters.m4')
 
 #
 # Machine Specific Config - !! MUST BE SET TO MATCH TEST MACHINE DRIVER !!

--- a/tools/test/topology/test-playback.m4
+++ b/tools/test/topology/test-playback.m4
@@ -38,11 +38,8 @@ define(`upcase', `translit(`$*', `a-z', `A-Z')')
 # TEST_PIPE_AMOUNT - Total amount of pipelines e.g. 1, 2, 3, 4
 #
 
-# Apply a non-trivial filter blob IIR and FIR tests. TODO: Note that the
-# PIPELINE_FILTERx notation will be updated in future for better flexibility.
-ifelse(TEST_PIPE_NAME, `eq-iir', `define(PIPELINE_FILTER1, `eq_iir_coef_loudness.m4')')
-ifelse(TEST_PIPE_NAME, `eq-fir', `define(PIPELINE_FILTER2, `eq_fir_coef_loudness.m4')')
-ifelse(TEST_PIPE_NAME, `tdfb',  `define(PIPELINE_FILTER1, `tdfb/coef_line2_50mm_pm90deg_48khz.m4')')
+# Define the algorithm configurations blobs to apply such as filter coefficients
+include(`test_pipeline_filters.m4')
 
 # Define TEST_HAS_PIPEn flags according to TEST_PIPE_AMOUNT. Those flags will be
 # used to determine whether PIPELINE_n should be added.

--- a/tools/test/topology/test_pipeline_filters.m4
+++ b/tools/test/topology/test_pipeline_filters.m4
@@ -1,0 +1,34 @@
+
+# Define the algorithm configurations blobs to apply such as filter coefficients
+
+# EQs
+ifelse(TEST_PIPE_NAME, `eq-iir', `define(PIPELINE_FILTER1, `eq_iir_coef_loudness.m4')')
+ifelse(TEST_PIPE_NAME, `eq-fir', `define(PIPELINE_FILTER2, `eq_fir_coef_loudness.m4')')
+
+# TDFB test pipelines with different names for different configurations
+
+# line array 2 mic
+ifelse(TEST_PIPE_NAME, `tdfb', `define(PIPELINE_FILTER1, `tdfb/coef_line2_50mm_pm90deg_48khz.m4')')
+
+# line array 4 mic
+ifelse(TEST_PIPE_NAME, `tdfb_line4_28mm_pm90deg_48khz',
+`
+define(PIPELINE_FILTER1, `tdfb/coef_line4_28mm_pm90deg_48khz.m4')
+define(TEST_PIPE_NAME, `tdfb')
+')
+
+# circular 8 mic, use 360 degree enum controls variant while line array
+# is 180 degrees
+ifelse(TEST_PIPE_NAME, `tdfb_circular8_100mm_az0el0deg_48khz',
+`
+define(PIPELINE_FILTER1, `tdfb/coef_circular8_100mm_az0el0deg_48khz.m4')
+define(TEST_PIPE_NAME, `tdfb360')
+')
+
+# circular 8 mic, use 360 degree enum controls variant while line array
+# is 180 degrees
+ifelse(TEST_PIPE_NAME, `tdfb_circular8_100mm_pm30deg_48khz',
+`
+define(PIPELINE_FILTER1, `tdfb/coef_circular8_100mm_pm30deg_48khz.m4')
+define(TEST_PIPE_NAME, `tdfb360')
+')

--- a/tools/test/topology/tplg-build.sh
+++ b/tools/test/topology/tplg-build.sh
@@ -227,7 +227,8 @@ done
 
 
 # for processing algorithms
-ALG_SINGLE_MODE_TESTS=(asrc eq-fir eq-iir src dcblock tdfb drc multiband-drc)
+ALG_SINGLE_MODE_TESTS=(asrc eq-fir eq-iir src dcblock drc multiband-drc tdfb
+		       tdfb_line4_28mm_pm90deg_48khz tdfb_circular8_100mm_pm30deg_48khz)
 ALG_SINGLE_SIMPLE_TESTS=(test-capture test-playback)
 ALG_MULTI_MODE_TESTS=(crossover)
 ALG_MULTI_SIMPLE_TESTS=(test-playback)


### PR DESCRIPTION
This patch adds Matlab script tdfb_direction_test.m. The test
simulates acoustical microphone array capture with 360 degrees
rotated noise source. The test topologies build adds an array
identifier to component name in topology file name. That
allows the scripts to simulate with several arrays. Now a
basic 2 mic array (no array suffix, just tdfb), 4 mic line,
and 8 mic circular are tested. Test pass/fail is so far only
visual check from plot.

The existing tdfb_test.c is extended to perform test with the
three test array configurations.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>