### PR TITLE
trace: add Zephyr git version to the initial FW ABI banner

### DIFF
--- a/src/trace/dma-trace.c
+++ b/src/trace/dma-trace.c
@@ -415,13 +415,19 @@ int dma_trace_enable(struct dma_trace_data *d)
 		goto out;
 	}
 
+#ifdef __ZEPHYR__
+#define ZEPHYR_VER_OPT " zephyr:" META_QUOTE(BUILD_VERSION)
+#else
+#define ZEPHYR_VER_OPT
+#endif
+
 	/* META_QUOTE(SOF_SRC_HASH) is part of the format string so it
 	 * goes to the .ldc file and does not go to the firmware
 	 * binary. It will be different from SOF_SRC_HASH in case of
 	 * mismatch.
 	 */
 #define SOF_BANNER_COMMON  \
-	"FW ABI 0x%x DBG ABI 0x%x tag " SOF_GIT_TAG \
+	"FW ABI 0x%x DBG ABI 0x%x tags SOF:" SOF_GIT_TAG  ZEPHYR_VER_OPT  \
 	" src hash 0x%08x (ldc hash " META_QUOTE(SOF_SRC_HASH) ")"
 
 	/* It should be the very first sent log for easy identification. */


### PR DESCRIPTION
Add Zephyr git version in the initial FW ABI banner. Sample output:
```
SHM: FW ABI 0x3014000 DBG ABI 0x5003000 \
SOF:v2.0-rc1-245-g4be53bca4ab5-dirty zephyr:v2.7.99-3167-g8a8abd69228d \
src hash 0xb8098c48 (ldc hash 0xb8098c48)
```
Signed-off-by: Marc Herbert <marc.herbert@intel.com>

Progress for #5093 