### PR TITLE
zephyr: spinlock: Align spinlock API to use Zephyr API

### DIFF
--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -32,10 +32,11 @@ DECLARE_TR_CTX(comp_tr, SOF_UUID(comp_uuid), LOG_LEVEL_INFO);
 int comp_register(struct comp_driver_info *drv)
 {
 	struct comp_driver_list *drivers = comp_drivers_get();
+	k_spinlock_key_t key;
 
-	spin_lock(&drivers->lock);
+	key = k_spin_lock(&drivers->lock);
 	list_item_prepend(&drv->list, &drivers->list);
-	spin_unlock(&drivers->lock);
+	k_spin_unlock(&drivers->lock, key);
 
 	return 0;
 }
@@ -43,10 +44,11 @@ int comp_register(struct comp_driver_info *drv)
 void comp_unregister(struct comp_driver_info *drv)
 {
 	struct comp_driver_list *drivers = comp_drivers_get();
+	k_spinlock_key_t key;
 
-	spin_lock(&drivers->lock);
+	key = k_spin_lock(&drivers->lock);
 	list_item_del(&drv->list);
-	spin_unlock(&drivers->lock);
+	k_spin_unlock(&drivers->lock, key);
 }
 
 /* NOTE: Keep the component state diagram up to date:

--- a/src/audio/pipeline/pipeline-graph.c
+++ b/src/audio/pipeline/pipeline-graph.c
@@ -60,8 +60,9 @@ static inline int pipeline_posn_offset_get(uint32_t *posn_offset)
 	struct pipeline_posn *pipeline_posn = pipeline_posn_get();
 	int ret = -EINVAL;
 	uint32_t i;
+	k_spinlock_key_t key;
 
-	spin_lock(&pipeline_posn->lock);
+	key = k_spin_lock(&pipeline_posn->lock);
 
 	for (i = 0; i < PPL_POSN_OFFSETS; ++i) {
 		if (!pipeline_posn->posn_offset[i]) {
@@ -73,7 +74,7 @@ static inline int pipeline_posn_offset_get(uint32_t *posn_offset)
 	}
 
 
-	spin_unlock(&pipeline_posn->lock);
+	k_spin_unlock(&pipeline_posn->lock, key);
 
 	return ret;
 }
@@ -86,13 +87,13 @@ static inline void pipeline_posn_offset_put(uint32_t posn_offset)
 {
 	struct pipeline_posn *pipeline_posn = pipeline_posn_get();
 	int i = posn_offset / sizeof(struct sof_ipc_stream_posn);
+	k_spinlock_key_t key;
 
-	spin_lock(&pipeline_posn->lock);
+	key = k_spin_lock(&pipeline_posn->lock);
 
 	pipeline_posn->posn_offset[i] = false;
 
-
-	spin_unlock(&pipeline_posn->lock);
+	k_spin_unlock(&pipeline_posn->lock, key);
 }
 
 void pipeline_posn_init(struct sof *sof)

--- a/src/drivers/amd/renoir/acp_bt_dma.c
+++ b/src/drivers/amd/renoir/acp_bt_dma.c
@@ -52,24 +52,24 @@ static uint64_t prev_rx_pos;
 static struct dma_chan_data *acp_dai_bt_dma_channel_get(struct dma *dma,
 						   unsigned int req_chan)
 {
-	uint32_t flags;
+	k_spinlock_key_t key;
 	struct dma_chan_data *channel;
 
-	spin_lock_irq(&dma->lock, flags);
+	key = k_spin_lock_irq(&dma->lock);
 	if (req_chan >= dma->plat_data.channels) {
-		spin_unlock_irq(&dma->lock, flags);
+		k_spin_unlock_irq(&dma->lock, key);
 		tr_err(&acp_bt_dma_tr, "DMA: Channel %d not in range", req_chan);
 		return NULL;
 	}
 	channel = &dma->chan[req_chan];
 	if (channel->status != COMP_STATE_INIT) {
-		spin_unlock_irq(&dma->lock, flags);
+		k_spin_unlock_irq(&dma->lock, key);
 		tr_err(&acp_bt_dma_tr, "DMA: channel already in use %d", req_chan);
 		return NULL;
 	}
 	atomic_add(&dma->num_channels_busy, 1);
 	channel->status = COMP_STATE_READY;
-	spin_unlock_irq(&dma->lock, flags);
+	k_spin_unlock_irq(&dma->lock, key);
 
 	return channel;
 }
@@ -77,13 +77,13 @@ static struct dma_chan_data *acp_dai_bt_dma_channel_get(struct dma *dma,
 /* channel must not be running when this is called */
 static void acp_dai_bt_dma_channel_put(struct dma_chan_data *channel)
 {
-	uint32_t flags;
+	k_spinlock_key_t key;
 
 	notifier_unregister_all(NULL, channel);
-	spin_lock_irq(&channel->dma->lock, flags);
+	key = k_spin_lock_irq(&channel->dma->lock);
 	channel->status = COMP_STATE_INIT;
 	atomic_sub(&channel->dma->num_channels_busy, 1);
-	spin_unlock_irq(&channel->dma->lock, flags);
+	k_spin_unlock_irq(&channel->dma->lock, key);
 }
 
 static int acp_dai_bt_dma_start(struct dma_chan_data *channel)

--- a/src/drivers/amd/renoir/acp_dmic_dma.c
+++ b/src/drivers/amd/renoir/acp_dmic_dma.c
@@ -42,38 +42,38 @@ DECLARE_TR_CTX(acp_dmic_dma_tr, SOF_UUID(acp_dmic_dma_uuid), LOG_LEVEL_INFO);
 static struct dma_chan_data *acp_dmic_dma_channel_get(struct dma *dma,
 						   unsigned int req_chan)
 {
-	uint32_t flags;
+	k_spinlock_key_t key;
 	struct dma_chan_data *channel;
 
-	spin_lock_irq(&dma->lock, flags);
+	key = k_spin_lock_irq(&dma->lock);
 	if (req_chan >= dma->plat_data.channels) {
-		spin_unlock_irq(&dma->lock, flags);
+		k_spin_unlock_irq(&dma->lock, key);
 		tr_err(&acp_dmic_dma_tr, "ACP_DMIC: Channel %d out of range",
 				req_chan);
 		return NULL;
 	}
 	channel = &dma->chan[req_chan];
 	if (channel->status != COMP_STATE_INIT) {
-		spin_unlock_irq(&dma->lock, flags);
+		k_spin_unlock_irq(&dma->lock, key);
 		tr_err(&acp_dmic_dma_tr, "ACP_DMIC: Cannot reuse channel %d",
 				req_chan);
 		return NULL;
 	}
 	atomic_add(&dma->num_channels_busy, 1);
 	channel->status = COMP_STATE_READY;
-	spin_unlock_irq(&dma->lock, flags);
+	k_spin_unlock_irq(&dma->lock, key);
 	return channel;
 }
 
 static void acp_dmic_dma_channel_put(struct dma_chan_data *channel)
 {
-	uint32_t flags;
+	k_spinlock_key_t key;
 
 	notifier_unregister_all(NULL, channel);
-	spin_lock_irq(&channel->dma->lock, flags);
+	key = k_spin_lock_irq(&channel->dma->lock);
 	channel->status = COMP_STATE_INIT;
 	atomic_sub(&channel->dma->num_channels_busy, 1);
-	spin_unlock_irq(&channel->dma->lock, flags);
+	k_spin_unlock_irq(&channel->dma->lock, key);
 }
 
 static int acp_dmic_dma_start(struct dma_chan_data *channel)

--- a/src/drivers/dw/ssi-spi.c
+++ b/src/drivers/dw/ssi-spi.c
@@ -484,15 +484,16 @@ static unsigned int n_spi_devices;
 struct spi *spi_get(enum spi_type type)
 {
 	struct spi *spi;
-	unsigned int i, flags;
+	unsigned int i;
+	k_spinlock_key_t key;
 
-	spin_lock_irq(&spi_lock, flags);
+	key = k_spin_lock_irq(&spi_lock);
 
 	for (i = 0, spi = spi_devices; i < n_spi_devices; i++, spi++)
 		if (spi->plat_data->type == type)
 			break;
 
-	spin_unlock_irq(&spi_lock, flags);
+	k_spin_unlock_irq(&spi_lock, key);
 
 	return i < n_spi_devices ? spi : NULL;
 }
@@ -500,10 +501,11 @@ struct spi *spi_get(enum spi_type type)
 int spi_install(const struct spi_platform_data *plat, size_t n)
 {
 	struct spi *spi;
-	unsigned int i, flags;
+	unsigned int i;
+	k_spinlock_key_t key;
 	int ret;
 
-	spin_lock_irq(&spi_lock, flags);
+	key = k_spin_lock_irq(&spi_lock);
 
 	if (spi_devices) {
 		ret = -EBUSY;
@@ -526,7 +528,7 @@ int spi_install(const struct spi_platform_data *plat, size_t n)
 	}
 
 unlock:
-	spin_unlock_irq(&spi_lock, flags);
+	k_spin_unlock_irq(&spi_lock, key);
 
 	return ret;
 }

--- a/src/drivers/generic/dummy-dma.c
+++ b/src/drivers/generic/dummy-dma.c
@@ -223,10 +223,10 @@ static ssize_t dummy_dma_do_copies(struct dma_chan_pdata *pdata, int bytes)
 static struct dma_chan_data *dummy_dma_channel_get(struct dma *dma,
 						   unsigned int req_chan)
 {
-	uint32_t flags;
+	k_spinlock_key_t key;
 	int i;
 
-	spin_lock_irq(&dma->lock, flags);
+	key = k_spin_lock_irq(&dma->lock);
 	for (i = 0; i < dma->plat_data.channels; i++) {
 		/* use channel if it's free */
 		if (dma->chan[i].status == COMP_STATE_INIT) {
@@ -235,11 +235,11 @@ static struct dma_chan_data *dummy_dma_channel_get(struct dma *dma,
 			atomic_add(&dma->num_channels_busy, 1);
 
 			/* return channel */
-			spin_unlock_irq(&dma->lock, flags);
+			k_spin_unlock_irq(&dma->lock, key);
 			return &dma->chan[i];
 		}
 	}
-	spin_unlock_irq(&dma->lock, flags);
+	k_spin_unlock_irq(&dma->lock, key);
 	tr_err(&ddma_tr, "dummy-dmac: %d no free channel",
 	       dma->plat_data.id);
 	return NULL;
@@ -272,11 +272,11 @@ static void dummy_dma_channel_put_unlocked(struct dma_chan_data *channel)
  */
 static void dummy_dma_channel_put(struct dma_chan_data *channel)
 {
-	uint32_t flags;
+	k_spinlock_key_t key;
 
-	spin_lock_irq(&channel->dma->lock, flags);
+	key = k_spin_lock_irq(&channel->dma->lock);
 	dummy_dma_channel_put_unlocked(channel);
-	spin_unlock_irq(&channel->dma->lock, flags);
+	k_spin_unlock_irq(&channel->dma->lock, key);
 }
 
 /* Since copies are synchronous, the triggers do nothing */
@@ -332,10 +332,10 @@ static int dummy_dma_set_config(struct dma_chan_data *channel,
 				struct dma_sg_config *config)
 {
 	struct dma_chan_pdata *ch = dma_chan_get_data(channel);
-	uint32_t flags;
+	k_spinlock_key_t key;
 	int ret = 0;
 
-	spin_lock_irq(&channel->dma->lock, flags);
+	key = k_spin_lock_irq(&channel->dma->lock);
 
 	if (!config->elem_array.count) {
 		tr_err(&ddma_tr, "dummy-dmac: %d channel %d no DMA descriptors",
@@ -364,7 +364,7 @@ static int dummy_dma_set_config(struct dma_chan_data *channel,
 
 	channel->status = COMP_STATE_PREPARE;
 out:
-	spin_unlock_irq(&channel->dma->lock, flags);
+	k_spin_unlock_irq(&channel->dma->lock, key);
 	return ret;
 }
 

--- a/src/drivers/intel/baytrail/ssp.c
+++ b/src/drivers/intel/baytrail/ssp.c
@@ -68,8 +68,9 @@ static int ssp_set_config(struct dai *dai, struct ipc_config_dai *common_config,
 	bool cfs = false;
 	bool cbs = false;
 	int ret = 0;
+	k_spinlock_key_t key;
 
-	spin_lock(&dai->lock);
+	key = k_spin_lock(&dai->lock);
 
 	/* is playback/capture already running */
 	if (ssp->state[DAI_DIR_PLAYBACK] == COMP_STATE_ACTIVE ||
@@ -444,7 +445,7 @@ static int ssp_set_config(struct dai *dai, struct ipc_config_dai *common_config,
 	dai_info(dai, "ssp_set_config(), done");
 
 out:
-	spin_unlock(&dai->lock);
+	k_spin_unlock(&dai->lock, key);
 
 	return ret;
 }
@@ -485,8 +486,9 @@ static int ssp_get_hw_params(struct dai *dai,
 static void ssp_start(struct dai *dai, int direction)
 {
 	struct ssp_pdata *ssp = dai_get_drvdata(dai);
+	k_spinlock_key_t key;
 
-	spin_lock(&dai->lock);
+	key = k_spin_lock(&dai->lock);
 
 	/* enable port */
 	ssp_update_bits(dai, SSCR0, SSCR0_SSE, SSCR0_SSE);
@@ -500,15 +502,16 @@ static void ssp_start(struct dai *dai, int direction)
 	else
 		ssp_update_bits(dai, SSCR1, SSCR1_RSRE, SSCR1_RSRE);
 
-	spin_unlock(&dai->lock);
+	k_spin_unlock(&dai->lock, key);
 }
 
 /* stop the SSP for either playback or capture */
 static void ssp_stop(struct dai *dai, int direction)
 {
 	struct ssp_pdata *ssp = dai_get_drvdata(dai);
+	k_spinlock_key_t key;
 
-	spin_lock(&dai->lock);
+	key = k_spin_lock(&dai->lock);
 
 	/* stop Rx if neeed */
 	if (direction == DAI_DIR_CAPTURE &&
@@ -534,7 +537,7 @@ static void ssp_stop(struct dai *dai, int direction)
 		dai_info(dai, "ssp_stop(), SSP port disabled");
 	}
 
-	spin_unlock(&dai->lock);
+	k_spin_unlock(&dai->lock, key);
 }
 
 static void ssp_pause(struct dai *dai, int direction)

--- a/src/drivers/intel/cavs/interrupt.c
+++ b/src/drivers/intel/cavs/interrupt.c
@@ -62,6 +62,7 @@ static inline void irq_lvl2_handler(void *data, int level, uint32_t ilxsd,
 	struct list_item *clist;
 	uint32_t status;
 	uint32_t tries = LVL2_MAX_TRIES;
+	k_spinlock_key_t key;
 
 	/* read active interrupt status */
 	status = irq_read(ilxsd);
@@ -75,7 +76,7 @@ static inline void irq_lvl2_handler(void *data, int level, uint32_t ilxsd,
 
 		status &= ~(1 << bit);
 
-		spin_lock(&cascade->lock);
+		key = k_spin_lock(&cascade->lock);
 
 		/* get child if any and run handler */
 		list_for_item(clist, &cascade->child[bit].list) {
@@ -83,16 +84,16 @@ static inline void irq_lvl2_handler(void *data, int level, uint32_t ilxsd,
 
 			if (child->handler && (child->cpu_mask & 1 << core)) {
 				/* run handler in non atomic context */
-				spin_unlock(&cascade->lock);
+				k_spin_unlock(&cascade->lock, key);
 				child->handler(child->handler_arg);
-				spin_lock(&cascade->lock);
+				k_spin_lock(&cascade->lock);
 
 				handled = true;
 			}
 
 		}
 
-		spin_unlock(&cascade->lock);
+		k_spin_unlock(&cascade->lock, key);
 
 		if (!handled) {
 			/* nobody cared ? */

--- a/src/drivers/intel/cavs/ipc.c
+++ b/src/drivers/intel/cavs/ipc.c
@@ -58,9 +58,9 @@ static void ipc_irq_handler(void *arg)
 {
 	struct ipc *ipc = arg;
 	uint32_t dipcctl;
-	uint32_t flags;
+	k_spinlock_key_t key;
 
-	spin_lock_irq(&ipc->lock, flags);
+	key = k_spin_lock_irq(&ipc->lock);
 
 #if CAVS_VERSION == CAVS_VERSION_1_5
 	uint32_t dipct;
@@ -128,7 +128,7 @@ static void ipc_irq_handler(void *arg)
 			  ipc_read(IPC_DIPCCTL) | IPC_DIPCCTL_IPCIDIE);
 	}
 
-	spin_unlock_irq(&ipc->lock, flags);
+	k_spin_unlock_irq(&ipc->lock, key);
 }
 
 #if CAVS_VERSION >= CAVS_VERSION_1_8

--- a/src/drivers/intel/haswell/ssp.c
+++ b/src/drivers/intel/haswell/ssp.c
@@ -44,8 +44,9 @@ static int ssp_set_config(struct dai *dai, struct ipc_config_dai *common_config,
 	uint32_t format;
 	bool inverted_frame = false;
 	int ret = 0;
+	k_spinlock_key_t key;
 
-	spin_lock(&dai->lock);
+	key = k_spin_lock(&dai->lock);
 
 	/* is playback/capture already running */
 	if (ssp->state[DAI_DIR_PLAYBACK] == COMP_STATE_ACTIVE ||
@@ -356,7 +357,7 @@ static int ssp_set_config(struct dai *dai, struct ipc_config_dai *common_config,
 	dai_info(dai, "ssp_set_config(), done");
 
 out:
-	spin_unlock(&dai->lock);
+	k_spin_unlock(&dai->lock, key);
 
 	return ret;
 }
@@ -397,8 +398,9 @@ static int ssp_get_hw_params(struct dai *dai,
 static void ssp_start(struct dai *dai, int direction)
 {
 	struct ssp_pdata *ssp = dai_get_drvdata(dai);
+	k_spinlock_key_t key;
 
-	spin_lock(&dai->lock);
+	key = k_spin_lock(&dai->lock);
 
 	dai_info(dai, "ssp_start()");
 
@@ -420,15 +422,16 @@ static void ssp_start(struct dai *dai, int direction)
 	/* enable port */
 	ssp->state[direction] = COMP_STATE_ACTIVE;
 
-	spin_unlock(&dai->lock);
+	k_spin_unlock(&dai->lock, key);
 }
 
 /* stop the SSP for either playback or capture */
 static void ssp_stop(struct dai *dai, int direction)
 {
 	struct ssp_pdata *ssp = dai_get_drvdata(dai);
+	k_spinlock_key_t key;
 
-	spin_lock(&dai->lock);
+	key = k_spin_lock(&dai->lock);
 
 	/* stop Rx if neeed */
 	if (direction == DAI_DIR_CAPTURE &&
@@ -457,7 +460,7 @@ static void ssp_stop(struct dai *dai, int direction)
 		dai_info(dai, "ssp_stop(), SSP port disabled");
 	}
 
-	spin_unlock(&dai->lock);
+	k_spin_unlock(&dai->lock, key);
 }
 
 static void ssp_pause(struct dai *dai, int direction)

--- a/src/drivers/intel/hda/hda-dma.c
+++ b/src/drivers/intel/hda/hda-dma.c
@@ -494,7 +494,7 @@ static int hda_dma_enable_unlock(struct dma_chan_data *channel)
 
 /* notify DMA to copy bytes */
 static int hda_dma_link_copy(struct dma_chan_data *channel, int bytes,
-			     uint32_t flags)
+			     k_spinlock_key_t key)
 {
 	return hda_dma_link_copy_ch(channel, bytes);
 }
@@ -534,7 +534,7 @@ static int hda_dma_host_copy(struct dma_chan_data *channel, int bytes,
 static struct dma_chan_data *hda_dma_channel_get(struct dma *dma,
 						 unsigned int channel)
 {
-	uint32_t flags;
+	k_spinlock_key_t key;
 
 	if (channel >= dma->plat_data.channels) {
 		tr_err(&hdma_tr, "hda-dmac: %d invalid channel %d",
@@ -542,7 +542,7 @@ static struct dma_chan_data *hda_dma_channel_get(struct dma *dma,
 		return NULL;
 	}
 
-	spin_lock_irq(&dma->lock, flags);
+	key = k_spin_lock_irq(&dma->lock);
 
 	tr_dbg(&hdma_tr, "hda-dmac: %d channel %d -> get", dma->plat_data.id, channel);
 
@@ -553,12 +553,12 @@ static struct dma_chan_data *hda_dma_channel_get(struct dma *dma,
 		atomic_add(&dma->num_channels_busy, 1);
 
 		/* return channel */
-		spin_unlock_irq(&dma->lock, flags);
+		k_spin_unlock_irq(&dma->lock, key);
 		return &dma->chan[channel];
 	}
 
 	/* DMAC has no free channels */
-	spin_unlock_irq(&dma->lock, flags);
+	k_spin_unlock_irq(&dma->lock, key);
 	tr_err(&hdma_tr, "hda-dmac: %d no free channel %d", dma->plat_data.id,
 	       channel);
 	return NULL;
@@ -583,11 +583,11 @@ static void hda_dma_channel_put_unlocked(struct dma_chan_data *channel)
 static void hda_dma_channel_put(struct dma_chan_data *channel)
 {
 	struct dma *dma = channel->dma;
-	uint32_t flags;
+	k_spinlock_key_t key;
 
-	spin_lock_irq(&dma->lock, flags);
+	key = k_spin_lock_irq(&dma->lock);
 	hda_dma_channel_put_unlocked(channel);
-	spin_unlock_irq(&dma->lock, flags);
+	k_spin_unlock_irq(&dma->lock, key);
 
 	atomic_sub(&dma->num_channels_busy, 1);
 }

--- a/src/drivers/intel/ssp/mn.c
+++ b/src/drivers/intel/ssp/mn.c
@@ -237,6 +237,7 @@ static inline int set_mclk_divider(uint16_t mclk_id, uint32_t mdivr_val)
 int mn_set_mclk(uint16_t mclk_id, uint32_t mclk_rate)
 {
 	struct mn *mn = mn_get();
+	k_spinlock_key_t key;
 	int ret = 0;
 
 	if (mclk_id >= DAI_NUM_SSP_MCLK) {
@@ -244,7 +245,7 @@ int mn_set_mclk(uint16_t mclk_id, uint32_t mclk_rate)
 		return -EINVAL;
 	}
 
-	spin_lock(&mn->lock);
+	key = k_spin_lock(&mn->lock);
 
 	if (is_mclk_source_in_use())
 		ret = check_current_mclk_source(mclk_id, mclk_rate);
@@ -265,7 +266,7 @@ int mn_set_mclk(uint16_t mclk_id, uint32_t mclk_rate)
 
 out:
 
-	spin_unlock(&mn->lock);
+	k_spin_unlock(&mn->lock, key);
 
 	return ret;
 }
@@ -282,8 +283,9 @@ void mn_release_mclk(uint32_t mclk_id)
 {
 	struct mn *mn = mn_get();
 	uint32_t mdivc;
+	k_spinlock_key_t key;
 
-	spin_lock(&mn->lock);
+	key = k_spin_lock(&mn->lock);
 
 	mn->mclk_sources_ref[mclk_id]--;
 
@@ -306,7 +308,7 @@ void mn_release_mclk(uint32_t mclk_id)
 
 		mn->mclk_source_clock = 0;
 	}
-	spin_unlock(&mn->lock);
+	k_spin_unlock(&mn->lock, key);
 }
 
 #if CONFIG_INTEL_MN
@@ -596,8 +598,9 @@ int mn_set_bclk(uint32_t dai_index, uint32_t bclk_rate,
 	uint32_t n = 1;
 	int ret = 0;
 	bool mn_in_use;
+	k_spinlock_key_t key;
 
-	spin_lock(&mn->lock);
+	key = k_spin_lock(&mn->lock);
 
 	mn->bclk_sources[dai_index] = MN_BCLK_SOURCE_NONE;
 
@@ -630,7 +633,7 @@ int mn_set_bclk(uint32_t dai_index, uint32_t bclk_rate,
 
 out:
 
-	spin_unlock(&mn->lock);
+	k_spin_unlock(&mn->lock, key);
 
 	return ret;
 }
@@ -639,25 +642,27 @@ void mn_release_bclk(uint32_t dai_index)
 {
 	struct mn *mn = mn_get();
 	bool mn_in_use;
+	k_spinlock_key_t key;
 
-	spin_lock(&mn->lock);
+	key = k_spin_lock(&mn->lock);
 	mn->bclk_sources[dai_index] = MN_BCLK_SOURCE_NONE;
 
 	mn_in_use = is_bclk_source_in_use(MN_BCLK_SOURCE_MN);
 	/* release the M/N clock source if not used */
 	if (!mn_in_use)
 		reset_bclk_mn_source();
-	spin_unlock(&mn->lock);
+	k_spin_unlock(&mn->lock, key);
 }
 
 void mn_reset_bclk_divider(uint32_t dai_index)
 {
 	struct mn *mn = mn_get();
+	k_spinlock_key_t key;
 
-	spin_lock(&mn->lock);
+	key = k_spin_lock(&mn->lock);
 	mn_reg_write(MN_MDIV_M_VAL(dai_index), dai_index, 1);
 	mn_reg_write(MN_MDIV_N_VAL(dai_index), dai_index, 1);
-	spin_unlock(&mn->lock);
+	k_spin_unlock(&mn->lock, key);
 }
 
 #endif

--- a/src/drivers/intel/ssp/ssp.c
+++ b/src/drivers/intel/ssp/ssp.c
@@ -232,6 +232,7 @@ static int ssp_set_config_tplg(struct dai *dai, struct ipc_config_dai *common_co
 	uint32_t active_tx_slots = 2;
 	uint32_t active_rx_slots = 2;
 	uint32_t sample_width = 2;
+	k_spinlock_key_t key;
 
 	bool inverted_bclk = false;
 	bool inverted_frame = false;
@@ -240,7 +241,7 @@ static int ssp_set_config_tplg(struct dai *dai, struct ipc_config_dai *common_co
 
 	int ret = 0;
 
-	spin_lock(&dai->lock);
+	key = k_spin_lock(&dai->lock);
 
 	/* ignore config if SSP is already configured */
 	if (ssp->state[DAI_DIR_PLAYBACK] > COMP_STATE_READY ||
@@ -765,7 +766,7 @@ clk:
 	}
 out:
 
-	spin_unlock(&dai->lock);
+	k_spin_unlock(&dai->lock, key);
 
 	return ret;
 }
@@ -934,8 +935,9 @@ static int ssp_get_hw_params(struct dai *dai,
 static void ssp_early_start(struct dai *dai, int direction)
 {
 	struct ssp_pdata *ssp = dai_get_drvdata(dai);
+	k_spinlock_key_t key;
 
-	spin_lock(&dai->lock);
+	key = k_spin_lock(&dai->lock);
 
 	/* request mclk/bclk */
 	ssp_pre_start(dai);
@@ -952,15 +954,16 @@ static void ssp_early_start(struct dai *dai, int direction)
 	}
 
 
-	spin_unlock(&dai->lock);
+	k_spin_unlock(&dai->lock, key);
 }
 
 /* start the SSP for either playback or capture */
 static void ssp_start(struct dai *dai, int direction)
 {
 	struct ssp_pdata *ssp = dai_get_drvdata(dai);
+	k_spinlock_key_t key;
 
-	spin_lock(&dai->lock);
+	key = k_spin_lock(&dai->lock);
 
 	dai_info(dai, "ssp_start()");
 
@@ -986,15 +989,16 @@ static void ssp_start(struct dai *dai, int direction)
 		break;
 	}
 
-	spin_unlock(&dai->lock);
+	k_spin_unlock(&dai->lock, key);
 }
 
 /* stop the SSP for either playback or capture */
 static void ssp_stop(struct dai *dai, int direction)
 {
 	struct ssp_pdata *ssp = dai_get_drvdata(dai);
+	k_spinlock_key_t key;
 
-	spin_lock(&dai->lock);
+	key = k_spin_lock(&dai->lock);
 
 	/*
 	 * Wait to get valid fifo status in clock consumer mode. TODO it's
@@ -1044,7 +1048,7 @@ static void ssp_stop(struct dai *dai, int direction)
 
 	ssp_post_stop(dai);
 
-	spin_unlock(&dai->lock);
+	k_spin_unlock(&dai->lock, key);
 }
 
 static void ssp_pause(struct dai *dai, int direction)

--- a/src/drivers/interrupt.c
+++ b/src/drivers/interrupt.c
@@ -53,14 +53,14 @@ int interrupt_cascade_register(const struct irq_cascade_tmpl *tmpl)
 {
 	struct cascade_root *root = cascade_root_get();
 	struct irq_cascade_desc **cascade;
-	unsigned long flags;
+	k_spinlock_key_t key;
 	unsigned int i;
 	int ret;
 
 	if (!tmpl->name || !tmpl->ops)
 		return -EINVAL;
 
-	spin_lock_irq(&root->lock, flags);
+	key = k_spin_lock_irq(&root->lock);
 
 	for (cascade = &root->list; *cascade;
 	     cascade = &(*cascade)->next) {
@@ -95,7 +95,7 @@ int interrupt_cascade_register(const struct irq_cascade_tmpl *tmpl)
 
 unlock:
 
-	spin_unlock_irq(&root->lock, flags);
+	k_spin_unlock_irq(&root->lock, key);
 
 	return ret;
 }
@@ -104,8 +104,8 @@ int interrupt_get_irq(unsigned int irq, const char *name)
 {
 	struct cascade_root *root = cascade_root_get();
 	struct irq_cascade_desc *cascade;
-	unsigned long flags;
 	int ret = -ENODEV;
+	k_spinlock_key_t key;
 
 	if (!name || name[0] == '\0')
 		return irq;
@@ -117,7 +117,7 @@ int interrupt_get_irq(unsigned int irq, const char *name)
 		return -EINVAL;
 	}
 
-	spin_lock_irq(&root->lock, flags);
+	key = k_spin_lock_irq(&root->lock);
 
 	for (cascade = root->list; cascade; cascade = cascade->next) {
 		/* .name is non-volatile */
@@ -129,7 +129,7 @@ int interrupt_get_irq(unsigned int irq, const char *name)
 	}
 
 
-	spin_unlock_irq(&root->lock, flags);
+	k_spin_unlock_irq(&root->lock, key);
 
 	return ret;
 }
@@ -138,12 +138,12 @@ struct irq_cascade_desc *interrupt_get_parent(uint32_t irq)
 {
 	struct cascade_root *root = cascade_root_get();
 	struct irq_cascade_desc *cascade, *c = NULL;
-	unsigned long flags;
+	k_spinlock_key_t key;
 
 	if (irq < PLATFORM_IRQ_HW_NUM)
 		return NULL;
 
-	spin_lock_irq(&root->lock, flags);
+	key = k_spin_lock_irq(&root->lock);
 
 	for (cascade = root->list; cascade; cascade = cascade->next) {
 		if (irq >= cascade->irq_base &&
@@ -155,7 +155,7 @@ struct irq_cascade_desc *interrupt_get_parent(uint32_t irq)
 	}
 
 
-	spin_unlock_irq(&root->lock, flags);
+	k_spin_unlock_irq(&root->lock, key);
 
 	return c;
 }
@@ -277,14 +277,14 @@ static uint32_t irq_enable_child(struct irq_cascade_desc *cascade, int irq,
 	struct irq_child *child;
 	unsigned int child_idx;
 	struct list_item *list;
-	unsigned long flags;
+	k_spinlock_key_t key;
 
 	/*
 	 * Locking is child to parent: when called recursively we are already
 	 * holding the child's lock and then also taking the parent's lock. The
 	 * same holds for the interrupt_(un)register() paths.
 	 */
-	spin_lock_irq(&cascade->lock, flags);
+	key = k_spin_lock_irq(&cascade->lock);
 
 	child = cascade->child + hw_irq;
 	child_idx = cascade->global_mask ? 0 : core;
@@ -311,7 +311,7 @@ static uint32_t irq_enable_child(struct irq_cascade_desc *cascade, int irq,
 	}
 
 
-	spin_unlock_irq(&cascade->lock, flags);
+	k_spin_unlock_irq(&cascade->lock, key);
 
 	return 0;
 }
@@ -324,9 +324,9 @@ static uint32_t irq_disable_child(struct irq_cascade_desc *cascade, int irq,
 	struct irq_child *child;
 	unsigned int child_idx;
 	struct list_item *list;
-	unsigned long flags;
+	k_spinlock_key_t key;
 
-	spin_lock_irq(&cascade->lock, flags);
+	key = k_spin_lock_irq(&cascade->lock);
 
 	child = cascade->child + hw_irq;
 	child_idx = cascade->global_mask ? 0 : core;
@@ -356,7 +356,7 @@ static uint32_t irq_disable_child(struct irq_cascade_desc *cascade, int irq,
 	}
 
 
-	spin_unlock_irq(&cascade->lock, flags);
+	k_spin_unlock_irq(&cascade->lock, key);
 
 	return 0;
 }
@@ -370,8 +370,7 @@ static int interrupt_register_internal(uint32_t irq, void (*handler)(void *arg),
 				       void *arg, struct irq_desc *desc)
 {
 	struct irq_cascade_desc *cascade;
-	/* Avoid a bogus compiler warning */
-	unsigned long flags = 0;
+	k_spinlock_key_t key;
 	int ret;
 
 	/* no parent means we are registering DSP internal IRQ */
@@ -389,9 +388,9 @@ static int interrupt_register_internal(uint32_t irq, void (*handler)(void *arg),
 #endif
 	}
 
-	spin_lock_irq(&cascade->lock, flags);
+	key = k_spin_lock_irq(&cascade->lock);
 	ret = irq_register_child(cascade, irq, handler, arg, desc);
-	spin_unlock_irq(&cascade->lock, flags);
+	k_spin_unlock_irq(&cascade->lock, key);
 
 	return ret;
 }
@@ -405,8 +404,7 @@ static void interrupt_unregister_internal(uint32_t irq, const void *arg,
 					  struct irq_desc *desc)
 {
 	struct irq_cascade_desc *cascade;
-	/* Avoid a bogus compiler warning */
-	unsigned long flags = 0;
+	k_spinlock_key_t key;
 
 	/* no parent means we are unregistering DSP internal IRQ */
 	cascade = interrupt_get_parent(irq);
@@ -424,9 +422,9 @@ static void interrupt_unregister_internal(uint32_t irq, const void *arg,
 		return;
 	}
 
-	spin_lock_irq(&cascade->lock, flags);
+	key = k_spin_lock_irq(&cascade->lock);
 	irq_unregister_child(cascade, irq, arg, desc);
-	spin_unlock_irq(&cascade->lock, flags);
+	k_spin_unlock_irq(&cascade->lock, key);
 }
 
 uint32_t interrupt_enable(uint32_t irq, void *arg)

--- a/src/drivers/mediatek/mt8195/interrupt.c
+++ b/src/drivers/mediatek/mt8195/interrupt.c
@@ -121,6 +121,7 @@ static inline void mtk_handle_irq(struct irq_cascade_desc *cascade,
 	int core = cpu_get_id();
 	struct list_item *clist;
 	struct irq_desc *child = NULL;
+	k_spinlock_key_t key;
 	int bit;
 	bool handled;
 
@@ -129,7 +130,7 @@ static inline void mtk_handle_irq(struct irq_cascade_desc *cascade,
 		handled = false;
 		status &= ~(1ull << bit);
 
-		spin_lock(&cascade->lock);
+		key = k_spin_lock(&cascade->lock);
 
 		list_for_item(clist, &cascade->child[bit].list) {
 			child = container_of(clist, struct irq_desc, irq_list);
@@ -140,7 +141,7 @@ static inline void mtk_handle_irq(struct irq_cascade_desc *cascade,
 			}
 		}
 
-		spin_unlock(&cascade->lock);
+		k_spin_unlock(&cascade->lock, key);
 
 		if (!handled) {
 			tr_err(&int_tr, "irq_handler(): not handled, bit %d", bit);

--- a/src/idc/idc.c
+++ b/src/idc/idc.c
@@ -323,15 +323,15 @@ static void idc_complete(void *data)
 	struct ipc *ipc = ipc_get();
 	struct idc *idc = data;
 	uint32_t type = iTS(idc->received_msg.header);
-	uint32_t flags;
+	k_spinlock_key_t key;
 
 	switch (type) {
 	case iTS(IDC_MSG_IPC):
 		/* Signal the host */
-		spin_lock_irq(&ipc->lock, flags);
+		key = k_spin_lock_irq(&ipc->lock);
 		ipc->task_mask &= ~IPC_TASK_SECONDARY_CORE;
 		ipc_complete_cmd(ipc);
-		spin_unlock_irq(&ipc->lock, flags);
+		k_spin_unlock_irq(&ipc->lock, key);
 	}
 }
 #endif

--- a/src/include/sof/ipc/msg.h
+++ b/src/include/sof/ipc/msg.h
@@ -72,15 +72,15 @@ static inline void ipc_msg_free(struct ipc_msg *msg)
 		return;
 
 	struct ipc *ipc = ipc_get();
-	uint32_t flags;
+	k_spinlock_key_t key;
 
-	spin_lock_irq(&ipc->lock, flags);
+	key = k_spin_lock_irq(&ipc->lock);
 
 	list_item_del(&msg->list);
 	rfree(msg->tx_data);
 	rfree(msg);
 
-	spin_unlock_irq(&ipc->lock, flags);
+	k_spin_unlock_irq(&ipc->lock, key);
 }
 
 /**

--- a/src/include/sof/spinlock.h
+++ b/src/include/sof/spinlock.h
@@ -19,6 +19,8 @@
 
 #include <stdint.h>
 
+typedef uint32_t k_spinlock_key_t;
+
 /*
  * Lock debugging provides a simple interface to debug deadlocks. The rmbox
  * trace output will show an output :-
@@ -38,7 +40,7 @@
  *     src/drivers/dw-dma.c:840:	spinlock_init(&dma->lock);
  *
  * grep -rn lock --include *.c | grep 439
- *     src/lib/alloc.c:439:	spin_lock_irq(&memmap.lock, flags);
+ *     src/lib/alloc.c:439:	k_spin_lock_irq(&memmap.lock, flags);
  *
  * Every lock entry and exit shows LcE and LcX in trace alongside the lock
  * line numbers in hex. e.g.
@@ -160,7 +162,7 @@ static inline void _spinlock_init(spinlock_t *lock, int line)
 #define spinlock_init(lock) _spinlock_init(lock, __LINE__)
 
 /* does nothing on UP systems */
-static inline void _spin_lock(spinlock_t *lock, int line)
+static inline k_spinlock_key_t _spin_lock(spinlock_t *lock, int line)
 {
 	spin_lock_dbg(line);
 #if CONFIG_DEBUG_LOCKS
@@ -171,16 +173,22 @@ static inline void _spin_lock(spinlock_t *lock, int line)
 #endif
 
 	/* spinlock has to be in a shared memory */
+	return 0;
 }
 
-#define spin_lock(lock) _spin_lock(lock, __LINE__)
+//#define spin_lock(lock) _spin_lock(lock, __LINE__)
+
+#define k_spin_lock(lock) _spin_lock(lock, __LINE__)
 
 /* disables all IRQ sources and takes lock - enter atomic context */
-uint32_t _spin_lock_irq(spinlock_t *lock);
+k_spinlock_key_t _k_spin_lock_irq(spinlock_t *lock);
 
-#define spin_lock_irq(lock, flags) (flags = _spin_lock_irq(lock))
+//#define k_spin_lock_irq(lock) _k_spin_lock_irq(lock)
 
-static inline void _spin_unlock(spinlock_t *lock, int line)
+#define k_spin_lock_irq(lock) _k_spin_lock_irq(lock)
+
+static inline void _spin_unlock(spinlock_t *lock, int line,
+				__attribute__((unused)) k_spinlock_key_t key)
 {
 	arch_spin_unlock(lock);
 #if CONFIG_DEBUG_LOCKS
@@ -190,11 +198,15 @@ static inline void _spin_unlock(spinlock_t *lock, int line)
 	/* spinlock has to be in a shared memory */
 }
 
-#define spin_unlock(lock) _spin_unlock(lock, __LINE__)
+//#define spin_unlock(lock) _spin_unlock(lock, __LINE__)
+
+#define k_spin_unlock(lock, key) _spin_unlock(lock, __LINE__, key)
 
 /* re-enables current IRQ sources and releases lock - leave atomic context */
-void _spin_unlock_irq(spinlock_t *lock, uint32_t flags, int line);
+void _k_spin_unlock_irq(spinlock_t *lock, k_spinlock_key_t key, int line);
 
-#define spin_unlock_irq(lock, flags) _spin_unlock_irq(lock, flags, __LINE__)
+//#define spin_unlock_irq(lock, flags) _k_spin_unlock_irq(lock, flags, __LINE__)
+
+#define k_spin_unlock_irq(lock, key) _k_spin_unlock_irq(lock, key, __LINE__)
 
 #endif /* __SOF_SPINLOCK_H__ */

--- a/src/ipc/ipc-common.c
+++ b/src/ipc/ipc-common.c
@@ -59,12 +59,12 @@ int ipc_process_on_core(uint32_t core, bool blocking)
 	 * will also reply to the host
 	 */
 	if (!blocking) {
-		uint32_t flags;
+		k_spinlock_key_t key;
 
 		ipc->core = core;
-		spin_lock_irq(&ipc->lock, flags);
+		key = k_spin_lock_irq(&ipc->lock);
 		ipc->task_mask |= IPC_TASK_SECONDARY_CORE;
-		spin_unlock_irq(&ipc->lock, flags);
+		k_spin_unlock_irq(&ipc->lock, key);
 	}
 
 	/* send IDC message */
@@ -176,9 +176,9 @@ void ipc_send_queued_msg(void)
 {
 	struct ipc *ipc = ipc_get();
 	struct ipc_msg *msg;
-	uint32_t flags;
+	k_spinlock_key_t key;
 
-	spin_lock_irq(&ipc->lock, flags);
+	key = k_spin_lock_irq(&ipc->lock);
 
 	/* any messages to send ? */
 	if (list_is_empty(&ipc->msg_list))
@@ -190,16 +190,16 @@ void ipc_send_queued_msg(void)
 	ipc_platform_send_msg(msg);
 
 out:
-	spin_unlock_irq(&ipc->lock, flags);
+	k_spin_unlock_irq(&ipc->lock, key);
 }
 
 void ipc_msg_send(struct ipc_msg *msg, void *data, bool high_priority)
 {
 	struct ipc *ipc = ipc_get();
-	uint32_t flags;
+	k_spinlock_key_t key;
 	int ret;
 
-	spin_lock_irq(&ipc->lock, flags);
+	key = k_spin_lock_irq(&ipc->lock);
 
 	/* copy mailbox data to message */
 	if (msg->tx_size > 0 && msg->tx_size < SOF_IPC_MSG_MAX_SIZE) {
@@ -223,7 +223,7 @@ void ipc_msg_send(struct ipc_msg *msg, void *data, bool high_priority)
 	}
 
 out:
-	spin_unlock_irq(&ipc->lock, flags);
+	k_spin_unlock_irq(&ipc->lock, key);
 }
 
 void ipc_schedule_process(struct ipc *ipc)
@@ -271,12 +271,12 @@ void ipc_complete_cmd(struct ipc *ipc)
 static void ipc_complete_task(void *data)
 {
 	struct ipc *ipc = data;
-	uint32_t flags;
+	k_spinlock_key_t key;
 
-	spin_lock_irq(&ipc->lock, flags);
+	key = k_spin_lock_irq(&ipc->lock);
 	ipc->task_mask &= ~IPC_TASK_INLINE;
 	ipc_complete_cmd(ipc);
-	spin_unlock_irq(&ipc->lock, flags);
+	k_spin_unlock_irq(&ipc->lock, key);
 }
 
 static enum task_state ipc_do_cmd(void *data)

--- a/src/ipc/ipc3/handler.c
+++ b/src/ipc/ipc3/handler.c
@@ -456,17 +456,17 @@ static int ipc_stream_trigger(uint32_t header)
 	 * synchronously.
 	 */
 	if (pipeline_is_timer_driven(pcm_dev->cd->pipeline)) {
-		uint32_t flags;
+		k_spinlock_key_t key;
 
-		spin_lock_irq(&ipc->lock, flags);
+		key = k_spin_lock_irq(&ipc->lock);
 		ipc->task_mask |= IPC_TASK_IN_THREAD;
-		spin_unlock_irq(&ipc->lock, flags);
+		k_spin_unlock_irq(&ipc->lock, key);
 
 		ret = pipeline_trigger(pcm_dev->cd->pipeline, pcm_dev->cd, cmd);
 		if (ret <= 0) {
-			spin_lock_irq(&ipc->lock, flags);
+			key = k_spin_lock_irq(&ipc->lock);
 			ipc->task_mask &= ~IPC_TASK_IN_THREAD;
-			spin_unlock_irq(&ipc->lock, flags);
+			k_spin_unlock_irq(&ipc->lock, key);
 		}
 	} else {
 		ret = pipeline_trigger_run(pcm_dev->cd->pipeline, pcm_dev->cd, cmd);

--- a/src/lib/clk.c
+++ b/src/lib/clk.c
@@ -53,7 +53,7 @@ void clock_set_freq(int clock, uint32_t hz)
 {
 	struct clock_info *clk_info = clocks_get() + clock;
 	uint32_t idx;
-	uint32_t flags;
+	k_spinlock_key_t key;
 
 	clk_notify_data.old_freq =
 		clk_info->freqs[clk_info->current_freq_idx].freq;
@@ -61,7 +61,7 @@ void clock_set_freq(int clock, uint32_t hz)
 		clk_info->freqs[clk_info->current_freq_idx].ticks_per_msec;
 
 	/* atomic context for changing clocks */
-	spin_lock_irq(&clk_info->lock, flags);
+	key = k_spin_lock_irq(&clk_info->lock);
 
 	/* get nearest frequency that is >= requested Hz */
 	idx = clock_get_nearest_freq_idx(clk_info->freqs, clk_info->freqs_num,
@@ -88,7 +88,7 @@ void clock_set_freq(int clock, uint32_t hz)
 		       clk_info->notification_mask, &clk_notify_data,
 		       sizeof(clk_notify_data));
 
-	spin_unlock_irq(&clk_info->lock, flags);
+	k_spin_unlock_irq(&clk_info->lock, key);
 }
 
 void clock_low_power_mode(int clock, bool enable)

--- a/src/lib/notifier.c
+++ b/src/lib/notifier.c
@@ -41,11 +41,12 @@ int notifier_register(void *receiver, void *caller, enum notify_id type,
 {
 	struct notify *notify = *arch_notify_get();
 	struct callback_handle *handle;
+	k_spinlock_key_t key;
 	int ret = 0;
 
 	assert(type >= NOTIFIER_ID_CPU_FREQ && type < NOTIFIER_ID_COUNT);
 
-	spin_lock(&notify->lock);
+	key = k_spin_lock(&notify->lock);
 
 	/* Find already registered event of this type */
 	if (flags & NOTIFIER_FLAG_AGGREGATE &&
@@ -74,7 +75,7 @@ int notifier_register(void *receiver, void *caller, enum notify_id type,
 	list_item_prepend(&handle->list, &notify->list[type]);
 
 out:
-	spin_unlock(&notify->lock);
+	k_spin_unlock(&notify->lock, key);
 	return ret;
 }
 
@@ -84,10 +85,11 @@ void notifier_unregister(void *receiver, void *caller, enum notify_id type)
 	struct list_item *wlist;
 	struct list_item *tlist;
 	struct callback_handle *handle;
+	k_spinlock_key_t key;
 
 	assert(type >= NOTIFIER_ID_CPU_FREQ && type < NOTIFIER_ID_COUNT);
 
-	spin_lock(&notify->lock);
+	key = k_spin_lock(&notify->lock);
 
 	/*
 	 * Unregister all matching callbacks
@@ -110,7 +112,7 @@ void notifier_unregister(void *receiver, void *caller, enum notify_id type)
 		}
 	}
 
-	spin_unlock(&notify->lock);
+	k_spin_unlock(&notify->lock, key);
 }
 
 void notifier_unregister_all(void *receiver, void *caller)

--- a/src/platform/intel/cavs/lib/clk.c
+++ b/src/platform/intel/cavs/lib/clk.c
@@ -84,7 +84,7 @@ static inline void select_cpu_clock(int freq_idx, bool release_unused)
 
 	/* lock clock for all cores */
 	for (i = 0; i < CONFIG_CORE_COUNT; i++)
-		spin_lock_irq(&clk_info[CLK_CPU(i)].lock, flags[i]);
+		flags[i] = k_spin_lock_irq(&clk_info[CLK_CPU(i)].lock);
 
 	/* change clock */
 	select_cpu_clock_hw(freq_idx, release_unused);
@@ -93,7 +93,7 @@ static inline void select_cpu_clock(int freq_idx, bool release_unused)
 
 	/* unlock clock for all cores */
 	for (i = CONFIG_CORE_COUNT - 1; i >= 0; i--)
-		spin_unlock_irq(&clk_info[CLK_CPU(i)].lock, flags[i]);
+		k_spin_unlock_irq(&clk_info[CLK_CPU(i)].lock, flags[i]);
 }
 
 /* LPRO_ONLY mode */
@@ -178,13 +178,13 @@ static void platform_clock_low_power_mode(int clock, bool enable)
 void platform_clock_on_waiti(void)
 {
 	struct pm_runtime_data *prd = pm_runtime_data_get();
-	uint32_t flags;
+	k_spinlock_key_t key;
 	int freq_idx;
 	int lowest_freq_idx;
 	bool pm_is_active;
 
 	/* hold the prd->lock for possible active_freq_idx switching */
-	spin_lock_irq(&prd->lock, flags);
+	key = k_spin_lock_irq(&prd->lock);
 
 	freq_idx = *cache_to_uncache(&active_freq_idx);
 	lowest_freq_idx = get_lowest_freq_idx(CLK_CPU(cpu_get_id()));
@@ -200,7 +200,7 @@ void platform_clock_on_waiti(void)
 			set_cpu_current_freq_idx(lowest_freq_idx, true);
 	}
 
-	spin_unlock_irq(&prd->lock, flags);
+	k_spin_unlock_irq(&prd->lock, key);
 
 	/* check if waiti HPRO->LPRO switching is needed */
 	pm_runtime_put(CORE_HP_CLK, cpu_get_id());
@@ -253,13 +253,13 @@ static void platform_clock_low_power_mode(int clock, bool enable)
 void platform_clock_on_waiti(void)
 {
 	struct pm_runtime_data *prd = pm_runtime_data_get();
-	uint32_t flags;
+	k_spinlock_key_t key;
 	int freq_idx;
 	int lowest_freq_idx;
 	bool pm_is_active;
 
 	/* hold the prd->lock for possible active_freq_idx switching */
-	spin_lock_irq(&prd->lock, flags);
+	key = k_spin_lock_irq(&prd->lock);
 
 	freq_idx = *cache_to_uncache(&active_freq_idx);
 	lowest_freq_idx = get_lowest_freq_idx(CLK_CPU(cpu_get_id()));
@@ -275,18 +275,18 @@ void platform_clock_on_waiti(void)
 			set_cpu_current_freq_idx(lowest_freq_idx, true);
 	}
 
-	spin_unlock_irq(&prd->lock, flags);
+	k_spin_unlock_irq(&prd->lock, key);
 }
 
 void platform_clock_on_wakeup(void)
 {
 	struct pm_runtime_data *prd = pm_runtime_data_get();
-	uint32_t flags;
+	k_spinlock_key_t key;
 	int current_idx;
 	int target_idx;
 
 	/* hold the prd->lock for possible active_freq_idx switching */
-	spin_lock_irq(&prd->lock, flags);
+	key = k_spin_lock(&prd->lock);
 
 	current_idx = get_current_freq_idx(CLK_CPU(cpu_get_id()));
 	target_idx = *cache_to_uncache(&active_freq_idx);
@@ -295,7 +295,7 @@ void platform_clock_on_wakeup(void)
 	if (current_idx != target_idx)
 		set_cpu_current_freq_idx(target_idx, true);
 
-	spin_unlock_irq(&prd->lock, flags);
+	k_spin_unlock(&prd->lock, key);
 }
 
 #endif

--- a/src/platform/intel/cavs/lib/pm_runtime.c
+++ b/src/platform/intel/cavs/lib/pm_runtime.c
@@ -54,13 +54,13 @@ static void cavs_pm_runtime_host_dma_l1_get(void)
 {
 	struct pm_runtime_data *prd = pm_runtime_data_get();
 	struct cavs_pm_runtime_data *pprd = prd->platform_data;
-	uint32_t flags;
+	k_spinlock_key_t key;
 
-	spin_lock_irq(&prd->lock, flags);
+	key = k_spin_lock_irq(&prd->lock);
 
 	pprd->host_dma_l1_sref++;
 
-	spin_unlock_irq(&prd->lock, flags);
+	k_spin_unlock_irq(&prd->lock, key);
 }
 
 /**
@@ -71,9 +71,9 @@ static inline void cavs_pm_runtime_host_dma_l1_put(void)
 {
 	struct pm_runtime_data *prd = pm_runtime_data_get();
 	struct cavs_pm_runtime_data *pprd = prd->platform_data;
-	uint32_t flags;
+	k_spinlock_key_t key;
 
-	spin_lock_irq(&prd->lock, flags);
+	key = k_spin_lock_irq(&prd->lock);
 
 	if (!--pprd->host_dma_l1_sref) {
 		shim_write(SHIM_SVCFG,
@@ -85,7 +85,7 @@ static inline void cavs_pm_runtime_host_dma_l1_put(void)
 			   shim_read(SHIM_SVCFG) & ~(SHIM_SVCFG_FORCE_L1_EXIT));
 	}
 
-	spin_unlock_irq(&prd->lock, flags);
+	k_spin_unlock_irq(&prd->lock, key);
 }
 
 static inline void cavs_pm_runtime_enable_dsp(bool enable)
@@ -369,9 +369,9 @@ static inline void cavs_pm_runtime_core_dis_hp_clk(uint32_t index)
 	int enabled_cores = cpu_enabled_cores();
 	struct pm_runtime_data *prd = pm_runtime_data_get();
 	struct cavs_pm_runtime_data *pprd = prd->platform_data;
-	uint32_t flags;
+	k_spinlock_key_t key;
 
-	spin_lock_irq(&prd->lock, flags);
+	key = k_spin_lock_irq(&prd->lock);
 
 	pprd->sleep_core_mask |= BIT(index);
 
@@ -381,21 +381,21 @@ static inline void cavs_pm_runtime_core_dis_hp_clk(uint32_t index)
 	if (all_active_cores_sleep)
 		clock_low_power_mode(CLK_CPU(index), true);
 
-	spin_unlock_irq(&prd->lock, flags);
+	k_spin_unlock_irq(&prd->lock, key);
 }
 
 static inline void cavs_pm_runtime_core_en_hp_clk(uint32_t index)
 {
 	struct pm_runtime_data *prd = pm_runtime_data_get();
 	struct cavs_pm_runtime_data *pprd = prd->platform_data;
-	uint32_t flags;
+	k_spinlock_key_t key;
 
-	spin_lock_irq(&prd->lock, flags);
+	key = k_spin_lock_irq(&prd->lock);
 
 	pprd->sleep_core_mask &= ~BIT(index);
 	clock_low_power_mode(CLK_CPU(index), false);
 
-	spin_unlock_irq(&prd->lock, flags);
+	k_spin_unlock_irq(&prd->lock, key);
 }
 
 static inline void cavs_pm_runtime_dis_dsp_pg(uint32_t index)
@@ -574,26 +574,26 @@ void platform_pm_runtime_prepare_d0ix_en(uint32_t index)
 {
 	struct pm_runtime_data *prd = pm_runtime_data_get();
 	struct cavs_pm_runtime_data *pprd = prd->platform_data;
-	uint32_t flags;
+	k_spinlock_key_t key;
 
-	spin_lock_irq(&prd->lock, flags);
+	key = k_spin_lock_irq(&prd->lock);
 
 	pprd->prepare_d0ix_core_mask |= BIT(index);
 
-	spin_unlock_irq(&prd->lock, flags);
+	k_spin_unlock_irq(&prd->lock, key);
 }
 
 void platform_pm_runtime_prepare_d0ix_dis(uint32_t index)
 {
 	struct pm_runtime_data *prd = pm_runtime_data_get();
 	struct cavs_pm_runtime_data *pprd = prd->platform_data;
-	uint32_t flags;
+	k_spinlock_key_t key;
 
-	spin_lock_irq(&prd->lock, flags);
+	key = k_spin_lock_irq(&prd->lock);
 
 	pprd->prepare_d0ix_core_mask &= ~BIT(index);
 
-	spin_unlock_irq(&prd->lock, flags);
+	k_spin_unlock_irq(&prd->lock, key);
 }
 
 int platform_pm_runtime_prepare_d0ix_is_req(uint32_t index)

--- a/src/schedule/zephyr.c
+++ b/src/schedule/zephyr.c
@@ -59,7 +59,7 @@ static void idc_handler(struct k_p4wq_work *work)
 	struct ipc *ipc = ipc_get();
 	struct idc_msg *msg = &zmsg->msg;
 	int payload = -1;
-	uint32_t flags;
+	k_spinlock_key_t key;
 
 	SOC_DCACHE_INVALIDATE(msg, sizeof(*msg));
 
@@ -81,10 +81,10 @@ static void idc_handler(struct k_p4wq_work *work)
 	case IDC_MSG_IPC:
 		idc_cmd(&idc->received_msg);
 		/* Signal the host */
-		spin_lock_irq(&ipc->lock, flags);
+		k_spin_lock_irq(&ipc->lock, flags);
 		ipc->task_mask &= ~IPC_TASK_SECONDARY_CORE;
 		ipc_complete_cmd(ipc);
-		spin_unlock_irq(&ipc->lock, flags);
+		k_spin_unlock_irq(&ipc->lock, flags);
 	}
 }
 

--- a/src/schedule/zephyr_domain.c
+++ b/src/schedule/zephyr_domain.c
@@ -132,7 +132,7 @@ static int zephyr_domain_register(struct ll_schedule_domain *domain,
 	struct zephyr_domain_thread *dt = zephyr_domain->domain_thread + core;
 	char thread_name[] = "ll_thread0";
 	k_tid_t thread;
-	uint32_t flags;
+	k_spinlock_key_t key;
 
 	tr_dbg(&ll_tr, "zephyr_domain_register()");
 
@@ -160,7 +160,7 @@ static int zephyr_domain_register(struct ll_schedule_domain *domain,
 
 	k_thread_start(thread);
 
-	spin_lock_irq(&domain->lock, flags);
+	k_spin_lock_irq(&domain->lock, flags);
 
 	if (!k_timer_user_data_get(&zephyr_domain->timer)) {
 		k_timeout_t start = {0};
@@ -173,7 +173,7 @@ static int zephyr_domain_register(struct ll_schedule_domain *domain,
 			k_timer_remaining_ticks(&zephyr_domain->timer);
 	}
 
-	spin_unlock_irq(&domain->lock, flags);
+	k_spin_unlock_irq(&domain->lock, flags);
 
 	tr_info(&ll_tr, "zephyr_domain_register domain->type %d domain->clk %d domain->ticks_per_ms %d period %d",
 		domain->type, domain->clk, domain->ticks_per_ms, (uint32_t)LL_TIMER_PERIOD_US);
@@ -186,7 +186,7 @@ static int zephyr_domain_unregister(struct ll_schedule_domain *domain,
 {
 	struct zephyr_domain *zephyr_domain = ll_sch_domain_get_pdata(domain);
 	int core = cpu_get_id();
-	uint32_t flags;
+	k_spinlock_key_t key;
 
 	tr_dbg(&ll_tr, "zephyr_domain_unregister()");
 
@@ -194,7 +194,7 @@ static int zephyr_domain_unregister(struct ll_schedule_domain *domain,
 	if (num_tasks)
 		return 0;
 
-	spin_lock_irq(&domain->lock, flags);
+	k_spin_lock_irq(&domain->lock, flags);
 
 	if (!atomic_read(&domain->total_num_tasks)) {
 		k_timer_stop(&zephyr_domain->timer);
@@ -203,7 +203,7 @@ static int zephyr_domain_unregister(struct ll_schedule_domain *domain,
 
 	zephyr_domain->domain_thread[core].handler = NULL;
 
-	spin_unlock_irq(&domain->lock, flags);
+	k_spin_unlock_irq(&domain->lock, flags);
 
 	tr_info(&ll_tr, "zephyr_domain_unregister domain->type %d domain->clk %d",
 		domain->type, domain->clk);

--- a/src/schedule/zephyr_ll.c
+++ b/src/schedule/zephyr_ll.c
@@ -173,7 +173,7 @@ static void zephyr_ll_run(void *data)
 	struct zephyr_ll *sch = data;
 	struct task *task;
 	struct list_item *list;
-	uint32_t flags;
+	k_spinlock_key_t key;
 
 	zephyr_ll_lock(sch, &flags);
 
@@ -278,7 +278,7 @@ static int zephyr_ll_task_schedule_common(struct zephyr_ll *sch, struct task *ta
 	struct task *task_iter;
 	struct list_item *list;
 	uint64_t delay = period ? period : start;
-	uint32_t flags;
+	k_spinlock_key_t key;
 	int ret;
 
 	zephyr_ll_assert_core(sch);
@@ -382,7 +382,7 @@ static int zephyr_ll_task_schedule_after(void *data, struct task *task, uint64_t
 static int zephyr_ll_task_free(void *data, struct task *task)
 {
 	struct zephyr_ll *sch = data;
-	uint32_t flags;
+	k_spinlock_key_t key;
 	struct zephyr_ll_pdata *pdata = task->priv_data;
 	bool must_wait, on_list = true;
 
@@ -446,7 +446,7 @@ static int zephyr_ll_task_free(void *data, struct task *task)
 static int zephyr_ll_task_cancel(void *data, struct task *task)
 {
 	struct zephyr_ll *sch = data;
-	uint32_t flags;
+	k_spinlock_key_t key;
 
 	zephyr_ll_assert_core(sch);
 

--- a/src/spinlock.c
+++ b/src/spinlock.c
@@ -22,15 +22,15 @@ DECLARE_TR_CTX(sl_tr, SOF_UUID(spinlock_uuid), LOG_LEVEL_INFO);
 
 #endif
 
-uint32_t _spin_lock_irq(spinlock_t *lock)
+k_spinlock_key_t _k_spin_lock_irq(spinlock_t *lock)
 {
-	uint32_t flags;
+	k_spinlock_key_t flags;
 
 	flags = interrupt_global_disable();
 #if CONFIG_DEBUG_LOCKS
 	lock_dbg_atomic++;
 #endif
-	spin_lock(lock);
+	k_spin_lock(lock);
 #if CONFIG_DEBUG_LOCKS
 	if (lock_dbg_atomic < DBG_LOCK_USERS)
 		lock_dbg_user[lock_dbg_atomic - 1] = (lock)->user;
@@ -38,9 +38,9 @@ uint32_t _spin_lock_irq(spinlock_t *lock)
 	return flags;
 }
 
-void _spin_unlock_irq(spinlock_t *lock, uint32_t flags, int line)
+void _k_spin_unlock_irq(spinlock_t *lock, uint32_t flags, int line)
 {
-	_spin_unlock(lock, line);
+	_spin_unlock(lock, line, 0);
 #if CONFIG_DEBUG_LOCKS
 	lock_dbg_atomic--;
 #endif

--- a/src/trace/trace.c
+++ b/src/trace/trace.c
@@ -456,9 +456,9 @@ void trace_flush_dma_to_mbox(void)
 {
 	struct trace *trace = trace_get();
 	volatile uint64_t *t;
-	uint32_t flags;
+	k_spinlock_key_t key;
 
-	spin_lock_irq(&trace->lock, flags);
+	key = k_spin_lock_irq(&trace->lock);
 
 	/* get mailbox position */
 	t = (volatile uint64_t *)(MAILBOX_TRACE_BASE + trace->pos);
@@ -466,33 +466,33 @@ void trace_flush_dma_to_mbox(void)
 	/* flush dma trace messages */
 	dma_trace_flush((void *)t);
 
-	spin_unlock_irq(&trace->lock, flags);
+	k_spin_unlock_irq(&trace->lock, key);
 }
 
 void trace_on(void)
 {
 	struct trace *trace = trace_get();
-	uint32_t flags;
+	k_spinlock_key_t key;
 
-	spin_lock_irq(&trace->lock, flags);
+	key = k_spin_lock_irq(&trace->lock);
 
 	trace->enable = 1;
 	dma_trace_on();
 
-	spin_unlock_irq(&trace->lock, flags);
+	k_spin_unlock_irq(&trace->lock, key);
 }
 
 void trace_off(void)
 {
 	struct trace *trace = trace_get();
-	uint32_t flags;
+	k_spinlock_key_t key;
 
-	spin_lock_irq(&trace->lock, flags);
+	key = k_spin_lock_irq(&trace->lock);
 
 	trace->enable = 0;
 	dma_trace_off();
 
-	spin_unlock_irq(&trace->lock, flags);
+	k_spin_unlock_irq(&trace->lock, key);
 }
 
 void trace_init(struct sof *sof)
@@ -536,11 +536,11 @@ static void mtrace_dict_entry_vl(bool atomic_context, uint32_t dict_entry_addres
 		mtrace_event(packet, MESSAGE_SIZE(n_args));
 	} else {
 		struct trace * const trace = trace_get();
-		uint32_t saved_flags;
+		k_spinlock_key_t key;
 
-		spin_lock_irq(&trace->lock, saved_flags);
+		key = k_spin_lock_irq(&trace->lock);
 		mtrace_event(packet, MESSAGE_SIZE(n_args));
-		spin_unlock_irq(&trace->lock, saved_flags);
+		k_spin_unlock_irq(&trace->lock, key);
 	}
 }
 

--- a/test/cmocka/src/common_mocks.c
+++ b/test/cmocka/src/common_mocks.c
@@ -146,14 +146,14 @@ volatile void * WEAK task_context_get(void)
 	return NULL;
 }
 
-uint32_t WEAK _spin_lock_irq(spinlock_t *lock)
+uint32_t WEAK _k_spin_lock_irq(spinlock_t *lock)
 {
 	(void)lock;
 
 	return 0;
 }
 
-void WEAK _spin_unlock_irq(spinlock_t *lock, uint32_t flags, int line)
+void WEAK _k_spin_unlock_irq(spinlock_t *lock, uint32_t flags, int line)
 {
 	(void)lock;
 	(void)flags;


### PR DESCRIPTION
Align the SOF spinlock API to align with Zephyr spinlock API
no functional changes to xtos logic.

This is first part of work for spinlock Zephyr alignment, subsequent
updates will align headers and associated splinlock dependecies.

Signed-off-by: Liam Girdwood <liam.r.girdwood@linux.intel.com>