### PR TITLE
pipeline: improve timestamp failure reporting

### DIFF
--- a/src/audio/pipeline/pipeline-stream.c
+++ b/src/audio/pipeline/pipeline-stream.c
@@ -459,7 +459,8 @@ static int pipeline_comp_timestamp(struct comp_dev *current,
 	struct pipeline_data *ppl_data = ctx->comp_data;
 
 	if (!comp_is_active(current)) {
-		pipe_dbg(current->pipeline, "pipeline_comp_timestamp(), current is not active");
+		comp_warn(current, "pipeline_comp_timestamp(), current in wrong state %u",
+			  current->state);
 		return 0;
 	}
 
@@ -492,7 +493,7 @@ void pipeline_get_timestamp(struct pipeline *p, struct comp_dev *host,
 
 	if (walk_ctx.comp_func(host, NULL, &walk_ctx, host->direction) !=
 	    PPL_STATUS_PATH_STOP)
-		pipe_warn(p, "pipeline_get_timestamp(): DAI position update failed");
+		pipe_dbg(p, "pipeline_get_timestamp(): DAI position update failed");
 
 	/* set timestamp resolution */
 	posn->timestamp_ns = p->period * 1000;


### PR DESCRIPTION
When pipeline_get_timestamp() fails it prints a warning message without context. Replace it with a more informative one.
