### PR TITLE
topology2: cavs-nocodec: add audio format tokens

### DIFF
--- a/tools/topology/topology2/cavs/CMakeLists.txt
+++ b/tools/topology/topology2/cavs/CMakeLists.txt
@@ -14,6 +14,8 @@ set(TPLGS
 "cavs-passthrough-hdmi\;cavs-mixin-mixout-hda\;HDA_CONFIG=mix"
 # CAVS SDW topology with passthrough pipelines
 "cavs-sdw\;cavs-sdw"
+# CAVS SSP topology with passthrough pipelines
+"cavs-nocodec\;cavs-nocodec"
 )
 
 # This will override the topology1 binaries with topology2 binaries

--- a/tools/topology/topology2/cavs/cavs-nocodec.conf
+++ b/tools/topology/topology2/cavs/cavs-nocodec.conf
@@ -1,21 +1,31 @@
-<include/common/vendor-token.conf>
-<include/common/tokens.conf>
-<include/common/manifest.conf>
-<include/common/pcm.conf>
-<include/common/pcm_caps.conf>
-<include/common/fe_dai.conf>
-<include/common/route.conf>
-<include/components/host.conf>
-<include/components/dai.conf>
-<include/components/pipeline.conf>
-<include/components/copier.conf>
-<include/dais/ssp.conf>
-<include/dais/dmic.conf>
-<include/dais/pdm_config.conf>
-<include/common/data.conf>
-<include/dais/hw_config.conf>
-<include/pipelines/cavs/passthrough-playback.conf>
-<include/pipelines/cavs/passthrough-capture.conf>
+<searchdir:cavs>
+<searchdir:include>
+<searchdir:include/common>
+<searchdir:include/components>
+<searchdir:include/dais>
+<searchdir:include/pipelines/cavs>
+
+<vendor-token.conf>
+<manifest.conf>
+<pdm_config.conf>
+<tokens.conf>
+<virtual.conf>
+<passthrough-playback.conf>
+<passthrough-capture.conf>
+<data.conf>
+<pcm.conf>
+<pcm_caps.conf>
+<fe_dai.conf>
+<ssp.conf>
+<dmic.conf>
+<hw_config.conf>
+<manifest.conf>
+<route.conf>
+<cavs/common_definitions.conf>
+<copier.conf>
+<pipeline.conf>
+<dai.conf>
+<host.conf>
 
 #
 # List of all DAIs
@@ -49,6 +59,22 @@ Object.Dai {
 			period_sink_count 0
 			period_source_count 2
 			format s16le
+			node_type $I2S_LINK_OUTPUT_CLASS
+			num_audio_formats 2
+			# 16-bit 48KHz 2ch
+			Object.Base.audio_format.1 {
+				in_bit_depth		32
+				out_bit_depth		32
+				dma_buffer_size "$[$obs * 2]"
+			}
+			# 32-bit 48KHz 2ch
+			Object.Base.audio_format.2 {
+				in_bit_depth		32
+				in_valid_bit_depth	32
+				out_bit_depth		32
+				out_valid_bit_depth	32
+				dma_buffer_size "$[$obs * 2]"
+			}
 		}
 
 		Object.Widget.copier."1" {
@@ -62,6 +88,22 @@ Object.Dai {
 			period_sink_count 2
 			period_source_count 0
 			format s16le
+			node_type $I2S_LINK_INPUT_CLASS
+			num_audio_formats 2
+			# 16-bit 48KHz 2ch
+			Object.Base.audio_format.1 {
+				in_bit_depth		32
+				out_bit_depth		32
+				dma_buffer_size "$[$ibs * 2]"
+			}
+			# 32-bit 48KHz 2ch
+			Object.Base.audio_format.2 {
+				in_bit_depth		32
+				in_valid_bit_depth	32
+				out_bit_depth		32
+				out_valid_bit_depth	32
+				dma_buffer_size "$[$ibs * 2]"
+			}
 		}
 	}
 	SSP."1" {
@@ -91,6 +133,22 @@ Object.Dai {
 			period_sink_count 0
 			period_source_count 2
 			format s16le
+			node_type $I2S_LINK_OUTPUT_CLASS
+			num_audio_formats 2
+			# 16-bit 48KHz 2ch
+			Object.Base.audio_format.1 {
+				in_bit_depth		32
+				out_bit_depth		32
+				dma_buffer_size "$[$obs * 2]"
+			}
+			# 32-bit 48KHz 2ch
+			Object.Base.audio_format.2 {
+				in_bit_depth		32
+				in_valid_bit_depth	32
+				out_bit_depth		32
+				out_valid_bit_depth	32
+				dma_buffer_size "$[$obs * 2]"
+			}
 		}
 
 		Object.Widget.copier."1" {
@@ -104,6 +162,22 @@ Object.Dai {
 			period_sink_count 2
 			period_source_count 0
 			format s16le
+			node_type $I2S_LINK_INPUT_CLASS
+			num_audio_formats 2
+			# 16-bit 48KHz 2ch
+			Object.Base.audio_format.1 {
+				in_bit_depth		32
+				out_bit_depth		32
+				dma_buffer_size "$[$ibs * 2]"
+			}
+			# 32-bit 48KHz 2ch
+			Object.Base.audio_format.2 {
+				in_bit_depth		32
+				in_valid_bit_depth	32
+				out_bit_depth		32
+				out_valid_bit_depth	32
+				dma_buffer_size "$[$ibs * 2]"
+			}
 		}
 	}
 	SSP."2" {
@@ -133,6 +207,22 @@ Object.Dai {
 			period_sink_count 0
 			period_source_count 2
 			format s16le
+			node_type $I2S_LINK_OUTPUT_CLASS
+			num_audio_formats 2
+			# 16-bit 48KHz 2ch
+			Object.Base.audio_format.1 {
+				in_bit_depth		32
+				out_bit_depth		32
+				dma_buffer_size "$[$obs * 2]"
+			}
+			# 32-bit 48KHz 2ch
+			Object.Base.audio_format.2 {
+				in_bit_depth		32
+				in_valid_bit_depth	32
+				out_bit_depth		32
+				out_valid_bit_depth	32
+				dma_buffer_size "$[$obs * 2]"
+			}
 		}
 
 		Object.Widget.copier."1" {
@@ -146,6 +236,22 @@ Object.Dai {
 			period_sink_count 2
 			period_source_count 0
 			format s16le
+			node_type $I2S_LINK_INPUT_CLASS
+			num_audio_formats 2
+			# 16-bit 48KHz 2ch
+			Object.Base.audio_format.1 {
+				in_bit_depth		32
+				out_bit_depth		32
+				dma_buffer_size "$[$ibs * 2]"
+			}
+			# 32-bit 48KHz 2ch
+			Object.Base.audio_format.2 {
+				in_bit_depth		32
+				in_valid_bit_depth	32
+				out_bit_depth		32
+				out_valid_bit_depth	32
+				dma_buffer_size "$[$ibs * 2]"
+			}
 		}
 	}
 	DMIC."0" {
@@ -188,6 +294,22 @@ Object.Dai {
 			period_sink_count 2
 			period_source_count 0
 			format s16le
+			node_type $DMIC_LINK_INPUT_CLASS
+			num_audio_formats 2
+			# 16-bit 48KHz 2ch
+			Object.Base.audio_format.1 {
+				in_bit_depth		32
+				out_bit_depth		32
+				dma_buffer_size "$[$ibs * 2]"
+			}
+			# 32-bit 48KHz 2ch
+			Object.Base.audio_format.2 {
+				in_bit_depth		32
+				in_valid_bit_depth	32
+				out_bit_depth		32
+				out_valid_bit_depth	32
+				dma_buffer_size "$[$ibs * 2]"
+			}
 		}
 
 		# PDM controller config
@@ -210,6 +332,12 @@ Object.Pipeline {
 		Object.Widget.pipeline.1.stream_name	"copier.SSP.1.0"
 
 		Object.Widget.copier.1.stream_name	"Passthrough Playback 0"
+
+		Object.Widget.copier.1.Object.Base.audio_format.1 {
+			# 16 -> 32 bits conversion is done here,
+			# so out_bit_depth is 32 (and in_bit_depth is 16).
+			out_bit_depth	32
+		}
 	}
 
 	passthrough-capture."2" {
@@ -219,6 +347,12 @@ Object.Pipeline {
 		Object.Widget.pipeline.1.stream_name	"copier.SSP.2.1"
 
 		Object.Widget.copier.1.stream_name	"Passthrough Capture 0"
+
+		Object.Widget.copier.1.Object.Base.audio_format.1 {
+			# 32 -> 16 bits conversion is done here,
+			# so in_bit_depth is 32 (and out_bit_depth is 16).
+			in_bit_depth	32
+		}
 	}
 
 	passthrough-playback."3" {
@@ -228,6 +362,12 @@ Object.Pipeline {
 		Object.Widget.pipeline.1.stream_name	"copier.SSP.3.0"
 
 		Object.Widget.copier.1.stream_name	"Passthrough Playback 1"
+
+		Object.Widget.copier.1.Object.Base.audio_format.1 {
+			# 16 -> 32 bits conversion is done here,
+			# so out_bit_depth is 32 (and in_bit_depth is 16).
+			out_bit_depth	32
+		}
 	}
 
 	passthrough-capture."4" {
@@ -237,6 +377,12 @@ Object.Pipeline {
 		Object.Widget.pipeline.1.stream_name	"copier.SSP.4.1"
 
 		Object.Widget.copier.1.stream_name	"Passthrough Capture 1"
+
+		Object.Widget.copier.1.Object.Base.audio_format.1 {
+			# 32 -> 16 bits conversion is done here,
+			# so in_bit_depth is 32 (and out_bit_depth is 16).
+			in_bit_depth	32
+		}
 	}
 
 	passthrough-playback."5" {
@@ -246,6 +392,12 @@ Object.Pipeline {
 		Object.Widget.pipeline.1.stream_name	"copier.SSP.5.0"
 
 		Object.Widget.copier.1.stream_name	"Passthrough Playback 2"
+
+		Object.Widget.copier.1.Object.Base.audio_format.1 {
+			# 16 -> 32 bits conversion is done here,
+			# so out_bit_depth is 32 (and in_bit_depth is 16).
+			out_bit_depth	32
+		}
 	}
 
 	passthrough-capture."6" {
@@ -255,6 +407,12 @@ Object.Pipeline {
 		Object.Widget.pipeline.1.stream_name	"copier.SSP.6.1"
 
 		Object.Widget.copier.1.stream_name	"Passthrough Capture 2"
+
+		Object.Widget.copier.1.Object.Base.audio_format.1 {
+			# 32 -> 16 bits conversion is done here,
+			# so in_bit_depth is 32 (and out_bit_depth is 16).
+			in_bit_depth	32
+		}
 	}
 
 	passthrough-capture."7" {
@@ -264,6 +422,12 @@ Object.Pipeline {
 		Object.Widget.pipeline.1.stream_name	"copier.DMIC.7.1"
 
 		Object.Widget.copier.1.stream_name	"Passthrough Capture 3"
+
+		Object.Widget.copier.1.Object.Base.audio_format.1 {
+			# 32 -> 16 bits conversion is done here,
+			# so in_bit_depth is 32 (and out_bit_depth is 16).
+			in_bit_depth	32
+		}
 	}
 }
 


### PR DESCRIPTION
Add audio format tokens for I2S + DMIC.

Signed-off-by: Bard Liao <yung-chuan.liao@linux.intel.com>