### PR TITLE
ipc4: add pcm conversion function for new format pattern

### DIFF
--- a/src/audio/Kconfig
+++ b/src/audio/Kconfig
@@ -531,6 +531,13 @@ config PCM_CONVERTER_FORMAT_S24_C32_AND_S24_C24
 	  Support conversion between 24 bit valid sample size in 32 bit container
 	  and 24 bit valid sample size in 24 bit container
 
+config PCM_CONVERTER_FORMAT_S16_C32_AND_S16_C32
+	bool "Support S16C32 <-> S16C32"
+	default n
+	help
+	  Support one-to-one copying conversion for 16 bit valid sample size in
+	  32 bit container
+
 config PCM_CONVERTER_FORMAT_CONVERT_HIFI3
 	bool "HIFI3 optimized conversion"
 	default y

--- a/src/audio/pcm_converter/pcm_converter_generic.c
+++ b/src/audio/pcm_converter/pcm_converter_generic.c
@@ -827,6 +827,10 @@ const struct pcm_func_vc_map pcm_func_vc_map[] = {
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S24_3LE,
 		SOF_IPC_FRAME_S24_3LE, ipc4_gtw_link, pcm_convert_s24_c32_to_s24_c24_link_gtw },
 #endif
+#if CONFIG_PCM_CONVERTER_FORMAT_S16_C32_AND_S16_C32
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S32_LE,
+		SOF_IPC_FRAME_S16_LE, ipc4_gtw_all, audio_stream_copy },
+#endif
 };
 
 const size_t pcm_func_vc_count = ARRAY_SIZE(pcm_func_vc_map);


### PR DESCRIPTION
In nocodec ipc4 test we have a new format
conversion : 32 bits container 16 bits valid sample bit
to itself. Just copy the source buffer to sink buffer.

Signed-off-by: Rander Wang <rander.wang@intel.com>