### PR TITLE
RFC: Preparation to dynamically setup codec_id for codec_adapter

### DIFF
--- a/src/audio/codec_adapter/codec/cadence.c
+++ b/src/audio/codec_adapter/codec/cadence.c
@@ -124,12 +124,17 @@ static int cadence_codec_resolve_api(struct comp_dev *dev, uint32_t api_id)
 
 static int cadence_codec_post_init(struct comp_dev *dev)
 {
+	uint32_t api_id = CODEC_GET_API_ID(DEFAULT_CODEC_ID);
 	struct module_data *codec = comp_get_module_data(dev);
 	struct cadence_codec_data *cd = codec->private;
 	uint32_t obj_size;
 	int ret;
 
 	comp_dbg(dev, "cadence_codec_post_init() start");
+
+	ret = cadence_codec_resolve_api(dev, api_id);
+	if (ret < 0)
+		return ret;
 
 	/* Obtain codec name */
 	API_CALL(cd, XA_API_CMD_GET_LIB_ID_STRINGS,
@@ -172,7 +177,6 @@ static int cadence_codec_init(struct comp_dev *dev)
 	int ret;
 	struct module_data *codec = comp_get_module_data(dev);
 	struct cadence_codec_data *cd = NULL;
-	uint32_t api_id = CODEC_GET_API_ID(DEFAULT_CODEC_ID);
 
 	comp_dbg(dev, "cadence_codec_init() start");
 
@@ -188,10 +192,6 @@ static int cadence_codec_init(struct comp_dev *dev)
 	cd->mem_tabs = NULL;
 	cd->api = NULL;
 	cd->setup_cfg.avail = false;
-
-	ret = cadence_codec_resolve_api(dev, api_id);
-	if (ret < 0)
-		goto free;
 
 	/* copy the setup config only for the first init */
 	if (codec->state == MODULE_DISABLED && codec->cfg.avail) {

--- a/src/audio/codec_adapter/codec/cadence.c
+++ b/src/audio/codec_adapter/codec/cadence.c
@@ -216,16 +216,9 @@ static int cadence_codec_init(struct comp_dev *dev)
 		setup_cfg->avail = true;
 	}
 
-	ret = cadence_codec_post_init(dev);
-	if (ret < 0)
-		goto free;
-
 	comp_dbg(dev, "cadence_codec_init() done");
 
 	return 0;
-free:
-	rfree(cd);
-	return ret;
 }
 
 static int cadence_codec_apply_config(struct comp_dev *dev)
@@ -455,6 +448,13 @@ static int cadence_codec_prepare(struct comp_dev *dev)
 	struct cadence_codec_data *cd = codec->private;
 
 	comp_dbg(dev, "cadence_codec_prepare() start");
+
+	ret = cadence_codec_post_init(dev);
+	if (ret < 0) {
+		comp_err(dev, "cadence_codec_prepare() error %x: failed post init",
+			 ret);
+		return ret;
+	}
 
 	ret = cadence_codec_apply_config(dev);
 	if (ret) {

--- a/src/audio/codec_adapter/codec/cadence.c
+++ b/src/audio/codec_adapter/codec/cadence.c
@@ -94,12 +94,56 @@ static struct cadence_api cadence_api_table[] = {
 #endif
 };
 
+static int cadence_codec_post_init(struct comp_dev *dev)
+{
+	struct module_data *codec = comp_get_module_data(dev);
+	struct cadence_codec_data *cd = codec->private;
+	uint32_t obj_size;
+	int ret;
+
+	comp_dbg(dev, "cadence_codec_post_init() start");
+
+	/* Obtain codec name */
+	API_CALL(cd, XA_API_CMD_GET_LIB_ID_STRINGS,
+		 XA_CMD_TYPE_LIB_NAME, cd->name, ret);
+	if (ret != LIB_NO_ERROR) {
+		comp_err(dev, "cadence_codec_post_init() error %x: failed to get lib name", ret);
+		return ret;
+	}
+
+	/* Get codec object size */
+	API_CALL(cd, XA_API_CMD_GET_API_SIZE, 0, &obj_size, ret);
+	if (ret != LIB_NO_ERROR) {
+		comp_err(dev, "cadence_codec_post_init() error %x: failed to get lib object size",
+			 ret);
+		return ret;
+	}
+	/* Allocate space for codec object */
+	cd->self = rballoc(0, SOF_MEM_CAPS_RAM, obj_size);
+	if (!cd->self) {
+		comp_err(dev, "cadence_codec_post_init(): failed to allocate space for lib object");
+		return -ENOMEM;
+	}
+
+	comp_dbg(dev, "cadence_codec_post_init(): allocated %d bytes for lib object", obj_size);
+
+	/* Set all params to their default values */
+	API_CALL(cd, XA_API_CMD_INIT, XA_CMD_TYPE_INIT_API_PRE_CONFIG_PARAMS, NULL, ret);
+	if (ret != LIB_NO_ERROR) {
+		rfree(cd->self);
+		return ret;
+	}
+
+	comp_dbg(dev, "cadence_codec_post_init() done");
+
+	return 0;
+}
+
 static int cadence_codec_init(struct comp_dev *dev)
 {
 	int ret;
 	struct module_data *codec = comp_get_module_data(dev);
 	struct cadence_codec_data *cd = NULL;
-	uint32_t obj_size;
 	uint32_t no_of_api = ARRAY_SIZE(cadence_api_table);
 	uint32_t api_id = CODEC_GET_API_ID(DEFAULT_CODEC_ID);
 	uint32_t i;
@@ -160,38 +204,9 @@ static int cadence_codec_init(struct comp_dev *dev)
 		setup_cfg->avail = true;
 	}
 
-	/* Obtain codec name */
-	API_CALL(cd, XA_API_CMD_GET_LIB_ID_STRINGS,
-		 XA_CMD_TYPE_LIB_NAME, cd->name, ret);
-	if (ret != LIB_NO_ERROR) {
-		comp_err(dev, "cadence_codec_init() error %x: failed to get lib name",
-			 ret);
+	ret = cadence_codec_post_init(dev);
+	if (ret < 0)
 		goto free;
-	}
-	/* Get codec object size */
-	API_CALL(cd, XA_API_CMD_GET_API_SIZE, 0, &obj_size, ret);
-	if (ret != LIB_NO_ERROR) {
-		comp_err(dev, "cadence_codec_init() error %x: failed to get lib object size",
-			 ret);
-		goto free;
-	}
-	/* Allocate space for codec object */
-	cd->self = rballoc(0, SOF_MEM_CAPS_RAM, obj_size);
-	if (!cd->self) {
-		comp_err(dev, "cadence_codec_init(): failed to allocate space for lib object");
-		ret = -ENOMEM;
-		goto free;
-	}
-
-	comp_dbg(dev, "cadence_codec_init(): allocated %d bytes for lib object", obj_size);
-
-	/* Set all params to their default values */
-	API_CALL(cd, XA_API_CMD_INIT, XA_CMD_TYPE_INIT_API_PRE_CONFIG_PARAMS,
-		 NULL, ret);
-	if (ret != LIB_NO_ERROR) {
-		rfree(cd->self);
-		goto free;
-	}
 
 	comp_dbg(dev, "cadence_codec_init() done");
 

--- a/src/include/ipc/stream.h
+++ b/src/include/ipc/stream.h
@@ -95,7 +95,9 @@ struct sof_ipc_stream_params {
 	uint32_t host_period_bytes;
 	uint16_t no_stream_position; /**< 1 means don't send stream position */
 
-	uint16_t reserved[3];
+	uint8_t codec_id;
+
+	uint8_t reserved[5];
 	uint16_t chmap[SOF_IPC_MAX_CHANNELS];	/**< channel map - SOF_CHMAP_ */
 } __attribute__((packed, aligned(4)));
 


### PR DESCRIPTION
Each family of codecs (e.g Cadence, DTS, WAVES) could support multiple processing algorithms. Best illustration for this is Cadence which suppports up to 14 algorithms (e.g DAP, MP3, AAC, DAB).

This PR wants to introduce a way to select the codec_id at runtime. The codec_id will be sent by the Linux kernel running on Host. 

First we need to make sure that we resolve the codec_id before any API function is called because that would be impossible not knowing the codec_id.

First patches of this PR addresses the cadence codecs. It moves any API call later when codec_id will be available. For this we introduce cadence_codec_postinit function which encapsulates the api calls at init and moves them intro prepare function.

The problem is that `module_interface` doesn't have an API for setting parameters.

Cc: @ranj063 