### PR TITLE
comp: re-link buffers in make_shared

### DIFF
--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -456,6 +456,9 @@ struct comp_dev *comp_make_shared(struct comp_dev *dev)
 {
 	struct list_item *old_bsource_list = &dev->bsource_list;
 	struct list_item *old_bsink_list = &dev->bsink_list;
+	struct list_item *buffer_list, *clist;
+	struct comp_buffer *buffer;
+	int dir;
 
 	/* flush cache to share */
 	dcache_writeback_region(dev, dev->size);
@@ -468,6 +471,22 @@ struct comp_dev *comp_make_shared(struct comp_dev *dev)
 	list_relink(&dev->bsource_list, old_bsource_list);
 	list_relink(&dev->bsink_list, old_bsink_list);
 	dev->is_shared = true;
+
+	/* re-link all buffers which are already connected to this
+	 * component
+	 */
+	for (dir = 0; dir <= PPL_CONN_DIR_BUFFER_TO_COMP; dir++) {
+		buffer_list = comp_buffer_list(dev, dir);
+
+		if (list_is_empty(buffer_list))
+			continue;
+
+		list_for_item(clist, buffer_list) {
+			buffer = buffer_from_list(clist, struct comp_buffer, dir);
+
+			buffer_set_comp(buffer, dev, dir);
+		}
+	}
 
 	return dev;
 }


### PR DESCRIPTION
After moving component to a new memory location, not only source and
sink lists need to re-link but also the buffers which already been
connected to this component.

Signed-off-by: Brent Lu <brent.lu@intel.com>