### PR TITLE
topology2: fix build issues with no command line definitions

### DIFF
--- a/tools/topology/CMakeLists.txt
+++ b/tools/topology/CMakeLists.txt
@@ -28,14 +28,34 @@ macro(add_alsatplg_command)
 	)
 endmacro()
 
-macro(add_alsatplg2_command)
-	add_custom_command(
-		MAIN_DEPENDENCY ${ARGV0}
-		OUTPUT ${ARGV1}
-		# -p to pre-process Topology2.0 conf file
-		COMMAND alsatplg \$\${VERBOSE:+-v 1} -I ${ARGV2} -D ${ARGV3} -p -c ${ARGV0} -o ${ARGV1}
-		USES_TERMINAL
-	)
+macro(add_alsatplg2_command input_file output_file include_path)
+	# command line definitions are optional
+	set (defines "")
+	set (optional_args ${ARGN})
+
+	# Set defines if there is an optional argument
+	list(LENGTH optional_args optional_args_count)
+	if (${optional_args_count} GREATER 0)
+		list(GET optional_args 0 defines)
+	endif()
+
+	if (defines STREQUAL "")
+		add_custom_command(
+			MAIN_DEPENDENCY ${input_file}
+			OUTPUT ${output_file}
+			# -p to pre-process Topology2.0 conf file
+			COMMAND alsatplg \$\${VERBOSE:+-v 1} -I ${include_path} -p -c ${input_file} -o ${output_file}
+			USES_TERMINAL
+		)
+	else()
+		add_custom_command(
+			MAIN_DEPENDENCY ${input_file}
+			OUTPUT ${output_file}
+			# -p to pre-process Topology2.0 conf file
+			COMMAND alsatplg \$\${VERBOSE:+-v 1} -I ${include_path} -D ${defines} -p -c ${input_file} -o ${output_file}
+			USES_TERMINAL
+		)
+	endif()
 endmacro()
 
 

--- a/tools/topology/topology2/cavs/CMakeLists.txt
+++ b/tools/topology/topology2/cavs/CMakeLists.txt
@@ -41,7 +41,7 @@ foreach(tplg ${TPLGS})
 	file(READ ${CMAKE_CURRENT_SOURCE_DIR}/${input}.conf CONTENTS)
 	file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/${output}.conf "${CONTENTS}")
 
-	add_alsatplg2_command(${output}.conf ${output}.tplg ${CMAKE_CURRENT_SOURCE_DIR} ${defines})
+	add_alsatplg2_command("${output}.conf" "${output}.tplg" "${CMAKE_CURRENT_SOURCE_DIR}" "${defines}")
 	add_custom_target(topology2_${output} DEPENDS ${output}.tplg)
 	add_dependencies(topology2_cavs topology2_${output})
 endforeach()


### PR DESCRIPTION
If there are not command line definitions, the build fails because the
4th argument to the add_alsatplg2_command macro is NULL.

Fix this by using named arguments for the macro and checking for the
optional argument for command line definitions.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>