### PR TITLE
ipc4: enabling SDW on windows

### DIFF
--- a/src/audio/copier.c
+++ b/src/audio/copier.c
@@ -246,7 +246,11 @@ static struct comp_dev *create_dai(struct comp_dev *parent_dev, struct copier_da
 		dai.type = SOF_DAI_INTEL_ALH;
 		dai.is_config_blob = true;
 		type = ipc4_gtw_alh;
-		dai.dai_index -= IPC4_ALH_DAI_INDEX_OFFSET;
+		/* copier id = (group id << 4) + codec id + IPC4_ALH_DAI_INDEX_OFFSET
+		 * dai_index = (group id << 8) + codec id;
+		 */
+		dai.dai_index = ((dai.dai_index & 0xF0) << DAI_NUM_ALH_BI_DIR_LINKS_GROUP) +
+			(dai.dai_index & 0xF) - IPC4_ALH_DAI_INDEX_OFFSET;
 		break;
 	case ipc4_dmic_link_input_class:
 		dai.type = SOF_DAI_INTEL_DMIC;

--- a/src/drivers/intel/alh.c
+++ b/src/drivers/intel/alh.c
@@ -62,7 +62,8 @@ static int alh_set_config_blob(struct dai *dai, struct ipc_config_dai *common_co
 
 	alh->params.channels = 2;
 	alh->params.rate = 48000;
-	alh->params.stream_id = alh_cfg->mapping[0].alh_id & 0xf;
+	/* the LSB 8bits are for stream id */
+	alh->params.stream_id = alh_cfg->mapping[0].alh_id & 0xff;
 
 	return 0;
 }

--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -153,7 +153,11 @@ static void get_llp_reg_info(struct dai_data *dd, uint32_t *node_id, uint32_t *o
 		*offset = 0;
 		*node_id = 0;
 	case SOF_DAI_INTEL_ALH:
-		id -= IPC4_ALH_DAI_INDEX_OFFSET;
+		/* id = group id << 4 + codec id + IPC4_ALH_DAI_INDEX_OFFSET
+		 * memory location = group id * 4 + codec id
+		 */
+		id =  ((id >> 4) & 0xF) * DAI_NUM_ALH_BI_DIR_LINKS_GROUP +
+			(id & 0xF) - IPC4_ALH_DAI_INDEX_OFFSET;
 		*offset = offsetof(struct ipc4_fw_registers, llp_sndw_reading_slots);
 		*offset += id * sizeof(struct ipc4_llp_reading_slot);
 		break;


### PR DESCRIPTION
The node id in copier config is built with group id
and codec id, we need to convert it to sof dai id.
    
Validated on windows. Now sdw playback can work on windows platform.
