### PR TITLE
topology: sof-adl-max98357a-rt5682-waves-2way: solution without changing waves wrapper code

### DIFF
--- a/tools/topology/topology1/CMakeLists.txt
+++ b/tools/topology/topology1/CMakeLists.txt
@@ -133,6 +133,7 @@ set(TPLGS
 	"sof-ehl-rt5660\;sof-ehl-rt5660-nohdmi"
 	"sof-tgl-max98357a-rt5682\;sof-tgl-max98357a-rt5682\;-DCODEC=MAX98357A\;-DFMT=s16le\;-DPLATFORM=tgl\;-DAMP_SSP=1"
 	"sof-tgl-max98357a-rt5682\;sof-adl-max98357a-rt5682\;-DCODEC=MAX98357A\;-DFMT=s16le\;-DPLATFORM=adl\;-DAMP_SSP=2"
+	"sof-tgl-max98357a-rt5682\;sof-adl-max98357a-rt5682-waves-2way\;-DCODEC=MAX98360A_TDM\;-DFMT=s32le\;-DPLATFORM=adl\;-DAMP_SSP=2\;-DWAVES\;-D2CH_2WAY"
 	"sof-tgl-max98357a-rt5682\;sof-adl-max98357a-rt5682-rtnr\;-DCODEC=MAX98357A\;-DFMT=s16le\;-DPLATFORM=adl\;-DAMP_SSP=2\;-DCHANNELS=2\;-DRTNR"
 	"sof-tgl-max98357a-rt5682\;sof-adl-max98357a-rt5682-4ch\;-DCODEC=MAX98360A_TDM\;-DFMT=s32le\;-DPLATFORM=adl\;-DAMP_SSP=2\;-D4CH_PASSTHROUGH"
 	"sof-tgl-max98357a-rt5682\;sof-adl-max98360a-rt5682\;-DCODEC=MAX98360A\;-DFMT=s32le\;-DPLATFORM=adl\;-DAMP_SSP=1"

--- a/tools/topology/topology1/sof/pipe-waves-demux-waves-playback-sched.m4
+++ b/tools/topology/topology1/sof/pipe-waves-demux-waves-playback-sched.m4
@@ -1,0 +1,208 @@
+# 2-way Pipeline with Waves codec
+#
+#  Low Latency Playback with 2 Waves codecs and Demux between them.
+#
+# Pipeline Endpoints for connection are :-
+#
+#      Low Latency Playback PCM
+#      Demux
+#      B3 (source endpoint)
+#
+#  host PCM_P -B0-> Waves(Stereo) -B1-> Demux -B2-> Waves(Woofer) -B3-> endpoint
+#
+
+DECLARE_SOF_RT_UUID("Waves codec", waves_codec_uuid, 0xd944281a, 0xafe9,
+                    0x4695, 0xa0, 0x43, 0xd7, 0xf6, 0x2b, 0x89, 0x53, 0x8e);
+define(`CA_UUID', waves_codec_uuid)
+
+# Include topology builder
+include(`utils.m4')
+include(`buffer.m4')
+include(`pcm.m4')
+include(`pga.m4')
+include(`muxdemux.m4')
+include(`mixercontrol.m4')
+include(`bytecontrol.m4')
+include(`dai.m4')
+include(`pipeline.m4')
+include(`codec_adapter.m4')
+
+ifdef(`ENDPOINT_NAME',`',`fatal_error(`Pipe requires ENDPOINT_NAME to be defined: Speakers, Headphones, etc.')')
+
+# demux Bytes control with max value of 255
+C_CONTROLBYTES(concat(`DEMUX', PIPELINE_ID), PIPELINE_ID,
+	CONTROLBYTES_OPS(bytes, 258 binds the mixer control to bytes get/put handlers, 258, 258),
+	CONTROLBYTES_EXTOPS(258 binds the mixer control to bytes get/put handlers, 258, 258),
+	, , ,
+	CONTROLBYTES_MAX(, 304),
+	,       concat(`demux_priv_', PIPELINE_ID))
+
+define(`SETUP_PARAMS_NAME_0', `Waves' `ENDPOINT_NAME' `Setup Stereo')
+
+CONTROLBYTES_PRIV(PP_SETUP_CONFIG_0,
+`       bytes "0x53,0x4f,0x46,0x00,'
+`       0x00,0x00,0x00,0x00,'
+`       0x20,0x00,0x00,0x00,'
+`       0x00,0x10,0x00,0x03,'
+`       0x00,0x00,0x00,0x00,'
+`       0x00,0x00,0x00,0x00,'
+`       0x00,0x00,0x00,0x00,'
+`       0x00,0x00,0x00,0x00,'
+
+`       0x00,0x01,0x41,0x57,'
+`       0x00,0x00,0x00,0x00,'
+`       0x80,0xBB,0x00,0x00,'
+`       0x20,0x00,0x00,0x00,'
+`       0x02,0x00,0x00,0x00,'
+
+`       0x00,0x00,0x00,0x00,'
+`       0x0c,0x00,0x00,0x00,'
+`       0x00,0x00,0x00,0x00"'
+)
+
+# Post process Bytes control for setup config
+C_CONTROLBYTES(SETUP_PARAMS_NAME_0, PIPELINE_ID,
+	CONTROLBYTES_OPS(bytes),
+	CONTROLBYTES_EXTOPS(void, 258, 258),
+	, , ,
+	CONTROLBYTES_MAX(, 8192),
+	,
+	PP_SETUP_CONFIG_0)
+
+define(`RUNTIME_PARAMS_NAME_0', `Waves' `ENDPOINT_NAME' `Runtime Stereo')
+
+CONTROLBYTES_PRIV(PP_RUNTIME_PARAMS_0,
+`       bytes "0x53,0x4f,0x46,0x00,'
+`       0x01,0x00,0x00,0x00,'
+`       0x00,0x00,0x00,0x00,'
+`       0x00,0x10,0x00,0x03,'
+`       0x00,0x00,0x00,0x00,'
+`       0x00,0x00,0x00,0x00,'
+`       0x00,0x00,0x00,0x00,'
+`       0x00,0x00,0x00,0x00"'
+)
+
+# Post process Bytes control for runtime config
+C_CONTROLBYTES(RUNTIME_PARAMS_NAME_0, PIPELINE_ID,
+	CONTROLBYTES_OPS(bytes),
+	CONTROLBYTES_EXTOPS(void, 258, 258),
+	, , ,
+	CONTROLBYTES_MAX(, 8192),
+	,
+	PP_RUNTIME_PARAMS_0)
+
+define(`SETUP_PARAMS_NAME_1', `Waves' `ENDPOINT_NAME' `Setup Woofer')
+
+CONTROLBYTES_PRIV(PP_SETUP_CONFIG_1,
+`       bytes "0x53,0x4f,0x46,0x00,'
+`       0x00,0x00,0x00,0x00,'
+`       0x20,0x00,0x00,0x00,'
+`       0x00,0x10,0x00,0x03,'
+`       0x00,0x00,0x00,0x00,'
+`       0x00,0x00,0x00,0x00,'
+`       0x00,0x00,0x00,0x00,'
+`       0x00,0x00,0x00,0x00,'
+
+`       0x00,0x01,0x41,0x57,'
+`       0x00,0x00,0x00,0x00,'
+`       0x80,0xBB,0x00,0x00,'
+`       0x20,0x00,0x00,0x00,'
+`       0x02,0x00,0x00,0x00,'
+
+`       0x00,0x00,0x00,0x00,'
+`       0x0c,0x00,0x00,0x00,'
+`       0x00,0x00,0x00,0x00"'
+)
+
+# Post process Bytes control for setup config
+C_CONTROLBYTES(SETUP_PARAMS_NAME_1, PIPELINE_ID,
+	CONTROLBYTES_OPS(bytes),
+	CONTROLBYTES_EXTOPS(void, 258, 258),
+	, , ,
+	CONTROLBYTES_MAX(, 8192),
+	,
+	PP_SETUP_CONFIG_1)
+
+define(`RUNTIME_PARAMS_NAME_1', `Waves' `ENDPOINT_NAME' `Runtime Woofer')
+
+CONTROLBYTES_PRIV(PP_RUNTIME_PARAMS_1,
+`       bytes "0x53,0x4f,0x46,0x00,'
+`       0x01,0x00,0x00,0x00,'
+`       0x00,0x00,0x00,0x00,'
+`       0x00,0x10,0x00,0x03,'
+`       0x00,0x00,0x00,0x00,'
+`       0x00,0x00,0x00,0x00,'
+`       0x00,0x00,0x00,0x00,'
+`       0x00,0x00,0x00,0x00"'
+)
+
+# Post process Bytes control for runtime config
+C_CONTROLBYTES(RUNTIME_PARAMS_NAME_1, PIPELINE_ID,
+	CONTROLBYTES_OPS(bytes),
+	CONTROLBYTES_EXTOPS(void, 258, 258),
+	, , ,
+	CONTROLBYTES_MAX(, 8192),
+	,
+	PP_RUNTIME_PARAMS_1)
+
+#
+# Components and Buffers
+#
+
+# Host "Low latency Playback" PCM
+# with 2 sink and 0 source periods
+W_PCM_PLAYBACK(PCM_ID, Low Latency Playback, 2, 0, SCHEDULE_CORE)
+
+W_CODEC_ADAPTER(0, PIPELINE_FORMAT, 2, 2, SCHEDULE_CORE,
+	LIST(`          ', "RUNTIME_PARAMS_NAME_0", "SETUP_PARAMS_NAME_0"))
+
+W_CODEC_ADAPTER(1, PIPELINE_FORMAT, 2, 2, SCHEDULE_CORE,
+	LIST(`          ', "RUNTIME_PARAMS_NAME_1", "SETUP_PARAMS_NAME_1"))
+
+# Mux 0 has 2 sink and source periods.
+W_MUXDEMUX(0, 1, PIPELINE_FORMAT, 2, 2, SCHEDULE_CORE,
+	LIST(`         ', concat(`DEMUX', PIPELINE_ID)))
+
+# Low Latency Buffers
+W_BUFFER(0, COMP_BUFFER_SIZE(2,
+	COMP_SAMPLE_SIZE(PIPELINE_FORMAT), PIPELINE_CHANNELS, COMP_PERIOD_FRAMES(PCM_MAX_RATE, SCHEDULE_PERIOD)),
+	PLATFORM_HOST_MEM_CAP)
+W_BUFFER(1, COMP_BUFFER_SIZE(2,
+	COMP_SAMPLE_SIZE(PIPELINE_FORMAT), PIPELINE_CHANNELS, COMP_PERIOD_FRAMES(PCM_MAX_RATE, SCHEDULE_PERIOD)),
+	PLATFORM_COMP_MEM_CAP)
+W_BUFFER(2, COMP_BUFFER_SIZE(2,
+	COMP_SAMPLE_SIZE(PIPELINE_FORMAT), PIPELINE_CHANNELS, COMP_PERIOD_FRAMES(PCM_MAX_RATE, SCHEDULE_PERIOD)),
+	PLATFORM_COMP_MEM_CAP)
+W_BUFFER(3, COMP_BUFFER_SIZE(2,
+	COMP_SAMPLE_SIZE(PIPELINE_FORMAT), PIPELINE_CHANNELS, COMP_PERIOD_FRAMES(PCM_MAX_RATE, SCHEDULE_PERIOD)),
+	PLATFORM_COMP_MEM_CAP)
+
+W_PIPELINE(SCHED_COMP, SCHEDULE_PERIOD, SCHEDULE_PRIORITY, SCHEDULE_CORE, SCHEDULE_TIME_DOMAIN, pipe_dai_schedule_plat)
+
+#
+# Pipeline Graph
+#
+#  host PCM_P -B0-> Waves(Stereo) -B1-> Demux -B2-> Waves(Woofer) -B3-> endpoint
+
+P_GRAPH(pipe-ll-playback-PIPELINE_ID, PIPELINE_ID,
+	LIST(`          ',
+	`dapm(N_BUFFER(0), N_PCMP(PCM_ID))',
+	`dapm(N_CODEC_ADAPTER(0), N_BUFFER(0))',
+	`dapm(N_BUFFER(1), N_CODEC_ADAPTER(0))',
+	`dapm(N_MUXDEMUX(0), N_BUFFER(1))',
+	`dapm(N_BUFFER(2), N_MUXDEMUX(0))',
+	`dapm(N_CODEC_ADAPTER(1), N_BUFFER(2))',
+	`dapm(N_BUFFER(3), N_CODEC_ADAPTER(1))'))
+#
+# Pipeline Source and Sinks
+#
+indir(`define', concat(`PIPELINE_SOURCE_', PIPELINE_ID), N_BUFFER(3))
+indir(`define', concat(`PIPELINE_DEMUX_', PIPELINE_ID), N_MUXDEMUX(0))
+indir(`define', concat(`PIPELINE_PCM_', PIPELINE_ID), Low Latency Playback PCM_ID)
+
+#
+# PCM Configuration
+#
+
+# PCM capabilities supported by FW
+PCM_CAPABILITIES(Low Latency Playback PCM_ID, CAPABILITY_FORMAT_NAME(PIPELINE_FORMAT), 48000, 48000, 2, PIPELINE_CHANNELS, 2, 16, 192, 16384, 65536, 65536)

--- a/tools/topology/topology1/sof/pipe-waves-mux-playback.m4
+++ b/tools/topology/topology1/sof/pipe-waves-mux-playback.m4
@@ -1,0 +1,130 @@
+# 2-way Pipeline with Waves codec
+#
+#  Low Latency Playback with Waves codec and Mux.
+#
+# Pipeline Endpoints for connection are :-
+#
+#      B0 (sink endpoint)
+#      Mux
+#      B2 (source endpoint)
+#
+#  source -- B0 --> Waves(Tweeter) --> B1 --> Mux --> B2 --> sink DAI
+#
+
+DECLARE_SOF_RT_UUID("Waves codec", waves_codec_uuid, 0xd944281a, 0xafe9,
+		    0x4695, 0xa0, 0x43, 0xd7, 0xf6, 0x2b, 0x89, 0x53, 0x8e);
+define(`CA_UUID', waves_codec_uuid)
+
+# Include topology builder
+include(`utils.m4')
+include(`buffer.m4')
+include(`pcm.m4')
+include(`muxdemux.m4')
+include(`mixercontrol.m4')
+include(`bytecontrol.m4')
+include(`dai.m4')
+include(`pipeline.m4')
+include(`codec_adapter.m4')
+
+ifdef(`ENDPOINT_NAME',`',`fatal_error(`Pipe requires ENDPOINT_NAME to be defined: Speakers, Headphones, etc.')')
+
+# Mux Bytes control with max value of 255
+C_CONTROLBYTES(concat(`MUX', PIPELINE_ID), PIPELINE_ID,
+	CONTROLBYTES_OPS(bytes, 258 binds the mixer control to bytes get/put handlers, 258, 258),
+	CONTROLBYTES_EXTOPS(258 binds the mixer control to bytes get/put handlers, 258, 258),
+	, , ,
+	CONTROLBYTES_MAX(, 304),
+	,       concat(`mux_priv_', PIPELINE_ID))
+
+define(`SETUP_PARAMS_NAME', `Waves' `ENDPOINT_NAME' `Setup Tweeter')
+
+CONTROLBYTES_PRIV(PP_SETUP_CONFIG,
+`       bytes "0x53,0x4f,0x46,0x00,'
+`       0x00,0x00,0x00,0x00,'
+`       0x20,0x00,0x00,0x00,'
+`       0x00,0x10,0x00,0x03,'
+`       0x00,0x00,0x00,0x00,'
+`       0x00,0x00,0x00,0x00,'
+`       0x00,0x00,0x00,0x00,'
+`       0x00,0x00,0x00,0x00,'
+
+`       0x00,0x01,0x41,0x57,'
+`       0x00,0x00,0x00,0x00,'
+`       0x80,0xBB,0x00,0x00,'
+`       0x20,0x00,0x00,0x00,'
+`       0x02,0x00,0x00,0x00,'
+
+`       0x00,0x00,0x00,0x00,'
+`       0x0c,0x00,0x00,0x00,'
+
+`       0x00,0x00,0x00,0x00"'
+)
+
+# Post process Bytes control for setup config
+C_CONTROLBYTES(SETUP_PARAMS_NAME, PIPELINE_ID,
+	CONTROLBYTES_OPS(bytes),
+	CONTROLBYTES_EXTOPS(void, 258, 258),
+	, , ,
+	CONTROLBYTES_MAX(, 8192),
+	,
+	PP_SETUP_CONFIG)
+
+define(`RUNTIME_PARAMS_NAME', `Waves' `ENDPOINT_NAME' `Runtime Tweeter')
+
+CONTROLBYTES_PRIV(PP_RUNTIME_PARAMS,
+`       bytes "0x53,0x4f,0x46,0x00,'
+`       0x01,0x00,0x00,0x00,'
+`       0x00,0x00,0x00,0x00,'
+`       0x00,0x10,0x00,0x03,'
+`       0x00,0x00,0x00,0x00,'
+`       0x00,0x00,0x00,0x00,'
+`       0x00,0x00,0x00,0x00,'
+`       0x00,0x00,0x00,0x00"'
+)
+
+# Post process Bytes control for runtime config
+C_CONTROLBYTES(RUNTIME_PARAMS_NAME, PIPELINE_ID,
+	CONTROLBYTES_OPS(bytes),
+	CONTROLBYTES_EXTOPS(void, 258, 258),
+	, , ,
+	CONTROLBYTES_MAX(, 8192),
+	,
+	PP_RUNTIME_PARAMS)
+
+#
+# Components and Buffers
+#
+
+W_CODEC_ADAPTER(0, PIPELINE_FORMAT, 2, 2, SCHEDULE_CORE,
+	LIST(`          ', "RUNTIME_PARAMS_NAME", "SETUP_PARAMS_NAME"))
+
+W_MUXDEMUX(0, 0, PIPELINE_FORMAT, 2, 2, SCHEDULE_CORE,
+	LIST(`         ', concat(`MUX', PIPELINE_ID)))
+
+# Low Latency Buffers
+W_BUFFER(0, COMP_BUFFER_SIZE(2,
+	COMP_SAMPLE_SIZE(PIPELINE_FORMAT), PIPELINE_CHANNELS, COMP_PERIOD_FRAMES(PCM_MAX_RATE, SCHEDULE_PERIOD)),
+	PLATFORM_HOST_MEM_CAP)
+W_BUFFER(1, COMP_BUFFER_SIZE(2,
+	COMP_SAMPLE_SIZE(PIPELINE_FORMAT), PIPELINE_CHANNELS, COMP_PERIOD_FRAMES(PCM_MAX_RATE, SCHEDULE_PERIOD)),
+	PLATFORM_COMP_MEM_CAP)
+W_BUFFER(2, COMP_BUFFER_SIZE(2,
+	COMP_SAMPLE_SIZE(PIPELINE_FORMAT), 4, COMP_PERIOD_FRAMES(PCM_MAX_RATE, SCHEDULE_PERIOD)),
+	PLATFORM_COMP_MEM_CAP)
+
+#
+# Graph connections to pipelines
+#
+#  source -- B0 --> Waves(Tweeter) --> B1 --> Mux --> B2 --> sink DAI
+#
+
+P_GRAPH(pipe-playback-sched-PIPELINE_ID, PIPELINE_ID,
+	LIST(`          ',
+	`dapm(N_CODEC_ADAPTER(0), N_BUFFER(0))',
+	`dapm(N_BUFFER(1), N_CODEC_ADAPTER(0))',
+	`dapm(N_MUXDEMUX(0), N_BUFFER(1))',
+	`dapm(N_BUFFER(2), N_MUXDEMUX(0))'))
+
+indir(`define', concat(`PIPELINE_SOURCE_', PIPELINE_ID), N_BUFFER(2))
+indir(`define', concat(`PIPELINE_MUX_', PIPELINE_ID), N_MUXDEMUX(0))
+indir(`define', concat(`PIPELINE_SINK_', PIPELINE_ID), N_BUFFER(0))


### PR DESCRIPTION
Add support for four max98357a speaker amplifiers running in TDM mode which format is 8 slots with 32 bit slot/sample width on ADL boards.
    
To implement the 2-way woofer/tweeter speaker function in SOF, there is a demux to create 2 streams for the branched pipelines. A Waves-codec widget is applied before the demux for audio quality enhancement, and the other Waves-codec
widgets are located one per branch for EQ/DRC including band-split filters of Woofer and Tweeter.
    
There is a mux before DAI to merge the branched Woofer and Tweeter streams into one 4-channel stream which is fed into DAI then.
    
The formation of this split-and-merge pipeline is a bit tricky. The topology graph is as following:
 ```   
   #host PCM0 -> WAVES -> DEMUX -> WAVES ---+                         <PIPE#9>
                              |             |
                              +--> WAVES -> MUX -> DAI (Speaker SSP)  <PIPE#1>
 ```

There are two pipelines with ID #1 and #9, where PIPE#9 is set DAI#1 as the scheduled component to make them being scheduled together. They are connected via DEMUX#9 and MUX#1.

The priority of PIPE#9 should be higher than PIPE#1 to assure PIPE#9 is scheduled first (PCM should be the first component for the copy process).
    
Moreover, the commit of mux_params() modification is required to support the split-and-merge pipeline design. In the commit mux_params() will update the stream channels for each sink buffer with regard to lookup tables, which are sourced from the matrices we provided in the topology file.

We know that the mux (or demux) is the channel-adjustable widget which handles the channel remap accordingly. In the existing cases so far, there is at most one mux or demux lied on the pipeline graph for each single endpoint device. The stream channels of all pipeline buffers will be distinguished by the both ends of the mux (or demux). Buffers located in the path toward PCM end will adopt channels as PCM params, while the ones located in the path toward DAI end will adopt channels as HW params.
    
However, in our case one demux and one mux are placed. That is, after the cuts on the spot of mux and demux there are 3 pieces: the path toward PCM end, the path toward DAI end, and the intermediate paths between mux and demux.

In the current pipeline_params() propagation the channels update will occur at the first mux/demux it traversed starting from PCM (downstream propagation for playback pipelines). So the stream params setup along pipeline buffers will be:

 ```   
   #host PCM0[2] -[2]-> WAVES -[2]-> DEMUX -[4]-> WAVES -[4]---+
                                         |                     |
                                         +--[4]-> WAVES -[4]-> MUX -[4]-> DAI (Speaker SSP[4])
 ```
(The numbers in brackets[ ] are the setup channels after  for buffers, where PCM params specifies 2-channel and HW params obtained from TDM SSP is 4.)

This setup is not as our expectation. The demux here performs stream duplication so the stream channels should be 2 for both sink and source buffers (2 sinks and 1 source). The mux plays the role of stream merger so the source buffers are 2-channel and the sink is 4-channel (1 sink and 2 sources).

 ```   
   #host PCM0[2] -[2]-> WAVES -[2]-> DEMUX -[2]-> WAVES -[2]---+
                                         |                     |
                                         +--[2]-> WAVES -[2]-> MUX -[4]-> DAI (Speaker SSP[4])
 ```
 
In practice, this information is specified in the mux/demux matrices provided in the topology, which are interpreted to lookup tables stored in comp_data of mux/demux. Therefore, "effective channels" could be counted by the number of valid copy elements in lookup tables for each sink buffer. We should apply "effective channels" to the downstream buffers during pipeline_params() propagation.

There are assumptions on calculating "effective channels", such like the output stream doesn't have the mixing channel (mapped to multiple input streams or channels), or the empty channel either (mapped to nothing).


