### PR TITLE
topology2: cavs-sdw: cavs-nocodec: add S32 format

### DIFF
--- a/tools/topology/topology2/cavs/cavs-nocodec.conf
+++ b/tools/topology/topology2/cavs/cavs-nocodec.conf
@@ -440,12 +440,12 @@ Object.PCM {
 
 		Object.PCM.pcm_caps."playback" {
 			name "Passthrough Playback 0"
-			formats 'S16_LE'
+			formats 'S16_LE,S32_LE'
 		}
 
 		Object.PCM.pcm_caps."capture" {
 			name "Passthrough Capture 0"
-			formats 'S16_LE'
+			formats 'S16_LE,S32_LE'
 		}
 	}
 	pcm."1" {
@@ -456,12 +456,12 @@ Object.PCM {
 
 		Object.PCM.pcm_caps."playback" {
 			name "Passthrough Playback 1"
-			formats 'S16_LE'
+			formats 'S16_LE,S32_LE'
 		}
 
 		Object.PCM.pcm_caps."capture" {
 			name "Passthrough Capture 1"
-			formats 'S16_LE'
+			formats 'S16_LE,S32_LE'
 		}
 	}
 	pcm."2" {
@@ -472,12 +472,12 @@ Object.PCM {
 
 		Object.PCM.pcm_caps."playback" {
 			name "Passthrough Playback 2"
-			formats 'S16_LE'
+			formats 'S16_LE,S32_LE'
 		}
 
 		Object.PCM.pcm_caps."capture" {
 			name "Passthrough Capture 2"
-			formats 'S16_LE'
+			formats 'S16_LE,S32_LE'
 		}
 	}
 	pcm."3" {
@@ -488,7 +488,7 @@ Object.PCM {
 
 		Object.PCM.pcm_caps."capture" {
 			name "Passthrough Capture 3"
-			formats 'S16_LE'
+			formats 'S16_LE,S32_LE'
 		}
 	}
 }

--- a/tools/topology/topology2/cavs/cavs-sdw.conf
+++ b/tools/topology/topology2/cavs/cavs-sdw.conf
@@ -158,7 +158,7 @@ Object.PCM {
 
 		Object.PCM.pcm_caps."playback" {
 			name "Passthrough Playback 0"
-			formats 'S16_LE'
+			formats 'S16_LE,S32_LE'
 		}
 	}
 	pcm."1" {
@@ -169,7 +169,7 @@ Object.PCM {
 
 		Object.PCM.pcm_caps."capture" {
 			name "Passthrough Capture 0"
-			formats 'S16_LE'
+			formats 'S16_LE,S32_LE'
 		}
 	}
 }


### PR DESCRIPTION
We do support 32 bit format. So add S32 to pcm_caps.

Signed-off-by: Bard Liao <yung-chuan.liao@linux.intel.com>