### PR TITLE
[DRAFT] [TEST] Updated rimage SHA to PR87 and upgraded minimal CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.20.0)
 
 if("${CMAKE_CURRENT_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_BINARY_DIR}")
 	message(FATAL_ERROR


### PR DESCRIPTION
This is a test for [rimage #87](https://github.com/thesofproject/rimage/pull/87).
Also upgrade of minimal CMake version to 3.20.0 as it makes no sense to upgrade only rimage CMake version since it is part of the SOF build.

Signed-off-by: Andrey Borisovich <andrey.borisovich@intel.com>