### PR TITLE
audio: add aligned limits for component copy function

### DIFF
--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -160,6 +160,17 @@ void comp_get_copy_limits(struct comp_buffer __sparse_cache *source,
 	cl->sink_bytes = cl->frames * cl->sink_frame_bytes;
 }
 
+void comp_get_copy_limits_frame_aligned(const struct comp_buffer __sparse_cache *source,
+					const struct comp_buffer __sparse_cache *sink,
+					struct comp_copy_limits *cl)
+{
+	cl->frames = audio_stream_avail_frames_aligned(&source->stream, &sink->stream);
+	cl->source_frame_bytes = audio_stream_frame_bytes(&source->stream);
+	cl->sink_frame_bytes = audio_stream_frame_bytes(&sink->stream);
+	cl->source_bytes = cl->frames * cl->source_frame_bytes;
+	cl->sink_bytes = cl->frames * cl->sink_frame_bytes;
+}
+
 struct comp_dev *comp_make_shared(struct comp_dev *dev)
 {
 	struct list_item *old_bsource_list = &dev->bsource_list;

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -814,6 +814,19 @@ void comp_get_copy_limits(struct comp_buffer __sparse_cache *source, struct comp
 			  struct comp_copy_limits *cl);
 
 /**
+ * Computes source to sink copy operation boundaries including maximum number
+ * of frames aligned with requirement that can be transferred (data available in
+ * source vs. free space available in sink).
+ *
+ * @param[in] source Buffer of source.
+ * @param[in] sink Buffer of sink.
+ * @param[out] cl Current copy limits.
+ */
+void comp_get_copy_limits_frame_aligned(const struct comp_buffer *source,
+					const struct comp_buffer *sink,
+					struct comp_copy_limits *cl);
+
+/**
  * Version of comp_get_copy_limits that locks both buffers to guarantee
  * consistent state readings.
  *
@@ -835,6 +848,29 @@ void comp_get_copy_limits_with_lock(struct comp_buffer *source,
 
 	buffer_release(source_c);
 	buffer_release(sink_c);
+}
+
+/**
+ * Version of comp_get_copy_limits_with_lock_frame_aligned that locks both
+ * buffers to guarantee consistent state readings and the frames aligned with
+ * the requirement.
+ *
+ * @param[in] source Buffer of source.
+ * @param[in] sink Buffer of sink
+ * @param[out] cl Current copy limits.
+ */
+static inline
+void comp_get_copy_limits_with_lock_frame_aligned(struct comp_buffer *source,
+						  struct comp_buffer *sink,
+						  struct comp_copy_limits *cl)
+{
+	source = buffer_acquire(source);
+	sink = buffer_acquire(sink);
+
+	comp_get_copy_limits_frame_aligned(source, sink, cl);
+
+	buffer_release(source);
+	buffer_release(sink);
 }
 
 /**

--- a/src/math/Kconfig
+++ b/src/math/Kconfig
@@ -52,12 +52,6 @@ config COMMON_LOGARITHM_FIXED
 	  This option builds common Logarithm function (log10(N)) which is the logarithm to
 	  the base 10.
 
-config NUMBERS_GCD
-	bool "Greatest common divisor"
-	default n
-	help
-	  Returns greatest common divisor for two parameters.
-
 config NUMBERS_NORM
 	bool "Norm function"
 	default n

--- a/src/math/numbers.c
+++ b/src/math/numbers.c
@@ -14,8 +14,6 @@
 #include <sof/math/numbers.h>
 #include <stdint.h>
 
-#if CONFIG_NUMBERS_GCD
-
 /* This function returns the greatest common divisor of two numbers
  * If both parameters are 0, gcd(0, 0) returns 0
  * If first parameters is 0 or second parameter is 0, gcd(0, b) returns b
@@ -74,8 +72,6 @@ int gcd(int a, int b)
 	/* restore common factors of 2 */
 	return a << k;
 }
-
-#endif /* CONFIG_NUMBERS_GCD */
 
 #if CONFIG_NUMBERS_VECTOR_FIND
 


### PR DESCRIPTION
add comp_get_copy_limits_with_lock_aligned API to meet requirement
of some xtensa intrinsics.

Signed-off-by: Andrula Song <xiaoyuan.song@intel.com>