### PR TITLE
Tools: Audio: Test: Fixes for Matlab audio quality test scripts run

### DIFF
--- a/tools/test/audio/comp_run.sh
+++ b/tools/test/audio/comp_run.sh
@@ -99,10 +99,17 @@ parse_args ()
     fi
 }
 
+delete_file_check ()
+{
+    if [ -f "$1" ]; then
+	rm -f "$1"
+    fi
+}
+
 run_testbench ()
 {
-    rm -f "$FN_OUT"
-    rm -f "$FN_TRACE"
+    delete_file_check "$FN_OUT"
+    delete_file_check "$FN_TRACE"
     if [ -z "$FN_TRACE" ]; then
 	# shellcheck disable=SC2086
 	$VALGRIND_CMD $CMD

--- a/tools/test/audio/test_utils/test_run.m
+++ b/tools/test/audio/test_utils/test_run.m
@@ -85,7 +85,7 @@ if isfield(test, 'trace')
 end
 
 % Override defaults in comp_run.sh
-fprintf(fh, 'VALGRIND=no\n', test.fs_in);
+fprintf(fh, 'VALGRIND=false\n', test.fs_in);
 fclose(fh);
 
 arg = sprintf('-t %s', fn_config);

--- a/tools/test/audio/test_utils/test_run.m
+++ b/tools/test/audio/test_utils/test_run.m
@@ -82,6 +82,8 @@ end
 
 if isfield(test, 'trace')
 	fprintf(fh, 'FN_TRACE=\"%s\"\n', test.trace);
+else
+	fprintf(fh, 'FN_TRACE=\"/dev/null"\n');
 end
 
 % Override defaults in comp_run.sh


### PR DESCRIPTION
The first patch fixes a regression with valgrind execution for quality tests. The second and third patch fix the massive trace flood from verbose trace from making tests run very slow.