### PR TITLE
topology1: mt8195: Add topology with DTS

### DIFF
--- a/tools/topology/topology1/CMakeLists.txt
+++ b/tools/topology/topology1/CMakeLists.txt
@@ -212,6 +212,7 @@ set(TPLGS
 	"sof-imx8mp-wm8960\;sof-imx8mp-drc-wm8960\;-DPPROC=drc"
 
 	"sof-mt8195-mt6359-rt1019-rt5682\;sof-mt8195-mt6359-rt1019-rt5682"
+	"sof-mt8195-mt6359-rt1019-rt5682\;sof-mt8195-mt6359-rt1019-rt5682-dts\;-DDTS=`DTS'"
 
 	"sof-acp-renoir\;sof-acp"
 	"sof-rn-rt5682-rt1019\;sof-rn-rt5682-rt1019"


### PR DESCRIPTION
Add CMake build definition for
sof-mt8195-mt6359-rt1019-rt5682-dts.tplg.

Signed-off-by: Li-Yu Yu <aaronyu@google.com>