### PR TITLE
topology2: use different SSP MCLK for different platforms

### DIFF
--- a/tools/topology/topology2/cavs/CMakeLists.txt
+++ b/tools/topology/topology2/cavs/CMakeLists.txt
@@ -14,8 +14,17 @@ set(TPLGS
 "cavs-passthrough-hdmi\;cavs-mixin-mixout-hda\;HDA_CONFIG=mix"
 # CAVS SDW topology with passthrough pipelines
 "cavs-sdw\;cavs-sdw"
-# CAVS SSP topology with passthrough pipelines
-"cavs-nocodec\;cavs-nocodec"
+# CAVS SSP topology with passthrough pipelines, default SSP MCLK is 38.4MHz
+"cavs-nocodec\;cavs-adl-nocodec"
+"cavs-nocodec\;cavs-ehl-nocodec"
+"cavs-nocodec\;cavs-tgl-nocodec"
+"cavs-nocodec\;cavs-tgl-h-nocodec"
+"cavs-nocodec\;cavs-jsl-nocodec"
+"cavs-nocodec\;cavs-icl-nocodec"
+"cavs-nocodec\;cavs-cml-nocodec\;MCLK=24000000"
+"cavs-nocodec\;cavs-cnl-nocodec\;MCLK=24000000"
+"cavs-nocodec\;cavs-glk-nocodec\;MCLK=19200000"
+"cavs-nocodec\;cavs-apl-nocodec\;MCLK=19200000"
 )
 
 # This will override the topology1 binaries with topology2 binaries

--- a/tools/topology/topology2/cavs/cavs-nocodec.conf
+++ b/tools/topology/topology2/cavs/cavs-nocodec.conf
@@ -27,6 +27,10 @@
 <dai.conf>
 <host.conf>
 
+Define {
+	MCLK 38400000
+}
+
 #
 # List of all DAIs
 #
@@ -42,7 +46,7 @@ Object.Dai {
 
 		Object.Base.hw_config."SSP0" {
 			id	0
-			mclk_freq	24000000
+			mclk_freq	$MCLK
 			bclk_freq	4800000
 			tdm_slot_width	32
 		}
@@ -116,7 +120,7 @@ Object.Dai {
 
 		Object.Base.hw_config."SSP1" {
 			id	0
-			mclk_freq	24000000
+			mclk_freq	$MCLK
 			bclk_freq	4800000
 			tdm_slot_width	32
 		}
@@ -190,7 +194,7 @@ Object.Dai {
 
 		Object.Base.hw_config."SSP2" {
 			id	0
-			mclk_freq	24000000
+			mclk_freq	$MCLK
 			bclk_freq	4800000
 			tdm_slot_width	32
 		}


### PR DESCRIPTION
Different platform uses different SSP MCLK frequency,
this patch applies different MCLK for different platform
for cavs-nocodec topology.

The MCLK frequencies are aligned with topology1.

Signed-off-by: Chao Song <chao.song@linux.intel.com>