### PR TITLE
Tools: Testbench: Add multi-core

### DIFF
--- a/src/audio/CMakeLists.txt
+++ b/src/audio/CMakeLists.txt
@@ -155,21 +155,23 @@ include(CheckCCompilerFlag)
 set(available_optimizations)
 
 # checks if flag is supported by compiler and sets needed flags
-macro(check_optimization opt_name flag extra_define)
+# note: to debug vectorisation please add "-fopt-info-vec-note" option after
+# the enable command below.
+macro(check_optimization opt_name flag enable_cmd extra_define)
 	check_c_compiler_flag(${flag} compiles_flag_${opt_name})
 	if(compiles_flag_${opt_name})
 		list(APPEND available_optimizations ${opt_name})
-		set(${opt_name}_flags ${flag} ${extra_define} -ffast-math)
+		set(${opt_name}_flags ${flag} ${extra_define} ${enable_cmd} -ffast-math)
 	endif()
 endmacro()
 
 # modules will be compiled only for flags supported by compiler
-check_optimization(sse42 -msse4.2 -DOPS_SSE42)
-check_optimization(avx -mavx -DOPS_AVX)
-check_optimization(avx2 -mavx2 -DOPS_AVX2)
-check_optimization(fma -mfma -DOPS_FMA)
-check_optimization(hifi2ep -mhifi2ep -DOPS_HIFI2EP)
-check_optimization(hifi3 -mhifi3 -DOPS_HIFI3)
+check_optimization(sse42 -msse4.2 -ftree-vectorize -DOPS_SSE42)
+check_optimization(avx -mavx -ftree-vectorize -DOPS_AVX)
+check_optimization(avx2 -mavx2 -ftree-vectorize -DOPS_AVX2)
+check_optimization(fma -mfma -ftree-vectorize -DOPS_FMA)
+check_optimization(hifi2ep -mhifi2ep "" -DOPS_HIFI2EP)
+check_optimization(hifi3 -mhifi3 "" -DOPS_HIFI3)
 
 set(sof_audio_modules volume src asrc eq-fir eq-iir dcblock crossover tdfb drc multiband_drc)
 

--- a/src/include/sof/trace/trace.h
+++ b/src/include/sof/trace/trace.h
@@ -25,6 +25,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <string.h>
 #if CONFIG_LIBRARY
 #include <stdio.h>
 #endif
@@ -235,8 +236,9 @@ do {											\
 	(void)id_1;									\
 	(void)id_2;									\
 	if (test_bench_trace) {								\
-		char *msg = "%s " format;						\
-		fprintf(stderr, msg, get_trace_class(comp_class), ##__VA_ARGS__);	\
+		char *msg = "(%s:%d) " format;						\
+		fprintf(stderr, msg, strrchr(__FILE__, '/') + 1,\
+			__LINE__, ##__VA_ARGS__);	\
 		fprintf(stderr, "\n");							\
 	}										\
 } while (0)

--- a/src/ipc/ipc-helper.c
+++ b/src/ipc/ipc-helper.c
@@ -267,8 +267,11 @@ int ipc_comp_free(struct ipc *ipc, uint32_t comp_id)
 
 	/* check whether component exists */
 	icd = ipc_get_comp_by_id(ipc, comp_id);
-	if (!icd)
+	if (!icd) {
+		tr_err(&ipc_tr, "ipc_comp_free(): comp id: %d is not found",
+		       comp_id);
 		return -ENODEV;
+	}
 
 	/* check type */
 	if (icd->type != COMP_TYPE_COMPONENT) {
@@ -282,8 +285,11 @@ int ipc_comp_free(struct ipc *ipc, uint32_t comp_id)
 		return ipc_process_on_core(icd->core, false);
 
 	/* check state */
-	if (icd->cd->state != COMP_STATE_READY)
+	if (icd->cd->state != COMP_STATE_READY) {
+		tr_err(&ipc_tr, "ipc_comp_free(): comp id: %d state is %d cannot be freed",
+		       comp_id, icd->cd->state);
 		return -EINVAL;
+	}
 
 	/* free component and remove from list */
 	comp_free(icd->cd);

--- a/src/platform/library/include/platform/lib/mailbox.h
+++ b/src/platform/library/include/platform/lib/mailbox.h
@@ -39,7 +39,8 @@
 
 #define MAILBOX_STREAM_OFFSET \
 	(MAILBOX_DEBUG_SIZE + MAILBOX_DEBUG_OFFSET)
-#define MAILBOX_STREAM_SIZE	0x200
+/* host mailbox can be bigger to support larger and more complex use cases */
+#define MAILBOX_STREAM_SIZE	0x2000
 #define MAILBOX_STREAM_BASE \
 	(MAILBOX_BASE + MAILBOX_STREAM_OFFSET)
 

--- a/src/platform/library/lib/alloc.c
+++ b/src/platform/library/lib/alloc.c
@@ -45,7 +45,9 @@ void *rbrealloc_align(void *ptr, uint32_t flags, uint32_t caps, size_t bytes,
 
 void heap_trace(struct mm_heap *heap, int size)
 {
+#if MALLOC_DEBUG
 	malloc_info(0, stdout);
+#endif
 }
 
 void heap_trace_all(int force)

--- a/src/platform/library/schedule/edf_schedule.c
+++ b/src/platform/library/schedule/edf_schedule.c
@@ -24,8 +24,6 @@ struct edf_schedule_data {
 	uint32_t clock;
 };
 
-static struct scheduler_ops schedule_edf_ops;
-
 static struct edf_schedule_data *sch;
 
 static int schedule_edf_task_complete(struct task *task)
@@ -49,38 +47,6 @@ static int schedule_edf_task(void *data, struct task *task, uint64_t start,
 		task->ops.run(task->data);
 
 	schedule_edf_task_complete(task);
-
-	return 0;
-}
-
-int schedule_task_init_edf(struct task *task, const struct sof_uuid_entry *uid,
-			   const struct task_ops *ops, void *data,
-			   uint16_t core, uint32_t flags)
-{
-	struct edf_task_pdata *edf_pdata;
-	int ret = 0;
-
-	ret = schedule_task_init(task, uid, SOF_SCHEDULE_EDF, 0, ops->run,
-				 data, core, flags);
-	if (ret < 0)
-		return ret;
-
-	edf_pdata = malloc(sizeof(*edf_pdata));
-	edf_sch_set_pdata(task, edf_pdata);
-
-	task->ops.complete = ops->complete;
-
-	return 0;
-}
-
-/* initialize scheduler */
-int scheduler_init_edf(void)
-{
-	tr_info(&edf_tr, "edf_scheduler_init()");
-	sch = malloc(sizeof(*sch));
-	list_init(&sch->list);
-
-	scheduler_init(SOF_SCHEDULE_EDF, &schedule_edf_ops, sch);
 
 	return 0;
 }
@@ -122,3 +88,35 @@ static struct scheduler_ops schedule_edf_ops = {
 	.schedule_task_free	= schedule_edf_task_free,
 	.scheduler_free		= edf_scheduler_free,
 };
+
+int schedule_task_init_edf(struct task *task, const struct sof_uuid_entry *uid,
+			   const struct task_ops *ops, void *data,
+			   uint16_t core, uint32_t flags)
+{
+	struct edf_task_pdata *edf_pdata;
+	int ret = 0;
+
+	ret = schedule_task_init(task, uid, SOF_SCHEDULE_EDF, 0, ops->run,
+				 data, core, flags);
+	if (ret < 0)
+		return ret;
+
+	edf_pdata = malloc(sizeof(*edf_pdata));
+	edf_sch_set_pdata(task, edf_pdata);
+
+	task->ops.complete = ops->complete;
+
+	return 0;
+}
+
+/* initialize scheduler */
+int scheduler_init_edf(void)
+{
+	tr_info(&edf_tr, "edf_scheduler_init()");
+	sch = malloc(sizeof(*sch));
+	list_init(&sch->list);
+
+	scheduler_init(SOF_SCHEDULE_EDF, &schedule_edf_ops, sch);
+
+	return 0;
+}

--- a/src/platform/library/schedule/ll_schedule.c
+++ b/src/platform/library/schedule/ll_schedule.c
@@ -4,14 +4,302 @@
 //
 // Author: Tomasz Lauda <tomasz.lauda@linux.intel.com>
 
-#include <sof/schedule/ll_schedule.h>
+#define _GNU_SOURCE
+
+#include <sof/audio/component.h>
+#include <sof/schedule/task.h>
 #include <sof/schedule/schedule.h>
+#include <sof/schedule/ll_schedule.h>
+#include <sof/schedule/ll_schedule_domain.h>
+#include <sof/lib/wait.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <stdint.h>
+#include <pthread.h>
+#include <poll.h>
+
+ /* scheduler testbench definition */
+
+/* 77de2074-828c-4044-a40b-420b72749e8b */
+DECLARE_SOF_UUID("ll-schedule", ll_sched_uuid, 0x77de2074, 0x828c, 0x4044,
+		 0xa4, 0x0b, 0x42, 0x0b, 0x72, 0x74, 0x9e, 0x8b);
+
+DECLARE_TR_CTX(ll_tr, SOF_UUID(ll_sched_uuid), LOG_LEVEL_INFO);
+
+struct ll_vcore {
+	struct list_item list; /* list of tasks in priority queue */
+	pthread_mutex_t list_mutex;
+	pthread_t thread_id;
+	int vcore_ready;
+	int core_id;
+};
+
+static int tick_period_us;
+
+static void *ll_thread(void *data)
+{
+	struct ll_vcore *vc = data;
+	struct timespec ts, td0, td1;
+	struct list_item *tlist, *tlist_;
+	struct task *task;
+	int err;
+	uint64_t delta;
+	cpu_set_t cpuset;
+	pthread_t thread;
+
+	/* Set affinity mask to pipeline core */
+	thread = pthread_self();
+	CPU_ZERO(&cpuset);
+	CPU_SET(vc->core_id, &cpuset);
+
+	printf("ll_schedule: new thread for core %d\n", vc->core_id);
+	err = pthread_setaffinity_np(thread, sizeof(cpuset), &cpuset);
+	if (err != 0)
+		fprintf(stderr, "error: failed to set CPU affinity to core %d: %s\n",
+			vc->core_id, strerror(err));
+
+	/* convert uS to seconds and ns */
+	ts.tv_sec = tick_period_us / 1000000;
+	ts.tv_nsec = (tick_period_us % 1000000) * 1000;
+
+	while (1) {
+		/*
+		 * The LL scheduler works with a periodic tick which we emulate
+		 * here to provide a similar processing experience on testbench
+		 * to actual DSP FW.
+		 */
+		if (tick_period_us) {
+			while (1) {
+				/* wait for next tick */
+				err = nanosleep(&ts, &ts);
+				if (err == 0)
+					break; /* sleep fully completed */
+				else if (err == EINTR) {
+					continue; /* interrupted - keep going */
+				} else {
+					/* something bad happened ... */
+					fprintf(stderr, "error: sleep failed: %s\n",
+						strerror(err));
+					goto out;
+				}
+			}
+		}
+
+		/* LL time slice now running at this point */
+		pthread_mutex_lock(&vc->list_mutex);
+
+		/* list empty then return */
+		if (list_is_empty(&vc->list)) {
+			pthread_mutex_unlock(&vc->list_mutex);
+			fprintf(stdout, "LL scheduler thread exit - list empty\n");
+			break;
+		}
+
+		/* iterate through the task list */
+		list_for_item_safe(tlist, tlist_, &vc->list) {
+			task = container_of(tlist, struct task, list);
+
+			/* only run queued tasks */
+			if (task->state == SOF_TASK_STATE_QUEUED) {
+				task->state = SOF_TASK_STATE_RUNNING;
+				pthread_mutex_unlock(&vc->list_mutex);
+
+				/* run task and time it */
+				clock_gettime(CLOCK_MONOTONIC, &td0);
+				task->ops.run(task->data);
+				clock_gettime(CLOCK_MONOTONIC, &td1);
+
+				pthread_mutex_lock(&vc->list_mutex);
+
+				/* only re-queue if not cancelled */
+				if (task->state == SOF_TASK_STATE_RUNNING)
+					task->state = SOF_TASK_STATE_QUEUED;
+
+				/* Calculate average task exec time */
+				delta = (td1.tv_sec - td0.tv_sec) * 1000000;
+				delta += (td1.tv_nsec - td0.tv_nsec) / 1000;
+				task->start += delta;
+			}
+		}
+
+		pthread_mutex_unlock(&vc->list_mutex);
+	}
+
+out:
+	/* nothing in list so stop LL thread */
+	vc->vcore_ready = 0;
+	return NULL;
+}
+
+static int schedule_ll_task_complete(void *data, struct task *task)
+{
+	struct ll_vcore *vc = data;
+
+	/* task is complete so remove it from list */
+	pthread_mutex_lock(&vc->list_mutex);
+	list_item_del(&task->list);
+	task->state = SOF_TASK_STATE_COMPLETED;
+	pthread_mutex_unlock(&vc->list_mutex);
+
+	return 0;
+}
+
+/* schedule new LL task */
+static int schedule_ll_task(void *data, struct task *task, uint64_t start,
+			    uint64_t period)
+{
+	struct ll_vcore *vc = data;
+	pthread_attr_t attr;
+	struct sched_param param;
+	int err;
+	bool valid_attr = false;
+	uid_t uid = getuid();
+	uid_t euid = geteuid();
+
+	/* add task to list */
+	pthread_mutex_lock(&vc->list_mutex);
+	list_item_prepend(&task->list, &vc->list);
+	task->state = SOF_TASK_STATE_QUEUED;
+	task->start = 0;
+	pthread_mutex_unlock(&vc->list_mutex);
+
+	/* is vcore thread running ? */
+	if (!vc->vcore_ready) {
+		/* do we have elevated privileges to attempt RT priority */
+		if (uid < 0 || uid != euid) {
+			/* attempt to set thread priority - needs suid */
+			printf("ll schedule: set RT priority\n");
+			err = pthread_attr_init(&attr);
+			if (err) {
+				printf("error: can't create thread attr %d %s\n",
+				       err, strerror(err));
+				goto create;
+			}
+
+			err = pthread_attr_setschedpolicy(&attr, SCHED_FIFO);
+			if (err) {
+				printf("error: can't set thread policy %d %s\n",
+				       err, strerror(err));
+				goto create;
+			}
+			param.sched_priority = 80;
+			err = pthread_attr_setschedparam(&attr, &param);
+			if (err) {
+				printf("error: can't set thread sched param %d %s\n",
+				       err, strerror(err));
+				goto create;
+			}
+			err = pthread_attr_setinheritsched(&attr, PTHREAD_EXPLICIT_SCHED);
+			if (err) {
+				printf("error: can't set thread inherit %d %s\n",
+				       err, strerror(err));
+				goto create;
+			}
+			valid_attr = true;
+		}
+
+create:
+		/* nope, so start thread for this virtual core */
+		err = pthread_create(&vc->thread_id, valid_attr ? &attr : NULL,
+				     ll_thread, &vc[task->core]);
+		if (err < 0) {
+			fprintf(stderr, "error: failed to create LL thread for vcore %d %s\n",
+				task->core, strerror(err));
+			return err;
+		}
+
+		vc->vcore_ready = 1;
+	}
+
+	return 0;
+}
+
+static void ll_scheduler_free(void *data, uint32_t flags)
+{
+	free(data);
+}
+
+/* TODO: scheduler free and cancel APIs can merge as part of Zephyr */
+static int schedule_ll_task_cancel(void *data, struct task *task)
+{
+	struct ll_vcore *vc = data;
+
+	pthread_mutex_lock(&vc->list_mutex);
+	/* delete task */
+	task->state = SOF_TASK_STATE_CANCEL;
+	list_item_del(&task->list);
+
+	/* list empty then return */
+	if (list_is_empty(&vc->list)) {
+		pthread_mutex_unlock(&vc->list_mutex);
+		pthread_join(vc->thread_id, NULL);
+	} else {
+		pthread_mutex_unlock(&vc->list_mutex);
+	}
+
+	return 0;
+}
+
+/* TODO: scheduler free and cancel APIs can merge as part of Zephyr */
+static int schedule_ll_task_free(void *data, struct task *task)
+{
+	struct ll_vcore *vc = data;
+
+	pthread_mutex_lock(&vc->list_mutex);
+	task->state = SOF_TASK_STATE_FREE;
+	list_item_del(&task->list);
+
+	/* list empty then return */
+	if (list_is_empty(&vc->list)) {
+		pthread_mutex_unlock(&vc->list_mutex);
+		pthread_join(vc->thread_id, NULL);
+	} else {
+		pthread_mutex_unlock(&vc->list_mutex);
+	}
+
+	return 0;
+}
+
+static struct scheduler_ops schedule_ll_ops = {
+	.schedule_task		= schedule_ll_task,
+	.schedule_task_running	= NULL,
+	.schedule_task_complete = schedule_ll_task_complete,
+	.reschedule_task	= NULL,
+	.schedule_task_cancel	= schedule_ll_task_cancel,
+	.schedule_task_free	= schedule_ll_task_free,
+	.scheduler_free		= ll_scheduler_free,
+};
 
 int schedule_task_init_ll(struct task *task,
 			  const struct sof_uuid_entry *uid, uint16_t type,
 			  uint16_t priority, enum task_state (*run)(void *data),
 			  void *data, uint16_t core, uint32_t flags)
 {
-	return schedule_task_init(task, uid, type, priority, run, data, core,
-				  flags);
+	return schedule_task_init(task, uid, SOF_SCHEDULE_LL_TIMER, 0, run,
+				  data, core, flags);
+}
+
+/* initialize scheduler */
+int scheduler_init_ll(struct ll_schedule_domain *domain)
+{
+	struct ll_vcore *vcore;
+	int i;
+
+	tr_info(&ll_tr, "ll_scheduler_init()");
+	tick_period_us = domain->next_tick;
+
+	vcore = calloc(sizeof(*vcore), CONFIG_CORE_COUNT);
+	if (!vcore)
+		return -ENOMEM;
+
+	for (i = 0; i < CONFIG_CORE_COUNT; i++) {
+		list_init(&vcore[i].list);
+		vcore[i].core_id = i;
+	}
+
+	scheduler_init(SOF_SCHEDULE_LL_TIMER, &schedule_ll_ops, vcore);
+
+	return 0;
 }

--- a/src/platform/library/schedule/schedule.c
+++ b/src/platform/library/schedule/schedule.c
@@ -29,7 +29,7 @@ int schedule_task_init(struct task *task,
 		return -EINVAL;
 
 	task->uid = uid;
-	task->type = SOF_SCHEDULE_EDF; /* Note: Force EDF scheduler */
+	task->type = type;
 	task->priority = priority;
 	task->core = core;
 	task->flags = flags;
@@ -59,7 +59,7 @@ void scheduler_init(int type, const struct scheduler_ops *ops, void *data)
 
 	sch = calloc(1, sizeof(*sch));
 	list_init(&sch->list);
-	sch->type = SOF_SCHEDULE_EDF; /* Note: Force EDF scheduler */
+	sch->type = type;
 	sch->ops = ops;
 	sch->data = data;
 

--- a/tools/fuzzer/fuzzer.h
+++ b/tools/fuzzer/fuzzer.h
@@ -132,9 +132,6 @@ void fuzzer_free_regions(struct fuzz *fuzzer);
 /* ipc */
 int fuzzer_send_msg(struct fuzz *fuzzer);
 
-/* topology */
-int parse_tplg(struct fuzz *fuzzer, char *tplg_filename);
-
 /* Convenience platform ops */
 static inline void fuzzer_mailbox_read(struct fuzz *fuzzer,
 				       struct mailbox *mailbox, int offset,

--- a/tools/fuzzer/main.c
+++ b/tools/fuzzer/main.c
@@ -19,6 +19,7 @@
 #include <ipc/control.h>
 #include "qemu-bridge.h"
 #include <ipc/trace.h>
+#include <tplg_parser/topology.h>
 
 int enable_fuzzer;
 
@@ -288,6 +289,7 @@ int main(int argc, char *argv[])
 	char *platform_name = NULL;
 	int i, j;
 	int regions = 0;
+	struct tplg_context ctx;
 
 	/* parse arguments */
 	while ((opt = getopt(argc, argv, "ht:p:")) != -1) {
@@ -343,9 +345,11 @@ int main(int argc, char *argv[])
 	/* allocate max ipc size bytes for the msg and reply */
 	fuzzer.msg.msg_data = malloc(SOF_IPC_MSG_MAX_SIZE);
 	fuzzer.msg.reply_data = malloc(SOF_IPC_MSG_MAX_SIZE);
+	ctx.fuzzer = &fuzzer;
+	ctx.tplg_file = topology_file;
 
 	/* load topology */
-	ret = parse_tplg(&fuzzer, topology_file);
+	ret = parse_topology(&ctx);
 	if (ret < 0)
 		exit(EXIT_FAILURE);
 

--- a/tools/fuzzer/topology.c
+++ b/tools/fuzzer/topology.c
@@ -111,16 +111,14 @@ static int load_graph(void *dev, struct comp_info *temp_comp_list,
 }
 
 /* load buffer DAPM widget */
-int load_buffer(void *dev, int comp_id, int pipeline_id,
-		struct snd_soc_tplg_dapm_widget *widget)
+int load_buffer(struct tplg_context *ctx)
 {
 	struct sof_ipc_buffer buffer;
-	struct fuzz *fuzzer = (struct fuzz *)dev;
+	struct fuzz *fuzzer = ctx->fuzzer;
 	struct sof_ipc_comp_reply r;
 	int ret;
 
-	ret = tplg_load_buffer(comp_id, pipeline_id, widget->priv.size, &buffer,
-			       fuzzer->tplg_file);
+	ret = tplg_load_buffer(ctx, &buffer);
 	if (ret < 0)
 		return ret;
 
@@ -139,15 +137,14 @@ int load_buffer(void *dev, int comp_id, int pipeline_id,
 }
 
 /* load pcm component */
-static int load_pcm(void *dev, int comp_id, int pipeline_id, int size, int dir)
+static int load_pcm(struct tplg_context *ctx, int dir)
 {
-	struct fuzz *fuzzer = (struct fuzz *)dev;
+	struct fuzz *fuzzer = ctx->fuzzer;
 	struct sof_ipc_comp_host host;
 	struct sof_ipc_comp_reply r;
 	int ret;
 
-	ret = tplg_load_pcm(comp_id, pipeline_id, size, dir, &host,
-			    fuzzer->tplg_file);
+	ret = tplg_load_pcm(ctx, dir, &host);
 	if (ret < 0)
 		return ret;
 
@@ -164,22 +161,20 @@ static int load_pcm(void *dev, int comp_id, int pipeline_id, int size, int dir)
 	return 0;
 }
 
-int load_aif_in_out(void *dev, int comp_id, int pipeline_id,
-		    struct snd_soc_tplg_dapm_widget *widget, int dir, void *tp)
+int load_aif_in_out(struct tplg_context *ctx, int dir)
 {
-	return load_pcm(dev, comp_id, pipeline_id, widget->priv.size, dir);
+	return load_pcm(ctx, dir);
 }
 
 /* load dai component */
-static int load_dai(struct fuzz *fuzzer, int comp_id, int pipeline_id,
-		    int size)
+static int load_dai(struct tplg_context *ctx)
 {
+	struct fuzz *fuzzer = ctx->fuzzer;
 	struct sof_ipc_comp_dai comp_dai;
 	struct sof_ipc_comp_reply r;
 	int ret;
 
-	ret = tplg_load_dai(comp_id, pipeline_id, size, &comp_dai,
-			    fuzzer->tplg_file);
+	ret = tplg_load_dai(ctx, &comp_dai);
 	if (ret < 0)
 		return ret;
 
@@ -197,23 +192,20 @@ static int load_dai(struct fuzz *fuzzer, int comp_id, int pipeline_id,
 	return 0;
 }
 
-int load_dai_in_out(void *dev, int comp_id, int pipeline_id,
-		    struct snd_soc_tplg_dapm_widget *widget, int dir, void *tp)
+int load_dai_in_out(struct tplg_context *ctx, int dir)
 {
-	return load_dai(dev, comp_id, pipeline_id, widget->priv.size);
+	return load_dai(ctx);
 }
 
 /* load pda dapm widget */
-int load_pga(void *dev, int comp_id, int pipeline_id,
-	     struct snd_soc_tplg_dapm_widget *widget)
+int load_pga(struct tplg_context *ctx)
 {
-	struct fuzz *fuzzer = (struct fuzz *)dev;
+	struct fuzz *fuzzer = ctx->fuzzer;
 	struct sof_ipc_comp_volume volume;
 	struct sof_ipc_comp_reply r;
 	int ret = 0;
 
-	ret = tplg_load_pga(comp_id, pipeline_id, widget->priv.size, &volume,
-			    fuzzer->tplg_file);
+	ret = tplg_load_pga(ctx, &volume);
 	if (ret < 0)
 		return ret;
 
@@ -231,20 +223,18 @@ int load_pga(void *dev, int comp_id, int pipeline_id,
 }
 
 /* load scheduler dapm widget */
-int load_pipeline(void *dev, int comp_id, int pipeline_id,
-		  struct snd_soc_tplg_dapm_widget *widget, int sched_id)
+int load_pipeline(struct tplg_context *ctx)
 {
 	struct sof_ipc_pipe_new pipeline;
-	struct fuzz *fuzzer = (struct fuzz *)dev;
+	struct fuzz *fuzzer = ctx->fuzzer;
 	struct sof_ipc_comp_reply r;
 	int ret;
 
-	ret = tplg_load_pipeline(comp_id, pipeline_id, widget->priv.size,
-				 &pipeline, fuzzer->tplg_file);
+	ret = tplg_load_pipeline(ctx, &pipeline);
 	if (ret < 0)
 		return ret;
 
-	pipeline.sched_id = sched_id;
+	pipeline.sched_id = ctx->sched_id;
 
 	/* configure fuzzer msg */
 	fuzzer->msg.header = pipeline.hdr.cmd;
@@ -261,16 +251,14 @@ int load_pipeline(void *dev, int comp_id, int pipeline_id,
 }
 
 /* load src dapm widget */
-int load_src(void *dev, int comp_id, int pipeline_id,
-	     struct snd_soc_tplg_dapm_widget *widget, void *params)
+int load_src(struct tplg_context *ctx)
 {
-	struct fuzz *fuzzer = (struct fuzz *)dev;
+	struct fuzz *fuzzer = ctx->fuzzer;
 	struct sof_ipc_comp_src src = {0};
 	struct sof_ipc_comp_reply r;
 	int ret = 0;
 
-	ret = tplg_load_src(comp_id, pipeline_id, widget->priv.size, &src,
-			    fuzzer->tplg_file);
+	ret = tplg_load_src(ctx, &src);
 	if (ret < 0)
 		return ret;
 
@@ -289,16 +277,14 @@ int load_src(void *dev, int comp_id, int pipeline_id,
 }
 
 /* load asrc dapm widget */
-int load_asrc(void *dev, int comp_id, int pipeline_id,
-	      struct snd_soc_tplg_dapm_widget *widget, void *params)
+int load_asrc(struct tplg_context *ctx)
 {
-	struct fuzz *fuzzer = (struct fuzz *)dev;
+	struct fuzz *fuzzer = ctx->fuzzer;
 	struct sof_ipc_comp_asrc asrc = {0};
 	struct sof_ipc_comp_reply r;
 	int ret = 0;
 
-	ret = tplg_load_asrc(comp_id, pipeline_id, widget->priv.size, &asrc,
-			     fuzzer->tplg_file);
+	ret = tplg_load_asrc(ctx, &asrc);
 	if (ret < 0)
 		return ret;
 
@@ -317,16 +303,14 @@ int load_asrc(void *dev, int comp_id, int pipeline_id,
 }
 
 /* load mixer dapm widget */
-int load_mixer(void *dev, int comp_id, int pipeline_id,
-	       struct snd_soc_tplg_dapm_widget *widget)
+int load_mixer(struct tplg_context *ctx)
 {
-	struct fuzz *fuzzer = (struct fuzz *)dev;
+	struct fuzz *fuzzer = ctx->fuzzer;
 	struct sof_ipc_comp_mixer mixer = {0};
 	struct sof_ipc_comp_reply r;
 	int ret = 0;
 
-	ret = tplg_load_mixer(comp_id, pipeline_id, widget->priv.size, &mixer,
-			      fuzzer->tplg_file);
+	ret = tplg_load_mixer(ctx, &mixer);
 	if (ret < 0)
 		return ret;
 
@@ -345,18 +329,17 @@ int load_mixer(void *dev, int comp_id, int pipeline_id,
 }
 
 /* load effect dapm widget */
-int load_process(void *dev, int comp_id, int pipeline_id,
-		 struct snd_soc_tplg_dapm_widget *widget)
+int load_process(struct tplg_context *ctx)
 {
 	return -EINVAL; /* Not implemented */
 }
 
 /* parse topology file and set up pipeline */
-int parse_tplg(struct fuzz *fuzzer, char *tplg_filename)
+int parse_topology(struct tplg_context *ctx)
 {
 	struct snd_soc_tplg_hdr *hdr;
-
-	struct comp_info *temp_comp_list = NULL;
+	struct fuzz *fuzzer = ctx->fuzzer;
+	struct comp_info *comp_list_realloc = NULL;
 	char message[DEBUG_MSG_LEN];
 	int next_comp_id = 0, num_comps = 0;
 	int i, ret = 0;
@@ -364,17 +347,25 @@ int parse_tplg(struct fuzz *fuzzer, char *tplg_filename)
 	int sched_id;
 
 	/* open topology file */
-	fuzzer->tplg_file = fopen(tplg_filename, "rb");
-	if (!fuzzer->tplg_file) {
-		fprintf(stderr, "error: opening topology file %s\n",
-			tplg_filename);
+	ctx->file = fopen(ctx->tplg_file, "rb");
+	if (!ctx->file) {
+		fprintf(stderr, "error: opening file %s\n", ctx->tplg_file);
 		return -errno;
 	}
+	fuzzer->tplg_file = ctx->file;
 
 	/* file size */
-	fseek(fuzzer->tplg_file, 0, SEEK_END);
-	file_size = ftell(fuzzer->tplg_file);
-	fseek(fuzzer->tplg_file, 0, SEEK_SET);
+	if (fseek(ctx->file, 0, SEEK_END)) {
+		fprintf(stderr, "error: seek to end of topology\n");
+		fclose(ctx->file);
+		return -errno;
+	}
+	file_size = ftell(ctx->file);
+	if (fseek(ctx->file, 0, SEEK_SET)) {
+		fprintf(stderr, "error: seek to beginning of topology\n");
+		fclose(ctx->file);
+		return -errno;
+	}
 
 	/* allocate memory */
 	size = sizeof(struct snd_soc_tplg_hdr);
@@ -405,26 +396,35 @@ int parse_tplg(struct fuzz *fuzzer, char *tplg_filename)
 				hdr->count);
 			fprintf(stdout, "debug %s\n", message);
 
-			num_comps += hdr->count;
-			size = sizeof(struct comp_info) * num_comps;
-			temp_comp_list = (struct comp_info *)
-					 realloc(temp_comp_list, size);
+			ctx->info_elems += hdr->count;
+			size = sizeof(struct comp_info) * ctx->info_elems;
+			comp_list_realloc = (struct comp_info *)
+					 realloc(ctx->info, size);
 
-			for (i = (num_comps - hdr->count); i < num_comps; i++)
-				ret = load_widget(fuzzer, FUZZER_DEV,
-						  temp_comp_list,
-						  next_comp_id++, i,
-						  hdr->index, NULL, &sched_id,
-						  fuzzer->tplg_file);
+			if (!comp_list_realloc && size) {
+				fprintf(stderr, "error: mem realloc\n");
+				return -ENOMEM;
+			}
+			ctx->info = comp_list_realloc;
+
+			for (i = (ctx->info_elems - hdr->count); i < ctx->info_elems; i++)
+				ctx->info[i].name = NULL;
+
+			for (ctx->info_index = (ctx->info_elems - hdr->count);
+			     ctx->info_index < ctx->info_elems;
+			     ctx->info_index++) {
+				ret = load_widget(ctx);
 				if (ret < 0) {
-					fprintf(stderr, "error: loading widget\n");
+					printf("error: loading widget\n");
 					goto finish;
-				}
+				} else if (ret > 0)
+					ctx->comp_id++;
+			}
 			break;
 
 		/* set up component connections from pipeline graph */
 		case SND_SOC_TPLG_TYPE_DAPM_GRAPH:
-			if (load_graph(fuzzer, temp_comp_list, hdr->count,
+			if (load_graph(fuzzer, comp_list_realloc, hdr->count,
 				       num_comps, hdr->index) < 0) {
 				fprintf(stderr, "error: pipeline graph\n");
 				return -EINVAL;
@@ -442,8 +442,8 @@ int parse_tplg(struct fuzz *fuzzer, char *tplg_filename)
 finish:
 	/* pipeline complete after pipeline connections are established */
 	for (i = 0; i < num_comps; i++)
-		if (temp_comp_list[i].type == SND_SOC_TPLG_DAPM_SCHEDULER)
-			complete_pipeline(fuzzer, temp_comp_list[i].id);
+		if (comp_list_realloc[i].type == SND_SOC_TPLG_DAPM_SCHEDULER)
+			complete_pipeline(fuzzer, comp_list_realloc[i].id);
 
 	fprintf(stdout, "debug: %s", "topology parsing end\n");
 
@@ -451,9 +451,9 @@ finish:
 	free(hdr);
 
 	for (i = 0; i < num_comps; i++)
-		free(temp_comp_list[i].name);
+		free(comp_list_realloc[i].name);
 
-	free(temp_comp_list);
+	free(comp_list_realloc);
 	fclose(fuzzer->tplg_file);
 	return 0;
 }

--- a/tools/testbench/CMakeLists.txt
+++ b/tools/testbench/CMakeLists.txt
@@ -73,6 +73,7 @@ add_dependencies(sof_parser_lib parser_ep)
 add_dependencies(testbench sof_parser_lib)
 target_link_libraries(testbench PRIVATE sof_library)
 target_link_libraries(testbench PRIVATE sof_parser_lib)
+target_link_libraries(testbench PRIVATE pthread)
 target_include_directories(testbench PRIVATE ${sof_install_directory}/include)
 target_include_directories(testbench PRIVATE ${parser_install_dir}/include)
 

--- a/tools/testbench/common_test.c
+++ b/tools/testbench/common_test.c
@@ -19,6 +19,8 @@
 #include <sof/lib/dai.h>
 #include <sof/lib/dma.h>
 #include <sof/schedule/edf_schedule.h>
+#include <sof/schedule/ll_schedule.h>
+#include <sof/schedule/ll_schedule_domain.h>
 #include <sof/schedule/schedule.h>
 #include <sof/lib/wait.h>
 #include <sof/audio/pipeline.h>
@@ -28,8 +30,12 @@
 
 /* testbench helper functions for pipeline setup and trigger */
 
-int tb_pipeline_setup(struct sof *sof)
+int tb_setup(struct sof *sof, struct testbench_prm *tp)
 {
+	struct ll_schedule_domain domain = {0};
+
+	domain.next_tick = tp->tick_period_us;
+
 	/* init components */
 	sys_comp_init(sof);
 
@@ -43,7 +49,13 @@ int tb_pipeline_setup(struct sof *sof)
 		return -EINVAL;
 	}
 
-	/* init scheduler */
+	/* init LL scheduler */
+	if (scheduler_init_ll(&domain) < 0) {
+		fprintf(stderr, "error: edf scheduler init\n");
+		return -EINVAL;
+	}
+
+	/* init EDF scheduler */
 	if (scheduler_init_edf() < 0) {
 		fprintf(stderr, "error: edf scheduler init\n");
 		return -EINVAL;

--- a/tools/testbench/common_test.c
+++ b/tools/testbench/common_test.c
@@ -37,7 +37,6 @@ int tb_pipeline_setup(struct sof *sof)
 	pipeline_posn_init(sof);
 	init_system_notify(sof);
 	scheduler_init_edf();
-	sa_init(sof, CONFIG_SYSTICK_PERIOD);
 
 	/* init IPC */
 	if (ipc_init(sof) < 0) {
@@ -68,7 +67,6 @@ void tb_pipeline_free(struct sof *sof)
 	struct notify **notify = arch_notify_get();
 	struct ipc_data *iipc;
 
-	free(sof->sa);
 	free(*notify);
 
 	/* free all scheduler data */

--- a/tools/testbench/common_test.c
+++ b/tools/testbench/common_test.c
@@ -36,7 +36,6 @@ int tb_pipeline_setup(struct sof *sof)
 	/* other necessary initializations, todo: follow better SOF init */
 	pipeline_posn_init(sof);
 	init_system_notify(sof);
-	scheduler_init_edf();
 
 	/* init IPC */
 	if (ipc_init(sof) < 0) {

--- a/tools/testbench/include/testbench/common_test.h
+++ b/tools/testbench/include/testbench/common_test.h
@@ -71,14 +71,20 @@ void sys_comp_file_init(void);
 
 void sys_comp_filewrite_init(void);
 
-int tb_pipeline_setup(struct sof *sof);
-void tb_pipeline_free(struct sof *sof);
+int tb_setup(struct sof *sof, struct testbench_prm *tp);
+void tb_free(struct sof *sof);
 
 int tb_pipeline_start(struct ipc *ipc, struct pipeline *p,
 		      struct testbench_prm *tp);
 
 int tb_pipeline_params(struct ipc *ipc, struct pipeline *p,
 		       struct testbench_prm *tp);
+
+int tb_pipeline_stop(struct ipc *ipc, struct pipeline *p,
+		     struct testbench_prm *tp);
+
+int tb_pipeline_reset(struct ipc *ipc, struct pipeline *p,
+		      struct testbench_prm *tp);
 
 void debug_print(char *message);
 

--- a/tools/testbench/include/testbench/common_test.h
+++ b/tools/testbench/include/testbench/common_test.h
@@ -18,13 +18,15 @@
 
 #include <sof/lib/uuid.h>
 
-#define DEBUG_MSG_LEN		256
-#define MAX_LIB_NAME_LEN	256
+#define DEBUG_MSG_LEN		1024
+#define MAX_LIB_NAME_LEN	1024
 
-#define MAX_OUTPUT_FILE_NUM	4
+#define MAX_OUTPUT_FILE_NUM	16
 
 /* number of widgets types supported in testbench */
 #define NUM_WIDGETS_SUPPORTED	11
+
+struct tplg_context;
 
 struct testbench_prm {
 	char *tplg_file; /* topology file to use */
@@ -32,6 +34,8 @@ struct testbench_prm {
 	char *output_file[MAX_OUTPUT_FILE_NUM]; /* output file names */
 	int output_file_num; /* number of output files */
 	char *bits_in; /* input bit format */
+	int pipelines[MAX_OUTPUT_FILE_NUM]; /* output file names */
+	int pipeline_num;
 	/*
 	 * input and output sample rate parameters
 	 * By default, these are calculated from pipeline frames_per_sched
@@ -50,6 +54,14 @@ struct testbench_prm {
 	int copy_iterations;
 	bool copy_check;
 	bool quiet;
+	int dynamic_pipeline_iterations;
+	int num_vcores;
+	int tick_period_us;
+	int pipeline_duration_ms;
+	int real_time;
+	FILE *file;
+	char *pipeline_string;
+	int output_file_index;
 };
 
 struct shared_lib_table {
@@ -96,7 +108,4 @@ int get_index_by_type(uint32_t comp_type,
 
 int get_index_by_uuid(struct sof_ipc_comp_ext *comp_ext,
 		      struct shared_lib_table *lib_table);
-
-int parse_topology(struct sof *sof,
-		   struct testbench_prm *tp, char *pipeline_msg);
 #endif

--- a/tools/testbench/include/testbench/file.h
+++ b/tools/testbench/include/testbench/file.h
@@ -36,6 +36,7 @@ struct file_state {
 	int n;
 	enum file_mode mode;
 	enum file_format f_format;
+	int copy_count;
 };
 
 /* file comp data */
@@ -48,6 +49,9 @@ struct file_comp_data {
 	int (*file_func)(struct comp_dev *dev, struct audio_stream *sink,
 			 struct audio_stream *source, uint32_t frames);
 
+	/* maximum limits */
+	int max_samples;
+	int max_copies;
 };
 
 #endif

--- a/tools/testbench/testbench.c
+++ b/tools/testbench/testbench.c
@@ -140,11 +140,11 @@ static void print_usage(char *executable)
 	printf("-o <output_file1,output_file2,...> ");
 	printf("-t <tplg_file> -b <input_format> -c <channels>");
 	printf("-a <comp1=comp1_library,comp2=comp2_library>\n");
-	printf("input_format should be S16_LE, S32_LE, S24_LE or FLOAT_LE\n");
+	printf("   input_format should be S16_LE, S32_LE, S24_LE or FLOAT_LE\n\n");
 	printf("Example Usage:\n");
 	printf("%s -i in.txt -o out.txt -t test.tplg ", executable);
-	printf("-r 48000 -R 96000 -c 2");
-	printf("-b S16_LE -a vol=libsof_volume.so\n");
+	printf("-r 48000 -R 96000 -c 2 ");
+	printf("-b S16_LE -a volume=libsof_volume.so\n");
 	printf("-C number of copy() iterations\n");
 }
 

--- a/tools/testbench/testbench.c
+++ b/tools/testbench/testbench.c
@@ -206,6 +206,7 @@ static void test_pipeline_free_comps(int pipeline_id)
 	struct list_item *clist;
 	struct list_item *temp;
 	struct ipc_comp_dev *icd = NULL;
+	int err;
 
 	/* remove the components for this pipeline */
 	list_for_item_safe(clist, temp, &sof_get()->ipc->comp_list) {
@@ -215,17 +216,26 @@ static void test_pipeline_free_comps(int pipeline_id)
 		case COMP_TYPE_COMPONENT:
 			if (icd->cd->pipeline->pipeline_id != pipeline_id)
 				break;
-			ipc_comp_free(sof_get()->ipc, icd->id);
+			err = ipc_comp_free(sof_get()->ipc, icd->id);
+			if (err)
+				fprintf(stderr, "failed to free comp %d\n",
+					icd->id);
 			break;
 		case COMP_TYPE_BUFFER:
 			if (icd->cb->pipeline_id != pipeline_id)
 				break;
-			ipc_buffer_free(sof_get()->ipc, icd->id);
+			err = ipc_buffer_free(sof_get()->ipc, icd->id);
+			if (err)
+				fprintf(stderr, "failed to free buffer %d\n",
+					icd->id);
 			break;
 		default:
 			if (icd->pipeline->pipeline_id != pipeline_id)
 				break;
-			ipc_pipeline_free(sof_get()->ipc, icd->id);
+			err = ipc_pipeline_free(sof_get()->ipc, icd->id);
+			if (err)
+				fprintf(stderr, "failed to free pipeline %d\n",
+					icd->id);
 			break;
 		}
 	}

--- a/tools/testbench/testbench.c
+++ b/tools/testbench/testbench.c
@@ -5,6 +5,7 @@
 // Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
 //         Ranjani Sridharan <ranjani.sridharan@linux.intel.com>
 
+#include <pthread.h>
 #include <sof/ipc/driver.h>
 #include <sof/ipc/topology.h>
 #include <sof/list.h>
@@ -14,6 +15,24 @@
 #include <tplg_parser/topology.h>
 #include "testbench/trace.h"
 #include "testbench/file.h"
+#include <limits.h>
+
+#ifdef TESTBENCH_CACHE_CHECK
+#include <arch/lib/cache.h>
+struct tb_cache_context hc = {0};
+
+/* cache debugger */
+struct tb_cache_context *tb_cache = &hc;
+int tb_elem_id;
+#else
+
+/* host thread context - folded into cachec context when cache debug is enabled */
+struct tb_host_context {
+	pthread_t thread_id[CONFIG_CORE_COUNT];
+};
+
+struct tb_host_context hc = {0};
+#endif
 
 #define DECLARE_SOF_TB_UUID(entity_name, uuid_name,			\
 			 va, vb, vc,					\
@@ -38,6 +57,12 @@ DECLARE_SOF_TB_UUID("multiband_drc", multiband_drc_uuid, 0x0d9f2256, 0x8e4f, 0x4
 		    0x84, 0x48, 0x23, 0x9a, 0x33, 0x4f, 0x11, 0x91);
 
 #define TESTBENCH_NCH 2 /* Stereo */
+
+struct pipeline_thread_data {
+	struct testbench_prm *tp;
+	int count;			/* copy iteration count */
+	int core_id;
+};
 
 /* shared library look up table */
 struct shared_lib_table lib_table[NUM_WIDGETS_SUPPORTED] = {
@@ -88,6 +113,31 @@ static int parse_output_files(char *outputs, struct testbench_prm *tp)
 
 	/* set total output file number */
 	tp->output_file_num = index;
+	return 0;
+}
+
+static int parse_pipelines(char *pipelines, struct testbench_prm *tp)
+{
+	char *output_token = NULL;
+	char *token = strtok_r(pipelines, ",", &output_token);
+	int index;
+
+	for (index = 0; index < MAX_OUTPUT_FILE_NUM && token; index++) {
+		/* get output file name with current index */
+		tp->pipelines[index] = atoi(token);
+
+		/* next output */
+		token = strtok_r(NULL, ",", &output_token);
+	}
+
+	if (index == MAX_OUTPUT_FILE_NUM && token) {
+		fprintf(stderr, "error: max output file number is %d\n",
+			MAX_OUTPUT_FILE_NUM);
+		return -EINVAL;
+	}
+
+	/* set total output file number */
+	tp->pipeline_num = index;
 	return 0;
 }
 
@@ -146,37 +196,134 @@ static void print_usage(char *executable)
 	printf("-r 48000 -R 96000 -c 2 ");
 	printf("-b S16_LE -a volume=libsof_volume.so\n");
 	printf("-C number of copy() iterations\n");
+	printf("-P number of dynamic pipeline iterations\n");
+	printf("-s Use real time priorities for threads (needs sudo)\n");
 }
 
 /* free components */
-static void free_comps(void)
+static void test_pipeline_free_comps(int pipeline_id)
 {
 	struct list_item *clist;
 	struct list_item *temp;
 	struct ipc_comp_dev *icd = NULL;
 
+	/* remove the components for this pipeline */
 	list_for_item_safe(clist, temp, &sof_get()->ipc->comp_list) {
 		icd = container_of(clist, struct ipc_comp_dev, list);
+
 		switch (icd->type) {
 		case COMP_TYPE_COMPONENT:
+			if (icd->cd->pipeline->pipeline_id != pipeline_id)
+				break;
 			ipc_comp_free(sof_get()->ipc, icd->id);
 			break;
 		case COMP_TYPE_BUFFER:
+			if (icd->cb->pipeline_id != pipeline_id)
+				break;
 			ipc_buffer_free(sof_get()->ipc, icd->id);
 			break;
 		default:
+			if (icd->pipeline->pipeline_id != pipeline_id)
+				break;
 			ipc_pipeline_free(sof_get()->ipc, icd->id);
 			break;
 		}
 	}
 }
 
-static void parse_input_args(int argc, char **argv, struct testbench_prm *tp)
+static void test_pipeline_set_test_limits(int pipeline_id, int max_copies,
+					  int max_samples)
+{
+	struct list_item *clist;
+	struct list_item *temp;
+	struct ipc_comp_dev *icd = NULL;
+	struct comp_dev *cd;
+	struct dai_data *dd;
+	struct file_comp_data *fcd;
+
+	/* set the test limits for this pipeline */
+	list_for_item_safe(clist, temp, &sof_get()->ipc->comp_list) {
+		icd = container_of(clist, struct ipc_comp_dev, list);
+
+		switch (icd->type) {
+		case COMP_TYPE_COMPONENT:
+			cd = icd->cd;
+			if (cd->pipeline->pipeline_id != pipeline_id)
+				break;
+
+			switch (cd->drv->type) {
+			case SOF_COMP_HOST:
+			case SOF_COMP_DAI:
+			case SOF_COMP_FILEREAD:
+			case SOF_COMP_FILEWRITE:
+				/* only file limits supported today. TODO: add others */
+				dd = comp_get_drvdata(cd);
+				fcd = comp_get_drvdata(dd->dai);
+				fcd->max_samples = max_samples;
+				fcd->max_copies = max_copies;
+				break;
+			default:
+				break;
+			}
+			break;
+		case COMP_TYPE_BUFFER:
+		default:
+			break;
+		}
+	}
+}
+
+static void test_pipeline_get_file_stats(int pipeline_id)
+{
+	struct list_item *clist;
+	struct list_item *temp;
+	struct ipc_comp_dev *icd;
+	struct comp_dev *cd;
+	struct dai_data *dd;
+	struct file_comp_data *fcd;
+	unsigned long time;
+
+	/* get the file IO status for each file in pipeline */
+	list_for_item_safe(clist, temp, &sof_get()->ipc->comp_list) {
+		icd = container_of(clist, struct ipc_comp_dev, list);
+
+		switch (icd->type) {
+		case COMP_TYPE_COMPONENT:
+			cd = icd->cd;
+			if (cd->pipeline->pipeline_id != pipeline_id)
+				break;
+			switch (cd->drv->type) {
+			case SOF_COMP_HOST:
+			case SOF_COMP_DAI:
+			case SOF_COMP_FILEREAD:
+			case SOF_COMP_FILEWRITE:
+				dd = comp_get_drvdata(cd);
+				fcd = comp_get_drvdata(dd->dai);
+
+				time = cd->pipeline->pipe_task->start;
+				if (fcd->fs.copy_count == 0)
+					fcd->fs.copy_count = 1;
+				printf("file %s: id %d: type %d: samples %d copies %d total time %zu uS avg time %zu uS\n",
+				       fcd->fs.fn, cd->ipc_config.id, cd->drv->type, fcd->fs.n,
+				       fcd->fs.copy_count, time, time / fcd->fs.copy_count);
+				break;
+			default:
+				break;
+			}
+			break;
+		case COMP_TYPE_BUFFER:
+		default:
+			break;
+		}
+	}
+}
+
+static int parse_input_args(int argc, char **argv, struct testbench_prm *tp)
 {
 	int option = 0;
 	int ret = 0;
 
-	while ((option = getopt(argc, argv, "hdqi:o:t:b:a:r:R:c:n:C:")) != -1) {
+	while ((option = getopt(argc, argv, "hdqi:o:t:b:a:r:R:c:n:C:P:Vp:T:D:")) != -1) {
 		switch (option) {
 		/* input sample file */
 		case 'i':
@@ -239,34 +386,325 @@ static void parse_input_args(int argc, char **argv, struct testbench_prm *tp)
 			tp->quiet = true;
 			break;
 
+		/* number of dynamic pipeline iterations */
+		case 'P':
+			tp->dynamic_pipeline_iterations = atoi(optarg);
+			break;
+
+		/* number of virtual cores */
+		case 'V':
+			tp->num_vcores = atoi(optarg);
+			break;
+
+		/* output sample files */
+		case 'p':
+			ret = parse_pipelines(optarg, tp);
+			break;
+
+		/* ticks per millisec, 0 = realtime (tickless) */
+		case 'T':
+			tp->tick_period_us = atoi(optarg);
+			break;
+
+		/* pipeline duration in millisec, 0 = realtime (tickless) */
+		case 'D':
+			tp->pipeline_duration_ms = atoi(optarg);
+			break;
+
 		/* print usage */
 		default:
 			fprintf(stderr, "unknown option %c\n", option);
+			ret = -EINVAL;
 			__attribute__ ((fallthrough));
 		case 'h':
 			print_usage(argv[0]);
-			exit(EXIT_FAILURE);
+			return ret;
 		}
 
 		if (ret < 0)
-			exit(EXIT_FAILURE);
+			return ret;
 	}
+
+	return ret;
+}
+
+static int test_pipeline_stop(struct pipeline_thread_data *ptdata,
+			      struct tplg_context *ctx)
+{
+	struct testbench_prm *tp = ptdata->tp;
+	struct ipc_comp_dev *pcm_dev;
+	struct pipeline *p;
+
+	pcm_dev = ipc_get_comp_by_id(sof_get()->ipc, tp->sched_id);
+	p = pcm_dev->cd->pipeline;
+
+	return tb_pipeline_stop(sof_get()->ipc, p, tp);
+}
+
+static int test_pipeline_reset(struct pipeline_thread_data *ptdata,
+			       struct tplg_context *ctx)
+{
+	struct testbench_prm *tp = ptdata->tp;
+	struct ipc_comp_dev *pcm_dev;
+	struct pipeline *p;
+
+	pcm_dev = ipc_get_comp_by_id(sof_get()->ipc, tp->sched_id);
+	p = pcm_dev->cd->pipeline;
+
+	return tb_pipeline_reset(sof_get()->ipc, p, tp);
+}
+
+static int test_pipeline_start(struct pipeline_thread_data *ptdata,
+			       struct tplg_context *ctx)
+{
+	struct testbench_prm *tp = ptdata->tp;
+	struct ipc_comp_dev *pcm_dev;
+	struct pipeline *p;
+
+	/* Run pipeline until EOF from fileread */
+	pcm_dev = ipc_get_comp_by_id(sof_get()->ipc, tp->sched_id);
+	p = pcm_dev->cd->pipeline;
+
+	/* input and output sample rate */
+	if (!tp->fs_in)
+		tp->fs_in = p->period * p->frames_per_sched;
+
+	if (!tp->fs_out)
+		tp->fs_out = p->period * p->frames_per_sched;
+
+	/* do we need to apply copy count limit ? */
+	if (tp->copy_check)
+		test_pipeline_set_test_limits(ctx->pipeline_id, tp->copy_iterations, 0);
+
+	/* set pipeline params and trigger start */
+	if (tb_pipeline_start(sof_get()->ipc, p, tp) < 0) {
+		fprintf(stderr, "error: pipeline params\n");
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+static int test_pipeline_get_state(struct pipeline_thread_data *ptdata,
+				   struct tplg_context *ctx)
+{
+	struct testbench_prm *tp = ptdata->tp;
+	struct ipc_comp_dev *pcm_dev;
+	struct pipeline *p;
+
+	/* Run pipeline until EOF from fileread */
+	pcm_dev = ipc_get_comp_by_id(sof_get()->ipc, tp->sched_id);
+	p = pcm_dev->cd->pipeline;
+	return p->pipe_task->state;
+}
+
+static int test_pipeline_load(struct pipeline_thread_data *ptdata,
+			      struct tplg_context *ctx, int pipeline_id)
+{
+	struct testbench_prm *tp = ptdata->tp;
+	int ret;
+
+	/* setup the thread virtual core config */
+	memset(ctx, 0, sizeof(*ctx));
+	ctx->comp_id = 1000 * ptdata->core_id;
+	ctx->core_id = ptdata->core_id;
+	ctx->file = tp->file;
+	ctx->sof = sof_get();
+	ctx->tp = tp;
+	ctx->tplg_file = tp->tplg_file;
+	ctx->pipeline_id = pipeline_id;
+
+	/* parse topology file and create pipeline */
+	ret = parse_topology(ctx);
+	if (ret < 0) {
+		fprintf(stderr, "error: parsing topology\n");
+		exit(EXIT_FAILURE);
+	}
+
+	return ret;
+}
+
+static void test_pipeline_free(struct pipeline_thread_data *ptdata,
+			       struct tplg_context *ctx, int pipeline_id)
+{
+	test_pipeline_free_comps(pipeline_id);
+}
+
+static void test_pipeline_stats(struct pipeline_thread_data *ptdata,
+				struct tplg_context *ctx, uint64_t delta)
+{
+	struct testbench_prm *tp = ptdata->tp;
+	int count = ptdata->count;
+	struct ipc_comp_dev *icd;
+	struct comp_dev *cd;
+	struct dai_data *dd;
+	struct pipeline *p;
+	struct file_comp_data *frcd, *fwcd;
+	int n_in, n_out;
+	int i;
+
+	/* Get pointer to filewrite */
+	icd = ipc_get_comp_by_id(sof_get()->ipc, tp->fw_id);
+	if (!icd) {
+		fprintf(stderr, "error: failed to get pointers to filewrite\n");
+		exit(EXIT_FAILURE);
+	}
+	cd = icd->cd;
+	dd = comp_get_drvdata(cd);
+	fwcd = comp_get_drvdata(dd->dai);
+
+	/* Get pointer to fileread */
+	icd = ipc_get_comp_by_id(sof_get()->ipc, tp->fr_id);
+	if (!icd) {
+		fprintf(stderr, "error: failed to get pointers to fileread\n");
+		exit(EXIT_FAILURE);
+	}
+	cd = icd->cd;
+	dd = comp_get_drvdata(cd);
+	frcd = comp_get_drvdata(dd->dai);
+
+	/* Run pipeline until EOF from fileread */
+	icd = ipc_get_comp_by_id(sof_get()->ipc, tp->sched_id);
+	p = icd->cd->pipeline;
+
+	/* input and output sample rate */
+	if (!tp->fs_in)
+		tp->fs_in = p->period * p->frames_per_sched;
+
+	if (!tp->fs_out)
+		tp->fs_out = p->period * p->frames_per_sched;
+
+	n_in = frcd->fs.n;
+	n_out = fwcd->fs.n;
+
+	/* print test summary */
+	printf("==========================================================\n");
+	printf("		           Test Summary %d\n", count);
+	printf("==========================================================\n");
+	printf("Test Pipeline:\n");
+	printf("%s\n", tp->pipeline_string);
+	test_pipeline_get_file_stats(ctx->pipeline_id);
+
+	printf("Input bit format: %s\n", tp->bits_in);
+	printf("Input sample rate: %d\n", tp->fs_in);
+	printf("Output sample rate: %d\n", tp->fs_out);
+	for (i = 0; i < tp->output_file_num; i++) {
+		printf("Output[%d] written to file: \"%s\"\n",
+		       i, tp->output_file[i]);
+	}
+	printf("Input sample (frame) count: %d (%d)\n", n_in, n_in / tp->channels_in);
+	printf("Output sample (frame) count: %d (%d)\n", n_out, n_out / tp->channels_out);
+	printf("Total execution time: %zu us, %.2f x realtime\n\n",
+	       delta, (double)((double)n_out / tp->channels_out / tp->fs_out) * 1000000 / delta);
+}
+
+/*
+ * Tester thread, one for each virtual core. This is NOT the thread that will
+ * execute the virtual core.
+ */
+static void *pipline_test(void *data)
+{
+	struct pipeline_thread_data *ptdata = data;
+	struct testbench_prm *tp = ptdata->tp;
+	int dp_count = 0;
+	struct tplg_context ctx;
+	struct timespec ts;
+	struct timespec td0, td1;
+	int err;
+	int nsleep_time;
+	int nsleep_limit;
+	uint64_t delta;
+
+	/* build, run and teardown pipelines */
+	while (dp_count < tp->dynamic_pipeline_iterations) {
+		fprintf(stdout, "pipeline run %d/%d\n", dp_count,
+			tp->dynamic_pipeline_iterations);
+
+		/* print test summary */
+		printf("==========================================================\n");
+		printf("		           Test Start %d\n", dp_count);
+		printf("==========================================================\n");
+
+		err = test_pipeline_load(ptdata, &ctx, tp->pipelines[0]);
+		if (err < 0) {
+			fprintf(stderr, "error: pipeline load %d failed %d\n",
+				dp_count, err);
+			break;
+		}
+
+		err = test_pipeline_start(ptdata, &ctx);
+		if (err < 0) {
+			fprintf(stderr, "error: pipeline run %d failed %d\n",
+				dp_count, err);
+			break;
+		}
+		clock_gettime(CLOCK_MONOTONIC, &td0);
+
+		/* sleep to let the pipeline work - we exit at timeout OR
+		 * if copy iterations OR max_samples is reached (whatever first)
+		 */
+		nsleep_time = 0;
+		ts.tv_sec = tp->tick_period_us / 1000000;
+		ts.tv_nsec = (tp->tick_period_us % 1000000) * 1000;
+		if (!tp->copy_check)
+			nsleep_limit = INT_MAX;
+		else
+			nsleep_limit = tp->copy_iterations *
+				       tp->pipeline_duration_ms;
+
+		while (nsleep_time < nsleep_limit) {
+			/* wait for next tick */
+			err = nanosleep(&ts, &ts);
+			if (err == 0) {
+				nsleep_time += tp->tick_period_us; /* sleep fully completed */
+				if (test_pipeline_get_state(ptdata, &ctx) ==
+				    SOF_TASK_STATE_CANCEL) {
+					fprintf(stdout, "pipeline cancelled !\n");
+					break;
+				}
+			} else {
+				if (err == EINTR) {
+					continue; /* interrupted - keep going */
+				} else {
+					printf("error: sleep failed: %s\n", strerror(err));
+					break;
+				}
+			}
+		}
+
+		clock_gettime(CLOCK_MONOTONIC, &td1);
+		err = test_pipeline_stop(ptdata, &ctx);
+		if (err < 0) {
+			fprintf(stderr, "error: pipeline stop %d failed %d\n",
+				dp_count, err);
+			break;
+		}
+
+		delta = (td1.tv_sec - td0.tv_sec) * 1000000;
+		delta += (td1.tv_nsec - td0.tv_nsec) / 1000;
+		test_pipeline_stats(ptdata, &ctx, delta);
+
+		err = test_pipeline_reset(ptdata, &ctx);
+		if (err < 0) {
+			fprintf(stderr, "error: pipeline stop %d failed %d\n",
+				dp_count, err);
+			break;
+		}
+
+		test_pipeline_free(ptdata, &ctx, tp->pipelines[0]);
+
+		ptdata->count++;
+		dp_count++;
+	}
+
+	return NULL;
 }
 
 int main(int argc, char **argv)
 {
 	struct testbench_prm tp;
-	struct ipc_comp_dev *pcm_dev;
-	struct pipeline *p;
-	struct pipeline *curr_p;
-	struct comp_dev *cd;
-	struct dai_data *dd;
-	struct file_comp_data *frcd, *fwcd;
-	char pipeline[DEBUG_MSG_LEN];
-	clock_t tic, toc;
-	double c_realtime, t_exec;
-	int n_in, n_out, ret;
-	int i;
+	struct pipeline_thread_data ptdata[CONFIG_CORE_COUNT];
+	int i, err;
 
 	/* initialize input and output sample rates, files, etc. */
 	debug = 0;
@@ -276,16 +714,27 @@ int main(int argc, char **argv)
 	tp.input_file = NULL;
 	tp.tplg_file = NULL;
 	tp.output_file_num = 0;
+	for (i = 0; i < MAX_OUTPUT_FILE_NUM; i++)
+		tp.output_file[i] = NULL;
+
 	tp.channels_in = TESTBENCH_NCH;
 	tp.channels_out = 0;
 	tp.max_pipeline_id = 0;
 	tp.copy_check = false;
 	tp.quiet = 0;
-	for (i = 0; i < MAX_OUTPUT_FILE_NUM; i++)
-		tp.output_file[i] = NULL;
+	tp.dynamic_pipeline_iterations = 1;
+	tp.num_vcores = 0;
+	tp.pipeline_string = calloc(1, DEBUG_MSG_LEN);
+	tp.pipelines[0] = 1;
+	tp.pipeline_num = 1;
+	tp.tick_period_us = 0; /* Execute fast non-real time, for 1 ms tick use -T 1000 */
+	tp.pipeline_duration_ms = 5000;
+	tp.copy_iterations = 1;
 
 	/* command line arguments*/
-	parse_input_args(argc, argv, &tp);
+	err = parse_input_args(argc, argv, &tp);
+	if (err < 0)
+		goto out;
 
 	if (!tp.channels_out)
 		tp.channels_out = tp.channels_in;
@@ -315,150 +764,60 @@ int main(int argc, char **argv)
 		exit(EXIT_FAILURE);
 	}
 
+	if (tp.num_vcores > CONFIG_CORE_COUNT) {
+		fprintf(stderr, "virtual core count %d is greater than max %d\n",
+			tp.num_vcores, CONFIG_CORE_COUNT);
+		print_usage(argv[0]);
+		exit(EXIT_FAILURE);
+	} else {
+		if (!tp.num_vcores)
+			tp.num_vcores = 1;
+	}
+
 	if (tp.quiet)
 		tb_enable_trace(false); /* reduce trace output */
 	else
 		tb_enable_trace(true);
 
 	/* initialize ipc and scheduler */
-	if (tb_pipeline_setup(sof_get()) < 0) {
+	if (tb_setup(sof_get(), &tp) < 0) {
 		fprintf(stderr, "error: pipeline init\n");
 		exit(EXIT_FAILURE);
 	}
 
-	/* parse topology file and create pipeline */
-	if (parse_topology(sof_get(), &tp, pipeline) < 0) {
-		fprintf(stderr, "error: parsing topology\n");
-		exit(EXIT_FAILURE);
-	}
+	/* build, run and teardown pipelines */
+	for (i = 0; i < tp.num_vcores; i++) {
+		ptdata[i].core_id = i;
+		ptdata[i].tp = &tp;
+		ptdata[i].count = 0;
 
-	/*
-	 * Note: This is a good place to place breakpoints when debugging. The component
-	 * has been loaded after topology parse so all the symbols exist at this point.
-	 *
-	 * Next, get pointer to filewrite.
-	 */
-	pcm_dev = ipc_get_comp_by_id(sof_get()->ipc, tp.fw_id);
-	if (!pcm_dev) {
-		fprintf(stderr, "error: failed to get pointers to filewrite\n");
-		exit(EXIT_FAILURE);
-	}
-	dd = comp_get_drvdata(pcm_dev->cd);
-	fwcd = comp_get_drvdata(dd->dai);
-
-	/* Get pointer to fileread */
-	pcm_dev = ipc_get_comp_by_id(sof_get()->ipc, tp.fr_id);
-	if (!pcm_dev) {
-		fprintf(stderr, "error: failed to get pointers to fileread\n");
-		exit(EXIT_FAILURE);
-	}
-	dd = comp_get_drvdata(pcm_dev->cd);
-	frcd = comp_get_drvdata(dd->dai);
-
-	/* Run pipeline until EOF from fileread */
-	pcm_dev = ipc_get_comp_by_id(sof_get()->ipc, tp.sched_id);
-	p = pcm_dev->cd->pipeline;
-
-	/* input and output sample rate */
-	if (!tp.fs_in)
-		tp.fs_in = p->period * p->frames_per_sched;
-
-	if (!tp.fs_out)
-		tp.fs_out = p->period * p->frames_per_sched;
-
-	/* set pipeline params and trigger start */
-	if (tb_pipeline_start(sof_get()->ipc, p, &tp) < 0) {
-		fprintf(stderr, "error: pipeline params\n");
-		exit(EXIT_FAILURE);
-	}
-
-	cd = pcm_dev->cd;
-
-	tic = clock();
-
-	while ((!frcd->fs.reached_eof) && (!fwcd->fs.write_failed)) {
-		/*
-		 * Schedule copy for all pipelines which have the same schedule
-		 * component as the working one.
-		 *
-		 * In common convention pipelines are added with monotonic
-		 * increasing IDs started from 1, we could take care of it in
-		 * test topologies so this for-loop will walk all pipelines.
-		 */
-		for (i = 1; i <= tp.max_pipeline_id; i++) {
-			pcm_dev = ipc_get_comp_by_ppl_id(sof_get()->ipc,
-							 COMP_TYPE_PIPELINE, i);
-			if (pcm_dev) {
-				curr_p = pcm_dev->pipeline;
-				if (pipeline_is_same_sched_comp(p, curr_p))
-					pipeline_schedule_copy(curr_p, 0);
-			}
-		}
-
-		/* are we bailing out after a fixed number of iterations ? */
-		if (tp.copy_check) {
-			if (--tp.copy_iterations == 0)
-				break;
+		err = pthread_create(&hc.thread_id[i], NULL,
+				     pipline_test, &ptdata[i]);
+		if (err) {
+			printf("error: can't create thread %d %s\n", err, strerror(err));
+			goto join;
 		}
 	}
 
-	if (fwcd->fs.write_failed) {
-		fprintf(stderr, "Error: File write failed.\n");
-		ret = EXIT_FAILURE;
-		goto err;
-	}
-
-	if (!frcd->fs.reached_eof && !tp.copy_check)
-		printf("warning: possible pipeline xrun\n");
-
-	/* reset and free pipeline */
-	toc = clock();
-
-	pipeline_trigger(p, cd, COMP_TRIGGER_STOP);
-	ret = pipeline_reset(p, cd);
-	if (ret < 0) {
-		fprintf(stderr, "error: pipeline reset\n");
-		ret = EXIT_FAILURE;
-		goto err;
-	}
-
-	n_in = frcd->fs.n;
-	n_out = fwcd->fs.n;
-	t_exec = (double)(toc - tic) / CLOCKS_PER_SEC;
-	c_realtime = (double)n_out / tp.channels_out / tp.fs_out / t_exec;
-
-	/* print test summary */
-	printf("==========================================================\n");
-	printf("		           Test Summary\n");
-	printf("==========================================================\n");
-	printf("Test Pipeline:\n");
-	printf("%s\n", pipeline);
-	printf("Input bit format: %s\n", tp.bits_in);
-	printf("Input sample rate: %d\n", tp.fs_in);
-	printf("Output sample rate: %d\n", tp.fs_out);
-	for (i = 0; i < tp.output_file_num; i++) {
-		printf("Output[%d] written to file: \"%s\"\n",
-		       i, tp.output_file[i]);
-	}
-	printf("Input sample count: %d\n", n_in);
-	printf("Output sample count: %d\n", n_out);
-	printf("Total execution time: %.2f us, %.2f x realtime\n",
-	       1e3 * t_exec, c_realtime);
-	ret = EXIT_SUCCESS;
-
-err:
-	/* free all components/buffers in pipeline */
-	free_comps();
+join:
+	for (i = 0; i < tp.num_vcores; i++)
+		err = pthread_join(hc.thread_id[i], NULL);
 
 	/* free other core FW services */
-	tb_pipeline_free(sof_get());
+	tb_free(sof_get());
 
+out:
 	/* free all other data */
 	free(tp.bits_in);
 	free(tp.input_file);
 	free(tp.tplg_file);
 	for (i = 0; i < tp.output_file_num; i++)
 		free(tp.output_file[i]);
+	free(tp.pipeline_string);
+
+#ifdef TESTBENCH_CACHE_CHECK
+	_cache_free_all();
+#endif
 
 	/* close shared library objects */
 	for (i = 0; i < NUM_WIDGETS_SUPPORTED; i++) {
@@ -466,5 +825,5 @@ err:
 			dlclose(lib_table[i].handle);
 	}
 
-	return ret;
+	return EXIT_SUCCESS;
 }

--- a/tools/testbench/topology.c
+++ b/tools/testbench/topology.c
@@ -20,10 +20,6 @@
 #include "testbench/common_test.h"
 #include "testbench/file.h"
 
-FILE *file;
-char pipeline_string[DEBUG_MSG_LEN];
-int output_file_index;
-
 const struct sof_dai_types sof_dais[] = {
 	{"SSP", SOF_DAI_INTEL_SSP},
 	{"HDA", SOF_DAI_INTEL_HDA},
@@ -101,6 +97,7 @@ int find_widget(struct comp_info *temp_comp_list, int count, char *name)
 
 /* load pipeline graph DAPM widget*/
 static int load_graph(void *dev, struct comp_info *temp_comp_list,
+		      struct testbench_prm *tp,
 		      int count, int num_comps, int pipeline_id)
 {
 	struct sof_ipc_pipe_comp_connect connection;
@@ -110,7 +107,7 @@ static int load_graph(void *dev, struct comp_info *temp_comp_list,
 
 	for (i = 0; i < count; i++) {
 		ret = tplg_load_graph(num_comps, pipeline_id, temp_comp_list,
-				      pipeline_string, &connection, file, i,
+				      tp->pipeline_string, &connection, tp->file, i,
 				      count);
 		if (ret < 0)
 			return ret;
@@ -133,19 +130,17 @@ static int load_graph(void *dev, struct comp_info *temp_comp_list,
 }
 
 /* load buffer DAPM widget */
-int load_buffer(void *dev, int comp_id, int pipeline_id,
-		struct snd_soc_tplg_dapm_widget *widget)
+int load_buffer(struct tplg_context *ctx)
 {
-	struct sof *sof = (struct sof *)dev;
+	struct sof *sof = ctx->sof;
 	struct sof_ipc_buffer buffer = {0};
-	int size = widget->priv.size;
 	int ret;
 
-	ret = tplg_load_buffer(comp_id, pipeline_id, size, &buffer, file);
+	ret = tplg_load_buffer(ctx, &buffer);
 	if (ret < 0)
 		return ret;
 
-	if (tplg_load_controls(widget->num_kcontrols, file) < 0) {
+	if (tplg_load_controls(ctx->widget->num_kcontrols, ctx->file) < 0) {
 		fprintf(stderr, "error: loading controls\n");
 		return -EINVAL;
 	}
@@ -160,12 +155,15 @@ int load_buffer(void *dev, int comp_id, int pipeline_id,
 }
 
 /* load fileread component */
-static int tplg_load_fileread(int comp_id, int pipeline_id, int size,
+static int tplg_load_fileread(struct tplg_context *ctx,
 			      struct sof_ipc_comp_file *fileread)
 {
 	struct snd_soc_tplg_vendor_array *array = NULL;
 	size_t total_array_size = 0;
 	size_t read_size;
+	FILE *file = ctx->file;
+	int size = ctx->widget->priv.size;
+	int comp_id = ctx->comp_id;
 	int ret;
 
 	/* allocate memory for vendor tuple array */
@@ -187,7 +185,8 @@ static int tplg_load_fileread(int comp_id, int pipeline_id, int size,
 		}
 
 		if (!is_valid_priv_size(total_array_size, size, array)) {
-			fprintf(stderr, "error: filewrite array size mismatch\n");
+			fprintf(stderr, "error: filewrite array size mismatch for widget size %d\n",
+				size);
 			free(array);
 			return -EINVAL;
 		}
@@ -215,21 +214,24 @@ static int tplg_load_fileread(int comp_id, int pipeline_id, int size,
 	fileread->comp.id = comp_id;
 
 	/* use fileread comp as scheduling comp */
-	fileread->comp.core = 0;
+	fileread->comp.core = ctx->core_id;
 	fileread->comp.hdr.size = sizeof(struct sof_ipc_comp_file);
 	fileread->comp.type = SOF_COMP_FILEREAD;
-	fileread->comp.pipeline_id = pipeline_id;
+	fileread->comp.pipeline_id = ctx->pipeline_id;
 	fileread->config.hdr.size = sizeof(struct sof_ipc_comp_config);
 	return 0;
 }
 
 /* load filewrite component */
-static int tplg_load_filewrite(int comp_id, int pipeline_id, int size,
+static int tplg_load_filewrite(struct tplg_context *ctx,
 			       struct sof_ipc_comp_file *filewrite)
 {
 	struct snd_soc_tplg_vendor_array *array = NULL;
 	size_t read_size;
 	size_t total_array_size = 0;
+	FILE *file = ctx->file;
+	int size = ctx->widget->priv.size;
+	int comp_id = ctx->comp_id;
 	int ret;
 
 	/* allocate memory for vendor tuple array */
@@ -271,33 +273,32 @@ static int tplg_load_filewrite(int comp_id, int pipeline_id, int size,
 	free(array);
 
 	/* configure filewrite */
-	filewrite->comp.core = 0;
+	filewrite->comp.core = ctx->core_id;
 	filewrite->comp.id = comp_id;
 	filewrite->mode = FILE_WRITE;
 	filewrite->comp.hdr.size = sizeof(struct sof_ipc_comp_file);
 	filewrite->comp.type = SOF_COMP_FILEWRITE;
-	filewrite->comp.pipeline_id = pipeline_id;
+	filewrite->comp.pipeline_id = ctx->pipeline_id;
 	filewrite->config.hdr.size = sizeof(struct sof_ipc_comp_config);
 	return 0;
 }
 
 /* load fileread component */
-static int load_fileread(void *dev, int comp_id, int pipeline_id,
-			 struct snd_soc_tplg_dapm_widget *widget, int dir,
-			 struct testbench_prm *tp)
+static int load_fileread(struct tplg_context *ctx, int dir)
 {
-	struct sof *sof = (struct sof *)dev;
+	struct sof *sof = ctx->sof;
+	struct testbench_prm *tp = ctx->tp;
+	FILE *file = ctx->file;
 	struct sof_ipc_comp_file fileread = {0};
-	int size = widget->priv.size;
 	int ret;
 
 	fileread.config.frame_fmt = find_format(tp->bits_in);
 
-	ret = tplg_load_fileread(comp_id, pipeline_id, size, &fileread);
+	ret = tplg_load_fileread(ctx, &fileread);
 	if (ret < 0)
 		return ret;
 
-	if (tplg_load_controls(widget->num_kcontrols, file) < 0) {
+	if (tplg_load_controls(ctx->widget->num_kcontrols, file) < 0) {
 		fprintf(stderr, "error: loading controls\n");
 		return -EINVAL;
 	}
@@ -306,8 +307,8 @@ static int load_fileread(void *dev, int comp_id, int pipeline_id,
 	fileread.fn = strdup(tp->input_file);
 
 	/* use fileread comp as scheduling comp */
-	tp->fr_id = comp_id;
-	tp->sched_id = comp_id;
+	tp->fr_id = ctx->comp_id;
+	tp->sched_id = ctx->comp_id;
 
 	/* Set format from testbench command line*/
 	fileread.rate = tp->fs_in;
@@ -330,33 +331,33 @@ static int load_fileread(void *dev, int comp_id, int pipeline_id,
 }
 
 /* load filewrite component */
-static int load_filewrite(struct sof *sof, int comp_id, int pipeline_id,
-			  struct snd_soc_tplg_dapm_widget *widget, int dir,
-			  struct testbench_prm *tp)
+static int load_filewrite(struct tplg_context *ctx, int dir)
 {
+	struct sof *sof = ctx->sof;
+	struct testbench_prm *tp = ctx->tp;
+	FILE *file = ctx->file;
 	struct sof_ipc_comp_file filewrite = {0};
-	int size = widget->priv.size;
 	int ret;
 
-	ret = tplg_load_filewrite(comp_id, pipeline_id, size, &filewrite);
+	ret = tplg_load_filewrite(ctx, &filewrite);
 	if (ret < 0)
 		return ret;
 
-	if (tplg_load_controls(widget->num_kcontrols, file) < 0) {
+	if (tplg_load_controls(ctx->widget->num_kcontrols, file) < 0) {
 		fprintf(stderr, "error: loading controls\n");
 		return -EINVAL;
 	}
 
 	/* configure filewrite (multiple output files are supported.) */
-	if (!tp->output_file[output_file_index]) {
+	if (!tp->output_file[tp->output_file_index]) {
 		fprintf(stderr, "error: output[%d] file name is null\n",
-			output_file_index);
+			tp->output_file_index);
 		return -EINVAL;
 	}
-	filewrite.fn = strdup(tp->output_file[output_file_index]);
-	if (output_file_index == 0)
-		tp->fw_id = comp_id;
-	output_file_index++;
+	filewrite.fn = strdup(tp->output_file[tp->output_file_index]);
+	if (tp->output_file_index == 0)
+		tp->fw_id = ctx->comp_id;
+	tp->output_file_index++;
 
 	/* Set format from testbench command line*/
 	filewrite.rate = tp->fs_out;
@@ -378,33 +379,26 @@ static int load_filewrite(struct sof *sof, int comp_id, int pipeline_id,
 	return 0;
 }
 
-int load_aif_in_out(void *dev, int comp_id, int pipeline_id,
-		    struct snd_soc_tplg_dapm_widget *widget, int dir, void *tp)
+int load_aif_in_out(struct tplg_context *ctx, int dir)
 {
 	if (dir == SOF_IPC_STREAM_PLAYBACK)
-		return load_fileread(dev, comp_id, pipeline_id, widget, dir,
-				     (struct testbench_prm *)tp);
-
-	return load_filewrite(dev, comp_id, pipeline_id, widget, dir,
-			      (struct testbench_prm *)tp);
+		return load_fileread(ctx, dir);
+	else
+		return load_filewrite(ctx, dir);
 }
 
-int load_dai_in_out(void *dev, int comp_id, int pipeline_id,
-		    struct snd_soc_tplg_dapm_widget *widget, int dir, void *tp)
+int load_dai_in_out(struct tplg_context *ctx, int dir)
 {
 	if (dir == SOF_IPC_STREAM_PLAYBACK)
-		return load_filewrite(dev, comp_id, pipeline_id, widget, dir,
-				      (struct testbench_prm *)tp);
-
-	return load_fileread(dev, comp_id, pipeline_id, widget, dir,
-			     (struct testbench_prm *)tp);
+		return load_filewrite(ctx, dir);
+	else
+		return load_fileread(ctx, dir);
 }
 
 /* load pda dapm widget */
-int load_pga(void *dev, int comp_id, int pipeline_id,
-	     struct snd_soc_tplg_dapm_widget *widget)
+int load_pga(struct tplg_context *ctx)
 {
-	struct sof *sof = (struct sof *)dev;
+	struct sof *sof = ctx->sof;
 	struct sof_ipc_comp_volume volume = {};
 	struct snd_soc_tplg_ctl_hdr *ctl = NULL;
 	struct snd_soc_tplg_mixer_control *mixer_ctl;
@@ -415,22 +409,21 @@ int load_pga(void *dev, int comp_id, int pipeline_id,
 	float vol_min_db;
 	float vol_max_db;
 	int channels = 0;
-	int size = widget->priv.size;
 	int ret = 0;
 
-	ret = tplg_load_pga(comp_id, pipeline_id, size, &volume, file);
+	ret = tplg_load_pga(ctx, &volume);
 	if (ret < 0)
 		return ret;
 
 	/* Only one control is supported*/
-	if (widget->num_kcontrols > 1) {
+	if (ctx->widget->num_kcontrols > 1) {
 		fprintf(stderr, "error: more than one kcontrol defined\n");
 		return -EINVAL;
 	}
 
 	/* Get control into ctl and priv_data */
-	if (widget->num_kcontrols) {
-		ret = tplg_load_one_control(&ctl, &priv_data, file);
+	if (ctx->widget->num_kcontrols) {
+		ret = tplg_load_one_control(&ctl, &priv_data, ctx->file);
 		if (ret < 0) {
 			fprintf(stderr, "error: failed control load\n");
 			return ret;
@@ -464,24 +457,23 @@ int load_pga(void *dev, int comp_id, int pipeline_id,
 }
 
 /* load scheduler dapm widget */
-int load_pipeline(void *dev, int comp_id, int pipeline_id,
-		  struct snd_soc_tplg_dapm_widget *widget, int sched_id)
+int load_pipeline(struct tplg_context *ctx)
 {
-	struct sof *sof = (struct sof *)dev;
+	struct sof *sof = ctx->sof;
 	struct sof_ipc_pipe_new pipeline = {0};
-	int size = widget->priv.size;
+	FILE *file = ctx->file;
 	int ret;
 
-	ret = tplg_load_pipeline(comp_id, pipeline_id, size, &pipeline, file);
+	ret = tplg_load_pipeline(ctx, &pipeline);
 	if (ret < 0)
 		return ret;
 
-	if (tplg_load_controls(widget->num_kcontrols, file) < 0) {
+	if (tplg_load_controls(ctx->widget->num_kcontrols, file) < 0) {
 		fprintf(stderr, "error: loading controls\n");
 		return -EINVAL;
 	}
 
-	pipeline.sched_id = sched_id;
+	pipeline.sched_id = ctx->sched_id;
 
 	/* Create pipeline */
 	if (ipc_pipeline_new(sof->ipc, (ipc_pipe_new *)&pipeline) < 0) {
@@ -493,21 +485,19 @@ int load_pipeline(void *dev, int comp_id, int pipeline_id,
 }
 
 /* load src dapm widget */
-int load_src(void *dev, int comp_id, int pipeline_id,
-	     struct snd_soc_tplg_dapm_widget *widget,
-	     void *params)
+int load_src(struct tplg_context *ctx)
 {
-	struct testbench_prm *tp = (struct testbench_prm *)params;
-	struct sof *sof = (struct sof *)dev;
+	struct sof *sof = ctx->sof;
 	struct sof_ipc_comp_src src = {0};
-	int size = widget->priv.size;
+	FILE *file = ctx->file;
+	struct testbench_prm *tp = ctx->tp;
 	int ret = 0;
 
-	ret = tplg_load_src(comp_id, pipeline_id, size, &src, file);
+	ret = tplg_load_src(ctx, &src);
 	if (ret < 0)
 		return ret;
 
-	if (tplg_load_controls(widget->num_kcontrols, file) < 0) {
+	if (tplg_load_controls(ctx->widget->num_kcontrols, file) < 0) {
 		fprintf(stderr, "error: loading controls\n");
 		return -EINVAL;
 	}
@@ -535,21 +525,19 @@ int load_src(void *dev, int comp_id, int pipeline_id,
 }
 
 /* load asrc dapm widget */
-int load_asrc(void *dev, int comp_id, int pipeline_id,
-	      struct snd_soc_tplg_dapm_widget *widget,
-	      void *params)
+int load_asrc(struct tplg_context *ctx)
 {
-	struct testbench_prm *tp = (struct testbench_prm *)params;
-	struct sof *sof = (struct sof *)dev;
+	struct snd_soc_tplg_dapm_widget *widget = ctx->widget;
+	struct sof *sof = ctx->sof;
 	struct sof_ipc_comp_asrc asrc = {0};
-	int size = widget->priv.size;
+	struct testbench_prm *tp = ctx->tp;
 	int ret = 0;
 
-	ret = tplg_load_asrc(comp_id, pipeline_id, size, &asrc, file);
+	ret = tplg_load_asrc(ctx, &asrc);
 	if (ret < 0)
 		return ret;
 
-	if (tplg_load_controls(widget->num_kcontrols, file) < 0) {
+	if (tplg_load_controls(widget->num_kcontrols, ctx->file) < 0) {
 		fprintf(stderr, "error: loading controls\n");
 		return -EINVAL;
 	}
@@ -629,21 +617,19 @@ static int process_append_data(struct sof_ipc_comp_process **process_ipc,
 }
 
 /* load process dapm widget */
-int load_process(void *dev, int comp_id, int pipeline_id,
-		 struct snd_soc_tplg_dapm_widget *widget)
+int load_process(struct tplg_context *ctx)
 {
-	struct sof *sof = (struct sof *)dev;
+	struct sof *sof = ctx->sof;
+	struct snd_soc_tplg_dapm_widget *widget = ctx->widget;
 	struct sof_ipc_comp_process process = {0};
 	struct sof_ipc_comp_process *process_ipc = NULL;
 	struct snd_soc_tplg_ctl_hdr *ctl = NULL;
 	struct sof_ipc_comp_ext comp_ext;
 	char *priv_data = NULL;
-	int size;
 	int ret = 0;
 	int i;
 
-	size = widget->priv.size;
-	ret = tplg_load_process(comp_id, pipeline_id, size, &process, file, &comp_ext);
+	ret = tplg_load_process(ctx, &process, &comp_ext);
 	if (ret < 0)
 		return ret;
 
@@ -654,7 +640,8 @@ int load_process(void *dev, int comp_id, int pipeline_id,
 
 	/* Get control into ctl and priv_data */
 	for (i = 0; i < widget->num_kcontrols; i++) {
-		ret = tplg_load_one_control(&ctl, &priv_data, file);
+		ret = tplg_load_one_control(&ctl, &priv_data, ctx->file);
+
 		if (ret < 0) {
 			fprintf(stderr, "error: failed control load\n");
 			return ret;
@@ -694,18 +681,17 @@ int load_process(void *dev, int comp_id, int pipeline_id,
 }
 
 /* load mixer dapm widget */
-int load_mixer(void *dev, int comp_id, int pipeline_id,
-	       struct snd_soc_tplg_dapm_widget *widget)
+int load_mixer(struct tplg_context *ctx)
 {
 	struct sof_ipc_comp_mixer mixer = {0};
-	int size = widget->priv.size;
+	FILE *file = ctx->file;
 	int ret = 0;
 
-	ret = tplg_load_mixer(comp_id, pipeline_id, size, &mixer, file);
+	ret = tplg_load_mixer(ctx, &mixer);
 	if (ret < 0)
 		return ret;
 
-	if (tplg_load_controls(widget->num_kcontrols, file) < 0) {
+	if (tplg_load_controls(ctx->widget->num_kcontrols, file) < 0) {
 		fprintf(stderr, "error: loading controls\n");
 		return -EINVAL;
 	}
@@ -713,39 +699,54 @@ int load_mixer(void *dev, int comp_id, int pipeline_id,
 	return ret;
 }
 
+static int get_next_hdr(struct tplg_context *ctx, struct snd_soc_tplg_hdr *hdr, size_t file_size)
+{
+	if (fseek(ctx->file, hdr->payload_size, SEEK_CUR)) {
+		fprintf(stderr, "error: fseek payload size\n");
+		return -errno;
+	}
+
+	if (ftell(ctx->file) == file_size)
+		return 0;
+
+	return 1;
+}
+
 /* parse topology file and set up pipeline */
-int parse_topology(struct sof *sof,
-		   struct testbench_prm *tp, char *pipeline_msg)
+int parse_topology(struct tplg_context *ctx)
 {
 	struct snd_soc_tplg_hdr *hdr;
-
-	/* initialize output file index */
-	output_file_index = 0;
-
-	struct comp_info *temp_comp_list = NULL, *comp_list_realloc = NULL;
+	struct testbench_prm *tp = ctx->tp;
+	struct comp_info *comp_list_realloc = NULL;
 	char message[DEBUG_MSG_LEN];
-	int next_comp_id = 0;
-	int num_comps = 0;
 	int i;
+	int next;
 	int ret = 0;
 	size_t file_size;
 	size_t size;
 
-	/* open topology file */
-	file = fopen(tp->tplg_file, "rb");
-	if (!file) {
-		fprintf(stderr, "error: opening file %s\n", tp->tplg_file);
-		return -EINVAL;
-	}
+	/* initialize output file index */
+	tp->output_file_index = 0;
 
-	/* file size */
-	if (fseek(file, 0, SEEK_END)) {
-		fprintf(stderr, "error: seek to end of topology\n");
+	/* open topology file */
+	ctx->file = fopen(ctx->tplg_file, "rb");
+	if (!ctx->file) {
+		fprintf(stderr, "error: opening file %s\n", ctx->tplg_file);
+		fprintf(stderr, "error: %s\n", strerror(errno));
 		return -errno;
 	}
-	file_size = ftell(file);
-	if (fseek(file, 0, SEEK_SET)) {
+	tp->file = ctx->file; /* duplicated until we can merge tp with ctx */
+
+	/* file size */
+	if (fseek(ctx->file, 0, SEEK_END)) {
+		fprintf(stderr, "error: seek to end of topology\n");
+		fclose(ctx->file);
+		return -errno;
+	}
+	file_size = ftell(ctx->file);
+	if (fseek(ctx->file, 0, SEEK_SET)) {
 		fprintf(stderr, "error: seek to beginning of topology\n");
+		fclose(ctx->file);
 		return -errno;
 	}
 
@@ -754,25 +755,39 @@ int parse_topology(struct sof *sof,
 	hdr = (struct snd_soc_tplg_hdr *)malloc(size);
 	if (!hdr) {
 		fprintf(stderr, "error: mem alloc\n");
+		fclose(ctx->file);
 		return -errno;
 	}
 
 	debug_print("topology parsing start\n");
 	while (1) {
 		/* read topology header */
-		ret = fread(hdr, sizeof(struct snd_soc_tplg_hdr), 1, file);
+		ret = fread(hdr, sizeof(struct snd_soc_tplg_hdr), 1, ctx->file);
 		if (ret != 1)
-			return -EINVAL;
+			goto out;
 
 		sprintf(message, "type: %x, size: 0x%x count: %d index: %d\n",
 			hdr->type, hdr->payload_size, hdr->count, hdr->index);
 
 		debug_print(message);
 
+		ctx->hdr = hdr;
+
+		if (hdr->index != ctx->pipeline_id) {
+			next = get_next_hdr(ctx, hdr, file_size);
+			if (next < 0)
+				goto out;
+			else if (next > 0)
+				continue;
+			else
+				goto finish;
+		}
+
 		/* parse header and load the next block based on type */
 		switch (hdr->type) {
 		/* load dapm widget */
 		case SND_SOC_TPLG_TYPE_DAPM_WIDGET:
+
 			sprintf(message, "number of DAPM widgets %d\n",
 				hdr->count);
 
@@ -782,70 +797,65 @@ int parse_topology(struct sof *sof,
 			if (hdr->index > tp->max_pipeline_id)
 				tp->max_pipeline_id = hdr->index;
 
-			num_comps += hdr->count;
-			size = sizeof(struct comp_info) * num_comps;
+			ctx->info_elems += hdr->count;
+			size = sizeof(struct comp_info) * ctx->info_elems;
 			comp_list_realloc = (struct comp_info *)
-					 realloc(temp_comp_list, size);
+					 realloc(ctx->info, size);
 
 			if (!comp_list_realloc && size) {
-				free(temp_comp_list);
-				free(hdr);
-				fclose(file);
 				fprintf(stderr, "error: mem realloc\n");
-				return -errno;
+				ret = -errno;
+				goto out;
 			}
-			temp_comp_list = comp_list_realloc;
+			ctx->info = comp_list_realloc;
 
-			for (i = (num_comps - hdr->count); i < num_comps; i++)
-				temp_comp_list[i].name = NULL;
+			for (i = (ctx->info_elems - hdr->count); i < ctx->info_elems; i++)
+				ctx->info[i].name = NULL;
 
-			for (i = (num_comps - hdr->count); i < num_comps; i++) {
-				ret = load_widget(sof, SOF_DEV,
-						  temp_comp_list,
-						  next_comp_id++, i,
-						  hdr->index, tp, &tp->sched_id,
-						  file);
+			for (ctx->info_index = (ctx->info_elems - hdr->count);
+			     ctx->info_index < ctx->info_elems;
+			     ctx->info_index++) {
+				ret = load_widget(ctx);
 				if (ret < 0) {
 					printf("error: loading widget\n");
 					goto finish;
-				}
+				} else if (ret > 0)
+					ctx->comp_id++;
 			}
 			break;
 
 		/* set up component connections from pipeline graph */
 		case SND_SOC_TPLG_TYPE_DAPM_GRAPH:
-			if (load_graph(sof, temp_comp_list, hdr->count,
-				       num_comps, hdr->index) < 0) {
+			if (load_graph(ctx->sof, ctx->info, tp, hdr->count,
+				       ctx->comp_id, hdr->index) < 0) {
 				fprintf(stderr, "error: pipeline graph\n");
-				return -EINVAL;
+				ret = -EINVAL;
+				goto out;
 			}
-			if (ftell(file) == file_size)
+			if (ftell(ctx->file) == file_size)
 				goto finish;
 			break;
 
 		default:
-			if (fseek(file, hdr->payload_size, SEEK_CUR)) {
-				fprintf(stderr, "error: fseek payload size\n");
-				return -errno;
-			}
-
-			if (ftell(file) == file_size)
+			next = get_next_hdr(ctx, hdr, file_size);
+			if (next < 0)
+				goto out;
+			else if (next == 0)
 				goto finish;
-
 			break;
 		}
 	}
 finish:
 	debug_print("topology parsing end\n");
-	strcpy(pipeline_msg, pipeline_string);
 
+out:
 	/* free all data */
 	free(hdr);
 
-	for (i = 0; i < num_comps; i++)
-		free(temp_comp_list[i].name);
+	for (i = 0; i < ctx->info_elems; i++)
+		free(ctx->info[i].name);
 
-	free(temp_comp_list);
-	fclose(file);
+	free(ctx->info);
+	fclose(ctx->file);
 	return ret;
 }

--- a/tools/tplg_parser/tplg_parser.c
+++ b/tools/tplg_parser/tplg_parser.c
@@ -150,18 +150,21 @@ int tplg_read_array(struct snd_soc_tplg_vendor_array *array, FILE *file)
 }
 
 /* load buffer DAPM widget */
-int tplg_load_buffer(int comp_id, int pipeline_id, int size,
-		     struct sof_ipc_buffer *buffer, FILE *file)
+int tplg_load_buffer(struct tplg_context *ctx,
+		     struct sof_ipc_buffer *buffer)
 {
 	struct snd_soc_tplg_vendor_array *array;
 	size_t read_size;
 	size_t parsed_size = 0;
+	FILE *file = ctx->file;
+	int size = ctx->widget->priv.size;
+	int comp_id = ctx->comp_id;
 	int ret;
 
 	/* configure buffer */
 	buffer->comp.core = 0;
 	buffer->comp.id = comp_id;
-	buffer->comp.pipeline_id = pipeline_id;
+	buffer->comp.pipeline_id = ctx->pipeline_id;
 	buffer->comp.hdr.cmd = SOF_IPC_GLB_TPLG_MSG | SOF_IPC_TPLG_BUFFER_NEW;
 	buffer->comp.type = SOF_COMP_BUFFER;
 	buffer->comp.hdr.size = sizeof(struct sof_ipc_buffer);
@@ -227,11 +230,14 @@ int tplg_load_buffer(int comp_id, int pipeline_id, int size,
 	return 0;
 }
 
-int tplg_load_pcm(int comp_id, int pipeline_id, int size, int dir,
-		  struct sof_ipc_comp_host *host, FILE *file)
+int tplg_load_pcm(struct tplg_context *ctx, int dir,
+		  struct sof_ipc_comp_host *host)
 {
 	struct snd_soc_tplg_vendor_array *array = NULL;
 	size_t total_array_size = 0, read_size;
+	FILE *file = ctx->file;
+	int size = ctx->widget->priv.size;
+	int comp_id = ctx->comp_id;
 	int ret;
 
 	/* configure host comp IPC message */
@@ -239,7 +245,7 @@ int tplg_load_pcm(int comp_id, int pipeline_id, int size, int dir,
 	host->comp.hdr.cmd = SOF_IPC_GLB_TPLG_MSG | SOF_IPC_TPLG_COMP_NEW;
 	host->comp.id = comp_id;
 	host->comp.type = SOF_COMP_HOST;
-	host->comp.pipeline_id = pipeline_id;
+	host->comp.pipeline_id = ctx->pipeline_id;
 	host->direction = dir;
 	host->config.hdr.size = sizeof(host->config);
 
@@ -300,11 +306,13 @@ int tplg_load_pcm(int comp_id, int pipeline_id, int size, int dir,
 }
 
 /* load dai component */
-int tplg_load_dai(int comp_id, int pipeline_id, int size,
-		  struct sof_ipc_comp_dai *comp_dai, FILE *file)
+int tplg_load_dai(struct tplg_context *ctx, struct sof_ipc_comp_dai *comp_dai)
 {
 	struct snd_soc_tplg_vendor_array *array;
 	size_t total_array_size = 0, read_size;
+	FILE *file = ctx->file;
+	int size = ctx->widget->priv.size;
+	int comp_id = ctx->comp_id;
 	int ret;
 
 	/* configure comp_dai */
@@ -312,7 +320,7 @@ int tplg_load_dai(int comp_id, int pipeline_id, int size,
 	comp_dai->comp.hdr.cmd = SOF_IPC_GLB_TPLG_MSG | SOF_IPC_TPLG_COMP_NEW;
 	comp_dai->comp.id = comp_id;
 	comp_dai->comp.type = SOF_COMP_DAI;
-	comp_dai->comp.pipeline_id = pipeline_id;
+	comp_dai->comp.pipeline_id = ctx->pipeline_id;
 	comp_dai->config.hdr.size = sizeof(comp_dai->config);
 
 	/* allocate memory for vendor tuple array */
@@ -373,11 +381,13 @@ int tplg_load_dai(int comp_id, int pipeline_id, int size,
 }
 
 /* load pda dapm widget */
-int tplg_load_pga(int comp_id, int pipeline_id, int size,
-		  struct sof_ipc_comp_volume *volume, FILE *file)
+int tplg_load_pga(struct tplg_context *ctx, struct sof_ipc_comp_volume *volume)
 {
 	struct snd_soc_tplg_vendor_array *array = NULL;
 	size_t total_array_size = 0, read_size;
+	FILE *file = ctx->file;
+	int size = ctx->widget->priv.size;
+	int comp_id = ctx->comp_id;
 	int ret;
 
 	/* allocate memory for vendor tuple array */
@@ -439,7 +449,7 @@ int tplg_load_pga(int comp_id, int pipeline_id, int size,
 	volume->comp.id = comp_id;
 	volume->comp.hdr.size = sizeof(struct sof_ipc_comp_volume);
 	volume->comp.type = SOF_COMP_VOLUME;
-	volume->comp.pipeline_id = pipeline_id;
+	volume->comp.pipeline_id = ctx->pipeline_id;
 	volume->config.hdr.size = sizeof(struct sof_ipc_comp_config);
 
 	free(array);
@@ -447,20 +457,21 @@ int tplg_load_pga(int comp_id, int pipeline_id, int size,
 }
 
 /* load scheduler dapm widget */
-int tplg_load_pipeline(int comp_id, int pipeline_id, int size,
-		       struct sof_ipc_pipe_new *pipeline, FILE *file)
+int tplg_load_pipeline(struct tplg_context *ctx,
+		       struct sof_ipc_pipe_new *pipeline)
 {
 	struct snd_soc_tplg_vendor_array *array = NULL;
 	size_t total_array_size = 0, read_size;
+	FILE *file = ctx->file;
+	int size = ctx->widget->priv.size;
+	int comp_id = ctx->comp_id;
 	int ret;
 
 	/* configure pipeline */
 	pipeline->comp_id = comp_id;
-	pipeline->pipeline_id = pipeline_id;
+	pipeline->pipeline_id = ctx->pipeline_id;
 	pipeline->hdr.size = sizeof(*pipeline);
 	pipeline->hdr.cmd = SOF_IPC_GLB_TPLG_MSG | SOF_IPC_TPLG_PIPE_NEW;
-	pipeline->comp_id = comp_id;
-	pipeline->pipeline_id = pipeline_id;
 
 	/* allocate memory for vendor tuple array */
 	array = (struct snd_soc_tplg_vendor_array *)malloc(size);
@@ -828,11 +839,14 @@ err:
 }
 
 /* load src dapm widget */
-int tplg_load_src(int comp_id, int pipeline_id, int size,
-		  struct sof_ipc_comp_src *src, FILE *file)
+int tplg_load_src(struct tplg_context *ctx,
+		  struct sof_ipc_comp_src *src)
 {
 	struct snd_soc_tplg_vendor_array *array = NULL;
 	size_t total_array_size = 0, read_size;
+	FILE *file = ctx->file;
+	int size = ctx->widget->priv.size;
+	int comp_id = ctx->comp_id;
 	int ret;
 
 	/* allocate memory for vendor tuple array */
@@ -900,7 +914,7 @@ int tplg_load_src(int comp_id, int pipeline_id, int size,
 	src->comp.id = comp_id;
 	src->comp.hdr.size = sizeof(struct sof_ipc_comp_src);
 	src->comp.type = SOF_COMP_SRC;
-	src->comp.pipeline_id = pipeline_id;
+	src->comp.pipeline_id = ctx->pipeline_id;
 	src->config.hdr.size = sizeof(struct sof_ipc_comp_config);
 
 	free(array);
@@ -908,12 +922,12 @@ int tplg_load_src(int comp_id, int pipeline_id, int size,
 }
 
 /* load asrc dapm widget */
-int tplg_load_asrc(int comp_id, int pipeline_id, int size,
-		   struct sof_ipc_comp_asrc *asrc, FILE *file)
+int tplg_load_asrc(struct tplg_context *ctx, struct sof_ipc_comp_asrc *asrc)
 {
 	struct snd_soc_tplg_vendor_array *array = NULL;
-	size_t total_array_size = 0, read_size;
-	int ret;
+	size_t total_array_size = 0, read_size, size = ctx->widget_size;
+	FILE *file = ctx->file;
+	int ret, comp_id = ctx->comp_id;
 
 	/* allocate memory for vendor tuple array */
 	array = (struct snd_soc_tplg_vendor_array *)malloc(size);
@@ -950,7 +964,7 @@ int tplg_load_asrc(int comp_id, int pipeline_id, int size,
 				       ARRAY_SIZE(comp_tokens), array,
 				       array->size);
 		if (ret != 0) {
-			fprintf(stderr, "error: parse asrc comp_tokens %d\n",
+			fprintf(stderr, "error: parse asrc comp_tokens %zu\n",
 				size);
 			free(MOVE_POINTER_BY_BYTES(array, -total_array_size));
 			return -EINVAL;
@@ -961,7 +975,7 @@ int tplg_load_asrc(int comp_id, int pipeline_id, int size,
 				       ARRAY_SIZE(asrc_tokens), array,
 				       array->size);
 		if (ret != 0) {
-			fprintf(stderr, "error: parse asrc tokens %d\n", size);
+			fprintf(stderr, "error: parse asrc tokens %zu\n", size);
 			free(MOVE_POINTER_BY_BYTES(array, -total_array_size));
 			return -EINVAL;
 		}
@@ -980,7 +994,7 @@ int tplg_load_asrc(int comp_id, int pipeline_id, int size,
 	asrc->comp.id = comp_id;
 	asrc->comp.hdr.size = sizeof(struct sof_ipc_comp_asrc);
 	asrc->comp.type = SOF_COMP_ASRC;
-	asrc->comp.pipeline_id = pipeline_id;
+	asrc->comp.pipeline_id = ctx->pipeline_id;
 	asrc->config.hdr.size = sizeof(struct sof_ipc_comp_config);
 
 	free(array);
@@ -988,13 +1002,16 @@ int tplg_load_asrc(int comp_id, int pipeline_id, int size,
 }
 
 /* load asrc dapm widget */
-int tplg_load_process(int comp_id, int pipeline_id, int size,
-		      struct sof_ipc_comp_process *process, FILE *file,
+int tplg_load_process(struct tplg_context *ctx,
+		      struct sof_ipc_comp_process *process,
 		      struct sof_ipc_comp_ext *comp_ext)
 {
 	struct snd_soc_tplg_vendor_array *array = NULL;
 	size_t total_array_size = 0;
 	size_t read_size;
+	FILE *file = ctx->file;
+	int size = ctx->widget->priv.size;
+	int comp_id = ctx->comp_id;
 	int ret;
 
 	/* allocate memory for vendor tuple array */
@@ -1075,7 +1092,7 @@ int tplg_load_process(int comp_id, int pipeline_id, int size,
 	process->comp.id = comp_id;
 	process->comp.hdr.size = sizeof(struct sof_ipc_comp_asrc);
 	process->comp.type = find_process_comp_type(process->type);
-	process->comp.pipeline_id = pipeline_id;
+	process->comp.pipeline_id = ctx->pipeline_id;
 	process->config.hdr.size = sizeof(struct sof_ipc_comp_config);
 
 	free(array);
@@ -1083,11 +1100,14 @@ int tplg_load_process(int comp_id, int pipeline_id, int size,
 }
 
 /* load mixer dapm widget */
-int tplg_load_mixer(int comp_id, int pipeline_id, int size,
-		    struct sof_ipc_comp_mixer *mixer, FILE *file)
+int tplg_load_mixer(struct tplg_context *ctx,
+		    struct sof_ipc_comp_mixer *mixer)
 {
 	struct snd_soc_tplg_vendor_array *array = NULL;
 	size_t total_array_size = 0, read_size;
+	FILE *file = ctx->file;
+	int size = ctx->widget->priv.size;
+	int comp_id = ctx->comp_id;
 	int ret;
 
 	/* allocate memory for vendor tuple array */
@@ -1145,7 +1165,7 @@ int tplg_load_mixer(int comp_id, int pipeline_id, int size,
 	mixer->comp.id = comp_id;
 	mixer->comp.hdr.size = sizeof(struct sof_ipc_comp_src);
 	mixer->comp.type = SOF_COMP_MIXER;
-	mixer->comp.pipeline_id = pipeline_id;
+	mixer->comp.pipeline_id = ctx->pipeline_id;
 	mixer->config.hdr.size = sizeof(struct sof_ipc_comp_config);
 
 	free(array);
@@ -1223,14 +1243,13 @@ int tplg_load_graph(int num_comps, int pipeline_id,
 }
 
 /* load dapm widget */
-int load_widget(void *dev, int dev_type, struct comp_info *temp_comp_list,
-		int comp_id, int comp_index, int pipeline_id,
-		void *tp, int *sched_id, FILE *file)
+int load_widget(struct tplg_context *ctx)
 {
-	struct snd_soc_tplg_dapm_widget *widget;
-	size_t read_size;
-	size_t size;
+	struct comp_info *temp_comp_list = ctx->info;
+	int comp_index = ctx->info_index;
+	int comp_id = ctx->comp_id;
 	int ret = 0;
+	int dev_type = ctx->dev_type;
 
 	if (!temp_comp_list) {
 		fprintf(stderr, "load_widget: temp_comp_list argument NULL\n");
@@ -1238,16 +1257,15 @@ int load_widget(void *dev, int dev_type, struct comp_info *temp_comp_list,
 	}
 
 	/* allocate memory for widget */
-	size = sizeof(struct snd_soc_tplg_dapm_widget);
-	widget = (struct snd_soc_tplg_dapm_widget *)malloc(size);
-	if (!widget) {
+	ctx->widget_size = sizeof(struct snd_soc_tplg_dapm_widget);
+	ctx->widget = malloc(ctx->widget_size);
+	if (!ctx->widget) {
 		fprintf(stderr, "error: mem alloc\n");
 		return -errno;
 	}
 
 	/* read widget data */
-	read_size = sizeof(struct snd_soc_tplg_dapm_widget);
-	ret = fread(widget, read_size, 1, file);
+	ret = fread(ctx->widget, ctx->widget_size, 1, ctx->file);
 	if (ret != 1) {
 		ret = -EINVAL;
 		goto exit;
@@ -1259,99 +1277,93 @@ int load_widget(void *dev, int dev_type, struct comp_info *temp_comp_list,
 	 * which will be used for setting up component connections
 	 */
 	temp_comp_list[comp_index].id = comp_id;
-	temp_comp_list[comp_index].name = strdup(widget->name);
-	temp_comp_list[comp_index].type = widget->id;
-	temp_comp_list[comp_index].pipeline_id = pipeline_id;
+	temp_comp_list[comp_index].name = strdup(ctx->widget->name);
+	temp_comp_list[comp_index].type = ctx->widget->id;
+	temp_comp_list[comp_index].pipeline_id = ctx->pipeline_id;
 
 	printf("debug: loading comp_id %d: widget %s id %d\n",
-	       comp_id, widget->name, widget->id);
+	       comp_id, ctx->widget->name, ctx->widget->id);
 
 	/* load widget based on type */
-	switch (widget->id) {
+	switch (ctx->widget->id) {
 
 	/* load pga widget */
-	case(SND_SOC_TPLG_DAPM_PGA):
-		if (load_pga(dev, comp_id, pipeline_id, widget) < 0) {
+	case SND_SOC_TPLG_DAPM_PGA:
+		if (load_pga(ctx) < 0) {
 			fprintf(stderr, "error: load pga\n");
 			ret = -EINVAL;
 			goto exit;
 		}
 		break;
-	case(SND_SOC_TPLG_DAPM_AIF_IN):
-		if (load_aif_in_out(dev, comp_id, pipeline_id, widget,
-				    SOF_IPC_STREAM_PLAYBACK, tp) < 0) {
+	case SND_SOC_TPLG_DAPM_AIF_IN:
+		if (load_aif_in_out(ctx, SOF_IPC_STREAM_PLAYBACK) < 0) {
 			fprintf(stderr, "error: load AIF IN failed\n");
 			ret = -EINVAL;
 			goto exit;
 		}
 		break;
-	case(SND_SOC_TPLG_DAPM_AIF_OUT):
-		if (load_aif_in_out(dev, comp_id, pipeline_id, widget,
-				    SOF_IPC_STREAM_CAPTURE, tp) < 0) {
+	case SND_SOC_TPLG_DAPM_AIF_OUT:
+		if (load_aif_in_out(ctx, SOF_IPC_STREAM_CAPTURE) < 0) {
 			fprintf(stderr, "error: load AIF OUT failed\n");
 			ret = -EINVAL;
 			goto exit;
 		}
 		break;
-	case(SND_SOC_TPLG_DAPM_DAI_IN):
-		if (load_dai_in_out(dev, comp_id, pipeline_id, widget,
-				    SOF_IPC_STREAM_PLAYBACK, tp) < 0) {
+	case SND_SOC_TPLG_DAPM_DAI_IN:
+		if (load_dai_in_out(ctx, SOF_IPC_STREAM_PLAYBACK) < 0) {
 			fprintf(stderr, "error: load filewrite\n");
 			ret = -EINVAL;
 			goto exit;
 		}
 		break;
-	case(SND_SOC_TPLG_DAPM_DAI_OUT):
-		if (load_dai_in_out(dev, comp_id, pipeline_id, widget,
-				    SOF_IPC_STREAM_CAPTURE, tp) < 0) {
+	case SND_SOC_TPLG_DAPM_DAI_OUT:
+		if (load_dai_in_out(ctx, SOF_IPC_STREAM_CAPTURE) < 0) {
 			fprintf(stderr, "error: load filewrite\n");
 			ret = -EINVAL;
 			goto exit;
 		}
 		break;
-	case(SND_SOC_TPLG_DAPM_BUFFER):
-		if (load_buffer(dev, comp_id, pipeline_id, widget) < 0) {
+	case SND_SOC_TPLG_DAPM_BUFFER:
+		if (load_buffer(ctx) < 0) {
 			fprintf(stderr, "error: load buffer\n");
 			ret = -EINVAL;
 			goto exit;
 		}
 		break;
-	case(SND_SOC_TPLG_DAPM_SCHEDULER):
+	case SND_SOC_TPLG_DAPM_SCHEDULER:
 		/* find comp id for scheduling comp */
 		if (dev_type == FUZZER_DEV)
-			*sched_id = find_widget(temp_comp_list, comp_id,
-						widget->sname);
+			ctx->sched_id = find_widget(temp_comp_list, comp_id, ctx->widget->sname);
 
-		if (load_pipeline(dev, comp_id, pipeline_id, widget,
-				  *sched_id) < 0) {
+		if (load_pipeline(ctx) < 0) {
 			fprintf(stderr, "error: load pipeline\n");
 			ret = -EINVAL;
 			goto exit;
 		}
 		break;
-	case(SND_SOC_TPLG_DAPM_SRC):
-		if (load_src(dev, comp_id, pipeline_id, widget, tp) < 0) {
+	case SND_SOC_TPLG_DAPM_SRC:
+		if (load_src(ctx) < 0) {
 			fprintf(stderr, "error: load src\n");
 			ret = -EINVAL;
 			goto exit;
 		}
 		break;
-	case(SND_SOC_TPLG_DAPM_ASRC):
-		if (load_asrc(dev, comp_id, pipeline_id, widget, tp) < 0) {
+	case SND_SOC_TPLG_DAPM_ASRC:
+		if (load_asrc(ctx) < 0) {
 			fprintf(stderr, "error: load src\n");
 			ret = -EINVAL;
 			goto exit;
 		}
 		break;
-	case(SND_SOC_TPLG_DAPM_MIXER):
-		if (load_mixer(dev, comp_id, pipeline_id, widget) < 0) {
+	case SND_SOC_TPLG_DAPM_MIXER:
+		if (load_mixer(ctx) < 0) {
 			fprintf(stderr, "error: load mixer\n");
 			ret = -EINVAL;
 			goto exit;
 		}
 		break;
-	case(SND_SOC_TPLG_DAPM_EFFECT):
-		if (load_process(dev, comp_id, pipeline_id, widget) < 0) {
+	case SND_SOC_TPLG_DAPM_EFFECT:
+		if (load_process(ctx) < 0) {
 			fprintf(stderr, "error: load effect\n");
 			ret = -EINVAL;
 			goto exit;
@@ -1359,26 +1371,27 @@ int load_widget(void *dev, int dev_type, struct comp_info *temp_comp_list,
 		break;
 	/* unsupported widgets */
 	default:
-		if (fseek(file, widget->priv.size, SEEK_CUR)) {
+		if (fseek(ctx->file, ctx->widget->priv.size, SEEK_CUR)) {
 			fprintf(stderr, "error: fseek unsupported widget\n");
 			ret = -errno;
 			goto exit;
 		}
 
-		printf("info: Widget type not supported %d\n", widget->id);
-		ret = tplg_load_controls(widget->num_kcontrols, file);
+		printf("info: Widget type not supported %d\n", ctx->widget->id);
+		ret = tplg_load_controls(ctx->widget->num_kcontrols, ctx->file);
 		if (ret < 0) {
 			fprintf(stderr, "error: loading controls\n");
 			goto exit;
 		}
+		ret = 0;
 		break;
 	}
 
-	ret = 0;
+	ret = 1;
 
 exit:
 	/* free allocated widget data */
-	free(widget);
+	free(ctx->widget);
 	return ret;
 }
 


### PR DESCRIPTION
This is rebased version of #4653 with commits 12 (testbench: cache: add support for initial testbench cache checker) and 13 (arch: host: Add host locking via pthread mutexes dropped). 

Commit 17 fix approach is changed because the first way broke pipeline HW parameters get from file DAI. In this version mimicking of DAI is improved to not segfault from missing init delay function access.