### PR TITLE
codec_adapter: fix deep_buffer_bytes calculation

### DIFF
--- a/src/audio/codec_adapter/codec_adapter.c
+++ b/src/audio/codec_adapter/codec_adapter.c
@@ -163,8 +163,15 @@ int codec_adapter_prepare(struct comp_dev *dev)
 			       (mod->period_bytes / md->mpd.in_buff_size) + 1;
 	}
 
+	/*
+	 * deep_buffer_bytes is a measure of how many bytes we need to send to the DAI before
+	 * the module starts producing samples. In a normal copy() walk it might be possible that
+	 * the first period_bytes copied to input_buffer might not be enough for the processing
+	 * to begin. So, in order to prevent the DAI from starving, it needs to be fed zeroes until
+	 * the module starts processing and generating output samples.
+	 */
 	if (md->mpd.in_buff_size != mod->period_bytes)
-		mod->deep_buff_bytes = mod->period_bytes * buff_periods;
+		mod->deep_buff_bytes = MIN(mod->period_bytes, md->mpd.in_buff_size) * buff_periods;
 
 	/* Allocate local buffer */
 	buff_size = MAX(mod->period_bytes, md->mpd.out_buff_size) * buff_periods;

--- a/src/audio/codec_adapter/codec_adapter.c
+++ b/src/audio/codec_adapter/codec_adapter.c
@@ -106,9 +106,7 @@ int codec_adapter_prepare(struct comp_dev *dev)
 	int ret;
 	struct processing_module *mod = comp_get_drvdata(dev);
 	struct module_data *md = &mod->priv;
-	uint32_t buff_periods = 2; /* default periods of local buffer,
-				    * may change if case of deep buffering
-				    */
+	uint32_t buff_periods;
 	uint32_t buff_size; /* size of local buffer */
 
 	comp_dbg(dev, "codec_adapter_prepare() start");
@@ -146,6 +144,8 @@ int codec_adapter_prepare(struct comp_dev *dev)
 		return -EIO;
 	}
 
+	mod->deep_buff_bytes = 0;
+
 	/* Codec is prepared, now we need to configure processing settings.
 	 * If codec internal buffer is not equal to natural multiple of pipeline
 	 * buffer we have a situation where CA have to deep buffer certain amount
@@ -153,21 +153,18 @@ int codec_adapter_prepare(struct comp_dev *dev)
 	 * generate output once started (same situation happens for compress streams
 	 * as well).
 	 */
-	if (md->mpd.in_buff_size != mod->period_bytes) {
-		if (md->mpd.in_buff_size > mod->period_bytes) {
-			buff_periods = (md->mpd.in_buff_size % mod->period_bytes) ?
-				       (md->mpd.in_buff_size / mod->period_bytes) + 2 :
-				       (md->mpd.in_buff_size / mod->period_bytes) + 1;
-		} else {
-			buff_periods = (mod->period_bytes % md->mpd.in_buff_size) ?
-				       (mod->period_bytes / md->mpd.in_buff_size) + 2 :
-				       (mod->period_bytes / md->mpd.in_buff_size) + 1;
-		}
-
-		mod->deep_buff_bytes = mod->period_bytes * buff_periods;
+	if (md->mpd.in_buff_size > mod->period_bytes) {
+		buff_periods = (md->mpd.in_buff_size % mod->period_bytes) ?
+			       (md->mpd.in_buff_size / mod->period_bytes) + 2 :
+			       (md->mpd.in_buff_size / mod->period_bytes) + 1;
 	} else {
-		mod->deep_buff_bytes = 0;
+		buff_periods = (mod->period_bytes % md->mpd.in_buff_size) ?
+			       (mod->period_bytes / md->mpd.in_buff_size) + 2 :
+			       (mod->period_bytes / md->mpd.in_buff_size) + 1;
 	}
+
+	if (md->mpd.in_buff_size != mod->period_bytes)
+		mod->deep_buff_bytes = mod->period_bytes * buff_periods;
 
 	/* Allocate local buffer */
 	buff_size = MAX(mod->period_bytes, md->mpd.out_buff_size) * buff_periods;

--- a/src/audio/codec_adapter/codec_adapter.c
+++ b/src/audio/codec_adapter/codec_adapter.c
@@ -173,8 +173,24 @@ int codec_adapter_prepare(struct comp_dev *dev)
 	if (md->mpd.in_buff_size != mod->period_bytes)
 		mod->deep_buff_bytes = MIN(mod->period_bytes, md->mpd.in_buff_size) * buff_periods;
 
-	/* Allocate local buffer */
+	if (md->mpd.out_buff_size > mod->period_bytes) {
+		buff_periods = (md->mpd.out_buff_size % mod->period_bytes) ?
+			       (md->mpd.out_buff_size / mod->period_bytes) + 2 :
+			       (md->mpd.out_buff_size / mod->period_bytes) + 1;
+	} else {
+		buff_periods = (mod->period_bytes % md->mpd.out_buff_size) ?
+			       (mod->period_bytes / md->mpd.out_buff_size) + 2 :
+			       (mod->period_bytes / md->mpd.out_buff_size) + 1;
+	}
+
+	/*
+	 * It is possible that the module process() will produce more data than period_bytes but
+	 * the DAI can consume only period_bytes every period. So, the local buffer needs to be
+	 * large enough to save the produced output samples.
+	 */
 	buff_size = MAX(mod->period_bytes, md->mpd.out_buff_size) * buff_periods;
+
+	/* Allocate local buffer */
 	if (mod->local_buff) {
 		ret = buffer_set_size(mod->local_buff, buff_size);
 		if (ret < 0) {


### PR DESCRIPTION
Fix the deep_buffer_bytes calculation to use the out_buff_size instead
of in_buff_size. Remove the default periods for the local buffer as the
calculation should work out to 2 when period bytes and out_buff_size are
equal.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>