### PR TITLE
Adl004 backport patches

### DIFF
--- a/src/audio/smart_amp/smart_amp_maxim_dsm.c
+++ b/src/audio/smart_amp/smart_amp_maxim_dsm.c
@@ -212,7 +212,7 @@ int maxim_dsm_set_param(struct smart_amp_mod_struct_t *hspk,
 	/* Model database */
 	int32_t *db = (int32_t *)caldata->data;
 	/* Payload buffer */
-	int *wparam = ASSUME_ALIGNED(cdata->data->data, 4);
+	uint32_t *wparam = (uint32_t *)ASSUME_ALIGNED(cdata->data->data, 4);
 	/* number of parameters to read */
 	int num_param = (cdata->num_elems >> 2);
 	int idx, id, ch;

--- a/src/schedule/ll_schedule.c
+++ b/src/schedule/ll_schedule.c
@@ -665,15 +665,13 @@ static void scheduler_free_ll(void *data, uint32_t flags)
 	struct ll_schedule_data *sch = data;
 	uint32_t irq_flags;
 
-	if (flags & SOF_SCHEDULER_FREE_IRQ_ONLY)
-		return;
-
 	irq_local_disable(irq_flags);
 
 	domain_unregister(sch->domain, NULL, 0);
 
-	notifier_unregister(sch, NULL,
-			    NOTIFIER_CLK_CHANGE_ID(sch->domain->clk));
+	if (!(flags & SOF_SCHEDULER_FREE_IRQ_ONLY))
+		notifier_unregister(sch, NULL,
+				    NOTIFIER_CLK_CHANGE_ID(sch->domain->clk));
 
 	irq_local_enable(irq_flags);
 }


### PR DESCRIPTION
ll_schedule: unregister domain in free function with IRQ_ONLY_FLAG
ghd: update creation process

Above 2 patches are merged in main , we need them in adl004 branch.

smart amp: fix set param build warning
https://github.com/thesofproject/sof/pull/5283

This is a fix in dsm , above PR posted to main branch.