### PR TITLE
Use typeof() to make ASSUME_ALIGNED() type safe

### DIFF
--- a/src/audio/crossover/crossover.c
+++ b/src/audio/crossover/crossover.c
@@ -491,7 +491,7 @@ static int crossover_cmd_set_data(struct comp_dev *dev,
 		comp_info(dev, "crossover_cmd_set_data(), SOF_CTRL_CMD_BINARY");
 
 		/* Find size from header */
-		request = (struct sof_crossover_config *)ASSUME_ALIGNED(cdata->data->data, 4);
+		request = (struct sof_crossover_config *)ASSUME_ALIGNED(&cdata->data->data, 4);
 		bs = request->size;
 
 		/* Check that there is no work-in-progress previous request */

--- a/src/audio/eq_iir/iir.c
+++ b/src/audio/eq_iir/iir.c
@@ -29,7 +29,7 @@ int iir_init_coef_df2t(struct iir_state_df2t *iir,
 {
 	iir->biquads = config->num_sections;
 	iir->biquads_in_series = config->num_sections_in_series;
-	iir->coef = ASSUME_ALIGNED(config->biquads, 4);
+	iir->coef = ASSUME_ALIGNED(&config->biquads[0], 4);
 
 	return 0;
 }

--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -284,7 +284,7 @@ static int mux_ctrl_set_cmd(struct comp_dev *dev,
 	switch (cdata->cmd) {
 	case SOF_CTRL_CMD_BINARY:
 		cfg = (struct sof_mux_config *)
-		      ASSUME_ALIGNED(cdata->data->data, 4);
+		      ASSUME_ALIGNED(&cdata->data->data, 4);
 
 		ret = mux_set_values(dev, cd, cfg);
 		break;

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -247,7 +247,7 @@ static int selector_ctrl_set_data(struct comp_dev *dev,
 		comp_info(dev, "selector_ctrl_set_data(), SOF_CTRL_CMD_BINARY");
 
 		cfg = (struct sof_sel_config *)
-		      ASSUME_ALIGNED(cdata->data->data, 4);
+		      ASSUME_ALIGNED(&cdata->data->data, 4);
 
 		/* Just set the configuration */
 		cd->config.in_channels_count = cfg->in_channels_count;

--- a/src/audio/smart_amp/smart_amp.c
+++ b/src/audio/smart_amp/smart_amp.c
@@ -292,7 +292,7 @@ static int smart_amp_set_config(struct comp_dev *dev,
 
 	/* Copy new config, find size from header */
 	cfg = (struct sof_smart_amp_config *)
-	       ASSUME_ALIGNED(cdata->data->data, sizeof(uint32_t));
+	       ASSUME_ALIGNED(&cdata->data->data, sizeof(uint32_t));
 	bs = cfg->size;
 
 	comp_dbg(dev, "smart_amp_set_config(), actual blob size = %u, expected blob size = %u",

--- a/src/audio/smart_amp/smart_amp_maxim_dsm.c
+++ b/src/audio/smart_amp/smart_amp_maxim_dsm.c
@@ -212,7 +212,7 @@ int maxim_dsm_set_param(struct smart_amp_mod_struct_t *hspk,
 	/* Model database */
 	int32_t *db = (int32_t *)caldata->data;
 	/* Payload buffer */
-	int *wparam = ASSUME_ALIGNED(cdata->data->data, 4);
+	uint32_t *wparam = (uint32_t *)ASSUME_ALIGNED(&cdata->data->data, 4);
 	/* number of parameters to read */
 	int num_param = (cdata->num_elems >> 2);
 	int idx, id, ch;

--- a/src/audio/tone.c
+++ b/src/audio/tone.c
@@ -541,7 +541,7 @@ static int tone_cmd_set_data(struct comp_dev *dev,
 	case SOF_CTRL_CMD_ENUM:
 		comp_info(dev, "tone_cmd_set_data(), SOF_CTRL_CMD_ENUM, cdata->index = %u",
 			  cdata->index);
-		compv = (struct sof_ipc_ctrl_value_comp *)ASSUME_ALIGNED(cdata->data->data, 4);
+		compv = (struct sof_ipc_ctrl_value_comp *)ASSUME_ALIGNED(&cdata->data->data, 4);
 
 		for (i = 0; i < (int)cdata->num_elems; i++) {
 			ch = compv[i].index;

--- a/src/include/ipc/control.h
+++ b/src/include/ipc/control.h
@@ -136,6 +136,13 @@ struct sof_ipc_ctrl_data {
 	/* reserved for future use */
 	uint32_t reserved[6];
 
+	/* Flexible array members[] are forbidden in unions but this
+	 * does not seem to bother gcc as long as non-standard
+	 * zero-length arrays[0] are used instead.  Nesting flexible
+	 * array member declarations in arrays or structures is
+	 * forbidden too. Cleaning this up would likely require code
+	 * changes to explicitly cast intermediate steps.
+	 */
 	/* control data - add new types if needed */
 	union {
 		/* channel values can be used by volume type controls */

--- a/src/include/sof/common.h
+++ b/src/include/sof/common.h
@@ -179,7 +179,7 @@
  * alignment. This compiler builtin may not be available on all compilers so
  * this macro can be defined as NULL if needed.
  */
-#define ASSUME_ALIGNED(x, a) __builtin_assume_aligned(x, a)
+#define ASSUME_ALIGNED(x, a) ((typeof(x))__builtin_assume_aligned((x), a))
 #endif /* __XCC__ */
 
 #endif /* __ASSEMBLER__ */

--- a/src/samples/audio/smart_amp_test.c
+++ b/src/samples/audio/smart_amp_test.c
@@ -92,7 +92,7 @@ static int smart_amp_set_config(struct comp_dev *dev,
 
 	/* Copy new config, find size from header */
 	cfg = (struct sof_smart_amp_config *)
-	       ASSUME_ALIGNED(cdata->data->data, sizeof(uint32_t));
+	       ASSUME_ALIGNED(&cdata->data->data, sizeof(uint32_t));
 	bs = cfg->size;
 
 	comp_dbg(dev, "smart_amp_set_config(), actual blob size = %u, expected blob size = %u",


### PR DESCRIPTION
2 commits, please see commit messages.

Prompted by #5283