### PR TITLE
Revert "zephyr: (cosmetic) make a needlessly global variable static"

### DIFF
--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -541,7 +541,7 @@ void sys_comp_smart_amp_init(void);
  * sof-logger. This makes smex fail. Define at least one such section to
  * fix the build when sof-logger is not used.
  */
-static const void *smex_placeholder_f(void)
+static inline const void *smex_placeholder_f(void)
 {
 	_DECLARE_LOG_ENTRY(LOG_LEVEL_DEBUG,
 			   "placeholder so .static_log.X are not all empty",
@@ -550,10 +550,10 @@ static const void *smex_placeholder_f(void)
 	return &log_entry;
 }
 
-/* Need to actually use the function and store a reference to the log entry
- * otherwise the compiler optimizes everything away.
+/* Need to actually use the function and export something otherwise the
+ * compiler optimizes everything away.
  */
-static const void *_smex_placeholder;
+const void *_smex_placeholder;
 
 int task_main_start(struct sof *sof)
 {


### PR DESCRIPTION
This reverts commit 079ce95b988384225d3f1dc2013811d4c41b3d82.

As explained in the comment that it modified, predicted in the #5159
discussion and reproduced in test #5290 /
https://github.com/thesofproject/sof/runs/4988844402, this commit broke
`CONFIG_TRACE=n`. Simple reproduction steps:
```
 $ rm -rf zephyrproject/build-apl

 $ echo 'CONFIG_TRACE=n' >> \
    boards/xtensa/intel_adsp_cavs15/intel_adsp_cavs15_defconfig

 $ sof/scripts/xtensa-build-zephyr.sh [ -p /path/to/zephyrproject ]  apl

fw abi main version:	3.20.1
fw abi dbg version:	5.3.0
warning: can't find section .static_log_entries in zephyr/zephyr.elf
error: section .static_log_entries can't be found
error: unable to write dictionaries, -22
```
Signed-off-by: Marc Herbert <marc.herbert@intel.com>