### PR TITLE
amd: renoir: Add lock for synchronization b/w host and DSP

### DIFF
--- a/src/drivers/amd/renoir/ipc.c
+++ b/src/drivers/amd/renoir/ipc.c
@@ -83,6 +83,9 @@ static void irq_handler(void *arg)
 {
 	struct ipc *ipc = arg;
 	uint32_t status;
+	uint32_t lock;
+	uint32_t delay_cnt = 10000;
+	bool lock_fail = false;
 	acp_dsp_sw_intr_stat_t swintrstat;
 	acp_sw_intr_trig_t  swintrtrig;
 
@@ -91,6 +94,19 @@ static void irq_handler(void *arg)
 	if (status) {
 		/* Interrupt source */
 		if (sof_ipc_host_status()) {
+			lock = io_reg_read(PU_REGISTER_BASE + ACP_AXI2DAGB_SEM_0);
+			while (lock) {
+				lock = io_reg_read(PU_REGISTER_BASE + ACP_AXI2DAGB_SEM_0);
+				if (!delay_cnt) {
+					lock_fail = true;
+					break;
+				}
+				delay_cnt--;
+			}
+			if (lock_fail) {
+				tr_err(&ipc_tr, "ACP fail to acquire the lock");
+				return;
+			}
 			/* Check if it is response from host */
 			if (sof_ipc_host_ack_flag()) {
 				/* Clear the ACK from host  */
@@ -113,6 +129,7 @@ static void irq_handler(void *arg)
 				acp_ack_intr_from_host();
 				ipc_schedule_process(ipc);
 			}
+			io_reg_write((PU_REGISTER_BASE + ACP_AXI2DAGB_SEM_0), lock);
 		} else {
 			tr_err(&ipc_tr, "IPC:interrupt without setting flags host status 0x%x",
 			       sof_ipc_host_status());
@@ -155,6 +172,8 @@ int ipc_platform_send_msg(struct ipc_msg *msg)
 	acp_sw_intr_trig_t  sw_intr_trig;
 	acp_dsp_sw_intr_stat_t sw_intr_stat;
 	uint32_t status;
+	uint32_t lock;
+	uint32_t delay_cnt = 10000;
 	/* Check if host cleared the status for previous messages */
 	sw_intr_stat = (acp_dsp_sw_intr_stat_t)
 		io_reg_read(PU_REGISTER_BASE + ACP_DSP_SW_INTR_STAT);
@@ -163,8 +182,20 @@ int ipc_platform_send_msg(struct ipc_msg *msg)
 		sw_intr_stat = (acp_dsp_sw_intr_stat_t)
 				io_reg_read(PU_REGISTER_BASE + ACP_DSP_SW_INTR_STAT);
 		status =  sw_intr_stat.bits.dsp0_to_host_intr_stat;
-		return ret;
+		ret = -EBUSY;
+		goto out;
 	}
+	lock = io_reg_read(PU_REGISTER_BASE + ACP_AXI2DAGB_SEM_0);
+	while (lock) {
+		lock = io_reg_read(PU_REGISTER_BASE + ACP_AXI2DAGB_SEM_0);
+		if (!delay_cnt) {
+			ret = -EBUSY;
+			break;
+		}
+		delay_cnt--;
+	}
+	if (ret)
+		goto out;
 	/* Write new message in the mailbox */
 	mailbox_dspbox_write(0, msg->tx_data, msg->tx_size);
 	list_item_del(&msg->list);
@@ -174,9 +205,10 @@ int ipc_platform_send_msg(struct ipc_msg *msg)
 	acp_dsp_to_host_Intr_trig();
 	/* Disable the trigger bit in ACP_DSP_SW_INTR_TRIG register */
 	sw_intr_trig = (acp_sw_intr_trig_t)io_reg_read(PU_REGISTER_BASE + ACP_SW_INTR_TRIG);
-	sw_intr_trig.bits.trig_host_to_dsp0_intr1 = INTERRUPT_DISABLE;
 	sw_intr_trig.bits.trig_dsp0_to_host_intr = INTERRUPT_DISABLE;
 	io_reg_write((PU_REGISTER_BASE + ACP_SW_INTR_TRIG), sw_intr_trig.u32all);
+	io_reg_write((PU_REGISTER_BASE + ACP_AXI2DAGB_SEM_0), lock);
+out:
 	return ret;
 }
 

--- a/src/platform/amd/renoir/include/platform/chip_offset_byte.h
+++ b/src/platform/amd/renoir/include/platform/chip_offset_byte.h
@@ -32,6 +32,7 @@
 
 #define ACP_TIMER                                     0x1241874
 #define ACP_TIMER_CNTL                                0x1241878
+#define ACP_AXI2DAGB_SEM_0			      0x1241880
 
 #define ACP_SRBM_CLIENT_BASE_ADDR                     0x1241BBC
 #define ACP_SRBM_Client_RDDATA                        0x1241BC0

--- a/src/platform/amd/renoir/platform.c
+++ b/src/platform/amd/renoir/platform.c
@@ -117,11 +117,16 @@ int platform_init(struct sof *sof)
 
 int platform_boot_complete(uint32_t boot_message)
 {
+	acp_sw_intr_trig_t  swintrtrig;
 	volatile acp_scratch_mem_config_t *pscratch_mem_cfg =
 		(volatile acp_scratch_mem_config_t *)(PU_REGISTER_BASE + SCRATCH_REG_OFFSET);
 	mailbox_dspbox_write(0, &ready, sizeof(ready));
 	pscratch_mem_cfg->acp_dsp_msg_write = 1;
 	acp_dsp_to_host_Intr_trig();
+	/* Configures the trigger bit in ACP_DSP_SW_INTR_TRIG register */
+	swintrtrig = (acp_sw_intr_trig_t)io_reg_read(PU_REGISTER_BASE + ACP_SW_INTR_TRIG);
+	swintrtrig.bits.trig_dsp0_to_host_intr  = INTERRUPT_DISABLE;
+	io_reg_write((PU_REGISTER_BASE + ACP_SW_INTR_TRIG), swintrtrig.u32all);
 	clock_set_freq(CLK_CPU(cpu_get_id()), CLK_DEFAULT_CPU_HZ);
 	return 0;
 }


### PR DESCRIPTION
Add hardware semaphore lock before accessing trigger
bits to acheive proper sychronization between host and
DSP during IPC communication.

Note: Same hardware lock is implemented in amd host driver.

Signed-off-by: balapati <balakishore.pati@amd.com>