### PR TITLE
zephyr: always use Zephyr interface to power up secondary cores

### DIFF
--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -719,14 +719,22 @@ static FUNC_NORETURN void secondary_init(void *arg)
 
 int arch_cpu_enable_core(int id)
 {
-	atomic_clear(&start_flag);
-
-	/* Power up secondary core */
 	pm_runtime_get(PM_RUNTIME_DSP, PWRD_BY_TPLG | id);
 
+	return 0;
+}
+
+int z_wrapper_cpu_enable_secondary_core(int id)
+{
+	/*
+	 * This is an open-coded version of zephyr/kernel/smp.c
+	 * z_smp_start_cpu(). We do this, so we can use a customized
+	 * secondary_init() for SOF.
+	 */
+
+	atomic_clear(&start_flag);
 	arch_start_cpu(id, z_interrupt_stacks[id], CONFIG_ISR_STACK_SIZE,
 		       secondary_init, &start_flag);
-
 	atomic_set(&start_flag, 1);
 
 	return 0;


### PR DESCRIPTION
Currently both Zephyr architecture hooks in wrapper.c and
SOF runtime-PM for DSP cores, have code to power up and down
the cores.

Some of this is necessary overlap until full replacement of
SOF runtime-PM is available. But for secondary core power up,
we can already clean up the flow and hook the Zephyr core
enable code to runtime-PM driver directly. This ensure if
other drivers (like the cAVS clock driver) use runtime-PM
framework to power up a secondary core, this will now also
go through Zephyr as it should be.

Currently there is only on runtime-PM driver in the tree,
so changes are limited to the the cAVS runtime-PM driver.

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>