### PR TITLE
topology1: Add sample topology for i.MX8MP boards with wm8904 codec

### DIFF
--- a/tools/topology/topology1/CMakeLists.txt
+++ b/tools/topology/topology1/CMakeLists.txt
@@ -212,6 +212,7 @@ set(TPLGS
 	"sof-imx8mp-wm8960\;sof-imx8mp-eq-iir-wm8960\;-DPPROC=eq-iir-volume"
 	"sof-imx8mp-wm8960\;sof-imx8mp-eq-fir-wm8960\;-DPPROC=eq-fir-volume"
 	"sof-imx8mp-wm8960\;sof-imx8mp-drc-wm8960\;-DPPROC=drc"
+	"sof-imx8mp-wm8904\;sof-imx8mp-wm8904\;-DPPROC=volume"
 
 	"sof-mt8195-mt6359-rt1019-rt5682\;sof-mt8195-mt6359-rt1019-rt5682"
 	"sof-mt8195-mt6359-rt1019-rt5682\;sof-mt8195-mt6359-rt1019-rt5682-dts\;-DDTS=`DTS'"

--- a/tools/topology/topology1/sof-imx8mp-wm8904.m4
+++ b/tools/topology/topology1/sof-imx8mp-wm8904.m4
@@ -1,0 +1,82 @@
+#
+# Topology for i.MX8MP board with wm8904 codec
+#
+
+# Include topology builder
+include(`utils.m4')
+include(`dai.m4')
+include(`pipeline.m4')
+include(`sai.m4')
+include(`pcm.m4')
+include(`buffer.m4')
+
+# Include TLV library
+include(`common/tlv.m4')
+
+# Include Token library
+include(`sof/tokens.m4')
+
+# Include DSP configuration
+include(`platform/imx/imx8.m4')
+
+#
+# Define the pipelines
+#
+# PCM0 <----> volume <-----> SAI3 (wm8904)
+#
+
+dnl PIPELINE_PCM_ADD(pipeline,
+dnl     pipe id, pcm, max channels, format,
+dnl     period, priority, core,
+dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
+dnl     time_domain, sched_comp)
+
+# Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
+# Set 1000us deadline with priority 0 on core 0
+PIPELINE_PCM_ADD(sof/pipe-`PPROC'-playback.m4,
+	1, 0, 2, s32le,
+	1000, 0, 0,
+	44100, 44100, 44100)
+
+# Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s32le.
+# Set 1000us deadline with priority 0 on core 0
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
+	2, 0, 2, s32le,
+	1000, 0, 0,
+	44100, 44100, 44100)
+#
+# DAIs configuration
+#
+
+dnl DAI_ADD(pipeline,
+dnl     pipe id, dai type, dai_index, dai_be,
+dnl     buffer, periods, format,
+dnl     period, priority, core, time_domain)
+
+# playback DAI is SAI3 using 2 periods
+# Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+	1, SAI, 3, sai3-wm8904-hifi,
+	PIPELINE_SOURCE_1, 2, s32le,
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_DMA)
+
+# capture DAI is SAI3 using 2 periods
+# Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-capture.m4,
+	2, SAI, 3, sai3-wm8904-hifi,
+	PIPELINE_SINK_2, 2, s32le,
+	1000, 0, 0)
+
+
+# PCM Low Latency, id 0
+
+dnl PCM_DUPLEX_ADD(name, pcm_id, playback, capture)
+PCM_DUPLEX_ADD(Port0, 0, PIPELINE_PCM_1, PIPELINE_PCM_2)
+
+dnl DAI_CONFIG(type, idx, link_id, name, sai_config)
+DAI_CONFIG(SAI, 3, 0, sai3-wm8904-hifi,
+	SAI_CONFIG(I2S, SAI_CLOCK(mclk, 11565177, codec_mclk_in),
+		SAI_CLOCK(bclk, 1411200, codec_provider),
+		SAI_CLOCK(fsync, 44100, codec_provider),
+		SAI_TDM(2, 32, 3, 3),
+		SAI_CONFIG_DATA(SAI, 3, 0)))


### PR DESCRIPTION
Tested to work on Variscite Symphony-Board v1.3 with VAR-SOM-MX8M-PLUS

Sample device tree: https://gitlab.com/autogramma_multimedia_a/vendor/variscite/kernel_imx/-/commit/0e922e526bafe919fac9e89cf949e85c7b36b972