### PR TITLE
Revert "zephyr: implement arch_cpu_disable_core()"

### DIFF
--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -754,12 +754,7 @@ int arch_cpu_secondary_cores_prepare_d0ix(void)
 
 void arch_cpu_disable_core(int id)
 {
-	/*
-	 * As long as DSP core reference count is handled
-	 * with SOF runtime-PM driver, we need to disable
-	 * a core via RPM.
-	 */
-	pm_runtime_put(PM_RUNTIME_DSP, PWRD_BY_TPLG | id);
+	/* TODO: call Zephyr API */
 }
 
 int arch_cpu_is_core_enabled(int id)


### PR DESCRIPTION
This reverts commit 414089aa442dfdbdab6d37507adffddc09af179e.

Failures hit with 4core cAVS2.5 configuraions, so this has
to be reverted. We need an implementation that keeps both
Zephyr (and SOF runtime-DSP if still used) in the loop.

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>