### PR TITLE
ipc4: handler: fix for overwriting error code

### DIFF
--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -877,7 +877,10 @@ void ipc_cmd(ipc_cmd_hdr *_hdr)
 		char *data = ipc_get()->comp_data;
 		struct ipc4_message_reply reply;
 
-		err = ipc_wait_for_compound_msg();
+		if (ipc_wait_for_compound_msg() != 0) {
+			tr_err(&ipc_tr, "ipc4: failed to send delayed reply");
+			err = IPC4_FAILURE;
+		}
 
 		/* copy contents of message received */
 		reply.header.r.rsp = SOF_IPC4_MESSAGE_DIR_MSG_REPLY;


### PR DESCRIPTION
Value return by ipc_wait_for_compound_msg is overriding errors
reported by previous ipc handlers like ipc4_process_module_message.
This is causing false success report visible only on traces.
Error code should be overwritten only when operations fails.

Signed-off-by: Tomasz Leman <tomasz.m.leman@intel.com>