### PR TITLE
topology2: cavs-gain-hda: Add 32-bit support

### DIFF
--- a/tools/topology/topology2/cavs/cavs-gain-hda.conf
+++ b/tools/topology/topology2/cavs/cavs-gain-hda.conf
@@ -186,11 +186,11 @@ Object.PCM {
 		Object.Base.fe_dai.'HDA Analog' {}
 		Object.PCM.pcm_caps.playback {
 			name 'Gain Playback 0'
-			formats 'S24_LE,S16_LE'
+			formats 'S32_LE,S24_LE,S16_LE'
 		}
 		Object.PCM.pcm_caps.capture {
 			name 'Gain Capture 0'
-			formats 'S24_LE,S16_LE'
+			formats 'S32_LE,S24_LE,S16_LE'
 		}
 		direction duplex
 	}
@@ -200,11 +200,11 @@ Object.PCM {
 		Object.Base.fe_dai.'HDA Digital' {}
 		Object.PCM.pcm_caps.playback {
 			name 'Gain Playback 1'
-			formats 'S24_LE,S16_LE'
+			formats 'S32_LE,S24_LE,S16_LE'
 		}
 		Object.PCM.pcm_caps.capture {
 			name 'Gain Capture 1'
-			formats 'S24_LE,S16_LE'
+			formats 'S32_LE,S24_LE,S16_LE'
 		}
 		direction duplex
 	}


### PR DESCRIPTION
Add 32-bit support in PCM capabilities.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>