### PR TITLE
Add base sparse support

### DIFF
--- a/src/arch/xtensa/include/arch/debug/panic.h
+++ b/src/arch/xtensa/include/arch/debug/panic.h
@@ -56,7 +56,7 @@ static inline void arch_dump_regs(void *dump_buf, uintptr_t stack_ptr,
 {
 	fill_core_dump(dump_buf, stack_ptr, epc1);
 
-	dcache_writeback_region(dump_buf, ARCH_OOPS_SIZE);
+	dcache_writeback_region((__sparse_force void __sparse_cache *)dump_buf, ARCH_OOPS_SIZE);
 }
 
 #endif /* __ARCH_DEBUG_PANIC_H__ */

--- a/src/arch/xtensa/include/arch/lib/cache.h
+++ b/src/arch/xtensa/include/arch/lib/cache.h
@@ -17,6 +17,7 @@
 #if !defined(__ASSEMBLER__) && !defined(LINKER)
 
 #include <xtensa/hal.h>
+#include <sof/compiler_attributes.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -89,11 +90,11 @@ extern uint32_t _memmap_cacheattr_reset;
 #define is_cached(address) (!!((uintptr_t)(address) & SRAM_UNCACHED_ALIAS))
 #endif
 
-static inline void dcache_writeback_region(void *addr, size_t size)
+static inline void dcache_writeback_region(void __sparse_cache *addr, size_t size)
 {
 #if XCHAL_DCACHE_SIZE > 0
 	if (is_cached(addr))
-		xthal_dcache_region_writeback(addr, size);
+		xthal_dcache_region_writeback((__sparse_force void *)addr, size);
 #endif
 }
 
@@ -104,11 +105,11 @@ static inline void dcache_writeback_all(void)
 #endif
 }
 
-static inline void dcache_invalidate_region(void *addr, size_t size)
+static inline void dcache_invalidate_region(void __sparse_cache *addr, size_t size)
 {
 #if XCHAL_DCACHE_SIZE > 0
 	if (is_cached(addr))
-		xthal_dcache_region_invalidate(addr, size);
+		xthal_dcache_region_invalidate((__sparse_force void *)addr, size);
 #endif
 }
 
@@ -133,11 +134,11 @@ static inline void icache_invalidate_all(void)
 #endif
 }
 
-static inline void dcache_writeback_invalidate_region(void *addr, size_t size)
+static inline void dcache_writeback_invalidate_region(void __sparse_cache *addr, size_t size)
 {
 #if XCHAL_DCACHE_SIZE > 0
 	if (is_cached(addr))
-		xthal_dcache_region_writeback_inv(addr, size);
+		xthal_dcache_region_writeback_inv((__sparse_force void *)addr, size);
 #endif
 }
 

--- a/src/audio/aria/aria.c
+++ b/src/audio/aria/aria.c
@@ -133,7 +133,7 @@ static int init_aria(struct comp_dev *dev, struct comp_ipc_config *config,
 	list_init(&dev->bsource_list);
 	list_init(&dev->bsink_list);
 
-	dcache_invalidate_region(spec, sizeof(*aria));
+	dcache_invalidate_region((__sparse_force void __sparse_cache *)spec, sizeof(*aria));
 	cd = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM, sizeof(*cd));
 	if (!cd) {
 		comp_free(dev);
@@ -302,12 +302,14 @@ static int aria_copy(struct comp_dev *dev)
 			frag++;
 		}
 	}
-	dcache_writeback_region(cd->buf_in, c.frames * sink->stream.channels * sizeof(int32_t));
+	dcache_writeback_region((__sparse_force void __sparse_cache *)cd->buf_in,
+				c.frames * sink->stream.channels * sizeof(int32_t));
 
 	aria_process_data(dev, cd->buf_out, sink_bytes / sizeof(uint32_t),
 			  cd->buf_in, source_bytes / sizeof(uint32_t));
 
-	dcache_writeback_region(cd->buf_out, c.frames * sink->stream.channels * sizeof(int32_t));
+	dcache_writeback_region((__sparse_force void __sparse_cache *)cd->buf_out,
+				c.frames * sink->stream.channels * sizeof(int32_t));
 	frag = 0;
 	for (i = 0; i < c.frames; i++) {
 		for (channel = 0; channel < sink->stream.channels; channel++) {

--- a/src/audio/buffer.c
+++ b/src/audio/buffer.c
@@ -69,7 +69,7 @@ void buffer_zero(struct comp_buffer *buffer)
 
 	bzero(buffer->stream.addr, buffer->stream.size);
 	if (buffer->caps & SOF_MEM_CAPS_DMA)
-		dcache_writeback_region(buffer->stream.addr,
+		dcache_writeback_region((__sparse_force void __sparse_cache *)buffer->stream.addr,
 					buffer->stream.size);
 }
 

--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -168,7 +168,7 @@ struct comp_dev *comp_make_shared(struct comp_dev *dev)
 	int dir;
 
 	/* flush cache to share */
-	dcache_writeback_region(dev, dev->size);
+	dcache_writeback_region((__sparse_force void __sparse_cache *)dev, dev->size);
 
 	dev = platform_shared_get(dev, dev->size);
 

--- a/src/audio/copier.c
+++ b/src/audio/copier.c
@@ -342,7 +342,8 @@ static struct comp_dev *copier_new(const struct comp_driver *drv,
 	dev->ipc_config = *config;
 
 	config_size = copier->gtw_cfg.config_length * sizeof(uint32_t);
-	dcache_invalidate_region((char *)spec + sizeof(*copier), config_size);
+	dcache_invalidate_region((__sparse_force char __sparse_cache *)spec + sizeof(*copier),
+				 config_size);
 
 	size = sizeof(*cd);
 	cd = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM, size);
@@ -866,7 +867,7 @@ static int copier_set_sink_fmt(struct comp_dev *dev, void *data,
 	struct copier_data *cd = comp_get_drvdata(dev);
 
 	sink_fmt = (struct ipc4_copier_config_set_sink_format *)data;
-	dcache_invalidate_region(sink_fmt, sizeof(*sink_fmt));
+	dcache_invalidate_region((__sparse_force void __sparse_cache *)sink_fmt, sizeof(*sink_fmt));
 
 	if (max_data_size < sizeof(*sink_fmt)) {
 		comp_err(dev, "error: max_data_size %d should be bigger than %d", max_data_size,
@@ -911,7 +912,7 @@ static int set_attenuation(struct comp_dev *dev, uint32_t data_offset, char *dat
 		return -EINVAL;
 	}
 
-	dcache_invalidate_region(data, sizeof(uint32_t));
+	dcache_invalidate_region((__sparse_force void __sparse_cache *)data, sizeof(uint32_t));
 	attenuation = *(uint32_t *)data;
 	if (attenuation > 31) {
 		comp_err(dev, "attenuation %d is out of range", attenuation);

--- a/src/debug/gdb/gdb.c
+++ b/src/debug/gdb/gdb.c
@@ -475,6 +475,6 @@ static unsigned char *hex_to_mem(const unsigned char *buf, void *mem_,
 		mem++;
 	}
 
-	dcache_writeback_region((void *)mem, count);
+	dcache_writeback_region((__sparse_force void __sparse_cache *)mem, count);
 	return mem;
 }

--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -445,7 +445,7 @@ static int dw_dma_stop(struct dma_chan_data *channel)
 	}
 
 #ifndef __ZEPHYR__
-	dcache_writeback_region(dw_chan->lli,
+	dcache_writeback_region((__sparse_force void __sparse_cache *)dw_chan->lli,
 				sizeof(struct dw_lli) * channel->desc_count);
 #endif
 #endif
@@ -780,7 +780,7 @@ static int dw_dma_set_config(struct dma_chan_data *channel,
 
 	/* write back descriptors so DMA engine can read them directly */
 #ifndef __ZEPHYR__
-	dcache_writeback_region(dw_chan->lli,
+	dcache_writeback_region((__sparse_force void __sparse_cache *)dw_chan->lli,
 				sizeof(struct dw_lli) * channel->desc_count);
 #endif
 

--- a/src/drivers/dw/ssi-spi.c
+++ b/src/drivers/dw/ssi-spi.c
@@ -303,7 +303,8 @@ static enum task_state spi_completion_work(void *data)
 	case IPC_READ:
 		hdr = (struct sof_ipc_hdr *)spi->rx_buffer;
 
-		dcache_invalidate_region(spi->rx_buffer, SPI_BUFFER_SIZE);
+		dcache_invalidate_region((__sparse_force void __sparse_cache *)spi->rx_buffer,
+					 SPI_BUFFER_SIZE);
 		mailbox_hostbox_write(0, spi->rx_buffer, hdr->size);
 
 		ipc_schedule_process(ipc_get());
@@ -356,7 +357,7 @@ int spi_push(struct spi *spi, const void *data, size_t size)
 	ret = memcpy_s(config->src_buf, config->buffer_size, data, size);
 	assert(!ret);
 
-	dcache_writeback_region(config->src_buf, size);
+	dcache_writeback_region((__sparse_force void __sparse_cache *)config->src_buf, size);
 
 	ret = spi_trigger(spi, SPI_TRIGGER_START, SPI_DIR_TX);
 	if (ret < 0)
@@ -394,7 +395,7 @@ static int spi_slave_init(struct spi *spi)
 	if (ret < 0)
 		return ret;
 
-	dcache_invalidate_region(spi->rx_buffer, SPI_BUFFER_SIZE);
+	dcache_invalidate_region((__sparse_force void __sparse_cache *)spi->rx_buffer, SPI_BUFFER_SIZE);
 	ret = spi_trigger(spi, SPI_TRIGGER_START, SPI_DIR_RX);
 	if (ret < 0)
 		return ret;

--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -15,6 +15,7 @@
 #define __SOF_AUDIO_AUDIO_STREAM_H__
 
 #include <sof/audio/format.h>
+#include <sof/compiler_attributes.h>
 #include <sof/debug/panic.h>
 #include <sof/math/numbers.h>
 #include <sof/lib/alloc.h>
@@ -169,7 +170,7 @@ struct audio_stream {
  * @param params Parameters (frame format, rate, number of channels).
  * @return 0 if succeeded, error code otherwise.
  */
-static inline int audio_stream_set_params(struct audio_stream *buffer,
+static inline int audio_stream_set_params(struct audio_stream __sparse_cache *buffer,
 					  struct sof_ipc_stream_params *params)
 {
 	if (!params)
@@ -187,7 +188,7 @@ static inline int audio_stream_set_params(struct audio_stream *buffer,
  * @param buf Component buffer.
  * @return Period size in bytes.
  */
-static inline uint32_t audio_stream_frame_bytes(const struct audio_stream *buf)
+static inline uint32_t audio_stream_frame_bytes(const struct audio_stream __sparse_cache *buf)
 {
 	return get_frame_bytes(buf->frame_fmt, buf->channels);
 }
@@ -197,7 +198,7 @@ static inline uint32_t audio_stream_frame_bytes(const struct audio_stream *buf)
  * @param buf Component buffer.
  * @return Size of sample in bytes.
  */
-static inline uint32_t audio_stream_sample_bytes(const struct audio_stream *buf)
+static inline uint32_t audio_stream_sample_bytes(const struct audio_stream __sparse_cache *buf)
 {
 	return get_sample_bytes(buf->frame_fmt);
 }
@@ -208,7 +209,7 @@ static inline uint32_t audio_stream_sample_bytes(const struct audio_stream *buf)
  * @param frames Number of processing frames.
  * @return Period size in bytes.
  */
-static inline uint32_t audio_stream_period_bytes(const struct audio_stream *buf,
+static inline uint32_t audio_stream_period_bytes(const struct audio_stream __sparse_cache *buf,
 						 uint32_t frames)
 {
 	return frames * audio_stream_frame_bytes(buf);
@@ -221,7 +222,7 @@ static inline uint32_t audio_stream_period_bytes(const struct audio_stream *buf,
  * @param ptr Pointer
  * @return Pointer, adjusted if necessary.
  */
-static inline void *audio_stream_wrap(const struct audio_stream *buffer,
+static inline void *audio_stream_wrap(const struct audio_stream __sparse_cache *buffer,
 				      void *ptr)
 {
 	if (ptr >= buffer->end_addr)
@@ -240,7 +241,8 @@ static inline void *audio_stream_wrap(const struct audio_stream *buffer,
  * @param ptr Pointer
  * @return Pointer, adjusted if necessary.
  */
-static inline void *audio_stream_rewind_wrap(const struct audio_stream *buffer, void *ptr)
+static inline void *audio_stream_rewind_wrap(const struct audio_stream __sparse_cache *buffer,
+					     void *ptr)
 {
 	if (ptr < buffer->addr)
 		ptr = (char *)buffer->end_addr - ((char *)buffer->addr - (char *)ptr);
@@ -256,7 +258,7 @@ static inline void *audio_stream_rewind_wrap(const struct audio_stream *buffer, 
  * @return amount of data available for processing in bytes
  */
 static inline uint32_t
-audio_stream_get_avail_bytes(const struct audio_stream *stream)
+audio_stream_get_avail_bytes(const struct audio_stream __sparse_cache *stream)
 {
 	/*
 	 * In case of underrun-permitted stream, report buffer full instead of
@@ -276,7 +278,7 @@ audio_stream_get_avail_bytes(const struct audio_stream *stream)
  * @return amount of data available for processing in samples
  */
 static inline uint32_t
-audio_stream_get_avail_samples(const struct audio_stream *stream)
+audio_stream_get_avail_samples(const struct audio_stream __sparse_cache *stream)
 {
 	return audio_stream_get_avail_bytes(stream) /
 		audio_stream_sample_bytes(stream);
@@ -288,7 +290,7 @@ audio_stream_get_avail_samples(const struct audio_stream *stream)
  * @return amount of data available for processing in frames
  */
 static inline uint32_t
-audio_stream_get_avail_frames(const struct audio_stream *stream)
+audio_stream_get_avail_frames(const struct audio_stream __sparse_cache *stream)
 {
 	return audio_stream_get_avail_bytes(stream) /
 		audio_stream_frame_bytes(stream);
@@ -300,7 +302,7 @@ audio_stream_get_avail_frames(const struct audio_stream *stream)
  * @return amount of space free in bytes
  */
 static inline uint32_t
-audio_stream_get_free_bytes(const struct audio_stream *stream)
+audio_stream_get_free_bytes(const struct audio_stream __sparse_cache *stream)
 {
 	/*
 	 * In case of overrun-permitted stream, report buffer empty instead of
@@ -320,7 +322,7 @@ audio_stream_get_free_bytes(const struct audio_stream *stream)
  * @return amount of space free in samples
  */
 static inline uint32_t
-audio_stream_get_free_samples(const struct audio_stream *stream)
+audio_stream_get_free_samples(const struct audio_stream __sparse_cache *stream)
 {
 	return audio_stream_get_free_bytes(stream) /
 		audio_stream_sample_bytes(stream);
@@ -332,7 +334,7 @@ audio_stream_get_free_samples(const struct audio_stream *stream)
  * @return amount of space free in frames
  */
 static inline uint32_t
-audio_stream_get_free_frames(const struct audio_stream *stream)
+audio_stream_get_free_frames(const struct audio_stream __sparse_cache *stream)
 {
 	return audio_stream_get_free_bytes(stream) /
 		audio_stream_frame_bytes(stream);
@@ -348,8 +350,8 @@ audio_stream_get_free_frames(const struct audio_stream *stream)
  *  @return 1 if there is not enough free space in sink.
  *  @return -1 if there is not enough data in source.
  */
-static inline int audio_stream_can_copy_bytes(const struct audio_stream *source,
-					      const struct audio_stream *sink,
+static inline int audio_stream_can_copy_bytes(const struct audio_stream __sparse_cache *source,
+					      const struct audio_stream __sparse_cache *sink,
 					      uint32_t bytes)
 {
 	/* check for underrun */
@@ -373,8 +375,8 @@ static inline int audio_stream_can_copy_bytes(const struct audio_stream *source,
  * @return Number of bytes.
  */
 static inline uint32_t
-audio_stream_get_copy_bytes(const struct audio_stream *source,
-			    const struct audio_stream *sink)
+audio_stream_get_copy_bytes(const struct audio_stream __sparse_cache *source,
+			    const struct audio_stream __sparse_cache *sink)
 {
 	uint32_t avail = audio_stream_get_avail_bytes(source);
 	uint32_t free = audio_stream_get_free_bytes(sink);
@@ -394,8 +396,8 @@ audio_stream_get_copy_bytes(const struct audio_stream *source,
  * @return Number of frames.
  */
 static inline uint32_t
-audio_stream_avail_frames(const struct audio_stream *source,
-			  const struct audio_stream *sink)
+audio_stream_avail_frames(const struct audio_stream __sparse_cache *source,
+			  const struct audio_stream __sparse_cache *sink)
 {
 	uint32_t src_frames = audio_stream_get_avail_frames(source);
 	uint32_t sink_frames = audio_stream_get_free_frames(sink);
@@ -408,7 +410,7 @@ audio_stream_avail_frames(const struct audio_stream *source,
  * @param buffer Buffer to update.
  * @param bytes Number of written bytes.
  */
-static inline void audio_stream_produce(struct audio_stream *buffer,
+static inline void audio_stream_produce(struct audio_stream __sparse_cache *buffer,
 					uint32_t bytes)
 {
 	buffer->w_ptr = audio_stream_wrap(buffer,
@@ -436,7 +438,7 @@ static inline void audio_stream_produce(struct audio_stream *buffer,
  * @param buffer Buffer to update.
  * @param bytes Number of read bytes.
  */
-static inline void audio_stream_consume(struct audio_stream *buffer,
+static inline void audio_stream_consume(struct audio_stream __sparse_cache *buffer,
 					uint32_t bytes)
 {
 	buffer->r_ptr = audio_stream_wrap(buffer,
@@ -459,7 +461,7 @@ static inline void audio_stream_consume(struct audio_stream *buffer,
  * Resets the buffer.
  * @param buffer Buffer to reset.
  */
-static inline void audio_stream_reset(struct audio_stream *buffer)
+static inline void audio_stream_reset(struct audio_stream __sparse_cache *buffer)
 {
 	/* reset read and write pointer to buffer bas */
 	buffer->w_ptr = buffer->addr;
@@ -478,7 +480,7 @@ static inline void audio_stream_reset(struct audio_stream *buffer)
  * @param buff_addr Address of the memory block to assign.
  * @param size Size of the memory block in bytes.
  */
-static inline void audio_stream_init(struct audio_stream *buffer,
+static inline void audio_stream_init(struct audio_stream __sparse_cache *buffer,
 				     void *buff_addr, uint32_t size)
 {
 	buffer->size = size;
@@ -493,7 +495,7 @@ static inline void audio_stream_init(struct audio_stream *buffer,
  * @param buffer Buffer.
  * @param bytes Size of the fragment to invalidate.
  */
-static inline void audio_stream_invalidate(struct audio_stream *buffer,
+static inline void audio_stream_invalidate(struct audio_stream __sparse_cache *buffer,
 					   uint32_t bytes)
 {
 	uint32_t head_size = bytes;
@@ -517,7 +519,7 @@ static inline void audio_stream_invalidate(struct audio_stream *buffer,
  * @param buffer Buffer.
  * @param bytes Size of the fragment to write back.
  */
-static inline void audio_stream_writeback(struct audio_stream *buffer,
+static inline void audio_stream_writeback(struct audio_stream __sparse_cache *buffer,
 					  uint32_t bytes)
 {
 	uint32_t head_size = bytes;
@@ -536,19 +538,17 @@ static inline void audio_stream_writeback(struct audio_stream *buffer,
 }
 
 /**
- * @brief Calculates numbers of bytes to buffer wrap and return
- *	  minimum of calculated value and given bytes number.
+ * @brief Calculates numbers of bytes to buffer wrap.
  * @param source Stream to get information from.
  * @param ptr Read or write pointer from source
- * @return Number of data samples to buffer wrap or given samples number.
+ * @return Number of data samples to buffer wrap.
  */
 static inline int
-audio_stream_bytes_without_wrap(const struct audio_stream *source,
+audio_stream_bytes_without_wrap(const struct audio_stream __sparse_cache *source,
 				const void *ptr)
 {
 	assert((intptr_t)source->end_addr >= (intptr_t)ptr);
-	int to_end = (intptr_t)source->end_addr - (intptr_t)ptr;
-	return to_end;
+	return (intptr_t)source->end_addr - (intptr_t)ptr;
 }
 
 /**
@@ -560,7 +560,8 @@ audio_stream_bytes_without_wrap(const struct audio_stream *source,
  *	   need to add size of sample to returned bytes count.
  */
 static inline int
-audio_stream_rewind_bytes_without_wrap(const struct audio_stream *source, const void *ptr)
+audio_stream_rewind_bytes_without_wrap(const struct audio_stream __sparse_cache *source,
+				       const void *ptr)
 {
 	assert((intptr_t)ptr >= (intptr_t)source->addr);
 	int to_begin = (intptr_t)ptr - (intptr_t)source->addr;
@@ -575,7 +576,8 @@ audio_stream_rewind_bytes_without_wrap(const struct audio_stream *source, const 
  * @return Number of data s16 samples until circular wrap need at end
  */
 static inline int
-audio_stream_samples_without_wrap_s16(const struct audio_stream *source, const void *ptr)
+audio_stream_samples_without_wrap_s16(const struct audio_stream __sparse_cache *source,
+				      const void *ptr)
 {
 	int to_end = (int16_t *)source->end_addr - (int16_t *)ptr;
 
@@ -591,7 +593,8 @@ audio_stream_samples_without_wrap_s16(const struct audio_stream *source, const v
  * @return Number of data s24 samples until circular wrap need at end
  */
 static inline int
-audio_stream_samples_without_wrap_s24(const struct audio_stream *source, const void *ptr)
+audio_stream_samples_without_wrap_s24(const struct audio_stream __sparse_cache *source,
+				      const void *ptr)
 {
 	int to_end = (int32_t *)source->end_addr - (int32_t *)ptr;
 
@@ -607,7 +610,8 @@ audio_stream_samples_without_wrap_s24(const struct audio_stream *source, const v
  * @return Number of data s32 samples until circular wrap need at end
  */
 static inline int
-audio_stream_samples_without_wrap_s32(const struct audio_stream *source, const void *ptr)
+audio_stream_samples_without_wrap_s32(const struct audio_stream __sparse_cache *source,
+				      const void *ptr)
 {
 	int to_end = (int32_t *)source->end_addr - (int32_t *)ptr;
 
@@ -623,7 +627,7 @@ audio_stream_samples_without_wrap_s32(const struct audio_stream *source, const v
  * @return Number of data frames to buffer wrap.
  */
 static inline uint32_t
-audio_stream_frames_without_wrap(const struct audio_stream *source,
+audio_stream_frames_without_wrap(const struct audio_stream __sparse_cache *source,
 				 const void *ptr)
 {
 	uint32_t bytes = audio_stream_bytes_without_wrap(source, ptr);
@@ -641,8 +645,8 @@ audio_stream_frames_without_wrap(const struct audio_stream *source,
  * @param samples Number of samples to copy.
  * @return number of processed samples.
  */
-int audio_stream_copy(const struct audio_stream *source, uint32_t ioffset,
-		      struct audio_stream *sink, uint32_t ooffset, uint32_t samples);
+int audio_stream_copy(const struct audio_stream __sparse_cache *source, uint32_t ioffset,
+		      struct audio_stream __sparse_cache *sink, uint32_t ooffset, uint32_t samples);
 
 /**
  * Copies data from linear source buffer to circular sink buffer.
@@ -652,8 +656,9 @@ int audio_stream_copy(const struct audio_stream *source, uint32_t ioffset,
  * @param ooffset Offset (in samples) in sink buffer to start writing to.
  * @param samples Number of samples to copy.
  */
-void audio_stream_copy_from_linear(void *linear_source, int ioffset,
-				   struct audio_stream *sink, int ooffset, unsigned int samples);
+void audio_stream_copy_from_linear(const void *linear_source, int ioffset,
+				   struct audio_stream __sparse_cache *sink, int ooffset,
+				   unsigned int samples);
 
 /**
  * Copies data from circular source buffer to linear sink buffer.
@@ -663,7 +668,7 @@ void audio_stream_copy_from_linear(void *linear_source, int ioffset,
  * @param ooffset Offset (in samples) in sink buffer to start writing to.
  * @param samples Number of samples to copy.
  */
-void audio_stream_copy_to_linear(struct audio_stream *source, int ioffset,
+void audio_stream_copy_to_linear(const struct audio_stream __sparse_cache *source, int ioffset,
 				 void *linear_sink, int ooffset, unsigned int samples);
 
 /**
@@ -673,8 +678,8 @@ void audio_stream_copy_to_linear(struct audio_stream *source, int ioffset,
  * @return 0 if there is enough free space in buffer.
  * @return 1 if there is not enough free space in buffer.
  */
-static inline int audio_stream_set_zero(struct audio_stream *buffer,
-					  uint32_t bytes)
+static inline int audio_stream_set_zero(struct audio_stream __sparse_cache *buffer,
+					uint32_t bytes)
 {
 	uint32_t head_size = bytes;
 	uint32_t tail_size = 0;
@@ -698,8 +703,8 @@ static inline int audio_stream_set_zero(struct audio_stream *buffer,
 
 static inline void audio_stream_fmt_conversion(enum ipc4_bit_depth depth,
 					       enum ipc4_bit_depth valid,
-					       enum sof_ipc_frame *frame_fmt,
-					       enum sof_ipc_frame *valid_fmt,
+					       enum sof_ipc_frame __sparse_cache *frame_fmt,
+					       enum sof_ipc_frame __sparse_cache *valid_fmt,
 					       enum ipc4_sample_type type)
 {
 	/* IPC4_DEPTH_16BIT (16) <---> SOF_IPC_FRAME_S16_LE (0)

--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -505,9 +505,10 @@ static inline void audio_stream_invalidate(struct audio_stream *buffer,
 		tail_size = bytes - head_size;
 	}
 
-	dcache_invalidate_region(buffer->r_ptr, head_size);
+	dcache_invalidate_region((__sparse_force void __sparse_cache *)buffer->r_ptr, head_size);
 	if (tail_size)
-		dcache_invalidate_region(buffer->addr, tail_size);
+		dcache_invalidate_region((__sparse_force void __sparse_cache *)buffer->addr,
+					 tail_size);
 }
 
 /**
@@ -528,9 +529,10 @@ static inline void audio_stream_writeback(struct audio_stream *buffer,
 		tail_size = bytes - head_size;
 	}
 
-	dcache_writeback_region(buffer->w_ptr, head_size);
+	dcache_writeback_region((__sparse_force void __sparse_cache *)buffer->w_ptr, head_size);
 	if (tail_size)
-		dcache_writeback_region(buffer->addr, tail_size);
+		dcache_writeback_region((__sparse_force void __sparse_cache *)buffer->addr,
+					tail_size);
 }
 
 /**

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -837,7 +837,8 @@ void comp_get_copy_limits_with_lock(struct comp_buffer *source,
 static inline void comp_invalidate(struct comp_dev *dev)
 {
 	if (!dev->is_shared)
-		dcache_invalidate_region(dev, sizeof(struct comp_dev));
+		dcache_invalidate_region((__sparse_force void __sparse_cache *)dev,
+					 sizeof(struct comp_dev));
 }
 
 /**
@@ -847,7 +848,8 @@ static inline void comp_invalidate(struct comp_dev *dev)
 static inline void comp_writeback(struct comp_dev *dev)
 {
 	if (!dev->is_shared)
-		dcache_writeback_region(dev, sizeof(struct comp_dev));
+		dcache_writeback_region((__sparse_force void __sparse_cache *)dev,
+					sizeof(struct comp_dev));
 }
 
 /**

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -758,7 +758,7 @@ static inline void component_set_nearest_period_frames(struct comp_dev *current,
  * @param copy_bytes Requested size of data to be available.
  */
 static inline void comp_underrun(struct comp_dev *dev,
-				 struct comp_buffer *source,
+				 struct comp_buffer __sparse_cache *source,
 				 uint32_t copy_bytes)
 {
 	LOG_MODULE_DECLARE(component, CONFIG_SOF_LOG_LEVEL);
@@ -780,7 +780,7 @@ static inline void comp_underrun(struct comp_dev *dev,
  * @param sink Sink buffer.
  * @param copy_bytes Requested size of free space to be available.
  */
-static inline void comp_overrun(struct comp_dev *dev, struct comp_buffer *sink,
+static inline void comp_overrun(struct comp_dev *dev, struct comp_buffer __sparse_cache *sink,
 				uint32_t copy_bytes)
 {
 	LOG_MODULE_DECLARE(component, CONFIG_SOF_LOG_LEVEL);
@@ -805,7 +805,7 @@ static inline void comp_overrun(struct comp_dev *dev, struct comp_buffer *sink,
  * @param[in] sink Sink buffer.
  * @param[out] cl Current copy limits.
  */
-void comp_get_copy_limits(struct comp_buffer *source, struct comp_buffer *sink,
+void comp_get_copy_limits(struct comp_buffer __sparse_cache *source, struct comp_buffer __sparse_cache *sink,
 			  struct comp_copy_limits *cl);
 
 /**
@@ -821,13 +821,15 @@ void comp_get_copy_limits_with_lock(struct comp_buffer *source,
 				    struct comp_buffer *sink,
 				    struct comp_copy_limits *cl)
 {
-	source = buffer_acquire(source);
-	sink = buffer_acquire(sink);
+	struct comp_buffer __sparse_cache *source_c, *sink_c;
 
-	comp_get_copy_limits(source, sink, cl);
+	source_c = buffer_acquire(source);
+	sink_c = buffer_acquire(sink);
 
-	source = buffer_release(source);
-	sink = buffer_release(sink);
+	comp_get_copy_limits(source_c, sink_c, cl);
+
+	buffer_release(source_c);
+	buffer_release(sink_c);
 }
 
 /**

--- a/src/include/sof/common.h
+++ b/src/include/sof/common.h
@@ -113,6 +113,16 @@
 #define container_of(ptr, type, member) \
 	({const typeof(((type *)0)->member)*__memberptr = (ptr); \
 	(type *)((char *)__memberptr - offsetof(type, member)); })
+/*
+ * typeof() doesn't preserve __attribute__((address_space(x))) sparse
+ * annotations, so if an object belongs to such an address space, using the
+ * original form of container_of() will lose that annotation, which then will
+ * lead to sparse "different address spaces" warnings. We need to explicitly
+ * re-inforce the address space onto the new pointer.
+ */
+#define attr_container_of(ptr, type, member, attr) \
+	({const typeof(((type *)0)->member) attr *__memberptr = (ptr); \
+	(type *)((char attr *)__memberptr - offsetof(type, member)); })
 
 #define ffs(i) __builtin_ffs(i)
 #define ffsl(i) __builtin_ffsl(i)

--- a/src/include/sof/compiler_attributes.h
+++ b/src/include/sof/compiler_attributes.h
@@ -32,8 +32,8 @@
  * test will not be true here, and must go through
  * the Clang version test.
  */
-#if (defined(__GNUC__) && (__GNUC__ >= 7)) || \
-	(defined(__clang__) && (__clang_major__ >= 10))
+#if ((defined(__GNUC__) && (__GNUC__ >= 7)) || \
+     (defined(__clang__) && (__clang_major__ >= 10))) && !defined(__CHECKER__)
 
 #define COMPILER_FALLTHROUGH __attribute__((fallthrough))
 

--- a/src/include/sof/compiler_attributes.h
+++ b/src/include/sof/compiler_attributes.h
@@ -5,7 +5,15 @@
  * Author: Karol Trzcinski <karolx.trzcinski@linux.intel.com>
  */
 
-#ifndef __ZEPHYR__
+#ifdef __ZEPHYR__
+
+/* Get __sparse_cache and __sparse_force definitions if __CHECKER__ is defined */
+#include <debug/sparse.h>
+
+#else
+
+#define __sparse_cache
+#define __sparse_force
 
 #ifndef __packed
 #define __packed __attribute__((packed))

--- a/src/include/sof/lib/mailbox.h
+++ b/src/include/sof/lib/mailbox.h
@@ -49,7 +49,8 @@ void mailbox_dspbox_write(size_t offset, const void *src, size_t bytes)
 			   MAILBOX_DSPBOX_SIZE - offset, src, bytes);
 
 	assert(!ret);
-	dcache_writeback_region((void *)(MAILBOX_DSPBOX_BASE + offset), bytes);
+	dcache_writeback_region((__sparse_force void __sparse_cache *)(MAILBOX_DSPBOX_BASE +
+								       offset), bytes);
 }
 
 static inline
@@ -58,8 +59,8 @@ void mailbox_dspbox_read(void *dest, size_t dest_size,
 {
 	int ret;
 
-	dcache_invalidate_region((void *)(MAILBOX_DSPBOX_BASE + offset),
-				 bytes);
+	dcache_invalidate_region((__sparse_force void __sparse_cache *)(MAILBOX_DSPBOX_BASE +
+									offset), bytes);
 	ret = memcpy_s(dest, dest_size,
 		       (void *)(MAILBOX_DSPBOX_BASE + offset), bytes);
 	assert(!ret);
@@ -80,7 +81,8 @@ void mailbox_hostbox_write(size_t offset, const void *src, size_t bytes)
 			   MAILBOX_HOSTBOX_SIZE - offset, src, bytes);
 
 	assert(!ret);
-	dcache_writeback_region((void *)(MAILBOX_HOSTBOX_BASE + offset), bytes);
+	dcache_writeback_region((__sparse_force void __sparse_cache *)(MAILBOX_HOSTBOX_BASE +
+								       offset), bytes);
 }
 
 #endif
@@ -91,8 +93,8 @@ void mailbox_hostbox_read(void *dest, size_t dest_size,
 {
 	int ret;
 
-	dcache_invalidate_region((void *)(MAILBOX_HOSTBOX_BASE + offset),
-				 bytes);
+	dcache_invalidate_region((__sparse_force void __sparse_cache *)(MAILBOX_HOSTBOX_BASE +
+									offset), bytes);
 	ret = memcpy_s(dest, dest_size,
 		       (void *)(MAILBOX_HOSTBOX_BASE + offset), bytes);
 	assert(!ret);
@@ -105,8 +107,8 @@ void mailbox_stream_write(size_t offset, const void *src, size_t bytes)
 			   MAILBOX_STREAM_SIZE - offset, src, bytes);
 
 	assert(!ret);
-	dcache_writeback_region((void *)(MAILBOX_STREAM_BASE + offset),
-				bytes);
+	dcache_writeback_region((__sparse_force void __sparse_cache *)(MAILBOX_STREAM_BASE +
+								       offset), bytes);
 }
 
 #endif /* __SOF_LIB_MAILBOX_H__ */

--- a/src/init/init.c
+++ b/src/init/init.c
@@ -64,7 +64,7 @@ static inline void lp_sram_unpack(void)
 		size = *ptr++;
 
 		memcpy_s(dst, size, src, size);
-		dcache_writeback_region(dst, size);
+		dcache_writeback_region((__sparse_force void __sparse_cache *)dst, size);
 	}
 }
 #endif

--- a/src/ipc/ipc-common.c
+++ b/src/ipc/ipc-common.c
@@ -53,7 +53,7 @@ int ipc_process_on_core(uint32_t core, bool blocking)
 	}
 
 	/* The other core will write there its response */
-	dcache_invalidate_region((void *)MAILBOX_HOSTBOX_BASE,
+	dcache_invalidate_region((__sparse_force void __sparse_cache *)MAILBOX_HOSTBOX_BASE,
 				 ((struct sof_ipc_cmd_hdr *)ipc->comp_data)->size);
 
 	/*

--- a/src/ipc/ipc-helper.c
+++ b/src/ipc/ipc-helper.c
@@ -57,7 +57,8 @@ struct comp_buffer *buffer_new(const struct sof_ipc_buffer *desc)
 		memcpy_s(&buffer->tctx, sizeof(struct tr_ctx),
 			 &buffer_tr, sizeof(struct tr_ctx));
 
-		dcache_writeback_invalidate_region(buffer, sizeof(*buffer));
+		dcache_writeback_invalidate_region((__sparse_force void __sparse_cache *)buffer,
+						   sizeof(*buffer));
 	}
 
 	return buffer;

--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -449,11 +449,12 @@ static int ipc4_set_pipeline_state(union ipc4_message_header *ipc4)
 	cmd = state.header.r.ppl_state;
 
 	ppl_data = (struct ipc4_pipeline_set_state_data *)MAILBOX_HOSTBOX_BASE;
-	dcache_invalidate_region(ppl_data, sizeof(*ppl_data));
+	dcache_invalidate_region((__sparse_force void __sparse_cache *)ppl_data, sizeof(*ppl_data));
 	if (state.data.r.multi_ppl) {
 		ppl_count = ppl_data->pipelines_count;
 		ppl_id = ppl_data->ppl_id;
-		dcache_invalidate_region(ppl_id, sizeof(int) * ppl_count);
+		dcache_invalidate_region((__sparse_force void __sparse_cache *)ppl_id,
+					 sizeof(int) * ppl_count);
 	} else {
 		ppl_count = 1;
 		id = state.header.r.ppl_id;

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -87,7 +87,7 @@ struct comp_dev *comp_new(struct sof_ipc_comp *comp)
 	ipc_config.pipeline_id = comp->pipeline_id;
 	ipc_config.core = comp->core;
 
-	dcache_invalidate_region((void *)(MAILBOX_HOSTBOX_BASE),
+	dcache_invalidate_region((__sparse_force void __sparse_cache *)(MAILBOX_HOSTBOX_BASE),
 				 MAILBOX_HOSTBOX_SIZE);
 
 	dev = drv->ops.create(drv, &ipc_config, (void *)MAILBOX_HOSTBOX_BASE);

--- a/src/lib/notifier.c
+++ b/src/lib/notifier.c
@@ -148,7 +148,7 @@ void notifier_notify_remote(void)
 	struct notify_data *notify_data = notify_data_get() + cpu_get_id();
 
 	if (!list_is_empty(&notify->list[notify_data->type])) {
-		dcache_invalidate_region(notify_data->data,
+		dcache_invalidate_region((__sparse_force void __sparse_cache *)notify_data->data,
 					 notify_data->data_size);
 		notifier_notify(notify_data->caller, notify_data->type,
 				notify_data->data);
@@ -180,8 +180,8 @@ void notifier_event(const void *caller, enum notify_id type, uint32_t core_mask,
 				notify_data->data = data;
 				notify_data->data_size = data_size;
 
-				dcache_writeback_region(notify_data->data,
-							data_size);
+				dcache_writeback_region((__sparse_force void __sparse_cache *)
+							notify_data->data, data_size);
 
 				idc_send_msg(&notify_msg, IDC_NON_BLOCKING);
 			}

--- a/src/platform/intel/cavs/include/cavs/lib/mailbox.h
+++ b/src/platform/intel/cavs/include/cavs/lib/mailbox.h
@@ -111,7 +111,8 @@ static inline void mailbox_sw_regs_write(size_t offset, const void *src, size_t 
 			   MAILBOX_SW_REG_SIZE - offset, src, bytes);
 
 	assert(!ret);
-	dcache_writeback_region((void *)(MAILBOX_SW_REG_BASE + offset), bytes);
+	dcache_writeback_region((__sparse_force void __sparse_cache *)(MAILBOX_SW_REG_BASE +
+								       offset), bytes);
 }
 
 #endif /* __CAVS_LIB_MAILBOX_H__ */

--- a/src/platform/intel/cavs/include/cavs/lib/mailbox.h
+++ b/src/platform/intel/cavs/include/cavs/lib/mailbox.h
@@ -70,27 +70,30 @@
 static inline void mailbox_sw_reg_write(size_t offset, uint32_t src)
 {
 	volatile uint32_t *ptr;
+	volatile uint32_t __sparse_cache *ptr_c;
 
-	ptr = (volatile uint32_t *)(MAILBOX_SW_REG_BASE + offset);
-	ptr = cache_to_uncache(ptr);
+	ptr_c = (volatile uint32_t __sparse_cache *)(MAILBOX_SW_REG_BASE + offset);
+	ptr = cache_to_uncache((uint32_t __sparse_cache *)ptr_c);
 	*ptr = src;
 }
 
 static inline void mailbox_sw_reg_write64(size_t offset, uint64_t src)
 {
 	volatile uint64_t *ptr;
+	volatile uint64_t __sparse_cache *ptr_c;
 
-	ptr = (volatile uint64_t *)(MAILBOX_SW_REG_BASE + offset);
-	ptr = cache_to_uncache(ptr);
+	ptr_c = (volatile uint64_t __sparse_cache *)(MAILBOX_SW_REG_BASE + offset);
+	ptr = cache_to_uncache((uint64_t __sparse_cache *)ptr_c);
 	*ptr = src;
 }
 
 static inline uint32_t mailbox_sw_reg_read(size_t offset)
 {
 	volatile uint32_t *ptr;
+	volatile uint32_t __sparse_cache *ptr_c;
 
-	ptr = (volatile uint32_t *)(MAILBOX_SW_REG_BASE + offset);
-	ptr = cache_to_uncache(ptr);
+	ptr_c = (volatile uint32_t __sparse_cache *)(MAILBOX_SW_REG_BASE + offset);
+	ptr = cache_to_uncache((uint32_t __sparse_cache *)ptr_c);
 
 	return *ptr;
 }
@@ -98,9 +101,10 @@ static inline uint32_t mailbox_sw_reg_read(size_t offset)
 static inline uint64_t mailbox_sw_reg_read64(size_t offset)
 {
 	volatile uint64_t *ptr;
+	volatile uint64_t __sparse_cache *ptr_c;
 
-	ptr = (volatile uint64_t *)(MAILBOX_SW_REG_BASE + offset);
-	ptr = cache_to_uncache(ptr);
+	ptr_c = (volatile uint64_t __sparse_cache *)(MAILBOX_SW_REG_BASE + offset);
+	ptr = cache_to_uncache((uint64_t __sparse_cache *)ptr_c);
 
 	return *ptr;
 }

--- a/src/platform/intel/cavs/include/cavs/lib/memory.h
+++ b/src/platform/intel/cavs/include/cavs/lib/memory.h
@@ -88,10 +88,16 @@ struct sof;
 #define SRAM_ALIAS_OFFSET	SRAM_UNCACHED_ALIAS
 
 #if !defined UNIT_TEST
-#define uncache_to_cache(address) \
-	((__typeof__(address))((uint32_t)(address) | SRAM_ALIAS_OFFSET))
-#define cache_to_uncache(address) \
-	((__typeof__(address))((uint32_t)(address) & ~SRAM_ALIAS_OFFSET))
+static inline void __sparse_cache *uncache_to_cache(void *address)
+{
+	return (void __sparse_cache *)((uintptr_t)(address) | SRAM_ALIAS_OFFSET);
+}
+
+static inline void *cache_to_uncache(void __sparse_cache *address)
+{
+	return (void *)((uintptr_t)(address) & ~SRAM_ALIAS_OFFSET);
+}
+
 #define is_uncached(address) \
 	(((uint32_t)(address) & SRAM_ALIAS_MASK) == SRAM_ALIAS_BASE)
 #else

--- a/src/platform/intel/cavs/include/cavs/lib/memory.h
+++ b/src/platform/intel/cavs/include/cavs/lib/memory.h
@@ -120,7 +120,7 @@ struct sof;
 static inline void *platform_shared_get(void *ptr, int bytes)
 {
 #if CONFIG_CORE_COUNT > 1 && !defined __ZEPHYR__
-	dcache_invalidate_region(ptr, bytes);
+	dcache_invalidate_region((__sparse_force void __sparse_cache *)ptr, bytes);
 	return cache_to_uncache(ptr);
 #else
 	return ptr;

--- a/src/platform/intel/cavs/lib/clk.c
+++ b/src/platform/intel/cavs/lib/clk.c
@@ -162,7 +162,7 @@ static inline int get_lowest_freq_idx(int clock)
 static void platform_clock_low_power_mode(int clock, bool enable)
 {
 	int current_freq_idx = get_current_freq_idx(clock);
-	int freq_idx = *cache_to_uncache(&active_freq_idx);
+	int freq_idx = *(int *)cache_to_uncache(&active_freq_idx);
 
 	if (enable && current_freq_idx > CPU_LPRO_FREQ_IDX)
 		/* LPRO requests are fast, but requests for other ROs
@@ -186,7 +186,7 @@ void platform_clock_on_waiti(void)
 	/* hold the prd->lock for possible active_freq_idx switching */
 	key = k_spin_lock(&prd->lock);
 
-	freq_idx = *cache_to_uncache(&active_freq_idx);
+	freq_idx = *(int *)cache_to_uncache(&active_freq_idx);
 	lowest_freq_idx = get_lowest_freq_idx(CLK_CPU(cpu_get_id()));
 	pm_is_active = pm_runtime_is_active(PM_RUNTIME_DSP, PLATFORM_PRIMARY_CORE_ID);
 
@@ -261,7 +261,7 @@ void platform_clock_on_waiti(void)
 	/* hold the prd->lock for possible active_freq_idx switching */
 	key = k_spin_lock(&prd->lock);
 
-	freq_idx = *cache_to_uncache(&active_freq_idx);
+	freq_idx = *(int *)cache_to_uncache(&active_freq_idx);
 	lowest_freq_idx = get_lowest_freq_idx(CLK_CPU(cpu_get_id()));
 	pm_is_active = pm_runtime_is_active(PM_RUNTIME_DSP, PLATFORM_PRIMARY_CORE_ID);
 
@@ -289,7 +289,7 @@ void platform_clock_on_wakeup(void)
 	key = k_spin_lock(&prd->lock);
 
 	current_idx = get_current_freq_idx(CLK_CPU(cpu_get_id()));
-	target_idx = *cache_to_uncache(&active_freq_idx);
+	target_idx = *(int *)cache_to_uncache(&active_freq_idx);
 
 	/* restore the active cpu freq_idx manually */
 	if (current_idx != target_idx)

--- a/src/platform/intel/cavs/lib/mem_window.c
+++ b/src/platform/intel/cavs/lib/mem_window.c
@@ -25,7 +25,7 @@ static inline void memory_window_init(uint32_t index,
 	io_reg_write(DMWBA(index), base | wnd_flags);
 	if (init_flags & MEM_WND_INIT_CLEAR) {
 		bzero((void *)zero_base, zero_size);
-		dcache_writeback_region((void *)zero_base, zero_size);
+		dcache_writeback_region((__sparse_force void __sparse_cache *)zero_base, zero_size);
 	}
 }
 

--- a/src/platform/intel/cavs/lib/memory.c
+++ b/src/platform/intel/cavs/lib/memory.c
@@ -201,14 +201,14 @@ void platform_init_memmap(struct sof *sof)
 	sof->memory_map->runtime_shared[0].blocks = ARRAY_SIZE(rt_shared_heap_map);
 	sof->memory_map->runtime_shared[0].map = uncached_block_map(rt_shared_heap_map);
 	sof->memory_map->runtime_shared[0].heap =
-			cache_to_uncache((uintptr_t)&_runtime_shared_heap);
+		(uint32_t)cache_to_uncache(&_runtime_shared_heap);
 	sof->memory_map->runtime_shared[0].size = HEAP_RUNTIME_SHARED_SIZE;
 	sof->memory_map->runtime_shared[0].info.free = HEAP_RUNTIME_SHARED_SIZE;
 	sof->memory_map->runtime_shared[0].caps = SOF_MEM_CAPS_RAM | SOF_MEM_CAPS_EXT |
 		SOF_MEM_CAPS_CACHE;
 
 	/* .system_shared init */
-	sof->memory_map->system_shared[0].heap = cache_to_uncache((uintptr_t)&_system_shared_heap);
+	sof->memory_map->system_shared[0].heap = (uint32_t)cache_to_uncache(&_system_shared_heap);
 	sof->memory_map->system_shared[0].size = HEAP_SYSTEM_SHARED_SIZE;
 	sof->memory_map->system_shared[0].info.free = HEAP_SYSTEM_SHARED_SIZE;
 	sof->memory_map->system_shared[0].caps = SOF_MEM_CAPS_RAM | SOF_MEM_CAPS_EXT |
@@ -228,7 +228,7 @@ void platform_init_memmap(struct sof *sof)
 	/* heap buffer init */
 	sof->memory_map->buffer[0].blocks = ARRAY_SIZE(buf_heap_map);
 	sof->memory_map->buffer[0].map = uncached_block_map(buf_heap_map);
-	sof->memory_map->buffer[0].heap = cache_to_uncache((uintptr_t)&_buffer_heap);
+	sof->memory_map->buffer[0].heap = (uint32_t)cache_to_uncache(&_buffer_heap);
 	sof->memory_map->buffer[0].size = heap_buffer_size;
 	sof->memory_map->buffer[0].info.free = heap_buffer_size;
 	sof->memory_map->buffer[0].caps = SOF_MEM_CAPS_RAM | SOF_MEM_CAPS_HP |

--- a/src/platform/intel/cavs/lps_wait.c
+++ b/src/platform/intel/cavs/lps_wait.c
@@ -76,8 +76,8 @@ static void platform_pg_task(void)
 	 */
 	memcpy_s((void *)LPS_RESTORE_VECTOR_ADDR, LPS_RESTORE_VECTOR_SIZE,
 		 &lps_pic_restore_vector_literals, vector_size);
-	dcache_writeback_invalidate_region((void *)LPS_RESTORE_VECTOR_ADDR,
-					   vector_size);
+	dcache_writeback_invalidate_region((__sparse_force void __sparse_cache *)
+					   LPS_RESTORE_VECTOR_ADDR, vector_size);
 
 	/* set magic and vector in LPSRAM */
 	lpsram_hdr->adsp_lpsram_magic = LPSRAM_MAGIC_VALUE;

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -610,10 +610,12 @@ static void imr_layout_update(void *vector)
 	 * configuration, no symmetric task need to done in any
 	 * platform_resume() to clear the configuration.
 	 */
-	dcache_invalidate_region(imr_layout, sizeof(*imr_layout));
+	dcache_invalidate_region((__sparse_force void __sparse_cache *)imr_layout,
+				 sizeof(*imr_layout));
 	imr_layout->imr_state.header.adsp_imr_magic = ADSP_IMR_MAGIC_VALUE;
 	imr_layout->imr_state.header.imr_restore_vector = vector;
-	dcache_writeback_region(imr_layout, sizeof(*imr_layout));
+	dcache_writeback_region((__sparse_force void __sparse_cache *)imr_layout,
+				sizeof(*imr_layout));
 }
 #endif
 

--- a/src/probe/probe.c
+++ b/src/probe/probe.c
@@ -91,7 +91,7 @@ static int probe_dma_buffer_init(struct probe_dma_buf *buffer, uint32_t size,
 	}
 
 	bzero((void *)buffer->addr, size);
-	dcache_writeback_region((void *)buffer->addr, size);
+	dcache_writeback_region((__sparse_force void __sparse_cache *)buffer->addr, size);
 
 	/* initialise the DMA buffer */
 	buffer->size = size;
@@ -518,7 +518,7 @@ static int copy_to_pbuffer(struct probe_dma_buf *pbuf, void *data,
 		tr_err(&pr_tr, "copy_to_pbuffer(): memcpy_s() failed");
 		return -EINVAL;
 	}
-	dcache_writeback_region((void *)pbuf->w_ptr, head);
+	dcache_writeback_region((__sparse_force void __sparse_cache *)pbuf->w_ptr, head);
 
 	/* buffer ended so needs to do a second copy */
 	if (tail) {
@@ -528,7 +528,7 @@ static int copy_to_pbuffer(struct probe_dma_buf *pbuf, void *data,
 			tr_err(&pr_tr, "copy_to_pbuffer(): memcpy_s() failed");
 			return -EINVAL;
 		}
-		dcache_writeback_region((void *)pbuf->w_ptr, tail);
+		dcache_writeback_region((__sparse_force void __sparse_cache *)pbuf->w_ptr, tail);
 		pbuf->w_ptr = pbuf->w_ptr + tail;
 	} else {
 		pbuf->w_ptr = pbuf->w_ptr + head;
@@ -570,7 +570,7 @@ static int copy_from_pbuffer(struct probe_dma_buf *pbuf, void *data,
 	}
 
 	/* data from DMA so invalidate it */
-	dcache_invalidate_region((void *)pbuf->r_ptr, head);
+	dcache_invalidate_region((__sparse_force void __sparse_cache *)pbuf->r_ptr, head);
 	if (memcpy_s(data, bytes, (void *)pbuf->r_ptr, head)) {
 		tr_err(&pr_tr, "copy_from_pbuffer(): memcpy_s() failed");
 		return -EINVAL;
@@ -580,7 +580,7 @@ static int copy_from_pbuffer(struct probe_dma_buf *pbuf, void *data,
 	if (tail) {
 		/* starting from the beginning of the buffer */
 		pbuf->r_ptr = pbuf->addr;
-		dcache_invalidate_region((void *)pbuf->r_ptr, tail);
+		dcache_invalidate_region((__sparse_force void __sparse_cache *)pbuf->r_ptr, tail);
 		if (memcpy_s((char *)data + head, tail, (void *)pbuf->r_ptr, tail)) {
 			tr_err(&pr_tr, "copy_from_pbuffer(): memcpy_s() failed");
 			return -EINVAL;
@@ -627,7 +627,7 @@ static int probe_gen_header(struct comp_buffer *buffer, uint32_t size,
 	crc = crc32(0, header, sizeof(*header));
 	header->checksum = crc;
 
-	dcache_writeback_region(header, sizeof(*header));
+	dcache_writeback_region((__sparse_force void __sparse_cache *)header, sizeof(*header));
 
 	return copy_to_pbuffer(&_probe->ext_dma.dmapb, header,
 			       sizeof(struct probe_data_packet));

--- a/src/trace/dma-trace.c
+++ b/src/trace/dma-trace.c
@@ -288,7 +288,7 @@ static int dma_trace_buffer_init(struct dma_trace_data *d)
 	}
 
 	bzero(buf, DMA_TRACE_LOCAL_SIZE);
-	dcache_writeback_region(buf, DMA_TRACE_LOCAL_SIZE);
+	dcache_writeback_region((__sparse_force void __sparse_cache *)buf, DMA_TRACE_LOCAL_SIZE);
 
 	/* initialise the DMA buffer, whole sequence in section */
 	key = k_spin_lock(&d->lock);
@@ -551,7 +551,7 @@ void dma_trace_flush(void *t)
 	size = MIN(size, MAILBOX_TRACE_SIZE);
 
 	/* invalidate trace data */
-	dcache_invalidate_region((void *)t, size);
+	dcache_invalidate_region((__sparse_force void __sparse_cache *)t, size);
 
 	/* check for buffer wrap */
 	if ((char *)buffer->w_ptr - size < (char *)buffer->addr) {
@@ -569,7 +569,7 @@ void dma_trace_flush(void *t)
 	}
 
 	/* writeback trace data */
-	dcache_writeback_region((void *)t, size);
+	dcache_writeback_region((__sparse_force void __sparse_cache *)t, size);
 
 }
 
@@ -662,25 +662,29 @@ static void dtrace_add_event(const char *e, uint32_t length)
 		/* check for buffer wrap */
 		if (margin > length) {
 			/* no wrap */
-			dcache_invalidate_region(buffer->w_ptr, length);
+			dcache_invalidate_region((__sparse_force void __sparse_cache *)buffer->w_ptr,
+						 length);
 			ret = memcpy_s(buffer->w_ptr, length, e, length);
 			assert(!ret);
-			dcache_writeback_region(buffer->w_ptr, length);
+			dcache_writeback_region((__sparse_force void __sparse_cache *)buffer->w_ptr,
+						length);
 			buffer->w_ptr = (char *)buffer->w_ptr + length;
 		} else {
 			/* data is bigger than remaining margin so we wrap */
-			dcache_invalidate_region(buffer->w_ptr, margin);
+			dcache_invalidate_region((__sparse_force void __sparse_cache *)buffer->w_ptr,
+						 margin);
 			ret = memcpy_s(buffer->w_ptr, margin, e, margin);
 			assert(!ret);
-			dcache_writeback_region(buffer->w_ptr, margin);
+			dcache_writeback_region((__sparse_force void __sparse_cache *)buffer->w_ptr,
+						margin);
 			buffer->w_ptr = buffer->addr;
 
-			dcache_invalidate_region(buffer->w_ptr,
+			dcache_invalidate_region((__sparse_force void __sparse_cache *)buffer->w_ptr,
 						 length - margin);
 			ret = memcpy_s(buffer->w_ptr, length - margin,
 				       e + margin, length - margin);
 			assert(!ret);
-			dcache_writeback_region(buffer->w_ptr,
+			dcache_writeback_region((__sparse_force void __sparse_cache *)buffer->w_ptr,
 						length - margin);
 			buffer->w_ptr = (char *)buffer->w_ptr + length - margin;
 		}

--- a/src/trace/trace.c
+++ b/src/trace/trace.c
@@ -104,13 +104,14 @@ void mtrace_event(const char *data, uint32_t length)
 
 	if (available < length) { /* wrap */
 		memset(t + trace->pos, 0xff, available);
-		dcache_writeback_region(t + trace->pos, available);
+		dcache_writeback_region((__sparse_force char __sparse_cache *)t + trace->pos,
+					available);
 		trace->pos = 0;
 	}
 
 	memcpy_s(t + trace->pos, MAILBOX_TRACE_SIZE - trace->pos,
 		 data, length);
-	dcache_writeback_region(t + trace->pos, length);
+	dcache_writeback_region((__sparse_force char __sparse_cache *)t + trace->pos, length);
 	trace->pos += length;
 }
 #endif /* __ZEPHYR__ */
@@ -512,7 +513,7 @@ void trace_init(struct sof *sof)
 	 * Don't touch.
 	 */
 	bzero((void *)MAILBOX_TRACE_BASE, MAILBOX_TRACE_SIZE);
-	dcache_writeback_invalidate_region((void *)MAILBOX_TRACE_BASE,
+	dcache_writeback_invalidate_region((__sparse_force void __sparse_cache *)MAILBOX_TRACE_BASE,
 					   MAILBOX_TRACE_SIZE);
 #endif
 


### PR DESCRIPTION
This is mostly an FYI / RFC to collect opinions. We might actually never do this in SOF locally but push it directly to Zephyr. But we'll need to fix our code of course.
This is a good thing to have (TM) in general, and in particular we want to use sparse to identify coherent API abuses.
UPDATE March 04 2022: now this only contains basic sparse support, error fixes and an addition of the `__cache` annotation. Fixes for `__cache` and other warnings will come separately