### PR TITLE
dma-trace: Align dma trace buffer correctly, fixed Zephyr dtrace issue

### DIFF
--- a/src/drivers/intel/hda/hda-dma.c
+++ b/src/drivers/intel/hda/hda-dma.c
@@ -818,9 +818,17 @@ static int hda_dma_set_config(struct dma_chan_data *channel,
 
 	/* buffer size must be multiple of hda dma burst size */
 	if (buffer_bytes % HDA_DMA_BUFFER_ALIGNMENT) {
-		tr_err(&hdma_tr, "hda-dmac: %d chan %d - buffer not DMA aligned 0x%x",
+		tr_err(&hdma_tr, "hda-dmac: %d chan %d - buffer size not DMA aligned 0x%x",
 		       dma->plat_data.id,
 		       channel->index, buffer_bytes);
+		ret = -EINVAL;
+		goto out;
+	}
+	/* buffer base address must be correctly aligned */
+	if (buffer_addr % HDA_DMA_BUFFER_ADDRESS_ALIGNMENT) {
+		tr_err(&hdma_tr, "hda-dmac: %d chan %d - buffer address not DMA aligned 0x%x",
+		       dma->plat_data.id,
+		       channel->index, buffer_addr);
 		ret = -EINVAL;
 		goto out;
 	}

--- a/src/include/sof/lib/dma.h
+++ b/src/include/sof/lib/dma.h
@@ -541,8 +541,8 @@ int dma_copy_from_host_nowait(struct dma_copy *dc,
 			      int32_t size);
 
 /* DMA copy data from DSP to host */
-int dma_copy_to_host_nowait(struct dma_copy *dc, struct dma_sg_config *host_sg,
-	int32_t host_offset, void *local_ptr, int32_t size);
+int dma_copy_to_host(struct dma_copy *dc, struct dma_sg_config *host_sg,
+		     int32_t host_offset, void *local_ptr, int32_t size);
 
 int dma_copy_set_stream_tag(struct dma_copy *dc, uint32_t stream_tag);
 

--- a/src/ipc/dma-copy.c
+++ b/src/ipc/dma-copy.c
@@ -59,13 +59,13 @@ static struct dma_sg_elem *sg_get_elem_at(struct dma_sg_config *host_sg,
  */
 #if CONFIG_DMA_GW
 
-int dma_copy_to_host_nowait(struct dma_copy *dc, struct dma_sg_config *host_sg,
-			    int32_t host_offset, void *local_ptr, int32_t size)
+int dma_copy_to_host(struct dma_copy *dc, struct dma_sg_config *host_sg,
+		     int32_t host_offset, void *local_ptr, int32_t size)
 {
 	int ret;
 
 	/* tell gateway to copy */
-	ret = dma_copy(dc->chan, size, 0);
+	ret = dma_copy(dc->chan, size, DMA_COPY_BLOCKING);
 	if (ret < 0)
 		return ret;
 
@@ -75,8 +75,8 @@ int dma_copy_to_host_nowait(struct dma_copy *dc, struct dma_sg_config *host_sg,
 
 #else /* CONFIG_DMA_GW */
 
-int dma_copy_to_host_nowait(struct dma_copy *dc, struct dma_sg_config *host_sg,
-			    int32_t host_offset, void *local_ptr, int32_t size)
+int dma_copy_to_host(struct dma_copy *dc, struct dma_sg_config *host_sg,
+		     int32_t host_offset, void *local_ptr, int32_t size)
 {
 	struct dma_sg_config config;
 	struct dma_sg_elem *host_sg_elem;

--- a/src/probe/probe.c
+++ b/src/probe/probe.c
@@ -201,15 +201,15 @@ static enum task_state probe_task(void *data)
 	int err;
 
 	if (_probe->ext_dma.dmapb.avail > 0)
-		err = dma_copy_to_host_nowait(&_probe->ext_dma.dc,
-					      &_probe->ext_dma.config, 0,
-					       (void *)_probe->ext_dma.dmapb.r_ptr,
-					       _probe->ext_dma.dmapb.avail);
+		err = dma_copy_to_host(&_probe->ext_dma.dc,
+				       &_probe->ext_dma.config, 0,
+				       (void *)_probe->ext_dma.dmapb.r_ptr,
+				       _probe->ext_dma.dmapb.avail);
 	else
 		return SOF_TASK_STATE_RESCHEDULE;
 
 	if (err < 0) {
-		tr_err(&pr_tr, "probe_task(): dma_copy_to_host_nowait() failed.");
+		tr_err(&pr_tr, "probe_task(): dma_copy_to_host() failed.");
 		return err;
 	}
 

--- a/src/trace/dma-trace.c
+++ b/src/trace/dma-trace.c
@@ -83,10 +83,10 @@ static enum task_state trace_work(void *data)
 	d->copy_in_progress = 1;
 
 	/* copy this section to host */
-	size = dma_copy_to_host_nowait(&d->dc, config, d->posn.host_offset,
-				       buffer->r_ptr, size);
+	size = dma_copy_to_host(&d->dc, config, d->posn.host_offset,
+				buffer->r_ptr, size);
 	if (size < 0) {
-		tr_err(&dt_tr, "trace_work(): dma_copy_to_host_nowait() failed");
+		tr_err(&dt_tr, "trace_work(): dma_copy_to_host() failed");
 		goto out;
 	}
 


### PR DESCRIPTION
The first commit should be the the only one needed to fix https://github.com/thesofproject/sof/issues/5120 .
The second commit should make sure the same problem does not bite us again. The third commit is pretty much optional, but I think the fix is correct and it is also cleaning up the code a bit.