### PR TITLE
testbench: add option to override CPU core mapping

### DIFF
--- a/tools/testbench/testbench.c
+++ b/tools/testbench/testbench.c
@@ -208,6 +208,8 @@ static void print_usage(char *executable)
 	printf("  -n <output channels>\n");
 	printf("  -r <input rate>\n");
 	printf("  -R <output rate>\n\n");
+	printf("Environment variables\n");
+	printf("  SOF_HOST_CORE0=<i> - Map DSP core 0..N to host i..i+N\n");
 	printf("Help:\n");
 	printf("  -h\n\n");
 	printf("Example Usage:\n");


### PR DESCRIPTION
Add option to override how a core id, specified in SOF topology, is
mapped to host core. This allows to map a multithreaded pipeline
execution to specific range of host CPUs.

Implement the option via environment variable "SOF_HOST_CORE0", which is
understood by the CONFIG_LIBRARY implementation of ll-scheduler.

Document the usage to testbench help. mapping of DSP core ids specified
SOF_HOST_CORE

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>