### PR TITLE
WIP: cache: debug: add debug to detect coherent object clobbering

### DIFF
--- a/src/include/sof/coherent.h
+++ b/src/include/sof/coherent.h
@@ -53,6 +53,9 @@
  * The shared flag is only set at coherent init and thereafter it's RO.
  */
 struct coherent {
+#if 1
+	struct cache_debug debug;
+#endif
 	struct k_spinlock lock;	/* locking mechanism */
 	k_spinlock_key_t key;	/* lock flags */
 	uint16_t shared;	/* shared on other non coherent cores */


### PR DESCRIPTION
@lyakh this one's for you. We could also use the 3 spare words in struct coherent and perform runtime check during all the low level WB/INV calls.

Add a debug option to use the remaining 3 words of struct coherent to
add debug context to track uncache alias clobbering and non locked
access.

The intention is to detect clients who WB/INV managed coherent objects
without holding the locks AND to detect any clobbering of the uncache
coherent object mappings.

Signed-off-by: Liam Girdwood <liam.r.girdwood@linux.intel.com>