### PR TITLE
ipc4: fix progress bar issue with windows audio player

### DIFF
--- a/src/audio/copier.c
+++ b/src/audio/copier.c
@@ -731,6 +731,9 @@ static int copier_params(struct comp_dev *dev, struct sof_ipc_stream_params *par
 	params->buffer_fmt = cd->config.base.audio_fmt.interleaving_style;
 	params->buffer.size = cd->config.base.ibs;
 
+	/* disable ipc3 stream position */
+	params->no_stream_position = 1;
+
 	/* update each sink format */
 	list_for_item(sink_list, &dev->bsink_list) {
 		int j;

--- a/src/audio/copier.c
+++ b/src/audio/copier.c
@@ -550,6 +550,9 @@ static int copier_comp_trigger(struct comp_dev *dev, int cmd)
 	if (ret < 0)
 		return ret;
 
+	if (ret == COMP_STATUS_STATE_ALREADY_SET)
+		return PPL_STATUS_PATH_STOP;
+
 	if (cd->endpoint)
 		ret = cd->endpoint->drv->ops.trigger(cd->endpoint, cmd);
 

--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -605,8 +605,6 @@ static int dai_config_prepare(struct comp_dev *dev)
 	comp_info(dev, "dai_config_prepare(): new configured dma channel index %d",
 		  dd->chan->index);
 
-	dai_dma_position_init(dd);
-
 	/* setup callback */
 	notifier_register(dev, dd->chan, NOTIFIER_ID_DMA_COPY,
 			  dai_dma_cb, 0);

--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -228,6 +228,9 @@ static void dw_dma_channel_put_unlocked(struct dma_chan_data *channel)
 
 	dw_dma_interrupt_mask(channel);
 
+	/* disable linear link position */
+	platform_dw_dma_llp_disable(channel->dma, channel);
+
 	/* free the lli allocated by set_config*/
 	if (dw_chan->lli) {
 		rfree(dw_chan->lli);
@@ -442,9 +445,6 @@ static int dw_dma_stop(struct dma_chan_data *channel)
 	dcache_writeback_region(dw_chan->lli,
 				sizeof(struct dw_lli) * channel->desc_count);
 #endif
-
-	/* disable linear link position */
-	platform_dw_dma_llp_disable(dma, channel);
 
 	channel->status = COMP_STATE_PREPARE;
 

--- a/src/include/sof/audio/pipeline.h
+++ b/src/include/sof/audio/pipeline.h
@@ -199,6 +199,14 @@ int pipeline_for_each_comp(struct comp_dev *current,
 			   struct pipeline_walk_context *ctx, int dir);
 
 /**
+ * \brief Walks pipeline graph to find dai component and latency.
+ * \param[in] pipeline_id is the start pipeline id.
+ * \param[out] latency to dai.
+ * \return dai component.
+ */
+struct comp_dev *pipeline_get_dai_comp(uint32_t pipeline_id, uint32_t *latency);
+
+/**
  * Retrieves pipeline id from pipeline.
  * @param p pipeline.
  * @return pipeline id.

--- a/src/include/sof/lib/dai.h
+++ b/src/include/sof/lib/dai.h
@@ -521,11 +521,6 @@ int dai_assign_group(struct comp_dev *dev, uint32_t group_id);
 int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn);
 
 /**
- * \brief init dai dma position for host driver.
- */
-void dai_dma_position_init(struct dai_data *dd);
-
-/**
  * \brief update dai dma position for host driver.
  */
 void dai_dma_position_update(struct comp_dev *dev);

--- a/src/ipc/ipc3/dai.c
+++ b/src/ipc/ipc3/dai.c
@@ -365,6 +365,4 @@ int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn)
 	return 0;
 }
 
-void dai_dma_position_init(struct dai_data *dd) { }
-
 void dai_dma_position_update(struct comp_dev *dev) { }

--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -199,6 +199,21 @@ void dai_dma_release(struct comp_dev *dev)
 	}
 }
 
+static void dai_dma_position_init(struct dai_data *dd)
+{
+	struct ipc4_llp_reading_slot slot;
+	uint32_t llp_reg_offset;
+	uint32_t node_id;
+
+	get_llp_reg_info(dd, &node_id, &llp_reg_offset);
+	if (!node_id)
+		return;
+
+	memset_s(&slot, sizeof(slot), 0, sizeof(slot));
+	slot.node_id = node_id;
+	mailbox_sw_regs_write(llp_reg_offset, &slot, sizeof(slot));
+}
+
 int dai_config(struct comp_dev *dev, struct ipc_config_dai *common_config,
 	       void *spec_config)
 {
@@ -255,6 +270,8 @@ int dai_config(struct comp_dev *dev, struct ipc_config_dai *common_config,
 		}
 	}
 
+	dai_dma_position_init(dd);
+
 	return dai_set_config(dd->dai, common_config, copier_cfg->gtw_cfg.config_data);
 }
 
@@ -282,21 +299,6 @@ int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn)
 	dma_status(dd->chan, &status, dev->direction);
 
 	return 0;
-}
-
-void dai_dma_position_init(struct dai_data *dd)
-{
-	struct ipc4_llp_reading_slot slot;
-	uint32_t llp_reg_offset;
-	uint32_t node_id;
-
-	get_llp_reg_info(dd, &node_id, &llp_reg_offset);
-	if (!node_id)
-		return;
-
-	memset_s(&slot, sizeof(slot), 0, sizeof(slot));
-	slot.node_id = node_id;
-	mailbox_sw_regs_write(llp_reg_offset, &slot, sizeof(slot));
 }
 
 void dai_dma_position_update(struct comp_dev *dev)

--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -279,18 +279,9 @@ int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn)
 {
 	struct dai_data *dd = comp_get_drvdata(dev);
 	struct dma_chan_status status;
-	uint32_t frame_size;
 
-	/* calculate frame size */
-	frame_size = get_frame_bytes(dev->ipc_config.frame_fmt,
-				     dd->local_buffer->stream.channels);
-	if (!frame_size) {
-		comp_err(dev, "invalid frame size 0");
-		return -EINVAL;
-	}
-
-	/* sample count */
-	posn->dai_posn = dev->position / frame_size;
+	/* total processed bytes count */
+	posn->dai_posn = dev->position;
 
 	/* set stream start wallclock */
 	posn->wallclock = dd->wallclock;

--- a/src/platform/intel/cavs/include/cavs/drivers/dw-dma.h
+++ b/src/platform/intel/cavs/include/cavs/drivers/dw-dma.h
@@ -80,8 +80,11 @@ static inline void platform_dw_dma_llp_config(struct dma *dma,
 static inline void platform_dw_dma_llp_enable(struct dma *dma,
 					      struct dma_chan_data *chan)
 {
-	shim_write(DW_CHLLPC(dma, chan),
-		   shim_read(DW_CHLLPC(dma, chan)) | SHIM_GPDMA_CHLLPC_EN);
+	uint32_t val;
+
+	val = shim_read(DW_CHLLPC(dma, chan));
+	if (!(val & SHIM_GPDMA_CHLLPC_EN))
+		shim_write(DW_CHLLPC(dma, chan), val | SHIM_GPDMA_CHLLPC_EN);
 }
 
 static inline void platform_dw_dma_llp_disable(struct dma *dma,


### PR DESCRIPTION
The progress bar of windows audio player is out of order after pause-resume operation. It is caused by stream position calculation. audio driver uses stream_start  | end offset to build a stream position which are missed in SOF FW.

This patch adds support of stream_start  | end offset

Validated on windows