### PR TITLE
Tools: Test, Tune: Improve Matlab scripts for EQ testing

### DIFF
--- a/tools/test/audio/process_test.m
+++ b/tools/test/audio/process_test.m
@@ -281,10 +281,10 @@ end
 function test = g_spec(test, prm)
 
 switch lower(test.comp)
-	case 'eqiir'
+	case 'eq-iir'
 		blob = fullfile(prm.blobpath, prm.iirblob);
 		h = eq_blob_plot(blob, 'iir', test.fs, test.f, 0);
-	case 'eqfir'
+	case 'eq-fir'
 		blob = fullfile(prm.blobpath, prm.firblob);
 		h = eq_blob_plot(blob, 'fir', test.fs, test.f, 0);
 	otherwise
@@ -298,10 +298,10 @@ end
 function test = fr_mask(test, prm)
 
 switch lower(test.comp)
-	case 'eqiir'
+	case 'eq-iir'
 		blob = fullfile(prm.blobpath, prm.iirblob);
 		h = eq_blob_plot(blob, 'iir', test.fs, test.f, 0);
-	case 'eqfir'
+	case 'eq-fir'
 		blob = fullfile(prm.blobpath, prm.firblob);
 		h = eq_blob_plot(blob, 'fir', test.fs, test.f, 0);
 	otherwise

--- a/tools/tune/eq/eq_blob_plot.m
+++ b/tools/tune/eq/eq_blob_plot.m
@@ -11,6 +11,11 @@ function eq = eq_blob_plot(blobfn, eqtype, fs, f, doplot)
 % fs     - sample rate, defaults to 48 kHz if omitted
 % f      - frequency vector
 % dpplot
+%
+% Examples
+% eq_blob_plot('../../topology/topology1/m4/eq_iir_coef_loudness.m4', 'iir');
+% eq_blob_plot('../../ctl/eq_fir_mid.bin', 'fir');
+% eq_blob_plot('../../ctl/eq_iir_bassboost.txt', 'iir');
 
 % SPDX-License-Identifier: BSD-3-Clause
 %

--- a/tools/tune/eq/eq_fir_blob_decode.m
+++ b/tools/tune/eq/eq_fir_blob_decode.m
@@ -2,9 +2,9 @@ function eq = eq_fir_blob_decode(blob, resp_n)
 
 %% Decode a FIR EQ binary blob
 %
-% eq = eq_fir_blob_decode(blobfn, resp_n, fs, do_plot)
+% eq = eq_fir_blob_decode(blob, resp_n, fs, do_plot)
 %
-% blobfn  - file name of EQ setup blob
+% blob    - EQ setup blob 16 bit data vector
 % resp_n  - index of response to decode
 % fs      - sample rate, optional
 % do_plot - set to 1 for frequency response plot, optional
@@ -15,6 +15,11 @@ function eq = eq_fir_blob_decode(blob, resp_n)
 % channels_in_config - numbers of channels in blob
 % assign_response    - vector of EQ indexes assigned to channels
 % size               - length in bytes
+%
+% To decode a FIR blob, try first
+% eq_blob_plot('../../topology/topology1/m4/eq_fir_coef_loudness.m4', 'fir');
+% eq_blob_plot('../../ctl/eq_fir_loudness.bin', 'fir');
+% eq_blob_plot('../../ctl/eq_fir_loudness.txt', 'fir');
 
 % SPDX-License-Identifier: BSD-3-Clause
 %

--- a/tools/tune/eq/eq_iir_blob_decode.m
+++ b/tools/tune/eq/eq_iir_blob_decode.m
@@ -4,7 +4,7 @@ function eq = eq_iir_blob_decode(ublob, resp_n)
 %
 % eq = eq_fir_decode_blob(blobfn, resp_n)
 %
-% blobfn  - file name of EQ setup blob
+% blob    - EQ setup blob 32 bit data vector
 % resp_n  - index of response to decode
 % fs      - sample rate, optional
 % do_plot - set to 1 for frequency response plot, optional
@@ -15,6 +15,10 @@ function eq = eq_iir_blob_decode(ublob, resp_n)
 % channels_in_config - numbers of channels in blob
 % assign response    - vector of EQ indexes assigned to channels
 %
+% To decode a IIR blob, try iirst
+% eq_blob_plot('../../topology/topology1/m4/eq_iir_coef_loudness.m4', 'iir');
+% eq_blob_plot('../../ctl/eq_iir_loudness.bin', 'iir');
+% eq_blob_plot('../../ctl/eq_iir_loudness.txt', 'iir');
 
 % SPDX-License-Identifier: BSD-3-Clause
 %


### PR DESCRIPTION
The test scripts missed test component keyword change from e.g.
eqiir to eq-iir. Due to this the process_test() failed for IIR and
FIR for gain and frequency response due to wrong result expect.

The expected result is retrieved with the blob decode function. It
can be also used manually to check the filters defined in the
blob. The help texts in the decode functions needed fix. Also some
usage examples were added.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>