### PR TITLE
Audio: EQFIR: Optimize source and sink buffers use in generic C version

### DIFF
--- a/src/include/sof/audio/eq_fir/eq_fir.h
+++ b/src/include/sof/audio/eq_fir/eq_fir.h
@@ -23,6 +23,10 @@
 #include <user/fir.h>
 #include <stdint.h>
 
+/** \brief Macros to convert without division bytes count to samples count */
+#define EQ_FIR_BYTES_TO_S16_SAMPLES(b)	((b) >> 1)
+#define EQ_FIR_BYTES_TO_S32_SAMPLES(b)	((b) >> 2)
+
 #if CONFIG_FORMAT_S16LE
 void eq_fir_s16(struct fir_state_32x16 *fir, const struct audio_stream *source,
 		struct audio_stream *sink, int frames, int nch);


### PR DESCRIPTION
This patch replaces the audio stream read/write frag based
access to source and sink by block processing based on
audio_stream_bytes_without_wrap() bytes count.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>