### PR TITLE
Change CAVS passthrough and mixin/mixout topologies

### DIFF
--- a/tools/topology/topology2/cavs/CMakeLists.txt
+++ b/tools/topology/topology2/cavs/CMakeLists.txt
@@ -10,7 +10,7 @@ set(TPLGS
 "cavs-gain-hdmi\;cavs-gain-hdmi"
 # CAVS HDA topology with gain-based pipelines
 "cavs-gain-hdmi\;cavs-gain-hda\;HDA_CONFIG=gain"
-# CAVS HDA topology with mixer-based pipelines
+# CAVS HDA topology with mixer-based pipelines for HDA and passthrough pipelines for HDMI
 "cavs-passthrough-hdmi\;cavs-mixin-mixout-hda\;HDA_CONFIG=mix"
 # CAVS SDW topology with passthrough pipelines
 "cavs-sdw\;cavs-sdw"

--- a/tools/topology/topology2/cavs/cavs-mixin-mixout-hda.conf
+++ b/tools/topology/topology2/cavs/cavs-mixin-mixout-hda.conf
@@ -11,13 +11,18 @@ Object.Pipeline {
 	mixout-playback.0 {
 		index 2
 		Object.Widget.pipeline.1 {
-			stream_name 'copier.HDA.1.playback'
+			stream_name 'copier.HDA.2.1'
 		}
 
 		Object.Widget.copier.1 {
 			stream_name 'Analog Playback and Capture'
 			dai_type "HDA"
 			copier_type "HDA"
+		}
+		Object.Widget.gain.1 {
+			Object.Control.mixer.1 {
+				name '2 Main Playback Volume'
+			}
 		}
 
 		format s32le
@@ -26,10 +31,16 @@ Object.Pipeline {
 	mixin-playback.0 {
 		index 1
 		Object.Widget.pipeline.1 {
-			stream_name 'copier.HDA.1.playback'
+			stream_name 'copier.HDA.2.1'
 		}
 		Object.Widget.copier.1 {
 			stream_name 'Analog Playback'
+		}
+
+		Object.Widget.gain.1 {
+			Object.Control.mixer.1 {
+				name '1 2nd Playback Volume'
+			}
 		}
 
 		format s32le
@@ -38,10 +49,16 @@ Object.Pipeline {
 	mixout-capture.0 {
 		index 3
 		Object.Widget.pipeline.1 {
-			stream_name 'copier.HDA.0.capture'
+			stream_name 'copier.HDA.4.1'
 		}
 		Object.Widget.copier.1 {
 			stream_name 'Analog Capture'
+		}
+
+		Object.Widget.gain.1 {
+			Object.Control.mixer.1 {
+				name '3 2nd Capture Volume'
+			}
 		}
 
 		format s32le
@@ -50,13 +67,37 @@ Object.Pipeline {
 	mixin-capture.0 {
 		index 4
 		Object.Widget.pipeline.1 {
-			stream_name 'copier.HDA.1.capture'
+			stream_name 'copier.HDA.4.1'
 		}
 
 		Object.Widget.copier.1 {
 			stream_name 'Analog Playback and Capture'
 			dai_type "HDA"
 			copier_type "HDA"
+		}
+
+		Object.Widget.gain.1 {
+			Object.Control.mixer.1 {
+				name '4 Main Capture Volume'
+			}
+		}
+
+		format s32le
+	}
+
+	mixin-playback.1 {
+		index 12
+		Object.Widget.pipeline.1 {
+			stream_name 'copier.HDA.2.1'
+		}
+		Object.Widget.copier.1 {
+			stream_name 'Analog Deep Buffer Playback'
+		}
+
+		Object.Widget.gain.1 {
+			Object.Control.mixer.1 {
+				name '12 2nd Playback Volume'
+			}
 		}
 
 		format s32le
@@ -77,23 +118,39 @@ Object.PCM {
 		}
 		direction duplex
 	}
+
+	pcm.1 {
+		id 1
+		name 'HDA Analog Deep Buffer'
+		Object.Base.fe_dai.'HDA Analog Deep Buffer' {}
+		Object.PCM.pcm_caps.playback {
+			name 'Analog Deep Buffer Playback'
+			formats 'S32_LE,S24_LE,S16_LE'
+		}
+		direction playback
+	}
 }
 
 # top-level pipeline connections
-Object.Base.route.1 {
-	sink 'copier.HDA.2.1'
-	source 'mixout.2.1'
+Object.Base {
+	route.1 {
+		sink 'copier.HDA.2.1'
+		source 'gain.2.1'
+	}
+	route.2 {
+		source 'mixin.1.1'
+		sink 'mixout.2.1'
+	}
+	route.3 {
+		source 'copier.HDA.4.1'
+		sink 'gain.4.1'
+	}
+	route.4 {
+		source 'mixin.4.1'
+		sink 'mixout.3.1'
+	}
+	route.5 {
+		source 'mixin.12.1'
+		sink 'mixout.2.1'
+	}
 }
-Object.Base.route.2 {
-        source 'mixin.1.1'
-        sink 'mixout.2.1'
-}
-Object.Base.route.3 {
-	source 'copier.HDA.4.1'
-	sink 'mixin.4.1'
-}
-Object.Base.route.4 {
-        source 'mixin.4.1'
-        sink 'mixout.3.1'
-}
-

--- a/tools/topology/topology2/cavs/cavs-passthrough-hda.conf
+++ b/tools/topology/topology2/cavs/cavs-passthrough-hda.conf
@@ -1,23 +1,38 @@
 Object.Dai {
-	HDA.0 {
+	HDA.1 {
 		name 'Analog Playback and Capture'
 		id 4
 		default_hw_conf_id 4
-		Object.Base.hw_config.HDA0 {}
+		Object.Base.hw_config.HDA1 {}
 		direction duplex
+	}
+}
+Object.Pipeline {
+	passthrough-playback.1 {
+		index 1
+		Object.Widget.pipeline.1 {
+			stream_name 'copier.HDA.2.1'
+		}
 
-		Object.Widget.copier.0 {
-			direction playback
-			index 1
-			dai_index 1
-			type dai_in
+		Object.Widget.copier.1 {
+			stream_name 'Analog Playback'
+		}
+
+		format s32le
+	}
+
+	passthrough-be.1 {
+		direction	"playback"
+		index 2
+		Object.Widget.pipeline.1 {
+			stream_name 'copier.HDA.2.1'
+		}
+
+		Object.Widget.copier.1 {
+			stream_name 'Analog Playback and Capture'
 			dai_type "HDA"
 			copier_type "HDA"
-			stream_name 'Analog Playback and Capture'
-			period_sink_count 0
-			period_source_count 2
-			event_flags	127 # trapping PRE/POST_PMU/PMD events
-			event_type	2 # 1 for COPIER event for copier component
+			type dai_in
 			node_type $HDA_LINK_OUTPUT_CLASS
 			num_audio_formats 2
 			Object.Base.audio_format.1 {
@@ -31,19 +46,35 @@ Object.Dai {
 				dma_buffer_size "$[$obs * 2]"
 			}
 		}
+		format s16le
+	}
+
+	passthrough-capture.1 {
+		index 3
+		Object.Widget.pipeline.1 {
+			stream_name 'copier.HDA.4.1'
+		}
 
 		Object.Widget.copier.1 {
-			direction capture
-			index 3
-			dai_index 2
-			type dai_out
+			stream_name 'Analog Capture'
+		}
+
+		format s32le
+	}
+
+	passthrough-be.2 {
+		direction	"capture"
+		index 4
+		Object.Widget.pipeline.1 {
+			stream_name 'copier.HDA.4.1'
+		}
+
+		Object.Widget.copier.1 {
+			stream_name 'Analog Playback and Capture'
 			dai_type "HDA"
 			copier_type "HDA"
+			type dai_out
 			node_type $HDA_LINK_INPUT_CLASS
-			stream_name 'Analog Playback and Capture'
-			dai_index 1
-			period_sink_count 2
-			period_source_count 0
 			num_audio_formats 2
 			Object.Base.audio_format.1 {
 				dma_buffer_size "$[$ibs * 2]"
@@ -56,33 +87,7 @@ Object.Dai {
 				dma_buffer_size "$[$ibs * 2]"
 			}
 		}
-	}
-}
-Object.Pipeline {
-	passthrough-playback.0 {
-		index 1
-		Object.Widget.pipeline.1 {
-			stream_name 'copier.HDA.0.playback'
-		}
-
-		Object.Widget.copier.1 {
-			stream_name 'Analog Playback'
-		}
-
-		format s32le
-	}
-
-	passthrough-capture.0 {
-		index 3
-		Object.Widget.pipeline.1 {
-			stream_name 'copier.HDA.0.capture'
-		}
-
-		Object.Widget.copier.1 {
-			stream_name 'Analog Capture'
-		}
-
-		format s32le
+		format s16le
 	}
 }
 Object.PCM {
@@ -105,11 +110,11 @@ Object.PCM {
 # top-level pipeline connections
 Object.Base.route.1 {
 	source 'copier.host.1.1'
-	sink 'copier.HDA.1.0'
+	sink 'copier.HDA.2.1'
 }
 
 Object.Base.route.3 {
-	source 'copier.HDA.3.1'
+	source 'copier.HDA.4.1'
 	sink 'copier.host.3.1'
 }
 

--- a/tools/topology/topology2/cavs/cavs-passthrough-hdmi.conf
+++ b/tools/topology/topology2/cavs/cavs-passthrough-hdmi.conf
@@ -13,6 +13,7 @@
 <mixout-playback.conf>
 <mixin-capture.conf>
 <mixout-capture.conf>
+<passthrough-be.conf>
 <data.conf>
 <pcm.conf>
 <pcm_caps.conf>
@@ -29,8 +30,8 @@ Define {
 
 # include HDA config if needed.
 IncludeByKey.HDA_CONFIG {
-	"mix"	"cavs-mixin-mixout-hda.conf"
 	"passthrough"	"cavs-passthrough-hda.conf"
+	"mix"		"cavs-mixin-mixout-hda.conf"
 }
 
 Object.Dai {
@@ -39,29 +40,6 @@ Object.Dai {
 		id 1
 		default_hw_conf_id 1
 		Object.Base.hw_config.HDA4 {}
-		Object.Widget.copier.0 {
-			index 5
-			type dai_in
-			dai_type "HDA"
-                       copier_type "HDA"
-			stream_name iDisp1
-			period_sink_count 0
-			period_source_count 2
-			node_type $HDA_LINK_OUTPUT_CLASS
-			num_audio_formats 2
-			# 16-bit 48KHz 2ch
-			Object.Base.audio_format.1 {
-				dma_buffer_size "$[$obs * 2]"
-			}
-			# 32-bit 48KHz 2ch
-			Object.Base.audio_format.2 {
-				in_bit_depth		32
-				in_valid_bit_depth	32
-				out_bit_depth		32
-				out_valid_bit_depth	32
-				dma_buffer_size "$[$obs * 2]"
-			}
-		}
 		direction playback
 	}
 	HDA.5 {
@@ -69,29 +47,6 @@ Object.Dai {
 		id 2
 		default_hw_conf_id 2
 		Object.Base.hw_config.HDA5 {}
-		Object.Widget.copier.0 {
-			index 6
-			type dai_in
-			dai_type "HDA"
-			copier_type "HDA"
-			stream_name iDisp2
-			period_sink_count 0
-			period_source_count 2
-			node_type $HDA_LINK_OUTPUT_CLASS
-			num_audio_formats 2
-			# 16-bit 48KHz 2ch
-			Object.Base.audio_format.1 {
-				dma_buffer_size "$[$obs * 2]"
-			}
-			# 32-bit 48KHz 2ch
-			Object.Base.audio_format.2 {
-				in_bit_depth		32
-				in_valid_bit_depth	32
-				out_bit_depth		32
-				out_valid_bit_depth	32
-				dma_buffer_size "$[$obs * 2]"
-			}
-		}
 		direction playback
 	}
 	HDA.6 {
@@ -99,65 +54,84 @@ Object.Dai {
 		id 3
 		default_hw_conf_id 3
 		Object.Base.hw_config.HDA6 {}
-		Object.Widget.copier.0 {
-			index 7
-			type dai_in
-			dai_type "HDA"
-                       copier_type "HDA"
-			stream_name iDisp3
-			period_sink_count 0
-			period_source_count 2
-			node_type $HDA_LINK_OUTPUT_CLASS
-			num_audio_formats 2
-			# 16-bit 48KHz 2ch
-			Object.Base.audio_format.0 {
-				dma_buffer_size "$[$obs * 2]"
-			}
-			# 32-bit 48KHz 2ch
-			Object.Base.audio_format.1 {
-				in_bit_depth		32
-				in_valid_bit_depth	32
-				out_bit_depth		32
-				out_valid_bit_depth	32
-				dma_buffer_size "$[$obs * 2]"
-			}
-		}
 		direction playback
 	}
 }
 Object.Pipeline {
-	passthrough-playback.0 {
+	passthrough-playback.1 {
 		Object.Widget.pipeline.1 {
-			stream_name 'copier.HDA.4.playback'
+			stream_name 'copier.HDA.6.1'
 		}
 		Object.Widget.copier.1 {
-			stream_name 'Gain Playback 3'
+			stream_name 'Passthrough Playback 3'
 		}
 
 		format s16le
 		index 5
 	}
-	passthrough-playback.1 {
+	passthrough-be.1 {
+		direction	"playback"
+		index 6
 		Object.Widget.pipeline.1 {
-			stream_name 'copier.HDA.5.playback'
-		}
-		Object.Widget.copier.1 {
-			stream_name 'Gain Playback 4'
+			stream_name 'copier.HDA.6.1'
 		}
 
+		Object.Widget.copier.1 {
+			stream_name "iDisp1"
+			dai_type "HDA"
+			copier_type "HDA"
+		}
 		format s16le
-		index 6
 	}
 	passthrough-playback.2 {
 		Object.Widget.pipeline.1 {
-			stream_name 'copier.HDA.6.playback'
+			stream_name 'copier.HDA.8.1'
 		}
 		Object.Widget.copier.1 {
-			stream_name 'Gain Playback 5'
+			stream_name 'Passthrough Playback 4'
 		}
 
 		format s16le
 		index 7
+	}
+	passthrough-be.2 {
+		direction	"playback"
+		index 8
+		Object.Widget.pipeline.1 {
+			stream_name 'copier.HDA.8.1'
+		}
+
+		Object.Widget.copier.1 {
+			stream_name 'iDisp2'
+			dai_type "HDA"
+			copier_type "HDA"
+		}
+		format s16le
+	}
+	passthrough-playback.3 {
+		Object.Widget.pipeline.1 {
+			stream_name 'copier.HDA.10.1'
+		}
+		Object.Widget.copier.1 {
+			stream_name 'Passthrough Playback 5'
+		}
+
+		format s16le
+		index 9
+	}
+	passthrough-be.3 {
+		direction	"playback"
+		index 10
+		Object.Widget.pipeline.1 {
+			stream_name 'copier.HDA.10.1'
+		}
+
+		Object.Widget.copier.1 {
+			stream_name 'iDisp3'
+			dai_type "HDA"
+			copier_type "HDA"
+		}
+		format s16le
 	}
 }
 Object.PCM {
@@ -166,7 +140,7 @@ Object.PCM {
 		id 3
 		Object.Base.fe_dai.HDMI1 {}
 		Object.PCM.pcm_caps.playback {
-			name 'Gain Playback 3'
+			name 'Passthrough Playback 3'
 			formats 'S32_LE,S24_LE,S16_LE'
 		}
 		direction playback
@@ -176,7 +150,7 @@ Object.PCM {
 		id 4
 		Object.Base.fe_dai.HDMI2 {}
 		Object.PCM.pcm_caps.playback {
-			name 'Gain Playback 4'
+			name 'Passthrough Playback 4'
 			formats 'S32_LE,S24_LE,S16_LE'
 		}
 		direction playback
@@ -186,7 +160,7 @@ Object.PCM {
 		id 5
 		Object.Base.fe_dai.HDMI3 {}
 		Object.PCM.pcm_caps.playback {
-			name 'Gain Playback 5'
+			name 'Passthrough Playback 5'
 			formats 'S32_LE,S24_LE,S16_LE'
 		}
 		direction playback
@@ -194,17 +168,17 @@ Object.PCM {
 }
 
 # top-level pipeline connections
-Object.Base.route.5 {
+Object.Base.route.10 {
         source 'copier.host.5.1'
-        sink 'copier.HDA.5.0'
+        sink 'copier.HDA.6.1'
 }
-Object.Base.route.6 {
-        source 'copier.host.6.1'
-        sink 'copier.HDA.6.0'
-}
-Object.Base.route.7 {
+Object.Base.route.11 {
         source 'copier.host.7.1'
-        sink 'copier.HDA.7.0'
+        sink 'copier.HDA.8.1'
+}
+Object.Base.route.12 {
+        source 'copier.host.9.1'
+        sink 'copier.HDA.10.1'
 }
 
 Object.Widget.virtual {

--- a/tools/topology/topology2/include/components/gain.conf
+++ b/tools/topology/topology2/include/components/gain.conf
@@ -145,18 +145,6 @@ Class.Widget."gain" {
 		}
 	}
 
-	# gain audio formats
-	num_audio_formats 2
-	# 16-bit 48KHz 2ch
-	Object.Base.audio_format.0 {}
-	# 32-bit 48KHz 2ch
-	Object.Base.audio_format.1 {
-		in_bit_depth		32
-		in_valid_bit_depth	32
-		out_bit_depth		32
-		out_valid_bit_depth	32
-	}
-
 	# Default attribute values for gain widget
 	type 			"pga"
 	uuid 			"A8:A9:BC:61:D0:18:18:4A:8E:7B:26:39:21:98:04:B7"
@@ -166,4 +154,5 @@ Class.Widget."gain" {
 	curve_type		"linear"
 	curve_duration		10
 	init_value		0x7fffffff
+	num_audio_formats 1
 }

--- a/tools/topology/topology2/include/pipelines/cavs/gain-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/gain-capture.conf
@@ -68,7 +68,18 @@ Class.Pipeline."gain-capture" {
 			node_type $HDA_HOST_INPUT_CLASS
 		}
 
-		gain."1" {}
+		gain."1" {
+			num_audio_formats 2
+			#16-bit 48KHz 2ch
+			Object.Base.audio_format.1 {}
+			# 32-bit 48KHz 2ch
+			Object.Base.audio_format.2 {
+				in_bit_depth		32
+				in_valid_bit_depth	32
+				out_bit_depth		32
+				out_valid_bit_depth	32
+			}
+		}
 
 		pipeline."1" {
 			priority	0

--- a/tools/topology/topology2/include/pipelines/cavs/gain-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/gain-playback.conf
@@ -69,6 +69,16 @@ Class.Pipeline."gain-playback" {
 		}
 
 		gain."1" {
+			num_audio_formats 2
+			#16-bit 48KHz 2ch
+			Object.Base.audio_format.1 {}
+			# 32-bit 48KHz 2ch
+			Object.Base.audio_format.2 {
+				in_bit_depth		32
+				in_valid_bit_depth	32
+				out_bit_depth		32
+				out_valid_bit_depth	32
+			}
 		}
 
 		pipeline."1" {

--- a/tools/topology/topology2/include/pipelines/cavs/mixin-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixin-capture.conf
@@ -19,6 +19,7 @@
 
 <include/common/audio_format.conf>
 <include/components/copier.conf>
+<include/components/gain.conf>
 <include/components/mixin.conf>
 <include/components/pipeline.conf>
 
@@ -72,10 +73,26 @@ Class.Pipeline."mixin-capture" {
 		}
 
 		mixin."1" {}
+		gain."1" {
+			# 32-bit 48KHz 2ch
+			Object.Base.audio_format.1 {
+				in_bit_depth		32
+				in_valid_bit_depth	32
+				out_bit_depth		32
+				out_valid_bit_depth	32
+			}
+		}
 
 		pipeline."1" {
 			priority	0
 			lp_mode		0
+		}
+	}
+
+	Object.Base {
+		route.1 {
+			source gain..1
+			sink	mixin..1
 		}
 	}
 

--- a/tools/topology/topology2/include/pipelines/cavs/mixin-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixin-playback.conf
@@ -21,6 +21,7 @@
 <include/components/copier.conf>
 <include/components/mixin.conf>
 <include/components/pipeline.conf>
+<include/components/gain.conf>
 
 Class.Pipeline."mixin-playback" {
 
@@ -70,6 +71,16 @@ Class.Pipeline."mixin-playback" {
 			}
 		}
 
+		gain."1" {
+			# 32-bit 48KHz 2ch
+			Object.Base.audio_format.1 {
+				in_bit_depth		32
+				in_valid_bit_depth	32
+				out_bit_depth		32
+				out_valid_bit_depth	32
+			}
+		}
+
 		mixin."1" {}
 
 		pipeline."1" {
@@ -79,9 +90,13 @@ Class.Pipeline."mixin-playback" {
 	}
 
 	Object.Base {
-		route.0 {
+		route.1 {
 			source copier.host..1
-			sink	mixin..1
+			sink	gain..1
+		}
+		route.2 {
+			source	gain..1
+			sink mixin..1
 		}
 	}
 

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-capture.conf
@@ -21,6 +21,7 @@
 <include/components/copier.conf>
 <include/components/mixout.conf>
 <include/components/pipeline.conf>
+<include/components/gain.conf>
 
 Class.Pipeline."mixout-capture" {
 
@@ -72,6 +73,16 @@ Class.Pipeline."mixout-capture" {
 			}
 		}
 
+		gain."1"{
+			# 32-bit 48KHz 2ch
+			Object.Base.audio_format.1 {
+				in_bit_depth		32
+				in_valid_bit_depth	32
+				out_bit_depth		32
+				out_valid_bit_depth	32
+			}
+		}
+
 		pipeline."1" {
 			priority		0
 			lp_mode		0
@@ -79,8 +90,12 @@ Class.Pipeline."mixout-capture" {
 	}
 
 	Object.Base {
-		route.0 {
+		route.1 {
 			source	mixout..1
+			sink gain..1
+		}
+		route.2 {
+			source	gain..1
 			sink copier.host..1
 		}
 	}

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-playback.conf
@@ -19,6 +19,7 @@
 
 <include/common/audio_format.conf>
 <include/components/copier.conf>
+<include/components/gain.conf>
 <include/components/mixout.conf>
 <include/components/pipeline.conf>
 
@@ -71,10 +72,26 @@ Class.Pipeline."mixout-playback" {
 				dma_buffer_size "$[$obs * 2]"
 			}
 		}
+		gain."1" {
+			# 32-bit 48KHz 2ch
+			Object.Base.audio_format.1 {
+				in_bit_depth		32
+				in_valid_bit_depth	32
+				out_bit_depth		32
+				out_valid_bit_depth	32
+			}
+		}
 
 		pipeline."1" {
 			priority		0
 			lp_mode		0
+		}
+	}
+
+	Object.Base {
+		route.1 {
+			source mixout..1
+			sink	gain..1
 		}
 	}
 

--- a/tools/topology/topology2/include/pipelines/cavs/passthrough-be.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/passthrough-be.conf
@@ -1,0 +1,80 @@
+#
+# BE DAI passthrough pipeline
+#
+# All attributes defined herein are namespaced by alsatplg to
+# "Object.Pipeline.passthrough-be.N.attribute_name"
+#
+# Usage: mixin-playback pipeline object can be instantiated as:
+#
+# Object.Pipeline.dai-pipeline."N" {
+#	direction	"playback"
+# 	format		"s16le"
+# 	period		1000
+# 	time_domain	"timer"
+# 	channels	2
+# 	rate		48000
+# }
+#
+# Where N is the unique pipeline ID within the same alsaconf node.
+#
+
+<include/common/audio_format.conf>
+<include/components/copier.conf>
+<include/components/pipeline.conf>
+
+Class.Pipeline."passthrough-be" {
+
+	DefineAttribute."index" {}
+
+	<include/pipelines/pipeline-common.conf>
+
+	attributes {
+		!constructor [
+			"index"
+		]
+
+		!mandatory [
+			"format"
+		]
+
+		#
+		# mixin-playback objects instantiated within the same alsaconf node must have
+		# unique pipeline_id attribute
+		#
+		unique	"instance"
+	}
+
+	Object.Widget {
+		copier."1" {
+			type dai_in
+			node_type $HDA_LINK_OUTPUT_CLASS
+			num_audio_formats 2
+			# 16-bit 48KHz 2ch
+			Object.Base.audio_format.1 {
+				dma_buffer_size "$[$obs * 2]"
+			}
+			# 32-bit 48KHz 2ch
+			Object.Base.audio_format.2 {
+				in_bit_depth		32
+				in_valid_bit_depth	32
+				out_bit_depth		32
+				out_valid_bit_depth	32
+				dma_buffer_size "$[$obs * 2]"
+			}
+		}
+
+		pipeline."1" {
+			priority		0
+			lp_mode		0
+		}
+	}
+
+	time_domain	"timer"
+	dynamic_pipeline 1
+	channels	2
+	channels_min	2
+	channels_max	2
+	rate		48000
+	rate_min	48000
+	rate_max	48000
+}


### PR DESCRIPTION
The main change is to split up pipelines into FE and BE parts and add a deep buffer PCM to the mixin-mixout topology.
![tplg](https://user-images.githubusercontent.com/7766921/153498017-cedc6dfd-c848-4180-8e25-2b31c1d7c8b1.png)
 The mixin-mixout tplg looks like this:
