### PR TITLE
zephyr: add copier and base_fw components

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -685,6 +685,14 @@ zephyr_library_sources_ifdef(CONFIG_COMP_SRC
 	${SOF_AUDIO_PATH}/src/src.c
 )
 
+zephyr_library_sources_ifdef(CONFIG_COMP_BASEFW_IPC4
+	${SOF_AUDIO_PATH}/base_fw.c
+)
+
+zephyr_library_sources_ifdef(CONFIG_COMP_COPIER
+	${SOF_AUDIO_PATH}/copier.c
+)
+
 zephyr_library_sources_ifdef(CONFIG_SAMPLE_SMART_AMP
 	${SOF_SAMPLES_PATH}/audio/smart_amp_test.c
 )

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -535,6 +535,8 @@ void sys_comp_dcblock_init(void);
 void sys_comp_eq_iir_init(void);
 void sys_comp_kpb_init(void);
 void sys_comp_smart_amp_init(void);
+void sys_comp_basefw_init(void);
+void sys_comp_copier_init(void);
 
 /* Zephyr redefines log_message() and mtrace_printf() which leaves
  * totally empty the .static_log_entries ELF sections for the
@@ -628,6 +630,14 @@ int task_main_start(struct sof *sof)
 
 	if (IS_ENABLED(CONFIG_COMP_MUX)) {
 		sys_comp_mux_init();
+	}
+
+	if (IS_ENABLED(CONFIG_COMP_BASEFW_IPC4)) {
+		sys_comp_basefw_init();
+	}
+
+	if (IS_ENABLED(CONFIG_COMP_COPIER)) {
+		sys_comp_copier_init();
 	}
 
 	/* init pipeline position offsets */


### PR DESCRIPTION
The two components copier and base_fw are
essential to IPC4 support on SOF on Zephyr.

This patch integrates the build of the two
components to SOF build with zephyr RTOS.

Signed-off-by: Chao Song <chao.song@linux.intel.com>