### PR TITLE
probe: update dma copy method to dma_copy_to_host()

### DIFF
--- a/src/probe/probe.c
+++ b/src/probe/probe.c
@@ -869,10 +869,10 @@ static void probe_cb_produce(void *arg, enum notify_id type, void *data)
 
 		/* check if copy_bytes is still valid for dma copy */
 		if (copy_bytes > 0) {
-			ret = dma_copy_to_host_nowait(&dma->dc,
-						      &dma->config, 0,
-						      (void *)dma->dmapb.r_ptr,
-						      copy_bytes);
+			ret = dma_copy_to_host(&dma->dc,
+					       &dma->config, 0,
+					       (void *)dma->dmapb.r_ptr,
+					       copy_bytes);
 			if (ret < 0)
 				goto err;
 


### PR DESCRIPTION
Fixes commit 443b21de4b3f ("dma-trace: Fix potential race issue by using
blocking DMA copy")

Chrome build can pass now