### PR TITLE
asrc: Fixed sink rate selection

### DIFF
--- a/src/audio/asrc/asrc.c
+++ b/src/audio/asrc/asrc.c
@@ -530,7 +530,9 @@ static int asrc_params(struct comp_dev *dev,
 	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer,
 				source_list);
 
-	sinkb->stream.rate = asrc_get_sink_rate(&cd->ipc_config);
+	/* Don't change sink rate if value from IPC is 0 (auto detect) */
+	if (asrc_get_sink_rate(&cd->ipc_config))
+		sinkb->stream.rate = asrc_get_sink_rate(&cd->ipc_config);
 
 	/* set source/sink_frames/rate */
 	cd->source_rate = sourceb->stream.rate;


### PR DESCRIPTION
Don't change sink rate if value from IPC is 0 (auto detect)

This is fix for issue [5294](https://github.com/thesofproject/sof/issues/5294).

Signed-off-by: Adrian Warecki <adrianx.warecki@intel.com>