### PR TITLE
amd: renoir: clk: Fix ACP clock to default clock

### DIFF
--- a/src/platform/amd/renoir/lib/clk.c
+++ b/src/platform/amd/renoir/lib/clk.c
@@ -14,7 +14,7 @@
 #include <platform/chip_registers.h>
 
 static struct freq_table platform_cpu_freq[] = {
-	{600000000, 600000 },
+	{200000000, 200000 },
 };
 
 STATIC_ASSERT(NUM_CPU_FREQ == ARRAY_SIZE(platform_cpu_freq),
@@ -136,5 +136,4 @@ void platform_clock_init(struct sof *sof)
 		};
 		k_spinlock_init(&sof->clocks[i].lock);
 	}
-	acp_change_clock_notify(600000000);
 }


### PR DESCRIPTION
Fix ACP clocks to default clock during boot up time.

Signed-off-by: balapati <balakishore.pati@amd.com>