### PR TITLE
topology2: cavs: all pipelines should be dynamic by default

### DIFF
--- a/tools/topology/topology2/include/pipelines/cavs/gain-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/gain-capture.conf
@@ -84,6 +84,7 @@ Class.Pipeline."gain-capture" {
 	}
 
 	direction	"capture"
+	dynamic_pipeline 1
 	time_domain	"timer"
 	channels	2
 	channels_min	2

--- a/tools/topology/topology2/include/pipelines/cavs/gain-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/gain-playback.conf
@@ -85,6 +85,7 @@ Class.Pipeline."gain-playback" {
 	}
 
 	direction	"playback"
+	dynamic_pipeline 1
 	time_domain	"timer"
 	channels	2
 	channels_min	2

--- a/tools/topology/topology2/include/pipelines/cavs/mixin-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixin-capture.conf
@@ -80,6 +80,7 @@ Class.Pipeline."mixin-capture" {
 	}
 
 	direction	"capture"
+	dynamic_pipeline 1
 	time_domain	"timer"
 	channels	2
 	channels_min	2

--- a/tools/topology/topology2/include/pipelines/cavs/mixin-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixin-playback.conf
@@ -86,6 +86,7 @@ Class.Pipeline."mixin-playback" {
 	}
 
 	direction	"playback"
+	dynamic_pipeline 1
 	time_domain	"timer"
 	channels	2
 	channels_min	2

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-capture.conf
@@ -86,6 +86,7 @@ Class.Pipeline."mixout-capture" {
 	}
 
 	direction	"capture"
+	dynamic_pipeline 1
 	time_domain	"timer"
 	channels	2
 	channels_min	2

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-gain-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-gain-playback.conf
@@ -61,6 +61,7 @@ Class.Pipeline."mixout-gain-playback" {
 	}
 
 	direction	"playback"
+	dynamic_pipeline 1
 	time_domain	"timer"
 	channels	2
 	channels_min	2

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-playback.conf
@@ -79,6 +79,7 @@ Class.Pipeline."mixout-playback" {
 	}
 
 	direction	"playback"
+	dynamic_pipeline 1
 	time_domain	"timer"
 	channels	2
 	channels_min	2

--- a/tools/topology/topology2/include/pipelines/cavs/passthrough-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/passthrough-capture.conf
@@ -74,6 +74,7 @@ Class.Pipeline."passthrough-capture" {
 	}
 
 	direction	"capture"
+	dynamic_pipeline 1
 	time_domain	"timer"
 	channels	2
 	channels_min	2

--- a/tools/topology/topology2/include/pipelines/cavs/passthrough-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/passthrough-playback.conf
@@ -74,6 +74,7 @@ Class.Pipeline."passthrough-playback" {
 	}
 
 	direction	"playback"
+	dynamic_pipeline 1
 	time_domain	"timer"
 	channels	2
 	channels_min	2


### PR DESCRIPTION
Set all pipelines to be dynamic by default.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>