### PR TITLE
topology: Fix topologies to accomodate Alsa lib changes.

### DIFF
--- a/tools/topology/development/sof-tgl-nocodec-ci.m4
+++ b/tools/topology/development/sof-tgl-nocodec-ci.m4
@@ -56,7 +56,7 @@ define(matrix2, `ROUTE_MATRIX(7,
 			     `BITS_TO_BYTE(0, 0, 0 ,0 ,0 ,0 ,0 ,1)')')
 
 dnl name, num_streams, route_matrix list
-MUXDEMUX_CONFIG(demux_priv_1, 2, LIST(`	', `matrix1,', `matrix2'))
+MUXDEMUX_CONFIG(demux_priv_1, 2, LIST_NONEWLINE(`', `matrix1,', `matrix2'))
 
 #
 # Define the pipelines

--- a/tools/topology/m4/bytecontrol.m4
+++ b/tools/topology/m4/bytecontrol.m4
@@ -1,5 +1,8 @@
 divert(-1)
 
+# don't care value
+define(`XX', 0x00)
+
 dnl Define macro for byte control
 
 dnl CONTROLBYTES_MAX(comment, value)
@@ -60,9 +63,10 @@ define(`C_CONTROLBYTES',
 `	# control uses bespoke driver get/put/info ID for ext ops'
 `	$4'
 `'
-`	base STR($5)'
-`	num_regs STR($6)'
-`	mask STR($7)'
+`	# default base/num_regs/mask to avoid NULL STR'
+`	ifelse($5, `', base STR(XX), base STR($5))'
+`	ifelse($6, `', num_regs STR(XX), num_regs STR($6)`')'
+`	ifelse($7, `', mask STR(XX), mask STR($7)`')'
 `	$8'
 `	$9'
 `	access ['
@@ -88,9 +92,9 @@ define(`C_CONTROLBYTES_VOLATILE_READONLY',
 `	# control uses bespoke driver get/put/info ID for ext ops'
 `	$4'
 `'
-`	base STR($5)'
-`	num_regs STR($6)'
-`	mask STR($7)'
+`	ifelse($5, `', base STR(XX), base STR($5))'
+`	ifelse($6, `', num_regs STR(XX), num_regs STR($6)`')'
+`	ifelse($7, `', mask STR(XX), mask STR($7)`')'
 `	$8'
 `	$9'
 `	access ['
@@ -116,9 +120,9 @@ define(`C_CONTROLBYTES_WRITEONLY',
 `	# control uses bespoke driver get/put/info ID for ext ops'
 `	$4'
 `'
-`	base STR($5)'
-`	num_regs STR($6)'
-`	mask STR($7)'
+`	ifelse($5, `', base STR(XX), base STR($5))'
+`	ifelse($6, `', num_regs STR(XX), num_regs STR($6)`')'
+`	ifelse($7, `', mask STR(XX), mask STR($7)`')'
 `	$8'
 `	$9'
 `	access ['
@@ -143,9 +147,9 @@ define(`C_CONTROLBYTES_VOLATILE_RW',
 `	# control uses bespoke driver get/put/info ID for ext ops'
 `	$4'
 `'
-`	base STR($5)'
-`	num_regs STR($6)'
-`	mask STR($7)'
+`	ifelse($5, `', base STR(XX), base STR($5))'
+`	ifelse($6, `', num_regs STR(XX), num_regs STR($6)`')'
+`	ifelse($7, `', mask STR(XX), mask STR($7)`')'
 `	$8'
 `	$9'
 `	access ['

--- a/tools/topology/m4/utils.m4
+++ b/tools/topology/m4/utils.m4
@@ -19,7 +19,11 @@ dnl The first argument specifies the number of tabs to be added for formatting
 define(`LIST_LOOP', `argn(j,$@)
 $1ifelse(i,`2', `', `define(`i', decr(i))define(`j', incr(j))$0($@)')')
 
+define(`LIST_LOOP_NONEWLINE', `argn(j,$@)$1ifelse(i,`2', `', `define(`i', decr(i))define(`j', incr(j))$0($@)')')
+
 define(`LIST', `pushdef(`i', $#)pushdef(`j', `2')LIST_LOOP($@)popdef(i)popdef(j)')
+
+define(`LIST_NONEWLINE', `pushdef(`i', $#)pushdef(`j', `2')LIST_LOOP_NONEWLINE($@)popdef(i)popdef(j)')
 
 dnl Sums a list of variable arguments. Use as last argument in macro.
 define(`SUM_LOOP', `eval(argn(j,$@)

--- a/tools/topology/sof-apl-demux-pcm512x.m4
+++ b/tools/topology/sof-apl-demux-pcm512x.m4
@@ -49,7 +49,7 @@ define(matrix2, `ROUTE_MATRIX(5,
 			     `BITS_TO_BYTE(0, 0, 0 ,0 ,0 ,0 ,0 ,1)')')
 
 dnl name, num_streams, route_matrix list
-MUXDEMUX_CONFIG(demux_priv_1, 2, LIST(`	', `matrix1,', `matrix2'))
+MUXDEMUX_CONFIG(demux_priv_1, 2, LIST_NONEWLINE(`', `matrix1,', `matrix2'))
 
 #
 # Define the pipelines

--- a/tools/topology/sof-cml-demux-rt5682.m4
+++ b/tools/topology/sof-cml-demux-rt5682.m4
@@ -49,7 +49,7 @@ define(matrix2, `ROUTE_MATRIX(5,
 			     `BITS_TO_BYTE(0, 0, 0 ,0 ,0 ,0 ,0 ,1)')')
 
 dnl name, num_streams, route_matrix list
-MUXDEMUX_CONFIG(demux_priv_1, 2, LIST(`	', `matrix1,', `matrix2'))
+MUXDEMUX_CONFIG(demux_priv_1, 2, LIST_NONEWLINE(`', `matrix1,', `matrix2'))
 
 #
 # Define the pipelines

--- a/tools/topology/sof-icl-rt711-rt1308-rt715-hdmi.m4
+++ b/tools/topology/sof-icl-rt711-rt1308-rt715-hdmi.m4
@@ -63,7 +63,7 @@ define(matrix2, `ROUTE_MATRIX(4,
 			     `BITS_TO_BYTE(0, 0, 0 ,0 ,0 ,0 ,0 ,1)')')
 
 dnl name, num_streams, route_matrix list
-MUXDEMUX_CONFIG(demux_priv_3, 2, LIST(`	', `matrix1,', `matrix2'))
+MUXDEMUX_CONFIG(demux_priv_3, 2, LIST_NONEWLINE(`', `matrix1,', `matrix2'))
 ')
 
 #

--- a/tools/topology/sof-tgl-max98357a-rt5682.m4
+++ b/tools/topology/sof-tgl-max98357a-rt5682.m4
@@ -52,7 +52,7 @@ define(matrix2, `ROUTE_MATRIX(9,
 			     `BITS_TO_BYTE(0, 0, 0 ,0 ,0 ,0 ,0 ,1)')')
 
 dnl name, num_streams, route_matrix list
-MUXDEMUX_CONFIG(demux_priv_1, 2, LIST(`	', `matrix1,', `matrix2'))
+MUXDEMUX_CONFIG(demux_priv_1, 2, LIST_NONEWLINE(`', `matrix1,', `matrix2'))
 
 #
 # Define the pipelines


### PR DESCRIPTION
A change introduces in https://github.com/alsa-project/alsa-lib/issues/187 breaks topology on tgl-013-drop-stable.

This PR backports the relavant changes from main.