### PR TITLE
SRC: compilation fix for src_hifi4.c. This fixes dcb9aeb308a9

### DIFF
--- a/src/audio/src/src_hifi4.c
+++ b/src/audio/src/src_hifi4.c
@@ -10,6 +10,7 @@
 
 #if SRC_HIFI4
 
+#include <sof/math/numbers.h>
 #include <sof/audio/src/src.h>
 #include <xtensa/config/defs.h>
 #include <xtensa/tie/xt_hifi4.h>


### PR DESCRIPTION
SRC_HIFI4 compilation is not in a scope of sof upstream compilation check. Compilation fix is needed. 