### PR TITLE
Preparation for modifying the module process API - Part 1

### DIFF
--- a/src/audio/codec_adapter/codec/dts.c
+++ b/src/audio/codec_adapter/codec/dts.c
@@ -60,19 +60,20 @@ static int dts_effect_convert_sof_interface_result(struct comp_dev *dev,
 static int dts_effect_populate_buffer_configuration(struct comp_dev *dev,
 	DtsSofInterfaceBufferConfiguration *buffer_config)
 {
+	struct comp_buffer *source = list_first_item(&dev->bsource_list, struct comp_buffer,
+						     sink_list);
 	struct processing_module *mod = comp_get_drvdata(dev);
 	const struct audio_stream *stream;
 	DtsSofInterfaceBufferLayout buffer_layout;
 	DtsSofInterfaceBufferFormat buffer_format;
-
 	comp_dbg(dev, "dts_effect_populate_buffer_configuration() start");
 
-	if (!mod->ca_source)
+	if (!source)
 		return -EINVAL;
 
-	stream = &mod->ca_source->stream;
+	stream = &source->stream;
 
-	switch (mod->ca_source->buffer_fmt) {
+	switch (source->buffer_fmt) {
 	case SOF_IPC_BUFFER_INTERLEAVED:
 		buffer_layout = DTS_SOF_INTERFACE_BUFFER_LAYOUT_INTERLEAVED;
 		break;

--- a/src/audio/codec_adapter/codec/waves.c
+++ b/src/audio/codec_adapter/codec/waves.c
@@ -220,10 +220,20 @@ static int waves_effect_allocate(struct processing_module *mod)
 static int waves_effect_check(struct comp_dev *dev)
 {
 	struct processing_module *component = comp_get_drvdata(dev);
-	const struct audio_stream *src_fmt = &component->ca_source->stream;
-	const struct audio_stream *snk_fmt = &component->ca_sink->stream;
+	struct comp_buffer *sink = list_first_item(&dev->bsink_list, struct comp_buffer,
+						    source_list);
+	struct comp_buffer *source = list_first_item(&dev->bsource_list, struct comp_buffer,
+						     sink_list);
+	const struct audio_stream *src_fmt = &source->stream;
+	const struct audio_stream *snk_fmt = &sink->stream;
 
+	/* Init sink & source buffers */
 	comp_dbg(dev, "waves_effect_check() start");
+
+	if (!source || !sink) {
+		comp_err(dev, "waves_effect_check() source/sink buffer not found");
+		return -EINVAL;
+	}
 
 	/* todo use fallback to comp_verify_params when ready */
 
@@ -249,7 +259,7 @@ static int waves_effect_check(struct comp_dev *dev)
 	}
 
 	/* different interleaving is not supported */
-	if (component->ca_source->buffer_fmt != component->ca_sink->buffer_fmt) {
+	if (source->buffer_fmt != sink->buffer_fmt) {
 		comp_err(dev, "waves_effect_check() source %d sink %d buffer format mismatch");
 		return -EINVAL;
 	}
@@ -259,7 +269,7 @@ static int waves_effect_check(struct comp_dev *dev)
 		return -EINVAL;
 	}
 
-	if (!layout_is_supported(component->ca_source->buffer_fmt)) {
+	if (!layout_is_supported(source->buffer_fmt)) {
 		comp_err(dev, "waves_effect_check() non interleaved format not supported");
 		return -EINVAL;
 	}
@@ -281,11 +291,13 @@ static int waves_effect_check(struct comp_dev *dev)
 /* initializes MaxxEffect based on stream parameters */
 static int waves_effect_init(struct comp_dev *dev)
 {
+	struct comp_buffer *source = list_first_item(&dev->bsource_list, struct comp_buffer,
+						     sink_list);
 	struct module_data *codec = comp_get_module_data(dev);
 	struct waves_codec_data *waves_codec = codec->private;
 	struct processing_module *component = comp_get_drvdata(dev);
 
-	const struct audio_stream *src_fmt = &component->ca_source->stream;
+	const struct audio_stream *src_fmt = &source->stream;
 
 	MaxxStatus_t status;
 	MaxxBuffer_Format_t sample_format;
@@ -303,10 +315,10 @@ static int waves_effect_init(struct comp_dev *dev)
 		return -EINVAL;
 	}
 
-	buffer_format = layout_convert_sof_to_me(component->ca_source->buffer_fmt);
+	buffer_format = layout_convert_sof_to_me(source->buffer_fmt);
 	if (buffer_format < 0) {
 		comp_err(dev, "waves_effect_init() sof buffer format %d not supported",
-			 component->ca_source->buffer_fmt);
+			 source->buffer_fmt);
 		return -EINVAL;
 	}
 

--- a/src/audio/codec_adapter/codec_adapter.c
+++ b/src/audio/codec_adapter/codec_adapter.c
@@ -252,27 +252,30 @@ ca_copy_from_source_to_module(const struct audio_stream *source, void *buff, uin
 					   tail_size);
 }
 
+/**
+ * Function to copy processed samples from the module buffer to sink buffer
+ * @sink: sink audio buffer stream
+ * @buff: pointer to the module output buffer
+ * @bytes: number of bytes available in the module output buffer
+ */
 static void
-ca_copy_from_module_to_sink(const struct module_processing_data *mpd,
-			    const struct audio_stream *sink, size_t bytes)
+ca_copy_from_module_to_sink(const struct audio_stream *sink, void *buff, size_t bytes)
 {
-	/* head_size - free space until end of local buffer */
-	const int without_wrap =
-		audio_stream_bytes_without_wrap(sink, sink->w_ptr);
+	/* head_size - free space until end of sink buffer */
+	const int without_wrap = audio_stream_bytes_without_wrap(sink, sink->w_ptr);
 	uint32_t head_size = MIN(bytes, without_wrap);
 	/* tail_size - rest of the bytes that needs to be written
 	 * starting from the beginning of the buffer
 	 */
 	uint32_t tail_size = bytes - head_size;
 
-	/* copy head_size to sink buffer */
-	memcpy_s(sink->w_ptr, sink->size, mpd->out_buff, head_size);
+	/* copy "head_size" samples to sink buffer */
+	memcpy_s(sink->w_ptr, sink->size, buff, head_size);
+
+	/* copy rest of the samples after buffer wrap */
 	if (tail_size)
-	/* copy reset of the samples after wrap-up */
-		memcpy_s(audio_stream_wrap(sink,
-					   (char *)sink->w_ptr + head_size),
-			 sink->size,
-			 (char *)mpd->out_buff + head_size, tail_size);
+		memcpy_s(audio_stream_wrap(sink, (char *)sink->w_ptr + head_size),
+			 sink->size, (char *)buff + head_size, tail_size);
 }
 
 /**
@@ -368,7 +371,7 @@ int codec_adapter_copy(struct comp_dev *dev)
 			 ret);
 		goto db_verify;
 	}
-	ca_copy_from_module_to_sink(&md->mpd, &local_buff->stream, md->mpd.produced);
+	ca_copy_from_module_to_sink(&local_buff->stream, md->mpd.out_buff, md->mpd.produced);
 
 	bytes_to_process -= md->mpd.consumed;
 	processed += md->mpd.consumed;

--- a/src/audio/codec_adapter/codec_adapter.c
+++ b/src/audio/codec_adapter/codec_adapter.c
@@ -225,9 +225,8 @@ int codec_adapter_params(struct comp_dev *dev,
 }
 
 static void
-codec_adapter_copy_from_source_to_lib(const struct audio_stream *source,
-				      const struct module_processing_data *mpd,
-				      size_t bytes)
+ca_copy_from_source_to_module(const struct audio_stream *source,
+			      const struct module_processing_data *mpd, size_t bytes)
 {
 	/* head_size - available data until end of local buffer */
 	const int without_wrap = audio_stream_bytes_without_wrap(source, source->r_ptr);
@@ -329,8 +328,7 @@ int codec_adapter_copy(struct comp_dev *dev)
 
 	if (!md->mpd.init_done) {
 		buffer_stream_invalidate(source, codec_buff_size);
-		codec_adapter_copy_from_source_to_lib(&source->stream, &md->mpd,
-						      codec_buff_size);
+		ca_copy_from_source_to_module(&source->stream, &md->mpd, codec_buff_size);
 		md->mpd.avail = codec_buff_size;
 		ret = module_process(dev);
 		if (ret)
@@ -344,8 +342,7 @@ int codec_adapter_copy(struct comp_dev *dev)
 	}
 
 	buffer_stream_invalidate(source, codec_buff_size);
-	codec_adapter_copy_from_source_to_lib(&source->stream, &md->mpd,
-					      codec_buff_size);
+	ca_copy_from_source_to_module(&source->stream, &md->mpd, codec_buff_size);
 	md->mpd.avail = codec_buff_size;
 	ret = module_process(dev);
 	if (ret) {

--- a/src/audio/codec_adapter/codec_adapter.c
+++ b/src/audio/codec_adapter/codec_adapter.c
@@ -253,9 +253,8 @@ ca_copy_from_source_to_module(const struct audio_stream *source, void *buff, uin
 }
 
 static void
-codec_adapter_copy_from_lib_to_sink(const struct module_processing_data *mpd,
-				    const struct audio_stream *sink,
-				    size_t bytes)
+ca_copy_from_module_to_sink(const struct module_processing_data *mpd,
+			    const struct audio_stream *sink, size_t bytes)
 {
 	/* head_size - free space until end of local buffer */
 	const int without_wrap =
@@ -369,8 +368,7 @@ int codec_adapter_copy(struct comp_dev *dev)
 			 ret);
 		goto db_verify;
 	}
-	codec_adapter_copy_from_lib_to_sink(&md->mpd, &local_buff->stream,
-					    md->mpd.produced);
+	ca_copy_from_module_to_sink(&md->mpd, &local_buff->stream, md->mpd.produced);
 
 	bytes_to_process -= md->mpd.consumed;
 	processed += md->mpd.consumed;

--- a/src/include/sof/audio/codec_adapter/codec/generic.h
+++ b/src/include/sof/audio/codec_adapter/codec/generic.h
@@ -249,8 +249,6 @@ struct module_data {
 /* codec_adapter private, runtime data */
 struct processing_module {
 	struct module_data priv; /**< module private data */
-	struct comp_buffer *ca_sink;
-	struct comp_buffer *ca_source;
 	struct comp_buffer *local_buff;
 	struct sof_ipc_stream_params stream_params;
 	/*


### PR DESCRIPTION
In preparation for modifying the process API to pass pointers to the input/output buffers and their counts, make some prelimiary changes to avoid using the ca_source/ca_sink pointers in teh codec implementations. Also, modify the copy functions to be reusable for multiple buffers by passing the buffer pointers and the bytes available.