### PR TITLE
Fix xtensa-build-zephyr.py on windows

### DIFF
--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -380,10 +380,11 @@ def build_platforms():
 		shutil.copy2(str(fw_file_to_copy), str(fw_file_installed))
 
 	# Install sof-logger
-	sof_logger_executable_to_copy = pathlib.Path(west_top, platform_build_dir_name, "zephyr",
-		"sof-logger_ep", "build", "logger", "sof-logger")
+	sof_logger_dir = pathlib.Path(west_top, platform_build_dir_name, "zephyr",
+		"sof-logger_ep", "build", "logger")
+	sof_logger_executable_to_copy = pathlib.Path(shutil.which("sof-logger", path=sof_logger_dir))
 	tools_output_dir = pathlib.Path(STAGING_DIR, "tools")
-	sof_logger_installed_file = pathlib.Path(tools_output_dir, "sof-logger").resolve()
+	sof_logger_installed_file = pathlib.Path(tools_output_dir, sof_logger_executable_to_copy.name).resolve()
 	os.makedirs(os.path.dirname(sof_logger_installed_file), exist_ok=True)
 	# looses file owner and group - file is commonly accessible
 	shutil.copy2(str(sof_logger_executable_to_copy), str(sof_logger_installed_file))


### PR DESCRIPTION
Single commit, fixes [Rewritten xtensa-build-zephyr.sh to python](https://github.com/thesofproject/sof/pull/5299/commits/5897bbeec94de06521a6df2bf4a3a65de872116e) commit from [PR5299](https://github.com/thesofproject/sof/pull/5299).

Existing xtensa-build-zephyr.py failed to copy sof logger
executable to staging directory on Windows OS due to missing '.exe' file extension.
This fixes the script.

Quick-tested sof-logger.exe on Windows with help of @marc-hb .
Most features are not working correctly since the tool tries to resolve /sys/kernel/debug/sof directory
which obviously do not exist on Windows. Command `sof-logger.exe -d some.ldc` works dumping ldc file information to stdout.

Signed-off-by: Andrey Borisovich <andrey.borisovich@intel.com>