### PR TITLE
dma-trace.c: fix unsupported mtrace_printf("%s", ...) string specifier

### DIFF
--- a/src/trace/dma-trace.c
+++ b/src/trace/dma-trace.c
@@ -228,7 +228,7 @@ static int dma_trace_buffer_init(struct dma_trace_data *d)
 
 	if (!d || !d->dc.dmac) {
 		mtrace_printf(LOG_LEVEL_ERROR,
-			      "%s failed: no DMAC!", __func__);
+			      "dma_trace_buffer_init() failed, no DMAC! d=%p", d);
 		return -ENODEV;
 	}
 


### PR DESCRIPTION
The dictionary does not support character strings.

Fixes commit c11562b00a29 ("dma-trace: Align DMA buffer correctly to fix
dma tracing issues")

Take the opportunity to log more pointers (which _are_ supported).

Fixes the following error message:
```
 TIMESTAMP         (us)              DELTA  C# COMPONENT          LOCATION                      CONTENT
error: String printing is not supported
[           2.604167] (           0.000000) c0 dma-trace             src/trace/dma-trace.c:266  ERROR <String @ 0xbe035e60> failed: no DMAC
```
Signed-off-by: Marc Herbert <marc.herbert@intel.com>