### PR TITLE
Prepare codec adapter to work with zephyr (1)

### DIFF
--- a/src/audio/codec_adapter/codec/generic.c
+++ b/src/audio/codec_adapter/codec/generic.c
@@ -176,7 +176,7 @@ int module_free_memory(struct processing_module *mod, void *ptr)
 	}
 
 	comp_err(mod->dev, "module_free_memory: error: could not find memory pointed by %p",
-		 (uint32_t)ptr);
+		 ptr);
 
 	return -EINVAL;
 }
@@ -398,7 +398,7 @@ int module_set_configuration(struct processing_module *mod,
 
 	ret = memcpy_s(dst, size - offset, fragment, fragment_size);
 	if (ret < 0) {
-		comp_err(dev, "module_set_configuration(): error: failed to copy fragment",
+		comp_err(dev, "module_set_configuration(): error: %d failed to copy fragment",
 			 ret);
 		return ret;
 	}

--- a/src/include/sof/audio/codec_adapter/codec/generic.h
+++ b/src/include/sof/audio/codec_adapter/codec/generic.h
@@ -54,13 +54,13 @@ static SHARED_DATA struct comp_driver_info comp_codec_adapter_info = { \
 	.drv = &comp_codec_adapter, \
 }; \
 \
-UT_STATIC void sys_comp_codec_##adapter_init(void) \
+UT_STATIC void sys_comp_codec_##adapter##_init(void) \
 { \
 	comp_register(platform_shared_get(&comp_codec_adapter_info, \
 					  sizeof(comp_codec_adapter_info))); \
 } \
 \
-DECLARE_MODULE(sys_comp_codec_##adapter_init)
+DECLARE_MODULE(sys_comp_codec_##adapter##_init)
 
 struct processing_module;
 

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -609,6 +609,20 @@ zephyr_library_sources_ifdef(CONFIG_COMP_VOLUME
 	${SOF_AUDIO_PATH}/volume/volume.c
 )
 
+zephyr_library_sources_ifdef(CONFIG_COMP_CODEC_ADAPTER
+	${SOF_AUDIO_PATH}/codec_adapter/codec_adapter.c
+	${SOF_AUDIO_PATH}/codec_adapter/codec/generic.c
+)
+
+if (CONFIG_COMP_CODEC_ADAPTER)
+zephyr_library_sources_ifdef(CONFIG_CADENCE_CODEC
+	${SOF_AUDIO_PATH}/codec_adapter/codec/cadence.c
+)
+zephyr_library_sources_ifdef(CONFIG_PASSTHROUGH_CODEC
+	${SOF_AUDIO_PATH}/codec_adapter/codec/passthrough.c
+)
+endif()
+
 zephyr_library_sources_ifdef(CONFIG_COMP_SRC
 	${SOF_AUDIO_PATH}/src/src_hifi2ep.c
 	${SOF_AUDIO_PATH}/src/src_generic.c

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -537,6 +537,8 @@ void sys_comp_kpb_init(void);
 void sys_comp_smart_amp_init(void);
 void sys_comp_basefw_init(void);
 void sys_comp_copier_init(void);
+void sys_comp_codec_cadence_interface_init(void);
+void sys_comp_codec_passthrough_interface_init(void);
 
 /* Zephyr redefines log_message() and mtrace_printf() which leaves
  * totally empty the .static_log_entries ELF sections for the
@@ -638,6 +640,14 @@ int task_main_start(struct sof *sof)
 
 	if (IS_ENABLED(CONFIG_COMP_COPIER)) {
 		sys_comp_copier_init();
+	}
+
+	if (IS_ENABLED(CONFIG_CADENCE_CODEC)) {
+		sys_comp_codec_cadence_interface_init();
+	}
+
+	if (IS_ENABLED(CONFIG_PASSTHROUGH_CODEC)) {
+		sys_comp_codec_passthrough_interface_init();
 	}
 
 	/* init pipeline position offsets */


### PR DESCRIPTION
This is the first part on preparing codec adapter to work with zephyr.

This does:
- fix some build warnings / errors (given the fact that zephyr uses prink which has stronger params checks)
- fix DECLARE_CODEC_ADAPTER macro. this was generic same symbols names for init functions().
- add codec adapter components to zephyr/wrapper.c