### PR TITLE
[SKIP CI] .github: add mt8186 and mt8195 to "build-only"

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -86,9 +86,13 @@ jobs:
 
     strategy:
       matrix:
+        # Use groups to avoid spamming the web interface.
+        # Don't use a single big group so a single failure does not block
+        # all other builds.
         platform: [imx8ulp,
                    sue jsl tgl,
                    rn,
+                   mt8186 mt8195,
         ]
 
     steps:


### PR DESCRIPTION
I don't know whether the emulator is ready yet.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>