### PR TITLE
topology2: HDA: add 24 bit audio format

### DIFF
--- a/tools/topology/topology2/include/pipelines/cavs/gain-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/gain-capture.conf
@@ -52,13 +52,21 @@ Class.Pipeline."gain-capture" {
 		copier."1" {
 			copier_type	"host"
 			type	"aif_out"
-			num_audio_formats 2
+			num_audio_formats 3
 			# 16-bit 48KHz 2ch
 			Object.Base.audio_format.1 {
 				dma_buffer_size "$[$obs * 2]"
 			}
-			# 32-bit 48KHz 2ch
+			# 24-bit 48KHz 2ch
 			Object.Base.audio_format.2 {
+				in_bit_depth		32
+				in_valid_bit_depth	32
+				out_bit_depth		32
+				out_valid_bit_depth	24
+				dma_buffer_size "$[$obs * 2]"
+			}
+			# 32-bit 48KHz 2ch
+			Object.Base.audio_format.3 {
 				in_bit_depth		32
 				in_valid_bit_depth	32
 				out_bit_depth		32

--- a/tools/topology/topology2/include/pipelines/cavs/gain-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/gain-playback.conf
@@ -52,13 +52,21 @@ Class.Pipeline."gain-playback" {
 		copier."1" {
 			copier_type	"host"
 			type	"aif_in"
-			num_audio_formats 2
+			num_audio_formats 3
 			# 16-bit 48KHz 2ch
 			Object.Base.audio_format.1 {
 				dma_buffer_size "$[$ibs * 2]"
 			}
-			# 32-bit 48KHz 2ch
+			# 24-bit 48KHz 2ch
 			Object.Base.audio_format.2 {
+				in_bit_depth		32
+				in_valid_bit_depth	24
+				out_bit_depth		32
+				out_valid_bit_depth	32
+				dma_buffer_size "$[$obs * 2]"
+			}
+			# 32-bit 48KHz 2ch
+			Object.Base.audio_format.3 {
 				in_bit_depth		32
 				in_valid_bit_depth	32
 				out_bit_depth		32

--- a/tools/topology/topology2/include/pipelines/cavs/mixin-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixin-playback.conf
@@ -54,15 +54,23 @@ Class.Pipeline."mixin-playback" {
 			copier_type	"host"
 			type	"aif_in"
 			node_type $HDA_HOST_OUTPUT_CLASS
-			num_audio_formats 2
+			num_audio_formats 3
 			# 16-bit 48KHz 2ch
 			Object.Base.audio_format.1 {
 				out_bit_depth		32
 				out_valid_bit_depth	32
 				dma_buffer_size "$[$ibs * 2]"
 			}
-			# 32-bit 48KHz 2ch
+			# 24-bit 48KHz 2ch
 			Object.Base.audio_format.2 {
+				in_bit_depth		32
+				in_valid_bit_depth	24
+				out_bit_depth		32
+				out_valid_bit_depth	32
+				dma_buffer_size "$[$obs * 2]"
+			}
+			# 32-bit 48KHz 2ch
+			Object.Base.audio_format.3 {
 				in_bit_depth		32
 				in_valid_bit_depth	32
 				out_bit_depth		32

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-capture.conf
@@ -56,15 +56,23 @@ Class.Pipeline."mixout-capture" {
 			copier_type "host"
 			type	"aif_out"
 			node_type $HDA_HOST_INPUT_CLASS
-			num_audio_formats 2
+			num_audio_formats 3
 			# 16-bit 48KHz 2ch
 			Object.Base.audio_format.1 {
 				in_bit_depth		32
 				in_valid_bit_depth	32
 				dma_buffer_size "$[$obs * 2]"
 			}
-			# 32-bit 48KHz 2ch
+			# 24-bit 48KHz 2ch
 			Object.Base.audio_format.2 {
+				in_bit_depth		32
+				in_valid_bit_depth	32
+				out_bit_depth		32
+				out_valid_bit_depth	24
+				dma_buffer_size "$[$obs * 2]"
+			}
+			# 32-bit 48KHz 2ch
+			Object.Base.audio_format.3 {
 				in_bit_depth		32
 				in_valid_bit_depth	32
 				out_bit_depth		32

--- a/tools/topology/topology2/include/pipelines/cavs/passthrough-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/passthrough-capture.conf
@@ -52,15 +52,23 @@ Class.Pipeline."passthrough-capture" {
 			copier_type	"host"
 			type	"aif_out"
 			node_type $HDA_HOST_INPUT_CLASS
-			num_audio_formats 2
+			num_audio_formats 3
 			# 16-bit output format 48KHz 2ch. Input sample format is always 32-bit for capture
 			Object.Base.audio_format.1 {
 				in_bit_depth		32
 				in_valid_bit_depth	32
 				dma_buffer_size "$[$obs * 2]"
 			}
-			# 32-bit 48KHz 2ch
+			# 24-bit 48KHz 2ch
 			Object.Base.audio_format.2 {
+				in_bit_depth		32
+				in_valid_bit_depth	32
+				out_bit_depth		32
+				out_valid_bit_depth	24
+				dma_buffer_size "$[$obs * 2]"
+			}
+			# 32-bit 48KHz 2ch
+			Object.Base.audio_format.3 {
 				in_bit_depth		32
 				in_valid_bit_depth	32
 				out_bit_depth		32

--- a/tools/topology/topology2/include/pipelines/cavs/passthrough-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/passthrough-playback.conf
@@ -52,15 +52,23 @@ Class.Pipeline."passthrough-playback" {
 			copier_type	"host"
 			node_type $HDA_HOST_OUTPUT_CLASS
 			type	"aif_in"
-			num_audio_formats 2
+			num_audio_formats 3
 			# 16-bit input format 48KHz 2ch. Output sample format is always 32-bit for playback
 			Object.Base.audio_format.1 {
 				out_bit_depth		32
 				out_valid_bit_depth	32
 				dma_buffer_size "$[$ibs * 2]"
 			}
-			# 32-bit 48KHz 2ch
+			# 24-bit 48KHz 2ch
 			Object.Base.audio_format.2 {
+				in_bit_depth		32
+				in_valid_bit_depth	24
+				out_bit_depth		32
+				out_valid_bit_depth	32
+				dma_buffer_size "$[$obs * 2]"
+			}
+			# 32-bit 48KHz 2ch
+			Object.Base.audio_format.3 {
 				in_bit_depth		32
 				in_valid_bit_depth	32
 				out_bit_depth		32


### PR DESCRIPTION
We declare that S24_LE is supported by a HDA PCM, but 24 bit audio
format is not included in the available audio format list.

Fixes: thesofproject/linux#3449 

Signed-off-by: Bard Liao <yung-chuan.liao@linux.intel.com>