### PR TITLE
ipc: Don't modify IPC message content in sending functions. 

### DIFF
--- a/src/drivers/amd/renoir/ipc.c
+++ b/src/drivers/amd/renoir/ipc.c
@@ -166,7 +166,7 @@ void ipc_platform_complete_cmd(struct ipc *ipc)
 	}
 }
 
-int ipc_platform_send_msg(struct ipc_msg *msg)
+int ipc_platform_send_msg(const struct ipc_msg *msg)
 {
 	int ret = 0;
 	acp_sw_intr_trig_t  sw_intr_trig;
@@ -198,7 +198,7 @@ int ipc_platform_send_msg(struct ipc_msg *msg)
 		goto out;
 	/* Write new message in the mailbox */
 	mailbox_dspbox_write(0, msg->tx_data, msg->tx_size);
-	list_item_del(&msg->list);
+
 	/* Need to set DSP message flag */
 	sof_ipc_dsp_msg_set();
 	/* now interrupt host to tell it we have sent a message */

--- a/src/drivers/imx/ipc.c
+++ b/src/drivers/imx/ipc.c
@@ -123,7 +123,7 @@ void ipc_platform_complete_cmd(struct ipc *ipc)
 	}
 }
 
-int ipc_platform_send_msg(struct ipc_msg *msg)
+int ipc_platform_send_msg(const struct ipc_msg *msg)
 {
 	struct ipc *ipc = ipc_get();
 	int ret = 0;
@@ -137,7 +137,7 @@ int ipc_platform_send_msg(struct ipc_msg *msg)
 
 	/* now send the message */
 	mailbox_dspbox_write(0, msg->tx_data, msg->tx_size);
-	list_item_del(&msg->list);
+
 	tr_dbg(&ipc_tr, "ipc: msg tx -> 0x%x", msg->header);
 
 	ipc->is_notification_pending = true;

--- a/src/drivers/imx/ipc.c
+++ b/src/drivers/imx/ipc.c
@@ -126,13 +126,11 @@ void ipc_platform_complete_cmd(struct ipc *ipc)
 int ipc_platform_send_msg(const struct ipc_msg *msg)
 {
 	struct ipc *ipc = ipc_get();
-	int ret = 0;
 
 	/* can't send notification when one is in progress */
 	if (ipc->is_notification_pending ||
 	    imx_mu_read(IMX_MU_xCR(IMX_MU_VERSION, IMX_MU_GCR)) & IMX_MU_xCR_GIRn(IMX_MU_VERSION, 1)) {
-		ret = -EBUSY;
-		goto out;
+		return -EBUSY;
 	}
 
 	/* now send the message */
@@ -144,10 +142,7 @@ int ipc_platform_send_msg(const struct ipc_msg *msg)
 
 	/* now interrupt host to tell it we have sent a message */
 	imx_mu_xcr_rmw(IMX_MU_VERSION, IMX_MU_GCR, IMX_MU_xCR_GIRn(IMX_MU_VERSION, 1), 0);
-
-out:
-
-	return ret;
+	return 0;
 }
 
 #if CONFIG_HOST_PTABLE

--- a/src/drivers/intel/baytrail/ipc.c
+++ b/src/drivers/intel/baytrail/ipc.c
@@ -111,7 +111,7 @@ void ipc_platform_complete_cmd(struct ipc *ipc)
 	shim_write(SHIM_IMRD, shim_read(SHIM_IMRD) & ~SHIM_IMRD_BUSY);
 }
 
-int ipc_platform_send_msg(struct ipc_msg *msg)
+int ipc_platform_send_msg(const struct ipc_msg *msg)
 {
 	struct ipc *ipc = ipc_get();
 	int ret = 0;
@@ -125,7 +125,7 @@ int ipc_platform_send_msg(struct ipc_msg *msg)
 
 	/* now send the message */
 	mailbox_dspbox_write(0, msg->tx_data, msg->tx_size);
-	list_item_del(&msg->list);
+
 	tr_dbg(&ipc_tr, "ipc: msg tx -> 0x%x", msg->header);
 
 	ipc->is_notification_pending = true;

--- a/src/drivers/intel/baytrail/ipc.c
+++ b/src/drivers/intel/baytrail/ipc.c
@@ -114,13 +114,11 @@ void ipc_platform_complete_cmd(struct ipc *ipc)
 int ipc_platform_send_msg(const struct ipc_msg *msg)
 {
 	struct ipc *ipc = ipc_get();
-	int ret = 0;
 
 	/* can't send notification when one is in progress */
 	if (ipc->is_notification_pending ||
 	    shim_read(SHIM_IPCDH) & (SHIM_IPCDH_BUSY | SHIM_IPCDH_DONE)) {
-		ret = -EBUSY;
-		goto out;
+		return -EBUSY;
 	}
 
 	/* now send the message */
@@ -133,10 +131,7 @@ int ipc_platform_send_msg(const struct ipc_msg *msg)
 	/* now interrupt host to tell it we have message sent */
 	shim_write(SHIM_IPCDL, msg->header);
 	shim_write(SHIM_IPCDH, SHIM_IPCDH_BUSY);
-
-out:
-
-	return ret;
+	return 0;
 }
 
 struct ipc_data_host_buffer *ipc_platform_get_host_buffer(struct ipc *ipc)

--- a/src/drivers/intel/cavs/ipc.c
+++ b/src/drivers/intel/cavs/ipc.c
@@ -218,7 +218,6 @@ int ipc_platform_send_msg(const struct ipc_msg *msg)
 {
 	struct ipc *ipc = ipc_get();
 	ipc_cmd_hdr *hdr;
-	int ret = 0;
 
 	if (ipc->is_notification_pending ||
 #if CAVS_VERSION == CAVS_VERSION_1_5
@@ -227,8 +226,7 @@ int ipc_platform_send_msg(const struct ipc_msg *msg)
 	    ipc_read(IPC_DIPCIDR) & IPC_DIPCIDR_BUSY ||
 	    ipc_read(IPC_DIPCIDA) & IPC_DIPCIDA_DONE) {
 #endif
-		ret = -EBUSY;
-		goto out;
+		return -EBUSY;
 	}
 
 	tr_dbg(&ipc_tr, "ipc: msg tx -> 0x%x", msg->header);
@@ -247,8 +245,7 @@ int ipc_platform_send_msg(const struct ipc_msg *msg)
 	ipc_write(IPC_DIPCIDR, IPC_DIPCIDR_BUSY | hdr[0]);
 #endif
 
-out:
-	return ret;
+	return 0;
 }
 
 int platform_ipc_init(struct ipc *ipc)

--- a/src/drivers/intel/cavs/ipc.c
+++ b/src/drivers/intel/cavs/ipc.c
@@ -214,7 +214,7 @@ void ipc_platform_complete_cmd(struct ipc *ipc)
 	ipc_write(IPC_DIPCCTL, ipc_read(IPC_DIPCCTL) | IPC_DIPCCTL_IPCTBIE);
 }
 
-int ipc_platform_send_msg(struct ipc_msg *msg)
+int ipc_platform_send_msg(const struct ipc_msg *msg)
 {
 	struct ipc *ipc = ipc_get();
 	ipc_cmd_hdr *hdr;
@@ -231,7 +231,6 @@ int ipc_platform_send_msg(struct ipc_msg *msg)
 		goto out;
 	}
 
-	list_item_del(&msg->list);
 	tr_dbg(&ipc_tr, "ipc: msg tx -> 0x%x", msg->header);
 
 	ipc->is_notification_pending = true;

--- a/src/drivers/intel/cavs/sue-ipc.c
+++ b/src/drivers/intel/cavs/sue-ipc.c
@@ -65,11 +65,11 @@ void ipc_platform_complete_cmd(struct ipc *ipc)
 {
 }
 
-int ipc_platform_send_msg(struct ipc_msg *msg)
+int ipc_platform_send_msg(const struct ipc_msg *msg)
 {
 	/* now send the message */
 	mailbox_dspbox_write(0, msg->tx_data, msg->tx_size);
-	list_item_del(&msg->list);
+
 	tr_dbg(&ipc_tr, "ipc: msg tx -> 0x%x", msg->header);
 
 	/* now interrupt host to tell it we have message sent */

--- a/src/drivers/intel/haswell/ipc.c
+++ b/src/drivers/intel/haswell/ipc.c
@@ -113,7 +113,7 @@ void ipc_platform_complete_cmd(struct ipc *ipc)
 
 }
 
-int ipc_platform_send_msg(struct ipc_msg *msg)
+int ipc_platform_send_msg(const struct ipc_msg *msg)
 {
 	struct ipc *ipc = ipc_get();
 	int ret = 0;
@@ -127,7 +127,7 @@ int ipc_platform_send_msg(struct ipc_msg *msg)
 
 	/* now send the message */
 	mailbox_dspbox_write(0, msg->tx_data, msg->tx_size);
-	list_item_del(&msg->list);
+
 	tr_dbg(&ipc_tr, "ipc: msg tx -> 0x%x", msg->header);
 
 	ipc->is_notification_pending = true;

--- a/src/drivers/intel/haswell/ipc.c
+++ b/src/drivers/intel/haswell/ipc.c
@@ -116,13 +116,11 @@ void ipc_platform_complete_cmd(struct ipc *ipc)
 int ipc_platform_send_msg(const struct ipc_msg *msg)
 {
 	struct ipc *ipc = ipc_get();
-	int ret = 0;
 
 	/* can't send nofication when one is in progress */
 	if (ipc->is_notification_pending ||
 	    shim_read(SHIM_IPCD) & (SHIM_IPCD_BUSY | SHIM_IPCD_DONE)) {
-		ret = -EBUSY;
-		goto out;
+		return -EBUSY;
 	}
 
 	/* now send the message */
@@ -135,9 +133,7 @@ int ipc_platform_send_msg(const struct ipc_msg *msg)
 	/* now interrupt host to tell it we have message sent */
 	shim_write(SHIM_IPCD, SHIM_IPCD_BUSY);
 
-out:
-
-	return ret;
+	return 0;
 }
 
 struct ipc_data_host_buffer *ipc_platform_get_host_buffer(struct ipc *ipc)

--- a/src/drivers/mediatek/mt8186/ipc.c
+++ b/src/drivers/mediatek/mt8186/ipc.c
@@ -89,7 +89,7 @@ void ipc_platform_complete_cmd(struct ipc *ipc)
 		wait_for_interrupt(0);
 }
 
-int ipc_platform_send_msg(struct ipc_msg *msg)
+int ipc_platform_send_msg(const struct ipc_msg *msg)
 {
 	struct ipc *ipc = ipc_get();
 
@@ -98,7 +98,7 @@ int ipc_platform_send_msg(struct ipc_msg *msg)
 
 	/* now send the message */
 	mailbox_dspbox_write(0, msg->tx_data, msg->tx_size);
-	list_item_del(&msg->list);
+
 	ipc->is_notification_pending = true;
 
 	/* now interrupt host to tell it we have sent a message */

--- a/src/drivers/mediatek/mt8195/ipc.c
+++ b/src/drivers/mediatek/mt8195/ipc.c
@@ -88,7 +88,7 @@ void ipc_platform_complete_cmd(struct ipc *ipc)
 		wait_for_interrupt(0);
 }
 
-int ipc_platform_send_msg(struct ipc_msg *msg)
+int ipc_platform_send_msg(const struct ipc_msg *msg)
 {
 	struct ipc *ipc = ipc_get();
 
@@ -97,7 +97,7 @@ int ipc_platform_send_msg(struct ipc_msg *msg)
 
 	/* now send the message */
 	mailbox_dspbox_write(0, msg->tx_data, msg->tx_size);
-	list_item_del(&msg->list);
+
 	ipc->is_notification_pending = true;
 
 	/* now interrupt host to tell it we have sent a message */

--- a/src/include/sof/ipc/common.h
+++ b/src/include/sof/ipc/common.h
@@ -178,7 +178,7 @@ int ipc_compact_write_msg(ipc_cmd_hdr *hdr);
  * @param[in] msg The ipc msg.
  * @return pointer to raw header or NULL.
  */
-ipc_cmd_hdr *ipc_prepare_to_send(struct ipc_msg *msg);
+ipc_cmd_hdr *ipc_prepare_to_send(const struct ipc_msg *msg);
 
 /**
  * \brief Validate mailbox contents for valid IPC header.

--- a/src/include/sof/ipc/driver.h
+++ b/src/include/sof/ipc/driver.h
@@ -50,7 +50,7 @@ void ipc_platform_complete_cmd(struct ipc *ipc);
  * @param msg The IPC message to send to host.
  * @return 0 on success.
  */
-int ipc_platform_send_msg(struct ipc_msg *msg);
+int ipc_platform_send_msg(const struct ipc_msg *msg);
 
 /**
  * \brief Retrieves the ipc_data_host_buffer allocated by the platform ipc.

--- a/src/ipc/ipc-common.c
+++ b/src/ipc/ipc-common.c
@@ -187,8 +187,9 @@ void ipc_send_queued_msg(void)
 	msg = list_first_item(&ipc->msg_list, struct ipc_msg,
 			      list);
 
-	ipc_platform_send_msg(msg);
-
+	if (ipc_platform_send_msg(msg) == 0)
+		/* Remove the message from the list if it has been successfully sent. */
+		list_item_del(&msg->list);
 out:
 	k_spin_unlock(&ipc->lock, key);
 }

--- a/src/ipc/ipc3/handler.c
+++ b/src/ipc/ipc3/handler.c
@@ -1538,7 +1538,7 @@ ipc_cmd_hdr *ipc_compact_read_msg(void)
 #endif
 
 /* prepare the message using ABI major layout */
-ipc_cmd_hdr *ipc_prepare_to_send(struct ipc_msg *msg)
+ipc_cmd_hdr *ipc_prepare_to_send(const struct ipc_msg *msg)
 {
 	static uint32_t hdr[2];
 

--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -830,16 +830,18 @@ ipc_cmd_hdr *ipc_compact_read_msg(void)
 
 ipc_cmd_hdr *ipc_prepare_to_send(struct ipc_msg *msg)
 {
+	uint32_t size;
+
 	msg_data.msg_out[0] = msg->header;
 	msg_data.msg_out[1] = *(uint32_t *)msg->tx_data;
 
 	/* the first uint of msg data is sent by ipc data register for ipc4 */
-	msg->tx_size -= sizeof(uint32_t);
-	if (msg->tx_size)
-		mailbox_dspbox_write(0, (uint32_t *)msg->tx_data + 1, msg->tx_size);
+	size = msg->tx_size - sizeof(uint32_t);
+	if (size)
+		mailbox_dspbox_write(0, (uint32_t *)msg->tx_data + 1, size);
 
 	/* free memory for get config function */
-	if (msg_reply.tx_size)
+	if (msg == &msg_reply && msg_reply.tx_size > sizeof(uint32_t))
 		rfree(msg_reply.tx_data);
 
 	return ipc_to_hdr(msg_data.msg_out);

--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -828,7 +828,7 @@ ipc_cmd_hdr *ipc_compact_read_msg(void)
 	return ipc_to_hdr(msg_data.msg_in);
 }
 
-ipc_cmd_hdr *ipc_prepare_to_send(struct ipc_msg *msg)
+ipc_cmd_hdr *ipc_prepare_to_send(const struct ipc_msg *msg)
 {
 	uint32_t size;
 

--- a/src/platform/library/include/platform/platform.h
+++ b/src/platform/library/include/platform/platform.h
@@ -68,7 +68,7 @@ static inline void platform_wait_for_interrupt(int level)
 	arch_wait_for_interrupt(level);
 }
 
-static inline int ipc_platform_send_msg(struct ipc_msg *msg) { return 0; }
+static inline int ipc_platform_send_msg(const struct ipc_msg *msg) { return 0; }
 
 #endif /* __PLATFORM_PLATFORM_H__ */
 

--- a/test/cmocka/src/common_mocks.c
+++ b/test/cmocka/src/common_mocks.c
@@ -219,7 +219,7 @@ void WEAK ipc_platform_complete_cmd(struct ipc *ipc)
 }
 
 #if !CONFIG_LIBRARY
-int WEAK ipc_platform_send_msg(struct ipc_msg *msg)
+int WEAK ipc_platform_send_msg(const struct ipc_msg *msg)
 {
 	return 0;
 }


### PR DESCRIPTION
While activating the dma-trace mechanism for ipc4, I discovered a problem in the ipc message send function. 
Log position notification are allocated once, and the same message is send multiple times. Sending function in ipc4 decrease data length, which leads to the corruption of subsequent notifications, and firmware crash on overflow. Additionally, the function frees the ipc response buffer without checking if the sent message is the ipc response.

To protect us from similar problems in the future, I added the const specifier to protect the message contents passed to
ipc_platform_send_msg and ipc_prepare_to_send functions. The deletion of the message from the list has been moved to ipc_send_queued_msg function.