### PR TITLE
timer: Align SOF timer API with Zephyr

### DIFF
--- a/src/arch/CMakeLists.txt
+++ b/src/arch/CMakeLists.txt
@@ -1,3 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 add_subdirectory(${ARCH})
+
+add_subdirectory("xtos-wrapper")

--- a/src/arch/CMakeLists.txt
+++ b/src/arch/CMakeLists.txt
@@ -2,4 +2,6 @@
 
 add_subdirectory(${ARCH})
 
-add_subdirectory("xtos-wrapper")
+if(NOT CONFIG_ZEPHYR_SOF_MODULE)
+	add_subdirectory("xtos-wrapper")
+endif()

--- a/src/arch/xtensa/drivers/CMakeLists.txt
+++ b/src/arch/xtensa/drivers/CMakeLists.txt
@@ -1,3 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-add_local_sources(sof interrupt.c timer.c cache_attr.c)
+add_local_sources(sof interrupt.c cache_attr.c)
+
+if(NOT CONFIG_ZEPHYR_SOF_MODULE)
+	add_local_sources(sof timer.c)
+endif()

--- a/src/arch/xtos-wrapper/CMakeLists.txt
+++ b/src/arch/xtos-wrapper/CMakeLists.txt
@@ -1,0 +1,1 @@
+target_include_directories(sof_public_headers INTERFACE include)

--- a/src/arch/xtos-wrapper/include/sof/drivers/timer.h
+++ b/src/arch/xtos-wrapper/include/sof/drivers/timer.h
@@ -11,6 +11,7 @@
 #include <arch/drivers/timer.h>
 #include <sof/lib/cpu.h>
 #include <sof/sof.h>
+#include <sof/platform.h>
 #include <stdint.h>
 
 struct comp_dev;
@@ -75,6 +76,46 @@ static inline uint64_t platform_safe_get_time(struct timer *timer)
 
 void platform_timer_start(struct timer *timer);
 void platform_timer_stop(struct timer *timer);
+
+static inline uint64_t k_ms_to_cyc_ceil64(uint64_t ms)
+{
+	return clock_ms_to_ticks(PLATFORM_DEFAULT_CLOCK, ms);
+}
+
+static inline uint64_t k_us_to_cyc_ceil64(uint64_t us)
+{
+	return clock_us_to_ticks(PLATFORM_DEFAULT_CLOCK, us);
+}
+
+static inline uint64_t k_ns_to_cyc_near64(uint64_t ns)
+{
+	return clock_ns_to_ticks(PLATFORM_DEFAULT_CLOCK, ns);
+}
+
+static inline uint64_t k_cyc_to_ms_near64(uint64_t ticks)
+{
+	return ticks / clock_ms_to_ticks(PLATFORM_DEFAULT_CLOCK, 1);
+}
+
+static inline uint64_t k_cyc_to_us_near64(uint64_t ticks)
+{
+	return ticks / clock_us_to_ticks(PLATFORM_DEFAULT_CLOCK, 1);
+}
+
+static inline uint64_t k_cycle_get_64(void)
+{
+	return platform_timer_get(timer_get());
+}
+
+static inline uint64_t k_cycle_get_64_atomic(void)
+{
+	return platform_timer_get_atomic(timer_get());
+}
+
+static inline uint64_t k_cycle_get_64_safe(void)
+{
+	return platform_safe_get_time(timer_get());
+}
 
 /* get timestamp for host stream DMA position */
 void platform_host_timestamp(struct comp_dev *host,

--- a/src/audio/pipeline/pipeline-stream.c
+++ b/src/audio/pipeline/pipeline-stream.c
@@ -424,8 +424,7 @@ int pipeline_trigger_run(struct pipeline *p, struct comp_dev *host, int cmd)
 		list_init(&walk_ctx.pipelines);
 
 		if (data.delay_ms)
-			wait_delay(clock_ms_to_ticks(PLATFORM_DEFAULT_CLOCK,
-						     data.delay_ms));
+			wait_delay_ms(data.delay_ms);
 
 		ret = walk_ctx.comp_func(host, NULL, &walk_ctx, host->direction);
 		if (ret < 0)

--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -462,7 +462,7 @@ static int dw_dma_status(struct dma_chan_data *channel,
 	status->state = channel->status;
 	status->r_pos = dma_reg_read(channel->dma, DW_SAR(channel->index));
 	status->w_pos = dma_reg_read(channel->dma, DW_DAR(channel->index));
-	status->timestamp = timer_get_system(timer_get());
+	status->timestamp = k_cycle_get_64();
 
 	if (status->ipc_posn_data) {
 		uint32_t *llp = (uint32_t *)status->ipc_posn_data;

--- a/src/drivers/dw/ssi-spi.c
+++ b/src/drivers/dw/ssi-spi.c
@@ -170,9 +170,7 @@ static void spi_stop(struct spi *spi)
 
 static void delay(unsigned int ms)
 {
-	uint64_t tick = clock_ms_to_ticks(PLATFORM_DEFAULT_CLOCK, ms);
-
-	wait_delay(tick);
+	wait_delay_ms(ms);
 }
 
 static int spi_trigger(struct spi *spi, int cmd, int direction)

--- a/src/drivers/generic/dummy-dma.c
+++ b/src/drivers/generic/dummy-dma.c
@@ -315,7 +315,7 @@ static int dummy_dma_status(struct dma_chan_data *channel,
 	status->r_pos = ch->r_pos;
 	status->w_pos = ch->w_pos;
 
-	status->timestamp = timer_get_system(timer_get());
+	status->timestamp = k_cycle_get_64();
 	return 0;
 }
 

--- a/src/drivers/host/timer.c
+++ b/src/drivers/host/timer.c
@@ -20,6 +20,7 @@ void platform_dai_timestamp(struct comp_dev *dai,
 {
 }
 
+#ifndef __ZEPHYR__
 uint64_t platform_timer_get(struct timer *timer)
 {
 	return 0;
@@ -33,3 +34,4 @@ uint64_t platform_timer_get_atomic(struct timer *timer)
 void platform_timer_stop(struct timer *timer)
 {
 }
+#endif /* __ZEPHYR__ */

--- a/src/drivers/imx/edma.c
+++ b/src/drivers/imx/edma.c
@@ -234,7 +234,7 @@ static int edma_status(struct dma_chan_data *channel,
 	 */
 	status->r_pos = dma_chan_reg_read(channel, EDMA_TCD_SADDR);
 	status->w_pos = dma_chan_reg_read(channel, EDMA_TCD_DADDR);
-	status->timestamp = timer_get_system(timer_get());
+	status->timestamp = k_cycle_get_64();
 	return 0;
 }
 

--- a/src/drivers/imx/sdma.c
+++ b/src/drivers/imx/sdma.c
@@ -556,7 +556,7 @@ static int sdma_status(struct dma_chan_data *channel,
 	status->flags = 0;
 	status->w_pos = 0;
 	status->r_pos = 0;
-	status->timestamp = timer_get_system(timer_get());
+	status->timestamp = k_cycle_get_64();
 
 	bd = (struct sdma_bd *)pdata->ccb->current_bd_paddr;
 

--- a/src/drivers/intel/baytrail/timer.c
+++ b/src/drivers/intel/baytrail/timer.c
@@ -19,6 +19,7 @@
 #include <errno.h>
 #include <stdint.h>
 
+#ifndef __ZEPHYR__
 static void platform_timer_64_handler(void *arg)
 {
 	struct timer *timer = arg;
@@ -142,6 +143,7 @@ uint64_t platform_timer_get_atomic(struct timer *timer)
 {
 	return platform_timer_get(timer);
 }
+#endif /* __ZEPHYR__ */
 
 /* get timestamp for host stream DMA position */
 void platform_host_timestamp(struct comp_dev *host,
@@ -167,7 +169,7 @@ void platform_dai_timestamp(struct comp_dev *dai,
 		posn->flags |= SOF_TIME_DAI_VALID;
 
 	/* get SSP wallclock - DAI sets this to stream start value */
-	posn->wallclock = platform_timer_get(timer_get()) - posn->wallclock;
+	posn->wallclock = k_cycle_get_64() - posn->wallclock;
 	posn->wallclock_hz = clock_get_freq(PLATFORM_DEFAULT_CLOCK);
 	posn->flags |= SOF_TIME_WALL_VALID | SOF_TIME_WALL_64;
 }
@@ -176,9 +178,10 @@ void platform_dai_timestamp(struct comp_dev *dai,
 void platform_dai_wallclock(struct comp_dev *dai, uint64_t *wallclock)
 {
 	/* only 1 wallclock on BYT */
-	*wallclock = platform_timer_get(timer_get());
+	*wallclock = k_cycle_get_64();
 }
 
+#ifndef __ZEPHYR__
 static int platform_timer_register(struct timer *timer,
 				   void (*handler)(void *arg), void *arg)
 {
@@ -235,3 +238,4 @@ void timer_disable(struct timer *timer, void *arg, int core)
 	interrupt_disable(timer->irq, arg);
 
 }
+#endif /* __ZEPHYR__ */

--- a/src/drivers/intel/cavs/timer.c
+++ b/src/drivers/intel/cavs/timer.c
@@ -20,6 +20,7 @@
 /** \brief Minimum number of timer recovery cycles in case of delay. */
 #define TIMER_MIN_RECOVER_CYCLES	240	/* ~10us at 24.576MHz */
 
+#ifndef __ZEPHYR__
 void platform_timer_start(struct timer *timer)
 {
 	/* run timer */
@@ -112,6 +113,7 @@ uint64_t platform_timer_get_atomic(struct timer *timer)
 
 	return ticks_now;
 }
+#endif /* __ZEPHYR__ */
 
 /* get timestamp for host stream DMA position */
 void platform_host_timestamp(struct comp_dev *host,
@@ -137,7 +139,7 @@ void platform_dai_timestamp(struct comp_dev *dai,
 		posn->flags |= SOF_TIME_DAI_VALID;
 
 	/* get SSP wallclock - DAI sets this to stream start value */
-	posn->wallclock = shim_read64(SHIM_DSPWC) - posn->wallclock;
+	posn->wallclock = k_cycle_get_64() - posn->wallclock;
 	posn->wallclock_hz = clock_get_freq(PLATFORM_DEFAULT_CLOCK);
 	posn->flags |= SOF_TIME_WALL_VALID;
 }
@@ -145,9 +147,10 @@ void platform_dai_timestamp(struct comp_dev *dai,
 /* get current wallclock for componnent */
 void platform_dai_wallclock(struct comp_dev *dai, uint64_t *wallclock)
 {
-	*wallclock = shim_read64(SHIM_DSPWC);
+	*wallclock = k_cycle_get_64();
 }
 
+#ifndef __ZEPHYR__
 static int platform_timer_register(struct timer *timer,
 				   void (*handler)(void *arg), void *arg)
 {
@@ -248,3 +251,4 @@ void timer_disable(struct timer *timer, void *arg, int core)
 	}
 
 }
+#endif /* __ZEPHYR__ */

--- a/src/drivers/intel/hda/hda-dma.c
+++ b/src/drivers/intel/hda/hda-dma.c
@@ -320,13 +320,10 @@ static inline int hda_dma_is_buffer_empty(struct dma_chan_data *chan)
 
 static int hda_dma_wait_for_buffer_full(struct dma_chan_data *chan)
 {
-	struct timer *timer = timer_get();
-	uint64_t deadline = platform_timer_get(timer) +
-		clock_ms_to_ticks(PLATFORM_DEFAULT_CLOCK, 1) *
-		HDA_DMA_TIMEOUT / 1000;
+	uint64_t deadline = k_cycle_get_64() + k_us_to_cyc_ceil64(HDA_DMA_TIMEOUT);
 
 	while (!hda_dma_is_buffer_full(chan)) {
-		if (deadline < platform_timer_get(timer)) {
+		if (deadline < k_cycle_get_64()) {
 			/* safe check in case we've got preempted after read */
 			if (hda_dma_is_buffer_full(chan))
 				return 0;
@@ -344,13 +341,10 @@ static int hda_dma_wait_for_buffer_full(struct dma_chan_data *chan)
 
 static int hda_dma_wait_for_buffer_empty(struct dma_chan_data *chan)
 {
-	struct timer *timer = timer_get();
-	uint64_t deadline = platform_timer_get(timer) +
-		clock_ms_to_ticks(PLATFORM_DEFAULT_CLOCK, 1) *
-		HDA_DMA_TIMEOUT / 1000;
+	uint64_t deadline = k_cycle_get_64() + k_us_to_cyc_ceil64(HDA_DMA_TIMEOUT);
 
 	while (!hda_dma_is_buffer_empty(chan)) {
-		if (deadline < platform_timer_get(timer)) {
+		if (deadline < k_cycle_get_64()) {
 			/* safe check in case we've got preempted after read */
 			if (hda_dma_is_buffer_empty(chan))
 				return 0;
@@ -730,7 +724,7 @@ static int hda_dma_status(struct dma_chan_data *channel,
 	status->state = channel->status;
 	status->r_pos = dma_chan_reg_read(channel, DGBRP);
 	status->w_pos = dma_chan_reg_read(channel, DGBWP);
-	status->timestamp = timer_get_system(timer_get());
+	status->timestamp = k_cycle_get_64();
 
 	return 0;
 }

--- a/src/idc/idc.c
+++ b/src/idc/idc.c
@@ -90,18 +90,14 @@ int idc_msg_status_get(uint32_t core)
  */
 int idc_wait_in_blocking_mode(uint32_t target_core, bool (*cond)(int))
 {
-	struct timer *timer = timer_get();
-	uint64_t deadline;
-
-	deadline = platform_timer_get(timer) +
-		clock_us_to_ticks(PLATFORM_DEFAULT_CLOCK, IDC_TIMEOUT);
+	uint64_t deadline = k_cycle_get_64() + k_us_to_cyc_ceil64(IDC_TIMEOUT);
 
 	while (!cond(target_core)) {
 
 		/* spin here so other core can access IO and timers freely */
 		idelay(8192);
 
-		if (deadline < platform_timer_get(timer))
+		if (deadline < k_cycle_get_64())
 			break;
 	}
 

--- a/src/include/sof/lib/clk.h
+++ b/src/include/sof/lib/clk.h
@@ -64,8 +64,6 @@ uint64_t clock_ns_to_ticks(int clock, uint64_t ns);
 
 uint64_t clock_ticks_per_sample(int clock, uint32_t sample_rate);
 
-void platform_timer_set_delta(struct timer *timer, uint64_t ns);
-
 static inline struct clock_info *clocks_get(void)
 {
 	return sof_get()->clocks;

--- a/src/include/sof/lib/clk.h
+++ b/src/include/sof/lib/clk.h
@@ -56,11 +56,13 @@ void clock_set_freq(int clock, uint32_t hz);
 
 void clock_low_power_mode(int clock, bool enable);
 
+#ifndef __ZEPHYR__
 uint64_t clock_ms_to_ticks(int clock, uint64_t ms);
 
 uint64_t clock_us_to_ticks(int clock, uint64_t us);
 
 uint64_t clock_ns_to_ticks(int clock, uint64_t ns);
+#endif /* __ZEPHYR__ */
 
 uint64_t clock_ticks_per_sample(int clock, uint32_t sample_rate);
 

--- a/src/include/sof/lib/clk.h
+++ b/src/include/sof/lib/clk.h
@@ -60,6 +60,8 @@ uint64_t clock_ms_to_ticks(int clock, uint64_t ms);
 
 uint64_t clock_us_to_ticks(int clock, uint64_t us);
 
+uint64_t clock_ns_to_ticks(int clock, uint64_t ns);
+
 uint64_t clock_ticks_per_sample(int clock, uint32_t sample_rate);
 
 void platform_timer_set_delta(struct timer *timer, uint64_t ns);

--- a/src/include/sof/lib/perf_cnt.h
+++ b/src/include/sof/lib/perf_cnt.h
@@ -39,8 +39,8 @@ struct perf_cnt_data {
 
 /** \brief Initializes timestamps with current timer values. */
 #define perf_cnt_init(pcd) do {						\
-		(pcd)->plat_ts = platform_timer_get(timer_get());	\
-		(pcd)->cpu_ts = timer_get_system(cpu_timer_get());	\
+		(pcd)->plat_ts = k_cycle_get_64();			\
+		(pcd)->cpu_ts = k_cycle_get_64();			\
 	} while (0)
 
 /* Trace macros that can be used as trace_m argument of the perf_cnt_stamp()
@@ -66,23 +66,23 @@ struct perf_cnt_data {
  *         more precise line number is desired in the logs.
  *  \param arg Argument passed to trace_m as arg.
  */
-#define perf_cnt_stamp(pcd, trace_m, arg) do {				  \
-		uint32_t plat_ts =					  \
-			(uint32_t) platform_timer_get(timer_get());	  \
-		uint32_t cpu_ts =					  \
-			(uint32_t) arch_timer_get_system(cpu_timer_get());\
-		if ((pcd)->plat_ts) {					  \
-			(pcd)->plat_delta_last = plat_ts - (pcd)->plat_ts;\
-			(pcd)->cpu_delta_last = cpu_ts - (pcd)->cpu_ts;   \
-		}							  \
-		(pcd)->plat_ts = plat_ts;				  \
-		(pcd)->cpu_ts = cpu_ts;					  \
-		if ((pcd)->plat_delta_last > (pcd)->plat_delta_peak)	  \
-			(pcd)->plat_delta_peak = (pcd)->plat_delta_last;  \
-		if ((pcd)->cpu_delta_last > (pcd)->cpu_delta_peak) {	  \
-			(pcd)->cpu_delta_peak = (pcd)->cpu_delta_last;	  \
-			trace_m(pcd, arg);				  \
-		}							  \
+#define perf_cnt_stamp(pcd, trace_m, arg) do {					\
+		uint32_t plat_ts =						\
+			(uint32_t)k_cycle_get_64();				\
+		uint32_t cpu_ts =						\
+			(uint32_t)k_cycle_get_64();				\
+		if ((pcd)->plat_ts) {						\
+			(pcd)->plat_delta_last = plat_ts - (pcd)->plat_ts;	\
+			(pcd)->cpu_delta_last = cpu_ts - (pcd)->cpu_ts;		\
+		}								\
+		(pcd)->plat_ts = plat_ts;					\
+		(pcd)->cpu_ts = cpu_ts;						\
+		if ((pcd)->plat_delta_last > (pcd)->plat_delta_peak)		\
+			(pcd)->plat_delta_peak = (pcd)->plat_delta_last;	\
+		if ((pcd)->cpu_delta_last > (pcd)->cpu_delta_peak) {		\
+			(pcd)->cpu_delta_peak = (pcd)->cpu_delta_last;		\
+			trace_m(pcd, arg);					\
+		}								\
 	} while (0)
 
 /**

--- a/src/include/sof/lib/wait.h
+++ b/src/include/sof/lib/wait.h
@@ -38,14 +38,28 @@ static inline void wait_for_interrupt(int level)
 	tr_dbg(&wait_tr, "WFX");
 }
 
+#if !CONFIG_LIBRARY
 /**
  * \brief Waits at least passed number of clocks.
  * \param[in] number_of_clks Minimum number of clocks to wait.
  */
-#if !CONFIG_LIBRARY
 void wait_delay(uint64_t number_of_clks);
+
+/**
+ * \brief Waits at least passed number of milliseconds.
+ * \param[in] ms Minimum number of milliseconds to wait.
+ */
+void wait_delay_ms(uint64_t ms);
+
+/**
+ * \brief Waits at least passed number of microseconds.
+ * \param[in] us Minimum number of microseconds to wait.
+ */
+void wait_delay_us(uint64_t us);
 #else
 static inline void wait_delay(uint64_t number_of_clks) {}
+static inline void wait_delay_ms(uint64_t ms) {}
+static inline void wait_delay_us(uint64_t us) {}
 #endif
 
 int poll_for_register_delay(uint32_t reg, uint32_t mask,

--- a/src/include/sof/schedule/ll_schedule_domain.h
+++ b/src/include/sof/schedule/ll_schedule_domain.h
@@ -188,8 +188,8 @@ static inline bool domain_is_pending(struct ll_schedule_domain *domain,
 #ifndef __ZEPHYR__
 struct ll_schedule_domain *timer_domain_init(struct timer *timer, int clk);
 #else
-struct ll_schedule_domain *zephyr_domain_init(struct timer *timer, int clk);
-#define timer_domain_init zephyr_domain_init
+struct ll_schedule_domain *zephyr_domain_init(int clk);
+#define timer_domain_init(timer, clk) zephyr_domain_init(clk)
 #endif
 
 struct ll_schedule_domain *dma_multi_chan_domain_init(struct dma *dma_array,

--- a/src/include/sof/schedule/ll_schedule_domain.h
+++ b/src/include/sof/schedule/ll_schedule_domain.h
@@ -84,7 +84,11 @@ static inline struct ll_schedule_domain *domain_init
 	domain->clk = clk;
 	domain->synchronous = synchronous;
 	domain->full_sync = false;
+#ifdef __ZEPHYR__
+	domain->ticks_per_ms = k_ms_to_cyc_ceil64(1);
+#else
 	domain->ticks_per_ms = clock_ms_to_ticks(clk, 1);
+#endif
 	domain->ops = ops;
 	/* maximum value means no tick has been set to timer */
 	domain->next_tick = UINT64_MAX;

--- a/src/include/sof/sof.h
+++ b/src/include/sof/sof.h
@@ -57,11 +57,13 @@ struct sof {
 	/* platform clock information */
 	struct clock_info *clocks;
 
+#ifndef __ZEPHYR__
 	/* default platform timer */
 	struct timer *platform_timer;
 
 	/* cpu (arch) timers - 1 per core */
 	struct timer *cpu_timers;
+#endif
 
 	/* timer domain for driving timer LL scheduler */
 	struct ll_schedule_domain *platform_timer_domain;

--- a/src/include/sof/trace/dma-trace.h
+++ b/src/include/sof/trace/dma-trace.h
@@ -42,11 +42,12 @@ struct dma_trace_data {
 	uint32_t copy_in_progress;
 	uint32_t stream_tag;
 	uint32_t active_stream_tag;
-	uint32_t dma_copy_align; /**< Minimal chunk of data possible to be
-				   *  copied by dma connected to host
-				   */
-	uint32_t dropped_entries; /* amount of dropped entries */
-	struct k_spinlock lock; /* dma trace lock */
+	uint32_t dma_copy_align;	/* Minimal chunk of data possible to be
+					 *  copied by dma connected to host
+					 */
+	uint32_t dropped_entries;	/* amount of dropped entries */
+	struct k_spinlock lock;		/* dma trace lock */
+	uint64_t time_delta;		/* difference between the host time */
 };
 
 int dma_trace_init_early(struct sof *sof);

--- a/src/include/sof/trace/trace.h
+++ b/src/include/sof/trace/trace.h
@@ -286,11 +286,11 @@ do {											\
 /* Just like XTOS, only the most urgent messages go to limited
  * shared memory.
  */
-#define _log_nodict(atomic, arg_count, lvl, format, ...) \
-do {							      \
-	if ((lvl) <= MTRACE_DUPLICATION_LEVEL)			      \
-		printk("%llu " format "\n", platform_timer_get(NULL), \
-		       ##__VA_ARGS__); \
+#define _log_nodict(atomic, arg_count, lvl, format, ...)		\
+do {									\
+	if ((lvl) <= MTRACE_DUPLICATION_LEVEL)				\
+		printk("%llu " format "\n", k_cycle_get_64(),		\
+		       ##__VA_ARGS__);					\
 } while (0)
 #else
 #define _log_nodict(atomic, n_args, lvl, format, ...)

--- a/src/ipc/ipc3/handler.c
+++ b/src/ipc/ipc3/handler.c
@@ -802,7 +802,6 @@ static int ipc_dma_trace_config(uint32_t header)
 	struct dma_trace_data *dmat = dma_trace_data_get();
 	struct ipc *ipc = ipc_get();
 	struct sof_ipc_dma_trace_params_ext params;
-	struct timer *timer = timer_get();
 	int err;
 
 	if (!dmat) {
@@ -820,8 +819,7 @@ static int ipc_dma_trace_config(uint32_t header)
 		 *  "SOF_IPC_TRACE_DMA_PARAMS_EXT" in your particular
 		 *  kernel version.
 		 */
-		dmat->time_delta = clock_ns_to_ticks(PLATFORM_DEFAULT_CLOCK, params.timestamp_ns) -
-				   platform_timer_get(timer);
+		dmat->time_delta = k_ns_to_cyc_near64(params.timestamp_ns) - k_cycle_get_64();
 	else
 		dmat->time_delta = 0;
 

--- a/src/ipc/ipc3/handler.c
+++ b/src/ipc/ipc3/handler.c
@@ -820,9 +820,10 @@ static int ipc_dma_trace_config(uint32_t header)
 		 *  "SOF_IPC_TRACE_DMA_PARAMS_EXT" in your particular
 		 *  kernel version.
 		 */
-		platform_timer_set_delta(timer, params.timestamp_ns);
+		dmat->time_delta = clock_ns_to_ticks(PLATFORM_DEFAULT_CLOCK, params.timestamp_ns) -
+				   platform_timer_get(timer);
 	else
-		timer->delta = 0;
+		dmat->time_delta = 0;
 
 #if CONFIG_HOST_PTABLE
 	err = ipc_process_host_buffer(ipc, &params.buffer,

--- a/src/lib/agent.c
+++ b/src/lib/agent.c
@@ -63,7 +63,7 @@ static enum task_state validate(void *data)
 	uint64_t current;
 	uint64_t delta;
 
-	current = platform_timer_get(timer_get());
+	current = k_cycle_get_64();
 	delta = current - sa->last_check;
 
 	perf_cnt_stamp(&sa->pcd, perf_sa_trace, 0 /* ignored */);
@@ -101,11 +101,7 @@ void sa_init(struct sof *sof, uint64_t timeout)
 	sof->sa = rzalloc(SOF_MEM_ZONE_SYS_SHARED, 0, SOF_MEM_CAPS_RAM, sizeof(*sof->sa));
 
 	/* set default timeouts */
-#ifdef __ZEPHYR__
 	ticks = k_us_to_cyc_ceil64(timeout);
-#else
-	ticks = clock_us_to_ticks(PLATFORM_DEFAULT_CLOCK, timeout);
-#endif
 
 	/* TODO: change values after minimal drifts will be assured */
 	sof->sa->panic_timeout = 2 * ticks;	/* 100% delay */
@@ -131,7 +127,7 @@ void sa_init(struct sof *sof, uint64_t timeout)
 	schedule_task(&sof->sa->work, 0, timeout);
 
 	/* set last check time to now to give time for boot completion */
-	sof->sa->last_check = platform_timer_get(timer_get());
+	sof->sa->last_check = k_cycle_get_64();
 
 }
 

--- a/src/lib/clk.c
+++ b/src/lib/clk.c
@@ -119,6 +119,13 @@ uint64_t clock_us_to_ticks(int clock, uint64_t us)
 	return ticks;
 }
 
+uint64_t clock_ns_to_ticks(int clock, uint64_t ns)
+{
+	struct clock_info *clk_info = clocks_get() + clock;
+
+	return clk_info->freqs[clk_info->current_freq_idx].ticks_per_msec * ns / 1000000ULL;
+}
+
 uint64_t clock_ticks_per_sample(int clock, uint32_t sample_rate)
 {
 	struct clock_info *clk_info = clocks_get() + clock;

--- a/src/lib/clk.c
+++ b/src/lib/clk.c
@@ -99,6 +99,7 @@ void clock_low_power_mode(int clock, bool enable)
 		clk_info->low_power_mode(clock, enable);
 }
 
+#ifndef __ZEPHYR__
 uint64_t clock_ms_to_ticks(int clock, uint64_t ms)
 {
 	struct clock_info *clk_info = clocks_get() + clock;
@@ -125,6 +126,7 @@ uint64_t clock_ns_to_ticks(int clock, uint64_t ns)
 
 	return clk_info->freqs[clk_info->current_freq_idx].ticks_per_msec * ns / 1000000ULL;
 }
+#endif /* __ZEPHYR__ */
 
 uint64_t clock_ticks_per_sample(int clock, uint32_t sample_rate)
 {

--- a/src/lib/clk.c
+++ b/src/lib/clk.c
@@ -138,15 +138,3 @@ uint64_t clock_ticks_per_sample(int clock, uint32_t sample_rate)
 
 	return ticks_per_sample;
 }
-
-void platform_timer_set_delta(struct timer *timer, uint64_t ns)
-{
-	struct clock_info *clk_info = clocks_get() + PLATFORM_DEFAULT_CLOCK;
-	uint32_t ticks_per_msec =
-		clk_info->freqs[clk_info->current_freq_idx].ticks_per_msec;
-	uint64_t ticks;
-
-	ticks = ticks_per_msec * ns / 1000000;
-	timer->delta = ticks - platform_timer_get(timer);
-
-}

--- a/src/lib/pm_runtime.c
+++ b/src/lib/pm_runtime.c
@@ -144,7 +144,7 @@ void init_dsp_r_state(enum dsp_r_state r_state)
 	r_counters = rzalloc(SOF_MEM_ZONE_SYS_SHARED, 0, SOF_MEM_CAPS_RAM, sizeof(*r_counters));
 	prd->r_counters = r_counters;
 
-	r_counters->ts = platform_timer_get(timer_get());
+	r_counters->ts = k_cycle_get_64();
 	r_counters->cur_r_state = r_state;
 }
 
@@ -159,7 +159,7 @@ void report_dsp_r_state(enum dsp_r_state r_state)
 	if (!r_counters || r_counters->cur_r_state == r_state)
 		return;
 
-	ts = platform_timer_get(timer_get());
+	ts = k_cycle_get_64();
 	delta = ts - r_counters->ts;
 
 	delta += mailbox_sw_reg_read64(SRAM_REG_R_STATE_TRACE_BASE +

--- a/src/lib/wait.c
+++ b/src/lib/wait.c
@@ -31,7 +31,7 @@ DECLARE_TR_CTX(wait_tr, SOF_UUID(wait_uuid), LOG_LEVEL_INFO);
 int poll_for_register_delay(uint32_t reg, uint32_t mask,
 			    uint32_t val, uint64_t us)
 {
-	uint64_t tick = clock_us_to_ticks(PLATFORM_DEFAULT_CLOCK, us);
+	uint64_t tick = k_us_to_cyc_ceil64(us);
 	uint32_t tries = DEFAULT_TRY_TIMES;
 	uint64_t delta = tick / tries;
 
@@ -58,19 +58,18 @@ int poll_for_register_delay(uint32_t reg, uint32_t mask,
 
 void wait_delay(uint64_t number_of_clks)
 {
-	struct timer *timer = timer_get();
-	uint64_t current = platform_timer_get(timer);
+	uint64_t timeout = k_cycle_get_64() + number_of_clks;
 
-	while ((platform_timer_get(timer) - current) < number_of_clks)
+	while (k_cycle_get_64() < timeout)
 		idelay(PLATFORM_DEFAULT_DELAY);
 }
 
 void wait_delay_ms(uint64_t ms)
 {
-	wait_delay(clock_ms_to_ticks(PLATFORM_DEFAULT_CLOCK, ms));
+	wait_delay(k_ms_to_cyc_ceil64(ms));
 }
 
 void wait_delay_us(uint64_t us)
 {
-	wait_delay(clock_us_to_ticks(PLATFORM_DEFAULT_CLOCK, us));
+	wait_delay(k_us_to_cyc_ceil64(us));
 }

--- a/src/lib/wait.c
+++ b/src/lib/wait.c
@@ -64,3 +64,13 @@ void wait_delay(uint64_t number_of_clks)
 	while ((platform_timer_get(timer) - current) < number_of_clks)
 		idelay(PLATFORM_DEFAULT_DELAY);
 }
+
+void wait_delay_ms(uint64_t ms)
+{
+	wait_delay(clock_ms_to_ticks(PLATFORM_DEFAULT_CLOCK, ms));
+}
+
+void wait_delay_us(uint64_t us)
+{
+	wait_delay(clock_us_to_ticks(PLATFORM_DEFAULT_CLOCK, us));
+}

--- a/src/platform/baytrail/platform.c
+++ b/src/platform/baytrail/platform.c
@@ -143,6 +143,7 @@ const struct ext_man_windows xsram_window
 	},
 };
 
+#ifndef __ZEPHYR__
 static SHARED_DATA struct timer timer = {
 	.id = TIMER3, /* external timer */
 	.irq = IRQ_NUM_EXT_TIMER,
@@ -152,6 +153,7 @@ static SHARED_DATA struct timer arch_timer = {
 	.id = TIMER1, /* internal timer */
 	.irq = IRQ_NUM_TIMER1,
 };
+#endif /* __ZEPHYR__ */
 
 int platform_boot_complete(uint32_t boot_message)
 {
@@ -190,8 +192,10 @@ int platform_init(struct sof *sof)
 #endif
 	int ret;
 
+#ifndef __ZEPHYR__
 	sof->platform_timer = &timer;
 	sof->cpu_timers = &arch_timer;
+#endif /* __ZEPHYR__ */
 
 	/* clear mailbox for early trace and debug */
 	trace_point(TRACE_BOOT_PLATFORM_MBOX);

--- a/src/platform/haswell/platform.c
+++ b/src/platform/haswell/platform.c
@@ -129,10 +129,12 @@ const struct ext_man_windows xsram_window
 	},
 };
 
+#ifndef __ZEPHYR__
 static SHARED_DATA struct timer timer = {
 	.id = TIMER1, /* internal timer */
 	.irq = IRQ_NUM_TIMER2,
 };
+#endif
 
 int platform_boot_complete(uint32_t boot_message)
 {
@@ -172,8 +174,10 @@ int platform_init(struct sof *sof)
 	struct dai *ssp1;
 	int ret;
 
+#ifndef __ZEPHYR__
 	sof->platform_timer = &timer;
 	sof->cpu_timers = &timer;
+#endif
 
 	/* clear mailbox for early trace and debug */
 	trace_point(TRACE_BOOT_PLATFORM_MBOX);

--- a/src/platform/imx8/platform.c
+++ b/src/platform/imx8/platform.c
@@ -128,10 +128,12 @@ const struct ext_man_windows xsram_window
 	}
 };
 
+#ifndef __ZEPHYR__
 static SHARED_DATA struct timer timer = {
 	.id = TIMER0, /* internal timer */
 	.irq = IRQ_NUM_TIMER0,
 };
+#endif
 
 int platform_boot_complete(uint32_t boot_message)
 {
@@ -153,8 +155,10 @@ int platform_init(struct sof *sof)
 {
 	int ret;
 
+#ifndef __ZEPHYR__
 	sof->platform_timer = &timer;
 	sof->cpu_timers = &timer;
+#endif
 
 #ifdef __ZEPHYR__
 	/* initialize cascade interrupts before any usage */

--- a/src/platform/imx8m/platform.c
+++ b/src/platform/imx8m/platform.c
@@ -127,10 +127,12 @@ const struct ext_man_windows xsram_window
 	},
 };
 
+#ifndef __ZEPHYR__
 static SHARED_DATA struct timer timer = {
 	.id = TIMER0, /* internal timer */
 	.irq = IRQ_NUM_TIMER0,
 };
+#endif
 
 int platform_boot_complete(uint32_t boot_message)
 {
@@ -152,8 +154,10 @@ int platform_init(struct sof *sof)
 {
 	int ret;
 
+#ifndef __ZEPHYR__
 	sof->platform_timer = &timer;
 	sof->cpu_timers = &timer;
+#endif
 
 #ifdef __ZEPHYR__
 	/* initialize cascade interrupts before any usage */

--- a/src/platform/imx8ulp/platform.c
+++ b/src/platform/imx8ulp/platform.c
@@ -124,10 +124,12 @@ const struct ext_man_windows xsram_window
 	}
 };
 
+#ifndef __ZEPHYR__
 static SHARED_DATA struct timer timer = {
 	.id = TIMER0, /* internal timer */
 	.irq = IRQ_NUM_TIMER0,
 };
+#endif
 
 int platform_boot_complete(uint32_t boot_message)
 {
@@ -149,8 +151,10 @@ int platform_init(struct sof *sof)
 {
 	int ret;
 
+#ifndef __ZEPHYR__
 	sof->platform_timer = &timer;
 	sof->cpu_timers = &timer;
+#endif
 
 	platform_interrupt_init();
 	platform_clock_init(sof);

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -268,6 +268,7 @@ const int n_iomux = ARRAY_SIZE(iomux_data);
 
 #endif
 
+#ifndef __ZEPHYR__
 static SHARED_DATA struct timer timer = {
 	.id = TIMER3, /* external timer */
 	.irq = IRQ_EXT_TSTAMP0_LVL2,
@@ -275,6 +276,7 @@ static SHARED_DATA struct timer timer = {
 };
 
 static SHARED_DATA struct timer arch_timers[CONFIG_CORE_COUNT];
+#endif
 
 #if CONFIG_DW_SPI
 
@@ -356,6 +358,7 @@ int platform_init(struct sof *sof)
 	int ret;
 	int i;
 
+#ifndef __ZEPHYR__
 	sof->platform_timer = cache_to_uncache(&timer);
 	sof->cpu_timers = (struct timer *)cache_to_uncache(&arch_timers);
 
@@ -364,6 +367,7 @@ int platform_init(struct sof *sof)
 			.id = TIMER1, /* internal timer */
 			.irq = IRQ_NUM_TIMER2,
 		};
+#endif
 
 	/* Turn off memory for all unused cores */
 	for (i = 0; i < CONFIG_CORE_COUNT; i++)
@@ -401,8 +405,7 @@ int platform_init(struct sof *sof)
 	scheduler_init_edf();
 
 	/* init low latency timer domain and scheduler */
-	sof->platform_timer_domain =
-		timer_domain_init(sof->platform_timer, PLATFORM_DEFAULT_CLOCK);
+	sof->platform_timer_domain = timer_domain_init(sof->platform_timer, PLATFORM_DEFAULT_CLOCK);
 	scheduler_init_ll(sof->platform_timer_domain);
 
 	/* init the system agent */

--- a/src/platform/library/lib/clk.c
+++ b/src/platform/library/lib/clk.c
@@ -2,6 +2,7 @@
 
 #include <sof/lib/clk.h>
 
+#ifndef __ZEPHYR__
 uint64_t clock_ms_to_ticks(int clock, uint64_t ms)
 {
 	return 0;
@@ -16,3 +17,4 @@ uint64_t clock_ns_to_ticks(int clock, uint64_t ns)
 {
 	return 0;
 }
+#endif /* __ZEPHYR__ */

--- a/src/platform/library/lib/clk.c
+++ b/src/platform/library/lib/clk.c
@@ -12,4 +12,9 @@ uint64_t clock_us_to_ticks(int clock, uint64_t us)
 	return 0;
 }
 
+uint64_t clock_ns_to_ticks(int clock, uint64_t ns)
+{
+	return 0;
+}
+
 void platform_timer_set_delta(struct timer *timer, uint64_t ns) {}

--- a/src/platform/library/lib/clk.c
+++ b/src/platform/library/lib/clk.c
@@ -16,5 +16,3 @@ uint64_t clock_ns_to_ticks(int clock, uint64_t ns)
 {
 	return 0;
 }
-
-void platform_timer_set_delta(struct timer *timer, uint64_t ns) {}

--- a/src/platform/library/platform.c
+++ b/src/platform/library/platform.c
@@ -13,7 +13,9 @@
 #include <sof/lib/mailbox.h>
 #include <sof/lib/dai.h>
 
+#ifndef __ZEPHYR__
 static SHARED_DATA struct timer timer = {};
+#endif /* __ZEPHYR__ */
 
 static uint8_t mailbox[MAILBOX_DSPBOX_SIZE +
 		       MAILBOX_HOSTBOX_SIZE +
@@ -36,8 +38,10 @@ int dmac_init(struct sof *sof)
 
 int platform_init(struct sof *sof)
 {
+#ifndef __ZEPHYR__
 	sof->platform_timer = &timer;
 	sof->cpu_timers = &timer;
+#endif
 
 	platform_clock_init(sof);
 

--- a/src/platform/mt8195/lib/clk.c
+++ b/src/platform/mt8195/lib/clk.c
@@ -82,11 +82,11 @@ static void clk_dsppll_enable(void)
 
 	io_reg_update_bits(AUDIODSP_CK_CG, 0x1 << RG_AUDIODSP_SW_CG, 0x0);
 	clk_setl(DSPPLL_CON4, PLL_PWR_ON);
-	wait_delay(clock_us_to_ticks(PLATFORM_DEFAULT_CLOCK, 1));
+	wait_delay_us(1);
 	clk_clrl(DSPPLL_CON4, PLL_ISO_EN);
-	wait_delay(clock_us_to_ticks(PLATFORM_DEFAULT_CLOCK, 1));
+	wait_delay_us(1);
 	clk_setl(DSPPLL_CON0, PLL_EN);
-	wait_delay(clock_us_to_ticks(PLATFORM_DEFAULT_CLOCK, 20));
+	wait_delay_us(20);
 	dsppll_enable = 1;
 }
 
@@ -95,9 +95,9 @@ static void clk_dsppll_disable(void)
 	tr_dbg(&clkdrv_tr, "clk_dsppll_disable\n");
 
 	clk_clrl(DSPPLL_CON0, PLL_EN);
-	wait_delay(clock_us_to_ticks(PLATFORM_DEFAULT_CLOCK, 1));
+	wait_delay_us(1);
 	clk_setl(DSPPLL_CON4, PLL_ISO_EN);
-	wait_delay(clock_us_to_ticks(PLATFORM_DEFAULT_CLOCK, 1));
+	wait_delay_us(1);
 	clk_clrl(DSPPLL_CON4, PLL_PWR_ON);
 	dsppll_enable = 0;
 }

--- a/src/probe/probe.c
+++ b/src/probe/probe.c
@@ -613,7 +613,7 @@ static int probe_gen_header(struct comp_buffer *buffer, uint32_t size,
 	uint32_t crc;
 
 	header = &_probe->header;
-	timestamp = platform_timer_get(timer_get());
+	timestamp = k_cycle_get_64();
 
 	header->sync_word = PROBE_EXTRACT_SYNC_WORD;
 	header->buffer_id = buffer->id;

--- a/src/samples/audio/kwd_nn_detect_test.c
+++ b/src/samples/audio/kwd_nn_detect_test.c
@@ -62,7 +62,6 @@ void kwd_nn_detect_test(struct comp_dev *dev,
 		if (test_keyword_get_input_size(dev) > one_sec_samples) {
 			uint64_t time_start;
 			uint64_t time_stop;
-			struct timer *timer = timer_get();
 			int result;
 			int i, j;
 
@@ -78,15 +77,14 @@ void kwd_nn_detect_test(struct comp_dev *dev,
 				 test_keyword_get_input_byte(dev, 6),
 				 test_keyword_get_input_byte(dev, 7)
 			);
-			time_start = platform_timer_get(timer);
+			time_start = k_cycle_get_64();
 			kwd_nn_preprocess_1s(test_keyword_get_input(dev), preprocessed_data);
 			kwd_nn_process_data(preprocessed_data, confidences);
 			result = kwd_nn_detect_postprocess(confidences);
-			time_stop = platform_timer_get(timer);
+			time_stop = k_cycle_get_64();
 			comp_dbg(dev,
 				 "KWD: kwd_nn_detect_test_copy() inference done in %u ms",
-				 (unsigned int)((time_stop - time_start)
-				 / clock_ms_to_ticks(PLATFORM_DEFAULT_CLOCK, 1)));
+				 (unsigned int)k_cyc_to_ms_near64(time_stop - time_start));
 			switch (result) {
 			case KWD_NN_YES_KEYWORD:
 			case KWD_NN_NO_KEYWORD:

--- a/src/schedule/dma_multi_chan_domain.c
+++ b/src/schedule/dma_multi_chan_domain.c
@@ -316,7 +316,7 @@ static bool dma_multi_chan_domain_is_pending(struct ll_schedule_domain *domain,
 				/* it's too soon for this task */
 				if (!pipe_task->registrable &&
 				    pipe_task->task.start >
-				    platform_timer_get_atomic(timer_get()))
+				    k_cycle_get_64_atomic())
 					continue;
 			}
 

--- a/src/schedule/dma_single_chan_domain.c
+++ b/src/schedule/dma_single_chan_domain.c
@@ -450,7 +450,7 @@ static void dma_single_chan_domain_set(struct ll_schedule_domain *domain,
 		return;
 
 	if (dma_domain->channel_changed) {
-		domain->next_tick = platform_timer_get_atomic(timer_get());
+		domain->next_tick = k_cycle_get_64_atomic();
 
 		dma_domain->channel_changed = false;
 	} else {
@@ -487,7 +487,7 @@ static void dma_single_chan_domain_clear(struct ll_schedule_domain *domain)
 static bool dma_single_chan_domain_is_pending(struct ll_schedule_domain *domain,
 					      struct task *task, struct comp_dev **comp)
 {
-	return task->start <= platform_timer_get_atomic(timer_get());
+	return task->start <= k_cycle_get_64_atomic();
 }
 
 /**

--- a/src/schedule/zephyr_domain.c
+++ b/src/schedule/zephyr_domain.c
@@ -47,7 +47,6 @@ struct zephyr_domain_thread {
 
 struct zephyr_domain {
 	struct k_timer timer;
-	struct timer *ll_timer;
 	struct zephyr_domain_thread domain_thread[CONFIG_CORE_COUNT];
 	struct ll_schedule_domain *ll_domain;
 };
@@ -229,7 +228,7 @@ static const struct ll_schedule_domain_ops zephyr_domain_ops = {
 	.domain_is_pending	= zephyr_domain_is_pending
 };
 
-struct ll_schedule_domain *zephyr_domain_init(struct timer *timer, int clk)
+struct ll_schedule_domain *zephyr_domain_init(int clk)
 {
 	struct ll_schedule_domain *domain;
 	struct zephyr_domain *zephyr_domain;
@@ -240,7 +239,6 @@ struct ll_schedule_domain *zephyr_domain_init(struct timer *timer, int clk)
 	zephyr_domain = rzalloc(SOF_MEM_ZONE_SYS_SHARED, 0, SOF_MEM_CAPS_RAM,
 				sizeof(*zephyr_domain));
 
-	zephyr_domain->ll_timer = timer;
 	zephyr_domain->ll_domain = domain;
 
 	ll_sch_domain_set_pdata(domain, zephyr_domain);

--- a/src/trace/trace.c
+++ b/src/trace/trace.c
@@ -74,9 +74,9 @@ static void put_header(void *dst, const struct sof_uuid_entry *uid,
 		       uint32_t id_1, uint32_t id_2,
 		       uint32_t entry, uint64_t timestamp)
 {
-	struct timer *timer = timer_get();
+	struct dma_trace_data *trace_data = dma_trace_data_get();
 	/* Support very early tracing */
-	uint64_t delta = timer ? timer->delta : 0;
+	uint64_t delta = dma_trace_initialized(trace_data) ? trace_data->time_delta : 0;
 	struct log_entry_header header;
 	int ret;
 
@@ -89,7 +89,6 @@ static void put_header(void *dst, const struct sof_uuid_entry *uid,
 
 	ret = memcpy_s(dst, sizeof(header), &header, sizeof(header));
 	assert(!ret);
-
 }
 
 #ifndef __ZEPHYR__

--- a/src/trace/trace.c
+++ b/src/trace/trace.c
@@ -243,8 +243,7 @@ static void dma_trace_log(bool send_atomic, uint32_t log_entry, const struct tr_
 	int i;
 
 	/* fill log content. arg_count is in the dictionary. */
-	put_header(data, ctx->uuid_p, id_1, id_2, log_entry,
-		   platform_safe_get_time(timer_get()));
+	put_header(data, ctx->uuid_p, id_1, id_2, log_entry, k_cycle_get_64_safe());
 
 	for (i = 0; i < arg_count; ++i)
 		data[PAYLOAD_OFFSET(i)] = va_arg(vargs, uint32_t);
@@ -285,7 +284,7 @@ void trace_log_filtered(bool send_atomic, const void *log_entry, const struct tr
 
 #if CONFIG_TRACE_FILTERING_ADAPTIVE
 	if (!trace->user_filter_override) {
-		const uint64_t current_ts = platform_safe_get_time(timer_get());
+		const uint64_t current_ts = k_cycle_get_64_safe();
 
 		emit_recent_entries(current_ts);
 
@@ -523,7 +522,7 @@ static void mtrace_dict_entry_vl(bool atomic_context, uint32_t dict_entry_addres
 	int i;
 	char packet[MESSAGE_SIZE(_TRACE_EVENT_MAX_ARGUMENT_COUNT)];
 	uint32_t *args = (uint32_t *)&packet[MESSAGE_SIZE(0)];
-	const uint64_t tstamp = platform_safe_get_time(timer_get());
+	const uint64_t tstamp = k_cycle_get_64_safe();
 
 	put_header(packet, dt_tr.uuid_p, _TRACE_INV_ID, _TRACE_INV_ID,
 		   dict_entry_address, tstamp);

--- a/test/cmocka/CMakeLists.txt
+++ b/test/cmocka/CMakeLists.txt
@@ -60,6 +60,7 @@ endif()
 if(CONFIG_CAVS)
 	target_include_directories(sof_options INTERFACE ${PROJECT_SOURCE_DIR}/src/platform/intel/cavs/include)
 endif()
+target_include_directories(sof_options INTERFACE ${PROJECT_SOURCE_DIR}/src/arch/xtos-wrapper/include)
 
 # linker script, just for log entries
 set(memory_mock_lds_in ${PROJECT_SOURCE_DIR}/test/cmocka/memory_mock.x.in)
@@ -107,7 +108,7 @@ function(cmocka_test test_name)
 	# Cmocka requires this define for stdint.h that defines uintptr
 	target_compile_definitions(${test_name} PRIVATE -D_UINTPTR_T_DEFINED)
 
-        # Enable features those would be disabled in some platforms
+	# Enable features those would be disabled in some platforms
 	target_compile_definitions(${test_name} PRIVATE -DCONFIG_NUMBERS_GCD -DCONFIG_NUMBERS_NORM -DCONFIG_NUMBERS_VECTOR_FIND)
 
 	# Skip running alloc test on HOST until it's fixed (it passes and is run

--- a/test/cmocka/src/common_mocks.c
+++ b/test/cmocka/src/common_mocks.c
@@ -32,7 +32,9 @@
 
 /* global contexts */
 WEAK struct ipc *_ipc;
+#ifndef __ZEPHYR__
 WEAK struct timer *platform_timer;
+#endif
 WEAK struct schedulers *schedulers;
 WEAK struct sof sof;
 WEAK struct tr_ctx buffer_tr;
@@ -330,6 +332,7 @@ int WEAK comp_set_state(struct comp_dev *dev, int cmd)
 	return 0;
 }
 
+#ifndef __ZEPHYR__
 uint64_t WEAK clock_ms_to_ticks(int clock, uint64_t ms)
 {
 	(void)clock;
@@ -353,6 +356,7 @@ uint64_t WEAK clock_ns_to_ticks(int clock, uint64_t us)
 
 	return 0;
 }
+#endif /* __ZEPHYR__ */
 
 #if CONFIG_MULTICORE && !CONFIG_LIBRARY
 

--- a/test/cmocka/src/common_mocks.c
+++ b/test/cmocka/src/common_mocks.c
@@ -228,6 +228,14 @@ void WEAK wait_delay(uint64_t number_of_clks)
 {
 }
 
+void WEAK wait_delay_ms(uint64_t ms)
+{
+}
+
+void WEAK wait_delay_us(uint64_t us)
+{
+}
+
 void WEAK xthal_icache_region_invalidate(void *addr, unsigned size)
 {
 }

--- a/test/cmocka/src/common_mocks.c
+++ b/test/cmocka/src/common_mocks.c
@@ -346,6 +346,14 @@ uint64_t WEAK clock_us_to_ticks(int clock, uint64_t us)
 	return 0;
 }
 
+uint64_t WEAK clock_ns_to_ticks(int clock, uint64_t us)
+{
+	(void)clock;
+	(void)us;
+
+	return 0;
+}
+
 #if CONFIG_MULTICORE && !CONFIG_LIBRARY
 
 int WEAK idc_send_msg(struct idc_msg *msg, uint32_t mode)

--- a/zephyr/include/sof/drivers/timer.h
+++ b/zephyr/include/sof/drivers/timer.h
@@ -1,0 +1,32 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2022 Intel Corporation. All rights reserved.
+ */
+
+#ifndef __SOF_DRIVERS_TIMER1_H__
+#define __SOF_DRIVERS_TIMER1_H__
+
+#include <stdint.h>
+#include <sof/lib/cpu.h>
+#include <sof/sof.h>
+#include <sof/platform.h>
+
+struct comp_dev;
+struct sof_ipc_stream_posn;
+
+#define k_cycle_get_64_safe()		k_cycle_get_64()
+#define k_cycle_get_64_atomic()		k_cycle_get_64()
+#define platform_timer_stop(x)
+
+/* get timestamp for host stream DMA position */
+void platform_host_timestamp(struct comp_dev *host,
+			     struct sof_ipc_stream_posn *posn);
+
+/* get timestamp for DAI stream DMA position */
+void platform_dai_timestamp(struct comp_dev *dai,
+			    struct sof_ipc_stream_posn *posn);
+
+/* get current wallclock for componnent */
+void platform_dai_wallclock(struct comp_dev *dai, uint64_t *wallclock);
+
+#endif /* __SOF_DRIVERS_TIMER_H1__ */

--- a/zephyr/include/sof/trace/trace.h
+++ b/zephyr/include/sof/trace/trace.h
@@ -32,10 +32,10 @@ uint64_t platform_timer_get(struct timer *timer);
 #undef mtrace_printf
 
 #if USE_PRINTK
-#define mtrace_printf(level, format, ...)				\
-	do {								        \
-		if ((level) <= SOF_ZEPHYR_TRACE_LEVEL)                          \
-			printk("%llu: " format "\n", platform_timer_get(NULL),	\
+#define mtrace_printf(level, format, ...)					\
+	do {									\
+		if ((level) <= SOF_ZEPHYR_TRACE_LEVEL)				\
+			printk("%llu: " format "\n", k_cycle_get_64(),		\
 				##__VA_ARGS__);					\
 	} while (0)
 #else


### PR DESCRIPTION
The purpose of this PR is to prepare the SOF to use zephyr timer API.

Added functions platform_timer_ticks_to_ms and platform_timer_ticks_to_us which allows convert the time expressed in ticks to seconds.

Waiting for a certain time has been simplified by adding a functions wait_delay_ms and wait_delay_us. Previously now, its required a conversion between time to ticks using clock_ms_to_ticks.

New functions platform_timer_timeout_calc_ms and platform_timer_timeout_calc_us simplify the timeout calculation.