### PR TITLE
topology: fix echo reference topologies.

### DIFF
--- a/tools/topology/topology1/sof-adl-nau8825.m4
+++ b/tools/topology/topology1/sof-adl-nau8825.m4
@@ -272,8 +272,13 @@ DAI_ADD(sof/pipe-dai-playback.m4,
         1, SSP, SPK_SSP_INDEX, SPK_SSP_NAME,
         PIPELINE_SOURCE_1, 2, s16le,
         1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
-# currently this dai is here as "virtual" capture backend
-W_DAI_IN(SSP, SPK_SSP_INDEX, SPK_SSP_NAME, s16le, 3, 0)
+
+# The echo refenrence pipeline has no connections in it,
+# it is used for the capture DAI widget to dock.
+DAI_ADD(sof/pipe-echo-ref-dai-capture.m4,
+	29, SSP, SPK_SSP_INDEX, SPK_SSP_NAME,
+	PIPELINE_SINK_29, 3, s16le,
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # Capture pipeline 9 from demux on PCM 6 using max 2 channels of s32le.
 PIPELINE_PCM_ADD(sof/pipe-passthrough-capture-sched.m4,

--- a/tools/topology/topology1/sof-apl-demux-pcm512x.m4
+++ b/tools/topology/topology1/sof-apl-demux-pcm512x.m4
@@ -113,8 +113,12 @@ DAI_ADD(sof/pipe-dai-playback.m4,
 	PIPELINE_SOURCE_1, 2, s24le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# currently this dai is here as "virtual" capture backend
-W_DAI_IN(SSP, 5, SSP5-Codec, s24le, 3, 0)
+# The echo refenrence pipeline has no connections in it,
+# it is used for the capture DAI widget to dock.
+DAI_ADD(sof/pipe-echo-ref-dai-capture.m4,
+	29, SSP, 5, SSP5-Codec,
+	PIPELINE_SINK_29, 3, s24le,
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # Capture pipeline 5 from demux on PCM 5 using max 2 channels of s32le.
 PIPELINE_PCM_ADD(sof/pipe-passthrough-capture-sched.m4,

--- a/tools/topology/topology1/sof-tgl-max98357a-rt5682.m4
+++ b/tools/topology/topology1/sof-tgl-max98357a-rt5682.m4
@@ -247,8 +247,13 @@ DAI_ADD(sof/pipe-dai-capture.m4,
 ',
 `
 ifdef(`2CH_2WAY',`# No echo reference for 2-way speakers',
-`# currently this dai is here as "virtual" capture backend
-W_DAI_IN(SSP, SPK_SSP_INDEX, SPK_SSP_NAME, FMT, 3, 0)
+`
+# The echo refenrence pipeline has no connections in it,
+# it is used for the capture DAI widget to dock.
+DAI_ADD(sof/pipe-echo-ref-dai-capture.m4,
+	29, SSP, SPK_SSP_INDEX, SPK_SSP_NAME,
+	PIPELINE_SINK_29, 3, FMT,
+	SPK_MIC_PERIOD_US, 0, SPK_PLAYBACK_CORE, SCHEDULE_TIME_DOMAIN_TIMER)
 
 `# Capture pipeline 9 from demux on PCM 6 using max 'ifdef(`4CH_PASSTHROUGH', `4', `2')` channels of s32le.'
 PIPELINE_PCM_ADD(sof/pipe-passthrough-capture-sched.m4,

--- a/tools/topology/topology1/sof/pipe-echo-ref-dai-capture.m4
+++ b/tools/topology/topology1/sof/pipe-echo-ref-dai-capture.m4
@@ -1,0 +1,23 @@
+#
+# The pipeline for echo reference feature, it is used
+# for the capture DAI to dock.
+#
+# No connections in this pipeline.
+#
+
+# Include topology builder
+include(`utils.m4')
+include(`dai.m4')
+include(`pipeline.m4')
+
+#
+# DAI definitions
+#
+W_DAI_IN(DAI_TYPE, DAI_INDEX, DAI_BE, DAI_FORMAT, DAI_PERIODS, 0, SCHEDULE_CORE)
+
+#
+# DAI pipeline - always use 0 for DAIs
+#
+W_PIPELINE(N_DAI_IN, SCHEDULE_PERIOD, SCHEDULE_PRIORITY, SCHEDULE_CORE, SCHEDULE_TIME_DOMAIN, pipe_dai_schedule_plat)
+
+indir(`define', concat(`PIPELINE_SCHED_COMP_', PIPELINE_ID), N_DAI_IN)


### PR DESCRIPTION
Two commits:
- Fix existing macro call to W_DAI_IN, which requires 7 parameters , but only 6 are given.
- Move virtual dai on echo ref pipeline to another pipeline, to avoid it's bad impact on pipeline walking in the kernel, which make echo reference cannot work. 

Special thanks to @ranj063 

Fixes: https://github.com/thesofproject/sof/issues/5395