### PR TITLE
dma-trace: Preserve logs while dtrace is disabled

### DIFF
--- a/src/trace/dma-trace.c
+++ b/src/trace/dma-trace.c
@@ -491,6 +491,8 @@ out:
 
 void dma_trace_disable(struct dma_trace_data *d)
 {
+	struct dma_trace_buf *buffer = &d->dmatb;
+
 	/* cancel trace work */
 	schedule_task_cancel(&d->dmat_work);
 
@@ -507,6 +509,14 @@ void dma_trace_disable(struct dma_trace_data *d)
 		d->host_size = 0;
 	}
 #endif
+
+	/*
+	 * Reset the local read and write pointers to preserve the captured logs
+	 * while the dtrace is disabed
+	 */
+	buffer->w_ptr = buffer->addr;
+	buffer->r_ptr = buffer->addr;
+	buffer->avail = 0;
 }
 
 /** Sends all pending DMA messages to mailbox (for emergencies) */


### PR DESCRIPTION
When the dma-trace is enabled (or re-enabled) the DMA channel is
re-initialized, configured.
The DMA will start reading data from the local buffer from the start (!!)
it can not be configured to start reading from the point it is left off.

Because of this, if the dtrace is disabled and re-enabled, the DMA will
copy old log entries starting from the beginning of the local buffer.

To be able to preserve the logs while the dtrace is disable we need to
reset both read and write pointers on the local buffer and when the dtrace
is again enabled we can transfer the logs from this point, without
misaligned or missed logs.

Signed-off-by: Peter Ujfalusi <peter.ujfalusi@linux.intel.com>