### PR TITLE
Backport "copy ipc config" to adl-004-drop-stable

### DIFF
--- a/src/audio/google_rtc_audio_processing.c
+++ b/src/audio/google_rtc_audio_processing.c
@@ -150,8 +150,11 @@ static struct comp_dev *google_rtc_audio_processing_create(
 
 	/* Create component device with an effect processing component */
 	dev = comp_alloc(drv, sizeof(*dev));
+
 	if (!dev)
 		return NULL;
+
+	dev->ipc_config = *config;
 
 	/* Create private component data */
 	cd = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM, sizeof(*cd));

--- a/src/audio/smart_amp/smart_amp.c
+++ b/src/audio/smart_amp/smart_amp.c
@@ -226,6 +226,8 @@ static struct comp_dev *smart_amp_new(const struct comp_driver *drv,
 	if (!dev)
 		return NULL;
 
+	dev->ipc_config = *config;
+
 	sad = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM, sizeof(*sad));
 	if (!sad) {
 		rfree(dev);


### PR DESCRIPTION
This backports PR #5382 to adl-004-drop-stable

Original description:
```
It appears in the conversion of the IPC API the copy in the smart amp
code was missed and as a result the component loses its ID which results
in the graph being broken and a crash on trigger. 
```
