### PR TITLE
ll_schedule: add a DSP load tracker to ll_tasks_execute

### DIFF
--- a/Kconfig.sof
+++ b/Kconfig.sof
@@ -171,6 +171,15 @@ config DEBUG_IPC_COUNTERS
 	help
 	  Select for enabling tracing IPC counter in SRAM_REG mailbox
 
+config SCHEDULE_LOG_CYCLE_STATISTICS
+	bool "Log cycles per tick statistics for each task separately"
+	default y
+	help
+	  Log DSP cycle usage statistics about once per second (1ms *
+	  1024) for each task separately. The printed data is task's
+	  meta information, average number of cycles/tick, and maximum
+	  number of cycles/tick during the previous 1024 tick period.
+
 config PERFORMANCE_COUNTERS
 	bool "Performance counters"
 	default n

--- a/src/include/sof/schedule/task.h
+++ b/src/include/sof/schedule/task.h
@@ -69,6 +69,8 @@ struct task {
 	struct task_ops ops;	/**< task operations */
 #ifdef __ZEPHYR__
 	struct k_work_delayable z_delayed_work;
+#endif
+#if defined(CONFIG_SCHEDULE_LOG_CYCLE_STATISTICS) || defined(__ZEPHYR__)
 	uint32_t cycles_sum;
 	uint32_t cycles_max;
 	uint32_t cycles_cnt;


### PR DESCRIPTION
Add a lightweight load calculatio to ll_tasks_execute() and prints out
the average every 2^10 runs (roughly once per second on most systems).

Example log output:
--cut--
[     6950848.421715] (      809129.187500) c0 ll-schedule        ./schedule/ll_schedule.c:139  INFO ll avg 19720/38400
[     8868838.449667] (      679100.000000) c0 ll-schedule        ./schedule/ll_schedule.c:139  INFO ll avg 19658/38400
[    10802857.643650] (      565147.187500) c0 ll-schedule        ./schedule/ll_schedule.c:139  INFO ll avg 19822/38400
--cut--

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>