### PR TITLE
[SKIP CI] .github: switch to new xtensa-build-zephyr.py

### DIFF
--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -20,4 +20,5 @@ jobs:
       - name: build
         run: docker run -v "$(pwd)":/workdir
              docker.io/zephyrprojectrtos/zephyr-build:latest
-             ./zephyr/docker-build.sh -- -DEXTRA_CFLAGS='-Werror'
+             ./zephyr/docker-build.sh --cmake-args=-DEXTRA_CFLAGS=-Werror
+             --cmake-args=--warn-uninitialized   -a

--- a/zephyr/docker-build.sh
+++ b/zephyr/docker-build.sh
@@ -13,10 +13,7 @@ set -x
 unset ZEPHYR_BASE
 
 # Make sure we're in the right place; chgrp -R below.
-test -e ./scripts/xtensa-build-zephyr.sh
-
-sudo apt-get update
-sudo apt-get -y install tree
+test -e ./scripts/xtensa-build-zephyr.py
 
 # As of container version 0.18.4,
 # https://github.com/zephyrproject-rtos/docker-image/blob/master/Dockerfile
@@ -29,12 +26,12 @@ ls -ld /opt/toolchains/zephyr-sdk-*
 ln -s  /opt/toolchains/zephyr-sdk-*  ~/
 
 if test -e zephyrproject; then
-    ./scripts/xtensa-build-zephyr.sh -a "$@"
-else
+    ./scripts/xtensa-build-zephyr.py  "$@"
+else # -c(lone) with west init etc.
     # Matches docker.io/zephyrprojectrtos/zephyr-build:latest gid
     ls -ln | head
     stat .
     sudo chgrp -R 1000 .
     sudo chmod -R g+rwX .
-    ./scripts/xtensa-build-zephyr.sh -a -c "$@"
+    ./scripts/xtensa-build-zephyr.py -c "$@"
 fi


### PR DESCRIPTION
Switch Github Actions away from older shell script.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>