### PR TITLE
Restore Zephyr version in banner, fix 'zephyr:BUILD_VERSION'

### DIFF
--- a/src/trace/dma-trace.c
+++ b/src/trace/dma-trace.c
@@ -28,6 +28,10 @@
 #include <user/abi_dbg.h>
 #include <sof_versions.h>
 
+#ifdef __ZEPHYR__
+#include <version.h>
+#endif
+
 #include <errno.h>
 #include <stddef.h>
 #include <stdint.h>


### PR DESCRIPTION
This fixes the banner which was recently added by SOF commit
a053e04d7ee1 ("trace: add Zephyr git version to the initial FW ABI
banner")
```
  SHM: FW ABI ... tags SOF:v1.2.3 zephyr:zephyr-v3.0.0-346-g1470228eb10
```
... but was broken very soon after by Zephyr commit [91709778a487](https://github.com/zephyrproject-rtos/zephyr/commits/91709778a487) ("cmake:
version.h generation performed at build time")
```
  SHM: FW ABI ... tags SOF:v1.2.3 zephyr:BUILD_VERSION
```
Signed-off-by: Marc Herbert <marc.herbert@intel.com>