### PR TITLE
Revert "dma-trace: Preserve logs while dtrace is disabled"

### DIFF
--- a/src/trace/dma-trace.c
+++ b/src/trace/dma-trace.c
@@ -491,8 +491,6 @@ out:
 
 void dma_trace_disable(struct dma_trace_data *d)
 {
-	struct dma_trace_buf *buffer = &d->dmatb;
-
 	/* cancel trace work */
 	schedule_task_cancel(&d->dmat_work);
 
@@ -509,14 +507,6 @@ void dma_trace_disable(struct dma_trace_data *d)
 		d->host_size = 0;
 	}
 #endif
-
-	/*
-	 * Reset the local read and write pointers to preserve the captured logs
-	 * while the dtrace is disabed
-	 */
-	buffer->w_ptr = buffer->addr;
-	buffer->r_ptr = buffer->addr;
-	buffer->avail = 0;
 }
 
 /** Sends all pending DMA messages to mailbox (for emergencies) */


### PR DESCRIPTION
This reverts commit 58ce6e68608fdbec49a9835dfb8b76e0fa848187.

This commit has caused the DMA trace to be frequently empty on a number
of ADL and TGL in daily runs for two days in a row (test runs 10429 and
10459).

The DMA trace could be completely empty in the past but that was on
different platforms and a very long time ago, this had been fixed in
bug #4333 and had not happened for many months.

The _only_ commit difference between the last successful test
run (10402) and the first failing one (10459) is this commit.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>