### PR TITLE
[WIP] sof: replace log calls with zephyr logging api

### DIFF
--- a/Kconfig.sof
+++ b/Kconfig.sof
@@ -125,6 +125,10 @@ if !ZEPHYR_SOF_MODULE
 	rsource "Kconfig.xtos-build"
 endif
 
+if ZEPHYR_SOF_MODULE
+	rsource "Kconfig.zephyr-log"
+endif
+
 menu "Debug"
 
 config DEBUG

--- a/Kconfig.zephyr-log
+++ b/Kconfig.zephyr-log
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+
+menu "Logging"
+
+config LOG
+	bool "Enable logging"
+	default y
+	help
+	  Select for log support
+
+choice "SOF_LOG_LEVEL_CHOICE"
+	prompt "Max compiled-in log level for SOF"
+	default SOF_LOG_LEVEL_INF
+	depends on LOG
+
+config SOF_LOG_LEVEL_OFF
+	bool "Off"
+	help
+	  Set log level to off
+
+config SOF_LOG_LEVEL_ERR
+	bool "Error"
+	help
+	  Set log level to error
+
+config SOF_LOG_LEVEL_WRN
+	bool "Warning"
+	help
+	  Set log level to warning
+
+config SOF_LOG_LEVEL_INF
+	bool "Info"
+	help
+	  Set log level to info
+
+config SOF_LOG_LEVEL_DBG
+	bool "Debug"
+	help
+	  Set log level to debug
+
+endchoice
+
+config SOF_LOG_LEVEL
+	int
+	depends on LOG
+	default 0 if SOF_LOG_LEVEL_OFF
+	default 1 if SOF_LOG_LEVEL_ERR
+	default 2 if SOF_LOG_LEVEL_WRN
+	default 3 if SOF_LOG_LEVEL_INF
+	default 4 if SOF_LOG_LEVEL_DBG
+
+endmenu

--- a/src/audio/asrc/asrc.c
+++ b/src/audio/asrc/asrc.c
@@ -53,6 +53,8 @@ typedef void (*asrc_proc_func)(struct comp_dev *dev,
 
 static const struct comp_driver comp_asrc;
 
+LOG_MODULE_REGISTER(asrc, CONFIG_SOF_LOG_LEVEL);
+
 #ifndef CONFIG_IPC_MAJOR_4
 /* c8ec72f6-8526-4faf-9d39-a23d0b541de2 */
 DECLARE_SOF_RT_UUID("asrc", asrc_uuid, 0xc8ec72f6, 0x8526, 0x4faf,

--- a/src/audio/asrc/asrc_farrow.c
+++ b/src/audio/asrc/asrc_farrow.c
@@ -15,6 +15,8 @@
 #include <sof/audio/asrc/asrc_config.h>
 #include <sof/audio/asrc/asrc_farrow.h>
 
+LOG_MODULE_DECLARE(asrc, CONFIG_SOF_LOG_LEVEL);
+
 #define CONVERT_COEFF(x) ((int32_t)(x))
 
 /* Rate skew in Q2.30 format can be 0.5 - 2.0 x rate */

--- a/src/audio/asrc/asrc_farrow_generic.c
+++ b/src/audio/asrc/asrc_farrow_generic.c
@@ -9,6 +9,8 @@
 #include <sof/audio/asrc/asrc_farrow.h>
 #include <sof/audio/format.h>
 
+LOG_MODULE_DECLARE(asrc, CONFIG_SOF_LOG_LEVEL);
+
 void asrc_fir_filter16(struct asrc_farrow *src_obj, int16_t **output_buffers,
 		       int index_output_frame)
 {

--- a/src/audio/asrc/asrc_farrow_hifi3.c
+++ b/src/audio/asrc/asrc_farrow_hifi3.c
@@ -9,6 +9,8 @@
 
 #include <xtensa/tie/xt_hifi3.h>
 
+LOG_MODULE_DECLARE(asrc, CONFIG_SOF_LOG_LEVEL);
+
 void asrc_fir_filter16(struct asrc_farrow *src_obj, int16_t **output_buffers,
 		       int index_output_frame)
 {

--- a/src/audio/base_fw.c
+++ b/src/audio/base_fw.c
@@ -8,6 +8,8 @@
 #include <ipc4/pipeline.h>
 #include <sof_versions.h>
 
+LOG_MODULE_REGISTER(basefw, CONFIG_SOF_LOG_LEVEL);
+
 /* 0e398c32-5ade-ba4b-93b1-c50432280ee4 */
 DECLARE_SOF_RT_UUID("basefw", basefw_comp_uuid, 0xe398c32, 0x5ade, 0xba4b,
 		    0x93, 0xb1, 0xc5, 0x04, 0x32, 0x28, 0x0e, 0xe4);

--- a/src/audio/buffer.c
+++ b/src/audio/buffer.c
@@ -19,6 +19,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+LOG_MODULE_REGISTER(buffer, CONFIG_SOF_LOG_LEVEL);
+
 /* 42544c92-8e92-4e41-b679-34519f1c1d28 */
 DECLARE_SOF_RT_UUID("buffer", buffer_uuid, 0x42544c92, 0x8e92, 0x4e41,
 		 0xb6, 0x79, 0x34, 0x51, 0x9f, 0x1c, 0x1d, 0x28);

--- a/src/audio/channel_map.c
+++ b/src/audio/channel_map.c
@@ -14,6 +14,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+LOG_MODULE_REGISTER(channel_map, CONFIG_SOF_LOG_LEVEL);
+
 /* ec290e95-4a20-47eb-bbff-d9c888431831 */
 DECLARE_SOF_UUID("channel-map", chmap_uuid, 0xec290e95, 0x4a20, 0x47eb,
 		 0xbb, 0xff, 0xd9, 0xc8, 0x88, 0x43, 0x18, 0x31);

--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -21,6 +21,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+LOG_MODULE_REGISTER(component, CONFIG_SOF_LOG_LEVEL);
+
 static SHARED_DATA struct comp_driver_list cd;
 
 /* 7c42ce8b-0108-43d0-9137-56d660478c5f */

--- a/src/audio/copier.c
+++ b/src/audio/copier.c
@@ -38,6 +38,8 @@
 
 static const struct comp_driver comp_copier;
 
+LOG_MODULE_REGISTER(copier, CONFIG_SOF_LOG_LEVEL);
+
 /* this id aligns windows driver requirement to support windows driver */
 /* 9ba00c83-ca12-4a83-943c-1fa2e82f9dda */
 DECLARE_SOF_RT_UUID("copier", copier_comp_uuid, 0x9ba00c83, 0xca12, 0x4a83,

--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -35,6 +35,8 @@
 
 static const struct comp_driver comp_dai;
 
+LOG_MODULE_REGISTER(comp_dai, CONFIG_SOF_LOG_LEVEL);
+
 /* c2b00d27-ffbc-4150-a51a-245c79c5e54b */
 DECLARE_SOF_RT_UUID("dai", dai_comp_uuid, 0xc2b00d27, 0xffbc, 0x4150,
 		 0xa5, 0x1a, 0x24, 0x5c, 0x79, 0xc5, 0xe5, 0x4b);

--- a/src/audio/dcblock/dcblock.c
+++ b/src/audio/dcblock/dcblock.c
@@ -31,6 +31,8 @@
 
 static const struct comp_driver comp_dcblock;
 
+LOG_MODULE_REGISTER(dcblock, CONFIG_SOF_LOG_LEVEL);
+
 /* b809efaf-5681-42b1-9ed6-04bb012dd384 */
 DECLARE_SOF_RT_UUID("dcblock", dcblock_uuid, 0xb809efaf, 0x5681, 0x42b1,
 		 0x9e, 0xd6, 0x04, 0xbb, 0x01, 0x2d, 0xd3, 0x84);

--- a/src/audio/dcblock/dcblock_generic.c
+++ b/src/audio/dcblock/dcblock_generic.c
@@ -9,6 +9,8 @@
 #include <sof/audio/format.h>
 #include <sof/audio/dcblock/dcblock.h>
 
+LOG_MODULE_DECLARE(dcblock, CONFIG_SOF_LOG_LEVEL);
+
 /**
  *
  * Genereric processing function. Input is 32 bits.

--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -36,6 +36,8 @@
 
 static const struct comp_driver comp_eq_fir;
 
+LOG_MODULE_REGISTER(eq_fir, CONFIG_SOF_LOG_LEVEL);
+
 /* 43a90ce7-f3a5-41df-ac06-ba98651ae6a3 */
 DECLARE_SOF_RT_UUID("eq-fir", eq_fir_uuid, 0x43a90ce7, 0xf3a5, 0x41df,
 		 0xac, 0x06, 0xba, 0x98, 0x65, 0x1a, 0xe6, 0xa3);

--- a/src/audio/eq_fir/eq_fir_generic.c
+++ b/src/audio/eq_fir/eq_fir_generic.c
@@ -16,6 +16,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+LOG_MODULE_DECLARE(eq_fir, CONFIG_SOF_LOG_LEVEL);
+
 #if CONFIG_FORMAT_S16LE
 void eq_fir_s16(struct fir_state_32x16 fir[], const struct audio_stream *source,
 		struct audio_stream *sink, int frames, int nch)

--- a/src/audio/eq_fir/eq_fir_hifi2ep.c
+++ b/src/audio/eq_fir/eq_fir_hifi2ep.c
@@ -18,6 +18,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+LOG_MODULE_DECLARE(eq_fir, CONFIG_SOF_LOG_LEVEL);
+
 #if CONFIG_FORMAT_S32LE
 /* For even frame lengths use FIR filter that processes two sequential
  * sample per call.

--- a/src/audio/eq_fir/eq_fir_hifi3.c
+++ b/src/audio/eq_fir/eq_fir_hifi3.c
@@ -17,6 +17,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+LOG_MODULE_DECLARE(eq_fir, CONFIG_SOF_LOG_LEVEL);
+
 #if CONFIG_FORMAT_S32LE
 /* For even frame lengths use FIR filter that processes two sequential
  * sample per call.

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -35,6 +35,8 @@
 
 static const struct comp_driver comp_eq_iir;
 
+LOG_MODULE_REGISTER(eq_iir, CONFIG_SOF_LOG_LEVEL);
+
 /* 5150c0e6-27f9-4ec8-8351-c705b642d12f */
 DECLARE_SOF_RT_UUID("eq-iir", eq_iir_uuid, 0x5150c0e6, 0x27f9, 0x4ec8,
 		 0x83, 0x51, 0xc7, 0x05, 0xb6, 0x42, 0xd1, 0x2f);

--- a/src/audio/google_hotword_detect.c
+++ b/src/audio/google_hotword_detect.c
@@ -40,6 +40,8 @@
 
 static const struct comp_driver ghd_driver;
 
+LOG_MODULE_REGISTER(google_hotword_detect, CONFIG_SOF_LOG_LEVEL);
+
 /* c3c74249-058e-414f-8240-4da5f3fc2389 */
 DECLARE_SOF_RT_UUID("google-hotword-detect", ghd_uuid,
 		    0xc3c74249, 0x058e, 0x414f,

--- a/src/audio/google_rtc_audio_processing.c
+++ b/src/audio/google_rtc_audio_processing.c
@@ -35,6 +35,8 @@
 
 #define GOOGLE_RTC_AUDIO_PROCESSING_SAMPLERATE 48000
 
+LOG_MODULE_REGISTER(google_rtc_audio_processing, CONFIG_SOF_LOG_LEVEL);
+
 /* b780a0a6-269f-466f-b477-23dfa05af758 */
 DECLARE_SOF_RT_UUID("google-rtc-audio-processing", google_rtc_audio_processing_uuid,
 					0xb780a0a6, 0x269f, 0x466f, 0xb4, 0x77, 0x23, 0xdf, 0xa0,

--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -34,6 +34,8 @@
 
 static const struct comp_driver comp_host;
 
+LOG_MODULE_REGISTER(host, CONFIG_SOF_LOG_LEVEL);
+
 /* 8b9d100c-6d78-418f-90a3-e0e805d0852b */
 DECLARE_SOF_RT_UUID("host", host_uuid, 0x8b9d100c, 0x6d78, 0x418f,
 		 0x90, 0xa3, 0xe0, 0xe8, 0x05, 0xd0, 0x85, 0x2b);

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -48,6 +48,8 @@
 
 static const struct comp_driver comp_kpb;
 
+LOG_MODULE_REGISTER(kpb, CONFIG_SOF_LOG_LEVEL);
+
 /* d8218443-5ff3-4a4c-b388-6cfe07b9562e */
 DECLARE_SOF_RT_UUID("kpb", kpb_uuid, 0xd8218443, 0x5ff3, 0x4a4c,
 		 0xb3, 0x88, 0x6c, 0xfe, 0x07, 0xb9, 0x56, 0x2e);

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -32,6 +32,8 @@
 
 static const struct comp_driver comp_mixer;
 
+LOG_MODULE_REGISTER(mixer, CONFIG_SOF_LOG_LEVEL);
+
 #if CONFIG_IPC_MAJOR_3
 /* bc06c037-12aa-417c-9a97-89282e321a76 */
 DECLARE_SOF_RT_UUID("mixer", mixer_uuid, 0xbc06c037, 0x12aa, 0x417c,

--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -33,6 +33,8 @@
 
 static const struct comp_driver comp_mux;
 
+LOG_MODULE_REGISTER(mux_demux, CONFIG_SOF_LOG_LEVEL);
+
 /* c607ff4d-9cb6-49dc-b678-7da3c63ea557 */
 DECLARE_SOF_RT_UUID("mux", mux_uuid, 0xc607ff4d, 0x9cb6, 0x49dc,
 		 0xb6, 0x78, 0x7d, 0xa3, 0xc6, 0x3e, 0xa5, 0x57);

--- a/src/audio/mux/mux_generic.c
+++ b/src/audio/mux/mux_generic.c
@@ -16,6 +16,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+LOG_MODULE_DECLARE(mux_demux, CONFIG_SOF_LOG_LEVEL);
+
 static void mux_check_for_wrap(struct audio_stream *sink,
 			       const struct audio_stream **sources,
 			       struct mux_look_up *lookup)

--- a/src/audio/pipeline/pipeline-graph.c
+++ b/src/audio/pipeline/pipeline-graph.c
@@ -23,6 +23,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+LOG_MODULE_REGISTER(pipe, CONFIG_SOF_LOG_LEVEL);
+
 /* 4e934adb-b0ec-4d33-a086-c1022f921321 */
 DECLARE_SOF_RT_UUID("pipe", pipe_uuid, 0x4e934adb, 0xb0ec, 0x4d33,
 		    0xa0, 0x86, 0xc1, 0x02, 0x2f, 0x92, 0x13, 0x21);

--- a/src/audio/pipeline/pipeline-params.c
+++ b/src/audio/pipeline/pipeline-params.c
@@ -19,6 +19,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+LOG_MODULE_DECLARE(pipe, CONFIG_SOF_LOG_LEVEL);
+
 static int pipeline_comp_params_neg(struct comp_dev *current,
 				    struct comp_buffer *calling_buf,
 				    struct pipeline_walk_context *ctx,

--- a/src/audio/pipeline/pipeline-schedule.c
+++ b/src/audio/pipeline/pipeline-schedule.c
@@ -24,6 +24,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+LOG_MODULE_DECLARE(pipe, CONFIG_SOF_LOG_LEVEL);
+
 /* f11818eb-e92e-4082-82a3-dc54c604ebb3 */
 DECLARE_SOF_UUID("pipe-task", pipe_task_uuid, 0xf11818eb, 0xe92e, 0x4082,
 		 0x82,  0xa3, 0xdc, 0x54, 0xc6, 0x04, 0xeb, 0xb3);

--- a/src/audio/pipeline/pipeline-stream.c
+++ b/src/audio/pipeline/pipeline-stream.c
@@ -20,6 +20,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+LOG_MODULE_DECLARE(pipe, CONFIG_SOF_LOG_LEVEL);
+
 /*
  * Check whether pipeline is incapable of acquiring data for capture.
  *

--- a/src/audio/pipeline/pipeline-xrun.c
+++ b/src/audio/pipeline/pipeline-xrun.c
@@ -20,6 +20,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+LOG_MODULE_DECLARE(pipe, CONFIG_SOF_LOG_LEVEL);
+
 /*
  * This flag disables firmware-side xrun recovery.
  * It should remain enabled in the situation when the

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -38,6 +38,8 @@
 
 static const struct comp_driver comp_selector;
 
+LOG_MODULE_REGISTER(selector, CONFIG_SOF_LOG_LEVEL);
+
 /* 55a88ed5-3d18-46ca-88f1-0ee6eae9930f */
 DECLARE_SOF_RT_UUID("selector", selector_uuid, 0x55a88ed5, 0x3d18, 0x46ca,
 		 0x88, 0xf1, 0x0e, 0xe6, 0xea, 0xe9, 0x93, 0x0f);

--- a/src/audio/selector/selector_generic.c
+++ b/src/audio/selector/selector_generic.c
@@ -18,6 +18,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+LOG_MODULE_DECLARE(selector, CONFIG_SOF_LOG_LEVEL);
+
 #define BYTES_TO_S16_SAMPLES	1
 #define BYTES_TO_S32_SAMPLES	2
 

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -53,6 +53,9 @@
 #define MAX_OUT_DELAY_SIZE_XNCH (PLATFORM_MAX_CHANNELS * MAX_OUT_DELAY_SIZE)
 
 static const struct comp_driver comp_src;
+
+LOG_MODULE_REGISTER(src, CONFIG_SOF_LOG_LEVEL);
+
 #if CONFIG_IPC_MAJOR_4
 /* e61bb28d-149a-4c1f-b709-46823ef5f5a3 */
 DECLARE_SOF_RT_UUID("src", src_uuid, 0xe61bb28d, 0x149a, 0x4c1f,

--- a/src/audio/src/src_hifi4.c
+++ b/src/audio/src/src_hifi4.c
@@ -17,6 +17,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+LOG_MODULE_DECLARE(src, CONFIG_SOF_LOG_LEVEL);
+
 /* HiFi4 has
  * 16x 64 bit registers in register file AE_DR
  */

--- a/src/audio/switch.c
+++ b/src/audio/switch.c
@@ -16,6 +16,8 @@
 
 static const struct comp_driver comp_switch;
 
+LOG_MODULE_REGISTER(switch, CONFIG_SOF_LOG_LEVEL);
+
 /* 385cc44b-f34e-4b9b-8be0-535c5f43a825 */
 DECLARE_SOF_RT_UUID("switch", switch_uuid, 0x385cc44b, 0xf34e, 0x4b9b,
 		 0x8b, 0xe0, 0x53, 0x5c, 0x5f, 0x43, 0xa8, 0x25);

--- a/src/audio/tone.c
+++ b/src/audio/tone.c
@@ -46,6 +46,8 @@
 
 static const struct comp_driver comp_tone;
 
+LOG_MODULE_REGISTER(tone, CONFIG_SOF_LOG_LEVEL);
+
 /* 04e3f894-2c5c-4f2e-8dc1-694eeaab53fa */
 DECLARE_SOF_RT_UUID("tone", tone_uuid, 0x04e3f894, 0x2c5c, 0x4f2e,
 		 0x8d, 0xc1, 0x69, 0x4e, 0xea, 0xab, 0x53, 0xfa);

--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -46,6 +46,8 @@
 
 static const struct comp_driver comp_volume;
 
+LOG_MODULE_REGISTER(volume, CONFIG_SOF_LOG_LEVEL);
+
 #if CONFIG_IPC_MAJOR_3
 /* b77e677e-5ff4-4188-af14-fba8bdbf8682 */
 DECLARE_SOF_RT_UUID("pga", volume_uuid, 0xb77e677e, 0x5ff4, 0x4188,

--- a/src/audio/volume/volume_generic.c
+++ b/src/audio/volume/volume_generic.c
@@ -26,6 +26,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+LOG_MODULE_DECLARE(volume, CONFIG_SOF_LOG_LEVEL);
+
 #if CONFIG_FORMAT_S24LE
 /**
  * \brief Volume s24 to s24 multiply function

--- a/src/audio/volume/volume_hifi3.c
+++ b/src/audio/volume/volume_hifi3.c
@@ -23,6 +23,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+LOG_MODULE_DECLARE(volume, CONFIG_SOF_LOG_LEVEL);
+
 /**
  * \brief store volume gain 4 times for xtensa multi-way intrinsic operations.
  * Simultaneous processing 2 data.

--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -44,6 +44,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+LOG_MODULE_REGISTER(dw_dma, CONFIG_SOF_LOG_LEVEL);
+
 /* 298873bc-d532-4d93-a540-95ee6bcf3456 */
 DECLARE_SOF_UUID("dw-dma", dw_dma_uuid, 0x298873bc, 0xd532, 0x4d93,
 		 0xa5, 0x40, 0x95, 0xee, 0x6b, 0xcf, 0x34, 0x56);

--- a/src/drivers/generic/dummy-dma.c
+++ b/src/drivers/generic/dummy-dma.c
@@ -46,6 +46,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+LOG_MODULE_REGISTER(dummy_dma, CONFIG_SOF_LOG_LEVEL);
+
 /* f6d15ad3-b122-458c-ae9b-0ab0b5867aa0 */
 DECLARE_SOF_UUID("dummy-dma", dummy_dma_uuid, 0xf6d15ad3, 0xb122, 0x458c,
 		 0xae, 0x9b, 0x0a, 0xb0, 0xb5, 0x86, 0x7a, 0xa0);

--- a/src/drivers/imx/edma.c
+++ b/src/drivers/imx/edma.c
@@ -19,6 +19,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+LOG_MODULE_REGISTER(edma, CONFIG_SOF_LOG_LEVEL);
+
 /* 3d73a110-0930-457f-be51-34453e56287b */
 DECLARE_SOF_UUID("edma", edma_uuid, 0x3d73a110, 0x0930, 0x457f,
 		 0xbe, 0x51, 0x34, 0x45, 0x3e, 0x56, 0x28, 0x7b);

--- a/src/drivers/imx/esai.c
+++ b/src/drivers/imx/esai.c
@@ -18,6 +18,8 @@
 #include <errno.h>
 #include <stdint.h>
 
+LOG_MODULE_REGISTER(esai, CONFIG_SOF_LOG_LEVEL);
+
 /* 889f6dcd-ddcd-4e05-aa5b-0d39f8bca961 */
 DECLARE_SOF_UUID("esai", esai_uuid, 0x889f6dcd, 0xddcd, 0x4e05,
 		 0xaa, 0x5b, 0x0d, 0x39, 0xf8, 0xbc, 0xa9, 0x61);

--- a/src/drivers/imx/interrupt-generic.c
+++ b/src/drivers/imx/interrupt-generic.c
@@ -18,6 +18,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+LOG_MODULE_REGISTER(generic_irq_imx, CONFIG_SOF_LOG_LEVEL);
+
 /* fa00558c-d653-4851-a03a-b21f125a9524 */
 DECLARE_SOF_UUID("generic-irq-imx", generic_irq_imx_uuid, 0xfa00558c, 0xd653, 0x4851,
 		 0xa0, 0x3a, 0xb2, 0x1f, 0x12, 0x5a, 0x95, 0x24);

--- a/src/drivers/imx/interrupt-irqsteer.c
+++ b/src/drivers/imx/interrupt-irqsteer.c
@@ -19,6 +19,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+LOG_MODULE_REGISTER(irq_imx, CONFIG_SOF_LOG_LEVEL);
+
 /* fa00558c-d653-4851-a03a-b21f125a9524 */
 DECLARE_SOF_UUID("irq-imx", irq_imx_uuid, 0xfa00558c, 0xd653, 0x4851,
 		 0xa0, 0x3a, 0xb2, 0x1f, 0x12, 0x5a, 0x95, 0x24);

--- a/src/drivers/imx/ipc.c
+++ b/src/drivers/imx/ipc.c
@@ -31,6 +31,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+LOG_MODULE_REGISTER(ipc_task, CONFIG_SOF_LOG_LEVEL);
+
 /* 389c9186-5a7d-4ad1-a02c-a02ecdadfb33 */
 DECLARE_SOF_UUID("ipc-task", ipc_task_uuid, 0x389c9186, 0x5a7d, 0x4ad1,
 		 0xa0, 0x2c, 0xa0, 0x2e, 0xcd, 0xad, 0xfb, 0x33);

--- a/src/drivers/imx/sai.c
+++ b/src/drivers/imx/sai.c
@@ -18,6 +18,8 @@
 #include <errno.h>
 #include <stdint.h>
 
+LOG_MODULE_REGISTER(sai, CONFIG_SOF_LOG_LEVEL);
+
 /* 9302adf5-88be-4234-a0a7-dca538ef81f4 */
 DECLARE_SOF_UUID("sai", sai_uuid, 0x9302adf5, 0x88be, 0x4234,
 		 0xa0, 0xa7, 0xdc, 0xa5, 0x38, 0xef, 0x81, 0xf4);

--- a/src/drivers/imx/sdma.c
+++ b/src/drivers/imx/sdma.c
@@ -18,6 +18,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+LOG_MODULE_REGISTER(sdma, CONFIG_SOF_LOG_LEVEL);
+
 /* 70d223ef-2b91-4aac-b444-d89a0db2793a */
 DECLARE_SOF_UUID("sdma", sdma_uuid, 0x70d223ef, 0x2b91, 0x4aac,
 		 0xb4, 0x44, 0xd8, 0x9a, 0x0d, 0xb2, 0x79, 0x3a);

--- a/src/drivers/intel/alh.c
+++ b/src/drivers/intel/alh.c
@@ -18,6 +18,8 @@
 #include <stdint.h>
 #include <ipc4/alh.h>
 
+LOG_MODULE_REGISTER(alh, CONFIG_SOF_LOG_LEVEL);
+
 /* a8e4218c-e863-4c93-84e7-5c27d2504501 */
 DECLARE_SOF_UUID("alh-dai", alh_uuid, 0xa8e4218c, 0xe863, 0x4c93,
 		 0x84, 0xe7, 0x5c, 0x27, 0xd2, 0x50, 0x45, 0x01);

--- a/src/drivers/intel/cavs/ipc.c
+++ b/src/drivers/intel/cavs/ipc.c
@@ -28,6 +28,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+LOG_MODULE_REGISTER(ipc_task, CONFIG_SOF_LOG_LEVEL);
+
 /* 8fa1d42f-bc6f-464b-867f-547af08834da */
 DECLARE_SOF_UUID("ipc-task", ipc_task_uuid, 0x8fa1d42f, 0xbc6f, 0x464b,
 		 0x86, 0x7f, 0x54, 0x7a, 0xf0, 0x88, 0x34, 0xda);

--- a/src/drivers/intel/cavs/timestamp.c
+++ b/src/drivers/intel/cavs/timestamp.c
@@ -16,6 +16,8 @@
 #include <errno.h>
 #include <stdint.h>
 
+LOG_MODULE_REGISTER(dai_ts, CONFIG_SOF_LOG_LEVEL);
+
 int timestamp_hda_config(struct dai *dai, struct timestamp_cfg *cfg)
 {
 	int i;

--- a/src/drivers/intel/dmic/dmic.c
+++ b/src/drivers/intel/dmic/dmic.c
@@ -35,6 +35,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+LOG_MODULE_REGISTER(dmic, CONFIG_SOF_LOG_LEVEL);
+
 /* aafc26fe-3b8d-498d-8bd6-248fc72efa31 */
 DECLARE_SOF_UUID("dmic-dai", dmic_uuid, 0xaafc26fe, 0x3b8d, 0x498d,
 		 0x8b, 0xd6, 0x24, 0x8f, 0xc7, 0x2e, 0xfa, 0x31);

--- a/src/drivers/intel/dmic/dmic_computed.c
+++ b/src/drivers/intel/dmic/dmic_computed.c
@@ -16,6 +16,8 @@
 /* Decimation filters */
 #include <sof/audio/coefficients/pdm_decim/pdm_decim_table.h>
 
+LOG_MODULE_DECLARE(dmic, CONFIG_SOF_LOG_LEVEL);
+
 /* Base addresses (in PDM scope) of 2ch PDM controllers and coefficient RAM. */
 static const uint32_t base[4] = {PDM0, PDM1, PDM2, PDM3};
 static const uint32_t coef_base_a[4] = {PDM0_COEFFICIENT_A, PDM1_COEFFICIENT_A,

--- a/src/drivers/intel/dmic/dmic_nhlt.c
+++ b/src/drivers/intel/dmic/dmic_nhlt.c
@@ -10,6 +10,8 @@
 #include <ipc/dai-intel.h>
 #include <stdint.h>
 
+LOG_MODULE_DECLARE(dmic, CONFIG_SOF_LOG_LEVEL);
+
 /* Base addresses (in PDM scope) of 2ch PDM controllers and coefficient RAM. */
 static const uint32_t base[4] = {PDM0, PDM1, PDM2, PDM3};
 static const uint32_t coef_base_a[4] = {PDM0_COEFFICIENT_A, PDM1_COEFFICIENT_A,

--- a/src/drivers/intel/hda/hda-dma.c
+++ b/src/drivers/intel/hda/hda-dma.c
@@ -100,6 +100,8 @@
  *    to ensure DMA is idle
  */
 
+LOG_MODULE_REGISTER(hda_dma, CONFIG_SOF_LOG_LEVEL);
+
 /* ee12fa71-4579-45d7-bde2-b32c6893a122 */
 DECLARE_SOF_UUID("hda-dma", hda_dma_uuid, 0xee12fa71, 0x4579, 0x45d7,
 		 0xbd, 0xe2, 0xb3, 0x2c, 0x68, 0x93, 0xa1, 0x22);

--- a/src/drivers/intel/hda/hda.c
+++ b/src/drivers/intel/hda/hda.c
@@ -14,6 +14,8 @@
 #include <ipc/stream.h>
 #include <ipc/topology.h>
 
+LOG_MODULE_REGISTER(hda_dai, CONFIG_SOF_LOG_LEVEL);
+
 /* bc9ebe20-4577-41bb-9eed-d0cb236328da */
 DECLARE_SOF_UUID("hda-dai", hda_uuid, 0xbc9ebe20, 0x4577, 0x41bb,
 		 0x9e, 0xed, 0xd0, 0xcb, 0x23, 0x63, 0x28, 0xda);

--- a/src/drivers/intel/ssp/mn.c
+++ b/src/drivers/intel/ssp/mn.c
@@ -20,6 +20,7 @@
 #include <stdint.h>
 
 /* tracing */
+LOG_MODULE_REGISTER(mn, CONFIG_SOF_LOG_LEVEL);
 
 /* fa3b3763-759c-4c64-82b6-3dd239c89f58 */
 DECLARE_SOF_UUID("mn", mn_uuid, 0xfa3b3763, 0x759c, 0x4c64,

--- a/src/drivers/intel/ssp/ssp.c
+++ b/src/drivers/intel/ssp/ssp.c
@@ -33,6 +33,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+LOG_MODULE_REGISTER(ssp_dai, CONFIG_SOF_LOG_LEVEL);
+
 /* 31458125-95c4-4085-8f3f-497434cb2daf */
 DECLARE_SOF_UUID("ssp-dai", ssp_uuid, 0x31458125, 0x95c4, 0x4085,
 		 0x8f, 0x3f, 0x49, 0x74, 0x34, 0xcb, 0x2d, 0xaf);

--- a/src/drivers/interrupt.c
+++ b/src/drivers/interrupt.c
@@ -20,6 +20,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+LOG_MODULE_REGISTER(irq, CONFIG_SOF_LOG_LEVEL);
+
 /* 1862d39a-3a84-4d64-8c91-dce1dfc122db */
 
 DECLARE_SOF_UUID("irq", irq_uuid, 0x1862d39a, 0x3a84, 0x4d64,

--- a/src/idc/idc.c
+++ b/src/idc/idc.c
@@ -32,6 +32,8 @@
 #include <errno.h>
 #include <stdint.h>
 
+LOG_MODULE_REGISTER(idc, CONFIG_SOF_LOG_LEVEL);
+
 /** \brief IDC message payload per core. */
 static SHARED_DATA struct idc_payload static_payload[CONFIG_CORE_COUNT];
 

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -49,6 +49,17 @@ extern struct tr_ctx buffer_tr;
 /** \brief Retrieves subid (comp id) from the buffer */
 #define trace_buf_get_subid(buf_ptr) ((buf_ptr)->id)
 
+#ifdef __ZEPHYR__
+
+#define buf_err(buf_ptr, __e, ...) LOG_ERR(__e, ##__VA_ARGS__)
+
+#define buf_warn(buf_ptr, __e, ...) LOG_WRN(__e, ##__VA_ARGS__)
+
+#define buf_info(buf_ptr, __e, ...) LOG_INF(__e, ##__VA_ARGS__)
+
+#define buf_dbg(buf_ptr, __e, ...) LOG_DBG(__e, ##__VA_ARGS__)
+
+#else
 /** \brief Trace error message from buffer */
 #define buf_err(buf_ptr, __e, ...)					\
 	trace_dev_err(trace_buf_get_tr_ctx, trace_buf_get_id,		\
@@ -72,6 +83,8 @@ extern struct tr_ctx buffer_tr;
 	trace_dev_dbg(trace_buf_get_tr_ctx, trace_buf_get_id,		\
 		      trace_buf_get_subid, buf_ptr, __e, ##__VA_ARGS__)
 #endif
+
+#endif /* #ifdef _ZEPHYR__ */
 
 /** @}*/
 

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -152,6 +152,26 @@ enum {
 /** \brief Retrieves subid (comp id) from the component device */
 #define trace_comp_get_subid(comp_p) ((comp_p)->ipc_config.id)
 
+#ifdef __ZEPHYR__
+/* class (driver) level (no device object) tracing */
+#define comp_cl_err(drv_p, __e, ...) LOG_ERR(__e, ##__VA_ARGS__)
+
+#define comp_cl_warn(drv_p, __e, ...) LOG_WRN(__e, ##__VA_ARGS__)
+
+#define comp_cl_info(drv_p, __e, ...) LOG_INF(__e, ##__VA_ARGS__)
+
+#define comp_cl_dbg(drv_p, __e, ...) LOG_DBG(__e, ##__VA_ARGS__)
+
+/* device level tracing */
+#define comp_err(comp_p, __e, ...) LOG_ERR(__e, ##__VA_ARGS__)
+
+#define comp_warn(comp_p, __e, ...) LOG_WRN(__e, ##__VA_ARGS__)
+
+#define comp_info(comp_p, __e, ...) LOG_INF(__e, ##__VA_ARGS__)
+
+#define comp_dbg(comp_p, __e, ...) LOG_DBG(__e, ##__VA_ARGS__)
+
+#else
 /* class (driver) level (no device object) tracing */
 
 /** \brief Trace error message from component driver (no comp instance) */
@@ -207,6 +227,8 @@ enum {
 #define comp_dbg(comp_p, __e, ...)					\
 	trace_dev_dbg(trace_comp_get_tr_ctx, trace_comp_get_id,		\
 		      trace_comp_get_subid, comp_p, __e, ##__VA_ARGS__)
+
+#endif
 
 #define comp_perf_info(pcd, comp_p)					\
 	comp_info(comp_p, "perf comp_copy peak plat %d cpu %d",		\
@@ -739,6 +761,8 @@ static inline void comp_underrun(struct comp_dev *dev,
 				 struct comp_buffer *source,
 				 uint32_t copy_bytes)
 {
+	LOG_MODULE_DECLARE(component, CONFIG_SOF_LOG_LEVEL);
+
 	int32_t bytes = (int32_t)audio_stream_get_avail_bytes(&source->stream) -
 			copy_bytes;
 
@@ -759,6 +783,7 @@ static inline void comp_underrun(struct comp_dev *dev,
 static inline void comp_overrun(struct comp_dev *dev, struct comp_buffer *sink,
 				uint32_t copy_bytes)
 {
+	LOG_MODULE_DECLARE(component, CONFIG_SOF_LOG_LEVEL);
 	int32_t bytes = (int32_t)copy_bytes -
 			audio_stream_get_free_bytes(&sink->stream);
 

--- a/src/include/sof/audio/component_ext.h
+++ b/src/include/sof/audio/component_ext.h
@@ -109,6 +109,7 @@ static inline int comp_dai_get_hw_params(struct comp_dev *dev,
 static inline int comp_cmd(struct comp_dev *dev, int cmd, void *data,
 			   int max_data_size)
 {
+	LOG_MODULE_DECLARE(component, CONFIG_SOF_LOG_LEVEL);
 	struct sof_ipc_ctrl_data *cdata = ASSUME_ALIGNED(data, 4);
 
 	if (cmd == COMP_CMD_SET_DATA &&

--- a/src/include/sof/audio/component_ext.h
+++ b/src/include/sof/audio/component_ext.h
@@ -84,8 +84,10 @@ static inline int comp_params(struct comp_dev *dev,
 		} else {
 			/* not defined, run the default handler */
 			ret = comp_verify_params(dev, 0, params);
+#ifndef __ZEPHYR__
 			if (ret < 0)
 				comp_err(dev, "pcm params verification failed");
+#endif
 		}
 	}
 
@@ -172,9 +174,13 @@ static inline int comp_copy(struct comp_dev *dev)
 
 	/* copy only if we are the owner of the component */
 	if (cpu_is_me(dev->ipc_config.core)) {
+#ifndef __ZEPHYR__
 		perf_cnt_init(&dev->pcd);
+#endif
 		ret = dev->drv->ops.copy(dev);
+#ifndef __ZEPHYR__
 		perf_cnt_stamp(&dev->pcd, comp_perf_info, dev);
+#endif
 	}
 
 	return ret;

--- a/src/include/sof/audio/pipeline-trace.h
+++ b/src/include/sof/audio/pipeline-trace.h
@@ -37,6 +37,18 @@ extern struct tr_ctx pipe_tr;
 	tr_dbg(&pipe_tr, __e, ##__VA_ARGS__)
 
 /* device tracing */
+#ifdef __ZEPHYR__
+
+#define pipe_err(pipe_p, __e, ...) LOG_ERR(__e, ##__VA_ARGS__)
+
+#define pipe_warn(pipe_p, __e, ...) LOG_WRN(__e, ##__VA_ARGS__)
+
+#define pipe_info(pipe_p, __e, ...) LOG_INF(__e, ##__VA_ARGS__)
+
+#define pipe_dbg(pipe_p, __e, ...) LOG_DBG(__e, ##__VA_ARGS__)
+
+#else
+
 #define pipe_err(pipe_p, __e, ...)					\
 	trace_dev_err(trace_pipe_get_tr_ctx, trace_pipe_get_id,		\
 		      trace_pipe_get_subid, pipe_p, __e, ##__VA_ARGS__)
@@ -52,5 +64,7 @@ extern struct tr_ctx pipe_tr;
 #define pipe_dbg(pipe_p, __e, ...)					\
 	trace_dev_dbg(trace_pipe_get_tr_ctx, trace_pipe_get_id,		\
 		      trace_pipe_get_subid, pipe_p, __e, ##__VA_ARGS__)
+
+#endif
 
 #endif

--- a/src/include/sof/audio/volume.h
+++ b/src/include/sof/audio/volume.h
@@ -205,6 +205,8 @@ static inline vol_scale_func vol_get_processing_function(struct comp_dev *dev)
  */
 static inline vol_scale_func vol_get_processing_function(struct comp_dev *dev)
 {
+	LOG_MODULE_DECLARE(volume, CONFIG_SOF_LOG_LEVEL);
+
 	struct vol_data *cd = comp_get_drvdata(dev);
 
 	switch (cd->base.audio_fmt.depth) {

--- a/src/include/sof/lib/dai.h
+++ b/src/include/sof/lib/dai.h
@@ -215,6 +215,26 @@ struct dai_type_info {
 #define trace_dai_get_id(dai_p) ((dai_p)->drv->type)
 #define trace_dai_get_subid(dai_p) ((dai_p)->index)
 
+#ifdef __ZEPHYR__
+/* driver level tracing */
+#define dai_cl_err(drv_p, __e, ...) LOG_ERR(__e, ##__VA_ARGS__)
+
+#define dai_cl_warn(drv_p, __e, ...) LOG_WRN(__e, ##__VA_ARGS__)
+
+#define dai_cl_info(drv_p, __e, ...) LOG_INF(__e, ##__VA_ARGS__)
+
+#define dai_cl_dbg(drv_p, __e, ...) LOG_DBG(__e, ##__VA_ARGS__)
+
+/* device level tracing */
+#define dai_err(dai_p, __e, ...) LOG_ERR(__e, ##__VA_ARGS__)
+
+#define dai_warn(dai_p, __e, ...) LOG_WRN(__e, ##__VA_ARGS__)
+
+#define dai_info(dai_p, __e, ...) LOG_INF(__e, ##__VA_ARGS__)
+
+#define dai_dbg(dai_p, __e, ...) LOG_DBG(__e, ##__VA_ARGS__)
+
+#else
 /* class (driver) level (no device object) tracing */
 
 #define dai_cl_err(drv_p, __e, ...)		\
@@ -262,6 +282,8 @@ struct dai_type_info {
 	trace_dev_dbg(trace_dai_get_tr_ctx,				\
 		      trace_dai_get_id,					\
 		      trace_dai_get_subid, dai_p, __e, ##__VA_ARGS__)
+
+#endif
 
 /**
  * \brief API to request DAI group

--- a/src/include/sof/lib/wait.h
+++ b/src/include/sof/lib/wait.h
@@ -29,6 +29,8 @@ extern struct tr_ctx wait_tr;
 
 static inline void wait_for_interrupt(int level)
 {
+	LOG_MODULE_DECLARE(wait, CONFIG_SOF_LOG_LEVEL);
+
 	tr_dbg(&wait_tr, "WFE");
 #if CONFIG_DEBUG_LOCKS
 	if (lock_dbg_atomic)

--- a/src/include/sof/trace/trace.h
+++ b/src/include/sof/trace/trace.h
@@ -30,6 +30,10 @@
 #include <stdio.h>
 #endif
 
+#ifdef __ZEPHYR__
+#include <logging/log.h>
+#endif
+
 struct sof;
 struct trace;
 struct tr_ctx;
@@ -435,42 +439,59 @@ struct tr_ctx {
 
 /* tracing from infrastructure part */
 
-#define tr_err(ctx, fmt, ...) \
-	trace_error_with_ids(_TRACE_INV_CLASS, ctx, \
-			     _TRACE_INV_ID, _TRACE_INV_ID, fmt, ##__VA_ARGS__)
-
 #define tr_err_atomic(ctx, fmt, ...) \
 	trace_error_atomic_with_ids(_TRACE_INV_CLASS, ctx, \
 				    _TRACE_INV_ID, _TRACE_INV_ID, \
 				    fmt, ##__VA_ARGS__)
-
-#define tr_warn(ctx, fmt, ...) \
-	trace_warn_with_ids(_TRACE_INV_CLASS, ctx, \
-			    _TRACE_INV_ID, _TRACE_INV_ID, fmt, ##__VA_ARGS__)
 
 #define tr_warn_atomic(ctx, fmt, ...) \
 	trace_warn_atomic_with_ids(_TRACE_INV_CLASS, ctx, \
 				   _TRACE_INV_ID, _TRACE_INV_ID, \
 				   fmt, ##__VA_ARGS__)
 
-#define tr_info(ctx, fmt, ...) \
-	trace_event_with_ids(_TRACE_INV_CLASS, ctx, \
-			     _TRACE_INV_ID, _TRACE_INV_ID, fmt, ##__VA_ARGS__)
-
 #define tr_info_atomic(ctx, fmt, ...) \
 	trace_event_atomic_with_ids(_TRACE_INV_CLASS, ctx, \
 				    _TRACE_INV_ID, _TRACE_INV_ID, \
 				    fmt, ##__VA_ARGS__)
+
+#define tr_dbg_atomic(ctx, fmt, ...) \
+	tracev_event_atomic_with_ids(_TRACE_INV_CLASS, ctx, \
+				     _TRACE_INV_ID, _TRACE_INV_ID, \
+				     fmt, ##__VA_ARGS__)
+
+#ifdef __ZEPHYR__
+
+#define tr_err(ctx, fmt, ...) LOG_ERR(fmt, ##__VA_ARGS__)
+
+#define tr_warn(ctx, fmt, ...) LOG_WRN(fmt, ##__VA_ARGS__)
+
+#define tr_info(ctx, fmt, ...) LOG_INF(fmt, ##__VA_ARGS__)
+
+#define tr_dbg(ctx, fmt, ...) LOG_DBG(fmt, ##__VA_ARGS__)
+
+#else
+
+#define LOG_MODULE_REGISTER(ctx, level)
+#define LOG_MODULE_DECLARE(ctx, level)
+
+#define tr_err(ctx, fmt, ...) \
+	trace_error_with_ids(_TRACE_INV_CLASS, ctx, \
+			     _TRACE_INV_ID, _TRACE_INV_ID, fmt, ##__VA_ARGS__)
+
+#define tr_warn(ctx, fmt, ...) \
+	trace_warn_with_ids(_TRACE_INV_CLASS, ctx, \
+			    _TRACE_INV_ID, _TRACE_INV_ID, fmt, ##__VA_ARGS__)
+
+#define tr_info(ctx, fmt, ...) \
+	trace_event_with_ids(_TRACE_INV_CLASS, ctx, \
+			     _TRACE_INV_ID, _TRACE_INV_ID, fmt, ##__VA_ARGS__)
 
 /* tracev_ output depends on CONFIG_TRACEV=y */
 #define tr_dbg(ctx, fmt, ...) \
 	tracev_event_with_ids(_TRACE_INV_CLASS, ctx, \
 			      _TRACE_INV_ID, _TRACE_INV_ID, fmt, ##__VA_ARGS__)
 
-#define tr_dbg_atomic(ctx, fmt, ...) \
-	tracev_event_atomic_with_ids(_TRACE_INV_CLASS, ctx, \
-				     _TRACE_INV_ID, _TRACE_INV_ID, \
-				     fmt, ##__VA_ARGS__)
+#endif
 
 #if CONFIG_TRACE
 

--- a/src/ipc/dma-copy.c
+++ b/src/ipc/dma-copy.c
@@ -18,6 +18,7 @@
 #include <stdint.h>
 
 /* tracing */
+LOG_MODULE_REGISTER(dma_copy, CONFIG_SOF_LOG_LEVEL);
 
 /* 729bf8b5-e873-4bf5-9690-8e2a3fd33911 */
 DECLARE_SOF_UUID("dma-copy", dma_copy_uuid, 0x729bf8b5, 0xe873, 0x4bf5,

--- a/src/ipc/ipc-common.c
+++ b/src/ipc/ipc-common.c
@@ -32,6 +32,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+LOG_MODULE_REGISTER(ipc, CONFIG_SOF_LOG_LEVEL);
+
 /* be60f97d-78df-4796-a0ee-435cb56b720a */
 DECLARE_SOF_UUID("ipc", ipc_uuid, 0xbe60f97d, 0x78df, 0x4796,
 		 0xa0, 0xee, 0x43, 0x5c, 0xb5, 0x6b, 0x72, 0x0a);

--- a/src/ipc/ipc-helper.c
+++ b/src/ipc/ipc-helper.c
@@ -32,6 +32,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+LOG_MODULE_DECLARE(ipc, CONFIG_SOF_LOG_LEVEL);
+
 /* create a new component in the pipeline */
 struct comp_buffer *buffer_new(const struct sof_ipc_buffer *desc)
 {

--- a/src/ipc/ipc3/dai.c
+++ b/src/ipc/ipc3/dai.c
@@ -27,6 +27,8 @@
 #include <ipc/stream.h>
 #include <ipc/topology.h>
 
+LOG_MODULE_DECLARE(ipc, CONFIG_SOF_LOG_LEVEL);
+
 int dai_config_dma_channel(struct comp_dev *dev, void *spec_config)
 {
 	struct dai_data *dd = comp_get_drvdata(dev);

--- a/src/ipc/ipc3/handler.c
+++ b/src/ipc/ipc3/handler.c
@@ -52,6 +52,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+LOG_MODULE_DECLARE(ipc, CONFIG_SOF_LOG_LEVEL);
+
 #if CONFIG_CAVS && CAVS_VERSION >= CAVS_VERSION_1_8
 #include <ipc/header-intel-cavs.h>
 #include <cavs/drivers/sideband-ipc.h>

--- a/src/ipc/ipc3/helper.c
+++ b/src/ipc/ipc3/helper.c
@@ -29,6 +29,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+LOG_MODULE_DECLARE(ipc, CONFIG_SOF_LOG_LEVEL);
+
 extern struct tr_ctx comp_tr;
 
 /**

--- a/src/ipc/ipc3/host-page-table.c
+++ b/src/ipc/ipc3/host-page-table.c
@@ -14,6 +14,8 @@
 #include <errno.h>
 #include <stdint.h>
 
+LOG_MODULE_DECLARE(ipc, CONFIG_SOF_LOG_LEVEL);
+
 /*
  * Parse the host page tables and create the audio DMA SG configuration
  * for host audio DMA buffer. This involves creating a dma_sg_elem for each

--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -28,6 +28,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+LOG_MODULE_DECLARE(ipc, CONFIG_SOF_LOG_LEVEL);
+
 int dai_config_dma_channel(struct comp_dev *dev, void *spec_config)
 {
 	struct ipc4_copier_module_cfg *copier_cfg = spec_config;

--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -37,6 +37,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+LOG_MODULE_DECLARE(ipc, CONFIG_SOF_LOG_LEVEL);
+
 struct ipc4_msg_data {
 	uint32_t msg_in[2]; /* local copy of current message from host header */
 	uint32_t msg_out[2]; /* local copy of current message to host header */

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -34,6 +34,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+LOG_MODULE_DECLARE(ipc, CONFIG_SOF_LOG_LEVEL);
+
 #define IPC4_MOD_ID(x) ((x) >> 16)
 
 extern struct tr_ctx comp_tr;

--- a/src/lib/agent.c
+++ b/src/lib/agent.c
@@ -38,6 +38,8 @@
 #include <kernel.h>
 #endif
 
+LOG_MODULE_REGISTER(sa, CONFIG_SOF_LOG_LEVEL);
+
 /* 5276b491-5b64-464e-8984-dc228ef9e6a1 */
 DECLARE_SOF_UUID("sa", sa_uuid, 0x5276b491, 0x5b64, 0x464e,
 		 0x89, 0x84, 0xdc, 0x22, 0x8e, 0xf9, 0xe6, 0xa1);

--- a/src/lib/alloc.c
+++ b/src/lib/alloc.c
@@ -24,6 +24,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+LOG_MODULE_REGISTER(memory, CONFIG_SOF_LOG_LEVEL);
+
 /* 425d6e68-145c-4455-b0b2-c7260b0600a5 */
 DECLARE_SOF_UUID("memory", mem_uuid, 0x425d6e68, 0x145c, 0x4455,
 		 0xb0, 0xb2, 0xc7, 0x26, 0x0b, 0x06, 0x00, 0xa5);

--- a/src/lib/clk.c
+++ b/src/lib/clk.c
@@ -18,6 +18,8 @@
 #include <user/trace.h>
 #include <stdint.h>
 
+LOG_MODULE_REGISTER(clock, CONFIG_SOF_LOG_LEVEL);
+
 /* 8890ea76-0df9-44ae-87e6-994f4c15e9fa */
 DECLARE_SOF_UUID("clock", clock_uuid, 0x8890ea76, 0x0df9, 0x44ae,
 		 0x87, 0xe6, 0x99, 0x4f, 0x4c, 0x15, 0xe9, 0xfa);

--- a/src/lib/dai.c
+++ b/src/lib/dai.c
@@ -17,6 +17,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+LOG_MODULE_REGISTER(dai, CONFIG_SOF_LOG_LEVEL);
+
 /* 06711c94-d37d-4a76-b302-bbf6944fdd2b */
 DECLARE_SOF_UUID("dai", dai_uuid, 0x06711c94, 0xd37d, 0x4a76,
 		 0xb3, 0x02, 0xbb, 0xf6, 0x94, 0x4f, 0xdd, 0x2b);

--- a/src/lib/dma.c
+++ b/src/lib/dma.c
@@ -20,6 +20,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+LOG_MODULE_REGISTER(dma, CONFIG_SOF_LOG_LEVEL);
+
 /* bc3526a7-9b86-4ab4-84a5-2e02ae70cc10 */
 DECLARE_SOF_UUID("dma", dma_uuid, 0xbc3526a7, 0x9b86, 0x4ab4,
 		 0x84, 0xa5, 0x2e, 0x02, 0xae, 0x70, 0xcc, 0x10);

--- a/src/lib/notifier.c
+++ b/src/lib/notifier.c
@@ -19,6 +19,8 @@
 #include <ipc/topology.h>
 #include <stdint.h>
 
+LOG_MODULE_REGISTER(notifier, CONFIG_SOF_LOG_LEVEL);
+
 /* 1fb15a7a-83cd-4c2e-8b32-4da1b2adeeaf */
 DECLARE_SOF_UUID("notifier", notifier_uuid, 0x1fb15a7a, 0x83cd, 0x4c2e,
 		 0x8b, 0x32, 0x4d, 0xa1, 0xb2, 0xad, 0xee, 0xaf);

--- a/src/lib/pm_runtime.c
+++ b/src/lib/pm_runtime.c
@@ -20,6 +20,8 @@
 #include <ipc/topology.h>
 #include <stdint.h>
 
+LOG_MODULE_REGISTER(pm_runtime, CONFIG_SOF_LOG_LEVEL);
+
 /* d7f6712d-131c-45a7-82ed-6aa9dc2291ea */
 DECLARE_SOF_UUID("pm-runtime", pm_runtime_uuid, 0xd7f6712d, 0x131c, 0x45a7,
 		 0x82, 0xed, 0x6a, 0xa9, 0xdc, 0x22, 0x91, 0xea);

--- a/src/lib/wait.c
+++ b/src/lib/wait.c
@@ -20,6 +20,8 @@
 #include <stdint.h>
 #include <inttypes.h>
 
+LOG_MODULE_REGISTER(wait, CONFIG_SOF_LOG_LEVEL);
+
 /* 1028070e-04e8-46ab-8d81-10a0116ce738 */
 DECLARE_SOF_UUID("wait", wait_uuid, 0x1028070e, 0x04e8, 0x46ab,
 		 0x8d, 0x81, 0x10, 0xa0, 0x11, 0x6c, 0xe7, 0x38);

--- a/src/platform/intel/cavs/lib/pm_memory.c
+++ b/src/platform/intel/cavs/lib/pm_memory.c
@@ -16,6 +16,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+LOG_MODULE_REGISTER(pm_memory, CONFIG_SOF_LOG_LEVEL);
+
 /* 14f25ab6-3a4b-4e5d-b343-2a142d4e4d92 */
 DECLARE_SOF_UUID("pm-memory", pm_mem_uuid, 0x14f25ab6, 0x3a4b, 0x4e5d,
 		 0xb3, 0x43, 0x2a, 0x14, 0x2d, 0x4e, 0x4d, 0x92);

--- a/src/platform/intel/cavs/lib/pm_runtime.c
+++ b/src/platform/intel/cavs/lib/pm_runtime.c
@@ -40,6 +40,8 @@
 #include <cavs/lib/power_down.h>
 #endif
 
+LOG_MODULE_REGISTER(power, CONFIG_SOF_LOG_LEVEL);
+
 /* 76cc9773-440c-4df9-95a8-72defe7796fc */
 DECLARE_SOF_UUID("power", power_uuid, 0x76cc9773, 0x440c, 0x4df9,
 		 0x95, 0xa8, 0x72, 0xde, 0xfe, 0x77, 0x96, 0xfc);

--- a/src/samples/audio/detect_test.c
+++ b/src/samples/audio/detect_test.c
@@ -54,6 +54,8 @@
 
 static const struct comp_driver comp_keyword;
 
+LOG_MODULE_REGISTER(kd_test, CONFIG_SOF_LOG_LEVEL);
+
 /* eba8d51f-7827-47b5-82ee-de6e7743af67 */
 DECLARE_SOF_RT_UUID("kd-test", keyword_uuid, 0xeba8d51f, 0x7827, 0x47b5,
 		 0x82, 0xee, 0xde, 0x6e, 0x77, 0x43, 0xaf, 0x67);

--- a/src/samples/audio/smart_amp_test.c
+++ b/src/samples/audio/smart_amp_test.c
@@ -12,6 +12,8 @@
 
 static const struct comp_driver comp_smart_amp;
 
+LOG_MODULE_REGISTER(smart_amp_test, CONFIG_SOF_LOG_LEVEL);
+
 /* 167a961e-8ae4-11ea-89f1-000c29ce1635 */
 DECLARE_SOF_RT_UUID("smart_amp-test", smart_amp_comp_uuid, 0x167a961e, 0x8ae4,
 		    0x11ea, 0x89, 0xf1, 0x00, 0x0c, 0x29, 0xce, 0x16, 0x35);

--- a/src/schedule/dma_multi_chan_domain.c
+++ b/src/schedule/dma_multi_chan_domain.c
@@ -23,6 +23,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+LOG_MODULE_DECLARE(ll_schedule, CONFIG_SOF_LOG_LEVEL);
+
 /* For i.MX, when building SOF with Zephyr, we use wrapper.c,
  * interrupt.c and interrupt-irqsteer.c which causes name
  * collisions.

--- a/src/schedule/dma_single_chan_domain.c
+++ b/src/schedule/dma_single_chan_domain.c
@@ -27,6 +27,8 @@
 
 #define DMA_DOMAIN_OWNER_INVALID	0xFFFFFFFF
 
+LOG_MODULE_DECLARE(ll_schedule, CONFIG_SOF_LOG_LEVEL);
+
 struct dma_domain_data {
 	int irq;
 	struct dma_chan_data *channel;

--- a/src/schedule/ll_schedule.c
+++ b/src/schedule/ll_schedule.c
@@ -33,6 +33,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+LOG_MODULE_REGISTER(ll_schedule, CONFIG_SOF_LOG_LEVEL);
+
 /* 4f9c3ec7-7b55-400c-86b3-502b4420e625 */
 DECLARE_SOF_UUID("ll-schedule", ll_sched_uuid, 0x4f9c3ec7, 0x7b55, 0x400c,
 		 0x86, 0xb3, 0x50, 0x2b, 0x44, 0x20, 0xe6, 0x25);

--- a/src/schedule/schedule.c
+++ b/src/schedule/schedule.c
@@ -15,6 +15,8 @@
 #include <errno.h>
 #include <stdint.h>
 
+LOG_MODULE_REGISTER(schedule, CONFIG_SOF_LOG_LEVEL);
+
 /* 3dee06de-f25a-4e10-ae1f-abc9573873ea */
 DECLARE_SOF_UUID("schedule", sch_uuid, 0x3dee06de, 0xf25a, 0x4e10,
 		 0xae, 0x1f, 0xab, 0xc9, 0x57, 0x38, 0x73, 0xea);

--- a/src/schedule/zephyr_domain.c
+++ b/src/schedule/zephyr_domain.c
@@ -23,6 +23,8 @@
 #include <kernel.h>
 #include <sys_clock.h>
 
+LOG_MODULE_DECLARE(ll_schedule, CONFIG_SOF_LOG_LEVEL);
+
 /*
  * Currently the Zephyr clock rate is part it's Kconfig known at build time.
  * SOF on Intel CAVS platforms currently only aligns with Zephyr when both

--- a/src/schedule/zephyr_ll.c
+++ b/src/schedule/zephyr_ll.c
@@ -15,6 +15,8 @@
 
 #include <kernel.h>
 
+LOG_MODULE_REGISTER(ll_schedule, CONFIG_SOF_LOG_LEVEL);
+
 /* 1547fe68-de0c-11eb-8461-3158a1294853 */
 DECLARE_SOF_UUID("zll-schedule", zll_sched_uuid, 0x1547fe68, 0xde0c, 0x11eb,
 		 0x84, 0x61, 0x31, 0x58, 0xa1, 0x29, 0x48, 0x53);

--- a/src/trace/dma-trace.c
+++ b/src/trace/dma-trace.c
@@ -36,6 +36,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+LOG_MODULE_REGISTER(dma_trace, CONFIG_SOF_LOG_LEVEL);
+
 /* 58782c63-1326-4185-8459-22272e12d1f1 */
 DECLARE_SOF_UUID("dma-trace", dma_trace_uuid, 0x58782c63, 0x1326, 0x4185,
 		 0x84, 0x59, 0x22, 0x27, 0x2e, 0x12, 0xd1, 0xf1);

--- a/src/trace/trace.c
+++ b/src/trace/trace.c
@@ -27,6 +27,9 @@
 #include <stdarg.h>
 #include <stdint.h>
 
+/* every trace calls uses IPC context in this file */
+LOG_MODULE_DECLARE(ipc, CONFIG_SOF_LOG_LEVEL);
+
 extern struct tr_ctx dt_tr;
 
 #if CONFIG_TRACE_FILTERING_ADAPTIVE

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -31,6 +31,8 @@
 #include <arch/xtensa/cache.h>
 #endif
 
+LOG_MODULE_REGISTER(zephyr, CONFIG_SOF_LOG_LEVEL);
+
 extern K_KERNEL_STACK_ARRAY_DEFINE(z_interrupt_stacks, CONFIG_MP_NUM_CPUS,
 				   CONFIG_ISR_STACK_SIZE);
 


### PR DESCRIPTION
The log context in zephyr is per file or module.

To use zephyr logging api, LOG_MODULE_REGISTER is used
to register a log context, LOG_MODULE_DECLARE is used
to refer to the registered context.

For function in header file, LOG_MODULE_DECLARE should
be used within that function to avoid context collapse,
a condition one source file have multiple context
registered or declared.

Signed-off-by: Chao Song <chao.song@linux.intel.com>