### PR TITLE
xtensa-build-zephyr: add ipc4 build support for tgl

### DIFF
--- a/platforms/tgl/tgl_ipc4_overlay.conf
+++ b/platforms/tgl/tgl_ipc4_overlay.conf
@@ -1,0 +1,1 @@
+CONFIG_IPC_MAJOR_4=y

--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -50,6 +50,8 @@ platform_list = [
 	{
 		"name": "tgl",
 		"PLAT_CONFIG": "intel_adsp_cavs25",
+		"IPC4_CONFIG_OVERLAY": "tgl_ipc4_overlay.conf",
+		"IPC4_RIMAGE_DESC": "tgl-cavs.toml",
 		"XTENSA_CORE": "cavs2x_LX6HiFi3_2017_8",
 		"XTENSA_TOOLS_VERSION": f"RG-2017.8{xtensa_tools_version_postfix}",
 		"RIMAGE_KEY": pathlib.Path("modules", "audio", "sof", "keys", "otc_private_key_3k.pem")
@@ -116,6 +118,8 @@ def parse_args():
 						help="Build all currently supported platforms")
 	parser.add_argument("platforms", nargs="*", action=validate_platforms_arguments,
 						help="List of platforms to build")
+	parser.add_argument("-i", "--ipc", required=False, choices=["IPC3", "IPC4"],
+						default="IPC3", help="IPC major version")
 	parser.add_argument("-j", "--jobs", required=False, type=int,
 						default=multiprocessing.cpu_count(),
 						help="Set number of make build jobs for rimage."
@@ -353,6 +357,10 @@ def build_platforms():
 		if args.verbose >= 1:
 			build_cmd.append("-DCMAKE_VERBOSE_MAKEFILE=ON")
 
+		if args.ipc == "IPC4":
+			overlay = pathlib.Path(SOF_TOP, "platforms", platform, platform_dict["IPC4_CONFIG_OVERLAY"])
+			build_cmd.append(f"-DOVERLAY_CONFIG={overlay}")
+
 		# Build
 		execute_command(build_cmd, check=True, cwd=west_top)
 		smex_executable = pathlib.Path(west_top, platform_build_dir_name, "zephyr", "smex_ep",
@@ -386,6 +394,11 @@ def build_platforms():
 		else:
 			signing_key = default_rimage_key
 		sign_cmd += ["--tool-data", str(rimage_config), "--", "-k", str(signing_key)]
+
+		if args.ipc == "IPC4":
+			rimage_desc = pathlib.Path(SOF_TOP, "rimage", "config", platform_dict["IPC4_RIMAGE_DESC"])
+			sign_cmd += ["-c", rimage_desc]
+
 		execute_command(sign_cmd, check=True, cwd=west_top)
 		# Install by copy
 		fw_file_to_copy = pathlib.Path(west_top, platform_build_dir_name, "zephyr", "zephyr.ri")


### PR DESCRIPTION
Add ipc4 build support for tgl with OVERLAY_CONFIG.

Signed-off-by: Chao Song <chao.song@linux.intel.com>

if any other IPC4 config should be added, please comment.

similar implementation in xtensa-build-zephyr.sh will not be done, because it is going to be deprecated, use xtensa-build-zephyr.py instead.