### PR TITLE
dma-trace: Print banners in case of dtrace re-initialization atempt

### DIFF
--- a/src/trace/dma-trace.c
+++ b/src/trace/dma-trace.c
@@ -248,16 +248,9 @@ static int dma_trace_buffer_init(struct dma_trace_data *d)
 	uint32_t addr_align;
 	int err;
 
-	/*
-	 * Keep the existing dtrace buffer to avoid memory leak, unlikely to
-	 * happen if host correctly using the dma_trace_disable().
-	 *
-	 * The buffer can not be freed up here as it is likely in use.
-	 * The (re-)initialization will happen in dma_trace_start() when it is
-	 * safe to do (the DMA is stopped)
-	 */
+	/* Keep the existing dtrace buffer to avoid memory leak */
 	if (dma_trace_initialized(d))
-		return 0;
+		goto print_banners;
 
 	if (!d || !d->dc.dmac) {
 		mtrace_printf(LOG_LEVEL_ERROR,
@@ -317,6 +310,7 @@ static int dma_trace_buffer_init(struct dma_trace_data *d)
 	}
 #endif
 
+print_banners:
 #ifdef __ZEPHYR__
 #define ZEPHYR_VER_OPT " zephyr:" META_QUOTE(BUILD_VERSION)
 #else


### PR DESCRIPTION
The dtrace internal buffer is permanent from the point it is allocated.

If a SOF_IPC_TRACE_DMA_FREE IPC received the DMA channel is released and
the read/write pointer in the local dtrace buffer is reset to 0.

However, if the DSP is not powered down before the dtrace is re-enabled
then the banner is not going to be printed and since the write pointer
is reset (since the new DMA channel will start the copy from the start of
the buffer), further prints will overwrite the data which might include
the banner from the first boot when the buffer was allocated.

Print the banners in response to a dtrace enable call all the time.

Signed-off-by: Peter Ujfalusi <peter.ujfalusi@linux.intel.com>