### PR TITLE
ipc4: SetDx

### DIFF
--- a/src/include/ipc4/base_fw.h
+++ b/src/include/ipc4/base_fw.h
@@ -63,10 +63,7 @@ enum ipc4_basefw_params {
 
 	IPC4_DSP_RESOURCE_STATE = 1,
 
-	/* Use LARGE_CONFIG_SET to prepare core(s) for new DX state.
-	 * Ipc mailbox must contain properly built DxStateInfo struct
-	 */
-	IPC4_DX_STATE = 2,
+	IPC4_RESERVED = 2,
 
 	/* Driver sends this request to enable/disable notifications. This message
 	 * should be used by the driver in debug mode to avoid flooding host with
@@ -438,26 +435,6 @@ struct ipc4_phys_mem_pages {
 	uint32_t mem_type;
 	/* Number of pages */
 	uint32_t pages;
-} __attribute__((packed, aligned(4)));
-
-/*TODO: how do we enter D0i3 */
-enum ipc4_dx_states {
-	/*D0 state means that dsp in this state is powered up and ready for processing */
-	IPC4_D0_STATE = 0,
-	/* D3 state means that dsp in this state is powered down or not yet
-	 * ready for processing. No idc/ipc should be send to core in this state.
-	 */
-	IPC4_D3_STATE = 3,
-};
-
-struct ipc4_dx_state_info {
-	/* Indicates which cores are subject to change the power state */
-	uint32_t core_mask;
-	/* Indicates core state.
-	 * bit[core_id] = 0 -> put core_id to D3
-	 * bit[core_id] = 1 -> put core_id to D0
-	 */
-	uint32_t dx_mask;
 } __attribute__((packed, aligned(4)));
 
 #define IPC4_UNDERRUN_AT_GATEWAY_NOTIFICATION_MASK_IDX	0

--- a/src/include/ipc4/module.h
+++ b/src/include/ipc4/module.h
@@ -334,6 +334,16 @@ struct ipc4_module_set_d0ix {
 	} data;
 } __attribute__((packed, aligned(4)));
 
+struct ipc4_dx_state_info {
+	/* Indicates which cores are subject to change the power state */
+	uint32_t core_mask;
+	/* Indicates core state.
+	 * bit[core_id] = 0 -> put core_id to D3
+	 * bit[core_id] = 1 -> put core_id to D0
+	 */
+	uint32_t dx_mask;
+} __packed __aligned(4);
+
 struct ipc4_module_set_dx {
 	union {
 		uint32_t dat;

--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -748,10 +748,8 @@ static int ipc4_module_process_dx(union ipc4_message_header *ipc4)
 	module_id = dx.header.r.module_id;
 	instance_id = dx.header.r.instance_id;
 
-	tr_dbg(&ipc_tr, "ipc4_module_process_d0ix %x : %x", module_id, instance_id);
-
 	/* only module 0 can be used to set dx state */
-	if (dx.header.r.module_id || dx.header.r.instance_id) {
+	if (module_id || instance_id) {
 		tr_err(&ipc_tr, "invalid resource id %x : %x", module_id, instance_id);
 		return IPC4_INVALID_RESOURCE_ID;
 	}


### PR DESCRIPTION
Complementing the implementation of SetDX ipc message handling:

- adding support and validation of message payload,
- enabling/disabling cores according to the DX state mask,
- unblocking the path for primary core power down.