### PR TITLE
[Intel ADL-003 backport] drivers: Intel: SSP: fix update of DAI config in prepared state

### DIFF
--- a/src/drivers/intel/ssp/ssp.c
+++ b/src/drivers/intel/ssp/ssp.c
@@ -270,8 +270,17 @@ static int ssp_set_config(struct dai *dai,
 	/* ignore config if SSP is already configured */
 	if (ssp->state[DAI_DIR_PLAYBACK] > COMP_STATE_READY ||
 	    ssp->state[DAI_DIR_CAPTURE] > COMP_STATE_READY) {
-		dai_info(dai, "ssp_set_config(): Already configured. Ignore config");
-		goto clk;
+		if (!memcmp(&ssp->params, &config->ssp, sizeof(ssp->params))) {
+			dai_info(dai, "ssp_set_config(): Already configured. Ignore config");
+			goto clk;
+		}
+
+		if (ssp->clk_active & (SSP_CLK_MCLK_ACTIVE | SSP_CLK_BCLK_ACTIVE)) {
+			dai_warn(dai, "ssp_set_config(): SSP active, cannot change config");
+			goto clk;
+		}
+
+		/* safe to proceed and change HW config */
 	}
 
 	dai_info(dai, "ssp_set_config(), config->format = 0x%4x",


### PR DESCRIPTION
The checks added in commit fc73578be774 ("drivers: Intel: SSP: ignore
config when SSP is already configured") also filter out cases where the
SSP parameters actually are modified in prepare state. This will happen
e.g. with a topology that has multiple configs for SSP and uses static
topology loading.

Modify the checks such that reconfiguration is done if:
 - the config is actually modified,
 - early MCLK/BCLK is not running.

BugLink: https://github.com/thesofproject/sof/issues/5375
Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>
(cherry picked from commit bcc789f981c908a3f1f68247ba4ff71ef6e7c227)