### PR TITLE
drivers: imx: esai/sai: Add .remove callback

### DIFF
--- a/src/drivers/imx/esai.c
+++ b/src/drivers/imx/esai.c
@@ -363,6 +363,18 @@ static int esai_probe(struct dai *dai)
 	return 0;
 }
 
+static int esai_remove(struct dai *dai)
+{
+	struct esai_pdata *pdata = dai_get_drvdata(dai);
+
+	dai_info(dai, "esai_remove()");
+
+	rfree(pdata);
+	dai_set_drvdata(dai, NULL);
+
+	return 0;
+}
+
 static int esai_get_handshake(struct dai *dai, int direction, int stream_id)
 {
 	int handshake = dai->plat_data.fifo[direction].handshake;
@@ -411,6 +423,7 @@ const struct dai_driver esai_driver = {
 		.trigger		= esai_trigger,
 		.set_config		= esai_set_config,
 		.probe			= esai_probe,
+		.remove			= esai_remove,
 		.get_handshake		= esai_get_handshake,
 		.get_fifo		= esai_get_fifo,
 		.get_hw_params		= esai_get_hw_params,

--- a/src/drivers/imx/sai.c
+++ b/src/drivers/imx/sai.c
@@ -393,6 +393,18 @@ static int sai_probe(struct dai *dai)
 	return 0;
 }
 
+static int sai_remove(struct dai *dai)
+{
+	struct sai_pdata *sai = dai_get_drvdata(dai);
+
+	dai_info(dai, "sai_remove()");
+
+	rfree(sai);
+	dai_set_drvdata(dai, NULL);
+
+	return 0;
+}
+
 static int sai_get_handshake(struct dai *dai, int direction, int stream_id)
 {
 	return dai->plat_data.fifo[direction].handshake;
@@ -438,6 +450,7 @@ const struct dai_driver sai_driver = {
 		.trigger		= sai_trigger,
 		.set_config		= sai_set_config,
 		.probe			= sai_probe,
+		.remove			= sai_remove,
 		.get_handshake		= sai_get_handshake,
 		.get_fifo		= sai_get_fifo,
 		.get_hw_params		= sai_get_hw_params,


### PR DESCRIPTION
With dynamic pipeline feature, pipelines are destroyed
when SOF device enters suspend and .remove callback is called in order
to free memory.

SAI/ESAI are missing this callback and the FW crashes. Fix this by
adding .remove callback.

Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>