### PR TITLE
zephyr: only allocate cached memory on cAVS 1.8+

### DIFF
--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -3,7 +3,7 @@ rsource "../Kconfig.sof"
 
 config SOF_ZEPHYR_HEAP_CACHED
 	bool "Cached Zephyr heap for SOF memory non-shared zones"
-	default y if CAVS
+	default y if CAVS && !CAVS_VERSION_1_5
 	default n
 	help
 	  Enable cached heap by mapping cached SOF memory zones to different


### PR DESCRIPTION
Using cached heap allocations on cAVS 1.5 / APL leads to data corruption. Disable it until further investigation.