### PR TITLE
codec_adapter: Fix crash in codec_adapter_free

### DIFF
--- a/src/audio/buffer.c
+++ b/src/audio/buffer.c
@@ -161,6 +161,9 @@ void buffer_free(struct comp_buffer *buffer)
 
 	buf_dbg(buffer, "buffer_free()");
 
+	if (!buffer)
+		return;
+
 	notifier_event(buffer, NOTIFIER_ID_BUFFER_FREE,
 		       NOTIFIER_TARGET_CORE_LOCAL, &cb_data, sizeof(cb_data));
 


### PR DESCRIPTION
mod->local_buff is only allocated when the module is prepared.
With dynamic pipelines we could have the situation where the pipeline
is created then SOF device enters suspend and pipeline is destroyed.

Thus we try to free unallocated mod->local_buf. Fix this by only
freeing local_buff if it is allocated.

Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>