### PR TITLE
xtensa-build-zephyr: use separate Zephyr config for TGPH builds

### DIFF
--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -58,7 +58,7 @@ platform_list = [
 	},
 	{
 		"name": "tgl-h",
-		"PLAT_CONFIG": "intel_adsp_cavs25",
+		"PLAT_CONFIG": "intel_adsp_cavs25_tgph",
 		"XTENSA_CORE": "cavs2x_LX6HiFi3_2017_8",
 		"XTENSA_TOOLS_VERSION": f"RG-2017.8{xtensa_tools_version_postfix}",
 		"RIMAGE_KEY": pathlib.Path("modules", "audio", "sof", "keys", "otc_private_key_3k.pem")

--- a/scripts/xtensa-build-zephyr.sh
+++ b/scripts/xtensa-build-zephyr.sh
@@ -196,6 +196,9 @@ build_platforms()
 				;;
 			tgl-h|tgl)
 				PLAT_CONFIG='intel_adsp_cavs25'
+				if test $platform = tgl-h ; then
+				    PLAT_CONFIG="intel_adsp_cavs25_tgph"
+				fi
 				XTENSA_CORE="cavs2x_LX6HiFi3_2017_8"
 				XTENSA_TOOLS_VERSION="RG-2017.8-linux"
 				RIMAGE_KEY=modules/audio/sof/keys/otc_private_key_3k.pem


### PR DESCRIPTION
Zephyr recently added support for separate configs for 2-core and 4-core
variants of cAVS2.5. Use the new "tgph" configuration for when building
SOF for TigerLake-H variant.

BugLink: https://github.com/thesofproject/sof/issues/5018
Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>