### PR TITLE
zephyr: spinlock: Fix compile time warnings

### DIFF
--- a/src/include/sof/spinlock.h
+++ b/src/include/sof/spinlock.h
@@ -166,6 +166,8 @@ void _k_spin_unlock_irq(struct k_spinlock *lock, k_spinlock_key_t key, int line)
 
 #else
 
+#include <kernel.h>
+
 /* This has to be moved to Zephyr */
 static inline void k_spinlock_init(struct k_spinlock *lock)
 {


### PR DESCRIPTION
With Zephyr, spinlock.h needs to know `struct k_spinlock`
definition.

Include, Zephyr's <kernel.h> header.

This fixes compile time warnings like this:

z/modules/audio/sof/zephyr/../src/include/sof/schedule/ll_schedule_domain.h:
In function 'domain_init'"
z/modules/audio/sof/zephyr/../src/include/sof/schedule/ll_schedule_domain.h:93:18:
warning: passing argument 1 of 'k_spinlock_init' from incompatible
pointer type [-Wincompatible-pointer-types]

Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>