### PR TITLE
ipc4: setdx: prevent d0 when ppl are active

### DIFF
--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -738,7 +738,7 @@ static int ipc4_module_process_d0ix(union ipc4_message_header *ipc4)
 	return 0;
 }
 
-/* power up core 0 */
+/* enable/disable cores according to the state mask */
 static int ipc4_module_process_dx(union ipc4_message_header *ipc4)
 {
 	struct ipc4_module_set_dx dx;


### PR DESCRIPTION
FW should not enter D0 when there are still active pipelines.
Additionally, this pull request fixes infinity loop case in ipc SetDx handler.