### PR TITLE
ipc4: invalidate dcache for host mailbox

### DIFF
--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -757,6 +757,7 @@ static int ipc4_module_process_dx(union ipc4_message_header *ipc4)
 		return IPC4_INVALID_RESOURCE_ID;
 	}
 
+	dcache_invalidate_region((void *)(MAILBOX_HOSTBOX_BASE), sizeof(dx_info));
 	memcpy_s(&dx_info, sizeof(dx_info), (const void *)MAILBOX_HOSTBOX_BASE, sizeof(dx_info));
 
 	/* check if core enable mask is valid */


### PR DESCRIPTION
Fix a regression issue on windows. Need to invalidate dcache
for host message or FW will get garbage data.

Signed-off-by: Rander Wang <rander.wang@intel.com>