### PR TITLE
Audio: volume: Optimize source and sink buffers usage

### DIFF
--- a/src/audio/volume/volume_hifi3.c
+++ b/src/audio/volume/volume_hifi3.c
@@ -24,16 +24,6 @@
 #include <stdint.h>
 
 /**
- * \brief Sets buffer to be circular using HiFi3 functions.
- * \param[in,out] buffer Circular buffer.
- */
-static void vol_setup_circular(const struct audio_stream *buffer)
-{
-	AE_SETCBEGIN0(buffer->addr);
-	AE_SETCEND0(buffer->end_addr);
-}
-
-/**
  * \brief store volume gain 4 times for xtensa multi-way intrinsic operations.
  * Simultaneous processing 2 data.
  * \param[in,out] cd Volume component private data.
@@ -77,15 +67,15 @@ static void vol_s24_to_s24_s32(struct comp_dev *dev, struct audio_stream *sink,
 	ae_f32x2 volume;
 	ae_f32x2 *buf;
 	ae_f32x2 *buf_end;
+	int i, n, m;
+	ae_f32x2 *vol;
 	ae_valign inu;
-	ae_valign outu;
-	int i;
+	ae_valign outu = AE_ZALIGN64();
 	ae_f32x2 *in = (ae_f32x2 *)source->r_ptr;
 	ae_f32x2 *out = (ae_f32x2 *)sink->w_ptr;
-	ae_f32x2 *vol;
 	const int channels_count = sink->channels;
 	const int inc = sizeof(ae_f32x2);
-	const int samples = channels_count * frames;
+	int samples = channels_count * frames;
 
 	/** to ensure the adsress is 8-byte aligned and avoid risk of
 	 * error loading of volume gain while the cd->vol would be set
@@ -95,53 +85,50 @@ static void vol_s24_to_s24_s32(struct comp_dev *dev, struct audio_stream *sink,
 	buf = (ae_f32x2 *)cd->vol;
 	buf_end = (ae_f32x2 *)(cd->vol + channels_count * 2);
 	vol = (ae_f32x2 *)buf;
+	/* Set buf who stores the volume gain data as circular buffer */
+	AE_SETCBEGIN0(buf);
+	AE_SETCEND0(buf_end);
 
-	/* use alignment register to prime the memory to
-	 * avoid risk of buf not aligned to 64 bits.
-	 */
-	AE_LA32X2POS_PC(inu, in);
-	AE_SA64POS_FC(outu, out);
+	while (samples) {
+		m = VOL_BYTES_TO_S32_SAMPLES(audio_stream_bytes_without_wrap(source, in));
+		n = MIN(m, samples);
+		m = VOL_BYTES_TO_S32_SAMPLES(audio_stream_bytes_without_wrap(sink, out));
+		n = MIN(m, n);
+		inu = AE_LA64_PP(in);
+		/* process two continuous sample data once */
+		for (i = 0; i < n; i += 2) {
+			/* Load the volume value */
+			AE_L32X2_XC(volume, vol, inc);
 
-	/* process two continuous sample data once */
-	for (i = 0; i < samples; i += 2) {
-		/* Set buf who stores the volume gain data as circular buffer */
-		AE_SETCBEGIN0(buf);
-		AE_SETCEND0(buf_end);
+			/* Load the input sample */
+			AE_LA32X2_IP(in_sample, inu, in);
 
-		/* Load the volume value */
-		AE_L32X2_XC(volume, vol, inc);
-
-		/* Set source as circular buffer */
-		vol_setup_circular(source);
-
-		/* Load the input sample */
-		AE_LA32X2_IC(in_sample, inu, in);
-
-		/* Multiply the input sample */
+			/* Multiply the input sample */
 #if COMP_VOLUME_Q8_16
-		out_sample = AE_MULFP32X2RS(AE_SLAI32S(volume, 7), AE_SLAI32(in_sample, 8));
+			out_sample = AE_MULFP32X2RS(AE_SLAI32S(volume, 7), AE_SLAI32(in_sample, 8));
 #elif COMP_VOLUME_Q1_23
-		out_sample = AE_MULFP32X2RS(volume, AE_SLAI32(in_sample, 8));
+			out_sample = AE_MULFP32X2RS(volume, AE_SLAI32(in_sample, 8));
 #else
 #error "Need CONFIG_COMP_VOLUME_Qx_y"
 #endif
 
-		/* Shift for S24_LE */
-		out_sample = AE_SLAI32S(out_sample, 8);
-		out_sample = AE_SRAI32(out_sample, 8);
+			/* Shift for S24_LE */
+			out_sample = AE_SLAI32S(out_sample, 8);
+			out_sample = AE_SRAI32(out_sample, 8);
 
-		/* Set sink as circular buffer */
-		vol_setup_circular(sink);
+			/* Store the output sample */
+			AE_SA32X2_IP(out_sample, outu, out);
 
-		/* Store the output sample */
-		AE_SA32X2_IC(out_sample, outu, out);
-
-		/* calc peak vol
-		 * TODO: fix channel value
-		 */
-		peak_vol_calc(cd, out_sample, 0);
+			/* calc peak vol
+			 * TODO: fix channel value
+			 */
+			peak_vol_calc(cd, out_sample, 0);
+		}
+		AE_SA64POS_FP(outu, out);
+		samples -= n;
+		in = audio_stream_wrap(source, in);
+		out = audio_stream_wrap(sink, out);
 	}
-
 	/* update peak vol */
 	peak_vol_update(cd);
 }
@@ -163,19 +150,19 @@ static void vol_s32_to_s24_s32(struct comp_dev *dev, struct audio_stream *sink,
 	ae_f32x2 in_sample = AE_ZERO32();
 	ae_f32x2 out_sample;
 	ae_f32x2 volume;
-	int i;
+	int i, n, m;
 	ae_f64 mult0;
 	ae_f64 mult1;
 	ae_f32x2 *buf;
 	ae_f32x2 *buf_end;
 	ae_f32x2 *vol;
+	ae_valign inu;
+	ae_valign outu = AE_ZALIGN64();
 	const int inc = sizeof(ae_f32x2);
 	const int channels_count = sink->channels;
-	const int samples = channels_count * frames;
+	int samples = channels_count * frames;
 	ae_f32x2 *in = (ae_f32x2 *)source->r_ptr;
 	ae_f32x2 *out = (ae_f32x2 *)sink->w_ptr;
-	ae_valign inu;
-	ae_valign outu;
 
 	/** to ensure the address is 8-byte aligned and avoid risk of
 	 * error loading of volume gain while the cd->vol would be set
@@ -185,52 +172,52 @@ static void vol_s32_to_s24_s32(struct comp_dev *dev, struct audio_stream *sink,
 	buf = (ae_f32x2 *)cd->vol;
 	buf_end = (ae_f32x2 *)(cd->vol + channels_count * 2);
 	vol = (ae_f32x2 *)buf;
+	/* Set buf who stores the volume gain data as circular buffer */
+	AE_SETCBEGIN0(buf);
+	AE_SETCEND0(buf_end);
+	while (samples) {
+		m = VOL_BYTES_TO_S32_SAMPLES(audio_stream_bytes_without_wrap(source, in));
+		n = MIN(m, samples);
+		m = VOL_BYTES_TO_S32_SAMPLES(audio_stream_bytes_without_wrap(sink, out));
+		n = MIN(m, n);
+		inu = AE_LA64_PP(in);
+		/* process two continuous sample data once */
+		for (i = 0; i < n; i += 2) {
+			/* Load the volume value */
+			AE_L32X2_XC(volume, vol, inc);
 
-	/* use alignment register to prime the memory to
-	 * avoid risk of buf not aligned to 64 bits.
-	 */
-	AE_LA32X2POS_PC(inu, in);
-	AE_SA64POS_FC(outu, out);
-
-	/* process two continuous sample data once */
-	for (i = 0; i < samples; i += 2) {
-		/* Set buf who stores the volume gain data as circular buffer */
-		AE_SETCBEGIN0(buf);
-		AE_SETCEND0(buf_end);
-
-		/* Load the volume value */
-		AE_L32X2_XC(volume, vol, inc);
-
-		/* Set source as circular buffer */
-		vol_setup_circular(source);
-
-		/* Load the input sample */
-		AE_LA32X2_IC(in_sample, inu, in);
+			/* Load the input sample */
+			AE_LA32X2_IP(in_sample, inu, in);
 
 #if COMP_VOLUME_Q8_16
-		mult0 = AE_MULF32S_HH(volume, in_sample);	/* Q8.16 x Q1.31 << 1 -> Q9.48 */
-		mult0 = AE_SRAI64(mult0, 1);			/* Q9.47 */
-		mult1 = AE_MULF32S_LL(volume, in_sample);
-		mult1 = AE_SRAI64(mult1, 1);
-		out_sample = AE_ROUND32X2F48SSYM(mult0, mult1);	/* Q9.47 -> Q1.31 */
+			/* Q8.16 x Q1.31 << 1 -> Q9.48 */
+			mult0 = AE_MULF32S_HH(volume, in_sample);
+			mult0 = AE_SRAI64(mult0, 1);			/* Q9.47 */
+			mult1 = AE_MULF32S_LL(volume, in_sample);
+			mult1 = AE_SRAI64(mult1, 1);
+			out_sample = AE_ROUND32X2F48SSYM(mult0, mult1);	/* Q9.47 -> Q1.31 */
 #elif COMP_VOLUME_Q1_23
-		mult0 = AE_MULF32S_HH(volume, in_sample);	/* Q1.23 x Q1.31 << 1 -> Q2.55 */
-		mult0 = AE_SRAI64(mult0, 8);			/* Q2.47 */
-		mult1 = AE_MULF32S_LL(volume, in_sample);
-		mult1 = AE_SRAI64(mult1, 8);
-		out_sample = AE_ROUND32X2F48SSYM(mult0, mult1);	/* Q2.47 -> Q1.31 */
+			/* Q1.23 x Q1.31 << 1 -> Q2.55 */
+			mult0 = AE_MULF32S_HH(volume, in_sample);
+			mult0 = AE_SRAI64(mult0, 8);			/* Q2.47 */
+			mult1 = AE_MULF32S_LL(volume, in_sample);
+			mult1 = AE_SRAI64(mult1, 8);
+			out_sample = AE_ROUND32X2F48SSYM(mult0, mult1);	/* Q2.47 -> Q1.31 */
 #else
 #error "Need CONFIG_COMP_VOLUME_Qx_y"
 #endif
-		vol_setup_circular(sink);
-		AE_SA32X2_IC(out_sample, outu, out);
+			AE_SA32X2_IP(out_sample, outu, out);
 
-		/* calc peak vol
-		 * TODO: fix channel value
-		 */
-		peak_vol_calc(cd, out_sample, 0);
+			/* calc peak vol
+			 * TODO: fix channel value
+			 */
+			peak_vol_calc(cd, out_sample, 0);
+		}
+		AE_SA64POS_FP(outu, out);
+		samples -= n;
+		in = audio_stream_wrap(source, in);
+		out = audio_stream_wrap(sink, out);
 	}
-
 	/* update peak vol */
 	peak_vol_update(cd);
 }
@@ -252,17 +239,17 @@ static void vol_s16_to_s16(struct comp_dev *dev, struct audio_stream *sink,
 	ae_f32x2 out_sample0, out_sample1;
 	ae_f16x4 in_sample = AE_ZERO16();
 	ae_f16x4 out_sample = AE_ZERO16();
-	int i;
+	int i, n, m;
 	ae_f32x2 *buf;
 	ae_f32x2 *buf_end;
 	ae_f32x2 *vol;
 	ae_valign inu;
-	ae_valign outu;
+	ae_valign outu = AE_ZALIGN64();
 	ae_f16x4 *in = (ae_f16x4 *)source->r_ptr;
 	ae_f16x4 *out = (ae_f16x4 *)sink->w_ptr;
 	const int channels_count = sink->channels;
 	const int inc = sizeof(ae_f32x2);
-	const int samples = channels_count * frames;
+	int samples = channels_count * frames;
 
 	/** to ensure the adsress is 8-byte aligned and avoid risk of
 	 * error loading of volume gain while the cd->vol would be set
@@ -273,59 +260,56 @@ static void vol_s16_to_s16(struct comp_dev *dev, struct audio_stream *sink,
 	buf_end = (ae_f32x2 *)(cd->vol + channels_count * 4);
 	vol = buf;
 
-	/*
-	 * use alignment register to prime the volume memory to avoid
-	 * risk of buf not aligned to 8-byte
-	 */
-	AE_LA16X4POS_PC(inu, in);
-	AE_SA64POS_FC(outu, out);
+	/* Set buf as circular buffer */
+	AE_SETCBEGIN0(buf);
+	AE_SETCEND0(buf_end);
+	while (samples) {
+		m = VOL_BYTES_TO_S16_SAMPLES(audio_stream_bytes_without_wrap(source, in));
+		n = MIN(m, samples);
+		m = VOL_BYTES_TO_S16_SAMPLES(audio_stream_bytes_without_wrap(sink, out));
+		n = MIN(m, n);
+		inu = AE_LA64_PP(in);
+		for (i = 0; i < n; i += 4) {
+			/* load first two volume gain */
+			AE_L32X2_XC(volume0, vol, inc);
 
-	for (i = 0; i < samples; i += 4) {
-		/* Set buf as circular buffer */
-		AE_SETCBEGIN0(buf);
-		AE_SETCEND0(buf_end);
-
-		/* load first two volume gain */
-		AE_L32X2_XC(volume0, vol, inc);
-
-		/* load second two volume gain */
-		AE_L32X2_XC(volume1, vol, inc);
+			/* load second two volume gain */
+			AE_L32X2_XC(volume1, vol, inc);
 
 #if COMP_VOLUME_Q8_16
-		/* Q8.16 to Q9.23 */
-		volume0 = AE_SLAI32S(volume0, 7);
-		volume1 = AE_SLAI32S(volume1, 7);
+			/* Q8.16 to Q9.23 */
+			volume0 = AE_SLAI32S(volume0, 7);
+			volume1 = AE_SLAI32S(volume1, 7);
 #elif COMP_VOLUME_Q1_23
-		/* No need to shift, Q1.23 is OK as such */
+			/* No need to shift, Q1.23 is OK as such */
 #else
 #error "Need CONFIG_COMP_VOLUME_Qx_y"
 #endif
+			/* Load the input sample */
+			AE_LA16X4_IP(in_sample, inu, in);
 
-		/* Set source as circular buffer */
-		vol_setup_circular(source);
+			/* Multiply the input sample */
+			out_sample0 = AE_MULFP32X16X2RS_H(volume0, in_sample);
+			out_sample1 = AE_MULFP32X16X2RS_L(volume1, in_sample);
 
-		/* Load the input sample */
-		AE_LA16X4_IC(in_sample, inu, in);
+			/* Q9.23 to Q1.31 */
+			out_sample0 = AE_SLAI32S(out_sample0, 8);
+			out_sample1 = AE_SLAI32S(out_sample1, 8);
 
-		/* Multiply the input sample */
-		out_sample0 = AE_MULFP32X16X2RS_H(volume0, in_sample);
-		out_sample1 = AE_MULFP32X16X2RS_L(volume1, in_sample);
+			/* store the output */
+			out_sample = AE_ROUND16X4F32SSYM(out_sample0, out_sample1);
+			// AE_SA16X4_IC(out_sample, outu, out);
+			AE_SA16X4_IP(out_sample, outu, out);
 
-		/* Q9.23 to Q1.31 */
-		out_sample0 = AE_SLAI32S(out_sample0, 8);
-		out_sample1 = AE_SLAI32S(out_sample1, 8);
-
-		/* Set sink as circular buffer */
-		vol_setup_circular(sink);
-
-		/* store the output */
-		out_sample = AE_ROUND16X4F32SSYM(out_sample0, out_sample1);
-		AE_SA16X4_IC(out_sample, outu, out);
-
-		/* calc peak vol
-		 * TODO: fix channel value
-		 */
-		peak_vol_calc(cd, out_sample0, 0);
+			/* calc peak vol
+			 * TODO: fix channel value
+			 */
+			peak_vol_calc(cd, out_sample0, 0);
+		}
+		AE_SA64POS_FP(outu, out);
+		samples -= n;
+		in = audio_stream_wrap(source, in);
+		out = audio_stream_wrap(sink, out);
 	}
 	/* update peak vol */
 	peak_vol_update(cd);


### PR DESCRIPTION
This patch replaces the audio stream read/write frag based
access to source and sink by block processing based on
audio_stream_bytes_without_wrap() bytes count.

Test all platform first.

Signed-off-by: Andrula Song <xiaoyuan.song@intel.com>