### PR TITLE
zephyr: fix race in secondary core power-up

### DIFF
--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -25,6 +25,7 @@
 #include <device.h>
 #include <soc.h>
 #include <kernel.h>
+#include <version.h>
 
 #if !CONFIG_KERNEL_COHERENCE
 #include <arch/xtensa/cache.h>
@@ -767,6 +768,10 @@ int z_wrapper_cpu_enable_secondary_core(int id)
 
 	if (arch_cpu_active(id))
 		return 0;
+
+#if ZEPHYR_VERSION(3, 0, 99) <= ZEPHYR_VERSION_CODE
+	z_init_cpu(id);
+#endif
 
 	atomic_clear(&start_flag);
 	atomic_clear(&ready_flag);


### PR DESCRIPTION
z_wrapper_cpu_enable_secondary_core() may be called
repeatedly on a core that is already running. Add a check
to ensure we do not try to restart a core that is already
running.

Also add a check for ready_flag as done in upstream Zephyr
kernel/smp.c to ensure z_wrapper_cpu_enable_secondary_core()
does not return until the target core has finished its
startup and arch_cpu_active() returns true.

BugLink: https://github.com/thesofproject/sof/issues/5446
Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>