### PR TITLE
google_rtc: copy ipc to dev (Backport to tgl-013-drop-stable)

### DIFF
--- a/src/audio/google_rtc_audio_processing.c
+++ b/src/audio/google_rtc_audio_processing.c
@@ -149,8 +149,11 @@ static struct comp_dev *google_rtc_audio_processing_create(
 
 	/* Create component device with an effect processing component */
 	dev = comp_alloc(drv, sizeof(*dev));
+
 	if (!dev)
 		return NULL;
+
+	dev->ipc_config = *config;
 
 	/* Create private component data */
 	cd = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM, sizeof(*cd));


### PR DESCRIPTION
This is possibly a copy paste bug from the smart amp component.

Signed-off-by: Curtis Malainey <cujomalainey@chromium.org>
(cherry picked from commit 8b519858c5b2951403715aff7b1583c668596a76)