### PR TITLE
topology1: sof-glk-es8336: use mclk ID0

### DIFF
--- a/tools/topology/topology1/sof-glk-es8336.m4
+++ b/tools/topology/topology1/sof-glk-es8336.m4
@@ -161,7 +161,7 @@ DAI_CONFIG(SSP, SSP_NUM, 0, `SSP'SSP_NUM`-Codec',
 		SSP_CLOCK(bclk, 2400000, codec_slave),
 		SSP_CLOCK(fsync, 48000, codec_slave),
 		SSP_TDM(2, 25, 3, 3),
-		SSP_CONFIG_DATA(SSP, SSP_NUM, 24, 1)))
+		SSP_CONFIG_DATA(SSP, SSP_NUM, 24, 0)))
 
 
 # 3 HDMI/DP outputs (ID: 3,4,5)


### PR DESCRIPTION
It's not clear why the initial contribution used mclk ID1, mclk ID0 is
used by 99% of devices - and a manual inspection of NHLT supports that
claim. We will have to deal with the MCLK ID1 case with quirks.

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>