### PR TITLE
codec_adapter: Move input/output buffer allocation to prepare

### DIFF
--- a/src/include/sof/audio/codec_adapter/codec/generic.h
+++ b/src/include/sof/audio/codec_adapter/codec/generic.h
@@ -282,6 +282,9 @@ struct processing_module {
 	struct comp_dev *dev;
 	uint32_t period_bytes; /** pipeline period bytes */
 	uint32_t deep_buff_bytes; /**< copy start threshold */
+	uint32_t output_buffer_size; /**< size of local buffer to save produced samples */
+	struct input_stream_buffer *input_buffers;
+	struct output_stream_buffer *output_buffers;
 	uint32_t num_input_buffers; /**< number of input buffers */
 	uint32_t num_output_buffers; /**< number of output buffers */
 };


### PR DESCRIPTION
Add 2 fields for input_buffers and output_buffers to struct
processing_module. Move the memory allocation for input/output
buffers for the module to the prepare op from the copy op.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>