### PR TITLE
codec_adapter: dts: remove included header

### DIFF
--- a/src/audio/codec_adapter/codec/dts.c
+++ b/src/audio/codec_adapter/codec/dts.c
@@ -5,7 +5,6 @@
 // Author: Mark Barton <mark.barton@xperi.com>
 
 #include "sof/audio/codec_adapter/codec/generic.h"
-#include "sof/audio/codec_adapter/codec/dts.h"
 
 #include "DtsSofInterface.h"
 


### PR DESCRIPTION
dts.h has been deleted.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>