### PR TITLE
topology1: Simplify the DMICPROC selection

### DIFF
--- a/tools/topology/topology1/platform/intel/intel-generic-dmic-kwd.m4
+++ b/tools/topology/topology1/platform/intel/intel-generic-dmic-kwd.m4
@@ -45,21 +45,10 @@ ifdef(`DMIC_PIPELINE_48k_CORE_ID',`',define(DMIC_PIPELINE_48k_CORE_ID, 0))
 ifdef(`DMIC_DAI_LINK_16k_NAME',`',define(DMIC_DAI_LINK_16k_NAME, `dmic16k'))
 
 # DMICPROC is set by makefile, available type: passthrough/eq-iir-volume
-ifdef(`IGO',
-`define(DMICPROC, igonr)',
-`ifdef(`RTNR',
-`define(DMICPROC, rtnr)',
-`ifdef(`GOOGLE_RTC_AUDIO_PROCESSING',
-`define(DMICPROC, google-rtc-audio-processing)', `define(DMICPROC, passthrough)')')')
+ifdef(`DMICPROC', `', `define(DMICPROC, passthrough)')
 
-# Prolong period to 16ms for igo_nr process
-ifdef(`IGO',
-  `define(`INTEL_GENERIC_DMIC_KWD_PERIOD', 16000)',
-  `ifdef(`GOOGLE_RTC_AUDIO_PROCESSING',
-    `define(`INTEL_GENERIC_DMIC_KWD_PERIOD', 10000)',
-	`define(`INTEL_GENERIC_DMIC_KWD_PERIOD', 1000)'
-  )'
-)
+dnl Unless explicitly specified, dmic period at 48k is 1ms
+ifdef(`DMIC_48k_PERIOD_US', `', `define(`DMIC_48k_PERIOD_US', 1000)')
 
 # define(DMIC_DAI_LINK_16k_PDM, `STEREO_PDM0') define the PDM port, default is STEREO_PDM0
 ifdef(`DMIC_DAI_LINK_16k_PDM',`',`define(DMIC_DAI_LINK_16k_PDM, `STEREO_PDM0')')
@@ -86,7 +75,7 @@ define(`PGA_NAME', Dmic0)
 
 PIPELINE_PCM_ADD(sof/pipe-`DMICPROC'-capture.m4,
         DMIC_PIPELINE_48k_ID, DMIC_PCM_48k_ID, CHANNELS, s32le,
-        INTEL_GENERIC_DMIC_KWD_PERIOD, 0, DMIC_PIPELINE_48k_CORE_ID, 48000, 48000, 48000)
+        DMIC_48k_PERIOD_US, 0, DMIC_PIPELINE_48k_CORE_ID, 48000, 48000, 48000)
 undefine(`PGA_NAME')
 undefine(`PIPELINE_FILTER1')
 undefine(`PIPELINE_FILTER2')
@@ -119,7 +108,7 @@ dnl     deadline, priority, core, time_domain)
 DAI_ADD(sof/pipe-dai-capture.m4,
         DMIC_PIPELINE_48k_ID, DMIC, 0, DMIC_DAI_LINK_48k_NAME,
         concat(`PIPELINE_SINK_', DMIC_PIPELINE_48k_ID), 2, s32le,
-        INTEL_GENERIC_DMIC_KWD_PERIOD, 0, DMIC_PIPELINE_48k_CORE_ID, SCHEDULE_TIME_DOMAIN_TIMER)
+        DMIC_48k_PERIOD_US, 0, DMIC_PIPELINE_48k_CORE_ID, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is DMIC 1 using 3 periods
 # Buffers use s32le format, with 320 frame per 20000us on core 0 with priority 0

--- a/tools/topology/topology1/platform/intel/intel-generic-dmic.m4
+++ b/tools/topology/topology1/platform/intel/intel-generic-dmic.m4
@@ -42,6 +42,9 @@ ifdef(`DMIC_PCM_CHANNELS', `', `define(DMIC_PCM_CHANNELS, CHANNELS)')
 ifdef(`DMIC16K_DAI_CHANNELS', `', `define(DMIC16K_DAI_CHANNELS, CHANNELS)')
 ifdef(`DMIC16K_PCM_CHANNELS', `', `define(DMIC16K_PCM_CHANNELS, CHANNELS)')
 
+dnl Unless explicitly specified, dmic period at 48k is 1ms
+ifdef(`DMIC_48k_PERIOD_US', `', `define(DMIC_48k_PERIOD_US, 1000)')
+
 ## Prolong period to 4ms for RTNR
 ifdef(`RTNR', `define(`INTEL_GENERIC_DMIC_PERIOD', 4000)', `define(`INTEL_GENERIC_DMIC_PERIOD', 1000)')
 ifdef(`RTNR', `define(`INTEL_GENERIC_DMIC_PERIOD_INV', 250)', `define(`INTEL_GENERIC_DMIC_PERIOD_INV', 1000)')
@@ -86,7 +89,7 @@ define(`PGA_NAME', Dmic0)
 
 PIPELINE_PCM_ADD(sof/pipe-DMICPROC-capture.m4,
 	DMIC_PIPELINE_48k_ID, DMIC_PCM_48k_ID, DMIC_PCM_CHANNELS, s32le,
-	1000, 0, DMIC_48k_CORE_ID, 48000, 48000, 48000)
+	DMIC_48k_PERIOD_US, 0, DMIC_48k_CORE_ID, 48000, 48000, 48000)
 
 undefine(`PGA_NAME')
 undefine(`PIPELINE_FILTER1')
@@ -124,7 +127,7 @@ dnl     deadline, priority, core, time_domain)
 DAI_ADD(sof/pipe-dai-capture.m4,
 	DMIC_PIPELINE_48k_ID, DMIC, 0, DMIC_DAI_LINK_48k_NAME,
 	concat(`PIPELINE_SINK_', DMIC_PIPELINE_48k_ID), 2, s32le,
-	1000, 0, DMIC_48k_CORE_ID, SCHEDULE_TIME_DOMAIN_TIMER)
+	DMIC_48k_PERIOD_US, 0, DMIC_48k_CORE_ID, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is DMIC 1 using 2 periods
 # Buffers use s32le format, with 16 frame per 1000us on core 0 with priority 0

--- a/tools/topology/topology1/sof-tgl-max98357a-rt5682.m4
+++ b/tools/topology/topology1/sof-tgl-max98357a-rt5682.m4
@@ -134,7 +134,17 @@ define(DMIC_PIPELINE_KWD_ID, `12')
 define(DMIC_DAI_LINK_16k_ID, `2')
 define(DMIC_PIPELINE_48k_CORE_ID, `1')
 
+ifdef(`RTNR', `define(`DMICPROC', rtnr)', `')
+ifdef(`GOOGLE_RTC_AUDIO_PROCESSING',
+	`define(`DMICPROC', google-rtc-audio-processing)'
+	`define(`DMIC_48k_PERIOD_US', 10000)'
+	,
+	`')
+
 ifdef(`GOOGLE_RTC_AUDIO_PROCESSING', `define(`SPK_PLAYBACK_CORE', DMIC_PIPELINE_48k_CORE_ID)', `define(`SPK_PLAYBACK_CORE', `0')')
+
+# Google RTC Audio processing processes 10ms at a time. It needs to have time to process it.
+ifdef(`GOOGLE_RTC_AUDIO_PROCESSING', `define(`DMIC_48k_PERIOD', 10000)', `')
 
 # define pcm, pipeline and dai id
 define(KWD_PIPE_SCH_DEADLINE_US, 5000)

--- a/tools/topology/topology1/sof-tgl-max98373-rt5682.m4
+++ b/tools/topology/topology1/sof-tgl-max98373-rt5682.m4
@@ -84,6 +84,12 @@ define(DMIC_DAI_LINK_16k_ID, `2')
 define(DMIC_PIPELINE_48k_CORE_ID, 1)
 # define pcm, pipeline and dai id
 define(KWD_PIPE_SCH_DEADLINE_US, 20000)
+
+ifdef(`IGO',
+  `define(`DMICPROC', igonr)'
+  `define(`DMIC_48k_PERIOD_US', 16000)',
+  `')
+
 # include the generic dmic with kwd
 include(`platform/intel/intel-generic-dmic-kwd.m4')
 


### PR DESCRIPTION
This should make sure to surface pipeline period and microphone
processing in the top topology file so incoherence are easier to spot
and correct.

I compared topology1/production/*.conf outputs prior and after the
change: except some new line and comment change introduced by the
simplification, there are no changes.

Signed-off-by: Lionel Koenig <lionelk@google.com>