### PR TITLE
xtensa-build-all.sh: Default private key leaking between platforms

### DIFF
--- a/scripts/xtensa-build-all.sh
+++ b/scripts/xtensa-build-all.sh
@@ -7,8 +7,8 @@ set -e
 
 # Platforms with a toolchain available in the latest Docker image and
 # built by the -a option.
-DEFAULT_PLATFORMS=(  byt cht bdw hsw apl skl kbl cnl sue icl jsl \
-                    imx8 imx8x imx8m imx8ulp tgl tgl-h rn mt8186 mt8195 )
+DEFAULT_PLATFORMS=(  byt cht bdw hsw tgl tgl-h apl skl kbl cnl sue icl jsl \
+                    imx8 imx8x imx8m imx8ulp rn mt8186 mt8195 )
 
 # Work in progress can be added to this "staging area" without breaking
 # the -a option for everyone.
@@ -185,6 +185,7 @@ for platform in "${PLATFORMS[@]}"
 do
 	HAVE_ROM='no'
 	DEFCONFIG_PATCH=''
+	PLATFORM_PRIVATE_KEY=''
 
 	case $platform in
 		byt)
@@ -281,10 +282,7 @@ do
 			XTENSA_TOOLS_VERSION="RG-2017.8-linux"
 			HAVE_ROM='yes'
 			# default key for TGL
-			if [ -z "$PRIVATE_KEY_OPTION" ]
-			then
-	PRIVATE_KEY_OPTION="-D${SIGNING_TOOL}_PRIVATE_KEY=$SOF_TOP/keys/otc_private_key_3k.pem"
-			fi
+	PLATFORM_PRIVATE_KEY="-D${SIGNING_TOOL}_PRIVATE_KEY=$SOF_TOP/keys/otc_private_key_3k.pem"
 			;;
 		tgl-h)
 			PLATFORM="tgph"
@@ -293,10 +291,7 @@ do
 			XTENSA_TOOLS_VERSION="RG-2017.8-linux"
 			HAVE_ROM='yes'
 			# default key for TGL
-			if [ -z "$PRIVATE_KEY_OPTION" ]
-			then
-	PRIVATE_KEY_OPTION="-D${SIGNING_TOOL}_PRIVATE_KEY=$SOF_TOP/keys/otc_private_key_3k.pem"
-			fi
+	PLATFORM_PRIVATE_KEY="-D${SIGNING_TOOL}_PRIVATE_KEY=$SOF_TOP/keys/otc_private_key_3k.pem"
 			;;
 		jsl)
 			PLATFORM="jasperlake"
@@ -349,6 +344,8 @@ do
 			;;
 
 	esac
+
+	test -z "${PRIVATE_KEY_OPTION}" || PLATFORM_PRIVATE_KEY="${PRIVATE_KEY_OPTION}"
 
 	if [ -n "$XTENSA_TOOLS_ROOT" ]
 	then
@@ -403,7 +400,7 @@ do
 		-DROOT_DIR="$ROOT" \
 		-DMEU_OPENSSL="${MEU_OPENSSL}" \
 		"${MEU_PATH_OPTION}" \
-		"${PRIVATE_KEY_OPTION}" \
+		"${PLATFORM_PRIVATE_KEY}" \
 		-DINIT_CONFIG=${PLATFORM}${DEFCONFIG_PATCH}_defconfig \
 		-DEXTRA_CFLAGS="${EXTRA_CFLAGS}" \
 		"$SOF_TOP"

--- a/scripts/xtensa-build-all.sh
+++ b/scripts/xtensa-build-all.sh
@@ -275,23 +275,14 @@ do
 			XTENSA_TOOLS_VERSION="RG-2017.8-linux"
 			HAVE_ROM='yes'
 			;;
-		tgl)
+		tgl|tgl-h)
 			PLATFORM="tgplp"
 			XTENSA_CORE="cavs2x_LX6HiFi3_2017_8"
 			HOST="xtensa-cnl-elf"
 			XTENSA_TOOLS_VERSION="RG-2017.8-linux"
 			HAVE_ROM='yes'
 			# default key for TGL
-	PLATFORM_PRIVATE_KEY="-D${SIGNING_TOOL}_PRIVATE_KEY=$SOF_TOP/keys/otc_private_key_3k.pem"
-			;;
-		tgl-h)
-			PLATFORM="tgph"
-			XTENSA_CORE="cavs2x_LX6HiFi3_2017_8"
-			HOST="xtensa-cnl-elf"
-			XTENSA_TOOLS_VERSION="RG-2017.8-linux"
-			HAVE_ROM='yes'
-			# default key for TGL
-	PLATFORM_PRIVATE_KEY="-D${SIGNING_TOOL}_PRIVATE_KEY=$SOF_TOP/keys/otc_private_key_3k.pem"
+			PLATFORM_PRIVATE_KEY="-D${SIGNING_TOOL}_PRIVATE_KEY=$SOF_TOP/keys/otc_private_key_3k.pem"
 			;;
 		jsl)
 			PLATFORM="jasperlake"
@@ -330,12 +321,12 @@ do
 			HOST="xtensa-rn-elf"
 			XTENSA_TOOLS_VERSION="RF-2016.4-linux"
 			;;
-                mt8186)
-                        PLATFORM="mt8186"
-                        XTENSA_CORE="hifi5_7stg_I64D128"
-                        HOST="xtensa-mt8186-elf"
-                        XTENSA_TOOLS_VERSION="RI-2020.5-linux"
-                        ;;
+		mt8186)
+			PLATFORM="mt8186"
+			XTENSA_CORE="hifi5_7stg_I64D128"
+			HOST="xtensa-mt8186-elf"
+			XTENSA_TOOLS_VERSION="RI-2020.5-linux"
+			;;
 		mt8195)
 			PLATFORM="mt8195"
 			XTENSA_CORE="hifi4_8195_PROD"


### PR DESCRIPTION
Private key file passed by user is stored in PRIVATE_KEY_OPTION variable. When building for many platforms, if user not pass path to key file, default value will be set in PRIVATE_KEY_OPTION. During building second platform, default key from the first one are treated as key passed by user and default key will not be applied.

I introduced the new variable PLATFORM_PRIVATE_KEY, which holds default signing key for current platform. If user passed own key, this value is later set in this variable. The xtensa-build-zephyr script works the same way. Changed DEFAULT_PLATFORMS and moved TGL platform to the middle of the list to make sure any future leakage like this one is detected immediately.