### PR TITLE
topology1: mt8195: support 2ms pipeline capture period

### DIFF
--- a/tools/topology/topology1/sof-mt8195-mt6359-rt1019-rt5682.m4
+++ b/tools/topology/topology1/sof-mt8195-mt6359-rt1019-rt5682.m4
@@ -51,17 +51,17 @@ PIPELINE_PCM_ADD(
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 3 on PCM 18 using max 2 channels of s16le
-# Set 1000us deadline with priority 0 on core 0
+# Set 2000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
 	3, 18, 2, s16le,
-	1000, 0, 0,
+	2000, 0, 0,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 4 on PCM 19 using max 2 channels of s16le
-# Set 1000us deadline with priority 0 on core 0
+# Set 2000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
 	4, 19, 2, s16le,
-	1000, 0, 0,
+	2000, 0, 0,
 	48000, 48000, 48000)
 
 #
@@ -89,18 +89,18 @@ DAI_ADD(sof/pipe-dai-playback.m4,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is AFE using 2 periods
-# Buffers use s16le format, with 48 frame per 1000us on core 0 with priority 0
+# Buffers use s16le format, with 48 frame per 2000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	3, AFE, 2, AFE_SOF_UL4,
 	PIPELINE_SINK_3, 2, s16le,
-	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+	2000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is AFE using 2 periods
-# Buffers use s16le format, with 48 frame per 1000us on core 0 with priority 0
+# Buffers use s16le format, with 48 frame per 2000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	4, AFE, 3, AFE_SOF_UL5,
 	PIPELINE_SINK_4, 2, s16le,
-	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+	2000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 #SCHEDULE_TIME_DOMAIN_DMA
 dnl PCM_PLAYBACK_ADD(name, pcm_id, playback)


### PR DESCRIPTION
Hi,
This PR changes the capture pipeline period to 2ms.
When host is more heavy loading(e.g. camera recoding case),
the size of dai buffer is 4ms and not enough. Increase 2ms
period capture pipeline to buffer more data to avoid overrun.
Please help to review it. Thanks