### PR TITLE
dma: make DMA platform data static

### DIFF
--- a/src/platform/amd/renoir/lib/dma.c
+++ b/src/platform/amd/renoir/lib/dma.c
@@ -22,7 +22,7 @@ extern struct dma_ops acp_dai_bt_dma_ops;
 #endif
 extern struct dma_ops acp_dai_sp_dma_ops;
 
-SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
+static SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
 {
 	.plat_data = {
 		.id		= DMA_ID_DMA0,
@@ -78,7 +78,7 @@ SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
 #endif
 };
 
-const struct dma_info lib_dma = {
+static const struct dma_info lib_dma = {
 	.dma_array = dma,
 	.num_dmas = ARRAY_SIZE(dma)
 };

--- a/src/platform/baytrail/lib/dma.c
+++ b/src/platform/baytrail/lib/dma.c
@@ -12,7 +12,7 @@
 #include <sof/sof.h>
 #include <sof/spinlock.h>
 
-const struct dw_drv_plat_data dmac0 = {
+static const struct dw_drv_plat_data dmac0 = {
 	.chan[0] = {
 		.class	= 6,
 		.weight = 0,
@@ -47,7 +47,7 @@ const struct dw_drv_plat_data dmac0 = {
 	},
 };
 
-const struct dw_drv_plat_data dmac1 = {
+static const struct dw_drv_plat_data dmac1 = {
 	.chan[0] = {
 		.class	= 7,
 		.weight = 0,
@@ -83,7 +83,7 @@ const struct dw_drv_plat_data dmac1 = {
 };
 
 #if defined CONFIG_CHERRYTRAIL_EXTRA_DW_DMA
-const struct dw_drv_plat_data dmac2 = {
+static const struct dw_drv_plat_data dmac2 = {
 	.chan[0] = {
 		.class	= 7,
 		.weight = 0,
@@ -135,7 +135,7 @@ const struct dw_drv_plat_data dmac2 = {
  *    Channels 2-7 - Mem to Mem
  *
  */
-SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
+static SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
 {
 	/* DMAC 0 Mem2Phe and Phe2Mem Transfers */
 	.plat_data = {
@@ -185,7 +185,7 @@ SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
 #endif
 };
 
-const struct dma_info lib_dma = {
+static const struct dma_info lib_dma = {
 	.dma_array = dma,
 	.num_dmas = ARRAY_SIZE(dma)
 };

--- a/src/platform/haswell/lib/dma.c
+++ b/src/platform/haswell/lib/dma.c
@@ -14,7 +14,7 @@
 #include <sof/sof.h>
 #include <sof/spinlock.h>
 
-const struct dw_drv_plat_data dmac0 = {
+static const struct dw_drv_plat_data dmac0 = {
 	.chan[0] = {
 		.class	= 6,
 		.weight = 0,
@@ -49,7 +49,7 @@ const struct dw_drv_plat_data dmac0 = {
 	},
 };
 
-const struct dw_drv_plat_data dmac1 = {
+static const struct dw_drv_plat_data dmac1 = {
 	.chan[0] = {
 		.class	= 7,
 		.weight = 0,
@@ -84,7 +84,7 @@ const struct dw_drv_plat_data dmac1 = {
 	},
 };
 
-SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
+static SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
 {
 	.plat_data = {
 		.id		= DMA_ID_DMAC0,
@@ -114,7 +114,7 @@ SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
 	.ops		= &dw_dma_ops,
 },};
 
-const struct dma_info lib_dma = {
+static const struct dma_info lib_dma = {
 	.dma_array = dma,
 	.num_dmas = ARRAY_SIZE(dma)
 };

--- a/src/platform/imx8/lib/dma.c
+++ b/src/platform/imx8/lib/dma.c
@@ -15,14 +15,14 @@
 extern struct dma_ops dummy_dma_ops;
 extern struct dma_ops edma_ops;
 
-const int edma0_ints[EDMA0_CHAN_MAX] = {
+static const int edma0_ints[EDMA0_CHAN_MAX] = {
 	[EDMA0_ESAI_CHAN_RX] = EDMA0_ESAI_CHAN_RX_IRQ,
 	[EDMA0_ESAI_CHAN_TX] = EDMA0_ESAI_CHAN_TX_IRQ,
 	[EDMA0_SAI_CHAN_RX] = EDMA0_SAI_CHAN_RX_IRQ,
 	[EDMA0_SAI_CHAN_TX] = EDMA0_SAI_CHAN_TX_IRQ,
 };
 
-SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
+static SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
 {
 	.plat_data = {
 		.id		= DMA_ID_EDMA0,
@@ -46,7 +46,7 @@ SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
 },
 };
 
-const struct dma_info lib_dma = {
+static const struct dma_info lib_dma = {
 	.dma_array = dma,
 	.num_dmas = ARRAY_SIZE(dma)
 };

--- a/src/platform/imx8m/lib/dma.c
+++ b/src/platform/imx8m/lib/dma.c
@@ -14,7 +14,7 @@
 extern struct dma_ops dummy_dma_ops;
 extern struct dma_ops sdma_ops;
 
-SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
+static SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
 {
 	.plat_data = {
 		.id		= DMA_ID_HOST,
@@ -41,7 +41,7 @@ SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
 },
 };
 
-const struct dma_info lib_dma = {
+static const struct dma_info lib_dma = {
 	.dma_array = dma,
 	.num_dmas = ARRAY_SIZE(dma)
 };

--- a/src/platform/imx8ulp/lib/dma.c
+++ b/src/platform/imx8ulp/lib/dma.c
@@ -15,12 +15,12 @@
 extern struct dma_ops dummy_dma_ops;
 extern struct dma_ops edma_ops;
 
-const int edma2_ints[IMX8ULP_EDMA2_CHAN_MAX] = {
+static const int edma2_ints[IMX8ULP_EDMA2_CHAN_MAX] = {
 	[IMX8ULP_EDMA2_CHAN0] = IMX8ULP_EDMA2_CHAN0_IRQ,
 	[IMX8ULP_EDMA2_CHAN1] = IMX8ULP_EDMA2_CHAN1_IRQ,
 };
 
-SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
+static SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
 {
 	.plat_data = {
 		.id		= DMA_ID_EDMA2,
@@ -44,7 +44,7 @@ SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
 },
 };
 
-const struct dma_info lib_dma = {
+static const struct dma_info lib_dma = {
 	.dma_array = dma,
 	.num_dmas = ARRAY_SIZE(dma)
 };

--- a/src/platform/intel/cavs/lib/dma.c
+++ b/src/platform/intel/cavs/lib/dma.c
@@ -35,7 +35,7 @@
 #define DMAC1_CLASS 7
 #endif
 
-const struct dw_drv_plat_data dmac0 = {
+static const struct dw_drv_plat_data dmac0 = {
 	.chan[0] = {
 		.class	= DMAC0_CLASS,
 		.weight = 0,
@@ -70,7 +70,7 @@ const struct dw_drv_plat_data dmac0 = {
 	},
 };
 
-const struct dw_drv_plat_data dmac1 = {
+static const struct dw_drv_plat_data dmac1 = {
 	.chan[0] = {
 		.class	= DMAC1_CLASS,
 		.weight = 0,
@@ -106,7 +106,7 @@ const struct dw_drv_plat_data dmac1 = {
 };
 
 #if CONFIG_SUECREEK
-struct SHARED_DATA dma dma[PLATFORM_NUM_DMACS] = {
+static struct SHARED_DATA dma dma[PLATFORM_NUM_DMACS] = {
 {	/* LP GP DMAC 0 */
 	.plat_data = {
 		.id		= DMA_GP_LP_DMAC0,
@@ -155,7 +155,7 @@ struct SHARED_DATA dma dma[PLATFORM_NUM_DMACS] = {
 };
 
 #else
-SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
+static SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
 {	/* Low Power GP DMAC 0 */
 	.plat_data = {
 		.id		= DMA_GP_LP_DMAC0,
@@ -238,7 +238,7 @@ SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
 },};
 #endif
 
-const struct dma_info lib_dma = {
+static const struct dma_info lib_dma = {
 	.dma_array = cache_to_uncache_init((struct dma *)dma),
 	.num_dmas = ARRAY_SIZE(dma)
 };

--- a/src/platform/mt8186/lib/dma.c
+++ b/src/platform/mt8186/lib/dma.c
@@ -14,7 +14,7 @@
 
 extern const struct dma_ops dummy_dma_ops;
 
-SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
+static SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
 {
 	.plat_data = {
 		.id		= DMA_ID_HOST,
@@ -26,7 +26,7 @@ SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
 },
 };
 
-const struct dma_info lib_dma = { .dma_array = dma, .num_dmas = ARRAY_SIZE(dma) };
+static const struct dma_info lib_dma = { .dma_array = dma, .num_dmas = ARRAY_SIZE(dma) };
 
 int dmac_init(struct sof *sof)
 {

--- a/src/platform/mt8195/lib/dma.c
+++ b/src/platform/mt8195/lib/dma.c
@@ -17,7 +17,7 @@
 extern struct dma_ops dummy_dma_ops;
 extern struct dma_ops memif_ops;
 
-SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
+static SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
 {
 	.plat_data = {
 		.id		= DMA_ID_HOST,
@@ -39,7 +39,7 @@ SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
 },
 };
 
-const struct dma_info lib_dma = { .dma_array = dma, .num_dmas = ARRAY_SIZE(dma) };
+static const struct dma_info lib_dma = { .dma_array = dma, .num_dmas = ARRAY_SIZE(dma) };
 
 int dmac_init(struct sof *sof)
 {


### PR DESCRIPTION
Each platform defines a list of DMA controllers and related objects in their lib/dma.c files. All of them are needlessly defined as global. Make them all static.
