### PR TITLE
Codec Adapter: Add support for multiple input/output buffers - Part 1

### DIFF
--- a/src/audio/codec_adapter/codec/cadence.c
+++ b/src/audio/codec_adapter/codec/cadence.c
@@ -509,6 +509,12 @@ cadence_codec_process(struct processing_module *mod,
 	struct cadence_codec_data *cd = codec->private;
 	int ret;
 
+	/* Proceed only if we have enough data to fill the module buffer completely */
+	if (input_buffers[0].size < codec->mpd.in_buff_size) {
+		comp_dbg(dev, "cadence_codec_process(): not enough data to process");
+		return -ENODATA;
+	}
+
 	/* do not proceed with processing if not enough free left in the local buffer */
 	if (codec->mpd.init_done) {
 		int output_bytes = cadence_codec_get_samples(dev) *

--- a/src/audio/codec_adapter/codec/cadence.c
+++ b/src/audio/codec_adapter/codec/cadence.c
@@ -518,7 +518,9 @@ cadence_codec_process(struct processing_module *mod,
 		if (local_buff->stream.free < output_bytes)
 			return -ENOSPC;
 	} else {
-		return cadence_codec_init_process(dev);
+		ret = cadence_codec_init_process(dev);
+		input_buffers[0].consumed = codec->mpd.consumed;
+		return ret;
 	}
 
 	comp_dbg(dev, "cadence_codec_process() start");
@@ -550,6 +552,8 @@ cadence_codec_process(struct processing_module *mod,
 			 ret);
 		return ret;
 	}
+
+	input_buffers[0].consumed = codec->mpd.consumed;
 
 	comp_dbg(dev, "cadence_codec_process() done");
 

--- a/src/audio/codec_adapter/codec/dts.c
+++ b/src/audio/codec_adapter/codec/dts.c
@@ -228,6 +228,12 @@ dts_codec_process(struct processing_module *mod,
 	DtsSofInterfaceResult dts_result;
 	unsigned int bytes_processed = 0;
 
+	/* Proceed only if we have enough data to fill the module buffer completely */
+	if (input_buffers[0].size < codec->mpd.in_buff_size) {
+		comp_dbg(dev, "dts_codec_process(): not enough data to process");
+		return -ENODATA;
+	}
+
 	if (!codec->mpd.init_done)
 		return dts_codec_init_process(dev);
 

--- a/src/audio/codec_adapter/codec/dts.c
+++ b/src/audio/codec_adapter/codec/dts.c
@@ -242,6 +242,8 @@ dts_codec_process(struct processing_module *mod,
 	if (ret)
 		comp_err(dev, "dts_codec_process() failed %d %d", ret, dts_result);
 
+	input_buffers[0].consumed = codec->mpd.consumed;
+
 	comp_dbg(dev, "dts_codec_process() done");
 
 	return ret;

--- a/src/audio/codec_adapter/codec/generic.c
+++ b/src/audio/codec_adapter/codec/generic.c
@@ -245,7 +245,7 @@ int module_process(struct processing_module *mod, struct input_stream_buffer *in
 
 	ret = md->ops->process(mod, input_buffers, num_input_buffers, output_buffers,
 			       num_output_buffers);
-	if (ret && ret != -ENOSPC) {
+	if (ret && ret != -ENOSPC && ret != -ENODATA) {
 		comp_err(dev, "module_process() error %d: for comp %d",
 			 ret, dev_comp_id(dev));
 		return ret;

--- a/src/audio/codec_adapter/codec/passthrough.c
+++ b/src/audio/codec_adapter/codec/passthrough.c
@@ -65,6 +65,12 @@ passthrough_codec_process(struct processing_module *mod,
 	struct comp_dev *dev = mod->dev;
 	struct module_data *codec = comp_get_module_data(dev);
 
+	/* Proceed only if we have enough data to fill the module buffer completely */
+	if (input_buffers[0].size < codec->mpd.in_buff_size) {
+		comp_dbg(dev, "passthrough_codec_process(): not enough data to process");
+		return -ENODATA;
+	}
+
 	if (!codec->mpd.init_done)
 		return passthrough_codec_init_process(dev);
 

--- a/src/audio/codec_adapter/codec/passthrough.c
+++ b/src/audio/codec_adapter/codec/passthrough.c
@@ -75,6 +75,8 @@ passthrough_codec_process(struct processing_module *mod,
 	codec->mpd.produced = mod->period_bytes;
 	codec->mpd.consumed = mod->period_bytes;
 
+	input_buffers[0].consumed = codec->mpd.consumed;
+
 	return 0;
 }
 

--- a/src/audio/codec_adapter/codec/waves.c
+++ b/src/audio/codec_adapter/codec/waves.c
@@ -715,6 +715,12 @@ waves_codec_process(struct processing_module *mod,
 	struct module_data *codec = comp_get_module_data(dev);
 	struct waves_codec_data *waves_codec = codec->private;
 
+	/* Proceed only if we have enough data to fill the module buffer completely */
+	if (input_buffers[0].size < codec->mpd.in_buff_size) {
+		comp_dbg(dev, "waves_codec_process(): not enough data to process");
+		return -ENODATA;
+	}
+
 	if (!codec->mpd.init_done)
 		return waves_codec_init_process(dev);
 

--- a/src/audio/codec_adapter/codec/waves.c
+++ b/src/audio/codec_adapter/codec/waves.c
@@ -760,6 +760,8 @@ waves_codec_process(struct processing_module *mod,
 	if (ret)
 		comp_err(dev, "waves_codec_process() failed %d", ret);
 
+	input_buffers[0].consumed = codec->mpd.consumed;
+
 	comp_dbg(dev, "waves_codec_process() done");
 	return ret;
 }

--- a/src/audio/codec_adapter/codec_adapter.c
+++ b/src/audio/codec_adapter/codec_adapter.c
@@ -66,6 +66,7 @@ struct comp_dev *codec_adapter_new(const struct comp_driver *drv,
 	mod->dev = dev;
 
 	comp_set_drvdata(dev, mod);
+	list_init(&mod->sink_buffer_list);
 
 	/* Copy initial config */
 	if (ipc_codec_adapter->size) {
@@ -108,7 +109,7 @@ int codec_adapter_prepare(struct comp_dev *dev)
 	int ret;
 	struct processing_module *mod = comp_get_drvdata(dev);
 	struct module_data *md = &mod->priv;
-	struct list_item *blist;
+	struct list_item *blist, *_blist;
 	uint32_t buff_periods;
 	uint32_t buff_size; /* size of local buffer */
 	int i = 0;
@@ -236,20 +237,50 @@ int codec_adapter_prepare(struct comp_dev *dev)
 		i++;
 	}
 
+	/* allocate buffer for all sinks */
+	if (list_is_empty(&mod->sink_buffer_list)) {
+		for (i = 0; i < mod->num_output_buffers; i++) {
+			struct comp_buffer *buffer = buffer_alloc(buff_size, SOF_MEM_CAPS_RAM,
+								  PLATFORM_DCACHE_ALIGN);
+			if (!buffer) {
+				comp_err(dev, "codec_adapter_prepare(): failed to allocate local buffer");
+				ret = -ENOMEM;
+				goto free;
+			}
+			list_item_append(&buffer->sink_list, &mod->sink_buffer_list);
+			buffer_set_params(buffer, &mod->stream_params, BUFFER_UPDATE_FORCE);
+			buffer_reset_pos(buffer, NULL);
+		}
+	} else {
+		list_for_item(blist, &mod->sink_buffer_list) {
+			struct comp_buffer *buffer = container_of(blist, struct comp_buffer,
+								  sink_list);
+
+			ret = buffer_set_size(buffer, buff_size);
+			if (ret < 0) {
+				comp_err(dev, "codec_adapter_prepare(): buffer_set_size() failed, buff_size = %u",
+					 buff_size);
+				goto free;
+			}
+			buffer_set_params(buffer, &mod->stream_params, BUFFER_UPDATE_FORCE);
+			buffer_reset_pos(buffer, NULL);
+		}
+	}
+
 	/* Allocate local buffer */
 	if (mod->local_buff) {
 		ret = buffer_set_size(mod->local_buff, buff_size);
 		if (ret < 0) {
 			comp_err(dev, "codec_adapter_prepare(): buffer_set_size() failed, buff_size = %u",
 				 buff_size);
-			goto out_free;
+			goto free;
 		}
 	} else {
 		mod->local_buff = buffer_alloc(buff_size, SOF_MEM_CAPS_RAM, PLATFORM_DCACHE_ALIGN);
 		if (!mod->local_buff) {
 			comp_err(dev, "codec_adapter_prepare(): failed to allocate local buffer");
 			ret = -ENOMEM;
-			goto out_free;
+			goto free;
 		}
 
 	}
@@ -261,6 +292,14 @@ int codec_adapter_prepare(struct comp_dev *dev)
 
 	return 0;
 
+free:
+	list_for_item_safe(blist, _blist, &mod->sink_buffer_list) {
+		struct comp_buffer *buffer = container_of(blist, struct comp_buffer,
+							  sink_list);
+
+		list_item_del(&buffer->sink_list);
+		buffer_free(buffer);
+	}
 out_free:
 	for (i = 0; i < mod->num_output_buffers; i++)
 		rfree(mod->output_buffers[i].data);
@@ -272,6 +311,7 @@ in_free:
 		rfree(mod->input_buffers[i].data);
 
 	rfree(mod->input_buffers);
+
 	return ret;
 }
 
@@ -477,6 +517,19 @@ int codec_adapter_copy(struct comp_dev *dev)
 	}
 	ca_copy_from_module_to_sink(&local_buff->stream, md->mpd.out_buff, md->mpd.produced);
 
+	/* copy all produced output samples */
+	i = 0;
+	list_for_item(blist, &mod->sink_buffer_list) {
+		struct comp_buffer *buffer = container_of(blist, struct comp_buffer, sink_list);
+
+		if (mod->output_buffers[i].size > 0) {
+			ca_copy_from_module_to_sink(&buffer->stream, mod->output_buffers[i].data,
+						    mod->output_buffers[i].size);
+			audio_stream_produce(&buffer->stream, mod->output_buffers[i].size);
+		}
+		i++;
+	}
+
 	bytes_to_process -= md->mpd.consumed;
 	processed += md->mpd.consumed;
 	produced += md->mpd.produced;
@@ -642,6 +695,7 @@ int codec_adapter_reset(struct comp_dev *dev)
 {
 	int ret, i;
 	struct processing_module *mod = comp_get_drvdata(dev);
+	struct list_item *blist;
 
 	comp_dbg(dev, "codec_adapter_reset(): resetting");
 
@@ -668,6 +722,13 @@ int codec_adapter_reset(struct comp_dev *dev)
 	mod->num_input_buffers = 0;
 	mod->num_output_buffers = 0;
 
+	list_for_item(blist, &mod->sink_buffer_list) {
+		struct comp_buffer *buffer = container_of(blist, struct comp_buffer,
+							  sink_list);
+
+		buffer_zero(buffer);
+	}
+
 	comp_dbg(dev, "codec_adapter_reset(): done");
 
 	return comp_set_state(dev, COMP_TRIGGER_RESET);
@@ -677,6 +738,7 @@ void codec_adapter_free(struct comp_dev *dev)
 {
 	int ret;
 	struct processing_module *mod = comp_get_drvdata(dev);
+	struct list_item *blist, *_blist;
 
 	comp_dbg(dev, "codec_adapter_free(): start");
 
@@ -685,6 +747,15 @@ void codec_adapter_free(struct comp_dev *dev)
 		comp_err(dev, "codec_adapter_free(): error %d, codec free failed", ret);
 
 	buffer_free(mod->local_buff);
+
+	list_for_item_safe(blist, _blist, &mod->sink_buffer_list) {
+		struct comp_buffer *buffer = container_of(blist, struct comp_buffer,
+							  sink_list);
+
+		list_item_del(&buffer->sink_list);
+		buffer_free(buffer);
+	}
+
 	rfree(mod);
 	rfree(dev);
 }

--- a/src/audio/codec_adapter/codec_adapter.c
+++ b/src/audio/codec_adapter/codec_adapter.c
@@ -512,6 +512,7 @@ int codec_adapter_copy(struct comp_dev *dev)
 		mod->input_buffers[i].size = bytes_to_process;
 		ca_copy_from_source_to_module(&source->stream, mod->input_buffers[i].data,
 					      size, bytes_to_process);
+		mod->input_buffers[i].consumed = 0;
 		i++;
 	}
 

--- a/src/audio/codec_adapter/codec_adapter.c
+++ b/src/audio/codec_adapter/codec_adapter.c
@@ -413,10 +413,51 @@ static void generate_zeroes(struct comp_buffer *sink, uint32_t bytes)
 	comp_update_buffer_produce(sink, bytes);
 }
 
+static void module_copy_samples(struct comp_dev *dev, struct comp_buffer *src_buffer,
+				struct comp_buffer *sink_buffer, uint32_t produced)
+{
+	struct processing_module *mod = comp_get_drvdata(dev);
+	struct comp_copy_limits cl;
+	uint32_t copy_bytes;
+
+	if (!produced && !mod->deep_buff_bytes) {
+		comp_dbg(dev, "module_copy_samples(): nothing processed in this call");
+		/*
+		 * No data produced anything in this period but there still be data in the buffer
+		 * to copy to sink
+		 */
+		if (audio_stream_get_avail_bytes(&src_buffer->stream) >= mod->period_bytes)
+			goto copy_period;
+
+		return;
+	}
+
+	if (mod->deep_buff_bytes) {
+		if (mod->deep_buff_bytes >= audio_stream_get_avail_bytes(&src_buffer->stream)) {
+			generate_zeroes(sink_buffer, mod->period_bytes);
+			return;
+		}
+
+		comp_dbg(dev, "module_copy_samples(): deep buffering has ended after gathering %d bytes of processed data",
+			 audio_stream_get_avail_bytes(&src_buffer->stream));
+		mod->deep_buff_bytes = 0;
+	}
+
+copy_period:
+	comp_get_copy_limits_with_lock(src_buffer, sink_buffer, &cl);
+	copy_bytes = cl.frames * cl.source_frame_bytes;
+	audio_stream_copy(&src_buffer->stream, 0, &sink_buffer->stream, 0,
+			  copy_bytes / mod->stream_params.sample_container_bytes);
+	buffer_stream_writeback(sink_buffer, copy_bytes);
+
+	comp_update_buffer_produce(sink_buffer, copy_bytes);
+	comp_update_buffer_consume(src_buffer, copy_bytes);
+}
+
 int codec_adapter_copy(struct comp_dev *dev)
 {
 	int ret = 0;
-	uint32_t bytes_to_process, copy_bytes, processed = 0, produced = 0;
+	uint32_t bytes_to_process, processed = 0, produced = 0;
 	struct comp_buffer *source = list_first_item(&dev->bsource_list, struct comp_buffer,
 						     sink_list);
 	struct comp_buffer *sink = list_first_item(&dev->bsink_list, struct comp_buffer,
@@ -547,39 +588,8 @@ int codec_adapter_copy(struct comp_dev *dev)
 	audio_stream_produce(&local_buff->stream, md->mpd.produced);
 
 db_verify:
-	if (!produced && !mod->deep_buff_bytes) {
-		comp_dbg(dev, "codec_adapter_copy(): nothing processed in this call");
-		/* we haven't produced anything in this period but we
-		 * still have data in the local buffer to copy to sink
-		 */
-		if (audio_stream_get_avail_bytes(&local_buff->stream) >= mod->period_bytes)
-			goto copy_period;
+	module_copy_samples(dev, mod->local_buff, sink, md->mpd.produced);
 
-		goto end;
-	}
-
-	if (mod->deep_buff_bytes) {
-		if (mod->deep_buff_bytes >= audio_stream_get_avail_bytes(&local_buff->stream)) {
-			generate_zeroes(sink, mod->period_bytes);
-			goto end;
-		}
-
-		comp_dbg(dev, "codec_adapter_copy(): deep buffering has ended after gathering %d bytes of processed data",
-			 audio_stream_get_avail_bytes(&local_buff->stream));
-		mod->deep_buff_bytes = 0;
-	}
-
-copy_period:
-	comp_get_copy_limits_with_lock(local_buff, sink, &cl);
-	copy_bytes = cl.frames * cl.source_frame_bytes;
-	audio_stream_copy(&local_buff->stream, 0,
-			  &sink->stream, 0,
-			  copy_bytes / mod->stream_params.sample_container_bytes);
-	buffer_stream_writeback(sink, copy_bytes);
-
-	comp_update_buffer_produce(sink, copy_bytes);
-	comp_update_buffer_consume(local_buff, copy_bytes);
-end:
 	comp_dbg(dev, "codec_adapter_copy(): processed %d in this call %d bytes left for next period",
 		 processed, bytes_to_process);
 out:

--- a/src/audio/codec_adapter/codec_adapter.c
+++ b/src/audio/codec_adapter/codec_adapter.c
@@ -489,7 +489,13 @@ int codec_adapter_copy(struct comp_dev *dev)
 
 		bytes_to_process -= md->mpd.consumed;
 		processed += md->mpd.consumed;
-		comp_update_buffer_consume(source, md->mpd.consumed);
+
+		i = 0;
+		list_for_item(blist, &dev->bsource_list) {
+			source = container_of(blist, struct comp_buffer, sink_list);
+			comp_update_buffer_consume(source, mod->input_buffers[i].consumed);
+			i++;
+		}
 		if (bytes_to_process < codec_buff_size)
 			goto db_verify;
 	}
@@ -530,12 +536,19 @@ int codec_adapter_copy(struct comp_dev *dev)
 		i++;
 	}
 
+	/* consume data from all source buffers */
+	i = 0;
+	list_for_item(blist, &dev->bsource_list) {
+		source = container_of(blist, struct comp_buffer, sink_list);
+		comp_update_buffer_consume(source, mod->input_buffers[i].consumed);
+		i++;
+	}
+
 	bytes_to_process -= md->mpd.consumed;
 	processed += md->mpd.consumed;
 	produced += md->mpd.produced;
 
 	audio_stream_produce(&local_buff->stream, md->mpd.produced);
-	comp_update_buffer_consume(source, md->mpd.consumed);
 
 db_verify:
 	if (!produced && !mod->deep_buff_bytes) {

--- a/src/audio/codec_adapter/codec_adapter.c
+++ b/src/audio/codec_adapter/codec_adapter.c
@@ -468,15 +468,6 @@ int codec_adapter_copy(struct comp_dev *dev)
 	source = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
 	bytes_to_process = cl.frames * cl.source_frame_bytes;
 
-	/* Proceed only if we have enough data to fill the lib buffer
-	 * completely. If you don't fill whole buffer
-	 * the lib won't process it.
-	 */
-	if (bytes_to_process < codec_buff_size) {
-		comp_dbg(dev, "codec_adapter_copy(): source has less data than codec buffer size - processing terminated.");
-		goto db_verify;
-	}
-
 	if (!md->mpd.init_done) {
 		buffer_stream_invalidate(source, codec_buff_size);
 		ca_copy_from_source_to_module(&source->stream, md->mpd.in_buff,
@@ -484,8 +475,13 @@ int codec_adapter_copy(struct comp_dev *dev)
 		md->mpd.avail = codec_buff_size;
 		ret = module_process(mod, mod->input_buffers, mod->num_input_buffers,
 				     mod->output_buffers, mod->num_output_buffers);
-		if (ret)
+		if (ret < 0) {
+			if (ret == -ENODATA) {
+				ret = 0;
+				goto db_verify;
+			}
 			goto out;
+		}
 
 		bytes_to_process -= md->mpd.consumed;
 		processed += md->mpd.consumed;
@@ -507,7 +503,7 @@ int codec_adapter_copy(struct comp_dev *dev)
 	ret = module_process(mod, mod->input_buffers, mod->num_input_buffers,
 			     mod->output_buffers, mod->num_output_buffers);
 	if (ret) {
-		if (ret == -ENOSPC) {
+		if (ret == -ENOSPC || ret == -ENODATA) {
 			ret = 0;
 			goto db_verify;
 		}

--- a/src/audio/codec_adapter/codec_adapter.c
+++ b/src/audio/codec_adapter/codec_adapter.c
@@ -13,7 +13,6 @@
  * \brief Processing component aimed to work with external codec libraries
  * \author Marcin Rajwa <marcin.rajwa@linux.intel.com>
  */
-
 #include <sof/audio/buffer.h>
 #include <sof/audio/component.h>
 #include <sof/audio/ipc-config.h>
@@ -22,6 +21,8 @@
 #include <sof/common.h>
 #include <sof/platform.h>
 #include <sof/ut.h>
+#include <limits.h>
+#include <stdint.h>
 
 /**
  * \brief Create a codec adapter component.
@@ -469,6 +470,7 @@ int codec_adapter_copy(struct comp_dev *dev)
 	struct comp_copy_limits cl;
 	struct list_item *blist;
 	size_t size = MAX(mod->deep_buff_bytes, mod->period_bytes);
+	uint32_t min_free_frames = UINT_MAX;
 	int i = 0;
 
 	if (!source || !sink) {
@@ -482,6 +484,17 @@ int codec_adapter_copy(struct comp_dev *dev)
 	comp_dbg(dev, "codec_adapter_copy() start: codec_buff_size: %d, local_buff free: %d source avail %d",
 		 codec_buff_size, local_buff->stream.free, source->stream.avail);
 
+	/* get the least number of free frames from all sinks */
+	list_for_item(blist, &dev->bsink_list) {
+		uint32_t free_sink_frames;
+
+		sink = container_of(blist, struct comp_buffer, source_list);
+		free_sink_frames = audio_stream_get_free_frames(&sink->stream);
+
+		if (free_sink_frames < min_free_frames)
+			min_free_frames = free_sink_frames;
+	}
+
 	/* copy source samples into input buffer */
 	list_for_item(blist, &dev->bsource_list) {
 		int frames, source_frame_bytes;
@@ -489,7 +502,7 @@ int codec_adapter_copy(struct comp_dev *dev)
 		source = container_of(blist, struct comp_buffer, sink_list);
 
 		source = buffer_acquire(source);
-		frames = audio_stream_avail_frames(&source->stream, &sink->stream);
+		frames = MIN(min_free_frames, audio_stream_get_avail_frames(&source->stream));
 		source_frame_bytes = audio_stream_frame_bytes(&source->stream);
 		source = buffer_release(source);
 

--- a/src/include/sof/audio/codec_adapter/codec/generic.h
+++ b/src/include/sof/audio/codec_adapter/codec/generic.h
@@ -275,6 +275,8 @@ struct processing_module {
 	struct module_data priv; /**< module private data */
 	struct comp_buffer *local_buff;
 	struct sof_ipc_stream_params stream_params;
+	struct list_item sink_buffer_list; /* list of sink buffers to save produced output */
+
 	/*
 	 * This is a temporary change in order to support the trace messages in the modules. This
 	 * will be removed once the trace API is updated.


### PR DESCRIPTION
Add support for processing samples from multiple input buffers and copying the output to multiple output buffers.