### PR TITLE
version.cmake: make XTOS and Zephyr .ldc file different from each other + other cleanups.

### DIFF
--- a/scripts/cmake/version.cmake
+++ b/scripts/cmake/version.cmake
@@ -30,10 +30,10 @@ message(STATUS "SOF version.cmake starting at ${build_start_time} UTC")
 # --no-abbrev-commit because some git servers like github allow fetching
 # by full length SHA (others forbid this entirely, see last page of
 # `git help fetch-pack`)
-message(STATUS "Building SOF git commit with parent(s):")
+message(STATUS "${SOF_ROOT_SOURCE_DIRECTORY} is at git commit with parent(s):")
 # Note execute_process() failures are ignored by default (missing git...)
 execute_process(
-	COMMAND git -C "${CMAKE_CURRENT_SOURCE_DIR}"
+	COMMAND git -C "${SOF_ROOT_SOURCE_DIRECTORY}"
 		log --parents --no-abbrev-commit --decorate -n 1 HEAD
 	)
 

--- a/scripts/cmake/version.cmake
+++ b/scripts/cmake/version.cmake
@@ -42,14 +42,14 @@ execute_process(
 # the same name auto-generated in the top _build_ directory by "make
 # dist", see dist.cmake
 set(TARBALL_VERSION_FILE_NAME ".tarball-version")
-# in Zephyr this is sof/zephyr/.tarball-version
+
 set(TARBALL_VERSION_SOURCE_PATH "${SOF_ROOT_SOURCE_DIRECTORY}/${TARBALL_VERSION_FILE_NAME}")
 
 if(EXISTS ${TARBALL_VERSION_SOURCE_PATH})
 	file(STRINGS ${TARBALL_VERSION_SOURCE_PATH} lines ENCODING "UTF-8")
 	list(GET lines 0 GIT_TAG)
 	list(GET lines 1 GIT_LOG_HASH)
-	message(STATUS "Found ${TARBALL_VERSION_FILE_NAME}")
+	message(STATUS "Found ${TARBALL_VERSION_SOURCE_PATH}")
 else()
 	# execute_process() errors are not fatal by default!
 	execute_process(

--- a/scripts/cmake/version.cmake
+++ b/scripts/cmake/version.cmake
@@ -24,14 +24,17 @@ string(TIMESTAMP build_start_time UTC)
 message(STATUS "SOF version.cmake starting at ${build_start_time} UTC")
 
 # Most CI engines test a temporary merge of the pull request with a
-# moving target: the latest target branch. In that case the SHA version
-# gathered by git describe is disposable hence useless. Only the
-# --parents SHA are useful.
+# moving target: the latest target branch. In that case the HEAD SHA is
+# very volatile and the --parents are much more relevant and useful.
+#
+# --no-abbrev-commit because some git servers like github allow fetching
+# by full length SHA (others forbid this entirely, see last page of
+# `git help fetch-pack`)
 message(STATUS "Building SOF git commit with parent(s):")
 # Note execute_process() failures are ignored by default (missing git...)
 execute_process(
 	COMMAND git -C "${CMAKE_CURRENT_SOURCE_DIR}"
-		log --parents --oneline --decorate -n 1 HEAD
+		log --parents --no-abbrev-commit --decorate -n 1 HEAD
 	)
 
 

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -672,7 +672,7 @@ zephyr_library_link_libraries(SOF)
 target_link_libraries(SOF INTERFACE zephyr_interface)
 
 # Setup SOF directories
-set(SOF_ROOT_SOURCE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+set(SOF_ROOT_SOURCE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/..)
 set(SOF_ROOT_BINARY_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
 # This generated/ directory is shared with Zephyr.


### PR DESCRIPTION
5 commits. The main one:

[version.cmake: make XTOS and Zephyr .ldc file different from each other](https://github.com/thesofproject/sof/commit/dced4400f9e8e062e6de97d59b0af56c04e625c8) 

This is especially important considering some sof-bin releases are now
"hybrid": with a mix of XTOS and Zephyr.