### PR TITLE
topology1: sof-cml-src-rt5682: remove extra space after values

### DIFF
--- a/tools/topology/topology1/development/sof-cml-src-rt5682.m4
+++ b/tools/topology/topology1/development/sof-cml-src-rt5682.m4
@@ -70,7 +70,7 @@ PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	5, 3, 2, s32le,
 	1000, 0, 0,
-	48000 ,48000 ,48000)
+	48000, 48000, 48000)
 
 # Low Latency playback pipeline 6 on PCM 4 using max 2 channels of s32le.
 # Set 1000us deadline with priority 0 on core 0


### PR DESCRIPTION
The string parser in alsa-lib is sensitive to these now. So fix it.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>
(cherry picked from commit db041556ce48b0535d5fa4d77d19d166e2938c05)