### PR TITLE
Tools: Test: Fix mistake in script test_run.m

### DIFF
--- a/tools/test/audio/test_utils/test_run.m
+++ b/tools/test/audio/test_utils/test_run.m
@@ -87,7 +87,7 @@ else
 end
 
 % Override defaults in comp_run.sh
-fprintf(fh, 'VALGRIND=false\n', test.fs_in);
+fprintf(fh, 'VALGRIND=false\n');
 fclose(fh);
 
 arg = sprintf('-t %s', fn_config);


### PR DESCRIPTION
Remove the extra argument for fprintf(). For some reason there was
no harm seen but this should trigger an error when run in Octave or
Matlab.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>