### PR TITLE
xtensa-build-all.sh: Use appropriate defconfig for tgl-h platform

### DIFF
--- a/scripts/xtensa-build-all.sh
+++ b/scripts/xtensa-build-all.sh
@@ -275,8 +275,17 @@ do
 			XTENSA_TOOLS_VERSION="RG-2017.8-linux"
 			HAVE_ROM='yes'
 			;;
-		tgl|tgl-h)
+		tgl)
 			PLATFORM="tgplp"
+			XTENSA_CORE="cavs2x_LX6HiFi3_2017_8"
+			HOST="xtensa-cnl-elf"
+			XTENSA_TOOLS_VERSION="RG-2017.8-linux"
+			HAVE_ROM='yes'
+			# default key for TGL
+			PLATFORM_PRIVATE_KEY="-D${SIGNING_TOOL}_PRIVATE_KEY=$SOF_TOP/keys/otc_private_key_3k.pem"
+			;;
+		tgl-h)
+			PLATFORM="tgph"
 			XTENSA_CORE="cavs2x_LX6HiFi3_2017_8"
 			HOST="xtensa-cnl-elf"
 			XTENSA_TOOLS_VERSION="RG-2017.8-linux"


### PR DESCRIPTION
Recent combination of tgl and tgl-h building resulted in use of an invalid defconfig file for tgl-h platform. This PR reverts that change.

Fixes #5493