### PR TITLE
zephyr/cmake: Add support for linking with cadence libs

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -618,6 +618,15 @@ if (CONFIG_COMP_CODEC_ADAPTER)
 zephyr_library_sources_ifdef(CONFIG_CADENCE_CODEC
 	${SOF_AUDIO_PATH}/codec_adapter/codec/cadence.c
 )
+
+if (CONFIG_CADENCE_CODEC_MP3_DEC)
+zephyr_library_import(xa_mp3_dec ${CONFIG_CADENCE_CODEC_MP3_DEC_LIB})
+endif()
+
+if (CONFIG_CADENCE_CODEC_AAC_DEC)
+zephyr_library_import(xa_aac_dec ${CONFIG_CADENCE_CODEC_AAC_DEC_LIB})
+endif()
+
 zephyr_library_sources_ifdef(CONFIG_PASSTHROUGH_CODEC
 	${SOF_AUDIO_PATH}/codec_adapter/codec/passthrough.c
 )


### PR DESCRIPTION
We add support for linking with Cadence AAC/MP3 libs.

Cadence lib MP3 support is enabled via CONFIG_CADENCE_CODEC_MP3_DEC config
symbol. Path to library file needs to be set via CONFIG_CADENCE_CODEC_MP3_DEC_LIB

Similar for AAC.

Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>