### PR TITLE
zephyr: correct the idc payload initialization

### DIFF
--- a/src/idc/idc.c
+++ b/src/idc/idc.c
@@ -342,12 +342,13 @@ int idc_init(void)
 		.get_deadline = ipc_task_deadline,
 		.complete = idc_complete,
 	};
+
+	*idc = rzalloc(SOF_MEM_ZONE_SYS, 0, SOF_MEM_CAPS_RAM, sizeof(**idc));
 #endif
 
 	tr_info(&idc_tr, "idc_init()");
 
 	/* initialize idc data */
-	*idc = rzalloc(SOF_MEM_ZONE_SYS, 0, SOF_MEM_CAPS_RAM, sizeof(**idc));
 	(*idc)->payload = platform_shared_get(static_payload, sizeof(static_payload));
 
 	/* process task */

--- a/src/include/sof/drivers/idc.h
+++ b/src/include/sof/drivers/idc.h
@@ -20,6 +20,7 @@
 #include <sof/trace/trace.h>
 #include <user/trace.h>
 #include <stdint.h>
+#include <sof/lib/cache.h>
 
 /** \brief IDC send blocking flag. */
 #define IDC_BLOCKING		0
@@ -96,7 +97,7 @@
 #define iTS(x)	(((x) >> IDC_TYPE_SHIFT) & IDC_TYPE_MASK)
 
 /** \brief Max IDC message payload size in bytes. */
-#define IDC_MAX_PAYLOAD_SIZE	96
+#define IDC_MAX_PAYLOAD_SIZE	(DCACHE_LINE_SIZE * 2)
 
 /** \brief IDC free function flags */
 #define IDC_FREE_IRQ_ONLY	BIT(0)	/**< disable only irqs */


### PR DESCRIPTION
Remove the dynamic allocation of per-core idc elements since these
are already statically allocated in a form of idc array in zephyr/wrapper.c.
The payload pointer initialization need to use idc entries which are returned by
get_idc() call.

Signed-off-by: Rafal Redzimski <rafal.f.redzimski@intel.com>