### PR TITLE
topology1: Set Dmic samplerate to 48000Hz

### DIFF
--- a/src/drivers/amd/renoir/acp_dmic_dai.c
+++ b/src/drivers/amd/renoir/acp_dmic_dai.c
@@ -73,7 +73,7 @@ static int acp_dmic_dai_get_hw_params(struct dai *dai,
 			      int dir)
 {
 	/* ACP only currently supports these parameters */
-	params->rate = ACP_SAMPLE_RATE_16K;/* 16000 sample rate only for dmic */
+	params->rate = ACP_DEFAULT_SAMPLE_RATE;
 	params->channels = ACP_DEFAULT_NUM_CHANNELS;
 	params->buffer_fmt = SOF_IPC_BUFFER_INTERLEAVED;
 	params->frame_fmt = SOF_IPC_FRAME_S32_LE;

--- a/src/drivers/amd/renoir/acp_dmic_dma.c
+++ b/src/drivers/amd/renoir/acp_dmic_dma.c
@@ -96,8 +96,8 @@ static int acp_dmic_dma_start(struct dma_chan_data *channel)
 		deci_fctr.u32all = 2;
 		io_reg_write(PU_REGISTER_BASE + ACP_WOV_PDM_DECIMATION_FACTOR,
 							deci_fctr.u32all);
-		/* DMIC Clock for 16K sample rate */
-		clk_ctrl.bits.brm_clk_ctrl = 1;
+		/* DMIC Clock */
+		clk_ctrl.bits.brm_clk_ctrl = 7;
 		io_reg_write(PU_REGISTER_BASE + ACP_WOV_CLK_CTRL,
 						clk_ctrl.u32all);
 		/* PDM Control */

--- a/src/include/sof/drivers/acp_dai_dma.h
+++ b/src/include/sof/drivers/acp_dai_dma.h
@@ -27,8 +27,6 @@ int acp_dma_init(struct sof *sof);
 /* default sample rate */
 #define ACP_DEFAULT_SAMPLE_RATE     48000
 
-#define ACP_SAMPLE_RATE_16K	16000
-
 #define ACP_DMA_BUFFER_ALIGN	64
 #define ACP_DMA_TRANS_SIZE	64
 #define ACP_DAI_DMA_BUFFER_PERIOD_COUNT		2

--- a/tools/topology/topology1/sof-acp-renoir.m4
+++ b/tools/topology/topology1/sof-acp-renoir.m4
@@ -52,14 +52,14 @@ PCM_DUPLEX_ADD(I2SSP, 0, PIPELINE_PCM_1, PIPELINE_PCM_2)
 PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
         3, 1, 2, s32le,
         2000, 0, 0,
-        16000, 16000, 16000)
+        48000, 48000, 48000)
 
 DAI_ADD(sof/pipe-dai-capture.m4, 3, ACPDMIC, 0, acp-dmic-codec,
 PIPELINE_SINK_3, 2, s32le, 2000, 0, 0, SCHEDULE_TIME_DOMAIN_DMA)
 
 dnl DAI_CONFIG(type, dai_index, link_id, name, acpdmic_config)
 DAI_CONFIG(ACPDMIC, 3, 2, acp-dmic-codec,
-	   ACPDMIC_CONFIG(ACPDMIC_CONFIG_DATA(ACPDMIC, 3, 16000, 2)))
+	   ACPDMIC_CONFIG(ACPDMIC_CONFIG_DATA(ACPDMIC, 3, 48000, 2)))
 
 # PCM id 1
 PCM_CAPTURE_ADD(DMIC, 1, PIPELINE_PCM_3)

--- a/tools/topology/topology1/sof-rn-rt5682-max98360.m4
+++ b/tools/topology/topology1/sof-rn-rt5682-max98360.m4
@@ -57,7 +57,7 @@ PCM_DUPLEX_ADD(I2SSP, 0, PIPELINE_PCM_1, PIPELINE_PCM_2)
 PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
 	3, 1, 2, s32le,
 	2000, 0, 0,
-	16000, 16000, 16000)
+	48000, 48000, 48000)
 
 DAI_ADD(sof/pipe-dai-capture.m4,
 	3, ACPDMIC, 0, acp-dmic-codec,
@@ -66,7 +66,7 @@ DAI_ADD(sof/pipe-dai-capture.m4,
 
 dnl DAI_CONFIG(type, dai_index, link_id, name, acpdmic_config)
 DAI_CONFIG(ACPDMIC, 3, 2, acp-dmic-codec,
-	ACPDMIC_CONFIG(ACPDMIC_CONFIG_DATA(ACPDMIC, 3, 16000, 2)))
+	ACPDMIC_CONFIG(ACPDMIC_CONFIG_DATA(ACPDMIC, 3, 48000, 2)))
 
 # PCM id 1
 PCM_CAPTURE_ADD(DMIC, 1, PIPELINE_PCM_3)

--- a/tools/topology/topology1/sof-rn-rt5682-rt1019.m4
+++ b/tools/topology/topology1/sof-rn-rt5682-rt1019.m4
@@ -57,7 +57,7 @@ PCM_DUPLEX_ADD(I2SSP, 0, PIPELINE_PCM_1, PIPELINE_PCM_2)
 PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
 	3, 1, 2, s32le,
 	2000, 0, 0,
-	16000, 16000, 16000)
+	48000, 48000, 48000)
 
 DAI_ADD(sof/pipe-dai-capture.m4,
 	3, ACPDMIC, 0, acp-dmic-codec,
@@ -66,7 +66,7 @@ DAI_ADD(sof/pipe-dai-capture.m4,
 
 dnl DAI_CONFIG(type, dai_index, link_id, name, acpdmic_config)
 DAI_CONFIG(ACPDMIC, 3, 2, acp-dmic-codec,
-	ACPDMIC_CONFIG(ACPDMIC_CONFIG_DATA(ACPDMIC, 3, 16000, 2)))
+	ACPDMIC_CONFIG(ACPDMIC_CONFIG_DATA(ACPDMIC, 3, 48000, 2)))
 
 # PCM id 1
 PCM_CAPTURE_ADD(DMIC, 1, PIPELINE_PCM_3)


### PR DESCRIPTION
Set default samplerate for DMIC to 48000Hz for
amd platforms.

Signed-off-by: Balakishorepati <balaKishore.pati@amd.com>