### PR TITLE
xtensa-build-zephyr.py: do not modify submodules after building!

### DIFF
--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -367,8 +367,6 @@ def build_platforms():
 		# Extract metadata
 		execute_command([str(smex_executable), "-l", str(fw_ldc_file), str(input_elf_file)],
 			check=True)
-		# Update SOF submodules
-		git_submodules_update()
 		# CMake - configure rimage module
 		rimage_dir_name="build-rimage"
 		sof_mirror_dir = pathlib.Path("modules", "audio", "sof")


### PR DESCRIPTION
The older shell script had a deprecated convenience hack to clone
submodules before building rimage but _only if submodules were missing_!

While trying to preserve that, the new script changed that to an
unconditional git submodule update that can be destructive when
submodules are already present.

Generally speaking, using git and building must always be two very
distinct activities. No one wants the source code to change quietly from
one build to the next.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>