### PR TITLE
topology2: common: fix to add '$' for SAMPLE_TYPE_LSB_INTEGER

### DIFF
--- a/tools/topology/topology2/include/common/audio_format.conf
+++ b/tools/topology/topology2/include/common/audio_format.conf
@@ -96,7 +96,7 @@ Class.Base."audio_format" {
 		constraints {
 			!valid_values [
 				$SAMPLE_TYPE_MSB_INTEGER
-				SAMPLE_TYPE_LSB_INTEGER
+				$SAMPLE_TYPE_LSB_INTEGER
 				$SAMPLE_TYPE_SIGNED_INTEGER
 				$SAMPLE_TYPE_UNSIGNED_INTEGER
 				$SAMPLE_TYPE_FLOAT
@@ -185,7 +185,7 @@ Class.Base."audio_format" {
 		constraints {
 			!valid_values [
 				$SAMPLE_TYPE_MSB_INTEGER
-				SAMPLE_TYPE_LSB_INTEGER
+				$SAMPLE_TYPE_LSB_INTEGER
 				$SAMPLE_TYPE_SIGNED_INTEGER
 				$SAMPLE_TYPE_UNSIGNED_INTEGER
 				$SAMPLE_TYPE_FLOAT


### PR DESCRIPTION
$ and S are hard to tell in text editor. Without '$' final value are
much different.

Signed-off-by: Fred Oh <fred.oh@linux.intel.com>