### PR TITLE
xtensa-build-zephyr.sh: fix shellsheck warning

### DIFF
--- a/scripts/xtensa-build-zephyr.sh
+++ b/scripts/xtensa-build-zephyr.sh
@@ -196,7 +196,7 @@ build_platforms()
 				;;
 			tgl-h|tgl)
 				PLAT_CONFIG='intel_adsp_cavs25'
-				if test $platform = tgl-h ; then
+				if test "$platform" = tgl-h ; then
 				    PLAT_CONFIG="intel_adsp_cavs25_tgph"
 				fi
 				XTENSA_CORE="cavs2x_LX6HiFi3_2017_8"


### PR DESCRIPTION
In scripts/xtensa-build-zephyr.sh line 199:

  if test $platform = tgl-h ; then
           ^-------^ SC2086: Double quote to prevent globbing
			     and word splitting.

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>