### PR TITLE
Clean up all `SHARED_DATA` data

### DIFF
--- a/src/audio/pipeline/pipeline-graph.c
+++ b/src/audio/pipeline/pipeline-graph.c
@@ -39,7 +39,7 @@ struct pipeline_posn {
 	struct k_spinlock lock;			/**< lock mechanism */
 };
 /* the pipeline position lookup table */
-static SHARED_DATA struct pipeline_posn pipeline_posn;
+static SHARED_DATA struct pipeline_posn pipeline_posn_shared;
 
 /**
  * \brief Retrieves pipeline position structure.
@@ -98,8 +98,8 @@ static inline void pipeline_posn_offset_put(uint32_t posn_offset)
 
 void pipeline_posn_init(struct sof *sof)
 {
-	sof->pipeline_posn = platform_shared_get(&pipeline_posn,
-						 sizeof(pipeline_posn));
+	sof->pipeline_posn = platform_shared_get(&pipeline_posn_shared,
+						 sizeof(pipeline_posn_shared));
 	k_spinlock_init(&sof->pipeline_posn->lock);
 }
 

--- a/src/drivers/intel/ssp/mn.c
+++ b/src/drivers/intel/ssp/mn.c
@@ -62,13 +62,13 @@ struct mn {
 	struct k_spinlock lock; /**< lock mechanism */
 };
 
-static SHARED_DATA struct mn mn;
+static SHARED_DATA struct mn mn_shared;
 
 void mn_init(struct sof *sof)
 {
 	int i;
 
-	sof->mn = platform_shared_get(&mn, sizeof(mn));
+	sof->mn = platform_shared_get(&mn_shared, sizeof(mn_shared));
 
 	sof->mn->mclk_source_clock = 0;
 

--- a/src/idc/idc.c
+++ b/src/idc/idc.c
@@ -348,7 +348,7 @@ int idc_init(void)
 
 	/* initialize idc data */
 	*idc = rzalloc(SOF_MEM_ZONE_SYS, 0, SOF_MEM_CAPS_RAM, sizeof(**idc));
-	(*idc)->payload = cache_to_uncache((struct idc_payload *)static_payload);
+	(*idc)->payload = platform_shared_get(static_payload, sizeof(static_payload));
 
 	/* process task */
 #ifndef __ZEPHYR__

--- a/src/lib/notifier.c
+++ b/src/lib/notifier.c
@@ -25,7 +25,7 @@ DECLARE_SOF_UUID("notifier", notifier_uuid, 0x1fb15a7a, 0x83cd, 0x4c2e,
 
 DECLARE_TR_CTX(nt_tr, SOF_UUID(notifier_uuid), LOG_LEVEL_INFO);
 
-static SHARED_DATA struct notify_data notify_data[CONFIG_CORE_COUNT];
+static SHARED_DATA struct notify_data notify_data_shared[CONFIG_CORE_COUNT];
 
 struct callback_handle {
 	void *receiver;
@@ -199,8 +199,8 @@ void init_system_notify(struct sof *sof)
 		list_init(&(*notify)->list[i]);
 
 	if (cpu_get_id() == PLATFORM_PRIMARY_CORE_ID)
-		sof->notify_data = platform_shared_get(notify_data,
-						       sizeof(notify_data));
+		sof->notify_data = platform_shared_get(notify_data_shared,
+						       sizeof(notify_data_shared));
 }
 
 void free_system_notify(void)

--- a/src/platform/amd/renoir/include/platform/lib/memory.h
+++ b/src/platform/amd/renoir/include/platform/lib/memory.h
@@ -136,7 +136,8 @@
 
 #define uncache_to_cache(address)	address
 #define cache_to_uncache(address)	address
-#define is_uncached(address)			0
+#define cache_to_uncache_init(address)	address
+#define is_uncached(address)		0
 
 #define HEAP_BUF_ALIGNMENT		PLATFORM_DCACHE_ALIGN
 

--- a/src/platform/amd/renoir/lib/clk.c
+++ b/src/platform/amd/renoir/lib/clk.c
@@ -123,7 +123,8 @@ void platform_clock_init(struct sof *sof)
 {
 	int i;
 
-	sof->clocks = platform_clocks_info;
+	sof->clocks = platform_shared_get(platform_clocks_info, sizeof(platform_clocks_info));
+
 	for (i = 0; i < PLATFORM_CORE_COUNT; i++) {
 		sof->clocks[i] = (struct clock_info) {
 			.freqs_num = NUM_CPU_FREQ,

--- a/src/platform/amd/renoir/lib/dma.c
+++ b/src/platform/amd/renoir/lib/dma.c
@@ -79,7 +79,7 @@ static SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
 };
 
 static const struct dma_info lib_dma = {
-	.dma_array = dma,
+	.dma_array = cache_to_uncache_init((struct dma *)dma),
 	.num_dmas = ARRAY_SIZE(dma)
 };
 

--- a/src/platform/amd/renoir/lib/memory.c
+++ b/src/platform/amd/renoir/lib/memory.c
@@ -91,5 +91,5 @@ static SHARED_DATA struct mm memmap = {
 void platform_init_memmap(struct sof *sof)
 {
 	/* memmap has been initialized statically as a part of .data */
-	sof->memory_map = &memmap;
+	sof->memory_map = platform_shared_get(&memmap, sizeof(memmap));
 }

--- a/src/platform/amd/renoir/platform.c
+++ b/src/platform/amd/renoir/platform.c
@@ -61,7 +61,7 @@ static const struct sof_ipc_fw_ready ready
 	.flags = DEBUG_SET_FW_READY_FLAGS,
 };
 
-static SHARED_DATA struct timer timer = {
+static SHARED_DATA struct timer timer_shared = {
 	.id = TIMER0,
 	.irq = IRQ_NUM_TIMER0,
 };
@@ -70,8 +70,9 @@ int platform_init(struct sof *sof)
 {
 	int ret;
 
-	sof->platform_timer = &timer;
-	sof->cpu_timers = &timer;
+	sof->platform_timer = platform_shared_get(&timer_shared, sizeof(timer_shared));
+	sof->cpu_timers = sof->platform_timer;
+
 	/* to view system memory */
 	platform_interrupt_init();
 	platform_clock_init(sof);

--- a/src/platform/baytrail/include/platform/lib/memory.h
+++ b/src/platform/baytrail/include/platform/lib/memory.h
@@ -24,6 +24,7 @@ void platform_init_memmap(struct sof *sof);
 
 #define uncache_to_cache(address)	address
 #define cache_to_uncache(address)	address
+#define cache_to_uncache_init(address)	address
 #define is_uncached(address)		0
 
 static inline void *platform_shared_get(void *ptr, int bytes)

--- a/src/platform/baytrail/lib/clk.c
+++ b/src/platform/baytrail/lib/clk.c
@@ -115,7 +115,7 @@ void platform_clock_init(struct sof *sof)
 {
 	int i;
 
-	sof->clocks = platform_clocks_info;
+	sof->clocks = platform_shared_get(platform_clocks_info, sizeof(platform_clocks_info));
 
 	for (i = 0; i < NUM_CLOCKS; i++)
 		k_spinlock_init(&sof->clocks[i].lock);

--- a/src/platform/baytrail/lib/dai.c
+++ b/src/platform/baytrail/lib/dai.c
@@ -119,7 +119,7 @@ static SHARED_DATA struct dai ssp[] = {
 const struct dai_type_info dti[] = {
 	{
 		.type = SOF_DAI_INTEL_SSP,
-		.dai_array = ssp,
+		.dai_array = cache_to_uncache_init((struct dai *)ssp),
 		.num_dais = ARRAY_SIZE(ssp)
 	}
 };
@@ -135,7 +135,7 @@ int dai_init(struct sof *sof)
 
 	/* initialize spin locks early to enable ref counting */
 	for (i = 0; i < ARRAY_SIZE(ssp); i++)
-		k_spinlock_init(&ssp[i].lock);
+		k_spinlock_init(&dti[0].dai_array[i].lock);
 
 	sof->dai_info = &lib_dai;
 

--- a/src/platform/baytrail/lib/dma.c
+++ b/src/platform/baytrail/lib/dma.c
@@ -186,7 +186,7 @@ static SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
 };
 
 static const struct dma_info lib_dma = {
-	.dma_array = dma,
+	.dma_array = cache_to_uncache_init((struct dma *)dma),
 	.num_dmas = ARRAY_SIZE(dma)
 };
 

--- a/src/platform/baytrail/lib/memory.c
+++ b/src/platform/baytrail/lib/memory.c
@@ -92,5 +92,5 @@ static SHARED_DATA struct mm memmap = {
 void platform_init_memmap(struct sof *sof)
 {
 	/*  memmap has been initialized statically as a part of .data */
-	sof->memory_map = &memmap;
+	sof->memory_map = platform_shared_get(&memmap, sizeof(memmap));
 }

--- a/src/platform/baytrail/platform.c
+++ b/src/platform/baytrail/platform.c
@@ -144,7 +144,7 @@ const struct ext_man_windows xsram_window
 };
 
 #ifndef __ZEPHYR__
-static SHARED_DATA struct timer timer = {
+static SHARED_DATA struct timer platform_timer = {
 	.id = TIMER3, /* external timer */
 	.irq = IRQ_NUM_EXT_TIMER,
 };
@@ -193,8 +193,8 @@ int platform_init(struct sof *sof)
 	int ret;
 
 #ifndef __ZEPHYR__
-	sof->platform_timer = &timer;
-	sof->cpu_timers = &arch_timer;
+	sof->platform_timer = platform_shared_get(&platform_timer, sizeof(platform_timer));
+	sof->cpu_timers = platform_shared_get(&arch_timer, sizeof(arch_timer));
 #endif /* __ZEPHYR__ */
 
 	/* clear mailbox for early trace and debug */

--- a/src/platform/haswell/include/platform/lib/memory.h
+++ b/src/platform/haswell/include/platform/lib/memory.h
@@ -24,6 +24,7 @@ void platform_init_memmap(struct sof *sof);
 
 #define uncache_to_cache(address)	address
 #define cache_to_uncache(address)	address
+#define cache_to_uncache_init(address)	address
 #define is_uncached(address)		0
 
 static inline void *platform_shared_get(void *ptr, int bytes)

--- a/src/platform/haswell/lib/clk.c
+++ b/src/platform/haswell/lib/clk.c
@@ -87,7 +87,7 @@ void platform_clock_init(struct sof *sof)
 {
 	int i;
 
-	sof->clocks = platform_clocks_info;
+	sof->clocks = platform_shared_get(platform_clocks_info, sizeof(platform_clocks_info));
 
 	for (i = 0; i < NUM_CLOCKS; i++)
 		k_spinlock_init(&sof->clocks[i].lock);

--- a/src/platform/haswell/lib/dai.c
+++ b/src/platform/haswell/lib/dai.c
@@ -52,7 +52,7 @@ static SHARED_DATA struct dai ssp[2] = {
 const struct dai_type_info dti[] = {
 	{
 		.type = SOF_DAI_INTEL_SSP,
-		.dai_array = ssp,
+		.dai_array = cache_to_uncache_init((struct dai *)ssp),
 		.num_dais = ARRAY_SIZE(ssp)
 	}
 };
@@ -68,7 +68,7 @@ int dai_init(struct sof *sof)
 
 	/* initialize spin locks early to enable ref counting */
 	for (i = 0; i < ARRAY_SIZE(ssp); i++)
-		k_spinlock_init(&ssp[i].lock);
+		k_spinlock_init(&dti[0].dai_array[i].lock);
 
 	sof->dai_info = &lib_dai;
 

--- a/src/platform/haswell/lib/dma.c
+++ b/src/platform/haswell/lib/dma.c
@@ -115,7 +115,7 @@ static SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
 },};
 
 static const struct dma_info lib_dma = {
-	.dma_array = dma,
+	.dma_array = cache_to_uncache_init((struct dma *)dma),
 	.num_dmas = ARRAY_SIZE(dma)
 };
 

--- a/src/platform/haswell/lib/memory.c
+++ b/src/platform/haswell/lib/memory.c
@@ -92,5 +92,5 @@ static SHARED_DATA struct mm memmap = {
 void platform_init_memmap(struct sof *sof)
 {
 	/*  memmap has been initialized statically as a part of .data */
-	sof->memory_map = &memmap;
+	sof->memory_map = platform_shared_get(&memmap, sizeof(memmap));
 }

--- a/src/platform/haswell/platform.c
+++ b/src/platform/haswell/platform.c
@@ -130,7 +130,7 @@ const struct ext_man_windows xsram_window
 };
 
 #ifndef __ZEPHYR__
-static SHARED_DATA struct timer timer = {
+static SHARED_DATA struct timer timer_shared = {
 	.id = TIMER1, /* internal timer */
 	.irq = IRQ_NUM_TIMER2,
 };
@@ -175,8 +175,8 @@ int platform_init(struct sof *sof)
 	int ret;
 
 #ifndef __ZEPHYR__
-	sof->platform_timer = &timer;
-	sof->cpu_timers = &timer;
+	sof->platform_timer = platform_shared_get(&timer_shared, sizeof(timer_shared));
+	sof->cpu_timers = sof->platform_timer;
 #endif
 
 	/* clear mailbox for early trace and debug */

--- a/src/platform/imx8/include/platform/lib/memory.h
+++ b/src/platform/imx8/include/platform/lib/memory.h
@@ -194,6 +194,7 @@ static inline void *platform_shared_get(void *ptr, int bytes)
 
 #define uncache_to_cache(address)	address
 #define cache_to_uncache(address)	address
+#define cache_to_uncache_init(address)	address
 #define is_uncached(address)		0
 
 /**

--- a/src/platform/imx8/lib/clk.c
+++ b/src/platform/imx8/lib/clk.c
@@ -33,7 +33,7 @@ void platform_clock_init(struct sof *sof)
 {
 	int i;
 
-	sof->clocks = platform_clocks_info;
+	sof->clocks = platform_shared_get(platform_clocks_info, sizeof(platform_clocks_info));
 
 	for (i = 0; i < CONFIG_CORE_COUNT; i++) {
 		sof->clocks[i] = (struct clock_info) {

--- a/src/platform/imx8/lib/dai.c
+++ b/src/platform/imx8/lib/dai.c
@@ -73,12 +73,12 @@ static SHARED_DATA struct dai sai[] = {
 const struct dai_type_info dti[] = {
 	{
 		.type = SOF_DAI_IMX_SAI,
-		.dai_array = sai,
+		.dai_array = cache_to_uncache_init((struct dai *)sai),
 		.num_dais = ARRAY_SIZE(sai)
 	},
 	{
 		.type = SOF_DAI_IMX_ESAI,
-		.dai_array = esai,
+		.dai_array = cache_to_uncache_init((struct dai *)esai),
 		.num_dais = ARRAY_SIZE(esai)
 	},
 };
@@ -94,10 +94,10 @@ int dai_init(struct sof *sof)
 
 	 /* initialize spin locks early to enable ref counting */
 	for (i = 0; i < ARRAY_SIZE(esai); i++)
-		k_spinlock_init(&esai[i].lock);
+		k_spinlock_init(&dti[1].dai_array[i].lock);
 
 	for (i = 0; i < ARRAY_SIZE(sai); i++)
-		k_spinlock_init(&sai[i].lock);
+		k_spinlock_init(&dti[0].dai_array[i].lock);
 
 	sof->dai_info = &lib_dai;
 

--- a/src/platform/imx8/lib/dma.c
+++ b/src/platform/imx8/lib/dma.c
@@ -47,7 +47,7 @@ static SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
 };
 
 static const struct dma_info lib_dma = {
-	.dma_array = dma,
+	.dma_array = cache_to_uncache_init((struct dma *)dma),
 	.num_dmas = ARRAY_SIZE(dma)
 };
 

--- a/src/platform/imx8/lib/memory.c
+++ b/src/platform/imx8/lib/memory.c
@@ -95,5 +95,5 @@ static SHARED_DATA struct mm memmap = {
 void platform_init_memmap(struct sof *sof)
 {
 	/* memmap has been initialized statically as a part of .data */
-	sof->memory_map = &memmap;
+	sof->memory_map = platform_shared_get(&memmap, sizeof(memmap));
 }

--- a/src/platform/imx8/platform.c
+++ b/src/platform/imx8/platform.c
@@ -129,7 +129,7 @@ const struct ext_man_windows xsram_window
 };
 
 #ifndef __ZEPHYR__
-static SHARED_DATA struct timer timer = {
+static SHARED_DATA struct timer timer_shared = {
 	.id = TIMER0, /* internal timer */
 	.irq = IRQ_NUM_TIMER0,
 };
@@ -156,8 +156,8 @@ int platform_init(struct sof *sof)
 	int ret;
 
 #ifndef __ZEPHYR__
-	sof->platform_timer = &timer;
-	sof->cpu_timers = &timer;
+	sof->platform_timer = platform_shared_get(&timer_shared, sizeof(timer_shared));
+	sof->cpu_timers = sof->platform_timer;
 #endif
 
 #ifdef __ZEPHYR__

--- a/src/platform/imx8m/include/platform/lib/memory.h
+++ b/src/platform/imx8m/include/platform/lib/memory.h
@@ -193,6 +193,7 @@ void platform_init_memmap(struct sof *sof);
 
 #define uncache_to_cache(address)	address
 #define cache_to_uncache(address)	address
+#define cache_to_uncache_init(address)	address
 #define is_uncached(address)		0
 
 static inline void *platform_shared_get(void *ptr, int bytes)

--- a/src/platform/imx8m/lib/clk.c
+++ b/src/platform/imx8m/lib/clk.c
@@ -28,7 +28,7 @@ void platform_clock_init(struct sof *sof)
 {
 	int i;
 
-	sof->clocks = platform_clocks_info;
+	sof->clocks = platform_shared_get(platform_clocks_info, sizeof(platform_clocks_info));
 
 	for (i = 0; i < CONFIG_CORE_COUNT; i++) {
 		sof->clocks[i] = (struct clock_info) {

--- a/src/platform/imx8m/lib/dai.c
+++ b/src/platform/imx8m/lib/dai.c
@@ -59,7 +59,7 @@ static SHARED_DATA struct dai sai[] = {
 const struct dai_type_info dti[] = {
 	{
 		.type = SOF_DAI_IMX_SAI,
-		.dai_array = sai,
+		.dai_array = cache_to_uncache_init((struct dai *)sai),
 		.num_dais = ARRAY_SIZE(sai)
 	},
 };
@@ -75,7 +75,7 @@ int dai_init(struct sof *sof)
 
 	/* initialize spin locks early to enable ref counting */
 	for (i = 0; i < ARRAY_SIZE(sai); i++)
-		k_spinlock_init(&sai[i].lock);
+		k_spinlock_init(&dti[0].dai_array[i].lock);
 
 	sof->dai_info = &lib_dai;
 

--- a/src/platform/imx8m/lib/dma.c
+++ b/src/platform/imx8m/lib/dma.c
@@ -42,7 +42,7 @@ static SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
 };
 
 static const struct dma_info lib_dma = {
-	.dma_array = dma,
+	.dma_array = cache_to_uncache_init((struct dma *)dma),
 	.num_dmas = ARRAY_SIZE(dma)
 };
 

--- a/src/platform/imx8m/lib/memory.c
+++ b/src/platform/imx8m/lib/memory.c
@@ -97,5 +97,5 @@ static SHARED_DATA struct mm memmap = {
 void platform_init_memmap(struct sof *sof)
 {
 	/* memmap has been initialized statically as a part of .data */
-	sof->memory_map = &memmap;
+	sof->memory_map = platform_shared_get(&memmap, sizeof(memmap));
 }

--- a/src/platform/imx8m/platform.c
+++ b/src/platform/imx8m/platform.c
@@ -128,7 +128,7 @@ const struct ext_man_windows xsram_window
 };
 
 #ifndef __ZEPHYR__
-static SHARED_DATA struct timer timer = {
+static SHARED_DATA struct timer timer_shared = {
 	.id = TIMER0, /* internal timer */
 	.irq = IRQ_NUM_TIMER0,
 };
@@ -155,8 +155,8 @@ int platform_init(struct sof *sof)
 	int ret;
 
 #ifndef __ZEPHYR__
-	sof->platform_timer = &timer;
-	sof->cpu_timers = &timer;
+	sof->platform_timer = platform_shared_get(&timer_shared, sizeof(timer_shared));
+	sof->cpu_timers = sof->platform_timer;
 #endif
 
 #ifdef __ZEPHYR__

--- a/src/platform/imx8ulp/include/platform/lib/memory.h
+++ b/src/platform/imx8ulp/include/platform/lib/memory.h
@@ -192,6 +192,7 @@ void platform_init_memmap(struct sof *sof);
 
 #define uncache_to_cache(address)	address
 #define cache_to_uncache(address)	address
+#define cache_to_uncache_init(address)	address
 #define is_uncached(address)		0
 
 static inline void *platform_shared_get(void *ptr, int bytes)

--- a/src/platform/imx8ulp/lib/clk.c
+++ b/src/platform/imx8ulp/lib/clk.c
@@ -25,7 +25,7 @@ void platform_clock_init(struct sof *sof)
 {
 	int i;
 
-	sof->clocks = platform_clocks_info;
+	sof->clocks = platform_shared_get(platform_clocks_info, sizeof(platform_clocks_info));
 
 	for (i = 0; i < CONFIG_CORE_COUNT; i++) {
 		sof->clocks[i] = (struct clock_info) {

--- a/src/platform/imx8ulp/lib/dai.c
+++ b/src/platform/imx8ulp/lib/dai.c
@@ -71,7 +71,7 @@ static SHARED_DATA struct dai sai[] = {
 const struct dai_type_info dti[] = {
 	{
 		.type = SOF_DAI_IMX_SAI,
-		.dai_array = sai,
+		.dai_array = cache_to_uncache_init((struct dai *)sai),
 		.num_dais = ARRAY_SIZE(sai)
 	},
 };
@@ -87,7 +87,7 @@ int dai_init(struct sof *sof)
 
 	 /* initialize spin locks early to enable ref counting */
 	for (i = 0; i < ARRAY_SIZE(sai); i++)
-		k_spinlock_init(&sai[i].lock);
+		k_spinlock_init(&dti[0].dai_array[i].lock);
 
 	platform_shared_commit(sai, sizeof(*sai));
 

--- a/src/platform/imx8ulp/lib/dma.c
+++ b/src/platform/imx8ulp/lib/dma.c
@@ -45,7 +45,7 @@ static SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
 };
 
 static const struct dma_info lib_dma = {
-	.dma_array = dma,
+	.dma_array = cache_to_uncache_init((struct dma *)dma),
 	.num_dmas = ARRAY_SIZE(dma)
 };
 

--- a/src/platform/imx8ulp/lib/memory.c
+++ b/src/platform/imx8ulp/lib/memory.c
@@ -96,5 +96,5 @@ static SHARED_DATA struct mm memmap = {
 void platform_init_memmap(struct sof *sof)
 {
 	/* memmap has been initialized statically as a part of .data */
-	sof->memory_map = &memmap;
+	sof->memory_map = platform_shared_get(&memmap, sizeof(memmap));
 }

--- a/src/platform/imx8ulp/platform.c
+++ b/src/platform/imx8ulp/platform.c
@@ -125,7 +125,7 @@ const struct ext_man_windows xsram_window
 };
 
 #ifndef __ZEPHYR__
-static SHARED_DATA struct timer timer = {
+static SHARED_DATA struct timer timer_shared = {
 	.id = TIMER0, /* internal timer */
 	.irq = IRQ_NUM_TIMER0,
 };
@@ -152,8 +152,8 @@ int platform_init(struct sof *sof)
 	int ret;
 
 #ifndef __ZEPHYR__
-	sof->platform_timer = &timer;
-	sof->cpu_timers = &timer;
+	sof->platform_timer = platform_shared_get(&timer_shared, sizeof(timer_shared));
+	sof->cpu_timers = sof->platform_timer;
 #endif
 
 	platform_interrupt_init();

--- a/src/platform/intel/cavs/include/cavs/lib/memory.h
+++ b/src/platform/intel/cavs/include/cavs/lib/memory.h
@@ -77,7 +77,7 @@ struct sof;
  * uncached memory region. SMP platforms without uncache can simply
  * align to cache line size instead.
  */
-#if CONFIG_CORE_COUNT > 1 && !defined(UNIT_TEST) && !defined __ZEPHYR__
+#if !defined(UNIT_TEST) && !defined __ZEPHYR__
 #define SHARED_DATA	__section(".shared_data") __attribute__((aligned(PLATFORM_DCACHE_ALIGN)))
 #else
 #define SHARED_DATA

--- a/src/platform/intel/cavs/lib/clk.c
+++ b/src/platform/intel/cavs/lib/clk.c
@@ -311,8 +311,7 @@ void platform_clock_init(struct sof *sof)
 	uint32_t platform_lowest_clock = CPU_LOWEST_FREQ_IDX;
 	int i;
 
-	sof->clocks =
-		cache_to_uncache((struct clock_info *)platform_clocks_info);
+	sof->clocks = platform_shared_get(platform_clocks_info, sizeof(platform_clocks_info));
 
 #if CAVS_VERSION == CAVS_VERSION_2_5
 	/*

--- a/src/platform/intel/cavs/lib/memory.c
+++ b/src/platform/intel/cavs/lib/memory.c
@@ -146,7 +146,7 @@ void platform_init_memmap(struct sof *sof)
 				sizeof(struct block_map) * ARRAY_SIZE(buf_heap_map));
 
 	/* access memory map through uncached region */
-	sof->memory_map = cache_to_uncache(&memmap);
+	sof->memory_map = platform_shared_get(&memmap, sizeof(memmap));
 
 	/* .system primary core initialization */
 	sof->memory_map->system[0].heap = (uintptr_t)&_system_heap;

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -269,7 +269,7 @@ const int n_iomux = ARRAY_SIZE(iomux_data);
 #endif
 
 #ifndef __ZEPHYR__
-static SHARED_DATA struct timer timer = {
+static SHARED_DATA struct timer platform_timer = {
 	.id = TIMER3, /* external timer */
 	.irq = IRQ_EXT_TSTAMP0_LVL2,
 	.irq_name = irq_name_level2,
@@ -359,8 +359,8 @@ int platform_init(struct sof *sof)
 	int i;
 
 #ifndef __ZEPHYR__
-	sof->platform_timer = cache_to_uncache(&timer);
-	sof->cpu_timers = (struct timer *)cache_to_uncache(&arch_timers);
+	sof->platform_timer = platform_shared_get(&platform_timer, sizeof(platform_timer));
+	sof->cpu_timers = platform_shared_get(arch_timers, sizeof(arch_timers));
 
 	for (i = 0; i < CONFIG_CORE_COUNT; i++)
 		sof->cpu_timers[i] = (struct timer) {

--- a/src/platform/mt8186/include/platform/lib/memory.h
+++ b/src/platform/mt8186/include/platform/lib/memory.h
@@ -190,6 +190,7 @@ static inline void *platform_shared_get(void *ptr, int bytes)
 
 #define uncache_to_cache(address)	address
 #define cache_to_uncache(address)	address
+#define cache_to_uncache_init(address)	address
 #define is_uncached(address)		0
 
 /**

--- a/src/platform/mt8186/lib/clk.c
+++ b/src/platform/mt8186/lib/clk.c
@@ -86,7 +86,7 @@ void platform_clock_init(struct sof *sof)
 {
 	int i;
 
-	sof->clocks = platform_clocks_info;
+	sof->clocks = platform_shared_get(platform_clocks_info, sizeof(platform_clocks_info));
 
 	for (i = 0; i < CONFIG_CORE_COUNT; i++) {
 		sof->clocks[i] = (struct clock_info){

--- a/src/platform/mt8186/lib/dma.c
+++ b/src/platform/mt8186/lib/dma.c
@@ -26,7 +26,10 @@ static SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
 },
 };
 
-static const struct dma_info lib_dma = { .dma_array = dma, .num_dmas = ARRAY_SIZE(dma) };
+static const struct dma_info lib_dma = {
+	.dma_array = cache_to_uncache_init((struct dma *)dma),
+	.num_dmas = ARRAY_SIZE(dma)
+};
 
 int dmac_init(struct sof *sof)
 {

--- a/src/platform/mt8186/lib/memory.c
+++ b/src/platform/mt8186/lib/memory.c
@@ -97,5 +97,5 @@ static SHARED_DATA struct mm memmap = {
 void platform_init_memmap(struct sof *sof)
 {
 	/* memmap has been initialized statically as a part of .data */
-	sof->memory_map = &memmap;
+	sof->memory_map = platform_shared_get(&memmap, sizeof(memmap));
 }

--- a/src/platform/mt8186/platform.c
+++ b/src/platform/mt8186/platform.c
@@ -120,7 +120,7 @@ const struct ext_man_windows xsram_window
 	}
 };
 
-static SHARED_DATA struct timer timer = {
+static SHARED_DATA struct timer timer_shared = {
 	.id = OSTIMER0,
 	.irq = MTK_DSP_IRQ_OSTIMER32,
 };
@@ -168,8 +168,8 @@ int platform_init(struct sof *sof)
 {
 	int ret;
 
-	sof->platform_timer = &timer;
-	sof->cpu_timers = &timer;
+	sof->platform_timer = platform_shared_get(&timer_shared, sizeof(timer_shared));
+	sof->cpu_timers = sof->platform_timer;
 
 	platform_interrupt_init();
 	platform_clock_init(sof);

--- a/src/platform/mt8195/include/platform/lib/memory.h
+++ b/src/platform/mt8195/include/platform/lib/memory.h
@@ -185,6 +185,7 @@ static inline void *platform_shared_get(void *ptr, int bytes)
 
 #define uncache_to_cache(address) address
 #define cache_to_uncache(address) address
+#define cache_to_uncache_init(address) address
 #define is_uncached(address) 0
 
 /**

--- a/src/platform/mt8195/lib/clk.c
+++ b/src/platform/mt8195/lib/clk.c
@@ -178,7 +178,7 @@ void platform_clock_init(struct sof *sof)
 {
 	int i;
 
-	sof->clocks = platform_clocks_info;
+	sof->clocks = platform_shared_get(platform_clocks_info, sizeof(platform_clocks_info));
 
 	for (i = 0; i < CONFIG_CORE_COUNT; i++) {
 		sof->clocks[i] = (struct clock_info){

--- a/src/platform/mt8195/lib/dma.c
+++ b/src/platform/mt8195/lib/dma.c
@@ -39,7 +39,10 @@ static SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
 },
 };
 
-static const struct dma_info lib_dma = { .dma_array = dma, .num_dmas = ARRAY_SIZE(dma) };
+static const struct dma_info lib_dma = {
+	.dma_array = cache_to_uncache_init((struct dma *)dma),
+	.num_dmas = ARRAY_SIZE(dma)
+};
 
 int dmac_init(struct sof *sof)
 {

--- a/src/platform/mt8195/lib/memory.c
+++ b/src/platform/mt8195/lib/memory.c
@@ -96,5 +96,5 @@ static SHARED_DATA struct mm memmap = {
 void platform_init_memmap(struct sof *sof)
 {
 	/* memmap has been initialized statically as a part of .data */
-	sof->memory_map = &memmap;
+	sof->memory_map = platform_shared_get(&memmap, sizeof(memmap));
 }

--- a/src/platform/mt8195/platform.c
+++ b/src/platform/mt8195/platform.c
@@ -120,7 +120,7 @@ const struct ext_man_windows xsram_window
 	}
 };
 
-static SHARED_DATA struct timer timer = {
+static SHARED_DATA struct timer timer_shared = {
 	.id = OSTIMER0,
 	.irq = LX_ADSP_TIMTER_IRQ0_B,
 };
@@ -181,8 +181,8 @@ int platform_init(struct sof *sof)
 {
 	int ret;
 
-	sof->platform_timer = &timer;
-	sof->cpu_timers = &timer;
+	sof->platform_timer = platform_shared_get(&timer_shared, sizeof(timer_shared));
+	sof->cpu_timers = sof->platform_timer;
 
 	platform_interrupt_init();
 	platform_clock_init(sof);


### PR DESCRIPTION
Objects, defined with a `SHARED_DATA` attribute should go into a separate section in both single- and multi-core configurations. Access to them at run-time should only be performed via the `platform_shared_get()` accessor and at initialisation time with `cache_to_uncache_init()`