### PR TITLE
backport to stable-2.1: removal of "git submodule update" from xtensa-build-zephyr.py

### DIFF
--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -185,7 +185,7 @@ sign must be used (https://bugs.python.org/issue9334)""",
 	if args.clone_mode and not args.z:
 		args.z = "main"		# set default name for -z if -c specified
 
-	if args.west_path:			# allow user override path to zephyr project
+	if args.west_path: # let the user provide an already existing zephyrproject/ anywhere
 		west_top = pathlib.Path(args.west_path)
 	elif not args.clone_mode:	# if neather -p nor -c provided, use -p
 		args.west_path = west_top
@@ -422,9 +422,6 @@ def run_clone_mode():
 	create_zephyr_directory()
 	west_init_update()
 	git_submodules_update()
-	if args.platforms:
-		build_platforms()
-		show_installed_files()
 
 def run_point_mode():
 	global west_top, SOF_TOP
@@ -436,9 +433,6 @@ def run_point_mode():
 		raise FileNotFoundError("West topdir returned {} as workspace but it"
 			" does not exist".format(west_workspace_path))
 	create_zephyr_sof_symlink()
-	if args.platforms:
-		build_platforms()
-		show_installed_files()
 
 def main():
 	parse_args()
@@ -448,11 +442,17 @@ def main():
 	else:
 		print("Building platforms: {}".format(" ".join(args.platforms)))
 
-	# Two mutually exclusive working modes are supported
+	# we made two modes mutually exclusive with argparse
 	if args.west_path:
+		# check west_path input + create symlink if needed
 		run_point_mode()
 	if args.clone_mode:
+		# Initialize zephyr project with west
 		run_clone_mode()
+
+	if args.platforms:
+		build_platforms()
+		show_installed_files()
 
 if __name__ == "__main__":
 	main()

--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -367,8 +367,6 @@ def build_platforms():
 		# Extract metadata
 		execute_command([str(smex_executable), "-l", str(fw_ldc_file), str(input_elf_file)],
 			check=True)
-		# Update SOF submodules
-		git_submodules_update()
 		# CMake - configure rimage module
 		rimage_dir_name="build-rimage"
 		sof_mirror_dir = pathlib.Path("modules", "audio", "sof")

--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -223,11 +223,6 @@ def show_installed_files():
 	for pre, fill, node in RenderTree(graph_root):
 		print(f"{pre}{node.name}")
 
-def git_submodules_update():
-	global SOF_TOP
-	execute_command(["git", "submodule", "update", "--init", "--recursive"], timeout=600,
-		check=True, cwd=SOF_TOP)
-
 def check_west_installation():
 	west_path = shutil.which("west")
 	if not west_path:
@@ -419,7 +414,6 @@ def run_clone_mode():
 		raise RuntimeError("Zephyr found already! Not downloading it again")
 	create_zephyr_directory()
 	west_init_update()
-	git_submodules_update()
 
 def run_point_mode():
 	global west_top, SOF_TOP

--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -425,8 +425,6 @@ def run_clone_mode():
 	if args.platforms:
 		build_platforms()
 		show_installed_files()
-	else:
-		git_submodules_update()
 
 def run_point_mode():
 	global west_top, SOF_TOP


### PR DESCRIPTION
git submodule update is a potentially destructive operation. It won't affect automation but it would really hurt developers debugging some rimage-related issue in 2.1