### PR TITLE
mediatek: mt8195: afe-drv: fix fs cppcheck warning

### DIFF
--- a/src/drivers/mediatek/mt8195/afe-drv.c
+++ b/src/drivers/mediatek/mt8195/afe-drv.c
@@ -292,7 +292,7 @@ int afe_irq_clear(struct mtk_base_afe *afe, int id)
 int afe_irq_config(struct mtk_base_afe *afe, int id, unsigned int rate, unsigned int period)
 {
 	struct mtk_base_afe_irq *irq = &afe->irqs[id];
-	unsigned int fs;
+	int fs;
 
 	afe_reg_update_bits(afe, irq->irq_data->irq_cnt_reg,
 			    irq->irq_data->irq_cnt_maskbit << irq->irq_data->irq_cnt_shift,


### PR DESCRIPTION
This patch defines fs as signed integer in afe_irq_config to fix cppcheck warning which is discussed in https://github.com/thesofproject/sof/issues/4816
Please help to review it. Thanks.