### PR TITLE
topology1: Fix m4 issue in conditional definition [adl-004-drop-stable]

### DIFF
--- a/tools/topology/topology1/sof-tgl-max98357a-rt5682.m4
+++ b/tools/topology/topology1/sof-tgl-max98357a-rt5682.m4
@@ -102,7 +102,7 @@ ifdef(`GOOGLE_RTC_AUDIO_PROCESSING',
 # PCM99 <---- volume <---- DMIC01 (dmic 48k capture)
 # PCM100 <---- kpb <---- DMIC16K (dmic 16k capture)
 
-ifdef(`GOOGLE_RTC_AUDIO_PROCESSING', define(`SPK_MIC_PERIOD_US', 10000), define(`SPK_MIC_PERIOD_US', 1000))
+ifdef(`GOOGLE_RTC_AUDIO_PROCESSING', `define(`SPK_MIC_PERIOD_US', 10000)', `define(`SPK_MIC_PERIOD_US', 1000)')
 
 ifdef(`NO_AMP',`',`
 # Define pipeline id for sof-tgl-CODEC-rt5682.m4


### PR DESCRIPTION
Due to m4 peculiarities it is require to escape the content of an
ifdef. I forgot to add those escaping for around the `SPK_MIC_PERIOD_US`
definition leading to erroneous value if GOOGLE_RTC_AUDIO_PROCESSING was
defined.

Signed-off-by: Lionel Koenig <lionelk@google.com>
(cherry picked from commit 980a5b25b3d97654e2583a12fcc165b47f3a717f)

This backports #5466 to adl-004-drop-stable