### PR TITLE
Codec Adapter: Use the passed input buffers

### DIFF
--- a/src/audio/codec_adapter/codec/cadence.c
+++ b/src/audio/codec_adapter/codec/cadence.c
@@ -509,6 +509,12 @@ cadence_codec_process(struct processing_module *mod,
 	struct cadence_codec_data *cd = codec->private;
 	int ret;
 
+	/* Proceed only if we have enough data to fill the module buffer completely */
+	if (input_buffers[0].size < codec->mpd.in_buff_size) {
+		comp_dbg(dev, "cadence_codec_process(): not enough data to process");
+		return -ENODATA;
+	}
+
 	/* do not proceed with processing if not enough free left in the local buffer */
 	if (codec->mpd.init_done) {
 		int output_bytes = cadence_codec_get_samples(dev) *

--- a/src/audio/codec_adapter/codec/dts.c
+++ b/src/audio/codec_adapter/codec/dts.c
@@ -228,6 +228,12 @@ dts_codec_process(struct processing_module *mod,
 	DtsSofInterfaceResult dts_result;
 	unsigned int bytes_processed = 0;
 
+	/* Proceed only if we have enough data to fill the module buffer completely */
+	if (input_buffers[0].size < codec->mpd.in_buff_size) {
+		comp_dbg(dev, "dts_codec_process(): not enough data to process");
+		return -ENODATA;
+	}
+
 	if (!codec->mpd.init_done)
 		return dts_codec_init_process(dev);
 

--- a/src/audio/codec_adapter/codec/dts.c
+++ b/src/audio/codec_adapter/codec/dts.c
@@ -234,8 +234,15 @@ dts_codec_process(struct processing_module *mod,
 		return -ENODATA;
 	}
 
-	if (!codec->mpd.init_done)
-		return dts_codec_init_process(dev);
+	if (!codec->mpd.init_done) {
+		ret = dts_codec_init_process(dev);
+		if (ret < 0)
+			return ret;
+	}
+
+	memcpy_s(codec->mpd.in_buff, codec->mpd.in_buff_size,
+		 input_buffers[0].data, codec->mpd.in_buff_size);
+	codec->mpd.avail = codec->mpd.in_buff_size;
 
 	comp_dbg(dev, "dts_codec_process() start");
 
@@ -244,6 +251,7 @@ dts_codec_process(struct processing_module *mod,
 
 	codec->mpd.consumed = !ret ? bytes_processed : 0;
 	codec->mpd.produced = !ret ? bytes_processed : 0;
+	input_buffers[0].consumed = codec->mpd.consumed;
 
 	if (ret)
 		comp_err(dev, "dts_codec_process() failed %d %d", ret, dts_result);

--- a/src/audio/codec_adapter/codec/generic.c
+++ b/src/audio/codec_adapter/codec/generic.c
@@ -245,7 +245,7 @@ int module_process(struct processing_module *mod, struct input_stream_buffer *in
 
 	ret = md->ops->process(mod, input_buffers, num_input_buffers, output_buffers,
 			       num_output_buffers);
-	if (ret && ret != -ENOSPC) {
+	if (ret && ret != -ENOSPC && ret != -ENODATA) {
 		comp_err(dev, "module_process() error %d: for comp %d",
 			 ret, dev_comp_id(dev));
 		return ret;

--- a/src/audio/codec_adapter/codec/passthrough.c
+++ b/src/audio/codec_adapter/codec/passthrough.c
@@ -65,6 +65,12 @@ passthrough_codec_process(struct processing_module *mod,
 	struct comp_dev *dev = mod->dev;
 	struct module_data *codec = comp_get_module_data(dev);
 
+	/* Proceed only if we have enough data to fill the module buffer completely */
+	if (input_buffers[0].size < codec->mpd.in_buff_size) {
+		comp_dbg(dev, "passthrough_codec_process(): not enough data to process");
+		return -ENODATA;
+	}
+
 	if (!codec->mpd.init_done)
 		return passthrough_codec_init_process(dev);
 

--- a/src/audio/codec_adapter/codec/passthrough.c
+++ b/src/audio/codec_adapter/codec/passthrough.c
@@ -72,7 +72,10 @@ passthrough_codec_process(struct processing_module *mod,
 	}
 
 	if (!codec->mpd.init_done)
-		return passthrough_codec_init_process(dev);
+		passthrough_codec_init_process(dev);
+
+	memcpy_s(codec->mpd.in_buff, codec->mpd.in_buff_size,
+		 input_buffers[0].data, codec->mpd.in_buff_size);
 
 	comp_dbg(dev, "passthrough_codec_process()");
 
@@ -80,6 +83,7 @@ passthrough_codec_process(struct processing_module *mod,
 		 codec->mpd.in_buff, codec->mpd.in_buff_size);
 	codec->mpd.produced = mod->period_bytes;
 	codec->mpd.consumed = mod->period_bytes;
+	input_buffers[0].consumed = codec->mpd.consumed;
 
 	return 0;
 }

--- a/src/audio/codec_adapter/codec/waves.c
+++ b/src/audio/codec_adapter/codec/waves.c
@@ -722,7 +722,11 @@ waves_codec_process(struct processing_module *mod,
 	}
 
 	if (!codec->mpd.init_done)
-		return waves_codec_init_process(dev);
+		waves_codec_init_process(dev);
+
+	memcpy_s(codes->mpd.in_buff, codec->mpd.in_buff_size,
+		 input_buffers[0].data, codec->mpd.in_buff_size);
+	codec->mpd.avail = codec->mpd.in_buff_size;
 
 	comp_dbg(dev, "waves_codec_process() start");
 
@@ -760,6 +764,7 @@ waves_codec_process(struct processing_module *mod,
 		codec->mpd.produced = waves_codec->o_stream.numAvailableSamples *
 			waves_codec->o_format.numChannels * waves_codec->sample_size_in_bytes;
 		codec->mpd.consumed = codec->mpd.produced;
+		input_buffers[0].consumed = codec->mpd.consumed;
 		ret = 0;
 	}
 

--- a/src/audio/codec_adapter/codec/waves.c
+++ b/src/audio/codec_adapter/codec/waves.c
@@ -715,6 +715,12 @@ waves_codec_process(struct processing_module *mod,
 	struct module_data *codec = comp_get_module_data(dev);
 	struct waves_codec_data *waves_codec = codec->private;
 
+	/* Proceed only if we have enough data to fill the module buffer completely */
+	if (input_buffers[0].size < codec->mpd.in_buff_size) {
+		comp_dbg(dev, "waves_codec_process(): not enough data to process");
+		return -ENODATA;
+	}
+
 	if (!codec->mpd.init_done)
 		return waves_codec_init_process(dev);
 


### PR DESCRIPTION
Use the passed input buffers and move the initialization call within the first process callback for each codec.