### PR TITLE
ipc4: revert "ipc4: fix pipeline reset"

### DIFF
--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -153,30 +153,6 @@ error:
 	return err;
 }
 
-static int propagate_state_to_ppl_comp(struct ipc *ipc, uint32_t ppl_id, int cmd)
-{
-	int ret = IPC4_INVALID_RESOURCE_ID;
-	struct ipc_comp_dev *icd;
-	struct list_item *clist;
-
-	list_for_item(clist, &ipc->comp_list) {
-		icd = container_of(clist, struct ipc_comp_dev, list);
-		if (icd->type != COMP_TYPE_COMPONENT)
-			continue;
-
-		if (!cpu_is_me(icd->core))
-			continue;
-
-		if (ipc_comp_pipe_id(icd) == ppl_id) {
-			ret = comp_set_state(icd->cd, cmd);
-			if (ret != 0)
-				return IPC4_INVALID_REQUEST;
-		}
-	}
-
-	return ret;
-}
-
 static bool is_any_ppl_active(void)
 {
 	struct ipc_comp_dev *icd;
@@ -303,13 +279,9 @@ static int set_pipeline_state(uint32_t id, uint32_t cmd, bool *delayed)
 			}
 		}
 
-		ret = propagate_state_to_ppl_comp(ipc, id, COMP_TRIGGER_RESET);
-		if (ret != 0)
-			return ret;
-
 		/* resource is not released by triggering reset which is used by current FW */
 		ret = pipeline_reset(host->cd->pipeline, host->cd);
-		if (ret != 0)
+		if (ret < 0)
 			ret = IPC4_INVALID_REQUEST;
 
 		return ret;


### PR DESCRIPTION
This reverts commit 819c023d236ada6adbb8bc1610466e754c15f2ff.
Fix a regression issue on windows.

Component is set to reset status in pipeline_reset, so no
need to propagate reset status to each component.

Discussed with @tmleman  and fixed it. https://github.com/thesofproject/sof/pull/5342#issuecomment-1063813209