### PR TITLE
ipc4: fix the compound ipc wait timeout

### DIFF
--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -390,7 +390,7 @@ static void ipc_compound_msg_done(uint32_t msg_id, int error)
 
 static int ipc_wait_for_compound_msg(void)
 {
-	int try_count = 10;
+	int try_count = 30;
 	int ret = 0;
 
 	while (msg_data.delayed_reply) {


### PR DESCRIPTION
The number of retries is too small to successfully handle some
compound IPC messages (in particular setting pipeline state to running
in case of multi-core distributed pipeline).

Signed-off-by: Rafal Redzimski <rafal.f.redzimski@intel.com>