### PR TITLE
ipc4: dai: reset llp position to 0 for dai_reset

### DIFF
--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -186,8 +186,13 @@ void dai_dma_release(struct comp_dev *dev)
 
 		get_llp_reg_info(dd, &node_id, &llp_reg_offset);
 		if (node_id) {
-			/* clear memory window */
+			/* reset llp position to 0 in memory window for reset state.
+			 * clear node id and llp position to 0 when dai is free
+			 */
 			memset_s(&slot, sizeof(slot), 0, sizeof(slot));
+			if (dev->state == COMP_STATE_PAUSED)
+				slot.node_id = node_id;
+
 			mailbox_sw_regs_write(llp_reg_offset, &slot, sizeof(slot));
 		}
 


### PR DESCRIPTION
Progress bar of audio player disappears when it is dragged by
mouse. In this case pipeline is first paused then reset.Driver
checks the llp position in memory windows by node id. Driver
can't find llp position since fw cleared node id. This patch
reserves node id for pause-reset case and only reset llp position.
The node_id will be cleared when dai is free.

Signed-off-by: Rander Wang <rander.wang@intel.com>