### PR TITLE
[SOF-2.1 BACKPORT] xtensa-build-all: add a separate target for JSL

### DIFF
--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -48,6 +48,12 @@ platform_list = [
 		"XTENSA_TOOLS_VERSION": f"RG-2017.8{xtensa_tools_version_postfix}"
 	},
 	{
+		"name": "jsl",
+		"PLAT_CONFIG": "intel_adsp_cavs20_jsl",
+		"XTENSA_CORE": "X6H3CNL_2017_8",
+		"XTENSA_TOOLS_VERSION": f"RG-2017.8{xtensa_tools_version_postfix}"
+	},
+	{
 		"name": "tgl",
 		"PLAT_CONFIG": "intel_adsp_cavs25",
 		"IPC4_CONFIG_OVERLAY": "ipc4_overlay.conf",

--- a/scripts/xtensa-build-zephyr.sh
+++ b/scripts/xtensa-build-zephyr.sh
@@ -11,7 +11,7 @@ SOF_TOP=$(cd "$(dirname "$0")" && cd .. && pwd)
 DEFAULT_PLATFORMS=()
 
 # Intel
-DEFAULT_PLATFORMS+=(apl cnl icl tgl-h tgl)
+DEFAULT_PLATFORMS+=(apl cnl icl jsl tgl-h tgl)
 
 # NXP
 DEFAULT_PLATFORMS+=(imx8 imx8x imx8m)
@@ -189,8 +189,11 @@ build_platforms()
 				XTENSA_CORE="X6H3CNL_2017_8"
 				XTENSA_TOOLS_VERSION="RG-2017.8-linux"
 				;;
-			icl)
+			icl|jsl)
 				PLAT_CONFIG='intel_adsp_cavs20'
+				if test "$platform" = jsl ; then
+				    PLAT_CONFIG="intel_adsp_cavs20_jsl"
+                                fi
 				XTENSA_CORE="X6H3CNL_2017_8"
 				XTENSA_TOOLS_VERSION="RG-2017.8-linux"
 				;;


### PR DESCRIPTION
Use intel_adsp_cavs20_jsl Zephyr board when building for
Intel Jasper Lake.

BugLink: https://github.com/thesofproject/sof/issues/4539
Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>
(cherry picked from commit 6d0ecc37cc282a6c9df991168931697ba2213138)