### PR TITLE
platform: disable system agent on Zephyr builds

### DIFF
--- a/src/platform/Kconfig
+++ b/src/platform/Kconfig
@@ -490,6 +490,7 @@ config SYSTICK_PERIOD
 
 config HAVE_AGENT
 	bool "Enable system agent"
+	default n if ZEPHYR_SOF_MODULE
 	default y
 	help
 	  Enables system agent. It can be disabled on systems


### PR DESCRIPTION
The system agent is not required with SOF Zephyr builds
as the Zephyr ll scheduler implementation can track DSP
load and print periodic status of the load and any observed
overruns in scheduling.

Disabling agent is beneficial as agent can create a lot of DMA traffic
when DMA trace is enabled. This happens if there is jitter in agent
execution, with delta slightly over the warning threshold. This can
itself worsen the scheduling variation and lead to actual problems.

BugLink: https://github.com/thesofproject/sof/issues/5556
Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>