### PR TITLE
ipc4: add support for voice recorder in windows 10

### DIFF
--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -98,11 +98,12 @@ int comp_set_state(struct comp_dev *dev, int cmd)
 		break;
 	case COMP_TRIGGER_RESET:
 		/* reset always succeeds */
-		if (dev->state == COMP_STATE_ACTIVE ||
-		    dev->state == COMP_STATE_PAUSED) {
+		if (dev->state == COMP_STATE_ACTIVE)
 			comp_err(dev, "comp_set_state(): wrong state = %u, COMP_TRIGGER_RESET",
 				 dev->state);
-		}
+		else if (dev->state == COMP_STATE_PAUSED)
+			comp_info(dev, "comp_set_state(): state = %u, COMP_TRIGGER_RESET",
+				  dev->state);
 		break;
 	case COMP_TRIGGER_PREPARE:
 		if (dev->state != COMP_STATE_READY) {

--- a/src/audio/copier.c
+++ b/src/audio/copier.c
@@ -170,6 +170,7 @@ static struct comp_dev *create_host(struct comp_dev *parent_dev, struct copier_d
 	if (!drv)
 		return NULL;
 
+	parent_dev->ipc_config.type = SOF_COMP_HOST;
 	config->type = SOF_COMP_HOST;
 
 	create_endpoint_buffer(parent_dev, cd, config, copier_cfg);
@@ -222,6 +223,7 @@ static struct comp_dev *create_dai(struct comp_dev *parent_dev, struct copier_da
 	if (!drv)
 		return NULL;
 
+	parent_dev->ipc_config.type = SOF_COMP_DAI;
 	config->type = SOF_COMP_DAI;
 	create_endpoint_buffer(parent_dev, cd, config, copier);
 

--- a/src/audio/copier.c
+++ b/src/audio/copier.c
@@ -68,7 +68,8 @@ struct copier_data {
 
 static pcm_converter_func get_converter_func(struct ipc4_audio_format *in_fmt,
 					     struct ipc4_audio_format *out_fmt,
-					     enum ipc4_gateway_type type);
+					     enum ipc4_gateway_type type,
+					     enum ipc4_direction_type);
 
 static void create_endpoint_buffer(struct comp_dev *parent_dev,
 				   struct copier_data *cd,
@@ -196,7 +197,7 @@ static struct comp_dev *create_host(struct comp_dev *parent_dev, struct copier_d
 	}
 
 	cd->converter[0] = get_converter_func(&copier_cfg->base.audio_fmt, &copier_cfg->out_fmt,
-					      ipc4_gtw_host);
+					      ipc4_gtw_host, IPC4_DIRECTION(dir));
 
 	return dev;
 }
@@ -294,7 +295,8 @@ static struct comp_dev *create_dai(struct comp_dev *parent_dev, struct copier_da
 		cd->bsource_buffer = false;
 	}
 
-	cd->converter[0] = get_converter_func(&copier->base.audio_fmt, &copier->out_fmt, type);
+	cd->converter[0] = get_converter_func(&copier->base.audio_fmt, &copier->out_fmt, type,
+					      IPC4_DIRECTION(dai.direction));
 
 	return dev;
 }
@@ -460,7 +462,8 @@ static bool use_no_container_convert_function(enum sof_ipc_frame in,
 
 static pcm_converter_func get_converter_func(struct ipc4_audio_format *in_fmt,
 					     struct ipc4_audio_format *out_fmt,
-					     enum ipc4_gateway_type type)
+					     enum ipc4_gateway_type type,
+					     enum ipc4_direction_type dir)
 {
 	enum sof_ipc_frame in, in_valid, out, out_valid;
 
@@ -473,7 +476,7 @@ static pcm_converter_func get_converter_func(struct ipc4_audio_format *in_fmt,
 	if (use_no_container_convert_function(in, in_valid, out, out_valid))
 		return pcm_get_conversion_function(in, out);
 	else
-		return pcm_get_conversion_vc_function(in, in_valid, out, out_valid, type);
+		return pcm_get_conversion_vc_function(in, in_valid, out, out_valid, type, dir);
 }
 
 static int copier_prepare(struct comp_dev *dev)
@@ -501,7 +504,8 @@ static int copier_prepare(struct comp_dev *dev)
 	} else {
 		/* set up format conversion function */
 		cd->converter[0] = get_converter_func(&cd->config.base.audio_fmt,
-						      &cd->config.out_fmt, ipc4_gtw_none);
+						      &cd->config.out_fmt, ipc4_gtw_none,
+						      ipc4_bidirection);
 		if (!cd->converter[0]) {
 			comp_err(dev, "can't support for in format %d, out format %d",
 				 cd->config.base.audio_fmt.depth,  cd->config.out_fmt.depth);
@@ -874,7 +878,8 @@ static int copier_set_sink_fmt(struct comp_dev *dev, void *data,
 
 	cd->out_fmt[sink_fmt->sink_id] = sink_fmt->sink_fmt;
 	cd->converter[sink_fmt->sink_id] = get_converter_func(&sink_fmt->source_fmt,
-							      &sink_fmt->sink_fmt, ipc4_gtw_none);
+							      &sink_fmt->sink_fmt, ipc4_gtw_none,
+							      ipc4_bidirection);
 
 	return 0;
 }

--- a/src/audio/pcm_converter/pcm_converter_generic.c
+++ b/src/audio/pcm_converter/pcm_converter_generic.c
@@ -785,51 +785,63 @@ static int pcm_convert_s24_c32_to_s24_c24_link_gtw(const struct audio_stream *so
 const struct pcm_func_vc_map pcm_func_vc_map[] = {
 #if CONFIG_PCM_CONVERTER_FORMAT_S16_C16_AND_S16_C32
 	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE,
-		ipc4_gtw_all, pcm_convert_s16_c16_to_s16_c32 },
+		ipc4_gtw_all, ipc4_bidirection, pcm_convert_s16_c16_to_s16_c32 },
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S16_LE,
-		ipc4_gtw_all, pcm_convert_s16_c32_to_s16_c16 },
+		ipc4_gtw_all, ipc4_bidirection, pcm_convert_s16_c32_to_s16_c16 },
 #endif
 #if CONFIG_PCM_CONVERTER_FORMAT_S16_C32_AND_S32_C32
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE,
-		ipc4_gtw_all, pcm_convert_s16_c32_to_s32_c32 },
+		ipc4_gtw_all, ipc4_bidirection, pcm_convert_s16_c32_to_s32_c32 },
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE,
-		ipc4_gtw_all, pcm_convert_s32_c32_to_s16_c32 },
+		ipc4_gtw_all, ipc4_bidirection, pcm_convert_s32_c32_to_s16_c32 },
 #endif
 #if CONFIG_PCM_CONVERTER_FORMAT_S16_C32_AND_S24_C32
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE,
-		ipc4_gtw_all, pcm_convert_s16_c32_to_s24_c32 },
+		ipc4_gtw_all & ~ipc4_gtw_alh, ipc4_bidirection, pcm_convert_s16_c32_to_s24_c32 },
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE,
+		ipc4_gtw_alh, ipc4_capture, pcm_convert_s32_to_s24 },
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE,
-		ipc4_gtw_all, pcm_convert_s24_c32_to_s16_c32 },
+		ipc4_gtw_all & ~ipc4_gtw_alh, ipc4_bidirection, pcm_convert_s24_c32_to_s16_c32 },
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE,
+		ipc4_gtw_alh, ipc4_playback, pcm_convert_s24_to_s32 },
 #endif
 #if CONFIG_PCM_CONVERTER_FORMAT_S32LE && CONFIG_PCM_CONVERTER_FORMAT_S24LE
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE,
-		ipc4_gtw_all & ~(ipc4_gtw_link | ipc4_gtw_alh | ipc4_gtw_host), audio_stream_copy },
+		ipc4_gtw_all & ~(ipc4_gtw_link | ipc4_gtw_alh | ipc4_gtw_host), ipc4_bidirection,
+		audio_stream_copy},
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE,
-		ipc4_gtw_link | ipc4_gtw_alh, pcm_convert_s24_to_s32 },
+		ipc4_gtw_link | ipc4_gtw_alh, ipc4_playback, pcm_convert_s24_to_s32 },
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE,
-		ipc4_gtw_host, pcm_convert_s32_to_s24 },
+		ipc4_gtw_link | ipc4_gtw_alh, ipc4_capture, pcm_convert_s32_to_s24 },
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE,
+		ipc4_gtw_host, ipc4_playback, pcm_convert_s32_to_s24 },
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE,
+		ipc4_gtw_host, ipc4_capture, pcm_convert_s24_to_s32 },
 #endif
 #if CONFIG_PCM_CONVERTER_FORMAT_S24LE && CONFIG_PCM_CONVERTER_FORMAT_S16LE
 	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S32_LE,
 		SOF_IPC_FRAME_S24_4LE, ipc4_gtw_all & ~(ipc4_gtw_link | ipc4_gtw_alh),
-		pcm_convert_s16_to_s24 },
+		ipc4_bidirection, pcm_convert_s16_to_s24 },
 	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S32_LE,
-		SOF_IPC_FRAME_S24_4LE, ipc4_gtw_link | ipc4_gtw_alh, pcm_convert_s16_to_s32 },
+		SOF_IPC_FRAME_S24_4LE, ipc4_gtw_link | ipc4_gtw_alh, ipc4_playback,
+		pcm_convert_s16_to_s32},
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S16_LE,
-		SOF_IPC_FRAME_S16_LE, ipc4_gtw_all, pcm_convert_s24_to_s16 },
+		SOF_IPC_FRAME_S16_LE, ipc4_gtw_all, ipc4_bidirection, pcm_convert_s24_to_s16 },
 #endif
 #if CONFIG_PCM_CONVERTER_FORMAT_S24_C24_AND_S24_C32
 	{ SOF_IPC_FRAME_S24_3LE, SOF_IPC_FRAME_S24_3LE, SOF_IPC_FRAME_S32_LE,
-		SOF_IPC_FRAME_S24_4LE, ipc4_gtw_all, pcm_convert_s24_c24_to_s24_c32 },
+		SOF_IPC_FRAME_S24_4LE, ipc4_gtw_all, ipc4_bidirection,
+		pcm_convert_s24_c24_to_s24_c32},
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S24_3LE,
 		SOF_IPC_FRAME_S24_3LE, ipc4_gtw_all & ~ipc4_gtw_link,
-		pcm_convert_s24_c32_to_s24_c24 },
+		ipc4_bidirection, pcm_convert_s24_c32_to_s24_c24 },
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S24_3LE,
-		SOF_IPC_FRAME_S24_3LE, ipc4_gtw_link, pcm_convert_s24_c32_to_s24_c24_link_gtw },
+		SOF_IPC_FRAME_S24_3LE, ipc4_gtw_link, ipc4_playback,
+		pcm_convert_s24_c32_to_s24_c24_link_gtw },
 #endif
 #if CONFIG_PCM_CONVERTER_FORMAT_S16_C32_AND_S16_C32
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S32_LE,
-		SOF_IPC_FRAME_S16_LE, ipc4_gtw_all, audio_stream_copy },
+		SOF_IPC_FRAME_S16_LE, ipc4_gtw_all, ipc4_bidirection, audio_stream_copy },
 #endif
 };
 

--- a/src/audio/pipeline/pipeline-graph.c
+++ b/src/audio/pipeline/pipeline-graph.c
@@ -431,6 +431,11 @@ struct comp_dev *pipeline_get_dai_comp(uint32_t pipeline_id, uint32_t *latency)
 		buffer = buffer_from_list(comp_buffer_list(sink->cd, PPL_DIR_DOWNSTREAM)->next,
 					  struct comp_buffer, PPL_DIR_DOWNSTREAM);
 		buff_comp = buffer_get_comp(buffer, PPL_DIR_DOWNSTREAM);
+
+		/* buffer_comp is in another pipeline and it is not complete */
+		if (!buff_comp->pipeline)
+			return NULL;
+
 		sink = ipc_get_ppl_sink_comp(ipc, buff_comp->pipeline->pipeline_id);
 
 		if (!sink)

--- a/src/include/ipc4/gateway.h
+++ b/src/include/ipc4/gateway.h
@@ -197,4 +197,11 @@ enum ipc4_gateway_type {
 	ipc4_gtw_all	= BIT(6) - 1
 };
 
+enum ipc4_direction_type {
+	ipc4_playback = BIT(0),
+	ipc4_capture = BIT(1),
+	ipc4_bidirection = BIT(0) | BIT(1)
+};
+
+#define IPC4_DIRECTION(x) BIT(x)
 #endif

--- a/src/include/sof/audio/pcm_converter.h
+++ b/src/include/sof/audio/pcm_converter.h
@@ -103,6 +103,7 @@ struct pcm_func_vc_map {
 	enum sof_ipc_frame sink;	/**< sink frame container format */
 	enum sof_ipc_frame valid_sink_bits;	/**< sink frame format */
 	uint32_t type;	/**< gateway type */
+	enum ipc4_direction_type direction;	/**< support playback, capture or both */
 	pcm_converter_func func; /**< PCM conversion function */
 };
 
@@ -119,13 +120,15 @@ extern const size_t pcm_func_vc_count;
  * \param out_bits is sink container format.
  * \param valid_out_bits is sink valid sample format.
  * \param type is gateway type
+ * \param dir is playback or capture
  */
 static inline pcm_converter_func
 pcm_get_conversion_vc_function(enum sof_ipc_frame in_bits,
 			       enum sof_ipc_frame valid_in_bits,
 			       enum sof_ipc_frame out_bits,
 			       enum sof_ipc_frame valid_out_bits,
-			       enum ipc4_gateway_type type)
+			       enum ipc4_gateway_type type,
+			       enum ipc4_direction_type dir)
 {
 	uint32_t i;
 
@@ -140,6 +143,9 @@ pcm_get_conversion_vc_function(enum sof_ipc_frame in_bits,
 			continue;
 
 		if (!(type & pcm_func_vc_map[i].type))
+			continue;
+
+		if (!(dir & pcm_func_vc_map[i].direction))
 			continue;
 
 		return pcm_func_vc_map[i].func;


### PR DESCRIPTION
Voice recorder can capture voice and save it to hard disk. This patch fixes some bugs and add support of format conversion used by it.