### PR TITLE
ipc4: dai: update wallclock for position update

### DIFF
--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -283,7 +283,7 @@ int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn)
 	/* total processed bytes count */
 	posn->dai_posn = dev->position;
 
-	/* set stream start wallclock */
+	platform_dai_wallclock(dev, &dd->wallclock);
 	posn->wallclock = dd->wallclock;
 
 	status.ipc_posn_data = &posn->comp_posn;
@@ -307,6 +307,8 @@ void dai_dma_position_update(struct comp_dev *dev)
 
 	status.ipc_posn_data = llp_data;
 	dma_status(dd->chan, &status, dev->direction);
+
+	platform_dai_wallclock(dev, &dd->wallclock);
 
 	slot.node_id = node_id;
 	slot.reading.llp_l = llp_data[0];


### PR DESCRIPTION
The original code was copied from ipc3 path but the wallclock usage
is different. In ipc4 path fw needs update it for each position update.

Signed-off-by: Rander Wang <rander.wang@intel.com>