### PR TITLE
[RTNR] Reserve more memory for RTNR for ADL platform

### DIFF
--- a/src/platform/tigerlake/include/platform/lib/memory.h
+++ b/src/platform/tigerlake/include/platform/lib/memory.h
@@ -266,8 +266,8 @@
 #else
 /* Reserve more memory for RTNR */
 #ifdef CONFIG_COMP_RTNR
-#define RT_TIMES	5
-#define RT_SHARED_TIMES	11
+#define RT_TIMES	4
+#define RT_SHARED_TIMES	8
 #else
 #define RT_TIMES	8
 #define RT_SHARED_TIMES	16


### PR DESCRIPTION
This PR cherry-picks #88925cd from main to adl-004-drop-stable to reserve more memory for RTNR.