### PR TITLE
google_aec: Use frag_write to write data.

### DIFF
--- a/src/audio/google_rtc_audio_processing.c
+++ b/src/audio/google_rtc_audio_processing.c
@@ -401,7 +401,7 @@ static int google_rtc_audio_processing_copy(struct comp_dev *dev)
 		cd->raw_mic_buffer[cd->raw_mic_buffer_index] = *src;
 		++cd->raw_mic_buffer_index;
 
-		dst = audio_stream_read_frag_s16(&cd->output->stream, output_buff_frag);
+		dst = audio_stream_write_frag_s16(&cd->output->stream, output_buff_frag);
 		*dst = cd->output_buffer[cd->output_buffer_index];
 		++cd->output_buffer_index;
 


### PR DESCRIPTION
Due to a mistake, I was using the read API to get a pointer to the
place to write data. This commit corrects it.

Signed-off-by: Lionel Koenig <lionelk@google.com>