### PR TITLE
audio: crossover: fix the mistake of sink stream pointer

### DIFF
--- a/src/audio/crossover/crossover_generic.c
+++ b/src/audio/crossover/crossover_generic.c
@@ -103,7 +103,7 @@ static void crossover_s16_default_pass(const struct comp_dev *dev,
 		for (j = 0; j < num_sinks; j++) {
 			if (!sinks[j])
 				continue;
-			y = audio_stream_read_frag_s16((&sinks[j]->stream), i);
+			y = audio_stream_write_frag_s16((&sinks[j]->stream), i);
 			*y = *x;
 		}
 	}
@@ -127,7 +127,7 @@ static void crossover_s32_default_pass(const struct comp_dev *dev,
 		for (j = 0; j < num_sinks; j++) {
 			if (!sinks[j])
 				continue;
-			y = audio_stream_read_frag_s32((&sinks[j]->stream), i);
+			y = audio_stream_write_frag_s32((&sinks[j]->stream), i);
 			*y = *x;
 		}
 	}
@@ -162,8 +162,8 @@ static void crossover_s16_default(const struct comp_dev *dev,
 				if (!sinks[j])
 					continue;
 				sink_stream = &sinks[j]->stream;
-				y = audio_stream_read_frag_s16(sink_stream,
-							       idx);
+				y = audio_stream_write_frag_s16(sink_stream,
+								idx);
 				*y = sat_int16(Q_SHIFT_RND(out[j], 31, 15));
 			}
 
@@ -201,8 +201,8 @@ static void crossover_s24_default(const struct comp_dev *dev,
 				if (!sinks[j])
 					continue;
 				sink_stream = &sinks[j]->stream;
-				y = audio_stream_read_frag_s32(sink_stream,
-							       idx);
+				y = audio_stream_write_frag_s32(sink_stream,
+								idx);
 				*y = sat_int24(Q_SHIFT_RND(out[j], 31, 23));
 			}
 
@@ -240,8 +240,8 @@ static void crossover_s32_default(const struct comp_dev *dev,
 				if (!sinks[j])
 					continue;
 				sink_stream = &sinks[j]->stream;
-				y = audio_stream_read_frag_s32(sink_stream,
-							       idx);
+				y = audio_stream_write_frag_s32(sink_stream,
+								idx);
 				*y = out[j];
 			}
 


### PR DESCRIPTION
to fix the mistake of using audio_stream_read_frag* while
getting output sink buffer pointer.

Signed-off-by: Andrula Song <xiaoyuan.song@intel.com>