### PR TITLE
audio: dcblock: fix mistakes of sink stream pointer

### DIFF
--- a/src/audio/dcblock/dcblock_generic.c
+++ b/src/audio/dcblock/dcblock_generic.c
@@ -53,7 +53,7 @@ static void dcblock_s16_default(const struct comp_dev *dev,
 		idx = ch;
 		for (i = 0; i < frames; i++) {
 			x = audio_stream_read_frag_s16(source, idx);
-			y = audio_stream_read_frag_s16(sink, idx);
+			y = audio_stream_write_frag_s16(sink, idx);
 			tmp = dcblock_generic(state, R, *x << 16);
 			*y = sat_int16(Q_SHIFT_RND(tmp, 31, 15));
 			idx += nch;
@@ -85,7 +85,7 @@ static void dcblock_s24_default(const struct comp_dev *dev,
 		idx = ch;
 		for (i = 0; i < frames; i++) {
 			x = audio_stream_read_frag_s32(source, idx);
-			y = audio_stream_read_frag_s32(sink, idx);
+			y = audio_stream_write_frag_s32(sink, idx);
 			tmp = dcblock_generic(state, R, *x << 8);
 			*y = sat_int24(Q_SHIFT_RND(tmp, 31, 23));
 			idx += nch;
@@ -116,7 +116,7 @@ static void dcblock_s32_default(const struct comp_dev *dev,
 		idx = ch;
 		for (i = 0; i < frames; i++) {
 			x = audio_stream_read_frag_s32(source, idx);
-			y = audio_stream_read_frag_s32(sink, idx);
+			y = audio_stream_write_frag_s32(sink, idx);
 			*y = dcblock_generic(state, R, *x);
 			idx += nch;
 		}


### PR DESCRIPTION
to fix the mistakes of using audio_stream_read_frag*
while geeting output sink buffer pointer.

Signed-off-by: Andrula Song <xiaoyuan.song@intel.com>