### PR TITLE
Support for dynamic codec adapter id - Part 1

### DIFF
--- a/src/audio/codec_adapter/codec/cadence.c
+++ b/src/audio/codec_adapter/codec/cadence.c
@@ -678,7 +678,7 @@ cadence_codec_set_configuration(struct processing_module *mod, uint32_t config_i
 
 	/* return if more fragments are expected or if the module is not prepared */
 	if ((pos != MODULE_CFG_FRAGMENT_LAST && pos != MODULE_CFG_FRAGMENT_SINGLE) ||
-	    md->state < MODULE_INITIALIZED)
+	    md->state < MODULE_IDLE)
 		return 0;
 
 	/* whole configuration received, apply it now */

--- a/src/audio/codec_adapter/codec/cadence.c
+++ b/src/audio/codec_adapter/codec/cadence.c
@@ -94,13 +94,59 @@ static struct cadence_api cadence_api_table[] = {
 #endif
 };
 
+static int cadence_codec_post_init(struct processing_module *mod)
+{
+	int ret;
+	struct comp_dev *dev = mod->dev;
+	struct module_data *codec = comp_get_module_data(dev);
+	struct cadence_codec_data *cd = codec->private;
+	uint32_t obj_size;
+
+	comp_dbg(dev, "cadence_codec_post_init() start");
+
+	/* Obtain codec name */
+	API_CALL(cd, XA_API_CMD_GET_LIB_ID_STRINGS,
+		 XA_CMD_TYPE_LIB_NAME, cd->name, ret);
+	if (ret != LIB_NO_ERROR) {
+		comp_err(dev, "cadence_codec_init() error %x: failed to get lib name",
+			 ret);
+		return ret;
+	}
+	/* Get codec object size */
+	API_CALL(cd, XA_API_CMD_GET_API_SIZE, 0, &obj_size, ret);
+	if (ret != LIB_NO_ERROR) {
+		comp_err(dev, "cadence_codec_init() error %x: failed to get lib object size",
+			 ret);
+		return ret;
+	}
+	/* Allocate space for codec object */
+	cd->self = rballoc(0, SOF_MEM_CAPS_RAM, obj_size);
+	if (!cd->self) {
+		comp_err(dev, "cadence_codec_init(): failed to allocate space for lib object");
+		return -ENOMEM;
+	}
+
+	comp_dbg(dev, "cadence_codec_post_init(): allocated %d bytes for lib object", obj_size);
+
+	/* Set all params to their default values */
+	API_CALL(cd, XA_API_CMD_INIT, XA_CMD_TYPE_INIT_API_PRE_CONFIG_PARAMS,
+		 NULL, ret);
+	if (ret != LIB_NO_ERROR) {
+		rfree(cd->self);
+		return ret;
+	}
+
+	comp_dbg(dev, "cadence_codec_post_init() done");
+
+	return 0;
+}
+
 static int cadence_codec_init(struct processing_module *mod)
 {
 	int ret;
 	struct comp_dev *dev = mod->dev;
 	struct module_data *codec = comp_get_module_data(dev);
 	struct cadence_codec_data *cd = NULL;
-	uint32_t obj_size;
 	uint32_t no_of_api = ARRAY_SIZE(cadence_api_table);
 	uint32_t api_id = CODEC_GET_API_ID(DEFAULT_CODEC_ID);
 	uint32_t i;
@@ -160,38 +206,9 @@ static int cadence_codec_init(struct processing_module *mod)
 		setup_cfg->avail = true;
 	}
 
-	/* Obtain codec name */
-	API_CALL(cd, XA_API_CMD_GET_LIB_ID_STRINGS,
-		 XA_CMD_TYPE_LIB_NAME, cd->name, ret);
-	if (ret != LIB_NO_ERROR) {
-		comp_err(dev, "cadence_codec_init() error %x: failed to get lib name",
-			 ret);
-		goto free;
-	}
-	/* Get codec object size */
-	API_CALL(cd, XA_API_CMD_GET_API_SIZE, 0, &obj_size, ret);
-	if (ret != LIB_NO_ERROR) {
-		comp_err(dev, "cadence_codec_init() error %x: failed to get lib object size",
-			 ret);
-		goto free;
-	}
-	/* Allocate space for codec object */
-	cd->self = rballoc(0, SOF_MEM_CAPS_RAM, obj_size);
-	if (!cd->self) {
-		comp_err(dev, "cadence_codec_init(): failed to allocate space for lib object");
-		ret = -ENOMEM;
-		goto free;
-	}
-
-	comp_dbg(dev, "cadence_codec_init(): allocated %d bytes for lib object", obj_size);
-
-	/* Set all params to their default values */
-	API_CALL(cd, XA_API_CMD_INIT, XA_CMD_TYPE_INIT_API_PRE_CONFIG_PARAMS,
-		 NULL, ret);
-	if (ret != LIB_NO_ERROR) {
-		rfree(cd->self);
-		goto free;
-	}
+	ret = cadence_codec_post_init(mod);
+	if (ret)
+		return ret;
 
 	comp_dbg(dev, "cadence_codec_init() done");
 

--- a/src/audio/codec_adapter/codec/cadence.c
+++ b/src/audio/codec_adapter/codec/cadence.c
@@ -128,9 +128,14 @@ static int cadence_codec_post_init(struct processing_module *mod)
 	struct comp_dev *dev = mod->dev;
 	struct module_data *codec = comp_get_module_data(dev);
 	struct cadence_codec_data *cd = codec->private;
+	uint32_t api_id = CODEC_GET_API_ID(DEFAULT_CODEC_ID);
 	uint32_t obj_size;
 
 	comp_dbg(dev, "cadence_codec_post_init() start");
+
+	ret = cadence_codec_resolve_api(mod, api_id);
+	if (ret < 0)
+		return ret;
 
 	/* Obtain codec name */
 	API_CALL(cd, XA_API_CMD_GET_LIB_ID_STRINGS,
@@ -175,7 +180,6 @@ static int cadence_codec_init(struct processing_module *mod)
 	struct comp_dev *dev = mod->dev;
 	struct module_data *codec = comp_get_module_data(dev);
 	struct cadence_codec_data *cd = NULL;
-	uint32_t api_id = CODEC_GET_API_ID(DEFAULT_CODEC_ID);
 
 	comp_dbg(dev, "cadence_codec_init() start");
 
@@ -191,10 +195,6 @@ static int cadence_codec_init(struct processing_module *mod)
 	cd->mem_tabs = NULL;
 	cd->api = NULL;
 	cd->setup_cfg.avail = false;
-
-	ret = cadence_codec_resolve_api(mod, api_id);
-	if (ret < 0)
-		return ret;
 
 	/* copy the setup config only for the first init */
 	if (codec->state == MODULE_DISABLED && codec->cfg.avail) {


### PR DESCRIPTION
This patch series only move around in order to prepare for sending the codec_adapter ID at runtime from Linux kernel side.

We move all Cadence API calls from init() to prepare() because codec_id will not be available at init(). Earliest case where we could get the codec_id from Linux kernel is at set_params(). the call to prepare() is done later so at the point the codec_id will be know.

