### PR TITLE
Support for dynamic codec adapter id - Part 2

### DIFF
--- a/src/audio/codec_adapter/codec/cadence.c
+++ b/src/audio/codec_adapter/codec/cadence.c
@@ -537,8 +537,8 @@ cadence_codec_process(struct processing_module *mod,
 	struct module_data *codec = comp_get_module_data(dev);
 	struct cadence_codec_data *cd = codec->private;
 	int output_bytes = cadence_codec_get_samples(dev) *
-				mod->stream_params.sample_container_bytes *
-				mod->stream_params.channels;
+				mod->stream_params->sample_container_bytes *
+				mod->stream_params->channels;
 	uint32_t remaining = input_buffers[0].size;
 	int ret;
 

--- a/src/audio/codec_adapter/codec_adapter.c
+++ b/src/audio/codec_adapter/codec_adapter.c
@@ -311,7 +311,7 @@ int codec_adapter_params(struct comp_dev *dev,
 		rfree(mod->stream_params);
 
 	mod->stream_params = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM,
-				     sizeof(*mod->stream_params));
+				     sizeof(*mod->stream_params) + params->ext_data_length);
 	if (!mod->stream_params)
 		return -ENOMEM;
 
@@ -319,6 +319,15 @@ int codec_adapter_params(struct comp_dev *dev,
 		       params, sizeof(struct sof_ipc_stream_params));
 	if (ret < 0)
 		return ret;
+
+	if (params->ext_data_length) {
+		ret = memcpy_s((uint8_t *)mod->stream_params->data,
+			       params->ext_data_length,
+			       (uint8_t *)params->data,
+			       params->ext_data_length);
+		if (ret < 0)
+			return ret;
+	}
 
 	mod->period_bytes = params->sample_container_bytes *
 			   params->channels * params->rate / 1000;

--- a/src/audio/codec_adapter/codec_adapter.c
+++ b/src/audio/codec_adapter/codec_adapter.c
@@ -308,7 +308,8 @@ int codec_adapter_params(struct comp_dev *dev,
 
 	ret = memcpy_s(&mod->stream_params, sizeof(struct sof_ipc_stream_params),
 		       params, sizeof(struct sof_ipc_stream_params));
-	assert(!ret);
+	if (ret < 0)
+		return ret;
 
 	mod->period_bytes = params->sample_container_bytes *
 			   params->channels * params->rate / 1000;

--- a/src/include/ipc/stream.h
+++ b/src/include/ipc/stream.h
@@ -95,9 +95,12 @@ struct sof_ipc_stream_params {
 	uint32_t host_period_bytes;
 	uint16_t no_stream_position; /**< 1 means don't send stream position */
 	uint8_t cont_update_posn; /**< 1 means continuous update stream position */
+	uint8_t reserved0;
+	uint16_t ext_data_length; /**< 0 means no extended data */
 
-	uint8_t reserved[5];
+	uint8_t reserved[2];
 	uint16_t chmap[SOF_IPC_MAX_CHANNELS];	/**< channel map - SOF_CHMAP_ */
+	int8_t data[]; /**< extended data */
 } __attribute__((packed, aligned(4)));
 
 /* PCM params info - SOF_IPC_STREAM_PCM_PARAMS */

--- a/src/include/kernel/abi.h
+++ b/src/include/kernel/abi.h
@@ -29,7 +29,7 @@
 
 /** \brief SOF ABI version major, minor and patch numbers */
 #define SOF_ABI_MAJOR 3
-#define SOF_ABI_MINOR 21
+#define SOF_ABI_MINOR 22
 #define SOF_ABI_PATCH 0
 
 /** \brief SOF ABI version number. Format within 32bit word is MMmmmppp */

--- a/src/include/sof/audio/codec_adapter/codec/generic.h
+++ b/src/include/sof/audio/codec_adapter/codec/generic.h
@@ -275,7 +275,7 @@ struct module_data {
 /* codec_adapter private, runtime data */
 struct processing_module {
 	struct module_data priv; /**< module private data */
-	struct sof_ipc_stream_params stream_params;
+	struct sof_ipc_stream_params *stream_params;
 	struct list_item sink_buffer_list; /* list of sink buffers to save produced output */
 
 	/*

--- a/src/ipc/ipc3/handler.c
+++ b/src/ipc/ipc3/handler.c
@@ -219,8 +219,26 @@ static int ipc_stream_pcm_params(uint32_t stream)
 		return -EINVAL;
 	}
 
-	if (IPC_IS_SIZE_INVALID(pcm_params.params)) {
-		IPC_SIZE_ERROR_TRACE(&ipc_tr, pcm_params.params);
+	/* sanity check for pcm_params size */
+	if (pcm_params.hdr.size !=
+	    sizeof(pcm_params) + pcm_params.params.ext_data_length) {
+		tr_err(&ipc_tr, "pcm_params invalid size, hdr.size=%d, ext_data_len=%d",
+		       pcm_params.hdr.size, pcm_params.params.ext_data_length);
+		return -EINVAL;
+	}
+
+	/* sanity check for pcm_params.params size */
+	if (pcm_params.params.hdr.size !=
+	    sizeof(pcm_params.params) + pcm_params.params.ext_data_length) {
+		tr_err(&ipc_tr, "pcm_params.params invalid size, hdr.size=%d, ext_data_len=%d",
+		       pcm_params.params.hdr.size, pcm_params.params.ext_data_length);
+		return -EINVAL;
+	}
+
+	if (sizeof(pcm_params) + pcm_params.params.ext_data_length > SOF_IPC_MSG_MAX_SIZE) {
+		tr_err(&ipc_tr, "pcm_params ext_data_length invalid size %d max allowed %d",
+		       pcm_params.params.ext_data_length,
+		       SOF_IPC_MSG_MAX_SIZE - sizeof(pcm_params));
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
This is a follow up of: https://github.com/thesofproject/sof/pull/5591

In this PR we expand `sof_ipc_stream_params` with the capability of holding extra data appended at the end. We take 2 bytes from `sof_ipc_stream_params` reserved bytes and use it to keep hold of the extended data.

Most of the patches are for this. Also bump ABI minor. 

This will also require a kernel PR which will posted soon.