### PR TITLE
ipc4: base_fw: Fix firmware version type in basefw_config IPC

### DIFF
--- a/src/audio/base_fw.c
+++ b/src/audio/base_fw.c
@@ -37,7 +37,7 @@ static inline struct ipc4_tuple *next_tuple(struct ipc4_tuple *tuple)
 
 static int basefw_config(uint32_t *data_offset, char *data)
 {
-	uint32_t version[4] = {SOF_MAJOR, SOF_MINOR, SOF_MICRO, SOF_BUILD};
+	uint16_t version[4] = {SOF_MAJOR, SOF_MINOR, SOF_MICRO, SOF_BUILD};
 	struct ipc4_tuple *tuple = (struct ipc4_tuple *)data;
 	struct ipc4_scheduler_config sche_cfg;
 


### PR DESCRIPTION
The firmware version numbers should use u16 type, not u32.

Signed-off-by: Peter Ujfalusi <peter.ujfalusi@linux.intel.com>