### PR TITLE
ipc4: base_fw: Simplify firmware version type in basefw_get_dsp_prope…

### DIFF
--- a/src/audio/base_fw.c
+++ b/src/audio/base_fw.c
@@ -226,7 +226,7 @@ static int basefw_get_dsp_properties(uint32_t *data_offset, char *data)
 	uint16_t fw_version[4] = {SOF_MAJOR, SOF_MINOR, SOF_MICRO, SOF_BUILD};
 	uint32_t value;
 
-	set_tuple(tuple, IPC4_FW_VERSION, sizeof(uint16_t) * 4, &fw_version);
+	set_tuple(tuple, IPC4_FW_VERSION, sizeof(fw_version), fw_version);
 
 	tuple = next_tuple(tuple);
 	set_tuple_uint32(tuple, IPC4_DSP_CORES, CONFIG_CORE_COUNT);


### PR DESCRIPTION
…rties

Use the sizeof on the fw_version array to remove the magic number for the
size calculation and drop the address modifier for the data pointer.

Signed-off-by: Peter Ujfalusi <peter.ujfalusi@linux.intel.com>