### PR TITLE
ipc4: skip component in the incomplete pipeline

### DIFF
--- a/src/audio/pipeline/pipeline-graph.c
+++ b/src/audio/pipeline/pipeline-graph.c
@@ -431,6 +431,11 @@ struct comp_dev *pipeline_get_dai_comp(uint32_t pipeline_id, uint32_t *latency)
 		buffer = buffer_from_list(comp_buffer_list(sink->cd, PPL_DIR_DOWNSTREAM)->next,
 					  struct comp_buffer, PPL_DIR_DOWNSTREAM);
 		buff_comp = buffer_get_comp(buffer, PPL_DIR_DOWNSTREAM);
+
+		/* buffer_comp is in another incomplete pipeline */
+		if (!buff_comp->pipeline)
+			return NULL;
+
 		sink = ipc_get_ppl_sink_comp(ipc, buff_comp->pipeline->pipeline_id);
 
 		if (!sink)


### PR DESCRIPTION
Fix a error found by ipc4 Linux driver. Component
pipeline may be incomplete, so the pipeline is not
updated to the component. Skip this pipeline and
return dai of null.

fix: https://github.com/thesofproject/sof/issues/5281