### PR TITLE
ipc4: free buffer when pipeline is free

### DIFF
--- a/src/audio/copier.c
+++ b/src/audio/copier.c
@@ -429,7 +429,7 @@ static void copier_free(struct comp_dev *dev)
 		cd->endpoint->drv->ops.free(cd->endpoint);
 
 	if (cd->endpoint_buffer)
-		buffer_release(cd->endpoint_buffer);
+		buffer_free(cd->endpoint_buffer);
 
 	rfree(cd);
 	rfree(dev);

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -160,6 +160,20 @@ static int ipc_pipeline_module_free(uint32_t pipeline_id)
 
 	icd = ipc_get_comp_by_ppl_id(ipc, COMP_TYPE_COMPONENT, pipeline_id);
 	while (icd) {
+		struct comp_buffer *sink;
+		struct list_item *sink_list;
+		struct list_item *tmp_list;
+
+		/* free sink buffer allocated by current component in bind function */
+		list_for_item_safe(sink_list, tmp_list, &icd->cd->bsink_list) {
+			sink = container_of(sink_list, struct comp_buffer, source_list);
+
+			pipeline_disconnect(icd->cd, sink, PPL_DIR_DOWNSTREAM);
+			pipeline_disconnect(icd->cd, sink, PPL_DIR_UPSTREAM);
+
+			buffer_free(sink);
+		}
+
 		ret = ipc_comp_free(ipc, icd->id);
 		if (ret)
 			return ret;


### PR DESCRIPTION
When two modules in different pipeline are unbind, the buffer used
    by them is free. The buffer is not free if they are in the same
    pipeline. So we need to free buffer when pipeline is free
