### PR TITLE
ipc4: handler: Fix compilation with gcc in ipc4_set_pipeline_state()

### DIFF
--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -434,9 +434,9 @@ static int ipc4_set_pipeline_state(union ipc4_message_header *ipc4)
 {
 	struct ipc4_pipeline_set_state_data *ppl_data;
 	struct ipc4_pipeline_set_state state;
+	uint32_t status = COMP_STATE_INIT;
 	uint32_t cmd, ppl_count;
 	uint32_t *ppl_id, id;
-	uint32_t status;
 	int ret = 0;
 	int i;
 


### PR DESCRIPTION
gcc fails with the following warning (treated as error):
sof/src/ipc/ipc4/handler.c: In function 'ipc_cmd':
sof/src/ipc/ipc4/handler.c:471:5: error: 'status' may be used uninitialized in this function [-Werror=maybe-uninitialized]
  471 |  if (status == COMP_STATE_READY)
      |     ^
sof/src/ipc/ipc4/handler.c:439:11: note: 'status' was declared here
  439 |  uint32_t status;
      |           ^~~~~~
cc1: all warnings being treated as errors
make[2]: *** [CMakeFiles/sof.dir/build.make:380: CMakeFiles/sof.dir/src/ipc/ipc4/handler.c.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:2042: CMakeFiles/sof.dir/all] Error 2
make: *** [Makefile:136: all] Error 2

Based on the code, this is a false warning since ppl_count should never be
0 (unless ppl_data->pipelines_count is 0), but never the less, the firmware
does not compile with gcc.

Fixes: 72394a62def31 ("ipc4: update component direction when pipeline is complete")
Signed-off-by: Peter Ujfalusi <peter.ujfalusi@linux.intel.com>