### PR TITLE
topology1: move capture dai to another pipeline for echo ref

### DIFF
--- a/tools/topology/topology1/sof-adl-nau8825.m4
+++ b/tools/topology/topology1/sof-adl-nau8825.m4
@@ -272,8 +272,13 @@ DAI_ADD(sof/pipe-dai-playback.m4,
         1, SSP, SPK_SSP_INDEX, SPK_SSP_NAME,
         PIPELINE_SOURCE_1, 2, s16le,
         1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
-# currently this dai is here as "virtual" capture backend
-W_DAI_IN(SSP, SPK_SSP_INDEX, SPK_SSP_NAME, s16le, 3, 0)
+
+# The echo refenrence pipeline has no connections in it,
+# it is used for the capture DAI widget to dock.
+DAI_ADD(sof/pipe-echo-ref-dai-capture.m4,
+	29, SSP, SPK_SSP_INDEX, SPK_SSP_NAME,
+	PIPELINE_SINK_29, 3, s16le,
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # Capture pipeline 9 from demux on PCM 6 using max 2 channels of s32le.
 PIPELINE_PCM_ADD(sof/pipe-passthrough-capture-sched.m4,

--- a/tools/topology/topology1/sof-apl-demux-pcm512x.m4
+++ b/tools/topology/topology1/sof-apl-demux-pcm512x.m4
@@ -113,8 +113,12 @@ DAI_ADD(sof/pipe-dai-playback.m4,
 	PIPELINE_SOURCE_1, 2, s24le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# currently this dai is here as "virtual" capture backend
-W_DAI_IN(SSP, 5, SSP5-Codec, s24le, 3, 0)
+# The echo refenrence pipeline has no connections in it,
+# it is used for the capture DAI widget to dock.
+DAI_ADD(sof/pipe-echo-ref-dai-capture.m4,
+	29, SSP, 5, SSP5-Codec,
+	PIPELINE_SINK_29, 3, s24le,
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # Capture pipeline 5 from demux on PCM 5 using max 2 channels of s32le.
 PIPELINE_PCM_ADD(sof/pipe-passthrough-capture-sched.m4,

--- a/tools/topology/topology1/sof-tgl-max98357a-rt5682.m4
+++ b/tools/topology/topology1/sof-tgl-max98357a-rt5682.m4
@@ -271,8 +271,13 @@ DAI_ADD(sof/pipe-dai-capture.m4,
 ',
 `
 ifdef(`2CH_2WAY',`# No echo reference for 2-way speakers',
-`# currently this dai is here as "virtual" capture backend
-W_DAI_IN(SSP, SPK_SSP_INDEX, SPK_SSP_NAME, FMT, 3, 0)
+`
+# The echo refenrence pipeline has no connections in it,
+# it is used for the capture DAI widget to dock.
+DAI_ADD(sof/pipe-echo-ref-dai-capture.m4,
+	29, SSP, SPK_SSP_INDEX, SPK_SSP_NAME,
+	PIPELINE_SINK_29, 3, FMT,
+	SPK_MIC_PERIOD_US, 0, SPK_PLAYBACK_CORE, SCHEDULE_TIME_DOMAIN_TIMER)
 
 `# Capture pipeline 9 from demux on PCM 6 using max 'ifdef(`4CH_PASSTHROUGH', `4', `2')` channels of s32le.'
 PIPELINE_PCM_ADD(sof/pipe-passthrough-capture-sched.m4,

--- a/tools/topology/topology1/sof/pipe-echo-ref-dai-capture.m4
+++ b/tools/topology/topology1/sof/pipe-echo-ref-dai-capture.m4
@@ -1,0 +1,23 @@
+#
+# The pipeline for echo reference feature, it is used
+# for the capture DAI to dock.
+#
+# No connections in this pipeline.
+#
+
+# Include topology builder
+include(`utils.m4')
+include(`dai.m4')
+include(`pipeline.m4')
+
+#
+# DAI definitions
+#
+W_DAI_IN(DAI_TYPE, DAI_INDEX, DAI_BE, DAI_FORMAT, DAI_PERIODS, 0, SCHEDULE_CORE)
+
+#
+# DAI pipeline - always use 0 for DAIs
+#
+W_PIPELINE(N_DAI_IN, SCHEDULE_PERIOD, SCHEDULE_PRIORITY, SCHEDULE_CORE, SCHEDULE_TIME_DOMAIN, pipe_dai_schedule_plat)
+
+indir(`define', concat(`PIPELINE_SCHED_COMP_', PIPELINE_ID), N_DAI_IN)


### PR DESCRIPTION
The explanation takes sof-adl-max98357a-rt5682 as an example:

During pipeline_complete(), we search for the source widget
for a pipeline from a list and the ipc_get_ppl_comp() returns
the first widget from the list of source widgets for a pipeline.

With SSP2.IN on pipeline 1, which is the same pipeline ID as the
ECHO_REF playback pipeline for PCM0P, pipeline_complete() for
pipeline 1 ends up not walking the rest of widgets in pipeline 1.

This Echo Ref feature works in chrome kernel today by accident,
because we set up the widgets in the reverse order after resuming
from runtime suspend and the source widget happens to be PCM0P.

To fix this, create a new pipeline for the capture dai widget SSP2.IN,
so that it doesn't pollute the widget list for pipeline 1.

Fixes: #5395

Signed-off-by: Chao Song <chao.song@linux.intel.com>