### PR TITLE
rtnr: Decouple switch-enable control from params blob

### DIFF
--- a/src/include/sof/audio/rtnr/rtnr.h
+++ b/src/include/sof/audio/rtnr/rtnr.h
@@ -22,6 +22,8 @@ typedef void (*rtnr_func)(struct comp_dev *dev,
 						  struct audio_stream *sink,
 						  int frames);
 
+typedef int (*rtnr_copy_func)(struct comp_dev *dev);
+
 /* RTNR component private data */
 struct comp_data {
 	struct comp_data_blob_handler *model_handler;
@@ -38,6 +40,7 @@ struct comp_data {
 	int ref_shift;
 	bool ref_32bits;
 	bool ref_active;
+	rtnr_copy_func rtnr_copy_func; /** Processing or passthrough */
 	rtnr_func rtnr_func; /** Processing function */
 	void *rtk_agl;
 };

--- a/tools/topology/topology1/m4/rtnr.m4
+++ b/tools/topology/topology1/m4/rtnr.m4
@@ -60,6 +60,9 @@ define(`W_RTNR',
 `	bytes ['
 		$6
 `	]'
+`	mixer ['
+		$7
+`	]'
 `}')
 
 divert(0)dnl

--- a/tools/topology/topology1/sof/pipe-rtnr-capture.m4
+++ b/tools/topology/topology1/sof/pipe-rtnr-capture.m4
@@ -13,6 +13,7 @@ include(`buffer.m4')
 include(`pcm.m4')
 include(`dai.m4')
 include(`pipeline.m4')
+include(`mixercontrol.m4')
 include(`bytecontrol.m4')
 include(`rtnr.m4')
 
@@ -45,6 +46,19 @@ C_CONTROLBYTES(DEF_RTNR_BYTES, PIPELINE_ID,
 	,
 	DEF_RTNR_PRIV)
 
+# RTNR Enable switch
+define(DEF_RTNR_ENABLE, concat(`rtnr_enable_', PIPELINE_ID))
+define(`CONTROL_NAME', `DEF_RTNR_ENABLE')
+
+C_CONTROLMIXER(DEF_RTNR_ENABLE, PIPELINE_ID,
+	CONTROLMIXER_OPS(volsw, 259 binds the mixer control to switch get/put handlers, 259, 259),
+	CONTROLMIXER_MAX(max 1 indicates switch type control, 1),
+	false,
+	,
+	Channel register and shift for Front Center,
+	LIST(`	', KCONTROL_CHANNEL(FC, 3, 0)),
+	"1")
+undefine(`CONTROL_NAME')
 
 #
 # Components and Buffers
@@ -55,7 +69,9 @@ C_CONTROLBYTES(DEF_RTNR_BYTES, PIPELINE_ID,
 W_PCM_CAPTURE(PCM_ID, Capture, 0, 2, SCHEDULE_CORE)
 
 # "RTNR 0" has 2 sink period and 2 source periods
-W_RTNR(0, PIPELINE_FORMAT, 2, DAI_PERIODS, SCHEDULE_CORE, LIST(`		', "DEF_RTNR_BYTES"))
+W_RTNR(0, PIPELINE_FORMAT, 2, DAI_PERIODS, SCHEDULE_CORE,
+	LIST(`		', "DEF_RTNR_BYTES"),
+	LIST(`          ', "DEF_RTNR_ENABLE"))
 
 # Capture Buffers
 W_BUFFER(0, COMP_BUFFER_SIZE(4,
@@ -86,5 +102,6 @@ PCM_CAPABILITIES(Capture PCM_ID, CAPABILITY_FORMAT_NAME(PIPELINE_FORMAT),
 	PCM_MIN_RATE, PCM_MAX_RATE, PIPELINE_CHANNELS, PIPELINE_CHANNELS,
 	2, 16, 192, 16384, RTNR_BUFFER_SIZE_MIN, RTNR_BUFFER_SIZE_MAX)
 
+undefine(`DEF_RTNR_ENABLE')
 undefine(`DEF_RTNR_PRIV')
 undefine(`DEF_RTNR_BYTES')


### PR DESCRIPTION
The ideal implementation for the feature component control is to have:
 - A switch-typed control for enabling/disabling the feature processing
 - A byte-typed control for the feature parameters

Typically the feature parameters should be set only once on DSP init. Updating
new parameters is supported but we should minimize such occurences. A decoupled
switch control provides the perfect solution to enable/disable the feature
without touching params, which is also less cost and error-prone.

Moreover, due to the security request there should be a bypass path under the
switch control, which routes around the feature library for audio samples as
the passthrough.

Hi Realtek folks,
Please help to verify this patch (I only verified the functionality of the switch control).
The example to set the switch value by UCM config:
```
cset "name='RTNR10.0 rtnr_enable_10' off"
cset "name='RTNR10.0 rtnr_enable_10' on"
```
You can also set/get via amixer for testing purposes:
```
amixer -c0 cset name='RTNR10.0 rtnr_enable_10' 1
amixer -c0 cget name='RTNR10.0 rtnr_enable_10'
``` 