### PR TITLE
IPC command timeout in record test

### DIFF
--- a/src/drivers/intel/cavs/dmic.c
+++ b/src/drivers/intel/cavs/dmic.c
@@ -1417,6 +1417,7 @@ static void dmic_stop(struct dai *dai)
 
 	dmic_active_fifos--;
 
+	schedule_task_cancel(&dmic->dmicwork);
 out:
 	spin_unlock(dai->lock);
 }

--- a/src/drivers/intel/cavs/dmic.c
+++ b/src/drivers/intel/cavs/dmic.c
@@ -175,9 +175,16 @@ static enum task_state dmic_work(void *data)
 	int32_t gval;
 	uint32_t val;
 	int i;
+	int ret;
 
 	tracev_dmic("dmic_work()");
-	spin_lock(dai->lock);
+
+	spin_try_lock(dai->lock, ret);
+	if (!ret) {
+		tracev_dmic("dmic_work(): spin_try_lock(dai->lock, ret)"
+			    "failed: RESCHEDULE");
+		return SOF_TASK_STATE_RESCHEDULE;
+	}
 
 	/* Increment gain with logarithmic step.
 	 * Gain is Q2.30 and gain modifier is Q12.20.

--- a/src/include/sof/spinlock.h
+++ b/src/include/sof/spinlock.h
@@ -189,10 +189,10 @@ extern uint32_t lock_dbg_user[DBG_LOCK_USERS];
 		arch_spin_lock(lock); \
 	} while (0)
 
-#define spin_try_lock(lock) \
+#define spin_try_lock(lock, ret) \
 	do { \
 		spin_lock_dbg(); \
-		arch_try_lock(lock); \
+		ret = arch_try_lock(lock); \
 	} while (0)
 
 #define spin_unlock(lock) \


### PR DESCRIPTION
Backport the fix from main branch:

https://github.com/thesofproject/sof/pull/2078

The target CML device passes record test which has 2000 loops.
