### PR TITLE
drivers: amd: renoir: use sample rate from topology

### DIFF
--- a/src/drivers/amd/renoir/acp_dmic_dai.c
+++ b/src/drivers/amd/renoir/acp_dmic_dai.c
@@ -28,7 +28,29 @@ DECLARE_TR_CTX(acp_dmic_dai_tr, SOF_UUID(acp_dmic_dai_uuid), LOG_LEVEL_INFO);
 static inline int acp_dmic_dai_set_config(struct dai *dai, struct ipc_config_dai *common_config,
 					  void *spec_config)
 {
-	/* nothing to do on dmic dai */
+	dai_info(dai, "ACP: acp_dmic_set_config");
+	struct sof_ipc_dai_config *config = spec_config;
+	struct acp_pdata *acpdata = dai_get_drvdata(dai);
+	acp_wov_clk_ctrl_t clk_ctrl;
+
+	acpdata->config = *config;
+	acpdata->dmic_params = config->acpdmic;
+	clk_ctrl = (acp_wov_clk_ctrl_t)io_reg_read(PU_REGISTER_BASE + ACP_WOV_PDM_DMA_ENABLE);
+	clk_ctrl.u32all = 0;
+	switch (acpdata->dmic_params.pdm_rate) {
+	case 48000:
+		/* DMIC Clock for 48K sample rate */
+		clk_ctrl.bits.brm_clk_ctrl = 7;
+		break;
+	case 16000:
+		/* DMIC Clock for 16K sample rate */
+		clk_ctrl.bits.brm_clk_ctrl = 1;
+		break;
+	default:
+		dai_info(dai, "ACP:acp_dmic_set_config unsupported samplerate");
+		return -EINVAL;
+	}
+	io_reg_write(PU_REGISTER_BASE + ACP_WOV_CLK_CTRL, clk_ctrl.u32all);
 	return 0;
 }
 
@@ -46,7 +68,26 @@ static int acp_dmic_dai_trigger(struct dai *dai, int cmd, int direction)
 
 static int acp_dmic_dai_probe(struct dai *dai)
 {
-	/* TODO */
+	struct acp_pdata *acp;
+
+	dai_info(dai, "ACP: acp_dmic_dai_probe");
+	/* allocate private data */
+	acp = rzalloc(SOF_MEM_ZONE_RUNTIME_SHARED, 0, SOF_MEM_CAPS_RAM, sizeof(*acp));
+	if (!acp) {
+		dai_err(dai, "acp_dmic_dai_probe(): alloc failed");
+		return -ENOMEM;
+	}
+	dai_set_drvdata(dai, acp);
+	return 0;
+}
+
+static int acp_dmic_dai_remove(struct dai *dai)
+{
+	struct acp_pdata *acp = dai_get_drvdata(dai);
+
+	dai_info(dai, "acp_dmic_dai_remove()");
+	rfree(acp);
+	dai_set_drvdata(dai, NULL);
 	return 0;
 }
 
@@ -72,8 +113,17 @@ static int acp_dmic_dai_get_hw_params(struct dai *dai,
 			      struct sof_ipc_stream_params *params,
 			      int dir)
 {
-	/* ACP only currently supports these parameters */
-	params->rate = ACP_DEFAULT_SAMPLE_RATE;
+	struct acp_pdata *acpdata = dai_get_drvdata(dai);
+
+	switch (acpdata->dmic_params.pdm_rate) {
+	case 48000:
+	case 16000:
+		params->rate = acpdata->dmic_params.pdm_rate;
+		break;
+	default:
+		dai_info(dai, "ACP:unsupported samplerate %d", acpdata->dmic_params.pdm_rate);
+		params->rate = ACP_DEFAULT_SAMPLE_RATE;
+	}
 	params->channels = ACP_DEFAULT_NUM_CHANNELS;
 	params->buffer_fmt = SOF_IPC_BUFFER_INTERLEAVED;
 	params->frame_fmt = SOF_IPC_FRAME_S32_LE;
@@ -90,6 +140,7 @@ const struct dai_driver acp_dmic_dai_driver = {
 		.trigger		= acp_dmic_dai_trigger,
 		.set_config		= acp_dmic_dai_set_config,
 		.probe			= acp_dmic_dai_probe,
+		.remove			= acp_dmic_dai_remove,
 		.get_fifo		= acp_dmic_dai_get_fifo,
 		.get_handshake		= acp_dmic_dai_get_handshake,
 		.get_hw_params		= acp_dmic_dai_get_hw_params,

--- a/src/drivers/amd/renoir/acp_dmic_dma.c
+++ b/src/drivers/amd/renoir/acp_dmic_dma.c
@@ -80,7 +80,6 @@ static int acp_dmic_dma_start(struct dma_chan_data *channel)
 {
 	acp_wov_pdm_no_of_channels_t pdm_channels;
 	acp_wov_pdm_decimation_factor_t deci_fctr;
-	acp_wov_clk_ctrl_t clk_ctrl;
 	acp_wov_misc_ctrl_t wov_misc_ctrl;
 	acp_wov_pdm_dma_enable_t  pdm_dma_enable;
 	struct timer *timer = timer_get();
@@ -96,10 +95,6 @@ static int acp_dmic_dma_start(struct dma_chan_data *channel)
 		deci_fctr.u32all = 2;
 		io_reg_write(PU_REGISTER_BASE + ACP_WOV_PDM_DECIMATION_FACTOR,
 							deci_fctr.u32all);
-		/* DMIC Clock */
-		clk_ctrl.bits.brm_clk_ctrl = 7;
-		io_reg_write(PU_REGISTER_BASE + ACP_WOV_CLK_CTRL,
-						clk_ctrl.u32all);
 		/* PDM Control */
 		wov_misc_ctrl = (acp_wov_misc_ctrl_t)
 			io_reg_read(PU_REGISTER_BASE + ACP_WOV_MISC_CTRL);

--- a/src/include/ipc/dai-amd.h
+++ b/src/include/ipc/dai-amd.h
@@ -1,0 +1,27 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2022 AMD. All rights reserved.
+ *
+ * Author:	Basavaraj Hiregoudar <basavaraj.hiregoudar@amd.com>
+ *		Bala Kishore <balakishore.pati@amd.com>
+ */
+
+#ifndef __IPC_DAI_AMD_H__
+#define __IPC_DAI_AMD_H__
+
+#include <ipc/header.h>
+#include <stdint.h>
+
+/* DAI Configuration Request - SOF_IPC_DAI_ACP_DMIC_CONFIG */
+struct sof_ipc_dai_acpdmic_params {
+	uint32_t pdm_rate;
+	uint32_t pdm_ch;
+} __attribute__((packed, aligned(4)));
+
+/* ACP Configuration Request - SOF_IPC_DAI_AMD_CONFIG */
+struct sof_ipc_dai_acp_params {
+	uint32_t reserved0;
+	uint32_t fsync_rate;
+	uint32_t tdm_slots;
+} __attribute__((packed, aligned(4)));
+#endif /* __IPC_DAI_AMD_H__ */

--- a/src/include/ipc/dai.h
+++ b/src/include/ipc/dai.h
@@ -19,6 +19,7 @@
 #include <ipc/dai-intel.h>
 #include <ipc/dai-imx.h>
 #include <ipc/dai-mediatek.h>
+#include <ipc/dai-amd.h>
 #include <ipc/header.h>
 #include <stdint.h>
 
@@ -113,6 +114,9 @@ struct sof_ipc_dai_config {
 		struct sof_ipc_dai_alh_params alh;
 		struct sof_ipc_dai_esai_params esai;
 		struct sof_ipc_dai_sai_params sai;
+		struct sof_ipc_dai_acp_params acpbt;
+		struct sof_ipc_dai_acp_params acpsp;
+		struct sof_ipc_dai_acpdmic_params acpdmic;
 		struct sof_ipc_dai_afe_params afe;
 	};
 } __attribute__((packed, aligned(4)));

--- a/src/include/kernel/abi.h
+++ b/src/include/kernel/abi.h
@@ -29,7 +29,7 @@
 
 /** \brief SOF ABI version major, minor and patch numbers */
 #define SOF_ABI_MAJOR 3
-#define SOF_ABI_MINOR 21
+#define SOF_ABI_MINOR 22
 #define SOF_ABI_PATCH 0
 
 /** \brief SOF ABI version number. Format within 32bit word is MMmmmppp */

--- a/src/include/sof/drivers/acp_dai_dma.h
+++ b/src/include/sof/drivers/acp_dai_dma.h
@@ -9,6 +9,9 @@
 #ifndef __SOF_DRIVERS_ACPDMA_H__
 #define __SOF_DRIVERS_ACPDMA_H__
 
+#include <ipc/dai.h>
+#include <ipc/dai-amd.h>
+#include <sof/lib/dai.h>
 #include <sof/bit.h>
 #include <sof/trace/trace.h>
 #include <user/trace.h>
@@ -35,4 +38,11 @@ int acp_dma_init(struct sof *sof);
 extern const struct dai_driver acp_spdai_driver;
 extern const struct dai_driver acp_btdai_driver;
 extern const struct dai_driver acp_dmic_dai_driver;
+
+/* ACP private data */
+struct acp_pdata {
+	struct sof_ipc_dai_config config;
+	struct sof_ipc_dai_acpdmic_params dmic_params;
+	struct sof_ipc_dai_acp_params params;
+};
 #endif /* __SOF_DRIVERS_ACPDMA_H__ */


### PR DESCRIPTION
So far we only support 48000Hz as default sample rate.
Now introduce acp_params structure to pass configuration
from topology via AP to DSP.

Only Sample rate param for now to configure dmic clk.

While here, align sof_ipc_dai_acp_params struct
with the one from kernel.

Increment only ABI MINOR version which makes the
SOF FW backward compatible with older kernel versions

Signed-off-by: Balakishorepati <balaKishore.pati@amd.com>