### PR TITLE
notifier: Use coherent memory allocation

### DIFF
--- a/src/lib/notifier.c
+++ b/src/lib/notifier.c
@@ -191,7 +191,7 @@ void init_system_notify(struct sof *sof)
 {
 	struct notify **notify = arch_notify_get();
 	int i;
-	*notify = rzalloc(SOF_MEM_ZONE_SYS, 0, SOF_MEM_CAPS_RAM,
+	*notify = rzalloc(SOF_MEM_ZONE_SYS, SOF_MEM_FLAG_COHERENT, SOF_MEM_CAPS_RAM,
 			  sizeof(**notify));
 
 	k_spinlock_init(&(*notify)->lock);


### PR DESCRIPTION
The notifier struct contains a spin lock which was located in
incoherent memory. This caused an assert on startup when enabling the
build with CONFIG_ASSERT in Zephyr.

At the very least this fix enables building and running with
SPIN_VALIDATE and ASSERT which could help diagnosing issues such
as the panic_dump being garbled.

Signed-off-by: Tom Burdick <thomas.burdick@intel.com>