### PR TITLE
pipeline: do not reschedule pipe task if already in target state

### DIFF
--- a/src/audio/pipeline/pipeline-schedule.c
+++ b/src/audio/pipeline/pipeline-schedule.c
@@ -53,6 +53,8 @@ static enum task_state pipeline_task_cmd(struct pipeline *p,
 				SOF_TASK_STATE_COMPLETED;
 		case COMP_TRIGGER_PRE_START:
 		case COMP_TRIGGER_PRE_RELEASE:
+			if (p->status == COMP_STATE_ACTIVE)
+				return SOF_TASK_STATE_RUNNING;
 			p->status = COMP_STATE_ACTIVE;
 		}
 


### PR DESCRIPTION
When processing a trigger action in pipeline_task_cmd(), do
not return SOF_TASK_STATE_RESCHEDULE if the pipeline is already
in requested ACTIVE state.

The unnecessary reschedule can cause scheduling bubbles in
topologies with mixer fed by multiple source pipelines. When
the frontend pipelines are released from pause or started,
the connected pipelines that are already running, need to keep
running. A reschedule will cause a gap in scheduling in
of the downstream pipeline(s) mixer feeds.

This fix is not sufficient on its own, but is part of the fixes
to address: https://github.com/thesofproject/sof/issues/5469

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>