### PR TITLE
xtensa-build-zephyr.py: forbid shell=True

### DIFF
--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -200,11 +200,17 @@ sign must be used (https://bugs.python.org/issue9334)""",
 def execute_command(*run_args, **run_kwargs):
 	"""[summary] Provides wrapper for subprocess.run that prints
 	command executed when 'more verbose' verbosity level is set."""
+	command_args = run_args[0]
+
+	# If you really need the shell in some non-portable section then
+	# invoke subprocess.run() directly.
+	if run_kwargs.get('shell') or not isinstance(command_args, list):
+		raise RuntimeError("Do not rely on non-portable shell parsing")
+
 	if args.verbose >= 0:
 		cwd = run_kwargs.get('cwd')
-		command_args = run_args[0]
 		print_cwd = f"In dir: {cwd}" if cwd else f"in current dir: {os.getcwd()}"
-		print_args = shlex.join(command_args) if isinstance(command_args, list) else command_args
+		print_args = shlex.join(command_args)
 		print(f"{print_cwd}; running command: {print_args}", flush=True)
 
 	return subprocess.run(*run_args, **run_kwargs)


### PR DESCRIPTION
The entire purpose of replacing the older shell script with Python was
to achieve cross platform compatibility. shell=True would lose that.

See also
https://docs.python.org/3/library/subprocess.html#security-considerations

Signed-off-by: Marc Herbert <marc.herbert@intel.com>