### PR TITLE
topology2: abi: fix size of ABI bytes

### DIFF
--- a/tools/topology/topology2/CMakeLists.txt
+++ b/tools/topology/topology2/CMakeLists.txt
@@ -3,12 +3,6 @@ add_custom_target(topologies2
 	COMMAND ${CMAKE_COMMAND} -E copy_directory cavs ${SOF_TOPOLOGY_BINARY_DIRECTORY}
 )
 
-# generate ABI
-execute_process(
-	COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/get_abi.sh ${SOF_ROOT_SOURCE_DIRECTORY}
-	OUTPUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/abi.conf
-)
-
 # check alsatplg version and built topology2 if alsatplg version is 1.2.6 or greater
 # This will override any common topologies built with topology1
 execute_process(COMMAND alsatplg --version RESULT_VARIABLE STATUS OUTPUT_VARIABLE ALSA_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)

--- a/tools/topology/topology2/cavs/CMakeLists.txt
+++ b/tools/topology/topology2/cavs/CMakeLists.txt
@@ -30,6 +30,12 @@ PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt.bin"
 PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-cavs-tgl-nocodec.bin"
 )
 
+# generate ABI for IPC4
+execute_process(
+	COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../get_abi.sh ${SOF_ROOT_SOURCE_DIRECTORY} "ipc4"
+	OUTPUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/abi.conf
+)
+
 # This will override the topology1 binaries with topology2 binaries
 add_custom_target(topology2_cavs)
 add_dependencies(topologies2 topology2_cavs)
@@ -52,7 +58,7 @@ foreach(tplg ${TPLGS})
 	#
 	# BUG: move this from CMake configuration time to build time to
 	# fix incremental builds
-	configure_file(${CMAKE_CURRENT_BINARY_DIR}/../abi.conf ${CMAKE_CURRENT_BINARY_DIR}/${output}.conf)
+	configure_file(${CMAKE_CURRENT_BINARY_DIR}/abi.conf ${CMAKE_CURRENT_BINARY_DIR}/${output}.conf)
 	file(READ ${CMAKE_CURRENT_SOURCE_DIR}/${input}.conf CONTENTS)
 	file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/${output}.conf "${CONTENTS}")
 

--- a/tools/topology/topology2/get_abi.sh
+++ b/tools/topology/topology2/get_abi.sh
@@ -11,6 +11,29 @@ cat <<EOF_HEADER
 Object.Base.manifest."sof_manifest" {
 	Object.Base.data."SOF ABI" {
 EOF_HEADER
-printf '\t\tbytes\t"0x%02x,' "$ABI_MAJOR"
-printf "0x%02x," "$ABI_MINOR"
-printf '0x%02x\"\n\t}\n}' "$ABI_PATCH"
+
+print_1byte()
+{
+	printf '0x%02x' "$(("$1" & 0xff))"
+}
+
+print_2bytes()
+{
+	printf '0x%02x,0x%02x' "$(("$1" & 0xff))" "$((("$1" & 0xff00) >> 8))"
+}
+
+printf '\t\tbytes\t\"'
+for vers in $ABI_MAJOR $ABI_MINOR; do
+	case "$2" in
+		ipc3) print_1byte "$vers" ;;
+		ipc4) print_2bytes "$vers" ;;
+	esac
+	printf ','
+done
+
+case "$2" in
+	ipc3) print_1byte "$ABI_PATCH" ;;
+	ipc4) print_2bytes "$ABI_PATCH" ;;
+esac
+
+printf '\"\n\t}\n}'


### PR DESCRIPTION
The major/minor/patch values are represented with u16 in the FW. So,
adjust the numbers of bytes when adding the ABI to the topology
manifest. This only applies to IPC4. For IPC3, we still only use 3
bytes as there's no clean way to increase the number of bytes without
breaking backwards compatibility with the older kernel.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>