### PR TITLE
ipc4: handler: Perform platform context save before primary core shut…

### DIFF
--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -849,6 +849,9 @@ static int ipc4_module_process_dx(union ipc4_message_header *ipc4)
 			return IPC4_BUSY;
 		}
 
+		/* do platform specific suspending */
+		platform_context_save(sof_get());
+
 		ipc_get()->pm_prepare_D3 = 1;
 		/* TODO: prepare for D3 */
 	}


### PR DESCRIPTION
…down

Run the platform_context_save() before we shut down the primary core.
As an implementation detail: the context save implements the code to
prepare for IMR boot on platforms where it is supported.

Signed-off-by: Peter Ujfalusi <peter.ujfalusi@linux.intel.com>