### PR TITLE
Fix building stable-v2.0 topologies with latest ALSA

### DIFF
--- a/tools/test/topology/test-all.m4
+++ b/tools/test/topology/test-all.m4
@@ -86,7 +86,7 @@ PCM_DUPLEX_ADD(Passthrough, 0, PIPELINE_PCM_1, PIPELINE_PCM_2)
 # using TEST_SSP_PHY_BITS bit sample container on SSP TEST_DAI_PORT
 #
 DAI_CONFIG(TEST_DAI_TYPE, TEST_DAI_PORT,
-	   ifelse(index(TEST_DAI_LINK_NAME, NoCodec), -1, 0 ,TEST_DAI_PORT),
+	   ifelse(index(TEST_DAI_LINK_NAME, NoCodec), -1, 0, TEST_DAI_PORT),
 	   TEST_DAI_LINK_NAME,
 	   SSP_CONFIG(TEST_SSP_MODE,
 		      SSP_CLOCK(mclk, TEST_SSP_MCLK, codec_mclk_in),

--- a/tools/topology/topology1/development/sof-apl-nocodec-demux-eq-2ch4ch.m4
+++ b/tools/topology/topology1/development/sof-apl-nocodec-demux-eq-2ch4ch.m4
@@ -11,6 +11,7 @@ include(`utils.m4')
 include(`dai.m4')
 include(`ssp.m4')
 include(`pipeline.m4')
+include(`muxdemux.m4')
 
 # Include TLV library
 include(`common/tlv.m4')
@@ -21,6 +22,26 @@ include(`sof/tokens.m4')
 # Include Apollolake DSP configuration
 include(`platform/intel/bxt.m4')
 include(`platform/intel/dmic.m4')
+
+dnl Configure demux
+dnl name, pipeline_id, routing_matrix_rows
+dnl Diagonal 1's in routing matrix mean that every input channel is
+dnl copied to corresponding output channels in all output streams.
+dnl I.e. row index is the input channel, 1 means it is copied to
+dnl corresponding output channel (column index), 0 means it is discarded.
+dnl There's a separate matrix for all outputs.
+define(matrix1, `ROUTE_MATRIX(1,
+			     `BITS_TO_BYTE(1, 0, 0 ,0 ,0 ,0 ,0 ,0)',
+			     `BITS_TO_BYTE(1, 0, 0 ,0 ,0 ,0 ,0 ,0)',
+			     `BITS_TO_BYTE(0, 1, 0 ,0 ,0 ,0 ,0 ,0)',
+			     `BITS_TO_BYTE(0, 1, 0 ,0 ,0 ,0 ,0 ,0)',
+			     `BITS_TO_BYTE(0, 0, 0 ,0 ,0 ,0 ,0 ,0)',
+			     `BITS_TO_BYTE(0, 0, 0 ,0 ,0 ,0 ,0 ,0)',
+			     `BITS_TO_BYTE(0, 0, 0 ,0 ,0 ,0 ,0 ,0)',
+			     `BITS_TO_BYTE(0, 0, 0 ,0 ,0 ,0 ,0 ,0)')')
+
+dnl name, num_streams, route_matrix list
+MUXDEMUX_CONFIG(demux_priv_1, 1, LIST(`	', `matrix1'))
 
 #
 # Define the pipelines

--- a/tools/topology/topology1/development/sof-apl-nocodec-demux-eq-2ch4ch.m4
+++ b/tools/topology/topology1/development/sof-apl-nocodec-demux-eq-2ch4ch.m4
@@ -41,7 +41,7 @@ define(matrix1, `ROUTE_MATRIX(1,
 			     `BITS_TO_BYTE(0, 0, 0 ,0 ,0 ,0 ,0 ,0)')')
 
 dnl name, num_streams, route_matrix list
-MUXDEMUX_CONFIG(demux_priv_1, 1, LIST(`	', `matrix1'))
+MUXDEMUX_CONFIG(demux_priv_1, 1, LIST_NONEWLINE(`', `matrix1'))
 
 #
 # Define the pipelines

--- a/tools/topology/topology1/development/sof-apl-nocodec-demux-eq-4ch4ch.m4
+++ b/tools/topology/topology1/development/sof-apl-nocodec-demux-eq-4ch4ch.m4
@@ -11,6 +11,7 @@ include(`utils.m4')
 include(`dai.m4')
 include(`ssp.m4')
 include(`pipeline.m4')
+include(`muxdemux.m4')
 
 # Include TLV library
 include(`common/tlv.m4')
@@ -21,6 +22,26 @@ include(`sof/tokens.m4')
 # Include Apollolake DSP configuration
 include(`platform/intel/bxt.m4')
 include(`platform/intel/dmic.m4')
+
+dnl Configure demux
+dnl name, pipeline_id, routing_matrix_rows
+dnl Diagonal 1's in routing matrix mean that every input channel is
+dnl copied to corresponding output channels in all output streams.
+dnl I.e. row index is the input channel, 1 means it is copied to
+dnl corresponding output channel (column index), 0 means it is discarded.
+dnl There's a separate matrix for all outputs.
+define(matrix1, `ROUTE_MATRIX(1,
+			     `BITS_TO_BYTE(1, 0, 0 ,0 ,0 ,0 ,0 ,0)',
+			     `BITS_TO_BYTE(1, 0, 0 ,0 ,0 ,0 ,0 ,0)',
+			     `BITS_TO_BYTE(0, 1, 0 ,0 ,0 ,0 ,0 ,0)',
+			     `BITS_TO_BYTE(0, 1, 0 ,0 ,0 ,0 ,0 ,0)',
+			     `BITS_TO_BYTE(0, 0, 0 ,0 ,0 ,0 ,0 ,0)',
+			     `BITS_TO_BYTE(0, 0, 0 ,0 ,0 ,0 ,0 ,0)',
+			     `BITS_TO_BYTE(0, 0, 0 ,0 ,0 ,0 ,0 ,0)',
+			     `BITS_TO_BYTE(0, 0, 0 ,0 ,0 ,0 ,0 ,0)')')
+
+dnl name, num_streams, route_matrix list
+MUXDEMUX_CONFIG(demux_priv_1, 1, LIST(`	', `matrix1'))
 
 #
 # Define the pipelines

--- a/tools/topology/topology1/development/sof-apl-nocodec-demux-eq-4ch4ch.m4
+++ b/tools/topology/topology1/development/sof-apl-nocodec-demux-eq-4ch4ch.m4
@@ -41,7 +41,7 @@ define(matrix1, `ROUTE_MATRIX(1,
 			     `BITS_TO_BYTE(0, 0, 0 ,0 ,0 ,0 ,0 ,0)')')
 
 dnl name, num_streams, route_matrix list
-MUXDEMUX_CONFIG(demux_priv_1, 1, LIST(`	', `matrix1'))
+MUXDEMUX_CONFIG(demux_priv_1, 1, LIST_NONEWLINE(`', `matrix1'))
 
 #
 # Define the pipelines

--- a/tools/topology/topology1/development/sof-cml-src-rt5682.m4
+++ b/tools/topology/topology1/development/sof-cml-src-rt5682.m4
@@ -70,7 +70,7 @@ PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	5, 3, 2, s32le,
 	1000, 0, 0,
-	48000 ,48000 ,48000)
+	48000, 48000, 48000)
 
 # Low Latency playback pipeline 6 on PCM 4 using max 2 channels of s32le.
 # Set 1000us deadline with priority 0 on core 0

--- a/tools/topology/topology1/development/sof-tgl-nocodec-ci.m4
+++ b/tools/topology/topology1/development/sof-tgl-nocodec-ci.m4
@@ -56,7 +56,7 @@ define(matrix2, `ROUTE_MATRIX(7,
 			     `BITS_TO_BYTE(0, 0, 0 ,0 ,0 ,0 ,0 ,1)')')
 
 dnl name, num_streams, route_matrix list
-MUXDEMUX_CONFIG(demux_priv_1, 2, LIST(`	', `matrix1,', `matrix2'))
+MUXDEMUX_CONFIG(demux_priv_1, 2, LIST_NONEWLINE(`', `matrix1,', `matrix2'))
 
 #
 # Define the pipelines

--- a/tools/topology/topology1/m4/utils.m4
+++ b/tools/topology/topology1/m4/utils.m4
@@ -19,7 +19,11 @@ dnl The first argument specifies the number of tabs to be added for formatting
 define(`LIST_LOOP', `argn(j,$@)
 $1ifelse(i,`2', `', `define(`i', decr(i))define(`j', incr(j))$0($@)')')
 
+define(`LIST_LOOP_NONEWLINE', `argn(j,$@)$1ifelse(i,`2', `', `define(`i', decr(i))define(`j', incr(j))$0($@)')')
+
 define(`LIST', `pushdef(`i', $#)pushdef(`j', `2')LIST_LOOP($@)popdef(i)popdef(j)')
+
+define(`LIST_NONEWLINE', `pushdef(`i', $#)pushdef(`j', `2')LIST_LOOP_NONEWLINE($@)popdef(i)popdef(j)')
 
 dnl Sums a list of variable arguments. Use as last argument in macro.
 define(`SUM_LOOP', `eval(argn(j,$@)

--- a/tools/topology/topology1/sof-adl-nau8825.m4
+++ b/tools/topology/topology1/sof-adl-nau8825.m4
@@ -74,7 +74,7 @@ dnl There's a separate matrix for all outputs.
 			     `BITS_TO_BYTE(0, 0, 0 ,0 ,0 ,0 ,0 ,1)')')'
 
 dnl name, num_streams, route_matrix list
-`MUXDEMUX_CONFIG(demux_priv_1, 2, LIST(`	', `matrix1,', `matrix2'))')
+`MUXDEMUX_CONFIG(demux_priv_1, 2, LIST_NONEWLINE(`', `matrix1,', `matrix2'))')
 
 ifdef(`NO_AMP',,`
 ifdef(`SMART_AMP',`

--- a/tools/topology/topology1/sof-apl-demux-pcm512x.m4
+++ b/tools/topology/topology1/sof-apl-demux-pcm512x.m4
@@ -49,7 +49,7 @@ define(matrix2, `ROUTE_MATRIX(5,
 			     `BITS_TO_BYTE(0, 0, 0 ,0 ,0 ,0 ,0 ,1)')')
 
 dnl name, num_streams, route_matrix list
-MUXDEMUX_CONFIG(demux_priv_1, 2, LIST(`	', `matrix1,', `matrix2'))
+MUXDEMUX_CONFIG(demux_priv_1, 2, LIST_NONEWLINE(`', `matrix1,', `matrix2'))
 
 #
 # Define the pipelines

--- a/tools/topology/topology1/sof-cml-demux-rt5682.m4
+++ b/tools/topology/topology1/sof-cml-demux-rt5682.m4
@@ -49,7 +49,7 @@ define(matrix2, `ROUTE_MATRIX(5,
 			     `BITS_TO_BYTE(0, 0, 0 ,0 ,0 ,0 ,0 ,1)')')
 
 dnl name, num_streams, route_matrix list
-MUXDEMUX_CONFIG(demux_priv_1, 2, LIST(`	', `matrix1,', `matrix2'))
+MUXDEMUX_CONFIG(demux_priv_1, 2, LIST_NONEWLINE(`', `matrix1,', `matrix2'))
 
 #
 # Define the pipelines

--- a/tools/topology/topology1/sof-icl-rt711-rt1308-rt715-hdmi.m4
+++ b/tools/topology/topology1/sof-icl-rt711-rt1308-rt715-hdmi.m4
@@ -63,7 +63,7 @@ define(matrix2, `ROUTE_MATRIX(4,
 			     `BITS_TO_BYTE(0, 0, 0 ,0 ,0 ,0 ,0 ,1)')')
 
 dnl name, num_streams, route_matrix list
-MUXDEMUX_CONFIG(demux_priv_3, 2, LIST(`	', `matrix1,', `matrix2'))
+MUXDEMUX_CONFIG(demux_priv_3, 2, LIST_NONEWLINE(`', `matrix1,', `matrix2'))
 ')
 
 #

--- a/tools/topology/topology1/sof-tgl-max98357a-rt5682.m4
+++ b/tools/topology/topology1/sof-tgl-max98357a-rt5682.m4
@@ -52,7 +52,7 @@ define(matrix2, `ROUTE_MATRIX(9,
 			     `BITS_TO_BYTE(0, 0, 0 ,0 ,0 ,0 ,0 ,1)')')
 
 dnl name, num_streams, route_matrix list
-MUXDEMUX_CONFIG(demux_priv_1, 2, LIST(`	', `matrix1,', `matrix2'))
+MUXDEMUX_CONFIG(demux_priv_1, 2, LIST_NONEWLINE(`', `matrix1,', `matrix2'))
 
 #
 # Define the pipelines

--- a/tools/topology/topology1/sof/pipe-demux-eq-iir-playback.m4
+++ b/tools/topology/topology1/sof/pipe-demux-eq-iir-playback.m4
@@ -11,26 +11,6 @@ include(`muxdemux.m4')
 include(`bytecontrol.m4')
 include(`eq_iir.m4')
 
-dnl Configure demux
-dnl name, pipeline_id, routing_matrix_rows
-dnl Diagonal 1's in routing matrix mean that every input channel is
-dnl copied to corresponding output channels in all output streams.
-dnl I.e. row index is the input channel, 1 means it is copied to
-dnl corresponding output channel (column index), 0 means it is discarded.
-dnl There's a separate matrix for all outputs.
-define(matrix1, `ROUTE_MATRIX(1,
-			     `BITS_TO_BYTE(1, 0, 0 ,0 ,0 ,0 ,0 ,0)',
-			     `BITS_TO_BYTE(1, 0, 0 ,0 ,0 ,0 ,0 ,0)',
-			     `BITS_TO_BYTE(0, 1, 0 ,0 ,0 ,0 ,0 ,0)',
-			     `BITS_TO_BYTE(0, 1, 0 ,0 ,0 ,0 ,0 ,0)',
-			     `BITS_TO_BYTE(0, 0, 0 ,0 ,0 ,0 ,0 ,0)',
-			     `BITS_TO_BYTE(0, 0, 0 ,0 ,0 ,0 ,0 ,0)',
-			     `BITS_TO_BYTE(0, 0, 0 ,0 ,0 ,0 ,0 ,0)',
-			     `BITS_TO_BYTE(0, 0, 0 ,0 ,0 ,0 ,0 ,0)')')
-
-dnl name, num_streams, route_matrix list
-MUXDEMUX_CONFIG(demux_priv_1, 1, LIST(`	', `matrix1'))
-
 # demux Bytes control with max value of 255
 C_CONTROLBYTES(concat(`DEMUX', PIPELINE_ID), PIPELINE_ID,
 	CONTROLBYTES_OPS(bytes, 258 binds the mixer control to bytes get/put handlers, 258, 258),
@@ -135,6 +115,5 @@ indir(`define', concat(`PIPELINE_PCM_', PIPELINE_ID), Speaker Playback PCM_ID)
 # PCM capabilities supported by FW
 PCM_CAPABILITIES(Speaker Playback PCM_ID, CAPABILITY_FORMAT_NAME(PIPELINE_FORMAT), 48000, 48000, 2, PIPELINE_CHANNELS, 2, 16, 192, 16384, 65536, 65536)
 
-undefine(`matrix1')
 undefine(`DEF_EQIIR_COEF')
 undefine(`DEF_EQIIR_PRIV')


### PR DESCRIPTION
Same as #5632 but for stable-v2.0

Cherry-picks with almost no conflict, just a minor conflict for https://github.com/thesofproject/sof/commit/3e1c160e5053eae66769ad19955df83a08218270 caused by the lack of f41010d3868d5