### PR TITLE
ipc4: Stop dai when dai_free is called

### DIFF
--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -222,6 +222,9 @@ static void dai_free(struct comp_dev *dev)
 		dd->chan->dev_data = NULL;
 	}
 
+	if (dev->state != COMP_STATE_PREPARE)
+		dai_trigger(dd->dai, COMP_TRIGGER_STOP, dev->direction);
+
 	dma_put(dd->dma);
 
 	dai_put(dd->dai);


### PR DESCRIPTION
Stops dai before freeing it. In ipc3 flow it is done by issuing a separate stop trigger
ipc command. 

Signed-off-by: Krzysztof Frydryk <krzysztofx.frydryk@intel.com>