### PR TITLE
Tools: Topology: Add a development topology to RUN SRC on UP2

### DIFF
--- a/tools/topology/topology1/development/CMakeLists.txt
+++ b/tools/topology/topology1/development/CMakeLists.txt
@@ -3,6 +3,7 @@
 set(TPLGS
 	"sof-apl-asrc-pcm512x\;sof-apl-asrc-pcm512x"
 	"sof-apl-asrc-wm8804\;sof-apl-asrc-wm8804"
+	"sof-apl-src-pcm512x\;sof-apl-src-pcm512x"
 	"sof-apl-dmic-a96k-b16k\;sof-apl-dmic-a96k-b16k"
 	"sof-apl-dmic-asymmetric\;sof-apl-dmic-a2ch-b2ch\;-DDMICSETTING=apl-dmic-a2b2"
 	"sof-apl-dmic-asymmetric\;sof-apl-dmic-a2ch-b4ch\;-DDMICSETTING=apl-dmic-a2b4"

--- a/tools/topology/topology1/development/sof-apl-src-pcm512x.m4
+++ b/tools/topology/topology1/development/sof-apl-src-pcm512x.m4
@@ -1,0 +1,117 @@
+#
+# Topology for Apollolake UP^2 with pcm512x codec for testing SRC
+#
+
+# Include topology builder
+include(`utils.m4')
+include(`dai.m4')
+include(`pipeline.m4')
+include(`ssp.m4')
+
+# Include TLV library
+include(`common/tlv.m4')
+
+# Include Token library
+include(`sof/tokens.m4')
+
+# Include Apollolake DSP configuration
+include(`platform/intel/bxt.m4')
+include(`platform/intel/dmic.m4')
+
+DEBUG_START
+
+#
+# Define the pipelines
+#
+# PCM0 --> SRC --> Volume --> SSP5 (pcm512x)
+# PCM5 <-- SRC <-- Volume <-- DMIC0 (DMIC)
+# PCM6 <-- SRC <-- Volume <-- DMIC1 (DMIC16kHz)
+
+dnl PIPELINE_PCM_ADD(pipeline,
+dnl     pipe id, pcm, max channels, format,
+dnl     period, priority, core,
+dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
+dnl	time_domain, sched_comp)
+
+# Playback pipeline 1 on PCM 0 using max 2 channels of s32le.
+# Set 1000us deadline with priority 0 on core 0
+PIPELINE_PCM_ADD(sof/pipe-src-volume-playback.m4,
+	1, 0, 2, s32le,
+	1000, 0, 0,
+	8000, 192000, 48000)
+
+# DMIC capture pipeline 2 on PCM 5 using max 2 channels.
+# 1000us deadline with priority 0 on core 0
+PIPELINE_PCM_ADD(sof/pipe-src-volume-capture.m4,
+        2, 5, 2, s32le,
+        1000, 0, 0,
+        8000, 192000, 48000)
+
+# DMIC16kHz capture pipeline 2 on PCM 6 using max 2 channels.
+# 1000us deadline with priority 0 on core 0
+PIPELINE_PCM_ADD(sof/pipe-src-volume-capture.m4,
+        3, 6, 2, s32le,
+        1000, 0, 0,
+        8000, 192000, 16000)
+
+#
+# DAIs configuration
+#
+
+dnl DAI_ADD(pipeline,
+dnl     pipe id, dai type, dai_index, dai_be,
+dnl     buffer, periods, format,
+dnl     deadline, priority, core, time_domain)
+
+# playback DAI is SSP5 using 2 periods
+# Buffers use s24le format, 1000us deadline with priority 0 on core 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+	1, SSP, 5, SSP5-Codec,
+	PIPELINE_SOURCE_1, 2, s24le,
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+
+# capture DAI is DMIC using 2 periods
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
+DAI_ADD(sof/pipe-dai-capture.m4,
+        2, DMIC, 0, dmic01,
+        PIPELINE_SINK_2, 2, s32le,
+        1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+
+# capture DAI is DMIC16kHz using 2 periods
+# Buffers use s16le format, 1000us deadline with priority 0 on core 0
+DAI_ADD(sof/pipe-dai-capture.m4,
+        3, DMIC, 1, dmic16k,
+        PIPELINE_SINK_3, 2, s32le,
+        1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+
+# PCM, id 0
+dnl PCM_PLAYBACK_ADD(name, pcm_id, playback)
+PCM_PLAYBACK_ADD(Port5, 0, PIPELINE_PCM_1)
+PCM_CAPTURE_ADD(DMIC, 5, PIPELINE_PCM_2)
+PCM_CAPTURE_ADD(DMIC16kHz, 6, PIPELINE_PCM_3)
+
+#
+# BE configurations - overrides config in ACPI if present
+#
+
+#SSP 5 (ID: 0)
+DAI_CONFIG(SSP, 5, 0, SSP5-Codec,
+	SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24576000, codec_mclk_in),
+		SSP_CLOCK(bclk, 3072000, codec_slave),
+		SSP_CLOCK(fsync, 48000, codec_slave),
+		SSP_TDM(2, 32, 3, 3),
+		SSP_CONFIG_DATA(SSP, 5, 24)))
+
+# DMIC (ID: 1)
+DAI_CONFIG(DMIC, 0, 1, dmic01,
+           DMIC_CONFIG(1, 2400000, 4800000, 40, 60, 48000,
+                DMIC_WORD_LENGTH(s32le), 400, DMIC, 0,
+                PDM_CONFIG(DMIC, 0, STEREO_PDM0)))
+
+# DMIC16kHz (ID: 2)
+DAI_CONFIG(DMIC, 1, 2, dmic16k,
+           DMIC_CONFIG(1, 2400000, 4800000, 40, 60, 16000,
+                DMIC_WORD_LENGTH(s32le), 400, DMIC, 1,
+                PDM_CONFIG(DMIC, 1, STEREO_PDM0)))
+
+DEBUG_END


### PR DESCRIPTION
Add this topology to be able to test SRC playback and capture.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>