### PR TITLE
[TEST] cmake: remove -fno-inline-functions

### DIFF
--- a/src/arch/xtensa/CMakeLists.txt
+++ b/src/arch/xtensa/CMakeLists.txt
@@ -108,7 +108,7 @@ else()
 endif()
 
 # C & ASM flags
-target_compile_options(sof_options INTERFACE ${stdlib_flag} -fno-inline-functions ${XTENSA_C_ASM_FLAGS})
+target_compile_options(sof_options INTERFACE ${stdlib_flag} ${XTENSA_C_ASM_FLAGS})
 
 # C flags
 # TODO: Generator expressions are supported only with Make and Ninja,

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -694,7 +694,7 @@ find_package(Python3 COMPONENTS Interpreter)
 set(PYTHON3 "${Python3_EXECUTABLE}")
 
 # SOF uses GNU C99 extensions. TODO other flags required ?
-target_compile_options(SOF INTERFACE -std=gnu99 -fno-inline-functions)
+target_compile_options(SOF INTERFACE -std=gnu99)
 
 # Toolchain info
 add_definitions(-DXCC_TOOLS_VERSION="${ZEPHYR_TOOLCHAIN_VARIANT}" -DCC_OPTIMIZE_FLAGS="${OPTIMIZATION_FLAG}")


### PR DESCRIPTION
Just a test, see #5212

Same as TEST PR #5213 but extended to Zephyr

Signed-off-by: Marc Herbert <marc.herbert@intel.com>