### PR TITLE
ipc4: base_fw: return fail for not supported ipc

### DIFF
--- a/src/audio/base_fw.c
+++ b/src/audio/base_fw.c
@@ -308,7 +308,15 @@ static int basefw_set_large_config(struct comp_dev *dev,
 				   uint32_t data_offset,
 				   char *data)
 {
-	return 0;
+	switch (param_id) {
+	case IPC4_FW_CONFIG:
+		tr_warn(&basefw_comp_tr, "returning success for Set FW_CONFIG without handling it");
+		return 0;
+	default:
+		break;
+	}
+
+	return IPC4_UNKNOWN_MESSAGE_TYPE;
 };
 
 static const struct comp_driver comp_basefw = {


### PR DESCRIPTION
Base FW is lacking implementation for large config set. Returning 0 is
hiding the existing problem and will lead to false success reports. Tests
using this functionality will fail in later steps, making it difficult to
debug.

However, IPC4_FW_CONFIG have to be exception. All existing tests used by
FW team are using this IPC. Its required to maintain unity of tests for
all platforms.

Signed-off-by: Tomasz Leman <tomasz.m.leman@intel.com>