### PR TITLE
zephyr: Use type compatible with Zephyr linker declarations

### DIFF
--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -68,9 +68,9 @@ __section(".heap_mem") static uint8_t __aligned(64) heapmem[HEAPMEM_SIZE];
 
 #else
 
-extern uint8_t _end, _heap_sentry;
-#define heapmem ((uint8_t *)ALIGN_UP((uintptr_t)&_end, PLATFORM_DCACHE_ALIGN))
-#define HEAPMEM_SIZE (&_heap_sentry - heapmem)
+extern char _end[], _heap_sentry[];
+#define heapmem ((uint8_t *)ALIGN_UP((uintptr_t)_end, PLATFORM_DCACHE_ALIGN))
+#define HEAPMEM_SIZE ((uint8_t *)_heap_sentry - heapmem)
 
 #endif
 


### PR DESCRIPTION
`_end` and `_heap_sentry` linker symbols are used to infer heap size. In
Zephyr, `_end` is referenced as `char []` while in SOF as `uint8_t`.
This may "conflicting types", should those declarations be built
together.

This patch changes the Zephyr wrapper to also use `char []`, thus
avoiding this issue.

Signed-off-by: Ederson de Souza <ederson.desouza@intel.com>