### PR TITLE
stable-v2.0: .github/zephyr: hardcode zephyr container version to v0.21.0

### DIFF
--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -19,5 +19,5 @@ jobs:
       # -e https_proxy=...
       - name: build
         run: docker run -v "$(pwd)":/workdir
-             docker.io/zephyrprojectrtos/zephyr-build:latest
+             docker.io/zephyrprojectrtos/zephyr-build:v0.21.0
              ./zephyr/docker-build.sh -- -DEXTRA_CFLAGS='-Werror'


### PR DESCRIPTION
The container v0.22.0 changed the toolchain locations, for instance
for APL it changed from

 `/opt/toolchains/zephyr-sdk-0.13.1/xtensa/intel_apl_adsp/...`

to

 `/opt/toolchains/zephyr-sdk-0.14.0/xtensa-intel_apl_adsp_zephyr-elf/...`

The new location is not found by the old Zephyr version fd089b361d8aebbc
that is currently hardcoded for this branch by previous SOF commit
b678a4dcaa1e. This causes the failure shown below, see real build
failure example in #5641.

The docker image v0.21.0 is the last one that has the old location.
https://hub.docker.com/r/zephyrprojectrtos/zephyr-build/tags

I suspect the name change happened in this commit:
https://github.com/zephyrproject-rtos/sdk-ng/commit/c701e23bcce86f27f3a7
```
-- Using toolchain: zephyr 0.14.0 (/opt/toolchains/zephyr-sdk-0.14.0)
-- Found dtc:
/opt/toolchains/zephyr-sdk-0.14.0/sysroots/x86_64-pokysdk-linux/usr/bin/dtc
(found suitable version "1.6.0", minimum required is "1.4.6")
  ...
  ...
CMake Error at
/workdir/zephyrproject/zephyr/cmake/compiler/gcc/target.cmake:10
-- Configuring incomplete, errors occurred!
  C compiler
/opt/toolchains/zephyr-sdk-0.14.0/xtensa/intel_apl_adsp/ \
 xtensa-intel_apl_adsp_zephyr-elf/bin/xtensa-intel_apl_adsp_zephyr-elf-gcc
      not found - Please check your toolchain installation
      Call Stack (most recent call first):
/workdir/zephyrproject/zephyr/cmake/target_toolchain.cmake:57
/workdir/zephyrproject/zephyr/cmake/app/boilerplate.cmake:599
/.../zephyrproject/zephyr/share/zephyr-package/cmake/ZephyrConfig.cmake:24
/.../zephyrproject/zephyr/share/zephyr-package/cmake/ZephyrConfig.cmake:35
```
Signed-off-by: Marc Herbert <marc.herbert@intel.com>