### PR TITLE
audio: remove all redundant list init's

### DIFF
--- a/src/audio/aria/aria.c
+++ b/src/audio/aria/aria.c
@@ -130,8 +130,6 @@ static int init_aria(struct comp_dev *dev, struct comp_ipc_config *config,
 	int ret;
 
 	dev->ipc_config = *config;
-	list_init(&dev->bsource_list);
-	list_init(&dev->bsink_list);
 
 	dcache_invalidate_region(spec, sizeof(*aria));
 	cd = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM, sizeof(*cd));

--- a/src/audio/copier.c
+++ b/src/audio/copier.c
@@ -183,9 +183,6 @@ static struct comp_dev *create_host(struct comp_dev *parent_dev, struct copier_d
 	if (!dev)
 		return NULL;
 
-	list_init(&dev->bsource_list);
-	list_init(&dev->bsink_list);
-
 	if (cd->direction == SOF_IPC_STREAM_PLAYBACK) {
 		comp_buffer_connect(dev, config->core, cd->endpoint_buffer,
 				    PPL_CONN_DIR_COMP_TO_BUFFER);
@@ -278,9 +275,6 @@ static struct comp_dev *create_dai(struct comp_dev *parent_dev, struct copier_da
 
 	pipeline->sched_id = config->id;
 
-	list_init(&dev->bsource_list);
-	list_init(&dev->bsink_list);
-
 	ret = comp_dai_config(dev, &dai, copier);
 	if (ret < 0)
 		return NULL;
@@ -354,9 +348,6 @@ static struct comp_dev *copier_new(const struct comp_driver *drv,
 	mailbox_hostbox_read(&cd->config, size, 0, size);
 	cd->out_fmt[0] = cd->config.out_fmt;
 	comp_set_drvdata(dev, cd);
-
-	list_init(&dev->bsource_list);
-	list_init(&dev->bsink_list);
 
 	ipc_pipe = ipc_get_comp_by_ppl_id(ipc, COMP_TYPE_PIPELINE, config->pipeline_id);
 	if (!ipc_pipe) {

--- a/src/audio/up_down_mixer/up_down_mixer.c
+++ b/src/audio/up_down_mixer/up_down_mixer.c
@@ -342,8 +342,6 @@ static int init_up_down_mixer(struct comp_dev *dev, struct comp_ipc_config *conf
 	int ret;
 
 	dev->ipc_config = *config;
-	list_init(&dev->bsource_list);
-	list_init(&dev->bsink_list);
 
 	dcache_invalidate_region(spec, sizeof(*up_down_mixer));
 	cd = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM, sizeof(*cd));

--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -595,8 +595,6 @@ static struct comp_dev *volume_new(const struct comp_driver *drv,
 		return NULL;
 
 	dev->ipc_config = *config;
-	list_init(&dev->bsource_list);
-	list_init(&dev->bsink_list);
 
 	cd = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM,
 		     sizeof(struct vol_data));

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -396,8 +396,6 @@ static struct comp_dev *ipc4_create_host(uint32_t pipeline_id, uint32_t id, uint
 		return NULL;
 
 	dev->direction = dir;
-	list_init(&dev->bsource_list);
-	list_init(&dev->bsink_list);
 
 	return dev;
 }
@@ -435,8 +433,6 @@ static struct comp_dev *ipc4_create_dai(struct pipeline *pipe, uint32_t id, uint
 	pipe->sched_id = id;
 
 	dev->direction = dir;
-	list_init(&dev->bsource_list);
-	list_init(&dev->bsink_list);
 
 	ret = comp_dai_config(dev, &dai, copier_cfg);
 	if (ret < 0)


### PR DESCRIPTION
comp_new() for both IPC3 and IPC4 initializes the source/sink buffer
lists already. So, remove the redundant init from the component create
callbacks.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>