### PR TITLE
audio: volume: initialize variables before using

### DIFF
--- a/src/audio/volume/volume_hifi3.c
+++ b/src/audio/volume/volume_hifi3.c
@@ -63,13 +63,13 @@ static void vol_s24_to_s24_s32(struct comp_dev *dev, struct audio_stream *sink,
 {
 	struct vol_data *cd = comp_get_drvdata(dev);
 	ae_f32x2 in_sample = AE_ZERO32();
-	ae_f32x2 out_sample;
-	ae_f32x2 volume;
+	ae_f32x2 out_sample = AE_ZERO32();
+	ae_f32x2 volume = AE_ZERO32();
 	ae_f32x2 *buf;
 	ae_f32x2 *buf_end;
 	int i, n, m;
 	ae_f32x2 *vol;
-	ae_valign inu;
+	ae_valign inu = AE_ZALIGN64();
 	ae_valign outu = AE_ZALIGN64();
 	ae_f32x2 *in = (ae_f32x2 *)source->r_ptr;
 	ae_f32x2 *out = (ae_f32x2 *)sink->w_ptr;
@@ -148,15 +148,15 @@ static void vol_s32_to_s24_s32(struct comp_dev *dev, struct audio_stream *sink,
 {
 	struct vol_data *cd = comp_get_drvdata(dev);
 	ae_f32x2 in_sample = AE_ZERO32();
-	ae_f32x2 out_sample;
-	ae_f32x2 volume;
+	ae_f32x2 out_sample = AE_ZERO32();
+	ae_f32x2 volume = AE_ZERO32();
 	int i, n, m;
 	ae_f64 mult0;
 	ae_f64 mult1;
 	ae_f32x2 *buf;
 	ae_f32x2 *buf_end;
 	ae_f32x2 *vol;
-	ae_valign inu;
+	ae_valign inu = AE_ZALIGN64();
 	ae_valign outu = AE_ZALIGN64();
 	const int inc = sizeof(ae_f32x2);
 	const int channels_count = sink->channels;
@@ -235,15 +235,17 @@ static void vol_s16_to_s16(struct comp_dev *dev, struct audio_stream *sink,
 			   const struct audio_stream *source, uint32_t frames)
 {
 	struct vol_data *cd = comp_get_drvdata(dev);
-	ae_f32x2 volume0, volume1;
-	ae_f32x2 out_sample0, out_sample1;
+	ae_f32x2 volume0 = AE_ZERO32();
+	ae_f32x2 volume1 = AE_ZERO32();
+	ae_f32x2 out_sample0 = AE_ZERO32();
+	ae_f32x2 out_sample1 = AE_ZERO32();
 	ae_f16x4 in_sample = AE_ZERO16();
 	ae_f16x4 out_sample = AE_ZERO16();
 	int i, n, m;
 	ae_f32x2 *buf;
 	ae_f32x2 *buf_end;
 	ae_f32x2 *vol;
-	ae_valign inu;
+	ae_valign inu = AE_ZALIGN64();
 	ae_valign outu = AE_ZALIGN64();
 	ae_f16x4 *in = (ae_f16x4 *)source->r_ptr;
 	ae_f16x4 *out = (ae_f16x4 *)sink->w_ptr;


### PR DESCRIPTION
initialize the variables for xtensa intrinsics.

Signed-off-by: Andrula Song <xiaoyuan.song@intel.com>