### PR TITLE
buffer: fix dereference before null check

### DIFF
--- a/src/audio/buffer.c
+++ b/src/audio/buffer.c
@@ -159,10 +159,10 @@ void buffer_free(struct comp_buffer *buffer)
 		.buffer = buffer,
 	};
 
-	buf_dbg(buffer, "buffer_free()");
-
 	if (!buffer)
 		return;
+
+	buf_dbg(buffer, "buffer_free()");
 
 	notifier_event(buffer, NOTIFIER_ID_BUFFER_FREE,
 		       NOTIFIER_TARGET_CORE_LOCAL, &cb_data, sizeof(cb_data));


### PR DESCRIPTION
This will fix null dereference issue reported by KW