### PR TITLE
ipc4: fix pipeline reset trigger from paused state

### DIFF
--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -268,7 +268,7 @@ static int set_pipeline_state(uint32_t id, uint32_t cmd, bool *delayed, uint32_t
 		if (status == COMP_STATE_READY)
 			return 0;
 
-		if (status == COMP_STATE_ACTIVE) {
+		if (status == COMP_STATE_ACTIVE || COMP_STATE_PAUSED) {
 			ret = pipeline_trigger(host->cd->pipeline, host->cd, COMP_TRIGGER_STOP);
 			if (ret < 0) {
 				tr_err(&ipc_tr, "ipc: comp %d trigger 0x%x failed %d",


### PR DESCRIPTION
When pipeline reset was called from paused state, it was not stopped
beforehand. This resulted in improper device turn-off sequence.
This implementation fits IPC4 pipeline state transitions
```
   Ipc4 pipeline message <------> ipc3 pipeline message
   RUNNING     <-------> TRIGGER START
   INIT + PAUSED  <-------> PIPELINE COMPLETE
   INIT + RESET <-------> PIPELINE COMPLETE
   PAUSED      <-------> TRIGER_PAUSE
   RESET       <-------> TRIGER_STOP + RESET
   EOS(end of stream) <-------> NOT SUPPORT NOW
```

Signed-off-by: Krzysztof Frydryk <krzysztofx.frydryk@intel.com>