### PR TITLE
alloc: Making heap trace dump more readable

### DIFF
--- a/src/lib/alloc.c
+++ b/src/lib/alloc.c
@@ -565,18 +565,18 @@ void heap_trace(struct mm_heap *heap, int size)
 		tr_info(&mem_tr, " heap: 0x%x size %d blocks %d caps 0x%x",
 			heap->heap, heap->size, heap->blocks,
 			heap->caps);
-		tr_info(&mem_tr, "  used %d free %d", heap->info.used,
+		tr_info(&mem_tr, "  (In Bytes) used %d free %d", heap->info.used,
 			heap->info.free);
 
 		/* map[j]'s base is calculated based on map[j-1] */
 		for (j = 0; j < heap->blocks; j++) {
 			current_map = &heap->map[j];
 
-			tr_info(&mem_tr, "  block %d base 0x%x size %d",
-				j, current_map->base,
-				current_map->block_size);
-			tr_info(&mem_tr, "   count %d free %d",
+			tr_info(&mem_tr, " %d Bytes blocks ID:%d base 0x%x",
+				current_map->block_size, j, current_map->base);
+			tr_info(&mem_tr, "   Number of Blocks: total % used %d free %d",
 				current_map->count,
+				(current_map->count - current_map->free_count),
 				current_map->free_count);
 		}
 


### PR DESCRIPTION
This Patch to help easily understand available heap from the trace dump.

Current dump:
src/lib/alloc.c:567  heap: 0xbe206000 size 12288 blocks 3 caps 0x65
src/lib/alloc.c:569   used 448 free 11840
src/lib/alloc.c:577   block 0 base 0xbe206000 size 64
src/lib/alloc.c:580    count 64 free 57

Dump with this patch:
src/lib/alloc.c:567  INFO  heap: 0xbe206000 size 12288 blocks 3 caps 0x65
src/lib/alloc.c:569  INFO   (In Bytes) used 0 free 12288
src/lib/alloc.c:576  INFO  64 Bytes blocks ID:0 base 0xbe206000
src/lib/alloc.c:580  INFO    Number of Blocks: total 64 used 0 free 64
