### PR TITLE
xtensa-build-zephyr.py:  default to subprocess.run(check=True) . Disable some pylint warnings.

### DIFF
--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: BSD-3-Clause
 
+#pylint:disable=mixed-indentation
+#pylint:disable=invalid-name
+#pylint:disable=missing-function-docstring
 import argparse
 import shlex
 import subprocess

--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -216,6 +216,10 @@ def execute_command(*run_args, **run_kwargs):
 		print_args = shlex.join(command_args)
 		print(f"{print_cwd}; running command: {print_args}", flush=True)
 
+	if run_kwargs.get('check') is None:
+		run_kwargs['check'] = True
+	#pylint:disable=subprocess-run-check
+
 	return subprocess.run(*run_args, **run_kwargs)
 
 def show_installed_files():


### PR DESCRIPTION
2 commits, see commit messages.