### PR TITLE
ipc4: pipeline: stop preparing component in another pipeline

### DIFF
--- a/src/audio/pipeline/pipeline-params.c
+++ b/src/audio/pipeline/pipeline-params.c
@@ -14,6 +14,8 @@
 #include <sof/spinlock.h>
 #include <ipc/stream.h>
 #include <ipc/topology.h>
+#include <ipc4/error_status.h>
+#include <ipc4/module.h>
 #include <errno.h>
 #include <stdbool.h>
 #include <stddef.h>
@@ -304,6 +306,10 @@ static int pipeline_comp_prepare(struct comp_dev *current,
 			    end_type == COMP_ENDPOINT_NODE)
 				return 0;
 		}
+
+		/* ipc4 module is only prepared in its parent pipeline */
+		if (IPC4_MOD_ID(current->ipc_config.id))
+			return 0;
 	}
 
 	err = pipeline_comp_task_init(current->pipeline);


### PR DESCRIPTION
Currently we stop preparing when a component in another
pipeline only for some conditions. For passthrough
pipeline host & dai are in different pipelines, these conditions
can't cover it. Actually we should only prepare component in its
parent pipeline, not in other pipeline.

This patch make sure that component is prepared in its own pipeline.

fixes https://github.com/thesofproject/sof/issues/5661