### PR TITLE
stable-v2.0: set default value instead of hardcoding Zephyr commit 

### DIFF
--- a/scripts/xtensa-build-zephyr.sh
+++ b/scripts/xtensa-build-zephyr.sh
@@ -121,9 +121,8 @@ west_init_update()
 	local init_remote="${1:-https://github.com/zephyrproject-rtos/zephyr}"
 
 	# This can be a branch, a 40-digit SHA or empty to fetch the
-	# default branch. Example:
-	# local init_ref=${2:-sof/stable-v2.1}
-	local init_ref="$2"
+	# default branch
+	local init_ref="${2:-fd089b361d8aebbcb49cca989444aaeb0b6fbb4d}"
 
 	# git fetch accepts anything, even 40-digits SHA but git clone is
 	# less flexible. So we git clone the default branch first to get
@@ -146,9 +145,6 @@ west_init_update()
 
 	# zephyr_fetch_and_switch    origin   pull/38374/head
 	# zephyr_fetch_and_switch    origin   19d5448ec117fde8076bec4d0e61da53147f3315
-
-	# SOF2.0 release uses this commit, verified in  2021-12-03 daily test
-	zephyr_fetch_and_switch    origin   fd089b361d8aebbcb49cca989444aaeb0b6fbb4d
 
 	# SECURITY WARNING for reviewers: never allow unknown code from
 	# unknown submitters on any CI system.

--- a/scripts/xtensa-build-zephyr.sh
+++ b/scripts/xtensa-build-zephyr.sh
@@ -74,6 +74,8 @@ usage: $0 [options] [ platform(s) ] [ -- cmake arguments ]
           sof/ and zephyr-project/ directories are not nested in one
           another.
 
+       -v Verbose Makefile log
+
 This script supports XtensaTools but only when installed in a specific
 directory structure, example:
 
@@ -244,6 +246,9 @@ build_platforms()
 			 # show a confusing error.
 			/bin/pwd
 
+			local verbose
+			[ -z "$BUILD_VERBOSE" ] || verbose=-v
+
 			if test -e  "$bdir/build.ninja" || test -e  "$bdir/Makefile"; then
 			    test -z "${CMAKE_ARGS+defined}" ||
 				die 'Cannot re-define CMAKE_ARGS, you must delete %s first\n' \
@@ -252,10 +257,10 @@ build_platforms()
 			    # CMAKE_ARGS this _not_ does force CMake to re-run and passing
 			    # a different board by mistake is very nicely caught by west.
 			    set -x
-			    west build --build-dir "$bdir" --board "$PLAT_CONFIG"
+			    west $verbose build --build-dir "$bdir" --board "$PLAT_CONFIG"
 			else
 			    set -x
-			    west build --build-dir "$bdir" --board "$PLAT_CONFIG" \
+			    west $verbose build --build-dir "$bdir" --board "$PLAT_CONFIG" \
 				zephyr/samples/subsys/audio/sof \
 				-- "${CMAKE_ARGS[@]}"
 			fi
@@ -301,7 +306,7 @@ parse_args()
 	local OPTIND=1
 
 	# Parse -options
-	while getopts "acz:j:k:p:" OPTION; do
+	while getopts "acz:j:k:p:v" OPTION; do
 		case "$OPTION" in
 			a) PLATFORMS=("${DEFAULT_PLATFORMS[@]}") ;;
 			c) DO_CLONE=yes ;;
@@ -309,6 +314,7 @@ parse_args()
 			j) BUILD_JOBS="$OPTARG" ;;
 			k) RIMAGE_KEY_OPT="$OPTARG" ;;
 			p) zeproj="$OPTARG" ;;
+			v) BUILD_VERBOSE=true ;;
 			*) print_usage; exit 1 ;;
 		esac
 	done

--- a/scripts/xtensa-build-zephyr.sh
+++ b/scripts/xtensa-build-zephyr.sh
@@ -59,6 +59,9 @@ usage: $0 [options] [ platform(s) ] [ -- cmake arguments ]
           Incompatible with -p. To stop after downloading Zephyr, do not
           pass any platform or cmake argument.
 
+       -u Initial Zephyr remote for the -c option. Default value:
+            https://github.com/zephyrproject-rtos/zephyr
+
        -z Initial Zephyr git ref for the -c option. Can be a branch, tag,
           full SHA1 in a fork, magic pull/12345/merge,... anything as long as
           it is fetchable from https://github.com/zephyrproject-rtos/zephyr/
@@ -113,18 +116,26 @@ zephyr_fetch_and_switch()
 # link back to sof/
 west_init_update()
 {
-	local init_ref="$1"
+	# Default Zephyr remote and branch if nothing passed on the
+	# command line.
+	local init_remote="${1:-https://github.com/zephyrproject-rtos/zephyr}"
 
-	# Or, we could have a default value:
-	# init_ref=${1:-811a09bd8305}
+	# This can be a branch, a 40-digit SHA or empty to fetch the
+	# default branch. Example:
+	# local init_ref=${2:-sof/stable-v2.1}
+	local init_ref="$2"
 
-	git clone --depth=5 https://github.com/zephyrproject-rtos/zephyr \
-	    "$WEST_TOP"/zephyr
+	# git fetch accepts anything, even 40-digits SHA but git clone is
+	# less flexible. So we git clone the default branch first to get
+	# started and then we switch to any 'z_ref' thanks to git fetch.
+	( set -x
+	  git clone --depth=5 "$init_remote" "$WEST_TOP"/zephyr
+	)
 
 	# To keep things simple, this moves to a detached HEAD even when
 	# init_ref is a (remote) branch.
 	test -z "$init_ref" ||
-	    zephyr_fetch_and_switch     origin   "${init_ref}"
+	    zephyr_fetch_and_switch  "${init_remote}"   "${init_ref}"
 
 	# This shows how to point CI at any Zephyr commit from anywhere
 	# and to run all tests on it. Simply edit remote and reference,
@@ -302,14 +313,15 @@ build_platforms()
 parse_args()
 {
 	local zeproj
-	unset zephyr_ref
+	unset zephyr_remote zephyr_ref
 	local OPTIND=1
 
 	# Parse -options
-	while getopts "acz:j:k:p:v" OPTION; do
+	while getopts "acu:z:j:k:p:v" OPTION; do
 		case "$OPTION" in
 			a) PLATFORMS=("${DEFAULT_PLATFORMS[@]}") ;;
 			c) DO_CLONE=yes ;;
+			u) zephyr_remote="$OPTARG" ;;
 			z) zephyr_ref="$OPTARG" ;;
 			j) BUILD_JOBS="$OPTARG" ;;
 			k) RIMAGE_KEY_OPT="$OPTARG" ;;
@@ -328,8 +340,8 @@ parse_args()
 	    die 'Cannot use -p with -c, -c supports %s only' "${SOF_TOP}/zephyrproject"
 	fi
 
-	if [ -n "$zephyr_ref" ] && [ -z "$DO_CLONE" ]; then
-	   die '%s' '-z without -c makes no sense'
+	if [ -n "$zephyr_remote" -o -n "$zephyr_ref" ] && [ -z "$DO_CLONE" ]; then
+	   die '%s' '-u or -z without -c makes no sense'
 	fi
 
 	if [ -n "$zeproj" ]; then
@@ -407,7 +419,7 @@ see https://docs.zephyrproject.org/latest/getting_started/index.html"
 		# Resolve symlinks
 		mkdir "$zep"; WEST_TOP=$( cd "$zep" && /bin/pwd )
 
-		west_init_update "${zephyr_ref}"
+		west_init_update "${zephyr_remote}" "${zephyr_ref}"
 
 	else
 		 # Look for Zephyr and define WEST_TOP


### PR DESCRIPTION
2 clean cherry-picks from main + unhardcoding the Zephyr commit. Review commits separately.

Zero functional change when you don't (try to) pass a zephyr commit on the command line.