### PR TITLE
topology1: sof-adl-rt1019-rt5682: add new topology

### DIFF
--- a/tools/topology/topology1/CMakeLists.txt
+++ b/tools/topology/topology1/CMakeLists.txt
@@ -154,6 +154,7 @@ set(TPLGS
 	"sof-tgl-max98357a-rt5682\;sof-adl-max98390-rt5682-rtnr\;-DCODEC=MAX98390\;-DFMT=s32le\;-DPLATFORM=adl\;-DAMP_SSP=1\;-DBT_OFFLOAD\;-DCHANNELS=2\;-DRTNR\;-DNOHOTWORD\;-DDMICPROC=rtnr\;-DNO16KDMIC\;-DDMIC_48k_CORE_ID=1"
 	"sof-tgl-max98357a-rt5682\;sof-adl-max98390-ssp2-rt5682-ssp0\;-DCODEC=MAX98390\;-DFMT=s32le\;-DPLATFORM=adl\;-DAMP_SSP=2"
 	"sof-tgl-max98357a-rt5682\;sof-adl-rt5682\;-DNO_AMP\;-DPLATFORM=adl"
+	"sof-tgl-max98357a-rt5682\;sof-adl-rt1019-rt5682\;-DCODEC=RT1019\;-DFMT=s16le\;-DPLATFORM=adl\;-DAMP_SSP=1"
 	"sof-tgl-max98373-rt5682\;sof-tgl-max98373-rt5682\;-DAMP_SSP=1"
 	"sof-tgl-max98373-rt5682\;sof-tgl-max98373-rt5682-igonr\;-DAMP_SSP=1\;-DIGO"
 	"sof-tgl-max98373-rt5682\;sof-tgl-max98373-rt5682-xperi\;-DAMP_SSP=1\;-DINCLUDE_IIR_EQ=1"

--- a/tools/topology/topology1/sof-tgl-max98357a-rt5682.m4
+++ b/tools/topology/topology1/sof-tgl-max98357a-rt5682.m4
@@ -419,7 +419,13 @@ ifelse(
 		SSP_CLOCK(bclk, 6144000, codec_slave),
 		SSP_CLOCK(fsync, 48000, codec_slave),
 		SSP_TDM(4, 32, 3, 15),
-	SSP_CONFIG_DATA(SSP, SPK_SSP_INDEX, 32)))',
+		SSP_CONFIG_DATA(SSP, SPK_SSP_INDEX, 32)))',
+	CODEC, `RT1019', `
+	SSP_CONFIG(I2S, SSP_CLOCK(mclk, 19200000, codec_mclk_in),
+                SSP_CLOCK(bclk, 1536000, codec_slave),
+                SSP_CLOCK(fsync, 48000, codec_slave),
+                SSP_TDM(2, 16, 3, 3),
+                SSP_CONFIG_DATA(SSP, SPK_SSP_INDEX, 16)))',
 	)')
 
 # SSP 0 (ID: 0)


### PR DESCRIPTION
for amplifier rt1019 SSP1 link is used
for headset rt5682 SSP0 link is used

Signed-off-by: Vamshi Krishna <vamshi.krishna.gopal@intel.com>