### PR TITLE
perf_cnt: add the tracing of window-based average calculation

### DIFF
--- a/Kconfig.sof
+++ b/Kconfig.sof
@@ -196,6 +196,17 @@ config PERFORMANCE_COUNTERS
 	  use the stamp() macro periodically to find out how long the cpu
 	  was in active/sleep state between the calls and estimate the cpu load.
 
+config PERFORMANCE_COUNTERS_RUN_AVERAGE
+	bool "Performance counters run average"
+	depends on PERFORMANCE_COUNTERS
+	default n
+	help
+	  Enables tracing of performance measurements with window-based average
+	  calculations. In addition to the usage of stamp(), the performance
+	  counter will compute the average number of cpu cycles/ticks spent
+	  within the window size of 1024 scheduled tasks and log it out via
+	  tracings.
+
 config DSP_RESIDENCY_COUNTERS
 	bool "DSP residency counters"
 	default n

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -231,7 +231,7 @@ enum {
 #endif /* #if defined(__ZEPHYR__) && defined(CONFIG_ZEPHYR_LOG) */
 
 #define comp_perf_info(pcd, comp_p)					\
-	comp_info(comp_p, "perf comp_copy peak plat %d cpu %d",		\
+	comp_info(comp_p, "perf comp_copy peak plat %u cpu %u",		\
 		  (uint32_t)((pcd)->plat_delta_peak),			\
 		  (uint32_t)((pcd)->cpu_delta_peak))
 

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -235,6 +235,11 @@ enum {
 		  (uint32_t)((pcd)->plat_delta_peak),			\
 		  (uint32_t)((pcd)->cpu_delta_peak))
 
+#define comp_perf_avg_info(pcd, comp_p)					\
+	comp_info(comp_p, "perf comp_copy cpu avg %u (current peak %u)",\
+		  (uint32_t)((pcd)->cpu_delta_sum),			\
+		  (uint32_t)((pcd)->cpu_delta_peak))
+
 /** @}*/
 
 /** \brief Type of endpoint this component is connected to in a pipeline */

--- a/src/include/sof/audio/component_ext.h
+++ b/src/include/sof/audio/component_ext.h
@@ -194,6 +194,7 @@ static inline int comp_copy(struct comp_dev *dev)
  */
 #ifndef __ZEPHYR__
 		perf_cnt_stamp(&dev->pcd, comp_perf_info, dev);
+		perf_cnt_average(&dev->pcd, comp_perf_avg_info, dev);
 #endif
 	}
 

--- a/src/lib/agent.c
+++ b/src/lib/agent.c
@@ -57,6 +57,16 @@ static void perf_sa_trace(struct perf_cnt_data *pcd, int ignored)
 		(uint32_t)((pcd)->plat_delta_peak),
 		(uint32_t)((pcd)->cpu_delta_peak));
 }
+
+#if CONFIG_PERFORMANCE_COUNTERS_RUN_AVERAGE
+static void perf_avg_sa_trace(struct perf_cnt_data *pcd, int ignored)
+{
+	tr_info(&sa_tr, "perf sys_load cpu avg %u (current peak %u)",
+		(uint32_t)((pcd)->cpu_delta_sum),
+		(uint32_t)((pcd)->cpu_delta_peak));
+}
+#endif
+
 #endif
 
 static enum task_state validate(void *data)
@@ -69,6 +79,7 @@ static enum task_state validate(void *data)
 	delta = current - sa->last_check;
 
 	perf_cnt_stamp(&sa->pcd, perf_sa_trace, 0 /* ignored */);
+	perf_cnt_average(&sa->pcd, perf_avg_sa_trace, 0 /* ignored */);
 
 #if CONFIG_AGENT_PANIC_ON_DELAY
 	/* panic timeout */

--- a/src/schedule/ll_schedule.c
+++ b/src/schedule/ll_schedule.c
@@ -85,6 +85,16 @@ static void perf_ll_sched_trace(struct perf_cnt_data *pcd, int ignored)
 		(uint32_t)((pcd)->plat_delta_peak),
 		(uint32_t)((pcd)->cpu_delta_peak));
 }
+
+#if CONFIG_PERFORMANCE_COUNTERS_RUN_AVERAGE
+static void perf_avg_ll_sched_trace(struct perf_cnt_data *pcd, int ignored)
+{
+	tr_info(&ll_tr, "perf ll_work cpu avg %u (current peak %u)",
+		(uint32_t)((pcd)->cpu_delta_sum),
+		(uint32_t)((pcd)->cpu_delta_peak));
+}
+#endif
+
 #endif
 
 static bool schedule_ll_is_pending(struct ll_schedule_data *sch)
@@ -315,6 +325,7 @@ static void schedule_ll_tasks_run(void *data)
 		       NOTIFIER_TARGET_CORE_LOCAL, NULL, 0);
 
 	perf_cnt_stamp(&sch->pcd, perf_ll_sched_trace, 0 /* ignored */);
+	perf_cnt_average(&sch->pcd, perf_avg_ll_sched_trace, 0 /* ignored */);
 
 	key = k_spin_lock(&domain->lock);
 


### PR DESCRIPTION
The average number of cpu cycles/ticks spent could be provided per 1024
scheduled tasks by the performance counter. It would be more accurate for
MCPS measurement than the peak number. Even so, the tracing macro will log
both of them to provide more insights.

This is enabled by CONFIG_PERFORMANCE_COUNTERS_RUN_AVERAGE, which depends
on CONFIG_PERFORMANCE_COUNTERS.