### PR TITLE
ipc4: copier: add multiple gateway support

### DIFF
--- a/src/drivers/intel/alh.c
+++ b/src/drivers/intel/alh.c
@@ -59,13 +59,22 @@ static int alh_set_config_blob(struct dai *dai, struct ipc_config_dai *common_co
 	struct alh_pdata *alh = dai_get_drvdata(dai);
 	struct sof_alh_configuration_blob *blob = spec_config;
 	struct ipc4_alh_multi_gtw_cfg *alh_cfg = &blob->alh_cfg;
+	int i;
 
 	dai_info(dai, "alh_set_config_blob()");
 
-	alh->params.channels = 2;
 	alh->params.rate = 48000;
-	/* the LSB 8bits are for stream id */
-	alh->params.stream_id = alh_cfg->mapping[0].alh_id & 0xff;
+
+	for (i = 0; i < alh_cfg->count; i++) {
+		/* the LSB 8bits are for stream id */
+		int alh_id = alh_cfg->mapping[i].alh_id & 0xff;
+
+		if (IPC4_ALH_DAI_INDEX(alh_id) == dai->index) {
+			alh->params.stream_id = alh_id;
+			alh->params.channels = popcount(alh_cfg->mapping[i].channel_mask);
+			break;
+		}
+	}
 
 	return 0;
 }

--- a/src/include/ipc4/alh.h
+++ b/src/include/ipc4/alh.h
@@ -30,6 +30,12 @@
 #define IPC4_ALH_MAX_NUMBER_OF_GTW 16
 #define IPC4_ALH_DAI_INDEX_OFFSET 7
 
+/* copier id = (group id << 4) + codec id + IPC4_ALH_DAI_INDEX_OFFSET
+ * dai_index = (group id << 8) + codec id;
+ */
+#define IPC4_ALH_DAI_INDEX(x) ((((x) & 0xF0) << DAI_NUM_ALH_BI_DIR_LINKS_GROUP) + \
+				(((x) & 0xF) - IPC4_ALH_DAI_INDEX_OFFSET))
+
 struct ipc4_alh_multi_gtw_cfg {
 	/* Number of single channels (valid items in mapping array). */
 	uint32_t count;

--- a/src/include/ipc4/copier.h
+++ b/src/include/ipc4/copier.h
@@ -183,6 +183,11 @@ union ipc4_cfg_param_id_data {
 
 #define IPC4_COPIER_MODULE_OUTPUT_PINS_COUNT		4
 
+/*
+ * Gateway can only be connected to input pin "0" or output pin "0".
+ */
+#define IPC4_COPIER_GATEWAY_PIN 0
+
 enum ipc4_copier_features {
 	/* ff FAST_MODE bit is set in CopierModuleCfg::copier_feature_mask then
 	 * copier is able to transfer more than ibs. This bit shall be set only if


### PR DESCRIPTION
There are some usage cases that multiple gateways are
used, such as two alh dais to support single stream on
some productions with two codecs to support two speakers.
In this case two dais config are included by one copier.

This patch enables multiple gateway support in one
copier and creates corresponding dai for these gateways.

Signed-off-by: Rander Wang <rander.wang@intel.com>