### PR TITLE
topology2: cavs-nocodec: Add support for MTL nocodec topology

### DIFF
--- a/tools/topology/topology2/cavs/CMakeLists.txt
+++ b/tools/topology/topology2/cavs/CMakeLists.txt
@@ -28,6 +28,9 @@ PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt.bin"
 # CAVS SSP topology for TGL
 "cavs-nocodec\;cavs-tgl-nocodec\;NUM_DMICS=2,\
 PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-cavs-tgl-nocodec.bin"
+# SSP topology for MTL
+"cavs-nocodec\;sof-mtl-nocodec\;PLATFORM=mtl,NUM_DMICS=2,\
+PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-ace-mtl-nocodec.bin"
 )
 
 # generate ABI for IPC4

--- a/tools/topology/topology2/cavs/cavs-nocodec.conf
+++ b/tools/topology/topology2/cavs/cavs-nocodec.conf
@@ -41,6 +41,12 @@ Define {
 	DMIC0_NAME			'NoCodec-6'
 	DMIC0_PCM_CAPS			'Passthrough Capture 13'
 	DMIC0_PIPELINE_STREAM_NAME	'copier.DMIC.14.1'
+	PLATFORM 			"none"
+}
+
+# override defaults with platform-specific config
+IncludeByKey.PLATFORM {
+	"mtl"	"platform/intel/mtl.conf"
 }
 
 # include DMIC config if needed.

--- a/tools/topology/topology2/cavs/platform/intel/mtl.conf
+++ b/tools/topology/topology2/cavs/platform/intel/mtl.conf
@@ -1,0 +1,4 @@
+# MTL-specific variable definitions
+Define {
+	DMIC_DRIVER_VERSION		3
+}


### PR DESCRIPTION
The key difference is the DMIC HW IP version.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>