### PR TITLE
IPC4: fix capture issue in CI test

### DIFF
--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -216,6 +216,7 @@ static int set_pipeline_state(uint32_t id, uint32_t cmd, bool *delayed, uint32_t
 	}
 
 	status = pcm_dev->pipeline->status;
+	*ppl_status = status;
 	/* source & sink components are set when pipeline is set to COMP_STATE_INIT */
 	if (status != COMP_STATE_INIT) {
 		int host_id;
@@ -261,6 +262,7 @@ static int set_pipeline_state(uint32_t id, uint32_t cmd, bool *delayed, uint32_t
 			if (ret < 0)
 				ret = IPC4_INVALID_REQUEST;
 
+			*ppl_status = COMP_STATE_READY;
 			return ret;
 		}
 
@@ -291,6 +293,7 @@ static int set_pipeline_state(uint32_t id, uint32_t cmd, bool *delayed, uint32_t
 			if (ret < 0)
 				ret = IPC4_INVALID_REQUEST;
 
+			*ppl_status = COMP_STATE_READY;
 			return ret;
 		}
 


### PR DESCRIPTION
This issue is found by CI capture test with Linux ipc4 driver.
 For a pipeline like module A <-> mixin <-> mixout, mixin is
first bound to mixout then bound to module A in CI test. The
original code assume that moudle A is first bound to mixin
 since windows driver always bind module from data source to
data sink.

Also need to update direction in each module