### PR TITLE
topology1: sof-hda-generic: remove digital paths

### DIFF
--- a/tools/topology/topology1/sof-hda-generic.m4
+++ b/tools/topology/topology1/sof-hda-generic.m4
@@ -46,8 +46,6 @@ define(PIPE_HEADSET_PLAYBACK, `sof/pipe-mixer-`HSPROC'-dai-playback.m4')
 #
 # PCM0P --> volume     (pipe 1) --> HDA Analog (HDA Analog playback)
 # PCM0C <-- volume, EQ (pipe 2) <-- HDA Analog (HDA Analog capture)
-# PCM1P --> volume     (pipe 3) --> HDA Digital (HDA Digital playback)
-# PCM1C <-- volume, EQ (pipe 4) <-- HDA Digital (HDA Digital capture)
 # PCM3  ----> volume (pipe 7) ----> iDisp1 (HDMI/DP playback, BE link 3)
 # PCM4  ----> Volume (pipe 8) ----> iDisp2 (HDMI/DP playback, BE link 4)
 # PCM5  ----> volume (pipe 9) ----> iDisp3 (HDMI/DP playback, BE link 5)
@@ -61,20 +59,6 @@ ifdef(`HSPROC_FILTER2', `define(PIPELINE_FILTER2, HSPROC_FILTER2)', `undefine(`P
 # 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-highpass-capture.m4,
 	2, 0, 2, s24le,
-	1000, 0, 0,
-	48000, 48000, 48000)
-
-# Low Latency playback pipeline 3 on PCM 1 using max 2 channels of s24le.
-# 1000us deadline with priority 0 on core 0
-PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
-	3, 1, 2, s24le,
-	1000, 0, 0,
-	48000, 48000, 48000)
-
-# Low Latency capture pipeline 4 on PCM 1 using max 2 channels of s24le.
-# 1000us deadline with priority 0 on core 0
-PIPELINE_PCM_ADD(sof/pipe-highpass-capture.m4,
-	4, 1, 2, s24le,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
@@ -132,20 +116,6 @@ DAI_ADD(sof/pipe-dai-capture.m4,
 	PIPELINE_SINK_2, 2, s32le,
 	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
-# playback DAI is HDA Digital using 2 periods
-# Dai buffers use s32le format, 1000us deadline with priority 0 on core 0
-DAI_ADD(sof/pipe-dai-playback.m4,
-        3, HDA, 2, Digital Playback and Capture,
-        PIPELINE_SOURCE_3, 2, s32le,
-        1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
-
-# capture DAI is HDA Digital using 2 periods
-# Dai buffers use s32le format, 1000us deadline with priority 0 on core 0
-DAI_ADD(sof/pipe-dai-capture.m4,
-        4, HDA, 3, Digital Playback and Capture,
-	PIPELINE_SINK_4, 2, s32le,
-	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
-
 # playback DAI is iDisp1 using 2 periods
 # Dai buffers use s32le format, 1000us deadline with priority 0 on core 0
 DAI_ADD(sof/pipe-dai-playback.m4,
@@ -177,7 +147,6 @@ SectionGraph."mixer-host" {
 }
 
 PCM_DUPLEX_ADD(HDA Analog, 0, PIPELINE_PCM_30, PIPELINE_PCM_2)
-PCM_DUPLEX_ADD(HDA Digital, 1, PIPELINE_PCM_3, PIPELINE_PCM_4)
 PCM_PLAYBACK_ADD(HDMI1, 3, PIPELINE_PCM_7)
 PCM_PLAYBACK_ADD(HDMI2, 4, PIPELINE_PCM_8)
 PCM_PLAYBACK_ADD(HDMI3, 5, PIPELINE_PCM_9)
@@ -189,8 +158,7 @@ PCM_PLAYBACK_ADD(HDMI3, 5, PIPELINE_PCM_9)
 # HDA outputs
 DAI_CONFIG(HDA, 0, 4, Analog Playback and Capture,
 	HDA_CONFIG(HDA_CONFIG_DATA(HDA, 0, 48000, 2)))
-DAI_CONFIG(HDA, 1, 5, Digital Playback and Capture,
-	HDA_CONFIG(HDA_CONFIG_DATA(HDA, 1, 48000, 2)))
+
 # 3 HDMI/DP outputs (ID: 3,4,5)
 DAI_CONFIG(HDA, 4, 1, iDisp1,
 	HDA_CONFIG(HDA_CONFIG_DATA(HDA, 4, 48000, 2)))


### PR DESCRIPTION
These paths are not well supported on all devices and lead to errors such as

17:06:06 kernel: HDA Digital: ASoC: dpcm_be_dai_startup() failed at Digital Playback and Capture (-22)
17:06:06 kernel: Digital Playback and Capture: __soc_pcm_open() failed (-22)
17:06:06 kernel: snd_hda_codec_conexant ehdaudio0D0: ASoC: error at snd_soc_dai_startup on Digital Codec DAI: -22
17:06:06 kernel: snd_hda_codec_conexant ehdaudio0D0: ASoC: error at snd_soc_dai_startup on Digital Codec DAI: -22
17:06:06 kernel: snd_hda_codec_conexant ehdaudio0D0: didn't find PCM for DAI Digital Codec DAI

We've already removed this digital path for IPC4/topology2, let's also remove this for topology1.

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>