### PR TITLE
platform: Rename module_init section

### DIFF
--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -655,7 +655,7 @@ static inline struct comp_dev *comp_alloc(const struct comp_driver *drv,
  *	DECLARE_MODULE(sys_*_init);
  */
 #define DECLARE_MODULE(init) __attribute__((__used__)) \
-	__section(".module_init") static void(*f##init)(void) = init
+	__section(".initcall") static void(*f##init)(void) = init
 #endif
 
 /** \name Component registration

--- a/src/platform/amd/renoir/renoir.x.in
+++ b/src/platform/amd/renoir/renoir.x.in
@@ -381,7 +381,7 @@ SECTIONS
   .module_init : ALIGN(4)
   {
    _module_init_start = ABSOLUTE(.);
-    *(*.module_init)
+    *(*.initcall)
     _module_init_end = ABSOLUTE(.);
   } >sof_sdram0 :sof_sdram0_phdr
 

--- a/src/platform/apollolake/apollolake.x.in
+++ b/src/platform/apollolake/apollolake.x.in
@@ -420,7 +420,7 @@ SECTIONS
   .module_init : ALIGN(4)
   {
     _module_init_start = ABSOLUTE(.);
-    *(*.module_init)
+    *(*.initcall)
     _module_init_end = ABSOLUTE(.);
   } >sof_fw :sof_fw_phdr
 

--- a/src/platform/baytrail/baytrail.x.in
+++ b/src/platform/baytrail/baytrail.x.in
@@ -391,7 +391,7 @@ SECTIONS
   .module_init : ALIGN(4)
   {
     _module_init_start = ABSOLUTE(.);
-    *(*.module_init)
+    *(*.initcall)
     _module_init_end = ABSOLUTE(.);
   } >sof_data :sof_data_phdr
 

--- a/src/platform/cannonlake/cannonlake.x.in
+++ b/src/platform/cannonlake/cannonlake.x.in
@@ -385,7 +385,7 @@ SECTIONS
   .module_init : ALIGN(4)
   {
     _module_init_start = ABSOLUTE(.);
-    *(*.module_init)
+    *(*.initcall)
     _module_init_end = ABSOLUTE(.);
   } >sof_fw :sof_fw_phdr
 

--- a/src/platform/haswell/haswell.x.in
+++ b/src/platform/haswell/haswell.x.in
@@ -399,7 +399,7 @@ SECTIONS
   .module_init : ALIGN(4)
   {
     _module_init_start = ABSOLUTE(.);
-    *(*.module_init)
+    *(*.initcall)
     _module_init_end = ABSOLUTE(.);
   } >sof_data :sof_data_phdr
   .data : ALIGN(4)

--- a/src/platform/icelake/icelake.x.in
+++ b/src/platform/icelake/icelake.x.in
@@ -389,7 +389,7 @@ SECTIONS
   .module_init : ALIGN(4)
   {
     _module_init_start = ABSOLUTE(.);
-    *(*.module_init)
+    *(*.initcall)
     _module_init_end = ABSOLUTE(.);
   } >sof_fw :sof_fw_phdr
 

--- a/src/platform/imx8/imx8.x.in
+++ b/src/platform/imx8/imx8.x.in
@@ -339,7 +339,7 @@ SECTIONS
   .module_init : ALIGN(4)
   {
    _module_init_start = ABSOLUTE(.);
-    *(*.module_init)
+    *(*.initcall)
     _module_init_end = ABSOLUTE(.);
   } >sof_sdram0 :sof_sdram0_phdr
 

--- a/src/platform/imx8m/imx8m.x.in
+++ b/src/platform/imx8m/imx8m.x.in
@@ -339,7 +339,7 @@ SECTIONS
   .module_init : ALIGN(4)
   {
    _module_init_start = ABSOLUTE(.);
-    *(*.module_init)
+    *(*.initcall)
     _module_init_end = ABSOLUTE(.);
   } >sof_sdram0 :sof_sdram0_phdr
 

--- a/src/platform/imx8ulp/imx8ulp.x.in
+++ b/src/platform/imx8ulp/imx8ulp.x.in
@@ -332,7 +332,7 @@ SECTIONS
   .module_init : ALIGN(4)
   {
    _module_init_start = ABSOLUTE(.);
-    *(*.module_init)
+    *(*.initcall)
     _module_init_end = ABSOLUTE(.);
   } >sof_sdram0 :sof_sdram0_phdr
 

--- a/src/platform/mt8186/mt8186.x.in
+++ b/src/platform/mt8186/mt8186.x.in
@@ -336,7 +336,7 @@ SECTIONS
   .module_init : ALIGN(4)
   {
    _module_init_start = ABSOLUTE(.);
-    *(*.module_init)
+    *(*.initcall)
     _module_init_end = ABSOLUTE(.);
   } >sof_sram :sof_sram_phdr
 

--- a/src/platform/mt8195/mt8195.x.in
+++ b/src/platform/mt8195/mt8195.x.in
@@ -298,7 +298,7 @@ SECTIONS
   .module_init : ALIGN(4)
   {
    _module_init_start = ABSOLUTE(.);
-    *(*.module_init)
+    *(*.initcall)
     _module_init_end = ABSOLUTE(.);
   } >sof_sram0 :sof_sram0_phdr
 

--- a/src/platform/suecreek/suecreek.x.in
+++ b/src/platform/suecreek/suecreek.x.in
@@ -387,7 +387,7 @@ SECTIONS
   .module_init : ALIGN(4)
   {
     _module_init_start = ABSOLUTE(.);
-    *(*.module_init)
+    *(*.initcall)
     _module_init_end = ABSOLUTE(.);
   } >sof_fw :sof_fw_phdr
 

--- a/src/platform/tigerlake/tigerlake.x.in
+++ b/src/platform/tigerlake/tigerlake.x.in
@@ -439,7 +439,7 @@ SECTIONS
   .module_init : ALIGN(4)
   {
     _module_init_start = ABSOLUTE(.);
-    *(*.module_init)
+    *(*.initcall)
     _module_init_end = ABSOLUTE(.);
   } >sof_fw :sof_fw_phdr
 


### PR DESCRIPTION
.module_init sections is used to keep all components constructor
functions.

Zephyr uses -ffunction-sections option which will create a section for
each function. Unfortunately, this creates a section named .module_init
for the function module_init() used to initialize the processing module
generic layer.

Thus, places module_init() in the constructor area named .module_init
which is wrong.

To avoid this we rename .module_init section for constructors to
.initcall.

Fixes: https://github.com/thesofproject/sof/issues/5662
Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>