### PR TITLE
ipc4: handler: ipc4_get_large_config_module_instance: Fixed handling of memory allocation error

### DIFF
--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -633,6 +633,7 @@ static int ipc4_get_large_config_module_instance(union ipc4_message_header *ipc4
 	const struct comp_driver *drv;
 	struct comp_dev *dev = NULL;
 	uint32_t data_offset;
+	void *response_buffer;
 	int ret;
 
 	memcpy_s(&config, sizeof(config), ipc4, sizeof(config));
@@ -685,9 +686,12 @@ static int ipc4_get_large_config_module_instance(union ipc4_message_header *ipc4
 	if (ret)
 		return ret;
 
-	msg_reply.tx_size = data_offset + sizeof(reply.data.dat);
-	msg_reply.tx_data = rballoc(0, SOF_MEM_CAPS_RAM, msg_reply.tx_size);
-	if (!msg_reply.tx_data) {
+	data_offset += sizeof(reply.data.dat);
+	response_buffer = rballoc(0, SOF_MEM_CAPS_RAM, data_offset);
+	if (response_buffer) {
+		msg_reply.tx_size = data_offset;
+		msg_reply.tx_data = response_buffer;
+	} else {
 		tr_err(&ipc_tr, "error: failed to allocate tx_data");
 		ret = IPC4_OUT_OF_MEMORY;
 	}
@@ -1021,7 +1025,7 @@ void ipc_cmd(ipc_cmd_hdr *_hdr)
 		reply.header.r.msg_tgt = in->r.msg_tgt;
 		reply.header.r.type = in->r.type;
 		if (msg_data.delayed_error)
-			reply.header.r.status = err;
+			reply.header.r.status = msg_data.delayed_error;
 		else
 			reply.header.r.status = err;
 


### PR DESCRIPTION
This PR fixes handling of memory allocation error in ipc4_get_large_config_module_instance function. The value returned by the rballoc function is stored in the global variable msg_reply.tx_data. If an allocation error occurs, the function returns an error, but tx_data is overwritten with null. This value is then used in the ipc_msg_send function which leads to null pointer reference.