### PR TITLE
Revert "ipc4: setdx: skip sending ipc response"

### DIFF
--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -1002,12 +1002,6 @@ void ipc_cmd(ipc_cmd_hdr *_hdr)
 
 	/* FW sends a ipc message to host if request bit is set*/
 	if (in->r.rsp == SOF_IPC4_MESSAGE_DIR_MSG_REQUEST) {
-		/**
-		 * If FW is on the path to D3 on primary core,
-		 * IPC response will be send during power down procedure.
-		 */
-		if (ipc_get()->pm_prepare_D3 && in->r.type == SOF_IPC4_MOD_SET_DX)
-			return;
 		char *data = ipc_get()->comp_data;
 		struct ipc4_message_reply reply;
 


### PR DESCRIPTION
This reverts commit 9b3715fc168aa547495917001735a3ced76b3419.

The commit causes the following error:
[  146.052617] sof-audio-pci-intel-tgl 0000:00:1f.3: ipc tx      : 0x47000000|0x0: MOD_SET_DX [data size: 8]
[  146.556588] sof-audio-pci-intel-tgl 0000:00:1f.3: ipc timed out for 0x47000000|0x0
[  146.556596] sof-audio-pci-intel-tgl 0000:00:1f.3: ctx_save IPC error: -110, proceeding with suspend

The reason is that for IPC4 the reply format is different compared to what
IPC3 is using and also the signaling is different.

If we skip sending the reply, there will be no reply going to be sent to
the host.

Signed-off-by: Peter Ujfalusi <peter.ujfalusi@linux.intel.com>