### PR TITLE
Audio: clean up stream data and processing functions in crossover on reset.

### DIFF
--- a/src/audio/crossover/crossover.c
+++ b/src/audio/crossover/crossover.c
@@ -835,6 +835,11 @@ static int crossover_reset(struct comp_dev *dev)
 
 	crossover_reset_state(cd);
 
+	cd->crossover_process = NULL;
+	cd->crossover_split = NULL;
+	cd->config = NULL;
+	cd->config_new = NULL;
+
 	comp_set_state(dev, COMP_TRIGGER_RESET);
 
 	return 0;


### PR DESCRIPTION
This PR contributes to issue #4488 