### PR TITLE
Audio: Clean up processing function and coefficients of dcblock on reset.

### DIFF
--- a/src/audio/dcblock/dcblock.c
+++ b/src/audio/dcblock/dcblock.c
@@ -382,6 +382,9 @@ static int dcblock_reset(struct comp_dev *dev)
 	comp_info(dev, "dcblock_reset()");
 
 	dcblock_init_state(cd);
+
+	cd->dcblock_func = NULL;
+
 	comp_set_state(dev, COMP_TRIGGER_RESET);
 
 	return 0;


### PR DESCRIPTION
This PR contributes to issues #4488 