### PR TITLE
tools: stop copying v2 topologies to the v1 directory

### DIFF
--- a/installer/GNUmakefile
+++ b/installer/GNUmakefile
@@ -260,6 +260,8 @@ ifneq (true,${BUILD_ONLY_ONCE})
 .PHONY: ${BUILD_TOOLS}
 endif
 
+# Deploy and release only "official", top-level topology files starting
+# with the 'sof-' prefix to avoid any experimental stuff.
 topologies: ${BUILD_TOOLS}
 	install ${INSTALL_OPTS}  -t ${STAGING_SOF_TPLG}${VERSION_SUFFIX}/ \
                ${BUILD_TOOLS}/topology/sof-*.tplg

--- a/tools/topology/topology1/CMakeLists.txt
+++ b/tools/topology/topology1/CMakeLists.txt
@@ -239,9 +239,7 @@ set(TPLGS
 # down.
 add_subdirectory(production)
 
-# "Install" all v1 production topologies two directory levels up. In the
-# future, v2 topologies will be "installed" instead in the same place so
-# users get upgraded without doing anything.
+# "Install" all v1 production topologies two directory levels up.
 add_custom_target(topologies1 ALL
     COMMAND ${CMAKE_COMMAND} -E copy_directory production ${SOF_TOPOLOGY_BINARY_DIRECTORY}
 )

--- a/tools/topology/topology2/CMakeLists.txt
+++ b/tools/topology/topology2/CMakeLists.txt
@@ -1,10 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
-add_custom_target(topologies2
-	COMMAND ${CMAKE_COMMAND} -E copy_directory cavs ${SOF_TOPOLOGY_BINARY_DIRECTORY}
-)
+add_custom_target(topologies2)
 
 # check alsatplg version and built topology2 if alsatplg version is 1.2.6 or greater
-# This will override any common topologies built with topology1
 execute_process(COMMAND alsatplg --version RESULT_VARIABLE STATUS OUTPUT_VARIABLE ALSA_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
 if(STATUS AND NOT STATUS EQUAL 0)
 	message(WARNING "alsatplg error: ${STATUS}, topology2 will be skipped")
@@ -16,10 +13,6 @@ else()
 		message(WARNING "topology2 will be skipped. Minimum required version for alsatplg: 1.2.6")
 	else()
 		add_dependencies(topologies topologies2)
-
-		# make sure topology1 always builds first so that the installed binaries from v2 override the ones from v1
-		add_dependencies(topologies2 topologies1)
-
 	endif()
 endif()
 

--- a/tools/topology/topology2/cavs/CMakeLists.txt
+++ b/tools/topology/topology2/cavs/CMakeLists.txt
@@ -39,7 +39,6 @@ execute_process(
 	OUTPUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/abi.conf
 )
 
-# This will override the topology1 binaries with topology2 binaries
 add_custom_target(topology2_cavs)
 add_dependencies(topologies2 topology2_cavs)
 


### PR DESCRIPTION
See the long and detailed commit message. See also deep buffer #4611 for more context.