### PR TITLE
Fix the IPC4 header extension usage

### DIFF
--- a/src/audio/google_hotword_detect.c
+++ b/src/audio/google_hotword_detect.c
@@ -114,7 +114,7 @@ static struct comp_dev *ghd_create(const struct comp_driver *drv,
 	cd->event.event_type = SOF_CTRL_EVENT_KD;
 	cd->event.num_elems = 0;
 
-	cd->msg = ipc_msg_init(cd->event.rhdr.hdr.cmd, sizeof(cd->event));
+	cd->msg = ipc_msg_init(cd->event.rhdr.hdr.cmd, cd->event.rhdr.size);
 	if (!cd->msg) {
 		comp_err(dev, "ghd_create(): ipc_msg_init failed");
 		goto cd_fail;

--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -657,7 +657,7 @@ static struct comp_dev *host_new(const struct comp_driver *drv,
 
 	ipc_build_stream_posn(&hd->posn, SOF_IPC_STREAM_POSITION, dev->ipc_config.id);
 
-	hd->msg = ipc_msg_init(hd->posn.rhdr.hdr.cmd, sizeof(hd->posn));
+	hd->msg = ipc_msg_init(hd->posn.rhdr.hdr.cmd, hd->posn.rhdr.hdr.size);
 	if (!hd->msg) {
 		comp_err(dev, "host_new(): ipc_msg_init failed");
 		dma_put(hd->dma);

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -744,7 +744,7 @@ static int mixin_bind(struct comp_dev *dev, void *data)
 
 	bu = (struct ipc4_module_bind_unbind *)data;
 	src_id = IPC4_COMP_ID(bu->header.r.module_id, bu->header.r.instance_id);
-	sink_id = IPC4_COMP_ID(bu->data.r.dst_module_id, bu->data.r.dst_instance_id);
+	sink_id = IPC4_COMP_ID(bu->header_ext.r.dst_module_id, bu->header_ext.r.dst_instance_id);
 
 	/* mixin -> mixout */
 	if (dev->ipc_config.id == src_id) {

--- a/src/audio/pipeline/pipeline-graph.c
+++ b/src/audio/pipeline/pipeline-graph.c
@@ -144,7 +144,7 @@ struct pipeline *pipeline_new(uint32_t pipeline_id, uint32_t priority, uint32_t 
 	/* just for retrieving valid ipc_msg header */
 	ipc_build_stream_posn(&posn, SOF_IPC_STREAM_TRIG_XRUN, p->comp_id);
 
-	p->msg = ipc_msg_init(posn.rhdr.hdr.cmd, sizeof(posn));
+	p->msg = ipc_msg_init(posn.rhdr.hdr.cmd, posn.rhdr.hdr.size);
 	if (!p->msg) {
 		pipe_err(p, "pipeline_new(): ipc_msg_init failed");
 		rfree(p);

--- a/src/drivers/intel/ace/ipc.c
+++ b/src/drivers/intel/ace/ipc.c
@@ -1,0 +1,323 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2016 Intel Corporation. All rights reserved.
+//
+// Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
+//         Keyon Jie <yang.jie@linux.intel.com>
+//         Rander Wang <rander.wang@intel.com>
+
+#include <ace/version.h>
+#include <sof/drivers/interrupt.h>
+#include <sof/ipc/driver.h>
+#include <sof/ipc/msg.h>
+#include <sof/ipc/schedule.h>
+#include <sof/lib/mailbox.h>
+#include <sof/lib/memory.h>
+#include <sof/lib/pm_runtime.h>
+#include <sof/lib/uuid.h>
+#include <sof/lib/wait.h>
+#include <sof/list.h>
+#include <sof/platform.h>
+#include <sof/schedule/edf_schedule.h>
+#include <sof/schedule/schedule.h>
+#include <sof/schedule/task.h>
+#include <sof/spinlock.h>
+#include <ipc/header.h>
+#include <ipc/regs_ipc_ace.h>
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#define ENABLE 1
+#define DISABLE 0
+
+/* 8fa1d42f-bc6f-464b-867f-547af08834da */
+DECLARE_SOF_UUID("ipc-task", ipc_task_uuid, 0x8fa1d42f, 0xbc6f, 0x464b,
+		 0x86, 0x7f, 0x54, 0x7a, 0xf0, 0x88, 0x34, 0xda);
+
+/* No private data for IPC */
+
+#if CONFIG_DEBUG_IPC_COUNTERS
+
+static inline void increment_ipc_received_counter(void)
+{
+	static uint32_t ipc_received_counter;
+
+	mailbox_sw_reg_write(SRAM_REG_FW_IPC_RECEIVED_COUNT,
+			     ipc_received_counter++);
+}
+
+static inline void increment_ipc_processed_counter(void)
+{
+	static uint32_t ipc_processed_counter;
+	uint32_t *uncache_counter = cache_to_uncache(&ipc_processed_counter);
+
+	mailbox_sw_reg_write(SRAM_REG_FW_IPC_PROCESSED_COUNT,
+			     (*uncache_counter)++);
+}
+
+#endif /* CONFIG_DEBUG_IPC_COUNTERS */
+
+/* test code to check working IRQ */
+static void ipc_irq_handler(void *arg)
+{
+	struct ipc *ipc = arg;
+	k_spinlock_key_t key;
+
+	key = k_spin_lock(&ipc->lock);
+
+	union DfIPCxTDR dipctdr;
+	union DfIPCxCTL dipcctl;
+	union DfIPCxIDA dipcida;
+
+	dipctdr.full = ipc_read(DfIPCxTDR_REG);
+	dipcctl.full = ipc_read(DfIPCxCTL_REG);
+	dipcida.full = ipc_read(DfIPCxIDA_REG);
+
+	/* TODO: add some debug messages here */
+
+	/* new message from host */
+	if (dipctdr.part.busy && dipcctl.part.ipctbie) {
+		/* mask Busy interrupt */
+		ipc_write(DfIPCxCTL_REG, dipcctl.full & ~1);
+
+#if CONFIG_DEBUG_IPC_COUNTERS
+		increment_ipc_received_counter();
+#endif
+		ipc_schedule_process(ipc);
+	}
+
+	/* reply message(done) from host */
+	if (dipcida.part.done) {
+		/* mask Done interrupt */
+		ipc_write(IPC_DIPCCTL,
+			  ipc_read(IPC_DIPCCTL) & ~IPC_DIPCCTL_IPCIDIE);
+
+		/* clear DONE bit - tell host we have completed the operation */
+		ipc_write(DfIPCxIDA_REG,
+				  ipc_read(DfIPCxIDA_REG) | IPC_DIPCTDA_DONE);
+
+		ipc->is_notification_pending = false;
+
+		/* unmask Done interrupt */
+		ipc_write(DfIPCxCTL_REG,
+			  ipc_read(DfIPCxCTL_REG) | IPC_DIPCCTL_IPCIDIE);
+	}
+
+	k_spin_unlock(&ipc->lock, key);
+}
+
+int ipc_platform_compact_read_msg(ipc_cmd_hdr *hdr, int words)
+{
+	uint32_t *chdr = (uint32_t *)hdr;
+
+	/* compact messages are 2 words on CAVS 1.8 onwards */
+	if (words != 2)
+		return 0;
+
+	chdr[0] = ipc_read(DfIPCxTDR_REG);
+	chdr[1] = ipc_read(DfIPCxTDDy_REG);
+
+	return 2; /* number of words read */
+}
+
+int ipc_platform_compact_write_msg(ipc_cmd_hdr *hdr, int words)
+{
+	uint32_t *chdr = (uint32_t *)hdr;
+
+	/* compact messages are 2 words on CAVS 1.8 onwards */
+	if (words != 2)
+		return 0;
+
+	/* command complete will set the busy/done bits */
+	ipc_write(IPC_DIPCTDR, chdr[0] & ~IPC_DIPCTDR_BUSY);
+	ipc_write(IPC_DIPCTDD, chdr[1]);
+
+	return 2; /* number of words written */
+}
+
+enum task_state ipc_platform_do_cmd(struct ipc *ipc)
+{
+	ipc_cmd_hdr *hdr;
+
+	hdr = ipc_compact_read_msg();
+
+	/* perform command */
+	ipc_cmd(hdr);
+
+	/* are we about to enter D3 ? */
+	if (ipc->pm_prepare_D3)
+		/* no return - memory will be powered off and IPC sent */
+		platform_pm_runtime_power_off();
+
+	return SOF_TASK_STATE_COMPLETED;
+}
+
+void ipc_platform_complete_cmd(struct ipc *ipc)
+{
+	/* write 1 to clear busy, and trigger interrupt to host*/
+	ipc_write(IPC_DIPCTDR, ipc_read(IPC_DIPCTDR) | IPC_DIPCTDR_BUSY);
+	ipc_write(IPC_DIPCTDA, ipc_read(IPC_DIPCTDA) | IPC_DIPCTDA_DONE);
+
+#if CONFIG_DEBUG_IPC_COUNTERS
+	increment_ipc_processed_counter();
+#endif
+
+	/* unmask Busy interrupt */
+	ipc_write(IPC_DIPCCTL, ipc_read(IPC_DIPCCTL) | IPC_DIPCCTL_IPCTBIE);
+}
+
+int ipc_platform_send_msg(const struct ipc_msg *msg)
+{
+	struct ipc *ipc = ipc_get();
+	ipc_cmd_hdr *hdr;
+
+	if (ipc->is_notification_pending ||
+	    ipc_read(IPC_DIPCIDR) & IPC_DIPCIDR_BUSY ||
+	    ipc_read(IPC_DIPCIDA) & IPC_DIPCIDA_DONE) {
+		return -EBUSY;
+	}
+
+	tr_dbg(&ipc_tr, "ipc: msg tx -> 0x%x", msg->header);
+
+	ipc->is_notification_pending = true;
+
+	/* prepare the message and copy to mailbox */
+	hdr = ipc_prepare_to_send(msg);
+
+	/* now interrupt host to tell it we have message sent */
+	ipc_write(IPC_DIPCIDD, hdr->dat[1]);
+	ipc_write(IPC_DIPCIDR, IPC_DIPCIDR_BUSY | hdr->dat[0]);
+
+	/* Clear request */
+	ipc_write(IPC_DIPCTDR, ipc_read(IPC_DIPCTDR) | IPC_DIPCTDR_BUSY);
+	ipc_write(IPC_DIPCTDA, ipc_read(IPC_DIPCTDA) & ~IPC_DIPCTDA_DONE);
+	return 0;
+}
+
+/*
+ * Used to enable IPC interrupt in the controller.
+ * TODO: make it a generic function as ACE FW ipc_controller_irq()
+ */
+static inline void
+ipc_controller_irq(bool operation)
+{
+	uint32_t dw_num = 0x00;
+	uint32_t mask = 1;
+	volatile uint16_t * const instancePtr =
+		(volatile uint16_t *) (MS_REG_HIPCIS);
+	volatile uint32_t * const dw_en = (uint32_t *)MS_BLOCK_DINTIP;
+	volatile uint32_t * const dw_mask = (uint32_t *)MS_REG_IRQ_INTMASK_L0;
+
+	if (operation == ENABLE) {
+		*instancePtr |= mask;
+		*dw_en |= BIT(dw_num);
+		*dw_mask &= ~BIT(dw_num);
+	} else {
+		*instancePtr &= ~mask;
+		*dw_en &= ~BIT(dw_num);
+		*dw_mask |= BIT(dw_num);
+	}
+}
+
+int platform_ipc_init(struct ipc *ipc)
+{
+	ipc_set_drvdata(ipc, NULL);
+
+	/* schedule task */
+	schedule_task_init_edf(&ipc->ipc_task, SOF_UUID(ipc_task_uuid),
+			       &ipc_task_ops, ipc, 0, 0);
+
+	interrupt_register(PLATFORM_IPC_INTERRUPT, ipc_irq_handler, ipc);
+	interrupt_enable(LVL_2_IRQ_NUMBER, ipc);
+
+	/* enable IPC interrupts from host */
+	ipc_write(DfIPCxCTL_REG, IPC_DIPCCTL_IPCIDIE | IPC_DIPCCTL_IPCTBIE);
+	ipc_controller_irq(ENABLE);
+
+	return 0;
+}
+
+#if CONFIG_IPC_POLLING
+
+int ipc_platform_poll_init(void)
+{
+	return 0;
+}
+
+/* tell host we have completed command */
+void ipc_platform_poll_set_cmd_done(void)
+{
+	/* write 1 to clear busy, and trigger interrupt to host*/
+	ipc_write(IPC_DIPCTDR, ipc_read(IPC_DIPCTDR) | IPC_DIPCTDR_BUSY);
+	ipc_write(IPC_DIPCTDA, ipc_read(IPC_DIPCTDA) | IPC_DIPCTDA_DONE);
+
+	/* unmask Busy interrupt */
+	ipc_write(IPC_DIPCCTL, ipc_read(IPC_DIPCCTL) | IPC_DIPCCTL_IPCTBIE);
+}
+
+/* read the IPC register for any new command messages */
+int ipc_platform_poll_is_cmd_pending(void)
+{
+	uint32_t dipcctl = ipc_read(IPC_DIPCCTL);
+	uint32_t dipctdr = ipc_read(IPC_DIPCTDR);
+
+	/* new message from host */
+	if (dipctdr & IPC_DIPCTDR_BUSY && dipcctl & IPC_DIPCCTL_IPCTBIE) {
+		/* mask Busy interrupt */
+		ipc_write(IPC_DIPCCTL, dipcctl & ~IPC_DIPCCTL_IPCTBIE);
+
+		/* new message */
+		return 1;
+	}
+
+	/* no new message */
+	return 0;
+}
+
+int ipc_platform_poll_is_host_ready(void)
+{
+	uint32_t dipcida = ipc_read(IPC_DIPCIDA);
+
+	/* reply message(done) from host */
+	if (dipcida & IPC_DIPCIDA_DONE) {
+		/* mask Done interrupt */
+		ipc_write(IPC_DIPCCTL,
+			  ipc_read(IPC_DIPCCTL) & ~IPC_DIPCCTL_IPCIDIE);
+
+		/* clear DONE bit - tell host we have completed the operation */
+		ipc_write(IPC_DIPCIDA,
+			  ipc_read(IPC_DIPCIDA) | IPC_DIPCIDA_DONE);
+
+		/* unmask Done interrupt */
+		ipc_write(IPC_DIPCCTL,
+			  ipc_read(IPC_DIPCCTL) | IPC_DIPCCTL_IPCIDIE);
+
+		/* host has completed */
+		return 1;
+	}
+
+	/* host still pending */
+	return 0;
+}
+
+int ipc_platform_poll_tx_host_msg(struct ipc_msg *msg)
+{
+	if (ipc_read(IPC_DIPCIDR) & IPC_DIPCIDR_BUSY ||
+	    ipc_read(IPC_DIPCIDA) & IPC_DIPCIDA_DONE)
+		/* cant send message atm */
+		return 0;
+
+	/* now send the message */
+	mailbox_dspbox_write(0, msg->tx_data, msg->tx_size);
+
+	/* now interrupt host to tell it we have message sent */
+	ipc_write(IPC_DIPCIDD, 0);
+	ipc_write(IPC_DIPCIDR, IPC_DIPCIDR_BUSY | msg->header);
+
+	/* message sent */
+	return 1;
+}
+
+#endif /* CONFIG_IPC_POLLING */

--- a/src/include/ipc4/header.h
+++ b/src/include/ipc4/header.h
@@ -94,23 +94,26 @@ enum ipc4_message_type {
  * When msg_tgt is SOF_IPC4_MESSAGE_TARGET_FW_GEN_MSG then type is
  * enum ipc4_message_type.
  */
-union ipc4_message_header {
-	uint32_t dat;
+struct ipc4_message_header {
+	union  {
+		uint32_t dat;
 
-	struct {
-		uint32_t rsvd0 : 24;
+		struct {
+			uint32_t rsvd0 : 24;
 
-		/**< One of Global::Type */
-		uint32_t type : 5;
+			/**< One of Global::Type */
+			uint32_t type : 5;
 
-		/**< Msg::MSG_REQUEST */
-		uint32_t rsp : 1;
+			/**< Msg::MSG_REQUEST */
+			uint32_t rsp : 1;
 
-		/**< Msg::FW_GEN_MSG */
-		uint32_t msg_tgt : 1;
+			/**< Msg::FW_GEN_MSG */
+			uint32_t msg_tgt : 1;
 
-		uint32_t _reserved_0 : 1;
-	} r;
+			uint32_t _reserved_0 : 1;
+		} r;
+	};
+	uint32_t header_ext;
 } __attribute__((packed, aligned(4)));
 
 struct ipc4_message_reply {
@@ -134,6 +137,8 @@ struct ipc4_message_reply {
 			uint32_t _reserved_0 : 1;
 		} r;
 	} header;
+
+	uint32_t header_ext;
 
 	union {
 		uint32_t dat;

--- a/src/include/ipc4/module.h
+++ b/src/include/ipc4/module.h
@@ -142,7 +142,7 @@ struct ipc4_module_init_instance {
 			uint32_t extended_init      : 1;
 			uint32_t _hw_reserved_2     : 2;
 		} r;
-	} data;
+	} header_ext;
 
 	struct ipc4_module_init_ext_init ext_init;
 	struct ipc4_module_init_ext_data ext_data;
@@ -197,7 +197,7 @@ struct ipc4_module_bind_unbind {
 			uint32_t src_queue : SOF_IPC4_SRC_QUEUE_ID_BITFIELD_SIZE;
 			uint32_t _reserved_2 : 2;
 		} r;
-	} data;
+	} header_ext;
 } __attribute__((packed, aligned(4)));
 
 struct ipc4_module_large_config {
@@ -233,7 +233,7 @@ struct ipc4_module_large_config {
 			uint32_t init_block : 1;
 			uint32_t _reserved_2 : 2;
 		} r;
-	} data;
+	} header_ext;
 } __attribute__((packed, aligned(4)));
 
 struct ipc4_module_large_config_reply {
@@ -266,7 +266,7 @@ struct ipc4_module_large_config_reply {
 			uint32_t init_block : 1;
 			uint32_t _reserved_2 : 2;
 		} r;
-	} data;
+	} header_ext;
 } __attribute__((packed, aligned(4)));
 
 struct ipc4_module_delete_instance {
@@ -293,7 +293,7 @@ struct ipc4_module_delete_instance {
 			uint32_t rsvd : 30;
 			uint32_t _reserved_1 : 2;
 		} r;
-	} data;
+	} header_ext;
 } __attribute__((packed, aligned(4)));
 
 struct ipc4_module_set_d0ix {
@@ -331,7 +331,7 @@ struct ipc4_module_set_d0ix {
 			uint32_t rsvd1			: 26;
 			uint32_t _reserved_2	: 2;
 		} r;
-	} data;
+	} header_ext;
 } __attribute__((packed, aligned(4)));
 
 struct ipc4_dx_state_info {
@@ -370,7 +370,7 @@ struct ipc4_module_set_dx {
 			uint32_t rsvd				: 30;
 			uint32_t _reserved_2		: 2;
 		} r;
-	} data;
+	} header_ext;
 } __attribute__((packed, aligned(4)));
 
 #define IPC4_COMP_ID(x, y)	((x) << 16 | (y))

--- a/src/include/ipc4/pipeline.h
+++ b/src/include/ipc4/pipeline.h
@@ -108,7 +108,7 @@ struct ipc4_pipeline_create {
 			uint32_t rsvd2          : 10;
 			uint32_t _reserved_2    : 2;
 		} r;
-	} data;
+	} header_ext;
 } __attribute__((packed, aligned(4)));
 
 /*!
@@ -147,7 +147,7 @@ struct ipc4_pipeline_delete {
 			uint32_t rsvd1          : 30;
 			uint32_t _reserved_2    : 2;
 		} r;
-	} data;
+	} header_ext;
 } __attribute__((packed, aligned(4)));
 
 /*!
@@ -212,7 +212,7 @@ struct ipc4_pipeline_set_state {
 			uint32_t rsvd1      : 28;
 			uint32_t _reserved_2: 2;
 		} r;
-	} data;
+	} header_ext;
 
 	/* multiple pipeline states */
 	struct ipc4_pipeline_set_state_data s_data;
@@ -249,7 +249,7 @@ struct ipc4_pipeline_set_state_reply {
 			uint32_t ppl_id     : 30;
 			uint32_t _reserved_2: 2;
 		} r;
-	} data;
+	} header_ext;
 } __attribute__((packed, aligned(4)));
 
 /**< This IPC message is sent to the FW in order to retrieve a pipeline state. */
@@ -279,7 +279,7 @@ struct ipc4_pipeline_get_state {
 			uint32_t rsvd1      : 30;
 			uint32_t _reserved_2: 2;
 		} r;
-	} data;
+	} header_ext;
 } __attribute__((packed, aligned(4)));
 
 /**< Sent by the FW in response to GetPipelineState. */
@@ -310,7 +310,7 @@ struct ipc4_pipeline_get_state_reply {
 			uint32_t rsvd1      : 25;
 			uint32_t _reserved_2: 2;
 		} r;
-	} data;
+	} header_ext;
 } __attribute__((packed, aligned(4)));
 
 /*!
@@ -345,7 +345,7 @@ struct ipc4_pipeline_get_context_size {
 			uint32_t rsvd1          : 30;
 			uint32_t _reserved_2    : 2;
 		} r;
-	} data;
+	} header_ext;
 } __attribute__((packed, aligned(4)));
 
 /**< Reply to Get Pipeline Context Size. */
@@ -376,7 +376,7 @@ struct ipc4_pipeline_get_context_size_reply {
 			uint32_t rsvd1      : 14;
 			uint32_t _reserved_2: 2;
 		} r;
-	} data;
+	} header_ext;
 } __attribute__((packed, aligned(4)));
 
 struct ipc4_chain_dma {
@@ -413,7 +413,7 @@ struct ipc4_chain_dma {
 			uint32_t rsvd1		: 6;
 			uint32_t _reserved_2		: 2;
 		} r;
-	} data;
+	} header_ext;
 } __attribute__((packed, aligned(4)));
 
 #endif

--- a/src/include/sof/ipc/common.h
+++ b/src/include/sof/ipc/common.h
@@ -23,7 +23,9 @@ struct dma_sg_elem_array;
 struct ipc_msg;
 
 /* generic IPC header regardless of ABI MAJOR type that is always 4 byte aligned */
-typedef uint32_t ipc_cmd_hdr;
+typedef struct ipc_cmd_hdr_ {
+	uint32_t dat[2];
+} ipc_cmd_hdr;
 
 /*
  * Common IPC logic uses standard types for abstract IPC features. This means all ABI MAJOR
@@ -34,7 +36,7 @@ typedef uint32_t ipc_cmd_hdr;
 #define ipc_from_hdr(x) ((struct sof_ipc_cmd_hdr *)x)
 #elif CONFIG_IPC_MAJOR_4
 #include <ipc4/header.h>
-#define ipc_from_hdr(x) ((union ipc4_message_header *)x)
+#define ipc_from_hdr(x) ((struct ipc4_message_header *)x)
 #else
 #error "No or invalid IPC MAJOR version selected."
 #endif
@@ -158,7 +160,7 @@ int ipc_dai_data_config(struct comp_dev *dev);
  * @param[in] header header.
  * @param[in] data data.
  */
-void ipc_boot_complete_msg(ipc_cmd_hdr *header, uint32_t *data);
+void ipc_boot_complete_msg(ipc_cmd_hdr *header);
 
 /**
  * \brief Read a compact IPC message or return NULL for normal message.

--- a/src/include/sof/ipc/msg.h
+++ b/src/include/sof/ipc/msg.h
@@ -30,6 +30,7 @@ struct dma_sg_elem_array;
 
 struct ipc_msg {
 	uint32_t header;	/* specific to platform */
+	uint32_t header_ext; /* extension specific to platform */
 	uint32_t tx_size;	/* payload size in bytes */
 	void *tx_data;		/* pointer to payload data */
 	struct list_item list;
@@ -38,28 +39,20 @@ struct ipc_msg {
 /**
  * \brief Initialise a new IPC message.
  * @param header Message header metadata
- * @param size Message size in bytes.
+ * @param header_ext Message header extension metadata
+ * @param size Message data size in bytes.
+ * @return New IPC message.
+ */
+struct ipc_msg *ipc_msg_w_ext_init(uint32_t header, uint32_t header_ext, uint32_t size);
+/**
+ * \brief Initialise a new IPC message.
+ * @param header Message header metadata
+ * @param size Message data size in bytes.
  * @return New IPC message.
  */
 static inline struct ipc_msg *ipc_msg_init(uint32_t header, uint32_t size)
 {
-	struct ipc_msg *msg;
-
-	msg = rzalloc(SOF_MEM_ZONE_RUNTIME_SHARED, 0, SOF_MEM_CAPS_RAM, sizeof(*msg));
-	if (!msg)
-		return NULL;
-
-	msg->tx_data = rzalloc(SOF_MEM_ZONE_RUNTIME_SHARED, 0, SOF_MEM_CAPS_RAM, size);
-	if (!msg->tx_data) {
-		rfree(msg);
-		return NULL;
-	}
-
-	msg->header = header;
-	msg->tx_size = size;
-	list_init(&msg->list);
-
-	return msg;
+	return ipc_msg_w_ext_init(header, 0, size);
 }
 
 /**

--- a/src/platform/intel/ace/platform.c
+++ b/src/platform/intel/ace/platform.c
@@ -1,0 +1,558 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2022 Intel Corporation. All rights reserved.
+//
+// Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
+//         Keyon Jie <yang.jie@linux.intel.com>
+//         Rander Wang <rander.wang@intel.com>
+//         Janusz Jankowski <janusz.jankowski@linux.intel.com>
+
+#include <ace/version.h>
+#if CONFIG_CAVS_LPS
+#include <ace/lps_wait.h>
+#endif /* CONFIG_CAVS_LPS */
+#include <ace/mem_window.h>
+#include <sof/common.h>
+#include <sof/compiler_info.h>
+#include <sof/debug/debug.h>
+#include <sof/drivers/dw-dma.h>
+#include <sof/drivers/idc.h>
+#include <sof/drivers/interrupt.h>
+#include <sof/ipc/common.h>
+#include <sof/drivers/timer.h>
+#include <sof/fw-ready-metadata.h>
+#include <sof/lib/agent.h>
+#include <sof/lib/cache.h>
+#include <sof/lib/clk.h>
+#include <sof/lib/cpu.h>
+#include <sof/lib/dai.h>
+#include <sof/lib/dma.h>
+#include <sof/lib/io.h>
+#include <sof/lib/mailbox.h>
+#include <sof/lib/memory.h>
+#include <sof/lib/mm_heap.h>
+#include <sof/lib/notifier.h>
+#include <sof/lib/pm_runtime.h>
+#include <sof/lib/wait.h>
+#include <sof/platform.h>
+#include <sof/schedule/edf_schedule.h>
+#include <sof/schedule/ll_schedule.h>
+#include <sof/schedule/ll_schedule_domain.h>
+#include <sof/trace/dma-trace.h>
+#include <sof/trace/trace.h>
+#include <ipc/header.h>
+#include <ipc/info.h>
+#include <kernel/abi.h>
+#include <kernel/ext_manifest.h>
+
+#include <sof_versions.h>
+#include <errno.h>
+#include <stdint.h>
+
+static const struct sof_ipc_fw_ready ready
+	__section(".fw_ready") = {
+	.hdr = {
+		.cmd = SOF_IPC_FW_READY,
+		.size = sizeof(struct sof_ipc_fw_ready),
+	},
+	.version = {
+		.hdr.size = sizeof(struct sof_ipc_fw_version),
+		.micro = SOF_MICRO,
+		.minor = SOF_MINOR,
+		.major = SOF_MAJOR,
+/* opt-in; reproducible build by default */
+#if BLD_COUNTERS
+		.build = SOF_BUILD, /* See version-build-counter.cmake */
+		.date = __DATE__,
+		.time = __TIME__,
+#else /* BLD_COUNTERS */
+		.build = -1,
+		.date = "dtermin.\0",
+		.time = "fwready.\0",
+#endif /* BLD_COUNTERS */
+		.tag = SOF_TAG,
+		.abi_version = SOF_ABI_VERSION,
+		.src_hash = SOF_SRC_HASH,
+	},
+#if CONFIG_CAVS_IMR_D3_PERSISTENT
+	.flags = DEBUG_SET_FW_READY_FLAGS | SOF_IPC_INFO_D3_PERSISTENT,
+#else /* CONFIG_CAVS_IMR_D3_PERSISTENT */
+	.flags = DEBUG_SET_FW_READY_FLAGS,
+#endif /* CONFIG_CAVS_IMR_D3_PERSISTENT */
+};
+
+#if CONFIG_MEM_WND
+
+#define SRAM_WINDOW_HOST_OFFSET(x) (0x80000 + x * 0x20000)
+#define NUM_WINDOWS 7
+
+const struct ext_man_windows xsram_window
+		__aligned(EXT_MAN_ALIGN) __section(".fw_metadata") __unused = {
+	.hdr = {
+		.type = EXT_MAN_ELEM_WINDOW,
+		.elem_size = ALIGN_UP_COMPILE(sizeof(struct ext_man_windows), EXT_MAN_ALIGN),
+	},
+	.window = {
+		.ext_hdr	= {
+			.hdr.cmd = SOF_IPC_FW_READY,
+			.hdr.size = sizeof(struct sof_ipc_window),
+			.type	= SOF_IPC_EXT_WINDOW,
+		},
+		.num_windows	= NUM_WINDOWS,
+		.window	= {
+			{
+				.type	= SOF_IPC_REGION_REGS,
+				.id	= 0,	/* map to host window 0 */
+				.flags	= 0, // TODO: set later
+				.size	= MAILBOX_SW_REG_SIZE,
+				.offset	= 0,
+			},
+			{
+				.type	= SOF_IPC_REGION_UPBOX,
+				.id	= 0,	/* map to host window 0 */
+				.flags	= 0, // TODO: set later
+				.size	= MAILBOX_DSPBOX_SIZE,
+				.offset	= MAILBOX_SW_REG_SIZE,
+			},
+			{
+				.type	= SOF_IPC_REGION_DOWNBOX,
+				.id	= 1,	/* map to host window 1 */
+				.flags	= 0, // TODO: set later
+				.size	= MAILBOX_HOSTBOX_SIZE,
+				.offset	= 0,
+			},
+			{
+				.type	= SOF_IPC_REGION_DEBUG,
+				.id	= 2,	/* map to host window 2 */
+				.flags	= 0, // TODO: set later
+				.size	= MAILBOX_DEBUG_SIZE,
+				.offset	= 0,
+			},
+			{
+				.type	= SOF_IPC_REGION_EXCEPTION,
+				.id	= 2,	/* map to host window 2 */
+				.flags	= 0, // TODO: set later
+				.size	= MAILBOX_EXCEPTION_SIZE,
+				.offset	= MAILBOX_EXCEPTION_OFFSET,
+			},
+			{
+				.type	= SOF_IPC_REGION_STREAM,
+				.id	= 2,	/* map to host window 2 */
+				.flags	= 0, // TODO: set later
+				.size	= MAILBOX_STREAM_SIZE,
+				.offset	= MAILBOX_STREAM_OFFSET,
+			},
+			{
+				.type	= SOF_IPC_REGION_TRACE,
+				.id	= 3,	/* map to host window 3 */
+				.flags	= 0, // TODO: set later
+				.size	= MAILBOX_TRACE_SIZE,
+				.offset	= 0,
+			},
+		},
+	},
+};
+
+#endif /* CONFIG_MEM_WND */
+
+#if CONFIG_CAVS_LPRO_ONLY
+#define CAVS_DEFAULT_RO		SHIM_CLKCTL_RLROSCC
+#define CAVS_DEFAULT_RO_FOR_MEM	SHIM_CLKCTL_OCS_LP_RING
+#else /* CONFIG_CAVS_LPRO_ONLY */
+#define CAVS_DEFAULT_RO		SHIM_CLKCTL_RHROSCC
+#define CAVS_DEFAULT_RO_FOR_MEM	SHIM_CLKCTL_OCS_HP_RING
+#endif /* CONFIG_CAVS_LPRO_ONLY */
+
+#if CONFIG_DW_GPIO
+
+#include <sof/drivers/gpio.h>
+
+const struct gpio_pin_config gpio_data[] = {
+	{	/* GPIO0 */
+		.mux_id = 1,
+		.mux_config = {.bit = 0, .mask = 3, .fn = 1},
+	}, {	/* GPIO1 */
+		.mux_id = 1,
+		.mux_config = {.bit = 2, .mask = 3, .fn = 1},
+	}, {	/* GPIO2 */
+		.mux_id = 1,
+		.mux_config = {.bit = 4, .mask = 3, .fn = 1},
+	}, {	/* GPIO3 */
+		.mux_id = 1,
+		.mux_config = {.bit = 6, .mask = 3, .fn = 1},
+	}, {	/* GPIO4 */
+		.mux_id = 1,
+		.mux_config = {.bit = 8, .mask = 3, .fn = 1},
+	}, {	/* GPIO5 */
+		.mux_id = 1,
+		.mux_config = {.bit = 10, .mask = 3, .fn = 1},
+	}, {	/* GPIO6 */
+		.mux_id = 1,
+		.mux_config = {.bit = 12, .mask = 3, .fn = 1},
+	}, {	/* GPIO7 */
+		.mux_id = 1,
+		.mux_config = {.bit = 14, .mask = 3, .fn = 1},
+	}, {	/* GPIO8 */
+		.mux_id = 1,
+		.mux_config = {.bit = 16, .mask = 1, .fn = 1},
+	}, {	/* GPIO9 */
+		.mux_id = 0,
+		.mux_config = {.bit = 11, .mask = 1, .fn = 1},
+	}, {	/* GPIO10 */
+		.mux_id = 0,
+		.mux_config = {.bit = 11, .mask = 1, .fn = 1},
+	}, {	/* GPIO11 */
+		.mux_id = 0,
+		.mux_config = {.bit = 11, .mask = 1, .fn = 1},
+	}, {	/* GPIO12 */
+		.mux_id = 0,
+		.mux_config = {.bit = 11, .mask = 1, .fn = 1},
+	}, {	/* GPIO13 */
+		.mux_id = 0,
+		.mux_config = {.bit = 0, .mask = 1, .fn = 1},
+	}, {	/* GPIO14 */
+		.mux_id = 0,
+		.mux_config = {.bit = 1, .mask = 1, .fn = 1},
+	}, {	/* GPIO15 */
+		.mux_id = 0,
+		.mux_config = {.bit = 9, .mask = 1, .fn = 1},
+	}, {	/* GPIO16 */
+		.mux_id = 0,
+		.mux_config = {.bit = 9, .mask = 1, .fn = 1},
+	}, {	/* GPIO17 */
+		.mux_id = 0,
+		.mux_config = {.bit = 9, .mask = 1, .fn = 1},
+	}, {	/* GPIO18 */
+		.mux_id = 0,
+		.mux_config = {.bit = 9, .mask = 1, .fn = 1},
+	}, {	/* GPIO19 */
+		.mux_id = 0,
+		.mux_config = {.bit = 10, .mask = 1, .fn = 1},
+	}, {	/* GPIO20 */
+		.mux_id = 0,
+		.mux_config = {.bit = 10, .mask = 1, .fn = 1},
+	}, {	/* GPIO21 */
+		.mux_id = 0,
+		.mux_config = {.bit = 10, .mask = 1, .fn = 1},
+	}, {	/* GPIO22 */
+		.mux_id = 0,
+		.mux_config = {.bit = 10, .mask = 1, .fn = 1},
+	}, {	/* GPIO23 */
+		.mux_id = 0,
+		.mux_config = {.bit = 16, .mask = 1, .fn = 1},
+	}, {	/* GPIO24 */
+		.mux_id = 0,
+		.mux_config = {.bit = 16, .mask = 1, .fn = 1},
+	}, {	/* GPIO25 */
+		.mux_id = 0,
+		.mux_config = {.bit = 26, .mask = 1, .fn = 1},
+	},
+};
+
+const int n_gpios = ARRAY_SIZE(gpio_data);
+
+#if CONFIG_INTEL_IOMUX
+
+#include <sof/drivers/iomux.h>
+
+struct iomux iomux_data[] = {
+	{.base = EXT_CTRL_BASE + 0x30,},
+	{.base = EXT_CTRL_BASE + 0x34,},
+	{.base = EXT_CTRL_BASE + 0x38,},
+};
+
+const int n_iomux = ARRAY_SIZE(iomux_data);
+
+#endif /* CONFIG_INTEL_IOMUX */
+
+#endif /* CONFIG_DW_GPIO */
+
+#ifndef __ZEPHYR__
+static SHARED_DATA struct timer timer = {
+	.id = TIMER3, /* external timer */
+	.irq = IRQ_EXT_TSTAMP0_LVL2,
+	.irq_name = irq_name_level2,
+};
+
+static SHARED_DATA struct timer arch_timers[CONFIG_CORE_COUNT];
+#endif
+
+#if CONFIG_DW_SPI
+
+#include <sof/drivers/spi.h>
+
+static struct spi_platform_data spi = {
+	.base		= DW_SPI_SLAVE_BASE,
+	.type		= SOF_SPI_INTEL_SLAVE,
+	.fifo[SPI_DIR_RX] = {
+		.handshake	= DMA_HANDSHAKE_SSI_RX,
+	},
+	.fifo[SPI_DIR_TX] = {
+		.handshake	= DMA_HANDSHAKE_SSI_TX,
+	}
+};
+
+int platform_boot_complete(uint32_t boot_message)
+{
+	return spi_push(spi_get(SOF_SPI_INTEL_SLAVE), &ready, sizeof(ready));
+}
+
+#else /* CONFIG_DW_SPI */
+
+int platform_boot_complete(uint32_t boot_message)
+{
+	ipc_cmd_hdr header;
+	uint32_t data;
+
+	mailbox_dspbox_write(0, &ready, sizeof(ready));
+
+	/* get any IPC specific boot message and optional data */
+	data = SRAM_WINDOW_HOST_OFFSET(0) >> 12;
+	ipc_boot_complete_msg(&header);
+
+	/* tell host we are ready */
+	ipc_write(DfIPCxIDDy_REG, header.dat[0]);
+	ipc_write(DfIPCxIDR_REG, IPC_DIPCIDR_BUSY | header.dat[0]);
+
+	return 0;
+}
+
+#endif /* CONFIG_DW_SPI */
+
+/* init HW  */
+static void platform_init_hw(void)
+{
+	io_reg_write(DSP_INIT_GENO,
+		GENO_MDIVOSEL | GENO_DIOPTOSEL);
+
+	io_reg_write(DSP_INIT_IOPO,
+		IOPO_DMIC_FLAG | IOPO_I2S_FLAG);
+
+	io_reg_write(DSP_INIT_LPGPDMA(0),
+		LPGPDMA_CHOSEL_FLAG | LPGPDMA_CTLOSEL_FLAG);
+	io_reg_write(DSP_INIT_LPGPDMA(1),
+		LPGPDMA_CHOSEL_FLAG | LPGPDMA_CTLOSEL_FLAG);
+}
+
+/* Runs on the primary core only */
+int platform_init(struct sof *sof)
+{
+#if CONFIG_DW_SPI
+	struct spi *spi_dev;
+#endif /* CONFIG_DW_SPI */
+	int ret;
+#ifndef __ZEPHYR__
+	int i;
+
+	sof->platform_timer = cache_to_uncache(&timer);
+	sof->cpu_timers = (struct timer *)cache_to_uncache(&arch_timers);
+
+	for (i = 0; i < CONFIG_CORE_COUNT; i++)
+		sof->cpu_timers[i] = (struct timer) {
+			.id = TIMER1, /* internal timer */
+			.irq = IRQ_NUM_TIMER2,
+		};
+#endif
+
+	/* Turn off memory for all unused cores */
+	// TODO: to be enabled for MTL
+#if !CONFIG_METEORLAKE
+	for (i = 0; i < CONFIG_CORE_COUNT; i++)
+		if (i != PLATFORM_PRIMARY_CORE_ID)
+			pm_runtime_put(CORE_MEMORY_POW, i);
+#endif /* !CONFIG_METEORLAKE */
+
+	/* pm runtime already initialized, request the DSP to stay in D0
+	 * until we are allowed to do full power gating (by the IPC req).
+	 */
+	pm_runtime_disable(PM_RUNTIME_DSP, 0);
+
+	trace_point(TRACE_BOOT_PLATFORM_ENTRY);
+	platform_init_hw();
+
+	trace_point(TRACE_BOOT_PLATFORM_IRQ);
+	platform_interrupt_init();
+
+#if CONFIG_MEM_WND
+	trace_point(TRACE_BOOT_PLATFORM_MBOX);
+	platform_memory_windows_init(MEM_WND_INIT_CLEAR);
+#endif /* CONFIG_MEM_WND */
+
+#ifndef __ZEPHYR__
+	/* init timers, clocks and schedulers */
+	trace_point(TRACE_BOOT_PLATFORM_TIMER);
+	platform_timer_start(sof->platform_timer);
+#endif /* !__ZEPHYR__ */
+
+	trace_point(TRACE_BOOT_PLATFORM_CLOCK);
+	platform_clock_init(sof);
+
+	trace_point(TRACE_BOOT_PLATFORM_SCHED);
+	scheduler_init_edf();
+
+	/* init low latency timer domain and scheduler */
+	sof->platform_timer_domain =
+		timer_domain_init(sof->platform_timer, PLATFORM_DEFAULT_CLOCK);
+	scheduler_init_ll(sof->platform_timer_domain);
+
+	/* init the system agent */
+	trace_point(TRACE_BOOT_PLATFORM_AGENT);
+	sa_init(sof, CONFIG_SYSTICK_PERIOD);
+
+	/* Set CPU to max frequency for booting (single shim_write below) */
+	trace_point(TRACE_BOOT_PLATFORM_CPU_FREQ);
+
+	shim_write(SHIM_GPDMA_CLKCTL(0), SHIM_CLKCTL_LPGPDMA_SPA);
+	shim_write(SHIM_GPDMA_CLKCTL(1), SHIM_CLKCTL_LPGPDMA_SPA);
+	while (!(shim_read(SHIM_GPDMA_CLKCTL(0)) & SHIM_CLKCTL_LPGPDMA_CPA))
+		idelay(16);
+
+	/* init DMACs */
+	trace_point(TRACE_BOOT_PLATFORM_DMA);
+	ret = dmac_init(sof);
+	if (ret < 0)
+		return ret;
+
+	/* init low latency single channel DW-DMA domain and scheduler */
+	sof->platform_dma_domain =
+		dma_single_chan_domain_init
+			(&sof->dma_info->dma_array[PLATFORM_DW_DMA_INDEX],
+			 PLATFORM_NUM_DW_DMACS,
+			 PLATFORM_DEFAULT_CLOCK);
+	scheduler_init_ll(sof->platform_dma_domain);
+
+	/* initialize the host IPC mechanisms */
+	trace_point(TRACE_BOOT_PLATFORM_IPC);
+	ipc_init(sof);
+
+	/* initialize IDC mechanism */
+	trace_point(TRACE_BOOT_PLATFORM_IDC);
+	ret = idc_init();
+	if (ret < 0)
+		return ret;
+
+	/* init DAIs */
+	trace_point(TRACE_BOOT_PLATFORM_DAI);
+	ret = dai_init(sof);
+	if (ret < 0)
+		return ret;
+
+#if CONFIG_DW_SPI
+	/* initialize the SPI slave */
+	trace_point(TRACE_BOOT_PLATFORM_SPI);
+	spi_init();
+	ret = spi_install(&spi, 1);
+	if (ret < 0)
+		return ret;
+
+	spi_dev = spi_get(SOF_SPI_INTEL_SLAVE);
+	if (!spi_dev)
+		return -ENODEV;
+
+	/* initialize the SPI-SLave module */
+	ret = spi_probe(spi_dev);
+	if (ret < 0)
+		return ret;
+#elif CONFIG_TRACE
+	/* Initialize DMA for Trace*/
+	trace_point(TRACE_BOOT_PLATFORM_DMA_TRACE);
+	dma_trace_init_complete(sof->dmat);
+#endif /* CONFIG_DW_SPI */
+
+	/* show heap status */
+	heap_trace_all(1);
+
+	return 0;
+}
+
+#ifndef __ZEPHYR__
+void platform_wait_for_interrupt(int level)
+{
+	platform_clock_on_waiti();
+
+#ifdef CONFIG_MULTICORE
+	int cpu_id = cpu_get_id();
+
+	/* for secondary cores, if prepare_d0ix_core_mask flag is set for
+	 * specific core, we should prepare for power down before going to wait
+	 * - it is required by D0->D0ix flow.
+	 */
+	if (cpu_id != PLATFORM_PRIMARY_CORE_ID &&
+	    platform_pm_runtime_prepare_d0ix_is_req(cpu_id))
+		cpu_power_down_core(CPU_POWER_DOWN_MEMORY_ON);
+#endif /* CONFIG_MULTICORE */
+
+#if CONFIG_CAVS_LPS
+	if (pm_runtime_is_active(PM_RUNTIME_DSP, PLATFORM_PRIMARY_CORE_ID) ||
+	    cpu_get_id() != PLATFORM_PRIMARY_CORE_ID)
+		arch_wait_for_interrupt(level);
+	else
+		lps_wait_for_interrupt(level);
+#else /* CONFIG_CAVS_LPS */
+	arch_wait_for_interrupt(level);
+#endif /* CONFIG_CAVS_LPS */
+}
+#endif /* !__ZEPHYR__ */
+
+#if CONFIG_CAVS_IMR_D3_PERSISTENT
+/* These structs and macros are from from the ROM code header
+ * on cAVS platforms, please keep them immutable
+ */
+
+#define ADSP_IMR_MAGIC_VALUE		0x02468ACE
+#define IMR_L1_CACHE_ADDRESS		0xB0000000
+
+struct imr_header {
+	uint32_t adsp_imr_magic;
+	uint32_t structure_version;
+	uint32_t structure_size;
+	uint32_t imr_state;
+	uint32_t imr_size;
+	void *imr_restore_vector;
+};
+
+struct imr_state {
+	struct imr_header header;
+	uint8_t reserved[0x1000 - sizeof(struct imr_header)];
+};
+
+struct imr_layout {
+	uint8_t     css_reserved[0x1000];
+	struct imr_state    imr_state;
+};
+
+/* cAVS ROM structs and macros end */
+
+static void imr_layout_update(void *vector)
+{
+	struct imr_layout *imr_layout = (struct imr_layout *)(IMR_L1_CACHE_ADDRESS);
+
+	/* update the IMR layout and write it back to uncache memory
+	 * for ROM code usage. The ROM code will read this from IMR
+	 * at the subsequent run and decide (e.g. combine with checking
+	 * if FW_PURGE IPC from host got) if it can use the previous
+	 * IMR FW directly. So this here is only a host->FW->ROM one way
+	 * configuration, no symmetric task need to done in any
+	 * platform_resume() to clear the configuration.
+	 */
+	dcache_invalidate_region(imr_layout, sizeof(*imr_layout));
+	imr_layout->imr_state.header.adsp_imr_magic = ADSP_IMR_MAGIC_VALUE;
+	imr_layout->imr_state.header.imr_restore_vector = vector;
+	dcache_writeback_region(imr_layout, sizeof(*imr_layout));
+}
+#endif /* CONFIG_CAVS_IMR_D3_PERSISTENT */
+
+int platform_context_save(struct sof *sof)
+{
+#if CONFIG_CAVS_IMR_D3_PERSISTENT
+	/*
+	 * Both runtime PM and S2Idle suspend works on APL, while S3 ([deep])
+	 * doesn't. Only support IMR restoring on cAVS 1.8 and onward at the
+	 * moment.
+	 * TODO: Root cause of why IMR restore doesn't work on APL during S3
+	 * cycle.
+	 */
+	imr_layout_update((void *)IMR_BOOT_LDR_TEXT_ENTRY_BASE);
+#endif /* CONFIG_CAVS_IMR_D3_PERSISTENT */
+	return 0;
+}

--- a/src/trace/dma-trace.c
+++ b/src/trace/dma-trace.c
@@ -156,6 +156,10 @@ int dma_trace_init_early(struct sof *sof)
 	k_spinlock_init(&sof->dmat->lock);
 
 	ipc_build_trace_posn(&sof->dmat->posn);
+	/*volatile int loop = 1;
+	while (loop) {
+		__asm__ volatile("nop");
+	}*/
 	sof->dmat->msg = ipc_msg_init(sof->dmat->posn.rhdr.hdr.cmd,
 				      sof->dmat->posn.rhdr.hdr.size);
 	if (!sof->dmat->msg) {

--- a/src/trace/trace.c
+++ b/src/trace/trace.c
@@ -493,7 +493,7 @@ void trace_off(void)
 	k_spin_unlock(&trace->lock, key);
 }
 
-void trace_init(struct sof *sof)
+__attribute__((optimize("-O0"))) void trace_init(struct sof *sof)
 {
 	sof->trace = rzalloc(SOF_MEM_ZONE_SYS_SHARED, 0, SOF_MEM_CAPS_RAM, sizeof(*sof->trace));
 	sof->trace->enable = 1;


### PR DESCRIPTION
Adapt IPC structures to use largest available IPC ABI version header.

Signed-off-by: Rafal Redzimski <rafal.f.redzimski@intel.com>