### PR TITLE
SOF IPC header cleanup

### DIFF
--- a/src/audio/google_hotword_detect.c
+++ b/src/audio/google_hotword_detect.c
@@ -116,7 +116,7 @@ static struct comp_dev *ghd_create(const struct comp_driver *drv,
 	cd->event.event_type = SOF_CTRL_EVENT_KD;
 	cd->event.num_elems = 0;
 
-	cd->msg = ipc_msg_init(cd->event.rhdr.hdr.cmd, sizeof(cd->event));
+	cd->msg = ipc_msg_init(cd->event.rhdr.hdr.cmd, cd->event.rhdr.size);
 	if (!cd->msg) {
 		comp_err(dev, "ghd_create(): ipc_msg_init failed");
 		goto cd_fail;

--- a/src/audio/host.c
+++ b/src/audio/host.c
@@ -659,7 +659,7 @@ static struct comp_dev *host_new(const struct comp_driver *drv,
 
 	ipc_build_stream_posn(&hd->posn, SOF_IPC_STREAM_POSITION, dev->ipc_config.id);
 
-	hd->msg = ipc_msg_init(hd->posn.rhdr.hdr.cmd, sizeof(hd->posn));
+	hd->msg = ipc_msg_init(hd->posn.rhdr.hdr.cmd, hd->posn.rhdr.hdr.size);
 	if (!hd->msg) {
 		comp_err(dev, "host_new(): ipc_msg_init failed");
 		dma_put(hd->dma);

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -745,8 +745,8 @@ static int mixin_bind(struct comp_dev *dev, void *data)
 	int src_id, sink_id;
 
 	bu = (struct ipc4_module_bind_unbind *)data;
-	src_id = IPC4_COMP_ID(bu->header.r.module_id, bu->header.r.instance_id);
-	sink_id = IPC4_COMP_ID(bu->data.r.dst_module_id, bu->data.r.dst_instance_id);
+	src_id = IPC4_COMP_ID(bu->primary.r.module_id, bu->primary.r.instance_id);
+	sink_id = IPC4_COMP_ID(bu->extension.r.dst_module_id, bu->extension.r.dst_instance_id);
 
 	/* mixin -> mixout */
 	if (dev->ipc_config.id == src_id) {

--- a/src/audio/pipeline/pipeline-graph.c
+++ b/src/audio/pipeline/pipeline-graph.c
@@ -146,7 +146,7 @@ struct pipeline *pipeline_new(uint32_t pipeline_id, uint32_t priority, uint32_t 
 	/* just for retrieving valid ipc_msg header */
 	ipc_build_stream_posn(&posn, SOF_IPC_STREAM_TRIG_XRUN, p->comp_id);
 
-	p->msg = ipc_msg_init(posn.rhdr.hdr.cmd, sizeof(posn));
+	p->msg = ipc_msg_init(posn.rhdr.hdr.cmd, posn.rhdr.hdr.size);
 	if (!p->msg) {
 		pipe_err(p, "pipeline_new(): ipc_msg_init failed");
 		rfree(p);

--- a/src/drivers/amd/renoir/ipc.c
+++ b/src/drivers/amd/renoir/ipc.c
@@ -139,7 +139,7 @@ static void irq_handler(void *arg)
 
 enum task_state ipc_platform_do_cmd(struct ipc *ipc)
 {
-	ipc_cmd_hdr *hdr;
+	struct ipc_cmd_hdr *hdr;
 
 	hdr = mailbox_validate();
 	ipc_cmd(hdr);

--- a/src/drivers/host/ipc.c
+++ b/src/drivers/host/ipc.c
@@ -19,12 +19,12 @@ struct ipc_data {
 	struct ipc_data_host_buffer dh_buffer;
 };
 
-int ipc_platform_compact_write_msg(ipc_cmd_hdr *hdr, int words)
+int ipc_platform_compact_write_msg(struct ipc_cmd_hdr *hdr, int words)
 {
 	return 0; /* number of words read - not currently used on this platform */
 }
 
-int ipc_platform_compact_read_msg(ipc_cmd_hdr *hdr, int words)
+int ipc_platform_compact_read_msg(struct ipc_cmd_hdr *hdr, int words)
 {
 	return 0; /* number of words read - not currently used on this platform */
 }

--- a/src/drivers/imx/ipc.c
+++ b/src/drivers/imx/ipc.c
@@ -82,19 +82,19 @@ static void irq_handler(void *arg)
 	}
 }
 
-int ipc_platform_compact_write_msg(ipc_cmd_hdr *hdr, int words)
+int ipc_platform_compact_write_msg(struct ipc_cmd_hdr *hdr, int words)
 {
 	return 0; /* number of words read - not currently used on this platform */
 }
 
-int ipc_platform_compact_read_msg(ipc_cmd_hdr *hdr, int words)
+int ipc_platform_compact_read_msg(struct ipc_cmd_hdr *hdr, int words)
 {
 	return 0; /* number of words read - not currently used on this platform */
 }
 
 enum task_state ipc_platform_do_cmd(struct ipc *ipc)
 {
-	ipc_cmd_hdr *hdr;
+	struct ipc_cmd_hdr *hdr;
 	/* Use struct ipc_data *iipc = ipc_get_drvdata(ipc); if needed */
 
 	/* perform command */

--- a/src/drivers/intel/baytrail/ipc.c
+++ b/src/drivers/intel/baytrail/ipc.c
@@ -75,19 +75,19 @@ static void irq_handler(void *arg)
 	}
 }
 
-int ipc_platform_compact_write_msg(ipc_cmd_hdr *hdr, int words)
+int ipc_platform_compact_write_msg(struct ipc_cmd_hdr *hdr, int words)
 {
 	return 0; /* number of words read - not currently used on this platform */
 }
 
-int ipc_platform_compact_read_msg(ipc_cmd_hdr *hdr, int words)
+int ipc_platform_compact_read_msg(struct ipc_cmd_hdr *hdr, int words)
 {
 	return 0; /* number of words read - not currently used on this platform */
 }
 
 enum task_state ipc_platform_do_cmd(struct ipc *ipc)
 {
-	ipc_cmd_hdr *hdr;
+	struct ipc_cmd_hdr *hdr;
 	/* Use struct ipc_data *iipc = ipc_get_drvdata(ipc); if needed */
 
 	/* perform command */

--- a/src/drivers/intel/cavs/sue-ipc.c
+++ b/src/drivers/intel/cavs/sue-ipc.c
@@ -26,12 +26,12 @@
 DECLARE_SOF_UUID("ipc-task", ipc_task_uuid, 0x7552b3a1, 0x98dd, 0x4419,
 		 0xad, 0x6f, 0xfb, 0xf2, 0x1e, 0xbf, 0xce, 0xec);
 
-int ipc_platform_compact_write_msg(ipc_cmd_hdr *hdr, int words)
+int ipc_platform_compact_write_msg(struct ipc_cmd_hdr *hdr, int words)
 {
 	return 0; /* number of words read - not currently used on this platform */
 }
 
-int ipc_platform_compact_read_msg(ipc_cmd_hdr *hdr, int words)
+int ipc_platform_compact_read_msg(struct ipc_cmd_hdr *hdr, int words)
 {
 	return 0; /* number of words read - not currently used on this platform */
 }
@@ -39,7 +39,7 @@ int ipc_platform_compact_read_msg(ipc_cmd_hdr *hdr, int words)
 /* No private data for IPC */
 enum task_state ipc_platform_do_cmd(struct ipc *ipc)
 {
-	ipc_cmd_hdr *hdr;
+	struct ipc_cmd_hdr *hdr;
 	struct sof_ipc_reply reply;
 
 	/* perform command */

--- a/src/drivers/intel/haswell/ipc.c
+++ b/src/drivers/intel/haswell/ipc.c
@@ -69,19 +69,19 @@ static void irq_handler(void *arg)
 	}
 }
 
-int ipc_platform_compact_write_msg(ipc_cmd_hdr *hdr, int words)
+int ipc_platform_compact_write_msg(struct ipc_cmd_hdr *hdr, int words)
 {
 	return 0; /* number of words read - not currently used on this platform */
 }
 
-int ipc_platform_compact_read_msg(ipc_cmd_hdr *hdr, int words)
+int ipc_platform_compact_read_msg(struct ipc_cmd_hdr *hdr, int words)
 {
 	return 0; /* number of words read - not currently used on this platform */
 }
 
 enum task_state ipc_platform_do_cmd(struct ipc *ipc)
 {
-	ipc_cmd_hdr *hdr;
+	struct ipc_cmd_hdr *hdr;
 	/* Use struct ipc_data *iipc = ipc_get_drvdata(ipc); if needed */
 
 	/* perform command */

--- a/src/include/ipc/header.h
+++ b/src/include/ipc/header.h
@@ -18,6 +18,24 @@
 
 #include <stdint.h>
 
+/**
+ * Common IPC logic uses standard types for abstract IPC features. This means all ABI MAJOR
+ * abstraction is done in the IPC layer only and not in the surrounding infrastructure.
+ */
+#if CONFIG_IPC_MAJOR_3
+#include <ipc3/header.h>
+#elif CONFIG_IPC_MAJOR_4
+#include <ipc4/header.h>
+#endif
+
+/**
+ * Generic IPC Header structure - Header for all IPC structures which provides
+ * abstraction of IPC header implementation for different IPC ABI MAJOR types.
+ */
+struct ipc_cmd_hdr;
+
+#define ipc_to_hdr(x) ((struct ipc_cmd_hdr *)x)
+
 /** \addtogroup sof_uapi uAPI
  * SOF uAPI specification
  *

--- a/src/include/ipc3/header.h
+++ b/src/include/ipc3/header.h
@@ -1,0 +1,40 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2021 Intel Corporation. All rights reserved.
+ */
+
+/*
+ * This file contains structures that are exact copies of an existing ABI used
+ * by IOT middleware. They are Intel specific and will be used by one middleware.
+ *
+ * Some of the structures may contain programming implementations that makes them
+ * unsuitable for generic use and general usage.
+ *
+ * This code is mostly copied "as-is" from existing C++ interface files hence the use of
+ * different style in places. The intention is to keep the interface as close as possible to
+ * original so it's easier to track changes with IPC host code.
+ */
+
+/**
+ * \file include/ipc3/header.h
+ * \brief IPC3 global definitions.
+ * NOTE: This ABI uses bit fields and is non portable.
+ */
+
+#ifndef __SOF_IPC3_HEADER_H__
+#define __SOF_IPC3_HEADER_H__
+
+#include <stdint.h>
+
+#define ipc_from_hdr(x) ((struct sof_ipc_cmd_hdr *)x)
+
+/**
+ * \brief Generic message header. IPC MAJOR 3 version.
+ * All IPC3 messages use this header as abstraction
+ * to platform specific calls.
+ */
+struct ipc_cmd_hdr {
+	uint32_t dat[2];
+};
+
+#endif

--- a/src/include/ipc4/header.h
+++ b/src/include/ipc4/header.h
@@ -94,23 +94,32 @@ enum ipc4_message_type {
  * When msg_tgt is SOF_IPC4_MESSAGE_TARGET_FW_GEN_MSG then type is
  * enum ipc4_message_type.
  */
-union ipc4_message_header {
-	uint32_t dat;
+struct ipc4_message_request {
+	union  {
+		uint32_t dat;
 
-	struct {
-		uint32_t rsvd0 : 24;
+		struct {
+			uint32_t rsvd0 : 24;
 
-		/**< One of Global::Type */
-		uint32_t type : 5;
+			/**< One of Global::Type */
+			uint32_t type : 5;
 
-		/**< Msg::MSG_REQUEST */
-		uint32_t rsp : 1;
+			/**< Msg::MSG_REQUEST */
+			uint32_t rsp : 1;
 
-		/**< Msg::FW_GEN_MSG */
-		uint32_t msg_tgt : 1;
+			/**< Msg::FW_GEN_MSG */
+			uint32_t msg_tgt : 1;
 
-		uint32_t _reserved_0 : 1;
-	} r;
+			uint32_t _reserved_0 : 1;
+		} r;
+	} primary;
+	union  {
+		uint32_t dat;
+		struct {
+			uint32_t ext_data : 30;
+			uint32_t _reserved_0 : 2;
+		} r;
+	} extension;
 } __attribute__((packed, aligned(4)));
 
 struct ipc4_message_reply {
@@ -133,7 +142,7 @@ struct ipc4_message_reply {
 			/**< Reserved field (HW ctrl bits) */
 			uint32_t _reserved_0 : 1;
 		} r;
-	} header;
+	} primary;
 
 	union {
 		uint32_t dat;
@@ -145,7 +154,7 @@ struct ipc4_message_reply {
 			/**< Reserved field (HW ctrl bits) */
 			uint32_t _reserved_2 : 2;
 		} r;
-	} data;
+	} extension;
 } __attribute((packed, aligned(4)));
 
 #endif

--- a/src/include/ipc4/header.h
+++ b/src/include/ipc4/header.h
@@ -26,6 +26,8 @@
 
 #include <stdint.h>
 
+#define ipc_from_hdr(x) ((struct ipc4_message_request *)x)
+
 /**< Message target, value of msg_tgt field. */
 enum ipc4_message_target {
 	/**< Global FW message */
@@ -87,6 +89,16 @@ enum ipc4_message_type {
 
 	/**< Maximum message number */
 	SOF_IPC4_GLB_MAX_IXC_MESSAGE_TYPE = 31
+};
+
+/**
+ * \brief Generic message header. IPC MAJOR 4 version.
+ * All IPC4 messages use this header as abstraction
+ * to platform specific calls.
+ */
+struct ipc_cmd_hdr {
+	uint32_t pri;
+	uint32_t ext;
 };
 
 /**

--- a/src/include/ipc4/module.h
+++ b/src/include/ipc4/module.h
@@ -124,7 +124,7 @@ struct ipc4_module_init_instance {
 			uint32_t msg_tgt            : 1;
 			uint32_t _reserved_0        : 1;
 		} r;
-	} header;
+	} primary;
 
 	union {
 		uint32_t dat;
@@ -142,7 +142,7 @@ struct ipc4_module_init_instance {
 			uint32_t extended_init      : 1;
 			uint32_t _hw_reserved_2     : 2;
 		} r;
-	} data;
+	} extension;
 
 	struct ipc4_module_init_ext_init ext_init;
 	struct ipc4_module_init_ext_data ext_data;
@@ -181,7 +181,7 @@ struct ipc4_module_bind_unbind {
 			uint32_t msg_tgt : 1;
 			uint32_t _reserved_0 : 1;
 		} r;
-	} header;
+	} primary;
 
 	union {
 		uint32_t dat;
@@ -197,7 +197,7 @@ struct ipc4_module_bind_unbind {
 			uint32_t src_queue : SOF_IPC4_SRC_QUEUE_ID_BITFIELD_SIZE;
 			uint32_t _reserved_2 : 2;
 		} r;
-	} data;
+	} extension;
 } __attribute__((packed, aligned(4)));
 
 struct ipc4_module_large_config {
@@ -217,7 +217,7 @@ struct ipc4_module_large_config {
 			uint32_t msg_tgt : 1;
 			uint32_t _reserved_0 : 1;
 			} r;
-		} header;
+		} primary;
 
 	union {
 		uint32_t dat;
@@ -233,7 +233,7 @@ struct ipc4_module_large_config {
 			uint32_t init_block : 1;
 			uint32_t _reserved_2 : 2;
 		} r;
-	} data;
+	} extension;
 } __attribute__((packed, aligned(4)));
 
 struct ipc4_module_large_config_reply {
@@ -250,7 +250,7 @@ struct ipc4_module_large_config_reply {
 			uint32_t msg_tgt : 1;
 			uint32_t _reserved_0 : 1;
 			} r;
-		} header;
+		} primary;
 
 	union {
 		uint32_t dat;
@@ -266,7 +266,7 @@ struct ipc4_module_large_config_reply {
 			uint32_t init_block : 1;
 			uint32_t _reserved_2 : 2;
 		} r;
-	} data;
+	} extension;
 } __attribute__((packed, aligned(4)));
 
 struct ipc4_module_delete_instance {
@@ -284,7 +284,7 @@ struct ipc4_module_delete_instance {
 			uint32_t msg_tgt : 1;
 			uint32_t _reserved_0 : 1;
 		} r;
-	} header;
+	} primary;
 
 	union {
 		uint32_t dat;
@@ -293,7 +293,7 @@ struct ipc4_module_delete_instance {
 			uint32_t rsvd : 30;
 			uint32_t _reserved_1 : 2;
 		} r;
-	} data;
+	} extension;
 } __attribute__((packed, aligned(4)));
 
 struct ipc4_module_set_d0ix {
@@ -313,7 +313,7 @@ struct ipc4_module_set_d0ix {
 			uint32_t msg_tgt		: 1;
 			uint32_t _reserved_0	: 1;
 		} r;
-	} header;
+	} primary;
 
 	union {
 		uint32_t dat;
@@ -331,7 +331,7 @@ struct ipc4_module_set_d0ix {
 			uint32_t rsvd1			: 26;
 			uint32_t _reserved_2	: 2;
 		} r;
-	} data;
+	} extension;
 } __attribute__((packed, aligned(4)));
 
 struct ipc4_dx_state_info {
@@ -361,7 +361,7 @@ struct ipc4_module_set_dx {
 			uint32_t msg_tgt			: 1;
 			uint32_t _reserved_0		: 1;
 		} r;
-	} header;
+	} primary;
 
 	union {
 		uint32_t dat;
@@ -370,7 +370,7 @@ struct ipc4_module_set_dx {
 			uint32_t rsvd				: 30;
 			uint32_t _reserved_2		: 2;
 		} r;
-	} data;
+	} extension;
 } __attribute__((packed, aligned(4)));
 
 #define IPC4_COMP_ID(x, y)	((x) << 16 | (y))

--- a/src/include/ipc4/notification.h
+++ b/src/include/ipc4/notification.h
@@ -24,7 +24,7 @@
 #define __IPC4_NOTIFICATION_H__
 
 #include <stdint.h>
-#include <ipc4/header.h>
+#include <ipc/header.h>
 
 /* ipc4 notification msg */
 enum sof_ipc4_notification_type {

--- a/src/include/ipc4/pipeline.h
+++ b/src/include/ipc4/pipeline.h
@@ -95,7 +95,7 @@ struct ipc4_pipeline_create {
 			uint32_t msg_tgt        : 1;
 			uint32_t _reserved_0    : 1;
 		} r;
-	} header;
+	} primary;
 
 	union{
 		uint32_t dat;
@@ -108,7 +108,7 @@ struct ipc4_pipeline_create {
 			uint32_t rsvd2          : 10;
 			uint32_t _reserved_2    : 2;
 		} r;
-	} data;
+	} extension;
 } __attribute__((packed, aligned(4)));
 
 /*!
@@ -138,7 +138,7 @@ struct ipc4_pipeline_delete {
 			uint32_t msg_tgt        : 1;
 			uint32_t _reserved_0    : 1;
 		} r;
-	} header;
+	} primary;
 
 	union{
 		uint32_t dat;
@@ -147,7 +147,7 @@ struct ipc4_pipeline_delete {
 			uint32_t rsvd1          : 30;
 			uint32_t _reserved_2    : 2;
 		} r;
-	} data;
+	} extension;
 } __attribute__((packed, aligned(4)));
 
 /*!
@@ -199,7 +199,7 @@ struct ipc4_pipeline_set_state {
 			uint32_t msg_tgt    : 1;
 			uint32_t _reserved_0: 1;
 		} r;
-	} header;
+	} primary;
 
 	union{
 		uint32_t dat;
@@ -212,7 +212,7 @@ struct ipc4_pipeline_set_state {
 			uint32_t rsvd1      : 28;
 			uint32_t _reserved_2: 2;
 		} r;
-	} data;
+	} extension;
 
 	/* multiple pipeline states */
 	struct ipc4_pipeline_set_state_data s_data;
@@ -239,7 +239,7 @@ struct ipc4_pipeline_set_state_reply {
 			uint32_t msg_tgt    : 1;
 			uint32_t _reserved_0: 1;
 		} r;
-	} header;
+	} primary;
 
 	union{
 		uint32_t dat;
@@ -249,7 +249,7 @@ struct ipc4_pipeline_set_state_reply {
 			uint32_t ppl_id     : 30;
 			uint32_t _reserved_2: 2;
 		} r;
-	} data;
+	} extension;
 } __attribute__((packed, aligned(4)));
 
 /**< This IPC message is sent to the FW in order to retrieve a pipeline state. */
@@ -270,7 +270,7 @@ struct ipc4_pipeline_get_state {
 			uint32_t msg_tgt    : 1;
 			uint32_t _reserved_0: 1;
 			} r;
-	} header;
+	} primary;
 
 	union{
 		uint32_t dat;
@@ -279,7 +279,7 @@ struct ipc4_pipeline_get_state {
 			uint32_t rsvd1      : 30;
 			uint32_t _reserved_2: 2;
 		} r;
-	} data;
+	} extension;
 } __attribute__((packed, aligned(4)));
 
 /**< Sent by the FW in response to GetPipelineState. */
@@ -299,7 +299,7 @@ struct ipc4_pipeline_get_state_reply {
 			uint32_t msg_tgt    : 1;
 			uint32_t _reserved_0: 1;
 		} r;
-	} header;
+	} primary;
 
 	union{
 		uint32_t dat;
@@ -310,7 +310,7 @@ struct ipc4_pipeline_get_state_reply {
 			uint32_t rsvd1      : 25;
 			uint32_t _reserved_2: 2;
 		} r;
-	} data;
+	} extension;
 } __attribute__((packed, aligned(4)));
 
 /*!
@@ -336,7 +336,7 @@ struct ipc4_pipeline_get_context_size {
 			uint32_t msg_tgt        : 1;
 			uint32_t _reserved_0    : 1;
 		} r;
-	} header;
+	} primary;
 
 	union{
 		uint32_t dat;
@@ -345,7 +345,7 @@ struct ipc4_pipeline_get_context_size {
 			uint32_t rsvd1          : 30;
 			uint32_t _reserved_2    : 2;
 		} r;
-	} data;
+	} extension;
 } __attribute__((packed, aligned(4)));
 
 /**< Reply to Get Pipeline Context Size. */
@@ -365,7 +365,7 @@ struct ipc4_pipeline_get_context_size_reply {
 			uint32_t msg_tgt    : 1;
 			uint32_t _reserved_0: 1;
 		} r;
-	} header;
+	} primary;
 
 	union{
 		uint32_t dat;
@@ -376,7 +376,7 @@ struct ipc4_pipeline_get_context_size_reply {
 			uint32_t rsvd1      : 14;
 			uint32_t _reserved_2: 2;
 		} r;
-	} data;
+	} extension;
 } __attribute__((packed, aligned(4)));
 
 struct ipc4_chain_dma {
@@ -402,7 +402,7 @@ struct ipc4_chain_dma {
 		uint32_t msg_tgt		: 1;
 		uint32_t _reserved_0		: 1;
 		} r;
-	} header;
+	} primary;
 
 	union {
 		uint32_t dat;
@@ -413,7 +413,7 @@ struct ipc4_chain_dma {
 			uint32_t rsvd1		: 6;
 			uint32_t _reserved_2		: 2;
 		} r;
-	} data;
+	} extension;
 } __attribute__((packed, aligned(4)));
 
 #endif

--- a/src/include/kernel/abi.h
+++ b/src/include/kernel/abi.h
@@ -30,7 +30,7 @@
 /** \brief SOF ABI version major, minor and patch numbers */
 #define SOF_ABI_MAJOR 3
 #define SOF_ABI_MINOR 22
-#define SOF_ABI_PATCH 0
+#define SOF_ABI_PATCH 1
 
 /** \brief SOF ABI version number. Format within 32bit word is MMmmmppp */
 #define SOF_ABI_MAJOR_SHIFT	24

--- a/src/include/sof/ipc/common.h
+++ b/src/include/sof/ipc/common.h
@@ -18,34 +18,10 @@
 #include <user/trace.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <ipc/header.h>
 
 struct dma_sg_elem_array;
 struct ipc_msg;
-
-/*
- * Common IPC logic uses standard types for abstract IPC features. This means all ABI MAJOR
- * abstraction is done in the IPC layer only and not in the surrounding infrastructure.
- */
-#if CONFIG_IPC_MAJOR_3
-#include <ipc/header.h>
-#define ipc_from_hdr(x) ((struct sof_ipc_cmd_hdr *)x)
-
-struct ipc_cmd_hdr {
-	uint32_t dat[2];
-};
-#elif CONFIG_IPC_MAJOR_4
-#include <ipc4/header.h>
-#define ipc_from_hdr(x) ((struct ipc4_message_request *)x)
-
-struct ipc_cmd_hdr {
-	uint32_t pri;
-	uint32_t ext;
-};
-#else
-#error "No or invalid IPC MAJOR version selected."
-#endif
-
-#define ipc_to_hdr(x) ((struct ipc_cmd_hdr *)x)
 
 /* validates internal non tail structures within IPC command structure */
 #define IPC_IS_SIZE_INVALID(object)					\

--- a/src/include/sof/ipc/common.h
+++ b/src/include/sof/ipc/common.h
@@ -34,7 +34,7 @@ typedef uint32_t ipc_cmd_hdr;
 #define ipc_from_hdr(x) ((struct sof_ipc_cmd_hdr *)x)
 #elif CONFIG_IPC_MAJOR_4
 #include <ipc4/header.h>
-#define ipc_from_hdr(x) ((union ipc4_message_header *)x)
+#define ipc_from_hdr(x) ((struct ipc4_message_request *)x)
 #else
 #error "No or invalid IPC MAJOR version selected."
 #endif

--- a/src/include/sof/ipc/driver.h
+++ b/src/include/sof/ipc/driver.h
@@ -67,7 +67,7 @@ struct ipc_data_host_buffer *ipc_platform_get_host_buffer(struct ipc *ipc);
  * @param[in] words Number of words to read in header.
  * @return Number of word written.
  */
-int ipc_platform_compact_read_msg(ipc_cmd_hdr *hdr, int words);
+int ipc_platform_compact_read_msg(struct ipc_cmd_hdr *hdr, int words);
 
 /**
  * \brief Write a compact IPC message to hardware.
@@ -75,7 +75,7 @@ int ipc_platform_compact_read_msg(ipc_cmd_hdr *hdr, int words);
  * @param[in] words Number of words to be written from header.
  * @return Number of word written.
  */
-int ipc_platform_compact_write_msg(ipc_cmd_hdr *hdr, int words);
+int ipc_platform_compact_write_msg(struct ipc_cmd_hdr *hdr, int words);
 
 /**
  * \brief Initialise IPC hardware for polling mode.

--- a/src/include/sof/ipc/msg.h
+++ b/src/include/sof/ipc/msg.h
@@ -30,18 +30,21 @@ struct dma_sg_elem_array;
 
 struct ipc_msg {
 	uint32_t header;	/* specific to platform */
+	uint32_t extension;	/* extension specific to platform */
 	uint32_t tx_size;	/* payload size in bytes */
 	void *tx_data;		/* pointer to payload data */
 	struct list_item list;
 };
 
 /**
- * \brief Initialise a new IPC message.
+ * \brief Initialize a new IPC message.
  * @param header Message header metadata
- * @param size Message size in bytes.
+ * @param extension Message header extension metadata
+ * @param size Message data size in bytes.
  * @return New IPC message.
  */
-static inline struct ipc_msg *ipc_msg_init(uint32_t header, uint32_t size)
+static inline struct ipc_msg *ipc_msg_w_ext_init(uint32_t header, uint32_t extension,
+						 uint32_t size)
 {
 	struct ipc_msg *msg;
 
@@ -49,17 +52,31 @@ static inline struct ipc_msg *ipc_msg_init(uint32_t header, uint32_t size)
 	if (!msg)
 		return NULL;
 
-	msg->tx_data = rzalloc(SOF_MEM_ZONE_RUNTIME_SHARED, 0, SOF_MEM_CAPS_RAM, size);
-	if (!msg->tx_data) {
-		rfree(msg);
-		return NULL;
+	if (size) {
+		msg->tx_data = rzalloc(SOF_MEM_ZONE_RUNTIME_SHARED, 0, SOF_MEM_CAPS_RAM, size);
+		if (!msg->tx_data) {
+			rfree(msg);
+			return NULL;
+		}
 	}
 
 	msg->header = header;
+	msg->extension = extension;
 	msg->tx_size = size;
 	list_init(&msg->list);
 
 	return msg;
+}
+
+/**
+ * \brief Initialise a new IPC message.
+ * @param header Message header metadata
+ * @param size Message data size in bytes.
+ * @return New IPC message.
+ */
+static inline struct ipc_msg *ipc_msg_init(uint32_t header, uint32_t size)
+{
+	return ipc_msg_w_ext_init(header, 0, size);
 }
 
 /**

--- a/src/ipc/ipc3/handler.c
+++ b/src/ipc/ipc3/handler.c
@@ -89,7 +89,7 @@ LOG_MODULE_DECLARE(ipc, CONFIG_SOF_LOG_LEVEL);
 			((struct sof_ipc_cmd_hdr *)tx),			\
 			sizeof(rx))
 
-ipc_cmd_hdr *mailbox_validate(void)
+struct ipc_cmd_hdr *mailbox_validate(void)
 {
 	struct sof_ipc_cmd_hdr *hdr = ipc_get()->comp_data;
 
@@ -1524,7 +1524,7 @@ static int ipc_glb_test_message(uint32_t header)
 #endif
 
 #if CONFIG_CAVS && CAVS_VERSION >= CAVS_VERSION_1_8
-static ipc_cmd_hdr *ipc_cavs_read_set_d0ix(ipc_cmd_hdr *hdr)
+static struct ipc_cmd_hdr *ipc_cavs_read_set_d0ix(struct ipc_cmd_hdr *hdr)
 {
 	struct sof_ipc_pm_gate *cmd = ipc_get()->comp_data;
 	uint32_t *chdr = (uint32_t *)hdr;
@@ -1539,10 +1539,10 @@ static ipc_cmd_hdr *ipc_cavs_read_set_d0ix(ipc_cmd_hdr *hdr)
 /*
  * Read a compact IPC message or return NULL for normal message.
  */
-ipc_cmd_hdr *ipc_compact_read_msg(void)
+struct ipc_cmd_hdr *ipc_compact_read_msg(void)
 {
 	uint32_t chdr[2];
-	ipc_cmd_hdr *hdr = (ipc_cmd_hdr *)chdr;
+	struct ipc_cmd_hdr *hdr = (struct ipc_cmd_hdr *)chdr;
 	int words;
 
 	words = ipc_platform_compact_read_msg(hdr, 2);
@@ -1563,7 +1563,7 @@ ipc_cmd_hdr *ipc_compact_read_msg(void)
 #endif
 
 /* prepare the message using ABI major layout */
-ipc_cmd_hdr *ipc_prepare_to_send(const struct ipc_msg *msg)
+struct ipc_cmd_hdr *ipc_prepare_to_send(const struct ipc_msg *msg)
 {
 	static uint32_t hdr[2];
 
@@ -1575,16 +1575,17 @@ ipc_cmd_hdr *ipc_prepare_to_send(const struct ipc_msg *msg)
 	return ipc_to_hdr(hdr);
 }
 
-void ipc_boot_complete_msg(ipc_cmd_hdr *header, uint32_t *data)
+void ipc_boot_complete_msg(struct ipc_cmd_hdr *header, uint32_t data)
 {
-	*header = SOF_IPC_FW_READY;
+	header->dat[0] = SOF_IPC_FW_READY;
+	header->dat[1] = data;
 }
 
 /*
  * Global IPC Operations.
  */
 
-void ipc_cmd(ipc_cmd_hdr *_hdr)
+void ipc_cmd(struct ipc_cmd_hdr *_hdr)
 {
 	struct sof_ipc_cmd_hdr *hdr = ipc_from_hdr(_hdr);
 	struct ipc *ipc = ipc_get();

--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -17,7 +17,7 @@
 #include <sof/platform.h>
 #include <sof/sof.h>
 #include <ipc4/gateway.h>
-#include <ipc4/header.h>
+#include <ipc/header.h>
 #include <ipc4/alh.h>
 #include <ipc4/ssp.h>
 #include <ipc4/copier.h>

--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -25,7 +25,7 @@
 #include <sof/math/numbers.h>
 #include <sof/trace/trace.h>
 #include <ipc4/error_status.h>
-#include <ipc4/header.h>
+#include <ipc/header.h>
 #include <ipc4/module.h>
 #include <ipc4/pipeline.h>
 #include <ipc4/notification.h>

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -25,7 +25,7 @@
 #include <rimage/sof/user/manifest.h>
 #include <ipc4/base-config.h>
 #include <ipc4/copier.h>
-#include <ipc4/header.h>
+#include <ipc/header.h>
 #include <ipc4/notification.h>
 #include <ipc4/pipeline.h>
 #include <ipc4/module.h>

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -59,7 +59,7 @@ bool ipc_trigger_trace_xfer(uint32_t avail)
 void ipc_build_trace_posn(struct sof_ipc_dma_trace_posn *posn)
 {
 	posn->rhdr.hdr.cmd =  SOF_IPC4_NOTIF_HEADER(SOF_IPC4_NOTIFY_LOG_BUFFER_STATUS);
-	posn->rhdr.hdr.size = sizeof(uint32_t);
+	posn->rhdr.hdr.size = 0;
 }
 
 struct comp_dev *comp_new(struct sof_ipc_comp *comp)

--- a/tools/oss-fuzz/fuzz_ipc.c
+++ b/tools/oss-fuzz/fuzz_ipc.c
@@ -25,7 +25,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 	if (hdr->size < sizeof(*hdr) || hdr->size > SOF_IPC_MSG_MAX_SIZE)
 		goto done;
 
-	ipc_cmd((ipc_cmd_hdr *)hdr);
+	ipc_cmd((struct ipc_cmd_hdr *)hdr);
 done:
 	free(hdr);
 	return 0;  // Non-zero return values are reserved for future use.


### PR DESCRIPTION
Refactor of code related to IPC handling.
PR Includes:
- fix the parameters passed to ipc_msg_init
- update of common ipc4 structures to reflect primary/extension contents of ipc4 header
- update of ipc4 command specific structures to reflect primary/extension contents of ipc4 header
- remove the special treatment of the extension dword which had been part of payload data
- update the ipc_cmd_hdr to be used safely for ipc3 and ipc4