### PR TITLE
pcm_converter: fix uninitialised variables

### DIFF
--- a/src/audio/pcm_converter/pcm_converter_generic.c
+++ b/src/audio/pcm_converter/pcm_converter_generic.c
@@ -747,7 +747,7 @@ static int pcm_convert_s24_c32_to_s24_c24_link_gtw(const struct audio_stream *so
 	int32_t *src = source->r_ptr;
 	uint16_t *dst = sink->w_ptr;
 	int processed;
-	int nmax, i, n;
+	int nmax, i = 0, n = 0;
 
 	src += ioffset;
 	assert(ooffset == 0);


### PR DESCRIPTION
Two variables i and n in pcm_convert_s24_c32_to_s24_c24_link_gtw() can be used uninitialised, which breaks compilation. Initialise them to 0 which guarantees, that we don't perform any changes in the invalid case of processed >= samples.
