### PR TITLE
Audio: Rename audio stream read/write frag functions with prefix deprecated

### DIFF
--- a/src/audio/aria/aria.c
+++ b/src/audio/aria/aria.c
@@ -296,8 +296,8 @@ static int aria_copy(struct comp_dev *dev)
 
 	for (i = 0; i < c.frames; i++) {
 		for (channel = 0; channel < sink->stream.channels; channel++) {
-			cd->buf_in[frag] = *(int32_t *)audio_stream_read_frag_s32(&source->stream,
-										  frag);
+			cd->buf_in[frag] = *(int32_t *)deprecated_audio_stream_read_frag_s32(&source->stream,
+											     frag);
 
 			frag++;
 		}
@@ -311,7 +311,7 @@ static int aria_copy(struct comp_dev *dev)
 	frag = 0;
 	for (i = 0; i < c.frames; i++) {
 		for (channel = 0; channel < sink->stream.channels; channel++) {
-			destp = audio_stream_write_frag_s32(&sink->stream, frag);
+			destp = deprecated_audio_stream_write_frag_s32(&sink->stream, frag);
 			*destp = cd->buf_out[frag];
 
 			frag++;

--- a/src/audio/copier.c
+++ b/src/audio/copier.c
@@ -661,7 +661,7 @@ static inline int apply_attenuation(struct comp_dev *dev, struct copier_data *cd
 	case SOF_IPC_FRAME_S24_4LE:
 	case SOF_IPC_FRAME_S32_LE:
 		for (i = 0; i < frame * sink->stream.channels; i++) {
-			dst = audio_stream_read_frag_s32(&sink->stream, buff_frag);
+			dst = deprecated_audio_stream_read_frag_s32(&sink->stream, buff_frag);
 			*dst >>= cd->attenuation;
 			buff_frag++;
 		}

--- a/src/audio/crossover/crossover_generic.c
+++ b/src/audio/crossover/crossover_generic.c
@@ -99,11 +99,11 @@ static void crossover_s16_default_pass(const struct comp_dev *dev,
 	int n = source_stream->channels * frames;
 
 	for (i = 0; i < n; i++) {
-		x = audio_stream_read_frag_s16(source_stream, i);
+		x = deprecated_audio_stream_read_frag_s16(source_stream, i);
 		for (j = 0; j < num_sinks; j++) {
 			if (!sinks[j])
 				continue;
-			y = audio_stream_write_frag_s16((&sinks[j]->stream), i);
+			y = deprecated_audio_stream_write_frag_s16((&sinks[j]->stream), i);
 			*y = *x;
 		}
 	}
@@ -123,11 +123,11 @@ static void crossover_s32_default_pass(const struct comp_dev *dev,
 	int n = source_stream->channels * frames;
 
 	for (i = 0; i < n; i++) {
-		x = audio_stream_read_frag_s32(source_stream, i);
+		x = deprecated_audio_stream_read_frag_s32(source_stream, i);
 		for (j = 0; j < num_sinks; j++) {
 			if (!sinks[j])
 				continue;
-			y = audio_stream_write_frag_s32((&sinks[j]->stream), i);
+			y = deprecated_audio_stream_write_frag_s32((&sinks[j]->stream), i);
 			*y = *x;
 		}
 	}
@@ -155,15 +155,14 @@ static void crossover_s16_default(const struct comp_dev *dev,
 		idx = ch;
 		state = &cd->state[ch];
 		for (i = 0; i < frames; i++) {
-			x = audio_stream_read_frag_s16(source_stream, idx);
+			x = deprecated_audio_stream_read_frag_s16(source_stream, idx);
 			cd->crossover_split(*x << 16, out, state);
 
 			for (j = 0; j < num_sinks; j++) {
 				if (!sinks[j])
 					continue;
 				sink_stream = &sinks[j]->stream;
-				y = audio_stream_write_frag_s16(sink_stream,
-								idx);
+				y = deprecated_audio_stream_write_frag_s16(sink_stream, idx);
 				*y = sat_int16(Q_SHIFT_RND(out[j], 31, 15));
 			}
 
@@ -194,15 +193,14 @@ static void crossover_s24_default(const struct comp_dev *dev,
 		idx = ch;
 		state = &cd->state[ch];
 		for (i = 0; i < frames; i++) {
-			x = audio_stream_read_frag_s32(source_stream, idx);
+			x = deprecated_audio_stream_read_frag_s32(source_stream, idx);
 			cd->crossover_split(*x << 8, out, state);
 
 			for (j = 0; j < num_sinks; j++) {
 				if (!sinks[j])
 					continue;
 				sink_stream = &sinks[j]->stream;
-				y = audio_stream_write_frag_s32(sink_stream,
-								idx);
+				y = deprecated_audio_stream_write_frag_s32(sink_stream, idx);
 				*y = sat_int24(Q_SHIFT_RND(out[j], 31, 23));
 			}
 
@@ -233,15 +231,14 @@ static void crossover_s32_default(const struct comp_dev *dev,
 		idx = ch;
 		state = &cd->state[0];
 		for (i = 0; i < frames; i++) {
-			x = audio_stream_read_frag_s32(source_stream, idx);
+			x = deprecated_audio_stream_read_frag_s32(source_stream, idx);
 			cd->crossover_split(*x, out, state);
 
 			for (j = 0; j < num_sinks; j++) {
 				if (!sinks[j])
 					continue;
 				sink_stream = &sinks[j]->stream;
-				y = audio_stream_write_frag_s32(sink_stream,
-								idx);
+				y = deprecated_audio_stream_write_frag_s32(sink_stream, idx);
 				*y = out[j];
 			}
 

--- a/src/audio/dcblock/dcblock_generic.c
+++ b/src/audio/dcblock/dcblock_generic.c
@@ -52,8 +52,8 @@ static void dcblock_s16_default(const struct comp_dev *dev,
 		R = cd->R_coeffs[ch];
 		idx = ch;
 		for (i = 0; i < frames; i++) {
-			x = audio_stream_read_frag_s16(source, idx);
-			y = audio_stream_write_frag_s16(sink, idx);
+			x = deprecated_audio_stream_read_frag_s16(source, idx);
+			y = deprecated_audio_stream_write_frag_s16(sink, idx);
 			tmp = dcblock_generic(state, R, *x << 16);
 			*y = sat_int16(Q_SHIFT_RND(tmp, 31, 15));
 			idx += nch;
@@ -84,8 +84,8 @@ static void dcblock_s24_default(const struct comp_dev *dev,
 		R = cd->R_coeffs[ch];
 		idx = ch;
 		for (i = 0; i < frames; i++) {
-			x = audio_stream_read_frag_s32(source, idx);
-			y = audio_stream_write_frag_s32(sink, idx);
+			x = deprecated_audio_stream_read_frag_s32(source, idx);
+			y = deprecated_audio_stream_write_frag_s32(sink, idx);
 			tmp = dcblock_generic(state, R, *x << 8);
 			*y = sat_int24(Q_SHIFT_RND(tmp, 31, 23));
 			idx += nch;
@@ -115,8 +115,8 @@ static void dcblock_s32_default(const struct comp_dev *dev,
 		R = cd->R_coeffs[ch];
 		idx = ch;
 		for (i = 0; i < frames; i++) {
-			x = audio_stream_read_frag_s32(source, idx);
-			y = audio_stream_write_frag_s32(sink, idx);
+			x = deprecated_audio_stream_read_frag_s32(source, idx);
+			y = deprecated_audio_stream_write_frag_s32(sink, idx);
 			*y = dcblock_generic(state, R, *x);
 			idx += nch;
 		}

--- a/src/audio/drc/drc_generic.c
+++ b/src/audio/drc/drc_generic.c
@@ -477,8 +477,8 @@ static void drc_s16_default_pass(const struct comp_dev *dev,
 	int n = source->channels * frames;
 
 	for (i = 0; i < n; i++) {
-		x = audio_stream_read_frag_s16(source, i);
-		y = audio_stream_write_frag_s16(sink, i);
+		x = deprecated_audio_stream_read_frag_s16(source, i);
+		y = deprecated_audio_stream_write_frag_s16(sink, i);
 		*y = *x;
 	}
 }
@@ -496,8 +496,8 @@ static void drc_s32_default_pass(const struct comp_dev *dev,
 	int n = source->channels * frames;
 
 	for (i = 0; i < n; i++) {
-		x = audio_stream_read_frag_s32(source, i);
-		y = audio_stream_write_frag_s32(sink, i);
+		x = deprecated_audio_stream_read_frag_s32(source, i);
+		y = deprecated_audio_stream_write_frag_s32(sink, i);
 		*y = *x;
 	}
 }
@@ -539,8 +539,8 @@ static void drc_s16_default(const struct comp_dev *dev,
 			pd_read = (int16_t *)state->pre_delay_buffers[ch] + pd_read_index;
 			idx = ch;
 			for (i = 0; i < frames; ++i) {
-				x = audio_stream_read_frag_s16(source, idx);
-				y = audio_stream_write_frag_s16(sink, idx);
+				x = deprecated_audio_stream_read_frag_s16(source, idx);
+				y = deprecated_audio_stream_write_frag_s16(sink, idx);
 				*pd_write = *x;
 				*y = *pd_read;
 				if (++pd_write_index == CONFIG_DRC_MAX_PRE_DELAY_FRAMES) {
@@ -585,8 +585,8 @@ static void drc_s16_default(const struct comp_dev *dev,
 			pd_read = (int16_t *)state->pre_delay_buffers[ch] + pd_read_index;
 			idx = i * nch + ch;
 			for (f = 0; f < fragment; ++f) {
-				x = audio_stream_read_frag_s16(source, idx);
-				y = audio_stream_write_frag_s16(sink, idx);
+				x = deprecated_audio_stream_read_frag_s16(source, idx);
+				y = deprecated_audio_stream_write_frag_s16(sink, idx);
 				*pd_write = *x;
 				*y = *pd_read;
 				pd_write++;
@@ -645,8 +645,8 @@ static void drc_s24_default(const struct comp_dev *dev,
 			pd_read = (int32_t *)state->pre_delay_buffers[ch] + pd_read_index;
 			idx = ch;
 			for (i = 0; i < frames; ++i) {
-				x = audio_stream_read_frag_s32(source, idx);
-				y = audio_stream_write_frag_s32(sink, idx);
+				x = deprecated_audio_stream_read_frag_s32(source, idx);
+				y = deprecated_audio_stream_write_frag_s32(sink, idx);
 				*pd_write = *x;
 				*y = *pd_read;
 				if (++pd_write_index == CONFIG_DRC_MAX_PRE_DELAY_FRAMES) {
@@ -691,8 +691,8 @@ static void drc_s24_default(const struct comp_dev *dev,
 			pd_read = (int32_t *)state->pre_delay_buffers[ch] + pd_read_index;
 			idx = i * nch + ch;
 			for (f = 0; f < fragment; ++f) {
-				x = audio_stream_read_frag_s32(source, idx);
-				y = audio_stream_write_frag_s32(sink, idx);
+				x = deprecated_audio_stream_read_frag_s32(source, idx);
+				y = deprecated_audio_stream_write_frag_s32(sink, idx);
 
 				/* Write/Read pre_delay_buffer as s32 format */
 				*pd_write = *x << 8;
@@ -754,8 +754,8 @@ static void drc_s32_default(const struct comp_dev *dev,
 			pd_read = (int32_t *)state->pre_delay_buffers[ch] + pd_read_index;
 			idx = ch;
 			for (i = 0; i < frames; ++i) {
-				x = audio_stream_read_frag_s32(source, idx);
-				y = audio_stream_write_frag_s32(sink, idx);
+				x = deprecated_audio_stream_read_frag_s32(source, idx);
+				y = deprecated_audio_stream_write_frag_s32(sink, idx);
 				*pd_write = *x;
 				*y = *pd_read;
 				if (++pd_write_index == CONFIG_DRC_MAX_PRE_DELAY_FRAMES) {
@@ -800,8 +800,8 @@ static void drc_s32_default(const struct comp_dev *dev,
 			pd_read = (int32_t *)state->pre_delay_buffers[ch] + pd_read_index;
 			idx = i * nch + ch;
 			for (f = 0; f < fragment; ++f) {
-				x = audio_stream_read_frag_s32(source, idx);
-				y = audio_stream_write_frag_s32(sink, idx);
+				x = deprecated_audio_stream_read_frag_s32(source, idx);
+				y = deprecated_audio_stream_write_frag_s32(sink, idx);
 				*pd_write = *x;
 				*y = *pd_read;
 				pd_write++;

--- a/src/audio/google_rtc_audio_processing.c
+++ b/src/audio/google_rtc_audio_processing.c
@@ -401,8 +401,8 @@ static int google_rtc_audio_processing_copy(struct comp_dev *dev)
 	aec_reference_buff_frag = 0;
 	for (frame = 0; frame < num_aec_reference_frames; frame++) {
 		for (channel = 0; channel < cd->num_aec_reference_channels; ++channel) {
-			src = audio_stream_read_frag_s16(&cd->aec_reference->stream,
-							 aec_reference_buff_frag + channel);
+			src = deprecated_audio_stream_read_frag_s16(&cd->aec_reference->stream,
+								    aec_reference_buff_frag + channel);
 			cd->aec_reference_buffer[cd->num_aec_reference_channels *
 				cd->aec_reference_frame_index + channel] = *src;
 		}
@@ -423,12 +423,12 @@ static int google_rtc_audio_processing_copy(struct comp_dev *dev)
 	raw_microphone_buff_frag = 0;
 	output_buff_frag = 0;
 	for (frame = 0; frame < cl.frames; frame++) {
-		src = audio_stream_read_frag_s16(&cd->raw_microphone->stream,
-										 raw_microphone_buff_frag);
+		src = deprecated_audio_stream_read_frag_s16(&cd->raw_microphone->stream,
+							    raw_microphone_buff_frag);
 		cd->raw_mic_buffer[cd->raw_mic_buffer_index] = *src;
 		++cd->raw_mic_buffer_index;
 
-		dst = audio_stream_write_frag_s16(&cd->output->stream, output_buff_frag);
+		dst = deprecated_audio_stream_write_frag_s16(&cd->output->stream, output_buff_frag);
 		*dst = cd->output_buffer[cd->output_buffer_index];
 		++cd->output_buffer_index;
 

--- a/src/audio/igo_nr/igo_nr.c
+++ b/src/audio/igo_nr/igo_nr.c
@@ -88,12 +88,13 @@ static void igo_nr_capture_s16(struct comp_data *cd,
 		for (j = 0; j < nch; j++) {
 			if (j == cd->config.active_channel_idx)
 				continue;
-			x = audio_stream_read_frag_s16(source, idx_in + j);
-			y = audio_stream_write_frag_s16(sink, idx_in + j);
+			x = deprecated_audio_stream_read_frag_s16(source, idx_in + j);
+			y = deprecated_audio_stream_write_frag_s16(sink, idx_in + j);
 			*y = (*x);
 		}
 
-		x = audio_stream_read_frag_s16(source, idx_in + cd->config.active_channel_idx);
+		x = deprecated_audio_stream_read_frag_s16(source,
+							  idx_in + cd->config.active_channel_idx);
 		cd->in[i] = (*x);
 
 		idx_in += nch;
@@ -103,7 +104,8 @@ static void igo_nr_capture_s16(struct comp_data *cd,
 
 	/* Interleave write the processed data into active output channel. */
 	for (i = 0; i < frames; i++) {
-		y = audio_stream_write_frag_s16(sink, idx_out + cd->config.active_channel_idx);
+		y = deprecated_audio_stream_write_frag_s16(sink,
+							   idx_out + cd->config.active_channel_idx);
 		*y = (cd->out[i]);
 
 #if CONFIG_DEBUG
@@ -113,7 +115,7 @@ static void igo_nr_capture_s16(struct comp_data *cd,
 		else
 			dbg_ch_idx = cd->config.active_channel_idx + 1;
 		if (dbg_en) {
-			y = audio_stream_write_frag_s16(sink, idx_out + dbg_ch_idx);
+			y = deprecated_audio_stream_write_frag_s16(sink, idx_out + dbg_ch_idx);
 			*y = (cd->in[i]);
 		}
 #endif
@@ -147,12 +149,12 @@ static void igo_nr_capture_s24(struct comp_data *cd,
 		for (j = 0; j < nch; j++) {
 			if (j == cd->config.active_channel_idx)
 				continue;
-			x = audio_stream_read_frag_s32(source, idx_in + j);
-			y = audio_stream_write_frag_s32(sink, idx_in + j);
+			x = deprecated_audio_stream_read_frag_s32(source, idx_in + j);
+			y = deprecated_audio_stream_write_frag_s32(sink, idx_in + j);
 			*y = (*x);
 		}
 
-		x = audio_stream_read_frag_s32(source, idx_in + cd->config.active_channel_idx);
+		x = deprecated_audio_stream_read_frag_s32(source, idx_in + cd->config.active_channel_idx);
 		cd->in[i] = Q_SHIFT_RND(*x, 24, 16);
 
 		idx_in += nch;
@@ -162,7 +164,8 @@ static void igo_nr_capture_s24(struct comp_data *cd,
 
 	/* Interleave write the processed data into active output channel. */
 	for (i = 0; i < frames; i++) {
-		y = audio_stream_write_frag_s32(sink, idx_out + cd->config.active_channel_idx);
+		y = deprecated_audio_stream_write_frag_s32(sink,
+							   idx_out + cd->config.active_channel_idx);
 		*y = (cd->out[i]) << 8;
 
 #if CONFIG_DEBUG
@@ -172,7 +175,7 @@ static void igo_nr_capture_s24(struct comp_data *cd,
 		else
 			dbg_ch_idx = cd->config.active_channel_idx + 1;
 		if (dbg_en) {
-			y = audio_stream_write_frag_s32(sink, idx_out + dbg_ch_idx);
+			y = deprecated_audio_stream_write_frag_s32(sink, idx_out + dbg_ch_idx);
 			*y = (cd->in[i]) << 8;
 		}
 #endif
@@ -205,12 +208,13 @@ static void igo_nr_capture_s32(struct comp_data *cd,
 		for (j = 0; j < nch; j++) {
 			if (j == cd->config.active_channel_idx)
 				continue;
-			x = audio_stream_read_frag_s32(source, idx_in + j);
-			y = audio_stream_write_frag_s32(sink, idx_in + j);
+			x = deprecated_audio_stream_read_frag_s32(source, idx_in + j);
+			y = deprecated_audio_stream_write_frag_s32(sink, idx_in + j);
 			*y = (*x);
 		}
 
-		x = audio_stream_read_frag_s32(source, idx_in + cd->config.active_channel_idx);
+		x = deprecated_audio_stream_read_frag_s32(source,
+							  idx_in + cd->config.active_channel_idx);
 		cd->in[i] = Q_SHIFT_RND(*x, 32, 16);
 
 		idx_in += nch;
@@ -220,7 +224,8 @@ static void igo_nr_capture_s32(struct comp_data *cd,
 
 	/* Interleave write the processed data into active output channel. */
 	for (i = 0; i < frames; i++) {
-		y = audio_stream_write_frag_s32(sink, idx_out + cd->config.active_channel_idx);
+		y = deprecated_audio_stream_write_frag_s32(sink,
+							   idx_out + cd->config.active_channel_idx);
 		*y = (cd->out[i]) << 16;
 
 #if CONFIG_DEBUG
@@ -230,7 +235,7 @@ static void igo_nr_capture_s32(struct comp_data *cd,
 		else
 			dbg_ch_idx = cd->config.active_channel_idx + 1;
 		if (dbg_en) {
-			y = audio_stream_write_frag_s32(sink, idx_out + dbg_ch_idx);
+			y = deprecated_audio_stream_write_frag_s32(sink, idx_out + dbg_ch_idx);
 			*y = (cd->in[i]) << 16;
 		}
 #endif

--- a/src/audio/smart_amp/smart_amp_generic.c
+++ b/src/audio/smart_amp/smart_amp_generic.c
@@ -40,8 +40,8 @@ static void smart_amp_s16_ff_default(const struct comp_dev *dev,
 	for (ch = 0; ch < nch; ch++) {
 		idx = ch;
 		for (i = 0; i < frames; i++) {
-			x = audio_stream_read_frag_s16(source, idx);
-			y = audio_stream_read_frag_s16(sink, idx);
+			x = deprecated_audio_stream_read_frag_s16(source, idx);
+			y = deprecated_audio_stream_read_frag_s16(sink, idx);
 			tmp = smart_amp_ff_generic(*x << 16);
 			*y = sat_int16(Q_SHIFT_RND(tmp, 31, 15));
 			idx += nch;
@@ -68,8 +68,8 @@ static void smart_amp_s24_ff_default(const struct comp_dev *dev,
 	for (ch = 0; ch < nch; ch++) {
 		idx = ch;
 		for (i = 0; i < frames; i++) {
-			x = audio_stream_read_frag_s32(source, idx);
-			y = audio_stream_read_frag_s32(sink, idx);
+			x = deprecated_audio_stream_read_frag_s32(source, idx);
+			y = deprecated_audio_stream_read_frag_s32(sink, idx);
 			tmp = smart_amp_ff_generic(*x << 8);
 			*y = sat_int24(Q_SHIFT_RND(tmp, 31, 23));
 			idx += nch;
@@ -95,8 +95,8 @@ static void smart_amp_s32_ff_default(const struct comp_dev *dev,
 	for (ch = 0; ch < nch; ch++) {
 		idx = ch;
 		for (i = 0; i < frames; i++) {
-			x = audio_stream_read_frag_s32(source, idx);
-			y = audio_stream_read_frag_s32(sink, idx);
+			x = deprecated_audio_stream_read_frag_s32(source, idx);
+			y = deprecated_audio_stream_read_frag_s32(sink, idx);
 			*y = smart_amp_ff_generic(*x);
 			idx += nch;
 		}
@@ -120,7 +120,7 @@ static void smart_amp_s16_fb_default(const struct comp_dev *dev,
 	for (ch = 0; ch < nch; ch++) {
 		idx = ch;
 		for (i = 0; i < frames; i++) {
-			x = audio_stream_read_frag_s16(feedback, idx);
+			x = deprecated_audio_stream_read_frag_s16(feedback, idx);
 			smart_amp_fb_generic(*x << 16);
 			idx += nch;
 		}
@@ -144,7 +144,7 @@ static void smart_amp_s24_fb_default(const struct comp_dev *dev,
 	for (ch = 0; ch < nch; ch++) {
 		idx = ch;
 		for (i = 0; i < frames; i++) {
-			x = audio_stream_read_frag_s32(feedback, idx);
+			x = deprecated_audio_stream_read_frag_s32(feedback, idx);
 			smart_amp_fb_generic(*x << 8);
 			idx += nch;
 		}
@@ -168,7 +168,7 @@ static void smart_amp_s32_fb_default(const struct comp_dev *dev,
 	for (ch = 0; ch < nch; ch++) {
 		idx = ch;
 		for (i = 0; i < frames; i++) {
-			x = audio_stream_read_frag_s32(feedback, idx);
+			x = deprecated_audio_stream_read_frag_s32(feedback, idx);
 			smart_amp_ff_generic(*x);
 			idx += nch;
 		}

--- a/src/audio/smart_amp/smart_amp_maxim_dsm.c
+++ b/src/audio/smart_amp/smart_amp_maxim_dsm.c
@@ -599,9 +599,7 @@ static int smart_amp_get_buffer(int32_t *buf, uint32_t frames,
 				if (chan_map[ch] == -1)
 					continue;
 				index = in_frag + chan_map[ch];
-				input.buf16 =
-					audio_stream_read_frag_s16(stream,
-								   index);
+				input.buf16 = deprecated_audio_stream_read_frag_s16(stream, index);
 				output.buf16[num_ch * idx + ch] = *input.buf16;
 			}
 			in_frag += stream->channels;
@@ -614,9 +612,7 @@ static int smart_amp_get_buffer(int32_t *buf, uint32_t frames,
 				if (chan_map[ch] == -1)
 					continue;
 				index = in_frag + chan_map[ch];
-				input.buf32 =
-					audio_stream_read_frag_s32(stream,
-								   index);
+				input.buf32 = deprecated_audio_stream_read_frag_s32(stream, index);
 				output.buf32[num_ch * idx + ch] = *input.buf32;
 			}
 			in_frag += stream->channels;
@@ -650,9 +646,8 @@ static int smart_amp_put_buffer(int32_t *buf, uint32_t frames,
 					out_frag++;
 					continue;
 				}
-				output.buf16 =
-					audio_stream_write_frag_s16(stream,
-								    out_frag);
+				output.buf16 = deprecated_audio_stream_write_frag_s16(stream,
+										      out_frag);
 				*output.buf16 = input.buf16[num_ch_in * idx + ch];
 				out_frag++;
 			}
@@ -666,9 +661,8 @@ static int smart_amp_put_buffer(int32_t *buf, uint32_t frames,
 					out_frag++;
 					continue;
 				}
-				output.buf32 =
-					audio_stream_write_frag_s32(stream,
-								    out_frag);
+				output.buf32 = deprecated_audio_stream_write_frag_s32(stream,
+										      out_frag);
 				*output.buf32 = input.buf32[num_ch_in * idx + ch];
 				out_frag++;
 			}

--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -86,25 +86,33 @@ struct audio_stream {
 	audio_stream_get_frag(buffer, (buffer)->r_ptr, idx, size)
 
 /**
- * Retrieves readable address of a signed 16-bit sample at specified index.
+ * Retrieves readable address of a signed 16-bit sample at specified index. Use
+ * only to get initial buffer pointer.
  * @param buffer Buffer.
  * @param idx Index of sample.
  * @return Pointer to the sample.
  *
  * @see audio_stream_get_frag().
  */
-#define audio_stream_read_frag_s16(buffer, idx) \
+#define audio_stream_read_initial_frag_s16(buffer, idx) \
+	audio_stream_get_frag(buffer, (buffer)->r_ptr, idx, sizeof(int16_t))
+
+#define deprecated_audio_stream_read_frag_s16(buffer, idx) \
 	audio_stream_get_frag(buffer, (buffer)->r_ptr, idx, sizeof(int16_t))
 
 /**
- * Retrieves readable address of a signed 32-bit sample at specified index.
+ * Retrieves readable address of a signed 32-bit sample at specified index. Use
+ * only to get initial buffer pointer.
  * @param buffer Buffer.
  * @param idx Index of sample.
  * @return Pointer to the sample.
  *
  * @see audio_stream_get_frag().
  */
-#define audio_stream_read_frag_s32(buffer, idx) \
+#define audio_stream_read_initial_frag_s32(buffer, idx) \
+	audio_stream_get_frag(buffer, (buffer)->r_ptr, idx, sizeof(int32_t))
+
+#define deprecated_audio_stream_read_frag_s32(buffer, idx) \
 	audio_stream_get_frag(buffer, (buffer)->r_ptr, idx, sizeof(int32_t))
 
 /**
@@ -129,25 +137,33 @@ struct audio_stream {
 	audio_stream_get_frag(buffer, (buffer)->w_ptr, idx, size)
 
 /**
- * Retrieves writeable address of a signed 16-bit sample at specified index.
+ * Retrieves writeable address of a signed 16-bit sample at specified index. Use
+ * only to get initial buffer pointer.
  * @param buffer Buffer.
  * @param idx Index of sample.
  * @return Pointer to the space for sample.
  *
  * @see audio_stream_get_frag().
  */
-#define audio_stream_write_frag_s16(buffer, idx) \
+#define audio_stream_write_initial_frag_s16(buffer, idx) \
+	audio_stream_get_frag(buffer, (buffer)->w_ptr, idx, sizeof(int16_t))
+
+#define deprecated_audio_stream_write_frag_s16(buffer, idx) \
 	audio_stream_get_frag(buffer, (buffer)->w_ptr, idx, sizeof(int16_t))
 
 /**
- * Retrieves writeable address of a signed 32-bit sample at specified index.
+ * Retrieves writeable address of a signed 32-bit sample at specified index. Use
+ * only to get initial buffer pointer.
  * @param buffer Buffer.
  * @param idx Index of sample.
  * @return Pointer to the space for sample.
  *
  * @see audio_stream_get_frag().
  */
-#define audio_stream_write_frag_s32(buffer, idx) \
+#define audio_stream_write_initial_frag_s32(buffer, idx) \
+	audio_stream_get_frag(buffer, (buffer)->w_ptr, idx, sizeof(int32_t))
+
+#define deprecated_audio_stream_write_frag_s32(buffer, idx) \
 	audio_stream_get_frag(buffer, (buffer)->w_ptr, idx, sizeof(int32_t))
 
 /**

--- a/src/samples/audio/detect_test.c
+++ b/src/samples/audio/detect_test.c
@@ -176,8 +176,8 @@ static void default_detect_test(struct comp_dev *dev,
 	/* perform detection within current period */
 	for (sample = 0; sample < count && !cd->detected; ++sample) {
 		src = (valid_bits == 16U) ?
-		      audio_stream_read_frag_s16(source, sample) :
-		      audio_stream_read_frag_s32(source, sample);
+		      deprecated_audio_stream_read_frag_s16(source, sample) :
+		      deprecated_audio_stream_read_frag_s32(source, sample);
 		if (valid_bits > 16U) {
 			diff = abs(*(int32_t *)src) - abs(cd->activation);
 		} else {

--- a/src/samples/audio/kwd_nn_detect_test.c
+++ b/src/samples/audio/kwd_nn_detect_test.c
@@ -46,8 +46,8 @@ void kwd_nn_detect_test(struct comp_dev *dev,
 	/* perform detection within current period */
 	for (sample = 0; sample < count && !test_keyword_get_detected(dev); ++sample) {
 		src = (test_keyword_get_sample_valid_bytes(dev) * 8 == 16U) ?
-			audio_stream_read_frag_s16(source, sample) :
-			audio_stream_read_frag_s32(source, sample);
+			deprecated_audio_stream_read_frag_s16(source, sample) :
+			deprecated_audio_stream_read_frag_s32(source, sample);
 		if (test_keyword_get_input_size(dev) < KWD_NN_IN_BUFF_SIZE) {
 			if (test_keyword_get_sample_valid_bytes(dev) == 16U)
 				test_keyword_set_input_elem(dev,

--- a/src/samples/audio/smart_amp_test.c
+++ b/src/samples/audio/smart_amp_test.c
@@ -342,11 +342,9 @@ static int smart_amp_process_s16(struct comp_dev *dev,
 	for (i = 0; i < frames; i++) {
 		for (j = 0 ; j < sad->out_channels; j++) {
 			if (chan_map[j] != -1) {
-				src = audio_stream_read_frag_s16(source,
-								 in_frag +
-								 chan_map[j]);
-				dest = audio_stream_write_frag_s16(sink,
-								   out_frag);
+				src = deprecated_audio_stream_read_frag_s16(source,
+									    in_frag + chan_map[j]);
+				dest = deprecated_audio_stream_write_frag_s16(sink, out_frag);
 				*dest = *src;
 			}
 			out_frag++;
@@ -374,11 +372,9 @@ static int smart_amp_process_s32(struct comp_dev *dev,
 	for (i = 0; i < frames; i++) {
 		for (j = 0 ; j < sad->out_channels; j++) {
 			if (chan_map[j] != -1) {
-				src = audio_stream_read_frag_s32(source,
-								 in_frag +
-								 chan_map[j]);
-				dest = audio_stream_write_frag_s32(sink,
-								   out_frag);
+				src = deprecated_audio_stream_read_frag_s32(source,
+									    in_frag + chan_map[j]);
+				dest = deprecated_audio_stream_write_frag_s32(sink, out_frag);
 				*dest = *src;
 			}
 			out_frag++;


### PR DESCRIPTION
The purpose of this patch is to highlight and discourage use of
not efficient audio stream functions.

The functions audio_stream_read_frag_s16/32() and
audio_stream_write_frag_s16/32() cause high processing load when
used for every sample in copy() processing. This patch renames the
poor performing function usages with prefix deprecated.

The valid use of the same functions is enabled with renamed function
audio_stream_read/write_initial_frag_s16/32(). It is acceptable use to
get a buffer pointer once before the samples processing.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>