### PR TITLE
[Temporarily Inactive] zephyr: alh: add ALH zephyr driver

### DIFF
--- a/src/audio/dai.c
+++ b/src/audio/dai.c
@@ -95,7 +95,7 @@ static void dai_dma_cb(void *arg, enum notify_id type, void *data)
 	/* stop dma copy for pause/stop/xrun */
 	if (dev->state != COMP_STATE_ACTIVE || dd->xrun) {
 		/* stop the DAI */
-		dai_trigger(dd->dai, COMP_TRIGGER_STOP, dev->direction);
+		dai_trigger_sof(dd->dai, COMP_TRIGGER_STOP, dev->direction);
 
 		/* tell DMA not to reload */
 		next->status = DMA_CB_STATUS_END;
@@ -730,7 +730,7 @@ static int dai_comp_trigger_internal(struct comp_dev *dev, int cmd)
 			if (ret < 0)
 				return ret;
 			/* start the DAI */
-			dai_trigger(dd->dai, cmd, dev->direction);
+			dai_trigger_sof(dd->dai, cmd, dev->direction);
 		} else {
 			dd->xrun = 0;
 		}
@@ -753,7 +753,7 @@ static int dai_comp_trigger_internal(struct comp_dev *dev, int cmd)
 				return ret;
 
 			/* start the DAI */
-			dai_trigger(dd->dai, cmd, dev->direction);
+			dai_trigger_sof(dd->dai, cmd, dev->direction);
 			ret = dma_start(dd->chan);
 			if (ret < 0)
 				return ret;
@@ -780,16 +780,16 @@ static int dai_comp_trigger_internal(struct comp_dev *dev, int cmd)
  */
 #if CONFIG_DMA_SUSPEND_DRAIN
 		ret = dma_stop(dd->chan);
-		dai_trigger(dd->dai, cmd, dev->direction);
+		dai_trigger_sof(dd->dai, cmd, dev->direction);
 #else
-		dai_trigger(dd->dai, cmd, dev->direction);
+		dai_trigger_sof(dd->dai, cmd, dev->direction);
 		ret = dma_stop(dd->chan);
 #endif
 		break;
 	case COMP_TRIGGER_PAUSE:
 		comp_dbg(dev, "dai_comp_trigger_internal(), PAUSE");
 		ret = dma_pause(dd->chan);
-		dai_trigger(dd->dai, cmd, dev->direction);
+		dai_trigger_sof(dd->dai, cmd, dev->direction);
 		break;
 	case COMP_TRIGGER_PRE_START:
 	case COMP_TRIGGER_PRE_RELEASE:
@@ -797,7 +797,7 @@ static int dai_comp_trigger_internal(struct comp_dev *dev, int cmd)
 		if (dd->xrun)
 			dd->xrun = 0;
 		else
-			dai_trigger(dd->dai, cmd, dev->direction);
+			dai_trigger_sof(dd->dai, cmd, dev->direction);
 		break;
 	}
 

--- a/src/drivers/intel/CMakeLists.txt
+++ b/src/drivers/intel/CMakeLists.txt
@@ -18,7 +18,7 @@ if(CONFIG_INTEL_SSP)
 endif()
 
 if(CONFIG_INTEL_ALH)
-	add_local_sources(sof alh.c)
+	add_subdirectory(alh)
 endif()
 
 if(CONFIG_INTEL_DMIC)

--- a/src/drivers/intel/alh/CMakeLists.txt
+++ b/src/drivers/intel/alh/CMakeLists.txt
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+add_local_sources(sof alh.c)

--- a/src/drivers/intel/alh/alh-zephyr.c
+++ b/src/drivers/intel/alh/alh-zephyr.c
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2022 Intel Corporation. All rights reserved.
+//
+// Author: Adrian Bonislawski <adrian.bonislawski@intel.com>
+
+#include <sof/audio/component.h>
+#include <sof/lib/dai.h>
+#include <sof/lib/dma.h>
+#include <sof/lib/memory.h>
+#include <sof/lib/uuid.h>
+#include <sof/trace/trace.h>
+#include <sof/common.h>
+#include <ipc/dai.h>
+#include <ipc/stream.h>
+#include <ipc/topology.h>
+#include <user/trace.h>
+#include <stdint.h>
+#include <ipc4/alh.h>
+
+/* zephyr dai driver */
+#include <drivers/dai.h>
+
+/* a8e4218c-e863-4c93-84e7-5c27d2504501 */
+DECLARE_SOF_UUID("alh-dai", alh_uuid, 0xa8e4218c, 0xe863, 0x4c93,
+		 0x84, 0xe7, 0x5c, 0x27, 0xd2, 0x50, 0x45, 0x01);
+
+DECLARE_TR_CTX(alh_tr, SOF_UUID(alh_uuid), LOG_LEVEL_INFO);
+
+static int alh_trigger_zephyr(struct dai *dai, int cmd, int direction)
+{
+	enum dai_trigger_cmd cmd_z;
+
+	switch(cmd) {
+	case COMP_TRIGGER_STOP:
+		cmd_z = DAI_TRIGGER_STOP;
+		break;
+	case COMP_TRIGGER_START:
+	case COMP_TRIGGER_RELEASE:
+		cmd_z = DAI_TRIGGER_START;
+		break;
+	case COMP_TRIGGER_PAUSE:
+		cmd_z = DAI_TRIGGER_PAUSE;
+		break;
+	case COMP_TRIGGER_PRE_START:
+	case COMP_TRIGGER_PRE_RELEASE:
+		cmd_z = DAI_TRIGGER_PRE_START;
+		break;
+	default:
+	       return -EINVAL;
+	}
+
+	return dai_trigger(dai->z_drv, direction, cmd_z);
+}
+
+static int alh_set_config_zephyr(struct dai *dai, struct ipc_config_dai *common_config,
+				 void *spec_config)
+{
+	struct sof_ipc_dai_config *sof_cfg;
+	struct dai_config cfg;
+
+	sof_cfg = (struct sof_ipc_dai_config *)spec_config;
+	cfg.dai_index = common_config->dai_index;
+	cfg.format = sof_cfg->format;
+	cfg.options = sof_cfg->flags;
+
+	if(common_config->is_config_blob) {
+		cfg.type = DAI_INTEL_ALH_NHLT;
+		return dai_config_set(dai->z_drv, &cfg, spec_config);
+	} else {
+		cfg.type = DAI_INTEL_ALH;
+		return dai_config_set(dai->z_drv, &cfg, &sof_cfg->alh);
+	}
+}
+
+static int alh_get_hw_params_zephyr(struct dai *dai, struct sof_ipc_stream_params  *params, int dir)
+{
+	const struct dai_config *cfg;
+
+	cfg = dai_config_get(dai->z_drv, dir);
+
+	params->rate = cfg->rate;
+	params->buffer_fmt = 0;
+	params->channels = cfg->channels;
+
+	switch (cfg->word_size) {
+        case 16:
+                params->frame_fmt = SOF_IPC_FRAME_S16_LE;
+                break;
+        case 24:
+                params->frame_fmt = SOF_IPC_FRAME_S24_4LE;
+                break;
+        case 32:
+                params->frame_fmt = SOF_IPC_FRAME_S32_LE;
+                break;
+        default:
+		dai_warn(dai,"%d not supported format", cfg->word_size);
+        }
+
+	return 0;
+}
+
+static int alh_get_handshake_zephyr(struct dai *dai, int direction, int stream_id)
+{
+	const struct dai_properties *props;
+
+	props = dai_get_properties(dai->z_drv, direction, stream_id);
+
+	return props->dma_hs_id;
+}
+
+static int alh_get_fifo_zephyr(struct dai *dai, int direction, int stream_id)
+{
+	const struct dai_properties *props;
+
+	props = dai_get_properties(dai->z_drv, direction, stream_id);
+
+	return props->fifo_address;
+}
+
+static int alh_get_stream_id_zephyr(struct dai *dai, int direction)
+{
+	const struct dai_properties *props;
+
+	props = dai_get_properties(dai->z_drv, direction, 0);
+
+	return props->stream_id;
+}
+
+static int alh_probe_zephyr(struct dai *dai)
+{
+	return dai_probe(dai->z_drv);
+}
+
+static int alh_remove_zephyr(struct dai *dai)
+{
+	return dai_remove(dai->z_drv);
+}
+
+const struct dai_driver alh_driver = {
+	.type = SOF_DAI_INTEL_ALH,
+	.uid = SOF_UUID(alh_uuid),
+	.tctx = &alh_tr,
+	.dma_caps = DMA_CAP_GP_LP | DMA_CAP_GP_HP,
+	.dma_dev = DMA_DEV_ALH,
+	.ops = {
+		.trigger		= alh_trigger_zephyr,
+		.set_config		= alh_set_config_zephyr,
+		.get_hw_params		= alh_get_hw_params_zephyr,
+		.get_handshake		= alh_get_handshake_zephyr,
+		.get_fifo		= alh_get_fifo_zephyr,
+		.get_stream_id		= alh_get_stream_id_zephyr,
+		.probe			= alh_probe_zephyr,
+		.remove			= alh_remove_zephyr,
+	},
+};

--- a/src/drivers/intel/alh/alh.c
+++ b/src/drivers/intel/alh/alh.c
@@ -144,6 +144,13 @@ static int alh_get_fifo(struct dai *dai, int direction, int stream_id)
 	return ALH_BASE + offset + ALH_STREAM_OFFSET * stream_id;
 }
 
+static int alh_get_stream_id(struct dai *dai, int direction)
+{
+	struct alh_pdata *alh = dai_get_drvdata(dai);
+
+	return alh->params.stream_id;
+}
+
 const struct dai_driver alh_driver = {
 	.type = SOF_DAI_INTEL_ALH,
 	.uid = SOF_UUID(alh_uuid),
@@ -156,6 +163,7 @@ const struct dai_driver alh_driver = {
 		.get_hw_params		= alh_get_hw_params,
 		.get_handshake		= alh_get_handshake,
 		.get_fifo		= alh_get_fifo,
+		.get_stream_id	= alh_get_stream_id,
 		.probe			= alh_probe,
 		.remove			= alh_remove,
 	},

--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -68,7 +68,6 @@ int ipc_dai_data_config(struct comp_dev *dev)
 	struct ipc_config_dai *dai = &dd->ipc_config;
 	struct ipc4_copier_module_cfg *copier_cfg;
 	struct dai *dai_p = dd->dai;
-	struct alh_pdata *alh;
 
 	if (!dai) {
 		comp_err(dev, "dai_data_config(): no dai!\n");
@@ -100,20 +99,18 @@ int ipc_dai_data_config(struct comp_dev *dev)
 	case SOF_DAI_INTEL_HDA:
 		break;
 	case SOF_DAI_INTEL_ALH:
-		alh = dai_get_drvdata(dai_p);
 		/* SDW HW FIFO always requires 32bit MSB aligned sample data for
 		 * all formats, such as 8/16/24/32 bits.
 		 */
 		dev->ipc_config.frame_fmt = SOF_IPC_FRAME_S32_LE;
 		dd->dma_buffer->stream.frame_fmt = dev->ipc_config.frame_fmt;
 
-		dd->config.burst_elems =
-			dd->dai->plat_data.fifo[dai->direction].depth;
+		dd->config.burst_elems = ALH_GPDMA_BURST_LENGTH;
 
 		/* As with HDA, the DMA channel is assigned in runtime,
 		 * not during topology parsing.
 		 */
-		dd->stream_id = alh->params.stream_id;
+		dd->stream_id = dai_get_stream_id(dai_p, 0);//alh->params.stream_id;
 
 		comp_dbg(dev, "dai_data_config() SOF_DAI_INTEL_ALH dd->dma_buffer->stream.frame_fmt %#x stream_id %d",
 			 dd->dma_buffer->stream.frame_fmt, dd->stream_id);

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -161,7 +161,7 @@ if (CONFIG_SOC_SERIES_INTEL_CAVS_V15)
 	)
 
 	zephyr_library_sources_ifdef(CONFIG_INTEL_ALH
-		${SOF_DRIVERS_PATH}/intel/alh.c
+		${SOF_DRIVERS_PATH}/intel/alh/alh.c
 	)
 
 	zephyr_library_sources_ifdef(CONFIG_INTEL_DMIC
@@ -227,7 +227,7 @@ if (CONFIG_SOC_SERIES_INTEL_CAVS_V18)
 	)
 
 	zephyr_library_sources_ifdef(CONFIG_INTEL_ALH
-		${SOF_DRIVERS_PATH}/intel/alh.c
+		${SOF_DRIVERS_PATH}/intel/alh/alh.c
 	)
 
 	zephyr_library_sources_ifdef(CONFIG_INTEL_DMIC
@@ -295,7 +295,7 @@ if (CONFIG_SOC_SERIES_INTEL_CAVS_V20)
 	)
 
 	zephyr_library_sources_ifdef(CONFIG_INTEL_ALH
-		${SOF_DRIVERS_PATH}/intel/alh.c
+		${SOF_DRIVERS_PATH}/intel/alh/alh.c
 	)
 
 	zephyr_library_sources_ifdef(CONFIG_INTEL_DMIC
@@ -363,7 +363,7 @@ if (CONFIG_SOC_SERIES_INTEL_CAVS_V25)
 	)
 
 	zephyr_library_sources_ifdef(CONFIG_INTEL_ALH
-		${SOF_DRIVERS_PATH}/intel/alh.c
+		${SOF_DRIVERS_PATH}/intel/alh/alh-zephyr.c
 	)
 
 	zephyr_library_sources_ifdef(CONFIG_INTEL_DMIC


### PR DESCRIPTION
Rename dai funcs, add zephyr alh driver,
add get_stream_id to dai driver
Switch to ALH zephyr driver in zephyr build

based on SSP example https://github.com/juimonen/sof/commits/ssp-wip