### PR TITLE
zephyr/docker-build.sh: match UID with 'adduser' instead of 'chgrp -R'

### DIFF
--- a/scripts/docker-run.sh
+++ b/scripts/docker-run.sh
@@ -25,6 +25,11 @@ if tty --quiet; then
     SOF_DOCKER_RUN="$SOF_DOCKER_RUN --tty"
 fi
 
+# Not fatal, just a warning to allow other "creative" solutions.
+# TODO: fix this with 'adduser' like in zephyr/docker-build.sh
+test "$(id -n)" = 1001 ||
+    >&2 printf "Warning: this script should be run as user ID 1001 to match the container\n"
+
 set -x
 docker run -i -v "${SOF_TOP}":/home/sof/work/sof.git \
 	-v "${SOF_TOP}":/home/sof/work/sof-bind-mount-DO-NOT-DELETE \

--- a/zephyr/docker-build.sh
+++ b/zephyr/docker-build.sh
@@ -12,8 +12,54 @@ set -x
 
 unset ZEPHYR_BASE
 
-# Make sure we're in the right place; chgrp -R below.
+# Make sure we're in the right place
 test -e ./scripts/xtensa-build-zephyr.py
+
+
+# See https://stackoverflow.com/questions/35291520/docker-and-userns-remap-how-to-manage-volume-permissions-to-share-data-betwee + many others
+exec_as_sof_uid()
+{
+    local sof_uid; sof_uid="$(stat --printf='%u' .)"
+    local current_uid; current_uid="$(id -u)"
+    if test "$current_uid" = "$sof_uid"; then
+        return 0
+    fi
+
+    # Add new container user matching the host user owning the SOF
+    # checkout
+    local sof_user; sof_user="$(id "$sof_uid")" || {
+        sof_user=sof_zephyr_docker_builder
+
+        local sof_guid; sof_guid="$(stat --printf='%g' .)"
+
+        getent group "$sof_guid" ||
+            sudo groupadd -g  "$sof_guid" sof_zephyr_docker_group
+
+        sudo useradd -m -u "$sof_uid" -g "$sof_guid" "$sof_user"
+
+        local current_user; current_user="$(id -un)"
+
+        # Copy sudo permissions just in case the build needs it
+        sudo sed -e "s/$current_user/$sof_user/" /etc/sudoers.d/"$current_user" |
+            sudo tee -a /etc/sudoers.d/"$sof_user"
+        sudo chmod --reference=/etc/sudoers.d/"$current_user" \
+             /etc/sudoers.d/"$sof_user"
+    }
+
+    # Safety delay: slower infinite loops are much better
+    sleep 0.5
+
+    # Double sudo to work around some funny restriction in
+    # zephyr-build:/etc/sudoers: 'user' can do anything but... only as
+    # root.
+    sudo sudo -u "$sof_user" "$0" "$@"
+    exit "$?"
+}
+
+exec_as_sof_uid "$@"
+
+# Work in progress: move more code to a function
+# https://github.com/thesofproject/sof-test/issues/740
 
 # As of container version 0.18.4,
 # https://github.com/zephyrproject-rtos/docker-image/blob/master/Dockerfile
@@ -28,10 +74,5 @@ ln -s  /opt/toolchains/zephyr-sdk-*  ~/
 if test -e zephyrproject; then
     ./scripts/xtensa-build-zephyr.py  "$@"
 else # -c(lone) with west init etc.
-    # Matches docker.io/zephyrprojectrtos/zephyr-build:latest gid
-    ls -ln | head
-    stat .
-    sudo chgrp -R 1000 .
-    sudo chmod -R g+rwX .
     ./scripts/xtensa-build-zephyr.py -c "$@"
 fi


### PR DESCRIPTION
This fixes SOF version.cmake which was just broken by a recent git
security update and started to fail like this:

```
  -- SOF version.cmake starting at 2022-04-25T18:14:56Z UTC
  -- /workdir/zephyr/.. is at git commit with parent(s):
  fatal: unsafe repository ('/workdir' is owned by someone else)
  To add an exception for this directory, call:

   git config --global --add safe.directory /workdir
```
(example at https://github.com/thesofproject/sof/runs/6162885265)

chgrp -R was always an ugly hack because it was messing with
(persistent) file permissions on the host, outside the container. This
new adduser solution is unfortunately much more code but it does not
leak any side effect outside the container.

Do not fix scripts/docker-run.sh yet because there is still no UID
mismatch between Github Actions and the SOF container (they're both
1001) but add a warning + TODO.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>