### PR TITLE
IPC: IPC4: Fix GCC build errors

### DIFF
--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -201,7 +201,7 @@ static bool is_any_ppl_active(void)
 static int set_pipeline_state(uint32_t id, uint32_t cmd, bool *delayed, uint32_t *ppl_status)
 {
 	struct ipc_comp_dev *pcm_dev;
-	struct ipc_comp_dev *host;
+	struct ipc_comp_dev *host = NULL;
 	struct ipc *ipc = ipc_get();
 	int status;
 	int ret;

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -581,8 +581,8 @@ int ipc4_create_chain_dma(struct ipc *ipc, struct ipc4_chain_dma *cdma)
 	host->period = ipc_pipe->pipeline->period;
 
 	ret = ipc4_add_comp_dev(host);
-	if (ret < 0)
-		return IPC4_FAILURE;
+	if (ret != IPC4_SUCCESS)
+		return ret;
 
 	memset_s(&params, sizeof(params), 0, sizeof(params));
 	memset_s(&copier_cfg, sizeof(copier_cfg), 0, sizeof(copier_cfg));
@@ -603,8 +603,8 @@ int ipc4_create_chain_dma(struct ipc *ipc, struct ipc4_chain_dma *cdma)
 	dai->period = ipc_pipe->pipeline->period;
 
 	ret = ipc4_add_comp_dev(dai);
-	if (ret < 0)
-		return IPC4_FAILURE;
+	if (ret != IPC4_SUCCESS)
+		return ret;
 
 	buf_id = dai_id + 1;
 	if (dir == SOF_IPC_STREAM_PLAYBACK) {
@@ -825,5 +825,5 @@ int ipc4_add_comp_dev(struct comp_dev *dev)
 	/* add new component to the list */
 	list_item_append(&icd->list, &ipc->comp_list);
 
-	return 0;
+	return IPC4_SUCCESS;
 };


### PR DESCRIPTION
This patch fixes errors:

```
src/ipc/ipc4/handler.c: In function 'ipc_cmd':
src/ipc/ipc4/handler.c:204:23: error: 'host' may be used uninitialized
in this function [-Werror=maybe-uninitialized]
  struct ipc_comp_dev *host;
                       ^~~~
src/ipc/ipc4/helper.c: In function 'ipc4_trigger_chain_dma':
src/ipc/ipc4/helper.c:667:6: error: 'ret' may be used uninitialized
in this function [-Werror=maybe-uninitialized]
  int ret;
      ^~~
src/ipc/ipc4/helper.c: In function 'ipc4_create_chain_dma':
src/ipc/ipc4/helper.c:507:13: error: 'frame_size' may be
used uninitialized in this function [-Werror=maybe-uninitialized]
  frame_size >>= 1;
  ~~~~~~~~~~~^~~~~

src/ipc/ipc4/helper.c:482:11: note: 'frame_size' was declared here
  uint32_t frame_size;
           ^~~~~~~~~~

```
Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>