### PR TITLE
[SKIP CI] .github: IPC4: build supported TGL platforms first

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:  # just a vector in this case
         make_env: [
           IPC_VERSION=,  # default version
-          IPC_VERSION=IPC4 UNSIGNED_list= SIGNED_list='cnl icl jsl tgl tgl-h',
+          IPC_VERSION=IPC4 UNSIGNED_list= SIGNED_list='tgl tgl-h cnl icl jsl',
         ]
 
     steps:


### PR DESCRIPTION
When the build fails we don't want to waste time wondering whether TGL
is affected or not. Other, unsupported platforms are only providing some
nice to have "randconfig" coverage (#5364), they're not important.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>