### PR TITLE
stable-v2.0: un-hardcode Zephyr container and SDK

### DIFF
--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -19,5 +19,5 @@ jobs:
       # -e https_proxy=...
       - name: build
         run: docker run -v "$(pwd)":/workdir
-             docker.io/zephyrprojectrtos/zephyr-build:v0.21.0
+             docker.io/zephyrprojectrtos/zephyr-build:latest
              ./zephyr/docker-build.sh -- -DEXTRA_CFLAGS='-Werror'

--- a/scripts/xtensa-build-zephyr.sh
+++ b/scripts/xtensa-build-zephyr.sh
@@ -118,11 +118,11 @@ west_init_update()
 {
 	# Default Zephyr remote and branch if nothing passed on the
 	# command line.
-	local init_remote="${1:-https://github.com/zephyrproject-rtos/zephyr}"
+	local init_remote="${1:-https://github.com/thesofproject/zephyr}"
 
 	# This can be a branch, a 40-digit SHA or empty to fetch the
 	# default branch
-	local init_ref="${2:-fd089b361d8aebbcb49cca989444aaeb0b6fbb4d}"
+	local init_ref="${2:-sof/stable-v2.0}"
 
 	# git fetch accepts anything, even 40-digits SHA but git clone is
 	# less flexible. So we git clone the default branch first to get


### PR DESCRIPTION
2 commits, see commit messages.