### PR TITLE
ipc4: use SOF_COMP_COPIER for copier module

### DIFF
--- a/src/audio/copier.c
+++ b/src/audio/copier.c
@@ -171,9 +171,7 @@ static struct comp_dev *create_host(struct comp_dev *parent_dev, struct copier_d
 	if (!drv)
 		return NULL;
 
-	parent_dev->ipc_config.type = SOF_COMP_HOST;
 	config->type = SOF_COMP_HOST;
-
 	create_endpoint_buffer(parent_dev, cd, config, copier_cfg);
 
 	memset(&ipc_host, 0, sizeof(ipc_host));
@@ -224,7 +222,6 @@ static struct comp_dev *create_dai(struct comp_dev *parent_dev, struct copier_da
 	if (!drv)
 		return NULL;
 
-	parent_dev->ipc_config.type = SOF_COMP_DAI;
 	config->type = SOF_COMP_DAI;
 	create_endpoint_buffer(parent_dev, cd, config, copier);
 

--- a/src/include/sof/ipc/topology.h
+++ b/src/include/sof/ipc/topology.h
@@ -52,6 +52,7 @@ int ipc4_add_comp_dev(struct comp_dev *dev);
 const struct comp_driver *ipc4_get_drv(uint8_t *uuid);
 int ipc4_create_chain_dma(struct ipc *ipc, struct ipc4_chain_dma *cdma);
 int ipc4_trigger_chain_dma(struct ipc *ipc, struct ipc4_chain_dma *cdma);
+bool ipc4_comp_is_gateway(struct comp_dev *dev);
 #else
 #error "No or invalid IPC MAJOR version selected."
 #endif

--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -420,8 +420,7 @@ static int update_dir_to_pipeline_component(uint32_t *ppl_id, uint32_t count)
 				 * since one of them is for playback and the other one
 				 * is for capture
 				 */
-				if (dev_comp_type(icd->cd) == SOF_COMP_HOST ||
-				    dev_comp_type(icd->cd) == SOF_COMP_DAI)
+				if (ipc4_comp_is_gateway(icd->cd))
 					break;
 
 				icd->cd->direction = dai->direction;

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -771,6 +771,21 @@ out:
 	return drv;
 }
 
+bool ipc4_comp_is_gateway(struct comp_dev *dev)
+{
+	const struct sof_uuid copier = {0x9ba00c83, 0xca12, 0x4a83, {0x94, 0x3c,
+		0x1f, 0xa2, 0xe8, 0x2f, 0x9d, 0xda}};
+
+	/* check whether it is a copier module with copier uuid */
+	if (!memcmp(dev->drv->uid, &copier, UUID_SIZE)) {
+		/* dai or host, not a module for copy */
+		if (list_is_empty(&dev->bsink_list) || list_is_empty(&dev->bsource_list))
+			return true;
+	}
+
+	return false;
+}
+
 const struct comp_driver *ipc4_get_comp_drv(int module_id)
 {
 	struct sof_man_fw_desc *desc = (struct sof_man_fw_desc *)IMR_BOOT_LDR_MANIFEST_BASE;


### PR DESCRIPTION
Fix a capture issue on windows. Currently we use SOF_COMP_HOST
or SOF_COMP_DAI for copier with host or dai included. But There
are some functions process copier as host or dai since its type
is that type. This will result to unexpect error.

This patch introduce SOF_COMP_COPIER for copier so that it can
be indentified in ipc4 framework.

Signed-off-by: Rander Wang <rander.wang@intel.com>