### PR TITLE
Add RTNR library path for MT8195

### DIFF
--- a/src/audio/rtnr/CMakeLists.txt
+++ b/src/audio/rtnr/CMakeLists.txt
@@ -2,7 +2,8 @@
 
 add_local_sources(sof rtnr.c)
 
-sof_add_static_library(SOF_RTK_MA_API rtklib/tgl/libSOF_RTK_MA_API.a)
-sof_add_static_library(Suite_rename rtklib/tgl/libSuite_rename.a)
-sof_add_static_library(Net rtklib/tgl/libNet.a)
-sof_add_static_library(Preset rtklib/tgl/libPreset.a)
+if(CONFIG_TIGERLAKE)
+	add_subdirectory(rtklib/tgl)
+elseif(CONFIG_MT8195)
+	add_subdirectory(rtklib/mt8195)
+endif()

--- a/src/audio/rtnr/rtklib/mt8195/CMakeLists.txt
+++ b/src/audio/rtnr/rtklib/mt8195/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+sof_add_static_library(SOF_RTK_MA_API libSOF_RTK_MA_API.a)
+sof_add_static_library(Suite_rename libSuite_MaLtFP.a)
+sof_add_static_library(Net libNet.a)
+sof_add_static_library(Preset libPreset.a)
+
+

--- a/src/audio/rtnr/rtklib/mt8195/README.txt
+++ b/src/audio/rtnr/rtklib/mt8195/README.txt
@@ -1,0 +1,1 @@
+Put libSOF_RTK_MA_API.a, libSuite_MaLtFP.a, libNet.a and libPreset.a here.

--- a/src/audio/rtnr/rtklib/tgl/CMakeLists.txt
+++ b/src/audio/rtnr/rtklib/tgl/CMakeLists.txt
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+sof_add_static_library(SOF_RTK_MA_API libSOF_RTK_MA_API.a)
+sof_add_static_library(Suite_rename libSuite_rename.a)
+sof_add_static_library(Net libNet.a)
+sof_add_static_library(Preset libPreset.a)
+


### PR DESCRIPTION
This PR separates RTNR library path for multiple platforms including MT8195.