### PR TITLE
drivers: amd: renoir: add remove call back function

### DIFF
--- a/src/drivers/amd/renoir/acp_bt_dai.c
+++ b/src/drivers/amd/renoir/acp_bt_dai.c
@@ -44,6 +44,12 @@ static int btdai_probe(struct dai *dai)
 	return 0;
 }
 
+static int btdai_remove(struct dai *dai)
+{
+	/* TODO */
+	return 0;
+}
+
 static int btdai_get_fifo(struct dai *dai, int direction, int stream_id)
 {
 	switch (direction) {
@@ -82,6 +88,7 @@ const struct dai_driver acp_btdai_driver = {
 		.trigger		= btdai_trigger,
 		.set_config		= btdai_set_config,
 		.probe			= btdai_probe,
+		.remove			= btdai_remove,
 		.get_fifo		= btdai_get_fifo,
 		.get_handshake		= btdai_get_handshake,
 		.get_hw_params		= btdai_get_hw_params,

--- a/src/drivers/amd/renoir/acp_sp_dai.c
+++ b/src/drivers/amd/renoir/acp_sp_dai.c
@@ -43,6 +43,12 @@ static int spdai_probe(struct dai *dai)
 	return 0;
 }
 
+static int spdai_remove(struct dai *dai)
+{
+	/* TODO*/
+	return 0;
+}
+
 static int spdai_get_fifo(struct dai *dai, int direction, int stream_id)
 {
 	switch (direction) {
@@ -82,6 +88,7 @@ const struct dai_driver acp_spdai_driver = {
 		.trigger		= spdai_trigger,
 		.set_config		= spdai_set_config,
 		.probe			= spdai_probe,
+		.remove			= spdai_remove,
 		.get_fifo		= spdai_get_fifo,
 		.get_handshake		= spdai_get_handshake,
 		.get_hw_params          = spdai_get_hw_params,


### PR DESCRIPTION
Add remove callback function for SP and BT dai
drivers in dai ops.

This callbacks definition will resolve the firmware
NULL pointer access during remove sequence from sof core.

Signed-off-by: Balakishorepati <balaKishore.pati@amd.com>