### PR TITLE
Make Zephyr build compatible with optional assert()

### DIFF
--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -300,8 +300,10 @@ static int mux_ctrl_get_cmd(struct comp_dev *dev,
 			sizeof(struct mux_stream_data);
 
 		/* copy back to user space */
-		assert(!memcpy_s(cdata->data->data, ((struct sof_abi_hdr *)
-				 (cdata->data))->size, cfg, reply_size));
+		const int mux_memcpy_err __unused =
+			memcpy_s(cdata->data->data, ((struct sof_abi_hdr *)
+						     (cdata->data))->size, cfg, reply_size);
+		assert(!mux_memcpy_err);
 
 		cdata->data->abi = SOF_ABI_VERSION;
 		cdata->data->size = reply_size;

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -798,9 +798,12 @@ static int src_trigger(struct comp_dev *dev, int cmd)
 
 	comp_info(dev, "src_trigger()");
 
-	if (cmd == COMP_TRIGGER_START || cmd == COMP_TRIGGER_RELEASE)
-		assert(cd->polyphase_func);
-
+	if (cmd == COMP_TRIGGER_START || cmd == COMP_TRIGGER_RELEASE) {
+		if (!cd->polyphase_func) {
+			comp_err(dev, "polyphase_func is not set");
+			return -EINVAL;
+		}
+	}
 	return comp_set_state(dev, cmd);
 }
 

--- a/src/idc/idc.c
+++ b/src/idc/idc.c
@@ -368,7 +368,7 @@ int idc_init(void)
 
 int idc_restore(void)
 {
-	struct idc **idc = idc_get();
+	struct idc **idc __unused = idc_get();
 
 	tr_info(&idc_tr, "idc_restore()");
 

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -669,7 +669,7 @@ static inline struct comp_dev *comp_alloc(const struct comp_driver *drv,
  * @return Private data.
  */
 #define comp_get_drvdata(c) \
-	c->priv_data
+	(c->priv_data)
 
 #if defined UNIT_TEST || defined __ZEPHYR__
 #define DECLARE_MODULE(init)

--- a/src/include/sof/debug/panic.h
+++ b/src/include/sof/debug/panic.h
@@ -39,7 +39,12 @@ void panic_dump(uint32_t p, struct sof_ipc_panic_info *panic_info,
 		if (!(x))	\
 			k_oops();\
 	} while (0)
-#else
+/* To print the asserted expression on failure:
+ *  #define assert(x) __ASSERT(x, #x)
+ */
+
+#else /* __ZEPHYR__ */
+
 
 void __panic(uint32_t p, char *filename, uint32_t linenum) SOF_NORETURN;
 

--- a/src/include/sof/lib/mailbox.h
+++ b/src/include/sof/lib/mailbox.h
@@ -9,6 +9,7 @@
 #ifndef __SOF_LIB_MAILBOX_H__
 #define __SOF_LIB_MAILBOX_H__
 
+#include <sof/common.h>
 #include <kernel/mailbox.h>
 #include <platform/lib/mailbox.h>
 #include <sof/debug/panic.h>
@@ -45,10 +46,10 @@
 static inline
 void mailbox_dspbox_write(size_t offset, const void *src, size_t bytes)
 {
-	int ret = memcpy_s((void *)(MAILBOX_DSPBOX_BASE + offset),
-			   MAILBOX_DSPBOX_SIZE - offset, src, bytes);
+	int dsp_write_err __unused = memcpy_s((void *)(MAILBOX_DSPBOX_BASE + offset),
+					      MAILBOX_DSPBOX_SIZE - offset, src, bytes);
 
-	assert(!ret);
+	assert(!dsp_write_err);
 	dcache_writeback_region((__sparse_force void __sparse_cache *)(MAILBOX_DSPBOX_BASE +
 								       offset), bytes);
 }
@@ -57,13 +58,13 @@ static inline
 void mailbox_dspbox_read(void *dest, size_t dest_size,
 			 size_t offset, size_t bytes)
 {
-	int ret;
+	int dsp_read_err __unused;
 
 	dcache_invalidate_region((__sparse_force void __sparse_cache *)(MAILBOX_DSPBOX_BASE +
 									offset), bytes);
-	ret = memcpy_s(dest, dest_size,
-		       (void *)(MAILBOX_DSPBOX_BASE + offset), bytes);
-	assert(!ret);
+	dsp_read_err = memcpy_s(dest, dest_size,
+				(void *)(MAILBOX_DSPBOX_BASE + offset), bytes);
+	assert(!dsp_read_err);
 }
 
 #if CONFIG_LIBRARY
@@ -77,10 +78,10 @@ void mailbox_hostbox_write(size_t offset, const void *src, size_t bytes)
 static inline
 void mailbox_hostbox_write(size_t offset, const void *src, size_t bytes)
 {
-	int ret = memcpy_s((void *)(MAILBOX_HOSTBOX_BASE + offset),
-			   MAILBOX_HOSTBOX_SIZE - offset, src, bytes);
+	int host_write_err __unused = memcpy_s((void *)(MAILBOX_HOSTBOX_BASE + offset),
+					       MAILBOX_HOSTBOX_SIZE - offset, src, bytes);
 
-	assert(!ret);
+	assert(!host_write_err);
 	dcache_writeback_region((__sparse_force void __sparse_cache *)(MAILBOX_HOSTBOX_BASE +
 								       offset), bytes);
 }
@@ -91,22 +92,22 @@ static inline
 void mailbox_hostbox_read(void *dest, size_t dest_size,
 			  size_t offset, size_t bytes)
 {
-	int ret;
+	int host_read_err __unused;
 
 	dcache_invalidate_region((__sparse_force void __sparse_cache *)(MAILBOX_HOSTBOX_BASE +
 									offset), bytes);
-	ret = memcpy_s(dest, dest_size,
-		       (void *)(MAILBOX_HOSTBOX_BASE + offset), bytes);
-	assert(!ret);
+	host_read_err = memcpy_s(dest, dest_size,
+				 (void *)(MAILBOX_HOSTBOX_BASE + offset), bytes);
+	assert(!host_read_err);
 }
 
 static inline
 void mailbox_stream_write(size_t offset, const void *src, size_t bytes)
 {
-	int ret = memcpy_s((void *)(MAILBOX_STREAM_BASE + offset),
-			   MAILBOX_STREAM_SIZE - offset, src, bytes);
+	int stream_write_err __unused = memcpy_s((void *)(MAILBOX_STREAM_BASE + offset),
+						 MAILBOX_STREAM_SIZE - offset, src, bytes);
 
-	assert(!ret);
+	assert(!stream_write_err);
 	dcache_writeback_region((__sparse_force void __sparse_cache *)(MAILBOX_STREAM_BASE +
 								       offset), bytes);
 }

--- a/src/platform/intel/cavs/include/cavs/lib/mailbox.h
+++ b/src/platform/intel/cavs/include/cavs/lib/mailbox.h
@@ -111,10 +111,10 @@ static inline uint64_t mailbox_sw_reg_read64(size_t offset)
 
 static inline void mailbox_sw_regs_write(size_t offset, const void *src, size_t bytes)
 {
-	int ret = memcpy_s((void *)(MAILBOX_SW_REG_BASE + offset),
-			   MAILBOX_SW_REG_SIZE - offset, src, bytes);
+	int regs_write_err __unused = memcpy_s((void *)(MAILBOX_SW_REG_BASE + offset),
+					       MAILBOX_SW_REG_SIZE - offset, src, bytes);
 
-	assert(!ret);
+	assert(!regs_write_err);
 	dcache_writeback_region((__sparse_force void __sparse_cache *)(MAILBOX_SW_REG_BASE +
 								       offset), bytes);
 }


### PR DESCRIPTION
2 commits

----

Break down buggy assert(!memcpy_s(...)) into two statements

assert() semantics are very clear: because asserts are optional, the
argument should never have side-effect, period. assert arguments should
be treated exactly the same as logging arguments. So
`assert(!memcpy_s())` is an obvious bug. Use variable to break that down
into two statements.

Fixes commit 0b7fd030b391 ("demux: return config on COMP_CMD_GET_DATA")

Fixes commit 385586a5f664 ("zephyr: implement IDC using P4WQ")

----

Make Zephyr build compatible with optional assert() with __unused

For some legacy reason(s), SOF assert() is not optional. This is unlike
any other assert() anywhere else. This hasn't been a problem yet because
until now SOF assert() has been mapped to a non-optional and limited
Zephyr k_oops()

This commit makes it possible to temporarily or permanently switch the
Zephyr build to Zephyr's __ASSERT(expr, #expr) macro which logs the
asserted expression. This commit does NOT make such a switch.

Note this commit is not enough to make assert() optional in the XTOS
build.