### PR TITLE
[RFC] CMake: pass firmware file micro version to rimage

### DIFF
--- a/src/arch/xtensa/CMakeLists.txt
+++ b/src/arch/xtensa/CMakeLists.txt
@@ -457,7 +457,7 @@ if(MEU_PATH OR DEFINED MEU_NO_SIGN) # Don't sign with rimage
 			-s ${MEU_OFFSET}
 			-k ${RIMAGE_PRIVATE_KEY}
 			-i ${RIMAGE_IMR_TYPE}
-			-f ${SOF_MAJOR}.${SOF_MINOR}
+			-f ${SOF_MAJOR}.${SOF_MINOR}.${SOF_MICRO}
 			-b ${SOF_BUILD}
 			-e
 			${bootloader_binary_path}
@@ -498,7 +498,7 @@ else() # sign with rimage
 			-c "${PROJECT_SOURCE_DIR}/rimage/config/${fw_name}.toml"
 			-k ${RIMAGE_PRIVATE_KEY}
 			-i ${RIMAGE_IMR_TYPE}
-			-f ${SOF_MAJOR}.${SOF_MINOR}
+			-f ${SOF_MAJOR}.${SOF_MINOR}.${SOF_MICRO}
 			-b ${SOF_BUILD}
 			-e
 			${bootloader_binary_path}

--- a/tools/ctl/ctl.c
+++ b/tools/ctl/ctl.c
@@ -202,7 +202,7 @@ static void hex_data_dump(struct ctl_data *ctl_data)
 	/* Print out in 16bit hex format */
 	for (i = 0; i < n; i++) {
 		if (!(i % 8))
-			fprintf(stdout, "%08lx ",
+			fprintf(stdout, "%08zx ",
 				i * sizeof(uint16_t));
 		fprintf(stdout, "%04x ", config[i]);
 		if ((i % 8) == 7)
@@ -410,7 +410,7 @@ static void ctl_dump(struct ctl_data *ctl_data)
 {
 	FILE *fh;
 	int offset = 0;
-	size_t n;/* in bytes */
+	size_t n = 0;/* in bytes */
 
 	if (ctl_data->out_fd > 0) {
 		if (ctl_data->binary) {
@@ -441,7 +441,7 @@ static void ctl_dump(struct ctl_data *ctl_data)
 			csv_data_dump(ctl_data, fh);
 		}
 
-		fprintf(stdout, "%ld bytes written to file.\n", n);
+		fprintf(stdout, "%zd bytes written to file.\n", n);
 		fclose(fh);
 	} else {
 		/* dump to stdout */


### PR DESCRIPTION
To fix https://github.com/thesofproject/sof/issues/5693

This PR depends on https://github.com/thesofproject/rimage/pull/91, which needs to be merged at first

SOF CMake defines SOF_MAJOR, SOF_MINOR and SOF_MICRO for 3 fields of
firmware file version major.minor.micro. But CMake only passes the major
and minor version to rimage.

Now CMake will also pass the mirco version to rimage, so that rimage can
write it to different firmware manifest headers for cAVS platforms and
then sof_ri_info.py will be able to dump entire file version info from
the firmware binary.