### PR TITLE
[RFC] CMake: pass firmware file micro version to rimage

### DIFF
--- a/src/arch/xtensa/CMakeLists.txt
+++ b/src/arch/xtensa/CMakeLists.txt
@@ -457,7 +457,7 @@ if(MEU_PATH OR DEFINED MEU_NO_SIGN) # Don't sign with rimage
 			-s ${MEU_OFFSET}
 			-k ${RIMAGE_PRIVATE_KEY}
 			-i ${RIMAGE_IMR_TYPE}
-			-f ${SOF_MAJOR}.${SOF_MINOR}
+			-f ${SOF_MAJOR}.${SOF_MINOR}.${SOF_MICRO}
 			-b ${SOF_BUILD}
 			-e
 			${bootloader_binary_path}
@@ -498,7 +498,7 @@ else() # sign with rimage
 			-c "${PROJECT_SOURCE_DIR}/rimage/config/${fw_name}.toml"
 			-k ${RIMAGE_PRIVATE_KEY}
 			-i ${RIMAGE_IMR_TYPE}
-			-f ${SOF_MAJOR}.${SOF_MINOR}
+			-f ${SOF_MAJOR}.${SOF_MINOR}.${SOF_MICRO}
 			-b ${SOF_BUILD}
 			-e
 			${bootloader_binary_path}


### PR DESCRIPTION
To fix https://github.com/thesofproject/sof/issues/5693

This PR depends on https://github.com/thesofproject/rimage/pull/91 . The rimage PR needs to be merged at first.

SOF CMake defines SOF_MAJOR, SOF_MINOR and SOF_MICRO for 3 fields of
firmware file version major.minor.micro. But CMake only passes the major
and minor version to rimage.

Now CMake will also pass the mirco version to rimage, so that rimage can
write it to different firmware manifest headers for cAVS platforms and
then sof_ri_info.py will be able to dump entire file version info from
the firmware binary.
