### PR TITLE
mux: Use a fixed size for mux_stream_data

### DIFF
--- a/src/include/sof/audio/mux.h
+++ b/src/include/sof/audio/mux.h
@@ -55,7 +55,8 @@ struct mux_stream_data {
 	uint8_t num_channels_deprecated;	/* deprecated in ABI 3.15 */
 	uint8_t mask[PLATFORM_MAX_CHANNELS];
 
-	uint8_t reserved[(20 - PLATFORM_MAX_CHANNELS - 1) % 4]; // padding to ensure proper alignment of following instances
+	uint8_t reserved1[8 - PLATFORM_MAX_CHANNELS]; // padding for extra channels
+	uint8_t reserved2[3]; // padding to ensure proper alignment of following instances
 };
 
 typedef void(*demux_func)(struct comp_dev *dev, struct audio_stream *sink,

--- a/src/include/sof/audio/mux.h
+++ b/src/include/sof/audio/mux.h
@@ -57,7 +57,7 @@ struct mux_stream_data {
 
 	uint8_t reserved1[8 - PLATFORM_MAX_CHANNELS]; // padding for extra channels
 	uint8_t reserved2[3]; // padding to ensure proper alignment of following instances
-};
+} __attribute__((packed, aligned(4)));
 
 typedef void(*demux_func)(struct comp_dev *dev, struct audio_stream *sink,
 			  const struct audio_stream *source, uint32_t frames,
@@ -113,7 +113,7 @@ struct sof_mux_config {
 	uint16_t reserved; // padding to ensure proper alignment
 
 	struct mux_stream_data streams[];
-};
+} __attribute__((packed, aligned(4)));
 
 struct comp_data {
 	union {


### PR DESCRIPTION
If PLATFORM_MAX_CHANNELS < 8 the mux_stream_data becomes
smaller, however there is no easy to way
supply a smaller ROUTE_MATRIX in m4/muxdemux.m4.

Instead, pad the mux_stream_data so the sizes from firmware
and topology match.

Signed-off-by: Li-Yu Yu <aaronyu@google.com>