### PR TITLE
platform: Enable IMR boot for all CAVS platforms

### DIFF
--- a/src/platform/Kconfig
+++ b/src/platform/Kconfig
@@ -447,7 +447,7 @@ config CAVS_USE_LPRO_IN_WAITI
 
 config CAVS_IMR_D3_PERSISTENT
 	bool "Intel IMR content persistent on DSP in D3"
-	depends on CAVS && !CAVS_VERSION_1_5
+	depends on CAVS
 	default y
 	help
 	  Select this if the Intel cAVS platform can keep the


### PR DESCRIPTION
With the recent kernel change the IMR restore sequence got modified a bit
and it might have some effect on the APL issue.

Signed-off-by: Peter Ujfalusi <peter.ujfalusi@linux.intel.com>