### PR TITLE
RTNR: Decouple switch-enable control from params blob

### DIFF
--- a/src/audio/rtnr/rtnr.c
+++ b/src/audio/rtnr/rtnr.c
@@ -181,24 +181,6 @@ static rtnr_func rtnr_find_func(enum sof_ipc_frame fmt)
 	return NULL;
 }
 
-static inline void rtnr_set_process(struct comp_dev *dev)
-{
-	comp_info(dev, "rtnr_set_process()");
-	struct comp_data *cd = comp_get_drvdata(dev);
-
-	cd->process_enable = true;
-	RTKMA_API_Bypass(cd->rtk_agl, 0);
-}
-
-static inline void rtnr_set_bypass(struct comp_dev *dev)
-{
-	comp_info(dev, "rtnr_set_bypass()");
-	struct comp_data *cd = comp_get_drvdata(dev);
-
-	cd->process_enable = false;
-	RTKMA_API_Bypass(cd->rtk_agl, 1);
-}
-
 static inline void rtnr_set_process_sample_rate(struct comp_dev *dev, uint32_t sample_rate)
 {
 	comp_dbg(dev, "rtnr_set_process_sample_rate()");
@@ -217,25 +199,14 @@ static int32_t rtnr_check_config_validity(struct comp_dev *dev,
 		comp_err(dev, "rtnr_check_config_validity() error: invalid cd->model_handler");
 		ret = -EINVAL;
 	} else {
-		comp_info(dev, "rtnr_check_config_validity() enabled: %d sample_rate:%d",
-				p_config->params.enabled,
+		comp_info(dev, "rtnr_check_config_validity() sample_rate:%d",
 				p_config->params.sample_rate);
-
-		if (p_config->params.enabled)
-			rtnr_set_process(dev);
-		else
-			rtnr_set_bypass(dev);
 
 		rtnr_set_process_sample_rate(dev, p_config->params.sample_rate);
 	}
 
 	return ret;
 }
-
-
-/*
- * End of RTNR setup code. Next the standard component methods.
- */
 
 static struct comp_dev *rtnr_new(const struct comp_driver *drv,
 								struct comp_ipc_config *config,
@@ -270,6 +241,8 @@ static struct comp_dev *rtnr_new(const struct comp_driver *drv,
 
 	comp_set_drvdata(dev, cd);
 
+	cd->process_enable = false;
+
 	/* Handler for configuration data */
 	cd->model_handler = comp_data_blob_handler_new(dev);
 	if (!cd->model_handler) {
@@ -287,7 +260,7 @@ static struct comp_dev *rtnr_new(const struct comp_driver *drv,
 	/* Component defaults */
 	cd->source_channel = 0;
 
-    /* Check config */
+	/* Get default sample rate from topology */
 	ret = rtnr_check_config_validity(dev, cd);
 	if (ret < 0) {
 		comp_cl_err(&comp_rtnr, "rtnr_new(): rtnr_check_config_validity() failed.");
@@ -416,9 +389,6 @@ static int rtnr_cmd_set_data(struct comp_dev *dev,
 		break;
 	}
 
-	if (ret >= 0)
-		ret = rtnr_check_config_validity(dev, cd);
-
 	return ret;
 }
 
@@ -450,16 +420,15 @@ static int32_t rtnr_set_value(struct comp_dev *dev, struct sof_ipc_ctrl_data *cd
 {
 	uint32_t val = 0;
 	int32_t j;
+	struct comp_data *cd = comp_get_drvdata(dev);
 
 	for (j = 0; j < cdata->num_elems; j++) {
 		val |= cdata->chanv[j].value;
 		comp_info(dev, "rtnr_set_value(), value = %u", val);
 	}
 
-	if (val)
-		rtnr_set_process(dev);
-	else
-		rtnr_set_bypass(dev);
+	cd->process_enable = !val;
+	RTKMA_API_Bypass(cd->rtk_agl, !val);
 
 	return 0;
 }
@@ -585,7 +554,7 @@ static int rtnr_prepare(struct comp_dev *dev)
 	struct comp_buffer *sinkb;
 	int ret;
 
-	comp_info(dev, "rtnr_prepare()");
+	comp_dbg(dev, "rtnr_prepare()");
 
 	ret = comp_set_state(dev, COMP_TRIGGER_PREPARE);
 	if (ret < 0)
@@ -594,11 +563,20 @@ static int rtnr_prepare(struct comp_dev *dev)
 	if (ret == COMP_STATUS_STATE_ALREADY_SET)
 		return PPL_STATUS_PATH_STOP;
 
+	/* Check config */
+	ret = rtnr_check_config_validity(dev, cd);
+	if (ret < 0) {
+		comp_cl_err(&comp_rtnr, "rtnr_prepare(): rtnr_check_config_validity() failed.");
+		goto err;
+	}
+
+	/* Initialize RTNR */
+
 	/* Get sink data format */
 	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
 	cd->sink_format = sinkb->stream.frame_fmt;
 
-	/* Check source and sink PCM format and get copy function */
+	/* Check source and sink PCM format and get processing function */
 	comp_info(dev, "rtnr_prepare(), sink_format=%d", cd->sink_format);
 	cd->rtnr_func = rtnr_find_func(cd->sink_format);
 	if (!cd->rtnr_func) {
@@ -606,13 +584,9 @@ static int rtnr_prepare(struct comp_dev *dev)
 		goto err;
 	}
 
-	/* Default on */
-	cd->process_enable = true;
-
 	/* Clear in/out buffers */
 	RTKMA_API_Prepare(cd->rtk_agl);
 
-	/* Initialize RTNR */
 	return 0;
 
 err:

--- a/src/include/sof/audio/rtnr/rtnr.h
+++ b/src/include/sof/audio/rtnr/rtnr.h
@@ -22,6 +22,8 @@ typedef void (*rtnr_func)(struct comp_dev *dev,
 						  struct audio_stream *sink,
 						  int frames);
 
+#define RTNR_MAX_SOURCES		1 /* Microphone stream */
+
 /* RTNR component private data */
 struct comp_data {
 	struct comp_data_blob_handler *model_handler;

--- a/tools/topology/topology1/m4/rtnr.m4
+++ b/tools/topology/topology1/m4/rtnr.m4
@@ -60,6 +60,9 @@ define(`W_RTNR',
 `	bytes ['
 		$6
 `	]'
+`	mixer ['
+		$7
+`	]'
 `}')
 
 divert(0)dnl

--- a/tools/topology/topology1/sof/pipe-rtnr-capture-16khz.m4
+++ b/tools/topology/topology1/sof/pipe-rtnr-capture-16khz.m4
@@ -13,6 +13,7 @@ include(`buffer.m4')
 include(`pcm.m4')
 include(`dai.m4')
 include(`pipeline.m4')
+include(`mixercontrol.m4')
 include(`bytecontrol.m4')
 include(`rtnr.m4')
 
@@ -45,6 +46,19 @@ C_CONTROLBYTES(DEF_RTNR_BYTES, PIPELINE_ID,
 	,
 	DEF_RTNR_PRIV)
 
+# RTNR Enable switch
+define(DEF_RTNR_ENABLE, concat(`rtnr_enable_', PIPELINE_ID))
+define(`CONTROL_NAME', `DEF_RTNR_ENABLE')
+
+C_CONTROLMIXER(DEF_RTNR_ENABLE, PIPELINE_ID,
+	CONTROLMIXER_OPS(volsw, 259 binds the mixer control to switch get/put handlers, 259, 259),
+	CONTROLMIXER_MAX(max 1 indicates switch type control, 1),
+	false,
+	,
+	Channel register and shift for Front Center,
+	LIST(`	', KCONTROL_CHANNEL(FC, 3, 0)),
+	"1")
+undefine(`CONTROL_NAME')
 
 #
 # Components and Buffers
@@ -55,7 +69,9 @@ C_CONTROLBYTES(DEF_RTNR_BYTES, PIPELINE_ID,
 W_PCM_CAPTURE(PCM_ID, Capture, 0, 2, DMIC_PIPELINE_16k_CORE_ID)
 
 # "RTNR 0" has 2 sink period and 2 source periods
-W_RTNR(0, PIPELINE_FORMAT, 2, DAI_PERIODS, DMIC_PIPELINE_16k_CORE_ID, LIST(`		', "DEF_RTNR_BYTES"))
+W_RTNR(0, PIPELINE_FORMAT, 2, DAI_PERIODS, SCHEDULE_CORE,
+	LIST(`		', "DEF_RTNR_BYTES"),
+	LIST(`          ', "DEF_RTNR_ENABLE"))
 
 # Capture Buffers
 W_BUFFER(0, COMP_BUFFER_SIZE(4,
@@ -86,5 +102,6 @@ PCM_CAPABILITIES(Capture PCM_ID, CAPABILITY_FORMAT_NAME(PIPELINE_FORMAT),
 	PCM_MIN_RATE, PCM_MAX_RATE, PIPELINE_CHANNELS, PIPELINE_CHANNELS,
 	2, 16, 192, 16384, RTNR_BUFFER_SIZE_MIN, RTNR_BUFFER_SIZE_MAX)
 
+undefine(`DEF_RTNR_ENABLE')
 undefine(`DEF_RTNR_PRIV')
 undefine(`DEF_RTNR_BYTES')

--- a/tools/topology/topology1/sof/pipe-rtnr-capture.m4
+++ b/tools/topology/topology1/sof/pipe-rtnr-capture.m4
@@ -13,6 +13,7 @@ include(`buffer.m4')
 include(`pcm.m4')
 include(`dai.m4')
 include(`pipeline.m4')
+include(`mixercontrol.m4')
 include(`bytecontrol.m4')
 include(`rtnr.m4')
 
@@ -45,6 +46,19 @@ C_CONTROLBYTES(DEF_RTNR_BYTES, PIPELINE_ID,
 	,
 	DEF_RTNR_PRIV)
 
+# RTNR Enable switch
+define(DEF_RTNR_ENABLE, concat(`rtnr_enable_', PIPELINE_ID))
+define(`CONTROL_NAME', `DEF_RTNR_ENABLE')
+
+C_CONTROLMIXER(DEF_RTNR_ENABLE, PIPELINE_ID,
+	CONTROLMIXER_OPS(volsw, 259 binds the mixer control to switch get/put handlers, 259, 259),
+	CONTROLMIXER_MAX(max 1 indicates switch type control, 1),
+	false,
+	,
+	Channel register and shift for Front Center,
+	LIST(`	', KCONTROL_CHANNEL(FC, 3, 0)),
+	"1")
+undefine(`CONTROL_NAME')
 
 #
 # Components and Buffers
@@ -55,7 +69,9 @@ C_CONTROLBYTES(DEF_RTNR_BYTES, PIPELINE_ID,
 W_PCM_CAPTURE(PCM_ID, Capture, 0, 2, SCHEDULE_CORE)
 
 # "RTNR 0" has 2 sink period and 2 source periods
-W_RTNR(0, PIPELINE_FORMAT, 2, DAI_PERIODS, SCHEDULE_CORE, LIST(`		', "DEF_RTNR_BYTES"))
+W_RTNR(0, PIPELINE_FORMAT, 2, DAI_PERIODS, SCHEDULE_CORE,
+	LIST(`		', "DEF_RTNR_BYTES"),
+	LIST(`          ', "DEF_RTNR_ENABLE"))
 
 # Capture Buffers
 W_BUFFER(0, COMP_BUFFER_SIZE(4,
@@ -86,5 +102,6 @@ PCM_CAPABILITIES(Capture PCM_ID, CAPABILITY_FORMAT_NAME(PIPELINE_FORMAT),
 	PCM_MIN_RATE, PCM_MAX_RATE, PIPELINE_CHANNELS, PIPELINE_CHANNELS,
 	2, 16, 192, 16384, RTNR_BUFFER_SIZE_MIN, RTNR_BUFFER_SIZE_MAX)
 
+undefine(`DEF_RTNR_ENABLE')
 undefine(`DEF_RTNR_PRIV')
 undefine(`DEF_RTNR_BYTES')


### PR DESCRIPTION
This PR is based on https://github.com/thesofproject/sof/pull/5616

It decouples the switch-typed control for enabling/disabling from the control bytes.

Previously, control blobs should be sent from userspace to to toggle RTNR on/off.
With this PR, RTNR can be toggled by setting the UCM switch value.

cset "name='RTNR10.0 rtnr_enable_10' off"
cset "name='RTNR10.0 rtnr_enable_10' on"

or from command line

amixer -c0 cset name='RTNR10.0 rtnr_enable_10' 1
amixer -c0 cget name='RTNR10.0 rtnr_enable_10' 0

Signed-off-by: Pin-chih Lin [johnylin@google.com](mailto:johnylin@google.com)
Signed-off-by: Ming Jen Tai [mingjen_tai@realtek.com](mailto:mingjen_tai@realtek.com)

Cherry-picked from 2e6bfbec1ccc069129b3f91212fc8e6af04284bb