### PR TITLE
k_usleep() and k_msleep() wrappers for xtos

### DIFF
--- a/src/arch/xtos-wrapper/include/kernel.h
+++ b/src/arch/xtos-wrapper/include/kernel.h
@@ -1,0 +1,25 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2022 Intel Corporation. All rights reserved.
+ *
+ * Author: Jyri Sarha <jyri.sarha@intel.com>
+ */
+
+#ifndef __XTOS_WRAPPER_KERNEL_H__
+#define __XTOS_WRAPPER_KERNEL_H__
+
+#include <sof/lib/wait.h>
+
+#include <stdint.h>
+
+static inline void k_msleep(int32_t ms)
+{
+	wait_delay_ms(ms);
+}
+
+static inline void k_usleep(int32_t us)
+{
+	wait_delay_us(us);
+}
+
+#endif /* __XTOS_WRAPPER_KERNEL_H__ */

--- a/src/audio/pipeline/pipeline-stream.c
+++ b/src/audio/pipeline/pipeline-stream.c
@@ -15,6 +15,9 @@
 #include <sof/string.h>
 #include <ipc/stream.h>
 #include <ipc/topology.h>
+
+#include <kernel.h>
+
 #include <errno.h>
 #include <stdbool.h>
 #include <stddef.h>
@@ -430,7 +433,7 @@ int pipeline_trigger_run(struct pipeline *p, struct comp_dev *host, int cmd)
 		list_init(&walk_ctx.pipelines);
 
 		if (data.delay_ms)
-			wait_delay_ms(data.delay_ms);
+			k_msleep(data.delay_ms);
 
 		ret = walk_ctx.comp_func(host, NULL, &walk_ctx, host->direction);
 		if (ret < 0)


### PR DESCRIPTION
I left out the k_sleep() for cycles alone, to avoid k_timeout_t definition for XTOS. It did not look like that was needed. 