### PR TITLE
dai: add op to fetch dai fifo depth

### DIFF
--- a/src/drivers/imx/esai.c
+++ b/src/drivers/imx/esai.c
@@ -398,6 +398,18 @@ static int esai_get_fifo(struct dai *dai, int direction, int stream_id)
 	}
 }
 
+static int esai_get_fifo_depth(struct dai *dai, int direction)
+{
+	switch (direction) {
+	case DAI_DIR_PLAYBACK:
+	case DAI_DIR_CAPTURE:
+		return dai->plat_data.fifo[direction].depth;
+	default:
+		dai_err(dai, "esai_get_fifo_depth(): Invalid direction");
+		return -EINVAL;
+	}
+}
+
 static int esai_get_hw_params(struct dai *dai,
 			      struct sof_ipc_stream_params *params,
 			      int dir)
@@ -428,6 +440,7 @@ const struct dai_driver esai_driver = {
 		.remove			= esai_remove,
 		.get_handshake		= esai_get_handshake,
 		.get_fifo		= esai_get_fifo,
+		.get_fifo_depth		= esai_get_fifo_depth,
 		.get_hw_params		= esai_get_hw_params,
 	},
 };

--- a/src/drivers/imx/sai.c
+++ b/src/drivers/imx/sai.c
@@ -424,6 +424,18 @@ static int sai_get_fifo(struct dai *dai, int direction, int stream_id)
 	}
 }
 
+static int sai_get_fifo_depth(struct dai *dai, int direction)
+{
+	switch (direction) {
+	case DAI_DIR_PLAYBACK:
+	case DAI_DIR_CAPTURE:
+		return dai->plat_data.fifo[direction].depth;
+	default:
+		dai_err(dai, "esai_get_fifo_depth(): Invalid direction");
+		return -EINVAL;
+	}
+}
+
 static int sai_get_hw_params(struct dai *dai,
 			     struct sof_ipc_stream_params *params,
 			     int dir)
@@ -455,6 +467,7 @@ const struct dai_driver sai_driver = {
 		.remove			= sai_remove,
 		.get_handshake		= sai_get_handshake,
 		.get_fifo		= sai_get_fifo,
+		.get_fifo_depth		= sai_get_fifo_depth,
 		.get_hw_params		= sai_get_hw_params,
 	},
 };

--- a/src/drivers/intel/alh.c
+++ b/src/drivers/intel/alh.c
@@ -146,6 +146,11 @@ static int alh_get_fifo(struct dai *dai, int direction, int stream_id)
 	return ALH_BASE + offset + ALH_STREAM_OFFSET * stream_id;
 }
 
+static int alh_get_fifo_depth(struct dai *dai, int direction)
+{
+	return dai->plat_data.fifo[direction].depth;
+}
+
 const struct dai_driver alh_driver = {
 	.type = SOF_DAI_INTEL_ALH,
 	.uid = SOF_UUID(alh_uuid),
@@ -158,6 +163,7 @@ const struct dai_driver alh_driver = {
 		.get_hw_params		= alh_get_hw_params,
 		.get_handshake		= alh_get_handshake,
 		.get_fifo		= alh_get_fifo,
+		.get_fifo_depth		= alh_get_fifo_depth,
 		.probe			= alh_probe,
 		.remove			= alh_remove,
 	},

--- a/src/drivers/intel/dmic/dmic.c
+++ b/src/drivers/intel/dmic/dmic.c
@@ -617,6 +617,11 @@ static int dmic_get_fifo(struct dai *dai, int direction, int stream_id)
 	return dai->plat_data.fifo[SOF_IPC_STREAM_CAPTURE].offset;
 }
 
+static int dmic_get_fifo_depth(struct dai *dai, int direction)
+{
+	return dai->plat_data.fifo[SOF_IPC_STREAM_CAPTURE].depth;
+}
+
 const struct dai_driver dmic_driver = {
 	.type = SOF_DAI_INTEL_DMIC,
 	.uid = SOF_UUID(dmic_uuid),
@@ -629,6 +634,7 @@ const struct dai_driver dmic_driver = {
 		.get_hw_params		= dmic_get_hw_params,
 		.get_handshake		= dmic_get_handshake,
 		.get_fifo		= dmic_get_fifo,
+		.get_fifo_depth		= dmic_get_fifo_depth,
 		.probe			= dmic_probe,
 		.remove			= dmic_remove,
 	},

--- a/src/include/sof/lib/dai.h
+++ b/src/include/sof/lib/dai.h
@@ -85,6 +85,7 @@ struct dai_ops {
 	int (*probe)(struct dai *dai);
 	int (*remove)(struct dai *dai);
 	uint32_t (*get_init_delay_ms)(struct dai *dai);
+	int (*get_fifo_depth)(struct dai *dai, int direction);
 };
 
 struct timestamp_cfg {
@@ -466,6 +467,14 @@ static inline uint32_t dai_get_init_delay_ms(struct dai *dai)
 {
 	if (dai && dai->drv->ops.get_init_delay_ms)
 		return dai->drv->ops.get_init_delay_ms(dai);
+
+	return 0;
+}
+
+static inline int dai_get_fifo_depth(struct dai *dai, int direction)
+{
+	if (dai && dai->drv->ops.get_fifo_depth)
+		return dai->drv->ops.get_fifo_depth(dai, direction);
 
 	return 0;
 }

--- a/src/ipc/ipc3/dai.c
+++ b/src/ipc/ipc3/dai.c
@@ -125,7 +125,7 @@ int ipc_dai_data_config(struct comp_dev *dev)
 		break;
 	case SOF_DAI_INTEL_DMIC:
 		/* Depth is passed by DMIC driver that retrieves it from blob */
-		dd->config.burst_elems = dd->dai->plat_data.fifo->depth;
+		dd->config.burst_elems = dai_get_fifo_depth(dd->dai, dai->direction);
 		comp_info(dev, "dai_data_config() burst_elems = %d", dd->config.burst_elems);
 		break;
 	case SOF_DAI_INTEL_HDA:
@@ -136,10 +136,7 @@ int ipc_dai_data_config(struct comp_dev *dev)
 		 */
 		dev->ipc_config.frame_fmt = SOF_IPC_FRAME_S32_LE;
 		dd->dma_buffer->stream.frame_fmt = dev->ipc_config.frame_fmt;
-
-		dd->config.burst_elems =
-			dd->dai->plat_data.fifo[dai->direction].depth;
-
+		dd->config.burst_elems = dai_get_fifo_depth(dd->dai, dai->direction);
 		/* As with HDA, the DMA channel is assigned in runtime,
 		 * not during topology parsing.
 		 */
@@ -148,8 +145,7 @@ int ipc_dai_data_config(struct comp_dev *dev)
 	case SOF_DAI_IMX_SAI:
 		COMPILER_FALLTHROUGH;
 	case SOF_DAI_IMX_ESAI:
-		dd->config.burst_elems =
-			dd->dai->plat_data.fifo[dai->direction].depth;
+		dd->config.burst_elems = dai_get_fifo_depth(dd->dai, dai->direction);
 		break;
 	case SOF_DAI_AMD_BT:
 		dev->ipc_config.frame_fmt = SOF_IPC_FRAME_S16_LE;

--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -96,7 +96,7 @@ int ipc_dai_data_config(struct comp_dev *dev)
 		break;
 	case SOF_DAI_INTEL_DMIC:
 		/* Depth is passed by DMIC driver that retrieves it from blob */
-		dd->config.burst_elems = dd->dai->plat_data.fifo->depth;
+		dd->config.burst_elems = dai_get_fifo_depth(dd->dai, dai->direction);
 		comp_info(dev, "dai_data_config() burst_elems = %d", dd->config.burst_elems);
 		break;
 	case SOF_DAI_INTEL_HDA:
@@ -109,8 +109,7 @@ int ipc_dai_data_config(struct comp_dev *dev)
 		dev->ipc_config.frame_fmt = SOF_IPC_FRAME_S32_LE;
 		dd->dma_buffer->stream.frame_fmt = dev->ipc_config.frame_fmt;
 
-		dd->config.burst_elems =
-			dd->dai->plat_data.fifo[dai->direction].depth;
+		dd->config.burst_elems = dai_get_fifo_depth(dd->dai, dai->direction);
 
 		/* As with HDA, the DMA channel is assigned in runtime,
 		 * not during topology parsing.


### PR DESCRIPTION
Add function to fetch dai fifo depth from driver platform data, as for
some reason it is missing. Update all drivers that are actually using
it.

Signed-off-by: Jaska Uimonen <jaska.uimonen@intel.com>