### PR TITLE
buffer: add cached consume and produce update versions

### DIFF
--- a/src/audio/buffer.c
+++ b/src/audio/buffer.c
@@ -252,3 +252,67 @@ void comp_update_buffer_consume(struct comp_buffer *buffer, uint32_t bytes)
 
 	buffer = buffer_release(buffer);
 }
+
+void comp_update_buffer_cached_produce(struct comp_buffer __sparse_cache *buffer, uint32_t bytes)
+{
+	struct buffer_cb_transact cb_data = {
+		.buffer = cache_to_uncache(buffer),
+		.transaction_amount = bytes,
+		.transaction_begin_address = buffer->stream.w_ptr,
+	};
+
+	/* return if no bytes */
+	if (!bytes) {
+		buf_dbg(buffer, "comp_update_buffer_produce(), no bytes to produce, source->comp.id = %u, source->comp.type = %u, sink->comp.id = %u, sink->comp.type = %u",
+			dev_comp_id(buffer->source),
+			dev_comp_type(buffer->source),
+			dev_comp_id(buffer->sink),
+			dev_comp_type(buffer->sink));
+		return;
+	}
+
+	audio_stream_produce(&buffer->stream, bytes);
+
+	/* Notifier looks for the pointer value to match it against registration */
+	notifier_event(cache_to_uncache(buffer), NOTIFIER_ID_BUFFER_PRODUCE,
+		       NOTIFIER_TARGET_CORE_LOCAL, &cb_data, sizeof(cb_data));
+
+	buf_dbg(buffer, "comp_update_buffer_produce(), ((buffer->avail << 16) | buffer->free) = %08x, ((buffer->id << 16) | buffer->size) = %08x",
+		(audio_stream_get_avail_bytes(&buffer->stream) << 16) |
+		 audio_stream_get_free_bytes(&buffer->stream),
+		(buffer->id << 16) | buffer->stream.size);
+	buf_dbg(buffer, "comp_update_buffer_produce(), ((buffer->r_ptr - buffer->addr) << 16 | (buffer->w_ptr - buffer->addr)) = %08x",
+		((char *)buffer->stream.r_ptr - (char *)buffer->stream.addr) << 16 |
+		((char *)buffer->stream.w_ptr - (char *)buffer->stream.addr));
+}
+
+void comp_update_buffer_cached_consume(struct comp_buffer __sparse_cache *buffer, uint32_t bytes)
+{
+	struct buffer_cb_transact cb_data = {
+		.buffer = cache_to_uncache(buffer),
+		.transaction_amount = bytes,
+		.transaction_begin_address = buffer->stream.r_ptr,
+	};
+
+	/* return if no bytes */
+	if (!bytes) {
+		buf_dbg(buffer, "comp_update_buffer_consume(), no bytes to consume, source->comp.id = %u, source->comp.type = %u, sink->comp.id = %u, sink->comp.type = %u",
+			dev_comp_id(buffer->source),
+			dev_comp_type(buffer->source),
+			dev_comp_id(buffer->sink),
+			dev_comp_type(buffer->sink));
+		return;
+	}
+
+	audio_stream_consume(&buffer->stream, bytes);
+
+	notifier_event(cache_to_uncache(buffer), NOTIFIER_ID_BUFFER_CONSUME,
+		       NOTIFIER_TARGET_CORE_LOCAL, &cb_data, sizeof(cb_data));
+
+	buf_dbg(buffer, "comp_update_buffer_consume(), (buffer->avail << 16) | buffer->free = %08x, (buffer->id << 16) | buffer->size = %08x, (buffer->r_ptr - buffer->addr) << 16 | (buffer->w_ptr - buffer->addr)) = %08x",
+		(audio_stream_get_avail_bytes(&buffer->stream) << 16) |
+		 audio_stream_get_free_bytes(&buffer->stream),
+		(buffer->id << 16) | buffer->stream.size,
+		((char *)buffer->stream.r_ptr - (char *)buffer->stream.addr) << 16 |
+		((char *)buffer->stream.w_ptr - (char *)buffer->stream.addr));
+}

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -198,9 +198,11 @@ void buffer_zero(struct comp_buffer __sparse_cache *buffer);
 
 /* called by a component after producing data into this buffer */
 void comp_update_buffer_produce(struct comp_buffer *buffer, uint32_t bytes);
+void comp_update_buffer_cached_produce(struct comp_buffer __sparse_cache *buffer, uint32_t bytes);
 
 /* called by a component after consuming data from this buffer */
 void comp_update_buffer_consume(struct comp_buffer *buffer, uint32_t bytes);
+void comp_update_buffer_cached_consume(struct comp_buffer __sparse_cache *buffer, uint32_t bytes);
 
 int buffer_set_params(struct comp_buffer __sparse_cache *buffer,
 		      struct sof_ipc_stream_params *params, bool force_update);


### PR DESCRIPTION
comp_update_buffer_produce() and comp_update_buffer_consume() acquire and release buffers internally. We need versions of those functions, that take already acquired cached buffer objects as arguments, we will switch over to them completely gradually. This patch adds such functions.
