### PR TITLE
cache coherency: 2 correctness patches

### DIFF
--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -811,7 +811,7 @@ static int ipc4_module_process_dx(union ipc4_message_header *ipc4)
 		return IPC4_INVALID_RESOURCE_ID;
 	}
 
-	dcache_invalidate_region((void *)(MAILBOX_HOSTBOX_BASE), sizeof(dx_info));
+	dcache_invalidate_region((__sparse_force void __sparse_cache *)MAILBOX_HOSTBOX_BASE, sizeof(dx_info));
 	memcpy_s(&dx_info, sizeof(dx_info), (const void *)MAILBOX_HOSTBOX_BASE, sizeof(dx_info));
 
 	/* check if core enable mask is valid */

--- a/src/platform/intel/cavs/include/cavs/lib/power_down.h
+++ b/src/platform/intel/cavs/include/cavs/lib/power_down.h
@@ -11,6 +11,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include <sof/compiler_attributes.h>
+
 /**
  * Power down procedure.
  * Locks its code in L1 cache and shuts down memories.
@@ -19,6 +21,6 @@
  * (each bit corresponds to one ebb)
  * @return                       nothing returned - this function never quits
  */
-void power_down(bool disable_lpsram, uint32_t *hpsram_pwrgating_mask);
+void power_down(bool disable_lpsram, uint32_t __sparse_cache *hpsram_pwrgating_mask);
 
 #endif /* __CAVS_LIB_POWER_DOWN_H__ */

--- a/src/platform/intel/cavs/lib/clk.c
+++ b/src/platform/intel/cavs/lib/clk.c
@@ -139,7 +139,7 @@ static SHARED_DATA int active_freq_idx = CPU_DEFAULT_IDX;
  */
 static inline void set_cpu_current_freq_idx(int freq_idx, bool release_unused)
 {
-	int *uncached_freq_idx = cache_to_uncache(&active_freq_idx);
+	int *uncached_freq_idx = cache_to_uncache((__sparse_force void __sparse_cache *)&active_freq_idx);
 
 	select_cpu_clock(freq_idx, release_unused);
 	*uncached_freq_idx = freq_idx;
@@ -162,7 +162,7 @@ static inline int get_lowest_freq_idx(int clock)
 static void platform_clock_low_power_mode(int clock, bool enable)
 {
 	int current_freq_idx = get_current_freq_idx(clock);
-	int freq_idx = *(int *)cache_to_uncache(&active_freq_idx);
+	int freq_idx = *(int *)cache_to_uncache((__sparse_force void __sparse_cache *)&active_freq_idx);
 
 	if (enable && current_freq_idx > CPU_LPRO_FREQ_IDX)
 		/* LPRO requests are fast, but requests for other ROs
@@ -186,7 +186,7 @@ void platform_clock_on_waiti(void)
 	/* hold the prd->lock for possible active_freq_idx switching */
 	key = k_spin_lock(&prd->lock);
 
-	freq_idx = *(int *)cache_to_uncache(&active_freq_idx);
+	freq_idx = *(int *)cache_to_uncache((__sparse_force void __sparse_cache *)&active_freq_idx);
 	lowest_freq_idx = get_lowest_freq_idx(CLK_CPU(cpu_get_id()));
 	pm_is_active = pm_runtime_is_active(PM_RUNTIME_DSP, PLATFORM_PRIMARY_CORE_ID);
 


### PR DESCRIPTION
These two patches fix sparse warnings about address space mismatches. These patches do not depend on #5782 and can be merged independently