### PR TITLE
git: remove "module" from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,6 @@ src/arch/xtensa/module
 src/arch/xtensa/rom
 src/arch/xtensa/rom-*
 boot_module
-module
 
 tap-driver.sh
 test-driver


### PR DESCRIPTION
We now have a "module" directory under src/audio/module_adapter/module so it shouldn't be ignored by git any more.
