### PR TITLE
xtensa-build-zephyr.py: make sure that west can find SOF

### DIFF
--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -321,11 +321,18 @@ def west_init_update():
 
 def build_platforms():
 	global west_top, SOF_TOP
-	# double check that west workspace is initialized
-	execute_command(["west", "topdir"], stderr=subprocess.DEVNULL,
-		stdout=subprocess.DEVNULL, cwd=west_top)
 	print(f"SOF_TOP={SOF_TOP}")
 	print(f"west_top={west_top}")
+
+	# Verify that zephyrproject is initialized and that it has a
+	# correct pointer back to us SOF.  create_zephyr_sof_symlink()
+	# takes care of that but it's optional; maybe cloning was done
+	# outside this script.  The link can also fail when hopping in
+	# and out of a container.  Without this check, a not found SOF
+	# would fail later with surprisingly cryptic Kconfig errors.
+	execute_command(["west", "status", "hal_xtensa", "sof"], cwd=west_top,
+			stdout=subprocess.DEVNULL)
+
 	global STAGING_DIR
 	STAGING_DIR = pathlib.Path(west_top, "build-sof-staging")
 	# smex does not use 'install -D'

--- a/zephyr/docker-build.sh
+++ b/zephyr/docker-build.sh
@@ -69,7 +69,7 @@ unset ZEPHYR_SDK_INSTALL_DIR
 
 # Zephyr's CMake does not look in /opt but it searches $HOME
 ls -ld /opt/toolchains/zephyr-sdk-*
-ln -s  /opt/toolchains/zephyr-sdk-*  ~/
+ln -s  /opt/toolchains/zephyr-sdk-*  ~/ || true
 
 if test -e zephyrproject; then
     ./scripts/xtensa-build-zephyr.py  "$@"


### PR DESCRIPTION
This can fail for various reasons listed in a comment.

Remove now redundant `west topdir` check.

Without this check, a not found SOF fails with very cryptic Kconfig
errors:
```
zephyr/samples/subsys/audio/sof/prj.conf:5:
  warning: attempt to assign the value 'n' to undefined symbol HAVE_AGENT

zephyr/samples/subsys/audio/sof/prj.conf:8:
  warning: attempt to assign the value 'n' to undefined symbol
  DEBUG_MEMORY_USAGE_SCAN

zephyr/samples/subsys/audio/sof/boards/intel_adsp_cavs15.conf:1:
 warning: attempt to assign the value 'y' to undefined symbol APOLLOLAKE
```
etc.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>