### PR TITLE
module_adapter: Don't use config->type to identify component

### DIFF
--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -35,23 +35,14 @@ struct comp_dev *module_adapter_new(const struct comp_driver *drv,
 	int ret;
 	struct comp_dev *dev;
 	struct processing_module *mod;
+	struct ipc_config_process *ipc_module_adapter = spec;
 	unsigned char *data;
 	uint32_t size;
 
-	switch (config->type) {
-	case SOF_COMP_MODULE_ADAPTER:
-	{
-		struct ipc_config_process *ipc_module_adapter = spec;
-
-		size = ipc_module_adapter->size;
-		data = ipc_module_adapter->data;
-		break;
-	}
-	default:
-		return NULL;
-	}
-
 	comp_cl_dbg(drv, "module_adapter_new() start");
+
+	size = ipc_module_adapter->size;
+	data = ipc_module_adapter->data;
 
 	if (!config) {
 		comp_cl_err(drv, "module_adapter_new(), wrong input params! drv = %x config = %x",


### PR DESCRIPTION
We need to use UUID in order to identify a component. For now
we only support module_adapter components so just skip checking
config->type.

Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>