### PR TITLE
sof: workaround shared memory log collision with zephyr

### DIFF
--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -60,12 +60,22 @@ extern struct tr_ctx buffer_tr;
 #define buf_dbg(buf_ptr, __e, ...) LOG_DBG(__e, ##__VA_ARGS__)
 
 #else
+
+/* Use Zephyr logging for error trace if Zephyr is used to avoid the
+ * collision with SOF etrace, because they both use shared memory.
+ */
+#ifndef __ZEPHYR__
 /** \brief Trace error message from buffer */
 #define buf_err(buf_ptr, __e, ...)						\
 	trace_dev_err(trace_buf_get_tr_ctx, trace_buf_get_id,			\
 		      trace_buf_get_subid,					\
 		      (__sparse_force const struct comp_buffer *)buf_ptr,	\
 		      __e, ##__VA_ARGS__)
+#else
+
+#define buf_err(ctx, fmt, ...) LOG_ERR(fmt, ##__VA_ARGS__)
+
+#endif
 
 /** \brief Trace warning message from buffer */
 #define buf_warn(buf_ptr, __e, ...)						\

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -174,6 +174,10 @@ enum {
 #else
 /* class (driver) level (no device object) tracing */
 
+/* Use Zephyr logging for error trace if Zephyr is used to avoid the
+ * collision with SOF etrace, because they both use shared memory.
+ */
+#ifndef __ZEPHYR__
 /** \brief Trace error message from component driver (no comp instance) */
 #define comp_cl_err(drv_p, __e, ...)			\
 	trace_dev_err(trace_comp_drv_get_tr_ctx,	\
@@ -181,6 +185,21 @@ enum {
 		      trace_comp_drv_get_subid,		\
 		      drv_p,				\
 		      __e, ##__VA_ARGS__)
+
+/** \brief Trace error message from component device */
+#define comp_err(comp_p, __e, ...)					\
+	trace_dev_err(trace_comp_get_tr_ctx, trace_comp_get_id,		\
+		      trace_comp_get_subid, comp_p, __e, ##__VA_ARGS__)
+
+#else
+
+/** \brief Trace error message from component driver (no comp instance) */
+#define comp_cl_err(drv_p, __e, ...) LOG_ERR(__e, ##__VA_ARGS__)
+
+/** \brief Trace error message from component device */
+#define comp_err(comp_p, __e, ...) LOG_ERR(__e, ##__VA_ARGS__)
+
+#endif
 
 /** \brief Trace warning message from component driver (no comp instance) */
 #define comp_cl_warn(drv_p, __e, ...)			\
@@ -207,11 +226,6 @@ enum {
 		      __e, ##__VA_ARGS__)
 
 /* device tracing */
-
-/** \brief Trace error message from component device */
-#define comp_err(comp_p, __e, ...)					\
-	trace_dev_err(trace_comp_get_tr_ctx, trace_comp_get_id,		\
-		      trace_comp_get_subid, comp_p, __e, ##__VA_ARGS__)
 
 /** \brief Trace warning message from component device */
 #define comp_warn(comp_p, __e, ...)					\

--- a/src/include/sof/audio/pipeline-trace.h
+++ b/src/include/sof/audio/pipeline-trace.h
@@ -49,9 +49,19 @@ extern struct tr_ctx pipe_tr;
 
 #else
 
+/* Use Zephyr logging for error trace if Zephyr is used to avoid the
+ * collision with SOF etrace, because they both use shared memory.
+ */
+#ifndef __ZEPHYR__
+
 #define pipe_err(pipe_p, __e, ...)					\
 	trace_dev_err(trace_pipe_get_tr_ctx, trace_pipe_get_id,		\
 		      trace_pipe_get_subid, pipe_p, __e, ##__VA_ARGS__)
+#else
+
+#define pipe_err(ctx, fmt, ...) LOG_ERR(fmt, ##__VA_ARGS__)
+
+#endif
 
 #define pipe_warn(pipe_p, __e, ...)					\
 	trace_dev_warn(trace_pipe_get_tr_ctx, trace_pipe_get_id,	\

--- a/src/include/sof/lib/dai.h
+++ b/src/include/sof/lib/dai.h
@@ -236,13 +236,31 @@ struct dai_type_info {
 #define dai_dbg(dai_p, __e, ...) LOG_DBG(__e, ##__VA_ARGS__)
 
 #else
-/* class (driver) level (no device object) tracing */
+
+/* Use Zephyr logging for error trace if Zephyr is used to avoid the
+ * collision with SOF etrace, because they both use shared memory.
+ */
+#ifndef __ZEPHYR__
 
 #define dai_cl_err(drv_p, __e, ...)		\
 	trace_dev_err(trace_dai_dvr_get_tr_ctx,	\
 		      trace_dai_drv_get_id,	\
 		      trace_dai_drv_get_subid,	\
 		      drv_p, __e, ##__VA_ARGS__)
+
+#define dai_err(dai_p, __e, ...)					\
+	trace_dev_err(trace_dai_get_tr_ctx,				\
+		      trace_dai_get_id,					\
+		      trace_dai_get_subid, dai_p, __e, ##__VA_ARGS__)
+#else
+
+#define dai_cl_err(drv_p, __e, ...) LOG_ERR(__e, ##__VA_ARGS__)
+
+#define dai_err(dai_p, __e, ...) LOG_ERR(__e, ##__VA_ARGS__)
+
+#endif
+
+/* class (driver) level (no device object) tracing */
 
 #define dai_cl_warn(drv_p, __e, ...)		\
 	trace_dev_warn(trace_dai_drv_get_tr_ctx,\
@@ -263,11 +281,6 @@ struct dai_type_info {
 		      drv_p, __e, ##__VA_ARGS__)
 
 /* device tracing */
-
-#define dai_err(dai_p, __e, ...)					\
-	trace_dev_err(trace_dai_get_tr_ctx,				\
-		      trace_dai_get_id,					\
-		      trace_dai_get_subid, dai_p, __e, ##__VA_ARGS__)
 
 #define dai_warn(dai_p, __e, ...)					\
 	trace_dev_warn(trace_dai_get_tr_ctx,				\

--- a/src/include/sof/trace/trace.h
+++ b/src/include/sof/trace/trace.h
@@ -471,17 +471,24 @@ struct tr_ctx {
 
 #else
 
+/* Use Zephyr logging for error trace if Zephyr is used to avoid the
+ * collision with SOF etrace, because they both use shared memory.
+ */
+#ifndef __ZEPHYR__
 /* Only define these two macros for XTOS to avoid the collision with
  * zephyr/include/zephyr/logging/log.h
  */
-#ifndef __ZEPHYR__
 #define LOG_MODULE_REGISTER(ctx, level)
 #define LOG_MODULE_DECLARE(ctx, level)
-#endif
 
 #define tr_err(ctx, fmt, ...) \
 	trace_error_with_ids(_TRACE_INV_CLASS, ctx, \
 			     _TRACE_INV_ID, _TRACE_INV_ID, fmt, ##__VA_ARGS__)
+#else
+
+#define tr_err(ctx, fmt, ...) LOG_ERR(fmt, ##__VA_ARGS__)
+
+#endif
 
 #define tr_warn(ctx, fmt, ...) \
 	trace_warn_with_ids(_TRACE_INV_CLASS, ctx, \


### PR DESCRIPTION
For SOF with Zephyr RTOS, both zephyr logging and sof
logging are enabled currently, shared memory log collision
happens sometimes because both zephyr and SOF error trace
use shared memory for logging.

This patch uses Zehpyr logging for error trace to mitigate
the log collision issue in SOF logging system transition
stage. Once the transition is done, this should be revreted.

With this patch, logging behavior stated below:
- SOF + XTOS: SOF DMA trace and SOF shared memory trace are used.

- SOF + Zephyr and CONFIG_ZEPHYR_LOG=y: Zephyr logging is used.

- SOF + Zephyr and CONFIG_ZEPHYR_LOG=n: Zephyr logging is used
  for Zephyr OS and SOF error logs, SOF DMA trace is used for
  SOF info/dbg/warn logs.

Signed-off-by: Chao Song <chao.song@linux.intel.com>