### PR TITLE
checkpatch: add __sparse_cache and __sparse_force attributes

### DIFF
--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -371,6 +371,8 @@ our $Ident	= qr{
 		}x;
 our $Storage	= qr{extern|static|asmlinkage};
 our $Sparse	= qr{
+			__sparse_cache|
+			__sparse_force|
 			__user|
 			__kernel|
 			__force|


### PR DESCRIPTION
These attributes were added to Zephyr's include/zephyr/debug/sparse.h by
commit 17eb313a1b15 ("sparse: add an address space and a __sparse_force
annotation")

This gets rid of dozens of warnings in
https://github.com/thesofproject/sof/runs/6387526478

```
ERROR: need consistent spacing around '*' (ctx:WxV)
+	struct comp_buffer __sparse_cache *buffer_c, *sink_c;
 	                                  ^

ERROR: need consistent spacing around '*' (ctx:WxV)
+	struct comp_buffer __sparse_cache *source_c;
 	                                  ^
```

etc.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>