### PR TITLE
ipc4: don't create pipeline msg for ipc4

### DIFF
--- a/src/audio/pipeline/pipeline-graph.c
+++ b/src/audio/pipeline/pipeline-graph.c
@@ -146,11 +146,13 @@ struct pipeline *pipeline_new(uint32_t pipeline_id, uint32_t priority, uint32_t 
 	/* just for retrieving valid ipc_msg header */
 	ipc_build_stream_posn(&posn, SOF_IPC_STREAM_TRIG_XRUN, p->comp_id);
 
-	p->msg = ipc_msg_init(posn.rhdr.hdr.cmd, posn.rhdr.hdr.size);
-	if (!p->msg) {
-		pipe_err(p, "pipeline_new(): ipc_msg_init failed");
-		rfree(p);
-		return NULL;
+	if (posn.rhdr.hdr.size) {
+		p->msg = ipc_msg_init(posn.rhdr.hdr.cmd, posn.rhdr.hdr.size);
+		if (!p->msg) {
+			pipe_err(p, "pipeline_new(): ipc_msg_init failed");
+			rfree(p);
+			return NULL;
+		}
 	}
 
 	return p;

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -44,6 +44,7 @@ extern struct tr_ctx comp_tr;
 void ipc_build_stream_posn(struct sof_ipc_stream_posn *posn, uint32_t type,
 			   uint32_t id)
 {
+	memset(posn, 0, sizeof(*posn));
 }
 
 void ipc_build_comp_event(struct sof_ipc_comp_event *event, uint32_t type,


### PR DESCRIPTION
Fixed random error issue on both windows and Linux.
In ipc4 path ipc_build_stream_posn does nothing so
the posn.rhdr.hdr.size has a random value and sometimes
is very big. This result to memory allocation failure at here
or else in the following allocation.

This patch doesn't create ipc->msg when posn.rhdr.hdr.size
is zero for ipc4 case.

Signed-off-by: Rander Wang <rander.wang@intel.com>