### PR TITLE
overlays: add common/debug_overlay.conf for debug build

### DIFF
--- a/overlays/common/debug_overlay.conf
+++ b/overlays/common/debug_overlay.conf
@@ -1,0 +1,1 @@
+CONFIG_DEBUG=y


### PR DESCRIPTION
The debug_overlay.conf is somehow missing from #5792,
add it in this patch.

Signed-off-by: Chao Song <chao.song@linux.intel.com>

My bad that I didn't notice that this file is missing from #5792 in new push before, until I want to add CI support now