### PR TITLE
zephyr: secondary cores power down

### DIFF
--- a/src/idc/idc.c
+++ b/src/idc/idc.c
@@ -283,9 +283,14 @@ void idc_cmd(struct idc_msg *msg)
 	int ret = 0;
 
 	switch (type) {
+#ifndef __ZEPHYR__
+/* In flow with Zephyr this IDC is not used.
+ * Primary core is forcing OFF state directly via power manager.
+ */
 	case iTS(IDC_MSG_POWER_DOWN):
 		cpu_power_down_core(0);
 		break;
+#endif
 	case iTS(IDC_MSG_NOTIFY):
 		notifier_notify_remote();
 		break;

--- a/src/include/sof/lib/cpu.h
+++ b/src/include/sof/lib/cpu.h
@@ -37,11 +37,12 @@ static inline bool cpu_is_me(int id)
 }
 
 #ifdef __ZEPHYR__
+
+#include <zephyr/arch/cpu.h>
+
 int cpu_enable_core(int id);
 
 void cpu_disable_core(int id);
-
-int cpu_is_core_enabled(int id);
 
 int cpu_enabled_cores(void);
 
@@ -59,7 +60,7 @@ static inline void cpu_disable_core(int id)
 	arch_cpu_disable_core(id);
 }
 
-static inline int cpu_is_core_enabled(int id)
+static inline bool arch_cpu_active(int id)
 {
 	return arch_cpu_is_core_enabled(id);
 }

--- a/src/include/sof/lib/cpu.h
+++ b/src/include/sof/lib/cpu.h
@@ -36,6 +36,19 @@ static inline bool cpu_is_me(int id)
 	return id == cpu_get_id();
 }
 
+#ifdef __ZEPHYR__
+int cpu_enable_core(int id);
+
+void cpu_disable_core(int id);
+
+int cpu_is_core_enabled(int id);
+
+int cpu_enabled_cores(void);
+
+int cpu_restore_secondary_cores(void);
+
+int cpu_secondary_cores_prepare_d0ix(void);
+#else
 static inline int cpu_enable_core(int id)
 {
 	return arch_cpu_enable_core(id);
@@ -65,6 +78,7 @@ static inline int cpu_secondary_cores_prepare_d0ix(void)
 {
 	return arch_cpu_secondary_cores_prepare_d0ix();
 }
+#endif /* __ZEPHYR__ */
 
 #endif
 

--- a/src/ipc/ipc-common.c
+++ b/src/ipc/ipc-common.c
@@ -47,7 +47,7 @@ int ipc_process_on_core(uint32_t core, bool blocking)
 	int ret;
 
 	/* check if requested core is enabled */
-	if (!cpu_is_core_enabled(core)) {
+	if (!arch_cpu_active(core)) {
 		tr_err(&ipc_tr, "ipc_process_on_core(): core #%d is disabled", core);
 		return -EACCES;
 	}

--- a/src/lib-zephyr/cpu.c
+++ b/src/lib-zephyr/cpu.c
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2022 Intel Corporation. All rights reserved.
+//
+// Author: Tomasz Leman <tomasz.m.leman@intel.com>
+
+/**
+ * \file
+ * \brief Zephyr RTOS CPU implementation file
+ * \authors Tomasz Leman <tomasz.m.leman@intel.com>
+ */
+
+#include <sof/init.h>
+#include <sof/lib/cpu.h>
+#include <sof/lib/pm_runtime.h>
+#include <sof/lib/wait.h>
+#include <sof/trace/trace.h>
+
+/* Zephyr includes */
+#include <pm/pm.h>
+#include <soc.h>
+#include <kernel.h>
+#include <version.h>
+
+extern struct tr_ctx zephyr_tr;
+
+#if CONFIG_MULTICORE && CONFIG_SMP
+
+extern K_KERNEL_STACK_ARRAY_DEFINE(z_interrupt_stacks, CONFIG_MP_NUM_CPUS,
+				   CONFIG_ISR_STACK_SIZE);
+
+static atomic_t start_flag;
+static atomic_t ready_flag;
+
+/* Zephyr kernel_internal.h interface */
+extern void smp_timer_init(void);
+
+static FUNC_NORETURN void secondary_init(void *arg)
+{
+	struct k_thread dummy_thread;
+
+	/*
+	 * This is an open-coded version of zephyr/kernel/smp.c
+	 * smp_init_top(). We do this so that we can call SOF
+	 * secondary_core_init() for each core.
+	 */
+
+	atomic_set(&ready_flag, 1);
+	z_smp_thread_init(arg, &dummy_thread);
+	smp_timer_init();
+
+	secondary_core_init(sof_get());
+
+#ifdef CONFIG_THREAD_STACK_INFO
+	dummy_thread.stack_info.start = (uintptr_t)z_interrupt_stacks +
+		arch_curr_cpu()->id * Z_KERNEL_STACK_LEN(CONFIG_ISR_STACK_SIZE);
+	dummy_thread.stack_info.size = Z_KERNEL_STACK_LEN(CONFIG_ISR_STACK_SIZE);
+#endif
+
+	z_smp_thread_swap();
+
+	CODE_UNREACHABLE; /* LCOV_EXCL_LINE */
+}
+
+int cpu_enable_core(int id)
+{
+	/* only called from single core, no RMW lock */
+	__ASSERT_NO_MSG(cpu_get_id() == PLATFORM_PRIMARY_CORE_ID);
+	/*
+	 * This is an open-coded version of zephyr/kernel/smp.c
+	 * z_smp_start_cpu(). We do this, so we can use a customized
+	 * secondary_init() for SOF.
+	 */
+
+	if (arch_cpu_active(id))
+		return 0;
+
+#if ZEPHYR_VERSION(3, 0, 99) <= ZEPHYR_VERSION_CODE
+	z_init_cpu(id);
+#endif
+
+	atomic_clear(&start_flag);
+	atomic_clear(&ready_flag);
+
+	arch_start_cpu(id, z_interrupt_stacks[id], CONFIG_ISR_STACK_SIZE,
+		       secondary_init, &start_flag);
+
+	while (!atomic_get(&ready_flag))
+		k_busy_wait(100);
+
+	atomic_set(&start_flag, 1);
+
+	return 0;
+}
+
+void cpu_disable_core(int id)
+{
+	if (!arch_cpu_active(id)) {
+		tr_warn(&zephyr_tr, "core %d is already disabled", id);
+		return;
+	}
+#if defined(CONFIG_PM)
+	/* only called from single core, no RMW lock */
+	__ASSERT_NO_MSG(cpu_get_id() == PLATFORM_PRIMARY_CORE_ID);
+
+	/* TODO: before requesting core shut down check if it's not actively used */
+	if (!pm_state_force(id, &(struct pm_state_info){PM_STATE_SOFT_OFF, 0, 0})) {
+		tr_err(&zephyr_tr, "failed to set PM_STATE_SOFT_OFF on core %d", id);
+		return;
+	}
+
+	/* Primary core will be turn off by the host after it enter SOFT_OFF state */
+	if (cpu_is_primary(id))
+		return;
+
+	uint64_t timeout = k_cycle_get_64() +
+			   k_ms_to_cyc_ceil64(CONFIG_SECONDARY_CORE_DISABLING_TIMEOUT);
+
+	/* Waiting for secondary core to enter idle state */
+	while (arch_cpu_active(id) && (k_cycle_get_64() < timeout))
+		idelay(PLATFORM_DEFAULT_DELAY);
+
+	if (arch_cpu_active(id)) {
+		tr_err(&zephyr_tr, "core %d did not enter idle state", id);
+		return;
+	}
+
+	if (soc_adsp_halt_cpu(id) != 0)
+		tr_err(&zephyr_tr, "failed to disable core %d", id);
+#endif /* CONFIG_PM */
+}
+
+int cpu_is_core_enabled(int id)
+{
+	return arch_cpu_active(id);
+}
+
+int cpu_enabled_cores(void)
+{
+	unsigned int i;
+	int mask = 0;
+
+	for (i = 0; i < CONFIG_MP_NUM_CPUS; i++)
+		if (arch_cpu_active(i))
+			mask |= BIT(i);
+
+	return mask;
+}
+
+int cpu_restore_secondary_cores(void)
+{
+	/* TODO: use Zephyr API */
+	return 0;
+}
+
+int cpu_secondary_cores_prepare_d0ix(void)
+{
+	/* TODO: use Zephyr API */
+	return 0;
+}
+
+#endif /* CONFIG_MULTICORE && CONFIG_SMP */

--- a/src/lib-zephyr/cpu.c
+++ b/src/lib-zephyr/cpu.c
@@ -130,11 +130,6 @@ void cpu_disable_core(int id)
 #endif /* CONFIG_PM */
 }
 
-int cpu_is_core_enabled(int id)
-{
-	return arch_cpu_active(id);
-}
-
 int cpu_enabled_cores(void)
 {
 	unsigned int i;

--- a/src/lib/notifier.c
+++ b/src/lib/notifier.c
@@ -168,7 +168,7 @@ void notifier_event(const void *caller, enum notify_id type, uint32_t core_mask,
 		if (core_mask & NOTIFIER_TARGET_CORE_MASK(i)) {
 			if (i == cpu_get_id()) {
 				notifier_notify(caller, type, data);
-			} else if (cpu_is_core_enabled(i)) {
+			} else if (arch_cpu_active(i)) {
 				notify_msg.core = i;
 				notify_data = notify_data_get() + i;
 				notify_data->caller = caller;

--- a/src/platform/Kconfig
+++ b/src/platform/Kconfig
@@ -532,4 +532,11 @@ config SOF_STACK_SIZE
 	  and might be useful when creating more complex audio processing
 	  components.
 
+config SECONDARY_CORE_DISABLING_TIMEOUT
+	int
+	default 5000
+	depends on MULTICORE
+	help
+	  Timeout value (in ms) for secondary core to enter D3 state.
+
 endmenu

--- a/src/platform/intel/cavs/lib/pm_runtime.c
+++ b/src/platform/intel/cavs/lib/pm_runtime.c
@@ -17,6 +17,7 @@
 #include <sof/debug/panic.h>
 #include <sof/drivers/interrupt.h>
 #include <sof/lib/alloc.h>
+#include <sof/lib/cpu.h>
 #include <sof/lib/dai.h>
 #include <sof/lib/io.h>
 #include <sof/lib/memory.h>
@@ -51,9 +52,7 @@ DECLARE_TR_CTX(power_tr, SOF_UUID(power_uuid), LOG_LEVEL_INFO);
 /*
  * To support Zephyr, some adaptation is needed to the driver.
  */
-#ifdef __ZEPHYR__
-extern int z_wrapper_cpu_enable_secondary_core(int id);
-#endif
+
 
 /**
  * \brief Registers Host DMA usage that should not trigger
@@ -434,7 +433,7 @@ static inline void cavs_pm_runtime_dis_dsp_pg(uint32_t index)
 		 * In Zephyr secondary power-up needs to go via Zephyr
 		 * SMP kernel core, so we can't program PWRCTL directly here.
 		 */
-		z_wrapper_cpu_enable_secondary_core(index);
+		cpu_enable_core(index);
 #else
 		/* Secondary core power up */
 		shim_write16(SHIM_PWRCTL, shim_read16(SHIM_PWRCTL) |

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -519,6 +519,7 @@ zephyr_library_sources(
 	${SOF_SRC_PATH}/schedule/dma_single_chan_domain.c
 	${SOF_SRC_PATH}/schedule/dma_multi_chan_domain.c
 	${SOF_SRC_PATH}/idc/zephyr_idc.c
+	${SOF_SRC_PATH}/lib-zephyr/cpu.c
 
 	# Bridge wrapper between SOF and Zephyr APIs - Will shrink over time.
 	wrapper.c

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -34,9 +34,6 @@
 
 LOG_MODULE_REGISTER(zephyr, CONFIG_SOF_LOG_LEVEL);
 
-extern K_KERNEL_STACK_ARRAY_DEFINE(z_interrupt_stacks, CONFIG_MP_NUM_CPUS,
-				   CONFIG_ISR_STACK_SIZE);
-
 /* 300aaad4-45d2-8313-25d0-5e1d6086cdd1 */
 DECLARE_SOF_RT_UUID("zephyr", zephyr_uuid, 0x300aaad4, 0x45d2, 0x8313,
 		 0x25, 0xd0, 0x5e, 0x1d, 0x60, 0x86, 0xcd, 0xd1);
@@ -482,8 +479,6 @@ static inline const void *smex_placeholder_f(void)
  */
 const void *_smex_placeholder;
 
-static int w_core_enable_mask;
-
 int task_main_start(struct sof *sof)
 {
 	_smex_placeholder = smex_placeholder_f();
@@ -595,7 +590,6 @@ int task_main_start(struct sof *sof)
 	 * (only called from single core, no RMW lock)
 	 */
 	__ASSERT_NO_MSG(cpu_get_id() == PLATFORM_PRIMARY_CORE_ID);
-	w_core_enable_mask |= BIT(PLATFORM_PRIMARY_CORE_ID);
 
 	/* Temporary fix for issue #4356 */
 	(void)notifier_register(NULL, scheduler_get_data(SOF_IPC_QUEUED_DOMAIN),
@@ -655,116 +649,6 @@ void platform_dai_wallclock(struct comp_dev *dai, uint64_t *wallclock)
  * Mostly empty today waiting pending Zephyr CAVS SMP integration.
  */
 #if CONFIG_MULTICORE && CONFIG_SMP
-static atomic_t start_flag;
-static atomic_t ready_flag;
-
-/* Zephyr kernel_internal.h interface */
-void smp_timer_init(void);
-
-static FUNC_NORETURN void secondary_init(void *arg)
-{
-	struct k_thread dummy_thread;
-
-	/*
-	 * This is an open-coded version of zephyr/kernel/smp.c
-	 * smp_init_top(). We do this so that we can call SOF
-	 * secondary_core_init() for each core.
-	 */
-
-	atomic_set(&ready_flag, 1);
-	z_smp_thread_init(arg, &dummy_thread);
-	smp_timer_init();
-
-	secondary_core_init(sof_get());
-
-#ifdef CONFIG_THREAD_STACK_INFO
-	dummy_thread.stack_info.start = (uintptr_t)z_interrupt_stacks +
-		arch_curr_cpu()->id * Z_KERNEL_STACK_LEN(CONFIG_ISR_STACK_SIZE);
-	dummy_thread.stack_info.size = Z_KERNEL_STACK_LEN(CONFIG_ISR_STACK_SIZE);
-#endif
-
-	z_smp_thread_swap();
-
-	CODE_UNREACHABLE; /* LCOV_EXCL_LINE */
-}
-
-int arch_cpu_enable_core(int id)
-{
-	pm_runtime_get(PM_RUNTIME_DSP, PWRD_BY_TPLG | id);
-
-	/* only called from single core, no RMW lock */
-	__ASSERT_NO_MSG(cpu_get_id() == PLATFORM_PRIMARY_CORE_ID);
-
-	w_core_enable_mask |= BIT(id);
-
-	return 0;
-}
-
-int z_wrapper_cpu_enable_secondary_core(int id)
-{
-	/*
-	 * This is an open-coded version of zephyr/kernel/smp.c
-	 * z_smp_start_cpu(). We do this, so we can use a customized
-	 * secondary_init() for SOF.
-	 */
-
-	if (arch_cpu_active(id))
-		return 0;
-
-#if ZEPHYR_VERSION(3, 0, 99) <= ZEPHYR_VERSION_CODE
-	z_init_cpu(id);
-#endif
-
-	atomic_clear(&start_flag);
-	atomic_clear(&ready_flag);
-
-	arch_start_cpu(id, z_interrupt_stacks[id], CONFIG_ISR_STACK_SIZE,
-		       secondary_init, &start_flag);
-
-	while (!atomic_get(&ready_flag))
-		k_busy_wait(100);
-
-	atomic_set(&start_flag, 1);
-
-	return 0;
-}
-
-int arch_cpu_restore_secondary_cores(void)
-{
-	/* TODO: use Zephyr version */
-	return 0;
-}
-
-int arch_cpu_secondary_cores_prepare_d0ix(void)
-{
-	/* TODO: use Zephyr version */
-	return 0;
-}
-
-void arch_cpu_disable_core(int id)
-{
-	/* TODO: call Zephyr API */
-
-	/* only called from single core, no RMW lock */
-	__ASSERT_NO_MSG(cpu_get_id() == PLATFORM_PRIMARY_CORE_ID);
-
-	w_core_enable_mask &= ~BIT(id);
-}
-
-int arch_cpu_is_core_enabled(int id)
-{
-	return w_core_enable_mask & BIT(id);
-}
-
-void cpu_power_down_core(uint32_t flags)
-{
-	/* TODO: use Zephyr version */
-}
-
-int arch_cpu_enabled_cores(void)
-{
-	return w_core_enable_mask;
-}
 
 static struct idc idc[CONFIG_MP_NUM_CPUS];
 static struct idc *p_idc[CONFIG_MP_NUM_CPUS];


### PR DESCRIPTION
Adding implementation of cpu cores disabling function with usage of a zephyr power manager.
Refactorization of a existing code and moving it to the target location (out of the zephyr wrapper).