### PR TITLE
topology: sof-cavs-nocodec: Move host pipelines to different cores

### DIFF
--- a/tools/topology/topology1/sof-cavs-nocodec.m4
+++ b/tools/topology/topology1/sof-cavs-nocodec.m4
@@ -52,6 +52,8 @@ ifelse(NCORES, `4',
 define(DMIC_48k_CORE_ID, `0')
 define(DMIC_16k_CORE_ID, `0')
 define(SSP0_CORE_ID, `0')
+define(SSP0_PIPE7_CORE_ID, `1')
+define(SSP0_PIPE11_CORE_ID, `0')
 define(SSP1_CORE_ID, `0')
 define(SSP2_CORE_ID, `0')
 ')
@@ -61,6 +63,8 @@ ifelse(NCORES, `2',
 define(DMIC_48k_CORE_ID, `0')
 define(DMIC_16k_CORE_ID, `0')
 define(SSP0_CORE_ID, `0')
+define(SSP0_PIPE7_CORE_ID, `0')
+define(SSP0_PIPE11_CORE_ID, `0')
 define(SSP1_CORE_ID, `0')
 define(SSP2_CORE_ID, `0')
 ')
@@ -70,6 +74,8 @@ ifelse(NCORES, `1',
 define(DMIC_48k_CORE_ID, `0')
 define(DMIC_16k_CORE_ID, `0')
 define(SSP0_CORE_ID, `0')
+define(SSP0_PIPE7_CORE_ID, `0')
+define(SSP0_PIPE11_CORE_ID, `0')
 define(SSP1_CORE_ID, `0')
 define(SSP2_CORE_ID, `0')
 ')
@@ -155,7 +161,7 @@ DAI_ADD(sof/pipe-mixer-volume-dai-playback.m4,
 # Set 1000us deadline on core SSP0_CORE_ID with priority 0
 PIPELINE_PCM_ADD(sof/pipe-host-volume-playback.m4,
 	7, 0, 2, PIPE_BITS,
-	1000, 0, SSP0_CORE_ID,
+	1000, 0, SSP0_PIPE7_CORE_ID,
 	48000, 48000, 48000,
 	SCHEDULE_TIME_DOMAIN_TIMER,
 	PIPELINE_PLAYBACK_SCHED_COMP_1)
@@ -166,7 +172,7 @@ PIPELINE_PCM_ADD(sof/pipe-host-volume-playback.m4,
 ifelse(PLATFORM, `bxt', `',
 `PIPELINE_PCM_ADD(sof/pipe-host-volume-playback.m4,
 	11, 3, 2, PIPE_BITS,
-	1000, 0, SSP0_CORE_ID,
+	1000, 0, SSP0_PIPE11_CORE_ID,
 	48000, 48000, 48000,
 	SCHEDULE_TIME_DOMAIN_TIMER,
 	PIPELINE_PLAYBACK_SCHED_COMP_1)')


### PR DESCRIPTION
Move the host pipelines to be on a different core from that of the DAI
pipeline for platforms that have 4 DSP cores.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>