### PR TITLE
topology: add dmic1 dai for topology2 default dmic

### DIFF
--- a/tools/topology/topology2/cavs/cavs-nocodec.conf
+++ b/tools/topology/topology2/cavs/cavs-nocodec.conf
@@ -39,6 +39,7 @@ Define {
 	DMIC0_HOST_PIPELINE_SINK	'copier.host.13.1'
 	DMIC0_DAI_PIPELINE_SRC		'copier.DMIC.14.1'
 	DMIC0_NAME			'NoCodec-6'
+	DMIC1_NAME			'NoCodec-7'
 	DMIC0_PCM_CAPS			'Passthrough Capture 13'
 	DMIC0_PIPELINE_STREAM_NAME	'copier.DMIC.14.1'
 	PLATFORM 			"none"

--- a/tools/topology/topology2/cavs/platform/intel/dmic-default.conf
+++ b/tools/topology/topology2/cavs/platform/intel/dmic-default.conf
@@ -5,6 +5,7 @@ Define {
 	PDM1_MIC_A_ENABLE	0
 	PDM1_MIC_B_ENABLE	0
 	DMIC0_ID		6 # Default link ID based on HDA generic machine driver
+	DMIC1_ID		7 # Default link ID based on HDA generic machine driver
 	FORMAT			s32le
 	# IO_CLK applicable for ICL, JSL, TGL and ADL
 	DMIC_IO_CLK		38400000
@@ -15,6 +16,7 @@ Define {
 	DMIC0_HOST_PIPELINE_SINK "copier.host.11.1"
 	DMIC0_DAI_PIPELINE_SRC "copier.DMIC.12.1"
 	DMIC0_NAME	dmic01
+	DMIC1_NAME	dmic16k
 	DMIC0_PCM_CAPS	"Passthrough Capture 11"
 	DMIC0_PIPELINE_STREAM_NAME "copier.DMIC.12.1"
 }

--- a/tools/topology/topology2/cavs/platform/intel/dmic-generic.conf
+++ b/tools/topology/topology2/cavs/platform/intel/dmic-generic.conf
@@ -29,6 +29,39 @@ Object.Dai {
 	}
 }
 
+Object.Dai {
+       DMIC.1 {
+               name                    $DMIC1_NAME
+               id                      $DMIC1_ID
+               dai_index               1
+               driver_version          $DMIC_DRIVER_VERSION
+               io_clk                  $DMIC_IO_CLK
+               sample_rate             16000
+               clk_min         500000
+               clk_max         4800000
+               unmute_ramp_time_ms     200
+               # num_pdm_active should always set to 2 but depending on the number of DMIC's
+               # the mic's are enabled or disabled in each PDM.
+               num_pdm_active  2
+
+               Object.Base.hw_config."DMIC1" {
+                       id      0
+               }
+
+               # PDM controller config
+               Object.Base.pdm_config."3" {
+                       mic_a_enable    $PDM0_MIC_A_ENABLE
+                       mic_b_enable    $PDM0_MIC_B_ENABLE
+                       ctrl_id 0
+               }
+               Object.Base.pdm_config."4" {
+                       ctrl_id 1
+                       mic_a_enable    $PDM1_MIC_A_ENABLE
+                       mic_b_enable    $PDM1_MIC_B_ENABLE
+               }
+       }
+}
+
 Object.Pipeline {
 	passthrough-capture.0 {
 		format		$FORMAT


### PR DESCRIPTION
Add the second 16kHz dmic1 dai to topology2 dmic config. This dai
doesn't yet have a pipeline, but it will be used in nhlt blob
calculation. Internal testing showed that some firmware variants need
the 16kHz dai to be defined in nhlt blob even though it is not used. The
pipeline for this dai will be added later.

Signed-off-by: Jaska Uimonen <jaska.uimonen@intel.com>