### PR TITLE
ipc4: use buffer_free to free buffer

### DIFF
--- a/src/audio/copier.c
+++ b/src/audio/copier.c
@@ -525,7 +525,7 @@ static void copier_free(struct comp_dev *dev)
 
 	for (i = 0; i < cd->endpoint_num; i++) {
 		cd->endpoint[i]->drv->ops.free(cd->endpoint[i]);
-		buffer_release(cd->endpoint_buffer[i]);
+		buffer_free(cd->endpoint_buffer[i]);
 	}
 
 	rfree(cd);


### PR DESCRIPTION
Fix memory leak in stress test. Buffer_release is for cache
operation not for memory free. And buffer_free can free memory
and also release buffer.

Signed-off-by: Rander Wang <rander.wang@intel.com>