### PR TITLE
ipc4: ack ipc message then reply the status

### DIFF
--- a/src/include/sof/ipc/driver.h
+++ b/src/include/sof/ipc/driver.h
@@ -46,6 +46,11 @@ enum task_state ipc_platform_do_cmd(struct ipc *ipc);
 void ipc_platform_complete_cmd(struct ipc *ipc);
 
 /**
+ * \brief Tell host we have received the last IPC command.
+ */
+void ipc_platform_ack_cmd(struct ipc *ipc);
+
+/**
  * \brief Send IPC message to host.
  * @param msg The IPC message to send to host.
  * @return 0 on success.

--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -971,8 +971,11 @@ void ipc_cmd(struct ipc_cmd_hdr *_hdr)
 	enum ipc4_message_target target;
 	int err;
 
-	if (!in)
+	if (!in) {
+		tr_err(&ipc_tr, "ipc4 failed for NULL message");
+		ipc_platform_ack_cmd(ipc_get());
 		return;
+	}
 
 	/* no process on scheduled thread */
 	msg_data.delayed_reply = 0;
@@ -998,6 +1001,8 @@ void ipc_cmd(struct ipc_cmd_hdr *_hdr)
 
 	if (err)
 		tr_err(&ipc_tr, "ipc4: %d failed err %d", target, err);
+
+	ipc_platform_ack_cmd(ipc_get());
 
 	/* FW sends an ipc message to host if request bit is clear */
 	if (in->primary.r.rsp == SOF_IPC4_MESSAGE_DIR_MSG_REQUEST) {


### PR DESCRIPTION
Fixed random ipc timeout issues. Currently fw reply
the status of ipc message first then ack the ipc msg.
The problem is that host driver will send msg to fw
when reply message is received but at this time the
ack interrupt may be not triggered by fw since host
cpu is much faster than dsp. And then the sent
msg can't be received by dsp for ipc interrupt is
not cleared by ack interrupt.

This new sequence is also expected by windows driver
and validated on windows platform.

Signed-off-by: Rander Wang <rander.wang@intel.com>