### PR TITLE
Intel modules adapter implementation

### DIFF
--- a/src/audio/module_adapter/iadk/iadk_module_adapter.cpp
+++ b/src/audio/module_adapter/iadk/iadk_module_adapter.cpp
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2020 Intel Corporation. All rights reserved.
+//
+// Author: Jaroslaw Stelter <jaroslaw.stelter@linux.intel.com>
+
+#include <iadk_module_adapter.h>
+#include <system_error.h>
+#include <errno.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef intel_adsp::ProcessingModuleInterface::ErrorCode::Type IntelErrorCode;
+
+namespace dsp_fw
+{
+
+  IadkModuleAdapter::IadkModuleAdapter(intel_adsp::ProcessingModuleInterface& processing_module,
+				       void *comp_dev_instance,
+				       uint32_t module_id,
+				       uint32_t instance_id,
+				       uint32_t core_id,
+				       size_t module_size)
+				       :processing_module_(processing_module)
+{
+}
+
+int IadkModuleAdapter::IadkModuleAdapter_Init(void)
+{
+	return processing_module_.Init();
+}
+
+int IadkModuleAdapter::IadkModuleAdapter_Prepare(void)
+{
+	return 0;
+}
+
+uint32_t IadkModuleAdapter::IadkModuleAdapter_Process(struct input_stream_buffer *input_buffers,
+						      int num_input_buffers,
+						      struct output_stream_buffer *output_buffers,
+						      int num_output_buffers)
+{
+	uint32_t ret = 0;
+	if ((num_input_buffers > 0) && (num_output_buffers > 0)) {
+		intel_adsp::InputStreamBuffer input_stream_buffers[INPUT_PIN_COUNT];
+		intel_adsp::OutputStreamBuffer output_stream_buffers[OUTPUT_PIN_COUNT];
+		for (int i = 0; i < (int)num_input_buffers; i++) {
+			intel_adsp::InputStreamFlags flags = {};
+			flags.end_of_stream = input_buffers[i].end_of_stream;
+			const intel_adsp::InputStreamBuffer isb_data(
+				(uint8_t *)input_buffers[i].data,
+				input_buffers[i].size,
+				flags);
+			new (&input_stream_buffers[i]) intel_adsp::InputStreamBuffer(isb_data);
+		}
+
+		for (int i = 0; i < (int)num_output_buffers; i++) {
+			const intel_adsp::OutputStreamBuffer osb_data(
+					(uint8_t *)output_buffers[i].data,
+					output_buffers[i].size);
+			new (&output_stream_buffers[i]) intel_adsp::OutputStreamBuffer(osb_data);
+		}
+
+		ret = processing_module_.Process(input_stream_buffers, output_stream_buffers);
+
+		for (int i = 0; i < (int)num_input_buffers; i++) {
+			input_buffers[i].consumed = input_buffers[i].size;
+		}
+
+		for (int i = 0; i < (int)num_output_buffers; i++) {
+			output_buffers[i].size = output_stream_buffers[i].size;
+		}
+	}
+	return ret;
+}
+
+AdspErrorCode
+IadkModuleAdapter::IadkModuleAdapter_SetConfiguration(uint32_t config_id,
+						      enum module_cfg_fragment_position pos,
+						      uint32_t data_offset_size,
+						      const uint8_t *fragment_buffer,
+						      size_t fragment_size,
+						      uint8_t *response,
+						      size_t &response_size)
+{
+	intel_adsp::ConfigurationFragmentPosition fragment_position =
+			(intel_adsp::ConfigurationFragmentPosition::Enum) pos;
+
+	return processing_module_.SetConfiguration(config_id, fragment_position,
+						   data_offset_size, fragment_buffer,
+						   fragment_size, response, response_size);
+}
+
+AdspErrorCode
+IadkModuleAdapter::IadkModuleAdapter_GetConfiguration(uint32_t config_id,
+						      enum module_cfg_fragment_position pos,
+						      uint32_t data_offset_size,
+						      uint8_t *fragment_buffer,
+						      size_t fragment_size)
+{
+	intel_adsp::ConfigurationFragmentPosition fragment_position =
+			(intel_adsp::ConfigurationFragmentPosition::Enum) pos;
+
+	return processing_module_.GetConfiguration(config_id, fragment_position,
+						   data_offset_size, fragment_buffer,
+						   fragment_size);
+}
+
+
+void IadkModuleAdapter::IadkModuleAdapter_SetProcessingMode(enum module_processing_mode sof_mode)
+{
+	intel_adsp::ProcessingMode mode;
+	sof_mode == MODULE_PROCESSING_NORMAL ?
+		(mode = intel_adsp::ProcessingMode::NORMAL) :
+		(mode = intel_adsp::ProcessingMode::BYPASS);
+	processing_module_.SetProcessingMode(mode);
+}
+
+
+void IadkModuleAdapter::IadkModuleAdapter_Reset(void)
+{
+	processing_module_.Reset();
+}
+
+enum module_processing_mode IadkModuleAdapter::IadkModuleAdapter_GetProcessingMode(void)
+{
+	enum module_processing_mode sof_mode;
+	intel_adsp::ProcessingMode mode = processing_module_.GetProcessingMode();
+	mode == intel_adsp::ProcessingMode::NORMAL ?
+		(sof_mode = MODULE_PROCESSING_NORMAL) : (sof_mode = MODULE_PROCESSING_BYPASS);
+	return sof_mode;
+}
+
+/* C wrappers for C++  ProcessingModuleInterface() methods. */
+int IadkModuleAdapter::IadkModuleAdapter_Free(void)
+{
+	return processing_module_.Delete();
+}
+
+
+int iadk_wrapper_init(void *md)
+{
+	struct IadkModuleAdapter *mod_adp = (struct IadkModuleAdapter *) md;
+	return mod_adp->IadkModuleAdapter_Init();
+}
+
+int iadk_wrapper_prepare(void *md)
+{
+	struct IadkModuleAdapter *mod_adp = (struct IadkModuleAdapter *) md;
+	return mod_adp->IadkModuleAdapter_Prepare();
+}
+
+int iadk_wrapper_set_processing_mode(void *md,
+				     enum module_processing_mode mode)
+{
+	struct IadkModuleAdapter *mod_adp = (struct IadkModuleAdapter *) md;
+	mod_adp->IadkModuleAdapter_SetProcessingMode(mode);
+	return 0;
+}
+
+enum module_processing_mode iadk_wrapper_get_processing_mode(void *md)
+{
+	struct IadkModuleAdapter *mod_adp = (struct IadkModuleAdapter *) md;
+	return mod_adp->IadkModuleAdapter_GetProcessingMode();
+}
+
+int iadk_wrapper_reset(void *md)
+{
+	struct IadkModuleAdapter *mod_adp = (struct IadkModuleAdapter *) md;
+	mod_adp->IadkModuleAdapter_Reset();
+	return 0;
+}
+
+int iadk_wrapper_free(void *md)
+{
+	struct IadkModuleAdapter *mod_adp = (struct IadkModuleAdapter *) md;
+	return mod_adp->IadkModuleAdapter_Free();
+}
+
+int iadk_wrapper_set_configuration(void *md, uint32_t config_id,
+				   enum module_cfg_fragment_position pos,
+				   uint32_t data_offset_size,
+				   const uint8_t *fragment, size_t fragment_size,
+				   uint8_t *response, size_t response_size)
+{
+	struct IadkModuleAdapter *mod_adp = (struct IadkModuleAdapter *) md;
+	return mod_adp->IadkModuleAdapter_SetConfiguration(config_id, pos,
+							   data_offset_size,
+							   fragment, fragment_size,
+							   response, response_size);
+}
+
+int iadk_wrapper_get_configuration(void *md, uint32_t config_id,
+				   enum module_cfg_fragment_position pos,
+				   uint32_t data_offset_size,
+				   uint8_t *fragment, size_t fragment_size)
+{
+	struct IadkModuleAdapter *mod_adp = (struct IadkModuleAdapter *) md;
+	return mod_adp->IadkModuleAdapter_GetConfiguration(config_id, pos,
+							   data_offset_size,
+							   fragment,
+							   fragment_size);
+}
+
+
+int iadk_wrapper_process(void *md, struct input_stream_buffer *input_buffers,
+			 int num_input_buffers, struct output_stream_buffer *output_buffers,
+			 int num_output_buffers)
+{
+	struct IadkModuleAdapter *mod_adp = (struct IadkModuleAdapter *) md;
+	return mod_adp->IadkModuleAdapter_Process(input_buffers, num_input_buffers,
+						  output_buffers, num_output_buffers);
+}
+} /* namespace dsp_fw */
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#ifdef __cplusplus
+void* operator new(size_t size, intel_adsp::InputStreamBuffer* placeholder) throw()
+{
+	return placeholder;
+}
+
+void* operator new(size_t size, intel_adsp::OutputStreamBuffer* placeholder) throw()
+{
+	return placeholder;
+}
+#endif
+

--- a/src/audio/module_adapter/iadk/module_initial_settings_concrete.cpp
+++ b/src/audio/module_adapter/iadk/module_initial_settings_concrete.cpp
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2020 Intel Corporation. All rights reserved.
+//
+// Author: Jaroslaw Stelter <jaroslaw.stelter@linux.intel.com>
+
+#include <adsp_stddef.h>
+#include <module_initial_settings_concrete.h>
+#include <logger.h>
+
+extern "C" {
+int memcpy_s(void * dst, size_t maxlen, const void * src, size_t len);
+} /* extern "C" */
+
+using namespace intel_adsp;
+
+namespace dsp_fw
+{
+
+#pragma pack(4) /* this directive is useless when compiling for xtensa but it highlights */
+		/* the packing requirement. */
+struct CompoundCfg
+{
+	BaseModuleCfg cfg;
+	BaseModuleCfgExt cfg_ext;
+};
+#pragma pack()
+
+
+/*! \brief Initializes a new ModuleInitialSettingsConcrete instance given an */
+/*   INIT_INSTANCE IPC message blob */
+ModuleInitialSettingsConcrete::ModuleInitialSettingsConcrete(DwordArray const &cfg_ipc_msg) :
+							     cfg_(NULL), cfg_ext_(NULL)
+{
+	const size_t ipc_msg_size =
+		reinterpret_cast<DwordArray const&>(cfg_ipc_msg).size() * sizeof(uint32_t);
+
+	if (ipc_msg_size < sizeof(BaseModuleCfg)) {
+		/* unexpected INIT_INSTANCE message size. Simply return as message
+		 * is unparsable.
+		 */
+		return;
+	}
+
+	if (ipc_msg_size > sizeof(CompoundCfg) -
+		sizeof(InputPinFormat) - sizeof(OutputPinFormat)) {
+
+		/* INIT_INSTANCE message seems to be compound message        */
+		/* It shall contain BaseModuleCfg + BaseModuleCfgExt +       */
+		/* optionally some InputPinFormat[] + OutputPinFormat[] data */
+		CompoundCfg const * unvalidated_compound_cfg = cfg_ipc_msg.dataAs<CompoundCfg>();
+		const size_t computed_msg_size =
+			sizeof(CompoundCfg) -
+			/* CompoundCfg already contains one InputPinFormat and
+			 * one InputPinFormat
+			 */
+			(sizeof(InputPinFormat) + sizeof(OutputPinFormat)) +
+			unvalidated_compound_cfg->cfg_ext.nb_input_pins*sizeof(InputPinFormat) +
+			unvalidated_compound_cfg->cfg_ext.nb_output_pins*sizeof(InputPinFormat);
+
+		/* check size consistency */
+		if (ipc_msg_size != computed_msg_size) {
+			/* unexpected INIT_INSTANCE message size. Simply return as message
+			 * is unparsable.
+			 */
+			return;
+		}
+
+		/* looks like a valid compound config message has been found */
+		cfg_ = &unvalidated_compound_cfg->cfg;
+		cfg_ext_ = &unvalidated_compound_cfg->cfg_ext;
+	}
+	else if (ipc_msg_size == sizeof(BaseModuleCfg)) {
+		/* INIT_INSTANCE message seems to be the legacy one */
+		cfg_ = cfg_ipc_msg.dataAs<BaseModuleCfg>();
+	}
+}
+
+void ModuleInitialSettingsConcrete::DeduceBaseModuleCfgExt(size_t in_pins_count,
+							   size_t out_pins_count)
+{
+	if (!cfg_ext_) {
+		/* BaseModuleCfgExt data was not part of the INIT_INSTANCE IPC message */
+		/* We need to create it on-the-fly */
+		tmp_cfg_ext_.tlv.nb_input_pins = in_pins_count;
+		tmp_cfg_ext_.tlv.nb_output_pins = out_pins_count;
+
+		InputPinFormat* input_pins = tmp_cfg_ext_.tlv.input_pins;
+		/* InputPinFormat data are all identically initialized based on audio format
+		 * available in the BaseModuleCfg data.
+		 */
+		for (size_t i = 0 ; i < in_pins_count ; i++) {
+			/*  Initialize all input pins with same audio format */
+			input_pins[i].ibs = cfg_->ibs;
+			input_pins[i].pin_index = i;
+			memcpy_s(&input_pins[i].audio_fmt,
+				 sizeof(input_pins[i].audio_fmt),
+				 &cfg_->audio_fmt,
+				 sizeof(AudioFormat));
+		}
+
+		OutputPinFormat* output_pins =
+				reinterpret_cast<OutputPinFormat*>(&input_pins[in_pins_count]);
+		for (size_t i = 0 ; i < out_pins_count ; i++) {
+			/*  Initialize all pins obs with same obs value */
+			output_pins[i].obs = cfg_->obs;
+			output_pins[i].pin_index = i;
+			memcpy_s(&output_pins[i].audio_fmt,
+				 sizeof(output_pins[i].audio_fmt),
+				 &cfg_->audio_fmt,
+				 sizeof(AudioFormat));
+		}
+
+		/* a valid BaseModuleCfgExt has been created on-the-fly */
+		cfg_ext_ = reinterpret_cast<BaseModuleCfgExt const*>(&tmp_cfg_ext_);
+	}
+}
+
+void const* ModuleInitialSettingsConcrete::GetUntypedItem(ModuleInitialSettingsKey key,
+							  size_t &length)
+{
+	void const* array = NULL;
+	length = 0;
+
+	switch(key)
+	{
+	case intel_adsp::LEGACY_STRUCT:
+		length = 1;
+		array = cfg_;
+		break;
+
+	case intel_adsp::IN_PINS_FORMAT:
+		length = cfg_ext_->nb_input_pins;
+		array = &cfg_ext_->input_pins[0];
+		break;
+
+	case intel_adsp::OUT_PINS_FORMAT:
+		length = cfg_ext_->nb_output_pins;
+		/* output_pins array follows the input_pins array in BaseModuleCfgExt
+		 * struct layout
+		 */
+		array = reinterpret_cast<OutputPinFormat const*>
+					(&cfg_ext_->input_pins[cfg_ext_->nb_input_pins]);
+		break;
+
+	default:
+		break;
+	}
+	return array;
+}
+
+} /* namespace dsp_fw */

--- a/src/audio/module_adapter/iadk/system_agent.cpp
+++ b/src/audio/module_adapter/iadk/system_agent.cpp
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2020 Intel Corporation. All rights reserved.
+//
+// Author: Jaroslaw Stelter <jaroslaw.stelter@linux.intel.com>
+
+/*
+ * SOF System Agent - register IADK Loadable Library in SOF infrastructure.
+ */
+
+#include <errno.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <sof/string.h>
+#include <utilities/array.h>
+#include <adsp_error_code.h>
+#include <logger.h>
+#include <system_service.h>
+#include <system_agent_interface.h>
+#include <module_initial_settings_concrete.h>
+#include <iadk_module_adapter.h>
+#include <system_agent.h>
+
+using namespace intel_adsp;
+using namespace intel_adsp::system;
+using namespace dsp_fw;
+
+void* operator new(size_t size, intel_adsp::ModuleHandle *placeholder) throw()
+{
+	return placeholder;
+}
+
+extern "C" {
+
+	void SystemServiceLogMessage (AdspLogPriority log_priority, uint32_t log_entry,
+				      AdspLogHandle const* log_handle, uint32_t param1,
+				      uint32_t param2, uint32_t param3, uint32_t param4);
+
+	AdspErrorCode SystemServiceSafeMemcpy(void *RESTRICT dst, size_t maxlen,
+					      const void *RESTRICT src, size_t len);
+
+	AdspErrorCode SystemServiceSafeMemmove(void *dst, size_t maxlen,
+					       const void *src, size_t len);
+
+	void* SystemServiceVecMemset(void *dst, int c, size_t len);
+
+	AdspErrorCode SystemServiceCreateNotification(NotificationParams *params,
+						      uint8_t *notification_buffer,
+						      uint32_t notification_buffer_size,
+						      AdspNotificationHandle *handle);
+
+	AdspErrorCode SystemServiceSendNotificationMessage(NotificationTarget notification_target,
+							   AdspNotificationHandle message,
+							   uint32_t actual_payload_size);
+
+	AdspErrorCode SystemServiceGetInterface(AdspIfaceId id, SystemServiceIface **iface);
+}
+
+namespace intel_adsp
+{
+namespace system
+{
+
+/* Structure storing handles to system service operations */
+AdspSystemService SystemAgent::system_service_ = {
+	SystemServiceLogMessage,
+	SystemServiceSafeMemcpy,
+	SystemServiceSafeMemmove,
+	SystemServiceVecMemset,
+	SystemServiceCreateNotification,
+	SystemServiceSendNotificationMessage,
+	SystemServiceGetInterface,
+};
+
+SystemAgent::SystemAgent(uint32_t module_id,
+			 uint32_t instance_id,
+			 uint32_t core_id,
+			 uint32_t log_handle) :
+			     log_handle_(log_handle),
+			     core_id_(core_id),
+			     module_id_(module_id),
+			     instance_id_(instance_id),
+			     module_handle_(NULL)
+{}
+
+
+void SystemAgent::CheckIn(ProcessingModuleInterface& processing_module,
+			  ModuleHandle &module_handle,
+			  LogHandle *&log_handle)
+{
+	module_handle_ = &module_handle;
+	/* Initializes the ModuleAdapter into the ModuleHandle */
+	IadkModuleAdapter* module_adapter =
+		new (module_handle_)IadkModuleAdapter(processing_module,
+		NULL,
+		module_id_,
+		instance_id_,
+		core_id_,
+		module_size_
+		);
+	log_handle = reinterpret_cast<LogHandle*>(log_handle_);
+}
+
+int SystemAgent::CheckIn(ProcessingModuleFactoryInterface& module_factory,
+			 ModulePlaceholder *module_placeholder,
+			 size_t processing_module_size,
+			 uint32_t core_id,
+			 const void *obfuscated_mod_cfg,
+			 void *obfuscated_parent_ppl,
+			 void **obfuscated_modinst_p)
+{
+	IoPinsInfo pins_info;
+	const dsp_fw::DwordArray& cfg_ipc_msg =
+			*reinterpret_cast<const dsp_fw::DwordArray*>(obfuscated_mod_cfg);
+	ModuleInitialSettingsConcrete settings(cfg_ipc_msg);
+
+	ProcessingModulePrerequisites prerequisites;
+	module_factory.GetPrerequisites(prerequisites);
+
+	/* Note: If module has no output pins, it requires HungryRTSink */
+	/*       to terminate parent Pipeline */
+	const bool hungry_rt_sink_required = prerequisites.output_pins_count == 0;
+	if (hungry_rt_sink_required) prerequisites.output_pins_count = 1;
+
+	if ((prerequisites.input_pins_count < 1) ||
+		(prerequisites.input_pins_count > INPUT_PIN_COUNT) ||
+		(prerequisites.output_pins_count < 1) ||
+		(prerequisites.output_pins_count > OUTPUT_PIN_COUNT))
+		return -1;
+
+	/* Deduce BaseModuleCfgExt if it was not part of the INIT_INSTANCE IPC message */
+	settings.DeduceBaseModuleCfgExt(prerequisites.input_pins_count,
+					prerequisites.output_pins_count);
+
+	module_factory.Create(*this, module_placeholder, ModuleInitialSettings(settings), pins_info);
+	IadkModuleAdapter& module_adapter = *reinterpret_cast<IadkModuleAdapter*>(module_handle_);
+	*obfuscated_modinst_p = &module_adapter;
+	reinterpret_cast<intel_adsp::ProcessingModuleInterface*>(module_placeholder)->Init();
+	return 0;
+}
+
+} /* namespace system */
+} /* namespace intel_adsp */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+/* The create_instance_f is a function call type known in IADK module. The module entry_point
+ * points to this type of function which starts module creation.
+ */
+typedef int (*create_instance_f)(uint32_t module_id, uint32_t instance_id, uint32_t core_id,
+				 void *mod_cfg, void *parent_ppl, void **mod_ptr);
+
+void* system_agent_start(uint32_t entry_point, uint32_t module_id, uint32_t instance_id,
+			 uint32_t core_id, uint32_t log_handle, void* mod_cfg)
+{
+	uint32_t ret;
+	SystemAgent system_agent(module_id, instance_id, core_id, log_handle);
+	void* system_agent_p = reinterpret_cast<void*>(&system_agent);
+
+	create_instance_f ci = (create_instance_f)(entry_point);
+	ret = ci(module_id, instance_id, core_id, mod_cfg, NULL, &system_agent_p);
+
+	return system_agent_p;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+extern "C" void __cxa_pure_virtual()  __attribute__((weak));
+
+void __cxa_pure_virtual()
+{
+}
+

--- a/src/audio/module_adapter/iadk/system_service.c
+++ b/src/audio/module_adapter/iadk/system_service.c
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2020 Intel Corporation. All rights reserved.
+//
+// Author: Jaroslaw Stelter <jaroslaw.stelter@linux.intel.com>
+
+/*
+ * System Service interface for ADSP loadable library.
+ */
+
+#include <errno.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <sof/common.h>
+#include <sof/sof.h>
+#include <sof/string.h>
+#include <ipc4/notification.h>
+#include <sof/ipc/msg.h>
+#include <adsp_error_code.h>
+#include <system_service.h>
+#include <sof/lib_manager.h>
+
+#define RSIZE_MAX 0x7FFFFFFF
+
+void SystemServiceLogMessage(AdspLogPriority log_priority, uint32_t log_entry,
+			     AdspLogHandle const *log_handle, uint32_t param1, uint32_t param2,
+			     uint32_t param3, uint32_t param4)
+{
+	uint32_t argc = (log_entry & 0x7);
+	/* TODO: Need to call here function like _log_sofdict, since we do not have format */
+	/*       passed from library */
+	/* This function could be finished when cAVS/ACE logging formats support will be */
+	/* added to SOF.*/
+	switch (argc) {
+	case 1:
+	break;
+
+	case 2:
+	break;
+
+	case 3:
+	break;
+
+	case 4:
+	break;
+
+	default:
+	break;
+	}
+}
+
+AdspErrorCode SystemServiceSafeMemcpy(void *RESTRICT dst, size_t maxlen, const void *RESTRICT src,
+				      size_t len)
+{
+	return (AdspErrorCode) memcpy_s(dst, maxlen, src, len);
+}
+
+AdspErrorCode SystemServiceSafeMemmove(void *dst, size_t maxlen, const void *src, size_t len)
+{
+	if (dst == NULL || maxlen > RSIZE_MAX)
+		return ADSP_INVALID_PARAMETERS;
+
+	if (src == NULL || len > maxlen) {
+		memset(dst, 0, maxlen);
+		return ADSP_INVALID_PARAMETERS;
+	}
+
+	if (len != 0) {
+		/* TODO: now it is memcopy. Finally it will be remap maybe?
+		 * Fix it when memory management API will be available.
+		 * memmove(dst, src, len);
+		 */
+		memcpy_s(dst, maxlen, src, len);
+	}
+	return ADSP_NO_ERROR;
+}
+
+void *SystemServiceVecMemset(void *dst, int c, size_t len)
+{
+	/* TODO: Currently simple memset. Should be changed. */
+	memset(dst, c, len);
+	return dst;
+}
+
+AdspErrorCode SystemServiceCreateNotification(NotificationParams *params,
+					      uint8_t *notification_buffer,
+					      uint32_t notification_buffer_size,
+					      AdspNotificationHandle *handle)
+{
+	if ((params == NULL) || (notification_buffer == NULL)
+		|| (notification_buffer_size <= 0) || (handle == NULL))
+		return ADSP_INVALID_PARAMETERS;
+
+	/* TODO: IPC header setup */
+	/* https://github.com/thesofproject/sof/pull/5720 needed for completion. */
+	union ipc4_notification_header header;
+
+	header.r.notif_type = params->type;
+	header.r._reserved_0 = params->user_val_1;
+	header.r.type = SOF_IPC4_GLB_NOTIFICATION;
+	header.r.rsp = SOF_IPC4_MESSAGE_DIR_MSG_REQUEST;
+	header.r.msg_tgt = SOF_IPC4_MESSAGE_TARGET_FW_GEN_MSG;
+	struct ipc_msg *msg = lib_notif_msg_init((uint32_t)header.dat, notification_buffer_size);
+
+	if (msg) {
+		*handle = (AdspNotificationHandle)msg;
+		params->payload = msg->tx_data;
+	}
+
+	return ADSP_NO_ERROR;
+}
+
+AdspErrorCode SystemServiceSendNotificationMessage(NotificationTarget notification_target,
+						   AdspNotificationHandle message,
+						   uint32_t actual_payload_size)
+{
+	if ((message == NULL) || (actual_payload_size == 0))
+		return ADSP_INVALID_PARAMETERS;
+
+	struct ipc_msg *msg = (struct ipc_msg *)message;
+
+	lib_notif_msg_send(msg);
+	return ADSP_NO_ERROR;
+}
+
+AdspErrorCode SystemServiceGetInterface(AdspIfaceId id, SystemServiceIface  **iface)
+{
+	if (id < 0)
+		return ADSP_INVALID_PARAMETERS;
+	return ADSP_NO_ERROR;
+}
+

--- a/src/audio/module_adapter/module/iadk_modules.c
+++ b/src/audio/module_adapter/module/iadk_modules.c
@@ -1,0 +1,319 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2020 Intel Corporation. All rights reserved.
+//
+// Author: Jaroslaw Stelter <jaroslaw.stelter@linux.intel.com>
+
+#include <sof/audio/module_adapter/module/generic.h>
+#include <sof/audio/module_adapter/module/iadk_modules.h>
+#include <utilities/array.h>
+#include <system_agent.h>
+#include <sof/lib_manager.h>
+
+/* Intel module adapter is an extension to SOF module adapter component that allows to integrate
+ * modules developed under IADK (Intel Audio Development Kit) Framework. IADK modules uses uniform
+ * set of interfaces and are linked into separate library. These modules are loaded in runtime
+ * through library_manager and then after registration into SOF component infrastructure are
+ * interfaced through module adapter API.
+ *
+ * There is variety of modules developed under IADK Framework by 3rd party vendors. The assumption
+ * here is to integrate these modules with SOF infrastructure without modules code modifications.
+ * Another assumption is that the 3rd party modules should be loaded in runtime without need
+ * of rebuild the base firmware.
+ * Therefore C++ function, structures and variables definition are here kept with original form from
+ * IADK Framework. This provides binary compatibility for already developed 3rd party modules.
+ *
+ * Since IADK modules uses ProcessingModuleInterface to control/data transfer and AdspSystemService
+ * to use base FW services from internal module code, there is a communication shim layer defined
+ * in intel directory.
+ *
+ * Since ProcessingModuleInterface consists of virtual functions, there are C++ -> C wrappers
+ * defined to access the interface calls from SOF code.
+ *
+ * There are three entities in intel module adapter package:
+ *  - System Agent - A mediator to allow the custom module to interact with the base SOF FW.
+ *                   It calls IADK module entry point and provides all necessary information to
+ *                   connect both sides of ProcessingModuleInterface and System Service.
+ *  - System Service - exposes of SOF base FW services to the module.
+ *  - Processing Module Adapter - SOF base FW side of ProcessingModuleInterface API
+ */
+
+/* ee2585f2-e7d8-43dc-90ab-4224e00c3e84 */
+DECLARE_SOF_RT_UUID("iadk_modules", intel_uuid, 0xee2585f2, 0xe7d8, 0x43dc,
+		    0x90, 0xab, 0x42, 0x24, 0xe0, 0x0c, 0x3e, 0x84);
+DECLARE_TR_CTX(intel_codec_tr, SOF_UUID(intel_uuid), LOG_LEVEL_INFO);
+
+/**
+ * \brief iadk_modules_init.
+ * \param[in] mod - processing module pointer.
+ *
+ * \return: zero on success
+ *          error code on failure
+ */
+static int iadk_modules_init(struct processing_module *mod)
+{
+	uint32_t module_entry_point;
+	struct module_data *md = &mod->priv;
+	struct comp_dev *dev = mod->dev;
+	int ret = 0;
+	byte_array_t mod_cfg;
+
+	mod_cfg.data = md->cfg.data;
+	/* Intel modules expects DW size here */
+	mod_cfg.size = (md->cfg.size >> 2);
+
+	struct comp_ipc_config *config = &(mod->dev->ipc_config);
+
+	/* At this point module resources are allocated and it is moved to L2 memory. */
+	module_entry_point = lib_manager_allocate_module(dev->drv, config, md->cfg.data);
+	if (module_entry_point == 0) {
+		comp_err(dev, "iadk_modules_init(), lib_manager_allocate_module() failed!");
+		return -EINVAL;
+	}
+	mod->priv.module_entry_point = module_entry_point;
+	comp_info(mod->dev, "iadk_modules_init() start");
+
+	uint32_t module_id = IPC4_MOD_ID(mod->dev->ipc_config.id);
+	uint32_t instance_id = IPC4_INST_ID(mod->dev->ipc_config.id);
+	uint32_t log_handle = (uint32_t) mod->dev->drv->tctx;
+	/* Connect loadable module interfaces with module adapter entity. */
+	void *mod_adp = system_agent_start(md->module_entry_point, module_id,
+					   instance_id, 0, log_handle, (void *)&mod_cfg);
+
+	md->module_adapter = mod_adp;
+	/* Call module specific init function if exists. */
+	ret = iadk_wrapper_init(mod->priv.module_adapter);
+	return ret;
+}
+
+/**
+ * \brief iadk_modules_prepare.
+ * \param[in] mod - processing module pointer.
+ *
+ * \return: zero on success
+ *          error code on failure
+ *
+ * \note:   We use ipc4_base_module_cfg since this is only what we know about module
+ *          configuration. Its internal structure is proprietary to the module implementation.
+ *          There is one assumption - all IADK modules utilize IPC4 protocol.
+ */
+static int iadk_modules_prepare(struct processing_module *mod)
+{
+	struct comp_dev *dev = mod->dev;
+	struct module_data *codec = &mod->priv;
+	struct ipc4_base_module_cfg *src_cfg =
+			(struct ipc4_base_module_cfg *)lib_manager_get_config(dev);
+	int ret = 0;
+
+	comp_info(dev, "iadk_modules_prepare()");
+
+	codec->mpd.in_buff = rballoc(0, SOF_MEM_CAPS_RAM, src_cfg->ibs);
+	if (!codec->mpd.in_buff) {
+		comp_err(dev, "iadk_modules_prepare(): Failed to alloc in_buff");
+		return -ENOMEM;
+	}
+	codec->mpd.in_buff_size = src_cfg->ibs;
+
+	codec->mpd.out_buff = rballoc(0, SOF_MEM_CAPS_RAM, src_cfg->obs);
+	if (!codec->mpd.out_buff) {
+		comp_err(dev, "iadk_modules_prepare(): Failed to alloc out_buff");
+		rfree(codec->mpd.in_buff);
+		return -ENOMEM;
+	}
+	codec->mpd.out_buff_size = src_cfg->obs;
+	/* Call module specific prepare function if exists. */
+	ret = iadk_wrapper_prepare(mod->priv.module_adapter);
+	return 0;
+}
+
+static int iadk_modules_init_process(struct processing_module *mod)
+{
+	struct module_data *codec = &mod->priv;
+	struct comp_dev *dev = mod->dev;
+
+	comp_dbg(dev, "iadk_modules_init_process()");
+
+	codec->mpd.produced = 0;
+	codec->mpd.consumed = 0;
+	codec->mpd.init_done = 1;
+
+	return 0;
+}
+
+/**
+ * \brief iadk_modules_process.
+ * \param[in] mod - processing module pointer.
+ *
+ * \return: zero on success
+ *          error code on failure
+ */
+static int iadk_modules_process(struct processing_module *mod,
+				struct input_stream_buffer *input_buffers,
+				int num_input_buffers,
+				struct output_stream_buffer *output_buffers,
+				int num_output_buffers)
+{
+	struct comp_dev *dev = mod->dev;
+	struct module_data *md = &mod->priv;
+	struct list_item *blist;
+	int ret;
+	int i = 0;
+
+	if (!md->mpd.init_done)
+		iadk_modules_init_process(mod);
+
+	/* IADK modules require output buffer size to set to its real size. */
+	list_for_item(blist, &dev->bsource_list) {
+		mod->output_buffers[i].size = md->mpd.out_buff_size;
+		i++;
+	}
+	/* Call module specific process function. */
+	ret = iadk_wrapper_process(mod->priv.module_adapter,
+				   input_buffers, num_input_buffers,
+				   output_buffers, num_output_buffers);
+
+	return ret;
+}
+
+/**
+ * \brief iadk_modules_free.
+ * \param[in] mod - processing module pointer.
+ *
+ * \return: zero on success
+ *          error code on failure
+ */
+static int iadk_modules_free(struct processing_module *mod)
+{
+	struct comp_dev *dev = mod->dev;
+	struct module_data *md = &mod->priv;
+	struct comp_ipc_config *config = &(mod->dev->ipc_config);
+	int ret = 0;
+
+	comp_info(dev, "iadk_modules_free()");
+	ret = iadk_wrapper_free(mod->priv.module_adapter);
+	rfree(md->mpd.in_buff);
+	rfree(md->mpd.out_buff);
+
+	/* Free module resources allocated in L2 memory. */
+	ret = lib_manager_free_module(dev->drv, config);
+	if (ret < 0)
+		comp_err(dev, "iadk_modules_free(), lib_manager_free_module() failed!");
+
+	return ret;
+}
+
+/**
+ * \brief iadk_modules_set_configuration - Common method to assemble large configuration message
+ * \param[in] mod - struct processing_module pointer
+ * \param[in] config_id - Configuration ID
+ * \param[in] pos - position of the fragment in the large message
+ * \param[in] data_offset_size: size of the whole configuration if it is the first fragment or the
+ *	      only fragment. Otherwise, it is the offset of the fragment in the whole
+ *	      configuration.
+ * \param[in] fragment: configuration fragment buffer
+ * \param[in] fragment_size: size of @fragment
+ * \params[in] response: optional response buffer to fill
+ * \params[in] response_size: size of @response
+ *
+ * \return: 0 upon success or error upon failure
+ */
+static int iadk_modules_set_configuration(struct processing_module *mod, uint32_t config_id,
+					  enum module_cfg_fragment_position pos,
+					  uint32_t data_offset_size, const uint8_t *fragment,
+					  size_t fragment_size, uint8_t *response,
+					  size_t response_size)
+{
+	return iadk_wrapper_set_configuration(mod->priv.module_adapter, config_id, pos,
+					      data_offset_size, fragment, fragment_size,
+					      response, response_size);
+}
+
+/**
+ * \brief iadk_modules_get_configuration - Common method to retrieve module configuration
+ * \param[in] mod - struct processing_module pointer
+ * \param[in] config_id - Configuration ID
+ * \param[in] pos - position of the fragment in the large message
+ * \param[in] data_offset_size: size of the whole configuration if it is the first fragment or the
+ *	      only fragment. Otherwise, it is the offset of the fragment in the whole configuration.
+ * \param[in] fragment: configuration fragment buffer
+ * \param[in] fragment_size: size of @fragment
+ *
+ * \return: 0 upon success or error upon failure
+ */
+static int iadk_modules_get_configuration(struct processing_module *mod, uint32_t config_id,
+					  enum module_cfg_fragment_position pos,
+					  uint32_t data_offset_size, const uint8_t *fragment,
+					  size_t fragment_size)
+{
+	return iadk_wrapper_get_configuration(mod->priv.module_adapter, config_id, pos,
+					      data_offset_size, fragment, fragment_size);
+}
+
+/**
+ * \brief Sets the processing mode for the module.
+ * \param[in] mod - struct processing_module pointer
+ * \param[in] mode - module processing mode to be set
+ *
+ * \return: 0 upon success or error upon failure
+ */
+static int iadk_modules_set_processing_mode(struct processing_module *mod,
+					    enum module_processing_mode mode)
+{
+	return iadk_wrapper_set_processing_mode(mod->priv.module_adapter, mode);
+}
+
+/**
+ * \brief Gets the processing mode actually set for the module.
+ * \param[in] mod - struct processing_module pointer
+ *
+ * \return: enum - module processing mode value
+ */
+static enum module_processing_mode iadk_modules_get_processing_mode(struct processing_module *mod)
+{
+	return iadk_wrapper_get_processing_mode(mod->priv.module_adapter);
+}
+
+/**
+ * \brief Upon call to this method the ADSP system requires the module to reset its
+ * internal state into a well-known initial value.
+ * \param[in] mod - struct processing_module pointer
+ *
+ * \return: 0 upon success or error upon failure
+ */
+static int iadk_modules_reset(struct processing_module *mod)
+{
+	return iadk_wrapper_reset(mod->priv.module_adapter);
+}
+
+/* Processing Module Adapter API*/
+static struct module_interface iadk_interface = {
+	.init  = iadk_modules_init,
+	.prepare = iadk_modules_prepare,
+	.process = iadk_modules_process,
+	.set_processing_mode = iadk_modules_set_processing_mode,
+	.get_processing_mode = iadk_modules_get_processing_mode,
+	.set_configuration = iadk_modules_set_configuration,
+	.get_configuration = iadk_modules_get_configuration,
+	.reset = iadk_modules_reset,
+	.free = iadk_modules_free,
+};
+
+/**
+ * \brief Create a module adapter component.
+ * \param[in] drv - component driver pointer.
+ * \param[in] config - component ipc descriptor pointer.
+ * \param[in] spec - pointer to module configuration data
+ *
+ * \return: a pointer to newly created module adapter component on success. NULL on error.
+ *
+ * \note: For dynamically loaded module the spec size is not known by base FW, since this is
+ *        loaded module specific information. Therefore configuration size is required here.
+ *        New module details are discovered during its loading, therefore comp_driver initialisation
+ *        happens at this point.
+ */
+struct comp_dev *iadk_modules_shim_new(const struct comp_driver *drv,
+				       struct comp_ipc_config *config,
+				       void *spec)
+{
+	return module_adapter_new(drv, config, &iadk_interface, spec);
+}

--- a/src/include/sof/audio/module_adapter/iadk/adsp_error_code.h
+++ b/src/include/sof/audio/module_adapter/iadk/adsp_error_code.h
@@ -1,0 +1,37 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2022 Intel Corporation. All rights reserved.
+ */
+
+#ifndef _ADSP_ERROR_CODE_H_
+#define _ADSP_ERROR_CODE_H_
+
+#include <stdint.h>
+
+/**
+ * Defines error codes that are returned in the ADSP project.
+ * NOTE: intel_adsp::ErrorCode should be merged into this namespaceless
+ * type to be used in 3rd party's C code.
+ */
+typedef uint32_t AdspErrorCode;
+
+ /* Reports no error */
+#define ADSP_NO_ERROR 0
+/* Reports that some parameters passed to the method are invalid */
+#define ADSP_INVALID_PARAMETERS 1
+/* Reports that the system or resource is busy. */
+#define ADSP_BUSY_RESOURCE 4
+/**
+ * Module has detected some unexpected critical situation (e.g. memory corruption).
+ * Upon this error code the ADSP System is asked to stop any interactions with the module
+ * instance.
+ */
+#define ADSP_FATAL_FAILURE 6
+/* Report out of memory. */
+#define ADSP_OUT_OF_MEMORY 15
+/* Report invalid target. */
+#define ADSP_INVALID_TARGET 142
+/* Service is not supported on target platform. */
+#define ADSP_SERVICE_UNAVAILABLE 143
+
+#endif /* _ADSP_ERROR_CODE_H_ */

--- a/src/include/sof/audio/module_adapter/iadk/adsp_stddef.h
+++ b/src/include/sof/audio/module_adapter/iadk/adsp_stddef.h
@@ -1,0 +1,57 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2022 Intel Corporation. All rights reserved.
+ */
+
+#ifndef _ADSP_STDDEF_H_
+#define _ADSP_STDDEF_H_
+
+#include <stddef.h>
+#include <stdint.h>
+#include <sys/util.h>
+#include <user/trace.h>
+
+#ifdef __XTENSA__
+  #define RESTRICT __restrict
+#else
+  #define RESTRICT
+#endif
+
+/*! Log level priority enumeration. */
+typedef enum log_priority {
+	/*! Critical message. */
+	L_CRITICAL = LOG_LEVEL_CRITICAL,
+	/*! Error message. */
+	L_ERROR = LOG_LEVEL_ERROR,
+	/*! High importance log level. */
+	L_HIGH = LOG_LEVEL_ERROR,
+	/*! Warning message. */
+	L_WARNING = LOG_LEVEL_WARNING,
+	/*! Medium importance log level. */
+	L_MEDIUM = LOG_LEVEL_WARNING,
+	/*! Low importance log level. */
+	L_LOW = LOG_LEVEL_INFO,
+	/*! Information. */
+	L_INFO = LOG_LEVEL_INFO,
+	/*! Verbose message. */
+	L_VERBOSE = LOG_LEVEL_VERBOSE,
+	L_DEBUG   = LOG_LEVEL_DEBUG,
+	L_MAX     = LOG_LEVEL_DEBUG,
+} AdspLogPriority,
+	log_priority_e;
+struct AdspLogHandle;
+typedef struct AdspLogHandle AdspLogHandle;
+
+#ifdef __cplusplus
+namespace intel_adsp
+{
+struct ModulePlaceholder {};
+}
+inline void *operator new(size_t size, intel_adsp::ModulePlaceholder * placeholder) throw()
+{
+	(void)size;
+	return placeholder;
+}
+#endif /* #ifdef __cplusplus */
+
+#endif /*_ADSP_STDDEF_H_ */

--- a/src/include/sof/audio/module_adapter/iadk/fixed_array.h
+++ b/src/include/sof/audio/module_adapter/iadk/fixed_array.h
@@ -1,0 +1,77 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2022 Intel Corporation. All rights reserved.
+ */
+/*! \file fixed_array.h */
+
+#ifndef _ADSP_FIXED_ARRAY_H_
+#define _ADSP_FIXED_ARRAY_H_
+
+#include <stddef.h>
+
+namespace intel_adsp
+{
+	/* \brief Fixed-size container of continuous elements whose size is specified at runtime.
+	 *
+	 * This container is very similar to the C-array except that its fixed-size is specified at
+	 * runtime.
+	 * It acts as a facade to expose a memory buffer as a array of elements with same type.
+	 *
+	 *  \tparam VALUE   type of the array elements.
+	 */
+	template < class VALUE >
+	struct FixedArray {
+		typedef VALUE ValueType;
+
+		/*! \brief Initializes a new instance of FixedArray.
+		 */
+		explicit FixedArray(ValueType *array, size_t length) :
+				    array_(array), length_(length)
+		{}
+
+		/*! \brief Gets value at the given index of the array.
+		 *  \param index    index of the value to retrieve. By default index is set to 0.
+		 *  \note If index is out of range (i.e. is equal or greater than value returned by
+		 *        GetLength()) the returned value is mal-formed.
+		 *  \remarks Return is by value rather than reference to prevent client code from
+		 *           working with dangling reference.
+		 *  Indeed a FixedArray object does not own the underlying associated buffer.
+		 */
+		ValueType GetValue(int index = 0) const
+		{
+			return array_[index];
+		}
+
+		/*! \brief Subscript operator.
+		 *
+		 * This method actually returns  the result of GetValue()
+		 */
+		ValueType operator[](int index) const
+		{
+			return GetValue(index);
+		}
+
+		/*! \brief Gets the number of elements
+		 */
+		size_t GetLength(void) const
+		{
+			return length_;
+		}
+
+		/*! \brief Copies the values wrapped by the FixedArray into the given C-array
+		 */
+		void Copy(ValueType *array, size_t length) const
+		{
+			length = MIN(length, length_);
+			for (int i = 0 ; i < length ; i++)
+				array[i] = array_[i];
+		}
+
+	private:
+		ValueType * const array_;
+		size_t const length_;
+	};
+
+} /* namespace intel_adsp */
+
+#endif /* #ifndef _ADSP_FIXED_ARRAY_H_ */

--- a/src/include/sof/audio/module_adapter/iadk/iadk_module_adapter.h
+++ b/src/include/sof/audio/module_adapter/iadk/iadk_module_adapter.h
@@ -1,0 +1,146 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2022 Intel Corporation. All rights reserved.
+ *
+ * Author: Jaroslaw Stelter <jaroslaw.stelter@intel.com>
+ *
+ */
+
+#ifndef _IADK_MODULE_ADAPTER_H
+#define _IADK_MODULE_ADAPTER_H
+
+#ifdef __cplusplus
+
+#include <processing_module_interface.h>
+#include <module_initial_settings.h>
+#include <adsp_stddef.h>
+#include <system_error.h>
+
+#include <sof/audio/module_adapter/module/module_interface.h>
+
+extern "C" {
+namespace dsp_fw
+{
+	/*!
+	 * \brief This ModuleAdapter class can adapt a ProcessingModuleInterface instance into
+	 *        a ModuleInstance instance.
+	 *
+	 * The overall base FW can only handle ModuleInstance object. Purpose of this adapter is
+	 * to turn an intel_adsp::ProcessingModuleInterface object into a ModuleInstance object.
+	 */
+	class IadkModuleAdapter
+	{
+	public:
+		IadkModuleAdapter(intel_adsp::ProcessingModuleInterface &processing_module,
+		                  void *comp_dev_instance,
+		                  uint32_t module_id,
+		                  uint32_t instance_id,
+		                  uint32_t core_id,
+		                  size_t module_size);
+
+		/**
+		 * Module specific initialization procedure, called as part of
+		 *
+		 */
+		int IadkModuleAdapter_Init(void);
+
+		/**
+		 * Module specific prepare procedure, called as part of codec_adapter
+		 * component preparation in .prepare()
+		 */
+		int IadkModuleAdapter_Prepare(void);
+
+		/**
+		 * Module specific processing procedure, called as part of codec_adapter
+		 * component copy in .copy(). This procedure is responsible to consume
+		 * samples provided by the codec_adapter and produce/output the processed
+		 * ones back to codec_adapter.
+		 */
+		uint32_t IadkModuleAdapter_Process(struct input_stream_buffer *input_buffers,
+						   int num_input_buffers,
+						   struct output_stream_buffer *output_buffers,
+						   int num_output_buffers);
+
+		/**
+		 * Module specific apply config procedure, called by codec_adapter every time
+		 * a new RUNTIME configuration has been sent if the adapter has been
+		 * prepared. This will not be called for SETUP cfg.
+		 */
+		AdspErrorCode
+		IadkModuleAdapter_SetConfiguration(uint32_t config_id,
+		                               enum module_cfg_fragment_position fragment_position,
+		                               uint32_t data_offset_size,
+		                               const uint8_t *fragment_buffer,
+		                               size_t fragment_size,
+		                               uint8_t *response,
+		                               size_t &response_size) /*override*/;
+
+		/**
+		 * Retrieves the configuration message for the given configuration ID.
+		 */
+		AdspErrorCode
+		IadkModuleAdapter_GetConfiguration(uint32_t config_id,
+		                               enum module_cfg_fragment_position fragment_position,
+		                               uint32_t data_offset_size,
+		                               uint8_t *fragment_buffer,
+		                               size_t fragment_size);
+		/**
+		 * Module specific reset procedure, called as part of codec_adapter component
+		 * reset in .reset(). This should reset all parameters to their initial stage
+		 * but leave allocated memory intact.
+		 */
+		void IadkModuleAdapter_Reset(void);
+		/**
+		 * Module specific free procedure, called as part of codec_adapter component
+		 * free in .free(). This should free all memory allocated by module.
+		 */
+		int IadkModuleAdapter_Free(void);
+		void IadkModuleAdapter_SetProcessingMode(enum module_processing_mode sof_mode);
+
+		enum module_processing_mode IadkModuleAdapter_GetProcessingMode(void);
+
+	private:
+
+		intel_adsp::ProcessingModuleInterface &processing_module_;
+	};
+
+} /* namespace dsp_fw */
+
+} /* extern "C" */
+
+void *operator new(size_t size, intel_adsp::InputStreamBuffer *placeholder) throw();
+void *operator new(size_t size, intel_adsp::OutputStreamBuffer *placeholder) throw();
+
+#else /* __cplusplus */
+
+/* C wrappers for C++  ProcessingModuleInterface() methods. */
+int iadk_wrapper_init(void *md);
+
+int iadk_wrapper_prepare(void *md);
+
+int iadk_wrapper_set_processing_mode(void *md, enum module_processing_mode mode);
+
+enum module_processing_mode iadk_wrapper_get_processing_mode(void *md);
+
+int iadk_wrapper_reset(void *md);
+
+int iadk_wrapper_free(void *md);
+
+int iadk_wrapper_set_configuration(void *md, uint32_t config_id,
+				   enum module_cfg_fragment_position pos,
+				   uint32_t data_offset_size,
+				   const uint8_t *fragment, size_t fragment_size,
+				   uint8_t *response, size_t response_size);
+
+int iadk_wrapper_get_configuration(void *md, uint32_t config_id,
+				   enum module_cfg_fragment_position pos,
+				   uint32_t data_offset_size,
+				   uint8_t *fragment, size_t fragment_size);
+
+int iadk_wrapper_process(void *md, struct input_stream_buffer *input_buffers,
+			 int num_input_buffers, struct output_stream_buffer *output_buffers,
+			 int num_output_buffers);
+
+#endif /* __cplusplus */
+
+#endif /*_IADK_MODULE_ADAPTER_H */

--- a/src/include/sof/audio/module_adapter/iadk/logger.h
+++ b/src/include/sof/audio/module_adapter/iadk/logger.h
@@ -1,0 +1,49 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2022 Intel Corporation. All rights reserved.
+ */
+/*! \file logger.h */
+
+#ifndef _ADSP_FDK_LOGGER_H_
+#define _ADSP_FDK_LOGGER_H_
+
+#include <stdint.h>
+#include "system_service.h"
+#ifdef __cplusplus
+namespace intel_adsp
+{
+/*! \brief Helper class which handles the values list passed at call to the LOG_MESSAGE macro.
+ * \internal
+ * This class should not be used directly. log sending can be performed with help of the macro
+ *  \ref LOG_MESSAGE.
+ */
+class Logger
+{
+public:
+	/*! \cond INTERNAL */
+	Logger(AdspSystemService const &system_service, AdspLogHandle const &log_handle)
+		:
+			system_service_(system_service),
+			log_handle_(log_handle)
+	{}
+
+	template<AdspLogPriority LOG_LEVEL>
+	void SendMessage(uint32_t log_entry, uint32_t _ignored, uint32_t param1 = 0,
+			 uint32_t param2 = 0, uint32_t param3 = 0, uint32_t param4 = 0)
+	{
+		(void)_ignored;
+		system_service_.LogMessage(LOG_LEVEL, log_entry, &log_handle_,
+					   param1, param2, param3, param4);
+	}
+
+	/*! \endcond INTERNAL */
+private:
+	AdspSystemService const &system_service_;
+	AdspLogHandle const &log_handle_;
+};
+
+} /* namespace intel_adsp */
+
+#endif /* #ifdef __cplusplus */
+
+#endif /* _ADSP_FDK_LOGGER_H_ */

--- a/src/include/sof/audio/module_adapter/iadk/module_initial_settings.h
+++ b/src/include/sof/audio/module_adapter/iadk/module_initial_settings.h
@@ -1,0 +1,180 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2022 Intel Corporation. All rights reserved.
+ */
+/*! \file module_initial_settings.h */
+
+#ifndef _ADSP_MODULE_INITIAL_SETTINGS_H_
+#define _ADSP_MODULE_INITIAL_SETTINGS_H_
+
+#include "adsp_stddef.h"
+#include "fixed_array.h"
+#include <ipc4/base-config.h>
+
+/* Mapping of IPC4 definitions into IADK naming counterpart */
+typedef struct ipc4_base_module_cfg BaseModuleCfg;
+typedef struct ipc4_base_module_cfg LegacyModuleInitialSettings;
+typedef struct ipc4_input_pin_format InputPinFormat;
+typedef struct ipc4_output_pin_format OutputPinFormat;
+typedef struct ipc4_audio_format AudioFormat;
+
+#define INPUT_PIN_COUNT		(1 << 3)
+#define OUTPUT_PIN_COUNT	(1 << 3)
+
+namespace intel_adsp
+{
+	/*! \brief Enumeration values of keys to access to the ModuleInitialSettings items */
+	enum ModuleInitialSettingsKey {
+		/*! \brief Key value to retrieve the LegacyModuleInitialSettings item from the
+		 * ModuleInitialSettings.
+		 *  \deprecated New module shall not work with this item as it will be removed
+		 *  in next API release.
+		 */
+		LEGACY_STRUCT = 0,
+		/*! \brief Key value to retrieve the array of InputPinFormat item from
+		 * the ModuleInitialSettings.
+		 */
+		IN_PINS_FORMAT,
+		/*! \brief Key value to retrieve the array of OutputPinFormat item from
+		 * the ModuleInitialSettings.
+		 */
+		OUT_PINS_FORMAT
+	};
+
+	/*!    \brief Helps to identify type of a ModuleInitialSettings item referenced by its KEY
+	 *      \tparam KEY          identifying the settings item
+	 */
+	template < ModuleInitialSettingsKey KEY > struct ModuleInitialSettingsItem
+	{
+		/*! \brief value type of the SETTINGS item for the given KEY value.
+		 * \note ValueType shall have copy constructor
+		 */
+		typedef void ValueType;
+	};
+
+	/*! \brief Defines the interface to retrieve untyped items based
+	 * on ModuleInitialSettingsKey values.
+	 * \internal
+	 */
+	struct ModuleInitialSettingsInterface {
+		/*! \internal */
+		virtual void const *GetUntypedItem(ModuleInitialSettingsKey key,
+						   size_t & length) = 0;
+	};
+
+	namespace system
+	{ class SystemAgent; }
+
+	/*! \brief The set of settings item given for initialization of a Module instance.
+	 *
+	 * The ModuleInitialSettings is a container of heterogeneous typed value items. Each item
+	 * is a key-value pair where key is an enumeration value of ModuleInitialSettingsKey
+	 */
+	class ModuleInitialSettings
+	{
+		template < class DERIVED, class PROCESSING_MODULE >
+				friend class ProcessingModuleFactory;
+				friend class system::SystemAgent;
+
+	public:
+		/*! \brief A FixedArray whose construction is only granted to
+		 * ModuleInitialSettings
+		 */
+		template < class VALUE >
+		struct Array : public FixedArray < VALUE >
+		{
+			friend class ModuleInitialSettings;
+			typedef VALUE ValueType;
+
+		/*! \brief Initializes a new instance of Array.
+		 */
+		explicit Array(ValueType *array, size_t length) :
+				FixedArray < ValueType > (array, length)
+		{}
+
+		private:
+			/*! \brief copy constructor is invalidated to prevent client code from
+			 * working with dangling reference. Consider the Copy() operation if
+			 * a copy of the settings item array is required.
+			 */
+			Array(Array < ValueType > const &);
+
+			/*! \brief copy-assignment operator is invalidated to prevent client code
+			 * from working with dangling reference. Consider the Copy() operation if
+			 * a copy of the settings item array is required.
+			 */
+			Array < ValueType > &operator = (Array < ValueType > const &);
+		};
+
+		/*! \brief the type of keys to access to the ModuleInitialSettings items */
+		typedef ModuleInitialSettingsKey Key;
+
+		/*! \brief Initializes a new instance of ModuleInitialSettings given some
+		 * ModuleInitialSettingsInterface object
+		 */
+		explicit ModuleInitialSettings(ModuleInitialSettingsInterface & performer) :
+			performer_(performer)
+		{}
+
+		/*! \brief Retrieves the item as an array of values for the given key.
+		 *  \note Any item is represented as a value array even if it has a single value.
+		 *  \remarks If no item is found for the given key, the returned array will
+		 *  have null length.
+		 *  \tparam key     value of the Key to retrieve the item.
+		 */
+		template < Key key >
+		const Array < typename ModuleInitialSettingsItem < key >
+					:: ValueType const > GetItem()
+		{
+			size_t length;
+
+			return Array < typename ModuleInitialSettingsItem < key >
+					:: ValueType const > (
+			reinterpret_cast < typename ModuleInitialSettingsItem < key >
+					:: ValueType const *>
+					(performer_.GetUntypedItem(key, length)), length);
+		}
+
+	private:
+		/*! \brief For sake of safety ModuleInitialSettings is not "publicly" copy-able.
+		 * Indeed, ModuleInitialSettings instance holds references on some ADSP System
+		 * resources which are only available for a temporary lifetime.
+		 */
+		ModuleInitialSettings(ModuleInitialSettings const &src) :
+				performer_(src.performer_) { }
+		/*! ModuleInitialSettings(ModuleInitialSettings const&) */
+		ModuleInitialSettings operator = (ModuleInitialSettings const &src);
+
+		ModuleInitialSettingsInterface & performer_;
+	};
+
+	/*! \brief Boilerplate to identify type of the ModuleInitialSettings item associated
+	 * to the "LEGACY_STRUCT" key
+	 *  \internal
+	 */
+	template < > struct ModuleInitialSettingsItem < LEGACY_STRUCT >
+	{
+		typedef LegacyModuleInitialSettings ValueType;
+	};
+
+	/*! \brief Boilerplate to identify type of the ModuleInitialSettings item associated
+	 * to the "IN_PINS_FORMAT" key
+	 *  \internal
+	 */
+	template < > struct ModuleInitialSettingsItem < IN_PINS_FORMAT >
+	{
+		typedef InputPinFormat ValueType;
+	};
+
+	/*! \brief Boilerplate to identify type of the ModuleInitialSettings item associated
+	 * to the "OUT_PINS_FORMAT" key
+	 *  \internal
+	 */
+	template < > struct ModuleInitialSettingsItem < OUT_PINS_FORMAT >
+	{
+		typedef OutputPinFormat ValueType;
+	};
+
+} /*namespace intel_adsp */
+
+#endif /* #ifndef _ADSP_MODULE_INITIAL_SETTINGS_H_ */

--- a/src/include/sof/audio/module_adapter/iadk/module_initial_settings_concrete.h
+++ b/src/include/sof/audio/module_adapter/iadk/module_initial_settings_concrete.h
@@ -1,0 +1,114 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2022 Intel Corporation. All rights reserved.
+ */
+
+#ifndef _MODULE_INITIAL_SETTINGS_CONCRETE_H
+#define _MODULE_INITIAL_SETTINGS_CONCRETE_H
+
+#include "module_initial_settings.h"
+#include <utilities/array.h>
+#include <sof/compiler_attributes.h>
+
+#include <stddef.h>
+
+#pragma pack(push, 4)
+struct BaseModuleCfgExt {
+	/*!
+	 * \brief Specifies number of items in input_pins array. Maximum size is 8.
+	 */
+	uint16_t nb_input_pins;
+	/*!
+	 * \brief Specifies number of items in output_pins array. Maximum size is 8.
+	 */
+	uint16_t nb_output_pins;
+	/*!
+	 * \brief Not used, set to 0.
+	 */
+	uint8_t  reserved[12];
+	/*!
+	 * \brief Specifies format of input pins.
+	 * \remarks Pin format arrays may be non-continuous i.e. may contain pin #0
+	 * format followed by pin #2 format
+	 * in case pin #1 will not be in use. FW assigned format of the pin based
+	 * on pin_index, not on a position of the item in the array.
+	 * Applies to both input and output pins.
+	 */
+	InputPinFormat input_pins[1];
+	/*!
+	 * \brief Specifies format of output pins.
+	 */
+	OutputPinFormat output_pins[1];
+};
+#pragma pack(pop)
+
+namespace dsp_fw
+{
+/*! \brief concrete implementation of the intel_adsp::ModuleInitialSettingsInterface
+ *
+ * Allow to retrieve the settings items in the INIT_INSTANCE IPC message
+ */
+struct ModuleInitialSettingsConcrete : public intel_adsp::ModuleInitialSettingsInterface
+{
+	/*! \brief Initializes a new ModuleInitialSettingsConcrete instance given
+	 *  an INIT_INSTANCE IPC message blob
+	 */
+	explicit ModuleInitialSettingsConcrete(DwordArray const &cfg_ipc_msg);
+
+	/*! \brief Extrapolates some hard-coded BaseModuleCfgExt based on the legacy
+	 * BaseModuleCfg and the given input count and output count.
+	 *  \remarks If BaseModuleCfgExt was actually already part of
+	 *  the INIT_INSTANCE IPC message, nothing is performed.
+	 */
+	void DeduceBaseModuleCfgExt(size_t in_pins_count, size_t out_pins_count);
+
+	/*! \brief Gets the untyped value array of the settings item for the given key
+	 *  \note In this methods it is assumed that the given INIT_INSTANCE IPC message
+	 *   has a valid content
+	 *  \warning IsParsable() result shall have been checked before invoking this method.
+	 */
+	virtual void const *GetUntypedItem(intel_adsp::ModuleInitialSettingsKey key,
+					   size_t &length);
+
+	/*! \brief Indicates if the given INIT_INSTANCE IPC message is parse-able */
+	bool IsParsable(void) const
+	{
+		return ((cfg_ != NULL) || (cfg_ext_ != NULL));
+	}
+
+	/*! \brief Gets pointer on the BaseModuleCfg data retrieved from the IPC message */
+	BaseModuleCfg const *GetBaseModuleCfg(void) const
+	{
+		return cfg_;
+	}
+
+	/*! \brief Gets pointer on the BaseModuleCfgExt data retrieved from the IPC message */
+	BaseModuleCfgExt const *GetBaseModuleCfgExt(void) const
+	{
+		return cfg_ext_;
+	}
+
+private:
+	BaseModuleCfg const *cfg_;
+	BaseModuleCfgExt const *cfg_ext_;
+	/* temporary extended module config for case where it is not part of
+	 * the INIT_INSTANCE IPC message
+	 */
+	union {
+		BaseModuleCfgExt tlv;
+		/* struct below reserved the placeholder for the biggest possible BaseModuleCfgExt
+		 * block.
+		 */
+		struct {
+			uint16_t           do_not_use1;
+			uint16_t           do_not_use2;
+			uint8_t            do_not_use3[8];
+			uint32_t           do_not_use4;
+			InputPinFormat     do_not_use5[INPUT_PIN_COUNT];
+			OutputPinFormat    do_not_use6[OUTPUT_PIN_COUNT];
+		} placeholder;
+	} tmp_cfg_ext_;
+};
+}
+
+#endif /*_MODULE_INITIAL_SETTINGS_CONCRETE_H */

--- a/src/include/sof/audio/module_adapter/iadk/processing_module_factory_interface.h
+++ b/src/include/sof/audio/module_adapter/iadk/processing_module_factory_interface.h
@@ -1,0 +1,149 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2022 Intel Corporation. All rights reserved.
+ */
+/*! \file processing_module_factory_interface.h */
+
+#ifndef _PROCESSING_MODULE_FACTORY_INTERFACE_H_
+#define _PROCESSING_MODULE_FACTORY_INTERFACE_H_
+
+#include "processing_module_interface.h"
+#include "system_agent_interface.h"
+#include "processing_module_prerequisites.h"
+#include "module_initial_settings.h"
+
+namespace intel_adsp
+{
+	/*! \brief defines type of the pin endpoint.
+	 *
+	 * A custom module is required to provide to the ADSP System some PinEndpoint value arrays.
+	 * Arrays length shall be as long as it has input and output pins.
+	 * (ref \ref ProcessingModuleFactoryInterface::Create()).
+	 */
+	typedef void *PinEndpoint;
+	typedef struct { void *prt[2]; } FwdEvent;
+
+	/*! \brief holds information about pins of a module.
+	 *
+	 * For each custom module,
+	 * input pins of a module are associated to some "sources" PinEndPoint and
+	 * output pins are associated to some sinks "PinEndPoint" objects.
+	 * Those sinks and sources objects shall be instantiated by the custom module and delivered
+	 * to the ADSP System with this IoPinsInfo structure
+	 * (through \ref ProcessingModuleFactoryInterface::Create()).
+	 *
+	 * \note The "pin" of a module is purely conceptual and has no programmatic correspondence.
+	 * A module has as many input/output pins as input/output streams which can be
+	 * driven through it.
+	 */
+	struct IoPinsInfo {
+		/*!
+		 * \brief pointer on a PinEndpoint array with "sources_count" elements
+		 *
+		 * A module is required to provide some PinEndpoint arrays to allow
+		 * the ADSP System to drive streams into the module.
+		 */
+		PinEndpoint *sources;
+		/*!
+		 * \brief pointer on a PinEndpoint array with "sinks_count" elements
+		 *
+		 * A module is required to provide some PinEndpoint arrays to allow
+		 * the ADSP System to drive stream out of the module.
+		 */
+		PinEndpoint *sinks;
+		/*!
+		 * \brief pointer on a FwdEvents array with "events_count" elements
+		 *
+		 * A module is required to provide some FwdEvents arrays to allow
+		 * the ADSP System to handle key phrase detection.
+		 */
+		FwdEvent *events;
+
+		/*! \brief description of buffer reserved for DP queue objects and buffers
+		 * used for all additional input and output pins (e.g. reference pin)
+		 */
+		uint8_t *pins_mem_pool;
+		size_t pins_mem_pool_size;
+	};
+
+	/*!
+	 * \brief The ProcessingModuleFactoryInterface class defines requirements for creating
+	 * a processing module controllable by the ADSP System.
+	 */
+	class ProcessingModuleFactoryInterface
+	{
+	public:
+		/*!
+		 * \brief Scoped enumeration of error code value which can be reported by
+		 * a ProcessingModuleFactoryInterface object
+		 */
+		struct ErrorCode : intel_adsp::ErrorCode {
+			/*! \brief list of named error codes specific to
+			 * the ProcessingModuleFactoryInterface
+			 */
+			enum Enum {
+				/*!< Reports that the given value of Input Buffer Size is invalid */
+				INVALID_IBS = intel_adsp::ErrorCode::MaxValue + 1,
+				/*!< Reports that the given value of Output Buffer Size is invalid*/
+				INVALID_OBS,
+				/*!< Reports that the given value of Cycles Per Chunk processing
+				 * is invalid
+				 */
+				INVALID_CPC,
+				/*!< Reports that the settings provided for module creation
+				 * are invalid
+				 */
+				INVALID_SETTINGS
+			};
+			/*! \brief Indicates the minimal value of the enumeration */
+			static Enum const MinValue = INVALID_IBS;
+			/*! \brief Indicates the maximal value of the enumeration */
+			static Enum const MaxValue = INVALID_SETTINGS;
+
+			/*!
+			 * \brief Initializes a new instance of ErrorCode given a value
+			 */
+			explicit ErrorCode(Type value)
+				:   intel_adsp::ErrorCode(value)
+			{}
+		};
+
+		/*!
+		 * \brief Indicates the prerequisites for module instance creation.
+		 *
+		 * ADSP System calls this method before each module instance creation.
+		 * \param [out] module_prereqs reports module prerequisites
+		 *              that ADSP System needs to prepare the module creation.
+		 */
+		virtual void GetPrerequisites(ProcessingModulePrerequisites & module_prereqs
+				) = 0;
+		/*!
+		 * \brief Creates a ProcessingModuleInstance instance in the given placeholder.
+		 *
+		 * The custom implementation of the Create method is expected to handle
+		 * initialization of the custom module instances.
+		 * \note The ADSP System will provide a dedicated memory \e placeholder for every
+		 *       module instance to create.
+		 *
+		 * \param [in] system_agent the SystemAgentInterface object which can register the
+		 *             module instance which is being initialized
+		 * \param [in] module_placeholder the pointer to the memory location where the
+		 *             module instance can be initialized using the "new placement syntax".
+		 * Note that the size of the placeholder given by the System is worth
+		 * the size of the processing module class given as parameter of the
+		 * DECLARE_LOADABLE_MODULE macro
+		 * \param [in] initial_settings  initial settings for module startup.
+		 * \param [out] pins_info will report the IoPinsInfo data that ADSP System
+		 *              requires to bind the input and output streams to the module.
+		 * \return some ErrorCode value upon creation status.
+		 */
+		virtual ErrorCode::Type Create(SystemAgentInterface & system_agent,
+				ModulePlaceholder * module_placeholder,
+				ModuleInitialSettings initial_settings,
+				IoPinsInfo & pins_info
+			) = 0;
+	}; /* class ProcessingModuleFactoryInterface */
+
+} /* namespace intel_adsp */
+
+#endif /* #ifndef _PROCESSING_MODULE_FACTORY_INTERFACE_H_ */

--- a/src/include/sof/audio/module_adapter/iadk/processing_module_interface.h
+++ b/src/include/sof/audio/module_adapter/iadk/processing_module_interface.h
@@ -1,0 +1,405 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2022 Intel Corporation. All rights reserved.
+ */
+/*! \file processing_module_interface.h */
+
+#ifndef _ADSP_PROCESSING_MODULE_INTERFACE_H_
+#define _ADSP_PROCESSING_MODULE_INTERFACE_H_
+
+#include "system_error.h"
+
+#include <stdint.h>
+#include <stddef.h>
+
+namespace intel_adsp
+{
+	/*! \brief Scoped enumeration which defines processing mode values
+	 * \see ProcessingModuleInterface::SetProcessingMode()
+	 */
+	struct ProcessingMode {
+		/*! \brief enumeration values of processing mode */
+		enum Enum {
+			NORMAL = 0,/*!< Indicates that module is expected to apply its custom
+				    * processing on signal.
+				    */
+			BYPASS	/*!< Indicates that module is expected to not apply its custom
+				 * processing on signal. The module is expected to forward as far
+				 * as possible the input signals unmodified
+				 * with respect of the signal continuity at the mode transition.
+				 */
+		};
+
+		/*! \brief Underlying type for storing of ProcessingMode value */
+		typedef int Type;
+
+		/*! \brief Initializes a new instance of ProcessingMode with the NORMAL
+		 * as default value
+		 */
+		ProcessingMode(void)
+			:   value_(NORMAL)
+		{}
+
+		/*! \brief Implicitly initializes a new instance of ProcessingMode given
+		 * an Enum value
+		 */
+		ProcessingMode(Enum mode_value)
+			:   value_(mode_value)
+		{}
+
+		/*! \brief Implicitly converts a ProcessingMode object into an Enum value */
+		operator Enum(void)
+		{
+			return (Enum) value_;
+		}
+
+	private:
+		Type value_;
+	};
+
+	/*! \brief defines the bitfield structure of flags associated to an InputStreamBuffer
+	 */
+	struct InputStreamFlags {
+		/*!< indicates that End Of Stream condition has occurred on the input stream */
+		bool end_of_stream : 1;
+	};
+
+	/*! \brief Descriptor of the data stream buffer extracted from a input module pin
+	 * \see ProcessingModuleInterface::Process()
+	 */
+	struct InputStreamBuffer {
+		InputStreamBuffer() : data(), size(), flags() {}
+		InputStreamBuffer(uint8_t *_data, size_t _size,
+		InputStreamFlags _flags) : data(_data), size(_size), flags(_flags) {}
+		uint8_t *const data; /*!< data stream buffer */
+		/*!
+		 * \brief size indicator about the data in the stream buffer
+		 *
+		 * - When read, it indicates the size of available data in the data stream buffer
+		 * - When written, it reports the size of data which has actually be considered
+		 *   during the buffer processing
+		 *   (can be less than the given available data size)
+		 */
+		size_t size;
+		const InputStreamFlags flags; /*!< readonly status flags about the input stream */
+	};
+
+	/*! \brief Descriptor of the data stream buffer to inject into an output module pin
+	 * \see ProcessingModuleInterface::Process()
+	 */
+	struct OutputStreamBuffer {
+		OutputStreamBuffer() : data(), size() {}
+		OutputStreamBuffer(uint8_t *_data, size_t _size) : data(_data), size(_size) {}
+		uint8_t *const data; /*!< data stream buffer */
+		/*!
+		 * \brief size indicator about the data in the stream buffer
+		 *
+		 * - When read, it indicates the size of available room in the stream buffer
+		 * - When written, it reports the size of data which has actually be produced
+		 *   into the buffer during the buffer processing
+		 *   (can be less than the given available room size)
+		 */
+		size_t size;
+	};
+
+	/*! \brief Scoped enumeration which defines location of a configuration message fragment
+	 *  in the whole message
+	 *
+	 * \see
+	 * - ProcessingModuleInterface::SetConfiguration()
+	 * - ProcessingModuleInterface::GetConfiguration()
+	 */
+	struct ConfigurationFragmentPosition {
+		/*! \brief enumeration values of fragment position tag */
+		enum Enum {
+			/*!< Indicates that the associacted fragment is in the middle of message
+			 *  transmission (nor first neither last one)
+			 */
+			MIDDLE = 0,
+			/*!< Indicates that the associacted fragment is the first one of
+			 * a multi-fragment message transmission
+			 */
+			FIRST = 1,
+			/*!< Indicates that the associacted fragment is the last one of
+			 * a multi-fragment message transmission
+			 */
+			LAST = 2,
+			/*!< Indicates that the associacted fragment is the single one of
+			 * the message transmission
+			 */
+			SINGLE = 3
+		};
+
+		/*! \brief Underlying type for storing of ConfigurationFragmentPosition value */
+		typedef int Type;
+
+		/*! \brief Implicitly initializes a new instance of ConfigurationFragmentPosition
+		 * given an Enum value
+		 */
+		ConfigurationFragmentPosition(Enum mode_value)
+			:   value_(mode_value)
+		{}
+
+		/*! \brief Implicitly converts a ConfigurationFragmentPosition object
+		 * into an Enum value
+		 */
+		operator Enum(void)
+		{
+			return (Enum) value_;
+		}
+
+	private:
+		Type value_;
+	};
+
+	/*!
+	 * \brief The ProcessingModuleInterface class defines the interface that user-defined module
+	 * shall comply with to be manageable by the ADSP System.
+	 *
+	 * It is also configurable through the couple of method
+	 * SetConfiguration() / GetConfiguration().
+	 * A ProcessingModuleInterface object consumes data stream from its input pins and produces
+	 * data stream into its output pins.
+	 */
+	class ProcessingModuleInterface
+	{
+	public:
+		/*!
+		 * \brief Scoped enumeration of error code value which can be reported by
+		 * a ProcessingModuleInterface object
+		 */
+		struct ErrorCode : intel_adsp::ErrorCode {
+			/*! \brief list of named error codes specific to the
+			 * ProcessingModuleInterface
+			 */
+			enum Enum {
+				/*!< Reports that the message content given for configuration
+				 * is invalid
+				 */
+				INVALID_CONFIGURATION = intel_adsp::ErrorCode::MaxValue + 1,
+				/*!< Reports that the module does not support retrieval of its
+				 * current configuration information
+				 */
+				NO_CONFIGURATION
+			};
+			/*! \brief Indicates the minimal value of the enumeration */
+			static Enum const MinValue = INVALID_CONFIGURATION;
+			/*! \brief Indicates the maximal value of the enumeration */
+			static Enum const MaxValue = NO_CONFIGURATION;
+
+			/*!
+			 * \brief Initializes a new instance of ErrorCode given a value
+			 */
+			explicit ErrorCode(Type value)
+				:   intel_adsp::ErrorCode(value)
+			{}
+		};
+		/*!
+		 * \brief Additional method called after module initialization
+		 */
+		virtual ErrorCode::Type Init(void) = 0;
+		/*!
+		 * \brief Destructor that may contain logic executed on module destruction
+		 */
+		virtual ErrorCode::Type Delete(void) = 0;
+
+		/*!
+		 * \brief Processes the stream buffers extracted from the input pins and produces
+		 * the resulting signal in stream buffer of the output pins.
+		 *
+		 * The user-defined implementation of Process() is generally expected to consume
+		 * all the samples available in the input stream buffers and should produce the
+		 * samples for all free room available in the output stream buffers. Note that
+		 * in normal condition all connected input pins will receive "ibs"
+		 * (i.e. "Input Buffer Size") data bytes in their input stream buffers and output
+		 * pins should produce "obs" (i.e. "Output Buffer Size") data bytes in their
+		 * output stream buffers. ("ibs" and "obs" values are given to module at
+		 * construction time within the \ref ModuleInitialSettings parameter).
+		 * However in "end of stream" condition input stream buffers may be filled with
+		 * less data count than "ibs".
+		 * Therefore less data count than "obs" can be put in the output buffers.
+		 *
+		 * \remarks Length of input_stream_buffers and output_stream_buffers C-arrays
+		 * don't need to be part of the Process() prototype as those lengths are
+		 * well-known by the user-defined implementation of the ProcessingModuleInterface.
+		 * \return Custom implementation can return a user-defined error code value.
+		 * This user-defined error code will be transmitted to
+		 * host driver if the value is different from 0 (0 is considered as
+		 * a "no-error value")
+		 */
+		virtual uint32_t Process(
+			InputStreamBuffer * input_stream_buffers,
+			/*!< [in,out] C-array of input buffers to process. "data" field value can
+			 * be NULL if the associated pin is not connected
+			 */
+			OutputStreamBuffer * output_stream_buffers
+			/*!< [in,out] C-array of output buffers to produce. "data" field value
+			 * can be NULL if the associated pin is not connected
+			 * \note "size" field value is set with the total room available in
+			 * the output buffers at Process() method call.
+			 * It shall be updated within the method to report to the ADSP System
+			 * the actual data size put in the output buffers.
+			 */
+		) = 0;
+		/*!
+		 * \brief Upon call to this method the ADSP system requires the module to reset its
+		 * internal state into a well-known initial value.
+		 *
+		 * Parameters which may have been set through SetConfiguration() are supposed to be
+		 * left unchanged.
+		 * \remarks E.g. a configurable FIR filter module will reset its internal samples
+		 * history buffer but not the taps values
+		 * (which may have been configured through SetConfiguration())
+		 */
+		virtual void Reset(void) = 0;
+
+		/*!
+		 * \brief Sets the processing mode for the module.
+		 *
+		 * Upon the transition from one processing mode to another, the module is required
+		 * to handle enabling/disabling of its custom processing
+		 * as smoothly as possible (no glitch, no signal discontinuity).
+		 *
+		 * \note This method is actually only relevant for modules which only manipulate
+		 * PCM signal streams.
+		 * Thus, the ADSP System will only fire the SetProcessingMode() method for
+		 * those kind of modules. (e.g. not for signal decoders, encoders etc.)
+		 * Moreover, disabling the processing of modules which convert the trait of
+		 * the signal samples (bit depth, sampling rate, etc.)
+		 * would make the resulting stream(s) unsuitable for the downstream modules.
+		 * Therefore ADSP System will not fire this method for such modules too.
+		 */
+		virtual void SetProcessingMode(ProcessingMode mode) = 0;
+		/*!
+		 * \brief Gets the processing mode for the module.
+		 */
+		virtual ProcessingMode GetProcessingMode(void) = 0;
+		/*!
+		 * \brief Applies the upcoming configuration message for the given
+		 * configuration ID.
+		 *
+		 * If the complete configuration message is greater than 4096 bytes,
+		 * the transmission will be split into several fragments (lesser or equal
+		 * to 4096 bytes). In this case the ADSP System will perform multiple calls
+		 * to SetConfiguration() until completion of the configuration message sending.
+		 * \note config_id indicates ID of the configuration message only on the first
+		 * fragment sending otherwise it is set to 0.
+		 */
+		virtual ErrorCode::Type SetConfiguration(
+				uint32_t config_id,
+				/*!< [in] indicates ID of the configuration message that
+				 * is provided
+				 */
+				ConfigurationFragmentPosition fragment_position,
+				/*!< [in] indicates position of the fragment in the
+				 * whole message transmission
+				 */
+				uint32_t data_offset_size,
+				/*!< [in] Meaning of parameter depends on the fragment_position
+				 * value:
+				 * - if fragment_position is worth
+				 *   ConfigurationFragmentPosition::FIRST or
+				 *   ConfigurationFragmentPosition::SINGLE
+				 *   data_offset_size indicates the data size of the full message
+				 * - if fragment_position is worth
+				 *   ConfigurationFragmentPosition::MIDDLE or
+				 *   ConfigurationFragmentPosition::LAST
+				 *   data_offset_size indicates the position offset of the received
+				 *   fragment in the full message.
+				 */
+				const uint8_t *fragment_buffer,
+				/*!< [in] the configuration fragment buffer */
+				size_t fragment_size,
+				 /*!< [in] the fragment buffer size.
+				  * As per ADSP System design the fragment_size value will not
+				  * exceed 4096 bytes.
+				  */
+				uint8_t *response,
+				/*!< [out] the response message buffer to optionally fill */
+				size_t & response_size
+				/** [in,out] the response message size.
+				 * As per ADSP System design the response_size value shall not
+				 * exceed 2048 bytes.
+				 * Implementation of SetConfiguration shall set response_size
+				 * value to the actual size (in bytes) of the response message
+				 */
+
+			) = 0;
+		/*!
+		 * \brief Retrieves the configuration message for the given configuration ID.
+		 *
+		 * If the complete configuration message is greater than 4096 bytes,
+		 * the transmission will be split into several fragments (lesser or equal
+		 * to 4096 bytes). In this case the ADSP System will perform multiple call to
+		 * GetConfiguration() until completion of the configuration message retrieval.
+		 * \note config_id indicates ID of the configuration message only on first
+		 * fragment retrieval otherwise it is set to 0.
+		 */
+		virtual ErrorCode::Type GetConfiguration(
+				uint32_t config_id,
+				/*!< [in] indicates ID of the configuration message that is
+				 * requested to be returned
+				 */
+				ConfigurationFragmentPosition fragment_position,
+				/*!< [in] indicates position of the fragment in the whole
+				 * message transmission
+				 */
+				uint32_t & data_offset_size,
+				/*!< [in,out] Meaning of parameter depends on the
+				 * fragment_position value.
+				 * - if fragment_position is worth
+				 * ConfigurationFragmentPosition::FIRST or
+				 * ConfigurationFragmentPosition::SINGLE
+				 *   data_offset_size shall report the data size of the
+				 *   full message
+				 * - if fragment_position is worth
+				 * ConfigurationFragmentPosition::MIDDLE or
+				 * ConfigurationFragmentPosition::LAST
+				 *   data_offset_size indicates the position offset of the
+				 *   received fragment in the full message
+				 */
+				uint8_t *fragment_buffer,
+				/*!< [out] the fragment buffer to fill */
+				size_t & fragment_size
+				/*!< [in,out] the fragment buffer size.
+				 * The actual size of data written into the fragment buffer
+				 * shall be reported to the ADSP System.
+				 */
+			) = 0;
+	};
+	/*! \class ProcessingModuleInterface
+	 * See also
+	 * --------
+	 * - the ProcessingModuleFactoryInterface interface which defines the factory for custom
+	 *   processing module (in processing_module_factory_interface.h)
+	 * - the template class ProcessingModule which provides a partial default implementation
+	 *   for ProcessingModuleInterface suitable for most of custom processing modules
+	 *   (in processing_module.h).
+	 */
+
+	class DetectorModuleInterface : public ProcessingModuleInterface
+	{
+	public:
+
+		/*! Object processing state */
+		typedef enum {
+			/*! Data are processed */
+			PROCESSING = 0,
+			/*! No data are processed */
+			IDLE = 1,
+		} State;
+
+		/*! Get processing state of module. */
+		virtual State GetState(void) = 0;
+
+		/*! Get idle period that the module processing are not required */
+		virtual uint64_t GetIdlePeriod(void) = 0;
+
+		/*! Method for handle stream processing */
+		virtual void OnStreamState(uint64_t counter,
+					uint32_t stream_index,
+					State state) = 0;
+	};
+} /*namespace intel_adsp */
+
+#endif /* #ifndef _ADSP_PROCESSING_MODULE_INTERFACE_H_ */

--- a/src/include/sof/audio/module_adapter/iadk/processing_module_prerequisites.h
+++ b/src/include/sof/audio/module_adapter/iadk/processing_module_prerequisites.h
@@ -1,0 +1,139 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2022 Intel Corporation. All rights reserved.
+ */
+/*! \file processing_module_prerequisites.h */
+
+#ifndef _PROCESSING_MODULE_PREREQUISITES_H_
+#define _PROCESSING_MODULE_PREREQUISITES_H_
+
+#include <stdint.h>
+#include <stddef.h>
+
+namespace intel_adsp
+{
+	/*!
+	 * \brief "Scoped enumeration" of values which specify data buffer alignment of input or
+	 * output stream buffer.
+	 */
+	struct StreamBufferAlignment {
+		/*! \brief the enumeration type of StreamBufferAlignment "scoped enumeration" */
+		enum WordSize {
+			/*! \brief enumeration tag for 4-bytes aligned buffer */
+			_4_BYTES = 4,
+			/*! \brief enumeration tag for 8-bytes aligned buffer */
+			_8_BYTES = 8
+		};
+
+		/*! \brief Type of the inner integral value */
+		typedef uint8_t Type;
+
+		/*! \brief Initializes a new instance of StreamBufferAlignment with value set
+		 * to _4_BYTES
+		 */
+		StreamBufferAlignment(void)
+			:   value(_4_BYTES)
+		{}
+
+		/*! \brief Initializes a new instance of StreamBufferAlignment given
+		 * a StreamBufferAlignment::WordSize value
+		 */
+		StreamBufferAlignment(WordSize val)
+			:   value(val)
+		{}
+
+		/*! \brief Initializes a new instance of StreamBufferAlignment given
+		 * a StreamBufferAlignment::Type value
+		 */
+		explicit StreamBufferAlignment(Type val)
+			:   value(val)
+		{}
+
+		/*! \brief Copy constructor */
+		StreamBufferAlignment(const StreamBufferAlignment &ref)
+			:   value(ref.value)
+		{}
+
+		/*! \brief Implicit cast operator to IoChunkAligment::WordSize */
+		operator WordSize(void)
+		{
+			return (WordSize) value;
+		}
+
+		/*! \brief Implicit cast operator to IoChunkAligment::Type */
+		operator Type(void)
+		{
+			return value;
+		}
+
+		/*! \brief default assignment operator */
+		StreamBufferAlignment &operator = (const StreamBufferAlignment &src)
+		{
+			value = src.value;
+			return *this;
+		}
+
+		/*! \brief assignment operator given a StreamBufferAlignment::WordSize value */
+		StreamBufferAlignment &operator = (const StreamBufferAlignment::WordSize &src)
+		{
+			value = src;
+			return *this;
+		}
+
+		/*! \brief implement comparison operator */
+		bool operator>(const StreamBufferAlignment &r) const
+		{ return value > r.value; }
+
+		/*! \brief implement comparison operator */
+		bool operator<(const StreamBufferAlignment &r) const
+		{ return value < r.value; }
+
+		/*! \brief implement comparison operator */
+		bool operator == (const StreamBufferAlignment &r) const
+		{ return value == r.value; }
+
+		/*! \brief implement comparison operator */
+		bool operator != (const StreamBufferAlignment &r) const
+		{ return value != r.value; }
+
+	private:
+		/*! \brief inner integral value for the StreamBufferAlignment */
+		Type value;
+	};
+
+	/*!
+	 * \brief Descriptor on prerequisites for ProcessingModuleInterface instance creation.
+	 */
+	struct ProcessingModulePrerequisites {
+	public:
+		/*! \brief Initializes a new instance of ProcessingModulePrerequisites
+		 * with default values
+		 */
+		ProcessingModulePrerequisites()
+			:   stream_buffer_alignment(StreamBufferAlignment::_4_BYTES),
+			    input_pins_count(0), output_pins_count(0), event_count(0)
+		{}
+
+		/*! \brief holds the buffer alignment constraint in size of bytes for input
+		 *  or output chunk buffer
+		 *
+		 * Default constructor set this field value to StreamBufferAlignment::_4_BYTES.
+		 */
+		StreamBufferAlignment stream_buffer_alignment;
+
+		/*! \brief Indicates the count of input pins for the module type about
+		 *  to be created.
+		 */
+		size_t input_pins_count;
+		/*! \brief Indicates the count of output pins for the module type about
+		 * to be created.
+		 */
+		size_t output_pins_count;
+		/*! \brief Indicates the count of events for the module type about
+		 *  to be created.
+		 */
+		size_t event_count;
+	};
+}
+
+#endif /* _PROCESSING_MODULE_PREREQUISITES_H_ */

--- a/src/include/sof/audio/module_adapter/iadk/system_agent.h
+++ b/src/include/sof/audio/module_adapter/iadk/system_agent.h
@@ -1,0 +1,81 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2022 Intel Corporation. All rights reserved.
+ */
+
+#ifndef _SYSTEM_AGENT_H
+#define _SYSTEM_AGENT_H
+
+#ifdef __cplusplus
+
+#include <processing_module_factory_interface.h>
+#include <system_service.h>
+
+namespace intel_adsp
+{
+namespace system
+{
+	/*! \brief The SystemAgent is a mediator to allow the custom module to interact
+	 *  with the base FW
+	 *
+	 * A SystemAgent can only be delivered by the ADSP System.
+	 * Once registered, a ModuleHandle instance can be handled by the ADSP System.
+	 */
+	class SystemAgent : public intel_adsp::SystemAgentInterface
+	{
+	public:
+		SystemAgent(uint32_t module_id,
+			    uint32_t instance_id,
+			    uint32_t core_id,
+			    uint32_t log_handle);
+
+		/*! \brief Initializes a new instance of ModuleAdapter in the ModuleHandle buffer*/
+		virtual void CheckIn(intel_adsp::ProcessingModuleInterface & processing_module,
+				     intel_adsp::ModuleHandle & module_handle,
+				     intel_adsp::LogHandle * &log_handle) /*override*/;
+
+		/*! \return a value part of error code list defined within the adsp_error.h*/
+		virtual int CheckIn(intel_adsp::ProcessingModuleFactoryInterface & module_factory,
+				    intel_adsp::ModulePlaceholder * module_placeholder,
+				    size_t processing_module_size,
+				    uint32_t core_id,
+				    const void *obfuscated_mod_cfg,
+				    void *obfuscated_parent_ppl,
+				    void **obfuscated_modinst_p) /*override*/;
+
+		virtual intel_adsp::SystemService const &GetSystemService() /*override*/
+		{
+			return
+			    reinterpret_cast<intel_adsp::SystemService const &>(system_service_);
+		}
+
+		virtual intel_adsp::LogHandle const &GetLogHandle() /*override*/
+		{
+			return *reinterpret_cast<intel_adsp::LogHandle const *>(&log_handle_);
+		}
+
+	private:
+		static AdspSystemService system_service_;
+		uint32_t log_handle_;
+		uint32_t const core_id_;
+		uint32_t module_id_;
+		uint32_t instance_id_;
+		uint32_t module_size_;
+		intel_adsp::ModuleHandle * module_handle_;
+
+	}; /* class SystemAgent */
+} /* namespace system */
+} /* namespace intel_adsp */
+
+#endif /* #ifdef __cplusplus */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+void *system_agent_start(uint32_t entry_point, uint32_t module_id, uint32_t instance_id,
+			 uint32_t core_id, uint32_t log_handle, void *mod_cfg);
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _SYSTEM_AGENT_H */

--- a/src/include/sof/audio/module_adapter/iadk/system_agent_interface.h
+++ b/src/include/sof/audio/module_adapter/iadk/system_agent_interface.h
@@ -1,0 +1,139 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2022 Intel Corporation. All rights reserved.
+ */
+/*! \internal \file system_agent_interface.h */
+
+#ifndef _ADSP_SYSTEM_AGENT_INTERFACE_H_
+#define _ADSP_SYSTEM_AGENT_INTERFACE_H_
+
+#include "system_service.h"
+#include "system_error.h"
+
+#include <stdint.h>
+#include <stddef.h>
+
+namespace intel_adsp
+{
+	struct ModulePlaceholder;
+	class ProcessingModuleFactoryInterface;
+	class ProcessingModuleInterface;
+	class DetectorModuleInterface;
+	class ModuleInitialSettings;
+	struct ProcessingModulePrerequisites;
+	struct IoPinsInfo;
+	class ModuleHandle;
+	struct LogHandle;
+
+namespace internal
+{
+	class Endpoint;
+} /* namespace internal */
+
+	/*! \brief The SystemAgentInterface is a mediator to allow loadable module to interact
+	 *  with the ADSP System.
+	 *
+	 * It allows loadable module and factory to register themselves
+	 * and provide the list of the service functions exposed by the ADSP System.
+	 * \note user-defined code should not directly interact with the SystemAgentInterface
+	 * and rather should take leverage of the ProcessingModule and ProcessingModuleInterface
+	 * base classes.
+	 */
+	class SystemAgentInterface
+	{
+	public:
+		/*!
+		 * \brief Scoped enumeration of error code value which can be reported by
+		 * a SystemAgentInterface object
+		 */
+		struct ErrorCode : intel_adsp::ErrorCode
+		{
+			/*! \brief list of named error codes specific to the SystemAgentInterface */
+			enum Enum {
+				/*!< Reports that ProcessingModuleFactoryInterface::Create()
+				 * has exited with error
+				 */
+				MODULE_CREATION_FAILURE = intel_adsp::ErrorCode::MaxValue + 1
+			};
+			/*! \brief Indicates the minimal value of the enumeration */
+			static Enum const MinValue = MODULE_CREATION_FAILURE;
+			/*! \brief Indicates the maximal value of the enumeration */
+			static Enum const MaxValue = MODULE_CREATION_FAILURE;
+
+			/*!
+			 * \brief Initializes a new instance of ErrorCode given a value
+			 */
+			explicit ErrorCode(Type value)
+				:   intel_adsp::ErrorCode(value)
+			{}
+		};
+
+		/*! \brief Allows a ProcessingModuleInterface instance to be registered in
+		 * the ADSP System
+		 *
+		 * internal purpose.
+		 */
+		virtual void CheckIn(ProcessingModuleInterface & processing_module,
+				     /**< the instance to register for later use in processing
+				      * pipeline
+				      */
+				     ModuleHandle & module_handle,
+				     /**< the object that is required by the ADSP System to handle
+				      * the module
+				      */
+				     LogHandle * &log_handle /**< module logging context */
+				    ) = 0;
+
+		/*! \brief Allows a ProcessingModuleFactoryInterface instance to be registered in
+		 * the ADSP System
+		 *
+		 * internal purpose.
+		 */
+		virtual int CheckIn(ProcessingModuleFactoryInterface & module_factory,
+				    /*!< the instance to register */
+				    ModulePlaceholder * module_placeholder,
+				    /*!< the place holder in memory for instantiation of
+				     * a ProcessingModuleInterface instance
+				     */
+				    size_t,
+				    uint32_t,
+				    const void*,
+				    void*,
+				    void**) = 0;
+
+		/*!
+		 * \brief Gets the SystemService instance which contains all the service functions
+		 */
+		virtual SystemService const &GetSystemService(void) = 0;
+
+		/*!
+		 * \brief Gets the LogHandle required to send some log message
+		 */
+		virtual LogHandle const &GetLogHandle(void) = 0;
+	};
+
+	class SystemAgentInterface2 : public SystemAgentInterface
+	{
+	public:
+
+		/*! \brief Allows a ProcessingModuleInterface instance to be registered in
+		 * the ADSP System as detector module
+		 *
+		 * internal purpose.
+		 */
+		virtual void CheckInDetector(DetectorModuleInterface & processing_module,
+					     /*!< the instance to register for later use in
+					      * processing pipeline
+					      */
+					     ModuleHandle & module_handle,
+					     /*!< the object that is required by the ADSP System
+					      *  to handle the module
+					      */
+					     LogHandle * &log_handle
+					     /*!< module logging context */
+					    ) = 0;
+	};
+
+} /* namespace intel_adsp */
+
+#endif /* _ADSP_SYSTEM_AGENT_H_ */

--- a/src/include/sof/audio/module_adapter/iadk/system_error.h
+++ b/src/include/sof/audio/module_adapter/iadk/system_error.h
@@ -1,0 +1,79 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2022 Intel Corporation. All rights reserved.
+ */
+/*! \file system_error.h */
+
+#ifndef _ADSP_SYSTEM_ERROR_H_
+#define _ADSP_SYSTEM_ERROR_H_
+
+#include "adsp_error_code.h"
+
+namespace intel_adsp
+{
+	/*!
+	 * \brief Scoped enumeration of common error code values which can be reported
+	 *  to ADSP System
+	 */
+	struct ErrorCode {
+		/*! \brief type of the error code value */
+		typedef int Type;
+
+		/*! \brief list of named error codes */
+		enum Enum {
+			NO_ERROR = ADSP_NO_ERROR,
+			INVALID_PARAMETERS = ADSP_INVALID_PARAMETERS,
+			BUSY = ADSP_BUSY_RESOURCE,
+			FATAL_FAILURE = ADSP_FATAL_FAILURE,
+
+		};
+		/*! \brief Indicates the minimal value in the enumeration list */
+		static Enum const MinValue = NO_ERROR;
+		/*! \brief Indicates the maximal value in the enumeration list */
+		static Enum const MaxValue = FATAL_FAILURE;
+
+		/*! \brief Initializes a new ErrorCode instance given a value of error code */
+		explicit ErrorCode(Type value)
+			:   value_(value) { }
+
+		/*! \brief Returns the current value of the ErrorCode */
+		Type operator()() const
+		{
+			return value_;
+		}
+
+		/*! \brief Converts the ErrorCode instance into its code value */
+		operator Type(void) const
+		{
+			return value_;
+		}
+
+		/*! \brief Evaluates the ErrorCode value against a given value */
+		bool operator == (Type a)
+		{
+			return value_ == a;
+		}
+
+		/*!
+		 * \brief Gets a const reference on the error code value
+		 */
+		const Type & Value() const
+		{
+			return value_;
+		}
+
+	protected:
+		/*!
+		 * \brief Gets a reference on the error code value
+		 */
+		Type & Value()
+		{
+			return value_;
+		}
+
+	private:
+		Type value_;
+	};
+}
+
+#endif /*_ADSP_SYSTEM_ERROR_H_ */

--- a/src/include/sof/audio/module_adapter/iadk/system_service.h
+++ b/src/include/sof/audio/module_adapter/iadk/system_service.h
@@ -1,0 +1,236 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2022 Intel Corporation. All rights reserved.
+ */
+/*! \file system_service.h */
+
+#ifndef _ADSP_SYSTEM_SERVICE_H_
+#define _ADSP_SYSTEM_SERVICE_H_
+
+#include "logger.h"
+#include "adsp_stddef.h"
+#include "adsp_error_code.h"
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*! \brief This struct defines the obfuscating type for notifications. */
+typedef struct _AdspNotificationHandle {} *AdspNotificationHandle;
+
+/*! \brief Defines parameters used by ADSP system during notification creation. */
+typedef struct _NotificationParams {
+	uint32_t type;              /*!< Notification type */
+	uint16_t user_val_1;        /*!< 16 bits user value available directly in IPC header
+				     * for some notifications
+				     */
+	uint32_t user_val_2;        /*!< 30 bits user value available directly in IPC header
+				     * for some notifications
+				     */
+	uint32_t max_payload_size;  /*!< Data size of payload (NotificationCreate updates this
+				     * value to max possible payload size)
+				     */
+	uint8_t *payload;           /*!< Pointer on the payload */
+} NotificationParams;
+
+/*! \brief Defines parameters used by ADSP system during Module Event notification creation. */
+typedef struct _ModuleEventNotification {
+	uint32_t module_instance_id; /*!< Module ID (MS word) + Module Instance ID (LS word) */
+	uint32_t event_id;           /*!< Module specific event ID. */
+	uint32_t event_data_size;    /*!< Size of event_data array in bytes. May be set to 0
+				      * in case there is no data.
+				      */
+	uint32_t event_data[0];      /*< Optional event data (size set to 0 as it is optional
+				      * data)
+				      */
+} ModuleEventNotification;
+
+/*! \brief Defines notification targets supported by ADSP system */
+typedef enum _NotificationTarget {
+	DSP_TO_HOST = 1,  /*!< Notification target is HOST */
+	DSP_TO_ISH = 2    /*!< Notification target is ISH */
+} NotificationTarget;
+
+/*! \brief Defines notification types supported by ADSP system */
+typedef enum _NotificationType {
+	VOICE_COMMAND_NOTIFICATION = 4,	/*!< intel_adsp define corresponding to PHRASE_DETECTED
+					 * notification
+					 */
+	AUDIO_CLASSIFIER_RESULTS = 9,	/*!< intel_adsp define corresponding to FW_AUD_CLASS_RESULT
+					 * notification
+					 */
+	MODULE_EVENT_NOTIFICATION = 12,	/*!< intel_adsp define corresponding to MODULE_NOTIFICATION
+					 * notification
+					 */
+} NotificationType;
+
+/*! \brief Defines prototype of the "LogMessage" function
+ *
+ * \param log_priority define the log priority for the message to be sent.
+ *        The ADSP System may have been configured by the host to filter log message below
+ *        a given priority.
+ * \param log_entry provides information on log sender and log point location.
+ * \param log_handle \copybrief AdspLogHandle
+ * \param param1 some uint32_t value to include in the log message.
+ * \param param2 some uint32_t value to include in the log message.
+ * \param param3 some uint32_t value to include in the log message.
+ * \param param4 some uint32_t value to include in the log message.
+ *
+ * \see LOG_MESSAGE
+ */
+typedef void (*SystemServiceLogMessageFct) (AdspLogPriority log_priority, uint32_t log_entry,
+					    AdspLogHandle const *log_handle, uint32_t param1,
+					    uint32_t param2, uint32_t param3, uint32_t param4);
+
+/*! \brief Defines prototype of the "SafeMemcpy" function
+ *
+ * \param dst define the address of destination buffer
+ * \param maxlen define the size of destination buffer
+ * \param src define the address of source buffer
+ * \param len define the number of bytes
+ * \return zero if success, error code otherwise
+ */
+typedef AdspErrorCode (*SystemServiceSafeMemcpyFct) (void *RESTRICT dst, size_t maxlen,
+						     const void *RESTRICT src, size_t len);
+
+/*! \brief Defines prototype of the "SafeMemmove" function
+ *
+ * \param dst define the address of destination buffer
+ * \param maxlen define the size of destination buffer
+ * \param src define the address of source buffer
+ * \param len define the number of bytes
+ * \return zero if success, error code otherwise
+ */
+typedef AdspErrorCode (*SystemServiceSafeMemmoveFct) (void *dst, size_t maxlen,
+						      const void *src, size_t len);
+
+/*! \brief Defines prototype of the "VecMemset" function
+ *
+ * \param dst define the address of destination buffer
+ * \param c define the fill byte
+ * \param len define the number of bytes
+ * \return pointer to dst
+ */
+typedef void* (*SystemServiceVecMemsetFct) (void *dst, int c, size_t len);
+
+/*! \brief Defines prototype of the "NotificationCreate" function
+ *
+ * \param params pointer on NotificationParams input structure
+ * \param notification_buffer pointer on the notification buffer declared in module
+ * \param notification_buffer_size size of the notification buffer declared in module
+ * \param handle pointer on AdspNotificationHandle structure
+ * \return error if notification_buffer is too small or NULL
+ */
+typedef AdspErrorCode (*SystemServiceCreateNotificationFct) (NotificationParams *params,
+							     uint8_t *notification_buffer,
+							     uint32_t notification_buffer_size,
+							     AdspNotificationHandle *handle);
+
+/*! \brief Defines prototype of the "NotificationSend" function
+ *
+ * \param notification_target notification target is HOST or ISH
+ * \param message the AdspNotificationHandle structure used for notification
+ * \param actual_payload_size size of the notification data (excluding notification header)
+ * \return error if invalid target
+ */
+typedef AdspErrorCode (*SystemServiceSendNotificationMessageFct) (
+						    NotificationTarget notification_target,
+						    AdspNotificationHandle message,
+						    uint32_t actual_payload_size);
+
+typedef enum _AdspIfaceId {
+	IfaceIdGNA = 0x1000,			/*!< Reserved for ADSP system */
+	IfaceIdInferenceService = 0x1001,	/*!< See InferenceServiceInterface */
+	IfaceIdSDCA = 0x1002,			/*!< See SdcaInterface */
+	IfaceIdAsyncMessageService = 0x1003,	/*!< See AsyncMessageInterface */
+	IfaceIdAMService = 0x1005,		/*!< Reserved for ADSP system */
+	IfaceIdKpbService = 0x1006		/*!< See KpbInterface */
+} AdspIfaceId;
+
+/*! \brief sub interface definition.
+ * This type may contain generic interface properties like id or struct size if needed.
+ */
+typedef struct _SystemServiceIface {} SystemServiceIface;
+
+/*! \brief Defines prototype of the "GetInterface" function
+ *
+ * \param id service id
+ * \param iface pointer to retrieved interface
+ * \return error if service not supported
+ */
+typedef AdspErrorCode (*SystemServiceGetInterfaceFct) (AdspIfaceId id, SystemServiceIface **iface);
+
+/*! \brief The AdspSystemService is actually a set of C-function pointers gathered in a C-struct
+ * which brings some basic functionalities to module in runtime.
+ *
+ * The system service can be retrieved with help of either the
+ * intel_adsp::ProcessingModuleFactory::GetSystemService() method
+ * or the intel_adsp::ProcessingModule::GetSysstemService() method.
+ */
+typedef struct AdspSystemService {
+	/*! The SystemService::LogMessage function provides capability to send some log message to
+	 * the host for debugging purposes. This log can be caught by the FDK Tools and displayed
+	 * in the Debug window. The prototype of this function is given by the
+	 * \ref SystemServiceLogMessageFct typedef.
+	 *
+	 * \remarks This service function is not expected to be called directly by the user code.
+	 * Instead, the LOG_MESSAGE should be invoked for this purpose.
+	 */
+	const SystemServiceLogMessageFct LogMessage;
+
+	/*! The SystemService::SafeMemcpy function provides capability to use SafeMemcpy function
+	 * provided by ADSP System.
+	 * The prototype of this function is given by the \ref SystemServiceSafeMemcpyFct typedef.
+	 */
+	const SystemServiceSafeMemcpyFct SafeMemcpy;
+
+	/*! The SystemService::SafeMemmove function provides capability to use SafeMemmove function
+	 * provided by ADSP System.
+	 * The prototype of this function is given by the \ref SystemServiceSafeMemmoveFct typedef.
+	 */
+	const SystemServiceSafeMemmoveFct SafeMemmove;
+
+	/*! The SystemService::VecMemset function provides capability to use VecMemset function
+	 * provided by ADSP System.
+	 * The prototype of this function is given by the \ref SystemServiceVecMemsetFct typedef.
+	 */
+	const SystemServiceVecMemsetFct VecMemset;
+
+	/*! The SystemService::NotificationCreate function provides capability to use
+	 * NotificationCreate function provided by ADSP System.
+	 * The prototype of this function is given by the
+	 * \ref SystemServiceCreateNotificationFct typedef.
+	 */
+	const SystemServiceCreateNotificationFct NotificationCreate;
+
+	/*! The SystemService::NotificationSend function provides capability to use
+	 * NotificationSend function provided by ADSP System.
+	 * The prototype of this function is given by the \ref
+	 * SystemServiceSendNotificationMessageFct typedef.
+	 */
+	const SystemServiceSendNotificationMessageFct NotificationSend;
+
+	/*! The SystemService::GetInterface function provides capability to retrieve additional
+	 * services provided by ADSP System. The prototype of this function is given by the \ref
+	 * SystemServiceGetInterfaceFct typedef.
+	 */
+	const SystemServiceGetInterfaceFct GetInterface;
+
+} AdspSystemService;
+
+#ifdef __cplusplus
+namespace intel_adsp
+{
+/*! \brief Alias type of AdspSystemService which can be used in C++.
+ */
+struct SystemService : public AdspSystemService {};
+}
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _ADSP_SYSTEM_SERVICE_H_ */

--- a/src/include/sof/audio/module_adapter/iadk/utilities/array.h
+++ b/src/include/sof/audio/module_adapter/iadk/utilities/array.h
@@ -1,0 +1,376 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2022 Intel Corporation. All rights reserved.
+ */
+
+#ifndef DSP_FW_FW_ARRAY_H_
+#define DSP_FW_FW_ARRAY_H_
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*! Wrapper for buffer descriptor. */
+typedef struct byte_array {
+	/*! Pointer to buffer begin. */
+	uint8_t    *data;
+	/*! Size of buffer (in number of elements, typically bytes). */
+	size_t      size;
+} byte_array_t;
+
+static inline uint8_t *array_get_data(const byte_array_t *ba)
+{
+	return (uint8_t *)ba->data;
+}
+
+static inline uint8_t *array_get_data_end(const byte_array_t *ba)
+{
+	return array_get_data(ba) + ba->size;
+}
+
+
+static inline size_t array_get_size(const byte_array_t *ba)
+{
+	return ba->size;
+}
+
+static inline uint8_t *array_alloc_from(byte_array_t *ba,
+					size_t required_size)
+{
+	/* TODO: add alignment */
+	/* TODO: validate inputs */
+	/* TODO: move this to more appropriate file */
+
+	uint8_t *cached_data = array_get_data(ba);
+
+	ba->data += required_size;
+	ba->size -= required_size;
+
+	return cached_data;
+}
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#ifdef __cplusplus
+/* clang-format off */
+#define assert(cond)
+
+static inline uint8_t *array_get_data(const byte_array_t &ba)
+{
+	return (uint8_t *)ba.data;
+}
+
+static inline size_t array_get_size(const byte_array_t &ba)
+{
+	return ba.size;
+}
+
+namespace dsp_fw
+{
+/*!
+ *  Provides a safe wrapper around array allocated in continuous memory.
+ *  Size of the array specified by the client is checked on any attempt
+ *  to access the array data.
+ *
+ * \note Wrapper does not take over ownership of the array. The array
+ * must be deallocated elsewhere by its proper owner.
+ *
+ * \note All copy operations are shallow bit copies of the array.
+ * The array is expected to keep built-in types or pointers, so
+ * there is no assignment operator called for each copied entry.
+ *
+ * \note Array (especially Array<uint8_t>/ByteArray) can be casted to
+ * byte_array_t as there are binary compatible
+ */
+template < class T >
+class Array /*: public byte_array*/
+{
+public:
+
+/*!
+ * Default ctor to provide two-stage initialization completed by Init() call.
+ */
+Array()
+{
+	data_ = NULL;
+	size_ = 0;
+}
+
+/*!
+ * Constructs the object and initializes pointer and size to the provided
+ * values.
+ *
+ * \param ptr - Pointer to the array.
+ * \param size - Size of the array pointed by the ptr.
+ */
+Array(T * ptr, size_t size)
+{
+	data_ = (T *)ptr;
+	size_ = size;
+}
+
+/*!
+ *  Completes two-stage object initialization when initialized by the default
+ *  ctor.
+ *
+ * \param ptr - Pointer to the array.
+ * \param size - Size of the array pointed by the ptr.
+ */
+void Init(T *ptr, size_t size)
+{
+	data_ = (T *)ptr;
+	size_ = size;
+}
+
+/*!
+ * Completes two-stage object initialization when initialized by the default
+ * ctor.
+ *
+ * \param ptr - Pointer to the array.
+ * \param end - Pointer to the end of the array.
+ */
+void InitWithRange(T *ptr, T *ptr_end)
+{
+	assert(ptr_end >= ptr);
+	data_ = (T *)ptr;
+	size_ = ptr_end - ptr;
+}
+
+/*!
+ * Detaches the wrapper from the array object. Provided for the sake of
+ * completeness since array lifetime is not bound to the wrapper lifetime.
+ */
+void Detach(void) { data_ = NULL; size_ = 0; }
+/*!
+ * Retrieves the size of the array.
+ *
+ * \return Size of the array. It may be zero if the wrapper is not fully
+ *         initialized.
+ */
+size_t size(void) const { return size_; }
+/*!
+ * Retrieves allocated size of buffer in bytes.
+ */
+size_t alloc_size(void) const { return size()*sizeof(T); }
+/*!
+ * Resizes the array.
+ */
+void Resize(size_t new_size) { size_ = new_size; }
+/*!
+ * Retrieves address of the array (const version).
+ * \return Address of the array. It may be null if the wrapper is not fully
+ * initialized.
+ */
+const T *data(void) const { return (const T *)data_; }
+/*!
+ * Retrieves address of the array (modifiable version).
+ *
+ * \return Address of the array. It may be null if the wrapper is not fully
+ * initialized.
+ */
+T *data(void) { return (T *)data_; }
+/*!
+ * Retrieves address of end of the array (const version).
+ * \return Address of the array.
+ */
+const T *data_end(void) const { return data() + size_; }
+/*!
+ * Retrieves address of end of the array (modifiable version).
+ * \return Address of end of the array.
+ */
+T *data_end(void) { return data() + size_; }
+/*!
+ * Safe (in debug) operator to access element of the array (const version).
+ *
+ * \param idx Index of the element to be accessed.
+ * \return Reference to the element.
+ */
+const T & operator[](size_t idx) const {
+	/*assert(idx < size()); //TODO: no exceptions, release err handling req */
+	return data()[idx];
+}
+
+/*!
+ * Safe (in debug) operator to access element of the array (modifiable version).
+ *
+ * \param idx Index of the element to be accessed.
+ * \return Reference to the element.
+ */
+T & operator[](size_t idx) {
+	/*assert(idx < size()); //TODO: no exceptions, release err handling req */
+	return data()[idx];
+}
+
+/*!
+ * Safe copy-from operation that verifies size of source and this.
+ *
+ * \param src Address of the source array to be copied into this.
+ * \param srcSize Size of the source array.
+ * \param dst_offset Offset in the destination array to start copying data at
+ * (expressed in number of items).
+ */
+void copyFrom(const T *src, size_t srcSize, size_t dst_offset = 0)
+{
+	assert(data() != NULL);
+	assert(size() > dst_offset);
+	assert((size() - dst_offset) >= srcSize);
+	memcpy_s(data() + dst_offset, alloc_size() - dst_offset * sizeof(T),
+		src, srcSize * sizeof(T));
+}
+
+/*!
+ * Safe copy-from operation that verifies size of source and this.
+ *
+ * \param src The source array to be copied into this.
+ * \param dst_offset Offset in the destination array to start copying data at
+ * (expressed in number of items).
+ */
+void copyFrom(const Array < T > &src, size_t dst_offset = 0)
+{
+	assert(data() != 0);
+	assert(size() > dst_offset);
+	assert((size() - dst_offset) >= src.size());
+	memcpy_s(data() + dst_offset, alloc_size() - dst_offset * sizeof(T),
+		src.data(), src.alloc_size());
+}
+
+/*!
+ * Safe copy-to operation that verifies size of the destination and this.
+ * \param dst Address of the destination array to be overwritten by this.
+ * \param dstSize Size of the destination array.
+ */
+void copyTo(T *dst, size_t dstSize) const {
+	assert(data() != 0);
+	assert(size() <= dstSize);
+	memcpy_s(dst, dstSize * sizeof(T), data(), alloc_size());
+}
+
+/*!
+ * Safe copy-to operation that verifies size of the destination and this.
+ * \param dst The destination array to be overwritten by this.
+ */
+void copyTo(Array < T > &dst) const {
+	assert(data() != 0);
+	assert(size() <= dst.size());
+	memcpy_s(dst.data(), dst.alloc_size(), data(), alloc_size());
+}
+
+/*!
+ * Copies as much as specified size starting from specified offset.
+ * \param dst Destination buffer.
+ * \param copy_size Number of items to be copied.
+ * \param src_offset Offset in the source buffer (in number of items).
+ */
+void copyFragmentTo(Array < T > &dst, size_t copy_size, size_t src_offset = 0) const {
+	assert(data() != 0);
+	assert((src_offset + copy_size) <= size());
+	assert(copy_size <= dst.size());
+	memcpy_s(dst.data(), dst.alloc_size(), data() + src_offset, copy_size * sizeof(T));
+}
+
+/*!
+ * Safe cast of the content of the array to the specified type (modifiable
+ * version).
+ * \return Pointer to the requested type if array is large enough to be
+ *        casted, NULL otherwise.
+ */
+template < class TC >
+TC *dataAs(void)
+{
+	if (alloc_size() < sizeof(TC)) {
+		assert(false);
+		return NULL;
+	}
+	return reinterpret_cast < TC * > (data());
+}
+
+template < class TC >
+TC *dataAsArray(size_t size)
+{
+	if (alloc_size() < sizeof(TC)*size) {
+		assert(false);
+		return NULL;
+	}
+	return reinterpret_cast < TC * > (data());
+}
+
+/*!
+ * Safe cast of the content of the array to the specified type (const version).
+ * \return Pointer to the requested type if array is large enough to be
+ * casted, NULL otherwise.
+ */
+template < class TC >
+const TC *dataAs(void) const {
+	if (alloc_size() < sizeof(TC)) {
+		assert(false);
+		return NULL;
+	}
+	return reinterpret_cast < const TC * > (data());
+}
+
+/*!
+ * Inserts object of specified type into the buffer.
+ * Use this explicit call instead of operator=(TC) or stream-like <<.
+ */
+template < class TC >
+void setDataAs(const TC & d)
+{
+	TC *t = dataAs < TC > ();
+
+	if (t == NULL) {
+		assert(false);
+		return;
+	}
+	*t = d; /* using operator=, not shallow copy */
+	Resize(sizeof(TC));
+}
+
+/*!
+ * Safe zero-memory on the underlying buffer.
+ */
+void clear(void)
+{
+	memset(data(), 0x00, alloc_size());
+}
+
+void Swap(Array < T > *array)
+{
+	Array < T > temp(*array);
+	array->data_ = data_;
+	array->size_ = size_;
+	this->data_ = temp.data_;
+	this->size_ = temp.size_;
+}
+
+void Swap(Array < T > &array)
+{
+	Array < T > temp(array);
+	array.data_ = data_;
+	array.size_ = size_;
+	this->data_ = temp.data_;
+	this->size_ = temp.size_;
+}
+private:
+	T *data_;
+	size_t size_;
+};
+
+/*!
+ * Predefined type of array of bytes.
+ */
+typedef Array < uint8_t > ByteArray;
+
+/*!
+ * Predefined type of array of dwords.
+ */
+typedef Array < uint32_t > DwordArray;
+
+} /* end of namespace dsp_fw */
+
+#endif /* __cplusplus */
+/* clang-format on */
+#endif /* #ifndef DSP_FW_FW_ARRAY_H_ */

--- a/src/include/sof/audio/module_adapter/module/generic.h
+++ b/src/include/sof/audio/module_adapter/module/generic.h
@@ -15,6 +15,11 @@
 #include <sof/audio/component.h>
 #include <sof/ut.h>
 #include <sof/lib/memory.h>
+#include "module_interface.h"
+
+#if CONFIG_INTEL_MODULES
+#include "iadk_modules.h"
+#endif
 
 #define module_get_private_data(mod) (mod->priv.private)
 #define MAX_BLOB_SIZE 8192
@@ -65,140 +70,6 @@ UT_STATIC void sys_comp_module_##adapter##_init(void) \
 } \
 \
 DECLARE_MODULE(sys_comp_module_##adapter##_init)
-
-struct processing_module;
-
-/**
- * \enum module_cfg_fragment_position
- * \brief Fragment position in config
- * MODULE_CFG_FRAGMENT_FIRST: first fragment of the large configuration
- * MODULE_CFG_FRAGMENT_SINGLE: only fragment of the configuration
- * MODULE_CFG_FRAGMENT_LAST: last fragment of the configuration
- * MODULE_CFG_FRAGMENT_MIDDLE: intermediate fragment of the large configuration
- */
-enum module_cfg_fragment_position {
-	MODULE_CFG_FRAGMENT_MIDDLE,
-	MODULE_CFG_FRAGMENT_FIRST,
-	MODULE_CFG_FRAGMENT_LAST,
-	MODULE_CFG_FRAGMENT_SINGLE,
-};
-
-/**
- * \enum module_processing_mode
- * MODULE_PROCESSING_NORMAL: Indicates that module is expected to apply its custom processing on
- *			      the input signal
- * MODULE_PROCESSING_BYPASS: Indicates that module is expected to skip custom processing on
- *			      the input signal and act as a passthrough component
- */
-
-enum module_processing_mode {
-	MODULE_PROCESSING_NORMAL,
-	MODULE_PROCESSING_BYPASS,
-};
-
-/**
- * \struct input_stream_buffer
- * \brief Input stream buffer
- */
-struct input_stream_buffer {
-	void __sparse_cache *data; /* data stream buffer */
-	uint32_t size; /* size of data in the buffer */
-	uint32_t consumed; /* number of bytes consumed by the module */
-
-	/* Indicates end of stream condition has occurred on the input stream */
-	bool end_of_stream;
-};
-
-/**
- * \struct output_stream_buffer
- * \brief Output stream buffer
- */
-struct output_stream_buffer {
-	void __sparse_cache *data; /* data stream buffer */
-	uint32_t size; /* size of data in the buffer */
-};
-
-/*****************************************************************************/
-/* Module generic data types						     */
-/*****************************************************************************/
-/**
- * \struct module_interface
- * \brief 3rd party processing module interface
- */
-struct module_interface {
-	/**
-	 * Module specific initialization procedure, called as part of
-	 * module_adapter component creation in .new()
-	 */
-	int (*init)(struct processing_module *mod);
-	/**
-	 * Module specific prepare procedure, called as part of module_adapter
-	 * component preparation in .prepare()
-	 */
-	int (*prepare)(struct processing_module *mod);
-	/**
-	 * Module specific processing procedure, called as part of module_adapter
-	 * component copy in .copy(). This procedure is responsible to consume
-	 * samples provided by the module_adapter and produce/output the processed
-	 * ones back to module_adapter.
-	 */
-	int (*process)(struct processing_module *mod, struct input_stream_buffer *input_buffers,
-		       int num_input_buffers, struct output_stream_buffer *output_buffers,
-		       int num_output_buffers);
-
-	/**
-	 * Set module configuration for the given configuration ID
-	 *
-	 * If the complete configuration message is greater than MAX_BLOB_SIZE bytes, the
-	 * transmission will be split into several smaller fragments.
-	 * In this case the ADSP System will perform multiple calls to SetConfiguration() until
-	 * completion of the configuration message sending.
-	 * \note config_id indicates ID of the configuration message only on the first fragment
-	 * sending, otherwise it is set to 0.
-	 */
-	int (*set_configuration)(struct processing_module *mod,
-				 uint32_t config_id,
-				 enum module_cfg_fragment_position pos, uint32_t data_offset_size,
-				 const uint8_t *fragment, size_t fragment_size, uint8_t *response,
-				 size_t response_size);
-
-	/**
-	 * Get module runtime configuration for the given configuration ID
-	 *
-	 * If the complete configuration message is greater than MAX_BLOB_SIZE bytes, the
-	 * transmission will be split into several smaller fragments.
-	 * In this case the ADSP System will perform multiple calls to GetConfiguration() until
-	 * completion of the configuration message retrieval.
-	 * \note config_id indicates ID of the configuration message only on the first fragment
-	 * retrieval, otherwise it is set to 0.
-	 */
-	int (*get_configuration)(struct processing_module *mod,
-				 uint32_t config_id, uint32_t *data_offset_size,
-				 uint8_t *fragment, size_t fragment_size);
-
-	/**
-	 * Set processing mode for the module
-	 */
-	int (*set_processing_mode)(struct processing_module *mod,
-				   enum module_processing_mode mode);
-
-	/**
-	 * Get the current processing mode for the module
-	 */
-	enum module_processing_mode (*get_processing_mode)(struct processing_module *mod);
-
-	/**
-	 * Module specific reset procedure, called as part of module_adapter component
-	 * reset in .reset(). This should reset all parameters to their initial stage
-	 * but leave allocated memory intact.
-	 */
-	int (*reset)(struct processing_module *mod);
-	/**
-	 * Module specific free procedure, called as part of module_adapter component
-	 * free in .free(). This should free all memory allocated by module.
-	 */
-	int (*free)(struct processing_module *mod);
-};
 
 /**
  * \enum module_state

--- a/src/include/sof/audio/module_adapter/module/generic.h
+++ b/src/include/sof/audio/module_adapter/module/generic.h
@@ -144,6 +144,8 @@ struct module_data {
 	struct module_interface *ops; /**< module specific operations */
 	struct module_memory memory; /**< memory allocated by module */
 	struct module_processing_data mpd; /**< shared data comp <-> module */
+	void *module_adapter; /**<loadable module interface handle */
+	uint32_t module_entry_point; /**<loadable module entry point address */
 };
 
 /* module_adapter private, runtime data */

--- a/src/include/sof/audio/module_adapter/module/iadk_modules.h
+++ b/src/include/sof/audio/module_adapter/module/iadk_modules.h
@@ -1,0 +1,57 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2019 Intel Corporation. All rights reserved.
+ *
+ * Author: Jaroslaw Stelter <jaroslaw.stelter@intel.com>
+ */
+
+#ifndef __SOF_AUDIO_IADK_MODULES__
+#define __SOF_AUDIO_IADK_MODULES__
+
+#include <iadk_module_adapter.h>
+
+/* Intel module adapter is an extension to SOF module adapter component that allows to integrate
+ * modules developed under IADK (Intel Audio Development Kit) Framework. IADK modules uses uniform
+ * set of interfaces and are linked into separate library. These modules are loaded in runtime
+ * through library_manager and then after registration into SOF component infrastructure are
+ * interfaced through module adapter API.
+ * Since IADK modules uses ProcessingModuleInterface to control/data transfer and AdspSystemService
+ * to use base FW services from internal module code, there is a communication shim layer defined
+ * in intel directory.
+ *
+ * Since ProcessingModuleInterface consists of virtual functions, there are C++ -> C wrappers
+ * defined to access the interface calls from SOF code.
+ *
+ * The main assumption here was to load IADK Modules without any code modifications. Therefore C++
+ * function, structures and variables definition are here kept with original form from
+ * IADK Framework. This provides binary compatibility for already developed 3rd party modules.
+ *
+ * There are three entities in intel module adapter package:
+ *  - System Agent - A mediator to allow the custom module to interact with the base SOF FW.
+ *                   It calls IADK module entry point and provides all necessary information to
+ *                   connect both sides of ProcessingModuleInterface and System Service.
+ *  - System Service - exposes of SOF base FW services to the module.
+ *  - Processing Module Adapter - SOF base FW side of ProcessingModuleInterface API
+ */
+
+
+struct comp_dev *iadk_modules_shim_new(const struct comp_driver *drv,
+				       struct comp_ipc_config *config,
+				       void *spec);
+
+#define DECLARE_DYNAMIC_MODULE_ADAPTER(comp_dynamic_module, mtype, uuid, tr) \
+do { \
+	(comp_dynamic_module)->type = mtype; \
+	(comp_dynamic_module)->uid = SOF_RT_UUID(uuid); \
+	(comp_dynamic_module)->tctx = &(tr); \
+	(comp_dynamic_module)->ops.create = *iadk_modules_shim_new; \
+	(comp_dynamic_module)->ops.prepare = module_adapter_prepare; \
+	(comp_dynamic_module)->ops.params = module_adapter_params; \
+	(comp_dynamic_module)->ops.copy = module_adapter_copy; \
+	(comp_dynamic_module)->ops.cmd = module_adapter_cmd; \
+	(comp_dynamic_module)->ops.trigger = module_adapter_trigger; \
+	(comp_dynamic_module)->ops.reset = module_adapter_reset; \
+	(comp_dynamic_module)->ops.free = module_adapter_free; \
+} while (0)
+
+#endif /* __SOF_AUDIO_IADK_MODULES__ */

--- a/src/include/sof/audio/module_adapter/module/module_interface.h
+++ b/src/include/sof/audio/module_adapter/module/module_interface.h
@@ -1,0 +1,146 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2020 Intel Corporation. All rights reserved.
+ *
+ *
+ * \file common.h
+ * \brief Extract from generic.h definitions that need to be included
+ *        in intel module adapter code.
+ * \author Jaroslaw Stelter <jaroslaw.stelter@intel.com>
+ *
+ */
+
+#ifndef __SOF_MODULE_INTERFACE__
+#define __SOF_MODULE_INTERFACE__
+
+/**
+ * \enum module_cfg_fragment_position
+ * \brief Fragment position in config
+ * MODULE_CFG_FRAGMENT_FIRST: first fragment of the large configuration
+ * MODULE_CFG_FRAGMENT_SINGLE: only fragment of the configuration
+ * MODULE_CFG_FRAGMENT_LAST: last fragment of the configuration
+ * MODULE_CFG_FRAGMENT_MIDDLE: intermediate fragment of the large configuration
+ */
+enum module_cfg_fragment_position {
+	MODULE_CFG_FRAGMENT_MIDDLE = 0,
+	MODULE_CFG_FRAGMENT_FIRST,
+	MODULE_CFG_FRAGMENT_LAST,
+	MODULE_CFG_FRAGMENT_SINGLE,
+};
+
+/**
+ * \enum module_processing_mode
+ * MODULE_PROCESSING_NORMAL: Indicates that module is expected to apply its custom processing on
+ *			      the input signal
+ * MODULE_PROCESSING_BYPASS: Indicates that module is expected to skip custom processing on
+ *			      the input signal and act as a passthrough component
+ */
+
+enum module_processing_mode {
+	MODULE_PROCESSING_NORMAL = 0,
+	MODULE_PROCESSING_BYPASS,
+};
+
+/**
+ * \struct input_stream_buffer
+ * \brief Input stream buffer
+ */
+struct input_stream_buffer {
+	void *data; /* data stream buffer */
+	uint32_t size; /* size of data in the buffer */
+	uint32_t consumed; /* number of bytes consumed by the module */
+
+	/* Indicates end of stream condition has occurred on the input stream */
+	bool end_of_stream;
+};
+
+/**
+ * \struct output_stream_buffer
+ * \brief Output stream buffer
+ */
+struct output_stream_buffer {
+	void *data; /* data stream buffer */
+	uint32_t size; /* size of data in the buffer */
+};
+
+struct processing_module;
+/**
+ * \struct module_interface
+ * \brief 3rd party processing module interface
+ */
+struct module_interface {
+	/**
+	 * Module specific initialization procedure, called as part of
+	 * module_adapter component creation in .new()
+	 */
+	int (*init)(struct processing_module *mod);
+	/**
+	 * Module specific prepare procedure, called as part of module_adapter
+	 * component preparation in .prepare()
+	 */
+	int (*prepare)(struct processing_module *mod);
+	/**
+	 * Module specific processing procedure, called as part of module_adapter
+	 * component copy in .copy(). This procedure is responsible to consume
+	 * samples provided by the module_adapter and produce/output the processed
+	 * ones back to module_adapter.
+	 */
+	int (*process)(struct processing_module *mod, struct input_stream_buffer *input_buffers,
+		       int num_input_buffers, struct output_stream_buffer *output_buffers,
+		       int num_output_buffers);
+
+	/**
+	 * Set module configuration for the given configuration ID
+	 *
+	 * If the complete configuration message is greater than MAX_BLOB_SIZE bytes, the
+	 * transmission will be split into several smaller fragments.
+	 * In this case the ADSP System will perform multiple calls to SetConfiguration() until
+	 * completion of the configuration message sending.
+	 * \note config_id indicates ID of the configuration message only on the first fragment
+	 * sending, otherwise it is set to 0.
+	 */
+	int (*set_configuration)(struct processing_module *mod,
+				 uint32_t config_id,
+				 enum module_cfg_fragment_position pos, uint32_t data_offset_size,
+				 const uint8_t *fragment, size_t fragment_size, uint8_t *response,
+				 size_t response_size);
+
+	/**
+	 * Get module runtime configuration for the given configuration ID
+	 *
+	 * If the complete configuration message is greater than MAX_BLOB_SIZE bytes, the
+	 * transmission will be split into several smaller fragments.
+	 * In this case the ADSP System will perform multiple calls to GetConfiguration() until
+	 * completion of the configuration message retrieval.
+	 * \note config_id indicates ID of the configuration message only on the first fragment
+	 * retrieval, otherwise it is set to 0.
+	 */
+	int (*get_configuration)(struct processing_module *mod,
+				 uint32_t config_id, uint32_t *data_offset_size,
+				 uint8_t *fragment, size_t fragment_size);
+
+	/**
+	 * Set processing mode for the module
+	 */
+	int (*set_processing_mode)(struct processing_module *mod,
+				   enum module_processing_mode mode);
+
+	/**
+	 * Get the current processing mode for the module
+	 */
+	enum module_processing_mode (*get_processing_mode)(struct processing_module *mod);
+
+	/**
+	 * Module specific reset procedure, called as part of module_adapter component
+	 * reset in .reset(). This should reset all parameters to their initial stage
+	 * but leave allocated memory intact.
+	 */
+	int (*reset)(struct processing_module *mod);
+	/**
+	 * Module specific free procedure, called as part of module_adapter component
+	 * free in .free(). This should free all memory allocated by module.
+	 */
+	int (*free)(struct processing_module *mod);
+};
+
+#endif /* __SOF_MODULE_INTERFACE__ */


### PR DESCRIPTION
Intel module adapter is an extension to SOF module adapter component that allows to integrate
modules developed under IADK (Intel Audio Development Kit) Framework. IADK modules uses uniform
set of interfaces and are linked into separate library. These modules are loaded in runtime
through library_manager and then after registration into SOF component infrastructure are
interfaced through module adapter API.

There is variety of modules developed under IADK Framework by 3rd party vendors. The assumption
here is to integrate these modules with SOF infrastructure without modules code modifications.
Another assumption is that the 3rd party modules should be loaded in runtime without need
of rebuild the base firmware.
Therefore C++ function, structures and variables definition are here kept with original form from
IADK Framework. This provides binary compatibility for already developed 3rd party modules.

Since IADK modules uses ProcessingModuleInterface to control/data transfer and AdspSystemService
to use base FW services from internal module code, there is a communication shim layer defined
in intel_module_adapter directory.

Since ProcessingModuleInterface consists of virtual functions, there are C++ -> C wrappers
defined to access the interface calls from SOF code.

There are three entities in intel module adapter package:
 - System Agent - A mediator to allow the custom module to interact with the base SOF FW.
                  It calls IADK module entry point and provides all necessary information to
                  connect both sides of ProcessingModuleInterface and System Service.
 - System Service - exposes of SOF base FW services to the module.
 - Processing Module Adapter - SOF base FW side of ProcessingModuleInterface API

This code will be usable after this PR: https://github.com/thesofproject/sof/pull/5796 will be integrated. 
