### PR TITLE
DMIC: eliminate the gain ramping task

### DIFF
--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -179,6 +179,7 @@ static struct comp_dev *dai_new(const struct comp_driver *drv,
 		comp_cl_err(&comp_dai, "dai_new(): dai_get() failed to create DAI.");
 		goto error;
 	}
+	dd->dai->dd = dd;
 	dd->ipc_config = *dai;
 
 	/* request GP LP DMA with shared access privilege */

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -952,6 +952,9 @@ static int dai_copy(struct comp_dev *dev)
 		return 0;
 	}
 
+	if (dd->dai->drv->ops.copy)
+		dd->dai->drv->ops.copy(dd->dai);
+
 	ret = dma_copy_legacy(dd->chan, copy_bytes, 0);
 	if (ret < 0) {
 		dai_report_xrun(dev, copy_bytes);

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -1052,6 +1052,9 @@ static int dai_copy(struct comp_dev *dev)
 		return 0;
 	}
 
+	if (dd->dai->drv->ops.copy)
+		dd->dai->drv->ops.copy(dd->dai);
+
 	struct dma_cb_data next = {
 		.channel = dd->chan,
 		.elem = { .size = copy_bytes },

--- a/src/include/sof/drivers/dmic.h
+++ b/src/include/sof/drivers/dmic.h
@@ -76,7 +76,6 @@
 #include <sof/bit.h>
 #include <sof/lib/dai.h>
 #include <sof/lib/wait.h>
-#include <sof/schedule/task.h>
 #include <stdint.h>
 
 /* Parameters used in modes computation */
@@ -472,12 +471,12 @@ struct dmic_global_shared {
 /* DMIC private data */
 struct dmic_pdata {
 	struct dmic_global_shared *global;	/* Common data for all DMIC DAI instances */
-	struct task dmicwork;			/* HW gain ramp update task */
 	uint16_t enable[DMIC_HW_CONTROLLERS];	/* Mic 0 and 1 enable bits array for PDMx */
 	uint32_t state;				/* Driver component state */
-	int32_t startcount;			/* Counter in dmicwork that controls HW unmute */
+	int32_t startcount;			/* Counter that controls HW unmute */
 	int32_t gain_coef;			/* Gain update constant */
 	int32_t gain;				/* Gain value to be applied to HW */
+	int32_t unmute_ramp_time_ms;		/* Unmute ramp time in milliseconds */
 	int irq;				/* Interrupt number used */
 	enum sof_ipc_frame dai_format;		/* PCM format s32_le etc. */
 	int dai_channels;			/* Channels count */

--- a/src/include/sof/lib/dai.h
+++ b/src/include/sof/lib/dai.h
@@ -86,6 +86,7 @@ struct dai_ops {
 	int (*remove)(struct dai *dai);
 	uint32_t (*get_init_delay_ms)(struct dai *dai);
 	int (*get_fifo_depth)(struct dai *dai, int direction);
+	void (*copy)(struct dai *dai);	/* Can be used by DAIs to prepare for data copying */
 };
 
 struct timestamp_cfg {

--- a/src/include/sof/lib/dai.h
+++ b/src/include/sof/lib/dai.h
@@ -161,6 +161,7 @@ struct dai_data {
 #ifdef __ZEPHYR__
 	struct dma_config *z_config;
 #endif
+	struct comp_dev *dai_dev;
 	struct comp_buffer *dma_buffer;
 	struct comp_buffer *local_buffer;
 	struct timestamp_cfg ts_config;
@@ -199,6 +200,7 @@ struct dai {
 	int sref;		/**< simple ref counter, guarded by lock */
 	struct dai_plat_data plat_data;
 	const struct dai_driver *drv;
+	const struct dai_data *dd;
 	void *priv_data;
 };
 

--- a/src/ipc/ipc3/dai.c
+++ b/src/ipc/ipc3/dai.c
@@ -284,6 +284,8 @@ int dai_config(struct comp_dev *dev, struct ipc_config_dai *common_config,
 		return 0;
 	}
 
+	dd->dai_dev = dev;
+
 	switch (config->flags & SOF_DAI_CONFIG_FLAGS_CMD_MASK) {
 	case SOF_DAI_CONFIG_FLAGS_HW_PARAMS:
 		/* set the delayed_dma_stop flag */

--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -266,6 +266,8 @@ int dai_config(struct comp_dev *dev, struct ipc_config_dai *common_config,
 	if (dai_config_dma_channel(dev, spec_config) == DMA_CHAN_INVALID)
 		return 0;
 
+	dd->dai_dev = dev;
+
 	/* allocated dai_config if not yet */
 	if (!dd->dai_spec_config) {
 		size = sizeof(*copier_cfg);


### PR DESCRIPTION
The DMIC driver currently uses a separate task to perform gain ramping on start up. This can be achieved from the `.copy()` context avoiding an additional asynchronous context and races associated with it.