### PR TITLE
ipc4: cavs: power_down: Send SET_DX reply on power down

### DIFF
--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -999,10 +999,18 @@ void ipc_cmd(struct ipc_cmd_hdr *_hdr)
 	if (err)
 		tr_err(&ipc_tr, "ipc4: %d failed err %d", target, err);
 
-	/* FW sends a ipc message to host if request bit is set*/
+	/* FW sends an ipc message to host if request bit is clear */
 	if (in->primary.r.rsp == SOF_IPC4_MESSAGE_DIR_MSG_REQUEST) {
 		char *data = ipc_get()->comp_data;
 		struct ipc4_message_reply reply;
+
+		/* Do not send reply for SET_DX if we are going to enter D3
+		 * The reply is going to be sent as part of the power down
+		 * sequence
+		 */
+		if (in->primary.r.type == SOF_IPC4_MOD_SET_DX &&
+		    ipc_get()->pm_prepare_D3)
+			return;
 
 		if (ipc_wait_for_compound_msg() != 0) {
 			tr_err(&ipc_tr, "ipc4: failed to send delayed reply");

--- a/src/platform/intel/cavs/lib/power_down.S
+++ b/src/platform/intel/cavs/lib/power_down.S
@@ -26,8 +26,15 @@
 	.align 64
 power_down_literals:
 	.literal_position
+#if CONFIG_IPC_MAJOR_3
 ipc_flag:
 	.word IPC_DIPCTDR_BUSY
+#elif CONFIG_IPC_MAJOR_4
+set_dx_reply:
+	/* BUSY (bit31), MODULE_MSG (bit30), reply (bit29), SET_DX (bit 24-28: 7) */
+	.word 0xE7000000
+
+#endif
 sram_dis_loop_cnt:
 	.word 4096
 
@@ -137,6 +144,7 @@ _PD_DISABLE_HPSRAM:
 	m_cavs_set_hpldo_state temp_reg0, temp_reg1, temp_reg2
 
 _PD_SEND_IPC:
+#if CONFIG_IPC_MAJOR_3
 /* Send IPC to host informing of PD completion - Clear BUSY
  * bit by writing IPC_DIPCTDR_BUSY to IPC_DIPCTDR
  * and writing IPC_DIPCTDA_DONE to IPC_DIPCTDA
@@ -150,6 +158,17 @@ _PD_SEND_IPC:
 	l32i temp_reg1, host_base, IPC_DIPCTDA
 	or temp_reg1, temp_reg1, temp_reg2
 	s32i temp_reg1, host_base, IPC_DIPCTDA
+#elif CONFIG_IPC_MAJOR_4
+/* Send IPC reply for SET_DX message */
+	movi temp_reg1, 0
+	s32i temp_reg1, host_base, IPC_DIPCIDD
+
+	movi temp_reg1, set_dx_reply
+	l32i temp_reg1, temp_reg1, 0
+	s32i temp_reg1, host_base, IPC_DIPCIDR
+#else
+#error "Support for this IPC version is not implemented"
+#endif
 
 _PD_SLEEP:
 /* effecfively executes:


### PR DESCRIPTION
Skip sending reply message to a SET_DX if pm_prepare_D3 is set and do it
in power down time in a same way as it is done with IPC3.

Signed-off-by: Peter Ujfalusi <peter.ujfalusi@linux.intel.com>