### PR TITLE
ipc4: set component direction if it is not set

### DIFF
--- a/src/audio/copier.c
+++ b/src/audio/copier.c
@@ -1167,6 +1167,25 @@ static int copier_get_large_config(struct comp_dev *dev, uint32_t param_id,
 	return -EINVAL;
 }
 
+static int copier_get_attribute(struct comp_dev *dev, uint32_t type, void *value)
+{
+	struct copier_data *cd = comp_get_drvdata(dev);
+
+	switch (type) {
+	case COMP_ATTR_COPY_DIR:
+		/* direction is set based on gateway type */
+		if (!cd->endpoint_num)
+			return -EINVAL;
+
+		*(uint32_t *)value = dev->direction;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
 static const struct comp_driver comp_copier = {
 	.uid	= SOF_RT_UUID(copier_comp_uuid),
 	.tctx	= &copier_comp_tr,
@@ -1180,6 +1199,7 @@ static const struct comp_driver comp_copier = {
 		.params			= copier_params,
 		.prepare		= copier_prepare,
 		.reset			= copier_reset,
+		.get_attribute		= copier_get_attribute,
 	},
 };
 

--- a/src/include/sof/ipc/topology.h
+++ b/src/include/sof/ipc/topology.h
@@ -52,7 +52,7 @@ int ipc4_add_comp_dev(struct comp_dev *dev);
 const struct comp_driver *ipc4_get_drv(uint8_t *uuid);
 int ipc4_create_chain_dma(struct ipc *ipc, struct ipc4_chain_dma *cdma);
 int ipc4_trigger_chain_dma(struct ipc *ipc, struct ipc4_chain_dma *cdma);
-bool ipc4_comp_is_gateway(struct comp_dev *dev);
+bool ipc4_comp_has_dir(struct comp_dev *dev);
 #else
 #error "No or invalid IPC MAJOR version selected."
 #endif

--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -422,7 +422,7 @@ static int update_dir_to_pipeline_component(uint32_t *ppl_id, uint32_t count)
 				 * since one of them is for playback and the other one
 				 * is for capture
 				 */
-				if (ipc4_comp_is_gateway(icd->cd))
+				if (ipc4_comp_has_dir(icd->cd))
 					break;
 
 				icd->cd->direction = dai->direction;

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -780,17 +780,13 @@ out:
 	return drv;
 }
 
-bool ipc4_comp_is_gateway(struct comp_dev *dev)
+bool ipc4_comp_has_dir(struct comp_dev *dev)
 {
-	const struct sof_uuid copier = {0x9ba00c83, 0xca12, 0x4a83, {0x94, 0x3c,
-		0x1f, 0xa2, 0xe8, 0x2f, 0x9d, 0xda}};
+	int dir = -EINVAL;
 
-	/* check whether it is a copier module with copier uuid */
-	if (!memcmp(dev->drv->uid, &copier, UUID_SIZE)) {
-		/* dai or host, not a module for copy */
-		if (list_is_empty(&dev->bsink_list) || list_is_empty(&dev->bsource_list))
-			return true;
-	}
+	comp_get_attribute(dev, COMP_ATTR_COPY_DIR, &dir);
+	if (dir == SOF_IPC_STREAM_PLAYBACK || dir == SOF_IPC_STREAM_CAPTURE)
+		return true;
 
 	return false;
 }


### PR DESCRIPTION
FW doesn't set component direction if the component is
for gateway. Now check the component direction and
skip set it if it is set. Only the direction of gateway
module is figured out based on gateway type so
only copier module supports get_attribute of direction.

The original method can't deal with a corner case that
gateway module has both input & output.

Signed-off-by: Rander Wang <rander.wang@intel.com>