### PR TITLE
intel: dmic: set plat_data fifo depth for capture

### DIFF
--- a/src/drivers/intel/dmic/dmic_nhlt.c
+++ b/src/drivers/intel/dmic/dmic_nhlt.c
@@ -318,7 +318,7 @@ int dmic_set_config_nhlt(struct dai *dai, void *spec_config)
 	 * configuration
 	 */
 	bfth = OUTCONTROL0_BFTH_GET(val);
-	dai->plat_data.fifo->depth = 1 << bfth;
+	dai->plat_data.fifo[SOF_IPC_STREAM_CAPTURE].depth = 1 << bfth;
 
 	/* Get PDMx registers */
 	pdm_ctrl_mask = ((struct nhlt_pdm_ctrl_mask *)p)->pdm_ctrl_mask;


### PR DESCRIPTION
This patch sets plat_data fifo depth for SOF_IPC_STREAM_CAPTURE instead
of a SOF_IPC_STREAM_PLAYBACK. The value is later read with
get_fifo_depth().

Without this patch the driver sets the value to fifo[0].depth and then
reads from fifo[1].depth.

Signed-off-by: Tomasz Leman <tomasz.m.leman@intel.com>