### PR TITLE
audio: fix the unsymmetrical order of lock and unlock.

### DIFF
--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -844,8 +844,8 @@ void comp_get_copy_limits_with_lock(struct comp_buffer *source,
 
 	comp_get_copy_limits(source_c, sink_c, cl);
 
-	buffer_release(source_c);
 	buffer_release(sink_c);
+	buffer_release(source_c);
 }
 
 /**


### PR DESCRIPTION
fix the unsymmetrical order of lock and unlock issue in
function comp_get_copy_limits_with_lock to avoid IPC
tiime out risk.

Signed-off-by: Andrula Song <xiaoyuan.song@intel.com>