### PR TITLE
dai: remove bogus IRQ disabling in DAI group triggering

### DIFF
--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -810,7 +810,6 @@ static int dai_comp_trigger(struct comp_dev *dev, int cmd)
 {
 	struct dai_data *dd = comp_get_drvdata(dev);
 	struct dai_group *group = dd->group;
-	uint32_t irq_flags;
 	int ret = 0;
 
 	/* DAI not in a group, use normal trigger */
@@ -848,11 +847,8 @@ static int dai_comp_trigger(struct comp_dev *dev, int cmd)
 			 * and we may begin the actual trigger process
 			 * synchronously.
 			 */
-
-			irq_local_disable(irq_flags);
 			notifier_event(group, NOTIFIER_ID_DAI_TRIGGER,
 				       BIT(cpu_get_id()), NULL, 0);
-			irq_local_enable(irq_flags);
 
 			/* return error of last trigger */
 			ret = group->trigger_ret;

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -906,7 +906,6 @@ static int dai_comp_trigger(struct comp_dev *dev, int cmd)
 {
 	struct dai_data *dd = comp_get_drvdata(dev);
 	struct dai_group *group = dd->group;
-	uint32_t irq_flags;
 	int ret = 0;
 
 	/* DAI not in a group, use normal trigger */
@@ -944,11 +943,8 @@ static int dai_comp_trigger(struct comp_dev *dev, int cmd)
 			 * and we may begin the actual trigger process
 			 * synchronously.
 			 */
-
-			irq_local_disable(irq_flags);
 			notifier_event(group, NOTIFIER_ID_DAI_TRIGGER,
 				       BIT(cpu_get_id()), NULL, 0);
-			irq_local_enable(irq_flags);
 
 			/* return error of last trigger */
 			ret = group->trigger_ret;


### PR DESCRIPTION
Disabling IRQs when sending a notification doesn't seem to be required and is potentially risky if that notification causes re-scheduling.
