### PR TITLE
xtensa-build-zephyr.py: add option to change output file layout for different platforms and keys

### DIFF
--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -186,6 +186,11 @@ Note '-C --warn-uninitialized' is not supported by argparse, an equal
 sign must be used (https://bugs.python.org/issue9334)""",
 	)
 
+	parser.add_argument("--key-type-subdir", default="community",
+			    choices=["community", "none", "dbgkey"],
+			    help="""Output subdirectory for rimage signing key type.
+Default key type subdirectory is \"community\".""")
+
 	args = parser.parse_args()
 
 	if args.all:
@@ -469,6 +474,7 @@ def build_platforms():
 			signing_key = platform_dict["RIMAGE_KEY"]
 		else:
 			signing_key = default_rimage_key
+
 		sign_cmd += ["--tool-data", str(rimage_config), "--", "-k", str(signing_key)]
 
 		sign_cmd += ["-f", get_sof_version(abs_build_dir)]
@@ -480,7 +486,12 @@ def build_platforms():
 		execute_command(sign_cmd, cwd=west_top)
 		# Install by copy
 		fw_file_to_copy = pathlib.Path(west_top, platform_build_dir_name, "zephyr", "zephyr.ri")
-		fw_file_installed = pathlib.Path(sof_output_dir, "community", f"sof-{platform}.ri")
+		if args.key_type_subdir == "none":
+			fw_file_installed = pathlib.Path(sof_output_dir,
+							 f"sof-{platform}.ri")
+		else:
+			fw_file_installed = pathlib.Path(sof_output_dir, args.key_type_subdir,
+							 f"sof-{platform}.ri")
 		os.makedirs(os.path.dirname(fw_file_installed), exist_ok=True)
 		# looses file owner and group - file is commonly accessible
 		shutil.copy2(str(fw_file_to_copy), str(fw_file_installed))

--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -15,7 +15,7 @@ import multiprocessing
 import os
 import warnings
 # anytree module is defined in Zephyr build requirements
-from anytree import Node, RenderTree
+from anytree import AnyNode, RenderTree
 
 # Constant value resolves SOF_TOP directory as: "this script directory/.."
 SOF_TOP = pathlib.Path(__file__).parents[1].resolve()
@@ -242,18 +242,18 @@ def execute_command(*run_args, **run_kwargs):
 def show_installed_files():
 	"""[summary] Scans output directory building binary tree from files and folders
 	then presents them in similar way to linux tree command."""
-	graph_root = Node(STAGING_DIR.name, parent=None)
+	graph_root = AnyNode(name=STAGING_DIR.name, long_name=STAGING_DIR.name, parent=None)
 	relative_entries = [entry.relative_to(STAGING_DIR) for entry in STAGING_DIR.glob("**/*")]
 	nodes = [ graph_root ]
 	for entry in relative_entries:
 		if str(entry.parent) == ".":
-			nodes.append(Node(entry.name, parent=graph_root))
+			nodes.append(AnyNode(name=entry.name, long_name=str(entry), parent=graph_root))
 		else:
-			node_parent = [node for node in nodes if node.name == str(entry.parent.name)][0]
+			node_parent = [node for node in nodes if node.long_name == str(entry.parent)][0]
 			if not node_parent:
 				warnings.warn("Failed to construct installed files tree")
 				return
-			nodes.append(Node(entry.name, parent=node_parent))
+			nodes.append(AnyNode(name=entry.name, long_name=str(entry), parent=node_parent))
 	for pre, fill, node in RenderTree(graph_root):
 		print(f"{pre}{node.name}")
 

--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -191,6 +191,12 @@ sign must be used (https://bugs.python.org/issue9334)""",
 			    help="""Output subdirectory for rimage signing key type.
 Default key type subdirectory is \"community\".""")
 
+
+	parser.add_argument("--use-platform-subdir", default = False,
+			    action="store_true",
+			    help="""Use an output subdirectory for each platform.
+Otherwise, all firmware files are installed in the same staging directory by default.""")
+
 	args = parser.parse_args()
 
 	if args.all:
@@ -372,6 +378,12 @@ def build_platforms():
 	sof_output_dir = pathlib.Path(STAGING_DIR, "sof")
 	sof_output_dir.mkdir(mode=511, parents=True, exist_ok=True)
 	for platform in args.platforms:
+		if args.use_platform_subdir:
+			sof_platform_output_dir = pathlib.Path(sof_output_dir, platform)
+			sof_platform_output_dir.mkdir(parents=True, exist_ok=True)
+		else:
+			sof_platform_output_dir = sof_output_dir
+
 		platform_dict = [x for x in platform_list if x["name"] == platform][0]
 		xtensa_tools_root_dir = os.getenv("XTENSA_TOOLS_ROOT")
 		# when XTENSA_TOOLS_ROOT environmental variable is set,
@@ -447,7 +459,7 @@ def build_platforms():
 		execute_command(build_cmd, cwd=west_top)
 		smex_executable = pathlib.Path(west_top, platform_build_dir_name, "zephyr", "smex_ep",
 			"build", "smex")
-		fw_ldc_file = pathlib.Path(sof_output_dir, f"sof-{platform}.ldc")
+		fw_ldc_file = pathlib.Path(sof_platform_output_dir, f"sof-{platform}.ldc")
 		input_elf_file = pathlib.Path(west_top, platform_build_dir_name, "zephyr", "zephyr.elf")
 		# Extract metadata
 		execute_command([str(smex_executable), "-l", str(fw_ldc_file), str(input_elf_file)])
@@ -487,10 +499,10 @@ def build_platforms():
 		# Install by copy
 		fw_file_to_copy = pathlib.Path(west_top, platform_build_dir_name, "zephyr", "zephyr.ri")
 		if args.key_type_subdir == "none":
-			fw_file_installed = pathlib.Path(sof_output_dir,
+			fw_file_installed = pathlib.Path(sof_platform_output_dir,
 							 f"sof-{platform}.ri")
 		else:
-			fw_file_installed = pathlib.Path(sof_output_dir, args.key_type_subdir,
+			fw_file_installed = pathlib.Path(sof_platform_output_dir, args.key_type_subdir,
 							 f"sof-{platform}.ri")
 		os.makedirs(os.path.dirname(fw_file_installed), exist_ok=True)
 		# looses file owner and group - file is commonly accessible


### PR DESCRIPTION
This series include 3 patches:
- xtensa-build-zephyr.py: add option to specify name of non-default signing key
- xtensa-build-zephyr.py: add option to create an output directory for each platform
- xtensa-build-zephyr.py: avoid showing wrong layout of installed files  (a bug fixing)

Users can make xtensa-build-zephyr.py to generate output layout like this:
```
sof/<platform_name>/<key_name>/sof-<platform_name>.ri
                  /sof-<platform_name>.ldc
```
And this layout will comply with that in Linux distribution for firmware supporting IPC4 of new Intel platforms.

**Updates of v2:**
- Use option `--key-type-subdir` to choose the output subdirectory name for signing key type. Define the list 'community', 'dbgkey' and 'none' for valid key types.
- use option '--use-platform-subdir' to create output subdirectory for each platform. Remove unnecessary mode settings when creating the platform subdirectory.
- For the AnyNode fix, use 'name' as before and introduce a new attribute 'long_name' to store node path and search its parent.
