### PR TITLE
[SKIP CI] .github: independent strict and non-strict runs of check patch

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -17,6 +17,12 @@ on: [pull_request]
 jobs:
   checkpatch:
     runs-on: ubuntu-20.04
+
+    strategy:
+      fail-false: false
+      matrix:
+        strictness : [ "", --strict, ]
+
     env:
       PR_NUM: ${{github.event.number}}
       # TODO: reduce duplication with scripts/sof-*-commit-hook.sh
@@ -41,12 +47,11 @@ jobs:
            # show what we got
            git --no-pager log --oneline --graph --decorate --max-count=50
 
-      - name: normal checkpatch
-        run: .github/workflows/checkpatch_list.sh ${CHK_CMD_OPTS} < PR_SHAs.txt
-
-      - name: checkpatch --strict
+      - name: checkpatch
+        env:
+          strictness: ${{ matrix.strictness }}
         run: .github/workflows/checkpatch_list.sh ${CHK_CMD_OPTS}
-                 --strict < PR_SHAs.txt
+                 ${strictness} < PR_SHAs.txt
   yamllint:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This makes the difference between "strict" and regular failures very
clear.

Stopping after non-strict failures is misleading, it can give the wrong
impression that there are very few warnings left.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>