### PR TITLE
[SKIP CI] .github: independent strict and non-strict runs of check patch

### DIFF
--- a/.github/workflows/checkpatch_list.sh
+++ b/.github/workflows/checkpatch_list.sh
@@ -11,10 +11,12 @@ set -e
 main()
 {
     local failures=0
+    set -x
     while read -r sha ; do
         printf '\n    -------------- \n\n'
         ./scripts/checkpatch.pl $@ -g $sha || failures=$((failures+1))
     done
+    set +x
     printf '\n    -------------- \n\n'
     return $failures
 }

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -17,6 +17,12 @@ on: [pull_request]
 jobs:
   checkpatch:
     runs-on: ubuntu-20.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        strictness: [null, --strict]
+
     env:
       PR_NUM: ${{github.event.number}}
       # TODO: reduce duplication with scripts/sof-*-commit-hook.sh
@@ -41,12 +47,12 @@ jobs:
            # show what we got
            git --no-pager log --oneline --graph --decorate --max-count=50
 
-      - name: normal checkpatch
-        run: .github/workflows/checkpatch_list.sh ${CHK_CMD_OPTS} < PR_SHAs.txt
-
-      - name: checkpatch --strict
+      - name: checkpatch
+        env:
+          STRICTNESS: ${{ matrix.strictness }}
         run: .github/workflows/checkpatch_list.sh ${CHK_CMD_OPTS}
-                 --strict < PR_SHAs.txt
+          ${STRICTNESS} < PR_SHAs.txt
+
   yamllint:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This makes the difference between "strict" and regular failures very
clear.

Stopping after non-strict failures is misleading, it can give the wrong
impression that there are very few warnings left.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>