### PR TITLE
xtensa-build-zephyr.py: switch default to sof/stable-v2.2

### DIFF
--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -144,7 +144,7 @@ def parse_args():
 						help="Initial Zephyr git ref for the -c option."
 						" Can be a branch, tag, full SHA1 in a fork")
 	parser.add_argument("-u", "--url", required=False,
-						default="https://github.com/zephyrproject-rtos/zephyr/",
+						default="https://github.com/thesofproject/zephyr/",
 						help="URL to clone Zephyr from")
 	mode_group = parser.add_mutually_exclusive_group()
 	mode_group.add_argument("-p", "--west_path", required=False, type=pathlib.Path,
@@ -197,7 +197,7 @@ sign must be used (https://bugs.python.org/issue9334)""",
 	if args.zephyr_ref and not args.clone_mode:
 		raise RuntimeError(f"Argument -z without -c makes no sense")
 	if args.clone_mode and not args.zephyr_ref:
-		args.zephyr_ref = "main"	# set default name for -z if -c specified
+		args.zephyr_ref = "sof/stable-v2.2"	# set default name for -z if -c specified
 
 	if args.west_path: # let the user provide an already existing zephyrproject/ anywhere
 		west_top = pathlib.Path(args.west_path)


### PR DESCRIPTION
This is only for SOF v2.2 release branch stable-v2.2

This PR includes 2 commits:

- The release branch is created for SOF v2.2 in the cloned Zephyr repo:  
   https://github.com/thesofproject/zephyr/tree/sof/stable-v2.2
   This points to unmodified Zephyr upstream tag v3.1.0-rc3
   
  Set default Zephyr URL to this cloned repo and switch default branch to sof/stable-v2.2

- Cherry pick commit [xtensa-build-zephyr.py: pass SOF firmware file version string to rimage](https://github.com/thesofproject/sof/pull/5893/commits/317b6da2cb586902287cd37efe6871b1d6e84949) from main branch.
