### PR TITLE
[TEST IGNORE] test Zephyr rename 46308 back to 'cavstool.py'

### DIFF
--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -308,8 +308,8 @@ def west_init_update():
 	# fetching of (full 40-digits) SHAs; even SHAs not in origin but
 	# in forks! See the end of "git help fetch-pack".
 	#
-	# z_remote = "https://somewhere.else"
-	# z_ref = "pull/38374/head"
+	z_remote = "https://github.com/zephyrproject-rtos/zephyr"
+	z_ref = "pull/46308/head"
 	# z_ref = "cb9a279050c4e8ad4663ee78688d8e7de1cac953"
 
 	# SECURITY WARNING for reviewers: never allow unknown code from


### PR DESCRIPTION
See https://github.com/zephyrproject-rtos/zephyr/pull/46308 which
hopefully fixes Zephyr build in SOF CI

Signed-off-by: Marc Herbert <marc.herbert@intel.com>