### PR TITLE
[SKIP CI] docker: add AMD/Rembrandt gcc toolchain

### DIFF
--- a/scripts/docker_build/sof_builder/Dockerfile
+++ b/scripts/docker_build/sof_builder/Dockerfile
@@ -88,7 +88,7 @@ RUN cd "$HOME" && \
 	git clone $CLONE_DEFAULTS --branch sof-gcc10x $CT_NG_REPO && \
 	cd crosstool-ng && \
 	./bootstrap && ./configure --prefix=`pwd` && make && make install && \
-	for arch in byt hsw apl cnl imx imx8m imx8ulp rn mt8186 mt8195; do \
+	for arch in byt hsw apl cnl imx imx8m imx8ulp rn rmb mt8186 mt8195; do \
 		echo "$arch: ct-ng build start..." && \
 		cp config-${arch}-gcc10.2-gdb9 .config && \
 		# replace the build dist to save space
@@ -104,6 +104,7 @@ ENV PATH="/home/sof/work/xtensa-hsw-elf/bin:${PATH}"
 ENV PATH="/home/sof/work/xtensa-apl-elf/bin:${PATH}"
 ENV PATH="/home/sof/work/xtensa-cnl-elf/bin:${PATH}"
 ENV PATH="/home/sof/work/xtensa-rn-elf/bin:${PATH}"
+ENV PATH="/home/sof/work/xtensa-rmb-elf/bin:${PATH}"
 ENV PATH="/home/sof/work/xtensa-imx-elf/bin:${PATH}"
 ENV PATH="/home/sof/work/xtensa-imx8m-elf/bin:${PATH}"
 ENV PATH="/home/sof/work/xtensa-imx8ulp-elf/bin:${PATH}"
@@ -114,7 +115,7 @@ ARG NEWLIB_REPO=https://github.com/jcmvbkbc/newlib-xtensa.git
 RUN cd "$HOME" && \
 	git clone $CLONE_DEFAULTS --branch xtensa $NEWLIB_REPO && \
 	cd newlib-xtensa && \
-	for arch in byt hsw apl cnl imx imx8m imx8ulp rn mt8186 mt8195; do \
+	for arch in byt hsw apl cnl imx imx8m imx8ulp rn rmb mt8186 mt8195; do \
 		./configure --target=xtensa-${arch}-elf \
 		--prefix=/home/sof/work/xtensa-root && \
 		make && make install && \


### PR DESCRIPTION
Add AMD/Rembrandt (rmb) gcc toolchain to thesofproject/sof docker image.

Signed-off-by: Fred Oh <fred.oh@linux.intel.com>