### PR TITLE
IPC4: DAI: Add sampling frequency to ipc_config_dai

### DIFF
--- a/src/audio/copier.c
+++ b/src/audio/copier.c
@@ -324,6 +324,7 @@ static int create_dai(struct comp_dev *parent_dev, struct copier_data *cd,
 	dai_index[dai_count - 1] = node_id.f.v_index;
 	dai.direction = node_id.f.dma_type % 2;
 	dai.is_config_blob = true;
+	dai.sampling_frequency = copier->out_fmt.sampling_frequency;
 
 	switch (node_id.f.dma_type) {
 	case ipc4_hda_link_output_class:

--- a/src/drivers/intel/alh.c
+++ b/src/drivers/intel/alh.c
@@ -63,7 +63,7 @@ static int alh_set_config_blob(struct dai *dai, struct ipc_config_dai *common_co
 
 	dai_info(dai, "alh_set_config_blob()");
 
-	alh->params.rate = 48000;
+	alh->params.rate = common_config->sampling_frequency;
 
 	for (i = 0; i < alh_cfg->count; i++) {
 		/* the LSB 8bits are for stream id */

--- a/src/drivers/intel/ssp/ssp.c
+++ b/src/drivers/intel/ssp/ssp.c
@@ -825,7 +825,7 @@ static int ssp_set_config_blob(struct dai *dai, struct ipc_config_dai *common_co
 	ssp->config.ssp.tdm_slots = SSCR0_FRDC_GET(ssc0);
 	ssp->config.ssp.tx_slots = SSTSA_GET(sstsa);
 	ssp->config.ssp.rx_slots = SSRSA_GET(ssrsa);
-	ssp->config.ssp.fsync_rate = 48000;
+	ssp->config.ssp.fsync_rate = common_config->sampling_frequency;
 	ssp->params = ssp->config.ssp;
 
 	ssp->state[DAI_DIR_PLAYBACK] = COMP_STATE_PREPARE;

--- a/src/include/sof/audio/ipc-config.h
+++ b/src/include/sof/audio/ipc-config.h
@@ -27,6 +27,7 @@ struct ipc_config_dai {
 	uint32_t dai_index;	/**< index of this type dai */
 	uint32_t type;		/**< DAI type - SOF_DAI_ */
 	/* physical protocol and clocking */
+	uint32_t sampling_frequency; /**< DAI sampling frequency - required only with IPC4 */
 	uint16_t format;	/**< SOF_DAI_FMT_ */
 	uint16_t group_id;	/**< group ID, 0 means no group (ABI 3.17) */
 	bool is_config_blob;	/**< DAI specific configuration is a blob */


### PR DESCRIPTION
For some of the dai devices, sampling frequency is not passed as a part
of IPC4 blob. Added this value to ipc_config_dai, so during
configuration devices can access it through their common_config
argument.
This fixes ALH and SSP not working with other sampling frequencies than default ones when using IPC4.

Signed-off-by: Krzysztof Frydryk <krzysztofx.frydryk@intel.com>