### PR TITLE
copier: remove get_attribute op

### DIFF
--- a/src/audio/copier.c
+++ b/src/audio/copier.c
@@ -1167,25 +1167,6 @@ static int copier_get_large_config(struct comp_dev *dev, uint32_t param_id,
 	return -EINVAL;
 }
 
-static int copier_get_attribute(struct comp_dev *dev, uint32_t type, void *value)
-{
-	struct copier_data *cd = comp_get_drvdata(dev);
-
-	switch (type) {
-	case COMP_ATTR_COPY_DIR:
-		/* direction is set based on gateway type */
-		if (!cd->endpoint_num)
-			return -EINVAL;
-
-		*(uint32_t *)value = dev->direction;
-		break;
-	default:
-		return -EINVAL;
-	}
-
-	return 0;
-}
-
 static const struct comp_driver comp_copier = {
 	.uid	= SOF_RT_UUID(copier_comp_uuid),
 	.tctx	= &copier_comp_tr,
@@ -1199,7 +1180,6 @@ static const struct comp_driver comp_copier = {
 		.params			= copier_params,
 		.prepare		= copier_prepare,
 		.reset			= copier_reset,
-		.get_attribute		= copier_get_attribute,
 	},
 };
 

--- a/src/include/sof/ipc/topology.h
+++ b/src/include/sof/ipc/topology.h
@@ -52,7 +52,6 @@ int ipc4_add_comp_dev(struct comp_dev *dev);
 const struct comp_driver *ipc4_get_drv(uint8_t *uuid);
 int ipc4_create_chain_dma(struct ipc *ipc, struct ipc4_chain_dma *cdma);
 int ipc4_trigger_chain_dma(struct ipc *ipc, struct ipc4_chain_dma *cdma);
-bool ipc4_comp_has_dir(struct comp_dev *dev);
 #else
 #error "No or invalid IPC MAJOR version selected."
 #endif

--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -416,13 +416,16 @@ static int update_dir_to_pipeline_component(uint32_t *ppl_id, uint32_t count)
 
 		for (i = 0; i < count; i++) {
 			if (ipc_comp_pipe_id(icd) == ppl_id[i]) {
+				struct comp_dev *dev = icd->cd;
+				struct comp_ipc_config config = dev->ipc_config;
+
 				/* don't update direction for host & dai since they
 				 * have direction. Especially in dai copier to dai copier
 				 * case the direction can't be modified to single value
 				 * since one of them is for playback and the other one
 				 * is for capture
 				 */
-				if (ipc4_comp_has_dir(icd->cd))
+				if (config.type == SOF_COMP_HOST || config.type == SOF_COMP_DAI)
 					break;
 
 				icd->cd->direction = dai->direction;

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -780,17 +780,6 @@ out:
 	return drv;
 }
 
-bool ipc4_comp_has_dir(struct comp_dev *dev)
-{
-	int dir = -EINVAL;
-
-	comp_get_attribute(dev, COMP_ATTR_COPY_DIR, &dir);
-	if (dir == SOF_IPC_STREAM_PLAYBACK || dir == SOF_IPC_STREAM_CAPTURE)
-		return true;
-
-	return false;
-}
-
 const struct comp_driver *ipc4_get_comp_drv(int module_id)
 {
 	struct sof_man_fw_desc *desc = (struct sof_man_fw_desc *)IMR_BOOT_LDR_MANIFEST_BASE;


### PR DESCRIPTION
The get_attribute op for copier is used to determine whether the
direction has already been set or not so that the handler can skip
resetting the direction for host/dai components. Remove the op and use
the component type in the dev's ipc_config directly.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>