### PR TITLE
copier: remove get_attribute op

### DIFF
--- a/src/audio/copier.c
+++ b/src/audio/copier.c
@@ -505,6 +505,8 @@ static struct comp_dev *copier_new(const struct comp_driver *drv,
 				    (uint32_t)node_id.f.dma_type);
 			goto error_cd;
 		};
+
+		dev->direction_set = true;
 	}
 
 	dev->direction = cd->direction;
@@ -1167,25 +1169,6 @@ static int copier_get_large_config(struct comp_dev *dev, uint32_t param_id,
 	return -EINVAL;
 }
 
-static int copier_get_attribute(struct comp_dev *dev, uint32_t type, void *value)
-{
-	struct copier_data *cd = comp_get_drvdata(dev);
-
-	switch (type) {
-	case COMP_ATTR_COPY_DIR:
-		/* direction is set based on gateway type */
-		if (!cd->endpoint_num)
-			return -EINVAL;
-
-		*(uint32_t *)value = dev->direction;
-		break;
-	default:
-		return -EINVAL;
-	}
-
-	return 0;
-}
-
 static const struct comp_driver comp_copier = {
 	.uid	= SOF_RT_UUID(copier_comp_uuid),
 	.tctx	= &copier_comp_tr,
@@ -1199,7 +1182,6 @@ static const struct comp_driver comp_copier = {
 		.params			= copier_params,
 		.prepare		= copier_prepare,
 		.reset			= copier_reset,
-		.get_attribute		= copier_get_attribute,
 	},
 };
 

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -561,6 +561,7 @@ struct comp_dev {
 
 	/* common runtime configuration for downstream/upstream */
 	uint32_t direction;	/**< enum sof_ipc_stream_direction */
+	bool direction_set; /**< flag indicating that the direction has been set */
 
 	const struct comp_driver *drv;	/**< driver */
 

--- a/src/include/sof/ipc/topology.h
+++ b/src/include/sof/ipc/topology.h
@@ -52,7 +52,6 @@ int ipc4_add_comp_dev(struct comp_dev *dev);
 const struct comp_driver *ipc4_get_drv(uint8_t *uuid);
 int ipc4_create_chain_dma(struct ipc *ipc, struct ipc4_chain_dma *cdma);
 int ipc4_trigger_chain_dma(struct ipc *ipc, struct ipc4_chain_dma *cdma);
-bool ipc4_comp_has_dir(struct comp_dev *dev);
 #else
 #error "No or invalid IPC MAJOR version selected."
 #endif

--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -416,13 +416,15 @@ static int update_dir_to_pipeline_component(uint32_t *ppl_id, uint32_t count)
 
 		for (i = 0; i < count; i++) {
 			if (ipc_comp_pipe_id(icd) == ppl_id[i]) {
+				struct comp_dev *dev = icd->cd;
+
 				/* don't update direction for host & dai since they
 				 * have direction. Especially in dai copier to dai copier
 				 * case the direction can't be modified to single value
 				 * since one of them is for playback and the other one
 				 * is for capture
 				 */
-				if (ipc4_comp_has_dir(icd->cd))
+				if (dev->direction_set)
 					break;
 
 				icd->cd->direction = dai->direction;

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -780,17 +780,6 @@ out:
 	return drv;
 }
 
-bool ipc4_comp_has_dir(struct comp_dev *dev)
-{
-	int dir = -EINVAL;
-
-	comp_get_attribute(dev, COMP_ATTR_COPY_DIR, &dir);
-	if (dir == SOF_IPC_STREAM_PLAYBACK || dir == SOF_IPC_STREAM_CAPTURE)
-		return true;
-
-	return false;
-}
-
 const struct comp_driver *ipc4_get_comp_drv(int module_id)
 {
 	struct sof_man_fw_desc *desc = (struct sof_man_fw_desc *)IMR_BOOT_LDR_MANIFEST_BASE;


### PR DESCRIPTION
The get_attribute op for copier is used to determine whether the
direction has already been set or not so that the handler can skip
resetting the direction for host/dai components. Remove the op and use
the new fieldm direction_set in struct comp_dev to determine whether the
direction should be updated or not. Also, set the direction_set flag for
host/dai copier when it is created.

This change is in preparation to convert the copier module to use the
module interface instead of the comp_drv ops.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>