### PR TITLE
xtensa-build-zephyr.py: fix find_west_workspace() to return west topdir

### DIFF
--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -265,10 +265,10 @@ def find_west_workspace():
 	paths = [ pathlib.Path(os.getcwd()), SOF_TOP, west_top]
 	for path in paths:
 		if path.is_dir():
-			result = execute_command(["west", "topdir"], stderr=subprocess.DEVNULL,
-				stdout=subprocess.DEVNULL, check=False, cwd=path)
+			result = execute_command(["west", "topdir"], capture_output=True,
+						 text=True, check=False, cwd=path)
 		if result.returncode == 0:
-			return path
+			return pathlib.Path(result.stdout.rstrip(os.linesep))
 	return None
 
 def create_zephyr_directory():
@@ -291,12 +291,14 @@ def create_zephyr_directory():
 
 def create_zephyr_sof_symlink():
 	global west_top, SOF_TOP
+	if not west_top.exists():
+		raise FileNotFoundError("No west top: {}".format(west_top))
 	audio_modules_dir = pathlib.Path(west_top, "modules", "audio")
 	audio_modules_dir.mkdir(mode=511, parents=True, exist_ok=True)
 	sof_symlink = pathlib.Path(audio_modules_dir, "sof")
 	# Symlinks creation requires administrative privileges in Windows or special user rights
 	try:
-		if not sof_symlink.is_symlink():
+		if not sof_symlink.exists():
 			sof_symlink.symlink_to(SOF_TOP, target_is_directory=True)
 	except:
 		print(f"Failed to create symbolic link: {sof_symlink} to {SOF_TOP}."
@@ -375,6 +377,7 @@ def build_platforms():
 	execute_command(["west", "status", "hal_xtensa", "sof"], cwd=west_top,
 			stdout=subprocess.DEVNULL)
 
+	assert(west_top.exists())
 	global STAGING_DIR
 	STAGING_DIR = pathlib.Path(west_top, "build-sof-staging")
 	# smex does not use 'install -D'
@@ -534,6 +537,7 @@ def run_point_mode():
 	if not west_workspace_path.exists():
 		raise FileNotFoundError("West topdir returned {} as workspace but it"
 			" does not exist".format(west_workspace_path))
+	west_top = west_workspace_path
 	create_zephyr_sof_symlink()
 
 def main():


### PR DESCRIPTION
When neither -c nor -p is passed, the script defaults to '-p
SOF_TOP/zephyrproject', initializing the `west_top` global with
that. When everything is already cloned, this becomes
zephyrproject/modules/audio/sof/zephyrproject which is really not a
`west topdir`. Then west is pointed at:
 real_west_top/modules/audio/sof/zephyrproject/zephyr/samples/subsys/audio/sof
which obviously fails.

This was found while testing
https://thesofproject.github.io/latest/getting_started/build-guide/build-with-zephyr.html
and trying (and failing) to switch away from the older .sh script.

Fix find_west_workspace() to return the output of `west topdir` and use
that to update the `west_top` global.

This bug was introduced from the very start when the script was
converted from shell to python. The shell script did not have this
problem because it could be used without using neither -c nor -p. This
logical difference was mentioned in the code review:
https://github.com/thesofproject/sof/pull/5299#discussion_r801158177

Also remove a couple of accidental creations of a sof/zephyrproject/
directory when sof is already inside a higher zephyrproject.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>