### PR TITLE
ipc4: setdx: message completion delay

### DIFF
--- a/src/include/sof/ipc/common.h
+++ b/src/include/sof/ipc/common.h
@@ -46,6 +46,7 @@ extern struct tr_ctx ipc_tr;
 #define IPC_TASK_INLINE		BIT(0)
 #define IPC_TASK_IN_THREAD	BIT(1)
 #define IPC_TASK_SECONDARY_CORE	BIT(2)
+#define IPC_TASK_POWERDOWN      BIT(3)
 
 struct ipc {
 	struct k_spinlock lock;	/* locking mechanism */

--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -1003,15 +1003,15 @@ void ipc_cmd(struct ipc_cmd_hdr *_hdr)
 
 	/* FW sends an ipc message to host if request bit is clear */
 	if (in->primary.r.rsp == SOF_IPC4_MESSAGE_DIR_MSG_REQUEST) {
-		char *data = ipc_get()->comp_data;
+		struct ipc *ipc = ipc_get();
+		char *data = ipc->comp_data;
 		struct ipc4_message_reply reply;
 
 		/* Do not send reply for SET_DX if we are going to enter D3
 		 * The reply is going to be sent as part of the power down
 		 * sequence
 		 */
-		if (in->primary.r.type == SOF_IPC4_MOD_SET_DX &&
-		    ipc_get()->pm_prepare_D3)
+		if (ipc->task_mask & IPC_TASK_POWERDOWN)
 			return;
 
 		if (ipc_wait_for_compound_msg() != 0) {

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -629,6 +629,10 @@ static void imr_layout_update(void *vector)
 
 int platform_context_save(struct sof *sof)
 {
+#if CONFIG_IPC_MAJOR_4
+	ipc_get()->task_mask |= IPC_TASK_POWERDOWN;
+#endif
+
 #if CONFIG_CAVS_IMR_D3_PERSISTENT
 	/*
 	 * Both runtime PM and S2Idle suspend works on APL, while S3 ([deep])


### PR DESCRIPTION
During transition from D0 to D3, IPC processing completion is done
during power down procedure (file power_down.S).

FW build based on XTOS never exit from ipc_do_cmd() and will not enter
ipc_complete_cmd(). Zephyr based FW on other hand will execute power
down procedure after enering idle,  when IPC processing task is
completed. Therefore it should be skipped here.

Signed-off-by: Tomasz Leman <tomasz.m.leman@intel.com>