### PR TITLE
zephyr_ll: add task_cancel function state judgement

### DIFF
--- a/src/schedule/zephyr_ll.c
+++ b/src/schedule/zephyr_ll.c
@@ -457,7 +457,8 @@ static int zephyr_ll_task_cancel(void *data, struct task *task)
 	 * kept atomic, so we have to lock here too.
 	 */
 	zephyr_ll_lock(sch, &flags);
-	task->state = SOF_TASK_STATE_CANCEL;
+	if (task->state != SOF_TASK_STATE_FREE)
+		task->state = SOF_TASK_STATE_CANCEL;
 	zephyr_ll_unlock(sch, &flags);
 
 	return 0;


### PR DESCRIPTION
when call pause and then call stop, it will cause next triger start failed

Signed-off-by: honglin leng <a909204013@gmail.com>