### PR TITLE
buffer: fix wrong coherent_shared() call with Zephyr

### DIFF
--- a/src/include/sof/coherent.h
+++ b/src/include/sof/coherent.h
@@ -334,8 +334,15 @@ static inline void __coherent_init(struct coherent *c, const size_t size)
 
 #define coherent_free(object, member) do {} while (0)
 
-/* no function on cache coherent architectures */
-#define coherent_shared(object, member) (object)->member.shared = true
+static inline void __coherent_shared(struct coherent *c, const size_t size)
+{
+	c->key = k_spin_lock(&c->lock);
+	c->shared = true;
+	k_spin_unlock(&c->lock, c->key);
+}
+
+#define coherent_shared(object, member) __coherent_shared(&(object)->member, \
+							  sizeof(*object))
 
 #ifdef __ZEPHYR__
 __must_check static inline struct coherent __sparse_cache *coherent_acquire_thread(

--- a/src/include/sof/coherent.h
+++ b/src/include/sof/coherent.h
@@ -386,6 +386,16 @@ static inline void __coherent_init_thread(struct coherent *c, const size_t size)
 
 #define coherent_init_thread(object, member) __coherent_init_thread(&(object)->member, \
 								    sizeof(*object))
+
+static inline void __coherent_shared_thread(struct coherent *c, const size_t size)
+{
+	k_mutex_lock(&c->mutex, K_FOREVER);
+	c->shared = true;
+	k_mutex_unlock(&c->mutex);
+}
+
+#define coherent_shared_thread(object, member) __coherent_shared_thread(&(object)->member, \
+									sizeof(*object))
 #endif /* __ZEPHYR__ */
 
 #endif /* CONFIG_INCOHERENT */

--- a/src/ipc/ipc-helper.c
+++ b/src/ipc/ipc-helper.c
@@ -187,7 +187,7 @@ int comp_buffer_connect(struct comp_dev *comp, uint32_t comp_core,
 	if (buffer->core != comp_core) {
 
 		/* set the buffer as a coherent object */
-		coherent_shared(buffer, c);
+		coherent_shared_thread(buffer, c);
 
 		if (!comp->is_shared)
 			comp = comp_make_shared(comp);


### PR DESCRIPTION
When connecting a buffer to a component, if the buffer is shared it has to be configured as such. This is done by calling coherent_shared() for coherent objects, protected by a spin-lock. However, buffers under Zephyr are protected by a mutex, therefore coherent_shared_thread() has to be used.
