### PR TITLE
Audio: Rename audio stream read/write frag functions with prefix deprecated

### DIFF
--- a/src/audio/aria/aria.c
+++ b/src/audio/aria/aria.c
@@ -299,8 +299,8 @@ static int aria_copy(struct comp_dev *dev)
 
 	for (i = 0; i < c.frames; i++) {
 		for (channel = 0; channel < sink_c->stream.channels; channel++) {
-			cd->buf_in[frag] = *(int32_t *)audio_stream_read_frag_s32(&source_c->stream,
-										  frag);
+			cd->buf_in[frag] = *(int32_t *)deprecated_audio_stream_read_frag_s32
+					   (&sink_c->stream, frag);
 
 			frag++;
 		}
@@ -316,7 +316,7 @@ static int aria_copy(struct comp_dev *dev)
 	frag = 0;
 	for (i = 0; i < c.frames; i++) {
 		for (channel = 0; channel < sink_c->stream.channels; channel++) {
-			destp = audio_stream_write_frag_s32(&sink_c->stream, frag);
+			destp = deprecated_audio_stream_write_frag_s32(&sink_c->stream, frag);
 			*destp = cd->buf_out[frag];
 
 			frag++;

--- a/src/audio/crossover/crossover_generic.c
+++ b/src/audio/crossover/crossover_generic.c
@@ -99,11 +99,11 @@ static void crossover_s16_default_pass(const struct comp_dev *dev,
 	int n = source_stream->channels * frames;
 
 	for (i = 0; i < n; i++) {
-		x = audio_stream_read_frag_s16(source_stream, i);
+		x = deprecated_audio_stream_read_frag_s16(source_stream, i);
 		for (j = 0; j < num_sinks; j++) {
 			if (!sinks[j])
 				continue;
-			y = audio_stream_write_frag_s16((&sinks[j]->stream), i);
+			y = deprecated_audio_stream_write_frag_s16((&sinks[j]->stream), i);
 			*y = *x;
 		}
 	}
@@ -123,11 +123,11 @@ static void crossover_s32_default_pass(const struct comp_dev *dev,
 	int n = source_stream->channels * frames;
 
 	for (i = 0; i < n; i++) {
-		x = audio_stream_read_frag_s32(source_stream, i);
+		x = deprecated_audio_stream_read_frag_s32(source_stream, i);
 		for (j = 0; j < num_sinks; j++) {
 			if (!sinks[j])
 				continue;
-			y = audio_stream_write_frag_s32((&sinks[j]->stream), i);
+			y = deprecated_audio_stream_write_frag_s32((&sinks[j]->stream), i);
 			*y = *x;
 		}
 	}
@@ -155,15 +155,14 @@ static void crossover_s16_default(const struct comp_dev *dev,
 		idx = ch;
 		state = &cd->state[ch];
 		for (i = 0; i < frames; i++) {
-			x = audio_stream_read_frag_s16(source_stream, idx);
+			x = deprecated_audio_stream_read_frag_s16(source_stream, idx);
 			cd->crossover_split(*x << 16, out, state);
 
 			for (j = 0; j < num_sinks; j++) {
 				if (!sinks[j])
 					continue;
 				sink_stream = &sinks[j]->stream;
-				y = audio_stream_write_frag_s16(sink_stream,
-								idx);
+				y = deprecated_audio_stream_write_frag_s16(sink_stream, idx);
 				*y = sat_int16(Q_SHIFT_RND(out[j], 31, 15));
 			}
 
@@ -194,15 +193,14 @@ static void crossover_s24_default(const struct comp_dev *dev,
 		idx = ch;
 		state = &cd->state[ch];
 		for (i = 0; i < frames; i++) {
-			x = audio_stream_read_frag_s32(source_stream, idx);
+			x = deprecated_audio_stream_read_frag_s32(source_stream, idx);
 			cd->crossover_split(*x << 8, out, state);
 
 			for (j = 0; j < num_sinks; j++) {
 				if (!sinks[j])
 					continue;
 				sink_stream = &sinks[j]->stream;
-				y = audio_stream_write_frag_s32(sink_stream,
-								idx);
+				y = deprecated_audio_stream_write_frag_s32(sink_stream, idx);
 				*y = sat_int24(Q_SHIFT_RND(out[j], 31, 23));
 			}
 
@@ -233,15 +231,14 @@ static void crossover_s32_default(const struct comp_dev *dev,
 		idx = ch;
 		state = &cd->state[0];
 		for (i = 0; i < frames; i++) {
-			x = audio_stream_read_frag_s32(source_stream, idx);
+			x = deprecated_audio_stream_read_frag_s32(source_stream, idx);
 			cd->crossover_split(*x, out, state);
 
 			for (j = 0; j < num_sinks; j++) {
 				if (!sinks[j])
 					continue;
 				sink_stream = &sinks[j]->stream;
-				y = audio_stream_write_frag_s32(sink_stream,
-								idx);
+				y = deprecated_audio_stream_write_frag_s32(sink_stream, idx);
 				*y = out[j];
 			}
 

--- a/src/audio/igo_nr/igo_nr.c
+++ b/src/audio/igo_nr/igo_nr.c
@@ -88,12 +88,13 @@ static void igo_nr_capture_s16(struct comp_data *cd,
 		for (j = 0; j < nch; j++) {
 			if (j == cd->config.active_channel_idx)
 				continue;
-			x = audio_stream_read_frag_s16(source, idx_in + j);
-			y = audio_stream_write_frag_s16(sink, idx_in + j);
+			x = deprecated_audio_stream_read_frag_s16(source, idx_in + j);
+			y = deprecated_audio_stream_write_frag_s16(sink, idx_in + j);
 			*y = (*x);
 		}
 
-		x = audio_stream_read_frag_s16(source, idx_in + cd->config.active_channel_idx);
+		x = deprecated_audio_stream_read_frag_s16(source,
+							  idx_in + cd->config.active_channel_idx);
 		cd->in[i] = (*x);
 
 		idx_in += nch;
@@ -103,7 +104,8 @@ static void igo_nr_capture_s16(struct comp_data *cd,
 
 	/* Interleave write the processed data into active output channel. */
 	for (i = 0; i < frames; i++) {
-		y = audio_stream_write_frag_s16(sink, idx_out + cd->config.active_channel_idx);
+		y = deprecated_audio_stream_write_frag_s16(sink,
+							   idx_out + cd->config.active_channel_idx);
 		*y = (cd->out[i]);
 
 #if CONFIG_DEBUG
@@ -113,7 +115,7 @@ static void igo_nr_capture_s16(struct comp_data *cd,
 		else
 			dbg_ch_idx = cd->config.active_channel_idx + 1;
 		if (dbg_en) {
-			y = audio_stream_write_frag_s16(sink, idx_out + dbg_ch_idx);
+			y = deprecated_audio_stream_write_frag_s16(sink, idx_out + dbg_ch_idx);
 			*y = (cd->in[i]);
 		}
 #endif
@@ -147,12 +149,13 @@ static void igo_nr_capture_s24(struct comp_data *cd,
 		for (j = 0; j < nch; j++) {
 			if (j == cd->config.active_channel_idx)
 				continue;
-			x = audio_stream_read_frag_s32(source, idx_in + j);
-			y = audio_stream_write_frag_s32(sink, idx_in + j);
+			x = deprecated_audio_stream_read_frag_s32(source, idx_in + j);
+			y = deprecated_audio_stream_write_frag_s32(sink, idx_in + j);
 			*y = (*x);
 		}
 
-		x = audio_stream_read_frag_s32(source, idx_in + cd->config.active_channel_idx);
+		x = deprecated_audio_stream_read_frag_s32(source,
+							  idx_in + cd->config.active_channel_idx);
 		cd->in[i] = Q_SHIFT_RND(*x, 24, 16);
 
 		idx_in += nch;
@@ -162,7 +165,8 @@ static void igo_nr_capture_s24(struct comp_data *cd,
 
 	/* Interleave write the processed data into active output channel. */
 	for (i = 0; i < frames; i++) {
-		y = audio_stream_write_frag_s32(sink, idx_out + cd->config.active_channel_idx);
+		y = deprecated_audio_stream_write_frag_s32(sink,
+							   idx_out + cd->config.active_channel_idx);
 		*y = (cd->out[i]) << 8;
 
 #if CONFIG_DEBUG
@@ -172,7 +176,7 @@ static void igo_nr_capture_s24(struct comp_data *cd,
 		else
 			dbg_ch_idx = cd->config.active_channel_idx + 1;
 		if (dbg_en) {
-			y = audio_stream_write_frag_s32(sink, idx_out + dbg_ch_idx);
+			y = deprecated_audio_stream_write_frag_s32(sink, idx_out + dbg_ch_idx);
 			*y = (cd->in[i]) << 8;
 		}
 #endif
@@ -205,12 +209,13 @@ static void igo_nr_capture_s32(struct comp_data *cd,
 		for (j = 0; j < nch; j++) {
 			if (j == cd->config.active_channel_idx)
 				continue;
-			x = audio_stream_read_frag_s32(source, idx_in + j);
-			y = audio_stream_write_frag_s32(sink, idx_in + j);
+			x = deprecated_audio_stream_read_frag_s32(source, idx_in + j);
+			y = deprecated_audio_stream_write_frag_s32(sink, idx_in + j);
 			*y = (*x);
 		}
 
-		x = audio_stream_read_frag_s32(source, idx_in + cd->config.active_channel_idx);
+		x = deprecated_audio_stream_read_frag_s32(source,
+							  idx_in + cd->config.active_channel_idx);
 		cd->in[i] = Q_SHIFT_RND(*x, 32, 16);
 
 		idx_in += nch;
@@ -220,7 +225,8 @@ static void igo_nr_capture_s32(struct comp_data *cd,
 
 	/* Interleave write the processed data into active output channel. */
 	for (i = 0; i < frames; i++) {
-		y = audio_stream_write_frag_s32(sink, idx_out + cd->config.active_channel_idx);
+		y = deprecated_audio_stream_write_frag_s32(sink,
+							   idx_out + cd->config.active_channel_idx);
 		*y = (cd->out[i]) << 16;
 
 #if CONFIG_DEBUG
@@ -230,7 +236,7 @@ static void igo_nr_capture_s32(struct comp_data *cd,
 		else
 			dbg_ch_idx = cd->config.active_channel_idx + 1;
 		if (dbg_en) {
-			y = audio_stream_write_frag_s32(sink, idx_out + dbg_ch_idx);
+			y = deprecated_audio_stream_write_frag_s32(sink, idx_out + dbg_ch_idx);
 			*y = (cd->in[i]) << 16;
 		}
 #endif

--- a/src/audio/smart_amp/smart_amp_generic.c
+++ b/src/audio/smart_amp/smart_amp_generic.c
@@ -40,8 +40,8 @@ static void smart_amp_s16_ff_default(const struct comp_dev *dev,
 	for (ch = 0; ch < nch; ch++) {
 		idx = ch;
 		for (i = 0; i < frames; i++) {
-			x = audio_stream_read_frag_s16(source, idx);
-			y = audio_stream_read_frag_s16(sink, idx);
+			x = deprecated_audio_stream_read_frag_s16(source, idx);
+			y = deprecated_audio_stream_read_frag_s16(sink, idx);
 			tmp = smart_amp_ff_generic(*x << 16);
 			*y = sat_int16(Q_SHIFT_RND(tmp, 31, 15));
 			idx += nch;
@@ -68,8 +68,8 @@ static void smart_amp_s24_ff_default(const struct comp_dev *dev,
 	for (ch = 0; ch < nch; ch++) {
 		idx = ch;
 		for (i = 0; i < frames; i++) {
-			x = audio_stream_read_frag_s32(source, idx);
-			y = audio_stream_read_frag_s32(sink, idx);
+			x = deprecated_audio_stream_read_frag_s32(source, idx);
+			y = deprecated_audio_stream_read_frag_s32(sink, idx);
 			tmp = smart_amp_ff_generic(*x << 8);
 			*y = sat_int24(Q_SHIFT_RND(tmp, 31, 23));
 			idx += nch;
@@ -95,8 +95,8 @@ static void smart_amp_s32_ff_default(const struct comp_dev *dev,
 	for (ch = 0; ch < nch; ch++) {
 		idx = ch;
 		for (i = 0; i < frames; i++) {
-			x = audio_stream_read_frag_s32(source, idx);
-			y = audio_stream_read_frag_s32(sink, idx);
+			x = deprecated_audio_stream_read_frag_s32(source, idx);
+			y = deprecated_audio_stream_read_frag_s32(sink, idx);
 			*y = smart_amp_ff_generic(*x);
 			idx += nch;
 		}
@@ -120,7 +120,7 @@ static void smart_amp_s16_fb_default(const struct comp_dev *dev,
 	for (ch = 0; ch < nch; ch++) {
 		idx = ch;
 		for (i = 0; i < frames; i++) {
-			x = audio_stream_read_frag_s16(feedback, idx);
+			x = deprecated_audio_stream_read_frag_s16(feedback, idx);
 			smart_amp_fb_generic(*x << 16);
 			idx += nch;
 		}
@@ -144,7 +144,7 @@ static void smart_amp_s24_fb_default(const struct comp_dev *dev,
 	for (ch = 0; ch < nch; ch++) {
 		idx = ch;
 		for (i = 0; i < frames; i++) {
-			x = audio_stream_read_frag_s32(feedback, idx);
+			x = deprecated_audio_stream_read_frag_s32(feedback, idx);
 			smart_amp_fb_generic(*x << 8);
 			idx += nch;
 		}
@@ -168,7 +168,7 @@ static void smart_amp_s32_fb_default(const struct comp_dev *dev,
 	for (ch = 0; ch < nch; ch++) {
 		idx = ch;
 		for (i = 0; i < frames; i++) {
-			x = audio_stream_read_frag_s32(feedback, idx);
+			x = deprecated_audio_stream_read_frag_s32(feedback, idx);
 			smart_amp_ff_generic(*x);
 			idx += nch;
 		}

--- a/src/audio/smart_amp/smart_amp_maxim_dsm.c
+++ b/src/audio/smart_amp/smart_amp_maxim_dsm.c
@@ -600,8 +600,7 @@ static int smart_amp_get_buffer(int32_t *buf, uint32_t frames,
 					continue;
 				index = in_frag + chan_map[ch];
 				input.buf16 =
-					audio_stream_read_frag_s16(stream,
-								   index);
+					deprecated_audio_stream_read_frag_s16(stream, index);
 				output.buf16[num_ch * idx + ch] = *input.buf16;
 			}
 			in_frag += stream->channels;
@@ -615,8 +614,7 @@ static int smart_amp_get_buffer(int32_t *buf, uint32_t frames,
 					continue;
 				index = in_frag + chan_map[ch];
 				input.buf32 =
-					audio_stream_read_frag_s32(stream,
-								   index);
+					deprecated_audio_stream_read_frag_s32(stream, index);
 				output.buf32[num_ch * idx + ch] = *input.buf32;
 			}
 			in_frag += stream->channels;
@@ -651,8 +649,7 @@ static int smart_amp_put_buffer(int32_t *buf, uint32_t frames,
 					continue;
 				}
 				output.buf16 =
-					audio_stream_write_frag_s16(stream,
-								    out_frag);
+					deprecated_audio_stream_write_frag_s16(stream, out_frag);
 				*output.buf16 = input.buf16[num_ch_in * idx + ch];
 				out_frag++;
 			}
@@ -667,8 +664,7 @@ static int smart_amp_put_buffer(int32_t *buf, uint32_t frames,
 					continue;
 				}
 				output.buf32 =
-					audio_stream_write_frag_s32(stream,
-								    out_frag);
+					deprecated_audio_stream_write_frag_s32(stream, out_frag);
 				*output.buf32 = input.buf32[num_ch_in * idx + ch];
 				out_frag++;
 			}

--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -99,25 +99,33 @@ struct audio_stream {
 	audio_stream_get_frag(buffer, (buffer)->r_ptr, idx, size)
 
 /**
- * Retrieves readable address of a signed 16-bit sample at specified index.
+ * Retrieves readable address of a signed 16-bit sample at specified index. Use
+ * only to get initial buffer pointer.
  * @param buffer Buffer.
  * @param idx Index of sample.
  * @return Pointer to the sample.
  *
  * @see audio_stream_get_frag().
  */
-#define audio_stream_read_frag_s16(buffer, idx) \
+#define audio_stream_read_initial_frag_s16(buffer, idx) \
+	audio_stream_get_frag(buffer, (buffer)->r_ptr, idx, sizeof(int16_t))
+
+#define deprecated_audio_stream_read_frag_s16(buffer, idx) \
 	audio_stream_get_frag(buffer, (buffer)->r_ptr, idx, sizeof(int16_t))
 
 /**
- * Retrieves readable address of a signed 32-bit sample at specified index.
+ * Retrieves readable address of a signed 32-bit sample at specified index. Use
+ * only to get initial buffer pointer.
  * @param buffer Buffer.
  * @param idx Index of sample.
  * @return Pointer to the sample.
  *
  * @see audio_stream_get_frag().
  */
-#define audio_stream_read_frag_s32(buffer, idx) \
+#define audio_stream_read_initial_frag_s32(buffer, idx) \
+	audio_stream_get_frag(buffer, (buffer)->r_ptr, idx, sizeof(int32_t))
+
+#define deprecated_audio_stream_read_frag_s32(buffer, idx) \
 	audio_stream_get_frag(buffer, (buffer)->r_ptr, idx, sizeof(int32_t))
 
 /**
@@ -142,25 +150,33 @@ struct audio_stream {
 	audio_stream_get_frag(buffer, (buffer)->w_ptr, idx, size)
 
 /**
- * Retrieves writeable address of a signed 16-bit sample at specified index.
+ * Retrieves writeable address of a signed 16-bit sample at specified index. Use
+ * only to get initial buffer pointer.
  * @param buffer Buffer.
  * @param idx Index of sample.
  * @return Pointer to the space for sample.
  *
  * @see audio_stream_get_frag().
  */
-#define audio_stream_write_frag_s16(buffer, idx) \
+#define audio_stream_write_initial_frag_s16(buffer, idx) \
+	audio_stream_get_frag(buffer, (buffer)->w_ptr, idx, sizeof(int16_t))
+
+#define deprecated_audio_stream_write_frag_s16(buffer, idx) \
 	audio_stream_get_frag(buffer, (buffer)->w_ptr, idx, sizeof(int16_t))
 
 /**
- * Retrieves writeable address of a signed 32-bit sample at specified index.
+ * Retrieves writeable address of a signed 32-bit sample at specified index. Use
+ * only to get initial buffer pointer.
  * @param buffer Buffer.
  * @param idx Index of sample.
  * @return Pointer to the space for sample.
  *
  * @see audio_stream_get_frag().
  */
-#define audio_stream_write_frag_s32(buffer, idx) \
+#define audio_stream_write_initial_frag_s32(buffer, idx) \
+	audio_stream_get_frag(buffer, (buffer)->w_ptr, idx, sizeof(int32_t))
+
+#define deprecated_audio_stream_write_frag_s32(buffer, idx) \
 	audio_stream_get_frag(buffer, (buffer)->w_ptr, idx, sizeof(int32_t))
 
 /**

--- a/src/samples/audio/detect_test.c
+++ b/src/samples/audio/detect_test.c
@@ -179,8 +179,8 @@ static void default_detect_test(struct comp_dev *dev,
 	/* perform detection within current period */
 	for (sample = 0; sample < count && !cd->detected; ++sample) {
 		src = (valid_bits == 16U) ?
-		      audio_stream_read_frag_s16(source, sample) :
-		      audio_stream_read_frag_s32(source, sample);
+		      deprecated_audio_stream_read_frag_s16(source, sample) :
+		      deprecated_audio_stream_read_frag_s32(source, sample);
 		if (valid_bits > 16U) {
 			diff = abs(*(int32_t *)src) - abs(cd->activation);
 		} else {

--- a/src/samples/audio/kwd_nn_detect_test.c
+++ b/src/samples/audio/kwd_nn_detect_test.c
@@ -47,8 +47,8 @@ void kwd_nn_detect_test(struct comp_dev *dev,
 	/* perform detection within current period */
 	for (sample = 0; sample < count && !test_keyword_get_detected(dev); ++sample) {
 		src = (test_keyword_get_sample_valid_bytes(dev) * 8 == 16U) ?
-			audio_stream_read_frag_s16(source, sample) :
-			audio_stream_read_frag_s32(source, sample);
+			deprecated_audio_stream_read_frag_s16(source, sample) :
+			deprecated_audio_stream_read_frag_s32(source, sample);
 		if (test_keyword_get_input_size(dev) < KWD_NN_IN_BUFF_SIZE) {
 			if (test_keyword_get_sample_valid_bytes(dev) == 16U)
 				test_keyword_set_input_elem(dev,

--- a/src/samples/audio/smart_amp_test.c
+++ b/src/samples/audio/smart_amp_test.c
@@ -348,11 +348,10 @@ static int smart_amp_process_s16(struct comp_dev *dev,
 	for (i = 0; i < frames; i++) {
 		for (j = 0 ; j < sad->out_channels; j++) {
 			if (chan_map[j] != -1) {
-				src = audio_stream_read_frag_s16(source,
-								 in_frag +
-								 chan_map[j]);
-				dest = audio_stream_write_frag_s16(sink,
-								   out_frag);
+				src = deprecated_audio_stream_read_frag_s16(source,
+									    in_frag + chan_map[j]);
+				dest = deprecated_audio_stream_write_frag_s16(sink,
+									      out_frag);
 				*dest = *src;
 			}
 			out_frag++;
@@ -380,11 +379,10 @@ static int smart_amp_process_s32(struct comp_dev *dev,
 	for (i = 0; i < frames; i++) {
 		for (j = 0 ; j < sad->out_channels; j++) {
 			if (chan_map[j] != -1) {
-				src = audio_stream_read_frag_s32(source,
-								 in_frag +
-								 chan_map[j]);
-				dest = audio_stream_write_frag_s32(sink,
-								   out_frag);
+				src = deprecated_audio_stream_read_frag_s32(source,
+									    in_frag + chan_map[j]);
+				dest = deprecated_audio_stream_write_frag_s32(sink,
+									      out_frag);
 				*dest = *src;
 			}
 			out_frag++;

--- a/test/cmocka/src/audio/eq_iir/eq_iir_process.c
+++ b/test/cmocka/src/audio/eq_iir/eq_iir_process.c
@@ -177,7 +177,7 @@ static void fill_source_s16(struct test_data *td, int frames_max)
 	frames = MIN(audio_stream_get_free_frames(ss), frames_max);
 	samples = frames * ss->channels;
 	for (i = 0; i < samples; i++) {
-		x = audio_stream_write_frag_s16(ss, i);
+		x = deprecated_audio_stream_write_frag_s16(ss, i);
 		*x = sat_int16(Q_SHIFT_RND(chirp_2ch[buffer_fill_data.idx++], 31, 15));
 		samples_processed++;
 		if (buffer_fill_data.idx == CHIRP_2CH_LENGTH) {
@@ -210,7 +210,7 @@ static void verify_sink_s16(struct test_data *td)
 	frames = audio_stream_get_avail_frames(ss);
 	samples = frames * ss->channels;
 	for (i = 0; i < samples; i++) {
-		x = audio_stream_read_frag_s16(ss, i);
+		x = deprecated_audio_stream_read_frag_s16(ss, i);
 		out = *x;
 		ref = sat_int16(Q_SHIFT_RND(chirp_iir_ref_2ch[buffer_verify_data.idx++], 31, 15));
 		delta = ref - out;
@@ -241,7 +241,7 @@ static void fill_source_s24(struct test_data *td, int frames_max)
 	frames = MIN(audio_stream_get_free_frames(ss), frames_max);
 	samples = frames * ss->channels;
 	for (i = 0; i < samples; i++) {
-		x = audio_stream_write_frag_s32(ss, i);
+		x = deprecated_audio_stream_write_frag_s32(ss, i);
 		*x = sat_int24(Q_SHIFT_RND(chirp_2ch[buffer_fill_data.idx++], 31, 23));
 		samples_processed++;
 		if (buffer_fill_data.idx == CHIRP_2CH_LENGTH) {
@@ -274,7 +274,7 @@ static void verify_sink_s24(struct test_data *td)
 	frames = audio_stream_get_avail_frames(ss);
 	samples = frames * ss->channels;
 	for (i = 0; i < samples; i++) {
-		x = audio_stream_read_frag_s32(ss, i);
+		x = deprecated_audio_stream_read_frag_s32(ss, i);
 		out = (*x << 8) >> 8; /* Make sure there's no 24 bit overflow */
 		ref = sat_int24(Q_SHIFT_RND(chirp_iir_ref_2ch[buffer_verify_data.idx++], 31, 23));
 		delta = ref - out;
@@ -305,7 +305,7 @@ static void fill_source_s32(struct test_data *td, int frames_max)
 	frames = MIN(audio_stream_get_free_frames(ss), frames_max);
 	samples = frames * ss->channels;
 	for (i = 0; i < samples; i++) {
-		x = audio_stream_write_frag_s32(ss, i);
+		x = deprecated_audio_stream_write_frag_s32(ss, i);
 		*x = chirp_2ch[buffer_fill_data.idx++];
 		samples_processed++;
 		if (buffer_fill_data.idx == CHIRP_2CH_LENGTH) {
@@ -338,7 +338,7 @@ static void verify_sink_s32(struct test_data *td)
 	frames = audio_stream_get_avail_frames(ss);
 	samples = frames * ss->channels;
 	for (i = 0; i < samples; i++) {
-		x = audio_stream_read_frag_s32(ss, i);
+		x = deprecated_audio_stream_read_frag_s32(ss, i);
 		out = *x;
 		ref = chirp_iir_ref_2ch[buffer_verify_data.idx++];
 		delta = (int64_t)ref - (int64_t)out;

--- a/test/cmocka/src/audio/selector/selector_test.c
+++ b/test/cmocka/src/audio/selector/selector_test.c
@@ -111,7 +111,7 @@ static void fill_source_s16(struct sel_test_state *sel_state)
 	int i;
 
 	for (i = 0; i < audio_stream_get_free_samples(stream); i++) {
-		w_ptr = audio_stream_write_frag_s16(stream, i);
+		w_ptr = deprecated_audio_stream_write_frag_s16(stream, i);
 		*w_ptr = i;
 	}
 
@@ -191,7 +191,7 @@ static void fill_source_s32(struct sel_test_state *sel_state)
 	int i;
 
 	for (i = 0; i < audio_stream_get_free_samples(stream); i++) {
-		w_ptr = audio_stream_write_frag_s32(stream, i);
+		w_ptr = deprecated_audio_stream_write_frag_s32(stream, i);
 		*w_ptr = i << 16;
 	}
 


### PR DESCRIPTION
The purpose of this patch is to highlight and discourage use of
not efficient audio stream functions.(the subsequent to PR #5726)

The functions audio_stream_read_frag_s16/32() and
audio_stream_write_frag_s16/32() cause high processing load when
used for every sample in copy() processing. This patch renames the
poor performing function usages with prefix deprecated.

The valid use of the same functions is enabled with renamed function
audio_stream_read/write_initial_frag_s16/32(). It is acceptable use to
get a buffer pointer once before the samples processing.

Signed-off-by: Andrula Song <xiaoyuan.song@intel.com>