### PR TITLE
module_adapter: add zephyr logging support

### DIFF
--- a/src/audio/module_adapter/module/generic.c
+++ b/src/audio/module_adapter/module/generic.c
@@ -13,6 +13,8 @@
 
 #include <sof/audio/module_adapter/module/generic.h>
 
+LOG_MODULE_DECLARE(module_adapter, CONFIG_SOF_LOG_LEVEL);
+
 /*****************************************************************************/
 /* Local helper functions						     */
 /*****************************************************************************/

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -21,6 +21,8 @@
 #include <limits.h>
 #include <stdint.h>
 
+LOG_MODULE_REGISTER(module_adapter, CONFIG_SOF_LOG_LEVEL);
+
 /**
  * \brief Create a module adapter component.
  * \param[in] drv - component driver pointer.


### PR DESCRIPTION
Add zephyr logging declares to module_adapter as it doesn't
compile otherwise when zephyr logging is enabled.

Signed-off-by: Jaska Uimonen <jaska.uimonen@intel.com>