### PR TITLE
host-zephyr: add zephyr logging support

### DIFF
--- a/src/audio/host-zephyr.c
+++ b/src/audio/host-zephyr.c
@@ -34,6 +34,8 @@
 
 static const struct comp_driver comp_host;
 
+LOG_MODULE_REGISTER(host_comp, CONFIG_SOF_LOG_LEVEL);
+
 /* 8b9d100c-6d78-418f-90a3-e0e805d0852b */
 DECLARE_SOF_RT_UUID("host", host_uuid, 0x8b9d100c, 0x6d78, 0x418f,
 		    0x90, 0xa3, 0xe0, 0xe8, 0x05, 0xd0, 0x85, 0x2b);


### PR DESCRIPTION
Add zephyr logging register to host as it doesn't compile otherwise when
zephyr logging is enabled.

Signed-off-by: Jaska Uimonen <jaska.uimonen@intel.com>