### PR TITLE
module-adapter: fix prohibitively verbose log message

### DIFF
--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -554,7 +554,7 @@ int module_adapter_copy(struct comp_dev *dev)
 	uint32_t min_free_frames = UINT_MAX;
 	int ret, i = 0;
 
-	comp_info(dev, "module_adapter_copy(): start");
+	comp_dbg(dev, "module_adapter_copy(): start");
 
 	source = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
 	sink = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);


### PR DESCRIPTION
module_adapter_copy() is typically called every millisecond for each copy. Issuing an "info"-level log statement with that frequency floods the log. Replace it with a "comp_dbg()."
