### PR TITLE
dai: groups: Add group ifdef also to ipc4 dai

### DIFF
--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -263,13 +263,14 @@ int dai_config(struct comp_dev *dev, struct ipc_config_dai *common_config,
 		return 0;
 	}
 
+#if CONFIG_COMP_DAI_GROUP
 	if (common_config->group_id) {
 		ret = dai_assign_group(dev, common_config->group_id);
 
 		if (ret)
 			return ret;
 	}
-
+#endif
 	/* do nothing for asking for channel free, for compatibility. */
 	if (dai_config_dma_channel(dev, spec_config) == DMA_CHAN_INVALID)
 		return 0;


### PR DESCRIPTION
ipc4 dai is missing the group ifdef, thus add it there.

Signed-off-by: Jaska Uimonen <jaska.uimonen@intel.com>