### PR TITLE
zephyr: panic: switch to __ASSERT_NO_MSG() for assert()

### DIFF
--- a/src/include/sof/debug/panic.h
+++ b/src/include/sof/debug/panic.h
@@ -34,11 +34,8 @@ void panic_dump(uint32_t p, struct sof_ipc_panic_info *panic_info,
 #include <kernel.h>
 #define panic(x) k_panic()
 
-#define assert(x) \
-	do {			\
-		if (!(x))	\
-			k_oops();\
-	} while (0)
+#define assert(x) __ASSERT_NO_MSG(x)
+
 /* To print the asserted expression on failure:
  *  #define assert(x) __ASSERT(x, #x)
  */


### PR DESCRIPTION
Continue the changes done in commit bc39c0e91284 ("Make Zephyr build
compatible with optional assert() with __unused") and switch
to use __ASSERT_NO_MSG() as implementation of assert() when SOF
is build with Zephyr.

This allows for build time control of asserts with standard
CONFIG_ASSERT option(s) and ensures same policy is used for asserts in
both Zephyr and SOF code.

This effectively disables assert checks in the default build for Zephyr,
improves performance of a typical single ll scheduled audio component by
0.08 MCPS. Performance was tested with the Intel Tiger Lake system,
build with XCC 12.0.8 as defined in sof/scripts/xtensa-build-zephyr.py.

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>