### PR TITLE
volume: free volume config data during free

### DIFF
--- a/src/audio/module_adapter/module/volume/volume.c
+++ b/src/audio/module_adapter/module/volume/volume.c
@@ -1331,8 +1331,13 @@ fail:
 static void volume_legacy_free(struct comp_dev *dev)
 {
 	struct processing_module *mod = comp_get_drvdata(dev);
+	struct module_data *md = &mod->priv;
+	struct module_config *cfg = &md->cfg;
 
 	comp_dbg(dev, "volume_legacy_free()");
+
+	if (cfg->data)
+		rfree(cfg->data);
 
 	volume_free(mod);
 


### PR DESCRIPTION
Free the memory allocated for volume config data in the free op.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>