### PR TITLE
topology1: sof-tgl-rt711-rt1308: add missing switch

### DIFF
--- a/tools/topology/topology1/sof-tgl-rt711-rt1308.m4
+++ b/tools/topology/topology1/sof-tgl-rt711-rt1308.m4
@@ -114,7 +114,7 @@ ifelse(PLATFORM, `adl', `
 
 # Low Latency capture pipeline 2 on PCM 1 using max 2 channels of s32le.
 # Schedule 48 frames per 1000us deadline with priority 0 on core 0
-PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
+PIPELINE_PCM_ADD(sof/pipe-volume-switch-capture.m4,
 	2, 1, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000)


### PR DESCRIPTION
For some reason we never added the switch in this topology, with leads
to a missing control when parsing UCM files

BugLink: https://github.com/thesofproject/sof/issues/5950
BugLink: https://github.com/alsa-project/alsa-ucm-conf/issues/179
Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>