### PR TITLE
Implement mclk always on feature

### DIFF
--- a/src/include/ipc/dai-intel.h
+++ b/src/include/ipc/dai-intel.h
@@ -60,6 +60,8 @@
 #define SOF_DAI_INTEL_SSP_CLKCTRL_MCLK_ES		BIT(6)
 /* bclk early start */
 #define SOF_DAI_INTEL_SSP_CLKCTRL_BCLK_ES		BIT(7)
+/* mclk always on */
+#define SOF_DAI_INTEL_SSP_CLKCTRL_MCLK_AON		BIT(8)
 
 /* DMIC max. four controllers for eight microphone channels */
 #define SOF_DAI_INTEL_DMIC_NUM_CTRL			4

--- a/src/include/kernel/abi.h
+++ b/src/include/kernel/abi.h
@@ -29,8 +29,8 @@
 
 /** \brief SOF ABI version major, minor and patch numbers */
 #define SOF_ABI_MAJOR 3
-#define SOF_ABI_MINOR 22
-#define SOF_ABI_PATCH 1
+#define SOF_ABI_MINOR 23
+#define SOF_ABI_PATCH 0
 
 /** \brief SOF ABI version number. Format within 32bit word is MMmmmppp */
 #define SOF_ABI_MAJOR_SHIFT	24

--- a/src/include/sof/drivers/ssp.h
+++ b/src/include/sof/drivers/ssp.h
@@ -232,6 +232,7 @@ extern const struct dai_driver ssp_driver;
 #define SSP_CLK_MCLK_ACTIVE	BIT(1)
 #define SSP_CLK_BCLK_ES_REQ	BIT(2)
 #define SSP_CLK_BCLK_ACTIVE	BIT(3)
+#define SSP_CLK_MCLK_AON_REQ	BIT(4)
 
 /* SSP private data */
 struct ssp_pdata {

--- a/tools/topology/topology1/platform/common/ssp.m4
+++ b/tools/topology/topology1/platform/common/ssp.m4
@@ -34,6 +34,8 @@ dnl SSP_CC_MCLK_ES 64 = (1 << 6)
 define(`SSP_CC_MCLK_ES', 64)
 dnl SSP_CC_BCLK_ES 128 = (1 << 7)
 define(`SSP_CC_BCLK_ES', 128)
+dnl SSP_CC_BCLK_ES 256 = (1 << 8)
+define(`SSP_CC_MCLK_AON', 256)
 
 dnl SSP_CONFIG_DATA(type, idx, valid bits, mclk_id, quirks, bclk_delay,
 dnl clks_control, pulse_width, padding)

--- a/tools/topology/topology1/sof-jsl-rt5682.m4
+++ b/tools/topology/topology1/sof-jsl-rt5682.m4
@@ -178,7 +178,7 @@ DAI_CONFIG(SSP, 0, 0, SSP0-Codec,
 		SSP_CLOCK(bclk, 2400000, codec_slave),
 		SSP_CLOCK(fsync, 48000, codec_slave),
 		SSP_TDM(2, 25, 3, 3),
-		SSP_CONFIG_DATA(SSP, 0, 24, 0, 0, 0, SSP_CC_BCLK_ES)))
+		SSP_CONFIG_DATA(SSP, 0, 24, 0, 0, 0, eval(SSP_CC_BCLK_ES | SSP_CC_MCLK_AON))))
 
 # SSP 1 (ID: 6)
 DAI_CONFIG(SSP, SPK_INDEX, 6, SPK_NAME,


### PR DESCRIPTION
We've got an issue report that there is pop noise when audio is paused on Chrome JSL chromebooks. After triage, the root cause is the commit d5840a920 ("ssp: move mclk request/release to pre_start and post_stop"). In the earliest design, mclk is enabled in set_config() function and not disabled. The commit changed the behavior and turns on the mclk only when there is audio playback/capture running.

I tried to enable the early mclk feature but it doesn't work. Codec vendor says "MCLK need turned on before power on codec function and turned off after power off codec function." which means the mclk needs to keep toggling when there is I2C activity. The early mclk disables the clock at hw_free which seems to be still too early.

In this PR I add the always-on function back as a feature. In this way we need to modify all topology files of rt5682 of all platforms. I wonder if we just modify the default behavior of mclk to keep always-on to avoid the modification to topology files?
