### PR TITLE
Please refet to https://github.com/zephyrproject-rtos/zephyr/pull/46880

### DIFF
--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -335,8 +335,8 @@ def west_init_update():
 	# fetching of (full 40-digits) SHAs; even SHAs not in origin but
 	# in forks! See the end of "git help fetch-pack".
 	#
-	# z_remote = "https://somewhere.else"
-	# z_ref = "pull/38374/head"
+	z_remote = "https://github.com/zephyrproject-rtos/zephyr"
+	z_ref = "pull/46880/head"
 	# z_ref = "cb9a279050c4e8ad4663ee78688d8e7de1cac953"
 
 	# SECURITY WARNING for reviewers: never allow unknown code from


### PR DESCRIPTION
I refine the cavstool.py to adapt our testing environment. Basically
it doesn't change the logic of the firmware loader itself. Submit
this to run test just in case.

Signed-off-by: Enjia Mai <enjia.mai@intel.com>