### PR TITLE
platform: mtk: add clib memory layout for mt8195

### DIFF
--- a/src/platform/mt8195/mt8195.x.in
+++ b/src/platform/mt8195/mt8195.x.in
@@ -346,6 +346,22 @@ SECTIONS
     _data_end = ABSOLUTE(.);
   } >sof_sram0 :sof_sram0_phdr
 
+  .clib.data : ALIGN(4)
+  {
+    _clib_data_start = ABSOLUTE(.);
+    *(.clib.data)
+    . = ALIGN (4);
+    _clib_data_end = ABSOLUTE(.);
+  } >sof_sram0 :sof_sram0_phdr
+
+  .clib.rodata : ALIGN(4)
+  {
+    _clib_rodata_start = ABSOLUTE(.);
+    *(.clib.rodata)
+    . = ALIGN (4);
+    _clib_rodata_end = ABSOLUTE(.);
+  } >sof_sram0 :sof_sram0_phdr
+
   .lit4 : ALIGN(4)
   {
     _lit4_start = ABSOLUTE(.);


### PR DESCRIPTION
Support clib data and rodata for mt8195.

Signed-off-by: YC Hung <yc.hung@mediatek.com>