### PR TITLE
[DO NOT MERGE] ipc4: base_fw: report non-zero LOG_BYTES_SIZE

### DIFF
--- a/src/audio/base_fw.c
+++ b/src/audio/base_fw.c
@@ -71,7 +71,7 @@ static int basefw_config(uint32_t *data_offset, char *data)
 
 	/* TODO: add log support */
 	tuple = next_tuple(tuple);
-	set_tuple_uint32(tuple, IPC4_TRACE_LOG_BYTES_FW_CFG, 0);
+	set_tuple_uint32(tuple, IPC4_TRACE_LOG_BYTES_FW_CFG, 1024);
 
 	tuple = next_tuple(tuple);
 	set_tuple_uint32(tuple, IPC4_MAX_PPL_CNT_FW_CFG, IPC4_MAX_PPL_COUNT);


### PR DESCRIPTION
To enable ipc4-mtrace in kernel driver, report a non-zero
log buffer size.

This is a temporary patch and needs to be revised before
merging.

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>