### PR TITLE
xtensa-build-zephyr: copy ALL cavstool*.py scripts

### DIFF
--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -538,14 +538,20 @@ def build_platforms():
 
 	src_dest_list += [(sof_logger_executable_to_copy, sof_logger_installed_file)]
 
-	src_dest_list += [(pathlib.Path(west_top) /
-			  "zephyr" / "soc" / "xtensa" / "intel_adsp" / "tools" / "cavstool.py",
-			  tools_output_dir)]
+	# Append future files to `src_dest_list` here (but prefer
+	# copying entire directories; more flexible)
 
 	for _src, _dst in src_dest_list:
 		os.makedirs(os.path.dirname(_dst), exist_ok=True)
 		# looses file owner and group - file is commonly accessible
 		shutil.copy2(str(_src), str(_dst))
+
+	# cavstool and friends
+	shutil.copytree(pathlib.Path(west_top) /
+			  "zephyr" / "soc" / "xtensa" / "intel_adsp" / "tools",
+			tools_output_dir,
+			symlinks=True, ignore_dangling_symlinks=True, dirs_exist_ok=True)
+
 
 def run_clone_mode():
 	if find_west_workspace():


### PR DESCRIPTION
Quoting https://github.com/zephyrproject-rtos/zephyr/pull/46880#pullrequestreview-1020096140

> No complaints about the code here. Just a general comment:

> I do worry that as cavstool grows features (first to add the test
> integration support, now the new client/server architecture) that
> we're obscuring the core code that does the loading behind a big
> facade of other stuff that also has to be run In Just The Right Way to
> make things work. That impedes development flow. It might be time to
> split the code up so that a minimal "just run this file please" tool
> can continue to be maintained.`

Long story short: `cavstool.py` is likely to be split in the future.

To be readi-er, copy the entire `zephyr/soc/xtensa/intel_adsp/tools/`
directory.

Copying the entire directory also copies scripts that will never be used
on a test device like `cavstool_client.py`. They're small Python script
sso we don't care: keep it simple.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>