### PR TITLE
ipc4: add basic ipc4 support in selector

### DIFF
--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -36,11 +36,11 @@
 #include <stddef.h>
 #include <stdint.h>
 
-static const struct comp_driver comp_selector;
-
 LOG_MODULE_REGISTER(selector, CONFIG_SOF_LOG_LEVEL);
 
 #if CONFIG_IPC_MAJOR_3
+static const struct comp_driver comp_selector;
+
 /* 55a88ed5-3d18-46ca-88f1-0ee6eae9930f */
 DECLARE_SOF_RT_UUID("selector", selector_uuid, 0x55a88ed5, 0x3d18, 0x46ca,
 		    0x88, 0xf1, 0x0e, 0xe6, 0xea, 0xe9, 0x93, 0x0f);
@@ -52,194 +52,6 @@ DECLARE_SOF_RT_UUID("selector", selector_uuid, 0x32fe92c1, 0x1e17, 0x4fc2,
 #endif
 
 DECLARE_TR_CTX(selector_tr, SOF_UUID(selector_uuid), LOG_LEVEL_INFO);
-
-/**
- * \brief Creates selector component.
- *
- * \return Pointer to selector base component device.
- */
-#if CONFIG_IPC_MAJOR_3
-static struct comp_dev *selector_new(const struct comp_driver *drv,
-				     struct comp_ipc_config *config,
-				     void *spec)
-{
-	struct ipc_config_process *ipc_process = spec;
-	size_t bs = ipc_process->size;
-	struct comp_dev *dev;
-	struct comp_data *cd;
-	int ret;
-
-	comp_cl_info(&comp_selector, "selector_new()");
-
-	dev = comp_alloc(drv, sizeof(*dev));
-	if (!dev)
-		return NULL;
-	dev->ipc_config = *config;
-
-	cd = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM, sizeof(*cd));
-	if (!cd) {
-		rfree(dev);
-		return NULL;
-	}
-
-	comp_set_drvdata(dev, cd);
-
-	ret = memcpy_s(&cd->config, sizeof(cd->config), ipc_process->data, bs);
-	assert(!ret);
-
-	dev->state = COMP_STATE_READY;
-	return dev;
-}
-
-static void set_selector_params(struct comp_dev *dev,
-				struct sof_ipc_stream_params *params)
-{
-}
-#else
-static void build_config(struct comp_data *cd)
-{
-	enum sof_ipc_frame valid_format;
-
-	cd->source_format = cd->md.base_cfg.audio_fmt.depth;
-	audio_stream_fmt_conversion(cd->md.base_cfg.audio_fmt.depth,
-				    cd->md.base_cfg.audio_fmt.valid_bit_depth,
-				    &cd->source_format,
-				    &valid_format,
-				    cd->md.base_cfg.audio_fmt.s_type);
-
-	audio_stream_fmt_conversion(cd->md.output_format.depth,
-				    cd->md.output_format.valid_bit_depth,
-				    &cd->sink_format,
-				    &valid_format,
-				    cd->md.output_format.s_type);
-
-	cd->config.in_channels_count = cd->md.base_cfg.audio_fmt.channels_count;
-	cd->config.out_channels_count = cd->md.output_format.channels_count;
-}
-
-static struct comp_dev *selector_new(const struct comp_driver *drv,
-				     struct comp_ipc_config *config,
-				     void *spec)
-{
-	struct micsel_data *ipc_process = spec;
-	struct comp_dev *dev;
-	struct comp_data *cd;
-	int ret;
-
-	comp_cl_info(&comp_selector, "selector_new()");
-
-	dev = comp_alloc(drv, sizeof(*dev));
-	if (!dev)
-		return NULL;
-	dev->ipc_config = *config;
-
-	cd = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM, sizeof(*cd));
-	if (!cd) {
-		rfree(dev);
-		return NULL;
-	}
-
-	comp_set_drvdata(dev, cd);
-
-	ret = memcpy_s(&cd->md, sizeof(cd->md), ipc_process, sizeof(*ipc_process));
-	assert(!ret);
-
-	build_config(cd);
-
-	dev->state = COMP_STATE_READY;
-	return dev;
-}
-
-static void set_selector_params(struct comp_dev *dev,
-				struct sof_ipc_stream_params *params)
-{
-	struct comp_data *cd = comp_get_drvdata(dev);
-	struct comp_buffer __sparse_cache *source_b;
-	struct comp_buffer __sparse_cache *source;
-	struct ipc4_audio_format *out_fmt;
-	struct list_item *sink_list;
-	int i;
-
-	if (dev->direction == SOF_IPC_STREAM_PLAYBACK)
-		params->channels = cd->config.in_channels_count;
-	else
-		params->channels = cd->config.out_channels_count;
-
-	params->rate = cd->md.base_cfg.audio_fmt.sampling_frequency;
-	params->frame_fmt = cd->source_format;
-
-	out_fmt = &cd->md.output_format;
-	for (i = 0; i < SOF_IPC_MAX_CHANNELS; i++)
-		params->chmap[i] = (out_fmt->ch_map >> i * 4) & 0xf;
-
-	/* update each sink format */
-	list_for_item(sink_list, &dev->bsink_list) {
-		struct comp_buffer *sink_b =
-			container_of(sink_list, struct comp_buffer, source_list);
-		struct comp_buffer __sparse_cache *sink = buffer_acquire(sink_b);
-
-		sink->stream.channels = params->channels;
-		sink->stream.rate = params->rate;
-		audio_stream_fmt_conversion(out_fmt->depth,
-					    out_fmt->valid_bit_depth,
-					    &sink->stream.frame_fmt,
-					    &sink->stream.valid_sample_fmt,
-					    out_fmt->s_type);
-
-		sink->buffer_fmt = out_fmt->interleaving_style;
-
-		for (i = 0; i < SOF_IPC_MAX_CHANNELS; i++)
-			sink->chmap[i] = (out_fmt->ch_map >> i * 4) & 0xf;
-
-		sink->hw_params_configured = true;
-		buffer_release(sink);
-	}
-
-	/* update the source format
-	 * used only for rare cases where two pipelines are connected by a shared
-	 * buffer and 2 copiers, this will set source format only for shared buffers
-	 * for a short time when the second pipeline already started
-	 * and the first one is not ready yet along with sink buffers params
-	 */
-	source_b = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
-	source = buffer_acquire(source_b);
-	if (!source->hw_params_configured) {
-		struct ipc4_audio_format *in_fmt;
-
-		in_fmt = &cd->md.base_cfg.audio_fmt;
-		source->stream.channels = in_fmt->channels_count;
-		source->stream.rate = in_fmt->sampling_frequency;
-		audio_stream_fmt_conversion(in_fmt->depth,
-					    in_fmt->valid_bit_depth,
-					    &source->stream.frame_fmt,
-					    &source->stream.valid_sample_fmt,
-					    in_fmt->s_type);
-
-		source->buffer_fmt = in_fmt->interleaving_style;
-
-		for (i = 0; i < SOF_IPC_MAX_CHANNELS; i++)
-			source->chmap[i] = (in_fmt->ch_map >> i * 4) & 0xf;
-
-		source->hw_params_configured = true;
-	}
-
-	buffer_release(source);
-}
-#endif
-
-/**
- * \brief Frees selector component.
- * \param[in,out] dev Selector base component device.
- */
-static void selector_free(struct comp_dev *dev)
-{
-	struct comp_data *cd = comp_get_drvdata(dev);
-
-	comp_info(dev, "selector_free()");
-
-	rfree(cd);
-	rfree(dev);
-}
 
 static int selector_verify_params(struct comp_dev *dev,
 				  struct sof_ipc_stream_params *params)
@@ -353,6 +165,53 @@ static int selector_verify_params(struct comp_dev *dev,
 	return 0;
 }
 
+#if CONFIG_IPC_MAJOR_3
+static struct comp_dev *selector_new(const struct comp_driver *drv,
+				     struct comp_ipc_config *config,
+				     void *spec)
+{
+	struct ipc_config_process *ipc_process = spec;
+	size_t bs = ipc_process->size;
+	struct comp_dev *dev;
+	struct comp_data *cd;
+	int ret;
+
+	comp_cl_info(&comp_selector, "selector_new()");
+
+	dev = comp_alloc(drv, sizeof(*dev));
+	if (!dev)
+		return NULL;
+	dev->ipc_config = *config;
+
+	cd = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM, sizeof(*cd));
+	if (!cd) {
+		rfree(dev);
+		return NULL;
+	}
+
+	comp_set_drvdata(dev, cd);
+
+	ret = memcpy_s(&cd->config, sizeof(cd->config), ipc_process->data, bs);
+	assert(!ret);
+
+	dev->state = COMP_STATE_READY;
+	return dev;
+}
+
+/**
+ * \brief Frees selector component.
+ * \param[in,out] dev Selector base component device.
+ */
+static void selector_free(struct comp_dev *dev)
+{
+	struct comp_data *cd = comp_get_drvdata(dev);
+
+	comp_info(dev, "selector_free()");
+
+	rfree(cd);
+	rfree(dev);
+}
+
 /**
  * \brief Sets selector component audio stream parameters.
  * \param[in,out] dev Selector base component device.
@@ -367,8 +226,6 @@ static int selector_params(struct comp_dev *dev,
 
 	comp_info(dev, "selector_params()");
 
-	set_selector_params(dev, params);
-
 	err = selector_verify_params(dev, params);
 	if (err < 0) {
 		comp_err(dev, "selector_params(): pcm params verification failed.");
@@ -378,7 +235,6 @@ static int selector_params(struct comp_dev *dev,
 	return 0;
 }
 
-#if CONFIG_IPC_MAJOR_3
 /**
  * \brief Sets selector control command.
  * \param[in,out] dev Selector base component device.
@@ -487,29 +343,6 @@ static int selector_cmd(struct comp_dev *dev, int cmd, void *data,
 
 	return ret;
 }
-#else
-static int selector_set_large_config(struct comp_dev *dev,
-				     uint32_t param_id,
-				     bool first_block,
-				     bool last_block,
-				     uint32_t data_offset,
-				     char *data)
-{
-	/* ToDo: add support */
-	return 0;
-}
-
-static int selector_get_large_config(struct comp_dev *dev,
-				     uint32_t param_id,
-				     bool first_block,
-				     bool last_block,
-				     uint32_t *data_offset,
-				     char *data)
-{
-	/* ToDo: add support */
-	return 0;
-}
-#endif
 
 /**
  * \brief Sets component state.
@@ -718,12 +551,7 @@ static const struct comp_driver comp_selector = {
 		.create		= selector_new,
 		.free		= selector_free,
 		.params		= selector_params,
-#if CONFIG_IPC_MAJOR_4
-		.set_large_config = selector_set_large_config,
-		.get_large_config = selector_get_large_config,
-#else
 		.cmd		= selector_cmd,
-#endif
 		.trigger	= selector_trigger,
 		.copy		= selector_copy,
 		.prepare	= selector_prepare,
@@ -743,3 +571,327 @@ UT_STATIC void sys_comp_selector_init(void)
 }
 
 DECLARE_MODULE(sys_comp_selector_init);
+#else
+static void build_config(struct comp_data *cd)
+{
+	enum sof_ipc_frame valid_format;
+
+	cd->source_format = cd->md.base_cfg.audio_fmt.depth;
+	audio_stream_fmt_conversion(cd->md.base_cfg.audio_fmt.depth,
+				    cd->md.base_cfg.audio_fmt.valid_bit_depth,
+				    &cd->source_format,
+				    &valid_format,
+				    cd->md.base_cfg.audio_fmt.s_type);
+
+	audio_stream_fmt_conversion(cd->md.output_format.depth,
+				    cd->md.output_format.valid_bit_depth,
+				    &cd->sink_format,
+				    &valid_format,
+				    cd->md.output_format.s_type);
+
+	cd->config.in_channels_count = cd->md.base_cfg.audio_fmt.channels_count;
+	cd->config.out_channels_count = cd->md.output_format.channels_count;
+}
+
+static int selector_init(struct processing_module *mod)
+{
+	struct module_data *md = &mod->priv;
+	struct module_config *cfg = &md->cfg;
+	struct comp_dev *dev = mod->dev;
+	struct comp_data *cd;
+	int ret;
+
+	comp_dbg(dev, "selector_init()");
+
+	cd = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM, sizeof(*cd));
+	if (!cd)
+		return -ENOMEM;
+
+	md->private = cd;
+
+	ret = memcpy_s(&cd->md, sizeof(cd->md), cfg->data, sizeof(cd->md));
+	assert(!ret);
+
+	build_config(cd);
+
+	return 0;
+}
+
+static void set_selector_params(struct comp_dev *dev,
+				struct sof_ipc_stream_params *params)
+{
+	struct comp_data *cd = comp_get_drvdata(dev);
+	struct comp_buffer __sparse_cache *source;
+	struct ipc4_audio_format *out_fmt;
+	struct comp_buffer *src_buf;
+	struct list_item *sink_list;
+	int i;
+
+	if (dev->direction == SOF_IPC_STREAM_PLAYBACK)
+		params->channels = cd->config.in_channels_count;
+	else
+		params->channels = cd->config.out_channels_count;
+
+	params->rate = cd->md.base_cfg.audio_fmt.sampling_frequency;
+	params->frame_fmt = cd->source_format;
+
+	out_fmt = &cd->md.output_format;
+	for (i = 0; i < SOF_IPC_MAX_CHANNELS; i++)
+		params->chmap[i] = (out_fmt->ch_map >> i * 4) & 0xf;
+
+	/* update each sink format */
+	list_for_item(sink_list, &dev->bsink_list) {
+		struct comp_buffer *sink_buf =
+			container_of(sink_list, struct comp_buffer, source_list);
+		struct comp_buffer __sparse_cache *sink = buffer_acquire(sink_buf);
+
+		sink->stream.channels = params->channels;
+		sink->stream.rate = params->rate;
+		audio_stream_fmt_conversion(out_fmt->depth,
+					    out_fmt->valid_bit_depth,
+					    &sink->stream.frame_fmt,
+					    &sink->stream.valid_sample_fmt,
+					    out_fmt->s_type);
+
+		sink->buffer_fmt = out_fmt->interleaving_style;
+
+		for (i = 0; i < SOF_IPC_MAX_CHANNELS; i++)
+			sink->chmap[i] = (out_fmt->ch_map >> i * 4) & 0xf;
+
+		sink->hw_params_configured = true;
+		buffer_release(sink);
+	}
+
+	/* update the source format
+	 * used only for rare cases where two pipelines are connected by a shared
+	 * buffer and 2 copiers, this will set source format only for shared buffers
+	 * for a short time when the second pipeline already started
+	 * and the first one is not ready yet along with sink buffers params
+	 */
+	src_buf = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
+	source = buffer_acquire(src_buf);
+	if (!source->hw_params_configured) {
+		struct ipc4_audio_format *in_fmt;
+
+		in_fmt = &cd->md.base_cfg.audio_fmt;
+		source->stream.channels = in_fmt->channels_count;
+		source->stream.rate = in_fmt->sampling_frequency;
+		audio_stream_fmt_conversion(in_fmt->depth,
+					    in_fmt->valid_bit_depth,
+					    &source->stream.frame_fmt,
+					    &source->stream.valid_sample_fmt,
+					    in_fmt->s_type);
+
+		source->buffer_fmt = in_fmt->interleaving_style;
+
+		for (i = 0; i < SOF_IPC_MAX_CHANNELS; i++)
+			source->chmap[i] = (in_fmt->ch_map >> i * 4) & 0xf;
+
+		source->hw_params_configured = true;
+	}
+
+	buffer_release(source);
+}
+
+/**
+ * \brief Frees selector component.
+ * \param[in,out] dev Selector base component device.
+ */
+static int selector_free(struct processing_module *mod)
+{
+	struct comp_data *cd = module_get_private_data(mod);
+	struct comp_dev *dev = mod->dev;
+
+	comp_dbg(dev, "selector_free()");
+
+	rfree(cd);
+
+	return 0;
+}
+
+/**
+ * \brief Sets selector component audio stream parameters.
+ * \param[in,out] dev Selector base component device.
+ * \return Error code.
+ *
+ * All done in prepare since we need to know source and sink component params.
+ */
+static int selector_params(struct processing_module *mod)
+{
+	struct sof_ipc_stream_params *params = mod->stream_params;
+	struct comp_dev *dev = mod->dev;
+	int err;
+
+	comp_info(dev, "selector_params()");
+
+	set_selector_params(dev, params);
+
+	err = selector_verify_params(dev, params);
+	if (err < 0) {
+		comp_err(dev, "selector_params(): pcm params verification failed.");
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+static int selector_set_config(struct processing_module *mod, uint32_t config_id,
+			       enum module_cfg_fragment_position pos, uint32_t data_offset_size,
+			       const uint8_t *fragment, size_t fragment_size, uint8_t *response,
+			       size_t response_size)
+{
+	/* ToDo: add support */
+	return 0;
+}
+
+static int selector_get_config(struct processing_module *mod, uint32_t config_id,
+			       uint32_t *data_offset_size, uint8_t *fragment, size_t fragment_size)
+{
+	/* ToDo: add support */
+	return 0;
+}
+
+/**
+ * \brief Copies and processes stream data.
+ * \param[in,out] dev Selector base component device.
+ * \return Error code.
+ */
+static int selector_process(struct processing_module *mod,
+			    struct input_stream_buffer *input_buffers,
+			    int num_input_buffers,
+			    struct output_stream_buffer *output_buffers,
+			    int num_output_buffers)
+{
+	struct comp_data *cd = module_get_private_data(mod);
+	uint32_t avail_frames = input_buffers[0].size;
+	struct comp_dev *dev = mod->dev;
+
+	comp_dbg(dev, "selector_process()");
+
+	if (!avail_frames)
+		return PPL_STATUS_PATH_STOP;
+
+	/* copy selected channels from in to out */
+	cd->sel_func(mod, input_buffers, output_buffers, avail_frames);
+
+	return 0;
+}
+
+/**
+ * \brief Prepares selector component for processing.
+ * \param[in,out] dev Selector base component device.
+ * \return Error code.
+ */
+static int selector_prepare(struct processing_module *mod)
+{
+	struct comp_data *cd = module_get_private_data(mod);
+	struct module_data *md = &mod->priv;
+	struct comp_dev *dev = mod->dev;
+	struct comp_buffer *sinkb, *sourceb;
+	struct comp_buffer __sparse_cache *sink_c, *source_c;
+	size_t sink_size;
+	int ret;
+
+	comp_info(dev, "selector_prepare()");
+
+	ret = selector_params(mod);
+	if (ret < 0)
+		return ret;
+
+	if (ret == COMP_STATUS_STATE_ALREADY_SET)
+		return PPL_STATUS_PATH_STOP;
+
+	/* selector component will have 1 source and 1 sink buffer */
+	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
+	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
+
+	source_c = buffer_acquire(sourceb);
+	sink_c = buffer_acquire(sinkb);
+
+	/* get source data format and period bytes */
+	cd->source_format = source_c->stream.frame_fmt;
+	cd->source_period_bytes = audio_stream_period_bytes(&source_c->stream, dev->frames);
+
+	/* get sink data format and period bytes */
+	cd->sink_format = sink_c->stream.frame_fmt;
+	cd->sink_period_bytes = audio_stream_period_bytes(&sink_c->stream, dev->frames);
+
+	/* There is an assumption that sink component will report out
+	 * proper number of channels [1] for selector to actually
+	 * reduce channel count between source and sink
+	 */
+	comp_info(dev, "selector_prepare(): sourceb->schannels = %u",
+		  source_c->stream.channels);
+	comp_info(dev, "selector_prepare(): sinkb->channels = %u",
+		  sink_c->stream.channels);
+
+	sink_size = sink_c->stream.size;
+
+	md->mpd.in_buff_size = cd->source_period_bytes;
+	md->mpd.out_buff_size = cd->sink_period_bytes;
+
+	buffer_release(sink_c);
+	buffer_release(source_c);
+
+	if (sink_size < cd->sink_period_bytes) {
+		comp_err(dev, "selector_prepare(): sink buffer size %d is insufficient < %d",
+			 sink_size, cd->sink_period_bytes);
+		return -ENOMEM;
+	}
+
+	/* validate */
+	if (cd->sink_period_bytes == 0) {
+		comp_err(dev, "selector_prepare(): cd->sink_period_bytes = 0, dev->frames = %u",
+			 dev->frames);
+		return -EINVAL;
+	}
+
+	if (cd->source_period_bytes == 0) {
+		comp_err(dev, "selector_prepare(): cd->source_period_bytes = 0, dev->frames = %u",
+			 dev->frames);
+		return -EINVAL;
+	}
+
+	cd->sel_func = sel_get_processing_function(mod);
+	if (!cd->sel_func) {
+		comp_err(dev, "selector_prepare(): invalid cd->sel_func, cd->source_format = %u, cd->sink_format = %u, cd->out_channels_count = %u",
+			 cd->source_format, cd->sink_format,
+			 cd->config.out_channels_count);
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+/**
+ * \brief Resets selector component.
+ * \param[in,out] dev Selector base component device.
+ * \return Error code.
+ */
+static int selector_reset(struct processing_module *mod)
+{
+	struct comp_data *cd = module_get_private_data(mod);
+	struct comp_dev *dev = mod->dev;
+
+	comp_info(dev, "selector_reset()");
+
+	cd->source_period_bytes = 0;
+	cd->sink_period_bytes = 0;
+	cd->sel_func = NULL;
+
+	return 0;
+}
+
+/** \brief Selector component definition. */
+static struct module_interface selector_interface = {
+	.init			= selector_init,
+	.prepare		= selector_prepare,
+	.process		= selector_process,
+	.set_configuration	= selector_set_config,
+	.get_configuration	= selector_get_config,
+	.reset			= selector_reset,
+	.free			= selector_free
+};
+
+DECLARE_MODULE_ADAPTER(selector_interface, selector_uuid, selector_tr);
+#endif

--- a/src/audio/selector/selector_generic.c
+++ b/src/audio/selector/selector_generic.c
@@ -23,6 +23,7 @@ LOG_MODULE_DECLARE(selector, CONFIG_SOF_LOG_LEVEL);
 #define BYTES_TO_S16_SAMPLES	1
 #define BYTES_TO_S32_SAMPLES	2
 
+#if CONFIG_IPC_MAJOR_3
 #if CONFIG_FORMAT_S16LE
 /**
  * \brief Channel selection for 16 bit, 1 channel data format.
@@ -87,7 +88,7 @@ static void sel_s16le_nch(struct comp_dev *dev, struct audio_stream __sparse_cac
 		b = MIN(b, bmax);
 		bmax = audio_stream_bytes_without_wrap(sink, dst);
 		b = MIN(b, bmax);
-		memcpy(dst, src, b);
+		memcpy_s(dst, b, src, b);
 		src = audio_stream_wrap(source, src + b);
 		dst = audio_stream_wrap(sink, dst + b);
 		bytes_copied += b;
@@ -159,13 +160,180 @@ static void sel_s32le_nch(struct comp_dev *dev, struct audio_stream __sparse_cac
 		b = MIN(b, bmax);
 		bmax = audio_stream_bytes_without_wrap(sink, dst);
 		b = MIN(b, bmax);
-		memcpy(dst, src, b);
+		memcpy_s(dst, b, src, b);
 		src = audio_stream_wrap(source, src + b);
 		dst = audio_stream_wrap(sink, dst + b);
 		bytes_copied += b;
 	}
 }
 #endif /* CONFIG_FORMAT_S24LE || CONFIG_FORMAT_S32LE */
+
+#else
+#if CONFIG_FORMAT_S16LE
+/**
+ * \brief Channel selection for 16 bit, 1 channel data format.
+ * \param[in,out] mod Selector base module device.
+ * \param[in,out] bsource Source buffer.
+ * \param[in,out] bsink Sink buffer.
+ * \param[in] frames Number of frames to process.
+ */
+static void sel_s16le_1ch(struct processing_module *mod, struct input_stream_buffer *bsource,
+			  struct output_stream_buffer *bsink, uint32_t frames)
+{
+	struct comp_data *cd = module_get_private_data(mod);
+	struct audio_stream __sparse_cache *source = bsource->data;
+	struct audio_stream __sparse_cache *sink = bsink->data;
+	int16_t *src = source->r_ptr;
+	int16_t *dest = sink->w_ptr;
+	int16_t *src_ch;
+	int nmax;
+	int i;
+	int n;
+	int processed = 0;
+	const int source_frame_bytes = audio_stream_frame_bytes(source);
+	const unsigned int nch = source->channels;
+	const unsigned int sel_channel = cd->config.sel_channel; /* 0 to nch - 1 */
+
+	while (processed < frames) {
+		n = frames - processed;
+		nmax = audio_stream_bytes_without_wrap(source, src) / source_frame_bytes;
+		n = MIN(n, nmax);
+		nmax = audio_stream_bytes_without_wrap(sink, dest) >> BYTES_TO_S16_SAMPLES;
+		n = MIN(n, nmax);
+		src_ch = src + sel_channel;
+		for (i = 0; i < n; i++) {
+			*dest = *src_ch;
+			src_ch += nch;
+			dest++;
+		}
+		src = audio_stream_wrap(source, src + nch * n);
+		dest = audio_stream_wrap(sink, dest);
+		processed += n;
+	}
+
+	bsource->consumed += processed >> BYTES_TO_S16_SAMPLES;
+	bsink->size += processed >> BYTES_TO_S16_SAMPLES;
+}
+
+/**
+ * \brief Channel selection for 16 bit, at least 2 channels data format.
+ * \param[in,out] mod Selector base module device.
+ * \param[in,out] bsource Source buffer.
+ * \param[in,out] bsink Sink buffer.
+ * \param[in] frames Number of frames to process.
+ */
+static void sel_s16le_nch(struct processing_module *mod, struct input_stream_buffer *bsource,
+			  struct output_stream_buffer *bsink, uint32_t frames)
+{
+	struct audio_stream __sparse_cache *source = bsource->data;
+	struct audio_stream __sparse_cache *sink = bsink->data;
+	int8_t *src = (int8_t *)source->r_ptr;
+	int8_t *dst = (int8_t *)sink->w_ptr;
+	int bmax;
+	int b;
+	int bytes_copied = 0;
+	const int bytes_total = frames * audio_stream_frame_bytes(source);
+
+	while (bytes_copied < bytes_total) {
+		b = bytes_total - bytes_copied;
+		bmax = audio_stream_bytes_without_wrap(source, src);
+		b = MIN(b, bmax);
+		bmax = audio_stream_bytes_without_wrap(sink, dst);
+		b = MIN(b, bmax);
+		memcpy_s(dst, b, src, b);
+		src = audio_stream_wrap(source, src + b);
+		dst = audio_stream_wrap(sink, dst + b);
+		bytes_copied += b;
+	}
+
+	bsource->consumed += bytes_copied >> BYTES_TO_S16_SAMPLES;
+	bsink->size += bytes_copied >> BYTES_TO_S16_SAMPLES;
+}
+#endif /* CONFIG_FORMAT_S16LE */
+
+#if CONFIG_FORMAT_S24LE || CONFIG_FORMAT_S32LE
+/**
+ * \brief Channel selection for 32 bit, 1 channel data format.
+ * \param[in,out] mod Selector base module device.
+ * \param[in,out] bsource Source buffer.
+ * \param[in,out] bsink Sink buffer.
+ * \param[in] frames Number of frames to process.
+ */
+static void sel_s32le_1ch(struct processing_module *mod, struct input_stream_buffer *bsource,
+			  struct output_stream_buffer *bsink, uint32_t frames)
+{
+	struct comp_data *cd = module_get_private_data(mod);
+	struct audio_stream __sparse_cache *source = bsource->data;
+	struct audio_stream __sparse_cache *sink = bsink->data;
+	int32_t *src = source->r_ptr;
+	int32_t *dest = sink->w_ptr;
+	int32_t *src_ch;
+	int nmax;
+	int i;
+	int n;
+	int processed = 0;
+	const int source_frame_bytes = audio_stream_frame_bytes(source);
+	const unsigned int nch = source->channels;
+	const unsigned int sel_channel = cd->config.sel_channel; /* 0 to nch - 1 */
+
+	while (processed < frames) {
+		n = frames - processed;
+		nmax = audio_stream_bytes_without_wrap(source, src) / source_frame_bytes;
+		n = MIN(n, nmax);
+		nmax = audio_stream_bytes_without_wrap(sink, dest) >> BYTES_TO_S32_SAMPLES;
+		n = MIN(n, nmax);
+		src_ch = src + sel_channel;
+		for (i = 0; i < n; i++) {
+			*dest = *src_ch;
+			src_ch += nch;
+			dest++;
+		}
+		src = audio_stream_wrap(source, src + nch * n);
+		dest = audio_stream_wrap(sink, dest);
+		processed += n;
+	}
+
+	bsource->consumed += processed >> BYTES_TO_S32_SAMPLES;
+	bsink->size += processed >> BYTES_TO_S32_SAMPLES;
+}
+
+/**
+ * \brief Channel selection for 32 bit, at least 2 channels data format.
+ * \param[in,out] mod Selector base module device.
+ * \param[in,out] bsource Source buffer.
+ * \param[in,out] bsink Sink buffer.
+ * \param[in] frames Number of frames to process.
+ */
+static void sel_s32le_nch(struct processing_module *mod, struct input_stream_buffer *bsource,
+			  struct output_stream_buffer *bsink, uint32_t frames)
+{
+	struct audio_stream __sparse_cache *source = bsource->data;
+	struct audio_stream __sparse_cache *sink = bsink->data;
+
+	int8_t *src = (int8_t *)source->r_ptr;
+	int8_t *dst = (int8_t *)sink->w_ptr;
+	int bmax;
+	int b;
+	int bytes_copied = 0;
+	const int bytes_total = frames * audio_stream_frame_bytes(source);
+
+	while (bytes_copied < bytes_total) {
+		b = bytes_total - bytes_copied;
+		bmax = audio_stream_bytes_without_wrap(source, src);
+		b = MIN(b, bmax);
+		bmax = audio_stream_bytes_without_wrap(sink, dst);
+		b = MIN(b, bmax);
+		memcpy_s(dst, b, src, b);
+		src = audio_stream_wrap(source, src + b);
+		dst = audio_stream_wrap(sink, dst + b);
+		bytes_copied += b;
+	}
+
+	bsource->consumed += bytes_copied >> BYTES_TO_S32_SAMPLES;
+	bsink->size += bytes_copied >> BYTES_TO_S32_SAMPLES;
+}
+#endif /* CONFIG_FORMAT_S24LE || CONFIG_FORMAT_S32LE */
+#endif
 
 const struct comp_func_map func_table[] = {
 #if CONFIG_FORMAT_S16LE
@@ -185,6 +353,7 @@ const struct comp_func_map func_table[] = {
 #endif /* CONFIG_FORMAT_S32LE */
 };
 
+#if CONFIG_IPC_MAJOR_3
 sel_func sel_get_processing_function(struct comp_dev *dev)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
@@ -203,3 +372,23 @@ sel_func sel_get_processing_function(struct comp_dev *dev)
 
 	return NULL;
 }
+#else
+sel_func sel_get_processing_function(struct processing_module *mod)
+{
+	struct comp_data *cd = module_get_private_data(mod);
+	int i;
+
+	/* map the channel selection function for source and sink buffers */
+	for (i = 0; i < ARRAY_SIZE(func_table); i++) {
+		if (cd->source_format != func_table[i].source)
+			continue;
+		if (cd->config.out_channels_count != func_table[i].out_channels)
+			continue;
+
+		/* TODO: add additional criteria as needed */
+		return func_table[i].sel_func;
+	}
+
+	return NULL;
+}
+#endif

--- a/src/include/sof/audio/selector.h
+++ b/src/include/sof/audio/selector.h
@@ -16,6 +16,9 @@
 
 #include <sof/trace/trace.h>
 #include <ipc/stream.h>
+#if CONFIG_IPC_MAJOR_4
+#include <ipc4/base-config.h>
+#endif
 #include <user/selector.h>
 #include <user/trace.h>
 #include <stdint.h>
@@ -36,8 +39,19 @@ struct comp_dev;
 typedef void (*sel_func)(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
 			 const struct audio_stream __sparse_cache *source, uint32_t frames);
 
+#if CONFIG_IPC_MAJOR_4
+struct micsel_data {
+	struct ipc4_base_module_cfg base_cfg;
+	struct ipc4_audio_format output_format;
+};
+#endif
+
 /** \brief Selector component private data. */
 struct comp_data {
+#if CONFIG_IPC_MAJOR_4
+		struct micsel_data md;
+#endif
+
 	uint32_t source_period_bytes;	/**< source number of period bytes */
 	uint32_t sink_period_bytes;	/**< sink number of period bytes */
 	enum sof_ipc_frame source_format;	/**< source frame format */

--- a/src/include/sof/audio/selector.h
+++ b/src/include/sof/audio/selector.h
@@ -14,6 +14,7 @@
 #ifndef __SOF_AUDIO_SELECTOR_H__
 #define __SOF_AUDIO_SELECTOR_H__
 
+#include <sof/audio/module_adapter/module/generic.h>
 #include <sof/trace/trace.h>
 #include <ipc/stream.h>
 #if CONFIG_IPC_MAJOR_4
@@ -35,15 +36,18 @@ struct comp_dev;
 #define SEL_SINK_2CH 2
 #define SEL_SINK_4CH 4
 
-/** \brief selector processing function interface */
-typedef void (*sel_func)(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
-			 const struct audio_stream __sparse_cache *source, uint32_t frames);
-
 #if CONFIG_IPC_MAJOR_4
+/** \brief selector processing function interface */
+typedef void (*sel_func)(struct processing_module *mod, struct input_stream_buffer *bsource,
+		       struct output_stream_buffer *bsink, uint32_t frames);
+
 struct micsel_data {
 	struct ipc4_base_module_cfg base_cfg;
 	struct ipc4_audio_format output_format;
 };
+#else
+typedef void (*sel_func)(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
+			 const struct audio_stream __sparse_cache *source, uint32_t frames);
 #endif
 
 /** \brief Selector component private data. */
@@ -70,6 +74,17 @@ struct comp_func_map {
 /** \brief Map of formats with dedicated processing functions. */
 extern const struct comp_func_map func_map[];
 
+#if CONFIG_IPC_MAJOR_4
+/**
+ * \brief Retrieves selector processing function.
+ * \param[in,out] mod Selector module adapter.
+ */
+sel_func sel_get_processing_function(struct processing_module *mod);
+
+#ifdef UNIT_TEST
+void sys_comp_module_selector_interface_init(void);
+#endif
+#else
 /**
  * \brief Retrieves selector processing function.
  * \param[in,out] dev Selector base component device.
@@ -78,6 +93,7 @@ sel_func sel_get_processing_function(struct comp_dev *dev);
 
 #ifdef UNIT_TEST
 void sys_comp_selector_init(void);
+#endif
 #endif
 
 #endif /* __SOF_AUDIO_SELECTOR_H__ */

--- a/test/cmocka/src/audio/selector/selector_test.c
+++ b/test/cmocka/src/audio/selector/selector_test.c
@@ -13,8 +13,12 @@
 #include <cmocka.h>
 #include <sof/audio/buffer.h>
 #include <sof/audio/component.h>
+#if CONFIG_IPC_MAJOR_4
+#include <sof/audio/module_adapter/module/generic.h>
+#endif
 #include <sof/audio/selector.h>
 
+#if CONFIG_IPC_MAJOR_3
 struct sel_test_state {
 	struct comp_dev *dev;
 	struct comp_buffer *sink;
@@ -102,6 +106,114 @@ static int teardown(void **state)
 
 	return 0;
 }
+#else
+struct sel_test_state {
+	struct processing_module *mod;
+	struct comp_buffer *sink;
+	struct comp_buffer *source;
+	struct input_stream_buffer *input;
+	struct output_stream_buffer *output;
+	size_t size;
+	uint32_t channels;
+	void (*verify)(struct processing_module *mod, struct audio_stream *sink,
+		       struct audio_stream *source);
+};
+
+struct sel_test_parameters {
+	uint32_t in_channels;
+	uint32_t out_channels;
+	uint32_t sel_channel;
+	uint32_t frames;
+	uint32_t buffer_size_ms;
+	uint32_t source_format;
+	uint32_t sink_format;
+	void (*verify)(struct processing_module *mod, struct audio_stream *sink,
+		       struct audio_stream *source);
+};
+
+static int setup(void **state)
+{
+	struct sel_test_parameters *parameters = *state;
+	struct sel_test_state *sel_state;
+	struct module_data *md;
+	struct comp_dev *dev;
+	struct comp_data *cd;
+	uint32_t size = 0;
+
+	/* allocate new state */
+	sel_state = test_malloc(sizeof(*sel_state));
+
+	/* allocate and set new device */
+	sel_state->mod = test_malloc(sizeof(struct processing_module));
+	dev = test_malloc(sizeof(struct comp_dev));
+	dev->frames = parameters->frames;
+	sel_state->mod->dev = dev;
+
+	list_init(&dev->bsink_list);
+	list_init(&dev->bsource_list);
+
+	/* allocate and set new data */
+	cd = test_malloc(sizeof(*cd));
+	md = &sel_state->mod->priv;
+	comp_set_drvdata(dev, sel_state->mod);
+	md->private = cd;
+
+	cd->source_format = parameters->source_format;
+	cd->sink_format = parameters->sink_format;
+
+	/* prepare parameters that will be used by sel_get_processing_function */
+	cd->config.in_channels_count = parameters->in_channels;
+	cd->config.out_channels_count = parameters->out_channels;
+	cd->config.sel_channel = parameters->sel_channel;
+
+	cd->sel_func = sel_get_processing_function(sel_state->mod);
+
+	/* allocate new sink buffer */
+	size = parameters->frames * get_frame_bytes(parameters->sink_format,
+	       parameters->out_channels) * parameters->buffer_size_ms;
+	sel_state->size = size;
+	sel_state->sink = create_test_sink(dev, 0, parameters->sink_format,
+					   parameters->out_channels, size);
+
+	/* allocate new source buffer */
+	size = parameters->frames * get_frame_bytes(parameters->source_format,
+	       parameters->in_channels) * parameters->buffer_size_ms;
+
+	sel_state->source = create_test_source(dev, 0, parameters->source_format,
+					       parameters->in_channels, size);
+
+	sel_state->input = test_malloc(sizeof(struct input_stream_buffer));
+	sel_state->input->data = &sel_state->source->stream;
+	sel_state->output = test_malloc(sizeof(struct output_stream_buffer));
+	sel_state->output->data = &sel_state->sink->stream;
+
+	/* assigns verification function */
+	sel_state->verify = parameters->verify;
+
+	/* assign test state */
+	*state = sel_state;
+
+	return 0;
+}
+
+static int teardown(void **state)
+{
+	struct sel_test_state *sel_state = *state;
+	struct comp_data *cd = module_get_private_data(sel_state->mod);
+
+	/* free everything */
+	test_free(cd);
+	test_free(sel_state->mod->dev);
+	test_free(sel_state->mod);
+	test_free(sel_state->input);
+	test_free(sel_state->output);
+	free_test_sink(sel_state->sink);
+	free_test_source(sel_state->source);
+	test_free(sel_state);
+
+	return 0;
+}
+#endif
 
 #if CONFIG_FORMAT_S16LE
 static void fill_source_s16(struct sel_test_state *sel_state)
@@ -118,11 +230,19 @@ static void fill_source_s16(struct sel_test_state *sel_state)
 	audio_stream_produce(stream, audio_stream_get_free_bytes(stream));
 }
 
+#if CONFIG_IPC_MAJOR_3
 static void verify_s16le_Xch_to_1ch(struct comp_dev *dev,
 				    struct audio_stream *sink,
 				    struct audio_stream *source)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
+#else
+static void verify_s16le_Xch_to_1ch(struct processing_module *mod,
+				    struct audio_stream *sink,
+				    struct audio_stream *source)
+{
+	struct comp_data *cd = module_get_private_data(mod);
+#endif
 	const uint16_t *src = (uint16_t *)source->r_ptr;
 	const uint16_t *dst = (uint16_t *)sink->w_ptr;
 	uint32_t in_channels = cd->config.in_channels_count;
@@ -143,9 +263,15 @@ static void verify_s16le_Xch_to_1ch(struct comp_dev *dev,
 	}
 }
 
+#if CONFIG_IPC_MAJOR_3
 static void verify_s16le_2ch_to_2ch(struct comp_dev *dev,
 				    struct audio_stream *sink,
 				    struct audio_stream *source)
+#else
+static void verify_s16le_2ch_to_2ch(struct processing_module *mod,
+				    struct audio_stream *sink,
+				    struct audio_stream *source)
+#endif
 {
 	const uint16_t *src = (uint16_t *)source->r_ptr;
 	const uint16_t *dst = (uint16_t *)sink->w_ptr;
@@ -162,9 +288,15 @@ static void verify_s16le_2ch_to_2ch(struct comp_dev *dev,
 	}
 }
 
+#if CONFIG_IPC_MAJOR_3
 static void verify_s16le_4ch_to_4ch(struct comp_dev *dev,
 				    struct audio_stream *sink,
 				    struct audio_stream *source)
+#else
+static void verify_s16le_4ch_to_4ch(struct processing_module *mod,
+				    struct audio_stream *sink,
+				    struct audio_stream *source)
+#endif
 {
 	const uint16_t *src = (uint16_t *)source->r_ptr;
 	const uint16_t *dst = (uint16_t *)sink->w_ptr;
@@ -198,11 +330,20 @@ static void fill_source_s32(struct sel_test_state *sel_state)
 	audio_stream_produce(stream, audio_stream_get_free_bytes(stream));
 }
 
+#if CONFIG_IPC_MAJOR_3
 static void verify_s32le_Xch_to_1ch(struct comp_dev *dev,
 				    struct audio_stream *sink,
 				    struct audio_stream *source)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
+
+#else
+static void verify_s32le_Xch_to_1ch(struct processing_module *mod,
+				    struct audio_stream *sink,
+				    struct audio_stream *source)
+{
+	struct comp_data *cd = module_get_private_data(mod);
+#endif
 	const uint32_t *src = (uint32_t *)source->r_ptr;
 	const uint32_t *dst = (uint32_t *)sink->w_ptr;
 	uint32_t in_channels = cd->config.in_channels_count;
@@ -223,9 +364,15 @@ static void verify_s32le_Xch_to_1ch(struct comp_dev *dev,
 	}
 }
 
+#if CONFIG_IPC_MAJOR_3
 static void verify_s32le_2ch_to_2ch(struct comp_dev *dev,
 				    struct audio_stream *sink,
 				    struct audio_stream *source)
+#else
+static void verify_s32le_2ch_to_2ch(struct processing_module *mod,
+				    struct audio_stream *sink,
+				    struct audio_stream *source)
+#endif
 {
 	const uint32_t *src = (uint32_t *)source->r_ptr;
 	const uint32_t *dst = (uint32_t *)sink->w_ptr;
@@ -242,9 +389,15 @@ static void verify_s32le_2ch_to_2ch(struct comp_dev *dev,
 	}
 }
 
+#if CONFIG_IPC_MAJOR_3
 static void verify_s32le_4ch_to_4ch(struct comp_dev *dev,
 				    struct audio_stream *sink,
 				    struct audio_stream *source)
+#else
+static void verify_s32le_4ch_to_4ch(struct processing_module *mod,
+				    struct audio_stream *sink,
+				    struct audio_stream *source)
+#endif
 {
 	const uint32_t *src = (uint32_t *)source->r_ptr;
 	const uint32_t *dst = (uint32_t *)sink->w_ptr;
@@ -265,7 +418,12 @@ static void verify_s32le_4ch_to_4ch(struct comp_dev *dev,
 static void test_audio_sel(void **state)
 {
 	struct sel_test_state *sel_state = *state;
+#if CONFIG_IPC_MAJOR_3
 	struct comp_data *cd = comp_get_drvdata(sel_state->dev);
+#else
+	struct processing_module *mod = sel_state->mod;
+	struct comp_data *cd = module_get_private_data(mod);
+#endif
 
 	switch (cd->source_format) {
 #if CONFIG_FORMAT_S16LE
@@ -284,10 +442,22 @@ static void test_audio_sel(void **state)
 	case SOF_IPC_FRAME_S24_3LE:
 		break;
 	}
+
+#if CONFIG_IPC_MAJOR_3
 	cd->sel_func(sel_state->dev, &sel_state->sink->stream, &sel_state->source->stream,
 		     sel_state->dev->frames);
 
 	sel_state->verify(sel_state->dev, &sel_state->sink->stream, &sel_state->source->stream);
+
+#else
+	sel_state->input->consumed = 0;
+	sel_state->output->size = 0;
+
+	cd->sel_func(mod, sel_state->input, sel_state->output,
+		     mod->dev->frames);
+
+	sel_state->verify(mod, &sel_state->sink->stream, &sel_state->source->stream);
+#endif
 }
 
 static struct sel_test_parameters parameters[] = {

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -445,7 +445,11 @@ void sys_comp_mixer_init(void);
 void sys_comp_dai_init(void);
 void sys_comp_src_init(void);
 void sys_comp_mux_init(void);
+#if CONFIG_IPC_MAJOR_3
 void sys_comp_selector_init(void);
+#else
+void sys_comp_module_selector_interface_init(void);
+#endif
 void sys_comp_switch_init(void);
 void sys_comp_tone_init(void);
 void sys_comp_eq_fir_init(void);
@@ -540,8 +544,11 @@ int task_main_start(struct sof *sof)
 		sys_comp_src_init();
 
 	if (IS_ENABLED(CONFIG_COMP_SEL))
+#if CONFIG_IPC_MAJOR_3
 		sys_comp_selector_init();
-
+#else
+		sys_comp_module_selector_interface_init();
+#endif
 	if (IS_ENABLED(CONFIG_COMP_SWITCH))
 		sys_comp_switch_init();
 


### PR DESCRIPTION
Although this patch doesn't support large_config_set|get and
corresponding per-channel process, it can support simple usage
of selector and support capture applications like voice recoder,
zoom on windows platform. It will be used for WOV development
in recently.

Signed-off-by: Rander Wang <rander.wang@intel.com>