### PR TITLE
topology2: add missing num_audio_formats for gain

### DIFF
--- a/tools/topology/topology2/include/pipelines/cavs/dai-copier-gain-mixin-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/dai-copier-gain-mixin-capture.conf
@@ -68,6 +68,7 @@ Class.Pipeline."dai-copier-gain-mixin-capture" {
 
 		mixin."1" {}
 		gain."1" {
+			num_audio_formats	1
 			# 32-bit 48KHz 2ch
 			Object.Base.audio_format.1 {
 				in_bit_depth		32

--- a/tools/topology/topology2/include/pipelines/cavs/host-copier-gain-mixin-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/host-copier-gain-mixin-playback.conf
@@ -80,6 +80,7 @@ Class.Pipeline."host-copier-gain-mixin-playback" {
 		}
 
 		gain."1" {
+			num_audio_formats	1
 			# 32-bit 48KHz 2ch
 			Object.Base.audio_format.1 {
 				in_bit_depth		32


### PR DESCRIPTION
The default class level num_audio_formats for gain is
removed in 773a05a32ec130fc3661e6ac8f89c937d356ce98,
which causes gain widget num_audio_formats parsing issue
in the kernel for topology with below two pipelines:
  - dai-copier-gain-mixin-capture
  - host-copier-gain-mixin-playback

This patch adds num_audio_formats for gain widget in
above two pipelines.

Signed-off-by: Chao Song <chao.song@linux.intel.com>