### PR TITLE
topology2: pipelines: cavs: Add missing num_audio_formats for gains

### DIFF
--- a/tools/topology/topology2/include/pipelines/cavs/dai-copier-gain-mixin-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/dai-copier-gain-mixin-capture.conf
@@ -68,6 +68,7 @@ Class.Pipeline."dai-copier-gain-mixin-capture" {
 
 		mixin."1" {}
 		gain."1" {
+			num_audio_formats 1
 			# 32-bit 48KHz 2ch
 			Object.Base.audio_format.1 {
 				in_bit_depth		32

--- a/tools/topology/topology2/include/pipelines/cavs/host-copier-gain-mixin-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/host-copier-gain-mixin-playback.conf
@@ -80,6 +80,7 @@ Class.Pipeline."host-copier-gain-mixin-playback" {
 		}
 
 		gain."1" {
+			num_audio_formats 1
 			# 32-bit 48KHz 2ch
 			Object.Base.audio_format.1 {
 				in_bit_depth		32


### PR DESCRIPTION
Commit 773a05a32ec1 ("topology2: add S24LE support") removed the default
1 from include/gain.conf but failed to add it to the pipeline config files.

This causes topology parsing error since the supported audio formats count
is invalid in these cases.

Signed-off-by: Peter Ujfalusi <peter.ujfalusi@linux.intel.com>