### PR TITLE
Doxygen: Increase DOT_GRAPH_MAX_NODES to 120

### DIFF
--- a/doc/sof.doxygen.in
+++ b/doc/sof.doxygen.in
@@ -39,3 +39,6 @@ TYPEDEF_HIDES_STRUCT = YES
 #FILTER_SOURCE_FILES = YES
 
 HTML_TIMESTAMP = NO
+
+# Avoid error "Include graph for 'foobar.h' not generated, too many nodes"
+DOT_GRAPH_MAX_NODES = 120


### PR DESCRIPTION
This avoids a currently happening error:

"error: Include graph for 'src_ipc4_int32_table.h' not generated,
too many nodes (89), threshold is 50. Consider increasing
DOT_GRAPH_MAX_NODES."

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>