### PR TITLE
[SKIP CI] .github: doxygen: upgrade to Ubuntu 22.04

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -37,7 +37,7 @@ on:
 jobs:
 
   doxygen:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This should upgrade doxygen from version 1.8.17 to 1.9.1

This will hopefully provide FAIL_ON_WARNINGS and fix issues like
https://github.com/doxygen/doxygen/issues/7970

Signed-off-by: Marc Herbert <marc.herbert@intel.com>