### PR TITLE
Audio: copier: add hifi version implementation of apply_attenuation

### DIFF
--- a/src/audio/CMakeLists.txt
+++ b/src/audio/CMakeLists.txt
@@ -129,10 +129,8 @@ if(NOT CONFIG_LIBRARY)
 		add_subdirectory(igo_nr)
 	endif()
 	if(CONFIG_COMP_COPIER)
-                add_local_sources(sof
-                        copier.c
-                )
-        endif()
+		add_subdirectory(copier)
+	endif()
 	if(CONFIG_COMP_RTNR)
 		add_subdirectory(rtnr)
 	endif()

--- a/src/audio/copier/CMakeLists.txt
+++ b/src/audio/copier/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_local_sources(sof copier.c copier_hifi.c copier_generic.c)
+

--- a/src/audio/copier/copier_generic.c
+++ b/src/audio/copier/copier_generic.c
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2022 Intel Corporation. All rights reserved.
+//
+// Author: Andrula Song <xiaoyuan.song@intel.com>
+
+#include <ipc4/copier.h>
+
+#ifdef COPIER_GENERIC
+
+#include <sof/audio/buffer.h>
+#include <sof/audio/component_ext.h>
+#include <sof/audio/format.h>
+#include <sof/audio/pipeline.h>
+#include <sof/audio/component.h>
+#include <sof/common.h>
+#include <stddef.h>
+#include <errno.h>
+#include <stdint.h>
+
+int apply_attenuation(struct comp_dev *dev, struct copier_data *cd,
+		      struct comp_buffer __sparse_cache *sink, int frame)
+{
+	int i;
+	int n;
+	int nmax;
+	int remaining_samples = frame * sink->stream.channels;
+	int32_t *dst = sink->stream.r_ptr;
+
+	/* only support attenuation in format of 32bit */
+	switch (sink->stream.frame_fmt) {
+	case SOF_IPC_FRAME_S16_LE:
+		comp_err(dev, "16bit sample isn't supported by attenuation");
+		return -EINVAL;
+	case SOF_IPC_FRAME_S24_4LE:
+	case SOF_IPC_FRAME_S32_LE:
+		while (remaining_samples) {
+			nmax = audio_stream_samples_without_wrap_s32(&sink->stream, dst);
+			n = MIN(remaining_samples, nmax);
+			for (i = 0; i < n; i++) {
+				*dst >>= cd->attenuation;
+				dst++;
+			}
+			remaining_samples -= n;
+			dst = audio_stream_wrap(&sink->stream, dst);
+		}
+
+		return 0;
+	default:
+		comp_err(dev, "unsupported format %d for attenuation", sink->stream.frame_fmt);
+		return -EINVAL;
+	}
+}
+
+#endif

--- a/src/audio/copier/copier_hifi.c
+++ b/src/audio/copier/copier_hifi.c
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2022 Intel Corporation. All rights reserved.
+//
+// Author: Andrula Song <xiaoyuan.song@intel.com>
+#include <ipc4/copier.h>
+
+#if __XCC__ && (XCHAL_HAVE_HIFI3 || XCHAL_HAVE_HIFI4)
+
+#include <sof/audio/buffer.h>
+#include <sof/audio/component_ext.h>
+#include <sof/audio/format.h>
+#include <sof/audio/pipeline.h>
+#include <sof/audio/component.h>
+#include <sof/common.h>
+#include <stddef.h>
+#include <errno.h>
+#include <stdint.h>
+#include <xtensa/tie/xt_hifi3.h>
+
+int apply_attenuation(struct comp_dev *dev, struct copier_data *cd,
+		      struct comp_buffer __sparse_cache *sink, int frame)
+{
+	int i;
+	int n;
+	int nmax;
+	ae_int32x2 sample;
+	ae_valign uu = AE_ZALIGN64();
+	ae_valign su = AE_ZALIGN64();
+	int remaining_samples = frame * sink->stream.channels;
+	uint32_t *dst = sink->stream.r_ptr;
+	ae_int32x2 *in = (ae_int32x2 *)dst;
+	ae_int32x2 *out = (ae_int32x2 *)dst;
+
+	/* only support attenuation in format of 32bit */
+	switch (sink->stream.frame_fmt) {
+	case SOF_IPC_FRAME_S16_LE:
+		comp_err(dev, "16bit sample isn't supported by attenuation");
+		return -EINVAL;
+	case SOF_IPC_FRAME_S24_4LE:
+	case SOF_IPC_FRAME_S32_LE:
+		while (remaining_samples) {
+			nmax = audio_stream_samples_without_wrap_s32(&sink->stream, dst);
+			in = (ae_int32x2 *)dst;
+			out = (ae_int32x2 *)dst;
+			uu = AE_LA64_PP(in);
+			n = MIN(remaining_samples, nmax);
+			for (i = 0; i < n; i += 2) {
+				AE_LA32X2_IP(sample, uu, in);
+				sample = AE_SRAA32(sample, cd->attenuation);
+				AE_SA32X2_IP(sample, su, out);
+			}
+			AE_SA64POS_FP(su, out);
+			remaining_samples -= n;
+			dst = audio_stream_wrap(&sink->stream, dst + n);
+		}
+
+		return 0;
+	default:
+		comp_err(dev, "unsupported format %d for attenuation", sink->stream.frame_fmt);
+		return -EINVAL;
+	}
+}
+#endif

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -709,7 +709,9 @@ zephyr_library_sources_ifdef(CONFIG_COMP_BASEFW_IPC4
 )
 
 zephyr_library_sources_ifdef(CONFIG_COMP_COPIER
-	${SOF_AUDIO_PATH}/copier.c
+	${SOF_AUDIO_PATH}/copier/copier_generic.c
+	${SOF_AUDIO_PATH}/copier/copier_hifi.c
+	${SOF_AUDIO_PATH}/copier/copier.c
 )
 
 zephyr_library_sources_ifdef(CONFIG_MAXIM_DSM


### PR DESCRIPTION
add hifi version implementation of apply_attenuation, using xtensa
instructions can save about 74% cycles than the original one.

Signed-off-by: Andrula Song <xiaoyuan.song@intel.com>