### PR TITLE
dai: host: copier: component: New pipeline latency calculation algorithm

### DIFF
--- a/src/audio/asrc/asrc.c
+++ b/src/audio/asrc/asrc.c
@@ -71,8 +71,8 @@ DECLARE_TR_CTX(asrc_tr, SOF_UUID(asrc_uuid), LOG_LEVEL_INFO);
 /* asrc component private data */
 struct comp_data {
 #if CONFIG_IPC_MAJOR_4
-	/* Must be the 1st field, function ipc4_create_buffer casts components private data as
-	 * ipc4_base_module_cfg!
+	/* Must be the 1st field, function ipc4_comp_get_base_module_cfg casts components
+	 * private data as ipc4_base_module_cfg!
 	 */
 	struct ipc4_asrc_module_cfg ipc_config;
 #else

--- a/src/audio/copier.c
+++ b/src/audio/copier.c
@@ -323,7 +323,7 @@ static int create_dai(struct comp_dev *parent_dev, struct copier_data *cd,
 
 	memset(&dai, 0, sizeof(dai));
 	dai_count = 1;
-	node_id.dw = copier->gtw_cfg.node_id;
+	node_id = copier->gtw_cfg.node_id;
 	dai_index[dai_count - 1] = node_id.f.v_index;
 	dai.direction = node_id.f.dma_type % 2;
 	dai.is_config_blob = true;
@@ -401,12 +401,10 @@ static int create_dai(struct comp_dev *parent_dev, struct copier_data *cd,
 
 static int init_pipeline_reg(struct copier_data *cd)
 {
-	union ipc4_connector_node_id node_id;
 	struct ipc4_pipeline_registers pipe_reg;
 	uint8_t gateway_id;
 
-	node_id.dw = cd->config.gtw_cfg.node_id;
-	gateway_id = node_id.f.v_index;
+	gateway_id = cd->config.gtw_cfg.node_id.f.v_index;
 	if (gateway_id >= IPC4_MAX_PIPELINE_REG_SLOTS) {
 		comp_cl_err(&comp_copier, "gateway_id %u out of array bounds.", gateway_id);
 		return -EINVAL;
@@ -470,9 +468,9 @@ static struct comp_dev *copier_new(const struct comp_driver *drv,
 
 	dev->pipeline = ipc_pipe->pipeline;
 
+	node_id = copier->gtw_cfg.node_id;
 	/* copier is linked to gateway */
-	if (copier->gtw_cfg.node_id != IPC4_INVALID_NODE_ID) {
-		node_id.dw = copier->gtw_cfg.node_id;
+	if (node_id.dw != IPC4_INVALID_NODE_ID) {
 		cd->direction = node_id.f.dma_type % 2;
 
 		switch (node_id.f.dma_type) {
@@ -942,7 +940,6 @@ static void update_internal_comp(struct comp_dev *parent, struct comp_dev *child
 static int copier_params(struct comp_dev *dev, struct sof_ipc_stream_params *params)
 {
 	struct copier_data *cd = comp_get_drvdata(dev);
-	union ipc4_connector_node_id node_id;
 	struct comp_buffer *sink, *source;
 	struct comp_buffer __sparse_cache *sink_c, *source_c;
 	struct list_item *sink_list;
@@ -958,8 +955,7 @@ static int copier_params(struct comp_dev *dev, struct sof_ipc_stream_params *par
 	params->sample_container_bytes = cd->config.base.audio_fmt.depth;
 	params->sample_valid_bytes = cd->config.base.audio_fmt.valid_bit_depth;
 
-	node_id.dw = cd->config.gtw_cfg.node_id;
-	params->stream_tag = node_id.f.v_index + 1;
+	params->stream_tag = cd->config.gtw_cfg.node_id.f.v_index + 1;
 	params->frame_fmt = dev->ipc_config.frame_fmt;
 	params->buffer_fmt = cd->config.base.audio_fmt.interleaving_style;
 	params->buffer.size = cd->config.base.ibs;

--- a/src/audio/copier.c
+++ b/src/audio/copier.c
@@ -48,8 +48,8 @@ DECLARE_SOF_RT_UUID("copier", copier_comp_uuid, 0x9ba00c83, 0xca12, 0x4a83,
 DECLARE_TR_CTX(copier_comp_tr, SOF_UUID(copier_comp_uuid), LOG_LEVEL_INFO);
 
 struct copier_data {
-	/* Must be the 1st field, function ipc4_create_buffer casts components private data
-	 * as ipc4_base_module_cfg!
+	/* Must be the 1st field, function ipc4_comp_get_base_module_cfg casts components
+	 * private data as ipc4_base_module_cfg!
 	 */
 	struct ipc4_copier_module_cfg config;
 	struct comp_dev *endpoint[IPC4_COPIER_MODULE_OUTPUT_PINS_COUNT];

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -733,9 +733,6 @@ static void dai_update_start_position(struct comp_dev *dev)
 
 	/* update starting wallclock */
 	platform_dai_wallclock(dev, &dd->wallclock);
-
-	/* update start position */
-	dd->start_position = dev->position;
 }
 
 /* used to pass standard and bespoke command (with data) to component */

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -152,7 +152,7 @@ static void dai_dma_cb(void *arg, enum notify_id type, void *data)
 				audio_stream_frame_bytes(&sink_c->stream));
 	} else {
 		/* update host position (in bytes offset) for drivers */
-		dev->position += bytes;
+		dd->total_data_processed += bytes;
 	}
 
 	buffer_release(local_buf);
@@ -665,7 +665,7 @@ static int dai_prepare(struct comp_dev *dev)
 	if (ret == COMP_STATUS_STATE_ALREADY_SET)
 		return PPL_STATUS_PATH_STOP;
 
-	dev->position = 0;
+	dd->total_data_processed = 0;
 
 	if (!dd->chan) {
 		comp_err(dev, "dai_prepare(): Missing dd->chan.");
@@ -720,7 +720,7 @@ static int dai_reset(struct comp_dev *dev)
 	}
 
 	dd->wallclock = 0;
-	dev->position = 0;
+	dd->total_data_processed = 0;
 	dd->xrun = 0;
 	comp_set_state(dev, COMP_TRIGGER_RESET);
 
@@ -1066,25 +1066,41 @@ static int dai_ts_get(struct comp_dev *dev, struct timestamp_data *tsd)
 	return dd->dai->drv->ts_ops.ts_get(dd->dai, &dd->ts_config, tsd);
 }
 
+static uint64_t dai_get_processed_data(struct comp_dev *dev, uint32_t stream_no, bool input)
+{
+	struct dai_data *dd = comp_get_drvdata(dev);
+	uint64_t ret = 0;
+	bool source = dev->direction == SOF_IPC_STREAM_CAPTURE;
+
+	/* Return value only if direction and stream number match.
+	 * The dai supports only one stream.
+	 */
+	if (stream_no == 0 && source == input)
+		ret = dd->total_data_processed;
+
+	return ret;
+}
+
 static const struct comp_driver comp_dai = {
 	.type	= SOF_COMP_DAI,
 	.uid	= SOF_RT_UUID(dai_comp_uuid),
 	.tctx	= &dai_comp_tr,
 	.ops	= {
-		.create			= dai_new,
-		.free			= dai_free,
-		.params			= dai_params,
-		.dai_get_hw_params	= dai_comp_get_hw_params,
-		.trigger		= dai_comp_trigger,
-		.copy			= dai_copy,
-		.prepare		= dai_prepare,
-		.reset			= dai_reset,
-		.dai_config		= dai_config,
-		.position		= dai_position,
-		.dai_ts_config		= dai_ts_config,
-		.dai_ts_start		= dai_ts_start,
-		.dai_ts_stop		= dai_ts_stop,
-		.dai_ts_get		= dai_ts_get,
+		.create				= dai_new,
+		.free				= dai_free,
+		.params				= dai_params,
+		.dai_get_hw_params		= dai_comp_get_hw_params,
+		.trigger			= dai_comp_trigger,
+		.copy				= dai_copy,
+		.prepare			= dai_prepare,
+		.reset				= dai_reset,
+		.dai_config			= dai_config,
+		.position			= dai_position,
+		.dai_ts_config			= dai_ts_config,
+		.dai_ts_start			= dai_ts_start,
+		.dai_ts_stop			= dai_ts_stop,
+		.dai_ts_get			= dai_ts_get,
+		.get_total_data_processed	= dai_get_processed_data,
 	},
 };
 

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -280,12 +280,6 @@ static void dai_dma_cb(void *arg, enum notify_id type, void *data)
 	} else {
 		/* update host position (in bytes offset) for drivers */
 		dev->position += bytes;
-		if (dd->dai_pos) {
-			dd->dai_pos_blks += bytes;
-			*dd->dai_pos = dd->dai_pos_blks +
-				(char *)buffer_ptr -
-				(char *)dma_buf->stream.addr;
-		}
 	}
 
 	buffer_release(local_buf);
@@ -335,8 +329,6 @@ static struct comp_dev *dai_new(const struct comp_driver *drv,
 	}
 
 	dma_sg_init(&dd->config.elem_array);
-	dd->dai_pos = NULL;
-	dd->dai_pos_blks = 0;
 	dd->xrun = 0;
 	dd->chan = NULL;
 
@@ -938,10 +930,6 @@ static int dai_reset(struct comp_dev *dev)
 		dd->dma_buffer = NULL;
 	}
 
-	dd->dai_pos_blks = 0;
-	if (dd->dai_pos)
-		*dd->dai_pos = 0;
-	dd->dai_pos = NULL;
 	dd->wallclock = 0;
 	dev->position = 0;
 	dd->xrun = 0;

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -944,9 +944,6 @@ static void dai_update_start_position(struct comp_dev *dev)
 
 	/* update starting wallclock */
 	platform_dai_wallclock(dev, &dd->wallclock);
-
-	/* update start position */
-	dd->start_position = dev->position;
 }
 
 /* used to pass standard and bespoke command (with data) to component */

--- a/src/audio/host-legacy.c
+++ b/src/audio/host-legacy.c
@@ -78,6 +78,7 @@ struct host_data {
 	uint32_t host_period_bytes;
 	uint16_t stream_tag;
 	uint16_t no_stream_position; /**< 1 means don't send stream position */
+	uint64_t total_data_processed;
 	uint8_t cont_update_posn; /**< 1 means continuous update stream position */
 
 	/* host component attributes */
@@ -333,7 +334,7 @@ static void host_update_position(struct comp_dev *dev, uint32_t bytes)
 	if (ret < 0)
 		return;
 
-	dev->position += bytes;
+	hd->total_data_processed += bytes;
 
 	/* new local period, update host buffer position blks
 	 * local_pos is queried by the ops.position() API
@@ -951,7 +952,7 @@ static int host_pointer_reset(struct comp_dev *dev)
 	/* reset buffer pointers */
 	hd->local_pos = 0;
 	hd->report_pos = 0;
-	dev->position = 0;
+	hd->total_data_processed = 0;
 
 	return 0;
 }
@@ -1054,21 +1055,37 @@ static int host_set_attribute(struct comp_dev *dev, uint32_t type,
 	return 0;
 }
 
+static uint64_t host_get_processed_data(struct comp_dev *dev, uint32_t stream_no, bool input)
+{
+	struct host_data *hd = comp_get_drvdata(dev);
+	uint64_t ret = 0;
+	bool source = dev->direction == SOF_IPC_STREAM_CAPTURE;
+
+	/* Return value only if direction and stream number match.
+	 * The host supports only one stream.
+	 */
+	if (stream_no == 0 && source == input)
+		ret = hd->total_data_processed;
+
+	return ret;
+}
+
 static const struct comp_driver comp_host = {
 	.type	= SOF_COMP_HOST,
 	.uid	= SOF_RT_UUID(host_uuid),
 	.tctx	= &host_tr,
 	.ops	= {
-		.create		= host_new,
-		.free		= host_free,
-		.params		= host_params,
-		.reset		= host_reset,
-		.trigger	= host_trigger,
-		.copy		= host_copy,
-		.prepare	= host_prepare,
-		.position	= host_position,
-		.get_attribute	= host_get_attribute,
-		.set_attribute	= host_set_attribute,
+		.create				= host_new,
+		.free				= host_free,
+		.params				= host_params,
+		.reset				= host_reset,
+		.trigger			= host_trigger,
+		.copy				= host_copy,
+		.prepare			= host_prepare,
+		.position			= host_position,
+		.get_attribute			= host_get_attribute,
+		.set_attribute			= host_set_attribute,
+		.get_total_data_processed	= host_get_processed_data,
 	},
 };
 

--- a/src/audio/mixer.c
+++ b/src/audio/mixer.c
@@ -54,6 +54,9 @@ DECLARE_TR_CTX(mixer_tr, SOF_UUID(mixer_uuid), LOG_LEVEL_INFO);
 /* mixer component private data */
 struct mixer_data {
 #if CONFIG_IPC_MAJOR_4
+	/* Must be the 1st field, function ipc4_comp_get_base_module_cfg casts components
+	 * private data as ipc4_base_module_cfg!
+	 */
 	struct ipc4_base_module_cfg base_cfg;
 #endif
 

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -86,8 +86,8 @@ struct ipc4_config_src {
 
 struct comp_data {
 #if CONFIG_IPC_MAJOR_4
-	/* Must be the 1st field, function ipc4_create_buffer casts components private data as
-	 * ipc4_base_module_cfg!
+	/* Must be the 1st field, function ipc4_comp_get_base_module_cfg casts components
+	 * private data as ipc4_base_module_cfg!
 	 */
 	struct ipc4_config_src ipc_config;
 #else

--- a/src/include/ipc4/copier.h
+++ b/src/include/ipc4/copier.h
@@ -26,6 +26,7 @@
 
 #include <stdint.h>
 #include <ipc4/base-config.h>
+#include <ipc4/gateway.h>
 
 /* This is basic module config that may serve as a base for more specialized, module
  * specific config received along with Init Module Instance from host.
@@ -201,7 +202,7 @@ struct ipc4_copier_gateway_cfg {
 	 * specified gateway using either input pin 0 or output pin 0 depending on
 	 * the node's direction, otherwise the data in this structure is ignored.
 	 */
-	uint32_t node_id;
+	union ipc4_connector_node_id node_id;
 	/* preferred Gateway DMA buffer size (in bytes).
 	 * FW attempts to allocate DMA buffer according to this value, however it may
 	 * fall back to IBS/OBS * 2 in case there is no memory available for deeper

--- a/src/include/sof/audio/aria/aria.h
+++ b/src/include/sof/audio/aria/aria.h
@@ -53,6 +53,9 @@ int aria_process_data(struct comp_dev *dev, int32_t *__restrict dst,
  * \brief Aria component private data.
  */
 struct aria_data {
+	/* Must be the 1st field, function ipc4_comp_get_base_module_cfg casts components
+	 * private data as ipc4_base_module_cfg!
+	 */
 	struct ipc4_base_module_cfg base;
 
 	/* channels count */

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -542,7 +542,6 @@ struct comp_dev {
 
 	/* runtime */
 	uint16_t state;		   /**< COMP_STATE_ */
-	uint64_t position;	   /**< component rendering position */
 	uint32_t frames;	   /**< number of frames we copy to sink */
 	struct pipeline *pipeline; /**< pipeline we belong to */
 

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -492,6 +492,15 @@ struct comp_ops {
 				bool last_block,
 				uint32_t data_offset,
 				char *data);
+
+	/**
+	 * Returns total data processed in number bytes.
+	 * @param dev Component device
+	 * @param stream_no Index of input/output stream
+	 * @param input Selects between input (true) or output (false) stream direction
+	 * @return total data processed if succeeded, 0 otherwise.
+	 */
+	uint64_t (*get_total_data_processed)(struct comp_dev *dev, uint32_t stream_no, bool input);
 };
 
 /**

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -128,6 +128,7 @@ enum {
 #define COMP_ATTR_COPY_TYPE	0	/**< Comp copy type attribute */
 #define COMP_ATTR_HOST_BUFFER	1	/**< Comp host buffer attribute */
 #define COMP_ATTR_COPY_DIR	2	/**< Comp copy direction */
+#define COMP_ATTR_VDMA_INDEX	3	/**< Comp index of the virtual DMA at the gateway. */
 /** @}*/
 
 /** \name Trace macros

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -936,6 +936,16 @@ static inline int comp_get_state(struct comp_dev *req_dev, struct comp_dev *dev)
 int comp_verify_params(struct comp_dev *dev, uint32_t flag,
 		       struct sof_ipc_stream_params *params);
 
+#if CONFIG_IPC_MAJOR_4
+/**
+ * Temporary ugly function to get components base configuration. Fix me!
+ */
+static inline struct ipc4_base_module_cfg *ipc4_comp_get_base_module_cfg(struct comp_dev *dev)
+{
+	return (struct ipc4_base_module_cfg *)comp_get_drvdata(dev);
+}
+#endif
+
 /** @}*/
 
 #endif /* __SOF_AUDIO_COMPONENT_H__ */

--- a/src/include/sof/audio/component_ext.h
+++ b/src/include/sof/audio/component_ext.h
@@ -387,6 +387,17 @@ static inline int comp_unbind(struct comp_dev *dev, void *data)
 	return ret;
 }
 
+static inline uint64_t comp_get_total_data_processed(struct comp_dev *dev, uint32_t stream_no,
+						     bool input)
+{
+	uint64_t ret = 0;
+
+	if (dev->drv->ops.get_total_data_processed)
+		ret = dev->drv->ops.get_total_data_processed(dev, stream_no, input);
+
+	return ret;
+}
+
 /** @}*/
 
 #endif /* __SOF_AUDIO_COMPONENT_INT_H__ */

--- a/src/include/sof/audio/pipeline.h
+++ b/src/include/sof/audio/pipeline.h
@@ -200,12 +200,21 @@ int pipeline_for_each_comp(struct comp_dev *current,
 			   struct pipeline_walk_context *ctx, int dir);
 
 /**
+ * \brief Walks pipeline graph to find dai component.
+ * \param[in] pipeline_id is the start pipeline id.
+ * \return dai component.
+ */
+struct comp_dev *pipeline_get_dai_comp(uint32_t pipeline_id);
+
+#if CONFIG_IPC_MAJOR_4
+/**
  * \brief Walks pipeline graph to find dai component and latency.
  * \param[in] pipeline_id is the start pipeline id.
  * \param[out] latency to dai.
  * \return dai component.
  */
-struct comp_dev *pipeline_get_dai_comp(uint32_t pipeline_id, uint32_t *latency);
+struct comp_dev *pipeline_get_dai_comp_latency(uint32_t pipeline_id, uint32_t *latency);
+#endif
 
 /**
  * Retrieves pipeline id from pipeline.

--- a/src/include/sof/audio/up_down_mixer/up_down_mixer.h
+++ b/src/include/sof/audio/up_down_mixer/up_down_mixer.h
@@ -114,6 +114,9 @@ static inline enum ipc4_channel_index get_channel_index(const channel_map map,
  * \brief up_down_mixer component private data.
  */
 struct up_down_mixer_data {
+	/* Must be the 1st field, function ipc4_comp_get_base_module_cfg casts components
+	 * private data as ipc4_base_module_cfg!
+	 */
 	struct ipc4_base_module_cfg base;
 	/** Number of channels in the input buffer. */
 	size_t in_channel_no;

--- a/src/include/sof/lib/dai-legacy.h
+++ b/src/include/sof/lib/dai-legacy.h
@@ -167,22 +167,18 @@ struct dai_data {
 	struct timestamp_cfg ts_config;
 	struct dai *dai;
 	struct dma *dma;
-	struct dai_group *group;	/**< NULL if no group assigned */
-	int xrun;		/* true if we are doing xrun recovery */
+	struct dai_group *group;		/* NULL if no group assigned */
+	int xrun;				/* true if we are doing xrun recovery */
 
-	pcm_converter_func process;	/* processing function */
+	pcm_converter_func process;		/* processing function */
 
-	uint32_t dai_pos_blks;	/* position in bytes (nearest block) */
-	uint64_t start_position;	/* position on start */
-	uint32_t period_bytes;	/**< number of bytes per one period */
-
-	/* host can read back this value without IPC */
-	uint64_t *dai_pos;
+	uint64_t start_position;		/* position on start */
+	uint32_t period_bytes;			/* number of bytes per one period */
 
 	struct ipc_config_dai ipc_config;	/* generic common config */
-	void *dai_spec_config;	/* dai specific config from the host */
+	void *dai_spec_config;			/* dai specific config from the host */
 
-	uint64_t wallclock;	/* wall clock at stream start */
+	uint64_t wallclock;			/* wall clock at stream start */
 
 	/*
 	 * flag indicating two-step stop/pause for DAI comp and DAI DMA.

--- a/src/include/sof/lib/dai-legacy.h
+++ b/src/include/sof/lib/dai-legacy.h
@@ -173,6 +173,7 @@ struct dai_data {
 	pcm_converter_func process;		/* processing function */
 
 	uint32_t period_bytes;			/* number of bytes per one period */
+	uint64_t total_data_processed;
 
 	struct ipc_config_dai ipc_config;	/* generic common config */
 	void *dai_spec_config;			/* dai specific config from the host */

--- a/src/include/sof/lib/dai-legacy.h
+++ b/src/include/sof/lib/dai-legacy.h
@@ -172,7 +172,6 @@ struct dai_data {
 
 	pcm_converter_func process;		/* processing function */
 
-	uint64_t start_position;		/* position on start */
 	uint32_t period_bytes;			/* number of bytes per one period */
 
 	struct ipc_config_dai ipc_config;	/* generic common config */

--- a/src/include/sof/lib/dai-zephyr.h
+++ b/src/include/sof/lib/dai-zephyr.h
@@ -136,6 +136,7 @@ struct dai_data {
 	pcm_converter_func process;		/* processing function */
 
 	uint32_t period_bytes;			/* number of bytes per one period */
+	uint64_t total_data_processed;
 
 	struct ipc_config_dai ipc_config;	/* generic common config */
 	void *dai_spec_config;			/* dai specific config from the host */

--- a/src/include/sof/lib/dai-zephyr.h
+++ b/src/include/sof/lib/dai-zephyr.h
@@ -130,22 +130,18 @@ struct dai_data {
 	struct timestamp_cfg ts_config;
 	struct dai *dai;
 	struct dma *dma;
-	struct dai_group *group;	/**< NULL if no group assigned */
-	int xrun;		/* true if we are doing xrun recovery */
+	struct dai_group *group;		/* NULL if no group assigned */
+	int xrun;				/* true if we are doing xrun recovery */
 
-	pcm_converter_func process;	/* processing function */
+	pcm_converter_func process;		/* processing function */
 
-	uint32_t dai_pos_blks;	/* position in bytes (nearest block) */
-	uint64_t start_position;	/* position on start */
-	uint32_t period_bytes;	/**< number of bytes per one period */
-
-	/* host can read back this value without IPC */
-	uint64_t *dai_pos;
+	uint64_t start_position;		/* position on start */
+	uint32_t period_bytes;			/* number of bytes per one period */
 
 	struct ipc_config_dai ipc_config;	/* generic common config */
-	void *dai_spec_config;	/* dai specific config from the host */
+	void *dai_spec_config;			/* dai specific config from the host */
 
-	uint64_t wallclock;	/* wall clock at stream start */
+	uint64_t wallclock;			/* wall clock at stream start */
 
 	/*
 	 * flag indicating two-step stop/pause for DAI comp and DAI DMA.

--- a/src/include/sof/lib/dai-zephyr.h
+++ b/src/include/sof/lib/dai-zephyr.h
@@ -135,7 +135,6 @@ struct dai_data {
 
 	pcm_converter_func process;		/* processing function */
 
-	uint64_t start_position;		/* position on start */
 	uint32_t period_bytes;			/* number of bytes per one period */
 
 	struct ipc_config_dai ipc_config;	/* generic common config */

--- a/src/ipc/ipc3/dai.c
+++ b/src/ipc/ipc3/dai.c
@@ -375,7 +375,7 @@ int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn)
 	struct dai_data *dd = comp_get_drvdata(dev);
 
 	/* TODO: improve accuracy by adding current DMA position */
-	posn->dai_posn = dev->position;
+	posn->dai_posn = dd->total_data_processed;
 
 	/* set stream start wallclock */
 	posn->wallclock = dd->wallclock;

--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -33,7 +33,6 @@ LOG_MODULE_DECLARE(ipc, CONFIG_SOF_LOG_LEVEL);
 int dai_config_dma_channel(struct comp_dev *dev, void *spec_config)
 {
 	struct ipc4_copier_module_cfg *copier_cfg = spec_config;
-	union ipc4_connector_node_id node;
 	struct dai_data *dd = comp_get_drvdata(dev);
 	struct ipc_config_dai *dai = &dd->ipc_config;
 	int channel;
@@ -45,8 +44,7 @@ int dai_config_dma_channel(struct comp_dev *dev, void *spec_config)
 		channel = 0;
 		break;
 	case SOF_DAI_INTEL_HDA:
-		node.dw = copier_cfg->gtw_cfg.node_id;
-		channel = node.f.v_index;
+		channel = copier_cfg->gtw_cfg.node_id.f.v_index;
 		break;
 	case SOF_DAI_INTEL_ALH:
 		/* As with HDA, the DMA channel is assigned in runtime,
@@ -151,7 +149,7 @@ static void get_llp_reg_info(struct comp_dev *dev, uint32_t *node_id, uint32_t *
 	uint32_t id;
 
 	copier_cfg = dd->dai_spec_config;
-	node.dw = copier_cfg->gtw_cfg.node_id;
+	node = copier_cfg->gtw_cfg.node_id;
 	/* 13 bits of type + index */
 	*node_id = node.dw & 0x1FFF;
 	id = node.f.v_index;

--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -327,7 +327,7 @@ int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn)
 	struct dma_chan_status status;
 
 	/* total processed bytes count */
-	posn->dai_posn = dev->position;
+	posn->dai_posn = dd->total_data_processed;
 
 	platform_dai_wallclock(dev, &dd->wallclock);
 	posn->wallclock = dd->wallclock;

--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -396,12 +396,12 @@ static int update_dir_to_pipeline_component(uint32_t *ppl_id, uint32_t count)
 	struct comp_dev *dai;
 	struct list_item *clist;
 	struct ipc *ipc;
-	uint32_t latency, i;
+	uint32_t i;
 
 	ipc = ipc_get();
 
 	/* only dai has direction based on gateway type */
-	dai = pipeline_get_dai_comp(ppl_id[0], &latency);
+	dai = pipeline_get_dai_comp(ppl_id[0]);
 	/* skip host copier to host copier case */
 	if (!dai) {
 		tr_info(&ipc_tr, "no dai is found");

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -469,7 +469,7 @@ static struct comp_dev *ipc4_create_dai(struct pipeline *pipe, uint32_t id, uint
 	list_init(&dev->bsource_list);
 	list_init(&dev->bsink_list);
 
-	copier_cfg->gtw_cfg.node_id = link_chan;
+	copier_cfg->gtw_cfg.node_id.dw = link_chan;
 	ret = comp_dai_config(dev, &dai, copier_cfg);
 	if (ret < 0)
 		return NULL;

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -240,7 +240,7 @@ static struct comp_buffer *ipc4_create_buffer(struct comp_dev *src, struct comp_
 	struct sof_ipc_buffer ipc_buf;
 	int buf_size;
 
-	src_cfg = (struct ipc4_base_module_cfg *)comp_get_drvdata(src);
+	src_cfg = ipc4_comp_get_base_module_cfg(src);
 
 	/* double it since obs is single buffer size */
 	buf_size = src_cfg->obs * 2;


### PR DESCRIPTION
The main goal of this PR is to update the algorithm of pipeline latency calculation. It is based on the number of buffered data blocks between the first and last component.

For this purpose, I have added a new function to the component's api that allows to read the total number of processed data by it. Then, I introduced total_data_processed counter in dai_data and host_data structure. The counters of processed data has been moved from a component device structure to the components private data. Finally I removed the position field from comp_dev structure which become unused. This field was ambiguous - it was not known whether it mean consumed or produced data. I added a similar processed data counters to the Copier module.

In the future, the stamping of start and stop of the pipe will be moved to MixIn component. I have some made preparations for this process in the Copier module. I added reading the dma index using the get_attribute function and reading the gateway position using the position method.

By the way, I cleaned the dai structure from unused fields: dai_pos, dai_pos_blks and start_position.

Changed a declaration of node_id in ipc4_copier_gateway_cfg to use a aproprietary type. This change makes easier to reference the node_id field. Thanks to it, you don't have to wonder what type the value should be casted. It make our work easier and minimize the risk of a mistake.

The ipc_get_ppl_comp function has been simplified by removing the duplicate loop. Now the component list is only reviewed once and both conditions are checked simultaneously.

Created new function comp_get_base_module_cfg for ipc4 which allows to get component's base configuration. This function is still access a component's private data in ugly way but it allows solve this issue easier in the future.

