### PR TITLE
[SKIP CI] .github: add sof-docs build to Github Actions

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -54,6 +54,42 @@ jobs:
           ninja -C docbuild -v doc
 
 
+  # This is unfortunately a mix of sof-docs/.github/ + the previous job
+  # above, duplicating a bit of both: please keep in sync with both. We
+  # build sof-docs here too because waiting for sof-docs CI to find
+  # regressions introduced in sof.git is very time-consuming, see
+  # example in
+  # https://github.com/thesofproject/sof/pull/5731#issuecomment-1175630147
+  sof-docs:
+    runs-on: ubuntu-20.04  # sof-docs is still stuck to this for now
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: apt-get update
+        run: sudo apt-get update
+
+      - name: apt-get install
+        run: sudo apt-get -y install
+             doxygen make default-jre graphviz cmake ninja-build
+
+      - name: doxygen
+        run: cmake -GNinja -S doc/ -B doxybuild/ && ninja -C doxybuild/ -v doc
+
+        # Nested git clone, this is fine
+      - name: clone sof-docs
+        run: git clone https://github.com/thesofproject/sof-docs sof-docs/
+
+      - name: PATH += .local/bin
+        run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: 'pip install -r sof-docs/scripts/requirements.txt'
+        run: pip install -r sof-docs/scripts/requirements.txt
+
+      - name: build sof-docs
+        run: make -C sof-docs/ html SOF_DOC_BUILD="$(pwd)"/doxybuild/
+
+
   testbench:
     runs-on: ubuntu-20.04
 


### PR DESCRIPTION
From time to time sof-docs regressions are introduced in sof.git. This
introduces a random and sometimes long delay between when the regression
is introduced and when it is found. A recent example is
https://github.com/thesofproject/sof/pull/5731#issuecomment-1175630147
where the doxygen comments were duplicated. Doxygen alone did not mind,
then the sof-docs build failed much later which took multiple people a
lot of time to understand and bisect.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>