### PR TITLE
Add mixer based hda topology for MTL

### DIFF
--- a/tools/topology/topology2/cavs/CMakeLists.txt
+++ b/tools/topology/topology2/cavs/CMakeLists.txt
@@ -20,9 +20,9 @@ HDA_CONFIG=mix,NUM_DMICS=2,PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt.bin"
 "cavs-passthrough-hdmi\;cavs-mixin-mixout-hda-4ch-tgl\;\
 HDA_CONFIG=mix,NUM_DMICS=4,PLATFORM=cnl,PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,\
 PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt.bin"
-# MTL: CAVS HDA topology with passthrough pipelines for HDMI
-"cavs-passthrough-hdmi\;cavs-passthrough-hda-4ch-mtl\;PLATFORM=mtl,\
-NUM_DMICS=4,PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-mtl.bin"
+# MTL: CAVS HDA topology with mixer-based pipelines for HDA and passthrough pipelines for HDMI
+"cavs-passthrough-hdmi\;cavs-mixin-mixout-hda-4ch-mtl\;PLATFORM=mtl,\
+HDA_CONFIG=mix,NUM_DMICS=4,PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-mtl-hda-mix.bin"
 
 # CAVS SDW topology with passthrough pipelines
 "cavs-sdw\;cavs-sdw"

--- a/tools/topology/topology2/cavs/CMakeLists.txt
+++ b/tools/topology/topology2/cavs/CMakeLists.txt
@@ -8,20 +8,19 @@ set(TPLGS
 "cavs-passthrough-hdmi\;cavs-mixin-mixout-hda\;HDA_CONFIG=mix"
 # If the alsatplg plugins for NHLT are not available, the NHLT blobs will not be added to the
 # topologies below.
-# TGL: CAVS HDA topology with mixer-based pipelines for HDA and passthrough pipelines for HDMI
-"cavs-passthrough-hdmi\;cavs-mixin-mixout-hda-2ch-tgl\;\
-HDA_CONFIG=mix,NUM_DMICS=2,PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt.bin"
 # CNL: CAVS HDA topology with mixer-based pipelines for HDA and passthrough pipelines for HDMI
 "cavs-passthrough-hdmi\;cavs-mixin-mixout-hda-2ch-cnl\;\
 HDA_CONFIG=mix,NUM_DMICS=2,PLATFORM=cnl,PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt.bin"
-# TGL: CAVS HDA topology with mixer-based pipelines for HDA and passthrough pipelines for HDMI
-"cavs-passthrough-hdmi\;cavs-mixin-mixout-hda-4ch-tgl\;\
-HDA_CONFIG=mix,NUM_DMICS=4,PLATFORM=cnl,PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,\
-PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt.bin"
-# CNL: CAVS HDA topology with mixer-based pipelines for HDA and passthrough pipelines for HDMI
 "cavs-passthrough-hdmi\;cavs-mixin-mixout-hda-4ch-cnl\;\
 HDA_CONFIG=mix,NUM_DMICS=4,PLATFORM=cnl,PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,\
 PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt.bin"
+# TGL: CAVS HDA topology with mixer-based pipelines for HDA and passthrough pipelines for HDMI
+"cavs-passthrough-hdmi\;cavs-mixin-mixout-hda-2ch-tgl\;\
+HDA_CONFIG=mix,NUM_DMICS=2,PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt.bin"
+"cavs-passthrough-hdmi\;cavs-mixin-mixout-hda-4ch-tgl\;\
+HDA_CONFIG=mix,NUM_DMICS=4,PLATFORM=cnl,PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,\
+PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt.bin"
+# MTL: CAVS HDA topology with passthrough pipelines for HDMI
 "cavs-passthrough-hdmi\;cavs-passthrough-hda-4ch-mtl\;PLATFORM=mtl,\
 NUM_DMICS=4,PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-mtl.bin"
 


### PR DESCRIPTION
This is cavs-passthrough-hda-4ch-mtl.tplg, which is already in the CMakLists.txt
![cavs-passthrough-hda-4ch-mtl](https://user-images.githubusercontent.com/45636982/177624265-72a39416-8076-4846-bd80-80c2fd08de86.png)

This is new topology from this PR, cavs-mixin-mixout-hda-4ch-mtl.tplg
I tested with Realtek AIOC40, ALC256 HDA codec.
![cavs-mixin-mixout-hda-4ch-mtl](https://user-images.githubusercontent.com/45636982/177624261-6ff10c4d-b5e4-4bcf-9222-d3c68d376f23.png)
