### PR TITLE
module_adapter: Add support for IPC4 in module_adapter_new

### DIFF
--- a/src/audio/aria/aria.c
+++ b/src/audio/aria/aria.c
@@ -335,6 +335,21 @@ out:
 	return 0;
 }
 
+static int aria_get_attribute(struct comp_dev *dev, uint32_t type, void *value)
+{
+	struct aria_data *cd = comp_get_drvdata(dev);
+
+	switch (type) {
+	case COMP_ATTR_BASE_CONFIG:
+		*(struct ipc4_base_module_cfg *)value = cd->base;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
 static const struct comp_driver comp_aria = {
 	.uid	= SOF_RT_UUID(aria_comp_uuid),
 	.tctx	= &aria_comp_tr,
@@ -345,6 +360,7 @@ static const struct comp_driver comp_aria = {
 		.copy			= aria_copy,
 		.prepare		= aria_prepare,
 		.reset			= aria_reset,
+		.get_attribute		= aria_get_attribute,
 	},
 };
 

--- a/src/audio/asrc/asrc.c
+++ b/src/audio/asrc/asrc.c
@@ -71,9 +71,6 @@ DECLARE_TR_CTX(asrc_tr, SOF_UUID(asrc_uuid), LOG_LEVEL_INFO);
 /* asrc component private data */
 struct comp_data {
 #if CONFIG_IPC_MAJOR_4
-	/* Must be the 1st field, function ipc4_comp_get_base_module_cfg casts components
-	 * private data as ipc4_base_module_cfg!
-	 */
 	struct ipc4_asrc_module_cfg ipc_config;
 #else
 	struct ipc_config_asrc ipc_config;
@@ -308,6 +305,21 @@ static inline uint32_t asrc_get_operation_mode(const struct ipc4_asrc_module_cfg
 static inline bool asrc_get_asynchronous_mode(const struct ipc4_asrc_module_cfg *ipc_asrc)
 {
 	return false;
+}
+
+static int asrc_get_attribute(struct comp_dev *dev, uint32_t type, void *value)
+{
+	struct comp_data *cd = comp_get_drvdata(dev);
+
+	switch (type) {
+	case COMP_ATTR_BASE_CONFIG:
+		*(struct ipc4_base_module_cfg *)value = cd->ipc_config.base;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	return 0;
 }
 #endif
 
@@ -1077,6 +1089,9 @@ static const struct comp_driver comp_asrc = {
 		.copy = asrc_copy,
 		.prepare = asrc_prepare,
 		.reset = asrc_reset,
+#if CONFIG_IPC_MAJOR_4
+		.get_attribute = asrc_get_attribute,
+#endif
 	},
 };
 

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -1195,6 +1195,9 @@ static int copier_get_attribute(struct comp_dev *dev, uint32_t type, void *value
 	case COMP_ATTR_VDMA_INDEX:
 		*(uint32_t *)value = cd->config.gtw_cfg.node_id.f.v_index;
 		break;
+	case COMP_ATTR_BASE_CONFIG:
+		*(struct ipc4_base_module_cfg *)value = cd->config.base;
+		break;
 	default:
 		return -EINVAL;
 	}

--- a/src/audio/mixin_mixout.c
+++ b/src/audio/mixin_mixout.c
@@ -990,6 +990,36 @@ static int mixout_unbind(struct comp_dev *dev, void *data)
 	return 0;
 }
 
+static int mixin_get_attribute(struct comp_dev *dev, uint32_t type, void *value)
+{
+	struct mixin_data *md = comp_get_drvdata(dev);
+
+	switch (type) {
+	case COMP_ATTR_BASE_CONFIG:
+		*(struct ipc4_base_module_cfg *)value = md->base_cfg;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+static int mixout_get_attribute(struct comp_dev *dev, uint32_t type, void *value)
+{
+	struct mixout_data *md = comp_get_drvdata(dev);
+
+	switch (type) {
+	case COMP_ATTR_BASE_CONFIG:
+		*(struct ipc4_base_module_cfg *)value = md->base_cfg;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
 static const struct comp_driver comp_mixin = {
 	.uid	= SOF_RT_UUID(mixin_uuid),
 	.tctx	= &mixin_tr,
@@ -1001,6 +1031,7 @@ static const struct comp_driver comp_mixin = {
 		.trigger = mixinout_trigger,
 		.copy    = mixin_copy,
 		.reset   = mixin_reset,
+		.get_attribute = mixin_get_attribute,
 	},
 };
 
@@ -1030,6 +1061,7 @@ static const struct comp_driver comp_mixout = {
 		.bind    = mixout_bind,
 		.unbind  = mixout_unbind,
 		.reset   = mixout_reset,
+		.get_attribute = mixout_get_attribute,
 	},
 };
 

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -963,7 +963,27 @@ int module_get_large_config(struct comp_dev *dev, uint32_t param_id, bool first_
 						  (uint8_t *)data, fragment_size);
 	return 0;
 }
+
+int module_adapter_get_attribute(struct comp_dev *dev, uint32_t type, void *value)
+{
+	struct processing_module *mod = comp_get_drvdata(dev);
+
+	switch (type) {
+	case COMP_ATTR_BASE_CONFIG:
+		memcpy_s(value, sizeof(struct ipc4_base_module_cfg), mod->priv.private,
+			 sizeof(struct ipc4_base_module_cfg));
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	return 0;
+}
 #else
+int module_adapter_get_attribute(struct comp_dev *dev, uint32_t type, void *value)
+{
+	return -EINVAL;
+}
 int module_set_large_config(struct comp_dev *dev, uint32_t param_id, bool first_block,
 			    bool last_block, uint32_t data_offset, char *data)
 {

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -86,9 +86,6 @@ struct ipc4_config_src {
 
 struct comp_data {
 #if CONFIG_IPC_MAJOR_4
-	/* Must be the 1st field, function ipc4_comp_get_base_module_cfg casts components
-	 * private data as ipc4_base_module_cfg!
-	 */
 	struct ipc4_config_src ipc_config;
 #else
 	struct ipc_config_src ipc_config;
@@ -484,6 +481,21 @@ static void src_copy_sxx(struct comp_dev *dev,
 }
 
 #if CONFIG_IPC_MAJOR_4
+static int src_get_attribute(struct comp_dev *dev, uint32_t type, void *value)
+{
+	struct comp_data *cd = comp_get_drvdata(dev);
+
+	switch (type) {
+	case COMP_ATTR_BASE_CONFIG:
+		*(struct ipc4_base_module_cfg *)value = cd->ipc_config.base;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
 static int src_rate_check(void *spec)
 {
 	struct ipc4_config_src *ipc_src = spec;
@@ -1071,6 +1083,9 @@ static const struct comp_driver comp_src = {
 		.copy = src_copy,
 		.prepare = src_prepare,
 		.reset = src_reset,
+#if CONFIG_IPC_MAJOR_4
+		.get_attribute = src_get_attribute,
+#endif
 	},
 };
 

--- a/src/audio/up_down_mixer/up_down_mixer.c
+++ b/src/audio/up_down_mixer/up_down_mixer.c
@@ -505,6 +505,21 @@ static int up_down_mixer_trigger(struct comp_dev *dev, int cmd)
 	return comp_set_state(dev, cmd);
 }
 
+static int up_down_mixer_get_attribute(struct comp_dev *dev, uint32_t type, void *value)
+{
+	struct up_down_mixer_data *cd = comp_get_drvdata(dev);
+
+	switch (type) {
+	case COMP_ATTR_BASE_CONFIG:
+		*(struct ipc4_base_module_cfg *)value = cd->base;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
 static const struct comp_driver comp_up_down_mixer = {
 	.uid	= SOF_RT_UUID(up_down_mixer_comp_uuid),
 	.tctx	= &up_down_mixer_comp_tr,
@@ -515,6 +530,7 @@ static const struct comp_driver comp_up_down_mixer = {
 		.copy			= up_down_mixer_copy,
 		.prepare		= up_down_mixer_prepare,
 		.reset			= up_down_mixer_reset,
+		.get_attribute		= up_down_mixer_get_attribute,
 	},
 };
 

--- a/src/include/ipc4/copier.h
+++ b/src/include/ipc4/copier.h
@@ -321,9 +321,6 @@ struct ipc4_data_segment_enabled {
 } __attribute__((packed, aligned(4)));
 
 struct copier_data {
-	/* Must be the 1st field, function ipc4_comp_get_base_module_cfg casts components
-	 * private data as ipc4_base_module_cfg!
-	 */
 	struct ipc4_copier_module_cfg config;
 	struct comp_dev *endpoint[IPC4_COPIER_MODULE_OUTPUT_PINS_COUNT];
 	struct comp_buffer *endpoint_buffer[IPC4_COPIER_MODULE_OUTPUT_PINS_COUNT];

--- a/src/include/sof/audio/aria/aria.h
+++ b/src/include/sof/audio/aria/aria.h
@@ -53,9 +53,6 @@ int aria_process_data(struct comp_dev *dev, int32_t *__restrict dst,
  * \brief Aria component private data.
  */
 struct aria_data {
-	/* Must be the 1st field, function ipc4_comp_get_base_module_cfg casts components
-	 * private data as ipc4_base_module_cfg!
-	 */
 	struct ipc4_base_module_cfg base;
 
 	/* channels count */

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -129,6 +129,7 @@ enum {
 #define COMP_ATTR_HOST_BUFFER	1	/**< Comp host buffer attribute */
 #define COMP_ATTR_COPY_DIR	2	/**< Comp copy direction */
 #define COMP_ATTR_VDMA_INDEX	3	/**< Comp index of the virtual DMA at the gateway. */
+#define COMP_ATTR_BASE_CONFIG	4	/**< Component base config */
 /** @}*/
 
 /** \name Trace macros
@@ -936,16 +937,6 @@ static inline int comp_get_state(struct comp_dev *req_dev, struct comp_dev *dev)
  */
 int comp_verify_params(struct comp_dev *dev, uint32_t flag,
 		       struct sof_ipc_stream_params *params);
-
-#if CONFIG_IPC_MAJOR_4
-/**
- * Temporary ugly function to get components base configuration. Fix me!
- */
-static inline struct ipc4_base_module_cfg *ipc4_comp_get_base_module_cfg(struct comp_dev *dev)
-{
-	return (struct ipc4_base_module_cfg *)comp_get_drvdata(dev);
-}
-#endif
 
 /** @}*/
 

--- a/src/include/sof/audio/module_adapter/module/generic.h
+++ b/src/include/sof/audio/module_adapter/module/generic.h
@@ -50,6 +50,7 @@ static const struct comp_driver comp_##adapter##_module = { \
 		.free = module_adapter_free, \
 		.set_large_config = module_set_large_config,\
 		.get_large_config = module_get_large_config,\
+		.get_attribute = module_adapter_get_attribute,\
 	}, \
 }; \
 \
@@ -333,5 +334,6 @@ int module_set_large_config(struct comp_dev *dev, uint32_t param_id, bool first_
 			    bool last_block, uint32_t data_offset, char *data);
 int module_get_large_config(struct comp_dev *dev, uint32_t param_id, bool first_block,
 			    bool last_block, uint32_t *data_offset, char *data);
+int module_adapter_get_attribute(struct comp_dev *dev, uint32_t type, void *value);
 
 #endif /* __SOF_AUDIO_MODULE_GENERIC__ */

--- a/src/include/sof/audio/up_down_mixer/up_down_mixer.h
+++ b/src/include/sof/audio/up_down_mixer/up_down_mixer.h
@@ -114,9 +114,6 @@ static inline enum ipc4_channel_index get_channel_index(const channel_map map,
  * \brief up_down_mixer component private data.
  */
 struct up_down_mixer_data {
-	/* Must be the 1st field, function ipc4_comp_get_base_module_cfg casts components
-	 * private data as ipc4_base_module_cfg!
-	 */
 	struct ipc4_base_module_cfg base;
 	/** Number of channels in the input buffer. */
 	size_t in_channel_no;

--- a/src/include/sof/audio/volume.h
+++ b/src/include/sof/audio/volume.h
@@ -208,7 +208,8 @@ static inline vol_scale_func vol_get_processing_function(struct comp_dev *dev,
 static inline vol_scale_func vol_get_processing_function(struct comp_dev *dev,
 							 struct comp_buffer __sparse_cache *sinkb)
 {
-	struct vol_data *cd = comp_get_drvdata(dev);
+	struct processing_module *mod = comp_get_drvdata(dev);
+	struct vol_data *cd = module_get_private_data(mod);
 
 	switch (cd->base.audio_fmt.depth) {
 	case IPC4_DEPTH_16BIT:


### PR DESCRIPTION
Just copy the entire mailbox into the confid data for IPC4.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>