### PR TITLE
[SKIP CI] Exclude dai-legacy.h from doxygen to avoid clashes with dai-zephyr.h

### DIFF
--- a/src/include/sof/lib/dai-legacy.h
+++ b/src/include/sof/lib/dai-legacy.h
@@ -10,6 +10,8 @@
  */
 
 /**
+  * \cond XTOS_DUP_FIXME
+  *
   * \file include/sof/lib/dai.h
   * \brief DAI Drivers definition
   * \author Liam Girdwood <liam.r.girdwood@linux.intel.com>
@@ -564,3 +566,5 @@ void dai_dma_position_update(struct comp_dev *dev);
 /** @}*/
 
 #endif /* __SOF_LIB_DAI_LEGACY_H__ */
+
+/** \endcond */


### PR DESCRIPTION
This fixes the sof-docs build and stops producing a dai-drivers-api.html
garbage that randomly mixed the two .h files.

```
Warning: Duplicate target detected:
    group__sof__dai__drivers_1ga8c720c310f408b2f97ce014562d6a910
sof-docs/api/dai-drivers-api.rst:4: WARNING: Duplicate ID:
   "group__sof__dai__drivers_1ga8c720c310f408b2f97ce014562d6a910".
sof-docs/api/dai-drivers-api.rst:4: WARNING: Duplicate explicit target name:
   "group__sof__dai__drivers_1ga8c720c310f408b2f97ce014562d6a910".

sof/sof-docs/api/dai-drivers-api.rst:6: WARNING:
  Duplicate declaration, const struct device* dai::drv
```

(Temporarily?) fixes commit 015ec63c4dad7d5bf ("zephyr: add glue code to
use zephyr dai drivers") that introduced a lot of duplication with
dai-zephyr.h. See more details at
https://github.com/thesofproject/sof/pull/5731#issuecomment-1175630147

Signed-off-by: Marc Herbert <marc.herbert@intel.com>