### PR TITLE
[TEST Zephyr] intel_adsp: Use device tree to enable/disable each HDA driver #47565

### DIFF
--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -374,7 +374,7 @@ def west_init_update():
 	#
 	# z_remote = "https://somewhere.else"
 	# z_ref = "pull/38374/head"
-	# z_ref = "cb9a279050c4e8ad4663ee78688d8e7de1cac953"
+	z_ref = "572ccd531dca072c56a143dbe2ac142299f7f83f"
 
 	# SECURITY WARNING for reviewers: never allow unknown code from
 	# unknown submitters on any CI system.


### PR DESCRIPTION
Testing untested https://github.com/zephyrproject-rtos/zephyr/pull/47565
`intel_adsp: Use device tree to enable/disable each HDA driver` which was merged to avoid (thoroughly tested) revert https://github.com/zephyrproject-rtos/zephyr/pull/47524)

Signed-off-by: Marc Herbert <marc.herbert@intel.com>