### PR TITLE
xtensa-build-zephyr.py: speed up thanks to an _actually_ shallow clone

### DIFF
--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -380,7 +380,7 @@ def west_init_update():
 	# unknown submitters on any CI system.
 
 	execute_command(["git", "clone", "--depth", "5", args.url, str(zephyr_dir)], timeout=1200)
-	execute_command(["git", "fetch", z_remote, z_ref], timeout=300, cwd=zephyr_dir)
+	execute_command(["git", "fetch", "--depth", "5", z_remote, z_ref], timeout=300, cwd=zephyr_dir)
 	execute_command(["git", "checkout", "FETCH_HEAD"], cwd=zephyr_dir)
 	execute_command(["git", "-C", str(zephyr_dir), "--no-pager", "log", "--oneline", "--graph",
 		"--decorate", "--max-count=20"])


### PR DESCRIPTION
This will significantly speed up CI in some cases.

Fixes commit ffdf001eeeba ("xtensa-build-zephyr.py: clone zephyr with
--depth 5")

When I added --depth 5 to git clone in that commit I naively assumed git
fetch would "inherit" that. I think it does but only when fetching an
_existing_ (and shallow) branch, not when fetching something new.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>