### PR TITLE
[skip ci, TEST,DO_NOT_REVIEW]topology2: add num_source/sink_pins tokens for widget

### DIFF
--- a/tools/topology/topology2/cavs/cavs-nocodec.conf
+++ b/tools/topology/topology2/cavs/cavs-nocodec.conf
@@ -9,6 +9,8 @@
 <vendor-token.conf>
 <manifest.conf>
 <pdm_config.conf>
+<sink_pin_binding.conf>
+<src_pin_binding.conf>
 <tokens.conf>
 <virtual.conf>
 <passthrough-playback.conf>
@@ -143,6 +145,18 @@ Object.Pipeline {
 		}
 		Object.Widget.copier.1 {
 			stream_name 'SSP0 Playback'
+			Object.Base.src_pin_binding.1 {
+				src_pin_binding_wname	"copier.SSP.2.1"
+			}
+			Object.Base.src_pin_binding.2 {
+				src_pin_binding_wname	"NC"
+			}
+			Object.Base.src_pin_binding.3 {
+				src_pin_binding_wname	"NC"
+			}
+			Object.Base.src_pin_binding.4 {
+				src_pin_binding_wname	"NC"
+			}
 		}
 	}
 

--- a/tools/topology/topology2/include/common/sink_pin_binding.conf
+++ b/tools/topology/topology2/include/common/sink_pin_binding.conf
@@ -1,0 +1,34 @@
+#
+# The sink pin binding class definition. All attributes defined herein are
+# namespaced by alsatplg to "Object.Base.sink_pin_binding.instance.attribute_name".
+#
+# Usage: Sink pin binding objects can be instantiated as
+#
+#	Object.Base.sink_pin_binding."0" {
+#		wname	"copier.host.1.0"
+#	}
+#
+# where 0 is the unique instance name for the sink_pin_binding object within the
+# same alsaconf node.
+
+Class.Base."sink_pin_binding" {
+
+	DefineAttribute."instance" {}
+
+	# The widget name that the sink pin should be bound with.
+	DefineAttribute."sink_pin_binding_wname" {
+		token_ref "sof_tkn_comp.string"
+	}
+
+	attributes {
+		!constructor [
+			"instance"
+		]
+
+		!mandatory [
+			"sink_pin_binding_wname"
+		]
+
+		unique	"instance"
+	}
+}

--- a/tools/topology/topology2/include/common/src_pin_binding.conf
+++ b/tools/topology/topology2/include/common/src_pin_binding.conf
@@ -1,0 +1,37 @@
+#
+# The source pin binding class definition. All attributes defined herein are
+# namespaced by alsatplg to "Object.Base.src_pin_binding.instance.attribute_name".
+#
+# Usage: Source pin binding objects can be instantiated as
+#
+#	Object.Base.src_pin_binding."0" {
+#		wname	"copier.host.1.0"
+#	}
+#
+# where 0 is the unique instance name for the src_pin_binding object within the
+# same alsaconf node.
+
+Class.Base."src_pin_binding" {
+
+	DefineAttribute."instance" {}
+
+	# The widget name that the source pin should be bound with.
+	DefineAttribute."src_pin_binding_wname" {
+		token_ref "sof_tkn_comp.string"
+	}
+
+	attributes {
+		!constructor [
+			"instance"
+		]
+
+		!mandatory [
+			"src_pin_binding_wname"
+		]
+		#
+		# id attribute values for pin_binding_widget objects must be unique in the
+		# same alsaconf node
+		#
+		unique	"instance"
+	}
+}

--- a/tools/topology/topology2/include/common/tokens.conf
+++ b/tools/topology/topology2/include/common/tokens.conf
@@ -17,6 +17,10 @@ Object.Base.VendorToken {
 		num_audio_formats	410
 		num_sink_pins		411
 		num_source_pins		412
+		# The token for sink/source pin binding, it specifies
+		# the widget name that the queue is connected from/to.
+		sink_pin_binding_wname	413
+		src_pin_binding_wname	414
 	}
 
 	"sof_tkn_dai" {

--- a/tools/topology/topology2/include/common/tokens.conf
+++ b/tools/topology/topology2/include/common/tokens.conf
@@ -15,6 +15,8 @@ Object.Base.VendorToken {
 		cpc			406
 		is_pages		409
 		num_audio_formats	410
+		num_sink_pins		411
+		num_source_pins		412
 	}
 
 	"sof_tkn_dai" {

--- a/tools/topology/topology2/include/components/cavs/src.conf
+++ b/tools/topology/topology2/include/components/cavs/src.conf
@@ -64,6 +64,8 @@ Class.Widget."src" {
 
 		!mandatory [
 			"rate_out"
+			"num_sink_pins"
+			"num_source_pins"
 		]
 
 		#
@@ -93,4 +95,6 @@ Class.Widget."src" {
 	no_pm		"true"
 
 	rate_out	48000
+	num_sink_pins	1
+	num_source_pins	1
 }

--- a/tools/topology/topology2/include/components/copier.conf
+++ b/tools/topology/topology2/include/components/copier.conf
@@ -157,6 +157,8 @@ Class.Widget."copier" {
 			"no_pm"
 			"uuid"
 			"copier_type"
+			"num_sink_pins"
+			"num_source_pins"
 		]
 
 		#
@@ -185,6 +187,8 @@ Class.Widget."copier" {
 	core_id	0
 	cpc		1647
 	bss_size	280
+	num_sink_pins	1
+	num_source_pins	4
 
 	# math expression for computing is_pages
 	is_pages "$[(($bss_size + 4095) & -4095) / 4096]"

--- a/tools/topology/topology2/include/components/gain.conf
+++ b/tools/topology/topology2/include/components/gain.conf
@@ -92,6 +92,15 @@ Class.Widget."gain" {
 			"index"
 			"instance"
 		]
+		#
+		# mandatory attributes that must be provided when the buffer class is instantiated
+		#
+		!mandatory [
+			"no_pm"
+			"uuid"
+			"num_sink_pins"
+			"num_source_pins"
+		]
 
 		#
 		# immutable attributes cannot be modified in the object instance
@@ -154,4 +163,6 @@ Class.Widget."gain" {
 	curve_type		"linear"
 	curve_duration		10
 	init_value		0x7fffffff
+	num_sink_pins	1
+	num_source_pins	1
 }

--- a/tools/topology/topology2/include/components/mixin.conf
+++ b/tools/topology/topology2/include/components/mixin.conf
@@ -78,6 +78,8 @@ Class.Widget."mixin" {
 			"no_pm"
 			"uuid"
 			"mix_type"
+			"num_sink_pins"
+			"num_source_pins"
 		]
 
 		#
@@ -125,4 +127,6 @@ Class.Widget."mixin" {
 	no_pm 		"true"
 	core_id	0
 	cpc 910
+	num_sink_pins	1
+	num_source_pins	3
 }

--- a/tools/topology/topology2/include/components/mixout.conf
+++ b/tools/topology/topology2/include/components/mixout.conf
@@ -78,6 +78,8 @@ Class.Widget."mixout" {
 			"no_pm"
 			"uuid"
 			"mix_type"
+			"num_sink_pins"
+			"num_source_pins"
 		]
 
 		#
@@ -125,4 +127,6 @@ Class.Widget."mixout" {
 	no_pm 		"true"
 	core_id	0
 	cpc 		5000
+	num_sink_pins	8
+	num_source_pins	1
 }

--- a/tools/topology/topology2/include/components/widget-common.conf
+++ b/tools/topology/topology2/include/components/widget-common.conf
@@ -82,3 +82,15 @@ DefineAttribute."preload_count" {
 	# Token set reference name and type
 	token_ref	"sof_tkn_comp.word"
 }
+
+# Number of sink pins a widget can support
+DefineAttribute."num_sink_pins" {
+	# Token set reference name and type
+	token_ref	"sof_tkn_comp.word"
+}
+
+# Number of source pins a widget can support
+DefineAttribute."num_source_pins" {
+	# Token set reference name and type
+	token_ref	"sof_tkn_comp.word"
+}


### PR DESCRIPTION
These two tokens will be used by the kernel to decide the
supported number of source/sink pins, thus to allocate
correct widget queue id in route setup.

Signed-off-by: Chao Song <chao.song@linux.intel.com>

This sof PR is used to test https://github.com/thesofproject/linux/pull/3746, and can also be a demo for adding num_source_pins & num_sink_pins.

I'd like to make those two attributes mandatory, because it is very natural and intuitive to know how many input pins and output pins a widget can support.