### PR TITLE
[SKIP CI] Use west manifest in SOF

### DIFF
--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -13,13 +13,16 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         # From time to time this will catch a git tag and change SOF_VERSION
-        with: {fetch-depth: 10, submodules: recursive}
+        with:
+          fetch-depth: 10
+          path: ./workspace/sof
 
       # https://github.com/zephyrproject-rtos/docker-image
       # Note: env variables can be passed to the container with
       # -e https_proxy=...
       - name: build
-        run: docker run -v "$(pwd)":/workdir
+        run: docker run -v "$(pwd)/workspace":/workspace
+             --workdir /workspace
              ghcr.io/zephyrproject-rtos/zephyr-build:latest
-             ./zephyr/docker-build.sh --cmake-args=-DEXTRA_CFLAGS=-Werror
-             --cmake-args=--warn-uninitialized   -a
+             ./sof/zephyr/docker-build.sh --cmake-args=-DEXTRA_CFLAGS=-Werror
+             --cmake-args=--warn-uninitialized -a

--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -17,6 +17,10 @@ import os
 import warnings
 # anytree module is defined in Zephyr build requirements
 from anytree import AnyNode, RenderTree
+from packaging import version
+
+# Version of this script matching Major.Minor.Patch style.
+VERSION = version.Version("2.0.0")
 
 # Constant value resolves SOF_TOP directory as: "this script directory/.."
 SOF_TOP = pathlib.Path(__file__).parents[1].resolve()
@@ -210,6 +214,8 @@ Otherwise, all firmware files are installed in the same staging directory by def
 			    help="""Run script in non-interactive mode when user input can not be provided.
 This should be used with programmatic script invocations (eg. Continuous Integration).
 				""")
+	parser.add_argument("--version", required=False, action="store_true",
+			    help="Prints version of this script.")
 
 	args = parser.parse_args()
 
@@ -572,6 +578,9 @@ def build_platforms():
 
 def main():
 	parse_args()
+	if args.version:
+		print(VERSION)
+		sys.exit(0)
 	check_west_installation()
 	if len(args.platforms) == 0:
 		print("No platform build requested")

--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -21,7 +21,7 @@ from anytree import AnyNode, RenderTree
 # Constant value resolves SOF_TOP directory as: "this script directory/.."
 SOF_TOP = pathlib.Path(__file__).parents[1].resolve()
 west_top = pathlib.Path(SOF_TOP, "..").resolve()
-default_rimage_key = pathlib.Path("modules", "audio", "sof", "keys", "otc_private_key.pem")
+default_rimage_key = pathlib.Path(SOF_TOP, "keys", "otc_private_key.pem")
 
 sof_version = None
 
@@ -66,7 +66,7 @@ platform_list = [
 		"IPC4_RIMAGE_DESC": "tgl-cavs.toml",
 		"XTENSA_CORE": "cavs2x_LX6HiFi3_2017_8",
 		"XTENSA_TOOLS_VERSION": f"RG-2017.8{xtensa_tools_version_postfix}",
-		"RIMAGE_KEY": pathlib.Path("modules", "audio", "sof", "keys", "otc_private_key_3k.pem")
+		"RIMAGE_KEY": pathlib.Path(SOF_TOP, "keys", "otc_private_key_3k.pem")
 	},
 	{
 		"name": "tgl-h",
@@ -75,7 +75,7 @@ platform_list = [
 		"IPC4_RIMAGE_DESC": "tgl-h-cavs.toml",
 		"XTENSA_CORE": "cavs2x_LX6HiFi3_2017_8",
 		"XTENSA_TOOLS_VERSION": f"RG-2017.8{xtensa_tools_version_postfix}",
-		"RIMAGE_KEY": pathlib.Path("modules", "audio", "sof", "keys", "otc_private_key_3k.pem")
+		"RIMAGE_KEY": pathlib.Path(SOF_TOP, "keys", "otc_private_key_3k.pem")
 	},
 	# NXP platforms
 	{
@@ -499,8 +499,7 @@ def build_platforms():
 		execute_command([str(smex_executable), "-l", str(fw_ldc_file), str(input_elf_file)])
 		# CMake - configure rimage module
 		rimage_dir_name="build-rimage"
-		sof_mirror_dir = pathlib.Path("modules", "audio", "sof")
-		rimage_source_dir = pathlib.Path(sof_mirror_dir, "rimage")
+		rimage_source_dir = pathlib.Path(SOF_TOP, "rimage")
 		execute_command(["cmake", "-B", rimage_dir_name, "-S", str(rimage_source_dir)],
 			cwd=west_top)
 		# CMake build rimage module
@@ -508,7 +507,7 @@ def build_platforms():
 			cwd=west_top)
 		# Sign firmware
 		rimage_executable = shutil.which("rimage", path=pathlib.Path(west_top, rimage_dir_name))
-		rimage_config = pathlib.Path(sof_mirror_dir, "rimage", "config")
+		rimage_config = pathlib.Path(SOF_TOP, "rimage", "config")
 		sign_cmd = ["west"]
 		sign_cmd += ["-v"] * args.verbose
 		sign_cmd += ["sign", "--build-dir", platform_build_dir_name, "--tool", "rimage"]

--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -206,6 +206,11 @@ Default key type subdirectory is \"community\".""")
 			    help="""Use an output subdirectory for each platform.
 Otherwise, all firmware files are installed in the same staging directory by default.""")
 
+	parser.add_argument("--no-interactive", default=False, action="store_true",
+			    help="""Run script in non-interactive mode when user input can not be provided.
+This should be used with programmatic script invocations (eg. Continuous Integration).
+				""")
+
 	args = parser.parse_args()
 
 	if args.all:
@@ -272,18 +277,48 @@ def check_west_installation():
 			"https://docs.zephyrproject.org/latest/getting_started/index.html")
 	print(f"Found west: {west_path}")
 
-def find_west_workspace():
-	"""[summary] Validates whether west workspace had been initialized and points to SOF manifest.
+def west_reinitialize(west_root_dir: pathlib.Path, west_manifest_path: pathlib.Path):
+	"""[summary] Performs west reinitialization to SOF manifest file asking user for permission.
+	Prints error message if script is running in non-interactive mode.
 
-	:return: [description] Returns west topdir and path to west manifest west.yml, otherwise None, None.
-	:rtype: [type] bool, pathlib.Path
+	:param west_root_dir: directory where is initialized.
+	:type west_root_dir: pathlib.Path
+	:param west_manifest_path: manifest file to which west is initialized.
+	:type west_manifest_path: pathlib.Path
+	:raises RuntimeError: Raised when west is initialized to wrong manifest file
+	(not SOFs manifest) and script is running in non-interactive mode.
+	"""
+	global west_top
+	message = "West is initialized to manifest other than SOFs!\n"
+	message +=  f"Initialized to manifest: {west_manifest_path}." + "\n"
+	dot_west_directory  = pathlib.Path(west_root_dir.resolve(), ".west")
+	if args.no_interactive:
+		message += f"Try deleting {dot_west_directory } directory and rerun this script."
+		raise RuntimeError(message)
+	question = message + "Reinitialize west to SOF manifest? [Y/n] "
+	print(f"{question}")
+	while True:
+		reinitialize_answer = input().lower()
+		if reinitialize_answer == "y" or reinitialize_answer == "n":
+			break
+		sys.stdout.write('Please respond with \'Y\' or \'n\'.\n')
+
+	if reinitialize_answer != 'y':
+		sys.exit("Can not proceed. Reinitialize your west manifest to SOF and rerun this script.")
+	shutil.rmtree(dot_west_directory)
+	execute_command(["west", "init", "-l", f"{SOF_TOP}"], cwd=west_top)
+
+def west_init_if_needed():
+	"""[summary] Validates whether west workspace had been initialized and points to SOF manifest.
+	Peforms west initialization if needed.
 	"""
 	global west_top, SOF_TOP
 	west_manifest_path = pathlib.Path(SOF_TOP, "west.yml")
 	result_rootdir = execute_command(["west", "topdir"], capture_output=True, cwd=west_top,
 		timeout=10, check=False)
 	if result_rootdir.returncode != 0:
-		return None, None
+		execute_command(["west", "init", "-l", f"{SOF_TOP}"], cwd=west_top)
+		return
 	west_root_dir = pathlib.Path(result_rootdir.stdout.decode().strip('\n')).resolve()
 	result_manifest_dir = execute_command(["west", "config", "manifest.path"], capture_output=True,
 		cwd=west_top, timeout=10, check=True)
@@ -291,20 +326,11 @@ def find_west_workspace():
 	manifest_file_result = execute_command(["west", "config", "manifest.file"], capture_output=True,
 		cwd=west_top, timeout=10, check=True)
 	returned_manifest_path = pathlib.Path(west_manifest_dir, manifest_file_result.stdout.decode().strip('\n'))
-	west_workspace_dir = pathlib.Path(west_root_dir, ".west")
-	if str(returned_manifest_path) != str(west_manifest_path):
-		message = "West is initialized to manifest other than SOFs!\n"
-		message += f"Initialized to manifest: {returned_manifest_path}." + "\n"
-		message += f"Try removing {west_workspace_dir} directory and rerun this script."
-		raise RuntimeError(message)
-	return west_workspace_dir, west_manifest_path
-	for path in paths:
-		if path.is_dir():
-			result = execute_command(["west", "topdir"], capture_output=True,
-						 text=True, check=False, cwd=path)
-		if result.returncode == 0:
-			return pathlib.Path(result.stdout.rstrip(os.linesep))
-	return None
+	if not returned_manifest_path.samefile(west_manifest_path):
+		west_reinitialize(west_root_dir, returned_manifest_path)
+	else:
+		print(f"West workspace: {west_root_dir}")
+		print(f"West manifest path: {west_manifest_path}")
 
 def create_zephyr_directory():
 	global west_top
@@ -342,17 +368,6 @@ def create_zephyr_sof_symlink():
 			"see: https://docs.microsoft.com/en-us/windows/security/threat-protection/"
 			"security-policy-settings/create-symbolic-links")
 		raise
-
-def west_init():
-	"""[summary] Performs west initialization.
-	"""
-	global west_top
-	west_workspace_dir, west_manifest_path = find_west_workspace()
-	if not west_workspace_dir:
-		execute_command(["west", "init", "-l", str(SOF_TOP)], check=True, cwd=west_top)
-		return
-	print(f"West workspace: {west_workspace_dir}")
-	print(f"West manifest path: {west_manifest_path}")
 
 def west_update():
 	"""[summary] Clones all west manifest projects to specified revisions"""
@@ -470,7 +485,12 @@ def build_platforms():
 			build_cmd.append(f"-DOVERLAY_CONFIG={overlays}")
 
 		# Build
-		execute_command(build_cmd, cwd=west_top)
+		try:
+			execute_command(build_cmd, cwd=west_top)
+		except:
+			zephyr_path = pathlib.Path(west_top, "zephyr")
+			if not os.path.exists(zephyr_path):
+				sys.exit("Zephyr project not found. Please run this script with -c flag or clone manually.")
 		smex_executable = pathlib.Path(west_top, platform_build_dir_name, "zephyr", "smex_ep",
 			"build", "smex")
 		fw_ldc_file = pathlib.Path(sof_platform_output_dir, f"sof-{platform}.ldc")
@@ -559,7 +579,8 @@ def main():
 	else:
 		print("Building platforms: {}".format(" ".join(args.platforms)))
 
-	west_init()
+	west_init_if_needed()
+
 	if args.update:
 		# Initialize zephyr project with west
 		west_update()

--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -20,8 +20,7 @@ from anytree import AnyNode, RenderTree
 
 # Constant value resolves SOF_TOP directory as: "this script directory/.."
 SOF_TOP = pathlib.Path(__file__).parents[1].resolve()
-# Default value may be overriten by -p arg
-west_top = pathlib.Path(SOF_TOP, "zephyrproject")
+west_top = pathlib.Path(SOF_TOP, "..").resolve()
 default_rimage_key = pathlib.Path("modules", "audio", "sof", "keys", "otc_private_key.pem")
 
 sof_version = None
@@ -173,34 +172,13 @@ Noted that with fw_naming set as 'AVS', there will be output subdirectories for 
 						help="Path to a non-default rimage signing key.")
 	parser.add_argument("-o", "--overlay", type=pathlib.Path, required=False, action='append',
 						default=[], help="Paths to overlays")
-	parser.add_argument("-z", "--zephyr-ref", required=False,
-						help="Initial Zephyr git ref for the -c option."
-						" Can be a branch, tag, full SHA1 in a fork")
-	parser.add_argument("-u", "--url", required=False,
-						default="https://github.com/zephyrproject-rtos/zephyr/",
-						help="URL to clone Zephyr from")
-	mode_group = parser.add_mutually_exclusive_group()
-	mode_group.add_argument("-p", "--west_path", required=False, type=pathlib.Path,
-				help="""Points to existing Zephyr project directory. Incompatible with -c.
-Uses by default path used by -c mode: SOF_TOP/zephyrproject.
-If zephyr-project/modules/audio/sof is missing then a
-symbolic link pointing to SOF_TOP directory will automatically be
-created and west will recognize it as its new sof module.
-If zephyr-project/modules/audio/sof already exists and is a
-different copy than where this script is run from, then the
-behavior is undefined.
-This -p option is always required_if the real (not symbolic)
-sof/ and zephyr-project/ directories are not nested in one
-another.""",
-	)
-	mode_group.add_argument("-c", "--clone_mode", required=False, action="store_true",
-				help="""Using west, downloads inside this sof clone a new Zephyr
-project with the required git repos. Creates a
-sof/zephyrproject/modules/audio/sof symbolic link pointing
-back at this sof clone.
-Incompatible with -p. To stop after downloading Zephyr, do not
-pass any platform or cmake argument.""",
-	)
+	parser.add_argument("-p", "--pristine", required=False, action="store_true",
+						help="Perform pristine build removing build directory.")
+	parser.add_argument("-u", "--update", required=False, action="store_true",
+		help="""Runs west update command - clones SOF dependencies. Downloads next to this sof clone a new Zephyr
+project with its required dependencies. Creates a modules/audio/sof symbolic link pointing
+back at this sof clone.  All projects are checkout out to
+revision defined in manifests of SOF and Zephyr.""")
 	parser.add_argument('-v', '--verbose', default=0, action='count',
 			    help="""Verbosity level. Repetition of the flag increases verbosity.
 The same number of '-v' is passed to "west".
@@ -245,15 +223,7 @@ Otherwise, all firmware files are installed in the same staging directory by def
 		if args.ipc != "IPC4":
 			args.ipc="IPC4"
 			warnings.warn(f"The option '--fw-naming AVS' has to be used with '-i IPC4'. Enable '-i IPC4' automatically.")
-	if args.zephyr_ref and not args.clone_mode:
-		raise RuntimeError(f"Argument -z without -c makes no sense")
-	if args.clone_mode and not args.zephyr_ref:
-		args.zephyr_ref = "main"	# set default name for -z if -c specified
 
-	if args.west_path: # let the user provide an already existing zephyrproject/ anywhere
-		west_top = pathlib.Path(args.west_path)
-	elif not args.clone_mode:	# if neather -p nor -c provided, use -p
-		args.west_path = west_top
 
 def execute_command(*run_args, **run_kwargs):
 	"""[summary] Provides wrapper for subprocess.run that prints
@@ -303,14 +273,31 @@ def check_west_installation():
 	print(f"Found west: {west_path}")
 
 def find_west_workspace():
-	"""[summary] Scans for west workspaces using west topdir command by checking script execution
-	west_top and SOF_TOP directories.
+	"""[summary] Validates whether west workspace had been initialized and points to SOF manifest.
 
-	:return: [description] Returns path when west workspace had been found, otherwise None
+	:return: [description] Returns west topdir and path to west manifest west.yml, otherwise None, None.
 	:rtype: [type] bool, pathlib.Path
 	"""
 	global west_top, SOF_TOP
-	paths = [ pathlib.Path(os.getcwd()), SOF_TOP, west_top]
+	west_manifest_path = pathlib.Path(SOF_TOP, "west.yml")
+	result_rootdir = execute_command(["west", "topdir"], capture_output=True, cwd=west_top,
+		timeout=10, check=False)
+	if result_rootdir.returncode != 0:
+		return None, None
+	west_root_dir = pathlib.Path(result_rootdir.stdout.decode().strip('\n')).resolve()
+	result_manifest_dir = execute_command(["west", "config", "manifest.path"], capture_output=True,
+		cwd=west_top, timeout=10, check=True)
+	west_manifest_dir = pathlib.Path(west_root_dir, result_manifest_dir.stdout.decode().strip('\n')).resolve()
+	manifest_file_result = execute_command(["west", "config", "manifest.file"], capture_output=True,
+		cwd=west_top, timeout=10, check=True)
+	returned_manifest_path = pathlib.Path(west_manifest_dir, manifest_file_result.stdout.decode().strip('\n'))
+	west_workspace_dir = pathlib.Path(west_root_dir, ".west")
+	if str(returned_manifest_path) != str(west_manifest_path):
+		message = "West is initialized to manifest other than SOFs!\n"
+		message += f"Initialized to manifest: {returned_manifest_path}." + "\n"
+		message += f"Try removing {west_workspace_dir} directory and rerun this script."
+		raise RuntimeError(message)
+	return west_workspace_dir, west_manifest_path
 	for path in paths:
 		if path.is_dir():
 			result = execute_command(["west", "topdir"], capture_output=True,
@@ -356,38 +343,22 @@ def create_zephyr_sof_symlink():
 			"security-policy-settings/create-symbolic-links")
 		raise
 
-def west_init_update():
-	"""[summary] Downloads zephyrproject inside sof/ and create a ../../.. symbolic
-	link back to sof/"""
-	global west_top, SOF_TOP
-	zephyr_dir = pathlib.Path(west_top, "zephyr")
+def west_init():
+	"""[summary] Performs west initialization.
+	"""
+	global west_top
+	west_workspace_dir, west_manifest_path = find_west_workspace()
+	if not west_workspace_dir:
+		execute_command(["west", "init", "-l", str(SOF_TOP)], check=True, cwd=west_top)
+		return
+	print(f"West workspace: {west_workspace_dir}")
+	print(f"West manifest path: {west_manifest_path}")
 
-	z_remote = "origin"
-	z_ref = args.zephyr_ref
+def west_update():
+	"""[summary] Clones all west manifest projects to specified revisions"""
+	global west_top
+	execute_command(["west", "update"], check=True, timeout=3000, cwd=west_top)
 
-	# Example of how to override SOF CI and point it at any Zephyr
-	# commit from anywhere and to run all tests on it. Simply
-	# uncomment and edit these lines and submit as an SOF Pull
-	# Request. Note: unlike many git servers, github allows direct
-	# fetching of (full 40-digits) SHAs; even SHAs not in origin but
-	# in forks! See the end of "git help fetch-pack".
-	#
-	# z_remote = "https://somewhere.else"
-	# z_ref = "pull/38374/head"
-	# z_ref = "cb9a279050c4e8ad4663ee78688d8e7de1cac953"
-
-	# SECURITY WARNING for reviewers: never allow unknown code from
-	# unknown submitters on any CI system.
-
-	execute_command(["git", "clone", "--depth", "5", args.url, str(zephyr_dir)], timeout=1200)
-	execute_command(["git", "fetch", "--depth", "5", z_remote, z_ref], timeout=300, cwd=zephyr_dir)
-	execute_command(["git", "checkout", "FETCH_HEAD"], cwd=zephyr_dir)
-	execute_command(["git", "-C", str(zephyr_dir), "--no-pager", "log", "--oneline", "--graph",
-		"--decorate", "--max-count=20"])
-	execute_command(["west", "init", "-l", str(zephyr_dir)])
-	create_zephyr_sof_symlink()
-	# Do NOT "west update sof"!!
-	execute_command(["west", "update", "zephyr", "hal_xtensa"], timeout=300, cwd=west_top)
 
 def get_sof_version(abs_build_dir):
 	"""[summary] Get version string major.minor.micro of SOF firmware
@@ -416,16 +387,6 @@ def build_platforms():
 	print(f"SOF_TOP={SOF_TOP}")
 	print(f"west_top={west_top}")
 
-	# Verify that zephyrproject is initialized and that it has a
-	# correct pointer back to us SOF.  create_zephyr_sof_symlink()
-	# takes care of that but it's optional; maybe cloning was done
-	# outside this script.  The link can also fail when hopping in
-	# and out of a container.  Without this check, a not found SOF
-	# would fail later with surprisingly cryptic Kconfig errors.
-	execute_command(["west", "status", "hal_xtensa", "sof"], cwd=west_top,
-			stdout=subprocess.DEVNULL)
-
-	assert(west_top.exists())
 	global STAGING_DIR
 	STAGING_DIR = pathlib.Path(west_top, "build-sof-staging")
 	# smex does not use 'install -D'
@@ -485,6 +446,8 @@ def build_platforms():
 		build_cmd += ["build", "--build-dir", platform_build_dir_name]
 		source_dir = pathlib.Path(SOF_TOP, "app")
 		build_cmd += ["--board", PLAT_CONFIG, str(source_dir)]
+		if args.pristine:
+			build_cmd += ["-p", "always"]
 
 		build_cmd.append('--')
 		if args.cmake_args:
@@ -588,25 +551,6 @@ def build_platforms():
 			tools_output_dir,
 			symlinks=True, ignore_dangling_symlinks=True, dirs_exist_ok=True)
 
-
-def run_clone_mode():
-	if find_west_workspace():
-		raise RuntimeError("Zephyr found already! Not downloading it again")
-	create_zephyr_directory()
-	west_init_update()
-
-def run_point_mode():
-	global west_top, SOF_TOP
-	west_workspace_path = find_west_workspace()
-	if not west_workspace_path:
-		raise RuntimeError("Failed to find west workspace.\nScanned directories:\n{}\n{}\n{}"
-			.format(os.getcwd(), SOF_TOP, west_top))
-	if not west_workspace_path.exists():
-		raise FileNotFoundError("West topdir returned {} as workspace but it"
-			" does not exist".format(west_workspace_path))
-	west_top = west_workspace_path
-	create_zephyr_sof_symlink()
-
 def main():
 	parse_args()
 	check_west_installation()
@@ -615,13 +559,11 @@ def main():
 	else:
 		print("Building platforms: {}".format(" ".join(args.platforms)))
 
-	# we made two modes mutually exclusive with argparse
-	if args.west_path:
-		# check west_path input + create symlink if needed
-		run_point_mode()
-	if args.clone_mode:
+	west_init()
+	if args.update:
 		# Initialize zephyr project with west
-		run_clone_mode()
+		west_update()
+		create_zephyr_sof_symlink()
 
 	if args.platforms:
 		build_platforms()

--- a/submanifests/README.txt
+++ b/submanifests/README.txt
@@ -1,0 +1,12 @@
+This directory can contain additional west manifest files. Any files
+in this directory will be included in the main west.yml file sorted by
+filename.
+
+For more details about how this works, see this part of the west
+documentation:
+
+https://docs.zephyrproject.org/latest/guides/west/manifest.html#example-2-2-downstream-with-directory-of-manifest-files
+
+Note: do not delete this file if there is no other content in submanifests directory.
+Submanifests directory must exist for west update command to work (even if does not contain any actual manifests).
+This is a known bug, see: https://github.com/zephyrproject-rtos/west/issues/594

--- a/west.yml
+++ b/west.yml
@@ -1,0 +1,38 @@
+# SOF west manifest
+manifest:
+  defaults:
+    remote: thesofproject
+
+  remotes:
+    - name: thesofproject
+      url-base: https://github.com/thesofproject
+    - name: zephyrproject
+      url-base: https://github.com/zephyrproject-rtos
+
+  projects:
+    - name: rimage
+      repo-path: rimage
+      path: sof/rimage
+      revision: 02abc5d342a3ee6965bdc933ea1439d85d0256da
+
+    - name: tomlc99
+      repo-path: tomlc99
+      path: sof/rimage/tomlc99
+      revision: e3a03f5ec7d8d33be705c5ce8a632d998ce9b4d1
+
+      # west update will override your local changes to this revision
+    - name: zephyr
+      repo-path: zephyr
+      revision: 63a497280f22aea39793dd9de9731469a83ce533
+      remote: zephyrproject
+      import:
+        name-whitelist:
+          - hal_xtensa
+          - mbedtls
+          - mipi-sys-t
+          - lz4
+          - tinycrypt
+
+  self:
+    path: sof
+    import: submanifests

--- a/west.yml
+++ b/west.yml
@@ -1,5 +1,7 @@
 # SOF west manifest
 manifest:
+  version: "0.13"
+
   defaults:
     remote: thesofproject
 

--- a/zephyr/docker-build.sh
+++ b/zephyr/docker-build.sh
@@ -13,7 +13,7 @@ set -x
 unset ZEPHYR_BASE
 
 # Make sure we're in the right place
-test -e ./scripts/xtensa-build-zephyr.py
+test -e ./sof/scripts/xtensa-build-zephyr.py
 
 
 # See https://stackoverflow.com/questions/35291520/docker-and-userns-remap-how-to-manage-volume-permissions-to-share-data-betwee + many others
@@ -71,8 +71,4 @@ unset ZEPHYR_SDK_INSTALL_DIR
 ls -ld /opt/toolchains/zephyr-sdk-*
 ln -s  /opt/toolchains/zephyr-sdk-*  ~/ || true
 
-if test -e zephyrproject; then
-    ./scripts/xtensa-build-zephyr.py  "$@"
-else # -c(lone) with west init etc.
-    ./scripts/xtensa-build-zephyr.py -c "$@"
-fi
+./sof/scripts/xtensa-build-zephyr.py -u --no-interactive "$@"


### PR DESCRIPTION
### Implemented west tool along with its manifest to SOF
To use it please install: `pip3 install --user -U west`
### Features

- You may now clone SOF project without git using west init <SOF_URL> command (well... after this PR is merged).
- If you already cloned SOF using git, run command `west init -l <SOF_DIR>` to use west
- You may also use xtensa-build-zephyr.py convenience script that will do this for you
- Executing command `west update` will cause to download SOF dependencies (previously submodules) and zephyr along with dependencies required for SOF platforms building and testing (except modules/audio/sof - we don't need another SOF copy!)
- If you are **not** using xtensa-build-zephyr.py when building with Zephyr, you need to manually create a symlink for Zephyr:
`ln -s ./modules/audio/sof ./sof ` (run in _~/workspace/my_sof_workspace_ see directory structure example below)

### Changes to GIT

- Submodules rimage and tomlc99 are now managed by west and were removed from git submodules
- rimage directory added to .gitignore

### Changes to directory structure of SOF & Zephyr

- Due to west manifest specification we could not maintain existing directory layout where Zephyr is placed in SOF/zephyrproject directory. West manifest requires to have a .west workspace initialized one folder "up" in relation to west.yml manifest. New layout looks like the following (SOF placed side-by-side to Zephyr and its modules):
![image](https://user-images.githubusercontent.com/12482515/178645375-2f859d45-4fa9-42e1-809e-505de791fc79.png)

### Changes to xtensa-build-zephyr.py

- "Clone-mode" (-c flag) had been removed and replaced by new "-u, --update" flag that clones zephyr with required dependencies using west manifest. It differs from old "clone mode" by the fact that if run it will not fail when components are already cloned but will update their revisions to those matching manifest. If you have active changes on the any component, revision will not be updated (but if you have a custom branch with no changes it will be changed to manifest revision).
- "Point-mode" had been completely removed as it is no longer possible to maintain this mode when west manifest expects (and defines!) directory where Zephyr project is located.
- "-z flag" had been removed as you can now set your custom Zephyr revision in the west.yml file.

Signed-off-by: Andrey Borisovich <andrey.borisovich@intel.com>