### PR TITLE
ipc_get_ppl_comp: Prefer returning a dai component

### DIFF
--- a/src/ipc/ipc-common.c
+++ b/src/ipc/ipc-common.c
@@ -131,6 +131,7 @@ struct ipc_comp_dev *ipc_get_ppl_comp(struct ipc *ipc, uint32_t pipeline_id, int
 	struct comp_buffer *buffer;
 	struct comp_dev *buff_comp;
 	struct list_item *clist;
+	struct ipc_comp_dev *next_ppl_icd = NULL;
 
 	list_for_item(clist, &ipc->comp_list) {
 		icd = container_of(clist, struct ipc_comp_dev, list);
@@ -154,12 +155,12 @@ struct ipc_comp_dev *ipc_get_ppl_comp(struct ipc *ipc, uint32_t pipeline_id, int
 
 			/* Next component is placed on another pipeline */
 			if (buff_comp && dev_comp_pipe_id(buff_comp) != pipeline_id)
-				return icd;
+				next_ppl_icd = icd;
 		}
 
 	}
 
-	return NULL;
+	return next_ppl_icd;
 }
 
 void ipc_send_queued_msg(void)


### PR DESCRIPTION
Before the introduced optimization in commit
<95f6f88be705> ipc: Simplication of the ipc_get_ppl_comp function
this function first walks a list of components looking for dai, then it again walks the list looking for a component which connecting two pipelines. Optimization changed the behavior, and the first matching dai or connector was returned. This patch 
reverts to the previous behavior. Pipelines connector is only returned if no dai is found. 

Fixes #6003