### PR TITLE
[SKIP CI] doc/CMakeLists.txt: build by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,9 +31,6 @@
 *.xslt
 *.mbox
 
-doc/doxygen
-*.doxygen
-
 *.gz
 *.xz
 src/arch/xtensa/sof
@@ -53,11 +50,6 @@ __pycache__
 .checkpatch-camelcase.git.*
 
 build*/
-CMakeCache.txt
-CMakeFiles
-doc/*.cmake
-doc/*.ninja
-doc/Makefile
 
 # Eclipse project metadata
 .settings

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -13,7 +13,7 @@ configure_file(
 	"${PROJECT_BINARY_DIR}/sof.doxygen"
 )
 
-add_custom_target("doc"
+add_custom_target("doc" ALL
 	COMMAND doxygen sof.doxygen
 	VERBATIM
 	USES_TERMINAL


### PR DESCRIPTION
2 commits:
- build something by default with `make` or `ninja`, secret word `make doc` not needed anymore
- clean-up .gitignore for deprecated in-source builds