### PR TITLE
ipc4: Fix wrong condition statement in set_pipeline_state

### DIFF
--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -273,7 +273,7 @@ static int set_pipeline_state(uint32_t id, uint32_t cmd, bool *delayed, uint32_t
 		if (status == COMP_STATE_READY)
 			return 0;
 
-		if (status == COMP_STATE_ACTIVE || COMP_STATE_PAUSED) {
+		if (status == COMP_STATE_ACTIVE || status == COMP_STATE_PAUSED) {
 			ret = pipeline_trigger(host->cd->pipeline, host->cd, COMP_TRIGGER_STOP);
 			if (ret < 0) {
 				tr_err(&ipc_tr, "ipc: comp %d trigger 0x%x failed %d",


### PR DESCRIPTION
The condition statement is wrong in set_pipeline_state() when handling
SOF_IPC4_PIPELINE_STATE_RESET cmd.

Signed-off-by: Libin Yang <libin.yang@intel.com>