### PR TITLE
topology2: Add rt5682+max98357a support

### DIFF
--- a/tools/topology/topology2/cavs-rt5682.conf
+++ b/tools/topology/topology2/cavs-rt5682.conf
@@ -1,0 +1,274 @@
+<searchdir:include>
+<searchdir:include/common>
+<searchdir:include/components>
+<searchdir:include/dais>
+<searchdir:include/pipelines/cavs>
+<searchdir:platform/intel>
+
+<vendor-token.conf>
+<manifest.conf>
+<pdm_config.conf>
+<tokens.conf>
+<virtual.conf>
+<passthrough-playback.conf>
+<passthrough-capture.conf>
+<passthrough-be.conf>
+<host-copier-gain-mixin-playback.conf>
+<mixout-gain-dai-copier-playback.conf>
+<data.conf>
+<pcm.conf>
+<pcm_caps.conf>
+<fe_dai.conf>
+<ssp.conf>
+<dmic.conf>
+<hda.conf>
+<hw_config.conf>
+<manifest.conf>
+<route.conf>
+<common_definitions.conf>
+<copier.conf>
+<pipeline.conf>
+<dai.conf>
+<host.conf>
+<dmic-default.conf>
+<hdmi-default.conf>
+
+Define {
+	MCLK 				24576000
+	NUM_DMICS			0
+	# override DMIC default definitions
+	NUM_DMICS			0
+	DMIC0_ID			1
+	DMIC1_ID			2
+	DMIC0_HOST_PIPELINE_ID		13
+	DMIC0_DAI_PIPELINE_ID		14
+	DMIC0_HOST_PIPELINE_SINK	'copier.host.13.1'
+	DMIC0_DAI_PIPELINE_SRC		'copier.DMIC.14.1'
+	DMIC0_NAME			'dmic01'
+	DMIC0_PCM_CAPS			'Passthrough Capture 13'
+	DMIC0_PIPELINE_STREAM_NAME	'copier.DMIC.14.1'
+	# override BE link ids
+	NUM_HDMIS			0
+	HDMI1_ID			3
+	HDMI2_ID			4
+	HDMI3_ID			5
+	HDMI4_ID			6
+	SPK_ID				7
+	PLATFORM 			"none"
+	USE_CHAIN_DMA			"false"
+}
+
+# override defaults with platform-specific config
+IncludeByKey.PLATFORM {
+	"mtl"	"platform/intel/mtl.conf"
+}
+
+# include DMIC config if needed.
+IncludeByKey.NUM_DMICS {
+	"[1-4]"	"platform/intel/dmic-generic.conf"
+}
+
+# include HDMI config if needed.
+IncludeByKey.NUM_HDMIS {
+	"[3-4]"	"platform/intel/hdmi-generic.conf"
+}
+
+#
+# List of all DAIs
+#
+#SSP Index: 0, Direction: duplex
+Object.Dai {
+	SSP."0" {
+		id 		0
+		dai_index	0
+		direction	"duplex"
+		name		SSP0-Codec
+		default_hw_conf_id	0
+		sample_bits		32
+		io_clk		$MCLK
+
+		Object.Base.hw_config."SSP0" {
+			id	0
+			mclk_freq	$MCLK
+			bclk_freq	3072000
+			tdm_slot_width	32
+		}
+	}
+	SSP."1" {
+		id 		$SPK_ID
+		dai_index	1
+		direction	"playback"
+		name		SSP1-Codec
+		default_hw_conf_id	0
+		sample_bits		32
+		io_clk		$MCLK
+
+		Object.Base.hw_config."SSP1" {
+			id	0
+			mclk_freq	$MCLK
+			bclk_freq	3072000
+			tdm_slot_width	32
+		}
+	}
+}
+
+#
+# Pipeline definitions
+#
+# PCM0 ---> gain ----> Mixin ----> Mixout ----> gain ----> SSP0
+# PCM1 ---> gain ----> Mixin ----> Mixout ----> gain ----> SSP1
+#
+# SSP0 ----> PCM0
+# SSP1 ----> PCM1
+
+# Pipeline ID:1 PCM ID: 0
+Object.Pipeline {
+	# playback pipelines
+	host-copier-gain-mixin-playback.1 {
+		index	1
+
+		Object.Widget.copier.1 {
+			stream_name	'SSP0 Playback'
+		}
+		Object.Widget.gain.1 {
+			Object.Control.mixer.1 {
+				name	'Playback Volume 1'
+			}
+		}
+	}
+
+	mixout-gain-dai-copier-playback.1 {
+		index	2
+
+		Object.Widget.copier.1 {
+			dai_index 0
+			dai_type	"SSP"
+			copier_type	"SSP"
+			stream_name	"SSP0-Codec"
+			node_type $I2S_LINK_OUTPUT_CLASS
+		}
+
+		Object.Widget.gain.1 {
+			Object.Control.mixer.1 {
+				name	'Main Playback Volume 2'
+			}
+		}
+	}
+
+	host-copier-gain-mixin-playback.2 {
+		index	3
+
+		Object.Widget.copier.1 {
+			stream_name	'SSP1 Playback'
+		}
+		Object.Widget.gain.1 {
+			Object.Control.mixer.1 {
+				name	'Playback Volume 3'
+			}
+		}
+	}
+
+	mixout-gain-dai-copier-playback.2 {
+		index	4
+
+		Object.Widget.copier.1 {
+			dai_index	1
+			dai_type	"SSP"
+			copier_type	"SSP"
+			stream_name	"SSP1-Codec"
+			node_type	$I2S_LINK_OUTPUT_CLASS
+		}
+
+		Object.Widget.gain.1 {
+			Object.Control.mixer.1 {
+				name	'Main Playback Volume 4'
+			}
+		}
+	}
+
+	passthrough-capture.1 {
+		index	5
+
+		Object.Widget.copier.1 {
+			stream_name	'SSP0 Capture'
+		}
+	}
+
+	passthrough-be.1 {
+		index	6
+		direction	capture
+
+		Object.Widget.copier."1" {
+			dai_index	0
+			dai_type	"SSP"
+			type		dai_out
+			copier_type	"SSP"
+			stream_name	"SSP0-Codec"
+			node_type	$I2S_LINK_INPUT_CLASS
+			Object.Base.audio_format.1 {
+				in_bit_depth		32
+				in_valid_bit_depth	32
+				out_bit_depth		32
+				out_valid_bit_depth	32
+				dma_buffer_size "$[$ibs * 2]"
+			}
+		}
+	}
+}
+
+Object.PCM {
+	pcm."0" {
+		name	"Headset"
+		id	0
+		direction	"duplex"
+		Object.Base.fe_dai."Headset" {}
+
+		Object.PCM.pcm_caps."playback" {
+			name	"SSP0 Playback"
+			formats	'S16_LE,S24_LE,S32_LE'
+		}
+
+		Object.PCM.pcm_caps."capture" {
+			name	"SSP0 Capture"
+			formats	'S16_LE,S24_LE,S32_LE'
+		}
+	}
+	pcm."1" {
+		name	"Speakers"
+		id	1
+		direction	"playback"
+		Object.Base.fe_dai."Speakers" {}
+
+		Object.PCM.pcm_caps."playback" {
+			name	"SSP1 Playback"
+			formats	'S16_LE,S24_LE,S32_LE'
+		}
+	}
+}
+
+Object.Base {
+	route."1" {
+		source	"gain.2.1"
+		sink	"copier.SSP.2.1"
+	}
+
+	route."2" {
+		source	"mixin.1.1"
+		sink	"mixout.2.1"
+	}
+
+	route."3" {
+		source	"gain.4.1"
+		sink	"copier.SSP.4.1"
+	}
+
+	route."4" {
+		source	"mixin.3.1"
+		sink	"mixout.4.1"
+	}
+
+	route."5" {
+		source	"copier.SSP.6.1"
+		sink	"copier.host.5.1"
+	}
+}

--- a/tools/topology/topology2/sof-ace-tplg/CMakeLists.txt
+++ b/tools/topology/topology2/sof-ace-tplg/CMakeLists.txt
@@ -26,6 +26,9 @@ PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-mtl-sdw-dmic.bin"
 # SSP topology for MTL
 "cavs-nocodec\;sof-mtl-nocodec\;PLATFORM=mtl,NUM_DMICS=2,\
 PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-mtl-nocodec.bin"
+
+"cavs-rt5682\;sof-mtl-max98357a-rt5682\;PLATFORM=mtl,NUM_DMICS=4,PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,NUM_HDMIS=4,\
+PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-mtl-max98357a-rt5682.bin"
 )
 
 add_custom_target(topology2_ace)


### PR DESCRIPTION
make topology2_sof-mtl-max98357a-rt5682

localhost ~ # aplay -l
**** List of PLAYBACK Hardware Devices ****
card 0: sofrt5682 [sof-rt5682], device 0: Headset (*) []
  Subdevices: 1/1
  Subdevice #0: subdevice #0
card 0: sofrt5682 [sof-rt5682], device 1: dummy-spk (*) []
  Subdevices: 1/1
  Subdevice #0: subdevice #0
card 0: sofrt5682 [sof-rt5682], device 5: HDMI1 (*) []
  Subdevices: 1/1
  Subdevice #0: subdevice #0
card 0: sofrt5682 [sof-rt5682], device 6: HDMI2 (*) []
  Subdevices: 1/1
  Subdevice #0: subdevice #0
card 0: sofrt5682 [sof-rt5682], device 7: HDMI3 (*) []
  Subdevices: 1/1
  Subdevice #0: subdevice #0
card 0: sofrt5682 [sof-rt5682], device 8: HDMI4 (*) []
  Subdevices: 1/1
  Subdevice #0: subdevice #0
localhost ~ # arecord -l
**** List of CAPTURE Hardware Devices ****
card 0: sofrt5682 [sof-rt5682], device 0: Headset (*) []
  Subdevices: 1/1
  Subdevice #0: subdevice #0

Signed-off-by: Yong Zhi <yong.zhi@intel.com>