### PR TITLE
dai-zephyr: Set dai rate in config

### DIFF
--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -136,6 +136,7 @@ int dai_set_config(struct dai *dai, struct ipc_config_dai *common_config,
 	is_blob = common_config->is_config_blob;
 	cfg.format = sof_cfg->format;
 	cfg.options = sof_cfg->flags;
+	cfg.rate = common_config->sampling_frequency;
 
 	switch (common_config->type) {
 	case SOF_DAI_INTEL_SSP:


### PR DESCRIPTION
Fill in cfg.rate to be used by zephyr native drivers as rate is not
always present in ipc config. 
Needed for zephyr-side pr: https://github.com/zephyrproject-rtos/zephyr/pull/48254

Signed-off-by: Krzysztof Frydryk <krzysztofx.frydryk@intel.com>