### PR TITLE
Kconfig visual fixes

### DIFF
--- a/src/audio/Kconfig
+++ b/src/audio/Kconfig
@@ -452,13 +452,13 @@ config COMP_MODULE_ADAPTER
 	  "src\include\sof\audio\module_adapter\interfaces.h". It is possible to link several
 	  different codecs and use them in parallel.
 
+rsource "module_adapter/Kconfig"
+
 config COMP_LEGACY_INTERFACE
 	bool "Use legacy component driver interface"
 	default n
 	help
 	  Use the legacy component driver interface for component instead of the module adapter.
-
-rsource "module_adapter/Kconfig"
 
 config COMP_IGO_NR
 	bool "IGO NR component"

--- a/src/audio/module_adapter/Kconfig
+++ b/src/audio/module_adapter/Kconfig
@@ -11,50 +11,6 @@ menu "Processing modules"
 		  This will cause codec adapter component to include header
 		  files specific to CADENCE base codecs.
 
-	config COMP_VOLUME
-		bool "Volume component"
-		default y
-		depends on COMP_MODULE_ADAPTER
-		help
-		  Select for Volume component
-
-if COMP_VOLUME
-
-config COMP_VOLUME_WINDOWS_FADE
-       bool "Windows Fade shape volume transitions support"
-       help
-         This option enables volume ramp shape that follows
-	 power of 1.75. The shape is not linear, not logarithmic.
-	 The power function uses a lookup table that consumes
-	 256 bytes. The topology must set volume ramp token to
-	 SOF_VOLUME_WINDOWS_FADE for the volume instance to use
-	 this ramp shape.
-
-config COMP_VOLUME_LINEAR_RAMP
-       bool "Linear ramp volume transitions support"
-	   default y
-	   depends on IPC_MAJOR_3
-       help
-         This option enables volume linear ramp shape.
-
-config COMP_PEAK_VOL
-       bool "Report peak vol data to host"
-	   default y
-	   depends on IPC_MAJOR_4
-       help
-         This option enables reporting to host peak vol regs.
-         See: struct ipc4_peak_volume_regs
-
-config COMP_GAIN
-	bool "GAIN component"
-	default y
-	depends on IPC_MAJOR_4
-	help
-	  This option enables gain to change volume. It works
-	  as peak volume without updating peak vol to host
-
-endif # volume
-
 if CADENCE_CODEC
 	config CADENCE_CODEC_WRAPPER
 		bool 'Cadence codec wrapper'
@@ -192,7 +148,51 @@ if CADENCE_CODEC
 		  This option is a string and takes the full name of the SRC library binary.
 	endif
 
-endif
+endif # Cadence
+
+	config COMP_VOLUME
+		bool "Volume component"
+		default y
+		depends on COMP_MODULE_ADAPTER
+		help
+		  Select for Volume component
+
+if COMP_VOLUME
+
+config COMP_VOLUME_WINDOWS_FADE
+       bool "Windows Fade shape volume transitions support"
+       help
+         This option enables volume ramp shape that follows
+	 power of 1.75. The shape is not linear, not logarithmic.
+	 The power function uses a lookup table that consumes
+	 256 bytes. The topology must set volume ramp token to
+	 SOF_VOLUME_WINDOWS_FADE for the volume instance to use
+	 this ramp shape.
+
+config COMP_VOLUME_LINEAR_RAMP
+       bool "Linear ramp volume transitions support"
+	   default y
+	   depends on IPC_MAJOR_3
+       help
+         This option enables volume linear ramp shape.
+
+config COMP_PEAK_VOL
+       bool "Report peak vol data to host"
+	   default y
+	   depends on IPC_MAJOR_4
+       help
+         This option enables reporting to host peak vol regs.
+         See: struct ipc4_peak_volume_regs
+
+config COMP_GAIN
+	bool "GAIN component"
+	default y
+	depends on IPC_MAJOR_4
+	help
+	  This option enables gain to change volume. It works
+	  as peak volume without updating peak vol to host
+
+endif # volume
 
 	config PASSTHROUGH_CODEC
 		bool "Passthrough codec"


### PR DESCRIPTION
Some config options are not correctly grouped up, instead showing up later than intended.

Old code:

```
[*] Module adapter
[ ] Use legacy component driver interface
    Processing modules  --->
```

New code:

```
[*] Module adapter
    Processing modules  --->
[ ] Use legacy component driver interface
```

Also, old code:
```
[*] Cadence codec
[*] Volume component
[ ]     Windows Fade shape volume transitions support
[*]     Linear ramp volume transitions support
[ ] Cadence codec wrapper (NEW)
[ ] Cadence AAC decoder (NEW)
[ ] Cadence BSAC decoder (NEW)
[ ] Cadence DAB decoder (NEW)
[ ] Cadence DRM decoder (NEW)
[ ] Cadence MP3 decoder (NEW)
[ ] Cadence SBC decoder (NEW)
[ ] Cadence VORBIS decoder (NEW)
[ ] Cadence SRC polyphase (NEW)
[ ] Passthrough codec
```

New code:

```
[*] Cadence codec
[ ]     Cadence codec wrapper (NEW)
[ ]     Cadence AAC decoder (NEW)
[ ]     Cadence BSAC decoder (NEW)
[ ]     Cadence DAB decoder (NEW)
[ ]     Cadence DRM decoder (NEW)
[ ]     Cadence MP3 decoder (NEW)
[ ]     Cadence SBC decoder (NEW)
[ ]     Cadence VORBIS decoder (NEW)
[ ]     Cadence SRC polyphase (NEW)
[*] Volume component
[ ]     Windows Fade shape volume transitions support
[*]     Linear ramp volume transitions support
[ ] Passthrough codec
```