### PR TITLE
src: enable hifi4 optimized src build with zephyr

### DIFF
--- a/src/audio/src/src_hifi4.c
+++ b/src/audio/src/src_hifi4.c
@@ -17,6 +17,11 @@
 #include <stddef.h>
 #include <stdint.h>
 
+/* sof/math/numbers.h doesn't define MIN when used with zephyr */
+#ifdef __ZEPHYR__
+#include <zephyr/sys/util.h>
+#endif /* __ZEPHYR__ */
+
 /* HiFi4 has
  * 16x 64 bit registers in register file AE_DR
  */

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -707,6 +707,7 @@ zephyr_library_sources_ifdef(CONFIG_COMP_SRC
 	${SOF_AUDIO_PATH}/src/src_hifi2ep.c
 	${SOF_AUDIO_PATH}/src/src_generic.c
 	${SOF_AUDIO_PATH}/src/src_hifi3.c
+	${SOF_AUDIO_PATH}/src/src_hifi4.c
 	${SOF_AUDIO_PATH}/src/src.c
 )
 


### PR DESCRIPTION
Add src_hifi4.c to sources when building with zephyr.

include util.h from zephyr for `MIN` macro

Signed-off-by: Krzysztof Frydryk <krzysztofx.frydryk@intel.com>