### PR TITLE
timer: Introduce sof_cycle_get_64

### DIFF
--- a/src/arch/xtos-wrapper/include/sof/drivers/timer.h
+++ b/src/arch/xtos-wrapper/include/sof/drivers/timer.h
@@ -102,17 +102,17 @@ static inline uint64_t k_cyc_to_us_near64(uint64_t ticks)
 	return ticks / clock_us_to_ticks(PLATFORM_DEFAULT_CLOCK, 1);
 }
 
-static inline uint64_t k_cycle_get_64(void)
+static inline uint64_t sof_cycle_get_64(void)
 {
 	return platform_timer_get(timer_get());
 }
 
-static inline uint64_t k_cycle_get_64_atomic(void)
+static inline uint64_t sof_cycle_get_64_atomic(void)
 {
 	return platform_timer_get_atomic(timer_get());
 }
 
-static inline uint64_t k_cycle_get_64_safe(void)
+static inline uint64_t sof_cycle_get_64_safe(void)
 {
 	return platform_safe_get_time(timer_get());
 }

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -890,7 +890,7 @@ static int kpb_buffer_data(struct comp_dev *dev,
 
 	kpb_change_state(kpb, KPB_STATE_BUFFERING);
 
-	timeout = k_cycle_get_64() + k_ms_to_cyc_ceil64(1);
+	timeout = sof_cycle_get_64() + k_ms_to_cyc_ceil64(1);
 	/* Let's store audio stream data in internal history buffer */
 	while (size_to_copy) {
 		/* Reset was requested, it's time to stop buffering and finish
@@ -903,7 +903,7 @@ static int kpb_buffer_data(struct comp_dev *dev,
 		}
 
 		/* Are we stuck in buffering? */
-		current_time = k_cycle_get_64();
+		current_time = sof_cycle_get_64();
 		if (timeout < current_time) {
 			timeout = k_cyc_to_ms_near64(current_time - timeout);
 			if (timeout <= UINT_MAX)
@@ -1239,7 +1239,7 @@ static enum task_state kpb_draining_task(void *arg)
 	uint64_t current_time;
 	size_t period_bytes = 0;
 	size_t period_bytes_limit = draining_data->pb_limit;
-	size_t period_copy_start = k_cycle_get_64();
+	size_t period_copy_start = sof_cycle_get_64();
 	size_t time_taken;
 	size_t *rt_stream_update = &draining_data->buffered_while_draining;
 	struct comp_data *kpb = comp_get_drvdata(draining_data->dev);
@@ -1256,7 +1256,7 @@ static enum task_state kpb_draining_task(void *arg)
 	/* Change KPB internal state to DRAINING */
 	kpb_change_state(kpb, KPB_STATE_DRAINING);
 
-	draining_time_start = k_cycle_get_64();
+	draining_time_start = sof_cycle_get_64();
 
 	while (drain_req > 0) {
 		/* Have we received reset request? */
@@ -1269,12 +1269,12 @@ static enum task_state kpb_draining_task(void *arg)
 		 * to read the data already provided?
 		 */
 		if (sync_mode_on &&
-		    next_copy_time > k_cycle_get_64()) {
+		    next_copy_time > sof_cycle_get_64()) {
 			period_bytes = 0;
-			period_copy_start = k_cycle_get_64();
+			period_copy_start = sof_cycle_get_64();
 			continue;
 		} else if (next_copy_time == 0) {
-			period_copy_start = k_cycle_get_64();
+			period_copy_start = sof_cycle_get_64();
 		}
 
 		size_to_read = (uintptr_t)buff->end_addr - (uintptr_t)buff->r_ptr;
@@ -1321,7 +1321,7 @@ static enum task_state kpb_draining_task(void *arg)
 		}
 
 		if (sync_mode_on && period_bytes >= period_bytes_limit) {
-			current_time = k_cycle_get_64();
+			current_time = sof_cycle_get_64();
 			time_taken = current_time - period_copy_start;
 			next_copy_time = current_time + drain_interval -
 					 time_taken;
@@ -1351,7 +1351,7 @@ static enum task_state kpb_draining_task(void *arg)
 	}
 
 out:
-	draining_time_end = k_cycle_get_64();
+	draining_time_end = sof_cycle_get_64();
 
 	buffer_release(sink);
 

--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -466,7 +466,7 @@ static int dw_dma_status(struct dma_chan_data *channel,
 	status->state = channel->status;
 	status->r_pos = dma_reg_read(channel->dma, DW_SAR(channel->index));
 	status->w_pos = dma_reg_read(channel->dma, DW_DAR(channel->index));
-	status->timestamp = k_cycle_get_64();
+	status->timestamp = sof_cycle_get_64();
 
 	if (status->ipc_posn_data) {
 		uint32_t *llp = (uint32_t *)status->ipc_posn_data;

--- a/src/drivers/generic/dummy-dma.c
+++ b/src/drivers/generic/dummy-dma.c
@@ -317,7 +317,7 @@ static int dummy_dma_status(struct dma_chan_data *channel,
 	status->r_pos = ch->r_pos;
 	status->w_pos = ch->w_pos;
 
-	status->timestamp = k_cycle_get_64();
+	status->timestamp = sof_cycle_get_64();
 	return 0;
 }
 

--- a/src/drivers/imx/edma.c
+++ b/src/drivers/imx/edma.c
@@ -236,7 +236,7 @@ static int edma_status(struct dma_chan_data *channel,
 	 */
 	status->r_pos = dma_chan_reg_read(channel, EDMA_TCD_SADDR);
 	status->w_pos = dma_chan_reg_read(channel, EDMA_TCD_DADDR);
-	status->timestamp = k_cycle_get_64();
+	status->timestamp = sof_cycle_get_64();
 	return 0;
 }
 

--- a/src/drivers/imx/sdma.c
+++ b/src/drivers/imx/sdma.c
@@ -558,7 +558,7 @@ static int sdma_status(struct dma_chan_data *channel,
 	status->flags = 0;
 	status->w_pos = 0;
 	status->r_pos = 0;
-	status->timestamp = k_cycle_get_64();
+	status->timestamp = sof_cycle_get_64();
 
 	bd = (struct sdma_bd *)pdata->ccb->current_bd_paddr;
 

--- a/src/drivers/intel/baytrail/timer.c
+++ b/src/drivers/intel/baytrail/timer.c
@@ -169,7 +169,7 @@ void platform_dai_timestamp(struct comp_dev *dai,
 		posn->flags |= SOF_TIME_DAI_VALID;
 
 	/* get SSP wallclock - DAI sets this to stream start value */
-	posn->wallclock = k_cycle_get_64() - posn->wallclock;
+	posn->wallclock = sof_cycle_get_64() - posn->wallclock;
 	posn->wallclock_hz = clock_get_freq(PLATFORM_DEFAULT_CLOCK);
 	posn->flags |= SOF_TIME_WALL_VALID | SOF_TIME_WALL_64;
 }
@@ -178,7 +178,7 @@ void platform_dai_timestamp(struct comp_dev *dai,
 void platform_dai_wallclock(struct comp_dev *dai, uint64_t *wallclock)
 {
 	/* only 1 wallclock on BYT */
-	*wallclock = k_cycle_get_64();
+	*wallclock = sof_cycle_get_64();
 }
 
 #ifndef __ZEPHYR__

--- a/src/drivers/intel/cavs/timer.c
+++ b/src/drivers/intel/cavs/timer.c
@@ -139,7 +139,7 @@ void platform_dai_timestamp(struct comp_dev *dai,
 		posn->flags |= SOF_TIME_DAI_VALID;
 
 	/* get SSP wallclock - DAI sets this to stream start value */
-	posn->wallclock = k_cycle_get_64() - posn->wallclock;
+	posn->wallclock = sof_cycle_get_64() - posn->wallclock;
 	posn->wallclock_hz = clock_get_freq(PLATFORM_DEFAULT_CLOCK);
 	posn->flags |= SOF_TIME_WALL_VALID;
 }
@@ -147,7 +147,7 @@ void platform_dai_timestamp(struct comp_dev *dai,
 /* get current wallclock for componnent */
 void platform_dai_wallclock(struct comp_dev *dai, uint64_t *wallclock)
 {
-	*wallclock = k_cycle_get_64();
+	*wallclock = sof_cycle_get_64();
 }
 
 #ifndef __ZEPHYR__

--- a/src/drivers/intel/haswell/timer.c
+++ b/src/drivers/intel/haswell/timer.c
@@ -73,7 +73,7 @@ void platform_dai_timestamp(struct comp_dev *dai,
 		posn->flags |= SOF_TIME_DAI_VALID;
 
 	/* get SSP wallclock - DAI sets this to stream start value */
-	posn->wallclock = k_cycle_get_64() - posn->wallclock;
+	posn->wallclock = sof_cycle_get_64() - posn->wallclock;
 	posn->wallclock_hz = clock_get_freq(PLATFORM_DEFAULT_CLOCK);
 	posn->flags |= SOF_TIME_WALL_VALID | SOF_TIME_WALL_64;
 }
@@ -82,7 +82,7 @@ void platform_dai_timestamp(struct comp_dev *dai,
 void platform_dai_wallclock(struct comp_dev *dai, uint64_t *wallclock)
 {
 	/* only 1 wallclock on HSW */
-	*wallclock = k_cycle_get_64();
+	*wallclock = sof_cycle_get_64();
 }
 
 #ifndef __ZEPHYR__

--- a/src/drivers/intel/hda/hda-dma.c
+++ b/src/drivers/intel/hda/hda-dma.c
@@ -322,10 +322,10 @@ static inline int hda_dma_is_buffer_empty(struct dma_chan_data *chan)
 
 static int hda_dma_wait_for_buffer_full(struct dma_chan_data *chan)
 {
-	uint64_t deadline = k_cycle_get_64() + k_us_to_cyc_ceil64(HDA_DMA_TIMEOUT);
+	uint64_t deadline = sof_cycle_get_64() + k_us_to_cyc_ceil64(HDA_DMA_TIMEOUT);
 
 	while (!hda_dma_is_buffer_full(chan)) {
-		if (deadline < k_cycle_get_64()) {
+		if (deadline < sof_cycle_get_64()) {
 			/* safe check in case we've got preempted after read */
 			if (hda_dma_is_buffer_full(chan))
 				return 0;
@@ -343,10 +343,10 @@ static int hda_dma_wait_for_buffer_full(struct dma_chan_data *chan)
 
 static int hda_dma_wait_for_buffer_empty(struct dma_chan_data *chan)
 {
-	uint64_t deadline = k_cycle_get_64() + k_us_to_cyc_ceil64(HDA_DMA_TIMEOUT);
+	uint64_t deadline = sof_cycle_get_64() + k_us_to_cyc_ceil64(HDA_DMA_TIMEOUT);
 
 	while (!hda_dma_is_buffer_empty(chan)) {
-		if (deadline < k_cycle_get_64()) {
+		if (deadline < sof_cycle_get_64()) {
 			/* safe check in case we've got preempted after read */
 			if (hda_dma_is_buffer_empty(chan))
 				return 0;
@@ -726,7 +726,7 @@ static int hda_dma_status(struct dma_chan_data *channel,
 	status->state = channel->status;
 	status->r_pos = dma_chan_reg_read(channel, DGBRP);
 	status->w_pos = dma_chan_reg_read(channel, DGBWP);
-	status->timestamp = k_cycle_get_64();
+	status->timestamp = sof_cycle_get_64();
 
 	return 0;
 }

--- a/src/idc/idc.c
+++ b/src/idc/idc.c
@@ -92,14 +92,14 @@ int idc_msg_status_get(uint32_t core)
  */
 int idc_wait_in_blocking_mode(uint32_t target_core, bool (*cond)(int))
 {
-	uint64_t deadline = k_cycle_get_64() + k_us_to_cyc_ceil64(IDC_TIMEOUT);
+	uint64_t deadline = sof_cycle_get_64() + k_us_to_cyc_ceil64(IDC_TIMEOUT);
 
 	while (!cond(target_core)) {
 
 		/* spin here so other core can access IO and timers freely */
 		idelay(8192);
 
-		if (deadline < k_cycle_get_64())
+		if (deadline < sof_cycle_get_64())
 			break;
 	}
 

--- a/src/include/sof/lib/perf_cnt.h
+++ b/src/include/sof/lib/perf_cnt.h
@@ -48,7 +48,7 @@ struct perf_cnt_data {
 	#ifdef CONFIG_TIMING_FUNCTIONS
 		#define perf_cnt_get_cpu_ts arch_timing_counter_get
 	#else
-		#define perf_cnt_get_cpu_ts k_cycle_get_64
+		#define perf_cnt_get_cpu_ts sof_cycle_get_64
 	#endif	/* CONFIG_TIMING_FUNCTIONS */
 #else
 	#define perf_cnt_get_cpu_ts() timer_get_system(cpu_timer_get())
@@ -56,7 +56,7 @@ struct perf_cnt_data {
 
 /** \brief Initializes timestamps with current timer values. */
 #define perf_cnt_init(pcd) do {						\
-		(pcd)->plat_ts = k_cycle_get_64();			\
+		(pcd)->plat_ts = sof_cycle_get_64();			\
 		(pcd)->cpu_ts = perf_cnt_get_cpu_ts();			\
 	} while (0)
 
@@ -112,7 +112,7 @@ struct perf_cnt_data {
  */
 #define perf_cnt_stamp(pcd, trace_m, arg) do {					\
 		uint32_t plat_ts =						\
-			(uint32_t)k_cycle_get_64();				\
+			(uint32_t)sof_cycle_get_64();				\
 		uint32_t cpu_ts =						\
 			(uint32_t)perf_cnt_get_cpu_ts();			\
 		if ((pcd)->plat_ts) {						\

--- a/src/ipc/ipc3/handler.c
+++ b/src/ipc/ipc3/handler.c
@@ -839,7 +839,7 @@ static int ipc_dma_trace_config(uint32_t header)
 		 *  "SOF_IPC_TRACE_DMA_PARAMS_EXT" in your particular
 		 *  kernel version.
 		 */
-		dmat->time_delta = k_ns_to_cyc_near64(params.timestamp_ns) - k_cycle_get_64();
+		dmat->time_delta = k_ns_to_cyc_near64(params.timestamp_ns) - sof_cycle_get_64();
 	else
 		dmat->time_delta = 0;
 

--- a/src/lib/agent.c
+++ b/src/lib/agent.c
@@ -75,7 +75,7 @@ static enum task_state validate(void *data)
 	uint64_t current;
 	uint64_t delta;
 
-	current = k_cycle_get_64();
+	current = sof_cycle_get_64();
 	delta = current - sa->last_check;
 
 	perf_cnt_stamp(&sa->pcd, perf_sa_trace, 0 /* ignored */);
@@ -140,7 +140,7 @@ void sa_init(struct sof *sof, uint64_t timeout)
 	schedule_task(&sof->sa->work, 0, timeout);
 
 	/* set last check time to now to give time for boot completion */
-	sof->sa->last_check = k_cycle_get_64();
+	sof->sa->last_check = sof_cycle_get_64();
 
 }
 

--- a/src/lib/pm_runtime.c
+++ b/src/lib/pm_runtime.c
@@ -146,7 +146,7 @@ void init_dsp_r_state(enum dsp_r_state r_state)
 	r_counters = rzalloc(SOF_MEM_ZONE_SYS_SHARED, 0, SOF_MEM_CAPS_RAM, sizeof(*r_counters));
 	prd->r_counters = r_counters;
 
-	r_counters->ts = k_cycle_get_64();
+	r_counters->ts = sof_cycle_get_64();
 	r_counters->cur_r_state = r_state;
 }
 
@@ -161,7 +161,7 @@ void report_dsp_r_state(enum dsp_r_state r_state)
 	if (!r_counters || r_counters->cur_r_state == r_state)
 		return;
 
-	ts = k_cycle_get_64();
+	ts = sof_cycle_get_64();
 	delta = ts - r_counters->ts;
 
 	delta += mailbox_sw_reg_read64(SRAM_REG_R_STATE_TRACE_BASE +

--- a/src/lib/wait.c
+++ b/src/lib/wait.c
@@ -60,9 +60,9 @@ int poll_for_register_delay(uint32_t reg, uint32_t mask,
 
 void wait_delay(uint64_t number_of_clks)
 {
-	uint64_t timeout = k_cycle_get_64() + number_of_clks;
+	uint64_t timeout = sof_cycle_get_64() + number_of_clks;
 
-	while (k_cycle_get_64() < timeout)
+	while (sof_cycle_get_64() < timeout)
 		idelay(PLATFORM_DEFAULT_DELAY);
 }
 

--- a/src/probe/probe.c
+++ b/src/probe/probe.c
@@ -613,7 +613,7 @@ static int probe_gen_header(struct comp_buffer *buffer, uint32_t size,
 	uint32_t crc;
 
 	header = &_probe->header;
-	timestamp = k_cycle_get_64();
+	timestamp = sof_cycle_get_64();
 
 	header->sync_word = PROBE_EXTRACT_SYNC_WORD;
 	header->buffer_id = buffer->id;

--- a/src/samples/audio/kwd_nn_detect_test.c
+++ b/src/samples/audio/kwd_nn_detect_test.c
@@ -78,11 +78,11 @@ void kwd_nn_detect_test(struct comp_dev *dev,
 				 test_keyword_get_input_byte(dev, 6),
 				 test_keyword_get_input_byte(dev, 7)
 			);
-			time_start = k_cycle_get_64();
+			time_start = sof_cycle_get_64();
 			kwd_nn_preprocess_1s(test_keyword_get_input(dev), preprocessed_data);
 			kwd_nn_process_data(preprocessed_data, confidences);
 			result = kwd_nn_detect_postprocess(confidences);
-			time_stop = k_cycle_get_64();
+			time_stop = sof_cycle_get_64();
 			comp_dbg(dev,
 				 "KWD: kwd_nn_detect_test_copy() inference done in %u ms",
 				 (unsigned int)k_cyc_to_ms_near64(time_stop - time_start));

--- a/src/schedule/dma_multi_chan_domain.c
+++ b/src/schedule/dma_multi_chan_domain.c
@@ -318,7 +318,7 @@ static bool dma_multi_chan_domain_is_pending(struct ll_schedule_domain *domain,
 				/* it's too soon for this task */
 				if (!pipe_task->registrable &&
 				    pipe_task->task.start >
-				    k_cycle_get_64_atomic())
+				    sof_cycle_get_64_atomic())
 					continue;
 			}
 

--- a/src/schedule/dma_single_chan_domain.c
+++ b/src/schedule/dma_single_chan_domain.c
@@ -452,7 +452,7 @@ static void dma_single_chan_domain_set(struct ll_schedule_domain *domain,
 		return;
 
 	if (dma_domain->channel_changed) {
-		domain->next_tick = k_cycle_get_64_atomic();
+		domain->next_tick = sof_cycle_get_64_atomic();
 
 		dma_domain->channel_changed = false;
 	} else {
@@ -489,7 +489,7 @@ static void dma_single_chan_domain_clear(struct ll_schedule_domain *domain)
 static bool dma_single_chan_domain_is_pending(struct ll_schedule_domain *domain,
 					      struct task *task, struct comp_dev **comp)
 {
-	return task->start <= k_cycle_get_64_atomic();
+	return task->start <= sof_cycle_get_64_atomic();
 }
 
 /**

--- a/src/schedule/ll_schedule.c
+++ b/src/schedule/ll_schedule.c
@@ -220,7 +220,7 @@ static void schedule_ll_tasks_execute(struct ll_schedule_data *sch)
 		tr_dbg(&ll_tr, "task %p %pU being started...", task, task->uid);
 
 #ifdef CONFIG_SCHEDULE_LOG_CYCLE_STATISTICS
-		cycles0 = (uint32_t)k_cycle_get_64();
+		cycles0 = (uint32_t)sof_cycle_get_64();
 #endif
 		task->state = SOF_TASK_STATE_RUNNING;
 
@@ -248,7 +248,7 @@ static void schedule_ll_tasks_execute(struct ll_schedule_data *sch)
 		k_spin_unlock(&domain->lock, key);
 
 #ifdef CONFIG_SCHEDULE_LOG_CYCLE_STATISTICS
-		cycles1 = (uint32_t)k_cycle_get_64();
+		cycles1 = (uint32_t)sof_cycle_get_64();
 		dsp_load_check(task, cycles0, cycles1);
 #endif
 	}
@@ -299,7 +299,7 @@ static void schedule_ll_tasks_run(void *data)
 
 	tr_dbg(&ll_tr, "timer interrupt on core %d, at %u, previous next_tick %u",
 	       core,
-	       (unsigned int)k_cycle_get_64_atomic(),
+	       (unsigned int)sof_cycle_get_64_atomic(),
 	       (unsigned int)domain->next_tick);
 
 	irq_local_disable(flags);
@@ -330,7 +330,7 @@ static void schedule_ll_tasks_run(void *data)
 	key = k_spin_lock(&domain->lock);
 
 	/* reset the new_target_tick for the first core */
-	if (domain->new_target_tick < k_cycle_get_64_atomic())
+	if (domain->new_target_tick < sof_cycle_get_64_atomic())
 		domain->new_target_tick = UINT64_MAX;
 
 	/* update the new_target_tick according to tasks on current core */
@@ -380,7 +380,7 @@ static int schedule_ll_domain_set(struct ll_schedule_data *sch,
 
 	task_start_us = period ? period : start;
 	task_start_ticks = domain->ticks_per_ms * task_start_us / 1000;
-	task_start = task_start_ticks + k_cycle_get_64_atomic();
+	task_start = task_start_ticks + sof_cycle_get_64_atomic();
 
 	if (reference) {
 		task->start = reference->start;
@@ -415,7 +415,7 @@ static int schedule_ll_domain_set(struct ll_schedule_data *sch,
 
 	tr_info(&ll_tr, "new added task->start %u at %u",
 		(unsigned int)task->start,
-		(unsigned int)k_cycle_get_64_atomic());
+		(unsigned int)sof_cycle_get_64_atomic());
 	tr_info(&ll_tr, "num_tasks %ld total_num_tasks %ld",
 		atomic_read(&sch->num_tasks),
 		atomic_read(&domain->total_num_tasks));
@@ -698,7 +698,7 @@ static int reschedule_ll_task(void *data, struct task *task, uint64_t start)
 
 	time = sch->domain->ticks_per_ms * start / 1000;
 
-	time += k_cycle_get_64_atomic();
+	time += sof_cycle_get_64_atomic();
 
 	irq_local_disable(flags);
 
@@ -741,7 +741,7 @@ static void scheduler_free_ll(void *data, uint32_t flags)
 static void ll_scheduler_recalculate_tasks(struct ll_schedule_data *sch,
 					   struct clock_notify_data *clk_data)
 {
-	uint64_t current = k_cycle_get_64_atomic();
+	uint64_t current = sof_cycle_get_64_atomic();
 	struct list_item *tlist;
 	struct task *task;
 	uint64_t delta_ms;

--- a/src/trace/trace.c
+++ b/src/trace/trace.c
@@ -247,7 +247,7 @@ static void dma_trace_log(bool send_atomic, uint32_t log_entry, const struct tr_
 	int i;
 
 	/* fill log content. arg_count is in the dictionary. */
-	put_header(data, ctx->uuid_p, id_1, id_2, log_entry, k_cycle_get_64_safe());
+	put_header(data, ctx->uuid_p, id_1, id_2, log_entry, sof_cycle_get_64_safe());
 
 	for (i = 0; i < arg_count; ++i)
 		data[PAYLOAD_OFFSET(i)] = va_arg(vargs, uint32_t);
@@ -288,7 +288,7 @@ void trace_log_filtered(bool send_atomic, const void *log_entry, const struct tr
 
 #if CONFIG_TRACE_FILTERING_ADAPTIVE
 	if (!trace->user_filter_override) {
-		const uint64_t current_ts = k_cycle_get_64_safe();
+		const uint64_t current_ts = sof_cycle_get_64_safe();
 
 		emit_recent_entries(current_ts);
 
@@ -526,7 +526,7 @@ static void mtrace_dict_entry_vl(bool atomic_context, uint32_t dict_entry_addres
 	int i;
 	char packet[MESSAGE_SIZE(_TRACE_EVENT_MAX_ARGUMENT_COUNT)];
 	uint32_t *args = (uint32_t *)&packet[MESSAGE_SIZE(0)];
-	const uint64_t tstamp = k_cycle_get_64_safe();
+	const uint64_t tstamp = sof_cycle_get_64_safe();
 
 	put_header(packet, dt_tr.uuid_p, _TRACE_INV_ID, _TRACE_INV_ID,
 		   dict_entry_address, tstamp);

--- a/zephyr/include/sof/drivers/timer.h
+++ b/zephyr/include/sof/drivers/timer.h
@@ -14,8 +14,16 @@
 struct comp_dev;
 struct sof_ipc_stream_posn;
 
-#define k_cycle_get_64_safe()		k_cycle_get_64()
-#define k_cycle_get_64_atomic()		k_cycle_get_64()
+static inline uint64_t sof_cycle_get_64(void)
+{
+	if (IS_ENABLED(CONFIG_TIMER_HAS_64BIT_CYCLE_COUNTER))
+		return k_cycle_get_64();
+	else
+		return k_ticks_to_cyc_floor64(k_uptime_ticks());
+}
+
+#define sof_cycle_get_64_safe()		sof_cycle_get_64()
+#define sof_cycle_get_64_atomic()	sof_cycle_get_64()
 #define platform_timer_stop(x)
 
 /* get timestamp for host stream DMA position */

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -678,7 +678,7 @@ void platform_dai_timestamp(struct comp_dev *dai,
 		posn->flags |= SOF_TIME_DAI_VALID;
 
 	/* get SSP wallclock - DAI sets this to stream start value */
-	posn->wallclock = k_cycle_get_64() - posn->wallclock;
+	posn->wallclock = sof_cycle_get_64() - posn->wallclock;
 	posn->wallclock_hz = clock_get_freq(PLATFORM_DEFAULT_CLOCK);
 	posn->flags |= SOF_TIME_WALL_VALID;
 }
@@ -686,7 +686,7 @@ void platform_dai_timestamp(struct comp_dev *dai,
 /* get current wallclock for componnent */
 void platform_dai_wallclock(struct comp_dev *dai, uint64_t *wallclock)
 {
-	*wallclock = k_cycle_get_64();
+	*wallclock = sof_cycle_get_64();
 }
 
 /*


### PR DESCRIPTION
With Zephyr, SOF uses k_cycle_get_64() API in order to
count clock cycles.

Not all platforms have a 64bit counter (e.g i.MX dsp integration
only has xtensa timer which is limited to 32 bits).

So, instead of using k_cycle_get_64 introduce new API sof_cycle_get_64
which keeps the existing behavior for platforms which define
CONFIG_TIMER_HAS_64BIT_CYCLE_COUNTER, otherwise use k_uptime_ticks().

See comments from @andyross at
https://github.com/zephyrproject-rtos/zephyr/pull/48318

Suggested-by: Andy Ross <andrew.j.ross@intel.com>
Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>