### PR TITLE
Get updated dai posn

### DIFF
--- a/src/audio/pipeline/pipeline-stream.c
+++ b/src/audio/pipeline/pipeline-stream.c
@@ -459,51 +459,25 @@ out:
 	return ret;
 }
 
-/* Walk the graph to active components in any pipeline to find
- * the first active DAI and return it's timestamp.
- */
-static int pipeline_comp_timestamp(struct comp_dev *current,
-				   struct comp_buffer *calling_buf,
-				   struct pipeline_walk_context *ctx, int dir)
-{
-	struct pipeline_data *ppl_data = ctx->comp_data;
-
-	if (!comp_is_active(current)) {
-		comp_warn(current, "pipeline_comp_timestamp(), current in wrong state %u",
-			  current->state);
-		return 0;
-	}
-
-	/* is component a DAI endpoint? */
-	if (current != ppl_data->start &&
-	    (dev_comp_type(current) == SOF_COMP_DAI ||
-	    dev_comp_type(current) == SOF_COMP_SG_DAI)) {
-		platform_dai_timestamp(current, ppl_data->posn);
-		return PPL_STATUS_PATH_STOP;
-	}
-
-	return pipeline_for_each_comp(current, ctx, dir);
-}
-
 /* Get the timestamps for host and first active DAI found. */
 void pipeline_get_timestamp(struct pipeline *p, struct comp_dev *host,
 			    struct sof_ipc_stream_posn *posn)
 {
-	struct pipeline_data data;
-	struct pipeline_walk_context walk_ctx = {
-		.comp_func = pipeline_comp_timestamp,
-		.comp_data = &data,
-		.skip_incomplete = true,
-	};
+	struct comp_dev *dai;
 
 	platform_host_timestamp(host, posn);
 
-	data.start = host;
-	data.posn = posn;
+	if (host->direction == SOF_IPC_STREAM_PLAYBACK)
+		dai = pipeline_get_dai_comp(host->pipeline->pipeline_id, PPL_DIR_DOWNSTREAM);
+	else
+		dai = pipeline_get_dai_comp(host->pipeline->pipeline_id, PPL_DIR_UPSTREAM);
 
-	if (walk_ctx.comp_func(host, NULL, &walk_ctx, host->direction) !=
-	    PPL_STATUS_PATH_STOP)
+	if (!dai) {
 		pipe_dbg(p, "pipeline_get_timestamp(): DAI position update failed");
+		return;
+	}
+
+	platform_dai_timestamp(dai, posn);
 
 	/* set timestamp resolution */
 	posn->timestamp_ns = p->period * 1000;

--- a/src/include/sof/audio/pipeline.h
+++ b/src/include/sof/audio/pipeline.h
@@ -203,9 +203,10 @@ int pipeline_for_each_comp(struct comp_dev *current,
 /**
  * \brief Walks pipeline graph to find dai component.
  * \param[in] pipeline_id is the start pipeline id.
+ * \param[in] dir is the direction of the traversal.
  * \return dai component.
  */
-struct comp_dev *pipeline_get_dai_comp(uint32_t pipeline_id);
+struct comp_dev *pipeline_get_dai_comp(uint32_t pipeline_id, int dir);
 
 #if CONFIG_IPC_MAJOR_4
 /**


### PR DESCRIPTION
**Description of the problem**

We would like to get the number of decompressed frames using `dai_posn`. At the moment, adding the following code to
`sof_compr_pointer` (found at `sound/soc/sof/compress.c`):

```
       tstamp->pcm_io_frames = spcm->stream[cstream->direction].posn.dai_posn / 8;
```
will not work because `dai_posn` is not updated (it's always 0). This is because of the way `pipeline_for_each_comp` (found at
`src/audio/pipeline/pipeline-graph.c`) and `host_dma_cb` (found at `src/audio/host-legacy.c`) work.


`pipeline_for_each_comp` sets the `walking` flag of each of the component buffers to `true` as it traverses them and then sets it back to `false` when the traversal is done.

`host_dma_cb` calls `host_update_position` which in turn calls `pipeline_get_timestamp` after some host copy operations (depends on the value of `update_mailbox`).

The problem comes from the fact that because `pipeline_copy` traverses the pipeline graph and calls the copy operation for each of the components it will also call the host copy operation which will call `host_dma_cb` after it's done. This will not work because the `walking` flag of the buffer linked to the host component is already set to `true` by the copy operation so `pipeline_get_timestamp` will not be able to get to the DAI and get the updated `dai_posn`.

What this change intends to do is to bypass the graph traversal process using `pipeline_for_each_comp` (which will not work because of the copy operation) in order to get the updated `dai_posn`.

**Platform:** i.MX8QM