### PR TITLE
ipc4: setdx: error checking on core disabling

### DIFF
--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -859,6 +859,10 @@ static int ipc4_module_process_dx(struct ipc4_message_request *ipc4)
 			}
 		} else {
 			cpu_disable_core(core_id);
+			if (cpu_is_core_enabled(core_id)) {
+				tr_err(&ipc_tr, "failed to disable core %d", core_id);
+				return IPC4_FAILURE;
+			}
 		}
 	}
 
@@ -879,7 +883,6 @@ static int ipc4_module_process_dx(struct ipc4_message_request *ipc4)
 		platform_context_save(sof_get());
 
 		ipc_get()->pm_prepare_D3 = 1;
-		/* TODO: prepare for D3 */
 	}
 
 	return IPC4_SUCCESS;


### PR DESCRIPTION
If operation of disabling secondary core fails at any of the steps, host
will only learn about it after checking the SPA/CPA bits.

This patch adds checking core state after it disabling. If core will be
still active ipc response will report error.

Additionally, it removes an outdated comment.

Signed-off-by: Tomasz Leman <tomasz.m.leman@intel.com>