### PR TITLE
RTNR: Modify used static libraries

### DIFF
--- a/src/audio/rtnr/rtklib/tgl/CMakeLists.txt
+++ b/src/audio/rtnr/rtklib/tgl/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 sof_add_static_library(SOF_RTK_MA_API libSOF_RTK_MA_API.a)
-sof_add_static_library(Suite_rename libSuite_rename.a)
-sof_add_static_library(Net libNet.a)
+sof_add_static_library(Suite_MaLtFP libSuite_MaLtFP.a)
 sof_add_static_library(Preset libPreset.a)
+sof_add_static_library(utils libutils.a)
 

--- a/src/audio/rtnr/rtklib/tgl/README.txt
+++ b/src/audio/rtnr/rtklib/tgl/README.txt
@@ -1,1 +1,1 @@
-Put libSOF_RTK_MA_API.a, libSuite_rename.a, libNet.a and libPreset.a here.
+Put libSOF_RTK_MA_API.a, libSuite_MaLtFP.a, libPreset.a and libutils.a here.


### PR DESCRIPTION
With the version released in 20220728, some libraries are removed or renamed.