### PR TITLE
Audio: Pcm_converter: add hifi3 version new functions

### DIFF
--- a/src/audio/pcm_converter/pcm_converter_hifi3.c
+++ b/src/audio/pcm_converter/pcm_converter_hifi3.c
@@ -207,7 +207,7 @@ static int pcm_convert_s16_to_s32(const struct audio_stream __sparse_cache *sour
 		for (i = 0; i < m; i++) {
 			/* load four 16 bit samples */
 			AE_LA16X4_IP(sample, inu, in);
-			/* shift right and store four 32 bit samples */
+			/* shift left and store four 32 bit samples */
 			AE_SA32X2_IP(AE_CVT32X2F16_32(sample), outu, out);
 			AE_SA32X2_IP(AE_CVT32X2F16_10(sample), outu, out);
 		}
@@ -413,6 +413,53 @@ static int pcm_convert_s32_to_s24(const struct audio_stream __sparse_cache *sour
 	return samples;
 }
 
+static int pcm_convert_s32_to_s24_be(const struct audio_stream __sparse_cache *source,
+				     uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+				     uint32_t ooffset, uint32_t samples)
+{
+	int32_t *src = source->r_ptr;
+	int32_t *dst = sink->w_ptr;
+	ae_int32x2 sample = AE_ZERO32();
+	uint32_t nmax, i, n, m, left_samples;
+	ae_valign outu = AE_ZALIGN64();
+	ae_valign inu = AE_ZALIGN64();
+
+	ae_int32x2 *in = audio_stream_wrap(source, src + ioffset);
+	ae_int32x2 *out = audio_stream_wrap(sink, dst + ooffset);
+
+	for (left_samples = samples; left_samples; left_samples -= n) {
+		nmax = audio_stream_samples_without_wrap_s32(source, in);
+		n = MIN(left_samples, nmax);
+		nmax = audio_stream_samples_without_wrap_s32(sink, out);
+		n = MIN(n, nmax);
+		m = n >> 1;
+		inu = AE_LA64_PP(in);
+		for (i = 0; i < m; i++) {
+			/* load 2 32 bit samples */
+			AE_LA32X2_IP(sample, inu, in);
+			/* shift with saturation and rounding */
+			sample = AE_SRAA32RS(sample, 8);
+			sample = AE_SLAI32S(sample, 8);
+			AE_SA32X2_IP(sample, outu, out);
+		}
+		AE_SA64POS_FP(outu, out);
+
+		/* process the left 1 sample to avoid memory access overrun */
+		if (n & 0x01) {
+			/* load one 32 bit sample */
+			AE_L32_IP(sample, (ae_int32 *)in, sizeof(ae_int32));
+			/* shift with saturation and rounding and store one 32 bit sample */
+			sample = AE_SRAA32RS(sample, 8);
+			sample = AE_SLAI32S(sample, 8);
+			AE_S32_L_IP(sample, (ae_int32 *)out, sizeof(ae_int32));
+		}
+
+		in = audio_stream_wrap(source, in);
+		out = audio_stream_wrap(sink, out);
+	}
+
+	return samples;
+}
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_S24LE && CONFIG_PCM_CONVERTER_FORMAT_S32LE */
 
 #if XCHAL_HAVE_FP
@@ -724,6 +771,9 @@ const struct pcm_func_map pcm_func_map[] = {
 #if CONFIG_PCM_CONVERTER_FORMAT_S24LE
 	{ SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S24_4LE, audio_stream_copy },
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_S24LE */
+#if CONFIG_PCM_CONVERTER_FORMAT_S24_3LE
+	{ SOF_IPC_FRAME_S24_3LE, SOF_IPC_FRAME_S24_3LE, audio_stream_copy },
+#endif /* CONFIG_PCM_CONVERTER_FORMAT_S24_3LE */
 #if CONFIG_PCM_CONVERTER_FORMAT_S24LE && CONFIG_PCM_CONVERTER_FORMAT_S16LE
 	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S24_4LE, pcm_convert_s16_to_s24 },
 	{ SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S16_LE, pcm_convert_s24_to_s16 },
@@ -757,7 +807,480 @@ const struct pcm_func_map pcm_func_map[] = {
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_FLOAT && CONFIG_PCM_CONVERTER_FORMAT_S32LE */
 #endif /* XCHAL_HAVE_FP */
 };
-
 const size_t pcm_func_count = ARRAY_SIZE(pcm_func_map);
+
+#if CONFIG_PCM_CONVERTER_FORMAT_S16_C16_AND_S16_C32
+static int pcm_convert_s16_c16_to_s16_c32(const struct audio_stream __sparse_cache *source,
+					  uint32_t ioffset,
+					  struct audio_stream __sparse_cache *sink,
+					  uint32_t ooffset, uint32_t samples)
+{
+	int16_t *src = source->r_ptr;
+	int32_t *dst = sink->w_ptr;
+	ae_int16x4 sample = AE_ZERO16();
+	uint32_t nmax, i, n, m, left, left_samples;
+	ae_valign inu = AE_ZALIGN64();
+	ae_valign outu = AE_ZALIGN64();
+
+	ae_int16x4 *in = audio_stream_wrap(source, src + ioffset);
+	ae_int32x2 *out = audio_stream_wrap(sink, dst + ooffset);
+
+	for (left_samples = samples; left_samples; left_samples -= n) {
+		nmax = audio_stream_samples_without_wrap_s16(source, in);
+		n = MIN(left_samples, nmax);
+		nmax = audio_stream_samples_without_wrap_s32(sink, out);
+		n = MIN(n, nmax);
+		m = n >> 2;
+		left = n & 0x03;
+
+		inu = AE_LA64_PP(in);
+		for (i = 0; i < m; i++) {
+			/* load four 16 bit samples */
+			AE_LA16X4_IP(sample, inu, in);
+			/* shift right and store four 32 bit samples */
+			AE_SA32X2_IP(AE_SEXT32X2D16_32(sample), outu, out);
+			AE_SA32X2_IP(AE_SEXT32X2D16_10(sample), outu, out);
+		}
+		AE_SA64POS_FP(outu, out);
+
+		/* process the left samples that less than 4
+		 * one by one to avoid memory access overrun
+		 */
+		for (i = 0; i < left ; i++) {
+			/* load one 16 bit samples */
+			AE_L16_IP(sample, (ae_int16 *)in, sizeof(ae_int16));
+
+			/* store one 32 bit sample */
+			AE_S32_L_IP(AE_SEXT32X2D16_32(sample), (ae_int32 *)out, sizeof(ae_int32));
+		}
+
+		in = audio_stream_wrap(source, in);
+		out = audio_stream_wrap(sink, out);
+	}
+	return samples;
+}
+
+static int pcm_convert_s16_c32_to_s16_c16(const struct audio_stream __sparse_cache *source,
+					  uint32_t ioffset,
+					  struct audio_stream __sparse_cache *sink,
+					  uint32_t ooffset, uint32_t samples)
+{
+	int32_t *src = source->r_ptr;
+	int16_t *dst = sink->w_ptr;
+	ae_int16x4 sample = AE_ZERO16();
+	ae_int32x2 sample_1 = AE_ZERO32();
+	ae_int32x2 sample_2 = AE_ZERO32();
+	uint32_t nmax, i, n, m, left, left_samples;
+	ae_valign outu = AE_ZALIGN64();
+	ae_valign inu = AE_ZALIGN64();
+
+	ae_int32x2 *in = audio_stream_wrap(source, src + ioffset);
+	ae_int16x4 *out = audio_stream_wrap(sink, dst + ooffset);
+
+	for (left_samples = samples; left_samples; left_samples -= n) {
+		nmax = audio_stream_samples_without_wrap_s32(source, in);
+		n = MIN(left_samples, nmax);
+		nmax = audio_stream_samples_without_wrap_s16(sink, out);
+		n = MIN(n, nmax);
+		m = n >> 2;
+		left = n & 0x3;
+		inu = AE_LA64_PP(in);
+		for (i = 0; i < m; i++) {
+			/* load four 32 bit samples */
+			AE_LA32X2_IP(sample_1, inu, in);
+			AE_LA32X2_IP(sample_2, inu, in);
+
+			/* truncate the LSB 16bit of four 32-bit signed elements*/
+			sample = AE_CVT16X4(sample_1, sample_2);
+
+			/* store four 16 bit samples */
+			AE_SA16X4_IP(sample, outu, out);
+		}
+		AE_SA64POS_FP(outu, out);
+
+		/* process the left samples that less than 4
+		 * one by one to avoid memory access overrun
+		 */
+		for (i = 0; i < left ; i++) {
+			/* load one 32 bit samples */
+			AE_L32_IP(sample_1, (ae_int32 *)in, sizeof(ae_int32));
+			/* shift and round */
+			sample = AE_CVT16X4(sample_1, sample_1);
+			/* store one 16 bit sample */
+			AE_S16_0_IP(AE_MOVAD16_0(sample), (ae_int16 *)out, sizeof(ae_int16));
+		}
+
+		in = audio_stream_wrap(source, in);
+		out = audio_stream_wrap(sink, out);
+	}
+
+	return samples;
+}
+#endif
+
+#if CONFIG_PCM_CONVERTER_FORMAT_S16_C32_AND_S32_C32
+static int pcm_convert_s16_c32_to_s32_c32(const struct audio_stream __sparse_cache *source,
+					  uint32_t ioffset,
+					  struct audio_stream __sparse_cache *sink,
+					  uint32_t ooffset, uint32_t samples)
+{
+	int32_t *src = source->r_ptr;
+	int32_t *dst = sink->w_ptr;
+	ae_int32x2 sample = AE_ZERO32();
+	uint32_t nmax, i, n, m, left_samples;
+	ae_valign outu = AE_ZALIGN64();
+	ae_valign inu = AE_ZALIGN64();
+
+	ae_int32x2 *in = audio_stream_wrap(source, src + ioffset);
+	ae_int32x2 *out = audio_stream_wrap(sink, dst + ooffset);
+
+	for (left_samples = samples; left_samples; left_samples -= n) {
+		nmax = audio_stream_samples_without_wrap_s32(source, in);
+		n = MIN(left_samples, nmax);
+		nmax = audio_stream_samples_without_wrap_s32(sink, out);
+		n = MIN(n, nmax);
+		m = n >> 1;
+		inu = AE_LA64_PP(in);
+		for (i = 0; i < m; i++) {
+			/* load 2 32 bit samples */
+			AE_LA32X2_IP(sample, inu, in);
+			/* shift left and store two 32 bit samples */
+			AE_SA32X2_IP(AE_SLAI32(sample, 16), outu, out);
+		}
+		AE_SA64POS_FP(outu, out);
+
+		/* process the left 1 sample to avoid memory access overrun */
+		if (n & 0x01) {
+			AE_L32_IP(sample, (ae_int32 *)in, sizeof(ae_int32));
+			AE_S32_L_IP(AE_SLAI32(sample, 16), (ae_int32 *)out, sizeof(ae_int32));
+		}
+
+		in = audio_stream_wrap(source, in);
+		out = audio_stream_wrap(sink, out);
+	}
+
+	return samples;
+}
+
+static int pcm_convert_s32_c32_to_s16_c32(const struct audio_stream __sparse_cache *source,
+					  uint32_t ioffset,
+					  struct audio_stream __sparse_cache *sink,
+					  uint32_t ooffset, uint32_t samples)
+{
+	int32_t *src = source->r_ptr;
+	int32_t *dst = sink->w_ptr;
+	ae_int32x2 sample = AE_ZERO32();
+	uint32_t nmax, i, n, m, left_samples;
+	ae_valign outu = AE_ZALIGN64();
+	ae_valign inu = AE_ZALIGN64();
+
+	ae_int32x2 *in = audio_stream_wrap(source, src + ioffset);
+	ae_int32x2 *out = audio_stream_wrap(sink, dst + ooffset);
+
+	for (left_samples = samples; left_samples; left_samples -= n) {
+		nmax = audio_stream_samples_without_wrap_s32(source, in);
+		n = MIN(left_samples, nmax);
+		nmax = audio_stream_samples_without_wrap_s32(sink, out);
+		n = MIN(n, nmax);
+		m = n >> 1;
+		inu = AE_LA64_PP(in);
+		for (i = 0; i < m; i++) {
+			/* load 2 32 bit samples */
+			AE_LA32X2_IP(sample, inu, in);
+			/* shift right and store two 32 bit samples */
+			AE_SA32X2_IP(AE_SRAA32RS(sample, 16), outu, out);
+		}
+		AE_SA64POS_FP(outu, out);
+
+		/* process the left 1 sample to avoid memory access overrun */
+		if (n & 0x01) {
+			AE_L32_IP(sample, (ae_int32 *)in, sizeof(ae_int32));
+			AE_S32_L_IP(AE_SRAA32RS(sample, 16), (ae_int32 *)out, sizeof(ae_int32));
+		}
+
+		in = audio_stream_wrap(source, in);
+		out = audio_stream_wrap(sink, out);
+	}
+
+	return samples;
+}
+#endif
+
+#if CONFIG_PCM_CONVERTER_FORMAT_S16_C32_AND_S24_C32
+static int pcm_convert_s16_c32_to_s24_c32(const struct audio_stream __sparse_cache *source,
+					  uint32_t ioffset,
+					  struct audio_stream __sparse_cache *sink,
+					  uint32_t ooffset, uint32_t samples)
+{
+	int32_t *src = source->r_ptr;
+	int32_t *dst = sink->w_ptr;
+	ae_int32x2 sample = AE_ZERO32();
+	uint32_t nmax, i, n, m, left_samples;
+	ae_valign outu = AE_ZALIGN64();
+	ae_valign inu = AE_ZALIGN64();
+
+	ae_int32x2 *in = audio_stream_wrap(source, src + ioffset);
+	ae_int32x2 *out = audio_stream_wrap(sink, dst + ooffset);
+
+	for (left_samples = samples; left_samples; left_samples -= n) {
+		nmax = audio_stream_samples_without_wrap_s32(source, in);
+		n = MIN(left_samples, nmax);
+		nmax = audio_stream_samples_without_wrap_s32(sink, out);
+		n = MIN(n, nmax);
+		m = n >> 1;
+		inu = AE_LA64_PP(in);
+		for (i = 0; i < m; i++) {
+			/* load 2 32 bit samples */
+			AE_LA32X2_IP(sample, inu, in);
+			/* shift left and store two 32 bit samples */
+			AE_SA32X2_IP(AE_SLAI32(sample, 8), outu, out);
+		}
+		AE_SA64POS_FP(outu, out);
+
+		/* process the left 1 sample to avoid memory access overrun */
+		if (n & 0x01) {
+			AE_L32_IP(sample, (ae_int32 *)in, sizeof(ae_int32));
+			AE_S32_L_IP(AE_SLAI32(sample, 8), (ae_int32 *)out, sizeof(ae_int32));
+		}
+
+		in = audio_stream_wrap(source, in);
+		out = audio_stream_wrap(sink, out);
+	}
+
+	return samples;
+}
+
+static ae_int32x2 pcm_shift_s24_c32_to_s16(ae_int32x2 sample)
+{
+	/*get the lsb 24bit,sign_extend_s24 */
+	sample = AE_MOVINT24X2_FROMF32X2(sample);
+	sample = AE_SLAI32S(sample, 8);
+	sample = AE_SRAA32RS(sample, 8);
+	/* Q_SHIFT_RND */
+	sample = AE_SRAA32RS(sample, 8);
+
+	return sample;
+}
+
+static int pcm_convert_s24_c32_to_s16_c32(const struct audio_stream __sparse_cache *source,
+					  uint32_t ioffset,
+					  struct audio_stream __sparse_cache *sink,
+					  uint32_t ooffset, uint32_t samples)
+{
+	int32_t *src = source->r_ptr;
+	int32_t *dst = sink->w_ptr;
+	ae_int32x2 sample = AE_ZERO32();
+	uint32_t nmax, i, n, m, left_samples;
+	ae_valign outu = AE_ZALIGN64();
+	ae_valign inu = AE_ZALIGN64();
+
+	ae_int32x2 *in = audio_stream_wrap(source, src + ioffset);
+	ae_int32x2 *out = audio_stream_wrap(sink, dst + ooffset);
+
+	for (left_samples = samples; left_samples; left_samples -= n) {
+		nmax = audio_stream_samples_without_wrap_s32(source, in);
+		n = MIN(left_samples, nmax);
+		nmax = audio_stream_samples_without_wrap_s32(sink, out);
+		n = MIN(n, nmax);
+		m = n >> 1;
+		inu = AE_LA64_PP(in);
+		for (i = 0; i < m; i++) {
+			/* load 2 32 bit samples */
+			AE_LA32X2_IP(sample, inu, in);
+			sample = pcm_shift_s24_c32_to_s16(sample);
+			/* shift left and store two 32 bit samples */
+			AE_SA32X2_IP(sample, outu, out);
+		}
+		AE_SA64POS_FP(outu, out);
+
+		/* process the left 1 sample to avoid memory access overrun */
+		if (n & 0x01) {
+			AE_L32_IP(sample, (ae_int32 *)in, sizeof(ae_int32));
+			sample = pcm_shift_s24_c32_to_s16(sample);
+			AE_S32_L_IP(sample, (ae_int32 *)out, sizeof(ae_int32));
+		}
+
+		in = audio_stream_wrap(source, in);
+		out = audio_stream_wrap(sink, out);
+	}
+
+	return samples;
+}
+#endif
+
+#if CONFIG_PCM_CONVERTER_FORMAT_S24_C24_AND_S24_C32
+static int pcm_convert_s24_c24_to_s24_c32(const struct audio_stream __sparse_cache *source,
+					  uint32_t ioffset,
+					  struct audio_stream __sparse_cache *sink,
+					  uint32_t ooffset, uint32_t samples)
+{
+	uint8_t *src = source->r_ptr;
+	int32_t *dst = sink->w_ptr;
+	ae_int24x2 sample24 =  AE_ZERO24();
+	ae_int32x2 sample = AE_ZERO32();
+	uint32_t nmax, i, n, m, left_samples;
+	ae_valign outu = AE_ZALIGN64();
+	ae_valign inu = AE_ZALIGN64();
+
+	ae_int24x2 *in = audio_stream_wrap(source, src + ioffset * 3);
+	ae_int32x2 *out = audio_stream_wrap(sink, dst + ooffset);
+
+	for (left_samples = samples; left_samples; left_samples -= n) {
+		nmax = audio_stream_bytes_without_wrap(source, in) / 3;
+		n = MIN(left_samples, nmax);
+		nmax = audio_stream_samples_without_wrap_s32(sink, out);
+		n = MIN(n, nmax);
+		m = n >> 1;
+		inu = AE_LA64_PP(in);
+		for (i = 0; i < m; i++) {
+			/* load 2 32 bit samples */
+			AE_LA24X2_IP(sample24, inu, in);
+			sample = AE_MOVINT32_FROMINT24X2(sample24);
+			/* shift left and store two 32 bit samples */
+			AE_SA32X2_IP(sample, outu, out);
+		}
+		AE_SA64POS_FP(outu, out);
+
+		/* process the left 1 sample to avoid memory access overrun */
+		if (n & 0x01) {
+			AE_LA24_IP(sample24, inu, in);
+			sample = AE_MOVINT32_FROMINT24X2(sample24);
+			AE_S32_L_IP(sample, (ae_int32 *)out,
+				    sizeof(ae_int32));
+		}
+
+		in = audio_stream_wrap(source, in);
+		out = audio_stream_wrap(sink, out);
+	}
+
+	return samples;
+}
+
+static int pcm_convert_s24_c32_to_s24_c24(const struct audio_stream __sparse_cache *source,
+					  uint32_t ioffset,
+					  struct audio_stream __sparse_cache *sink,
+					  uint32_t ooffset, uint32_t samples)
+{
+	int32_t *src = source->r_ptr;
+	uint8_t *dst = sink->w_ptr;
+	ae_int32x2 sample = AE_ZERO32();
+	ae_int24x2 sample24 =  AE_ZERO24();
+	uint32_t nmax, i, n, m, left_samples;
+	ae_valign outu = AE_ZALIGN64();
+	ae_valign inu = AE_ZALIGN64();
+
+	ae_int32x2 *in = audio_stream_wrap(source, src + ioffset);
+	ae_int24x2 *out = audio_stream_wrap(sink, dst + ooffset * 3);
+
+	for (left_samples = samples; left_samples; left_samples -= n) {
+		nmax = audio_stream_samples_without_wrap_s32(source, in);
+		n = MIN(left_samples, nmax);
+		nmax = audio_stream_bytes_without_wrap(sink, out) / 3;
+		n = MIN(n, nmax);
+		m = n >> 1;
+		inu = AE_LA64_PP(in);
+		for (i = 0; i < m; i++) {
+			/* load 2 32 bit samples */
+			AE_LA32X2_IP(sample, inu, in);
+			sample24 = AE_MOVINT24X2_FROMF32X2(sample);
+			AE_SA24X2_IP(sample24, outu, out);
+		}
+		AE_SA64POS_FP(outu, out);
+
+		/* process the left 1 sample to avoid memory access overrun */
+		if (n & 0x01) {
+			AE_L32_IP(sample, (ae_int32 *)in, sizeof(ae_int32));
+			sample24 = AE_MOVINT24X2_FROMF32X2(sample);
+			AE_SA24_IP(sample24, outu, out);
+		}
+
+		in = audio_stream_wrap(source, in);
+		out = audio_stream_wrap(sink, out);
+	}
+
+	return samples;
+}
+
+/* Haven't implement the pcm_convert_s24_c32_to_s24_c24_link_gtw since there are some
+ * errors in that function. Need to wait for the function to be corrected and verified.
+ */
+#endif
+
+/* Different gateway has different sample layout requirement
+ * (1) hda link gateway: 24le sample should be converted to 24be one
+ * (2) alh gateway: all data format layout should be in big-endian style in 32bit container,
+ *     .e.g. 24le stream should be convert to 24be one
+ * (3) ssp gateway: all sample should be in container size of 32bit
+ */
+const struct pcm_func_vc_map pcm_func_vc_map[] = {
+#if CONFIG_PCM_CONVERTER_FORMAT_S16_C16_AND_S16_C32
+	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE,
+		ipc4_gtw_all, ipc4_bidirection, pcm_convert_s16_c16_to_s16_c32 },
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S16_LE,
+		ipc4_gtw_all, ipc4_bidirection, pcm_convert_s16_c32_to_s16_c16 },
+#endif
+#if CONFIG_PCM_CONVERTER_FORMAT_S16_C32_AND_S32_C32
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE,
+		ipc4_gtw_all, ipc4_bidirection, pcm_convert_s16_c32_to_s32_c32 },
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE,
+		ipc4_gtw_all, ipc4_bidirection, pcm_convert_s32_c32_to_s16_c32 },
+#endif
+#if CONFIG_PCM_CONVERTER_FORMAT_S16_C32_AND_S24_C32
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE,
+		ipc4_gtw_all & ~ipc4_gtw_alh, ipc4_bidirection, pcm_convert_s16_c32_to_s24_c32 },
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE,
+		ipc4_gtw_alh, ipc4_capture, pcm_convert_s32_to_s24 },
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE,
+		ipc4_gtw_all & ~ipc4_gtw_alh, ipc4_bidirection, pcm_convert_s24_c32_to_s16_c32 },
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE,
+		ipc4_gtw_alh, ipc4_playback, pcm_convert_s24_to_s32 },
+#endif
+#if CONFIG_PCM_CONVERTER_FORMAT_S32LE && CONFIG_PCM_CONVERTER_FORMAT_S24LE
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE,
+		ipc4_gtw_all & ~(ipc4_gtw_link | ipc4_gtw_alh | ipc4_gtw_host), ipc4_bidirection,
+		audio_stream_copy},
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE,
+		ipc4_gtw_link | ipc4_gtw_alh, ipc4_playback, pcm_convert_s24_to_s32 },
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE,
+		ipc4_gtw_link | ipc4_gtw_alh, ipc4_capture, pcm_convert_s32_to_s24 },
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE,
+		ipc4_gtw_host, ipc4_playback, pcm_convert_s32_to_s24 },
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE,
+		ipc4_gtw_host, ipc4_capture, pcm_convert_s24_to_s32 },
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE,
+		ipc4_gtw_all, ipc4_bidirection, pcm_convert_s24_to_s32},
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE,
+		ipc4_gtw_all & ~(ipc4_gtw_link | ipc4_gtw_alh), ipc4_bidirection,
+		pcm_convert_s32_to_s24 },
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE,
+		ipc4_gtw_link | ipc4_gtw_alh, ipc4_playback, pcm_convert_s32_to_s24_be },
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE,
+		ipc4_gtw_link | ipc4_gtw_alh, ipc4_capture, pcm_convert_s32_to_s24 },
+#endif
+#if CONFIG_PCM_CONVERTER_FORMAT_S24LE && CONFIG_PCM_CONVERTER_FORMAT_S16LE
+	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S32_LE,
+		SOF_IPC_FRAME_S24_4LE, ipc4_gtw_all & ~(ipc4_gtw_link | ipc4_gtw_alh),
+		ipc4_bidirection, pcm_convert_s16_to_s24 },
+	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S32_LE,
+		SOF_IPC_FRAME_S24_4LE, ipc4_gtw_link | ipc4_gtw_alh, ipc4_playback,
+		pcm_convert_s16_to_s32},
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S16_LE,
+		SOF_IPC_FRAME_S16_LE, ipc4_gtw_all, ipc4_bidirection, pcm_convert_s24_to_s16 },
+#endif
+#if CONFIG_PCM_CONVERTER_FORMAT_S24_C24_AND_S24_C32
+	{ SOF_IPC_FRAME_S24_3LE, SOF_IPC_FRAME_S24_3LE, SOF_IPC_FRAME_S32_LE,
+		SOF_IPC_FRAME_S24_4LE, ipc4_gtw_all, ipc4_bidirection,
+		pcm_convert_s24_c24_to_s24_c32},
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S24_3LE,
+		SOF_IPC_FRAME_S24_3LE, ipc4_gtw_all & ~ipc4_gtw_link,
+		ipc4_bidirection, pcm_convert_s24_c32_to_s24_c24 },
+#endif
+#if CONFIG_PCM_CONVERTER_FORMAT_S16_C32_AND_S16_C32
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S32_LE,
+		SOF_IPC_FRAME_S16_LE, ipc4_gtw_all, ipc4_bidirection, audio_stream_copy },
+#endif
+};
+
+const size_t pcm_func_vc_count = ARRAY_SIZE(pcm_func_vc_map);
 
 #endif

--- a/src/include/sof/audio/pcm_converter.h
+++ b/src/include/sof/audio/pcm_converter.h
@@ -30,11 +30,7 @@ struct audio_stream;
 
 #ifndef UNIT_TEST
 #if __XCC__ && XCHAL_HAVE_HIFI3 && CONFIG_FORMAT_CONVERT_HIFI3
-#if __ZEPHYR__ && CONFIG_IPC_MAJOR_4
-#define PCM_CONVERTER_GENERIC
-#else
 #define PCM_CONVERTER_HIFI3
-#endif
 #else
 #define PCM_CONVERTER_GENERIC
 #endif


### PR DESCRIPTION
Use hifi3 instructions implement new format conversion functions
of pcm_func_vc_map. Keep pcm_convert_s24_c32_to_s24_c24_link_gtw
as C version, since there are still some bugs. Will implement this
function after those bugs fixed as the original assumption of author.

Signed-off-by: Andrula Song <xiaoyuan.song@intel.com>