### PR TITLE
Add new submanifests/sof-ci-jenkins/zephyr-override.yml

### DIFF
--- a/submanifests/sof-ci-jenkins/zephyr-override-template.yml
+++ b/submanifests/sof-ci-jenkins/zephyr-override-template.yml
@@ -1,0 +1,26 @@
+---
+# This file is used by sof-ci/jenkins (Linux CI) like this:
+#
+# sed -e 's/=sof_zephyr_revision_override=/zephyr_version_to_test/' \
+#        submanifests/sof-ci-jenkins/zephyr-override-template.yml \
+#   > submanifests/50-sof-ci-jenkins-zephyr-override.yml
+#
+# where 'zephyr_version_to_test' is a fetchable git version (branch, tag,
+# complete SHA1,...)
+# You can override this substitution by changing the revision: below.
+#
+# The number prefix '50-' is just an example, you must adjust it if you
+# use other submanifests/*.yml files. West sorts submanifests/*.yml
+# files before reading them, see west's documentation currently hosted
+# on the Zephyr website.
+
+manifest:
+  projects:
+    # override zephyr project in west.yml
+    - name: zephyr
+      url: https://github.com/zephyrproject-rtos/zephyr
+      revision: =sof_zephyr_revision_override=
+      import:
+        # Download only what sof-ci-jenkins uses to save a lot of time
+        name-allowlist:
+          - hal_xtensa


### PR DESCRIPTION
This file provides the flexibility to test any Zephyr commit in Linux
CI without any pollution of `git -C sof describe --dirty`. See (too)
long discussion in #6005 for details.

This new file will have no effect until #6005 is merged. However it can
and SHOULD be merged before #6005 because #6005 is backwards
incompatible and requires a "flag day" and the synchronization of
several moving parts. So merging this commit earlier means having one
less moving part to synchronize and it will simplify "flag day"
rehearsals.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>