### PR TITLE
zephyr: implement a Zephyr logging backend for mtrace

### DIFF
--- a/src/audio/base_fw.c
+++ b/src/audio/base_fw.c
@@ -71,7 +71,7 @@ static int basefw_config(uint32_t *data_offset, char *data)
 
 	/* TODO: add log support */
 	tuple = next_tuple(tuple);
-	set_tuple_uint32(tuple, IPC4_TRACE_LOG_BYTES_FW_CFG, 0);
+	set_tuple_uint32(tuple, IPC4_TRACE_LOG_BYTES_FW_CFG, 1024);
 
 	tuple = next_tuple(tuple);
 	set_tuple_uint32(tuple, IPC4_MAX_PPL_CNT_FW_CFG, IPC4_MAX_PPL_COUNT);

--- a/src/trace/log_backend_mtrace.c
+++ b/src/trace/log_backend_mtrace.c
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2019,2022 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/logging/log_backend.h>
+#include <zephyr/logging/log_core.h>
+#include <zephyr/logging/log_output.h>
+#include <zephyr/logging/log_backend_std.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/winstream.h>
+#include <soc.h>
+#include <adsp_memory.h>
+
+/*
+ * A lock is needed as log_process() and log_panic() have no internal locks
+ * to prevent concurrency. Meaning if log_process is called after
+ * log_panic was called previously, log_process may happen from another
+ * CPU and calling context than the log processing thread running in
+ * the background. On an SMP system this is a race.
+ *
+ * This caused a race on the output trace such that the logging output
+ * was garbled and useless.
+ */
+static struct k_spinlock lock;
+
+static uint32_t log_format_current = CONFIG_LOG_BACKEND_ADSP_OUTPUT_DEFAULT;
+
+static struct sys_winstream *winstream;
+
+#define SOF_MTRACE_DESCRIPTOR_SIZE	12 /* 3 x u32 */
+#define SOF_MTRACE_PAGE_SIZE		0x1000
+#define SOF_MTRACE_SLOT_SIZE		SOF_MTRACE_PAGE_SIZE
+
+static void mtrace_init(void)
+{
+	uint8_t *buf2 = z_soc_uncached_ptr((void *)HP_SRAM_WIN2_BASE);
+	uint8_t *toffset = (uint8_t*)buf2 + 4;
+	unsigned int boffset = SOF_MTRACE_SLOT_SIZE + 8;
+	volatile uint32_t *type = (uint32_t*) toffset;
+
+	/* FIXME: something zeros window2 after soc_trace_init(), so
+	 * this has to be redone here ondemand until issue rootcaused */
+	if (*type != 0x474f4c00) {
+		*type = 0x474f4c00;
+
+		winstream = sys_winstream_init(buf2 + boffset, HP_SRAM_WIN2_SIZE - boffset);
+	}
+}
+
+static void mtrace_update_dsp_writeptr(void)
+{
+	uint8_t *buf = z_soc_uncached_ptr((void *)HP_SRAM_WIN2_BASE);
+	unsigned int winstr_offset = SOF_MTRACE_SLOT_SIZE + 2 * sizeof(uint32_t);
+	unsigned int dspptr_offset = SOF_MTRACE_SLOT_SIZE + sizeof(uint32_t);
+	struct sys_winstream *winstream = (struct sys_winstream *)(buf + winstr_offset);
+	uint32_t pos = winstream->end + 4 * sizeof(uint32_t);
+	volatile uint32_t *dsp_ptr = (uint32_t*)(buf + dspptr_offset);
+
+	/* copy write pointer maintained by winstream to correct
+	 * place (as expected by driver) */
+	*dsp_ptr = pos;
+}
+
+static void mtrace_out(int8_t *str, size_t len)
+{
+	/* FIXME: the WIN2 area gets overwritten/zeroed
+	 *        some time after soc_trace_init(), so as
+	 *        a stopgap, keep reinitializing the WIN2
+	 *        headers */
+	mtrace_init();
+
+	if (len == 0) {
+		return;
+	}
+
+	sys_winstream_write(winstream, str, len);
+	mtrace_update_dsp_writeptr();
+}
+
+static int char_out(uint8_t *data, size_t length, void *ctx)
+{
+	mtrace_out(data, length);
+
+	return length;
+}
+
+/**
+ * 80 bytes seems to catch most sensibly sized log message lines
+ * in one go letting the trace out call output whole complete
+ * lines. This avoids the overhead of a spin lock in the trace_out
+ * more often as well as avoiding entwined characters from printk if
+ * LOG_PRINTK=n.
+ */
+#define LOG_BUF_SIZE 80
+static uint8_t log_buf[LOG_BUF_SIZE];
+
+LOG_OUTPUT_DEFINE(log_output_adsp_mtrace, char_out, log_buf, sizeof(log_buf));
+
+static uint32_t format_flags(void)
+{
+	uint32_t flags = LOG_OUTPUT_FLAG_LEVEL | LOG_OUTPUT_FLAG_TIMESTAMP;
+
+	if (IS_ENABLED(CONFIG_LOG_BACKEND_FORMAT_TIMESTAMP)) {
+		flags |= LOG_OUTPUT_FLAG_FORMAT_TIMESTAMP;
+	}
+
+	return flags;
+}
+
+static void panic(struct log_backend const *const backend)
+{
+	k_spinlock_key_t key = k_spin_lock(&lock);
+
+	log_backend_std_panic(&log_output_adsp_mtrace);
+
+	k_spin_unlock(&lock, key);
+}
+
+static inline void dropped(const struct log_backend *const backend,
+			   uint32_t cnt)
+{
+	log_output_dropped_process(&log_output_adsp_mtrace, cnt);
+}
+
+static void process(const struct log_backend *const backend,
+		union log_msg_generic *msg)
+{
+	log_format_func_t log_output_func = log_format_func_t_get(log_format_current);
+
+	k_spinlock_key_t key = k_spin_lock(&lock);
+
+	log_output_func(&log_output_adsp_mtrace, &msg->log, format_flags());
+
+	k_spin_unlock(&lock, key);
+}
+
+static int format_set(const struct log_backend *const backend, uint32_t log_type)
+{
+	log_format_current = log_type;
+	return 0;
+}
+
+/**
+ * Lazily initialized, while the DMA may not be setup we continue
+ * to buffer log messages untilt he buffer is full.
+ */
+static void init(const struct log_backend *const backend)
+{
+	ARG_UNUSED(backend);
+
+	/* TODO: remove, this just to debug the logging backend itself */
+	const char dbg[] = "mtrace log init\n";
+	intel_adsp_trace_out(dbg, sizeof(dbg));
+}
+
+const struct log_backend_api log_backend_adsp_mtrace_api = {
+	.process = process,
+	.dropped = IS_ENABLED(CONFIG_LOG_MODE_IMMEDIATE) ? NULL : dropped,
+	.panic = panic,
+	.format_set = format_set,
+	.init = init,
+};
+
+LOG_BACKEND_DEFINE(log_backend_adsp_mtrace, log_backend_adsp_mtrace_api, true);

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -600,6 +600,7 @@ zephyr_library_sources_ifdef(CONFIG_IPC_MAJOR_4
 zephyr_library_sources_ifdef(CONFIG_TRACE
 	${SOF_SRC_PATH}/trace/dma-trace.c
 	${SOF_SRC_PATH}/trace/trace.c
+	${SOF_SRC_PATH}/trace/log_backend_mtrace.c
 )
 
 # Optional SOF sources - depends on Kconfig - WIP


### PR DESCRIPTION
    zephyr: implement a Zephyr logging backend for mtrace
    
    This is a proof-of-concept that implements a Zephyr logging
    backend on SOF side. The implementation matches the SOF kernel
    "mtrace" debugfs interface.
    
    Implementation on SOF side allows to easily use SOF side
    concepts like the IPC4 messages in the logging backend directly.
    
    This patch is a partial implementation. Notably missing:
      - a IPC4 notification needs to be sent when new log data
        is added to the buffer (with some configurable thresholds
        that can be set by host)
      - the mtrace layout divides the SRAM window into multiple slots,
        this PR only uses a single slot
      - the slot configuration is hardcoded to expose a single
        debug slot, with no support for multicore debug

Alternative to implementing this on Zephyr side: https://github.com/zephyrproject-rtos/zephyr/pull/47058

For end2end testing with Linux driver:
- depends on (Zephyr): https://github.com/zephyrproject-rtos/zephyr/pull/47058/commits/0929468a30a6324e719ae2e3b40cb292af27c826
- depends on (SOF): https://github.com/thesofproject/linux/pull/3728 and https://github.com/thesofproject/sof/pull/5962
- 