### PR TITLE
installer: add rpl and rpl-s aliases to tgl and tgl-h

### DIFF
--- a/installer/GNUmakefile
+++ b/installer/GNUmakefile
@@ -23,7 +23,7 @@ SIGNED_list  ?= apl cnl icl jsl tgl tgl-h
 #   git grep 'sof-.*\.ri' -- sound/soc/
 
 ALIAS_SAME_KEY_list  := glk cfl cml
-ALIAS_OTHER_KEY_list := ehl adl adl-s
+ALIAS_OTHER_KEY_list := ehl adl adl-s rpl rpl-s
 ALIAS_list ?= ${ALIAS_SAME_KEY_list} ${ALIAS_OTHER_KEY_list}
 
 
@@ -42,6 +42,8 @@ target_of_cml := cnl
 target_of_ehl := tgl
 target_of_adl   := tgl
 target_of_adl-s := tgl-h
+target_of_rpl   := tgl
+target_of_rpl-s := tgl-h
 
 ifeq (,${TOOLCHAIN})
   ifeq (,${XTENSA_TOOLS_ROOT})

--- a/installer/tests/staging_sofIPC4_ref.txt
+++ b/installer/tests/staging_sofIPC4_ref.txt
@@ -9,6 +9,8 @@
 │   ├── sof-glk.ri -> sof-apl.ri
 │   ├── sof-icl.ri
 │   ├── sof-jsl.ri
+│   ├── sof-rpl-s.ri -> sof-tgl-h.ri
+│   ├── sof-rpl.ri -> sof-tgl.ri
 │   ├── sof-tgl-h.ri
 │   └── sof-tgl.ri
 ├── intel-signed
@@ -33,9 +35,13 @@
 ├── sof-icl.ri -> intel-signed/sof-icl.ri
 ├── sof-jsl.ldc
 ├── sof-jsl.ri -> intel-signed/sof-jsl.ri
+├── sof-rpl-s.ldc -> sof-tgl-h.ldc
+├── sof-rpl-s.ri -> intel-signed/sof-rpl-s.ri
+├── sof-rpl.ldc -> sof-tgl.ldc
+├── sof-rpl.ri -> intel-signed/sof-rpl.ri
 ├── sof-tgl-h.ldc
 ├── sof-tgl-h.ri -> intel-signed/sof-tgl-h.ri
 ├── sof-tgl.ldc
 └── sof-tgl.ri -> intel-signed/sof-tgl.ri
 
-2 directories, 36 files
+2 directories, 42 files

--- a/installer/tests/staging_sof_ref.txt
+++ b/installer/tests/staging_sof_ref.txt
@@ -10,6 +10,8 @@
 │   ├── sof-glk.ri -> sof-apl.ri
 │   ├── sof-icl.ri
 │   ├── sof-jsl.ri
+│   ├── sof-rpl-s.ri -> sof-tgl-h.ri
+│   ├── sof-rpl.ri -> sof-tgl.ri
 │   ├── sof-tgl-h.ri
 │   └── sof-tgl.ri
 ├── intel-signed
@@ -42,9 +44,13 @@
 ├── sof-icl.ri -> intel-signed/sof-icl.ri
 ├── sof-jsl.ldc
 ├── sof-jsl.ri -> intel-signed/sof-jsl.ri
+├── sof-rpl-s.ldc -> sof-tgl-h.ldc
+├── sof-rpl-s.ri -> intel-signed/sof-rpl-s.ri
+├── sof-rpl.ldc -> sof-tgl.ldc
+├── sof-rpl.ri -> intel-signed/sof-rpl.ri
 ├── sof-tgl-h.ldc
 ├── sof-tgl-h.ri -> intel-signed/sof-tgl-h.ri
 ├── sof-tgl.ldc
 └── sof-tgl.ri -> intel-signed/sof-tgl.ri
 
-2 directories, 45 files
+2 directories, 51 files


### PR DESCRIPTION
rpl firmware is tgl but signed with a different key

This commit adds the following files and links below
```
$ tree installer/staging/sof |
     grep -e tgl  -e rpl -e community |
     grep -v -e adl -e ehl

├── community
│   ├── sof-rpl.ri -> sof-tgl.ri
│   ├── sof-rpl-s.ri -> sof-tgl-h.ri
│   ├── sof-tgl-h.ri
│   └── sof-tgl.ri
├── sof-rpl.ldc -> sof-tgl.ldc
├── sof-rpl.ri -> intel-signed/sof-rpl.ri
├── sof-rpl-s.ldc -> sof-tgl-h.ldc
├── sof-rpl-s.ri -> intel-signed/sof-rpl-s.ri
├── sof-tgl-h.ldc
├── sof-tgl-h.ri -> intel-signed/sof-tgl-h.ri
├── sof-tgl.ldc
└── sof-tgl.ri -> intel-signed/sof-tgl.ri
```
Signed-off-by: Marc Herbert <marc.herbert@intel.com>