### PR TITLE
docker-build.sh: don't switch versions when already initialized

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -22,11 +22,15 @@ manifest:
       path: sof/rimage/tomlc99
       revision: e3a03f5ec7d8d33be705c5ce8a632d998ce9b4d1
 
-      # west update will override your local changes to this revision
     - name: zephyr
       repo-path: zephyr
       revision: 63a497280f22aea39793dd9de9731469a83ce533
       remote: zephyrproject
+      # Import some projects listed in zephyr/west.yml@revision
+      #
+      # Warning: changes to zephyr/west.yml or to any other _imported_
+      # west.yml file are _ignored_ by design!  Only the above
+      # 'revision:' of zephyr/west.yml is used.
       import:
         name-whitelist:
           - hal_xtensa
@@ -37,4 +41,6 @@ manifest:
 
   self:
     path: sof
+    # Changes to submanifests/*.yml files _are_ effective; these have no
+    # specified 'revision:'
     import: submanifests

--- a/zephyr/docker-build.sh
+++ b/zephyr/docker-build.sh
@@ -71,4 +71,9 @@ unset ZEPHYR_SDK_INSTALL_DIR
 ls -ld /opt/toolchains/zephyr-sdk-*
 ln -s  /opt/toolchains/zephyr-sdk-*  ~/ || true
 
-./sof/scripts/xtensa-build-zephyr.py -u --no-interactive "$@"
+if test -e .west || test -e zephyr; then
+    init_update=''
+else
+    init_update='-u'
+fi
+./sof/scripts/xtensa-build-zephyr.py $init_update --no-interactive "$@"


### PR DESCRIPTION
2 commits, main one:

Restore ability to use (and test!) zephyr/docker-build.sh locally
without overwriting work in progress.

Fixes commit https://github.com/thesofproject/sof/commit/b371373f7d7486014ea7d80a5836d8958f3d93a9 ("scripts: docker-build.sh updated with
changes from xtensa-build-zephyr.py")

Signed-off-by: Marc Herbert <marc.herbert@intel.com>