### PR TITLE
sof: add zephyr prefix for zephyr header files

### DIFF
--- a/src/audio/pipeline/pipeline-stream.c
+++ b/src/audio/pipeline/pipeline-stream.c
@@ -15,13 +15,17 @@
 #include <sof/string.h>
 #include <ipc/stream.h>
 #include <ipc/topology.h>
-
-#include <kernel.h>
-
 #include <errno.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+
+#ifdef __ZEPHYR__
+#include <zephyr/kernel.h>
+#else
+/* the xtos wrapper */
+#include <kernel.h>
+#endif
 
 LOG_MODULE_DECLARE(pipe, CONFIG_SOF_LOG_LEVEL);
 

--- a/src/include/sof/compiler_attributes.h
+++ b/src/include/sof/compiler_attributes.h
@@ -8,7 +8,7 @@
 #ifdef __ZEPHYR__
 
 /* Get __sparse_cache and __sparse_force definitions if __CHECKER__ is defined */
-#include <debug/sparse.h>
+#include <zephyr/debug/sparse.h>
 
 #else
 

--- a/src/include/sof/debug/panic.h
+++ b/src/include/sof/debug/panic.h
@@ -31,7 +31,7 @@ void panic_dump(uint32_t p, struct sof_ipc_panic_info *panic_info,
 	SOF_NORETURN;
 
 #ifdef __ZEPHYR__
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #define panic(x) k_panic()
 
 #define assert(x) __ASSERT_NO_MSG(x)

--- a/src/include/sof/lib/dma.h
+++ b/src/include/sof/lib/dma.h
@@ -29,8 +29,8 @@
 #include <stdint.h>
 
 #ifdef __ZEPHYR__
-#include <device.h>
-#include <drivers/dma.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/dma.h>
 #endif
 
 struct comp_buffer;

--- a/src/include/sof/schedule/task.h
+++ b/src/include/sof/schedule/task.h
@@ -15,7 +15,7 @@
 #include <stdint.h>
 
 #ifdef __ZEPHYR__
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #endif
 
 struct comp_dev;

--- a/src/include/sof/spinlock.h
+++ b/src/include/sof/spinlock.h
@@ -166,7 +166,7 @@ void _k_spin_unlock_irq(struct k_spinlock *lock, k_spinlock_key_t key, int line)
 
 #else
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 
 /* This has to be moved to Zephyr */
 static inline void k_spinlock_init(struct k_spinlock *lock)

--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -30,13 +30,17 @@
 #include <ipc4/notification.h>
 #include <ipc/trace.h>
 #include <user/trace.h>
-
-#include <kernel.h>
-
 #include <errno.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+
+#ifdef __ZEPHYR__
+#include <zephyr/kernel.h>
+#else
+/* the xtos wrapper */
+#include <kernel.h>
+#endif
 
 LOG_MODULE_DECLARE(ipc, CONFIG_SOF_LOG_LEVEL);
 

--- a/src/platform/intel/cavs/lib/dma.c
+++ b/src/platform/intel/cavs/lib/dma.c
@@ -16,7 +16,7 @@
 #include <sof/sof.h>
 #include <sof/spinlock.h>
 #ifdef __ZEPHYR__
-#include <device.h>
+#include <zephyr/device.h>
 #endif
 
 #if CONFIG_APOLLOLAKE

--- a/zephyr/include/sof/atomic.h
+++ b/zephyr/include/sof/atomic.h
@@ -6,7 +6,7 @@
 #ifndef __INCLUDE_ATOMIC_H_
 #define __INCLUDE_ATOMIC_H_
 
-#include <sys/atomic.h>
+#include <zephyr/sys/atomic.h>
 
 /* Zephyr commit 174cb7f9f183 switched 'atomic_t' from 'int' to
  * 'long'. As we don't support 64 bits, this should have made no


### PR DESCRIPTION
The legacy include path will be deprecated on zephyr side:

https://github.com/zephyrproject-rtos/zephyr/commit/855216f

This patch adds zephyr prefix for zephyr headers to fix
the build failure due to legacy include path deprecation.

Signed-off-by: Chao Song <chao.song@linux.intel.com>