### PR TITLE
west: update to newer Zephyr baseline

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -24,7 +24,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 63a497280f22aea39793dd9de9731469a83ce533
+      revision: 8e55e59c5917b61d563d5e8bf759e8aeb746ff8b
       remote: zephyrproject
       # Import some projects listed in zephyr/west.yml@revision
       #


### PR DESCRIPTION
Update zephyr to commit 8e55e59c5917 ('arch: introduce config DCLS').

Fixes build errors due to missing core-isa.h with tgl Intel target with
gcc build chain.

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>