### PR TITLE
Revert "Audio: SRC: Increase length of internal buffer"

### DIFF
--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -54,12 +54,6 @@
 #define MAX_FIR_DELAY_SIZE_XNCH (PLATFORM_MAX_CHANNELS * MAX_FIR_DELAY_SIZE)
 #define MAX_OUT_DELAY_SIZE_XNCH (PLATFORM_MAX_CHANNELS * MAX_OUT_DELAY_SIZE)
 
-/* Coefficient to convert internal min. block multiple to buffer size between
- * stages 1 and 2. This is empirically found value plus a tenth that avoids
- * condition where processing can't happen due to run out of this buffer. Use Q4.12.
- */
-#define SBUF_LENGTH_MULTIPLIER Q_CONVERT_FLOAT(2.4, 12)
-
 static const struct comp_driver comp_src;
 
 LOG_MODULE_REGISTER(src, CONFIG_SOF_LOG_LEVEL);
@@ -201,8 +195,7 @@ int src_buffer_lengths(struct src_param *a, int fs_in, int fs_out, int nch,
 		 * variable number of blocks to process per each stage
 		 * there is no equation known for minimum size.
 		 */
-		a->sbuf_length = Q_MULTSR_32X32(nch * stage1->blk_out * r1,
-						SBUF_LENGTH_MULTIPLIER, 0, 12, 0);
+		a->sbuf_length = 2 * nch * stage1->blk_out * r1;
 	}
 
 	a->src_multich = a->fir_s1 + a->fir_s2 + a->out_s1 + a->out_s2;


### PR DESCRIPTION
This reverts commit 3aff4598f7ebd79d8cfb0398d85a85bbf4ba37e1.

This commit causes i.MX pipelines that convert from 44.1khz to 48khz to
freeze, when the firmware is compiled with Xtensa toolchain.