### PR TITLE
scripts: fix detection of build errors in xtensa-build-zephyr.py

### DIFF
--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -497,6 +497,7 @@ def build_platforms():
 			zephyr_path = pathlib.Path(west_top, "zephyr")
 			if not os.path.exists(zephyr_path):
 				sys.exit("Zephyr project not found. Please run this script with -c flag or clone manually.")
+			raise
 		smex_executable = pathlib.Path(west_top, platform_build_dir_name, "zephyr", "smex_ep",
 			"build", "smex")
 		fw_ldc_file = pathlib.Path(sof_platform_output_dir, f"sof-{platform}.ldc")


### PR DESCRIPTION
The logic to warn about a missing zephyr subdirectory unintentionally
masks all build errors. Fix this.

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>