### PR TITLE
imx: clk: Fix zephyr header include

### DIFF
--- a/src/platform/imx8/lib/clk.c
+++ b/src/platform/imx8/lib/clk.c
@@ -13,7 +13,7 @@
 #include <sof/spinlock.h>
 
 #ifdef __ZEPHYR__
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 #endif
 
 const struct freq_table platform_cpu_freq[] = {

--- a/src/platform/imx8m/lib/clk.c
+++ b/src/platform/imx8m/lib/clk.c
@@ -12,7 +12,7 @@
 #include <sof/spinlock.h>
 
 #ifdef __ZEPHYR__
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 #endif
 
 const struct freq_table platform_cpu_freq[] = {


### PR DESCRIPTION
After Zephyr commit:

855216f582d2 ("kconfig: default to LEGACY_INCLUDE_PATH=n")

we get a compile time error because legacy include paths are not
supported by default.

Fix this by adding 'zephyr/' prefix in proper places.

Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>