### PR TITLE
[SKIP CI] .github/zephyr.yml: cosmetic matrix re-ordering

### DIFF
--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -14,10 +14,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        zephyr_revision: [
-          manifest_revision,
-          "https://github.com/zephyrproject-rtos/zephyr  main",
-        ]
         IPC_platforms: [
           # IPC3
           apl cnl,
@@ -26,6 +22,10 @@ jobs:
           imx8 imx8x imx8m,
           # only tgl has IPC4 overlay file now
           -i IPC4 tgl,
+        ]
+        zephyr_revision: [
+          manifest_revision,
+          "https://github.com/zephyrproject-rtos/zephyr  main",
         ]
 
     steps:


### PR DESCRIPTION
No functional change, this is a pure re-ordering of the matrix
parameters to put the shorter ones first which helps see more in narrow
columns like when looking as build logs on github.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>