### PR TITLE
 probe: fix compiler warning on uninitialized data in probe_gen_format()

### DIFF
--- a/src/probe/probe.c
+++ b/src/probe/probe.c
@@ -671,6 +671,7 @@ static uint32_t probe_gen_format(uint32_t frame_fmt, uint32_t rate,
 		tr_err(&pr_tr, "probe_gen_format(): Invalid frame format specified = 0x%08x",
 		       frame_fmt);
 		assert(false);
+		return 0;
 	}
 
 	switch (rate) {


### PR DESCRIPTION

probe: fix compiler warning on uninitialized data in probe_gen_format()

Compiler emits a warning about possibly uninitialized use of valid_bytes
and container_bytes. Add an explicit return that covers this case.
The code has a "assert(false)" statement already, but this is not
sufficient and the compiler rightly warns about this.

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>