### PR TITLE
kconfig: remove undefined kconfig NUMBERS_GCD

### DIFF
--- a/src/drivers/intel/Kconfig
+++ b/src/drivers/intel/Kconfig
@@ -11,7 +11,6 @@ config INTEL_HDA
 config INTEL_MN
 	bool
 	depends on CAVS
-	select NUMBERS_GCD
 	default n
 	help
 	  Select this if the platform supports M/N dividers.
@@ -43,7 +42,6 @@ config INTEL_ALH
 config INTEL_DMIC
 	bool "Intel DMIC driver"
 	depends on CAVS
-	select NUMBERS_GCD
 	select NUMBERS_NORM
 	select NUMBERS_VECTOR_FIND
 	select MATH_DECIBELS

--- a/test/cmocka/CMakeLists.txt
+++ b/test/cmocka/CMakeLists.txt
@@ -109,7 +109,7 @@ function(cmocka_test test_name)
 	target_compile_definitions(${test_name} PRIVATE -D_UINTPTR_T_DEFINED)
 
 	# Enable features those would be disabled in some platforms
-	target_compile_definitions(${test_name} PRIVATE -DCONFIG_NUMBERS_GCD -DCONFIG_NUMBERS_NORM -DCONFIG_NUMBERS_VECTOR_FIND)
+	target_compile_definitions(${test_name} PRIVATE -DCONFIG_NUMBERS_NORM -DCONFIG_NUMBERS_VECTOR_FIND)
 
 	# Skip running alloc test on HOST until it's fixed (it passes and is run
 	# with xt-run)


### PR DESCRIPTION
NUMBERS_GCD was removed in commit 9611d126ba5. We should not be
selecting or buildign with an undefined Kconfig.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
