### PR TITLE
Topology1: Allow S24_4LE and S32_LE playback with PCM4

### DIFF
--- a/tools/topology/topology1/sof-apl-pcm512x.m4
+++ b/tools/topology/topology1/sof-apl-pcm512x.m4
@@ -123,10 +123,10 @@ DAI_ADD(sof/pipe-dai-capture.m4,
 	PIPELINE_SINK_6, 2, s24le,
 	1000, 0, 0, SSP_SCHEDULE_TIME_DOMAIN)
 
-# Media playback pipeline 5 on PCM 4 using max 2 channels of s16le.
+# Media playback pipeline 5 on PCM 4 using max 2 channels of s32le.
 # Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-pcm-media.m4,
-	5, 4, 2, s16le,
+	5, 4, 2, s32le,
 	1000, 0, 0,
 	8000, 96000, FSYNC,
 	SSP_SCHEDULE_TIME_DOMAIN,


### PR DESCRIPTION
This patch allows to test SRC with all 16/24/32 bit formats
in UP-squared device. Without this patch only 16 bit is
supported.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>