### PR TITLE
Audio: SRC: Cleanup traces in src_params()

### DIFF
--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -709,8 +709,8 @@ static int src_params(struct comp_dev *dev,
 	cd->sink_frames = dev->frames;
 
 	/* Allocate needed memory for delay lines */
-	comp_info(dev, "src_params(), source_rate = %u, sink_rate = %u",
-		  cd->source_rate, cd->sink_rate);
+	comp_info(dev, "src_params(), source_rate = %u, sink_rate = %u, format = %d",
+		  cd->source_rate, cd->sink_rate, source_c->stream.frame_fmt);
 	comp_info(dev, "src_params(), sourceb->channels = %u, sinkb->channels = %u, dev->frames = %u",
 		  source_c->stream.channels, sink_c->stream.channels, dev->frames);
 	err = src_buffer_lengths(&cd->param, cd->source_rate, cd->sink_rate,
@@ -719,9 +719,6 @@ static int src_params(struct comp_dev *dev,
 		comp_err(dev, "src_params(): src_buffer_lengths() failed");
 		goto out;
 	}
-
-	comp_info(dev, "src_params(), blk_in = %u, blk_out = %u",
-		  cd->param.blk_in, cd->param.blk_out);
 
 	delay_lines_size = sizeof(int32_t) * cd->param.total;
 	if (delay_lines_size == 0) {


### PR DESCRIPTION
The stream format info is useful for debugging SRC issues so it
is added to comp_info() trace print.

The blk_in and blk_out are at this code location always zeros so
the comp_info() to trace them is unnecessary.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>