### PR TITLE
[RFC]: Add support for drain operation

### DIFF
--- a/src/include/ipc/stream.h
+++ b/src/include/ipc/stream.h
@@ -158,4 +158,9 @@ struct sof_ipc_stream_posn {
 	int32_t xrun_size;	/**< XRUN size in bytes */
 } __attribute__((packed, aligned(4)));
 
+/* drain information */
+struct sof_ipc_stream_drain {
+	struct sof_ipc_reply rhdr;
+} __attribute__((packed, aligned(4)));
+
 #endif /* __IPC_STREAM_H__ */

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -65,6 +65,7 @@ struct timestamp_data;
 #define COMP_STATE_PAUSED	4	/**< Component paused */
 #define COMP_STATE_ACTIVE	5	/**< Component active */
 #define COMP_STATE_PRE_ACTIVE	6	/**< Component after early initialisation */
+#define COMP_STATE_DRAINING	7	/**< Component draining */
 /** @}*/
 
 /** \name Standard Component Stream Commands
@@ -91,6 +92,7 @@ enum {
 	COMP_TRIGGER_POST_STOP,		/**< Finalize stop component stream */
 	COMP_TRIGGER_POST_PAUSE,	/**< Finalize pause component stream */
 	COMP_TRIGGER_NO_ACTION,		/**< No action required */
+	COMP_TRIGGER_DRAIN,		/**< Start drain operation */
 };
 /** @}*/
 

--- a/src/include/sof/ipc/common.h
+++ b/src/include/sof/ipc/common.h
@@ -197,4 +197,9 @@ void ipc_msg_reply(struct sof_ipc_reply *reply);
  */
 void ipc_complete_cmd(struct ipc *ipc);
 
+/**
+ * \brief Notify host that the drain operation is done.
+ */
+int ipc_stream_drain_notify(void);
+
 #endif /* __SOF_DRIVERS_IPC_H__ */

--- a/src/ipc/ipc3/handler.c
+++ b/src/ipc/ipc3/handler.c
@@ -506,6 +506,9 @@ static int ipc_stream_trigger(uint32_t header)
 	case SOF_IPC_STREAM_TRIG_RELEASE:
 		cmd = COMP_TRIGGER_PRE_RELEASE;
 		break;
+	case SOF_IPC_STREAM_TRIG_DRAIN:
+		cmd = COMP_TRIGGER_DRAIN;
+		break;
 	/* XRUN is special case- TODO */
 	case SOF_IPC_STREAM_TRIG_XRUN:
 		return 0;


### PR DESCRIPTION
Associated kernel PR: https://github.com/thesofproject/linux/pull/3808

This, like the kernel PR, is a rough attempt of implementing support for the drain operation.

Notes:

- because of the fact that the FW expects to receive a TRIG_STOP before receiving a PCM_FREE an error message will be printed before changing the state from ACTIVE to READY: ` comp_set_state(): wrong state = 5, COMP_TRIGGER_RESET`. I was wondering why the transition from ACTIVE to READY is somewhat treated like an error? (somewhat because it prints an error message but it still changes the state)