### PR TITLE
[RFC] ipc: find components on other cores too

### DIFF
--- a/src/ipc/ipc-common.c
+++ b/src/ipc/ipc-common.c
@@ -138,9 +138,6 @@ struct ipc_comp_dev *ipc_get_ppl_comp(struct ipc *ipc, uint32_t pipeline_id, int
 		if (icd->type != COMP_TYPE_COMPONENT)
 			continue;
 
-		if (!cpu_is_me(icd->core))
-			continue;
-
 		/* first try to find the module in the pipeline */
 		if (dev_comp_pipe_id(icd->cd) == pipeline_id) {
 			struct list_item *buffer_list = comp_buffer_list(icd->cd, dir);


### PR DESCRIPTION
No reason for ipc_get_ppl_comp() to only look for components on the same core as where it is running, same pipeline components can run on different cores too.

With this I was able to modify a playback pipeline with a PGA as its sink, connecting to a mixer in another pipeline, to run that PGA on a different core.