### PR TITLE
[SKIP CI] .github: add rmb to gcc build only platform

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -160,7 +160,7 @@ jobs:
         # does not block all other builds.
         platform: [imx8ulp,
                    sue jsl tgl,
-                   rn,
+                   rn rmb,
                    mt8186 mt8195,
         ]
 


### PR DESCRIPTION
SOF Docker image supports AMD/Rembrandt gcc toolchain from tag 20220809,
which is latest as of now.

Signed-off-by: Fred Oh <fred.oh@linux.intel.com>