### PR TITLE
codec_adapter: correct the way to get the scheduling period

### DIFF
--- a/src/audio/codec_adapter/codec/waves.c
+++ b/src/audio/codec_adapter/codec/waves.c
@@ -330,9 +330,12 @@ static int waves_effect_init(struct comp_dev *dev)
 	waves_codec->o_format = waves_codec->i_format;
 
 	waves_codec->sample_size_in_bytes = sample_bytes;
-	waves_codec->buffer_bytes = component->period_bytes;
-	waves_codec->buffer_samples = waves_codec->buffer_bytes / src_fmt->channels /
-		waves_codec->sample_size_in_bytes;
+	/* Prepare a buffer for 1 period worth of data
+	 * dev->pipeline->period stands for the scheduling period in us
+	 */
+	waves_codec->buffer_samples = src_fmt->rate * dev->pipeline->period / 1000000;
+	waves_codec->buffer_bytes = waves_codec->buffer_samples * src_fmt->channels *
+	        waves_codec->sample_size_in_bytes;
 
 	// trace allows printing only up-to 4 words at a time
 	// logging all the information in two calls


### PR DESCRIPTION
Scheduling period should be acquired from dev->pipeline->period

Signed-off-by: CY Kuei <cyk@waves.com>