### PR TITLE
Mixin: fix binding

### DIFF
--- a/src/audio/mixin_mixout.c
+++ b/src/audio/mixin_mixout.c
@@ -557,6 +557,7 @@ static int mixin_copy(struct comp_dev *dev)
 	if (source_avail_bytes > 0) {
 		bytes_to_copy = MIN(source_avail_bytes, sinks_free_bytes);
 		bytes_to_consume_from_source_buf = bytes_to_copy;
+		buffer_stream_invalidate(source_c, bytes_to_copy);
 	} else {
 		/* if source does not produce any data -- do NOT stop mixing but generate
 		 * silence as that source output.
@@ -566,9 +567,6 @@ static int mixin_copy(struct comp_dev *dev)
 		bytes_to_copy = MIN(audio_stream_period_bytes(&source_c->stream, dev->frames),
 				    sinks_free_bytes);
 	}
-
-	if (source_avail_bytes > 0)
-		buffer_stream_invalidate(source_c, bytes_to_copy);
 
 	/* iterate over all connected mixouts and mix source data into each mixout sink buffer */
 	list_for_item(blist, &dev->bsink_list) {

--- a/src/audio/mixin_mixout.c
+++ b/src/audio/mixin_mixout.c
@@ -478,7 +478,7 @@ static void silence(struct audio_stream __sparse_cache *stream, uint32_t start,
 
 /* Most of the mixing is done here on mixin side. mixin mixes its source data
  * into each connected mixout sink buffer. Basically, if mixout sink buffer has
- * no data, mixin copies its source data into mixin sink buffer. If moxout sink
+ * no data, mixin copies its source data into mixout sink buffer. If moxout sink
  * buffer has some data (written there by other mixin), mixin reads mixout sink
  * buffer data, mixes it with its source data and writes back to mixout sink
  * buffer. So after all mixin mixin_copy() calls, mixout sink buffer contains
@@ -1004,11 +1004,12 @@ static int mixout_bind(struct comp_dev *dev, void *data)
 	md = comp_get_drvdata(dev);
 	mixed_data_info = mixed_data_info_acquire(md->mixed_data_info);
 
-	/* mixout -> new sink */
-	if (dev->ipc_config.id == src_id) {
-		mixed_data_info->mixed_bytes = 0;
-		memset(mixed_data_info->source_info, 0, sizeof(mixed_data_info->source_info));
-	} else { /* new mixin -> mixout */
+	/*
+	 * If dev->ipc_config.id == src_id then we're called for the downstream
+	 * link, nothing to do
+	 */
+	if (dev->ipc_config.id != src_id) {
+		/* new mixin -> mixout */
 		struct comp_dev *mixin;
 		struct mixout_source_info *source_info;
 
@@ -1057,7 +1058,6 @@ static int mixout_unbind(struct comp_dev *dev, void *data)
 
 	/* mixout -> new sink */
 	if (dev->ipc_config.id == src_id) {
-		/* not really necessary as same is done in mixout_bind() */
 		mixed_data_info->mixed_bytes = 0;
 		memset(mixed_data_info->source_info, 0, sizeof(mixed_data_info->source_info));
 	} else { /* new mixin -> mixout */


### PR DESCRIPTION
.bind() is called twice, in the order this is currently done in SOF, the second call overwrites with 0 the valid configuration from the first call. Remove that overwrite.