### PR TITLE
zephyr: macros: Avoid macros redefinition

### DIFF
--- a/src/include/sof/bit.h
+++ b/src/include/sof/bit.h
@@ -8,10 +8,9 @@
 #ifndef __SOF_BIT_H__
 #define __SOF_BIT_H__
 
-/* Zephyr defines this - remove local copy once Zephyr integration complete */
-#ifdef BIT
-#undef BIT
-#endif
+#ifdef __ZEPHYR__
+#include <zephyr/sys/util_macro.h>
+#else
 
 #if ASSEMBLY
 #define BIT(b)			(1 << (b))
@@ -19,14 +18,18 @@
 #define BIT(b)			(1UL << (b))
 #endif
 
-#define MASK(b_hi, b_lo)	\
-	(((1ULL << ((b_hi) - (b_lo) + 1ULL)) - 1ULL) << (b_lo))
-#define SET_BIT(b, x)		(((x) & 1) << (b))
 #define SET_BITS(b_hi, b_lo, x)	\
 	(((x) & ((1ULL << ((b_hi) - (b_lo) + 1ULL)) - 1ULL)) << (b_lo))
 #define GET_BIT(b, x) \
 	(((x) & (1ULL << (b))) >> (b))
+
+#endif	/* __ZEPHYR__ */
+
 #define GET_BITS(b_hi, b_lo, x) \
 	(((x) & MASK(b_hi, b_lo)) >> (b_lo))
+
+#define MASK(b_hi, b_lo)	\
+	(((1ULL << ((b_hi) - (b_lo) + 1ULL)) - 1ULL) << (b_lo))
+#define SET_BIT(b, x)		(((x) & 1) << (b))
 
 #endif /* __SOF_BIT_H__ */


### PR DESCRIPTION
Some macros defined in SoF are also being defined in Zephyr.
Just avoiding redefinition un-defining these macros.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>