### PR TITLE
Add new topologies for PCM capture/playback using compress API

### DIFF
--- a/tools/topology/topology1/development/CMakeLists.txt
+++ b/tools/topology/topology1/development/CMakeLists.txt
@@ -31,6 +31,7 @@ set(TPLGS
 	"sof-imx8-compr-pcm-cap-wm8960\;sof-imx8-compr-pcm-cap-wm8960"
 	"sof-imx8mp-compr-aac-wm8960\;sof-imx8mp-compr-aac-wm8960"
 	"sof-imx8mp-compr-mp3-wm8960\;sof-imx8mp-compr-mp3-wm8960"
+	"sof-imx8mp-compr-pcm-wm8960\;sof-imx8mp-compr-pcm-wm8960"
 	"sof-apl-nocodec-demux-eq-4ch4ch\;sof-apl-nocodec-demux-eq-4ch4ch"
 	"sof-apl-nocodec-demux-eq-2ch4ch\;sof-apl-nocodec-demux-eq-2ch4ch"
 

--- a/tools/topology/topology1/development/CMakeLists.txt
+++ b/tools/topology/topology1/development/CMakeLists.txt
@@ -27,6 +27,7 @@ set(TPLGS
 	"sof-imx8-src-cs42888\;sof-imx8-src-cs42888"
 	"sof-imx8-compr-aac-wm8960\;sof-imx8-compr-aac-wm8960"
 	"sof-imx8-compr-mp3-wm8960\;sof-imx8-compr-mp3-wm8960"
+	"sof-imx8-compr-pcm-wm8960\;sof-imx8-compr-pcm-wm8960"
 	"sof-imx8mp-compr-aac-wm8960\;sof-imx8mp-compr-aac-wm8960"
 	"sof-imx8mp-compr-mp3-wm8960\;sof-imx8mp-compr-mp3-wm8960"
 	"sof-apl-nocodec-demux-eq-4ch4ch\;sof-apl-nocodec-demux-eq-4ch4ch"

--- a/tools/topology/topology1/development/CMakeLists.txt
+++ b/tools/topology/topology1/development/CMakeLists.txt
@@ -32,6 +32,7 @@ set(TPLGS
 	"sof-imx8mp-compr-aac-wm8960\;sof-imx8mp-compr-aac-wm8960"
 	"sof-imx8mp-compr-mp3-wm8960\;sof-imx8mp-compr-mp3-wm8960"
 	"sof-imx8mp-compr-pcm-wm8960\;sof-imx8mp-compr-pcm-wm8960"
+	"sof-imx8mp-compr-pcm-cap-wm8960\;sof-imx8mp-compr-pcm-cap-wm8960"
 	"sof-apl-nocodec-demux-eq-4ch4ch\;sof-apl-nocodec-demux-eq-4ch4ch"
 	"sof-apl-nocodec-demux-eq-2ch4ch\;sof-apl-nocodec-demux-eq-2ch4ch"
 

--- a/tools/topology/topology1/development/CMakeLists.txt
+++ b/tools/topology/topology1/development/CMakeLists.txt
@@ -28,6 +28,7 @@ set(TPLGS
 	"sof-imx8-compr-aac-wm8960\;sof-imx8-compr-aac-wm8960"
 	"sof-imx8-compr-mp3-wm8960\;sof-imx8-compr-mp3-wm8960"
 	"sof-imx8-compr-pcm-wm8960\;sof-imx8-compr-pcm-wm8960"
+	"sof-imx8-compr-pcm-cap-wm8960\;sof-imx8-compr-pcm-cap-wm8960"
 	"sof-imx8mp-compr-aac-wm8960\;sof-imx8mp-compr-aac-wm8960"
 	"sof-imx8mp-compr-mp3-wm8960\;sof-imx8mp-compr-mp3-wm8960"
 	"sof-apl-nocodec-demux-eq-4ch4ch\;sof-apl-nocodec-demux-eq-4ch4ch"

--- a/tools/topology/topology1/development/sof-imx8-compr-pcm-cap-wm8960.m4
+++ b/tools/topology/topology1/development/sof-imx8-compr-pcm-cap-wm8960.m4
@@ -1,0 +1,90 @@
+#
+# Topology with codec_adapter processing component for i.MX8QM/i.MX8QXP
+#
+
+# Include topology builder
+include(`utils.m4')
+include(`dai.m4')
+include(`pipeline.m4')
+include(`sai.m4')
+include(`pcm.m4')
+include(`buffer.m4')
+
+# Include TLV library
+include(`common/tlv.m4')
+
+# Include Token library
+include(`sof/tokens.m4')
+
+# Include DSP configuration
+include(`platform/imx/imx8.m4')
+
+
+# Post process setup config
+
+ #codec Post Process setup config
+#
+# Define the pipelines
+#
+# PCM0 <---- volume <----- SAI3 (wm8960)
+#
+
+DECLARE_SOF_RT_UUID("passthrough_codec", passthrough_uuid, 0x376b5e44, 0x9c82,
+		0x4ec2, 0xbc, 0x83, 0x10, 0xea, 0x10, 0x1a, 0xf8, 0x8f);
+
+define(`CA_UUID', passthrough_uuid)
+
+# Post process setup config for playback
+define(`CA_SETUP_CONTROLBYTES',
+``	bytes "0x53,0x4f,0x46,0x00,0x00,0x00,0x00,0x00,'
+`	0x00,0x00,0x00,0x00,0x00,0x10,0x00,0x03,'
+`	0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,'
+`	0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00"''
+)
+
+define(`CA_SETUP_CONTROLBYTES_MAX', 300)
+
+undefine(`DAI_PERIODS')
+define(`DAI_PERIODS', 2)
+
+dnl PIPELINE_PCM_ADD(pipeline,
+dnl     pipe id, pcm, max channels, format,
+dnl     period, priority, core,
+dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
+dnl     time_domain, sched_comp)
+
+# Low Latency capture pipeline 1 on PCM 0 using max 2 channels of s32le.
+# Set 1000us deadline with priority 0 on core 0
+PIPELINE_PCM_ADD(sof/pipe-codec-adapter-capture.m4,
+	1, 0, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+#
+# DAIs configuration
+#
+
+dnl DAI_ADD(pipeline,
+dnl     pipe id, dai type, dai_index, dai_be,
+dnl     buffer, periods, format,
+dnl     period, priority, core, time_domain)
+
+# capture DAI is SAI3 using 2 periods
+# Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-capture.m4,
+	1, SAI, 1, sai1-wm8960-hifi,
+	PIPELINE_SINK_1, 2, s32le,
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_DMA)
+
+# PCM Low Latency, id 0
+
+dnl COMPR_CAPTURE_ADD(name, pcm_id, capture)
+COMPR_CAPTURE_ADD(Port0, 0, PIPELINE_PCM_1)
+
+dnl DAI_CONFIG(type, idx, link_id, name, sai_config)
+DAI_CONFIG(SAI, 1, 0, sai1-wm8960-hifi,
+	SAI_CONFIG(I2S, SAI_CLOCK(mclk, 12288000, codec_mclk_in),
+		SAI_CLOCK(bclk, 3072000, codec_master),
+		SAI_CLOCK(fsync, 48000, codec_master),
+		SAI_TDM(2, 32, 3, 3),
+		SAI_CONFIG_DATA(SAI, 1, 0)))

--- a/tools/topology/topology1/development/sof-imx8-compr-pcm-wm8960.m4
+++ b/tools/topology/topology1/development/sof-imx8-compr-pcm-wm8960.m4
@@ -1,0 +1,90 @@
+#
+# Topology with codec_adapter processing component for i.MX8QM/i.MX8QXP
+#
+
+# Include topology builder
+include(`utils.m4')
+include(`dai.m4')
+include(`pipeline.m4')
+include(`sai.m4')
+include(`pcm.m4')
+include(`buffer.m4')
+
+# Include TLV library
+include(`common/tlv.m4')
+
+# Include Token library
+include(`sof/tokens.m4')
+
+# Include DSP configuration
+include(`platform/imx/imx8.m4')
+
+
+# Post process setup config
+
+ #codec Post Process setup config
+#
+# Define the pipelines
+#
+# PCM0 ----> volume -----> SAI3 (wm8960)
+#
+
+DECLARE_SOF_RT_UUID("passthrough_codec", passthrough_uuid, 0x376b5e44, 0x9c82,
+		0x4ec2, 0xbc, 0x83, 0x10, 0xea, 0x10, 0x1a, 0xf8, 0x8f);
+
+define(`CA_UUID', passthrough_uuid)
+
+# Post process setup config for playback
+define(`CA_SETUP_CONTROLBYTES',
+``	bytes "0x53,0x4f,0x46,0x00,0x00,0x00,0x00,0x00,'
+`	0x00,0x00,0x00,0x00,0x00,0x10,0x00,0x03,'
+`	0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,'
+`	0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00"''
+)
+
+define(`CA_SETUP_CONTROLBYTES_MAX', 300)
+
+undefine(`DAI_PERIODS')
+define(`DAI_PERIODS', 2)
+
+dnl PIPELINE_PCM_ADD(pipeline,
+dnl     pipe id, pcm, max channels, format,
+dnl     period, priority, core,
+dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
+dnl     time_domain, sched_comp)
+
+# Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
+# Set 1000us deadline with priority 0 on core 0
+PIPELINE_PCM_ADD(sof/pipe-codec-adapter-playback.m4,
+	1, 0, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+#
+# DAIs configuration
+#
+
+dnl DAI_ADD(pipeline,
+dnl     pipe id, dai type, dai_index, dai_be,
+dnl     buffer, periods, format,
+dnl     period, priority, core, time_domain)
+
+# playback DAI is SAI3 using 2 periods
+# Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+	1, SAI, 1, sai1-wm8960-hifi,
+	PIPELINE_SOURCE_1, 2, s32le,
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_DMA)
+
+# PCM Low Latency, id 0
+
+dnl COMPR_PLAYBACK_ADD(name, pcm_id, playback)
+COMPR_PLAYBACK_ADD(Port0, 0, PIPELINE_PCM_1)
+
+dnl DAI_CONFIG(type, idx, link_id, name, sai_config)
+DAI_CONFIG(SAI, 1, 0, sai1-wm8960-hifi,
+	SAI_CONFIG(I2S, SAI_CLOCK(mclk, 12288000, codec_mclk_in),
+		SAI_CLOCK(bclk, 3072000, codec_master),
+		SAI_CLOCK(fsync, 48000, codec_master),
+		SAI_TDM(2, 32, 3, 3),
+		SAI_CONFIG_DATA(SAI, 1, 0)))

--- a/tools/topology/topology1/development/sof-imx8mp-compr-pcm-cap-wm8960.m4
+++ b/tools/topology/topology1/development/sof-imx8mp-compr-pcm-cap-wm8960.m4
@@ -1,0 +1,91 @@
+#
+# Topology with codec_adapter processing component for i.MX8MP
+#
+
+# Include topology builder
+include(`utils.m4')
+include(`dai.m4')
+include(`pipeline.m4')
+include(`sai.m4')
+include(`pcm.m4')
+include(`buffer.m4')
+
+# Include TLV library
+include(`common/tlv.m4')
+
+# Include Token library
+include(`sof/tokens.m4')
+
+# Include DSP configuration
+include(`platform/imx/imx8.m4')
+
+
+# Post process setup config
+
+ #codec Post Process setup config
+#
+# Define the pipelines
+#
+# PCM0 <---- volume <----- SAI3 (wm8960)
+#
+
+DECLARE_SOF_RT_UUID("passthrough_codec", passthrough_uuid, 0x376b5e44, 0x9c82, 0x4ec2,
+		0xbc, 0x83, 0x10, 0xea, 0x10, 0x1a, 0xf8, 0x8f);
+
+define(`CA_UUID', passthrough_uuid)
+
+# Post process setup config
+define(`CA_SETUP_CONTROLBYTES',
+``	bytes "0x53,0x4f,0x46,0x00,0x00,0x00,0x00,0x00,'
+`	0x00,0x00,0x00,0x00,0x00,0x10,0x00,0x03,'
+`	0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,'
+`	0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00"''
+)
+
+define(`CA_SETUP_CONTROLBYTES_MAX', 300)
+
+undefine(`DAI_PERIODS')
+define(`DAI_PERIODS', 2)
+
+dnl PIPELINE_PCM_ADD(pipeline,
+dnl     pipe id, pcm, max channels, format,
+dnl     period, priority, core,
+dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
+dnl     time_domain, sched_comp)
+
+# Low Latency capture pipeline 1 on PCM 0 using max 2 channels of s32le.
+# Set 1000us deadline with priority 0 on core 0
+PIPELINE_PCM_ADD(sof/pipe-codec-adapter-capture.m4,
+	1, 0, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+#
+# DAIs configuration
+#
+
+dnl DAI_ADD(pipeline,
+dnl     pipe id, dai type, dai_index, dai_be,
+dnl     buffer, periods, format,
+dnl     period, priority, core, time_domain)
+
+# capture DAI is SAI3 using 2 periods
+# Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-capture.m4,
+	1, SAI, 3, sai3-wm8960-hifi,
+	PIPELINE_SOURCE_1, 2, s32le,
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_DMA)
+
+
+# PCM Low Latency, id 0
+
+dnl COMPR_CAPTURE_ADD(name, pcm_id, capture)
+COMPR_CAPTURE_ADD(Port0, 0, PIPELINE_PCM_1)
+
+dnl DAI_CONFIG(type, idx, link_id, name, sai_config)
+DAI_CONFIG(SAI, 3, 0, sai3-wm8960-hifi,
+	SAI_CONFIG(I2S, SAI_CLOCK(mclk, 12288000, codec_mclk_in),
+		SAI_CLOCK(bclk, 3072000, codec_master),
+		SAI_CLOCK(fsync, 48000, codec_master),
+		SAI_TDM(2, 32, 3, 3),
+		SAI_CONFIG_DATA(SAI, 3, 0)))

--- a/tools/topology/topology1/development/sof-imx8mp-compr-pcm-wm8960.m4
+++ b/tools/topology/topology1/development/sof-imx8mp-compr-pcm-wm8960.m4
@@ -1,0 +1,91 @@
+#
+# Topology with codec_adapter processing component for i.MX8MP
+#
+
+# Include topology builder
+include(`utils.m4')
+include(`dai.m4')
+include(`pipeline.m4')
+include(`sai.m4')
+include(`pcm.m4')
+include(`buffer.m4')
+
+# Include TLV library
+include(`common/tlv.m4')
+
+# Include Token library
+include(`sof/tokens.m4')
+
+# Include DSP configuration
+include(`platform/imx/imx8.m4')
+
+
+# Post process setup config
+
+ #codec Post Process setup config
+#
+# Define the pipelines
+#
+# PCM0 ----> volume -----> SAI3 (wm8960)
+#
+
+DECLARE_SOF_RT_UUID("passthrough_codec", passthrough_uuid, 0x376b5e44, 0x9c82, 0x4ec2,
+		0xbc, 0x83, 0x10, 0xea, 0x10, 0x1a, 0xf8, 0x8f);
+
+define(`CA_UUID', passthrough_uuid)
+
+# Post process setup config
+define(`CA_SETUP_CONTROLBYTES',
+``	bytes "0x53,0x4f,0x46,0x00,0x00,0x00,0x00,0x00,'
+`	0x00,0x00,0x00,0x00,0x00,0x10,0x00,0x03,'
+`	0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,'
+`	0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00"''
+)
+
+define(`CA_SETUP_CONTROLBYTES_MAX', 300)
+
+undefine(`DAI_PERIODS')
+define(`DAI_PERIODS', 2)
+
+dnl PIPELINE_PCM_ADD(pipeline,
+dnl     pipe id, pcm, max channels, format,
+dnl     period, priority, core,
+dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
+dnl     time_domain, sched_comp)
+
+# Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
+# Set 1000us deadline with priority 0 on core 0
+PIPELINE_PCM_ADD(sof/pipe-codec-adapter-playback.m4,
+	1, 0, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+#
+# DAIs configuration
+#
+
+dnl DAI_ADD(pipeline,
+dnl     pipe id, dai type, dai_index, dai_be,
+dnl     buffer, periods, format,
+dnl     period, priority, core, time_domain)
+
+# playback DAI is SAI3 using 2 periods
+# Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+	1, SAI, 3, sai3-wm8960-hifi,
+	PIPELINE_SOURCE_1, 2, s32le,
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_DMA)
+
+
+# PCM Low Latency, id 0
+
+dnl COMPR_PLAYBACK_ADD(name, pcm_id, playback)
+COMPR_PLAYBACK_ADD(Port0, 0, PIPELINE_PCM_1)
+
+dnl DAI_CONFIG(type, idx, link_id, name, sai_config)
+DAI_CONFIG(SAI, 3, 0, sai3-wm8960-hifi,
+	SAI_CONFIG(I2S, SAI_CLOCK(mclk, 12288000, codec_mclk_in),
+		SAI_CLOCK(bclk, 3072000, codec_master),
+		SAI_CLOCK(fsync, 48000, codec_master),
+		SAI_TDM(2, 32, 3, 3),
+		SAI_CONFIG_DATA(SAI, 3, 0)))

--- a/tools/topology/topology1/m4/pcm.m4
+++ b/tools/topology/topology1/m4/pcm.m4
@@ -171,6 +171,13 @@ PCM_CAPTURE_ADD_COMMON($1, $2, $3, 0, false),
 `fatal_error(`Invalid parameters ($#) to PCM_CAPTURE_ADD')')'
 )
 
+dnl COMPR_CAPTURE_ADD(name, pcm_id, capture)
+define(`COMPR_CAPTURE_ADD',
+`ifelse(`$#', `3',
+PCM_CAPTURE_ADD_COMMON($1, $2, $3, 0, true),
+`fatal_error(`Invalid parameters ($#) to COMPR_CAPTURE_ADD')')'
+)
+
 dnl PCM_CAPTURE_LP_ADD(name, pcm_id, capture)
 define(`PCM_CAPTURE_LP_ADD',
 `ifelse(`$#', `3',

--- a/tools/topology/topology1/m4/pcm.m4
+++ b/tools/topology/topology1/m4/pcm.m4
@@ -128,7 +128,7 @@ define(`PCM_PLAYBACK_ADD_COMMON',
 `}', `fatal_error(`Invalid parameters ($#) to PCM_PLAYBACK_ADD_COMMON')')'
 )
 
-dnl PCM_CAPTURE_ADD_COMMON(name, pcm_id, capture, lp)
+dnl PCM_CAPTURE_ADD_COMMON(name, pcm_id, capture, lp, compress)
 define(`PCM_CAPTURE_ADD_COMMON',
 `ifelse(`$4', `1',
 `SectionVendorTuples."$1_tuples_w" {'
@@ -155,6 +155,8 @@ define(`PCM_CAPTURE_ADD_COMMON',
 `'
 `		capabilities STR($3)'
 `	}'
+`'
+`	compress STR($5)'
 `ifelse(`$4', `1',
 `       data ['
 `               "$1_data_w"'
@@ -165,14 +167,14 @@ define(`PCM_CAPTURE_ADD_COMMON',
 dnl PCM_CAPTURE_ADD(name, pcm_id, capture)
 define(`PCM_CAPTURE_ADD',
 `ifelse(`$#', `3',
-PCM_CAPTURE_ADD_COMMON($1, $2, $3, 0),
+PCM_CAPTURE_ADD_COMMON($1, $2, $3, 0, false),
 `fatal_error(`Invalid parameters ($#) to PCM_CAPTURE_ADD')')'
 )
 
 dnl PCM_CAPTURE_LP_ADD(name, pcm_id, capture)
 define(`PCM_CAPTURE_LP_ADD',
 `ifelse(`$#', `3',
-PCM_CAPTURE_ADD_COMMON($1, $2, $3, 1),
+PCM_CAPTURE_ADD_COMMON($1, $2, $3, 1, false),
 `fatal_error(`Invalid parameters ($#) to PCM_CAPTURE_LP_ADD')')'
 )
 


### PR DESCRIPTION
The purpose of this series of patches is to introduce new topologies that make use of the compress API in order to play/capture using the PCM format. This is mostly used to test the compress API.