### PR TITLE
Disable some invalid doxygen

### DIFF
--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -157,7 +157,7 @@ static void kpb_lock_init(struct comp_data *kpb)
 
 #endif /* __ZEPHYR__ */
 
-/**
+/*
  * \brief Create a key phrase buffer component.
  * \param[in] config - generic ipc component pointer.
  *

--- a/src/audio/module_adapter/module/generic.c
+++ b/src/audio/module_adapter/module/generic.c
@@ -325,7 +325,7 @@ int module_free(struct processing_module *mod)
 	return ret;
 }
 
-/**
+/*
  * \brief Set module configuration - Common method to assemble large configuration message
  * \param[in] mod - struct processing_module pointer
  * \param[in] config_id - Configuration ID

--- a/src/audio/module_adapter/module/iadk_modules.c
+++ b/src/audio/module_adapter/module/iadk_modules.c
@@ -140,7 +140,7 @@ static int iadk_modules_init_process(struct processing_module *mod)
 	return 0;
 }
 
-/**
+/*
  * \brief iadk_modules_process.
  * \param[in] mod - processing module pointer.
  *
@@ -202,7 +202,7 @@ static int iadk_modules_free(struct processing_module *mod)
 	return ret;
 }
 
-/**
+/*
  * \brief iadk_modules_set_configuration - Common method to assemble large configuration message
  * \param[in] mod - struct processing_module pointer
  * \param[in] config_id - Configuration ID
@@ -228,7 +228,7 @@ static int iadk_modules_set_configuration(struct processing_module *mod, uint32_
 					      response, response_size);
 }
 
-/**
+/*
  * \brief iadk_modules_get_configuration - Common method to retrieve module configuration
  * \param[in] mod - struct processing_module pointer
  * \param[in] config_id - Configuration ID

--- a/src/audio/module_adapter/module/volume/volume.c
+++ b/src/audio/module_adapter/module/volume/volume.c
@@ -1064,7 +1064,7 @@ static void volume_update_current_vol_ipc4(struct vol_data *cd)
 #endif
 }
 
-/**
+/*
  * \brief Copies and processes stream data.
  * \param[in,out] mod Volume processing module handle
 
@@ -1111,7 +1111,7 @@ static int volume_process(struct processing_module *mod,
 	return 0;
 }
 
-/**
+/*
  * \brief Retrieves volume zero crossing function.
  * \param[in,out] dev Volume base component device.
  */

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -23,7 +23,7 @@
 
 LOG_MODULE_REGISTER(module_adapter, CONFIG_SOF_LOG_LEVEL);
 
-/**
+/*
  * \brief Create a module adapter component.
  * \param[in] drv - component driver pointer.
  * \param[in] config - component ipc descriptor pointer.
@@ -380,7 +380,7 @@ int module_adapter_params(struct comp_dev *dev, struct sof_ipc_stream_params *pa
 	return 0;
 }
 
-/**
+/*
  * Function to copy from source buffer to the module buffer
  * @source: source audio buffer stream
  * @buff: pointer to the module input buffer
@@ -407,7 +407,7 @@ ca_copy_from_source_to_module(const struct audio_stream __sparse_cache *source,
 					 MIN(buff_size, tail_size));
 }
 
-/**
+/*
  * Function to copy processed samples from the module buffer to sink buffer
  * @sink: sink audio buffer stream
  * @buff: pointer to the module output buffer

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -898,11 +898,14 @@ static inline int comp_get_state(struct comp_dev *req_dev, struct comp_dev *dev)
 }
 
 /**
+ * Warning: duplicate declaration in topology.h
+ *
  * Called by component in  params() function in order to set and update some of
  * downstream (playback) or upstream (capture) buffer parameters with pcm
  * parameters. There is a possibility to specify which of parameters won't be
  * overwritten (e.g. SRC component should not overwrite rate parameter, because
  * it is able to change it).
+ *
  * @param dev Component device
  * @param flag Specifies which parameter should not be updated
  * @param params pcm params

--- a/src/include/sof/ipc/topology.h
+++ b/src/include/sof/ipc/topology.h
@@ -199,12 +199,8 @@ int32_t ipc_comp_pipe_id(const struct ipc_comp_dev *icd);
 int ipc_comp_dai_config(struct ipc *ipc, struct ipc_config_dai *common_config,
 			void *spec_config);
 
-/**
- * \brief verify component params
- * @param dev Component dev
- * @param flag Component setting flag
- * @param params Ipc params
- * @return verify status
+/*
+ * Warning: duplicate declaration in component.h
  */
 int comp_verify_params(struct comp_dev *dev, uint32_t flag,
 		       struct sof_ipc_stream_params *params);

--- a/src/platform/imx8ulp/include/platform/lib/cpu.h
+++ b/src/platform/imx8ulp/include/platform/lib/cpu.h
@@ -5,7 +5,7 @@
  * Author: Peng Zhang <peng.zhang_8@nxp.com>
  */
 
-/**
+/*
  * \file platform/lib/cpu.h
  * \brief DSP core parameters.
  */


### PR DESCRIPTION
2 commits, main one:

Disable some invalid doxygen comment blocks

Simply replace `/**` with `/*`. This can be very easily reverted if
someone ever fixes the corresponding comment.

We don't build doxygen for .C files in continuous integration, only for
.H files. We don't build doxygen for .C files in continuous integration
because there are way too many errors and no one has time to fix
them. Because we never build doxygen for .C files, people keep adding
untested and invalid doxygen comments or they change the code while
leaving the doxygen out of sync.

I build doxygen for .C files locally. The call graphs are especially
useful (they don't need doxygen comments). I have local hacks to filter
out the most common doxygen errors. The broken doxygen comments disabled
by this commit escaped my local filters.