### PR TITLE
ipc4: remove report dsp properties to host driver

### DIFF
--- a/src/audio/base_fw.c
+++ b/src/audio/base_fw.c
@@ -222,42 +222,6 @@ static int basefw_mem_state_info(uint32_t *data_offset, char *data)
 	return 0;
 }
 
-static int basefw_get_dsp_properties(uint32_t *data_offset, char *data)
-{
-	struct ipc4_tuple *tuple = (struct ipc4_tuple *)data;
-	uint16_t fw_version[4] = {SOF_MAJOR, SOF_MINOR, SOF_MICRO, SOF_BUILD};
-	uint32_t value;
-
-	set_tuple(tuple, IPC4_FW_VERSION, sizeof(fw_version), fw_version);
-
-	tuple = next_tuple(tuple);
-	set_tuple_uint32(tuple, IPC4_DSP_CORES, CONFIG_CORE_COUNT);
-
-	tuple = next_tuple(tuple);
-	set_tuple_uint32(tuple, IPC4_MEM_PAGE_SIZE, HOST_PAGE_SIZE);
-
-	tuple = next_tuple(tuple);
-	value = DIV_ROUND_UP(EBB_BANKS_IN_SEGMENT * SRAM_BANK_SIZE, HOST_PAGE_SIZE);
-	set_tuple_uint32(tuple, IPC4_TOTAL_PHYS_MEM_PAGES, value);
-
-	tuple = next_tuple(tuple);
-	set_tuple_uint32(tuple, IPC4_DL_MAILBOX_SIZE, MAILBOX_HOSTBOX_SIZE);
-
-	tuple = next_tuple(tuple);
-	set_tuple_uint32(tuple, IPC4_UL_MAILBOX_SIZE, MAILBOX_DSPBOX_SIZE);
-
-	tuple = next_tuple(tuple);
-	set_tuple_uint32(tuple, IPC4_TRACE_LOG_SIZE, DMA_TRACE_LOCAL_SIZE);
-
-	tuple = next_tuple(tuple);
-	set_tuple_uint32(tuple, IPC4_MAX_PPL_CNT, 26);
-
-	tuple = next_tuple(tuple);
-	*data_offset = (int)((char *)tuple - data);
-
-	return 0;
-}
-
 static int basefw_get_large_config(struct comp_dev *dev,
 				   uint32_t param_id,
 				   bool first_block,
@@ -281,8 +245,6 @@ static int basefw_get_large_config(struct comp_dev *dev,
 		return basefw_hw_config(data_offset, data);
 	case IPC4_MEMORY_STATE_INFO_GET:
 		return basefw_mem_state_info(data_offset, data);
-	case IPC4_DSP_PROPERTIES:
-		return basefw_get_dsp_properties(data_offset, data);
 	/* TODO: add more support */
 	case IPC4_DSP_RESOURCE_STATE:
 	case IPC4_NOTIFICATION_MASK:

--- a/src/include/ipc4/base_fw.h
+++ b/src/include/ipc4/base_fw.h
@@ -44,17 +44,6 @@
 /* Max pipeline count supported by ipc4 */
 #define IPC4_MAX_PPL_COUNT 16
 
-enum ipc4_basefw_properties {
-	IPC4_FW_VERSION,	/**< Firmware version */
-	IPC4_DSP_CORES,	/**< dsp cores count in audio subsystem */
-	IPC4_MEM_PAGE_SIZE,	/**< memory page size */
-	IPC4_TOTAL_PHYS_MEM_PAGES,	/**< total memory in page size */
-	IPC4_DL_MAILBOX_SIZE,	/**< download mailbox size */
-	IPC4_UL_MAILBOX_SIZE,	/**< uplaod mailbox size */
-	IPC4_TRACE_LOG_SIZE,	/**< trace log buffer size */
-	IPC4_MAX_PPL_CNT	/**< max pipleine count */
-};
-
 enum ipc4_basefw_params {
 	/* Use LARGE_CONFIG_GET to retrieve fw properties as TLV structure
 	 * with typeof AdspProperties.


### PR DESCRIPTION
The ADSP properties are obsolete and not using by host driver so can be removed.

Signed-off-by: Damian Nikodem <damian.nikodem@intel.com>