### PR TITLE
rtnr: Set process_enabled by default and keep its value in rtnr_reset() 

### DIFF
--- a/src/audio/rtnr/rtnr.c
+++ b/src/audio/rtnr/rtnr.c
@@ -240,7 +240,7 @@ static struct comp_dev *rtnr_new(const struct comp_driver *drv,
 
 	comp_set_drvdata(dev, cd);
 
-	cd->process_enable = false;
+	cd->process_enable = true;
 
 	/* Handler for configuration data */
 	cd->model_handler = comp_data_blob_handler_new(dev);
@@ -690,7 +690,6 @@ static int rtnr_reset(struct comp_dev *dev)
 
 	cd->sink_format = 0;
 	cd->rtnr_func = NULL;
-	cd->process_enable = false;
 	cd->source_rate = 0;
 	cd->sink_rate = 0;
 


### PR DESCRIPTION
This PR enables RTNR processing by default and keeps its value while the recording is finished.

Since rtnr_reset() will be called once recording is finished, the value of process_enabled should not be changed in this function. 

Otherwise every new recording will start with the value set in rtnr_reset() and it should be an incorrect behavior.