### PR TITLE
make buffer_release() and coherent_release() return void

### DIFF
--- a/src/audio/mixin_mixout.c
+++ b/src/audio/mixin_mixout.c
@@ -97,11 +97,9 @@ struct mixed_data_info __sparse_cache *mixed_data_info_acquire(struct mixed_data
 }
 
 static inline
-struct mixed_data_info *mixed_data_info_release(struct mixed_data_info __sparse_cache *mdi)
+void mixed_data_info_release(struct mixed_data_info __sparse_cache *mdi)
 {
-	struct coherent *c = coherent_release_thread(&mdi->c, sizeof(*mdi));
-
-	return container_of(c, struct mixed_data_info, c);
+	coherent_release_thread(&mdi->c, sizeof(*mdi));
 }
 
 /* mixin component private data */

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -223,11 +223,9 @@ __must_check static inline struct comp_buffer __sparse_cache *buffer_acquire(
 	return attr_container_of(c, struct comp_buffer __sparse_cache, c, __sparse_cache);
 }
 
-static inline struct comp_buffer *buffer_release(struct comp_buffer __sparse_cache *buffer)
+static inline void buffer_release(struct comp_buffer __sparse_cache *buffer)
 {
-	struct coherent *c = coherent_release_thread(&buffer->c, sizeof(*buffer));
-
-	return container_of(c, struct comp_buffer, c);
+	coherent_release_thread(&buffer->c, sizeof(*buffer));
 }
 
 static inline struct comp_dev *buffer_get_comp(struct comp_buffer *buffer, int dir)

--- a/src/include/sof/coherent.h
+++ b/src/include/sof/coherent.h
@@ -133,8 +133,8 @@ __must_check static inline struct coherent __sparse_cache *coherent_acquire(stru
 	return cc;
 }
 
-static inline struct coherent *coherent_release(struct coherent __sparse_cache *c,
-						const size_t size)
+static inline void coherent_release(struct coherent __sparse_cache *c,
+				    const size_t size)
 {
 	struct coherent *uc = cache_to_uncache(c);
 
@@ -152,8 +152,6 @@ static inline struct coherent *coherent_release(struct coherent __sparse_cache *
 		/* unlock on uncache alias */
 		k_spin_unlock(&uc->lock, uc->key);
 	}
-
-	return uc;
 }
 
 static inline void __coherent_init(struct coherent *c, const size_t size)
@@ -216,8 +214,8 @@ __must_check static inline struct coherent __sparse_cache *coherent_acquire_thre
 	return cc;
 }
 
-static inline struct coherent *coherent_release_thread(struct coherent __sparse_cache *c,
-						       const size_t size)
+static inline void coherent_release_thread(struct coherent __sparse_cache *c,
+					   const size_t size)
 {
 	struct coherent *uc = cache_to_uncache(c);
 
@@ -236,8 +234,6 @@ static inline struct coherent *coherent_release_thread(struct coherent __sparse_
 		/* unlock on uncache alias */
 		k_mutex_unlock(&uc->mutex);
 	}
-
-	return uc;
 }
 
 static inline void __coherent_init_thread(struct coherent *c, const size_t size)
@@ -305,8 +301,8 @@ __must_check static inline struct coherent __sparse_cache *coherent_acquire(stru
 	return (__sparse_force struct coherent __sparse_cache *)c;
 }
 
-static inline struct coherent *coherent_release(struct coherent __sparse_cache *c,
-						const size_t size)
+static inline void coherent_release(struct coherent __sparse_cache *c,
+				    const size_t size)
 {
 	if (c->shared) {
 		struct coherent *uc = cache_to_uncache(c);
@@ -316,8 +312,6 @@ static inline struct coherent *coherent_release(struct coherent __sparse_cache *
 
 		k_spin_unlock(&uc->lock, uc->key);
 	}
-
-	return (__sparse_force struct coherent *)c;
 }
 
 static inline void __coherent_init(struct coherent *c, const size_t size)
@@ -360,8 +354,8 @@ __must_check static inline struct coherent __sparse_cache *coherent_acquire_thre
 	return (__sparse_force struct coherent __sparse_cache *)c;
 }
 
-static inline struct coherent *coherent_release_thread(struct coherent __sparse_cache *c,
-						       const size_t size)
+static inline void coherent_release_thread(struct coherent __sparse_cache *c,
+					   const size_t size)
 {
 	if (c->shared) {
 		struct coherent *uc = cache_to_uncache(c);
@@ -371,8 +365,6 @@ static inline struct coherent *coherent_release_thread(struct coherent __sparse_
 
 		k_mutex_unlock(&uc->mutex);
 	}
-
-	return (__sparse_force struct coherent *)c;
 }
 
 static inline void __coherent_init_thread(struct coherent *c, const size_t size)


### PR DESCRIPTION
buffer_release() and coherent_release() don't need to return any value, make them return void