### PR TITLE
Module adapter: make the .data pointer cached

### DIFF
--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -270,8 +270,7 @@ int module_adapter_prepare(struct comp_dev *dev)
 	list_for_item(blist, &dev->bsource_list) {
 		size_t size = MAX(mod->deep_buff_bytes, mod->period_bytes);
 
-		mod->input_buffers[i].data = (__sparse_force void __sparse_cache *)rballoc(0,
-									SOF_MEM_CAPS_RAM, size);
+		mod->input_buffers[i].data = rballoc(0, SOF_MEM_CAPS_RAM, size);
 		if (!mod->input_buffers[i].data) {
 			comp_err(mod->dev, "module_adapter_prepare(): Failed to alloc input buffer data");
 			ret = -ENOMEM;
@@ -283,8 +282,7 @@ int module_adapter_prepare(struct comp_dev *dev)
 	/* allocate memory for output buffer data */
 	i = 0;
 	list_for_item(blist, &dev->bsink_list) {
-		mod->output_buffers[i].data = (__sparse_force void __sparse_cache *)rballoc(0,
-							SOF_MEM_CAPS_RAM, md->mpd.out_buff_size);
+		mod->output_buffers[i].data = rballoc(0, SOF_MEM_CAPS_RAM, md->mpd.out_buff_size);
 		if (!mod->output_buffers[i].data) {
 			comp_err(mod->dev, "module_adapter_prepare(): Failed to alloc output buffer data");
 			ret = -ENOMEM;

--- a/src/include/sof/audio/module_adapter/module/module_interface.h
+++ b/src/include/sof/audio/module_adapter/module/module_interface.h
@@ -13,6 +13,8 @@
 #ifndef __SOF_MODULE_INTERFACE__
 #define __SOF_MODULE_INTERFACE__
 
+#include <sof/compiler_attributes.h>
+
 /**
  * \enum module_cfg_fragment_position
  * \brief Fragment position in config
@@ -46,7 +48,7 @@ enum module_processing_mode {
  * \brief Input stream buffer
  */
 struct input_stream_buffer {
-	void *data; /* data stream buffer */
+	void __sparse_cache *data; /* data stream buffer */
 	uint32_t size; /* size of data in the buffer */
 	uint32_t consumed; /* number of bytes consumed by the module */
 
@@ -59,7 +61,7 @@ struct input_stream_buffer {
  * \brief Output stream buffer
  */
 struct output_stream_buffer {
-	void *data; /* data stream buffer */
+	void __sparse_cache *data; /* data stream buffer */
 	uint32_t size; /* size of data in the buffer */
 };
 


### PR DESCRIPTION
Force all module-adapter API users to use cached data