### PR TITLE
Fix pause-release not working on i.MX

### DIFF
--- a/src/drivers/imx/edma.c
+++ b/src/drivers/imx/edma.c
@@ -151,9 +151,6 @@ static int edma_start(struct dma_chan_data *channel)
 		return -EINVAL;
 
 	channel->status = COMP_STATE_ACTIVE;
-	/* Do the HW start of the DMA */
-	dma_chan_reg_update_bits(channel, EDMA_TCD_CSR,
-				 EDMA_TCD_CSR_START, EDMA_TCD_CSR_START);
 	/* Allow the HW to automatically trigger further transfers */
 	dma_chan_reg_update_bits(channel, EDMA_CH_CSR,
 				 EDMA_CH_CSR_ERQ_EARQ, EDMA_CH_CSR_ERQ_EARQ);

--- a/src/drivers/imx/edma.c
+++ b/src/drivers/imx/edma.c
@@ -168,7 +168,7 @@ static int edma_release(struct dma_chan_data *channel)
 	if (channel->status != COMP_STATE_PAUSED)
 		return -EINVAL;
 
-	channel->status = COMP_STATE_ACTIVE;
+	channel->status = COMP_STATE_PREPARE;
 	return 0;
 }
 

--- a/src/drivers/imx/edma.c
+++ b/src/drivers/imx/edma.c
@@ -147,7 +147,7 @@ static int edma_start(struct dma_chan_data *channel)
 	tr_info(&edma_tr, "EDMA: start(%d)", channel->index);
 
 	if (channel->status != COMP_STATE_PREPARE &&
-	    channel->status != COMP_STATE_SUSPEND)
+	    channel->status != COMP_STATE_PAUSED)
 		return -EINVAL;
 
 	channel->status = COMP_STATE_ACTIVE;

--- a/src/drivers/imx/sai.c
+++ b/src/drivers/imx/sai.c
@@ -371,8 +371,10 @@ static int sai_trigger(struct dai *dai, int cmd, int direction)
 
 	switch (cmd) {
 	case COMP_TRIGGER_START:
-	case COMP_TRIGGER_RELEASE:
 		sai_start(dai, direction);
+		break;
+	case COMP_TRIGGER_RELEASE:
+		sai_release(dai, direction);
 		break;
 	case COMP_TRIGGER_STOP:
 	case COMP_TRIGGER_PAUSE:

--- a/src/drivers/imx/sdma.c
+++ b/src/drivers/imx/sdma.c
@@ -458,7 +458,7 @@ static int sdma_start(struct dma_chan_data *channel)
 	tr_dbg(&sdma_tr, "sdma_start(%d)", channel->index);
 
 	if (channel->status != COMP_STATE_PREPARE &&
-	    channel->status != COMP_STATE_SUSPEND)
+	    channel->status != COMP_STATE_PAUSED)
 		return -EINVAL;
 
 	channel->status = COMP_STATE_ACTIVE;


### PR DESCRIPTION
Currently, when we're trying to pause and then resume a stream we get an error message from the FW saying that a `comp_trigger()` operation failed. This was caused by the fact that `edma_release` would set the channel state to COMP_STATE_ACTIVE and `edma_start` would not allow the transition from that state.

In order to fix this, `edma_release` now changes the state to COMP_STATE_PRE_ACTIVE and `edma_start` allow the transition from COMP_STATE_PRE_ACTIVE to COMP_STATE_ACTIVE. This way, the EDMA states will be consistent with the comp state diagram found at https://thesofproject.github.io/latest/architectures/firmware/components/component-overview.html.

Another problem with `edma_start` was the fact that it was allowing the transition from COMP_STATE_SUSPEND to COMP_STATE_ACTIVE which is wrong because that state is never set in the edma driver.

Another solution to the pause-resume problem would be to simply set the state of the edma channel to COMP_STATE_PREPARE on `edma_release`. This would also work but it would be inconsistent with the aforementioned comp state diagram.