### PR TITLE
topology2: build only when alsatplg is v1.2.7 or greater

### DIFF
--- a/tools/topology/topology2/CMakeLists.txt
+++ b/tools/topology/topology2/CMakeLists.txt
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 add_custom_target(topologies2)
 
-# check alsatplg version and built topology2 if alsatplg version is 1.2.6 or greater
+# Check alsatplg version and build topology2 if alsatplg version is
+# 1.2.7 or greater, see https://github.com/thesofproject/sof/issues/5323
 execute_process(COMMAND alsatplg --version RESULT_VARIABLE STATUS OUTPUT_VARIABLE ALSA_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
 if(STATUS AND NOT STATUS EQUAL 0)
 	message(WARNING "alsatplg error: ${STATUS}, topology2 will be skipped")
@@ -9,8 +10,8 @@ else()
 	string(REPLACE "\n" ";" ALSA_VERSION_LIST ${ALSA_VERSION})
 	list(GET ALSA_VERSION_LIST 0 ALSATPLG_VERSION)
 	string(REGEX MATCH "[0-9]\.[0-9]\.*[0-9]*" ALSATPLG_VERSION_NUMBER ${ALSATPLG_VERSION})
-	if(${ALSATPLG_VERSION_NUMBER} VERSION_LESS "1.2.6")
-		message(WARNING "topology2 will be skipped. Minimum required version for alsatplg: 1.2.6")
+	if(${ALSATPLG_VERSION_NUMBER} VERSION_LESS "1.2.7")
+		message(WARNING "topology2 will be skipped. Minimum required version for alsatplg: 1.2.7")
 	else()
 		add_dependencies(topologies topologies2)
 	endif()


### PR DESCRIPTION
Fixes: #5323

The v1.2.6 requirement was a lie the whole time because alsatplg v1.2.6
does not have any `-I` option. The truth was: un-released alsa-utils
from git was required. The check for v1.2.6 was an approximation good
enough for many users but not for everyone, see for instance #5323.

Now that alsa-utils v1.2.7 has been released we can stop lying:
 https://github.com/alsa-project/alsa-utils/commit/7d934f3142549

Signed-off-by: Marc Herbert <marc.herbert@intel.com>