### PR TITLE
rtnr: cherry-pick to sync with latest version on main branch

### DIFF
--- a/src/audio/rtnr/CMakeLists.txt
+++ b/src/audio/rtnr/CMakeLists.txt
@@ -2,7 +2,8 @@
 
 add_local_sources(sof rtnr.c)
 
-sof_add_static_library(SOF_RTK_MA_API rtklib/tgl/libSOF_RTK_MA_API.a)
-sof_add_static_library(Suite_rename rtklib/tgl/libSuite_rename.a)
-sof_add_static_library(Net rtklib/tgl/libNet.a)
-sof_add_static_library(Preset rtklib/tgl/libPreset.a)
+if(CONFIG_TIGERLAKE)
+	add_subdirectory(rtklib/tgl)
+elseif(CONFIG_MT8195)
+	add_subdirectory(rtklib/mt8195)
+endif()

--- a/src/audio/rtnr/rtklib/mt8195/CMakeLists.txt
+++ b/src/audio/rtnr/rtklib/mt8195/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+sof_add_static_library(SOF_RTK_MA_API libSOF_RTK_MA_API.a)
+sof_add_static_library(Suite_rename libSuite_MaLtFP.a)
+sof_add_static_library(Net libNet.a)
+sof_add_static_library(Preset libPreset.a)
+
+

--- a/src/audio/rtnr/rtklib/mt8195/README.txt
+++ b/src/audio/rtnr/rtklib/mt8195/README.txt
@@ -1,0 +1,1 @@
+Put libSOF_RTK_MA_API.a, libSuite_MaLtFP.a, libNet.a and libPreset.a here.

--- a/src/audio/rtnr/rtklib/tgl/CMakeLists.txt
+++ b/src/audio/rtnr/rtklib/tgl/CMakeLists.txt
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+sof_add_static_library(SOF_RTK_MA_API libSOF_RTK_MA_API.a)
+sof_add_static_library(Suite_rename libSuite_rename.a)
+sof_add_static_library(Net libNet.a)
+sof_add_static_library(Preset libPreset.a)
+

--- a/src/audio/rtnr/rtklib/tgl/CMakeLists.txt
+++ b/src/audio/rtnr/rtklib/tgl/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 sof_add_static_library(SOF_RTK_MA_API libSOF_RTK_MA_API.a)
-sof_add_static_library(Suite_rename libSuite_rename.a)
-sof_add_static_library(Net libNet.a)
+sof_add_static_library(Suite_MaLtFP libSuite_MaLtFP.a)
 sof_add_static_library(Preset libPreset.a)
+sof_add_static_library(utils libutils.a)
 

--- a/src/audio/rtnr/rtklib/tgl/README.txt
+++ b/src/audio/rtnr/rtklib/tgl/README.txt
@@ -1,1 +1,1 @@
-Put libSOF_RTK_MA_API.a, libSuite_rename.a, libNet.a and libPreset.a here.
+Put libSOF_RTK_MA_API.a, libSuite_MaLtFP.a, libPreset.a and libutils.a here.

--- a/src/audio/rtnr/rtnr.c
+++ b/src/audio/rtnr/rtnr.c
@@ -645,8 +645,13 @@ static int rtnr_reset(struct comp_dev *dev)
 	struct comp_data *cd = comp_get_drvdata(dev);
 
 	comp_info(dev, "rtnr_reset()");
+
 	cd->sink_format = 0;
 	cd->rtnr_func = NULL;
+	cd->process_enable = false;
+	cd->source_rate = 0;
+	cd->sink_rate = 0;
+
 	comp_set_state(dev, COMP_TRIGGER_RESET);
 	return 0;
 }

--- a/src/audio/rtnr/rtnr.c
+++ b/src/audio/rtnr/rtnr.c
@@ -237,7 +237,7 @@ static struct comp_dev *rtnr_new(const struct comp_driver *drv,
 
 	comp_set_drvdata(dev, cd);
 
-	cd->process_enable = false;
+	cd->process_enable = true;
 
 	/* Handler for configuration data */
 	cd->model_handler = comp_data_blob_handler_new(dev);
@@ -669,7 +669,6 @@ static int rtnr_reset(struct comp_dev *dev)
 
 	cd->sink_format = 0;
 	cd->rtnr_func = NULL;
-	cd->process_enable = false;
 	cd->source_rate = 0;
 	cd->sink_rate = 0;
 


### PR DESCRIPTION
This PR merges back following RTNR related commits from main to adl-004-drop-stable

39e99ac69734002b9cc3d36c03913a4b5f06dd21 [Rtnr: Clean up state on component reset](https://github.com/thesofproject/sof/commit/39e99ac69734002b9cc3d36c03913a4b5f06dd21)
605c6662712655adc2ca417b639c1a1523468920 [rtnr: passthrough audio by stream copy](https://github.com/thesofproject/sof/commit/605c6662712655adc2ca417b639c1a1523468920)
5c3594afe8b99aeed6dd845099408655130f8b0f [rtnr: Set process_enabled by default and keep its value in rtnr_reset()](https://github.com/thesofproject/sof/commit/5c3594afe8b99aeed6dd845099408655130f8b0f)
05bd87da37092e8db0d741b6595a6eb9e7a29ffb [Add RTNR library path for MT8195](https://github.com/thesofproject/sof/commit/05bd87da37092e8db0d741b6595a6eb9e7a29ffb)
f781a0b554be2d81511db02ee835f5c325ad3253 [Modify used static libraries](https://github.com/thesofproject/sof/commit/f781a0b554be2d81511db02ee835f5c325ad3253)