### PR TITLE
dai: fix compiler warnings

### DIFF
--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -437,7 +437,7 @@ static int dai_playback_params(struct comp_dev *dev, uint32_t period_bytes,
 	struct dma_sg_config *config = &dd->config;
 	struct dma_config *dma_cfg;
 	struct dma_block_config *dma_block_cfg;
-	struct dma_block_config *prev;
+	struct dma_block_config *prev = NULL;
 	struct comp_buffer __sparse_cache *dma_buf = buffer_acquire(dd->dma_buffer),
 		*local_buf = buffer_acquire(dd->local_buffer);
 	uint32_t local_fmt = local_buf->stream.frame_fmt;
@@ -550,7 +550,7 @@ static int dai_capture_params(struct comp_dev *dev, uint32_t period_bytes,
 	struct dma_sg_config *config = &dd->config;
 	struct dma_config *dma_cfg;
 	struct dma_block_config *dma_block_cfg;
-	struct dma_block_config *prev;
+	struct dma_block_config *prev = NULL;
 	struct comp_buffer __sparse_cache *dma_buf = buffer_acquire(dd->dma_buffer),
 		*local_buf = buffer_acquire(dd->local_buffer);
 	uint32_t local_fmt = local_buf->stream.frame_fmt;


### PR DESCRIPTION
Fix uninitialised variable warnings in dai-zephyr.c
