### PR TITLE
xtensa-build-zephyr.py: require python 3.8

### DIFF
--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -11,7 +11,7 @@ import shlex
 import subprocess
 import pathlib
 import errno
-import platform
+import platform as py_platform
 import sys
 import shutil
 import multiprocessing
@@ -35,13 +35,13 @@ default_rimage_key = pathlib.Path(SOF_TOP, "keys", "otc_private_key.pem")
 
 sof_version = None
 
-if platform.system() == "Windows":
+if py_platform.system() == "Windows":
 	xtensa_tools_version_postfix = "-win32"
-elif platform.system() == "Linux":
+elif py_platform.system() == "Linux":
 	xtensa_tools_version_postfix = "-linux"
 else:
 	xtensa_tools_version_postfix = "-unsupportedOS"
-	warnings.warn(f"Your operating system: {platform.system()} is not supported")
+	warnings.warn(f"Your operating system: {py_platform.system()} is not supported")
 
 platform_list = [
 	# Intel platforms

--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -234,10 +234,10 @@ This should be used with programmatic script invocations (eg. Continuous Integra
 	if args.fw_naming == 'AVS':
 		if not args.use_platform_subdir:
 			args.use_platform_subdir=True
-			warnings.warn(f"The option '--fw-naming AVS' has to be used with '--use-platform-subdir'. Enable '--use-platform-subdir' automatically.")
+			warnings.warn("The option '--fw-naming AVS' has to be used with '--use-platform-subdir'. Enable '--use-platform-subdir' automatically.")
 		if args.ipc != "IPC4":
 			args.ipc="IPC4"
-			warnings.warn(f"The option '--fw-naming AVS' has to be used with '-i IPC4'. Enable '-i IPC4' automatically.")
+			warnings.warn("The option '--fw-naming AVS' has to be used with '-i IPC4'. Enable '-i IPC4' automatically.")
 
 
 def execute_command(*run_args, **run_kwargs):

--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -19,6 +19,10 @@ import warnings
 from anytree import AnyNode, RenderTree
 from packaging import version
 
+MIN_PYTHON_VERSION = 3, 8
+assert sys.version_info >= MIN_PYTHON_VERSION, \
+	f"Python {MIN_PYTHON_VERSION} or above is required."
+
 # Version of this script matching Major.Minor.Patch style.
 VERSION = version.Version("2.0.0")
 

--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: BSD-3-Clause
 
+# W0311, W0312, C0103, C0116
+#pylint:disable=bad-indentation
 #pylint:disable=mixed-indentation
 #pylint:disable=invalid-name
 #pylint:disable=missing-function-docstring


### PR DESCRIPTION
Fixes #6121