### PR TITLE
rtnr: Modify used static libraries for MT8195

### DIFF
--- a/src/audio/rtnr/rtklib/mt8195/CMakeLists.txt
+++ b/src/audio/rtnr/rtklib/mt8195/CMakeLists.txt
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 sof_add_static_library(SOF_RTK_MA_API libSOF_RTK_MA_API.a)
-sof_add_static_library(Suite_rename libSuite_MaLtFP.a)
-sof_add_static_library(Net libNet.a)
+sof_add_static_library(Suite_MaLtFP libSuite_MaLtFP.a)
 sof_add_static_library(Preset libPreset.a)
+sof_add_static_library(utils libUtils.a)
 
 

--- a/src/audio/rtnr/rtklib/mt8195/README.txt
+++ b/src/audio/rtnr/rtklib/mt8195/README.txt
@@ -1,1 +1,1 @@
-Put libSOF_RTK_MA_API.a, libSuite_MaLtFP.a, libNet.a and libPreset.a here.
+Put libSOF_RTK_MA_API.a, libSuite_MaLtFP.a, libPreset.a and libutils.a here.


### PR DESCRIPTION
With the version released in 20220809, some libraries are removed or renamed.
This PR modifies the used libraries for MT8195 platform.