### PR TITLE
module_adapter: always propagate prepare() to module

### DIFF
--- a/src/audio/module_adapter/module/cadence.c
+++ b/src/audio/module_adapter/module/cadence.c
@@ -490,6 +490,15 @@ static int cadence_codec_prepare(struct processing_module *mod)
 	struct module_data *codec = &mod->priv;
 	struct cadence_codec_data *cd = codec->private;
 
+	if (mod->priv.state >= MODULE_IDLE) {
+		/* TODO: handle the case that stream_params was changed afterwards (different from
+		 *       the one applied on module codec initialization).
+		 */
+		comp_dbg(dev, "cadence_codec_prepare(): skipped by module under state %d",
+			 mod->priv.state);
+		return 0;
+	}
+
 	comp_dbg(dev, "cadence_codec_prepare() start");
 
 	ret = cadence_codec_post_init(mod);

--- a/src/audio/module_adapter/module/dts.c
+++ b/src/audio/module_adapter/module/dts.c
@@ -177,6 +177,15 @@ static int dts_codec_prepare(struct processing_module *mod)
 	DtsSofInterfaceBufferConfiguration buffer_configuration;
 	DtsSofInterfaceResult dts_result;
 
+	if (mod->priv.state >= MODULE_IDLE) {
+		/* TODO: handle the case that stream_params was changed afterwards (different from
+		 *       the one applied on module codec initialization).
+		 */
+		comp_dbg(dev, "dts_codec_prepare(): skipped by module under state %d",
+			 mod->priv.state);
+		return 0;
+	}
+
 	comp_dbg(dev, "dts_codec_prepare() start");
 
 	ret = dts_effect_populate_buffer_configuration(dev, &buffer_configuration);

--- a/src/audio/module_adapter/module/generic.c
+++ b/src/audio/module_adapter/module/generic.c
@@ -197,15 +197,13 @@ int module_prepare(struct processing_module *mod)
 
 	comp_dbg(dev, "module_prepare() start");
 
-	if (mod->priv.state == MODULE_IDLE)
-		return 0;
 	if (mod->priv.state < MODULE_INITIALIZED)
 		return -EPERM;
 
 	ret = md->ops->prepare(mod);
 	if (ret) {
-		comp_err(dev, "module_prepare() error %d: module specific prepare failed, comp_id %d",
-			 ret, dev_comp_id(dev));
+		comp_err(dev, "module_prepare() error %d: module specific prepare failed, comp_id %din state %d",
+			 ret, dev_comp_id(dev), md->state);
 		return ret;
 	}
 

--- a/src/audio/module_adapter/module/iadk_modules.c
+++ b/src/audio/module_adapter/module/iadk_modules.c
@@ -105,6 +105,15 @@ static int iadk_modules_prepare(struct processing_module *mod)
 			(struct ipc4_base_module_cfg *)lib_manager_get_config(dev);
 	int ret = 0;
 
+	if (mod->priv.state >= MODULE_IDLE) {
+		/* TODO: handle the case that stream_params was changed afterwards (different from
+		 *       the one applied on module codec initialization).
+		 */
+		comp_dbg(dev, "iadk_modules_prepare(): skipped by module under state %d",
+			 mod->priv.state);
+		return 0;
+	}
+
 	comp_info(dev, "iadk_modules_prepare()");
 
 	codec->mpd.in_buff = rballoc(0, SOF_MEM_CAPS_RAM, src_cfg->ibs);

--- a/src/audio/module_adapter/module/passthrough.c
+++ b/src/audio/module_adapter/module/passthrough.c
@@ -24,6 +24,15 @@ static int passthrough_codec_prepare(struct processing_module *mod)
 	struct comp_dev *dev = mod->dev;
 	struct module_data *codec = &mod->priv;
 
+	if (mod->priv.state >= MODULE_IDLE) {
+		/* TODO: handle the case that stream_params was changed afterwards (different from
+		 *       the one applied on module codec initialization).
+		 */
+		comp_dbg(dev, "passthrough_codec_prepare(): skipped by module under state %d",
+			 mod->priv.state;
+		return 0;
+	}
+
 	comp_info(dev, "passthrough_codec_prepare()");
 
 	codec->mpd.in_buff = rballoc(0, SOF_MEM_CAPS_RAM, mod->period_bytes);

--- a/src/audio/module_adapter/module/volume/volume.c
+++ b/src/audio/module_adapter/module/volume/volume.c
@@ -1182,6 +1182,15 @@ static int volume_prepare(struct processing_module *mod)
 	int ret;
 	int i;
 
+	if (mod->priv.state >= MODULE_IDLE) {
+		/* TODO: handle the case that stream_params was changed afterwards (different from
+		 *       the one applied on module codec initialization).
+		 */
+		comp_dbg(dev, "volume_prepare(): skipped by module under state %d",
+			 mod->priv.state);
+		return 0;
+	}
+
 	comp_dbg(dev, "volume_prepare()");
 
 #if CONFIG_IPC_MAJOR_4

--- a/src/audio/module_adapter/module/waves.c
+++ b/src/audio/module_adapter/module/waves.c
@@ -687,6 +687,15 @@ static int waves_codec_prepare(struct processing_module *mod)
 	struct comp_dev *dev = mod->dev;
 	int ret;
 
+	if (mod->priv.state >= MODULE_IDLE) {
+		/* TODO: handle the case that stream_params was changed afterwards (different from
+		 *       the one applied on module codec initialization).
+		 */
+		comp_dbg(dev, "waves_codec_prepare(): skipped by module under state %d",
+			 mod->priv.state);
+		return 0;
+	}
+
 	comp_dbg(dev, "waves_codec_prepare() start");
 
 	ret = waves_effect_check(dev);

--- a/src/include/sof/audio/module_adapter/module/generic.h
+++ b/src/include/sof/audio/module_adapter/module/generic.h
@@ -77,8 +77,8 @@ DECLARE_MODULE(sys_comp_module_##adapter##_init)
  */
 enum module_state {
 	MODULE_DISABLED, /**< Module isn't initialized yet or has been freed.*/
-	MODULE_INITIALIZED, /**< Module initialized or reset. */
-	MODULE_IDLE, /**< Module is idle now. */
+	MODULE_INITIALIZED, /**< Module is initialized, not prepared yet. */
+	MODULE_IDLE, /**< Module has been prepared and is idle now. */
 	MODULE_PROCESSING, /**< Module is processing samples now. */
 };
 

--- a/src/include/sof/audio/module_adapter/module/module_interface.h
+++ b/src/include/sof/audio/module_adapter/module/module_interface.h
@@ -76,7 +76,13 @@ struct module_interface {
 	int (*init)(struct processing_module *mod);
 	/**
 	 * Module specific prepare procedure, called as part of module_adapter
-	 * component preparation in .prepare()
+	 * component preparation in .prepare().
+	 * This procedure should be handled differently in respect of the module state:
+	 *   @ MODULE_INITIALIZED: fully run the specific prepare procedure as it is the first time
+	 *                         getting .prepare() for this module.
+	 *   @ MODULE_IDLE: take actions only when mod->stream_params is different from the last
+	 *                  .prepare(), which may cause changes of module parameters, e.g. required
+	 *                  size for data buffers, sample format, and etc.
 	 */
 	int (*prepare)(struct processing_module *mod);
 	/**


### PR DESCRIPTION
At present, module_adapter only propagates prepare() to the module for the first time. For modules, the specific reset() procedure only restores the initial stage after prepared, init_process() is applied to start module processing. Therefore, module_adapter blocks all the following prepare() calls to module.

However, it leads to problems that modules won't be notified for the stream parameter change once it happens afterwards, since prepare() is blocked by module_adapter. It actually breaks the ALSA conformance test in Google auto-lab, as the test
automation will run with S16, S24, S32 sample format successively.

This commit removes the logic of blocking prepare() in module_adapter which makes sure that the stream parameter change can be informed to modules. Accordingly, modules should be responsible for handling stream parameter in an adaptive manner.