### PR TITLE
Audio: copier: Fix return value if pipeline_get_dai_comp_latency() fails

### DIFF
--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -675,7 +675,7 @@ static int copier_comp_trigger(struct comp_dev *dev, int cmd)
 	dai_copier = pipeline_get_dai_comp_latency(dev->pipeline->pipeline_id, &latency);
 	if (!dai_copier) {
 		comp_err(dev, "failed to find dai comp or sink pipeline not running.");
-		return ret;
+		return -ENODEV;
 	}
 
 	dai_cd = comp_get_drvdata(dai_copier);


### PR DESCRIPTION
There is no use returning ret from a previous call assigning it if
pipeline_get_dai_comp_latency() has failed. In fact this crashes the
firmware.

Signed-off-by: Jyri Sarha <jyri.sarha@intel.com>