### PR TITLE
copier_hifi: fix Zephyr logging

### DIFF
--- a/src/audio/copier/copier_hifi.c
+++ b/src/audio/copier/copier_hifi.c
@@ -18,6 +18,8 @@
 #include <stdint.h>
 #include <xtensa/tie/xt_hifi3.h>
 
+LOG_MODULE_REGISTER(copier_hifi, CONFIG_SOF_LOG_LEVEL);
+
 int apply_attenuation(struct comp_dev *dev, struct copier_data *cd,
 		      struct comp_buffer __sparse_cache *sink, int frame)
 {


### PR DESCRIPTION
Add log definition for Zephyr allowing to build this module
for Zephyr when logging is enabled.

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>