### PR TITLE
lib: alloc: Add missing format specifier

### DIFF
--- a/src/lib/alloc.c
+++ b/src/lib/alloc.c
@@ -576,7 +576,7 @@ void heap_trace(struct mm_heap *heap, int size)
 
 			tr_info(&mem_tr, " %d Bytes blocks ID:%d base 0x%x",
 				current_map->block_size, j, current_map->base);
-			tr_info(&mem_tr, "   Number of Blocks: total % used %d free %d",
+			tr_info(&mem_tr, "   Number of Blocks: total %d used %d free %d",
 				current_map->count,
 				(current_map->count - current_map->free_count),
 				current_map->free_count);


### PR DESCRIPTION
This causes problems when displaying heap traces.

Fixes: b67c2bf0d9732 ("alloc: Making heap trace dump more readable")
Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>