### PR TITLE
platform: imx: Set PLATFORM_DCACHE_ALIGN to 32

### DIFF
--- a/src/platform/imx8/include/platform/lib/memory.h
+++ b/src/platform/imx8/include/platform/lib/memory.h
@@ -13,7 +13,7 @@
 #include <sof/lib/cache.h>
 
 /* data cache line alignment */
-#define PLATFORM_DCACHE_ALIGN	sizeof(void *)
+#define PLATFORM_DCACHE_ALIGN	32
 
 /* physical DSP addresses */
 

--- a/src/platform/imx8m/include/platform/lib/memory.h
+++ b/src/platform/imx8m/include/platform/lib/memory.h
@@ -13,7 +13,7 @@
 #include <sof/lib/cache.h>
 
 /* data cache line alignment */
-#define PLATFORM_DCACHE_ALIGN	sizeof(void *)
+#define PLATFORM_DCACHE_ALIGN	32
 
 /* physical DSP addresses */
 

--- a/src/platform/imx8ulp/include/platform/lib/memory.h
+++ b/src/platform/imx8ulp/include/platform/lib/memory.h
@@ -14,7 +14,7 @@
 
 
 /* data cache line alignment */
-#define PLATFORM_DCACHE_ALIGN	sizeof(void *)
+#define PLATFORM_DCACHE_ALIGN	32
 
 /* physical DSP addresses */
 


### PR DESCRIPTION
Ideally PLATFORM_DCACHE_ALIGN should be equal with DCACHE_LINE_SIZE,
but on i.MX dcache line size is 128 and it is too big for XTOS based
memory allocator.

See commit 8354454b4df0 ("platform: imx: Fix PLATFORM_DCACHE_ALIGN")

On the other hand the current value which is 4 doesn't work well with
Zephyr.

So, increase the PLATFORM_DCACHE_ALIGN to 32 which works well for XTOS /
Zephyr.

Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>