### PR TITLE
module adapter: pass config size to module for ipc4

### DIFF
--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -102,7 +102,15 @@ struct comp_dev *module_adapter_new(const struct comp_driver *drv,
 	struct module_data *md = &mod->priv;
 	struct module_config *dst = &md->cfg;
 
-	dst->data = spec;
+	if (drv->type == SOF_COMP_MODULE_ADAPTER) {
+		struct ipc_config_process *ipc_module_adapter = spec;
+
+		dst->data = ipc_module_adapter->data;
+		dst->size = ipc_module_adapter->size;
+	} else {
+		dst->data = spec;
+	}
+
 #endif
 
 	/* Init processing module */

--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -608,6 +608,7 @@ static int ipc4_init_module_instance(struct ipc4_message_request *ipc4)
 	comp.id = IPC4_COMP_ID(module.primary.r.module_id, module.primary.r.instance_id);
 	comp.pipeline_id = module.extension.r.ppl_instance_id;
 	comp.core = module.extension.r.core_id;
+	comp.ext_data_length = module.extension.r.param_block_size;
 	dev = comp_new(&comp);
 	if (!dev) {
 		tr_err(&ipc_tr, "error: failed to init module %x : %x",


### PR DESCRIPTION
IPC4 SOF_IPC4_MOD_INIT_INSTANCE provides size of the configuration
blob for the module. This size should be passed down to module adapter
and forwarded to module.
There are several reasons for using it:
- consistency with IPC3 flow;
- need for passing the size to IADK loadable modules;
- possibility to graceful failure in case of configuration inconsistency.

Signed-off-by: Jaroslaw Stelter <Jaroslaw.Stelter@intel.com>