### PR TITLE
[RFC] module: set state to INITIALIZED after reset

### DIFF
--- a/src/audio/module_adapter/module/generic.c
+++ b/src/audio/module_adapter/module/generic.c
@@ -283,7 +283,7 @@ int module_reset(struct processing_module *mod)
 	/* module resets itself to the initial condition after prepare()
 	 * so let's change its state to reflect that.
 	 */
-	md->state = MODULE_IDLE;
+	md->state = MODULE_INITIALIZED;
 
 	return 0;
 }


### PR DESCRIPTION
This fixes a flow when streaming is stopped and re-started without tearing down pipelines. Volume .reset() method resets the sampling rate to 0, so the next attempt to divide through it results in an exception. Setting the module state to INITIALIZED forces a new .prepare() invocation, which configures the module again.

UPDATE: Not sure if this breaks anything, so setting it to "RFC" first