### PR TITLE
[SKIP CI] .github actions: testbench clean up

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -108,7 +108,7 @@ jobs:
 
       - name: apt get
         run: sudo apt-get update &&
-             sudo apt-get -y install valgrind alsa-utils
+             sudo apt-get -y install valgrind alsa-utils libasound2-dev
 
       # testbench needs some topologies.
       - name: build test topologies

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -106,20 +106,15 @@ jobs:
       - uses: actions/checkout@v2
         with: {fetch-depth: 5}
 
-      - name: apt get valgrind
-        run: sudo apt-get update && sudo apt-get -y install valgrind
-
-      - name: docker
-        run: docker pull thesofproject/sof && docker tag thesofproject/sof sof
+      - name: apt get
+        run: sudo apt-get update &&
+             sudo apt-get -y install valgrind alsa-utils
 
       # testbench needs some topologies.
-      # Use our docker container to avoid the "unsupported widget type asrc"
-      # bug in ALSA 1.2.2
-      # https://github.com/thesofproject/sof/issues/2543
       - name: build test topologies
-        run: ./scripts/docker-run.sh ./scripts/build-tools.sh -t ||
+        run: ./scripts/build-tools.sh -t ||
              VERBOSE=1 NO_PROCESSORS=1 USE_XARGS=no
-             ./scripts/docker-run.sh ./scripts/build-tools.sh -t
+             ./scripts/build-tools.sh -t
 
       - name: build testbench
         run: ./scripts/rebuild-testbench.sh

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -9,10 +9,9 @@
 # github.com also has a powerful web editor that can be used without
 # committing.
 
-# This is the name of this workflow and should technically be called
-# something like "Main Workflow" but the place where most people see
-# this name is the Checks window next to other, non-github checks.
-name: GitHub Actions
+# TODO: finishing scattering this very old workflow to more specific
+# .yml files
+name: Main Actions
 
 # yamllint disable-line rule:truthy
 on:
@@ -101,7 +100,7 @@ jobs:
 
 
   testbench:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Upgrade to Ubuntu 22 VM.

Stop building test topologies in docker, not required anymore.

Add ALSA headers to help with topology re-org #6009 