### PR TITLE
topology1: remove mt8186 unused topologies

### DIFF
--- a/tools/topology/topology1/CMakeLists.txt
+++ b/tools/topology/topology1/CMakeLists.txt
@@ -236,9 +236,8 @@ set(TPLGS
         "sof-mt8195-mt6359-rt1019-rt5682\;sof-mt8195-mt6359-max98390-rt5682"
 	"sof-mt8195-mt6359-rt1019-rt5682\;sof-mt8195-mt6359-max98390-rt5682-rtnr\;-DCHANNELS=2\;-DRTNR"
 	"sof-mt8195-mt6359-rt1019-rt5682\;sof-mt8195-mt6359-max98390-rt5682-google-aec-rtnr\;-DGOOGLE_RTC_AUDIO_PROCESSING\;-DCHANNELS=2\;-DRTNR"
-	"sof-mt8186-mt6366\;sof-mt8186-mt6366-rt1019-rt5682s"
+	"sof-mt8186-mt6366\;sof-mt8186"
 	"sof-mt8186-mt6366\;sof-mt8186-mt6366-rt1019-rt5682s-waves\;-DWAVES=1"
-	"sof-mt8186-mt6366\;sof-mt8186-mt6366-da7219-max98357"
 
 	"sof-acp-renoir\;sof-acp"
 	"sof-rn-rt5682-rt1019\;sof-rn-rt5682-rt1019"


### PR DESCRIPTION
remove mt8186 unused topologies.
we use sof-mt8186 on our demo board, sof-mt8186-mt6366-rt1019-rt5682s
and sof-mt8186-mt6366-da7219-max98357 will not be used anymore.

Signed-off-by: Chunxu Li <chunxu.li@mediatek.com>