### PR TITLE
Revert "copier_hifi: copier logging fix"

### DIFF
--- a/src/audio/copier/copier_hifi.c
+++ b/src/audio/copier/copier_hifi.c
@@ -7,8 +7,6 @@
 
 #if __XCC__ && (XCHAL_HAVE_HIFI3 || XCHAL_HAVE_HIFI4)
 
-LOG_MODULE_REGISTER(copier_hifi, CONFIG_SOF_LOG_LEVEL);
-
 #include <sof/audio/buffer.h>
 #include <sof/audio/component_ext.h>
 #include <sof/audio/format.h>


### PR DESCRIPTION
This reverts commit a0b832686cfdacb5b2d61f7002aa41b210d215db.

There was a PR merge "conflict" as the log defines we're in different
place in the file. This same log define was already added in commit:
2c4e403d4d680ecfb31aaa493b88b12389125584

So remove the duplicate.

Signed-off-by: Jaska Uimonen <jaska.uimonen@intel.com>