### PR TITLE
pipeline: let selector terminate the pipeline when stopping

### DIFF
--- a/src/audio/pipeline/pipeline-stream.c
+++ b/src/audio/pipeline/pipeline-stream.c
@@ -351,8 +351,17 @@ static int pipeline_comp_trigger(struct comp_dev *current,
 
 	/* send command to the component and update pipeline state */
 	err = comp_trigger(current, ppl_data->cmd);
-	if (err < 0)
+	switch (err) {
+	case 0:
+		break;
+	case PPL_STATUS_PATH_STOP:
+		current->pipeline->trigger.aborted = true;
+		COMPILER_FALLTHROUGH;
+	case PPL_STATUS_PATH_TERMINATE:
+		return PPL_STATUS_PATH_STOP;
+	default:
 		return err;
+	}
 
 	if (err == PPL_STATUS_PATH_STOP) {
 		current->pipeline->trigger.aborted = true;

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -374,7 +374,7 @@ static int selector_trigger(struct comp_dev *dev, int cmd)
 
 	buffer_release(source_c);
 
-	return type == SOF_COMP_KPB ? PPL_STATUS_PATH_STOP : ret;
+	return type == SOF_COMP_KPB ? PPL_STATUS_PATH_TERMINATE : ret;
 }
 
 /**

--- a/src/include/sof/audio/pipeline.h
+++ b/src/include/sof/audio/pipeline.h
@@ -27,8 +27,16 @@ struct comp_dev;
 struct ipc;
 struct ipc_msg;
 
-/* Pipeline status to stop execution of current path */
-#define PPL_STATUS_PATH_STOP	1
+/*
+ * Pipeline status to stop execution of current path, but to keep the
+ * pipeline alive, when processing COMP_TRIGGER_STOP or COMP_TRIGGER_PAUSE
+ */
+#define PPL_STATUS_PATH_STOP		1
+/*
+ * Pipeline status to stop execution of current path, and to terminate the
+ * pipeline, when processing COMP_TRIGGER_STOP or COMP_TRIGGER_PAUSE
+ */
+#define PPL_STATUS_PATH_TERMINATE	2
 
 /* Pipeline scheduled in another thread other than ipc thread */
 #define PPL_STATUS_SCHEDULED	2


### PR DESCRIPTION
Usually when processing COMP_TRIGGER_PAUSE or COMP_TRIGGER_STOP if a component returns PPL_STATUS_PATH_STOP it means, that the trigger propagation should stop and the pipeline should be kept alive. However, in some cases propagation should be stopped, but the pipeline should be terminated. This is the case with the selector component, when used in a keyword detection pipeline. Add a new PPL_STATUS_PATH_TERMINATE return value for such cases.
