### PR TITLE
ipc4: invalidate cache for set large config message

### DIFF
--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -996,7 +996,6 @@ static int copier_set_sink_fmt(struct comp_dev *dev, void *data,
 	struct copier_data *cd = comp_get_drvdata(dev);
 
 	sink_fmt = (struct ipc4_copier_config_set_sink_format *)data;
-	dcache_invalidate_region((__sparse_force void __sparse_cache *)sink_fmt, sizeof(*sink_fmt));
 
 	if (max_data_size < sizeof(*sink_fmt)) {
 		comp_err(dev, "error: max_data_size %d should be bigger than %d", max_data_size,
@@ -1041,7 +1040,6 @@ static int set_attenuation(struct comp_dev *dev, uint32_t data_offset, char *dat
 		return -EINVAL;
 	}
 
-	dcache_invalidate_region((__sparse_force void __sparse_cache *)data, sizeof(uint32_t));
 	attenuation = *(uint32_t *)data;
 	if (attenuation > 31) {
 		comp_err(dev, "attenuation %d is out of range", attenuation);

--- a/src/audio/mixin_mixout.c
+++ b/src/audio/mixin_mixout.c
@@ -1156,8 +1156,6 @@ static int mixin_set_large_config(struct comp_dev *dev, uint32_t param_id, bool 
 		return -EINVAL;
 	}
 
-	dcache_invalidate_region((__sparse_force void __sparse_cache *)data, data_offset_or_size);
-
 	cfg = (struct ipc4_mixer_mode_config *)data;
 
 	if (cfg->mixer_mode_config_count < 1 || cfg->mixer_mode_config_count > MIXIN_MAX_SINKS) {

--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -727,6 +727,7 @@ static int ipc4_set_large_config_module_instance(struct ipc4_message_request *ip
 	int ret;
 
 	memcpy_s(&config, sizeof(config), ipc4, sizeof(config));
+	dcache_invalidate_region((__sparse_force void __sparse_cache *)MAILBOX_HOSTBOX_BASE, config.extension.r.data_off_size);
 	tr_dbg(&ipc_tr, "ipc4_set_large_config_module_instance %x : %x",
 	       (uint32_t)config.primary.r.module_id, (uint32_t)config.primary.r.instance_id);
 


### PR DESCRIPTION
This will fix cache issue when several messages were sent one after another