### PR TITLE
coherent: make CONFIG_INCOHERENT selectable from menuconfig

### DIFF
--- a/src/arch/xtensa/Kconfig
+++ b/src/arch/xtensa/Kconfig
@@ -17,12 +17,3 @@ config WAKEUP_HOOK
 	  This config should be selected by other platform-level configs.
 	  Platforms that use it, have to implement hook function
 	  platform_interrupt_on_wakeup.
-
-config INCOHERENT
-	bool
-	default n
-	help
-	  The architecture is cache incoherent. i.e FW has to manually manage
-	  cache coherency amongst objects that are used on multiple cores.
-	  This setting should only be disabled for cache incoherent
-	  architectures if they are being used in UP mode.

--- a/src/platform/Kconfig
+++ b/src/platform/Kconfig
@@ -156,7 +156,6 @@ config TIGERLAKE
 	select XT_WAITI_DELAY
 	select NO_SECONDARY_CORE_ROM
 	select CAVS_USE_LPRO_IN_WAITI
-	select INCOHERENT
 	help
 	  Select if your target platform is Tigerlake-compatible
 
@@ -544,5 +543,19 @@ config SOF_STACK_SIZE
 	  IPC calls. Increasing it allows deeper call stack on those IPC
 	  and might be useful when creating more complex audio processing
 	  components.
+
+if XTENSA
+
+config INCOHERENT
+	bool "Enable cached data access via the Coherent API"
+	default y if TIGERLAKE
+	default n
+	help
+	  The architecture is cache incoherent. i.e FW has to manually manage
+	  cache coherency amongst objects that are used on multiple cores.
+	  This setting should only be disabled for cache incoherent
+	  architectures for testing without cached access to shared data.
+
+endif
 
 endmenu


### PR DESCRIPTION
At the moment `CONFIG_INCOHERENT` is automatically enabled when `CONFIG_TIMERLAKE` is set and cannot be switched from menuconfig. Enable that to make debugging with limited cache use possible.

To debug with cached access only enabled for stack and read-only data, unselect `CONFIG_INCOHERENT` and `CONFIG__SOF_ZEPHYR_HEAP_CACHED`