### PR TITLE
audio: copier: fix always-true comparison in copier_comp_trigger

### DIFF
--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -648,7 +648,7 @@ static int copier_comp_trigger(struct comp_dev *dev, int cmd)
 	struct copier_data *dai_cd;
 	struct comp_buffer *buffer;
 	uint32_t latency;
-	int ret;
+	int ret, i;
 
 	comp_dbg(dev, "copier_comp_trigger()");
 
@@ -659,14 +659,10 @@ static int copier_comp_trigger(struct comp_dev *dev, int cmd)
 	if (ret == COMP_STATUS_STATE_ALREADY_SET)
 		return PPL_STATUS_PATH_STOP;
 
-	if (cd->endpoint) {
-		int i;
-
-		for (i = 0; i < cd->endpoint_num; i++) {
-			ret = cd->endpoint[i]->drv->ops.trigger(cd->endpoint[i], cmd);
-			if (ret < 0)
-				break;
-		}
+	for (i = 0; i < cd->endpoint_num; i++) {
+		ret = cd->endpoint[i]->drv->ops.trigger(cd->endpoint[i], cmd);
+		if (ret < 0)
+			break;
 	}
 
 	if (ret < 0 || !cd->endpoint_num || !cd->pipeline_reg_offset)


### PR DESCRIPTION
Fix compiler error related to endpoint field:

src/audio/copier/copier.c:662:13: error: the comparison will always
evaluate as 'true' for the address of 'endpoint' will never be
NULL [-Werror=address]

  662 |         if (cd->endpoint) {
      |             ^~

src/include/ipc4/copier.h:325:26: note: 'endpoint' declared here
  325 |         struct comp_dev *endpoint[IPC4_COPIER_MODULE_OUTPUT_PINS_COUNT];

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>