### PR TITLE
rtnr: cherry pick to sync mt8195/v0.4 branch with latest version on main

### DIFF
--- a/src/audio/rtnr/rtklib/mt8195/CMakeLists.txt
+++ b/src/audio/rtnr/rtklib/mt8195/CMakeLists.txt
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 sof_add_static_library(SOF_RTK_MA_API libSOF_RTK_MA_API.a)
-sof_add_static_library(Suite_rename libSuite_MaLtFP.a)
-sof_add_static_library(Net libNet.a)
+sof_add_static_library(Suite_MaLtFP libSuite_MaLtFP.a)
 sof_add_static_library(Preset libPreset.a)
+sof_add_static_library(utils libUtils.a)
 
 

--- a/src/audio/rtnr/rtklib/mt8195/CMakeLists.txt
+++ b/src/audio/rtnr/rtklib/mt8195/CMakeLists.txt
@@ -3,6 +3,6 @@
 sof_add_static_library(SOF_RTK_MA_API libSOF_RTK_MA_API.a)
 sof_add_static_library(Suite_MaLtFP libSuite_MaLtFP.a)
 sof_add_static_library(Preset libPreset.a)
-sof_add_static_library(utils libUtils.a)
+sof_add_static_library(utils libutils.a)
 
 

--- a/src/audio/rtnr/rtklib/mt8195/README.txt
+++ b/src/audio/rtnr/rtklib/mt8195/README.txt
@@ -1,1 +1,1 @@
-Put libSOF_RTK_MA_API.a, libSuite_MaLtFP.a, libNet.a and libPreset.a here.
+Put libSOF_RTK_MA_API.a, libSuite_MaLtFP.a, libPreset.a and libutils.a here.

--- a/src/audio/rtnr/rtklib/tgl/CMakeLists.txt
+++ b/src/audio/rtnr/rtklib/tgl/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 sof_add_static_library(SOF_RTK_MA_API libSOF_RTK_MA_API.a)
-sof_add_static_library(Suite_rename libSuite_rename.a)
-sof_add_static_library(Net libNet.a)
+sof_add_static_library(Suite_MaLtFP libSuite_MaLtFP.a)
 sof_add_static_library(Preset libPreset.a)
+sof_add_static_library(utils libutils.a)
 

--- a/src/audio/rtnr/rtklib/tgl/README.txt
+++ b/src/audio/rtnr/rtklib/tgl/README.txt
@@ -1,1 +1,1 @@
-Put libSOF_RTK_MA_API.a, libSuite_rename.a, libNet.a and libPreset.a here.
+Put libSOF_RTK_MA_API.a, libSuite_MaLtFP.a, libPreset.a and libutils.a here.

--- a/src/audio/rtnr/rtnr.c
+++ b/src/audio/rtnr/rtnr.c
@@ -666,8 +666,13 @@ static int rtnr_reset(struct comp_dev *dev)
 	struct comp_data *cd = comp_get_drvdata(dev);
 
 	comp_info(dev, "rtnr_reset()");
+
 	cd->sink_format = 0;
 	cd->rtnr_func = NULL;
+	cd->process_enable = false;
+	cd->source_rate = 0;
+	cd->sink_rate = 0;
+
 	comp_set_state(dev, COMP_TRIGGER_RESET);
 	return 0;
 }

--- a/src/audio/rtnr/rtnr.c
+++ b/src/audio/rtnr/rtnr.c
@@ -237,7 +237,7 @@ static struct comp_dev *rtnr_new(const struct comp_driver *drv,
 
 	comp_set_drvdata(dev, cd);
 
-	cd->process_enable = false;
+	cd->process_enable = true;
 
 	/* Handler for configuration data */
 	cd->model_handler = comp_data_blob_handler_new(dev);
@@ -669,7 +669,6 @@ static int rtnr_reset(struct comp_dev *dev)
 
 	cd->sink_format = 0;
 	cd->rtnr_func = NULL;
-	cd->process_enable = false;
 	cd->source_rate = 0;
 	cd->sink_rate = 0;
 


### PR DESCRIPTION
This PR merges back following RTNR related commits from main to mt8195/v0.4

f781a0b554be2d81511db02ee835f5c325ad3253 [Modify used static libraries](https://github.com/thesofproject/sof/commit/f781a0b554be2d81511db02ee835f5c325ad3253)
39e99ac69734002b9cc3d36c03913a4b5f06dd21 [Rtnr: Clean up state on component reset](https://github.com/thesofproject/sof/commit/39e99ac69734002b9cc3d36c03913a4b5f06dd21)
5c3594afe8b99aeed6dd845099408655130f8b0f [rtnr: Set process_enabled by default and keep its value in rtnr_reset()](https://github.com/thesofproject/sof/commit/5c3594afe8b99aeed6dd845099408655130f8b0f)
0b18ca82ac0b13f49701b5f47d9b12d974a7ddc9 [rtnr: Modify used static libraries for MT8195](https://github.com/thesofproject/sof/commit/0b18ca82ac0b13f49701b5f47d9b12d974a7ddc9)
e1d2b8d1a3c08f295b9a7423f398a9fc5065300b [Fix RTNR library naming](https://github.com/thesofproject/sof/commit/e1d2b8d1a3c08f295b9a7423f398a9fc5065300b)
