### PR TITLE
module_adapter: add request for prepare() after reset by module

### DIFF
--- a/src/audio/module_adapter/module/volume/volume.c
+++ b/src/audio/module_adapter/module/volume/volume.c
@@ -1285,7 +1285,7 @@ static int volume_reset(struct processing_module *mod)
 
 	comp_dbg(mod->dev, "volume_reset()");
 	reset_state(cd);
-	return 0;
+	return MODULE_PREPARE_REQUESTED;
 }
 
 #if CONFIG_COMP_LEGACY_INTERFACE

--- a/src/include/sof/audio/module_adapter/module/generic.h
+++ b/src/include/sof/audio/module_adapter/module/generic.h
@@ -83,6 +83,15 @@ enum module_state {
 };
 
 /**
+ * \enum module_retcode
+ * \brief Module-specific return codes - 0 is preserved for function success and
+ * all negative values are preserved for errors.
+ */
+enum module_retcode {
+	MODULE_PREPARE_REQUESTED = 1, /**< Module requests prepare() call after reset. */
+};
+
+/**
  * \struct module_param
  * \brief Module TLV parameters container - used for both config types.
  * For example if one want to set the sample_rate to 16 [kHz] and this


### PR DESCRIPTION
At present, module_adapter only propagates prepare() to the module for the first time. The expectation for module specific reset() procedure is to restore the initial condition after prepared, so module_adapter blocks all the following prepare() calls to module.
    
However, it leads to problems that modules won't be notified for the stream parameter change afterwards since prepare() is blocked by module_adapter. Moreover, it breaks Volume module as mentioned in #6034.