### PR TITLE
cmake: stop sneakily downloading missing submodules at build time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ set(SOF_ROOT_BINARY_DIRECTORY "${PROJECT_BINARY_DIR}")
 # check git hooks
 include(scripts/cmake/git-hooks.cmake)
 
-# checkout submodules
+# Check submodules
 include(scripts/cmake/git-submodules.cmake)
 
 # most of other options are set on per-arch and per-target basis

--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -1346,7 +1346,7 @@ sub top_of_kernel_tree {
 
 	if ($SOF) {
 		@tree_check = (
-			"LICENCE", "README.md", "rimage", "tools",
+			"LICENCE", "README.md", "tools",
 			"scripts", "doc", "src", "CODEOWNERS",
 			"CMakeLists.txt",
 		);

--- a/scripts/cmake/git-submodules.cmake
+++ b/scripts/cmake/git-submodules.cmake
@@ -34,23 +34,12 @@ if(GIT_FOUND AND EXISTS "${SOF_ROOT_SOURCE_DIRECTORY}/.git")
 
 	elseif(NOT BUILD_UNIT_TESTS AND
 	    NOT CONFIG_LIBRARY)
-	# Automated initialization for convenience. You can defeat it by
-	# manually initializing rimage and _not_ some other
-	# submodule. In that case you get the warning above.
 
-	# TODO: get rid of this CMake configuration time
-	# hack. Downloading, configuring and building should always be
-	# kept separate; that's CI 101.
-
-		message(STATUS "Git submodules update HACK")
-		execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --merge --recursive
-				WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-				RESULT_VARIABLE GIT_SUBMOD_RESULT)
-
-		if(NOT GIT_SUBMOD_RESULT EQUAL "0")
-			message(FATAL_ERROR "git submodule update --init failed with ${GIT_SUBMOD_RESULT}, please checkout submodules")
-		endif()
-
+		message(FATAL_ERROR
+"${RIMAGE_CMAKE} not found. You should have used 'git clone --recursive'. \
+To fix this existing git clone run:
+git submodule update --init --merge --recursive
+")
 	endif() # rimage/CMakeLists.txt
 
 endif() # .git/


### PR DESCRIPTION
Note this change does NOT affect Zephyr builds in any shape or form as
Zephyr builds simply don't use the CMake files changed by this commit.

Downloading missing submodules at build time was never a good idea;
always a hack. Downloading and building should always be kept separate
from each other for version control and bill of materials reasons and to
support "off-line" builds; build inputs should always be available.

Now that Zephyr builds have just moved away from git submodules
(replaced by west), stop sneakily downloading missing submodules at
build time while the user cannot notice, overwhelmed by the volume of
build logs. Someone building XTOS first and Zephyr second could
unknowningly end up in a "hybrid" and undesired situation where git
submodules and west would be BOTH pointing at the same rimage clone.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>