### PR TITLE
volume: cast function parameters to (int64_t)

### DIFF
--- a/src/audio/module_adapter/module/volume/volume.c
+++ b/src/audio/module_adapter/module/volume/volume.c
@@ -520,7 +520,7 @@ static inline void init_ramp(struct vol_data *cd, uint32_t curve_duration, uint3
 	/* In IPC4 driver sends curve_duration in hundred of ns - it should be
 	 * converted into ms value required by firmware
 	 */
-	cd->initial_ramp = Q_MULTSR_32X32(curve_duration,
+	cd->initial_ramp = Q_MULTSR_32X32((int64_t)curve_duration,
 					  Q_CONVERT_FLOAT(1.0 / 10000, 31), 0, 31, 0);
 
 	if (!cd->initial_ramp) {


### PR DESCRIPTION
The parameters px and py in
Q_MULTSR_32X32(px, py, qx, qy, qp) function
must be cast to (int64_t) if other type.

Signed-off-by: Arsen Eloglian <ArsenX.Eloglian@intel.com>