### PR TITLE
header: rtos: use rtos specific version of wait.h

### DIFF
--- a/src/arch/xtensa/lib/cpu.c
+++ b/src/arch/xtensa/lib/cpu.c
@@ -20,7 +20,7 @@
 #include <sof/lib/mm_heap.h>
 #include <sof/lib/notifier.h>
 #include <sof/lib/pm_runtime.h>
-#include <sof/lib/wait.h>
+#include <rtos/wait.h>
 #include <sof/schedule/schedule.h>
 #include <sof/sof.h>
 #include <sof/trace/trace.h>

--- a/src/arch/xtensa/schedule/task.c
+++ b/src/arch/xtensa/schedule/task.c
@@ -16,7 +16,7 @@
 #include <sof/lib/cache.h>
 #include <sof/lib/cpu.h>
 #include <sof/lib/memory.h>
-#include <sof/lib/wait.h>
+#include <rtos/wait.h>
 #include <sof/schedule/edf_schedule.h>
 #include <sof/schedule/schedule.h>
 #include <sof/schedule/task.h>

--- a/src/audio/google_hotword_detect.c
+++ b/src/audio/google_hotword_detect.c
@@ -16,7 +16,7 @@
 #include <sof/lib/alloc.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/notifier.h>
-#include <sof/lib/wait.h>
+#include <rtos/wait.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
 #include <sof/math/numbers.h>

--- a/src/audio/google_rtc_audio_processing.c
+++ b/src/audio/google_rtc_audio_processing.c
@@ -20,7 +20,7 @@
 #include <sof/lib/memory.h>
 #include <sof/lib/notifier.h>
 #include <sof/lib/uuid.h>
-#include <sof/lib/wait.h>
+#include <rtos/wait.h>
 #include <sof/list.h>
 #include <sof/math/numbers.h>
 #include <rtos/string.h>

--- a/src/audio/pipeline/pipeline-stream.c
+++ b/src/audio/pipeline/pipeline-stream.c
@@ -9,7 +9,7 @@
 #include <sof/audio/component_ext.h>
 #include <sof/audio/pipeline.h>
 #include <sof/lib/dai.h>
-#include <sof/lib/wait.h>
+#include <rtos/wait.h>
 #include <sof/list.h>
 #include <rtos/spinlock.h>
 #include <rtos/string.h>

--- a/src/drivers/amd/rembrandt/ipc.c
+++ b/src/drivers/amd/rembrandt/ipc.c
@@ -18,7 +18,7 @@
 #include <sof/lib/mailbox.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
-#include <sof/lib/wait.h>
+#include <rtos/wait.h>
 #include <sof/list.h>
 #include <sof/platform.h>
 #include <sof/schedule/edf_schedule.h>

--- a/src/drivers/amd/renoir/ipc.c
+++ b/src/drivers/amd/renoir/ipc.c
@@ -19,7 +19,7 @@
 #include <sof/lib/mailbox.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
-#include <sof/lib/wait.h>
+#include <rtos/wait.h>
 #include <sof/list.h>
 #include <sof/platform.h>
 #include <sof/schedule/edf_schedule.h>

--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -33,7 +33,7 @@
 #include <sof/lib/dma.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/pm_runtime.h>
-#include <sof/lib/wait.h>
+#include <rtos/wait.h>
 #include <sof/lib/notifier.h>
 #include <sof/platform.h>
 #include <rtos/spinlock.h>

--- a/src/drivers/dw/ssi-spi.c
+++ b/src/drivers/dw/ssi-spi.c
@@ -18,7 +18,7 @@
 #include <sof/lib/mailbox.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
-#include <sof/lib/wait.h>
+#include <rtos/wait.h>
 #include <sof/platform.h>
 #include <sof/schedule/ll_schedule.h>
 #include <sof/schedule/schedule.h>

--- a/src/drivers/imx/ipc.c
+++ b/src/drivers/imx/ipc.c
@@ -15,7 +15,7 @@
 #include <sof/lib/mailbox.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
-#include <sof/lib/wait.h>
+#include <rtos/wait.h>
 #include <sof/list.h>
 #include <sof/platform.h>
 #include <sof/schedule/edf_schedule.h>

--- a/src/drivers/imx/sai.c
+++ b/src/drivers/imx/sai.c
@@ -12,7 +12,7 @@
 #include <sof/drivers/sai.h>
 #include <sof/lib/dai.h>
 #include <sof/lib/dma.h>
-#include <sof/lib/wait.h>
+#include <rtos/wait.h>
 #include <sof/lib/uuid.h>
 #include <ipc/dai.h>
 #include <errno.h>

--- a/src/drivers/imx/sdma.c
+++ b/src/drivers/imx/sdma.c
@@ -12,7 +12,7 @@
 #include <sof/lib/io.h>
 #include <sof/lib/notifier.h>
 #include <sof/lib/uuid.h>
-#include <sof/lib/wait.h>
+#include <rtos/wait.h>
 #include <sof/platform.h>
 #include <errno.h>
 #include <stddef.h>

--- a/src/drivers/intel/baytrail/ipc.c
+++ b/src/drivers/intel/baytrail/ipc.c
@@ -15,7 +15,7 @@
 #include <sof/lib/memory.h>
 #include <sof/lib/shim.h>
 #include <sof/lib/uuid.h>
-#include <sof/lib/wait.h>
+#include <rtos/wait.h>
 #include <sof/list.h>
 #include <sof/platform.h>
 #include <sof/schedule/edf_schedule.h>

--- a/src/drivers/intel/cavs/ipc.c
+++ b/src/drivers/intel/cavs/ipc.c
@@ -15,7 +15,7 @@
 #include <sof/lib/memory.h>
 #include <sof/lib/pm_runtime.h>
 #include <sof/lib/uuid.h>
-#include <sof/lib/wait.h>
+#include <rtos/wait.h>
 #include <sof/list.h>
 #include <sof/platform.h>
 #include <sof/schedule/edf_schedule.h>

--- a/src/drivers/intel/cavs/sue-ipc.c
+++ b/src/drivers/intel/cavs/sue-ipc.c
@@ -12,7 +12,7 @@
 #include <sof/lib/mailbox.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
-#include <sof/lib/wait.h>
+#include <rtos/wait.h>
 #include <sof/list.h>
 #include <sof/schedule/edf_schedule.h>
 #include <sof/schedule/schedule.h>

--- a/src/drivers/intel/haswell/ipc.c
+++ b/src/drivers/intel/haswell/ipc.c
@@ -14,7 +14,7 @@
 #include <sof/lib/memory.h>
 #include <sof/lib/shim.h>
 #include <sof/lib/uuid.h>
-#include <sof/lib/wait.h>
+#include <rtos/wait.h>
 #include <sof/list.h>
 #include <sof/platform.h>
 #include <sof/schedule/edf_schedule.h>

--- a/src/drivers/intel/pmc-ipc.c
+++ b/src/drivers/intel/pmc-ipc.c
@@ -9,7 +9,7 @@
 #include <sof/drivers/pmc.h>
 #include <sof/lib/alloc.h>
 #include <sof/lib/shim.h>
-#include <sof/lib/wait.h>
+#include <rtos/wait.h>
 #include <sof/platform.h>
 #include <ipc/topology.h>
 #include <errno.h>

--- a/src/drivers/intel/ssp/ssp.c
+++ b/src/drivers/intel/ssp/ssp.c
@@ -18,7 +18,7 @@
 #include <sof/lib/memory.h>
 #include <sof/lib/pm_runtime.h>
 #include <sof/lib/uuid.h>
-#include <sof/lib/wait.h>
+#include <rtos/wait.h>
 #include <sof/platform.h>
 #include <rtos/spinlock.h>
 #include <sof/trace/trace.h>

--- a/src/drivers/mediatek/mt8186/ipc.c
+++ b/src/drivers/mediatek/mt8186/ipc.c
@@ -15,7 +15,7 @@
 #include <sof/lib/mailbox.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
-#include <sof/lib/wait.h>
+#include <rtos/wait.h>
 #include <sof/list.h>
 #include <sof/platform.h>
 #include <sof/schedule/edf_schedule.h>

--- a/src/drivers/mediatek/mt8195/ipc.c
+++ b/src/drivers/mediatek/mt8195/ipc.c
@@ -14,7 +14,7 @@
 #include <sof/lib/mailbox.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
-#include <sof/lib/wait.h>
+#include <rtos/wait.h>
 #include <sof/list.h>
 #include <sof/platform.h>
 #include <sof/schedule/edf_schedule.h>

--- a/src/idc/idc.c
+++ b/src/idc/idc.c
@@ -20,7 +20,7 @@
 #include <sof/lib/pm_runtime.h>
 #include <sof/lib/uuid.h>
 #include <sof/platform.h>
-#include <arch/lib/wait.h>
+#include <rtos/wait.h>
 #include <sof/schedule/edf_schedule.h>
 #include <sof/schedule/ll_schedule.h>
 #include <sof/schedule/schedule.h>

--- a/src/include/sof/drivers/dmic.h
+++ b/src/include/sof/drivers/dmic.h
@@ -71,7 +71,7 @@
 #include <sof/audio/format.h>
 #include <rtos/bit.h>
 #include <sof/lib/dai.h>
-#include <sof/lib/wait.h>
+#include <rtos/wait.h>
 #include <stdint.h>
 
 /* Parameters used in modes computation */

--- a/src/include/sof/drivers/mu.h
+++ b/src/include/sof/drivers/mu.h
@@ -11,6 +11,7 @@
 #define __SOF_DRIVERS_MU_H__
 
 #include <rtos/bit.h>
+#include <sof/lib/clk.h>
 #include <stdint.h>
 
 enum imx_mu_type {

--- a/src/include/sof/drivers/ssp.h
+++ b/src/include/sof/drivers/ssp.h
@@ -11,7 +11,7 @@
 #include <rtos/bit.h>
 #include <sof/lib/clk.h>
 #include <sof/lib/dai.h>
-#include <sof/lib/wait.h>
+#include <rtos/wait.h>
 #include <sof/trace/trace.h>
 #include <ipc/dai.h>
 #include <ipc/dai-intel.h>

--- a/src/init/init.c
+++ b/src/init/init.c
@@ -17,7 +17,7 @@
 #include <sof/lib/mm_heap.h>
 #include <sof/lib/notifier.h>
 #include <sof/lib/pm_runtime.h>
-#include <sof/lib/wait.h>
+#include <rtos/wait.h>
 #include <sof/platform.h>
 #include <sof/schedule/task.h>
 #include <sof/sof.h>

--- a/src/ipc/ipc3/handler.c
+++ b/src/ipc/ipc3/handler.c
@@ -19,6 +19,7 @@
 #include <sof/debug/gdb/gdb.h>
 #include <sof/debug/panic.h>
 #include <sof/drivers/idc.h>
+#include <sof/drivers/interrupt.h>
 #include <sof/ipc/common.h>
 #include <sof/ipc/msg.h>
 #include <sof/ipc/driver.h>

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -18,7 +18,7 @@
 #include <sof/lib/mailbox.h>
 #include <sof/list.h>
 #include <sof/platform.h>
-#include <sof/lib/wait.h>
+#include <rtos/wait.h>
 
 #include <sof/sof.h>
 #include <rtos/spinlock.h>

--- a/src/lib/wait.c
+++ b/src/lib/wait.c
@@ -11,7 +11,7 @@
 #include <sof/lib/clk.h>
 #include <sof/lib/io.h>
 #include <sof/lib/uuid.h>
-#include <sof/lib/wait.h>
+#include <rtos/wait.h>
 #include <sof/platform.h>
 #include <sof/schedule/schedule.h>
 #include <sof/trace/trace.h>

--- a/src/platform/amd/rembrandt/include/platform/platform.h
+++ b/src/platform/amd/rembrandt/include/platform/platform.h
@@ -12,7 +12,6 @@
 
 #if !defined(__ASSEMBLER__) && !defined(LINKER)
 
-#include <arch/lib/wait.h>
 #include <sof/drivers/interrupt.h>
 #include <sof/lib/clk.h>
 #include <sof/lib/mailbox.h>
@@ -87,10 +86,7 @@ static inline void platform_panic(uint32_t p)
  * May be power-optimized using platform specific capabilities.
  * @param level Interrupt level.
  */
-static inline void platform_wait_for_interrupt(int level)
-{
-	arch_wait_for_interrupt(level);
-}
+void platform_wait_for_interrupt(int level);
 
 extern intptr_t _module_init_start;
 extern intptr_t _module_init_end;

--- a/src/platform/amd/rembrandt/platform.c
+++ b/src/platform/amd/rembrandt/platform.c
@@ -197,3 +197,8 @@ int platform_context_save(struct sof *sof)
 {
 	return 0;
 }
+
+void platform_wait_for_interrupt(int level)
+{
+	arch_wait_for_interrupt(level);
+}

--- a/src/platform/amd/renoir/include/platform/platform.h
+++ b/src/platform/amd/renoir/include/platform/platform.h
@@ -13,7 +13,6 @@
 
 #if !defined(__ASSEMBLER__) && !defined(LINKER)
 
-#include <arch/lib/wait.h>
 #include <sof/drivers/interrupt.h>
 #include <sof/lib/clk.h>
 #include <sof/lib/mailbox.h>
@@ -88,10 +87,7 @@ static inline void platform_panic(uint32_t p)
  * May be power-optimized using platform specific capabilities.
  * @param level Interrupt level.
  */
-static inline void platform_wait_for_interrupt(int level)
-{
-	arch_wait_for_interrupt(level);
-}
+void platform_wait_for_interrupt(int level);
 
 extern intptr_t _module_init_start;
 extern intptr_t _module_init_end;

--- a/src/platform/amd/renoir/platform.c
+++ b/src/platform/amd/renoir/platform.c
@@ -198,3 +198,8 @@ int platform_context_save(struct sof *sof)
 {
 	return 0;
 }
+
+void platform_wait_for_interrupt(int level)
+{
+	arch_wait_for_interrupt(level);
+}

--- a/src/platform/baytrail/include/platform/platform.h
+++ b/src/platform/baytrail/include/platform/platform.h
@@ -20,7 +20,6 @@
 
 #if !defined(__ASSEMBLER__) && !defined(LINKER)
 
-#include <arch/lib/wait.h>
 #include <sof/drivers/interrupt.h>
 #include <sof/lib/clk.h>
 #include <sof/lib/mailbox.h>
@@ -90,13 +89,7 @@ static inline void platform_panic(uint32_t p)
  * May be power-optimized using platform specific capabilities.
  * @param level Interrupt level.
  */
-static inline void platform_wait_for_interrupt(int level)
-{
-	if (arch_interrupt_get_level())
-		panic(SOF_IPC_PANIC_WFI);
-
-	arch_wait_for_interrupt(level);
-}
+void platform_wait_for_interrupt(int level);
 
 /* Platform defined trace code */
 #define platform_trace_point(__x) \

--- a/src/platform/baytrail/platform.c
+++ b/src/platform/baytrail/platform.c
@@ -334,3 +334,11 @@ int platform_context_save(struct sof *sof)
 {
 	return 0;
 }
+
+void platform_wait_for_interrupt(int level)
+{
+	if (arch_interrupt_get_level())
+		panic(SOF_IPC_PANIC_WFI);
+
+	arch_wait_for_interrupt(level);
+}

--- a/src/platform/haswell/include/platform/platform.h
+++ b/src/platform/haswell/include/platform/platform.h
@@ -16,7 +16,6 @@
 
 #if !defined(__ASSEMBLER__) && !defined(LINKER)
 
-#include <arch/lib/wait.h>
 #include <sof/drivers/interrupt.h>
 #include <sof/lib/clk.h>
 #include <sof/lib/mailbox.h>
@@ -83,13 +82,7 @@ static inline void platform_panic(uint32_t p)
  * May be power-optimized using platform specific capabilities.
  * @param level Interrupt level.
  */
-static inline void platform_wait_for_interrupt(int level)
-{
-	if (arch_interrupt_get_level())
-		panic(SOF_IPC_PANIC_WFI);
-
-	arch_wait_for_interrupt(level);
-}
+void platform_wait_for_interrupt(int level);
 
 extern intptr_t _module_init_start;
 extern intptr_t _module_init_end;

--- a/src/platform/haswell/platform.c
+++ b/src/platform/haswell/platform.c
@@ -265,3 +265,11 @@ int platform_context_save(struct sof *sof)
 {
 	return 0;
 }
+
+void platform_wait_for_interrupt(int level)
+{
+	if (arch_interrupt_get_level())
+		panic(SOF_IPC_PANIC_WFI);
+
+	arch_wait_for_interrupt(level);
+}

--- a/src/platform/imx8/include/platform/platform.h
+++ b/src/platform/imx8/include/platform/platform.h
@@ -12,9 +12,6 @@
 
 #if !defined(__ASSEMBLER__) && !defined(LINKER)
 
-#include <arch/lib/wait.h>
-#include <sof/drivers/interrupt.h>
-#include <sof/lib/clk.h>
 #include <sof/drivers/mu.h>
 #include <sof/lib/mailbox.h>
 #include <stddef.h>
@@ -80,10 +77,7 @@ static inline void platform_panic(uint32_t p)
  * May be power-optimized using platform specific capabilities.
  * @param level Interrupt level.
  */
-static inline void platform_wait_for_interrupt(int level)
-{
-	arch_wait_for_interrupt(level);
-}
+void platform_wait_for_interrupt(int level);
 
 extern intptr_t _module_init_start;
 extern intptr_t _module_init_end;

--- a/src/platform/imx8/platform.c
+++ b/src/platform/imx8/platform.c
@@ -221,3 +221,10 @@ int platform_context_save(struct sof *sof)
 {
 	return 0;
 }
+
+#ifndef __ZEPHYR__
+void platform_wait_for_interrupt(int level)
+{
+	arch_wait_for_interrupt(level);
+}
+#endif

--- a/src/platform/imx8m/include/platform/platform.h
+++ b/src/platform/imx8m/include/platform/platform.h
@@ -12,8 +12,6 @@
 
 #if !defined(__ASSEMBLER__) && !defined(LINKER)
 
-#include <arch/lib/wait.h>
-#include <sof/drivers/interrupt.h>
 #include <sof/lib/clk.h>
 #include <sof/lib/mailbox.h>
 #include <stddef.h>
@@ -69,10 +67,7 @@ static inline void platform_panic(uint32_t p)
  * May be power-optimized using platform specific capabilities.
  * @param level Interrupt level.
  */
-static inline void platform_wait_for_interrupt(int level)
-{
-	arch_wait_for_interrupt(level);
-}
+void platform_wait_for_interrupt(int level);
 
 extern intptr_t _module_init_start;
 extern intptr_t _module_init_end;

--- a/src/platform/imx8m/platform.c
+++ b/src/platform/imx8m/platform.c
@@ -221,3 +221,10 @@ int platform_context_save(struct sof *sof)
 {
 	return 0;
 }
+
+#ifndef __ZEPHYR__
+void platform_wait_for_interrupt(int level)
+{
+	arch_wait_for_interrupt(level);
+}
+#endif

--- a/src/platform/imx8ulp/include/platform/platform.h
+++ b/src/platform/imx8ulp/include/platform/platform.h
@@ -12,9 +12,6 @@
 
 #if !defined(__ASSEMBLER__) && !defined(LINKER)
 
-#include <arch/lib/wait.h>
-#include <sof/drivers/interrupt.h>
-#include <sof/lib/clk.h>
 #include <sof/drivers/mu.h>
 #include <sof/lib/mailbox.h>
 #include <stddef.h>
@@ -80,10 +77,7 @@ static inline void platform_panic(uint32_t p)
  * May be power-optimized using platform specific capabilities.
  * @param level Interrupt level.
  */
-static inline void platform_wait_for_interrupt(int level)
-{
-	arch_wait_for_interrupt(level);
-}
+void platform_wait_for_interrupt(int level);
 
 extern intptr_t _module_init_start;
 extern intptr_t _module_init_end;

--- a/src/platform/imx8ulp/platform.c
+++ b/src/platform/imx8ulp/platform.c
@@ -207,3 +207,10 @@ int platform_context_save(struct sof *sof)
 {
 	return 0;
 }
+
+#ifndef __ZEPHYR__
+void platform_wait_for_interrupt(int level)
+{
+	arch_wait_for_interrupt(level);
+}
+#endif

--- a/src/platform/intel/cavs/boot_loader.c
+++ b/src/platform/intel/cavs/boot_loader.c
@@ -10,7 +10,7 @@
 #include <sof/lib/io.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/shim.h>
-#include <sof/lib/wait.h>
+#include <rtos/wait.h>
 #include <sof/platform.h>
 #include <sof/sof.h>
 #include <sof/trace/trace.h>

--- a/src/platform/intel/cavs/include/cavs/lib/pm_memory.h
+++ b/src/platform/intel/cavs/include/cavs/lib/pm_memory.h
@@ -14,12 +14,13 @@
 #ifndef __CAVS_LIB_PM_MEMORY_H__
 #define __CAVS_LIB_PM_MEMORY_H__
 
+#include <sof/platform.h>
 #include <cavs/version.h>
 #include <rtos/bit.h>
 #include <sof/lib/io.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/shim.h>
-#include <sof/lib/wait.h>
+#include <rtos/wait.h>
 #include <sof/math/numbers.h>
 
 #include <stdbool.h>

--- a/src/platform/intel/cavs/lib/pm_runtime.c
+++ b/src/platform/intel/cavs/lib/pm_runtime.c
@@ -23,7 +23,7 @@
 #include <sof/lib/pm_runtime.h>
 #include <sof/lib/shim.h>
 #include <sof/lib/uuid.h>
-#include <sof/lib/wait.h>
+#include <rtos/wait.h>
 #include <sof/platform.h>
 #include <rtos/spinlock.h>
 #include <sof/trace/trace.h>

--- a/src/platform/intel/cavs/lps_wait.c
+++ b/src/platform/intel/cavs/lps_wait.c
@@ -4,7 +4,7 @@
 //
 // Author: Marcin Maka <marcin.maka@linux.intel.com>
 
-#include <arch/lib/wait.h>
+#include <rtos/wait.h>
 #include <cavs/lps_ctx.h>
 #include <cavs/lps_wait.h>
 #include <cavs/mem_window.h>

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -33,7 +33,7 @@
 #include <sof/lib/mm_heap.h>
 #include <sof/lib/notifier.h>
 #include <sof/lib/pm_runtime.h>
-#include <sof/lib/wait.h>
+#include <rtos/wait.h>
 #include <sof/platform.h>
 #include <sof/schedule/edf_schedule.h>
 #include <sof/schedule/ll_schedule.h>

--- a/src/platform/library/include/platform/platform.h
+++ b/src/platform/library/include/platform/platform.h
@@ -11,7 +11,7 @@
 #ifndef __PLATFORM_PLATFORM_H__
 #define __PLATFORM_PLATFORM_H__
 
-#include <arch/lib/wait.h>
+#include <rtos/wait.h>
 #include <sof/lib/clk.h>
 #include <sof/lib/mailbox.h>
 #include <stdint.h>
@@ -63,10 +63,8 @@ static inline void platform_panic(uint32_t p) {}
  * May be power-optimized using platform specific capabilities.
  * @param level Interrupt level.
  */
-static inline void platform_wait_for_interrupt(int level)
-{
-	arch_wait_for_interrupt(level);
-}
+static inline void platform_wait_for_interrupt(int level) {}
+
 
 static inline int ipc_platform_send_msg(const struct ipc_msg *msg) { return 0; }
 

--- a/src/platform/library/schedule/edf_schedule.c
+++ b/src/platform/library/schedule/edf_schedule.c
@@ -8,7 +8,7 @@
 #include <sof/schedule/task.h>
 #include <stdint.h>
 #include <sof/schedule/edf_schedule.h>
-#include <sof/lib/wait.h>
+#include <rtos/wait.h>
 #include <stdlib.h>
 
  /* scheduler testbench definition */

--- a/src/platform/library/schedule/ll_schedule.c
+++ b/src/platform/library/schedule/ll_schedule.c
@@ -11,7 +11,7 @@
 #include <sof/schedule/schedule.h>
 #include <sof/schedule/ll_schedule.h>
 #include <sof/schedule/ll_schedule_domain.h>
-#include <sof/lib/wait.h>
+#include <rtos/wait.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>

--- a/src/platform/library/schedule/schedule.c
+++ b/src/platform/library/schedule/schedule.c
@@ -10,7 +10,7 @@
 #include <sof/audio/component.h>
 #include <sof/schedule/task.h>
 #include <stdint.h>
-#include <sof/lib/wait.h>
+#include <rtos/wait.h>
 #include <stdlib.h>
 
 static struct schedulers *testbench_schedulers_ptr; /* Initialized as NULL */

--- a/src/platform/mt8186/include/platform/platform.h
+++ b/src/platform/mt8186/include/platform/platform.h
@@ -12,9 +12,6 @@
 
 #if !defined(__ASSEMBLER__) && !defined(LINKER)
 
-#include <arch/lib/wait.h>
-#include <sof/drivers/interrupt.h>
-#include <sof/lib/clk.h>
 #include <sof/lib/mailbox.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -79,10 +76,7 @@ static inline void platform_panic(uint32_t p)
  * May be power-optimized using platform specific capabilities.
  * @param level Interrupt level.
  */
-static inline void platform_wait_for_interrupt(int level)
-{
-	arch_wait_for_interrupt(level);
-}
+void platform_wait_for_interrupt(int level);
 
 extern intptr_t _module_init_start;
 extern intptr_t _module_init_end;

--- a/src/platform/mt8186/platform.c
+++ b/src/platform/mt8186/platform.c
@@ -216,3 +216,9 @@ int platform_context_save(struct sof *sof)
 {
 	return 0;
 }
+
+void platform_wait_for_interrupt(int level)
+{
+	arch_wait_for_interrupt(level);
+}
+

--- a/src/platform/mt8195/include/platform/platform.h
+++ b/src/platform/mt8195/include/platform/platform.h
@@ -11,9 +11,6 @@
 
 #if !defined(__ASSEMBLER__) && !defined(LINKER)
 
-#include <arch/lib/wait.h>
-#include <sof/drivers/interrupt.h>
-#include <sof/lib/clk.h>
 #include <sof/lib/mailbox.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -79,10 +76,7 @@ static inline void platform_panic(uint32_t p)
  * May be power-optimized using platform specific capabilities.
  * @param level Interrupt level.
  */
-static inline void platform_wait_for_interrupt(int level)
-{
-	arch_wait_for_interrupt(level);
-}
+void platform_wait_for_interrupt(int level);
 
 extern intptr_t _module_init_start;
 extern intptr_t _module_init_end;

--- a/src/platform/mt8195/lib/clk.c
+++ b/src/platform/mt8195/lib/clk.c
@@ -10,7 +10,7 @@
 #include <sof/lib/memory.h>
 #include <sof/lib/notifier.h>
 #include <sof/lib/uuid.h>
-#include <sof/lib/wait.h>
+#include <rtos/wait.h>
 #include <sof/sof.h>
 #include <rtos/spinlock.h>
 

--- a/src/platform/mt8195/platform.c
+++ b/src/platform/mt8195/platform.c
@@ -230,3 +230,8 @@ int platform_context_save(struct sof *sof)
 {
 	return 0;
 }
+
+void platform_wait_for_interrupt(int level)
+{
+	arch_wait_for_interrupt(level);
+}

--- a/src/samples/audio/detect_test.c
+++ b/src/samples/audio/detect_test.c
@@ -17,7 +17,7 @@
 #include <sof/lib/alloc.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/notifier.h>
-#include <sof/lib/wait.h>
+#include <rtos/wait.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
 #include <sof/math/numbers.h>

--- a/src/samples/audio/kwd_nn_detect_test.c
+++ b/src/samples/audio/kwd_nn_detect_test.c
@@ -11,7 +11,7 @@
 #include <sof/samples/audio/kwd_nn/kwd_nn_process.h>
 #include <sof/samples/audio/detect_test.h>
 #include <sof/audio/component.h>
-#include <sof/lib/wait.h>
+#include <rtos/wait.h>
 #include <stdint.h>
 
 static __aligned(64) uint8_t preprocessed_data[KWD_NN_CONFIG_PREPROCESSED_SIZE];

--- a/src/schedule/task.c
+++ b/src/schedule/task.c
@@ -17,7 +17,7 @@
 #include <sof/lib/cpu.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
-#include <sof/lib/wait.h>
+#include <rtos/wait.h>
 #include <sof/platform.h>
 #include <sof/schedule/edf_schedule.h>
 #include <sof/schedule/schedule.h>

--- a/test/cmocka/src/common_mocks.c
+++ b/test/cmocka/src/common_mocks.c
@@ -19,7 +19,7 @@
 #include <sof/audio/component_ext.h>
 #include <sof/lib/clk.h>
 #include <sof/lib/notifier.h>
-#include <sof/lib/wait.h>
+#include <rtos/wait.h>
 #include <arch/lib/cpu.h>
 #include <stdlib.h>
 #include <stdarg.h>

--- a/tools/testbench/common_test.c
+++ b/tools/testbench/common_test.c
@@ -22,7 +22,7 @@
 #include <sof/schedule/ll_schedule.h>
 #include <sof/schedule/ll_schedule_domain.h>
 #include <sof/schedule/schedule.h>
-#include <sof/lib/wait.h>
+#include <rtos/wait.h>
 #include <sof/audio/pipeline.h>
 #include "testbench/common_test.h"
 #include "testbench/trace.h"

--- a/xtos/include/rtos/kernel.h
+++ b/xtos/include/rtos/kernel.h
@@ -8,7 +8,7 @@
 #ifndef __XTOS_RTOS_KERNEL_H__
 #define __XTOS_RTOS_KERNEL_H__
 
-#include <sof/lib/wait.h>
+#include <rtos/wait.h>
 
 #include <stdint.h>
 

--- a/xtos/include/rtos/wait.h
+++ b/xtos/include/rtos/wait.h
@@ -9,17 +9,19 @@
  * Simple wait for event completion and signaling with timeouts.
  */
 
-#ifndef __SOF_LIB_WAIT_H__
-#define __SOF_LIB_WAIT_H__
+#ifndef __XTOS_RTOS_WAIT_H__
+#define __XTOS_RTOS_WAIT_H__
 
+#include <stddef.h>
+#include <stdint.h>
+
+#if !CONFIG_LIBRARY
 #include <arch/lib/wait.h>
+#include <sof/drivers/interrupt.h>
 #include <sof/drivers/timer.h>
 #include <rtos/spinlock.h>
 #include <sof/trace/trace.h>
 #include <user/trace.h>
-
-#include <stddef.h>
-#include <stdint.h>
 
 extern struct tr_ctx wait_tr;
 
@@ -36,7 +38,6 @@ static inline void wait_for_interrupt(int level)
 	tr_dbg(&wait_tr, "WFX");
 }
 
-#if !CONFIG_LIBRARY
 /**
  * \brief Waits at least passed number of clocks.
  * \param[in] number_of_clks Minimum number of clocks to wait.
@@ -63,4 +64,4 @@ static inline void wait_delay_us(uint64_t us) {}
 int poll_for_register_delay(uint32_t reg, uint32_t mask,
 			    uint32_t val, uint64_t us);
 
-#endif /* __SOF_LIB_WAIT_H__ */
+#endif /* __XTOS_RTOS_WAIT_H__ */

--- a/xtos/include/sof/drivers/timer.h
+++ b/xtos/include/sof/drivers/timer.h
@@ -9,6 +9,7 @@
 #define __SOF_DRIVERS_TIMER_H__
 
 #include <arch/drivers/timer.h>
+#include <sof/lib/clk.h>
 #include <sof/lib/cpu.h>
 #include <sof/sof.h>
 #include <sof/platform.h>

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -541,7 +541,6 @@ zephyr_library_sources(
 	${SOF_LIB_PATH}/clk.c
 	${SOF_LIB_PATH}/notifier.c
 	${SOF_LIB_PATH}/pm_runtime.c
-	${SOF_LIB_PATH}/wait.c
 	${SOF_LIB_PATH}/dma.c
 	${SOF_LIB_PATH}/dai.c
 

--- a/zephyr/edf_schedule.c
+++ b/zephyr/edf_schedule.c
@@ -8,7 +8,7 @@
 #include <sof/schedule/task.h>
 #include <stdint.h>
 #include <sof/schedule/edf_schedule.h>
-#include <sof/lib/wait.h>
+#include <rtos/wait.h>
 
 #include <zephyr/kernel.h>
 #include <zephyr/sys_clock.h>

--- a/zephyr/include/rtos/wait.h
+++ b/zephyr/include/rtos/wait.h
@@ -1,0 +1,54 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2022 Intel Corporation. All rights reserved.
+ *
+ * Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
+ */
+
+#ifndef __ZEPHYR_RTOS_WAIT_H__
+#define __ZEPHYR_RTOS_WAIT_H__
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <zephyr/kernel.h>
+
+/* TODO: use equivalent Zephyr */
+static inline void idelay(int n)
+{
+	while (n--)
+		asm volatile("nop");
+}
+
+/* DSP default delay in cycles - all platforms use this today */
+#define PLATFORM_DEFAULT_DELAY	12
+
+static inline void wait_delay(uint64_t number_of_clks)
+{
+	uint64_t timeout = k_cycle_get_64() + number_of_clks;
+
+	while (k_cycle_get_64() < timeout)
+		idelay(PLATFORM_DEFAULT_DELAY);
+}
+
+static inline void wait_delay_ms(uint64_t ms)
+{
+	wait_delay(k_ms_to_cyc_ceil64(ms));
+}
+
+static inline void wait_delay_us(uint64_t us)
+{
+	wait_delay(k_us_to_cyc_ceil64(us));
+}
+
+int poll_for_register_delay(uint32_t reg, uint32_t mask,
+			    uint32_t val, uint64_t us);
+
+/* TODO: this is tmp used by some IMX IPC drivers that have not transitioned
+ * to Zephyr. To be removed after drivers migrated to Zephyr. It's xtensa only too.
+ */
+static inline void wait_for_interrupt(int level)
+{
+	asm volatile("waiti 0");
+}
+
+#endif /* __ZEPHYR_RTOS_WAIT_H__ */


### PR DESCRIPTION
Code can now include <rtos/wait.h> and uses native Zephyr 64
cycle API instead of SOF version.

Signed-off-by: Liam Girdwood <liam.r.girdwood@linux.intel.com>