### PR TITLE
Enable CPP code build in SOF project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ endif()
 
 include(scripts/cmake/misc.cmake)
 
-project(SOF C ASM)
+project(SOF C CXX ASM)
 
 # intended to be used where PROJECT_* variables are not set
 # for example in standalone scripts like version.cmake

--- a/scripts/cmake/xtensa-platform.cmake
+++ b/scripts/cmake/xtensa-platform.cmake
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 set(CMAKE_C_OUTPUT_EXTENSION ".o")
+set(CMAKE_CXX_OUTPUT_EXTENSION ".o")
 set(CMAKE_ASM_OUTPUT_EXTENSION ".o")

--- a/scripts/cmake/xtensa-toolchain.cmake
+++ b/scripts/cmake/xtensa-toolchain.cmake
@@ -42,6 +42,9 @@ set(CMAKE_C_COMPILER_FORCED 1)
 set(CMAKE_ASM_COMPILER_ID GNU)
 set(CMAKE_C_COMPILER_ID GNU)
 
+set(CMAKE_CXX_STANDARD 98)
+set(CMAKE_CXX_FLAGS "$$(CMAKE_C_FLAGS) -fno-exceptions -fno-rtti -g2")
+
 # in case if *_FORCED variables are ignored,
 # try to just compile lib instead of executable
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
@@ -50,8 +53,10 @@ set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 if(TOOLCHAIN STREQUAL "xt")
 	set(XCC 1)
 	set(CMAKE_C_COMPILER ${CROSS_COMPILE}xcc)
+	set(CMAKE_CXX_COMPILER ${CROSS_COMPILE}xc++)
 else()
 	set(CMAKE_C_COMPILER ${CROSS_COMPILE}gcc)
+	set(CMAKE_CXX_COMPILER ${CROSS_COMPILE}g++)
 endif()
 
 find_program(CMAKE_LD NAMES "${CROSS_COMPILE}ld" PATHS ENV PATH NO_DEFAULT_PATH)


### PR DESCRIPTION
Part of IADK module adapter code is written in CPP to
interface with IADK origin binaries.
CPP code compilation need to be enabled to build this code.

Signed-off-by: Jaroslaw Stelter <Jaroslaw.Stelter@intel.com>