### PR TITLE
Drivers: DMIC: Fix risk for overflow in unmute ramp calculation

### DIFF
--- a/src/include/sof/drivers/dmic.h
+++ b/src/include/sof/drivers/dmic.h
@@ -563,10 +563,10 @@ extern const struct dai_driver dmic_driver;
 
 static inline int dmic_get_unmute_ramp_from_samplerate(int rate)
 {
-	int time_ms;
+	int32_t time_ms;
 
-	time_ms = Q_MULTSR_32X32((int32_t)rate, LOGRAMP_TIME_COEF_Q15, 0, 15, 0) +
-		LOGRAMP_TIME_OFFS_Q0;
+	time_ms = sat_int32(Q_MULTSR_32X32((int64_t)rate, LOGRAMP_TIME_COEF_Q15, 0, 15, 0) +
+		LOGRAMP_TIME_OFFS_Q0);
 	if (time_ms > LOGRAMP_TIME_MAX_MS)
 		return LOGRAMP_TIME_MAX_MS;
 


### PR DESCRIPTION
This patch adds cast to int64_t for the multiplication and adds 32 bit
saturation to ensure overflow of the product is not possible.

This function is used to calculate ramp time in IPC4 NHLT blob mode
where the time is not passed from topology. Currently rates up to
48 kHz remain under product int32_t range, so normally there is no
issue. However 96 kHz rate would always result to incorrect
LOGRAMP_TIME_MIN_MS (10 ms).

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>