### PR TITLE
module_adapter: Modify reset API

### DIFF
--- a/src/audio/module_adapter/module/cadence.c
+++ b/src/audio/module_adapter/module/cadence.c
@@ -653,7 +653,6 @@ cadence_codec_process(struct processing_module *mod,
 
 static int cadence_codec_reset(struct processing_module *mod)
 {
-	struct comp_dev *dev = mod->dev;
 	struct module_data *codec = &mod->priv;
 	struct cadence_codec_data *cd = codec->private;
 	int ret;
@@ -674,12 +673,6 @@ static int cadence_codec_reset(struct processing_module *mod)
 
 	rfree(cd->self);
 	cd->self = NULL;
-
-	ret = cadence_codec_prepare(mod);
-	if (ret) {
-		comp_err(dev, "cadence_codec_reset() error %x: could not re-prepare codec after reset",
-			ret);
-	}
 
 	return ret;
 }

--- a/src/audio/module_adapter/module/generic.c
+++ b/src/audio/module_adapter/module/generic.c
@@ -280,10 +280,11 @@ int module_reset(struct processing_module *mod)
 	md->cfg.size = 0;
 	rfree(md->cfg.data);
 
-	/* module resets itself to the initial condition after prepare()
-	 * so let's change its state to reflect that.
+	/*
+	 * reset the state to allow the module's prepare callback to be invoked again for the
+	 * subsequent triggers
 	 */
-	md->state = MODULE_IDLE;
+	md->state = MODULE_INITIALIZED;
 
 	return 0;
 }

--- a/src/audio/module_adapter/module/passthrough.c
+++ b/src/audio/module_adapter/module/passthrough.c
@@ -96,22 +96,20 @@ passthrough_codec_process(struct processing_module *mod,
 
 static int passthrough_codec_reset(struct processing_module *mod)
 {
+	struct module_data *codec = &mod->priv;
+
 	comp_info(mod->dev, "passthrough_codec_reset()");
 
-	/* nothing to do */
+	rfree(codec->mpd.in_buff);
+	rfree(codec->mpd.out_buff);
 	return 0;
 }
 
 static int passthrough_codec_free(struct processing_module *mod)
 {
-	struct comp_dev *dev = mod->dev;
-	struct module_data *codec = &mod->priv;
-
 	comp_info(dev, "passthrough_codec_free()");
 
-	rfree(codec->mpd.in_buff);
-	rfree(codec->mpd.out_buff);
-
+	/* Nothing to do */
 	return 0;
 }
 

--- a/src/include/sof/audio/module_adapter/module/module_interface.h
+++ b/src/include/sof/audio/module_adapter/module/module_interface.h
@@ -133,12 +133,12 @@ struct module_interface {
 	/**
 	 * Module specific reset procedure, called as part of module_adapter component
 	 * reset in .reset(). This should reset all parameters to their initial stage
-	 * but leave allocated memory intact.
+	 * and free all memory allocated during prepare().
 	 */
 	int (*reset)(struct processing_module *mod);
 	/**
 	 * Module specific free procedure, called as part of module_adapter component
-	 * free in .free(). This should free all memory allocated by module.
+	 * free in .free(). This should free all memory allocated during module initialization.
 	 */
 	int (*free)(struct processing_module *mod);
 };


### PR DESCRIPTION
Modify the definition of the reset API in the module adapter interface
to make sure that it should reset the module state back to
MODULE_INITIALIZED and free all memory that was allocated during the
prepare() callback. With this change, stopping and restarting streams
will always be guaranteed to invoke the module's prepare() callback.
Also, fix the passthrough and cadence codec implementation to follow the
new definition.

Fixes #6034 