### PR TITLE
test/tplg-build.sh: remove spurious xargs -n1 option

### DIFF
--- a/tools/test/topology/tplg-build.sh
+++ b/tools/test/topology/tplg-build.sh
@@ -311,10 +311,11 @@ then
 		$shell_name
 
 	#execute alsatplg to create topology binary
+	# $TEST_STRINGS is a very long line of comma-delimited filenames.
 	printf '%s generating %s/*.tplg files with alsatplg...\n' \
 		"$0" "$BUILD_OUTPUT"
 	TEST_STRINGS=${TEST_STRINGS%?}
 	echo $TEST_STRINGS | tr '\n' ',' |
-		xargs ${VERBOSE:+-t} -d ',' -P${NO_PROCESSORS} -n1 -I string \
+		xargs ${VERBOSE:+-t} -d ',' -P${NO_PROCESSORS} -I string \
 		    alsatplg ${VERBOSE:+-v 1} -c string".conf" -o string".tplg"
 fi


### PR DESCRIPTION
The xargs option `-I/--replace` hardcodes max lines `-L 1`. In other
words, it always splits the input line by line and ignores whitespace
delimiters inside each line. Initial xargs commit
d0f4aba9340d9 ("topology: speed up topology build") used `--replace`
after `-n/--max-args=1` which was silently ignored by xargs version
4.7.0. Now xargs 4.8.0 prints the following warning:

  xargs: warning: options --max-args and --replace/-I/-i are mutually
        exclusive, ignoring previous --max-args value

Remove the ignored `-n 1` to remove the warning.

I compared the outputs before and after this commit and they're exactly
the same.

There's an extra twist. The same xargs command also uses the
`-d/--delimiter=,` option which makes xargs ignore newlines and
"translates" any max-line `-L` option to `--max-args`; including the `-L
1` max implied by `--replace`. This twist does not make a difference:
any max-line or max-args is always overridden by `--replace` whether
`--delimiter` is used or not.

Of course this entire xargs script is re-inventing (C)Make/ninja that
provide build parallelism for free and much more... I digress.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>