### PR TITLE
IPC4: fix ipc_send_queued_msg() logic

### DIFF
--- a/src/include/sof/ipc/common.h
+++ b/src/include/sof/ipc/common.h
@@ -65,6 +65,9 @@ struct ipc {
 	/* processing task */
 	struct task ipc_task;
 
+	/* task for flushing outbound messages */
+	struct task ipc_tx_task;
+
 	void *private;
 };
 

--- a/src/ipc/ipc-common.c
+++ b/src/ipc/ipc-common.c
@@ -14,6 +14,7 @@
 #include <sof/ipc/common.h>
 #include <sof/ipc/msg.h>
 #include <sof/ipc/driver.h>
+#include <sof/schedule/ll_schedule.h>
 #include <sof/ipc/schedule.h>
 #include <sof/lib/alloc.h>
 #include <sof/lib/cache.h>
@@ -168,6 +169,9 @@ void ipc_send_queued_msg(void)
 
 	key = k_spin_lock(&ipc->lock);
 
+	if (ipc->pm_prepare_D3)
+		goto out;
+
 	/* any messages to send ? */
 	if (list_is_empty(&ipc->msg_list))
 		goto out;
@@ -212,6 +216,8 @@ void ipc_msg_send(struct ipc_msg *msg, void *data, bool high_priority)
 			list_item_append(&msg->list, &ipc->msg_list);
 	}
 
+	schedule_task(&ipc->ipc_tx_task, IPC_PERIOD_USEC, IPC_PERIOD_USEC);
+
 out:
 	k_spin_unlock(&ipc->lock, key);
 }
@@ -219,6 +225,25 @@ out:
 void ipc_schedule_process(struct ipc *ipc)
 {
 	schedule_task(&ipc->ipc_task, 0, IPC_PERIOD_USEC);
+}
+
+static enum task_state ipc_tx_task_run(void *data)
+{
+	struct ipc *ipc = data;
+	enum task_state ret = SOF_TASK_STATE_RESCHEDULE;
+	k_spinlock_key_t key;
+
+	ipc_send_queued_msg();
+
+	key = k_spin_lock(&ipc->lock);
+
+	if (ipc->pm_prepare_D3 ||
+	    list_is_empty(&ipc->msg_list))
+		ret = SOF_TASK_STATE_COMPLETED;
+
+	k_spin_unlock(&ipc->lock, key);
+
+	return ret;
 }
 
 int ipc_init(struct sof *sof)
@@ -233,6 +258,10 @@ int ipc_init(struct sof *sof)
 	k_spinlock_init(&sof->ipc->lock);
 	list_init(&sof->ipc->msg_list);
 	list_init(&sof->ipc->comp_list);
+
+	schedule_task_init_ll(&sof->ipc->ipc_tx_task, SOF_UUID(ipc_uuid),
+			      SOF_SCHEDULE_LL_TIMER, SOF_TASK_PRI_MED,
+			      ipc_tx_task_run, sof->ipc, 0, 0);
 
 	return platform_ipc_init(sof->ipc);
 }

--- a/src/schedule/task.c
+++ b/src/schedule/task.c
@@ -49,16 +49,10 @@ static uint64_t task_main_deadline(void *data)
 
 enum task_state task_main_primary_core(void *data)
 {
-	struct ipc *ipc = ipc_get();
-
 	/* main audio processing loop */
 	while (1) {
 		/* sleep until next IPC or DMA */
 		wait_for_interrupt(0);
-
-		if (!ipc->pm_prepare_D3)
-			ipc_send_queued_msg();
-
 	}
 
 	return SOF_TASK_STATE_COMPLETED;


### PR DESCRIPTION
Fix issues with ipc_send_queued_msg() both in generic IPC4 code, as well as a seperate problem in Zephyr SOF builds.

FYI @bardliao  @abonislawski @marcinszkudlinski 