### PR TITLE
library manager: fix outdated include path

### DIFF
--- a/src/library_manager/lib_manager.c
+++ b/src/library_manager/lib_manager.c
@@ -15,7 +15,7 @@
 #include <sof/ipc/topology.h>
 
 #include <sof/sof.h>
-#include <sof/spinlock.h>
+#include <rtos/spinlock.h>
 #include <sof/lib_manager.h>
 #include <sof/audio/module_adapter/module/generic.h>
 


### PR DESCRIPTION
Fix spinlock.h include path as in 1629a1f72c7b4c9f203dabbb83d361fbf2b5b9c5

Signed-off-by: Krzysztof Frydryk <krzysztofx.frydryk@intel.com>