### PR TITLE
mixin: fix asynchronous pipeline termination

### DIFF
--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -670,8 +670,12 @@ static int copier_comp_trigger(struct comp_dev *dev, int cmd)
 
 	dai_copier = pipeline_get_dai_comp_latency(dev->pipeline->pipeline_id, &latency);
 	if (!dai_copier) {
-		comp_err(dev, "failed to find dai comp or sink pipeline not running.");
-		return ret;
+		/*
+		 * Can happen if the DAI pipeline has already stopped but the
+		 * host pipeline is still running
+		 */
+		comp_dbg(dev, "failed to find dai comp or sink pipeline not running.");
+		return 0;
 	}
 
 	dai_cd = comp_get_drvdata(dai_copier);

--- a/src/audio/mixin_mixout.c
+++ b/src/audio/mixin_mixout.c
@@ -704,10 +704,15 @@ static int mixin_copy(struct comp_dev *dev)
 		mixed_data_info = mixed_data_info_acquire(mixout_data->mixed_data_info);
 		src_info = find_mixout_source_info(mixed_data_info, dev);
 		if (!src_info) {
-			comp_err(dev, "No source info");
+			/*
+			 * This can happen if the mixout pipeline has already
+			 * been stopped and its reset has cleared its source
+			 * info array.
+			 */
+			comp_dbg(dev, "No source info");
 			mixed_data_info_release(mixed_data_info);
 			buffer_release(source_c);
-			return -EINVAL;
+			return 0;
 		}
 
 		sink_c = buffer_acquire(sink);

--- a/src/audio/mixin_mixout.c
+++ b/src/audio/mixin_mixout.c
@@ -205,7 +205,7 @@ static struct comp_dev *mixout_new(const struct comp_driver *drv,
 
 	memcpy_s(&md->base_cfg, sizeof(md->base_cfg), spec, sizeof(md->base_cfg));
 
-	md->mixed_data_info = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM,
+	md->mixed_data_info = rzalloc(SOF_MEM_ZONE_RUNTIME_SHARED, 0, SOF_MEM_CAPS_RAM,
 				      sizeof(struct mixed_data_info));
 	if (!md->mixed_data_info) {
 		rfree(md);

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -174,8 +174,11 @@ void *rmalloc(enum mem_zone zone, uint32_t flags, uint32_t caps, size_t bytes)
 		ptr = (__sparse_force void *)heap_alloc_aligned_cached(&sof_heap, 0, bytes);
 	} else {
 		/*
-		 * XTOS alloc implementation has used dcache alignment,
-		 * so SOF application code is expecting this behaviour.
+		 * XTOS alloc implementation has used dcache alignment, so SOF
+		 * application code is expecting this behaviour. Besides, when
+		 * using memory with the coherent API, we will force cache
+		 * invalidation and writeback accordingly, so we must take care
+		 * not to corrupt adjacent memory from the same cache line.
 		 */
 		ptr = heap_alloc_aligned(&sof_heap, PLATFORM_DCACHE_ALIGN, bytes);
 	}


### PR DESCRIPTION
fix a case, when one of the two linked pipelines has terminated and the other one is still copying