### PR TITLE
detect_test: add ipc4 support

### DIFF
--- a/src/include/ipc4/detect_test.h
+++ b/src/include/ipc4/detect_test.h
@@ -1,0 +1,35 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2022 Intel Corporation. All rights reserved.
+ *
+ * Author: Ievgen Ganakov <ievgen.ganakov@intel.com>
+ */
+
+/**
+ * \file include/ipc4/detect_test.h
+ * \brief KD module definitions.
+ * NOTE: This ABI uses bit fields and is non portable.
+ */
+
+#ifndef __SOF_IPC4_DETECT_TEST_H__
+#define __SOF_IPC4_DETECT_TEST_H__
+
+enum ipc4_detect_test_module_config_params {
+	/* Use LARGE_CONFIG_SET to process model blob. Ipc mailbox must
+	 * contain properly configured BLOB for Detect Keyword module.
+	 */
+	IPC4_DETECT_TEST_SET_MODEL_BLOB = 1,
+
+	/* Use LARGE_CONFIG_SET to set Detect Keyword module parameters.
+	 * Ipc mailbox must contain properly built sof_detect_test_config
+	 * struct.
+	 */
+	IPC4_DETECT_TEST_SET_CONFIG = 2,
+
+	/* Use LARGE_CONFIG_GET to retrieve Detect Test config
+	 * Ipc mailbox must contain properly built sof_detect_test_config
+	 * struct.
+	 */
+	IPC4_DETECT_TEST_GET_CONFIG = 3
+};
+#endif

--- a/src/include/sof/audio/data_blob.h
+++ b/src/include/sof/audio/data_blob.h
@@ -76,6 +76,19 @@ int comp_data_blob_set_cmd(struct comp_data_blob_handler *blob_handler,
 int comp_data_blob_set(struct comp_data_blob_handler *blob_handler,
 		       enum module_cfg_fragment_position pos, uint32_t data_offset_size,
 		       const uint8_t *fragment, size_t fragment_size);
+
+/**
+ * Handles IPC4 set large config.
+ *
+ * @param blob_handler: Data blob handler
+ * @param first_block: Flag indicates it is a first block of data
+ * @param last_block: Flag indicates it is a last block of data
+ * @param data_offset: Size/offset of the data being sent
+ * @param data: Pointer to the data array
+ */
+int ipc4_comp_data_blob_set(struct comp_data_blob_handler *blob_handler,
+			    bool first_block, bool last_block,
+			    uint32_t data_offset, char *data);
 /**
  * Handles IPC get command.
  * @param blob_handler Data blob handler

--- a/src/include/sof/samples/audio/detect_test.h
+++ b/src/include/sof/samples/audio/detect_test.h
@@ -14,6 +14,26 @@
 #define SOF_DETECT_TEST_CONFIG	0
 #define SOF_DETECT_TEST_MODEL	1
 
+#ifdef CONFIG_IPC_MAJOR_4
+struct sof_detect_test_config {
+	struct ipc4_base_module_cfg base;
+
+	/** synthetic system load settings */
+	uint32_t load_mips;
+
+	/** time in ms after which detection is activated */
+	uint32_t preamble_time;
+
+	/** activation right shift, determines the speed of activation */
+	uint32_t activation_shift;
+
+	/** activation threshold */
+	uint32_t activation_threshold;
+
+	/** default draining size in bytes */
+	uint32_t drain_req;
+} __packed __aligned(4);
+#else /* CONFIG_IPC_MAJOR_4 */
 struct sof_detect_test_config {
 	uint32_t size;
 
@@ -37,7 +57,8 @@ struct sof_detect_test_config {
 
 	/** reserved for future use */
 	uint32_t reserved[1];
-} __attribute__((packed));
+} __packed;
+#endif /* CONFIG_IPC_MAJOR_4 */
 
 uint16_t test_keyword_get_sample_valid_bytes(struct comp_dev *dev);
 


### PR DESCRIPTION
Add ipc4 support for KD module keeping ipc3
backward compatibility. Add ipc4 model blob
handler based on large_config_set architecture

Signed-off-by: Ievgen Ganakov <ievgen.ganakov@intel.com>