### PR TITLE
Audio: TDFB: Fix suspicious looking Q_MULTSR_32X32 macro usage

### DIFF
--- a/src/audio/tdfb/tdfb.c
+++ b/src/audio/tdfb/tdfb.c
@@ -806,7 +806,7 @@ static int tdfb_prepare(struct comp_dev *dev)
 	/* The max. amount of processing need to be limited for sound direction
 	 * processing. Max frames is used in tdfb_direction_init() and copy().
 	 */
-	cd->max_frames = Q_MULTSR_32X32(dev->frames, TDFB_MAX_FRAMES_MULT_Q14, 0, 14, 0);
+	cd->max_frames = Q_MULTSR_16X16((int32_t)dev->frames, TDFB_MAX_FRAMES_MULT_Q14, 0, 14, 0);
 	comp_info(dev, "dev_frames = %d, max_frames = %d", dev->frames, cd->max_frames);
 
 	/* Initialize tracking */

--- a/src/include/sof/audio/format.h
+++ b/src/include/sof/audio/format.h
@@ -79,6 +79,18 @@
 #define Q_SHIFT_LEFT(x, src_q, dst_q) ((x) << ((dst_q) - (src_q)))
 
 /* Fractional multiplication with shift
+ * Note that the parameters px and py must be cast to (int32_t) if other type.
+ */
+#define Q_MULTS_16X16(px, py, qx, qy, qp) \
+	((px) * (py) >> (((qx) + (qy) - (qp))))
+
+/* Fractional multiplication with shift and round
+ * Note that the parameters px and py must be cast to (int32_t) if other type.
+ */
+#define Q_MULTSR_16X16(px, py, qx, qy, qp) \
+	((((px) * (py) >> ((qx) + (qy) - (qp) - 1)) + 1) >> 1)
+
+/* Fractional multiplication with shift
  * Note that the parameters px and py must be cast to (int64_t) if other type.
  */
 #define Q_MULTS_32X32(px, py, qx, qy, qp) \


### PR DESCRIPTION
This patch adds to header file sof/audio/format.h two new macros
for 16 * 16 fractional multiply. It's identical to 32 bit but the
name suggests that operands are 16 bit where case to int32_t is
sufficient for the product.

- The calculation of cd->max_frames is changed use Q_MULTSR_16X16()
- Max_lag calculation is added type cast to int64_t though it does
  not overflow with 48 kHz. But it could overflow with 96 kHz rate.
- A comment about 64 bit type is added to calculation of thr
- src_x and src_y calculation is done with Q_MULTSR_16X16()
- az_slow calculation is done with Q_MULTSR_16X16
- deg calculation is done with Q_MULTSR_16X16

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>