### PR TITLE
ipc4: fix copier crash, fix copier set sink format handling

### DIFF
--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -993,7 +993,8 @@ static int copier_set_sink_fmt(struct comp_dev *dev, void *data,
 		return -EINVAL;
 	}
 
-	if (cd->endpoint_num && sink_fmt->sink_id == IPC4_COPIER_GATEWAY_PIN) {
+	if (cd->endpoint_num && cd->bsource_buffer &&
+	    sink_fmt->sink_id == IPC4_COPIER_GATEWAY_PIN) {
 		comp_err(dev, "can't change gateway format");
 		return -EINVAL;
 	}


### PR DESCRIPTION
(1) ipc4: fix copier crash

Buffer params (like stream format) are usually setup by component's
params() handler. params() is called before pipeline start. When copier
is binded with component on another pipeline, it might happen that
copier copy() is already running while other component params() was not
yet executed (by other pipiline).

Processing buffer with uninitialized params usually leads to crash:
division by 0 channels when calculating frames.

(2) ipc4: fix copier set sink format handling

When gateway is copier's source, this should not prevent
from calling "set sink format" for sink pin 0.