### PR TITLE
zephyr: deprecate zephyr.h and use kernel.h header

### DIFF
--- a/app/src/main.c
+++ b/app/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(main, LOG_LEVEL_DBG);

--- a/src/logging/log_backend_probe.c
+++ b/src/logging/log_backend_probe.c
@@ -6,7 +6,7 @@
 #include <zephyr/logging/log_core.h>
 #include <zephyr/logging/log_output.h>
 #include <zephyr/logging/log_backend_std.h>
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 
 #include <sof/audio/buffer.h>
 #include <sof/ipc/topology.h>


### PR DESCRIPTION
The zephyr header zephyr.h should be only used with
CONFIG_LEGACY_INCLUDE_PATH, which is deprecate by both
Zephyr and SOF.

The latest zephyr main will complain if zephyr.h is
used but CONFIG_LEGACY_INCLUDE_PATH disabled.

This patch deprecates zephyr.h and uses kernel.h instead,
so that we don't break with latest zephyr.

Signed-off-by: Chao Song <chao.song@linux.intel.com>

```
In file included from /zep_workspace/sof/app/src/main.c:7:
/zep_workspace/zephyr/include/zephyr/zephyr.h:13:2: error: #warning "<zephyr/zephyr.h> is deprecated, include <zephyr/kernel.h> instead" [-Werror=cpp]
   13 | #warning "<zephyr/zephyr.h> is deprecated, include <zephyr/kernel.h> instead"
      |  ^~~~~~~
cc1: all warnings being treated as errors
```