### PR TITLE
xtensa-build-zephyr.py: copy mtrace-reader.py to tools folder

### DIFF
--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -574,6 +574,10 @@ def build_platforms():
 
 	src_dest_list += [(sof_logger_executable_to_copy, sof_logger_installed_file)]
 
+	src_dest_list += [(pathlib.Path(SOF_TOP) /
+		"tools" / "mtrace"/ "mtrace-reader.py",
+		tools_output_dir)]
+
 	# Append future files to `src_dest_list` here (but prefer
 	# copying entire directories; more flexible)
 


### PR DESCRIPTION
we will switch to using this new logging tool, copy it to the tools
folder, then it will be uploaded to CI storage after building.

Signed-off-by: Keqiao Zhang <keqiao.zhang@intel.com>