### PR TITLE
[stable-v2.3] scripts: remove byt-jsl from default builds

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:  # just a vector in this case
         make_env: [
           IPC_VERSION=,  # default version
-          IPC_VERSION=IPC4 UNSIGNED_list= SIGNED_list='tgl tgl-h cnl icl jsl',
+          IPC_VERSION=IPC4 UNSIGNED_list= SIGNED_list='tgl tgl-h',
         ]
 
     steps:

--- a/installer/GNUmakefile
+++ b/installer/GNUmakefile
@@ -15,21 +15,25 @@
 # released by Intel.
 
 # See rimage/config/*.toml
-UNSIGNED_list ?= bdw byt cht
-SIGNED_list  ?= apl cnl icl jsl tgl tgl-h
+SIGNED_list  ?= tgl tgl-h
 
 # To find aliases, try in a Linux kernel git clone:
 #
 #   git grep 'sof-.*\.ri' -- sound/soc/
 
-ALIAS_SAME_KEY_list  := glk cfl cml
-ALIAS_OTHER_KEY_list := ehl adl adl-s rpl rpl-s
-ALIAS_list ?= ${ALIAS_SAME_KEY_list} ${ALIAS_OTHER_KEY_list}
+ALIAS_OTHER_KEY_list += adl adl-s rpl rpl-s
 
+# Not supported in the main branch anymore, go to stable-v2.3
+# UNSIGNED_list += bdw byt cht
+# SIGNED_list   += apl cnl icl jsl
+# ALIAS_SAME_KEY_list  += glk cfl cml
+# ALIAS_OTHER_KEY_list += ehl
 
-# Older platforms not released anymore
+# Much older platforms
 # UNSIGNED_list += hsw sue
 # SIGNED_list += kbl skl
+
+ALIAS_list := ${ALIAS_SAME_KEY_list} ${ALIAS_OTHER_KEY_list}
 
 $(info UNSIGNED_list = ${UNSIGNED_list} )
 $(info SIGNED_list   = ${SIGNED_list}   )

--- a/installer/tests/staging_sofIPC4_ref.txt
+++ b/installer/tests/staging_sofIPC4_ref.txt
@@ -2,39 +2,15 @@
 ├── community
 │   ├── sof-adl-s.ri -> sof-tgl-h.ri
 │   ├── sof-adl.ri -> sof-tgl.ri
-│   ├── sof-cfl.ri -> sof-cnl.ri
-│   ├── sof-cml.ri -> sof-cnl.ri
-│   ├── sof-cnl.ri
-│   ├── sof-ehl.ri -> sof-tgl.ri
-│   ├── sof-glk.ri -> sof-apl.ri
-│   ├── sof-icl.ri
-│   ├── sof-jsl.ri
 │   ├── sof-rpl-s.ri -> sof-tgl-h.ri
 │   ├── sof-rpl.ri -> sof-tgl.ri
 │   ├── sof-tgl-h.ri
 │   └── sof-tgl.ri
 ├── intel-signed
-│   ├── sof-cfl.ri -> sof-cnl.ri
-│   ├── sof-cml.ri -> sof-cnl.ri
-│   └── sof-glk.ri -> sof-apl.ri
 ├── sof-adl-s.ldc -> sof-tgl-h.ldc
 ├── sof-adl-s.ri -> intel-signed/sof-adl-s.ri
 ├── sof-adl.ldc -> sof-tgl.ldc
 ├── sof-adl.ri -> intel-signed/sof-adl.ri
-├── sof-cfl.ldc -> sof-cnl.ldc
-├── sof-cfl.ri -> intel-signed/sof-cfl.ri
-├── sof-cml.ldc -> sof-cnl.ldc
-├── sof-cml.ri -> intel-signed/sof-cml.ri
-├── sof-cnl.ldc
-├── sof-cnl.ri -> intel-signed/sof-cnl.ri
-├── sof-ehl.ldc -> sof-tgl.ldc
-├── sof-ehl.ri -> intel-signed/sof-ehl.ri
-├── sof-glk.ldc -> sof-apl.ldc
-├── sof-glk.ri -> intel-signed/sof-glk.ri
-├── sof-icl.ldc
-├── sof-icl.ri -> intel-signed/sof-icl.ri
-├── sof-jsl.ldc
-├── sof-jsl.ri -> intel-signed/sof-jsl.ri
 ├── sof-rpl-s.ldc -> sof-tgl-h.ldc
 ├── sof-rpl-s.ri -> intel-signed/sof-rpl-s.ri
 ├── sof-rpl.ldc -> sof-tgl.ldc
@@ -44,4 +20,4 @@
 ├── sof-tgl.ldc
 └── sof-tgl.ri -> intel-signed/sof-tgl.ri
 
-2 directories, 42 files
+2 directories, 18 files

--- a/installer/tests/staging_sof_ref.txt
+++ b/installer/tests/staging_sof_ref.txt
@@ -2,48 +2,15 @@
 ├── community
 │   ├── sof-adl-s.ri -> sof-tgl-h.ri
 │   ├── sof-adl.ri -> sof-tgl.ri
-│   ├── sof-apl.ri
-│   ├── sof-cfl.ri -> sof-cnl.ri
-│   ├── sof-cml.ri -> sof-cnl.ri
-│   ├── sof-cnl.ri
-│   ├── sof-ehl.ri -> sof-tgl.ri
-│   ├── sof-glk.ri -> sof-apl.ri
-│   ├── sof-icl.ri
-│   ├── sof-jsl.ri
 │   ├── sof-rpl-s.ri -> sof-tgl-h.ri
 │   ├── sof-rpl.ri -> sof-tgl.ri
 │   ├── sof-tgl-h.ri
 │   └── sof-tgl.ri
 ├── intel-signed
-│   ├── sof-cfl.ri -> sof-cnl.ri
-│   ├── sof-cml.ri -> sof-cnl.ri
-│   └── sof-glk.ri -> sof-apl.ri
 ├── sof-adl-s.ldc -> sof-tgl-h.ldc
 ├── sof-adl-s.ri -> intel-signed/sof-adl-s.ri
 ├── sof-adl.ldc -> sof-tgl.ldc
 ├── sof-adl.ri -> intel-signed/sof-adl.ri
-├── sof-apl.ldc
-├── sof-apl.ri -> intel-signed/sof-apl.ri
-├── sof-bdw.ldc
-├── sof-bdw.ri
-├── sof-byt.ldc
-├── sof-byt.ri
-├── sof-cfl.ldc -> sof-cnl.ldc
-├── sof-cfl.ri -> intel-signed/sof-cfl.ri
-├── sof-cht.ldc
-├── sof-cht.ri
-├── sof-cml.ldc -> sof-cnl.ldc
-├── sof-cml.ri -> intel-signed/sof-cml.ri
-├── sof-cnl.ldc
-├── sof-cnl.ri -> intel-signed/sof-cnl.ri
-├── sof-ehl.ldc -> sof-tgl.ldc
-├── sof-ehl.ri -> intel-signed/sof-ehl.ri
-├── sof-glk.ldc -> sof-apl.ldc
-├── sof-glk.ri -> intel-signed/sof-glk.ri
-├── sof-icl.ldc
-├── sof-icl.ri -> intel-signed/sof-icl.ri
-├── sof-jsl.ldc
-├── sof-jsl.ri -> intel-signed/sof-jsl.ri
 ├── sof-rpl-s.ldc -> sof-tgl-h.ldc
 ├── sof-rpl-s.ri -> intel-signed/sof-rpl-s.ri
 ├── sof-rpl.ldc -> sof-tgl.ldc
@@ -53,4 +20,4 @@
 ├── sof-tgl.ldc
 └── sof-tgl.ri -> intel-signed/sof-tgl.ri
 
-2 directories, 51 files
+2 directories, 18 files

--- a/scripts/xtensa-build-all.sh
+++ b/scripts/xtensa-build-all.sh
@@ -8,12 +8,11 @@ set -e
 # Platforms with a toolchain available in the latest Docker image and
 # built by the -a option.
 DEFAULT_PLATFORMS=(  byt cht bdw hsw tgl tgl-h apl skl kbl cnl sue icl jsl \
-                    imx8 imx8x imx8m imx8ulp rn mt8186 mt8195 )
+                    imx8 imx8x imx8m imx8ulp rn rmb mt8186 mt8195 )
 
 # Work in progress can be added to this "staging area" without breaking
 # the -a option for everyone.
 SUPPORTED_PLATFORMS=( "${DEFAULT_PLATFORMS[@]}" )
-SUPPORTED_PLATFORMS=( "${DEFAULT_PLATFORMS[@]}" rmb)
 
 BUILD_ROM=no
 BUILD_DEBUG=no

--- a/scripts/xtensa-build-all.sh
+++ b/scripts/xtensa-build-all.sh
@@ -5,14 +5,23 @@
 # stop on most errors
 set -e
 
-# Platforms with a toolchain available in the latest Docker image and
-# built by the -a option.
-DEFAULT_PLATFORMS=(  byt cht bdw hsw tgl tgl-h apl skl kbl cnl sue icl jsl \
-                    imx8 imx8x imx8m imx8ulp rn rmb mt8186 mt8195 )
+# Platforms built and tested by default in CI using the `-a` option.
+# They must have a toolchain available in the latest Docker image.
+DEFAULT_PLATFORMS=(
+    tgl tgl-h
+    imx8 imx8x imx8m imx8ulp
+    rn rmb
+    mt8186 mt8195
+)
 
 # Work in progress can be added to this "staging area" without breaking
 # the -a option for everyone.
 SUPPORTED_PLATFORMS=( "${DEFAULT_PLATFORMS[@]}" )
+
+# Not actually "supported" in the main branch anymore (go to stable-v2.3
+# instead) but kept here for historical reasons and experimentation
+# convenience.
+SUPPORTED_PLATFORMS+=( byt hsw cht bdw apl skl kbl cnl sue icl jsl )
 
 BUILD_ROM=no
 BUILD_DEBUG=no
@@ -58,7 +67,7 @@ https://thesofproject.github.io/latest/developer_guides/firmware/cmake.html
 usage: $0 [options] platform(s)
 
        -r Build rom if available (gcc only)
-       -a Build all platforms which have a toolchain in the latest Docker image
+       -a Build all default platforms fully supported by the latest Docker image and CI
        -u Force CONFIG_MULTICORE=n
        -d Enable debug build
        -c Interactive menuconfig
@@ -102,7 +111,7 @@ myXtensa/
 
 $ XTENSA_TOOLS_ROOT=/path/to/myXtensa $0 ...
 
-Supported platforms ${SUPPORTED_PLATFORMS[*]}
+Known platforms: ${SUPPORTED_PLATFORMS[*]}
 
 EOF
 }
@@ -155,7 +164,7 @@ for arg in "$@"; do
 	done
 	if [ "$platform" == "none" ]; then
 		echo "Error: Unknown platform specified: $arg"
-		echo "Supported platforms are: ${SUPPORTED_PLATFORMS[*]}"
+		echo "Known platforms are: ${SUPPORTED_PLATFORMS[*]}"
 		exit 1
 	fi
 done
@@ -163,7 +172,7 @@ done
 # check target platform(s) have been passed in
 if [ ${#PLATFORMS[@]} -eq 0 ];
 then
-	echo "Error: No platforms specified. Supported are: " \
+	echo "Error: No platform specified. Known platforms: " \
 		"${SUPPORTED_PLATFORMS[*]}"
 	print_usage
 	exit 1


### PR DESCRIPTION
Clean cherry-picks.

Required for 2.3 release.