### PR TITLE
IPC4: Improve TX resend logic on Zephyr

### DIFF
--- a/app/prj.conf
+++ b/app/prj.conf
@@ -18,6 +18,11 @@ CONFIG_SCHED_DEADLINE=y
 CONFIG_SCHED_CPU_MASK=y
 CONFIG_SMP_BOOT_DELAY=y
 
+# SOF code assumes system work queue and other system
+# wide threads are pinned to a single core.
+# CPU_MASK_PIN_ONLY must be set for all SOF builds.
+CONFIG_SCHED_CPU_MASK_PIN_ONLY=y
+
 # Fix the sys ticks value  until following bugs are solved:
 # - https://github.com/zephyrproject-rtos/zephyr/issues/46378
 CONFIG_SYS_CLOCK_TICKS_PER_SEC=15000

--- a/src/include/sof/ipc/common.h
+++ b/src/include/sof/ipc/common.h
@@ -65,6 +65,10 @@ struct ipc {
 	/* processing task */
 	struct task ipc_task;
 
+#ifdef __ZEPHYR__
+	struct k_work_delayable z_delayed_work;
+#endif
+
 	void *private;
 };
 

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -403,15 +403,6 @@ unsigned int _xtos_ints_off(unsigned int mask)
 	return 0;
 }
 
-void ipc_send_queued_msg(void);
-
-static void ipc_send_queued_callback(void *private_data, enum notify_id event_type,
-				     void *caller_data)
-{
-	if (!ipc_get()->pm_prepare_D3)
-		ipc_send_queued_msg();
-}
-
 /*
  * Audio components.
  *
@@ -650,11 +641,6 @@ int task_main_start(struct sof *sof)
 	 */
 	__ASSERT_NO_MSG(cpu_get_id() == PLATFORM_PRIMARY_CORE_ID);
 	w_core_enable_mask |= BIT(PLATFORM_PRIMARY_CORE_ID);
-
-	/* Temporary fix for issue #4356 */
-	(void)notifier_register(NULL, scheduler_get_data(SOF_IPC_QUEUED_DOMAIN),
-				NOTIFIER_ID_LL_POST_RUN,
-				ipc_send_queued_callback, 0);
 
 	/* let host know DSP boot is complete */
 	ret = platform_boot_complete(0);


### PR DESCRIPTION
After realizing we have a competing "TX sender" in zephyr/wrapper.c, I've modified the approach in #6243 . This takes benefit of the Zephyr CONFIG_SCHED_CPU_MASK_PIN_ONLY feature which allows to pin systems threads to specific cores of the system. In practise we can simply use the Zephyr system work queue, instead of using a LL-scheduler task, or a LL_POST_RUN notifier, to flush out pending IPC messages.

This fixes the issues with current codebase (Zephyr builds) where IPC TX messages were not flushed out if no LL task was running.

This also cleans up code from zephyr/wrapper.c.

