### PR TITLE
ll-schedule: degrade an error message to a warning

### DIFF
--- a/src/schedule/zephyr_ll.c
+++ b/src/schedule/zephyr_ll.c
@@ -512,8 +512,8 @@ int zephyr_ll_scheduler_init(struct ll_schedule_domain *domain)
 	struct zephyr_ll *sch;
 
 	if (domain->type != SOF_SCHEDULE_LL_TIMER) {
-		tr_err(&ll_tr, "zephyr_ll_scheduler_init(): unsupported domain %u",
-		       domain->type);
+		tr_warn(&ll_tr, "zephyr_ll_scheduler_init(): unsupported domain %u",
+			domain->type);
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
SOF always tries to register both scheduling domains - timer and DMA, even though the DMA domain isn't used in current topologies on newer architectures and isn't supported under Zephyr. Degrade the error message printed upon each boot due to this lack of support to a warning.
