### PR TITLE
topology2: add lp_mode as a attribute in pipeline

### DIFF
--- a/tools/topology/topology2/include/components/pipeline.conf
+++ b/tools/topology/topology2/include/components/pipeline.conf
@@ -84,6 +84,17 @@ Class.Widget."pipeline" {
 		token_ref	"sof_tkn_scheduler.word"
 	}
 
+	DefineAttribute."lp_mode" {
+		# Token reference and type
+		token_ref	"sof_tkn_scheduler.word"
+		constraints {
+			!tuple_values [
+				1
+				0
+			]
+		}
+	}
+
 	attributes {
 		# pipeline widget name will be constructed as pipeline.1, pipeline.2 etc
 		!constructor [


### PR DESCRIPTION
Currently lp_mode setting is not included by topology binary since lp_mode is not defined as a attribute. This patch adds it in pipeline.

Signed-off-by: Rander Wang <rander.wang@intel.com>