### PR TITLE
ghd: Fix build error for ghd

### DIFF
--- a/src/audio/google_hotword_detect.c
+++ b/src/audio/google_hotword_detect.c
@@ -116,7 +116,7 @@ static struct comp_dev *ghd_create(const struct comp_driver *drv,
 	cd->event.event_type = SOF_CTRL_EVENT_KD;
 	cd->event.num_elems = 0;
 
-	cd->msg = ipc_msg_init(cd->event.rhdr.hdr.cmd, cd->event.rhdr.size);
+	cd->msg = ipc_msg_init(cd->event.rhdr.hdr.cmd, cd->event.rhdr.hdr.size);
 	if (!cd->msg) {
 		comp_err(dev, "ghd_create(): ipc_msg_init failed");
 		goto cd_fail;


### PR DESCRIPTION
Size parameter is moved from
struct sof_ipc_reply to struct sof_ipc_cmd_hdr.
Added changes accordingly.

Signed-off-by: Vamshi Krishna Gopal <vamshi.krishna.gopal@intel.com>