### PR TITLE
topology1:enable SOF EQ + DTS on AMD renoir

### DIFF
--- a/tools/topology/topology1/sof-rn-rt5682-rt1019.m4
+++ b/tools/topology/topology1/sof-rn-rt5682-rt1019.m4
@@ -21,16 +21,16 @@ include(`platform/amd/acp.m4')
 # Playback pipeline 1 on PCM 0 using max 2 channels of s16le.
 # Schedule 96 frames per 2000us deadline on core 0 with priority 0
 PIPELINE_PCM_ADD(
-ifdef(`DTS', sof/pipe-dts-codec-playback.m4, sof/pipe-passthrough-playback.m4),
+ifdef(`DTS', sof/pipe-eq-iir-dts-codec-playback.m4, sof/pipe-passthrough-playback.m4),
 	1, 0, 2, s16le,
-	2000, 0, 0,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 # playback DAI is ACPSP using 2 periods
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, ACPSP, 0, acp-headset-codec,
 	PIPELINE_SOURCE_1, 2, s16le,
-	2000, 0, 0, SCHEDULE_TIME_DOMAIN_DMA)
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_DMA)
 
 DAI_CONFIG(ACPSP, 0, 0, acp-headset-codec,
 	ACPSP_CONFIG(I2S, ACP_CLOCK(mclk, 49152000, codec_mclk_in),
@@ -42,14 +42,14 @@ DAI_CONFIG(ACPSP, 0, 0, acp-headset-codec,
 # Capture pipeline 2 on PCM 0 using max 2 channels of s16le.
 PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
 	2, 0, 2, s16le,
-	2000, 0, 0,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 # Capture DAI is ACPSP using 2 periods
 DAI_ADD(sof/pipe-dai-capture.m4,
 	2, ACPSP, 0, acp-headset-codec,
 	PIPELINE_SINK_2, 2, s16le,
-	2000, 0, 0, SCHEDULE_TIME_DOMAIN_DMA)
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_DMA)
 
 # PCM  id 0
 PCM_DUPLEX_ADD(I2SSP, 0, PIPELINE_PCM_1, PIPELINE_PCM_2)
@@ -57,13 +57,13 @@ PCM_DUPLEX_ADD(I2SSP, 0, PIPELINE_PCM_1, PIPELINE_PCM_2)
 # Capture pipeline 3 on PCM 1 using max 2 channels of s32le.
 PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
 	3, 1, 2, s32le,
-	2000, 0, 0,
+	1000, 0, 0,
 	48000, 48000, 48000)
 
 DAI_ADD(sof/pipe-dai-capture.m4,
 	3, ACPDMIC, 0, acp-dmic-codec,
 	PIPELINE_SINK_3, 2, s32le,
-	2000, 0, 0, SCHEDULE_TIME_DOMAIN_DMA)
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_DMA)
 
 dnl DAI_CONFIG(type, dai_index, link_id, name, acpdmic_config)
 DAI_CONFIG(ACPDMIC, 3, 2, acp-dmic-codec,


### PR DESCRIPTION
Period has to be 1ms to avoid playback noise issue on Renoir when SOF EQ + DTS are both enabled.

Signed-off-by: Joe.Cheng <joe.cheng@xperi.com>