### PR TITLE
ipc4: do not fail if pipeline state is already set correctly

### DIFF
--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -309,7 +309,8 @@ static int set_pipeline_state(uint32_t id, uint32_t cmd, bool *delayed, uint32_t
 			return ret;
 		}
 
-		if (status == COMP_STATE_READY)
+		if (status == COMP_STATE_READY ||
+		    status == COMP_STATE_PAUSED)
 			return 0;
 
 		cmd = COMP_TRIGGER_PAUSE;


### PR DESCRIPTION
If pipeline state already matches the requested state, do not return an error.

Improve the log messages of the related checks.

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>