### PR TITLE
zephyr: both BDW and BYT are not supported in zephyr

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -105,48 +105,6 @@ zephyr_include_directories(
 # SOC level sources
 # Files that are commented may not be needed.
 
-# Intel BYT, CHT, BSW platforms
-if (CONFIG_SOC_SERIES_INTEL_ADSP_BAYTRAIL)
-
-	# Driver sources
-	zephyr_library_sources(
-		${SOF_DRIVERS_PATH}/intel/baytrail/ipc.c
-		${SOF_DRIVERS_PATH}/intel/baytrail/ssp.c
-		${SOF_DRIVERS_PATH}/intel/pmc-ipc.c
-	)
-
-	# Platform sources
-	zephyr_library_sources(
-		${SOF_PLATFORM_PATH}/baytrail/platform.c
-		${SOF_PLATFORM_PATH}/baytrail/lib/dai.c
-		${SOF_PLATFORM_PATH}/baytrail/lib/clk.c
-		${SOF_PLATFORM_PATH}/baytrail/lib/dma.c
-		${SOF_SRC_PATH}/schedule/dma_multi_chan_domain.c
-	)
-
-	# SOF core infrastructure - runs on top of Zephyr
-	zephyr_library_sources(
-		${SOF_SRC_PATH}/schedule/ll_schedule.c
-	)
-
-	set(PLATFORM "baytrail")
-endif()
-
-# Intel HSW, BDW platforms
-if (CONFIG_SOC_SERIES_INTEL_ADSP_BROADWELL)
-	zephyr_library_sources(
-		${SOF_DRIVERS_PATH}/intel/haswell/ipc.c
-		${SOF_DRIVERS_PATH}/intel/haswell/ssp.c
-	)
-
-	# SOF core infrastructure - runs on top of Zephyr
-	zephyr_library_sources(
-		${SOF_SRC_PATH}/schedule/ll_schedule.c
-	)
-
-	set(PLATFORM "haswell")
-endif()
-
 # Intel APL, KBL, SKL CAVS 1.5 platforms
 if (CONFIG_SOC_SERIES_INTEL_CAVS_V15)
 

--- a/zephyr/include/rtos/interrupt.h
+++ b/zephyr/include/rtos/interrupt.h
@@ -48,9 +48,7 @@ static inline void interrupt_unregister(uint32_t irq, const void *arg)
  */
 static inline int interrupt_get_irq(unsigned int irq, const char *cascade)
 {
-#if CONFIG_SOC_SERIES_INTEL_ADSP_BAYTRAIL ||\
-	CONFIG_SOC_SERIES_INTEL_ADSP_BROADWELL || \
-	CONFIG_LIBRARY
+#ifdef CONFIG_LIBRARY
 	return irq;
 #else
 	if (cascade == irq_name_level2)


### PR DESCRIPTION
Both Broadwell and Baytrail are not supported in zephyr and those
Kconfigs are not defined anywhere, neither in SOF nor in zephyr.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
