### PR TITLE
CMake: pass firmware file micro version to rimage

### DIFF
--- a/src/arch/xtensa/CMakeLists.txt
+++ b/src/arch/xtensa/CMakeLists.txt
@@ -455,7 +455,7 @@ if(MEU_PATH OR DEFINED MEU_NO_SIGN) # Don't sign with rimage
 			-s ${MEU_OFFSET}
 			-k ${RIMAGE_PRIVATE_KEY}
 			-i ${RIMAGE_IMR_TYPE}
-			-f ${SOF_MAJOR}.${SOF_MINOR}
+			-f ${SOF_MAJOR}.${SOF_MINOR}.${SOF_MICRO}
 			-b ${SOF_BUILD}
 			-e
 			${bootloader_binary_path}
@@ -496,7 +496,7 @@ else() # sign with rimage
 			-c "${PROJECT_SOURCE_DIR}/rimage/config/${fw_name}.toml"
 			-k ${RIMAGE_PRIVATE_KEY}
 			-i ${RIMAGE_IMR_TYPE}
-			-f ${SOF_MAJOR}.${SOF_MINOR}
+			-f ${SOF_MAJOR}.${SOF_MINOR}.${SOF_MICRO}
 			-b ${SOF_BUILD}
 			-e
 			${bootloader_binary_path}


### PR DESCRIPTION
Fix build fail of mt8195/v0.4 with rimage repo having commit 9d453321f892b7ec3f0 merged at 2022/5/4.

Build fail message:
error: cannot parse firmware version major.minor.micro
src/arch/xtensa/CMakeFiles/run_rimage.dir/build.make:57: recipe for target 'src/arch/xtensa/CMakeFiles/run_rimage' failed
make[3]: *** [src/arch/xtensa/CMakeFiles/run_rimage] Error 234
CMakeFiles/Makefile2:1898: recipe for target 'src/arch/xtensa/CMakeFiles/run_rimage.dir/all' failed

--
SOF CMake defines SOF_MAJOR, SOF_MINOR and SOF_MICRO for 3 fields of firmware file version major.minor.micro. But CMake only passes the major and minor version to rimage.

Now CMake will also pass the mirco version to rimage, so that rimage can write it to different firmware manifest headers for cAVS platforms and then sof_ri_info.py will be able to dump entire file version info from the firmware binary.

Signed-off-by: Mengdong Lin <mengdong.lin@intel.com>