### PR TITLE
module_adapter: add helper for module config fragment position

### DIFF
--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -917,17 +917,7 @@ int module_set_large_config(struct comp_dev *dev, uint32_t param_id, bool first_
 	size_t fragment_size;
 
 	/* set fragment position */
-	if (first_block) {
-		if (last_block)
-			pos = MODULE_CFG_FRAGMENT_SINGLE;
-		else
-			pos = MODULE_CFG_FRAGMENT_FIRST;
-	} else {
-		if (!last_block)
-			pos = MODULE_CFG_FRAGMENT_MIDDLE;
-		else
-			pos = MODULE_CFG_FRAGMENT_LAST;
-	}
+	pos = first_last_block_to_frag_pos(first_block, last_block);
 
 	switch (pos) {
 	case MODULE_CFG_FRAGMENT_SINGLE:

--- a/src/include/sof/audio/module_adapter/module/module_interface.h
+++ b/src/include/sof/audio/module_adapter/module/module_interface.h
@@ -143,4 +143,11 @@ struct module_interface {
 	int (*free)(struct processing_module *mod);
 };
 
+/* Convert first_block/last_block indicator to fragment position */
+static inline enum module_cfg_fragment_position
+first_last_block_to_frag_pos(bool first_block, bool last_block)
+{
+	return (last_block << 1) | first_block;
+}
+
 #endif /* __SOF_MODULE_INTERFACE__ */


### PR DESCRIPTION
This patch adds a helper to convert first_block/last_block indicator to module_cfg_fragment_position enum, which is more efficient than if-else test.

Signed-off-by: Chao Song <chao.song@linux.intel.com>