### PR TITLE
module_adapter:Fix dangling pointer issue in module reset

### DIFF
--- a/src/audio/module_adapter/module/generic.c
+++ b/src/audio/module_adapter/module/generic.c
@@ -279,6 +279,7 @@ int module_reset(struct processing_module *mod)
 	md->cfg.avail = false;
 	md->cfg.size = 0;
 	rfree(md->cfg.data);
+	md->cfg.data = NULL;
 
 	/*
 	 * reset the state to allow the module's prepare callback to be invoked again for the
@@ -318,9 +319,11 @@ int module_free(struct processing_module *mod)
 	md->cfg.avail = false;
 	md->cfg.size = 0;
 	rfree(md->cfg.data);
-	if (md->runtime_params)
+	md->cfg.data = NULL;
+	if (md->runtime_params) {
 		rfree(md->runtime_params);
-
+		md->runtime_params = NULL;
+	}
 	md->state = MODULE_DISABLED;
 
 	return ret;


### PR DESCRIPTION
During module_reset and module_free Calls, pointers are not getting reset to NULL which causes dangling pointer exceptions. Initialize pointers to NULL after deallocating the memory.

Signed-off-by: Balakishorepati <balaKishore.pati@amd.com>