### PR TITLE
drivers:amd: Fix aclk issue in standalone dmic usecase

### DIFF
--- a/src/drivers/amd/rembrandt/acp_bt_dma.c
+++ b/src/drivers/amd/rembrandt/acp_bt_dma.c
@@ -94,11 +94,13 @@ static int acp_dai_bt_dma_start(struct dma_chan_data *channel)
 	acp_bttdm_ier_t         bt_ier;
 	acp_bttdm_iter_t        bt_tdm_iter;
 	acp_bttdm_irer_t        bt_tdm_irer;
+	uint32_t		acp_pdm_en;
 
 	bt_tdm_iter = (acp_bttdm_iter_t)io_reg_read((PU_REGISTER_BASE + ACP_BTTDM_ITER));
 	bt_tdm_irer = (acp_bttdm_irer_t)io_reg_read((PU_REGISTER_BASE + ACP_BTTDM_IRER));
+	acp_pdm_en = (uint32_t)io_reg_read(PU_REGISTER_BASE + ACP_WOV_PDM_ENABLE);
 
-	if (!bt_tdm_iter.bits.bttdm_txen && !bt_tdm_irer.bits.bttdm_rx_en)
+	if (!bt_tdm_iter.bits.bttdm_txen && !bt_tdm_irer.bits.bttdm_rx_en && !acp_pdm_en)
 		/* Request SMU to set aclk to 600 Mhz */
 		acp_change_clock_notify(600000000);
 
@@ -149,6 +151,7 @@ static int acp_dai_bt_dma_stop(struct dma_chan_data *channel)
 {
 	acp_bttdm_iter_t        bt_tdm_iter;
 	acp_bttdm_irer_t        bt_tdm_irer;
+	uint32_t		acp_pdm_en;
 
 	switch (channel->status) {
 	case COMP_STATE_READY:
@@ -176,10 +179,13 @@ static int acp_dai_bt_dma_stop(struct dma_chan_data *channel)
 
 	bt_tdm_iter = (acp_bttdm_iter_t)io_reg_read(PU_REGISTER_BASE + ACP_BTTDM_ITER);
 	bt_tdm_irer = (acp_bttdm_irer_t)io_reg_read(PU_REGISTER_BASE + ACP_BTTDM_IRER);
+	acp_pdm_en = (uint32_t)io_reg_read(PU_REGISTER_BASE + ACP_WOV_PDM_ENABLE);
+
 	if (!bt_tdm_iter.bits.bttdm_txen && !bt_tdm_irer.bits.bttdm_rx_en) {
 		io_reg_write((PU_REGISTER_BASE + ACP_BTTDM_IER), BT_IER_DISABLE);
 		/* Request SMU to scale down aclk to minimum clk */
-		acp_change_clock_notify(0);
+		if (!acp_pdm_en)
+			acp_change_clock_notify(0);
 	}
 
 	return 0;

--- a/src/drivers/amd/rembrandt/acp_sp_dma.c
+++ b/src/drivers/amd/rembrandt/acp_sp_dma.c
@@ -86,14 +86,16 @@ static void acp_dai_sp_dma_channel_put(struct dma_chan_data *channel)
 
 static int acp_dai_sp_dma_start(struct dma_chan_data *channel)
 {
-	acp_i2stdm_ier_t sp_ier;
-	acp_i2stdm_iter_t sp_iter;
-	acp_i2stdm_irer_t sp_irer;
+	acp_i2stdm_ier_t	sp_ier;
+	acp_i2stdm_iter_t	sp_iter;
+	acp_i2stdm_irer_t	sp_irer;
+	uint32_t		acp_pdm_en;
 
 	sp_iter = (acp_i2stdm_iter_t)io_reg_read((PU_REGISTER_BASE + ACP_I2STDM_ITER));
 	sp_irer = (acp_i2stdm_irer_t)io_reg_read((PU_REGISTER_BASE + ACP_I2STDM_IRER));
+	acp_pdm_en = (uint32_t)io_reg_read(PU_REGISTER_BASE + ACP_WOV_PDM_ENABLE);
 
-	if (!sp_iter.bits.i2stdm_txen && !sp_irer.bits.i2stdm_rx_en)
+	if (!sp_iter.bits.i2stdm_txen && !sp_irer.bits.i2stdm_rx_en && !acp_pdm_en)
 		/* Request SMU to set aclk to 600 Mhz */
 		acp_change_clock_notify(600000000);
 
@@ -142,8 +144,9 @@ static int acp_dai_sp_dma_pause(struct dma_chan_data *channel)
 
 static int acp_dai_sp_dma_stop(struct dma_chan_data *channel)
 {
-	acp_i2stdm_irer_t sp_irer;
-	acp_i2stdm_iter_t sp_iter;
+	acp_i2stdm_irer_t	sp_irer;
+	acp_i2stdm_iter_t	sp_iter;
+	uint32_t		acp_pdm_en;
 
 	switch (channel->status) {
 	case COMP_STATE_READY:
@@ -170,10 +173,13 @@ static int acp_dai_sp_dma_stop(struct dma_chan_data *channel)
 	}
 	sp_iter = (acp_i2stdm_iter_t)io_reg_read((PU_REGISTER_BASE + ACP_I2STDM_ITER));
 	sp_irer = (acp_i2stdm_irer_t)io_reg_read((PU_REGISTER_BASE + ACP_I2STDM_IRER));
+	acp_pdm_en = (uint32_t)io_reg_read(PU_REGISTER_BASE + ACP_WOV_PDM_ENABLE);
+
 	if (!sp_iter.bits.i2stdm_txen && !sp_irer.bits.i2stdm_rx_en) {
 		io_reg_write((PU_REGISTER_BASE + ACP_I2STDM_IER), SP_IER_DISABLE);
 		/* Request SMU to scale down aclk to minimum clk */
-		acp_change_clock_notify(0);
+		if (!acp_pdm_en)
+			acp_change_clock_notify(0);
 	}
 
 	return 0;

--- a/src/drivers/amd/rembrandt/interrupt.c
+++ b/src/drivers/amd/rembrandt/interrupt.c
@@ -413,8 +413,7 @@ void acp_ack_intr_from_host(void)
 	/* acknowledge the host interrupt */
 	acp_dsp_sw_intr_stat_t sw_intr_stat;
 
-	sw_intr_stat = (acp_dsp_sw_intr_stat_t)io_reg_read(PU_REGISTER_BASE +
-							ACP_DSP_SW_INTR_STAT);
+	sw_intr_stat.u32all = 0;
 	sw_intr_stat.bits.host_to_dsp0_intr1_stat = INTERRUPT_ENABLE;
 	io_reg_write((PU_REGISTER_BASE + ACP_DSP_SW_INTR_STAT), sw_intr_stat.u32all);
 }

--- a/src/drivers/amd/renoir/acp_dmic_dma.c
+++ b/src/drivers/amd/renoir/acp_dmic_dma.c
@@ -82,9 +82,21 @@ static int acp_dmic_dma_start(struct dma_chan_data *channel)
 	acp_wov_pdm_decimation_factor_t deci_fctr;
 	acp_wov_misc_ctrl_t wov_misc_ctrl;
 	acp_wov_pdm_dma_enable_t  pdm_dma_enable;
+	acp_i2stdm_iter_t	sp_iter;
+	acp_i2stdm_irer_t	sp_irer;
+	uint32_t		acp_pdm_en;
 	struct timer *timer = timer_get();
 	uint64_t deadline = platform_timer_get(timer) +
 				clock_ms_to_ticks(PLATFORM_DEFAULT_CLOCK, 1) * 500 / 1000;
+
+	sp_iter = (acp_i2stdm_iter_t)io_reg_read((PU_REGISTER_BASE + ACP_I2STDM_ITER));
+	sp_irer = (acp_i2stdm_irer_t)io_reg_read((PU_REGISTER_BASE + ACP_I2STDM_IRER));
+	acp_pdm_en = (uint32_t)io_reg_read(PU_REGISTER_BASE + ACP_WOV_PDM_ENABLE);
+
+	if (!sp_iter.bits.i2stdm_txen && !sp_irer.bits.i2stdm_rx_en && !acp_pdm_en)
+		/* Request SMU to set aclk to 600 Mhz */
+		acp_change_clock_notify(600000000);
+
 	channel->status = COMP_STATE_ACTIVE;
 	if (channel->direction == DMA_DIR_DEV_TO_MEM) {
 		/* Channel for DMIC */
@@ -140,6 +152,9 @@ static int acp_dmic_dma_pause(struct dma_chan_data *channel)
 static int acp_dmic_dma_stop(struct dma_chan_data *channel)
 {
 	acp_wov_pdm_dma_enable_t  pdm_dma_enable;
+	acp_i2stdm_iter_t	sp_iter;
+	acp_i2stdm_irer_t	sp_irer;
+	uint32_t		acp_pdm_en;
 	struct timer *timer = timer_get();
 	uint64_t deadline = platform_timer_get(timer) +
 			clock_ms_to_ticks(PLATFORM_DEFAULT_CLOCK, 1) * 500 / 1000;
@@ -175,6 +190,14 @@ static int acp_dmic_dma_stop(struct dma_chan_data *channel)
 	io_reg_write(PU_REGISTER_BASE + ACP_WOV_PDM_ENABLE, 0);
 	/* Clear PDM FIFO */
 	io_reg_write(PU_REGISTER_BASE + ACP_WOV_PDM_FIFO_FLUSH, 1);
+	sp_iter = (acp_i2stdm_iter_t)io_reg_read((PU_REGISTER_BASE + ACP_I2STDM_ITER));
+	sp_irer = (acp_i2stdm_irer_t)io_reg_read((PU_REGISTER_BASE + ACP_I2STDM_IRER));
+	acp_pdm_en = (uint32_t)io_reg_read(PU_REGISTER_BASE + ACP_WOV_PDM_ENABLE);
+
+	if (!sp_iter.bits.i2stdm_txen && !sp_irer.bits.i2stdm_rx_en && !acp_pdm_en)
+		/* Request SMU to set aclk to minimum aclk */
+		acp_change_clock_notify(0);
+
 	return 0;
 }
 

--- a/src/drivers/amd/renoir/interrupt.c
+++ b/src/drivers/amd/renoir/interrupt.c
@@ -376,8 +376,7 @@ void acp_ack_intr_from_host(void)
 	/* acknowledge the host interrupt */
 	acp_dsp_sw_intr_stat_t sw_intr_stat;
 
-	sw_intr_stat = (acp_dsp_sw_intr_stat_t)io_reg_read(PU_REGISTER_BASE +
-							ACP_DSP_SW_INTR_STAT);
+	sw_intr_stat.u32all = 0;
 	sw_intr_stat.bits.host_to_dsp0_intr1_stat = INTERRUPT_ENABLE;
 	io_reg_write((PU_REGISTER_BASE + ACP_DSP_SW_INTR_STAT), sw_intr_stat.u32all);
 }


### PR DESCRIPTION
Change aclk to max or minimum during playback,capture usecases start and stop based on dmic status.

Signed-off-by: Balakishorepati <balaKishore.pati@amd.com>