### PR TITLE
[SKIP CI] Add sparse build to Github Actions

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -59,4 +59,9 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: run yamllint
-        run: yamllint --strict .github/workflows/*.yml
+        # Quoting to please all parsers is hard. This indirection helps.
+        env:
+          yamllint_config: '{extends: default, rules: {line-length: {max: 100}}}'
+        run: yamllint -f parsable
+          -d "$yamllint_config"
+          --strict .github/workflows/*.yml *.yml

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -54,3 +54,47 @@ jobs:
         run: cd workspace && ./sof/zephyr/docker-run.sh
              ./sof/zephyr/docker-build.sh --cmake-args=-DEXTRA_CFLAGS=-Werror
              --cmake-args=--warn-uninitialized ${{ matrix.IPC_platforms }}
+
+
+  # As of sparse commit ce1a6720f69e / Sept 2022, the exit status of sparse.c is an
+  # unusable mess and always zero in practice. "Send patches"? So for now the only purpose
+  # of this check is to keep sparse _usable_ and demo how to use it but not to catch any
+  # regression.
+  #
+  # The only, undocumented way to make sparse return a non-zero exit status is to use its
+  # -Wsparse-error option; see check_symbols() code in sparse.c. Without -Wsparse-error,
+  # sparse.c always returns zero no matter how many warnings and errors it printed. BUT of
+  # course -Wsparse-error has another, intended and expected effect documented in "man
+  # sparse": promote all our (very many) warnings into errors. Which means we cannot use
+  # -Wsparse-error yet, otherwise it would be "always red".
+  #
+  # Note sparse does not support promoting individual warning types to errors either.
+  sparse_always_green:
+    runs-on: ubuntu-22.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        platforms: [
+          {platform: tgl,
+           real_cc: xtensa-intel_s1000_zephyr-elf/bin/xtensa-intel_s1000_zephyr-elf-gcc},
+        ]
+
+    steps:
+      - uses: actions/checkout@v2
+        # From time to time this will catch a git tag and change SOF_VERSION
+        with:
+          fetch-depth: 10
+          path: ./workspace/sof
+
+      - name: west clones
+        run: pip3 install west && cd workspace/sof/ && west init -l &&
+               west update --narrow --fetch-opt=--depth=5
+
+      - name: build
+        run: cd workspace &&
+             ZSDK=/opt/toolchains/zephyr-sdk-0.15.0;
+             _RCC=${{ matrix.platforms.real_cc }};
+             REAL_CC="$ZSDK/$_RCC" ./sof/zephyr/docker-run.sh
+             ./sof/zephyr/docker-build.sh ${{ matrix.platforms.platform }}
+             --cmake-args=-DSPARSE=y  # --cmake-args=-DEXTRA_CFLAGS=-Wsparse-error

--- a/scripts/xtensa-build-all.sh
+++ b/scripts/xtensa-build-all.sh
@@ -392,6 +392,8 @@ do
 	then
 		TOOLCHAIN=xt
 		ROOT="$XTENSA_BUILDS_DIR/$XTENSA_CORE/xtensa-elf"
+		# CMake cannot set (evil) build-time environment variables at configure time:
+# https://gitlab.kitware.com/cmake/community/-/wikis/FAQ#how-can-i-get-or-set-environment-variables
 		export XTENSA_SYSTEM=$XTENSA_BUILDS_DIR/$XTENSA_CORE/config
 		printf 'XTENSA_SYSTEM=%s\n' "${XTENSA_SYSTEM}"
 		PATH=$XTENSA_TOOLS_DIR/XtensaTools/bin:$OLDPATH

--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -470,7 +470,7 @@ def build_platforms():
 		abs_build_dir = pathlib.Path(west_top, platform_build_dir_name)
 		if (pathlib.Path(abs_build_dir, "build.ninja").is_file()
 		    or pathlib.Path(abs_build_dir, "Makefile").is_file()):
-			if args.cmake_args:
+			if args.cmake_args and not args.pristine:
 				print(args.cmake_args)
 				raise RuntimeError("Some CMake arguments are ignored in incremental builds, "
 						   + f"you must delete {abs_build_dir} first")

--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -456,7 +456,9 @@ def build_platforms():
 			print(f"XTENSA_TOOLCHAIN_PATH={XTENSA_TOOLCHAIN_PATH}")
 			print(f"TOOLCHAIN_VER={TOOLCHAIN_VER}")
 
-			# set variables expected by xcc toolchain
+			# Set variables expected by xcc toolchain. CMake cannot set (evil) build-time
+			# environment variables at configure time:
+			# https://gitlab.kitware.com/cmake/community/-/wikis/FAQ#how-can-i-get-or-set-environment-variables
 			XTENSA_BUILDS_DIR=str(pathlib.Path(xtensa_tools_root_dir, "install", "builds",
 				TOOLCHAIN_VER).absolute())
 			XTENSA_SYSTEM = str(pathlib.Path(XTENSA_BUILDS_DIR, XTENSA_CORE, "config").absolute())

--- a/west.yml
+++ b/west.yml
@@ -1,3 +1,4 @@
+---
 # SOF west manifest
 manifest:
   version: "0.13"

--- a/zephyr/docker-build.sh
+++ b/zephyr/docker-build.sh
@@ -15,6 +15,10 @@ unset ZEPHYR_BASE
 # Make sure we're in the right place
 test -e ./sof/scripts/xtensa-build-zephyr.py
 
+# See .github/workflows/zephyr.yml
+PATH="$PATH":/opt/sparse/bin
+command -v sparse  || true
+: REAL_CC="$REAL_CC"
 
 # See https://stackoverflow.com/questions/35291520/docker-and-userns-remap-how-to-manage-volume-permissions-to-share-data-betwee + many others
 exec_as_sof_uid()
@@ -52,7 +56,7 @@ exec_as_sof_uid()
     # Double sudo to work around some funny restriction in
     # zephyr-build:/etc/sudoers: 'user' can do anything but... only as
     # root.
-    sudo sudo -u "$sof_user" "$0" "$@"
+    sudo sudo -u "$sof_user" REAL_CC="$REAL_CC" "$0" "$@"
     exit "$?"
 }
 
@@ -76,4 +80,7 @@ if test -e .west || test -e zephyr; then
 else
     init_update='-u'
 fi
-./sof/scripts/xtensa-build-zephyr.py $init_update --no-interactive "$@"
+
+# To investigate what went wrong enable the trailing comment.
+# This cannot be enabled by default for automation reasons.
+./sof/scripts/xtensa-build-zephyr.py $init_update --no-interactive "$@" # || /bin/bash

--- a/zephyr/docker-run.sh
+++ b/zephyr/docker-run.sh
@@ -53,6 +53,7 @@ main()
     docker run -i -v "$(west topdir)":/zep_workspace \
            --workdir /zep_workspace \
            $SOF_DOCKER_RUN \
+           --env REAL_CC \
            ghcr.io/zephyrproject-rtos/zephyr-build:latest \
            "$@"
 }


### PR DESCRIPTION
4 commits.

Main one:

The next step is to find how to extract the (too many?) errors.

In the mean time this already makes sure the build process never bitrots
and that it will always possible to use sparse. It also "documents" how
to use sparse: just copy/paste the commands run by CI.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>
