### PR TITLE
ipc4: block mixin pipeline if no active sink

### DIFF
--- a/src/audio/mixin_mixout.c
+++ b/src/audio/mixin_mixout.c
@@ -742,10 +742,7 @@ static int mixin_copy(struct comp_dev *dev)
 	bytes_to_consume_from_source_buf = 0;
 	if (source_avail_frames > 0) {
 		if (active_mixout_cnt == 0) {
-			/* discard source data */
-			comp_update_buffer_consume(source_c,
-						   audio_stream_period_bytes(&source_c->stream,
-									     source_avail_frames));
+			/* block mixin pipeline until at least one mixout pipeline started */
 			buffer_release(source_c);
 			return 0;
 		}


### PR DESCRIPTION
In case mixin pipeline is running but mixout pipeline is not -- do not discard source data but block source pipeline until at least one sink (mixout) started.

A typical topology is to have mixin and mixout in separate pipelines. Often, mixout pipeline is started a few milliseconds later after mixin pipeline. In such case mixin pipeline should be blocked until mixout pipeline started to do not loose any audio periods.

Signed-off-by: Serhiy Katsyuba <serhiy.katsyuba@intel.com>