### PR TITLE
xtensa-build-zephyr.py: remove misleading -i IPC3 option

### DIFF
--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -14,14 +14,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Using groups to avoid spamming the small results box with too
+        # many lines. Pay attention to COMMAS.
         IPC_platforms: [
-          # IPC3
+          # - IPC3 default
           apl cnl,
           icl jsl,
           tgl tgl-h,
           imx8 imx8x imx8m,
+          # - IPC4 default
           mtl,
-          # only tgl has IPC4 overlay file now
+          # Very few IPC3 platforms support IPC4 too.
           -i IPC4 tgl,
         ]
         zephyr_revision: [

--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -152,8 +152,9 @@ def parse_args():
 						help="List of platforms to build")
 	parser.add_argument("-d", "--debug", required=False, action="store_true",
 						help="Enable debug build")
-	parser.add_argument("-i", "--ipc", required=False, choices=["IPC3", "IPC4"],
-						default="IPC3", help="IPC major version")
+	parser.add_argument("-i", "--ipc", required=False, choices=["IPC4"],
+			    help="""Generic shortcut for: --overlay <platform>/ipc4_overlay.conf. Valid only
+for IPC3 platforms supporting IPC4 too.""")
     # NO SOF release will ever user the option --fw-naming.
     # This option is only for disguising SOF IPC4 as CAVS IPC4 and only in cases where
     # the kernel 'ipc_type' expects CAVS IPC4. In this way, developers and CI can test


### PR DESCRIPTION
`./xtensa-build-zephyr.py -i IPC3 mtl` builds the MTL default: IPC4.
This is wrong, remove the misleading "IPC3" option which never did
anything at all.

Fix the --help string to describe what actually happens. This is a build
script, no need for fancy abstractions and indirections that don't even
match reality. Just tell it like it is.