### PR TITLE
topology2: Revert the conditional topology2 building for CAVS/ACE

### DIFF
--- a/tools/topology/topology2/CMakeLists.txt
+++ b/tools/topology/topology2/CMakeLists.txt
@@ -17,8 +17,4 @@ else()
 	endif()
 endif()
 
-if (CONFIG_CAVS)
 add_subdirectory(cavs)
-elseif(CONFIG_ACE)
-add_subdirectory(ace)
-endif()


### PR DESCRIPTION
The MTL support added conditional build for topology2 based on CONFIG_CAVS or CONFIG_ACE.
This is wrong for several reasons:
There is not ace directory present
The Kconfig system is not used when building topologies, so we are ending up not building topology2 files at all.

There is no reason why CAVS and ACE topologies should be exclusive.

Fixes: 784bce763c0e ("mtl: Added meteorlake platform to the build system")
Signed-off-by: Peter Ujfalusi <peter.ujfalusi@linux.intel.com>