### PR TITLE
cherry pick module_adapter changes from main to amd_rn_dts

### DIFF
--- a/src/audio/module_adapter/module/cadence.c
+++ b/src/audio/module_adapter/module/cadence.c
@@ -653,7 +653,6 @@ cadence_codec_process(struct processing_module *mod,
 
 static int cadence_codec_reset(struct processing_module *mod)
 {
-	struct comp_dev *dev = mod->dev;
 	struct module_data *codec = &mod->priv;
 	struct cadence_codec_data *cd = codec->private;
 	int ret;
@@ -674,12 +673,6 @@ static int cadence_codec_reset(struct processing_module *mod)
 
 	rfree(cd->self);
 	cd->self = NULL;
-
-	ret = cadence_codec_prepare(mod);
-	if (ret) {
-		comp_err(dev, "cadence_codec_reset() error %x: could not re-prepare codec after reset",
-			ret);
-	}
 
 	return ret;
 }

--- a/src/audio/module_adapter/module/generic.c
+++ b/src/audio/module_adapter/module/generic.c
@@ -279,6 +279,7 @@ int module_reset(struct processing_module *mod)
 	md->cfg.avail = false;
 	md->cfg.size = 0;
 	rfree(md->cfg.data);
+	md->cfg.data = NULL;
 
 	/*
 	 * reset the state to allow the module's prepare callback to be invoked again for the
@@ -318,9 +319,11 @@ int module_free(struct processing_module *mod)
 	md->cfg.avail = false;
 	md->cfg.size = 0;
 	rfree(md->cfg.data);
-	if (md->runtime_params)
+	md->cfg.data = NULL;
+	if (md->runtime_params) {
 		rfree(md->runtime_params);
-
+		md->runtime_params = NULL;
+	}
 	md->state = MODULE_DISABLED;
 
 	return ret;

--- a/src/audio/module_adapter/module/generic.c
+++ b/src/audio/module_adapter/module/generic.c
@@ -280,10 +280,11 @@ int module_reset(struct processing_module *mod)
 	md->cfg.size = 0;
 	rfree(md->cfg.data);
 
-	/* module resets itself to the initial condition after prepare()
-	 * so let's change its state to reflect that.
+	/*
+	 * reset the state to allow the module's prepare callback to be invoked again for the
+	 * subsequent triggers
 	 */
-	md->state = MODULE_IDLE;
+	md->state = MODULE_INITIALIZED;
 
 	return 0;
 }

--- a/src/audio/module_adapter/module/passthrough.c
+++ b/src/audio/module_adapter/module/passthrough.c
@@ -96,22 +96,20 @@ passthrough_codec_process(struct processing_module *mod,
 
 static int passthrough_codec_reset(struct processing_module *mod)
 {
+	struct module_data *codec = &mod->priv;
+
 	comp_info(mod->dev, "passthrough_codec_reset()");
 
-	/* nothing to do */
+	rfree(codec->mpd.in_buff);
+	rfree(codec->mpd.out_buff);
 	return 0;
 }
 
 static int passthrough_codec_free(struct processing_module *mod)
 {
-	struct comp_dev *dev = mod->dev;
-	struct module_data *codec = &mod->priv;
-
 	comp_info(dev, "passthrough_codec_free()");
 
-	rfree(codec->mpd.in_buff);
-	rfree(codec->mpd.out_buff);
-
+	/* Nothing to do */
 	return 0;
 }
 

--- a/src/include/sof/audio/module_adapter/module/generic.h
+++ b/src/include/sof/audio/module_adapter/module/generic.h
@@ -190,12 +190,12 @@ struct module_interface {
 	/**
 	 * Module specific reset procedure, called as part of module_adapter component
 	 * reset in .reset(). This should reset all parameters to their initial stage
-	 * but leave allocated memory intact.
+	 * and free all memory allocated during prepare().
 	 */
 	int (*reset)(struct processing_module *mod);
 	/**
 	 * Module specific free procedure, called as part of module_adapter component
-	 * free in .free(). This should free all memory allocated by module.
+	 * free in .free(). This should free all memory allocated during module initialization.
 	 */
 	int (*free)(struct processing_module *mod);
 };


### PR DESCRIPTION
b3106c396e540c260bba3b08c218f6598ea74726 module_adapter: get the actual period_bytes
b9889d52d0e1b6002ee016b55fa0487544fc0593 module_adapter: Modify reset API
53b3bc6a956ae5957966336f88980438f1f85a88 module_adapter:Fix dangling pointer issue in module reset