### PR TITLE
cherry pick module_adapter changes from main to mt8195/v0.4

### DIFF
--- a/src/audio/codec_adapter/codec/generic.c
+++ b/src/audio/codec_adapter/codec/generic.c
@@ -322,10 +322,11 @@ int module_reset(struct comp_dev *dev)
 	md->r_cfg.size = 0;
 	rfree(md->r_cfg.data);
 
-	/* module resets itself to the initial condition after prepare()
-	 * so let's change its state to reflect that.
+	/*
+	 * reset the state to allow the module's prepare callback to be invoked again for the
+	 * subsequent triggers
 	 */
-	md->state = MODULE_IDLE;
+	md->state = MODULE_INITIALIZED;
 
 	return 0;
 }

--- a/src/audio/codec_adapter/codec/generic.c
+++ b/src/audio/codec_adapter/codec/generic.c
@@ -321,6 +321,7 @@ int module_reset(struct comp_dev *dev)
 	md->r_cfg.avail = false;
 	md->r_cfg.size = 0;
 	rfree(md->r_cfg.data);
+	md->r_cfg.data = NULL;
 
 	/*
 	 * reset the state to allow the module's prepare callback to be invoked again for the
@@ -367,9 +368,13 @@ int module_free(struct comp_dev *dev)
 	md->r_cfg.size = 0;
 	rfree(md->r_cfg.data);
 	rfree(md->s_cfg.data);
-	if (md->runtime_params)
-		rfree(md->runtime_params);
+	md->r_cfg.data = NULL;
+	md->s_cfg.data = NULL;
 
+	if (md->runtime_params) {
+		rfree(md->runtime_params);
+		md->runtime_params = NULL;
+	}
 	md->state = MODULE_DISABLED;
 
 	return ret;

--- a/src/audio/codec_adapter/codec_adapter.c
+++ b/src/audio/codec_adapter/codec_adapter.c
@@ -135,6 +135,13 @@ int codec_adapter_prepare(struct comp_dev *dev)
 		return PPL_STATUS_PATH_STOP;
 	}
 
+
+	/* Get period_bytes first on prepare(). At this point it is guaranteed that the stream
+	 * parameter from sink buffer is settled, and still prior to all references to period_bytes.
+	 */
+	mod->period_bytes = audio_stream_period_bytes(&mod->ca_sink->stream, dev->frames);
+	comp_dbg(dev, "codec_adapter_prepare(): got period_bytes = %u", mod->period_bytes);
+
 	/* Prepare codec */
 	ret = module_prepare(dev);
 	if (ret) {
@@ -209,8 +216,6 @@ int codec_adapter_params(struct comp_dev *dev,
 		       params, sizeof(struct sof_ipc_stream_params));
 	assert(!ret);
 
-	mod->period_bytes = params->sample_container_bytes *
-			   params->channels * params->rate / 1000;
 	return 0;
 }
 

--- a/src/include/sof/audio/codec_adapter/codec/generic.h
+++ b/src/include/sof/audio/codec_adapter/codec/generic.h
@@ -97,12 +97,12 @@ struct module_interface {
 	/**
 	 * Module specific reset procedure, called as part of codec_adapter component
 	 * reset in .reset(). This should reset all parameters to their initial stage
-	 * but leave allocated memory intact.
+	 * and free all memory allocated during prepare().
 	 */
 	int (*reset)(struct comp_dev *dev);
 	/**
 	 * Module specific free procedure, called as part of codec_adapter component
-	 * free in .free(). This should free all memory allocated by module.
+	 * free in .free(). This should free all memory allocated during module initialization.
 	 */
 	int (*free)(struct comp_dev *dev);
 };


### PR DESCRIPTION
https://github.com/thesofproject/sof/commit/b3106c396e540c260bba3b08c218f6598ea74726 module_adapter: get the actual period_bytes
https://github.com/thesofproject/sof/commit/b9889d52d0e1b6002ee016b55fa0487544fc0593 module_adapter: Modify reset API
https://github.com/thesofproject/sof/commit/53b3bc6a956ae5957966336f88980438f1f85a88 module_adapter:Fix dangling pointer issue in module reset

Note that commits were modified to be rollback-applied to codec_adapter instead.