### PR TITLE
cherry pick module_adapter changes from main to adl-004-drop-stable

### DIFF
--- a/src/audio/codec_adapter/codec/generic.c
+++ b/src/audio/codec_adapter/codec/generic.c
@@ -335,6 +335,7 @@ int codec_reset(struct comp_dev *dev)
 	codec->r_cfg.avail = false;
 	codec->r_cfg.size = 0;
 	rfree(codec->r_cfg.data);
+	codec->r_cfg.data = NULL;
 
 	/*
 	 * reset the state to allow the codec's prepare callback to be invoked again for the
@@ -381,9 +382,13 @@ int codec_free(struct comp_dev *dev)
 	codec->r_cfg.size = 0;
 	rfree(codec->r_cfg.data);
 	rfree(codec->s_cfg.data);
-	if (codec->runtime_params)
-		rfree(codec->runtime_params);
+	codec->r_cfg.data = NULL;
+	codec->s_cfg.data = NULL;
 
+	if (codec->runtime_params) {
+		rfree(codec->runtime_params);
+		codec->runtime_params = NULL;
+	}
 	codec->state = CODEC_DISABLED;
 
 	return ret;

--- a/src/audio/codec_adapter/codec/generic.c
+++ b/src/audio/codec_adapter/codec/generic.c
@@ -336,10 +336,11 @@ int codec_reset(struct comp_dev *dev)
 	codec->r_cfg.size = 0;
 	rfree(codec->r_cfg.data);
 
-	/* Codec reset itself to the initial condition after prepare()
-	 * so let's change its state to reflect that.
+	/*
+	 * reset the state to allow the codec's prepare callback to be invoked again for the
+	 * subsequent triggers
 	 */
-	codec->state = CODEC_IDLE;
+	codec->state = CODEC_INITIALIZED;
 
 	return 0;
 }

--- a/src/audio/codec_adapter/codec_adapter.c
+++ b/src/audio/codec_adapter/codec_adapter.c
@@ -203,6 +203,12 @@ int codec_adapter_prepare(struct comp_dev *dev)
 		return PPL_STATUS_PATH_STOP;
 	}
 
+	/* Get period_bytes first on prepare(). At this point it is guaranteed that the stream
+	 * parameter from sink buffer is settled, and still prior to all references to period_bytes.
+	 */
+	cd->period_bytes = audio_stream_period_bytes(&cd->ca_sink->stream, dev->frames);
+	comp_dbg(dev, "codec_adapter_prepare(): got period_bytes = %u", cd->period_bytes);
+
 	/* Prepare codec */
 	ret = codec_prepare(dev);
 	if (ret) {
@@ -278,8 +284,6 @@ int codec_adapter_params(struct comp_dev *dev,
 		       params, sizeof(struct sof_ipc_stream_params));
 	assert(!ret);
 
-	cd->period_bytes = params->sample_container_bytes *
-			   params->channels * params->rate / 1000;
 	return 0;
 }
 

--- a/src/include/sof/audio/codec_adapter/codec/generic.h
+++ b/src/include/sof/audio/codec_adapter/codec/generic.h
@@ -116,12 +116,12 @@ struct codec_interface {
 	/**
 	 * Codec specific reset procedure, called as part of codec_adapter component
 	 * reset in .reset(). This should reset all parameters to their initial stage
-	 * but leave allocated memory intact.
+	 * and free all memory allocated during prepare().
 	 */
 	int (*reset)(struct comp_dev *dev);
 	/**
 	 * Codec specific free procedure, called as part of codec_adapter component
-	 * free in .free(). This should free all memory allocated by codec.
+	 * free in .free(). This should free all memory allocated during codec initialization.
 	 */
 	int (*free)(struct comp_dev *dev);
 };


### PR DESCRIPTION
https://github.com/thesofproject/sof/commit/b3106c396e540c260bba3b08c218f6598ea74726 module_adapter: get the actual period_bytes
https://github.com/thesofproject/sof/commit/b9889d52d0e1b6002ee016b55fa0487544fc0593 module_adapter: Modify reset API
https://github.com/thesofproject/sof/commit/53b3bc6a956ae5957966336f88980438f1f85a88 module_adapter:Fix dangling pointer issue in module reset

Note that commits were modified to be rollback-applied to codec_adapter instead.