### PR TITLE
Audio: EQ-IIR: Fix the bug of parallel EQ calculation

### DIFF
--- a/src/math/iir_df2t_generic.c
+++ b/src/math/iir_df2t_generic.c
@@ -60,8 +60,9 @@ int32_t iir_df2t(struct iir_state_df2t *iir, int32_t x)
 		return x;
 
 	/* Coefficients order in coef[] is {a2, a1, b2, b1, b0, shift, gain} */
-	in = x;
 	for (j = 0; j < iir->biquads; j += iir->biquads_in_series) {
+		/* the first for loop is for parallel EQs, and they have the same input */
+		in = x;
 		for (i = 0; i < iir->biquads_in_series; i++) {
 			/* Compute output: Delay is Q3.61
 			 * Q2.30 x Q1.31 -> Q3.61

--- a/src/math/iir_df2t_hifi3.c
+++ b/src/math/iir_df2t_hifi3.c
@@ -71,8 +71,9 @@ int32_t iir_df2t(struct iir_state_df2t *iir, int32_t x)
 	/* Coefficients order in coef[] is {a2, a1, b2, b1, b0, shift, gain} */
 	coefp = (ae_f32x2 *)&iir->coef[0];
 	delayp = (ae_f64 *)&iir->delay[0];
-	in = x;
 	for (j = 0; j < iir->biquads; j += nseries) {
+		/* the first for loop is for parallel EQs, and they have the same input */
+		in = x;
 		for (i = 0; i < nseries; i++) {
 			/* Compute output: Delay is kept Q17.47 while multiply
 			 * instruction gives Q2.30 x Q1.31 -> Q18.46. Need to


### PR DESCRIPTION
As for our previous design, if we have parallel EQs like filters bank, they get the same input and outputs are summed. There is a mistake of the input assignment in our current code, this commit will fix it.

Signed-off-by: Andrula Song <xiaoyuan.song@intel.com>