### PR TITLE
Revert "topology2: nocodec: add volume and mixer support"

### DIFF
--- a/tools/topology/topology2/cavs/cavs-nocodec.conf
+++ b/tools/topology/topology2/cavs/cavs-nocodec.conf
@@ -11,11 +11,9 @@
 <pdm_config.conf>
 <tokens.conf>
 <virtual.conf>
+<passthrough-playback.conf>
 <passthrough-capture.conf>
 <passthrough-be.conf>
-<host-copier-gain-mixin-playback.conf>
-<mixout-gain-dai-copier-playback.conf>
-<gain-capture.conf>
 <data.conf>
 <pcm.conf>
 <pcm_caps.conf>
@@ -118,36 +116,13 @@ Object.Dai {
 #
 # Pipeline definitions
 #
-# PCM0 ---> gain ----> Mixin ----> Mixout ----> gain ----> SSP0
-# PCM1 ---> gain ----> Mixin ----> Mixout ----> gain ----> SSP1
-# PCM2 ---> gain ----> Mixin ----> Mixout ----> gain ----> SSP2
-#
-# SSP0 ---> gain ----> PCM0
-# SSP1 ---> gain ----> PCM1
-# SSP2 ---> gain ----> PCM2
 
 # Pipeline ID:1 PCM ID: 0
 Object.Pipeline {
 	# playback pipelines
-	host-copier-gain-mixin-playback.1 {
-		index	1
-
-		Object.Widget.pipeline.1 {
-			stream_name 'NoCodec-0'
-		}
-		Object.Widget.copier.1 {
-			stream_name 'SSP0 Playback'
-		}
-		Object.Widget.gain.1 {
-			Object.Control.mixer.1 {
-				name 'Playback Volume 1'
-			}
-		}
-	}
-
-	mixout-gain-dai-copier-playback.1 {
-		index 2
-
+	passthrough-be.1 {
+		index	2
+		direction	playback
 		Object.Widget.pipeline.1 {
 			stream_name 'NoCodec-0'
 		}
@@ -159,33 +134,21 @@ Object.Pipeline {
 			stream_name "NoCodec-0"
 			node_type $I2S_LINK_OUTPUT_CLASS
 		}
-
-		Object.Widget.gain.1 {
-			Object.Control.mixer.1 {
-				name 'Main Playback Volume 2'
-			}
-		}
 	}
 
-	host-copier-gain-mixin-playback.2 {
-		index	3
-
+	passthrough-playback.1 {
+		index	1
 		Object.Widget.pipeline.1 {
-			stream_name 'NoCodec-1'
+			stream_name 'NoCodec-0'
 		}
 		Object.Widget.copier.1 {
-			stream_name 'SSP1 Playback'
-		}
-		Object.Widget.gain.1 {
-			Object.Control.mixer.1 {
-				name 'Playback Volume 3'
-			}
+			stream_name 'SSP0 Playback'
 		}
 	}
 
-	mixout-gain-dai-copier-playback.2 {
-		index 4
-
+	passthrough-be.2 {
+		index	4
+		direction	playback
 		Object.Widget.pipeline.1 {
 			stream_name 'NoCodec-1'
 		}
@@ -197,65 +160,52 @@ Object.Pipeline {
 			stream_name "NoCodec-1"
 			node_type $I2S_LINK_OUTPUT_CLASS
 		}
+	}
 
-		Object.Widget.gain.1 {
-			Object.Control.mixer.1 {
-				name 'Main Playback Volume 4'
-			}
+	passthrough-playback.2 {
+		index	3
+		Object.Widget.pipeline.1 {
+			stream_name 'NoCodec-1'
+		}
+		Object.Widget.copier.1 {
+			stream_name 'SSP1 Playback'
 		}
 	}
 
-	host-copier-gain-mixin-playback.3 {
-		index	5
+	passthrough-be.3 {
+		index	6
+		direction	playback
+		Object.Widget.pipeline.1 {
+			stream_name 'NoCodec-2'
+		}
 
+		Object.Widget.copier.1 {
+			dai_index 2
+			dai_type "SSP"
+			copier_type "SSP"
+			stream_name "NoCodec-2"
+			node_type $I2S_LINK_OUTPUT_CLASS
+		}
+	}
+
+	passthrough-playback.3 {
+		index	5
 		Object.Widget.pipeline.1 {
 			stream_name 'NoCodec-2'
 		}
 		Object.Widget.copier.1 {
 			stream_name 'SSP2 Playback'
 		}
-		Object.Widget.gain.1 {
-			Object.Control.mixer.1 {
-				name 'Playback Volume 5'
-			}
-		}
-	}
-
-	mixout-gain-dai-copier-playback.3 {
-		index 6
-
-		Object.Widget.pipeline.1 {
-			stream_name 'NoCodec-2'
-		}
-
-		Object.Widget.copier.1 {
-			dai_index 1
-			dai_type "SSP"
-			copier_type "SSP"
-			stream_name "NoCodec-2"
-			node_type $I2S_LINK_OUTPUT_CLASS
-		}
-
-		Object.Widget.gain.1 {
-			Object.Control.mixer.1 {
-				name 'Main Playback Volume 6'
-			}
-		}
 	}
 
 	# capture pipelines
-	gain-capture.1 {
+	passthrough-capture.1 {
 		index 	7
 		Object.Widget.pipeline.1 {
 			stream_name 'NoCodec-0'
 		}
 		Object.Widget.copier.1 {
 			stream_name 'SSP0 Capture'
-		}
-		Object.Widget.gain.1 {
-			Object.Control.mixer.1 {
-				name 'Main Capture Volume 7'
-			}
 		}
 	}
 
@@ -283,18 +233,13 @@ Object.Pipeline {
 		}
 	}
 
-	gain-capture.2 {
+	passthrough-capture.2 {
 		index 	9
 		Object.Widget.pipeline.1 {
 			stream_name 'NoCodec-1'
 		}
 		Object.Widget.copier.1 {
 			stream_name 'SSP1 Capture'
-		}
-		Object.Widget.gain.1 {
-			Object.Control.mixer.1 {
-				name 'Main Capture Volume 9'
-			}
 		}
 	}
 
@@ -322,18 +267,13 @@ Object.Pipeline {
 		}
 	}
 
-	gain-capture.3 {
+	passthrough-capture.3 {
 		index 	11
 		Object.Widget.pipeline.1 {
 			stream_name 'NoCodec-2'
 		}
 		Object.Widget.copier.1 {
 			stream_name 'SSP2 Capture'
-		}
-		Object.Widget.gain.1 {
-			Object.Control.mixer.1 {
-				name 'Main Capture Volume 11'
-			}
 		}
 	}
 
@@ -415,45 +355,33 @@ Object.PCM {
 
 Object.Base {
 	route."1" {
-		source	"gain.2.1"
+		source	"copier.host.1.1"
 		sink	"copier.SSP.2.1"
 	}
 
 	route."2" {
-		source	"mixin.1.1"
-		sink	"mixout.2.1"
+		source	"copier.host.3.1"
+		sink	"copier.SSP.4.1"
 	}
 
 	route."3" {
-		source	"gain.4.1"
-		sink	"copier.SSP.4.1"
+		source	"copier.host.5.1"
+		sink	"copier.SSP.6.1"
 	}
+
 	route."4" {
-		source	"mixin.3.1"
-		sink	"mixout.4.1"
+		source	"copier.SSP.8.1"
+		sink	"copier.host.7.1"
 	}
 
 	route."5" {
-		source	"gain.6.1"
-		sink	"copier.SSP.6.1"
-	}
-	route."6" {
-		source	"mixin.5.1"
-		sink	"mixout.6.1"
-	}
-
-	route."7" {
-		source	"copier.SSP.8.1"
-		sink	"gain.7.1"
-	}
-
-	route."8" {
 		source	"copier.SSP.10.1"
-		sink	"gain.9.1"
+		sink	"copier.host.9.1"
 	}
 
-	route."9" {
+	route."6" {
 		source	"copier.SSP.12.1"
-		sink	"gain.11.1"
+		sink	"copier.host.11.1"
 	}
+
 }


### PR DESCRIPTION
This reverts commit e31c7abeeb59051c4bc529f77488feaa9585a7d5.

This caused most tests to fail on sh-tglu-rvp-nocodec-ci-02 in daily run 15919, see some more errors in logs shared in initial PR #6318 and new issue #6367
```
  FW reported error: 113 - Invalid destination queue (pin) ID provided
  ipc error for msg 0x45000004|0x6
  sof_ipc4_route_setup: failed to bind modules copier.SSP.8.1 -> gain.7.1
```
I don't know why this failed and I did NOT test this revert, however:
- This topology change is apparently the only thing that changed compared to the day before.
- The error message seems very much related.
- Other people seem to agree.
- According to Ranjani, this feature is not urgent.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>