### PR TITLE
zephyr: app: tune logging configuration for SOF needs

### DIFF
--- a/app/prj.conf
+++ b/app/prj.conf
@@ -1,8 +1,11 @@
 CONFIG_SOF=y
-CONFIG_LOG=y
-CONFIG_LOG_PRINTK=y
 CONFIG_BUILD_OUTPUT_BIN=n
 CONFIG_HAVE_AGENT=n
+
+CONFIG_LOG=y
+CONFIG_LOG_PRINTK=y
+# Log processing is offloaded to a low-priority thread.
+CONFIG_LOG_MODE_DEFERRED=y
 
 # Requires heap_info() be implemented, but no Zephyr wrapper
 CONFIG_DEBUG_MEMORY_USAGE_SCAN=n

--- a/app/prj.conf
+++ b/app/prj.conf
@@ -13,6 +13,8 @@ CONFIG_LOG_PROCESS_THREAD_SLEEP_MS=100
 # Frontend buffer must be large enough to cover all
 # typical bursts of log messages.
 CONFIG_LOG_BUFFER_SIZE=4096
+# Use stack that is sufficient for SOF backends
+CONFIG_LOG_PROCESS_THREAD_STACK_SIZE=4096
 
 # Requires heap_info() be implemented, but no Zephyr wrapper
 CONFIG_DEBUG_MEMORY_USAGE_SCAN=n

--- a/app/prj.conf
+++ b/app/prj.conf
@@ -10,6 +10,9 @@ CONFIG_LOG_MODE_DEFERRED=y
 # if more than 5 messages are queued by the frontend.
 CONFIG_LOG_PROCESS_TRIGGER_THRESHOLD=5
 CONFIG_LOG_PROCESS_THREAD_SLEEP_MS=100
+# Frontend buffer must be large enough to cover all
+# typical bursts of log messages.
+CONFIG_LOG_BUFFER_SIZE=4096
 
 # Requires heap_info() be implemented, but no Zephyr wrapper
 CONFIG_DEBUG_MEMORY_USAGE_SCAN=n

--- a/app/prj.conf
+++ b/app/prj.conf
@@ -6,6 +6,10 @@ CONFIG_LOG=y
 CONFIG_LOG_PRINTK=y
 # Log processing is offloaded to a low-priority thread.
 CONFIG_LOG_MODE_DEFERRED=y
+# Wake the low-priority log thread every 100ms and/or
+# if more than 5 messages are queued by the frontend.
+CONFIG_LOG_PROCESS_TRIGGER_THRESHOLD=5
+CONFIG_LOG_PROCESS_THREAD_SLEEP_MS=100
 
 # Requires heap_info() be implemented, but no Zephyr wrapper
 CONFIG_DEBUG_MEMORY_USAGE_SCAN=n


### PR DESCRIPTION
A set of patches to make the logging subsystem configuration explicit for SOF builds (e.g. use of DEFERRED mode) and tune various settings to be more appropriate for rate/usage/pattern of logs typical to SOF.

These settings are on the safe side (e.g. with stack size), and invidividual product overlay may switch to more optimized settings. But at top-level it makes sense to use values that work across all typical SOF usage.


