### PR TITLE
audio: buffer: fix crash with IPC4 build and DBG log level

### DIFF
--- a/src/audio/buffer.c
+++ b/src/audio/buffer.c
@@ -218,10 +218,10 @@ void comp_update_buffer_produce(struct comp_buffer __sparse_cache *buffer, uint3
 	/* return if no bytes */
 	if (!bytes) {
 		buf_dbg(buffer, "comp_update_buffer_produce(), no bytes to produce, source->comp.id = %u, source->comp.type = %u, sink->comp.id = %u, sink->comp.type = %u",
-			dev_comp_id(buffer->source),
-			dev_comp_type(buffer->source),
-			dev_comp_id(buffer->sink),
-			dev_comp_type(buffer->sink));
+			buffer->source ? dev_comp_id(buffer->source) : (unsigned int)UINT32_MAX,
+			buffer->source ? dev_comp_type(buffer->source) : (unsigned int)UINT32_MAX,
+			buffer->sink ? dev_comp_id(buffer->sink) : (unsigned int)UINT32_MAX,
+			buffer->sink ? dev_comp_type(buffer->sink) : (unsigned int)UINT32_MAX);
 		return;
 	}
 
@@ -251,10 +251,10 @@ void comp_update_buffer_consume(struct comp_buffer __sparse_cache *buffer, uint3
 	/* return if no bytes */
 	if (!bytes) {
 		buf_dbg(buffer, "comp_update_buffer_consume(), no bytes to consume, source->comp.id = %u, source->comp.type = %u, sink->comp.id = %u, sink->comp.type = %u",
-			dev_comp_id(buffer->source),
-			dev_comp_type(buffer->source),
-			dev_comp_id(buffer->sink),
-			dev_comp_type(buffer->sink));
+			buffer->source ? dev_comp_id(buffer->source) : (unsigned int)UINT32_MAX,
+			buffer->source ? dev_comp_type(buffer->source) : (unsigned int)UINT32_MAX,
+			buffer->sink ? dev_comp_id(buffer->sink) : (unsigned int)UINT32_MAX,
+			buffer->sink ? dev_comp_type(buffer->sink) : (unsigned int)UINT32_MAX);
 		return;
 	}
 


### PR DESCRIPTION
A null dereference is hit when comp_update_buffer_produce() or comp_update_buffer_consume() is called with either a NULL buffer->sink or buffer->source. This condition happens regularly in IPC4 builds.

Issue is limited to SOF builds with logging at DEBUG level.

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>