### PR TITLE
ace_v1x: host system time set and get

### DIFF
--- a/src/include/ipc4/base_fw.h
+++ b/src/include/ipc4/base_fw.h
@@ -558,6 +558,21 @@ struct ipc4_system_time_info {
 	struct ipc4_system_time dsp_time;
 } __attribute__((packed, aligned(4)));
 
+struct ipc4_ext_system_time {
+	/* Lower DWORD of current system time value. */
+	uint32_t utc_l;
+	/* Upper DWORD of current system time value. */
+	uint32_t utc_u;
+	/* Lower DWORD of current RTC value. */
+	uint32_t rtc_l;
+	/* Upper DWORD of current RTC value. */
+	uint32_t rtc_u;
+	/* Lower DWORD of current ART value. */
+	uint32_t art_l;
+	/* Upper DWORD of current ART value. */
+	uint32_t art_u;
+};
+
 enum ipc4_pipeline_attributes {
 	/* Determines whether on pipeline will be allocated module(s) with ULP capability */
 	IPC4_ULTRA_LOW_POWER     = 0,


### PR DESCRIPTION
Base firmware functionality for setting and getting system time. This is for passing the information about host system time. It is then used by FW to translate event timestamps e.g. logs to host system time domain

Signed-off-by: Piotr Kmiecik <piotrx.kmiecik@intel.com>