### PR TITLE
ipc4: add mixing-based processing in channel selector

### DIFF
--- a/src/audio/selector/selector_generic.c
+++ b/src/audio/selector/selector_generic.c
@@ -171,171 +171,145 @@ static void sel_s32le_nch(struct comp_dev *dev, struct audio_stream __sparse_cac
 #else
 #if CONFIG_FORMAT_S16LE
 /**
- * \brief Channel selection for 16 bit, 1 channel data format.
- * \param[in,out] mod Selector base module device.
+ * \brief Mixing routine for 16-bit, m channel input x n channel output single frame.
+ * \param[out] dst Sink buffer.
+ * \param[in] dst_channels Number of sink channels.
+ * \param[in] src Source data.
+ * \param[in] src_channels Number of source channels.
+ * \param[in] coeffs_config IPC4 micsel config with Q10 coefficients.
+ */
+static void process_frame_s16le(int16_t dst[], int dst_channels,
+				int16_t src[], int src_channels,
+				struct ipc4_selector_coeffs_config *coeffs_config)
+{
+	int32_t accum;
+	int i, j;
+
+	for (i = 0; i < dst_channels; i++) {
+		accum = 0;
+		for (j = 0; j < src_channels; j++)
+			accum += (int32_t)src[j] * (int32_t)coeffs_config->coeffs[i][j];
+
+		/* shift out 10 LSbits with rounding to get 16-bit result */
+		dst[i] = (int16_t)((accum + (1 << 9)) >> 10);
+	}
+}
+
+/**
+ * \brief Channel selection for 16-bit, m channel input x n channel output data format.
+ * \param[in] mod Selector base module device.
  * \param[in,out] bsource Source buffer.
  * \param[in,out] bsink Sink buffer.
  * \param[in] frames Number of frames to process.
  */
-static void sel_s16le_1ch(struct processing_module *mod, struct input_stream_buffer *bsource,
-			  struct output_stream_buffer *bsink, uint32_t frames)
+static void sel_s16le(struct processing_module *mod, struct input_stream_buffer *bsource,
+		      struct output_stream_buffer *bsink, uint32_t frames)
 {
 	struct comp_data *cd = module_get_private_data(mod);
 	struct audio_stream __sparse_cache *source = bsource->data;
 	struct audio_stream __sparse_cache *sink = bsink->data;
 	int16_t *src = source->r_ptr;
 	int16_t *dest = sink->w_ptr;
-	int16_t *src_ch;
 	int nmax;
 	int i;
 	int n;
 	int processed = 0;
-	const int source_frame_bytes = audio_stream_frame_bytes(source);
-	const unsigned int nch = source->channels;
-	const unsigned int sel_channel = cd->config.sel_channel; /* 0 to nch - 1 */
+	int source_frame_bytes = audio_stream_frame_bytes(source);
+	int sink_frame_bytes = audio_stream_frame_bytes(sink);
 
 	while (processed < frames) {
 		n = frames - processed;
 		nmax = audio_stream_bytes_without_wrap(source, src) / source_frame_bytes;
 		n = MIN(n, nmax);
-		nmax = audio_stream_bytes_without_wrap(sink, dest) >> BYTES_TO_S16_SAMPLES;
+		nmax = audio_stream_bytes_without_wrap(sink, dest) / sink_frame_bytes;
 		n = MIN(n, nmax);
-		src_ch = src + sel_channel;
 		for (i = 0; i < n; i++) {
-			*dest = *src_ch;
-			src_ch += nch;
-			dest++;
+			process_frame_s16le(dest, sink->channels, src, source->channels,
+					    &cd->coeffs_config);
+			src += source->channels;
+			dest += sink->channels;
 		}
-		src = audio_stream_wrap(source, src + nch * n);
+		src = audio_stream_wrap(source, src);
 		dest = audio_stream_wrap(sink, dest);
 		processed += n;
 	}
 
-	bsource->consumed += processed >> BYTES_TO_S16_SAMPLES;
-	bsink->size += processed >> BYTES_TO_S16_SAMPLES;
-}
-
-/**
- * \brief Channel selection for 16 bit, at least 2 channels data format.
- * \param[in,out] mod Selector base module device.
- * \param[in,out] bsource Source buffer.
- * \param[in,out] bsink Sink buffer.
- * \param[in] frames Number of frames to process.
- */
-static void sel_s16le_nch(struct processing_module *mod, struct input_stream_buffer *bsource,
-			  struct output_stream_buffer *bsink, uint32_t frames)
-{
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
-	int8_t *src = (int8_t *)source->r_ptr;
-	int8_t *dst = (int8_t *)sink->w_ptr;
-	int bmax;
-	int b;
-	int bytes_copied = 0;
-	const int bytes_total = frames * audio_stream_frame_bytes(source);
-
-	while (bytes_copied < bytes_total) {
-		b = bytes_total - bytes_copied;
-		bmax = audio_stream_bytes_without_wrap(source, src);
-		b = MIN(b, bmax);
-		bmax = audio_stream_bytes_without_wrap(sink, dst);
-		b = MIN(b, bmax);
-		memcpy_s(dst, b, src, b);
-		src = audio_stream_wrap(source, src + b);
-		dst = audio_stream_wrap(sink, dst + b);
-		bytes_copied += b;
-	}
-
-	bsource->consumed += bytes_copied >> BYTES_TO_S16_SAMPLES;
-	bsink->size += bytes_copied >> BYTES_TO_S16_SAMPLES;
+	module_update_buffer_position(bsource, bsink, frames);
 }
 #endif /* CONFIG_FORMAT_S16LE */
 
 #if CONFIG_FORMAT_S24LE || CONFIG_FORMAT_S32LE
 /**
- * \brief Channel selection for 32 bit, 1 channel data format.
- * \param[in,out] mod Selector base module device.
+ * \brief Mixing routine for 32-bit, m channel input x n channel output single frame.
+ * \param[out] dst Sink buffer.
+ * \param[in] dst_channels Number of sink channels.
+ * \param[in] src Source data.
+ * \param[in] src_channels Number of source channels.
+ * \param[in] coeffs_config IPC4 micsel config with Q10 coefficients.
+ */
+static void process_frame_s32le(int32_t dst[], int dst_channels,
+				int32_t src[], int src_channels,
+				struct ipc4_selector_coeffs_config *coeffs_config)
+{
+	int64_t accum;
+	int i, j;
+
+	for (i = 0; i < dst_channels; i++) {
+		accum = 0;
+		for (j = 0; j < src_channels; j++)
+			accum += (int64_t)src[j] * (int64_t)coeffs_config->coeffs[i][j];
+
+		/* shift out 10 LSbits with rounding to get 32-bit result */
+		dst[i] = (int32_t)((accum + (1 << 9)) >> 10);
+	}
+}
+
+/**
+ * \brief Channel selection for 32-bit, m channel input x n channel output data format.
+ * \param[in] mod Selector base module device.
  * \param[in,out] bsource Source buffer.
  * \param[in,out] bsink Sink buffer.
  * \param[in] frames Number of frames to process.
  */
-static void sel_s32le_1ch(struct processing_module *mod, struct input_stream_buffer *bsource,
-			  struct output_stream_buffer *bsink, uint32_t frames)
+static void sel_s32le(struct processing_module *mod, struct input_stream_buffer *bsource,
+		      struct output_stream_buffer *bsink, uint32_t frames)
 {
 	struct comp_data *cd = module_get_private_data(mod);
 	struct audio_stream __sparse_cache *source = bsource->data;
 	struct audio_stream __sparse_cache *sink = bsink->data;
 	int32_t *src = source->r_ptr;
 	int32_t *dest = sink->w_ptr;
-	int32_t *src_ch;
 	int nmax;
 	int i;
 	int n;
 	int processed = 0;
-	const int source_frame_bytes = audio_stream_frame_bytes(source);
-	const unsigned int nch = source->channels;
-	const unsigned int sel_channel = cd->config.sel_channel; /* 0 to nch - 1 */
+	int source_frame_bytes = audio_stream_frame_bytes(source);
+	int sink_frame_bytes = audio_stream_frame_bytes(sink);
 
 	while (processed < frames) {
 		n = frames - processed;
 		nmax = audio_stream_bytes_without_wrap(source, src) / source_frame_bytes;
 		n = MIN(n, nmax);
-		nmax = audio_stream_bytes_without_wrap(sink, dest) >> BYTES_TO_S32_SAMPLES;
+		nmax = audio_stream_bytes_without_wrap(sink, dest) / sink_frame_bytes;
 		n = MIN(n, nmax);
-		src_ch = src + sel_channel;
 		for (i = 0; i < n; i++) {
-			*dest = *src_ch;
-			src_ch += nch;
-			dest++;
+			process_frame_s32le(dest, sink->channels, src, source->channels,
+					    &cd->coeffs_config);
+			src += source->channels;
+			dest += sink->channels;
 		}
-		src = audio_stream_wrap(source, src + nch * n);
+		src = audio_stream_wrap(source, src);
 		dest = audio_stream_wrap(sink, dest);
 		processed += n;
 	}
 
-	bsource->consumed += processed >> BYTES_TO_S32_SAMPLES;
-	bsink->size += processed >> BYTES_TO_S32_SAMPLES;
-}
-
-/**
- * \brief Channel selection for 32 bit, at least 2 channels data format.
- * \param[in,out] mod Selector base module device.
- * \param[in,out] bsource Source buffer.
- * \param[in,out] bsink Sink buffer.
- * \param[in] frames Number of frames to process.
- */
-static void sel_s32le_nch(struct processing_module *mod, struct input_stream_buffer *bsource,
-			  struct output_stream_buffer *bsink, uint32_t frames)
-{
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
-
-	int8_t *src = (int8_t *)source->r_ptr;
-	int8_t *dst = (int8_t *)sink->w_ptr;
-	int bmax;
-	int b;
-	int bytes_copied = 0;
-	const int bytes_total = frames * audio_stream_frame_bytes(source);
-
-	while (bytes_copied < bytes_total) {
-		b = bytes_total - bytes_copied;
-		bmax = audio_stream_bytes_without_wrap(source, src);
-		b = MIN(b, bmax);
-		bmax = audio_stream_bytes_without_wrap(sink, dst);
-		b = MIN(b, bmax);
-		memcpy_s(dst, b, src, b);
-		src = audio_stream_wrap(source, src + b);
-		dst = audio_stream_wrap(sink, dst + b);
-		bytes_copied += b;
-	}
-
-	bsource->consumed += bytes_copied >> BYTES_TO_S32_SAMPLES;
-	bsink->size += bytes_copied >> BYTES_TO_S32_SAMPLES;
+	module_update_buffer_position(bsource, bsink, frames);
 }
 #endif /* CONFIG_FORMAT_S24LE || CONFIG_FORMAT_S32LE */
 #endif
 
 const struct comp_func_map func_table[] = {
+#if CONFIG_IPC_MAJOR_3
 #if CONFIG_FORMAT_S16LE
 	{SOF_IPC_FRAME_S16_LE, 1, sel_s16le_1ch},
 	{SOF_IPC_FRAME_S16_LE, 2, sel_s16le_nch},
@@ -351,6 +325,17 @@ const struct comp_func_map func_table[] = {
 	{SOF_IPC_FRAME_S32_LE, 2, sel_s32le_nch},
 	{SOF_IPC_FRAME_S32_LE, 4, sel_s32le_nch},
 #endif /* CONFIG_FORMAT_S32LE */
+#else
+#if CONFIG_FORMAT_S16LE
+	{SOF_IPC_FRAME_S16_LE, 0, sel_s16le},
+#endif
+#if CONFIG_FORMAT_S24LE
+	{SOF_IPC_FRAME_S24_4LE, 0, sel_s32le},
+#endif
+#if CONFIG_FORMAT_S32LE
+	{SOF_IPC_FRAME_S32_LE, 0, sel_s32le},
+#endif
+#endif
 };
 
 #if CONFIG_IPC_MAJOR_3
@@ -381,8 +366,6 @@ sel_func sel_get_processing_function(struct processing_module *mod)
 	/* map the channel selection function for source and sink buffers */
 	for (i = 0; i < ARRAY_SIZE(func_table); i++) {
 		if (cd->source_format != func_table[i].source)
-			continue;
-		if (cd->config.out_channels_count != func_table[i].out_channels)
 			continue;
 
 		/* TODO: add additional criteria as needed */

--- a/src/include/sof/audio/selector.h
+++ b/src/include/sof/audio/selector.h
@@ -27,6 +27,7 @@
 struct comp_buffer;
 struct comp_dev;
 
+#if CONFIG_IPC_MAJOR_3
 /** \brief Supported channel count on input. */
 #define SEL_SOURCE_2CH 2
 #define SEL_SOURCE_4CH 4
@@ -35,6 +36,13 @@ struct comp_dev;
 #define SEL_SINK_1CH 1
 #define SEL_SINK_2CH 2
 #define SEL_SINK_4CH 4
+#else
+/** \brief Maximum supported channel count on input. */
+#define SEL_SOURCE_CHANNELS_MAX 8
+
+/** \brief Maximum supported channel count on output. */
+#define SEL_SINK_CHANNELS_MAX   8
+#endif
 
 #if CONFIG_IPC_MAJOR_4
 /** \brief selector processing function interface */
@@ -45,6 +53,20 @@ struct micsel_data {
 	struct ipc4_base_module_cfg base_cfg;
 	struct ipc4_audio_format output_format;
 };
+
+/** \brief IPC4 configuration IDs for selector. */
+enum ipc4_selector_config_id {
+	IPC4_SELECTOR_COEFFS_CONFIG_ID = 0,	/**< Mixing coefficients config ID */
+};
+
+/** \brief IPC4 mixing coefficients configuration. */
+struct ipc4_selector_coeffs_config {
+	uint16_t rsvd0;	/**< Unused field, keeps the structure aligned with common layout */
+	uint16_t rsvd1;	/**< Unused field, keeps the structure aligned with common layout */
+
+	/** Mixing coefficients in Q10 fixed point format */
+	int16_t coeffs[SEL_SINK_CHANNELS_MAX][SEL_SOURCE_CHANNELS_MAX];
+};
 #else
 typedef void (*sel_func)(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
 			 const struct audio_stream __sparse_cache *source, uint32_t frames);
@@ -53,7 +75,8 @@ typedef void (*sel_func)(struct comp_dev *dev, struct audio_stream __sparse_cach
 /** \brief Selector component private data. */
 struct comp_data {
 #if CONFIG_IPC_MAJOR_4
-		struct micsel_data md;
+	struct micsel_data md;
+	struct ipc4_selector_coeffs_config coeffs_config;
 #endif
 
 	uint32_t source_period_bytes;	/**< source number of period bytes */


### PR DESCRIPTION
Add mixing-based processing in channel selector to implement capabilities resulting from IPC4 configuration.

Signed-off-by: Tomasz Lissowski <tomasz.lissowski@intel.com>