### PR TITLE
Tools: Test: Fix false success if no processing happened

### DIFF
--- a/tools/test/audio/process_test.m
+++ b/tools/test/audio/process_test.m
@@ -139,15 +139,18 @@ function  [n_fail, n_pass, n_na] = process_test(comp, bits_in_list, bits_out_lis
 	fprintf('Number of skipped tests = %d\n', r.n_skipped);
 	fprintf('============================================================\n');
 
-	if r.n_fail > 0 || r.n_pass < 1
+	n_fail = r.n_fail;
+	n_pass = r.n_pass;
+	n_na = r.n_na;
+	if r.n_fail < 1 && r.n_pass < 1
+		fprintf('\nERROR: No test results.\n');
+		n_fail = 1;
+	elseif r.n_fail > 0
 		fprintf('\nERROR: TEST FAILED!!!\n');
 	else
 		fprintf('\nTest passed.\n');
 	end
 
-	n_fail = r.n_fail;
-	n_pass = r.n_pass;
-	n_na = r.n_na;
 end
 
 %% ------------------------------------------------------------


### PR DESCRIPTION
The test is treated passed if there were no failed cases. The fix in this patch is to force one failed case if both failed and passed counts are zeros. Then the upper level test scripts/host-testbench.sh reports correctly the test fail.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>