### PR TITLE
add pipeline and component ids to audio specifics logs in output for Zephyr

### DIFF
--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -51,13 +51,23 @@ extern struct tr_ctx buffer_tr;
 
 #if defined(__ZEPHYR__) && defined(CONFIG_ZEPHYR_LOG)
 
-#define buf_err(buf_ptr, __e, ...) LOG_ERR(__e, ##__VA_ARGS__)
+#if CONFIG_IPC_MAJOR_4
+#define __BUF_FMT "buf:%u %#x "
+#else
+#define __BUF_FMT "buf:%u.%u "
+#endif
 
-#define buf_warn(buf_ptr, __e, ...) LOG_WRN(__e, ##__VA_ARGS__)
+#define buf_err(buf_ptr, __e, ...) LOG_ERR(__BUF_FMT __e, trace_buf_get_id(buf_ptr), \
+					   trace_buf_get_subid(buf_ptr), ##__VA_ARGS__)
 
-#define buf_info(buf_ptr, __e, ...) LOG_INF(__e, ##__VA_ARGS__)
+#define buf_warn(buf_ptr, __e, ...) LOG_WRN(__BUF_FMT __e, trace_buf_get_id(buf_ptr), \
+					    trace_buf_get_subid(buf_ptr), ##__VA_ARGS__)
 
-#define buf_dbg(buf_ptr, __e, ...) LOG_DBG(__e, ##__VA_ARGS__)
+#define buf_info(buf_ptr, __e, ...) LOG_INF(__BUF_FMT __e, trace_buf_get_id(buf_ptr), \
+					    trace_buf_get_subid(buf_ptr), ##__VA_ARGS__)
+
+#define buf_dbg(buf_ptr, __e, ...) LOG_DBG(__BUF_FMT __e, trace_buf_get_id(buf_ptr), \
+					   trace_buf_get_subid(buf_ptr), ##__VA_ARGS__)
 
 #else
 /** \brief Trace error message from buffer */

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -165,13 +165,24 @@ enum {
 #define comp_cl_dbg(drv_p, __e, ...) LOG_DBG(__e, ##__VA_ARGS__)
 
 /* device level tracing */
-#define comp_err(comp_p, __e, ...) LOG_ERR(__e, ##__VA_ARGS__)
 
-#define comp_warn(comp_p, __e, ...) LOG_WRN(__e, ##__VA_ARGS__)
+#if CONFIG_IPC_MAJOR_4
+#define __COMP_FMT "comp:%u %#x "
+#else
+#define __COMP_FMT "comp:%u.%u "
+#endif
 
-#define comp_info(comp_p, __e, ...) LOG_INF(__e, ##__VA_ARGS__)
+#define comp_err(comp_p, __e, ...) LOG_ERR(__COMP_FMT __e, trace_comp_get_id(comp_p), \
+					   trace_comp_get_subid(comp_p), ##__VA_ARGS__)
 
-#define comp_dbg(comp_p, __e, ...) LOG_DBG(__e, ##__VA_ARGS__)
+#define comp_warn(comp_p, __e, ...) LOG_WRN(__COMP_FMT __e, trace_comp_get_id(comp_p), \
+					    trace_comp_get_subid(comp_p), ##__VA_ARGS__)
+
+#define comp_info(comp_p, __e, ...) LOG_INF(__COMP_FMT __e, trace_comp_get_id(comp_p), \
+					    trace_comp_get_subid(comp_p), ##__VA_ARGS__)
+
+#define comp_dbg(comp_p, __e, ...) LOG_DBG(__COMP_FMT __e, trace_comp_get_id(comp_p), \
+					   trace_comp_get_subid(comp_p), ##__VA_ARGS__)
 
 #else
 /* class (driver) level (no device object) tracing */

--- a/src/include/sof/audio/pipeline-trace.h
+++ b/src/include/sof/audio/pipeline-trace.h
@@ -39,13 +39,23 @@ extern struct tr_ctx pipe_tr;
 /* device tracing */
 #if defined(__ZEPHYR__) && defined(CONFIG_ZEPHYR_LOG)
 
-#define pipe_err(pipe_p, __e, ...) LOG_ERR(__e, ##__VA_ARGS__)
+#if CONFIG_IPC_MAJOR_4
+#define __PIPE_FMT "pipe:%u %#x "
+#else
+#define __PIPE_FMT "pipe:%u.%u "
+#endif
 
-#define pipe_warn(pipe_p, __e, ...) LOG_WRN(__e, ##__VA_ARGS__)
+#define pipe_err(pipe_p, __e, ...) LOG_ERR(__PIPE_FMT __e, trace_pipe_get_id(pipe_p), \
+					   trace_pipe_get_subid(pipe_p), ##__VA_ARGS__)
 
-#define pipe_info(pipe_p, __e, ...) LOG_INF(__e, ##__VA_ARGS__)
+#define pipe_warn(pipe_p, __e, ...) LOG_WRN(__PIPE_FMT __e, trace_pipe_get_id(pipe_p), \
+					    trace_pipe_get_subid(pipe_p), ##__VA_ARGS__)
 
-#define pipe_dbg(pipe_p, __e, ...) LOG_DBG(__e, ##__VA_ARGS__)
+#define pipe_info(pipe_p, __e, ...) LOG_INF(__PIPE_FMT __e, trace_pipe_get_id(pipe_p), \
+					    trace_pipe_get_subid(pipe_p), ##__VA_ARGS__)
+
+#define pipe_dbg(pipe_p, __e, ...) LOG_DBG(__PIPE_FMT __e, trace_pipe_get_id(pipe_p), \
+					   trace_pipe_get_subid(pipe_p), ##__VA_ARGS__)
 
 #else
 


### PR DESCRIPTION
The component and pipeline identifiers were direct part of the older
SOF dictionary format. This information was added directly to encoded
output and was not part of the log message. When using Zephyr logging
subsystem, this type of audio specific information has be to put
as part of the log messages like any other log content.

Modify the various audio specific logging macros to add pipeline and component
identifiers to all printed log messages.
