### PR TITLE
topology2: pipeline: Add token to qualify a backend pipeline

### DIFF
--- a/tools/topology/topology2/include/common/tokens.conf
+++ b/tools/topology/topology2/include/common/tokens.conf
@@ -69,6 +69,7 @@ Object.Base.VendorToken {
 		dynamic_pipeline	206
 		# ABI 4.0 onwards
 		lp_mode		207
+		be_pipeline		208
 	}
 
 	"sof_tkn_intel_ssp" {

--- a/tools/topology/topology2/include/components/pipeline.conf
+++ b/tools/topology/topology2/include/components/pipeline.conf
@@ -95,6 +95,21 @@ Class.Widget."pipeline" {
 		}
 	}
 
+	#
+	# be_pipeline: boolean indicating that it is a backend pipeline, which is any pipeline that
+	#	       contains a dai_in or a dai_out widget
+	#
+	DefineAttribute."be_pipeline" {
+		type	"string"
+		token_ref	"sof_tkn_scheduler.bool"
+		constraints {
+			!valid_values [
+				"true"
+				"false"
+			]
+		}
+	}
+
 	attributes {
 		# pipeline widget name will be constructed as pipeline.1, pipeline.2 etc
 		!constructor [

--- a/tools/topology/topology2/include/pipelines/cavs/dai-copier-gain-mixin-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/dai-copier-gain-mixin-capture.conf
@@ -96,4 +96,5 @@ Class.Pipeline."dai-copier-gain-mixin-capture" {
 	rate		48000
 	rate_min	48000
 	rate_max	48000
+	be_pipeline	"true"
 }

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-gain-dai-copier-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-gain-dai-copier-playback.conf
@@ -111,4 +111,5 @@ Class.Pipeline."mixout-gain-dai-copier-playback" {
 	rate		48000
 	rate_min	48000
 	rate_max	48000
+	be_pipeline	"true"
 }

--- a/tools/topology/topology2/include/pipelines/cavs/passthrough-be.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/passthrough-be.conf
@@ -90,4 +90,5 @@ Class.Pipeline."passthrough-be" {
 	rate		48000
 	rate_min	48000
 	rate_max	48000
+	be_pipeline	"true"
 }

--- a/tools/topology/topology2/include/pipelines/pipeline-common.conf
+++ b/tools/topology/topology2/include/pipelines/pipeline-common.conf
@@ -79,3 +79,17 @@ DefineAttribute."time_domain" {
 
 # flag to indicate if the pipeline is dynamic
 DefineAttribute."dynamic_pipeline" {}
+
+#
+# be_pipeline: boolean indicating that it is a backend pipeline, which is any pipeline that
+#	       contains a dai_in or a dai_out widget
+#
+DefineAttribute."be_pipeline" {
+	type	"string"
+	constraints {
+		!valid_values [
+			"true"
+			"false"
+		]
+	}
+}


### PR DESCRIPTION
Add a new token to the pipeline widget to indicate that it is a backend pipeline. This will be used by the driver to skip triggering backend pipelines during the PCM trigger op.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>