### PR TITLE
topology: mt8195: rtnr: Set 5ms period for RTNR on MT8195

### DIFF
--- a/tools/topology/topology1/sof-mt8195-mt6359-rt1019-rt5682.m4
+++ b/tools/topology/topology1/sof-mt8195-mt6359-rt1019-rt5682.m4
@@ -53,7 +53,15 @@ define(matrix2, `ROUTE_MATRIX(3,
 
 ifdef(`GOOGLE_RTC_AUDIO_PROCESSING', `MUXDEMUX_CONFIG(demux_priv_1, 2, LIST_NONEWLINE(`', `matrix1,', `matrix2'))')
 ifdef(`GOOGLE_RTC_AUDIO_PROCESSING', `define(`SPK_PERIOD_US', 10000)', `define(`SPK_PERIOD_US', 1000)')
-ifdef(`GOOGLE_RTC_AUDIO_PROCESSING', `define(`MIC_PERIOD_US', 10000)', `define(`MIC_PERIOD_US', 2000)')
+
+ifdef(`GOOGLE_RTC_AUDIO_PROCESSING',
+	`define(`MIC_PERIOD_US', 10000)'
+	,
+	`ifdef(`RTNR',
+# 5ms period is required for RTNR build 20220728 and later versions
+		`define(`MIC_PERIOD_US', 5000)',
+        `define(`MIC_PERIOD_US', 2000)')'
+)
 
 #
 # Define the pipelines


### PR DESCRIPTION
With the  release of RTNR version 20220728, period for capturing pipeline requires at least 5ms.

This PR set 5ms period for RTNR in MT8195 topology.