### PR TITLE
 west.yml: upgrade Zephyr to ed661a6c6909

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -25,7 +25,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 0956647aaf6bd2b1e840adcc86db503f274d84a9
+      revision: ed661a6c6909b338035b026cfc101ddda65ab8eb
       remote: zephyrproject
       # Import some projects listed in zephyr/west.yml@revision
       #


### PR DESCRIPTION
west.yml: upgrade Zephyr to ed661a6c6909

Upgrade Zephyr from 0956647aaf6bd2b1e840adcc86db503f274d84a9 to
ed661a6c6909b338035b026cfc101ddda65ab8eb (1020 commits, including
441 since v3.2.0 tag).