### PR TITLE
topology2: cavs-nocodec: Add an intermediate pipeline

### DIFF
--- a/tools/topology/topology2/cavs/cavs-nocodec.conf
+++ b/tools/topology/topology2/cavs/cavs-nocodec.conf
@@ -15,6 +15,7 @@
 <passthrough-be.conf>
 <host-copier-gain-mixin-playback.conf>
 <mixout-gain-dai-copier-playback.conf>
+<mixout-gain-mixin-playback.conf>
 <data.conf>
 <pcm.conf>
 <pcm_caps.conf>
@@ -140,6 +141,20 @@ Object.Pipeline {
 		Object.Widget.gain.1 {
 			Object.Control.mixer.1 {
 				name 'Playback Volume 1'
+			}
+		}
+	}
+
+	mixout-gain-mixin-playback.1 {
+		index 15
+
+		Object.Widget.pipeline.1 {
+			stream_name 'NoCodec-0'
+		}
+
+		Object.Widget.gain.1 {
+			Object.Control.mixer.1 {
+				name 'Playback Volume 15'
 			}
 		}
 	}
@@ -405,6 +420,11 @@ Object.Base {
 
 	route."2" {
 		source	"mixin.1.1"
+		sink	"mixout.15.1"
+	}
+
+	route."10" {
+		source	"mixin.15.1"
 		sink	"mixout.2.1"
 	}
 

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-gain-mixin-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-gain-mixin-playback.conf
@@ -1,0 +1,95 @@
+#
+# BE playback pipeline: mixout-gain-mixin
+#
+# All attributes defined herein are namespaced
+# by alsatplg to "Object.Pipeline.mixout-gain-mixin-playback.N.attribute_name"
+#
+# Usage: mixout-gain-mixin-playback pipeline object can be instantiated as:
+#
+# Object.Pipeline.mixout-gain-mixin-playback."N" {
+# 	period		1000
+# 	time_domain	"timer"
+# 	channels	2
+# 	rate		48000
+# }
+#
+# Where N is the unique pipeline ID within the same alsaconf node.
+#
+
+<include/common/audio_format.conf>
+<include/components/copier.conf>
+<include/components/gain.conf>
+<include/components/mixout.conf>
+<include/components/pipeline.conf>
+
+Class.Pipeline."mixout-gain-mixin-playback" {
+
+	DefineAttribute."index" {}
+
+	<include/pipelines/pipeline-common.conf>
+
+	attributes {
+		!constructor [
+			"index"
+		]
+
+		!immutable [
+			"direction"
+		]
+
+		#
+		# mixout-gain-mixin-playback objects instantiated within the same alsaconf node must have
+		# unique pipeline_id attribute
+		#
+		unique	"instance"
+	}
+
+	Object.Widget {
+		mixout."1" {}
+		gain."1" {
+			num_audio_formats 2
+
+			# 32-bit 48KHz 2ch
+			Object.Base.audio_format.1 {
+				in_bit_depth		32
+				in_valid_bit_depth	24
+				out_bit_depth		32
+				out_valid_bit_depth	24
+			}
+
+			Object.Base.audio_format.2 {
+				in_bit_depth		32
+				in_valid_bit_depth	32
+				out_bit_depth		32
+				out_valid_bit_depth	32
+			}
+		}
+		mixin."1" {}
+
+		pipeline."1" {
+			priority		0
+			lp_mode		0
+		}
+	}
+
+	Object.Base {
+		route.1 {
+			source mixout..1
+			sink	gain..1
+		}
+		route.2 {
+			source gain..1
+			sink	mixin..1
+		}
+	}
+
+	direction	"playback"
+	dynamic_pipeline 1
+	time_domain	"timer"
+	channels	2
+	channels_min	2
+	channels_max	2
+	rate		48000
+	rate_min	48000
+	rate_max	48000
+}


### PR DESCRIPTION
Add an intermediate pipeline between the host and DAI pipelines.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>