### PR TITLE
xtensa-build-zephyr.py: restore lost reproducible .ri checksum

### DIFF
--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -38,6 +38,10 @@ import warnings
 from anytree import AnyNode, RenderTree
 from packaging import version
 
+# https://chrisyeh96.github.io/2017/08/08/definitive-guide-python-imports.html#case-3-importing-from-parent-directory
+sys.path.insert(1, os.path.join(sys.path[0], '..'))
+from tools.sof_ri_info import sof_ri_info
+
 MIN_PYTHON_VERSION = 3, 8
 assert sys.version_info >= MIN_PYTHON_VERSION, \
 	f"Python {MIN_PYTHON_VERSION} or above is required."
@@ -591,6 +595,8 @@ def build_platforms():
 
 		execute_command(sign_cmd, cwd=west_top)
 
+		if platform not in NO_RIMAGE_PLATFORMS:
+			reproducible_checksum(platform, west_top / platform_build_dir_name / "zephyr" / "zephyr.ri")
 
 		# Install to STAGING_DIR
 		abs_build_dir = pathlib.Path(west_top) / platform_build_dir_name / "zephyr"
@@ -641,6 +647,22 @@ def build_platforms():
 			  "zephyr" / "soc" / "xtensa" / "intel_adsp" / "tools",
 			tools_output_dir,
 			symlinks=True, ignore_dangling_symlinks=True, dirs_exist_ok=True)
+
+
+NO_RIMAGE_PLATFORMS = ['imx8', 'imx8x', 'imx8m']
+RI_INFO_FIXME = ['mtl']
+
+def reproducible_checksum(platform, ri_file):
+
+	if platform in RI_INFO_FIXME:
+		print(f"FIXME: sof_ri_info does not support '{platform}'")
+		return
+
+	parsed_ri = sof_ri_info.parse_fw_bin(ri_file, False, False)
+	repro_output = ri_file.parent / ("reproducible-" + ri_file.name)
+	chk256 = sof_ri_info.EraseVariables(ri_file, parsed_ri, west_top / repro_output)
+	print('sha256sum {0}\n{1} {0}'.format(repro_output, chk256))
+
 
 def main():
 	parse_args()

--- a/tools/sof_ri_info/sof_ri_info.py
+++ b/tools/sof_ri_info/sof_ri_info.py
@@ -867,7 +867,7 @@ class BinReader():
         self.verbose = verbose
         self.cur_offset = 0
         self.ext_mft_length = 0
-        self.info('Reading SOF ri image ' + path, show_offset=False)
+        self.info(f'Reading SOF ri image {path}', show_offset=False)
         self.file_name = path
         # read the content
         self.data = open(path, 'rb').read()


### PR DESCRIPTION
At the end of the build, parse the .ri file and print a reproducible
checksum of the its content.

This feature was in xtensa-build-zephyr.sh but never made it to the .py
conversion. It was lost when the .sh file was deleted in commit
https://github.com/thesofproject/sof/commit/ef028f634a0607d7706149b9248824b43664f9fc ("Removed obsolete xtensa-build-zephyr.sh")