### PR TITLE
topology2: add pass-through topology for nocodec 

### DIFF
--- a/tools/topology/topology2/cavs/CMakeLists.txt
+++ b/tools/topology/topology2/cavs/CMakeLists.txt
@@ -40,9 +40,15 @@ PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-mtl-sdw-dmic.bin"
 # CAVS SSP topology for TGL
 "cavs-nocodec\;cavs-tgl-nocodec\;NUM_DMICS=4,PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,\
 PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-cavs-tgl-nocodec.bin"
+
+"cavs-nocodec\;cavs-tgl-mixer-nocodec\;NUM_DMICS=4,PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,\
+PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-cavs-tgl-mixer-nocodec.bin,PIPELINE_CONFIG=mixer"
 # SSP topology for MTL
 "cavs-nocodec\;sof-mtl-nocodec\;PLATFORM=mtl,NUM_DMICS=2,\
 PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-ace-mtl-nocodec.bin"
+
+"cavs-nocodec\;sof-mtl-mixer-nocodec\;PLATFORM=mtl,NUM_DMICS=2,\
+PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-ace-mtl-mixer-nocodec.bin,PIPELINE_CONFIG=mixer"
 )
 
 # generate ABI for IPC4

--- a/tools/topology/topology2/cavs/cavs-nocodec-mixin-mixout.conf
+++ b/tools/topology/topology2/cavs/cavs-nocodec-mixin-mixout.conf
@@ -1,0 +1,153 @@
+# Pipeline definitions
+#
+# PCM0 ---> gain ----> Mixin ----> Mixout ----> gain ----> SSP0
+# PCM1 ---> gain ----> Mixin ----> Mixout ----> gain ----> SSP1
+# PCM2 ---> gain ----> Mixin ----> Mixout ----> gain ----> SSP2
+
+# Pipeline ID:1 PCM ID: 0
+Object.Pipeline {
+	# playback pipelines
+	host-copier-gain-mixin-playback.1 {
+		index	1
+
+		Object.Widget.pipeline.1 {
+			stream_name 'NoCodec-0'
+		}
+		Object.Widget.copier.1 {
+			stream_name 'SSP0 Playback'
+		}
+		Object.Widget.gain.1 {
+			Object.Control.mixer.1 {
+				name 'Playback Volume 1'
+			}
+		}
+	}
+
+	mixout-gain-dai-copier-playback.1 {
+		index 2
+
+		Object.Widget.pipeline.1 {
+			stream_name 'NoCodec-0'
+		}
+
+		Object.Widget.copier.1 {
+			dai_index 0
+			dai_type "SSP"
+			copier_type "SSP"
+			stream_name "NoCodec-0"
+			node_type $I2S_LINK_OUTPUT_CLASS
+		}
+
+		Object.Widget.gain.1 {
+			Object.Control.mixer.1 {
+				name 'Main Playback Volume 2'
+			}
+		}
+	}
+
+	host-copier-gain-mixin-playback.2 {
+		index	3
+
+		Object.Widget.pipeline.1 {
+			stream_name 'NoCodec-1'
+		}
+		Object.Widget.copier.1 {
+			stream_name 'SSP1 Playback'
+		}
+		Object.Widget.gain.1 {
+			Object.Control.mixer.1 {
+				name 'Playback Volume 3'
+			}
+		}
+	}
+
+	mixout-gain-dai-copier-playback.2 {
+		index 4
+
+		Object.Widget.pipeline.1 {
+			stream_name 'NoCodec-1'
+		}
+
+		Object.Widget.copier.1 {
+			dai_index 1
+			dai_type "SSP"
+			copier_type "SSP"
+			stream_name "NoCodec-1"
+			node_type $I2S_LINK_OUTPUT_CLASS
+		}
+
+		Object.Widget.gain.1 {
+			Object.Control.mixer.1 {
+				name 'Main Playback Volume 4'
+			}
+		}
+	}
+
+	host-copier-gain-mixin-playback.3 {
+		index	5
+
+		Object.Widget.pipeline.1 {
+			stream_name 'NoCodec-2'
+		}
+		Object.Widget.copier.1 {
+			stream_name 'SSP2 Playback'
+		}
+		Object.Widget.gain.1 {
+			Object.Control.mixer.1 {
+				name 'Playback Volume 5'
+			}
+		}
+	}
+
+	mixout-gain-dai-copier-playback.3 {
+		index 6
+
+		Object.Widget.pipeline.1 {
+			stream_name 'NoCodec-2'
+		}
+
+		Object.Widget.copier.1 {
+			dai_index 2
+			dai_type "SSP"
+			copier_type "SSP"
+			stream_name "NoCodec-2"
+			node_type $I2S_LINK_OUTPUT_CLASS
+		}
+
+		Object.Widget.gain.1 {
+			Object.Control.mixer.1 {
+				name 'Main Playback Volume 6'
+			}
+		}
+	}
+}
+
+Object.Base {
+	route."1" {
+		source	"gain.2.1"
+		sink	"copier.SSP.2.1"
+	}
+
+	route."2" {
+		source	"mixin.1.1"
+		sink	"mixout.2.1"
+	}
+
+	route."3" {
+		source	"gain.4.1"
+		sink	"copier.SSP.4.1"
+	}
+	route."4" {
+		source	"mixin.3.1"
+		sink	"mixout.4.1"
+	}
+
+	route."5" {
+		source	"gain.6.1"
+		sink	"copier.SSP.6.1"
+	}
+	route."6" {
+		source	"mixin.5.1"
+		sink	"mixout.6.1"
+	}
+}

--- a/tools/topology/topology2/cavs/cavs-nocodec-passthrough.conf
+++ b/tools/topology/topology2/cavs/cavs-nocodec-passthrough.conf
@@ -1,0 +1,102 @@
+#
+# Pipeline definitions
+#
+
+# Pipeline ID:1 PCM ID: 0
+Object.Pipeline {
+	# playback pipelines
+	passthrough-be.1 {
+		index	2
+		direction	playback
+		Object.Widget.pipeline.1 {
+			stream_name 'NoCodec-0'
+		}
+
+		Object.Widget.copier.1 {
+			dai_index 0
+			dai_type "SSP"
+			copier_type "SSP"
+			stream_name "NoCodec-0"
+			node_type $I2S_LINK_OUTPUT_CLASS
+		}
+	}
+
+	passthrough-playback.1 {
+		index	1
+		Object.Widget.pipeline.1 {
+			stream_name 'NoCodec-0'
+		}
+		Object.Widget.copier.1 {
+			stream_name 'SSP0 Playback'
+		}
+	}
+
+	passthrough-be.2 {
+		index	4
+		direction	playback
+		Object.Widget.pipeline.1 {
+			stream_name 'NoCodec-1'
+		}
+
+		Object.Widget.copier.1 {
+			dai_index 1
+			dai_type "SSP"
+			copier_type "SSP"
+			stream_name "NoCodec-1"
+			node_type $I2S_LINK_OUTPUT_CLASS
+		}
+	}
+
+	passthrough-playback.2 {
+		index	3
+		Object.Widget.pipeline.1 {
+			stream_name 'NoCodec-1'
+		}
+		Object.Widget.copier.1 {
+			stream_name 'SSP1 Playback'
+		}
+	}
+
+	passthrough-be.3 {
+		index	6
+		direction	playback
+		Object.Widget.pipeline.1 {
+			stream_name 'NoCodec-2'
+		}
+
+		Object.Widget.copier.1 {
+			dai_index 2
+			dai_type "SSP"
+			copier_type "SSP"
+			stream_name "NoCodec-2"
+			node_type $I2S_LINK_OUTPUT_CLASS
+		}
+	}
+
+	passthrough-playback.3 {
+		index	5
+		Object.Widget.pipeline.1 {
+			stream_name 'NoCodec-2'
+		}
+		Object.Widget.copier.1 {
+			stream_name 'SSP2 Playback'
+		}
+	}
+}
+
+Object.Base {
+	route."1" {
+		source	"copier.host.1.1"
+		sink	"copier.SSP.2.1"
+	}
+
+	route."2" {
+		source	"copier.host.3.1"
+		sink	"copier.SSP.4.1"
+	}
+
+	route."3" {
+		source	"copier.host.5.1"
+		sink	"copier.SSP.6.1"
+	}
+}

--- a/tools/topology/topology2/cavs/cavs-nocodec.conf
+++ b/tools/topology/topology2/cavs/cavs-nocodec.conf
@@ -11,10 +11,11 @@
 <pdm_config.conf>
 <tokens.conf>
 <virtual.conf>
+<passthrough-playback.conf>
 <passthrough-capture.conf>
-<passthrough-be.conf>
 <host-copier-gain-mixin-playback.conf>
 <mixout-gain-dai-copier-playback.conf>
+<passthrough-be.conf>
 <data.conf>
 <pcm.conf>
 <pcm_caps.conf>
@@ -44,6 +45,7 @@ Define {
 	DMIC0_PCM_CAPS			'Passthrough Capture 13'
 	DMIC0_PIPELINE_STREAM_NAME	'copier.DMIC.14.1'
 	PLATFORM 			"none"
+	PIPELINE_CONFIG			"passthrough"
 }
 
 # override defaults with platform-specific config
@@ -54,6 +56,12 @@ IncludeByKey.PLATFORM {
 # include DMIC config if needed.
 IncludeByKey.NUM_DMICS {
 	"[1-4]"	"platform/intel/dmic-generic.conf"
+}
+
+# include passthrough/mixer-based pipelines
+IncludeByKey.PIPELINE_CONFIG {
+	"passthrough"	"cavs-nocodec-passthrough.conf"
+	"mixer"		"cavs-nocodec-mixin-mixout.conf"
 }
 
 #
@@ -117,131 +125,9 @@ Object.Dai {
 #
 # Pipeline definitions
 #
-# PCM0 ---> gain ----> Mixin ----> Mixout ----> gain ----> SSP0
-# PCM1 ---> gain ----> Mixin ----> Mixout ----> gain ----> SSP1
-# PCM2 ---> gain ----> Mixin ----> Mixout ----> gain ----> SSP2
-#
-# SSP0 ----> PCM0
-# SSP1 ----> PCM1
-# SSP2 ----> PCM2
 
 # Pipeline ID:1 PCM ID: 0
 Object.Pipeline {
-	# playback pipelines
-	host-copier-gain-mixin-playback.1 {
-		index	1
-
-		Object.Widget.pipeline.1 {
-			stream_name 'NoCodec-0'
-		}
-		Object.Widget.copier.1 {
-			stream_name 'SSP0 Playback'
-		}
-		Object.Widget.gain.1 {
-			Object.Control.mixer.1 {
-				name 'Playback Volume 1'
-			}
-		}
-	}
-
-	mixout-gain-dai-copier-playback.1 {
-		index 2
-
-		Object.Widget.pipeline.1 {
-			stream_name 'NoCodec-0'
-		}
-
-		Object.Widget.copier.1 {
-			dai_index 0
-			dai_type "SSP"
-			copier_type "SSP"
-			stream_name "NoCodec-0"
-			node_type $I2S_LINK_OUTPUT_CLASS
-		}
-
-		Object.Widget.gain.1 {
-			Object.Control.mixer.1 {
-				name 'Main Playback Volume 2'
-			}
-		}
-	}
-
-	host-copier-gain-mixin-playback.2 {
-		index	3
-
-		Object.Widget.pipeline.1 {
-			stream_name 'NoCodec-1'
-		}
-		Object.Widget.copier.1 {
-			stream_name 'SSP1 Playback'
-		}
-		Object.Widget.gain.1 {
-			Object.Control.mixer.1 {
-				name 'Playback Volume 3'
-			}
-		}
-	}
-
-	mixout-gain-dai-copier-playback.2 {
-		index 4
-
-		Object.Widget.pipeline.1 {
-			stream_name 'NoCodec-1'
-		}
-
-		Object.Widget.copier.1 {
-			dai_index 1
-			dai_type "SSP"
-			copier_type "SSP"
-			stream_name "NoCodec-1"
-			node_type $I2S_LINK_OUTPUT_CLASS
-		}
-
-		Object.Widget.gain.1 {
-			Object.Control.mixer.1 {
-				name 'Main Playback Volume 4'
-			}
-		}
-	}
-
-	host-copier-gain-mixin-playback.3 {
-		index	5
-
-		Object.Widget.pipeline.1 {
-			stream_name 'NoCodec-2'
-		}
-		Object.Widget.copier.1 {
-			stream_name 'SSP2 Playback'
-		}
-		Object.Widget.gain.1 {
-			Object.Control.mixer.1 {
-				name 'Playback Volume 5'
-			}
-		}
-	}
-
-	mixout-gain-dai-copier-playback.3 {
-		index 6
-
-		Object.Widget.pipeline.1 {
-			stream_name 'NoCodec-2'
-		}
-
-		Object.Widget.copier.1 {
-			dai_index 1
-			dai_type "SSP"
-			copier_type "SSP"
-			stream_name "NoCodec-2"
-			node_type $I2S_LINK_OUTPUT_CLASS
-		}
-
-		Object.Widget.gain.1 {
-			Object.Control.mixer.1 {
-				name 'Main Playback Volume 6'
-			}
-		}
-	}
-
 	# capture pipelines
 	passthrough-capture.1 {
 		index 	7
@@ -398,34 +284,6 @@ Object.PCM {
 }
 
 Object.Base {
-	route."1" {
-		source	"gain.2.1"
-		sink	"copier.SSP.2.1"
-	}
-
-	route."2" {
-		source	"mixin.1.1"
-		sink	"mixout.2.1"
-	}
-
-	route."3" {
-		source	"gain.4.1"
-		sink	"copier.SSP.4.1"
-	}
-	route."4" {
-		source	"mixin.3.1"
-		sink	"mixout.4.1"
-	}
-
-	route."5" {
-		source	"gain.6.1"
-		sink	"copier.SSP.6.1"
-	}
-	route."6" {
-		source	"mixin.5.1"
-		sink	"mixout.6.1"
-	}
-
 	route."7" {
 		source	"copier.SSP.8.1"
 		sink	"copier.host.7.1"


### PR DESCRIPTION
After adding mixer in nocodec topology we got many issues with multi-stream stress test. These issues are related to both kernel or cSOF, and can't be fixed in short time. It will block the coming ipc4 PR test in CI. To prepare for CI and go on debugging these issues, we will support both pass-through and mixer topology. 