### PR TITLE
[amd-rn-prod-001 ONLY] Support multi-config identification via enum control of module_adapter

### DIFF
--- a/src/audio/module_adapter/module/dts.c
+++ b/src/audio/module_adapter/module/dts.c
@@ -15,6 +15,22 @@ DECLARE_TR_CTX(dts_tr, SOF_UUID(dts_uuid), LOG_LEVEL_INFO);
 
 #define MAX_EXPECTED_DTS_CONFIG_DATA_SIZE 8192
 
+/* The enumeration should be aligned as topology side. */
+enum dts_config_mode_id {
+	DTS_CONFIG_MODE_BYPASS    = 0,
+	DTS_CONFIG_MODE_SPEAKERS  = 1,
+	DTS_CONFIG_MODE_HEADPHONE = 2,
+	DTS_CONFIG_MODE_LINEOUT   = DTS_CONFIG_MODE_BYPASS,
+	DTS_CONFIG_MODE_MAX       = 3, /* for defining the number of config entries */
+};
+
+struct dts_module_private_data {
+	DtsSofInterfaceInst *inst;            /* DTS SDK instance */
+	struct module_param *config[DTS_CONFIG_MODE_MAX]; /* table of config entries */
+};
+
+static int dts_codec_apply_config(struct processing_module *mod);
+
 static void *dts_effect_allocate_codec_memory(void *mod_void, unsigned int length,
 					      unsigned int alignment)
 {
@@ -118,14 +134,21 @@ static int dts_codec_init(struct processing_module *mod)
 	int ret;
 	struct comp_dev *dev = mod->dev;
 	struct module_data *codec = &mod->priv;
+	struct dts_module_private_data *dts_private = NULL;
 	DtsSofInterfaceResult dts_result;
 	DtsSofInterfaceVersionInfo interface_version;
 	DtsSofInterfaceVersionInfo sdk_version;
 
 	comp_dbg(dev, "dts_codec_init() start");
 
-	dts_result = dtsSofInterfaceInit((DtsSofInterfaceInst **)&(codec->private),
-		dts_effect_allocate_codec_memory, mod);
+	dts_private = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM,
+			      sizeof(struct dts_module_private_data));
+	if (!dts_private) {
+		comp_err(dev, "dts_codec_init(): failed to allocate dts_module_private_data");
+		return -ENOMEM;
+	}
+
+	dts_result = dtsSofInterfaceInit(&dts_private->inst, dts_effect_allocate_codec_memory, mod);
 	ret = dts_effect_convert_sof_interface_result(dev, dts_result);
 
 	if (ret)
@@ -153,6 +176,8 @@ static int dts_codec_init(struct processing_module *mod)
 	if (ret)
 		comp_err(dev, "dts_codec_init() failed %d %d", ret, dts_result);
 
+	codec->private = dts_private;
+
 	comp_dbg(dev, "dts_codec_init() done");
 
 	return ret;
@@ -163,10 +188,21 @@ static int dts_codec_prepare(struct processing_module *mod)
 	int ret;
 	struct comp_dev *dev = mod->dev;
 	struct module_data *codec = &mod->priv;
+	struct dts_module_private_data *dts_private = codec->private;
 	DtsSofInterfaceBufferConfiguration buffer_configuration;
 	DtsSofInterfaceResult dts_result;
 
 	comp_dbg(dev, "dts_codec_prepare() start");
+
+	/*
+	 * mod->config_mode should have been assigned the index as wanted via mixer control so
+	 * apply the stored config to DTS SDK now.
+	 */
+	ret = dts_codec_apply_config(mod);
+	if (ret) {
+		comp_err(dev, "dts_codec_prepare() dts_codec_apply_config failed %d", ret);
+		return ret;
+	}
 
 	ret = dts_effect_populate_buffer_configuration(dev, &buffer_configuration);
 	if (ret) {
@@ -177,7 +213,7 @@ static int dts_codec_prepare(struct processing_module *mod)
 	}
 
 	dts_result = dtsSofInterfacePrepare(
-		(DtsSofInterfaceInst *)codec->private,
+		dts_private->inst,
 		&buffer_configuration,
 		&codec->mpd.in_buff,
 		&codec->mpd.in_buff_size,
@@ -198,11 +234,12 @@ static int dts_codec_init_process(struct processing_module *mod)
 	int ret;
 	struct comp_dev *dev = mod->dev;
 	struct module_data *codec = &mod->priv;
+	struct dts_module_private_data *dts_private = codec->private;
 	DtsSofInterfaceResult dts_result;
 
 	comp_dbg(dev, "dts_codec_init_process() start");
 
-	dts_result = dtsSofInterfaceInitProcess(codec->private);
+	dts_result = dtsSofInterfaceInitProcess(dts_private->inst);
 	ret = dts_effect_convert_sof_interface_result(dev, dts_result);
 
 	codec->mpd.produced = 0;
@@ -225,6 +262,7 @@ dts_codec_process(struct processing_module *mod,
 	int ret;
 	struct comp_dev *dev = mod->dev;
 	struct module_data *codec = &mod->priv;
+	struct dts_module_private_data *dts_private = codec->private;
 	DtsSofInterfaceResult dts_result;
 	unsigned int bytes_processed = 0;
 
@@ -246,7 +284,7 @@ dts_codec_process(struct processing_module *mod,
 
 	comp_dbg(dev, "dts_codec_process() start");
 
-	dts_result = dtsSofInterfaceProcess(codec->private, &bytes_processed);
+	dts_result = dtsSofInterfaceProcess(dts_private->inst, &bytes_processed);
 	ret = dts_effect_convert_sof_interface_result(dev, dts_result);
 
 	codec->mpd.consumed = !ret ? bytes_processed : 0;
@@ -268,32 +306,40 @@ dts_codec_process(struct processing_module *mod,
 	return ret;
 }
 
-static int dts_codec_apply_config(struct processing_module *mod)
+/*
+ * For read-only byte control, all configs (speaker, headphone, and etc.) will be loaded after
+ * module initiated. Just store them to internal buffers without applying to SDK. "apply_config"
+ * will be done on prepare() according to the config index assigned via enum control.
+ *
+ * Internal buffers for storage are required because mod->priv.cfg.data will be freed once it is
+ * transferred down to module.
+ */
+static int dts_codec_store_config(struct processing_module *mod)
 {
 	int ret = 0;
 	struct comp_dev *dev = mod->dev;
 	struct module_data *codec = &mod->priv;
+	struct dts_module_private_data *dts_private = codec->private;
 	struct module_config *config;
 	struct module_param *param;
+	struct module_param *dst_param;
 	uint32_t config_header_size;
 	uint32_t config_data_size;
 	uint32_t param_header_size;
-	uint32_t param_data_size;
 	uint32_t i;
 	uint32_t param_number = 0;
-	DtsSofInterfaceResult dts_result;
 
-	comp_dbg(dev, "dts_codec_apply_config() start");
+	comp_dbg(dev, "dts_codec_store_config() start");
 
 	config = &codec->cfg;
 
 	/* Check that config->data isn't invalid and has size greater than 0 */
 	config_header_size = sizeof(config->size) + sizeof(config->avail);
 	if (config->size < config_header_size) {
-		comp_err(dev, "dts_codec_apply_config() config->data is invalid");
+		comp_err(dev, "dts_codec_store_config() config->data is invalid");
 		return -EINVAL;
 	} else if (config->size == config_header_size) {
-		comp_err(dev, "dts_codec_apply_config() size of config->data is 0");
+		comp_err(dev, "dts_codec_store_config() size of config->data is 0");
 		return -EINVAL;
 	}
 
@@ -303,7 +349,7 @@ static int dts_codec_apply_config(struct processing_module *mod)
 	/* Check that config->data is not greater than the max expected for DTS data */
 	if (config_data_size > MAX_EXPECTED_DTS_CONFIG_DATA_SIZE) {
 		comp_err(dev,
-			"dts_codec_apply_config() size of config->data is larger than max for DTS data");
+			"dts_codec_store_config() size of config->data is larger than max for DTS data");
 		return -EINVAL;
 	}
 
@@ -314,31 +360,91 @@ static int dts_codec_apply_config(struct processing_module *mod)
 		param_header_size = sizeof(param->id) + sizeof(param->size);
 
 		/* If param->size is less than param_header_size, then this param is not valid */
-		if (param->size < param_header_size) {
-			comp_err(dev, "dts_codec_apply_config() param is invalid");
+		if (param->size <= param_header_size) {
+			comp_err(dev, "dts_codec_store_config() param is invalid");
 			return 0;
 		}
 
-		/* Only process param->data if it has size greater than 0 */
-		if (param->size > param_header_size) {
-			/* Calculate size of param->data */
-			param_data_size = param->size - param_header_size;
-
-			if (param_data_size) {
-				dts_result = dtsSofInterfaceApplyConfig(codec->private, param->id,
-					param->data, param_data_size);
-				ret = dts_effect_convert_sof_interface_result(dev, dts_result);
-				if (ret) {
-					comp_err(dev,
-						"dts_codec_apply_config() dtsSofInterfaceApplyConfig failed %d",
-						dts_result);
-					return ret;
-				}
-			}
+		/* If param->id is larger than DTS_CONFIG_MODE_MAX, it is not valid */
+		if (param->id >= DTS_CONFIG_MODE_MAX) {
+			comp_err(dev, "dts_codec_store_config() param->id %u is invalid",
+				 param->id);
+			return 0;
 		}
+
+		if (!dts_private->config[param->id]) {
+			/* No space for config available yet, allocate now */
+			dst_param = rballoc(0, SOF_MEM_CAPS_RAM, param->size);
+		} else if (dts_private->config[param->id]->size != param->size) {
+			/* The size allocated for previous config doesn't match the new one.
+			 * Free old container and allocate new one.
+			 */
+			rfree(dts_private->config[param->id]);
+			dst_param = rballoc(0, SOF_MEM_CAPS_RAM, param->size);
+		} else {
+			dst_param = dts_private->config[param->id];
+		}
+
+		if (!dst_param) {
+			comp_err(dev, "dts_codec_store_config() failed to allocate dst_param");
+			return -ENOMEM;
+		}
+
+		ret = memcpy_s(dst_param, param->size, param, param->size);
+		assert(!ret);
+
+		comp_dbg(dev, "dts_codec_store_config() stored config id %u size %u", param->id,
+			 param->size);
+		dts_private->config[param->id] = dst_param;
+
+		/* For backward compatibility, set to be inclined to apply the last config blob
+		 * written to module.
+		 */
+		mod->config_mode = param->id;
 
 		/* Advance to the next module_param */
 		i += param->size;
+	}
+
+	comp_dbg(dev, "dts_codec_store_config() done");
+
+	return ret;
+}
+
+static int dts_codec_apply_config(struct processing_module *mod)
+{
+	int ret = 0;
+	struct comp_dev *dev = mod->dev;
+	struct module_data *codec = &mod->priv;
+	struct dts_module_private_data *dts_private = codec->private;
+	struct module_param *param;
+	uint32_t param_header_size;
+	uint32_t param_data_size;
+	DtsSofInterfaceResult dts_result;
+
+	comp_dbg(dev, "dts_codec_apply_config() start");
+
+	if (mod->config_mode >= DTS_CONFIG_MODE_MAX || !dts_private->config[mod->config_mode]) {
+		comp_err(dev, "dts_codec_apply_config() config_mode %u is invalid",
+			 mod->config_mode);
+		return -EINVAL;
+	}
+
+	param = (struct module_param *)dts_private->config[mod->config_mode];
+	param_header_size = sizeof(param->id) + sizeof(param->size);
+	param_data_size = param->size - param_header_size;
+
+	/*
+	 * Pass constant 1 to arg parameterId instead of param->id. parameterId is re-defined by
+	 * SDK for internal multi-config support usage in the future version.
+	 */
+	dts_result = dtsSofInterfaceApplyConfig(dts_private->inst, 1, param->data,
+						param_data_size);
+	ret = dts_effect_convert_sof_interface_result(dev, dts_result);
+	if (ret) {
+		comp_err(dev, "dts_codec_apply_config() dtsSofInterfaceApplyConfig failed %d",
+			 dts_result);
+		return ret;
 	}
 
 	comp_dbg(dev, "dts_codec_apply_config() done");
@@ -351,11 +457,12 @@ static int dts_codec_reset(struct processing_module *mod)
 	int ret;
 	struct comp_dev *dev = mod->dev;
 	struct module_data *codec = &mod->priv;
+	struct dts_module_private_data *dts_private = codec->private;
 	DtsSofInterfaceResult dts_result;
 
 	comp_dbg(dev, "dts_codec_reset() start");
 
-	dts_result = dtsSofInterfaceReset(codec->private);
+	dts_result = dtsSofInterfaceReset(dts_private->inst);
 	ret = dts_effect_convert_sof_interface_result(dev, dts_result);
 
 	if (ret)
@@ -371,17 +478,24 @@ static int dts_codec_free(struct processing_module *mod)
 	int ret;
 	struct comp_dev *dev = mod->dev;
 	struct module_data *codec = &mod->priv;
+	struct dts_module_private_data *dts_private = codec->private;
+	int i;
 	DtsSofInterfaceResult dts_result;
 
 	comp_dbg(dev, "dts_codec_free() start");
 
-	dts_result = dtsSofInterfaceFree(codec->private);
+	dts_result = dtsSofInterfaceFree(dts_private->inst);
 	ret = dts_effect_convert_sof_interface_result(dev, dts_result);
 
 	if (ret)
 		comp_err(dev, "dts_codec_free() failed %d %d", ret, dts_result);
 
 	module_free_all_memory(mod);
+
+	/* Free dts_module_private_data */
+	for (i = 0; i < DTS_CONFIG_MODE_MAX; i++)
+		rfree(dts_private->config[i]);
+	rfree(dts_private);
 
 	comp_dbg(dev, "dts_codec_free() done");
 
@@ -408,15 +522,15 @@ dts_codec_set_configuration(struct processing_module *mod, uint32_t config_id,
 	    md->state < MODULE_INITIALIZED)
 		return 0;
 
-	/* whole configuration received, apply it now */
-	ret = dts_codec_apply_config(mod);
+	/* whole configuration received, store it now */
+	ret = dts_codec_store_config(mod);
 	if (ret) {
-		comp_err(dev, "dts_codec_set_configuration(): error %x: runtime config apply failed",
+		comp_err(dev, "dts_codec_set_configuration(): error %x: runtime config store failed",
 			 ret);
 		return ret;
 	}
 
-	comp_dbg(dev, "dts_codec_set_configuration(): config applied");
+	comp_dbg(dev, "dts_codec_set_configuration(): config stored");
 
 	return 0;
 }

--- a/src/include/sof/audio/module_adapter/module/generic.h
+++ b/src/include/sof/audio/module_adapter/module/generic.h
@@ -298,6 +298,12 @@ struct processing_module {
 	 * period_bytes every copy
 	 */
 	bool simple_copy;
+
+	/*
+	 * for AMD branch only. It is configured by enum control for config blob selection for the
+	 * inner module.
+	 */
+	uint32_t config_mode;
 };
 
 /*****************************************************************************/

--- a/tools/topology/topology1/CMakeLists.txt
+++ b/tools/topology/topology1/CMakeLists.txt
@@ -241,7 +241,7 @@ set(TPLGS
 
 	"sof-acp-renoir\;sof-acp"
 	"sof-rn-rt5682-rt1019\;sof-rn-rt5682-rt1019"
-	"sof-rn-rt5682-rt1019\;sof-rn-rt5682-rt1019-dts\;-DDTS=`DTS'"
+	"sof-rn-rt5682-rt1019\;sof-rn-rt5682-rt1019-dts\;-DCODEC_CONFIG_MODE_SEL\;-DDTS=`DTS'"
 	"sof-rn-rt5682-max98360\;sof-rn-rt5682-max98360"
 )
 

--- a/tools/topology/topology1/m4/codec_adapter.m4
+++ b/tools/topology/topology1/m4/codec_adapter.m4
@@ -52,7 +52,9 @@ define(`W_CODEC_ADAPTER',
 `	bytes ['
 		$6
 `	]'
-
+`	enum ['
+		$7
+`	]'
 `}')
 
 divert(0)dnl

--- a/tools/topology/topology1/m4/dts_codec_adapter.m4
+++ b/tools/topology/topology1/m4/dts_codec_adapter.m4
@@ -62,3 +62,20 @@ C_CONTROLBYTES(CA_RUNTIME_CONTROLBYTES_NAME_PIPE, PIPELINE_ID,
         ,
         CA_RUNTIME_PARAMS)
 
+ifdef(`CODEC_CONFIG_MODE_SEL', `
+
+# Codec adapter enum control for config mode selection
+define(`CA_CONFIG_MODE_SEL_NAME_PIPE', concat(`DTS Codec Config Mode ', PIPELINE_ID))
+
+define(`CONTROL_NAME', `CA_CONFIG_MODE_SEL_NAME_PIPE')
+# Codec adapter enum list. 0: bypass (optional), 1: speaker, 2: headphone.
+CONTROLENUM_LIST(`CA_CONFIG_MODE_VALUES',
+	LIST(`   ', `"bypass"', `"speaker"', `"headphone"'))
+
+# Codec adapter enm control
+C_CONTROLENUM(CA_CONFIG_MODE_SEL_NAME_PIPE, PIPELINE_ID,
+	CA_CONFIG_MODE_VALUES,
+	LIST(`  ', ENUM_CHANNEL(FC, 3, 0)),
+	CONTROLENUM_OPS(enum, 257 binds the mixer control to enum get/put handlers, 257, 257))
+undefine(`CONTROL_NAME')
+')

--- a/tools/topology/topology1/sof/pipe-dts-codec-playback.m4
+++ b/tools/topology/topology1/sof/pipe-dts-codec-playback.m4
@@ -12,6 +12,7 @@ include(`dai.m4')
 include(`pipeline.m4')
 include(`codec_adapter.m4')
 include(`bytecontrol.m4')
+include(`enumcontrol.m4')
 
 #
 # Controls
@@ -34,7 +35,8 @@ ifdef(`CA_SCHEDULE_CORE',`', `define(`CA_SCHEDULE_CORE', `SCHEDULE_CORE')')
 W_PCM_PLAYBACK(PCM_ID, Passthrough Playback, DAI_PERIODS, 0, SCHEDULE_CORE)
 
 W_CODEC_ADAPTER(0, PIPELINE_FORMAT, DAI_PERIODS, DAI_PERIODS, CA_SCHEDULE_CORE,
-        LIST(`          ', "CA_SETUP_CONTROLBYTES_NAME_PIPE", "CA_RUNTIME_CONTROLBYTES_NAME_PIPE"))
+        LIST(`          ', "CA_SETUP_CONTROLBYTES_NAME_PIPE", "CA_RUNTIME_CONTROLBYTES_NAME_PIPE"),
+        ifdef(`CODEC_CONFIG_MODE_SEL', `LIST(`          ', "CA_CONFIG_MODE_SEL_NAME_PIPE")'))
 
 # Playback Buffers
 W_BUFFER(0, COMP_BUFFER_SIZE(2,
@@ -67,6 +69,8 @@ indir(`define', concat(`PIPELINE_PCM_', PIPELINE_ID), Passthrough Playback PCM_I
 
 PCM_CAPABILITIES(Passthrough Playback PCM_ID, CAPABILITY_FORMAT_NAME(PIPELINE_FORMAT), PCM_MIN_RATE, PCM_MAX_RATE, 2, PIPELINE_CHANNELS, 2, 16, 192, 16384, 65536, 65536)
 
+undefine(`CA_CONFIG_MODE_VALUES')
+undefine(`CA_CONFIG_MODE_SEL_NAME_PIPE')
 undefine(`CA_RUNTIME_CONTROLBYTES_NAME_PIPE')
 undefine(`CA_RUNTIME_PARAMS')
 undefine(`CA_SETUP_CONTROLBYTES_NAME_PIPE')

--- a/tools/topology/topology1/sof/pipe-eq-iir-dts-codec-playback.m4
+++ b/tools/topology/topology1/sof/pipe-eq-iir-dts-codec-playback.m4
@@ -13,6 +13,7 @@ include(`pipeline.m4')
 include(`codec_adapter.m4')
 include(`bytecontrol.m4')
 include(`eq_iir.m4')
+include(`enumcontrol.m4')
 
 #
 # Controls
@@ -54,7 +55,8 @@ ifdef(`CA_SCHEDULE_CORE',`', `define(`CA_SCHEDULE_CORE', `SCHEDULE_CORE')')
 W_PCM_PLAYBACK(PCM_ID, Passthrough Playback, DAI_PERIODS, 0, SCHEDULE_CORE)
 
 W_CODEC_ADAPTER(0, PIPELINE_FORMAT, DAI_PERIODS, DAI_PERIODS, CA_SCHEDULE_CORE,
-        LIST(`          ', "CA_SETUP_CONTROLBYTES_NAME_PIPE", "CA_RUNTIME_CONTROLBYTES_NAME_PIPE"))
+        LIST(`          ', "CA_SETUP_CONTROLBYTES_NAME_PIPE", "CA_RUNTIME_CONTROLBYTES_NAME_PIPE"),
+        ifdef(`CODEC_CONFIG_MODE_SEL', `LIST(`          ', "CA_CONFIG_MODE_SEL_NAME_PIPE")'))
 
 # "EQ 0" has 2 sink period and 2 source periods
 W_EQ_IIR(0, PIPELINE_FORMAT, 2, 2, SCHEDULE_CORE,
@@ -96,6 +98,8 @@ indir(`define', concat(`PIPELINE_PCM_', PIPELINE_ID), Passthrough Playback PCM_I
 
 PCM_CAPABILITIES(Passthrough Playback PCM_ID, CAPABILITY_FORMAT_NAME(PIPELINE_FORMAT), PCM_MIN_RATE, PCM_MAX_RATE, 2, PIPELINE_CHANNELS, 2, 16, 192, 16384, 65536, 65536)
 
+undefine(`CA_CONFIG_MODE_VALUES')
+undefine(`CA_CONFIG_MODE_SEL_NAME_PIPE')
 undefine(`CA_RUNTIME_CONTROLBYTES_NAME_PIPE')
 undefine(`CA_RUNTIME_PARAMS')
 undefine(`CA_SETUP_CONTROLBYTES_NAME_PIPE')


### PR DESCRIPTION
**Note: commits will NOT be landed to main.** (might be landed to other production branches on demand)

For the purposes of security concerns, the bytes control for 3P components will be set as read-only for production builds. For project Dewatt (ChromeOS device under AMD Renoir platform), DTS (under module_adapter) is applied on ACP SP playback pipeline, which is exclusively shared to Speakers and Headphone BE.

The config blob of DTS should be specified individually for Speakers and Headphone during the switch of active output device. However the bytes control is no more writable after topology initialization. As alternative, the enum control is added on module_adapter for multi-config identification support.

By these commits, the multi-config blobs should be assigned via the control private data for read-only bytes control, or once from external during sound card initialization, as the format of module_param with the enumerated indices as param->id. Blobs are stored by internal cache and applied accordingly to the value of enum control on prepare(). The client needs to set the corresponding value to enum control before switching the active output device. 