### PR TITLE
[Do Not Merge] ipc4: invalidate host mailbox cache after IPC completion

### DIFF
--- a/src/audio/mixin_mixout.c
+++ b/src/audio/mixin_mixout.c
@@ -935,16 +935,9 @@ static int mixin_reset(struct comp_dev *dev)
 
 static int mixout_reset(struct comp_dev *dev)
 {
-	struct mixout_data *mixout_data;
-	struct mixed_data_info __sparse_cache *mixed_data_info;
 	struct list_item *blist;
 
 	comp_dbg(dev, "mixout_reset()");
-
-	mixout_data = comp_get_drvdata(dev);
-	mixed_data_info = mixed_data_info_acquire(mixout_data->mixed_data_info);
-	memset(mixed_data_info->source_info, 0, sizeof(mixed_data_info->source_info));
-	mixed_data_info_release(mixed_data_info);
 
 	if (dev->pipeline->source_comp->direction == SOF_IPC_STREAM_PLAYBACK) {
 		list_for_item(blist, &dev->bsource_list) {

--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -1133,4 +1133,7 @@ void ipc_cmd(struct ipc_cmd_hdr *_hdr)
 
 		ipc_msg_send(&msg_reply, data, true);
 	}
+
+	dcache_invalidate_region((__sparse_force void __sparse_cache *)MAILBOX_HOSTBOX_BASE,
+				 MAILBOX_HOSTBOX_SIZE);
 }


### PR DESCRIPTION
IPC4 uses a mailbox for configuration data, received from the host, and it accesses it via a cached alias. To prevent stale cache issues cache contents is invalidated before reading data from the mailbox, but this isn't enough. When a new IPC is received the cache contents from the previous IPC can be written back over the new data before cache is invalidated. To avoid this cache has to be invalidated after IPC processing has completed.
