### PR TITLE
zephyr: Fix cycle counting on i.MX

### DIFF
--- a/zephyr/include/rtos/wait.h
+++ b/zephyr/include/rtos/wait.h
@@ -11,6 +11,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <zephyr/kernel.h>
+#include <rtos/timer.h>
 
 /* TODO: use equivalent Zephyr */
 static inline void idelay(int n)
@@ -24,9 +25,9 @@ static inline void idelay(int n)
 
 static inline void wait_delay(uint64_t number_of_clks)
 {
-	uint64_t timeout = k_cycle_get_64() + number_of_clks;
+	uint64_t timeout = sof_cycle_get_64() + number_of_clks;
 
-	while (k_cycle_get_64() < timeout)
+	while (sof_cycle_get_64() < timeout)
 		idelay(PLATFORM_DEFAULT_DELAY);
 }
 

--- a/zephyr/include/sof/trace/trace.h
+++ b/zephyr/include/sof/trace/trace.h
@@ -35,7 +35,7 @@ uint64_t platform_timer_get(struct timer *timer);
 #define mtrace_printf(level, format, ...)					\
 	do {									\
 		if ((level) <= SOF_ZEPHYR_TRACE_LEVEL)				\
-			printk("%llu: " format "\n", k_cycle_get_64(),		\
+			printk("%llu: " format "\n", sof_cycle_get_64(),	\
 				##__VA_ARGS__);					\
 	} while (0)
 #else

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -664,7 +664,7 @@ void platform_dai_timestamp(struct comp_dev *dai,
 		posn->flags |= SOF_TIME_DAI_VALID;
 
 	/* get SSP wallclock - DAI sets this to stream start value */
-	posn->wallclock = k_cycle_get_64() - posn->wallclock;
+	posn->wallclock = sof_cycle_get_64() - posn->wallclock;
 	posn->wallclock_hz = clock_get_freq(PLATFORM_DEFAULT_CLOCK);
 	posn->flags |= SOF_TIME_WALL_VALID;
 }
@@ -672,7 +672,7 @@ void platform_dai_timestamp(struct comp_dev *dai,
 /* get current wallclock for componnent */
 void platform_dai_wallclock(struct comp_dev *dai, uint64_t *wallclock)
 {
-	*wallclock = k_cycle_get_64();
+	*wallclock = sof_cycle_get_64();
 }
 
 /*


### PR DESCRIPTION
On i.MX8 k_cycle_get_64 always returns 0 so use sof_cycle_get_64 instead.

There is no better solution to support 64bit cycle counting for i.MX and will have to stick with this implementation.

Fixes: c3c94fc515188 ("header: rtos: use rtos specific version of wait.h")
Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>