### PR TITLE
topology2: fix multi-stream test issue in ci

### DIFF
--- a/tools/topology/topology2/cavs/cavs-nocodec.conf
+++ b/tools/topology/topology2/cavs/cavs-nocodec.conf
@@ -228,7 +228,7 @@ Object.Pipeline {
 		}
 
 		Object.Widget.copier.1 {
-			dai_index 1
+			dai_index 2
 			dai_type "SSP"
 			copier_type "SSP"
 			stream_name "NoCodec-2"


### PR DESCRIPTION
Duplicated dai index result to module initialization faiure in multi-stream test. Dai 2 should be used by stream nocodec-2.

passed failed cases in CI daily test.