### PR TITLE
[PATCH RFC]     rtos: wait: Use native Zephyr API for waiting

### DIFF
--- a/zephyr/include/rtos/wait.h
+++ b/zephyr/include/rtos/wait.h
@@ -12,11 +12,9 @@
 #include <stdbool.h>
 #include <zephyr/kernel.h>
 
-/* TODO: use equivalent Zephyr */
 static inline void idelay(int n)
 {
-	while (n--)
-		asm volatile("nop");
+	k_busy_wait((uint32_t)n);
 }
 
 /* DSP default delay in cycles - all platforms use this today */
@@ -24,20 +22,21 @@ static inline void idelay(int n)
 
 static inline void wait_delay(uint64_t number_of_clks)
 {
-	uint64_t timeout = sof_cycle_get_64() + number_of_clks;
+	uint64_t timeout;
 
-	while (sof_cycle_get_64() < timeout)
-		idelay(PLATFORM_DEFAULT_DELAY);
+	timeout = number_of_clks * NSEC_PER_SEC / CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC;
+
+	k_busy_wait((uint32_t)timeout);
 }
 
 static inline void wait_delay_ms(uint64_t ms)
 {
-	wait_delay(k_ms_to_cyc_ceil64(ms));
+	k_busy_wait((uint32_t)(ms * 1000));
 }
 
 static inline void wait_delay_us(uint64_t us)
 {
-	wait_delay(k_us_to_cyc_ceil64(us));
+	k_busy_wait((uint32_t)us);
 }
 
 int poll_for_register_delay(uint32_t reg, uint32_t mask,

--- a/zephyr/include/rtos/wait.h
+++ b/zephyr/include/rtos/wait.h
@@ -24,9 +24,9 @@ static inline void idelay(int n)
 
 static inline void wait_delay(uint64_t number_of_clks)
 {
-	uint64_t timeout = k_cycle_get_64() + number_of_clks;
+	uint64_t timeout = sof_cycle_get_64() + number_of_clks;
 
-	while (k_cycle_get_64() < timeout)
+	while (sof_cycle_get_64() < timeout)
 		idelay(PLATFORM_DEFAULT_DELAY);
 }
 

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -664,7 +664,7 @@ void platform_dai_timestamp(struct comp_dev *dai,
 		posn->flags |= SOF_TIME_DAI_VALID;
 
 	/* get SSP wallclock - DAI sets this to stream start value */
-	posn->wallclock = k_cycle_get_64() - posn->wallclock;
+	posn->wallclock = sof_cycle_get_64() - posn->wallclock;
 	posn->wallclock_hz = clock_get_freq(PLATFORM_DEFAULT_CLOCK);
 	posn->flags |= SOF_TIME_WALL_VALID;
 }
@@ -672,7 +672,7 @@ void platform_dai_timestamp(struct comp_dev *dai,
 /* get current wallclock for componnent */
 void platform_dai_wallclock(struct comp_dev *dai, uint64_t *wallclock)
 {
-	*wallclock = k_cycle_get_64();
+	*wallclock = sof_cycle_get_64();
 }
 
 /*


### PR DESCRIPTION
Make use of k_busy_wait instead of idelay.

Note that this PR depends on https://github.com/thesofproject/sof/pull/6416 and it also brings patch from that PR in order for CI to run.