### PR TITLE
stable v2.2: cherry pick ADL topology support for ES83x6 and HDMI_In Capture

### DIFF
--- a/tools/topology/topology1/CMakeLists.txt
+++ b/tools/topology/topology1/CMakeLists.txt
@@ -249,6 +249,8 @@ set(TPLGS
 	"sof-glk-es8336\;sof-tgl-es8336-dmic4ch-ssp2\;-DPLATFORM=tgl\;-DSSP_NUM=2\;-DCHANNELS=4"
 
 	"sof-glk-es8336\;sof-adl-es8336-ssp1\;-DPLATFORM=adl\;-DSSP_NUM=1\;-DCHANNELS=0"
+	#sof-adl-es8336-ssp1-hdmi-ssp02 supports es8336 codec along with 2xHDMI_over_SSP Capture's.
+	"sof-glk-es8336\;sof-adl-es8336-ssp1-hdmi-ssp02\;-DPLATFORM=adl\;-DSSP_NUM=1\;-DCHANNELS=0\;-DHDMI_1_SSP_NUM=0\;-DHDMI_2_SSP_NUM=2"
 
 	"sof-imx8-nocodec\;sof-imx8-nocodec"
 	"sof-imx8-cs42888\;sof-imx8-cs42888"

--- a/tools/topology/topology1/CMakeLists.txt
+++ b/tools/topology/topology1/CMakeLists.txt
@@ -248,6 +248,8 @@ set(TPLGS
 	"sof-glk-es8336\;sof-tgl-es8336-dmic4ch-ssp1\;-DPLATFORM=tgl\;-DSSP_NUM=1\;-DCHANNELS=4"
 	"sof-glk-es8336\;sof-tgl-es8336-dmic4ch-ssp2\;-DPLATFORM=tgl\;-DSSP_NUM=2\;-DCHANNELS=4"
 
+	"sof-glk-es8336\;sof-adl-es8336-ssp1\;-DPLATFORM=adl\;-DSSP_NUM=1\;-DCHANNELS=0"
+
 	"sof-imx8-nocodec\;sof-imx8-nocodec"
 	"sof-imx8-cs42888\;sof-imx8-cs42888"
 	"sof-imx8-nocodec-sai\;sof-imx8-nocodec-sai"

--- a/tools/topology/topology1/platform/intel/intel-hdmi-ssp.m4
+++ b/tools/topology/topology1/platform/intel/intel-hdmi-ssp.m4
@@ -1,0 +1,53 @@
+#
+# HDMI-SSP Audio Offload support
+#
+
+include(`ssp.m4')
+
+define(`HDMI_SSP_NAME', concat(concat(`SSP', HDMI_SSP_NUM),`-HDMI'))
+define(`HDMI_SSP_PCM_NAME', concat(concat(`HDMI-', HDMI_SSP_NUM),`-In'))
+
+# variable that need to be defined in upper m4
+ifdef(`HDMI_SSP_PIPELINE_CP_ID',`',`fatal_error(note: Need to define capture pcm id for ssp intel-hdmi-in
+)')
+ifdef(`HDMI_SSP_DAI_LINK_ID',`',`fatal_error(note: Need to define DAI link id for ssp intel-hdmi-in
+)')
+ifdef(`HDMI_SSP_PCM_ID',`',`fatal_error(note: Need to define pipeline PCM dev id for ssp intel-hdmi-in
+)')
+
+
+# Low Latency capture pipeline 4 on PCM HDMI_SSP_PCM_ID using max 2 channels of s32le.
+# 1000us deadline with priority 0 on core 0
+PIPELINE_PCM_ADD(sof/pipe-low-latency-capture.m4,
+	HDMI_SSP_PIPELINE_CP_ID, HDMI_SSP_PCM_ID, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+
+# capture DAI is SSP using 2 periods
+# Buffers use s32le format, 1000us deadline with priority 0 on core 0
+DAI_ADD(sof/pipe-dai-capture.m4,
+	HDMI_SSP_PIPELINE_CP_ID, SSP, HDMI_SSP_NUM, HDMI_SSP_NAME,
+	concat(`PIPELINE_SINK_', HDMI_SSP_PIPELINE_CP_ID), 2, s32le,
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_DMA)
+
+
+PCM_CAPTURE_ADD(HDMI_SSP_PCM_NAME, HDMI_SSP_PCM_ID, concat(`PIPELINE_PCM_', HDMI_SSP_PIPELINE_CP_ID))
+
+
+#BE configuration in slave mode
+DAI_CONFIG(SSP, HDMI_SSP_NUM, HDMI_SSP_DAI_LINK_ID, HDMI_SSP_NAME,
+	   SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24576000, codec_mclk_in),
+		      SSP_CLOCK(bclk, 3072000, codec_provider),
+		      SSP_CLOCK(fsync, 48000, codec_provider),
+		      SSP_TDM(2, 32, 3, 3),
+		      SSP_CONFIG_DATA(SSP, HDMI_SSP_NUM, 32, 0)))
+
+
+undefine(`HDMI_SSP_PIPELINE_CP_ID')
+undefine(`HDMI_SSP_DAI_LINK_ID')
+undefine(`HDMI_SSP_PCM_ID') dnl use fixed PCM_ID
+undefine(`HDMI_SSP_NUM')
+undefine(`HDMI_SSP_NAME')
+undefine(`HDMI_SSP_PCM_NAME')
+

--- a/tools/topology/topology1/sof-glk-es8336.m4
+++ b/tools/topology/topology1/sof-glk-es8336.m4
@@ -53,6 +53,24 @@ include(`platform/intel/intel-generic-dmic.m4')
 '
 )
 
+# Add HDMI-SSP Audio Offload pass-through
+ifdef(`HDMI_1_SSP_NUM',
+`	define(`HDMI_SSP_NUM', HDMI_1_SSP_NUM)
+	define(`HDMI_SSP_PIPELINE_CP_ID', `8')
+	define(`HDMI_SSP_DAI_LINK_ID', 6)
+	define(`HDMI_SSP_PCM_ID', `3') dnl use fixed PCM_ID
+	include(`platform/intel/intel-hdmi-ssp.m4')
+'
+)
+
+ifdef(`HDMI_2_SSP_NUM',
+`	define(`HDMI_SSP_NUM', HDMI_2_SSP_NUM)
+	define(`HDMI_SSP_PIPELINE_CP_ID', `9')
+	define(`HDMI_SSP_DAI_LINK_ID', 7)
+	define(`HDMI_SSP_PCM_ID', `4') dnl use fixed PCM_ID
+	include(`platform/intel/intel-hdmi-ssp.m4')
+'
+)
 
 DEBUG_START
 #
@@ -68,6 +86,16 @@ ifelse(CHANNELS, `0',
 # PCM5  ----> volume (pipe 5)   -----> iDisp1 (HDMI/DP playback, BE link 5)
 # PCM6  ----> Volume (pipe 6)   -----> iDisp2 (HDMI/DP playback, BE link 6)
 # PCM7  ----> volume (pipe 7)   -----> iDisp3 (HDMI/DP playback, BE link 7)
+ifdef(`HDMI_1_SSP_NUM',
+`
+# PCM3 <---- volume <----- HDMI_1_SSP_NUM (lt6911)
+'
+)
+ifdef(`HDMI_2_SSP_NUM',
+`
+# PCM4 <---- volume <----- HDMI_2_SSP_NUM (lt6911)
+'
+)
 
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
 # 1000us deadline with priority 0 on core 0


### PR DESCRIPTION
Stable-v2.2 is the recommended branch for Intel released platforms till RPL. So cherry pick these 2 topology commits from main to stable-v2.2: 
586716e1b93037e06b6ba6dbd05c7fe7ac7c9ce4 topology1: CMakeLists: add ADL support for ES83x6 & HDMI_In Capture
187c845ddcd8d010212d0e6602f89d80f22e75db topology1: CMakeLists: add ADL support for ES83x6
