### PR TITLE
ipc4: dai: reduce get_llp_reg_info log verbosity

### DIFF
--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -171,7 +171,7 @@ static void get_llp_reg_info(struct comp_dev *dev, uint32_t *node_id, uint32_t *
 			*offset = offsetof(struct ipc4_fw_registers, llp_sndw_reading_slots);
 			*offset += id * sizeof(struct ipc4_llp_reading_slot);
 		} else {
-			comp_err(dev, "get_llp_reg_info(): sndw id %u out of array bounds.", id);
+			comp_dbg(dev, "get_llp_reg_info(): sndw id %u out of array bounds.", id);
 			*node_id = 0;
 		}
 
@@ -181,7 +181,7 @@ static void get_llp_reg_info(struct comp_dev *dev, uint32_t *node_id, uint32_t *
 			*offset = offsetof(struct ipc4_fw_registers, llp_gpdma_reading_slots);
 			*offset += id * sizeof(struct ipc4_llp_reading_slot);
 		} else {
-			comp_err(dev, "get_llp_reg_info(): gpdma id %u out of array bounds.", id);
+			comp_dbg(dev, "get_llp_reg_info(): gpdma id %u out of array bounds.", id);
 			*node_id = 0;
 		}
 


### PR DESCRIPTION
The "get_llp_reg_info(): gpdma id 32 out of array bounds." message is hit constantly with current mainline topologies with no apparent impact to functinality.

The log is printed at a very high rate, which causes CPU and SRAM traffic pressure that affects test execution.

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>