### PR TITLE
Revert mixer and volume addition from cavs-nocodec

### DIFF
--- a/tools/topology/topology2/cavs/cavs-nocodec.conf
+++ b/tools/topology/topology2/cavs/cavs-nocodec.conf
@@ -228,7 +228,7 @@ Object.Pipeline {
 		}
 
 		Object.Widget.copier.1 {
-			dai_index 2
+			dai_index 1
 			dai_type "SSP"
 			copier_type "SSP"
 			stream_name "NoCodec-2"

--- a/tools/topology/topology2/cavs/cavs-nocodec.conf
+++ b/tools/topology/topology2/cavs/cavs-nocodec.conf
@@ -11,10 +11,9 @@
 <pdm_config.conf>
 <tokens.conf>
 <virtual.conf>
+<passthrough-playback.conf>
 <passthrough-capture.conf>
 <passthrough-be.conf>
-<host-copier-gain-mixin-playback.conf>
-<mixout-gain-dai-copier-playback.conf>
 <data.conf>
 <pcm.conf>
 <pcm_caps.conf>
@@ -117,36 +116,13 @@ Object.Dai {
 #
 # Pipeline definitions
 #
-# PCM0 ---> gain ----> Mixin ----> Mixout ----> gain ----> SSP0
-# PCM1 ---> gain ----> Mixin ----> Mixout ----> gain ----> SSP1
-# PCM2 ---> gain ----> Mixin ----> Mixout ----> gain ----> SSP2
-#
-# SSP0 ----> PCM0
-# SSP1 ----> PCM1
-# SSP2 ----> PCM2
 
 # Pipeline ID:1 PCM ID: 0
 Object.Pipeline {
 	# playback pipelines
-	host-copier-gain-mixin-playback.1 {
-		index	1
-
-		Object.Widget.pipeline.1 {
-			stream_name 'NoCodec-0'
-		}
-		Object.Widget.copier.1 {
-			stream_name 'SSP0 Playback'
-		}
-		Object.Widget.gain.1 {
-			Object.Control.mixer.1 {
-				name 'Playback Volume 1'
-			}
-		}
-	}
-
-	mixout-gain-dai-copier-playback.1 {
-		index 2
-
+	passthrough-be.1 {
+		index	2
+		direction	playback
 		Object.Widget.pipeline.1 {
 			stream_name 'NoCodec-0'
 		}
@@ -158,33 +134,21 @@ Object.Pipeline {
 			stream_name "NoCodec-0"
 			node_type $I2S_LINK_OUTPUT_CLASS
 		}
-
-		Object.Widget.gain.1 {
-			Object.Control.mixer.1 {
-				name 'Main Playback Volume 2'
-			}
-		}
 	}
 
-	host-copier-gain-mixin-playback.2 {
-		index	3
-
+	passthrough-playback.1 {
+		index	1
 		Object.Widget.pipeline.1 {
-			stream_name 'NoCodec-1'
+			stream_name 'NoCodec-0'
 		}
 		Object.Widget.copier.1 {
-			stream_name 'SSP1 Playback'
-		}
-		Object.Widget.gain.1 {
-			Object.Control.mixer.1 {
-				name 'Playback Volume 3'
-			}
+			stream_name 'SSP0 Playback'
 		}
 	}
 
-	mixout-gain-dai-copier-playback.2 {
-		index 4
-
+	passthrough-be.2 {
+		index	4
+		direction	playback
 		Object.Widget.pipeline.1 {
 			stream_name 'NoCodec-1'
 		}
@@ -196,49 +160,41 @@ Object.Pipeline {
 			stream_name "NoCodec-1"
 			node_type $I2S_LINK_OUTPUT_CLASS
 		}
-
-		Object.Widget.gain.1 {
-			Object.Control.mixer.1 {
-				name 'Main Playback Volume 4'
-			}
-		}
 	}
 
-	host-copier-gain-mixin-playback.3 {
-		index	5
-
+	passthrough-playback.2 {
+		index	3
 		Object.Widget.pipeline.1 {
-			stream_name 'NoCodec-2'
+			stream_name 'NoCodec-1'
 		}
 		Object.Widget.copier.1 {
-			stream_name 'SSP2 Playback'
-		}
-		Object.Widget.gain.1 {
-			Object.Control.mixer.1 {
-				name 'Playback Volume 5'
-			}
+			stream_name 'SSP1 Playback'
 		}
 	}
 
-	mixout-gain-dai-copier-playback.3 {
-		index 6
-
+	passthrough-be.3 {
+		index	6
+		direction	playback
 		Object.Widget.pipeline.1 {
 			stream_name 'NoCodec-2'
 		}
 
 		Object.Widget.copier.1 {
-			dai_index 1
+			dai_index 2
 			dai_type "SSP"
 			copier_type "SSP"
 			stream_name "NoCodec-2"
 			node_type $I2S_LINK_OUTPUT_CLASS
 		}
+	}
 
-		Object.Widget.gain.1 {
-			Object.Control.mixer.1 {
-				name 'Main Playback Volume 6'
-			}
+	passthrough-playback.3 {
+		index	5
+		Object.Widget.pipeline.1 {
+			stream_name 'NoCodec-2'
+		}
+		Object.Widget.copier.1 {
+			stream_name 'SSP2 Playback'
 		}
 	}
 
@@ -399,45 +355,33 @@ Object.PCM {
 
 Object.Base {
 	route."1" {
-		source	"gain.2.1"
+		source	"copier.host.1.1"
 		sink	"copier.SSP.2.1"
 	}
 
 	route."2" {
-		source	"mixin.1.1"
-		sink	"mixout.2.1"
+		source	"copier.host.3.1"
+		sink	"copier.SSP.4.1"
 	}
 
 	route."3" {
-		source	"gain.4.1"
-		sink	"copier.SSP.4.1"
-	}
-	route."4" {
-		source	"mixin.3.1"
-		sink	"mixout.4.1"
-	}
-
-	route."5" {
-		source	"gain.6.1"
+		source	"copier.host.5.1"
 		sink	"copier.SSP.6.1"
 	}
-	route."6" {
-		source	"mixin.5.1"
-		sink	"mixout.6.1"
-	}
 
-	route."7" {
+	route."4" {
 		source	"copier.SSP.8.1"
 		sink	"copier.host.7.1"
 	}
 
-	route."8" {
+	route."5" {
 		source	"copier.SSP.10.1"
 		sink	"copier.host.9.1"
 	}
 
-	route."9" {
+	route."6" {
 		source	"copier.SSP.12.1"
 		sink	"copier.host.11.1"
 	}
+
 }


### PR DESCRIPTION
The mixer is not mature enough to be enabled in nocdec topology and the fix today did not help.

A potential issue found with reset() handling, work in progress in https://github.com/thesofproject/sof/pull/6414

Submitting this to prepare for plan-B. If the fix is delayed or does not help, we need to merge this and come back to mixer enabling when code is more mature.