### PR TITLE
[IPC4] make sure not to modify host memory window contents

### DIFF
--- a/src/audio/aria/aria.c
+++ b/src/audio/aria/aria.c
@@ -122,10 +122,10 @@ int aria_process_data(struct comp_dev *dev,
 	return aria_algo_buffer_data(dev, src, src_size);
 }
 
-static int init_aria(struct comp_dev *dev, struct comp_ipc_config *config,
-		     void *spec)
+static int init_aria(struct comp_dev *dev, const struct comp_ipc_config *config,
+		     const void *spec)
 {
-	struct ipc4_aria_module_cfg *aria = spec;
+	const struct ipc4_aria_module_cfg *aria = spec;
 	struct aria_data *cd;
 	size_t ibs, chc, sgs, sgc, req_mem, att;
 	void *buf, *buf_in, *buf_out;
@@ -181,7 +181,8 @@ static int init_aria(struct comp_dev *dev, struct comp_ipc_config *config,
 }
 
 static struct comp_dev *aria_new(const struct comp_driver *drv,
-				 struct comp_ipc_config *config, void *spec)
+				 const struct comp_ipc_config *config,
+				 const void *spec)
 {
 	struct comp_dev *dev;
 	int ret;

--- a/src/audio/asrc/asrc.c
+++ b/src/audio/asrc/asrc.c
@@ -324,14 +324,14 @@ static int asrc_get_attribute(struct comp_dev *dev, uint32_t type, void *value)
 #endif
 
 static struct comp_dev *asrc_new(const struct comp_driver *drv,
-				 struct comp_ipc_config *config,
-				 void *spec)
+				 const struct comp_ipc_config *config,
+				 const void *spec)
 {
 	struct comp_dev *dev;
 #ifndef CONFIG_IPC_MAJOR_4
-	struct ipc_config_asrc *ipc_asrc = spec;
+	const struct ipc_config_asrc *ipc_asrc = spec;
 #else
-	struct ipc4_asrc_module_cfg *ipc_asrc = spec;
+	const struct ipc4_asrc_module_cfg *ipc_asrc = spec;
 #endif
 	struct comp_data *cd;
 

--- a/src/audio/base_fw.c
+++ b/src/audio/base_fw.c
@@ -239,14 +239,14 @@ static uint32_t basefw_set_system_time(uint32_t param_id,
 				       bool first_block,
 				       bool last_block,
 				       uint32_t data_offset,
-				       char *data)
+				       const char *data)
 {
 	/* TODO: configurate time to logging subsystem */
 	if (!(first_block && last_block))
 		return IPC4_INVALID_REQUEST;
 
-	global_system_time_info.host_time.val_l = ((struct ipc4_system_time *)data)->val_l;
-	global_system_time_info.host_time.val_u = ((struct ipc4_system_time *)data)->val_u;
+	global_system_time_info.host_time.val_l = ((const struct ipc4_system_time *)data)->val_l;
+	global_system_time_info.host_time.val_u = ((const struct ipc4_system_time *)data)->val_u;
 
 	uint64_t current_dsp_time = sof_cycle_get_64();
 

--- a/src/audio/base_fw.c
+++ b/src/audio/base_fw.c
@@ -383,7 +383,7 @@ static int basefw_set_large_config(struct comp_dev *dev,
 				   bool first_block,
 				   bool last_block,
 				   uint32_t data_offset,
-				   char *data)
+				   const char *data)
 {
 	switch (param_id) {
 	case IPC4_FW_CONFIG:

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -55,7 +55,7 @@ static pcm_converter_func get_converter_func(const struct ipc4_audio_format *in_
 static int create_endpoint_buffer(struct comp_dev *parent_dev,
 				  struct copier_data *cd,
 				  struct comp_ipc_config *config,
-				  struct ipc4_copier_module_cfg *copier_cfg,
+				  const struct ipc4_copier_module_cfg *copier_cfg,
 				  enum ipc4_gateway_type type,
 				  int index)
 {
@@ -166,7 +166,7 @@ static int create_endpoint_buffer(struct comp_dev *parent_dev,
  */
 static int create_host(struct comp_dev *parent_dev, struct copier_data *cd,
 		       struct comp_ipc_config *config,
-		       struct ipc4_copier_module_cfg *copier_cfg,
+		       const struct ipc4_copier_module_cfg *copier_cfg,
 		       int dir)
 {
 	struct sof_uuid host = {0x8b9d100c, 0x6d78, 0x418f, {0x90, 0xa3, 0xe0,
@@ -231,7 +231,7 @@ e_buf:
 static int init_dai(struct comp_dev *parent_dev,
 		    const struct comp_driver *drv,
 		    struct comp_ipc_config *config,
-		    struct ipc4_copier_module_cfg *copier,
+		    const struct ipc4_copier_module_cfg *copier,
 		    struct pipeline *pipeline,
 		    struct ipc_config_dai *dai,
 		    enum ipc4_gateway_type type,
@@ -300,7 +300,7 @@ e_buf:
  */
 static int create_dai(struct comp_dev *parent_dev, struct copier_data *cd,
 		      struct comp_ipc_config *config,
-		      struct ipc4_copier_module_cfg *copier,
+		      const struct ipc4_copier_module_cfg *copier,
 		      struct pipeline *pipeline)
 {
 	struct sof_uuid id = {0xc2b00d27, 0xffbc, 0x4150, {0xa5, 0x1a, 0x24,
@@ -429,10 +429,10 @@ static int init_pipeline_reg(struct comp_dev *dev)
 }
 
 static struct comp_dev *copier_new(const struct comp_driver *drv,
-				   struct comp_ipc_config *config,
-				   void *spec)
+				   const struct comp_ipc_config *config,
+				   const void *spec)
 {
-	struct ipc4_copier_module_cfg *copier = spec;
+	const struct ipc4_copier_module_cfg *copier = spec;
 	union ipc4_connector_node_id node_id;
 	struct ipc_comp_dev *ipc_pipe;
 	struct ipc *ipc = ipc_get();
@@ -484,7 +484,7 @@ static struct comp_dev *copier_new(const struct comp_driver *drv,
 		switch (node_id.f.dma_type) {
 		case ipc4_hda_host_output_class:
 		case ipc4_hda_host_input_class:
-			if (create_host(dev, cd, config, copier, cd->direction)) {
+			if (create_host(dev, cd, &dev->ipc_config, copier, cd->direction)) {
 				comp_cl_err(&comp_copier, "unenable to create host");
 				goto error_cd;
 			}
@@ -505,7 +505,7 @@ static struct comp_dev *copier_new(const struct comp_driver *drv,
 		case ipc4_i2s_link_input_class:
 		case ipc4_alh_link_output_class:
 		case ipc4_alh_link_input_class:
-			if (create_dai(dev, cd, config, copier, ipc_pipe->pipeline)) {
+			if (create_dai(dev, cd, &dev->ipc_config, copier, ipc_pipe->pipeline)) {
 				comp_cl_err(&comp_copier, "unenable to create dai");
 				goto error_cd;
 			}

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -47,8 +47,8 @@ DECLARE_SOF_RT_UUID("copier", copier_comp_uuid, 0x9ba00c83, 0xca12, 0x4a83,
 
 DECLARE_TR_CTX(copier_comp_tr, SOF_UUID(copier_comp_uuid), LOG_LEVEL_INFO);
 
-static pcm_converter_func get_converter_func(struct ipc4_audio_format *in_fmt,
-					     struct ipc4_audio_format *out_fmt,
+static pcm_converter_func get_converter_func(const struct ipc4_audio_format *in_fmt,
+					     const struct ipc4_audio_format *out_fmt,
 					     enum ipc4_gateway_type type,
 					     enum ipc4_direction_type);
 
@@ -571,8 +571,8 @@ static bool use_no_container_convert_function(enum sof_ipc_frame in,
 	return false;
 }
 
-static pcm_converter_func get_converter_func(struct ipc4_audio_format *in_fmt,
-					     struct ipc4_audio_format *out_fmt,
+static pcm_converter_func get_converter_func(const struct ipc4_audio_format *in_fmt,
+					     const struct ipc4_audio_format *out_fmt,
 					     enum ipc4_gateway_type type,
 					     enum ipc4_direction_type dir)
 {
@@ -1016,13 +1016,11 @@ static int copier_params(struct comp_dev *dev, struct sof_ipc_stream_params *par
 	return ret;
 }
 
-static int copier_set_sink_fmt(struct comp_dev *dev, void *data,
+static int copier_set_sink_fmt(struct comp_dev *dev, const void *data,
 			       int max_data_size)
 {
-	struct ipc4_copier_config_set_sink_format *sink_fmt;
+	const struct ipc4_copier_config_set_sink_format *sink_fmt = data;
 	struct copier_data *cd = comp_get_drvdata(dev);
-
-	sink_fmt = (struct ipc4_copier_config_set_sink_format *)data;
 
 	if (max_data_size < sizeof(*sink_fmt)) {
 		comp_err(dev, "error: max_data_size %d should be bigger than %d", max_data_size,
@@ -1055,7 +1053,7 @@ static int copier_set_sink_fmt(struct comp_dev *dev, void *data,
 	return 0;
 }
 
-static int set_attenuation(struct comp_dev *dev, uint32_t data_offset, char *data)
+static int set_attenuation(struct comp_dev *dev, uint32_t data_offset, const char *data)
 {
 	struct copier_data *cd = comp_get_drvdata(dev);
 	struct comp_buffer *sink;
@@ -1068,7 +1066,7 @@ static int set_attenuation(struct comp_dev *dev, uint32_t data_offset, char *dat
 		return -EINVAL;
 	}
 
-	attenuation = *(uint32_t *)data;
+	attenuation = *(const uint32_t *)data;
 	if (attenuation > 31) {
 		comp_err(dev, "attenuation %d is out of range", attenuation);
 		return -EINVAL;
@@ -1092,7 +1090,7 @@ static int copier_set_large_config(struct comp_dev *dev, uint32_t param_id,
 				   bool first_block,
 				   bool last_block,
 				   uint32_t data_offset,
-				   char *data)
+				   const char *data)
 {
 	comp_dbg(dev, "copier_set_large_config()");
 

--- a/src/audio/crossover/crossover.c
+++ b/src/audio/crossover/crossover.c
@@ -321,12 +321,12 @@ static int crossover_setup(struct comp_data *cd, int nch)
  * \return Pointer to Crossover Filter component device.
  */
 static struct comp_dev *crossover_new(const struct comp_driver *drv,
-				      struct comp_ipc_config *config,
-				      void *spec)
+				      const struct comp_ipc_config *config,
+				      const void *spec)
 {
 	struct comp_dev *dev;
 	struct comp_data *cd;
-	struct ipc_config_process *ipc_crossover = spec;;
+	const struct ipc_config_process *ipc_crossover = spec;
 	size_t bs = ipc_crossover->size;
 	int ret;
 

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -160,11 +160,11 @@ static void dai_dma_cb(void *arg, enum notify_id type, void *data)
 }
 
 static struct comp_dev *dai_new(const struct comp_driver *drv,
-				struct comp_ipc_config *config,
-				void *spec)
+				const struct comp_ipc_config *config,
+				const void *spec)
 {
 	struct comp_dev *dev;
-	struct ipc_config_dai *dai = spec;
+	const struct ipc_config_dai *dai = spec;
 	struct dai_data *dd;
 	uint32_t dir, caps, dma_dev;
 

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -291,11 +291,11 @@ static void dai_dma_cb(void *arg, enum notify_id type, void *data)
 }
 
 static struct comp_dev *dai_new(const struct comp_driver *drv,
-				struct comp_ipc_config *config,
-				void *spec)
+				const struct comp_ipc_config *config,
+				const void *spec)
 {
 	struct comp_dev *dev;
-	struct ipc_config_dai *dai_cfg = spec;
+	const struct ipc_config_dai *dai_cfg = spec;
 	struct dai_data *dd;
 	uint32_t dir;
 

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -123,15 +123,14 @@ static int dai_trigger_op(struct dai *dai, int cmd, int direction)
 
 /* called from src/ipc/ipc3/handler.c and src/ipc/ipc4/dai.c */
 int dai_set_config(struct dai *dai, struct ipc_config_dai *common_config,
-		   void *spec_config)
+		   const void *spec_config)
 {
 	const struct device *dev = dai->dev;
-	struct sof_ipc_dai_config *sof_cfg;
+	const struct sof_ipc_dai_config *sof_cfg = spec_config;
 	struct dai_config cfg;
-	void *cfg_params;
+	const void *cfg_params;
 	bool is_blob;
 
-	sof_cfg = spec_config;
 	cfg.dai_index = common_config->dai_index;
 	is_blob = common_config->is_config_blob;
 	cfg.format = sof_cfg->format;

--- a/src/audio/data_blob.c
+++ b/src/audio/data_blob.c
@@ -114,7 +114,7 @@ bool comp_is_current_data_blob_valid(struct comp_data_blob_handler
 }
 
 int comp_init_data_blob(struct comp_data_blob_handler *blob_handler,
-			uint32_t size, void *init_data)
+			uint32_t size, const void *init_data)
 {
 	int ret;
 
@@ -276,7 +276,7 @@ int ipc4_comp_data_blob_set(struct comp_data_blob_handler *blob_handler,
 			    bool first_block,
 			    bool last_block,
 			    uint32_t data_offset,
-			    char *data)
+			    const char *data)
 {
 	int ret;
 	int valid_data_size;

--- a/src/audio/dcblock/dcblock.c
+++ b/src/audio/dcblock/dcblock.c
@@ -67,12 +67,12 @@ static void dcblock_init_state(struct comp_data *cd)
  * \return Pointer to DC Blocking Filter component device.
  */
 static struct comp_dev *dcblock_new(const struct comp_driver *drv,
-				    struct comp_ipc_config *config,
-				    void *spec)
+				    const struct comp_ipc_config *config,
+				    const void *spec)
 {
 	struct comp_dev *dev;
 	struct comp_data *cd;
-	struct ipc_config_process *ipc_dcblock = spec;
+	const struct ipc_config_process *ipc_dcblock = spec;
 	size_t bs = ipc_dcblock->size;
 	int ret;
 

--- a/src/audio/drc/drc.c
+++ b/src/audio/drc/drc.c
@@ -140,12 +140,12 @@ static int drc_setup(struct drc_comp_data *cd, uint16_t channels, uint32_t rate)
  */
 
 static struct comp_dev *drc_new(const struct comp_driver *drv,
-				struct comp_ipc_config *config,
-				void *spec)
+				const struct comp_ipc_config *config,
+				const void *spec)
 {
 	struct comp_dev *dev = NULL;
 	struct drc_comp_data *cd = NULL;
-	struct ipc_config_process *ipc_drc = spec;
+	const struct ipc_config_process *ipc_drc = spec;
 	size_t bs = ipc_drc->size;
 	int ret;
 

--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -353,7 +353,7 @@ static int eq_fir_init(struct processing_module *mod)
 	/* Allocate and make a copy of the coefficients blob and reset FIR. If
 	 * the EQ is configured later in run-time the size is zero.
 	 */
-	ret = comp_init_data_blob(cd->model_handler, bs, cfg->data);
+	ret = comp_init_data_blob(cd->model_handler, bs, cfg->init_data);
 	if (ret < 0) {
 		comp_err(dev, "eq_fir_init(): comp_init_data_blob() failed.");
 		goto err_init;

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -589,12 +589,12 @@ static int eq_iir_setup(struct comp_data *cd, int nch)
  */
 
 static struct comp_dev *eq_iir_new(const struct comp_driver *drv,
-				   struct comp_ipc_config *config,
-				   void *spec)
+				   const struct comp_ipc_config *config,
+				   const void *spec)
 {
 	struct comp_dev *dev = NULL;
 	struct comp_data *cd = NULL;
-	struct ipc_config_process *ipc_iir = spec;
+	const struct ipc_config_process *ipc_iir = spec;
 	size_t bs = ipc_iir->size;
 	int i;
 	int ret;

--- a/src/audio/google_hotword_detect.c
+++ b/src/audio/google_hotword_detect.c
@@ -88,8 +88,8 @@ static void notify_kpb(const struct comp_dev *dev)
 }
 
 static struct comp_dev *ghd_create(const struct comp_driver *drv,
-				   struct comp_ipc_config *config,
-				   void *spec)
+				   const struct comp_ipc_config *config,
+				   const void *spec)
 {
 	struct comp_dev *dev;
 	struct comp_data *cd;

--- a/src/audio/google_rtc_audio_processing.c
+++ b/src/audio/google_rtc_audio_processing.c
@@ -200,8 +200,8 @@ static int google_rtc_audio_processing_cmd(struct comp_dev *dev, int cmd, void *
 
 static struct comp_dev *google_rtc_audio_processing_create(
 	const struct comp_driver *drv,
-	struct comp_ipc_config *config,
-	void *spec)
+	const struct comp_ipc_config *config,
+	const void *spec)
 {
 	struct comp_dev *dev;
 	struct google_rtc_audio_processing_comp_data *cd;

--- a/src/audio/host-legacy.c
+++ b/src/audio/host-legacy.c
@@ -615,12 +615,12 @@ static int host_trigger(struct comp_dev *dev, int cmd)
 }
 
 static struct comp_dev *host_new(const struct comp_driver *drv,
-				 struct comp_ipc_config *config,
-				 void *spec)
+				 const struct comp_ipc_config *config,
+				 const void *spec)
 {
 	struct comp_dev *dev;
 	struct host_data *hd;
-	struct ipc_config_host *ipc_host = spec;
+	const struct ipc_config_host *ipc_host = spec;
 	uint32_t dir;
 
 	comp_cl_dbg(&comp_host, "host_new()");

--- a/src/audio/host-zephyr.c
+++ b/src/audio/host-zephyr.c
@@ -640,12 +640,12 @@ static int host_trigger(struct comp_dev *dev, int cmd)
 }
 
 static struct comp_dev *host_new(const struct comp_driver *drv,
-				 struct comp_ipc_config *config,
-				 void *spec)
+				 const struct comp_ipc_config *config,
+				 const void *spec)
 {
 	struct comp_dev *dev;
 	struct host_data *hd;
-	struct ipc_config_host *ipc_host = spec;
+	const struct ipc_config_host *ipc_host = spec;
 	uint32_t dir;
 
 	comp_cl_dbg(&comp_host, "host_new()");

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -164,10 +164,10 @@ static void kpb_lock_init(struct comp_data *kpb)
  * \return: a pointer to newly created KPB component.
  */
 static struct comp_dev *kpb_new(const struct comp_driver *drv,
-				struct comp_ipc_config *config,
-				void *spec)
+				const struct comp_ipc_config *config,
+				const void *spec)
 {
-	struct ipc_config_process *ipc_process = spec;
+	const struct ipc_config_process *ipc_process = spec;
 	struct task_ops ops = {
 		.run = kpb_draining_task,
 		.get_deadline = kpb_task_deadline,

--- a/src/audio/mfcc/mfcc.c
+++ b/src/audio/mfcc/mfcc.c
@@ -104,7 +104,7 @@ static int mfcc_init(struct processing_module *mod)
 	}
 
 	/* Get configuration data */
-	ret = comp_init_data_blob(cd->model_handler, bs, cfg->data);
+	ret = comp_init_data_blob(cd->model_handler, bs, cfg->init_data);
 	if (ret < 0) {
 		comp_err(mod->dev, "mfcc_init(): comp_init_data_blob() failed.");
 		goto err_init;

--- a/src/audio/mixer/mixer.c
+++ b/src/audio/mixer/mixer.c
@@ -50,8 +50,8 @@ struct mixer_data {
 };
 
 static struct comp_dev *mixer_new(const struct comp_driver *drv,
-				  struct comp_ipc_config *config,
-				  void *spec)
+				  const struct comp_ipc_config *config,
+				  const void *spec)
 {
 	struct comp_dev *dev;
 	struct mixer_data *md;

--- a/src/audio/mixin_mixout.c
+++ b/src/audio/mixin_mixout.c
@@ -1356,9 +1356,9 @@ static int mixout_get_attribute(struct comp_dev *dev, uint32_t type, void *value
 }
 
 static int mixin_set_large_config(struct comp_dev *dev, uint32_t param_id, bool first_block,
-				  bool last_block, uint32_t data_offset_or_size, char *data)
+				  bool last_block, uint32_t data_offset_or_size, const char *data)
 {
-	struct ipc4_mixer_mode_config *cfg;
+	const struct ipc4_mixer_mode_config *cfg;
 	struct mixin_data *mixin_data;
 	int i;
 	uint32_t sink_index;
@@ -1387,7 +1387,7 @@ static int mixin_set_large_config(struct comp_dev *dev, uint32_t param_id, bool 
 		return -EINVAL;
 	}
 
-	cfg = (struct ipc4_mixer_mode_config *)data;
+	cfg = (const struct ipc4_mixer_mode_config *)data;
 
 	if (cfg->mixer_mode_config_count < 1 || cfg->mixer_mode_config_count > MIXIN_MAX_SINKS) {
 		comp_err(dev, "mixin_set_large_config() invalid mixer_mode_config_count: %u",

--- a/src/audio/mixin_mixout.c
+++ b/src/audio/mixin_mixout.c
@@ -139,8 +139,8 @@ struct mixout_data {
 };
 
 static struct comp_dev *mixin_new(const struct comp_driver *drv,
-				  struct comp_ipc_config *config,
-				  void *spec)
+				  const struct comp_ipc_config *config,
+				  const void *spec)
 {
 	struct comp_dev *dev;
 	struct mixin_data *md;
@@ -182,8 +182,8 @@ static struct comp_dev *mixin_new(const struct comp_driver *drv,
 }
 
 static struct comp_dev *mixout_new(const struct comp_driver *drv,
-				   struct comp_ipc_config *config,
-				   void *spec)
+				   const struct comp_ipc_config *config,
+				   const void *spec)
 {
 	struct comp_dev *dev;
 	struct mixout_data *md;

--- a/src/audio/module_adapter/module/cadence.c
+++ b/src/audio/module_adapter/module/cadence.c
@@ -240,7 +240,8 @@ static int cadence_codec_init(struct processing_module *mod)
 
 		/* copy the setup config */
 		setup_cfg->size = codec->cfg.size;
-		ret = memcpy_s(setup_cfg->data, setup_cfg->size, codec->cfg.data, setup_cfg->size);
+		ret = memcpy_s(setup_cfg->data, setup_cfg->size,
+			       codec->cfg.init_data, setup_cfg->size);
 		if (ret) {
 			comp_err(dev, "cadence_codec_init(): failed to copy setup config %d", ret);
 			goto free;

--- a/src/audio/module_adapter/module/generic.c
+++ b/src/audio/module_adapter/module/generic.c
@@ -20,7 +20,7 @@ LOG_MODULE_DECLARE(module_adapter, CONFIG_SOF_LOG_LEVEL);
 /*****************************************************************************/
 static int validate_config(struct module_config *cfg);
 
-int module_load_config(struct comp_dev *dev, void *cfg, size_t size)
+int module_load_config(struct comp_dev *dev, const void *cfg, size_t size)
 {
 	int ret;
 	struct module_config *dst;

--- a/src/audio/module_adapter/module/iadk_modules.c
+++ b/src/audio/module_adapter/module/iadk_modules.c
@@ -63,8 +63,8 @@ static int iadk_modules_init(struct processing_module *mod)
 
 	mod_cfg.data = md->cfg.data;
 	/* Intel modules expects DW size here */
-	mod_cfg.size = (md->cfg.size >> 2);
-	md->private = md->cfg.data;
+	mod_cfg.size = md->cfg.size >> 2;
+	md->private = mod;
 
 	struct comp_ipc_config *config = &(mod->dev->ipc_config);
 

--- a/src/audio/module_adapter/module/volume/volume.c
+++ b/src/audio/module_adapter/module/volume/volume.c
@@ -540,7 +540,7 @@ static int volume_init(struct processing_module *mod)
 	struct module_data *md = &mod->priv;
 	struct module_config *cfg = &md->cfg;
 	struct comp_dev *dev = mod->dev;
-	struct ipc4_peak_volume_module_cfg *vol = cfg->data;
+	const struct ipc4_peak_volume_module_cfg *vol = cfg->init_data;
 	uint32_t target_volume[SOF_IPC_MAX_CHANNELS];
 	struct vol_data *cd;
 	const size_t vol_size = sizeof(int32_t) * SOF_IPC_MAX_CHANNELS * 4;
@@ -1291,8 +1291,8 @@ static int volume_reset(struct processing_module *mod)
 static const struct comp_driver comp_volume;
 
 static struct comp_dev *volume_new(const struct comp_driver *drv,
-				   struct comp_ipc_config *config,
-				   void *spec)
+				   const struct comp_ipc_config *config,
+				   const void *spec)
 {
 	struct processing_module *mod;
 	struct module_config *dst;
@@ -1499,7 +1499,7 @@ static const struct comp_driver comp_volume = {
 	.uid	= SOF_RT_UUID(volume_uuid),
 	.tctx	= &volume_tr,
 	.ops	= {
-		.create	= volume_new,
+		.create		= volume_new,
 		.free		= volume_legacy_free,
 		.cmd		= volume_cmd,
 		.trigger	= volume_trigger,

--- a/src/audio/module_adapter/module/volume/volume.c
+++ b/src/audio/module_adapter/module/volume/volume.c
@@ -566,9 +566,7 @@ static int volume_init(struct processing_module *mod)
 
 	md->private = cd;
 
-	mailbox_hostbox_read(&cd->base, sizeof(cd->base), 0, sizeof(cd->base));
-
-	channels_count = cd->base.audio_fmt.channels_count;
+	channels_count = mod->priv.cfg.base_cfg.audio_fmt.channels_count;
 
 	for (channel = 0; channel < channels_count ; channel++) {
 		if (vol->config[0].channel_id == IPC4_ALL_CHANNELS_MASK)
@@ -947,7 +945,7 @@ static int volume_set_config(struct processing_module *mod, uint32_t config_id,
 	switch (config_id) {
 	case IPC4_VOLUME:
 		if (cdata->channel_id == IPC4_ALL_CHANNELS_MASK) {
-			for (i = 0; i < cd->base.audio_fmt.channels_count; i++) {
+			for (i = 0; i < mod->priv.cfg.base_cfg.audio_fmt.channels_count; i++) {
 				set_volume_ipc4(cd, i, cdata->target_volume,
 						cdata->curve_type,
 						cdata->curve_duration);
@@ -1012,7 +1010,6 @@ static int volume_get_config(struct processing_module *mod,
 
 static int volume_params(struct processing_module *mod)
 {
-	struct vol_data *cd = module_get_private_data(mod);
 	struct sof_ipc_stream_params *params = mod->stream_params;
 	struct sof_ipc_stream_params vol_params;
 	struct comp_dev *dev = mod->dev;
@@ -1024,19 +1021,19 @@ static int volume_params(struct processing_module *mod)
 	comp_dbg(dev, "volume_params()");
 
 	vol_params = *params;
-	vol_params.channels = cd->base.audio_fmt.channels_count;
-	vol_params.rate = cd->base.audio_fmt.sampling_frequency;
-	vol_params.buffer_fmt = cd->base.audio_fmt.interleaving_style;
+	vol_params.channels = mod->priv.cfg.base_cfg.audio_fmt.channels_count;
+	vol_params.rate = mod->priv.cfg.base_cfg.audio_fmt.sampling_frequency;
+	vol_params.buffer_fmt = mod->priv.cfg.base_cfg.audio_fmt.interleaving_style;
 
-	audio_stream_fmt_conversion(cd->base.audio_fmt.depth,
-				    cd->base.audio_fmt.valid_bit_depth,
+	audio_stream_fmt_conversion(mod->priv.cfg.base_cfg.audio_fmt.depth,
+				    mod->priv.cfg.base_cfg.audio_fmt.valid_bit_depth,
 				    &frame_fmt, &valid_fmt,
-				    cd->base.audio_fmt.s_type);
+				    mod->priv.cfg.base_cfg.audio_fmt.s_type);
 
 	vol_params.frame_fmt = frame_fmt;
 
 	for (i = 0; i < SOF_IPC_MAX_CHANNELS; i++)
-		vol_params.chmap[i] = (cd->base.audio_fmt.ch_map >> i * 4) & 0xf;
+		vol_params.chmap[i] = (mod->priv.cfg.base_cfg.audio_fmt.ch_map >> i * 4) & 0xf;
 
 	component_set_nearest_period_frames(dev, vol_params.rate);
 

--- a/src/audio/module_adapter/module/volume/volume.c
+++ b/src/audio/module_adapter/module/volume/volume.c
@@ -541,6 +541,7 @@ static int volume_init(struct processing_module *mod)
 	struct module_config *cfg = &md->cfg;
 	struct comp_dev *dev = mod->dev;
 	struct ipc4_peak_volume_module_cfg *vol = cfg->data;
+	uint32_t target_volume[SOF_IPC_MAX_CHANNELS];
 	struct vol_data *cd;
 	const size_t vol_size = sizeof(int32_t) * SOF_IPC_MAX_CHANNELS * 4;
 	uint32_t channels_count;
@@ -575,16 +576,16 @@ static int volume_init(struct processing_module *mod)
 		else
 			channel_cfg = channel;
 
-		vol->config[channel].target_volume =
+		target_volume[channel] =
 			convert_volume_ipc4_to_ipc3(dev, vol->config[channel].target_volume);
 
 		set_volume_ipc4(cd, channel,
-				vol->config[channel_cfg].target_volume,
+				target_volume[channel_cfg],
 				vol->config[channel_cfg].curve_type,
 				vol->config[channel_cfg].curve_duration);
 	}
 
-	init_ramp(cd, vol->config[0].curve_duration, vol->config[0].target_volume);
+	init_ramp(cd, vol->config[0].curve_duration, target_volume[0]);
 
 	instance_id = IPC4_INST_ID(dev_comp_id(dev));
 	if (instance_id >= IPC4_MAX_PEAK_VOL_REG_SLOTS) {

--- a/src/audio/module_adapter/module/waves.c
+++ b/src/audio/module_adapter/module/waves.c
@@ -653,7 +653,8 @@ static int waves_codec_init(struct processing_module *mod)
 
 		/* copy the setup config */
 		setup_cfg->size = codec->cfg.size;
-		ret = memcpy_s(setup_cfg->data, setup_cfg->size, codec->cfg.data, setup_cfg->size);
+		ret = memcpy_s(setup_cfg->data, setup_cfg->size,
+			       codec->cfg.init_data, setup_cfg->size);
 		if (ret) {
 			comp_err(dev, "waves_codec_init(): failed to copy setup config %d", ret);
 			module_free_memory(mod, waves_codec);

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -912,7 +912,7 @@ void module_adapter_free(struct comp_dev *dev)
 
 #if CONFIG_IPC_MAJOR_4
 int module_set_large_config(struct comp_dev *dev, uint32_t param_id, bool first_block,
-			    bool last_block, uint32_t data_offset_size, char *data)
+			    bool last_block, uint32_t data_offset_size, const char *data)
 {
 	struct processing_module *mod = comp_get_drvdata(dev);
 	struct module_data *md = &mod->priv;
@@ -992,7 +992,7 @@ int module_adapter_get_attribute(struct comp_dev *dev, uint32_t type, void *valu
 	return -EINVAL;
 }
 int module_set_large_config(struct comp_dev *dev, uint32_t param_id, bool first_block,
-			    bool last_block, uint32_t data_offset, char *data)
+			    bool last_block, uint32_t data_offset, const char *data)
 {
 	return 0;
 }

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -107,6 +107,8 @@ struct comp_dev *module_adapter_new(const struct comp_driver *drv,
 
 		dst->data = ipc_module_adapter->data;
 		dst->size = ipc_module_adapter->size;
+
+		memcpy(&dst->base_cfg, ipc_module_adapter->data, sizeof(dst->base_cfg));
 	} else {
 		dst->data = spec;
 	}
@@ -977,8 +979,8 @@ int module_adapter_get_attribute(struct comp_dev *dev, uint32_t type, void *valu
 
 	switch (type) {
 	case COMP_ATTR_BASE_CONFIG:
-		memcpy_s(value, sizeof(struct ipc4_base_module_cfg), mod->priv.private,
-			 sizeof(struct ipc4_base_module_cfg));
+		memcpy_s(value, sizeof(struct ipc4_base_module_cfg),
+			 &mod->priv.cfg.base_cfg, sizeof(mod->priv.cfg.base_cfg));
 		break;
 	default:
 		return -EINVAL;

--- a/src/audio/multiband_drc/multiband_drc.c
+++ b/src/audio/multiband_drc/multiband_drc.c
@@ -227,12 +227,12 @@ static int multiband_drc_setup(struct multiband_drc_comp_data *cd, int16_t chann
  */
 
 static struct comp_dev *multiband_drc_new(const struct comp_driver *drv,
-					  struct comp_ipc_config *config,
-					  void *spec)
+					  const struct comp_ipc_config *config,
+					  const void *spec)
 {
 	struct comp_dev *dev = NULL;
 	struct multiband_drc_comp_data *cd = NULL;
-	struct ipc_config_process *ipc_multiband_drc = spec;
+	const struct ipc_config_process *ipc_multiband_drc = spec;
 	size_t bs = ipc_multiband_drc->size;
 	int ret;
 

--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -164,10 +164,10 @@ static int mux_set_values(struct comp_dev *dev, struct comp_data *cd,
 
 #if CONFIG_IPC_MAJOR_3
 static struct comp_dev *mux_new(const struct comp_driver *drv,
-				struct comp_ipc_config *config,
-				void *spec)
+				const struct comp_ipc_config *config,
+				const void *spec)
 {
-	struct ipc_config_process *ipc_process = spec;
+	const struct ipc_config_process *ipc_process = spec;
 	size_t bs = ipc_process->size;
 	struct comp_dev *dev;
 	struct comp_data *cd;
@@ -237,10 +237,10 @@ static int build_config(struct comp_data *cd, struct comp_dev *dev)
 }
 
 static struct comp_dev *mux_new(const struct comp_driver *drv,
-				struct comp_ipc_config *config,
-				void *spec)
+				const struct comp_ipc_config *config,
+				const void *spec)
 {
-	struct mux_data *ipc_process = spec;
+	const struct mux_data *ipc_process = spec;
 	struct comp_dev *dev;
 	struct comp_data *cd;
 	int ret;

--- a/src/audio/rtnr/rtnr.c
+++ b/src/audio/rtnr/rtnr.c
@@ -219,10 +219,10 @@ static int32_t rtnr_check_config_validity(struct comp_dev *dev,
 }
 
 static struct comp_dev *rtnr_new(const struct comp_driver *drv,
-								struct comp_ipc_config *config,
-								void *spec)
+				 const struct comp_ipc_config *config,
+				 const void *spec)
 {
-	struct ipc_config_process *ipc_rtnr = spec;
+	const struct ipc_config_process *ipc_rtnr = spec;
 	struct comp_dev *dev;
 	struct comp_data *cd;
 	size_t bs = ipc_rtnr->size;

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -167,10 +167,10 @@ static int selector_verify_params(struct comp_dev *dev,
 }
 
 static struct comp_dev *selector_new(const struct comp_driver *drv,
-				     struct comp_ipc_config *config,
-				     void *spec)
+				     const struct comp_ipc_config *config,
+				     const void *spec)
 {
-	struct ipc_config_process *ipc_process = spec;
+	const struct ipc_config_process *ipc_process = spec;
 	size_t bs = ipc_process->size;
 	struct comp_dev *dev;
 	struct comp_data *cd;

--- a/src/audio/smart_amp/smart_amp.c
+++ b/src/audio/smart_amp/smart_amp.c
@@ -211,11 +211,11 @@ static inline int smart_amp_alloc_caldata(struct comp_dev *dev,
 }
 
 static struct comp_dev *smart_amp_new(const struct comp_driver *drv,
-				      struct comp_ipc_config *config,
-				      void *spec)
+				      const struct comp_ipc_config *config,
+				      const void *spec)
 {
 	struct comp_dev *dev;
-	struct ipc_config_process *ipc_sa = spec;
+	const struct ipc_config_process *ipc_sa = spec;
 	struct smart_amp_data *sad;
 	struct sof_smart_amp_config *cfg;
 	size_t bs;

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -489,9 +489,9 @@ static int src_get_attribute(struct comp_dev *dev, uint32_t type, void *value)
 	return 0;
 }
 
-static int src_rate_check(void *spec)
+static int src_rate_check(const void *spec)
 {
-	struct ipc4_config_src *ipc_src = spec;
+	const struct ipc4_config_src *ipc_src = spec;
 
 	if (ipc_src->base.audio_fmt.sampling_frequency == 0 && ipc_src->sink_rate == 0)
 		return -EINVAL;
@@ -546,9 +546,9 @@ static void src_set_sink_params(struct comp_dev *dev, struct comp_buffer __spars
 }
 
 #elif CONFIG_IPC_MAJOR_3
-static int src_rate_check(void *spec)
+static int src_rate_check(const void *spec)
 {
-	struct ipc_config_src *ipc_src = spec;
+	const struct ipc_config_src *ipc_src = spec;
 
 	if (ipc_src->source_rate == 0 && ipc_src->sink_rate == 0)
 		return -EINVAL;
@@ -573,8 +573,8 @@ static void src_set_sink_params(struct comp_dev *dev, struct comp_buffer __spars
 #endif /* CONFIG_IPC_MAJOR_4 */
 
 static struct comp_dev *src_new(const struct comp_driver *drv,
-				struct comp_ipc_config *config,
-				void *spec)
+				const struct comp_ipc_config *config,
+				const void *spec)
 {
 	struct comp_dev *dev;
 	struct comp_data *cd;

--- a/src/audio/switch.c
+++ b/src/audio/switch.c
@@ -25,8 +25,8 @@ DECLARE_SOF_RT_UUID("switch", switch_uuid, 0x385cc44b, 0xf34e, 0x4b9b,
 DECLARE_TR_CTX(switch_tr, SOF_UUID(switch_uuid), LOG_LEVEL_INFO);
 
 static struct comp_dev *switch_new(const struct comp_driver *drv,
-				   struct comp_ipc_config *config,
-				   void *spec)
+				   const struct comp_ipc_config *config,
+				   const void *spec)
 {
 	comp_cl_info(&comp_switch, "switch_new()");
 

--- a/src/audio/tdfb/tdfb.c
+++ b/src/audio/tdfb/tdfb.c
@@ -409,10 +409,10 @@ static int tdfb_setup(struct tdfb_comp_data *cd, int source_nch, int sink_nch)
  */
 
 static struct comp_dev *tdfb_new(const struct comp_driver *drv,
-				 struct comp_ipc_config *config,
-				 void *spec)
+				 const struct comp_ipc_config *config,
+				 const void *spec)
 {
-	struct ipc_config_process *ipc_tdfb = spec;
+	const struct ipc_config_process *ipc_tdfb = spec;
 	struct comp_dev *dev = NULL;
 	struct tdfb_comp_data *cd = NULL;
 	size_t bs = ipc_tdfb->size;

--- a/src/audio/tone.c
+++ b/src/audio/tone.c
@@ -377,11 +377,11 @@ static int tonegen_init(struct tone_state *sg, int32_t fs, int32_t f, int32_t a)
  */
 
 static struct comp_dev *tone_new(const struct comp_driver *drv,
-				 struct comp_ipc_config *config,
-				 void *spec)
+				 const struct comp_ipc_config *config,
+				 const void *spec)
 {
 	struct comp_dev *dev;
-	struct ipc_config_tone *ipc_tone = spec;
+	const struct ipc_config_tone *ipc_tone = spec;
 	struct comp_data *cd;
 	int i;
 

--- a/src/audio/up_down_mixer/up_down_mixer.c
+++ b/src/audio/up_down_mixer/up_down_mixer.c
@@ -408,8 +408,8 @@ static int init_up_down_mixer(struct comp_dev *dev, struct comp_ipc_config *conf
 }
 
 static struct comp_dev *up_down_mixer_new(const struct comp_driver *drv,
-					  struct comp_ipc_config *config,
-					  void *spec)
+					  const struct comp_ipc_config *config,
+					  const void *spec)
 {
 	struct comp_dev *dev;
 	int ret;

--- a/src/drivers/amd/rembrandt/acp_bt_dai.c
+++ b/src/drivers/amd/rembrandt/acp_bt_dai.c
@@ -25,7 +25,7 @@ DECLARE_SOF_UUID("btdai", btdai_uuid, 0x4abd71ba, 0x8619, 0x458a,
 DECLARE_TR_CTX(btdai_tr, SOF_UUID(btdai_uuid), LOG_LEVEL_INFO);
 
 static inline int btdai_set_config(struct dai *dai, struct ipc_config_dai *common_config,
-				   void *spec_config)
+				   const void *spec_config)
 {
 	/* nothing to do on rembrandt */
 	return 0;

--- a/src/drivers/amd/rembrandt/acp_dmic_dai.c
+++ b/src/drivers/amd/rembrandt/acp_dmic_dai.c
@@ -25,10 +25,10 @@ DECLARE_SOF_UUID("acp_dmic_dai", acp_dmic_dai_uuid, 0x0ae40946, 0xdfd2, 0x4140,
 DECLARE_TR_CTX(acp_dmic_dai_tr, SOF_UUID(acp_dmic_dai_uuid), LOG_LEVEL_INFO);
 
 static inline int acp_dmic_dai_set_config(struct dai *dai, struct ipc_config_dai *common_config,
-					  void *spec_config)
+					  const void *spec_config)
 {
 	acp_wov_pdm_no_of_channels_t pdm_channels;
-	struct sof_ipc_dai_config *config = spec_config;
+	const struct sof_ipc_dai_config *config = spec_config;
 	struct acp_pdata *acpdata = dai_get_drvdata(dai);
 	acp_wov_clk_ctrl_t clk_ctrl;
 

--- a/src/drivers/amd/rembrandt/acp_hs_dai.c
+++ b/src/drivers/amd/rembrandt/acp_hs_dai.c
@@ -24,7 +24,7 @@ DECLARE_SOF_UUID("hsdai", hsdai_uuid, 0x8f00c3bb, 0xe835, 0x4767,
 DECLARE_TR_CTX(hsdai_tr, SOF_UUID(hsdai_uuid), LOG_LEVEL_INFO);
 
 static inline int hsdai_set_config(struct dai *dai, struct ipc_config_dai *common_config,
-				   void *spec_config)
+				   const void *spec_config)
 {
 	/* set master clk for hs dai */
 	io_reg_write(PU_REGISTER_BASE + ACP_I2STDM2_MSTRCLKGEN, 0x40081);

--- a/src/drivers/amd/rembrandt/acp_sp_dai.c
+++ b/src/drivers/amd/rembrandt/acp_sp_dai.c
@@ -24,7 +24,7 @@ DECLARE_SOF_UUID("spdai", spdai_uuid, 0x4abd71ba, 0x8619, 0x458a,
 DECLARE_TR_CTX(spdai_tr, SOF_UUID(spdai_uuid), LOG_LEVEL_INFO);
 
 static inline int spdai_set_config(struct dai *dai, struct ipc_config_dai *common_config,
-				   void *spec_config)
+				   const void *spec_config)
 {
 	/* nothing to do on rembrandt for SP dai */
 	return 0;

--- a/src/drivers/amd/renoir/acp_bt_dai.c
+++ b/src/drivers/amd/renoir/acp_bt_dai.c
@@ -26,7 +26,7 @@ DECLARE_SOF_UUID("btdai", btdai_uuid, 0x4abd71ba, 0x8619, 0x458a,
 DECLARE_TR_CTX(btdai_tr, SOF_UUID(btdai_uuid), LOG_LEVEL_INFO);
 
 static inline int btdai_set_config(struct dai *dai, struct ipc_config_dai *common_config,
-				   void *spec_config)
+				   const void *spec_config)
 {
 	/* nothing to do on renoir */
 	return 0;

--- a/src/drivers/amd/renoir/acp_dmic_dai.c
+++ b/src/drivers/amd/renoir/acp_dmic_dai.c
@@ -26,11 +26,11 @@ DECLARE_SOF_UUID("acp_dmic_dai", acp_dmic_dai_uuid, 0x0ae40946, 0xdfd2, 0x4140,
 DECLARE_TR_CTX(acp_dmic_dai_tr, SOF_UUID(acp_dmic_dai_uuid), LOG_LEVEL_INFO);
 
 static inline int acp_dmic_dai_set_config(struct dai *dai, struct ipc_config_dai *common_config,
-					  void *spec_config)
+					  const void *spec_config)
 {
 	dai_info(dai, "ACP: acp_dmic_set_config");
 	acp_wov_pdm_no_of_channels_t pdm_channels;
-	struct sof_ipc_dai_config *config = spec_config;
+	const struct sof_ipc_dai_config *config = spec_config;
 	struct acp_pdata *acpdata = dai_get_drvdata(dai);
 	acp_wov_clk_ctrl_t clk_ctrl;
 

--- a/src/drivers/amd/renoir/acp_sp_dai.c
+++ b/src/drivers/amd/renoir/acp_sp_dai.c
@@ -25,7 +25,7 @@ DECLARE_SOF_UUID("spdai", spdai_uuid, 0x4abd71ba, 0x8619, 0x458a,
 DECLARE_TR_CTX(spdai_tr, SOF_UUID(spdai_uuid), LOG_LEVEL_INFO);
 
 static inline int spdai_set_config(struct dai *dai, struct ipc_config_dai *common_config,
-				   void *spec_config)
+				   const void *spec_config)
 {
 	/* nothing to do on renoir for SP dai */
 	return 0;

--- a/src/drivers/imx/esai.c
+++ b/src/drivers/imx/esai.c
@@ -47,9 +47,9 @@ struct esai_pdata {
 };
 
 static inline int esai_set_config(struct dai *dai, struct ipc_config_dai *common_config,
-				  void *spec_config)
+				  const void *spec_config)
 {
-	struct sof_ipc_dai_config *config = spec_config;
+	const struct sof_ipc_dai_config *config = spec_config;
 	uint32_t xcr = 0, xccr = 0, mask;
 	struct esai_pdata *esai = dai_get_drvdata(dai);
 

--- a/src/drivers/imx/sai.c
+++ b/src/drivers/imx/sai.c
@@ -198,10 +198,10 @@ static void sai_stop(struct dai *dai, int direction)
 }
 
 static inline int sai_set_config(struct dai *dai, struct ipc_config_dai *common_config,
-				 void *spec_config)
+				 const void *spec_config)
 {
 	dai_info(dai, "SAI: sai_set_config");
-	struct sof_ipc_dai_config *config = spec_config;
+	const struct sof_ipc_dai_config *config = spec_config;
 	uint32_t val_cr2 = 0, val_cr4 = 0, val_cr5 = 0;
 	uint32_t mask_cr2 = 0, mask_cr4 = 0, mask_cr5 = 0;
 	struct sai_pdata *sai = dai_get_drvdata(dai);

--- a/src/drivers/intel/alh.c
+++ b/src/drivers/intel/alh.c
@@ -34,10 +34,10 @@ static int alh_trigger(struct dai *dai, int cmd, int direction)
 }
 
 static int alh_set_config_tplg(struct dai *dai, struct ipc_config_dai *common_config,
-			       void *spec_config)
+			       const void *spec_config)
 {
 	struct alh_pdata *alh = dai_get_drvdata(dai);
-	struct sof_ipc_dai_config *config = spec_config;
+	const struct sof_ipc_dai_config *config = spec_config;
 
 	dai_info(dai, "alh_set_config_tplg() config->format = 0x%4x", config->format);
 
@@ -54,11 +54,11 @@ static int alh_set_config_tplg(struct dai *dai, struct ipc_config_dai *common_co
 }
 
 static int alh_set_config_blob(struct dai *dai, struct ipc_config_dai *common_config,
-			       void *spec_config)
+			       const void *spec_config)
 {
 	struct alh_pdata *alh = dai_get_drvdata(dai);
-	struct sof_alh_configuration_blob *blob = spec_config;
-	struct ipc4_alh_multi_gtw_cfg *alh_cfg = &blob->alh_cfg;
+	const struct sof_alh_configuration_blob *blob = spec_config;
+	const struct ipc4_alh_multi_gtw_cfg *alh_cfg = &blob->alh_cfg;
 	int i;
 
 	dai_info(dai, "alh_set_config_blob()");
@@ -80,7 +80,7 @@ static int alh_set_config_blob(struct dai *dai, struct ipc_config_dai *common_co
 }
 
 static int alh_set_config(struct dai *dai, struct ipc_config_dai *common_config,
-			  void *spec_config)
+			  const void *spec_config)
 {
 	if (!common_config->is_config_blob)
 		return alh_set_config_tplg(dai, common_config, spec_config);

--- a/src/drivers/intel/baytrail/ssp.c
+++ b/src/drivers/intel/baytrail/ssp.c
@@ -45,9 +45,9 @@ static void ssp_empty_rx_fifo(struct dai *dai)
 
 /* Digital Audio interface formatting */
 static int ssp_set_config(struct dai *dai, struct ipc_config_dai *common_config,
-			  void *spec_config)
+			  const void *spec_config)
 {
-	struct sof_ipc_dai_config *config = spec_config;
+	const struct sof_ipc_dai_config *config = spec_config;
 	struct ssp_pdata *ssp = dai_get_drvdata(dai);
 	uint32_t sscr0;
 	uint32_t sscr1;

--- a/src/drivers/intel/dmic/dmic.c
+++ b/src/drivers/intel/dmic/dmic.c
@@ -154,14 +154,15 @@ static int dmic_get_hw_params(struct dai *dai,
 #endif
 }
 
-static int dmic_set_config(struct dai *dai, struct ipc_config_dai *common_config, void *spec_config)
+static int dmic_set_config(struct dai *dai, struct ipc_config_dai *common_config,
+			   const void *spec_config)
 {
 	struct dmic_pdata *dmic = dai_get_drvdata(dai);
 	int ret = 0;
 	int di = dai->index;
 	k_spinlock_key_t key;
 #if CONFIG_INTEL_DMIC_TPLG_PARAMS
-	struct sof_ipc_dai_config *config = spec_config;
+	const struct sof_ipc_dai_config *config = spec_config;
 	int i;
 	int j;
 #endif

--- a/src/drivers/intel/dmic/dmic_nhlt.c
+++ b/src/drivers/intel/dmic/dmic_nhlt.c
@@ -192,7 +192,7 @@ static int nhlt_dmic_dai_params_get(struct dai *dai, uint32_t *outcontrol,
 }
 #endif
 
-int dmic_set_config_nhlt(struct dai *dai, void *spec_config)
+int dmic_set_config_nhlt(struct dai *dai, const void *spec_config)
 {
 	struct dmic_pdata *dmic = dai_get_drvdata(dai);
 	struct nhlt_pdm_ctrl_cfg *pdm_cfg[DMIC_HW_CONTROLLERS_MAX];

--- a/src/drivers/intel/haswell/ssp.c
+++ b/src/drivers/intel/haswell/ssp.c
@@ -24,9 +24,9 @@
 
 /* Digital Audio interface formatting */
 static int ssp_set_config(struct dai *dai, struct ipc_config_dai *common_config,
-			  void *spec_config)
+			  const void *spec_config)
 {
-	struct sof_ipc_dai_config *config = spec_config;
+	const struct sof_ipc_dai_config *config = spec_config;
 	struct ssp_pdata *ssp = dai_get_drvdata(dai);
 	uint32_t sscr0;
 	uint32_t sscr1;

--- a/src/drivers/intel/hda/hda.c
+++ b/src/drivers/intel/hda/hda.c
@@ -28,11 +28,11 @@ static int hda_trigger(struct dai *dai, int cmd, int direction)
 }
 
 static int hda_set_config(struct dai *dai,  struct ipc_config_dai *common_config,
-			  void *spec_config)
+			  const void *spec_config)
 {
 	struct hda_pdata *hda = dai_get_drvdata(dai);
-	struct sof_ipc_dai_config *dai_config = spec_config;
-	struct sof_ipc_dai_hda_params *params = &dai_config->hda;
+	const struct sof_ipc_dai_config *dai_config = spec_config;
+	const struct sof_ipc_dai_hda_params *params = &dai_config->hda;
 
 	/* no params in blob which only includes lp mode setting */
 	if (common_config->is_config_blob)

--- a/src/drivers/intel/ssp/ssp.c
+++ b/src/drivers/intel/ssp/ssp.c
@@ -209,10 +209,10 @@ static void ssp_bclk_disable_unprepare(struct dai *dai)
 
 /* Digital Audio interface formatting */
 static int ssp_set_config_tplg(struct dai *dai, struct ipc_config_dai *common_config,
-			       void *spec_config)
+			       const void *spec_config)
 {
 	struct ssp_pdata *ssp = dai_get_drvdata(dai);
-	struct sof_ipc_dai_config *config = spec_config;
+	const struct sof_ipc_dai_config *config = spec_config;
 	uint32_t sscr0;
 	uint32_t sscr1;
 	uint32_t sscr2;
@@ -794,9 +794,9 @@ out:
 }
 
 static int ssp_set_config_blob(struct dai *dai, struct ipc_config_dai *common_config,
-			       void *spec_config)
+			       const void *spec_config)
 {
-	struct ipc4_ssp_configuration_blob *blob = spec_config;
+	const struct ipc4_ssp_configuration_blob *blob = spec_config;
 	struct ssp_pdata *ssp = dai_get_drvdata(dai);
 	uint32_t ssc0, sstsa, ssrsa;
 
@@ -860,7 +860,7 @@ static int ssp_set_config_blob(struct dai *dai, struct ipc_config_dai *common_co
 }
 
 static int ssp_set_config(struct dai *dai, struct ipc_config_dai *common_config,
-			  void *spec_config)
+			  const void *spec_config)
 {
 	if (!common_config->is_config_blob)
 		return ssp_set_config_tplg(dai, common_config, spec_config);

--- a/src/drivers/mediatek/mt8186/afe-dai.c
+++ b/src/drivers/mediatek/mt8186/afe-dai.c
@@ -33,9 +33,9 @@ static int afe_dai_drv_trigger(struct dai *dai, int cmd, int direction)
 }
 
 static int afe_dai_drv_set_config(struct dai *dai, struct ipc_config_dai *common_config,
-				  void *spec_config)
+				  const void *spec_config)
 {
-	struct sof_ipc_dai_config *config = spec_config;
+	const struct sof_ipc_dai_config *config = spec_config;
 	struct mtk_base_afe *afe = dai_get_drvdata(dai);
 
 	return afe_dai_set_config(afe,

--- a/src/drivers/mediatek/mt8195/afe-dai.c
+++ b/src/drivers/mediatek/mt8195/afe-dai.c
@@ -33,9 +33,9 @@ static int afe_dai_drv_trigger(struct dai *dai, int cmd, int direction)
 }
 
 static int afe_dai_drv_set_config(struct dai *dai, struct ipc_config_dai *common_config,
-				  void *spec_config)
+				  const void *spec_config)
 {
-	struct sof_ipc_dai_config *config = spec_config;
+	const struct sof_ipc_dai_config *config = spec_config;
 	struct mtk_base_afe *afe = dai_get_drvdata(dai);
 
 	afe_dai_set_config(afe,

--- a/src/include/ipc4/logging.h
+++ b/src/include/ipc4/logging.h
@@ -11,7 +11,7 @@
 int ipc4_logging_enable_logs(bool first_block,
 			     bool last_block,
 			     uint32_t data_offset_or_size,
-			     char *data);
+			     const char *data);
 
 int ipc4_logging_shutdown(void);
 

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -304,8 +304,8 @@ struct comp_ops {
 	 * All parameters should be initialized to their default values.
 	 */
 	struct comp_dev *(*create)(const struct comp_driver *drv,
-				   struct comp_ipc_config *ipc_config,
-				   void *ipc_specific_config);
+				   const struct comp_ipc_config *ipc_config,
+				   const void *ipc_specific_config);
 
 	/**
 	 * Called to delete the specified component device.

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -348,7 +348,7 @@ struct comp_ops {
 	 * Mandatory for components that allocate DAI.
 	 */
 	int (*dai_config)(struct comp_dev *dev, struct ipc_config_dai *dai_config,
-			  void *dai_spec_config);
+			  const void *dai_spec_config);
 
 	/**
 	 * Used to pass standard and bespoke commands (with optional data).

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -506,7 +506,7 @@ struct comp_ops {
 				bool first_block,
 				bool last_block,
 				uint32_t data_offset,
-				char *data);
+				const char *data);
 
 	/**
 	 * Returns total data processed in number bytes.

--- a/src/include/sof/audio/component_ext.h
+++ b/src/include/sof/audio/component_ext.h
@@ -219,7 +219,7 @@ static inline int comp_reset(struct comp_dev *dev)
 
 /** See comp_ops::dai_config */
 static inline int comp_dai_config(struct comp_dev *dev, struct ipc_config_dai *config,
-				  void *spec_config)
+				  const void *spec_config)
 {
 	if (dev->drv->ops.dai_config)
 		return dev->drv->ops.dai_config(dev, config, spec_config);

--- a/src/include/sof/audio/data_blob.h
+++ b/src/include/sof/audio/data_blob.h
@@ -53,7 +53,7 @@ bool comp_is_current_data_blob_valid(struct comp_data_blob_handler
  * @param init_data Initial data blob values
  */
 int comp_init_data_blob(struct comp_data_blob_handler *blob_handler,
-			uint32_t size, void *init_data);
+			uint32_t size, const void *init_data);
 
 /**
  * Handles IPC set command.
@@ -88,7 +88,7 @@ int comp_data_blob_set(struct comp_data_blob_handler *blob_handler,
  */
 int ipc4_comp_data_blob_set(struct comp_data_blob_handler *blob_handler,
 			    bool first_block, bool last_block,
-			    uint32_t data_offset, char *data);
+			    uint32_t data_offset, const char *data);
 /**
  * Handles IPC get command.
  * @param blob_handler Data blob handler

--- a/src/include/sof/audio/ipc-config.h
+++ b/src/include/sof/audio/ipc-config.h
@@ -91,7 +91,7 @@ struct ipc_config_process {
 	uint32_t size;	/**< size of bespoke data section in bytes */
 	uint32_t type;	/**< sof_ipc_process_type */
 
-	unsigned char *data;
+	const unsigned char *data;
 };
 
 /* file IO ipc comp */

--- a/src/include/sof/audio/module_adapter/module/generic.h
+++ b/src/include/sof/audio/module_adapter/module/generic.h
@@ -204,7 +204,7 @@ int module_adapter_trigger(struct comp_dev *dev, int cmd);
 void module_adapter_free(struct comp_dev *dev);
 int module_adapter_reset(struct comp_dev *dev);
 int module_set_large_config(struct comp_dev *dev, uint32_t param_id, bool first_block,
-			    bool last_block, uint32_t data_offset, char *data);
+			    bool last_block, uint32_t data_offset, const char *data);
 int module_get_large_config(struct comp_dev *dev, uint32_t param_id, bool first_block,
 			    bool last_block, uint32_t *data_offset, char *data);
 int module_adapter_get_attribute(struct comp_dev *dev, uint32_t type, void *value);

--- a/src/include/sof/audio/module_adapter/module/generic.h
+++ b/src/include/sof/audio/module_adapter/module/generic.h
@@ -34,8 +34,8 @@
 
 #define DECLARE_MODULE_ADAPTER(adapter, uuid, tr) \
 static struct comp_dev *module_##adapter##_shim_new(const struct comp_driver *drv, \
-					 struct comp_ipc_config *config, \
-					 void *spec) \
+					 const struct comp_ipc_config *config, \
+					 const void *spec) \
 { \
 	return module_adapter_new(drv, config, &(adapter), spec);\
 } \
@@ -108,6 +108,7 @@ struct module_config {
 	size_t size; /**< Specifies the size of whole config */
 	bool avail; /**< Marks config as available to use.*/
 	void *data; /**< tlv config, a pointer to memory where config is stored. */
+	const void *init_data; /**< Initial IPC configuration. */
 #if CONFIG_IPC_MAJOR_4
 	struct ipc4_base_module_cfg base_cfg;
 #endif
@@ -179,7 +180,7 @@ struct processing_module {
 /*****************************************************************************/
 /* Module generic interfaces						     */
 /*****************************************************************************/
-int module_load_config(struct comp_dev *dev, void *cfg, size_t size);
+int module_load_config(struct comp_dev *dev, const void *cfg, size_t size);
 int module_init(struct processing_module *mod, struct module_interface *interface);
 void *module_allocate_memory(struct processing_module *mod, uint32_t size, uint32_t alignment);
 int module_free_memory(struct processing_module *mod, void *ptr);
@@ -197,8 +198,8 @@ int module_set_configuration(struct processing_module *mod,
 			     size_t response_size);
 
 struct comp_dev *module_adapter_new(const struct comp_driver *drv,
-				    struct comp_ipc_config *config,
-				    struct module_interface *interface, void *spec);
+				    const struct comp_ipc_config *config,
+				    struct module_interface *interface, const void *spec);
 int module_adapter_prepare(struct comp_dev *dev);
 int module_adapter_params(struct comp_dev *dev, struct sof_ipc_stream_params *params);
 int module_adapter_copy(struct comp_dev *dev);

--- a/src/include/sof/audio/module_adapter/module/generic.h
+++ b/src/include/sof/audio/module_adapter/module/generic.h
@@ -108,6 +108,9 @@ struct module_config {
 	size_t size; /**< Specifies the size of whole config */
 	bool avail; /**< Marks config as available to use.*/
 	void *data; /**< tlv config, a pointer to memory where config is stored. */
+#if CONFIG_IPC_MAJOR_4
+	struct ipc4_base_module_cfg base_cfg;
+#endif
 };
 
 /**

--- a/src/include/sof/audio/module_adapter/module/iadk_modules.h
+++ b/src/include/sof/audio/module_adapter/module/iadk_modules.h
@@ -36,8 +36,8 @@
 
 
 struct comp_dev *iadk_modules_shim_new(const struct comp_driver *drv,
-				       struct comp_ipc_config *config,
-				       void *spec);
+				       const struct comp_ipc_config *config,
+				       const void *spec);
 
 #define DECLARE_DYNAMIC_MODULE_ADAPTER(comp_dynamic_module, mtype, uuid, tr) \
 do { \

--- a/src/include/sof/audio/selector.h
+++ b/src/include/sof/audio/selector.h
@@ -49,11 +49,6 @@ struct comp_dev;
 typedef void (*sel_func)(struct processing_module *mod, struct input_stream_buffer *bsource,
 		       struct output_stream_buffer *bsink, uint32_t frames);
 
-struct micsel_data {
-	struct ipc4_base_module_cfg base_cfg;
-	struct ipc4_audio_format output_format;
-};
-
 /** \brief IPC4 configuration IDs for selector. */
 enum ipc4_selector_config_id {
 	IPC4_SELECTOR_COEFFS_CONFIG_ID = 0,	/**< Mixing coefficients config ID */
@@ -75,7 +70,7 @@ typedef void (*sel_func)(struct comp_dev *dev, struct audio_stream __sparse_cach
 /** \brief Selector component private data. */
 struct comp_data {
 #if CONFIG_IPC_MAJOR_4
-	struct micsel_data md;
+	struct ipc4_audio_format output_format;
 	struct ipc4_selector_coeffs_config coeffs_config;
 #endif
 

--- a/src/include/sof/audio/volume.h
+++ b/src/include/sof/audio/volume.h
@@ -129,7 +129,6 @@ typedef int32_t (*vol_ramp_func)(struct processing_module *mod, int32_t ramp_tim
 
 struct vol_data {
 #if CONFIG_IPC_MAJOR_4
-	struct ipc4_base_module_cfg base;	/**< module config */
 	uint32_t mailbox_offset;		/**< store peak volume in mailbox */
 
 	/**< these values will be stored to mailbox for host (IPC4) */
@@ -209,16 +208,15 @@ static inline vol_scale_func vol_get_processing_function(struct comp_dev *dev,
 							 struct comp_buffer __sparse_cache *sinkb)
 {
 	struct processing_module *mod = comp_get_drvdata(dev);
-	struct vol_data *cd = module_get_private_data(mod);
 
-	switch (cd->base.audio_fmt.depth) {
+	switch (mod->priv.cfg.base_cfg.audio_fmt.depth) {
 	case IPC4_DEPTH_16BIT:
 		return volume_func_map[0].func;
 	case IPC4_DEPTH_32BIT:
 		return volume_func_map[2].func;
 	default:
 		comp_err(dev, "vol_get_processing_function(): unsupported depth %d",
-			 cd->base.audio_fmt.depth);
+			 mod->priv.cfg.base_cfg.audio_fmt.depth);
 		return NULL;
 	}
 }

--- a/src/include/sof/drivers/dmic.h
+++ b/src/include/sof/drivers/dmic.h
@@ -556,7 +556,7 @@ struct nhlt_pdm_fir_coeffs {
 
 int dmic_set_config_computed(struct dai *dai);
 int dmic_get_hw_params_computed(struct dai *dai, struct sof_ipc_stream_params *params, int dir);
-int dmic_set_config_nhlt(struct dai *dai, void *spec_config);
+int dmic_set_config_nhlt(struct dai *dai, const void *spec_config);
 int dmic_get_hw_params_nhlt(struct dai *dai, struct sof_ipc_stream_params *params, int dir);
 
 extern const struct dai_driver dmic_driver;

--- a/src/include/sof/lib/dai-legacy.h
+++ b/src/include/sof/lib/dai-legacy.h
@@ -80,7 +80,7 @@ struct sof_ipc_stream_params;
  */
 struct dai_ops {
 	int (*set_config)(struct dai *dai, struct ipc_config_dai *config,
-			  void *spec_config);
+			  const void *spec_config);
 	int (*trigger)(struct dai *dai, int cmd, int direction);
 	int (*get_hw_params)(struct dai *dai,
 			     struct sof_ipc_stream_params *params, int dir);
@@ -395,7 +395,7 @@ void dai_put(struct dai *dai);
  * \brief Digital Audio interface formatting
  */
 static inline int dai_set_config(struct dai *dai, struct ipc_config_dai *config,
-				 void *spec_config)
+				 const void *spec_config)
 {
 	return dai->drv->ops.set_config(dai, config, spec_config);
 }
@@ -532,7 +532,7 @@ static inline const struct dai_info *dai_info_get(void)
 /**
  * \brief Configure DMA channel for DAI
  */
-int dai_config_dma_channel(struct comp_dev *dev, void *config);
+int dai_config_dma_channel(struct comp_dev *dev, const void *config);
 
 /**
  * \brief Reset DAI DMA config
@@ -543,7 +543,7 @@ void dai_dma_release(struct comp_dev *dev);
  * \brief Configure DAI physical interface.
  */
 int dai_config(struct comp_dev *dev,  struct ipc_config_dai *common_config,
-	       void *spec_config);
+	       const void *spec_config);
 
 /**
  * \brief Assign DAI to a group for simultaneous triggering.

--- a/src/include/sof/lib/dai-zephyr.h
+++ b/src/include/sof/lib/dai-zephyr.h
@@ -216,7 +216,7 @@ void dai_put(struct dai *dai);
 /**
  * \brief Digital Audio interface formatting
  */
-int dai_set_config(struct dai *dai, struct ipc_config_dai *config, void *spec_config);
+int dai_set_config(struct dai *dai, struct ipc_config_dai *config, const void *spec_config);
 
 /**
  * \brief Get Digital Audio interface DMA Handshake
@@ -241,7 +241,7 @@ int dai_get_stream_id(struct dai *dai, int direction);
 /**
  * \brief Configure DMA channel for DAI
  */
-int dai_config_dma_channel(struct comp_dev *dev, void *config);
+int dai_config_dma_channel(struct comp_dev *dev, const void *config);
 
 /**
  * \brief Reset DAI DMA config
@@ -251,7 +251,7 @@ void dai_dma_release(struct comp_dev *dev);
 /**
  * \brief Configure DAI physical interface.
  */
-int dai_config(struct comp_dev *dev,  struct ipc_config_dai *common_cfg, void *spec_cfg);
+int dai_config(struct comp_dev *dev,  struct ipc_config_dai *common_cfg, const void *spec_cfg);
 
 /**
  * \brief Assign DAI to a group for simultaneous triggering.

--- a/src/include/sof/lib_manager.h
+++ b/src/include/sof/lib_manager.h
@@ -132,7 +132,7 @@ struct sof_man_fw_desc *lib_manager_get_library_module_desc(int module_id);
  */
 uint32_t lib_manager_allocate_module(const struct comp_driver *drv,
 				     struct comp_ipc_config *ipc_config,
-				     void *ipc_specific_config);
+				     const void *ipc_specific_config);
 
 /*
  * \brief Free module

--- a/src/include/sof/probe/probe.h
+++ b/src/include/sof/probe/probe.h
@@ -48,7 +48,7 @@ int probe_deinit(void);
  * param[in] count - number of DMAs configured during this call
  * param[in] probe_dma - Array of size 'count' with configuration data for DMAs
  */
-int probe_dma_add(uint32_t count, struct probe_dma *probe_dma);
+int probe_dma_add(uint32_t count, const struct probe_dma *probe_dma);
 
 /*
  * \brief Get info about connected injection DMAs
@@ -65,7 +65,7 @@ int probe_dma_info(struct sof_ipc_probe_info_params *data, uint32_t max_size);
  * param[in] stream_tag - array for size 'count' with stream tags associated
  *			  with DMAs to be removed
  */
-int probe_dma_remove(uint32_t count, uint32_t *stream_tag);
+int probe_dma_remove(uint32_t count, const uint32_t *stream_tag);
 
 /*
  * \brief Set probe points
@@ -73,7 +73,7 @@ int probe_dma_remove(uint32_t count, uint32_t *stream_tag);
  * param[in] count - number of probe points configured this call
  * param[in] probe - array of size 'count' with configuration of probe points
  */
-int probe_point_add(uint32_t count, struct probe_point *probe);
+int probe_point_add(uint32_t count, const struct probe_point *probe);
 
 /*
  * \brief Get info about connected probe points
@@ -90,7 +90,7 @@ int probe_point_info(struct sof_ipc_probe_info_params *data, uint32_t max_size);
  * param[in] buffer_id - array of size 'count' with IDs of buffers to which
  *			 probes were attached
  */
-int probe_point_remove(uint32_t count, uint32_t *buffer_id);
+int probe_point_remove(uint32_t count, const uint32_t *buffer_id);
 
 /**
  * \brief Retrieves probes structure.

--- a/src/include/sof/probe/probe.h
+++ b/src/include/sof/probe/probe.h
@@ -32,7 +32,7 @@ void probe_logging_init(probe_logging_hook_t hook);
  *		      In case extraction_probe_dma is NULL, extraction probes
  *		      are unavailable.
  */
-int probe_init(struct probe_dma *extraction_probe_dma);
+int probe_init(const struct probe_dma *extraction_probe_dma);
 
 /*
  * \brief Deinitialize probes subsystem.

--- a/src/ipc/ipc3/dai.c
+++ b/src/ipc/ipc3/dai.c
@@ -29,10 +29,10 @@
 
 LOG_MODULE_DECLARE(ipc, CONFIG_SOF_LOG_LEVEL);
 
-int dai_config_dma_channel(struct comp_dev *dev, void *spec_config)
+int dai_config_dma_channel(struct comp_dev *dev, const void *spec_config)
 {
 	struct dai_data *dd = comp_get_drvdata(dev);
-	struct sof_ipc_dai_config *config = spec_config;
+	const struct sof_ipc_dai_config *config = spec_config;
 	struct ipc_config_dai *dai = &dd->ipc_config;
 	int channel;
 	int handshake;
@@ -284,9 +284,9 @@ void dai_dma_release(struct comp_dev *dev)
 }
 
 int dai_config(struct comp_dev *dev, struct ipc_config_dai *common_config,
-	       void *spec_config)
+	       const void *spec_config)
 {
-	struct sof_ipc_dai_config *config = spec_config;
+	const struct sof_ipc_dai_config *config = spec_config;
 	struct dai_data *dd = comp_get_drvdata(dev);
 	int ret;
 

--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -30,9 +30,9 @@
 
 LOG_MODULE_DECLARE(ipc, CONFIG_SOF_LOG_LEVEL);
 
-int dai_config_dma_channel(struct comp_dev *dev, void *spec_config)
+int dai_config_dma_channel(struct comp_dev *dev, const void *spec_config)
 {
-	struct ipc4_copier_module_cfg *copier_cfg = spec_config;
+	const struct ipc4_copier_module_cfg *copier_cfg = spec_config;
 	struct dai_data *dd = comp_get_drvdata(dev);
 	struct ipc_config_dai *dai = &dd->ipc_config;
 	int channel;
@@ -256,9 +256,9 @@ static void dai_dma_position_init(struct comp_dev *dev)
 }
 
 int dai_config(struct comp_dev *dev, struct ipc_config_dai *common_config,
-	       void *spec_config)
+	       const void *spec_config)
 {
-	struct ipc4_copier_module_cfg *copier_cfg = spec_config;
+	const struct ipc4_copier_module_cfg *copier_cfg = spec_config;
 	struct dai_data *dd = comp_get_drvdata(dev);
 	int size;
 	int ret;

--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -410,7 +410,7 @@ static int ipc_wait_for_compound_msg(void)
  * after pipeline is complete. In ipc4 path, direction is figured out and
  * set it to each component after connected pipeline are complete.
  */
-static int update_dir_to_pipeline_component(uint32_t *ppl_id, uint32_t count)
+static int update_dir_to_pipeline_component(const uint32_t *ppl_id, uint32_t count)
 {
 	struct ipc_comp_dev *icd;
 	struct ipc_comp_dev *pipe;
@@ -471,11 +471,11 @@ static int update_dir_to_pipeline_component(uint32_t *ppl_id, uint32_t count)
 
 static int ipc4_set_pipeline_state(struct ipc4_message_request *ipc4)
 {
-	struct ipc4_pipeline_set_state_data *ppl_data;
+	const struct ipc4_pipeline_set_state_data *ppl_data;
 	struct ipc4_pipeline_set_state state;
 	uint32_t status = COMP_STATE_INIT;
-	uint32_t cmd, ppl_count;
-	uint32_t *ppl_id, id;
+	uint32_t cmd, ppl_count, id;
+	const uint32_t *ppl_id;
 	int ret = 0;
 	int i;
 
@@ -483,8 +483,9 @@ static int ipc4_set_pipeline_state(struct ipc4_message_request *ipc4)
 	state.extension.dat = ipc4->extension.dat;
 	cmd = state.primary.r.ppl_state;
 
-	ppl_data = (struct ipc4_pipeline_set_state_data *)MAILBOX_HOSTBOX_BASE;
-	dcache_invalidate_region((__sparse_force void __sparse_cache *)ppl_data, sizeof(*ppl_data));
+	ppl_data = (const struct ipc4_pipeline_set_state_data *)MAILBOX_HOSTBOX_BASE;
+	dcache_invalidate_region((__sparse_force void __sparse_cache *)ppl_data,
+				 sizeof(*ppl_data));
 	if (state.extension.r.multi_ppl) {
 		ppl_count = ppl_data->pipelines_count;
 		ppl_id = ppl_data->ppl_id;
@@ -767,7 +768,8 @@ static int ipc4_set_large_config_module_instance(struct ipc4_message_request *ip
 	int ret;
 
 	memcpy_s(&config, sizeof(config), ipc4, sizeof(config));
-	dcache_invalidate_region((__sparse_force void __sparse_cache *)MAILBOX_HOSTBOX_BASE, config.extension.r.data_off_size);
+	dcache_invalidate_region((__sparse_force void __sparse_cache *)MAILBOX_HOSTBOX_BASE,
+				 config.extension.r.data_off_size);
 	tr_dbg(&ipc_tr, "ipc4_set_large_config_module_instance %x : %x",
 	       (uint32_t)config.primary.r.module_id, (uint32_t)config.primary.r.instance_id);
 
@@ -791,7 +793,7 @@ static int ipc4_set_large_config_module_instance(struct ipc4_message_request *ip
 					config.extension.r.init_block,
 					config.extension.r.final_block,
 					config.extension.r.data_off_size,
-					(char *)MAILBOX_HOSTBOX_BASE);
+					(const char *)MAILBOX_HOSTBOX_BASE);
 	if (ret < 0) {
 		tr_err(&ipc_tr, "failed to set large_config_module_instance %x : %x",
 		       (uint32_t)config.primary.r.module_id,

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -71,7 +71,6 @@ struct comp_dev *comp_new(struct sof_ipc_comp *comp)
 	struct comp_ipc_config ipc_config;
 	const struct comp_driver *drv;
 	struct comp_dev *dev;
-	struct ipc_config_process spec;
 
 	drv = ipc4_get_comp_drv(IPC4_MOD_ID(comp->id));
 	if (!drv)
@@ -92,16 +91,18 @@ struct comp_dev *comp_new(struct sof_ipc_comp *comp)
 	ipc_config.pipeline_id = comp->pipeline_id;
 	ipc_config.core = comp->core;
 
-	dcache_invalidate_region((__sparse_force void __sparse_cache *)(MAILBOX_HOSTBOX_BASE),
+	dcache_invalidate_region((__sparse_force void __sparse_cache *)MAILBOX_HOSTBOX_BASE,
 				 MAILBOX_HOSTBOX_SIZE);
 
 	if (drv->type == SOF_COMP_MODULE_ADAPTER) {
-		spec.data = (unsigned char *)MAILBOX_HOSTBOX_BASE;
-		/* spec_size in IPC4 is in DW. Convert to bytes. */
-		spec.size = comp->ext_data_length * 4;
-		dev = drv->ops.create(drv, &ipc_config, (void *)&spec);
+		const struct ipc_config_process spec = {
+			.data = (const unsigned char *)MAILBOX_HOSTBOX_BASE,
+			/* spec_size in IPC4 is in DW. Convert to bytes. */
+			.size = comp->ext_data_length * 4,
+		};
+		dev = drv->ops.create(drv, &ipc_config, (const void *)&spec);
 	} else {
-		dev = drv->ops.create(drv, &ipc_config, (void *)MAILBOX_HOSTBOX_BASE);
+		dev = drv->ops.create(drv, &ipc_config, (const void *)MAILBOX_HOSTBOX_BASE);
 	}
 	if (!dev)
 		return NULL;

--- a/src/ipc/ipc4/logging.c
+++ b/src/ipc/ipc4/logging.c
@@ -108,10 +108,10 @@ static uint64_t mtrace_task_deadline(void *data)
 int ipc4_logging_enable_logs(bool first_block,
 			     bool last_block,
 			     uint32_t data_offset_or_size,
-			     char *data)
+			     const char *data)
 {
 	const struct log_backend *log_backend = log_backend_adsp_mtrace_get();
-	struct ipc4_log_state_info *log_state;
+	const struct ipc4_log_state_info *log_state;
 	struct task_ops ops = {
 		.run = mtrace_task_run,
 		.get_deadline = mtrace_task_deadline,
@@ -134,7 +134,7 @@ int ipc4_logging_enable_logs(bool first_block,
 	 * TODO: support is missing for extended log state info that
 	 *       allows to configure logging type
 	 */
-	log_state = (struct ipc4_log_state_info *)data;
+	log_state = (const struct ipc4_log_state_info *)data;
 
 	if (log_state->enable) {
 		adsp_mtrace_log_init(mtrace_log_hook);
@@ -173,7 +173,7 @@ int ipc4_logging_shutdown(void)
 int ipc4_logging_enable_logs(bool first_block,
 			     bool last_block,
 			     uint32_t data_offset_or_size,
-			     char *data)
+			     const char *data)
 {
 	return IPC4_UNKNOWN_MESSAGE_TYPE;
 }

--- a/src/library_manager/lib_manager.c
+++ b/src/library_manager/lib_manager.c
@@ -231,11 +231,11 @@ static int lib_manager_free_module_instance(uint32_t module_id, uint32_t instanc
 
 uint32_t lib_manager_allocate_module(const struct comp_driver *drv,
 				     struct comp_ipc_config *ipc_config,
-				     void *ipc_specific_config)
+				     const void *ipc_specific_config)
 {
 	struct sof_man_fw_desc *desc;
 	struct sof_man_module *mod;
-	struct ipc4_base_module_cfg *base_cfg = ipc_specific_config;
+	const struct ipc4_base_module_cfg *base_cfg = ipc_specific_config;
 	int ret;
 	uint32_t module_id = IPC4_MOD_ID(ipc_config->id);
 	uint32_t entry_index = LIB_MANAGER_GET_MODULE_INDEX(module_id);

--- a/src/probe/probe.c
+++ b/src/probe/probe.c
@@ -1189,15 +1189,17 @@ int probe_point_add(uint32_t count, struct probe_point *probe)
 			return -EINVAL;
 #endif
 		} else {
+			probe_point_id_t *new_buf_id = &_probe->probe_points[first_free].buffer_id;
+
 #if CONFIG_IPC_MAJOR_4
-			notifier_register(&probe[i].buffer_id.full_id, buf, NOTIFIER_ID_BUFFER_PRODUCE,
+			notifier_register(&new_buf_id->full_id, buf, NOTIFIER_ID_BUFFER_PRODUCE,
 					  &probe_cb_produce, 0);
-			notifier_register(&probe[i].buffer_id.full_id, buf, NOTIFIER_ID_BUFFER_FREE,
+			notifier_register(&new_buf_id->full_id, buf, NOTIFIER_ID_BUFFER_FREE,
 					  &probe_cb_free, 0);
 #else
-			notifier_register(&probe[i].buffer_id.full_id, dev->cb, NOTIFIER_ID_BUFFER_PRODUCE,
+			notifier_register(&new_buf_id->full_id, dev->cb, NOTIFIER_ID_BUFFER_PRODUCE,
 					  &probe_cb_produce, 0);
-			notifier_register(&probe[i].buffer_id.full_id, dev->cb, NOTIFIER_ID_BUFFER_FREE,
+			notifier_register(&new_buf_id->full_id, dev->cb, NOTIFIER_ID_BUFFER_FREE,
 					  &probe_cb_free, 0);
 #endif
 		}

--- a/src/probe/probe.c
+++ b/src/probe/probe.c
@@ -260,7 +260,7 @@ static enum task_state probe_task(void *data)
 	return SOF_TASK_STATE_RESCHEDULE;
 }
 
-int probe_init(struct probe_dma *probe_dma)
+int probe_init(const struct probe_dma *probe_dma)
 {
 	struct probe_pdata *_probe = probe_get();
 	uint32_t i;
@@ -1356,9 +1356,9 @@ int probe_point_remove(uint32_t count, const uint32_t *buffer_id)
 
 #if CONFIG_IPC_MAJOR_4
 static struct comp_dev *probe_new(const struct comp_driver *drv,
-				  struct comp_ipc_config *config, void *spec)
+				  const struct comp_ipc_config *config, const void *spec)
 {
-	struct ipc4_probe_module_cfg *probe_cfg = spec;
+	const struct ipc4_probe_module_cfg *probe_cfg = spec;
 	struct comp_dev *dev;
 	int ret;
 

--- a/src/probe/probe.c
+++ b/src/probe/probe.c
@@ -1052,6 +1052,8 @@ int probe_point_add(uint32_t count, struct probe_point *probe)
 
 	/* add all probe points if they are corresponding to valid component and DMA */
 	for (i = 0; i < count; i++) {
+		uint32_t stream_tag;
+
 		tr_dbg(&pr_tr, "\tprobe[%u] buffer_id = %u, purpose = %u, stream_tag = %u",
 		       i, probe[i].buffer_id.full_id, probe[i].purpose,
 		       probe[i].stream_tag);
@@ -1145,7 +1147,6 @@ int probe_point_add(uint32_t count, struct probe_point *probe)
 				    _probe->inject_dma[j].stream_tag ==
 				    probe[i].stream_tag) {
 					dma_found = 1;
-					probe[i].stream_tag = probe[i].stream_tag;
 					break;
 				}
 			}
@@ -1161,6 +1162,8 @@ int probe_point_add(uint32_t count, struct probe_point *probe)
 
 				return -EBUSY;
 			}
+
+			stream_tag = probe[i].stream_tag;
 		} else {
 			/* prepare extraction DMA */
 			for (j = 0; j < CONFIG_PROBE_POINTS_MAX; j++) {
@@ -1173,14 +1176,13 @@ int probe_point_add(uint32_t count, struct probe_point *probe)
 				schedule_task(&_probe->dmap_work, 1000, 1000);
 			}
 			/* ignore probe stream tag for extraction probes */
-			probe[i].stream_tag = _probe->ext_dma.stream_tag;
+			stream_tag = _probe->ext_dma.stream_tag;
 		}
 
 		/* probe point valid, save it */
 		_probe->probe_points[first_free].buffer_id = probe[i].buffer_id;
 		_probe->probe_points[first_free].purpose = probe[i].purpose;
-		_probe->probe_points[first_free].stream_tag =
-			probe[i].stream_tag;
+		_probe->probe_points[first_free].stream_tag = stream_tag;
 
 		if (fw_logs) {
 #if CONFIG_LOG_BACKEND_SOF_PROBE

--- a/src/samples/audio/detect_test.c
+++ b/src/samples/audio/detect_test.c
@@ -232,7 +232,7 @@ static int test_keyword_get_threshold(struct comp_dev *dev, int sample_width)
 }
 
 static int test_keyword_apply_config(struct comp_dev *dev,
-				     struct sof_detect_test_config *cfg)
+				     const struct sof_detect_test_config *cfg)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 	uint16_t sample_width;
@@ -266,17 +266,17 @@ static int test_keyword_apply_config(struct comp_dev *dev,
 }
 
 static struct comp_dev *test_keyword_new(const struct comp_driver *drv,
-					 struct comp_ipc_config *config,
-					 void *spec)
+					 const struct comp_ipc_config *config,
+					 const void *spec)
 {
 	struct comp_dev *dev = NULL;
 #if CONFIG_IPC_MAJOR_4
-	struct sof_detect_test_config *ipc_keyword = spec;
+	const struct sof_detect_test_config *ipc_keyword = spec;
 #else
-	struct ipc_config_process *ipc_keyword = spec;
+	const struct ipc_config_process *ipc_keyword = spec;
 #endif /* CONFIG_IPC_MAJOR_4 */
 	struct comp_data *cd = NULL;
-	struct sof_detect_test_config *cfg;
+	const struct sof_detect_test_config *cfg;
 	int ret = 0;
 	size_t bs;
 
@@ -308,7 +308,7 @@ static struct comp_dev *test_keyword_new(const struct comp_driver *drv,
 	cfg = ipc_keyword;
 	bs = sizeof(*ipc_keyword);
 #else
-	cfg = (struct sof_detect_test_config *)ipc_keyword->data;
+	cfg = (const struct sof_detect_test_config *)ipc_keyword->data;
 	bs = ipc_keyword->size;
 #endif /* CONFIG_IPC_MAJOR_4 */
 
@@ -403,14 +403,14 @@ static void test_keyword_set_params(struct comp_dev *dev,
 	params->frame_fmt = frame_fmt;
 }
 
-static int test_keyword_set_config(struct comp_dev *dev, char *data,
+static int test_keyword_set_config(struct comp_dev *dev, const char *data,
 				   uint32_t data_size)
 {
-	struct sof_detect_test_config *cfg;
+	const struct sof_detect_test_config *cfg;
 	size_t cfg_size;
 
 	/* Copy new config */
-	cfg = (struct sof_detect_test_config *)data;
+	cfg = (const struct sof_detect_test_config *)data;
 	cfg_size = data_size;
 
 	comp_info(dev, "test_keyword_set_config(): config size = %u",
@@ -455,7 +455,7 @@ static int test_keyword_set_large_config(struct comp_dev *dev,
 					 bool first_block,
 					 bool last_block,
 					 uint32_t data_offset,
-					 char *data)
+					 const char *data)
 {
 	comp_dbg(dev, "test_keyword_set_large_config()");
 	struct comp_data *cd = comp_get_drvdata(dev);

--- a/src/samples/audio/smart_amp_test.c
+++ b/src/samples/audio/smart_amp_test.c
@@ -39,11 +39,11 @@ struct smart_amp_data {
 };
 
 static struct comp_dev *smart_amp_new(const struct comp_driver *drv,
-				      struct comp_ipc_config *config,
-				      void *spec)
+				      const struct comp_ipc_config *config,
+				      const void *spec)
 {
 	struct comp_dev *dev = NULL;
-	struct ipc_config_process *ipc_sa = spec;
+	const struct ipc_config_process *ipc_sa = spec;
 	struct smart_amp_data *sad = NULL;
 	struct sof_smart_amp_config *cfg;
 	size_t bs;

--- a/test/cmocka/src/audio/mixer/comp_mock.c
+++ b/test/cmocka/src/audio/mixer/comp_mock.c
@@ -19,8 +19,8 @@
 #include "comp_mock.h"
 
 static struct comp_dev *mock_comp_new(const struct comp_driver *drv,
-				      struct comp_ipc_config *config,
-				      void *spec)
+				      const struct comp_ipc_config *config,
+				      const void *spec)
 {
 	struct comp_dev *dev = calloc(1, sizeof(struct comp_dev));
 

--- a/tools/testbench/file.c
+++ b/tools/testbench/file.c
@@ -533,12 +533,12 @@ static enum file_format get_file_format(char *filename)
 }
 
 static struct comp_dev *file_new(const struct comp_driver *drv,
-				 struct comp_ipc_config *config,
-				 void *spec)
+				 const struct comp_ipc_config *config,
+				 const void *spec)
 {
 	const struct dai_driver *fdrv;
 	struct comp_dev *dev;
-	struct ipc_comp_file *ipc_file = spec;
+	const struct ipc_comp_file *ipc_file = spec;
 	struct dai_data *dd;
 	struct dai *fdai;
 	struct file_comp_data *cd;


### PR DESCRIPTION
Data, sent by the host to the DSP via the memory window should be read-only