### PR TITLE
[SKIP CI] Tools: Test: Fix upper band limit in THD+N SRC test

### DIFF
--- a/tools/test/audio/src_test.m
+++ b/tools/test/audio/src_test.m
@@ -263,9 +263,7 @@ end
 prm = src_param(t.fs1, t.fs2, test.coef_bits);
 test.f_start = 20;
 test.f_end = prm.c_pb*min(t.fs1, t.fs2);
-test.fu = prm.c_pb*min(t.fs1, t.fs2);
-%test.f_end = 0.4535*min(t.fs1, t.fs2);
-%test.fu = 0.4535*min(t.fs1, t.fs2);
+test.fu = prm.c_pb * t.fs2;
 
 %% Create input file
 test = thdnf_test_input(test);


### PR DESCRIPTION
This patch fixes the upper frequency for distortion plus noise measurement. The min(fs1, fs2) leaves part of upper band unmeasured and gives a too good looking THD+N performance figure when output rate is higher than input rate. The proper way is to measure the (near) full output rate bandwidth.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>