### PR TITLE
west.yml: upgrade rimage to 3ee717eebc6a2a512a0216363ae77473f94532c1

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -34,7 +34,7 @@ manifest:
     - name: rimage
       repo-path: rimage
       path: sof/rimage
-      revision: 542924d70c1715671ad8213440f01dc6dadb52e4
+      revision: 3ee717eebc6a2a512a0216363ae77473f94532c1
 
     - name: tomlc99
       repo-path: tomlc99


### PR DESCRIPTION
upgrade rimage to
3ee717eebc6a2a512a0216363ae77473f94532c1

3ee717eebc6a probe: mtl.toml invaliv probe type
1f4a36e21f00 mux: fix module type
dcfd11bc4d5b mux: add mux cfg to list of modules
d957e0368b86 rimage: make ace15 signing to support openssl3 a1b6e6db33ab manifest: add fw_ver_micro to manifest fb28357912da config: mtl: add probe module

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>