### PR TITLE
copier: fix return value when dai copier is not found

### DIFF
--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -696,7 +696,7 @@ static int copier_comp_trigger(struct comp_dev *dev, int cmd)
 	dai_copier = pipeline_get_dai_comp_latency(dev->pipeline->pipeline_id, &latency);
 	if (!dai_copier) {
 		comp_err(dev, "failed to find dai comp or sink pipeline not running.");
-		return ret;
+		return -ENODEV;
 	}
 
 	dai_cd = comp_get_drvdata(dai_copier);


### PR DESCRIPTION
ret will be previously 0 and even though you get the error in the logs as below, everything seemingly works OK.

[00:00:00.003,000] <err> copier: failed to find dai comp or sink pipeline not running. [00:00:00.003,000] <err> copier: failed to find dai comp or sink pipeline not running.

Return a proper error instead of just letting this one through.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>