### PR TITLE
ipc4: handler: skip setting state when pipeline is already active

### DIFF
--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -250,6 +250,10 @@ static int set_pipeline_state(uint32_t id, uint32_t cmd, bool *delayed, uint32_t
 
 	switch (cmd) {
 	case SOF_IPC4_PIPELINE_STATE_RUNNING:
+		/* nothing to do if the pipeline is already running */
+		if (status == COMP_STATE_ACTIVE)
+			return 0;
+
 		if (status != COMP_STATE_PAUSED && status != COMP_STATE_READY) {
 			tr_err(&ipc_tr, "ipc: current status %d", status);
 			return IPC4_INVALID_REQUEST;


### PR DESCRIPTION
No need to proceed if the pipeline is already active.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>