### PR TITLE
xtensa-build-zephyr.py: cleanup and re-organize to prepare for installing more files

### DIFF
--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -1,11 +1,28 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: BSD-3-Clause
 
-# W0311, W0312, C0103, C0116
-#pylint:disable=bad-indentation
-#pylint:disable=mixed-indentation
-#pylint:disable=invalid-name
-#pylint:disable=missing-function-docstring
+# Too much noise for now, these can be re-enabled after they've been
+# fixed (if that does not break `git blame` too much)
+
+# W0311, W0312, W0603
+# pylint:disable=bad-indentation
+# pylint:disable=mixed-indentation
+# pylint:disable=global-statement
+
+# C0103, C0114, C0116
+# pylint:disable=invalid-name
+# pylint:disable=missing-module-docstring
+# pylint:disable=missing-function-docstring
+
+# Non-indentation whitespace has been removed from newer pylint. It does
+# not hurt to keep them for older versions. The recommendation is to use
+# a formatter like `black` instead, unfortunately this would totally
+# destroy git blame, git revert, etc.
+
+# C0326, C0330
+# pylint:disable=bad-whitespace
+# pylint:disable=bad-continuation
+
 import argparse
 import shlex
 import subprocess

--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -591,21 +591,27 @@ def build_platforms():
 
 		execute_command(sign_cmd, cwd=west_top)
 
-		# Install by copy
+
+		# Install to STAGING_DIR
+		abs_build_dir = pathlib.Path(west_top) / platform_build_dir_name / "zephyr"
+
 		if args.fw_naming == "AVS":
+			# Disguise ourselves for local testing purposes
 			output_fwname="dsp_basefw.bin"
 		else:
+			# Regular name
 			output_fwname="".join(["sof-", platform, ".ri"])
-		fw_file_to_copy = pathlib.Path(west_top, platform_build_dir_name, "zephyr", "zephyr.ri")
-		if args.key_type_subdir == "none":
-			fw_file_installed = pathlib.Path(sof_platform_output_dir,
-							 f"{output_fwname}")
-		else:
-			fw_file_installed = pathlib.Path(sof_platform_output_dir, args.key_type_subdir,
-							 f"{output_fwname}")
-		os.makedirs(os.path.dirname(fw_file_installed), exist_ok=True)
+
+		shutil.copy2(abs_build_dir / "zephyr.ri", abs_build_dir / output_fwname)
+		fw_file_to_copy = abs_build_dir / output_fwname
+
+		install_key_dir = sof_platform_output_dir
+		if args.key_type_subdir != "none":
+			install_key_dir = install_key_dir / args.key_type_subdir
+
+		os.makedirs(install_key_dir, exist_ok=True)
 		# looses file owner and group - file is commonly accessible
-		shutil.copy2(str(fw_file_to_copy), str(fw_file_installed))
+		shutil.copy2(fw_file_to_copy, install_key_dir)
 
 	src_dest_list = []
 

--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -295,18 +295,22 @@ def show_installed_files():
 	"""[summary] Scans output directory building binary tree from files and folders
 	then presents them in similar way to linux tree command."""
 	graph_root = AnyNode(name=STAGING_DIR.name, long_name=STAGING_DIR.name, parent=None)
-	relative_entries = [entry.relative_to(STAGING_DIR) for entry in STAGING_DIR.glob("**/*")]
+	relative_entries = [
+		entry.relative_to(STAGING_DIR) for entry in sorted(STAGING_DIR.glob("**/*"))
+	]
 	nodes = [ graph_root ]
 	for entry in relative_entries:
+		# Node's documentation does allow random attributes
+		# pylint: disable=no-member
 		if str(entry.parent) == ".":
 			nodes.append(AnyNode(name=entry.name, long_name=str(entry), parent=graph_root))
 		else:
-			node_parent = [node for node in nodes if node.long_name == str(entry.parent)][0]
-			if not node_parent:
-				warnings.warn("Failed to construct installed files tree")
-				return
-			nodes.append(AnyNode(name=entry.name, long_name=str(entry), parent=node_parent))
-	for pre, fill, node in RenderTree(graph_root):
+			# sorted() makes sure our parent is already there.
+			# This is slightly awkward, a recursive function would be more readable
+			matches = [node for node in nodes if node.long_name == str(entry.parent)]
+			assert len(matches) == 1, f'"{entry}" does not have exactly one parent'
+			nodes.append(AnyNode(name=entry.name, long_name=str(entry), parent=matches[0]))
+	for pre, _, node in RenderTree(graph_root):
 		print(f"{pre}{node.name}")
 
 def check_west_installation():

--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -585,16 +585,17 @@ def build_platforms():
 
 		sign_cmd += ["-b", sof_build_vers]
 
-		if args.fw_naming == "AVS":
-			output_fwname="dsp_basefw.bin"
-		else:
-			output_fwname="".join(["sof-", platform, ".ri"])
 		if args.ipc == "IPC4":
 			rimage_desc = pathlib.Path(SOF_TOP, "rimage", "config", platform_dict["IPC4_RIMAGE_DESC"])
 			sign_cmd += ["-c", str(rimage_desc)]
 
 		execute_command(sign_cmd, cwd=west_top)
+
 		# Install by copy
+		if args.fw_naming == "AVS":
+			output_fwname="dsp_basefw.bin"
+		else:
+			output_fwname="".join(["sof-", platform, ".ri"])
 		fw_file_to_copy = pathlib.Path(west_top, platform_build_dir_name, "zephyr", "zephyr.ri")
 		if args.key_type_subdir == "none":
 			fw_file_installed = pathlib.Path(sof_platform_output_dir,

--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -294,7 +294,7 @@ def execute_command(*run_args, **run_kwargs):
 def show_installed_files():
 	"""[summary] Scans output directory building binary tree from files and folders
 	then presents them in similar way to linux tree command."""
-	graph_root = AnyNode(name=STAGING_DIR.name, long_name=STAGING_DIR.name, parent=None)
+	graph_root = AnyNode(name=STAGING_DIR.name, long_name=".", parent=None)
 	relative_entries = [
 		entry.relative_to(STAGING_DIR) for entry in sorted(STAGING_DIR.glob("**/*"))
 	]
@@ -302,14 +302,11 @@ def show_installed_files():
 	for entry in relative_entries:
 		# Node's documentation does allow random attributes
 		# pylint: disable=no-member
-		if str(entry.parent) == ".":
-			nodes.append(AnyNode(name=entry.name, long_name=str(entry), parent=graph_root))
-		else:
-			# sorted() makes sure our parent is already there.
-			# This is slightly awkward, a recursive function would be more readable
-			matches = [node for node in nodes if node.long_name == str(entry.parent)]
-			assert len(matches) == 1, f'"{entry}" does not have exactly one parent'
-			nodes.append(AnyNode(name=entry.name, long_name=str(entry), parent=matches[0]))
+		# sorted() makes sure our parent is already there.
+		# This is slightly awkward, a recursive function would be more readable
+		matches = [node for node in nodes if node.long_name == str(entry.parent)]
+		assert len(matches) == 1, f'"{entry}" does not have exactly one parent'
+		nodes.append(AnyNode(name=entry.name, long_name=str(entry), parent=matches[0]))
 	for pre, _, node in RenderTree(graph_root):
 		print(f"{pre}{node.name}")
 


### PR DESCRIPTION
This is preparing the addition of zephyr.elf, zephyr.lst and possibly other files to `build-sof-staging`. For now this PR should make no difference, the purpose is to make the actual addition much smaller and easier to review and to find any bugs in this one _before_ the actual change.

No difference except maybe one small bugfix in the final "tree" listing - depending on whether pathlib.glob(**/*) was ever random and where.

This also makes `pylint xtensa-build-zephyr.py` finally usable.