### PR TITLE
soc: ace: fix IPC D3 power state entry

### DIFF
--- a/src/ipc/ipc-zephyr.c
+++ b/src/ipc/ipc-zephyr.c
@@ -17,7 +17,11 @@
 #include <sof/ipc/schedule.h>
 #include <sof/lib/mailbox.h>
 #include <sof/lib/memory.h>
+#if defined(CONFIG_PM_POLICY_CUSTOM)
+#include <sof/lib/cpu.h>
+#else
 #include <sof/lib/pm_runtime.h>
+#endif
 #include <sof/lib/uuid.h>
 #include <rtos/wait.h>
 #include <sof/list.h>
@@ -124,13 +128,25 @@ enum task_state ipc_platform_do_cmd(struct ipc *ipc)
 	/* perform command */
 	ipc_cmd(hdr);
 
-#if CONFIG_SOC_SERIES_INTEL_ADSP_CAVS
-	/* are we about to enter D3 ? */
-	if (ipc->pm_prepare_D3) {
-		/* no return - memory will be powered off and IPC sent */
+	if (ipc->task_mask & IPC_TASK_POWERDOWN ||
+	    ipc_get()->pm_prepare_D3) {
+#if defined(CONFIG_PM_POLICY_CUSTOM)
+		/**
+		 * @note For primary core this function
+		 * will only force set lower power state
+		 * in power management settings.
+		 * Core will enter D3 state after exit
+		 * IPC thread during idle.
+		 */
+		cpu_disable_core(PLATFORM_PRIMARY_CORE_ID);
+#else
+		/**
+		 * @note no return - memory will be
+		 * powered off and IPC sent.
+		 */
 		platform_pm_runtime_power_off();
+#endif /* CONFIG_PM_POLICY_CUSTOM  */
 	}
-#endif
 
 	return SOF_TASK_STATE_COMPLETED;
 }
@@ -168,7 +184,7 @@ int platform_ipc_init(struct ipc *ipc)
 	schedule_task_init_edf(&ipc->ipc_task, SOF_UUID(ipc_task_uuid),
 			       &ipc_task_ops, ipc, 0, 0);
 
-	/* configure interrupt - some work is done internally by Zephytr API */
+	/* configure interrupt - work is done internally by Zephyr API */
 
 	/* attach handlers */
 	intel_adsp_ipc_set_message_handler(INTEL_ADSP_IPC_HOST_DEV, message_handler, ipc);

--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -880,6 +880,9 @@ static int ipc4_module_process_dx(struct ipc4_message_request *ipc4)
 			return IPC4_BUSY;
 		}
 
+#if defined(CONFIG_PM)
+		ipc_get()->task_mask |= IPC_TASK_POWERDOWN;
+#endif
 		/* do platform specific suspending */
 		platform_context_save(sof_get());
 


### PR DESCRIPTION
**Fist commit**
Patch fixes D3 issue - now platform enters and wakes up from D3 correctly. 
It had been achieved using Zephyr cpu function call that redirects D3 flow to power down assembly code
sending IPC response to host just before powering down.

~**Second commit**~
~Adds pm notifiers to Zephyr power manager to allocate IMR memory inside SOF code in order to save LPSRAM and HPSRAM memory before powering down.~
Edit: dropped for now due to missing implementation of devices context restore.
https://github.com/zephyrproject-rtos/zephyr/pull/53105 will be used instead to skip context restore for now.
It will be implemented soon<sup>tm</sup>.

Requires:

- [x] https://github.com/thesofproject/sof/pull/6360
- [x] https://github.com/thesofproject/sof/pull/6041
- [x] https://github.com/zephyrproject-rtos/zephyr/pull/51414
- [x] https://github.com/thesofproject/sof/pull/6489
- [x] https://github.com/zephyrproject-rtos/zephyr/pull/47840
- [x] https://github.com/thesofproject/sof/pull/6613
- [x] https://github.com/thesofproject/sof/pull/6697
- [x] https://github.com/zephyrproject-rtos/zephyr/pull/53105
- [x] https://github.com/thesofproject/sof/pull/6828


Signed-off-by: Andrey Borisovich <andrey.borisovich@intel.com>
Signed-off-by: Marcin Szkudlinski <marcin.szkudlinski@intel.com>
Signed-off-by: Tomasz Leman <tomasz.m.leman@intel.com>