### PR TITLE
ipc4: rework llp slot allocation

### DIFF
--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -234,6 +234,8 @@ static void dai_free(struct comp_dev *dev)
 
 	dma_put(dd->dma);
 
+	dai_release_llp_slot(dev);
+
 	dai_put(dd->dai);
 
 	if (dd->dai_spec_config)

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -367,6 +367,8 @@ static void dai_free(struct comp_dev *dev)
 
 	dma_put(dd->dma);
 
+	dai_release_llp_slot(dev);
+
 	dai_put(dd->dai);
 
 	rfree(dd->dai_spec_config);

--- a/src/include/ipc4/gateway.h
+++ b/src/include/ipc4/gateway.h
@@ -86,6 +86,9 @@ enum ipc4_connector_node_id_type {
 /**< Invalid raw node id (to indicate uninitialized node id). */
 #define IPC4_INVALID_NODE_ID	0xffffffff
 
+/**< all bits of v_index and dma_type */
+#define IPC4_NODE_ID_MASK	0x1fff
+
 /**< Base top-level structure of an address of a gateway. */
 /*!
  * The virtual index value, presented on the top level as raw 8 bits,
@@ -186,6 +189,8 @@ struct ipc4_gateway_config_blob {
 	 */
 	uint32_t threshold_low;
 } __attribute__((packed, aligned(4)));
+
+#define ALH_MULTI_GTW_BASE	0x50
 
 enum ipc4_gateway_type {
 	ipc4_gtw_none	= BIT(0),

--- a/src/include/sof/lib/dai-legacy.h
+++ b/src/include/sof/lib/dai-legacy.h
@@ -570,6 +570,11 @@ int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn);
  * \brief update dai dma position for host driver.
  */
 void dai_dma_position_update(struct comp_dev *dev);
+
+/**
+ * \brief release llp slot
+ */
+void dai_release_llp_slot(struct comp_dev *dev);
 /** @}*/
 
 #endif /* __SOF_LIB_DAI_LEGACY_H__ */

--- a/src/include/sof/lib/dai-legacy.h
+++ b/src/include/sof/lib/dai-legacy.h
@@ -156,6 +156,14 @@ struct dai_plat_data {
 };
 
 /**
+ * \brief llp slot info for memory window
+ */
+struct llp_slot_info {
+	uint32_t node_id;
+	uint32_t reg_offset;
+};
+
+/**
  * \brief DAI runtime data
  */
 struct dai_data {
@@ -190,6 +198,9 @@ struct dai_data {
 	 * the SOF_DAI_CONFIG_FLAGS_PAUSE flag.
 	 */
 	bool delayed_dma_stop;
+
+	/* llp slot info in memory windows */
+	struct llp_slot_info slot_info;
 };
 
 struct dai {

--- a/src/include/sof/lib/dai-zephyr.h
+++ b/src/include/sof/lib/dai-zephyr.h
@@ -278,6 +278,11 @@ int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn);
  * \brief update dai dma position for host driver.
  */
 void dai_dma_position_update(struct comp_dev *dev);
+
+/**
+ * \brief release llp slot
+ */
+void dai_release_llp_slot(struct comp_dev *dev);
 /** @}*/
 
 #endif /* __SOF_LIB_DAI_ZEPHYR_H__ */

--- a/src/include/sof/lib/dai-zephyr.h
+++ b/src/include/sof/lib/dai-zephyr.h
@@ -111,6 +111,14 @@ struct dai_group {
 };
 
 /**
+ * \brief llp slot info for memory window
+ */
+struct llp_slot_info {
+	uint32_t node_id;
+	uint32_t reg_offset;
+};
+
+/**
  * \brief DAI runtime data
  */
 struct dai_data {
@@ -146,6 +154,9 @@ struct dai_data {
 	 * the SOF_DAI_CONFIG_FLAGS_PAUSE flag.
 	 */
 	bool delayed_dma_stop;
+
+	/* llp slot info in memory windows */
+	struct llp_slot_info slot_info;
 };
 
 /* these 3 are here to satisfy clk.c and ssp.h interconnection, will be removed leter */

--- a/src/include/sof/sof.h
+++ b/src/include/sof/sof.h
@@ -11,6 +11,7 @@
 #include <arch/sof.h>
 #include <sof/common.h>
 #include <sof/lib/memory.h>
+#include <rtos/spinlock.h>
 
 struct cascade_root;
 struct clock_info;
@@ -104,6 +105,11 @@ struct sof {
 #ifdef CONFIG_LIBRARY_MANAGER
 	/* dynamically loaded libraries */
 	struct ext_library *ext_library;
+#endif
+
+#if CONFIG_IPC_MAJOR_4
+	/* lock for fw_reg access */
+	struct k_spinlock fw_reg_lock;
 #endif
 
 	__aligned(PLATFORM_DCACHE_ALIGN) int alignment[0];

--- a/src/init/init.c
+++ b/src/init/init.c
@@ -276,7 +276,10 @@ static int primary_core_init(int argc, char *argv[], struct sof *sof)
 	size_t ipc4_abi_ver_offset = offsetof(struct ipc4_fw_registers, abi_ver);
 
 	mailbox_sw_reg_write(ipc4_abi_ver_offset, IPC4_FW_REGS_ABI_VER);
+
+	k_spinlock_init(&sof->fw_reg_lock);
 #endif
+
 	trace_point(TRACE_BOOT_PLATFORM);
 
 #if CONFIG_NO_SECONDARY_CORE_ROM

--- a/src/ipc/ipc3/dai.c
+++ b/src/ipc/ipc3/dai.c
@@ -397,3 +397,5 @@ int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn)
 }
 
 void dai_dma_position_update(struct comp_dev *dev) { }
+
+void dai_release_llp_slot(struct comp_dev *dev) { }


### PR DESCRIPTION
Current llp slot is allocated based on virtual index
in node id which is incorrect since different dai may
use the same virtual index. It should be allocated
according to allocated dma engine and channel id.


ref: https://github.com/thesofproject/sof/issues/6424