### PR TITLE
Audio: EQ-IIR: add Direct-1 format implementation

### DIFF
--- a/src/audio/tdfb/tdfb_direction.c
+++ b/src/audio/tdfb/tdfb_direction.c
@@ -174,7 +174,7 @@ static bool line_array_mode_check(struct tdfb_comp_data *cd)
 
 int tdfb_direction_init(struct tdfb_comp_data *cd, int32_t fs, int ch_count)
 {
-	struct sof_eq_iir_header_df2t *filt;
+	struct sof_eq_iir_header *filt;
 	int64_t *delay;
 	int32_t d_max;
 	int32_t t_max;
@@ -185,10 +185,10 @@ int tdfb_direction_init(struct tdfb_comp_data *cd, int32_t fs, int ch_count)
 	/* Select emphasis response per sample rate */
 	switch (fs) {
 	case 16000:
-		filt = (struct sof_eq_iir_header_df2t *)iir_emphasis_16k;
+		filt = (struct sof_eq_iir_header *)iir_emphasis_16k;
 		break;
 	case 48000:
-		filt = (struct sof_eq_iir_header_df2t *)iir_emphasis_48k;
+		filt = (struct sof_eq_iir_header *)iir_emphasis_48k;
 		break;
 	default:
 		return -EINVAL;

--- a/src/include/sof/math/iir_df1.h
+++ b/src/include/sof/math/iir_df1.h
@@ -1,0 +1,42 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2022 Intel Corporation. All rights reserved.
+ *
+ * Author: Andrula Song <andrula.song@intel.com>
+ */
+
+#ifndef __SOF_MATH_IIR_DF1_H__
+#define __SOF_MATH_IIR_DF1_H__
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define IIR_DF1_NUM_STATE 4
+
+#define IIR_DF1_GENERIC 1
+struct iir_state_df1 {
+	unsigned int biquads; /* Number of IIR 2nd order sections total */
+	unsigned int biquads_in_series; /* Number of IIR 2nd order sections
+					 * in series.
+					 */
+	int32_t *coef; /* Pointer to IIR coefficients */
+	int32_t *delay; /* Pointer to IIR delay line */
+};
+
+struct sof_eq_iir_header;
+
+int iir_init_coef_df1(struct iir_state_df1 *iir,
+		      struct sof_eq_iir_header *config);
+
+int iir_delay_size_df1(struct sof_eq_iir_header *config);
+
+void iir_init_delay_df1(struct iir_state_df1 *iir, int32_t **state);
+
+void iir_reset_df1(struct iir_state_df1 *iir);
+
+int32_t iir_df1(struct iir_state_df1 *iir, int32_t x);
+
+/* Inline functions */
+#include "iir_df1_generic.h"
+
+#endif

--- a/src/include/sof/math/iir_df1_generic.h
+++ b/src/include/sof/math/iir_df1_generic.h
@@ -1,0 +1,34 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2022 Intel Corporation. All rights reserved.
+ *
+ * Author: Andrula Song <andrula.song@intel.com>
+ */
+
+#ifndef __IIR_DF1_GENERIC_H__
+#define __IIR_DF1_GENERIC_H__
+
+#include <stdint.h>
+
+static inline int16_t iir_df1_s16(struct iir_state_df1 *iir, int16_t x)
+{
+	return sat_int16(Q_SHIFT_RND(iir_df1(iir, ((int32_t)x) << 16), 31, 15));
+}
+
+static inline int32_t iir_df1_s24(struct iir_state_df1 *iir, int32_t x)
+{
+	return sat_int24(Q_SHIFT_RND(iir_df1(iir, x << 8), 31, 23));
+}
+
+static inline int16_t iir_df1_s32_s16(struct iir_state_df1 *iir, int32_t x)
+{
+	return sat_int16(Q_SHIFT_RND(iir_df1(iir, x), 31, 15));
+}
+
+static inline int32_t iir_df1_s32_s24(struct iir_state_df1 *iir, int32_t x)
+{
+	return sat_int24(Q_SHIFT_RND(iir_df1(iir, x), 31, 23));
+}
+
+#endif /* __IIR_DF2T_GENERIC_H__ */
+

--- a/src/include/sof/math/iir_df2t.h
+++ b/src/include/sof/math/iir_df2t.h
@@ -58,12 +58,12 @@ struct iir_state_df2t {
 	int64_t *delay; /* Pointer to IIR delay line */
 };
 
-struct sof_eq_iir_header_df2t;
+struct sof_eq_iir_header;
 
 int iir_init_coef_df2t(struct iir_state_df2t *iir,
-		       struct sof_eq_iir_header_df2t *config);
+		       struct sof_eq_iir_header *config);
 
-int iir_delay_size_df2t(struct sof_eq_iir_header_df2t *config);
+int iir_delay_size_df2t(struct sof_eq_iir_header *config);
 
 void iir_init_delay_df2t(struct iir_state_df2t *iir, int64_t **delay);
 

--- a/src/include/user/eq.h
+++ b/src/include/user/eq.h
@@ -114,7 +114,7 @@ struct sof_eq_iir_config {
 	int32_t data[]; /* eq_assign[channels], eq 0, eq 1, ... */
 } __attribute__((packed));
 
-struct sof_eq_iir_header_df2t {
+struct sof_eq_iir_header {
 	uint32_t num_sections;
 	uint32_t num_sections_in_series;
 
@@ -124,7 +124,7 @@ struct sof_eq_iir_header_df2t {
 	int32_t biquads[]; /* Repeated biquad coefficients */
 } __attribute__((packed));
 
-struct sof_eq_iir_biquad_df2t {
+struct sof_eq_iir_biquad {
 	int32_t a2; /* Q2.30 */
 	int32_t a1; /* Q2.30 */
 	int32_t b2; /* Q2.30 */
@@ -135,20 +135,20 @@ struct sof_eq_iir_biquad_df2t {
 } __attribute__((packed));
 
 /* A full 22th order equalizer with 11 biquads cover octave bands 1-11 in
- * in the 0 - 20 kHz bandwidth.
+ * the 0 - 20 kHz bandwidth.
  */
-#define SOF_EQ_IIR_DF2T_BIQUADS_MAX 11
+#define SOF_EQ_IIR_BIQUADS_MAX 11
 
-/* The number of int32_t words in sof_eq_iir_header_df2t:
+/* The number of int32_t words in sof_eq_iir_header:
  *	num_sections, num_sections_in_series, reserved[4]
  */
-#define SOF_EQ_IIR_NHEADER_DF2T \
-	(sizeof(struct sof_eq_iir_header_df2t) / sizeof(int32_t))
+#define SOF_EQ_IIR_NHEADER \
+	(sizeof(struct sof_eq_iir_header) / sizeof(int32_t))
 
-/* The number of int32_t words in sof_eq_iir_biquad_df2t:
+/* The number of int32_t words in sof_eq_iir_biquad:
  *	a2, a1, b2, b1, b0, output_shift, output_gain
  */
-#define SOF_EQ_IIR_NBIQUAD_DF2T \
-	(sizeof(struct sof_eq_iir_biquad_df2t) / sizeof(int32_t))
+#define SOF_EQ_IIR_NBIQUAD \
+	(sizeof(struct sof_eq_iir_biquad) / sizeof(int32_t))
 
 #endif /* __USER_EQ_H__ */

--- a/src/math/CMakeLists.txt
+++ b/src/math/CMakeLists.txt
@@ -43,7 +43,11 @@ if(CONFIG_MATH_FFT)
 endif()
 
 if(CONFIG_MATH_IIR_DF2T)
-        add_local_sources(sof iir_df2t_generic.c iir_df2t_hifi3.c iir.c)
+        add_local_sources(sof iir_df2t_generic.c iir_df2t_hifi3.c iir_df2t.c)
+endif()
+
+if(CONFIG_MATH_IIR_DF1)
+        add_local_sources(sof iir_df1_generic.c iir_df1.c)
 endif()
 
 if(CONFIG_MATH_WINDOW)

--- a/src/math/Kconfig
+++ b/src/math/Kconfig
@@ -115,11 +115,18 @@ config MATH_FIR
 	  impulse response.
 
 config MATH_IIR_DF2T
-	bool "IIR filter library"
+	bool "IIR DF2T filter library"
 	default n
 	help
 	  Select this to build IIR (Infinite Impulse Response) filter
 	  or type 2-transposed library.
+
+config MATH_IIR_DF1
+	bool "IIR DF1 filter library"
+	default y
+	help
+	  Select this to build IIR (Infinite Impulse Response) filter
+	  or type Direct-1 library.
 
 config MATH_WINDOW
 	bool "Window functions library"

--- a/src/math/iir_df1.c
+++ b/src/math/iir_df1.c
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2022 Intel Corporation. All rights reserved.
+//
+// Author: Andrula Song <andrula.song@intel.com>
+
+#include <sof/common.h>
+#include <sof/audio/format.h>
+#include <sof/math/iir_df1.h>
+#include <user/eq.h>
+#include <errno.h>
+#include <stddef.h>
+#include <stdint.h>
+
+int iir_delay_size_df1(struct sof_eq_iir_header *config)
+{
+	int n = config->num_sections; /* One section uses two unit delays */
+
+	if (n > SOF_EQ_IIR_BIQUADS_MAX || n < 1)
+		return -EINVAL;
+
+	return 4 * n * sizeof(int32_t);
+}
+
+int iir_init_coef_df1(struct iir_state_df1 *iir,
+		      struct sof_eq_iir_header *config)
+{
+	iir->biquads = config->num_sections;
+	iir->biquads_in_series = config->num_sections_in_series;
+	iir->coef = ASSUME_ALIGNED(&config->biquads[0], 4);
+
+	return 0;
+}
+
+void iir_init_delay_df1(struct iir_state_df1 *iir, int32_t **delay)
+{
+	/* Set state line of this IIR */
+	iir->delay = *delay;
+
+	/* Point to next IIR delay line start. */
+	*delay += 4 * iir->biquads;
+}
+
+void iir_reset_df1(struct iir_state_df1 *iir)
+{
+	iir->biquads = 0;
+	iir->biquads_in_series = 0;
+	iir->coef = NULL;
+	/* Note: May need to know the beginning of dynamic allocation after so
+	 * omitting setting iir->delay to NULL.
+	 */
+}

--- a/src/math/iir_df1_generic.c
+++ b/src/math/iir_df1_generic.c
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2022 Intel Corporation. All rights reserved.
+//
+// Author: Andrula Song <andrula.song@intel.com>
+
+#include <stdint.h>
+#include <stddef.h>
+#include <errno.h>
+#include <sof/audio/format.h>
+#include <sof/math/iir_df1.h>
+#include <user/eq.h>
+
+#if IIR_DF1_GENERIC
+
+/*
+ * Direct form II transposed second order filter block (biquad)
+ *
+ *              +----+                            +---+    +-------+
+ * X(z) ---o--->| b0 |---> + --+-------------o--->| g |--->| shift |---> Y(z)
+ *         |    +----+     ^   ^             |    +---+    +-------+
+ *         |               |   |             |
+ *     +------+            |   |          +------+
+ *     | z^-1 |            |   |          | z^-1 |
+ *     +------+            |   |          +------+
+ *         |    +----+     |   |     +----+   |
+ *         o--->| b1 |---> +   + <---| a1 |---o
+ *         |    +----+     ^   ^     +----+   |
+ *         |               |   |              |
+ *     +------+            |   |          +------+
+ *     | z^-1 |            |   |          | z^-1 |
+ *     +------+            |   |          +------+
+ *         |               ^   ^              |
+ *         |    +----+     |   |     +----+   |
+ *         o--->| b2 |---> +   +<--- | a2 |---o
+ *              +----+               +----+
+ *
+ * y[n] = b0 * x[n] + b1 * x[n-1] + b2 * x[n-2] + a1 * y[n-1] + a2 * y[n-2]
+ * the a1 a2 has been negated during calculation
+ */
+
+/* Series DF1 IIR */
+
+/* 32 bit data, 32 bit coefficients and 32 bit state variables */
+
+int32_t iir_df1(struct iir_state_df1 *iir, int32_t x)
+{
+	int32_t in;
+	int32_t tmp;
+	int64_t out = 0;
+	int64_t acc;
+	int i;
+	int j;
+	int d = 0; /* Index to state */
+	int c = 0; /* Index to coefficient a2 */
+	int32_t *coefp = iir->coef;
+	int32_t *delay = iir->delay;
+	int nseries = iir->biquads_in_series;
+
+	/* Bypass is set with number of biquads set to zero. */
+	if (!iir->biquads)
+		return x;
+
+	/* Coefficients order in coef[] is {a2, a1, b2, b1, b0, shift, gain} */
+	/* Delay order in state[] is {y(n - 2), y(n - 1), x(n - 2), x(n - 1)} */
+	for (j = 0; j < iir->biquads; j += nseries) {
+		in = x;
+		for (i = 0; i < nseries; i++) {
+			/* Compute output: Delay is Q3.61
+			 * Q2.30 x Q1.31 -> Q3.61
+			 * Shift Q3.61 to Q3.31 with rounding, saturate to Q1.31
+			 */
+			acc = ((int64_t)coefp[c]) * delay[d]; /* a2 * y(n - 2) */
+			acc += ((int64_t)coefp[c + 1]) * delay[d + 1]; /* a1 * y(n - 1) */
+			acc += ((int64_t)coefp[c + 2]) * delay[d + 2]; /* b2 * x(n - 2) */
+			acc += ((int64_t)coefp[c + 3]) * delay[d + 3]; /* b1 * x(n - 1) */
+			acc += ((int64_t)coefp[c + 4]) * in; /* b0 * x */
+			tmp = (int32_t)sat_int32(Q_SHIFT_RND(acc, 61, 31));
+
+			/* update the delay value */
+			delay[d] = delay[d + 1];
+			delay[d + 1] = tmp;
+			delay[d + 2] = delay[d + 3];
+			delay[d + 3] = in;
+
+			/* Apply gain Q2.14 x Q1.31 -> Q3.45 */
+			acc = ((int64_t)coefp[c + 6]) * tmp; /* Gain */
+
+			/* Apply biquad output shift right parameter
+			 * simultaneously with Q3.45 to Q3.31 conversion. Then
+			 * saturate to 32 bits Q1.31 and prepare for next
+			 * biquad.
+			 */
+			acc = Q_SHIFT_RND(acc, 45 + coefp[c + 5], 31);
+			in = sat_int32(acc);
+
+			/* Proceed to next biquad coefficients and delay
+			 * lines.
+			 */
+			c += SOF_EQ_IIR_NBIQUAD;
+			d += IIR_DF1_NUM_STATE;
+		}
+		/* Output of previous section is in variable in */
+		out += (int64_t)in;
+	}
+	return sat_int32(out);
+}
+
+#endif

--- a/src/math/iir_df2t.c
+++ b/src/math/iir_df2t.c
@@ -14,18 +14,18 @@
 #include <stddef.h>
 #include <stdint.h>
 
-int iir_delay_size_df2t(struct sof_eq_iir_header_df2t *config)
+int iir_delay_size_df2t(struct sof_eq_iir_header *config)
 {
 	int n = config->num_sections; /* One section uses two unit delays */
 
-	if (n > SOF_EQ_IIR_DF2T_BIQUADS_MAX || n < 1)
+	if (n > SOF_EQ_IIR_BIQUADS_MAX || n < 1)
 		return -EINVAL;
 
 	return 2 * n * sizeof(int64_t);
 }
 
 int iir_init_coef_df2t(struct iir_state_df2t *iir,
-		       struct sof_eq_iir_header_df2t *config)
+		       struct sof_eq_iir_header *config)
 {
 	iir->biquads = config->num_sections;
 	iir->biquads_in_series = config->num_sections_in_series;

--- a/src/math/iir_df2t_generic.c
+++ b/src/math/iir_df2t_generic.c
@@ -96,7 +96,7 @@ int32_t iir_df2t(struct iir_state_df2t *iir, int32_t x)
 			/* Proceed to next biquad coefficients and delay
 			 * lines.
 			 */
-			c += SOF_EQ_IIR_NBIQUAD_DF2T;
+			c += SOF_EQ_IIR_NBIQUAD;
 			d += IIR_DF2T_NUM_DELAYS;
 		}
 		/* Output of previous section is in variable in */

--- a/test/cmocka/src/audio/eq_iir/CMakeLists.txt
+++ b/test/cmocka/src/audio/eq_iir/CMakeLists.txt
@@ -13,7 +13,9 @@ add_compile_options(-DUNIT_TEST)
 
 add_library(audio_for_eq_iir STATIC
 	${PROJECT_SOURCE_DIR}/src/audio/eq_iir/eq_iir.c
-	${PROJECT_SOURCE_DIR}/src/math/iir.c
+	${PROJECT_SOURCE_DIR}/src/math/iir_df1.c
+		${PROJECT_SOURCE_DIR}/src/math/iir_df1_generic.c
+	${PROJECT_SOURCE_DIR}/src/math/iir_df2t.c
         ${PROJECT_SOURCE_DIR}/src/math/iir_df2t_generic.c
         ${PROJECT_SOURCE_DIR}/src/math/iir_df2t_hifi3.c
 	${PROJECT_SOURCE_DIR}/src/audio/buffer.c


### PR DESCRIPTION
Add C version Direct-1 format implementation for IIR. Compared with the original Direct-2 transport format, Direct-1 has better performance on low frequency since lower quantization noise.

Signed-off-by: Andrula Song <xiaoyuan.song@intel.com>