### PR TITLE
Audio: EQ-IIR: add Direct-1 format implementation

### DIFF
--- a/src/audio/crossover/crossover.c
+++ b/src/audio/crossover/crossover.c
@@ -187,7 +187,7 @@ static int crossover_assign_sinks(struct comp_dev *dev,
  *	       high/low pass filter.
  * \param[out] lr4 initialized struct
  */
-static int crossover_init_coef_lr4(struct sof_eq_iir_biquad_df2t *coef,
+static int crossover_init_coef_lr4(struct sof_eq_iir_biquad *coef,
 				   struct iir_state_df2t *lr4)
 {
 	int ret;
@@ -197,19 +197,19 @@ static int crossover_init_coef_lr4(struct sof_eq_iir_biquad_df2t *coef,
 	 * iir_state_df2t, it requires two copies of coefficients in a row.
 	 */
 	lr4->coef = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM,
-			    sizeof(struct sof_eq_iir_biquad_df2t) * 2);
+			    sizeof(struct sof_eq_iir_biquad) * 2);
 	if (!lr4->coef)
 		return -ENOMEM;
 
 	/* coefficients of the first biquad */
-	ret = memcpy_s(lr4->coef, sizeof(struct sof_eq_iir_biquad_df2t),
-		       coef, sizeof(struct sof_eq_iir_biquad_df2t));
+	ret = memcpy_s(lr4->coef, sizeof(struct sof_eq_iir_biquad),
+		       coef, sizeof(struct sof_eq_iir_biquad));
 	assert(!ret);
 
 	/* coefficients of the second biquad */
-	ret = memcpy_s(lr4->coef + SOF_EQ_IIR_NBIQUAD_DF2T,
-		       sizeof(struct sof_eq_iir_biquad_df2t),
-		       coef, sizeof(struct sof_eq_iir_biquad_df2t));
+	ret = memcpy_s(lr4->coef + SOF_EQ_IIR_NBIQUAD,
+		       sizeof(struct sof_eq_iir_biquad),
+		       coef, sizeof(struct sof_eq_iir_biquad));
 	assert(!ret);
 
 	/* LR4 filters are two 2nd order filters, so only need 4 delay slots
@@ -230,7 +230,7 @@ static int crossover_init_coef_lr4(struct sof_eq_iir_biquad_df2t *coef,
 /**
  * \brief Initializes the crossover coefficients for one channel
  */
-int crossover_init_coef_ch(struct sof_eq_iir_biquad_df2t *coef,
+int crossover_init_coef_ch(struct sof_eq_iir_biquad *coef,
 			   struct crossover_state *ch_state,
 			   int32_t num_sinks)
 {
@@ -264,7 +264,7 @@ int crossover_init_coef_ch(struct sof_eq_iir_biquad_df2t *coef,
  */
 static int crossover_init_coef(struct comp_data *cd, int nch)
 {
-	struct sof_eq_iir_biquad_df2t *crossover;
+	struct sof_eq_iir_biquad *crossover;
 	struct sof_crossover_config *config = cd->config;
 	int ch, err;
 

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -447,8 +447,8 @@ static void eq_iir_free_delaylines(struct comp_data *cd)
 static int eq_iir_init_coef(struct sof_eq_iir_config *config,
 			    struct iir_state_df2t *iir, int nch)
 {
-	struct sof_eq_iir_header_df2t *lookup[SOF_EQ_IIR_MAX_RESPONSES];
-	struct sof_eq_iir_header_df2t *eq;
+	struct sof_eq_iir_header *lookup[SOF_EQ_IIR_MAX_RESPONSES];
+	struct sof_eq_iir_header *eq;
 	int32_t *assign_response;
 	int32_t *coef_data;
 	int size_sum = 0;
@@ -480,10 +480,10 @@ static int eq_iir_init_coef(struct sof_eq_iir_config *config,
 				   4);
 	for (i = 0; i < SOF_EQ_IIR_MAX_RESPONSES; i++) {
 		if (i < config->number_of_responses) {
-			eq = (struct sof_eq_iir_header_df2t *)&coef_data[j];
+			eq = (struct sof_eq_iir_header *)&coef_data[j];
 			lookup[i] = eq;
-			j += SOF_EQ_IIR_NHEADER_DF2T
-				+ SOF_EQ_IIR_NBIQUAD_DF2T * eq->num_sections;
+			j += SOF_EQ_IIR_NHEADER
+				+ SOF_EQ_IIR_NBIQUAD * eq->num_sections;
 		} else {
 			lookup[i] = NULL;
 		}

--- a/src/audio/multiband_drc/multiband_drc.c
+++ b/src/audio/multiband_drc/multiband_drc.c
@@ -70,19 +70,19 @@ static inline void multiband_drc_reset_state(struct multiband_drc_state *state)
 		multiband_drc_iir_reset_state_ch(&state->deemphasis[i]);
 }
 
-static int multiband_drc_eq_init_coef_ch(struct sof_eq_iir_biquad_df2t *coef,
+static int multiband_drc_eq_init_coef_ch(struct sof_eq_iir_biquad *coef,
 					 struct iir_state_df2t *eq)
 {
 	int ret;
 
 	eq->coef = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM,
-			   sizeof(struct sof_eq_iir_biquad_df2t) * SOF_EMP_DEEMP_BIQUADS);
+			   sizeof(struct sof_eq_iir_biquad) * SOF_EMP_DEEMP_BIQUADS);
 	if (!eq->coef)
 		return -ENOMEM;
 
 	/* Coefficients of the first biquad and second biquad */
-	ret = memcpy_s(eq->coef, sizeof(struct sof_eq_iir_biquad_df2t) * SOF_EMP_DEEMP_BIQUADS,
-		       coef, sizeof(struct sof_eq_iir_biquad_df2t) * SOF_EMP_DEEMP_BIQUADS);
+	ret = memcpy_s(eq->coef, sizeof(struct sof_eq_iir_biquad) * SOF_EMP_DEEMP_BIQUADS,
+		       coef, sizeof(struct sof_eq_iir_biquad) * SOF_EMP_DEEMP_BIQUADS);
 	assert(!ret);
 
 	/* EQ filters are two 2nd order filters, so only need 4 delay slots
@@ -102,9 +102,9 @@ static int multiband_drc_eq_init_coef_ch(struct sof_eq_iir_biquad_df2t *coef,
 
 static int multiband_drc_init_coef(struct multiband_drc_comp_data *cd, int16_t nch, uint32_t rate)
 {
-	struct sof_eq_iir_biquad_df2t *crossover;
-	struct sof_eq_iir_biquad_df2t *emphasis;
-	struct sof_eq_iir_biquad_df2t *deemphasis;
+	struct sof_eq_iir_biquad *crossover;
+	struct sof_eq_iir_biquad *emphasis;
+	struct sof_eq_iir_biquad *deemphasis;
 	struct sof_multiband_drc_config *config = cd->config;
 	struct multiband_drc_state *state = &cd->state;
 	uint32_t sample_bytes = get_sample_bytes(cd->source_format);

--- a/src/audio/tdfb/tdfb_direction.c
+++ b/src/audio/tdfb/tdfb_direction.c
@@ -174,7 +174,7 @@ static bool line_array_mode_check(struct tdfb_comp_data *cd)
 
 int tdfb_direction_init(struct tdfb_comp_data *cd, int32_t fs, int ch_count)
 {
-	struct sof_eq_iir_header_df2t *filt;
+	struct sof_eq_iir_header *filt;
 	int64_t *delay;
 	int32_t d_max;
 	int32_t t_max;
@@ -185,10 +185,10 @@ int tdfb_direction_init(struct tdfb_comp_data *cd, int32_t fs, int ch_count)
 	/* Select emphasis response per sample rate */
 	switch (fs) {
 	case 16000:
-		filt = (struct sof_eq_iir_header_df2t *)iir_emphasis_16k;
+		filt = (struct sof_eq_iir_header *)iir_emphasis_16k;
 		break;
 	case 48000:
-		filt = (struct sof_eq_iir_header_df2t *)iir_emphasis_48k;
+		filt = (struct sof_eq_iir_header *)iir_emphasis_48k;
 		break;
 	default:
 		return -EINVAL;

--- a/src/include/sof/audio/crossover/crossover_algorithm.h
+++ b/src/include/sof/audio/crossover/crossover_algorithm.h
@@ -17,7 +17,7 @@
 void crossover_reset_state_ch(struct crossover_state *ch_state);
 
 /* crossover init function */
-int crossover_init_coef_ch(struct sof_eq_iir_biquad_df2t *coef,
+int crossover_init_coef_ch(struct sof_eq_iir_biquad *coef,
 			   struct crossover_state *ch_state,
 			   int32_t num_sinks);
 

--- a/src/include/sof/math/iir_df1.h
+++ b/src/include/sof/math/iir_df1.h
@@ -1,0 +1,60 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2022 Intel Corporation. All rights reserved.
+ *
+ * Author: Andrula Song <andrula.song@intel.com>
+ */
+
+#ifndef __SOF_MATH_IIR_DF1_H__
+#define __SOF_MATH_IIR_DF1_H__
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define IIR_DF1_NUM_STATE 4
+
+#if defined __XCC__
+#include <xtensa/config/core-isa.h>
+#if XCHAL_HAVE_HIFI3
+#define IIR_DF1_GENERIC	0
+#define IIR_DF1_HIFI3	1
+#else
+#define IIR_DF1_GENERIC	1
+#define IIR_DF1_HIFI3	0
+#endif /* XCHAL_HAVE_HIFI3 */
+#else
+/* GCC */
+#define IIR_DF1_GENERIC	1
+#define IIR_DF1_HIFI3	0
+#endif
+
+struct iir_state_df1 {
+	unsigned int biquads; /* Number of IIR 2nd order sections total */
+	unsigned int biquads_in_series; /* Number of IIR 2nd order sections
+					 * in series.
+					 */
+	int32_t *coef; /* Pointer to IIR coefficients */
+	int32_t *delay; /* Pointer to IIR delay line */
+};
+
+struct sof_eq_iir_header;
+
+int iir_init_coef_df1(struct iir_state_df1 *iir,
+		      struct sof_eq_iir_header *config);
+
+int iir_delay_size_df1(struct sof_eq_iir_header *config);
+
+void iir_init_delay_df1(struct iir_state_df1 *iir, int32_t **state);
+
+void iir_reset_df1(struct iir_state_df1 *iir);
+
+int32_t iir_df1(struct iir_state_df1 *iir, int32_t x);
+
+/* Inline functions */
+#if IIR_DF1_HIFI3
+#include "iir_df1_hifi3.h"
+#else
+#include "iir_df1_generic.h"
+#endif
+
+#endif

--- a/src/include/sof/math/iir_df1_generic.h
+++ b/src/include/sof/math/iir_df1_generic.h
@@ -1,0 +1,34 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2022 Intel Corporation. All rights reserved.
+ *
+ * Author: Andrula Song <andrula.song@intel.com>
+ */
+
+#ifndef __IIR_DF1_GENERIC_H__
+#define __IIR_DF1_GENERIC_H__
+
+#include <stdint.h>
+
+static inline int16_t iir_df1_s16(struct iir_state_df1 *iir, int16_t x)
+{
+	return sat_int16(Q_SHIFT_RND(iir_df1(iir, ((int32_t)x) << 16), 31, 15));
+}
+
+static inline int32_t iir_df1_s24(struct iir_state_df1 *iir, int32_t x)
+{
+	return sat_int24(Q_SHIFT_RND(iir_df1(iir, x << 8), 31, 23));
+}
+
+static inline int16_t iir_df1_s32_s16(struct iir_state_df1 *iir, int32_t x)
+{
+	return sat_int16(Q_SHIFT_RND(iir_df1(iir, x), 31, 15));
+}
+
+static inline int32_t iir_df1_s32_s24(struct iir_state_df1 *iir, int32_t x)
+{
+	return sat_int24(Q_SHIFT_RND(iir_df1(iir, x), 31, 23));
+}
+
+#endif /* __IIR_DF2T_GENERIC_H__ */
+

--- a/src/include/sof/math/iir_df1_hifi3.h
+++ b/src/include/sof/math/iir_df1_hifi3.h
@@ -1,0 +1,43 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2022 Intel Corporation. All rights reserved.
+ *
+ * Author: Andrula Song <andrula.song@intel.com>
+ */
+
+#ifndef __IIR_DF1_HIFI3_H__
+#define __IIR_DF1_HIFI3_H__
+
+#include <xtensa/tie/xt_hifi3.h>
+#include <stdint.h>
+
+static inline int16_t iir_df1_s16(struct iir_state_df1 *iir, int16_t x)
+{
+	ae_f32x2 y = iir_df1(iir, ((int32_t)x) << 16);
+
+	return AE_ROUND16X4F32SSYM(y, y);
+}
+
+static inline int32_t iir_df1_s24(struct iir_state_df1 *iir, int32_t x)
+{
+	ae_f32x2 y = iir_df1(iir, x << 8);
+
+	return AE_SRAI32(AE_SLAI32S(AE_SRAI32R(y, 8), 8), 8);
+}
+
+static inline int16_t iir_df1_s32_s16(struct iir_state_df1 *iir, int32_t x)
+{
+	ae_f32x2 y = iir_df1(iir, x);
+
+	return AE_ROUND16X4F32SSYM(y, y);
+}
+
+static inline int32_t iir_df1_s32_s24(struct iir_state_df1 *iir, int32_t x)
+{
+	ae_f32x2 y = iir_df1(iir, x);
+
+	return AE_SRAI32(AE_SLAI32S(AE_SRAI32R(y, 8), 8), 8);
+}
+
+#endif /* __IIR_DF1_HIFI3_H__ */
+

--- a/src/include/sof/math/iir_df2t.h
+++ b/src/include/sof/math/iir_df2t.h
@@ -58,12 +58,12 @@ struct iir_state_df2t {
 	int64_t *delay; /* Pointer to IIR delay line */
 };
 
-struct sof_eq_iir_header_df2t;
+struct sof_eq_iir_header;
 
 int iir_init_coef_df2t(struct iir_state_df2t *iir,
-		       struct sof_eq_iir_header_df2t *config);
+		       struct sof_eq_iir_header *config);
 
-int iir_delay_size_df2t(struct sof_eq_iir_header_df2t *config);
+int iir_delay_size_df2t(struct sof_eq_iir_header *config);
 
 void iir_init_delay_df2t(struct iir_state_df2t *iir, int64_t **delay);
 

--- a/src/include/user/crossover.h
+++ b/src/include/user/crossover.h
@@ -60,7 +60,7 @@
   *                  |
   *                  o--- LR4 HP0 ---> HIGH assign_sink[1]
   *
-  *         struct sof_eq_iir_biquad_df2t coef[(num_sinks - 1)*2]
+  *         struct sof_eq_iir_biquad coef[(num_sinks - 1)*2]
   *             The coefficients data for the LR4s. Depending on many
   *             sinks are set, the number entries of this field can vary.
   *             Each entry of the array defines the coefficients for one biquad
@@ -98,7 +98,7 @@ struct sof_crossover_config {
 	uint32_t reserved[4];
 
 	uint32_t assign_sink[SOF_CROSSOVER_MAX_STREAMS];
-	struct sof_eq_iir_biquad_df2t coef[];
+	struct sof_eq_iir_biquad coef[];
 };
 
 #endif // __USER_CROSSOVER_H__

--- a/src/include/user/eq.h
+++ b/src/include/user/eq.h
@@ -114,7 +114,7 @@ struct sof_eq_iir_config {
 	int32_t data[]; /* eq_assign[channels], eq 0, eq 1, ... */
 } __attribute__((packed));
 
-struct sof_eq_iir_header_df2t {
+struct sof_eq_iir_header {
 	uint32_t num_sections;
 	uint32_t num_sections_in_series;
 
@@ -124,7 +124,7 @@ struct sof_eq_iir_header_df2t {
 	int32_t biquads[]; /* Repeated biquad coefficients */
 } __attribute__((packed));
 
-struct sof_eq_iir_biquad_df2t {
+struct sof_eq_iir_biquad {
 	int32_t a2; /* Q2.30 */
 	int32_t a1; /* Q2.30 */
 	int32_t b2; /* Q2.30 */
@@ -135,20 +135,20 @@ struct sof_eq_iir_biquad_df2t {
 } __attribute__((packed));
 
 /* A full 22th order equalizer with 11 biquads cover octave bands 1-11 in
- * in the 0 - 20 kHz bandwidth.
+ * the 0 - 20 kHz bandwidth.
  */
-#define SOF_EQ_IIR_DF2T_BIQUADS_MAX 11
+#define SOF_EQ_IIR_BIQUADS_MAX 11
 
-/* The number of int32_t words in sof_eq_iir_header_df2t:
+/* The number of int32_t words in sof_eq_iir_header:
  *	num_sections, num_sections_in_series, reserved[4]
  */
-#define SOF_EQ_IIR_NHEADER_DF2T \
-	(sizeof(struct sof_eq_iir_header_df2t) / sizeof(int32_t))
+#define SOF_EQ_IIR_NHEADER \
+	(sizeof(struct sof_eq_iir_header) / sizeof(int32_t))
 
-/* The number of int32_t words in sof_eq_iir_biquad_df2t:
+/* The number of int32_t words in sof_eq_iir_biquad:
  *	a2, a1, b2, b1, b0, output_shift, output_gain
  */
-#define SOF_EQ_IIR_NBIQUAD_DF2T \
-	(sizeof(struct sof_eq_iir_biquad_df2t) / sizeof(int32_t))
+#define SOF_EQ_IIR_NBIQUAD \
+	(sizeof(struct sof_eq_iir_biquad) / sizeof(int32_t))
 
 #endif /* __USER_EQ_H__ */

--- a/src/include/user/multiband_drc.h
+++ b/src/include/user/multiband_drc.h
@@ -46,13 +46,13 @@
   *         Crossover, and the number of DRC components.
   *     uint32_t enable_emp_deemp
   *         1=enable Emphasis and Deemphasis Equalizer; 0=disable (passthrough)
-  *     struct sof_eq_iir_biquad_df2t emp_coef[2]
+  *     struct sof_eq_iir_biquad emp_coef[2]
   *         The coefficient data for Emphasis Equalizer, which is a cascade of 2
   *         biquad filters.
-  *     struct sof_eq_iir_biquad_df2t deemp_coef[2]
+  *     struct sof_eq_iir_biquad deemp_coef[2]
   *         The coefficient data for Deemphasis Equalizer, which is a cascade of
   *         2 biquad filters.
-  *     struct sof_eq_iir_biquad_df2t crossover_coef[6]
+  *     struct sof_eq_iir_biquad crossover_coef[6]
   *         The coefficient data for Crossover LR4 filters. Please refer
   *         src/include/user/crossover.h for details. Zeros will be filled if
   *         the entries are useless. For example, when 2-way crossover is used:
@@ -70,13 +70,13 @@ struct sof_multiband_drc_config {
 	uint32_t reserved[8];
 
 	/* config of emphasis eq-iir */
-	struct sof_eq_iir_biquad_df2t emp_coef[SOF_EMP_DEEMP_BIQUADS];
+	struct sof_eq_iir_biquad emp_coef[SOF_EMP_DEEMP_BIQUADS];
 
 	/* config of deemphasis eq-iir */
-	struct sof_eq_iir_biquad_df2t deemp_coef[SOF_EMP_DEEMP_BIQUADS];
+	struct sof_eq_iir_biquad deemp_coef[SOF_EMP_DEEMP_BIQUADS];
 
 	/* config of crossover */
-	struct sof_eq_iir_biquad_df2t crossover_coef[SOF_CROSSOVER_MAX_LR4];
+	struct sof_eq_iir_biquad crossover_coef[SOF_CROSSOVER_MAX_LR4];
 
 	/* config of multi-band drc */
 	struct sof_drc_params drc_coef[];

--- a/src/math/CMakeLists.txt
+++ b/src/math/CMakeLists.txt
@@ -43,7 +43,11 @@ if(CONFIG_MATH_FFT)
 endif()
 
 if(CONFIG_MATH_IIR_DF2T)
-        add_local_sources(sof iir_df2t_generic.c iir_df2t_hifi3.c iir.c)
+        add_local_sources(sof iir_df2t_generic.c iir_df2t_hifi3.c iir_df2t.c)
+endif()
+
+if(CONFIG_MATH_IIR_DF1)
+        add_local_sources(sof iir_df1_generic.c iir_df1_hifi3.c iir_df1.c)
 endif()
 
 if(CONFIG_MATH_WINDOW)

--- a/src/math/Kconfig
+++ b/src/math/Kconfig
@@ -115,11 +115,18 @@ config MATH_FIR
 	  impulse response.
 
 config MATH_IIR_DF2T
-	bool "IIR filter library"
+	bool "IIR DF2T filter library"
 	default n
 	help
 	  Select this to build IIR (Infinite Impulse Response) filter
 	  or type 2-transposed library.
+
+config MATH_IIR_DF1
+	bool "IIR DF1 filter library"
+	default n
+	help
+	  Select this to build IIR (Infinite Impulse Response) filter
+	  or type Direct-1 library.
 
 config MATH_WINDOW
 	bool "Window functions library"

--- a/src/math/iir_df1.c
+++ b/src/math/iir_df1.c
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2022 Intel Corporation. All rights reserved.
+//
+// Author: Andrula Song <andrula.song@intel.com>
+
+#include <sof/common.h>
+#include <sof/audio/format.h>
+#include <sof/math/iir_df1.h>
+#include <user/eq.h>
+#include <errno.h>
+#include <stddef.h>
+#include <stdint.h>
+
+int iir_delay_size_df1(struct sof_eq_iir_header *config)
+{
+	int n = config->num_sections; /* One section uses two unit delays */
+
+	if (n > SOF_EQ_IIR_BIQUADS_MAX || n < 1)
+		return -EINVAL;
+
+	return 4 * n * sizeof(int32_t);
+}
+
+int iir_init_coef_df1(struct iir_state_df1 *iir,
+		      struct sof_eq_iir_header *config)
+{
+	iir->biquads = config->num_sections;
+	iir->biquads_in_series = config->num_sections_in_series;
+	iir->coef = ASSUME_ALIGNED(&config->biquads[0], 4);
+
+	return 0;
+}
+
+void iir_init_delay_df1(struct iir_state_df1 *iir, int32_t **delay)
+{
+	/* Set state line of this IIR */
+	iir->delay = *delay;
+
+	/* Point to next IIR delay line start. */
+	*delay += 4 * iir->biquads;
+}
+
+void iir_reset_df1(struct iir_state_df1 *iir)
+{
+	iir->biquads = 0;
+	iir->biquads_in_series = 0;
+	iir->coef = NULL;
+	/* Note: May need to know the beginning of dynamic allocation after so
+	 * omitting setting iir->delay to NULL.
+	 */
+}

--- a/src/math/iir_df1_generic.c
+++ b/src/math/iir_df1_generic.c
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2022 Intel Corporation. All rights reserved.
+//
+// Author: Andrula Song <andrula.song@intel.com>
+
+#include <stdint.h>
+#include <stddef.h>
+#include <errno.h>
+#include <sof/audio/format.h>
+#include <sof/math/iir_df1.h>
+#include <user/eq.h>
+
+#if IIR_DF1_GENERIC
+
+/*
+ * Direct form I second order filter block (biquad)
+ *
+ *              +----+                            +---+    +-------+
+ * X(z) ---o--->| b0 |---> + --+-------------o--->| g |--->| shift |---> Y(z)
+ *         |    +----+     ^   ^             |    +---+    +-------+
+ *         |               |   |             |
+ *     +------+            |   |          +------+
+ *     | z^-1 |            |   |          | z^-1 |
+ *     +------+            |   |          +------+
+ *         |    +----+     |   |     +----+   |
+ *         o--->| b1 |---> +   + <---| a1 |---o
+ *         |    +----+     ^   ^     +----+   |
+ *         |               |   |              |
+ *     +------+            |   |          +------+
+ *     | z^-1 |            |   |          | z^-1 |
+ *     +------+            |   |          +------+
+ *         |               ^   ^              |
+ *         |    +----+     |   |     +----+   |
+ *         o--->| b2 |---> +   +<--- | a2 |---o
+ *              +----+               +----+
+ *
+ * y[n] = b0 * x[n] + b1 * x[n-1] + b2 * x[n-2] + a1 * y[n-1] + a2 * y[n-2]
+ * the a1 a2 has been negated during calculation
+ */
+
+/* Series DF1 IIR */
+
+/* 32 bit data, 32 bit coefficients and 32 bit state variables */
+
+int32_t iir_df1(struct iir_state_df1 *iir, int32_t x)
+{
+	int32_t in;
+	int32_t tmp;
+	int64_t out = 0;
+	int64_t acc;
+	int i;
+	int j;
+	int d = 0; /* Index to state */
+	int c = 0; /* Index to coefficient a2 */
+	int32_t *coefp = iir->coef;
+	int32_t *delay = iir->delay;
+	int nseries = iir->biquads_in_series;
+
+	/* Bypass is set with number of biquads set to zero. */
+	if (!iir->biquads)
+		return x;
+
+	/* Coefficients order in coef[] is {a2, a1, b2, b1, b0, shift, gain} */
+	/* Delay order in state[] is {y(n - 2), y(n - 1), x(n - 2), x(n - 1)} */
+	for (j = 0; j < iir->biquads; j += nseries) {
+		in = x;
+		for (i = 0; i < nseries; i++) {
+			/* Compute output: Delay is Q3.61
+			 * Q2.30 x Q1.31 -> Q3.61
+			 * Shift Q3.61 to Q3.31 with rounding, saturate to Q1.31
+			 */
+			acc = ((int64_t)coefp[c]) * delay[d]; /* a2 * y(n - 2) */
+			acc += ((int64_t)coefp[c + 1]) * delay[d + 1]; /* a1 * y(n - 1) */
+			acc += ((int64_t)coefp[c + 2]) * delay[d + 2]; /* b2 * x(n - 2) */
+			acc += ((int64_t)coefp[c + 3]) * delay[d + 3]; /* b1 * x(n - 1) */
+			acc += ((int64_t)coefp[c + 4]) * in; /* b0 * x */
+			tmp = (int32_t)sat_int32(Q_SHIFT_RND(acc, 61, 31));
+
+			/* update the delay value */
+			delay[d] = delay[d + 1];
+			delay[d + 1] = tmp;
+			delay[d + 2] = delay[d + 3];
+			delay[d + 3] = in;
+
+			/* Apply gain Q2.14 x Q1.31 -> Q3.45 */
+			acc = ((int64_t)coefp[c + 6]) * tmp; /* Gain */
+
+			/* Apply biquad output shift right parameter
+			 * simultaneously with Q3.45 to Q3.31 conversion. Then
+			 * saturate to 32 bits Q1.31 and prepare for next
+			 * biquad.
+			 */
+			acc = Q_SHIFT_RND(acc, 45 + coefp[c + 5], 31);
+			in = sat_int32(acc);
+
+			/* Proceed to next biquad coefficients and delay
+			 * lines.
+			 */
+			c += SOF_EQ_IIR_NBIQUAD;
+			d += IIR_DF1_NUM_STATE;
+		}
+		/* Output of previous section is in variable in */
+		out += (int64_t)in;
+	}
+	return sat_int32(out);
+}
+
+#endif

--- a/src/math/iir_df1_hifi3.c
+++ b/src/math/iir_df1_hifi3.c
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2022 Intel Corporation. All rights reserved.
+//
+// Author: Andrula Song <andrula.song@intel.com>
+
+#include <stdint.h>
+#include <stddef.h>
+#include <errno.h>
+#include <sof/audio/format.h>
+#include <sof/math/iir_df1.h>
+#include <user/eq.h>
+
+#if IIR_DF1_HIFI3
+
+/*
+ * Direct form I second order filter block (biquad)
+ *
+ *              +----+                            +---+    +-------+
+ * X(z) ---o--->| b0 |---> + --+-------------o--->| g |--->| shift |---> Y(z)
+ *         |    +----+     ^   ^             |    +---+    +-------+
+ *         |               |   |             |
+ *     +------+            |   |          +------+
+ *     | z^-1 |            |   |          | z^-1 |
+ *     +------+            |   |          +------+
+ *         |    +----+     |   |     +----+   |
+ *         o--->| b1 |---> +   + <---| a1 |---o
+ *         |    +----+     ^   ^     +----+   |
+ *         |               |   |              |
+ *     +------+            |   |          +------+
+ *     | z^-1 |            |   |          | z^-1 |
+ *     +------+            |   |          +------+
+ *         |               ^   ^              |
+ *         |    +----+     |   |     +----+   |
+ *         o--->| b2 |---> +   +<--- | a2 |---o
+ *              +----+               +----+
+ *
+ * y[n] = b0 * x[n] + b1 * x[n-1] + b2 * x[n-2] + a1 * y[n-1] + a2 * y[n-2]
+ * the a1 a2 has been negated during calculation
+ */
+
+/* Series DF1 IIR */
+
+/* 32 bit data, 32 bit coefficients and 32 bit state variables */
+
+int32_t iir_df1(struct iir_state_df1 *iir, int32_t x)
+{
+	ae_int64 acc;
+	ae_valign coef_align = AE_ZALIGN64();
+	ae_int32x2 coef_a2a1;
+	ae_int32x2 coef_b2b1;
+	ae_int32x2 coef_b0;
+	ae_int32x2 gain;
+	ae_int32x2 shift;
+	ae_int32x2 delay_y2y1;
+	ae_int32x2 delay_x2x1;
+	ae_int32 in;
+	ae_int32 tmp;
+	ae_int32x2 *coefp;
+	ae_int32x2 *delayp;
+	ae_int32 out = 0;
+	int32_t *delay_update;
+	int i;
+	int j;
+	int nseries = iir->biquads_in_series;
+
+	/* Bypass is set with number of biquads set to zero. */
+	if (!iir->biquads)
+		return x;
+
+	/* Coefficients order in coef[] is {a2, a1, b2, b1, b0, shift, gain} */
+	coefp = (ae_int32x2 *)&iir->coef[0];
+	delayp = (ae_int32x2 *)&iir->delay[0];
+	for (j = 0; j < iir->biquads; j += nseries) {
+		/* the first for loop is for parallel EQs, and they have the same input */
+		in = x;
+		for (i = 0; i < nseries; i++) {
+			/* Compute output: Delay is kept Q17.47 while multiply
+			 * instruction gives Q2.30 x Q1.31 -> Q18.46. Need to
+			 * shift delay line values right by one for same align
+			 * as MAC. Store to delay line need to be shifted left
+			 * by one similarly.
+			 */
+			coef_align = AE_LA64_PP(coefp);
+			AE_LA32X2_IP(coef_a2a1, coef_align, coefp);
+			AE_LA32X2_IP(coef_b2b1, coef_align, coefp);
+			AE_L32_IP(coef_b0, (ae_int32 *)coefp, 4);
+			AE_L32_IP(shift, (ae_int32 *)coefp, 4);
+			AE_L32_IP(gain, (ae_int32 *)coefp, 4);
+
+			AE_L32X2_IP(delay_y2y1, delayp, 8);
+			AE_L32X2_IP(delay_x2x1, delayp, 8);
+
+			acc = AE_MULF32R_HH(coef_a2a1, delay_y2y1); /* a2 * y(n - 2) */
+			AE_MULAF32R_LL(acc, coef_a2a1, delay_y2y1); /* a1 * y(n - 1) */
+			AE_MULAF32R_HH(acc, coef_b2b1, delay_x2x1); /* b2 * x(n - 2) */
+			AE_MULAF32R_LL(acc, coef_b2b1, delay_x2x1); /* b1 * x(n - 1) */
+			AE_MULAF32R_HH(acc, coef_b0, in); /*  b0 * x  */
+			acc = AE_SLAI64S(acc, 1); /* Convert to Q17.47 */
+			tmp = AE_ROUND32F48SSYM(acc); /* Round to Q1.31 */
+
+			/* update the state value */
+			delay_update = (int32_t *)delayp - 4;
+			delay_update[0] = delay_update[1];
+			delay_update[1] = tmp;
+			delay_update[2] = delay_update[3];
+			delay_update[3] = in;
+
+			/* Apply gain Q18.14 x Q1.31 -> Q34.30 */
+			acc = AE_MULF32R_HH(gain, tmp); /* Gain */
+			acc = AE_SLAI64S(acc, 17); /* Convert to Q17.47 */
+
+			/* Apply biquad output shift right parameter and then
+			 * round and saturate to 32 bits Q1.31.
+			 */
+			acc = AE_SRAA64(acc, shift);
+			in = AE_ROUND32F48SSYM(acc);
+		}
+		/* Output of previous section is in variable in */
+		out = AE_F32_ADDS_F32(out, in);
+	}
+	return out;
+}
+
+#endif

--- a/src/math/iir_df2t.c
+++ b/src/math/iir_df2t.c
@@ -14,18 +14,18 @@
 #include <stddef.h>
 #include <stdint.h>
 
-int iir_delay_size_df2t(struct sof_eq_iir_header_df2t *config)
+int iir_delay_size_df2t(struct sof_eq_iir_header *config)
 {
 	int n = config->num_sections; /* One section uses two unit delays */
 
-	if (n > SOF_EQ_IIR_DF2T_BIQUADS_MAX || n < 1)
+	if (n > SOF_EQ_IIR_BIQUADS_MAX || n < 1)
 		return -EINVAL;
 
 	return 2 * n * sizeof(int64_t);
 }
 
 int iir_init_coef_df2t(struct iir_state_df2t *iir,
-		       struct sof_eq_iir_header_df2t *config)
+		       struct sof_eq_iir_header *config)
 {
 	iir->biquads = config->num_sections;
 	iir->biquads_in_series = config->num_sections_in_series;

--- a/src/math/iir_df2t_generic.c
+++ b/src/math/iir_df2t_generic.c
@@ -96,7 +96,7 @@ int32_t iir_df2t(struct iir_state_df2t *iir, int32_t x)
 			/* Proceed to next biquad coefficients and delay
 			 * lines.
 			 */
-			c += SOF_EQ_IIR_NBIQUAD_DF2T;
+			c += SOF_EQ_IIR_NBIQUAD;
 			d += IIR_DF2T_NUM_DELAYS;
 		}
 		/* Output of previous section is in variable in */

--- a/src/math/iir_df2t_hifi3.c
+++ b/src/math/iir_df2t_hifi3.c
@@ -91,7 +91,7 @@ int32_t iir_df2t(struct iir_state_df2t *iir, int32_t x)
 			delayp++; /* Point to d1 */
 			AE_MULAF32R_HH(acc, coef_b0shift, in); /* Coef b0 */
 			acc = AE_SLAI64S(acc, 1); /* Convert to Q17.47 */
-			tmp = AE_ROUND32F48SSYM(acc); /* Rount to Q1.31 */
+			tmp = AE_ROUND32F48SSYM(acc); /* Round to Q1.31 */
 
 			/* Compute 1st delay d0 */
 			acc = AE_SRAI64(*delayp, 1); /* Convert d1 to Q18.46 */

--- a/test/cmocka/src/audio/eq_iir/CMakeLists.txt
+++ b/test/cmocka/src/audio/eq_iir/CMakeLists.txt
@@ -13,9 +13,12 @@ add_compile_options(-DUNIT_TEST)
 
 add_library(audio_for_eq_iir STATIC
 	${PROJECT_SOURCE_DIR}/src/audio/eq_iir/eq_iir.c
-	${PROJECT_SOURCE_DIR}/src/math/iir.c
-        ${PROJECT_SOURCE_DIR}/src/math/iir_df2t_generic.c
-        ${PROJECT_SOURCE_DIR}/src/math/iir_df2t_hifi3.c
+	${PROJECT_SOURCE_DIR}/src/math/iir_df1.c
+       ${PROJECT_SOURCE_DIR}/src/math/iir_df1_generic.c
+       ${PROJECT_SOURCE_DIR}/src/math/iir_df1_hifi3.c
+	${PROJECT_SOURCE_DIR}/src/math/iir_df2t.c
+       ${PROJECT_SOURCE_DIR}/src/math/iir_df2t_generic.c
+       ${PROJECT_SOURCE_DIR}/src/math/iir_df2t_hifi3.c
 	${PROJECT_SOURCE_DIR}/src/audio/buffer.c
 	${PROJECT_SOURCE_DIR}/src/audio/component.c
 	${PROJECT_SOURCE_DIR}/src/audio/data_blob.c

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -626,10 +626,19 @@ zephyr_library_sources_ifdef(CONFIG_COMP_FIR
 )
 
 zephyr_library_sources_ifdef(CONFIG_COMP_IIR
+	${SOF_AUDIO_PATH}/eq_iir/eq_iir.c
+)
+
+zephyr_library_sources_ifdef(CONFIG_MATH_IIR_DF1
+	${SOF_MATH_PATH}/iir_df1_generic.c
+	${SOF_MATH_PATH}/iir_df1_hifi3.c
+	${SOF_MATH_PATH}/iir_df1.c
+)
+
+zephyr_library_sources_ifdef(CONFIG_MATH_IIR_DF2T
 	${SOF_MATH_PATH}/iir_df2t_generic.c
 	${SOF_MATH_PATH}/iir_df2t_hifi3.c
-	${SOF_MATH_PATH}/iir.c
-	${SOF_AUDIO_PATH}/eq_iir/eq_iir.c
+	${SOF_MATH_PATH}/iir_df2t.c
 )
 
 zephyr_library_sources_ifdef(CONFIG_COMP_ASRC


### PR DESCRIPTION
Add C version Direct-1 format implementation for IIR. Compared with the original Direct-2 transport format, Direct-1 has better performance on low frequency since lower quantization noise.

Signed-off-by: Andrula Song <xiaoyuan.song@intel.com>