### PR TITLE
module_adapter: Fix compile time error

### DIFF
--- a/src/audio/module_adapter/module/passthrough.c
+++ b/src/audio/module_adapter/module/passthrough.c
@@ -107,7 +107,7 @@ static int passthrough_codec_reset(struct processing_module *mod)
 
 static int passthrough_codec_free(struct processing_module *mod)
 {
-	comp_info(dev, "passthrough_codec_free()");
+	comp_info(mod->dev, "passthrough_codec_free()");
 
 	/* Nothing to do */
 	return 0;


### PR DESCRIPTION
After commit e101aadcd1dc98 ("module_adapter: drop the comp_get_module_data() macro") API prototype was changed to accept a `processing_module` instead of a `comp_dev` but `dev` was still used inside passthrough_codec_free which generates a compile time error:

src/audio/module_adapter/module/passthrough.c:110:12: error: 'dev' undeclared (first use in this function)
  comp_info(dev, "passthrough_codec_free()");

Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>