### PR TITLE
[SKIP CI] Tools: Test: Audio: Fix standard low-pass help text

### DIFF
--- a/tools/test/audio/std_utils/stdlpf.m
+++ b/tools/test/audio/std_utils/stdlpf.m
@@ -1,8 +1,8 @@
 function y = stdlpf(x, fu, fs)
 
-%% y = stdhpf(x, fu, fs)
+%% y = stdlpf(x, fu, fs)
 %
-% Standard high-pass filter
+% Standard low-pass filter
 %
 % Input
 % x - input signal

--- a/tools/test/audio/std_utils/stdlpf_get.m
+++ b/tools/test/audio/std_utils/stdlpf_get.m
@@ -2,7 +2,7 @@ function b = stdlpf_get(fu, fs)
 
 %% b = stdlpf_get(fu, fs)
 %
-% Standard loww-pass filter
+% Standard low-pass filter
 %
 % Input
 % fu - upper band-edge frequency


### PR DESCRIPTION
Fix a confusing mistake high-pass -> low_pass and typo. It's only a user help text change for "help stdlpf".

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>