### PR TITLE
ipc4: handler: skip trigger if pipeline is already paused

### DIFF
--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -312,7 +312,8 @@ static int set_pipeline_state(uint32_t id, uint32_t cmd, bool *delayed, uint32_t
 			return ret;
 		}
 
-		if (status == COMP_STATE_READY)
+		/* return if pipeline is not active yet or if it is already paused */
+		if (status == COMP_STATE_READY || status == COMP_STATE_PAUSED)
 			return 0;
 
 		cmd = COMP_TRIGGER_PAUSE;


### PR DESCRIPTION
This will avoid the pipeline walk and all the NOP's in each module trigger when the pipeline is already paused.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>