### PR TITLE
ipc4: helper: Fix module unbinding 

### DIFF
--- a/src/audio/pipeline/pipeline-graph.c
+++ b/src/audio/pipeline/pipeline-graph.c
@@ -239,6 +239,7 @@ void pipeline_disconnect(struct comp_dev *comp, struct comp_buffer *buffer, int 
 		dcache_writeback_invalidate_region(uncache_to_cache(buf_list->prev),
 						   sizeof(struct list_item));
 	list_item_del(buf_list);
+	buffer_set_comp(buffer, NULL, dir);
 	irq_local_enable(flags);
 }
 

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -357,7 +357,6 @@ int ipc_comp_disconnect(struct ipc *ipc, ipc_pipe_comp_connect *_connect)
 	struct comp_dev *src, *sink;
 	struct list_item *sink_list;
 	uint32_t src_id, sink_id, buffer_id;
-	uint32_t flags;
 	int ret;
 
 	bu = (struct ipc4_module_bind_unbind *)_connect;
@@ -392,10 +391,8 @@ int ipc_comp_disconnect(struct ipc *ipc, ipc_pipe_comp_connect *_connect)
 	if (!buffer)
 		return IPC4_INVALID_RESOURCE_ID;
 
-	irq_local_disable(flags);
-	list_item_del(buffer_comp_list(buffer, PPL_CONN_DIR_COMP_TO_BUFFER));
-	list_item_del(buffer_comp_list(buffer, PPL_CONN_DIR_BUFFER_TO_COMP));
-	irq_local_enable(flags);
+	pipeline_disconnect(src, buffer, PPL_CONN_DIR_COMP_TO_BUFFER);
+	pipeline_disconnect(sink, buffer, PPL_CONN_DIR_BUFFER_TO_COMP);
 
 	buffer_free(buffer);
 


### PR DESCRIPTION
When 2 modules are bound together, they are bound with a buffer between them with the connection like this : source_module->buffer->sink_module.

So, what this means is that there is only one connection going from a module to the buffer. So, calling pipeline_disconnect() from the same module to the same buffer in both directions makes no sense.

The right way to free a module would be first disconnect the module from the sink buffer, then check if the sink buffer has been disconnected from its sink module. If so, the buffer should be freed. Otherwise the buffer will be freed whenever the sink module is disconnected from it. The same thing must be repeated for the module's source buffer as well.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>