### PR TITLE
xtensa-build-zephyr.py: pass -j option to west -> ninja

### DIFF
--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -410,7 +410,8 @@ def create_zephyr_sof_symlink():
 def west_update():
 	"""[summary] Clones all west manifest projects to specified revisions"""
 	global west_top
-	execute_command(["west", "update"], check=True, timeout=3000, cwd=west_top)
+	execute_command(["west", "update" , "--narrow", "--fetch-opt=--depth=5"],
+			timeout=3000, cwd=west_top)
 
 
 def get_build_and_sof_version(abs_build_dir):


### PR DESCRIPTION
This is especially useful when compiling each C file requires a network round-trip to a license server

Also stop overriding the ninja default when building rimage.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>