### PR TITLE
Audio: SRC: Fix SRC FIR off-by-one frame issue (generic, HiFi 2EP/3/4)

### DIFF
--- a/src/audio/src/src_generic.c
+++ b/src/audio/src/src_generic.c
@@ -246,8 +246,7 @@ void src_polyphase_stage_cir(struct src_stage_prm *s)
 	const int blk_in_words = nch * cfg->blk_in;
 	const int blk_out_words = nch * cfg->num_of_subfilters;
 	const int fir_length = fir->fir_delay_size;
-	const int rewind = nch * (cfg->blk_in
-		+ (cfg->num_of_subfilters - 1) * cfg->idm) - nch;
+	const int rewind = nch * (cfg->blk_in + (cfg->num_of_subfilters - 1) * cfg->idm);
 	const int nch_x_idm = nch * cfg->idm;
 	const size_t fir_size = fir->fir_delay_size * sizeof(int32_t);
 	const int taps_x_nch = cfg->subfilter_length * nch;
@@ -347,8 +346,7 @@ void src_polyphase_stage_cir_s16(struct src_stage_prm *s)
 	const int blk_in_words = nch * cfg->blk_in;
 	const int blk_out_words = nch * cfg->num_of_subfilters;
 	const int fir_length = fir->fir_delay_size;
-	const int rewind = nch * (cfg->blk_in
-		+ (cfg->num_of_subfilters - 1) * cfg->idm) - nch;
+	const int rewind = nch * (cfg->blk_in + (cfg->num_of_subfilters - 1) * cfg->idm);
 	const int nch_x_idm = nch * cfg->idm;
 	const size_t fir_size = fir->fir_delay_size * sizeof(int32_t);
 	const int taps_x_nch = cfg->subfilter_length * nch;

--- a/src/audio/src/src_hifi2ep.c
+++ b/src/audio/src/src_hifi2ep.c
@@ -323,8 +323,7 @@ void src_polyphase_stage_cir(struct src_stage_prm *s)
 	const int blk_out_words = nch * cfg->num_of_subfilters;
 	const int sz = sizeof(int32_t);
 	const int n_sz = -sizeof(int32_t);
-	const int rewind_sz = sz * (nch * (cfg->blk_in
-		+ (cfg->num_of_subfilters - 1) * cfg->idm) - nch);
+	const int rewind_sz = sz * nch * (cfg->blk_in + (cfg->num_of_subfilters - 1) * cfg->idm);
 	const int nch_x_idm_sz = -nch * cfg->idm * sizeof(int32_t);
 	const int taps_div_4 = cfg->subfilter_length >> 2;
 	int32_t *x_rptr = (int32_t *)s->x_rptr;
@@ -449,8 +448,7 @@ void src_polyphase_stage_cir_s16(struct src_stage_prm *s)
 	const int blk_out_words = nch * cfg->num_of_subfilters;
 	const int sz = sizeof(int32_t);
 	const int n_sz = -sizeof(int32_t);
-	const int rewind_sz = sz * (nch * (cfg->blk_in
-		+ (cfg->num_of_subfilters - 1) * cfg->idm) - nch);
+	const int rewind_sz = sz * nch * (cfg->blk_in + (cfg->num_of_subfilters - 1) * cfg->idm);
 	const int nch_x_idm_sz = -nch * cfg->idm * sizeof(int32_t);
 	const int taps_div_4 = cfg->subfilter_length >> 2;
 	int16_t *x_rptr = (int16_t *)s->x_rptr;

--- a/src/audio/src/src_hifi3.c
+++ b/src/audio/src/src_hifi3.c
@@ -327,8 +327,7 @@ void src_polyphase_stage_cir(struct src_stage_prm *s)
 	const int blk_out_words = nch * cfg->num_of_subfilters;
 	const int sz = sizeof(int32_t);
 	const int n_sz = -sizeof(int32_t);
-	const int rewind_sz = sz * (nch * (cfg->blk_in
-		+ (cfg->num_of_subfilters - 1) * cfg->idm) - nch);
+	const int rewind_sz = sz * nch * (cfg->blk_in + (cfg->num_of_subfilters - 1) * cfg->idm);
 	const int nch_x_idm_sz = -nch * cfg->idm * sizeof(int32_t);
 	const int taps_div_4 = cfg->subfilter_length >> 2;
 	int32_t *x_rptr = (int32_t *)s->x_rptr;
@@ -454,8 +453,7 @@ void src_polyphase_stage_cir_s16(struct src_stage_prm *s)
 	const int blk_out_words = nch * cfg->num_of_subfilters;
 	const int sz = sizeof(int32_t);
 	const int n_sz = -sizeof(int32_t);
-	const int rewind_sz = sz * (nch * (cfg->blk_in
-		+ (cfg->num_of_subfilters - 1) * cfg->idm) - nch);
+	const int rewind_sz = sz * nch * (cfg->blk_in + (cfg->num_of_subfilters - 1) * cfg->idm);
 	const int nch_x_idm_sz = -nch * cfg->idm * sizeof(int32_t);
 	const int taps_div_4 = cfg->subfilter_length >> 2;
 	int16_t *x_rptr = (int16_t *)s->x_rptr;

--- a/src/audio/src/src_hifi4.c
+++ b/src/audio/src/src_hifi4.c
@@ -334,8 +334,7 @@ void src_polyphase_stage_cir(struct src_stage_prm *s)
 	const int blk_out_words = nch * cfg->num_of_subfilters;
 	const int sz = sizeof(int32_t);
 	const int n_sz = -sizeof(int32_t);
-	const int rewind_sz = sz * (nch * (cfg->blk_in
-		+ (cfg->num_of_subfilters - 1) * cfg->idm) - nch);
+	const int rewind_sz = sz * nch * (cfg->blk_in + (cfg->num_of_subfilters - 1) * cfg->idm);
 	const int nch_x_idm_sz = -nch * cfg->idm * sizeof(int32_t);
 	const int taps_div_4 = cfg->subfilter_length >> 2;
 	int32_t *x_rptr = (int32_t *)s->x_rptr;
@@ -457,8 +456,7 @@ void src_polyphase_stage_cir_s16(struct src_stage_prm *s)
 	const int blk_out_words = nch * cfg->num_of_subfilters;
 	const int sz = sizeof(int32_t);
 	const int n_sz = -sizeof(int32_t);
-	const int rewind_sz = sz * (nch * (cfg->blk_in
-		+ (cfg->num_of_subfilters - 1) * cfg->idm) - nch);
+	const int rewind_sz = sz * nch * (cfg->blk_in + (cfg->num_of_subfilters - 1) * cfg->idm);
 	const int nch_x_idm_sz = -nch * cfg->idm * sizeof(int32_t);
 	const int taps_div_4 = cfg->subfilter_length >> 2;
 	int16_t *x_rptr = (int16_t *)s->x_rptr;


### PR DESCRIPTION
This patch fixes the pointer arithmetic to start FIR calculation from latest written PCM frame pointer. The rewind step was too small and caused the first FIR coefficient to be multiplied with the eldest frame in delay line while it should have pointed to youngest. The second coefficient multiplied with youngest, etc.

The time shift for FIR coefficient caused a difference to filter response vs. designed. Since especially in longer filters the first tap value is near zero the impact was hard to notice.

The "easy" conversions such as 8 kHz to 48 kHz with short filters and larger first tap values suffered most of this.

With this change THD+N for 8 kHz to 48 kHz improves:

```
		16 bits		24 bits		32 bits
Before		-60.59 dB		-63.98 dB		-63.98 dB
After		-62.35 dB		-80.39 dB		-80.40 dB

44.1 kHz to 48 kHz no impact:

		16 bits		24 bits		32 bits
Before		-62.36		-85.69		-85.72
After		-62.35		-85.69		-85.72
```

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>