### PR TITLE
Fix cavs-mixin-mixout-hda.conf

### DIFF
--- a/tools/topology/topology2/cavs/cavs-mixin-mixout-hda.conf
+++ b/tools/topology/topology2/cavs/cavs-mixin-mixout-hda.conf
@@ -57,32 +57,29 @@ Object.Pipeline {
 		}
 	}
 
-	mixout-gain-host-copier-capture.0 {
-		index 3
-
+	passthrough-capture.1 {
+		index 	3
 		Object.Widget.copier.1 {
 			stream_name $ANALOG_CAPTURE_PCM
 		}
-
-		Object.Widget.gain.1 {
-			Object.Control.mixer.1 {
-				name '3 2nd Capture Volume'
-			}
-		}
 	}
 
-	dai-copier-gain-mixin-capture.0 {
-		index 4
+	passthrough-be.1 {
+		index		4
+		direction	capture
 
-		Object.Widget.copier.1 {
-			stream_name $HDA_ANALOG_DAI_NAME
-			dai_type "HDA"
-			copier_type "HDA"
-		}
-
-		Object.Widget.gain.1 {
-			Object.Control.mixer.1 {
-				name '4 Main Capture Volume'
+		Object.Widget.copier."1" {
+			dai_type 	"HDA"
+			type		"dai_out"
+			copier_type	"HDA"
+			stream_name	$HDA_ANALOG_DAI_NAME
+			node_type	$HDA_LINK_INPUT_CLASS
+			Object.Base.audio_format.1 {
+				in_bit_depth		32
+				in_valid_bit_depth	32
+				out_bit_depth		32
+				out_valid_bit_depth	32
+				dma_buffer_size "$[$ibs * 2]"
 			}
 		}
 	}
@@ -128,13 +125,9 @@ Object.Base {
 	}
 	route.3 {
 		source 'copier.HDA.4.1'
-		sink 'gain.4.1'
+		sink 'copier.host.3.1'
 	}
 	route.4 {
-		source 'mixin.4.1'
-		sink 'mixout.3.1'
-	}
-	route.5 {
 		source 'mixin.5.1'
 		sink 'mixout.2.1'
 	}

--- a/tools/topology/topology2/cavs/cavs-passthrough-hdmi.conf
+++ b/tools/topology/topology2/cavs/cavs-passthrough-hdmi.conf
@@ -44,7 +44,6 @@ IncludeByKey.PLATFORM {
 
 # include HDA config if needed.
 IncludeByKey.HDA_CONFIG {
-	"passthrough"	"cavs-passthrough-hda.conf"
 	"mix"		"cavs-mixin-mixout-hda.conf"
 }
 


### PR DESCRIPTION
mixin/mixout can only be used for playback. So remove it from the HDA capture pipeline and use the passthrough instead.