### PR TITLE
rtnr: Cherry-pick period setting for RTNR from main to mt8195/v0.4 branch

### DIFF
--- a/tools/topology/topology1/sof-mt8195-mt6359-rt1019-rt5682.m4
+++ b/tools/topology/topology1/sof-mt8195-mt6359-rt1019-rt5682.m4
@@ -53,7 +53,15 @@ define(matrix2, `ROUTE_MATRIX(3,
 
 ifdef(`GOOGLE_RTC_AUDIO_PROCESSING', `MUXDEMUX_CONFIG(demux_priv_1, 2, LIST_NONEWLINE(`', `matrix1,', `matrix2'))')
 ifdef(`GOOGLE_RTC_AUDIO_PROCESSING', `define(`SPK_PERIOD_US', 10000)', `define(`SPK_PERIOD_US', 1000)')
-ifdef(`GOOGLE_RTC_AUDIO_PROCESSING', `define(`MIC_PERIOD_US', 10000)', `define(`MIC_PERIOD_US', 2000)')
+
+ifdef(`GOOGLE_RTC_AUDIO_PROCESSING',
+	`define(`MIC_PERIOD_US', 10000)'
+	,
+	`ifdef(`RTNR',
+# 5ms period is required for RTNR build 20220728 and later versions
+		`define(`MIC_PERIOD_US', 5000)',
+        `define(`MIC_PERIOD_US', 2000)')'
+)
 
 #
 # Define the pipelines


### PR DESCRIPTION
With the  release of RTNR version 20220728,
period for capturing pipeline requires at least 5ms.

This commit set 5ms period for RTNR in
MT8195 topology.

Signed-off-by: Ming Jen Tai <mingjen_tai@realtek.com>
(cherry picked from commit d77331fce1aa2a7056f310712a3fc3372ec405b1)