### PR TITLE
xtensa-build-zephyr.py: de-hardcode mode=511 in mkdir()

### DIFF
--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -389,7 +389,7 @@ def create_zephyr_directory():
 		# _better_ error message:
 		#         "zephyrproject already exists"
 
-	west_top.mkdir(mode=511, parents=False, exist_ok=False)
+	west_top.mkdir(parents=False, exist_ok=False)
 	west_top = west_top.resolve(strict=True)
 
 def create_zephyr_sof_symlink():
@@ -397,7 +397,7 @@ def create_zephyr_sof_symlink():
 	if not west_top.exists():
 		raise FileNotFoundError("No west top: {}".format(west_top))
 	audio_modules_dir = pathlib.Path(west_top, "modules", "audio")
-	audio_modules_dir.mkdir(mode=511, parents=True, exist_ok=True)
+	audio_modules_dir.mkdir(parents=True, exist_ok=True)
 	sof_symlink = pathlib.Path(audio_modules_dir, "sof")
 	# Symlinks creation requires administrative privileges in Windows or special user rights
 	try:
@@ -457,7 +457,7 @@ def build_platforms():
 
 	# smex does not use 'install -D'
 	sof_output_dir = pathlib.Path(STAGING_DIR, "sof")
-	sof_output_dir.mkdir(mode=511, parents=True, exist_ok=True)
+	sof_output_dir.mkdir(parents=True, exist_ok=True)
 	for platform in args.platforms:
 		if args.use_platform_subdir:
 			sof_platform_output_dir = pathlib.Path(sof_output_dir, platform)


### PR DESCRIPTION
These hardcoded 511 permissions came with the initial commit 1de3ef367584 ("Rewritten xtensa-build-zephyr.sh to python") without any particular explanation.

On Unix, permissions of new files and directories are a user preference set with the `umask`, different applications are not supposed to create directories differently.

On Windows/NTFS it's not clear what 511 maps to.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>