### PR TITLE
Revise mt8186 ADSP clock driver

### DIFF
--- a/src/drivers/mediatek/mt8186/ipc.c
+++ b/src/drivers/mediatek/mt8186/ipc.c
@@ -85,8 +85,10 @@ enum task_state ipc_platform_do_cmd(struct ipc *ipc)
 void ipc_platform_complete_cmd(struct ipc *ipc)
 {
 	trigger_irq_to_host_rsp();
-	while (ipc->pm_prepare_D3)
-		wait_for_interrupt(0);
+	while (ipc->pm_prepare_D3) {
+		clock_set_freq(CLK_CPU(cpu_get_id()), CLK_DEFAULT_CPU_HZ);
+		asm volatile("waiti 15");
+	}
 }
 
 int ipc_platform_send_msg(const struct ipc_msg *msg)

--- a/src/platform/mt8186/include/platform/lib/clk.h
+++ b/src/platform/mt8186/include/platform/lib/clk.h
@@ -20,7 +20,7 @@ struct sof;
 #define CLK_DEFAULT_CPU_HZ			26000000
 #define CLK_MAX_CPU_HZ				800000000
 #define NUM_CLOCKS				1
-#define NUM_CPU_FREQ				5
+#define NUM_CPU_FREQ				3
 
 /* MTK_ADSP_CLK_BUS_UPDATE */
 #define MTK_ADSP_CLK_BUS_UPDATE_BIT		BIT(31)
@@ -41,6 +41,13 @@ struct sof;
 #define MTK_CLK_ADSP_DSPPLL_2			3
 #define MTK_CLK_ADSP_DSPPLL_4			4
 #define MTK_CLK_ADSP_DSPPLL_8			5
+
+#define MTK_PLL_BASE_EN				BIT(0)
+#define MTK_PLL_PWR_ON				BIT(0)
+#define MTK_PLL_ISO_EN				BIT(1)
+
+#define MTK_PLL_DIV_RATIO_800M			0x810F6276
+#define MTK_PLL_DIV_RATIO_400M			0x831EC4ED
 
 /* List resource from low to high request */
 /* 0 is the lowest request */

--- a/src/platform/mt8186/lib/clk.c
+++ b/src/platform/mt8186/lib/clk.c
@@ -83,6 +83,7 @@ static void set_mux_adsp_bus_src_sel(uint32_t value)
 {
 	io_reg_write(MTK_ADSP_BUS_SRC, value);
 	io_reg_write(MTK_ADSP_CLK_BUS_UPDATE, MTK_ADSP_CLK_BUS_UPDATE_BIT);
+	wait_delay_us(1);
 
 	tr_dbg(&clkdrv_tr, "adsp_bus_mux=%x, MTK_ADSP_BUS_SRC=0x%08x\n",
 	       value, io_reg_read(MTK_ADSP_BUS_SRC));
@@ -133,6 +134,6 @@ void platform_clock_init(struct sof *sof)
 		k_spinlock_init(&sof->clocks[i].lock);
 	}
 
-	/* DSP bus clock */
 	set_mux_adsp_bus_src_sel(MTK_ADSP_CLK_BUS_SRC_EMI);
+	clock_set_freq(CLK_CPU(cpu_get_id()), CLK_MAX_CPU_HZ);
 }

--- a/src/platform/mt8186/platform.c
+++ b/src/platform/mt8186/platform.c
@@ -153,12 +153,6 @@ int platform_boot_complete(uint32_t boot_message)
 	/* now interrupt host to tell it we are done booting */
 	trigger_irq_to_host_req();
 
-	/* boot now complete so we can relax the CPU */
-	/* For now skip this to gain more processing performance
-	 * for SRC component.
-	 */
-	clock_set_freq(CLK_CPU(cpu_get_id()), CLK_MAX_CPU_HZ);
-
 	return 0;
 }
 


### PR DESCRIPTION
The mt8186 ADSP clock driver should initialize ADSP PLL after boot up before lift core frequency.
Also revise the flow of entering/leaving S3 state to prevent undefined behavior.