### PR TITLE
Math: Rename macros INT_MAX and INT_MIN

### DIFF
--- a/src/audio/module_adapter/module/volume/volume_generic.c
+++ b/src/audio/module_adapter/module/volume/volume_generic.c
@@ -65,7 +65,7 @@ static void vol_s24_to_s24(struct processing_module *mod, struct input_stream_bu
 	const int nch = source->channels;
 	int remaining_samples = frames * nch;
 #if CONFIG_COMP_PEAK_VOL
-	int32_t tmp = INT_MIN(32);
+	int32_t tmp = INT_MIN_FOR_NUMBER_OF_BITS(32);
 #endif
 
 	x = source->r_ptr;
@@ -128,7 +128,7 @@ static void vol_s32_to_s32(struct processing_module *mod, struct input_stream_bu
 	const int nch = source->channels;
 	int remaining_samples = frames * nch;
 #if CONFIG_COMP_PEAK_VOL
-	int32_t tmp = INT_MIN(32);
+	int32_t tmp = INT_MIN_FOR_NUMBER_OF_BITS(32);
 #endif
 
 	x = source->r_ptr;
@@ -195,7 +195,7 @@ static void vol_s16_to_s16(struct processing_module *mod, struct input_stream_bu
 	const int nch = source->channels;
 	int remaining_samples = frames * nch;
 #if CONFIG_COMP_PEAK_VOL
-	int16_t tmp = INT_MIN(16);
+	int16_t tmp = INT_MIN_FOR_NUMBER_OF_BITS(16);
 #endif
 
 	x = source->r_ptr;

--- a/src/drivers/intel/dmic/dmic_computed.c
+++ b/src/drivers/intel/dmic/dmic_computed.c
@@ -431,7 +431,7 @@ static int select_mode(struct dai *dai,
 	/* Calculate remaining gain to FIR in Q format used for gain
 	 * values.
 	 */
-	fir_in_max = INT_MAX(DMIC_HW_BITS_FIR_INPUT);
+	fir_in_max = INT_MAX_FOR_NUMBER_OF_BITS(DMIC_HW_BITS_FIR_INPUT);
 	if (cfg->cic_shift >= 0)
 		cic_out_max = g_cic >> cfg->cic_shift;
 	else

--- a/src/include/sof/math/numbers.h
+++ b/src/include/sof/math/numbers.h
@@ -105,19 +105,9 @@ uint32_t crc32(uint32_t base, const void *data, uint32_t bytes);
 #define merge_4b4b(high, low) (((uint8_t)(high) << 4) | \
 			       ((low) & 0xF))
 
-/* Zephyr defines this - remove local copy once Zephyr integration complete */
-#ifdef INT_MIN
-#undef INT_MIN
-#endif
-
-/* Zephyr defines this - remove local copy once Zephyr integration complete */
-#ifdef INT_MAX
-#undef INT_MAX
-#endif
-
 /* Get max and min signed integer values for N bits word length */
-#define INT_MAX(N)	((int64_t)((1ULL << ((N) - 1)) - 1))
-#define INT_MIN(N)	((int64_t)(-((1ULL << ((N) - 1)) - 1) - 1))
+#define INT_MAX_FOR_NUMBER_OF_BITS(N)	((int64_t)((1ULL << ((N) - 1)) - 1))
+#define INT_MIN_FOR_NUMBER_OF_BITS(N)	((int64_t)(-((1ULL << ((N) - 1)) - 1) - 1))
 
 /* Speed of sound (m/s) in 20 C temperature at standard atmospheric pressure */
 #define SPEED_OF_SOUND		343


### PR DESCRIPTION
The macro names in sof/math/numbers.h conflict with C library so they must be renamed. New macro names are
INT_MAX_FOR_NUMBER_OF_BITS() and INT_MIN_FOR_NUMBER_OF_BITS().

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>