### PR TITLE
[DNM] topology2: remove explicit dai_index setting for Dai object

### DIFF
--- a/tools/topology/topology2/cavs/cavs-nocodec.conf
+++ b/tools/topology/topology2/cavs/cavs-nocodec.conf
@@ -62,7 +62,6 @@ IncludeByKey.NUM_DMICS {
 Object.Dai {
 	SSP."0" {
 		id 		0
-		dai_index	0
 		direction	"duplex"
 		name		NoCodec-0
 		default_hw_conf_id	0
@@ -79,7 +78,6 @@ Object.Dai {
 	}
 	SSP."1" {
 		id 		1
-		dai_index	1
 		direction	"duplex"
 		name		NoCodec-1
 		default_hw_conf_id	0
@@ -96,7 +94,6 @@ Object.Dai {
 	}
 	SSP."2" {
 		id 		2
-		dai_index	2
 		direction	"duplex"
 		name		NoCodec-2
 		default_hw_conf_id	0

--- a/tools/topology/topology2/cavs/platform/intel/dmic-generic.conf
+++ b/tools/topology/topology2/cavs/platform/intel/dmic-generic.conf
@@ -33,7 +33,6 @@ Object.Dai {
        DMIC.1 {
                name                    $DMIC1_NAME
                id                      $DMIC1_ID
-               dai_index               1
                driver_version          $DMIC_DRIVER_VERSION
                io_clk                  $DMIC_IO_CLK
                sample_rate             16000


### PR DESCRIPTION
For Object.Dai.XX."N", the dai_index attribute can only be intialized to its unique instance number N.

Signed-off-by: Yong Zhi <yong.zhi@intel.com>