### PR TITLE
xtensa-build-zephyr.py: install and checksum .elf, .lst and other files

### DIFF
--- a/app/prj.conf
+++ b/app/prj.conf
@@ -1,5 +1,14 @@
 CONFIG_SOF=y
 CONFIG_BUILD_OUTPUT_BIN=n
+
+# The additional stripped .elf files are deterministic.
+# This adds very few files in the build directory and has
+# absolutely no other effect whatsoever.
+# See on-going discussion in
+# https://github.com/zephyrproject-rtos/zephyr/pull/51954
+# and usage in xtensa-build-zephyr.py
+CONFIG_BUILD_OUTPUT_STRIPPED=y
+
 CONFIG_HAVE_AGENT=n
 
 CONFIG_LOG=y

--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -657,28 +657,28 @@ def build_platforms():
 def install_platform(platform, sof_platform_output_dir):
 
 	# Keep in sync with caller
-		platform_build_dir_name = f"build-{platform}"
+	platform_build_dir_name = f"build-{platform}"
 
-		# Install to STAGING_DIR
-		abs_build_dir = pathlib.Path(west_top) / platform_build_dir_name / "zephyr"
+	# Install to STAGING_DIR
+	abs_build_dir = pathlib.Path(west_top) / platform_build_dir_name / "zephyr"
 
-		if args.fw_naming == "AVS":
-			# Disguise ourselves for local testing purposes
-			output_fwname="dsp_basefw.bin"
-		else:
-			# Regular name
-			output_fwname="".join(["sof-", platform, ".ri"])
+	if args.fw_naming == "AVS":
+		# Disguise ourselves for local testing purposes
+		output_fwname = "dsp_basefw.bin"
+	else:
+		# Regular name
+		output_fwname = "".join(["sof-", platform, ".ri"])
 
-		shutil.copy2(abs_build_dir / "zephyr.ri", abs_build_dir / output_fwname)
-		fw_file_to_copy = abs_build_dir / output_fwname
+	shutil.copy2(abs_build_dir / "zephyr.ri", abs_build_dir / output_fwname)
+	fw_file_to_copy = abs_build_dir / output_fwname
 
-		install_key_dir = sof_platform_output_dir
-		if args.key_type_subdir != "none":
-			install_key_dir = install_key_dir / args.key_type_subdir
+	install_key_dir = sof_platform_output_dir
+	if args.key_type_subdir != "none":
+		install_key_dir = install_key_dir / args.key_type_subdir
 
-		os.makedirs(install_key_dir, exist_ok=True)
-		# looses file owner and group - file is commonly accessible
-		shutil.copy2(fw_file_to_copy, install_key_dir)
+	os.makedirs(install_key_dir, exist_ok=True)
+	# looses file owner and group - file is commonly accessible
+	shutil.copy2(fw_file_to_copy, install_key_dir)
 
 
 # As of October 2022, sof_ri_info.py expects .ri files to include a CSE manifest / signature.

--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -174,8 +174,8 @@ def parse_args():
 	parser.add_argument("-d", "--debug", required=False, action="store_true",
 						help="Enable debug build")
 	parser.add_argument("-i", "--ipc", required=False, choices=["IPC4"],
-			    help="""Generic shortcut for: --overlay <platform>/ipc4_overlay.conf. Valid only
-for IPC3 platforms supporting IPC4 too.""")
+			    help="""Applies --overlay <platform>/ipc4_overlay.conf
+and a different rimage config. Valid only for IPC3 platforms supporting IPC4 too.""")
     # NO SOF release will ever user the option --fw-naming.
     # This option is only for disguising SOF IPC4 as CAVS IPC4 and only in cases where
     # the kernel 'ipc_type' expects CAVS IPC4. In this way, developers and CI can test
@@ -530,8 +530,9 @@ def build_platforms():
 		if args.debug:
 			overlays.append(str(pathlib.Path(SOF_TOP, "app", "debug_overlay.conf")))
 
-		# The '-i IPC4' is a shortcut for '-o path_to_ipc4_overlay', we are good if both
-		# are provided, because it's no harm to merge the same overlay twice.
+		# The '-i IPC4' is a shortcut for '-o path_to_ipc4_overlay' (and more), we
+		# are good if both are provided, because it's no harm to merge the same
+		# overlay twice.
 		if args.ipc == "IPC4":
 			overlays.append(str(pathlib.Path(SOF_TOP, "app", "overlays", platform,
                             platform_dict["IPC4_CONFIG_OVERLAY"])))

--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -622,26 +622,7 @@ def build_platforms():
 		if platform not in RI_INFO_UNSUPPORTED:
 			reproducible_checksum(platform, west_top / platform_build_dir_name / "zephyr" / "zephyr.ri")
 
-		# Install to STAGING_DIR
-		abs_build_dir = pathlib.Path(west_top) / platform_build_dir_name / "zephyr"
-
-		if args.fw_naming == "AVS":
-			# Disguise ourselves for local testing purposes
-			output_fwname="dsp_basefw.bin"
-		else:
-			# Regular name
-			output_fwname="".join(["sof-", platform, ".ri"])
-
-		shutil.copy2(abs_build_dir / "zephyr.ri", abs_build_dir / output_fwname)
-		fw_file_to_copy = abs_build_dir / output_fwname
-
-		install_key_dir = sof_platform_output_dir
-		if args.key_type_subdir != "none":
-			install_key_dir = install_key_dir / args.key_type_subdir
-
-		os.makedirs(install_key_dir, exist_ok=True)
-		# looses file owner and group - file is commonly accessible
-		shutil.copy2(fw_file_to_copy, install_key_dir)
+		install_platform(platform, sof_platform_output_dir)
 
 	src_dest_list = []
 
@@ -671,6 +652,34 @@ def build_platforms():
 			  "zephyr" / "soc" / "xtensa" / "intel_adsp" / "tools",
 			tools_output_dir,
 			symlinks=True, ignore_dangling_symlinks=True, dirs_exist_ok=True)
+
+
+def install_platform(platform, sof_platform_output_dir):
+
+	# Keep in sync with caller
+		platform_build_dir_name = f"build-{platform}"
+
+		# Install to STAGING_DIR
+		abs_build_dir = pathlib.Path(west_top) / platform_build_dir_name / "zephyr"
+
+		if args.fw_naming == "AVS":
+			# Disguise ourselves for local testing purposes
+			output_fwname="dsp_basefw.bin"
+		else:
+			# Regular name
+			output_fwname="".join(["sof-", platform, ".ri"])
+
+		shutil.copy2(abs_build_dir / "zephyr.ri", abs_build_dir / output_fwname)
+		fw_file_to_copy = abs_build_dir / output_fwname
+
+		install_key_dir = sof_platform_output_dir
+		if args.key_type_subdir != "none":
+			install_key_dir = install_key_dir / args.key_type_subdir
+
+		os.makedirs(install_key_dir, exist_ok=True)
+		# looses file owner and group - file is commonly accessible
+		shutil.copy2(fw_file_to_copy, install_key_dir)
+
 
 # As of October 2022, sof_ri_info.py expects .ri files to include a CSE manifest / signature.
 # Don't run sof_ri_info and ignore silently .ri files that don't have one.


### PR DESCRIPTION
4 commits = 3 refactorings with no effect + 1 last commit adding the feature. Separate reviews recommended. See commit messages.

Sample new output below. The sha256 is computed on the _uncompressed_
files and _not_ affected by gzip metadata.

```
build-sof-staging
├── sof
│   ├── community
│   │   ├── sof-imx8.ri         sha256=50c5423d2355ef3ed91...
│   │   └── sof-tgl.ri          sha256=6b1d26c12a63de5dfc8...
│   ├── sof-imx8.ldc    sha256=520d365d188d5ef4e907d3dd8c9...
│   └── sof-tgl.ldc     sha256=cdce6ad340d4dc047e71e738eb0...
├── sof-info
│   ├── imx8
│   │   ├── config.gz
│   │   ├── zephyr.elf.gz
│   │   ├── zephyr.lst.gz       sha256=8c83c3fc92df0a871dd...
│   │   ├── zephyr.map.gz
│   │   └── zephyr.strip.gz     sha256=d3ce3d3450c67bb3580...
│   └── tgl
│       ├── boot.mod.gz         sha256=d9c9e82e75fa6d061bf...
│       ├── config.gz
│       ├── main.mod.gz
│       ├── stripped-main.mod.gz        sha256=c367dccca6d...
│       ├── zephyr.elf.gz
│       ├── zephyr.lst.gz       sha256=5474bc5e58a5d000109...
│       ├── zephyr.map.gz
│       └── zephyr.strip.gz     sha256=6285f41c0682b33b7e0...
└── tools
    ├── cavstool.py
    ├── cavstool_client.py
    ├── cavstwist.sh
    ├── mtrace-reader.py
    ├── remote-fw-service.py
    └── sof-logger
```

cc:
- https://github.com/zephyrproject-rtos/zephyr/pull/51736
- https://github.com/zephyrproject-rtos/zephyr/pull/51737
- https://github.com/zephyrproject-rtos/zephyr/pull/51954