### PR TITLE
IADK: fix a wrong assignment

### DIFF
--- a/src/include/sof/audio/module_adapter/module/iadk_modules.h
+++ b/src/include/sof/audio/module_adapter/module/iadk_modules.h
@@ -44,7 +44,7 @@ do { \
 	(comp_dynamic_module)->type = mtype; \
 	(comp_dynamic_module)->uid = SOF_RT_UUID(uuid); \
 	(comp_dynamic_module)->tctx = &(tr); \
-	(comp_dynamic_module)->ops.create = *iadk_modules_shim_new; \
+	(comp_dynamic_module)->ops.create = iadk_modules_shim_new; \
 	(comp_dynamic_module)->ops.prepare = module_adapter_prepare; \
 	(comp_dynamic_module)->ops.params = module_adapter_params; \
 	(comp_dynamic_module)->ops.copy = module_adapter_copy; \

--- a/src/ipc/ipc-common.c
+++ b/src/ipc/ipc-common.c
@@ -93,7 +93,6 @@ struct ipc_comp_dev *ipc_get_comp_by_id(struct ipc *ipc, uint32_t id)
 		icd = container_of(clist, struct ipc_comp_dev, list);
 		if (icd->id == id)
 			return icd;
-
 	}
 
 	return NULL;
@@ -116,7 +115,6 @@ struct ipc_comp_dev *ipc_get_comp_by_ppl_id(struct ipc *ipc, uint16_t type, uint
 
 		if (ipc_comp_pipe_id(icd) == ppl_id)
 			return icd;
-
 	}
 
 	return NULL;
@@ -154,7 +152,6 @@ struct ipc_comp_dev *ipc_get_ppl_comp(struct ipc *ipc, uint32_t pipeline_id, int
 			if (buff_comp && dev_comp_pipe_id(buff_comp) != pipeline_id)
 				next_ppl_icd = icd;
 		}
-
 	}
 
 	return next_ppl_icd;


### PR DESCRIPTION
An IADK compilation fix and a cosmetic empty-line clean-up