### PR TITLE
Audio: replace the IIR lib used by EQ and TDFB with DF1

### DIFF
--- a/src/audio/Kconfig
+++ b/src/audio/Kconfig
@@ -134,7 +134,7 @@ config COMP_IIR
 	bool "IIR component"
 	select COMP_BLOB
 	default y
-	select MATH_IIR_DF2T
+	select MATH_IIR_DF1
 	help
 	  Select for IIR component
 
@@ -427,7 +427,7 @@ endif # COMP_ASRC
 config COMP_TDFB
 	bool "TDFB component"
 	select MATH_FIR
-	select MATH_IIR_DF2T
+	select MATH_IIR_DF1
 	select SQRT_FIXED
 	select CORDIC_FIXED
 	select COMP_BLOB

--- a/src/include/sof/audio/tdfb/tdfb_comp.h
+++ b/src/include/sof/audio/tdfb/tdfb_comp.h
@@ -13,7 +13,7 @@
 #include <sof/math/fir_generic.h>
 #include <sof/math/fir_hifi2ep.h>
 #include <sof/math/fir_hifi3.h>
-#include <sof/math/iir_df2t.h>
+#include <sof/math/iir_df1.h>
 #include <user/tdfb.h>
 
 /* Select optimized code variant when xt-xcc compiler is used */
@@ -57,7 +57,7 @@
 /* TDFB component private data */
 
 struct tdfb_direction_data {
-	struct iir_state_df2t emphasis[PLATFORM_MAX_CHANNELS];
+	struct iir_state_df1 emphasis[PLATFORM_MAX_CHANNELS];
 	int32_t timediff[PLATFORM_MAX_CHANNELS];
 	int32_t timediff_iter[PLATFORM_MAX_CHANNELS];
 	int64_t level_ambient;
@@ -65,7 +65,7 @@ struct tdfb_direction_data {
 	int32_t level;
 	int32_t unit_delay; /* Q1.31 seconds */
 	int32_t frame_count_since_control;
-	int64_t *df2t_delay;
+	int32_t *df1_delay;
 	int32_t *r;
 	int16_t *d;
 	int16_t *d_end;

--- a/src/include/sof/math/iir_df1_generic.h
+++ b/src/include/sof/math/iir_df1_generic.h
@@ -30,5 +30,5 @@ static inline int32_t iir_df1_s32_s24(struct iir_state_df1 *iir, int32_t x)
 	return sat_int24(Q_SHIFT_RND(iir_df1(iir, x), 31, 23));
 }
 
-#endif /* __IIR_DF2T_GENERIC_H__ */
+#endif /* __IIR_DF1_GENERIC_H__ */
 


### PR DESCRIPTION
Compared with DF2T, the DF1 has better performance on low frequency and saves about 9.9% cycles on HiFi3 version, so select DF1 instead of DF2T as the default IIR lib for component EQ and TDFB.

Signed-off-by: Andrula Song <xiaoyuan.song@intel.com>