### PR TITLE
[SKIP CI] .github: fail on errors and address space warnings in sparse output

### DIFF
--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -60,20 +60,12 @@ jobs:
              --cmake-args=--warn-uninitialized ${{ matrix.IPC_platforms }}
 
 
-  # As of sparse commit ce1a6720f69e / Sept 2022, the exit status of sparse.c is an
-  # unusable mess and always zero in practice. "Send patches"? So for now the only purpose
-  # of this check is to keep sparse _usable_ and demo how to use it but not to catch any
-  # regression.
-  #
-  # The only, undocumented way to make sparse return a non-zero exit status is to use its
-  # -Wsparse-error option; see check_symbols() code in sparse.c. Without -Wsparse-error,
-  # sparse.c always returns zero no matter how many warnings and errors it printed. BUT of
-  # course -Wsparse-error has another, intended and expected effect documented in "man
-  # sparse": promote all our (very many) warnings into errors. Which means we cannot use
-  # -Wsparse-error yet, otherwise it would be "always red".
-  #
-  # Note sparse does not support promoting individual warning types to errors either.
-  sparse_always_green:
+  # As of sparse commit ce1a6720f69e / Sept 2022, the exit status of
+  # sparse.c is an unusable mess and always zero in practice. Moreover
+  # SOF has hundreds of sparse warnings right now. So fail only on a
+  # small subset of specific warnings defined in
+  # sof/scripts/parse_sparse_output.sh
+  sparse-subset:
     runs-on: ubuntu-22.04
 
     strategy:
@@ -117,4 +109,4 @@ jobs:
           ZSDK=$(cat zsdk_location); _RCC=${{ matrix.platforms.real_cc }}
           REAL_CC="$ZSDK/$_RCC" ./sof/zephyr/docker-run.sh                          \
              ./sof/zephyr/docker-build.sh ${{ matrix.platforms.platform }}          \
-             --cmake-args=-DSPARSE=y  # --cmake-args=-DEXTRA_CFLAGS=-Wsparse-error
+             --cmake-args=-DSPARSE=y | ./sof/scripts/parse_sparse_output.sh

--- a/scripts/parse_sparse_output.sh
+++ b/scripts/parse_sparse_output.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# SPDX-License-Identifier: BSD-3-Clause
+
+# "sparse" is not designed for automated testing: its exit code is
+# mostly useless. So this script extracts from its output the most
+# important messages instead and returns 1 if any is found.
+
+# As of Sep. 2022, sparse's exit status is by default always zero even
+# when there is an error, see check_symbols() in sparse.c. There is a
+# -DEXTRA_CFLAGS=-Wsparse-error option that returns non-zero... for any
+# warning even the most harmless one and it seems to stops on the first
+# one. SOF has hundreds of sparse warnings now.
+
+main()
+{
+    >&2 printf 'Reminder: to see ALL warnings you must as usual build _from scratch_\n'
+
+    # To reproduce an 'error: ' and test this script try commenting out
+    # `defined(__CHECKER__)` in common.h.
+    #
+    # To reproduce the 'different address space' warning and test this
+    # script try deleting a __sparse_cache annotation like the one in
+    # src/audio/mixer/mixer.c
+
+    ! grep -i  \
+        -e '[[:space:]]error:[[:space:]]'  \
+        -e '[[:space:]]warning:[[:space:]].*different address space' \
+
+}
+
+main "$@"


### PR DESCRIPTION
sparse does not have a useful exit status so let's use 'grep' instead.

Fixes: #6317

Signed-off-by: Marc Herbert <marc.herbert@intel.com>