### PR TITLE
dai-zephyr: check for NULL in functions

### DIFF
--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -197,7 +197,12 @@ int dai_get_handshake(struct dai *dai, int direction, int stream_id)
 /* called from ipc/ipc3/dai.c and ipc/ipc4/dai.c */
 int dai_get_fifo_depth(struct dai *dai, int direction)
 {
-	const struct dai_properties *props = dai_get_properties(dai->dev, direction, 0);
+	const struct dai_properties *props;
+
+	if (!dai)
+		return 0;
+
+	props = dai_get_properties(dai->dev, direction, 0);
 
 	return props->fifo_depth;
 }
@@ -1321,7 +1326,12 @@ static int dai_ts_stop_op(struct comp_dev *dev)
 
 uint32_t dai_get_init_delay_ms(struct dai *dai)
 {
-	const struct dai_properties *props = dai_get_properties(dai->dev, 0, 0);
+	const struct dai_properties *props;
+
+	if (!dai)
+		return 0;
+
+	props = dai_get_properties(dai->dev, 0, 0);
 
 	return props->reg_init_delay;
 }


### PR DESCRIPTION
Check for NULL in init_delay and fifo functions. These are called in very early stage when dai might not be set. Thus fix it and align with legacy.

Signed-off-by: Jaska Uimonen <jaska.uimonen@intel.com>