### PR TITLE
zephyr-ipc: Invoke platform_pm_runtime_power_off during D3

### DIFF
--- a/src/ipc/ipc-zephyr.c
+++ b/src/ipc/ipc-zephyr.c
@@ -125,6 +125,14 @@ enum task_state ipc_platform_do_cmd(struct ipc *ipc)
 	/* perform command */
 	ipc_cmd(hdr);
 
+#if CONFIG_SOC_SERIES_INTEL_ADSP_CAVS
+	/* are we about to enter D3 ? */
+	if (ipc->pm_prepare_D3) {
+		/* no return - memory will be powered off and IPC sent */
+		platform_pm_runtime_power_off();
+	}
+#endif
+
 	return SOF_TASK_STATE_COMPLETED;
 }
 


### PR DESCRIPTION
When entering D3, call the platform_pm_runtime_power_off to prevent the IPC timeouts seen with the CTX_SAVE IPC seen on the host.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>