### PR TITLE
mtl upstream: mux: fix FW build with xt-clang

### DIFF
--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -101,8 +101,8 @@ static bool mux_mix_check(struct sof_mux_config *cfg)
 static int mux_set_values(struct comp_dev *dev, struct comp_data *cd,
 			  struct sof_mux_config *cfg)
 {
-	uint8_t i;
-	uint8_t j;
+	unsigned int i;
+	unsigned int j;
 
 	comp_info(dev, "mux_set_values()");
 


### PR DESCRIPTION
Newer Xtensa toolchain replaces xt-xcc with xt-clang. For some reason xt-clang fails to build SOF when uint8_t type is used as index of for() loop. This change unblocks building of SOF with xt-clang.

Signed-off-by: Jaroslaw Stelter <Jaroslaw.Stelter@intel.com>