### PR TITLE
topology2: cavs-passthrough-hdmi: Add support for chained DMA

### DIFF
--- a/tools/topology/topology2/cavs/CMakeLists.txt
+++ b/tools/topology/topology2/cavs/CMakeLists.txt
@@ -3,23 +3,24 @@
 # Array of "input-file-name;output-file-name;comma separated pre-processor variables"
 set(TPLGS
 # CAVS HDMI only topology with passthrough pipelines
-"cavs-passthrough-hdmi\;cavs-passthrough-hdmi"
+"cavs-passthrough-hdmi\;cavs-passthrough-hdmi\;USE_CHAIN_DMA=true"
 # CAVS HDA topology with mixer-based pipelines for HDA and passthrough pipelines for HDMI
-"cavs-passthrough-hdmi\;cavs-mixin-mixout-hda\;HDA_CONFIG=mix"
+"cavs-passthrough-hdmi\;cavs-mixin-mixout-hda\;HDA_CONFIG=mix,USE_CHAIN_DMA=true"
 # If the alsatplg plugins for NHLT are not available, the NHLT blobs will not be added to the
 # topologies below.
 # CNL: CAVS HDA topology with mixer-based pipelines for HDA and passthrough pipelines for HDMI
 "cavs-passthrough-hdmi\;cavs-mixin-mixout-hda-2ch-cnl\;\
-HDA_CONFIG=mix,NUM_DMICS=2,PLATFORM=cnl,PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt.bin"
+HDA_CONFIG=mix,NUM_DMICS=2,PLATFORM=cnl,PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt.bin,\
+USE_CHAIN_DMA=true"
 "cavs-passthrough-hdmi\;cavs-mixin-mixout-hda-4ch-cnl\;\
 HDA_CONFIG=mix,NUM_DMICS=4,PLATFORM=cnl,PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,\
-PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt.bin"
+PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt.bin,USE_CHAIN_DMA=true"
 # TGL: CAVS HDA topology with mixer-based pipelines for HDA and passthrough pipelines for HDMI
 "cavs-passthrough-hdmi\;cavs-mixin-mixout-hda-2ch-tgl\;\
-HDA_CONFIG=mix,NUM_DMICS=2,PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt.bin"
+HDA_CONFIG=mix,NUM_DMICS=2,PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt.bin,USE_CHAIN_DMA=true"
 "cavs-passthrough-hdmi\;cavs-mixin-mixout-hda-4ch-tgl\;\
 HDA_CONFIG=mix,NUM_DMICS=4,PLATFORM=cnl,PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,\
-PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt.bin"
+PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt.bin,USE_CHAIN_DMA=true"
 # MTL: CAVS HDA topology with mixer-based pipelines for HDA and passthrough pipelines for HDMI
 "cavs-passthrough-hdmi\;cavs-mixin-mixout-hda-4ch-mtl\;PLATFORM=mtl,\
 HDA_CONFIG=mix,NUM_DMICS=4,PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-mtl-hda-mix.bin"

--- a/tools/topology/topology2/cavs/cavs-passthrough-hdmi.conf
+++ b/tools/topology/topology2/cavs/cavs-passthrough-hdmi.conf
@@ -34,6 +34,7 @@ Define {
 	HDA_CONFIG  "none"
 	PLATFORM "none"
 	NUM_DMICS 0
+	USE_CHAIN_DMA	"false"
 }
 
 # override defaults with platform-specific config

--- a/tools/topology/topology2/cavs/cavs-sdw.conf
+++ b/tools/topology/topology2/cavs/cavs-sdw.conf
@@ -50,6 +50,7 @@ Define {
 	DMIC1_ID 5
 	DMIC0_PCM_CAPS 'Passthrough Capture 13'
 	DMIC0_PIPELINE_STREAM_NAME 'copier.DMIC.14.1'
+	USE_CHAIN_DMA	"false"
 }
 
 # include DMIC config if needed.

--- a/tools/topology/topology2/cavs/platform/intel/hdmi-4th.conf
+++ b/tools/topology/topology2/cavs/platform/intel/hdmi-4th.conf
@@ -17,6 +17,7 @@ Object.Pipeline {
 		}
 
 		index $HDMI4_HOST_PIPELINE_ID
+		use_chain_dma	$USE_CHAIN_DMA
 	}
 	passthrough-be.23 {
 		direction	"playback"
@@ -30,6 +31,7 @@ Object.Pipeline {
 			dai_type "HDA"
 			copier_type "HDA"
 		}
+		use_chain_dma	$USE_CHAIN_DMA
 	}
 }
 Object.PCM {
@@ -39,7 +41,7 @@ Object.PCM {
 		Object.Base.fe_dai.HDMI4 {}
 		Object.PCM.pcm_caps.playback {
 			name $HDMI4_PCM_CAPS
-			formats 'S32_LE,S24_LE,S16_LE'
+			formats 'S32_LE,S16_LE'
 		}
 		direction playback
 	}

--- a/tools/topology/topology2/cavs/platform/intel/hdmi-generic.conf
+++ b/tools/topology/topology2/cavs/platform/intel/hdmi-generic.conf
@@ -31,6 +31,7 @@ Object.Pipeline {
 		}
 
 		index $HDMI1_HOST_PIPELINE_ID
+		use_chain_dma	$USE_CHAIN_DMA
 	}
 	passthrough-be.20 {
 		direction	"playback"
@@ -44,6 +45,7 @@ Object.Pipeline {
 			dai_type "HDA"
 			copier_type "HDA"
 		}
+		use_chain_dma	$USE_CHAIN_DMA
 	}
 	passthrough-playback.21 {
 		Object.Widget.pipeline.1 {
@@ -54,6 +56,7 @@ Object.Pipeline {
 		}
 
 		index $HDMI2_HOST_PIPELINE_ID
+		use_chain_dma	$USE_CHAIN_DMA
 	}
 	passthrough-be.21 {
 		direction	"playback"
@@ -67,6 +70,7 @@ Object.Pipeline {
 			dai_type "HDA"
 			copier_type "HDA"
 		}
+		use_chain_dma	$USE_CHAIN_DMA
 	}
 	passthrough-playback.22 {
 		Object.Widget.pipeline.1 {
@@ -77,6 +81,7 @@ Object.Pipeline {
 		}
 
 		index $HDMI3_HOST_PIPELINE_ID
+		use_chain_dma	$USE_CHAIN_DMA
 	}
 	passthrough-be.22 {
 		direction	"playback"
@@ -90,6 +95,7 @@ Object.Pipeline {
 			dai_type "HDA"
 			copier_type "HDA"
 		}
+		use_chain_dma	$USE_CHAIN_DMA
 	}
 }
 Object.PCM {
@@ -99,7 +105,7 @@ Object.PCM {
 		Object.Base.fe_dai.HDMI1 {}
 		Object.PCM.pcm_caps.playback {
 			name $HDMI1_PCM_CAPS
-			formats 'S32_LE,S24_LE,S16_LE'
+			formats 'S32_LE,S16_LE'
 		}
 		direction playback
 	}
@@ -109,7 +115,7 @@ Object.PCM {
 		Object.Base.fe_dai.HDMI2 {}
 		Object.PCM.pcm_caps.playback {
 			name $HDMI2_PCM_CAPS
-			formats 'S32_LE,S24_LE,S16_LE'
+			formats 'S32_LE,S16_LE'
 		}
 		direction playback
 	}
@@ -119,7 +125,7 @@ Object.PCM {
 		Object.Base.fe_dai.HDMI3 {}
 		Object.PCM.pcm_caps.playback {
 			name $HDMI3_PCM_CAPS
-			formats 'S32_LE,S24_LE,S16_LE'
+			formats 'S32_LE,S16_LE'
 		}
 		direction playback
 	}

--- a/tools/topology/topology2/include/common/tokens.conf
+++ b/tools/topology/topology2/include/common/tokens.conf
@@ -69,6 +69,7 @@ Object.Base.VendorToken {
 		dynamic_pipeline	206
 		# ABI 4.0 onwards
 		lp_mode		207
+		use_chain_dma		209
 	}
 
 	"sof_tkn_intel_ssp" {

--- a/tools/topology/topology2/include/components/pipeline.conf
+++ b/tools/topology/topology2/include/components/pipeline.conf
@@ -95,6 +95,18 @@ Class.Widget."pipeline" {
 		}
 	}
 
+	# Skip setting up the pipeline in the DSP in the case of chained DMA mode
+	DefineAttribute."use_chain_dma" {
+		type	"string"
+		token_ref	"sof_tkn_scheduler.bool"
+		constraints {
+			!valid_values [
+				"true"
+				"false"
+			]
+		}
+	}
+
 	attributes {
 		# pipeline widget name will be constructed as pipeline.1, pipeline.2 etc
 		!constructor [

--- a/tools/topology/topology2/include/pipelines/pipeline-common.conf
+++ b/tools/topology/topology2/include/pipelines/pipeline-common.conf
@@ -79,3 +79,14 @@ DefineAttribute."time_domain" {
 
 # flag to indicate if the pipeline is dynamic
 DefineAttribute."dynamic_pipeline" {}
+
+# Skip setting up the pipeline in the DSP when use_chain_dma is set.
+DefineAttribute."use_chain_dma" {
+	type	"string"
+	constraints {
+		!valid_values [
+			"true"
+			"false"
+		]
+	}
+}


### PR DESCRIPTION
Add support for chaind DMA pipelines in the HDMI passthrough topology. This version should work even if the kernel does not support chained DMA as yet.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>