### PR TITLE
ipc4: fix asserts in ipc_compound_pre_start and msg_done

### DIFF
--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -353,9 +353,7 @@ static void ipc_compound_pre_start(int msg_id)
 	/* ipc thread will wait for all scheduled ipc messages to be complete
 	 * Use a reference count to check status of these ipc messages.
 	 */
-	int old_val __unused = atomic_add(&msg_data.delayed_reply, 1);
-
-	assert(old_val == 0);
+	atomic_add(&msg_data.delayed_reply, 1);
 }
 
 static void ipc_compound_post_start(uint32_t msg_id, int ret, bool delayed)
@@ -378,9 +376,7 @@ static void ipc_compound_msg_done(uint32_t msg_id, int error)
 		return;
 	}
 
-	int old_val __unused = atomic_sub(&msg_data.delayed_reply, 1);
-
-	assert(old_val == 1);
+	atomic_sub(&msg_data.delayed_reply, 1);
 
 	/* error reported in delayed pipeline task */
 	if (error < 0) {


### PR DESCRIPTION
In review of commit 76e35fbec2be ("ipc4: use atomic primitives to maintain delayed_reply state"), we had a debate whether 'delayed_reply' was really a counter at all, or should it be a boolean. As a compromise, we kept it as a counter, but added asserts on its expected values.

Now soon after, the SOF driver started using compound SET_PIPELINE_STATE calls, which led to 'delayed_reply' really becoming a counter now due to loop in ipc4_set_pipeline_state().

The code is correct, but now the assert statements are no longer correct, so remove them.

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>