### PR TITLE
audio: up_down_mixer: fix build warnings on discarding const

### DIFF
--- a/src/audio/up_down_mixer/up_down_mixer.c
+++ b/src/audio/up_down_mixer/up_down_mixer.c
@@ -337,9 +337,10 @@ static void up_down_mixer_free(struct comp_dev *dev)
 	rfree(dev);
 }
 
-static int init_up_down_mixer(struct comp_dev *dev, struct comp_ipc_config *config, void *spec)
+static int init_up_down_mixer(struct comp_dev *dev, const struct comp_ipc_config *config,
+			      const void *spec)
 {
-	struct ipc4_up_down_mixer_module_cfg *up_down_mixer = spec;
+	const struct ipc4_up_down_mixer_module_cfg *up_down_mixer = spec;
 	struct up_down_mixer_data *cd;
 	int ret;
 


### PR DESCRIPTION
Fix compiler warnings on discarding const when passing arguments to init_up_down_mixer [-Werror=discarded-qualifiers].

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>