### PR TITLE
app: zephyr: add CONFIG_ASSERT debug overlay

### DIFF
--- a/app/debug_overlay.conf
+++ b/app/debug_overlay.conf
@@ -1,1 +1,11 @@
 CONFIG_DEBUG=y
+CONFIG_ASSERT=y
+
+# Following options can be enabled additionally,
+# but will incur a higher runtime cost, so are thus
+# disabled by default.
+#
+# CONFIG_STACK_SENTINEL=y
+# CONFIG_SYS_HEAP_VALIDATE=y
+# CONFIG_SPIN_VALIDATE=y
+# CONFIG_SPIN_LOCK_TIME_LIMIT=50000


### PR DESCRIPTION
Enable CONFIG_ASSERT=y in SOF debug overlay.

Also add a commented out list of additional useful Zephyr debugging
tools to the overlay. These incur a higher runtime cost, so are left
disabled by default. These are all debug tools that have been tested to
work with SOF and found useful.

Dependencies for merging (SOF):

- [x] https://github.com/thesofproject/sof/pull/6823
- [x] https://github.com/thesofproject/sof/pull/6897
- [x] https://github.com/thesofproject/sof/pull/6899
- [x] https://github.com/thesofproject/sof/pull/6900
- [x] https://github.com/thesofproject/sof/pull/6836 (OR https://github.com/thesofproject/sof/pull/6909 )
- [x] https://github.com/thesofproject/sof/pull/7110 (needed for Zephyr baseline update)
- [x] Zephyr baseline update (to bring in all fixes in below fix) -> https://github.com/thesofproject/sof/pull/7125
- [x] rootcause assert hit in mixin_mixout/mixin_mixout.c:368 (https://sof-ci.01.org/sofpr/PR6530/build4058/devicetest/index.html)

Dependencies for merging (Zephyr):
- [x] https://github.com/zephyrproject-rtos/zephyr/pull/53394
- [x] https://github.com/zephyrproject-rtos/zephyr/pull/53395
- [x] https://github.com/zephyrproject-rtos/zephyr/pull/54278
- [x] to merge PR54278, solution is needed for regression observed in https://github.com/thesofproject/sof/pull/6965 that is now blocking Zephyr updates, fix in https://github.com/thesofproject/sof/pull/7044
- [x] https://github.com/zephyrproject-rtos/zephyr/pull/54900
