### PR TITLE
audio: up_down_mixer: add stubs for generic ANSI C version

### DIFF
--- a/src/audio/up_down_mixer/up_down_mixer.c
+++ b/src/audio/up_down_mixer/up_down_mixer.c
@@ -337,9 +337,10 @@ static void up_down_mixer_free(struct comp_dev *dev)
 	rfree(dev);
 }
 
-static int init_up_down_mixer(struct comp_dev *dev, struct comp_ipc_config *config, void *spec)
+static int init_up_down_mixer(struct comp_dev *dev, const struct comp_ipc_config *config,
+			      const void *spec)
 {
-	struct ipc4_up_down_mixer_module_cfg *up_down_mixer = spec;
+	const struct ipc4_up_down_mixer_module_cfg *up_down_mixer = spec;
 	struct up_down_mixer_data *cd;
 	int ret;
 

--- a/src/audio/up_down_mixer/up_down_mixer_hifi3.c
+++ b/src/audio/up_down_mixer/up_down_mixer_hifi3.c
@@ -1915,6 +1915,187 @@ void upmix32bit_quatro_to_5_1(struct up_down_mixer_data *cd, const uint8_t * con
 	}
 }
 
-#else
-	#error "Only hifi3 version supported."
+#else /* !XCHAL_HAVE_HIFI3 */
+
+/* TODO: replace with generic ANSI C version */
+
+void upmix32bit_1_to_5_1(struct up_down_mixer_data *cd, const uint8_t * const in_data,
+			 const uint32_t in_size, uint8_t * const out_data)
+{
+	panic(0);
+}
+
+void upmix16bit_1_to_5_1(struct up_down_mixer_data *cd, const uint8_t * const in_data,
+			 const uint32_t in_size, uint8_t * const out_data)
+{
+	panic(0);
+}
+
+void upmix32bit_2_0_to_5_1(struct up_down_mixer_data *cd, const uint8_t * const in_data,
+			   const uint32_t in_size, uint8_t * const out_data)
+{
+	panic(0);
+}
+
+void upmix16bit_2_0_to_5_1(struct up_down_mixer_data *cd, const uint8_t * const in_data,
+			   const uint32_t in_size, uint8_t * const out_data)
+{
+	panic(0);
+}
+
+void upmix32bit_2_0_to_7_1(struct up_down_mixer_data *cd, const uint8_t * const in_data,
+			   const uint32_t in_size, uint8_t * const out_data)
+{
+	panic(0);
+}
+
+void shiftcopy32bit_mono(struct up_down_mixer_data *cd, const uint8_t * const in_data,
+			 const uint32_t in_size, uint8_t * const out_data)
+{
+	panic(0);
+}
+
+void shiftcopy32bit_stereo(struct up_down_mixer_data *cd, const uint8_t * const in_data,
+			   const uint32_t in_size, uint8_t * const out_data)
+{
+	panic(0);
+}
+
+void downmix32bit_2_1(struct up_down_mixer_data *cd, const uint8_t * const in_data,
+		      const uint32_t in_size, uint8_t * const out_data)
+{
+	panic(0);
+}
+
+void downmix32bit_3_0(struct up_down_mixer_data *cd, const uint8_t * const in_data,
+		      const uint32_t in_size, uint8_t * const out_data)
+{
+	panic(0);
+}
+
+void downmix32bit_3_1(struct up_down_mixer_data *cd, const uint8_t * const in_data,
+		      const uint32_t in_size, uint8_t * const out_data)
+{
+	panic(0);
+}
+
+void downmix32bit(struct up_down_mixer_data *cd, const uint8_t * const in_data,
+		  const uint32_t in_size, uint8_t * const out_data)
+{
+	panic(0);
+}
+
+void downmix32bit_4_0(struct up_down_mixer_data *cd, const uint8_t * const in_data,
+		      const uint32_t in_size, uint8_t * const out_data)
+{
+	panic(0);
+}
+
+void downmix32bit_5_0_mono(struct up_down_mixer_data *cd, const uint8_t * const in_data,
+			   const uint32_t in_size, uint8_t * const out_data)
+{
+	panic(0);
+}
+
+void downmix32bit_5_1(struct up_down_mixer_data *cd, const uint8_t * const in_data,
+		      const uint32_t in_size, uint8_t * const out_data)
+{
+	panic(0);
+}
+
+void downmix32bit_7_1(struct up_down_mixer_data *cd, const uint8_t * const in_data,
+		      const uint32_t in_size, uint8_t * const out_data)
+{
+	panic(0);
+}
+
+void downmix16bit_stereo(struct up_down_mixer_data *cd, const uint8_t * const in_data,
+			 const uint32_t in_size, uint8_t * const out_data)
+{
+}
+
+void shiftcopy16bit_mono(struct up_down_mixer_data *cd, const uint8_t * const in_data,
+			 const uint32_t in_size, uint8_t * const out_data)
+{
+	panic(0);
+}
+
+void shiftcopy16bit_stereo(struct up_down_mixer_data *cd, const uint8_t * const in_data,
+			   const uint32_t in_size, uint8_t * const out_data)
+{
+	panic(0);
+}
+
+void downmix16bit(struct up_down_mixer_data *cd, const uint8_t * const in_data,
+		  const uint32_t in_size, uint8_t * const out_data)
+{
+	panic(0);
+}
+
+void downmix16bit_5_1(struct up_down_mixer_data *cd, const uint8_t * const in_data,
+		      const uint32_t in_size, uint8_t * const out_data)
+{
+	panic(0);
+}
+
+void downmix16bit_4ch_mono(struct up_down_mixer_data *cd, const uint8_t * const in_data,
+			   const uint32_t in_size, uint8_t * const out_data)
+{
+	panic(0);
+}
+
+void downmix32bit_stereo(struct up_down_mixer_data *cd, const uint8_t * const in_data,
+			 const uint32_t in_size, uint8_t * const out_data)
+{
+	panic(0);
+}
+
+void downmix32bit_3_1_mono(struct up_down_mixer_data *cd, const uint8_t * const in_data,
+			   const uint32_t in_size, uint8_t * const out_data)
+{
+	panic(0);
+}
+
+void downmix32bit_4_0_mono(struct up_down_mixer_data *cd, const uint8_t * const in_data,
+			   const uint32_t in_size, uint8_t * const out_data)
+{
+	panic(0);
+}
+
+void downmix32bit_quatro_mono(struct up_down_mixer_data *cd, const uint8_t * const in_data,
+			      const uint32_t in_size, uint8_t * const out_data)
+{
+	panic(0);
+}
+
+void downmix32bit_5_1_mono(struct up_down_mixer_data *cd, const uint8_t * const in_data,
+			   const uint32_t in_size, uint8_t * const out_data)
+{
+	panic(0);
+}
+
+void downmix32bit_7_1_mono(struct up_down_mixer_data *cd, const uint8_t * const in_data,
+			   const uint32_t in_size, uint8_t * const out_data)
+{
+	panic(0);
+}
+
+void downmix32bit_7_1_to_5_1(struct up_down_mixer_data *cd, const uint8_t * const in_data,
+			     const uint32_t in_size, uint8_t * const out_data)
+{
+	panic(0);
+}
+
+void upmix32bit_4_0_to_5_1(struct up_down_mixer_data *cd, const uint8_t * const in_data,
+			   const uint32_t in_size, uint8_t * const out_data)
+{
+	panic(0);
+}
+
+void upmix32bit_quatro_to_5_1(struct up_down_mixer_data *cd, const uint8_t * const in_data,
+			      const uint32_t in_size, uint8_t * const out_data)
+{
+	panic(0);
+}
+
 #endif


### PR DESCRIPTION
The up_down_mixer currently depends on Hifi3 intrinsics and there is no generic ANSI C version provides. This leads to CI build errors with Zephyr SDK toolchain version, which doesn't support Hifi/XCC extensions.

Add stubs for the generic implementation to allow the CI build checks to pass. Code will raise a panic if execution is attempted as the implementation is missing.

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>