### PR TITLE
iadk_modules: Fixes to pass correct configuration

### DIFF
--- a/src/audio/module_adapter/module/iadk_modules.c
+++ b/src/audio/module_adapter/module/iadk_modules.c
@@ -60,7 +60,7 @@ static int iadk_modules_init(struct processing_module *mod)
 	int ret = 0;
 	byte_array_t mod_cfg;
 
-	mod_cfg.data = (uint8_t *)&md->cfg.base_cfg;
+	mod_cfg.data = (uint8_t *)md->cfg.init_data;
 	/* Intel modules expects DW size here */
 	mod_cfg.size = md->cfg.size >> 2;
 	md->private = mod;

--- a/src/include/sof/audio/module_adapter/module/iadk_modules.h
+++ b/src/include/sof/audio/module_adapter/module/iadk_modules.h
@@ -52,6 +52,9 @@ do { \
 	(comp_dynamic_module)->ops.trigger = module_adapter_trigger; \
 	(comp_dynamic_module)->ops.reset = module_adapter_reset; \
 	(comp_dynamic_module)->ops.free = module_adapter_free; \
+	(comp_dynamic_module)->ops.set_large_config = module_set_large_config;\
+	(comp_dynamic_module)->ops.get_large_config = module_get_large_config;\
+	(comp_dynamic_module)->ops.get_attribute = module_adapter_get_attribute; \
 } while (0)
 
 #endif /* __SOF_AUDIO_IADK_MODULES__ */


### PR DESCRIPTION
This PR introduced two fixes:
1. Adds get_attribute, set_large_config and get_large config to IADK module adapter initialization.
2. Since IADK modules could require proprietary configuration. Therefore during module creation whole IPC4 configuration buffer is required, not only  ipc4_base_module_cfg structure.