### PR TITLE
topology2: cavs-sdw: add Speaker and Microphone pcm

### DIFF
--- a/tools/topology/topology2/avs-tplg/CMakeLists.txt
+++ b/tools/topology/topology2/avs-tplg/CMakeLists.txt
@@ -17,6 +17,18 @@ PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-hda-generic-4ch.bin,USE_CHAIN_DMA=true
 # CAVS SDW topology with passthrough pipelines
 "cavs-sdw\;cavs-sdw\;DEEPBUFFER_FW_DMA_MS=100"
 
+# IPC4 topology for TGL rt711 Headset + rt1316 Amplifier + rt714 DMIC
+"cavs-sdw\;sof-tgl-rt711-rt1316-rt714\;NUM_SDW_AMPS=2,SDW_DMIC=1"
+
+# IPC4 topology for TGL rt711 Headset + rt1308 Amplifier + rt715 DMIC
+"cavs-sdw\;sof-tgl-rt715-rt711-rt1308-mono\;NUM_SDW_AMPS=1,SDW_DMIC=1,\
+SDW_JACK_OUT_STREAM=SDW1-Playback,SDW_JACK_IN_STREAM=SDW1-Capture,\
+SDW_SPK_STREAM=SDW2-Playback,SDW_DMIC_STREAM=SDW0-Capture"
+
+# IPC4 topology for TGL rt711 Headset + rt1308 Amplifier + PCH DMIC
+"cavs-sdw\;sof-tgl-rt711-rt1308-4ch\;NUM_SDW_AMPS=1,NUM_DMICS=4,DMIC0_ID=3,\
+DMIC1_ID=4,PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1"
+
 # CAVS SDW with SRC gain and mixer support
 "cavs-sdw-src-gain-mixin\;cavs-sdw-src-gain-mixin"
 

--- a/tools/topology/topology2/cavs-sdw.conf
+++ b/tools/topology/topology2/cavs-sdw.conf
@@ -55,6 +55,10 @@ Define {
 	DEEP_BUFFER_PIPELINE_SRC        'mixin.15.1'
 	DEEP_BUFFER_PIPELINE_SINK       'mixout.2.1'
 	DEEP_BUFFER_PCM_NAME		'Deepbuffer Jack Out'
+	SDW_JACK_OUT_STREAM	'SDW0-Playback'
+	SDW_JACK_IN_STREAM	'SDW0-Capture'
+	SDW_JACK_OUT_BE_ID	0
+	SDW_JACK_IN_BE_ID	1
 }
 
 # include DMIC config if needed.
@@ -82,9 +86,9 @@ IncludeByKey.DEEPBUFFER_FW_DMA_MS{
 #ALH Index: 0, Direction: duplex
 Object.Dai {
 	ALH."2" {
-		id 		0
+		id 		$SDW_JACK_OUT_BE_ID
 		direction	"playback"
-		name		SDW0-Playback
+		name		$SDW_JACK_OUT_STREAM
 		default_hw_conf_id	0
 		rate			48000
 		channels		2
@@ -94,9 +98,9 @@ Object.Dai {
 		}
 	}
 	ALH."3" {
-		id 		1
+		id 		$SDW_JACK_IN_BE_ID
 		direction	"capture"
-		name		SDW0-Capture
+		name		$SDW_JACK_IN_STREAM
 		default_hw_conf_id	1
 		rate			48000
 		channels		2
@@ -132,7 +136,7 @@ Object.Pipeline {
 		Object.Widget.pipeline.1.stream_name	"copier.ALH.2.1"
 
 		Object.Widget.copier.1 {
-			stream_name 'SDW0-Playback'
+			stream_name $SDW_JACK_OUT_STREAM
 			dai_type "ALH"
 			copier_type "ALH"
 			node_type $ALH_LINK_OUTPUT_CLASS
@@ -163,7 +167,7 @@ Object.Pipeline {
 			stream_name	'copier.ALH.3.1'
 		}
 		Object.Widget.copier.1 {
-			stream_name	'SDW0-Capture'
+			stream_name	$SDW_JACK_IN_STREAM
 			dai_type	"ALH"
 			copier_type	"ALH"
 			type		"dai_out"

--- a/tools/topology/topology2/cavs-sdw.conf
+++ b/tools/topology/topology2/cavs-sdw.conf
@@ -59,6 +59,8 @@ Define {
 	SDW_JACK_IN_STREAM	'SDW0-Capture'
 	SDW_JACK_OUT_BE_ID	0
 	SDW_JACK_IN_BE_ID	1
+	NUM_SDW_AMPS 0
+	SDW_DMIC 0
 }
 
 # include DMIC config if needed.
@@ -78,6 +80,14 @@ IncludeByKey.NUM_HDMIS {
 # include deep buffer config if buffer size is in 1 - 1000 ms.
 IncludeByKey.DEEPBUFFER_FW_DMA_MS{
         "[1-1000]" "platform/intel/deep-buffer.conf"
+}
+
+IncludeByKey.NUM_SDW_AMPS {
+"[1-2]" "platform/intel/sdw-amp-generic.conf"
+}
+
+IncludeByKey.SDW_DMIC {
+"1" "platform/intel/sdw-dmic-generic.conf"
 }
 
 #

--- a/tools/topology/topology2/cavs-sdw.conf
+++ b/tools/topology/topology2/cavs-sdw.conf
@@ -40,10 +40,10 @@ Define {
 	# override DMIC default definitions
 	PDM1_MIC_A_ENABLE 1
 	PDM1_MIC_B_ENABLE 1
-	DMIC0_HOST_PIPELINE_ID 13
-	DMIC0_DAI_PIPELINE_ID 14
-	DMIC0_HOST_PIPELINE_SINK 'copier.host.13.1'
-	DMIC0_DAI_PIPELINE_SRC 'copier.DMIC.14.1'
+	DMIC0_HOST_PIPELINE_ID 100
+	DMIC0_DAI_PIPELINE_ID 101
+	DMIC0_HOST_PIPELINE_SINK 'copier.host.100.1'
+	DMIC0_DAI_PIPELINE_SRC 'copier.DMIC.101.1'
 	DMIC0_NAME 'dmic01'
 	DMIC0_ID 4
 	DMIC1_ID 5
@@ -113,8 +113,8 @@ Object.Dai {
 
 # Pipeline ID:1 PCM ID: 0
 Object.Pipeline {
-	host-copier-gain-mixin-playback."1" {
-		index 1
+	host-copier-gain-mixin-playback.0 {
+		index 0
 
 	Object.Widget.copier.1 {
 		stream_name "volume playback 0"
@@ -126,8 +126,8 @@ Object.Pipeline {
 		}
 	}
 
-	mixout-gain-dai-copier-playback."2" {
-		index 2
+	mixout-gain-dai-copier-playback.1 {
+		index 1
 
 		Object.Widget.pipeline.1.stream_name	"copier.ALH.2.1"
 
@@ -144,8 +144,8 @@ Object.Pipeline {
 		}
 	}
 
-	passthrough-capture."4" {
-		index 4
+	passthrough-capture.10 {
+		index 10
 		Object.Widget.pipeline.1.stream_name	"copier.ALH.3.1"
 
 		Object.Widget.copier.1.stream_name	"Passthrough Capture 0"
@@ -155,9 +155,9 @@ Object.Pipeline {
 			in_bit_depth	32
 		}
 	}
-	passthrough-be.3 {
+	passthrough-be.11 {
 		direction	"capture"
-		index 3
+		index 11
 		copier_type "ALH"
 		Object.Widget.pipeline.1 {
 			stream_name	'copier.ALH.3.1'
@@ -173,7 +173,7 @@ Object.Pipeline {
 }
 
 Object.PCM {
-	pcm."0" {
+	pcm.0 {
 		name	"Jack out"
 		id 0
 		direction	"playback"
@@ -184,7 +184,7 @@ Object.PCM {
 			formats 'S16_LE,S32_LE'
 		}
 	}
-	pcm."1" {
+	pcm.1 {
 		name	"Jack in"
 		id 1
 		direction	"capture"
@@ -198,18 +198,18 @@ Object.PCM {
 }
 
 Object.Base {
-	route."0" {
-		source	"gain.2.1"
-		sink	"copier.ALH.2.1"
+	route.0 {
+		source	"gain.1.1"
+		sink	"copier.ALH.1.1"
 	}
 
-	route."1" {
-		source	"copier.ALH.3.1"
-		sink	"copier.host.4.1"
+	route.1 {
+		source "mixin.0.1"
+		sink "mixout.1.1"
 	}
 
-	route."2" {
-		source "mixin.1.1"
-		sink "mixout.2.1"
+	route.10 {
+		source	"copier.ALH.11.1"
+		sink	"copier.host.10.1"
 	}
 }

--- a/tools/topology/topology2/platform/intel/alh-2nd-spk.conf
+++ b/tools/topology/topology2/platform/intel/alh-2nd-spk.conf
@@ -1,0 +1,15 @@
+
+Object.Pipeline {
+	passthrough-be.$ALH_2ND_SPK_ID {
+		direction	"playback"
+		index $ALH_2ND_SPK_ID
+		copier_type "ALH"
+		Object.Widget.copier.1 {
+			stream_name	$SDW_SPK_STREAM
+			dai_type	"ALH"
+			copier_type	"ALH"
+			type		"dai_in"
+			node_type $ALH_LINK_OUTPUT_CLASS
+		}
+	}
+}

--- a/tools/topology/topology2/platform/intel/dmic-generic.conf
+++ b/tools/topology/topology2/platform/intel/dmic-generic.conf
@@ -63,7 +63,7 @@ Object.Dai {
 }
 
 Object.Pipeline {
-	passthrough-capture.0 {
+	passthrough-capture.100 {
 		format		$FORMAT
 		index 		$DMIC0_HOST_PIPELINE_ID
 		Object.Widget.pipeline.1 {
@@ -74,7 +74,7 @@ Object.Pipeline {
 		}
 	}
 
-	passthrough-be.11 {
+	passthrough-be.101 {
 		direction	"capture"
 		format 	$FORMAT
 		index		$DMIC0_DAI_PIPELINE_ID

--- a/tools/topology/topology2/platform/intel/sdw-amp-generic.conf
+++ b/tools/topology/topology2/platform/intel/sdw-amp-generic.conf
@@ -1,0 +1,84 @@
+# route and pipeline index start from pcm id * 10
+
+Define {
+	SDW_SPK_STREAM 'SDW1-Playback'
+	ALH_2ND_SPK_ID 22
+	SDW_AMP_BE_ID 2
+}
+
+Object.Dai {
+	ALH."514" {
+		id 		$SDW_AMP_BE_ID
+		direction	"playback"
+		name		$SDW_SPK_STREAM
+		default_hw_conf_id	0
+		rate			48000
+		channels		2
+
+		Object.Base.hw_config."ALH514" {
+			id	0
+		}
+	}
+}
+
+Object.Pipeline {
+	host-copier-gain-mixin-playback.20 {
+		index 20
+
+		Object.Widget.copier.1 {
+			stream_name "sdw amplifiers"
+		}
+		Object.Widget.gain.1 {
+			Object.Control.mixer.1 {
+				name 'Amplifier Volume'
+			}
+		}
+	}
+
+	mixout-gain-dai-copier-playback.21 {
+		index 21
+
+		Object.Widget.copier.1 {
+			stream_name $SDW_SPK_STREAM
+			dai_type "ALH"
+			copier_type "ALH"
+			node_type $ALH_LINK_OUTPUT_CLASS
+		}
+		Object.Widget.gain.1 {
+			Object.Control.mixer.1 {
+				name 'Main Amplifier Volume'
+			}
+		}
+	}
+
+}
+
+IncludeByKey.NUM_SDW_AMPS {
+"2" "platform/intel/alh-2nd-spk.conf"
+}
+
+Object.PCM {
+	pcm.2 {
+		name	"Speaker"
+		id 2
+		direction	"playback"
+		Object.Base.fe_dai."Speaker" {}
+
+		Object.PCM.pcm_caps."playback" {
+			name "sdw amplifiers"
+			formats 'S16_LE,S24_LE,S32_LE'
+		}
+	}
+}
+
+Object.Base {
+	route.20 {
+		source	"gain.21.1"
+		sink	"copier.ALH.21.1"
+	}
+
+	route.21 {
+		source 'mixin.20.1'
+		sink 'mixout.21.1'
+	}
+}

--- a/tools/topology/topology2/platform/intel/sdw-dmic-generic.conf
+++ b/tools/topology/topology2/platform/intel/sdw-dmic-generic.conf
@@ -1,0 +1,67 @@
+# route and pipeline index start from pcm id * 10
+
+Define {
+	SDW_DMIC_STREAM 'SDW3-Capture'
+	SDW_DMIC_BE_ID 4
+}
+
+Object.Dai {
+	ALH."771" {
+		id 		$SDW_DMIC_BE_ID
+		direction	"capture"
+		name		$SDW_DMIC_STREAM
+		default_hw_conf_id	0
+		rate			48000
+		channels		2
+
+		Object.Base.hw_config."ALH771" {
+			id	0
+		}
+	}
+}
+
+Object.Pipeline {
+	passthrough-capture.40 {
+		index 40
+
+		Object.Widget.copier.1.stream_name	"sdw dmic"
+		Object.Widget.copier.1.Object.Base.audio_format.1 {
+			# 32 -> 16 bits conversion is done here,
+			# so in_bit_depth is 32 (and out_bit_depth is 16).
+			in_bit_depth	32
+		}
+	}
+	passthrough-be.41 {
+		direction	"capture"
+		index 41
+		copier_type "ALH"
+		Object.Widget.copier.1 {
+			stream_name	$SDW_DMIC_STREAM
+			dai_type	"ALH"
+			copier_type	"ALH"
+			type		"dai_out"
+			node_type $ALH_LINK_INPUT_CLASS
+		}
+	}
+}
+
+Object.PCM {
+	pcm.4 {
+		name	"Microphone"
+		id 4
+		direction	"capture"
+		Object.Base.fe_dai."SDW DMIC" {}
+
+		Object.PCM.pcm_caps."capture" {
+			name "sdw dmic"
+			formats 'S16_LE,S24_LE,S32_LE'
+		}
+	}
+}
+
+Object.Base {
+	route.40 {
+		source	"copier.ALH.41.1"
+		sink	"copier.host.40.1"
+	}
+}


### PR DESCRIPTION
Add Speaker PCM to cavs-sdw topology. The default is for no aggregated speaker and AGGREGATED=1 should be set in CMakeLists.txt for aggregated speaker.
The 2nd ALH copier stream name should be the same as the 1st ALH copier, and no need to connect to the route.
The 2nd ALH copier data will be set to the 1st ALH copier's gateway config in the aggregated mode.

Signed-off-by: Bard Liao <yung-chuan.liao@linux.intel.com>