### PR TITLE
cavs: dma: Add device nodes for link DMA

### DIFF
--- a/src/platform/intel/cavs/lib/dma.c
+++ b/src/platform/intel/cavs/lib/dma.c
@@ -274,6 +274,16 @@ int dmac_init(struct sof *sof)
 			z_dev = DEVICE_DT_GET(DT_NODELABEL(hda_host_out));
 #endif
 			break;
+		case DMA_LINK_IN_DMAC:
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(hda_link_in), okay)
+			z_dev = DEVICE_DT_GET(DT_NODELABEL(hda_link_in));
+#endif
+			break;
+		case DMA_LINK_OUT_DMAC:
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(hda_link_out), okay)
+			z_dev = DEVICE_DT_GET(DT_NODELABEL(hda_link_out));
+#endif
+			break;
 		case DMA_GP_LP_DMAC0:
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(lpgpdma0), okay)
 			z_dev = DEVICE_DT_GET(DT_NODELABEL(lpgpdma0));


### PR DESCRIPTION
Add the device nodes for HDA link DMA when using the native zephyr drivers.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>