### PR TITLE
Detect double rimage git checkout

### DIFF
--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -561,7 +561,24 @@ def build_platforms():
 
 		# CMake - configure rimage module
 		rimage_dir_name="build-rimage"
-		rimage_source_dir = pathlib.Path(SOF_TOP, "rimage")
+
+		# Paths in `west.yml` must be "static", we cannot have something like a
+		# variable "$my_sof_path/rimage/" checkout.  In the future "rimage/" will
+		# be moved one level up and it won't be nested inside "sof/" anymore. But
+		# for now we must stick to `sof/rimage/[tomlc99]` for
+		# backwards-compatibility with XTOS platforms and git submodules, see more
+		# detailed comments in west.yml
+		rimage_source_dir = pathlib.Path(west_top, "sof", "rimage")
+
+		# Detect non-west rimage duplicates
+		nested_rimage = pathlib.Path(SOF_TOP, "rimage")
+		if nested_rimage.is_dir() and not nested_rimage.samefile(rimage_source_dir):
+			raise RuntimeError(
+				f"""Two rimage source directories found.
+     Move non-west {nested_rimage} out of west workspace {west_top}.
+     See output of 'west list'."""
+			)
+
 		execute_command(["cmake", "-B", rimage_dir_name, "-S", str(rimage_source_dir)],
 			cwd=west_top)
 		# CMake build rimage module

--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -574,7 +574,7 @@ def build_platforms():
 
 		# Sign firmware
 		rimage_executable = shutil.which("rimage", path=pathlib.Path(west_top, rimage_dir_name))
-		rimage_config = pathlib.Path(SOF_TOP, "rimage", "config")
+		rimage_config = pathlib.Path(rimage_source_dir, "config")
 		sign_cmd = ["west"]
 		sign_cmd += ["-v"] * args.verbose
 		sign_cmd += ["sign", "--build-dir", platform_build_dir_name, "--tool", "rimage"]

--- a/west.yml
+++ b/west.yml
@@ -59,11 +59,6 @@ manifest:
           - tinycrypt
 
   self:
-    # sof can unfortunately NOT be cloned as "sof2" nor "sof-topic1"
-    # because for now rimage is cloned as "sof/rimage", tomlc99 as
-    # "sof/rimage/tomlc99" and probably other build issues that we have
-    # not discovered yet.
-    path: sof
     # Changes to submanifests/*.yml files _are_ effective; these have no
     # specified 'revision:'
     import: submanifests


### PR DESCRIPTION
3 commits. Main one:

xtensa-build-zephyr.py: detect multiple rimage checkouts and abort

When cloning sof under a different directory name like
sof-experiment1 ((which is bad but we can't stop it unfortunately and it
keeps happening), it's common to end up with two rimage git checkouts:
sof/rimage and sof-experiment1/rimage. Detect this and fail immediately.