### PR TITLE
Revise mt8186 ADSP clock driver

### DIFF
--- a/src/platform/mt8186/include/platform/lib/clk.h
+++ b/src/platform/mt8186/include/platform/lib/clk.h
@@ -30,10 +30,8 @@ struct sof;
 #define MTK_ADSP_CLK_BUS_SRC_EMI		0
 #define MTK_ADSP_CLK_BUS_SRC_LOCAL		1
 
-/* MTK_CLK_CFG_UPDATE */
-#define MTK_CLK_CFG_ADSP_UPDATE			BIT(16)
-
 /* MTK_CLK_CFG_11 */
+#define MTK_CLK_CFG_ADSP_UPDATE			BIT(16)
 #define MTK_CLK_ADSP_OFFSET			24
 #define MTK_CLK_ADSP_MASK			0x7
 #define MTK_CLK_ADSP_26M			0
@@ -42,6 +40,25 @@ struct sof;
 #define MTK_CLK_ADSP_DSPPLL_2			3
 #define MTK_CLK_ADSP_DSPPLL_4			4
 #define MTK_CLK_ADSP_DSPPLL_8			5
+
+/* MTK_CLK_CFG_15 */
+#define MTK_CLK_CFG_ADSP_BUS_UPDATE		BIT(31)
+#define MTK_CLK_ADSP_BUS_OFFSET			17
+#define MTK_CLK_ADSP_BUS_MASK			0x7
+#define MTK_CLK_ADSP_BUS_26M			0
+#define MTK_CLK_ADSP_BUS_ULPOSC_D_2		1
+#define MTK_CLK_ADSP_BUS_MAINPPLL_D_5		2
+#define MTK_CLK_ADSP_BUS_MAINPPLL_D_2_D_2	3
+#define MTK_CLK_ADSP_BUS_MAINPPLL_D_3		4
+#define MTK_CLK_ADSP_BUS_RESERVED		5
+#define MTK_CLK_ADSP_BUS_UNIVPLL_D_3		6
+
+#define MTK_PLL_BASE_EN				BIT(0)
+#define MTK_PLL_PWR_ON				BIT(0)
+#define MTK_PLL_ISO_EN				BIT(1)
+
+#define MTK_PLL_DIV_RATIO_300M			0x831713B2
+#define MTK_PLL_DIV_RATIO_400M			0x831EC4ED
 
 /* List resource from low to high request */
 /* 0 is the lowest request */

--- a/src/platform/mt8186/include/platform/lib/clk.h
+++ b/src/platform/mt8186/include/platform/lib/clk.h
@@ -18,9 +18,10 @@ struct sof;
 
 #define CLK_CPU(x)				(x)
 #define CLK_DEFAULT_CPU_HZ			26000000
-#define CLK_MAX_CPU_HZ				800000000
+/* check vcore voltage before select higher frequency than 300M */
+#define CLK_MAX_CPU_HZ				300000000
 #define NUM_CLOCKS				1
-#define NUM_CPU_FREQ				5
+#define NUM_CPU_FREQ				3
 
 /* MTK_ADSP_CLK_BUS_UPDATE */
 #define MTK_ADSP_CLK_BUS_UPDATE_BIT		BIT(31)
@@ -46,10 +47,8 @@ struct sof;
 /* 0 is the lowest request */
 enum ADSP_HW_DSP_CLK {
 	ADSP_CLK_26M = 0,
-	ADSP_CLK_PLL_800M_D_8,
-	ADSP_CLK_PLL_800M_D_4,
-	ADSP_CLK_PLL_800M_D_2,
-	ADSP_CLK_PLL_800M,
+	ADSP_CLK_PLL_300M,
+	ADSP_CLK_PLL_400M,
 };
 
 void platform_clock_init(struct sof *sof);

--- a/src/platform/mt8186/lib/clk.c
+++ b/src/platform/mt8186/lib/clk.c
@@ -26,10 +26,8 @@ DECLARE_TR_CTX(clkdrv_tr, SOF_UUID(clkdrv_uuid), LOG_LEVEL_INFO);
 /* default voltage is 0.8V */
 const struct freq_table platform_cpu_freq[] = {
 	{  26000000, 26000},
-	{ 100000000, 26000},
-	{ 200000000, 26000},
+	{ 300000000, 26000},
 	{ 400000000, 26000},
-	{ 800000000, 26000},
 };
 
 STATIC_ASSERT(ARRAY_SIZE(platform_cpu_freq) == NUM_CPU_FREQ,
@@ -62,20 +60,17 @@ static int clock_platform_set_dsp_freq(int clock, int freq_idx)
 	case ADSP_CLK_26M:
 		set_mux_adsp_sel(MTK_CLK_ADSP_26M);
 		break;
-	case ADSP_CLK_PLL_800M_D_8:
-		set_mux_adsp_sel(MTK_CLK_ADSP_DSPPLL_8);
+	case ADSP_CLK_PLL_300M:
+		clock_platform_set_dsp_freq(clock, ADSP_CLK_26M);
+		set_mux_adsp_sel(MTK_CLK_ADSP_DSPPLL);
 		break;
-	case ADSP_CLK_PLL_800M_D_4:
-		set_mux_adsp_sel(MTK_CLK_ADSP_DSPPLL_4);
-		break;
-	case ADSP_CLK_PLL_800M_D_2:
-		set_mux_adsp_sel(MTK_CLK_ADSP_DSPPLL_2);
-		break;
-	case ADSP_CLK_PLL_800M:
+	case ADSP_CLK_PLL_400M:
+		clock_platform_set_dsp_freq(clock, ADSP_CLK_26M);
 		set_mux_adsp_sel(MTK_CLK_ADSP_DSPPLL);
 		break;
 	default:
-		set_mux_adsp_sel(MTK_CLK_ADSP_26M);
+		clock_platform_set_dsp_freq(clock, ADSP_CLK_26M);
+		tr_err(&clkdrv_tr, "unknown freq index %x\n", freq_idx);
 		break;
 	}
 

--- a/src/platform/mt8186/lib/clk.c
+++ b/src/platform/mt8186/lib/clk.c
@@ -85,6 +85,7 @@ static void set_mux_adsp_bus_src_sel(uint32_t value)
 {
 	io_reg_write(MTK_ADSP_BUS_SRC, value);
 	io_reg_write(MTK_ADSP_CLK_BUS_UPDATE, MTK_ADSP_CLK_BUS_UPDATE_BIT);
+	wait_delay_us(1);
 
 	tr_dbg(&clkdrv_tr, "adsp_bus_mux=%x, MTK_ADSP_BUS_SRC=0x%08x\n",
 	       value, io_reg_read(MTK_ADSP_BUS_SRC));
@@ -151,4 +152,6 @@ void platform_clock_init(struct sof *sof)
 
 		k_spinlock_init(&sof->clocks[i].lock);
 	}
+
+	clock_set_freq(CLK_CPU(cpu_get_id()), CLK_MAX_CPU_HZ);
 }

--- a/src/platform/mt8186/lib/clk.c
+++ b/src/platform/mt8186/lib/clk.c
@@ -6,15 +6,16 @@
 //         Tinghan Shen <tinghan.shen@mediatek.com>
 
 #include <platform/drivers/mt_reg_base.h>
-#include <sof/common.h>
 #include <rtos/clk.h>
+#include <rtos/spinlock.h>
+#include <rtos/wait.h>
+#include <sof/common.h>
 #include <sof/lib/cpu.h>
 #include <sof/lib/io.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/notifier.h>
 #include <sof/lib/uuid.h>
 #include <sof/sof.h>
-#include <rtos/spinlock.h>
 #include <sof/trace/trace.h>
 
 /* 53863428-9a72-44df-af0f-fe45ea2348ba */
@@ -35,6 +36,41 @@ STATIC_ASSERT(ARRAY_SIZE(platform_cpu_freq) == NUM_CPU_FREQ,
 
 static SHARED_DATA struct clock_info platform_clocks_info[NUM_CLOCKS];
 
+static void clk_dsppll_enable(uint32_t value)
+{
+	tr_dbg(&clkdrv_tr, "clk_dsppll_enable: %d\n", value);
+
+	switch (value) {
+	case ADSP_CLK_PLL_300M:
+		io_reg_write(MTK_ADSPPLL_CON1, MTK_PLL_DIV_RATIO_300M);
+		break;
+	case ADSP_CLK_PLL_400M:
+		io_reg_write(MTK_ADSPPLL_CON1, MTK_PLL_DIV_RATIO_400M);
+		break;
+	default:
+		tr_err(&clkdrv_tr, "invalid dsppll: %d\n", value);
+		return;
+	}
+
+	io_reg_update_bits(MTK_ADSPPLL_CON3, MTK_PLL_PWR_ON, MTK_PLL_PWR_ON);
+	wait_delay_us(20);
+	io_reg_update_bits(MTK_ADSPPLL_CON3, MTK_PLL_ISO_EN, 0);
+	wait_delay_us(1);
+	io_reg_update_bits(MTK_ADSPPLL_CON0, MTK_PLL_BASE_EN, MTK_PLL_BASE_EN);
+	wait_delay_us(20);
+}
+
+static void clk_dsppll_disable(void)
+{
+	tr_dbg(&clkdrv_tr, "clk_dsppll_disable\n");
+
+	io_reg_update_bits(MTK_ADSPPLL_CON0, MTK_PLL_BASE_EN, 0);
+	wait_delay_us(1);
+	io_reg_update_bits(MTK_ADSPPLL_CON3, MTK_PLL_ISO_EN, MTK_PLL_ISO_EN);
+	wait_delay_us(1);
+	io_reg_update_bits(MTK_ADSPPLL_CON3, MTK_PLL_PWR_ON, 0);
+}
+
 static void set_mux_adsp_sel(uint32_t value)
 {
 	io_reg_write(MTK_CLK_CFG_11_CLR, MTK_CLK_ADSP_MASK << MTK_CLK_ADSP_OFFSET);
@@ -54,19 +90,38 @@ static void set_mux_adsp_bus_src_sel(uint32_t value)
 	       value, io_reg_read(MTK_ADSP_BUS_SRC));
 }
 
+static void set_mux_adsp_bus_sel(uint32_t value)
+{
+	io_reg_write(MTK_CLK_CFG_15_CLR, MTK_CLK_ADSP_BUS_MASK << MTK_CLK_ADSP_BUS_OFFSET);
+	io_reg_write(MTK_CLK_CFG_15_SET, value << MTK_CLK_ADSP_BUS_OFFSET);
+	io_reg_write(MTK_CLK_CFG_UPDATE, MTK_CLK_CFG_ADSP_BUS_UPDATE);
+
+	tr_dbg(&clkdrv_tr, "adsp_bus_clk_mux=%x, CLK_CFG_15=0x%08x\n",
+	       value, io_reg_read(MTK_CLK_CFG_15));
+}
+
 static int clock_platform_set_dsp_freq(int clock, int freq_idx)
 {
 	switch (freq_idx) {
 	case ADSP_CLK_26M:
+		set_mux_adsp_bus_sel(MTK_CLK_ADSP_BUS_26M);
+		set_mux_adsp_bus_src_sel(MTK_ADSP_CLK_BUS_SRC_LOCAL);
 		set_mux_adsp_sel(MTK_CLK_ADSP_26M);
+		clk_dsppll_disable();
 		break;
 	case ADSP_CLK_PLL_300M:
 		clock_platform_set_dsp_freq(clock, ADSP_CLK_26M);
+		clk_dsppll_enable(ADSP_CLK_PLL_300M);
 		set_mux_adsp_sel(MTK_CLK_ADSP_DSPPLL);
+		set_mux_adsp_bus_src_sel(MTK_ADSP_CLK_BUS_SRC_EMI);
+		set_mux_adsp_bus_sel(MTK_CLK_ADSP_BUS_26M);
 		break;
 	case ADSP_CLK_PLL_400M:
 		clock_platform_set_dsp_freq(clock, ADSP_CLK_26M);
+		clk_dsppll_enable(ADSP_CLK_PLL_400M);
 		set_mux_adsp_sel(MTK_CLK_ADSP_DSPPLL);
+		set_mux_adsp_bus_src_sel(MTK_ADSP_CLK_BUS_SRC_EMI);
+		set_mux_adsp_bus_sel(MTK_CLK_ADSP_BUS_26M);
 		break;
 	default:
 		clock_platform_set_dsp_freq(clock, ADSP_CLK_26M);
@@ -96,7 +151,4 @@ void platform_clock_init(struct sof *sof)
 
 		k_spinlock_init(&sof->clocks[i].lock);
 	}
-
-	/* DSP bus clock */
-	set_mux_adsp_bus_src_sel(MTK_ADSP_CLK_BUS_SRC_EMI);
 }

--- a/src/platform/mt8186/platform.c
+++ b/src/platform/mt8186/platform.c
@@ -153,12 +153,6 @@ int platform_boot_complete(uint32_t boot_message)
 	/* now interrupt host to tell it we are done booting */
 	trigger_irq_to_host_req();
 
-	/* boot now complete so we can relax the CPU */
-	/* For now skip this to gain more processing performance
-	 * for SRC component.
-	 */
-	clock_set_freq(CLK_CPU(cpu_get_id()), CLK_MAX_CPU_HZ);
-
 	return 0;
 }
 


### PR DESCRIPTION
The mt8186 ADSP clock driver should initialize ADSP PLL after boot up before lift core frequency.
The flow of entering/leaving S3 state is also revised to prevent undefined behavior.

The patches were reviewed at https://github.com/thesofproject/sof/pull/6488
The PR was closed because we found a regression issue. 
The regression issue is fixed at this PR.