### PR TITLE
Audio: SRC: Refinements for common 2-stage and generic C FIR

### DIFF
--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -393,7 +393,6 @@ static void src_2s(struct comp_dev *dev, struct comp_data *cd,
 	 * the period length or just under it.
 	 */
 	s1.times = cd->param.stage1_times;
-	s1_blk_in = s1.times * cd->src.stage1->blk_in * nch;
 	s1_blk_out = s1.times * cd->src.stage1->blk_out * nch;
 
 	/* The sbuf may limit how many times s1 can be looped. It's harder
@@ -402,11 +401,11 @@ static void src_2s(struct comp_dev *dev, struct comp_data *cd,
 	 */
 	if (s1_blk_out > sbuf_free) {
 		s1.times = sbuf_free / (cd->src.stage1->blk_out * nch);
-		s1_blk_in = s1.times * cd->src.stage1->blk_in * nch;
 		s1_blk_out = s1.times * cd->src.stage1->blk_out * nch;
 		comp_dbg(dev, "s1.times = %d", s1.times);
 	}
 
+	s1_blk_in = s1.times * cd->src.stage1->blk_in * nch;
 	if (avail_b >= s1_blk_in * sz && sbuf_free >= s1_blk_out) {
 		cd->polyphase_func(&s1);
 
@@ -417,15 +416,14 @@ static void src_2s(struct comp_dev *dev, struct comp_data *cd,
 
 	s2.times = cd->param.stage2_times;
 	s2_blk_in = s2.times * cd->src.stage2->blk_in * nch;
-	s2_blk_out = s2.times * cd->src.stage2->blk_out * nch;
 	if (s2_blk_in > cd->sbuf_avail) {
 		s2.times = cd->sbuf_avail / (cd->src.stage2->blk_in * nch);
 		s2_blk_in = s2.times * cd->src.stage2->blk_in * nch;
-		s2_blk_out = s2.times * cd->src.stage2->blk_out * nch;
 		comp_dbg(dev, "s2.times = %d", s2.times);
 	}
 
 	/* Test if second stage can be run with default block length. */
+	s2_blk_out = s2.times * cd->src.stage2->blk_out * nch;
 	if (cd->sbuf_avail >= s2_blk_in && free_b >= s2_blk_out * sz) {
 		cd->polyphase_func(&s2);
 

--- a/src/audio/src/src_generic.c
+++ b/src/audio/src/src_generic.c
@@ -21,7 +21,6 @@
 
 static inline void fir_filter_generic(int32_t *rp, const void *cp, int32_t *wp0,
 				      int32_t *fir_start, int32_t *fir_end,
-				      const int fir_delay_length,
 				      const int taps_x_nch,
 				      const int shift, const int nch)
 {
@@ -115,7 +114,6 @@ static inline void fir_filter_generic(int32_t *rp, const void *cp, int32_t *wp0,
 
 static inline void fir_filter_generic(int32_t *rp, const void *cp, int32_t *wp0,
 				      int32_t *fir_start, int32_t *fir_end,
-				      int fir_delay_length,
 				      const int taps_x_nch, const int shift,
 				      const int nch)
 {
@@ -233,7 +231,6 @@ void src_polyphase_stage_cir(struct src_stage_prm *s)
 	const int nch_x_odm = cfg->odm * nch;
 	const int blk_in_words = nch * cfg->blk_in;
 	const int blk_out_words = nch * cfg->num_of_subfilters;
-	const int fir_length = fir->fir_delay_size;
 	const int rewind = nch * (cfg->blk_in + (cfg->num_of_subfilters - 1) * cfg->idm);
 	const int nch_x_idm = nch * cfg->idm;
 	const size_t fir_size = fir->fir_delay_size * sizeof(int32_t);
@@ -276,8 +273,7 @@ void src_polyphase_stage_cir(struct src_stage_prm *s)
 		src_inc_wrap(&rp, fir_end, fir_size);
 		wp = fir->out_rp;
 		for (i = 0; i < cfg->num_of_subfilters; i++) {
-			fir_filter_generic(rp, cp, wp,
-					   fir_delay, fir_end, fir_length,
+			fir_filter_generic(rp, cp, wp, fir_delay, fir_end,
 					   taps_x_nch, cfg->shift, nch);
 			wp += nch_x_odm;
 			cp = (char *)cp + subfilter_size;
@@ -333,7 +329,6 @@ void src_polyphase_stage_cir_s16(struct src_stage_prm *s)
 	const int nch_x_odm = cfg->odm * nch;
 	const int blk_in_words = nch * cfg->blk_in;
 	const int blk_out_words = nch * cfg->num_of_subfilters;
-	const int fir_length = fir->fir_delay_size;
 	const int rewind = nch * (cfg->blk_in + (cfg->num_of_subfilters - 1) * cfg->idm);
 	const int nch_x_idm = nch * cfg->idm;
 	const size_t fir_size = fir->fir_delay_size * sizeof(int32_t);
@@ -376,8 +371,7 @@ void src_polyphase_stage_cir_s16(struct src_stage_prm *s)
 		src_inc_wrap(&rp, fir_end, fir_size);
 		wp = fir->out_rp;
 		for (i = 0; i < cfg->num_of_subfilters; i++) {
-			fir_filter_generic(rp, cp, wp,
-					   fir_delay, fir_end, fir_length,
+			fir_filter_generic(rp, cp, wp, fir_delay, fir_end,
 					   taps_x_nch, cfg->shift, nch);
 			wp += nch_x_odm;
 			cp = (char *)cp + subfilter_size;

--- a/src/audio/src/src_generic.c
+++ b/src/audio/src/src_generic.c
@@ -64,9 +64,10 @@ static inline void fir_filter_generic(int32_t *rp, const void *cp, int32_t *wp0,
 			y1 += (int64_t)(*coef) * data[1];
 		}
 
-		if (data == fir_end)
-			data = fir_start;
-
+		/* No need to check for circular wrap. Pointer data is moved to
+		 * fir_start to be used by next loop if n2 is greater than zero.
+		 */
+		data = fir_start;
 		for (i = 0; i < n2; i++, coef++, data += 2) {
 			y0 += (int64_t)(*coef) * data[0];
 			y1 += (int64_t)(*coef) * data[1];
@@ -98,9 +99,10 @@ static inline void fir_filter_generic(int32_t *rp, const void *cp, int32_t *wp0,
 		for (i = 0; i < n1; i += nch, coef++, data += nch)
 			y0 += (int64_t)(*coef) * (*data);
 
-		if (data >= fir_end)
-			data -= fir_delay_length;
-
+		/* No need to check for circular wrap. Pointer data is moved to fir_start
+		 * plus actual channel to be used by next loop if n2 is greater than zero.
+		 */
+		data = fir_start + nch - j - 1;
 		for (i = 0; i < n2; i += nch, coef++, data += nch)
 			y0 += (int64_t)(*coef) * (*data);
 
@@ -159,9 +161,10 @@ static inline void fir_filter_generic(int32_t *rp, const void *cp, int32_t *wp0,
 			y1 += (int64_t)scaled_coef * data[1];
 		}
 
-		if (data == fir_end)
-			data = fir_start;
-
+		/* No need to check for circular wrap. Pointer data is moved to
+		 * fir_start to be used by next loop if n2 is greater than zero.
+		 */
+		data = fir_start;
 		for (i = 0; i < n2; i++, coef++, data += 2) {
 			scaled_coef = *coef >> 8;
 			y0 += (int64_t)scaled_coef * data[0];
@@ -193,9 +196,10 @@ static inline void fir_filter_generic(int32_t *rp, const void *cp, int32_t *wp0,
 		for (i = 0; i < n1; i += nch, coef++, data += nch)
 			y0 += (int64_t)(*coef >> 8) * (*data);
 
-		if (data >= fir_end)
-			data -= fir_delay_length;
-
+		/* No need to check for circular wrap. Pointer data is moved to fir_start
+		 * plus actual channel to be used by next loop if n2 is greater than zero.
+		 */
+		data = fir_start + nch - j - 1;
 		for (i = 0; i < n2; i += nch, coef++, data += nch)
 			y0 += (int64_t)(*coef >> 8) * (*data);
 


### PR DESCRIPTION
After changing this per review feedback the three commits are
- Audio: SRC: Optimize generic C fir data pointer wrap
- Audio: SRC: Refine input and output blocks count calculation
- Audio: SRC: Delete unused function parameter fir_delay_length

Only the first commit improves performance. The latter two have no measurable impact.

This PR saves in CML gcc build 2%, or 2.0 MCPS from 46.2 to 45.3
MCPS in stereo 44.1 kHz to 48 kHz conversion.
