### PR TITLE
cmake: upgrade cmake version to 3.20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 
 if("${CMAKE_CURRENT_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_BINARY_DIR}")
 	message(FATAL_ERROR

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -4,6 +4,8 @@
 # compile every Zephyr module that can be found.
 if(CONFIG_SOF)
 
+cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
+
 if(CONFIG_LIBRARY)
 	set(PLATFORM "library")
 	set(ARCH host)


### PR DESCRIPTION
Most of the Ubuntu 22.04 LTS OSes use now Cmake verson 3.22+. Most of the existing CI platforms also use newest Cmake versions. Zephyr project requires CMake 3.20.0 as minimal supported version. Time to move on and upgrade.

Signed-off-by: Andrey Borisovich <andrey.borisovich@intel.com>