### PR TITLE
pipeline-xrun: Reset pipeline when xrun occurs

### DIFF
--- a/src/audio/pipeline/pipeline-xrun.c
+++ b/src/audio/pipeline/pipeline-xrun.c
@@ -53,6 +53,7 @@ static int pipeline_comp_xrun(struct comp_dev *current,
 /* recover the pipeline from a XRUN condition */
 int pipeline_xrun_recover(struct pipeline *p)
 {
+	pipeline_reset(p, p->source_comp);
 	return -EINVAL;
 }
 


### PR DESCRIPTION
When a pipeline runs into an xrun, the state of the pipeline will be left as COMP_STATE_ACTIVE. Following this, when the application detects the xrun, it will try and stop the pipeline. This will result in a failure because the pipeline task has already completed and the state is ACTIVE. This will lead to the PIPELINE_DELETE IPC fail as well and the MOD_DX IPC fail because there are pipelines that are in the active state. To prevent this, reset the pipeline when an xrun occurs to leave in a READY state for pipeline stop, delete and DSP D3 entry to succeed.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>