### PR TITLE
topology2: cavs: Add SDW speaker,headset,hdmi and DMIC support

### DIFF
--- a/tools/topology/topology2/cavs/CMakeLists.txt
+++ b/tools/topology/topology2/cavs/CMakeLists.txt
@@ -38,6 +38,10 @@ HDA_CONFIG=mix,NUM_DMICS=4,PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,PREPROCESS_PL
 "cavs-sdw\;cavs-mtl-sdw-dmic\;NUM_DMICS=4,DMIC0_ID=2,DMIC1_ID=3,\
 PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-mtl-sdw-dmic.bin"
 
+# SDW external audio interface card(aic with SDW2-Headset codec, SDW0-Spk amp) + DMIC + HDMI topology with passthrough pipelines
+"cavs-sdw-aic\;cavs-mtl-sdw-aic-dmic-hdmi\;NUM_HDMIS=4,HDMI1_ID=6,HDMI2_ID=7,HDMI3_ID=8,HDMI4_ID=9,NUM_DMICS=4,\
+PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-mtl-sdw-aic-dmic.bin"
+
 # CAVS SSP topology for TGL
 "cavs-nocodec\;cavs-tgl-nocodec\;NUM_DMICS=4,PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,\
 PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-cavs-tgl-nocodec.bin"

--- a/tools/topology/topology2/cavs/cavs-sdw-aic.conf
+++ b/tools/topology/topology2/cavs/cavs-sdw-aic.conf
@@ -1,0 +1,287 @@
+<searchdir:cavs>
+<searchdir:include>
+<searchdir:include/common>
+<searchdir:include/components>
+<searchdir:include/dais>
+<searchdir:include/pipelines/cavs>
+<searchdir:cavs/platform/intel>
+
+<vendor-token.conf>
+<pdm_config.conf>
+<tokens.conf>
+<virtual.conf>
+<host-copier-gain-mixin-playback.conf>
+<mixout-gain-dai-copier-playback.conf>
+<deepbuffer-playback.conf>
+<passthrough-playback.conf>
+<passthrough-capture.conf>
+<passthrough-be.conf>
+<data.conf>
+<pcm.conf>
+<pcm_caps.conf>
+<fe_dai.conf>
+<alh.conf>
+<hda.conf>
+<dmic.conf>
+<hw_config.conf>
+<manifest.conf>
+<route.conf>
+<cavs/common_definitions.conf>
+<copier.conf>
+<pipeline.conf>
+<dai.conf>
+<host.conf>
+<dmic-default.conf>
+<hdmi-default.conf>
+
+Define {
+	DMIC_IO_CLK 38400000
+	NUM_DMICS 0
+	DMIC_DRIVER_VERSION 3
+	# override DMIC default definitions
+	PDM1_MIC_A_ENABLE 1
+	PDM1_MIC_B_ENABLE 1
+	DMIC0_HOST_PIPELINE_ID 13
+	DMIC0_DAI_PIPELINE_ID 14
+	DMIC0_HOST_PIPELINE_SINK 'copier.host.13.1'
+	DMIC0_DAI_PIPELINE_SRC 'copier.DMIC.14.1'
+	DMIC0_NAME 'dmic01'
+	DMIC0_ID 4
+	DMIC1_ID 5
+	DMIC0_PCM_CAPS 'Passthrough Capture 13'
+	DMIC0_PIPELINE_STREAM_NAME 'copier.DMIC.14.1'
+	USE_CHAIN_DMA	"false"
+}
+
+# include DMIC config if needed.
+IncludeByKey.NUM_DMICS {
+"[1-4]" "platform/intel/dmic-generic.conf"
+}
+
+Define {
+	NUM_HDMIS 0
+}
+
+# include HDMI config if needed.
+IncludeByKey.NUM_HDMIS {
+"[3-4]" "platform/intel/hdmi-generic.conf"
+}
+
+#
+# List of all DAIs
+#SDW2-Headset codec, SDW0-Spk amp
+#
+Object.Dai {
+	ALH."514" {
+		id 		0
+		direction	"playback"
+		name		SDW2-Playback
+		default_hw_conf_id	0
+		rate			48000
+		channels		2
+
+		Object.Base.hw_config."ALH514" {
+			id	0
+		}
+	}
+	ALH."515" {
+		id 		1
+		direction	"capture"
+		name		SDW2-Capture
+		default_hw_conf_id	1
+		rate			48000
+		channels		2
+
+		Object.Base.hw_config."ALH515" {
+			id	1
+		}
+	}
+	ALH."0" {
+		id 		2
+		direction	"playback"
+		name		SDW0-Playback
+		default_hw_conf_id	0
+		rate			48000
+		channels		2
+
+		Object.Base.hw_config."ALH2" {
+			id	0
+		}
+	}
+}
+
+#
+# Pipeline definitions
+#
+
+Object.Pipeline {
+	host-copier-gain-mixin-playback."1" {
+		index 1
+
+	Object.Widget.copier.1 {
+		stream_name "volume playback 0"
+	}
+	Object.Widget.gain.1 {
+		Object.Control.mixer.1 {
+			name '1 Playback Volume 0'
+			}
+		}
+	}
+
+	mixout-gain-dai-copier-playback."2" {
+		index 2
+
+		Object.Widget.pipeline.1.stream_name	"copier.ALH.2.1"
+
+		Object.Widget.copier.1 {
+			stream_name 'SDW2-Playback'
+			dai_type "ALH"
+			copier_type "ALH"
+			node_type $ALH_LINK_OUTPUT_CLASS
+		}
+		Object.Widget.gain.1 {
+			Object.Control.mixer.1 {
+				name '2 Main Playback Volume'
+			}
+		}
+	}
+
+	deepbuffer-playback."5" {
+		index 5
+
+		 Object.Widget.copier.1 {
+			 stream_name 'Deepbuffer Playback'
+		}
+
+		Object.Widget.gain.1 {
+			Object.Control.mixer.1 {
+				name '5 2nd Playback Volume'
+			}
+		}
+	}
+
+	passthrough-capture."4" {
+		index 4
+		Object.Widget.pipeline.1.stream_name	"copier.ALH.3.1"
+
+		Object.Widget.copier.1.stream_name	"Passthrough Capture 0"
+		Object.Widget.copier.1.Object.Base.audio_format.1 {
+			# 32 -> 16 bits conversion is done here,
+			# so in_bit_depth is 32 (and out_bit_depth is 16).
+			in_bit_depth	32
+		}
+	}
+
+	passthrough-be.3 {
+		direction	"capture"
+		index 3
+		copier_type "ALH"
+		Object.Widget.pipeline.1 {
+			stream_name	'copier.ALH.3.1'
+		}
+		Object.Widget.copier.1 {
+			stream_name	'SDW2-Capture'
+			dai_type	"ALH"
+			copier_type	"ALH"
+			type		"dai_out"
+			node_type $ALH_LINK_INPUT_CLASS
+		}
+	}
+
+	passthrough-playback."6" {
+		# pipeline_id
+		index 6
+
+		Object.Widget.pipeline.1.stream_name	"copier.ALH.7.1"
+		Object.Widget.copier.1.stream_name	"Passthrough Playback 0"
+	}
+
+	passthrough-be.7 {
+		direction	"playback"
+		index 7
+
+		Object.Widget.pipeline.1 {
+			stream_name	'copier.ALH.7.1'
+		}
+		Object.Widget.copier.1 {
+			stream_name	'SDW0-Playback'
+			dai_type	"ALH"
+			copier_type	"ALH"
+			type		"dai_in"
+			node_type $ALH_LINK_OUTPUT_CLASS
+		}
+	}
+}
+
+Object.PCM {
+	pcm."0" {
+		name	"Jack out"
+		id 0
+		direction	"playback"
+		Object.Base.fe_dai."Jack out" {}
+
+		Object.PCM.pcm_caps."playback" {
+			name "volume playback 0"
+			formats 'S16_LE,S32_LE'
+		}
+	}
+	pcm."1" {
+		name	"Jack in"
+		id 1
+		direction	"capture"
+		Object.Base.fe_dai."Jack in" {}
+
+		Object.PCM.pcm_caps."capture" {
+			name "Passthrough Capture 0"
+			formats 'S16_LE,S32_LE'
+		}
+	}
+	pcm."2" {
+		name 'DeepBuffer'
+		id 2
+		Object.Base.fe_dai.'DeepBuffer' {}
+		Object.PCM.pcm_caps.playback {
+			name 'Deepbuffer Playback'
+			formats 'S32_LE,S24_LE,S16_LE'
+		}
+		direction playback
+	}
+	pcm."3" {
+		name	"Speaker"
+		id 3
+		direction	"playback"
+		Object.Base.fe_dai."Speaker" {}
+
+		Object.PCM.pcm_caps."playback" {
+			name "Passthrough Playback 0"
+			formats 'S16_LE,S32_LE'
+		}
+	}
+}
+
+Object.Base {
+	route."0" {
+		source	"gain.2.1"
+		sink	"copier.ALH.2.1"
+	}
+
+	route."1" {
+		source	"copier.ALH.3.1"
+		sink	"copier.host.4.1"
+	}
+
+	route."2" {
+		source "mixin.1.1"
+		sink "mixout.2.1"
+	}
+
+	route.3 {
+		source 'mixin.5.1'
+		sink 'mixout.2.1'
+	}
+
+	route."4" {
+		source	"copier.host.6.1"
+		sink	"copier.ALH.7.1"
+	}
+}


### PR DESCRIPTION
This patch adds topology support to external SDW audio interface card (aic) with spk amp on SDW0 and headset codec on SDW2 along with DMIC and HDMI.

Hence, adding the entries for the same to match with below BE order:

SDW2-Playback, id 0
SDW2-Capture, id 1
SDW0-Playback, id 2
SDW0-Capture, id 3
dmic01, id 4
dmic16k, id 5
iDisp1, id 6
iDisp2, id 7
iDisp3, id 8
iDisp4, id 9

Signed-off-by: Yong Zhi <yong.zhi@intel.com>
Signed-off-by: jairaj-arava <jairaj.arava@intel.com>