### PR TITLE
copier: Don't block reset during xruns

### DIFF
--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -644,11 +644,6 @@ static int copier_reset(struct comp_dev *dev)
 
 	comp_dbg(dev, "copier_reset()");
 
-	if (dev->state == COMP_STATE_ACTIVE) {
-		comp_info(dev, "copier_config(): Component is in active state. Ignore resetting");
-		return 0;
-	}
-
 	cd->input_total_data_processed = 0;
 	cd->output_total_data_processed = 0;
 


### PR DESCRIPTION
When an xrun happens, the pipeline is reset to allow for a clean D3 entry. So remove the check for state in copier_reset() to allow the copier component to be reset during xruns.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>