### PR TITLE
zephyr: rtos: Add __vec_memcpy / __vec_memset

### DIFF
--- a/zephyr/include/rtos/string.h
+++ b/zephyr/include/rtos/string.h
@@ -63,6 +63,16 @@ static inline int memset_s(void *dest, size_t dest_size, int data, size_t count)
 	return 0;
 }
 
+static inline void *__vec_memcpy(void *dst, const void *src, size_t len)
+{
+	return memcpy(dst, src, len);
+}
+
+static inline void *__vec_memset(void *dest, int data, size_t src_size)
+{
+	return memset(dest, data, src_size);
+}
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif


### PR DESCRIPTION
libc used by Zephyr does not provide implementation for __vec_memcpy / __vec_memset so add them here.

Fixes c90055f2f51e ("header: rtos: use rtos specific version of string.h")
Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>