### PR TITLE
ipc4: idc: fix hdr data passed to idc_ipc msg

### DIFF
--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -1002,7 +1002,8 @@ void ipc_msg_reply(struct sof_ipc_reply *reply)
 
 void ipc_cmd(struct ipc_cmd_hdr *_hdr)
 {
-	struct ipc4_message_request *in = ipc_from_hdr(_hdr);
+	/* ignoring _hdr as it does not contain valid data in IPC4/IDC case */
+	struct ipc4_message_request *in = ipc_from_hdr(&msg_data.msg_in);
 	enum ipc4_message_target target;
 	int err;
 


### PR DESCRIPTION
Fix header data passed via idc_ipc command to ipc_cmd on secondary core.

In IPC3 handler, IPC msg header is stored in ipc->comp_data. ipc->comp_data passed to ipc_cmd() is valid for both cases:
- when calling ipc_cmd from ipc_platform_do_cmd for IPC handling
- when calling ipc_cmd from idc_ipc for IDC handling

In IPC4 handler, ipc->comp_data is not used to store IPC msg header. There is global structure msg_data instead. For IPC4, ipc_cmd() may be called in two cases:
- from ipc_platform_do_cmd for IPC handling: in this case, msg_data.msg_in is passed via ipc_compact_read_msg to handle IPC. This path is correct.
- from idc_ipc to handle IDC: in this case, still ipc->comp_data is passed, which does not contain valid IPC header. It passes invalid data to secondary core.

idc_ipc function is generic for all drivers, so changing it seems to be not recommended.
ipc_cmd function has common header for all drivers, so removing argument is also not a solution.

Fix problem by ignoring input argument for ipc_cmd in IPC4 handler and reading header from global msg_data struct.