### PR TITLE
component: add component ID print for IPC4 zephyr mtrace logging

### DIFF
--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -249,9 +249,9 @@ enum {
 		  (uint32_t)((pcd)->cpu_delta_peak))
 
 #define comp_perf_avg_info(pcd, comp_p)					\
-	comp_info(comp_p, "perf comp_copy samples %u period %u cpu avg %u peak %u",\
+	comp_info(comp_p, "perf comp:%x samples:%u avg:%u peak:%u",\
+		  (uint32_t)((comp_p)->drv->uid->a),            \
 		  (uint32_t)((comp_p)->frames),            \
-		  (uint32_t)((comp_p)->period),			    \
 		  (uint32_t)((pcd)->cpu_delta_sum),			\
 		  (uint32_t)((pcd)->cpu_delta_peak))
 


### PR DESCRIPTION
When enable profiling build, zephyr ipc4 mtrace log does not
include these info, so can't calculate each component performance.

This PR print these ID with each second performance data.
With these info, developer will easily get each component performance.

Below is a comparison between IPC3 sof logger and mtrace log:
IPC3:pga INFO perf comp_copy samples 48 period 1000
IPC4:c0 comp 61bca9a8 samples 48 period 1000 cpu avg 377 peak 630
Due to max line limiation, logs are shortened, IPC3 have pga displayed,
IPC4 does not, 61bca9a8 is added PGA component ID.

Signed-off-by: Baofeng Tian <baofeng.tian@intel.com>