### PR TITLE
[SKIP CI][test only] use same zephyr snapshot as mtl-002

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -43,8 +43,8 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 2e66fac6d3ff66502689a03520737bda7527ef6c
-      remote: zephyrproject
+      revision: 3301d341637a15a2e3a8820cb7f6b484e318e363
+      remote: thesofproject
       # Import some projects listed in zephyr/west.yml@revision
       #
       # Warning: changes to zephyr/west.yml or to any other _imported_


### PR DESCRIPTION
Please don't merge. This is only to compare test result between SOF main branch and mtl-002-drop-stable. 