### PR TITLE
zephyr: Add zephyr lib.c standalone file

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -579,6 +579,9 @@ zephyr_library_sources(
 	wrapper.c
 	edf_schedule.c
 	schedule.c
+
+	# Common library functions - Will be moved to Zephyr over time
+	lib.c
 )
 
 if(CONFIG_SCHEDULE_DMA_SINGLE_CHANNEL AND NOT(CONFIG_DMA_DOMAIN))

--- a/zephyr/include/rtos/string.h
+++ b/zephyr/include/rtos/string.h
@@ -11,6 +11,9 @@
 #include <stddef.h>
 #include <errno.h>
 
+void *__vec_memcpy(void *dst, const void *src, size_t len);
+void *__vec_memset(void *dest, int data, size_t src_size);
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -61,16 +64,6 @@ static inline int memset_s(void *dest, size_t dest_size, int data, size_t count)
 		return -ENOMEM;
 
 	return 0;
-}
-
-static inline void *__vec_memcpy(void *dst, const void *src, size_t len)
-{
-	return memcpy(dst, src, len);
-}
-
-static inline void *__vec_memset(void *dest, int data, size_t src_size)
-{
-	return memset(dest, data, src_size);
 }
 
 #ifdef __cplusplus

--- a/zephyr/lib.c
+++ b/zephyr/lib.c
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright 2022 NXP
+//
+// Author: Daniel Baluta <daniel.baluta@nxp.com>
+
+#include <rtos/string.h>
+
+#include <stddef.h>
+#include <stdint.h>
+
+void *__vec_memcpy(void *dst, const void *src, size_t len)
+{
+	return memcpy(dst, src, len);
+}
+
+void *__vec_memset(void *dest, int data, size_t src_size)
+{
+	return memset(dest, data, src_size);
+}


### PR DESCRIPTION
We need this in order to export symbols to external libraries.

E.g Cadence library needs __vec_memset / __vec_memcpy.

Previous commit d9aed376d59b ("zephyr: rtos: Add __vec_memcpy / __vec_memset") is not enough in the case of external libs.

Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>