### PR TITLE
topology2: fix audio format bit depth in deepbuffer copier

### DIFF
--- a/tools/topology/topology2/include/pipelines/cavs/deepbuffer-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/deepbuffer-playback.conf
@@ -53,7 +53,7 @@ Class.Pipeline."deepbuffer-playback" {
 			# 16-bit 48KHz 2ch
 			Object.Base.audio_format.1 {
 				out_bit_depth		32
-				out_valid_bit_depth	24
+				out_valid_bit_depth	32
 				# 100ms buffer
 				dma_buffer_size "$[$ibs * $DEEPBUFFER_FW_DMA_MS]"
 			}
@@ -62,7 +62,7 @@ Class.Pipeline."deepbuffer-playback" {
 				in_bit_depth		32
 				in_valid_bit_depth	24
 				out_bit_depth		32
-				out_valid_bit_depth	24
+				out_valid_bit_depth	32
 				# 100ms buffer
 				dma_buffer_size "$[$obs * $DEEPBUFFER_FW_DMA_MS]"
 			}


### PR DESCRIPTION
Fix out_valid_bit_depth for 16-bit and 24-bit audio formats.

Signed-off-by: Yong Zhi <yong.zhi@intel.com>