### PR TITLE
platform: mt8186: Disable ADSPPLL in S3 stage

### DIFF
--- a/src/platform/mt8186/platform.c
+++ b/src/platform/mt8186/platform.c
@@ -208,6 +208,7 @@ int platform_init(struct sof *sof)
 
 int platform_context_save(struct sof *sof)
 {
+	clock_set_freq(CLK_CPU(cpu_get_id()), CLK_DEFAULT_CPU_HZ);
 	return 0;
 }
 


### PR DESCRIPTION
The ADSPPLL clock is expected to be disabled in S3 stage. Fail to disable it may have premature wakeup in S3 stage.

Signed-off-by: Tinghan Shen <tinghan.shen@mediatek.com>