### PR TITLE
Backport mt8186 ADSP patches to branch mt8186/v0.2

### DIFF
--- a/src/platform/mt8186/platform.c
+++ b/src/platform/mt8186/platform.c
@@ -208,5 +208,6 @@ int platform_init(struct sof *sof)
 
 int platform_context_save(struct sof *sof)
 {
+	clock_set_freq(CLK_CPU(cpu_get_id()), CLK_DEFAULT_CPU_HZ);
 	return 0;
 }


### PR DESCRIPTION
platform: mt8186: Disable ADSPPLL in S3 stage

The ADSPPLL clock is expected to be disabled in S3 stage. 
Fail to disable it may have premature wakeup in S3 stage.

Signed-off-by: Tinghan Shen <tinghan.shen@mediatek.com>