### PR TITLE
Use ops wrapper instead of calling the ops directly for get_attribute

### DIFF
--- a/src/audio/pipeline/pipeline-graph.c
+++ b/src/audio/pipeline/pipeline-graph.c
@@ -536,7 +536,6 @@ struct comp_dev *pipeline_get_dai_comp_latency(uint32_t pipeline_id, uint32_t *l
 		uint64_t input_data, output_data;
 		struct ipc4_base_module_cfg input_base_cfg;
 		struct ipc4_base_module_cfg output_base_cfg;
-		const struct comp_driver *drv;
 		int ret;
 
 		/* Calculate pipeline latency */
@@ -545,13 +544,11 @@ struct comp_dev *pipeline_get_dai_comp_latency(uint32_t pipeline_id, uint32_t *l
 		if (!input_data || !output_data)
 			return NULL;
 
-		drv = source->drv;
-		ret = drv->ops.get_attribute(source, COMP_ATTR_BASE_CONFIG, &input_base_cfg);
+		ret = comp_get_attribute(source, COMP_ATTR_BASE_CONFIG, &input_base_cfg);
 		if (ret < 0)
 			return NULL;
 
-		drv = ipc_sink->cd->drv;
-		ret = drv->ops.get_attribute(ipc_sink->cd, COMP_ATTR_BASE_CONFIG, &output_base_cfg);
+		ret = comp_get_attribute(ipc_sink->cd, COMP_ATTR_BASE_CONFIG, &output_base_cfg);
 		if (ret < 0)
 			return NULL;
 

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -268,12 +268,11 @@ int ipc_pipeline_free(struct ipc *ipc, uint32_t comp_id)
 static struct comp_buffer *ipc4_create_buffer(struct comp_dev *src, struct comp_dev *sink,
 					      uint32_t src_queue, uint32_t dst_queue)
 {
-	const struct comp_driver *drv = src->drv;
 	struct ipc4_base_module_cfg src_cfg;
 	struct sof_ipc_buffer ipc_buf;
 	int buf_size, ret;
 
-	ret = drv->ops.get_attribute(src, COMP_ATTR_BASE_CONFIG, &src_cfg);
+	ret = comp_get_attribute(src, COMP_ATTR_BASE_CONFIG, &src_cfg);
 	if (ret < 0) {
 		tr_err(&ipc_tr, "failed to get base config for src %#x", dev_comp_id(src));
 		return NULL;


### PR DESCRIPTION
the wrapper checks if the ops exist, and call the ops only if it exists, which is safer