### PR TITLE
rtnr: cherry-pick formatting fix from main to mt8195/v0.4

### DIFF
--- a/src/audio/rtnr/rtnr.c
+++ b/src/audio/rtnr/rtnr.c
@@ -511,7 +511,7 @@ static int rtnr_set_config_bytes(struct comp_dev *dev,
 	 * the whole config data is received.
 	 */
 	if (size < sizeof(cd->config)) {
-		comp_err(dev, "rtnr_set_config_data(): invalid size %d",
+		comp_err(dev, "rtnr_set_config_data(): invalid size %u",
 			 size);
 		return -EINVAL;
 	}
@@ -522,7 +522,7 @@ static int rtnr_set_config_bytes(struct comp_dev *dev,
 		       sizeof(cd->config));
 
 	comp_info(dev,
-		  "rtnr_set_config_data(): sample_rate = %d, enabled=%d",
+		  "rtnr_set_config_data(): sample_rate = %u, enabled=%d",
 		  cd->config.params.sample_rate,
 		  cd->config.params.enabled);
 


### PR DESCRIPTION
This PR cherry-picks the following commit from main to mt8195/v0.4 branch to fix the formatting for unsigned parameters.

ef29d38ec2ff35adbb57d7dfac70ae6ab5fef250 [rtnr: Fix log formatting for unsigned parameters](https://github.com/thesofproject/sof/commit/ef29d38ec2ff35adbb57d7dfac70ae6ab5fef250)