### PR TITLE
platform: kconfig: Introduce MP_NUM_CPUS config

### DIFF
--- a/src/platform/Kconfig
+++ b/src/platform/Kconfig
@@ -304,6 +304,13 @@ config MAX_CORE_COUNT
 	help
 	  Maximum number of cores per configuration
 
+config MP_NUM_CPUS
+	int "Number of cores (Zephyr compatibility)"
+	default MAX_CORE_COUNT
+	range 1 MAX_CORE_COUNT
+	help
+	  Number of cores defined on Zephyr. Used for compatibility
+
 config CORE_COUNT
 	int "Number of cores"
 	default MP_NUM_CPUS if KERNEL_BIN_NAME = "zephyr"


### PR DESCRIPTION
This config is added as a refactor to make xtos behave more like Zephyr. It is needed to avoid a warning on the later use of MP_NUM_CPUS in CORE_COUNT on xtos builds.

This configuration would end up having a double definition when performing Zephyr builds; that should be fine.

Draft because I also intend to deprecate the regular CORE_COUNT config, so that MP_NUM_CPUS is used by all of the code within SOF instead of it.