### PR TITLE
ipc4: handler: Always invoke platform_context_save() when entering D3

### DIFF
--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -839,16 +839,12 @@ static int ipc4_module_process_dx(struct ipc4_message_request *ipc4)
 
 	/* Deactivating primary core if requested.  */
 	if (dx_info.core_mask & BIT(PLATFORM_PRIMARY_CORE_ID)) {
-		if (cpu_enabled_cores() & ~BIT(PLATFORM_PRIMARY_CORE_ID)) {
+		if (cpu_enabled_cores() & ~BIT(PLATFORM_PRIMARY_CORE_ID))
 			tr_err(&ipc_tr, "secondary cores 0x%x still active",
 			       cpu_enabled_cores());
-			return IPC4_BUSY;
-		}
 
-		if (is_any_ppl_active()) {
+		if (is_any_ppl_active())
 			tr_err(&ipc_tr, "some pipelines are still active");
-			return IPC4_BUSY;
-		}
 
 		/* do platform specific suspending */
 		platform_context_save(sof_get());


### PR DESCRIPTION
The host driver ignores the IPC errors and continues to power off the DSP after sending the request to power off the primary core. So, always platform_context_save() even in case of errors to avoid unexpected behaviour during resume.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>