### PR TITLE
Tools: Topology1: Add sof-hda-generic topology with SRC

### DIFF
--- a/tools/topology/topology1/development/CMakeLists.txt
+++ b/tools/topology/topology1/development/CMakeLists.txt
@@ -33,7 +33,6 @@ set(TPLGS
 	"sof-imx8mp-compr-pcm-cap-wm8960\;sof-imx8mp-compr-pcm-cap-wm8960"
 	"sof-apl-nocodec-demux-eq-4ch4ch\;sof-apl-nocodec-demux-eq-4ch4ch"
 	"sof-apl-nocodec-demux-eq-2ch4ch\;sof-apl-nocodec-demux-eq-2ch4ch"
-
 	"sof-hda-generic-kwd\;sof-hda-generic-2ch-kwd\;-DCHANNELS=2\;-DDYNAMIC=1"
 	"sof-hda-generic-kwd\;sof-hda-generic-4ch-kwd\;-DCHANNELS=4\;-DDYNAMIC=1"
 )
@@ -60,6 +59,9 @@ set(TPLGS_UP
 	"sof-hda-generic\;sof-hda-generic-2ch-drc\;-DCHANNELS=2\;-DHSPROC=drc\;-DDMICPROC_FILTER1=eq_iir_coef_highpass_40hz_20db_48khz.m4\;-DDMIC16KPROC_FILTER1=eq_iir_coef_highpass_40hz_20db_16khz.m4\;-DDYNAMIC=1"
 	"sof-hda-generic\;sof-hda-generic-2ch-mfcc\;-DCHANNELS=2\;-DHSPROC=volume\;-DDMICPROC_FILTER1=eq_iir_coef_highpass_40hz_20db_48khz.m4\;-DDMIC16KPROC_FILTER1=eq_iir_coef_highpass_40hz_20db_16khz.m4\;-DDYNAMIC=1\;-DDMIC16KPROC=eq-iir-mfcc"
 	"sof-tgl-rt711-rt1308\;sof-tgl-sdw-max98373-rt5682-dmic4ch-ampref\;-DCHANNELS=4\;-DEXT_AMP\;-DEXT_AMP_REF\;-DDMICPROC_FILTER1=eq_iir_coef_highpass_40hz_20db_48khz.m4\;-DDMIC16KPROC_FILTER1=eq_iir_coef_highpass_40hz_20db_16khz.m4\;-DPLATFORM=tgl"
+	"sof-hda-generic\;sof-hda-generic-src\;-DCHANNELS=0\;-DHSSFX=src-volume\;-DDMICPROC_FILTER1=eq_iir_coef_highpass_40hz_20db_48khz.m4\;-DDMIC16KPROC_FILTER1=eq_iir_coef_highpass_40hz_20db_16khz.m4"
+	"sof-hda-generic\;sof-hda-generic-2ch-src\;-DCHANNELS=2\;-DHSSFX=src-volume\;-DDMICPROC_FILTER1=eq_iir_coef_highpass_40hz_20db_48khz.m4\;-DDMIC16KPROC_FILTER1=eq_iir_coef_highpass_40hz_20db_16khz.m4"
+	"sof-hda-generic\;sof-hda-generic-4ch-src\;-DCHANNELS=4\;-DHSSFX=src-volume\;-DDMICPROC_FILTER1=eq_iir_coef_highpass_40hz_20db_48khz.m4\;-DDMIC16KPROC_FILTER1=eq_iir_coef_highpass_40hz_20db_16khz.m4"
 )
 
 add_custom_target(dev_topologies1 ALL)

--- a/tools/topology/topology1/sof-hda-generic.m4
+++ b/tools/topology/topology1/sof-hda-generic.m4
@@ -5,6 +5,7 @@
 ifdef(`DMICPROC', , `define(DMICPROC, eq-iir-volume)')
 ifdef(`DMIC16KPROC', , `define(DMIC16KPROC, eq-iir-volume)')
 ifdef(`HSPROC', , `define(HSPROC, volume)')
+ifdef(`HSSFX', , `define(HSSFX, volume)')
 
 # Include topology builder
 include(`utils.m4')
@@ -95,9 +96,13 @@ DAI_ADD(PIPE_HEADSET_PLAYBACK,
         NOT_USED_IGNORED, 2, s32le,
         1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER, 2, 48000)
 
+# If HSSFX_FILTERx is defined set PIPELINE_FILTERx
+ifdef(`HSSFX_FILTER1', `define(PIPELINE_FILTER1, HSSFX_FILTER1)', `undefine(`PIPELINE_FILTER1')')
+ifdef(`HSSFX_FILTER2', `define(PIPELINE_FILTER2, HSSFX_FILTER2)', `undefine(`PIPELINE_FILTER2')')
+
 # Low Latency playback pipeline 1 on PCM 30 using max 2 channels of s32le.
 # 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_ADD(sof/pipe-host-volume-playback.m4,
+PIPELINE_PCM_ADD(sof/pipe-host-HSSFX-playback.m4,
 	30, 0, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000,

--- a/tools/topology/topology1/sof/pipe-host-src-volume-playback.m4
+++ b/tools/topology/topology1/sof/pipe-host-src-volume-playback.m4
@@ -1,0 +1,110 @@
+# Host PCM Volume playback pipeline
+#
+# Pipeline Endpoints for connection are :-
+#
+#  host PCM_P --> B0 --> SRC 0 --> B1 --> Volume 0 --> B2 --> [other pipeline]
+
+# Include topology builder
+include(`utils.m4')
+include(`buffer.m4')
+include(`pcm.m4')
+include(`src.m4')
+include(`pga.m4')
+include(`dai.m4')
+include(`mixercontrol.m4')
+include(`pipeline.m4')
+
+#
+# Controls
+#
+# Volume Mixer control with max value of 32
+C_CONTROLMIXER(Playback Volume, PIPELINE_ID,
+	CONTROLMIXER_OPS(volsw, 256 binds the mixer control to volume get/put handlers, 256, 256),
+	CONTROLMIXER_MAX(, 32),
+	false,
+	CONTROLMIXER_TLV(TLV 32 steps from -64dB to 0dB for 2dB, vtlv_m64s2),
+	Channel register and shift for Front Left/Right,
+	VOLUME_CHANNEL_MAP)
+
+#
+# Volume configuration
+#
+
+define(DEF_PGA_TOKENS, concat(`pga_tokens_', PIPELINE_ID))
+define(DEF_PGA_CONF, concat(`pga_conf_', PIPELINE_ID))
+
+W_VENDORTUPLES(DEF_PGA_TOKENS, sof_volume_tokens,
+LIST(`		', `SOF_TKN_VOLUME_RAMP_STEP_TYPE	"0"'
+     `		', `SOF_TKN_VOLUME_RAMP_STEP_MS		"20"'))
+
+W_DATA(DEF_PGA_CONF, DEF_PGA_TOKENS)
+
+define(DEF_SRC_TOKENS, concat(`src_tokens_', PIPELINE_ID))
+define(DEF_SRC_CONF, concat(`src_conf_', PIPELINE_ID))
+
+W_VENDORTUPLES(DEF_SRC_TOKENS, sof_src_tokens,
+LIST(`		', `SOF_TKN_SRC_RATE_OUT	"PIPELINE_RATE"'))
+
+W_DATA(DEF_SRC_CONF, DEF_SRC_TOKENS)
+
+#
+# Components and Buffers
+#
+
+# Host "Playback" PCM
+# with 2 sink and 0 source periods
+W_PCM_PLAYBACK(PCM_ID, Playback, 2, 0, SCHEDULE_CORE)
+
+# "SRC" has 2 source and 2 sink periods
+W_SRC(0, PIPELINE_FORMAT, 2, 2, DEF_SRC_CONF)
+
+# "Volume" has 2 source and x sink periods
+W_PGA(0, PIPELINE_FORMAT, DAI_PERIODS, 2, DEF_PGA_CONF, SCHEDULE_CORE,
+	LIST(`		', "PIPELINE_ID Playback Volume"))
+
+# Playback Buffers
+W_BUFFER(0, COMP_BUFFER_SIZE(2,
+	COMP_SAMPLE_SIZE(PIPELINE_FORMAT), PIPELINE_CHANNELS, COMP_PERIOD_FRAMES(PCM_MAX_RATE, SCHEDULE_PERIOD)),
+	PLATFORM_HOST_MEM_CAP, SCHEDULE_CORE)
+W_BUFFER(1, COMP_BUFFER_SIZE(2,
+	COMP_SAMPLE_SIZE(PIPELINE_FORMAT), PIPELINE_CHANNELS, COMP_PERIOD_FRAMES(PCM_MAX_RATE, SCHEDULE_PERIOD)),
+	PLATFORM_HOST_MEM_CAP, SCHEDULE_CORE)
+W_BUFFER(2, COMP_BUFFER_SIZE(DAI_PERIODS,
+	COMP_SAMPLE_SIZE(DAI_FORMAT), PIPELINE_CHANNELS, COMP_PERIOD_FRAMES(PCM_MAX_RATE, SCHEDULE_PERIOD)),
+	PLATFORM_DAI_MEM_CAP, SCHEDULE_CORE)
+
+#
+# Pipeline Graph
+#
+#  host PCM_P --> B0 -- SRC 0 --> B1 --> Volume 0 --> B2 --> sink DAI0
+
+P_GRAPH(pipe-host-volume-playback, PIPELINE_ID,
+	LIST(`		',
+	`dapm(N_BUFFER(0), N_PCMP(PCM_ID))',
+	`dapm(N_SRC(0), N_BUFFER(0))',
+	`dapm(N_BUFFER(1), N_SRC(0))',
+	`dapm(N_PGA(0), N_BUFFER(1))',
+	`dapm(N_BUFFER(2), N_PGA(0))'))
+
+#
+# Pipeline Source and Sinks
+#
+indir(`define', concat(`PIPELINE_SOURCE_', PIPELINE_ID), N_BUFFER(2))
+indir(`define', concat(`PIPELINE_PCM_', PIPELINE_ID), Playback PCM_ID)
+
+#
+# Pipeline Configuration.
+#
+
+W_PIPELINE(SCHED_COMP, SCHEDULE_PERIOD, SCHEDULE_PRIORITY, SCHEDULE_CORE, SCHEDULE_TIME_DOMAIN, pipe_media_schedule_plat)
+
+#
+# PCM Configuration
+
+#
+PCM_CAPABILITIES(Playback PCM_ID, CAPABILITY_FORMAT_NAME(PIPELINE_FORMAT), 8000, 192000, 2, PIPELINE_CHANNELS, 2, 16, 192, 16384, 65536, 65536)
+
+undefine(`DEF_PGA_TOKENS')
+undefine(`DEF_PGA_CONF')
+undefine(`DEF_SRC_TOKENS')
+undefine(`DEF_SRC_CONF')


### PR DESCRIPTION
This patch adds to sof-hda-generic.m4 macros HSSFX, HSSFX_FILTER1, and HSSFX_FILTER2 those can be used to customize stream effect for PCM 30. The macro defaults to volume so the default topology build is not impacted.

The CMakeLists.txt in development is updated to build topologies sof-hda-generic-src.tplg, sof-hda-generic-2ch-src.tplg, and sof-hda-generic-4ch-src.tplg. The stream effect is set with HSSFX to src-volume.

The pipeline pipe-host-src-volume-playback.m4 is added. It is similar as pipe-host-volume-playback.m4 but a sample rate converter (SRC) is added after PCM, before volume. The PCM capability is changed to min 8000, max 192000 Hz.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>