### PR TITLE
dai-zephyr: Fix an erroneous free

### DIFF
--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -547,7 +547,8 @@ static int dai_playback_params(struct comp_dev *dev, uint32_t period_bytes,
 	dd->z_config = dma_cfg;
 
 free:
-	dma_sg_free(&config->elem_array);
+	if (err < 0)
+		dma_sg_free(&config->elem_array);
 out:
 	buffer_release(dma_buf);
 
@@ -675,7 +676,8 @@ static int dai_capture_params(struct comp_dev *dev, uint32_t period_bytes,
 	dd->z_config = dma_cfg;
 
 free:
-	dma_sg_free(&config->elem_array);
+	if (err < 0)
+		dma_sg_free(&config->elem_array);
 out:
 	buffer_release(dma_buf);
 


### PR DESCRIPTION
Do not free the config->elem_array when there's no error.

Fixes: faf2bd1067a3 ('dai-zephyr: free allocated memory in error paths')

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>