### PR TITLE
selector: use cfg->init_data in selector_init()

### DIFF
--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -603,7 +603,7 @@ static int selector_init(struct processing_module *mod)
 {
 	struct module_data *md = &mod->priv;
 	struct module_config *cfg = &md->cfg;
-	const struct ipc4_base_module_cfg *base_cfg = cfg->data;
+	const struct ipc4_base_module_cfg *base_cfg = cfg->init_data;
 	struct comp_data *cd;
 	int ret;
 


### PR DESCRIPTION
We are using cfg->init_data for the modules initialization and cfg->data is not ready when selector_init() is called. Using cfg->data in selector_init() will cause fw crash.

Signed-off-by: Libin Yang <libin.yang@intel.com>