### PR TITLE
IPC4: Enable multicore LL pipelines scenario logic

### DIFF
--- a/src/include/ipc4/pipeline.h
+++ b/src/include/ipc4/pipeline.h
@@ -105,7 +105,8 @@ struct ipc4_pipeline_create {
 			uint32_t lp             : 1;
 			uint32_t rsvd1          : 3;
 			uint32_t attributes     : 16;
-			uint32_t rsvd2          : 10;
+			uint32_t core_id        : 4;
+			uint32_t rsvd2          : 6;
 			uint32_t _reserved_2    : 2;
 		} r;
 	} extension;

--- a/src/include/sof/ipc/topology.h
+++ b/src/include/sof/ipc/topology.h
@@ -52,6 +52,7 @@ int ipc4_add_comp_dev(struct comp_dev *dev);
 const struct comp_driver *ipc4_get_drv(uint8_t *uuid);
 int ipc4_create_chain_dma(struct ipc *ipc, struct ipc4_chain_dma *cdma);
 int ipc4_trigger_chain_dma(struct ipc *ipc, struct ipc4_chain_dma *cdma, bool *delay);
+int ipc4_process_on_core(uint32_t core, bool blocking);
 #else
 #error "No or invalid IPC MAJOR version selected."
 #endif

--- a/src/ipc/ipc-common.c
+++ b/src/ipc/ipc-common.c
@@ -98,28 +98,6 @@ struct ipc_comp_dev *ipc_get_comp_by_id(struct ipc *ipc, uint32_t id)
 	return NULL;
 }
 
-struct ipc_comp_dev *ipc_get_comp_by_ppl_id(struct ipc *ipc, uint16_t type, uint32_t ppl_id)
-{
-	struct ipc_comp_dev *icd;
-	struct list_item *clist;
-
-	list_for_item(clist, &ipc->comp_list) {
-		icd = container_of(clist, struct ipc_comp_dev, list);
-		if (icd->type != type) {
-			continue;
-		}
-
-		if (!cpu_is_me(icd->core)) {
-			continue;
-		}
-
-		if (ipc_comp_pipe_id(icd) == ppl_id)
-			return icd;
-	}
-
-	return NULL;
-}
-
 /* Walks through the list of components looking for a sink/source endpoint component
  * of the given pipeline
  */

--- a/src/ipc/ipc3/helper.c
+++ b/src/ipc/ipc3/helper.c
@@ -288,6 +288,23 @@ static void comp_specific_builder(struct sof_ipc_comp *comp,
 	}
 }
 
+struct ipc_comp_dev *ipc_get_comp_by_ppl_id(struct ipc *ipc, uint16_t type, uint32_t ppl_id)
+{
+	struct ipc_comp_dev *icd;
+	struct list_item *clist;
+
+	list_for_item(clist, &ipc->comp_list) {
+		icd = container_of(clist, struct ipc_comp_dev, list);
+		if (icd->type != type)
+			continue;
+		if (!cpu_is_me(icd->core))
+			continue;
+		if (ipc_comp_pipe_id(icd) == ppl_id)
+			return icd;
+	}
+	return NULL;
+}
+
 struct comp_dev *comp_new(struct sof_ipc_comp *comp)
 {
 	struct comp_ipc_config config;

--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -1055,6 +1055,10 @@ void ipc_cmd(struct ipc_cmd_hdr *_hdr)
 		char *data = ipc->comp_data;
 		struct ipc4_message_reply reply;
 
+		/* Reply prepared by secondary core */
+		if ((ipc->task_mask & IPC_TASK_SECONDARY_CORE) && cpu_is_primary(cpu_get_id()))
+			return;
+
 		/* Do not send reply for SET_DX if we are going to enter D3
 		 * The reply is going to be sent as part of the power down
 		 * sequence

--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -240,7 +240,7 @@ static int set_pipeline_state(uint32_t id, uint32_t cmd, bool *delayed)
 
 		/* check core */
 		if (!cpu_is_me(host->core))
-			return ipc_process_on_core(host->core, false);
+			return ipc4_process_on_core(host->core, false);
 	}
 
 	switch (cmd) {

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -115,6 +115,32 @@ struct comp_dev *comp_new(struct sof_ipc_comp *comp)
 	return dev;
 }
 
+struct ipc_comp_dev *ipc_get_comp_by_ppl_id(struct ipc *ipc, uint16_t type, uint32_t ppl_id)
+{
+	struct ipc_comp_dev *icd;
+	struct list_item *clist;
+
+	list_for_item(clist, &ipc->comp_list) {
+		icd = container_of(clist, struct ipc_comp_dev, list);
+		if (icd->type != type)
+			continue;
+
+		/* For IPC4, ipc_comp_dev.id field is equal to Pipeline ID
+		 * in case of type COMP_TYPE_PIPELINE - can check directly here
+		 */
+		if (type == COMP_TYPE_PIPELINE) {
+			if (icd->id == ppl_id)
+				return icd;
+		} else {
+			if (!cpu_is_me(icd->core))
+				continue;
+			if (ipc_comp_pipe_id(icd) == ppl_id)
+				return icd;
+		}
+	}
+	return NULL;
+}
+
 static int ipc4_create_pipeline(struct ipc *ipc, uint32_t pipeline_id, uint32_t priority,
 				uint32_t memory_size)
 {


### PR DESCRIPTION
This PR implements SOF logic in IPC4 handler to enable multicore LL pipelines.
This is first draft or changes, that allows to use basic multicore scenarios.

Main assumptions:
- Pipeline and Module related IPC's forwarded to target core. Their data accessed only by this core, to avoid cache coherency problems.
- To allow pipeline allocation by target core, adding core_id field into CreatePipeline IPC struct for IPC4
- IPC's are forwarded to secondary core by IDC in non-blocking mode. Secondary core processes command and put response into IPC uplink queue.
- MultiPipelineSetState IPC currently supports only cases when all pipelines in command are allocated on the same target core 

This design is consistent with IPC3 handler implementation.

Future work to be done:
- Pipeline and Module data allocated on application heap separated per target core
- Support for connected pipelines allocated on different cores
- IDC queue to handle IPC responses and async messages
- Synchronized start of IPC's via MultiPipelineSetState
- Support for DP modules in multicore scenarios