### PR TITLE
Fix sparse build by using our own sparse branch

### DIFF
--- a/.github/workflows/sparse-zephyr.yml
+++ b/.github/workflows/sparse-zephyr.yml
@@ -57,4 +57,6 @@ jobs:
           ZSDK=$(cat zsdk_location); _RCC=${{ matrix.platforms.real_cc }}
           REAL_CC="$ZSDK/$_RCC" ./sof/zephyr/docker-run.sh                          \
              ./sof/zephyr/docker-build.sh ${{ matrix.platforms.platform }}          \
-             --cmake-args=-DSPARSE=y | ./sof/scripts/parse_sparse_output.sh
+             --cmake-args=-DSPARSE=y 2>&1 | tee _.log
+             printf '\n\n\t\t\t  ---- Messages below are treated as sparse errors --- \n\n\n'
+             (set -x; ./sof/scripts/parse_sparse_output.sh < _.log)

--- a/.github/workflows/sparse-zephyr.yml
+++ b/.github/workflows/sparse-zephyr.yml
@@ -14,7 +14,10 @@ jobs:
   # small subset of specific warnings defined in
   # sof/scripts/parse_sparse_output.sh
   warnings-subset:
-    runs-on: ubuntu-22.04
+
+    # We're sharing binaries with the zephyr-build container so keep
+    # this in sync with it.
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/sparse-zephyr.yml
+++ b/.github/workflows/sparse-zephyr.yml
@@ -38,7 +38,19 @@ jobs:
         ]
 
     steps:
-      - uses: actions/checkout@v2
+      - name: git clone sparse analyzer
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 10
+          # TODO: switch to thesofproject/sparse
+          repository: marc-hb/sparse
+          path: workspace/sparse
+
+      - name: build sparse analyzer
+        run: cd workspace/sparse && make -j4
+
+      - name: git clone sof
+        uses: actions/checkout@v3
         # From time to time this will catch a git tag and change SOF_VERSION
         with:
           fetch-depth: 10
@@ -51,7 +63,7 @@ jobs:
       # We have to painfully extract REAL_CC from the docker image to
       # tell the Zephyr build what it... already knows and wants!! Zephyr
       # commit 3ebb18b8826 explains this sparse problem.
-      - name: build
+      - name: analyze zephyr
         working-directory: ./workspace
         run: |
           ./sof/zephyr/docker-run.sh /bin/sh -c               \

--- a/scripts/parse_sparse_output.sh
+++ b/scripts/parse_sparse_output.sh
@@ -22,7 +22,7 @@ main()
     # script try deleting a __sparse_cache annotation like the one in
     # src/audio/mixer/mixer.c
 
-    ! grep -i  \
+    ! grep -v 'alsatplg.*topology2.*skip' | grep -i  \
         -e '[[:space:]]error:[[:space:]]'  \
         -e '[[:space:]]warning:[[:space:]].*different address space' \
 

--- a/zephyr/docker-build.sh
+++ b/zephyr/docker-build.sh
@@ -16,8 +16,10 @@ unset ZEPHYR_BASE
 test -e ./sof/scripts/xtensa-build-zephyr.py
 
 # See .github/workflows/zephyr.yml
-PATH="$PATH":/opt/sparse/bin
-command -v sparse  || true
+# /opt/sparse is the current location in the zephyr-build image.
+# Give any sparse in the workspace precedence.
+PATH="$(pwd)"/sparse:/opt/sparse/bin:"$PATH"
+command -V sparse  || true
 : REAL_CC="$REAL_CC"
 
 

--- a/zephyr/docker-run.sh
+++ b/zephyr/docker-run.sh
@@ -47,8 +47,13 @@ main()
 
     cd "$SOF_TOP"
 
+    run_command lsb_release -a
     set -x
+    run_command "$@"
+}
 
+run_command()
+{
     docker run -i -v "$(west topdir)":/zep_workspace \
            --workdir /zep_workspace \
            $SOF_DOCKER_RUN \


### PR DESCRIPTION
Use our own sparse branch, we cannot wait for critical sparse fixes like @lyakh's
`xtensa: switch to little endianness` https://marc.info/?l=linux-sparse&m=166861736724543
and others to be merged