### PR TITLE
xt-clang: Do not use -std=gnu99 for C++

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -895,7 +895,8 @@ find_package(Python3 COMPONENTS Interpreter)
 set(PYTHON3 "${Python3_EXECUTABLE}")
 
 # SOF uses GNU C99 extensions. TODO other flags required ?
-target_compile_options(SOF INTERFACE -std=gnu99 -fno-inline-functions)
+target_compile_options(SOF INTERFACE -fno-inline-functions)
+target_compile_options(SOF INTERFACE $<$<COMPILE_LANGUAGE:C,ASM>: -std=gnu99>)
 
 # Toolchain info
 add_definitions(-DXCC_TOOLS_VERSION="${ZEPHYR_TOOLCHAIN_VARIANT}" -DCC_OPTIMIZE_FLAGS="${OPTIMIZATION_FLAG}")


### PR DESCRIPTION
Option -std=gnu99 applied to C++ files trigerrs warning for xcc compiler however throws error for xt-clang.
This patch limits usage of this flag to C, ASM code only.

Signed-off-by: Jaroslaw Stelter <Jaroslaw.Stelter@intel.com>