### PR TITLE
lib: MCPS budget manager

### DIFF
--- a/src/include/ipc4/base_fw.h
+++ b/src/include/ipc4/base_fw.h
@@ -667,3 +667,8 @@ struct ipc4_log_state_info {
 	 */
 	uint32_t logs_mask[IPC4_MAX_LIBS_COUNT];
 } __attribute__((packed, aligned(4)));
+
+enum ipc4_power_state_type {
+	IPC4_ACTIVE_CORES_MASK = 0,
+	IPC4_CORE_KCPS = 1,
+};

--- a/src/include/sof/lib/cpu-clk-manager.h
+++ b/src/include/sof/lib/cpu-clk-manager.h
@@ -1,0 +1,57 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2022 Intel Corporation. All rights reserved.
+ *
+ * Author: Krzysztof Frydryk <frydryk.krzysztof@intel.com>
+ */
+
+/**
+ * \file include/sof/lib/cpu-clk-manager.h
+ * \brief CPU clk manager definition
+ * \author Krzysztof Frydryk <krzysztofx.frydryk@intel.com>
+ */
+
+#ifndef __SOF_LIB_CPU_CLK_MANAGER_H__
+#define __SOF_LIB_CPU_CLK_MANAGER_H__
+
+#include <rtos/spinlock.h>
+#include <sof/sof.h>
+#include <stdint.h>
+
+/**
+ * \brief CPS budget data.
+ */
+struct kcps_budget_data {
+	/* uncache only */
+	int kcps_consumption[CONFIG_CORE_COUNT];	/* Sum of declared consumptions on core */
+	struct k_spinlock lock;
+};
+
+/**
+ * \brief Declare KCPS usage on core
+ *
+ * Declare KCPS (kilo cycles per second) CPU usage on core and adjust
+ * CPU clock according to sum of declared consumptions.
+ *
+ * Declared consumption can be negative in case of freeing CPS.
+ *
+ * @param core The core to which consumption should be pinned
+ * @param kcps_delta declared usage. Can be negative.
+ */
+int core_kcps_adjust(int core, int kcps_delta);
+
+/**
+ * \brief Get KCPS usage on core
+ *
+ * Get declared KCPS usage on core
+ *
+ * @param core The core which consumption should be returned
+ */
+int core_kcps_get(int core);
+
+/**
+ * \brief Init KCPS budget mechanism
+ */
+int kcps_budget_init(void);
+
+#endif /*__SOF_LIB_CPU_CLK_MANAGER_H__ */

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -23,4 +23,5 @@ add_local_sources(sof
 	dma.c
 	dai.c
 	wait.c
+	cpu-clk-manager.c
 )

--- a/src/lib/cpu-clk-manager.c
+++ b/src/lib/cpu-clk-manager.c
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2022 Intel Corporation. All rights reserved.
+//
+// Author: Krzysztof Frydryk <frydryk.krzysztof@intel.com>
+
+#include <rtos/spinlock.h>
+#include <sof/sof.h>
+#include <stdint.h>
+#include <sof/lib/cpu-clk-manager.h>
+#include <rtos/clk.h>
+#include <sof/sof.h>
+#include <sof/math/numbers.h>
+#include <errno.h>
+#ifdef __ZEPHYR__
+#include <zephyr/sys/util.h>
+#endif /* __ZEPHYR__ */
+
+static struct kcps_budget_data kcps_data;
+
+static int request_freq_change(unsigned int core, int freq)
+{
+	int current_freq;
+	int selected_freq_id;
+	struct clock_info *clk;
+
+	clk = clocks_get() + core;
+
+	for (selected_freq_id = 0; selected_freq_id < clk->freqs_num; selected_freq_id++) {
+		if (freq < clk->freqs[selected_freq_id].freq)
+			break;
+	}
+
+	/* don't change clock frequency if already using proper clock */
+	current_freq = clock_get_freq(core);
+	if (clk->freqs[selected_freq_id].freq != current_freq)
+		clock_set_freq(core, freq);
+
+	return 0;
+}
+
+static int max_core_consumption(void)
+{
+	int result = 0;
+	unsigned int core;
+
+	for (core = 0; core < CONFIG_CORE_COUNT; core++)
+		result = MAX(result, kcps_data.kcps_consumption[core]);
+
+	return result;
+}
+
+int core_kcps_adjust(int adjusted_core_id, int kcps_delta)
+{
+	k_spinlock_key_t key;
+	int freq;
+	unsigned int core_id;
+	int ret = 0;
+
+	key = k_spin_lock(&kcps_data.lock);
+	kcps_data.kcps_consumption[adjusted_core_id] += kcps_delta;
+
+	/* set clock according to maximum requested mcps budget */
+	freq = max_core_consumption();
+
+	for (core_id = 0; core_id < CONFIG_CORE_COUNT; core_id++) {
+		/* Convert kcps to cps */
+		ret = request_freq_change(core_id, freq * 1000);
+		if (ret < 0)
+			goto out;
+	}
+
+out:
+	k_spin_unlock(&kcps_data.lock, key);
+
+	return ret;
+}
+
+int core_kcps_get(int core)
+{
+	k_spinlock_key_t key;
+	int ret;
+
+	key = k_spin_lock(&kcps_data.lock);
+	ret = kcps_data.kcps_consumption[core];
+	k_spin_unlock(&kcps_data.lock, key);
+	return ret;
+}
+
+int kcps_budget_init(void)
+{
+	k_spinlock_init(&kcps_data.lock);
+
+	return 0;
+}

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -549,6 +549,7 @@ zephyr_library_sources(
 	${SOF_LIB_PATH}/clk.c
 	${SOF_LIB_PATH}/notifier.c
 	${SOF_LIB_PATH}/pm_runtime.c
+	${SOF_LIB_PATH}/cpu-clk-manager.c
 	${SOF_LIB_PATH}/dma.c
 	${SOF_LIB_PATH}/dai.c
 


### PR DESCRIPTION
Add initial implementation of mcps budget management.

Ideally it should be used to control cpu clock, so that it runs on the lowest frequency suitable for performed tasks.
Different parts of FW can request/free some budget using `core_cps_adjust` and clock should be changed accordingly. (i.e. when setting pipeline to run we should request budget required by its modules).

Currently there is no proper performance data to be used, so it's advised to request some artificial, high budget on platform init to keep the clock running fast and avoid performance issues.

Requires https://github.com/zephyrproject-rtos/zephyr/pull/52205 to work on mtl