### PR TITLE
ipc4: Fix chain DMA trigger handling

### DIFF
--- a/src/include/sof/ipc/topology.h
+++ b/src/include/sof/ipc/topology.h
@@ -51,7 +51,7 @@ struct comp_dev *ipc4_get_comp_dev(uint32_t comp_id);
 int ipc4_add_comp_dev(struct comp_dev *dev);
 const struct comp_driver *ipc4_get_drv(uint8_t *uuid);
 int ipc4_create_chain_dma(struct ipc *ipc, struct ipc4_chain_dma *cdma);
-int ipc4_trigger_chain_dma(struct ipc *ipc, struct ipc4_chain_dma *cdma);
+int ipc4_trigger_chain_dma(struct ipc *ipc, struct ipc4_chain_dma *cdma, bool *delay);
 #else
 #error "No or invalid IPC MAJOR version selected."
 #endif


### PR DESCRIPTION
We need to pass the pipeline_trigger() return value through in ipc4_trigger_chain_dma() for the possibly delayed reply message sending to work correctly.

Signed-off-by: Jyri Sarha <jyri.sarha@intel.com>