### PR TITLE
[SKIP CI] Added daily tests workflow

### DIFF
--- a/.github/workflows/daily-tests.yml
+++ b/.github/workflows/daily-tests.yml
@@ -1,0 +1,20 @@
+---
+# https://docs.github.com/en/actions/using-workflows/reusing-workflows
+# https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
+
+name: Daily tests
+
+# yamllint disable-line rule:truthy
+on:
+  # To configure goto https://crontab.guru/
+  schedule:
+    # daily at 00:00 UTC
+    - cron: '0 0 * * *'
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  run-all-main-actions:
+    uses: ./.github/workflows/pull-request.yml
+  run-zephyr-builds:
+    uses: ./.github/workflows/zephyr.yml

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -28,6 +28,8 @@ on:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+  # Allows to call this forkflow from other workflows
+  workflow_call:
 
 jobs:
 

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -5,7 +5,7 @@ name: Zephyr
 # 'workflow_dispatch' allows running this workflow manually from the
 # 'Actions' tab
 # yamllint disable-line rule:truthy
-on: [push, pull_request, workflow_dispatch]
+on: [push, pull_request, workflow_dispatch, workflow_call]
 
 jobs:
   build:


### PR DESCRIPTION
Daily tests workflow triggers "Main Actions" workflow from ./.github/workflows/pull-requests.yml on the main branch
in the time interval defined in schedule/cron node.
Cron value may be set to run in some desired time intervals.
Cron values online configurator: https://crontab.guru

Github references:
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
https://docs.github.com/en/actions/using-workflows/reusing-workflows

Signed-off-by: Andrey Borisovich <andrey.borisovich@intel.com>