### PR TITLE
imx: clear general purpose pending interrupt

### DIFF
--- a/src/drivers/imx/ipc.c
+++ b/src/drivers/imx/ipc.c
@@ -194,6 +194,11 @@ int platform_ipc_init(struct ipc *ipc)
 	interrupt_register(PLATFORM_IPC_INTERRUPT, irq_handler, ipc);
 	interrupt_enable(PLATFORM_IPC_INTERRUPT, ipc);
 
+	/* Clear GP pending interrupt #0 and #1 */
+	imx_mu_xsr_rmw(IMX_MU_VERSION, IMX_MU_GSR,
+		       IMX_MU_xSR_GIPn(IMX_MU_VERSION, 0) |
+		       IMX_MU_xSR_GIPn(IMX_MU_VERSION, 1), 0);
+
 	/* enable GP #0 for Host -> DSP message notification
 	 * enable GP #1 for DSP -> Host message notification
 	 */


### PR DESCRIPTION
Clear general purpose pending interrupt
before enabling interrupts between host and DSP.
The GIPn bit, from MU Status Register is cleared
by writing it as “1” in order to de-assert the
interrupt request source at the interrupt controller.

This fixes a fw loading failure after a soft reboot caused by GIP bit that was 1.
The problem was the MU which triggered endless interrupts causing timeout on Kernel side, which was waiting for FW_READY message.

Signed-off-by: Iuliana Prodan <iuliana.prodan@nxp.com>