### PR TITLE
topology: fix DMICPROC undefined issue for intel-generic-dmic

### DIFF
--- a/tools/topology/topology1/platform/intel/intel-generic-dmic.m4
+++ b/tools/topology/topology1/platform/intel/intel-generic-dmic.m4
@@ -11,6 +11,8 @@ ifdef(`DMIC_16k_PCM_NAME',`',
 `define(DMIC_16k_PCM_NAME, `DMIC16kHz')')
 
 # variable that need to be defined in upper m4
+ifdef(`DMICPROC',`',`fatal_error(note: Need to define dmic processing for intel-generic-dmic
+)')
 ifdef(`CHANNELS',`',`fatal_error(note: Need to define channel number for intel-generic-dmic
 )')
 ifdef(`DMIC_PCM_48k_ID',`',`fatal_error(note: Need to define dmic48k pcm id for intel-generic-dmic

--- a/tools/topology/topology1/sof-tgl-max98357a-rt5682.m4
+++ b/tools/topology/topology1/sof-tgl-max98357a-rt5682.m4
@@ -171,6 +171,7 @@ ifdef(`NOHOTWORD',
 `
 define(NO16KDMIC)
 define(DMIC_48k_CORE_ID, 1)
+ifdef(`DMICPROC',`',`define(`DMICPROC', passthrough)')
 include(`platform/intel/intel-generic-dmic.m4')',
 `include(`platform/intel/intel-generic-dmic-kwd.m4')')
 


### PR DESCRIPTION
Adds fatal assertion in intel-generic-dmic.m4 for DMICPROC is not defined in upper m4, and fixes a potential risk of assertion by sof-tgl-max98357a-rt5682.m4.