### PR TITLE
topology: retrieve SPK_MIC_PERIOD_US=10000 config for google-aec

### DIFF
--- a/tools/topology/topology1/sof-tgl-max98357a-rt5682.m4
+++ b/tools/topology/topology1/sof-tgl-max98357a-rt5682.m4
@@ -114,7 +114,8 @@ ifdef(`WAVES',`
 # PCM99 <---- volume <---- DMIC01 (dmic 48k capture)
 # PCM100 <---- kpb <---- DMIC16K (dmic 16k capture)
 
-ifdef(`SPK_MIC_PERIOD_US',`', `define(`SPK_MIC_PERIOD_US', 1000)')
+ifdef(`SPK_MIC_PERIOD_US',`', `
+ifdef(`GOOGLE_RTC_AUDIO_PROCESSING',`define(`SPK_MIC_PERIOD_US', 10000)',`define(`SPK_MIC_PERIOD_US', 1000)')')
 
 ifdef(`NO_AMP',`',`
 # Define pipeline id for sof-tgl-CODEC-rt5682.m4


### PR DESCRIPTION
Commit 265ab371 removed the implication for setting SPK_MIC_PERIOD_US to 10000 while GOOGLE_RTC_AUDIO_PROCESSING is defined (google-aec is integrated).

This commit retrieves the implication.