### PR TITLE
Audio: Copier: Add missing DMIC DAI index mapping to create_dai()

### DIFF
--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -379,6 +379,7 @@ static int create_dai(struct comp_dev *parent_dev, struct copier_data *cd,
 
 		break;
 	case ipc4_dmic_link_input_class:
+		dai_index[dai_count - 1] = (dai_index[dai_count - 1] >> 5) & 0x7;
 		dai.type = SOF_DAI_INTEL_DMIC;
 		dai.is_config_blob = true;
 		type = ipc4_gtw_dmic;


### PR DESCRIPTION
The PR contains two commits
- Audio: Copier: Add missing DMIC DAI index mapping to create_dai()
- Tools: Topology2: Add DMIC16k capture to cavs-nocodec topologies

Edit - I removed the second topology2 commit. Now this is only a FW patch.