### PR TITLE
west.yml: update rimage to 65f345a52

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -34,7 +34,7 @@ manifest:
     - name: rimage
       repo-path: rimage
       path: sof/rimage
-      revision: 3ee717eebc6a2a512a0216363ae77473f94532c1
+      revision: 65f345a52e06a084192124364c563d8133d834c2
 
     - name: tomlc99
       repo-path: tomlc99


### PR DESCRIPTION
Update rimage to
65f345a52e06a084192124364c563d8133d834c2v

65f345a rimage: add src support
fe5b959 rimage: correct module type
f51ff46 rimage: remove incorrect module order check 
6623073 config: mtl: add kpb module
85a2d1e config: mtl: add kd module

Signed-off-by: Ievgen Ganakov <ievgen.ganakov@intel.com>