### PR TITLE
Audio: SRC: Increase stage buffer size and change copy() run condition

### DIFF
--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -196,6 +196,7 @@ int src_buffer_lengths(struct src_param *a, int fs_in, int fs_out, int nch,
 		 * there is no equation known for minimum size.
 		 */
 		a->sbuf_length = 2 * nch * stage1->blk_out * r1;
+		a->sbuf_length += a->sbuf_length >> 3;
 	}
 
 	a->src_multich = a->fir_s1 + a->fir_s2 + a->out_s1 + a->out_s2;
@@ -855,7 +856,7 @@ static int src_get_copy_limits(struct comp_data *cd,
 		sp->blk_out = sp->stage1_times * s1->blk_out;
 	}
 
-	if (sp->blk_in == 0 || sp->blk_out == 0)
+	if (sp->blk_in == 0 && sp->blk_out == 0)
 		return -EIO;
 
 	return 0;

--- a/src/audio/src/src_generic.c
+++ b/src/audio/src/src_generic.c
@@ -408,7 +408,7 @@ void src_polyphase_stage_cir_s16(struct src_stage_prm *s)
 			n_min = (m < n_min) ? m : n_min;
 			m -= n_min;
 			for (i = 0; i < n_min; i++) {
-				*y_wptr = Q_SHIFT_RND(*fir->out_rp, 31, 15);
+				*y_wptr = sat_int16(Q_SHIFT_RND(*fir->out_rp, 31, 15));
 				y_wptr++;
 				fir->out_rp++;
 			}

--- a/tools/test/audio/src_test.m
+++ b/tools/test/audio/src_test.m
@@ -465,7 +465,7 @@ end
 
 function src_test_result_print(t, testverbose, testacronym, ph)
 tstr = sprintf('%s SRC %d, %d', testverbose, t.fs1, t.fs2);
-if nargin > 3
+if nargin > 3 && ~isempty(ph)
         title(ph, tstr);
 else
         title(tstr);

--- a/tools/test/audio/src_test.m
+++ b/tools/test/audio/src_test.m
@@ -456,6 +456,7 @@ end
 function test = test_run_src(test, t)
 test.fs_in = test.fs1;
 test.fs_out = test.fs2;
+test.extra_opts = '-C 300000'; % Limit to 5 min max, assume 1 ms scheduling
 delete_check(1, test.fn_out);
 test = test_run(test);
 end

--- a/tools/test/audio/src_test.m
+++ b/tools/test/audio/src_test.m
@@ -7,8 +7,8 @@ function [n_fail, n_pass, n_na] = src_test(bits_in, bits_out, fs_in_list, fs_out
 %
 % bits_in    - input word length
 % bits_out   - output word length
-% fs_in      - vector of rates in
-% fs_out     - vector of rates out
+% fs_in      - vector of rates in, default 8 to 192 kHz
+% fs_out     - vector of rates out, default 8 to 192 kHz
 % full_test  - set to 0 for chirp only, 1 for all, default 1
 % show_plots - set to 1 to see plots, default 0
 %
@@ -27,6 +27,8 @@ mkdir_check('plots');
 mkdir_check('reports');
 
 %% Defaults for call parameters
+default_in  = [ 8 11.025 12 16 18.9 22.050 24 32 37.8 44.1 48 50 64 88.2 96 176.4 192] * 1e3;
+default_out = [ 8 11.025 12 16      22.05  24 32      44.1 48 50 64 88.2 96 176.4 192] * 1e3;
 if nargin < 1
 	bits_in = 32;
 end
@@ -34,18 +36,22 @@ if nargin < 2
 	bits_out = 32;
 end
 if nargin < 3
-        fs_in_list = [ 8 11.025 12 16 18.9 22.050 24 32 37.8 44.1 48 ...
-		       50 64 88.2 96 176.4 192] * 1e3;
+	fs_in_list = default_in;
 end
 if nargin < 4
-	fs_out_list = [ 8 11.025 12 16 22.05 24 32 44.1 48 ...
-		        50 64 88.2 96 176.4 192] * 1e3;
+	fs_out_list = default_out;
 end
 if nargin < 5
 	full_test = 1;
 end
 if nargin < 6
 	show_plots = 0;
+end
+if isempty(fs_in_list)
+	fs_in_list = default_in;
+end
+if isempty(fs_out_list)
+	fs_out_list = default_out;
 end
 
 %% Generic test pass/fail criteria

--- a/tools/test/audio/src_test.m
+++ b/tools/test/audio/src_test.m
@@ -413,7 +413,9 @@ test = test_run_src(test, t);
 %% Analyze
 test.fs = t.fs2;
 test = chirp_test_analyze(test);
-src_test_result_print(t, 'Chirp', 'chirpf');
+if test.fail >= 0
+	src_test_result_print(t, 'Chirp', 'chirpf');
+end
 
 % Delete files unless e.g. debugging and need data to run
 delete_check(t.files_delete, test.fn_in);

--- a/tools/test/audio/std_utils/aap_test_measure.m
+++ b/tools/test/audio/std_utils/aap_test_measure.m
@@ -7,6 +7,8 @@ function test = aap_test_measure(test)
 %% Reference: AES17 6.6.6 Attenuation of alias products
 %  http://www.aes.org/publications/standards/
 
+debug = 0;
+
 %% Load output file
 [x, nx] = load_test_output(test);
 if nx == 0
@@ -21,7 +23,9 @@ end
 win = hamming(nt_use);
 m0 = zeros(test.nf,1);
 for n=1:test.nf
-        fprintf('Measuring %.0f Hz ...\n', test.f(n));
+	if debug
+		fprintf('Measuring %.0f Hz ...\n', test.f(n));
+	end
         i1 = d+(n-1)*nt+nt_skip;
         i2 = i1+nt_use-1;
         m0(n) = level_dbfs(x(i1:i2).*win);

--- a/tools/test/audio/std_utils/aip_test_measure.m
+++ b/tools/test/audio/std_utils/aip_test_measure.m
@@ -7,6 +7,8 @@ function test = aip_test_measure(test)
 %% Reference: AES17 6.6.7 Attenuation of image products
 %  http://www.aes.org/publications/standards/
 
+debug = 0;
+
 %% Load output file
 [x, nx] = load_test_output(test);
 if nx == 0
@@ -25,7 +27,9 @@ mn = zeros(test.nf,1);
 b_lpf = stdlpf_get(test.fu, test.fs); % Get LPF coef
 b_hpf = stdhpf_get(test.fu, test.fs); % Get HPF coef
 for n=1:test.nf
-        fprintf('Measuring %.0f Hz ...\n', test.f(n));
+	if debug
+		fprintf('Measuring %.0f Hz ...\n', test.f(n));
+	end
         % Get notch coef for this frequency
         [b_notch, a_notch] = stdnotch_get(test.f(n), test.fs);
         i1 = d+(n-1)*nt+nt_skip;

--- a/tools/test/audio/std_utils/fr_test_measure.m
+++ b/tools/test/audio/std_utils/fr_test_measure.m
@@ -32,6 +32,8 @@ function test = fr_test_measure(test)
 % Copyright(c) 2017 Intel Corporation. All rights reserved.
 % Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
 
+debug = 0;
+
 %% Check if upper and lower mask is defined
 if length(test.fr_mask_flo) || length(test.fr_mask_fhi)
 	test.fr_lo = 0;
@@ -74,7 +76,9 @@ for channel = test.ch
         win = hamming(nt_use);
         m0 = zeros(test.nf,1);
         for n=1:test.nf
-                fprintf('Measuring %.0f Hz ...\n', test.f(n));
+		if debug
+			fprintf('Measuring %.0f Hz ...\n', test.f(n));
+		end
                 i1 = d+(n-1)*nt+nt_skip;
                 i2 = i1+nt_use-1;
                 m0(n) = level_dbfs(x(i1:i2,j).*win) -test.a_db;

--- a/tools/test/audio/std_utils/thdnf_test_measure.m
+++ b/tools/test/audio/std_utils/thdnf_test_measure.m
@@ -4,6 +4,7 @@ function test = thdnf_test_measure(test)
 % Copyright(c) 2017 Intel Corporation. All rights reserved.
 % Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
 
+debug = 0;
 test.ph = [];
 test.fh = [];
 
@@ -62,7 +63,9 @@ for i = 1:length(test.ch);
 	nn = 1;
 	for m=1:test.na
 		for n=1:test.nf
-			fprintf('Measuring %.0f Hz ...\n', test.f(n));
+			if debug
+				fprintf('Measuring %.0f Hz ...\n', test.f(n));
+			end
 			i1 = d+(nn-1)*nt+nt_skip;
 			i2 = i1+nt_use-1;
 			nn = nn+1;

--- a/tools/test/audio/test_utils/mix_sweep.m
+++ b/tools/test/audio/test_utils/mix_sweep.m
@@ -4,6 +4,8 @@ function  test = mix_sweep(test)
 % Copyright(c) 2017 Intel Corporation. All rights reserved.
 % Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
 
+debug = 0;
+
 %% Adjust tone lengt to integer number of samples
 test.nt = round(test.tl*test.fs); % Make number of samples per tone
 test.tl = test.nt/test.fs;        % an integer by adjusting tl.
@@ -59,7 +61,9 @@ for m=1:test.na
                 else
                         a = test.a;
                 end
-                fprintf('Mixing %.0f Hz %.1f dBFS sine ...\n', f, 20*log10(a));
+		if debug
+			fprintf('Mixing %.0f Hz %.1f dBFS sine ...\n', f, 20*log10(a));
+		end
                 s = multitone(test.fs, f, a, test.tl);
                 for ch=test.ch
                         x(i1:i2, ch) = dither_and_quantize(s.*win, test.bits_in);


### PR DESCRIPTION
The main changes are commits 1 and 2 to SRC code. First prevents a pipeline freeze. The second fixes an overflow with 16 bit audio data.

The rest of changes are improvements to src_test.m script. E.g. call testbench with copy limit of 5 min to stop frozen SRC and minor issues fixes and speedup with reduce of printing and plot window opening.