### PR TITLE
[SKIP CI] .github/checkpatch: rename --strict to --subjective

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        strictness: [null, --strict]
+        strictness: [null, --subjective]
 
     env:
       PR_NUM: ${{github.event.number}}


### PR DESCRIPTION
--subjective is strictly (pun intended) equivalent to --strict but it makes it more obvious that "checkpatch is not always right" (c) https://www.kernel.org/doc/html/latest/dev-tools/checkpatch.html

This should save some time in situations where some warnings conflict with each other like for instance
https://github.com/thesofproject/sof/pull/6655#discussion_r1031572596

or https://github.com/thesofproject/sof/pull/6613#issuecomment-1331532315

