### PR TITLE
west.yaml: move Zephyr to stable2.4 update

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: bd60b9289a635aedf80fc997e6b2a2de56fe5786
+      revision: 6c98251bf0fe15dfbda9aa60bf103cb55bae60c8
       remote: thesofproject
       # Import some projects listed in zephyr/west.yml@revision
       #


### PR DESCRIPTION
Upgrade Zephyr to stable2.4 branch in thesofproject, which has cherry-picked hda dai now from zephyr upstream. Don't update anything else from Zephyr upstream.

6c98251bf0fe1 hda dai upstream Zephyr version
79e212e515e29 revert hda dai PR version
bd60b9289a635 hda dai PR version
063984d0b8dec zephyr upstream main

Signed-off-by: Jaska Uimonen <jaska.uimonen@intel.com>