### PR TITLE
Remove legacy RTOS platforms from Zephyr build

### DIFF
--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -18,9 +18,6 @@ jobs:
         # many lines. Pay attention to COMMAS.
         IPC_platforms: [
           # - IPC3 default
-          apl cnl,
-          icl jsl,
-          tgl tgl-h,
           imx8 imx8x imx8m,
           # - IPC4 default
           mtl,


### PR DESCRIPTION
Removing old CAVS SOF RTOS platforms from being built with Zephyr in CI.

Signed-off-by: Andrey Borisovich <andrey.borisovich@intel.com>