### PR TITLE
math: Fix warnings about uninitialized variables

### DIFF
--- a/src/math/fir_hifi3.c
+++ b/src/math/fir_hifi3.c
@@ -95,9 +95,9 @@ void fir_32x16_hifi3(struct fir_state_32x16 *fir, ae_int32 x, ae_int32 *y,
 	ae_f64 a;
 	ae_valign u;
 	ae_f32x2 data2;
-	ae_f16x4 coefs;
-	ae_f32x2 d0;
-	ae_f32x2 d1;
+	ae_f16x4 coefs = AE_ZERO16(); /* Note: Init is not needed */
+	ae_f32x2 d0 = AE_ZERO32(); /* Note: Init is not needed */
+	ae_f32x2 d1 = AE_ZERO32(); /* Note: Init is not needed */
 	int i;
 	ae_int32 *dp = fir->rwp;
 	ae_int16x4 *coefp = (ae_int16x4 *)fir->coef;
@@ -173,9 +173,9 @@ void fir_32x16_2x_hifi3(struct fir_state_32x16 *fir, ae_int32 x0, ae_int32 x1,
 	ae_f64 a;
 	ae_f64 b;
 	ae_valign u;
-	ae_f32x2 d0;
-	ae_f32x2 d1;
-	ae_f16x4 coefs;
+	ae_f32x2 d0 = AE_ZERO32(); /* Note: Init is not needed */
+	ae_f32x2 d1 = AE_ZERO32(); /* Note: Init is not needed */
+	ae_f16x4 coefs = AE_ZERO16(); /* Note: Init is not needed */
 	int i;
 	ae_f32x2 *dp;
 	ae_f16x4 *coefp = fir->coef;

--- a/src/math/iir_df1_hifi3.c
+++ b/src/math/iir_df1_hifi3.c
@@ -47,13 +47,13 @@ int32_t iir_df1(struct iir_state_df1 *iir, int32_t x)
 {
 	ae_int64 acc;
 	ae_valign coef_align = AE_ZALIGN64();
-	ae_int32x2 coef_a2a1;
-	ae_int32x2 coef_b2b1;
-	ae_int32x2 coef_b0;
-	ae_int32x2 gain;
-	ae_int32x2 shift;
-	ae_int32x2 delay_y2y1;
-	ae_int32x2 delay_x2x1;
+	ae_int32x2 coef_a2a1 = AE_ZERO32(); /* Note: Init is not needed */
+	ae_int32x2 coef_b2b1 = AE_ZERO32(); /* Note: Init is not needed */
+	ae_int32x2 coef_b0 = AE_ZERO32(); /* Note: Init is not needed */
+	ae_int32x2 gain = AE_ZERO32(); /* Note: Init is not needed */
+	ae_int32x2 shift = AE_ZERO32(); /* Note: Init is not needed */
+	ae_int32x2 delay_y2y1 = AE_ZERO32(); /* Note: Init is not needed */
+	ae_int32x2 delay_x2x1 = AE_ZERO32(); /* Note: Init is not needed */
 	ae_int32 in;
 	ae_int32 tmp;
 	ae_int32x2 *coefp;


### PR DESCRIPTION
Minor changes to avoid warnings about uninitialized variables given by Klocwork.

This changes may slightly affect performance. Please reconsider if we really need them.

Signed-off-by: Piotr Kmiecik <piotrx.kmiecik@intel.com>