### PR TITLE
[SKIP CI] .github/workflows: upgrade actions/checkout@v2 -> v3

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with: {fetch-depth: 5, submodules: recursive}
 
       - name: docker
@@ -134,7 +134,7 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with: {fetch-depth: 0, submodules: recursive}
 
       - name: docker

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -30,7 +30,7 @@ jobs:
         ]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         # From time to time this will catch a git tag and change SOF_VERSION
         with:
           fetch-depth: 10


### PR DESCRIPTION
This should get rid of most warnings in daily tests

```
Node.js 12 actions are deprecated. For more information see:

https://github.blog/changelog/
 2022-09-22-github-actions-all-actions-will-begin-running-on-node16...
Please update the following actions to use Node.js 16: actions/checkout@v2
```

Example at
 https://github.com/thesofproject/sof/actions/runs/3597808171

v3 seems backward compatible. Upgrade only the most used instances for now (most used because of the `matrix` of platforms), upgrade everything in a few days if no issue is spotted.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>