### PR TITLE
topology2: cavs-rt5682: add deep buffer support on headsets

### DIFF
--- a/tools/topology/topology2/cavs-rt5682.conf
+++ b/tools/topology/topology2/cavs-rt5682.conf
@@ -15,6 +15,7 @@
 <passthrough-be.conf>
 <host-copier-gain-mixin-playback.conf>
 <mixout-gain-dai-copier-playback.conf>
+<deepbuffer-playback.conf>
 <data.conf>
 <pcm.conf>
 <pcm_caps.conf>
@@ -56,6 +57,11 @@ Define {
 	SPK_ID				7
 	PLATFORM 			"none"
 	USE_CHAIN_DMA			"false"
+	DEEP_BUFFER_PIPELINE_ID		15
+	DEEP_BUFFER_PCM_ID		31
+	DEEP_BUFFER_PIPELINE_SRC	'mixin.15.1'
+	DEEP_BUFFER_PIPELINE_SINK	'mixout.2.1'
+	DEEP_BUFFER_PCM_NAME		'Deepbuffer Jack Out'
 }
 
 # override defaults with platform-specific config
@@ -73,6 +79,10 @@ IncludeByKey.NUM_HDMIS {
 	"[3-4]"	"platform/intel/hdmi-generic.conf"
 }
 
+# include deep buffer config if buffer size is in 1 - 1000 ms.
+IncludeByKey.DEEPBUFFER_FW_DMA_MS{
+	"[1-1000]" "platform/intel/deep-buffer.conf"
+}
 #
 # List of all DAIs
 #
@@ -146,6 +156,14 @@ Object.Pipeline {
 			copier_type	"SSP"
 			stream_name	"SSP0-Codec"
 			node_type $I2S_LINK_OUTPUT_CLASS
+
+			# override for 24-bit
+			Object.Base.audio_format.1 {
+				in_bit_depth		32
+				in_valid_bit_depth	24
+				out_bit_depth		32
+				out_valid_bit_depth	32
+			}
 		}
 
 		Object.Widget.gain.1 {

--- a/tools/topology/topology2/sof-ace-tplg/CMakeLists.txt
+++ b/tools/topology/topology2/sof-ace-tplg/CMakeLists.txt
@@ -30,7 +30,7 @@ PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-mtl-rt711-4ch.bin,DEEPBUFFER_FW_DMA_MS
 PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-mtl-nocodec.bin,DEEPBUFFER_FW_DMA_MS=100"
 
 "cavs-rt5682\;sof-mtl-max98357a-rt5682\;PLATFORM=mtl,NUM_DMICS=4,PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,NUM_HDMIS=4,\
-PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-mtl-max98357a-rt5682.bin"
+PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-mtl-max98357a-rt5682.bin,DEEPBUFFER_FW_DMA_MS=10"
 )
 
 add_custom_target(topology2_ace)


### PR DESCRIPTION
Deep buffer is mixed with ssp1 stream.
Override mixout copier audio_format.1 from 32/24 to 32/32 for I2S.

Signed-off-by: Yong Zhi <yong.zhi@intel.com>