### PR TITLE
Fix D3 sequence for TGL

### DIFF
--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -878,6 +878,10 @@ static int ipc4_module_process_dx(struct ipc4_message_request *ipc4)
 		/* do platform specific suspending */
 		platform_context_save(sof_get());
 
+#if !defined(CONFIG_LIBRARY) && defined(CONFIG_CAVS)
+		arch_irq_lock();
+		platform_timer_stop(timer_get());
+#endif
 		ipc_get()->pm_prepare_D3 = 1;
 	}
 


### PR DESCRIPTION
This makes the D3 sequence for IPC3 and IPC4 identical for TGL and fixes https://github.com/thesofproject/sof/issues/6679 on TGL