### PR TITLE
Cache: fix allocation and address prefetch

### DIFF
--- a/src/audio/buffer.c
+++ b/src/audio/buffer.c
@@ -7,6 +7,7 @@
 
 #include <sof/audio/buffer.h>
 #include <sof/audio/component.h>
+#include <sof/common.h>
 #include <rtos/interrupt.h>
 #include <rtos/alloc.h>
 #include <rtos/cache.h>
@@ -40,9 +41,12 @@ struct comp_buffer *buffer_alloc(uint32_t size, uint32_t caps, uint32_t align)
 		return NULL;
 	}
 
-	/* allocate new buffer */
+	/*
+	 * allocate new buffer, align the allocation size to a cache line for
+	 * the coherent API
+	 */
 	buffer = rzalloc(SOF_MEM_ZONE_RUNTIME_SHARED, 0, SOF_MEM_CAPS_RAM,
-			 sizeof(*buffer));
+			 ALIGN_UP(sizeof(*buffer), PLATFORM_DCACHE_ALIGN));
 	if (!buffer) {
 		tr_err(&buffer_tr, "buffer_alloc(): could not alloc structure");
 		return NULL;

--- a/src/audio/mixin_mixout/mixin_mixout.c
+++ b/src/audio/mixin_mixout/mixin_mixout.c
@@ -198,8 +198,10 @@ static struct comp_dev *mixout_new(const struct comp_driver *drv,
 
 	memcpy_s(&md->base_cfg, sizeof(md->base_cfg), spec, sizeof(md->base_cfg));
 
+	/* align the allocation size to a cache line for the coherent API */
 	md->mixed_data_info = rzalloc(SOF_MEM_ZONE_RUNTIME_SHARED, 0, SOF_MEM_CAPS_RAM,
-				      sizeof(struct mixed_data_info));
+				      ALIGN_UP(sizeof(struct mixed_data_info),
+					       PLATFORM_DCACHE_ALIGN));
 	if (!md->mixed_data_info) {
 		rfree(md);
 		rfree(dev);

--- a/src/audio/pipeline/pipeline-graph.c
+++ b/src/audio/pipeline/pipeline-graph.c
@@ -185,6 +185,8 @@ int pipeline_connect(struct comp_dev *comp, struct comp_buffer *buffer,
 		     int dir)
 {
 	struct list_item *comp_list;
+	struct list_item __sparse_cache *needs_sync;
+	bool further_buffers_exist;
 	uint32_t flags;
 
 	if (dir == PPL_CONN_DIR_COMP_TO_BUFFER)
@@ -201,10 +203,14 @@ int pipeline_connect(struct comp_dev *comp, struct comp_buffer *buffer,
 	 * overwriting the modified header. FIXME: this is still a problem with
 	 * different cores.
 	 */
-	if (!list_is_empty(comp_list))
-		dcache_writeback_invalidate_region(uncache_to_cache(comp_list->next),
-						   sizeof(struct list_item));
+	further_buffers_exist = !list_is_empty(comp_list);
+	needs_sync = uncache_to_cache(comp_list->next);
+	if (further_buffers_exist)
+		dcache_writeback_region(needs_sync, sizeof(struct list_item));
+	/* The cache line can be prefetched here, invalidate it after prepending */
 	list_item_prepend(buffer_comp_list(buffer, dir), comp_list);
+	if (further_buffers_exist)
+		dcache_invalidate_region(needs_sync, sizeof(struct list_item));
 	buffer_set_comp(buffer, comp, dir);
 	irq_local_enable(flags);
 
@@ -214,6 +220,8 @@ int pipeline_connect(struct comp_dev *comp, struct comp_buffer *buffer,
 void pipeline_disconnect(struct comp_dev *comp, struct comp_buffer *buffer, int dir)
 {
 	struct list_item *buf_list, *comp_list;
+	struct list_item __sparse_cache *needs_sync_prev, *needs_sync_next;
+	bool buffers_after_exist, buffers_before_exist;
 	uint32_t flags;
 
 	if (dir == PPL_CONN_DIR_COMP_TO_BUFFER)
@@ -232,13 +240,20 @@ void pipeline_disconnect(struct comp_dev *comp, struct comp_buffer *buffer, int 
 	 * written back, overwriting the modified header. FIXME: this is still a
 	 * problem with different cores.
 	 */
-	if (comp_list != buf_list->next)
-		dcache_writeback_invalidate_region(uncache_to_cache(buf_list->next),
-						   sizeof(struct list_item));
-	if (comp_list != buf_list->prev)
-		dcache_writeback_invalidate_region(uncache_to_cache(buf_list->prev),
-						   sizeof(struct list_item));
+	buffers_after_exist = comp_list != buf_list->next;
+	buffers_before_exist = comp_list != buf_list->prev;
+	needs_sync_prev = uncache_to_cache(buf_list->prev);
+	needs_sync_next = uncache_to_cache(buf_list->next);
+	if (buffers_after_exist)
+		dcache_writeback_region(needs_sync_next, sizeof(struct list_item));
+	if (buffers_before_exist)
+		dcache_writeback_region(needs_sync_prev, sizeof(struct list_item));
+	/* buffers before or after can be prefetched here */
 	list_item_del(buf_list);
+	if (buffers_after_exist)
+		dcache_invalidate_region(needs_sync_next, sizeof(struct list_item));
+	if (buffers_before_exist)
+		dcache_invalidate_region(needs_sync_prev, sizeof(struct list_item));
 	buffer_set_comp(buffer, NULL, dir);
 	irq_local_enable(flags);
 }


### PR DESCRIPTION
1. Objects, handled using the coherent API, must be allocated as cached.
2. Make sure data-cache prefetch doesn't race against buffer linking and unlinking