### PR TITLE
Parameterize google rtc audio processing

### DIFF
--- a/src/audio/Kconfig
+++ b/src/audio/Kconfig
@@ -200,6 +200,54 @@ config COMP_GOOGLE_RTC_AUDIO_PROCESSING
 	  This component takes raw microphones input and playback reference
 	  and outputs an echo-free microphone signal.
 
+config COMP_GOOGLE_RTC_AUDIO_PROCESSING_SAMPLE_RATE_HZ
+	depends on COMP_GOOGLE_RTC_AUDIO_PROCESSING
+	int "Sample rate for Google Real Time Communication Audio processing"
+	default 48000
+	help
+	  Sets the sample rate for the memory buffer for the Google real-time
+	  communication audio processing.
+
+config COMP_GOOGLE_RTC_AUDIO_PROCESSING_NUM_CHANNELS
+	depends on COMP_GOOGLE_RTC_AUDIO_PROCESSING
+	int "Number of channels to process for Google Real Time Communication Audio processing"
+	default 1
+	help
+	  Sets the number of channels to process in the Google real-time
+	  communication audio processing.
+
+config COMP_GOOGLE_RTC_AUDIO_PROCESSING_NUM_AEC_REFERENCE_CHANNELS
+	depends on COMP_GOOGLE_RTC_AUDIO_PROCESSING
+	int "Number of AEC reference channels for Google Real Time Communication Audio processing"
+	default 2
+	help
+	  Sets the number AEC reference channels in the Google real-time
+	  communication audio processing.
+
+config COMP_GOOGLE_RTC_AUDIO_PROCESSING_MEMORY_BUFFER_SIZE_BYTES
+	depends on COMP_GOOGLE_RTC_AUDIO_PROCESSING
+	int "Memory buffer size for Google Real Time Communication Audio processing"
+	default 200000
+	help
+	  Sets the size of the memory buffer for the Google real-time
+	  communication audio processing.
+
+config COMP_GOOGLE_RTC_AUDIO_PROCESSING_ECHO_PATH_DELAY_MS
+	depends on COMP_GOOGLE_RTC_AUDIO_PROCESSING
+	int "Echo path delay for Google Real Time Communication Audio processing"
+	default 44
+	help
+	  Sets the echo path delay to use for the Google real-time communication
+	  audio processing.
+
+config COMP_GOOGLE_RTC_AUDIO_PROCESSING_MIC_HEADROOM_LINEAR
+	depends on COMP_GOOGLE_RTC_AUDIO_PROCESSING
+	int "Microphone headroom for Google Real Time Communication Audio processing"
+	default 4
+	help
+	  Sets the microphone headroom for the Google real-time communication audio
+	  processing.
+
 config GOOGLE_RTC_AUDIO_PROCESSING_MOCK
 	bool "Google Real Time Communication Audio processing mock"
 	default n

--- a/src/audio/google_rtc_audio_processing_mock.c
+++ b/src/audio/google_rtc_audio_processing_mock.c
@@ -12,7 +12,8 @@
 #include "sof/lib/alloc.h"
 #include "ipc/topology.h"
 
-#define GOOGLE_RTC_AUDIO_PROCESSING_SAMPLE_RATE_HZ 48000
+#define GOOGLE_RTC_AUDIO_PROCESSING_FREQENCY_TO_PERIOD_FRAMES 100
+#define GOOGLE_RTC_AUDIO_PROCESSING_MS_PER_SECOND 1000
 
 struct GoogleRtcAudioProcessingState {
 	int num_capture_channels;
@@ -22,27 +23,73 @@ struct GoogleRtcAudioProcessingState {
 	int16_t *aec_reference;
 };
 
-GoogleRtcAudioProcessingState *GoogleRtcAudioProcessingCreate()
+static void SetFormats(GoogleRtcAudioProcessingState *const state,
+		       capture_sample_rate_hz,
+		       int num_capture_input_channels,
+		       int num_capture_output_channels,
+		       int render_sample_rate_hz,
+		       int num_render_channels)
+{
+	state->num_capture_channels = num_capture_input_channels;
+	state->num_output_channels = num_capture_output_channels;
+	state->num_frames = capture_sample_rate_hz /
+		GOOGLE_RTC_AUDIO_PROCESSING_FREQENCY_TO_PERIOD_FRAMES;
+
+	state->num_aec_reference_channels = num_render_channels;
+	rfree(state->aec_reference);
+	state->aec_reference = rballoc(0,
+				       SOF_MEM_CAPS_RAM,
+				       sizeof(state->aec_reference[0]) *
+				       state->num_frames *
+				       state->num_aec_reference_channels);
+}
+
+void GoogleRtcAudioProcessingAttachMemoryBuffer(uint8_t *const buffer,
+						int buffer_size)
+{
+}
+
+void GoogleRtcAudioProcessingDetachMemoryBuffer(void)
+{
+}
+
+GoogleRtcAudioProcessingState *GoogleRtcAudioProcessingCreateWithConfig(int capture_sample_rate_hz,
+									int num_capture_input_channels,
+									int num_capture_output_channels,
+									int render_sample_rate_hz,
+									int num_render_channels,
+									const uint8_t *const config,
+									int config_size)
 {
 	struct GoogleRtcAudioProcessingState *s =
-			rballoc(0, SOF_MEM_CAPS_RAM, sizeof(GoogleRtcAudioProcessingState));
+		rballoc(0, SOF_MEM_CAPS_RAM, sizeof(GoogleRtcAudioProcessingState));
 	if (!s)
 		return NULL;
-	s->num_capture_channels = 1;
-	s->num_aec_reference_channels = 2;
-	s->num_output_channels = 1;
-	s->num_frames = GOOGLE_RTC_AUDIO_PROCESSING_SAMPLE_RATE_HZ * 10 / 1000;
-	s->aec_reference = rballoc(0,
-				   SOF_MEM_CAPS_RAM,
-				   sizeof(s->aec_reference[0]) *
-				   s->num_frames *
-				   s->num_aec_reference_channels
-				   );
+
+	s->aec_reference = NULL;
+	SetFormats(state,
+		   capture_sample_rate_hz,
+		   num_capture_input_channels,
+		   num_capture_output_channels,
+		   render_sample_rate_hz,
+		   num_render_channels);
+
 	if (!s->aec_reference) {
 		rfree(s);
 		return NULL;
 	}
 	return s;
+}
+
+GoogleRtcAudioProcessingState *GoogleRtcAudioProcessingCreate(void)
+{
+	return GoogleRtcAudioProcessingCreateWithConfig(CONFIG_COMP_GOOGLE_RTC_AUDIO_PROCESSING_SAMPLE_RATE_HZ,
+							1,
+							1,
+							CONFIG_COMP_GOOGLE_RTC_AUDIO_PROCESSING_SAMPLE_RATE_HZ,
+							2,
+							NULL,
+							0);
 }
 
 void GoogleRtcAudioProcessingFree(GoogleRtcAudioProcessingState *state)
@@ -53,27 +100,53 @@ void GoogleRtcAudioProcessingFree(GoogleRtcAudioProcessingState *state)
 	}
 }
 
-int GoogleRtcAudioProcessingGetFramesizeInMs(GoogleRtcAudioProcessingState *state)
+int GoogleRtcAudioProcessingSetStreamFormats(GoogleRtcAudioProcessingState *const state,
+					     int capture_sample_rate_hz,
+					     int num_capture_input_channels,
+					     int num_capture_output_channels,
+					     int render_sample_rate_hz,
+					     int num_render_channels)
 {
-	return state->num_frames * 1000 / GOOGLE_RTC_AUDIO_PROCESSING_SAMPLE_RATE_HZ;
+	SetFormats(state,
+		   capture_sample_rate_hz,
+		   num_capture_input_channels,
+		   num_capture_output_channels,
+		   render_sample_rate_hz,
+		   num_render_channels);
+	return 0;
 }
 
-int GoogleRtcAudioProcessingReconfigure(
-	GoogleRtcAudioProcessingState * const state, const uint8_t *const config,
-	int config_size)
+int GoogleRtcAudioProcessingParameters(GoogleRtcAudioProcessingState *const state,
+				       float *capture_headroom_linear,
+				       float *echo_path_delay_ms)
 {
 	return 0;
 }
 
-int GoogleRtcAudioProcessingProcessCapture_int16(
-	GoogleRtcAudioProcessingState *const state, const int16_t *const src,
-	int16_t *const dest)
+int GoogleRtcAudioProcessingGetFramesizeInMs(GoogleRtcAudioProcessingState *state)
+{
+	return state->num_frames *
+		GOOGLE_RTC_AUDIO_PROCESSING_MS_PER_SECOND /
+		CONFIG_COMP_GOOGLE_RTC_AUDIO_PROCESSING_SAMPLE_RATE_HZ;
+}
+
+int GoogleRtcAudioProcessingReconfigure(GoogleRtcAudioProcessingState *const state,
+					const uint8_t *const config,
+					int config_size)
+{
+	return 0;
+}
+
+int GoogleRtcAudioProcessingProcessCapture_int16(GoogleRtcAudioProcessingState *const state,
+						 const int16_t *const src,
+						 int16_t *const dest)
 {
 	int16_t *ref = state->aec_reference;
 	int16_t *mic = (int16_t *) src;
 	int16_t *out = dest;
 	int n;
 
+	memset(dest, 0, sizeof(int16_t) * state->num_output_channels * state->num_frames);
 	for (n = 0; n < state->num_frames; ++n) {
 		*out = *mic + *ref;
 		ref += state->num_aec_reference_channels;
@@ -83,14 +156,41 @@ int GoogleRtcAudioProcessingProcessCapture_int16(
 	return 0;
 }
 
-int GoogleRtcAudioProcessingAnalyzeRender_int16(
-	GoogleRtcAudioProcessingState *const state, const int16_t *const data)
+int GoogleRtcAudioProcessingAnalyzeRender_int16(GoogleRtcAudioProcessingState *const state,
+						const int16_t *const data)
 {
 	const size_t buffer_size =
-			sizeof(state->aec_reference[0])
-			* state->num_frames
-			* state->num_aec_reference_channels;
+		sizeof(state->aec_reference[0])
+		* state->num_frames
+		* state->num_aec_reference_channels;
 	memcpy_s(state->aec_reference, buffer_size,
 		 data, buffer_size);
 	return 0;
+}
+
+void GoogleRtcAudioProcessingParseSofConfigMessage(uint8_t *message,
+						   size_t message_size,
+						   uint8_t **google_rtc_audio_processing_config,
+						   size_t *google_rtc_audio_processing_config_size,
+						   int *num_capture_input_channels,
+						   int *num_capture_output_channels,
+						   float *aec_reference_delay,
+						   float *mic_gain,
+						   bool *google_rtc_audio_processing_config_present,
+						   bool *num_capture_input_channels_present,
+						   bool *num_capture_output_channels_present,
+						   bool *aec_reference_delay_present,
+						   bool *mic_gain_present)
+{
+	*google_rtc_audio_processing_config = NULL;
+	*google_rtc_audio_processing_config_size = 0;
+	*num_capture_input_channels = 1;
+	*num_capture_output_channels = 1;
+	*aec_reference_delay = 0;
+	*mic_gain = 1;
+	*google_rtc_audio_processing_config_present = false;
+	*num_capture_input_channels_present = false;
+	*num_capture_output_channels_present = false;
+	*aec_reference_delay_present = false;
+	*mic_gain_present = false;
 }

--- a/third_party/include/google_rtc_audio_processing.h
+++ b/third_party/include/google_rtc_audio_processing.h
@@ -13,16 +13,51 @@ extern "C" {
 #endif
 
 // This define ensure that the linked library matches the header file.
+// LINT.IfChange(api_version)
 #define GoogleRtcAudioProcessingCreate GoogleRtcAudioProcessingCreate_v1
+// LINT.ThenChange()
 
 typedef struct GoogleRtcAudioProcessingState GoogleRtcAudioProcessingState;
 
+// LINT.IfChange()
+
+// Attaches `buffer` to use for memory allocations. The ownership of `buffer`
+// remains within the caller.
+void GoogleRtcAudioProcessingAttachMemoryBuffer(uint8_t *const buffer,
+						int buffer_size);
+
+// Detaches any attached memory buffer used for memory allocations. Returns 0 if
+// success and non zero if failure.
+void GoogleRtcAudioProcessingDetachMemoryBuffer(void);
+
 // Creates an instance of GoogleRtcAudioProcessing with the tuning embedded in
-// the library.
+// the library. If creation fails, NULL is returned.
 GoogleRtcAudioProcessingState *GoogleRtcAudioProcessingCreate(void);
+
+// Creates an instance of GoogleRtcAudioProcessing based on `config` and stream
+// formats, where the content of config overrides any embedded parameters and
+// the stream formats overrides any content in the config. Setting `config` to
+// NULL means that no config is specified. If creation fails, NULL is returned.
+GoogleRtcAudioProcessingState *GoogleRtcAudioProcessingCreateWithConfig(
+    int capture_sample_rate_hz, int num_capture_input_channels,
+    int num_capture_output_channels, int render_sample_rate_hz,
+    int num_render_channels, const uint8_t *const config, int config_size);
 
 // Frees all allocated resources in `state`.
 void GoogleRtcAudioProcessingFree(GoogleRtcAudioProcessingState *state);
+
+// Specifies the stream formats to use. Returns 0 if success and non zero if
+// failure.
+int GoogleRtcAudioProcessingSetStreamFormats(
+    GoogleRtcAudioProcessingState *const state, int capture_sample_rate_hz,
+    int num_capture_input_channels, int num_capture_output_channels,
+    int render_sample_rate_hz, int num_render_channels);
+
+// Specifies setup-specific parameters. Returns 0 if success and non zero if
+// failure. Parameters which are NULL are ignored.
+int GoogleRtcAudioProcessingParameters(
+    GoogleRtcAudioProcessingState *const state, float *capture_headroom_linear,
+    float *echo_path_delay_ms);
 
 // Returns the framesize used for processing.
 int GoogleRtcAudioProcessingGetFramesizeInMs(
@@ -62,8 +97,10 @@ int GoogleRtcAudioProcessingAnalyzeRender_float32(
 int GoogleRtcAudioProcessingAnalyzeRender_int16(
     GoogleRtcAudioProcessingState *const state, const int16_t *const src);
 
+// LINT.ThenChange(:api_version)
+
 #ifdef __cplusplus
 }
 #endif
 
-#endif  // GOOGLE_RTC_AUDIO_PROCESSING_H
+#endif	// GOOGLE_RTC_AUDIO_PROCESSING_H

--- a/third_party/include/google_rtc_audio_processing_sof_message_reader.h
+++ b/third_party/include/google_rtc_audio_processing_sof_message_reader.h
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2022 Google LLC.
+//
+// Author: Per Ahgren <peah@google.com>
+#ifndef GOOGLE_RTC_AUDIO_PROCESSING_SOF_MESSAGE_READER_H_
+#define GOOGLE_RTC_AUDIO_PROCESSING_SOF_MESSAGE_READER_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Parses the fields from a SOF config message `message` of size `message_size`
+// intended for the GoogleRtcAudioProcessing component and the corresponding
+// outputs parameters based on the content. Any previous content in the output
+// parameters is overwritten regardless of the content in `message`.
+void GoogleRtcAudioProcessingParseSofConfigMessage(
+    uint8_t *message, size_t message_size,
+    uint8_t **google_rtc_audio_processing_config,
+    size_t *google_rtc_audio_processing_config_size,
+    int *num_capture_input_channels, int *num_capture_output_channels,
+    float *aec_reference_delay, float *mic_gain,
+    bool *google_rtc_audio_processing_config_present,
+    bool *num_capture_input_channels_present,
+    bool *num_capture_output_channels_present,
+    bool *aec_reference_delay_present, bool *mic_gain_present);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // GOOGLE_RTC_AUDIO_PROCESSING_SOF_MESSAGE_READER_H_


### PR DESCRIPTION
Changes in the GoogleRtcAudioProcessing component to
-Allow sample rate and number of channels to explicitly be specified.  
-Update the memory management.
-Allow parameters to be passed.