### PR TITLE
[stable-v2.4] west.yml: move Zephyr to 1941003c6f16b in sof/stable-v2.4

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 6c98251bf0fe15dfbda9aa60bf103cb55bae60c8
+      revision: 1941003c6f16b9162980bb8344c687504f3ff347
       remote: thesofproject
       # Import some projects listed in zephyr/west.yml@revision
       #


### PR DESCRIPTION
west.yml: move Zephyr to 1941003c6f16b in sof/stable-v2.4
    
Upgrade Zephyr to newer sof/stable-v2.4 bringing in following changes:
    
        1941003c6f16b dma: hda: calculate correct size if block_count > 1
        28de2d1c4cd59 dts: xtensa: intel: update cavs25_tgph to match cavs25
