### PR TITLE
topology2: cavs-rt5682: Add tdm config on SSP1

### DIFF
--- a/tools/topology/topology2/cavs-rt5682.conf
+++ b/tools/topology/topology2/cavs-rt5682.conf
@@ -56,6 +56,7 @@ Define {
 	SPK_ID				7
 	PLATFORM 			"none"
 	USE_CHAIN_DMA			"false"
+	I2S_HW_CONFIG_ID		0
 }
 
 # override defaults with platform-specific config
@@ -99,7 +100,7 @@ Object.Dai {
 		dai_index	1
 		direction	"playback"
 		name		SSP1-Codec
-		default_hw_conf_id	0
+		default_hw_conf_id	$I2S_HW_CONFIG_ID
 		sample_bits		32
 		io_clk		$MCLK
 
@@ -108,6 +109,16 @@ Object.Dai {
 			mclk_freq	$MCLK
 			bclk_freq	3072000
 			tdm_slot_width	32
+		}
+		Object.Base.hw_config."SSP1" {
+			id	1
+			mclk_freq	$MCLK
+			bclk_freq	6144000
+			tdm_slot_width	32
+			format		"DSP_A"
+			tdm_slots	4
+			tx_slots	3
+			rx_slots	15
 		}
 	}
 }

--- a/tools/topology/topology2/sof-ace-tplg/CMakeLists.txt
+++ b/tools/topology/topology2/sof-ace-tplg/CMakeLists.txt
@@ -31,6 +31,9 @@ PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-mtl-nocodec.bin,DEEPBUFFER_FW_DMA_MS=1
 
 "cavs-rt5682\;sof-mtl-max98357a-rt5682\;PLATFORM=mtl,NUM_DMICS=4,PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,NUM_HDMIS=4,\
 PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-mtl-max98357a-rt5682.bin"
+
+"cavs-rt5682\;sof-mtl-rt1019-rt5682\;PLATFORM=mtl,NUM_DMICS=4,PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,NUM_HDMIS=4,\
+PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-mtl-max98357a-rt5682.bin,I2S_HW_CONFIG_ID=1"
 )
 
 add_custom_target(topology2_ace)


### PR DESCRIPTION
Add tdm config which can be used by Gen4.1 AIC for 4xspk playback.

Signed-off-by: Yong Zhi <yong.zhi@intel.com>