### PR TITLE
memory: intel: increase task stack size for specific modules

### DIFF
--- a/src/platform/intel/cavs/include/cavs/lib/memory.h
+++ b/src/platform/intel/cavs/include/cavs/lib/memory.h
@@ -68,7 +68,12 @@
 #define HEAP_BUF_ALIGNMENT		PLATFORM_DCACHE_ALIGN
 
 /** \brief EDF task's default stack size in bytes. */
+/* increase stack size for RTNR and GOOGLE_RTC_AUDIO_PROCESSING */
+#if defined(CONFIG_COMP_RTNR) || defined(CONFIG_COMP_GOOGLE_RTC_AUDIO_PROCESSING)
+#define PLATFORM_TASK_DEFAULT_STACK_SIZE        0x2000
+#else
 #define PLATFORM_TASK_DEFAULT_STACK_SIZE	0x1000
+#endif
 
 #if !defined(__ASSEMBLER__) && !defined(LINKER)
 


### PR DESCRIPTION
Larger stack context stack size is required for RTNR and GOOGLE_RTC_AUDIO integration on Intel platforms.