### PR TITLE
ipc4: handler: Fix D3 entry sequence

### DIFF
--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -878,6 +878,10 @@ static int ipc4_module_process_dx(struct ipc4_message_request *ipc4)
 		/* do platform specific suspending */
 		platform_context_save(sof_get());
 
+#if !defined(CONFIG_LIBRARY) && defined(CONFIG_CAVS)
+		arch_irq_lock();
+		platform_timer_stop(timer_get());
+#endif
 		ipc_get()->pm_prepare_D3 = 1;
 	}
 


### PR DESCRIPTION
Stop platform timer and disable interrupts before D3 entry for CAVS platforms.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>
(cherry picked from commit 76c85091bf61cdcb3238c1d1aa0b3a56a8fdfcec)