### PR TITLE
pipeline: rollback pipeline state upon trigger error

### DIFF
--- a/src/audio/pipeline/pipeline-schedule.c
+++ b/src/audio/pipeline/pipeline-schedule.c
@@ -91,6 +91,18 @@ static enum task_state pipeline_task_cmd(struct pipeline *p,
 		pipe_err(p, "pipeline_task_cmd(): failed to trigger components: %d", err);
 		reply->error = err;
 		err = SOF_TASK_STATE_COMPLETED;
+		switch (cmd) {
+		case COMP_TRIGGER_START:
+		case COMP_TRIGGER_RELEASE:
+		case COMP_TRIGGER_PRE_START:
+		case COMP_TRIGGER_PRE_RELEASE:
+			p->status = COMP_STATE_PAUSED;
+			break;
+		case COMP_TRIGGER_STOP:
+		case COMP_TRIGGER_PAUSE:
+			p->status = COMP_STATE_ACTIVE;
+		}
+
 	} else {
 		switch (cmd) {
 		case COMP_TRIGGER_START:


### PR DESCRIPTION
If pipeline trigger fails, the pipeline state may be left in intermediate state like COMP_TRIGGER_PRE_START.

This is a problem in case a new trigger is sent to the same pipeline. The pipeline state may indicate the pipeline task is running, while in practise this is not the case. This can lead to IPC timeout as the trigger is incorrectly sent to delayed processing in the pipeline task (which is not running).

One case is the echo reference capture pipeline. This pipeline will return -ENODATA in case the linked playback pipeline is not running. Host may send a TRIG_STOP for the pipeline, and this will lead to IPC timeout:

[      100212.287685] (          20.468750) c0 pipe         9.47  ..../pipeline-schedule.c:64   ERROR pipeline_task_cmd(): failed to trigger components: -61
[      100233.121017] (          20.833332) c0 ll-schedule        ./schedule/ll_schedule.c:142  INFO task complete 0xbe1d00c0 pipe-task <f11818eb-e92e-4082-82a3-dc54c604ebb3>
[      100251.766850] (          18.645832) c0 ll-schedule        ./schedule/ll_schedule.c:145  INFO num_tasks 2 total_num_tasks 2
[      163209.316431] (       62957.550781) c0 ipc                  src/ipc/ipc3/handler.c:1576 INFO ipc: new cmd 0x60050000
[      163237.441430] (          28.124998) c0 pipe         9.47  ....../pipeline-stream.c:261  INFO pipe trigger cmd 0

Firmware will be stuck here as the command is never handled.

Fix the issue by rolling back pipeline state in case trigger error is hit.

Link: https://github.com/thesofproject/linux/issues/4083
Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>