### PR TITLE
src: avoid restless warn messages from comp_get_data_blob()

### DIFF
--- a/src/audio/google_rtc_audio_processing.c
+++ b/src/audio/google_rtc_audio_processing.c
@@ -98,6 +98,19 @@ static int google_rtc_audio_processing_reconfigure(struct comp_dev *dev)
 
 	comp_dbg(dev, "google_rtc_audio_processing_reconfigure()");
 
+	if (!comp_is_current_data_blob_valid(cd->tuning_handler) &&
+	    !comp_is_new_data_blob_available(cd->tuning_handler)) {
+		/*
+		 * The data blob hasn't been available once so far.
+		 *
+		 * This looks redundant since the same check will be done in
+		 * comp_get_data_blob() below. But without this early return,
+		 * hundreds of warn message lines are produced per second by
+		 * comp_get_data_blob() calls until the data blob is arrived.
+		 */
+		return 0;
+	}
+
 	config = comp_get_data_blob(cd->tuning_handler, &size, NULL);
 	if (size == 0) {
 		/* No data to be handled */

--- a/src/audio/rtnr/rtnr.c
+++ b/src/audio/rtnr/rtnr.c
@@ -491,6 +491,19 @@ static int rtnr_reconfigure(struct comp_dev *dev)
 
 	comp_dbg(dev, "rtnr_reconfigure()");
 
+	if (!comp_is_current_data_blob_valid(cd->model_handler) &&
+	    !comp_is_new_data_blob_available(cd->model_handler)) {
+		/*
+		 * The data blob hasn't been available once so far.
+		 *
+		 * This looks redundant since the same check will be done in
+		 * comp_get_data_blob() below. But without this early return,
+		 * hundreds of warn message lines are produced per second by
+		 * comp_get_data_blob() calls until the data blob is arrived.
+		 */
+		return 0;
+	}
+
 	config = comp_get_data_blob(cd->model_handler, &size, NULL);
 	comp_dbg(dev, "rtnr_reconfigure() size: %d", size);
 


### PR DESCRIPTION
At present codes of rtnr and google-rtc-audio-processing, a reconfigure() function is called per copy() routine to dynamically update config blob in COMP_STATE_ACTIVE state. The logic has no problem in practice.

However, if there are cases that config blob is always empty or arrived late, hundreds of warning message lines per second will be produced by comp_get_data_blob() called from reconfigure(), restlessly complaining that [data blob is not set](https://github.com/thesofproject/sof/blob/main/src/audio/data_blob.c#L84).

This commit adds a pre-check for early-return under such cases to skip comp_get_data_blob() calls with warn messages.