### PR TITLE
library_manager: fix dma_deinit order

### DIFF
--- a/src/library_manager/lib_manager.c
+++ b/src/library_manager/lib_manager.c
@@ -448,10 +448,12 @@ static int lib_manager_dma_init(struct lib_manager_dma_ext *dma_ext, uint32_t dm
 
 static int lib_manager_dma_deinit(struct lib_manager_dma_ext *dma_ext, uint32_t dma_id)
 {
-	if (dma_ext->dma->z_dev)
-		dma_release_channel(dma_ext->dma->z_dev, dma_id);
-	if (dma_ext->dma)
+	if (dma_ext->dma) {
+		if (dma_ext->dma->z_dev)
+			dma_release_channel(dma_ext->dma->z_dev, dma_id);
+
 		dma_put(dma_ext->dma);
+	}
 	return 0;
 }
 


### PR DESCRIPTION
Fixes commit f90f5f9a142d
dma ptr should be checked before dma->z_dev