### PR TITLE
west: move rimage sha to newest commit from mtl-002-drop-stable

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -34,7 +34,7 @@ manifest:
     - name: rimage
       repo-path: rimage
       path: sof/rimage
-      revision: 80e5d7e128e82047a779963f4cabce6cab179926
+      revision: 710108ff3f284e56da83948a0da15845024b2254
 
     - name: tomlc99
       repo-path: tomlc99


### PR DESCRIPTION
Signed-off-by: Marcin Szkudlinski <marcin.szkudlinski@intel.com>