### PR TITLE
Created CMakePresets.json for Zephyr application

### DIFF
--- a/.github/workflows/zephyr-presets.yml
+++ b/.github/workflows/zephyr-presets.yml
@@ -1,0 +1,68 @@
+---
+
+name: Zephyr Presets
+
+# 'workflow_dispatch' allows running this workflow manually from the
+# 'Actions' tab
+# yamllint disable-line rule:truthy
+on: [push, pull_request, workflow_dispatch, workflow_call]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # Using groups to avoid spamming the small results box with too
+        # many lines. Pay attention to COMMAS.
+        IPC_platforms: [
+          # - IPC4 default
+          mtl,
+          # Very few IPC3 platforms support IPC4 too.
+          -i IPC4 tgl,
+        ]
+        zephyr_revision: [
+          manifest_revision,
+          "https://github.com/zephyrproject-rtos/zephyr  main",
+        ]
+
+    steps:
+      - uses: actions/checkout@v3
+        # Download a full clone to fix `git describe`, sof_version.h and
+        # build reproducibility. sof.git is still small.
+        # This is especially useful for daily builds (but not just).
+        with:
+          fetch-depth: 0
+          path: ./workspace/sof
+
+      # As of December 2022 `--shallow-exclude=v3.2.0-rc3` fixes `git
+      # describe`, Zephyr's version.h and build reproducibility while
+      # downloading about 200MB less compared to a full clone.
+      #
+      # Ideally, the --shallow-exclude= argument should be regularly
+      # bumped whenever SOF upgrades Zephyr to keep this as fast as
+      # possible.
+      # In a bigger Zephyr future maybe we could move to a more permanent
+      # git fetch --shallow-since='5 months ago' because Zephyr follows
+      # a "roughly 4-month release" but for now that saves only 100MB
+      # https://docs.zephyrproject.org/latest/project/release_process.html
+      - name: west clones
+        run: pip3 install west && cd workspace/sof/ && west init -l &&
+               west update --narrow --fetch-opt=--depth=5 &&
+               git -C ../zephyr fetch --shallow-exclude=v3.2.0-rc3
+
+      - name: select zephyr revision
+        run: cd workspace/zephyr/ &&
+             if [ 'manifest_revision' != '${{ matrix.zephyr_revision }}' ]; then
+                 git fetch ${{ matrix.zephyr_revision }} &&
+                 git checkout FETCH_HEAD;
+             fi &&
+             git log --oneline -n 5 --decorate --graph --no-abbrev-commit
+
+      # https://github.com/zephyrproject-rtos/docker-image
+      # Note: env variables can be passed to the container with
+      # -e https_proxy=...
+      - name: build
+        run: cd workspace && ./sof/zephyr/docker-run.sh
+             ./sof/zephyr/docker-preset-build.sh ${{ matrix.IPC_platforms }}

--- a/app/CMakePresets.json
+++ b/app/CMakePresets.json
@@ -1,0 +1,171 @@
+{
+	"version": 3,
+	"cmakeMinimumRequired": {
+	  "major": 3,
+	  "minor": 21,
+	  "patch": 0
+	},
+
+	"configurePresets": [
+	{
+		"name": "common-settings",
+		"description": "List of common settings used by all configurations",
+		"hidden": true,
+		"generator": "Ninja",
+		"environment": {
+			"ZEPHYR_BASE": "${sourceDir}/../../zephyr"
+		}
+	},
+	{
+		"name": "mtl-xtensa-windows",
+		"displayName": "MTL Xtensa",
+		"inherits": [ "mtl-xtensa", "xtensa-toolchain-windows" ],
+		"environment": {
+			"XTENSA_TOOLS_VERSION": "RI-2020.5-win32"
+		}
+	},
+	{
+		"name": "mtl-xtensa-linux",
+		"displayName": "MTL Xtensa",
+		"inherits": [ "mtl-xtensa", "xtensa-toolchain-linux" ],
+		"environment": {
+			"XTENSA_TOOLS_VERSION": "RI-2020.5-linux"
+		}
+	},
+	{
+		"name": "mtl-xtensa",
+		"hidden": true,
+		"description": "Meteorlake build using Xtensa toolchain",
+		"inherits": "common-settings",
+		"binaryDir": "${sourceDir}/../../build-mtl",
+		"cacheVariables": {
+			"BOARD": "intel_adsp_ace15_mtpm",
+			"ZEPHYR_TOOLCHAIN_VARIANT":"xcc"
+		},
+		"environment": {
+			"XTENSA_CORE": "ace10_LX7HiFi4_RI_2020_5"
+		}
+	},
+	{
+		"name": "tgl-xtensa-windows",
+		"displayName": "TGL Xtensa",
+		"inherits": [ "tgl-xtensa", "xtensa-toolchain-windows" ],
+		"environment": {
+			"XTENSA_TOOLS_VERSION": "RG-2017.8-Win32"
+		}
+	},
+	{
+		"name": "tgl-xtensa-linux",
+		"displayName": "TGL Xtensa",
+		"inherits": [ "tgl-xtensa", "xtensa-toolchain-linux" ],
+		"environment": {
+			"XTENSA_TOOLS_VERSION": "RG-2017.8-linux"
+		}
+	},
+	{
+		"name": "tgl-xtensa",
+		"hidden": true,
+		"description": "Tigerlake build using Xtensa toolchain",
+		"inherits": "common-settings",
+		"binaryDir": "${sourceDir}/../../build-tgl",
+		"cacheVariables": {
+			"BOARD": "intel_adsp_cavs25",
+			"ZEPHYR_TOOLCHAIN_VARIANT":"xcc",
+			"OVERLAY_CONFIG": "overlays/tgl/ipc4_overlay.conf"
+		},
+		"environment": {
+			"XTENSA_CORE": "cavs2x_LX6HiFi3_2017_8"
+		}
+	},
+	{
+		"name": "xtensa-toolchain-windows",
+		"hidden": true,
+		"inherits": [ "windows", "xtensa-toolchain" ],
+		"environment": {
+			"XTENSA_INSTALL_PATH": "C:/usr/xtensa"
+		}
+	},
+	{
+		"name": "xtensa-toolchain-linux",
+		"hidden": true,
+		"inherits": [ "linux", "xtensa-toolchain" ],
+		"environment": {
+			"XTENSA_INSTALL_PATH": "~/xtensa"
+		}
+	},
+	{
+		"name": "xtensa-toolchain",
+		"description": "Common settings for Xtensa tools",
+		"hidden": true,
+		"environment": {
+			"XTENSA_TOOLS_DIR": "$env{XTENSA_INSTALL_PATH}/XtDevTools/install/tools",
+			"XTENSA_BUILDS_DIR": "$env{XTENSA_INSTALL_PATH}/XtDevTools/install/builds",
+			"XTENSA_TOOLCHAIN_PATH": "$env{XTENSA_TOOLS_DIR}/$env{XTENSA_TOOLS_VERSION}",
+			"XTENSA_TOOLS": "$env{XTENSA_TOOLS_DIR}/$env{XTENSA_TOOLS_VERSION}/XtensaTools",
+			"XTENSA_SYSTEM": "$env{XTENSA_BUILDS_DIR}/$env{XTENSA_TOOLS_VERSION}/$env{XTENSA_CORE}/config"
+		}
+	},
+	{
+		"name": "windows",
+		"description": "Indicates that preset is Windows specific",
+		"hidden": true,
+		"condition": {
+			"type": "equals",
+			"lhs": "${hostSystemName}",
+			"rhs": "Windows"
+		}
+	},
+	{
+		"name": "linux",
+		"description": "Indicates that preset is Linux specific",
+		"hidden": true,
+		"condition": {
+			"type": "equals",
+			"lhs": "${hostSystemName}",
+			"rhs": "Linux"
+		}
+	}
+	],
+
+	"buildPresets": [
+	{
+		"name": "mtl-xtensa-windows",
+		"displayName": "MTL Xtensa",
+		"description": "Build MTL with Xtensa toolchain",
+		"configurePreset": "mtl-xtensa-windows"
+	},
+	{
+		"name": "mtl-xtensa-windows-rebuild",
+		"displayName": "MTL Xtensa rebuild",
+		"description": "Cleans build files and rebuilds MTL with Xtensa toolchain",
+		"inherits": "mtl-xtensa-windows",
+		"cleanFirst": true
+	},
+	{
+		"name": "mtl-xtensa-linux",
+		"displayName": "MTL Xtensa",
+		"description": "Build MTL with Xtensa toolchain",
+		"configurePreset": "mtl-xtensa-linux"
+	},
+	{
+		"name": "mtl-xtensa-linux-rebuild",
+		"displayName": "MTL Xtensa rebuild",
+		"description": "Cleans build files and rebuilds MTL with Xtensa toolchain",
+		"inherits": "mtl-xtensa-linux",
+		"cleanFirst": true
+	},
+	{
+		"name": "tgl-xtensa-windows",
+		"displayName": "TGL Xtensa",
+		"description": "Build TGL with Xtensa toolchain",
+		"configurePreset": "tgl-xtensa-windows"
+	},
+	{
+		"name": "tgl-xtensa-windows-rebuild",
+		"displayName": "TGL Xtensa rebuild",
+		"description": "Cleans build files and rebuilds TGL with Xtensa toolchain",
+		"configurePreset": "tgl-xtensa-windows",
+		"cleanFirst": true
+	}
+	]
+}

--- a/zephyr/docker-preset-build.sh
+++ b/zephyr/docker-preset-build.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2021 Intel Corporation. All rights reserved.
+
+# "All problems can be solved by another level of indirection"
+# Ideally, this script would not be needed.
+#
+# Minor adjustments to the docker image provided by the Zephyr project.
+
+set -e
+set -x
+
+unset ZEPHYR_BASE
+
+# Make sure we're in the right place
+test -e ./sof/scripts/xtensa-build-zephyr.py
+
+# See .github/workflows/zephyr.yml
+# /opt/sparse is the current location in the zephyr-build image.
+# Give any sparse in the workspace precedence.
+PATH="$(pwd)"/sparse:/opt/sparse/bin:"$PATH"
+command -V sparse  || true
+: REAL_CC="$REAL_CC"
+
+
+# TODO: move all code to a function
+# https://github.com/thesofproject/sof-test/issues/740
+
+# As of container version 0.18.4,
+# https://github.com/zephyrproject-rtos/docker-image/blob/master/Dockerfile
+# installs two SDKs: ZSDK_VERSION=0.12.4 and ZSDK_ALT_VERSION=0.13.1
+# ZEPHYR_SDK_INSTALL_DIR points at ZSDK_VERSION but we want the latest.
+unset ZEPHYR_SDK_INSTALL_DIR
+
+# Zephyr's CMake does not look in /opt but it searches $HOME
+ls -ld /opt/toolchains/zephyr-sdk-*
+ln -s  /opt/toolchains/zephyr-sdk-*  ~/ || true
+
+# To investigate what went wrong enable the trailing comment.
+# This cannot be enabled by default for automation reasons.
+cd sof/app
+cmake -S . --preset "$@" # || /bin/bash
+cmake --build --preset "$@" # || /bin/bash


### PR DESCRIPTION
Alternative way of building the SOF project as Zephyr application is using CMake overlays. This provides similar functionality to xtensa-build-zephyr.py but is solution native to CMake. In this commit added TGL and MTL builds using Xtensa toolchain. Only elf file is built, integration with Rimage is TODO.

To test (example):
```
cd sof/app
cmake -S . --preset mtl-xtensa-linux
cmake --build --preset mtl-xtensa-linux
```
This will build .elf file without signing.
Rimage integration is TODO.
@marc-hb can you please test it on linux?
What toolchain are NXP platforms using?

Signed-off-by: Andrey Borisovich <andrey.borisovich@intel.com>