### PR TITLE
backport: dai: move AMD_HS to end of list to restore backwards-compatibility

### DIFF
--- a/src/include/ipc/dai.h
+++ b/src/include/ipc/dai.h
@@ -89,8 +89,8 @@ enum sof_ipc_dai_type {
 	SOF_DAI_AMD_BT,			/**< Amd BT */
 	SOF_DAI_AMD_SP,			/**< Amd SP */
 	SOF_DAI_AMD_DMIC,		/**< Amd DMIC */
+	SOF_DAI_MEDIATEK_AFE,           /**< Mtk AFE */
 	SOF_DAI_AMD_HS,			/**< Amd HS */
-	SOF_DAI_MEDIATEK_AFE            /**< Mtk AFE */
 };
 
 /* general purpose DAI configuration */


### PR DESCRIPTION
The addition of AMD_HS breaks Mediatek platforms by using an index previously allocated to Mediatek. This is a backwards-compatibility issue and needs to be fixed. All firmware released by AMD needs to be re-generated and re-distributed.

Fixes: 83ee5b49a987 ("dai: support for amd specific hs dai id")
Link: https://github.com/thesofproject/sof/issues/6615
Link: https://lore.kernel.org/alsa-devel/36a45c7a-820a-7675-d740-c0e83ae2c417@collabora.com/
Reported-by: AngeloGioacchino Del Regno <angelogioacchino.delregno@collabora.com>
Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>