### PR TITLE
topology2: cavs-sdw: fix DEEP_BUFFER_PIPELINE_SINK

### DIFF
--- a/tools/topology/topology2/cavs-sdw.conf
+++ b/tools/topology/topology2/cavs-sdw.conf
@@ -53,7 +53,7 @@ Define {
 	DEEP_BUFFER_PIPELINE_ID         15
 	DEEP_BUFFER_PCM_ID              31
 	DEEP_BUFFER_PIPELINE_SRC        'mixin.15.1'
-	DEEP_BUFFER_PIPELINE_SINK       'mixout.2.1'
+	DEEP_BUFFER_PIPELINE_SINK       'mixout.1.1'
 	DEEP_BUFFER_PCM_NAME		'Deepbuffer Jack Out'
 	SDW_JACK_OUT_STREAM	'SDW0-Playback'
 	SDW_JACK_IN_STREAM	'SDW0-Capture'


### PR DESCRIPTION
mixout-gain-dai-copier-playback.2 pipeline id has been changed to 1. Need to change mixout.2.1 to mixout.1.1 as well.

Fixes: https://github.com/thesofproject/sof/commit/f0a010052bd0216348e0906c7f84c5798bb8351d ("topology2: cavs-sdw: group route and pipeline index")
Signed-off-by: Bard Liao <yung-chuan.liao@linux.intel.com>

Fixes: #6778 