### PR TITLE
kpb: add support 24/24bit buffering for 1-6 channels [mtl-003-stable-only] 

### DIFF
--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -223,7 +223,7 @@ static void kpb_set_params(struct comp_dev *dev,
 	params->sample_valid_bytes =
 		kpb->ipc4_cfg.base_cfg.audio_fmt.valid_bit_depth / 8;
 	params->buffer_fmt = kpb->ipc4_cfg.base_cfg.audio_fmt.interleaving_style;
-	params->buffer.size = kpb->ipc4_cfg.base_cfg.obs * KPB_MAX_BUFF_TIME * 2;
+	params->buffer.size = kpb->ipc4_cfg.base_cfg.obs * KPB_MAX_BUFF_TIME * params->channels;
 
 	params->host_period_bytes = params->channels *
 				    params->sample_container_bytes *
@@ -703,7 +703,7 @@ static int kpb_prepare(struct comp_dev *dev)
 	struct comp_data *kpb = comp_get_drvdata(dev);
 	int ret = 0;
 	int i;
-	size_t hb_size_req = KPB_MAX_BUFFER_SIZE(kpb->config.sampling_width);
+	size_t hb_size_req = KPB_MAX_BUFFER_SIZE(kpb->config.sampling_width, kpb->config.channels);
 
 	comp_dbg(dev, "kpb_prepare()");
 
@@ -1903,13 +1903,13 @@ static inline bool validate_host_params(struct comp_dev *dev,
 		comp_err(dev, "kpb: host_period_size (%d) cannot be 0 and host_buffer_size (%d) cannot be 0",
 			 host_period_size, host_buffer_size);
 		return false;
-	} else if (HOST_BUFFER_MIN_SIZE(hb_size_req) >
+	} else if (HOST_BUFFER_MIN_SIZE(hb_size_req, kpb->config.channels) >
 		   host_buffer_size) {
 		/* Host buffer size is too small - history data
 		 * may get overwritten.
 		 */
 		comp_err(dev, "kpb: host_buffer_size (%d) must be at least %d",
-			 host_buffer_size, HOST_BUFFER_MIN_SIZE(hb_size_req));
+			 host_buffer_size, HOST_BUFFER_MIN_SIZE(hb_size_req, kpb->config.channels));
 		return false;
 	} else if (kpb->sync_draining_mode) {
 		/* Sync draining allowed. Check if we can perform draining

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -814,7 +814,7 @@ static int kpb_prepare(struct comp_dev *dev)
 	}
 
 	/* Disallow sync_draining_mode for now */
-	kpb->sync_draining_mode = false;
+	kpb->sync_draining_mode = true;
 
 	kpb_change_state(kpb, KPB_STATE_RUN);
 

--- a/src/include/sof/audio/kpb.h
+++ b/src/include/sof/audio/kpb.h
@@ -26,26 +26,25 @@ struct comp_buffer;
 #endif
 
 #define KPB_MAX_DRAINING_REQ (KPB_MAX_BUFF_TIME - HOST_WAKEUP_TIME)
-#define KPB_MAX_SUPPORTED_CHANNELS 2 /**< number of supported channels */
+#define KPB_MAX_SUPPORTED_CHANNELS 6 /**< number of supported channels */
 /**< number of samples taken each milisecond */
 #define	KPB_SAMPLES_PER_MS (KPB_SAMPLNG_FREQUENCY / 1000)
 #define	KPB_SAMPLNG_FREQUENCY 16000 /**< supported sampling frequency in Hz */
-#define KPB_NUM_OF_CHANNELS 2
 #define KPB_SAMPLE_CONTAINER_SIZE(sw) ((sw == 16) ? 16 : 32)
-#define KPB_MAX_BUFFER_SIZE(sw) ((KPB_SAMPLNG_FREQUENCY / 1000) * \
+#define KPB_MAX_BUFFER_SIZE(sw, channels_number) ((KPB_SAMPLNG_FREQUENCY / 1000) * \
 	(KPB_SAMPLE_CONTAINER_SIZE(sw) / 8) * KPB_MAX_BUFF_TIME * \
-	KPB_NUM_OF_CHANNELS)
+	 (channels_number))
 #define KPB_MAX_NO_OF_CLIENTS 2
 #define KPB_NO_OF_HISTORY_BUFFERS 2 /**< no of internal buffers */
 #define KPB_ALLOCATION_STEP 0x100
 #define KPB_NO_OF_MEM_POOLS 3
-#define KPB_BYTES_TO_FRAMES(bytes, sample_width) \
-	(bytes / ((KPB_SAMPLE_CONTAINER_SIZE(sample_width) / 8) * \
-	KPB_NUM_OF_CHANNELS))
+#define KPB_BYTES_TO_FRAMES(bytes, sample_width, channels_number) \
+	((bytes) / ((KPB_SAMPLE_CONTAINER_SIZE(sample_width) / 8) * \
+	 (channels_number)))
 /**< Defines how much faster draining is in comparison to pipeline copy. */
 #define KPB_DRAIN_NUM_OF_PPL_PERIODS_AT_ONCE 2
 /**< Host buffer shall be at least two times bigger than history buffer. */
-#define HOST_BUFFER_MIN_SIZE(hb) (hb * 2)
+#define HOST_BUFFER_MIN_SIZE(hb, channels_number) ((hb) * (channels_number))
 
 /**< Convert with right shift a bytes count to samples count */
 #define KPB_BYTES_TO_S16_SAMPLES(s)	((s) >> 1)

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -371,9 +371,6 @@ int ipc_comp_connect(struct ipc *ipc, ipc_pipe_comp_connect *_connect)
 		goto free;
 	}
 
-	ret = comp_bind(source, bu);
-	if (ret < 0)
-		goto e_src_bind;
 
 	ret = comp_buffer_connect(sink, sink->ipc_config.core, buffer,
 				  PPL_CONN_DIR_BUFFER_TO_COMP);
@@ -381,6 +378,10 @@ int ipc_comp_connect(struct ipc *ipc, ipc_pipe_comp_connect *_connect)
 		tr_err(&ipc_tr, "failed to connect internal buffer to sink %d", sink_id);
 		goto e_sink_connect;
 	}
+
+	ret = comp_bind(source, bu);
+	if (ret < 0)
+		goto e_src_bind;
 
 	ret = comp_bind(sink, bu);
 	if (ret < 0)

--- a/src/platform/meteorlake/include/platform/lib/memory.h
+++ b/src/platform/meteorlake/include/platform/lib/memory.h
@@ -56,7 +56,7 @@
 /**
  * size of HPSRAM system heap
  */
-#define HEAPMEM_SIZE 0x40000
+#define HEAPMEM_SIZE 0xD0000
 
 #endif /* __PLATFORM_LIB_MEMORY_H__ */
 


### PR DESCRIPTION
[mtl-003-stable-only] Need to make a version without HiFi.

FW infrastructure shall support buffering of historic data from 1ch up to 6 channels 24bit samples in 24bit container.
KPB module shall support on input 3 to 6 channels (1-4 mics + 2ch reference), 16kHz, 16/24bit . Output pins shall support:
For buffered pin same number of channels as on input, 16kHz, bit depth same as on input.

