### PR TITLE
ace: fix cache-uncache conversion macros for sparse

### DIFF
--- a/src/audio/mixin_mixout/mixin_mixout.c
+++ b/src/audio/mixin_mixout/mixin_mixout.c
@@ -9,6 +9,7 @@
 #include <sof/audio/pipeline.h>
 #include <sof/audio/ipc-config.h>
 #include <sof/common.h>
+#include <sof/compiler_attributes.h>
 #include <sof/debug/panic.h>
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
@@ -241,9 +242,9 @@ static void mixout_free(struct comp_dev *dev)
 	rfree(dev);
 }
 
-static
-struct mixout_source_info *find_mixout_source_info(struct mixed_data_info __sparse_cache *mdi,
-						   const struct comp_dev *mixin)
+static struct mixout_source_info __sparse_cache
+				*find_mixout_source_info(struct mixed_data_info __sparse_cache *mdi,
+							 const struct comp_dev *mixin)
 {
 	/* mixin == NULL is also a valid input -- this will find first unused entry */
 	int i;
@@ -407,7 +408,7 @@ static int mixin_copy(struct comp_dev *dev)
 		struct comp_buffer *sink;
 		struct mixout_data *mixout_data;
 		struct mixed_data_info __sparse_cache *mixed_data_info;
-		struct mixout_source_info *src_info;
+		struct mixout_source_info __sparse_cache *src_info;
 		struct comp_buffer __sparse_cache *sink_c;
 		uint32_t free_frames;
 
@@ -494,7 +495,7 @@ static int mixin_copy(struct comp_dev *dev)
 		struct comp_buffer *sink;
 		struct mixout_data *mixout_data;
 		struct mixed_data_info __sparse_cache *mixed_data_info;
-		struct mixout_source_info *src_info;
+		struct mixout_source_info __sparse_cache *src_info;
 		uint32_t start_frame;
 		struct comp_buffer __sparse_cache *sink_c;
 		uint32_t writeback_size;
@@ -591,7 +592,7 @@ static int mixout_copy(struct comp_dev *dev)
 	list_for_item(blist, &dev->bsource_list) {
 		struct comp_buffer *unused_in_between_buf;
 		struct comp_dev *mixin;
-		struct mixout_source_info *src_info;
+		struct mixout_source_info __sparse_cache *src_info;
 
 		unused_in_between_buf = buffer_from_list(blist, struct comp_buffer,
 							 PPL_DIR_UPSTREAM);
@@ -977,7 +978,7 @@ static int mixout_bind(struct comp_dev *dev, void *data)
 	if (dev->ipc_config.id != src_id) {
 		/* new mixin -> mixout */
 		struct comp_dev *mixin;
-		struct mixout_source_info *source_info;
+		struct mixout_source_info __sparse_cache *source_info;
 
 		mixin = ipc4_get_comp_dev(src_id);
 		if (!mixin) {
@@ -991,7 +992,7 @@ static int mixout_bind(struct comp_dev *dev, void *data)
 			/* this should never happen as source_info should
 			 * have been already cleared in mixout_unbind()
 			 */
-			memset(source_info, 0, sizeof(*source_info));
+			memset((__sparse_force void *)source_info, 0, sizeof(*source_info));
 		}
 		source_info = find_mixout_source_info(mixed_data_info, NULL);
 		if (!source_info) {
@@ -1025,7 +1026,7 @@ static int mixout_unbind(struct comp_dev *dev, void *data)
 	/* mixin -> mixout */
 	if (dev->ipc_config.id != src_id) {
 		struct comp_dev *mixin;
-		struct mixout_source_info *source_info;
+		struct mixout_source_info __sparse_cache *source_info;
 
 		mixin = ipc4_get_comp_dev(src_id);
 		if (!mixin) {
@@ -1036,7 +1037,7 @@ static int mixout_unbind(struct comp_dev *dev, void *data)
 
 		source_info = find_mixout_source_info(mixed_data_info, mixin);
 		if (source_info)
-			memset(source_info, 0, sizeof(*source_info));
+			memset((__sparse_force void *)source_info, 0, sizeof(*source_info));
 	}
 
 	mixed_data_info_release(mixed_data_info);

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -574,21 +574,22 @@ DECLARE_MODULE(sys_comp_selector_init);
 #else
 static void build_config(struct comp_data *cd, struct module_config *cfg)
 {
-	enum sof_ipc_frame valid_format;
+	enum sof_ipc_frame __sparse_cache frame_fmt, valid_fmt;
 	int i;
 
-	cd->source_format = cfg->base_cfg.audio_fmt.depth;
+	frame_fmt = cfg->base_cfg.audio_fmt.depth;
 	audio_stream_fmt_conversion(cfg->base_cfg.audio_fmt.depth,
 				    cfg->base_cfg.audio_fmt.valid_bit_depth,
-				    &cd->source_format,
-				    &valid_format,
+				    &frame_fmt, &valid_fmt,
 				    cfg->base_cfg.audio_fmt.s_type);
+	cd->source_format = frame_fmt;
 
+	frame_fmt = cd->sink_format;
 	audio_stream_fmt_conversion(cd->output_format.depth,
 				    cd->output_format.valid_bit_depth,
-				    &cd->sink_format,
-				    &valid_format,
+				    &frame_fmt, &valid_fmt,
 				    cd->output_format.s_type);
+	cd->sink_format = frame_fmt;
 
 	cd->config.in_channels_count = cfg->base_cfg.audio_fmt.channels_count;
 	cd->config.out_channels_count = cd->output_format.channels_count;

--- a/src/platform/intel/ace/include/ace/lib/mailbox.h
+++ b/src/platform/intel/ace/include/ace/lib/mailbox.h
@@ -39,9 +39,9 @@
 static inline void mailbox_sw_reg_write(size_t offset, uint32_t src)
 {
 	volatile uint32_t *ptr;
-	volatile uint32_t __sparse_cache *ptr_c;
+	uint32_t __sparse_cache *ptr_c;
 
-	ptr_c = (volatile uint32_t __sparse_cache *)(MAILBOX_SW_REG_BASE + offset);
+	ptr_c = (uint32_t __sparse_cache *)(MAILBOX_SW_REG_BASE + offset);
 	ptr = cache_to_uncache(ptr_c);
 	*ptr = src;
 }
@@ -49,9 +49,9 @@ static inline void mailbox_sw_reg_write(size_t offset, uint32_t src)
 static inline void mailbox_sw_reg_write64(size_t offset, uint64_t src)
 {
 	volatile uint64_t *ptr;
-	volatile uint64_t __sparse_cache *ptr_c;
+	uint64_t __sparse_cache *ptr_c;
 
-	ptr_c = (volatile uint64_t __sparse_cache *)(MAILBOX_SW_REG_BASE + offset);
+	ptr_c = (uint64_t __sparse_cache *)(MAILBOX_SW_REG_BASE + offset);
 	ptr = cache_to_uncache(ptr_c);
 	*ptr = src;
 }
@@ -59,9 +59,9 @@ static inline void mailbox_sw_reg_write64(size_t offset, uint64_t src)
 static inline uint32_t mailbox_sw_reg_read(size_t offset)
 {
 	volatile uint32_t *ptr;
-	volatile uint32_t __sparse_cache *ptr_c;
+	uint32_t __sparse_cache *ptr_c;
 
-	ptr_c = (volatile uint32_t __sparse_cache *)(MAILBOX_SW_REG_BASE + offset);
+	ptr_c = (uint32_t __sparse_cache *)(MAILBOX_SW_REG_BASE + offset);
 	ptr = cache_to_uncache(ptr_c);
 
 	return *ptr;
@@ -70,9 +70,9 @@ static inline uint32_t mailbox_sw_reg_read(size_t offset)
 static inline uint64_t mailbox_sw_reg_read64(size_t offset)
 {
 	volatile uint64_t *ptr;
-	volatile uint64_t __sparse_cache *ptr_c;
+	uint64_t __sparse_cache *ptr_c;
 
-	ptr_c = (volatile uint64_t __sparse_cache *)(MAILBOX_SW_REG_BASE + offset);
+	ptr_c = (uint64_t __sparse_cache *)(MAILBOX_SW_REG_BASE + offset);
 	ptr = cache_to_uncache(ptr_c);
 
 	return *ptr;

--- a/src/platform/intel/ace/include/ace/lib/memory.h
+++ b/src/platform/intel/ace/include/ace/lib/memory.h
@@ -40,14 +40,19 @@
 #define SRAM_ALIAS_OFFSET		0x60000000
 
 #if !defined UNIT_TEST
-#define uncache_to_cache(address) \
-				((__typeof__(address))(((uint32_t)(address) &  \
-				~SRAM_ALIAS_MASK) | SRAM_CACHED_BASE))
+static inline void __sparse_cache *uncache_to_cache(void *address)
+{
+	return (void __sparse_cache *)(((uintptr_t)(address) & ~SRAM_ALIAS_MASK) |
+				       SRAM_CACHED_BASE);
+}
+
+static inline void *cache_to_uncache(void __sparse_cache *address)
+{
+	return (void *)(((uintptr_t)(address) & ~SRAM_ALIAS_MASK) | SRAM_BASE);
+}
+
 #define is_uncached(address) \
 				(((uint32_t)(address) & SRAM_ALIAS_MASK) == SRAM_BASE)
-#define cache_to_uncache(address) \
-				((__typeof__(address))(((uint32_t)(address) & \
-				~SRAM_ALIAS_MASK) | SRAM_BASE))
 #else
 #define uncache_to_cache(address)       address
 #define cache_to_uncache(address)       address

--- a/zephyr/lib/alloc.c
+++ b/zephyr/lib/alloc.c
@@ -107,8 +107,8 @@ static inline uintptr_t get_l3_heap_start(void)
 	 * - main_fw_load_offset
 	 * - main fw size in manifest
 	 */
-	return (uintptr_t)z_soc_uncached_ptr(UINT_TO_POINTER
-			(ROUND_UP(IMR_L3_HEAP_BASE, L3_MEM_PAGE_SIZE)));
+	return (uintptr_t)z_soc_uncached_ptr((__sparse_force void __sparse_cache *)
+					     ROUND_UP(IMR_L3_HEAP_BASE, L3_MEM_PAGE_SIZE));
 }
 
 /**


### PR DESCRIPTION
cache_to_uncache() and uncache_to_cache() must be inline functions with proper argument annotations. Fix ACE definitions by alanogy with cAVS.
