### PR TITLE
ipc4: fix crash when using ALH DAI

### DIFF
--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -114,13 +114,12 @@ int ipc_dai_data_config(struct comp_dev *dev)
 		 * all formats, such as 8/16/24/32 bits.
 		 */
 		dev->ipc_config.frame_fmt = SOF_IPC_FRAME_S32_LE;
-		dd->dma_buffer->stream.frame_fmt = dev->ipc_config.frame_fmt;
 
 		dd->config.burst_elems = dai_get_fifo_depth(dd->dai, dai->direction);
 
+		comp_dbg(dev, "dai_data_config() SOF_DAI_INTEL_ALH dev->ipc_config.frame_fmt: %d, stream_id: %d",
+			 dev->ipc_config.frame_fmt, dd->stream_id);
 
-		comp_dbg(dev, "dai_data_config() SOF_DAI_INTEL_ALH dd->dma_buffer->stream.frame_fmt %#x stream_id %d",
-			 dd->dma_buffer->stream.frame_fmt, dd->stream_id);
 		break;
 	default:
 		/* other types of DAIs not handled for now */


### PR DESCRIPTION
dma_buffer is not yet created when ipc_dai_data_config() is called. Accessing dma_buffer->stream leads to crash.

Anyway, there is no need to set dd->dma_buffer->stream.frame_fmt = SOF_IPC_FRAME_S32_LE as this is done just after ipc_dai_data_config() in dai_params() by calling buffer_set_params().

Somewhat similar fix for IPC3 was done some time ago: 0ba90d8e2a.

Signed-off-by: Serhiy Katsyuba <serhiy.katsyuba@intel.com>