### PR TITLE
module_adapter: free memory resource

### DIFF
--- a/src/audio/module_adapter/module/waves.c
+++ b/src/audio/module_adapter/module/waves.c
@@ -829,6 +829,12 @@ static int waves_codec_reset(struct processing_module *mod)
 	if (ret)
 		comp_err(dev, "waves_codec_reset() failed %d", ret);
 
+	if (codec->mpd.in_buff)
+		module_free_memory(mod, codec->mpd.in_buff);
+
+	if (codec->mpd.out_buff)
+		module_free_memory(mod, codec->mpd.out_buff);
+
 	comp_dbg(dev, "waves_codec_reset() done");
 	return ret;
 }


### PR DESCRIPTION
Since module-specific prepare API will be called every time on prepare
 of module_adapter (stream start trigger), the reset API should
free all memory that was allocated during the prepare API.

Signed-off-by: barry.jan <barry.jan@waves.com>