### PR TITLE
[SKIP CI] .github/zephyr: re-add TGL IPC3 build for now

### DIFF
--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -21,8 +21,8 @@ jobs:
           imx8 imx8x imx8m,
           # - IPC4 default
           mtl,
-          # Some IPC3 platforms support IPC4 too.
-          -i IPC4 tgl, -i IPC4 tgl-h,
+          # Temporary testbed for Zephyr development.
+          -i IPC4 tgl tgl-h,
         ]
         zephyr_revision: [
           manifest_revision,

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -19,6 +19,7 @@ jobs:
         IPC_platforms: [
           # - IPC3 default
           imx8 imx8x imx8m,
+          tgl tgl-h,  # UNSUPPORTED! Will be removed
           # - IPC4 default
           mtl,
           # Temporary testbed for Zephyr development.


### PR DESCRIPTION
Partial revert of commit 687c6f305e46 (".github: workflow: removed legacy RTOS platforms from Zephyr build") that was a bit too "enthusiastic".

When someone breaks the Zephyr+IPC3 build we'd like to: 1. notice, 2. tell whether it's Intel-specific, IMX-specific or not specific.

This is a one-line change and unlike testing, building is "free". It can be removed in a second when/if that becomes a burden.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>