### PR TITLE
[DON'T REVIEW！！]Audio: Mixin_Mixout: Optimization with frame aligned API

### DIFF
--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -340,6 +340,18 @@ audio_stream_get_avail_samples(const struct audio_stream __sparse_cache *stream)
 }
 
 /**
+ * Calculates aligned available data in frames, handling underrun_permitted behaviour
+ * @param stream audio stream buffer pointer
+ * @return amount of data available for processing in frames
+ */
+static inline uint32_t
+audio_stream_get_avail_frames_aligned(const struct audio_stream __sparse_cache *stream)
+{
+	return (audio_stream_get_avail_bytes(stream) >> stream->frame_align_shift)
+		 * stream->frame_align;
+}
+
+/**
  * Calculates available data in frames, handling underrun_permitted behaviour
  * @param stream Stream pointer
  * @return amount of data available for processing in frames
@@ -393,6 +405,18 @@ audio_stream_get_free_frames(const struct audio_stream __sparse_cache *stream)
 {
 	return audio_stream_get_free_bytes(stream) /
 		audio_stream_frame_bytes(stream);
+}
+
+/**
+ * Calculates aligned free space in frames, handling overrun_permitted behaviour
+ * @param stream audio stream buffer
+ * @return amount of space free in frames
+ */
+static inline uint32_t
+audio_stream_get_free_frames_aligned(const struct audio_stream __sparse_cache *stream)
+{
+	return (audio_stream_get_free_bytes(stream) >> stream->frame_align_shift)
+	       * stream->frame_align;
 }
 
 /**


### PR DESCRIPTION
Using frame aligned API to keep sink source read/write pointer always 8 byte aligned to avoid corner case and unaligned processing of normal mode. The improvement of normal mode function would be at least 20% cycles saving.

Signed-off-by: Andrula Song <xiaoyuan.song@intel.com>