### PR TITLE
sof debug and trace: change sof log level for some modules

### DIFF
--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -485,7 +485,7 @@ static int dai_playback_params(struct comp_dev *dev, uint32_t period_bytes,
 		fifo = dai_get_fifo(dd->dai, dev->direction,
 				    dd->stream_id);
 
-		comp_info(dev, "dai_playback_params() fifo 0x%x", fifo);
+		comp_dbg(dev, "dai_playback_params() fifo 0x%x", fifo);
 
 		err = dma_sg_alloc(&config->elem_array, SOF_MEM_ZONE_RUNTIME,
 				   config->direction,
@@ -614,7 +614,7 @@ static int dai_capture_params(struct comp_dev *dev, uint32_t period_bytes,
 		fifo = dai_get_fifo(dd->dai, dev->direction,
 				    dd->stream_id);
 
-		comp_info(dev, "dai_capture_params() fifo 0x%x", fifo);
+		comp_dbg(dev, "dai_capture_params() fifo 0x%x", fifo);
 
 		err = dma_sg_alloc(&config->elem_array, SOF_MEM_ZONE_RUNTIME,
 				   config->direction,
@@ -844,7 +844,7 @@ static int dai_config_prepare(struct comp_dev *dev)
 	}
 
 	channel = dai_config_dma_channel(dev, dd->dai_spec_config);
-	comp_info(dev, "dai_config_prepare(), channel = %d", channel);
+	comp_dbg(dev, "dai_config_prepare(), channel = %d", channel);
 
 	/* do nothing for asking for channel free, for compatibility. */
 	if (channel == DMA_CHAN_INVALID) {
@@ -863,8 +863,8 @@ static int dai_config_prepare(struct comp_dev *dev)
 	dd->chan = &dd->dma->chan[channel];
 	dd->chan->dev_data = dd;
 
-	comp_info(dev, "dai_config_prepare(): new configured dma channel index %d",
-		  dd->chan->index);
+	comp_dbg(dev, "dai_config_prepare(): new configured dma channel index %d",
+		 dd->chan->index);
 
 	/* setup callback */
 	notifier_register(dev, dd->chan, NOTIFIER_ID_DMA_COPY,
@@ -879,7 +879,7 @@ static int dai_prepare(struct comp_dev *dev)
 	struct comp_buffer __sparse_cache *buffer_c;
 	int ret;
 
-	comp_info(dev, "dai_prepare()");
+	comp_dbg(dev, "dai_prepare()");
 
 	ret = dai_config_prepare(dev);
 	if (ret < 0)
@@ -930,7 +930,7 @@ static int dai_reset(struct comp_dev *dev)
 	struct dai_data *dd = comp_get_drvdata(dev);
 	struct dma_sg_config *config = &dd->config;
 
-	comp_info(dev, "dai_reset()");
+	comp_dbg(dev, "dai_reset()");
 
 	/*
 	 * DMA channel release should be skipped now for DAI's that support the two-step stop

--- a/src/audio/host-zephyr.c
+++ b/src/audio/host-zephyr.c
@@ -703,7 +703,7 @@ static void host_free(struct comp_dev *dev)
 {
 	struct host_data *hd = comp_get_drvdata(dev);
 
-	comp_info(dev, "host_free()");
+	comp_dbg(dev, "host_free()");
 
 	dma_put(hd->dma);
 

--- a/src/audio/module_adapter/module/generic.c
+++ b/src/audio/module_adapter/module/generic.c
@@ -81,7 +81,7 @@ int module_init(struct processing_module *mod, struct module_interface *interfac
 	struct module_data *md = &mod->priv;
 	struct comp_dev *dev = mod->dev;
 
-	comp_info(dev, "module_init() start");
+	comp_dbg(dev, "module_init() start");
 
 	if (mod->priv.state == MODULE_INITIALIZED)
 		return 0;
@@ -114,7 +114,7 @@ int module_init(struct processing_module *mod, struct module_interface *interfac
 		return ret;
 	}
 
-	comp_info(dev, "module_init() done");
+	comp_dbg(dev, "module_init() done");
 	md->state = MODULE_INITIALIZED;
 
 	return ret;

--- a/src/audio/module_adapter/module/volume/volume.c
+++ b/src/audio/module_adapter/module/volume/volume.c
@@ -808,8 +808,8 @@ static int volume_set_config(struct processing_module *mod, uint32_t config_id,
 		for (j = 0; j < cdata->num_elems; j++) {
 			ch = cdata->chanv[j].channel;
 			val = cdata->chanv[j].value;
-			comp_info(dev, "volume_set_config(), channel = %d, value = %u",
-				  ch, val);
+			comp_dbg(dev, "volume_set_config(), channel = %d, value = %u",
+				 ch, val);
 
 			if (ch >= SOF_IPC_MAX_CHANNELS) {
 				comp_err(dev, "volume_set_config(), illegal channel = %d",
@@ -838,8 +838,8 @@ static int volume_set_config(struct processing_module *mod, uint32_t config_id,
 		for (j = 0; j < cdata->num_elems; j++) {
 			ch = cdata->chanv[j].channel;
 			val = cdata->chanv[j].value;
-			comp_info(dev, "volume_set_config(), channel = %d, value = %u",
-				  ch, val);
+			comp_dbg(dev, "volume_set_config(), channel = %d, value = %u",
+				 ch, val);
 			if (ch >= SOF_IPC_MAX_CHANNELS) {
 				comp_err(dev, "volume_set_config(), illegal channel = %d",
 					 ch);
@@ -889,18 +889,18 @@ static int volume_get_config(struct processing_module *mod,
 		for (j = 0; j < cdata->num_elems; j++) {
 			cdata->chanv[j].channel = j;
 			cdata->chanv[j].value = cd->tvolume[j];
-			comp_info(dev, "volume_get_config(), channel = %u, value = %u",
-				  cdata->chanv[j].channel,
-				  cdata->chanv[j].value);
+			comp_dbg(dev, "volume_get_config(), channel = %u, value = %u",
+				 cdata->chanv[j].channel,
+				 cdata->chanv[j].value);
 		}
 		break;
 	case SOF_CTRL_CMD_SWITCH:
 		for (j = 0; j < cdata->num_elems; j++) {
 			cdata->chanv[j].channel = j;
 			cdata->chanv[j].value = !cd->muted[j];
-			comp_info(dev, "volume_get_config(), channel = %u, value = %u",
-				  cdata->chanv[j].channel,
-				  cdata->chanv[j].value);
+			comp_dbg(dev, "volume_get_config(), channel = %u, value = %u",
+				 cdata->chanv[j].channel,
+				 cdata->chanv[j].value);
 		}
 		break;
 	default:

--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -104,7 +104,7 @@ static int mux_set_values(struct comp_dev *dev, struct comp_data *cd,
 	unsigned int i;
 	unsigned int j;
 
-	comp_info(dev, "mux_set_values()");
+	comp_dbg(dev, "mux_set_values()");
 
 	/* check if number of streams configured doesn't exceed maximum */
 	if (cfg->num_streams > MUX_MAX_STREAMS) {
@@ -245,7 +245,7 @@ static struct comp_dev *mux_new(const struct comp_driver *drv,
 	struct comp_data *cd;
 	int ret;
 
-	comp_cl_info(&comp_mux, "mux_new()");
+	comp_cl_dbg(&comp_mux, "mux_new()");
 
 	dev = comp_alloc(drv, sizeof(*dev));
 	if (!dev)
@@ -404,7 +404,7 @@ static void mux_free(struct comp_dev *dev)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 
-	comp_info(dev, "mux_free()");
+	comp_dbg(dev, "mux_free()");
 
 	rfree(cd);
 	rfree(dev);
@@ -445,7 +445,7 @@ static int mux_params(struct comp_dev *dev,
 {
 	int ret;
 
-	comp_info(dev, "mux_params()");
+	comp_dbg(dev, "mux_params()");
 #if CONFIG_IPC_MAJOR_4
 	set_mux_params(dev, params);
 #endif
@@ -463,8 +463,8 @@ static int mux_ctrl_set_cmd(struct comp_dev *dev,
 	struct sof_mux_config *cfg;
 	int ret = 0;
 
-	comp_info(dev, "mux_ctrl_set_cmd(), cdata->cmd = 0x%08x",
-		  cdata->cmd);
+	comp_dbg(dev, "mux_ctrl_set_cmd(), cdata->cmd = 0x%08x",
+		 cdata->cmd);
 
 	switch (cdata->cmd) {
 	case SOF_CTRL_CMD_BINARY:
@@ -525,7 +525,7 @@ static int mux_cmd(struct comp_dev *dev, int cmd, void *data,
 {
 	struct sof_ipc_ctrl_data *cdata = ASSUME_ALIGNED(data, 4);
 
-	comp_info(dev, "mux_cmd() cmd = 0x%08x", cmd);
+	comp_dbg(dev, "mux_cmd() cmd = 0x%08x", cmd);
 
 	switch (cmd) {
 	case COMP_CMD_SET_DATA:
@@ -807,7 +807,7 @@ static int mux_reset(struct comp_dev *dev)
 	struct list_item *blist;
 	struct comp_data *cd = comp_get_drvdata(dev);
 
-	comp_info(dev, "mux_reset()");
+	comp_dbg(dev, "mux_reset()");
 
 	if (dir == SOF_IPC_STREAM_PLAYBACK) {
 		list_for_item(blist, &dev->bsource_list) {
@@ -840,7 +840,7 @@ static int mux_prepare(struct comp_dev *dev)
 	struct list_item *blist;
 	int ret;
 
-	comp_info(dev, "mux_prepare()");
+	comp_dbg(dev, "mux_prepare()");
 
 	if (dev->state != COMP_STATE_ACTIVE) {
 		if (dev->ipc_config.type == SOF_COMP_MUX)
@@ -903,7 +903,7 @@ static int mux_trigger(struct comp_dev *dev, int cmd)
 	unsigned int src_n_active, src_n_paused;
 	int ret;
 
-	comp_info(dev, "mux_trigger(), command = %u", cmd);
+	comp_dbg(dev, "mux_trigger(), command = %u", cmd);
 
 	/*
 	 * We are in a TRIGGER IPC. IPCs are serialised, while we're processing

--- a/src/audio/pipeline/pipeline-graph.c
+++ b/src/audio/pipeline/pipeline-graph.c
@@ -218,9 +218,9 @@ void pipeline_disconnect(struct comp_dev *comp, struct comp_buffer *buffer, int 
 	uint32_t flags;
 
 	if (dir == PPL_CONN_DIR_COMP_TO_BUFFER)
-		comp_info(comp, "disconnect buffer %d as sink", buffer->id);
+		comp_dbg(comp, "disconnect buffer %d as sink", buffer->id);
 	else
-		comp_info(comp, "disconnect buffer %d as source", buffer->id);
+		comp_dbg(comp, "disconnect buffer %d as source", buffer->id);
 
 	irq_local_disable(flags);
 	buf_list = buffer_comp_list(buffer, dir);
@@ -247,7 +247,7 @@ void pipeline_disconnect(struct comp_dev *comp, struct comp_buffer *buffer, int 
 /* pipelines must be inactive */
 int pipeline_free(struct pipeline *p)
 {
-	pipe_info(p, "pipeline_free()");
+	pipe_dbg(p, "pipeline_free()");
 
 	/*
 	 * pipeline_free should always be called only after all the widgets in the pipeline have
@@ -311,7 +311,7 @@ int pipeline_complete(struct pipeline *p, struct comp_dev *source,
 #endif
 	int ret;
 
-	pipe_info(p, "pipeline complete, clock freq %dHz", freq);
+	pipe_dbg(p, "pipeline complete, clock freq %dHz", freq);
 
 	/* check whether pipeline is already completed */
 	if (p->status != COMP_STATE_INIT) {
@@ -398,7 +398,7 @@ int pipeline_reset(struct pipeline *p, struct comp_dev *host)
 	};
 	int ret;
 
-	pipe_info(p, "pipe reset");
+	pipe_dbg(p, "pipe reset");
 
 	ret = walk_ctx.comp_func(host, NULL, &walk_ctx, host->direction);
 	if (ret < 0) {

--- a/src/audio/pipeline/pipeline-params.c
+++ b/src/audio/pipeline/pipeline-params.c
@@ -340,7 +340,7 @@ int pipeline_prepare(struct pipeline *p, struct comp_dev *dev)
 	};
 	int ret;
 
-	pipe_info(p, "pipe prepare");
+	pipe_dbg(p, "pipe prepare");
 
 	ppl_data.start = dev;
 

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -176,7 +176,7 @@ static struct comp_dev *selector_new(const struct comp_driver *drv,
 	struct comp_data *cd;
 	int ret;
 
-	comp_cl_info(&comp_selector, "selector_new()");
+	comp_cl_dbg(&comp_selector, "selector_new()");
 
 	dev = comp_alloc(drv, sizeof(*dev));
 	if (!dev)
@@ -206,7 +206,7 @@ static void selector_free(struct comp_dev *dev)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 
-	comp_info(dev, "selector_free()");
+	comp_dbg(dev, "selector_free()");
 
 	rfree(cd);
 	rfree(dev);
@@ -224,7 +224,7 @@ static int selector_params(struct comp_dev *dev,
 {
 	int err;
 
-	comp_info(dev, "selector_params()");
+	comp_dbg(dev, "selector_params()");
 
 	err = selector_verify_params(dev, params);
 	if (err < 0) {
@@ -250,7 +250,7 @@ static int selector_ctrl_set_data(struct comp_dev *dev,
 
 	switch (cdata->cmd) {
 	case SOF_CTRL_CMD_BINARY:
-		comp_info(dev, "selector_ctrl_set_data(), SOF_CTRL_CMD_BINARY");
+		comp_dbg(dev, "selector_ctrl_set_data(), SOF_CTRL_CMD_BINARY");
 
 		cfg = (struct sof_sel_config *)
 		      ASSUME_ALIGNED(&cdata->data->data, 4);
@@ -286,7 +286,7 @@ static int selector_ctrl_get_data(struct comp_dev *dev,
 
 	switch (cdata->cmd) {
 	case SOF_CTRL_CMD_BINARY:
-		comp_info(dev, "selector_ctrl_get_data(), SOF_CTRL_CMD_BINARY");
+		comp_dbg(dev, "selector_ctrl_get_data(), SOF_CTRL_CMD_BINARY");
 
 		/* Copy back to user space */
 		ret = memcpy_s(cdata->data->data, ((struct sof_abi_hdr *)
@@ -321,7 +321,7 @@ static int selector_cmd(struct comp_dev *dev, int cmd, void *data,
 	struct sof_ipc_ctrl_data *cdata = ASSUME_ALIGNED(data, 4);
 	int ret = 0;
 
-	comp_info(dev, "selector_cmd()");
+	comp_dbg(dev, "selector_cmd()");
 
 	switch (cmd) {
 	case COMP_CMD_SET_DATA:
@@ -331,10 +331,10 @@ static int selector_cmd(struct comp_dev *dev, int cmd, void *data,
 		ret = selector_ctrl_get_data(dev, cdata, max_data_size);
 		break;
 	case COMP_CMD_SET_VALUE:
-		comp_info(dev, "selector_cmd(), COMP_CMD_SET_VALUE");
+		comp_dbg(dev, "selector_cmd(), COMP_CMD_SET_VALUE");
 		break;
 	case COMP_CMD_GET_VALUE:
-		comp_info(dev, "selector_cmd(), COMP_CMD_GET_VALUE");
+		comp_dbg(dev, "selector_cmd(), COMP_CMD_GET_VALUE");
 		break;
 	default:
 		comp_err(dev, "selector_cmd(): invalid command");
@@ -357,7 +357,7 @@ static int selector_trigger(struct comp_dev *dev, int cmd)
 	enum sof_comp_type type;
 	int ret;
 
-	comp_info(dev, "selector_trigger()");
+	comp_dbg(dev, "selector_trigger()");
 
 	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer,
 				  sink_list);
@@ -443,7 +443,7 @@ static int selector_prepare(struct comp_dev *dev)
 	size_t sink_size;
 	int ret;
 
-	comp_info(dev, "selector_prepare()");
+	comp_dbg(dev, "selector_prepare()");
 
 	ret = comp_set_state(dev, COMP_TRIGGER_PREPARE);
 	if (ret < 0)
@@ -473,10 +473,10 @@ static int selector_prepare(struct comp_dev *dev)
 	 * proper number of channels [1] for selector to actually
 	 * reduce channel count between source and sink
 	 */
-	comp_info(dev, "selector_prepare(): sourceb->schannels = %u",
-		  source_c->stream.channels);
-	comp_info(dev, "selector_prepare(): sinkb->channels = %u",
-		  sink_c->stream.channels);
+	comp_dbg(dev, "selector_prepare(): sourceb->schannels = %u",
+		 source_c->stream.channels);
+	comp_dbg(dev, "selector_prepare(): sinkb->channels = %u",
+		 sink_c->stream.channels);
 
 	sink_size = sink_c->stream.size;
 
@@ -531,7 +531,7 @@ static int selector_reset(struct comp_dev *dev)
 	int ret;
 	struct comp_data *cd = comp_get_drvdata(dev);
 
-	comp_info(dev, "selector_reset()");
+	comp_dbg(dev, "selector_reset()");
 
 	cd->source_period_bytes = 0;
 	cd->sink_period_bytes = 0;
@@ -773,7 +773,7 @@ static int selector_params(struct processing_module *mod)
 	struct sof_ipc_stream_params *params = mod->stream_params;
 	int err;
 
-	comp_info(mod->dev, "selector_params()");
+	comp_dbg(mod->dev, "selector_params()");
 
 	set_selector_params(mod, params);
 
@@ -851,7 +851,7 @@ static int selector_prepare(struct processing_module *mod)
 	size_t sink_size;
 	int ret;
 
-	comp_info(dev, "selector_prepare()");
+	comp_dbg(dev, "selector_prepare()");
 
 	ret = selector_params(mod);
 	if (ret < 0)
@@ -882,10 +882,8 @@ static int selector_prepare(struct processing_module *mod)
 	 * proper number of channels [1] for selector to actually
 	 * reduce channel count between source and sink
 	 */
-	comp_info(dev, "selector_prepare(): sourceb->schannels = %u",
-		  source_c->stream.channels);
-	comp_info(dev, "selector_prepare(): sinkb->channels = %u",
-		  sink_c->stream.channels);
+	comp_info(dev, "selector_prepare(): source sink channel = %u %u",
+		  source_c->stream.channels, sink_c->stream.channels);
 
 	sink_size = sink_c->stream.size;
 
@@ -939,7 +937,7 @@ static int selector_reset(struct processing_module *mod)
 {
 	struct comp_data *cd = module_get_private_data(mod);
 
-	comp_info(mod->dev, "selector_reset()");
+	comp_dbg(mod->dev, "selector_reset()");
 
 	cd->source_period_bytes = 0;
 	cd->sink_period_bytes = 0;

--- a/src/idc/idc.c
+++ b/src/idc/idc.c
@@ -353,7 +353,7 @@ int idc_init(void)
 	*idc = rzalloc(SOF_MEM_ZONE_SYS, 0, SOF_MEM_CAPS_RAM, sizeof(**idc));
 #endif
 
-	tr_info(&idc_tr, "idc_init()");
+	tr_dbg(&idc_tr, "idc_init()");
 
 	/* initialize idc data */
 	(*idc)->payload = platform_shared_get(static_payload, sizeof(static_payload));

--- a/src/ipc/ipc-common.c
+++ b/src/ipc/ipc-common.c
@@ -242,7 +242,7 @@ void ipc_schedule_process(struct ipc *ipc)
 
 int ipc_init(struct sof *sof)
 {
-	tr_info(&ipc_tr, "ipc_init()");
+	tr_dbg(&ipc_tr, "ipc_init()");
 
 	/* init ipc data */
 	sof->ipc = rzalloc(SOF_MEM_ZONE_SYS_SHARED, 0, SOF_MEM_CAPS_RAM, sizeof(*sof->ipc));

--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -77,8 +77,8 @@ int ipc_dai_data_config(struct comp_dev *dev)
 		return -EINVAL;
 	}
 
-	comp_info(dev, "dai_data_config() dai type = %d index = %d dd %p",
-		  dai->type, dai->dai_index, dd);
+	comp_dbg(dev, "dai_data_config() dai type = %d index = %d dd %p",
+		 dai->type, dai->dai_index, dd);
 
 	/* cannot configure DAI while active */
 	if (dev->state == COMP_STATE_ACTIVE) {
@@ -96,7 +96,7 @@ int ipc_dai_data_config(struct comp_dev *dev)
 	case SOF_DAI_INTEL_DMIC:
 		/* Depth is passed by DMIC driver that retrieves it from blob */
 		dd->config.burst_elems = dai_get_fifo_depth(dd->dai, dai->direction);
-		comp_info(dev, "dai_data_config() burst_elems = %d", dd->config.burst_elems);
+		comp_dbg(dev, "dai_data_config() burst_elems = %d", dd->config.burst_elems);
 		break;
 	case SOF_DAI_INTEL_HDA:
 		break;


### PR DESCRIPTION
Change some log level from info to dbg, those changed place are not reporting errors, just information, so no risk and can be change back when debugging.

From performance perspective, before and after:
Before: [11.86] ll_schedule: ll timer avg 2329, max 2887, overruns 0
After:   [11.52] ll_schedule: ll timer avg 2226, max 2789, overruns 0

Signed-off-by: Baofeng Tian <baofeng.tian@intel.com>