### PR TITLE
buffer: NULL pointer protection

### DIFF
--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -677,6 +677,12 @@ int module_adapter_copy(struct comp_dev *dev)
 	}
 
 	if (mod->simple_copy) {
+		if (!source_c) {
+			ret = -ENODATA;
+			comp_err(dev, "comp_update_buffer_consume() %x: NULL dereference error",
+				 ret);
+			goto out;
+		}
 		comp_update_buffer_consume(source_c, mod->input_buffers[0].consumed);
 		buffer_release(sink_c);
 		buffer_release(source_c);


### PR DESCRIPTION
Static analysis discover scenario in which comp_update might point to NULL in certain situations. Additional condition preventing it is added.

Signed-off-by: Dobrowolski, PawelX <pawelx.dobrowolski@intel.com>