### PR TITLE
Buffer-attach

### DIFF
--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -311,7 +311,7 @@ int module_adapter_prepare(struct comp_dev *dev)
 				goto free;
 			}
 
-			list_item_append(&buffer->sink_list, &mod->sink_buffer_list);
+			buffer_attach(buffer, &mod->sink_buffer_list, PPL_DIR_UPSTREAM);
 
 			buffer_c = buffer_acquire(buffer);
 			buffer_set_params(buffer_c, mod->stream_params, BUFFER_UPDATE_FORCE);
@@ -347,7 +347,7 @@ free:
 		struct comp_buffer *buffer = container_of(blist, struct comp_buffer,
 							  sink_list);
 
-		list_item_del(&buffer->sink_list);
+		buffer_detach(buffer, &mod->sink_buffer_list, PPL_DIR_UPSTREAM);
 		buffer_free(buffer);
 	}
 out_free:
@@ -911,7 +911,7 @@ void module_adapter_free(struct comp_dev *dev)
 		struct comp_buffer *buffer = container_of(blist, struct comp_buffer,
 							  sink_list);
 
-		list_item_del(&buffer->sink_list);
+		buffer_detach(buffer, &mod->sink_buffer_list, PPL_DIR_UPSTREAM);
 		buffer_free(buffer);
 	}
 

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -238,6 +238,22 @@ static inline void buffer_release(struct comp_buffer __sparse_cache *buffer)
 	coherent_release_thread(&buffer->c, sizeof(*buffer));
 }
 
+/*
+ * Attach a new buffer at the beginning of the list. Note, that "head" must
+ * really be the head of the list, not a list head within another buffer. We
+ * don't synchronise its cache, so it must not be embedded in an object, using
+ * the coherent API. The caller takes care to protect list heads.
+ */
+void buffer_attach(struct comp_buffer *buffer, struct list_item *head, int dir);
+
+/*
+ * Detach a buffer from anywhere in the list. "head" is again the head of the
+ * list, we need it to verify, whether this buffer was the first or the last on
+ * the list. Again it is assumed that the head's cache doesn't need to be
+ * synchronized. The caller takes care to protect list heads.
+ */
+void buffer_detach(struct comp_buffer *buffer, struct list_item *head, int dir);
+
 static inline struct comp_dev *buffer_get_comp(struct comp_buffer *buffer, int dir)
 {
 	struct comp_buffer __sparse_cache *buffer_c = buffer_acquire(buffer);


### PR DESCRIPTION
A followup to #6730 - moving cache synchronisation when attaching and detaching buffers in separate functions