### PR TITLE
west.yml: upgrade Zephyr to c5b270e7b003

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 56284d7017dc593f18c3aaa128d2c4e596a8e4c8
+      revision: c5b270e7b0033f20e594fd18f2ac0ea26a16f687
       remote: zephyrproject
       # Import some projects listed in zephyr/west.yml@revision
       #


### PR DESCRIPTION
Total of 440 commits, including following related to intel_adsp/sparse/dmic/xtensa:

603cc2704579 dma: Add max block count attribute
2c162449eb4c xtensa: linker: Fix #52539 by updating the linker scripts 2dd4cbc75592 dts: xtensa: intel: update cavs25_tgph to match cavs25

Link: https://github.com/thesofproject/sof/issues/6710
Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>