### PR TITLE
zephyr/docker-build.sh: upgrade CMake to 3.21 or above

### DIFF
--- a/scripts/sudo-cwd.sh
+++ b/scripts/sudo-cwd.sh
@@ -63,7 +63,12 @@ exec_as_cwd_uid()
     # Double sudo to work around some funny restriction in
     # zephyr-build:/etc/sudoers: 'user' can do anything but... only as
     # root.
-    sudo sudo -u "$cwd_user" REAL_CC="$REAL_CC" "$@"
+    # Passing empty http[s]_proxy is OK
+    # shellcheck disable=SC2154
+    sudo sudo -u "$cwd_user" REAL_CC="$REAL_CC" \
+         http_proxy="$http_proxy"  https_proxy="$https_proxy" \
+         "$@"
+
     exit "$?"
 }
 

--- a/zephyr/docker-build.sh
+++ b/zephyr/docker-build.sh
@@ -36,6 +36,12 @@ unset ZEPHYR_SDK_INSTALL_DIR
 ls -ld /opt/toolchains/zephyr-sdk-*
 ln -s  /opt/toolchains/zephyr-sdk-*  ~/ || true
 
+# CMake v3.21 changed the order object files are passed to the linker.
+# This makes builds before that version not reproducible.
+# To save time don't install if recent enough.
+pip install 'cmake>=3.21'
+PATH="$HOME"/.local/bin:"$PATH"
+
 if test -e .west || test -e zephyr; then
     init_update=''
 else

--- a/zephyr/docker-run.sh
+++ b/zephyr/docker-run.sh
@@ -57,7 +57,7 @@ run_command()
     docker run -i -v "$(west topdir)":/zep_workspace \
            --workdir /zep_workspace \
            $SOF_DOCKER_RUN \
-           --env REAL_CC \
+           --env REAL_CC --env http_proxy --env https_proxy \
            ghcr.io/zephyrproject-rtos/zephyr-build:latest \
            ./sof/scripts/sudo-cwd.sh "$@"
 }


### PR DESCRIPTION
CMake 3.21 changed the order object files are passed the linker. This
breaks build reproducibility.