### PR TITLE
xtensa-build-zephyr.py: checksum deterministic configs.c

### DIFF
--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -728,6 +728,7 @@ def install_platform(platform, sof_platform_output_dir):
 	installed_files = [
 		# Fail if one of these is missing
 		InstFile(".config", "config"),
+		InstFile("misc/generated/configs.c", "generated_configs.c"),
 		InstFile(BIN_NAME + ".elf"),
 		InstFile(BIN_NAME + ".lst"),
 		InstFile(BIN_NAME + ".map"),
@@ -757,6 +758,7 @@ BIN_NAME = 'zephyr'
 
 CHECKSUM_WANTED = [
 	'*.ri',     # Some .ri files have a non-deterministic signature, others not
+	'*configs.c', # deterministic unlike .config
 	'*.strip', '*stripped*', # stripped ELF files are reproducible
 	'boot.mod', # no debug section -> no need to strip this ELF
 	BIN_NAME + '.lst',       # objdump --disassemble

--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -719,8 +719,8 @@ def install_platform(platform, sof_platform_output_dir):
 	@dataclass
 	class InstFile:
 		'How to install one file'
-		name: str
-		renameTo: str = None
+		name: pathlib.Path
+		renameTo: pathlib.Path = None
 		# TODO: upgrade this to 3 states: optional/warning/error
 		optional: bool = False
 		gzip: bool = True


### PR DESCRIPTION
xtensa-build-zephyr.py: checksum deterministic configs.c

.config is not deterministic because it has absolute paths in comments
and its order seems hard to predict. configs.c has the same information
generated in a determistic way.