### PR TITLE
Tools: Topology1: Add to development topologies DRC for UP2 board

### DIFF
--- a/tools/topology/topology1/development/CMakeLists.txt
+++ b/tools/topology/topology1/development/CMakeLists.txt
@@ -11,6 +11,8 @@ set(TPLGS
 	"sof-apl-dmic\;sof-apl-dmic-2ch\;-DCHANNELS=2\;-DCPROC=volume"
 	"sof-apl-dmic\;sof-apl-dmic-4ch\;-DCHANNELS=4\;-DCPROC=volume"
 	"sof-apl-pcm512x-nohdmi\;sof-apl-pcm512x-nohdmi\;-DPPROC=volume"
+	"sof-apl-pcm512x-nohdmi\;sof-apl-pcm512x-drc\;-DPPROC=drc"
+	"sof-apl-pcm512x-nohdmi\;sof-apl-pcm512x-mdrc\;-DPPROC=multiband-drc"
 	"sof-apl-src-50khz-pcm512x\;sof-apl-src-50khz-pcm512x"
 	"sof-cnl-rt5682-sdw2\;sof-cnl-rt5682-sdw2\;-DPLATFORM=cnl"
 	"sof-cml-src-rt5682\;sof-cml-src-rt5682"


### PR DESCRIPTION
This patch adds to development topologies build of minimal topologies sof-apl-pcm512x-drc.tplg and sof-apl-pcm512x-mdrc.tplg for testing.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>