### PR TITLE
[SKIP CI] .github/workflows: add tgl-h IPC4 build

### DIFF
--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -21,8 +21,8 @@ jobs:
           imx8 imx8x imx8m,
           # - IPC4 default
           mtl,
-          # Very few IPC3 platforms support IPC4 too.
-          -i IPC4 tgl,
+          # Some IPC3 platforms support IPC4 too.
+          -i IPC4 tgl, -i IPC4 tgl-h,
         ]
         zephyr_revision: [
           manifest_revision,


### PR DESCRIPTION
Add build check for Intel 'tgl-h' IPC4 build.

Link: https://github.com/thesofproject/sof/issues/6710
Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>