### PR TITLE
platform: mt8188: Fix build error

### DIFF
--- a/src/platform/mt8188/include/platform/lib/mailbox.h
+++ b/src/platform/mt8188/include/platform/lib/mailbox.h
@@ -63,6 +63,14 @@
 void trigger_irq_to_host_req(void);
 void trigger_irq_to_host_rsp(void);
 
+static inline void mailbox_sw_reg_write(size_t offset, uint32_t src)
+{
+	volatile uint32_t *ptr;
+
+	ptr = (volatile uint32_t *)(MAILBOX_DEBUG_BASE + offset);
+	*ptr = src;
+}
+
 #endif /* __PLATFORM_LIB_MAILBOX_H__ */
 
 #else


### PR DESCRIPTION
Add back the mailbox_sw_reg_write inline function
to fix build error of mt8188.

sof/src/platform/mt8188/include/platform/platform.h: In function ‘platform_panic’: sof/src/platform/mt8188/include/platform/platform.h:69: warning: implicit declaration of function ‘mailbox_sw_reg_write’

Signed-off-by: Tinghan Shen <tinghan.shen@mediatek.com>

--

I'm so sorry for introduce this build fail when update the mt8188 PR (https://github.com/thesofproject/sof/pull/6796).