### PR TITLE
selector: remove return error when input buffer is 0

### DIFF
--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -827,11 +827,9 @@ static int selector_process(struct processing_module *mod,
 
 	comp_dbg(mod->dev, "selector_process()");
 
-	if (!avail_frames)
-		return PPL_STATUS_PATH_STOP;
-
-	/* copy selected channels from in to out */
-	cd->sel_func(mod, input_buffers, output_buffers, avail_frames);
+	if (avail_frames)
+		/* copy selected channels from in to out */
+		cd->sel_func(mod, input_buffers, output_buffers, avail_frames);
 
 	return 0;
 }


### PR DESCRIPTION
A pipeline that contains a selector cannot be run before the pipeline that is connected to the selector because an error is returned. The order of the run pipelines should not matter for functionality.