### PR TITLE
ipc4: copier: Add support for ALH multi-gateways

### DIFF
--- a/src/include/ipc4/alh.h
+++ b/src/include/ipc4/alh.h
@@ -36,6 +36,14 @@
 #define IPC4_ALH_DAI_INDEX(x) ((((x) & 0xF0) << DAI_NUM_ALH_BI_DIR_LINKS_GROUP) + \
 				(((x) & 0xF) - IPC4_ALH_DAI_INDEX_OFFSET))
 
+/* Multi-gateways addressing starts from IPC4_ALH_MULTI_GTW_BASE */
+#define IPC4_ALH_MULTI_GTW_BASE 0x50
+
+static inline bool is_multi_gateway(const union ipc4_connector_node_id node_id)
+{
+	return node_id.f.v_index >= IPC4_ALH_MULTI_GTW_BASE;
+}
+
 struct ipc4_alh_multi_gtw_cfg {
 	/* Number of single channels (valid items in mapping array). */
 	uint32_t count;

--- a/src/include/ipc4/copier.h
+++ b/src/include/ipc4/copier.h
@@ -320,11 +320,21 @@ struct ipc4_data_segment_enabled {
 	uint32_t data_seg_size;
 } __attribute__((packed, aligned(4)));
 
+/* One of copy_single_channel_cXX() to mux/demux channels into/from copier multi_endpoint_buffer */
+typedef void (* channel_copy_func)(struct audio_stream __sparse_cache *dst,
+				   int dst_channel,
+				   const struct audio_stream __sparse_cache *src,
+				   int src_channel, int frame_count);
+
 struct copier_data {
 	struct ipc4_copier_module_cfg config;
 	struct comp_dev *endpoint[IPC4_COPIER_MODULE_OUTPUT_PINS_COUNT];
 	struct comp_buffer *endpoint_buffer[IPC4_COPIER_MODULE_OUTPUT_PINS_COUNT];
 	uint32_t endpoint_num;
+
+	/* buffer to mux/demux data from/to multiple endpoint buffers for ALH multi-gateway case */
+	struct comp_buffer *multi_endpoint_buffer;
+	channel_copy_func copy_single_channel;
 
 	bool bsource_buffer;
 


### PR DESCRIPTION
Adds ALH multi-gateway feature: functionality to mux/demux data from/into multiple gateways.

Signed-off-by: Serhiy Katsyuba <serhiy.katsyuba@intel.com>