### PR TITLE
[SKIP CI] .github/pull-request.yml: upgrade checkout v2 -> v3

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: apt get doxygen graphviz
         run: sudo apt-get -y install ninja-build doxygen graphviz
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-20.04  # sof-docs is still stuck to this for now
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: apt-get update
         run: sudo apt-get update
@@ -169,7 +169,7 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with: {fetch-depth: 0, submodules: recursive}
 
       - name: turn off HAVE_AGENT


### PR DESCRIPTION
This upgrade was already performed for other jobs in commit f71eb15818fd (".github/workflows: upgrade actions/checkout@v2 -> v3") and everything went fine. Finish the job and get rid of the last warnings in the daily tests (example:
https://github.com/thesofproject/sof/actions/runs/3709176785)

Signed-off-by: Marc Herbert <marc.herbert@intel.com>