### PR TITLE
Happy new year SOF - Windows CI is coming to town!

### DIFF
--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -77,6 +77,14 @@ jobs:
              ./sof/zephyr/docker-build.sh --cmake-args=-DEXTRA_CFLAGS=-Werror
              --cmake-args=--warn-uninitialized ${{ matrix.IPC_platforms }}
 
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: linux-build-output
+          path: |
+            ${{ github.workspace }}/workspace/build-sof-staging
+            ${{ github.workspace }}/workspace/**/compile_commands.json
+
   build-windows:
     runs-on: windows-latest
     strategy:
@@ -206,3 +214,11 @@ jobs:
           --no-interactive
           --cmake-args=-DEXTRA_CFLAGS=-Werror
           --cmake-args=--warn-uninitialized ${{ matrix.platforms }}
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: windows-build-output
+          path: |
+            ${{ github.workspace }}/workspace/build-sof-staging
+            ${{ github.workspace }}/workspace/**/compile_commands.json

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -10,7 +10,6 @@ on: [push, pull_request, workflow_dispatch, workflow_call]
 jobs:
   build:
     runs-on: ubuntu-20.04
-
     strategy:
       fail-fast: false
       matrix:
@@ -70,3 +69,133 @@ jobs:
         run: cd workspace && ./sof/zephyr/docker-run.sh
              ./sof/zephyr/docker-build.sh --cmake-args=-DEXTRA_CFLAGS=-Werror
              --cmake-args=--warn-uninitialized ${{ matrix.IPC_platforms }}
+
+  build-windows:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      # FIXME: Create common matrix for build-linux and build-windows
+      matrix:
+        # Using groups to avoid spamming the small results box with too
+        # many lines. Pay attention to COMMAS.
+        platforms: [
+          # - IPC3 default
+          imx8 imx8x imx8m,
+          tgl tgl-h,  # UNSUPPORTED! Will be removed
+          # - IPC4 default
+          mtl,
+          # Very few IPC3 platforms support IPC4 too.
+          -i IPC4 tgl tgl-h,
+        ]
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          path: ./workspace/sof
+
+      # Cache artifacts so we do not overload external servers with downloads
+      # Remember to change step key if you change the tools so old cache is not restored,
+      # or delete cache manually in Github Actions tab
+      - name: Cache unzip
+        id: cache-unzip
+        uses: actions/cache@v3.0.11
+        with:
+          path: unzip-5.51-1-bin.zip
+          key: ${{ runner.os }}-cache-unzip-5-51-1
+
+      - name: Cache wget
+        id: cache-wget
+        uses: actions/cache@v3.0.11
+        with:
+          path: wget-1.11.4-1-bin.zip
+          key: ${{ runner.os }}-cache-wget-1-11-4-1
+
+      - name: Cache Zephyr SDK
+        id: cache-zephyr-sdk
+        uses: actions/cache@v3.0.11
+        with:
+          path: zephyr-sdk-0.15.2_windows-x86_64.zip
+          key: ${{ runner.os }}-cache-zephyr-sdk-0-15-2
+
+      # Unzip is needed by Zephyr SDK setup.cmd installation script
+      - name: Download unzip
+        if: ${{ steps.cache-unzip.outputs.cache-hit != 'true' }}
+        run: |
+          curl -L -o unzip-5.51-1-bin.zip `
+          https://gnuwin32.sourceforge.net/downlinks/unzip-bin-zip.php
+
+      # Wget is needed by Zephyr SDK setup.cmd installation script
+      - name: Download wget
+        if: ${{ steps.cache-wget.outputs.cache-hit != 'true' }}
+        run: |
+          curl -L -O http://downloads.sourceforge.net/gnuwin32/wget-1.11.4-1-bin.zip
+
+      - name: Download Zephyr SDK
+        if: ${{ steps.cache-zephyr-sdk.outputs.cache-hit != 'true' }}
+        run: |  # yamllint disable-line rule:line-length
+          curl -L -O `
+          https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.2/zephyr-sdk-0.15.2_windows-x86_64.zip
+
+      # Unzips every .zip package to directory matching its name without extension
+      - name: Unzip downloaded packages
+        run: 7z x *.zip -o*
+
+      - name: Add unzip to system PATH
+        run: |
+          echo "${{ github.workspace }}/unzip-5.51-1-bin/bin" | `
+          Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Add wget to system PATH
+        run: |
+          echo "${{ github.workspace }}/wget-1.11.4-1-bin/bin" | `
+          Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      # Install Zephyr SDK - all toolchains including Host Tools
+      # and registering CMake package in the registry
+      # setup.cmd may not be called in from msys shell as it does not parse
+      # forward slash script input arguments correctly.
+      - name: Install Zephyr SDK
+        run: zephyr-sdk-0.15.2_windows-x86_64/zephyr-sdk-0.15.2/setup.cmd /t all /h /c
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.8'
+
+      - name: West install
+        run: pip3 install west
+
+      - name: West clone
+        working-directory: ${{ github.workspace }}/workspace
+        run: west init -l sof && west update
+
+      # Call Setup Python again to save the PIP packages in cache
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        id: cache-python
+        with:
+          python-version: '3.8'
+          cache: 'pip'
+          cache-dependency-path: workspace/zephyr/scripts/requirements.txt
+
+      # All requirements will be satisfied if the restored cache matches existing state
+      - name: Validate python PIP cache
+        working-directory: ${{ github.workspace }}/workspace
+        run: pip install -r zephyr/scripts/requirements.txt
+
+      # MSYS2 provides gcc x64_86 toolchain & openssl
+      - name: Initialize MSYS2
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MSYS
+          install: gcc openssl-devel
+          path-type: inherit
+
+      - name: Build
+        shell: msys2 {0}
+        working-directory: ${{ github.workspace }}/workspace
+        run: python sof/scripts/xtensa-build-zephyr.py
+          --no-interactive
+          --cmake-args=-DEXTRA_CFLAGS=-Werror
+          --cmake-args=--warn-uninitialized ${{ matrix.platforms }}

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -8,7 +8,7 @@ name: Zephyr
 on: [push, pull_request, workflow_dispatch, workflow_call]
 
 jobs:
-  build:
+  build-linux:
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -7,6 +7,13 @@ name: Zephyr
 # yamllint disable-line rule:truthy
 on: [push, pull_request, workflow_dispatch, workflow_call]
 
+# Specifies group name that stops previous wokrflows if the name matches
+concurrency:
+  # eg. "Zephyr-pull_request-my_fork_branch_to_merge"
+  # eg. "Zephyr-push-refs/heads/my_branch_merging"
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-linux:
     runs-on: ubuntu-20.04

--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -39,7 +39,7 @@ import gzip
 from dataclasses import dataclass
 
 # anytree module is defined in Zephyr build requirements
-from anytree import AnyNode, RenderTree
+from anytree import AnyNode, RenderTree, render
 from packaging import version
 
 # https://chrisyeh96.github.io/2017/08/08/definitive-guide-python-imports.html#case-3-importing-from-parent-directory
@@ -316,7 +316,7 @@ def show_installed_files():
 		assert len(matches) == 1, f'"{entry}" does not have exactly one parent'
 		nodes.append(AnyNode(name=entry.name, long_name=str(entry), parent=matches[0]))
 
-	for pre, _, node in RenderTree(graph_root):
+	for pre, _, node in RenderTree(graph_root, render.AsciiStyle):
 		fpath = STAGING_DIR / node.long_name
 		stem = node.name[:-3] if node.name.endswith(".gz") else node.name
 


### PR DESCRIPTION
### Adding Windows CI for Zephyr platforms by adding new "build-windows" job.

**Content**

Five commits:

1. Changed anytree.RenderTree style to ASCII style in the `xtensa-build-zephyr.py`. Github action console was failing to print fancy lines used in the previous style.
2. Added build-windows job to existing Zephyr workflow.
This builds SOF with Zephyr on Windows using Zephyr SDK and MSYS2.
"Manual environment setup" is done when comparing to linux build step (that uses Zephyr Docker container with ready-to-go environment). Windows build uses Github cache system to speed up the job and avoid excessive downloads from external servers.

3. Renamed Zephyr "build" job to "build-linux" job.

4. Added concurrency group to Zephyr workflow so the previous actions are stopped when new push to "similar context" is done. Eg. pushing fast to pull request will now stop previous uncompleted actions from running and start a new one with newest push. Same rule applies to triggering workflow manually with workflow_dispatch and daily tests.

5. Added build artifacts upload. Github allows to store build artifacts from jobs for 90 days.
This may be useful to:
  -examine compile commands by downloading compile_commands.json file
  -downloading fw .ri file to run it on the simulator
  -downloading for future Zephyr unit tests

**Some context and implementation decisions**
* [Zephyr SDK](https://github.com/zephyrproject-rtos/sdk-ng/releases/tag/v0.15.2) is downloaded once from Zephyr website then from [Github cache](https://docs.github.com/en/rest/actions/cache?apiVersion=2022-11-28) (10GB total per project as of day of writing).
* [Wget](https://gnuwin32.sourceforge.net/packages/wget.htm) and [unzip](https://gnuwin32.sourceforge.net/packages/unzip.htm) tools are not present on Windows by default. Downloading from
gnuwin32.sourceforge.net once, then from [Github cache](https://docs.github.com/en/rest/actions/cache?apiVersion=2022-11-28).
* Q: "Why not using wget and unzip from MSYS2 which is used anyway?
A: MSYS2 packages may not be cached in Github and we would re-download them every time.
* Q: "GCC and OpenSSL is provided by MSYS2. You just wrote that MSYS2 may not be cached. Why not just download windows binaries and cache them?"
A: GCC downloaded from other packages like chocolatey is still missing some linux specific system headers and compilation fails (rimage and sof-logger). OpenSSL used by rimage is currently taken from MSYS2 installation in rimage CMake files.
We had tried before to use OpenSSL binaries for Windows with rimage but there are implementation differences and it would require fixing up the code.

Signed-off-by: Andrey Borisovich <andrey.borisovich@intel.com>