### PR TITLE
platform: ace: dma: update buffer period count

### DIFF
--- a/src/platform/intel/ace/lib/dma.c
+++ b/src/platform/intel/ace/lib/dma.c
@@ -18,7 +18,7 @@
 #include <zephyr/device.h>
 
 #define DW_DMA_BUFFER_PERIOD_COUNT	0x4
-#define HDA_DMA_BUFFER_PERIOD_COUNT	2
+#define HDA_DMA_BUFFER_PERIOD_COUNT	4
 
 SHARED_DATA struct dma dma[] = {
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(lpgpdma0), okay)


### PR DESCRIPTION
Double the dma buffer period count as it
should be 128 for 1 channel, 256 for 2, etc.

Signed-off-by: Arsen Eloglian <ArsenX.Eloglian@intel.com>