### PR TITLE
ipc4: Fix error handling issues in ipc4

### DIFF
--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -275,6 +275,9 @@ static int set_pipeline_state(struct ipc_comp_dev *ppl_icd, uint32_t cmd,
 			}
 			if (ret == PPL_STATUS_SCHEDULED)
 				*delayed = true;
+			break;
+		default:
+			ret = 0;
 		}
 
 		/*


### PR DESCRIPTION
The set_pipeline_state() function could potentially end up with uninitialised ret variable. Set it to 0 to avoid returning uninitialised.
Fix from mtl-002-drop-stable: [https://github.com/thesofproject/sof/pull/6719](https://github.com/thesofproject/sof/pull/6719)

Signed-off-by: Jaroslaw Stelter <Jaroslaw.Stelter@intel.com>