### PR TITLE
lib_manager: iadk: Fix variable initialization issues

### DIFF
--- a/src/audio/module_adapter/iadk/system_agent.cpp
+++ b/src/audio/module_adapter/iadk/system_agent.cpp
@@ -81,9 +81,9 @@ SystemAgent::SystemAgent(uint32_t module_id,
 			     core_id_(core_id),
 			     module_id_(module_id),
 			     instance_id_(instance_id),
-			     module_handle_(NULL)
+			     module_handle_(NULL),
+			     module_size_(0)
 {}
-
 
 void SystemAgent::CheckIn(ProcessingModuleInterface& processing_module,
 			  ModuleHandle &module_handle,

--- a/src/library_manager/lib_manager.c
+++ b/src/library_manager/lib_manager.c
@@ -426,6 +426,8 @@ static int lib_manager_dma_init(struct lib_manager_dma_ext *dma_ext, uint32_t dm
 	int chan_index;
 	int ret;
 
+	/* Initialize dma_ext with zeros */
+	memset(dma_ext, 0, sizeof(struct lib_manager_dma_ext));
 	/* request DMA in the dir HMEM->LMEM */
 	dma_ext->dma = dma_get(DMA_DIR_HMEM_TO_LMEM, 0, DMA_DEV_HOST,
 			       DMA_ACCESS_EXCLUSIVE);
@@ -461,8 +463,11 @@ static int lib_manager_dma_init(struct lib_manager_dma_ext *dma_ext, uint32_t dm
 
 static int lib_manager_dma_deinit(struct lib_manager_dma_ext *dma_ext, uint32_t dma_id)
 {
-	dma_release_channel(dma_ext->dma->z_dev, dma_id);
-	dma_put(dma_ext->dma);
+	if (dma_ext->dma) {
+		dma_put(dma_ext->dma);
+		if (dma_ext->dma->z_dev)
+			dma_release_channel(dma_ext->dma->z_dev, dma_id);
+	}
 	return 0;
 }
 


### PR DESCRIPTION
This PR contains data initialization fixes in library manager and IADK modules.

Fix from mtl-002-drop-stable: [https://github.com/thesofproject/sof/pull/6718](https://github.com/thesofproject/sof/pull/6718)

Signed-off-by: Jaroslaw Stelter [Jaroslaw.Stelter@intel.com](mailto:Jaroslaw.Stelter@intel.com)