### PR TITLE
module_adapter: return 0 when component state is equal to requested state

### DIFF
--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -71,7 +71,11 @@ int comp_set_state(struct comp_dev *dev, int cmd)
 	if (dev->state == requested_state) {
 		comp_info(dev, "comp_set_state(), state already set to %u",
 			  dev->state);
+#ifdef CONFIG_IPC_MAJOR_4
+		return 0;
+#else
 		return COMP_STATUS_STATE_ALREADY_SET;
+#endif
 	}
 
 	switch (cmd) {


### PR DESCRIPTION
When dev->state == requested_state in comp_set_state then COMP_STATUS_STATE_ALREADY_SET (status 1) is returned. Then the pipeline trigger is aborted and status 1 is returned to the pipeline_task_cmd function (status 1 in this function means PPL_STATUS_PATH_STOP). Finally, the status of the pipeline does not change and the IPC response returns success. which causes errors with subsequent changes in the pipeline state (INVALID_IPC_REQUEST)