### PR TITLE
sof-logger: print error if -u uart option is given with no infile

### DIFF
--- a/tools/logger/logger.c
+++ b/tools/logger/logger.c
@@ -436,6 +436,11 @@ int main(int argc, char *argv[])
 	if (!config.in_file && !config.dump_ldc)
 		config.in_file = "/sys/kernel/debug/sof/etrace";
 
+	if (!config.in_file && baud) {
+		fprintf(stderr, "error: No UART device specified\n");
+		usage();
+	}
+
 	if (config.input_std) {
 		config.in_fd = stdin;
 	} else if (baud) {


### PR DESCRIPTION
sof-logger -u 115200 -d /lib/firmware/sof-foo.ldc

Leads to silent failure as a NULL is passed to open(). Add explicit error handling for this case.

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>