### PR TITLE
audio: dai-zephyr/host-zephyr: stop dma only once

### DIFF
--- a/src/audio/host-zephyr.c
+++ b/src/audio/host-zephyr.c
@@ -627,10 +627,13 @@ static int host_trigger(struct comp_dev *dev, int cmd)
 		break;
 	case COMP_TRIGGER_STOP:
 	case COMP_TRIGGER_XRUN:
-		ret = dma_stop(hd->chan->dma->z_dev, hd->chan->index);
-		if (ret < 0)
-			comp_err(dev, "host_trigger(): dma stop failed: %d",
-				 ret);
+		if (dev->state == COMP_STATE_ACTIVE) {
+			ret = dma_stop(hd->chan->dma->z_dev, hd->chan->index);
+			if (ret < 0)
+				comp_err(dev, "host_trigger(): dma stop failed: %d",
+					 ret);
+		}
+
 		break;
 	default:
 		break;
@@ -1048,7 +1051,8 @@ static int host_reset(struct comp_dev *dev)
 	comp_dbg(dev, "host_reset()");
 
 	if (hd->chan) {
-		dma_stop(hd->chan->dma->z_dev, hd->chan->index);
+		if (dev->state == COMP_STATE_ACTIVE)
+			dma_stop(hd->chan->dma->z_dev, hd->chan->index);
 
 		/* remove callback */
 		notifier_unregister(dev, hd->chan, NOTIFIER_ID_DMA_COPY);

--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -172,7 +172,9 @@ void dai_dma_release(struct comp_dev *dev)
 		 * TODO: refine power management when stream is paused
 		 */
 #if CONFIG_ZEPHYR_NATIVE_DRIVERS
-		dma_stop(dd->chan->dma->z_dev, dd->chan->index);
+		/* if reset is after pause dma has already been stopped */
+		if (dev->state != COMP_STATE_PAUSED)
+			dma_stop(dd->chan->dma->z_dev, dd->chan->index);
 
 		/* remove callback */
 		notifier_unregister(dev, dd->chan, NOTIFIER_ID_DMA_COPY);


### PR DESCRIPTION
Until now, one dma channel could be stopped multiple times without any problems. From commit af6d827b64 on zephyr it is required that the start and stop calls be perfectly balanced.

Zephyr device power manager stores an internal counter. Counter is incremented if device is used and decremented on device release. In this case when we call dma_start() and dma_stop().

If dma_stop() is called more times than dma_start() power manager will reaport a error -EALREADY.

Signed-off-by: Tomasz Leman <tomasz.m.leman@intel.com>