### PR TITLE
[SOF2.4] ipc4: copier: remove redundant assignment

### DIFF
--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -610,15 +610,16 @@ static int copier_prepare(struct comp_dev *dev)
 	if (ret == COMP_STATUS_STATE_ALREADY_SET)
 		return PPL_STATUS_PATH_STOP;
 
-	if (cd->endpoint_num) {
+	for (i = 0; i < cd->endpoint_num; i++) {
+		ret = cd->endpoint[i]->drv->ops.prepare(cd->endpoint[i]);
+		if (ret < 0)
+			break;
+	}
 
-		for (i = 0; i < cd->endpoint_num; i++) {
-			ret = cd->endpoint[i]->drv->ops.prepare(cd->endpoint[i]);
-			if (ret < 0)
-				break;
-		}
-	} else {
-		/* set up format conversion function */
+	if (!cd->endpoint_num) {
+		/* set up format conversion function for pin 0, for other pins (if any)
+		 * format is set in IPC4_COPIER_MODULE_CFG_PARAM_SET_SINK_FORMAT handler
+		 */
 		cd->converter[0] = get_converter_func(&cd->config.base.audio_fmt,
 							      &cd->config.out_fmt, ipc4_gtw_none,
 							      ipc4_bidirection);
@@ -626,9 +627,6 @@ static int copier_prepare(struct comp_dev *dev)
 			comp_err(dev, "can't support for in format %d, out format %d",
 				 cd->config.base.audio_fmt.depth,  cd->config.out_fmt.depth);
 			ret = -EINVAL;
-		} else {
-			for (i = 1; i < IPC4_COPIER_MODULE_OUTPUT_PINS_COUNT; i++)
-				cd->converter[i] = cd->converter[i];
 		}
 	}
 


### PR DESCRIPTION
Removes variable cd->converter[i] assigning to self. This fixes error reported by static code analyzer.

Signed-off-by: Serhiy Katsyuba <serhiy.katsyuba@intel.com>
(cherry picked from commit e06e1f0a441f2c3b3ed57ea801f35fc7b1b37c7c)
Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>