### PR TITLE
topology2: set sdw amp feedback pcm channel number

### DIFF
--- a/tools/topology/topology2/platform/intel/alh-2nd-spk.conf
+++ b/tools/topology/topology2/platform/intel/alh-2nd-spk.conf
@@ -1,4 +1,8 @@
 
+Define {
+	AMP_FEEDBACK_CH 4
+}
+
 Object.Pipeline {
 	passthrough-be.$ALH_2ND_SPK_ID {
 		direction	"playback"

--- a/tools/topology/topology2/platform/intel/sdw-amp-generic.conf
+++ b/tools/topology/topology2/platform/intel/sdw-amp-generic.conf
@@ -7,6 +7,7 @@ Define {
 	ALH_2ND_SPK_IN_ID 32
 	SDW_AMP_BE_ID 2
 	SDW_AMP_IN_BE_ID 3
+	AMP_FEEDBACK_CH 2
 }
 
 Object.Dai {
@@ -119,6 +120,8 @@ Object.PCM {
 		Object.PCM.pcm_caps."capture" {
 			name "amp feedback"
 			formats 'S16_LE,S32_LE'
+			channels_min $AMP_FEEDBACK_CH
+			channels_max $AMP_FEEDBACK_CH
 		}
 	}
 }


### PR DESCRIPTION
Assume an amplifier will provide 2 channels feedback.

Signed-off-by: Bard Liao <yung-chuan.liao@linux.intel.com>