### PR TITLE
logger: make "global_config" truly global

### DIFF
--- a/tools/logger/convert.c
+++ b/tools/logger/convert.c
@@ -1032,7 +1032,7 @@ static int dump_ldc_info(void)
 
 int convert(void)
 {
-	struct snd_sof_logs_header snd;
+	struct snd_sof_logs_header * const logs_hdr = malloc(sizeof(*logs_hdr));
 	struct snd_sof_uids_header uids_hdr;
 	int count, ret = 0;
 
@@ -1040,32 +1040,35 @@ int convert(void)
 	if (!global_config)
 		abort();
 
+	if (!logs_hdr)
+		abort();
+
 	/* just a shorter alias */
 	struct convert_config * const config = global_config;
 
-	config->logs_header = &snd;
+	config->logs_header = logs_hdr;
 
-	count = fread(&snd, sizeof(snd), 1, config->ldc_fd);
+	count = fread(logs_hdr, sizeof(*logs_hdr), 1, config->ldc_fd);
 	if (!count) {
 		log_err("Error while reading %s.\n", config->ldc_file);
 		return -ferror(config->ldc_fd);
 	}
 
-	if (strncmp((char *) snd.sig, SND_SOF_LOGS_SIG, SND_SOF_LOGS_SIG_SIZE)) {
+	if (strncmp((char *)logs_hdr->sig, SND_SOF_LOGS_SIG, SND_SOF_LOGS_SIG_SIZE)) {
 		log_err("Invalid ldc file signature.\n");
 		return -EINVAL;
 	}
 
 	if (global_config->version_fw && /* -n option */
 	    !global_config->dump_ldc) {
-		ret = verify_ldc_checksum(global_config->logs_header->version.src_hash);
+		ret = verify_ldc_checksum(logs_hdr->version.src_hash);
 		if (ret)
 			return ret;
 	}
 
 	/* default logger and ldc_file abi verification */
 	if (SOF_ABI_VERSION_INCOMPATIBLE(SOF_ABI_DBG_VERSION,
-					 snd.version.abi_version)) {
+					 logs_hdr->version.abi_version)) {
 		log_err("abi version in %s file does not coincide with abi version used by logger.\n",
 			config->ldc_file);
 		log_err("logger ABI Version is %d:%d:%d\n",
@@ -1073,14 +1076,14 @@ int convert(void)
 			SOF_ABI_VERSION_MINOR(SOF_ABI_DBG_VERSION),
 			SOF_ABI_VERSION_PATCH(SOF_ABI_DBG_VERSION));
 		log_err("ldc_file ABI Version is %d:%d:%d\n",
-			SOF_ABI_VERSION_MAJOR(snd.version.abi_version),
-			SOF_ABI_VERSION_MINOR(snd.version.abi_version),
-			SOF_ABI_VERSION_PATCH(snd.version.abi_version));
+			SOF_ABI_VERSION_MAJOR(logs_hdr->version.abi_version),
+			SOF_ABI_VERSION_MINOR(logs_hdr->version.abi_version),
+			SOF_ABI_VERSION_PATCH(logs_hdr->version.abi_version));
 		return -EINVAL;
 	}
 
 	/* read uuid section header */
-	fseek(config->ldc_fd, snd.data_offset + snd.data_length, SEEK_SET);
+	fseek(config->ldc_fd, logs_hdr->data_offset + logs_hdr->data_length, SEEK_SET);
 	count = fread(&uids_hdr, sizeof(uids_hdr), 1, config->ldc_fd);
 	if (!count) {
 		log_err("Error while reading uuids header from %s.\n", config->ldc_file);

--- a/tools/logger/convert.c
+++ b/tools/logger/convert.c
@@ -65,9 +65,6 @@ static const char *BAD_PTR_STR = "<bad uid ptr 0x%.8x>";
 #define UUID_LOWER "%s%s%s<%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x>%s%s%s"
 #define UUID_UPPER "%s%s%s<%08X-%04X-%04X-%02X%02X-%02X%02X%02X%02X%02X%02X>%s%s%s"
 
-/* pointer to config for global context */
-struct convert_config *global_config;
-
 static int read_entry_from_ldc_file(struct ldc_entry *entry, uint32_t log_entry_address);
 
 char *format_uid_raw(const struct sof_uuid_entry *uid_entry, int use_colors, int name_first,
@@ -1033,14 +1030,20 @@ static int dump_ldc_info(void)
 	return 0;
 }
 
-int convert(struct convert_config *config)
+int convert(void)
 {
 	struct snd_sof_logs_header snd;
 	struct snd_sof_uids_header uids_hdr;
 	int count, ret = 0;
 
+	/* const pointer initialized at build time */
+	if (!global_config)
+		abort();
+
+	/* just a shorter alias */
+	struct convert_config * const config = global_config;
+
 	config->logs_header = &snd;
-	global_config = config;
 
 	count = fread(&snd, sizeof(snd), 1, config->ldc_fd);
 	if (!count) {

--- a/tools/logger/convert.h
+++ b/tools/logger/convert.h
@@ -47,4 +47,8 @@ struct convert_config {
 };
 
 uint32_t get_uuid_key(const struct sof_uuid_entry *entry);
-int convert(struct convert_config *config);
+
+/* pointer to config for global context */
+extern struct convert_config * const global_config;
+
+int convert(void);

--- a/tools/logger/filter.c
+++ b/tools/logger/filter.c
@@ -22,8 +22,6 @@
 #define COMPONENTS_SEPARATOR ','
 #define COMPONENT_NAME_SCAN_STRING_LENGTH 32
 
-extern struct convert_config *global_config;
-
 /** map between log level given by user and enum value */
 static const struct {
 	const char name[16];

--- a/tools/logger/logger.c
+++ b/tools/logger/logger.c
@@ -277,6 +277,8 @@ cleanup:
 }
 #endif // HAS_INOTIFY
 
+static struct convert_config _global_config;
+struct convert_config * const global_config = &_global_config;
 
 int main(int argc, char *argv[])
 {
@@ -488,7 +490,8 @@ int main(int argc, char *argv[])
 		}
 	}
 
-	ret = -convert(&config);
+	_global_config = config;
+	ret = -convert();
 
 out:
 	/* free memory */

--- a/tools/logger/misc.c
+++ b/tools/logger/misc.c
@@ -41,8 +41,6 @@ char *log_asprintf(const char *format, ...)
 	return result;
 }
 
-extern struct convert_config *global_config;
-
 /** Prints 1. once to stderr. 2. a second time to the global out_fd if
  * out_fd is neither stderr nor stdout (because the -o option was used).
  */


### PR DESCRIPTION
Finish the job that commit 5b29dae9c870 ("logger: Create global convert_config variable to avoid spaghetti code.") started but did not finish, leaving behind a supposedly "global" variable that is actually a confusing global pointer to a struct local to the main() function.

This confuses some static analyzer complaining that stack values are being returned, see #6858 and #6738. This is a false positive because the main()'s stack lifespan is the same as a global but let's simplify things anyway.

Also stop using 'extern' in .c files, use a proper .h file instead.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>