### PR TITLE
library_manager: fix dma_deinit order

### DIFF
--- a/src/library_manager/lib_manager.c
+++ b/src/library_manager/lib_manager.c
@@ -464,9 +464,10 @@ static int lib_manager_dma_init(struct lib_manager_dma_ext *dma_ext, uint32_t dm
 static int lib_manager_dma_deinit(struct lib_manager_dma_ext *dma_ext, uint32_t dma_id)
 {
 	if (dma_ext->dma) {
-		dma_put(dma_ext->dma);
 		if (dma_ext->dma->z_dev)
 			dma_release_channel(dma_ext->dma->z_dev, dma_id);
+
+		dma_put(dma_ext->dma);
 	}
 	return 0;
 }


### PR DESCRIPTION
Fixes commit 4cc849d34b1b674e27c83f7fe29ef8cd0602563f
dma ptr should be checked before dma->z_dev

Signed-off-by: Adrian Bonislawski <adrian.bonislawski@intel.com>