### PR TITLE
dmic: Fix to support Windows host DMIC node_id range

### DIFF
--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -378,7 +378,11 @@ static int create_dai(struct comp_dev *parent_dev, struct copier_data *cd,
 
 		break;
 	case ipc4_dmic_link_input_class:
-		dai_index[dai_count - 1] = (dai_index[dai_count - 1] >> 5) & 0x7;
+		/* For some unknown reason Linux and Windows hosts use different range of node_id
+		 * for DMIC. Let's workaround to support both ranges.
+		 */
+		if (dai_index[dai_count - 1] >= BIT(5))
+			dai_index[dai_count - 1] = (dai_index[dai_count - 1] >> 5) & 0x7;
 		dai.type = SOF_DAI_INTEL_DMIC;
 		dai.is_config_blob = true;
 		type = ipc4_gtw_dmic;


### PR DESCRIPTION
This is a fix for a regression introduced by #6668.

For an unknown reason (probably a bug) Linux and Windows hosts use different range of node_id for DMIC. The fix workarounds the problem adding support for both ranges.

Signed-off-by: Serhiy Katsyuba <serhiy.katsyuba@intel.com>