### PR TITLE
[SOF2.4] Backport "library_manager: fix dma_deinit order" (PR6869)

### DIFF
--- a/src/library_manager/lib_manager.c
+++ b/src/library_manager/lib_manager.c
@@ -454,9 +454,10 @@ static int lib_manager_dma_init(struct lib_manager_dma_ext *dma_ext, uint32_t dm
 static int lib_manager_dma_deinit(struct lib_manager_dma_ext *dma_ext, uint32_t dma_id)
 {
 	if (dma_ext->dma) {
-		dma_put(dma_ext->dma);
 		if (dma_ext->dma->z_dev)
 			dma_release_channel(dma_ext->dma->z_dev, dma_id);
+
+		dma_put(dma_ext->dma);
 	}
 	return 0;
 }


### PR DESCRIPTION
Fixes commit f90f5f9a142d
dma ptr should be checked before dma->z_dev

Signed-off-by: Adrian Bonislawski <adrian.bonislawski@intel.com>
(cherry picked from commit 7c623256cba190ceb2153b87da170d63ce59ba21)
Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>