### PR TITLE
Revert Audio: Copier: Add missing DMIC DAI index mapping to create_dai()

### DIFF
--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -378,7 +378,6 @@ static int create_dai(struct comp_dev *parent_dev, struct copier_data *cd,
 
 		break;
 	case ipc4_dmic_link_input_class:
-		dai_index[dai_count - 1] = (dai_index[dai_count - 1] >> 5) & 0x7;
 		dai.type = SOF_DAI_INTEL_DMIC;
 		dai.is_config_blob = true;
 		type = ipc4_gtw_dmic;


### PR DESCRIPTION
This reverts commit 8d166a432f68ccd9ee657a58f379ed4f0f22b888.

This restores working DMIC functionality on Windows platform broken by #6668.

ATTENTION: This will break DMIC1 (DMIC with DAI index 1) functionality on Linux platform, DMIC0 should still work fine!
Non working DMIC1 should be fixed on Linux driver side, not this firmware.

Signed-off-by: Serhiy Katsyuba <serhiy.katsyuba@intel.com>