### PR TITLE
[SKIP CI] .github/zephyr: docker pull in a separate step

### DIFF
--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -69,6 +69,12 @@ jobs:
              fi &&
              git log --oneline -n 5 --decorate --graph --no-abbrev-commit
 
+      # Not strictly necessary but saves a lot of scrolling in the next step
+      # TODO, research caching:
+      # https://stackoverflow.com/questions/66421411/how-to-run-cached-docker-image-in-github-action
+      - name: docker pull         zephyrproject-rtos/zephyr-build
+        run: docker  pull ghcr.io/zephyrproject-rtos/zephyr-build:latest
+
       # https://github.com/zephyrproject-rtos/docker-image
       # Note: env variables can be passed to the container with
       # -e https_proxy=...


### PR DESCRIPTION
This saves a lot of scrolling in the next, most popular build step.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>