### PR TITLE
xtensa-build-zephyr.py: convert sof-info/ text files from CRLF to LF

### DIFF
--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -803,7 +803,7 @@ def install_platform(platform, sof_platform_output_dir):
 		# --strip-all does not remove the .comment section.
 		# Remove it like some gcc test scripts do:
 		# https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=c7046906c3ae
-		if "strip" in dstname:
+		if "strip" in str(dstname):
 			execute_command([str(x) for x in [objcopy, "--remove-section", ".comment", src, dst]])
 		else:
 			shutil.copy2(src, dst)


### PR DESCRIPTION
Building on Windows generates CRLF text files. Standardize checksums to
LF files.

As usual, files in the build directory are left untouched.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>