### PR TITLE
scripts: fix check whether CMake configuration succeeded

### DIFF
--- a/installer/GNUmakefile
+++ b/installer/GNUmakefile
@@ -201,7 +201,8 @@ endif
 # config file included here.
 ${BUILD_SOF_RIS}: ${BUILDS_ROOT}/build_%_${TOOLCHAIN}/sof.ri: | ${BUILDS_ROOT}
 	cd ${BUILDS_ROOT} && bdir="$$(dirname $@)" &&  \
-      if [ -d $${bdir} ] && [ xcc != "${TOOLCHAIN}" ] ; then \
+      if [ -e $${bdir}/build.ninja -o -e $${bdir}/Makefile ] && \
+          [ xcc != "${TOOLCHAIN}" ] ; then \
         cmake --build $${bdir} -- bin; else \
       $(CURDIR)/../scripts/xtensa-build-all.sh -i "${IPC_VERSION}" $*; fi
 
@@ -294,7 +295,8 @@ build_tools: ${BUILD_TOOLS}
 # We could use more targets rather than "set -e" with a multi-lines "for" loop.
 # That would be more flexible but also quite verbose.
 ${BUILD_TOOLS}:
-	set -e; if test -d ${BUILD_TOOLS}; then \
+	set -e; if test -e ${BUILD_TOOLS}/build.ninja || \
+                   test -e ${BUILD_TOOLS}/Makefile; then \
         for i in topologies ${TOOLS_TARGETS}; do \
           cmake --build ${BUILD_TOOLS} -- $$i; done; else         \
           BUILD_TOOLS_DIR=${BUILD_TOOLS} ../scripts/build-tools.sh -T ${TOOLS_FLAGS} ; \

--- a/scripts/build-tools.sh
+++ b/scripts/build-tools.sh
@@ -149,10 +149,11 @@ main()
                 exit
         fi
 
-        if ! test -e "$BUILD_TOOLS_DIR"/CMakeCache.txt; then
+        test -e "$BUILD_TOOLS_DIR"/build.ninja ||
+        test -e "$BUILD_TOOLS_DIR"/Makefile    || {
             warn_incremental_build=false
             reconfigure_build
-        fi
+        }
 
         if "$BUILD_ALL"; then
                 # default CMake targets


### PR DESCRIPTION
To test whether CMake configuration can be skipped, look for either a ninja.build or Makefile.

An existing build directory is NOT proof that CMake configuration succeeded. When CMake configuration failed, trying to build again fails with a super confusing "Makefile not found" error message.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>