### PR TITLE
[SKIP CI] .github/zephyr: fix uploads overwriting each other

### DIFF
--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -85,8 +85,9 @@ jobs:
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v3
+        if: ${{ matrix.zephyr_revision == 'manifest_revision' }}
         with:
-          name: linux-build-output
+          name: linux-build ${{ matrix.IPC_platforms }}
           path: |
             ${{ github.workspace }}/workspace/build-sof-staging
             ${{ github.workspace }}/workspace/**/compile_commands.json
@@ -224,7 +225,7 @@ jobs:
       - name: Upload build artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: windows-build-output
+          name: windows-build ${{ matrix.platforms}}
           path: |
             ${{ github.workspace }}/workspace/build-sof-staging
             ${{ github.workspace }}/workspace/**/compile_commands.json


### PR DESCRIPTION
From
https://github.com/actions/upload-artifact#uploading-to-the-same-artifact

> Warning: Be careful when uploading to the same artifact via multiple
> jobs as artifacts may become corrupted.

Fix bug where IPC3 and IPC4 builds were randomly overwriting each other and the same bug with different Zephyr revisions.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>