### PR TITLE
up_down_mixer: Convert module to use the module interface

### DIFF
--- a/src/include/sof/audio/up_down_mixer/up_down_mixer.h
+++ b/src/include/sof/audio/up_down_mixer/up_down_mixer.h
@@ -114,7 +114,6 @@ static inline enum ipc4_channel_index get_channel_index(const channel_map map,
  * \brief up_down_mixer component private data.
  */
 struct up_down_mixer_data {
-	struct ipc4_base_module_cfg base;
 	/** Number of channels in the input buffer. */
 	size_t in_channel_no;
 

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -225,7 +225,7 @@ void sys_comp_multiband_drc_init(void);
 void sys_comp_google_rtc_audio_processing_init(void);
 void sys_comp_igo_nr_init(void);
 void sys_comp_rtnr_init(void);
-void sys_comp_up_down_mixer_init(void);
+void sys_comp_module_up_down_mixer_interface_init(void);
 void sys_comp_tdfb_init(void);
 void sys_comp_ghd_init(void);
 void sys_comp_module_dts_interface_init(void);
@@ -370,7 +370,7 @@ int task_main_start(struct sof *sof)
 		sys_comp_rtnr_init();
 
 	if (IS_ENABLED(CONFIG_COMP_UP_DOWN_MIXER))
-		sys_comp_up_down_mixer_init();
+		sys_comp_module_up_down_mixer_interface_init();
 
 	if (IS_ENABLED(CONFIG_COMP_TDFB))
 		sys_comp_tdfb_init();


### PR DESCRIPTION
Use the module_adapter interface instead of comp_drv ops.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>