### PR TITLE
sof-ctl: add support for ipc4 mode

### DIFF
--- a/src/include/kernel/abi.h
+++ b/src/include/kernel/abi.h
@@ -62,4 +62,7 @@
 /** \brief SOF ABI magic number "SOF\0". */
 #define SOF_ABI_MAGIC		0x00464F53
 
+/* SOF IPC4 ABI magic number "SOF4". */
+#define SOF_IPC4_ABI_MAGIC	0x34464F53
+
 #endif /* __KERNEL_ABI_H__ */

--- a/src/include/kernel/header.h
+++ b/src/include/kernel/header.h
@@ -36,4 +36,26 @@ struct sof_abi_hdr {
 	uint32_t data[0];	/**< Component data - opaque to core */
 } __attribute__((packed));
 
+/**
+ * struct sof_ipc4_abi_hdr - Used by any bespoke component data structures or binary blobs.
+ * @magic: The magic number for the header. The value is 'S', 'O', 'F', '4'
+ * @size: The size in bytes of the data, excluding this struct
+ * @abi: SOF ABI version
+ * @blob_type: Type of blob: INIT_INSTANCE, CONFIG_SET or LARGE_CONFIG_SET
+ *             The value is of type enum sof_ipc4_module_type
+ * @param_id: ID indicating which parameter to update with the new data. The validity of
+ *            the param_id with blob_type is dependent on the module implementation.
+ * @reserved: Reserved for future use
+ * @data: Component data - opaque to core
+ */
+struct sof_ipc4_abi_hdr {
+	uint32_t magic;
+	uint32_t size;
+	uint32_t abi;
+	uint32_t blob_type;
+	uint32_t param_id;
+	uint32_t reserved[3];
+	uint32_t data[];
+}  __packed;
+
 #endif /* __KERNEL_HEADER_H__ */


### PR DESCRIPTION
This PR adds the sof-ctl support for ipc4 mode. User can run below command to generate the init instance data blob for ipc4:
```
# ./tools/build_tools/ctl/sof-ctl -I 'IPC4' -T 0 -g $size -b
```
