### PR TITLE
Audio: fix compile error for COMP_CROSSOVER

### DIFF
--- a/src/audio/Kconfig
+++ b/src/audio/Kconfig
@@ -190,6 +190,7 @@ config COMP_SEL
 config COMP_CROSSOVER
 	bool "Crossover Filter component"
 	select COMP_BLOB
+	select MATH_IIR_DF2T
 	default n
 	help
 	  Select for Crossover Filter component. A crossover can be used to


### PR DESCRIPTION
Linker fails to link iir_df2t() function when COMP_CROSSOVER is enabled. Need to select MATH_IIR_DF2T in Kconfig to build the iir_df2t() function as well.

Signed-off-by: Brent Lu <brent.lu@intel.com>