### PR TITLE
dai-zephyr: handle NULL case when calling dai_config_get()

### DIFF
--- a/src/lib/dai.c
+++ b/src/lib/dai.c
@@ -157,7 +157,7 @@ static const struct device *dai_get_zephyr_device(uint32_t type, uint32_t index)
 
 	for (i = 0; i < ARRAY_SIZE(zephyr_dev); i++) {
 		cfg = dai_config_get(zephyr_dev[i], dir);
-		if (cfg->type == type && cfg->dai_index == index)
+		if (cfg && cfg->type == type && cfg->dai_index == index)
 			return zephyr_dev[i];
 	}
 


### PR DESCRIPTION
As per interface documentation of dai_config_get(), the function may return NULL if the device is not configured for the requested direction. Handle this case explicitly.

Currently no upstream Zephyr driver returns NULL, but e.g. dmic driver returns invalid configuration when dai_config_get() is called with DAI_DIR_TX as direction.

Link: https://github.com/thesofproject/sof/issues/6896
Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>