### PR TITLE
peakvol: select correct processing function

### DIFF
--- a/src/audio/module_adapter/module/volume/volume.c
+++ b/src/audio/module_adapter/module/volume/volume.c
@@ -1135,7 +1135,7 @@ static vol_zc_func vol_get_zc_function(struct comp_dev *dev,
 
 	/* map the zc function to frame format */
 	for (i = 0; i < ARRAY_SIZE(zc_func_map); i++) {
-		if (sinkb->stream.frame_fmt == zc_func_map[i].frame_fmt)
+		if (sinkb->stream.valid_sample_fmt == zc_func_map[i].frame_fmt)
 			return zc_func_map[i].func;
 	}
 

--- a/src/include/sof/audio/volume.h
+++ b/src/include/sof/audio/volume.h
@@ -210,9 +210,11 @@ static inline vol_scale_func vol_get_processing_function(struct comp_dev *dev,
 {
 	struct processing_module *mod = comp_get_drvdata(dev);
 
-	switch (mod->priv.cfg.base_cfg.audio_fmt.depth) {
+	switch (mod->priv.cfg.base_cfg.audio_fmt.valid_bit_depth) {
 	case IPC4_DEPTH_16BIT:
 		return volume_func_map[0].func;
+	case IPC4_DEPTH_24BIT:
+		return volume_func_map[1].func;
 	case IPC4_DEPTH_32BIT:
 		return volume_func_map[2].func;
 	default:


### PR DESCRIPTION
24/32 function is never selected due to the fact that only the size of the container determines the selection of the function. It should be selected based on valid_bit_depth.

Signed-off-by: Kwasowiec, Fabiola <fabiola.kwasowiec@intel.com>