### PR TITLE
mixin-mixout: handle congestion corner case without assert

### DIFF
--- a/src/audio/mixin_mixout/mixin_mixout.c
+++ b/src/audio/mixin_mixout/mixin_mixout.c
@@ -423,7 +423,6 @@ static int mixin_process(struct processing_module *mod,
 		 * performance problems with processing data on time in mixout.
 		 */
 		start_frame = mixout_data->pending_frames[source_index];
-		assert(sinks_free_frames >= start_frame);
 
 		sink_c = buffer_acquire(sink);
 


### PR DESCRIPTION
If mixout is not able to process data, the "assert(sinks_free_frames >= start_frame)" condition is hit.

This is not correct usage of asserts as the condition may be hit due to performance reasons (and is frequently hit in pause-resume stress test with sof-test), and production builds will have asserts disabled, leading to undefined behaviour.

Instead of assert, add a check, emit a warning and truncate the amount of copied frames, to ensure deterministic behaviour in all conditions.

Link: https://github.com/thesofproject/sof/issues/6896
Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>