### PR TITLE
coredump-reader: set confirmation off

### DIFF
--- a/tools/coredumper/sof-coredump-reader.py
+++ b/tools/coredumper/sof-coredump-reader.py
@@ -719,6 +719,9 @@ class CoreDumpReader(object):
 
 		stdoutOpen()
 
+		# disable confirmation request for undefined breakpoint
+		stdoutPrint("set confirm off\n")
+
 		# for XTOS SOF build
 		stdoutPrint("break _MemErrorVector\n")
 		# for Zephyr SOF build


### PR DESCRIPTION
The undefined function may cause the debugger not able to run properly. Print a "set confirm off" instruction to the beginning of output file to solve this problem.

(xt-gdb) break _MemErrorVector
Breakpoint 1 at 0x9f180400
(xt-gdb) break _MemoryExceptionVector_text_start
Function "_MemoryExceptionVector_text_start" not defined. Make breakpoint pending on future shared library load? (y or [n]) run Please answer y or [n].
...

Signed-off-by: Brent Lu <brent.lu@intel.com>