### PR TITLE
west.yml: upgrade rimage to ba8534bb2378

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -34,7 +34,7 @@ manifest:
     - name: rimage
       repo-path: rimage
       path: sof/rimage
-      revision: 65f345a52e06a084192124364c563d8133d834c2
+      revision: ba8534bb237881beb281c56f5d03d92fa67eb0ec
 
     - name: tomlc99
       repo-path: tomlc99


### PR DESCRIPTION
upgrade rimage to
ba8534bb237881beb281c56f5d03d92fa67eb0ec

ba8534bb2378 Fix bitmap according to the IMR type
f3eef3cfb6ff Fix IMR type parsing
bdba8259fe3c Add a command line option to set an Intel-specific PV bit 1c48208850c9 config: tgl-cavs: add smart amp test module config 082b6261c9dc config: Add mt8188.toml

Signed-off-by: Jaska Uimonen <jaska.uimonen@intel.com>