### PR TITLE
[SKIP CI] .github/zephyr: use ScribeMD/docker-cache

### DIFF
--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -72,8 +72,8 @@ jobs:
       # Not strictly necessary but saves a lot of scrolling in the next step
       # TODO, research caching:
       # https://stackoverflow.com/questions/66421411/how-to-run-cached-docker-image-in-github-action
-      - name: docker pull         zephyrproject-rtos/zephyr-build
-        run: docker  pull ghcr.io/zephyrproject-rtos/zephyr-build:latest
+      - name: docker pull         zephyrproject-rtos/ci
+        run: docker  pull ghcr.io/zephyrproject-rtos/ci:latest
 
       # https://github.com/zephyrproject-rtos/docker-image
       # Note: env variables can be passed to the container with

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -69,6 +69,19 @@ jobs:
              fi &&
              git log --oneline -n 5 --decorate --graph --no-abbrev-commit
 
+      - name: get digest of latest ghcr.io/zephyrproject-rtos/ci
+        id: latest-zephyr-img
+        run: |
+          docker manifest inspect ghcr.io/zephyrproject-rtos/ci:latest -v | jq -r '.[0].Descriptor.digest' | tee latest-img
+          printf 'digest=%s\n' "$(cat latest-img)" >> "${GITHUB_OUTPUT}"
+          tail "${GITHUB_OUTPUT}"
+          df -h ~/
+
+      - name: Cache Docker images
+        uses: ScribeMD/docker-cache@0.2.6
+        with: # can't get digest :-(
+          key: zephyr-build-img-${{ steps.latest-zephyr-img.digest }}
+
       # Not strictly necessary but saves a lot of scrolling in the next step
       # TODO, research caching:
       # https://stackoverflow.com/questions/66421411/how-to-run-cached-docker-image-in-github-action
@@ -82,6 +95,12 @@ jobs:
         run: cd workspace && ./sof/zephyr/docker-run.sh
              ./sof/zephyr/docker-build.sh --cmake-args=-DEXTRA_CFLAGS=-Werror
              --cmake-args=--warn-uninitialized ${{ matrix.IPC_platforms }}
+
+      - name: debug
+        run: |
+          df -h ~
+          cat latest-img
+          echo steps.latest-zephyr-img.digest=${{ steps.latest-zephyr-img.digest }}
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v3

--- a/scripts/sudo-cwd.sh
+++ b/scripts/sudo-cwd.sh
@@ -54,10 +54,12 @@ exec_as_cwd_uid()
         local current_user; current_user="$(id -un)"
 
         # Copy sudo permissions just in case the build needs it
-        sudo sed -e "s/$current_user/$cwd_user/" /etc/sudoers.d/"$current_user" |
+        if test -e /etc/sudoers.d/"$current_user"; then
+          sudo sed -e "s/$current_user/$cwd_user/" /etc/sudoers.d/"$current_user" |
             sudo tee -a /etc/sudoers.d/"$cwd_user"
-        sudo chmod --reference=/etc/sudoers.d/"$current_user" \
+          sudo chmod --reference=/etc/sudoers.d/"$current_user" \
              /etc/sudoers.d/"$cwd_user"
+        fi
     }
 
     # Double sudo to work around some funny restriction in

--- a/zephyr/docker-run.sh
+++ b/zephyr/docker-run.sh
@@ -58,7 +58,7 @@ run_command()
            --workdir /zep_workspace \
            $SOF_DOCKER_RUN \
            --env REAL_CC --env http_proxy --env https_proxy \
-           ghcr.io/zephyrproject-rtos/zephyr-build:latest \
+           ghcr.io/zephyrproject-rtos/ci:latest \
            ./sof/scripts/sudo-cwd.sh "$@"
 }
 


### PR DESCRIPTION
Most of the time is spent in `git pull`; let's see if we can speed that up.

(This is especially painful when working on Github Actions themselves)

Signed-off-by: Marc Herbert <marc.herbert@intel.com>