### PR TITLE
scripts/sudo-cwd.sh: don't try to copy missing sudoers.d/ permissions

### DIFF
--- a/scripts/sudo-cwd.sh
+++ b/scripts/sudo-cwd.sh
@@ -54,10 +54,12 @@ exec_as_cwd_uid()
         local current_user; current_user="$(id -un)"
 
         # Copy sudo permissions just in case the build needs it
-        sudo sed -e "s/$current_user/$cwd_user/" /etc/sudoers.d/"$current_user" |
+        if test -e /etc/sudoers.d/"$current_user"; then
+          sudo sed -e "s/$current_user/$cwd_user/" /etc/sudoers.d/"$current_user" |
             sudo tee -a /etc/sudoers.d/"$cwd_user"
-        sudo chmod --reference=/etc/sudoers.d/"$current_user" \
+          sudo chmod --reference=/etc/sudoers.d/"$current_user" \
              /etc/sudoers.d/"$cwd_user"
+        fi
     }
 
     # Double sudo to work around some funny restriction in


### PR DESCRIPTION
Copying a file that does not exist obviously fails.

This bug was found when trying to switch from the current "Developer Image" to the smaller "CI Image":
https://github.com/zephyrproject-rtos/docker-image/pkgs/container/zephyr-build

Signed-off-by: Marc Herbert <marc.herbert@intel.com>