### PR TITLE
mtl: enlarge HEAPMEM_SIZE to 0x60000

### DIFF
--- a/src/platform/meteorlake/include/platform/lib/memory.h
+++ b/src/platform/meteorlake/include/platform/lib/memory.h
@@ -56,7 +56,7 @@
 /**
  * size of HPSRAM system heap
  */
-#define HEAPMEM_SIZE 0x40000
+#define HEAPMEM_SIZE 0x60000
 
 #endif /* __PLATFORM_LIB_MEMORY_H__ */
 


### PR DESCRIPTION
The heap mem size is not large enough. Enlarge the size to 0x600000.

Signed-off-by: Libin Yang <libin.yang@intel.com>