### PR TITLE
topology: set Speakers PPL running on C1 by default

### DIFF
--- a/tools/topology/topology1/m4/dts_codec_adapter.m4
+++ b/tools/topology/topology1/m4/dts_codec_adapter.m4
@@ -10,8 +10,6 @@ define(`CA_SETUP_CONTROLBYTES',
 define(`CA_SETUP_CONTROLBYTES_MAX', 8192)
 define(`CA_SETUP_CONTROLBYTES_NAME', `DTS Codec Setup ')
 
-define(`CA_SCHEDULE_CORE', 0)
-
 DECLARE_SOF_RT_UUID("DTS codec", dts_uuid, 0xd95fc34f, 0x370f, 0x4ac7, 0xbc, 0x86, 0xbf, 0xdc, 0x5b, 0xe2, 0x41, 0xe6)
 define(`CA_UUID', dts_uuid)
 

--- a/tools/topology/topology1/sof-adl-nau8825.m4
+++ b/tools/topology/topology1/sof-adl-nau8825.m4
@@ -95,6 +95,8 @@ ifdef(`BT_OFFLOAD', `
 
 ifdef(`SPK_MIC_PERIOD_US',`', `define(`SPK_MIC_PERIOD_US', 1000)')
 
+ifdef(`SPK_PLAYBACK_CORE', `', `define(`SPK_PLAYBACK_CORE', `0')')
+
 ifdef(`NO_AMP',,`
 ifdef(`SMART_AMP',`
 # Smart amplifier related
@@ -107,6 +109,8 @@ define(`SMART_SSP_NAME', concat(concat(`SSP', AMP_SSP),`-Codec'))
 define(`SMART_BE_ID', 7)
 #define SSP mclk
 define(`SSP_MCLK', 24576000)
+#define Core ID
+define(`SMART_AMP_CORE', SPK_PLAYBACK_CORE)
 # Playback related
 define(`SMART_PB_PPL_ID', 1)
 define(`SMART_PB_CH_NUM', 2)
@@ -178,7 +182,7 @@ ifdef(`SMART_AMP',,`
 # Schedule 48 frames per 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-demux-playback.m4,
 	1, 0, 2, s32le,
-	SPK_MIC_PERIOD_US, 0, 0,
+	SPK_MIC_PERIOD_US, 0, SPK_PLAYBACK_CORE,
 	48000, 48000, 48000)')')
 
 # Low Latency playback pipeline 2 on PCM 1 using max 2 channels of s32le.
@@ -282,19 +286,19 @@ ifdef(`SMART_AMP',,`
 DAI_ADD(sof/pipe-dai-playback.m4,
         1, SSP, SPK_SSP_INDEX, SPK_SSP_NAME,
         PIPELINE_SOURCE_1, 2, FMT,
-        SPK_MIC_PERIOD_US, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+        SPK_MIC_PERIOD_US, 0, SPK_PLAYBACK_CORE, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # The echo refenrence pipeline has no connections in it,
 # it is used for the capture DAI widget to dock.
 DAI_ADD(sof/pipe-echo-ref-dai-capture.m4,
 	29, SSP, SPK_SSP_INDEX, SPK_SSP_NAME,
 	PIPELINE_SINK_29, 3, FMT,
-	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+	1000, 0, SPK_PLAYBACK_CORE, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # Capture pipeline 9 from demux on PCM 6 using max 2 channels of s32le.
 PIPELINE_PCM_ADD(sof/pipe-passthrough-capture-sched.m4,
 	9, 6, 2, s32le,
-	1000, 1, 0,
+	1000, 1, SPK_PLAYBACK_CORE,
 	48000, 48000, 48000,
 	SCHEDULE_TIME_DOMAIN_TIMER,
 	PIPELINE_PLAYBACK_SCHED_COMP_1)

--- a/tools/topology/topology1/sof-adl-nau8825.m4
+++ b/tools/topology/topology1/sof-adl-nau8825.m4
@@ -95,7 +95,8 @@ ifdef(`BT_OFFLOAD', `
 
 ifdef(`SPK_MIC_PERIOD_US',`', `define(`SPK_MIC_PERIOD_US', 1000)')
 
-ifdef(`SPK_PLAYBACK_CORE', `', `define(`SPK_PLAYBACK_CORE', `0')')
+# Run Speakers pipeline on core#1 by default for low power considering
+ifdef(`SPK_PLAYBACK_CORE', `', `define(`SPK_PLAYBACK_CORE', `1')')
 
 ifdef(`NO_AMP',,`
 ifdef(`SMART_AMP',`

--- a/tools/topology/topology1/sof-eq-iir-dts-codec-smart-amplifier.m4
+++ b/tools/topology/topology1/sof-eq-iir-dts-codec-smart-amplifier.m4
@@ -119,7 +119,7 @@ dnl     time_domain, sched_comp)
 # Set 1000us deadline on core 0 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-eq-iir-dts-codec-smart-amp-playback.m4,
 	SMART_PB_PPL_ID, SMART_PCM_ID, SMART_PB_CH_NUM, s32le,
-	1000, 0, 0,
+	1000, 0, SMART_AMP_CORE,
 	48000, 48000, 48000)
 
 # Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s32le.
@@ -128,13 +128,13 @@ ifelse(SDW, `1',
 `
 PIPELINE_PCM_ADD(sof/pipe-amp-ref-capture.m4,
         SMART_REF_PPL_ID, eval(SMART_PCM_ID + 1), SMART_REF_CH_NUM, s32le,
-        1000, 0, 0,
+        1000, 0, SMART_AMP_CORE,
         48000, 48000, 48000)
 ',
 `
 PIPELINE_PCM_ADD(sof/pipe-amp-ref-capture.m4,
 	SMART_REF_PPL_ID, SMART_PCM_ID, SMART_REF_CH_NUM, s32le,
-	1000, 0, 0,
+	1000, 0, SMART_AMP_CORE,
 	48000, 48000, 48000)
 ')
 
@@ -154,14 +154,14 @@ ifelse(SDW, `1',
 DAI_ADD(sof/pipe-dai-playback.m4,
         SMART_PB_PPL_ID, ALH, SMART_ALH_INDEX, SMART_ALH_PLAYBACK_NAME,
         SMART_PIPE_SOURCE, 2, s24le,
-        1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+        1000, 0, SMART_AMP_CORE, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is ALH(ALH_INDEX) using 2 periods
 # Buffers use s32le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
         SMART_REF_PPL_ID, ALH, eval(SMART_ALH_INDEX + 1), SMART_ALH_CAPTURE_NAME,
         SMART_PIPE_SINK, 2, s24le,
-        1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+        1000, 0, SMART_AMP_CORE, SCHEDULE_TIME_DOMAIN_TIMER)
 ',
 `
 # playback DAI is SSP(SPP_INDEX) using 2 periods
@@ -169,14 +169,14 @@ DAI_ADD(sof/pipe-dai-capture.m4,
 DAI_ADD(sof/pipe-dai-playback.m4,
 	SMART_PB_PPL_ID, SSP, SMART_SSP_INDEX, SMART_SSP_NAME,
 	SMART_PIPE_SOURCE, 2, s32le,
-	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+	1000, 0, SMART_AMP_CORE, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is SSP(SSP_INDEX) using 2 periods
 # Buffers use s32le format, 1000us deadline on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	SMART_REF_PPL_ID, SSP, SMART_SSP_INDEX, SMART_SSP_NAME,
 	SMART_PIPE_SINK, 2, s32le,
-	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+	1000, 0, SMART_AMP_CORE, SCHEDULE_TIME_DOMAIN_TIMER)
 ')
 
 # Connect demux to smart_amp

--- a/tools/topology/topology1/sof-tgl-max98357a-rt5682.m4
+++ b/tools/topology/topology1/sof-tgl-max98357a-rt5682.m4
@@ -158,7 +158,8 @@ ifdef(`GOOGLE_RTC_AUDIO_PROCESSING',
 		`define(`DMIC_48k_PERIOD_US', 5000)')'
 )
 
-ifdef(`GOOGLE_RTC_AUDIO_PROCESSING', `define(`SPK_PLAYBACK_CORE', DMIC_PIPELINE_48k_CORE_ID)', `define(`SPK_PLAYBACK_CORE', `0')')
+ifdef(`GOOGLE_RTC_AUDIO_PROCESSING', `define(`SPK_PLAYBACK_CORE', DMIC_PIPELINE_48k_CORE_ID)',
+        `ifdef(`SPK_PLAYBACK_CORE', `', `define(`SPK_PLAYBACK_CORE', `0')')')
 
 # Google RTC Audio processing processes 10ms at a time. It needs to have time to process it.
 ifdef(`GOOGLE_RTC_AUDIO_PROCESSING', `define(`DMIC_48k_PERIOD', 10000)', `')

--- a/tools/topology/topology1/sof-tgl-max98357a-rt5682.m4
+++ b/tools/topology/topology1/sof-tgl-max98357a-rt5682.m4
@@ -158,8 +158,9 @@ ifdef(`GOOGLE_RTC_AUDIO_PROCESSING',
 		`define(`DMIC_48k_PERIOD_US', 5000)')'
 )
 
+# Run Speakers pipeline on core#1 by default for low power considering
 ifdef(`GOOGLE_RTC_AUDIO_PROCESSING', `define(`SPK_PLAYBACK_CORE', DMIC_PIPELINE_48k_CORE_ID)',
-        `ifdef(`SPK_PLAYBACK_CORE', `', `define(`SPK_PLAYBACK_CORE', `0')')')
+        `ifdef(`SPK_PLAYBACK_CORE', `', `define(`SPK_PLAYBACK_CORE', `1')')')
 
 # Google RTC Audio processing processes 10ms at a time. It needs to have time to process it.
 ifdef(`GOOGLE_RTC_AUDIO_PROCESSING', `define(`DMIC_48k_PERIOD', 10000)', `')

--- a/tools/topology/topology1/sof-tgl-max98373-rt5682.m4
+++ b/tools/topology/topology1/sof-tgl-max98373-rt5682.m4
@@ -38,7 +38,8 @@ DEBUG_START
 # PCM99 <---- volume <---- DMIC01 (dmic 48k capture)
 # PCM100 <---- kpb <---- DMIC16K (dmic 16k capture)
 
-ifdef(`SPK_PLAYBACK_CORE', `', `define(`SPK_PLAYBACK_CORE', `0')')
+# Run Speakers pipeline on core#1 by default for low power considering
+ifdef(`SPK_PLAYBACK_CORE', `', `define(`SPK_PLAYBACK_CORE', `1')')
 
 ifdef(`AMP_SSP',`',`fatal_error(note: Define AMP_SSP for speaker amp SSP Index)')
 # Smart amplifier related

--- a/tools/topology/topology1/sof-tgl-max98373-rt5682.m4
+++ b/tools/topology/topology1/sof-tgl-max98373-rt5682.m4
@@ -38,6 +38,7 @@ DEBUG_START
 # PCM99 <---- volume <---- DMIC01 (dmic 48k capture)
 # PCM100 <---- kpb <---- DMIC16K (dmic 16k capture)
 
+ifdef(`SPK_PLAYBACK_CORE', `', `define(`SPK_PLAYBACK_CORE', `0')')
 
 ifdef(`AMP_SSP',`',`fatal_error(note: Define AMP_SSP for speaker amp SSP Index)')
 # Smart amplifier related
@@ -50,6 +51,8 @@ define(`SMART_SSP_NAME', concat(concat(`SSP', AMP_SSP),`-Codec'))
 define(`SMART_BE_ID', 7)
 #define SSP mclk
 define(`SSP_MCLK', 24576000)
+# Run Smart Amp pipeline on core#1 by default for low power considering
+define(`SMART_AMP_CORE', SPK_PLAYBACK_CORE)
 # Playback related
 define(`SMART_PB_PPL_ID', 1)
 define(`SMART_PB_CH_NUM', 2)


### PR DESCRIPTION
For Intel platforms, C0 is on by default for processes necessary to run in low power cases, while C1..3 for processes with higher loads. This commit moves the default core to C1 for Speakers pipeline.

At the same time, we found this commit can resolve the DSP panic issue on builds with 3P post-processing solutions running on Speakers pipeline.