### PR TITLE
copier: fix allocation and configuration size

### DIFF
--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -22,6 +22,7 @@
 #include <sof/lib/notifier.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
+#include <rtos/spinlock.h>
 #include <rtos/string.h>
 #include <sof/ut.h>
 #include <sof/trace/trace.h>
@@ -192,36 +193,55 @@ static int dai_get_hw_params(struct dai *dai, struct sof_ipc_stream_params  *par
 /* called from ipc/ipc3/dai.c */
 int dai_get_handshake(struct dai *dai, int direction, int stream_id)
 {
-	const struct dai_properties *props = dai_get_properties(dai->dev, direction, stream_id);
+	k_spinlock_key_t key = k_spin_lock(&dai->lock);
+	const struct dai_properties *props = dai_get_properties(dai->dev, direction,
+								stream_id);
+	int hs_id = props->dma_hs_id;
 
-	return props->dma_hs_id;
+	k_spin_unlock(&dai->lock, key);
+
+	return hs_id;
 }
 
 /* called from ipc/ipc3/dai.c and ipc/ipc4/dai.c */
 int dai_get_fifo_depth(struct dai *dai, int direction)
 {
 	const struct dai_properties *props;
+	k_spinlock_key_t key;
+	int fifo_depth;
 
 	if (!dai)
 		return 0;
 
+	key = k_spin_lock(&dai->lock);
 	props = dai_get_properties(dai->dev, direction, 0);
+	fifo_depth = props->fifo_depth;
+	k_spin_unlock(&dai->lock, key);
 
-	return props->fifo_depth;
+	return fifo_depth;
 }
 
 int dai_get_stream_id(struct dai *dai, int direction)
 {
+	k_spinlock_key_t key = k_spin_lock(&dai->lock);
 	const struct dai_properties *props = dai_get_properties(dai->dev, direction, 0);
+	int stream_id = props->stream_id;
 
-	return props->stream_id;
+	k_spin_unlock(&dai->lock, key);
+
+	return stream_id;
 }
 
 static int dai_get_fifo(struct dai *dai, int direction, int stream_id)
 {
-	const struct dai_properties *props = dai_get_properties(dai->dev, direction, stream_id);
+	k_spinlock_key_t key = k_spin_lock(&dai->lock);
+	const struct dai_properties *props = dai_get_properties(dai->dev, direction,
+								stream_id);
+	int fifo_address = props->fifo_address;
 
-	return props->fifo_address;
+	k_spin_unlock(&dai->lock, key);
+
+	return fifo_address;
 }
 
 /* this is called by DMA driver every time descriptor has completed */
@@ -339,6 +359,8 @@ static struct comp_dev *dai_new(const struct comp_driver *drv,
 		comp_cl_err(&comp_dai, "dai_new(): dma_get() failed to get shared access to DMA.");
 		goto error;
 	}
+
+	k_spinlock_init(&dd->dai->lock);
 
 	dma_sg_init(&dd->config.elem_array);
 	dd->xrun = 0;
@@ -1398,13 +1420,18 @@ static int dai_ts_stop_op(struct comp_dev *dev)
 uint32_t dai_get_init_delay_ms(struct dai *dai)
 {
 	const struct dai_properties *props;
+	k_spinlock_key_t key;
+	uint32_t init_delay;
 
 	if (!dai)
 		return 0;
 
+	key = k_spin_lock(&dai->lock);
 	props = dai_get_properties(dai->dev, 0, 0);
+	init_delay = props->reg_init_delay;
+	k_spin_unlock(&dai->lock, key);
 
-	return props->reg_init_delay;
+	return init_delay;
 }
 
 static uint64_t dai_get_processed_data(struct comp_dev *dev, uint32_t stream_no, bool input)

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -11,7 +11,6 @@
 #include <sof/audio/pipeline.h>
 #include <sof/common.h>
 #include <sof/debug/panic.h>
-#include <rtos/interrupt.h>
 #include <sof/ipc/msg.h>
 #include <rtos/interrupt.h>
 #include <rtos/timer.h>

--- a/src/audio/pipeline/pipeline-stream.c
+++ b/src/audio/pipeline/pipeline-stream.c
@@ -322,9 +322,20 @@ static int pipeline_comp_trigger(struct comp_dev *current,
 	case COMP_TRIGGER_PRE_RELEASE:
 	case COMP_TRIGGER_PRE_START:
 		if (comp_get_endpoint_type(current) == COMP_ENDPOINT_DAI) {
-			struct dai_data *dd = comp_get_drvdata(current);
+			/*
+			 * Initialization delay is only used with SSP, where we
+			 * don't use more than one DAI per copier
+			 */
+			struct comp_dev *dai = comp_get_dai(current, 0);
 
-			ppl_data->delay_ms = dai_get_init_delay_ms(dd->dai);
+			if (dai) {
+				struct dai_data *dd = comp_get_drvdata(dai);
+
+				ppl_data->delay_ms = dai_get_init_delay_ms(dd->dai);
+			} else {
+				/* Chain DMA case */
+				ppl_data->delay_ms = 0;
+			}
 		}
 		break;
 	default:

--- a/src/include/ipc4/copier.h
+++ b/src/include/ipc4/copier.h
@@ -327,6 +327,11 @@ typedef void (* channel_copy_func)(struct audio_stream __sparse_cache *dst,
 				   int src_channel, int frame_count);
 
 struct copier_data {
+	/*
+	 * struct ipc4_copier_module_cfg actually has variable size, but we
+	 * don't need the variable size array at the end, we won't be copying it
+	 * from the IPC data.
+	 */
 	struct ipc4_copier_module_cfg config;
 	struct comp_dev *endpoint[IPC4_COPIER_MODULE_OUTPUT_PINS_COUNT];
 	struct comp_buffer *endpoint_buffer[IPC4_COPIER_MODULE_OUTPUT_PINS_COUNT];

--- a/src/include/sof/audio/component_ext.h
+++ b/src/include/sof/audio/component_ext.h
@@ -316,6 +316,26 @@ static inline int comp_get_endpoint_type(struct comp_dev *dev)
 	}
 }
 
+#if CONFIG_IPC_MAJOR_4
+#include <ipc4/copier.h>
+static inline struct comp_dev *comp_get_dai(struct comp_dev *parent, int index)
+{
+	struct copier_data *cd = comp_get_drvdata(parent);
+
+	if (index >= ARRAY_SIZE(cd->endpoint))
+		return NULL;
+
+	return cd->endpoint[index];
+}
+#elif CONFIG_IPC_MAJOR_3
+static inline struct comp_dev *comp_get_dai(struct comp_dev *parent, int index)
+{
+	return parent;
+}
+#else
+#error Unknown IPC major version
+#endif
+
 /**
  * Called to check whether component schedules its pipeline.
  * @param dev Component device.

--- a/src/include/sof/lib/dai-zephyr.h
+++ b/src/include/sof/lib/dai-zephyr.h
@@ -49,6 +49,7 @@ struct dai {
 	uint32_t dma_dev;
 	const struct device *dev;
 	const struct dai_data *dd;
+	struct k_spinlock lock;		/* protect properties */
 };
 
 struct timestamp_cfg {


### PR DESCRIPTION
Copier configuration size must include the variable size array in struct ipc4_copier_gateway_cfg.
