### PR TITLE
memory: Add virtual memory regions gathering and structs

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -450,6 +450,11 @@ if (CONFIG_ACE_VERSION_1_5)
 		${SOF_SRC_PATH}/schedule/zephyr_ll.c
 	)
 
+	# Sources for virtual heap management
+	zephyr_library_sources(
+		lib/regions_mm.c
+	)
+
 	zephyr_library_sources_ifdef(CONFIG_CAVS_LPS
 		${SOF_PLATFORM_PATH}/intel/ace/lps_wait.c
 	)

--- a/zephyr/include/sof/lib/regions_mm.h
+++ b/zephyr/include/sof/lib/regions_mm.h
@@ -1,0 +1,40 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright(c) 2022 Intel Corporation. All rights reserved.
+ *
+ * Author: Jakub Dabek <jakub.dabek@intel.com>
+ */
+
+#ifndef ZEPHYR_LIB_REGIONS_MM_H_
+#define ZEPHYR_LIB_REGIONS_MM_H_
+
+#include <adsp_memory.h>
+#include <adsp_memory_regions.h>
+#include <zephyr/drivers/mm/system_mm.h>
+#include <zephyr/sys/mem_blocks.h>
+#include <zephyr/init.h>
+#include <ipc/topology.h>
+
+/*
+ * Struct containing information on virtual memory heap.
+ * Information about allocated physical blocks is stored in
+ * physical_blocks_allocators variable and uses zephyr memblocks api.
+ */
+struct virtual_memory_heap {
+	/* zephyr provided virtual region */
+	struct sys_mm_drv_region *virtual_region;
+	/* physical pages allocators represented in memblocks */
+	struct sys_multi_mem_blocks physical_blocks_allocators;
+	/* SOF memory capability */
+	uint32_t memory_caps;
+};
+
+/* Available externaly array containing all information on virtual heaps
+ * Used to control physical allocations and overall virtual to physicall
+ * mapping on sof side (zephyr handles the actual assigning physical memory
+ * sof only requests it).
+ */
+extern struct virtual_memory_heap
+	vm_heaps[CONFIG_MP_MAX_NUM_CPUS + VIRTUAL_REGION_COUNT];
+
+#endif /* ZEPHYR_LIB_REGIONS_MM_H_ */

--- a/zephyr/lib/regions_mm.c
+++ b/zephyr/lib/regions_mm.c
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright(c) 2022 Intel Corporation. All rights reserved.
+ *
+ * Author: Jakub Dabek <jakub.dabek@intel.com>
+ */
+
+#include <sof/lib/regions_mm.h>
+
+struct virtual_memory_heap
+	vm_heaps[CONFIG_MP_MAX_NUM_CPUS + VIRTUAL_REGION_COUNT];
+
+/**
+ * @brief Fill vm_heaps array with information from zephyr.
+ *
+ * Virtual memory regions calculated in zephyr are translated here
+ * to a struct that will keep all information on current allocations
+ * and virtual to physical mappings that are related to heaps.
+ * System heap is not a part of this information. It only refers to
+ * virtual first heaps.
+ * Has to be initialized after calculations for regions is done in zephyr.
+ */
+static int virtual_heaps_init(const struct device *unused)
+{
+	ARG_UNUSED(unused);
+
+	struct sys_mm_drv_region *virtual_memory_regions =
+		(struct sys_mm_drv_region *)sys_mm_drv_query_memory_regions();
+
+	for (size_t i = 0;
+		i < CONFIG_MP_MAX_NUM_CPUS + VIRTUAL_REGION_COUNT;
+		i++) {
+		vm_heaps[i].virtual_region = &virtual_memory_regions[i];
+
+		switch (virtual_memory_regions[i].attr)	{
+		case MEM_REG_ATTR_CORE_HEAP:
+			vm_heaps[i].memory_caps =
+				SOF_MEM_CAPS_RAM | SOF_MEM_CAPS_HP | SOF_MEM_CAPS_CACHE;
+			break;
+		case MEM_REG_ATTR_SHARED_HEAP:
+			vm_heaps[i].memory_caps = SOF_MEM_CAPS_RAM | SOF_MEM_CAPS_HP;
+			break;
+		case MEM_REG_ATTR_OPPORTUNISTIC_MEMORY:
+			vm_heaps[i].memory_caps = SOF_MEM_CAPS_RAM | SOF_MEM_CAPS_HP;
+			break;
+		default:
+			return -EINVAL;
+		}
+	}
+
+	return 0;
+}
+
+SYS_INIT(virtual_heaps_init, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);


### PR DESCRIPTION
Add virtual memory regions info gathering from zephyr and introduce structs agregating this information.
Add proper defines for memory managment.

Signed-off-by: Jakub Dabek <jakub.dabek@intel.com>