### PR TITLE
[SKIP CI] github: add new SPDX-README.md and show it when checkpatch fails

### DIFF
--- a/.github/workflows/SPDX-README.md
+++ b/.github/workflows/SPDX-README.md
@@ -1,0 +1,31 @@
+Pleasing checkpatch is hard when adding new files because:
+
+- checkpatch wants a different SPDX style for .c versus .h files!
+- SOF rejects C99 comments starting with //
+
+The trick is to keep the SPDX separate. See solution below.
+
+References:
+- https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Documentation/process/license-rules.rst#n71
+- https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=9f3a89926d6d
+
+
+Start .h files like this:
+```
+/* SPDX-License-Identifier: ... */
+/*
+ * Copyright(c) ...
+ *
+ * Author: ...
+ */
+```
+
+Start .c files like this:
+```
+// SPDX-License-Identifier: ...
+/*
+ * Copyright(c) ...
+ *
+ * Author: ...
+ */
+```

--- a/.github/workflows/checkpatch_list.sh
+++ b/.github/workflows/checkpatch_list.sh
@@ -16,6 +16,11 @@ main()
         ./scripts/checkpatch.pl $@ -g $sha || failures=$((failures+1))
     done
     printf '\n    -------------- \n\n'
+
+    if [ $failures -ne 0 ]; then
+        cat .github/workflows/SPDX-README.md
+    fi
+
     return $failures
 }
 


### PR DESCRIPTION
Pleasing checkpatch is hard when adding new files.

This is tricky and comes up every time someone adds new files, examples in #6284, #6796, #6931 , etc.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>