### PR TITLE
dai: change to use new version of dai_config_get

### DIFF
--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -378,16 +378,18 @@ static int dai_comp_get_hw_params(struct comp_dev *dev,
 				  int dir)
 {
 	struct dai_data *dd = comp_get_drvdata(dev);
-	const struct dai_config *cfg = dai_config_get(dd->dai->dev, dir);
+	struct dai_config cfg;
+	int ret;
 
 	comp_dbg(dev, "dai_hw_params()");
 
-	if (!cfg)
-		return -EINVAL;
+	ret = dai_config_get(dd->dai->dev, &cfg, dir);
+	if (ret)
+		return ret;
 
-	params->rate = cfg->rate;
+	params->rate = cfg.rate;
 	params->buffer_fmt = 0;
-	params->channels = cfg->channels;
+	params->channels = cfg.channels;
 
 	/* dai_comp_get_hw_params() function fetches hardware dai parameters,
 	 * which then are propagating back through the pipeline, so that any
@@ -397,7 +399,7 @@ static int dai_comp_get_hw_params(struct comp_dev *dev,
 	 */
 	params->frame_fmt = dev->ipc_config.frame_fmt;
 
-	return 0;
+	return ret;
 }
 
 static int dai_comp_hw_params(struct comp_dev *dev, struct sof_ipc_stream_params *params)

--- a/src/lib/dai.c
+++ b/src/lib/dai.c
@@ -149,15 +149,16 @@ const struct device *zephyr_dev[] = {
 
 static const struct device *dai_get_zephyr_device(uint32_t type, uint32_t index)
 {
-	const struct dai_config *cfg;
+	struct dai_config cfg;
 	int dir;
 	int i;
 
 	dir = (type == SOF_DAI_INTEL_DMIC) ? DAI_DIR_RX : DAI_DIR_BOTH;
 
 	for (i = 0; i < ARRAY_SIZE(zephyr_dev); i++) {
-		cfg = dai_config_get(zephyr_dev[i], dir);
-		if (cfg && cfg->type == type && cfg->dai_index == index)
+		if (dai_config_get(zephyr_dev[i], &cfg, dir))
+			continue;
+		if (cfg.type == type && cfg.dai_index == index)
 			return zephyr_dev[i];
 	}
 

--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 0c0d73721edb808b51a7ab136cfe01d1b2c1f87d
+      revision: 9af2789cad17924298d705b99a1bca5f35ea88e2
       remote: zephyrproject
       # Import some projects listed in zephyr/west.yml@revision
       #


### PR DESCRIPTION
Start using new version of dai_config_get where config struct is given as pointer argument from outside.

Signed-off-by: Jaska Uimonen <jaska.uimonen@intel.com>