### PR TITLE
Tools: Topology1: Add three demuxed PCMs for DMIC capture example

### DIFF
--- a/tools/topology/topology1/development/CMakeLists.txt
+++ b/tools/topology/topology1/development/CMakeLists.txt
@@ -31,9 +31,10 @@ set(TPLGS
 	"sof-imx8mp-compr-mp3-wm8960\;sof-imx8mp-compr-mp3-wm8960"
 	"sof-apl-nocodec-demux-eq-4ch4ch\;sof-apl-nocodec-demux-eq-4ch4ch"
 	"sof-apl-nocodec-demux-eq-2ch4ch\;sof-apl-nocodec-demux-eq-2ch4ch"
-
 	"sof-hda-generic-kwd\;sof-hda-generic-2ch-kwd\;-DCHANNELS=2\;-DDYNAMIC=1"
 	"sof-hda-generic-kwd\;sof-hda-generic-4ch-kwd\;-DCHANNELS=4\;-DDYNAMIC=1"
+	"sof-hda-generic-2ch-demux-3pcm\;sof-hda-generic-2ch-demux-3pcm"
+	"sof-hda-generic-2ch-demux-demux-3pcm\;sof-hda-generic-2ch-demux-demux-3pcm"
 )
 
 

--- a/tools/topology/topology1/development/sof-hda-generic-2ch-demux-3pcm.m4
+++ b/tools/topology/topology1/development/sof-hda-generic-2ch-demux-3pcm.m4
@@ -1,0 +1,324 @@
+# Topology for SKL+ HDA Generic machine
+#
+
+# if XPROC is not defined, define with default pipe
+ifdef(`HSPROC', , `define(HSPROC, volume)')
+
+# Include topology builder
+include(`utils.m4')
+include(`dai.m4')
+include(`pipeline.m4')
+include(`hda.m4')
+include(`muxdemux.m4')
+
+# Include TLV library
+include(`common/tlv.m4')
+
+# Include Token library
+include(`sof/tokens.m4')
+
+# Include bxt DSP configuration
+include(`platform/intel/bxt.m4')
+
+# Intel DMIC
+include(`platform/intel/dmic.m4')
+
+# The pipeline naming notation is pipe-mixer-PROCESSING-dai-DIRECTION.m4
+# HSPROC is set by makefile, if not the default above is applied
+define(PIPE_HEADSET_PLAYBACK, `sof/pipe-mixer-`HSPROC'-dai-playback.m4')
+
+#
+# Define the pipelines
+#
+# PCM0P --> volume     (pipe 1) --> HDA Analog (HDA Analog playback)
+# PCM0C <-- volume, EQ (pipe 2) <-- HDA Analog (HDA Analog capture)
+# PCM3  ----> volume (pipe 7) ----> iDisp1 (HDMI/DP playback, BE link 3)
+# PCM4  ----> Volume (pipe 8) ----> iDisp2 (HDMI/DP playback, BE link 4)
+# PCM5  ----> volume (pipe 9) ----> iDisp3 (HDMI/DP playback, BE link 5)
+#
+
+# If HSPROC_FILTERx is defined set PIPELINE_FILTERx
+ifdef(`HSPROC_FILTER1', `define(PIPELINE_FILTER1, HSPROC_FILTER1)', `undefine(`PIPELINE_FILTER1')')
+ifdef(`HSPROC_FILTER2', `define(PIPELINE_FILTER2, HSPROC_FILTER2)', `undefine(`PIPELINE_FILTER2')')
+
+# Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s24le.
+# 1000us deadline with priority 0 on core 0
+PIPELINE_PCM_ADD(sof/pipe-highpass-capture.m4,
+	2, 0, 2, s24le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency playback pipeline 7 on PCM 3 using max 2 channels of s24le.
+# 1000us deadline with priority 0 on core 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+        7, 3, 2, s24le,
+        1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency playback pipeline 8 on PCM 4 using max 2 channels of s24le.
+# 1000us deadline with priority 0 on core 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+        8, 4, 2, s24le,
+        1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency playback pipeline 9 on PCM 5 using max 2 channels of s24le.
+# 1000us deadline with priority 0 on core 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+        9, 5, 2, s24le,
+        1000, 0, 0,
+	48000, 48000, 48000)
+
+#
+# DAIs configuration
+#
+
+# playback DAI is HDA Analog using 2 periods
+# Dai buffers use s32le format, 1000us deadline with priority 0 on core 0
+# The 'NOT_USED_IGNORED' is due to dependencies and is adjusted later with an explicit dapm line.
+DAI_ADD(PIPE_HEADSET_PLAYBACK,
+        1, HDA, 0, Analog Playback and Capture,
+        NOT_USED_IGNORED, 2, s32le,
+        1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER, 2, 48000)
+
+# Low Latency playback pipeline 1 on PCM 30 using max 2 channels of s32le.
+# 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-host-volume-playback.m4,
+	30, 0, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000,
+	SCHEDULE_TIME_DOMAIN_TIMER,
+	PIPELINE_PLAYBACK_SCHED_COMP_1)
+
+# Deep buffer playback pipeline 31 on PCM 31 using max 2 channels of s32le
+# Set 1000us deadline on core 0 with priority 0.
+# TODO: Modify pipeline deadline to account for deep buffering
+ifdef(`DEEP_BUFFER',
+`
+PIPELINE_PCM_ADD(sof/pipe-host-volume-playback.m4,
+	31, 31, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000,
+	SCHEDULE_TIME_DOMAIN_TIMER,
+	PIPELINE_PLAYBACK_SCHED_COMP_1)
+'
+)
+
+# Undefine PIPELINE_FILTERx to avoid to propagate elsewhere, other endpoints
+# with filters blobs will need similar handling as HSPROC_FILTERx.
+undefine(`PIPELINE_FILTER1')
+undefine(`PIPELINE_FILTER2')
+
+# capture DAI is HDA Analog using 2 periods
+# Dai buffers use s32le format, 1000us deadline with priority 0 on core 0
+DAI_ADD(sof/pipe-dai-capture.m4,
+        2, HDA, 1, Analog Playback and Capture,
+	PIPELINE_SINK_2, 2, s32le,
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+
+# playback DAI is iDisp1 using 2 periods
+# Dai buffers use s32le format, 1000us deadline with priority 0 on core 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+        7, HDA, 4, iDisp1,
+        PIPELINE_SOURCE_7, 2, s32le,
+        1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+
+# playback DAI is iDisp2 using 2 periods
+# Dai buffers use s32le format, 1000us deadline with priority 0 on core 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+        8, HDA, 5, iDisp2,
+        PIPELINE_SOURCE_8, 2, s32le,
+        1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+
+# playback DAI is iDisp3 using 2 periods
+# Dai buffers use s32le format, 1000us deadline with priority 0 on core 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+        9, HDA, 6, iDisp3,
+        PIPELINE_SOURCE_9, 2, s32le,
+        1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+
+SectionGraph."mixer-host" {
+	index "0"
+
+	lines [
+		# connect mixer dai pipelines to PCM pipelines
+		dapm(PIPELINE_MIXER_1, PIPELINE_SOURCE_30)
+ifdef(`DEEP_BUFFER',
+`
+		dapm(PIPELINE_MIXER_1, PIPELINE_SOURCE_31)
+'
+)
+	]
+}
+
+PCM_DUPLEX_ADD(HDA Analog, 0, PIPELINE_PCM_30, PIPELINE_PCM_2)
+ifdef(`DEEP_BUFFER',
+`
+PCM_PLAYBACK_ADD(HDA Analog Deep Buffer, 31, PIPELINE_PCM_31)
+'
+)
+PCM_PLAYBACK_ADD(HDMI1, 3, PIPELINE_PCM_7)
+PCM_PLAYBACK_ADD(HDMI2, 4, PIPELINE_PCM_8)
+PCM_PLAYBACK_ADD(HDMI3, 5, PIPELINE_PCM_9)
+
+#
+# PCM6C <-- volume <-- demux <-- DMIC
+#                      | |
+# PCM7C <-- volume <---+ |
+#                        |
+# PCM8C <-- volume <-----+
+
+define(DMIC_PCM_CHANNELS, `2')
+define(DMIC_48k_PCM_1_NAME, `Passthrough Capture 6')
+define(DMIC_48k_PCM_2_NAME, `Passthrough Capture 7')
+define(DMIC_48k_PCM_3_NAME, `Passthrough Capture 8')
+define(DMIC_PCM_1_48k_ID, `6')
+define(DMIC_PCM_2_48k_ID, `7')
+define(DMIC_PCM_3_48k_ID, `8')
+define(DMIC_DAI_LINK_48k_ID, `6')
+define(DMIC_PIPELINE_1_48k_ID, `10')
+define(DMIC_PIPELINE_2_48k_ID, `11')
+define(DMIC_PIPELINE_3_48k_ID, `12')
+define(DMIC_48k_PERIOD_US, `1000')
+define(DMIC_48k_CORE_ID, `0')
+define(DMIC_DAI_LINK_48k_NAME, `dmic01')
+define(DEF_STEREO_PDM, `STEREO_PDM0')
+
+#
+# Define the demux configure
+#
+dnl Configure demux
+dnl name, pipeline_id, routing_matrix_rows
+dnl Diagonal 1's in routing matrix mean that every input channel is
+dnl copied to corresponding output channels in all output streams.
+dnl I.e. row index is the input channel, 1 means it is copied to
+dnl corresponding output channel (column index), 0 means it is discarded.
+dnl There's a separate matrix for all outputs.
+define(matrix1, `ROUTE_MATRIX(10,
+                             `BITS_TO_BYTE(1, 0, 0 ,0 ,0 ,0 ,0 ,0)',
+                             `BITS_TO_BYTE(0, 1, 0 ,0 ,0 ,0 ,0 ,0)',
+                             `BITS_TO_BYTE(0, 0, 1 ,0 ,0 ,0 ,0 ,0)',
+                             `BITS_TO_BYTE(0, 0, 0 ,1 ,0 ,0 ,0 ,0)',
+                             `BITS_TO_BYTE(0, 0, 0 ,0 ,1 ,0 ,0 ,0)',
+                             `BITS_TO_BYTE(0, 0, 0 ,0 ,0 ,1 ,0 ,0)',
+                             `BITS_TO_BYTE(0, 0, 0 ,0 ,0 ,0 ,1 ,0)',
+                             `BITS_TO_BYTE(0, 0, 0 ,0 ,0 ,0 ,0 ,1)')')
+
+define(matrix2, `ROUTE_MATRIX(11,
+                             `BITS_TO_BYTE(1, 0, 0 ,0 ,0 ,0 ,0 ,0)',
+                             `BITS_TO_BYTE(0, 1, 0 ,0 ,0 ,0 ,0 ,0)',
+                             `BITS_TO_BYTE(0, 0, 1 ,0 ,0 ,0 ,0 ,0)',
+                             `BITS_TO_BYTE(0, 0, 0 ,1 ,0 ,0 ,0 ,0)',
+                             `BITS_TO_BYTE(0, 0, 0 ,0 ,1 ,0 ,0 ,0)',
+                             `BITS_TO_BYTE(0, 0, 0 ,0 ,0 ,1 ,0 ,0)',
+                             `BITS_TO_BYTE(0, 0, 0 ,0 ,0 ,0 ,1 ,0)',
+                             `BITS_TO_BYTE(0, 0, 0 ,0 ,0 ,0 ,0 ,1)')')
+
+define(matrix3, `ROUTE_MATRIX(12,
+                             `BITS_TO_BYTE(1, 0, 0 ,0 ,0 ,0 ,0 ,0)',
+                             `BITS_TO_BYTE(0, 1, 0 ,0 ,0 ,0 ,0 ,0)',
+                             `BITS_TO_BYTE(0, 0, 1 ,0 ,0 ,0 ,0 ,0)',
+                             `BITS_TO_BYTE(0, 0, 0 ,1 ,0 ,0 ,0 ,0)',
+                             `BITS_TO_BYTE(0, 0, 0 ,0 ,1 ,0 ,0 ,0)',
+                             `BITS_TO_BYTE(0, 0, 0 ,0 ,0 ,1 ,0 ,0)',
+                             `BITS_TO_BYTE(0, 0, 0 ,0 ,0 ,0 ,1 ,0)',
+                             `BITS_TO_BYTE(0, 0, 0 ,0 ,0 ,0 ,0 ,1)')')
+
+dnl DAI_ADD(pipeline,
+dnl     pipe id, dai type, dai_index, dai_be,
+dnl     buffer, periods, format,
+dnl     period , priority, core, time_domain,
+dnl     channels, rate, dynamic_pipe)
+DAI_ADD(sof/pipe-dai-demux-capture.m4,
+        13, DMIC, 0, DMIC_DAI_LINK_48k_NAME,
+        NOT_USED_IGNORED, 2, s32le,
+        1000, 0, DMIC_48k_CORE_ID, SCHEDULE_TIME_DOMAIN_TIMER, 2, 48000)
+
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
+	DMIC_PIPELINE_1_48k_ID, DMIC_PCM_1_48k_ID, DMIC_PCM_CHANNELS, s32le,
+	DMIC_48k_PERIOD_US, 0, DMIC_48k_CORE_ID, 48000, 48000, 48000,
+	SCHEDULE_TIME_DOMAIN_TIMER, PIPELINE_DEMUX_CAPTURE_SCHED_COMP_13)
+
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
+	DMIC_PIPELINE_2_48k_ID, DMIC_PCM_2_48k_ID, DMIC_PCM_CHANNELS, s32le,
+	DMIC_48k_PERIOD_US, 0, DMIC_48k_CORE_ID, 48000, 48000, 48000,
+	SCHEDULE_TIME_DOMAIN_TIMER, PIPELINE_DEMUX_CAPTURE_SCHED_COMP_13)
+
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
+	DMIC_PIPELINE_3_48k_ID, DMIC_PCM_3_48k_ID, DMIC_PCM_CHANNELS, s32le,
+	DMIC_48k_PERIOD_US, 0, DMIC_48k_CORE_ID, 48000, 48000, 48000,
+	SCHEDULE_TIME_DOMAIN_TIMER, PIPELINE_DEMUX_CAPTURE_SCHED_COMP_13)
+
+
+# Add pipeline widgets here to pipelines 10, 11, 12 to avoid modify
+# pipe-volume-capture.m4 with W_PIPELINE() addition
+W_PIPELINE_TOP(DMIC_PIPELINE_1_48k_ID, DMIC0.IN, 1000, 0, 0, 1, pipe_dai_schedule_plat)
+W_PIPELINE_TOP(DMIC_PIPELINE_2_48k_ID, DMIC0.IN, 1000, 0, 0, 1, pipe_dai_schedule_plat)
+W_PIPELINE_TOP(DMIC_PIPELINE_3_48k_ID, DMIC0.IN, 1000, 0, 0, 1, pipe_dai_schedule_plat)
+
+dnl name, num_streams, route_matrix list
+MUXDEMUX_CONFIG(demux_priv_13, 3, LIST_NONEWLINE(`', `matrix1,', `matrix2,', `matrix3'))
+
+SectionGraph."dai-demux" {
+	index "0"
+
+	lines [
+		# connect mixer dai pipelines to PCM pipelines
+		dapm(PIPELINE_SINK_10, PIPELINE_DEMUX_SOURCE_13)
+		dapm(PIPELINE_SINK_11, PIPELINE_DEMUX_SOURCE_13)
+		dapm(PIPELINE_SINK_12, PIPELINE_DEMUX_SOURCE_13)
+	]
+}
+
+dnl PCM_DUPLEX_ADD(name, pcm_id, playback, capture)
+dnl PCM_CAPTURE_ADD(name, pipeline, capture)
+PCM_CAPTURE_ADD(DMIC_48k_PCM_1_NAME, DMIC_PCM_1_48k_ID, concat(`PIPELINE_PCM_', DMIC_PIPELINE_1_48k_ID))
+PCM_CAPTURE_ADD(DMIC_48k_PCM_2_NAME, DMIC_PCM_2_48k_ID, concat(`PIPELINE_PCM_', DMIC_PIPELINE_2_48k_ID))
+PCM_CAPTURE_ADD(DMIC_48k_PCM_3_NAME, DMIC_PCM_3_48k_ID, concat(`PIPELINE_PCM_', DMIC_PIPELINE_3_48k_ID))
+
+dnl DAI_CONFIG(type, dai_index, link_id, name, ssp_config/dmic_config)
+DAI_CONFIG(DMIC, 0, DMIC_DAI_LINK_48k_ID, DMIC_DAI_LINK_48k_NAME,
+           DMIC_CONFIG(1, 2400000, 4800000, 40, 60, 48000,
+    	               DMIC_WORD_LENGTH(s32le), 200, DMIC, 0,
+           	       PDM_CONFIG(DMIC, 0, DEF_STEREO_PDM)))
+
+#
+# BE configurations - overrides config in ACPI if present
+#
+
+# HDA outputs
+DAI_CONFIG(HDA, 0, 4, Analog Playback and Capture,
+	HDA_CONFIG(HDA_CONFIG_DATA(HDA, 0, 48000, 2)))
+
+# 3 HDMI/DP outputs (ID: 3,4,5)
+DAI_CONFIG(HDA, 4, 1, iDisp1,
+	HDA_CONFIG(HDA_CONFIG_DATA(HDA, 4, 48000, 2)))
+DAI_CONFIG(HDA, 5, 2, iDisp2,
+	HDA_CONFIG(HDA_CONFIG_DATA(HDA, 5, 48000, 2)))
+DAI_CONFIG(HDA, 6, 3, iDisp3,
+	HDA_CONFIG(HDA_CONFIG_DATA(HDA, 6, 48000, 2)))
+
+
+VIRTUAL_DAPM_ROUTE_IN(codec0_in, HDA, 1, IN, 1)
+VIRTUAL_DAPM_ROUTE_IN(codec1_in, HDA, 3, IN, 2)
+VIRTUAL_DAPM_ROUTE_OUT(codec0_out, HDA, 0, OUT, 3)
+VIRTUAL_DAPM_ROUTE_OUT(codec1_out, HDA, 2, OUT, 4)
+
+# codec2 is not supported in dai links but it exists
+# in dapm routes, so hack this one to HDA1
+VIRTUAL_DAPM_ROUTE_IN(codec2_in, HDA, 3, IN, 5)
+VIRTUAL_DAPM_ROUTE_OUT(codec2_out, HDA, 2, OUT, 6)
+
+VIRTUAL_DAPM_ROUTE_OUT(iDisp1_out, HDA, 4, OUT, 7)
+VIRTUAL_DAPM_ROUTE_OUT(iDisp2_out, HDA, 5, OUT, 8)
+VIRTUAL_DAPM_ROUTE_OUT(iDisp3_out, HDA, 6, OUT, 9)
+
+VIRTUAL_WIDGET(iDisp3 Tx, out_drv, 0)
+VIRTUAL_WIDGET(iDisp2 Tx, out_drv, 1)
+VIRTUAL_WIDGET(iDisp1 Tx, out_drv, 2)
+VIRTUAL_WIDGET(Analog CPU Playback, out_drv, 3)
+VIRTUAL_WIDGET(Digital CPU Playback, out_drv, 4)
+VIRTUAL_WIDGET(Alt Analog CPU Playback, out_drv, 5)
+VIRTUAL_WIDGET(Analog CPU Capture, input, 6)
+VIRTUAL_WIDGET(Digital CPU Capture, input, 7)
+VIRTUAL_WIDGET(Alt Analog CPU Capture, input, 8)

--- a/tools/topology/topology1/development/sof-hda-generic-2ch-demux-demux-3pcm.m4
+++ b/tools/topology/topology1/development/sof-hda-generic-2ch-demux-demux-3pcm.m4
@@ -1,0 +1,374 @@
+# Topology for SKL+ HDA Generic machine
+#
+
+# if XPROC is not defined, define with default pipe
+ifdef(`HSPROC', , `define(HSPROC, volume)')
+
+# Include topology builder
+include(`utils.m4')
+include(`dai.m4')
+include(`pipeline.m4')
+include(`hda.m4')
+include(`muxdemux.m4')
+
+# Include TLV library
+include(`common/tlv.m4')
+
+# Include Token library
+include(`sof/tokens.m4')
+
+# Include bxt DSP configuration
+include(`platform/intel/bxt.m4')
+
+# Intel DMIC
+include(`platform/intel/dmic.m4')
+
+# The pipeline naming notation is pipe-mixer-PROCESSING-dai-DIRECTION.m4
+# HSPROC is set by makefile, if not the default above is applied
+define(PIPE_HEADSET_PLAYBACK, `sof/pipe-mixer-`HSPROC'-dai-playback.m4')
+
+#
+# Define the pipelines
+#
+# PCM0P --> volume     (pipe 1) --> HDA Analog (HDA Analog playback)
+# PCM0C <-- volume, EQ (pipe 2) <-- HDA Analog (HDA Analog capture)
+# PCM3  ----> volume (pipe 7) ----> iDisp1 (HDMI/DP playback, BE link 3)
+# PCM4  ----> Volume (pipe 8) ----> iDisp2 (HDMI/DP playback, BE link 4)
+# PCM5  ----> volume (pipe 9) ----> iDisp3 (HDMI/DP playback, BE link 5)
+#
+
+# If HSPROC_FILTERx is defined set PIPELINE_FILTERx
+ifdef(`HSPROC_FILTER1', `define(PIPELINE_FILTER1, HSPROC_FILTER1)', `undefine(`PIPELINE_FILTER1')')
+ifdef(`HSPROC_FILTER2', `define(PIPELINE_FILTER2, HSPROC_FILTER2)', `undefine(`PIPELINE_FILTER2')')
+
+# Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s24le.
+# 1000us deadline with priority 0 on core 0
+PIPELINE_PCM_ADD(sof/pipe-highpass-capture.m4,
+	2, 0, 2, s24le,
+	1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency playback pipeline 7 on PCM 3 using max 2 channels of s24le.
+# 1000us deadline with priority 0 on core 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+        7, 3, 2, s24le,
+        1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency playback pipeline 8 on PCM 4 using max 2 channels of s24le.
+# 1000us deadline with priority 0 on core 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+        8, 4, 2, s24le,
+        1000, 0, 0,
+	48000, 48000, 48000)
+
+# Low Latency playback pipeline 9 on PCM 5 using max 2 channels of s24le.
+# 1000us deadline with priority 0 on core 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+        9, 5, 2, s24le,
+        1000, 0, 0,
+	48000, 48000, 48000)
+
+#
+# DAIs configuration
+#
+
+# playback DAI is HDA Analog using 2 periods
+# Dai buffers use s32le format, 1000us deadline with priority 0 on core 0
+# The 'NOT_USED_IGNORED' is due to dependencies and is adjusted later with an explicit dapm line.
+DAI_ADD(PIPE_HEADSET_PLAYBACK,
+        1, HDA, 0, Analog Playback and Capture,
+        NOT_USED_IGNORED, 2, s32le,
+        1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER, 2, 48000)
+
+# Low Latency playback pipeline 1 on PCM 30 using max 2 channels of s32le.
+# 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-host-volume-playback.m4,
+	30, 0, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000,
+	SCHEDULE_TIME_DOMAIN_TIMER,
+	PIPELINE_PLAYBACK_SCHED_COMP_1)
+
+# Deep buffer playback pipeline 31 on PCM 31 using max 2 channels of s32le
+# Set 1000us deadline on core 0 with priority 0.
+# TODO: Modify pipeline deadline to account for deep buffering
+ifdef(`DEEP_BUFFER',
+`
+PIPELINE_PCM_ADD(sof/pipe-host-volume-playback.m4,
+	31, 31, 2, s32le,
+	1000, 0, 0,
+	48000, 48000, 48000,
+	SCHEDULE_TIME_DOMAIN_TIMER,
+	PIPELINE_PLAYBACK_SCHED_COMP_1)
+'
+)
+
+# Undefine PIPELINE_FILTERx to avoid to propagate elsewhere, other endpoints
+# with filters blobs will need similar handling as HSPROC_FILTERx.
+undefine(`PIPELINE_FILTER1')
+undefine(`PIPELINE_FILTER2')
+
+# capture DAI is HDA Analog using 2 periods
+# Dai buffers use s32le format, 1000us deadline with priority 0 on core 0
+DAI_ADD(sof/pipe-dai-capture.m4,
+        2, HDA, 1, Analog Playback and Capture,
+	PIPELINE_SINK_2, 2, s32le,
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+
+# playback DAI is iDisp1 using 2 periods
+# Dai buffers use s32le format, 1000us deadline with priority 0 on core 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+        7, HDA, 4, iDisp1,
+        PIPELINE_SOURCE_7, 2, s32le,
+        1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+
+# playback DAI is iDisp2 using 2 periods
+# Dai buffers use s32le format, 1000us deadline with priority 0 on core 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+        8, HDA, 5, iDisp2,
+        PIPELINE_SOURCE_8, 2, s32le,
+        1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+
+# playback DAI is iDisp3 using 2 periods
+# Dai buffers use s32le format, 1000us deadline with priority 0 on core 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+        9, HDA, 6, iDisp3,
+        PIPELINE_SOURCE_9, 2, s32le,
+        1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+
+SectionGraph."mixer-host" {
+	index "0"
+
+	lines [
+		# connect mixer dai pipelines to PCM pipelines
+		dapm(PIPELINE_MIXER_1, PIPELINE_SOURCE_30)
+ifdef(`DEEP_BUFFER',
+`
+		dapm(PIPELINE_MIXER_1, PIPELINE_SOURCE_31)
+'
+)
+	]
+}
+
+PCM_DUPLEX_ADD(HDA Analog, 0, PIPELINE_PCM_30, PIPELINE_PCM_2)
+ifdef(`DEEP_BUFFER',
+`
+PCM_PLAYBACK_ADD(HDA Analog Deep Buffer, 31, PIPELINE_PCM_31)
+'
+)
+PCM_PLAYBACK_ADD(HDMI1, 3, PIPELINE_PCM_7)
+PCM_PLAYBACK_ADD(HDMI2, 4, PIPELINE_PCM_8)
+PCM_PLAYBACK_ADD(HDMI3, 5, PIPELINE_PCM_9)
+
+#
+# PCM8C <-- volume <-- demux <-- volume <-- demux <-- DMIC
+#                        |                    |
+# PCM7C <-------------  -+                    |
+#                                             |
+# PCM6C <-------------------------------------+
+
+define(DMIC_PCM_CHANNELS, `2')
+define(DMIC_48k_PCM_1_NAME, `Passthrough Capture 11')
+define(DMIC_48k_PCM_2_NAME, `Passthrough Capture 13')
+define(DMIC_48k_PCM_3_NAME, `Passthrough Capture 14')
+define(DMIC_PCM_1_48k_ID, `6')
+define(DMIC_PCM_2_48k_ID, `7')
+define(DMIC_PCM_3_48k_ID, `8')
+define(DMIC_DAI_LINK_48k_ID, `6')
+define(DMIC_DAI_LINK_48k_NAME, `dmic01')
+define(DMIC_48k_PERIOD_US, `1000')
+define(DMIC_48k_CORE_ID, `0')
+define(DEF_STEREO_PDM, `STEREO_PDM0')
+
+#
+# Define the demux configure
+#
+dnl Configure demux
+dnl name, pipeline_id, routing_matrix_rows
+dnl Diagonal 1's in routing matrix mean that every input channel is
+dnl copied to corresponding output channels in all output streams.
+dnl I.e. row index is the input channel, 1 means it is copied to
+dnl corresponding output channel (column index), 0 means it is discarded.
+dnl There's a separate matrix for all outputs.
+define(matrix11, `ROUTE_MATRIX(11,
+                             `BITS_TO_BYTE(1, 0, 0 ,0 ,0 ,0 ,0 ,0)',
+                             `BITS_TO_BYTE(0, 1, 0 ,0 ,0 ,0 ,0 ,0)',
+                             `BITS_TO_BYTE(0, 0, 1 ,0 ,0 ,0 ,0 ,0)',
+                             `BITS_TO_BYTE(0, 0, 0 ,1 ,0 ,0 ,0 ,0)',
+                             `BITS_TO_BYTE(0, 0, 0 ,0 ,1 ,0 ,0 ,0)',
+                             `BITS_TO_BYTE(0, 0, 0 ,0 ,0 ,1 ,0 ,0)',
+                             `BITS_TO_BYTE(0, 0, 0 ,0 ,0 ,0 ,1 ,0)',
+                             `BITS_TO_BYTE(0, 0, 0 ,0 ,0 ,0 ,0 ,1)')')
+
+define(matrix12, `ROUTE_MATRIX(12,
+                             `BITS_TO_BYTE(1, 0, 0 ,0 ,0 ,0 ,0 ,0)',
+                             `BITS_TO_BYTE(0, 1, 0 ,0 ,0 ,0 ,0 ,0)',
+                             `BITS_TO_BYTE(0, 0, 1 ,0 ,0 ,0 ,0 ,0)',
+                             `BITS_TO_BYTE(0, 0, 0 ,1 ,0 ,0 ,0 ,0)',
+                             `BITS_TO_BYTE(0, 0, 0 ,0 ,1 ,0 ,0 ,0)',
+                             `BITS_TO_BYTE(0, 0, 0 ,0 ,0 ,1 ,0 ,0)',
+                             `BITS_TO_BYTE(0, 0, 0 ,0 ,0 ,0 ,1 ,0)',
+                             `BITS_TO_BYTE(0, 0, 0 ,0 ,0 ,0 ,0 ,1)')')
+
+define(matrix21, `ROUTE_MATRIX(13,
+                             `BITS_TO_BYTE(1, 0, 0 ,0 ,0 ,0 ,0 ,0)',
+                             `BITS_TO_BYTE(0, 1, 0 ,0 ,0 ,0 ,0 ,0)',
+                             `BITS_TO_BYTE(0, 0, 1 ,0 ,0 ,0 ,0 ,0)',
+                             `BITS_TO_BYTE(0, 0, 0 ,1 ,0 ,0 ,0 ,0)',
+                             `BITS_TO_BYTE(0, 0, 0 ,0 ,1 ,0 ,0 ,0)',
+                             `BITS_TO_BYTE(0, 0, 0 ,0 ,0 ,1 ,0 ,0)',
+                             `BITS_TO_BYTE(0, 0, 0 ,0 ,0 ,0 ,1 ,0)',
+                             `BITS_TO_BYTE(0, 0, 0 ,0 ,0 ,0 ,0 ,1)')')
+
+define(matrix22, `ROUTE_MATRIX(14,
+                             `BITS_TO_BYTE(1, 0, 0 ,0 ,0 ,0 ,0 ,0)',
+                             `BITS_TO_BYTE(0, 1, 0 ,0 ,0 ,0 ,0 ,0)',
+                             `BITS_TO_BYTE(0, 0, 1 ,0 ,0 ,0 ,0 ,0)',
+                             `BITS_TO_BYTE(0, 0, 0 ,1 ,0 ,0 ,0 ,0)',
+                             `BITS_TO_BYTE(0, 0, 0 ,0 ,1 ,0 ,0 ,0)',
+                             `BITS_TO_BYTE(0, 0, 0 ,0 ,0 ,1 ,0 ,0)',
+                             `BITS_TO_BYTE(0, 0, 0 ,0 ,0 ,0 ,1 ,0)',
+                             `BITS_TO_BYTE(0, 0, 0 ,0 ,0 ,0 ,0 ,1)')')
+
+
+dnl DAI_ADD(pipeline,
+dnl     pipe id, dai type, dai_index, dai_be,
+dnl     buffer, periods, format,
+dnl     period , priority, core, time_domain,
+dnl     channels, rate, dynamic_pipe)
+DAI_ADD(sof/pipe-dai-demux-capture.m4,
+        10, DMIC, 0, DMIC_DAI_LINK_48k_NAME,
+        NOT_USED_IGNORED, 2, s32le,
+        1000, 0, DMIC_48k_CORE_ID, SCHEDULE_TIME_DOMAIN_TIMER,
+	2, 48000, 0)
+
+# RAW DAI capture pipeline
+
+dnl PIPELINE_PCM_ADD(pipeline,
+dnl     pipe id, pcm, max channels, format,
+dnl     period, priority, core,
+dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
+dnl     time_domain, sched_comp, dynamic)
+PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
+	11, DMIC_PCM_1_48k_ID, 2, s32le,
+	DMIC_48k_PERIOD_US, 0, DMIC_48k_CORE_ID,
+	48000, 48000, 48000,
+	SCHEDULE_TIME_DOMAIN_TIMER, PIPELINE_DEMUX_CAPTURE_SCHED_COMP_10, 0)
+
+
+# Intermediate processing1-demux pipeline
+# Check: PIPELINE_ADD arg 13 DYNAMIC_PIPE errors -- omit now
+
+dnl PIPELINE_ADD(pipeline,
+dnl     pipe id, max channels, format,
+dnl     period, priority, core,
+dnl     sched_comp, time_domain,
+dnl     pcm_min_rate, pcm_max_rate, pipeline_rate, dynamic)
+PIPELINE_ADD(sof/pipe-volume-demux.m4,
+	12, 2, s32le,
+	DMIC_48k_PERIOD_US, 0, DMIC_48k_CORE_ID,
+	PIPELINE_DEMUX_CAPTURE_SCHED_COMP_10, SCHEDULE_TIME_DOMAIN_TIMER,
+	48000, 48000, 48000)
+
+# Capture PCM pipeline from processing1
+
+dnl PIPELINE_PCM_ADD(pipeline,
+dnl     pipe id, pcm, max channels, format,
+dnl     period, priority, core,
+dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
+dnl     time_domain, sched_comp, dynamic)
+PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
+	13, DMIC_PCM_2_48k_ID, DMIC_PCM_CHANNELS, s32le,
+	DMIC_48k_PERIOD_US, 0, DMIC_48k_CORE_ID,
+	48000, 48000, 48000,
+	SCHEDULE_TIME_DOMAIN_TIMER, PIPELINE_DEMUX_CAPTURE_SCHED_COMP_10, 0)
+
+# Capture PCM pipeline with processing2
+
+dnl PIPELINE_PCM_ADD(pipeline,
+dnl     pipe id, pcm, max channels, format,
+dnl     period, priority, core,
+dnl     pcm_min_rate, pcm_max_rate, pipeline_rate,
+dnl     time_domain, sched_comp, dynamic)
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
+	14, DMIC_PCM_3_48k_ID, DMIC_PCM_CHANNELS, s32le,
+	DMIC_48k_PERIOD_US, 0, DMIC_48k_CORE_ID,
+	48000, 48000, 48000,
+	SCHEDULE_TIME_DOMAIN_TIMER, PIPELINE_DEMUX_CAPTURE_SCHED_COMP_10, 0)
+
+# Add pipeline widgets here to pipelines 11, 13, 34 to avoid modify
+# pipe-passthrough-capture.m4 and pipe-volume-capture.m4 with
+# W_PIPELINE() additions
+W_PIPELINE_TOP(11, DMIC0.IN, 1000, 0, 0, 1, pipe_dai_schedule_plat)
+W_PIPELINE_TOP(13, DMIC0.IN, 1000, 0, 0, 1, pipe_dai_schedule_plat)
+W_PIPELINE_TOP(14, DMIC0.IN, 1000, 0, 0, 1, pipe_dai_schedule_plat)
+
+dnl name, num_streams, route_matrix list
+MUXDEMUX_CONFIG(demux_priv_10, 2, LIST_NONEWLINE(`', `matrix11,', `matrix12'))
+MUXDEMUX_CONFIG(demux_priv_12, 2, LIST_NONEWLINE(`', `matrix21,', `matrix22'))
+
+SectionGraph."dai-demux" {
+	index "0"
+
+	lines [
+		# connect mixer dai pipelines to PCM pipelines
+		dapm(PIPELINE_SINK_11, PIPELINE_DEMUX_SOURCE_10)
+		dapm(PIPELINE_SINK_12, PIPELINE_DEMUX_SOURCE_10)
+		dapm(PIPELINE_SINK_13, PIPELINE_DEMUX_SOURCE_12)
+		dapm(PIPELINE_SINK_14, PIPELINE_DEMUX_SOURCE_12)
+	]
+}
+
+dnl PCM_DUPLEX_ADD(name, pcm_id, playback, capture)
+dnl PCM_CAPTURE_ADD(name, pipeline, capture)
+PCM_CAPTURE_ADD(DMIC_48k_PCM_1_NAME, DMIC_PCM_1_48k_ID, PIPELINE_PCM_11)
+PCM_CAPTURE_ADD(DMIC_48k_PCM_2_NAME, DMIC_PCM_2_48k_ID, PIPELINE_PCM_13)
+PCM_CAPTURE_ADD(DMIC_48k_PCM_3_NAME, DMIC_PCM_3_48k_ID, PIPELINE_PCM_14)
+
+dnl DAI_CONFIG(type, dai_index, link_id, name, ssp_config/dmic_config)
+DAI_CONFIG(DMIC, 0, DMIC_DAI_LINK_48k_ID, DMIC_DAI_LINK_48k_NAME,
+           DMIC_CONFIG(1, 2400000, 4800000, 40, 60, 48000,
+    	               DMIC_WORD_LENGTH(s32le), 200, DMIC, 0,
+           	       PDM_CONFIG(DMIC, 0, DEF_STEREO_PDM)))
+
+#
+# BE configurations - overrides config in ACPI if present
+#
+
+# HDA outputs
+DAI_CONFIG(HDA, 0, 4, Analog Playback and Capture,
+	HDA_CONFIG(HDA_CONFIG_DATA(HDA, 0, 48000, 2)))
+
+# 3 HDMI/DP outputs (ID: 3,4,5)
+DAI_CONFIG(HDA, 4, 1, iDisp1,
+	HDA_CONFIG(HDA_CONFIG_DATA(HDA, 4, 48000, 2)))
+DAI_CONFIG(HDA, 5, 2, iDisp2,
+	HDA_CONFIG(HDA_CONFIG_DATA(HDA, 5, 48000, 2)))
+DAI_CONFIG(HDA, 6, 3, iDisp3,
+	HDA_CONFIG(HDA_CONFIG_DATA(HDA, 6, 48000, 2)))
+
+
+VIRTUAL_DAPM_ROUTE_IN(codec0_in, HDA, 1, IN, 1)
+VIRTUAL_DAPM_ROUTE_IN(codec1_in, HDA, 3, IN, 2)
+VIRTUAL_DAPM_ROUTE_OUT(codec0_out, HDA, 0, OUT, 3)
+VIRTUAL_DAPM_ROUTE_OUT(codec1_out, HDA, 2, OUT, 4)
+
+# codec2 is not supported in dai links but it exists
+# in dapm routes, so hack this one to HDA1
+VIRTUAL_DAPM_ROUTE_IN(codec2_in, HDA, 3, IN, 5)
+VIRTUAL_DAPM_ROUTE_OUT(codec2_out, HDA, 2, OUT, 6)
+
+VIRTUAL_DAPM_ROUTE_OUT(iDisp1_out, HDA, 4, OUT, 7)
+VIRTUAL_DAPM_ROUTE_OUT(iDisp2_out, HDA, 5, OUT, 8)
+VIRTUAL_DAPM_ROUTE_OUT(iDisp3_out, HDA, 6, OUT, 9)
+
+VIRTUAL_WIDGET(iDisp3 Tx, out_drv, 0)
+VIRTUAL_WIDGET(iDisp2 Tx, out_drv, 1)
+VIRTUAL_WIDGET(iDisp1 Tx, out_drv, 2)
+VIRTUAL_WIDGET(Analog CPU Playback, out_drv, 3)
+VIRTUAL_WIDGET(Digital CPU Playback, out_drv, 4)
+VIRTUAL_WIDGET(Alt Analog CPU Playback, out_drv, 5)
+VIRTUAL_WIDGET(Analog CPU Capture, input, 6)
+VIRTUAL_WIDGET(Digital CPU Capture, input, 7)
+VIRTUAL_WIDGET(Alt Analog CPU Capture, input, 8)

--- a/tools/topology/topology1/m4/pipeline.m4
+++ b/tools/topology/topology1/m4/pipeline.m4
@@ -48,6 +48,33 @@ define(`W_PIPELINE',
 `	]'
 `}')
 
+dnl W_PIPELINE_TOP(stream_index, stream_name, period, priority, core, time_domain, platform)
+define(`W_PIPELINE_TOP',
+`SectionVendorTuples."PIPELINE.$1.$2_tuples" {'
+`	tokens "sof_sched_tokens"'
+`	tuples."word" {'
+`		SOF_TKN_SCHED_PERIOD'		STR($3)
+`		SOF_TKN_SCHED_PRIORITY'		STR($4)
+`		SOF_TKN_SCHED_CORE'		STR($5)
+`		SOF_TKN_SCHED_FRAMES'		"0"
+`		SOF_TKN_SCHED_TIME_DOMAIN'	STR($6)
+`		SOF_TKN_SCHED_DYNAMIC_PIPELINE'	ifdef(`DYNAMIC', "1", ifelse(DYNAMIC_PIPE, `1', "1", "0"))
+`	}'
+`}'
+`SectionData."PIPELINE.$1.$2_data" {'
+`	tuples "PIPELINE.$1.$2_tuples"'
+`}'
+`SectionWidget."PIPELINE.$1.$2" {'
+`	index "$1"'
+`	type "scheduler"'
+`	no_pm "true"'
+`	stream_name "'$2`"'
+`	data ['
+`		"PIPELINE.$1.$2_data"'
+`		"'$7`"'
+`	]'
+`}')
+
 dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,
 dnl     period, priority, core,

--- a/tools/topology/topology1/sof/pipe-dai-demux-capture.m4
+++ b/tools/topology/topology1/sof/pipe-dai-demux-capture.m4
@@ -1,0 +1,59 @@
+#  DAI capture connector
+#
+# Pipeline Endpoints for connection are :-
+#
+#	Source DAI
+#       Demux
+#
+# Source DAI 0 --> B0 -> Demux
+#
+
+# Include topology builder
+include(`utils.m4')
+include(`muxdemux.m4')
+include(`bytecontrol.m4')
+include(`buffer.m4')
+include(`dai.m4')
+include(`pipeline.m4')
+
+#
+# Controls
+#
+# demux Bytes control with max value of 255
+C_CONTROLBYTES(concat(`DEMUX', PIPELINE_ID), PIPELINE_ID,
+	CONTROLBYTES_OPS(bytes, 258 binds the mixer control to bytes get/put handlers, 258, 258),
+	CONTROLBYTES_EXTOPS(258 binds the mixer control to bytes get/put handlers, 258, 258),
+	, , ,
+	CONTROLBYTES_MAX(, 304),
+	,	concat(`demux_priv_', PIPELINE_ID))
+
+# Mux 0 has 2 sink and source periods.
+W_MUXDEMUX(0, 1, PIPELINE_FORMAT, 2, 2, SCHEDULE_CORE,
+	LIST(`         ', concat(`DEMUX', PIPELINE_ID)))
+
+#
+# DAI definitions
+#
+W_DAI_IN(DAI_TYPE, DAI_INDEX, DAI_BE, DAI_FORMAT, 0, DAI_PERIODS, SCHEDULE_CORE)
+
+#
+# DAI pipeline - always use 0 for DAIs - FIXME WHY 0?
+#
+W_PIPELINE(N_DAI_IN, SCHEDULE_PERIOD, SCHEDULE_PRIORITY, SCHEDULE_CORE, SCHEDULE_TIME_DOMAIN,
+	pipe_dai_schedule_plat)
+
+# Low Latency Buffers
+W_BUFFER(0, COMP_BUFFER_SIZE(2,
+	COMP_SAMPLE_SIZE(DAI_FORMAT), DAI_CHANNELS, COMP_PERIOD_FRAMES(DAI_RATE, SCHEDULE_PERIOD)),
+	PLATFORM_COMP_MEM_CAP)
+
+#
+# Graph connections to pipelines
+#
+P_GRAPH(pipe-dai-demux-capture, PIPELINE_ID,
+	LIST(`		',
+	`dapm(N_BUFFER(0), N_DAI_IN)',
+	`dapm(N_MUXDEMUX(0), N_BUFFER(0))'))
+
+indir(`define', concat(`PIPELINE_DEMUX_CAPTURE_SCHED_COMP_', PIPELINE_ID), N_DAI_IN)
+indir(`define', concat(`PIPELINE_DEMUX_SOURCE_', PIPELINE_ID), N_MUXDEMUX(0))

--- a/tools/topology/topology1/sof/pipe-volume-demux.m4
+++ b/tools/topology/topology1/sof/pipe-volume-demux.m4
@@ -1,0 +1,92 @@
+# Capture pipeline part with volume processing and demux
+#
+# Pipeline Endpoints for connection are :-
+#
+#  demux <-- B0 <-- Volume 0 <-- B1
+
+# Include topology builder
+include(`utils.m4')
+include(`buffer.m4')
+include(`pcm.m4')
+include(`pga.m4')
+include(`dai.m4')
+include(`pipeline.m4')
+include(`bytecontrol.m4')
+include(`mixercontrol.m4')
+include(`muxdemux.m4')
+
+
+#
+# Controls
+#
+
+# Volume Mixer control with max value of 32
+C_CONTROLMIXER(Capture Volume, PIPELINE_ID,
+	CONTROLMIXER_OPS(volsw,
+		256 binds the mixer control to volume get/put handlers,
+		256, 256),
+	CONTROLMIXER_MAX(, 70),
+	false,
+	CONTROLMIXER_TLV(TLV 80 steps from -50dB to +20dB for 1dB, vtlv_m50s1),
+	Channel register and shift for Front Left/Right,
+	VOLUME_CHANNEL_MAP)
+
+# demux Bytes control with max value of 255
+C_CONTROLBYTES(concat(`DEMUX', PIPELINE_ID), PIPELINE_ID,
+	CONTROLBYTES_OPS(bytes, 258 binds the mixer control to bytes get/put handlers, 258, 258),
+	CONTROLBYTES_EXTOPS(258 binds the mixer control to bytes get/put handlers, 258, 258),
+	, , ,
+	CONTROLBYTES_MAX(, 304),
+	,	concat(`demux_priv_', PIPELINE_ID))
+
+# Volume Configuration
+define(DEF_PGA_TOKENS, concat(`pga_tokens_', PIPELINE_ID))
+define(DEF_PGA_CONF, concat(`pga_conf_', PIPELINE_ID))
+
+W_VENDORTUPLES(DEF_PGA_TOKENS, sof_volume_tokens,
+LIST(`		', `SOF_TKN_VOLUME_RAMP_STEP_TYPE	"0"'
+     `		', `SOF_TKN_VOLUME_RAMP_STEP_MS		"250"'))
+
+W_DATA(DEF_PGA_CONF, DEF_PGA_TOKENS)
+
+#
+# Components and Buffers
+#
+
+# "Volume" has 2 source and 2 sink periods
+W_PGA(0, PIPELINE_FORMAT, 2, 2, DEF_PGA_CONF, SCHEDULE_CORE,
+	LIST(`		', "PIPELINE_ID Capture Volume"))
+
+# Mux has 2 sink and 2 source periods.
+W_MUXDEMUX(0, 1, PIPELINE_FORMAT, 2, 2, SCHEDULE_CORE,
+	LIST(`         ', concat(`DEMUX', PIPELINE_ID)))
+
+# Capture Buffers
+W_BUFFER(0, COMP_BUFFER_SIZE(2,
+	COMP_SAMPLE_SIZE(PIPELINE_FORMAT), PIPELINE_CHANNELS,
+	COMP_PERIOD_FRAMES(PCM_MAX_RATE, SCHEDULE_PERIOD)), PLATFORM_PASS_MEM_CAP)
+
+W_BUFFER(1, COMP_BUFFER_SIZE(2,
+	COMP_SAMPLE_SIZE(PIPELINE_FORMAT), PIPELINE_CHANNELS,
+	COMP_PERIOD_FRAMES(PCM_MAX_RATE, SCHEDULE_PERIOD)), PLATFORM_PASS_MEM_CAP)
+
+W_PIPELINE(SCHED_COMP, SCHEDULE_PERIOD, SCHEDULE_PRIORITY, SCHEDULE_CORE, SCHEDULE_TIME_DOMAIN, pipe_dai_schedule_plat)
+
+#
+# Pipeline Graph
+#
+#  demux <-- B0 <-- Volume 0 <-- B1
+
+P_GRAPH(pipe-volume-demux, PIPELINE_ID,
+	LIST(`		',
+	`dapm(N_MUXDEMUX(0), N_BUFFER(0))',
+	`dapm(N_BUFFER(0), N_PGA(0))',
+	`dapm(N_PGA(0), N_BUFFER(1))'))
+#
+# Pipeline Source and Sinks
+#
+indir(`define', concat(`PIPELINE_SINK_', PIPELINE_ID), N_BUFFER(1))
+indir(`define', concat(`PIPELINE_DEMUX_SOURCE_', PIPELINE_ID), N_MUXDEMUX(0))
+
+undefine(`DEF_PGA_TOKENS')
+undefine(`DEF_PGA_CONF')


### PR DESCRIPTION
The topology sof-hda-generic-2ch-demux-3pcm.tplg uses a single demux to duplicate three times the same DMIC DAI capture.

The topology sof-hda-generic-2ch-demux-demux-3pcm.tplg uses two demux components to provide to PCMs raw DMIC capture, processing after PGA12.0, and processing after PGA12.0 and PGA14.0.

The patch adds to pipeline.m4 a modified version of macro W_PIPELINE() called W_PIPELINE_TOP() that can be used to add from top level topology pipeline widgets to pipelines those are missing it. It avoids topology load error.

Added pipelines pipe-dai-demux-capture.m4 and pipe-volume-demux.m4 are needed in these two example topologies.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>