### PR TITLE
mtl: Update zephyr and use new register name

### DIFF
--- a/src/platform/intel/ace/lib/pm_runtime.c
+++ b/src/platform/intel/ace/lib/pm_runtime.c
@@ -90,8 +90,8 @@ void platform_pm_runtime_disable(uint32_t context, uint32_t index)
 		tr_dbg(&power_tr, "putting prevent on d0i3");
 		pm_policy_state_lock_get(PM_STATE_RUNTIME_IDLE, PM_ALL_SUBSTATES);
 		/* Disable power gating when preventing */
-		DFDSPBRCP.bootctl[PLATFORM_PRIMARY_CORE_ID].bctl |=
-			DFDSPBRCP_BCTL_WAITIPCG | DFDSPBRCP_BCTL_WAITIPPG;
+		DSPCS.bootctl[PLATFORM_PRIMARY_CORE_ID].bctl |=
+			DSPBR_BCTL_WAITIPCG | DSPBR_BCTL_WAITIPPG;
 		break;
 	default:
 		break;

--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: e4fcb32451c587a3e4ba7f8bf3fc602b16f9652b
+      revision: d9c4ec31fc49e7eef3c8c3b0d07827cc04e6efee
       remote: zephyrproject
       # Import some projects listed in zephyr/west.yml@revision
       #


### PR DESCRIPTION
Some registers have been renamed in Zephyrs commit https://github.com/zephyrproject-rtos/zephyr/commit/21f278c04bc258eb344ac5b2123b49d760b5b71d. This PR changes the references from old to new names and update zephyr revision in west.