### PR TITLE
[SKIP CI] .github/zephyr: add new manifest-check

### DIFF
--- a/.github/workflows/sparse-zephyr.yml
+++ b/.github/workflows/sparse-zephyr.yml
@@ -61,8 +61,9 @@ jobs:
                west update --narrow --fetch-opt=--depth=5
 
       # Not strictly necessary but saves a lot of scrolling in the next step
-      # TODO, research caching:
-      # https://stackoverflow.com/questions/66421411/how-to-run-cached-docker-image-in-github-action
+      # Caching a 12G image is unfortunately not possible:
+      #   https://github.com/ScribeMD/docker-cache/issues/304
+      # For faster builds we would have to pay for some persistent runners.
       - name: docker pull         zephyrproject-rtos/zephyr-build
         run: docker  pull ghcr.io/zephyrproject-rtos/zephyr-build:latest
 

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -15,6 +15,30 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+
+  manifest-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          path: ./workspace/sof
+
+      - name: plain west update
+        run: |
+
+          : This plain 'west update' does not provide 100% certainty that
+          : all the manifest revisions make sense but it is quick and
+          : will catch many revision problems. Other jobs typically
+          : use 'west update --narrow' which is faster but
+          : also able to fetch "wild" SHA1s from any random place! --narrow
+          : is useful for testing unmerged Zephyr commits but risks
+          : accepting "invalid" ones, this will not.
+
+          pip3 install west
+          cd workspace/sof/
+          west init -l
+          west update
+
   build-linux:
     runs-on: ubuntu-20.04
     strategy:

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -70,8 +70,9 @@ jobs:
              git log --oneline -n 5 --decorate --graph --no-abbrev-commit
 
       # Not strictly necessary but saves a lot of scrolling in the next step
-      # TODO, research caching:
-      # https://stackoverflow.com/questions/66421411/how-to-run-cached-docker-image-in-github-action
+      # Caching a 12G image is unfortunately not possible:
+      #   https://github.com/ScribeMD/docker-cache/issues/304
+      # For faster builds we would have to pay for some persistent runners.
       - name: docker pull         zephyrproject-rtos/zephyr-build
         run: docker  pull ghcr.io/zephyrproject-rtos/zephyr-build:latest
 

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -215,7 +215,7 @@ jobs:
 
       - name: West clone
         working-directory: ${{ github.workspace }}/workspace
-        run: west init -l sof && west update
+        run: west init -l sof && west update --narrow
 
       # Call Setup Python again to save the PIP packages in cache
       - name: Setup Python


### PR DESCRIPTION
Other jobs typically use `west update --narrow` which is faster but also
able to fetch "wild" SHA1s from any random place!  It is useful for
testing unmerged Zephyr commits but risks accepting "invalid" zephyr
commits; this will not.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>