### PR TITLE
[STABLE v2.4] cherry-pick build reproducibility fixes

### DIFF
--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -456,8 +456,7 @@ def create_zephyr_sof_symlink():
 def west_update():
 	"""[summary] Clones all west manifest projects to specified revisions"""
 	global west_top
-	execute_command(["west", "update" , "--narrow", "--fetch-opt=--depth=5"],
-			timeout=3000, cwd=west_top)
+	execute_command(["west", "update"], check=True, timeout=3000, cwd=west_top)
 
 
 def get_build_and_sof_version(abs_build_dir):

--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -729,8 +729,8 @@ def install_platform(platform, sof_platform_output_dir):
 	@dataclass
 	class InstFile:
 		'How to install one file'
-		name: str
-		renameTo: str = None
+		name: pathlib.Path
+		renameTo: pathlib.Path = None
 		# TODO: upgrade this to 3 states: optional/warning/error
 		optional: bool = False
 		gzip: bool = True

--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -738,6 +738,7 @@ def install_platform(platform, sof_platform_output_dir):
 	installed_files = [
 		# Fail if one of these is missing
 		InstFile(".config", "config"),
+		InstFile("misc/generated/configs.c", "generated_configs.c"),
 		InstFile(BIN_NAME + ".elf"),
 		InstFile(BIN_NAME + ".lst"),
 		InstFile(BIN_NAME + ".map"),
@@ -792,6 +793,7 @@ BIN_NAME = 'zephyr'
 
 CHECKSUM_WANTED = [
 	'*.ri',     # Some .ri files have a non-deterministic signature, others not
+	'*configs.c', # deterministic unlike .config
 	'*.strip', '*stripped*', # stripped ELF files are reproducible
 	'boot.mod', # no debug section -> no need to strip this ELF
 	BIN_NAME + '.lst',       # objdump --disassemble

--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -743,13 +743,22 @@ def install_platform(platform, sof_platform_output_dir):
 		InstFile(BIN_NAME + ".map"),
 
 		# CONFIG_BUILD_OUTPUT_STRIPPED
-		InstFile(BIN_NAME + '.strip', optional=True),
+		# Renaming ELF files highlights the workaround below that strips the .comment section
+		InstFile(BIN_NAME + ".strip", renameTo=f"stripped-{BIN_NAME}.elf", optional=True),
 
 		# Not every platform has intermediate rimage modules
-		InstFile("main-stripped.mod", optional=True),
+		InstFile("main-stripped.mod", renameTo="stripped-main.elf", optional=True),
 		InstFile("boot.mod", optional=True),
 		InstFile("main.mod", optional=True),
 	]
+
+	# We cannot import at the start because zephyr may not be there yet
+	sys.path.insert(1, os.path.join(sys.path[0],
+					'..', '..', 'zephyr', 'scripts', 'west_commands'))
+	import zcmake
+
+	cmake_cache = zcmake.CMakeCache.from_build_dir(abs_build_dir.parent)
+	objcopy = cmake_cache.get("CMAKE_OBJCOPY")
 
 	sof_info = pathlib.Path(STAGING_DIR) / "sof-info" / platform
 	sof_info.mkdir(parents=True, exist_ok=True)
@@ -757,9 +766,25 @@ def install_platform(platform, sof_platform_output_dir):
 		if not pathlib.Path(abs_build_dir / f.name).is_file() and f.optional:
 			continue
 		dstname = f.renameTo or f.name
-		shutil.copy2(abs_build_dir / f.name, sof_info / dstname)
+
+		src = abs_build_dir / f.name
+		dst = sof_info / dstname
+
+		# Some Xtensa compilers (ab?)use the .ident / .comment
+		# section and append the typically absolute and not
+		# reproducible /path/to/the.c file after the usual
+		# compiler ID.
+		# https://sourceware.org/binutils/docs/as/Ident.html
+		#
+		# --strip-all does not remove the .comment section.
+		# Remove it like some gcc test scripts do:
+		# https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=c7046906c3ae
+		if "strip" in dstname:
+			execute_command([str(x) for x in [objcopy, "--remove-section", ".comment", src, dst]])
+		else:
+			shutil.copy2(src, dst)
 		if f.gzip:
-			gzip_compress(sof_info / dstname)
+			gzip_compress(dst)
 
 
 # Zephyr's CONFIG_KERNEL_BIN_NAME default value

--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -39,7 +39,7 @@ import gzip
 from dataclasses import dataclass
 
 # anytree module is defined in Zephyr build requirements
-from anytree import AnyNode, RenderTree
+from anytree import AnyNode, RenderTree, render
 from packaging import version
 
 # https://chrisyeh96.github.io/2017/08/08/definitive-guide-python-imports.html#case-3-importing-from-parent-directory
@@ -323,7 +323,7 @@ def show_installed_files():
 		assert len(matches) == 1, f'"{entry}" does not have exactly one parent'
 		nodes.append(AnyNode(name=entry.name, long_name=str(entry), parent=matches[0]))
 
-	for pre, _, node in RenderTree(graph_root):
+	for pre, _, node in RenderTree(graph_root, render.AsciiStyle):
 		fpath = STAGING_DIR / node.long_name
 		stem = node.name[:-3] if node.name.endswith(".gz") else node.name
 


### PR DESCRIPTION
Only clean `git cherry-pick -x` of well tested commits from main.

Better late than never? For 2.4.2...

Windows fixes are omitted.
