### PR TITLE
cherry-pick: module_adapter: free memory resource

### DIFF
--- a/src/audio/module_adapter/module/waves.c
+++ b/src/audio/module_adapter/module/waves.c
@@ -809,6 +809,12 @@ static int waves_codec_reset(struct processing_module *mod)
 	if (ret)
 		comp_err(dev, "waves_codec_reset() failed %d", ret);
 
+	if (codec->mpd.in_buff)
+		module_free_memory(mod, codec->mpd.in_buff);
+
+	if (codec->mpd.out_buff)
+		module_free_memory(mod, codec->mpd.out_buff);
+
 	comp_dbg(dev, "waves_codec_reset() done");
 	return ret;
 }


### PR DESCRIPTION
Cherry-pick this commit now in case it gets omitted in the future.

Since the reset API commits for module_adapter were merged on this branch.  This one will be necessary for running Waves in module_adapter.

@barry-waves @Zames-Chang PTAL
 