### PR TITLE
topology2: remove HDMI from topologies for MTL

### DIFF
--- a/tools/topology/topology2/development/CMakeLists.txt
+++ b/tools/topology/topology2/development/CMakeLists.txt
@@ -17,6 +17,9 @@ PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-tgl-nocodec.bin,DEEPBUFFER_FW_DMA_MS=1
 "cavs-nocodec\;sof-adl-nocodec\;NUM_DMICS=4,PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,\
 PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-adl-nocodec.bin,DEEPBUFFER_FW_DMA_MS=100"
 
+# SDW topology for MTL
+"cavs-sdw\;mtl-sdw\;NUM_HDMIS=0"
+
 # SDW + HDMI topology for MTL
 "cavs-sdw\;mtl-sdw-hdmi\;"
 

--- a/tools/topology/topology2/sof-ace-tplg/CMakeLists.txt
+++ b/tools/topology/topology2/sof-ace-tplg/CMakeLists.txt
@@ -16,7 +16,8 @@ HDA_CONFIG=mix,NUM_DMICS=2,PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-hda-generic
 DEEPBUFFER_FW_DMA_MS=100"
 
 # SDW + DMIC topology with passthrough pipelines
-"cavs-sdw\;sof-mtl-rt711-4ch\;NUM_DMICS=4,DMIC0_ID=2,DMIC1_ID=3,\
+# We will change NUM_HDMIS to 3 once HDMI is enabled on MTL RVP
+"cavs-sdw\;sof-mtl-rt711-4ch\;NUM_DMICS=4,DMIC0_ID=2,DMIC1_ID=3,NUM_HDMIS=0,\
 PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-mtl-rt711-4ch.bin,DEEPBUFFER_FW_DMA_MS=100"
 
 "cavs-rt5682\;sof-mtl-max98357a-rt5682\;PLATFORM=mtl,NUM_DMICS=4,PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,\


### PR DESCRIPTION
There is no HDMI support on MTL RVP for now.

Signed-off-by: Bard Liao <yung-chuan.liao@linux.intel.com>