### PR TITLE
ipc4: increase max pipeline count to 32

### DIFF
--- a/src/include/ipc4/base_fw.h
+++ b/src/include/ipc4/base_fw.h
@@ -42,7 +42,7 @@
 #define IPC4_MAX_LIBS_COUNT 16
 
 /* Max pipeline count supported by ipc4 */
-#define IPC4_MAX_PPL_COUNT 16
+#define IPC4_MAX_PPL_COUNT 32
 
 enum ipc4_basefw_params {
 	/* Use LARGE_CONFIG_GET to retrieve fw properties as TLV structure


### PR DESCRIPTION
Now each stream is built with at least two pipelines and this can't support more than 8 streams, 6 streams in normal. This results to CI test failure since it will tests all streams simultaneously although current topology is simple.

Now increase it to 32 for future enhancement.
![sof-tgl-nocodec](https://user-images.githubusercontent.com/39945651/212079629-fcd45bf7-28a1-431d-a860-93407cecbe8f.png)
