### PR TITLE
[SKIP CI] CODEOWNERS: be more selective when matching CMakeLists.txt files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,6 +7,8 @@
 # Order is important. The last matching pattern has the most precedence.
 # So if a pull request only touches javascript files, only these owners
 # will be requested to review.
+# File patterns work mostly like .gitignore. Try to keep this file
+# simple because it's literally impossible to test.
 
 # include files
 src/include/sof/drivers/dmic.h		@singalsu
@@ -63,7 +65,7 @@ src/debug/gdb/*				@abonislawski
 src/schedule				@abonislawski
 
 # other helpers
-# Mostly overridden by *.(ba)sh below
+# Many files overridden by *.(ba)sh pattern below
 scripts/*				@marc-hb @aborisovich
 
 # tools(old 'soft' repo)
@@ -78,11 +80,19 @@ tools/tune/dcblock/*			@thesofproject/google
 tools/tune/drc/*			@thesofproject/google
 tools/oss-fuzz/*			@thesofproject/google
 
-# build system
-**/CMakeLists.txt			@marc-hb @aborisovich
-# **/Kconfig
-# scripts/cmake/**
-# scripts/kconfig/**
+# CMake
+
+# Include only "top-level" CMakeLists.txt files; the other ones are just
+# dumb list of source files and generate too much noise.
+/CMakeLists.txt			@marc-hb @aborisovich
+/*/CMakeLists.txt			@marc-hb @aborisovich
+/test/cmocka/CMakeLists.txt		@marc-hb @aborisovich
+
+# There's a small enough number of files in tools/ and little
+# churn: keep it simple and take them all.
+# FIXME: some topology CMakeLists.txt files are configuration files
+# in disguise. Move them to actual configuration files.
+/tools/**/CMakeLists.txt		@marc-hb @aborisovich
 
 *.sh					@marc-hb
 *.bash					@marc-hb

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -14,10 +14,10 @@ src/include/ipc/**			@thesofproject/steering-committee
 src/include/ipc/**			@randerwang @marcinszkudlinski
 src/include/kernel/**			@thesofproject/steering-committee
 src/include/user/**			@thesofproject/steering-committee
-src/include/sof/debug/gdb/*		@mrajwa
-src/include/sof/audio/kpb.h		@mrajwa
+src/include/sof/debug/gdb/*		@abonislawski
+src/include/sof/audio/kpb.h		@abonislawski
 src/include/sof/audio/mux.h		@akloniex
-src/include/sof/audio/codec_adapter/*	@cujomalainey @mrajwa @dbaluta
+src/include/sof/audio/codec_adapter/*	@cujomalainey @abonislawski @dbaluta
 src/include/sof/drivers/acp_dai_dma.h	@bhiregoudar @sunilkumardommati
 src/include/sof/drivers/afe*		@yaochunhung
 
@@ -27,20 +27,20 @@ src/audio/eq*				@singalsu
 src/audio/eq_fir*			@singalsu
 src/audio/eq_iir*			@singalsu
 src/audio/tone.c			@singalsu
-src/audio/kpb.c				@mrajwa
+src/audio/kpb.c				@abonislawski
 src/audio/mux/*				@akloniex
 src/audio/dcblock*			@thesofproject/google
 src/audio/crossover*			@thesofproject/google
 src/audio/tdfb*                         @singalsu
 src/audio/drc/*				@thesofproject/google
 src/audio/multiband_drc/*		@thesofproject/google
-src/audio/codec_adapter/*		@cujomalainey @mrajwa @dbaluta
+src/audio/codec_adapter/*		@cujomalainey @abonislawski @dbaluta
 src/audio/google/*			@thesofproject/google
 
 # platforms
 src/platform/haswell/*			@randerwang
 src/platform/suecreek/*			@lyakh
-src/arch/xtensa/debug/gdb/*		@mrajwa
+src/arch/xtensa/debug/gdb/*		@abonislawski
 src/platform/imx8/**			@dbaluta
 src/platform/amd/**			@bhiregoudar @sunilkumardommati
 src/platform/mt8195/**		@yaochunhung @kuanhsuncheng
@@ -59,8 +59,8 @@ src/math/*				@singalsu
 src/ipc/*				@bardliao @marcinszkudlinski
 src/drivers/intel/cavs/sue-ipc.c	@lyakh
 src/lib/*				@libinyang
-src/debug/gdb/*				@mrajwa
-src/schedule				@mrajwa
+src/debug/gdb/*				@abonislawski
+src/schedule				@abonislawski
 
 # other helpers
 # Mostly overridden by *.(ba)sh below


### PR DESCRIPTION
I don't want to be spammed any more every time someone adds or renames a source file.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>