### PR TITLE
[SKIP CI] .github/zephyr: compare Windows and Linux builds

### DIFF
--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -259,3 +259,47 @@ jobs:
           path: |
             ${{ github.workspace }}/workspace/build-sof-staging
             ${{ github.workspace }}/workspace/**/compile_commands.json
+
+
+  compare-linux-win:
+
+    runs-on: ubuntu-latest
+
+    # - We don't compare _all_ the builds, and
+    # - even when some of the ones we compare fail, we still want to compare the rest.
+    if: ${{ always() }}
+    needs: [build-linux, build-windows]
+
+    steps:
+      - uses: actions/checkout@v3
+        # we need only one script but it's simpler to get the (last
+        # revision of the) whole repo and it takes seconds.
+        with:
+          # Isolate the clone in a subdirectory to make sure globbing
+          # does not catch random SOF files.
+          path: ./sof
+
+      - name: Download Windows and Linux builds
+        uses: actions/download-artifact@v3
+
+      - name: apt-get dos2unix
+        run: sudo apt-get update; sudo apt-get -y install dos2unix
+
+      - name: Delete and fix expected differences
+        run: |
+          ls -l
+          # run it twice to make sure it's idempotent
+          for i in 0 1; do
+            ./sof/zephyr/scripts/clean-expected-release-differences.sh \
+               windows-build* linux-build*
+          done
+
+      - name: Compare Linux vs Windows builds
+        run: |
+          # FIXME: for windows the Z_SDK version is hardcoded above, for Linux it's not.
+          diffs=0
+          for windir in windows-build*; do
+            lindir=linux-"${windir#windows-}"
+            diff -qr "$lindir" "$windir" || : $((diffs++))
+          done
+          exit $diffs

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -81,6 +81,8 @@ jobs:
       # a "roughly 4-month release" but for now that saves only 100MB
       # https://docs.zephyrproject.org/latest/project/release_process.html
       - name: west clones
+
+        # Get some git tags in Zephyr. keep in sync with build-windows below
         run: pip3 install west && cd workspace/sof/ && west init -l &&
                west update --narrow --fetch-opt=--depth=5 &&
                git -C ../zephyr fetch --shallow-exclude=v3.2.0-rc3
@@ -215,7 +217,10 @@ jobs:
 
       - name: West clone
         working-directory: ${{ github.workspace }}/workspace
-        run: west init -l sof && west update --narrow
+        # Keep in sync with build-linux above
+        run: west init -l sof &&
+             west update --narrow --fetch-opt=--depth=5 &&
+             git -C zephyr fetch --shallow-exclude=v3.2.0-rc3
 
       # Call Setup Python again to save the PIP packages in cache
       - name: Setup Python

--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -767,7 +767,7 @@ def install_platform(platform, sof_platform_output_dir):
 
 		# CONFIG_BUILD_OUTPUT_STRIPPED
 		# Renaming ELF files highlights the workaround below that strips the .comment section
-		InstFile(BIN_NAME + ".strip", renameTo=f"stripped-{BIN_NAME}.elf", optional=True),
+		InstFile(BIN_NAME + ".strip", renameTo=f"stripped-{BIN_NAME}.elf"),
 
 		# Not every platform has intermediate rimage modules
 		InstFile("main-stripped.mod", renameTo="stripped-main.elf", optional=True),

--- a/zephyr/scripts/clean-expected-release-differences.sh
+++ b/zephyr/scripts/clean-expected-release-differences.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+# SPDX-License-Identifier: BSD-3-Clause
+# shellcheck disable=SC3043
+
+set -e
+
+die()
+{
+    # shellcheck disable=SC2059
+    >&2 printf "$@"
+    exit 1
+}
+
+fix_dir()
+{
+    local bd="$1"
+
+    test -d "$bd"/build-sof-staging ||
+        die 'No %s/build-sof-staging directory\n' "$bd"
+
+    # config files have absolute paths
+    find "$bd" -name 'config.gz' -exec rm '{}' \;
+
+    # In case of a compression timestamp. Also gives better messages.
+    find "$bd" -name '*.gz' -print0 | xargs -r -0 gunzip
+
+    ( set -x
+
+      # Native binaries
+      rm -f "$bd"/build-sof-staging/tools/sof-logger*
+      # Python and other scripts
+      dos2unix "$bd"/build-sof-staging/tools/* || true
+
+      # signature salt
+      find "$bd" -name '*.ri' -exec rm '{}' \;
+
+      # debug symbols
+      find "$bd" -name main.mod   -exec rm '{}' \;
+      find "$bd" -name zephyr.elf -exec rm '{}' \;
+
+      # Unlike zephyr.lst, zephyr.map includes some debug information which is
+      # as usual full of absolute paths, e.g.:
+      #  /opt/toolchains/zephyr-sdk-0.15.2/xtensa-intel_s1000_..../libgcc.a(_divsf3.o)
+      # Delete non-reproducible information inside zephyr.map.
+      find "$bd" -name zephyr.map -exec sed -i'' -e \
+        's#[^[:blank:]]*zephyr-sdk-[^/]*/xtensa#ZSDK/xtensa#; s#\\#/#g; /^ \.debug_/ d' \
+        '{}' \;
+
+      # The above search/replace normalizes MOST but unfortunately not
+      # all the debug information! So let's delete zephyr.map after all :-(
+      # Comparing "almost normalized" zephyr.map files can be very
+      # useful to root cause differences: comment out this line in your
+      # local workspace.
+      find "$bd" -name zephyr.map -exec rm '{}' \;
+
+      find "$bd" -name 'compile_commands.json' -exec rm '{}' \;
+    )
+
+}
+
+main()
+{
+    for d in "$@"; do
+        fix_dir "$d"
+    done
+}
+
+
+main "$@"


### PR DESCRIPTION
The End.

This makes sure Windows builds and Linux builds produce identical binaries.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>