### PR TITLE
Optimize host copier with one less buffer copy

### DIFF
--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -953,6 +953,7 @@ static int copier_reset(struct comp_dev *dev)
 	struct ipc4_pipeline_registers pipe_reg;
 	int ret = 0;
 	int i;
+	bool flag = true;
 
 	comp_dbg(dev, "copier_reset()");
 
@@ -960,13 +961,16 @@ static int copier_reset(struct comp_dev *dev)
 	cd->output_total_data_processed = 0;
 
 	for (i = 0; i < cd->endpoint_num; i++) {
-		if (dev->ipc_config.type == SOF_COMP_HOST && !cd->ipc_gtw) {
+		if (dev->ipc_config.type == SOF_COMP_HOST && !cd->ipc_gtw && flag) {
+			/*
+			 * host copier endpoint_num will never be greater than 1
+			 */
 			if (cd->hd->chan)
-				notifier_unregister(cd->endpoint[i],
+				notifier_unregister(dev,
 						    cd->hd->chan, NOTIFIER_ID_DMA_COPY);
-
 			host_zephyr_reset(cd->hd, cd->endpoint[i]->state);
 			cd->endpoint[i]->state = COMP_STATE_READY;
+			flag = false;
 		} else {
 			ret = cd->endpoint[i]->drv->ops.reset(cd->endpoint[i]);
 			if (ret < 0)
@@ -1401,6 +1405,26 @@ static void update_buffer_format(struct comp_buffer __sparse_cache *buf_c,
 	buf_c->hw_params_configured = true;
 }
 
+/* This is called by DMA driver every time when DMA completes its current
+ * transfer between host and DSP.
+ */
+static void copier_dma_cb(void *arg, enum notify_id type, void *data)
+{
+	struct dma_cb_data *next = data;
+	struct comp_dev *dev = arg;
+	struct copier_data *cd = comp_get_drvdata(dev);
+	uint32_t bytes = next->elem.size;
+
+	comp_dbg(dev, "copier_dma_cb() %p", dev);
+
+	/* update position */
+	host_update_position(cd->hd, dev, bytes);
+
+	/* callback for one shot copy */
+	if (cd->hd->copy_type == COMP_COPY_ONE_SHOT)
+		host_one_shot_cb(cd->hd, bytes);
+}
+
 /* configure the DMA params */
 static int copier_params(struct comp_dev *dev, struct sof_ipc_stream_params *params)
 {
@@ -1501,8 +1525,8 @@ static int copier_params(struct comp_dev *dev, struct sof_ipc_stream_params *par
 							 is_scheduling_source);
 				if (ret >= 0)
 					/* set up callback */
-					notifier_register(child_dev, cd->hd->chan,
-							  NOTIFIER_ID_DMA_COPY, host_dma_cb, 0);
+					notifier_register(dev, cd->hd->chan,
+							  NOTIFIER_ID_DMA_COPY, copier_dma_cb, 0);
 			} else {
 				ret = cd->endpoint[i]->drv->ops.params(cd->endpoint[i],
 								       params);

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -1673,10 +1673,18 @@ static uint64_t copier_get_processed_data(struct comp_dev *dev, uint32_t stream_
 {
 	struct copier_data *cd = comp_get_drvdata(dev);
 	uint64_t ret = 0;
+	bool source = dev->direction == SOF_IPC_STREAM_CAPTURE;
 
 	if (cd->endpoint_num && cd->bsource_buffer != input) {
-		if (stream_no < cd->endpoint_num)
-			ret = comp_get_total_data_processed(cd->endpoint[stream_no], 0, input);
+		if (stream_no < cd->endpoint_num) {
+			if (dev->ipc_config.type == SOF_COMP_HOST && !cd->ipc_gtw) {
+				if (source == input)
+					ret = cd->hd->total_data_processed;
+			} else {
+				ret = comp_get_total_data_processed(cd->endpoint[stream_no],
+								    0, input);
+			}
+		}
 	} else {
 		if (stream_no == 0)
 			ret = input ? cd->input_total_data_processed :
@@ -1707,13 +1715,20 @@ static int copier_get_attribute(struct comp_dev *dev, uint32_t type, void *value
 static int copier_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn)
 {
 	struct copier_data *cd = comp_get_drvdata(dev);
+	int ret;
 
 	/* Exit if no endpoints */
 	if (!cd->endpoint_num)
 		return -EINVAL;
 
+	if (dev->ipc_config.type == SOF_COMP_HOST && !cd->ipc_gtw) {
+		posn->host_posn = cd->hd->local_pos;
+		ret = posn->host_posn;
+	} else {
+		ret = comp_position(cd->endpoint[IPC4_COPIER_GATEWAY_PIN], posn);
+	}
 	/* Return position from the default gateway pin */
-	return comp_position(cd->endpoint[IPC4_COPIER_GATEWAY_PIN], posn);
+	return ret;
 }
 
 static const struct comp_driver comp_copier = {

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -488,6 +488,8 @@ static int create_ipcgtw(struct comp_dev *parent_dev, struct copier_data *cd,
 	int ret;
 	struct comp_dev *dev;
 
+	cd->ipc_gtw = true;
+
 	drv = ipc4_get_drv((uint8_t *)&uuid);
 	if (!drv)
 		return -EINVAL;

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -36,6 +36,7 @@
 #include <errno.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <sof/audio/host_copier.h>
 
 static const struct comp_driver comp_copier;
 
@@ -212,6 +213,7 @@ static int create_host(struct comp_dev *parent_dev, struct copier_data *cd,
 	struct ipc_config_host ipc_host;
 	const struct comp_driver *drv;
 	struct comp_dev *dev;
+	struct host_data *hd;
 	int ret;
 
 	drv = ipc4_get_drv((uint8_t *)&host);
@@ -228,11 +230,25 @@ static int create_host(struct comp_dev *parent_dev, struct copier_data *cd,
 	ipc_host.direction = dir;
 	ipc_host.dma_buffer_size = copier_cfg->gtw_cfg.dma_buffer_size;
 
-	dev = drv->ops.create(drv, config, &ipc_host);
+	dev = comp_alloc(drv, sizeof(*dev));
 	if (!dev) {
-		ret = -EINVAL;
+		ret = -ENOMEM;
 		goto e_buf;
 	}
+	dev->ipc_config = *config;
+
+	hd = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM, sizeof(*hd));
+	if (!hd) {
+		ret = -ENOMEM;
+		goto e_dev;
+	}
+	comp_set_drvdata(dev, hd);
+	ret = host_zephyr_new(hd, parent_dev, &ipc_host, dev->ipc_config.id);
+	if (ret < 0) {
+		comp_err(parent_dev, "copier: host new failed with exit");
+		goto e_data;
+	}
+	dev->state = COMP_STATE_READY;
 
 	list_init(&dev->bsource_list);
 	list_init(&dev->bsink_list);
@@ -254,13 +270,20 @@ static int create_host(struct comp_dev *parent_dev, struct copier_data *cd,
 	if (!cd->converter[IPC4_COPIER_GATEWAY_PIN]) {
 		comp_err(parent_dev, "failed to get converter for host, dir %d", dir);
 		ret = -EINVAL;
-		goto e_buf;
+		goto e_conv;
 	}
 
 	cd->endpoint[cd->endpoint_num++] = dev;
+	cd->hd = hd;
 
 	return 0;
 
+e_conv:
+	host_zephyr_free(hd);
+e_data:
+	rfree(hd);
+e_dev:
+	rfree(dev);
 e_buf:
 	buffer_free(cd->endpoint_buffer[cd->endpoint_num]);
 	return ret;
@@ -700,9 +723,23 @@ static void copier_free(struct comp_dev *dev)
 {
 	struct copier_data *cd = comp_get_drvdata(dev);
 	int i;
+	bool free_host = true;
 
 	for (i = 0; i < cd->endpoint_num; i++) {
-		cd->endpoint[i]->drv->ops.free(cd->endpoint[i]);
+		if (cd->endpoint[i]->ipc_config.type == SOF_COMP_HOST &&
+		    !cd->ipc_gtw && free_host) {
+			/*
+			 * host copier endpoint_num will never be greater than 1
+			 * add one more flag for double safe the free operation.
+			 */
+			host_zephyr_free(cd->hd);
+			rfree(cd->hd);
+			rfree(cd->endpoint[i]);
+			free_host = false;
+		} else {
+			cd->endpoint[i]->drv->ops.free(cd->endpoint[i]);
+		}
+
 		buffer_free(cd->endpoint_buffer[i]);
 	}
 

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -1005,9 +1005,23 @@ static int copier_comp_trigger(struct comp_dev *dev, int cmd)
 		return PPL_STATUS_PATH_STOP;
 
 	for (i = 0; i < cd->endpoint_num; i++) {
-		ret = cd->endpoint[i]->drv->ops.trigger(cd->endpoint[i], cmd);
-		if (ret < 0)
-			break;
+		if (dev->ipc_config.type == SOF_COMP_HOST && !cd->ipc_gtw) {
+			ret = comp_set_state(cd->endpoint[i], cmd);
+			if (ret < 0)
+				break;
+
+			if (ret == COMP_STATUS_STATE_ALREADY_SET) {
+				ret = PPL_STATUS_PATH_STOP;
+				break;
+			}
+			ret = host_zephyr_trigger(cd->hd, dev, cmd);
+			if (ret < 0)
+				break;
+		} else {
+			ret = cd->endpoint[i]->drv->ops.trigger(cd->endpoint[i], cmd);
+			if (ret < 0)
+				break;
+		}
 	}
 
 	if (ret < 0 || !cd->endpoint_num || !cd->pipeline_reg_offset)

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -1213,8 +1213,9 @@ static int mux_into_multi_endpoint_buffer(struct copier_data *cd)
 	return 0;
 }
 
-static int do_endpoint_copy(struct copier_data *cd)
+static int do_endpoint_copy(struct comp_dev *dev)
 {
+	struct copier_data *cd = comp_get_drvdata(dev);
 	if (cd->multi_endpoint_buffer) {
 		int i;
 		int ret = 0;
@@ -1238,6 +1239,9 @@ static int do_endpoint_copy(struct copier_data *cd)
 
 		return ret;
 	} else {
+		if (dev->ipc_config.type == SOF_COMP_HOST && !cd->ipc_gtw)
+			return host_zephyr_copy(cd->hd, cd->endpoint[0]);
+
 		return cd->endpoint[0]->drv->ops.copy(cd->endpoint[0]);
 	}
 }
@@ -1303,7 +1307,7 @@ static int copier_copy(struct comp_dev *dev)
 
 	if (cd->endpoint_num && !cd->bsource_buffer) {
 		/* gateway(s) as input */
-		ret = do_endpoint_copy(cd);
+		ret = do_endpoint_copy(dev);
 		if (ret < 0)
 			return ret;
 
@@ -1329,7 +1333,7 @@ static int copier_copy(struct comp_dev *dev)
 				return ret;
 			}
 
-			ret = do_endpoint_copy(cd);
+			ret = do_endpoint_copy(dev);
 			if (ret < 0) {
 				buffer_release(src_c);
 				return ret;

--- a/src/audio/host-zephyr.c
+++ b/src/audio/host-zephyr.c
@@ -710,9 +710,7 @@ static int host_verify_params(struct comp_dev *dev,
 }
 
 int host_zephyr_params(struct host_data *hd, struct comp_dev *dev,
-		       struct sof_ipc_stream_params *params, struct list_item *sink_list,
-		       struct list_item *source_list, struct pipeline *pipeline,
-		       uint32_t frames, bool is_scheduling_source)
+		       struct sof_ipc_stream_params *params)
 {
 	struct dma_sg_config *config = &hd->config;
 	struct dma_sg_elem *sg_elem;
@@ -726,6 +724,7 @@ int host_zephyr_params(struct host_data *hd, struct comp_dev *dev,
 	uint32_t addr_align;
 	uint32_t align;
 	int i, channel, err;
+	bool is_scheduling_source = dev == dev->pipeline->sched_comp;
 
 	/* host params always installed by pipeline IPC */
 	hd->host_size = params->buffer.size;
@@ -759,17 +758,16 @@ int host_zephyr_params(struct host_data *hd, struct comp_dev *dev,
 	}
 
 	if (params->direction == SOF_IPC_STREAM_PLAYBACK)
-		hd->local_buffer = list_first_item(sink_list,
+		hd->local_buffer = list_first_item(&dev->bsink_list,
 						   struct comp_buffer,
 						   source_list);
 	else
-		hd->local_buffer = list_first_item(source_list,
+		hd->local_buffer = list_first_item(&dev->bsource_list,
 						   struct comp_buffer,
 						   sink_list);
 	host_buf_c = buffer_acquire(hd->local_buffer);
 
-	period_bytes = frames *
-		audio_stream_frame_bytes(&host_buf_c->stream);
+	period_bytes = dev->frames * get_frame_bytes(params->frame_fmt, params->channels);
 
 	if (!period_bytes) {
 		comp_err(dev, "host_params(): invalid period_bytes");
@@ -823,6 +821,17 @@ int host_zephyr_params(struct host_data *hd, struct comp_dev *dev,
 
 		dma_buf_c = buffer_acquire(hd->dma_buffer);
 		buffer_set_params(dma_buf_c, params, BUFFER_UPDATE_FORCE);
+
+		/* set processing function */
+		if (params->direction == SOF_IPC_STREAM_CAPTURE)
+			hd->process = pcm_get_conversion_function(host_buf_c->stream.frame_fmt,
+								  dma_buf_c->stream.frame_fmt);
+		else
+			hd->process = pcm_get_conversion_function(dma_buf_c->stream.frame_fmt,
+								  host_buf_c->stream.frame_fmt);
+
+		config->src_width = audio_stream_sample_bytes(&dma_buf_c->stream);
+		config->dest_width = config->src_width;
 		buffer_release(dma_buf_c);
 	}
 
@@ -833,12 +842,10 @@ int host_zephyr_params(struct host_data *hd, struct comp_dev *dev,
 		goto out;
 
 	/* set up DMA configuration - copy in sample bytes. */
-	config->src_width = audio_stream_sample_bytes(&host_buf_c->stream);
-	config->dest_width = audio_stream_sample_bytes(&host_buf_c->stream);
 	config->cyclic = 0;
-	config->irq_disabled = pipeline_is_timer_driven(pipeline);
+	config->irq_disabled = pipeline_is_timer_driven(dev->pipeline);
 	config->is_scheduling_source = is_scheduling_source;
-	config->period = pipeline->period;
+	config->period = dev->pipeline->period;
 
 	host_elements_reset(hd, params->direction);
 
@@ -923,10 +930,6 @@ int host_zephyr_params(struct host_data *hd, struct comp_dev *dev,
 	hd->copy = hd->copy_type == COMP_COPY_ONE_SHOT ? host_copy_one_shot :
 		host_copy_normal;
 
-	/* set processing function */
-	hd->process = pcm_get_conversion_function(host_buf_c->stream.frame_fmt,
-						  host_buf_c->stream.frame_fmt);
-
 out:
 	buffer_release(host_buf_c);
 	return err;
@@ -947,8 +950,7 @@ static int host_params(struct comp_dev *dev,
 		return err;
 	}
 
-	err = host_zephyr_params(hd, dev, params, &dev->bsink_list, &dev->bsource_list,
-				 dev->pipeline, dev->frames, dev == dev->pipeline->sched_comp);
+	err = host_zephyr_params(hd, dev, params);
 	if (err >= 0)
 		/* set up callback */
 		notifier_register(dev, hd->chan, NOTIFIER_ID_DMA_COPY, host_dma_cb, 0);

--- a/src/audio/host-zephyr.c
+++ b/src/audio/host-zephyr.c
@@ -246,9 +246,8 @@ static int host_copy_one_shot(struct host_data *hd, struct comp_dev *dev)
 }
 #endif
 
-static void host_update_position(struct comp_dev *dev, uint32_t bytes)
+void host_update_position(struct host_data *hd, struct comp_dev *dev, uint32_t bytes)
 {
-	struct host_data *hd = comp_get_drvdata(dev);
 	struct comp_buffer __sparse_cache *source;
 	struct comp_buffer __sparse_cache *sink;
 	int ret;
@@ -331,7 +330,7 @@ static void host_update_position(struct comp_dev *dev, uint32_t bytes)
  * This means we must check we do not overflow host period/buffer/page
  * boundaries on each transfer and split the DMA transfer if we do overflow.
  */
-static void host_one_shot_cb(struct host_data *hd, uint32_t bytes)
+void host_one_shot_cb(struct host_data *hd, uint32_t bytes)
 {
 	struct dma_sg_elem *local_elem = hd->config.elem_array.elems;
 	struct dma_sg_elem *source_elem;
@@ -375,7 +374,7 @@ void host_dma_cb(void *arg, enum notify_id type, void *data)
 	comp_cl_dbg(&comp_host, "host_dma_cb() %p", &comp_host);
 
 	/* update position */
-	host_update_position(dev, bytes);
+	host_update_position(hd, dev, bytes);
 
 	/* callback for one shot copy */
 	if (hd->copy_type == COMP_COPY_ONE_SHOT)

--- a/src/audio/host-zephyr.c
+++ b/src/audio/host-zephyr.c
@@ -5,6 +5,7 @@
 // Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
 //         Keyon Jie <yang.jie@linux.intel.com>
 
+#include <sof/audio/host_copier.h>
 #include <sof/audio/buffer.h>
 #include <sof/audio/component_ext.h>
 #include <sof/audio/pcm_converter.h>
@@ -42,73 +43,6 @@ DECLARE_SOF_RT_UUID("host", host_uuid, 0x8b9d100c, 0x6d78, 0x418f,
 		    0x90, 0xa3, 0xe0, 0xe8, 0x05, 0xd0, 0x85, 0x2b);
 
 DECLARE_TR_CTX(host_tr, SOF_UUID(host_uuid), LOG_LEVEL_INFO);
-
-/** \brief Host copy function interface. */
-typedef int (*host_copy_func)(struct comp_dev *dev);
-
-/**
- * \brief Host buffer info.
- */
-struct hc_buf {
-	struct dma_sg_elem_array elem_array; /**< array of SG elements */
-	uint32_t current;		/**< index of current element */
-	uint32_t current_end;
-};
-
-/**
- * \brief Host component data.
- *
- * Host reports local position in the host buffer every params.host_period_bytes
- * if the latter is != 0. report_pos is used to track progress since the last
- * multiple of host_period_bytes.
- *
- * host_size is the host buffer size (in bytes) specified in the IPC parameters.
- */
-struct host_data {
-	/* local DMA config */
-	struct dma *dma;
-	struct dma_chan_data *chan;
-	struct dma_sg_config config;
-	struct dma_config z_config;
-	struct comp_buffer *dma_buffer;
-	struct comp_buffer *local_buffer;
-
-	/* host position reporting related */
-	uint32_t host_size;	/**< Host buffer size (in bytes) */
-	uint32_t report_pos;	/**< Position in current report period */
-	uint32_t local_pos;	/**< Local position in host buffer */
-	uint32_t host_period_bytes;
-	uint16_t stream_tag;
-	uint16_t no_stream_position; /**< 1 means don't send stream position */
-	uint64_t total_data_processed;
-	uint8_t cont_update_posn; /**< 1 means continuous update stream position */
-
-	/* host component attributes */
-	enum comp_copy_type copy_type;	/**< Current host copy type */
-
-	/* local and host DMA buffer info */
-	struct hc_buf host;
-	struct hc_buf local;
-
-	/* pointers set during params to host or local above */
-	struct hc_buf *source;
-	struct hc_buf *sink;
-
-	uint32_t dma_copy_align; /**< Minimal chunk of data possible to be
-				   *  copied by dma connected to host
-				   */
-	uint32_t period_bytes;	/**< number of bytes per one period */
-
-	host_copy_func copy;	/**< host copy function */
-	pcm_converter_func process;	/**< processing function */
-
-	/* IPC host init info */
-	struct ipc_config_host ipc_host;
-
-	/* stream info */
-	struct sof_ipc_stream_posn posn; /* TODO: update this */
-	struct ipc_msg *msg;	/**< host notification */
-};
 
 static inline struct dma_sg_elem *next_buffer(struct hc_buf *hc)
 {
@@ -639,6 +573,41 @@ static int host_trigger(struct comp_dev *dev, int cmd)
 	return ret;
 }
 
+int host_zephyr_new(struct host_data *hd, struct comp_dev *dev,
+		    const struct ipc_config_host *ipc_host, uint32_t config_id)
+{
+	uint32_t dir;
+
+	hd->ipc_host = *ipc_host;
+	/* request HDA DMA with shared access privilege */
+	dir = hd->ipc_host.direction == SOF_IPC_STREAM_PLAYBACK ?
+		DMA_DIR_HMEM_TO_LMEM : DMA_DIR_LMEM_TO_HMEM;
+
+	hd->dma = dma_get(dir, 0, DMA_DEV_HOST, DMA_ACCESS_SHARED);
+	if (!hd->dma) {
+		comp_err(dev, "host_new(): dma_get() returned NULL");
+		return -ENODEV;
+	}
+
+	/* init buffer elems */
+	dma_sg_init(&hd->config.elem_array);
+	dma_sg_init(&hd->host.elem_array);
+	dma_sg_init(&hd->local.elem_array);
+
+	ipc_build_stream_posn(&hd->posn, SOF_IPC_STREAM_POSITION, config_id);
+
+	hd->msg = ipc_msg_init(hd->posn.rhdr.hdr.cmd, sizeof(hd->posn));
+	if (!hd->msg) {
+		comp_err(dev, "host_new(): ipc_msg_init failed");
+		dma_put(hd->dma);
+		return -ENOMEM;
+	}
+	hd->chan = NULL;
+	hd->copy_type = COMP_COPY_NORMAL;
+
+	return 0;
+}
+
 static struct comp_dev *host_new(const struct comp_driver *drv,
 				 const struct comp_ipc_config *config,
 				 const void *spec)
@@ -646,7 +615,7 @@ static struct comp_dev *host_new(const struct comp_driver *drv,
 	struct comp_dev *dev;
 	struct host_data *hd;
 	const struct ipc_config_host *ipc_host = spec;
-	uint32_t dir;
+	int ret;
 
 	comp_cl_dbg(&comp_host, "host_new()");
 
@@ -656,47 +625,32 @@ static struct comp_dev *host_new(const struct comp_driver *drv,
 	dev->ipc_config = *config;
 
 	hd = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM, sizeof(*hd));
-	if (!hd) {
-		rfree(dev);
-		return NULL;
-	}
+	if (!hd)
+		goto e_data;
 
 	comp_set_drvdata(dev, hd);
-	hd->ipc_host = *ipc_host;
 
-	/* request HDA DMA with shared access privilege */
-	dir = hd->ipc_host.direction == SOF_IPC_STREAM_PLAYBACK ?
-		DMA_DIR_HMEM_TO_LMEM : DMA_DIR_LMEM_TO_HMEM;
+	ret = host_zephyr_new(hd, dev, ipc_host, dev->ipc_config.id);
+	if (ret)
+		goto e_dev;
 
-	hd->dma = dma_get(dir, 0, DMA_DEV_HOST, DMA_ACCESS_SHARED);
-	if (!hd->dma) {
-		comp_err(dev, "host_new(): dma_get() returned NULL");
-		rfree(hd);
-		rfree(dev);
-		return NULL;
-	}
-
-	/* init buffer elems */
-	dma_sg_init(&hd->config.elem_array);
-	dma_sg_init(&hd->host.elem_array);
-	dma_sg_init(&hd->local.elem_array);
-
-	ipc_build_stream_posn(&hd->posn, SOF_IPC_STREAM_POSITION, dev->ipc_config.id);
-
-	hd->msg = ipc_msg_init(hd->posn.rhdr.hdr.cmd, sizeof(hd->posn));
-	if (!hd->msg) {
-		comp_err(dev, "host_new(): ipc_msg_init failed");
-		dma_put(hd->dma);
-		rfree(hd);
-		rfree(dev);
-		return NULL;
-	}
-
-	hd->chan = NULL;
-	hd->copy_type = COMP_COPY_NORMAL;
 	dev->state = COMP_STATE_READY;
 
 	return dev;
+
+e_dev:
+	rfree(hd);
+e_data:
+	rfree(dev);
+	return NULL;
+}
+
+void host_zephyr_free(struct host_data *hd)
+{
+	dma_put(hd->dma);
+
+	ipc_msg_free(hd->msg);
+	dma_sg_free(&hd->config.elem_array);
 }
 
 static void host_free(struct comp_dev *dev)
@@ -704,11 +658,7 @@ static void host_free(struct comp_dev *dev)
 	struct host_data *hd = comp_get_drvdata(dev);
 
 	comp_dbg(dev, "host_free()");
-
-	dma_put(hd->dma);
-
-	ipc_msg_free(hd->msg);
-	dma_sg_free(&hd->config.elem_array);
+	host_zephyr_free(hd);
 	rfree(hd);
 	rfree(dev);
 }

--- a/src/audio/host-zephyr.c
+++ b/src/audio/host-zephyr.c
@@ -371,7 +371,7 @@ static void host_one_shot_cb(struct comp_dev *dev, uint32_t bytes)
 /* This is called by DMA driver every time when DMA completes its current
  * transfer between host and DSP.
  */
-static void host_dma_cb(void *arg, enum notify_id type, void *data)
+void host_dma_cb(void *arg, enum notify_id type, void *data)
 {
 	struct dma_cb_data *next = data;
 	struct comp_dev *dev = arg;
@@ -474,16 +474,15 @@ static int host_copy_normal(struct comp_dev *dev)
 	return ret;
 }
 
-static int create_local_elems(struct comp_dev *dev, uint32_t buffer_count,
-			      uint32_t buffer_bytes)
+static int create_local_elems(struct host_data *hd, struct comp_dev *dev, uint32_t buffer_count,
+			      uint32_t buffer_bytes, uint32_t direction)
 {
-	struct host_data *hd = comp_get_drvdata(dev);
 	struct comp_buffer __sparse_cache *dma_buf_c;
 	struct dma_sg_elem_array *elem_array;
 	uint32_t dir;
 	int err;
 
-	dir = dev->direction == SOF_IPC_STREAM_PLAYBACK ?
+	dir = direction == SOF_IPC_STREAM_PLAYBACK ?
 		DMA_DIR_HMEM_TO_LMEM : DMA_DIR_LMEM_TO_HMEM;
 
 	/* if host buffer set we need to allocate local buffer */
@@ -670,9 +669,8 @@ static void host_free(struct comp_dev *dev)
 	rfree(dev);
 }
 
-static int host_elements_reset(struct comp_dev *dev)
+static int host_elements_reset(struct host_data *hd, int direction)
 {
-	struct host_data *hd = comp_get_drvdata(dev);
 	struct dma_sg_elem *source_elem;
 	struct dma_sg_elem *sink_elem;
 	struct dma_sg_elem *local_elem;
@@ -696,7 +694,7 @@ static int host_elements_reset(struct comp_dev *dev)
 		local_elem = hd->config.elem_array.elems;
 		local_elem->dest = sink_elem->dest;
 		local_elem->size =
-			dev->direction == SOF_IPC_STREAM_PLAYBACK ?
+			direction == SOF_IPC_STREAM_PLAYBACK ?
 			sink_elem->size : source_elem->size;
 		local_elem->src = source_elem->src;
 	}
@@ -720,11 +718,11 @@ static int host_verify_params(struct comp_dev *dev,
 	return 0;
 }
 
-/* configure the DMA params and descriptors for host buffer IO */
-static int host_params(struct comp_dev *dev,
-		       struct sof_ipc_stream_params *params)
+int host_zephyr_params(struct host_data *hd, struct comp_dev *dev,
+		       struct sof_ipc_stream_params *params, struct list_item *sink_list,
+		       struct list_item *source_list, struct pipeline *pipeline,
+		       uint32_t frames, bool is_scheduling_source)
 {
-	struct host_data *hd = comp_get_drvdata(dev);
 	struct dma_sg_config *config = &hd->config;
 	struct dma_sg_elem *sg_elem;
 	struct dma_config *dma_cfg = &hd->z_config;
@@ -737,14 +735,6 @@ static int host_params(struct comp_dev *dev,
 	uint32_t addr_align;
 	uint32_t align;
 	int i, channel, err;
-
-	comp_dbg(dev, "host_params()");
-
-	err = host_verify_params(dev, params);
-	if (err < 0) {
-		comp_err(dev, "host_params(): pcm params verification failed.");
-		return -EINVAL;
-	}
 
 	/* host params always installed by pipeline IPC */
 	hd->host_size = params->buffer.size;
@@ -777,17 +767,17 @@ static int host_params(struct comp_dev *dev,
 		return -EINVAL;
 	}
 
-	if (dev->direction == SOF_IPC_STREAM_PLAYBACK)
-		hd->local_buffer = list_first_item(&dev->bsink_list,
+	if (params->direction == SOF_IPC_STREAM_PLAYBACK)
+		hd->local_buffer = list_first_item(sink_list,
 						   struct comp_buffer,
 						   source_list);
 	else
-		hd->local_buffer = list_first_item(&dev->bsource_list,
+		hd->local_buffer = list_first_item(source_list,
 						   struct comp_buffer,
 						   sink_list);
 	host_buf_c = buffer_acquire(hd->local_buffer);
 
-	period_bytes = dev->frames *
+	period_bytes = frames *
 		audio_stream_frame_bytes(&host_buf_c->stream);
 
 	if (!period_bytes) {
@@ -797,7 +787,7 @@ static int host_params(struct comp_dev *dev,
 	}
 
 	/* determine source and sink buffer elements */
-	if (dev->direction == SOF_IPC_STREAM_PLAYBACK) {
+	if (params->direction == SOF_IPC_STREAM_PLAYBACK) {
 		config->direction = DMA_DIR_HMEM_TO_LMEM;
 		hd->source = &hd->host;
 		hd->sink = &hd->local;
@@ -846,7 +836,8 @@ static int host_params(struct comp_dev *dev,
 	}
 
 	/* create SG DMA elems for local DMA buffer */
-	err = create_local_elems(dev, period_count, buffer_size / period_count);
+	err = create_local_elems(hd, dev, period_count, buffer_size / period_count,
+				 params->direction);
 	if (err < 0)
 		goto out;
 
@@ -854,11 +845,11 @@ static int host_params(struct comp_dev *dev,
 	config->src_width = audio_stream_sample_bytes(&host_buf_c->stream);
 	config->dest_width = audio_stream_sample_bytes(&host_buf_c->stream);
 	config->cyclic = 0;
-	config->irq_disabled = pipeline_is_timer_driven(dev->pipeline);
-	config->is_scheduling_source = comp_is_scheduling_source(dev);
-	config->period = dev->pipeline->period;
+	config->irq_disabled = pipeline_is_timer_driven(pipeline);
+	config->is_scheduling_source = is_scheduling_source;
+	config->period = pipeline->period;
 
-	host_elements_reset(dev);
+	host_elements_reset(hd, params->direction);
 
 	hd->stream_tag -= 1;
 	uint32_t hda_chan = hd->stream_tag;
@@ -937,9 +928,6 @@ static int host_params(struct comp_dev *dev,
 	/* minimal copied data shouldn't be less than alignment */
 	hd->period_bytes = ALIGN_UP(period_bytes, hd->dma_copy_align);
 
-	/* set up callback */
-	notifier_register(dev, hd->chan, NOTIFIER_ID_DMA_COPY, host_dma_cb, 0);
-
 	/* set copy function */
 	hd->copy = hd->copy_type == COMP_COPY_ONE_SHOT ? host_copy_one_shot :
 		host_copy_normal;
@@ -950,6 +938,30 @@ static int host_params(struct comp_dev *dev,
 
 out:
 	buffer_release(host_buf_c);
+	return err;
+}
+
+/* configure the DMA params and descriptors for host buffer IO */
+static int host_params(struct comp_dev *dev,
+		       struct sof_ipc_stream_params *params)
+{
+	struct host_data *hd = comp_get_drvdata(dev);
+	int err;
+
+	comp_dbg(dev, "host_params()");
+
+	err = host_verify_params(dev, params);
+	if (err < 0) {
+		comp_err(dev, "host_params(): pcm params verification failed.");
+		return err;
+	}
+
+	err = host_zephyr_params(hd, dev, params, &dev->bsink_list, &dev->bsource_list,
+				 dev->pipeline, dev->frames, dev == dev->pipeline->sched_comp);
+	if (err >= 0)
+		/* set up callback */
+		notifier_register(dev, hd->chan, NOTIFIER_ID_DMA_COPY, host_dma_cb, 0);
+
 	return err;
 }
 

--- a/src/audio/host-zephyr.c
+++ b/src/audio/host-zephyr.c
@@ -514,29 +514,9 @@ static int create_local_elems(struct comp_dev *dev, uint32_t buffer_count,
 	return 0;
 }
 
-/**
- * \brief Command handler.
- * \param[in,out] dev Device
- * \param[in] cmd Command
- * \return 0 if successful, error code otherwise.
- *
- * Used to pass standard and bespoke commands (with data) to component.
- * This function is common for all dma types, with one exception:
- * dw-dma is run on demand, so no start()/stop() is issued.
- */
-static int host_trigger(struct comp_dev *dev, int cmd)
+int host_zephyr_trigger(struct host_data *hd, struct comp_dev *dev, int cmd)
 {
-	struct host_data *hd = comp_get_drvdata(dev);
-	int ret;
-
-	comp_dbg(dev, "host_trigger()");
-
-	ret = comp_set_state(dev, cmd);
-	if (ret < 0)
-		return ret;
-
-	if (ret == COMP_STATUS_STATE_ALREADY_SET)
-		return PPL_STATUS_PATH_STOP;
+	int ret = 0;
 
 	/* we should ignore any trigger commands besides start
 	 * when doing one shot, because transfers will stop automatically
@@ -571,6 +551,33 @@ static int host_trigger(struct comp_dev *dev, int cmd)
 	}
 
 	return ret;
+}
+
+/**
+ * \brief Command handler.
+ * \param[in,out] dev Device
+ * \param[in] cmd Command
+ * \return 0 if successful, error code otherwise.
+ *
+ * Used to pass standard and bespoke commands (with data) to component.
+ * This function is common for all dma types, with one exception:
+ * dw-dma is run on demand, so no start()/stop() is issued.
+ */
+static int host_trigger(struct comp_dev *dev, int cmd)
+{
+	struct host_data *hd = comp_get_drvdata(dev);
+	int ret;
+
+	comp_dbg(dev, "host_trigger()");
+
+	ret = comp_set_state(dev, cmd);
+	if (ret < 0)
+		return ret;
+
+	if (ret == COMP_STATUS_STATE_ALREADY_SET)
+		return PPL_STATUS_PATH_STOP;
+
+	return host_zephyr_trigger(hd, dev, cmd);
 }
 
 int host_zephyr_new(struct host_data *hd, struct comp_dev *dev,

--- a/src/include/ipc4/copier.h
+++ b/src/include/ipc4/copier.h
@@ -261,6 +261,7 @@ struct copier_data {
 	pcm_converter_func converter[IPC4_COPIER_MODULE_OUTPUT_PINS_COUNT];
 	uint64_t input_total_data_processed;
 	uint64_t output_total_data_processed;
+	bool ipc_gtw;
 };
 
 int apply_attenuation(struct comp_dev *dev, struct copier_data *cd,

--- a/src/include/ipc4/copier.h
+++ b/src/include/ipc4/copier.h
@@ -261,6 +261,7 @@ struct copier_data {
 	pcm_converter_func converter[IPC4_COPIER_MODULE_OUTPUT_PINS_COUNT];
 	uint64_t input_total_data_processed;
 	uint64_t output_total_data_processed;
+	struct host_data *hd;
 	bool ipc_gtw;
 };
 

--- a/src/include/sof/audio/host_copier.h
+++ b/src/include/sof/audio/host_copier.h
@@ -99,6 +99,8 @@ void host_zephyr_free(struct host_data *hd);
 int host_zephyr_prepare(struct host_data *hd);
 
 void host_zephyr_reset(struct host_data *hd, uint16_t state);
+
+int host_zephyr_trigger(struct host_data *hd, struct comp_dev *dev, int cmd);
 #else
 static inline int host_zephyr_new(struct host_data *hd, struct comp_dev *dev,
 				  const struct ipc_config_host *ipc_host, uint32_t config_id)
@@ -114,6 +116,12 @@ static inline int host_zephyr_prepare(struct host_data *hd)
 }
 
 static inline void host_zephyr_reset(struct host_data *hd, uint16_t state) {}
+
+static inline int host_zephyr_trigger(struct host_data *hd, struct comp_dev *dev,
+				      int cmd)
+{
+	return 0;
+}
 
 #endif
 #endif /* __SOF_HOST_COPIER_H__ */

--- a/src/include/sof/audio/host_copier.h
+++ b/src/include/sof/audio/host_copier.h
@@ -101,6 +101,13 @@ int host_zephyr_prepare(struct host_data *hd);
 void host_zephyr_reset(struct host_data *hd, uint16_t state);
 
 int host_zephyr_trigger(struct host_data *hd, struct comp_dev *dev, int cmd);
+
+int host_zephyr_params(struct host_data *hd, struct comp_dev *dev,
+		       struct sof_ipc_stream_params *params, struct list_item *sink_list,
+		       struct list_item *source_list, struct pipeline *pipeline,
+		       uint32_t frames, bool is_scheduling_source);
+
+void host_dma_cb(void *arg, enum notify_id type, void *data);
 #else
 static inline int host_zephyr_new(struct host_data *hd, struct comp_dev *dev,
 				  const struct ipc_config_host *ipc_host, uint32_t config_id)
@@ -122,6 +129,17 @@ static inline int host_zephyr_trigger(struct host_data *hd, struct comp_dev *dev
 {
 	return 0;
 }
+
+static inline int host_zephyr_params(struct host_data *hd, struct comp_dev *dev,
+				     struct sof_ipc_stream_params *params,
+				     struct list_item *sink_list,
+				     struct list_item *source_list, struct pipeline *pipeline,
+				     uint32_t frames, bool is_scheduling_source)
+{
+	return 0;
+}
+
+static inline void host_dma_cb(void *arg, enum notify_id type, void *data) {}
 
 #endif
 #endif /* __SOF_HOST_COPIER_H__ */

--- a/src/include/sof/audio/host_copier.h
+++ b/src/include/sof/audio/host_copier.h
@@ -21,8 +21,9 @@
 #include <ipc/stream.h>
 #include <sof/lib/notifier.h>
 
+struct host_data;
 /** \brief Host copy function interface. */
-typedef int (*host_copy_func)(struct comp_dev *dev);
+typedef int (*host_copy_func)(struct host_data *hd, struct comp_dev *dev);
 
 /**
  * \brief Host buffer info.
@@ -108,6 +109,7 @@ int host_zephyr_params(struct host_data *hd, struct comp_dev *dev,
 		       uint32_t frames, bool is_scheduling_source);
 
 void host_dma_cb(void *arg, enum notify_id type, void *data);
+int host_zephyr_copy(struct host_data *hd, struct comp_dev *dev);
 #else
 static inline int host_zephyr_new(struct host_data *hd, struct comp_dev *dev,
 				  const struct ipc_config_host *ipc_host, uint32_t config_id)
@@ -140,6 +142,11 @@ static inline int host_zephyr_params(struct host_data *hd, struct comp_dev *dev,
 }
 
 static inline void host_dma_cb(void *arg, enum notify_id type, void *data) {}
+
+static inline int host_zephyr_copy(struct host_data *hd, struct comp_dev *dev)
+{
+	return 0;
+}
 
 #endif
 #endif /* __SOF_HOST_COPIER_H__ */

--- a/src/include/sof/audio/host_copier.h
+++ b/src/include/sof/audio/host_copier.h
@@ -95,6 +95,10 @@ int host_zephyr_new(struct host_data *hd, struct comp_dev *dev,
 		    const struct ipc_config_host *ipc_host, uint32_t config_id);
 
 void host_zephyr_free(struct host_data *hd);
+
+int host_zephyr_prepare(struct host_data *hd);
+
+void host_zephyr_reset(struct host_data *hd, uint16_t state);
 #else
 static inline int host_zephyr_new(struct host_data *hd, struct comp_dev *dev,
 				  const struct ipc_config_host *ipc_host, uint32_t config_id)
@@ -103,6 +107,13 @@ static inline int host_zephyr_new(struct host_data *hd, struct comp_dev *dev,
 }
 
 static inline void host_zephyr_free(struct host_data *hd) {}
+
+static inline int host_zephyr_prepare(struct host_data *hd)
+{
+	return 0;
+}
+
+static inline void host_zephyr_reset(struct host_data *hd, uint16_t state) {}
 
 #endif
 #endif /* __SOF_HOST_COPIER_H__ */

--- a/src/include/sof/audio/host_copier.h
+++ b/src/include/sof/audio/host_copier.h
@@ -108,8 +108,11 @@ int host_zephyr_params(struct host_data *hd, struct comp_dev *dev,
 		       struct list_item *source_list, struct pipeline *pipeline,
 		       uint32_t frames, bool is_scheduling_source);
 
-void host_dma_cb(void *arg, enum notify_id type, void *data);
 int host_zephyr_copy(struct host_data *hd, struct comp_dev *dev);
+
+void host_update_position(struct host_data *hd, struct comp_dev *dev, uint32_t bytes);
+
+void host_one_shot_cb(struct host_data *hd, uint32_t bytes);
 #else
 static inline int host_zephyr_new(struct host_data *hd, struct comp_dev *dev,
 				  const struct ipc_config_host *ipc_host, uint32_t config_id)
@@ -141,12 +144,15 @@ static inline int host_zephyr_params(struct host_data *hd, struct comp_dev *dev,
 	return 0;
 }
 
-static inline void host_dma_cb(void *arg, enum notify_id type, void *data) {}
-
 static inline int host_zephyr_copy(struct host_data *hd, struct comp_dev *dev)
 {
 	return 0;
 }
+
+static inline void host_update_position(struct host_data *hd,
+					struct comp_dev *dev, uint32_t bytes) {}
+
+static inline void host_one_shot_cb(struct host_data *hd, uint32_t bytes) {}
 
 #endif
 #endif /* __SOF_HOST_COPIER_H__ */

--- a/src/include/sof/audio/host_copier.h
+++ b/src/include/sof/audio/host_copier.h
@@ -1,0 +1,108 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2023 Intel Corporation. All rights reserved.
+ *
+ * Author: Baofeng Tian <baofeng.tian@intel.com>
+ */
+
+/**
+ * \file audio/host_copier.h
+ * \brief host copier shared header file
+ * \authors Baofeng Tian <baofeng.tian@intel.com>
+ */
+
+#ifndef __SOF_HOST_COPIER_H__
+#define __SOF_HOST_COPIER_H__
+
+#include <sof/audio/component_ext.h>
+#include <sof/audio/pcm_converter.h>
+#include <sof/lib/dma.h>
+#include <sof/audio/ipc-config.h>
+#include <ipc/stream.h>
+#include <sof/lib/notifier.h>
+
+/** \brief Host copy function interface. */
+typedef int (*host_copy_func)(struct comp_dev *dev);
+
+/**
+ * \brief Host buffer info.
+ */
+struct hc_buf {
+	struct dma_sg_elem_array elem_array; /**< array of SG elements */
+	uint32_t current;		/**< index of current element */
+	uint32_t current_end;
+};
+
+/**
+ * \brief Host component data.
+ *
+ * Host reports local position in the host buffer every params.host_period_bytes
+ * if the latter is != 0. report_pos is used to track progress since the last
+ * multiple of host_period_bytes.
+ *
+ * host_size is the host buffer size (in bytes) specified in the IPC parameters.
+ */
+struct host_data {
+	/* local DMA config */
+	struct dma *dma;
+	struct dma_chan_data *chan;
+	struct dma_sg_config config;
+#ifdef __ZEPHYR__
+	struct dma_config z_config;
+#endif
+	struct comp_buffer *dma_buffer;
+	struct comp_buffer *local_buffer;
+
+	/* host position reporting related */
+	uint32_t host_size;	/**< Host buffer size (in bytes) */
+	uint32_t report_pos;	/**< Position in current report period */
+	uint32_t local_pos;	/**< Local position in host buffer */
+	uint32_t host_period_bytes;
+	uint16_t stream_tag;
+	uint16_t no_stream_position; /**< 1 means don't send stream position */
+	uint64_t total_data_processed;
+	uint8_t cont_update_posn; /**< 1 means continuous update stream position */
+
+	/* host component attributes */
+	enum comp_copy_type copy_type;	/**< Current host copy type */
+
+	/* local and host DMA buffer info */
+	struct hc_buf host;
+	struct hc_buf local;
+
+	/* pointers set during params to host or local above */
+	struct hc_buf *source;
+	struct hc_buf *sink;
+
+	uint32_t dma_copy_align; /**< Minimal chunk of data possible to be
+				   *  copied by dma connected to host
+				   */
+	uint32_t period_bytes;	/**< number of bytes per one period */
+
+	host_copy_func copy;	/**< host copy function */
+	pcm_converter_func process;	/**< processing function */
+
+	/* IPC host init info */
+	struct ipc_config_host ipc_host;
+
+	/* stream info */
+	struct sof_ipc_stream_posn posn; /* TODO: update this */
+	struct ipc_msg *msg;	/**< host notification */
+};
+
+#if CONFIG_ZEPHYR_NATIVE_DRIVERS
+int host_zephyr_new(struct host_data *hd, struct comp_dev *dev,
+		    const struct ipc_config_host *ipc_host, uint32_t config_id);
+
+void host_zephyr_free(struct host_data *hd);
+#else
+static inline int host_zephyr_new(struct host_data *hd, struct comp_dev *dev,
+				  const struct ipc_config_host *ipc_host, uint32_t config_id)
+{
+	return 0;
+}
+
+static inline void host_zephyr_free(struct host_data *hd) {}
+
+#endif
+#endif /* __SOF_HOST_COPIER_H__ */

--- a/src/include/sof/audio/host_copier.h
+++ b/src/include/sof/audio/host_copier.h
@@ -104,9 +104,7 @@ void host_zephyr_reset(struct host_data *hd, uint16_t state);
 int host_zephyr_trigger(struct host_data *hd, struct comp_dev *dev, int cmd);
 
 int host_zephyr_params(struct host_data *hd, struct comp_dev *dev,
-		       struct sof_ipc_stream_params *params, struct list_item *sink_list,
-		       struct list_item *source_list, struct pipeline *pipeline,
-		       uint32_t frames, bool is_scheduling_source);
+		       struct sof_ipc_stream_params *params);
 
 int host_zephyr_copy(struct host_data *hd, struct comp_dev *dev);
 
@@ -136,10 +134,7 @@ static inline int host_zephyr_trigger(struct host_data *hd, struct comp_dev *dev
 }
 
 static inline int host_zephyr_params(struct host_data *hd, struct comp_dev *dev,
-				     struct sof_ipc_stream_params *params,
-				     struct list_item *sink_list,
-				     struct list_item *source_list, struct pipeline *pipeline,
-				     uint32_t frames, bool is_scheduling_source)
+				     struct sof_ipc_stream_params *params)
 {
 	return 0;
 }


### PR DESCRIPTION
Currently, copier actually created 2 devices for data input, it is
host and copier, hence there are two times copy from DMA buffer
to local buffer then to component buffer.

This PR intend to remove host device and one more time copy
through use host data to handle host interface calling.

Basically, there are several steps to go there:

1. Add host data to copier data structure.
2. Share host data structure to copier by add a host copier common header file.
3. In copier, all host related ops calling should be replaced with new host exposed interface.
4. Remove one more time copy and host endpoint buffer.
5. Remove host device.

Performance data:
1. mcps, saved 1.9mcps, 5.9 --> 4.0, 33% saved for copier.
    Before: comp:0 0x40000 perf comp_copy samples 48 period 1000 cpu avg 586 peak 598
    After:   comp:0 0x40000 perf comp_copy samples 48 period 1000 cpu avg 408 peak 422

2. memory, since host endpoint buffer and host device got removed, for each copier,
   16bit/32bit 384/768 bytes saved for buffer, 112 saved for host device.
   As a summary, 16/32 bit playback/capture totally saved 496/884 bytes for each copier usage.
   For the cases that have more than 10 copier usage, memory saving is quite remarkable.

Note：multiple sink host copier is not tested and will be fixed in a follow up dai optimization PR.

Signed-off-by: Baofeng Tian <baofeng.tian@intel.com>