### PR TITLE
platform: ace: enable IDC on primary core

### DIFF
--- a/src/platform/intel/ace/platform.c
+++ b/src/platform/intel/ace/platform.c
@@ -100,6 +100,7 @@ int platform_init(struct sof *sof)
 	/* initialize the host IPC mechanisms */
 	trace_point(TRACE_BOOT_PLATFORM_IPC);
 	ipc_init(sof);
+	idc_init();
 
 	/* show heap status */
 	heap_trace_all(1);


### PR DESCRIPTION
Init IDC on primary core to enable receiving IDCs from secondary cores.

Signed-off-by: Krzysztof Frydryk <krzysztofx.frydryk@intel.com>