### PR TITLE
[UPDATE ZEPHYR] zephyr: dai: Check error code before xrun report

### DIFF
--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -1227,7 +1227,8 @@ static int dai_copy(struct comp_dev *dev)
 	/* get data sizes from DMA */
 	ret = dma_get_status(dd->chan->dma->z_dev, dd->chan->index, &stat);
 	if (ret < 0) {
-		dai_report_xrun(dev, 0);
+		if (ret == -EPIPE)
+			dai_report_xrun(dev, 0);
 		return ret;
 	}
 	avail_bytes = stat.pending_length;

--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: d9c4ec31fc49e7eef3c8c3b0d07827cc04e6efee
+      revision: 0de83109de16d438192d93c4ceb1ba2e416c1082
       remote: zephyrproject
       # Import some projects listed in zephyr/west.yml@revision
       #


### PR DESCRIPTION
The dma_get_status function returns -EINVAL if it detects an invalid parameter, -EPIPE if it detects an xrun. Added error code check before calling xrun handler.

Updated zephyr revision to 5d902ea621e43ec9a3916eed8dea5ab3647d81c3.