### PR TITLE
scripts/xtensa-build-zephyr.py: checksum [sof_]version.h files

### DIFF
--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -825,7 +825,12 @@ def install_platform(platform, sof_platform_output_dir):
 BIN_NAME = 'zephyr'
 
 CHECKSUM_WANTED = [
-	'*.ri',     # Some .ri files have a non-deterministic signature, others not
+	# Some .ri files have a deterministic signature, others use
+	# a cryptographic salt. Even for the latter a checksum is still
+	# useful to match an artefact with a specific build log.
+	'*.ri',
+	'dsp_basefw.bin',
+
 	'*version*.h',
 	'*configs.c', # deterministic unlike .config
 	'*.strip', '*stripped*', # stripped ELF files are reproducible

--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -761,6 +761,10 @@ def install_platform(platform, sof_platform_output_dir):
 		# Fail if one of these is missing
 		InstFile(".config", "config", txt=True),
 		InstFile("misc/generated/configs.c", "generated_configs.c", txt=True),
+		InstFile("include/generated/version.h", "zephyr_version.h",
+			 gzip=False, txt=True),
+		InstFile("include/generated/sof_versions.h", "sof_versions.h",
+			 gzip=False, txt=True),
 		InstFile(BIN_NAME + ".elf"),
 		InstFile(BIN_NAME + ".lst", txt=True),
 		InstFile(BIN_NAME + ".map", txt=True),
@@ -822,6 +826,7 @@ BIN_NAME = 'zephyr'
 
 CHECKSUM_WANTED = [
 	'*.ri',     # Some .ri files have a non-deterministic signature, others not
+	'*version*.h',
 	'*configs.c', # deterministic unlike .config
 	'*.strip', '*stripped*', # stripped ELF files are reproducible
 	'boot.mod', # no debug section -> no need to strip this ELF


### PR DESCRIPTION
`git describe` differences happen, especially when trying to optimize cloning and this is for instance what happened in
https://github.com/thesofproject/sof/pull/6950#issuecomment-1396150533 where zephyr tags were fetched on Linux but not on Windows

This also makes plain git version differences more obvious; no need to scroll all the way up and scan the build logs.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>