### PR TITLE
topology2: sof-mtl-rt711-4ch: specify PLATFORM=mtl

### DIFF
--- a/tools/topology/topology2/cavs-sdw.conf
+++ b/tools/topology/topology2/cavs-sdw.conf
@@ -34,6 +34,7 @@
 <hdmi-default.conf>
 
 Define {
+	PLATFORM 		"none"
 	DMIC_IO_CLK 38400000
 	NUM_DMICS 0
 	# override DMIC default definitions
@@ -60,6 +61,11 @@ Define {
 	SDW_JACK_IN_BE_ID	1
 	NUM_SDW_AMPS 0
 	SDW_DMIC 0
+}
+
+# override defaults with platform-specific config
+IncludeByKey.PLATFORM {
+	"mtl"	"platform/intel/mtl.conf"
 }
 
 # include DMIC config if needed.

--- a/tools/topology/topology2/sof-ace-tplg/CMakeLists.txt
+++ b/tools/topology/topology2/sof-ace-tplg/CMakeLists.txt
@@ -17,7 +17,7 @@ DEEPBUFFER_FW_DMA_MS=100"
 
 # SDW + DMIC topology with passthrough pipelines
 # We will change NUM_HDMIS to 3 once HDMI is enabled on MTL RVP
-"cavs-sdw\;sof-mtl-rt711-4ch\;NUM_DMICS=4,DMIC0_ID=2,DMIC1_ID=3,NUM_HDMIS=0,\
+"cavs-sdw\;sof-mtl-rt711-4ch\;PLATFORM=mtl,NUM_DMICS=4,DMIC0_ID=2,DMIC1_ID=3,NUM_HDMIS=0,\
 PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-mtl-rt711-4ch.bin,DEEPBUFFER_FW_DMA_MS=100"
 
 "cavs-rt5682\;sof-mtl-max98357a-rt5682\;PLATFORM=mtl,NUM_DMICS=4,PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,\


### PR DESCRIPTION
It worked because we defined DMIC_DRIVER_VERSION 3 as the default value. We have to specify PLATFORM=mtl when the default value was removed.

Fixes: #6968

Signed-off-by: Bard Liao <yung-chuan.liao@linux.intel.com>