### PR TITLE
dai-zephyr: fix crash in dai_reset

### DIFF
--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -982,9 +982,11 @@ static int dai_reset(struct comp_dev *dev)
 		dai_dma_release(dev);
 
 	dma_sg_free(&config->elem_array);
-	rfree(dd->z_config->head_block);
-	rfree(dd->z_config);
-	dd->z_config = NULL;
+	if (dd->z_config) {
+		rfree(dd->z_config->head_block);
+		rfree(dd->z_config);
+		dd->z_config = NULL;
+	}
 
 	if (dd->dma_buffer) {
 		buffer_free(dd->dma_buffer);


### PR DESCRIPTION
It is not guaranteed that 'dd->z_config' is set when dai_reset() is called. E.g. if the requested runtime parameters are not supported by the hardware, the parameter setup will not be completed. When dai_reset() is called in this state, a FW crash is hit due to NULL dereference.

Fix the issue by checking dd->z_config value before use.

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>