### PR TITLE
[SKIP CI] .github/SPDX-README.md: clarify .c/.h difference and applicability

### DIFF
--- a/.github/workflows/SPDX-README.md
+++ b/.github/workflows/SPDX-README.md
@@ -1,9 +1,12 @@
+Read this section if there are some SPDX warnings above.
 Pleasing checkpatch is hard when adding new files because:
 
-- checkpatch wants a different SPDX style for .c versus .h files!
-- SOF rejects C99 comments starting with //
+- checkpatch requests a different SPDX style for .c versus .h files.
+  This is because some .h files are included in linker scripts or
+  assembly code.
+- Some SOF reviewers reject C99 comments starting with //
 
-The trick is to keep the SPDX separate. See solution below.
+A trick is to keep the SPDX separate, see solution below.
 
 References:
 - https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Documentation/process/license-rules.rst#n71


### PR DESCRIPTION
Explain when this file applies and why there is a .c/.h difference.

I still don't understand why .c file don't use /* SPDX */ but I think it's still worth quoting a tiny bit from the official documentation anyway.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>