### PR TITLE
ipc4: dai: remove S32_LE hardcode for SSP DAIs

### DIFF
--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -90,8 +90,6 @@ int ipc_dai_data_config(struct comp_dev *dev)
 	case SOF_DAI_INTEL_SSP:
 		/* set dma burst elems to slot number */
 		dd->config.burst_elems = copier_cfg->base.audio_fmt.channels_count;
-		/* DMA buffer size is in fixed format of 32bit in IPC4 case */
-		dev->ipc_config.frame_fmt = SOF_IPC_FRAME_S32_LE;
 		break;
 	case SOF_DAI_INTEL_DMIC:
 		/* Depth is passed by DMIC driver that retrieves it from blob */


### PR DESCRIPTION
The limitation that SSP sample format is always S32_LE does not hold. There can be I2S codecs where 16bit sample width is used and SSP FIFO will expect 16bit samples from DMA.

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>