### PR TITLE
Apollo Lake needs MCLK 1 for working da7219

### DIFF
--- a/tools/topology/topology1/sof-apl-da7219.m4
+++ b/tools/topology/topology1/sof-apl-da7219.m4
@@ -157,21 +157,21 @@ PCM_PLAYBACK_ADD(HDMI3, 7, PIPELINE_PCM_7)
 # BE configurations - overrides config in ACPI if present
 #
 
-#SSP 5 (ID: 0) with 19.2 MHz mclk with MCLK_ID 0 (unused), 1.536 MHz blck
+#SSP 5 (ID: 0) with 19.2 MHz mclk with MCLK_ID 1 (unused), 1.536 MHz blck
 DAI_CONFIG(SSP, 5, 0, SSP5-Codec,
 	SSP_CONFIG(I2S, SSP_CLOCK(mclk, 19200000, codec_mclk_in),
 		SSP_CLOCK(bclk, 1536000, codec_slave),
 		SSP_CLOCK(fsync, 48000, codec_slave),
 		SSP_TDM(2, 16, 3, 3),
-		SSP_CONFIG_DATA(SSP, 5, 16, 0)))
+		SSP_CONFIG_DATA(SSP, 5, 16, 1)))
 
-#SSP 1 (ID: 1) with 19.2 MHz mclk with MCLK_ID 0, 1.92 MHz bclk
+#SSP 1 (ID: 1) with 19.2 MHz mclk with MCLK_ID 1, 1.92 MHz bclk
 DAI_CONFIG(SSP, 1, 1, SSP1-Codec,
 	SSP_CONFIG(I2S, SSP_CLOCK(mclk, 19200000, codec_mclk_in),
 		SSP_CLOCK(bclk, 1920000, codec_slave),
 		SSP_CLOCK(fsync, 48000, codec_slave),
 		SSP_TDM(2, 20, 3, 3),
-		SSP_CONFIG_DATA(SSP, 1, 16, 0)))
+		SSP_CONFIG_DATA(SSP, 1, 16, 1)))
 
 # dmic01 (id: 2)
 DAI_CONFIG(DMIC, 0, 2, dmic01,


### PR DESCRIPTION
Headphone output requires MCLK_ID to be set to 1

Fix for headphone issue noticed in #6963

Tested: https://www.youtube.com/watch?v=mtPHPJKPp6o