### PR TITLE
topology2: add a mixin-mixout level to nocodec

### DIFF
--- a/tools/topology/topology2/cavs-nocodec.conf
+++ b/tools/topology/topology2/cavs-nocodec.conf
@@ -22,6 +22,7 @@
 <gain-capture.conf>
 <gain-copier-capture.conf>
 <deepbuffer-playback.conf>
+<mixout-mixin.conf>
 <data.conf>
 <pcm.conf>
 <pcm_caps.conf>
@@ -64,6 +65,16 @@ Define {
 	DEEP_BUFFER_PIPELINE_SINK	'mixout.2.1'
 	DEEP_BUFFER_PCM_NAME		'Deepbuffer Port0'
 	SMART_AMP_UUID			"1e:96:7a:16:e4:8a:ea:11:89:f1:00:0c:29:ce:16:35"
+	# SSP0 stream has two versions: with 3 and with 5 pipelines
+	SSP0_MIXER_2LEVEL		0
+	SSP0_MIXER_PCM_ID_1		41
+	SSP0_MIXER_PIPELINE_ID_1	16
+	SSP0_MIXER_PIPELINE_ID_2	21
+	SSP0_MIXER_SOURCE_1		'mixin.1.1'
+	SSP0_MIXER_SINK_1		'mixout.2.1'
+	SSP0_MIXER_SOURCE_2		'mixin.16.1'
+	SSP0_MIXER_SINK_2		'mixout.16.1'
+	SSP0_MIXER_SOURCE_3		'mixin.21.1'
 }
 
 # override defaults with platform-specific config
@@ -144,14 +155,16 @@ Object.Dai.SSP [
 #
 # Pipeline definitions
 #
-# PCM0 ---> gain ----> Mixin ----> Mixout ----> gain ----> smart_amp ----> SSP0
-# PCM1 ---> gain ----> Mixin ----> Mixout ----> gain ----> SSP1
-# PCM2 ---> gain ----> Mixin ----> Mixout ----> gain ----> SSP2
-#
-# SSP0 ----> PCM0
-# SSP0 ----> smart_amp
-# SSP1 ----> PCM1
-# SSP2 ----> PCM2
+# PCM1 ---> gain ---> Mixin ---> Mixout ---> gain ---> SSP1
+# PCM2 ---> gain ---> Mixin ---> Mixout ---> gain ---> SSP2
+# PCM4 ---> gain ---> Mixin -------------------------->\
+# PCM3 ---> gain ---> Mixin ---->\                      \
+# PCM0 ---> gain ---> Mixin ---> Mixout ---> Mixin ---> Mixout ---> gain ---> smart_amp ---> SSP0
+#                                                                             /
+#    /---------------------------------------------------------------------->/
+# SSP0 ---> PCM0
+# SSP1 ---> PCM1
+# SSP2 ---> PCM2
 
 # Pipeline ID:1 PCM ID: 0
 Object.Pipeline.host-copier-gain-mixin-playback [
@@ -696,10 +709,6 @@ Object.Base.route [
 		sink	"copier.SSP.2.1"
 	}
 	{
-		source	"mixin.1.1"
-		sink	"mixout.2.1"
-	}
-	{
 		source	"gain.4.1"
 		sink	"copier.SSP.4.1"
 	}
@@ -752,3 +761,15 @@ Object.Base.route [
 		sink	"smart_amp.2.1"
 	}
 ]
+
+IncludeByKey.SSP0_MIXER_2LEVEL {
+	"0"	{
+			Object.Base.route [
+				{
+					source	$SSP0_MIXER_SOURCE_1
+					sink	$SSP0_MIXER_SINK_1
+				}
+			]
+		}
+	"1"	"platform/intel/nocodec-ssp0-2level.conf"
+}

--- a/tools/topology/topology2/development/CMakeLists.txt
+++ b/tools/topology/topology2/development/CMakeLists.txt
@@ -13,7 +13,9 @@ set(TPLGS
 
 # CAVS SSP topology for TGL
 "cavs-nocodec\;sof-tgl-nocodec\;NUM_DMICS=4,PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,\
-PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-tgl-nocodec.bin,DEEPBUFFER_FW_DMA_MS=100"
+PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-tgl-nocodec.bin,DEEPBUFFER_FW_DMA_MS=100,\
+SSP0_MIXER_2LEVEL=1"
+
 "cavs-nocodec\;sof-adl-nocodec\;NUM_DMICS=4,PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,\
 PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-adl-nocodec.bin,DEEPBUFFER_FW_DMA_MS=100"
 

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-mixin.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-mixin.conf
@@ -1,0 +1,69 @@
+# mid-stream pipeline: mixout-mixin.
+#
+# All attributes defined herein are namespaced
+# by alsatplg to "Object.Pipeline.mixout-mixin.N.attribute_name"
+#
+# Usage: mixout-mixin pipeline object can be instantiated as:
+#
+# Object.Pipeline.mixout-mixin."N" {
+# 	period		1000
+# 	time_domain	"timer"
+# 	channels	2
+# 	rate		48000
+# }
+#
+# Where N is the unique pipeline ID within the same alsaconf node.
+
+<include/components/mixin.conf>
+<include/components/mixout.conf>
+<include/components/pipeline.conf>
+
+Class.Pipeline."mixout-mixin" {
+
+	DefineAttribute."index" {}
+
+	<include/pipelines/pipeline-common.conf>
+
+	attributes {
+		!constructor [
+			"index"
+		]
+
+		!mandatory [
+			"direction"
+		]
+
+		#
+		# mixout-mixin objects instantiated within the same alsaconf node must have
+		# unique pipeline_id attribute
+		#
+		unique	"instance"
+	}
+
+	Object.Widget {
+		mixout.1 {}
+		mixin.1 {}
+
+		pipeline.1 {
+			priority	0
+			lp_mode		0
+		}
+	}
+
+	Object.Base {
+		route.1 {
+			source	mixout..1
+			sink	mixin..1
+		}
+	}
+
+	direction	"playback"
+	dynamic_pipeline 1
+	time_domain	"timer"
+	channels	2
+	channels_min	2
+	channels_max	2
+	rate		48000
+	rate_min	48000
+	rate_max	48000
+}

--- a/tools/topology/topology2/platform/intel/nocodec-ssp0-2level.conf
+++ b/tools/topology/topology2/platform/intel/nocodec-ssp0-2level.conf
@@ -1,0 +1,56 @@
+Object.Pipeline.host-copier-gain-mixin-playback [
+	{
+		index $SSP0_MIXER_PIPELINE_ID_2
+
+		Object.Widget.pipeline.1 {
+			stream_name 'NoCodec-0'
+		}
+		Object.Widget.copier.1 {
+			stream_name 'SSP0 Aux Playback'
+		}
+		Object.Widget.gain.1 {
+			Object.Control.mixer.1 {
+				name 'Playback Volume 8'
+			}
+		}
+	}
+]
+
+Object.Pipeline.mixout-mixin [
+	{
+		index $SSP0_MIXER_PIPELINE_ID_1
+
+		Object.Widget.pipeline.1 {
+			stream_name 'NoCodec-0'
+		}
+	}
+]
+
+Object.PCM.pcm [
+	{
+		name "Port0 Aux Playback"
+		id $SSP0_MIXER_PCM_ID_1
+		direction "playback"
+		Object.Base.fe_dai."Port0 aux" {}
+
+		Object.PCM.pcm_caps."playback" {
+			name "SSP0 Aux Playback"
+			formats 'S16_LE,S24_LE,S32_LE'
+		}
+	}
+]
+
+Object.Base.route [
+	{
+		source	$SSP0_MIXER_SOURCE_1
+		sink	$SSP0_MIXER_SINK_2
+	}
+	{
+		source	$SSP0_MIXER_SOURCE_2
+		sink	$SSP0_MIXER_SINK_1
+	}
+	{
+		source	$SSP0_MIXER_SOURCE_3
+		sink	$SSP0_MIXER_SINK_2
+	}
+]


### PR DESCRIPTION
Add a second level of mixin-mixout mixing and a PCM to the nocodec topology. Note, that it adds more hard-coded pipeline, route and PCM numbers in included topology files, but apparently there's no way ATM to specify those numbers at the caller level