### PR TITLE
topology2: Add instance attribute for all classes

### DIFF
--- a/tools/topology/topology2/cavs-mixin-mixout-hda.conf
+++ b/tools/topology/topology2/cavs-mixin-mixout-hda.conf
@@ -87,12 +87,16 @@ Object.PCM {
 	pcm.0 {
 		id 0
 		name 'HDA Analog'
-		Object.Base.fe_dai.'HDA Analog' {}
-		Object.PCM.pcm_caps.playback {
+		Object.Base.fe_dai.1 {
+			name "HDA Analog"
+		}
+		Object.PCM.pcm_caps.1 {
+			direction	"playback"
 			name $ANALOG_PLAYBACK_PCM
 			formats 'S32_LE,S24_LE,S16_LE'
 		}
-		Object.PCM.pcm_caps.capture {
+		Object.PCM.pcm_caps.2 {
+			direction	"capture"
 			name $ANALOG_CAPTURE_PCM
 			formats 'S32_LE,S24_LE,S16_LE'
 		}

--- a/tools/topology/topology2/cavs-nocodec.conf
+++ b/tools/topology/topology2/cavs-nocodec.conf
@@ -366,14 +366,18 @@ Object.PCM {
 		name	"Port0"
 		id 0
 		direction	"duplex"
-		Object.Base.fe_dai."Port0" {}
+		Object.Base.fe_dai.1 {
+			name	"Port0"
+		}
 
-		Object.PCM.pcm_caps."playback" {
+		Object.PCM.pcm_caps.1 {
+			direction	"playback"
 			name "SSP0 Playback"
 			formats 'S16_LE,S24_LE,S32_LE'
 		}
 
-		Object.PCM.pcm_caps."capture" {
+		Object.PCM.pcm_caps.2 {
+			direction	"capture"
 			name "SSP0 Capture"
 			formats 'S16_LE,S24_LE,S32_LE'
 		}
@@ -382,9 +386,10 @@ Object.PCM {
 		name	"ssp-capture"
 		id 12
 		direction	"capture"
-		Object.Base.fe_dai."ssp-capture" {}
-
-		Object.PCM.pcm_caps."capture" {
+		Object.Base.fe_dai.1 {
+			name	"ssp-capture"
+		}
+		Object.PCM.pcm_caps.1 {
 			name "SSP0-1 Capture"
 			formats 'S16_LE,S24_LE,S32_LE'
 		}
@@ -393,14 +398,18 @@ Object.PCM {
 		name	"Port1"
 		id 1
 		direction	"duplex"
-		Object.Base.fe_dai."Port1" {}
+		Object.Base.fe_dai.1 {
+			name	"Port1"
+		}
 
-		Object.PCM.pcm_caps."playback" {
+		Object.PCM.pcm_caps.1 {
+			direction	"playback"
 			name "SSP1 Playback"
 			formats 'S16_LE,S24_LE,S32_LE'
 		}
 
-		Object.PCM.pcm_caps."capture" {
+		Object.PCM.pcm_caps.2 {
+			direction	"capture"
 			name "SSP1 Capture"
 			formats 'S16_LE,S24_LE,S32_LE'
 		}
@@ -409,14 +418,18 @@ Object.PCM {
 		name	"Port2"
 		id 2
 		direction	"duplex"
-		Object.Base.fe_dai."Port2" {}
+		Object.Base.fe_dai.1 {
+			name	"Port2"
+		}
 
-		Object.PCM.pcm_caps."playback" {
+		Object.PCM.pcm_caps.1 {
+			direction	"playback"
 			name "SSP2 Playback"
 			formats 'S16_LE,S24_LE,S32_LE'
 		}
 
-		Object.PCM.pcm_caps."capture" {
+		Object.PCM.pcm_caps.2 {
+			direction	"capture"
 			name "SSP2 Capture"
 			formats 'S16_LE,S24_LE,S32_LE'
 		}

--- a/tools/topology/topology2/cavs-rt5682.conf
+++ b/tools/topology/topology2/cavs-rt5682.conf
@@ -249,15 +249,19 @@ Object.PCM {
 		name	"Headset"
 		id	0
 		direction	"duplex"
-		Object.Base.fe_dai."Headset" {}
+		Object.Base.fe_dai.1 {
+			name	"Headset"
+		}
 
-		Object.PCM.pcm_caps."playback" {
-			name	"$HEADSET_PLAYBACK_PCM_STREAM_NAME"
+		Object.PCM.pcm_caps.1 {
+			direction	"playback"
+			name		"$HEADSET_PLAYBACK_PCM_STREAM_NAME"
 			formats	'S16_LE,S24_LE,S32_LE'
 		}
 
-		Object.PCM.pcm_caps."capture" {
-			name	"$HEADSET_CAPTURE_PCM_STREAM_NAME"
+		Object.PCM.pcm_caps.2 {
+			direction	"capture"
+			name		"$HEADSET_CAPTURE_PCM_STREAM_NAME"
 			formats	'S16_LE,S24_LE,S32_LE'
 		}
 	}
@@ -265,9 +269,11 @@ Object.PCM {
 		name	"Speakers"
 		id	1
 		direction	"playback"
-		Object.Base.fe_dai."Speakers" {}
+		Object.Base.fe_dai.1 {
+			name	"Speakers"
+		}
 
-		Object.PCM.pcm_caps."playback" {
+		Object.PCM.pcm_caps.1 {
 			name	"$SPEAKER_PLAYBACK_PCM_STREAM_NAME"
 			formats	'S16_LE,S24_LE,S32_LE'
 		}

--- a/tools/topology/topology2/cavs-sdw-src-gain-mixin.conf
+++ b/tools/topology/topology2/cavs-sdw-src-gain-mixin.conf
@@ -133,9 +133,11 @@ Object.PCM {
 		name	"Jack out"
 		id 0
 		direction	"playback"
-		Object.Base.fe_dai."Jack out" {}
+		Object.Base.fe_dai.1 {
+			name	"Jack out"
+		}
 
-		Object.PCM.pcm_caps."playback" {
+		Object.PCM.pcm_caps.1 {
 			name "Gain Playback 0"
 			formats 'S16_LE,S32_LE'
 			rate_min 16000
@@ -146,9 +148,11 @@ Object.PCM {
 		name	"Jack in"
 		id 1
 		direction	"capture"
-		Object.Base.fe_dai."Jack in" {}
+		Object.Base.fe_dai.1 {
+			name	"Jack in"
+		}
 
-		Object.PCM.pcm_caps."capture" {
+		Object.PCM.pcm_caps.1 {
 			name "Passthrough Capture 0"
 			formats 'S16_LE,S32_LE'
 		}

--- a/tools/topology/topology2/cavs-sdw.conf
+++ b/tools/topology/topology2/cavs-sdw.conf
@@ -194,9 +194,11 @@ Object.PCM {
 		name	"Jack out"
 		id 0
 		direction	"playback"
-		Object.Base.fe_dai."Jack out" {}
+		Object.Base.fe_dai.1 {
+			name	"Jack out"
+		}
 
-		Object.PCM.pcm_caps."playback" {
+		Object.PCM.pcm_caps.1 {
 			name "volume playback 0"
 			formats 'S16_LE,S32_LE'
 		}
@@ -205,9 +207,11 @@ Object.PCM {
 		name	"Jack in"
 		id 1
 		direction	"capture"
-		Object.Base.fe_dai."Jack in" {}
+		Object.Base.fe_dai.1 {
+			name	"Jack in"
+		}
 
-		Object.PCM.pcm_caps."capture" {
+		Object.PCM.pcm_caps.1 {
 			name "Passthrough Capture 0"
 			formats 'S16_LE,S32_LE'
 		}

--- a/tools/topology/topology2/get_abi.sh
+++ b/tools/topology/topology2/get_abi.sh
@@ -8,8 +8,10 @@ ABI_MINOR=$(awk '/^ *# *define *SOF_ABI_MINOR / { print $3 }' $1/src/include/ker
 ABI_PATCH=$(awk '/^ *# *define *SOF_ABI_PATCH / { print $3 }' $1/src/include/kernel/abi.h)
 
 cat <<EOF_HEADER
-Object.Base.manifest."sof_manifest" {
-	Object.Base.data."SOF ABI" {
+Object.Base.manifest.1 {
+	name "sof_manifest"
+	Object.Base.data.1 {
+		name "SOF ABI"
 EOF_HEADER
 
 print_1byte()

--- a/tools/topology/topology2/include/common/data.conf
+++ b/tools/topology/topology2/include/common/data.conf
@@ -7,6 +7,8 @@
 #
 Class.Base."data" {
 
+	DefineAttribute."instance" {}
+
 	DefineAttribute."name" {
 		type	"string"
 	}
@@ -21,8 +23,8 @@ Class.Base."data" {
 		]
 		#
 		# data objects instantiated within the same alsaconf node must have unique
-		# name attribute
+		# instance attribute
 		#
-		unique	"name"
+		unique	"instance"
 	}
 }

--- a/tools/topology/topology2/include/common/fe_dai.conf
+++ b/tools/topology/topology2/include/common/fe_dai.conf
@@ -1,10 +1,10 @@
 #
 # FE DAI Class definition. All attributes defined herein are namespaced
-# by alsatplg to "Object.Base.fe_dai.NAME.attribute_name".
+# by alsatplg to "Object.Base.fe_dai.instance.attribute_name".
 #
 # Usage: FE DAI objects can be instantiated as
 #
-#	Object.Base.fe_dai."NAME" {
+#	Object.Base.fe_dai.1 {
 #		id	0
 #	}
 #
@@ -12,6 +12,8 @@
 # same alsaconf node.
 
 Class.Base."fe_dai" {
+
+	DefineAttribute."instance" {}
 
 	DefineAttribute."name" {
 		type	"string"
@@ -28,9 +30,9 @@ Class.Base."fe_dai" {
 			"id"
 		]
 		#
-		# name attribute values for fe_dai objects must be unique in the
+		# instance attribute values for fe_dai objects must be unique in the
 		# same alsaconf node
 		#
-		unique	"name"
+		unique	"instance"
 	}
 }

--- a/tools/topology/topology2/include/common/manifest.conf
+++ b/tools/topology/topology2/include/common/manifest.conf
@@ -3,6 +3,8 @@
 #
 
 Class.Base."manifest" {
+	DefineAttribute."instance" {}
+
 	DefineAttribute."name" {
 		type	"string"
 	}
@@ -23,10 +25,10 @@ Class.Base."manifest" {
 			"name"
 		]
 		#
-		# name attribute values for manifest objects must be unique
+		# instance attribute values for manifest objects must be unique
 		# in the same alsaconf node
 		#
-		unique	"name"
+		unique	"instance"
 	}
 
 	# as default don't generate nhlt

--- a/tools/topology/topology2/include/common/pcm_caps.conf
+++ b/tools/topology/topology2/include/common/pcm_caps.conf
@@ -1,10 +1,10 @@
 #
 # PCM Capabilities Class definition. All attributes defined herein are
-# namespaced by alsatplg to "Object.PCM.pcm_caps.DIRECTION.attribute_name".
+# namespaced by alsatplg to "Object.PCM.pcm_caps.instance.attribute_name".
 #
 # Usage: PCM object can be instantiated as:
 #
-#	Object.PCM.pcm_caps."DIRECTION" {
+#	Object.PCM.pcm_caps.1 {
 #		name			"Headset"
 #		direction		"playback"
 #		formats			"S32_LE,S24_LE,S16_LE"
@@ -19,6 +19,9 @@
 # the same alsaconf node (normally, pcm object).
 
 Class.PCM."pcm_caps" {
+
+	DefineAttribute."instance" {}
+
 	#
 	# Argument used to construct PCM Capabilities
 	#
@@ -72,9 +75,9 @@ Class.PCM."pcm_caps" {
 
 		#
 		# pcm_caps objects instantiated within the same alsaconf node must have unique
-		# direction attribute
+		# instance attribute
 		#
-		unique	"direction"
+		unique	"instance"
 	}
 
 	# Default attribute values for PCM capabilities

--- a/tools/topology/topology2/include/common/tokens.conf
+++ b/tools/topology/topology2/include/common/tokens.conf
@@ -3,7 +3,8 @@
 #
 
 Object.Base.VendorToken {
-	"sof_tkn_comp" {
+	"1" {
+		name "sof_tkn_comp"
 		period_sink_count	400
 		period_source_count	401
 		format			402
@@ -23,7 +24,8 @@ Object.Base.VendorToken {
 		src_pin_binding_wname	414
 	}
 
-	"sof_tkn_dai" {
+	"2" {
+		name "sof_tkn_dai"
 		# Token retired with ABI 3.2, do not use for new capabilities
 		dmac_config			153
 		dai_type			154
@@ -31,35 +33,41 @@ Object.Base.VendorToken {
 		direction			156
 	}
 
-	"sof_tkn_buffer" {
+	"3" {
+		name "sof_tkn_buffer"
 		size			100
 		caps			101
 	}
 
-	"sof_tkn_volume" {
+	"4" {
+		name "sof_tkn_volume"
 		ramp_step_type		250
 		ramp_step_ms		251
 	}
 
-	"sof_tkn_gain" {
+	"5" {
+		name "sof_tkn_gain"
 		curve_type		260
 		curve_duration		261
 		init_value		262
 	}
 
-	"sof_tkn_src" {
+	"6" {
+		name "sof_tkn_src"
 		rate_in				300
 		rate_out			301
 	}
 
-	"sof_tkn_asrc" {
+	"7" {
+		name "sof_tkn_asrc"
 		rate_in				320
 		rate_out			321
 		asynchronous_mode	322
 		operation_mode		323
 	}
 
-	"sof_tkn_scheduler" {
+	"8" {
+		name "sof_tkn_scheduler"
 		period			200
 		priority		201
 		mips			202
@@ -72,7 +80,8 @@ Object.Base.VendorToken {
 		use_chain_dma		209
 	}
 
-	"sof_tkn_intel_ssp" {
+	"9" {
+		name "sof_tkn_intel_ssp"
 		clks_control		500
 		mclk_id			501
 		sample_bits		502
@@ -82,7 +91,8 @@ Object.Base.VendorToken {
 		bclk_delay		506
 	}
 
-	"sof_tkn_intel_dmic" {
+	"10" {
+		name "sof_tkn_intel_dmic"
 		driver_version		600
 		clk_min			601
 		clk_max			602
@@ -96,7 +106,8 @@ Object.Base.VendorToken {
 
 	}
 
-	"sof_tkn_intel_dmic_pdm" {
+	"11" {
+		name "sof_tkn_intel_dmic_pdm"
 		ctrl_id		700
 		mic_a_enable	701
 		mic_b_enable	702
@@ -107,33 +118,39 @@ Object.Base.VendorToken {
 
 	}
 
-	 "sof_tkn_process" {
+	 "12" {
+		name "sof_tkn_process"
 		# Token payload_with_output_fmt specifies whether there is
 		# output audio format in the init instance ipc4 message payload.
 		payload_with_output_fmt         901
 	}
 
-	"sof_tkn_stream" {
+	"13" {
+		name "sof_tkn_stream"
 		playback_compatible_d0i3         "1200"
 		capture_compatible_d0i3          "1201"
 	}
 
-        "sof_tkn_mute_led" {
+        "14" {
+		name "sof_tkn_mute_led"
                 mute_led_use            1300
                 mute_led_direction      1301
         }
 
-	"sof_tkn_alh" {
+	"15" {
+		name "sof_tkn_alh"
 		rate		1400
 		channels	1401
 	}
 
-	"sof_tkn_mixinout" {
+	"16" {
+		name "sof_tkn_mixinout"
 		mix_type	1700
 	}
 
 	# ABI 4.0 onwards
-	"sof_tkn_cavs_audio_format" {
+	"17" {
+		name "sof_tkn_cavs_audio_format"
 		in_rate		1900
 		in_bit_depth		1901
 		in_valid_bit_depth	1902
@@ -160,7 +177,8 @@ Object.Base.VendorToken {
 	}
 
 	# ABI 4.0 onwards
-	"sof_tkn_copier" {
+	"18" {
+		name "sof_tkn_copier"
 		node_type		1980
 	}
 }

--- a/tools/topology/topology2/include/common/vendor-token.conf
+++ b/tools/topology/topology2/include/common/vendor-token.conf
@@ -15,6 +15,8 @@
 #
 
 Class.Base.VendorToken {
+	DefineAttribute."instance" {}
+
 	#
 	# name for the vendortoken object
 	#
@@ -31,9 +33,9 @@ Class.Base.VendorToken {
 		]
 
 		#
-		# name attribute values for VendorToken objects must be unique in the same alsaconf
+		# instance attribute values for VendorToken objects must be unique in the same alsaconf
 		# node
 		#
-		unique	"name"
+		unique	"instance"
 	}
 }

--- a/tools/topology/topology2/include/components/gain.conf
+++ b/tools/topology/topology2/include/components/gain.conf
@@ -129,12 +129,16 @@ Class.Widget."gain" {
 		# gain mixer control
 		mixer."1" {
 			#Channel register and shift for Front Left/Right
-			Object.Base.channel."fl" {
+			Object.Base.channel.1 {
+				name "fl"
 				shift	0
 			}
-			Object.Base.channel."fr" {}
+			Object.Base.channel.2 {
+				name "fr"
+			}
 
-			Object.Base.ops."ctl" {
+			Object.Base.ops.1 {
+				name	"ctl"
 				info 	"volsw"
 				#256 binds the mixer control to volume get/put handlers
 				get 	256
@@ -142,13 +146,15 @@ Class.Widget."gain" {
 			}
 			max 45
 
-			Object.Base.tlv."vtlv_m90s2" {
-                                        Object.Base.scale."m90s2" {
-						min     -9000
-						step    200
-						mute    1
-					}
-                                }
+			Object.Base.tlv.1 {
+				name	"vtlv_m90s2"
+				Object.Base.scale.1 {
+					name	m90s2
+					min     -9000
+					step    200
+					mute    1
+				}
+			}
 		}
 	}
 

--- a/tools/topology/topology2/include/components/pipeline.conf
+++ b/tools/topology/topology2/include/components/pipeline.conf
@@ -20,9 +20,6 @@ Class.Widget."pipeline" {
 	#include common component definition
 	<include/components/widget-common.conf>
 
-	# instance of pipeline object in the same alsaconf node
-	DefineAttribute."instance" {}
-
 	#
 	# Bespoke Tuples for Pipelines
 	#

--- a/tools/topology/topology2/include/components/virtual.conf
+++ b/tools/topology/topology2/include/components/virtual.conf
@@ -13,6 +13,8 @@
 #
 
 Class.Widget."virtual" {
+	DefineAttribute."instance" {}
+
 	#
 	# Argument used to construct virtual widget object: name
 	#
@@ -42,7 +44,7 @@ Class.Widget."virtual" {
 		!mandatory [
 			"type"
 		]
-		unique	"name"
+		unique	"instance"
 	}
 
 	# default attribute values for virtual widget

--- a/tools/topology/topology2/include/components/volume.conf
+++ b/tools/topology/topology2/include/components/volume.conf
@@ -116,12 +116,16 @@ Class.Widget."pga" {
 		# volume mixer control
 		mixer."1" {
 			#Channel register and shift for Front Left/Right
-			Object.Base.channel."fl" {
+			Object.Base.channel.1 {
+				name	"fl"
 				shift	0
 			}
-			Object.Base.channel."fr" {}
+			Object.Base.channel.2 {
+				name	"fr"
+			}
 
-			Object.Base.ops."ctl" {
+			Object.Base.ops.1 {
+				name	"ctl"
 				info 	"volsw"
 				#256 binds the mixer control to volume get/put handlers
 				get 	256
@@ -132,24 +136,29 @@ Class.Widget."pga" {
 
 		# mute switch control
 		mixer."2" {
-			Object.Base.channel."flw" {
+			Object.Base.channel.1 {
+				name	"flw"
 				reg	2
 				shift	0
 			}
-			Object.Base.channel."fl" {
+			Object.Base.channel.2 {
+				name	"fl"
 				reg	2
 				shift	1
 			}
-			Object.Base.channel."fr" {
+			Object.Base.channel.3 {
+				name	"fr"
 				reg	2
 				shift	2
 			}
-			Object.Base.channel."frw" {
+			Object.Base.channel.4 {
+				name	"frw"
 				reg	2
 				shift	3
 			}
 
-			Object.Base.ops."ctl" {
+			Object.Base.ops.1 {
+				name	"ctl"
 				info "volsw"
 				#259 binds the mixer control to switch get/put handlers
 				get "259"

--- a/tools/topology/topology2/include/components/widget-common.conf
+++ b/tools/topology/topology2/include/components/widget-common.conf
@@ -2,6 +2,9 @@
 # Common widget attribute definitions
 #
 
+# instance of the widget object
+DefineAttribute."instance" {}
+
 #
 # no_pm - maps to the DAPM widget's reg field
 # "false" value indicates that there is no direct DAPM for this widget

--- a/tools/topology/topology2/include/controls/common.conf
+++ b/tools/topology/topology2/include/controls/common.conf
@@ -8,7 +8,7 @@
 #	}
 #
 Class.Base."channel" {
-
+	DefineAttribute."instance" {}
 	# name of the channel
 	DefineAttribute."name" {
 		type	"string"
@@ -24,9 +24,9 @@ Class.Base."channel" {
 		]
 		#
 		# scale objects instantiated within the same alsaconf node must have unique
-		# name attribute
+		# instance attribute
 		#
-		unique	"name"
+		unique	"instance"
 	}
 
 	reg	1
@@ -41,6 +41,7 @@ Class.Base."channel" {
 #	}
 #
 Class.Base."ops" {
+	DefineAttribute."instance" {}
 	# ops name
 	DefineAttribute."name" {
 		type	"string"
@@ -61,9 +62,9 @@ Class.Base."ops" {
 		]
 		#
 		# ops objects instantiated within the same alsaconf node must have unique
-		# name attribute
+		# instance attribute
 		#
-		unique	"name"
+		unique	"instance"
 	}
 }
 
@@ -75,6 +76,7 @@ Class.Base."ops" {
 #	}
 #
 Class.Base."extops" {
+	DefineAttribute."instance" {}
 	# extops name
 	DefineAttribute."name" {
 		type	"string"
@@ -96,9 +98,9 @@ Class.Base."extops" {
 		]
 		#
 		# extops objects instantiated within the same alsaconf node must have unique
-		# name attribute
+		# instance attribute
 		#
-		unique	"name"
+		unique	"instance"
 	}
 }
 
@@ -109,6 +111,7 @@ Class.Base."extops" {
 #	}
 #
 Class.Base."scale" {
+	DefineAttribute."instance" {}
 	DefineAttribute."name" {
 		type "string"
 	}
@@ -125,9 +128,9 @@ Class.Base."scale" {
 		]
 		#
 		# scale objects instantiated within the same alsaconf node must have unique
-		# name attribute
+		# instance attribute
 		#
-		unique	"name"
+		unique	"instance"
 	}
 
 	# Default scale attributes: "-64dB step 2dB"
@@ -142,6 +145,7 @@ Class.Base."scale" {
 #		Object.Base.scale."0" {}
 #	}
 Class.Base."tlv" {
+	DefineAttribute."instance" {}
 	DefineAttribute."name" {
 		type	"string"
 	}
@@ -151,8 +155,8 @@ Class.Base."tlv" {
 		]
 		#
 		# TLV objects instantiated within the same alsaconf node must have unique
-		# name attribute
+		# instance attribute
 		#
-		unique	"name"
+		unique	"instance"
 	}
 }

--- a/tools/topology/topology2/include/controls/mixer.conf
+++ b/tools/topology/topology2/include/controls/mixer.conf
@@ -8,11 +8,13 @@
 #		index	1
 #		name	"1 Master Playback Volume"
 #		mas 32
-#			Object.Base.channel."fl" {
+#			Object.Base.channel.1 {
+#				name "fl"
 #				shift	0
 #				reg 0
 #			}
-#			Object.Base.channel."fr" {
+#			Object.Base.channel.2 {
+#				name "fr"
 #				shift 1
 #				reg 1
 #			}

--- a/tools/topology/topology2/include/dais/pdm_config.conf
+++ b/tools/topology/topology2/include/dais/pdm_config.conf
@@ -1,4 +1,5 @@
 Class.Base."pdm_config" {
+	DefineAttribute."instance" {}
 	#
 	# Argument used to construct DMIC PDM config
 	#
@@ -42,7 +43,7 @@ Class.Base."pdm_config" {
 			"clk_edge"
 			"skew"
 		]
-		unique "ctrl_id"
+		unique "instance"
 	}
 
 	# default attribute values

--- a/tools/topology/topology2/platform/intel/deep-buffer.conf
+++ b/tools/topology/topology2/platform/intel/deep-buffer.conf
@@ -22,9 +22,11 @@
 			direction playback
 			playback_compatible_d0i3 true
 
-			Object.Base.fe_dai.'DeepBuffer' {}
+			Object.Base.fe_dai.1 {
+				name "DeepBuffer"
+			}
 
-			Object.PCM.pcm_caps.playback {
+			Object.PCM.pcm_caps.1 {
 				name $DEEP_BUFFER_PCM_NAME
 				formats 'S16_LE,S24_LE,S32_LE'
 			}

--- a/tools/topology/topology2/platform/intel/dmic-generic.conf
+++ b/tools/topology/topology2/platform/intel/dmic-generic.conf
@@ -18,12 +18,12 @@ Object.Dai {
 		}
 
 		# PDM controller config
-		Object.Base.pdm_config."0" {
+		Object.Base.pdm_config.1 {
 			mic_a_enable	$PDM0_MIC_A_ENABLE
 			mic_b_enable	$PDM0_MIC_B_ENABLE
 			ctrl_id	0
 		}
-		Object.Base.pdm_config."1" {
+		Object.Base.pdm_config.2 {
 			ctrl_id	1
 			mic_a_enable	$PDM1_MIC_A_ENABLE
 			mic_b_enable	$PDM1_MIC_B_ENABLE
@@ -52,12 +52,12 @@ Object.Dai {
                }
 
                # PDM controller config
-               Object.Base.pdm_config."3" {
+               Object.Base.pdm_config.1 {
                        mic_a_enable    $PDM0_MIC_A_ENABLE
                        mic_b_enable    $PDM0_MIC_B_ENABLE
                        ctrl_id 0
                }
-               Object.Base.pdm_config."4" {
+               Object.Base.pdm_config.2 {
                        ctrl_id 1
                        mic_a_enable    $PDM1_MIC_A_ENABLE
                        mic_b_enable    $PDM1_MIC_B_ENABLE
@@ -126,9 +126,11 @@ Object.PCM {
 		name	"DMIC"
 		id 10
 		direction	"capture"
-		Object.Base.fe_dai."DMIC" {}
+		Object.Base.fe_dai.1 {
+			name "DMIC"
+		}
 
-		Object.PCM.pcm_caps."capture" {
+		Object.PCM.pcm_caps.1 {
 			name $DMIC0_PCM_CAPS
 			# only 32-bit capture supported now
 			formats 'S32_LE'

--- a/tools/topology/topology2/platform/intel/dmic-wov.conf
+++ b/tools/topology/topology2/platform/intel/dmic-wov.conf
@@ -120,9 +120,11 @@ Object.PCM {
 		name	"DMIC16k"
 		id	11
 		direction	"capture"
-		Object.Base.fe_dai."DMIC16k" {}
+		Object.Base.fe_dai.1 {
+			name "DMIC16k"
+		}
 
-		Object.PCM.pcm_caps."capture" {
+		Object.PCM.pcm_caps.1 {
 			name $DMIC1_PCM_CAPS
 			# only 32-bit capture supported now
 			formats 'S32_LE'

--- a/tools/topology/topology2/platform/intel/hdmi-4th.conf
+++ b/tools/topology/topology2/platform/intel/hdmi-4th.conf
@@ -35,8 +35,10 @@ Object.PCM {
 	pcm.8 {
 		name HDMI4
 		id $HDMI4_PCM_ID
-		Object.Base.fe_dai.HDMI4 {}
-		Object.PCM.pcm_caps.playback {
+		Object.Base.fe_dai.1 {
+			name	"HDMI4"
+		}
+		Object.PCM.pcm_caps.1 {
 			name $HDMI4_PCM_CAPS
 			formats 'S32_LE,S16_LE'
 		}

--- a/tools/topology/topology2/platform/intel/hdmi-generic.conf
+++ b/tools/topology/topology2/platform/intel/hdmi-generic.conf
@@ -92,8 +92,10 @@ Object.PCM {
 	pcm.5 {
 		name HDMI1
 		id $HDMI1_PCM_ID
-		Object.Base.fe_dai.HDMI1 {}
-		Object.PCM.pcm_caps.playback {
+		Object.Base.fe_dai.1 {
+			name "HDMI1"
+		}
+		Object.PCM.pcm_caps.1 {
 			name $HDMI1_PCM_CAPS
 			formats 'S32_LE,S16_LE'
 		}
@@ -102,8 +104,10 @@ Object.PCM {
 	pcm.6 {
 		name HDMI2
 		id $HDMI2_PCM_ID
-		Object.Base.fe_dai.HDMI2 {}
-		Object.PCM.pcm_caps.playback {
+		Object.Base.fe_dai.1 {
+			name "HDMI2"
+		}
+		Object.PCM.pcm_caps.1 {
 			name $HDMI2_PCM_CAPS
 			formats 'S32_LE,S16_LE'
 		}
@@ -112,8 +116,10 @@ Object.PCM {
 	pcm.7 {
 		name HDMI3
 		id $HDMI3_PCM_ID
-		Object.Base.fe_dai.HDMI3 {}
-		Object.PCM.pcm_caps.playback {
+		Object.Base.fe_dai.1 {
+			name "HDMI3"
+		}
+		Object.PCM.pcm_caps.1 {
 			name $HDMI3_PCM_CAPS
 			formats 'S32_LE,S16_LE'
 		}

--- a/tools/topology/topology2/platform/intel/sdw-amp-generic.conf
+++ b/tools/topology/topology2/platform/intel/sdw-amp-generic.conf
@@ -105,9 +105,11 @@ Object.PCM {
 		name	"Speaker"
 		id 2
 		direction	"playback"
-		Object.Base.fe_dai."Speaker" {}
+		Object.Base.fe_dai.1 {
+			name	"Speaker"
+		}
 
-		Object.PCM.pcm_caps."playback" {
+		Object.PCM.pcm_caps.1 {
 			name "sdw amplifiers"
 			formats 'S16_LE,S24_LE,S32_LE'
 		}
@@ -116,9 +118,11 @@ Object.PCM {
 		name	"Amp feedback"
 		id 3
 		direction	"capture"
-		Object.Base.fe_dai."Amp feedback" {}
+		Object.Base.fe_dai.1 {
+			name	"Amp feedback"
+		}
 
-		Object.PCM.pcm_caps."capture" {
+		Object.PCM.pcm_caps.1 {
 			name "amp feedback"
 			formats 'S16_LE,S32_LE'
 			channels_min $AMP_FEEDBACK_CH

--- a/tools/topology/topology2/platform/intel/sdw-dmic-generic.conf
+++ b/tools/topology/topology2/platform/intel/sdw-dmic-generic.conf
@@ -52,9 +52,11 @@ Object.PCM {
 		name	"Microphone"
 		id 4
 		direction	"capture"
-		Object.Base.fe_dai."SDW DMIC" {}
+		Object.Base.fe_dai.1 {
+			name "SDW DMIC"
+		}
 
-		Object.PCM.pcm_caps."capture" {
+		Object.PCM.pcm_caps.1 {
 			name "sdw dmic"
 			formats 'S16_LE,S24_LE,S32_LE'
 		}

--- a/tools/topology/topology2/sof-hda-generic.conf
+++ b/tools/topology/topology2/sof-hda-generic.conf
@@ -67,75 +67,93 @@ Define {
 <hdmi-generic.conf>
 
 Object.Widget.virtual {
-	codec0_in {
+	1 {
+		name 'codec0_in'
 		type input
 		index 1
 	}
-	codec1_in {
+	2 {
+		name 'codec1_in'
 		type input
 		index 2
 	}
-	codec0_out {
+	3 {
+		name 'codec0_out'
 		type output
 		index 3
 	}
-	codec1_out {
+	4 {
+		name 'codec1_out'
 		type output
 		index 4
 	}
-	codec2_in {
+	5 {
+		name 'codec2_in'
 		type input
 		index 5
 	}
-	codec2_out {
+	6 {
+		name 'codec2_out'
 		type output
 		index 6
 	}
-	iDisp1_out {
+	7 {
+		name 'iDisp1_out'
 		type output
 		index 7
 	}
-	iDisp2_out {
+	8 {
+		name 'iDisp2_out'
 		type output
 		index 8
 	}
-	iDisp3_out {
+	9 {
+		name 'iDisp3_out'
 		type output
 		index 9
 	}
-	'iDisp3 Tx' {
+	10 {
+		name 'iDisp3 Tx'
 		type out_drv
 		index 0
 	}
-	'iDisp2 Tx' {
+	11 {
+		name 'iDisp2 Tx'
 		type out_drv
 		index 1
 	}
-	'iDisp1 Tx' {
+	12 {
+		name 'iDisp1 Tx'
 		type out_drv
 		index 2
 	}
-	'Analog CPU Playback' {
+	13 {
+		name 'Analog CPU Playback'
 		type out_drv
 		index 3
 	}
-	'Digital CPU Playback' {
+	14 {
+		name 'Digital CPU Playback'
 		type out_drv
 		index 4
 	}
-	'Alt Analog CPU Playback' {
+	15 {
+		name 'Alt Analog CPU Playback'
 		type out_drv
 		index 5
 	}
-	'Analog CPU Capture' {
+	16 {
+		name 'Analog CPU Capture'
 		type input
 		index 6
 	}
-	'Digital CPU Capture' {
+	17 {
+		name 'Digital CPU Capture'
 		type input
 		index 7
 	}
-	'Alt Analog CPU Capture' {
+	18 {
+		name 'Alt Analog CPU Capture'
 		type input
 		index 8
 	}


### PR DESCRIPTION
In preparation for making it easier to write topology conf files that can be conditionally included without having to worry about conflicting node ID's for objects between the included file and the top-level conf file, modify all classes to include an instance attribute. This means that irrespective of the object type, all objects will be instantiated as follows:

Object.Widget.gain.1 {} or Object.Base.pdm_config.2 {} etc

The instance ID's are typically only meant for the alsatplg compiler to differentiate the nodes in the conf file and are not relevant for the kernel or the firmware. This change will allow the alsatplg compiler to be modified to automatically make the node ID's unique before conditionally including conf files.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>