### PR TITLE
Init: move to Zephyr native

### DIFF
--- a/src/audio/aria/aria.c
+++ b/src/audio/aria/aria.c
@@ -12,6 +12,7 @@
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
 #include <rtos/cache.h>
+#include <rtos/init.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/notifier.h>
 #include <sof/lib/uuid.h>
@@ -378,3 +379,4 @@ UT_STATIC void sys_comp_aria_init(void)
 }
 
 DECLARE_MODULE(sys_comp_aria_init);
+SOF_MODULE_INIT(aria, sys_comp_aria_init);

--- a/src/audio/asrc/asrc.c
+++ b/src/audio/asrc/asrc.c
@@ -11,6 +11,7 @@
 #include <sof/debug/panic.h>
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
+#include <rtos/init.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
 #include <sof/math/numbers.h>
@@ -1106,3 +1107,4 @@ UT_STATIC void sys_comp_asrc_init(void)
 }
 
 DECLARE_MODULE(sys_comp_asrc_init);
+SOF_MODULE_INIT(asrc, sys_comp_asrc_init);

--- a/src/audio/base_fw.c
+++ b/src/audio/base_fw.c
@@ -10,6 +10,7 @@
 #include <sof_versions.h>
 #include <sof/lib/cpu-clk-manager.h>
 #include <sof/lib/cpu.h>
+#include <rtos/init.h>
 
 #if CONFIG_ACE_V1X_ART_COUNTER || CONFIG_ACE_V1X_RTC_COUNTER
 #include <zephyr/device.h>
@@ -495,3 +496,4 @@ UT_STATIC void sys_comp_basefw_init(void)
 }
 
 DECLARE_MODULE(sys_comp_basefw_init);
+SOF_MODULE_INIT(basefw, sys_comp_basefw_init);

--- a/src/audio/chain_dma.c
+++ b/src/audio/chain_dma.c
@@ -23,6 +23,7 @@
 #include <ipc4/pipeline.h>
 #include <sof/ut.h>
 #include <zephyr/pm/policy.h>
+#include <rtos/init.h>
 
 static const struct comp_driver comp_chain_dma;
 static const uint32_t max_chain_number = DAI_NUM_HDA_OUT + DAI_NUM_HDA_IN;
@@ -653,3 +654,4 @@ UT_STATIC void sys_comp_chain_dma_init(void)
 }
 
 DECLARE_MODULE(sys_comp_chain_dma_init);
+SOF_MODULE_INIT(chain_dma, sys_comp_chain_dma_init);

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -17,6 +17,7 @@
 #include <rtos/timer.h>
 #include <rtos/alloc.h>
 #include <rtos/cache.h>
+#include <rtos/init.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/notifier.h>
 #include <sof/lib/uuid.h>
@@ -1565,3 +1566,4 @@ UT_STATIC void sys_comp_copier_init(void)
 }
 
 DECLARE_MODULE(sys_comp_copier_init);
+SOF_MODULE_INIT(copier, sys_comp_copier_init);

--- a/src/audio/crossover/crossover.c
+++ b/src/audio/crossover/crossover.c
@@ -16,6 +16,7 @@
 #include <sof/debug/panic.h>
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
+#include <rtos/init.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
 #include <sof/math/iir_df2t.h>
@@ -852,3 +853,4 @@ UT_STATIC void sys_comp_crossover_init(void)
 }
 
 DECLARE_MODULE(sys_comp_crossover_init);
+SOF_MODULE_INIT(crossover, sys_comp_crossover_init);

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -17,6 +17,7 @@
 #include <rtos/timer.h>
 #include <rtos/alloc.h>
 #include <rtos/cache.h>
+#include <rtos/init.h>
 #include <sof/lib/dai.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/notifier.h>
@@ -1117,3 +1118,4 @@ UT_STATIC void sys_comp_dai_init(void)
 }
 
 DECLARE_MODULE(sys_comp_dai_init);
+SOF_MODULE_INIT(dai, sys_comp_dai_init);

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -16,6 +16,7 @@
 #include <rtos/timer.h>
 #include <rtos/alloc.h>
 #include <rtos/cache.h>
+#include <rtos/init.h>
 #include <sof/lib/dai.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/notifier.h>
@@ -1459,3 +1460,4 @@ UT_STATIC void sys_comp_dai_init(void)
 }
 
 DECLARE_MODULE(sys_comp_dai_init);
+SOF_MODULE_INIT(dai, sys_comp_dai_init);

--- a/src/audio/dcblock/dcblock.c
+++ b/src/audio/dcblock/dcblock.c
@@ -14,6 +14,7 @@
 #include <sof/debug/panic.h>
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
+#include <rtos/init.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
@@ -431,3 +432,4 @@ UT_STATIC void sys_comp_dcblock_init(void)
 }
 
 DECLARE_MODULE(sys_comp_dcblock_init);
+SOF_MODULE_INIT(dcblock, sys_comp_dcblock_init);

--- a/src/audio/drc/drc.c
+++ b/src/audio/drc/drc.c
@@ -16,6 +16,7 @@
 #include <sof/debug/panic.h>
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
+#include <rtos/init.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
@@ -486,3 +487,4 @@ UT_STATIC void sys_comp_drc_init(void)
 }
 
 DECLARE_MODULE(sys_comp_drc_init);
+SOF_MODULE_INIT(drc, sys_comp_drc_init);

--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -17,6 +17,7 @@
 #include <sof/debug/panic.h>
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
+#include <rtos/init.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
@@ -544,3 +545,4 @@ static struct module_interface eq_fir_interface = {
 };
 
 DECLARE_MODULE_ADAPTER(eq_fir_interface, eq_fir_uuid, eq_fir_tr);
+SOF_MODULE_INIT(eq_fir, sys_comp_module_eq_fir_interface_init);

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -17,6 +17,7 @@
 #include <sof/debug/panic.h>
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
+#include <rtos/init.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
@@ -993,3 +994,4 @@ UT_STATIC void sys_comp_eq_iir_init(void)
 }
 
 DECLARE_MODULE(sys_comp_eq_iir_init);
+SOF_MODULE_INIT(eq_iir, sys_comp_eq_iir_init);

--- a/src/audio/google/google_hotword_detect.c
+++ b/src/audio/google/google_hotword_detect.c
@@ -14,6 +14,7 @@
 #include <sof/debug/panic.h>
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
+#include <rtos/init.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/notifier.h>
 #include <rtos/wait.h>
@@ -484,3 +485,4 @@ UT_STATIC void sys_comp_ghd_init(void)
 }
 
 DECLARE_MODULE(sys_comp_ghd_init);
+SOF_MODULE_INIT(ghd, sys_comp_ghd_init);

--- a/src/audio/google/google_rtc_audio_processing.c
+++ b/src/audio/google/google_rtc_audio_processing.c
@@ -17,6 +17,7 @@
 #include <sof/debug/panic.h>
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
+#include <rtos/init.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/notifier.h>
 #include <sof/lib/uuid.h>
@@ -690,3 +691,4 @@ UT_STATIC void sys_comp_google_rtc_audio_processing_init(void)
 }
 
 DECLARE_MODULE(sys_comp_google_rtc_audio_processing_init);
+SOF_MODULE_INIT(google_rtc_audio_processing, sys_comp_google_rtc_audio_processing_init);

--- a/src/audio/host-legacy.c
+++ b/src/audio/host-legacy.c
@@ -14,6 +14,7 @@
 #include <sof/debug/panic.h>
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
+#include <rtos/init.h>
 #include <sof/lib/dma.h>
 #include <sof/lib/mailbox.h>
 #include <sof/lib/memory.h>
@@ -1101,3 +1102,4 @@ UT_STATIC void sys_comp_host_init(void)
 }
 
 DECLARE_MODULE(sys_comp_host_init);
+SOF_MODULE_INIT(host, sys_comp_host_init);

--- a/src/audio/host-zephyr.c
+++ b/src/audio/host-zephyr.c
@@ -14,6 +14,7 @@
 #include <sof/debug/panic.h>
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
+#include <rtos/init.h>
 #include <sof/lib/dma.h>
 #include <sof/lib/mailbox.h>
 #include <sof/lib/memory.h>
@@ -1174,3 +1175,4 @@ UT_STATIC void sys_comp_host_init(void)
 }
 
 DECLARE_MODULE(sys_comp_host_init);
+SOF_MODULE_INIT(host, sys_comp_host_init);

--- a/src/audio/igo_nr/igo_nr.c
+++ b/src/audio/igo_nr/igo_nr.c
@@ -12,6 +12,7 @@
 #include <sof/common.h>
 #include <sof/debug/panic.h>
 #include <rtos/alloc.h>
+#include <rtos/init.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
@@ -853,3 +854,4 @@ UT_STATIC void sys_comp_igo_nr_init(void)
 }
 
 DECLARE_MODULE(sys_comp_igo_nr_init);
+SOF_MODULE_INIT(igo_nr, sys_comp_igo_nr_init);

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -25,6 +25,7 @@
 #include <rtos/timer.h>
 #include <rtos/alloc.h>
 #include <rtos/clk.h>
+#include <rtos/init.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/notifier.h>
 #include <sof/lib/pm_runtime.h>
@@ -1886,3 +1887,4 @@ UT_STATIC void sys_comp_kpb_init(void)
 }
 
 DECLARE_MODULE(sys_comp_kpb_init);
+SOF_MODULE_INIT(kpb, sys_comp_kpb_init);

--- a/src/audio/mixer/mixer.c
+++ b/src/audio/mixer/mixer.c
@@ -16,6 +16,7 @@
 #include <sof/debug/panic.h>
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
+#include <rtos/init.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
@@ -230,3 +231,4 @@ static struct module_interface mixer_interface = {
 };
 
 DECLARE_MODULE_ADAPTER(mixer_interface, mixer_uuid, mixer_tr);
+SOF_MODULE_INIT(mixer, sys_comp_module_mixer_interface_init);

--- a/src/audio/mixin_mixout/mixin_mixout.c
+++ b/src/audio/mixin_mixout/mixin_mixout.c
@@ -14,6 +14,7 @@
 #include <sof/debug/panic.h>
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
+#include <rtos/init.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
@@ -918,6 +919,7 @@ static struct module_interface mixin_interface = {
 };
 
 DECLARE_MODULE_ADAPTER(mixin_interface, mixin_uuid, mixin_tr);
+SOF_MODULE_INIT(mixin, sys_comp_module_mixin_interface_init);
 
 static struct module_interface mixout_interface = {
 	.init  = mixout_init,
@@ -928,3 +930,4 @@ static struct module_interface mixout_interface = {
 };
 
 DECLARE_MODULE_ADAPTER(mixout_interface, mixout_uuid, mixout_tr);
+SOF_MODULE_INIT(mixout, sys_comp_module_mixout_interface_init);

--- a/src/audio/module_adapter/module/cadence.c
+++ b/src/audio/module_adapter/module/cadence.c
@@ -14,6 +14,7 @@
 #include <sof/audio/module_adapter/module/generic.h>
 #include <sof/audio/module_adapter/module/cadence.h>
 #include <ipc/compress_params.h>
+#include <rtos/init.h>
 
 /* d8218443-5ff3-4a4c-b388-6cfe07b956aa */
 DECLARE_SOF_RT_UUID("cadence_codec", cadence_uuid, 0xd8218443, 0x5ff3, 0x4a4c,
@@ -749,3 +750,4 @@ static struct module_interface cadence_interface = {
 };
 
 DECLARE_MODULE_ADAPTER(cadence_interface, cadence_uuid, cadence_tr);
+SOF_MODULE_INIT(cadence, sys_comp_module_cadence_interface_init);

--- a/src/audio/module_adapter/module/dts.c
+++ b/src/audio/module_adapter/module/dts.c
@@ -5,6 +5,7 @@
 // Author: Mark Barton <mark.barton@xperi.com>
 
 #include "sof/audio/module_adapter/module/generic.h"
+#include <rtos/init.h>
 
 #include "DtsSofInterface.h"
 
@@ -462,3 +463,4 @@ static struct module_interface dts_interface = {
 };
 
 DECLARE_MODULE_ADAPTER(dts_interface, dts_uuid, dts_tr);
+SOF_MODULE_INIT(dts, sys_comp_module_dts_interface_init);

--- a/src/audio/module_adapter/module/passthrough.c
+++ b/src/audio/module_adapter/module/passthrough.c
@@ -7,6 +7,7 @@
 // Passthrough codec implementation to demonstrate Codec Adapter API
 
 #include <sof/audio/module_adapter/module/generic.h>
+#include <rtos/init.h>
 
 /* 376b5e44-9c82-4ec2-bc83-10ea101afa8f */
 DECLARE_SOF_RT_UUID("passthrough_codec", passthrough_uuid, 0x376b5e44, 0x9c82, 0x4ec2,
@@ -122,3 +123,4 @@ static struct module_interface passthrough_interface = {
 };
 
 DECLARE_MODULE_ADAPTER(passthrough_interface, passthrough_uuid, passthrough_tr);
+SOF_MODULE_INIT(passthrough, sys_comp_module_passthrough_interface_init);

--- a/src/audio/module_adapter/module/volume/volume.c
+++ b/src/audio/module_adapter/module/volume/volume.c
@@ -25,6 +25,7 @@
 #include <sof/debug/panic.h>
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
+#include <rtos/init.h>
 #include <sof/lib/cpu.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
@@ -1542,6 +1543,7 @@ UT_STATIC void sys_comp_volume_init(void)
 }
 
 DECLARE_MODULE(sys_comp_volume_init);
+SOF_MODULE_INIT(volume, sys_comp_volume_init);
 #else
 static struct module_interface volume_interface = {
 	.init  = volume_init,
@@ -1554,6 +1556,7 @@ static struct module_interface volume_interface = {
 };
 
 DECLARE_MODULE_ADAPTER(volume_interface, volume_uuid, volume_tr);
+SOF_MODULE_INIT(volume, sys_comp_module_volume_interface_init);
 
 #if CONFIG_COMP_GAIN
 static struct module_interface gain_interface = {
@@ -1567,5 +1570,6 @@ static struct module_interface gain_interface = {
 };
 
 DECLARE_MODULE_ADAPTER(gain_interface, gain_uuid, gain_tr);
+SOF_MODULE_INIT(gain, sys_comp_module_gain_interface_init);
 #endif
 #endif

--- a/src/audio/module_adapter/module/waves.c
+++ b/src/audio/module_adapter/module/waves.c
@@ -7,6 +7,7 @@
 #include <sof/audio/module_adapter/module/generic.h>
 #include <sof/debug/debug.h>
 #include <sof/compiler_attributes.h>
+#include <rtos/init.h>
 
 #include "MaxxEffect/MaxxEffect.h"
 #include "MaxxEffect/MaxxStream.h"
@@ -889,3 +890,4 @@ static struct module_interface waves_interface = {
 };
 
 DECLARE_MODULE_ADAPTER(waves_interface, waves_uuid, waves_tr);
+SOF_MODULE_INIT(waves, sys_comp_module_waves_interface_init);

--- a/src/audio/multiband_drc/multiband_drc.c
+++ b/src/audio/multiband_drc/multiband_drc.c
@@ -15,6 +15,7 @@
 #include <sof/debug/panic.h>
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
+#include <rtos/init.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
@@ -643,3 +644,4 @@ UT_STATIC void sys_comp_multiband_drc_init(void)
 }
 
 DECLARE_MODULE(sys_comp_multiband_drc_init);
+SOF_MODULE_INIT(multiband_drc, sys_comp_multiband_drc_init);

--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -5,8 +5,6 @@
 // Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
 //         Artur Kloniecki <arturx.kloniecki@linux.intel.com>
 
-
-
 #if CONFIG_COMP_MUX
 
 #include <sof/audio/component.h>
@@ -15,6 +13,7 @@
 #include <sof/common.h>
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
+#include <rtos/init.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
@@ -1012,5 +1011,6 @@ UT_STATIC void sys_comp_mux_init(void)
 }
 
 DECLARE_MODULE(sys_comp_mux_init);
+SOF_MODULE_INIT(mux, sys_comp_mux_init);
 
 #endif /* CONFIG_COMP_MUX */

--- a/src/audio/rtnr/rtnr.c
+++ b/src/audio/rtnr/rtnr.c
@@ -15,6 +15,7 @@
 #include <sof/debug/panic.h>
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
+#include <rtos/init.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
@@ -938,3 +939,4 @@ UT_STATIC void sys_comp_rtnr_init(void)
 
 
 DECLARE_MODULE(sys_comp_rtnr_init);
+SOF_MODULE_INIT(rtnr, sys_comp_rtnr_init);

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -21,6 +21,7 @@
 #include <sof/debug/panic.h>
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
+#include <rtos/init.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
@@ -571,6 +572,7 @@ UT_STATIC void sys_comp_selector_init(void)
 }
 
 DECLARE_MODULE(sys_comp_selector_init);
+SOF_MODULE_INIT(selector, sys_comp_selector_init);
 #else
 static void build_config(struct comp_data *cd, struct module_config *cfg)
 {
@@ -957,4 +959,5 @@ static struct module_interface selector_interface = {
 };
 
 DECLARE_MODULE_ADAPTER(selector_interface, selector_uuid, selector_tr);
+SOF_MODULE_INIT(selector, sys_comp_module_selector_interface_init);
 #endif

--- a/src/audio/smart_amp/smart_amp.c
+++ b/src/audio/smart_amp/smart_amp.c
@@ -4,6 +4,7 @@
 //
 // Author: Ryan Lee <ryans.lee@maximintegrated.com>
 
+#include <rtos/init.h>
 #include <sof/trace/trace.h>
 #include <sof/ipc/msg.h>
 #include <sof/ut.h>
@@ -782,3 +783,4 @@ UT_STATIC void sys_comp_smart_amp_init(void)
 }
 
 DECLARE_MODULE(sys_comp_smart_amp_init);
+SOF_MODULE_INIT(smart_amp, sys_comp_smart_amp_init);

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -18,6 +18,7 @@
 #include <sof/debug/panic.h>
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
+#include <rtos/init.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
@@ -1044,6 +1045,7 @@ static struct module_interface src_interface = {
 };
 
 DECLARE_MODULE_ADAPTER(src_interface, src_uuid, src_tr);
+SOF_MODULE_INIT(src, sys_comp_module_src_interface_init);
 
 #elif CONFIG_IPC_MAJOR_3
 static struct comp_dev *src_new(const struct comp_driver *drv,
@@ -1255,6 +1257,7 @@ UT_STATIC void sys_comp_src_init(void)
 }
 
 DECLARE_MODULE(sys_comp_src_init);
+SOF_MODULE_INIT(src, sys_comp_src_init);
 #else
 #error "No or invalid IPC MAJOR version selected."
 #endif

--- a/src/audio/switch.c
+++ b/src/audio/switch.c
@@ -13,6 +13,7 @@
 #include <ipc/topology.h>
 #include <user/trace.h>
 #include <stddef.h>
+#include <rtos/init.h>
 
 static const struct comp_driver comp_switch;
 
@@ -94,3 +95,4 @@ UT_STATIC void sys_comp_switch_init(void)
 }
 
 DECLARE_MODULE(sys_comp_switch_init);
+SOF_MODULE_INIT(switch, sys_comp_switch_init);

--- a/src/audio/tdfb/tdfb.c
+++ b/src/audio/tdfb/tdfb.c
@@ -18,6 +18,7 @@
 #include <sof/debug/panic.h>
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
+#include <rtos/init.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
@@ -905,3 +906,4 @@ UT_STATIC void sys_comp_tdfb_init(void)
 }
 
 DECLARE_MODULE(sys_comp_tdfb_init);
+SOF_MODULE_INIT(tdfb, sys_comp_tdfb_init);

--- a/src/audio/tone.c
+++ b/src/audio/tone.c
@@ -15,6 +15,7 @@
 #include <sof/debug/panic.h>
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
+#include <rtos/init.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
@@ -745,3 +746,4 @@ UT_STATIC void sys_comp_tone_init(void)
 }
 
 DECLARE_MODULE(sys_comp_tone_init);
+SOF_MODULE_INIT(tone, sys_comp_tone_init);

--- a/src/audio/up_down_mixer/up_down_mixer.c
+++ b/src/audio/up_down_mixer/up_down_mixer.c
@@ -15,6 +15,7 @@
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
 #include <rtos/cache.h>
+#include <rtos/init.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/notifier.h>
 #include <sof/lib/uuid.h>
@@ -463,3 +464,4 @@ static struct module_interface up_down_mixer_interface = {
 };
 
 DECLARE_MODULE_ADAPTER(up_down_mixer_interface, up_down_mixer_comp_uuid, up_down_mixer_comp_tr);
+SOF_MODULE_INIT(up_down_mixer, sys_comp_module_up_down_mixer_interface_init);

--- a/src/include/sof/schedule/task.h
+++ b/src/include/sof/schedule/task.h
@@ -122,5 +122,6 @@ void task_main_init(void);
 void task_main_free(void);
 
 int task_main_start(struct sof *sof);
+int start_complete(void);
 
 #endif /* __SOF_SCHEDULE_TASK_H__ */

--- a/src/init/init.c
+++ b/src/init/init.c
@@ -10,6 +10,7 @@
  */
 
 #include <sof/debug/panic.h>
+#include <rtos/init.h>
 #include <rtos/interrupt.h>
 #include <sof/init.h>
 #include <sof/lib/cpu.h>
@@ -315,6 +316,17 @@ int sof_main(int argc, char *argv[])
 {
 	trace_point(TRACE_BOOT_START);
 
-	return primary_core_init(argc, argv, &sof);
+	return start_complete();
 }
+
+struct device;
+
+static int sof_init(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	return primary_core_init(0, NULL, &sof);
+}
+
+SYS_INIT(sof_init, POST_KERNEL, 99);
 #endif

--- a/src/probe/probe.c
+++ b/src/probe/probe.c
@@ -11,6 +11,7 @@
 #include <sof/trace/trace.h>
 #include <user/trace.h>
 #include <rtos/alloc.h>
+#include <rtos/init.h>
 #include <sof/lib/dma.h>
 #include <sof/lib/notifier.h>
 #include <sof/lib/uuid.h>
@@ -1442,4 +1443,5 @@ UT_STATIC void sys_comp_probe_init(void)
 }
 
 DECLARE_MODULE(sys_comp_probe_init);
+SOF_MODULE_INIT(probe, sys_comp_probe_init);
 #endif

--- a/src/samples/audio/detect_test.c
+++ b/src/samples/audio/detect_test.c
@@ -15,6 +15,7 @@
 #include <sof/debug/panic.h>
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
+#include <rtos/init.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/notifier.h>
 #include <rtos/wait.h>
@@ -1021,3 +1022,4 @@ UT_STATIC void sys_comp_keyword_init(void)
 }
 
 DECLARE_MODULE(sys_comp_keyword_init);
+SOF_MODULE_INIT(keyword, sys_comp_keyword_init);

--- a/xtos/include/rtos/init.h
+++ b/xtos/include/rtos/init.h
@@ -1,0 +1,11 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright(c) 2023 Intel Corporation. All rights reserved.
+ */
+
+#ifndef __XTOS_RTOS_INIT_H__
+#define __XTOS_RTOS_INIT_H__
+
+#define SOF_MODULE_INIT(name, init)
+
+#endif /* __XTOS_RTOS_INIT_H__ */

--- a/zephyr/include/rtos/init.h
+++ b/zephyr/include/rtos/init.h
@@ -1,0 +1,20 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright(c) 2023 Intel Corporation. All rights reserved.
+ */
+
+#ifndef __ZEPHYR_RTOS_INIT_H__
+#define __ZEPHYR_RTOS_INIT_H__
+
+#include <zephyr/init.h>
+
+#define SOF_MODULE_INIT(name, init) \
+static int zephyr_##name##_init(const struct device *dev) \
+{ \
+	ARG_UNUSED(dev); \
+	init(); \
+	return 0; \
+} \
+SYS_INIT(zephyr_##name##_init, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY)
+
+#endif /* __ZEPHYR_RTOS_INIT_H__ */

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -182,7 +182,6 @@ static void sys_module_init(void)
  * constructors directly atm.
  */
 
-void sys_comp_tdfb_init(void);
 void sys_comp_ghd_init(void);
 void sys_comp_module_dts_interface_init(void);
 void sys_comp_module_waves_interface_init(void);
@@ -227,9 +226,6 @@ int task_main_start(struct sof *sof)
 
 int start_complete(void)
 {
-	if (IS_ENABLED(CONFIG_COMP_TDFB))
-		sys_comp_tdfb_init();
-
 	if (IS_ENABLED(CONFIG_COMP_GOOGLE_HOTWORD_DETECT))
 		sys_comp_ghd_init();
 

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -182,7 +182,6 @@ static void sys_module_init(void)
  * constructors directly atm.
  */
 
-void sys_comp_mux_init(void);
 void sys_comp_basefw_init(void);
 void sys_comp_copier_init(void);
 void sys_comp_module_cadence_interface_init(void);
@@ -240,9 +239,6 @@ int task_main_start(struct sof *sof)
 
 int start_complete(void)
 {
-	if (IS_ENABLED(CONFIG_COMP_MUX))
-		sys_comp_mux_init();
-
 	if (IS_ENABLED(CONFIG_COMP_BASEFW_IPC4))
 		sys_comp_basefw_init();
 

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -176,16 +176,6 @@ static void sys_module_init(void)
 #endif
 }
 
-/*
- * TODO: all the audio processing components/modules constructor should be
- * linked to the module_init section, but this is not happening. Just call
- * constructors directly atm.
- */
-
-#if CONFIG_IPC_MAJOR_4
-void sys_comp_probe_init(void);
-#endif
-
 /* Zephyr redefines log_message() and mtrace_printf() which leaves
  * totally empty the .static_log_entries ELF sections for the
  * sof-logger. This makes smex fail. Define at least one such section to
@@ -223,11 +213,6 @@ int task_main_start(struct sof *sof)
 
 int start_complete(void)
 {
-#if CONFIG_IPC_MAJOR_4
-	if (IS_ENABLED(CONFIG_PROBE))
-		sys_comp_probe_init();
-#endif
-
 #if defined(CONFIG_IMX)
 #define SOF_IPC_QUEUED_DOMAIN SOF_SCHEDULE_LL_DMA
 #else

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -182,7 +182,6 @@ static void sys_module_init(void)
  * constructors directly atm.
  */
 
-void sys_comp_igo_nr_init(void);
 void sys_comp_rtnr_init(void);
 void sys_comp_module_up_down_mixer_interface_init(void);
 void sys_comp_tdfb_init(void);
@@ -230,9 +229,6 @@ int task_main_start(struct sof *sof)
 
 int start_complete(void)
 {
-	if (IS_ENABLED(CONFIG_COMP_IGO_NR))
-		sys_comp_igo_nr_init();
-
 	if (IS_ENABLED(CONFIG_COMP_RTNR))
 		sys_comp_rtnr_init();
 

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -183,14 +183,11 @@ static void sys_module_init(void)
  */
 
 void sys_comp_host_init(void);
-void sys_comp_src_init(void);
 void sys_comp_mux_init(void);
 void sys_comp_chain_dma_init(void);
 #if CONFIG_IPC_MAJOR_3
-void sys_comp_src_init(void);
 void sys_comp_selector_init(void);
 #else
-void sys_comp_module_src_interface_init(void);
 void sys_comp_module_selector_interface_init(void);
 #endif
 void sys_comp_switch_init(void);
@@ -262,14 +259,6 @@ int task_main_start(struct sof *sof)
 
 int start_complete(void)
 {
-	if (IS_ENABLED(CONFIG_COMP_SRC)) {
-#if CONFIG_IPC_MAJOR_3
-		sys_comp_src_init();
-#else
-		sys_comp_module_src_interface_init();
-#endif
-	}
-
 	if (IS_ENABLED(CONFIG_COMP_SEL))
 #if CONFIG_IPC_MAJOR_3
 		sys_comp_selector_init();

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -183,11 +183,6 @@ static void sys_module_init(void)
  */
 
 void sys_comp_host_init(void);
-#if CONFIG_IPC_MAJOR_3
-void sys_comp_module_mixer_interface_init(void);
-#else
-void sys_comp_module_mixout_interface_init(void);
-#endif
 void sys_comp_dai_init(void);
 void sys_comp_src_init(void);
 void sys_comp_mux_init(void);
@@ -212,7 +207,6 @@ void sys_comp_basefw_init(void);
 void sys_comp_copier_init(void);
 void sys_comp_module_cadence_interface_init(void);
 void sys_comp_module_passthrough_interface_init(void);
-void sys_comp_module_mixin_interface_init(void);
 void sys_comp_aria_init(void);
 void sys_comp_crossover_init(void);
 void sys_comp_drc_init(void);
@@ -269,15 +263,6 @@ int task_main_start(struct sof *sof)
 
 int start_complete(void)
 {
-	if (IS_ENABLED(CONFIG_COMP_MIXER)) {
-#if CONFIG_IPC_MAJOR_3
-		sys_comp_module_mixer_interface_init();
-#else
-		sys_comp_module_mixout_interface_init();
-		sys_comp_module_mixin_interface_init();
-#endif
-	}
-
 	if (IS_ENABLED(CONFIG_COMP_DAI))
 		sys_comp_dai_init();
 

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -183,7 +183,6 @@ static void sys_module_init(void)
  */
 
 void sys_comp_mux_init(void);
-void sys_comp_dcblock_init(void);
 void sys_comp_basefw_init(void);
 void sys_comp_copier_init(void);
 void sys_comp_module_cadence_interface_init(void);
@@ -241,9 +240,6 @@ int task_main_start(struct sof *sof)
 
 int start_complete(void)
 {
-	if (IS_ENABLED(CONFIG_COMP_DCBLOCK))
-		sys_comp_dcblock_init();
-
 	if (IS_ENABLED(CONFIG_COMP_MUX))
 		sys_comp_mux_init();
 

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -183,7 +183,6 @@ static void sys_module_init(void)
  */
 
 void sys_comp_mux_init(void);
-void sys_comp_asrc_init(void);
 void sys_comp_dcblock_init(void);
 void sys_comp_basefw_init(void);
 void sys_comp_copier_init(void);
@@ -242,9 +241,6 @@ int task_main_start(struct sof *sof)
 
 int start_complete(void)
 {
-	if (IS_ENABLED(CONFIG_COMP_ASRC))
-		sys_comp_asrc_init();
-
 	if (IS_ENABLED(CONFIG_COMP_DCBLOCK))
 		sys_comp_dcblock_init();
 

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -212,12 +212,6 @@ void sys_comp_basefw_init(void);
 void sys_comp_copier_init(void);
 void sys_comp_module_cadence_interface_init(void);
 void sys_comp_module_passthrough_interface_init(void);
-#if CONFIG_COMP_LEGACY_INTERFACE
-void sys_comp_volume_init(void);
-#else
-void sys_comp_module_volume_interface_init(void);
-#endif
-void sys_comp_module_gain_interface_init(void);
 void sys_comp_module_mixin_interface_init(void);
 void sys_comp_aria_init(void);
 void sys_comp_crossover_init(void);
@@ -275,17 +269,6 @@ int task_main_start(struct sof *sof)
 
 int start_complete(void)
 {
-	if (IS_ENABLED(CONFIG_COMP_VOLUME)) {
-#if CONFIG_COMP_LEGACY_INTERFACE
-		sys_comp_volume_init();
-#else
-		sys_comp_module_volume_interface_init();
-#endif
-
-		if (IS_ENABLED(CONFIG_IPC_MAJOR_4))
-			sys_comp_module_gain_interface_init();
-	}
-
 	if (IS_ENABLED(CONFIG_COMP_MIXER)) {
 #if CONFIG_IPC_MAJOR_3
 		sys_comp_module_mixer_interface_init();

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -182,7 +182,6 @@ static void sys_module_init(void)
  * constructors directly atm.
  */
 
-void sys_comp_basefw_init(void);
 void sys_comp_copier_init(void);
 void sys_comp_module_cadence_interface_init(void);
 void sys_comp_module_passthrough_interface_init(void);
@@ -239,9 +238,6 @@ int task_main_start(struct sof *sof)
 
 int start_complete(void)
 {
-	if (IS_ENABLED(CONFIG_COMP_BASEFW_IPC4))
-		sys_comp_basefw_init();
-
 	if (IS_ENABLED(CONFIG_COMP_COPIER))
 		sys_comp_copier_init();
 

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -182,7 +182,6 @@ static void sys_module_init(void)
  * constructors directly atm.
  */
 
-void sys_comp_drc_init(void);
 void sys_comp_multiband_drc_init(void);
 void sys_comp_google_rtc_audio_processing_init(void);
 void sys_comp_igo_nr_init(void);
@@ -233,9 +232,6 @@ int task_main_start(struct sof *sof)
 
 int start_complete(void)
 {
-	if (IS_ENABLED(CONFIG_COMP_DRC))
-		sys_comp_drc_init();
-
 	if (IS_ENABLED(CONFIG_COMP_MULTIBAND_DRC))
 		sys_comp_multiband_drc_init();
 

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -182,7 +182,6 @@ static void sys_module_init(void)
  * constructors directly atm.
  */
 
-void sys_comp_rtnr_init(void);
 void sys_comp_module_up_down_mixer_interface_init(void);
 void sys_comp_tdfb_init(void);
 void sys_comp_ghd_init(void);
@@ -229,9 +228,6 @@ int task_main_start(struct sof *sof)
 
 int start_complete(void)
 {
-	if (IS_ENABLED(CONFIG_COMP_RTNR))
-		sys_comp_rtnr_init();
-
 	if (IS_ENABLED(CONFIG_COMP_UP_DOWN_MIXER))
 		sys_comp_module_up_down_mixer_interface_init();
 

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -182,7 +182,6 @@ static void sys_module_init(void)
  * constructors directly atm.
  */
 
-void sys_comp_module_dts_interface_init(void);
 void sys_comp_module_waves_interface_init(void);
 #if CONFIG_IPC_MAJOR_4
 void sys_comp_probe_init(void);
@@ -225,9 +224,6 @@ int task_main_start(struct sof *sof)
 
 int start_complete(void)
 {
-	if (IS_ENABLED(CONFIG_DTS_CODEC))
-		sys_comp_module_dts_interface_init();
-
 	if (IS_ENABLED(CONFIG_WAVES_CODEC))
 		sys_comp_module_waves_interface_init();
 #if CONFIG_IPC_MAJOR_4

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -182,7 +182,6 @@ static void sys_module_init(void)
  * constructors directly atm.
  */
 
-void sys_comp_host_init(void);
 void sys_comp_mux_init(void);
 void sys_comp_asrc_init(void);
 void sys_comp_dcblock_init(void);
@@ -236,9 +235,6 @@ int task_main_start(struct sof *sof)
 
 	/* init self-registered modules */
 	sys_module_init();
-
-	/* host is mandatory */
-	sys_comp_host_init();
 
 	/* init pipeline position offsets */
 	pipeline_posn_init(sof);

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -182,7 +182,6 @@ static void sys_module_init(void)
  * constructors directly atm.
  */
 
-void sys_comp_multiband_drc_init(void);
 void sys_comp_google_rtc_audio_processing_init(void);
 void sys_comp_igo_nr_init(void);
 void sys_comp_rtnr_init(void);
@@ -232,9 +231,6 @@ int task_main_start(struct sof *sof)
 
 int start_complete(void)
 {
-	if (IS_ENABLED(CONFIG_COMP_MULTIBAND_DRC))
-		sys_comp_multiband_drc_init();
-
 	if (IS_ENABLED(CONFIG_COMP_GOOGLE_RTC_AUDIO_PROCESSING))
 		sys_comp_google_rtc_audio_processing_init();
 

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -182,7 +182,6 @@ static void sys_module_init(void)
  * constructors directly atm.
  */
 
-void sys_comp_crossover_init(void);
 void sys_comp_drc_init(void);
 void sys_comp_multiband_drc_init(void);
 void sys_comp_google_rtc_audio_processing_init(void);
@@ -234,9 +233,6 @@ int task_main_start(struct sof *sof)
 
 int start_complete(void)
 {
-	if (IS_ENABLED(CONFIG_COMP_CROSSOVER))
-		sys_comp_crossover_init();
-
 	if (IS_ENABLED(CONFIG_COMP_DRC))
 		sys_comp_drc_init();
 

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -182,7 +182,6 @@ static void sys_module_init(void)
  * constructors directly atm.
  */
 
-void sys_comp_module_up_down_mixer_interface_init(void);
 void sys_comp_tdfb_init(void);
 void sys_comp_ghd_init(void);
 void sys_comp_module_dts_interface_init(void);
@@ -228,9 +227,6 @@ int task_main_start(struct sof *sof)
 
 int start_complete(void)
 {
-	if (IS_ENABLED(CONFIG_COMP_UP_DOWN_MIXER))
-		sys_comp_module_up_down_mixer_interface_init();
-
 	if (IS_ENABLED(CONFIG_COMP_TDFB))
 		sys_comp_tdfb_init();
 

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -185,7 +185,6 @@ static void sys_module_init(void)
 void sys_comp_mux_init(void);
 void sys_comp_asrc_init(void);
 void sys_comp_dcblock_init(void);
-void sys_comp_kpb_init(void);
 void sys_comp_smart_amp_init(void);
 void sys_comp_basefw_init(void);
 void sys_comp_copier_init(void);
@@ -244,9 +243,6 @@ int task_main_start(struct sof *sof)
 
 int start_complete(void)
 {
-	if (IS_ENABLED(CONFIG_COMP_KPB))
-		sys_comp_kpb_init();
-
 	if (IS_ENABLED(CONFIG_SAMPLE_SMART_AMP) ||
 	    IS_ENABLED(CONFIG_MAXIM_DSM))
 		sys_comp_smart_amp_init();

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -182,7 +182,6 @@ static void sys_module_init(void)
  * constructors directly atm.
  */
 
-void sys_comp_module_passthrough_interface_init(void);
 void sys_comp_aria_init(void);
 void sys_comp_crossover_init(void);
 void sys_comp_drc_init(void);
@@ -236,9 +235,6 @@ int task_main_start(struct sof *sof)
 
 int start_complete(void)
 {
-	if (IS_ENABLED(CONFIG_PASSTHROUGH_CODEC))
-		sys_comp_module_passthrough_interface_init();
-
 	if (IS_ENABLED(CONFIG_COMP_ARIA))
 		sys_comp_aria_init();
 

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -184,7 +184,6 @@ static void sys_module_init(void)
 
 void sys_comp_host_init(void);
 void sys_comp_mux_init(void);
-void sys_comp_chain_dma_init(void);
 #if CONFIG_IPC_MAJOR_3
 void sys_comp_selector_init(void);
 #else
@@ -347,10 +346,6 @@ int start_complete(void)
 	if (IS_ENABLED(CONFIG_PROBE))
 		sys_comp_probe_init();
 #endif
-
-	/* init chain dma manager*/
-	if (IS_ENABLED(CONFIG_COMP_CHAIN_DMA))
-		sys_comp_chain_dma_init();
 
 #if defined(CONFIG_IMX)
 #define SOF_IPC_QUEUED_DOMAIN SOF_SCHEDULE_LL_DMA

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -182,7 +182,6 @@ static void sys_module_init(void)
  * constructors directly atm.
  */
 
-void sys_comp_aria_init(void);
 void sys_comp_crossover_init(void);
 void sys_comp_drc_init(void);
 void sys_comp_multiband_drc_init(void);
@@ -235,9 +234,6 @@ int task_main_start(struct sof *sof)
 
 int start_complete(void)
 {
-	if (IS_ENABLED(CONFIG_COMP_ARIA))
-		sys_comp_aria_init();
-
 	if (IS_ENABLED(CONFIG_COMP_CROSSOVER))
 		sys_comp_crossover_init();
 

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -184,7 +184,6 @@ static void sys_module_init(void)
 
 void sys_comp_host_init(void);
 void sys_comp_mux_init(void);
-void sys_comp_module_eq_fir_interface_init(void);
 void sys_comp_keyword_init(void);
 void sys_comp_asrc_init(void);
 void sys_comp_dcblock_init(void);
@@ -251,9 +250,6 @@ int task_main_start(struct sof *sof)
 
 int start_complete(void)
 {
-	if (IS_ENABLED(CONFIG_COMP_FIR))
-		sys_comp_module_eq_fir_interface_init();
-
 	if (IS_ENABLED(CONFIG_COMP_IIR))
 		sys_comp_eq_iir_init();
 

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -184,7 +184,6 @@ static void sys_module_init(void)
 
 void sys_comp_host_init(void);
 void sys_comp_mux_init(void);
-void sys_comp_tone_init(void);
 void sys_comp_module_eq_fir_interface_init(void);
 void sys_comp_keyword_init(void);
 void sys_comp_asrc_init(void);
@@ -252,9 +251,6 @@ int task_main_start(struct sof *sof)
 
 int start_complete(void)
 {
-	if (IS_ENABLED(CONFIG_COMP_TONE))
-		sys_comp_tone_init();
-
 	if (IS_ENABLED(CONFIG_COMP_FIR))
 		sys_comp_module_eq_fir_interface_init();
 

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -184,11 +184,6 @@ static void sys_module_init(void)
 
 void sys_comp_host_init(void);
 void sys_comp_mux_init(void);
-#if CONFIG_IPC_MAJOR_3
-void sys_comp_selector_init(void);
-#else
-void sys_comp_module_selector_interface_init(void);
-#endif
 void sys_comp_switch_init(void);
 void sys_comp_tone_init(void);
 void sys_comp_module_eq_fir_interface_init(void);
@@ -258,12 +253,6 @@ int task_main_start(struct sof *sof)
 
 int start_complete(void)
 {
-	if (IS_ENABLED(CONFIG_COMP_SEL))
-#if CONFIG_IPC_MAJOR_3
-		sys_comp_selector_init();
-#else
-		sys_comp_module_selector_interface_init();
-#endif
 	if (IS_ENABLED(CONFIG_COMP_SWITCH))
 		sys_comp_switch_init();
 

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -182,7 +182,6 @@ static void sys_module_init(void)
  * constructors directly atm.
  */
 
-void sys_comp_copier_init(void);
 void sys_comp_module_cadence_interface_init(void);
 void sys_comp_module_passthrough_interface_init(void);
 void sys_comp_aria_init(void);
@@ -238,9 +237,6 @@ int task_main_start(struct sof *sof)
 
 int start_complete(void)
 {
-	if (IS_ENABLED(CONFIG_COMP_COPIER))
-		sys_comp_copier_init();
-
 	if (IS_ENABLED(CONFIG_CADENCE_CODEC))
 		sys_comp_module_cadence_interface_init();
 

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -184,7 +184,6 @@ static void sys_module_init(void)
 
 void sys_comp_host_init(void);
 void sys_comp_mux_init(void);
-void sys_comp_keyword_init(void);
 void sys_comp_asrc_init(void);
 void sys_comp_dcblock_init(void);
 void sys_comp_kpb_init(void);
@@ -249,9 +248,6 @@ int task_main_start(struct sof *sof)
 
 int start_complete(void)
 {
-	if (IS_ENABLED(CONFIG_SAMPLE_KEYPHRASE))
-		sys_comp_keyword_init();
-
 	if (IS_ENABLED(CONFIG_COMP_KPB))
 		sys_comp_kpb_init();
 

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -185,7 +185,6 @@ static void sys_module_init(void)
 void sys_comp_mux_init(void);
 void sys_comp_asrc_init(void);
 void sys_comp_dcblock_init(void);
-void sys_comp_smart_amp_init(void);
 void sys_comp_basefw_init(void);
 void sys_comp_copier_init(void);
 void sys_comp_module_cadence_interface_init(void);
@@ -243,10 +242,6 @@ int task_main_start(struct sof *sof)
 
 int start_complete(void)
 {
-	if (IS_ENABLED(CONFIG_SAMPLE_SMART_AMP) ||
-	    IS_ENABLED(CONFIG_MAXIM_DSM))
-		sys_comp_smart_amp_init();
-
 	if (IS_ENABLED(CONFIG_COMP_ASRC))
 		sys_comp_asrc_init();
 

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -182,7 +182,6 @@ static void sys_module_init(void)
  * constructors directly atm.
  */
 
-void sys_comp_module_waves_interface_init(void);
 #if CONFIG_IPC_MAJOR_4
 void sys_comp_probe_init(void);
 #endif
@@ -224,8 +223,6 @@ int task_main_start(struct sof *sof)
 
 int start_complete(void)
 {
-	if (IS_ENABLED(CONFIG_WAVES_CODEC))
-		sys_comp_module_waves_interface_init();
 #if CONFIG_IPC_MAJOR_4
 	if (IS_ENABLED(CONFIG_PROBE))
 		sys_comp_probe_init();

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -182,7 +182,6 @@ static void sys_module_init(void)
  * constructors directly atm.
  */
 
-void sys_comp_google_rtc_audio_processing_init(void);
 void sys_comp_igo_nr_init(void);
 void sys_comp_rtnr_init(void);
 void sys_comp_module_up_down_mixer_interface_init(void);
@@ -231,9 +230,6 @@ int task_main_start(struct sof *sof)
 
 int start_complete(void)
 {
-	if (IS_ENABLED(CONFIG_COMP_GOOGLE_RTC_AUDIO_PROCESSING))
-		sys_comp_google_rtc_audio_processing_init();
-
 	if (IS_ENABLED(CONFIG_COMP_IGO_NR))
 		sys_comp_igo_nr_init();
 

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -184,7 +184,6 @@ static void sys_module_init(void)
 
 void sys_comp_host_init(void);
 void sys_comp_mux_init(void);
-void sys_comp_switch_init(void);
 void sys_comp_tone_init(void);
 void sys_comp_module_eq_fir_interface_init(void);
 void sys_comp_keyword_init(void);
@@ -253,9 +252,6 @@ int task_main_start(struct sof *sof)
 
 int start_complete(void)
 {
-	if (IS_ENABLED(CONFIG_COMP_SWITCH))
-		sys_comp_switch_init();
-
 	if (IS_ENABLED(CONFIG_COMP_TONE))
 		sys_comp_tone_init();
 

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -258,8 +258,6 @@ int task_main_start(struct sof *sof)
 {
 	_smex_placeholder = smex_placeholder_f();
 
-	int ret;
-
 	/* init default audio components */
 	sys_comp_init(sof);
 
@@ -269,6 +267,14 @@ int task_main_start(struct sof *sof)
 	/* host is mandatory */
 	sys_comp_host_init();
 
+	/* init pipeline position offsets */
+	pipeline_posn_init(sof);
+
+	return 0;
+}
+
+int start_complete(void)
+{
 	if (IS_ENABLED(CONFIG_COMP_VOLUME)) {
 #if CONFIG_COMP_LEGACY_INTERFACE
 		sys_comp_volume_init();
@@ -388,8 +394,6 @@ int task_main_start(struct sof *sof)
 	if (IS_ENABLED(CONFIG_PROBE))
 		sys_comp_probe_init();
 #endif
-	/* init pipeline position offsets */
-	pipeline_posn_init(sof);
 
 	/* init chain dma manager*/
 	if (IS_ENABLED(CONFIG_COMP_CHAIN_DMA))
@@ -410,10 +414,9 @@ int task_main_start(struct sof *sof)
 	pm_policy_state_lock_get(PM_STATE_RUNTIME_IDLE, PM_ALL_SUBSTATES);
 	pm_policy_state_lock_get(PM_STATE_SOFT_OFF, PM_ALL_SUBSTATES);
 #endif
-	/* let host know DSP boot is complete */
-	ret = platform_boot_complete(0);
 
-	return ret;
+	/* let host know DSP boot is complete */
+	return platform_boot_complete(0);
 }
 
 /*

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -182,7 +182,6 @@ static void sys_module_init(void)
  * constructors directly atm.
  */
 
-void sys_comp_module_cadence_interface_init(void);
 void sys_comp_module_passthrough_interface_init(void);
 void sys_comp_aria_init(void);
 void sys_comp_crossover_init(void);
@@ -237,9 +236,6 @@ int task_main_start(struct sof *sof)
 
 int start_complete(void)
 {
-	if (IS_ENABLED(CONFIG_CADENCE_CODEC))
-		sys_comp_module_cadence_interface_init();
-
 	if (IS_ENABLED(CONFIG_PASSTHROUGH_CODEC))
 		sys_comp_module_passthrough_interface_init();
 

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -187,7 +187,6 @@ void sys_comp_mux_init(void);
 void sys_comp_keyword_init(void);
 void sys_comp_asrc_init(void);
 void sys_comp_dcblock_init(void);
-void sys_comp_eq_iir_init(void);
 void sys_comp_kpb_init(void);
 void sys_comp_smart_amp_init(void);
 void sys_comp_basefw_init(void);
@@ -250,9 +249,6 @@ int task_main_start(struct sof *sof)
 
 int start_complete(void)
 {
-	if (IS_ENABLED(CONFIG_COMP_IIR))
-		sys_comp_eq_iir_init();
-
 	if (IS_ENABLED(CONFIG_SAMPLE_KEYPHRASE))
 		sys_comp_keyword_init();
 

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -183,7 +183,6 @@ static void sys_module_init(void)
  */
 
 void sys_comp_host_init(void);
-void sys_comp_dai_init(void);
 void sys_comp_src_init(void);
 void sys_comp_mux_init(void);
 void sys_comp_chain_dma_init(void);
@@ -263,9 +262,6 @@ int task_main_start(struct sof *sof)
 
 int start_complete(void)
 {
-	if (IS_ENABLED(CONFIG_COMP_DAI))
-		sys_comp_dai_init();
-
 	if (IS_ENABLED(CONFIG_COMP_SRC)) {
 #if CONFIG_IPC_MAJOR_3
 		sys_comp_src_init();

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -182,7 +182,6 @@ static void sys_module_init(void)
  * constructors directly atm.
  */
 
-void sys_comp_ghd_init(void);
 void sys_comp_module_dts_interface_init(void);
 void sys_comp_module_waves_interface_init(void);
 #if CONFIG_IPC_MAJOR_4
@@ -226,9 +225,6 @@ int task_main_start(struct sof *sof)
 
 int start_complete(void)
 {
-	if (IS_ENABLED(CONFIG_COMP_GOOGLE_HOTWORD_DETECT))
-		sys_comp_ghd_init();
-
 	if (IS_ENABLED(CONFIG_DTS_CODEC))
 		sys_comp_module_dts_interface_init();
 

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -153,29 +153,6 @@ unsigned int _xtos_ints_off(unsigned int mask)
 	return 0;
 }
 
-/*
- * Audio components.
- *
- * Integrated except for linkage so symbols are "used" here until linker
- * support is ready in Zephyr. TODO: fix component linkage in Zephyr.
- */
-
-/* TODO: this is not yet working with Zephyr - section has been created but
- *  no symbols are being loaded into ELF file.
- */
-extern intptr_t _module_init_start;
-extern intptr_t _module_init_end;
-
-static void sys_module_init(void)
-{
-#if !CONFIG_LIBRARY
-	intptr_t *module_init = (intptr_t *)(&_module_init_start);
-
-	for (; module_init < (intptr_t *)&_module_init_end; ++module_init)
-		((void(*)(void))(*module_init))();
-#endif
-}
-
 /* Zephyr redefines log_message() and mtrace_printf() which leaves
  * totally empty the .static_log_entries ELF sections for the
  * sof-logger. This makes smex fail. Define at least one such section to
@@ -201,9 +178,6 @@ int task_main_start(struct sof *sof)
 
 	/* init default audio components */
 	sys_comp_init(sof);
-
-	/* init self-registered modules */
-	sys_module_init();
 
 	/* init pipeline position offsets */
 	pipeline_posn_init(sof);


### PR DESCRIPTION
Remove hard-coded module initialisation from `task_main_start()` and use the native Zephyr initialisation framework.
Note: Not all modules converted yet