### PR TITLE
cavs: dma: increase HDA DMA period count to 4

### DIFF
--- a/src/platform/intel/cavs/lib/dma.c
+++ b/src/platform/intel/cavs/lib/dma.c
@@ -109,7 +109,7 @@ static const struct dw_drv_plat_data dmac1 = {
 };
 
 /* DMA number of buffer periods */
-#define HDA_DMA_BUFFER_PERIOD_COUNT	2
+#define HDA_DMA_BUFFER_PERIOD_COUNT	4
 
 #if CONFIG_DMA_HW_LLI
 #define DW_DMA_BUFFER_PERIOD_COUNT	4


### PR DESCRIPTION
Align HDA DMA platform period count with value used on Intel ACE platforms. This only affects operation with native Zephyr DMA drivers.

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>