### PR TITLE
topology2: cavs: fix num_audio_formats to match the actual number

### DIFF
--- a/tools/topology/topology2/include/pipelines/cavs/dai-copier-gain-mixin-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/dai-copier-gain-mixin-capture.conf
@@ -50,7 +50,7 @@ Class.Pipeline."dai-copier-gain-mixin-capture" {
 			period_sink_count 2
 			period_source_count 0
 			node_type $HDA_LINK_INPUT_CLASS
-			num_audio_formats 2
+			num_audio_formats 1
 			# copier only supports one format based on mixin/mixout requirements: 32-bit 48KHz 2ch
 			Object.Base.audio_format.1 {
 				in_bit_depth		32

--- a/tools/topology/topology2/include/pipelines/cavs/dai-copier-gain-module-copier-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/dai-copier-gain-module-copier-capture.conf
@@ -49,7 +49,7 @@ Class.Pipeline."dai-copier-gain-module-copier-capture" {
 			type dai_out
 			period_sink_count 2
 			period_source_count 0
-			num_audio_formats 2
+			num_audio_formats 1
 			# copier only supports one format based on mixin/mixout requirements: 32-bit 48KHz 2ch
 			Object.Base.audio_format.1 {
 				in_bit_depth		32
@@ -65,7 +65,7 @@ Class.Pipeline."dai-copier-gain-module-copier-capture" {
 			copier_type	"module"
 			period_sink_count 2
 			period_source_count 0
-			num_audio_formats 2
+			num_audio_formats 1
 			Object.Base.audio_format.1 {
 				in_bit_depth		32
 				in_valid_bit_depth	32


### PR DESCRIPTION
Multiple pipelines had incorrect num_audio_formats leading to invalid format structures ending up to topology.

Example FW trace:

[ 1601.624195] sof-audio-pci-intel-tgl 0000:00:1f.3: Get input audio formats for copier.module.8.2 [ 1601.624197] sof-audio-pci-intel-tgl 0000:00:1f.3:  #0: 48000KHz, 32bit (ch_map 0xffffff10 ch_cfg 1 interleaving_style 0 fmt_cfg 0x2002) [ 1601.624201] sof-audio-pci-intel-tgl 0000:00:1f.3:  #1: 0KHz, 0bit (ch_map 0x0 ch_cfg 0 interleaving_style 0 fmt_cfg 0x0)

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>