### PR TITLE
topology2: control: bytes: Use instance ID to instantiate ops and extops

### DIFF
--- a/tools/topology/topology2/include/controls/bytes.conf
+++ b/tools/topology/topology2/include/controls/bytes.conf
@@ -69,11 +69,13 @@ Class.Control."bytes" {
 	}
 
 	# control uses bespoke driver get/put/info ID
-	Object.Base.ops."ctl" {
+	Object.Base.ops.1 {
+		name	"ctl"
 		info 	"bytes"
 	}
 
-	Object.Base.extops."extctl" {
+	Object.Base.extops.1 {
+		name	"extctl"
 		#258 binds the control to byte control get/put handlers
 		get 	258
 		put 	258


### PR DESCRIPTION
Use instance IDs as the class definitions have changed.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>