### PR TITLE
topology2: fix bt offload pipeline build

### DIFF
--- a/tools/topology/topology2/cavs-nocodec-bt.conf
+++ b/tools/topology/topology2/cavs-nocodec-bt.conf
@@ -77,7 +77,8 @@ Object.Dai {
 		sample_bits		32
 		quirks			"lbm_mode"
 		io_clk		$MCLK
-		Object.Base.hw_config."SSP0" {
+		Object.Base.hw_config.1 {
+			name	"SSP0"
 			id      0
 			mclk_freq       $MCLK
 			bclk_freq       3072000
@@ -94,7 +95,8 @@ Object.Dai {
 		quirks			"lbm_mode"
 		io_clk		$MCLK
 
-		Object.Base.hw_config."SSP1" {
+		Object.Base.hw_config.1 {
+			name	"SSP1"
 			id	0
 			mclk_freq	$MCLK
 			bclk_freq	3072000
@@ -237,14 +239,18 @@ Object.PCM {
 		name	"Port0"
 		id 0
 		direction	"duplex"
-		Object.Base.fe_dai."Port0" {}
+		Object.Base.fe_dai.1 {
+			name	"Port0"
+		}
 
-		Object.PCM.pcm_caps."playback" {
+		Object.PCM.pcm_caps.1 {
+			direction "playback"
 			name "SSP0 Playback"
 			formats 'S16_LE,S24_LE,S32_LE'
 		}
 
-		Object.PCM.pcm_caps."capture" {
+		Object.PCM.pcm_caps.2 {
+			direction "capture"
 			name "SSP0 Capture"
 			formats 'S16_LE,S24_LE,S32_LE'
 		}
@@ -253,14 +259,18 @@ Object.PCM {
 		name	"Port1"
 		id 1
 		direction	"duplex"
-		Object.Base.fe_dai."Port1" {}
+		Object.Base.fe_dai.1 {
+			name	"Port1"
+		}
 
-		Object.PCM.pcm_caps."playback" {
+		Object.PCM.pcm_caps.1 {
+			direction "playback"
 			name "SSP1 Playback"
 			formats 'S16_LE,S24_LE,S32_LE'
 		}
 
-		Object.PCM.pcm_caps."capture" {
+		Object.PCM.pcm_caps.2 {
+			direction "capture"
 			name "SSP1 Capture"
 			formats 'S16_LE,S24_LE,S32_LE'
 		}

--- a/tools/topology/topology2/platform/intel/bt-generic.conf
+++ b/tools/topology/topology2/platform/intel/bt-generic.conf
@@ -210,9 +210,12 @@ Object.PCM {
 		id 		$BT_PCM_ID
 		direction	"duplex"
 
-		Object.Base.fe_dai."Port2" {}
+		Object.Base.fe_dai.1 {
+			name	"Port2"
+		}
 
-		Object.PCM.pcm_caps."playback" {
+		Object.PCM.pcm_caps.1 {
+			direction   "playback"
 			name $BT_PB_PCM_CAPS
 			formats	'S16_LE'
 			rate_min 8000
@@ -221,7 +224,8 @@ Object.PCM {
 			channels_max 2
 		}
 
-		Object.PCM.pcm_caps."capture" {
+		Object.PCM.pcm_caps.2 {
+			direction   "capture"
 			name	$BT_CP_PCM_CAPS
 			formats 'S16_LE'
 			rate_min 8000


### PR DESCRIPTION
Fix bt offload pipeline with instance ids. This was an unfortunate merge error with recent instance id topology2 commit.

Signed-off-by: Jaska Uimonen <jaska.uimonen@intel.com>