### PR TITLE
smart_amp_test: convert to Zephyr native initialisation

### DIFF
--- a/src/samples/audio/smart_amp_test.c
+++ b/src/samples/audio/smart_amp_test.c
@@ -9,6 +9,7 @@
 #include <sof/audio/ipc-config.h>
 #include <sof/trace/trace.h>
 #include <sof/ipc/msg.h>
+#include <rtos/init.h>
 #include <sof/ut.h>
 
 #ifndef __ZEPHYR__
@@ -810,3 +811,4 @@ UT_STATIC void sys_comp_smart_amp_init(void)
 }
 
 DECLARE_MODULE(sys_comp_smart_amp_init);
+SOF_MODULE_INIT(smart_amp_test, sys_comp_smart_amp_init);


### PR DESCRIPTION
Use SOF_MODULE_INIT() to register smart_amp_test module with the Zephyr initialisation framework.

Signed-off-by: Chao Song <chao.song@linux.intel.com>

the conversion for smart amp test module is missing from https://github.com/thesofproject/sof/pull/6989, add it here.