### PR TITLE
MTL: enable smart_amp_test module

### DIFF
--- a/src/samples/audio/Kconfig
+++ b/src/samples/audio/Kconfig
@@ -4,7 +4,7 @@ menu "Audio component samples"
 	visible if SAMPLES
 
         config SAMPLE_SMART_AMP
-	        depends on CAVS && !CAVS_VERSION_1_5
+	        depends on CAVS && !CAVS_VERSION_1_5 || ACE
 	        bool "Smart amplifier test component"
 	        default y
 	        help


### PR DESCRIPTION
Enable building smart_amp_test module for MTL.

Signed-off-by: Chao Song <chao.song@linux.intel.com>

rimage PR: https://github.com/thesofproject/rimage/pull/127