### PR TITLE
Topology2: cavs-nocodec: remove multi-stream capture on SSP

### DIFF
--- a/tools/topology/topology2/cavs-nocodec.conf
+++ b/tools/topology/topology2/cavs-nocodec.conf
@@ -16,8 +16,6 @@
 <wov-detect.conf>
 <host-copier-gain-mixin-playback.conf>
 <mixout-gain-dai-copier-playback.conf>
-<dai-copier-gain-module-copier-capture.conf>
-<gain-capture.conf>
 <deepbuffer-playback.conf>
 <data.conf>
 <pcm.conf>
@@ -241,33 +239,15 @@ Object.Pipeline {
 	}
 
 	# capture pipelines
-	gain-capture.1 {
+	passthrough-capture.1 {
 		index 	7
 
 		Object.Widget.copier.1 {
 			stream_name 'SSP0 Capture'
 		}
-		Object.Widget.gain.1 {
-			Object.Control.mixer.1 {
-				name 'Main Capture Volume 1'
-			}
-		}
 	}
 
-	gain-capture.4 {
-		index 	17
-		format	s32le
-		Object.Widget.copier.1 {
-			stream_name 'SSP0-1 Capture'
-		}
-		Object.Widget.gain.1 {
-			Object.Control.mixer.1 {
-				name 'Main Capture Volume 2'
-			}
-		}
-	}
-
-	dai-copier-gain-module-copier-capture.4 {
+	passthrough-be.4 {
 		index		8
 		Object.Widget.copier."1" {
 			dai_index	0
@@ -282,22 +262,6 @@ Object.Pipeline {
 				out_bit_depth		32
 				out_valid_bit_depth	32
 				dma_buffer_size "$[$ibs * 2]"
-			}
-		}
-
-		Object.Widget.copier."2" {
-			stream_name	"NoCodec-0"
-			Object.Base.audio_format.1 {
-				in_bit_depth		32
-				in_valid_bit_depth	32
-				out_bit_depth		32
-				out_valid_bit_depth	32
-				dma_buffer_size "$[$ibs * 2]"
-			}
-		}
-		Object.Widget.gain.1 {
-			Object.Control.mixer.1 {
-				name 'Host Capture Volume'
 			}
 		}
 	}
@@ -382,18 +346,6 @@ Object.PCM {
 			formats 'S16_LE,S24_LE,S32_LE'
 		}
 	}
-	pcm."12" {
-		name	"ssp-capture"
-		id 12
-		direction	"capture"
-		Object.Base.fe_dai.1 {
-			name	"ssp-capture"
-		}
-		Object.PCM.pcm_caps.1 {
-			name "SSP0-1 Capture"
-			formats 'S16_LE,S24_LE,S32_LE'
-		}
-	}
 	pcm."1" {
 		name	"Port1"
 		id 1
@@ -467,7 +419,7 @@ Object.Base {
 
 	route."7" {
 		source	"copier.SSP.8.1"
-		sink	"gain.8.1"
+		sink	"copier.host.7.1"
 	}
 
 	route."8" {
@@ -479,15 +431,4 @@ Object.Base {
 		source	"copier.SSP.12.1"
 		sink	"copier.host.11.1"
 	}
-
-	route."10" {
-		source	"copier.module.8.2"
-		sink	"copier.module.7.2"
-	}
-
-	route."11" {
-		source	"copier.module.8.2"
-		sink	"copier.module.17.2"
-	}
-
 }


### PR DESCRIPTION
multi-stream capture is not needed on SSP port and it will make smart amp topology be more complexity.

Signed-off-by: Bard Liao <yung-chuan.liao@linux.intel.com>