### PR TITLE
[For MTL 003] MTL: enable smart_amp_test module

### DIFF
--- a/src/samples/audio/Kconfig
+++ b/src/samples/audio/Kconfig
@@ -4,7 +4,7 @@ menu "Audio component samples"
 	visible if SAMPLES
 
         config SAMPLE_SMART_AMP
-	        depends on CAVS && !CAVS_VERSION_1_5
+	        depends on CAVS && !CAVS_VERSION_1_5 || ACE
 	        bool "Smart amplifier test component"
 	        default y
 	        help

--- a/west.yml
+++ b/west.yml
@@ -34,7 +34,7 @@ manifest:
     - name: rimage
       repo-path: rimage
       path: sof/rimage
-      revision: 65f345a52e06a084192124364c563d8133d834c2
+      revision: 7bc3cfc946a04cbceebf7d0202a6d490c85dca72
 
     - name: tomlc99
       repo-path: tomlc99


### PR DESCRIPTION
Enable building smart_amp_test module for MTL.

Signed-off-by: Chao Song <chao.song@linux.intel.com>

originally from https://github.com/thesofproject/sof/pull/7005