### PR TITLE
topology2: copier: Add a new attribute

### DIFF
--- a/tools/topology/topology2/include/common/tokens.conf
+++ b/tools/topology/topology2/include/common/tokens.conf
@@ -180,5 +180,6 @@ Object.Base.VendorToken {
 	"18" {
 		name "sof_tkn_copier"
 		node_type		1980
+		deep_buffer_dma_ms	1981
 	}
 }

--- a/tools/topology/topology2/include/components/copier.conf
+++ b/tools/topology/topology2/include/components/copier.conf
@@ -139,6 +139,14 @@ Class.Widget."copier" {
 		}
 	}
 
+	#
+	# Deep buffer size in ms. Applicable only for host copiers
+	#
+	DefineAttribute."deep_buffer_dma_ms" {
+		# Token set reference name and type
+		token_ref	"sof_tkn_copier.word"
+	}
+
 	attributes {
 		#
 		# The copier widget name would be constructed using the copier type, index and

--- a/tools/topology/topology2/include/pipelines/cavs/deepbuffer-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/deepbuffer-playback.conf
@@ -50,6 +50,7 @@ Class.Pipeline."deepbuffer-playback" {
 			type	"aif_in"
 			node_type $HDA_HOST_OUTPUT_CLASS
 			num_audio_formats 3
+			deep_buffer_dma_ms	$DEEPBUFFER_FW_DMA_MS
 			# 16-bit 48KHz 2ch
 			Object.Base.audio_format.1 {
 				out_bit_depth		32


### PR DESCRIPTION
The dma_buffer_size is only applicable from the host/dai copiers and can be calculated using the ibs/obs in the base_cfg in the kernel.

So in preparation for removing the dma_buffer_size token from the audio format objects, add a new attribute, deep_buffer_dma_ms, in the copier that will be used to the send the deep buffer DMA size to the kernel.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>