### PR TITLE
Audio: EQ FIR: Get in prepare() channels count from sink stream

### DIFF
--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -564,7 +564,7 @@ static int eq_fir_prepare(struct processing_module *mod)
 	source_c = buffer_acquire(sourceb);
 	sink_c = buffer_acquire(sinkb);
 	eq_fir_set_alignment(&source_c->stream, &sink_c->stream);
-	channels = source_c->stream.channels;
+	channels = sink_c->stream.channels;
 	frame_fmt = source_c->stream.frame_fmt;
 	buffer_release(sink_c);
 	buffer_release(source_c);


### PR DESCRIPTION
In IPC4 prepare() the source stream channels count is not always set, it depends on topology. However the sink channels count has been just set by IPC4 params function that gets it from component's base configuration.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>