### PR TITLE
Tools: Test: Audio: Fix BITS_OUT in test run configuration

### DIFF
--- a/tools/test/audio/test_utils/test_run.m
+++ b/tools/test/audio/test_utils/test_run.m
@@ -60,7 +60,7 @@ fprintf(fh, 'COMP=\"%s\"\n', test.comp);
 fprintf(fh, 'DIRECTION=playback\n');
 fprintf(fh, 'BITS_IN=%d\n', test.bits_in);
 if isfield(test, 'bits_out') && (test.bits_in ~= test.bits_out)
-	fprintf(fh, 'BITS_IN=%d\n', test.bits_out);
+	fprintf(fh, 'BITS_OUT=%d\n', test.bits_out);
 end
 
 fprintf(fh, 'CHANNELS_IN=%d\n', test.nch_in);


### PR DESCRIPTION
This patch fixes a mistake with test run configuration for testbech tests where input and output word lengths are not the same.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>