### PR TITLE
hda: enable chain dma with ipc4 only

### DIFF
--- a/src/audio/Kconfig
+++ b/src/audio/Kconfig
@@ -30,6 +30,7 @@ config COMP_DAI_GROUP
 config COMP_CHAIN_DMA
 	  bool "Chain DMA component"
 	  default n
+	  depends on IPC_MAJOR_4
 	  help
 	    Chain DMA support in hardware
 


### PR DESCRIPTION
Hda chain work only with IPC4 compatible boards, therefore additional compilation dependency in Kconfig has to be added.

Signed-off-by: Piotr Makaruk <piotr.makaruk@intel.com>