### PR TITLE
board: intel_adsp_ace15_mtpm xtensa toolchain upgrade and enable xt-clang

### DIFF
--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -76,25 +76,29 @@ platform_list = [
 		"name": "apl",
 		"PLAT_CONFIG": "intel_adsp_cavs15",
 		"XTENSA_CORE": "X4H3I16w2D48w3a_2017_8",
-		"XTENSA_TOOLS_VERSION": f"RG-2017.8{xtensa_tools_version_postfix}"
+		"XTENSA_TOOLS_VERSION": f"RG-2017.8{xtensa_tools_version_postfix}",
+		"DEFAULT_TOOLCHAIN_VARIANT": "xcc"
 	},
 	{
 		"name": "cnl",
 		"PLAT_CONFIG": "intel_adsp_cavs18",
 		"XTENSA_CORE": "X6H3CNL_2017_8",
-		"XTENSA_TOOLS_VERSION": f"RG-2017.8{xtensa_tools_version_postfix}"
+		"XTENSA_TOOLS_VERSION": f"RG-2017.8{xtensa_tools_version_postfix}",
+		"DEFAULT_TOOLCHAIN_VARIANT": "xcc"
 	},
 	{
 		"name": "icl",
 		"PLAT_CONFIG": "intel_adsp_cavs20",
 		"XTENSA_CORE": "X6H3CNL_2017_8",
-		"XTENSA_TOOLS_VERSION": f"RG-2017.8{xtensa_tools_version_postfix}"
+		"XTENSA_TOOLS_VERSION": f"RG-2017.8{xtensa_tools_version_postfix}",
+		"DEFAULT_TOOLCHAIN_VARIANT": "xcc"
 	},
 	{
 		"name": "jsl",
 		"PLAT_CONFIG": "intel_adsp_cavs20_jsl",
 		"XTENSA_CORE": "X6H3CNL_2017_8",
-		"XTENSA_TOOLS_VERSION": f"RG-2017.8{xtensa_tools_version_postfix}"
+		"XTENSA_TOOLS_VERSION": f"RG-2017.8{xtensa_tools_version_postfix}",
+		"DEFAULT_TOOLCHAIN_VARIANT": "xcc"
 	},
 	{
 		"name": "tgl",
@@ -103,6 +107,7 @@ platform_list = [
 		"IPC4_RIMAGE_DESC": "tgl-cavs.toml",
 		"XTENSA_CORE": "cavs2x_LX6HiFi3_2017_8",
 		"XTENSA_TOOLS_VERSION": f"RG-2017.8{xtensa_tools_version_postfix}",
+		"DEFAULT_TOOLCHAIN_VARIANT": "xcc",
 		"RIMAGE_KEY": pathlib.Path(SOF_TOP, "keys", "otc_private_key_3k.pem")
 	},
 	{
@@ -112,13 +117,15 @@ platform_list = [
 		"IPC4_RIMAGE_DESC": "tgl-h-cavs.toml",
 		"XTENSA_CORE": "cavs2x_LX6HiFi3_2017_8",
 		"XTENSA_TOOLS_VERSION": f"RG-2017.8{xtensa_tools_version_postfix}",
+		"DEFAULT_TOOLCHAIN_VARIANT": "xcc",
 		"RIMAGE_KEY": pathlib.Path(SOF_TOP, "keys", "otc_private_key_3k.pem")
 	},
 	{
 		"name": "mtl",
 		"PLAT_CONFIG": "intel_adsp_ace15_mtpm",
-		"XTENSA_CORE": "ace10_LX7HiFi4_RI_2020_5",
-		"XTENSA_TOOLS_VERSION": f"RI-2020.5{xtensa_tools_version_postfix}",
+		"XTENSA_CORE": "ace10_LX7HiFi4_2022_10",
+		"XTENSA_TOOLS_VERSION": f"RI-2022.10{xtensa_tools_version_postfix}",
+		"DEFAULT_TOOLCHAIN_VARIANT": "xt-clang",
 		"RIMAGE_KEY": pathlib.Path(SOF_TOP, "keys", "otc_private_key_3k.pem")
 	},
 	# NXP platforms
@@ -542,7 +549,8 @@ def build_platforms():
 					"or is not a directory")
 
 			# set variables expected by zephyr/cmake/toolchain/xcc/generic.cmake
-			os.environ["ZEPHYR_TOOLCHAIN_VARIANT"] = "xcc"
+			os.environ["ZEPHYR_TOOLCHAIN_VARIANT"] = os.environ.get("ZEPHYR_TOOLCHAIN_VARIANT",
+				platform_dict["DEFAULT_TOOLCHAIN_VARIANT"])
 			XTENSA_TOOLCHAIN_PATH = str(pathlib.Path(xtensa_tools_root_dir, "install",
 				"tools").absolute())
 			os.environ["XTENSA_TOOLCHAIN_PATH"] = XTENSA_TOOLCHAIN_PATH

--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 9af2789cad17924298d705b99a1bca5f35ea88e2
+      revision: e3ae110a05d3427647a03fcbeff4478c195c5a48
       remote: zephyrproject
       # Import some projects listed in zephyr/west.yml@revision
       #

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -101,6 +101,10 @@ endif()
 
 # SOF module init
 zephyr_library_named(modules_sof)
+
+# Zephyr C++ code requires 14 or newer standard
+set_property(TARGET modules_sof PROPERTY CXX_STANDARD 17)
+
 zephyr_include_directories(
 	include
 )


### PR DESCRIPTION
Release toolchain for Intel Meteorlake board is Xtensa RI-2022.10.
Upgraded toolchain to final version. New Xtensa toolchains does not support obsolete xt-xcc driver anymore,
so we need to switch to new xt-clang driver.
In this PR:

- modified `xtensa-build-system.py` to build mtl platform with new Xtensa toolchain version RI-2022.10 and core ace10_LX7HiFi4_2022_10
- modified processes and `xtensa-build-system.py` to use new compiler **xt-clang** as the xt-xcc is not available anymore
in new Xtensa toolchains.
- added requirement to SOF project to use C++17 standard. This was caused by changes in Zephyr https://github.com/zephyrproject-rtos/zephyr/pull/53405 that require C++14 standard.
MTL has cpp code that uses those headers but we can move straight away to C++17 as the newest standard supported by xt-clang in this toolchain.
- please note: commit 9ae133d1abedd0ab8ebc8999954cf249648e84e7 will be dropped from this PR before merging. It contains temporary code to test new toolchain in Intel Internal CI & SOF CI and also provide debug logging. 

Merging this PR will require synchronization with the Intel Internal CI team so they can change environmental variables on their side that would select new toolchain as default in production.

Dependencies:

- [x] https://github.com/zephyrproject-rtos/zephyr/pull/54333 NOT MANDATORY
- [x] https://github.com/zephyrproject-rtos/zephyr/pull/54836
- [x] https://github.com/thesofproject/sof/pull/7096
- [x] Changes in the Intel internal CI.
- [x] full scope tests for MTL to prove lack of regression