### PR TITLE
Update fuzzing rig, make component creation work

### DIFF
--- a/scripts/fuzz.sh
+++ b/scripts/fuzz.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -e
+
+# Simple wrapper around a libfuzzer test run, as much for
+# documentation as direct use.  The idea here is really simple: build
+# for the Zephyr "native_posix" board (which is a just a x86
+# executable for the build host, not an emulated device) and run the
+# resulting zephyr.exe file.  This specifies a "fuzz_corpus" directory
+# to save the seeds that produce useful coverage output for use in
+# repeated runs (these are not particularly large, we might consider
+# curating and commiting such a seed directory to the tree).
+#
+# The tool will run until it finds a failure condition.  You will see
+# MANY errors on stdout from all the randomized input.  Don't try to
+# capture this, either let it output to a terminal or arrange to keep
+# only the last XXX lines after the tool exits.
+#
+# The only prerequisite to install is a clang compiler on the host.
+# Versions 12+ have all been observed to work.
+#
+# You will need the kconfigs specified below for correct operation,
+# but can add more at the end of this script's command line to
+# duplicate configurations as needed.  Alternatively you can pass
+# overlay files in kconfig syntax via -DOVERLAY_CONFIG=..., etc...
+
+export SOF_TOP=$(cd "$(dirname "$0")/.." && pwd)
+
+export ZEPHYR_BASE=$SOF_TOP/../zephyr
+export ZEPHYR_TOOLCHAIN_VARIANT=llvm
+
+main()
+{
+  west build -p -b native_posix $SOF_TOP/app/ -- \
+    -DCONFIG_ASSERT=y \
+    -DCONFIG_SYS_HEAP_BIG_ONLY=y \
+    -DCONFIG_ZEPHYR_NATIVE_DRIVERS=y \
+    -DCONFIG_ARCH_POSIX_LIBFUZZER=y \
+    -DCONFIG_ARCH_POSIX_FUZZ_TICKS=100 \
+    -DCONFIG_ASAN=y "$@"
+
+  mkdir -p ./fuzz_corpus
+  build/zephyr/zephyr.exe ./fuzz_corpus
+}
+
+main "$@"

--- a/src/platform/posix/include/platform/platform.h
+++ b/src/platform/posix/include/platform/platform.h
@@ -24,6 +24,8 @@
 
 #define PLATFORM_DEFAULT_DELAY 12
 
+struct sof;
+
 void posix_dma_init(struct sof *sof);
 void posix_dai_init(struct sof *sof);
 


### PR DESCRIPTION
Come back to the fuzzing rig, dust off my brain (been a rough January here for me, sorry), and update to hopefully finish off IPC coverage.

As mentioned earlier, TPLG_COMP_NEW commands weren't being covered (and if we can't create components, we aren't able to get coverage on anything else!) because of the way they work.  The input wants to match a 128 bit UUID value in the command vs. a table of drivers, and that haystack is too deep for even fuzzing to find the needle.  This plays a trick by using an otherwise-ignored bit of fuzz input to encode a "create a whiteboxed command" metacommand.  When triggered, this adds Just Enough Correct Input to get the code through the driver selection stage of the IPC parser, but leaves the other random bits random.   There were a bunch of ancestor variants here which were terrible hacks, but I'm actually kinda proud of how this finally turned out.

Anyway, now we get all the way to the individual component creation paths, essentially completing coverage of all the IPC3 input paths (IPC4 isn't default in the tree yet, but AFAICT the protocol bits the fuzzing rig touches are all identical and it "should" work fine, modulo fuzz-detected-bugs, when we cut over; it's on my list to figure out ahead of time).

Interestingly I didn't stumble on any new bugs doing this, which makes me a little worried.  But I've manually traced out every creation path I can find and know they're all being hit.

We're also not hitting as much of the runtime behavior as I would have liked.  The fuzzing rig is successfully creating components, but after just a handful it's out of memory and the resulting random collection of junk doesn't actually try to do anything.  Maybe that's just asking too much of fuzzing as a technique; it's really only intended for input validation code.