### PR TITLE
Audio: Mixer: Use frame aligned API

### DIFF
--- a/test/cmocka/src/audio/mixer/CMakeLists.txt
+++ b/test/cmocka/src/audio/mixer/CMakeLists.txt
@@ -19,5 +19,6 @@ cmocka_test(mixer
 	${PROJECT_SOURCE_DIR}/src/audio/pipeline/pipeline-schedule.c
 	${PROJECT_SOURCE_DIR}/src/audio/pipeline/pipeline-stream.c
 	${PROJECT_SOURCE_DIR}/src/audio/pipeline/pipeline-xrun.c
+	${PROJECT_SOURCE_DIR}/src/math/numbers.c
 )
 target_link_libraries(mixer PRIVATE -lm)


### PR DESCRIPTION
Using frame aligned API to reduce the division calculation in mixer process function.

Signed-off-by: Andrula Song <andrula.song@intel.com>