### PR TITLE
topology2: hdmi-generic.conf: Increase channels_max to 8 for HDMI 1-4

### DIFF
--- a/tools/topology/topology2/platform/intel/hdmi-generic.conf
+++ b/tools/topology/topology2/platform/intel/hdmi-generic.conf
@@ -139,6 +139,7 @@ Object.PCM {
 		Object.PCM.pcm_caps.1 {
 			name $HDMI1_PCM_CAPS
 			formats 'S32_LE,S16_LE'
+			channels_max 8
 		}
 		direction playback
 	}
@@ -151,6 +152,7 @@ Object.PCM {
 		Object.PCM.pcm_caps.1 {
 			name $HDMI2_PCM_CAPS
 			formats 'S32_LE,S16_LE'
+			channels_max 8
 		}
 		direction playback
 	}
@@ -163,6 +165,7 @@ Object.PCM {
 		Object.PCM.pcm_caps.1 {
 			name $HDMI3_PCM_CAPS
 			formats 'S32_LE,S16_LE'
+			channels_max 8
 		}
 		direction playback
 	}
@@ -178,6 +181,7 @@ Object.PCM {
 				Object.PCM.pcm_caps.1 {
 					name $HDMI4_PCM_CAPS
 					formats 'S32_LE,S16_LE'
+					channels_max 8
 				}
 				direction playback
 			}


### PR DESCRIPTION
Allow multichannel audio support for HDMI 1, 2, 3 and optional 4. This change allows maximum of 8 (7+1) channels, provided the connected displays EDID allows it.

Signed-off-by: Jyri Sarha <jyri.sarha@intel.com>