### PR TITLE
west.yml: upgrade rimage to 7bc3cfc

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -34,7 +34,7 @@ manifest:
     - name: rimage
       repo-path: rimage
       path: sof/rimage
-      revision: ba8534bb237881beb281c56f5d03d92fa67eb0ec
+      revision: 7bc3cfc946a04cbceebf7d0202a6d490c85dca72
 
     - name: tomlc99
       repo-path: tomlc99


### PR DESCRIPTION
upgrade rimage to
7bc3cfc946a04cbceebf7d0202a6d490c85dca72

7bc3cfc config: mtl: add smart amp test module config 3da7739 config: correct module config load_type
bc7d49d config: align module_type with mtl for tgl and tgl-h bdf48ee config: tgl-cavs: add fir and iir eq module config

Signed-off-by: Jaska Uimonen <jaska.uimonen@intel.com>