### PR TITLE
ipc: save pipeline attributes

### DIFF
--- a/src/include/sof/audio/pipeline.h
+++ b/src/include/sof/audio/pipeline.h
@@ -63,6 +63,7 @@ struct pipeline {
 	uint32_t frames_per_sched;/**< output frames of pipeline, 0 is variable */
 	uint32_t xrun_limit_usecs; /**< report xruns greater than limit */
 	uint32_t time_domain;	/**< scheduling time domain */
+	uint32_t attributes;   /**< pipeline attributes from IPC extension msg/ */
 
 	/* runtime status */
 	int32_t xrun_bytes;		/* last xrun length */


### PR DESCRIPTION
During create a new pipeline, the FW is not store information about pipeline attributes. The information is lost and we can not verify later if pipeline has ULP or Autonomous_reset attributes.

This PR added a attributes field in pipeline structure and save the information during pipeline create.