### PR TITLE
samples: convert smart amp test module to not expect the blob during init with IPC4

### DIFF
--- a/src/include/sof/samples/audio/smart_amp_test.h
+++ b/src/include/sof/samples/audio/smart_amp_test.h
@@ -87,24 +87,22 @@ typedef int(*smart_amp_proc)(struct comp_dev *dev,
  */
 
 struct sof_smart_amp_config {
-#if CONFIG_IPC_MAJOR_4
-	struct ipc4_base_module_cfg base;
-	uint16_t num_input_pin_fmt;
-	uint16_t num_output_pin_fmt;
-	uint8_t reserved[8];
-	/* length of data after output_pin_fmt */
-	uint32_t priv_param_len;
-	struct ipc4_input_pin_format input_pin_fmt[2];
-	struct ipc4_output_pin_format output_pin_fmt;
-#else
 	uint32_t size;
-#endif
 	uint32_t feedback_channels;
 	int8_t source_ch_map[PLATFORM_MAX_CHANNELS];
 	int8_t feedback_ch_map[PLATFORM_MAX_CHANNELS];
 };
 
 #if CONFIG_IPC_MAJOR_4
+
+#define SMART_AMP_NUM_IN_PINS		2
+#define SMART_AMP_NUM_OUT_PINS		1
+
+struct sof_smart_amp_ipc4_config {
+	struct ipc4_base_module_cfg base;
+	struct ipc4_input_pin_format input_pins[SMART_AMP_NUM_IN_PINS];
+	struct ipc4_output_pin_format output_pin;
+};
 
 enum smart_amp_config_params {
 	SMART_AMP_SET_MODEL = 1,


### PR DESCRIPTION
Hi,

the module initialization for IPC4 does not contain binary (configuration) blob, only base_cfg and optional bae_cfg_ext.
The configuration blob is sent as a large_config message separately.


