### PR TITLE
detect_test: Split the module config and blob receiving for IPC4

### DIFF
--- a/src/include/sof/samples/audio/detect_test.h
+++ b/src/include/sof/samples/audio/detect_test.h
@@ -14,26 +14,6 @@
 #define SOF_DETECT_TEST_CONFIG	0
 #define SOF_DETECT_TEST_MODEL	1
 
-#ifdef CONFIG_IPC_MAJOR_4
-struct sof_detect_test_config {
-	struct ipc4_base_module_cfg base;
-
-	/** synthetic system load settings */
-	uint32_t load_mips;
-
-	/** time in ms after which detection is activated */
-	uint32_t preamble_time;
-
-	/** activation right shift, determines the speed of activation */
-	uint32_t activation_shift;
-
-	/** activation threshold */
-	uint32_t activation_threshold;
-
-	/** default draining size in bytes */
-	uint32_t drain_req;
-} __packed __aligned(4);
-#else /* CONFIG_IPC_MAJOR_4 */
 struct sof_detect_test_config {
 	uint32_t size;
 
@@ -46,7 +26,7 @@ struct sof_detect_test_config {
 	/** activation right shift, determines the speed of activation */
 	uint16_t activation_shift;
 
-	/** sample width in bits */
+	/** sample width in bits - ignored with IPC4 */
 	int16_t sample_width;
 
 	/** activation threshold */
@@ -58,7 +38,6 @@ struct sof_detect_test_config {
 	/** reserved for future use */
 	uint32_t reserved[1];
 } __packed;
-#endif /* CONFIG_IPC_MAJOR_4 */
 
 uint16_t test_keyword_get_sample_valid_bytes(struct comp_dev *dev);
 


### PR DESCRIPTION
During the component create (module init) we are not receiving the blob containing the sof_detect_test_config, only the base_cfg is received. The sof_detect_test_config content will be sent via large_config_set at a later time.

The blob received via large_config_set must be the same format as the blob with IPC3 but in runtime the sample_width from the blob is ignored and the audio_fmt.depth is used from the base_cfg.

Signed-off-by: Peter Ujfalusi <peter.ujfalusi@linux.intel.com>