### PR TITLE
sof-ctl: Add support for handling IPC4 blobs

### DIFF
--- a/src/include/kernel/abi.h
+++ b/src/include/kernel/abi.h
@@ -61,5 +61,7 @@
 
 /** \brief SOF ABI magic number "SOF\0". */
 #define SOF_ABI_MAGIC		0x00464F53
+/** \brief SOF IPC4 ABI magic number "SOF4". */
+#define SOF_IPC4_ABI_MAGIC	0x34464F53
 
 #endif /* __KERNEL_ABI_H__ */

--- a/src/include/kernel/header.h
+++ b/src/include/kernel/header.h
@@ -22,16 +22,25 @@
  * \brief Header for all non IPC ABI data.
  *
  * Identifies data type, size and ABI.
- * Data header used for all component data structures and binary blobs sent to
- * firmware as runtime data. This data is typically sent by userspace
- * applications and tunnelled through any OS kernel (via binary kcontrol on
- * Linux) to the firmware.
+ * Only in case of IPC3 the data header used for all component data structures
+ * and binary blobs sent to firmware as runtime data. This data is typically sent
+ * by userspace applications and tunnelled through any OS kernel (via binary
+ * kcontrol on Linux) to the firmware.
+ * With IPC4 the ABI header is used between user space and kernel for verification
+ * purposes and to provide information about the attached binary blob, like the
+ * param_id of it.
  */
 struct sof_abi_hdr {
-	uint32_t magic;		/**< 'S', 'O', 'F', '\0' */
-	uint32_t type;		/**< component specific type */
+	uint32_t magic;		/**< Magic number for validation */
+				/**< for IPC3 data: 0x00464F53 ('S', 'O', 'F', '\0') */
+				/**< for IPC4 data: 0x34464F53 ('S', 'O', 'F', '4') */
+	uint32_t type;		/**< module specific parameter */
+				/**< for IPC3: Component specific type */
+				/**< for IPC4: parameter ID (param_id) of the data */
 	uint32_t size;		/**< size in bytes of data excl. this struct */
-	uint32_t abi;		/**< SOF ABI version */
+	uint32_t abi;		/**< SOF ABI version. */
+				/**< The version is valid in scope of the 'magic', */
+				/**< IPC3 and IPC4 ABI version numbers have no relationship. */
 	uint32_t reserved[4];	/**< reserved for future use */
 	uint32_t data[0];	/**< Component data - opaque to core */
 } __attribute__((packed));


### PR DESCRIPTION
Hi,

Update the ABI header to match with the kernel's recent changes to define it's use with IPC4 blobs.
Add support for generating and handling IPC4 blobs to sof-ctl.

this PR should be able to replace #6893
