### PR TITLE
module-adapter: allow different statuses

### DIFF
--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -622,12 +622,6 @@ module_single_sink_setup(struct comp_dev *dev,
 	int i = 0;
 
 	list_for_item(blist, &dev->bsource_list) {
-		/* check if the source dev is in the same state as the dev */
-		if (source_c[i]->source->state != dev->state) {
-			i++;
-			continue;
-		}
-
 		comp_get_copy_limits_frame_aligned(source_c[i], sinks_c[0], &c);
 
 		if (!mod->skip_src_buffer_invalidate)
@@ -665,12 +659,6 @@ module_single_source_setup(struct comp_dev *dev,
 	int i = 0;
 
 	list_for_item(blist, &dev->bsink_list) {
-		/* check if the sink dev is in the same state as the dev */
-		if (sinks_c[i]->sink->state != dev->state) {
-			i++;
-			continue;
-		}
-
 		comp_get_copy_limits_frame_aligned(source_c[0], sinks_c[i], &c);
 
 		min_frames = MIN(min_frames, c.frames);


### PR DESCRIPTION
The following problem is observed when testing pause functionality:

in a case of a playback stream host -> mixin -> mixout -> DAI where host and mixin belong to the pipeline A and mixout and DAI belong to pipeline B, pipeline B is scheduled before A. So at start we get: scheduler start
B: no data
A: read 1 period of data
scheduler sleep
(1 period of data pending in pipeline A)
scheduler start
B: send 1 period of data out
A: read 1 period of data
scheduler sleep
(1 period of data pending in pipeline A)
PAUSE
RELEASE
scheduler start
B: old data before sleep isn't sent because A is PAUSED A: read 1 period of data
scheduler sleep
(2 periods of data pending in pipeline A)
...

With repeated pause-release cycles this leads to buffer overrun. To fix this allow sending out data by pipeline B when A is still paused.
