### PR TITLE
eq-iir: fix address space notation

### DIFF
--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -826,7 +826,8 @@ static int eq_iir_process(struct processing_module *mod,
  * \param[in,out] source Structure pointer of source.
  * \param[in,out] sink Structure pointer of sink.
  */
-static void eq_iir_set_alignment(struct audio_stream *source, struct audio_stream *sink)
+static void eq_iir_set_alignment(struct audio_stream __sparse_cache *source,
+				 struct audio_stream __sparse_cache *sink)
 {
 	const uint32_t byte_align = 8;
 	const uint32_t frame_align_req = 2;


### PR DESCRIPTION
eq_iir_set_alignment() should use the  __sparse_cache annotation for both its arguments.
