### PR TITLE
cavs: increase exit delay on memory bank powerup

### DIFF
--- a/src/platform/intel/cavs/lib/pm_runtime.c
+++ b/src/platform/intel/cavs/lib/pm_runtime.c
@@ -367,6 +367,7 @@ static inline void cavs_pm_runtime_core_en_memory(uint32_t index)
 
 	cavs_pm_memory_hp_sram_power_gate(core_memory_ptr, SOF_CORE_S_SIZE,
 					  true);
+	idelay(MEMORY_POWER_CHANGE_DELAY);
 
 #endif
 }


### PR DESCRIPTION
For some reason the memory banks can still be inaccessible despite registers saying they are ready. If they are accessed prematurely this will result in a crash, typically when memory is being initialized. Adding this delay allows a device to pass over 1k reboots without a crash that previously could pass 5 cycles.

Signed-off-by: Curtis Malainey <cujomalainey@chromium.org>