### PR TITLE
topology2: ssp: add link clock aux data for mtl

### DIFF
--- a/tools/topology/topology2/cavs-nocodec-bt.conf
+++ b/tools/topology/topology2/cavs-nocodec-bt.conf
@@ -2,6 +2,7 @@
 <searchdir:include/common>
 <searchdir:include/components>
 <searchdir:include/dais>
+<searchdir:include/dais/intel>
 <searchdir:include/pipelines/cavs>
 <searchdir:platform/intel>
 
@@ -29,9 +30,11 @@
 <dai.conf>
 <host.conf>
 <dmic-default.conf>
+<ssp-default.conf>
 
 <bt-default.conf>
 <bt-generic.conf>
+<intel_ssp_aux_config.conf>
 
 Define {
 	MCLK 				24576000
@@ -78,12 +81,21 @@ Object.Dai.SSP [
 		sample_bits		32
 		quirks			"lbm_mode"
 		io_clk		$MCLK
+		version         $SSP_BLOB_VERSION
+
 		Object.Base.hw_config.1 {
 			name	"SSP0"
 			id      0
 			mclk_freq       $MCLK
 			bclk_freq       3072000
 			tdm_slot_width  32
+			IncludeByKey.PLATFORM {
+				"mtl" {
+					Object.Base.link_config.1 {
+						clock_source	1
+					}
+				}
+			}
 		}
 	}
 	{
@@ -95,6 +107,7 @@ Object.Dai.SSP [
 		sample_bits		32
 		quirks			"lbm_mode"
 		io_clk		$MCLK
+		version         $SSP_BLOB_VERSION
 
 		Object.Base.hw_config.1 {
 			name	"SSP1"
@@ -102,6 +115,13 @@ Object.Dai.SSP [
 			mclk_freq	$MCLK
 			bclk_freq	3072000
 			tdm_slot_width	32
+			IncludeByKey.PLATFORM {
+				"mtl" {
+					Object.Base.link_config.1 {
+						clock_source	1
+					}
+				}
+			}
 		}
 	}
 ]

--- a/tools/topology/topology2/cavs-nocodec.conf
+++ b/tools/topology/topology2/cavs-nocodec.conf
@@ -2,6 +2,7 @@
 <searchdir:include/common>
 <searchdir:include/components>
 <searchdir:include/dais>
+<searchdir:include/dais/intel>
 <searchdir:include/pipelines/cavs>
 <searchdir:platform/intel>
 
@@ -42,6 +43,9 @@
 <input_audio_format.conf>
 <output_audio_format.conf>
 <dmic-default.conf>
+<ssp-default.conf>
+<intel_ssp_aux_config.conf>
+
 
 Define {
 	MCLK 				24576000
@@ -94,6 +98,7 @@ Object.Dai.SSP [
 		sample_bits		32
 		quirks			"lbm_mode"
 		io_clk		$MCLK
+		version         $SSP_BLOB_VERSION
 
 		Object.Base.hw_config.1 {
 			name	"SSP0"
@@ -101,6 +106,13 @@ Object.Dai.SSP [
 			mclk_freq	$MCLK
 			bclk_freq	3072000
 			tdm_slot_width	32
+			IncludeByKey.PLATFORM {
+				"mtl" {
+					Object.Base.link_config.1 {
+						clock_source	1
+					}
+				}
+			}
 		}
 	}
 	{
@@ -112,6 +124,7 @@ Object.Dai.SSP [
 		sample_bits		32
 		quirks			"lbm_mode"
 		io_clk		$MCLK
+		version         $SSP_BLOB_VERSION
 
 		Object.Base.hw_config.1 {
 			name	"SSP1"
@@ -119,6 +132,13 @@ Object.Dai.SSP [
 			mclk_freq	$MCLK
 			bclk_freq	3072000
 			tdm_slot_width	32
+			IncludeByKey.PLATFORM {
+				"mtl" {
+					Object.Base.link_config.1 {
+						clock_source	1
+					}
+				}
+			}
 		}
 	}
 	{
@@ -130,6 +150,7 @@ Object.Dai.SSP [
 		sample_bits		32
 		quirks			"lbm_mode"
 		io_clk		$MCLK
+		version         $SSP_BLOB_VERSION
 
 		Object.Base.hw_config.1 {
 			name	"SSP2"
@@ -137,6 +158,13 @@ Object.Dai.SSP [
 			mclk_freq	$MCLK
 			bclk_freq	3072000
 			tdm_slot_width	32
+			IncludeByKey.PLATFORM {
+				"mtl" {
+					Object.Base.link_config.1 {
+						clock_source	1
+					}
+				}
+			}
 		}
 	}
 ]

--- a/tools/topology/topology2/cavs-rt5682.conf
+++ b/tools/topology/topology2/cavs-rt5682.conf
@@ -2,6 +2,7 @@
 <searchdir:include/common>
 <searchdir:include/components>
 <searchdir:include/dais>
+<searchdir:include/dais/intel>
 <searchdir:include/pipelines/cavs>
 <searchdir:platform/intel>
 
@@ -36,9 +37,11 @@
 <dai.conf>
 <host.conf>
 <dmic-default.conf>
+<ssp-default.conf>
 <hdmi-default.conf>
 <bt-default.conf>
 <bt-generic.conf>
+<intel_ssp_aux_config.conf>
 
 Define {
 	MCLK 				24576000
@@ -128,6 +131,7 @@ Object.Dai.SSP [
 		default_hw_conf_id	0
 		sample_bits		32
 		io_clk		$MCLK
+		version         $SSP_BLOB_VERSION
 
 		Object.Base.hw_config.1 {
 			name	$HEADSET_HW_CONFIG_NAME
@@ -135,6 +139,13 @@ Object.Dai.SSP [
 			mclk_freq	$MCLK
 			bclk_freq	3072000
 			tdm_slot_width	32
+			IncludeByKey.PLATFORM {
+				"mtl" {
+					Object.Base.link_config.1 {
+						clock_source	1
+					}
+				}
+			}
 		}
 	}
 	{
@@ -160,6 +171,13 @@ Object.Dai.SSP [
 			mclk_freq	$MCLK
 			bclk_freq	3072000
 			tdm_slot_width	32
+			IncludeByKey.PLATFORM {
+				"mtl" {
+					Object.Base.link_config.1 {
+						clock_source	1
+					}
+				}
+			}
 		}
 	}
 ]

--- a/tools/topology/topology2/platform/intel/bt-ssp-config-lbm.conf
+++ b/tools/topology/topology2/platform/intel/bt-ssp-config-lbm.conf
@@ -8,6 +8,7 @@ Object.Dai.SSP [
 		sample_bits		16
 		quirks			"lbm_mode"
 		io_clk			$BT_MCLK
+		version         	$SSP_BLOB_VERSION
 		Object.Base.hw_config.1 {
 			id		0
 			name		"BT-SCO-WB"
@@ -22,6 +23,13 @@ Object.Dai.SSP [
 			tdm_slots	1
 			tx_slots	1
 			rx_slots	1
+			IncludeByKey.PLATFORM {
+				"mtl" {
+					Object.Base.link_config.1 {
+						clock_source	1
+					}
+				}
+			}
 		}
 		Object.Base.hw_config.2 {
 			id		1
@@ -37,6 +45,13 @@ Object.Dai.SSP [
 			tdm_slots	1
 			tx_slots	1
 			rx_slots	1
+			IncludeByKey.PLATFORM {
+				"mtl" {
+					Object.Base.link_config.1 {
+						clock_source	1
+					}
+				}
+			}
 		}
 		Object.Base.hw_config.3 {
 			id		2
@@ -51,6 +66,13 @@ Object.Dai.SSP [
 			tdm_slots	2
 			tx_slots	3
 			rx_slots	3
+			IncludeByKey.PLATFORM {
+				"mtl" {
+					Object.Base.link_config.1 {
+						clock_source	1
+					}
+				}
+			}
 		}
 	}
 ]

--- a/tools/topology/topology2/platform/intel/bt-ssp-config.conf
+++ b/tools/topology/topology2/platform/intel/bt-ssp-config.conf
@@ -7,6 +7,7 @@ Object.Dai.SSP [
 		default_hw_conf_id	0
 		sample_bits		16
 		io_clk			$BT_MCLK
+		version         	$SSP_BLOB_VERSION
 		Object.Base.hw_config.1 {
 			id		0
 			name		"BT-SCO-WB"
@@ -21,6 +22,13 @@ Object.Dai.SSP [
 			tdm_slots	1
 			tx_slots	1
 			rx_slots	1
+			IncludeByKey.PLATFORM {
+				"mtl" {
+					Object.Base.link_config.1 {
+						clock_source	1
+					}
+				}
+			}
 		}
 		Object.Base.hw_config.2 {
 			id		1
@@ -36,6 +44,13 @@ Object.Dai.SSP [
 			tdm_slots	1
 			tx_slots	1
 			rx_slots	1
+			IncludeByKey.PLATFORM {
+				"mtl" {
+					Object.Base.link_config.1 {
+						clock_source	1
+					}
+				}
+			}
 		}
 		Object.Base.hw_config.3 {
 			id		2
@@ -50,6 +65,13 @@ Object.Dai.SSP [
 			tdm_slots	2
 			tx_slots	3
 			rx_slots	0
+			IncludeByKey.PLATFORM {
+				"mtl" {
+					Object.Base.link_config.1 {
+						clock_source	1
+					}
+				}
+			}
 		}
 	}
 ]

--- a/tools/topology/topology2/platform/intel/mtl.conf
+++ b/tools/topology/topology2/platform/intel/mtl.conf
@@ -1,4 +1,5 @@
 # MTL-specific variable definitions
 Define {
 	DMIC_DRIVER_VERSION		3
+	SSP_BLOB_VERSION		0x105
 }

--- a/tools/topology/topology2/platform/intel/ssp-default.conf
+++ b/tools/topology/topology2/platform/intel/ssp-default.conf
@@ -1,0 +1,4 @@
+# Default SSP variable definitions
+Define {
+       SSP_BLOB_VERSION		0x100
+}


### PR DESCRIPTION
Add conditional link clock settings for mtl ssp using auxiliary data in the blob generation.

Signed-off-by: Jaska Uimonen <jaska.uimonen@intel.com>