### PR TITLE
topology2: deep buffer: use 32 bits to align with other pipelines

### DIFF
--- a/tools/topology/topology2/include/pipelines/cavs/deepbuffer-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/deepbuffer-playback.conf
@@ -56,7 +56,7 @@ Class.Pipeline."deepbuffer-playback" {
 			# 16-bit 48KHz 2ch
 			Object.Base.audio_format.1 {
 				out_bit_depth		32
-				out_valid_bit_depth	24
+				out_valid_bit_depth	32
 				# 100ms buffer
 				dma_buffer_size "$[$ibs * $DEEPBUFFER_FW_DMA_MS]"
 			}
@@ -65,7 +65,7 @@ Class.Pipeline."deepbuffer-playback" {
 				in_bit_depth		32
 				in_valid_bit_depth	24
 				out_bit_depth		32
-				out_valid_bit_depth	24
+				out_valid_bit_depth	32
 				# 100ms buffer
 				dma_buffer_size "$[$obs * $DEEPBUFFER_FW_DMA_MS]"
 			}


### PR DESCRIPTION
Now deep buffer uses S24_LE but other pipelines use S32_LE internal format . Chrome team found a bug that deep buffer can't work well with I2S codec since fw only support S32_LE for I2S now.

This patch will use S32_LE to align with current requirement

Signed-off-by: Rander Wang <rander.wang@intel.com>