### PR TITLE
topology2: Use new attribute references notation in route definitions

### DIFF
--- a/tools/topology/topology2/include/pipelines/cavs/dai-copier-gain-mixin-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/dai-copier-gain-mixin-capture.conf
@@ -85,8 +85,8 @@ Class.Pipeline."dai-copier-gain-mixin-capture" {
 
 	Object.Base {
 		route.1 {
-			source gain..1
-			sink	mixin..1
+			source gain.$index.1
+			sink	mixin.$index.1
 		}
 	}
 

--- a/tools/topology/topology2/include/pipelines/cavs/dai-copier-gain-module-copier-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/dai-copier-gain-module-copier-capture.conf
@@ -100,8 +100,8 @@ Class.Pipeline."dai-copier-gain-module-copier-capture" {
 
 	Object.Base {
 		route.1 {
-			source gain..1
-			sink	copier.module..2
+			source gain.$index.1
+			sink	copier.module.$index.2
 		}
 	}
 

--- a/tools/topology/topology2/include/pipelines/cavs/dai-kpb-be.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/dai-kpb-be.conf
@@ -123,8 +123,8 @@ Class.Pipeline."dai-kpb-be" {
 
 	Object.Base {
 		route."1" {
-			source	"copier.DMIC..1"
-			sink	"kpb..1"
+			source	"copier.DMIC.$index.1"
+			sink	"kpb.$index.1"
 		}
 	}
 

--- a/tools/topology/topology2/include/pipelines/cavs/deepbuffer-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/deepbuffer-playback.conf
@@ -112,12 +112,12 @@ Class.Pipeline."deepbuffer-playback" {
 
 	Object.Base {
 		route.1 {
-			source copier.host..1
-			sink	gain..1
+			source copier.host.$index.1
+			sink	gain.$index.1
 		}
 		route.2 {
-			source	gain..1
-			sink mixin..1
+			source	gain.$index.1
+			sink mixin.$index.1
 		}
 	}
 

--- a/tools/topology/topology2/include/pipelines/cavs/gain-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/gain-capture.conf
@@ -118,8 +118,8 @@ Class.Pipeline."gain-capture" {
 
 	Object.Base {
 		route."1" {
-			source	"gain..1"
-			sink	"copier.host..1"
+			source	"gain.$index.1"
+			sink	"copier.host.$index.1"
 		}
 	}
 

--- a/tools/topology/topology2/include/pipelines/cavs/gain-copier-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/gain-copier-capture.conf
@@ -119,12 +119,12 @@ Class.Pipeline."gain-copier-capture" {
 
 	Object.Base {
 		route."1" {
-			source	"copier.module..2"
-			sink	"gain..1"
+			source	"copier.module.$index.2"
+			sink	"gain.$index.1"
 		}
 		route."2" {
-			source	"gain..1"
-			sink	"copier.host..1"
+			source	"gain.$index.1"
+			sink	"copier.host.$index.1"
 		}
 	}
 

--- a/tools/topology/topology2/include/pipelines/cavs/gain-module-copier.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/gain-module-copier.conf
@@ -86,8 +86,8 @@ Class.Pipeline."gain-module-copier" {
 
 	Object.Base {
 		route.1 {
-			source	gain..1
-			sink	copier.module..1
+			source	gain.$index.1
+			sink	copier.module.$index.1
 		}
 	}
 

--- a/tools/topology/topology2/include/pipelines/cavs/gain-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/gain-playback.conf
@@ -98,8 +98,8 @@ Class.Pipeline."gain-playback" {
 
 	Object.Base {
 		route."1" {
-			source	"copier.host..1"
-			sink	"gain..1"
+			source	"copier.host.$index.1"
+			sink	"gain.$index.1"
 		}
 	}
 

--- a/tools/topology/topology2/include/pipelines/cavs/host-copier-gain-mixin-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/host-copier-gain-mixin-playback.conf
@@ -107,12 +107,12 @@ Class.Pipeline."host-copier-gain-mixin-playback" {
 
 	Object.Base {
 		route.1 {
-			source copier.host..1
-			sink	gain..1
+			source copier.host.$index.1
+			sink	gain.$index.1
 		}
 		route.2 {
-			source	gain..1
-			sink mixin..1
+			source	gain.$index.1
+			sink mixin.$index.1
 		}
 	}
 

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-gain-dai-copier-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-gain-dai-copier-playback.conf
@@ -101,8 +101,8 @@ Class.Pipeline."mixout-gain-dai-copier-playback" {
 
 	Object.Base {
 		route.1 {
-			source mixout..1
-			sink	gain..1
+			source mixout.$index.1
+			sink	gain.$index.1
 		}
 	}
 

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-gain-host-copier-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-gain-host-copier-capture.conf
@@ -116,12 +116,12 @@ Class.Pipeline."mixout-gain-host-copier-capture" {
 
 	Object.Base {
 		route.1 {
-			source	mixout..1
-			sink gain..1
+			source	mixout.$index.1
+			sink gain.$index.1
 		}
 		route.2 {
-			source	gain..1
-			sink copier.host..1
+			source	gain.$index.1
+			sink copier.host.$index.1
 		}
 	}
 

--- a/tools/topology/topology2/include/pipelines/cavs/src-gain-mixin-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/src-gain-mixin-playback.conf
@@ -87,18 +87,18 @@ Class.Pipeline."src-gain-mixin-playback" {
 
 	Object.Base {
 		route."1" {
-			source	"copier.host..1"
-			sink	"src..1"
+			source	"copier.host.$index.1"
+			sink	"src.$index.1"
 		}
 
 		route."2" {
-			source  "src..1"
-			sink    "gain..1"
+			source  "src.$index.1"
+			sink    "gain.$index.1"
 		}
 
                 route."3" {
-                        source  "gain..1"
-                        sink    "mixin..1"
+                        source  "gain.$index.1"
+                        sink    "mixin.$index.1"
                 }
 	}
 

--- a/tools/topology/topology2/include/pipelines/cavs/wov-detect.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/wov-detect.conf
@@ -102,12 +102,12 @@ Class.Pipeline."wov-detect" {
 
 	Object.Base {
 		route."1" {
-			source "micsel..1"
-			sink "wov..1"
+			source "micsel.$index.1"
+			sink "wov.$index.1"
 		}
 
 		route."2" {
-			source "wov..1"
+			source "wov.$index.1"
 			sink "virtual.detect_sink"
 		}
 	}

--- a/tools/topology/topology2/include/pipelines/eq-iir-volume-capture.conf
+++ b/tools/topology/topology2/include/pipelines/eq-iir-volume-capture.conf
@@ -89,28 +89,28 @@ Class.Pipeline."eq-iir-volume-capture" {
 	# Pipeline connections
 	Object.Base {
 		route."1" {
-			source	buffer..1
-			sink host..capture
+			source	buffer.$index.1
+			sink host.$index.capture
 		}
 
 		route."2" {
-			source	pga..1
-			sink	buffer..1
+			source	pga.$index.1
+			sink	buffer.$index.1
 		}
 
 		route."3" {
-			source	buffer..2
-			sink	pga..1
+			source	buffer.$index.2
+			sink	pga.$index.1
 		}
 
 		route."4" {
-			source	eqiir..1
-			sink	buffer..2
+			source	eqiir.$index.1
+			sink	buffer.$index.2
 		}
 
 		route."5" {
-			source	buffer..3
-			sink	eqiir..1
+			source	buffer.$index.3
+			sink	eqiir.$index.1
 		}
 	}
 

--- a/tools/topology/topology2/include/pipelines/passthrough-capture.conf
+++ b/tools/topology/topology2/include/pipelines/passthrough-capture.conf
@@ -59,8 +59,8 @@ Class.Pipeline."passthrough-capture" {
 	# Pipeline connections
 	Object.Base {
 		route."1" {
-			source	"buffer..1"
-			sink	"host..capture"
+			source	"buffer.$index.1"
+			sink	"host.$index.capture"
 		}
 	}
 

--- a/tools/topology/topology2/include/pipelines/volume-capture.conf
+++ b/tools/topology/topology2/include/pipelines/volume-capture.conf
@@ -82,18 +82,18 @@ Class.Pipeline."volume-capture" {
 	# Pipeline connections
 	Object.Base {
 		route."1" {
-			source	"buffer..1"
-			sink	"host..capture"
+			source	"buffer.$index.1"
+			sink	"host.$index.capture"
 		}
 
 		route."2" {
-			source	"pga..1"
-			sink	"buffer..1"
+			source	"pga.$index.1"
+			sink	"buffer.$index.1"
 		}
 
 		route."3" {
-			source	"buffer..2"
-			sink	"pga..1"
+			source	"buffer.$index.2"
+			sink	"pga.$index.1"
 		}
 	}
 

--- a/tools/topology/topology2/include/pipelines/volume-demux-playback.conf
+++ b/tools/topology/topology2/include/pipelines/volume-demux-playback.conf
@@ -88,28 +88,28 @@ Class.Pipeline."volume-demux-playback" {
 	# Pipeline connections
 	Object.Base {
 		route."1" {
-			sink	buffer..1
-			source  host..playback
+			sink	buffer.$index.1
+			source  host.$index.playback
 		}
 
 		route."2" {
-			sink	pga..1
-			source	buffer..1
+			sink	pga.$index.1
+			source	buffer.$index.1
 		}
 
 		route."3" {
-			sink	buffer..2
-			source	pga..1
+			sink	buffer.$index.2
+			source	pga.$index.1
 		}
 
 		route."4" {
-			sink	muxdemux..1
-			source	buffer..2
+			sink	muxdemux.$index.1
+			source	buffer.$index.2
 		}
 
 		route."5" {
-			sink	buffer..3
-			source	muxdemux..1
+			sink	buffer.$index.3
+			source	muxdemux.$index.1
 		}
 	}
 

--- a/tools/topology/topology2/include/pipelines/volume-playback.conf
+++ b/tools/topology/topology2/include/pipelines/volume-playback.conf
@@ -79,18 +79,18 @@ Class.Pipeline."volume-playback" {
 	# when the route objects are built
 	Object.Base {
 		route."1" {
-			source	"host..playback"
-			sink	"buffer..1"
+			source	"host.$index.playback"
+			sink	"buffer.$index.1"
 		}
 
 		route."2" {
-			source	"buffer..1"
-			sink	"pga..1"
+			source	"buffer.$index.1"
+			sink	"pga.$index.1"
 		}
 
 		route."3" {
-			source	"pga..1"
-			sink	"buffer..2"
+			source	"pga.$index.1"
+			sink	"buffer.$index.2"
 		}
 	}
 


### PR DESCRIPTION
Changes all routes of form:
Object.Base {
	route.1 {
		source copier.host..1
		sink	gain..1
	}
	route.2 {
		source	gain..1
		sink mixin..1
	}
}

to

Object.Base {
	route.1 {
		source copier.host.$index.1
		sink	gain.$index.1
	}
	route.2 {
		source	gain.$index.1
		sink mixin.$index.1
	}
}

E.g. change ".." notation where the route index is expanded in between the dots to explicit reference to the route index.

Signed-off-by: Jyri Sarha <jyri.sarha@intel.com>