### PR TITLE
west.yml: update rimage

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -34,7 +34,7 @@ manifest:
     - name: rimage
       repo-path: rimage
       path: sof/rimage
-      revision: 7bc3cfc946a04cbceebf7d0202a6d490c85dca72
+      revision: 1e0a85b44a19db37f9dd18906091d87abd8bd5e6
 
     - name: tomlc99
       repo-path: tomlc99


### PR DESCRIPTION
Update rimage to d48ae7aadaa4806a12cc3a73b8d28ceb232911ce to include the changes needed for adding the module init config in the manifest.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>