### PR TITLE
topology2: add second capture stream for DMIC0 for MTL topology

### DIFF
--- a/tools/topology/topology2/cavs-rt5682.conf
+++ b/tools/topology/topology2/cavs-rt5682.conf
@@ -275,6 +275,67 @@ Object.Pipeline {
 			}
 		}
 	]
+
+	gain-capture [
+		{
+			format		$FORMAT
+			index		16
+
+			Object.Widget.pipeline.1 {
+				stream_name	"DMIC Raw"
+			}
+			Object.Widget.copier.1 {
+				stream_name	"DMIC Raw"
+				num_audio_formats 2
+				Object.Base.audio_format.1 {
+					in_bit_depth		32
+					in_valid_bit_depth	32
+					out_bit_depth		32
+					out_valid_bit_depth	32
+					dma_buffer_size "$[$ibs * 2]"
+				}
+				Object.Base.audio_format.2 {
+					in_channels		4
+					in_bit_depth		32
+					in_valid_bit_depth	32
+					out_channels		4
+					out_bit_depth		32
+					out_valid_bit_depth	32
+					dma_buffer_size "$[$ibs * 2]"
+					in_ch_cfg	$CHANNEL_CONFIG_QUATRO
+					in_ch_map	$CHANNEL_MAP_3_POINT_1
+					out_ch_cfg	$CHANNEL_CONFIG_QUATRO
+					out_ch_map	$CHANNEL_MAP_3_POINT_1
+				}
+			}
+			Object.Widget.gain.1 {
+				num_audio_formats 2
+				Object.Base.audio_format.1 {
+					in_bit_depth		32
+					in_valid_bit_depth	32
+					out_bit_depth		32
+					out_valid_bit_depth	32
+					dma_buffer_size "$[$ibs * 2]"
+				}
+				Object.Base.audio_format.2 {
+					in_channels		4
+					in_bit_depth		32
+					in_valid_bit_depth	32
+					out_channels		4
+					out_bit_depth		32
+					out_valid_bit_depth	32
+					dma_buffer_size "$[$ibs * 2]"
+					in_ch_cfg	$CHANNEL_CONFIG_QUATRO
+					in_ch_map	$CHANNEL_MAP_3_POINT_1
+					out_ch_cfg	$CHANNEL_CONFIG_QUATRO
+					out_ch_map	$CHANNEL_MAP_3_POINT_1
+				}
+				Object.Control.mixer.1 {
+					name 'Capture Raw Volume 1'
+				}
+			}
+		}
+	]
 }
 
 Object.PCM.pcm [
@@ -311,6 +372,20 @@ Object.PCM.pcm [
 			formats	'S16_LE,S24_LE,S32_LE'
 		}
 	}
+	{
+		name	"DMIC Raw"
+		id	18
+		direction	"capture"
+		Object.Base.fe_dai."DMIC Raw" {}
+
+		Object.PCM.pcm_caps."capture" {
+			name	"DMIC Raw"
+			# only 32-bit capture supported now
+			formats	'S32_LE'
+			channels_min $NUM_DMICS
+			channels_max $NUM_DMICS
+		}
+	}
 ]
 
 Object.Base.route [
@@ -333,5 +408,9 @@ Object.Base.route [
 	{
 		source	"copier.SSP.6.1"
 		sink	"copier.host.5.1"
+	}
+	{
+		source	"copier.module.14.2"
+		sink	"gain.16.1"
 	}
 ]


### PR DESCRIPTION
These changes adds a second stream for DMIC to the MTL Chromebook topology. The second stream can be used as a reference stream by the user. All the needed supporting changes were already merged via #6783.
Verified the functionality by simulataneously capturing data via both the streams and didn't see any issue in the recorded data as of now.
![image](https://user-images.githubusercontent.com/55807706/218611262-b7861f68-517a-4a82-9d6d-fafa582dd470.png)
