### PR TITLE
Audio: Volume: Add HiFi4 implementation of volume

### DIFF
--- a/src/audio/module_adapter/CMakeLists.txt
+++ b/src/audio/module_adapter/CMakeLists.txt
@@ -6,7 +6,7 @@ if(NOT CONFIG_LIBRARY)
 	endif()
 
 	if(CONFIG_COMP_VOLUME)
-	add_local_sources(sof module/volume/volume_generic.c module/volume/volume_hifi3.c module/volume/volume.c)
+	add_local_sources(sof module/volume/volume_generic.c module/volume/volume_hifi3.c module/volume/volume_hifi4.c module/volume/volume.c)
 	endif()
 
 	if(CONFIG_CADENCE_CODEC)

--- a/src/audio/module_adapter/module/volume/volume_generic.c
+++ b/src/audio/module_adapter/module/volume/volume_generic.c
@@ -26,7 +26,7 @@ LOG_MODULE_DECLARE(volume_generic, CONFIG_SOF_LOG_LEVEL);
 
 #include <sof/audio/volume.h>
 
-#ifdef CONFIG_GENERIC
+#if VOLUME_GENERIC
 
 #if CONFIG_FORMAT_S24LE
 /**

--- a/src/audio/module_adapter/module/volume/volume_hifi4.c
+++ b/src/audio/module_adapter/module/volume/volume_hifi4.c
@@ -17,21 +17,15 @@
 #include <stddef.h>
 #include <stdint.h>
 
-LOG_MODULE_DECLARE(volume_hifi3, CONFIG_SOF_LOG_LEVEL);
+LOG_MODULE_DECLARE(volume_hifi4, CONFIG_SOF_LOG_LEVEL);
 
 #include <sof/audio/volume.h>
 
-#if VOLUME_HIFI3
+#if VOLUME_HIFI4
 
-#include <xtensa/tie/xt_hifi3.h>
+#include <xtensa/tie/xt_hifi4.h>
 
-/**
- * \brief store volume gain 4 times for xtensa multi-way intrinsic operations.
- * Simultaneous processing 2 data.
- * \param[in,out] cd Volume component private data.
- * \param[in] channels_count Number of channels to process.
- */
-static void vol_store_gain(struct vol_data *cd, const int channels_count)
+static inline void vol_store_gain(struct vol_data *cd, const int channels_count)
 {
 	int32_t i;
 
@@ -45,19 +39,12 @@ static void vol_store_gain(struct vol_data *cd, const int channels_count)
 	cd->copy_gain = false;
 }
 
-static inline void peak_vol_calc(struct vol_data *cd, ae_f32x2 out_sample, size_t channel)
-{
-#if CONFIG_COMP_PEAK_VOL
-	cd->peak_regs.peak_meter[channel] = AE_MAX32(out_sample, cd->peak_regs.peak_meter[channel]);
-#endif
-}
-
 #if CONFIG_FORMAT_S24LE
 /**
  * \brief HiFi3 enabled volume processing from 24/32 bit to 24/32 or 32 bit.
  * \param[in,out] dev Volume base component device.
  * \param[in,out] sink Destination buffer.
- * \param[in,out] source Source buffer.
+ * \param[in,out] source Input buffer.
  * \param[in] frames Number of frames to process.
  */
 static void vol_s24_to_s24_s32(struct processing_module *mod, struct input_stream_buffer *bsource,
@@ -69,8 +56,6 @@ static void vol_s24_to_s24_s32(struct processing_module *mod, struct input_strea
 	ae_f32x2 in_sample = AE_ZERO32();
 	ae_f32x2 out_sample = AE_ZERO32();
 	ae_f32x2 volume = AE_ZERO32();
-	ae_f32x2 *buf;
-	ae_f32x2 *buf_end;
 	int i, n, m;
 	ae_f32x2 *vol;
 	ae_valign inu = AE_ZALIGN64();
@@ -80,6 +65,15 @@ static void vol_s24_to_s24_s32(struct processing_module *mod, struct input_strea
 	const int channels_count = sink->channels;
 	const int inc = sizeof(ae_f32x2);
 	int samples = channels_count * frames;
+#if CONFIG_COMP_PEAK_VOL
+	ae_f32x2 temp;
+	ae_f32x2 *peakvol = (ae_f32x2 *)cd->peak_vol;
+
+	/* Set peakvol(which stores the peak volume data twice) as circular buffer */
+	memset(peakvol, 0, sizeof(ae_f32) * channels_count * 2);
+	AE_SETCBEGIN1(cd->peak_vol);
+	AE_SETCEND1(cd->peak_vol  + channels_count * 2);
+#endif
 
 	/** to ensure the adsress is 8-byte aligned and avoid risk of
 	 * error loading of volume gain while the cd->vol would be set
@@ -88,20 +82,18 @@ static void vol_s24_to_s24_s32(struct processing_module *mod, struct input_strea
 	if (cd->copy_gain)
 		vol_store_gain(cd, channels_count);
 
-	buf = (ae_f32x2 *)cd->vol;
-	buf_end = (ae_f32x2 *)(cd->vol + channels_count * 2);
-	vol = (ae_f32x2 *)buf;
+	vol = (ae_f32x2 *)cd->vol;
 	/* Set buf who stores the volume gain data as circular buffer */
-	AE_SETCBEGIN0(buf);
-	AE_SETCEND0(buf_end);
+	AE_SETCBEGIN0(vol);
+	AE_SETCEND0(cd->vol + channels_count * 2);
 
 	bsource->consumed += VOL_S32_SAMPLES_TO_BYTES(samples);
 	bsink->size += VOL_S32_SAMPLES_TO_BYTES(samples);
 
 	while (samples) {
-		m = VOL_BYTES_TO_S32_SAMPLES(audio_stream_bytes_without_wrap(source, in));
+		m = audio_stream_samples_without_wrap_s32(source, in);
 		n = MIN(m, samples);
-		m = VOL_BYTES_TO_S32_SAMPLES(audio_stream_bytes_without_wrap(sink, out));
+		m = audio_stream_samples_without_wrap_s16(sink, out);
 		n = MIN(m, n);
 		inu = AE_LA64_PP(in);
 		/* process two continuous sample data once */
@@ -111,35 +103,40 @@ static void vol_s24_to_s24_s32(struct processing_module *mod, struct input_strea
 
 			/* Load the input sample */
 			AE_LA32X2_IP(in_sample, inu, in);
-
+#if CONFIG_COMP_PEAK_VOL
+			/* calculate the peak volume*/
+			AE_L32X2_XC1(temp, peakvol, 0);
+			temp = AE_MAXABS32S(in_sample, temp);
+			AE_S32X2_XC1(temp, peakvol, inc);
+#endif
 			/* Multiply the input sample */
 #if COMP_VOLUME_Q8_16
 			out_sample = AE_MULFP32X2RS(AE_SLAI32S(volume, 7), AE_SLAI32(in_sample, 8));
 #elif COMP_VOLUME_Q1_23
-			out_sample = AE_MULFP32X2RS(volume, AE_SLAI32(in_sample, 8));
+			 out_sample = AE_MULFP32X2RS(volume, AE_SLAI32S(in_sample, 8));
 #else
 #error "Need CONFIG_COMP_VOLUME_Qx_y"
 #endif
 
-			/* Shift for S24_LE */
-			out_sample = AE_SLAI32S(out_sample, 8);
-			out_sample = AE_SRAI32(out_sample, 8);
+			 /* Shift for S24_LE */
+			 out_sample = AE_SLAI32S(out_sample, 8);
+			 out_sample = AE_SRAI32(out_sample, 8);
 
 			/* Store the output sample */
 			AE_SA32X2_IP(out_sample, outu, out);
-
-			/* calc peak vol
-			 * TODO: fix channel value
-			 */
-			peak_vol_calc(cd, out_sample, 0);
 		}
 		AE_SA64POS_FP(outu, out);
 		samples -= n;
 		in = audio_stream_wrap(source, in);
 		out = audio_stream_wrap(sink, out);
 	}
+#if CONFIG_COMP_PEAK_VOL
+	for (i = 0; i < channels_count; i++)
+		cd->peak_regs.peak_meter[i] = MAX(cd->peak_vol[i],
+						  cd->peak_vol[i + channels_count]);
 	/* update peak vol */
 	peak_vol_update(cd);
+#endif
 }
 #endif /* CONFIG_FORMAT_S24LE */
 
@@ -148,7 +145,7 @@ static void vol_s24_to_s24_s32(struct processing_module *mod, struct input_strea
  * \brief HiFi3 enabled volume processing from 32 bit to 24/32 or 32 bit.
  * \param[in,out] mod Pointer to struct processing_module
  * \param[in,out] sink Destination buffer.
- * \param[in,out] source Source buffer.
+ * \param[in,out] source Input buffer.
  * \param[in] frames Number of frames to process.
  */
 static void vol_s32_to_s24_s32(struct processing_module *mod, struct input_stream_buffer *bsource,
@@ -173,6 +170,15 @@ static void vol_s32_to_s24_s32(struct processing_module *mod, struct input_strea
 	int samples = channels_count * frames;
 	ae_f32x2 *in = (ae_f32x2 *)source->r_ptr;
 	ae_f32x2 *out = (ae_f32x2 *)sink->w_ptr;
+#if CONFIG_COMP_PEAK_VOL
+	ae_f32x2 temp;
+	ae_f32x2 *peakvol = (ae_f32x2 *)cd->peak_vol;
+
+	/* Set peakvol(which stores the peak volume data twice) as circular buffer */
+	memset(peakvol, 0, sizeof(ae_f32) * channels_count * 2);
+	AE_SETCBEGIN1(cd->peak_vol);
+	AE_SETCEND1(cd->peak_vol  + channels_count * 2);
+#endif
 
 	/** to ensure the address is 8-byte aligned and avoid risk of
 	 * error loading of volume gain while the cd->vol would be set
@@ -192,9 +198,9 @@ static void vol_s32_to_s24_s32(struct processing_module *mod, struct input_strea
 	bsink->size += VOL_S32_SAMPLES_TO_BYTES(samples);
 
 	while (samples) {
-		m = VOL_BYTES_TO_S32_SAMPLES(audio_stream_bytes_without_wrap(source, in));
+		m = audio_stream_samples_without_wrap_s32(source, in);
 		n = MIN(m, samples);
-		m = VOL_BYTES_TO_S32_SAMPLES(audio_stream_bytes_without_wrap(sink, out));
+		m = audio_stream_samples_without_wrap_s32(sink, out);
 		n = MIN(m, n);
 		inu = AE_LA64_PP(in);
 		/* process two continuous sample data once */
@@ -204,6 +210,13 @@ static void vol_s32_to_s24_s32(struct processing_module *mod, struct input_strea
 
 			/* Load the input sample */
 			AE_LA32X2_IP(in_sample, inu, in);
+
+#if CONFIG_COMP_PEAK_VOL
+			/* calculate the peak volume*/
+			AE_L32X2_XC1(temp, peakvol, 0);
+			temp = AE_MAXABS32S(in_sample, temp);
+			AE_S32X2_XC1(temp, peakvol, inc);
+#endif
 
 #if COMP_VOLUME_Q8_16
 			/* Q8.16 x Q1.31 << 1 -> Q9.48 */
@@ -223,19 +236,19 @@ static void vol_s32_to_s24_s32(struct processing_module *mod, struct input_strea
 #error "Need CONFIG_COMP_VOLUME_Qx_y"
 #endif
 			AE_SA32X2_IP(out_sample, outu, out);
-
-			/* calc peak vol
-			 * TODO: fix channel value
-			 */
-			peak_vol_calc(cd, out_sample, 0);
 		}
 		AE_SA64POS_FP(outu, out);
 		samples -= n;
 		in = audio_stream_wrap(source, in);
 		out = audio_stream_wrap(sink, out);
 	}
+#if CONFIG_COMP_PEAK_VOL
+	for (i = 0; i < channels_count; i++)
+		cd->peak_regs.peak_meter[i] = MAX(cd->peak_vol[i],
+						  cd->peak_vol[i + channels_count]);
 	/* update peak vol */
 	peak_vol_update(cd);
+#endif
 }
 #endif /* CONFIG_FORMAT_S32LE */
 
@@ -244,7 +257,7 @@ static void vol_s32_to_s24_s32(struct processing_module *mod, struct input_strea
  * \brief HiFi3 enabled volume processing from 16 bit to 16 bit.
  * \param[in,out] dev Volume base component device.
  * \param[in,out] sink Destination buffer.
- * \param[in,out] source Source buffer.
+ * \param[in,out] source Input buffer.
  * \param[in] frames Number of frames to process.
  */
 static void vol_s16_to_s16(struct processing_module *mod, struct input_stream_buffer *bsource,
@@ -270,6 +283,15 @@ static void vol_s16_to_s16(struct processing_module *mod, struct input_stream_bu
 	const int channels_count = sink->channels;
 	const int inc = sizeof(ae_f32x2);
 	int samples = channels_count * frames;
+#if CONFIG_COMP_PEAK_VOL
+	ae_f32x2 temp;
+	ae_f32x2 *peakvol = (ae_f32x2 *)cd->peak_vol;
+
+	/* Set peakvol(which stores the peak volume data 4 times) as circular buffer */
+	memset(peakvol, 0, sizeof(ae_f32) * channels_count * 4);
+	AE_SETCBEGIN1(cd->peak_vol);
+	AE_SETCEND1(cd->peak_vol  + channels_count * 4);
+#endif
 
 	/** to ensure the adsress is 8-byte aligned and avoid risk of
 	 * error loading of volume gain while the cd->vol would be set
@@ -286,10 +308,13 @@ static void vol_s16_to_s16(struct processing_module *mod, struct input_stream_bu
 	AE_SETCBEGIN0(buf);
 	AE_SETCEND0(buf_end);
 
+	bsource->consumed += VOL_S16_SAMPLES_TO_BYTES(samples);
+	bsink->size += VOL_S16_SAMPLES_TO_BYTES(samples);
+
 	while (samples) {
-		m = VOL_BYTES_TO_S16_SAMPLES(audio_stream_bytes_without_wrap(source, in));
+		m = audio_stream_samples_without_wrap_s16(source, in);
 		n = MIN(m, samples);
-		m = VOL_BYTES_TO_S16_SAMPLES(audio_stream_bytes_without_wrap(sink, out));
+		m = audio_stream_samples_without_wrap_s16(sink, out);
 		n = MIN(m, n);
 		inu = AE_LA64_PP(in);
 		for (i = 0; i < n; i += 4) {
@@ -311,6 +336,17 @@ static void vol_s16_to_s16(struct processing_module *mod, struct input_stream_bu
 			/* Load the input sample */
 			AE_LA16X4_IP(in_sample, inu, in);
 
+#if CONFIG_COMP_PEAK_VOL
+			/* calculate the peak volume*/
+			AE_L32X2_XC1(temp, peakvol, 0);
+			temp = AE_MAXABS32S(AE_SEXT32X2D16_32(in_sample), temp);
+			AE_S32X2_XC1(temp, peakvol, inc);
+			/* calculate the peak volume*/
+			AE_L32X2_XC1(temp, peakvol, 0);
+			temp = AE_MAXABS32S(AE_SEXT32X2D16_10(in_sample), temp);
+			AE_S32X2_XC1(temp, peakvol, inc);
+#endif
+
 			/* Multiply the input sample */
 			out_sample0 = AE_MULFP32X16X2RS_H(volume0, in_sample);
 			out_sample1 = AE_MULFP32X16X2RS_L(volume1, in_sample);
@@ -321,23 +357,23 @@ static void vol_s16_to_s16(struct processing_module *mod, struct input_stream_bu
 
 			/* store the output */
 			out_sample = AE_ROUND16X4F32SSYM(out_sample0, out_sample1);
-			// AE_SA16X4_IC(out_sample, outu, out);
 			AE_SA16X4_IP(out_sample, outu, out);
-
-			/* calc peak vol
-			 * TODO: fix channel value
-			 */
-			peak_vol_calc(cd, out_sample0, 0);
 		}
 		AE_SA64POS_FP(outu, out);
 		samples -= n;
-		bsource->consumed += VOL_S16_SAMPLES_TO_BYTES(n);
-		bsink->size += VOL_S16_SAMPLES_TO_BYTES(n);
 		in = audio_stream_wrap(source, in);
 		out = audio_stream_wrap(sink, out);
 	}
+#if CONFIG_COMP_PEAK_VOL
+	for (i = 0; i < channels_count; i++) {
+		m = MAX(cd->peak_vol[i], cd->peak_vol[i + channels_count]);
+		m = MAX(m, cd->peak_vol[i + channels_count * 2]);
+		m = MAX(m, cd->peak_vol[i + channels_count * 3]);
+		cd->peak_regs.peak_meter[i] = m;
+	}
 	/* update peak vol */
 	peak_vol_update(cd);
+#endif
 }
 #endif /* CONFIG_FORMAT_S16LE */
 

--- a/src/include/sof/audio/volume.h
+++ b/src/include/sof/audio/volume.h
@@ -34,15 +34,30 @@
 struct comp_buffer;
 struct sof_ipc_ctrl_value_chan;
 
-#define CONFIG_GENERIC
-
 #if defined(__XCC__)
 #include <xtensa/config/core-isa.h>
 
-#if XCHAL_HAVE_HIFI3
-#undef CONFIG_GENERIC
+#if XCHAL_HAVE_HIFI4  /* HiFi 4 */
+
+#define VOLUME_GENERIC  0
+#define VOLUME_HIFI3	0
+#define VOLUME_HIFI4	1
+
+#elif XCHAL_HAVE_HIFI3  /* HiFi 3 */
+#define VOLUME_GENERIC  0
+#define VOLUME_HIFI3	1
+#define VOLUME_HIFI4	0
+
+#else /* if others use C version*/
+#define VOLUME_GENERIC  1
+#define VOLUME_HIFI3	0
+#define VOLUME_HIFI4	0
 #endif
 
+#else /* GCC */
+#define VOLUME_GENERIC  1
+#define VOLUME_HIFI3	0
+#define VOLUME_HIFI4	0
 #endif
 
 /**
@@ -133,6 +148,8 @@ struct vol_data {
 
 	/**< these values will be stored to mailbox for host (IPC4) */
 	struct ipc4_peak_volume_regs peak_regs;
+	/**< store temp peak volume 4 times for scale_vol function */
+	int32_t *peak_vol;
 #endif
 	int32_t volume[SOF_IPC_MAX_CHANNELS];	/**< current volume */
 	int32_t tvolume[SOF_IPC_MAX_CHANNELS];	/**< target volume */
@@ -141,6 +158,7 @@ struct vol_data {
 	int32_t ramp_coef[SOF_IPC_MAX_CHANNELS]; /**< parameter for slope */
 	/**< store current volume 4 times for scale_vol function */
 	int32_t *vol;
+
 	uint32_t initial_ramp;			/**< ramp space in ms */
 	uint32_t ramp_type;			/**< SOF_VOLUME_ */
 	int32_t vol_min;			/**< minimum volume */

--- a/test/cmocka/src/audio/volume/CMakeLists.txt
+++ b/test/cmocka/src/audio/volume/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(audio_for_volume STATIC
 	${PROJECT_SOURCE_DIR}/src/audio/module_adapter/module/volume/volume.c
 	${PROJECT_SOURCE_DIR}/src/audio/module_adapter/module/volume/volume_generic.c
 	${PROJECT_SOURCE_DIR}/src/audio/module_adapter/module/volume/volume_hifi3.c
+	${PROJECT_SOURCE_DIR}/src/audio/module_adapter/module/volume/volume_hifi4.c
 	${PROJECT_SOURCE_DIR}/src/audio/module_adapter/module_adapter.c
 	${PROJECT_SOURCE_DIR}/src/audio/module_adapter/module/generic.c
 	${PROJECT_SOURCE_DIR}/src/audio/buffer.c

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -745,6 +745,7 @@ zephyr_library_sources_ifdef(CONFIG_SAMPLE_KEYPHRASE
 
 zephyr_library_sources_ifdef(CONFIG_COMP_VOLUME
 	${SOF_AUDIO_MODULES_PATH}/volume/volume_hifi3.c
+	${SOF_AUDIO_MODULES_PATH}/volume/volume_hifi4.c
 	${SOF_AUDIO_MODULES_PATH}/volume/volume_generic.c
 	${SOF_AUDIO_MODULES_PATH}/volume/volume.c
 )


### PR DESCRIPTION
Add peak_vol to calculate peak volume with continuous sample processing. Since HiFi4 supports 2 circular buffers, so set both vol and peak_vol as circular buffer to store gain and temp peak value 4 times. And recaculate the peak volume after all samples are processed is faster than processing samples one by one.

Signed-off-by: Andrula Song <andrula.song@intel.com>