### PR TITLE
west.yml: upgrade rimage to 3863e94fa5d3

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -34,7 +34,7 @@ manifest:
     - name: rimage
       repo-path: rimage
       path: sof/rimage
-      revision: 7bc3cfc946a04cbceebf7d0202a6d490c85dca72
+      revision: 3863e94fa5d361e434f404655dac17541dbf20c6
 
     - name: tomlc99
       repo-path: tomlc99


### PR DESCRIPTION
Pull in following rimage changes:

3863e94fa5d3 Don't convert ROM addresses to cached aliases 1e0a85b44a19 config:tgl/tglh: Do not set cached/uncached address aliases 9b507ecc82d9 config: set cached and uncached aliases for affected platforms def9d51d7d81 Fix regression - make default return code an error d48ae7aadaa4 config: mtl: Set init_config for smart amp b5d762290f1a config: tgl-cavs: set init_config for smart test 15ea48177a2b src: adsp_config: Use reserved bits for module init config ec649f37d661 Convert all ELF addresses to cached for calculations

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>