### PR TITLE
pipeline: (cosmetic) remove unreachable code

### DIFF
--- a/src/audio/pipeline/pipeline-stream.c
+++ b/src/audio/pipeline/pipeline-stream.c
@@ -379,11 +379,6 @@ static int pipeline_comp_trigger(struct comp_dev *current,
 		return err;
 	}
 
-	if (err == PPL_STATUS_PATH_STOP) {
-		current->pipeline->trigger.aborted = true;
-		return err;
-	}
-
 	switch (ppl_data->cmd) {
 	case COMP_TRIGGER_PAUSE:
 	case COMP_TRIGGER_STOP:


### PR DESCRIPTION
Remove left-over unreachable code in pipeline_comp_trigger(): tje err == PPL_STATUS_PATH_STOP case is already processed and leads to a return from the function, therefore the same condition cannot be met a second time immediately after the return.
