### PR TITLE
lib: fix compiler macro for vec_mem*

### DIFF
--- a/src/arch/xtensa/include/arch/compiler_info.h
+++ b/src/arch/xtensa/include/arch/compiler_info.h
@@ -15,6 +15,7 @@
 #define __ARCH_COMPILER_INFO_H__
 
 #include <xtensa/hal.h>
+#include <xtensa/config/core-isa.h>
 
 /* read used compilator name and version */
 /* CC_NAME must consist of 3 characters with null termination */

--- a/src/lib/lib.c
+++ b/src/lib/lib.c
@@ -79,7 +79,7 @@ int memset_s(void *dest, size_t dest_size, int data, size_t count)
 	return arch_memset_s(dest, dest_size, data, count);
 }
 
-#if !__XCC || !XCHAL_HAVE_HIFI3 || !CONFIG_LIBRARY
+#if !__XCC__ || !XCHAL_HAVE_HIFI3 || CONFIG_LIBRARY
 void *__vec_memcpy(void *dst, const void *src, size_t len)
 {
 	return memcpy(dst, src, len);


### PR DESCRIPTION
using incorrect names for compiler, missing ISA header for HiFi check, also should add inlines if we don't have the HiFi implementations