### PR TITLE
Fixed warnings issued by new xt-clang compiler

### DIFF
--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -579,14 +579,12 @@ static void build_config(struct comp_data *cd, struct module_config *cfg)
 	enum sof_ipc_frame __sparse_cache frame_fmt, valid_fmt;
 	int i;
 
-	frame_fmt = cfg->base_cfg.audio_fmt.depth;
 	audio_stream_fmt_conversion(cfg->base_cfg.audio_fmt.depth,
 				    cfg->base_cfg.audio_fmt.valid_bit_depth,
 				    &frame_fmt, &valid_fmt,
 				    cfg->base_cfg.audio_fmt.s_type);
 	cd->source_format = frame_fmt;
 
-	frame_fmt = cd->sink_format;
 	audio_stream_fmt_conversion(cd->output_format.depth,
 				    cd->output_format.valid_bit_depth,
 				    &frame_fmt, &valid_fmt,

--- a/src/include/sof/audio/module_adapter/iadk/system_service.h
+++ b/src/include/sof/audio/module_adapter/iadk/system_service.h
@@ -13,6 +13,11 @@
 
 #include <stdint.h>
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wextern-c-compat"
+#endif //__clang__
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -232,5 +237,9 @@ struct SystemService : public AdspSystemService {};
 #ifdef __cplusplus
 }
 #endif
+
+#ifdef __clang__
+#pragma clang diagnostic pop // ignored "-Wextern-c-compat"
+#endif //__clang__
 
 #endif /* _ADSP_SYSTEM_SERVICE_H_ */


### PR DESCRIPTION
New Xtensa xt-clang driver issues new warnings that were not present before when using xt-xcc driver.
Fixed warnings related to enum cast to other enum. Silenced warnings related to C/C++ interoptability.

Signed-off-by: Andrey Borisovich <andrey.borisovich@intel.com>