### PR TITLE
[DNM] west.yml: upgrade Zephyr to 4d4e25292faa

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: d9c4ec31fc49e7eef3c8c3b0d07827cc04e6efee
+      revision: 4d4e25292faa2474c4ec90be6b5d42c200d0bf07
       remote: zephyrproject
       # Import some projects listed in zephyr/west.yml@revision
       #


### PR DESCRIPTION
Total of 1116 commits, including following related to intel_adsp/sparse/dmic/xtensa:

8f5bcb2e76c3 intel_adsp: ace: fix linker script for xcc-clang compiler
18ce85c20130 tests: intel_adsp: ssp: fix dma data sizes
60a20471b561 intel_adsp: ace: enable interrupts for secondary core
6045eed2f361 intel_adsp: ace: enable core power gating
e1dbc2efef50 intel_adsp: ace: add core power off step
a99b073392fc intel_adsp: ace: d3 exit update
156c7cd21759 intel_adsp: bbzero/bmemcpy with picolibc fix
60196ca1126a cmake: sparse: deprecate old sparse support
91902c5fd4db cmake: add sparse support to the new SCA infrastructure
a684714d5c82 soc: intel_adsp: Correct HDA parameter docstrings
db495a5ebee3 xtensa: stop execution under simulator for double exception
8ff88346955b xtensa: sparse: fix address space mismatch
7965fd2b4a8a samples/boards/intel_adsp: Make sample work with twister
422250d3b183 mm: intel_adsp_mtl_tlb: suppress sparse address space warnings
618a478ded70 xtensa: fix sparse warning when converting to uncache pointer
8b391dc43841 drivers: audio: dmic_nrfx_pdm: Fix a race condition in the driver
8794de2934f7 intel_adsp: soc: ace: Add communication widget driver
a9b3d935500c intel_adsp: dai: Add support for ALH up to 16 nodes
837432506269 drivers: dai: intel: dmic: don't use assert for error handling