### PR TITLE
[DNM] west.yml: upgrade Zephyr to b1e1b5e7b4a5

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: d9c4ec31fc49e7eef3c8c3b0d07827cc04e6efee
+      revision: b1e1b5e7b4a5c9c3e1cb379cbad0f24d5ea7fbd6
       remote: zephyrproject
       # Import some projects listed in zephyr/west.yml@revision
       #


### PR DESCRIPTION
Total of 449 commits, including following related to

db495a5ebee3 xtensa: stop execution under simulator for double exception
8ff88346955b xtensa: sparse: fix address space mismatch
7965fd2b4a8a samples/boards/intel_adsp: Make sample work with twister
422250d3b183 mm: intel_adsp_mtl_tlb: suppress sparse address space warnings
618a478ded70 xtensa: fix sparse warning when converting to uncache pointer
8b391dc43841 drivers: audio: dmic_nrfx_pdm: Fix a race condition in the driver
8794de2934f7 intel_adsp: soc: ace: Add communication widget driver
a9b3d935500c intel_adsp: dai: Add support for ALH up to 16 nodes
837432506269 drivers: dai: intel: dmic: don't use assert for error handling