### PR TITLE
xtensa-build-zephyr.py: apply debug_overlay after ipc4_overlay

### DIFF
--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -590,10 +590,6 @@ def build_platforms():
 			build_cmd += args.cmake_args
 
 		overlays = [str(item.resolve(True)) for item in args.overlay]
-		# The '-d' option is a shortcut for '-o path_to_debug_overlay', we are good
-		# if both are provided, because it's no harm to merge the same overlay twice.
-		if args.debug:
-			overlays.append(str(pathlib.Path(SOF_TOP, "app", "debug_overlay.conf")))
 
 		# The '-i IPC4' is a shortcut for '-o path_to_ipc4_overlay' (and more), we
 		# are good if both are provided, because it's no harm to merge the same
@@ -601,6 +597,11 @@ def build_platforms():
 		if args.ipc == "IPC4":
 			overlays.append(str(pathlib.Path(SOF_TOP, "app", "overlays", platform,
                             platform_dict["IPC4_CONFIG_OVERLAY"])))
+
+		# The '-d' option is a shortcut for '-o path_to_debug_overlay', we are good
+		# if both are provided, because it's no harm to merge the same overlay twice.
+		if args.debug:
+			overlays.append(str(pathlib.Path(SOF_TOP, "app", "debug_overlay.conf")))
 
 		if overlays:
 			overlays = ";".join(overlays)


### PR DESCRIPTION
The config overlays are applied in the order we specify them, the debug_overlay contains the debug configurations, and should be applied last to make sure those debug options take effect.

`CONFIG_SOF_LOG_LEVEL_INF=y` is defined in ipc4_overlay.conf, I personally in my branch added `CONFIG_SOF_LOG_LEVEL_DBG=y`, but no effect due to the order we apply ipc4_overlay.conf and debug_overlay.conf.  I think finally `CONFIG_SOF_LOG_LEVEL_DBG=y` will be added in debug_overlay.conf once mtrace is ready.