### PR TITLE
sof: audio: eq_fir: Fix GCC-specific check

### DIFF
--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -313,7 +313,7 @@ static int eq_fir_init_coef(struct comp_dev *dev, struct sof_eq_fir_config *conf
 		}
 
 #if defined FIR_MAX_LENGTH_BUILD_SPECIFIC
-		if (fir[i].taps * nch > FIR_MAX_LENGTH_BUILD_SPECIFIC) {
+		if (eq->length * nch > FIR_MAX_LENGTH_BUILD_SPECIFIC) {
 			comp_err(dev, "Filter length %d exceeds limitation for build.",
 				 fir[i].taps);
 			return -EINVAL;


### PR DESCRIPTION
Currently, the check to prevent too large filters from being loaded on GCC builds of SOF does not work correctly. This commit makes sure the error occurs immediately, instead of at the next coefficients change.