### PR TITLE
dai-zephyr: fixes to dma_stop() usage

### DIFF
--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -1014,6 +1014,7 @@ static void dai_update_start_position(struct comp_dev *dev)
 static int dai_comp_trigger_internal(struct comp_dev *dev, int cmd)
 {
 	struct dai_data *dd = comp_get_drvdata(dev);
+	int prev_state = dev->state;
 	int ret;
 
 	comp_dbg(dev, "dai_comp_trigger_internal(), command = %u", cmd);
@@ -1101,7 +1102,7 @@ static int dai_comp_trigger_internal(struct comp_dev *dev, int cmd)
 		dai_trigger_op(dd->dai, cmd, dev->direction);
 #else
 		dai_trigger_op(dd->dai, cmd, dev->direction);
-		if (dev->state == COMP_STATE_ACTIVE) {
+		if (prev_state == COMP_STATE_ACTIVE) {
 			ret = dma_stop(dd->chan->dma->z_dev, dd->chan->index);
 		} else {
 			comp_warn(dev, "dma was stopped earlier");
@@ -1111,7 +1112,7 @@ static int dai_comp_trigger_internal(struct comp_dev *dev, int cmd)
 		break;
 	case COMP_TRIGGER_PAUSE:
 		comp_dbg(dev, "dai_comp_trigger_internal(), PAUSE");
-		if (dev->state == COMP_STATE_ACTIVE) {
+		if (prev_state == COMP_STATE_ACTIVE) {
 			ret = dma_suspend(dd->chan->dma->z_dev, dd->chan->index);
 		} else {
 			comp_warn(dev, "dma was stopped earlier");

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -1102,9 +1102,8 @@ static int dai_comp_trigger_internal(struct comp_dev *dev, int cmd)
 		dai_trigger_op(dd->dai, cmd, dev->direction);
 #else
 		dai_trigger_op(dd->dai, cmd, dev->direction);
-		if (prev_state == COMP_STATE_ACTIVE) {
-			ret = dma_stop(dd->chan->dma->z_dev, dd->chan->index);
-		} else {
+		ret = dma_stop(dd->chan->dma->z_dev, dd->chan->index);
+		if (ret) {
 			comp_warn(dev, "dma was stopped earlier");
 			ret = 0;
 		}


### PR DESCRIPTION
To fix SOF SSP tests with latest Zephyr main, see failures without this fix in #7102

For all tests to pass, https://github.com/zephyrproject-rtos/zephyr/pull/54900 is also needed.