### PR TITLE
Tools: Topology2: Change PGA widget curve_duration to 20 ms

### DIFF
--- a/tools/topology/topology2/include/components/gain.conf
+++ b/tools/topology/topology2/include/components/gain.conf
@@ -167,7 +167,7 @@ Class.Widget."gain" {
 	period_sink_count	2
 	period_source_count	2
 	curve_type		"fade"
-	curve_duration		10
+	curve_duration		200000		# 20 ms
 	init_value		0x7fffffff
 	num_input_pins		1
 	num_output_pins		1


### PR DESCRIPTION
The previous value 10 is only 0.1 us that disables the gain ramp totally and causes harsh sounding volume transitions.