### PR TITLE
topology2: cavs-rt5682: override BT playback pipeline id 

### DIFF
--- a/tools/topology/topology2/cavs-rt5682.conf
+++ b/tools/topology/topology2/cavs-rt5682.conf
@@ -42,7 +42,6 @@
 
 Define {
 	MCLK 				24576000
-	NUM_DMICS			0
 	# override DMIC default definitions
 	NUM_DMICS			0
 	DMIC0_ID			1
@@ -84,6 +83,12 @@ Define {
 	ECHO_REF_HOST_PIPELINE_SINK	'copier.host.7.1'
 	ECHO_REF_DAI_PIPELINE_SRC	'copier.SSP.8.1'
 	ECHO_REF_COPIER_MODULE		'copier.module.8.2'
+	# override BT default definitions
+	BT_PB_HOST_PIPELINE_ID		9
+	BT_PB_DAI_PIPELINE_ID		10
+	BT_PB_HOST_PIPELINE_SINK "copier.SSP.10.1"
+	BT_PB_DAI_PIPELINE_SRC "copier.host.9.1"
+	BT_PB_PIPELINE_STREAM_NAME "copier.SSP.10.1"
 }
 
 # override defaults with platform-specific config


### PR DESCRIPTION
pipeline ID 7 and 8 are taken by ECHO_REF_HOST
and ECHO_REF_DAI, so bump the ID to next free values.