### PR TITLE
[DNM] west.yml: upgrade Zephyr to 0c0d73721ed

### DIFF
--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -1059,11 +1059,9 @@ static int dai_comp_trigger_internal(struct comp_dev *dev, int cmd)
 		/* only start the DAI if we are not XRUN handling */
 		if (dd->xrun == 0) {
 			/* recover valid start position */
-			if (dev->state == COMP_STATE_ACTIVE) {
-				ret = dma_stop(dd->chan->dma->z_dev, dd->chan->index);
-				if (ret < 0)
-					return ret;
-			}
+			ret = dma_stop(dd->chan->dma->z_dev, dd->chan->index);
+			if (ret < 0)
+				return ret;
 
 			/* dma_config needed after stop */
 			ret = dma_config(dd->chan->dma->z_dev, dd->chan->index, dd->z_config);
@@ -1101,23 +1099,12 @@ static int dai_comp_trigger_internal(struct comp_dev *dev, int cmd)
 		dai_trigger_op(dd->dai, cmd, dev->direction);
 #else
 		dai_trigger_op(dd->dai, cmd, dev->direction);
-		if (dev->state == COMP_STATE_ACTIVE) {
-			ret = dma_stop(dd->chan->dma->z_dev, dd->chan->index);
-		} else {
-			comp_warn(dev, "dma was stopped earlier");
-			ret = 0;
-		}
+		ret = dma_stop(dd->chan->dma->z_dev, dd->chan->index);
 #endif
 		break;
 	case COMP_TRIGGER_PAUSE:
 		comp_dbg(dev, "dai_comp_trigger_internal(), PAUSE");
-		if (dev->state == COMP_STATE_ACTIVE) {
-			ret = dma_suspend(dd->chan->dma->z_dev, dd->chan->index);
-		} else {
-			comp_warn(dev, "dma was stopped earlier");
-			ret = 0;
-		}
-
+		ret = dma_suspend(dd->chan->dma->z_dev, dd->chan->index);
 		dai_trigger_op(dd->dai, cmd, dev->direction);
 		break;
 	case COMP_TRIGGER_PRE_START:

--- a/src/audio/host-zephyr.c
+++ b/src/audio/host-zephyr.c
@@ -628,13 +628,10 @@ static int host_trigger(struct comp_dev *dev, int cmd)
 		break;
 	case COMP_TRIGGER_STOP:
 	case COMP_TRIGGER_XRUN:
-		if (dev->state == COMP_STATE_ACTIVE) {
-			ret = dma_stop(hd->chan->dma->z_dev, hd->chan->index);
-			if (ret < 0)
-				comp_err(dev, "host_trigger(): dma stop failed: %d",
-					 ret);
-		}
-
+		ret = dma_stop(hd->chan->dma->z_dev, hd->chan->index);
+		if (ret < 0)
+			comp_err(dev, "host_trigger(): dma stop failed: %d",
+				 ret);
 		break;
 	default:
 		break;
@@ -1052,8 +1049,7 @@ static int host_reset(struct comp_dev *dev)
 	comp_dbg(dev, "host_reset()");
 
 	if (hd->chan) {
-		if (dev->state == COMP_STATE_ACTIVE)
-			dma_stop(hd->chan->dma->z_dev, hd->chan->index);
+		dma_stop(hd->chan->dma->z_dev, hd->chan->index);
 
 		/* remove callback */
 		notifier_unregister(dev, hd->chan, NOTIFIER_ID_DMA_COPY);

--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -170,9 +170,7 @@ void dai_dma_release(struct comp_dev *dev)
 		 * TODO: refine power management when stream is paused
 		 */
 #if CONFIG_ZEPHYR_NATIVE_DRIVERS
-		/* if reset is after pause dma has already been stopped */
-		if (dev->state != COMP_STATE_PAUSED)
-			dma_stop(dd->chan->dma->z_dev, dd->chan->index);
+		dma_stop(dd->chan->dma->z_dev, dd->chan->index);
 
 		/* remove callback */
 		notifier_unregister(dev, dd->chan, NOTIFIER_ID_DMA_COPY);

--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: d9c4ec31fc49e7eef3c8c3b0d07827cc04e6efee
+      revision: 0c0d73721edb808b51a7ab136cfe01d1b2c1f87d
       remote: zephyrproject
       # Import some projects listed in zephyr/west.yml@revision
       #


### PR DESCRIPTION
Includes revert of commit fa0456e5a899 ("audio: dai-zephyr/host-zephyr: stop dma only once") to adapt to clarification of DMA interface semantics.

Total of 1168 commits, including following related to intel_adsp/sparse/dmic/xtensa:

8f5bcb2e76c3 intel_adsp: ace: fix linker script for xcc-clang compiler
18ce85c20130 tests: intel_adsp: ssp: fix dma data sizes
60a20471b561 intel_adsp: ace: enable interrupts for secondary core
6045eed2f361 intel_adsp: ace: enable core power gating
e1dbc2efef50 intel_adsp: ace: add core power off step
a99b073392fc intel_adsp: ace: d3 exit update
156c7cd21759 intel_adsp: bbzero/bmemcpy with picolibc fix
60196ca1126a cmake: sparse: deprecate old sparse support
91902c5fd4db cmake: add sparse support to the new SCA infrastructure
a684714d5c82 soc: intel_adsp: Correct HDA parameter docstrings
db495a5ebee3 xtensa: stop execution under simulator for double exception
8ff88346955b xtensa: sparse: fix address space mismatch
7965fd2b4a8a samples/boards/intel_adsp: Make sample work with twister
422250d3b183 mm: intel_adsp_mtl_tlb: suppress sparse address space warnings
618a478ded70 xtensa: fix sparse warning when converting to uncache pointer
8b391dc43841 drivers: audio: dmic_nrfx_pdm: Fix a race condition in the driver
8794de2934f7 intel_adsp: soc: ace: Add communication widget driver
a9b3d935500c intel_adsp: dai: Add support for ALH up to 16 nodes
837432506269 drivers: dai: intel: dmic: don't use assert for error handli