### PR TITLE
Tools: Topology2: Add high-pass IIR to HDA analog capture

### DIFF
--- a/tools/topology/topology2/cavs-mixin-mixout-hda.conf
+++ b/tools/topology/topology2/cavs-mixin-mixout-hda.conf
@@ -70,7 +70,7 @@ Object.Pipeline {
 		}
 	]
 
-	passthrough-capture-be [
+	highpass-capture-be [
 		{
 			index		4
 			direction	capture
@@ -87,6 +87,11 @@ Object.Pipeline {
 					out_bit_depth		32
 					out_valid_bit_depth	32
 					dma_buffer_size "$[$ibs * 2]"
+				}
+			}
+			Object.Widget.eqiir.1 {
+				Object.Control.bytes."1" {
+					name '4 Main capture Iir Eq'
 				}
 			}
 		}
@@ -125,6 +130,10 @@ Object.Base.route [
 	}
 	{
 		source 'copier.HDA.4.1'
+		sink 'eqiir.4.1'
+	}
+	{
+		source 'eqiir.4.1'
 		sink 'copier.host.3.1'
 	}
 ]

--- a/tools/topology/topology2/include/pipelines/cavs/highpass-capture-be.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/highpass-capture-be.conf
@@ -1,0 +1,87 @@
+#
+# BE DAI highpass pipeline for capture
+#
+# All attributes defined herein are namespaced by alsatplg to
+# "Object.Pipeline.highpass-be-capture.N.attribute_name"
+#
+# Usage: highpass-capture-be pipeline object can be instantiated as:
+#
+# Object.Pipeline.highpass-capture-be."N" {
+#	direction	"capture"
+# 	period		1000
+# 	time_domain	"timer"
+# 	channels	2
+# 	rate		48000
+# }
+#
+# Where N is the unique pipeline ID within the same alsaconf node.
+#
+
+<include/common/audio_format.conf>
+<include/components/copier.conf>
+<include/components/pipeline.conf>
+<include/controls/bytes.conf>
+<include/components/eqiir.conf>
+
+Class.Pipeline."highpass-capture-be" {
+
+	DefineAttribute."index" {}
+
+	<include/pipelines/pipeline-common.conf>
+
+	attributes {
+		!constructor [
+			"index"
+		]
+
+		unique	"instance"
+	}
+
+	Object.Widget {
+		copier."1" {
+			type dai_in
+			num_audio_formats 1
+			num_input_audio_formats 1
+			num_output_audio_formats 1
+
+			Object.Base.audio_format.1 {
+				in_bit_depth		32
+				in_valid_bit_depth	32
+				out_bit_depth		32
+				out_valid_bit_depth	32
+				dma_buffer_size "$[$obs * 2]"
+			}
+		}
+
+		eqiir."1" {
+			num_audio_formats 1
+			num_input_audio_formats 1
+			num_output_audio_formats 1
+
+			Object.Base.audio_format.1 {
+				in_bit_depth		32
+				in_valid_bit_depth	32
+				out_bit_depth		32
+				out_valid_bit_depth	32
+			}
+
+			Object.Control.bytes."1" {
+				<include/components/eqiir/highpass_40hz_0db_48khz.conf>
+			}
+		}
+
+		pipeline."1" {
+			priority		0
+			lp_mode		0
+		}
+	}
+
+	time_domain	"timer"
+	dynamic_pipeline 1
+	channels	2
+	channels_min	2
+	channels_max	2
+	rate		48000
+	rate_min	48000
+	rate_max	48000
+}

--- a/tools/topology/topology2/sof-hda-generic.conf
+++ b/tools/topology/topology2/sof-hda-generic.conf
@@ -21,6 +21,7 @@
 <deepbuffer-playback.conf>
 <passthrough-be.conf>
 <passthrough-capture-be.conf>
+<highpass-capture-be.conf>
 <data.conf>
 <pcm.conf>
 <pcm_caps.conf>


### PR DESCRIPTION
    This patch includes to sof-hda-generic.conf the new
    highpass-capture-be.conf as passthrough-capture-be.conf replacement
    that adds to DAI copier pipeline the IIR high-pass filter. The
    response is hard coded to 0 dB amplification and 40 Hz cut-off.
    
    The analog microphone headsets creates a strong DC input when the bias
    voltage settles. It can be even full-scale and sound very loud. The
    high-pass filter suppresses such input signal.
    
    Fixes #7116
