### PR TITLE
west.yml: upgrade Zephyr to 0c0d73721ed + adapted PR7110

### DIFF
--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -1014,6 +1014,7 @@ static void dai_update_start_position(struct comp_dev *dev)
 static int dai_comp_trigger_internal(struct comp_dev *dev, int cmd)
 {
 	struct dai_data *dd = comp_get_drvdata(dev);
+	int prev_state = dev->state;
 	int ret;
 
 	comp_dbg(dev, "dai_comp_trigger_internal(), command = %u", cmd);
@@ -1101,9 +1102,8 @@ static int dai_comp_trigger_internal(struct comp_dev *dev, int cmd)
 		dai_trigger_op(dd->dai, cmd, dev->direction);
 #else
 		dai_trigger_op(dd->dai, cmd, dev->direction);
-		if (dev->state == COMP_STATE_ACTIVE) {
-			ret = dma_stop(dd->chan->dma->z_dev, dd->chan->index);
-		} else {
+		ret = dma_stop(dd->chan->dma->z_dev, dd->chan->index);
+		if (ret) {
 			comp_warn(dev, "dma was stopped earlier");
 			ret = 0;
 		}
@@ -1111,7 +1111,7 @@ static int dai_comp_trigger_internal(struct comp_dev *dev, int cmd)
 		break;
 	case COMP_TRIGGER_PAUSE:
 		comp_dbg(dev, "dai_comp_trigger_internal(), PAUSE");
-		if (dev->state == COMP_STATE_ACTIVE) {
+		if (prev_state == COMP_STATE_ACTIVE) {
 			ret = dma_suspend(dd->chan->dma->z_dev, dd->chan->index);
 		} else {
 			comp_warn(dev, "dma was stopped earlier");

--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: d9c4ec31fc49e7eef3c8c3b0d07827cc04e6efee
+      revision: 0c0d73721edb808b51a7ab136cfe01d1b2c1f87d
       remote: zephyrproject
       # Import some projects listed in zephyr/west.yml@revision
       #


### PR DESCRIPTION
Includes patches to dai-zephyr.c to adapt to DMA interface change for DW/HDDMA drivers.

Total of 1168 commits, including following related to intel_adsp/sparse/dmic/xtensa:

8f5bcb2e76c3 intel_adsp: ace: fix linker script for xcc-clang compiler
18ce85c20130 tests: intel_adsp: ssp: fix dma data sizes
60a20471b561 intel_adsp: ace: enable interrupts for secondary core
6045eed2f361 intel_adsp: ace: enable core power gating
e1dbc2efef50 intel_adsp: ace: add core power off step
a99b073392fc intel_adsp: ace: d3 exit update
156c7cd21759 intel_adsp: bbzero/bmemcpy with picolibc fix
60196ca1126a cmake: sparse: deprecate old sparse support
91902c5fd4db cmake: add sparse support to the new SCA infrastructure
a684714d5c82 soc: intel_adsp: Correct HDA parameter docstrings
db495a5ebee3 xtensa: stop execution under simulator for double exception
8ff88346955b xtensa: sparse: fix address space mismatch
7965fd2b4a8a samples/boards/intel_adsp: Make sample work with twister
422250d3b183 mm: intel_adsp_mtl_tlb: suppress sparse address space warnings
618a478ded70 xtensa: fix sparse warning when converting to uncache pointer
8b391dc43841 drivers: audio: dmic_nrfx_pdm: Fix a race condition in the driver
8794de2934f7 intel_adsp: soc: ace: Add communication widget driver
a9b3d935500c intel_adsp: dai: Add support for ALH up to 16 nodes
837432506269 drivers: dai: intel: dmic: don't use assert for error handling