### PR TITLE
[RFC]module_adapter: introduce SYS_COMP_MODULE_INIT macro

### DIFF
--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -614,4 +614,4 @@ static struct module_interface eq_fir_interface = {
 };
 
 DECLARE_MODULE_ADAPTER(eq_fir_interface, eq_fir_uuid, eq_fir_tr);
-SOF_MODULE_INIT(eq_fir, sys_comp_module_eq_fir_interface_init);
+SOF_MODULE_INIT(eq_fir, SYS_COMP_MODULE_INIT(eq_fir_interface));

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -974,4 +974,4 @@ static struct module_interface eq_iir_interface = {
 };
 
 DECLARE_MODULE_ADAPTER(eq_iir_interface, eq_iir_uuid, eq_iir_tr);
-SOF_MODULE_INIT(eq_iir, sys_comp_module_eq_iir_interface_init);
+SOF_MODULE_INIT(eq_iir, SYS_COMP_MODULE_INIT(eq_iir_interface));

--- a/src/audio/mixer/mixer.c
+++ b/src/audio/mixer/mixer.c
@@ -259,4 +259,4 @@ static struct module_interface mixer_interface = {
 };
 
 DECLARE_MODULE_ADAPTER(mixer_interface, mixer_uuid, mixer_tr);
-SOF_MODULE_INIT(mixer, sys_comp_module_mixer_interface_init);
+SOF_MODULE_INIT(mixer, SYS_COMP_MODULE_INIT(mixer_interface));

--- a/src/audio/mixin_mixout/mixin_mixout.c
+++ b/src/audio/mixin_mixout/mixin_mixout.c
@@ -918,7 +918,7 @@ static struct module_interface mixin_interface = {
 };
 
 DECLARE_MODULE_ADAPTER(mixin_interface, mixin_uuid, mixin_tr);
-SOF_MODULE_INIT(mixin, sys_comp_module_mixin_interface_init);
+SOF_MODULE_INIT(mixin, SYS_COMP_MODULE_INIT(mixin_interface));
 
 static struct module_interface mixout_interface = {
 	.init  = mixout_init,
@@ -929,4 +929,4 @@ static struct module_interface mixout_interface = {
 };
 
 DECLARE_MODULE_ADAPTER(mixout_interface, mixout_uuid, mixout_tr);
-SOF_MODULE_INIT(mixout, sys_comp_module_mixout_interface_init);
+SOF_MODULE_INIT(mixout, SYS_COMP_MODULE_INIT(mixout_interface));

--- a/src/audio/module_adapter/module/cadence.c
+++ b/src/audio/module_adapter/module/cadence.c
@@ -750,4 +750,4 @@ static struct module_interface cadence_interface = {
 };
 
 DECLARE_MODULE_ADAPTER(cadence_interface, cadence_uuid, cadence_tr);
-SOF_MODULE_INIT(cadence, sys_comp_module_cadence_interface_init);
+SOF_MODULE_INIT(cadence, SYS_COMP_MODULE_INIT(cadence_interface));

--- a/src/audio/module_adapter/module/dts.c
+++ b/src/audio/module_adapter/module/dts.c
@@ -463,4 +463,4 @@ static struct module_interface dts_interface = {
 };
 
 DECLARE_MODULE_ADAPTER(dts_interface, dts_uuid, dts_tr);
-SOF_MODULE_INIT(dts, sys_comp_module_dts_interface_init);
+SOF_MODULE_INIT(dts, SYS_COMP_MODULE_INIT(dts_interface));

--- a/src/audio/module_adapter/module/passthrough.c
+++ b/src/audio/module_adapter/module/passthrough.c
@@ -123,4 +123,4 @@ static struct module_interface passthrough_interface = {
 };
 
 DECLARE_MODULE_ADAPTER(passthrough_interface, passthrough_uuid, passthrough_tr);
-SOF_MODULE_INIT(passthrough, sys_comp_module_passthrough_interface_init);
+SOF_MODULE_INIT(passthrough, SYS_COMP_MODULE_INIT(passthrough_interface));

--- a/src/audio/module_adapter/module/volume/volume.c
+++ b/src/audio/module_adapter/module/volume/volume.c
@@ -1556,7 +1556,7 @@ static struct module_interface volume_interface = {
 };
 
 DECLARE_MODULE_ADAPTER(volume_interface, volume_uuid, volume_tr);
-SOF_MODULE_INIT(volume, sys_comp_module_volume_interface_init);
+SOF_MODULE_INIT(volume, SYS_COMP_MODULE_INIT(volume_interface));
 
 #if CONFIG_COMP_GAIN
 static struct module_interface gain_interface = {
@@ -1570,6 +1570,6 @@ static struct module_interface gain_interface = {
 };
 
 DECLARE_MODULE_ADAPTER(gain_interface, gain_uuid, gain_tr);
-SOF_MODULE_INIT(gain, sys_comp_module_gain_interface_init);
+SOF_MODULE_INIT(gain, SYS_COMP_MODULE_INIT(gain_interface));
 #endif
 #endif

--- a/src/audio/module_adapter/module/waves.c
+++ b/src/audio/module_adapter/module/waves.c
@@ -891,4 +891,4 @@ static struct module_interface waves_interface = {
 };
 
 DECLARE_MODULE_ADAPTER(waves_interface, waves_uuid, waves_tr);
-SOF_MODULE_INIT(waves, sys_comp_module_waves_interface_init);
+SOF_MODULE_INIT(waves, SYS_COMP_MODULE_INIT(waves_interface));

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -957,5 +957,5 @@ static struct module_interface selector_interface = {
 };
 
 DECLARE_MODULE_ADAPTER(selector_interface, selector_uuid, selector_tr);
-SOF_MODULE_INIT(selector, sys_comp_module_selector_interface_init);
+SOF_MODULE_INIT(selector, SYS_COMP_MODULE_INIT(selector_interface));
 #endif

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -1050,7 +1050,7 @@ static struct module_interface src_interface = {
 };
 
 DECLARE_MODULE_ADAPTER(src_interface, src_uuid, src_tr);
-SOF_MODULE_INIT(src, sys_comp_module_src_interface_init);
+SOF_MODULE_INIT(src, SYS_COMP_MODULE_INIT(src_interface));
 
 #elif CONFIG_IPC_MAJOR_3
 static struct comp_dev *src_new(const struct comp_driver *drv,

--- a/src/audio/up_down_mixer/up_down_mixer.c
+++ b/src/audio/up_down_mixer/up_down_mixer.c
@@ -464,4 +464,4 @@ static struct module_interface up_down_mixer_interface = {
 };
 
 DECLARE_MODULE_ADAPTER(up_down_mixer_interface, up_down_mixer_comp_uuid, up_down_mixer_comp_tr);
-SOF_MODULE_INIT(up_down_mixer, sys_comp_module_up_down_mixer_interface_init);
+SOF_MODULE_INIT(up_down_mixer, SYS_COMP_MODULE_INIT(up_down_mixer_interface));

--- a/src/include/sof/audio/eq_fir/eq_fir.h
+++ b/src/include/sof/audio/eq_fir/eq_fir.h
@@ -53,7 +53,7 @@ void eq_fir_2x_s32(struct fir_state_32x16 *fir, struct input_stream_buffer *bsou
 #endif /* CONFIG_FORMAT_S32LE */
 
 #ifdef UNIT_TEST
-void sys_comp_module_eq_fir_interface_init(void);
+void SYS_COMP_MODULE_INIT(eq_fir_interface)(void);
 #endif
 
 #endif /* __SOF_AUDIO_EQ_FIR_EQ_FIR_H__ */

--- a/src/include/sof/audio/eq_iir/eq_iir.h
+++ b/src/include/sof/audio/eq_iir/eq_iir.h
@@ -33,7 +33,7 @@ struct eq_iir_func_map {
 };
 
 #ifdef UNIT_TEST
-void sys_comp_module_eq_iir_interface_init(void);
+void SYS_COMP_MODULE_INIT(eq_iir_interface)(void);
 #endif
 
 #endif /* __SOF_AUDIO_EQ_IIR_EQ_IIR_H__ */

--- a/src/include/sof/audio/mixer.h
+++ b/src/include/sof/audio/mixer.h
@@ -16,7 +16,7 @@
 #include <stdint.h>
 
 #ifdef UNIT_TEST
-void sys_comp_module_mixer_interface_init(void);
+void SYS_COMP_MODULE_INIT(mixer_interface)(void);
 #endif
 
 #define MIXER_GENERIC

--- a/src/include/sof/audio/module_adapter/module/generic.h
+++ b/src/include/sof/audio/module_adapter/module/generic.h
@@ -33,6 +33,9 @@
 				(value)); \
 	} while (0)
 
+#define SYS_COMP_MODULE_INIT(adapter) \
+	sys_comp_module_##adapter##_init
+
 #define DECLARE_MODULE_ADAPTER(adapter, uuid, tr) \
 static struct comp_dev *module_##adapter##_shim_new(const struct comp_driver *drv, \
 					 const struct comp_ipc_config *config, \
@@ -66,13 +69,13 @@ static SHARED_DATA struct comp_driver_info comp_module_##adapter##_info = { \
 	.drv = &comp_##adapter##_module, \
 }; \
 \
-UT_STATIC void sys_comp_module_##adapter##_init(void) \
+UT_STATIC void SYS_COMP_MODULE_INIT(adapter)(void) \
 { \
 	comp_register(platform_shared_get(&comp_module_##adapter##_info, \
 					  sizeof(comp_module_##adapter##_info))); \
 } \
 \
-DECLARE_MODULE(sys_comp_module_##adapter##_init)
+DECLARE_MODULE(SYS_COMP_MODULE_INIT(adapter))
 
 /**
  * \enum module_state

--- a/src/include/sof/audio/selector.h
+++ b/src/include/sof/audio/selector.h
@@ -100,7 +100,7 @@ extern const struct comp_func_map func_map[];
 sel_func sel_get_processing_function(struct processing_module *mod);
 
 #ifdef UNIT_TEST
-void sys_comp_module_selector_interface_init(void);
+void SYS_COMP_MODULE_INIT(selector_interface)(void);
 #endif
 #else
 /**

--- a/src/include/sof/audio/volume.h
+++ b/src/include/sof/audio/volume.h
@@ -237,7 +237,7 @@ static inline void peak_vol_update(struct vol_data *cd)
 #if CONFIG_COMP_LEGACY_INTERFACE
 void sys_comp_volume_init(void);
 #else
-void sys_comp_module_volume_interface_init(void);
+void SYS_COMP_MODULE_INIT(volume_interface)(void);
 #endif
 #endif
 

--- a/test/cmocka/src/audio/eq_fir/eq_fir_process.c
+++ b/test/cmocka/src/audio/eq_fir/eq_fir_process.c
@@ -62,7 +62,7 @@ struct test_data {
 static int setup_group(void **state)
 {
 	sys_comp_init(sof_get());
-	sys_comp_module_eq_fir_interface_init();
+	SYS_COMP_MODULE_INIT(eq_fir_interface)();
 	return 0;
 }
 

--- a/test/cmocka/src/audio/eq_iir/eq_iir_process.c
+++ b/test/cmocka/src/audio/eq_iir/eq_iir_process.c
@@ -61,7 +61,7 @@ struct test_data {
 static int setup_group(void **state)
 {
 	sys_comp_init(sof_get());
-	sys_comp_module_eq_iir_interface_init();
+	SYS_COMP_MODULE_INIT(eq_iir_interface)();
 	return 0;
 }
 


### PR DESCRIPTION
This patch introduces the SYS_COMP_MODULE_INIT helper macro for module initialization function, and uses it globally, so that for modules use module adapter, we have a unified way to declare and use the module initialization function.