### PR TITLE
ll-schedule: fix tasks removed during execution

### DIFF
--- a/src/audio/chain_dma.c
+++ b/src/audio/chain_dma.c
@@ -303,7 +303,6 @@ static int chain_task_start(struct comp_dev *dev)
 	}
 
 	pm_policy_state_lock_get(PM_STATE_RUNTIME_IDLE, PM_ALL_SUBSTATES);
-	cd->chain_task.state = SOF_TASK_STATE_INIT;
 	k_spin_unlock(&drivers->lock, key);
 
 	return 0;


### PR DESCRIPTION
Zephyr LL-scheduler is supposed to be able to handle tasks, removed or added while the scheduler is executing. However, there is a bug in that implementation. If the task, that is currently executing, is removed, its list head, that links it into the list of tasks, is initialised. So when trying to get a pointer to the next task we obtain a pointer to the same task.

BugLink: https://github.com/thesofproject/sof/issues/7084