### PR TITLE
Switch to using rtos/sof.h instead of sof/sof.h

### DIFF
--- a/src/arch/host/include/arch/sof.h
+++ b/src/arch/host/include/arch/sof.h
@@ -5,7 +5,7 @@
  * Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
  */
 
-#ifdef __SOF_SOF_H__
+#ifdef __XTOS_RTOS_SOF_H__
 
 #ifndef __ARCH_SOF_H__
 #define __ARCH_SOF_H__
@@ -14,6 +14,6 @@
 
 #else
 
-#error "This file shouldn't be included from outside of sof/sof.h"
+#error "This file shouldn't be included from outside of XTOS's rtos/sof.h"
 
-#endif /* __SOF_SOF_H__ */
+#endif /* __XTOS_RTOS_SOF_H__ */

--- a/src/arch/xtensa/include/arch/sof.h
+++ b/src/arch/xtensa/include/arch/sof.h
@@ -6,7 +6,7 @@
  *         Janusz Jankowski <janusz.jankowski@linux.intel.com>
  */
 
-#ifdef __SOF_SOF_H__
+#ifdef __XTOS_RTOS_SOF_H__
 
 #ifndef __ARCH_SOF_H__
 #define __ARCH_SOF_H__
@@ -20,6 +20,6 @@ void boot_primary_core(void);
 
 #else
 
-#error "This file shouldn't be included from outside of sof/sof.h"
+#error "This file shouldn't be included from outside of XTOS's rtos/sof.h"
 
-#endif /* __SOF_SOF_H__ */
+#endif /* __XTOS_RTOS_SOF_H__ */

--- a/src/arch/xtensa/init.c
+++ b/src/arch/xtensa/init.c
@@ -15,7 +15,7 @@
 #include <rtos/panic.h>
 #include <sof/init.h>
 #include <sof/lib/cpu.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <rtos/spinlock.h>
 
 #include <ipc/trace.h>

--- a/src/arch/xtensa/lib/cpu.c
+++ b/src/arch/xtensa/lib/cpu.c
@@ -22,7 +22,7 @@
 #include <sof/lib/pm_runtime.h>
 #include <rtos/wait.h>
 #include <sof/schedule/schedule.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <sof/trace/trace.h>
 #include <ipc/trace.h>
 #include <user/trace.h>

--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -13,7 +13,7 @@
 #include <rtos/cache.h>
 #include <sof/lib/memory.h>
 #include <sof/list.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <rtos/string.h>
 #include <ipc/topology.h>
 #include <errno.h>

--- a/src/audio/data_blob.c
+++ b/src/audio/data_blob.c
@@ -5,7 +5,7 @@
 // Author: Jyri Sarha <jyri.sarha@intel.com>
 
 #include <sof/audio/module_adapter/module/generic.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <rtos/alloc.h>
 #include <ipc/topology.h>
 #include <ipc/control.h>

--- a/src/audio/module_adapter/iadk/system_service.c
+++ b/src/audio/module_adapter/iadk/system_service.c
@@ -12,7 +12,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <sof/common.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <rtos/string.h>
 #include <ipc4/notification.h>
 #include <sof/ipc/msg.h>

--- a/src/drivers/intel/ssp/mn.c
+++ b/src/drivers/intel/ssp/mn.c
@@ -10,7 +10,7 @@
 #include <sof/lib/shim.h>
 #include <sof/lib/uuid.h>
 #include <sof/math/numbers.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <rtos/spinlock.h>
 #include <sof/trace/trace.h>
 

--- a/src/drivers/interrupt.c
+++ b/src/drivers/interrupt.c
@@ -12,7 +12,7 @@
 #include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <rtos/spinlock.h>
 #include <sof/trace/trace.h>
 #include <ipc/topology.h>

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -29,7 +29,7 @@
 #include <sof/lib/perf_cnt.h>
 #include <sof/math/numbers.h>
 #include <sof/schedule/schedule.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <sof/trace/trace.h>
 #include <ipc/control.h>
 #include <ipc/stream.h>

--- a/src/include/sof/audio/data_blob.h
+++ b/src/include/sof/audio/data_blob.h
@@ -9,7 +9,7 @@
 #define __SOF_AUDIO_DATA_BLOB_H__
 
 #include <sof/audio/module_adapter/module/generic.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 
 struct comp_dev;
 

--- a/src/include/sof/audio/pipeline-trace.h
+++ b/src/include/sof/audio/pipeline-trace.h
@@ -8,7 +8,7 @@
 #ifndef __SOF_AUDIO_PIPELINE_TRACE_H__
 #define __SOF_AUDIO_PIPELINE_TRACE_H__
 
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <sof/trace/trace.h>
 #include <user/trace.h>
 #include <errno.h>

--- a/src/include/sof/audio/pipeline.h
+++ b/src/include/sof/audio/pipeline.h
@@ -13,7 +13,7 @@
 #include <sof/lib/memory.h>
 #include <sof/list.h>
 #include <sof/schedule/task.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <rtos/spinlock.h>
 #include <sof/audio/pipeline-trace.h>
 #include <ipc/topology.h>

--- a/src/include/sof/debug/debug.h
+++ b/src/include/sof/debug/debug.h
@@ -13,7 +13,7 @@
 #include <rtos/panic.h>
 #include <rtos/cache.h>
 #include <sof/lib/cpu.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <rtos/string.h>
 #include <ipc/info.h>
 #include <ipc/trace.h>

--- a/src/include/sof/drivers/mn.h
+++ b/src/include/sof/drivers/mn.h
@@ -9,7 +9,7 @@
 #define __SOF_DRIVERS_MN_H__
 
 #include <platform/drivers/mn.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 
 #include <stdbool.h>
 #include <stdint.h>

--- a/src/include/sof/ipc/common.h
+++ b/src/include/sof/ipc/common.h
@@ -14,7 +14,7 @@
 #include <sof/list.h>
 #include <sof/schedule/task.h>
 #include <rtos/spinlock.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <user/trace.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/src/include/sof/ipc/driver.h
+++ b/src/include/sof/ipc/driver.h
@@ -10,7 +10,7 @@
 #define __SOF_IPC_DRIVER_H__
 
 #include <sof/platform.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <sof/ipc/common.h>
 #include <sof/schedule/task.h>
 #include <stdbool.h>

--- a/src/include/sof/ipc/msg.h
+++ b/src/include/sof/ipc/msg.h
@@ -17,7 +17,7 @@
 #include <sof/list.h>
 #include <sof/platform.h>
 #include <sof/schedule/task.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <rtos/spinlock.h>
 #include <sof/trace/trace.h>
 #include <sof/ipc/common.h>

--- a/src/include/sof/ipc/schedule.h
+++ b/src/include/sof/ipc/schedule.h
@@ -10,7 +10,7 @@
 #define __SOF_IPC_SCHEDULE_H__
 
 #include <sof/schedule/task.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <stdbool.h>
 #include <stdint.h>
 

--- a/src/include/sof/ipc/topology.h
+++ b/src/include/sof/ipc/topology.h
@@ -17,7 +17,7 @@
 #include <sof/list.h>
 #include <sof/platform.h>
 #include <sof/schedule/task.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <rtos/spinlock.h>
 #include <sof/trace/trace.h>
 #include <sof/ipc/common.h>

--- a/src/include/sof/lib/cpu-clk-manager.h
+++ b/src/include/sof/lib/cpu-clk-manager.h
@@ -15,7 +15,7 @@
 #define __SOF_LIB_CPU_CLK_MANAGER_H__
 
 #include <rtos/spinlock.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <stdint.h>
 
 /**

--- a/src/include/sof/lib/dai-legacy.h
+++ b/src/include/sof/lib/dai-legacy.h
@@ -28,7 +28,7 @@
 #include <sof/lib/memory.h>
 #include <sof/lib/dma.h>
 #include <sof/list.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <rtos/spinlock.h>
 #include <sof/trace/trace.h>
 #include <sof/ipc/topology.h>

--- a/src/include/sof/lib/dai-zephyr.h
+++ b/src/include/sof/lib/dai-zephyr.h
@@ -23,7 +23,7 @@
 #include <sof/lib/memory.h>
 #include <sof/lib/dma.h>
 #include <sof/list.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <rtos/spinlock.h>
 #include <sof/trace/trace.h>
 #include <sof/ipc/topology.h>

--- a/src/include/sof/lib/notifier.h
+++ b/src/include/sof/lib/notifier.h
@@ -11,7 +11,7 @@
 #include <rtos/bit.h>
 #include <sof/list.h>
 #include <rtos/spinlock.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <stdint.h>
 
 /* notifier target core masks */

--- a/src/include/sof/schedule/ll_schedule_domain.h
+++ b/src/include/sof/schedule/ll_schedule_domain.h
@@ -14,7 +14,7 @@
 #include <sof/lib/cpu.h>
 #include <rtos/clk.h>
 #include <sof/lib/memory.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <rtos/spinlock.h>
 #include <sof/trace/trace.h>
 #include <ipc/topology.h>

--- a/src/include/sof/trace/dma-trace.h
+++ b/src/include/sof/trace/dma-trace.h
@@ -10,7 +10,7 @@
 
 #include <sof/lib/dma.h>
 #include <sof/schedule/task.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <rtos/spinlock.h>
 #include <ipc/trace.h>
 #include <stdint.h>

--- a/src/include/sof/trace/trace.h
+++ b/src/include/sof/trace/trace.h
@@ -20,7 +20,7 @@
 #include <platform/trace/trace.h>
 #endif
 #include <sof/common.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <sof/trace/preproc.h>
 
 #include <stdbool.h>

--- a/src/init/init.c
+++ b/src/init/init.c
@@ -21,7 +21,7 @@
 #include <rtos/wait.h>
 #include <sof/platform.h>
 #include <sof/schedule/task.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <sof/trace/trace.h>
 #include <sof/drivers/idc.h>
 #include <sof/schedule/schedule.h>

--- a/src/ipc/ipc-common.c
+++ b/src/ipc/ipc-common.c
@@ -21,7 +21,7 @@
 #include <sof/lib/mailbox.h>
 #include <sof/list.h>
 #include <sof/platform.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <rtos/spinlock.h>
 #include <ipc/dai.h>
 #include <ipc/header.h>

--- a/src/ipc/ipc-helper.c
+++ b/src/ipc/ipc-helper.c
@@ -22,7 +22,7 @@
 #include <sof/lib/mailbox.h>
 #include <sof/list.h>
 #include <sof/platform.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <rtos/spinlock.h>
 #include <ipc/dai.h>
 #include <ipc/header.h>

--- a/src/ipc/ipc3/helper.c
+++ b/src/ipc/ipc3/helper.c
@@ -19,7 +19,7 @@
 #include <sof/lib/mailbox.h>
 #include <sof/list.h>
 #include <sof/platform.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <ipc/dai.h>
 #include <ipc/header.h>
 #include <ipc/stream.h>

--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -15,7 +15,7 @@
 #include <sof/lib/dai.h>
 #include <sof/lib/notifier.h>
 #include <sof/platform.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <ipc4/gateway.h>
 #include <ipc/header.h>
 #include <ipc4/alh.h>

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -23,7 +23,7 @@
 #include <adsp_memory.h> /* for IMR_BOOT_LDR_MANIFEST_BASE */
 #endif
 
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <rtos/spinlock.h>
 #include <rimage/cavs/cavs_ext_manifest.h>
 #include <rimage/sof/user/manifest.h>

--- a/src/lib/agent.c
+++ b/src/lib/agent.c
@@ -24,7 +24,7 @@
 #include <sof/schedule/ll_schedule.h>
 #include <sof/schedule/schedule.h>
 #include <sof/schedule/task.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <sof/trace/trace.h>
 #include <ipc/topology.h>
 #include <ipc/trace.h>

--- a/src/lib/cpu-clk-manager.c
+++ b/src/lib/cpu-clk-manager.c
@@ -5,11 +5,10 @@
 // Author: Krzysztof Frydryk <frydryk.krzysztof@intel.com>
 
 #include <rtos/spinlock.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <stdint.h>
 #include <sof/lib/cpu-clk-manager.h>
 #include <rtos/clk.h>
-#include <sof/sof.h>
 #include <sof/math/numbers.h>
 #include <errno.h>
 #ifdef __ZEPHYR__

--- a/src/lib/notifier.c
+++ b/src/lib/notifier.c
@@ -15,7 +15,7 @@
 #include <sof/lib/notifier.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <ipc/topology.h>
 #include <stdint.h>
 

--- a/src/lib/pm_runtime.c
+++ b/src/lib/pm_runtime.c
@@ -15,7 +15,7 @@
 #include <sof/lib/memory.h>
 #include <sof/lib/pm_runtime.h>
 #include <sof/lib/uuid.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <rtos/spinlock.h>
 #include <ipc/topology.h>
 #include <stdint.h>

--- a/src/library_manager/lib_manager.c
+++ b/src/library_manager/lib_manager.c
@@ -15,7 +15,7 @@
 #include <sof/compiler_attributes.h>
 #include <sof/ipc/topology.h>
 
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <rtos/spinlock.h>
 #include <sof/lib_manager.h>
 #include <sof/audio/module_adapter/module/generic.h>

--- a/src/library_manager/lib_notification.c
+++ b/src/library_manager/lib_notification.c
@@ -12,7 +12,7 @@
  * based on base FW message management. Therefore this code expose notification
  * calls aligned with cAVS/ACE System service API requirements.
  */
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <sof/list.h>
 #include <sof/ipc/msg.h>
 #include <sof/lib/memory.h>

--- a/src/platform/amd/rembrandt/lib/clk.c
+++ b/src/platform/amd/rembrandt/lib/clk.c
@@ -9,7 +9,7 @@
 #include <sof/lib/cpu.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/notifier.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <rtos/spinlock.h>
 #include <platform/chip_registers.h>
 

--- a/src/platform/amd/rembrandt/lib/dai.c
+++ b/src/platform/amd/rembrandt/lib/dai.c
@@ -9,7 +9,7 @@
 #include <sof/drivers/acp_dai_dma.h>
 #include <sof/lib/dai.h>
 #include <sof/lib/memory.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <rtos/spinlock.h>
 #include <ipc/dai.h>
 #include <ipc/stream.h>

--- a/src/platform/amd/rembrandt/lib/dma.c
+++ b/src/platform/amd/rembrandt/lib/dma.c
@@ -11,7 +11,7 @@
 #include <rtos/interrupt.h>
 #include <sof/lib/dma.h>
 #include <sof/lib/memory.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <rtos/spinlock.h>
 
 extern struct dma_ops acp_dma_ops;

--- a/src/platform/amd/rembrandt/lib/memory.c
+++ b/src/platform/amd/rembrandt/lib/memory.c
@@ -8,7 +8,7 @@
 #include <sof/lib/mm_heap.h>
 #include <sof/lib/memory.h>
 #include <sof/platform.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <ipc/topology.h>
 
 /* Heap blocks for system runtime */

--- a/src/platform/amd/rembrandt/platform.c
+++ b/src/platform/amd/rembrandt/platform.c
@@ -24,7 +24,7 @@
 #include <sof/schedule/edf_schedule.h>
 #include <sof/schedule/ll_schedule.h>
 #include <sof/schedule/ll_schedule_domain.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <sof/trace/dma-trace.h>
 #include <ipc/dai.h>
 #include <ipc/header.h>

--- a/src/platform/amd/renoir/lib/clk.c
+++ b/src/platform/amd/renoir/lib/clk.c
@@ -9,7 +9,7 @@
 #include <sof/lib/cpu.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/notifier.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <rtos/spinlock.h>
 #include <platform/chip_registers.h>
 

--- a/src/platform/amd/renoir/lib/dai.c
+++ b/src/platform/amd/renoir/lib/dai.c
@@ -10,7 +10,7 @@
 #include <sof/drivers/acp_dai_dma.h>
 #include <sof/lib/dai.h>
 #include <sof/lib/memory.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <rtos/spinlock.h>
 #include <ipc/dai.h>
 #include <ipc/stream.h>

--- a/src/platform/amd/renoir/lib/dma.c
+++ b/src/platform/amd/renoir/lib/dma.c
@@ -12,7 +12,7 @@
 #include <rtos/interrupt.h>
 #include <sof/lib/dma.h>
 #include <sof/lib/memory.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <rtos/spinlock.h>
 
 #define ACP_ADDR_MASK	0x20000000

--- a/src/platform/amd/renoir/lib/memory.c
+++ b/src/platform/amd/renoir/lib/memory.c
@@ -8,7 +8,7 @@
 #include <sof/lib/mm_heap.h>
 #include <sof/lib/memory.h>
 #include <sof/platform.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <ipc/topology.h>
 
 /* Heap blocks for system runtime */

--- a/src/platform/amd/renoir/platform.c
+++ b/src/platform/amd/renoir/platform.c
@@ -25,7 +25,7 @@
 #include <sof/schedule/edf_schedule.h>
 #include <sof/schedule/ll_schedule.h>
 #include <sof/schedule/ll_schedule_domain.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <sof/trace/dma-trace.h>
 #include <ipc/dai.h>
 #include <ipc/header.h>

--- a/src/platform/imx8/lib/clk.c
+++ b/src/platform/imx8/lib/clk.c
@@ -9,7 +9,7 @@
 #include <rtos/clk.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/notifier.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <rtos/spinlock.h>
 
 #ifdef __ZEPHYR__

--- a/src/platform/imx8/lib/dai.c
+++ b/src/platform/imx8/lib/dai.c
@@ -10,7 +10,7 @@
 #include <sof/drivers/sai.h>
 #include <sof/lib/dai.h>
 #include <sof/lib/memory.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <rtos/spinlock.h>
 #include <ipc/dai.h>
 #include <ipc/stream.h>

--- a/src/platform/imx8/lib/dma.c
+++ b/src/platform/imx8/lib/dma.c
@@ -9,7 +9,7 @@
 #include <rtos/interrupt.h>
 #include <sof/lib/dma.h>
 #include <sof/lib/memory.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <rtos/spinlock.h>
 
 extern struct dma_ops dummy_dma_ops;

--- a/src/platform/imx8/lib/memory.c
+++ b/src/platform/imx8/lib/memory.c
@@ -8,7 +8,7 @@
 #include <sof/lib/mm_heap.h>
 #include <sof/lib/memory.h>
 #include <sof/platform.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <ipc/topology.h>
 
 /* Heap blocks for system runtime */

--- a/src/platform/imx8/platform.c
+++ b/src/platform/imx8/platform.c
@@ -24,7 +24,7 @@
 #include <sof/schedule/edf_schedule.h>
 #include <sof/schedule/ll_schedule.h>
 #include <sof/schedule/ll_schedule_domain.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <sof/trace/dma-trace.h>
 #include <ipc/dai.h>
 #include <ipc/header.h>

--- a/src/platform/imx8m/lib/clk.c
+++ b/src/platform/imx8m/lib/clk.c
@@ -8,7 +8,7 @@
 #include <rtos/clk.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/notifier.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <rtos/spinlock.h>
 
 #ifdef __ZEPHYR__

--- a/src/platform/imx8m/lib/dai.c
+++ b/src/platform/imx8m/lib/dai.c
@@ -8,7 +8,7 @@
 #include <sof/drivers/sai.h>
 #include <sof/lib/dai.h>
 #include <sof/lib/memory.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <rtos/spinlock.h>
 #include <ipc/dai.h>
 #include <ipc/stream.h>

--- a/src/platform/imx8m/lib/dma.c
+++ b/src/platform/imx8m/lib/dma.c
@@ -8,7 +8,7 @@
 #include <rtos/interrupt.h>
 #include <sof/lib/dma.h>
 #include <sof/lib/memory.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <rtos/spinlock.h>
 
 extern struct dma_ops dummy_dma_ops;

--- a/src/platform/imx8m/lib/memory.c
+++ b/src/platform/imx8m/lib/memory.c
@@ -8,7 +8,7 @@
 #include <sof/lib/mm_heap.h>
 #include <sof/lib/memory.h>
 #include <sof/platform.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <ipc/topology.h>
 
 /* Heap blocks for system runtime */

--- a/src/platform/imx8m/platform.c
+++ b/src/platform/imx8m/platform.c
@@ -23,7 +23,7 @@
 #include <sof/schedule/edf_schedule.h>
 #include <sof/schedule/ll_schedule.h>
 #include <sof/schedule/ll_schedule_domain.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <sof/trace/dma-trace.h>
 #include <ipc/dai.h>
 #include <ipc/header.h>

--- a/src/platform/imx8ulp/lib/clk.c
+++ b/src/platform/imx8ulp/lib/clk.c
@@ -9,7 +9,7 @@
 #include <sof/lib/cpu.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/notifier.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <rtos/spinlock.h>
 
 const struct freq_table platform_cpu_freq[] = {

--- a/src/platform/imx8ulp/lib/dai.c
+++ b/src/platform/imx8ulp/lib/dai.c
@@ -9,7 +9,7 @@
 #include <sof/drivers/sai.h>
 #include <sof/lib/dai.h>
 #include <sof/lib/memory.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <rtos/spinlock.h>
 #include <ipc/dai.h>
 #include <ipc/stream.h>

--- a/src/platform/imx8ulp/lib/dma.c
+++ b/src/platform/imx8ulp/lib/dma.c
@@ -9,7 +9,7 @@
 #include <rtos/interrupt.h>
 #include <sof/lib/dma.h>
 #include <sof/lib/memory.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <rtos/spinlock.h>
 
 extern struct dma_ops dummy_dma_ops;

--- a/src/platform/imx8ulp/lib/memory.c
+++ b/src/platform/imx8ulp/lib/memory.c
@@ -9,7 +9,7 @@
 #include <sof/lib/mm_heap.h>
 #include <sof/lib/memory.h>
 #include <sof/platform.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <ipc/topology.h>
 
 /* Heap blocks for system runtime */

--- a/src/platform/imx8ulp/platform.c
+++ b/src/platform/imx8ulp/platform.c
@@ -24,7 +24,7 @@
 #include <sof/schedule/edf_schedule.h>
 #include <sof/schedule/ll_schedule.h>
 #include <sof/schedule/ll_schedule_domain.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <sof/trace/dma-trace.h>
 #include <ipc/dai.h>
 #include <ipc/header.h>

--- a/src/platform/intel/ace/lib/clk.c
+++ b/src/platform/intel/ace/lib/clk.c
@@ -7,7 +7,7 @@
 #include <sof/lib/notifier.h>
 #include <rtos/clk.h>
 #include <sof/drivers/ssp.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <sof/common.h>
 #include <sof/lib/memory.h>
 #include <rtos/spinlock.h>

--- a/src/platform/intel/ace/lib/dma.c
+++ b/src/platform/intel/ace/lib/dma.c
@@ -13,7 +13,7 @@
 #include <rtos/interrupt.h>
 #include <sof/lib/dma.h>
 #include <sof/lib/memory.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <rtos/spinlock.h>
 #include <zephyr/device.h>
 

--- a/src/platform/intel/cavs/boot_loader.c
+++ b/src/platform/intel/cavs/boot_loader.c
@@ -12,7 +12,7 @@
 #include <sof/lib/shim.h>
 #include <rtos/wait.h>
 #include <sof/platform.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <sof/trace/trace.h>
 #include <ipc/trace.h>
 #include <rimage/sof/user/manifest.h>

--- a/src/platform/intel/cavs/lib/clk.c
+++ b/src/platform/intel/cavs/lib/clk.c
@@ -10,7 +10,7 @@
 #include <sof/lib/memory.h>
 #include <sof/lib/notifier.h>
 #include <sof/lib/pm_runtime.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <rtos/spinlock.h>
 
 #include <cavs/version.h>

--- a/src/platform/intel/cavs/lib/dai.c
+++ b/src/platform/intel/cavs/lib/dai.c
@@ -14,7 +14,7 @@
 #include <sof/lib/dai.h>
 #include <sof/lib/dma.h>
 #include <sof/lib/memory.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <rtos/spinlock.h>
 #include <ipc/dai.h>
 #include <ipc/stream.h>

--- a/src/platform/intel/cavs/lib/dma.c
+++ b/src/platform/intel/cavs/lib/dma.c
@@ -13,7 +13,7 @@
 #include <rtos/interrupt.h>
 #include <sof/lib/dma.h>
 #include <sof/lib/memory.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <rtos/spinlock.h>
 #ifdef __ZEPHYR__
 #include <zephyr/device.h>

--- a/src/platform/intel/cavs/lib/memory.c
+++ b/src/platform/intel/cavs/lib/memory.c
@@ -11,7 +11,7 @@
 #include <sof/lib/cpu.h>
 #include <sof/lib/memory.h>
 #include <sof/platform.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <ipc/topology.h>
 #include <stdint.h>
 

--- a/src/platform/library/init.c
+++ b/src/platform/library/init.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <stdlib.h>
 
 /* main firmware context */

--- a/src/platform/library/lib/dai.c
+++ b/src/platform/library/lib/dai.c
@@ -4,7 +4,7 @@
 //
 // Author: Curtis Malainey <cujomalainey@chromium.org>
 
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <sof/lib/dai.h>
 
 const struct dai_type_info dti[] = {

--- a/src/platform/library/lib/memory.c
+++ b/src/platform/library/lib/memory.c
@@ -11,7 +11,7 @@
 #include <sof/lib/cpu.h>
 #include <sof/lib/memory.h>
 #include <sof/platform.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <ipc/topology.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/src/platform/library/platform.c
+++ b/src/platform/library/platform.c
@@ -4,7 +4,7 @@
 //
 // Author: Curtis Malainey <cujomalainey@chromium.org>
 
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <sof/ipc/driver.h>
 #include <rtos/timer.h>
 #include <sof/lib/agent.h>

--- a/src/platform/mt8186/lib/clk.c
+++ b/src/platform/mt8186/lib/clk.c
@@ -16,7 +16,7 @@
 #include <sof/lib/memory.h>
 #include <sof/lib/notifier.h>
 #include <sof/lib/uuid.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <sof/trace/trace.h>
 
 /* 53863428-9a72-44df-af0f-fe45ea2348ba */

--- a/src/platform/mt8186/lib/dai.c
+++ b/src/platform/mt8186/lib/dai.c
@@ -8,7 +8,7 @@
 #include <sof/common.h>
 #include <sof/lib/dai.h>
 #include <sof/lib/memory.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <rtos/spinlock.h>
 #include <ipc/dai.h>
 #include <ipc/stream.h>

--- a/src/platform/mt8186/lib/dma.c
+++ b/src/platform/mt8186/lib/dma.c
@@ -11,7 +11,7 @@
 #include <rtos/interrupt.h>
 #include <sof/lib/dma.h>
 #include <sof/lib/memory.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <rtos/spinlock.h>
 
 #include <mt8186-afe-regs.h>

--- a/src/platform/mt8186/lib/memory.c
+++ b/src/platform/mt8186/lib/memory.c
@@ -9,7 +9,7 @@
 #include <sof/common.h>
 #include <sof/lib/mm_heap.h>
 #include <sof/lib/memory.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <ipc/topology.h>
 
 /* Heap blocks for system runtime */

--- a/src/platform/mt8186/platform.c
+++ b/src/platform/mt8186/platform.c
@@ -25,7 +25,7 @@
 #include <sof/schedule/edf_schedule.h>
 #include <sof/schedule/ll_schedule.h>
 #include <sof/schedule/ll_schedule_domain.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <sof/trace/dma-trace.h>
 #include <ipc/dai.h>
 #include <ipc/header.h>

--- a/src/platform/mt8188/lib/clk.c
+++ b/src/platform/mt8188/lib/clk.c
@@ -16,7 +16,7 @@
 #include <sof/lib/memory.h>
 #include <sof/lib/notifier.h>
 #include <sof/lib/uuid.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <sof/trace/trace.h>
 
 /* 19d4e680-4479-48cc-af86-9f63d8b0098b */

--- a/src/platform/mt8188/lib/dai.c
+++ b/src/platform/mt8188/lib/dai.c
@@ -8,7 +8,7 @@
 #include <sof/common.h>
 #include <sof/lib/dai.h>
 #include <sof/lib/memory.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <rtos/spinlock.h>
 #include <ipc/dai.h>
 #include <ipc/stream.h>

--- a/src/platform/mt8188/lib/dma.c
+++ b/src/platform/mt8188/lib/dma.c
@@ -12,7 +12,7 @@
 #include <sof/drivers/afe-memif.h>
 #include <sof/lib/dma.h>
 #include <sof/lib/memory.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 
 #include <mt8188-afe-reg.h>
 #include <mt8188-afe-common.h>

--- a/src/platform/mt8188/lib/memory.c
+++ b/src/platform/mt8188/lib/memory.c
@@ -10,7 +10,7 @@
 #include <sof/common.h>
 #include <sof/lib/mm_heap.h>
 #include <sof/lib/memory.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 
 /* Heap blocks for system runtime */
 static SHARED_DATA struct block_hdr sys_rt_block64[HEAP_SYS_RT_COUNT64];

--- a/src/platform/mt8188/platform.c
+++ b/src/platform/mt8188/platform.c
@@ -32,7 +32,7 @@
 #include <sof/schedule/edf_schedule.h>
 #include <sof/schedule/ll_schedule.h>
 #include <sof/schedule/ll_schedule_domain.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <sof/trace/dma-trace.h>
 #include <sof_versions.h>
 #include <stdint.h>

--- a/src/platform/mt8195/lib/clk.c
+++ b/src/platform/mt8195/lib/clk.c
@@ -12,7 +12,7 @@
 #include <sof/lib/notifier.h>
 #include <sof/lib/uuid.h>
 #include <rtos/wait.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <rtos/spinlock.h>
 
 DECLARE_SOF_UUID("clkdrv", clkdrv_uuid, 0x23b12fd5, 0xc2a9, 0x41a8,

--- a/src/platform/mt8195/lib/dai.c
+++ b/src/platform/mt8195/lib/dai.c
@@ -8,7 +8,7 @@
 #include <sof/common.h>
 #include <sof/lib/dai.h>
 #include <sof/lib/memory.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <rtos/spinlock.h>
 #include <ipc/dai.h>
 #include <ipc/stream.h>

--- a/src/platform/mt8195/lib/dma.c
+++ b/src/platform/mt8195/lib/dma.c
@@ -10,7 +10,7 @@
 #include <rtos/interrupt.h>
 #include <sof/lib/dma.h>
 #include <sof/lib/memory.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <rtos/spinlock.h>
 
 #include <mt8195-afe-regs.h>

--- a/src/platform/mt8195/lib/memory.c
+++ b/src/platform/mt8195/lib/memory.c
@@ -8,7 +8,7 @@
 #include <sof/common.h>
 #include <sof/lib/mm_heap.h>
 #include <sof/lib/memory.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <ipc/topology.h>
 
 /* Heap blocks for system runtime */

--- a/src/platform/mt8195/platform.c
+++ b/src/platform/mt8195/platform.c
@@ -25,7 +25,7 @@
 #include <sof/schedule/edf_schedule.h>
 #include <sof/schedule/ll_schedule.h>
 #include <sof/schedule/ll_schedule_domain.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <sof/trace/dma-trace.h>
 #include <platform/drivers/timer.h>
 #include <ipc/dai.h>

--- a/src/schedule/edf_schedule.c
+++ b/src/schedule/edf_schedule.c
@@ -17,7 +17,7 @@
 #include <sof/schedule/edf_schedule.h>
 #include <sof/schedule/schedule.h>
 #include <sof/schedule/task.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <ipc/topology.h>
 #include <errno.h>
 #include <stddef.h>

--- a/src/schedule/task.c
+++ b/src/schedule/task.c
@@ -22,7 +22,7 @@
 #include <sof/schedule/edf_schedule.h>
 #include <sof/schedule/schedule.h>
 #include <sof/schedule/task.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <ipc/topology.h>
 #include <errno.h>
 #include <stddef.h>

--- a/src/trace/dma-trace.c
+++ b/src/trace/dma-trace.c
@@ -18,7 +18,7 @@
 #include <sof/schedule/ll_schedule.h>
 #include <sof/schedule/schedule.h>
 #include <sof/schedule/task.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <rtos/spinlock.h>
 #include <rtos/string.h>
 #include <sof/trace/dma-trace.h>

--- a/src/trace/trace.c
+++ b/src/trace/trace.c
@@ -17,7 +17,7 @@
 #include <sof/lib/memory.h>
 #include <sof/platform.h>
 #include <rtos/string.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <rtos/spinlock.h>
 #include <sof/trace/dma-trace.h>
 #include <sof/trace/preproc.h>

--- a/test/cmocka/include/test_group_generator.h
+++ b/test/cmocka/include/test_group_generator.h
@@ -7,7 +7,7 @@
 
 #include <test_simple_macro.h>
 #include <sof/trace/preproc.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <rtos/alloc.h>
 
 /* CMOCKA SETUP */

--- a/test/cmocka/src/audio/component/comp_set_state.c
+++ b/test/cmocka/src/audio/component/comp_set_state.c
@@ -12,7 +12,7 @@
 #include <setjmp.h>
 #include <stdint.h>
 #include <cmocka.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 
 enum test_type {
 	SUCCEED = 0,

--- a/test/cmocka/src/debugability/macros.c
+++ b/test/cmocka/src/debugability/macros.c
@@ -19,7 +19,7 @@
 #endif
 
 #include <sof/trace/preproc.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <sof/trace/trace.h>
 #include <user/trace.h>
 

--- a/test/cmocka/src/lib/alloc/alloc.c
+++ b/test/cmocka/src/lib/alloc/alloc.c
@@ -11,7 +11,7 @@
 #include <setjmp.h>
 #include <cmocka.h>
 
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <rtos/alloc.h>
 #include <sof/lib/mm_heap.h>
 #include <sof/lib/memory.h>

--- a/test/cmocka/src/lib/preproc/concat.c
+++ b/test/cmocka/src/lib/preproc/concat.c
@@ -13,7 +13,7 @@
 #include <cmocka.h>
 
 #include <sof/trace/preproc.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 
 #define TEST_PREFIX test_lib_preproc
 

--- a/test/cmocka/src/lib/preproc/defer.c
+++ b/test/cmocka/src/lib/preproc/defer.c
@@ -13,7 +13,7 @@
 #include <cmocka.h>
 
 #include <sof/trace/preproc.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 
 #define TEST_PREFIX test_lib_preproc
 

--- a/test/cmocka/src/lib/preproc/get_arg.c
+++ b/test/cmocka/src/lib/preproc/get_arg.c
@@ -12,7 +12,7 @@
 #include <cmocka.h>
 
 #include <sof/trace/preproc.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 
 static void test_lib_preproc_get_arg_1(void **state)
 {

--- a/test/cmocka/src/lib/preproc/seq.c
+++ b/test/cmocka/src/lib/preproc/seq.c
@@ -13,7 +13,7 @@
 #include <cmocka.h>
 
 #include <sof/trace/preproc.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 
 #define TEST_PREFIX test_lib_preproc
 

--- a/test/cmocka/src/lib/preproc/varargs_count.c
+++ b/test/cmocka/src/lib/preproc/varargs_count.c
@@ -13,7 +13,7 @@
 #include <cmocka.h>
 
 #include <sof/trace/preproc.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 
 #define TEST_PREFIX test_lib_preproc
 

--- a/test/cmocka/src/util.h
+++ b/test/cmocka/src/util.h
@@ -5,7 +5,7 @@
 // Author: Daniel Bogdzia <danielx.bogdzia@linux.intel.com>
 //         Janusz Jankowski <janusz.jankowski@linux.intel.com>
 
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <sof/audio/component.h>
 #include <rtos/alloc.h>
 

--- a/tools/testbench/common_test.c
+++ b/tools/testbench/common_test.c
@@ -9,7 +9,7 @@
 #include <stdlib.h>
 #include <rtos/string.h>
 #include <math.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <sof/schedule/task.h>
 #include <rtos/alloc.h>
 #include <sof/lib/notifier.h>

--- a/tools/testbench/file.c
+++ b/tools/testbench/file.c
@@ -10,7 +10,7 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <inttypes.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <sof/list.h>
 #include <sof/audio/stream.h>
 #include <sof/audio/ipc-config.h>

--- a/tools/testbench/include/testbench/common_test.h
+++ b/tools/testbench/include/testbench/common_test.h
@@ -11,7 +11,7 @@
 #include <stdbool.h>
 #include <time.h>
 #include <stdio.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <sof/audio/component_ext.h>
 #include <sof/math/numbers.h>
 #include <sof/audio/format.h>

--- a/xtos/include/rtos/clk.h
+++ b/xtos/include/rtos/clk.h
@@ -10,7 +10,7 @@
 #define __SOF_LIB_CLK_H__
 
 #include <platform/lib/clk.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <rtos/spinlock.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/xtos/include/rtos/interrupt.h
+++ b/xtos/include/rtos/interrupt.h
@@ -14,7 +14,7 @@
 #include <arch/drivers/interrupt.h>
 #include <sof/lib/cpu.h>
 #include <sof/list.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <rtos/spinlock.h>
 #include <sof/trace/trace.h>
 #include <user/trace.h>

--- a/xtos/include/rtos/sof.h
+++ b/xtos/include/rtos/sof.h
@@ -5,8 +5,8 @@
  * Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
  */
 
-#ifndef __SOF_SOF_H__
-#define __SOF_SOF_H__
+#ifndef __XTOS_RTOS_SOF_H__
+#define __XTOS_RTOS_SOF_H__
 
 #include <arch/sof.h>
 #include <sof/common.h>
@@ -58,13 +58,11 @@ struct sof {
 	/* platform clock information */
 	struct clock_info *clocks;
 
-#ifndef __ZEPHYR__
 	/* default platform timer */
 	struct timer *platform_timer;
 
 	/* cpu (arch) timers - 1 per core */
 	struct timer *cpu_timers;
-#endif
 
 	/* timer domain for driving timer LL scheduler */
 	struct ll_schedule_domain *platform_timer_domain;
@@ -117,4 +115,4 @@ struct sof {
 
 struct sof *sof_get(void);
 
-#endif /* __SOF_SOF_H__ */
+#endif /* __XTOS_RTOS_SOF_H__ */

--- a/xtos/include/rtos/timer.h
+++ b/xtos/include/rtos/timer.h
@@ -11,7 +11,7 @@
 #include <arch/drivers/timer.h>
 #include <rtos/clk.h>
 #include <sof/lib/cpu.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <sof/platform.h>
 #include <stdint.h>
 

--- a/xtos/include/sof/lib/agent.h
+++ b/xtos/include/sof/lib/agent.h
@@ -12,7 +12,7 @@
 #include <sof/lib/memory.h>
 #include <sof/lib/perf_cnt.h>
 #include <sof/schedule/task.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 
 #include <stdbool.h>
 #include <stdint.h>

--- a/xtos/include/sof/lib/dma.h
+++ b/xtos/include/sof/lib/dma.h
@@ -22,7 +22,7 @@
 #include <rtos/alloc.h>
 #include <sof/lib/io.h>
 #include <sof/lib/memory.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <rtos/spinlock.h>
 #include <stdbool.h>
 #include <stddef.h>

--- a/xtos/include/sof/lib/mm_heap.h
+++ b/xtos/include/sof/lib/mm_heap.h
@@ -13,7 +13,7 @@
 #include <rtos/alloc.h>
 #include <rtos/cache.h>
 #include <sof/lib/memory.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <rtos/spinlock.h>
 
 #include <stddef.h>

--- a/xtos/include/sof/lib/pm_runtime.h
+++ b/xtos/include/sof/lib/pm_runtime.h
@@ -16,7 +16,7 @@
 #define __SOF_LIB_PM_RUNTIME_H__
 
 #include <platform/lib/pm_runtime.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <rtos/spinlock.h>
 #include <sof/trace/trace.h>
 #include <user/trace.h>

--- a/zephyr/include/rtos/clk.h
+++ b/zephyr/include/rtos/clk.h
@@ -13,7 +13,7 @@
 #include <platform/lib/clk.h>
 
 /* TODO: most of the below is tied to the CLK drivers that need wrapped */
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <rtos/spinlock.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/zephyr/include/rtos/sof.h
+++ b/zephyr/include/rtos/sof.h
@@ -1,0 +1,110 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2016 Intel Corporation. All rights reserved.
+ *
+ * Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
+ */
+
+#ifndef __ZEPHYR_RTOS_SOF_H__
+#define __ZEPHYR_RTOS_SOF_H__
+
+#include <sof/common.h>
+#include <sof/lib/memory.h>
+#include <rtos/spinlock.h>
+
+struct cascade_root;
+struct clock_info;
+struct comp_driver_list;
+struct dai_info;
+struct dma_info;
+struct dma_trace_data;
+struct ipc;
+struct ll_schedule_domain;
+struct mm;
+struct mn;
+struct notify_data;
+struct pm_runtime_data;
+struct sa;
+struct trace;
+struct pipeline_posn;
+struct probe_pdata;
+
+/**
+ * \brief General firmware context.
+ * This structure holds all the global pointers, which can potentially
+ * be accessed by SMP code, hence it should be aligned to platform's
+ * data cache line size. Alignments in the both beginning and end are needed
+ * to avoid potential before and after data evictions.
+ */
+struct sof {
+	/* init data */
+	int argc;
+	char **argv;
+
+	/* ipc */
+	struct ipc *ipc;
+
+	/* system agent */
+	struct sa *sa;
+
+	/* DMA for Trace*/
+	struct dma_trace_data *dmat;
+
+	/* generic trace structure */
+	struct trace *trace;
+
+	/* platform clock information */
+	struct clock_info *clocks;
+
+	/* timer domain for driving timer LL scheduler */
+	struct ll_schedule_domain *platform_timer_domain;
+
+	/* DMA domain for driving DMA LL scheduler */
+	struct ll_schedule_domain *platform_dma_domain;
+
+	/* memory map */
+	struct mm *memory_map;
+
+	/* runtime power management data */
+	struct pm_runtime_data *prd;
+
+	/* shared notifier data */
+	struct notify_data *notify_data;
+
+	/* platform dai information */
+	const struct dai_info *dai_info;
+
+	/* platform DMA information */
+	const struct dma_info *dma_info;
+
+	/* cascading interrupt controller root */
+	struct cascade_root *cascade_root;
+
+	/* list of registered component drivers */
+	struct comp_driver_list *comp_drivers;
+
+	/* M/N dividers */
+	struct mn *mn;
+
+	/* probes */
+	struct probe_pdata *probe;
+
+	/* pipelines stream position */
+	struct pipeline_posn *pipeline_posn;
+
+#ifdef CONFIG_LIBRARY_MANAGER
+	/* dynamically loaded libraries */
+	struct ext_library *ext_library;
+#endif
+
+#if CONFIG_IPC_MAJOR_4
+	/* lock for fw_reg access */
+	struct k_spinlock fw_reg_lock;
+#endif
+
+	__aligned(PLATFORM_DCACHE_ALIGN) int alignment[0];
+} __aligned(PLATFORM_DCACHE_ALIGN);
+
+struct sof *sof_get(void);
+
+#endif /* __ZEPHYR_RTOS_SOF_H__ */

--- a/zephyr/include/rtos/timer.h
+++ b/zephyr/include/rtos/timer.h
@@ -9,7 +9,7 @@
 #include <stdint.h>
 #include <zephyr/kernel.h>
 #include <sof/lib/cpu.h>
-#include <sof/sof.h>
+#include <rtos/sof.h>
 #include <sof/platform.h>
 
 struct comp_dev;


### PR DESCRIPTION
The purpose of this commit is to separate the XTOS-specifc code from the Zephyr-specifc code found in sof/sof.h.