### PR TITLE
[SKIP CI] CODEOWNERS: restore dropped comment

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,9 +5,8 @@
 *       @lgirdwood @plbossart @mmaka1 @lbetlej @dbaluta
 
 # Order is important. The last matching pattern has the most precedence.
-# So if a pull request only touches javascript files, only these owners
-# will be requested to review.
-#
+# File patterns work mostly like .gitignore. Try to keep this file
+# simple because it's literally impossible to test.
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # include files


### PR DESCRIPTION
Fix minor misunderstanding in review of git commit 430893f18aac ("CODEOWNERS: refer to github documentation on file syntax")