### PR TITLE
buffer: add ref_count for buffer sharing

### DIFF
--- a/src/audio/buffer.c
+++ b/src/audio/buffer.c
@@ -180,7 +180,7 @@ void buffer_free(struct comp_buffer *buffer)
 		.buffer = buffer,
 	};
 
-	if (!buffer)
+	if (!buffer || atomic_get(&buffer->ref_count))
 		return;
 
 	buf_dbg(buffer, "buffer_free()");

--- a/src/audio/pipeline/pipeline-graph.c
+++ b/src/audio/pipeline/pipeline-graph.c
@@ -198,6 +198,7 @@ int pipeline_connect(struct comp_dev *comp, struct comp_buffer *buffer,
 	comp_list = comp_buffer_list(comp, dir);
 	buffer_attach(buffer, comp_list, dir);
 	buffer_set_comp(buffer, comp, dir);
+	atomic_inc(&buffer->ref_count);
 
 	irq_local_enable(flags);
 
@@ -219,6 +220,7 @@ void pipeline_disconnect(struct comp_dev *comp, struct comp_buffer *buffer, int 
 	comp_list = comp_buffer_list(comp, dir);
 	buffer_detach(buffer, comp_list, dir);
 	buffer_set_comp(buffer, NULL, dir);
+	atomic_dec(&buffer->ref_count);
 
 	irq_local_enable(flags);
 }

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -159,6 +159,8 @@ struct comp_buffer {
 
 	bool hw_params_configured; /**< indicates whether hw params were set */
 	bool walking;		/**< indicates if the buffer is being walked */
+
+	atomic_t ref_count;
 };
 
 /* Only to be used for synchronous same-core notifications! */


### PR DESCRIPTION
For smart amp or aec case, one buffer is shared between two streams which may work on different cores. When one of the stream is stopped, the buffer is unbind and removed. Now use ref_count to make sure that it will be deleted when the last user unbind it.