### PR TITLE
Audio: Fix the volume change doesn't take effect issue

### DIFF
--- a/src/audio/module_adapter/module/volume/volume.c
+++ b/src/audio/module_adapter/module/volume/volume.c
@@ -536,6 +536,7 @@ static inline void init_ramp(struct vol_data *cd, uint32_t curve_duration, uint3
 		cd->vol_min = VOL_MIN;
 		cd->vol_max = VOL_MAX;
 	}
+	cd->copy_gain = true;
 }
 
 static int volume_init(struct processing_module *mod)


### PR DESCRIPTION
If the initial_ramp is zero, the ramp_finished would always be true, that means we will never copy gain to circular buffer except we reset state.