### PR TITLE
IDC: set IDC task priority equal to that of the IPC task

### DIFF
--- a/src/idc/zephyr_idc.c
+++ b/src/idc/zephyr_idc.c
@@ -25,6 +25,7 @@
 #include <sof/drivers/idc.h>
 #include <sof/init.h>
 #include <sof/ipc/common.h>
+#include <sof/schedule/edf_schedule.h>
 #include <rtos/alloc.h>
 #include <rtos/spinlock.h>
 #include <ipc/topology.h>
@@ -110,8 +111,8 @@ int idc_send_msg(struct idc_msg *msg, uint32_t mode)
 
 	idc_send_memcpy_err = memcpy_s(msg_cp, sizeof(*msg_cp), msg, sizeof(*msg));
 	assert(!idc_send_memcpy_err);
-	/* TODO: verify .priority and .deadline */
-	work->priority = K_HIGHEST_THREAD_PRIO + 1;
+	/* Same priority as the IPC thread which is an EDF task and under Zephyr */
+	work->priority = EDF_ZEPHYR_PRIORITY;
 	work->deadline = 0;
 	work->handler = idc_handler;
 	work->sync = mode == IDC_BLOCKING;

--- a/src/include/sof/schedule/edf_schedule.h
+++ b/src/include/sof/schedule/edf_schedule.h
@@ -13,6 +13,8 @@
 #include <user/trace.h>
 #include <stdint.h>
 
+#define EDF_ZEPHYR_PRIORITY 1
+
 #define edf_sch_set_pdata(task, data) \
 	(task->priv_data = data)
 

--- a/zephyr/edf_schedule.c
+++ b/zephyr/edf_schedule.c
@@ -113,7 +113,7 @@ int scheduler_init_edf(void)
 	k_work_queue_start(&edf_workq,
 		       edf_workq_stack,
 		       K_THREAD_STACK_SIZEOF(edf_workq_stack),
-		       1, NULL);
+		       EDF_ZEPHYR_PRIORITY, NULL);
 
 	k_thread_suspend(thread);
 


### PR DESCRIPTION
One of the functions of the IDC thread is to execute IPCs on secondary cores, those have to be executed with the same priority as when they're run on the primary core, i.e. with the priority of the IPC thread. Set IDC thread priority equal to the IPC thread.