### PR TITLE
audio: chain_dma: do not hold spinlock when calling schedule_task_free

### DIFF
--- a/src/audio/chain_dma.c
+++ b/src/audio/chain_dma.c
@@ -338,10 +338,12 @@ static int chain_task_pause(struct comp_dev *dev)
 	if (!ret)
 		ret = ret2;
 
+	k_spin_unlock(&drivers->lock, key);
+
 	schedule_task_cancel(&cd->chain_task);
 	schedule_task_free(&cd->chain_task);
 	pm_policy_state_lock_put(PM_STATE_RUNTIME_IDLE, PM_ALL_SUBSTATES);
-	k_spin_unlock(&drivers->lock, key);
+
 	return ret;
 }
 


### PR DESCRIPTION
schedule_task_free() might be a blocking call. E.g. the Zephyr LL-scheduler implementation can call k_sem_take(). Do not call this function with a spinlock held.

Link: https://github.com/thesofproject/sof/issues/7156