### PR TITLE
topology2: Add kcps pipeline attribute

### DIFF
--- a/tools/topology/topology2/include/common/tokens.conf
+++ b/tools/topology/topology2/include/common/tokens.conf
@@ -80,6 +80,7 @@ Object.Base.VendorToken {
 		# ABI 4.0 onwards
 		lp_mode		207
 		use_chain_dma		209
+		kcps			210
 	}
 
 	"9" {

--- a/tools/topology/topology2/include/components/pipeline.conf
+++ b/tools/topology/topology2/include/components/pipeline.conf
@@ -13,6 +13,12 @@
 #
 # Where N is the unique instance number for pipeline widget in the same alsaconf node.
 
+Define {
+       # If KCPS value for the pipeline is 0 then the driver does not send any
+       # KCPS adjustment message to the firmware. This is the default.
+       KCPS_PIPELINE_DEFAULT	0
+}
+
 Class.Widget."pipeline" {
 	# pipeline_id for the pipeline widget
 	DefineAttribute."index" {}
@@ -104,6 +110,12 @@ Class.Widget."pipeline" {
 		}
 	}
 
+	# kcps requirements for the pipeline, default value defined bellow
+	DefineAttribute."kcps" {
+		# Token reference and type
+		token_ref	"sof_tkn_scheduler.word"
+	}
+
 	attributes {
 		# pipeline widget name will be constructed as pipeline.1, pipeline.2 etc
 		!constructor [
@@ -127,4 +139,5 @@ Class.Widget."pipeline" {
 	# Default attributes for pipeline
 	type 		"scheduler"
 	no_pm		"true"
+	kcps		$KCPS_PIPELINE_DEFAULT
 }


### PR DESCRIPTION
Adds kcps attribute to pipeline class with 400000 default value, and overrides the value in deepbuffer-playback pipeline with 50000.