### PR TITLE
Add xrun notification initialization

### DIFF
--- a/src/audio/Kconfig
+++ b/src/audio/Kconfig
@@ -34,6 +34,13 @@ config COMP_CHAIN_DMA
 	  help
 	    Chain DMA support in hardware
 
+config XRUN_NOTIFICATIONS_ENABLE
+	bool "Enable xrun notification"
+	default n
+	depends on IPC_MAJOR_4
+	help
+	  Enable xrun notifications sending to host
+
 config IPC4_GATEWAY
         bool "IPC4 Gateway"
         default y

--- a/src/ipc/ipc4/CMakeLists.txt
+++ b/src/ipc/ipc4/CMakeLists.txt
@@ -5,6 +5,7 @@ add_local_sources(sof
 	handler.c
 	helper.c
 	logging.c
+	notification.c
 )
 
 target_include_directories(sof_options INTERFACE ${PROJECT_SOURCE_DIR}/rimage/src/include)

--- a/src/ipc/ipc4/notification.c
+++ b/src/ipc/ipc4/notification.c
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright(c) 2023 Intel Corporation. All rights reserved.
+ *
+ * Author: Piotr Makaruk <piotr.makaruk@intel.com>
+ */
+
+#include <sof/common.h>
+#include <stdbool.h>
+#include <ipc4/notification.h>
+
+#if CONFIG_XRUN_NOTIFICATIONS_ENABLE
+void xrun_notif_msg_init(struct ipc_msg *msg_xrun, uint32_t resource_id, uint32_t event_type)
+{
+	struct ipc4_resource_event_data_notification *notif_data = msg_xrun->tx_data;
+	union ipc4_notification_header header;
+
+	header.r.notif_type = SOF_IPC4_NOTIFY_RESOURCE_EVENT;
+	header.r.type = SOF_IPC4_GLB_NOTIFICATION;
+	header.r.rsp = SOF_IPC4_MESSAGE_DIR_MSG_REQUEST;
+	header.r.msg_tgt = SOF_IPC4_MESSAGE_TARGET_FW_GEN_MSG;
+	msg_xrun->header = header.dat;
+
+	notif_data->resource_id = resource_id;
+	notif_data->event_type = event_type;
+	notif_data->resource_type = SOF_IPC4_GATEWAY;
+	memset(&notif_data->event_data, 0, sizeof(notif_data->event_data));
+}
+#endif

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -641,6 +641,7 @@ zephyr_library_sources_ifdef(CONFIG_IPC_MAJOR_4
 	${SOF_IPC_PATH}/ipc4/helper.c
 	${SOF_IPC_PATH}/ipc4/dai.c
 	${SOF_IPC_PATH}/ipc4/logging.c
+	${SOF_IPC_PATH}/ipc4/notification.c
 )
 
 zephyr_library_sources_ifdef(CONFIG_TRACE


### PR DESCRIPTION
- Add separate file for notifications initializations. All generic
initializations could be stored in one place
- Add initialization for generic xrun notification message which can be sent
by gateway.