### PR TITLE
module_adapter: support modules with input only

### DIFF
--- a/src/include/sof/audio/module_adapter/module/generic.h
+++ b/src/include/sof/audio/module_adapter/module/generic.h
@@ -153,6 +153,7 @@ struct module_data {
 	struct module_processing_data mpd; /**< shared data comp <-> module */
 	void *module_adapter; /**<loadable module interface handle */
 	uint32_t module_entry_point; /**<loadable module entry point address */
+	bool has_input_only; /**< flag to indicate that module has only input pin*/
 };
 
 /*


### PR DESCRIPTION
Current module adapter implementation doesn't support modules with input pin only, such as KD or other detectors.
This type of module just consumes data so there is no need to configure output processing buffer. 
Add parameter to `module_data` to configure input buffer but omit output buffer configuration.
