### PR TITLE
[DNM] imx: ipc: Clear IPC interrupt before registering it

### DIFF
--- a/src/drivers/imx/ipc.c
+++ b/src/drivers/imx/ipc.c
@@ -190,6 +190,8 @@ int platform_ipc_init(struct ipc *ipc)
 	}
 #endif
 
+	interrupt_clear(PLATFORM_IPC_INTERRUPT);
+
 	/* configure interrupt */
 	interrupt_register(PLATFORM_IPC_INTERRUPT, irq_handler, ipc);
 	interrupt_enable(PLATFORM_IPC_INTERRUPT, ipc);


### PR DESCRIPTION
After a suspend/resume cycle MU is reinitialized, but there might be an MU interrupt pending.

So, clear it in order to be able to receive next interrupts.