### PR TITLE
[SKIP CI] docker: upgrade to ubuntu 22.04 as a base image

### DIFF
--- a/scripts/docker-run.sh
+++ b/scripts/docker-run.sh
@@ -33,6 +33,8 @@ test "$(id -u)" = 1000 ||
   >&2 printf "Warning: this script should be run as user ID 1000 to match the container's account\n"
 
 set -x
+# FIXME: During the transition to sudo-cwd.sh, the tag will be "latest_ubuntu22.04".
+#       Later it will be back to latest
 docker run -i -v "${SOF_TOP}":/home/sof/work/sof.git \
 	-v "${SOF_TOP}":/home/sof/work/sof-bind-mount-DO-NOT-DELETE \
 	--env CMAKE_BUILD_TYPE \
@@ -42,6 +44,5 @@ docker run -i -v "${SOF_TOP}":/home/sof/work/sof.git \
 	--env VERBOSE \
 	--env http_proxy="$http_proxy" \
 	--env https_proxy="$https_proxy" \
-	--user "$(id -u)" \
 	$SOF_DOCKER_RUN \
-	thesofproject/sof "$@"
+	thesofproject/sof:latest_ubuntu22.04 ./scripts/sudo-cwd.sh "$@"

--- a/scripts/docker_build/sof_builder/Dockerfile
+++ b/scripts/docker_build/sof_builder/Dockerfile
@@ -14,8 +14,9 @@
 # docker run -it  -v <insert sof dir here>:/home/sof/work/sof.git --user `id -u` sof ./incremental.sh
 #
 
-FROM ubuntu:20.04
-ARG UID=1000
+FROM ubuntu:22.04
+# pick random high value to intentionally mismatch local UID
+ARG UID=1999
 
 ARG host_http_proxy
 ARG host_https_proxy
@@ -62,7 +63,11 @@ ARG CLONE_DEFAULTS="--depth 5"
 
 # Set up sof user
 RUN useradd --create-home -d /home/sof -u $UID -G sudo sof && \
+	echo 'sof ALL = NOPASSWD: ALL' > /etc/sudoers.d/sof && \
+	chmod 0440 /etc/sudoers.d/sof && \
 	echo "sof:test0000" | chpasswd && adduser sof sudo
+# allow others to read/traverse sof home
+RUN chmod o+rx /home/sof
 ENV HOME /home/sof
 
 # Use ToT alsa utils for the latest topology patches.


### PR DESCRIPTION
Upgrade Ubuntu to latest LTS version, 22.04.

This one line change is supposed to be enough but there is permission issue when UID is not matching with local UID.

```diff
-FROM ubuntu:20.04
+FROM ubuntu:22.04
```

All other lines are the fix for the permission issue.
