### PR TITLE
module_adapter: use type in abi header as config_id for IPC3

### DIFF
--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -742,9 +742,12 @@ static int module_adapter_set_params(struct comp_dev *dev, struct sof_ipc_ctrl_d
 			pos = MODULE_CFG_FRAGMENT_LAST;
 	}
 
-	/* IPC3 does not use config_id, so pass 0 for config ID as it will be ignored anyway */
+	/*
+	 * The type member in struct sof_abi_hdr is used for component's specific blob type
+	 * for IPC3, just like it is used for component's specific blob param_id for IPC4.
+	 */
 	if (md->ops->set_configuration)
-		return md->ops->set_configuration(mod, 0, pos, data_offset_size,
+		return md->ops->set_configuration(mod, cdata->data[0].type, pos, data_offset_size,
 						  (const uint8_t *)cdata->data[0].data,
 						  cdata->num_elems, NULL, 0);
 


### PR DESCRIPTION
The type member in struct sof_abi_hdr is used for component's specific blob type for IPC3, some module count on it to know the blob is for module config or module processing algorithm model. We should pass it to set_configuration ops.