### PR TITLE
ll-schedule: fix initial state handling on task free

### DIFF
--- a/src/schedule/zephyr_ll.c
+++ b/src/schedule/zephyr_ll.c
@@ -385,6 +385,8 @@ static int zephyr_ll_task_free(void *data, struct task *task)
 	 */
 	switch (task->state) {
 	case SOF_TASK_STATE_INIT:
+		must_wait = false;
+		break;
 	case SOF_TASK_STATE_FREE:
 		on_list = false;
 		/* fall through */


### PR DESCRIPTION
LL scheduler initial state require treatment in special case when task is already scheduled but not yet in running state. In that specific case it is on tasks list and it has to be deleted from it. Problem could arise when ipc stress tests are applied.