### PR TITLE
platform: ace: notifying about idle thread readiness

### DIFF
--- a/src/platform/intel/ace/platform.c
+++ b/src/platform/intel/ace/platform.c
@@ -24,6 +24,7 @@
 #include <ipc/info.h>
 #include <kernel/abi.h>
 #include <rtos/clk.h>
+#include <sof/lib/cpu.h>
 
 #include <sof_versions.h>
 #include <stdint.h>
@@ -74,6 +75,11 @@ int platform_boot_complete(uint32_t boot_message)
 	return ipc_platform_send_msg(&msg);
 }
 
+static struct pm_notifier pm_state_notifier = {
+	.state_entry = NULL,
+	.state_exit = cpu_notify_state_exit,
+};
+
 /* Runs on the primary core only */
 int platform_init(struct sof *sof)
 {
@@ -113,6 +119,9 @@ int platform_init(struct sof *sof)
 	ret = dmac_init(sof);
 	if (ret < 0)
 		return ret;
+
+	/* register power states entry / exit notifiers */
+	pm_notifier_register(&pm_state_notifier);
 
 	/* initialize the host IPC mechanisms */
 	trace_point(TRACE_BOOT_PLATFORM_IPC);

--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 3e02d48e4ead9978d10ee760c640bf55873f6e95
+      revision: aba3b12e311b4779338406fe3e7c4c54f655d0cd
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision

--- a/zephyr/include/sof/lib/cpu.h
+++ b/zephyr/include/sof/lib/cpu.h
@@ -20,9 +20,15 @@
 
 #include <stdbool.h>
 
-//#include <zephyr/sys/arch_interface.h>
-
 #include <zephyr/arch/arch_inlines.h>
+
+#if CONFIG_PM
+
+#include <zephyr/pm/pm.h>
+
+void cpu_notify_state_exit(enum pm_state state);
+
+#endif /* CONFIG_PM */
 
 /* let the compiler optimise when in single core mode */
 #if CONFIG_MULTICORE && CONFIG_SMP

--- a/zephyr/lib/cpu.c
+++ b/zephyr/lib/cpu.c
@@ -79,7 +79,13 @@ int cpu_enable_core(int id)
 		return 0;
 
 #if ZEPHYR_VERSION(3, 0, 99) <= ZEPHYR_VERSION_CODE
-	z_init_cpu(id);
+	/* During kernel initialization, the next pm state is set to ACTIVE. By checking this
+	 * value, we determine if this is the first core boot, if not, we need to skip idle thread
+	 * initialization. By reinitializing the idle thread, we would overwrite the kernel structs
+	 * and the idle thread stack.
+	 */
+	if (pm_state_next_get(id)->state == PM_STATE_ACTIVE)
+		z_init_cpu(id);
 #endif
 
 	atomic_clear(&start_flag);


### PR DESCRIPTION
Informing the primary core that the Idle thread on secondary core is ready. During the D3 exit flow thread is not initialize again, but restored from previously saved context.

Requires:

- [x] https://github.com/zephyrproject-rtos/zephyr/pull/55182