### PR TITLE
Tools: Topology2: Add high-pass IIR to SDW headset capture

### DIFF
--- a/tools/topology/topology2/cavs-sdw.conf
+++ b/tools/topology/topology2/cavs-sdw.conf
@@ -19,6 +19,7 @@
 <passthrough-capture.conf>
 <passthrough-be.conf>
 <passthrough-capture-be.conf>
+<highpass-capture-be.conf>
 <data.conf>
 <pcm.conf>
 <pcm_caps.conf>
@@ -187,7 +188,7 @@ Object.Pipeline {
 		}
 	]
 
-	passthrough-capture-be [
+	highpass-capture-be [
 		{
 			direction	"capture"
 			index 11
@@ -199,6 +200,11 @@ Object.Pipeline {
 				copier_type	"ALH"
 				type		"dai_out"
 				node_type $ALH_LINK_INPUT_CLASS
+			}
+			Object.Widget.eqiir.1 {
+				Object.Control.bytes."1" {
+					name '4 Main capture Iir Eq'
+				}
 			}
 		}
 	]
@@ -244,6 +250,10 @@ Object.Base.route [
 	}
 	{
 		source	"copier.ALH.11.1"
+		sink	"eqiir.11.1"
+	}
+	{
+		source	"eqiir.11.1"
 		sink	"copier.host.10.1"
 	}
 ]


### PR DESCRIPTION
    This patch changes the DAI passthrough pipeline in cavs-sdw.conf
    based topologies to similar pipeline but with IIR high-pass. The
    cut-off frequency is 40 Hz and gain is 0 dB. The same high-pass
    is used for HDA codec.
    
    The change suppresses most of DC signal pop noise from the
    beginning of capture or after press of headset button.
    
    The impacted topologies from current build are:
    
    cavs-sdw, mtl-sdw, sof-tgl-rt711-rt1316-rt714,
    sof-adl-rt711-l0-rt1316-l12-rt714-l3,
    sof-tgl-rt715-rt711-rt1308-mono, sof-tgl-rt711-rt1308-4ch,
    sof-adl-rt711-4ch, sof-mtl-rt711-4ch
 