### PR TITLE
clock: replace per-clock locks with a global one

### DIFF
--- a/src/platform/amd/rembrandt/lib/clk.c
+++ b/src/platform/amd/rembrandt/lib/clk.c
@@ -10,7 +10,6 @@
 #include <sof/lib/memory.h>
 #include <sof/lib/notifier.h>
 #include <rtos/sof.h>
-#include <rtos/spinlock.h>
 #include <platform/chip_registers.h>
 
 const struct freq_table platform_cpu_freq[] = {
@@ -139,6 +138,5 @@ void platform_clock_init(struct sof *sof)
 			.notification_mask = NOTIFIER_TARGET_CORE_MASK(i),
 			.set_freq = NULL,
 		};
-		k_spinlock_init(&sof->clocks[i].lock);
 	}
 }

--- a/src/platform/amd/renoir/lib/clk.c
+++ b/src/platform/amd/renoir/lib/clk.c
@@ -10,7 +10,6 @@
 #include <sof/lib/memory.h>
 #include <sof/lib/notifier.h>
 #include <rtos/sof.h>
-#include <rtos/spinlock.h>
 #include <platform/chip_registers.h>
 
 static struct freq_table platform_cpu_freq[] = {
@@ -135,6 +134,5 @@ void platform_clock_init(struct sof *sof)
 			.notification_mask = NOTIFIER_TARGET_CORE_MASK(i),
 			.set_freq = NULL,
 		};
-		k_spinlock_init(&sof->clocks[i].lock);
 	}
 }

--- a/src/platform/imx8/lib/clk.c
+++ b/src/platform/imx8/lib/clk.c
@@ -10,7 +10,6 @@
 #include <sof/lib/memory.h>
 #include <sof/lib/notifier.h>
 #include <rtos/sof.h>
-#include <rtos/spinlock.h>
 
 #ifdef __ZEPHYR__
 #include <zephyr/sys/util.h>
@@ -45,7 +44,5 @@ void platform_clock_init(struct sof *sof)
 			.notification_mask = NOTIFIER_TARGET_CORE_MASK(i),
 			.set_freq = NULL,
 		};
-
-		k_spinlock_init(&sof->clocks[i].lock);
 	}
 }

--- a/src/platform/imx8m/lib/clk.c
+++ b/src/platform/imx8m/lib/clk.c
@@ -9,7 +9,6 @@
 #include <sof/lib/memory.h>
 #include <sof/lib/notifier.h>
 #include <rtos/sof.h>
-#include <rtos/spinlock.h>
 
 #ifdef __ZEPHYR__
 #include <zephyr/sys/util.h>
@@ -40,7 +39,5 @@ void platform_clock_init(struct sof *sof)
 			.notification_mask = NOTIFIER_TARGET_CORE_MASK(i),
 			.set_freq = NULL,
 		};
-
-		k_spinlock_init(&sof->clocks[i].lock);
 	}
 }

--- a/src/platform/imx8ulp/lib/clk.c
+++ b/src/platform/imx8ulp/lib/clk.c
@@ -10,7 +10,6 @@
 #include <sof/lib/memory.h>
 #include <sof/lib/notifier.h>
 #include <rtos/sof.h>
-#include <rtos/spinlock.h>
 
 const struct freq_table platform_cpu_freq[] = {
 	{ 528000000, 528000 },
@@ -37,8 +36,6 @@ void platform_clock_init(struct sof *sof)
 			.notification_mask = NOTIFIER_TARGET_CORE_MASK(i),
 			.set_freq = NULL,
 		};
-
-		k_spinlock_init(&sof->clocks[i].lock);
 	}
 
 	platform_shared_commit(sof->clocks, sizeof(*sof->clocks) * NUM_CLOCKS);

--- a/src/platform/intel/ace/lib/clk.c
+++ b/src/platform/intel/ace/lib/clk.c
@@ -10,7 +10,6 @@
 #include <rtos/sof.h>
 #include <sof/common.h>
 #include <sof/lib/memory.h>
-#include <rtos/spinlock.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/clock_control.h>
 
@@ -40,7 +39,5 @@ void platform_clock_init(struct sof *sof)
 			.notification_mask = NOTIFIER_TARGET_CORE_MASK(i),
 			.set_freq = select_cpu_freq,
 		};
-
-		k_spinlock_init(&sof->clocks[i].lock);
 	}
 }

--- a/src/platform/intel/cavs/lib/clk.c
+++ b/src/platform/intel/cavs/lib/clk.c
@@ -76,24 +76,26 @@ static inline void select_cpu_clock_hw(int freq_idx, bool release_unused)
 }
 #endif
 
-static inline void select_cpu_clock(int freq_idx, bool release_unused)
+static void select_cpu_clock_unlocked(int freq_idx, bool release_unused)
 {
 	struct clock_info *clk_info = clocks_get();
-	k_spinlock_key_t key[CONFIG_CORE_COUNT];
 	int i;
-
-	/* lock clock for all cores */
-	for (i = 0; i < CONFIG_CORE_COUNT; i++)
-		key[i] = k_spin_lock(&clk_info[CLK_CPU(i)].lock);
 
 	/* change clock */
 	select_cpu_clock_hw(freq_idx, release_unused);
 	for (i = 0; i < CONFIG_CORE_COUNT; i++)
 		clk_info[CLK_CPU(i)].current_freq_idx = freq_idx;
+}
 
-	/* unlock clock for all cores */
-	for (i = CONFIG_CORE_COUNT - 1; i >= 0; i--)
-		k_spin_unlock(&clk_info[CLK_CPU(i)].lock, key[i]);
+static inline void select_cpu_clock(int freq_idx, bool release_unused)
+{
+	k_spinlock_key_t key;
+
+	key = clock_lock();
+
+	select_cpu_clock_unlocked(freq_idx, release_unused);
+
+	clock_unlock(key);
 }
 
 /* LPRO_ONLY mode */
@@ -302,7 +304,7 @@ void platform_clock_on_wakeup(void)
 
 static int clock_platform_set_cpu_freq(int clock, int freq_idx)
 {
-	set_cpu_current_freq_idx(freq_idx, true);
+	select_cpu_clock_unlocked(freq_idx, true);
 	return 0;
 }
 
@@ -338,9 +340,9 @@ void platform_clock_init(struct sof *sof)
 			.set_freq = clock_platform_set_cpu_freq,
 			.low_power_mode = platform_clock_low_power_mode,
 		};
-
-		k_spinlock_init(&sof->clocks[i].lock);
 	}
+
+	k_spinlock_init(&clk_lock);
 
 	sof->clocks[CLK_SSP] = (struct clock_info) {
 		.freqs_num = NUM_SSP_FREQ,
@@ -351,6 +353,4 @@ void platform_clock_init(struct sof *sof)
 		.notification_mask = NOTIFIER_TARGET_CORE_ALL_MASK,
 		.set_freq = NULL,
 	};
-
-	k_spinlock_init(&sof->clocks[CLK_SSP].lock);
 }

--- a/src/platform/mt8186/lib/clk.c
+++ b/src/platform/mt8186/lib/clk.c
@@ -8,7 +8,6 @@
 
 #include <platform/drivers/mt_reg_base.h>
 #include <rtos/clk.h>
-#include <rtos/spinlock.h>
 #include <rtos/wait.h>
 #include <sof/common.h>
 #include <sof/lib/cpu.h>
@@ -150,8 +149,6 @@ void platform_clock_init(struct sof *sof)
 			.notification_mask = NOTIFIER_TARGET_CORE_MASK(i),
 			.set_freq = clock_platform_set_dsp_freq,
 		};
-
-		k_spinlock_init(&sof->clocks[i].lock);
 	}
 
 	clock_set_freq(CLK_CPU(cpu_get_id()), CLK_MAX_CPU_HZ);

--- a/src/platform/mt8188/lib/clk.c
+++ b/src/platform/mt8188/lib/clk.c
@@ -8,7 +8,6 @@
 
 #include <platform/drivers/mt_reg_base.h>
 #include <rtos/clk.h>
-#include <rtos/spinlock.h>
 #include <rtos/wait.h>
 #include <sof/common.h>
 #include <sof/lib/cpu.h>
@@ -138,8 +137,6 @@ void platform_clock_init(struct sof *sof)
 			.notification_mask = NOTIFIER_TARGET_CORE_MASK(i),
 			.set_freq = clock_platform_set_dsp_freq,
 		};
-
-		k_spinlock_init(&sof->clocks[i].lock);
 	}
 
 	clock_set_freq(CLK_CPU(cpu_get_id()), CLK_MAX_CPU_HZ);

--- a/src/platform/mt8195/lib/clk.c
+++ b/src/platform/mt8195/lib/clk.c
@@ -13,7 +13,6 @@
 #include <sof/lib/uuid.h>
 #include <rtos/wait.h>
 #include <rtos/sof.h>
-#include <rtos/spinlock.h>
 
 DECLARE_SOF_UUID("clkdrv", clkdrv_uuid, 0x23b12fd5, 0xc2a9, 0x41a8,
 		 0xa2, 0xb3, 0x23, 0x1a, 0xb7, 0xdc, 0xdc, 0x70);
@@ -191,8 +190,6 @@ void platform_clock_init(struct sof *sof)
 			.notification_mask = NOTIFIER_TARGET_CORE_MASK(i),
 			.set_freq = clock_platform_set_cpu_freq,
 		};
-
-		k_spinlock_init(&sof->clocks[i].lock);
 	}
 
 	adsp_clock = 0;

--- a/xtos/include/rtos/clk.h
+++ b/xtos/include/rtos/clk.h
@@ -41,9 +41,8 @@ struct clock_info {
 	uint32_t lowest_freq_idx;	/* lowest possible clock */
 	uint32_t notification_id;
 	uint32_t notification_mask;
-	struct k_spinlock lock;
 
-	/* persistent change clock value in active state */
+	/* persistent change clock value in active state, caller must hold clk_lock */
 	int (*set_freq)(int clock, int freq_idx);
 
 	/* temporary change clock - don't modify default clock settings */
@@ -63,6 +62,18 @@ uint64_t clock_us_to_ticks(int clock, uint64_t us);
 uint64_t clock_ns_to_ticks(int clock, uint64_t ns);
 
 uint64_t clock_ticks_per_sample(int clock, uint32_t sample_rate);
+
+extern struct k_spinlock clk_lock;
+
+static inline k_spinlock_key_t clock_lock(void)
+{
+	return k_spin_lock(&clk_lock);
+}
+
+static inline void clock_unlock(k_spinlock_key_t key)
+{
+	k_spin_unlock(&clk_lock, key);
+}
 
 static inline struct clock_info *clocks_get(void)
 {

--- a/zephyr/include/rtos/clk.h
+++ b/zephyr/include/rtos/clk.h
@@ -44,9 +44,8 @@ struct clock_info {
 	uint32_t lowest_freq_idx;	/* lowest possible clock */
 	uint32_t notification_id;
 	uint32_t notification_mask;
-	struct k_spinlock lock;
 
-	/* persistent change clock value in active state */
+	/* persistent change clock value in active state, caller must hold clk_lock */
 	int (*set_freq)(int clock, int freq_idx);
 
 	/* temporary change clock - don't modify default clock settings */
@@ -60,6 +59,18 @@ void clock_set_freq(int clock, uint32_t hz);
 void clock_low_power_mode(int clock, bool enable);
 
 uint64_t clock_ticks_per_sample(int clock, uint32_t sample_rate);
+
+extern struct k_spinlock clk_lock;
+
+static inline k_spinlock_key_t clock_lock(void)
+{
+	return k_spin_lock(&clk_lock);
+}
+
+static inline void clock_unlock(k_spinlock_key_t key)
+{
+	k_spin_unlock(&clk_lock, key);
+}
 
 static inline struct clock_info *clocks_get(void)
 {


### PR DESCRIPTION
select_cpu_clock() on cAVS currently takes all the clock locks while adjusting them. And that function is called from clock_set_freq() which also takes one of those locks, which leads to a recursive spin-lock. To fix that remove per-clock spin-locks and use a global clock lock instead.