### PR TITLE
Revert "hda: chain dma: cancel task before freeing it"

### DIFF
--- a/src/audio/chain_dma.c
+++ b/src/audio/chain_dma.c
@@ -339,7 +339,6 @@ static int chain_task_pause(struct comp_dev *dev)
 
 	k_spin_unlock(&drivers->lock, key);
 
-	schedule_task_cancel(&cd->chain_task);
 	schedule_task_free(&cd->chain_task);
 	pm_policy_state_lock_put(PM_STATE_RUNTIME_IDLE, PM_ALL_SUBSTATES);
 


### PR DESCRIPTION
This was not the correct fix for the ll timer free crash issue. Now that the correct fix[1] is found and merged, this workaround can be removed.

[1] b3a808afa8c7 "chain-dma: fix scheduling exception"

This reverts commit 60e9e97e0df842c3030c0772b02120c807f6721a.

This should not be merged before https://github.com/thesofproject/sof/pull/7138 is in.