### PR TITLE
peakvol: add peak-meter attenuation adjustment

### DIFF
--- a/src/audio/module_adapter/module/volume/volume.c
+++ b/src/audio/module_adapter/module/volume/volume.c
@@ -1173,7 +1173,7 @@ static int volume_process(struct processing_module *mod,
 		}
 
 		/* copy and scale volume */
-		cd->scale_vol(mod, &input_buffers[0], &output_buffers[0], frames);
+		cd->scale_vol(mod, &input_buffers[0], &output_buffers[0], frames, cd->attenuation);
 
 		if (cd->vol_ramp_active)
 			cd->vol_ramp_elapsed_frames += frames;

--- a/src/audio/module_adapter/module/volume/volume_generic.c
+++ b/src/audio/module_adapter/module/volume/volume_generic.c
@@ -51,12 +51,14 @@ static inline int32_t vol_mult_s24_to_s24(int32_t x, int32_t vol)
  * \param[in,out] sink Destination buffer.
  * \param[in,out] source Input buffer.
  * \param[in] frames Number of frames to process.
+ * \param[in] attenuation factor for peakmeter adjustment (unused)
  *
  * Copy and scale volume from 24/32 bit source buffer
  * to 24/32 bit destination buffer.
  */
 static void vol_s24_to_s24(struct processing_module *mod, struct input_stream_buffer *bsource,
-			   struct output_stream_buffer *bsink, uint32_t frames)
+			   struct output_stream_buffer *bsink, uint32_t frames,
+			   uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
 	struct audio_stream __sparse_cache *source = bsource->data;
@@ -100,12 +102,14 @@ static void vol_s24_to_s24(struct processing_module *mod, struct input_stream_bu
  * \param[in,out] sink Destination buffer.
  * \param[in,out] source Input buffer.
  * \param[in] frames Number of frames to process.
+ * \param[in] attenuation factor for peakmeter adjustment (unused)
  *
  * Copy and scale volume from 32 bit source buffer
  * to 32 bit destination buffer.
  */
 static void vol_s32_to_s32(struct processing_module *mod, struct input_stream_buffer *bsource,
-			   struct output_stream_buffer *bsink, uint32_t frames)
+			   struct output_stream_buffer *bsink, uint32_t frames,
+			   uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
 	struct audio_stream __sparse_cache *source = bsource->data;
@@ -152,12 +156,14 @@ static void vol_s32_to_s32(struct processing_module *mod, struct input_stream_bu
  * \param[in,out] sink Destination buffer.
  * \param[in,out] source Input buffer.
  * \param[in] frames Number of frames to process.
+ * \param[in] attenuation factor for peakmeter adjustment (unused)
  *
  * Copy and scale volume from 16 bit source buffer
  * to 16 bit destination buffer.
  */
 static void vol_s16_to_s16(struct processing_module *mod, struct input_stream_buffer *bsource,
-			   struct output_stream_buffer *bsink, uint32_t frames)
+			   struct output_stream_buffer *bsink, uint32_t frames,
+			   uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
 	struct audio_stream __sparse_cache *source = bsource->data;

--- a/src/audio/module_adapter/module/volume/volume_generic_with_peakvol.c
+++ b/src/audio/module_adapter/module/volume/volume_generic_with_peakvol.c
@@ -47,12 +47,14 @@ static inline int32_t vol_mult_s24_to_s24(int32_t x, int32_t vol)
  * \param[in,out] sink Destination buffer.
  * \param[in,out] source Input buffer.
  * \param[in] frames Number of frames to process.
+ * \param[in] attenuation factor for peakmeter adjustment
  *
  * Copy and scale volume from 24/32 bit source buffer
  * to 24/32 bit destination buffer.
  */
 static void vol_s24_to_s24(struct processing_module *mod, struct input_stream_buffer *bsource,
-			   struct output_stream_buffer *bsink, uint32_t frames)
+			   struct output_stream_buffer *bsink, uint32_t frames,
+			   uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
 	struct audio_stream __sparse_cache *source = bsource->data;
@@ -85,6 +87,7 @@ static void vol_s24_to_s24(struct processing_module *mod, struct input_stream_bu
 				y0[i] = vol_mult_s24_to_s24(x0[i], vol);
 				tmp = MAX(abs(x0[i]), tmp);
 			}
+			tmp = tmp << attenuation;
 			cd->peak_regs.peak_meter[j] = MAX(tmp, cd->peak_regs.peak_meter[j]);
 		}
 		remaining_samples -= n;
@@ -103,12 +106,14 @@ static void vol_s24_to_s24(struct processing_module *mod, struct input_stream_bu
  * \param[in,out] sink Destination buffer.
  * \param[in,out] source Input buffer.
  * \param[in] frames Number of frames to process.
+ * \param[in] attenuation factor for peakmeter adjustment
  *
  * Copy and scale volume from 32 bit source buffer
  * to 32 bit destination buffer.
  */
 static void vol_s32_to_s32(struct processing_module *mod, struct input_stream_buffer *bsource,
-			   struct output_stream_buffer *bsink, uint32_t frames)
+			   struct output_stream_buffer *bsink, uint32_t frames,
+			   uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
 	struct audio_stream __sparse_cache *source = bsource->data;
@@ -144,6 +149,7 @@ static void vol_s32_to_s32(struct processing_module *mod, struct input_stream_bu
 							   Q_SHIFT_BITS_64(31, VOL_QXY_Y, 31));
 				tmp = MAX(abs(x0[i]), tmp);
 			}
+			tmp = tmp << attenuation;
 			cd->peak_regs.peak_meter[j] = MAX(tmp, cd->peak_regs.peak_meter[j]);
 		}
 		remaining_samples -= n;
@@ -163,12 +169,14 @@ static void vol_s32_to_s32(struct processing_module *mod, struct input_stream_bu
  * \param[in,out] sink Destination buffer.
  * \param[in,out] source Input buffer.
  * \param[in] frames Number of frames to process.
+ * \param[in] attenuation factor for peakmeter adjustment (unused for 16bit)
  *
  * Copy and scale volume from 16 bit source buffer
  * to 16 bit destination buffer.
  */
 static void vol_s16_to_s16(struct processing_module *mod, struct input_stream_buffer *bsource,
-			   struct output_stream_buffer *bsink, uint32_t frames)
+			   struct output_stream_buffer *bsink, uint32_t frames,
+			   uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
 	struct audio_stream __sparse_cache *source = bsource->data;

--- a/src/audio/module_adapter/module/volume/volume_hifi3.c
+++ b/src/audio/module_adapter/module/volume/volume_hifi3.c
@@ -52,9 +52,11 @@ static void vol_store_gain(struct vol_data *cd, const int channels_count)
  * \param[in,out] sink Destination buffer.
  * \param[in,out] source Input buffer.
  * \param[in] frames Number of frames to process.
+ * \param[in] attenuation factor for peakmeter adjustment (unused)
  */
 static void vol_s24_to_s24_s32(struct processing_module *mod, struct input_stream_buffer *bsource,
-			       struct output_stream_buffer *bsink, uint32_t frames)
+			       struct output_stream_buffer *bsink, uint32_t frames,
+			       uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
 	struct audio_stream __sparse_cache *source = bsource->data;
@@ -137,9 +139,11 @@ static void vol_s24_to_s24_s32(struct processing_module *mod, struct input_strea
  * \param[in,out] sink Destination buffer.
  * \param[in,out] source Input buffer.
  * \param[in] frames Number of frames to process.
+ * \param[in] attenuation factor for peakmeter adjustment (unused)
  */
 static void vol_s32_to_s24_s32(struct processing_module *mod, struct input_stream_buffer *bsource,
-			       struct output_stream_buffer *bsink, uint32_t frames)
+			       struct output_stream_buffer *bsink, uint32_t frames,
+			       uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
 	struct audio_stream __sparse_cache *source = bsource->data;
@@ -227,9 +231,11 @@ static void vol_s32_to_s24_s32(struct processing_module *mod, struct input_strea
  * \param[in,out] sink Destination buffer.
  * \param[in,out] source Input buffer.
  * \param[in] frames Number of frames to process.
+ * \param[in] attenuation factor for peakmeter adjustment (unused)
  */
 static void vol_s16_to_s16(struct processing_module *mod, struct input_stream_buffer *bsource,
-			   struct output_stream_buffer *bsink, uint32_t frames)
+			   struct output_stream_buffer *bsink, uint32_t frames,
+			   uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
 	struct audio_stream __sparse_cache *source = bsource->data;

--- a/src/audio/module_adapter/module/volume/volume_hifi3_with_peakvol.c
+++ b/src/audio/module_adapter/module/volume/volume_hifi3_with_peakvol.c
@@ -47,9 +47,11 @@ static inline void vol_store_gain(struct vol_data *cd, const int channels_count)
  * \param[in,out] sink Destination buffer.
  * \param[in,out] source Input buffer.
  * \param[in] frames Number of frames to process.
+ * \param[in] attenuation factor for peakmeter adjustment
  */
 static void vol_s24_to_s24_s32(struct processing_module *mod, struct input_stream_buffer *bsource,
-			       struct output_stream_buffer *bsink, uint32_t frames)
+			       struct output_stream_buffer *bsink, uint32_t frames,
+			       uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
 	struct audio_stream __sparse_cache *source = bsource->data;
@@ -130,7 +132,7 @@ static void vol_s24_to_s24_s32(struct processing_module *mod, struct input_strea
 	}
 	for (i = 0; i < channels_count; i++)
 		cd->peak_regs.peak_meter[i] = MAX(cd->peak_vol[i],
-						  cd->peak_vol[i + channels_count]);
+						  cd->peak_vol[i + channels_count]) << attenuation;
 	/* update peak vol */
 	peak_vol_update(cd);
 }
@@ -143,9 +145,11 @@ static void vol_s24_to_s24_s32(struct processing_module *mod, struct input_strea
  * \param[in,out] sink Destination buffer.
  * \param[in,out] source Input buffer.
  * \param[in] frames Number of frames to process.
+ * \param[in] attenuation factor for peakmeter adjustment
  */
 static void vol_s32_to_s24_s32(struct processing_module *mod, struct input_stream_buffer *bsource,
-			       struct output_stream_buffer *bsink, uint32_t frames)
+			       struct output_stream_buffer *bsink, uint32_t frames,
+			       uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
 	struct audio_stream __sparse_cache *source = bsource->data;
@@ -235,7 +239,8 @@ static void vol_s32_to_s24_s32(struct processing_module *mod, struct input_strea
 	}
 	for (i = 0; i < channels_count; i++)
 		cd->peak_regs.peak_meter[i] = MAX(cd->peak_vol[i],
-						  cd->peak_vol[i + channels_count]);
+						  cd->peak_vol[i + channels_count]) << attenuation;
+
 	/* update peak vol */
 	peak_vol_update(cd);
 }
@@ -248,9 +253,11 @@ static void vol_s32_to_s24_s32(struct processing_module *mod, struct input_strea
  * \param[in,out] sink Destination buffer.
  * \param[in,out] source Input buffer.
  * \param[in] frames Number of frames to process.
+ * \param[in] attenuation factor for peakmeter adjustment (unused for 16bit)
  */
 static void vol_s16_to_s16(struct processing_module *mod, struct input_stream_buffer *bsource,
-			   struct output_stream_buffer *bsink, uint32_t frames)
+			   struct output_stream_buffer *bsink, uint32_t frames,
+			   uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
 	struct audio_stream __sparse_cache *source = bsource->data;
@@ -369,9 +376,11 @@ static void vol_s16_to_s16(struct processing_module *mod, struct input_stream_bu
  * \param[in,out] sink Destination buffer.
  * \param[in,out] source Input buffer.
  * \param[in] frames Number of frames to process.
+ * \param[in] attenuation factor for peakmeter adjustment
  */
 static void vol_s24_to_s24_s32(struct processing_module *mod, struct input_stream_buffer *bsource,
-			       struct output_stream_buffer *bsink, uint32_t frames)
+			       struct output_stream_buffer *bsink, uint32_t frames,
+			       uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
 	struct audio_stream __sparse_cache *source = bsource->data;
@@ -427,6 +436,7 @@ static void vol_s24_to_s24_s32(struct processing_module *mod, struct input_strea
 				/* Store the output sample */
 				AE_S32_L_XP(out_sample, out, inc);
 			}
+			peak_vol = AE_SLAA32S(peak_vol, attenuation);
 			peak_meter[channel] = AE_MAX32(peak_vol, peak_meter[channel]);
 		}
 		samples -= n;
@@ -445,9 +455,11 @@ static void vol_s24_to_s24_s32(struct processing_module *mod, struct input_strea
  * \param[in,out] sink Destination buffer.
  * \param[in,out] source Input buffer.
  * \param[in] frames Number of frames to process.
+ * \param[in] attenuation factor for peakmeter adjustment
  */
 static void vol_s32_to_s24_s32(struct processing_module *mod, struct input_stream_buffer *bsource,
-			       struct output_stream_buffer *bsink, uint32_t frames)
+			       struct output_stream_buffer *bsink, uint32_t frames,
+			       uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
 	struct audio_stream __sparse_cache *source = bsource->data;
@@ -503,6 +515,7 @@ static void vol_s32_to_s24_s32(struct processing_module *mod, struct input_strea
 #endif
 				AE_S32_L_XP(out_sample, out, inc);
 			}
+			peak_vol = AE_SLAA32S(peak_vol, attenuation);
 			peak_meter[channel] = AE_MAX32(peak_vol, peak_meter[channel]);
 		}
 		samples -= n;
@@ -521,9 +534,11 @@ static void vol_s32_to_s24_s32(struct processing_module *mod, struct input_strea
  * \param[in,out] sink Destination buffer.
  * \param[in,out] source Input buffer.
  * \param[in] frames Number of frames to process.
+ * \param[in] attenuation factor for peakmeter adjustment (unused for 16bit)
  */
 static void vol_s16_to_s16(struct processing_module *mod, struct input_stream_buffer *bsource,
-			   struct output_stream_buffer *bsink, uint32_t frames)
+			   struct output_stream_buffer *bsink, uint32_t frames,
+			   uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
 	struct audio_stream __sparse_cache *source = bsource->data;

--- a/src/include/sof/audio/volume.h
+++ b/src/include/sof/audio/volume.h
@@ -160,6 +160,7 @@ struct vol_data {
 	vol_zc_func zc_get;			/**< function getting nearest zero crossing frame */
 	vol_ramp_func ramp_func;		/**< function for ramp shape */
 	bool copy_gain;				/**< control copy gain or not */
+	uint32_t attenuation;			/**< peakmeter adjustment in range [0 - 31] */
 };
 
 /** \brief Volume processing functions map. */

--- a/src/include/sof/audio/volume.h
+++ b/src/include/sof/audio/volume.h
@@ -113,7 +113,7 @@ struct sof_ipc_ctrl_value_chan;
  * \brief volume processing function interface
  */
 typedef void (*vol_scale_func)(struct processing_module *mod, struct input_stream_buffer *source,
-			       struct output_stream_buffer *sink, uint32_t frames);
+			struct output_stream_buffer *sink, uint32_t frames, uint32_t attenuation);
 
 /**
  * \brief volume interface for function getting nearest zero crossing frame

--- a/test/cmocka/src/audio/volume/volume_process.c
+++ b/test/cmocka/src/audio/volume/volume_process.c
@@ -282,7 +282,7 @@ static void test_audio_vol(void **state)
 	vol_state->output_buffers[0]->size = 0;
 
 	cd->scale_vol(mod, vol_state->input_buffers[0], vol_state->output_buffers[0],
-		      mod->dev->frames);
+		      mod->dev->frames, cd->attenuation);
 
 	vol_state->verify(mod, vol_state->sinks[0], vol_state->sources[0]);
 }


### PR DESCRIPTION
Add support for LargeConfigSet:SET_ATTENUATION IPC.

The purpose is to add attenuation adjustment for peak-meter.
To properly mix multiple streams without saturation, driver configures
attenuation to the input copier of each playback stream that is going
to be mixed into one output stream. In some topologies, PeakVol is
placed behind the copier with attenuation, hence its peak-meter value
is artificially scaled by FW. To report valid peak-meter value, FW has to
adjust the measurement by reverting attenuation provided in copier.

![image](https://user-images.githubusercontent.com/93585043/222731261-ddd8f51b-1a69-4e95-82cb-14f87b8721b9.png)


Missing implementation of SET_ATTENUATION for peak-meter blocks all Windows playback scenarios.

