### PR TITLE
copier: fix format check for set_attenuation

### DIFF
--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -1484,7 +1484,7 @@ static int set_attenuation(struct comp_dev *dev, uint32_t data_offset, const cha
 
 	list_for_item(sink_list, &dev->bsink_list) {
 		sink = container_of(sink_list, struct comp_buffer, source_list);
-		if (sink->buffer_fmt < SOF_IPC_FRAME_S24_4LE) {
+		if (sink->stream.frame_fmt < SOF_IPC_FRAME_S24_4LE) {
 			comp_err(dev, "sink %d in format %d isn't supported by attenuation",
 				 sink->id, sink->buffer_fmt);
 			return -EINVAL;


### PR DESCRIPTION
Fix format validation in set_attenuation function.

In previus implementation, bitdepth was compared to sink->buffer_fmt value, which is an enum sof_ipc_buffer_format (interleaved or not).

Format bitdepth is represented by stream.frame_fmt (enum sof_ipc_frame), so it should be compared to this value.