### PR TITLE
Fix "failed to find dai comp or sink pipeline not running."

### DIFF
--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -543,6 +543,7 @@ e_buf:
 }
 #endif
 
+/* Playback only */
 static int init_pipeline_reg(struct comp_dev *dev)
 {
 	struct copier_data *cd = comp_get_drvdata(dev);
@@ -945,6 +946,7 @@ static int copier_comp_trigger(struct comp_dev *dev, int cmd)
 			break;
 	}
 
+	/* For capture cd->pipeline_reg_offset == 0 */
 	if (ret < 0 || !cd->endpoint_num || !cd->pipeline_reg_offset)
 		return ret;
 

--- a/src/audio/host-legacy.c
+++ b/src/audio/host-legacy.c
@@ -1061,7 +1061,7 @@ static uint64_t host_get_processed_data(struct comp_dev *dev, uint32_t stream_no
 {
 	struct host_data *hd = comp_get_drvdata(dev);
 	uint64_t ret = 0;
-	bool source = dev->direction == SOF_IPC_STREAM_CAPTURE;
+	bool source = dev->direction == SOF_IPC_STREAM_PLAYBACK;
 
 	/* Return value only if direction and stream number match.
 	 * The host supports only one stream.

--- a/src/audio/host-zephyr.c
+++ b/src/audio/host-zephyr.c
@@ -1130,7 +1130,7 @@ static uint64_t host_get_processed_data(struct comp_dev *dev, uint32_t stream_no
 {
 	struct host_data *hd = comp_get_drvdata(dev);
 	uint64_t ret = 0;
-	bool source = dev->direction == SOF_IPC_STREAM_CAPTURE;
+	bool source = dev->direction == SOF_IPC_STREAM_PLAYBACK;
 
 	/* Return value only if direction and stream number match.
 	 * The host supports only one stream.

--- a/src/audio/pipeline/pipeline-graph.c
+++ b/src/audio/pipeline/pipeline-graph.c
@@ -486,7 +486,7 @@ struct comp_dev *pipeline_get_dai_comp(uint32_t pipeline_id, int dir)
 }
 
 #if CONFIG_IPC_MAJOR_4
-/* visit connected pipeline to find the dai comp and latency.
+/* Playback only: visit connected pipeline to find the dai comp and latency.
  * This function walks down through a pipelines chain looking for the target dai component.
  * Calculates the delay of each pipeline by determining the number of buffered blocks.
  */
@@ -521,8 +521,6 @@ struct comp_dev *pipeline_get_dai_comp_latency(uint32_t pipeline_id, uint32_t *l
 		/* Calculate pipeline latency */
 		input_data = comp_get_total_data_processed(source, 0, true);
 		output_data = comp_get_total_data_processed(ipc_sink->cd, 0, false);
-		if (!input_data || !output_data)
-			return NULL;
 
 		ret = comp_get_attribute(source, COMP_ATTR_BASE_CONFIG, &input_base_cfg);
 		if (ret < 0)
@@ -532,11 +530,13 @@ struct comp_dev *pipeline_get_dai_comp_latency(uint32_t pipeline_id, uint32_t *l
 		if (ret < 0)
 			return NULL;
 
-		*latency += input_data / input_base_cfg.ibs - output_data / output_base_cfg.obs;
+		if (input_data && output_data)
+			*latency += input_data / input_base_cfg.ibs -
+				output_data / output_base_cfg.obs;
 
-		/* If the component doesn't have a sink buffer, this is a dai. */
+		/* If the component doesn't have a sink buffer, it can be a dai. */
 		if (list_is_empty(&ipc_sink->cd->bsink_list))
-			return ipc_sink->cd;
+			return dev_comp_type(ipc_sink->cd) == SOF_COMP_DAI ? ipc_sink->cd : NULL;
 
 		/* Get a component connected to our sink buffer - hop to a next pipeline */
 		buffer = buffer_from_list(comp_buffer_list(ipc_sink->cd, PPL_DIR_DOWNSTREAM)->next,
@@ -544,7 +544,7 @@ struct comp_dev *pipeline_get_dai_comp_latency(uint32_t pipeline_id, uint32_t *l
 		source = buffer_get_comp(buffer, PPL_DIR_DOWNSTREAM);
 
 		/* buffer_comp is in another pipeline and it is not complete */
-		if (!source->pipeline)
+		if (!source || !source->pipeline)
 			return NULL;
 
 		/* Get a next sink component */

--- a/src/audio/pipeline/pipeline-graph.c
+++ b/src/audio/pipeline/pipeline-graph.c
@@ -514,8 +514,8 @@ struct comp_dev *pipeline_get_dai_comp_latency(uint32_t pipeline_id, uint32_t *l
 	while (ipc_sink) {
 		struct comp_buffer *buffer;
 		uint64_t input_data, output_data;
-		struct ipc4_base_module_cfg input_base_cfg;
-		struct ipc4_base_module_cfg output_base_cfg;
+		struct ipc4_base_module_cfg input_base_cfg = {.ibs = 0};
+		struct ipc4_base_module_cfg output_base_cfg = {.obs = 0};
 		int ret;
 
 		/* Calculate pipeline latency */
@@ -530,7 +530,7 @@ struct comp_dev *pipeline_get_dai_comp_latency(uint32_t pipeline_id, uint32_t *l
 		if (ret < 0)
 			return NULL;
 
-		if (input_data && output_data)
+		if (input_data && output_data && input_base_cfg.ibs && output_base_cfg.obs)
 			*latency += input_data / input_base_cfg.ibs -
 				output_data / output_base_cfg.obs;
 


### PR DESCRIPTION
The "failed to find dai comp or sink pipeline not running." error message has been bugging SOF developers since a long time without causing any apparent problems. Finally root-cause it and fix the underlying problem.