### PR TITLE
[SKIP CI] .github/sparse-zephyr: add missing workflow_call to fix daily tests

### DIFF
--- a/.github/workflows/sparse-zephyr.yml
+++ b/.github/workflows/sparse-zephyr.yml
@@ -5,7 +5,7 @@ name: Sparse Zephyr
 # 'workflow_dispatch' allows running this workflow manually from the
 # 'Actions' tab
 # yamllint disable-line rule:truthy
-on: [push, pull_request, workflow_dispatch]
+on: [push, pull_request, workflow_dispatch, workflow_call]
 
 jobs:
   # As of sparse commit ce1a6720f69e / Sept 2022, the exit status of


### PR DESCRIPTION
Fixes commit 98b4625a0d8d (".github/daily-tests.yml: add sparse-zephyr.yml") and daily tests which just started failing as found by @aborisovich in
https://github.com/thesofproject/sof/actions/runs/4333619550 and others (thanks!).