### PR TITLE
topology: sof-adl-nau8825: add variant with nau8318 amplifier

### DIFF
--- a/tools/topology/topology1/CMakeLists.txt
+++ b/tools/topology/topology1/CMakeLists.txt
@@ -179,6 +179,7 @@ set(TPLGS
 	"sof-adl-nau8825\;sof-adl-max98360a-nau8825\;-DCODEC=MAX98360A\;-DFMT=s16le\;-DAMP_SSP=1\;-DBT_OFFLOAD\;-DSPK_MIC_PERIOD_US=10000"
 	"sof-adl-nau8825\;sof-adl-rt1019-nau8825\;-DCODEC=RT1019P\;-DFMT=s16le\;-DAMP_SSP=2\;-DSPK_MIC_PERIOD_US=10000"
 	"sof-adl-nau8825\;sof-adl-rt1015-nau8825\;-DCODEC=RT1015P\;-DFMT=s32le\;-DAMP_SSP=1\;-DBT_OFFLOAD\;-DSPK_MIC_PERIOD_US=10000"
+	"sof-adl-nau8825\;sof-adl-nau8318-nau8825\;-DCODEC=NAU8318\;-DFMT=s16le\;-DAMP_SSP=1\;-DBT_OFFLOAD\;-DSPK_MIC_PERIOD_US=10000"
 	"sof-tgl-sdw-max98373-rt5682\;sof-tgl-sdw-max98373-rt5682\;-DCHANNELS=4\;-DPLATFORM=tgl"
 	"sof-tgl-sdw-max98373-rt5682\;sof-adl-sdw-max98373-rt5682\;-DCHANNELS=4\;-DPLATFORM=adl"
 	"sof-jsl-da7219\;sof-jsl-da7219\;-DPLATFORM=jsl"

--- a/tools/topology/topology1/sof-adl-nau8825.m4
+++ b/tools/topology/topology1/sof-adl-nau8825.m4
@@ -384,6 +384,12 @@ ifelse(
                 SSP_CLOCK(fsync, 48000, codec_slave),
                 SSP_TDM(2, 32, 3, 3),
                 SSP_CONFIG_DATA(SSP, SPK_SSP_INDEX, 32)))',
+	CODEC, `NAU8318', `
+        SSP_CONFIG(I2S, SSP_CLOCK(mclk, SSP_MCLK, codec_mclk_in),
+                SSP_CLOCK(bclk, 1536000, codec_slave),
+                SSP_CLOCK(fsync, 48000, codec_slave),
+                SSP_TDM(2, 16, 3, 3),
+                SSP_CONFIG_DATA(SSP, SPK_SSP_INDEX, 16)))',
 )')')
 
 DEBUG_END


### PR DESCRIPTION
Adding support for nau8318 Amplifier.

sof-adl-nau8318-nau8825:
    nau8825 headphone connects SSP0 link.
    nau8318 Amp speakers connects SSP1 link.
    bluetooth offload uses SSP2 link.

Signed-off-by: Ajye Huang <ajye_huang@compal.corp-partner.google.com>
Signed-off-by: Mac Chiang <mac.chiang@intel.com>
(cherry picked from commit cdcbdae705a42578dc99d6bf54f275c699afbc81)