### PR TITLE
[TEST ONLY][DNM][DNR] pipeline: handle failed latency calculation

### DIFF
--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -543,6 +543,7 @@ e_buf:
 }
 #endif
 
+/* Playback only */
 static int init_pipeline_reg(struct comp_dev *dev)
 {
 	struct copier_data *cd = comp_get_drvdata(dev);
@@ -945,6 +946,7 @@ static int copier_comp_trigger(struct comp_dev *dev, int cmd)
 			break;
 	}
 
+	/* For capture cd->pipeline_reg_offset == 0 */
 	if (ret < 0 || !cd->endpoint_num || !cd->pipeline_reg_offset)
 		return ret;
 

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -957,6 +957,15 @@ static int copier_comp_trigger(struct comp_dev *dev, int cmd)
 	}
 
 	dai_cd = comp_get_drvdata(dai_copier);
+	if (!dai_cd) {
+		comp_err(dev, "NULL copier data.");
+		return 0;
+	}
+	if (!dai_cd->endpoint[IPC4_COPIER_GATEWAY_PIN]) {
+		comp_err(dev, "NULL endpoint type %u.", dai_copier->ipc_config.type);
+		return 0;
+	}
+
 	/* dai is in another pipeline and it is not prepared or active */
 	if (dai_copier->state <= COMP_STATE_READY ||
 	    dai_cd->endpoint[IPC4_COPIER_GATEWAY_PIN]->state <= COMP_STATE_READY) {

--- a/src/audio/pipeline/pipeline-graph.c
+++ b/src/audio/pipeline/pipeline-graph.c
@@ -486,7 +486,7 @@ struct comp_dev *pipeline_get_dai_comp(uint32_t pipeline_id, int dir)
 }
 
 #if CONFIG_IPC_MAJOR_4
-/* visit connected pipeline to find the dai comp and latency.
+/* Playback only: visit connected pipeline to find the dai comp and latency.
  * This function walks down through a pipelines chain looking for the target dai component.
  * Calculates the delay of each pipeline by determining the number of buffered blocks.
  */
@@ -521,8 +521,6 @@ struct comp_dev *pipeline_get_dai_comp_latency(uint32_t pipeline_id, uint32_t *l
 		/* Calculate pipeline latency */
 		input_data = comp_get_total_data_processed(source, 0, true);
 		output_data = comp_get_total_data_processed(ipc_sink->cd, 0, false);
-		if (!input_data || !output_data)
-			return NULL;
 
 		ret = comp_get_attribute(source, COMP_ATTR_BASE_CONFIG, &input_base_cfg);
 		if (ret < 0)
@@ -532,7 +530,9 @@ struct comp_dev *pipeline_get_dai_comp_latency(uint32_t pipeline_id, uint32_t *l
 		if (ret < 0)
 			return NULL;
 
-		*latency += input_data / input_base_cfg.ibs - output_data / output_base_cfg.obs;
+		if (input_data && output_data)
+			*latency += input_data / input_base_cfg.ibs -
+				output_data / output_base_cfg.obs;
 
 		/* If the component doesn't have a sink buffer, this is a dai. */
 		if (list_is_empty(&ipc_sink->cd->bsink_list))

--- a/src/audio/pipeline/pipeline-graph.c
+++ b/src/audio/pipeline/pipeline-graph.c
@@ -536,15 +536,18 @@ struct comp_dev *pipeline_get_dai_comp_latency(uint32_t pipeline_id, uint32_t *l
 
 		/* If the component doesn't have a sink buffer, this is a dai. */
 		if (list_is_empty(&ipc_sink->cd->bsink_list))
-			return ipc_sink->cd;
+			return dev_comp_type(ipc_sink->cd) == SOF_COMP_DAI ? ipc_sink->cd : NULL;
 
 		/* Get a component connected to our sink buffer - hop to a next pipeline */
 		buffer = buffer_from_list(comp_buffer_list(ipc_sink->cd, PPL_DIR_DOWNSTREAM)->next,
 					  struct comp_buffer, PPL_DIR_DOWNSTREAM);
 		source = buffer_get_comp(buffer, PPL_DIR_DOWNSTREAM);
+		if (!source)
+			comp_err(ipc_sink->cd, "no downstream on output buffer: %p %p!",
+				 ipc_sink->cd, buffer_get_comp(buffer, PPL_DIR_UPSTREAM));
 
 		/* buffer_comp is in another pipeline and it is not complete */
-		if (!source->pipeline)
+		if (!source || !source->pipeline)
 			return NULL;
 
 		/* Get a next sink component */


### PR DESCRIPTION
test patch 1 of #7210 
copier_comp_trigger() calls pipeline_get_dai_comp_latency() for playback pipelines to obtain the pipeline DAI copier, if there is one, and to calculate the pipeline latency. The latency is calculated using the .get_total_data_processed() component operation, but that operation is only available for DAI, host and copier components. SOF pipelines often have other components at one of the pipeline ends, so the latency calculation fails. However, that shouldn't prevent pipeline_get_dai_comp_latency() from finding the DAI component.
This fixes the notorious "failed to find dai comp or sink pipeline not running." error message.