### PR TITLE
west.yml: upgrade rimage to d32db50

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -34,7 +34,7 @@ manifest:
     - name: rimage
       repo-path: rimage
       path: sof/rimage
-      revision: 3863e94fa5d361e434f404655dac17541dbf20c6
+      revision: d32db50b6104968e61adb2eb206f0b31e1682c18
 
     - name: tomlc99
       repo-path: tomlc99


### PR DESCRIPTION
Pull in following rimage changes:

d32db50 mtl: add Aria module to extended manifest
5bc2010 rimage: fix build error
35bc644 mtl: add eq-iir and fir support
6fad356 rimage: Removed hash context from image structure
6c7a151 hash: Remove old hash functions
d258ea2 manifest: pkcs1_5: Use new hash functions
2bd8be3 hash: New hash functions
93c5e8b misc_utils: Move byte_swap function to new misc_utils.c file
9ce1cc8 ext_manifest: Fix fw_ext_man_cavs_header version
a4ca53c toml_utils: Adding support for decimal numbers in hex parser
5ebbd65 rimage: use hex number
36c0c90 elf: Use the get_file_size function
98c7f7b manifest: Use the get_file_size function
6a64cb9 file_utils: Add a new get_file_size function
055ea7e file_utils: manifest: ext_manifest: Add new create_file_name function
fed69d4 toml_utils: adsp_config: Moved generic parser functions to toml_utils
0931d9c main: heap_adsp release fix
3aa199f config: mtl: set init_config for micsel
d48ad6b adsp_config: add dump for init_config
ffd0542 adsp_config: make the default value zero for init_config
cb9c880 config: tgl-cavs: add kpb, selector and kd support
bf23b5e config: mtl: set KDTEST module_type to 8