### PR TITLE
buffer: simplify buffer_from_list()

### DIFF
--- a/src/audio/mixin_mixout/mixin_mixout.c
+++ b/src/audio/mixin_mixout/mixin_mixout.c
@@ -630,7 +630,7 @@ static int mixin_params(struct processing_module *mod)
 		struct comp_buffer __sparse_cache *sink_c;
 		uint16_t sink_id;
 
-		sink = buffer_from_list(blist, struct comp_buffer, PPL_DIR_DOWNSTREAM);
+		sink = buffer_from_list(blist, PPL_DIR_DOWNSTREAM);
 		sink_c = buffer_acquire(sink);
 
 		sink_c->stream.channels = mod->priv.cfg.base_cfg.audio_fmt.channels_count;

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -217,7 +217,7 @@ int module_adapter_prepare(struct comp_dev *dev)
 		struct comp_buffer *buf;
 		struct comp_dev *source;
 
-		buf = buffer_from_list(blist, struct comp_buffer, PPL_DIR_UPSTREAM);
+		buf = buffer_from_list(blist, PPL_DIR_UPSTREAM);
 		source = buffer_get_comp(buf, PPL_DIR_UPSTREAM);
 
 		if (source->pipeline && source->pipeline->core != dev->pipeline->core)

--- a/src/audio/pipeline/pipeline-graph.c
+++ b/src/audio/pipeline/pipeline-graph.c
@@ -402,7 +402,7 @@ int pipeline_for_each_comp(struct comp_dev *current,
 
 	/* run this operation further */
 	list_for_item(clist, buffer_list) {
-		struct comp_buffer *buffer = buffer_from_list(clist, struct comp_buffer, dir);
+		struct comp_buffer *buffer = buffer_from_list(clist, dir);
 		struct comp_buffer __sparse_cache *buffer_c;
 		struct comp_dev *buffer_comp;
 		int err = 0;
@@ -472,7 +472,7 @@ struct comp_dev *pipeline_get_dai_comp(uint32_t pipeline_id, int dir)
 		if (list_is_empty(blist))
 			return crt->cd;
 
-		buffer = buffer_from_list(blist->next, struct comp_buffer, dir);
+		buffer = buffer_from_list(blist->next, dir);
 		comp = buffer_get_comp(buffer, dir);
 
 		/* buffer_comp is in another pipeline and it is not complete */
@@ -540,7 +540,7 @@ struct comp_dev *pipeline_get_dai_comp_latency(uint32_t pipeline_id, uint32_t *l
 
 		/* Get a component connected to our sink buffer - hop to a next pipeline */
 		buffer = buffer_from_list(comp_buffer_list(ipc_sink->cd, PPL_DIR_DOWNSTREAM)->next,
-					  struct comp_buffer, PPL_DIR_DOWNSTREAM);
+					  PPL_DIR_DOWNSTREAM);
 		source = buffer_get_comp(buffer, PPL_DIR_DOWNSTREAM);
 
 		/* buffer_comp is in another pipeline and it is not complete */

--- a/src/audio/pipeline/pipeline-stream.c
+++ b/src/audio/pipeline/pipeline-stream.c
@@ -239,8 +239,7 @@ static void pipeline_trigger_xrun(struct pipeline *p, struct comp_dev **host)
 			break;
 
 		list_for_item(clist, buffer_list) {
-			struct comp_buffer *buffer = buffer_from_list(clist,
-								      struct comp_buffer, dir);
+			struct comp_buffer *buffer = buffer_from_list(clist, dir);
 			struct comp_dev *buffer_comp = buffer_get_comp(buffer, dir);
 
 			switch (buffer_comp->pipeline->status) {

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -176,10 +176,10 @@ struct buffer_cb_free {
 	((dir) == PPL_DIR_DOWNSTREAM ? &buffer->source_list : \
 	 &buffer->sink_list)
 
-#define buffer_from_list(ptr, type, dir) \
+#define buffer_from_list(ptr, dir) \
 	((dir) == PPL_DIR_DOWNSTREAM ? \
-	 container_of(ptr, type, source_list) : \
-	 container_of(ptr, type, sink_list))
+	 container_of(ptr, struct comp_buffer, source_list) : \
+	 container_of(ptr, struct comp_buffer, sink_list))
 
 #define buffer_set_cb(buffer, func, data, type) \
 	do {				\

--- a/src/ipc/ipc-common.c
+++ b/src/ipc/ipc-common.c
@@ -125,7 +125,7 @@ struct ipc_comp_dev *ipc_get_ppl_comp(struct ipc *ipc, uint32_t pipeline_id, int
 
 			/* check all connected modules to see if they are on different pipelines */
 			list_for_item(blist, buffer_list) {
-				buffer = buffer_from_list(blist, struct comp_buffer, dir);
+				buffer = buffer_from_list(blist, dir);
 				buff_comp = buffer_get_comp(buffer, dir);
 
 				if (buff_comp && dev_comp_pipe_id(buff_comp) == pipeline_id)

--- a/src/ipc/ipc-helper.c
+++ b/src/ipc/ipc-helper.c
@@ -155,7 +155,7 @@ int comp_verify_params(struct comp_dev *dev, uint32_t flag,
 		buffer_list = comp_buffer_list(dev, dir);
 
 		list_for_item(clist, buffer_list) {
-			buf = buffer_from_list(clist, struct comp_buffer, dir);
+			buf = buffer_from_list(clist, dir);
 			buf_c = buffer_acquire(buf);
 			comp_update_params(flag, params, buf_c);
 			buffer_set_params(buf_c, params, BUFFER_UPDATE_FORCE);


### PR DESCRIPTION
buffer_from_list() is always used for buffer objects, the type is always struct comp_buffer. Hard code the type instead of always specifying is as a parameter.