### PR TITLE
dai: host: add fast mode

### DIFF
--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -227,6 +227,7 @@ static int create_host(struct comp_dev *parent_dev, struct copier_data *cd,
 	memset(&ipc_host, 0, sizeof(ipc_host));
 	ipc_host.direction = dir;
 	ipc_host.dma_buffer_size = copier_cfg->gtw_cfg.dma_buffer_size;
+	ipc_host.feature_mask = copier_cfg->copier_feature_mask;
 
 	dev = drv->ops.create(drv, config, &ipc_host);
 	if (!dev) {
@@ -384,6 +385,7 @@ static int create_dai(struct comp_dev *parent_dev, struct copier_data *cd,
 	dai.direction = get_gateway_direction(node_id.f.dma_type);
 	dai.is_config_blob = true;
 	dai.sampling_frequency = copier->out_fmt.sampling_frequency;
+	dai.feature_mask = copier->copier_feature_mask;
 
 	switch (node_id.f.dma_type) {
 	case ipc4_hda_link_output_class:

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -29,6 +29,7 @@
 #include <ipc/dai.h>
 #include <ipc/stream.h>
 #include <ipc/topology.h>
+#include <ipc4/copier.h>
 #include <user/trace.h>
 #include <errno.h>
 #include <stddef.h>
@@ -1257,8 +1258,10 @@ static int dai_copy(struct comp_dev *dev)
 
 	/* limit bytes per copy to one period for the whole pipeline
 	 * in order to avoid high load spike
+	 * if FAST_MODE is enabled, then one period limitation is omitted
 	 */
-	samples = MIN(samples, dd->period_bytes / sampling);
+	if (!(dd->ipc_config.feature_mask & BIT(IPC4_COPIER_FAST_MODE)))
+		samples = MIN(samples, dd->period_bytes / sampling);
 
 	copy_bytes = samples * sampling;
 

--- a/src/audio/host-zephyr.c
+++ b/src/audio/host-zephyr.c
@@ -10,6 +10,7 @@
 #include <sof/audio/pcm_converter.h>
 #include <sof/audio/pipeline.h>
 #include <sof/audio/ipc-config.h>
+#include <ipc4/copier.h>
 #include <sof/common.h>
 #include <rtos/panic.h>
 #include <sof/ipc/msg.h>
@@ -489,10 +490,15 @@ static uint32_t host_get_copy_bytes_normal(struct comp_dev *dev)
 	else
 		avail_bytes = audio_stream_get_avail_bytes(&buffer_c->stream);
 
+	copy_bytes = MIN(avail_bytes, free_bytes);
+
 	/* limit bytes per copy to one period for the whole pipeline
 	 * in order to avoid high load spike
+	 * if FAST_MODE is enabled, then one period limitation is omitted
 	 */
-	copy_bytes = MIN(hd->period_bytes, MIN(avail_bytes, free_bytes));
+	if (!(hd->ipc_host.feature_mask & BIT(IPC4_COPIER_FAST_MODE)))
+		copy_bytes = MIN(hd->period_bytes, copy_bytes);
+
 	if (!copy_bytes)
 		comp_info(dev, "no bytes to copy, available bytes: %d, free_bytes: %d",
 			  avail_bytes, free_bytes);

--- a/src/include/sof/audio/ipc-config.h
+++ b/src/include/sof/audio/ipc-config.h
@@ -20,6 +20,9 @@ struct ipc_config_host {
 	uint32_t no_irq;		/**< don't send periodic IRQ to host/DSP */
 	uint32_t dmac_config;		/**< DMA engine specific */
 	uint32_t dma_buffer_size;	/**< Requested DMA buffer size */
+	uint32_t feature_mask;		/**< copier feature mask (set directly from
+					  *  ipc4_copier_module_cfg on init)
+					  */
 };
 
 /* generic DAI component */
@@ -33,6 +36,9 @@ struct ipc_config_dai {
 	uint16_t format;		/**< SOF_DAI_FMT_ */
 	uint16_t group_id;		/**< group ID, 0 means no group (ABI 3.17) */
 	bool is_config_blob;		/**< DAI specific configuration is a blob */
+	uint32_t feature_mask;		/**< copier feature mask (set directly from
+					  *  ipc4_copier_module_cfg on init)
+					  */
 };
 
 /* generic volume component */


### PR DESCRIPTION
Add fast mode which enables to support unlimited transfer size (more than
ibs/obs) between a dma buffer and the copier. Enable it to satisfy
specific module requirements to guarantee enough data size to decoders or
from encoders since the pcm audio period size does not apply to variable
size frame.