### PR TITLE
Gain no name prefix

### DIFF
--- a/tools/topology/topology2/include/common/tokens.conf
+++ b/tools/topology/topology2/include/common/tokens.conf
@@ -52,6 +52,7 @@ Object.Base.VendorToken {
 		curve_type		260
 		curve_duration		261
 		init_value		262
+		no_wname_in_kcontrol_name	263
 	}
 
 	"6" {

--- a/tools/topology/topology2/include/components/eqiir.conf
+++ b/tools/topology/topology2/include/components/eqiir.conf
@@ -61,4 +61,5 @@ Class.Widget."eqiir" {
 	no_pm			"true"
 	num_input_pins		1
 	num_output_pins		1
+	no_wname_in_kcontrol_name	"true"
 }

--- a/tools/topology/topology2/include/components/gain.conf
+++ b/tools/topology/topology2/include/components/gain.conf
@@ -68,6 +68,18 @@ Class.Widget."gain" {
                 token_ref       "gain.word"
 	}
 
+	DefineAttribute."no_wname_in_kcontrol_name" {
+		type	"string"
+		# Token set reference name
+		token_ref	"gain.bool"
+		constraints {
+			!valid_values [
+				"true"
+				"false"
+			]
+		}
+	}
+
 	# Attribute categories
 	attributes {
 		#
@@ -156,4 +168,5 @@ Class.Widget."gain" {
 	init_value		0x7fffffff
 	num_input_pins		1
 	num_output_pins		1
+	no_wname_in_kcontrol_name	"true"
 }


### PR DESCRIPTION
"topology2: gain: Add "name_no_prefix" attribute to gain class" the main commit here. "topology2: cavs-mixin-mixout-hda: Rename mixin-mixout volumes, no prefix"  is an example how to use the new feature (and the old variable value expansion), but in it self its a serious attempt to fix the mixer naming problems found in cavs-mixin-mixout-hda.conf.

The associated Linux driver PR is needed this PR to work.