### PR TITLE
optimize copy times and remove dai device from copier

### DIFF
--- a/src/audio/asrc/asrc.c
+++ b/src/audio/asrc/asrc.c
@@ -33,6 +33,12 @@
 #if CONFIG_IPC_MAJOR_4
 #include <ipc4/base-config.h>
 #include <ipc4/asrc.h>
+#include <ipc4/copier.h>
+#include <ipc/dai.h>
+#if CONFIG_ZEPHYR_NATIVE_DRIVERS
+#include <zephyr/device.h>
+#include <zephyr/drivers/dai.h>
+#endif
 #endif
 
 /* Simple count value to prevent first delta timestamp
@@ -78,6 +84,7 @@ struct comp_data {
 #endif
 	struct asrc_farrow *asrc_obj;	/* ASRC core data */
 	struct comp_dev *dai_dev;	/* Associated DAI component */
+	struct copier_data *cd;		/* Associated copier component */
 	enum asrc_operation_mode mode;  /* Control for push or pull mode */
 	uint64_t ts;
 	uint32_t sink_rate;	/* Sample rate in Hz */
@@ -591,6 +598,197 @@ static int asrc_params(struct comp_dev *dev,
 	return 0;
 }
 
+#ifdef CONFIG_IPC_MAJOR_4
+
+#if CONFIG_ZEPHYR_NATIVE_DRIVERS
+/**
+ * \brief Get DAI parameters and configure timestamping
+ * \param[in, out] dev DAI device.
+ * \return Error code.
+ *
+ * This function retrieves various DAI parameters such as type, direction, index, and DMA
+ * controller information those are needed when configuring HW timestamping. Note that
+ * DAI must be prepared before this function is used (for DMA information). If not, an error
+ * is returned.
+ */
+static int dai_ts_config_op(struct comp_dev *dev)
+{
+	struct comp_data *cd = comp_get_drvdata(dev);
+	struct dai_data *dd = cd->cd->dd;
+	struct ipc_config_dai *dai = &dd->ipc_config;
+	struct dai_ts_cfg cfg;
+
+	comp_dbg(dev, "dai_ts_config()");
+	if (!dd->chan) {
+		comp_err(dev, "dai_ts_config(), No DMA channel information");
+		return -EINVAL;
+	}
+
+	switch (dai->type) {
+	case SOF_DAI_INTEL_SSP:
+		cfg.type = DAI_INTEL_SSP;
+		break;
+	case SOF_DAI_INTEL_ALH:
+		cfg.type = DAI_INTEL_ALH;
+		break;
+	case SOF_DAI_INTEL_DMIC:
+		cfg.type = DAI_INTEL_DMIC;
+		break;
+	default:
+		comp_err(dev, "dai_ts_config(), not supported dai type");
+		return -EINVAL;
+	}
+
+	cfg.direction = dai->direction;
+	cfg.index = dd->dai->index;
+	cfg.dma_id = dd->dma->plat_data.id;
+	cfg.dma_chan_index = dd->chan->index;
+	cfg.dma_chan_count = dd->dma->plat_data.channels;
+
+	return dai_ts_config(dd->dai->dev, &cfg);
+}
+
+static int dai_ts_start_op(struct comp_dev *dev)
+{
+	struct comp_data *cd = comp_get_drvdata(dev);
+	struct dai_data *dd = cd->cd->dd;
+	struct dai_ts_cfg cfg;
+
+	comp_dbg(dev, "dai_ts_start()");
+
+	return dai_ts_start(dd->dai->dev, &cfg);
+}
+
+static int dai_ts_get_op(struct comp_dev *dev, struct timestamp_data *tsd)
+{
+	struct comp_data *cd = comp_get_drvdata(dev);
+	struct dai_data *dd = cd->cd->dd;
+	struct dai_ts_data tsdata;
+	struct dai_ts_cfg cfg;
+	int ret;
+
+	comp_dbg(dev, "dai_ts_get()");
+
+	ret = dai_ts_get(dd->dai->dev, &cfg, &tsdata);
+
+	if (ret < 0)
+		return ret;
+
+	/* todo convert to timestamp_data */
+
+	return ret;
+}
+
+static int dai_ts_stop_op(struct comp_dev *dev)
+{
+	struct comp_data *cd = comp_get_drvdata(dev);
+	struct dai_data *dd = cd->cd->dd;
+	struct dai_ts_cfg cfg;
+
+	comp_dbg(dev, "dai_ts_stop()");
+
+	return dai_ts_stop(dd->dai->dev, &cfg);
+}
+#else
+static inline int dai_ts_config_op(struct comp_dev *dev)
+{
+	return 0;
+}
+
+static inline int dai_ts_start_op(struct comp_dev *dev)
+{
+	return 0;
+}
+
+static inline int dai_ts_get_op(struct comp_dev *dev, struct timestamp_data *tsd)
+{
+	return 0;
+}
+
+static inline int dai_ts_stop_op(struct comp_dev *dev)
+{
+	return 0;
+}
+
+#endif
+static int asrc_dai_find(struct comp_dev *dev, struct comp_data *cd)
+{
+	struct comp_buffer *sourceb, *sinkb;
+	struct comp_buffer __sparse_cache *source_c, *sink_c;
+	int pid;
+
+	/* Get current pipeline ID and walk to find the DAI */
+	pid = dev_comp_pipe_id(dev);
+	cd->cd = NULL;
+	if (cd->mode == ASRC_OM_PUSH) {
+		/* In push mode check if sink component is DAI */
+		do {
+			sinkb = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
+
+			sink_c = buffer_acquire(sinkb);
+			dev = sink_c->sink;
+			buffer_release(sink_c);
+
+			if (!dev) {
+				comp_cl_err(&comp_asrc, "At end, no DAI found.");
+				return -EINVAL;
+			}
+
+			if (dev_comp_pipe_id(dev) != pid) {
+				comp_cl_err(&comp_asrc, "No DAI sink in pipeline.");
+				return -EINVAL;
+			}
+
+		} while (dev_comp_type(dev) != SOF_COMP_DAI);
+	} else {
+		/* In pull mode check if source component is DAI */
+		do {
+			sourceb = list_first_item(&dev->bsource_list, struct comp_buffer,
+						  sink_list);
+
+			source_c = buffer_acquire(sourceb);
+			dev = source_c->source;
+			buffer_release(source_c);
+
+			if (!dev) {
+				comp_cl_err(&comp_asrc, "At beginning, no DAI found.");
+				return -EINVAL;
+			}
+
+			if (dev_comp_pipe_id(dev) != pid) {
+				comp_cl_err(&comp_asrc, "No DAI source in pipeline.");
+				return -EINVAL;
+			}
+		} while (dev_comp_type(dev) != SOF_COMP_DAI);
+	}
+
+	/* Point cd to copier data, dev here is copier dev */
+	cd->cd = comp_get_drvdata(dev);
+
+	return 0;
+}
+
+static int asrc_dai_configure_timestamp(struct comp_dev *dev)
+{
+	return dai_ts_config_op(dev);
+}
+
+static int asrc_dai_start_timestamp(struct comp_dev *dev)
+{
+	return dai_ts_start_op(dev);
+}
+
+static int asrc_dai_stop_timestamp(struct comp_dev *dev)
+{
+	return dai_ts_stop_op(dev);
+}
+
+static int asrc_dai_get_timestamp(struct comp_dev *dev,
+				  struct timestamp_data *tsd)
+{
+	return dai_ts_get_op(dev, tsd);
+}
+#else
 static int asrc_dai_find(struct comp_dev *dev, struct comp_data *cd)
 {
 	struct comp_buffer *sourceb, *sinkb;
@@ -647,8 +845,9 @@ static int asrc_dai_find(struct comp_dev *dev, struct comp_data *cd)
 	return 0;
 }
 
-static int asrc_dai_configure_timestamp(struct comp_data *cd)
+static int asrc_dai_configure_timestamp(struct comp_dev *dev)
 {
+	struct comp_data *cd = comp_get_drvdata(dev);
 	int ret;
 
 	if (cd->dai_dev)
@@ -659,8 +858,9 @@ static int asrc_dai_configure_timestamp(struct comp_data *cd)
 	return ret;
 }
 
-static int asrc_dai_start_timestamp(struct comp_data *cd)
+static int asrc_dai_start_timestamp(struct comp_dev *dev)
 {
+	struct comp_data *cd = comp_get_drvdata(dev);
 	int ret;
 
 	if (cd->dai_dev)
@@ -671,8 +871,9 @@ static int asrc_dai_start_timestamp(struct comp_data *cd)
 	return ret;
 }
 
-static int asrc_dai_stop_timestamp(struct comp_data *cd)
+static int asrc_dai_stop_timestamp(struct comp_dev *dev)
 {
+	struct comp_data *cd = comp_get_drvdata(dev);
 	int ret;
 
 	if (cd->dai_dev)
@@ -683,14 +884,17 @@ static int asrc_dai_stop_timestamp(struct comp_data *cd)
 	return ret;
 }
 
-static int asrc_dai_get_timestamp(struct comp_data *cd,
+static int asrc_dai_get_timestamp(struct comp_dev *dev,
 				  struct timestamp_data *tsd)
 {
+	struct comp_data *cd = comp_get_drvdata(dev);
+
 	if (!cd->dai_dev)
 		return -EINVAL;
 
 	return cd->dai_dev->drv->ops.dai_ts_get(cd->dai_dev, tsd);
 }
+#endif
 
 static int asrc_trigger(struct comp_dev *dev, int cmd)
 {
@@ -709,7 +913,7 @@ static int asrc_trigger(struct comp_dev *dev, int cmd)
 		}
 
 		cd->ts_count = 0;
-		ret = asrc_dai_configure_timestamp(cd);
+		ret = asrc_dai_configure_timestamp(dev);
 		if (ret) {
 			comp_err(dev, "No timestamp capability in DAI");
 			cd->track_drift = false;
@@ -927,12 +1131,13 @@ static int asrc_control_loop(struct comp_dev *dev, struct comp_data *cd)
 
 	if (!cd->ts_count) {
 		cd->ts_count++;
-		asrc_dai_start_timestamp(cd);
+		asrc_dai_start_timestamp(dev);
 		return 0;
 	}
 
-	ts_ret = asrc_dai_get_timestamp(cd, &tsd);
-	asrc_dai_start_timestamp(cd);
+	memset((void *)&tsd, 0, sizeof(tsd));
+	ts_ret = asrc_dai_get_timestamp(dev, &tsd);
+	asrc_dai_start_timestamp(dev);
 	if (ts_ret)
 		return ts_ret;
 
@@ -1073,7 +1278,7 @@ static int asrc_reset(struct comp_dev *dev)
 
 	/* If any resources feasible to stop */
 	if (cd->track_drift)
-		asrc_dai_stop_timestamp(cd);
+		asrc_dai_stop_timestamp(dev);
 
 	/* Free the allocations those were done in prepare() */
 	asrc_release_buffers(cd->asrc_obj);

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -305,61 +305,48 @@ static int init_dai(struct comp_dev *parent_dev,
 		    enum ipc4_gateway_type type,
 		    int index)
 {
-	struct comp_dev *dev;
+	enum sof_ipc_frame __sparse_cache in_frame_fmt, out_frame_fmt;
+	enum sof_ipc_frame __sparse_cache in_valid_fmt, out_valid_fmt;
 	struct copier_data *cd;
 	struct dai_data *dd;
 	int ret;
 
 	cd = comp_get_drvdata(parent_dev);
-	ret = create_endpoint_buffer(parent_dev, cd, config, copier, type, false, index);
-	if (ret < 0)
-		return ret;
 
-	dev = comp_alloc(drv, sizeof(*dev));
-	if (!dev) {
-		ret = -ENOMEM;
-		goto e_buf;
-	}
+	audio_stream_fmt_conversion(copier->base.audio_fmt.depth,
+				    copier->base.audio_fmt.valid_bit_depth,
+				    &in_frame_fmt,
+				    &in_valid_fmt,
+				    copier->base.audio_fmt.s_type);
 
-	dev->ipc_config = *config;
+	audio_stream_fmt_conversion(copier->out_fmt.depth,
+				    copier->out_fmt.valid_bit_depth,
+				    &out_frame_fmt,
+				    &out_valid_fmt,
+				    copier->out_fmt.s_type);
+
+	if (cd->direction == SOF_IPC_STREAM_PLAYBACK)
+		config->frame_fmt = out_frame_fmt;
+	else
+		config->frame_fmt = in_frame_fmt;
+
+	parent_dev->ipc_config.frame_fmt = config->frame_fmt;
 
 	dd = rzalloc(SOF_MEM_ZONE_RUNTIME_SHARED, 0, SOF_MEM_CAPS_RAM, sizeof(*dd));
 	if (!dd) {
 		ret = -ENOMEM;
-		goto e_data;
+		goto e_buf;
 	}
-
-	comp_set_drvdata(dev, dd);
 
 	ret = dai_zephyr_new(dd, parent_dev, dai);
 	if (ret < 0)
 		goto e_zephyr;
 
-	dev->state = COMP_STATE_READY;
-
-	if (dai->direction == SOF_IPC_STREAM_PLAYBACK)
-		pipeline->sink_comp = dev;
-	else
-		pipeline->source_comp = dev;
-
 	pipeline->sched_id = config->id;
-
-	list_init(&dev->bsource_list);
-	list_init(&dev->bsink_list);
 
 	ret = comp_dai_config(dd, parent_dev, dai, copier);
 	if (ret < 0)
 		goto e_buf;
-
-	if (dai->direction == SOF_IPC_STREAM_PLAYBACK) {
-		comp_buffer_connect(dev, config->core, cd->endpoint_buffer[cd->endpoint_num],
-				    PPL_CONN_DIR_BUFFER_TO_COMP);
-		cd->bsource_buffer = true;
-	} else {
-		comp_buffer_connect(dev, config->core, cd->endpoint_buffer[cd->endpoint_num],
-				    PPL_CONN_DIR_COMP_TO_BUFFER);
-		cd->bsource_buffer = false;
-	}
 
 	cd->converter[IPC4_COPIER_GATEWAY_PIN] =
 			get_converter_func(&copier->base.audio_fmt, &copier->out_fmt, type,
@@ -370,7 +357,7 @@ static int init_dai(struct comp_dev *parent_dev,
 		goto e_zephyr;
 	}
 
-	cd->endpoint[cd->endpoint_num++] = dev;
+	cd->endpoint_num++;
 	cd->dd = dd;
 
 	return 0;
@@ -378,11 +365,9 @@ static int init_dai(struct comp_dev *parent_dev,
 e_zephyr:
 	if (dd->group)
 		notifier_unregister(parent_dev, dd->group, NOTIFIER_ID_DAI_TRIGGER);
-	dai_zephyr_free(dd, dev);
-e_data:
-	rfree(dev);
+	dai_zephyr_free(dd);
 e_buf:
-	buffer_free(cd->endpoint_buffer[cd->endpoint_num]);
+
 	return ret;
 }
 
@@ -753,16 +738,13 @@ static void copier_free(struct comp_dev *dev)
 	case SOF_COMP_DAI:
 		if (cd->dd->group)
 			notifier_unregister(dev, cd->dd->group, NOTIFIER_ID_DAI_TRIGGER);
-		dai_zephyr_free(cd->dd, cd->endpoint[0]);
-		rfree(cd->endpoint[0]);
-		buffer_free(cd->endpoint_buffer[0]);
+		dai_zephyr_free(cd->dd);
 		break;
 	default:
 		comp_err(dev, "Unexpected device type to free %d",
 			 dev->ipc_config.type);
 		break;
 	}
-
 	rfree(cd);
 	rfree(dev);
 }
@@ -916,11 +898,11 @@ static int copier_prepare(struct comp_dev *dev)
 			return ret;
 		break;
 	case SOF_COMP_DAI:
-		ret = dai_config_prepare(cd->dd, cd->endpoint[0]);
+		ret = dai_config_prepare(cd->dd, dev);
 		if (ret < 0)
 			return ret;
 
-		ret = dai_zephyr_prepare(cd->dd, cd->endpoint[0]);
+		ret = dai_zephyr_prepare(cd->dd, dev);
 		if (ret < 0)
 			return ret;
 		break;
@@ -992,8 +974,7 @@ static int copier_reset(struct comp_dev *dev)
 		}
 		break;
 	case SOF_COMP_DAI:
-		dai_zephyr_reset(cd->dd, cd->endpoint[0]);
-		comp_set_state(cd->endpoint[0], COMP_TRIGGER_RESET);
+		dai_zephyr_reset(cd->dd, dev);
 		break;
 	default:
 		comp_err(dev, "Unexpected copier device type to reset %d",
@@ -1017,7 +998,6 @@ static int copier_comp_trigger(struct comp_dev *dev, int cmd)
 	struct copier_data *cd = comp_get_drvdata(dev);
 	struct sof_ipc_stream_posn posn;
 	struct comp_dev *dai_copier;
-	struct copier_data *dai_cd;
 	struct comp_buffer *buffer;
 	struct comp_buffer __sparse_cache *buffer_c;
 	uint32_t latency;
@@ -1041,7 +1021,7 @@ static int copier_comp_trigger(struct comp_dev *dev, int cmd)
 			ret = cd->endpoint[0]->drv->ops.trigger(cd->endpoint[0], cmd);
 		break;
 	case SOF_COMP_DAI:
-		ret = dai_zephyr_trigger(cd->dd, cd->endpoint[0], cmd);
+		ret = dai_zephyr_trigger(cd->dd, dev, cmd);
 		break;
 	default:
 		comp_err(dev, "Unexpected copier device type to trigger! %d",
@@ -1064,10 +1044,8 @@ static int copier_comp_trigger(struct comp_dev *dev, int cmd)
 		return 0;
 	}
 
-	dai_cd = comp_get_drvdata(dai_copier);
 	/* dai is in another pipeline and it is not prepared or active */
-	if (dai_copier->state <= COMP_STATE_READY ||
-	    dai_cd->endpoint[IPC4_COPIER_GATEWAY_PIN]->state <= COMP_STATE_READY) {
+	if (dai_copier->state <= COMP_STATE_READY) {
 		struct ipc4_pipeline_registers pipe_reg;
 
 		comp_warn(dev, "dai is not ready");
@@ -1344,7 +1322,8 @@ static int copier_copy(struct comp_dev *dev)
 
 	comp_dbg(dev, "copier_copy()");
 
-	if (dev->ipc_config.type == SOF_COMP_HOST && !cd->ipc_gtw)
+	if ((dev->ipc_config.type == SOF_COMP_HOST || dev->ipc_config.type == SOF_COMP_DAI) &&
+	    !cd->ipc_gtw)
 		return do_endpoint_copy(dev);
 
 	processed_data.source_bytes = 0;
@@ -1552,7 +1531,8 @@ static int copier_params(struct comp_dev *dev, struct sof_ipc_stream_params *par
 	}
 
 	for (i = 0; i < cd->endpoint_num; i++) {
-		update_internal_comp(dev, cd->endpoint[i]);
+		if (cd->endpoint[i])
+			update_internal_comp(dev, cd->endpoint[i]);
 
 		/* For ALH multi-gateway case, params->channels is a total multiplexed
 		 * number of channels. Demultiplexed number of channels for each individual
@@ -1594,9 +1574,7 @@ static int copier_params(struct comp_dev *dev, struct sof_ipc_stream_params *par
 				break;
 			case SOF_COMP_DAI:
 				ret = dai_zephyr_params(cd->dd, dev, params,
-							&period_count, &period_bytes,
-							&cd->endpoint[i]->bsource_list,
-							&cd->endpoint[i]->bsink_list);
+							&period_count, &period_bytes);
 				if (ret < 0)
 					break;
 
@@ -1744,11 +1722,17 @@ static int copier_get_large_config(struct comp_dev *dev, uint32_t param_id,
 	struct sof_ipc_stream_posn posn;
 	struct ipc4_llp_reading_extended llp_ext;
 	struct ipc4_llp_reading llp;
+	struct comp_dev *temp_dev;
+
+	if (cd->ipc_gtw)
+		temp_dev = cd->endpoint[IPC4_COPIER_GATEWAY_PIN];
+	else
+		temp_dev = dev;
 
 	switch (param_id) {
 	case IPC4_COPIER_MODULE_CFG_PARAM_LLP_READING:
 		if (!cd->endpoint_num ||
-		    comp_get_endpoint_type(cd->endpoint[IPC4_COPIER_GATEWAY_PIN]) !=
+		    comp_get_endpoint_type(temp_dev) !=
 		    COMP_ENDPOINT_DAI) {
 			comp_err(dev, "Invalid component type");
 			return -EINVAL;
@@ -1762,13 +1746,13 @@ static int copier_get_large_config(struct comp_dev *dev, uint32_t param_id,
 		*data_offset = sizeof(struct ipc4_llp_reading);
 		memset(&llp, 0, sizeof(llp));
 
-		if (cd->endpoint[IPC4_COPIER_GATEWAY_PIN]->state != COMP_STATE_ACTIVE) {
+		if (temp_dev->state != COMP_STATE_ACTIVE) {
 			memcpy_s(data, sizeof(llp), &llp, sizeof(llp));
 			return 0;
 		}
 
 		/* get llp from dai */
-		comp_position(cd->endpoint[IPC4_COPIER_GATEWAY_PIN], &posn);
+		comp_position(temp_dev, &posn);
 
 		convert_u64_to_u32s(posn.comp_posn, &llp.llp_l, &llp.llp_u);
 		convert_u64_to_u32s(posn.wallclock, &llp.wclk_l, &llp.wclk_u);
@@ -1778,7 +1762,7 @@ static int copier_get_large_config(struct comp_dev *dev, uint32_t param_id,
 
 	case IPC4_COPIER_MODULE_CFG_PARAM_LLP_READING_EXTENDED:
 		if (!cd->endpoint_num ||
-		    comp_get_endpoint_type(cd->endpoint[IPC4_COPIER_GATEWAY_PIN]) !=
+		    comp_get_endpoint_type(temp_dev) !=
 		    COMP_ENDPOINT_DAI) {
 			comp_err(dev, "Invalid component type");
 			return -EINVAL;
@@ -1792,13 +1776,13 @@ static int copier_get_large_config(struct comp_dev *dev, uint32_t param_id,
 		*data_offset = sizeof(struct ipc4_llp_reading_extended);
 		memset(&llp_ext, 0, sizeof(llp_ext));
 
-		if (cd->endpoint[IPC4_COPIER_GATEWAY_PIN]->state != COMP_STATE_ACTIVE) {
+		if (temp_dev->state != COMP_STATE_ACTIVE) {
 			memcpy_s(data, sizeof(llp_ext), &llp_ext, sizeof(llp_ext));
 			return 0;
 		}
 
 		/* get llp from dai */
-		comp_position(cd->endpoint[IPC4_COPIER_GATEWAY_PIN], &posn);
+		comp_position(temp_dev, &posn);
 
 		convert_u64_to_u32s(posn.comp_posn, &llp_ext.llp_reading.llp_l,
 				    &llp_ext.llp_reading.llp_u);
@@ -1910,7 +1894,7 @@ static int copier_position(struct comp_dev *dev, struct sof_ipc_stream_posn *pos
 		}
 		break;
 	case SOF_COMP_DAI:
-		ret = dai_zephyr_position(cd->dd, cd->endpoint[IPC4_COPIER_GATEWAY_PIN], posn);
+		ret = dai_zephyr_position(cd->dd, dev, posn);
 		break;
 	default:
 		comp_err(dev, "Unexpected copier device type to position! %d",

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -1276,6 +1276,8 @@ static int do_endpoint_copy(struct comp_dev *dev)
 	} else {
 		if (dev->ipc_config.type == SOF_COMP_HOST && !cd->ipc_gtw)
 			return host_zephyr_copy(cd->hd, dev, copier_dma_cb);
+		else if (dev->ipc_config.type == SOF_COMP_DAI)
+			return dai_zephyr_copy(cd->dd, dev);
 
 		return cd->endpoint[0]->drv->ops.copy(cd->endpoint[0]);
 	}

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -347,7 +347,7 @@ static int init_dai(struct comp_dev *parent_dev,
 	list_init(&dev->bsource_list);
 	list_init(&dev->bsink_list);
 
-	ret = comp_dai_config(dev, dai, copier);
+	ret = comp_dai_config(dd, parent_dev, dai, copier);
 	if (ret < 0)
 		goto e_buf;
 
@@ -376,6 +376,8 @@ static int init_dai(struct comp_dev *parent_dev,
 	return 0;
 
 e_zephyr:
+	if (dd->group)
+		notifier_unregister(parent_dev, dd->group, NOTIFIER_ID_DAI_TRIGGER);
 	dai_zephyr_free(dd, dev);
 e_data:
 	rfree(dev);
@@ -749,6 +751,8 @@ static void copier_free(struct comp_dev *dev)
 		}
 		break;
 	case SOF_COMP_DAI:
+		if (cd->dd->group)
+			notifier_unregister(dev, cd->dd->group, NOTIFIER_ID_DAI_TRIGGER);
 		dai_zephyr_free(cd->dd, cd->endpoint[0]);
 		rfree(cd->endpoint[0]);
 		buffer_free(cd->endpoint_buffer[0]);

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -1494,8 +1494,10 @@ static int copier_params(struct comp_dev *dev, struct sof_ipc_stream_params *par
 	struct comp_buffer *sink, *source;
 	struct comp_buffer __sparse_cache *sink_c, *source_c;
 	struct list_item *sink_list;
-	int ret = 0;
-	int i;
+	int i, ret = 0;
+	uint32_t period_count = 0;
+	uint32_t period_bytes = 0;
+
 
 	comp_dbg(dev, "copier_params()");
 
@@ -1561,21 +1563,47 @@ static int copier_params(struct comp_dev *dev, struct sof_ipc_stream_params *par
 			ret = cd->endpoint[i]->drv->ops.params(cd->endpoint[i],
 							       &demuxed_params);
 		} else {
-			if (dev->ipc_config.type == SOF_COMP_HOST && !cd->ipc_gtw) {
-				component_set_nearest_period_frames(dev, params->rate);
-				if (params->direction == SOF_IPC_STREAM_CAPTURE) {
-					params->buffer.size = cd->config.base.obs;
-					params->sample_container_bytes = cd->out_fmt->depth / 8;
-					params->sample_valid_bytes =
-						cd->out_fmt->valid_bit_depth / 8;
+			/*
+			 * three type of params, host/gtw/dai
+			 */
+			switch (dev->ipc_config.type) {
+			case SOF_COMP_HOST:
+				if (!cd->ipc_gtw) {
+					component_set_nearest_period_frames(dev, params->rate);
+					if (params->direction == SOF_IPC_STREAM_CAPTURE) {
+						params->buffer.size = cd->config.base.obs;
+						params->sample_container_bytes =
+							cd->out_fmt->depth / 8;
+						params->sample_valid_bytes =
+							cd->out_fmt->valid_bit_depth / 8;
+					}
+
+					ret = host_zephyr_params(cd->hd, dev, params, copier_notifier_cb);
+					cd->hd->process = cd->converter[IPC4_COPIER_GATEWAY_PIN];
+				} else {
+					/* handle gtw case */
+					ret = cd->endpoint[i]->drv->ops.params(cd->endpoint[i],
+									       params);
 				}
+				break;
+			case SOF_COMP_DAI:
+				ret = dai_zephyr_params(cd->dd, dev, params,
+							&period_count, &period_bytes,
+							&cd->endpoint[i]->bsource_list,
+							&cd->endpoint[i]->bsink_list);
+				if (ret < 0)
+					break;
 
-				ret = host_zephyr_params(cd->hd, dev, params, copier_notifier_cb);
-
-				cd->hd->process = cd->converter[IPC4_COPIER_GATEWAY_PIN];
-			} else {
-				ret = cd->endpoint[i]->drv->ops.params(cd->endpoint[i],
-								       params);
+				ret = dev->direction == SOF_IPC_STREAM_PLAYBACK ?
+					dai_playback_params(cd->dd, dev,
+							    period_bytes, period_count) :
+					dai_capture_params(cd->dd, dev,
+							   period_bytes, period_count);
+				break;
+			default:
+				comp_err(dev, "Unexpected copier device params! %d",
+					 dev->ipc_config.type);
+				break;
 			}
 		}
 		if (ret < 0)

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -235,7 +235,7 @@ static void dai_free(struct comp_dev *dev)
 
 	dma_put(dd->dma);
 
-	dai_release_llp_slot(dev);
+	dai_release_llp_slot(dd);
 
 	dai_put(dd->dai);
 

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -59,10 +59,8 @@ static void dai_atomic_trigger(void *arg, enum notify_id type, void *data)
 }
 
 /* Assign DAI to a group */
-int dai_assign_group(struct comp_dev *dev, uint32_t group_id)
+int dai_assign_group(struct dai_data *dd, struct comp_dev *dev, uint32_t group_id)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
-
 	if (dd->group) {
 		if (dd->group->group_id != group_id) {
 			comp_err(dev, "dai_assign_group(), DAI already in group %d, requested %d",

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -477,7 +477,7 @@ static int dai_params(struct comp_dev *dev,
 	comp_dbg(dev, "dai_params()");
 
 	/* configure dai_data first */
-	err = ipc_dai_data_config(dev);
+	err = ipc_dai_data_config(dd, dev, &dev->ipc_config.frame_fmt);
 	if (err < 0)
 		return err;
 

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -997,7 +997,7 @@ static int dai_copy(struct comp_dev *dev)
 		return ret;
 	}
 
-	dai_dma_position_update(dev);
+	dai_dma_position_update(dd, dev);
 
 	return ret;
 }

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -713,7 +713,7 @@ static int dai_reset(struct comp_dev *dev)
 	 * It will be done when the host sends the DAI_CONFIG IPC during hw_free.
 	 */
 	if (!dd->delayed_dma_stop)
-		dai_dma_release(dev);
+		dai_dma_release(dd, dev);
 
 	dma_sg_free(&config->elem_array);
 

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -620,7 +620,7 @@ static int dai_config_prepare(struct comp_dev *dev)
 		return 0;
 	}
 
-	channel = dai_config_dma_channel(dev, dd->dai_spec_config);
+	channel = dai_config_dma_channel(dd, dev, dd->dai_spec_config);
 	comp_info(dev, "dai_config_prepare(), channel = %d", channel);
 
 	/* do nothing for asking for channel free, for compatibility. */

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -1295,91 +1295,6 @@ static int dai_copy(struct comp_dev *dev)
 	return dai_zephyr_copy(dd, dev);
 }
 
-/**
- * \brief Get DAI parameters and configure timestamping
- * \param[in, out] dev DAI device.
- * \return Error code.
- *
- * This function retrieves various DAI parameters such as type, direction, index, and DMA
- * controller information those are needed when configuring HW timestamping. Note that
- * DAI must be prepared before this function is used (for DMA information). If not, an error
- * is returned.
- */
-static int dai_ts_config_op(struct comp_dev *dev)
-{
-	struct dai_data *dd = comp_get_drvdata(dev);
-	struct ipc_config_dai *dai = &dd->ipc_config;
-	struct dai_ts_cfg cfg;
-
-	comp_dbg(dev, "dai_ts_config()");
-	if (!dd->chan) {
-		comp_err(dev, "dai_ts_config(), No DMA channel information");
-		return -EINVAL;
-	}
-
-	switch (dai->type) {
-	case SOF_DAI_INTEL_SSP:
-		cfg.type = DAI_INTEL_SSP;
-		break;
-	case SOF_DAI_INTEL_ALH:
-		cfg.type = DAI_INTEL_ALH;
-		break;
-	case SOF_DAI_INTEL_DMIC:
-		cfg.type = DAI_INTEL_DMIC;
-		break;
-	default:
-		comp_err(dev, "dai_ts_config(), not supported dai type");
-		return -EINVAL;
-	}
-
-	cfg.direction = dai->direction;
-	cfg.index = dd->dai->index;
-	cfg.dma_id = dd->dma->plat_data.id;
-	cfg.dma_chan_index = dd->chan->index;
-	cfg.dma_chan_count = dd->dma->plat_data.channels;
-
-	return dai_ts_config(dd->dai->dev, &cfg);
-}
-
-static int dai_ts_start_op(struct comp_dev *dev)
-{
-	struct dai_data *dd = comp_get_drvdata(dev);
-	struct dai_ts_cfg cfg;
-
-	comp_dbg(dev, "dai_ts_start()");
-
-	return dai_ts_start(dd->dai->dev, &cfg);
-}
-
-static int dai_ts_get_op(struct comp_dev *dev, struct timestamp_data *tsd)
-{
-	struct dai_data *dd = comp_get_drvdata(dev);
-	struct dai_ts_data tsdata;
-	struct dai_ts_cfg cfg;
-	int ret;
-
-	comp_dbg(dev, "dai_ts_get()");
-
-	ret = dai_ts_get(dd->dai->dev, &cfg, &tsdata);
-
-	if (ret < 0)
-		return ret;
-
-	/* todo convert to timestamp_data */
-
-	return ret;
-}
-
-static int dai_ts_stop_op(struct comp_dev *dev)
-{
-	struct dai_data *dd = comp_get_drvdata(dev);
-	struct dai_ts_cfg cfg;
-
-	comp_dbg(dev, "dai_ts_stop()");
-
-	return dai_ts_stop(dd->dai->dev, &cfg);
-}
-
 uint32_t dai_get_init_delay_ms(struct dai *dai)
 {
 	const struct dai_properties *props;
@@ -1426,10 +1341,6 @@ static const struct comp_driver comp_dai = {
 		.reset				= dai_reset,
 		.position			= dai_position,
 		.dai_config			= dai_config,
-		.dai_ts_config			= dai_ts_config_op,
-		.dai_ts_start			= dai_ts_start_op,
-		.dai_ts_stop			= dai_ts_stop_op,
-		.dai_ts_get			= dai_ts_get_op,
 		.get_total_data_processed	= dai_get_processed_data,
 },
 };

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -64,10 +64,8 @@ static void dai_atomic_trigger(void *arg, enum notify_id type, void *data)
 }
 
 /* Assign DAI to a group */
-int dai_assign_group(struct comp_dev *dev, uint32_t group_id)
+int dai_assign_group(struct dai_data *dd, struct comp_dev *dev, uint32_t group_id)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
-
 	if (dd->group) {
 		if (dd->group->group_id != group_id) {
 			comp_err(dev, "dai_assign_group(), DAI already in group %d, requested %d",
@@ -361,7 +359,6 @@ e_data:
 void dai_zephyr_free(struct dai_data *dd, struct comp_dev *dev)
 {
 	if (dd->group) {
-		notifier_unregister(dev, dd->group, NOTIFIER_ID_DAI_TRIGGER);
 		dai_group_put(dd->group);
 	}
 	if (dd->chan) {
@@ -382,6 +379,9 @@ void dai_zephyr_free(struct dai_data *dd, struct comp_dev *dev)
 static void dai_free(struct comp_dev *dev)
 {
 	struct dai_data *dd = comp_get_drvdata(dev);
+
+	if (dd->group)
+		notifier_unregister(dev, dd->group, NOTIFIER_ID_DAI_TRIGGER);
 
 	dai_zephyr_free(dd, dev);
 
@@ -1340,7 +1340,6 @@ static const struct comp_driver comp_dai = {
 		.prepare			= dai_prepare,
 		.reset				= dai_reset,
 		.position			= dai_position,
-		.dai_config			= dai_config,
 		.get_total_data_processed	= dai_get_processed_data,
 },
 };

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -875,9 +875,8 @@ static int dai_params(struct comp_dev *dev, struct sof_ipc_stream_params *params
 		dai_capture_params(dev, period_bytes, period_count);
 }
 
-static int dai_config_prepare(struct comp_dev *dev)
+int dai_config_prepare(struct dai_data *dd, struct comp_dev *dev)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
 	int channel;
 
 	/* cannot configure DAI while active */
@@ -897,7 +896,7 @@ static int dai_config_prepare(struct comp_dev *dev)
 		return 0;
 	}
 
-	channel = dai_config_dma_channel(dev, dd->dai_spec_config);
+	channel = dai_config_dma_channel(dd, dev, dd->dai_spec_config);
 	comp_dbg(dev, "dai_config_prepare(), channel = %d", channel);
 
 	/* do nothing for asking for channel free, for compatibility. */
@@ -923,17 +922,10 @@ static int dai_config_prepare(struct comp_dev *dev)
 	return 0;
 }
 
-static int dai_prepare(struct comp_dev *dev)
+int dai_zephyr_prepare(struct dai_data *dd, struct comp_dev *dev)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
 	struct comp_buffer __sparse_cache *buffer_c;
 	int ret;
-
-	comp_dbg(dev, "dai_prepare()");
-
-	ret = dai_config_prepare(dev);
-	if (ret < 0)
-		return ret;
 
 	ret = comp_set_state(dev, COMP_TRIGGER_PREPARE);
 	if (ret < 0)
@@ -965,7 +957,7 @@ static int dai_prepare(struct comp_dev *dev)
 	if (dd->xrun) {
 		/* after prepare, we have recovered from xrun */
 		dd->xrun = 0;
-		return ret;
+		return -EINVAL;
 	}
 
 	ret = dma_config(dd->chan->dma->z_dev, dd->chan->index, dd->z_config);
@@ -973,6 +965,20 @@ static int dai_prepare(struct comp_dev *dev)
 		comp_set_state(dev, COMP_TRIGGER_RESET);
 
 	return ret;
+}
+
+static int dai_prepare(struct comp_dev *dev)
+{
+	struct dai_data *dd = comp_get_drvdata(dev);
+	int ret;
+
+	comp_dbg(dev, "dai_prepare()");
+
+	ret = dai_config_prepare(dd, dev);
+	if (ret < 0)
+		return ret;
+
+	return dai_zephyr_prepare(dd, dev);
 }
 
 static int dai_reset(struct comp_dev *dev)

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -284,34 +284,18 @@ static enum dma_cb_status dai_dma_cb(struct comp_dev *dev, uint32_t bytes)
 	return dma_status;
 }
 
-static struct comp_dev *dai_new(const struct comp_driver *drv,
-				const struct comp_ipc_config *config,
-				const void *spec)
+/*
+ * when copier call this function, dev will be passed with copier dev
+ */
+int dai_zephyr_new(struct dai_data *dd, struct comp_dev *dev,
+		   const struct ipc_config_dai *dai_cfg)
 {
-	struct comp_dev *dev;
-	const struct ipc_config_dai *dai_cfg = spec;
-	struct dai_data *dd;
 	uint32_t dir;
-
-	comp_cl_dbg(&comp_dai, "dai_new()");
-
-	dev = comp_alloc(drv, sizeof(*dev));
-	if (!dev)
-		return NULL;
-	dev->ipc_config = *config;
-
-	dd = rzalloc(SOF_MEM_ZONE_RUNTIME_SHARED, 0, SOF_MEM_CAPS_RAM, sizeof(*dd));
-	if (!dd) {
-		rfree(dev);
-		return NULL;
-	}
-
-	comp_set_drvdata(dev, dd);
 
 	dd->dai = dai_get(dai_cfg->type, dai_cfg->dai_index, DAI_CREAT);
 	if (!dd->dai) {
-		comp_cl_err(&comp_dai, "dai_new(): dai_get() failed to create DAI.");
-		goto error;
+		comp_err(dev, "dai_new(): dai_get() failed to create DAI.");
+		return -ENODEV;
 	}
 
 	dd->ipc_config = *dai_cfg;
@@ -322,8 +306,8 @@ static struct comp_dev *dai_new(const struct comp_driver *drv,
 
 	dd->dma = dma_get(dir, dd->dai->dma_caps, dd->dai->dma_dev, DMA_ACCESS_SHARED);
 	if (!dd->dma) {
-		comp_cl_err(&comp_dai, "dai_new(): dma_get() failed to get shared access to DMA.");
-		goto error;
+		comp_err(dev, "dai_new(): dma_get() failed to get shared access to DMA.");
+		return -ENODEV;
 	}
 
 	k_spinlock_init(&dd->dai->lock);
@@ -332,24 +316,55 @@ static struct comp_dev *dai_new(const struct comp_driver *drv,
 	dd->xrun = 0;
 	dd->chan = NULL;
 
+	return 0;
+}
+
+static struct comp_dev *dai_new(const struct comp_driver *drv,
+				const struct comp_ipc_config *config,
+				const void *spec)
+{
+	struct comp_dev *dev;
+	const struct ipc_config_dai *dai_cfg = spec;
+	struct dai_data *dd;
+	int ret;
+
+	comp_cl_dbg(&comp_dai, "dai_new()");
+
+	dev = comp_alloc(drv, sizeof(*dev));
+	if (!dev)
+		return NULL;
+	dev->ipc_config = *config;
+
+	dd = rzalloc(SOF_MEM_ZONE_RUNTIME_SHARED, 0, SOF_MEM_CAPS_RAM, sizeof(*dd));
+	if (!dd)
+		goto e_data;
+
+	comp_set_drvdata(dev, dd);
+
+	ret = dai_zephyr_new(dd, dev, dai_cfg);
+	if (ret < 0)
+		goto error;
+
 	dev->state = COMP_STATE_READY;
+
 	return dev;
 
 error:
 	rfree(dd);
+e_data:
 	rfree(dev);
 	return NULL;
 }
 
-static void dai_free(struct comp_dev *dev)
+/*
+ * dev need replace with copier dev, trigger and copy need register to copier dev
+ */
+void dai_zephyr_free(struct dai_data *dd, struct comp_dev *dev)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
-
 	if (dd->group) {
 		notifier_unregister(dev, dd->group, NOTIFIER_ID_DAI_TRIGGER);
 		dai_group_put(dd->group);
 	}
-
 	if (dd->chan) {
 		dma_release_channel(dd->dma->z_dev, dd->chan->index);
 		dd->chan->dev_data = NULL;
@@ -357,12 +372,20 @@ static void dai_free(struct comp_dev *dev)
 
 	dma_put(dd->dma);
 
-	dai_release_llp_slot(dev);
+	dai_release_llp_slot(dd);
 
 	dai_put(dd->dai);
 
 	rfree(dd->dai_spec_config);
 	rfree(dd);
+}
+
+static void dai_free(struct comp_dev *dev)
+{
+	struct dai_data *dd = comp_get_drvdata(dev);
+
+	dai_zephyr_free(dd, dev);
+
 	rfree(dev);
 }
 

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -981,19 +981,16 @@ static int dai_prepare(struct comp_dev *dev)
 	return dai_zephyr_prepare(dd, dev);
 }
 
-static int dai_reset(struct comp_dev *dev)
+void dai_zephyr_reset(struct dai_data *dd, struct comp_dev *dev)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
 	struct dma_sg_config *config = &dd->config;
-
-	comp_dbg(dev, "dai_reset()");
 
 	/*
 	 * DMA channel release should be skipped now for DAI's that support the two-step stop
 	 * option. It will be done when the host sends the DAI_CONFIG IPC during hw_free.
 	 */
 	if (!dd->delayed_dma_stop)
-		dai_dma_release(dev);
+		dai_dma_release(dd, dev);
 
 	dma_sg_free(&config->elem_array);
 	if (dd->z_config) {
@@ -1010,6 +1007,16 @@ static int dai_reset(struct comp_dev *dev)
 	dd->wallclock = 0;
 	dd->total_data_processed = 0;
 	dd->xrun = 0;
+}
+
+static int dai_reset(struct comp_dev *dev)
+{
+	struct dai_data *dd = comp_get_drvdata(dev);
+
+	comp_dbg(dev, "dai_reset()");
+
+	dai_zephyr_reset(dd, dev);
+
 	comp_set_state(dev, COMP_TRIGGER_RESET);
 
 	return 0;

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -56,7 +56,8 @@ static int dai_comp_trigger_internal(struct dai_data *dd, struct comp_dev *dev, 
 static void dai_atomic_trigger(void *arg, enum notify_id type, void *data)
 {
 	struct comp_dev *dev = arg;
-	struct dai_data *dd = comp_get_drvdata(dev);
+	struct copier_data *cd = comp_get_drvdata(dev);
+	struct dai_data *dd = cd->dd;
 	struct dai_group *group = dd->group;
 
 	/* Atomic context set by the last DAI to receive trigger command */
@@ -356,7 +357,7 @@ e_data:
 /*
  * dev need replace with copier dev, trigger and copy need register to copier dev
  */
-void dai_zephyr_free(struct dai_data *dd, struct comp_dev *dev)
+void dai_zephyr_free(struct dai_data *dd)
 {
 	if (dd->group) {
 		dai_group_put(dd->group);
@@ -383,7 +384,7 @@ static void dai_free(struct comp_dev *dev)
 	if (dd->group)
 		notifier_unregister(dev, dd->group, NOTIFIER_ID_DAI_TRIGGER);
 
-	dai_zephyr_free(dd, dev);
+	dai_zephyr_free(dd);
 
 	rfree(dev);
 }
@@ -683,9 +684,7 @@ out:
 int dai_zephyr_params(struct dai_data *dd, struct comp_dev *dev,
 		      struct sof_ipc_stream_params *params,
 		      uint32_t *count,
-		      uint32_t *bytes,
-		      struct list_item *bsource_list,
-		      struct list_item *bsink_list)
+		      uint32_t *bytes)
 {
 	struct sof_ipc_stream_params hw_params = *params;
 	struct comp_buffer __sparse_cache *buffer_c;
@@ -705,11 +704,11 @@ int dai_zephyr_params(struct dai_data *dd, struct comp_dev *dev,
 	component_set_nearest_period_frames(dev, params->rate);
 
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK)
-		dd->local_buffer = list_first_item(bsource_list,
+		dd->local_buffer = list_first_item(&dev->bsource_list,
 						   struct comp_buffer,
 						   sink_list);
 	else
-		dd->local_buffer = list_first_item(bsink_list,
+		dd->local_buffer = list_first_item(&dev->bsink_list,
 						   struct comp_buffer,
 						   source_list);
 
@@ -747,13 +746,8 @@ int dai_zephyr_params(struct dai_data *dd, struct comp_dev *dev,
 		return -EINVAL;
 	}
 
-	buffer_c = buffer_acquire(dd->local_buffer);
-
 	/* calculate frame size */
-	frame_size = get_frame_bytes(dev->ipc_config.frame_fmt,
-				     audio_stream_get_channels(&buffer_c->stream));
-
-	buffer_release(buffer_c);
+	frame_size = get_frame_bytes(dev->ipc_config.frame_fmt, params->channels);
 
 	/* calculate period size */
 	period_bytes = dev->frames * frame_size;
@@ -815,8 +809,7 @@ static int dai_params(struct comp_dev *dev, struct sof_ipc_stream_params *params
 
 	comp_dbg(dev, "dai_params()");
 
-	ret = dai_zephyr_params(dd, dev, params, &period_count, &period_bytes,
-				&dev->bsource_list, &dev->bsink_list);
+	ret = dai_zephyr_params(dd, dev, params, &period_count, &period_bytes);
 	if (ret < 0)
 		return ret;
 
@@ -876,13 +869,6 @@ int dai_zephyr_prepare(struct dai_data *dd, struct comp_dev *dev)
 {
 	struct comp_buffer __sparse_cache *buffer_c;
 	int ret;
-
-	ret = comp_set_state(dev, COMP_TRIGGER_PREPARE);
-	if (ret < 0)
-		return ret;
-
-	if (ret == COMP_STATUS_STATE_ALREADY_SET)
-		return PPL_STATUS_PATH_STOP;
 
 	dd->total_data_processed = 0;
 
@@ -980,13 +966,6 @@ static int dai_comp_trigger_internal(struct dai_data *dd, struct comp_dev *dev, 
 
 	comp_dbg(dev, "dai_comp_trigger_internal(), command = %u", cmd);
 
-	ret = comp_set_state(dev, cmd);
-	if (ret < 0)
-		return ret;
-
-	if (ret == COMP_STATUS_STATE_ALREADY_SET)
-		return PPL_STATUS_PATH_STOP;
-
 	switch (cmd) {
 	case COMP_TRIGGER_START:
 		comp_dbg(dev, "dai_comp_trigger_internal(), START");
@@ -1074,7 +1053,7 @@ static int dai_comp_trigger_internal(struct dai_data *dd, struct comp_dev *dev, 
 	case COMP_TRIGGER_PAUSE:
 		comp_dbg(dev, "dai_comp_trigger_internal(), PAUSE");
 #if CONFIG_COMP_DAI_TRIGGER_ORDER_REVERSE
-		if (prev_state == COMP_STATE_ACTIVE) {
+		if (prev_state == COMP_STATE_ACTIVE || prev_state == COMP_STATE_PAUSED) {
 			ret = dma_suspend(dd->chan->dma->z_dev, dd->chan->index);
 		} else {
 			comp_warn(dev, "dma was stopped earlier");
@@ -1083,7 +1062,7 @@ static int dai_comp_trigger_internal(struct dai_data *dd, struct comp_dev *dev, 
 		dai_trigger_op(dd->dai, cmd, dev->direction);
 #else
 		dai_trigger_op(dd->dai, cmd, dev->direction);
-		if (prev_state == COMP_STATE_ACTIVE) {
+		if (prev_state == COMP_STATE_ACTIVE || prev_state == COMP_STATE_PAUSED) {
 			ret = dma_suspend(dd->chan->dma->z_dev, dd->chan->index);
 		} else {
 			comp_warn(dev, "dma was stopped earlier");

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -51,7 +51,7 @@ DECLARE_TR_CTX(dai_comp_tr, SOF_UUID(dai_comp_uuid), LOG_LEVEL_INFO);
 
 #if CONFIG_COMP_DAI_GROUP
 
-static int dai_comp_trigger_internal(struct comp_dev *dev, int cmd);
+static int dai_comp_trigger_internal(struct dai_data *dd, struct comp_dev *dev, int cmd);
 
 static void dai_atomic_trigger(void *arg, enum notify_id type, void *data)
 {
@@ -60,7 +60,7 @@ static void dai_atomic_trigger(void *arg, enum notify_id type, void *data)
 	struct dai_group *group = dd->group;
 
 	/* Atomic context set by the last DAI to receive trigger command */
-	group->trigger_ret = dai_comp_trigger_internal(dev, group->trigger_cmd);
+	group->trigger_ret = dai_comp_trigger_internal(dd, dev, group->trigger_cmd);
 }
 
 /* Assign DAI to a group */
@@ -1022,20 +1022,11 @@ static int dai_reset(struct comp_dev *dev)
 	return 0;
 }
 
-static void dai_update_start_position(struct comp_dev *dev)
-{
-	struct dai_data *dd = comp_get_drvdata(dev);
-
-	/* update starting wallclock */
-	platform_dai_wallclock(dev, &dd->wallclock);
-}
-
 /* used to pass standard and bespoke command (with data) to component */
-static int dai_comp_trigger_internal(struct comp_dev *dev, int cmd)
+static int dai_comp_trigger_internal(struct dai_data *dd, struct comp_dev *dev, int cmd)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
 	int prev_state = dev->state;
-	int ret;
+	int ret = 0;
 
 	comp_dbg(dev, "dai_comp_trigger_internal(), command = %u", cmd);
 
@@ -1062,7 +1053,7 @@ static int dai_comp_trigger_internal(struct comp_dev *dev, int cmd)
 			dd->xrun = 0;
 		}
 
-		dai_update_start_position(dev);
+		platform_dai_wallclock(dev, &dd->wallclock);
 		break;
 	case COMP_TRIGGER_RELEASE:
 		/* before release, we clear the buffer data to 0s,
@@ -1101,7 +1092,7 @@ static int dai_comp_trigger_internal(struct comp_dev *dev, int cmd)
 			dd->xrun = 0;
 		}
 
-		dai_update_start_position(dev);
+		platform_dai_wallclock(dev, &dd->wallclock);
 		break;
 	case COMP_TRIGGER_XRUN:
 		comp_info(dev, "dai_comp_trigger_internal(), XRUN");
@@ -1163,17 +1154,16 @@ static int dai_comp_trigger_internal(struct comp_dev *dev, int cmd)
 	return ret;
 }
 
-static int dai_comp_trigger(struct comp_dev *dev, int cmd)
+int dai_zephyr_trigger(struct dai_data *dd, struct comp_dev *dev, int cmd)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
 	struct dai_group *group = dd->group;
 	uint32_t irq_flags;
 	int ret = 0;
 
 	/* DAI not in a group, use normal trigger */
 	if (!group) {
-		comp_dbg(dev, "dai_comp_trigger(), non-atomic trigger");
-		return dai_comp_trigger_internal(dev, cmd);
+		comp_dbg(dev, "dai_zephyr_trigger(), non-atomic trigger");
+		return dai_comp_trigger_internal(dd, dev, cmd);
 	}
 
 	/* DAI is grouped, so only trigger when the entire group is ready */
@@ -1182,13 +1172,13 @@ static int dai_comp_trigger(struct comp_dev *dev, int cmd)
 		/* First DAI to receive the trigger command,
 		 * prepare for atomic trigger
 		 */
-		comp_dbg(dev, "dai_comp_trigger(), begin atomic trigger for group %d",
+		comp_dbg(dev, "dai_zephyr_trigger(), begin atomic trigger for group %d",
 			 group->group_id);
 		group->trigger_cmd = cmd;
 		group->trigger_counter = group->num_dais - 1;
 	} else if (group->trigger_cmd != cmd) {
 		/* Already processing a different trigger command */
-		comp_err(dev, "dai_comp_trigger(), already processing atomic trigger");
+		comp_err(dev, "dai_zephyr_trigger(), already processing atomic trigger");
 		ret = -EAGAIN;
 	} else {
 		/* Count down the number of remaining DAIs required
@@ -1196,7 +1186,7 @@ static int dai_comp_trigger(struct comp_dev *dev, int cmd)
 		 * takes place
 		 */
 		group->trigger_counter--;
-		comp_dbg(dev, "dai_comp_trigger(), trigger counter %d, group %d",
+		comp_dbg(dev, "dai_zephyr_trigger(), trigger counter %d, group %d",
 			 group->trigger_counter, group->group_id);
 
 		if (!group->trigger_counter) {
@@ -1217,6 +1207,13 @@ static int dai_comp_trigger(struct comp_dev *dev, int cmd)
 	}
 
 	return ret;
+}
+
+static int dai_comp_trigger(struct comp_dev *dev, int cmd)
+{
+	struct dai_data *dd = comp_get_drvdata(dev);
+
+	return dai_zephyr_trigger(dd, dev, cmd);
 }
 
 /* report xrun occurrence */

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -219,9 +219,8 @@ static int dai_get_fifo(struct dai *dai, int direction, int stream_id)
 }
 
 /* this is called by DMA driver every time descriptor has completed */
-static enum dma_cb_status dai_dma_cb(struct comp_dev *dev, uint32_t bytes)
+static enum dma_cb_status dai_dma_cb(struct dai_data *dd, struct comp_dev *dev, uint32_t bytes)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
 	struct comp_buffer __sparse_cache *local_buf, *dma_buf;
 	enum dma_cb_status dma_status = DMA_CB_STATUS_RELOAD;
 	int ret;
@@ -1197,9 +1196,8 @@ static int dai_comp_trigger(struct comp_dev *dev, int cmd)
 }
 
 /* report xrun occurrence */
-static void dai_report_xrun(struct comp_dev *dev, uint32_t bytes)
+static void dai_report_xrun(struct dai_data *dd, struct comp_dev *dev, uint32_t bytes)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
 	struct comp_buffer __sparse_cache *buf_c = buffer_acquire(dd->local_buffer);
 
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK) {
@@ -1213,10 +1211,8 @@ static void dai_report_xrun(struct comp_dev *dev, uint32_t bytes)
 	buffer_release(buf_c);
 }
 
-/* copy and process stream data from source to sink buffers */
-static int dai_copy(struct comp_dev *dev)
+int dai_zephyr_copy(struct dai_data *dd, struct comp_dev *dev)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
 	uint32_t dma_fmt;
 	uint32_t sampling;
 	struct comp_buffer __sparse_cache *buf_c;
@@ -1228,8 +1224,6 @@ static int dai_copy(struct comp_dev *dev)
 	uint32_t sink_samples;
 	uint32_t samples;
 	int ret;
-
-	comp_dbg(dev, "dai_copy()");
 
 	/* get data sizes from DMA */
 	ret = dma_get_status(dd->chan->dma->z_dev, dd->chan->index, &stat);
@@ -1308,18 +1302,26 @@ static int dai_copy(struct comp_dev *dev)
 	if (ret < 0)
 		comp_warn(dev, "dai_copy(): dai trigger copy failed");
 
-	if (dai_dma_cb(dev, copy_bytes) == DMA_CB_STATUS_END)
+	if (dai_dma_cb(dd, dev, copy_bytes) == DMA_CB_STATUS_END)
 		dma_stop(dd->chan->dma->z_dev, dd->chan->index);
 
 	ret = dma_reload(dd->chan->dma->z_dev, dd->chan->index, 0, 0, copy_bytes);
 	if (ret < 0) {
-		dai_report_xrun(dev, copy_bytes);
+		dai_report_xrun(dd, dev, copy_bytes);
 		return ret;
 	}
 
-	dai_dma_position_update(dev);
+	dai_dma_position_update(dd, dev);
 
 	return ret;
+}
+
+/* copy and process stream data from source to sink buffers */
+static int dai_copy(struct comp_dev *dev)
+{
+	struct dai_data *dd = comp_get_drvdata(dev);
+
+	return dai_zephyr_copy(dd, dev);
 }
 
 /**

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -388,35 +388,6 @@ static void dai_free(struct comp_dev *dev)
 	rfree(dev);
 }
 
-static int dai_comp_get_hw_params(struct comp_dev *dev,
-				  struct sof_ipc_stream_params *params,
-				  int dir)
-{
-	struct dai_data *dd = comp_get_drvdata(dev);
-	struct dai_config cfg;
-	int ret;
-
-	comp_dbg(dev, "dai_hw_params()");
-
-	ret = dai_config_get(dd->dai->dev, &cfg, dir);
-	if (ret)
-		return ret;
-
-	params->rate = cfg.rate;
-	params->buffer_fmt = 0;
-	params->channels = cfg.channels;
-
-	/* dai_comp_get_hw_params() function fetches hardware dai parameters,
-	 * which then are propagating back through the pipeline, so that any
-	 * component can convert specific stream parameter. Here, we overwrite
-	 * frame_fmt hardware parameter as DAI component is able to convert
-	 * stream with different frame_fmt's (using pcm converter)
-	 */
-	params->frame_fmt = dev->ipc_config.frame_fmt;
-
-	return ret;
-}
-
 /* set component audio SSP and DMA configuration */
 int dai_playback_params(struct dai_data *dd, struct comp_dev *dev, uint32_t period_bytes,
 			uint32_t period_count)
@@ -1449,7 +1420,6 @@ static const struct comp_driver comp_dai = {
 		.create				= dai_new,
 		.free				= dai_free,
 		.params				= dai_params,
-		.dai_get_hw_params		= dai_comp_get_hw_params,
 		.trigger			= dai_comp_trigger,
 		.copy				= dai_copy,
 		.prepare			= dai_prepare,

--- a/src/audio/pipeline/pipeline-stream.c
+++ b/src/audio/pipeline/pipeline-stream.c
@@ -325,11 +325,22 @@ static int pipeline_comp_trigger(struct comp_dev *current,
 			 * Initialization delay is only used with SSP, where we
 			 * don't use more than one DAI per copier
 			 */
+#if CONFIG_IPC_MAJOR_4
+			/* ipc4 case, dd get from cd->dd */
+			struct copier_data *cd = comp_get_drvdata(current);
+
+			if (cd) {
+				struct dai_data *dd = cd->dd;
+
+#elif CONFIG_IPC_MAJOR_3
 			struct comp_dev *dai = comp_get_dai(current, 0);
 
 			if (dai) {
 				struct dai_data *dd = comp_get_drvdata(dai);
 
+#else
+#error Unknown IPC major version
+#endif
 				ppl_data->delay_ms = dai_get_init_delay_ms(dd->dai);
 			} else {
 				/* Chain DMA case */

--- a/src/include/ipc4/copier.h
+++ b/src/include/ipc4/copier.h
@@ -263,6 +263,7 @@ struct copier_data {
 	uint64_t output_total_data_processed;
 	struct host_data *hd;
 	bool ipc_gtw;
+	struct dai_data *dd;
 };
 
 int apply_attenuation(struct comp_dev *dev, struct copier_data *cd,

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -347,8 +347,8 @@ struct comp_ops {
 	 *
 	 * Mandatory for components that allocate DAI.
 	 */
-	int (*dai_config)(struct comp_dev *dev, struct ipc_config_dai *dai_config,
-			  const void *dai_spec_config);
+	int (*dai_config)(struct dai_data *dd, struct comp_dev *dev,
+			  struct ipc_config_dai *dai_config, const void *dai_spec_config);
 
 	/**
 	 * Used to pass standard and bespoke commands (with optional data).

--- a/src/include/sof/audio/component_ext.h
+++ b/src/include/sof/audio/component_ext.h
@@ -252,16 +252,27 @@ static inline int comp_reset(struct comp_dev *dev)
 	return 0;
 }
 
+#if CONFIG_IPC_MAJOR_3
 /** See comp_ops::dai_config */
 static inline int comp_dai_config(struct comp_dev *dev, struct ipc_config_dai *config,
 				  const void *spec_config)
 {
+	struct dai_data *dd = comp_get_drvdata(dev);
+
 	if (dev->drv->ops.dai_config)
-		return dev->drv->ops.dai_config(dev, config, spec_config);
+		return dev->drv->ops.dai_config(dd, dev, config, spec_config);
 
 	return 0;
 }
-
+#elif CONFIG_IPC_MAJOR_4
+static inline int comp_dai_config(struct dai_data *dd, struct comp_dev *dev,
+				  struct ipc_config_dai *config, const void *spec_config)
+{
+	return dai_config(dd, dev, config, spec_config);
+}
+#else
+#error Unknown IPC major version
+#endif
 /** See comp_ops::position */
 static inline int comp_position(struct comp_dev *dev,
 				struct sof_ipc_stream_posn *posn)

--- a/src/include/sof/audio/dai_copier.h
+++ b/src/include/sof/audio/dai_copier.h
@@ -24,7 +24,7 @@ int dai_zephyr_new(struct dai_data *dd, struct comp_dev *dev,
 /**
  * \brief dai free through dai_data
  */
-void dai_zephyr_free(struct dai_data *dd, struct comp_dev *dev);
+void dai_zephyr_free(struct dai_data *dd);
 
 /**
  * \brief dai config prepare through dai_data
@@ -64,9 +64,7 @@ int dai_capture_params(struct dai_data *dd, struct comp_dev *dev, uint32_t perio
 int dai_zephyr_params(struct dai_data *dd, struct comp_dev *dev,
 		      struct sof_ipc_stream_params *params,
 		      uint32_t *period_count,
-		      uint32_t *period_bytes,
-		      struct list_item *bsource_list,
-		      struct list_item *bsink_list);
+		      uint32_t *period_bytes);
 
 /**
  * \brief dai zephyr copy
@@ -85,7 +83,7 @@ static inline int dai_zephyr_new(struct dai_data *dd, struct comp_dev *dev,
 /**
  * \brief dai free through dai_data
  */
-static inline void dai_zephyr_free(struct dai_data *dd, struct comp_dev *dev) {}
+static inline void dai_zephyr_free(struct dai_data *dd) {}
 
 /**
  * \brief dai config prepare through dai_data
@@ -140,9 +138,7 @@ static inline int dai_capture_params(struct dai_data *dd, struct comp_dev *dev,
 static inline int dai_zephyr_params(struct dai_data *dd, struct comp_dev *dev,
 				    struct sof_ipc_stream_params *params,
 				    uint32_t *period_count,
-				    uint32_t *period_bytes,
-				    struct list_item *bsource_list,
-				    struct list_item *bsink_list)
+				    uint32_t *period_bytes)
 {
 	return 0;
 }

--- a/src/include/sof/audio/dai_copier.h
+++ b/src/include/sof/audio/dai_copier.h
@@ -40,6 +40,11 @@ int dai_zephyr_prepare(struct dai_data *dd, struct comp_dev *dev);
  * \brief dai zephyr reset
  */
 void dai_zephyr_reset(struct dai_data *dd, struct comp_dev *dev);
+
+/**
+ * \brief dai zephyr reset
+ */
+int dai_zephyr_trigger(struct dai_data *dd, struct comp_dev *dev, int cmd);
 #else
 /**
  * \brief dai new through dai_data
@@ -75,6 +80,14 @@ static inline int dai_zephyr_prepare(struct dai_data *dd, struct comp_dev *dev)
  * \brief dai zephyr reset
  */
 static inline void dai_zephyr_reset(struct dai_data *dd, struct comp_dev *dev) {}
+
+/**
+ * \brief dai zephyr reset
+ */
+static inline int dai_zephyr_trigger(struct dai_data *dd, struct comp_dev *dev, int cmd)
+{
+	return 0;
+}
 
 #endif
 #endif /* __SOF_LIB_DAI_COPIER_H__ */

--- a/src/include/sof/audio/dai_copier.h
+++ b/src/include/sof/audio/dai_copier.h
@@ -35,6 +35,11 @@ int dai_config_prepare(struct dai_data *dd, struct comp_dev *dev);
  * \brief dai config prepare through dai_data
  */
 int dai_zephyr_prepare(struct dai_data *dd, struct comp_dev *dev);
+
+/**
+ * \brief dai zephyr reset
+ */
+void dai_zephyr_reset(struct dai_data *dd, struct comp_dev *dev);
 #else
 /**
  * \brief dai new through dai_data
@@ -65,6 +70,11 @@ static inline int dai_zephyr_prepare(struct dai_data *dd, struct comp_dev *dev)
 {
 	return 0;
 }
+
+/**
+ * \brief dai zephyr reset
+ */
+static inline void dai_zephyr_reset(struct dai_data *dd, struct comp_dev *dev) {}
 
 #endif
 #endif /* __SOF_LIB_DAI_COPIER_H__ */

--- a/src/include/sof/audio/dai_copier.h
+++ b/src/include/sof/audio/dai_copier.h
@@ -25,6 +25,16 @@ int dai_zephyr_new(struct dai_data *dd, struct comp_dev *dev,
  * \brief dai free through dai_data
  */
 void dai_zephyr_free(struct dai_data *dd, struct comp_dev *dev);
+
+/**
+ * \brief dai config prepare through dai_data
+ */
+int dai_config_prepare(struct dai_data *dd, struct comp_dev *dev);
+
+/**
+ * \brief dai config prepare through dai_data
+ */
+int dai_zephyr_prepare(struct dai_data *dd, struct comp_dev *dev);
 #else
 /**
  * \brief dai new through dai_data
@@ -39,6 +49,22 @@ static inline int dai_zephyr_new(struct dai_data *dd, struct comp_dev *dev,
  * \brief dai free through dai_data
  */
 static inline void dai_zephyr_free(struct dai_data *dd, struct comp_dev *dev) {}
+
+/**
+ * \brief dai config prepare through dai_data
+ */
+static inline int dai_config_prepare(struct dai_data *dd, struct comp_dev *dev)
+{
+	return 0;
+}
+
+/**
+ * \brief dai config prepare through dai_data
+ */
+static inline int dai_zephyr_prepare(struct dai_data *dd, struct comp_dev *dev)
+{
+	return 0;
+}
 
 #endif
 #endif /* __SOF_LIB_DAI_COPIER_H__ */

--- a/src/include/sof/audio/dai_copier.h
+++ b/src/include/sof/audio/dai_copier.h
@@ -67,6 +67,11 @@ int dai_zephyr_params(struct dai_data *dd, struct comp_dev *dev,
 		      uint32_t *period_bytes,
 		      struct list_item *bsource_list,
 		      struct list_item *bsink_list);
+
+/**
+ * \brief dai zephyr copy
+ */
+int dai_zephyr_copy(struct dai_data *dd, struct comp_dev *dev);
 #else
 /**
  * \brief dai new through dai_data
@@ -138,6 +143,14 @@ static inline int dai_zephyr_params(struct dai_data *dd, struct comp_dev *dev,
 				    uint32_t *period_bytes,
 				    struct list_item *bsource_list,
 				    struct list_item *bsink_list)
+{
+	return 0;
+}
+
+/**
+ * \brief dai zephyr copy
+ */
+static inline int dai_zephyr_copy(struct dai_data *dd, struct comp_dev *dev)
 {
 	return 0;
 }

--- a/src/include/sof/audio/dai_copier.h
+++ b/src/include/sof/audio/dai_copier.h
@@ -1,0 +1,44 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2023 Intel Corporation. All rights reserved.
+ *
+ * Author: Baofeng Tian <baofeng.tian@intel.com>
+ */
+
+/**
+ * \file audio/dai_copier.h
+ * \brief dai copier shared header file
+ * \authors Baofeng Tian <baofeng.tian@intel.com>
+ */
+
+#ifndef __SOF_LIB_DAI_COPIER_H__
+#define __SOF_LIB_DAI_COPIER_H__
+
+#if CONFIG_ZEPHYR_NATIVE_DRIVERS
+/**
+ * \brief dai new through dai_data
+ */
+int dai_zephyr_new(struct dai_data *dd, struct comp_dev *dev,
+		   const struct ipc_config_dai *dai_cfg);
+
+/**
+ * \brief dai free through dai_data
+ */
+void dai_zephyr_free(struct dai_data *dd, struct comp_dev *dev);
+#else
+/**
+ * \brief dai new through dai_data
+ */
+static inline int dai_zephyr_new(struct dai_data *dd, struct comp_dev *dev,
+				 const struct ipc_config_dai *dai_cfg)
+{
+	return 0;
+}
+
+/**
+ * \brief dai free through dai_data
+ */
+static inline void dai_zephyr_free(struct dai_data *dd, struct comp_dev *dev) {}
+
+#endif
+#endif /* __SOF_LIB_DAI_COPIER_H__ */

--- a/src/include/sof/audio/dai_copier.h
+++ b/src/include/sof/audio/dai_copier.h
@@ -45,6 +45,28 @@ void dai_zephyr_reset(struct dai_data *dd, struct comp_dev *dev);
  * \brief dai zephyr reset
  */
 int dai_zephyr_trigger(struct dai_data *dd, struct comp_dev *dev, int cmd);
+
+/**
+ * \brief dai playback params
+ */
+int dai_playback_params(struct dai_data *dd, struct comp_dev *dev, uint32_t period_bytes,
+			uint32_t period_count);
+
+/**
+ * \brief dai capture params
+ */
+int dai_capture_params(struct dai_data *dd, struct comp_dev *dev, uint32_t period_bytes,
+		       uint32_t period_count);
+
+/**
+ * \brief dai zephyr params
+ */
+int dai_zephyr_params(struct dai_data *dd, struct comp_dev *dev,
+		      struct sof_ipc_stream_params *params,
+		      uint32_t *period_count,
+		      uint32_t *period_bytes,
+		      struct list_item *bsource_list,
+		      struct list_item *bsink_list);
 #else
 /**
  * \brief dai new through dai_data
@@ -85,6 +107,37 @@ static inline void dai_zephyr_reset(struct dai_data *dd, struct comp_dev *dev) {
  * \brief dai zephyr reset
  */
 static inline int dai_zephyr_trigger(struct dai_data *dd, struct comp_dev *dev, int cmd)
+{
+	return 0;
+}
+
+/**
+ * \brief dai playback params
+ */
+static inline int dai_playback_params(struct dai_data *dd, struct comp_dev *dev,
+				      uint32_t period_bytes, uint32_t period_count)
+{
+	return 0;
+}
+
+/**
+ * \brief dai capture params
+ */
+static inline int dai_capture_params(struct dai_data *dd, struct comp_dev *dev,
+				     uint32_t period_bytes, uint32_t period_count)
+{
+	return 0;
+}
+
+/**
+ * \brief dai zephyr params
+ */
+static inline int dai_zephyr_params(struct dai_data *dd, struct comp_dev *dev,
+				    struct sof_ipc_stream_params *params,
+				    uint32_t *period_count,
+				    uint32_t *period_bytes,
+				    struct list_item *bsource_list,
+				    struct list_item *bsink_list)
 {
 	return 0;
 }

--- a/src/include/sof/ipc/common.h
+++ b/src/include/sof/ipc/common.h
@@ -145,7 +145,8 @@ void ipc_send_buffer_status_notify(void);
  * \brief Configure DAI.
  * @return 0 on success.
  */
-int ipc_dai_data_config(struct comp_dev *dev);
+struct dai_data;
+int ipc_dai_data_config(struct dai_data *dd, struct comp_dev *dev, uint32_t *frame_fmt);
 
 /**
  * \brief create a IPC boot complete message.

--- a/src/include/sof/lib/dai-legacy.h
+++ b/src/include/sof/lib/dai-legacy.h
@@ -548,7 +548,7 @@ int dai_config_dma_channel(struct dai_data *dd, struct comp_dev *dev, const void
 /**
  * \brief Reset DAI DMA config
  */
-void dai_dma_release(struct comp_dev *dev);
+void dai_dma_release(struct dai_data *dd, struct comp_dev *dev);
 
 /**
  * \brief Configure DAI physical interface.

--- a/src/include/sof/lib/dai-legacy.h
+++ b/src/include/sof/lib/dai-legacy.h
@@ -575,7 +575,7 @@ int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn);
 /**
  * \brief update dai dma position for host driver.
  */
-void dai_dma_position_update(struct comp_dev *dev);
+void dai_dma_position_update(struct dai_data *dd, struct comp_dev *dev);
 
 /**
  * \brief release llp slot

--- a/src/include/sof/lib/dai-legacy.h
+++ b/src/include/sof/lib/dai-legacy.h
@@ -543,7 +543,7 @@ static inline const struct dai_info *dai_info_get(void)
 /**
  * \brief Configure DMA channel for DAI
  */
-int dai_config_dma_channel(struct comp_dev *dev, const void *config);
+int dai_config_dma_channel(struct dai_data *dd, struct comp_dev *dev, const void *config);
 
 /**
  * \brief Reset DAI DMA config

--- a/src/include/sof/lib/dai-legacy.h
+++ b/src/include/sof/lib/dai-legacy.h
@@ -562,6 +562,12 @@ int dai_config(struct comp_dev *dev,  struct ipc_config_dai *common_config,
 int dai_assign_group(struct comp_dev *dev, uint32_t group_id);
 
 /**
+ * \brief dai zephyr position
+ */
+int dai_zephyr_position(struct dai_data *dd, struct comp_dev *dev,
+			struct sof_ipc_stream_posn *posn);
+
+/**
  * \brief dai position for host driver.
  */
 int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn);

--- a/src/include/sof/lib/dai-legacy.h
+++ b/src/include/sof/lib/dai-legacy.h
@@ -574,7 +574,7 @@ void dai_dma_position_update(struct comp_dev *dev);
 /**
  * \brief release llp slot
  */
-void dai_release_llp_slot(struct comp_dev *dev);
+void dai_release_llp_slot(struct dai_data *dd);
 /** @}*/
 
 #endif /* __SOF_LIB_DAI_LEGACY_H__ */

--- a/src/include/sof/lib/dai-legacy.h
+++ b/src/include/sof/lib/dai-legacy.h
@@ -553,13 +553,13 @@ void dai_dma_release(struct dai_data *dd, struct comp_dev *dev);
 /**
  * \brief Configure DAI physical interface.
  */
-int dai_config(struct comp_dev *dev,  struct ipc_config_dai *common_config,
+int dai_config(struct dai_data *dd, struct comp_dev *dev,  struct ipc_config_dai *common_config,
 	       const void *spec_config);
 
 /**
  * \brief Assign DAI to a group for simultaneous triggering.
  */
-int dai_assign_group(struct comp_dev *dev, uint32_t group_id);
+int dai_assign_group(struct dai_data *dd, struct comp_dev *dev, uint32_t group_id);
 
 /**
  * \brief dai zephyr position

--- a/src/include/sof/lib/dai-zephyr.h
+++ b/src/include/sof/lib/dai-zephyr.h
@@ -286,7 +286,7 @@ int dai_zephyr_position(struct dai_data *dd, struct comp_dev *dev,
 /**
  * \brief update dai dma position for host driver.
  */
-void dai_dma_position_update(struct comp_dev *dev);
+void dai_dma_position_update(struct dai_data *dd, struct comp_dev *dev);
 
 /**
  * \brief release llp slot

--- a/src/include/sof/lib/dai-zephyr.h
+++ b/src/include/sof/lib/dai-zephyr.h
@@ -265,12 +265,13 @@ void dai_dma_release(struct dai_data *dd, struct comp_dev *dev);
 /**
  * \brief Configure DAI physical interface.
  */
-int dai_config(struct comp_dev *dev,  struct ipc_config_dai *common_cfg, const void *spec_cfg);
+int dai_config(struct dai_data *dd, struct comp_dev *dev,
+	       struct ipc_config_dai *common_cfg, const void *spec_cfg);
 
 /**
  * \brief Assign DAI to a group for simultaneous triggering.
  */
-int dai_assign_group(struct comp_dev *dev, uint32_t group_id);
+int dai_assign_group(struct dai_data *dd, struct comp_dev *dev, uint32_t group_id);
 
 /**
  * \brief dai position for host driver.

--- a/src/include/sof/lib/dai-zephyr.h
+++ b/src/include/sof/lib/dai-zephyr.h
@@ -278,6 +278,12 @@ int dai_assign_group(struct comp_dev *dev, uint32_t group_id);
 int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn);
 
 /**
+ * \brief dai zephyr position
+ */
+int dai_zephyr_position(struct dai_data *dd, struct comp_dev *dev,
+			struct sof_ipc_stream_posn *posn);
+
+/**
  * \brief update dai dma position for host driver.
  */
 void dai_dma_position_update(struct comp_dev *dev);

--- a/src/include/sof/lib/dai-zephyr.h
+++ b/src/include/sof/lib/dai-zephyr.h
@@ -283,7 +283,7 @@ void dai_dma_position_update(struct comp_dev *dev);
 /**
  * \brief release llp slot
  */
-void dai_release_llp_slot(struct comp_dev *dev);
+void dai_release_llp_slot(struct dai_data *dd);
 /** @}*/
 
 #endif /* __SOF_LIB_DAI_ZEPHYR_H__ */

--- a/src/include/sof/lib/dai-zephyr.h
+++ b/src/include/sof/lib/dai-zephyr.h
@@ -32,7 +32,9 @@
 #include <errno.h>
 #include <stddef.h>
 #include <stdint.h>
+#ifdef __ZEPHYR__
 #include <zephyr/device.h>
+#endif
 
 /** \addtogroup sof_dai_drivers DAI Drivers
  *  DAI Drivers API specification.
@@ -258,7 +260,7 @@ int dai_config_dma_channel(struct dai_data *dd, struct comp_dev *dev, const void
 /**
  * \brief Reset DAI DMA config
  */
-void dai_dma_release(struct comp_dev *dev);
+void dai_dma_release(struct dai_data *dd, struct comp_dev *dev);
 
 /**
  * \brief Configure DAI physical interface.

--- a/src/include/sof/lib/dai-zephyr.h
+++ b/src/include/sof/lib/dai-zephyr.h
@@ -253,7 +253,7 @@ int dai_get_stream_id(struct dai *dai, int direction);
 /**
  * \brief Configure DMA channel for DAI
  */
-int dai_config_dma_channel(struct comp_dev *dev, const void *config);
+int dai_config_dma_channel(struct dai_data *dd, struct comp_dev *dev, const void *config);
 
 /**
  * \brief Reset DAI DMA config

--- a/src/ipc/ipc3/dai.c
+++ b/src/ipc/ipc3/dai.c
@@ -262,10 +262,8 @@ int ipc_comp_dai_config(struct ipc *ipc, struct ipc_config_dai *common_config,
 	return ret;
 }
 
-void dai_dma_release(struct comp_dev *dev)
+void dai_dma_release(struct dai_data *dd, struct comp_dev *dev)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
-
 	/* cannot configure DAI while active */
 	if (dev->state == COMP_STATE_ACTIVE) {
 		comp_info(dev, "dai_config(): Component is in active state. Ignore resetting");
@@ -335,7 +333,7 @@ int dai_config(struct comp_dev *dev, struct ipc_config_dai *common_config,
 			if (ret < 0)
 				return ret;
 
-			dai_dma_release(dev);
+			dai_dma_release(dd, dev);
 		}
 
 		return 0;

--- a/src/ipc/ipc3/dai.c
+++ b/src/ipc/ipc3/dai.c
@@ -392,6 +392,6 @@ int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn)
 	return 0;
 }
 
-void dai_dma_position_update(struct comp_dev *dev) { }
+void dai_dma_position_update(struct dai_data *dd, struct comp_dev *dev) { }
 
 void dai_release_llp_slot(struct dai_data *dd) { }

--- a/src/ipc/ipc3/dai.c
+++ b/src/ipc/ipc3/dai.c
@@ -29,9 +29,8 @@
 
 LOG_MODULE_DECLARE(ipc, CONFIG_SOF_LOG_LEVEL);
 
-int dai_config_dma_channel(struct comp_dev *dev, const void *spec_config)
+int dai_config_dma_channel(struct dai_data *dd, struct comp_dev *dev, const void *spec_config)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
 	const struct sof_ipc_dai_config *config = spec_config;
 	struct ipc_config_dai *dai = &dd->ipc_config;
 	int channel;
@@ -360,7 +359,7 @@ int dai_config(struct comp_dev *dev, struct ipc_config_dai *common_config,
 	}
 #endif
 	/* do nothing for asking for channel free, for compatibility. */
-	if (dai_config_dma_channel(dev, spec_config) == DMA_CHAN_INVALID)
+	if (dai_config_dma_channel(dd, dev, spec_config) == DMA_CHAN_INVALID)
 		return 0;
 
 	/* allocated dai_config if not yet */

--- a/src/ipc/ipc3/dai.c
+++ b/src/ipc/ipc3/dai.c
@@ -398,4 +398,4 @@ int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn)
 
 void dai_dma_position_update(struct comp_dev *dev) { }
 
-void dai_release_llp_slot(struct comp_dev *dev) { }
+void dai_release_llp_slot(struct dai_data *dd) { }

--- a/src/ipc/ipc3/dai.c
+++ b/src/ipc/ipc3/dai.c
@@ -94,9 +94,8 @@ int dai_config_dma_channel(struct dai_data *dd, struct comp_dev *dev, const void
 	return channel;
 }
 
-int ipc_dai_data_config(struct comp_dev *dev)
+int ipc_dai_data_config(struct dai_data *dd, struct comp_dev *dev, uint32_t *frame_fmt)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
 	struct ipc_config_dai *dai = &dd->ipc_config;
 	struct sof_ipc_dai_config *config = ipc_from_dai_config(dd->dai_spec_config);
 	struct comp_buffer __sparse_cache *buffer_c;
@@ -140,10 +139,10 @@ int ipc_dai_data_config(struct comp_dev *dev)
 		/* SDW HW FIFO always requires 32bit MSB aligned sample data for
 		 * all formats, such as 8/16/24/32 bits.
 		 */
-		dev->ipc_config.frame_fmt = SOF_IPC_FRAME_S32_LE;
+		*frame_fmt = SOF_IPC_FRAME_S32_LE;
 		if (dd->dma_buffer) {
 			buffer_c = buffer_acquire(dd->dma_buffer);
-			audio_stream_set_frm_fmt(&buffer_c->stream, dev->ipc_config.frame_fmt);
+			audio_stream_set_frm_fmt(&buffer_c->stream, *frame_fmt);
 			buffer_release(buffer_c);
 		}
 		dd->config.burst_elems = dai_get_fifo_depth(dd->dai, dai->direction);
@@ -158,23 +157,23 @@ int ipc_dai_data_config(struct comp_dev *dev)
 		dd->config.burst_elems = dai_get_fifo_depth(dd->dai, dai->direction);
 		break;
 	case SOF_DAI_AMD_BT:
-		dev->ipc_config.frame_fmt = SOF_IPC_FRAME_S16_LE;
+		*frame_fmt = SOF_IPC_FRAME_S16_LE;
 		break;
 	case SOF_DAI_AMD_SP:
 	case SOF_DAI_AMD_SP_VIRTUAL:
-		dev->ipc_config.frame_fmt = SOF_IPC_FRAME_S16_LE;
+		*frame_fmt = SOF_IPC_FRAME_S16_LE;
 		break;
 	case SOF_DAI_AMD_DMIC:
-		dev->ipc_config.frame_fmt = SOF_IPC_FRAME_S32_LE;
+		*frame_fmt = SOF_IPC_FRAME_S32_LE;
 		if (dd->dma_buffer) {
 			buffer_c = buffer_acquire(dd->dma_buffer);
-			audio_stream_set_frm_fmt(&buffer_c->stream, dev->ipc_config.frame_fmt);
+			audio_stream_set_frm_fmt(&buffer_c->stream, *frame_fmt);
 			buffer_release(buffer_c);
 		}
 		break;
 	case SOF_DAI_AMD_HS:
 	case SOF_DAI_AMD_HS_VIRTUAL:
-		dev->ipc_config.frame_fmt = SOF_IPC_FRAME_S16_LE;
+		*frame_fmt = SOF_IPC_FRAME_S16_LE;
 		break;
 	case SOF_DAI_MEDIATEK_AFE:
 		break;

--- a/src/ipc/ipc3/dai.c
+++ b/src/ipc/ipc3/dai.c
@@ -283,11 +283,10 @@ void dai_dma_release(struct dai_data *dd, struct comp_dev *dev)
 	}
 }
 
-int dai_config(struct comp_dev *dev, struct ipc_config_dai *common_config,
+int dai_config(struct dai_data *dd, struct comp_dev *dev, struct ipc_config_dai *common_config,
 	       const void *spec_config)
 {
 	const struct sof_ipc_dai_config *config = spec_config;
-	struct dai_data *dd = comp_get_drvdata(dev);
 	int ret;
 
 	/* ignore if message not for this DAI id/type */
@@ -349,7 +348,7 @@ int dai_config(struct comp_dev *dev, struct ipc_config_dai *common_config,
 	}
 #if CONFIG_COMP_DAI_GROUP
 	if (config->group_id) {
-		ret = dai_assign_group(dev, config->group_id);
+		ret = dai_assign_group(dd, dev, config->group_id);
 
 		if (ret)
 			return ret;

--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -248,9 +248,8 @@ static int dai_get_unused_llp_slot(struct comp_dev *dev,
 	return offset;
 }
 
-static int dai_init_llp_info(struct comp_dev *dev)
+static int dai_init_llp_info(struct dai_data *dd, struct comp_dev *dev)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
 	struct ipc4_copier_module_cfg *copier_cfg;
 	union ipc4_connector_node_id node;
 	int ret;
@@ -278,11 +277,10 @@ static int dai_init_llp_info(struct comp_dev *dev)
 	return 0;
 }
 
-int dai_config(struct comp_dev *dev, struct ipc_config_dai *common_config,
+int dai_config(struct dai_data *dd, struct comp_dev *dev, struct ipc_config_dai *common_config,
 	       const void *spec_config)
 {
 	const struct ipc4_copier_module_cfg *copier_cfg = spec_config;
-	struct dai_data *dd = comp_get_drvdata(dev);
 	int size;
 	int ret;
 
@@ -308,7 +306,7 @@ int dai_config(struct comp_dev *dev, struct ipc_config_dai *common_config,
 
 #if CONFIG_COMP_DAI_GROUP
 	if (common_config->group_id) {
-		ret = dai_assign_group(dev, common_config->group_id);
+		ret = dai_assign_group(dd, dev, common_config->group_id);
 
 		if (ret)
 			return ret;
@@ -317,7 +315,7 @@ int dai_config(struct comp_dev *dev, struct ipc_config_dai *common_config,
 	/* do nothing for asking for channel free, for compatibility. */
 	if (dai_config_dma_channel(dd, dev, spec_config) == DMA_CHAN_INVALID)
 		return 0;
-
+	/* only period was used, so copier and dai are same */
 	dd->dai_dev = dev;
 
 	/* allocated dai_config if not yet */
@@ -337,7 +335,7 @@ int dai_config(struct comp_dev *dev, struct ipc_config_dai *common_config,
 		}
 	}
 
-	ret = dai_init_llp_info(dev);
+	ret = dai_init_llp_info(dd, dev);
 	if (ret < 0)
 		return ret;
 

--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -373,9 +373,8 @@ int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn)
 	return dai_zephyr_position(dd, dev, posn);
 }
 
-void dai_dma_position_update(struct comp_dev *dev)
+void dai_dma_position_update(struct dai_data *dd, struct comp_dev *dev)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
 	struct ipc4_llp_reading_slot slot;
 	struct dma_status status;
 	int ret;
@@ -422,9 +421,8 @@ int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn)
 	return dai_zephyr_position(dd, dev, posn);
 }
 
-void dai_dma_position_update(struct comp_dev *dev)
+void dai_dma_position_update(struct dai_data *dd, struct comp_dev *dev)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
 	struct ipc4_llp_reading_slot slot;
 	struct dma_chan_status status;
 	uint32_t llp_data[2];

--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -189,9 +189,8 @@ void dai_dma_release(struct comp_dev *dev)
 	}
 }
 
-void dai_release_llp_slot(struct comp_dev *dev)
+void dai_release_llp_slot(struct dai_data *dd)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
 	struct ipc4_llp_reading_slot slot;
 	k_spinlock_key_t key;
 

--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -346,9 +346,9 @@ int dai_config(struct comp_dev *dev, struct ipc_config_dai *common_config,
 }
 
 #if CONFIG_ZEPHYR_NATIVE_DRIVERS
-int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn)
+int dai_zephyr_position(struct dai_data *dd, struct comp_dev *dev,
+			struct sof_ipc_stream_posn *posn)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
 	struct dma_status status;
 	int ret;
 
@@ -365,6 +365,13 @@ int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn)
 	posn->comp_posn = status.total_copied;
 
 	return 0;
+}
+
+int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn)
+{
+	struct dai_data *dd = comp_get_drvdata(dev);
+
+	return dai_zephyr_position(dd, dev, posn);
 }
 
 void dai_dma_position_update(struct comp_dev *dev)
@@ -392,9 +399,9 @@ void dai_dma_position_update(struct comp_dev *dev)
 	mailbox_sw_regs_write(dd->slot_info.reg_offset, &slot, sizeof(slot));
 }
 #else
-int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn)
+int dai_zephyr_position(struct dai_data *dd, struct comp_dev *dev,
+			struct sof_ipc_stream_posn *posn)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
 	struct dma_chan_status status;
 
 	/* total processed bytes count */
@@ -407,6 +414,13 @@ int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn)
 	dma_status_legacy(dd->chan, &status, dev->direction);
 
 	return 0;
+}
+
+int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn)
+{
+	struct dai_data *dd = comp_get_drvdata(dev);
+
+	return dai_zephyr_position(dd, dev, posn);
 }
 
 void dai_dma_position_update(struct comp_dev *dev)

--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -30,10 +30,9 @@
 
 LOG_MODULE_DECLARE(ipc, CONFIG_SOF_LOG_LEVEL);
 
-int dai_config_dma_channel(struct comp_dev *dev, const void *spec_config)
+int dai_config_dma_channel(struct dai_data *dd, struct comp_dev *dev, const void *spec_config)
 {
 	const struct ipc4_copier_module_cfg *copier_cfg = spec_config;
-	struct dai_data *dd = comp_get_drvdata(dev);
 	struct ipc_config_dai *dai = &dd->ipc_config;
 	int channel;
 
@@ -319,7 +318,7 @@ int dai_config(struct comp_dev *dev, struct ipc_config_dai *common_config,
 	}
 #endif
 	/* do nothing for asking for channel free, for compatibility. */
-	if (dai_config_dma_channel(dev, spec_config) == DMA_CHAN_INVALID)
+	if (dai_config_dma_channel(dd, dev, spec_config) == DMA_CHAN_INVALID)
 		return 0;
 
 	dd->dai_dev = dev;

--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -170,14 +170,9 @@ void dai_dma_release(struct dai_data *dd, struct comp_dev *dev)
 		if (dev->state != COMP_STATE_PAUSED)
 			dma_stop(dd->chan->dma->z_dev, dd->chan->index);
 
-		/* remove callback */
-		notifier_unregister(dev, dd->chan, NOTIFIER_ID_DMA_COPY);
 		dma_release_channel(dd->chan->dma->z_dev, dd->chan->index);
 #else
 		dma_stop_legacy(dd->chan);
-
-		/* remove callback */
-		notifier_unregister(dev, dd->chan, NOTIFIER_ID_DMA_COPY);
 		dma_channel_put_legacy(dd->chan);
 #endif
 		dd->chan->dev_data = NULL;

--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -61,9 +61,8 @@ int dai_config_dma_channel(struct dai_data *dd, struct comp_dev *dev, const void
 	return channel;
 }
 
-int ipc_dai_data_config(struct comp_dev *dev)
+int ipc_dai_data_config(struct dai_data *dd, struct comp_dev *dev, uint32_t *frame_fmt)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
 	struct ipc_config_dai *dai = &dd->ipc_config;
 	struct ipc4_copier_module_cfg *copier_cfg = dd->dai_spec_config;
 	struct dai *dai_p = dd->dai;
@@ -110,12 +109,12 @@ int ipc_dai_data_config(struct comp_dev *dev)
 		/* SDW HW FIFO always requires 32bit MSB aligned sample data for
 		 * all formats, such as 8/16/24/32 bits.
 		 */
-		dev->ipc_config.frame_fmt = SOF_IPC_FRAME_S32_LE;
+		*frame_fmt = SOF_IPC_FRAME_S32_LE;
 
 		dd->config.burst_elems = dai_get_fifo_depth(dd->dai, dai->direction);
 
 		comp_dbg(dev, "dai_data_config() SOF_DAI_INTEL_ALH dev->ipc_config.frame_fmt: %d, stream_id: %d",
-			 dev->ipc_config.frame_fmt, dd->stream_id);
+			 *frame_fmt, dd->stream_id);
 
 		break;
 	default:

--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -137,10 +137,8 @@ int ipc_comp_dai_config(struct ipc *ipc, struct ipc_config_dai *common_config,
 	return 0;
 }
 
-void dai_dma_release(struct comp_dev *dev)
+void dai_dma_release(struct dai_data *dd, struct comp_dev *dev)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
-
 	/* cannot configure DAI while active */
 	if (dev->state == COMP_STATE_ACTIVE) {
 		comp_info(dev, "dai_config(): Component is in active state. Ignore resetting");


### PR DESCRIPTION
After SOF upgraded to IPC4, copier actually created 2 devices for
data input(capture) and output(playback), it is
 dai and copier,
hence there are two times copy from DMA buffer
to endpoint buffer then to component buffer.

This PR intend to remove dai device and one more time copy
through use dai data to handle host interface calling.

Basically, there are several steps to go there:

Add dai data to copier data structure.
Share dai data structure to copier by add a dai copier common header file.
In copier, all dai related ops calling should be replaced with new dai exposed interface.
Remove one more time copy and dai endpoint buffer.
Remove dai device.
Performance data:

mcps, saved 1.6mcps, 5.4 --> 3.8, around 30% saved for copier.
Before: 0x40001 perf comp_copy samples 48 period 1000 cpu avg 533 peak 553
After:   0x40001 perf comp_copy samples 48 period 1000 cpu avg 378 peak 397

memory, since host endpoint buffer and host device got removed, for each copier,
16bit/32bit 384/768 bytes saved for buffer, 112 saved for dai device.
As a summary, 16/32 bit playback/capture totally saved 496/884 bytes for each dai copier usage.
For the cases that have more than 10 copier usage, memory saving is quite remarkable.

Note：multiple sink dai copier is not tested and will be fixed in follow up PR.

Signed-off-by: Baofeng Tian baofeng.tian@intel.com