### PR TITLE
topology2: add WoV test topology on HDA platform

### DIFF
--- a/tools/topology/topology2/development/CMakeLists.txt
+++ b/tools/topology/topology2/development/CMakeLists.txt
@@ -39,6 +39,10 @@ PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-hda-efx-generic-4ch.bin,USE_CHAIN_DMA=
 DEEPBUFFER_FW_DMA_MS=100,EFX_FIR_PARAMS=passthrough,EFX_IIR_PARAMS=passthrough"
 # CAVS HDA topology with gain and SRC before mixin for HDA and passthrough pipelines for HDMI
 "sof-hda-generic\;sof-hda-src-generic\;HDA_CONFIG=src,USE_CHAIN_DMA=true,DEEPBUFFER_FW_DMA_MS=100"
+# HDA topology with WoV enabled
+"sof-hda-generic\;sof-mtl-hda-generic-2ch-kwd\;PLATFORM=mtl,HDA_CONFIG=mix,NUM_DMICS=2,\
+PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-mtl-hda-generic-2ch-kwd.bin,INCLUDE_WOV=true,\
+DEEPBUFFER_FW_DMA_MS=100"
 )
 add_custom_target(topology2_dev)
 

--- a/tools/topology/topology2/sof-hda-generic.conf
+++ b/tools/topology/topology2/sof-hda-generic.conf
@@ -20,6 +20,8 @@
 <gain-capture.conf>
 <deepbuffer-playback.conf>
 <passthrough-be.conf>
+<dai-kpb-be.conf>
+<wov-detect.conf>
 <passthrough-capture-be.conf>
 <highpass-capture-be.conf>
 <data.conf>
@@ -32,6 +34,10 @@
 <hw_config.conf>
 <manifest.conf>
 <route.conf>
+<output_pin_binding.conf>
+<kpb.conf>
+<input_audio_format.conf>
+<output_audio_format.conf>
 <common_definitions.conf>
 <dmic-default.conf>
 <hdmi-default.conf>
@@ -48,6 +54,18 @@ Define {
 	DMIC0_DAI_GAIN 'eqiir.12.1'
 	DMIC0_DAI_EQIIR "highpass_40hz_20db"
 	DMIC0_PCM_CAPS 'Gain Capture 11'
+	DMIC1_PCM_CAPS	'DMIC1 WOV Capture'
+	DMIC1_HOST_PIPELINE_ID		16
+	DMIC1_DAI_PIPELINE_ID		17
+	WOV_PIPELINE_ID			18
+	DMIC1_HOST_PIPELINE_SINK	'copier.host.16.1'
+	DMIC_WOV_DAI_PIPELINE_SRC	'copier.DMIC.17.1'
+	DMIC_WOV_DAI_PIPELINE_KPB	'kpb.17.1'
+	WOV_PIPELINE_SINK		'micsel.18.1'
+	WOV_PIPELINE_VIRTUAL		'virtual.detect_sink'
+	WOV_CPC				'360000'
+	DMIC1_PCM_CAPS			'DMIC1 WOV Capture'
+	DMIC1_PIPELINE_STREAM_NAME	'copier.DMIC.17.1'
 }
 
 # override defaults with platform-specific config


### PR DESCRIPTION
This patch adds the WoV test topolgy on HDA platform.
Previously #7106.

WoV feature test topology was added on nocodec platform, however, for MTL, there is pin conflict between SSP2 and DMIC, so we add WoV test topology on HDA platform.

This patch only adds topology for MTL, because MTL requires `DMIC_DRIVER_VERSION==3`, this is not true for TGL/ADL, it is not possible to use one topology for both. If needed, we can add a new topology for TGL/ADL, too.