### PR TITLE
topology2: cavs-nocodec: include SSP1 pipelines conditionally

### DIFF
--- a/tools/topology/topology2/cavs-nocodec.conf
+++ b/tools/topology/topology2/cavs-nocodec.conf
@@ -76,6 +76,7 @@ Define {
 	SSP0_MIXER_SOURCE_2		'mixin.16.1'
 	SSP0_MIXER_SINK_2		'mixout.16.1'
 	SSP0_MIXER_SOURCE_3		'mixin.21.1'
+	SSP1_ENABLED			"true"
 }
 
 # override defaults with platform-specific config
@@ -109,24 +110,6 @@ Object.Dai.SSP [
 
 		Object.Base.hw_config.1 {
 			name	"SSP0"
-			id	0
-			mclk_freq	$MCLK
-			bclk_freq	3072000
-			tdm_slot_width	32
-		}
-	}
-	{
-		id 		1
-		dai_index	1
-		direction	"duplex"
-		name		NoCodec-1
-		default_hw_conf_id	0
-		sample_bits		32
-		quirks			"lbm_mode"
-		io_clk		$MCLK
-
-		Object.Base.hw_config.1 {
-			name	"SSP1"
 			id	0
 			mclk_freq	$MCLK
 			bclk_freq	3072000
@@ -182,18 +165,6 @@ Object.Pipeline.host-copier-gain-mixin-playback [
 		}
 	}
 	{
-		index	3
-
-		Object.Widget.copier.1 {
-			stream_name 'SSP1 Playback'
-		}
-		Object.Widget.gain.1 {
-			Object.Control.mixer.1 {
-				name 'Playback Volume 3'
-			}
-		}
-	}
-	{
 		index	5
 
 		Object.Widget.copier.1 {
@@ -243,23 +214,6 @@ Object.Pipeline.mixout-gain-smart-amp-dai-copier-playback [
 ]
 
 Object.Pipeline.mixout-gain-dai-copier-playback [
-	{
-		index	4
-
-		Object.Widget.copier.1 {
-			dai_index 1
-			dai_type "SSP"
-			copier_type "SSP"
-			stream_name "NoCodec-1"
-			node_type $I2S_LINK_OUTPUT_CLASS
-		}
-
-		Object.Widget.gain.1 {
-			Object.Control.mixer.1 {
-				name 'Main Playback Volume 4'
-			}
-		}
-	}
 	{
 		index	6
 
@@ -417,13 +371,6 @@ Object.Pipeline.dai-copier-gain-module-copier-capture [
 ]
 
 Object.Pipeline.passthrough-capture [
-	{
-		index 	9
-
-		Object.Widget.copier.1 {
-			stream_name 'SSP1 Capture'
-		}
-	}
 	{
 		index 	11
 
@@ -635,26 +582,6 @@ Object.PCM.pcm [
 		}
 	}
 	{
-		name	"Port1"
-		id 1
-		direction	"duplex"
-		Object.Base.fe_dai.1 {
-			name	"Port1"
-		}
-
-		Object.PCM.pcm_caps.1 {
-			direction	"playback"
-			name "SSP1 Playback"
-			formats 'S16_LE,S24_LE,S32_LE'
-		}
-
-		Object.PCM.pcm_caps.2 {
-			direction	"capture"
-			name "SSP1 Capture"
-			formats 'S16_LE,S24_LE,S32_LE'
-		}
-	}
-	{
 		name	"Port2"
 		id 2
 		direction	"duplex"
@@ -710,14 +637,6 @@ Object.Base.route [
 		sink	"copier.SSP.2.1"
 	}
 	{
-		source	"gain.4.1"
-		sink	"copier.SSP.4.1"
-	}
-	{
-		source	"mixin.3.1"
-		sink	"mixout.4.1"
-	}
-	{
 		source	"gain.6.1"
 		sink	"copier.SSP.6.1"
 	}
@@ -728,10 +647,6 @@ Object.Base.route [
 	{
 		source	"copier.SSP.8.1"
 		sink	"gain.8.1"
-	}
-	{
-		source	"copier.SSP.10.1"
-		sink	"copier.host.9.1"
 	}
 	{
 		source	"copier.SSP.12.1"
@@ -773,4 +688,115 @@ IncludeByKey.SSP0_MIXER_2LEVEL {
 			]
 		}
 	"1"	"platform/intel/nocodec-ssp0-2level.conf"
+}
+
+
+# There is pinmux conflict between SSP1 and DMIC on MTL RVP,
+# so include SSP1 pipelines conditionally.
+IncludeByKey.SSP1_ENABLED {
+	"true" {
+		Object.Dai.SSP [
+			{
+				id 		1
+				dai_index	1
+				direction	"duplex"
+				name		NoCodec-1
+				default_hw_conf_id	0
+				sample_bits		32
+				quirks			"lbm_mode"
+				io_clk		$MCLK
+
+				Object.Base.hw_config.1 {
+					name	"SSP1"
+					id	0
+					mclk_freq	$MCLK
+					bclk_freq	3072000
+					tdm_slot_width	32
+				}
+			}
+		]
+
+		Object.Pipeline.host-copier-gain-mixin-playback [
+			{
+				index	3
+
+				Object.Widget.copier.1 {
+					stream_name 'SSP1 Playback'
+				}
+				Object.Widget.gain.1 {
+					Object.Control.mixer.1 {
+						name 'Playback Volume 3'
+					}
+				}
+			}
+		]
+
+		Object.Pipeline.mixout-gain-dai-copier-playback [
+			{
+				index	4
+
+				Object.Widget.copier.1 {
+					dai_index 1
+					dai_type "SSP"
+					copier_type "SSP"
+					stream_name "NoCodec-1"
+					node_type $I2S_LINK_OUTPUT_CLASS
+				}
+
+				Object.Widget.gain.1 {
+					Object.Control.mixer.1 {
+						name 'Main Playback Volume 4'
+					}
+				}
+			}
+		]
+
+		Object.Pipeline.passthrough-capture [
+			{
+				index 	9
+
+				Object.Widget.copier.1 {
+					stream_name 'SSP1 Capture'
+				}
+			}
+		]
+
+		Object.PCM.pcm [
+			{
+				name	"Port1"
+				id 1
+				direction	"duplex"
+				Object.Base.fe_dai.1 {
+					name	"Port1"
+				}
+
+				Object.PCM.pcm_caps.1 {
+					direction	"playback"
+					name "SSP1 Playback"
+					formats 'S16_LE,S24_LE,S32_LE'
+				}
+
+				Object.PCM.pcm_caps.2 {
+					direction	"capture"
+					name "SSP1 Capture"
+					formats 'S16_LE,S24_LE,S32_LE'
+				}
+			}
+		]
+
+		Object.Base.route [
+			{
+				source	"mixin.3.1"
+				sink	"mixout.4.1"
+			}
+			{
+				source	"gain.4.1"
+				sink	"copier.SSP.4.1"
+			}
+			{
+				source	"copier.SSP.10.1"
+				sink	"copier.host.9.1"
+			}
+		]
+	}
 }

--- a/tools/topology/topology2/development/tplg-targets.cmake
+++ b/tools/topology/topology2/development/tplg-targets.cmake
@@ -28,6 +28,8 @@ PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-adl-nocodec.bin,DEEPBUFFER_FW_DMA_MS=1
 # SSP topology for MTL
 "cavs-nocodec\;sof-mtl-nocodec\;PLATFORM=mtl,NUM_DMICS=2,\
 PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-mtl-nocodec.bin,DEEPBUFFER_FW_DMA_MS=100"
+"cavs-nocodec\;sof-mtl-nocodec-ssp0-ssp2\;PLATFORM=mtl,NUM_DMICS=2,SSP1_ENABLED=false,\
+PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-mtl-nocodec.bin,DEEPBUFFER_FW_DMA_MS=100"
 
 # CAVS HDA topology with mixer-based efx eq pipelines for HDA and passthrough pipelines for HDMI
 "sof-hda-generic\;sof-hda-efx-generic\;HDA_CONFIG=efx,USE_CHAIN_DMA=true,DEEPBUFFER_FW_DMA_MS=100,\


### PR DESCRIPTION
There is pinmux conflict between SSP1 and DMIC on MTL, as there are other SSPs can be used, we don't include SSP1 pipelines only for mtl to unlock DMIC test.