### PR TITLE
topology2: add cpc value for gain

### DIFF
--- a/tools/topology/topology2/include/components/gain.conf
+++ b/tools/topology/topology2/include/components/gain.conf
@@ -164,6 +164,7 @@ Class.Widget."gain" {
 	type 			"pga"
 	uuid 			"A8:A9:BC:61:D0:18:18:4A:8E:7B:26:39:21:98:04:B7"
 	no_pm			"true"
+	cpc 			10183
 	period_sink_count	2
 	period_source_count	2
 	curve_type		"fade"


### PR DESCRIPTION
The missing cpc in gain component results in wrong calculation for clock selection, and causes capture issues.

Link: https://github.com/thesofproject/sof/issues/7228
Link: https://github.com/thesofproject/sof/issues/7230