### PR TITLE
Tools: Testbench: Avoid need linux kernel headers in build

### DIFF
--- a/tools/testbench/CMakeLists.txt
+++ b/tools/testbench/CMakeLists.txt
@@ -7,6 +7,8 @@ project(SOF_TESTBENCH C)
 include(../../scripts/cmake/misc.cmake)
 include(CheckCCompilerFlag)
 
+set(default_asoc_h "/usr/include/alsa/sound/uapi/asoc.h")
+
 add_executable(testbench
 	testbench.c
 	common_test.c
@@ -30,6 +32,12 @@ target_include_directories(testbench PRIVATE
 	"${PROJECT_SOURCE_DIR}/xtos/include"
 )
 endif()
+
+# Configuration time, make copy
+configure_file(${default_asoc_h} ${CMAKE_CURRENT_BINARY_DIR}/include/alsa/sound/asoc.h)
+
+# Build time
+target_include_directories(testbench PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/include")
 
 # -Wimplicit-fallthrough is preferred, check if it's supported
 check_c_compiler_flag(-Wimplicit-fallthrough supports_implicit_fallthrough)

--- a/tools/testbench/include/linux/types.h
+++ b/tools/testbench/include/linux/types.h
@@ -1,0 +1,22 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#ifndef __TESTBENCH_LINUX_TYPES_H__
+#define __TESTBENCH_LINUX_TYPES_H__
+
+#include <stdint.h>
+
+/*
+ * This header files allows to include asoc.h for topology parsing to
+ * non-gcc builds with other C library, e.g. the one that is used by
+ * xt-xcc compiler. The kernel linux/types.h cannot be used because
+ * the other definitions there are not compatible with the toolchain.
+ */
+
+/* There are minimum types needed for alsa/sound/uapi/asoc.h */
+
+typedef int64_t __le64;
+typedef int32_t __le32;
+typedef int16_t __le16;
+typedef uint8_t __u8;
+
+#endif /* __TESTBENCH_LINUX_TYPES_H__ */

--- a/tools/tplg_parser/CMakeLists.txt
+++ b/tools/tplg_parser/CMakeLists.txt
@@ -7,6 +7,8 @@ project(SOF_TPLG_PARSER C)
 include(../../scripts/cmake/misc.cmake)
 include(CheckCCompilerFlag)
 
+set(default_asoc_h "/usr/include/alsa/sound/uapi/asoc.h")
+
 set(sof_source_directory "${PROJECT_SOURCE_DIR}/../..")
 
 if (CONFIG_LIBRARY_STATIC)
@@ -39,6 +41,12 @@ target_include_directories(sof_tplg_parser PRIVATE ${sof_source_directory}/src/p
 
 # TODO: The topology parser should NOT need to include RTOS header. FIX.
 target_include_directories(sof_tplg_parser PRIVATE ${sof_source_directory}/xtos/include)
+
+# Configuration time, make copy
+configure_file(${default_asoc_h} ${CMAKE_CURRENT_BINARY_DIR}/include/alsa/sound/asoc.h)
+
+# Build time
+target_include_directories(sof_tplg_parser PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/include")
 
 # -Wimplicit-fallthrough is preferred, check if it's supported
 check_c_compiler_flag(-Wimplicit-fallthrough supports_implicit_fallthrough)

--- a/tools/tplg_parser/include/linux/types.h
+++ b/tools/tplg_parser/include/linux/types.h
@@ -1,0 +1,22 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#ifndef __TPLG_PARSER_LINUX_TYPES_H__
+#define __TPLG_PARSER_LINUX_TYPES_H__
+
+#include <stdint.h>
+
+/*
+ * This header files allows to include asoc.h for topology parsing to
+ * non-gcc builds with other C library, e.g. the one that is used by
+ * xt-xcc compiler. The kernel linux/types.h cannot be used because
+ * the other definitions there are not compatible with the toolchain.
+ */
+
+/* There are minimum types needed for alsa/sound/uapi/asoc.h */
+
+typedef int64_t __le64;
+typedef int32_t __le32;
+typedef int16_t __le16;
+typedef uint8_t __u8;
+
+#endif /* __TPLG_PARSER_LINUX_TYPES_H__ */


### PR DESCRIPTION
This patch adds a simplified linux/types.h into testbench headers to enable include of ALSA asoc.h to build without other difficult kernel headers content.

The include path for asoc.h is changed in fuzzer, tplg_parser, and testbench to be without prefix alsa/sound/uapi to allow the Makefile headers path to specify only the uapi directory.

This change avoids build fail with xcc toolchain that can't use the gcc toolchain headers from the system where the ALSA headers are located.