### PR TITLE
xtensa-build-zephyr: fix DEFAULT_TOOLCHAIN_VARIANT spill on next platf

### DIFF
--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -534,6 +534,7 @@ def build_platforms():
 	sof_output_dir = pathlib.Path(STAGING_DIR, "sof")
 	sof_output_dir.mkdir(parents=True, exist_ok=True)
 	for platform in args.platforms:
+		platf_build_environ = os.environ.copy()
 		if args.use_platform_subdir:
 			sof_platform_output_dir = pathlib.Path(sof_output_dir, platform)
 			sof_platform_output_dir.mkdir(parents=True, exist_ok=True)
@@ -552,14 +553,14 @@ def build_platforms():
 					"or is not a directory")
 
 			# set variables expected by zephyr/cmake/toolchain/xcc/generic.cmake
-			os.environ["ZEPHYR_TOOLCHAIN_VARIANT"] = os.environ.get("ZEPHYR_TOOLCHAIN_VARIANT",
+			platf_build_environ["ZEPHYR_TOOLCHAIN_VARIANT"] = platf_build_environ.get("ZEPHYR_TOOLCHAIN_VARIANT",
 				platform_dict["DEFAULT_TOOLCHAIN_VARIANT"])
 			XTENSA_TOOLCHAIN_PATH = str(pathlib.Path(xtensa_tools_root_dir, "install",
 				"tools").absolute())
-			os.environ["XTENSA_TOOLCHAIN_PATH"] = XTENSA_TOOLCHAIN_PATH
+			platf_build_environ["XTENSA_TOOLCHAIN_PATH"] = XTENSA_TOOLCHAIN_PATH
 			TOOLCHAIN_VER = platform_dict["XTENSA_TOOLS_VERSION"]
 			XTENSA_CORE = platform_dict["XTENSA_CORE"]
-			os.environ["TOOLCHAIN_VER"] = TOOLCHAIN_VER
+			platf_build_environ["TOOLCHAIN_VER"] = TOOLCHAIN_VER
 			print(f"XTENSA_TOOLCHAIN_PATH={XTENSA_TOOLCHAIN_PATH}")
 			print(f"TOOLCHAIN_VER={TOOLCHAIN_VER}")
 
@@ -569,7 +570,7 @@ def build_platforms():
 			XTENSA_BUILDS_DIR=str(pathlib.Path(xtensa_tools_root_dir, "install", "builds",
 				TOOLCHAIN_VER).absolute())
 			XTENSA_SYSTEM = str(pathlib.Path(XTENSA_BUILDS_DIR, XTENSA_CORE, "config").absolute())
-			os.environ["XTENSA_SYSTEM"] = XTENSA_SYSTEM
+			platf_build_environ["XTENSA_SYSTEM"] = XTENSA_SYSTEM
 			print(f"XTENSA_SYSTEM={XTENSA_SYSTEM}")
 
 		platform_build_dir_name = f"build-{platform}"
@@ -619,7 +620,7 @@ def build_platforms():
 
 		# Build
 		try:
-			execute_command(build_cmd, cwd=west_top)
+			execute_command(build_cmd, cwd=west_top, env=platf_build_environ)
 		except subprocess.CalledProcessError as cpe:
 			zephyr_path = pathlib.Path(west_top, "zephyr")
 			if not os.path.exists(zephyr_path):


### PR DESCRIPTION
xtensa-build-zephyr.py has always defined XTENSA_ and other environment variables in the current environment shared by all platforms. This was always bad but apparently never a problem until the addition of the new DEFAULT_TOOLCHAIN_VARIANT (xcc or clang) variable.

Before DEFAULT_TOOLCHAIN_VARIANT, each platform's environment would simply override the previous one. However with the new DEFAULT_TOOLCHAIN_VARIANT, the current environment has precedence for more flexibility. This makes each platform "spill" onto the next one and `xtensa-build-zephyr.py -p tgl mtl` fail like this:

```
-- Board: intel_adsp_ace15_mtpm
-- Found toolchain: xcc (/home/XCC/install/tools)
CMake Error at zephyr/cmake/compiler/xcc/generic.cmake:9 (message):
  Zephyr was unable to find the toolchain.  Is the environment
  misconfigured?

  User-configuration:

  ZEPHYR_TOOLCHAIN_VARIANT: xcc

  Internal variables:

  CROSS_COMPILE:
  /home/XCC/install/tools/RI-2022.10-linux/XtensaTools/bin/xt-
```

To fix this, stop modifying the current os.environ and use a new, fresh os.environ.copy() for each platform instead.

Fixes commit 309fa264e29d ("xtensa-build-zephyr.py: upgraded Xtensa toolchain for MTL")

History repeats itself: commit 6bedd8e7427c ("xtensa-build-zephyr: fix RIMAGE_KEY when building multiple platforms") fixed the same logical error months ago in a different script.