### PR TITLE
topology2: extract new "tplg-targets.cmake" files from CMakeList.txt

### DIFF
--- a/tools/topology/topology2/avs-tplg/CMakeLists.txt
+++ b/tools/topology/topology2/avs-tplg/CMakeLists.txt
@@ -1,50 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-#  Array of "input-file-name;output-file-name;comma separated pre-processor variables"
-set(TPLGS
-# CAVS HDMI only topology with passthrough pipelines
-"sof-hda-generic\;sof-hda-generic-idisp\;USE_CHAIN_DMA=true,DEEPBUFFER_FW_DMA_MS=100"
-# CAVS HDA topology with mixer-based pipelines for HDA and passthrough pipelines for HDMI
-"sof-hda-generic\;sof-hda-generic\;HDA_CONFIG=mix,USE_CHAIN_DMA=true,DEEPBUFFER_FW_DMA_MS=100"
-# If the alsatplg plugins for NHLT are not available, the NHLT blobs will not be added to the
-# topologies below.
-"sof-hda-generic\;sof-hda-generic-2ch\;\
-HDA_CONFIG=mix,NUM_DMICS=2,PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-hda-generic-2ch.bin,USE_CHAIN_DMA=true,\
-DEEPBUFFER_FW_DMA_MS=100"
-"sof-hda-generic\;sof-hda-generic-4ch\;\
-HDA_CONFIG=mix,NUM_DMICS=4,PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,\
-PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-hda-generic-4ch.bin,USE_CHAIN_DMA=true,DEEPBUFFER_FW_DMA_MS=100"
-# CAVS SDW topology with passthrough pipelines
-"cavs-sdw\;cavs-sdw\;DEEPBUFFER_FW_DMA_MS=100,\
-PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-cavs-sdw.bin"
-
-# IPC4 topology for TGL rt711 Headset + rt1316 Amplifier + rt714 DMIC
-"cavs-sdw\;sof-tgl-rt711-rt1316-rt714\;NUM_SDW_AMPS=2,SDW_DMIC=1,\
-PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-tgl-rt711-rt1316-rt714.bin"
-
-"cavs-sdw\;sof-adl-rt711-l0-rt1316-l12-rt714-l3\;NUM_SDW_AMPS=2,SDW_DMIC=1"
-
-# IPC4 topology for TGL rt711 Headset + rt1308 Amplifier + rt715 DMIC
-"cavs-sdw\;sof-tgl-rt715-rt711-rt1308-mono\;NUM_SDW_AMPS=1,SDW_DMIC=1,\
-SDW_JACK_OUT_STREAM=SDW1-Playback,SDW_JACK_IN_STREAM=SDW1-Capture,\
-SDW_SPK_STREAM=SDW2-Playback,SDW_DMIC_STREAM=SDW0-Capture,SDW_AMP_FEEDBACK=false,\
-PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-tgl-rt715-rt711-rt1308-mono.bin"
-
-# IPC4 topology for TGL rt711 Headset + rt1308 Amplifier + PCH DMIC
-"cavs-sdw\;sof-tgl-rt711-rt1308-4ch\;NUM_SDW_AMPS=1,NUM_DMICS=4,DMIC0_ID=3,\
-DMIC1_ID=4,PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,SDW_AMP_FEEDBACK=false,\
-PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-tgl-rt711-rt1308-4ch.bin"
-
-"cavs-sdw\;sof-adl-rt711-4ch\;DEEPBUFFER_FW_DMA_MS=100,NUM_DMICS=4,DMIC0_ID=2,\
-DMIC1_ID=3,PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,HDMI1_ID=4,HDMI2_ID=5,\
-HDMI3_ID=6,PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-adl-rt711-4ch.bin"
-
-# BT offload
-"cavs-nocodec-bt\;sof-nocodec-bt\;PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-nocodec-bt.bin"
-# BT offload loopback test topology (lbm)
-"cavs-nocodec-bt\;sof-nocodec-bt-lbm\;BT_LOOPBACK_MODE=true,\
-PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-nocodec-bt-lbm.bin"
-)
+include(tplg-targets.cmake)
 
 add_custom_target(topology2_cavs)
 

--- a/tools/topology/topology2/avs-tplg/tplg-targets.cmake
+++ b/tools/topology/topology2/avs-tplg/tplg-targets.cmake
@@ -45,27 +45,3 @@ HDMI3_ID=6,PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-adl-rt711-4ch.bin"
 "cavs-nocodec-bt\;sof-nocodec-bt-lbm\;BT_LOOPBACK_MODE=true,\
 PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-nocodec-bt-lbm.bin"
 )
-
-add_custom_target(topology2_cavs)
-
-foreach(tplg ${TPLGS})
-	set(defines "")
-	list(LENGTH tplg length)
-	list(GET tplg 0 input)
-	list(GET tplg 1 output)
-
-	math(EXPR last_index "${length}-1")
-
-	# Get the pre-processor definitions from the 3rd item in the list for each topology
-	# ex: "hda-generic\;hda-generic-2ch\;HDA_CONFIG=gain,DMIC_CH=2", "defines" would contain "HDA_CONFIG=gain,DMIC_CH=2"
-	if (${last_index} EQUAL 2)
-		list(GET tplg ${last_index} defines)
-	endif()
-
-	add_alsatplg2_command("${CMAKE_CURRENT_BINARY_DIR}/../abi.conf" abi_target
-	  "${CMAKE_CURRENT_SOURCE_DIR}/../${input}" "${output}"
-	  "${CMAKE_CURRENT_SOURCE_DIR}/../" "${defines}")
-
-	add_custom_target(topology2_avs_${output} DEPENDS ${output}.tplg)
-	add_dependencies(topology2_cavs topology2_avs_${output})
-endforeach()

--- a/tools/topology/topology2/avs-tplg/tplg-targets.cmake
+++ b/tools/topology/topology2/avs-tplg/tplg-targets.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-#  Array of "input-file-name;output-file-name;comma separated pre-processor variables"
+# Array of "input-file-name;output-file-name;comma separated pre-processor variables"
 set(TPLGS
 # CAVS HDMI only topology with passthrough pipelines
 "sof-hda-generic\;sof-hda-generic-idisp\;USE_CHAIN_DMA=true,DEEPBUFFER_FW_DMA_MS=100"

--- a/tools/topology/topology2/development/CMakeLists.txt
+++ b/tools/topology/topology2/development/CMakeLists.txt
@@ -1,47 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-#  Array of "input-file-name;output-file-name;comma separated pre-processor variables"
-set(TPLGS
-# CAVS SDW topology with passthrough pipelines
-"cavs-sdw\;cavs-sdw\;DEEPBUFFER_FW_DMA_MS=100"
+include(tplg-targets.cmake)
 
-# CAVS SDW with SRC gain and mixer support
-"cavs-sdw-src-gain-mixin\;cavs-sdw-src-gain-mixin"
-
-# SDW + HDMI topology with passthrough pipelines
-"cavs-sdw\;cavs-sdw-hdmi\;DEEPBUFFER_FW_DMA_MS=100"
-
-# CAVS SSP topology for TGL
-"cavs-nocodec\;sof-tgl-nocodec\;NUM_DMICS=4,PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,\
-PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-tgl-nocodec.bin,DEEPBUFFER_FW_DMA_MS=100,\
-SSP0_MIXER_2LEVEL=1"
-
-"cavs-nocodec\;sof-adl-nocodec\;NUM_DMICS=4,PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,\
-PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-adl-nocodec.bin,DEEPBUFFER_FW_DMA_MS=100"
-
-# SDW topology for MTL
-"cavs-sdw\;mtl-sdw\;NUM_HDMIS=0"
-
-# SDW + HDMI topology for MTL
-"cavs-sdw\;mtl-sdw-hdmi\;PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-mtl-sdw-hdmi.bin"
-
-# SSP topology for MTL
-"cavs-nocodec\;sof-mtl-nocodec\;PLATFORM=mtl,NUM_DMICS=2,\
-PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-mtl-nocodec.bin,DEEPBUFFER_FW_DMA_MS=100"
-
-# CAVS HDA topology with mixer-based efx eq pipelines for HDA and passthrough pipelines for HDMI
-"sof-hda-generic\;sof-hda-efx-generic\;HDA_CONFIG=efx,USE_CHAIN_DMA=true,DEEPBUFFER_FW_DMA_MS=100,\
-EFX_FIR_PARAMS=passthrough,EFX_IIR_PARAMS=passthrough"
-"sof-hda-generic\;sof-hda-efx-generic-2ch\;\
-HDA_CONFIG=efx,NUM_DMICS=2,PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-hda-fir-generic-2ch.bin,\
-USE_CHAIN_DMA=true,DEEPBUFFER_FW_DMA_MS=100,EFX_FIR_PARAMS=passthrough,EFX_IIR_PARAMS=passthrough"
-"sof-hda-generic\;sof-hda-efx-generic-4ch\;\
-HDA_CONFIG=efx,NUM_DMICS=4,PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,\
-PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-hda-efx-generic-4ch.bin,USE_CHAIN_DMA=true,\
-DEEPBUFFER_FW_DMA_MS=100,EFX_FIR_PARAMS=passthrough,EFX_IIR_PARAMS=passthrough"
-# CAVS HDA topology with gain and SRC before mixin for HDA and passthrough pipelines for HDMI
-"sof-hda-generic\;sof-hda-src-generic\;HDA_CONFIG=src,USE_CHAIN_DMA=true,DEEPBUFFER_FW_DMA_MS=100"
-)
 add_custom_target(topology2_dev)
 
 foreach(tplg ${TPLGS})

--- a/tools/topology/topology2/development/tplg-targets.cmake
+++ b/tools/topology/topology2/development/tplg-targets.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-#  Array of "input-file-name;output-file-name;comma separated pre-processor variables"
+# Array of "input-file-name;output-file-name;comma separated pre-processor variables"
 set(TPLGS
 # CAVS SDW topology with passthrough pipelines
 "cavs-sdw\;cavs-sdw\;DEEPBUFFER_FW_DMA_MS=100"

--- a/tools/topology/topology2/development/tplg-targets.cmake
+++ b/tools/topology/topology2/development/tplg-targets.cmake
@@ -42,26 +42,4 @@ DEEPBUFFER_FW_DMA_MS=100,EFX_FIR_PARAMS=passthrough,EFX_IIR_PARAMS=passthrough"
 # CAVS HDA topology with gain and SRC before mixin for HDA and passthrough pipelines for HDMI
 "sof-hda-generic\;sof-hda-src-generic\;HDA_CONFIG=src,USE_CHAIN_DMA=true,DEEPBUFFER_FW_DMA_MS=100"
 )
-add_custom_target(topology2_dev)
 
-foreach(tplg ${TPLGS})
-	set(defines "")
-	list(LENGTH tplg length)
-	list(GET tplg 0 input)
-	list(GET tplg 1 output)
-
-	math(EXPR last_index "${length}-1")
-
-	# Get the pre-processor definitions from the 3rd item in the list for each topology
-	# ex: "hda-generic\;hda-generic-2ch\;HDA_CONFIG=gain,DMIC_CH=2", "defines" would contain "HDA_CONFIG=gain,DMIC_CH=2"
-	if (${last_index} EQUAL 2)
-		list(GET tplg ${last_index} defines)
-	endif()
-
-	add_alsatplg2_command("${CMAKE_CURRENT_BINARY_DIR}/../abi.conf" abi_target
-	  "${CMAKE_CURRENT_SOURCE_DIR}/../${input}" "${output}"
-	  "${CMAKE_CURRENT_SOURCE_DIR}/../" "${defines}")
-
-	add_custom_target(topology2_dev_${output} DEPENDS ${output}.tplg)
-	add_dependencies(topology2_dev topology2_dev_${output})
-endforeach()

--- a/tools/topology/topology2/sof-ace-tplg/CMakeLists.txt
+++ b/tools/topology/topology2/sof-ace-tplg/CMakeLists.txt
@@ -1,36 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-#  Array of "input-file-name;output-file-name;comma separated pre-processor variables"
-set(TPLGS
-# HDMI only topology with passthrough pipelines
-"sof-hda-generic\;sof-hda-generic-idisp\;USE_CHAIN_DMA=true,DEEPBUFFER_FW_DMA_MS=100"
-# HDA topology with mixer-based pipelines for HDA and passthrough pipelines for HDMI
-"sof-hda-generic\;sof-hda-generic\;HDA_CONFIG=mix,USE_CHAIN_DMA=true,DEEPBUFFER_FW_DMA_MS=100"
-# If the alsatplg plugins for NHLT are not available, the NHLT blobs will not be added to the
-# topologies below.
-"sof-hda-generic\;sof-hda-generic-4ch\;PLATFORM=mtl,\
-HDA_CONFIG=mix,NUM_DMICS=4,PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,PREPROCESS_PLUGINS=nhlt,\
-NHLT_BIN=nhlt-sof-hda-generic-4ch.bin,DEEPBUFFER_FW_DMA_MS=100"
-"sof-hda-generic\;sof-hda-generic-2ch\;PLATFORM=mtl,\
-HDA_CONFIG=mix,NUM_DMICS=2,PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-hda-generic-2ch.bin,\
-DEEPBUFFER_FW_DMA_MS=100"
-
-# SDW + DMIC topology with passthrough pipelines
-# We will change NUM_HDMIS to 3 once HDMI is enabled on MTL RVP
-"cavs-sdw\;sof-mtl-rt711-4ch\;PLATFORM=mtl,NUM_DMICS=4,DMIC0_ID=2,DMIC1_ID=3,NUM_HDMIS=0,\
-PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-mtl-rt711-4ch.bin,DEEPBUFFER_FW_DMA_MS=100"
-
-"cavs-rt5682\;sof-mtl-max98357a-rt5682\;PLATFORM=mtl,NUM_DMICS=4,PDM1_MIC_A_ENABLE=1,\
-PDM1_MIC_B_ENABLE=1,DMIC0_PCM_ID=99,PREPROCESS_PLUGINS=nhlt,\
-NHLT_BIN=nhlt-sof-mtl-max98357a-rt5682.bin,DEEPBUFFER_FW_DMA_MS=10,INCLUDE_ECHO_REF=true,\
-BT_NAME=SSP2-BT,BT_ID=8,BT_PCM_NAME=Bluetooth"
-
-"cavs-rt5682\;sof-mtl-max98357a-rt5682-ssp2-ssp0\;PLATFORM=mtl,NUM_DMICS=4,PDM1_MIC_A_ENABLE=1,\
-PDM1_MIC_B_ENABLE=1,DMIC0_PCM_ID=99,PREPROCESS_PLUGINS=nhlt,\
-NHLT_BIN=nhlt-sof-mtl-max98357a-rt5682.bin,DEEPBUFFER_FW_DMA_MS=10,HEADSET_SSP_DAI_INDEX=2,\
-SPEAKER_SSP_DAI_INDEX=0,HEADSET_CODEC_NAME=SSP2-Codec,SPEAKER_CODEC_NAME=SSP0-Codec,\
-BT_NAME=SSP1-BT,BT_INDEX=1,BT_ID=8,BT_PCM_NAME=Bluetooth,INCLUDE_ECHO_REF=true"
-)
+include(tplg-targets.cmake)
 
 add_custom_target(topology2_ace)
 

--- a/tools/topology/topology2/sof-ace-tplg/tplg-targets.cmake
+++ b/tools/topology/topology2/sof-ace-tplg/tplg-targets.cmake
@@ -31,27 +31,3 @@ NHLT_BIN=nhlt-sof-mtl-max98357a-rt5682.bin,DEEPBUFFER_FW_DMA_MS=10,HEADSET_SSP_D
 SPEAKER_SSP_DAI_INDEX=0,HEADSET_CODEC_NAME=SSP2-Codec,SPEAKER_CODEC_NAME=SSP0-Codec,\
 BT_NAME=SSP1-BT,BT_INDEX=1,BT_ID=8,BT_PCM_NAME=Bluetooth,INCLUDE_ECHO_REF=true"
 )
-
-add_custom_target(topology2_ace)
-
-foreach(tplg ${TPLGS})
-	set(defines "")
-	list(LENGTH tplg length)
-	list(GET tplg 0 input)
-	list(GET tplg 1 output)
-
-	math(EXPR last_index "${length}-1")
-
-	# Get the pre-processor definitions from the 3rd item in the list for each topology
-	# ex: "hda-generic\;hda-generic-2ch\;HDA_CONFIG=gain,DMIC_CH=2", "defines" would contain "HDA_CONFIG=gain,DMIC_CH=2"
-	if (${last_index} EQUAL 2)
-		list(GET tplg ${last_index} defines)
-	endif()
-
-	add_alsatplg2_command("${CMAKE_CURRENT_BINARY_DIR}/../abi.conf" abi_target
-	  "${CMAKE_CURRENT_SOURCE_DIR}/../${input}" "${output}"
-	  "${CMAKE_CURRENT_SOURCE_DIR}/../" "${defines}")
-
-	add_custom_target(topology2_ace_${output} DEPENDS ${output}.tplg)
-	add_dependencies(topology2_ace topology2_ace_${output})
-endforeach()

--- a/tools/topology/topology2/sof-ace-tplg/tplg-targets.cmake
+++ b/tools/topology/topology2/sof-ace-tplg/tplg-targets.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-#  Array of "input-file-name;output-file-name;comma separated pre-processor variables"
+# Array of "input-file-name;output-file-name;comma separated pre-processor variables"
 set(TPLGS
 # HDMI only topology with passthrough pipelines
 "sof-hda-generic\;sof-hda-generic-idisp\;USE_CHAIN_DMA=true,DEEPBUFFER_FW_DMA_MS=100"


### PR DESCRIPTION
The CMakeList.txt files in tools/topology/ have always confused two
different things:

- the list of .tplg files to generate, and
- the CMake logic used to invoke alsatplg and generate them.

Separate the two at last thanks a dead-simple `include()` command.  If I
had knew it was so easy I would have done this much sooner.

The `tools/build_tools/` directory is identical before versus after this
commit.

This will make it much faster to identify what actually changes in
future commits and pull requests.  This will also make CODEOWNERS
smarter and reduce Github notification noise.

Don't do it for topology1 to minimize churn and git disruption in
backports. Topology1 is not very active any more whereas topology2 has
never been released yet.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>