### PR TITLE
ipc4: smart_amp_test: use notifier to replace bind & unbind ops

### DIFF
--- a/src/include/sof/lib/notifier.h
+++ b/src/include/sof/lib/notifier.h
@@ -34,6 +34,8 @@ enum notify_id {
 	NOTIFIER_ID_LL_POST_RUN,		/* NULL */
 	NOTIFIER_ID_DMA_IRQ,			/* struct dma_chan_data * */
 	NOTIFIER_ID_DAI_TRIGGER,		/* struct dai_group * */
+	NOTIFIER_ID_MODULE_BIND,		/* struct ipc4_module_bind_unbind */
+	NOTIFIER_ID_MODULE_UNBIND,		/* struct ipc4_module_bind_unbind */
 	NOTIFIER_ID_COUNT
 };
 


### PR DESCRIPTION
To adapt smart_amp to module adapter interface we need to avoid using
    bind & unbind ops. Smart_amp uses bind & unbind ops to deal with
    feedback buffer. Now use notifier to achieve this feature.
