### PR TITLE
Clean up flexible arrays

### DIFF
--- a/src/include/ipc/channel_map.h
+++ b/src/include/ipc/channel_map.h
@@ -40,7 +40,7 @@ struct sof_ipc_channel_map {
 	uint32_t ext_id;
 	uint32_t ch_mask;
 	uint32_t reserved;
-	int32_t ch_coeffs[0];
+	int32_t ch_coeffs[];
 } __attribute__((packed, aligned(4)));
 
 /**
@@ -56,7 +56,7 @@ struct sof_ipc_stream_map {
 	struct sof_ipc_cmd_hdr hdr;
 	uint32_t num_ch_map;
 	uint32_t reserved[3];
-	struct sof_ipc_channel_map ch_map[0];
+	struct sof_ipc_channel_map ch_map[];
 } __attribute__((packed, aligned(4)));
 
 #endif /* __IPC_CHANNEL_MAP_H__ */

--- a/src/include/ipc/topology.h
+++ b/src/include/ipc/topology.h
@@ -235,7 +235,7 @@ struct sof_ipc_comp_process {
 	/* reserved for future use */
 	uint32_t reserved[7];
 
-	unsigned char data[0];
+	unsigned char data[];
 } __attribute__((packed, aligned(4)));
 
 /* IPC file component used by testbench only */

--- a/src/include/ipc4/base_fw.h
+++ b/src/include/ipc4/base_fw.h
@@ -401,7 +401,7 @@ enum ipc4_hw_config_params {
 struct ipc4_tuple {
 	uint32_t type;
 	uint32_t length;
-	char data[0];
+	char data[];
 } __attribute__((packed, aligned(4)));
 
 enum ipc4_memory_type {

--- a/src/include/ipc4/gateway.h
+++ b/src/include/ipc4/gateway.h
@@ -152,7 +152,7 @@ struct ipc4_gateway_config_data {
 	union ipc4_gateway_attributes gtw_attributes;
 
 	/**< Configuration BLOB */
-	uint32_t config_blob[0];
+	uint32_t config_blob[];
 } __attribute__((packed, aligned(4)));
 
 /**< Configuration for the IPC Gateway */

--- a/src/include/ipc4/ipcgtw.h
+++ b/src/include/ipc4/ipcgtw.h
@@ -48,7 +48,7 @@ struct ipc4_ipc_gateway_cmd_data {
 	/* node_id of the target gateway */
 	union ipc4_connector_node_id node_id;
 	/* Payload (actual size is in the header extension.r.data_size) */
-	uint8_t payload[0];
+	uint8_t payload[];
 };
 
 /* Reply to IPC gateway message */
@@ -60,7 +60,7 @@ struct ipc4_ipc_gateway_cmd_data_reply {
 	/* Total reply size is returned in reply header extension.r.data_size.
 	 * This payload size if 4 bytes smaller (size of the union above).
 	 */
-	uint8_t payload[0];
+	uint8_t payload[];
 };
 
 int ipcgtw_process_cmd(const struct ipc4_ipcgtw_cmd *cmd,

--- a/src/include/ipc4/module.h
+++ b/src/include/ipc4/module.h
@@ -4,9 +4,6 @@
  */
 
 /*
- * This file contains structures that are exact copies of an existing ABI used
- * by IOT middleware. They are Intel specific and will be used by one middleware.
- *
  * Some of the structures may contain programming implementations that makes them
  * unsuitable for generic use and general usage.
  *
@@ -145,11 +142,15 @@ struct ipc4_module_init_instance {
 			uint32_t _hw_reserved_2     : 2;
 		} r;
 	} extension;
-
-	struct ipc4_module_init_ext_init ext_init;
-	struct ipc4_module_init_ext_data ext_data;
-	struct ipc4_module_init_gna_config gna_config;
-	struct ipc4_module_init_data init_data;
+/*
+ * The following objects are optional and follow this structure in this
+ * order provided the respective object bit is set in preceding object.
+ *
+ *	struct ipc4_module_init_ext_init ext_init;
+ *	struct ipc4_module_init_ext_data ext_data;
+ *	struct ipc4_module_init_gna_config gna_config;
+ *	struct ipc4_module_init_data init_data;
+ */
 } __attribute__((packed, aligned(4)));
 
 /*!

--- a/src/include/ipc4/module.h
+++ b/src/include/ipc4/module.h
@@ -69,7 +69,7 @@ struct ipc4_module_init_ext_data {
 	struct ipc4_module_init_ext_init extended_init;
 
 	/**< Data (actual size set to param_block_size) */
-	uint32_t param_data[0];
+	uint32_t param_data[];
 } __attribute__((packed, aligned(4)));
 
 struct ipc4_module_init_gna_config {

--- a/src/include/ipc4/peak_volume.h
+++ b/src/include/ipc4/peak_volume.h
@@ -72,6 +72,6 @@ struct ipc4_peak_volume_config {
 
 struct ipc4_peak_volume_module_cfg {
 	struct ipc4_base_module_cfg base_cfg;
-	struct ipc4_peak_volume_config config[0];
+	struct ipc4_peak_volume_config config[];
 } __packed __aligned(8);
 #endif

--- a/src/include/ipc4/pipeline.h
+++ b/src/include/ipc4/pipeline.h
@@ -179,7 +179,7 @@ struct ipc4_pipeline_set_state_data {
 	/**< Number of items in ppl_id[] */
 	uint32_t pipelines_count;
 	/**< Pipeline ids */
-	uint32_t ppl_id[0];
+	uint32_t ppl_id[];
 } __attribute__((packed, aligned(4)));
 
 struct ipc4_pipeline_set_state {

--- a/src/include/ipc4/ssp.h
+++ b/src/include/ipc4/ssp.h
@@ -112,7 +112,7 @@ struct ipc4_ssp_configuration_blob {
 	struct ipc4_ssp_driver_config i2s_driver_config;
 
 	/* optional configuration parameters */
-	union ipc4_ssp_dma_control i2s_dma_control[0];
+	union ipc4_ssp_dma_control i2s_dma_control[];
 } __attribute__((packed, aligned(4)));
 
 #endif

--- a/src/include/kernel/header.h
+++ b/src/include/kernel/header.h
@@ -42,7 +42,7 @@ struct sof_abi_hdr {
 				/**< The version is valid in scope of the 'magic', */
 				/**< IPC3 and IPC4 ABI version numbers have no relationship. */
 	uint32_t reserved[4];	/**< reserved for future use */
-	uint32_t data[0];	/**< Component data - opaque to core */
+	uint32_t data[];	/**< Component data - opaque to core */
 } __attribute__((packed));
 
 #endif /* __KERNEL_HEADER_H__ */

--- a/src/include/sof/audio/module_adapter/iadk/system_service.h
+++ b/src/include/sof/audio/module_adapter/iadk/system_service.h
@@ -47,7 +47,7 @@ typedef struct _ModuleEventNotification {
 	uint32_t event_data_size;    /*!< Size of event_data array in bytes. May be set to 0
 				      * in case there is no data.
 				      */
-	uint32_t event_data[0];      /*< Optional event data (size set to 0 as it is optional
+	uint32_t event_data[];       /*!< Optional event data (size set to 0 as it is optional
 				      * data)
 				      */
 } ModuleEventNotification;


### PR DESCRIPTION
Make sure flexible arrays are only used in the end of structures and use them instead of 0-size arrays where possible.