### PR TITLE
[SKIP CI] ci: add cherry-pick check for release branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+---
+# SPDX-License-Identifier: BSD-3-Clause
+
+# yamllint disable-line rule:truthy
+on:
+  pull_request:
+    branches-ignore:
+      - main
+
+name: Validate
+
+# this job runs the following script
+# https://github.com/cujomalainey/cherry-pick-check/blob/main/entrypoint.sh
+
+jobs:
+  check:
+    name: Check Cherry Picks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check all commits exist in main
+        uses: cujomalainey/cherry-pick-check@v1
+        with:
+          require_ref: true
+          main_branch: main


### PR DESCRIPTION
Add a non mandatory check for release branches that help reviewers verify all patches have landed on main before the patch to release branch.

The current configuration requires the cherry-pick command to be run with -x. This can be configured to do subject matching if that is too much for developers.