### PR TITLE
mixer: skip inactive source

### DIFF
--- a/src/audio/mixer/mixer.c
+++ b/src/audio/mixer/mixer.c
@@ -100,6 +100,11 @@ static int mixer_process(struct processing_module *mod,
 
 		avail_frames = audio_stream_avail_frames_aligned(mod->input_buffers[i].data,
 								 mod->output_buffers[0].data);
+
+		/* if one source is inactive, skip it */
+		if (avail_frames == 0)
+			continue;
+
 		frames = MIN(frames, avail_frames);
 	}
 


### PR DESCRIPTION
In case one of the sources is inactive, the avail_frames for that source is 0 and the frames = 0.
So, later on, there is nothing to copy, even if, at least one source is still active.
In this case, we get a "write error: Input/output error".

To fix this, allow mixer to process data from at least one source, if that is active.
Or, in other words, if any source is inactive, skip it.