### PR TITLE
smart_amp_test: fix wrong config size in config get

### DIFF
--- a/src/samples/audio/smart_amp_test.c
+++ b/src/samples/audio/smart_amp_test.c
@@ -197,7 +197,7 @@ static inline int smart_amp_get_config(struct comp_dev *dev, char *data,
 	struct smart_amp_data *sad = comp_get_drvdata(dev);
 	uint32_t cfg_size;
 
-	cfg_size = sizeof(struct smart_amp_data);
+	cfg_size = sizeof(struct sof_smart_amp_config);
 
 	if (cfg_size > *data_size) {
 		comp_err(dev, "smart_amp_get_config(): wrong config size %d",


### PR DESCRIPTION
The config to get for smart_amp_test module is
struct sof_smart_amp_config, instead of the bigger
wrapper struct smart_amp_data, so the config size
should be the size of struct sof_smart_amp_config.

thanks @kv2019i for spotting the issue.