### PR TITLE
ipc4: update comp direction on pipeline complete

### DIFF
--- a/src/include/sof/ipc/topology.h
+++ b/src/include/sof/ipc/topology.h
@@ -55,6 +55,7 @@ int ipc4_chain_dma_state(struct comp_dev *dev, struct ipc4_chain_dma *cdma);
 int ipc4_create_chain_dma(struct ipc *ipc, struct ipc4_chain_dma *cdma);
 int ipc4_trigger_chain_dma(struct ipc *ipc, struct ipc4_chain_dma *cdma, bool *delay);
 int ipc4_process_on_core(uint32_t core, bool blocking);
+int ipc4_pipeline_complete(struct ipc *ipc, uint32_t comp_id);
 #else
 #error "No or invalid IPC MAJOR version selected."
 #endif

--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -258,7 +258,7 @@ static int set_pipeline_state(struct ipc_comp_dev *ppl_icd, uint32_t cmd,
 	case SOF_IPC4_PIPELINE_STATE_RESET:
 		switch (status) {
 		case COMP_STATE_INIT:
-			ret = ipc_pipeline_complete(ipc, ppl_icd->id);
+			ret = ipc4_pipeline_complete(ipc, ppl_icd->id);
 			if (ret < 0)
 				ret = IPC4_INVALID_REQUEST;
 
@@ -297,7 +297,7 @@ static int set_pipeline_state(struct ipc_comp_dev *ppl_icd, uint32_t cmd,
 	case SOF_IPC4_PIPELINE_STATE_PAUSED:
 		switch (status) {
 		case COMP_STATE_INIT:
-			ret = ipc_pipeline_complete(ipc, ppl_icd->id);
+			ret = ipc4_pipeline_complete(ipc, ppl_icd->id);
 			if (ret < 0)
 				ret = IPC4_INVALID_REQUEST;
 


### PR DESCRIPTION
Current pipeline implementation assumes that modules are bound one by one from input to output gateway (Host to DAI or DAI to Host). If neighbor module does not have direction configured, FW returns error.

This assumption is incorrect. Driver can bind modules that are not yet bound to any gateway. FW should check connections only when driver finish binding all modules and set pipeline state.

Note: This problem blocks all streams creation by Windows OED. OED playback and capture consist of 3 pipelines. Driver first binds modules inside pipelines and only then bind pipelines. When binding modules in inner pipeline, they do not have reference to gateway.

This patch resolves critical issues for Windows:
https://github.com/intel-innersource/drivers.audio.firmware.converged/issues/453
https://github.com/intel-innersource/drivers.audio.firmware.converged/issues/458