### PR TITLE
volume: add validity check on number of channels

### DIFF
--- a/src/audio/module_adapter/module/volume/volume.c
+++ b/src/audio/module_adapter/module/volume/volume.c
@@ -1300,7 +1300,13 @@ static int volume_prepare(struct processing_module *mod)
 	 * for entire topology specified time.
 	 */
 	cd->ramp_finished = false;
+
 	cd->channels = sink_c->stream.channels;
+	if (cd->channels > SOF_IPC_MAX_CHANNELS) {
+		ret = -EINVAL;
+		goto err;
+	}
+
 	cd->sample_rate_inv = (int32_t)(1000LL * INT32_MAX / sink_c->stream.rate);
 
 	buffer_release(sink_c);


### PR DESCRIPTION
Volume has multiple data arrays sized to SOF_IPC_MAX_CHANNELS and code that uses these arrays without bounds checks (like volume_ramp()).

Add a sanity check to volume_prepare() to ensure channels count is never set to a higher value.