### PR TITLE
dai-zephyr: possible division-by-zero if max_block_count is zero

### DIFF
--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -642,6 +642,11 @@ static int dai_capture_params(struct comp_dev *dev, uint32_t period_bytes,
 			goto out;
 		}
 
+		if (!max_block_count) {
+			comp_err(dev, "dai_capture_params(): invalid max-block-count of zero");
+			goto out;
+		}
+
 		if (max_block_count < period_count) {
 			comp_dbg(dev, "dai_capture_params(): block count = %d not supported by DMA", period_count);
 			buf_size = period_count * period_bytes;


### PR DESCRIPTION
If the max_block_count attribute is zero, this may lead to division by zero error. Handle this explicitly but reporting error if max_block_count is zero.