### PR TITLE
ipc4: fix NULL dereference

### DIFF
--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -482,7 +482,6 @@ static int ipc4_process_chain_dma(struct ipc4_message_request *ipc4)
 
 		cdma_comp = ipc_get_comp_by_id(ipc, comp_id);
 		if (!cdma_comp) {
-			comp_free(cdma_comp->cd);
 			return IPC4_FAILURE;
 		}
 


### PR DESCRIPTION
This will fix NULL dereference in ipc4_process_chain_dma()