### PR TITLE
xtensa-build-xephyr: fix xt-objcopy failure when default-params missing

### DIFF
--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -674,7 +674,7 @@ def build_platforms():
 		if platform not in RI_INFO_UNSUPPORTED:
 			reproducible_checksum(platform, west_top / platform_build_dir_name / "zephyr" / "zephyr.ri")
 
-		install_platform(platform, sof_platform_output_dir)
+		install_platform(platform, sof_platform_output_dir, platf_build_environ)
 
 	src_dest_list = []
 
@@ -706,7 +706,7 @@ def build_platforms():
 			symlinks=True, ignore_dangling_symlinks=True, dirs_exist_ok=True)
 
 
-def install_platform(platform, sof_platform_output_dir):
+def install_platform(platform, sof_platform_output_dir, platf_build_environ):
 
 	# Keep in sync with caller
 	platform_build_dir_name = f"build-{platform}"
@@ -797,7 +797,12 @@ def install_platform(platform, sof_platform_output_dir):
 		# Remove it like some gcc test scripts do:
 		# https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=c7046906c3ae
 		if "strip" in str(dstname):
-			execute_command([str(x) for x in [objcopy, "--remove-section", ".comment", src, dst]])
+			execute_command(
+				[str(x) for x in [objcopy, "--remove-section", ".comment", src, dst]],
+				# Some xtensa installs don't have a
+				# XtensaTools/config/default-params symbolic link
+				env=platf_build_environ,
+			)
 		elif f.txt:
 			dos2unix(src, dst)
 		else:


### PR DESCRIPTION
Fixes recent commit 8aab18351fd6 ("xtensa-build-zephyr: fix DEFAULT_TOOLCHAIN_VARIANT spill on next platf")

Some XtensaTools installation are missing this `default-params` symbolic link:

```
XtensaTools/config/
|-- X4H3I16w2D48w3a_2017_8-params
|-- X6H3CNL_2017_8-params
|-- cavs2x_LX6HiFi3_2017_8-params
`-- default-params -> cavs2x_LX6HiFi3_2017_8-params
```

Maybe it's missing when installing with the graphical interface?

This symbolic link is surprisingly enough to make `xt-objcopy` work _without_ the XTENSA_ variables. But when the variables _and_ the link are both missing, then `xt-objcopy` fails with the usual error:

```
in current dir: work/current/sof; running command:
 XtDevTools/install/tools/RG-2017.8-linux/XtensaTools/bin/xt-objcopy
 --remove-section .comment sof/build-tgl/zephyr/zephyr.strip
       build-sof-staging/sof-info/tgl/stripped-zephyr.elf
Error: there is no Xtensa core registered as the default.

You need to either specify the name of a registered Xtensa core (with
the --xtensa-core option or the XTENSA_CORE environment variable) or
specify a different registry of Xtensa cores (with the --xtensa-system
option or the XTENSA_SYSTEM environment variable).

The following Xtensa cores are available:
	hifiep_bd5
	cavs2x_LX6HiFi3_2017_8
	sample_config
	sample_flix
	...
```

Fix this failure by simply passing the XTENSA_ variables to xt-objcopy.

Kudos to Seppo Ingalsuo for the interactive debugging session that allowed root-causing this problem extremely quickly.