### PR TITLE
Copy rimage toml config files to SOF repository

### DIFF
--- a/config/apl.toml
+++ b/config/apl.toml
@@ -1,0 +1,49 @@
+version = [1, 8]
+
+[adsp]
+name = "apl"
+image_size = "0x0A0000"        # (8 + 2) bank * 64KB
+
+[[adsp.mem_zone]]
+type = "ROM"
+base = "0xBEFE0000"
+size = "0x00002000"
+[[adsp.mem_zone]]
+type = "SRAM"
+base = "0xA000A000"
+size = "0x100000"
+
+[cse]
+partition_name = "ADSP"
+[[cse.entry]]
+name = "ADSP.man"
+offset = "0x58"
+length = "0x378"
+[[cse.entry]]
+name = "cavs0015.met"
+offset = "0x400"
+length = "0x60"
+[[cse.entry]]
+name = "cavs0015"
+offset = "0x480"
+length = "0x0"  # calculated by rimage
+
+[css]
+
+[signed_pkg]
+name = "ADSP"
+[[signed_pkg.module]]
+name = "cavs0015.met"
+
+[partition_info]
+name = "ADSP"
+[[partition_info.module]]
+name = "cavs0015.met"
+
+[adsp_file]
+[[adsp_file.comp]]
+base_offset = "0x2000"
+
+[fw_desc.header]
+name = "ADSPFW"
+load_offset = "0x2000"

--- a/config/bdw.toml
+++ b/config/bdw.toml
@@ -1,0 +1,15 @@
+version = [1, 0]  # use simple file write
+
+[adsp]
+name = "bdw"
+
+[[adsp.mem_zone]]
+type = "IRAM"
+base = "0"
+size = "0x50000"
+host_offset = "0x000A0000"
+[[adsp.mem_zone]]
+type = "DRAM"
+base = "0x00400000"
+size = "0xA0000"
+host_offset = "0x0"

--- a/config/bsw.toml
+++ b/config/bsw.toml
@@ -1,0 +1,15 @@
+version = [1, 0]  # use simple file write
+
+[adsp]
+name = "bsw"
+
+[[adsp.mem_zone]]
+type = "IRAM"
+base = "0xFF2C0000"
+size = "0x14000"
+host_offset = "0x0C0000"
+[[adsp.mem_zone]]
+type = "DRAM"
+base = "0xFF300000"
+size = "0x28000"
+host_offset = "0x100000"

--- a/config/byt.toml
+++ b/config/byt.toml
@@ -1,0 +1,15 @@
+version = [1, 0]  # use simple file write
+
+[adsp]
+name = "byt"
+
+[[adsp.mem_zone]]
+type = "IRAM"
+base = "0xFF2C0000"
+size = "0x14000"
+host_offset = "0x0C0000"
+[[adsp.mem_zone]]
+type = "DRAM"
+base = "0xFF300000"
+size = "0x28000"
+host_offset = "0x100000"

--- a/config/cht.toml
+++ b/config/cht.toml
@@ -1,0 +1,15 @@
+version = [1, 0]  # use simple file write
+
+[adsp]
+name = "cht"
+
+[[adsp.mem_zone]]
+type = "IRAM"
+base = "0xFF2C0000"
+size = "0x14000"
+host_offset = "0x0C0000"
+[[adsp.mem_zone]]
+type = "DRAM"
+base = "0xFF300000"
+size = "0x28000"
+host_offset = "0x100000"

--- a/config/cnl.toml
+++ b/config/cnl.toml
@@ -1,0 +1,53 @@
+version = [1, 8]
+
+[adsp]
+name = "cnl"
+image_size = "0x300000"	# (47 + 1) bank * 64KB
+
+[[adsp.mem_zone]]
+type = "ROM"
+base = "0xBEFE0000"
+size = "0x00002000"
+[[adsp.mem_zone]]
+type = "IMR"
+base = "0xB0038000"
+size = "0x100000"
+[[adsp.mem_zone]]
+type = "SRAM"
+base = "0xBE040000"
+size = "0x100000"
+
+[cse]
+partition_name = "ADSP"
+[[cse.entry]]
+name = "ADSP.man"
+offset = "0x58"
+length = "0x378"
+[[cse.entry]]
+name = "cavs0015.met"
+offset = "0x400"
+length = "0x60"
+[[cse.entry]]
+name = "cavs0015"
+offset = "0x480"
+length = "0x0"  # calculated by rimage
+
+[css]
+
+[signed_pkg]
+name = "ADSP"
+[[signed_pkg.module]]
+name = "cavs0015.met"
+
+[partition_info]
+name = "ADSP"
+[[partition_info.module]]
+name = "cavs0015.met"
+
+[adsp_file]
+[[adsp_file.comp]]
+base_offset = "0x2000"
+
+[fw_desc.header]
+name = "ADSPFW"
+load_offset = "0x30000"

--- a/config/hsw.toml
+++ b/config/hsw.toml
@@ -1,0 +1,15 @@
+version = [1, 0]  # use simple file write
+
+[adsp]
+name = "hsw"
+
+[[adsp.mem_zone]]
+type = "IRAM"
+base = "0"
+size = "0x60000"
+host_offset = "0x80000"
+[[adsp.mem_zone]]
+type = "DRAM"
+base = "0x00400000"
+size = "0x80000"
+host_offset = "0x0"

--- a/config/icl.toml
+++ b/config/icl.toml
@@ -1,0 +1,53 @@
+version = [1, 8]
+
+[adsp]
+name = "icl"
+image_size = "0x300000"	# (47 + 1) bank * 64KB
+
+[[adsp.mem_zone]]
+type = "ROM"
+base = "0xBEFE0000"
+size = "0x00002000"
+[[adsp.mem_zone]]
+type = "IMR"
+base = "0xB0038000"
+size = "0x100000"
+[[adsp.mem_zone]]
+type = "SRAM"
+base = "0xBE040000"
+size = "0x100000"
+
+[cse]
+partition_name = "ADSP"
+[[cse.entry]]
+name = "ADSP.man"
+offset = "0x58"
+length = "0x378"
+[[cse.entry]]
+name = "cavs0015.met"
+offset = "0x400"
+length = "0x60"
+[[cse.entry]]
+name = "cavs0015"
+offset = "0x480"
+length = "0x0"  # calculated by rimage
+
+[css]
+
+[signed_pkg]
+name = "ADSP"
+[[signed_pkg.module]]
+name = "cavs0015.met"
+
+[partition_info]
+name = "ADSP"
+[[partition_info.module]]
+name = "cavs0015.met"
+
+[adsp_file]
+[[adsp_file.comp]]
+base_offset = "0x2000"
+
+[fw_desc.header]
+name = "ADSPFW"
+load_offset = "0x30000"

--- a/config/imx8.toml
+++ b/config/imx8.toml
@@ -1,0 +1,20 @@
+version = [1, 0]  # use simple file write
+
+[adsp]
+name = "imx8"
+
+[[adsp.mem_zone]]
+type = "IRAM"
+base = "0x596F8000"
+size = "0x800"
+host_offset = "0x10000"
+[[adsp.mem_zone]]
+type = "DRAM"
+base = "0x596E8000"
+size = "0x8000"
+host_offset = "0x0"
+[[adsp.mem_zone]]
+type = "SRAM"
+base = "0x92400000"
+size = "0x800000"
+host_offset = "0x0"

--- a/config/imx8m.toml
+++ b/config/imx8m.toml
@@ -1,0 +1,20 @@
+version = [1, 0]  # use simple file write
+
+[adsp]
+name = "imx8m"
+
+[[adsp.mem_zone]]
+type = "IRAM"
+base = "0x3b6F8000"
+size = "0x800"
+host_offset = "0x10000"
+[[adsp.mem_zone]]
+type = "DRAM"
+base = "0x3B6E8000"
+size = "0x8000"
+host_offset = "0x0"
+[[adsp.mem_zone]]
+type = "SRAM"
+base = "0x92400000"
+size = "0x800000"
+host_offset = "0x0"

--- a/config/imx8ulp.toml
+++ b/config/imx8ulp.toml
@@ -1,0 +1,20 @@
+version = [1, 0]  # use simple file write
+
+[adsp]
+name = "imx8ulp"
+
+[[adsp.mem_zone]]
+type = "IRAM"
+base = "0x21170000"
+size = "0x10000"
+host_offset = "0x0"
+[[adsp.mem_zone]]
+type = "DRAM"
+base = "0x21180000"
+size = "0x10000"
+host_offset = "0x10000"
+[[adsp.mem_zone]]
+type = "SRAM"
+base = "0x1a000000"
+size = "0x800000"
+host_offset = "0x0"

--- a/config/imx8x.toml
+++ b/config/imx8x.toml
@@ -1,0 +1,20 @@
+version = [1, 0]  # use simple file write
+
+[adsp]
+name = "imx8x"
+
+[[adsp.mem_zone]]
+type = "IRAM"
+base = "0x596F8000"
+size = "0x800"
+host_offset = "0x10000"
+[[adsp.mem_zone]]
+type = "DRAM"
+base = "0x596e8000"
+size = "0x8000"
+host_offset = "0x0"
+[[adsp.mem_zone]]
+type = "SRAM"
+base = "0x92400000"
+size = "0x800000"
+host_offset = "0x0"

--- a/config/jsl.toml
+++ b/config/jsl.toml
@@ -1,0 +1,53 @@
+version = [1, 8]
+
+[adsp]
+name = "icl"
+image_size = "0x110000"	# (16 + 1) bank * 64KB
+
+[[adsp.mem_zone]]
+type = "ROM"
+base = "0xBEFE0000"
+size = "0x00002000"
+[[adsp.mem_zone]]
+type = "IMR"
+base = "0xB0038000"
+size = "0x100000"
+[[adsp.mem_zone]]
+type = "SRAM"
+base = "0xBE040000"
+size = "0x100000"
+
+[cse]
+partition_name = "ADSP"
+[[cse.entry]]
+name = "ADSP.man"
+offset = "0x58"
+length = "0x378"
+[[cse.entry]]
+name = "cavs0015.met"
+offset = "0x400"
+length = "0x60"
+[[cse.entry]]
+name = "cavs0015"
+offset = "0x480"
+length = "0x0"  # calculated by rimage
+
+[css]
+
+[signed_pkg]
+name = "ADSP"
+[[signed_pkg.module]]
+name = "cavs0015.met"
+
+[partition_info]
+name = "ADSP"
+[[partition_info.module]]
+name = "cavs0015.met"
+
+[adsp_file]
+[[adsp_file.comp]]
+base_offset = "0x2000"
+
+[fw_desc.header]
+name = "ADSPFW"
+load_offset = "0x30000"

--- a/config/kbl.toml
+++ b/config/kbl.toml
@@ -1,0 +1,22 @@
+version = [1, 5]
+
+[adsp]
+name = "kbl"
+image_size = "0x200000" # (30 + 2) bank * 64KB
+
+[[adsp.mem_zone]]
+type = "ROM"
+base = "0xBEFE0000"
+size = "0x00002000"
+[[adsp.mem_zone]]
+type = "SRAM"
+base = "0xA000A000"
+size = "0x100000"
+
+[css]
+
+[fw_desc.header]
+name = "ADSPFW"
+load_offset = "0"
+hw_buf_base_addr = "0xBE500000"
+hw_buf_length = "0x4A000"

--- a/config/mt8186.toml
+++ b/config/mt8186.toml
@@ -1,0 +1,15 @@
+version = [1, 0]  # use simple file write
+
+[adsp]
+name = "mt8186"
+
+[[adsp.mem_zone]]
+type = "IRAM"
+base = "0x4e100000"
+size = "0x00100000"
+host_offset = "0x0"
+[[adsp.mem_zone]]
+type = "SRAM"
+base = "0x60000000"
+size = "0x00600000"
+host_offset = "0x0"

--- a/config/mt8188.toml
+++ b/config/mt8188.toml
@@ -1,0 +1,15 @@
+version = [1, 0]  # parse_adsp_config_v1_0()
+
+[adsp]
+name = "mt8188"
+
+[[adsp.mem_zone]]
+type = "IRAM"
+base = "0x4e100000"
+size = "0x00080000"
+host_offset = "0x0"
+[[adsp.mem_zone]]
+type = "SRAM"
+base = "0x60000000"
+size = "0x00600000"
+host_offset = "0x0"

--- a/config/mt8195.toml
+++ b/config/mt8195.toml
@@ -1,0 +1,15 @@
+version = [1, 0]  # use simple file write
+
+[adsp]
+name = "mt8195"
+
+[[adsp.mem_zone]]
+type = "IRAM"
+base = "0x40000000"
+size = "0x00040000"
+host_offset = "0x0"
+[[adsp.mem_zone]]
+type = "SRAM"
+base = "0x60000000"
+size = "0x00600000"
+host_offset = "0x0"

--- a/config/mtl.toml
+++ b/config/mtl.toml
@@ -1,0 +1,488 @@
+version = [3, 0]
+
+[adsp]
+name = "mtl"
+image_size = "0x2C0000" # (22) bank * 128KB
+alias_mask = "0xE0000000"
+
+[[adsp.mem_zone]]
+type = "ROM"
+base = "0x1FF80000"
+size = "0x400"
+[[adsp.mem_zone]]
+type = "IMR"
+base = "0xA104A000"
+size = "0x2000"
+[[adsp.mem_zone]]
+type = "SRAM"
+base = "0xa00f0000"
+size = "0x100000"
+
+[[adsp.mem_alias]]
+type = "uncached"
+base = "0x40000000"
+[[adsp.mem_alias]]
+type = "cached"
+base = "0xA0000000"
+
+[cse]
+partition_name = "ADSP"
+[[cse.entry]]
+name = "ADSP.man"
+offset = "0x5c"
+length = "0x464"
+[[cse.entry]]
+name = "ADSP.met"
+offset = "0x4c0"
+length = "0x70"
+[[cse.entry]]
+name = "ADSP"
+offset = "0x540"
+length = "0x0"  # calculated by rimage
+
+[css]
+
+[signed_pkg]
+name = "ADSP"
+partition_usage = "0x23"
+[[signed_pkg.module]]
+name = "ADSP.met"
+
+[adsp_file]
+[[adsp_file.comp]]
+base_offset = "0x2000"
+
+[fw_desc.header]
+name = "ADSPFW"
+load_offset = "0x40000"
+
+[module]
+count = 19
+	[[module.entry]]
+	name = "BRNGUP"
+	uuid = "2B79E4F3-4675-F649-89DF-3BC194A91AEB"
+	affinity_mask = "0x1"
+	instance_count = "1"
+	domain_types = "0"
+	load_type = "0"
+	module_type = "0"
+	auto_start = "0"
+
+	[[module.entry]]
+	name = "BASEFW"
+	uuid = "0E398C32-5ADE-BA4B-93B1-C50432280EE4"
+	affinity_mask = "3"
+	instance_count = "1"
+	domain_types = "0"
+	load_type = "0"
+	module_type = "0"
+	auto_start = "0"
+
+	[[module.entry]]
+	name = "MIXIN"
+	uuid = "39656EB2-3B71-4049-8D3F-F92CD5C43C09"
+	affinity_mask = "0x1"
+	instance_count = "30"
+	domain_types = "0"
+	load_type = "0"
+	module_type = "1"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [0,   0,   0xfeef, 0xc,  0x8,   0x45ff,
+		   1, 0, 0xfeef, 0xc, 0x8, 0x45ff,
+		   1, 0, 0xfeef, 0xc, 0x8, 0x45ff,
+		   1, 0, 0xfeef, 0xc, 0x8, 0x45ff]
+
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [ 0, 0, 0, 0, 296, 644000, 45, 60, 0, 0, 0,
+				1, 0, 0, 0, 296, 669900, 48, 64, 0, 0, 0,
+				2, 0, 0, 0, 296, 934000, 96, 128, 0, 0, 0,
+				3, 0, 0, 0, 296, 1137000, 96, 128, 0, 0, 0,
+				4, 0, 0, 0, 296, 1482000, 48, 64, 0, 0, 0,
+				5, 0, 0, 0, 296, 1746000, 96, 128, 0, 0, 0,
+				6, 0, 0, 0, 296, 2274000, 192, 256, 0, 0, 0,
+				7, 0, 0, 0, 296, 2700000, 48, 64, 0, 0, 0,
+				8, 0, 0, 0, 296, 2964000, 96, 128, 0, 0, 0,
+				9, 0, 0, 0, 296, 3492000, 192, 256, 0, 0, 0]
+
+	[[module.entry]]
+	name = "MIXOUT"
+	uuid = "3C56505A-24D7-418F-BDDC-C1F5A3AC2AE0"
+	affinity_mask = "0x1"
+	instance_count = "30"
+	domain_types = "0"
+	load_type = "0"
+	module_type = "2"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [0, 0, 0xfeef, 0xc, 0x8, 0x45ff,
+			0, 0, 0xfeef, 0xc, 0x8, 0x45ff,
+			0, 0, 0xfeef, 0xc, 0x8, 0x45ff,
+			0, 0, 0xfeef, 0xc, 0x8, 0x45ff,
+			0, 0, 0xfeef, 0xc, 0x8, 0x45ff,
+			0, 0, 0xfeef, 0xc, 0x8, 0x45ff,
+			0, 0, 0xfeef, 0xc, 0x8, 0x45ff,
+			0, 0, 0xfeef, 0xc, 0x8, 0x45ff,
+			1, 0, 0xfeef, 0xc, 0x8, 0x45ff]
+
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [0, 0, 0, 0, 520, 649600, 48, 64, 0, 0, 0,
+				1, 0, 0, 0, 520, 966300, 96, 128, 0, 0, 0,
+				2, 0, 0, 0, 520, 2101000, 48, 64, 0, 0, 0,
+				3, 0, 0, 0, 520, 2500800, 192, 256, 0, 0, 0,
+				4, 0, 0, 0, 520, 2616700, 192, 256, 0, 0, 0,
+				5, 0, 0, 0, 520, 2964500, 192, 256, 0, 0, 0,
+				6, 0, 0, 0, 520, 4202000, 96, 128, 0, 0, 0,
+				7, 0, 0, 0, 520, 3730000, 192, 256, 0, 0, 0]
+
+	[[module.entry]]
+	name = "COPIER"
+	uuid = "9BA00C83-CA12-4A83-943C-1FA2E82F9DDA"
+	affinity_mask = "0x1"
+	instance_count = "32"
+	domain_types = "0"
+	load_type = "0"
+	module_type = "3"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [0, 0, 0xfeef, 0xf, 0xf, 0x45ff,
+			1, 0, 0xfeef, 0xf, 0xf, 0x45ff,
+			1, 0, 0xfeef, 0xf, 0xf, 0x45ff,
+			1, 0, 0xfeef, 0xf, 0xf, 0x45ff,
+			1, 0, 0xfeef, 0xf, 0xf, 0x45ff]
+
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [ 0, 0, 0, 0, 280, 640100, 45, 60, 0, 0, 0,
+				1, 0, 0, 0, 280, 1106300, 192, 192, 0, 0, 0,
+				2, 0, 0, 0, 280, 1573000, 45, 45, 0, 0, 0,
+				3, 0, 0, 0, 280, 2040600, 192, 256, 0, 0, 0,
+				4, 0, 0, 0, 280, 2507500, 192, 256, 0, 0, 0,
+				5, 0, 0, 0, 280, 2999000, 192, 256, 0, 0, 0,
+				6, 0, 0, 0, 280, 3501000, 45, 60, 0, 0, 0,
+				7, 0, 0, 0, 280, 3927000, 192, 256, 0, 0, 0,
+				8, 0, 0, 0, 280, 4424000, 192, 256, 0, 0, 0,
+				9, 0, 0, 0, 280, 4941000, 192, 256, 0, 0, 0]
+
+	[[module.entry]]
+	name = "PEAKVOL"
+	uuid = "8A171323-94A3-4E1D-AFE9-FE5DBAA4C393"
+	affinity_mask = "0x1"
+	instance_count = "10"
+	domain_types = "0"
+	load_type = "0"
+	module_type = "4"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [0, 0, 0xfeef, 0xf, 0xa, 0x45ff,
+			1, 0, 0xfeef, 0xf, 0xa, 0x45ff]
+
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [0, 0, 0, 0, 480, 1114000, 48, 64, 0, 0, 0,
+				1, 0, 0, 0, 480, 3321600, 192, 256, 0, 0, 0,
+				2, 0, 0, 0, 480, 3786000, 192, 256, 0, 0, 0,
+				3, 0, 0, 0, 480, 4333000, 48, 64, 0, 0, 0,
+				4, 0, 0, 0, 480, 4910000, 192, 256, 0, 0, 0,
+				5, 0, 0, 0, 480, 5441000, 192, 256, 0, 0, 0,
+				6, 0, 0, 0, 480, 6265000, 192, 256, 0, 0, 0]
+
+	[[module.entry]]
+	name = "GAIN"
+	uuid = "61BCA9A8-18D0-4A18-8E7B-2639219804B7"
+	affinity_mask = "0x1"
+	instance_count = "40"
+	domain_types = "0"
+	load_type = "0"
+	module_type = "9"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [0, 0, 0xfeef, 0xf, 0xf, 0x45ff,
+			1, 0, 0xfeef, 0xf, 0xf, 0x45ff]
+
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [0, 0, 0, 0, 416, 914000, 48, 64, 0, 0, 0,
+				1, 0, 0, 0, 416, 1321600, 192, 256, 0, 0, 0,
+				2, 0, 0, 0, 416, 1786000, 192, 256, 0, 0, 0,
+				3, 0, 0, 0, 416, 2333000, 48, 64, 0, 0, 0,
+				4, 0, 0, 0, 416, 2910000, 192, 256, 0, 0, 0,
+				5, 0, 0, 0, 416, 3441000, 192, 256, 0, 0, 0,
+				6, 0, 0, 0, 416, 4265000, 192, 256, 0, 0, 0]
+
+	[[module.entry]]
+	name = "ASRC"
+	uuid = "66B4402D-B468-42F2-81A7-B37121863DD4"
+	affinity_mask = "0x3"
+	instance_count = "2"
+	domain_types = "0"
+
+	load_type = "0"
+	module_type = "9"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	pin = [0, 0, 0xfeef, 0xc, 0x8, 0x45ff,
+			1, 0, 0xfeef, 0xc, 0x8, 0x45ff]
+
+	mod_cfg = [0, 0, 0, 0, 20480, 4065600, 24, 22, 0, 0, 0,
+				1, 0, 0, 0, 20480, 5616000, 8, 25, 0, 0, 0,
+				2, 0, 0, 0, 20480, 7319200, 24, 27, 0, 0, 0,
+				3, 0, 0, 0, 20480, 9155300, 8, 27, 0, 0, 0,
+				4, 0, 0, 0, 20480, 10972600, 48, 54, 0, 0, 0,
+				5, 0, 0, 0, 20480, 12661000, 16, 36, 0, 0, 0,
+				6, 0, 0, 0, 20480, 14448500, 48, 96, 0, 0, 0,
+				7, 0, 0, 0, 20480, 16145000, 19, 68, 0, 0, 0,
+				8, 0, 0, 0, 20480, 17861300, 45, 102, 0, 0, 0,
+				9, 0, 0, 0, 20480, 21425900, 8, 36, 0, 0, 0,
+				10, 0, 0, 0, 20480, 22771000, 32, 102, 0, 0, 0,
+				11, 0, 0, 0, 20480, 23439000, 48, 27, 0, 0, 0,
+				12, 0, 0, 0, 20480, 33394000, 48, 51, 0, 0, 0,
+				13, 0, 0, 0, 20480, 36140000, 16, 96, 0, 0, 0,
+				14, 0, 0, 0, 20480, 38003000, 16, 68, 0, 0, 0,
+				15, 0, 0, 0, 20480, 39787000, 45, 51, 0, 0, 0]
+
+	[[module.entry]]
+	name = "SRC"
+	uuid = "E61BB28D-149A-4C1F-B709-46823EF5F5AE"
+	affinity_mask = "0x1"
+	#instance_count = "10"
+	domain_types = "0"
+	load_type = "0"
+	module_type = "7"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [0, 0, 0xffff, 0xc, 0x8, 0x05ff,
+			1, 0, 0xf6c9, 0xc, 0x8, 0x05ff]
+
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [0, 0, 0, 0, 12832, 1365500, 0, 0, 0, 1365, 0,
+				1, 0, 0, 0, 12832, 2302300, 0, 0, 0, 2302, 0,
+				2, 0, 0, 0, 12832, 3218200, 0, 0, 0, 3218, 0,
+				3, 0, 0, 0, 12832, 4169700, 0, 0, 0, 4169, 0,
+				4, 0, 0, 0, 12832, 5095100, 0, 0, 0, 5095, 0,
+				5, 0, 0, 0, 12832, 6014800, 0, 0, 0, 6014, 0,
+				6, 0, 0, 0, 12832, 6963500, 0, 0, 0, 6963, 0,
+				7, 0, 0, 0, 12832, 7791000, 0, 0, 0, 7791, 0,
+				8, 0, 0, 0, 12832, 8843000, 0, 0, 0, 8843, 0,
+				9, 0, 0, 0, 12832, 9755100, 0, 0, 0, 9755, 0,
+				10, 0, 0, 0, 12832, 10726500, 0, 0, 0, 10726, 0,
+				11, 0, 0, 0, 12832, 11624100, 0, 0, 0, 11624, 0,
+				12, 0, 0, 0, 12832, 12518700, 0, 0, 0, 12518, 0,
+				13, 0, 0, 0, 12832, 13555000, 0, 0, 0, 13555, 0,
+				14, 0, 0, 0, 12832, 14144500, 0, 0, 0, 14144, 0,
+				15, 0, 0, 0, 12832, 15809800, 0, 0, 0, 15809, 0,
+				16, 0, 0, 0, 12832, 16749000, 0, 0, 0, 16749, 0,
+				17, 0, 0, 0, 12832, 18433500, 0, 0, 0, 18433, 0,
+				18, 0, 0, 0, 12832, 19425900, 0, 0, 0, 19425, 0,
+				19, 0, 0, 0, 12832, 20396900, 0, 0, 0, 20396, 0,
+				20, 0, 0, 0, 12832, 20881000, 0, 0, 0, 20881, 0,
+				21, 0, 0, 0, 12832, 23431000, 0, 0, 0, 23431, 0,
+				22, 0, 0, 0, 12832, 30471000, 0, 0, 0, 30471, 0]
+
+	[[module.entry]]
+	name = "MICSEL"
+	uuid = "32FE92C1-1E17-4FC2-9758-C7F3542E980A"
+	affinity_mask = "0x1"
+	instance_count = "8"
+	domain_types = "0"
+	load_type = "0"
+	init_config = "1"
+	module_type = "0xC"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [0, 0, 0xfeef, 0xe, 0xa, 0x45ff, 1, 0, 0xfeef, 0xe, 0xa, 0x45ff]
+
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [0, 0, 0, 0, 960, 488500, 16, 16, 0, 0, 0,
+			1, 0, 0, 0, 960, 964500, 16, 16, 0, 0, 0,
+			2, 0, 0, 0, 960, 2003000, 16, 16, 0, 0, 0]
+
+	[[module.entry]]
+	name = "UPDWMIX"
+	uuid = "42F8060C-832F-4DBF-B247-51E961997B34"
+	affinity_mask = "0x1"
+	instance_count = "15"
+	domain_types = "0"
+	load_type = "0"
+	module_type = "5"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [0, 0, 0xffff, 0xc, 0x8, 0x05ff,
+			1, 0, 0xffff, 0xc, 0x8, 0x45ff]
+
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [0, 0, 0, 0, 216, 706000, 12, 16, 0, 0, 0,
+				1, 0, 0, 0, 216, 1271000, 8, 8, 0, 0, 0,
+				2, 0, 0, 0, 216, 1839000, 89, 118, 0, 0, 0,
+				3, 0, 0, 0, 216, 2435000, 48, 64, 0, 0, 0,
+				4, 0, 0, 0, 216, 3343000, 192, 192, 0, 0, 0,
+				5, 0, 0, 0, 216, 3961000, 177, 177, 0, 0, 0,
+				6, 0, 0, 0, 216, 4238000, 192, 256, 0, 0, 0,
+				7, 0, 0, 0, 216, 6691000, 192, 256, 0, 0, 0]
+
+	[[module.entry]]
+	name = "PROBE"
+	uuid = "7CAD0808-AB10-CD23-EF45-12AB34CD56EF"
+	affinity_mask = "0x1"
+	instance_count = "1"
+	domain_types = "0"
+	load_type = "0"
+	module_type = "9"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [0, 0, 0, 0, 4096, 100000, 48, 48, 0, 1000, 0]
+
+	[[module.entry]]
+	name = "MUX"
+	uuid = "64ce6e35-857a-4878-ace8-e2a2f42e3069"
+	affinity_mask = "0x1"
+	instance_count = "15"
+	domain_types = "0"
+	load_type = "0"
+	module_type = "6"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [0, 0, 0xfeef, 0xf, 0xa, 0x45ff,
+			0, 0, 0xfeef, 0xf, 0xa, 0x45ff,
+			1, 0, 0xfeef, 0xf, 0xa, 0x45ff]
+
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [0, 0, 0, 0, 280, 460700, 16, 16, 0, 0, 0]
+
+	[[module.entry]]
+	name = "KDTEST"
+	uuid = "EBA8D51F-7827-47B5-82EE-DE6E7743AF67"
+	affinity_mask = "0x1"
+	instance_count = "1"
+	domain_types = "0"
+	load_type = "0"
+	module_type = "8"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [0, 0, 0xfeef, 0xf, 0xf, 0x45ff,
+			1, 0, 0xfeef, 0xf, 0xa, 0x45ff]
+
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [0, 0, 0, 0, 480, 1114000, 64, 64, 0, 0, 0]
+
+	[[module.entry]]
+	name = "KPB"
+	uuid = "D8218443-5FF3-4A4C-B388-6CFE07B9562E"
+	affinity_mask = "0x1"
+	instance_count = "1"
+	domain_types = "0"
+	load_type = "0"
+	module_type = "0xB"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [0, 0, 0xfeef, 0xf, 0xf, 0x45ff,
+			1, 0, 0xfeef, 0xf, 0xa, 0x45ff]
+
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [0, 0, 0, 0, 14400, 1114000, 16, 16, 0, 0, 0]
+
+	# smart amp test module config
+	[[module.entry]]
+	name = "SMATEST"
+	uuid = "167A961E-8AE4-11EA-89F1-000C29CE1635"
+	affinity_mask = "0x1"
+	instance_count = "1"
+	domain_types = "0"
+	load_type = "0"
+	init_config = "1"
+	module_type = "0xD"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [0, 0, 0xfeef, 0xf, 0xa, 0x45ff,
+			0, 0, 0xfeef, 0xf, 0xa, 0x45ff,
+			1, 0, 0xfeef, 0xf, 0xa, 0x45ff]
+
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [0, 0, 0, 0, 4096, 1000000, 128, 128, 0, 0, 0]
+
+	# eq iir module config
+	[[module.entry]]
+	name = "EQIIR"
+	uuid = "5150C0E6-27F9-4EC8-8351-C705B642D12F"
+	affinity_mask = "0x1"
+	instance_count = "40"
+	domain_types = "0"
+	load_type = "0"
+	module_type = "9"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [0, 0, 0xfeef, 0xf, 0xf, 0x45ff,
+		1, 0, 0xfeef, 0xf, 0xf, 0x1ff]
+
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [0, 0, 0, 0, 4096, 1000000, 128, 128, 0, 0, 0]
+
+	# eq iir module config
+	[[module.entry]]
+	name = "EQFIR"
+	uuid = "43A90CE7-f3A5-41Df-AC06-BA98651AE6A3"
+	affinity_mask = "0x1"
+	instance_count = "40"
+	domain_types = "0"
+	load_type = "0"
+	module_type = "9"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [0, 0, 0xfeef, 0xf, 0xf, 0x45ff,
+		1, 0, 0xfeef, 0xf, 0xf, 0x1ff]
+
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [0, 0, 0, 0, 4096, 1000000, 128, 128, 0, 0, 0]
+
+	# Aria module config
+	[[module.entry]]
+	name = "ARIA"
+	uuid = "99F7166D-372C-43EF-81F6-22007AA15F03"
+	affinity_mask = "0x1"
+	instance_count = "8"
+	domain_types = "0"
+	load_type = "0"
+	init_config = "1"
+	module_type = "30"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [0, 0, 0xfeef, 0xf, 0xa, 0x45ff,
+			1, 0, 0xfeef, 0xf, 0xa, 0x45ff]
+
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [0, 0, 0, 0, 260, 1063000, 16, 21, 0, 0, 0,
+				1, 0, 0, 0, 260, 1873500, 192, 256, 0, 0, 0,
+				2, 0, 0, 0, 260, 2680000, 32, 42, 0, 0, 0,
+				3, 0, 0, 0, 260, 3591000, 64, 85, 0, 0, 0,
+				4, 0, 0, 0, 260, 4477000, 96, 128, 0, 0, 0,
+				5, 0, 0, 0, 260, 7195000, 192, 192, 0, 0, 0]

--- a/config/rmb.toml
+++ b/config/rmb.toml
@@ -1,0 +1,15 @@
+version = [1, 0]  # use simple file write
+
+[adsp]
+name = "rmb"
+
+[[adsp.mem_zone]]
+type = "IRAM"
+base = "0x7F000000"
+size = "0x40000"
+host_offset = "0x0"
+[[adsp.mem_zone]]
+type = "DRAM"
+base = "0xE0000000"
+size = "0xE0000"
+host_offset = "0x0"

--- a/config/rn.toml
+++ b/config/rn.toml
@@ -1,0 +1,15 @@
+version = [1, 0]  # use simple file write
+
+[adsp]
+name = "rn"
+
+[[adsp.mem_zone]]
+type = "IRAM"
+base = "0x20000000"
+size = "0x40000"
+host_offset = "0x0"
+[[adsp.mem_zone]]
+type = "DRAM"
+base = "0x21000000"
+size = "0xE0000"
+host_offset = "0x0"

--- a/config/skl.toml
+++ b/config/skl.toml
@@ -1,0 +1,22 @@
+version = [1, 5]
+
+[adsp]
+name = "skl"
+image_size = "0x200000" # (30 + 2) bank * 64KB
+
+[[adsp.mem_zone]]
+type = "ROM"
+base = "0xBEFE0000"
+size = "0x00002000"
+[[adsp.mem_zone]]
+type = "SRAM"
+base = "0xA000A000"
+size = "0x100000"
+
+[css]
+
+[fw_desc.header]
+name = "ADSPFW"
+load_offset = "0"
+hw_buf_base_addr = "0xBE500000"
+hw_buf_length = "0x4A000"

--- a/config/sue.toml
+++ b/config/sue.toml
@@ -1,0 +1,23 @@
+version = [1, 5]
+
+[adsp]
+name = "sue"
+image_size = "0x300000"        # (47 + 1) bank * 64KB
+exec_boot_ldr = 1
+
+[[adsp.mem_zone]]
+type = "ROM"
+base = "0xBEFE0000"
+size = "0x00002000"
+[[adsp.mem_zone]]
+type = "IMR"
+base = "0xb0038000"
+size = "0x100000"
+[[adsp.mem_zone]]
+type = "SRAM"
+base = "0xbe000000"
+size = "0x100000"
+
+[fw_desc.header]
+name = "ADSPFW"
+load_offset = "0x2000"

--- a/config/tgl-cavs.toml
+++ b/config/tgl-cavs.toml
@@ -1,0 +1,390 @@
+version = [2, 5]
+
+[adsp]
+name = "tgl"
+image_size = "0x2F0000"
+alias_mask = "0xE0000000"
+
+[[adsp.mem_zone]]
+type = "ROM"
+base = "0x9F180000"
+size = "0x00002000"
+[[adsp.mem_zone]]
+type = "IMR"
+base = "0xB0000000"
+size = "0x1000000"
+[[adsp.mem_zone]]
+type = "HP-SRAM"
+base = "0xBE000000"
+size = "0x800000"
+[[adsp.mem_zone]]
+type = "LP-SRAM"
+base = "0xBE800000"
+size = "0x40"
+
+[[adsp.mem_alias]]
+type = "uncached"
+base = "0x9E000000"
+[[adsp.mem_alias]]
+type = "cached"
+base = "0xBE000000"
+
+[cse]
+partition_name = "ADSP"
+[[cse.entry]]
+name = "ADSP.man"
+offset = "0x5c"
+length = "0x464"
+[[cse.entry]]
+name = "cavs0015.met"
+offset = "0x4c0"
+length = "0x70"
+[[cse.entry]]
+name = "cavs0015"
+offset = "0x540"
+length = "0x0"  # calculated by rimage
+
+[css]
+
+[signed_pkg]
+name = "ADSP"
+[[signed_pkg.module]]
+name = "cavs0015.met"
+
+[adsp_file]
+[[adsp_file.comp]]
+base_offset = "0x2000"
+
+[fw_desc.header]
+name = "ADSPFW"
+load_offset = "0x30000"
+
+[module]
+count = 15
+	[[module.entry]]
+	name = "BRNGUP"
+	uuid = "61EB0CB9-34D8-4F59-A21D-04C54C21D3A4"
+	affinity_mask = "0x1"
+	instance_count = "1"
+	domain_types = "0"
+	load_type = "0"
+	module_type = "0"
+	auto_start = "0"
+
+	[[module.entry]]
+	name = "BASEFW"
+	uuid = "383B9BE2-3518-4DB0-8891-B1470A8914F8"
+	affinity_mask = "3"
+	instance_count = "1"
+	domain_types = "0"
+	load_type = "0"
+	module_type = "0"
+	auto_start = "0"
+
+	[[module.entry]]
+	name = "MIXIN"
+	uuid = "39656EB2-3B71-4049-8D3F-F92CD5C43C09"
+	affinity_mask = "0x1"
+	instance_count = "30"
+	domain_types = "0"
+	load_type = "0"
+	module_type = "1"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [0,   0,   0xfeef, 0xc,  0x8,   0x45ff,
+		   1, 0, 0xfeef, 0xc, 0x8, 0x1ff,
+		   1, 0, 0xfeef, 0xc, 0x8, 0x1ff,
+		   1, 0, 0xfeef, 0xc, 0x8, 0x1ff,
+		   1, 0, 0xfeef, 0xc, 0x8, 0x1ff]
+
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [ 0, 0, 0, 0, 296, 644000, 45, 60, 0, 0, 0,
+				1, 0, 0, 0, 296, 669900, 48, 64, 0, 0, 0,
+				2, 0, 0, 0, 296, 934000, 96, 128, 0, 0, 0,
+				3, 0, 0, 0, 296, 1137000, 96, 128, 0, 0, 0,
+				4, 0, 0, 0, 296, 1482000, 48, 64, 0, 0, 0,
+				5, 0, 0, 0, 296, 1746000, 96, 128, 0, 0, 0,
+				6, 0, 0, 0, 296, 2274000, 192, 256, 0, 0, 0,
+				7, 0, 0, 0, 296, 2700000, 48, 64, 0, 0, 0,
+				8, 0, 0, 0, 296, 2964000, 96, 128, 0, 0, 0,
+				9, 0, 0, 0, 296, 3492000, 192, 256, 0, 0, 0]
+
+	[[module.entry]]
+	name = "MIXOUT"
+	uuid = "3C56505A-24D7-418F-BDDC-C1F5A3AC2AE0"
+	affinity_mask = "0x1"
+	instance_count = "30"
+	domain_types = "0"
+	load_type = "0"
+	module_type = "2"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [1, 0, 0xfeef, 0xc, 0x8, 0x45ff,
+			1, 0, 0xfeef, 0xc, 0x8, 0x1ff,
+			1, 0, 0xfeef, 0xc, 0x8, 0x1ff,
+			1, 0, 0xfeef, 0xc, 0x8, 0x1ff,
+			1, 0, 0xfeef, 0xc, 0x8, 0x1ff,
+			1, 0, 0xfeef, 0xc, 0x8, 0x1ff,
+			1, 0, 0xfeef, 0xc, 0x8, 0x1ff,
+			1, 0, 0xfeef, 0xc, 0x8, 0x1ff,
+			0, 0, 0xfeef, 0xc, 0x8, 0x1ff]
+
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [0, 0, 0, 0, 520, 649600, 48, 64, 0, 0, 0,
+				1, 0, 0, 0, 520, 966300, 96, 128, 0, 0, 0,
+				2, 0, 0, 0, 520, 2101000, 48, 64, 0, 0, 0,
+				3, 0, 0, 0, 520, 2500800, 192, 256, 0, 0, 0,
+				4, 0, 0, 0, 520, 2616700, 192, 256, 0, 0, 0,
+				5, 0, 0, 0, 520, 2964500, 192, 256, 0, 0, 0,
+				6, 0, 0, 0, 520, 4202000, 96, 128, 0, 0, 0,
+				7, 0, 0, 0, 520, 3730000, 192, 256, 0, 0, 0]
+
+	[[module.entry]]
+	name = "COPIER"
+	uuid = "9BA00C83-CA12-4A83-943C-1FA2E82F9DDA"
+	affinity_mask = "0x1"
+	instance_count = "32"
+	domain_types = "0"
+	load_type = "0"
+	module_type = "3"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [0, 0, 0xfeef, 0xf, 0xf, 0x45ff,
+			1, 0, 0xfeef, 0xf, 0xf, 0x1ff,
+			1, 0, 0xfeef, 0xf, 0xf, 0x1ff,
+			1, 0, 0xfeef, 0xf, 0xf, 0x1ff,
+			1, 0, 0xfeef, 0xf, 0xf, 0x1ff]
+
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [ 0, 0, 0, 0, 280, 640100, 45, 60, 0, 0, 0,
+				1, 0, 0, 0, 280, 1106300, 192, 192, 0, 0, 0,
+				2, 0, 0, 0, 280, 1573000, 45, 45, 0, 0, 0,
+				3, 0, 0, 0, 280, 2040600, 192, 256, 0, 0, 0,
+				4, 0, 0, 0, 280, 2507500, 192, 256, 0, 0, 0,
+				5, 0, 0, 0, 280, 2999000, 192, 256, 0, 0, 0,
+				6, 0, 0, 0, 280, 3501000, 45, 60, 0, 0, 0,
+				7, 0, 0, 0, 280, 3927000, 192, 256, 0, 0, 0,
+				8, 0, 0, 0, 280, 4424000, 192, 256, 0, 0, 0,
+				9, 0, 0, 0, 280, 4941000, 192, 256, 0, 0, 0]
+
+	[[module.entry]]
+	name = "PEAKVOL"
+	uuid = "8A171323-94A3-4E1D-AFE9-FE5DBAA4C393"
+	affinity_mask = "0x1"
+	instance_count = "10"
+	domain_types = "0"
+	load_type = "0"
+	module_type = "4"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [0, 0, 0xfeef, 0xf, 0xa, 0x45ff,
+			1, 0, 0xfeef, 0xf, 0xa, 0x1ff]
+
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [0, 0, 0, 0, 480, 1114000, 48, 64, 0, 0, 0,
+				1, 0, 0, 0, 480, 3321600, 192, 256, 0, 0, 0,
+				2, 0, 0, 0, 480, 3786000, 192, 256, 0, 0, 0,
+				3, 0, 0, 0, 480, 4333000, 48, 64, 0, 0, 0,
+				4, 0, 0, 0, 480, 4910000, 192, 256, 0, 0, 0,
+				5, 0, 0, 0, 480, 5441000, 192, 256, 0, 0, 0,
+				6, 0, 0, 0, 480, 6265000, 192, 256, 0, 0, 0]
+
+	[[module.entry]]
+	name = "GAIN"
+	uuid = "61BCA9A8-18D0-4A18-8E7B-2639219804B7"
+	affinity_mask = "0x1"
+	instance_count = "40"
+	domain_types = "0"
+	load_type = "0"
+	module_type = "9"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [0, 0, 0xfeef, 0xf, 0xf, 0x45ff,
+			1, 0, 0xfeef, 0xf, 0xf, 0x1ff]
+
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [0, 0, 0, 0, 416, 914000, 48, 64, 0, 0, 0,
+				1, 0, 0, 0, 416, 1321600, 192, 256, 0, 0, 0,
+				2, 0, 0, 0, 416, 1786000, 192, 256, 0, 0, 0,
+				3, 0, 0, 0, 416, 2333000, 48, 64, 0, 0, 0,
+				4, 0, 0, 0, 416, 2910000, 192, 256, 0, 0, 0,
+				5, 0, 0, 0, 416, 3441000, 192, 256, 0, 0, 0,
+				6, 0, 0, 0, 416, 4265000, 192, 256, 0, 0, 0]
+
+	[[module.entry]]
+	name = "PROBE"
+	uuid = "7CAD0808-AB10-CD23-EF45-12AB34CD56EF"
+	affinity_mask = "0x1"
+	instance_count = "1"
+	domain_types = "0"
+	load_type = "0"
+	module_type = "9"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [0, 0, 0, 0, 4096, 100000, 48, 48, 0, 1000, 0]
+
+	[[module.entry]]
+		name = "SRCINTC"
+		uuid = "e61bb28d-149a-4c1f-b709-46823ef5f5ae"
+		affinity_mask = "0xF"
+		instance_count = "10"
+		domain_types = "1"
+		load_type = "0"
+		module_type = "0x7"
+		auto_start = "0"
+		sched_caps = [1, 0x00008000]
+
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [0, 0, 0xffff, 0xc, 0x8, 0x45ff,
+		1, 0, 0xf6c9, 0xc, 0x8, 0x45ff]
+
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [0, 0, 0, 0, 12832, 1365500, 0, 0, 0, 1365, 0,
+		1, 0, 0, 0, 12832, 2302300, 0, 0, 0, 2302, 0,
+		2, 0, 0, 0, 12832, 3218200, 0, 0, 0, 3218, 0,
+		3, 0, 0, 0, 12832, 4169700, 0, 0, 0, 4169, 0,
+		4, 0, 0, 0, 12832, 5095100, 0, 0, 0, 5095, 0,
+		5, 0, 0, 0, 12832, 6014800, 0, 0, 0, 6014, 0,
+		6, 0, 0, 0, 12832, 6963500, 0, 0, 0, 6963, 0,
+		7, 0, 0, 0, 12832, 7791000, 0, 0, 0, 7791, 0,
+		8, 0, 0, 0, 12832, 8843000, 0, 0, 0, 8843, 0,
+		9, 0, 0, 0, 12832, 9755100, 0, 0, 0, 9755, 0,
+		10, 0, 0, 0, 12832, 10726500, 0, 0, 0, 10726, 0,
+		11, 0, 0, 0, 12832, 11624100, 0, 0, 0, 11624, 0,
+		12, 0, 0, 0, 12832, 12518700, 0, 0, 0, 12518, 0,
+		13, 0, 0, 0, 12832, 13555000, 0, 0, 0, 13555, 0,
+		14, 0, 0, 0, 12832, 14144500, 0, 0, 0, 14144, 0,
+		15, 0, 0, 0, 12832, 15809800, 0, 0, 0, 15809, 0,
+		16, 0, 0, 0, 12832, 16749000, 0, 0, 0, 16749, 0,
+		17, 0, 0, 0, 12832, 18433500, 0, 0, 0, 18433, 0,
+		18, 0, 0, 0, 12832, 19425900, 0, 0, 0, 19425, 0,
+		19, 0, 0, 0, 12832, 20396900, 0, 0, 0, 20396, 0,
+		20, 0, 0, 0, 12832, 20881000, 0, 0, 0, 20881, 0,
+		21, 0, 0, 0, 12832, 23431000, 0, 0, 0, 23431, 0,
+		22, 0, 0, 0, 12832, 30471000, 0, 0, 0, 30471, 0]
+
+	# smart amp test module config
+	[[module.entry]]
+	name = "SMATEST"
+	uuid = "167A961E-8AE4-11EA-89F1-000C29CE1635"
+	affinity_mask = "0x1"
+	instance_count = "1"
+	domain_types = "0"
+	load_type = "0"
+	module_type = "0xD"
+	init_config = "1"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [0, 0, 0xfeef, 0xf, 0xa, 0x45ff,
+			0, 0, 0xfeef, 0xf, 0xa, 0x45ff,
+			1, 0, 0xfeef, 0xf, 0xa, 0x45ff]
+
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [0, 0, 0, 0, 4096, 1000000, 128, 128, 0, 0, 0]
+
+	# eq iir module config
+	[[module.entry]]
+	name = "EQIIR"
+	uuid = "5150C0E6-27F9-4EC8-8351-C705B642D12F"
+	affinity_mask = "0x1"
+	instance_count = "40"
+	domain_types = "0"
+	load_type = "0"
+	module_type = "9"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [0, 0, 0xfeef, 0xf, 0xf, 0x45ff,
+			1, 0, 0xfeef, 0xf, 0xf, 0x1ff]
+
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [0, 0, 0, 0, 4096, 1000000, 128, 128, 0, 0, 0]
+
+	# eq iir module config
+	[[module.entry]]
+	name = "EQFIR"
+	uuid = "43A90CE7-f3A5-41Df-AC06-BA98651AE6A3"
+	affinity_mask = "0x1"
+	instance_count = "40"
+	domain_types = "0"
+	load_type = "0"
+	module_type = "9"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [0, 0, 0xfeef, 0xf, 0xf, 0x45ff,
+			1, 0, 0xfeef, 0xf, 0xf, 0x1ff]
+
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [0, 0, 0, 0, 4096, 1000000, 128, 128, 0, 0, 0]
+
+	[[module.entry]]
+	name = "KDTEST"
+	uuid = "EBA8D51F-7827-47B5-82EE-DE6E7743AF67"
+	affinity_mask = "0x1"
+	instance_count = "1"
+	domain_types = "0"
+	load_type = "1"
+	module_type = "8"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [0, 0, 0xfeef, 0xf, 0xf, 0x45ff,
+			1, 0, 0xfeef, 0xf, 0xa, 0x45ff]
+
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [0, 0, 0, 0, 480, 1114000, 64, 64, 0, 0, 0]
+
+	[[module.entry]]
+	name = "KPB"
+	uuid = "D8218443-5FF3-4A4C-B388-6CFE07B9562E"
+	affinity_mask = "0x1"
+	instance_count = "1"
+	domain_types = "0"
+	load_type = "1"
+	module_type = "0xB"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [0, 0, 0xfeef, 0xf, 0xf, 0x45ff,
+			1, 0, 0xfeef, 0xf, 0xa, 0x45ff]
+
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [0, 0, 0, 0, 14400, 1114000, 16, 16, 0, 0, 0]
+
+	[[module.entry]]
+	name = "MICSEL"
+	uuid = "32FE92C1-1E17-4FC2-9758-C7F3542E980A"
+	affinity_mask = "0x1"
+	instance_count = "8"
+	domain_types = "0"
+	load_type = "0"
+	module_type = "0xC"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [0, 0, 0xfeef, 0xe, 0xa, 0x45ff, 1, 0, 0xfeef, 0xe, 0xa, 0x45ff]
+
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [0, 0, 0, 0, 960, 488500, 16, 16, 0, 0, 0,
+			1, 0, 0, 0, 960, 964500, 16, 16, 0, 0, 0,
+			2, 0, 0, 0, 960, 2003000, 16, 16, 0, 0, 0]

--- a/config/tgl-h-cavs.toml
+++ b/config/tgl-h-cavs.toml
@@ -1,0 +1,237 @@
+version = [2, 5]
+
+[adsp]
+name = "tgl"
+image_size = "0x1F0000" # (30 + 1) bank * 64KB
+alias_mask = "0xE0000000"
+
+[[adsp.mem_zone]]
+type = "ROM"
+base = "0x9F180000"
+size = "0x00002000"
+[[adsp.mem_zone]]
+type = "IMR"
+base = "0xB0000000"
+size = "0x1000000"
+[[adsp.mem_zone]]
+type = "HP-SRAM"
+base = "0xBE000000"
+size = "0x800000"
+[[adsp.mem_zone]]
+type = "LP-SRAM"
+base = "0xBE800000"
+size = "0x40"
+
+[[adsp.mem_alias]]
+type = "uncached"
+base = "0x9E000000"
+[[adsp.mem_alias]]
+type = "cached"
+base = "0xBE000000"
+
+[cse]
+partition_name = "ADSP"
+[[cse.entry]]
+name = "ADSP.man"
+offset = "0x5c"
+length = "0x464"
+[[cse.entry]]
+name = "cavs0015.met"
+offset = "0x4c0"
+length = "0x70"
+[[cse.entry]]
+name = "cavs0015"
+offset = "0x540"
+length = "0x0"  # calculated by rimage
+
+[css]
+
+[signed_pkg]
+name = "ADSP"
+[[signed_pkg.module]]
+name = "cavs0015.met"
+
+[adsp_file]
+[[adsp_file.comp]]
+base_offset = "0x2000"
+
+[fw_desc.header]
+name = "ADSPFW"
+load_offset = "0x30000"
+
+[module]
+count = 8
+	[[module.entry]]
+	name = "BRNGUP"
+	uuid = "61EB0CB9-34D8-4F59-A21D-04C54C21D3A4"
+	affinity_mask = "0x1"
+	instance_count = "1"
+	domain_types = "0"
+	load_type = "0"
+	module_type = "0"
+	auto_start = "0"
+
+	[[module.entry]]
+	name = "BASEFW"
+	uuid = "383B9BE2-3518-4DB0-8891-B1470A8914F8"
+	affinity_mask = "3"
+	instance_count = "1"
+	domain_types = "0"
+	load_type = "0"
+	module_type = "0"
+	auto_start = "0"
+
+	[[module.entry]]
+	name = "MIXIN"
+	uuid = "39656EB2-3B71-4049-8D3F-F92CD5C43C09"
+	affinity_mask = "0x1"
+	instance_count = "30"
+	domain_types = "0"
+	load_type = "0"
+	module_type = "1"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [0,   0,   0xfeef, 0xc,  0x8,   0x45ff,
+		   1, 0, 0xfeef, 0xc, 0x8, 0x1ff,
+		   1, 0, 0xfeef, 0xc, 0x8, 0x1ff,
+		   1, 0, 0xfeef, 0xc, 0x8, 0x1ff,
+		   1, 0, 0xfeef, 0xc, 0x8, 0x1ff]
+
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [ 0, 0, 0, 0, 296, 644000, 45, 60, 0, 0, 0,
+				1, 0, 0, 0, 296, 669900, 48, 64, 0, 0, 0,
+				2, 0, 0, 0, 296, 934000, 96, 128, 0, 0, 0,
+				3, 0, 0, 0, 296, 1137000, 96, 128, 0, 0, 0,
+				4, 0, 0, 0, 296, 1482000, 48, 64, 0, 0, 0,
+				5, 0, 0, 0, 296, 1746000, 96, 128, 0, 0, 0,
+				6, 0, 0, 0, 296, 2274000, 192, 256, 0, 0, 0,
+				7, 0, 0, 0, 296, 2700000, 48, 64, 0, 0, 0,
+				8, 0, 0, 0, 296, 2964000, 96, 128, 0, 0, 0,
+				9, 0, 0, 0, 296, 3492000, 192, 256, 0, 0, 0]
+
+	[[module.entry]]
+	name = "MIXOUT"
+	uuid = "3C56505A-24D7-418F-BDDC-C1F5A3AC2AE0"
+	affinity_mask = "0x1"
+	instance_count = "30"
+	domain_types = "0"
+	load_type = "0"
+	module_type = "2"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [1, 0, 0xfeef, 0xc, 0x8, 0x45ff,
+			1, 0, 0xfeef, 0xc, 0x8, 0x1ff,
+			1, 0, 0xfeef, 0xc, 0x8, 0x1ff,
+			1, 0, 0xfeef, 0xc, 0x8, 0x1ff,
+			1, 0, 0xfeef, 0xc, 0x8, 0x1ff,
+			1, 0, 0xfeef, 0xc, 0x8, 0x1ff,
+			1, 0, 0xfeef, 0xc, 0x8, 0x1ff,
+			1, 0, 0xfeef, 0xc, 0x8, 0x1ff,
+			0, 0, 0xfeef, 0xc, 0x8, 0x1ff]
+
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [0, 0, 0, 0, 520, 649600, 48, 64, 0, 0, 0,
+				1, 0, 0, 0, 520, 966300, 96, 128, 0, 0, 0,
+				2, 0, 0, 0, 520, 2101000, 48, 64, 0, 0, 0,
+				3, 0, 0, 0, 520, 2500800, 192, 256, 0, 0, 0,
+				4, 0, 0, 0, 520, 2616700, 192, 256, 0, 0, 0,
+				5, 0, 0, 0, 520, 2964500, 192, 256, 0, 0, 0,
+				6, 0, 0, 0, 520, 4202000, 96, 128, 0, 0, 0,
+				7, 0, 0, 0, 520, 3730000, 192, 256, 0, 0, 0]
+
+	[[module.entry]]
+	name = "COPIER"
+	uuid = "9BA00C83-CA12-4A83-943C-1FA2E82F9DDA"
+	affinity_mask = "0x1"
+	instance_count = "32"
+	domain_types = "0"
+	load_type = "0"
+	module_type = "3"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [0, 0, 0xfeef, 0xf, 0xf, 0x45ff,
+			1, 0, 0xfeef, 0xf, 0xf, 0x1ff,
+			1, 0, 0xfeef, 0xf, 0xf, 0x1ff,
+			1, 0, 0xfeef, 0xf, 0xf, 0x1ff,
+			1, 0, 0xfeef, 0xf, 0xf, 0x1ff]
+
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [ 0, 0, 0, 0, 280, 640100, 45, 60, 0, 0, 0,
+				1, 0, 0, 0, 280, 1106300, 192, 192, 0, 0, 0,
+				2, 0, 0, 0, 280, 1573000, 45, 45, 0, 0, 0,
+				3, 0, 0, 0, 280, 2040600, 192, 256, 0, 0, 0,
+				4, 0, 0, 0, 280, 2507500, 192, 256, 0, 0, 0,
+				5, 0, 0, 0, 280, 2999000, 192, 256, 0, 0, 0,
+				6, 0, 0, 0, 280, 3501000, 45, 60, 0, 0, 0,
+				7, 0, 0, 0, 280, 3927000, 192, 256, 0, 0, 0,
+				8, 0, 0, 0, 280, 4424000, 192, 256, 0, 0, 0,
+				9, 0, 0, 0, 280, 4941000, 192, 256, 0, 0, 0]
+
+	[[module.entry]]
+	name = "PEAKVOL"
+	uuid = "8A171323-94A3-4E1D-AFE9-FE5DBAA4C393"
+	affinity_mask = "0x1"
+	instance_count = "10"
+	domain_types = "0"
+	load_type = "0"
+	module_type = "4"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [0, 0, 0xfeef, 0xf, 0xa, 0x45ff,
+			1, 0, 0xfeef, 0xf, 0xa, 0x1ff]
+
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [0, 0, 0, 0, 480, 1114000, 48, 64, 0, 0, 0,
+				1, 0, 0, 0, 480, 3321600, 192, 256, 0, 0, 0,
+				2, 0, 0, 0, 480, 3786000, 192, 256, 0, 0, 0,
+				3, 0, 0, 0, 480, 4333000, 48, 64, 0, 0, 0,
+				4, 0, 0, 0, 480, 4910000, 192, 256, 0, 0, 0,
+				5, 0, 0, 0, 480, 5441000, 192, 256, 0, 0, 0,
+				6, 0, 0, 0, 480, 6265000, 192, 256, 0, 0, 0]
+
+	[[module.entry]]
+	name = "GAIN"
+	uuid = "61BCA9A8-18D0-4A18-8E7B-2639219804B7"
+	affinity_mask = "0x1"
+	instance_count = "40"
+	domain_types = "0"
+	load_type = "0"
+	module_type = "9"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [0, 0, 0xfeef, 0xf, 0xf, 0x45ff,
+			1, 0, 0xfeef, 0xf, 0xf, 0x1ff]
+
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [0, 0, 0, 0, 416, 914000, 48, 64, 0, 0, 0,
+				1, 0, 0, 0, 416, 1321600, 192, 256, 0, 0, 0,
+				2, 0, 0, 0, 416, 1786000, 192, 256, 0, 0, 0,
+				3, 0, 0, 0, 416, 2333000, 48, 64, 0, 0, 0,
+				4, 0, 0, 0, 416, 2910000, 192, 256, 0, 0, 0,
+				5, 0, 0, 0, 416, 3441000, 192, 256, 0, 0, 0,
+				6, 0, 0, 0, 416, 4265000, 192, 256, 0, 0, 0]
+
+	[[module.entry]]
+	name = "PROBE"
+	uuid = "7CAD0808-AB10-CD23-EF45-12AB34CD56EF"
+	affinity_mask = "0x1"
+	instance_count = "1"
+	domain_types = "0"
+	load_type = "0"
+	module_type = "9"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [0, 0, 0, 0, 4096, 100000, 48, 48, 0, 1000, 0]
+

--- a/config/tgl-h.toml
+++ b/config/tgl-h.toml
@@ -1,0 +1,56 @@
+version = [2, 5]
+
+[adsp]
+name = "tgl"
+image_size = "0x1F0000" # (30 + 1) bank * 64KB
+alias_mask = "0xE0000000"
+
+[[adsp.mem_zone]]
+type = "ROM"
+base = "0x9F180000"
+size = "0x00002000"
+[[adsp.mem_zone]]
+type = "IMR"
+base = "0xB0038000"
+size = "0x100000"
+[[adsp.mem_zone]]
+type = "SRAM"
+base = "0xBE040000"
+size = "0x100000"
+
+[[adsp.mem_alias]]
+type = "uncached"
+base = "0x9E000000"
+[[adsp.mem_alias]]
+type = "cached"
+base = "0xBE000000"
+
+[cse]
+partition_name = "ADSP"
+[[cse.entry]]
+name = "ADSP.man"
+offset = "0x5c"
+length = "0x464"
+[[cse.entry]]
+name = "cavs0015.met"
+offset = "0x4c0"
+length = "0x70"
+[[cse.entry]]
+name = "cavs0015"
+offset = "0x540"
+length = "0x0"  # calculated by rimage
+
+[css]
+
+[signed_pkg]
+name = "ADSP"
+[[signed_pkg.module]]
+name = "cavs0015.met"
+
+[adsp_file]
+[[adsp_file.comp]]
+base_offset = "0x2000"
+
+[fw_desc.header]
+name = "ADSPFW"
+load_offset = "0x30000"

--- a/config/tgl.toml
+++ b/config/tgl.toml
@@ -1,0 +1,56 @@
+version = [2, 5]
+
+[adsp]
+name = "tgl"
+image_size = "0x2F0000" # (46 + 1) bank * 64KB
+alias_mask = "0xE0000000"
+
+[[adsp.mem_zone]]
+type = "ROM"
+base = "0x9F180000"
+size = "0x00002000"
+[[adsp.mem_zone]]
+type = "IMR"
+base = "0xB0038000"
+size = "0x100000"
+[[adsp.mem_zone]]
+type = "SRAM"
+base = "0xBE040000"
+size = "0x100000"
+
+[[adsp.mem_alias]]
+type = "uncached"
+base = "0x9E000000"
+[[adsp.mem_alias]]
+type = "cached"
+base = "0xBE000000"
+
+[cse]
+partition_name = "ADSP"
+[[cse.entry]]
+name = "ADSP.man"
+offset = "0x5c"
+length = "0x464"
+[[cse.entry]]
+name = "cavs0015.met"
+offset = "0x4c0"
+length = "0x70"
+[[cse.entry]]
+name = "cavs0015"
+offset = "0x540"
+length = "0x0"  # calculated by rimage
+
+[css]
+
+[signed_pkg]
+name = "ADSP"
+[[signed_pkg.module]]
+name = "cavs0015.met"
+
+[adsp_file]
+[[adsp_file.comp]]
+base_offset = "0x2000"
+
+[fw_desc.header]
+name = "ADSPFW"
+load_offset = "0x30000"

--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -637,7 +637,7 @@ def build_platforms():
 
 		# Sign firmware
 		rimage_executable = shutil.which("rimage", path=RIMAGE_BUILD_DIR)
-		rimage_config = RIMAGE_SOURCE_DIR / "config"
+		rimage_config = SOF_TOP / "config"
 		sign_cmd = ["west"]
 		sign_cmd += ["-v"] * args.verbose
 		sign_cmd += ["sign", "--build-dir", platform_build_dir_name, "--tool", "rimage"]
@@ -659,7 +659,7 @@ def build_platforms():
 		sign_cmd += ["-b", sof_build_vers]
 
 		if args.ipc == "IPC4":
-			rimage_desc = pathlib.Path(SOF_TOP, "rimage", "config", platform_dict["IPC4_RIMAGE_DESC"])
+			rimage_desc = pathlib.Path(SOF_TOP, "config", platform_dict["IPC4_RIMAGE_DESC"])
 			sign_cmd += ["-c", str(rimage_desc)]
 
 		execute_command(sign_cmd, cwd=west_top)

--- a/src/arch/xtensa/CMakeLists.txt
+++ b/src/arch/xtensa/CMakeLists.txt
@@ -448,7 +448,7 @@ if(MEU_PATH OR DEFINED MEU_NO_SIGN) # Don't sign with rimage
 		run_rimage
 		COMMAND ${PROJECT_BINARY_DIR}/rimage_ep/build/rimage
 			-o sof-${fw_name}.ri
-			-c "${PROJECT_SOURCE_DIR}/rimage/config/${fw_name}.toml"
+			-c "${PROJECT_SOURCE_DIR}/config/${fw_name}.toml"
 			-s ${MEU_OFFSET}
 			-k ${RIMAGE_PRIVATE_KEY}
 			-i ${RIMAGE_IMR_TYPE}
@@ -490,7 +490,7 @@ else() # sign with rimage
 		run_rimage
 		COMMAND ${PROJECT_BINARY_DIR}/rimage_ep/build/rimage
 			-o sof-${fw_name}.ri
-			-c "${PROJECT_SOURCE_DIR}/rimage/config/${fw_name}.toml"
+			-c "${PROJECT_SOURCE_DIR}/config/${fw_name}.toml"
 			-k ${RIMAGE_PRIVATE_KEY}
 			-i ${RIMAGE_IMR_TYPE}
 			-f ${SOF_MAJOR}.${SOF_MINOR}.${SOF_MICRO}


### PR DESCRIPTION
This patch moves rimage/config to sof/config.
Firmware manifest configuration files should stay
with SOF instead of rimage tool.

Link: https://github.com/thesofproject/sof/issues/7270

If you don't think sof/config is a good place, please comment the place you think is good.