### PR TITLE
aria: configure stream params

### DIFF
--- a/src/audio/aria/aria.c
+++ b/src/audio/aria/aria.c
@@ -151,7 +151,7 @@ static int init_aria(struct comp_dev *dev, const struct comp_ipc_config *config,
 
 	ibs = cd->base.ibs;
 	chc = cd->base.audio_fmt.channels_count;
-	sgs = (cd->base.audio_fmt.valid_bit_depth >> 3) * chc;
+	sgs = (cd->base.audio_fmt.depth >> 3) * chc;
 	sgc = ibs / sgs;
 	req_mem = get_required_emory(chc, sgc);
 	att = aria->attenuation;


### PR DESCRIPTION
Configure in/out buffer stream params.
In Windows scenarios, unconfigured values were causing zero-division exception in audio_stream_get_avail_frames.

Correct sample group size calculation for proper buffers management.