### PR TITLE
topology2: cavs-sdw: set capture host in_valid_bit_depth = 32

### DIFF
--- a/tools/topology/topology2/cavs-sdw.conf
+++ b/tools/topology/topology2/cavs-sdw.conf
@@ -181,9 +181,9 @@ Object.Pipeline {
 
 			Object.Widget.copier.1.stream_name	"Passthrough Capture 0"
 			Object.Widget.copier.1.Object.Base.audio_format.1 {
-				# 32 -> 16 bits conversion is done here,
-				# so in_bit_depth is 32 (and out_bit_depth is 16).
+				# 32/32 -> 16/16 bits conversion is done here
 				in_bit_depth	32
+				in_valid_bit_depth	32
 			}
 		}
 	]


### PR DESCRIPTION
For some reason the input valid bit depth was 16. But the output valid bit depth of the previous widget is 32. Fix it to 32 now.

Fixes: #7240 