### PR TITLE
platform: mt8195: Support C++ linkage with native/vendor xcc

### DIFF
--- a/src/platform/mt8195/mt8195.x.in
+++ b/src/platform/mt8195/mt8195.x.in
@@ -264,6 +264,7 @@ SECTIONS
     *(.rodata.*)
     *(.gnu.linkonce.r.*)
     *(.rodata1)
+    *(.clib.rodata)
     __XT_EXCEPTION_TABLE__ = ABSOLUTE(.);
     KEEP (*(.xt_except_table))
     KEEP (*(.gcc_except_table))
@@ -338,6 +339,7 @@ SECTIONS
     *(.gnu.linkonce.s.*)
     *(.sdata2)
     *(.sdata2.*)
+    *(.clib.data)
     *(.gnu.linkonce.s2.*)
     KEEP(*(.jcr))
     _trace_ctx_start = ABSOLUTE(.);

--- a/src/platform/mt8195/platform.c
+++ b/src/platform/mt8195/platform.c
@@ -236,3 +236,16 @@ void platform_wait_for_interrupt(int level)
 {
 	arch_wait_for_interrupt(level);
 }
+
+#ifdef __XCC__
+/* This is a stub for the Xtensa libc (not their newlib version),
+ * which inexplicably wants to pull in an unlink() implementation when
+ * linked against the C++ standard library.  Obviously nothing in SOF
+ * uses the C library filesystem layer, this is just spurious.
+ */
+int __attribute__((weak)) _unlink_r(struct _reent *ptr, const char *file);
+int __attribute__((weak)) _unlink_r(struct _reent *ptr, const char *file)
+{
+	return -1;
+}
+#endif


### PR DESCRIPTION
[Minor build fix for C++ linkage with the existing toolchains.  This was developed against the mt8195/v0.4 branch obviously, but is being submitted to main for propriety.  Someone (@marc-hb ?) will have to clue me in about the SOF process for cross-patching and backports.]

At least some versions of the Cadence toolchain for this platform are built with a slightly variant libc (vs. the newlib build which seems more common for other SOF devices).  That's fine in principle, SOF doesn't call anything out of the libc anyway.  But when linking with the C++ standard libraries, it pulls symbols out that need to go in otherwise-unrecognized linker sections.  And it wants to see an _unlink_r() function (the reentrant worker underneath unlink()) defined for reasons that completely escape me.