### PR TITLE
ipc4: Remove duplicate ALH_MULTI_GTW_BASE declaration

### DIFF
--- a/src/include/ipc4/gateway.h
+++ b/src/include/ipc4/gateway.h
@@ -202,8 +202,6 @@ struct ipc4_ipc_gateway_config_blob {
 	uint32_t threshold_low;
 } __attribute__((packed, aligned(4)));
 
-#define ALH_MULTI_GTW_BASE	0x50
-
 enum ipc4_gateway_type {
 	ipc4_gtw_none	= BIT(0),
 	ipc4_gtw_host	= BIT(1),

--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -219,8 +219,7 @@ static int dai_get_unused_llp_slot(struct comp_dev *dev,
 	int i;
 
 	/* sdw with multiple gateways uses sndw_reading_slots */
-	if (node->f.dma_type == ipc4_alh_link_output_class &&
-	    node->f.v_index >= ALH_MULTI_GTW_BASE) {
+	if (node->f.dma_type == ipc4_alh_link_output_class && is_multi_gateway(*node)) {
 		offset = SRAM_REG_LLP_SNDW_READING_SLOTS;
 		max_slot = IPC4_MAX_LLP_SNDW_READING_SLOTS - 1;
 	} else {


### PR DESCRIPTION
In ipc4/alh.h we have:
```
#define IPC4_ALH_MULTI_GTW_BASE 0x50
```
In ipc4/gateway.h:
```
#define ALH_MULTI_GTW_BASE 0x50
```

These were added almost simultaneously by two separate pull-requests. No need to have them both.

is_multi_gateway() is declared in ipc4/alh.h as:
```
/* Multi-gateways addressing starts from IPC4_ALH_MULTI_GTW_BASE */
#define IPC4_ALH_MULTI_GTW_BASE 0x50

static inline bool is_multi_gateway(const union ipc4_connector_node_id node_id)
{
	return node_id.f.v_index >= IPC4_ALH_MULTI_GTW_BASE;
}
```