### PR TITLE
dai-zephyr: Fix the ordering of DAI and DMA triggers during

### DIFF
--- a/src/audio/Kconfig
+++ b/src/audio/Kconfig
@@ -20,6 +20,13 @@ config COMP_DAI
 	help
 	  Select for DAI component
 
+config COMP_DAI_STOP_TRIGGER_ORDER_REVERSE
+	bool "Reverse the ordering of DMA and DAI triggers during STOP/PAUSE"
+	help
+	  Select if the ordering of DMA and DAI triggers during stop/pause should be reversed.
+	  The normal order during stop/pause is to stop DAI before stopping DMA. This option will
+	  allow reversing the order to do DMA stop before stopping DAI.
+
 config COMP_DAI_GROUP
 	bool "DAI Grouping support"
 	default y


### PR DESCRIPTION
pause/release

Pause the DAI before the DMA and start the DMA before starting the DAI during release.