### PR TITLE
coherent: fix cache flush logic if coherent is not the first member

### DIFF
--- a/src/include/sof/coherent.h
+++ b/src/include/sof/coherent.h
@@ -171,7 +171,7 @@ static inline void *__coherent_init(size_t offset, const size_t size)
 	c->core = cpu_get_id();
 	list_init(&c->list);
 	/* inv local data to coherent object */
-	dcache_invalidate_region(uncache_to_cache(c), size);
+	dcache_invalidate_region(uncache_to_cache(object), size);
 
 	return object;
 }
@@ -260,7 +260,7 @@ static inline void *__coherent_init_thread(size_t offset, const size_t size)
 	c->core = cpu_get_id();
 	list_init(&c->list);
 	/* inv local data to coherent object */
-	dcache_invalidate_region(uncache_to_cache(c), size);
+	dcache_invalidate_region(uncache_to_cache(object), size);
 
 	return object;
 }


### PR DESCRIPTION
If coherent object is at non-zero offset, the init call ends up invalidating data cache outside the allocated buffer.

All current users of "struct coherent" have the object as the first member, so nothing is broken with current code.