### PR TITLE
drivers: imx: remove unnecessary blank lines

### DIFF
--- a/src/drivers/imx/interrupt-irqsteer.c
+++ b/src/drivers/imx/interrupt-irqsteer.c
@@ -310,7 +310,6 @@ static inline void handle_irq_batch(struct irq_cascade_desc *cascade,
 
 				handled = true;
 			}
-
 		}
 
 		k_spin_unlock(&cascade->lock, key);
@@ -355,7 +354,6 @@ static inline void irq_handler(void *data, uint32_t line_index)
 			       (uint32_t)(status >> 32), (uint32_t)status);
 		}
 	}
-
 }
 
 #define DEFINE_IRQ_HANDLER(n) \
@@ -382,7 +380,6 @@ static void irq_mask(struct irq_desc *desc, uint32_t irq, unsigned int core)
 	irq += irq_base;
 
 	irqstr_mask_int(irq);
-
 }
 
 static void irq_unmask(struct irq_desc *desc, uint32_t irq, unsigned int core)
@@ -394,7 +391,6 @@ static void irq_unmask(struct irq_desc *desc, uint32_t irq, unsigned int core)
 	irq += irq_base;
 
 	irqstr_unmask_int(irq);
-
 }
 
 static const struct irq_cascade_ops irq_ops = {
@@ -479,7 +475,6 @@ void interrupt_mask(uint32_t irq, unsigned int cpu)
 	if (cascade && cascade->ops->mask)
 		cascade->ops->mask(&cascade->desc, irq - cascade->irq_base,
 				   cpu);
-
 }
 
 void interrupt_unmask(uint32_t irq, unsigned int cpu)
@@ -489,5 +484,4 @@ void interrupt_unmask(uint32_t irq, unsigned int cpu)
 	if (cascade && cascade->ops->unmask)
 		cascade->ops->unmask(&cascade->desc, irq - cascade->irq_base,
 				     cpu);
-
 }

--- a/src/drivers/imx/sdma.c
+++ b/src/drivers/imx/sdma.c
@@ -443,6 +443,7 @@ static void sdma_disable_event(struct dma_chan_data *channel, int eventnum)
 static void sdma_channel_put(struct dma_chan_data *channel)
 {
 	struct sdma_chan *pdata = dma_chan_get_data(channel);
+
 	if (channel->status == COMP_STATE_INIT)
 		return; /* Channel was already free */
 	tr_dbg(&sdma_tr, "sdma_channel_put(%d)", channel->index);

--- a/src/drivers/imx/timer.c
+++ b/src/drivers/imx/timer.c
@@ -99,17 +99,14 @@ int timer_register(struct timer *timer, void(*handler)(void *arg), void *arg)
 void timer_unregister(struct timer *timer, void *arg)
 {
 	interrupt_unregister(timer->irq, arg);
-
 }
 
 void timer_enable(struct timer *timer, void *arg, int core)
 {
 	interrupt_enable(timer->irq, arg);
-
 }
 
 void timer_disable(struct timer *timer, void *arg, int core)
 {
 	interrupt_disable(timer->irq, arg);
-
 }


### PR DESCRIPTION
Remove unnecessary blank lines before a close brace as reported by checkpatch script

"CHECK: Blank lines aren't necessary before a close brace '}'"