### PR TITLE
module_adapter: add queue ID to IO stream buffer for simple copy

### DIFF
--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -20,6 +20,7 @@
 #include <sof/ut.h>
 #include <limits.h>
 #include <stdint.h>
+#include <ipc4/module.h>
 
 LOG_MODULE_REGISTER(module_adapter, CONFIG_SOF_LOG_LEVEL);
 
@@ -644,6 +645,9 @@ module_single_sink_setup(struct comp_dev *dev,
 		 */
 		mod->input_buffers[i].size = c.frames;
 		mod->input_buffers[i].consumed = 0;
+#if CONFIG_IPC_MAJOR_4
+		mod->input_buffers[i].queue_id = IPC4_SINK_QUEUE_ID(source_c[i]->id);
+#endif
 
 		mod->input_buffers[i].data = &source_c[i]->stream;
 		i++;
@@ -653,6 +657,9 @@ module_single_sink_setup(struct comp_dev *dev,
 
 	mod->output_buffers[0].size = 0;
 	mod->output_buffers[0].data = &sinks_c[0]->stream;
+#if CONFIG_IPC_MAJOR_4
+	mod->output_buffers[0].queue_id = IPC4_SRC_QUEUE_ID(sinks_c[0]->id);
+#endif
 
 	return num_input_buffers;
 }
@@ -682,6 +689,9 @@ module_single_source_setup(struct comp_dev *dev,
 
 			mod->output_buffers[i].size = 0;
 			mod->output_buffers[i].data = &sinks_c[i]->stream;
+#if CONFIG_IPC_MAJOR_4
+			mod->output_buffers[i].queue_id = IPC4_SRC_QUEUE_ID(source_c[i]->id);
+#endif
 			i++;
 		}
 	}
@@ -695,6 +705,9 @@ module_single_source_setup(struct comp_dev *dev,
 	mod->input_buffers[0].size = min_frames;
 	mod->input_buffers[0].consumed = 0;
 	mod->input_buffers[0].data = &source_c[0]->stream;
+#if CONFIG_IPC_MAJOR_4
+	mod->input_buffers[0].queue_id = IPC4_SINK_QUEUE_ID(source_c[0]->id);
+#endif
 
 	return num_output_buffers;
 }

--- a/src/include/sof/audio/module_adapter/module/module_interface.h
+++ b/src/include/sof/audio/module_adapter/module/module_interface.h
@@ -51,6 +51,7 @@ struct input_stream_buffer {
 	void __sparse_cache *data; /* data stream buffer */
 	uint32_t size; /* size of data in the buffer */
 	uint32_t consumed; /* number of bytes consumed by the module */
+	uint32_t queue_id; /* The queue ID for the stream buffer */
 
 	/* Indicates end of stream condition has occurred on the input stream */
 	bool end_of_stream;
@@ -63,6 +64,7 @@ struct input_stream_buffer {
 struct output_stream_buffer {
 	void __sparse_cache *data; /* data stream buffer */
 	uint32_t size; /* size of data in the buffer */
+	uint32_t queue_id; /* The queue ID for the stream buffer */
 };
 
 struct processing_module;


### PR DESCRIPTION
Some components that have multiple inputs or outputs need to identify each input/output stream buffer, because the buffer may be put to special use. For example, the main input buffer and feedback input buffer for smart amp component must be identified, and can not be used interchangeably.

This patch adds queue ID to input/output stream buffer, so the component will know which buffer is special.

The buffer ID is composed by source/sink queue id in terms of route connection, so for input buffer of a widget, we need to get the sink queue ID of source buffer, vice versa for output buffer queue ID assignment.