### PR TITLE
Audio: TDFB: Convert to module adapter

### DIFF
--- a/src/audio/Kconfig
+++ b/src/audio/Kconfig
@@ -436,6 +436,7 @@ endif # COMP_ASRC
 
 config COMP_TDFB
 	bool "TDFB component"
+	depends on COMP_MODULE_ADAPTER
 	select MATH_FIR
 	select MATH_IIR_DF1
 	select SQRT_FIXED

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -942,12 +942,11 @@ static int module_adapter_get_set_params(struct comp_dev *dev, struct sof_ipc_ct
 	 */
 	if (set && md->ops->set_configuration)
 		return md->ops->set_configuration(mod, cdata->data[0].type, pos, data_offset_size,
-						  (const uint8_t *)cdata->data[0].data,
-						  cdata->num_elems, NULL, 0);
+						  (const uint8_t *)cdata, cdata->num_elems,
+						  NULL, 0);
 	else if (!set && md->ops->get_configuration)
 		return md->ops->get_configuration(mod, pos, &data_offset_size,
-						  (uint8_t *)cdata->data[0].data,
-						  cdata->num_elems);
+						  (uint8_t *)cdata, cdata->num_elems);
 
 	comp_warn(dev, "module_adapter_get_set_params(): no configuration op set for %d",
 		  dev_comp_id(dev));

--- a/src/audio/tdfb/tdfb_direction.c
+++ b/src/audio/tdfb/tdfb_direction.c
@@ -42,6 +42,11 @@
 /* Threshold for notifying user space, no more often than every 200 ms */
 #define CONTROL_UPDATE_MIN_TIME	Q_CONVERT_FLOAT(0.2, 16)
 
+/* Another filter, a bit mask for controlling notifications to user space, at least four
+ * periods with level over ambient
+ */
+#define CONTROL_UPDATE_MIN_MASK		0x0f
+
 /* Emphasis filters for sound direction (IIR). These coefficients were
  * created with the script tools/tune/tdfb/example_direction_emphasis.m
  * from output files tdfb_iir_emphasis_48k.h and tdfb_iir_emphasis_16k.h.
@@ -556,7 +561,7 @@ void tdfb_direction_estimate(struct tdfb_comp_data *cd, int frames, int ch_count
 	 * to update user space.
 	 */
 	if (new_az_value != cd->az_value_estimate && time_since > CONTROL_UPDATE_MIN_TIME &&
-	    (cd->direction.trigger & 0x15) == 0x15) {
+	    (cd->direction.trigger & CONTROL_UPDATE_MIN_MASK) == CONTROL_UPDATE_MIN_MASK) {
 		cd->az_value_estimate = new_az_value;
 		cd->direction.frame_count_since_control = 0;
 		cd->direction_change = true;

--- a/src/audio/tdfb/tdfb_generic.c
+++ b/src/audio/tdfb/tdfb_generic.c
@@ -55,10 +55,11 @@ static inline void tdfb_core(struct tdfb_comp_data *cd, int in_nch, int out_nch)
 
 
 #if CONFIG_FORMAT_S16LE
-void tdfb_fir_s16(struct tdfb_comp_data *cd,
-		  const struct audio_stream __sparse_cache *source,
-		  struct audio_stream __sparse_cache *sink, int frames)
+void tdfb_fir_s16(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource,
+		  struct output_stream_buffer *bsink, int frames)
 {
+	struct audio_stream __sparse_cache *source = bsource->data;
+	struct audio_stream __sparse_cache *sink = bsink->data;
 	int16_t *x = source->r_ptr;
 	int16_t *y = sink->w_ptr;
 	int fmax;
@@ -100,10 +101,11 @@ void tdfb_fir_s16(struct tdfb_comp_data *cd,
 #endif
 
 #if CONFIG_FORMAT_S24LE
-void tdfb_fir_s24(struct tdfb_comp_data *cd,
-		  const struct audio_stream __sparse_cache *source,
-		  struct audio_stream __sparse_cache *sink, int frames)
+void tdfb_fir_s24(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource,
+		  struct output_stream_buffer *bsink, int frames)
 {
+	struct audio_stream __sparse_cache *source = bsource->data;
+	struct audio_stream __sparse_cache *sink = bsink->data;
 	int32_t *x = source->r_ptr;
 	int32_t *y = sink->w_ptr;
 	int fmax;
@@ -145,9 +147,11 @@ void tdfb_fir_s24(struct tdfb_comp_data *cd,
 #endif
 
 #if CONFIG_FORMAT_S32LE
-void tdfb_fir_s32(struct tdfb_comp_data *cd, const struct audio_stream __sparse_cache *source,
-		  struct audio_stream __sparse_cache *sink, int frames)
+void tdfb_fir_s32(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource,
+		  struct output_stream_buffer *bsink, int frames)
 {
+	struct audio_stream __sparse_cache *source = bsource->data;
+	struct audio_stream __sparse_cache *sink = bsink->data;
 	int32_t *x = source->r_ptr;
 	int32_t *y = sink->w_ptr;
 	int fmax;

--- a/src/audio/tdfb/tdfb_hifi3.c
+++ b/src/audio/tdfb/tdfb_hifi3.c
@@ -16,10 +16,11 @@
 #include <sof/math/fir_hifi3.h>
 
 #if CONFIG_FORMAT_S16LE
-void tdfb_fir_s16(struct tdfb_comp_data *cd,
-		  const struct audio_stream __sparse_cache *source,
-		  struct audio_stream __sparse_cache *sink, int frames)
+void tdfb_fir_s16(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource,
+		  struct output_stream_buffer *bsink, int frames)
 {
+	struct audio_stream __sparse_cache *source = bsource->data;
+	struct audio_stream __sparse_cache *sink = bsink->data;
 	struct sof_tdfb_config *cfg = cd->config;
 	struct fir_state_32x16 *f;
 	ae_int16x4 d;
@@ -90,10 +91,11 @@ void tdfb_fir_s16(struct tdfb_comp_data *cd,
 #endif
 
 #if CONFIG_FORMAT_S24LE
-void tdfb_fir_s24(struct tdfb_comp_data *cd,
-		  const struct audio_stream __sparse_cache *source,
-		  struct audio_stream __sparse_cache *sink, int frames)
+void tdfb_fir_s24(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource,
+		  struct output_stream_buffer *bsink, int frames)
 {
+	struct audio_stream __sparse_cache *source = bsource->data;
+	struct audio_stream __sparse_cache *sink = bsink->data;
 	struct sof_tdfb_config *cfg = cd->config;
 	struct fir_state_32x16 *f;
 	ae_int32x2 d;
@@ -163,10 +165,11 @@ void tdfb_fir_s24(struct tdfb_comp_data *cd,
 #endif
 
 #if CONFIG_FORMAT_S32LE
-void tdfb_fir_s32(struct tdfb_comp_data *cd,
-		  const struct audio_stream __sparse_cache *source,
-		  struct audio_stream __sparse_cache *sink, int frames)
+void tdfb_fir_s32(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource,
+		  struct output_stream_buffer *bsink, int frames)
 {
+	struct audio_stream __sparse_cache *source = bsource->data;
+	struct audio_stream __sparse_cache *sink = bsink->data;
 	struct sof_tdfb_config *cfg = cd->config;
 	struct fir_state_32x16 *f;
 	ae_int32x2 d;

--- a/src/audio/tdfb/tdfb_hifiep.c
+++ b/src/audio/tdfb/tdfb_hifiep.c
@@ -55,10 +55,11 @@ static inline void tdfb_core(struct tdfb_comp_data *cd, int in_nch, int out_nch)
 }
 
 #if CONFIG_FORMAT_S16LE
-void tdfb_fir_s16(struct tdfb_comp_data *cd,
-		  const struct audio_stream __sparse_cache *source,
-		  struct audio_stream __sparse_cache *sink, int frames)
+void tdfb_fir_s16(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource,
+		  struct output_stream_buffer *bsink, int frames)
 {
+	struct audio_stream __sparse_cache *source = bsource->data;
+	struct audio_stream __sparse_cache *sink = bsink->data;
 	int16_t *x = source->r_ptr;
 	int16_t *y = sink->w_ptr;
 	int fmax;
@@ -100,10 +101,11 @@ void tdfb_fir_s16(struct tdfb_comp_data *cd,
 #endif
 
 #if CONFIG_FORMAT_S24LE
-void tdfb_fir_s24(struct tdfb_comp_data *cd,
-		  const struct audio_stream __sparse_cache *source,
-		  struct audio_stream __sparse_cache *sink, int frames)
+void tdfb_fir_s24(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource,
+		  struct output_stream_buffer *bsink, int frames)
 {
+	struct audio_stream __sparse_cache *source = bsource->data;
+	struct audio_stream __sparse_cache *sink = bsink->data;
 	int32_t *x = source->r_ptr;
 	int32_t *y = sink->w_ptr;
 	int fmax;
@@ -145,9 +147,11 @@ void tdfb_fir_s24(struct tdfb_comp_data *cd,
 #endif
 
 #if CONFIG_FORMAT_S32LE
-void tdfb_fir_s32(struct tdfb_comp_data *cd, const struct audio_stream __sparse_cache *source,
-		  struct audio_stream __sparse_cache *sink, int frames)
+void tdfb_fir_s32(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource,
+		  struct output_stream_buffer *bsink, int frames)
 {
+	struct audio_stream __sparse_cache *source = bsource->data;
+	struct audio_stream __sparse_cache *sink = bsink->data;
 	int32_t *x = source->r_ptr;
 	int32_t *y = sink->w_ptr;
 	int fmax;

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -715,7 +715,6 @@ void sys_comp_mixer_init(void);
 void sys_comp_multiband_drc_init(void);
 void sys_comp_selector_init(void);
 void sys_comp_src_init(void);
-void sys_comp_tdfb_init(void);
 
 void sys_comp_module_demux_interface_init(void);
 void sys_comp_module_eq_fir_interface_init(void);
@@ -723,6 +722,7 @@ void sys_comp_module_eq_iir_interface_init(void);
 void sys_comp_module_mfcc_interface_init(void);
 void sys_comp_module_mixer_interface_init(void);
 void sys_comp_module_mux_interface_init(void);
+void sys_comp_module_tdfb_interface_init(void);
 void sys_comp_module_volume_interface_init(void);
 
 #elif CONFIG_LIBRARY

--- a/src/include/sof/audio/tdfb/tdfb_comp.h
+++ b/src/include/sof/audio/tdfb/tdfb_comp.h
@@ -8,12 +8,13 @@
 #ifndef __SOF_AUDIO_TDFB_CONFIG_H__
 #define __SOF_AUDIO_TDFB_CONFIG_H__
 
-#include <sof/platform.h>
+#include <sof/audio/module_adapter/module/generic.h>
 #include <sof/audio/audio_stream.h>
 #include <sof/math/fir_generic.h>
 #include <sof/math/fir_hifi2ep.h>
 #include <sof/math/fir_hifi3.h>
 #include <sof/math/iir_df1.h>
+#include <sof/platform.h>
 #include <user/tdfb.h>
 
 /* Select optimized code variant when xt-xcc compiler is used */
@@ -104,27 +105,27 @@ struct tdfb_comp_data {
 	bool beam_on:1;			    /**< set true if beam is off */
 	bool update:1;			    /**< set true if control enum has been received */
 	void (*tdfb_func)(struct tdfb_comp_data *cd,
-			  const struct audio_stream __sparse_cache *source,
-			  struct audio_stream __sparse_cache *sink,
+			  struct input_stream_buffer *bsource,
+			  struct output_stream_buffer *bsink,
 			  int frames);
 };
 
 #if CONFIG_FORMAT_S16LE
 void tdfb_fir_s16(struct tdfb_comp_data *cd,
-		  const struct audio_stream __sparse_cache *source,
-		  struct audio_stream __sparse_cache *sink, int frames);
+		  struct input_stream_buffer *bsource,
+		  struct output_stream_buffer *bsink, int frames);
 #endif
 
 #if CONFIG_FORMAT_S24LE
 void tdfb_fir_s24(struct tdfb_comp_data *cd,
-		  const struct audio_stream __sparse_cache *source,
-		  struct audio_stream __sparse_cache *sink, int frames);
+		  struct input_stream_buffer *bsource,
+		  struct output_stream_buffer *bsink, int frames);
 #endif
 
 #if CONFIG_FORMAT_S32LE
 void tdfb_fir_s32(struct tdfb_comp_data *cd,
-		  const struct audio_stream __sparse_cache *source,
-		  struct audio_stream __sparse_cache *sink, int frames);
+		  struct input_stream_buffer *bsource,
+		  struct output_stream_buffer *bsink, int frames);
 #endif
 
 int tdfb_direction_init(struct tdfb_comp_data *cd, int32_t fs, int channels);
@@ -143,5 +144,9 @@ static inline void tdfb_cdec_s16(int16_t **ptr, int16_t *start, size_t size)
 	if (*ptr < start)
 		*ptr = (int16_t *)((uint8_t *)*ptr + size);
 }
+
+#ifdef UNIT_TEST
+void sys_comp_module_tdfb_interface_init(void);
+#endif
 
 #endif /* __SOF_AUDIO_TDFB_CONFIG_H__ */

--- a/tools/testbench/common_test.c
+++ b/tools/testbench/common_test.c
@@ -47,13 +47,13 @@ int tb_setup(struct sof *sof, struct testbench_prm *tp)
 	sys_comp_multiband_drc_init();
 	sys_comp_selector_init();
 	sys_comp_src_init();
-	sys_comp_tdfb_init();
 
 	/* Module adapter components */
 	sys_comp_module_demux_interface_init();
 	sys_comp_module_eq_fir_interface_init();
 	sys_comp_module_eq_iir_interface_init();
 	sys_comp_module_mux_interface_init();
+	sys_comp_module_tdfb_interface_init();
 	sys_comp_module_volume_interface_init();
 
 	/* other necessary initializations, todo: follow better SOF init */

--- a/tools/testbench/include/testbench/common_test.h
+++ b/tools/testbench/include/testbench/common_test.h
@@ -113,12 +113,12 @@ void sys_comp_mixer_init(void);
 void sys_comp_multiband_drc_init(void);
 void sys_comp_selector_init(void);
 void sys_comp_src_init(void);
-void sys_comp_tdfb_init(void);
 
 void sys_comp_module_demux_interface_init(void);
 void sys_comp_module_eq_fir_interface_init(void);
 void sys_comp_module_eq_iir_interface_init(void);
 void sys_comp_module_mux_interface_init(void);
+void sys_comp_module_tdfb_interface_init(void);
 void sys_comp_module_volume_interface_init(void);
 
 #endif


### PR DESCRIPTION
This patch converts the time domain fixed beamformer (TDFB) into module adapter API.
