### PR TITLE
Drivers: DW: Set DMA lli_desc->sar and lli_desc->dar

### DIFF
--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -709,6 +709,9 @@ static int dw_dma_set_config(struct dma_chan_data *channel,
 			goto out;
 		}
 
+		lli_desc->sar = sg_elem->src;
+		lli_desc->dar = sg_elem->dest;
+
 		if (sg_elem->size > DW_CTLH_BLOCK_TS_MASK) {
 			tr_err(&dwdma_tr, "dw_dma_set_config(): dma %d channel %d block size too big %d",
 			       channel->dma->plat_data.id,


### PR DESCRIPTION
This patch fixes DMIC capture for TGL platform in IPC3 mode. The error seen in firmware trace is:

ERROR dmic_irq_handler(): full fifo A or PDM overrun
ERROR dw_dma_get_data_size(): xrun detected

The set of sar and dar is restored to driver. It was removed with function dw_dma_mask_address() when removing support for BDW and HSW platforms. The two first lines removed from the function are needed for all platforms. The lines were added to where the function was originally called.

Fixes commit d80635054ff4
("platform: remove support for Broadwell and Haswell")

Suggested-by: Guennadi Liakhovetski <guennadi.liakhovetski@linux.intel.com>