### PR TITLE
west.yml: upgrade zephyr to e40859f7

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: e3ae110a05d3427647a03fcbeff4478c195c5a48
+      revision: e40859f787128b9a8e000b51009502278fc59586
       remote: zephyrproject
       # Import some projects listed in zephyr/west.yml@revision
       #


### PR DESCRIPTION
 west.yml: upgrade zephyr to e40859f7

Total of 1128 commits, including following related to
dma-dw/intel_adsp/sparse/dmic/xtensa:

e40859f78712 Revert "dma: dw: Do not program SAR/DAR and CTL_HI/LO when using HW LLI"
7a85983ebcf2 xtensa: remove ELF section address rewriting
b32b321f502a dma: dw: Poll to check for channel disable with timeout
6226f9e6e44f dma: dw: fix the return value check
08d9efb202cc dma: dw: Do not program SAR/DAR and CTL_HI/LO when using HW LLI
045c68673491 dma: dw: Add a debug utility function
bd705e68b048 soc: xtensa: esp32: increase shared memory region
9854c915ffdf intel_adsp: cpu init refactor
9d5c21d58003 dts: xtensa: nxp: remove unused include
68c1cafb411e intel_adsp: dts: ace: lower case 71C00 to fix DTC warning
a8c0123d3c54 intel_adsp: cmake: add_custom_command(.mod) to fix incremental build
b00c63e7640c footprint: ci: Remove audio SOF samples
1efaa94bc64b drivers: audio: dmic_nrfx_pdm: drop -pin support
8ef2cd20d90a Drivers: DAI: Intel: DMIC: Shorten unmute ramp time
eead89e7f22d soc: intel_adsp: cavstool.py: simplify asyncio.run() call
cdae0bb7596e boards: intel_adsp_ace15_mtpm uses xcc-clang toolchain for twister