### PR TITLE
Fix fuzz.sh regression and missing #includes exposed by recent XTOS/zephyr panic.h separation

### DIFF
--- a/src/include/sof/ipc/common.h
+++ b/src/include/sof/ipc/common.h
@@ -16,9 +16,11 @@
 #include <rtos/spinlock.h>
 #include <rtos/sof.h>
 #include <user/trace.h>
+#include <ipc/header.h>
+#include <ipc/stream.h>
+
 #include <stdbool.h>
 #include <stdint.h>
-#include <ipc/header.h>
 
 struct dma_sg_elem_array;
 struct ipc_msg;

--- a/src/include/sof/ipc/msg.h
+++ b/src/include/sof/ipc/msg.h
@@ -21,6 +21,8 @@
 #include <rtos/spinlock.h>
 #include <sof/trace/trace.h>
 #include <sof/ipc/common.h>
+#include <ipc/trace.h>
+
 #include <stdbool.h>
 #include <stdint.h>
 


### PR DESCRIPTION
See detailed commit messages.