### PR TITLE
topology2: cleanup basic definitions

### DIFF
--- a/tools/topology/topology2/cavs-mixin-mixout-efx-hda.conf
+++ b/tools/topology/topology2/cavs-mixin-mixout-efx-hda.conf
@@ -80,7 +80,7 @@ Object.Pipeline {
 		}
 	]
 
-	passthrough-be [
+	passthrough-playback-be [
 		{
 			index		4
 			direction	capture

--- a/tools/topology/topology2/cavs-mixin-mixout-efx-hda.conf
+++ b/tools/topology/topology2/cavs-mixin-mixout-efx-hda.conf
@@ -80,10 +80,9 @@ Object.Pipeline {
 		}
 	]
 
-	passthrough-playback-be [
+	passthrough-capture-be [
 		{
 			index		4
-			direction	capture
 
 			Object.Widget.copier."1" {
 				dai_type 	"HDA"

--- a/tools/topology/topology2/cavs-nocodec-bt.conf
+++ b/tools/topology/topology2/cavs-nocodec-bt.conf
@@ -12,7 +12,7 @@
 <virtual.conf>
 <passthrough-playback.conf>
 <passthrough-capture.conf>
-<passthrough-be.conf>
+<passthrough-playback-be.conf>
 <passthrough-capture-be.conf>
 <data.conf>
 <pcm.conf>
@@ -113,7 +113,7 @@ Object.Dai.SSP [
 # Pipeline ID:1 PCM ID: 0
 Object.Pipeline {
 	# playback pipelines
-	passthrough-be [
+	passthrough-playback-be [
 		{
 			index	2
 			direction	playback

--- a/tools/topology/topology2/cavs-nocodec-bt.conf
+++ b/tools/topology/topology2/cavs-nocodec-bt.conf
@@ -116,7 +116,6 @@ Object.Pipeline {
 	passthrough-playback-be [
 		{
 			index	2
-			direction	playback
 			Object.Widget.pipeline.1 {
 				stream_name 'NoCodec-0'
 			}
@@ -131,7 +130,6 @@ Object.Pipeline {
 		}
 		{
 			index	4
-			direction	playback
 			Object.Widget.pipeline.1 {
 				stream_name 'NoCodec-1'
 			}
@@ -192,7 +190,6 @@ Object.Pipeline {
 	passthrough-capture-be [
 		{
 			index		6
-			direction	capture
 			Object.Widget.pipeline.1 {
 				stream_name 'NoCodec-0'
 			}
@@ -215,7 +212,6 @@ Object.Pipeline {
 		}
 		{
 			index		10
-			direction	capture
 			Object.Widget.pipeline.1 {
 				stream_name 'NoCodec-1'
 			}

--- a/tools/topology/topology2/cavs-nocodec.conf
+++ b/tools/topology/topology2/cavs-nocodec.conf
@@ -436,7 +436,6 @@ Object.Pipeline.passthrough-capture [
 Object.Pipeline.passthrough-capture-be [
 	{
 		index		10
-		direction	capture
 
 		Object.Widget.copier."1" {
 			dai_index	1
@@ -456,7 +455,6 @@ Object.Pipeline.passthrough-capture-be [
 	}
 	{
 		index		12
-		direction	capture
 
 		Object.Widget.copier."1" {
 			dai_index	2

--- a/tools/topology/topology2/cavs-rt5682.conf
+++ b/tools/topology/topology2/cavs-rt5682.conf
@@ -261,7 +261,6 @@ Object.Pipeline {
 	passthrough-capture-be [
 		{
 			index	6
-			direction	capture
 
 			Object.Widget.copier."1" {
 				dai_index	$HEADSET_SSP_DAI_INDEX

--- a/tools/topology/topology2/cavs-rt5682.conf
+++ b/tools/topology/topology2/cavs-rt5682.conf
@@ -12,7 +12,7 @@
 <virtual.conf>
 <passthrough-playback.conf>
 <passthrough-capture.conf>
-<passthrough-be.conf>
+<passthrough-playback-be.conf>
 <passthrough-capture-be.conf>
 <host-copier-gain-mixin-playback.conf>
 <mixout-gain-dai-copier-playback.conf>

--- a/tools/topology/topology2/cavs-sdw-src-gain-mixin.conf
+++ b/tools/topology/topology2/cavs-sdw-src-gain-mixin.conf
@@ -123,7 +123,6 @@ Object.Pipeline {
 
 	passthrough-capture-be [
 		{
-			direction	"capture"
 			index 3
 			copier_type "ALH"
 			Object.Widget.copier.1 {

--- a/tools/topology/topology2/cavs-sdw.conf
+++ b/tools/topology/topology2/cavs-sdw.conf
@@ -17,7 +17,7 @@
 <deepbuffer-playback.conf>
 <passthrough-playback.conf>
 <passthrough-capture.conf>
-<passthrough-be.conf>
+<passthrough-playback-be.conf>
 <passthrough-capture-be.conf>
 <highpass-capture-be.conf>
 <data.conf>

--- a/tools/topology/topology2/cavs-src-mixin-mixout-hda.conf
+++ b/tools/topology/topology2/cavs-src-mixin-mixout-hda.conf
@@ -73,7 +73,7 @@ Object.Pipeline {
 		}
 	]
 
-	passthrough-be [
+	passthrough-playback-be [
 		{
 			index		4
 			direction	capture

--- a/tools/topology/topology2/cavs-src-mixin-mixout-hda.conf
+++ b/tools/topology/topology2/cavs-src-mixin-mixout-hda.conf
@@ -73,10 +73,9 @@ Object.Pipeline {
 		}
 	]
 
-	passthrough-playback-be [
+	passthrough-capture-be [
 		{
 			index		4
-			direction	capture
 
 			Object.Widget.copier."1" {
 				dai_type 	"HDA"

--- a/tools/topology/topology2/include/pipelines/cavs/dai-copier-eqiir-module-copier-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/dai-copier-eqiir-module-copier-capture.conf
@@ -47,7 +47,7 @@ Class.Pipeline."dai-copier-eqiir-module-copier-capture" {
 
 	Object.Widget {
 		copier."1" {
-			type dai_out
+			type dai_in
 			period_sink_count 2
 			period_source_count 0
 			num_audio_formats 1

--- a/tools/topology/topology2/include/pipelines/cavs/dai-copier-gain-mixin-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/dai-copier-gain-mixin-capture.conf
@@ -46,7 +46,7 @@ Class.Pipeline."dai-copier-gain-mixin-capture" {
 
 	Object.Widget {
 		copier."1" {
-			type dai_out
+			type dai_in
 			period_sink_count 2
 			period_source_count 0
 			node_type $HDA_LINK_INPUT_CLASS

--- a/tools/topology/topology2/include/pipelines/cavs/dai-copier-gain-module-copier-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/dai-copier-gain-module-copier-capture.conf
@@ -46,7 +46,7 @@ Class.Pipeline."dai-copier-gain-module-copier-capture" {
 
 	Object.Widget {
 		copier."1" {
-			type dai_out
+			type dai_in
 			period_sink_count 2
 			period_source_count 0
 			num_audio_formats 1

--- a/tools/topology/topology2/include/pipelines/cavs/deepbuffer-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/deepbuffer-playback.conf
@@ -49,6 +49,7 @@ Class.Pipeline."deepbuffer-playback" {
 			copier_type	"host"
 			type	"aif_in"
 			node_type $HDA_HOST_OUTPUT_CLASS
+
 			num_audio_formats 3
 			num_input_audio_formats 3
 			num_output_audio_formats 3

--- a/tools/topology/topology2/include/pipelines/cavs/deepbuffer-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/deepbuffer-playback.conf
@@ -67,7 +67,7 @@ Class.Pipeline."deepbuffer-playback" {
 				out_bit_depth		32
 				out_valid_bit_depth	32
 				# 100ms buffer
-				dma_buffer_size "$[$obs * $DEEPBUFFER_FW_DMA_MS]"
+				dma_buffer_size "$[$ibs * $DEEPBUFFER_FW_DMA_MS]"
 			}
 			# 32-bit 48KHz 2ch
 			Object.Base.audio_format.3 {

--- a/tools/topology/topology2/include/pipelines/cavs/gain-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/gain-capture.conf
@@ -48,6 +48,8 @@ Class.Pipeline."gain-capture" {
 		copier."1" {
 			copier_type	"host"
 			type	"aif_out"
+			node_type $HDA_HOST_INPUT_CLASS
+
 			num_audio_formats 3
 			num_input_audio_formats 3
 			num_output_audio_formats 3
@@ -73,7 +75,6 @@ Class.Pipeline."gain-capture" {
 				out_valid_bit_depth	32
 				dma_buffer_size "$[$obs * 2]"
 			}
-			node_type $HDA_HOST_INPUT_CLASS
 		}
 
 		gain."1" {

--- a/tools/topology/topology2/include/pipelines/cavs/gain-copier-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/gain-copier-capture.conf
@@ -48,6 +48,8 @@ Class.Pipeline."gain-copier-capture" {
 		copier."1" {
 			copier_type	"host"
 			type	"aif_out"
+			node_type $HDA_HOST_INPUT_CLASS
+
 			num_audio_formats 3
 			num_input_audio_formats 3
 			num_output_audio_formats 3
@@ -74,7 +76,6 @@ Class.Pipeline."gain-copier-capture" {
 				out_valid_bit_depth	32
 				dma_buffer_size "$[$obs * 2]"
 			}
-			node_type $HDA_HOST_INPUT_CLASS
 		}
 
 		gain."1" {

--- a/tools/topology/topology2/include/pipelines/cavs/gain-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/gain-playback.conf
@@ -47,6 +47,8 @@ Class.Pipeline."gain-playback" {
 		copier."1" {
 			copier_type	"host"
 			type	"aif_in"
+			node_type $HDA_HOST_OUTPUT_CLASS
+
 			num_audio_formats 3
 			num_input_audio_formats 3
 			num_output_audio_formats 3
@@ -72,7 +74,6 @@ Class.Pipeline."gain-playback" {
 				out_valid_bit_depth	32
 				dma_buffer_size "$[$ibs * 2]"
 			}
-			node_type $HDA_HOST_OUTPUT_CLASS
 		}
 
 		gain."1" {

--- a/tools/topology/topology2/include/pipelines/cavs/host-copier-gain-mixin-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/host-copier-gain-mixin-playback.conf
@@ -49,6 +49,7 @@ Class.Pipeline."host-copier-gain-mixin-playback" {
 			copier_type	"host"
 			type	"aif_in"
 			node_type $HDA_HOST_OUTPUT_CLASS
+
 			num_audio_formats 3
 			num_input_audio_formats 3
 			num_output_audio_formats 3

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-gain-dai-copier-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-gain-dai-copier-playback.conf
@@ -47,7 +47,7 @@ Class.Pipeline."mixout-gain-dai-copier-playback" {
 	Object.Widget {
 		mixout."1" {}
 		copier."1" {
-			type dai_in
+			type dai_out
 			node_type $HDA_LINK_OUTPUT_CLASS
 			period_sink_count 0
 			period_source_count 2

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-gain-efx-dai-copier-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-gain-efx-dai-copier-playback.conf
@@ -51,7 +51,7 @@ Class.Pipeline."mixout-gain-efx-dai-copier-playback" {
 	Object.Widget {
 		mixout."1" {}
 		copier."1" {
-			type dai_in
+			type dai_out
 			node_type $HDA_LINK_OUTPUT_CLASS
 			period_sink_count 0
 			period_source_count 2

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-gain-host-copier-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-gain-host-copier-capture.conf
@@ -51,6 +51,7 @@ Class.Pipeline."mixout-gain-host-copier-capture" {
 			copier_type "host"
 			type	"aif_out"
 			node_type $HDA_HOST_INPUT_CLASS
+
 			num_audio_formats 4
 			num_input_audio_formats 4
 			num_output_audio_formats 4

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-gain-smart-amp-dai-copier-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-gain-smart-amp-dai-copier-playback.conf
@@ -46,7 +46,7 @@ Class.Pipeline."mixout-gain-smart-amp-dai-copier-playback" {
 	Object.Widget {
 		mixout."1" {}
 		copier."1" {
-			type dai_in
+			type dai_out
 			node_type $HDA_LINK_OUTPUT_CLASS
 			num_audio_formats 2
 			num_input_audio_formats 2

--- a/tools/topology/topology2/include/pipelines/cavs/passthrough-capture-be.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/passthrough-capture-be.conf
@@ -32,6 +32,10 @@ Class.Pipeline."passthrough-capture-be" {
 			"index"
 		]
 
+		!immutable [
+			"direction"
+		]
+
 		unique	"instance"
 	}
 
@@ -57,6 +61,7 @@ Class.Pipeline."passthrough-capture-be" {
 		}
 	}
 
+	direction	"capture"
 	time_domain	"timer"
 	dynamic_pipeline 1
 	channels	2

--- a/tools/topology/topology2/include/pipelines/cavs/passthrough-capture-be.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/passthrough-capture-be.conf
@@ -2,11 +2,11 @@
 # BE DAI passthrough pipeline for capture
 #
 # All attributes defined herein are namespaced by alsatplg to
-# "Object.Pipeline.passthrough-be-capture.N.attribute_name"
+# "Object.Pipeline.passthrough-capture-be.N.attribute_name"
 #
-# Usage: mixin-playback pipeline object can be instantiated as:
+# Usage: passthrough-capture-be pipeline object can be instantiated as:
 #
-# Object.Pipeline.dai-pipeline."N" {
+# Object.Pipeline.passthrough-capture-be."N" {
 #	direction	"capture"
 # 	period		1000
 # 	time_domain	"timer"

--- a/tools/topology/topology2/include/pipelines/cavs/passthrough-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/passthrough-capture.conf
@@ -47,6 +47,7 @@ Class.Pipeline."passthrough-capture" {
 			copier_type	"host"
 			type	"aif_out"
 			node_type $HDA_HOST_INPUT_CLASS
+
 			num_audio_formats 6
 			num_input_audio_formats 6
 			num_output_audio_formats 6

--- a/tools/topology/topology2/include/pipelines/cavs/passthrough-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/passthrough-capture.conf
@@ -16,9 +16,9 @@
 # Where N is the unique pipeline ID within the same alsaconf node.
 #
 
-<include/common/audio_format.conf>
 <include/components/copier.conf>
 <include/components/pipeline.conf>
+<include/common/audio_format.conf>
 
 Class.Pipeline."passthrough-capture" {
 

--- a/tools/topology/topology2/include/pipelines/cavs/passthrough-playback-be.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/passthrough-playback-be.conf
@@ -32,17 +32,12 @@ Class.Pipeline."passthrough-playback-be" {
 			"index"
 		]
 
-		#
-		# mixin-playback objects instantiated within the same alsaconf node must have
-		# unique pipeline_id attribute
-		#
 		unique	"instance"
 	}
 
 	Object.Widget {
 		copier."1" {
-			type dai_in
-			node_type $HDA_LINK_OUTPUT_CLASS
+			type dai_out
 			num_audio_formats 3
 			num_input_audio_formats 3
 			num_output_audio_formats 3

--- a/tools/topology/topology2/include/pipelines/cavs/passthrough-playback-be.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/passthrough-playback-be.conf
@@ -32,6 +32,10 @@ Class.Pipeline."passthrough-playback-be" {
 			"index"
 		]
 
+		!immutable [
+			"direction"
+		]
+
 		unique	"instance"
 	}
 
@@ -79,6 +83,7 @@ Class.Pipeline."passthrough-playback-be" {
 		}
 	}
 
+	direction	"playback"
 	time_domain	"timer"
 	dynamic_pipeline 1
 	channels	2

--- a/tools/topology/topology2/include/pipelines/cavs/passthrough-playback-be.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/passthrough-playback-be.conf
@@ -2,11 +2,11 @@
 # BE DAI passthrough pipeline
 #
 # All attributes defined herein are namespaced by alsatplg to
-# "Object.Pipeline.passthrough-be.N.attribute_name"
+# "Object.Pipeline.passthrough-playback-be.N.attribute_name"
 #
-# Usage: mixin-playback pipeline object can be instantiated as:
+# Usage: passthrough-playback-be pipeline object can be instantiated as:
 #
-# Object.Pipeline.dai-pipeline."N" {
+# Object.Pipeline.passthrough-playback-be."N" {
 #	direction	"playback"
 # 	period		1000
 # 	time_domain	"timer"
@@ -21,7 +21,7 @@
 <include/components/copier.conf>
 <include/components/pipeline.conf>
 
-Class.Pipeline."passthrough-be" {
+Class.Pipeline."passthrough-playback-be" {
 
 	DefineAttribute."index" {}
 

--- a/tools/topology/topology2/include/pipelines/cavs/passthrough-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/passthrough-playback.conf
@@ -62,7 +62,7 @@ Class.Pipeline."passthrough-playback" {
 				in_valid_bit_depth	24
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$obs * 2]"
+				dma_buffer_size "$[$ibs * 2]"
 			}
 			# 32-bit 48KHz 2ch
 			Object.Base.audio_format.3 {

--- a/tools/topology/topology2/include/pipelines/cavs/passthrough-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/passthrough-playback.conf
@@ -45,8 +45,9 @@ Class.Pipeline."passthrough-playback" {
 	Object.Widget {
 		copier."1" {
 			copier_type	"host"
-			node_type $HDA_HOST_OUTPUT_CLASS
 			type	"aif_in"
+			node_type $HDA_HOST_OUTPUT_CLASS
+
 			num_audio_formats 3
 			num_input_audio_formats 3
 			num_output_audio_formats 3

--- a/tools/topology/topology2/include/pipelines/cavs/src-gain-mixin-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/src-gain-mixin-playback.conf
@@ -45,10 +45,9 @@ Class.Pipeline."src-gain-mixin-playback" {
 		copier."1" {
 			copier_type	"host"
 			type	"aif_in"
+			node_type $HDA_HOST_OUTPUT_CLASS
 
 			<include/components/src_passthrough_format.conf>
-
-			node_type $HDA_HOST_OUTPUT_CLASS
 		}
 
 		src."1" {

--- a/tools/topology/topology2/platform/intel/bt-generic.conf
+++ b/tools/topology/topology2/platform/intel/bt-generic.conf
@@ -11,7 +11,7 @@ Object.Pipeline {
 	passthrough-playback-be [
 		{
 			index		$BT_PB_DAI_PIPELINE_ID
-			direction	playback
+
 			Object.Widget.pipeline.1 {
 				stream_name	$BT_PB_PIPELINE_STREAM_NAME
 			}
@@ -156,7 +156,7 @@ Object.Pipeline {
 	passthrough-capture-be [
 		{
 			index		$BT_CP_DAI_PIPELINE_ID
-			direction	"capture"
+
 			Object.Widget.pipeline.1 {
 				stream_name $BT_CP_PIPELINE_STREAM_NAME
 			}

--- a/tools/topology/topology2/platform/intel/bt-generic.conf
+++ b/tools/topology/topology2/platform/intel/bt-generic.conf
@@ -8,7 +8,7 @@ IncludeByKey.BT_LOOPBACK_MODE {
 
 Object.Pipeline {
 	# playback pipelines
-	passthrough-be [
+	passthrough-playback-be [
 		{
 			index		$BT_PB_DAI_PIPELINE_ID
 			direction	playback

--- a/tools/topology/topology2/platform/intel/bt-generic.conf
+++ b/tools/topology/topology2/platform/intel/bt-generic.conf
@@ -78,7 +78,7 @@ Object.Pipeline {
 					out_valid_bit_depth	16
 					in_channels		2
 					out_channels		2
-					dma_buffer_size "$[$obs * 2]"
+					dma_buffer_size "$[$ibs * 2]"
 				}
 				Object.Base.audio_format.2 {
 					in_bit_depth		16
@@ -89,7 +89,7 @@ Object.Pipeline {
 					out_channels		1
 					in_rate		8000
 					out_rate		8000
-					dma_buffer_size "$[$obs * 2]"
+					dma_buffer_size "$[$ibs * 2]"
 				}
 				Object.Base.audio_format.3 {
 					in_bit_depth		16
@@ -100,7 +100,7 @@ Object.Pipeline {
 					out_channels		1
 					in_rate		16000
 					out_rate		16000
-					dma_buffer_size "$[$obs * 2]"
+					dma_buffer_size "$[$ibs * 2]"
 				}
 			}
 		}
@@ -178,7 +178,7 @@ Object.Pipeline {
 					out_valid_bit_depth	16
 					in_channels		2
 					out_channels		2
-					dma_buffer_size "$[$obs * 2]"
+					dma_buffer_size "$[$ibs * 2]"
 				}
 				Object.Base.audio_format.1 {
 					in_bit_depth		16
@@ -189,7 +189,7 @@ Object.Pipeline {
 					out_channels		1
 					in_rate		8000
 					out_rate		8000
-					dma_buffer_size "$[$obs * 2]"
+					dma_buffer_size "$[$ibs * 2]"
 				}
 				Object.Base.audio_format.2 {
 					in_bit_depth		16
@@ -200,7 +200,7 @@ Object.Pipeline {
 					out_channels		1
 					in_rate		16000
 					out_rate		16000
-					dma_buffer_size "$[$obs * 2]"
+					dma_buffer_size "$[$ibs * 2]"
 				}
 			}
 		}

--- a/tools/topology/topology2/platform/intel/hdmi-generic.conf
+++ b/tools/topology/topology2/platform/intel/hdmi-generic.conf
@@ -58,7 +58,7 @@ Object.Pipeline {
 			use_chain_dma	$USE_CHAIN_DMA
 		}
 	]
-	passthrough-be [
+	passthrough-playback-be [
 		{
 			direction	"playback"
 			index $HDMI1_DAI_PIPELINE_ID
@@ -167,7 +167,7 @@ IncludeByKey.NUM_HDMIS {
 				direction playback
 			}
 		]
-		Object.Pipeline.passthrough-be [
+		Object.Pipeline.passthrough-playback-be [
 			{
 				direction	"playback"
 				index $HDMI4_DAI_PIPELINE_ID

--- a/tools/topology/topology2/platform/intel/hdmi-generic.conf
+++ b/tools/topology/topology2/platform/intel/hdmi-generic.conf
@@ -60,7 +60,6 @@ Object.Pipeline {
 	]
 	passthrough-playback-be [
 		{
-			direction	"playback"
 			index $HDMI1_DAI_PIPELINE_ID
 
 			Object.Widget.copier.1 {
@@ -71,7 +70,6 @@ Object.Pipeline {
 			use_chain_dma	$USE_CHAIN_DMA
 		}
 		{
-			direction	"playback"
 			index $HDMI2_DAI_PIPELINE_ID
 
 			Object.Widget.copier.1 {
@@ -82,7 +80,6 @@ Object.Pipeline {
 			use_chain_dma	$USE_CHAIN_DMA
 		}
 		{
-			direction	"playback"
 			index $HDMI3_DAI_PIPELINE_ID
 			Object.Widget.copier.1 {
 				stream_name 'iDisp3'
@@ -169,7 +166,6 @@ IncludeByKey.NUM_HDMIS {
 		]
 		Object.Pipeline.passthrough-playback-be [
 			{
-				direction	"playback"
 				index $HDMI4_DAI_PIPELINE_ID
 
 				Object.Widget.copier.1 {

--- a/tools/topology/topology2/platform/intel/sdw-amp-generic.conf
+++ b/tools/topology/topology2/platform/intel/sdw-amp-generic.conf
@@ -163,7 +163,7 @@ IncludeByKey.SDW_AMP_FEEDBACK {
 				}
 			]
 
-			passthrough-be [
+			passthrough-capture-be [
 				{
 					direction	"capture"
 					index 31

--- a/tools/topology/topology2/platform/intel/sdw-amp-generic.conf
+++ b/tools/topology/topology2/platform/intel/sdw-amp-generic.conf
@@ -71,7 +71,7 @@ IncludeByKey.NUM_SDW_AMPS {
 		}
 
 		Object.Pipeline {
-			passthrough-be [
+			passthrough-playback-be [
 				{
 					direction	"playback"
 					index $ALH_2ND_SPK_ID

--- a/tools/topology/topology2/platform/intel/sdw-amp-generic.conf
+++ b/tools/topology/topology2/platform/intel/sdw-amp-generic.conf
@@ -73,7 +73,6 @@ IncludeByKey.NUM_SDW_AMPS {
 		Object.Pipeline {
 			passthrough-playback-be [
 				{
-					direction	"playback"
 					index $ALH_2ND_SPK_ID
 					copier_type "ALH"
 					Object.Widget.copier.1 {
@@ -87,7 +86,6 @@ IncludeByKey.NUM_SDW_AMPS {
 			]
 			passthrough-capture-be	[
 				{
-					direction	"capture"
 					index $ALH_2ND_SPK_IN_ID
 					copier_type "ALH"
 
@@ -165,7 +163,6 @@ IncludeByKey.SDW_AMP_FEEDBACK {
 
 			passthrough-capture-be [
 				{
-					direction	"capture"
 					index 31
 					copier_type "ALH"
 

--- a/tools/topology/topology2/platform/intel/sdw-dmic-generic.conf
+++ b/tools/topology/topology2/platform/intel/sdw-dmic-generic.conf
@@ -37,7 +37,6 @@ Object.Pipeline {
 	]
 	passthrough-capture-be [
 		{
-			direction	"capture"
 			index 41
 			copier_type "ALH"
 			Object.Widget.copier.1 {

--- a/tools/topology/topology2/sof-hda-generic.conf
+++ b/tools/topology/topology2/sof-hda-generic.conf
@@ -19,7 +19,7 @@
 <dai-copier-eqiir-module-copier-capture.conf>
 <gain-capture.conf>
 <deepbuffer-playback.conf>
-<passthrough-be.conf>
+<passthrough-playback-be.conf>
 <passthrough-capture-be.conf>
 <highpass-capture-be.conf>
 <data.conf>


### PR DESCRIPTION
I don't know how we managed to have so many blatant logical inversions and inconsistencies.

dai_in/out
ibs/obs
aif_in/aif_out
capture/playback direction and names

and all of the above.

If it looks bad it's because it is. We need stronger class definitions to avoid such issues.