### PR TITLE
coherent: fix allocation size

### DIFF
--- a/src/include/sof/coherent.h
+++ b/src/include/sof/coherent.h
@@ -156,7 +156,13 @@ static inline void coherent_release(struct coherent __sparse_cache *c,
 
 static inline void *__coherent_init(size_t offset, const size_t size)
 {
-	void *object = rzalloc(SOF_MEM_ZONE_RUNTIME_SHARED, 0, SOF_MEM_CAPS_RAM, size);
+	/*
+	 * Allocate an object with an uncached alias but align size on a cache-
+	 * line boundary to avoid sharing a cache line with the adjacent
+	 * allocation
+	 */
+	void *object = rzalloc(SOF_MEM_ZONE_RUNTIME_SHARED, 0, SOF_MEM_CAPS_RAM,
+			       ALIGN_UP(size, PLATFORM_DCACHE_ALIGN));
 	struct coherent *c;
 
 	if (!object)
@@ -245,7 +251,9 @@ static inline void coherent_release_thread(struct coherent __sparse_cache *c,
 
 static inline void *__coherent_init_thread(size_t offset, const size_t size)
 {
-	void *object = rzalloc(SOF_MEM_ZONE_RUNTIME_SHARED, 0, SOF_MEM_CAPS_RAM, size);
+	/* As above - prevent cache line sharing */
+	void *object = rzalloc(SOF_MEM_ZONE_RUNTIME_SHARED, 0, SOF_MEM_CAPS_RAM,
+			       ALIGN_UP(size, PLATFORM_DCACHE_ALIGN));
 	struct coherent *c;
 
 	if (!object)
@@ -331,7 +339,9 @@ static inline void coherent_release(struct coherent __sparse_cache *c,
 
 static inline void *__coherent_init(size_t offset, const size_t size)
 {
-	void *object = rzalloc(SOF_MEM_ZONE_RUNTIME_SHARED, 0, SOF_MEM_CAPS_RAM, size);
+	/* As in CONFIG_INCOHERENT case - prevent cache line sharing */
+	void *object = rzalloc(SOF_MEM_ZONE_RUNTIME_SHARED, 0, SOF_MEM_CAPS_RAM,
+			       ALIGN_UP(size, PLATFORM_DCACHE_ALIGN));
 	struct coherent *c;
 
 	if (!object)
@@ -394,11 +404,7 @@ static inline void coherent_release_thread(struct coherent __sparse_cache *c,
 
 static inline void *__coherent_init_thread(size_t offset, const size_t size)
 {
-	/*
-	 * Allocate an object with an uncached alias but align size on a cache-
-	 * line boundary to avoid sharing a cache line with the adjacent
-	 * allocation
-	 */
+	/* As above - prevent cache line sharing */
 	void *object = rzalloc(SOF_MEM_ZONE_RUNTIME_SHARED, 0, SOF_MEM_CAPS_RAM,
 			       ALIGN_UP(size, PLATFORM_DCACHE_ALIGN));
 	struct coherent *c;


### PR DESCRIPTION
When adding object allocation to the coherent API the size alignment was misplaced, re-opening a possibility for cache corruption when sharing cache lines with adjacent allocations. Move alignment to the correct places.