### PR TITLE
host-zephyr: remove notifier, call the copier callback directly

### DIFF
--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -19,7 +19,6 @@
 #include <rtos/cache.h>
 #include <rtos/init.h>
 #include <sof/lib/memory.h>
-#include <sof/lib/notifier.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
 #include <rtos/string.h>
@@ -929,12 +928,8 @@ static int copier_reset(struct comp_dev *dev)
 	cd->input_total_data_processed = 0;
 	cd->output_total_data_processed = 0;
 
-	if (dev->ipc_config.type == SOF_COMP_HOST && !cd->ipc_gtw) {
-		if (cd->hd->chan)
-			notifier_unregister(dev,
-					    cd->hd->chan, NOTIFIER_ID_DMA_COPY);
+	if (dev->ipc_config.type == SOF_COMP_HOST && !cd->ipc_gtw)
 		host_zephyr_reset(cd->hd, dev->state);
-	}
 
 	for (i = 0; i < cd->endpoint_num; i++) {
 		if (dev->ipc_config.type != SOF_COMP_HOST || cd->ipc_gtw) {
@@ -1188,9 +1183,12 @@ static int mux_into_multi_endpoint_buffer(struct copier_data *cd)
 	return 0;
 }
 
+static void copier_dma_cb(struct comp_dev *dev, size_t bytes);
+
 static int do_endpoint_copy(struct comp_dev *dev)
 {
 	struct copier_data *cd = comp_get_drvdata(dev);
+
 	if (cd->multi_endpoint_buffer) {
 		int i;
 		int ret = 0;
@@ -1215,7 +1213,7 @@ static int do_endpoint_copy(struct comp_dev *dev)
 		return ret;
 	} else {
 		if (dev->ipc_config.type == SOF_COMP_HOST && !cd->ipc_gtw)
-			return host_zephyr_copy(cd->hd, dev);
+			return host_zephyr_copy(cd->hd, dev, copier_dma_cb);
 
 		return cd->endpoint[0]->drv->ops.copy(cd->endpoint[0]);
 	}
@@ -1382,13 +1380,10 @@ static void update_buffer_format(struct comp_buffer __sparse_cache *buf_c,
 /* This is called by DMA driver every time when DMA completes its current
  * transfer between host and DSP.
  */
-static void copier_dma_cb(void *arg, enum notify_id type, void *data)
+static void copier_dma_cb(struct comp_dev *dev, size_t bytes)
 {
-	struct dma_cb_data *next = data;
-	struct comp_dev *dev = arg;
 	struct copier_data *cd = comp_get_drvdata(dev);
 	struct comp_buffer __sparse_cache *sink;
-	uint32_t bytes = next->elem.size;
 	int ret, frames;
 
 	comp_dbg(dev, "copier_dma_cb() %p", dev);
@@ -1417,6 +1412,14 @@ static void copier_dma_cb(void *arg, enum notify_id type, void *data)
 		buffer_stream_writeback(sink, bytes);
 		buffer_release(sink);
 	}
+}
+
+static void copier_notifier_cb(void *arg, enum notify_id type, void *data)
+{
+	struct dma_cb_data *next = data;
+	uint32_t bytes = next->elem.size;
+
+	copier_dma_cb(arg, bytes);
 }
 
 /* configure the DMA params */
@@ -1502,11 +1505,7 @@ static int copier_params(struct comp_dev *dev, struct sof_ipc_stream_params *par
 						cd->out_fmt->valid_bit_depth / 8;
 				}
 
-				ret = host_zephyr_params(cd->hd, dev, params);
-				if (ret >= 0)
-					/* set up callback */
-					notifier_register(dev, cd->hd->chan,
-							  NOTIFIER_ID_DMA_COPY, copier_dma_cb, 0);
+				ret = host_zephyr_params(cd->hd, dev, params, copier_notifier_cb);
 
 				cd->hd->process = cd->converter[IPC4_COPIER_GATEWAY_PIN];
 			} else {

--- a/src/audio/host-zephyr.c
+++ b/src/audio/host-zephyr.c
@@ -20,7 +20,6 @@
 #include <sof/lib/dma.h>
 #include <sof/lib/mailbox.h>
 #include <sof/lib/memory.h>
-#include <sof/lib/notifier.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
 #include <sof/math/numbers.h>
@@ -74,7 +73,8 @@ static uint32_t host_dma_get_split(struct host_data *hd, uint32_t bytes)
 
 #if CONFIG_FORCE_DMA_COPY_WHOLE_BLOCK
 
-static int host_dma_set_config_and_copy(struct host_data *hd, struct comp_dev *dev, uint32_t bytes)
+static int host_dma_set_config_and_copy(struct host_data *hd, struct comp_dev *dev, uint32_t bytes,
+					copy_callback_t cb)
 {
 	struct dma_sg_elem *local_elem = hd->config.elem_array.elems;
 	int ret;
@@ -89,12 +89,8 @@ static int host_dma_set_config_and_copy(struct host_data *hd, struct comp_dev *d
 		return ret;
 	}
 
-	struct dma_cb_data next = {
-		.channel = hd->chan,
-		.elem = { .size = bytes },
-	};
-	notifier_event(hd->chan, NOTIFIER_ID_DMA_COPY,
-		       NOTIFIER_TARGET_CORE_LOCAL, &next, sizeof(next));
+	cb(dev, bytes);
+
 	ret = dma_reload(hd->chan->dma->z_dev, hd->chan->index, 0, 0, bytes);
 	if (ret < 0) {
 		comp_err(dev, "host_dma_set_config_and_copy(): dma_copy() failed, ret = %d",
@@ -138,7 +134,7 @@ static uint32_t host_get_copy_bytes_one_shot(struct host_data *hd)
  * @param dev Host component device.
  * @return 0 if succeeded, error code otherwise.
  */
-static int host_copy_one_shot(struct host_data *hd, struct comp_dev *dev)
+static int host_copy_one_shot(struct host_data *hd, struct comp_dev *dev, copy_callback_t cb)
 {
 	uint32_t copy_bytes;
 	uint32_t split_value;
@@ -157,7 +153,7 @@ static int host_copy_one_shot(struct host_data *hd, struct comp_dev *dev)
 		split_value = host_dma_get_split(hd, copy_bytes);
 		copy_bytes -= split_value;
 
-		ret = host_dma_set_config_and_copy(hd, dev, copy_bytes);
+		ret = host_dma_set_config_and_copy(hd, dev, copy_bytes, cb);
 		if (ret < 0)
 			return ret;
 
@@ -213,7 +209,7 @@ static uint32_t host_get_copy_bytes_one_shot(struct host_data *hd)
  * @param dev Host component device.
  * @return 0 if succeeded, error code otherwise.
  */
-static int host_copy_one_shot(struct host_data *hd, struct comp_dev *dev)
+static int host_copy_one_shot(struct host_data *hd, struct comp_dev *dev, copy_callback_t cb)
 {
 	uint32_t copy_bytes;
 	int ret = 0;
@@ -233,12 +229,8 @@ static int host_copy_one_shot(struct host_data *hd, struct comp_dev *dev)
 		return ret;
 	}
 
-	struct dma_cb_data next = {
-		.channel = hd->chan,
-		.elem = { .size = copy_bytes },
-	};
-	notifier_event(hd->chan, NOTIFIER_ID_DMA_COPY,
-		       NOTIFIER_TARGET_CORE_LOCAL, &next, sizeof(next));
+	cb(dev, copy_bytes);
+
 	ret = dma_reload(hd->chan->dma->z_dev, hd->chan->index, 0, 0, copy_bytes);
 	if (ret < 0)
 		comp_err(dev, "host_copy_one_shot(): dma_copy() failed, ret = %u", ret);
@@ -365,12 +357,9 @@ void host_one_shot_cb(struct host_data *hd, uint32_t bytes)
 /* This is called by DMA driver every time when DMA completes its current
  * transfer between host and DSP.
  */
-static void host_dma_cb(void *arg, enum notify_id type, void *data)
+static void host_dma_cb(struct comp_dev *dev, size_t bytes)
 {
-	struct dma_cb_data *next = data;
-	struct comp_dev *dev = arg;
 	struct host_data *hd = comp_get_drvdata(dev);
-	uint32_t bytes = next->elem.size;
 
 	comp_cl_dbg(&comp_host, "host_dma_cb() %p", &comp_host);
 
@@ -450,7 +439,7 @@ static uint32_t host_get_copy_bytes_normal(struct host_data *hd, struct comp_dev
  * @param dev Host component device.
  * @return 0 if succeeded, error code otherwise.
  */
-static int host_copy_normal(struct host_data *hd, struct comp_dev *dev)
+static int host_copy_normal(struct host_data *hd, struct comp_dev *dev, copy_callback_t cb)
 {
 	struct comp_buffer __sparse_cache *buffer_c;
 	uint32_t copy_bytes;
@@ -467,12 +456,7 @@ static int host_copy_normal(struct host_data *hd, struct comp_dev *dev)
 	if (!copy_bytes)
 		return 0;
 
-	struct dma_cb_data next = {
-		.channel = hd->chan,
-		.elem = { .size = copy_bytes },
-	};
-	notifier_event(hd->chan, NOTIFIER_ID_DMA_COPY,
-		       NOTIFIER_TARGET_CORE_LOCAL, &next, sizeof(next));
+	cb(dev, copy_bytes);
 
 	hd->partial_size += copy_bytes;
 	buffer_c = buffer_acquire(hd->dma_buffer);
@@ -745,7 +729,7 @@ static int host_verify_params(struct comp_dev *dev,
 
 /* configure the DMA params and descriptors for host buffer IO */
 int host_zephyr_params(struct host_data *hd, struct comp_dev *dev,
-		       struct sof_ipc_stream_params *params)
+		       struct sof_ipc_stream_params *params, notifier_callback_t cb)
 {
 	struct dma_sg_config *config = &hd->config;
 	struct dma_sg_elem *sg_elem;
@@ -984,12 +968,7 @@ static int host_params(struct comp_dev *dev,
 		return err;
 	}
 
-	err = host_zephyr_params(hd, dev, params);
-	if (err >= 0)
-		/* set up callback */
-		notifier_register(dev, hd->chan, NOTIFIER_ID_DMA_COPY, host_dma_cb, 0);
-
-	return err;
+	return host_zephyr_params(hd, dev, params, NULL);
 }
 
 int host_zephyr_prepare(struct host_data *hd)
@@ -1065,9 +1044,6 @@ static int host_reset(struct comp_dev *dev)
 	struct host_data *hd = comp_get_drvdata(dev);
 
 	comp_dbg(dev, "host_reset()");
-	/* remove callback first for host reset */
-	if (hd->chan)
-		notifier_unregister(dev, hd->chan, NOTIFIER_ID_DMA_COPY);
 
 	host_zephyr_reset(hd, dev->state);
 	dev->state = COMP_STATE_READY;
@@ -1076,9 +1052,9 @@ static int host_reset(struct comp_dev *dev)
 }
 
 /* copy and process stream data from source to sink buffers */
-int host_zephyr_copy(struct host_data *hd, struct comp_dev *dev)
+int host_zephyr_copy(struct host_data *hd, struct comp_dev *dev, copy_callback_t cb)
 {
-	return hd->copy(hd, dev);
+	return hd->copy(hd, dev, cb);
 }
 
 static int host_copy(struct comp_dev *dev)
@@ -1088,7 +1064,7 @@ static int host_copy(struct comp_dev *dev)
 	if (dev->state != COMP_STATE_ACTIVE)
 		return 0;
 
-	return host_zephyr_copy(hd, dev);
+	return host_zephyr_copy(hd, dev, host_dma_cb);
 }
 
 static int host_get_attribute(struct comp_dev *dev, uint32_t type,

--- a/src/include/sof/audio/host_copier.h
+++ b/src/include/sof/audio/host_copier.h
@@ -21,9 +21,11 @@
 #include <ipc/stream.h>
 #include <sof/lib/notifier.h>
 
+typedef void (*copy_callback_t)(struct comp_dev *dev, size_t bytes);
+
 struct host_data;
 /** \brief Host copy function interface. */
-typedef int (*host_copy_func)(struct host_data *hd, struct comp_dev *dev);
+typedef int (*host_copy_func)(struct host_data *hd, struct comp_dev *dev, copy_callback_t cb);
 
 /**
  * \brief Host buffer info.
@@ -51,6 +53,8 @@ struct host_data {
 #ifdef __ZEPHYR__
 	struct dma_config z_config;
 #endif
+	struct comp_dev *cb_dev;
+
 	struct comp_buffer *dma_buffer;
 	struct comp_buffer *local_buffer;
 
@@ -100,8 +104,8 @@ int host_zephyr_prepare(struct host_data *hd);
 void host_zephyr_reset(struct host_data *hd, uint16_t state);
 int host_zephyr_trigger(struct host_data *hd, struct comp_dev *dev, int cmd);
 int host_zephyr_params(struct host_data *hd, struct comp_dev *dev,
-		       struct sof_ipc_stream_params *params);
-int host_zephyr_copy(struct host_data *hd, struct comp_dev *dev);
+		       struct sof_ipc_stream_params *params, notifier_callback_t cb);
+int host_zephyr_copy(struct host_data *hd, struct comp_dev *dev, copy_callback_t cb);
 void host_update_position(struct host_data *hd, struct comp_dev *dev, uint32_t bytes);
 void host_one_shot_cb(struct host_data *hd, uint32_t bytes);
 

--- a/src/include/sof/lib/notifier.h
+++ b/src/include/sof/lib/notifier.h
@@ -58,6 +58,9 @@ struct notify_data {
 
 struct notify **arch_notify_get(void);
 
+typedef void (*notifier_callback_t)(void *receiver_data, enum notify_id event_type,
+				    void *caller_data);
+
 /** Register a callback to be run when event 'type' happens.
  *
  * The identifier for un-registration is the tuple (receiver_data,
@@ -74,9 +77,7 @@ struct notify **arch_notify_get(void);
  * @param flags see NOTIFIER_FLAG_* above
  */
 int notifier_register(void *receiver_data, void *caller_id_filter, enum notify_id event_type,
-		      void (*callback)(void *receiver_data, enum notify_id event_type,
-				       void *caller_data),
-		      uint32_t flags);
+		      notifier_callback_t callback, uint32_t flags);
 
 /** Unregister all callbacks matching that arguments tuple. NULL acts
  * as a wildcard.


### PR DESCRIPTION
Using the notifier between the copier and the host makes little sense: it ends up in a direct function call, but before that it has to look for the correct callback in a global notifier list. The callback can perfectly be called directly instead.