### PR TITLE
drivers: imx: ipc: remove unnecessary blank line

### DIFF
--- a/src/drivers/imx/ipc.c
+++ b/src/drivers/imx/ipc.c
@@ -257,7 +257,6 @@ int ipc_platform_poll_is_cmd_pending(void)
 
 	/* new message from host */
 	if (status & IMX_MU_xSR_GIPn(IMX_MU_VERSION, 0)) {
-
 		/* Disable GP interrupt #0 */
 		imx_mu_xcr_rmw(IMX_MU_VERSION, IMX_MU_GIER, 0, IMX_MU_xCR_GIEn(IMX_MU_VERSION, 0));
 


### PR DESCRIPTION
Remove unnecessary blank line after '{' as reported
by checkpatch:

"CHECK: Blank lines aren't necessary after an open
brace '{'".

Signed-off-by: Alaa Emad <eng.alaaemad.ae@gmail.com>
