### PR TITLE
drivers: imx: fix checkpatch styling error

### DIFF
--- a/src/drivers/imx/ipc.c
+++ b/src/drivers/imx/ipc.c
@@ -132,7 +132,8 @@ int ipc_platform_send_msg(const struct ipc_msg *msg)
 
 	/* can't send notification when one is in progress */
 	if (ipc->is_notification_pending ||
-	    imx_mu_read(IMX_MU_xCR(IMX_MU_VERSION, IMX_MU_GCR)) & IMX_MU_xCR_GIRn(IMX_MU_VERSION, 1)) {
+	    imx_mu_read(IMX_MU_xCR(IMX_MU_VERSION, IMX_MU_GCR)) &
+					IMX_MU_xCR_GIRn(IMX_MU_VERSION, 1)) {
 		return -EBUSY;
 	}
 
@@ -223,8 +224,7 @@ int platform_ipc_init(struct ipc *ipc)
 	 * enable GP #0 for Host -> DSP message notification
 	 * enable GP #1 for DSP -> Host message confirmation
 	 */
-	imx_mu_xcr_rmw(IMX_MU_VERSION, IMX_MU_GIER,
-			IMX_MU_xCR_GIEn(IMX_MU_VERSION, 0) |
+	imx_mu_xcr_rmw(IMX_MU_VERSION, IMX_MU_GIER, IMX_MU_xCR_GIEn(IMX_MU_VERSION, 0) |
 			IMX_MU_xCR_GIEn(IMX_MU_VERSION, 1), 0);
 
 	return 0;
@@ -257,7 +257,6 @@ int ipc_platform_poll_is_cmd_pending(void)
 
 	/* new message from host */
 	if (status & IMX_MU_xSR_GIPn(IMX_MU_VERSION, 0)) {
-
 		/* Disable GP interrupt #0 */
 		imx_mu_xcr_rmw(IMX_MU_VERSION, IMX_MU_GIER, 0, IMX_MU_xCR_GIEn(IMX_MU_VERSION, 0));
 
@@ -307,7 +306,8 @@ int ipc_platform_poll_is_host_ready(void)
 int ipc_platform_poll_tx_host_msg(struct ipc_msg *msg)
 {
 	/* can't send notification when one is in progress */
-	if (imx_mu_read(IMX_MU_xCR(IMX_MU_VERSION, IMX_MU_GCR)) & IMX_MU_xCR_GIRn(IMX_MU_VERSION, 1))
+	if (imx_mu_read(IMX_MU_xCR(IMX_MU_VERSION, IMX_MU_GCR)) &
+		IMX_MU_xCR_GIRn(IMX_MU_VERSION, 1))
 		return 0;
 
 	/* now send the message */

--- a/src/drivers/imx/sai.c
+++ b/src/drivers/imx/sai.c
@@ -349,8 +349,7 @@ static inline int sai_set_config(struct dai *dai, struct ipc_config_dai *common_
 	dai_update_bits(dai, REG_SAI_XCR4(REG_TX_DIR), mask_cr4, val_cr4);
 	dai_update_bits(dai, REG_SAI_XCR5(REG_TX_DIR), mask_cr5, val_cr5);
 	/* turn on (set to zero) stereo slot */
-	dai_update_bits(dai, REG_SAI_XMR(REG_TX_DIR),  REG_SAI_XMR_MASK,
-		       twm);
+	dai_update_bits(dai, REG_SAI_XMR(REG_TX_DIR), REG_SAI_XMR_MASK, twm);
 
 	val_cr2 |= REG_SAI_CR2_SYNC;
 	mask_cr2 |= REG_SAI_CR2_SYNC_MASK;


### PR DESCRIPTION
# drivers: imx: fix checkpatch styling error
`drivers: imx: ipc`
Split long line into two short lines
at 135: FILE: src/drivers/imx/ipc.c:135:
"CHECK: line length of 103 exceeds 100 columns"

Modified to match the alignment of the open parenthesis
at 227: FILE: src/drivers/imx/ipc.c:227:
"CHECK: Alignment should match open parenthesis"

Split long line into two short lines
at 309: FILE: src/drivers/imx/ipc.c:309:
"CHECK: line length of 101 exceeds 100 columns"

`drivers: imx: sai`
Modified to match the alignment of the open parenthesis
at 353: FILE: src/drivers/imx/sai.c:353:
"CHECK: Alignment should match open parenthesis"
