### PR TITLE
topology1: set lower priority for DMIC task in GOOGLE_RTC_AUDIO case

### DIFF
--- a/tools/topology/topology1/platform/intel/intel-generic-dmic.m4
+++ b/tools/topology/topology1/platform/intel/intel-generic-dmic.m4
@@ -10,6 +10,9 @@ ifdef(`DMIC_48k_PCM_NAME',`',
 ifdef(`DMIC_16k_PCM_NAME',`',
 `define(DMIC_16k_PCM_NAME, `DMIC16kHz')')
 
+ifdef(`DMIC_48k_PRIORITY', `',
+`define(DMIC_48k_PRIORITY, 0)')
+
 # variable that need to be defined in upper m4
 ifdef(`DMICPROC',`',`fatal_error(note: Need to define dmic processing for intel-generic-dmic
 )')
@@ -127,7 +130,7 @@ dnl     deadline, priority, core, time_domain)
 DAI_ADD(sof/pipe-dai-capture.m4,
 	DMIC_PIPELINE_48k_ID, DMIC, 0, DMIC_DAI_LINK_48k_NAME,
 	concat(`PIPELINE_SINK_', DMIC_PIPELINE_48k_ID), 2, s32le,
-	DMIC_48k_PERIOD_US, 0, DMIC_48k_CORE_ID, SCHEDULE_TIME_DOMAIN_TIMER)
+	DMIC_48k_PERIOD_US, DMIC_48k_PRIORITY, DMIC_48k_CORE_ID, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is DMIC 1 using 2 periods
 # Buffers use s32le format, with 16 frame per 1000us on core 0 with priority 0

--- a/tools/topology/topology1/sof-tgl-max98357a-rt5682.m4
+++ b/tools/topology/topology1/sof-tgl-max98357a-rt5682.m4
@@ -165,6 +165,9 @@ ifdef(`GOOGLE_RTC_AUDIO_PROCESSING', `define(`SPK_PLAYBACK_CORE', DMIC_PIPELINE_
 # Google RTC Audio processing processes 10ms at a time. It needs to have time to process it.
 ifdef(`GOOGLE_RTC_AUDIO_PROCESSING', `define(`DMIC_48k_PERIOD', 10000)', `')
 
+# When Google RTC Audio (AEC) is applied, put DMIC pipe task after Speaker in schedule order.
+ifdef(`GOOGLE_RTC_AUDIO_PROCESSING', `define(`DMIC_48k_PRIORITY', 1)', `')
+
 # define pcm, pipeline and dai id
 define(KWD_PIPE_SCH_DEADLINE_US, 5000)
 


### PR DESCRIPTION
When GOOGLE_RTC_AUDIO is applied, Speaker and DMIC pipeline tasks are scheduled in the same domain. The AEC function in GOOGLE_RTC_AUDIO has the hard requirement for input sample synchronization between DMIC input and Echo reference (sourced from Speaker).

At present, both pipelines are pri-0 so the task order in schedule list depends on which pipeline starts first. DMIC pipeline task needs the most computation cycles due to AEC and NR processings, even more than the entire schedule period in peak. If DMIC is scheduled former than Speaker, the synchronization may be broken by the peak of DMIC task which punts Speaker task to the next period.

To avoid the above case, this commit sets DMIC as pri-1 on GOOGLE_RTC_AUDIO applied. It guarantees that DMIC task will be always put after Speaker task.