### PR TITLE
topology2: Mod cfg ibs obs cpc addition

### DIFF
--- a/tools/topology/topology2/include/common/mod_cfg.conf
+++ b/tools/topology/topology2/include/common/mod_cfg.conf
@@ -1,0 +1,45 @@
+# Class definition for module configuration object
+# mod_cfg objects can be instantiated as:
+#
+# Object.Base.mod_cfg."0" {
+#	ibs	384
+#	obs	384
+#	cpc	4600
+# }
+#
+
+Class.Base."mod_cfg" {
+
+    DefineAttribute."instance" {
+    }
+
+    # input buffer size
+    DefineAttribute."ibs" {
+	# Token set reference name
+	token_ref    "sof_tkn_mod_cfg.word"
+    }
+
+    # output buffer size
+    DefineAttribute."obs" {
+	# Token set reference name
+	token_ref    "sof_tkn_mod_cfg.word"
+    }
+
+    # Cycles Per Chunk
+    DefineAttribute."cpc" {
+	# Token set reference name
+	token_ref    "sof_tkn_mod_cfg.word"
+    }
+
+    attributes {
+	!constructor [
+	    "instance"
+	]
+
+	#
+	# mod_cfg objects instantiated within the same alsaconf node
+	# must have unique instance attribute values
+	#
+	unique	  "instance"
+    }
+}

--- a/tools/topology/topology2/include/common/tokens.conf
+++ b/tools/topology/topology2/include/common/tokens.conf
@@ -24,6 +24,7 @@ Object.Base.VendorToken {
 		output_pin_binding_name	414
 		num_input_audio_formats	415
 		num_output_audio_formats 416
+		num_mod_cfgs		417
 	}
 
 	"2" {
@@ -178,5 +179,13 @@ Object.Base.VendorToken {
 		name "sof_tkn_copier"
 		node_type		1980
 		deep_buffer_dma_ms	1981
+	}
+
+	# ABI 4.0 onwards
+	"19" {
+		name "sof_tkn_mod_cfg"
+		ibs			1990
+		obs			1991
+		cpc			1992
 	}
 }

--- a/tools/topology/topology2/include/components/widget-common.conf
+++ b/tools/topology/topology2/include/components/widget-common.conf
@@ -109,3 +109,9 @@ DefineAttribute."num_output_audio_formats" {
 	# Token set reference name and type
 	token_ref	"sof_tkn_comp.word"
 }
+
+# Number defined module configurations
+DefineAttribute."num_mod_cfgs" {
+	# Token set reference name and type
+	token_ref	"sof_tkn_comp.word"
+}

--- a/tools/topology/topology2/include/pipelines/cavs/dai-copier-be.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/dai-copier-be.conf
@@ -17,6 +17,7 @@
 #
 
 <include/common/audio_format.conf>
+<include/common/mod_cfg.conf>
 <include/components/copier.conf>
 <include/components/pipeline.conf>
 

--- a/tools/topology/topology2/include/pipelines/cavs/dai-copier-eqiir-module-copier-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/dai-copier-eqiir-module-copier-capture.conf
@@ -17,6 +17,7 @@
 #
 
 <include/common/audio_format.conf>
+<include/common/mod_cfg.conf>
 <include/components/copier.conf>
 <include/controls/bytes.conf>
 <include/components/eqiir.conf>

--- a/tools/topology/topology2/include/pipelines/cavs/dai-copier-gain-mixin-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/dai-copier-gain-mixin-capture.conf
@@ -17,6 +17,7 @@
 #
 
 <include/common/audio_format.conf>
+<include/common/mod_cfg.conf>
 <include/components/copier.conf>
 <include/components/gain.conf>
 <include/components/mixin.conf>

--- a/tools/topology/topology2/include/pipelines/cavs/dai-copier-gain-module-copier-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/dai-copier-gain-module-copier-capture.conf
@@ -17,6 +17,7 @@
 #
 
 <include/common/audio_format.conf>
+<include/common/mod_cfg.conf>
 <include/components/copier.conf>
 <include/components/gain.conf>
 <include/components/pipeline.conf>

--- a/tools/topology/topology2/include/pipelines/cavs/dai-kpb-be.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/dai-kpb-be.conf
@@ -18,6 +18,7 @@
 #
 
 <include/common/audio_format.conf>
+<include/common/mod_cfg.conf>
 <include/components/copier.conf>
 <include/components/pipeline.conf>
 <include/components/kpb.conf>

--- a/tools/topology/topology2/include/pipelines/cavs/deepbuffer-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/deepbuffer-playback.conf
@@ -17,6 +17,7 @@
 #
 
 <include/common/audio_format.conf>
+<include/common/mod_cfg.conf>
 <include/components/copier.conf>
 <include/components/mixin.conf>
 <include/components/pipeline.conf>

--- a/tools/topology/topology2/include/pipelines/cavs/gain-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/gain-capture.conf
@@ -18,6 +18,7 @@
 #
 
 <include/common/audio_format.conf>
+<include/common/mod_cfg.conf>
 <include/components/copier.conf>
 <include/components/gain.conf>
 <include/components/pipeline.conf>

--- a/tools/topology/topology2/include/pipelines/cavs/gain-copier-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/gain-copier-capture.conf
@@ -18,6 +18,7 @@
 #
 
 <include/common/audio_format.conf>
+<include/common/mod_cfg.conf>
 <include/components/copier.conf>
 <include/components/gain.conf>
 <include/components/pipeline.conf>

--- a/tools/topology/topology2/include/pipelines/cavs/gain-module-copier.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/gain-module-copier.conf
@@ -17,6 +17,7 @@
 #
 
 <include/common/audio_format.conf>
+<include/common/mod_cfg.conf>
 <include/components/copier.conf>
 <include/components/gain.conf>
 <include/components/pipeline.conf>

--- a/tools/topology/topology2/include/pipelines/cavs/gain-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/gain-playback.conf
@@ -17,6 +17,7 @@
 #
 
 <include/common/audio_format.conf>
+<include/common/mod_cfg.conf>
 <include/components/copier.conf>
 <include/components/gain.conf>
 <include/components/pipeline.conf>

--- a/tools/topology/topology2/include/pipelines/cavs/highpass-capture-be.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/highpass-capture-be.conf
@@ -18,6 +18,7 @@
 #
 
 <include/common/audio_format.conf>
+<include/common/mod_cfg.conf>
 <include/components/copier.conf>
 <include/components/pipeline.conf>
 <include/controls/bytes.conf>

--- a/tools/topology/topology2/include/pipelines/cavs/host-copier-gain-mixin-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/host-copier-gain-mixin-playback.conf
@@ -17,6 +17,7 @@
 #
 
 <include/common/audio_format.conf>
+<include/common/mod_cfg.conf>
 <include/components/copier.conf>
 <include/components/mixin.conf>
 <include/components/pipeline.conf>

--- a/tools/topology/topology2/include/pipelines/cavs/host-copier-gain-src-mixin-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/host-copier-gain-src-mixin-playback.conf
@@ -17,6 +17,7 @@
 #
 
 <include/common/audio_format.conf>
+<include/common/mod_cfg.conf>
 <include/components/copier.conf>
 <include/components/mixin.conf>
 <include/components/pipeline.conf>

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-gain-dai-copier-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-gain-dai-copier-playback.conf
@@ -17,6 +17,7 @@
 #
 
 <include/common/audio_format.conf>
+<include/common/mod_cfg.conf>
 <include/components/copier.conf>
 <include/components/gain.conf>
 <include/components/mixout.conf>

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-gain-efx-dai-copier-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-gain-efx-dai-copier-playback.conf
@@ -17,6 +17,7 @@
 #
 
 <include/common/audio_format.conf>
+<include/common/mod_cfg.conf>
 <include/components/copier.conf>
 <include/components/gain.conf>
 <include/components/mixout.conf>

--- a/tools/topology/topology2/include/pipelines/cavs/src-gain-mixin-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/src-gain-mixin-playback.conf
@@ -17,6 +17,7 @@
 #
 <common_definitions.conf>
 <include/common/audio_format.conf>
+<include/common/mod_cfg.conf>
 <include/components/copier.conf>
 <include/components/gain.conf>
 <include/components/mixin.conf>

--- a/tools/topology/topology2/include/pipelines/cavs/wov-detect.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/wov-detect.conf
@@ -18,6 +18,7 @@
 #
 
 <include/common/audio_format.conf>
+<include/common/mod_cfg.conf>
 <include/components/copier.conf>
 <include/components/micsel.conf>
 <include/components/wov.conf>


### PR DESCRIPTION
I am feeling quite clueless here, so even if this does not work, I push this out in hope someone can spot the problem.

For some reason the widget tuple array only contains the first instance of mod_cfg objects in the topology2 conf file. I am trying to read the array out with this code: https://github.com/jsarha/linux-sof/tree/peter-cpc-test