### PR TITLE
topology2: Remove dma_buffer_size attribute

### DIFF
--- a/tools/topology/topology2/cavs-mixin-mixout-efx-hda.conf
+++ b/tools/topology/topology2/cavs-mixin-mixout-efx-hda.conf
@@ -96,7 +96,6 @@ Object.Pipeline {
 					in_valid_bit_depth	32
 					out_bit_depth		32
 					out_valid_bit_depth	32
-					dma_buffer_size "$[$ibs * 2]"
 				}
 			}
 		}

--- a/tools/topology/topology2/cavs-mixin-mixout-hda.conf
+++ b/tools/topology/topology2/cavs-mixin-mixout-hda.conf
@@ -86,7 +86,6 @@ Object.Pipeline {
 					in_valid_bit_depth	32
 					out_bit_depth		32
 					out_valid_bit_depth	32
-					dma_buffer_size "$[$ibs * 2]"
 				}
 			}
 			Object.Widget.eqiir.1 {

--- a/tools/topology/topology2/cavs-nocodec-bt.conf
+++ b/tools/topology/topology2/cavs-nocodec-bt.conf
@@ -209,7 +209,6 @@ Object.Pipeline {
 					in_valid_bit_depth	32
 					out_bit_depth		32
 					out_valid_bit_depth	32
-					dma_buffer_size "$[$ibs * 2]"
 				}
 			}
 		}
@@ -232,7 +231,6 @@ Object.Pipeline {
 					in_valid_bit_depth	32
 					out_bit_depth		32
 					out_valid_bit_depth	32
-					dma_buffer_size "$[$ibs * 2]"
 				}
 			}
 		}

--- a/tools/topology/topology2/cavs-nocodec.conf
+++ b/tools/topology/topology2/cavs-nocodec.conf
@@ -278,7 +278,6 @@ Object.Pipeline.gain-module-copier [
 				in_valid_bit_depth	32
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$ibs * 2]"
 			}
 			Object.Base.audio_format.2 {
 				in_channels		4
@@ -287,7 +286,6 @@ Object.Pipeline.gain-module-copier [
 				out_channels		4
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$ibs * 2]"
 				in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
 				in_ch_map	$CHANNEL_MAP_3_POINT_1
 				out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
@@ -303,7 +301,6 @@ Object.Pipeline.gain-module-copier [
 				in_valid_bit_depth	32
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$ibs * 2]"
 			}
 			Object.Base.audio_format.2 {
 				in_channels		4
@@ -312,7 +309,6 @@ Object.Pipeline.gain-module-copier [
 				out_channels		4
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$ibs * 2]"
 				in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
 				in_ch_map	$CHANNEL_MAP_3_POINT_1
 				out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
@@ -340,7 +336,6 @@ Object.Pipeline.dai-copier-gain-module-copier-capture [
 				in_valid_bit_depth	32
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$ibs * 2]"
 			}
 
 			Object.Base.output_pin_binding.1 {
@@ -359,7 +354,6 @@ Object.Pipeline.dai-copier-gain-module-copier-capture [
 				in_valid_bit_depth	32
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$ibs * 2]"
 			}
 		}
 		Object.Widget.gain.1 {
@@ -397,7 +391,6 @@ Object.Pipeline.passthrough-capture-be [
 				in_valid_bit_depth	32
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$ibs * 2]"
 			}
 		}
 	}
@@ -417,7 +410,6 @@ Object.Pipeline.passthrough-capture-be [
 				in_valid_bit_depth	32
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$ibs * 2]"
 			}
 		}
 	}
@@ -440,7 +432,6 @@ Object.Pipeline.gain-capture [
 				in_valid_bit_depth	32
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$ibs * 2]"
 			}
 			Object.Base.audio_format.2 {
 				in_channels		4
@@ -449,7 +440,6 @@ Object.Pipeline.gain-capture [
 				out_channels		4
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$ibs * 2]"
 				in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
 				in_ch_map	$CHANNEL_MAP_3_POINT_1
 				out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
@@ -465,7 +455,6 @@ Object.Pipeline.gain-capture [
 				in_valid_bit_depth	32
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$ibs * 2]"
 			}
 			Object.Base.audio_format.2 {
 				in_channels		4
@@ -474,7 +463,6 @@ Object.Pipeline.gain-capture [
 				out_channels		4
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$ibs * 2]"
 				in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
 				in_ch_map	$CHANNEL_MAP_3_POINT_1
 				out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
@@ -501,7 +489,6 @@ Object.Pipeline.gain-capture [
 				in_valid_bit_depth	32
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$ibs * 2]"
 			}
 			Object.Base.audio_format.2 {
 				in_channels		4
@@ -510,7 +497,6 @@ Object.Pipeline.gain-capture [
 				out_channels		4
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$ibs * 2]"
 				in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
 				in_ch_map	$CHANNEL_MAP_3_POINT_1
 				out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
@@ -526,7 +512,6 @@ Object.Pipeline.gain-capture [
 				in_valid_bit_depth	32
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$ibs * 2]"
 			}
 			Object.Base.audio_format.2 {
 				in_channels		4
@@ -535,7 +520,6 @@ Object.Pipeline.gain-capture [
 				out_channels		4
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$ibs * 2]"
 				in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
 				in_ch_map	$CHANNEL_MAP_3_POINT_1
 				out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1

--- a/tools/topology/topology2/cavs-rt5682.conf
+++ b/tools/topology/topology2/cavs-rt5682.conf
@@ -275,7 +275,6 @@ Object.Pipeline {
 					in_valid_bit_depth	32
 					out_bit_depth		32
 					out_valid_bit_depth	32
-					dma_buffer_size "$[$ibs * 2]"
 				}
 			}
 		}
@@ -297,7 +296,6 @@ Object.Pipeline {
 					in_valid_bit_depth	32
 					out_bit_depth		32
 					out_valid_bit_depth	32
-					dma_buffer_size "$[$ibs * 2]"
 				}
 				Object.Base.audio_format.2 {
 					in_channels		4
@@ -306,7 +304,6 @@ Object.Pipeline {
 					out_channels		4
 					out_bit_depth		32
 					out_valid_bit_depth	32
-					dma_buffer_size "$[$ibs * 2]"
 					in_ch_cfg	$CHANNEL_CONFIG_QUATRO
 					in_ch_map	$CHANNEL_MAP_3_POINT_1
 					out_ch_cfg	$CHANNEL_CONFIG_QUATRO
@@ -320,7 +317,6 @@ Object.Pipeline {
 					in_valid_bit_depth	32
 					out_bit_depth		32
 					out_valid_bit_depth	32
-					dma_buffer_size "$[$ibs * 2]"
 				}
 				Object.Base.audio_format.2 {
 					in_channels		4
@@ -329,7 +325,6 @@ Object.Pipeline {
 					out_channels		4
 					out_bit_depth		32
 					out_valid_bit_depth	32
-					dma_buffer_size "$[$ibs * 2]"
 					in_ch_cfg	$CHANNEL_CONFIG_QUATRO
 					in_ch_map	$CHANNEL_MAP_3_POINT_1
 					out_ch_cfg	$CHANNEL_CONFIG_QUATRO

--- a/tools/topology/topology2/cavs-src-mixin-mixout-hda.conf
+++ b/tools/topology/topology2/cavs-src-mixin-mixout-hda.conf
@@ -89,7 +89,6 @@ Object.Pipeline {
 					in_valid_bit_depth	32
 					out_bit_depth		32
 					out_valid_bit_depth	32
-					dma_buffer_size "$[$ibs * 2]"
 				}
 			}
 		}

--- a/tools/topology/topology2/include/common/audio_format.conf
+++ b/tools/topology/topology2/include/common/audio_format.conf
@@ -193,10 +193,6 @@ Class.Base."audio_format" {
 		}
 	}
 
-	DefineAttribute."dma_buffer_size" {
-		# Token set reference name and type
-		token_ref	"sof_tkn_cavs_audio_format.word"
-	}
 
 	attributes {
 		!constructor [

--- a/tools/topology/topology2/include/common/tokens.conf
+++ b/tools/topology/topology2/include/common/tokens.conf
@@ -170,7 +170,7 @@ Object.Base.VendorToken {
 		# tokens up to 1969 reserved for future use
 		ibs			1970
 		obs			1971
-		dma_buffer_size		1972
+		dma_buffer_size		1972 #deprecated
 	}
 
 	# ABI 4.0 onwards

--- a/tools/topology/topology2/include/components/src_passthrough_format.conf
+++ b/tools/topology/topology2/include/components/src_passthrough_format.conf
@@ -11,7 +11,6 @@
 				out_rate                8000
 				out_bit_depth           32
 				out_valid_bit_depth     24
-				dma_buffer_size "$[$obs * 2]"
 			}
 
 			Object.Base.audio_format.2 {
@@ -21,7 +20,6 @@
 				out_rate                8000
 				out_bit_depth           32
 				out_valid_bit_depth     24
-				dma_buffer_size "$[$obs * 2]"
 			}
 
 			Object.Base.audio_format.3{
@@ -31,7 +29,6 @@
 				out_rate                8000
 				out_bit_depth           32
 				out_valid_bit_depth     32
-				dma_buffer_size "$[$obs * 2]"
 			}
 
 			# 11.025 khz input
@@ -42,7 +39,6 @@
 				out_rate                11025
 				out_bit_depth           32
 				out_valid_bit_depth     24
-				dma_buffer_size "$[$obs * 2]"
 			}
 
 			Object.Base.audio_format.5 {
@@ -52,7 +48,6 @@
 				out_rate                11025
 				out_bit_depth           32
 				out_valid_bit_depth     24
-				dma_buffer_size "$[$obs * 2]"
 			}
 
 			Object.Base.audio_format.6{
@@ -62,7 +57,6 @@
 				out_rate                11025
 				out_bit_depth           32
 				out_valid_bit_depth     32
-				dma_buffer_size "$[$obs * 2]"
 			}
 
 			# 12khz input
@@ -73,7 +67,6 @@
 				out_rate                12000
 				out_bit_depth           32
 				out_valid_bit_depth     24
-				dma_buffer_size "$[$obs * 2]"
 			}
 
 			Object.Base.audio_format.8 {
@@ -83,7 +76,6 @@
 				out_rate                12000
 				out_bit_depth           32
 				out_valid_bit_depth     24
-				dma_buffer_size "$[$obs * 2]"
 			}
 
 			Object.Base.audio_format.9{
@@ -93,7 +85,6 @@
 				out_rate                12000
 				out_bit_depth           32
 				out_valid_bit_depth     32
-				dma_buffer_size "$[$obs * 2]"
 			}
 
 			# 16khz input
@@ -104,7 +95,6 @@
 				out_rate                16000
 				out_bit_depth           32
 				out_valid_bit_depth     24
-				dma_buffer_size "$[$obs * 2]"
 			}
 
 			Object.Base.audio_format.11 {
@@ -114,7 +104,6 @@
 				out_rate                16000
 				out_bit_depth           32
 				out_valid_bit_depth     24
-				dma_buffer_size "$[$obs * 2]"
 			}
 
 			Object.Base.audio_format.12{
@@ -124,7 +113,6 @@
 				out_rate                16000
 				out_bit_depth           32
 				out_valid_bit_depth     32
-				dma_buffer_size "$[$obs * 2]"
 			}
 
 			# 22.05khz input
@@ -135,7 +123,6 @@
 				out_rate                22050
 				out_bit_depth           32
 				out_valid_bit_depth     24
-				dma_buffer_size "$[$obs * 2]"
 			}
 
 			Object.Base.audio_format.14 {
@@ -145,7 +132,6 @@
 				out_rate                22050
 				out_bit_depth           32
 				out_valid_bit_depth     24
-				dma_buffer_size "$[$obs * 2]"
 			}
 
 			Object.Base.audio_format.15{
@@ -155,7 +141,6 @@
 				out_rate                22050
 				out_bit_depth           32
 				out_valid_bit_depth     32
-				dma_buffer_size "$[$obs * 2]"
 			}
 
 
@@ -167,7 +152,6 @@
 				out_rate                24000
 				out_bit_depth           32
 				out_valid_bit_depth     24
-				dma_buffer_size "$[$obs * 2]"
 			}
 
 			Object.Base.audio_format.17 {
@@ -177,7 +161,6 @@
 				out_rate                24000
 				out_bit_depth           32
 				out_valid_bit_depth     24
-				dma_buffer_size "$[$obs * 2]"
 			}
 
 			Object.Base.audio_format.18{
@@ -187,7 +170,6 @@
 				out_rate                24000
 				out_bit_depth           32
 				out_valid_bit_depth     32
-				dma_buffer_size "$[$obs * 2]"
 			}
 
 			# 32khz input
@@ -198,7 +180,6 @@
 				out_rate                32000
 				out_bit_depth           32
 				out_valid_bit_depth     24
-				dma_buffer_size "$[$obs * 2]"
 			}
 
 			Object.Base.audio_format.20 {
@@ -208,7 +189,6 @@
 				out_rate                32000
 				out_bit_depth           32
 				out_valid_bit_depth     24
-				dma_buffer_size "$[$obs * 2]"
 			}
 
 			Object.Base.audio_format.21 {
@@ -218,7 +198,6 @@
 				out_rate                32000
 				out_bit_depth           32
 				out_valid_bit_depth     32
-				dma_buffer_size "$[$obs * 2]"
 			}
 
 			# 44.1khz input
@@ -229,7 +208,6 @@
 				out_rate                44100
 				out_bit_depth           32
 				out_valid_bit_depth     24
-				dma_buffer_size "$[$obs * 2]"
 			}
 
 			Object.Base.audio_format.23 {
@@ -239,7 +217,6 @@
 				out_rate                44100
 				out_bit_depth           32
 				out_valid_bit_depth     24
-				dma_buffer_size "$[$obs * 2]"
 			}
 
 			Object.Base.audio_format.24{
@@ -249,7 +226,6 @@
 				out_rate                44100
 				out_bit_depth           32
 				out_valid_bit_depth     32
-				dma_buffer_size "$[$obs * 2]"
 			}
 
 			# 48khz input
@@ -260,7 +236,6 @@
 				out_rate                48000
 				out_bit_depth           32
 				out_valid_bit_depth     24
-				dma_buffer_size "$[$obs * 2]"
 			}
 
 			Object.Base.audio_format.26 {
@@ -270,7 +245,6 @@
 				out_rate                48000
 				out_bit_depth           32
 				out_valid_bit_depth     24
-				dma_buffer_size "$[$obs * 2]"
 			}
 
 			Object.Base.audio_format.27 {
@@ -280,7 +254,6 @@
 				out_rate                48000
 				out_bit_depth           32
 				out_valid_bit_depth     32
-				dma_buffer_size "$[$obs * 2]"
 			}
 
 			# 64khz input
@@ -291,7 +264,6 @@
 				out_rate                64000
 				out_bit_depth           32
 				out_valid_bit_depth     24
-				dma_buffer_size "$[$obs * 2]"
 			}
 
 			Object.Base.audio_format.29 {
@@ -301,7 +273,6 @@
 				out_rate                64000
 				out_bit_depth           32
 				out_valid_bit_depth     24
-				dma_buffer_size "$[$obs * 2]"
 			}
 
 			Object.Base.audio_format.30 {
@@ -311,7 +282,6 @@
 				out_rate                64000
 				out_bit_depth           32
 				out_valid_bit_depth     32
-				dma_buffer_size "$[$obs * 2]"
 			}
 			# 88.2khz input
 			Object.Base.audio_format.31 {
@@ -321,7 +291,6 @@
 				out_rate                88200
 				out_bit_depth           32
 				out_valid_bit_depth     24
-				dma_buffer_size "$[$obs * 2]"
 			}
 
 			Object.Base.audio_format.32 {
@@ -331,7 +300,6 @@
 				out_rate                88200
 				out_bit_depth           32
 				out_valid_bit_depth     24
-				dma_buffer_size "$[$obs * 2]"
 			}
 
 			Object.Base.audio_format.33 {
@@ -341,7 +309,6 @@
 				out_rate                88200
 				out_bit_depth           32
 				out_valid_bit_depth     32
-				dma_buffer_size "$[$obs * 2]"
 			}
 
 			# 96khz input
@@ -352,7 +319,6 @@
 				out_rate                96000
 				out_bit_depth           32
 				out_valid_bit_depth     24
-				dma_buffer_size "$[$obs * 2]"
 			}
 
 			Object.Base.audio_format.35 {
@@ -362,7 +328,6 @@
 				out_rate                96000
 				out_bit_depth           32
 				out_valid_bit_depth     24
-				dma_buffer_size "$[$obs * 2]"
 			}
 
 			Object.Base.audio_format.36 {
@@ -372,7 +337,6 @@
 				out_rate                96000
 				out_bit_depth           32
 				out_valid_bit_depth     32
-				dma_buffer_size "$[$obs * 2]"
 			}
 
 			# 176.4khz input
@@ -383,7 +347,6 @@
 				out_rate                176400
 				out_bit_depth           32
 				out_valid_bit_depth     24
-				dma_buffer_size "$[$obs * 2]"
 			}
 
 			Object.Base.audio_format.38 {
@@ -393,7 +356,6 @@
 				out_rate                176400
 				out_bit_depth           32
 				out_valid_bit_depth     24
-				dma_buffer_size "$[$obs * 2]"
 			}
 
 			Object.Base.audio_format.39 {
@@ -403,7 +365,6 @@
 				out_rate                176400
 				out_bit_depth           32
 				out_valid_bit_depth     32
-				dma_buffer_size "$[$obs * 2]"
 			}
 
 			# 192khz input
@@ -414,7 +375,6 @@
 				out_rate                192000
 				out_bit_depth           32
 				out_valid_bit_depth     24
-				dma_buffer_size "$[$obs * 2]"
 			}
 
 			Object.Base.audio_format.41 {
@@ -424,7 +384,6 @@
 				out_rate                192000
 				out_bit_depth           32
 				out_valid_bit_depth     24
-				dma_buffer_size "$[$obs * 2]"
 			}
 
 			Object.Base.audio_format.42 {
@@ -434,5 +393,4 @@
 				out_rate                192000
 				out_bit_depth           32
 				out_valid_bit_depth     32
-				dma_buffer_size "$[$obs * 2]"
 			}

--- a/tools/topology/topology2/include/pipelines/cavs/dai-copier-be.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/dai-copier-be.conf
@@ -47,7 +47,6 @@ Class.Pipeline."dai-copier-be" {
 				in_valid_bit_depth	32
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size		"$[$obs * 2]"
 			}
 			# 32-bit 48KHz 4ch
 			Object.Base.audio_format.2 {
@@ -57,7 +56,6 @@ Class.Pipeline."dai-copier-be" {
 				out_channels		4
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$obs * 2]"
 				in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
 				in_ch_map	$CHANNEL_MAP_3_POINT_1
 				out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
@@ -69,7 +67,6 @@ Class.Pipeline."dai-copier-be" {
 				in_valid_bit_depth	24
 				out_bit_depth		32
 				out_valid_bit_depth	24
-				dma_buffer_size		"$[$obs * 2]"
 			}
 		}
 
@@ -84,7 +81,6 @@ Class.Pipeline."dai-copier-be" {
 				in_valid_bit_depth	32
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$ibs * 2]"
 			}
 		}
 

--- a/tools/topology/topology2/include/pipelines/cavs/dai-copier-eqiir-module-copier-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/dai-copier-eqiir-module-copier-capture.conf
@@ -59,7 +59,6 @@ Class.Pipeline."dai-copier-eqiir-module-copier-capture" {
 				in_valid_bit_depth	32
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$ibs * 2]"
 			}
 		}
 
@@ -97,7 +96,6 @@ Class.Pipeline."dai-copier-eqiir-module-copier-capture" {
 				in_valid_bit_depth	32
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$ibs * 2]"
 			}
 		}
 

--- a/tools/topology/topology2/include/pipelines/cavs/dai-copier-gain-mixin-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/dai-copier-gain-mixin-capture.conf
@@ -59,7 +59,6 @@ Class.Pipeline."dai-copier-gain-mixin-capture" {
 				in_valid_bit_depth	32
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$ibs * 2]"
 			}
 		}
 

--- a/tools/topology/topology2/include/pipelines/cavs/dai-copier-gain-module-copier-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/dai-copier-gain-module-copier-capture.conf
@@ -58,7 +58,6 @@ Class.Pipeline."dai-copier-gain-module-copier-capture" {
 				in_valid_bit_depth	32
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$ibs * 2]"
 			}
 		}
 
@@ -75,7 +74,6 @@ Class.Pipeline."dai-copier-gain-module-copier-capture" {
 				in_valid_bit_depth	32
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$ibs * 2]"
 			}
 		}
 		gain."1" {

--- a/tools/topology/topology2/include/pipelines/cavs/dai-kpb-be.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/dai-kpb-be.conf
@@ -53,7 +53,6 @@ Class.Pipeline."dai-kpb-be" {
 				in_valid_bit_depth      24
 				out_bit_depth           32
 				out_valid_bit_depth     24
-				dma_buffer_size "$[$obs * 2]"
 			}
 
 			Object.Base.audio_format.1 {
@@ -61,7 +60,6 @@ Class.Pipeline."dai-kpb-be" {
 				in_valid_bit_depth	32
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$obs * 2]"
 			}
 			# 32-bit 48KHz 4ch
 			Object.Base.audio_format.2 {
@@ -71,7 +69,6 @@ Class.Pipeline."dai-kpb-be" {
 				out_channels		4
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$obs * 2]"
 				in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
 				in_ch_map	$CHANNEL_MAP_3_POINT_1
 				out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1

--- a/tools/topology/topology2/include/pipelines/cavs/deepbuffer-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/deepbuffer-playback.conf
@@ -57,8 +57,6 @@ Class.Pipeline."deepbuffer-playback" {
 			Object.Base.audio_format.1 {
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				# 100ms buffer
-				dma_buffer_size "$[$ibs * $DEEPBUFFER_FW_DMA_MS]"
 			}
 			# 24-bit 48KHz 2ch
 			Object.Base.audio_format.2 {
@@ -66,8 +64,6 @@ Class.Pipeline."deepbuffer-playback" {
 				in_valid_bit_depth	24
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				# 100ms buffer
-				dma_buffer_size "$[$obs * $DEEPBUFFER_FW_DMA_MS]"
 			}
 			# 32-bit 48KHz 2ch
 			Object.Base.audio_format.3 {
@@ -75,8 +71,6 @@ Class.Pipeline."deepbuffer-playback" {
 				in_valid_bit_depth	32
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				# 100ms buffer
-				dma_buffer_size "$[$ibs * $DEEPBUFFER_FW_DMA_MS]"
 			}
 		}
 

--- a/tools/topology/topology2/include/pipelines/cavs/gain-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/gain-capture.conf
@@ -55,7 +55,6 @@ Class.Pipeline."gain-capture" {
 			Object.Base.audio_format.1 {
 				in_bit_depth		32
 				in_valid_bit_depth	32
-				dma_buffer_size "$[$obs * 2]"
 			}
 			# 24-bit 48KHz 2ch
 			Object.Base.audio_format.2 {
@@ -63,7 +62,6 @@ Class.Pipeline."gain-capture" {
 				in_valid_bit_depth	32
 				out_bit_depth		32
 				out_valid_bit_depth	24
-				dma_buffer_size "$[$obs * 2]"
 			}
 			# 32-bit 48KHz 2ch
 			Object.Base.audio_format.3 {
@@ -71,7 +69,6 @@ Class.Pipeline."gain-capture" {
 				in_valid_bit_depth	32
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$obs * 2]"
 			}
 			node_type $HDA_HOST_INPUT_CLASS
 		}
@@ -106,7 +103,6 @@ Class.Pipeline."gain-capture" {
 				in_valid_bit_depth	32
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$ibs * 2]"
 			}
 		}
 

--- a/tools/topology/topology2/include/pipelines/cavs/gain-copier-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/gain-copier-capture.conf
@@ -56,7 +56,6 @@ Class.Pipeline."gain-copier-capture" {
 			Object.Base.audio_format.1 {
 				in_bit_depth		32
 				in_valid_bit_depth	32
-				dma_buffer_size "$[$obs * 2]"
 			}
 			# 24-bit 48KHz 2ch
 			Object.Base.audio_format.2 {
@@ -64,7 +63,6 @@ Class.Pipeline."gain-copier-capture" {
 				in_valid_bit_depth	32
 				out_bit_depth		32
 				out_valid_bit_depth	24
-				dma_buffer_size "$[$obs * 2]"
 			}
 			# 32-bit 48KHz 2ch
 			Object.Base.audio_format.3 {
@@ -72,7 +70,6 @@ Class.Pipeline."gain-copier-capture" {
 				in_valid_bit_depth	32
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$obs * 2]"
 			}
 			node_type $HDA_HOST_INPUT_CLASS
 		}
@@ -107,7 +104,6 @@ Class.Pipeline."gain-copier-capture" {
 				in_valid_bit_depth	32
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$ibs * 2]"
 			}
 		}
 

--- a/tools/topology/topology2/include/pipelines/cavs/gain-module-copier.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/gain-module-copier.conf
@@ -74,7 +74,6 @@ Class.Pipeline."gain-module-copier" {
 				in_valid_bit_depth	32
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$ibs * 2]"
 			}
 		}
 

--- a/tools/topology/topology2/include/pipelines/cavs/gain-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/gain-playback.conf
@@ -54,7 +54,6 @@ Class.Pipeline."gain-playback" {
 			Object.Base.audio_format.1 {
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$ibs * 2]"
 			}
 			# 24-bit 48KHz 2ch
 			Object.Base.audio_format.2 {
@@ -62,7 +61,6 @@ Class.Pipeline."gain-playback" {
 				in_valid_bit_depth	24
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$obs * 2]"
 			}
 			# 32-bit 48KHz 2ch
 			Object.Base.audio_format.3 {
@@ -70,7 +68,6 @@ Class.Pipeline."gain-playback" {
 				in_valid_bit_depth	32
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$ibs * 2]"
 			}
 			node_type $HDA_HOST_OUTPUT_CLASS
 		}

--- a/tools/topology/topology2/include/pipelines/cavs/highpass-capture-be.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/highpass-capture-be.conf
@@ -49,7 +49,6 @@ Class.Pipeline."highpass-capture-be" {
 				in_valid_bit_depth	32
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$obs * 2]"
 			}
 		}
 

--- a/tools/topology/topology2/include/pipelines/cavs/host-copier-gain-mixin-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/host-copier-gain-mixin-playback.conf
@@ -56,7 +56,6 @@ Class.Pipeline."host-copier-gain-mixin-playback" {
 			Object.Base.audio_format.1 {
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$ibs * 2]"
 			}
 			# 24-bit 48KHz 2ch
 			Object.Base.audio_format.2 {
@@ -64,7 +63,6 @@ Class.Pipeline."host-copier-gain-mixin-playback" {
 				in_valid_bit_depth	24
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$obs * 2]"
 			}
 			# 32-bit 48KHz 2ch
 			Object.Base.audio_format.3 {
@@ -72,7 +70,6 @@ Class.Pipeline."host-copier-gain-mixin-playback" {
 				in_valid_bit_depth	32
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$ibs * 2]"
 			}
 		}
 

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-gain-dai-copier-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-gain-dai-copier-playback.conf
@@ -61,7 +61,6 @@ Class.Pipeline."mixout-gain-dai-copier-playback" {
 				in_valid_bit_depth	24
 				out_bit_depth		32
 				out_valid_bit_depth	24
-				dma_buffer_size "$[$obs * 2]"
 			}
 
 			Object.Base.audio_format.2 {
@@ -69,7 +68,6 @@ Class.Pipeline."mixout-gain-dai-copier-playback" {
 				in_valid_bit_depth	32
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$obs * 2]"
 			}
 		}
 		gain."1" {

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-gain-efx-dai-copier-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-gain-efx-dai-copier-playback.conf
@@ -65,7 +65,6 @@ Class.Pipeline."mixout-gain-efx-dai-copier-playback" {
 				in_valid_bit_depth	24
 				out_bit_depth		32
 				out_valid_bit_depth	24
-				dma_buffer_size "$[$obs * 2]"
 			}
 
 			Object.Base.audio_format.2 {
@@ -73,7 +72,6 @@ Class.Pipeline."mixout-gain-efx-dai-copier-playback" {
 				in_valid_bit_depth	32
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$obs * 2]"
 			}
 		}
 		gain."1" {

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-gain-host-copier-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-gain-host-copier-capture.conf
@@ -58,7 +58,6 @@ Class.Pipeline."mixout-gain-host-copier-capture" {
 			Object.Base.audio_format.1 {
 				in_bit_depth		32
 				in_valid_bit_depth	32
-				dma_buffer_size "$[$obs * 2]"
 			}
 			# 24-bit 48KHz 2ch
 			Object.Base.audio_format.2 {
@@ -66,7 +65,6 @@ Class.Pipeline."mixout-gain-host-copier-capture" {
 				in_valid_bit_depth	32
 				out_bit_depth		32
 				out_valid_bit_depth	24
-				dma_buffer_size "$[$obs * 2]"
 			}
 
 			Object.Base.audio_format.3 {
@@ -74,7 +72,6 @@ Class.Pipeline."mixout-gain-host-copier-capture" {
 				in_valid_bit_depth	24
 				out_bit_depth		32
 				out_valid_bit_depth	24
-				dma_buffer_size "$[$obs * 2]"
 			}
 
 			# 32-bit 48KHz 2ch
@@ -83,7 +80,6 @@ Class.Pipeline."mixout-gain-host-copier-capture" {
 				in_valid_bit_depth	32
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$obs * 2]"
 			}
 		}
 

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-gain-smart-amp-dai-copier-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-gain-smart-amp-dai-copier-playback.conf
@@ -58,7 +58,6 @@ Class.Pipeline."mixout-gain-smart-amp-dai-copier-playback" {
 				in_valid_bit_depth	24
 				out_bit_depth		32
 				out_valid_bit_depth	24
-				dma_buffer_size "$[$obs * 2]"
 			}
 
 			Object.Base.audio_format.2 {
@@ -66,7 +65,6 @@ Class.Pipeline."mixout-gain-smart-amp-dai-copier-playback" {
 				in_valid_bit_depth	32
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$obs * 2]"
 			}
 		}
 		gain."1" {

--- a/tools/topology/topology2/include/pipelines/cavs/passthrough-be.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/passthrough-be.conf
@@ -52,7 +52,6 @@ Class.Pipeline."passthrough-be" {
 				in_valid_bit_depth      24
 				out_bit_depth           32
 				out_valid_bit_depth     24
-				dma_buffer_size "$[$obs * 2]"
 			}
 
 			Object.Base.audio_format.1 {
@@ -60,7 +59,6 @@ Class.Pipeline."passthrough-be" {
 				in_valid_bit_depth	32
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$obs * 2]"
 			}
 			# 32-bit 48KHz 4ch
 			Object.Base.audio_format.2 {
@@ -70,7 +68,6 @@ Class.Pipeline."passthrough-be" {
 				out_channels		4
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$obs * 2]"
 				in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
 				in_ch_map	$CHANNEL_MAP_3_POINT_1
 				out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1

--- a/tools/topology/topology2/include/pipelines/cavs/passthrough-capture-be.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/passthrough-capture-be.conf
@@ -47,7 +47,6 @@ Class.Pipeline."passthrough-capture-be" {
 				in_valid_bit_depth	32
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$obs * 2]"
 			}
 		}
 

--- a/tools/topology/topology2/include/pipelines/cavs/passthrough-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/passthrough-capture.conf
@@ -54,7 +54,6 @@ Class.Pipeline."passthrough-capture" {
 			Object.Base.audio_format.1 {
 				in_bit_depth		32
 				in_valid_bit_depth	32
-				dma_buffer_size "$[$obs * 2]"
 			}
 			# 24-bit 48KHz 2ch
 			Object.Base.audio_format.2 {
@@ -62,7 +61,6 @@ Class.Pipeline."passthrough-capture" {
 				in_valid_bit_depth	32
 				out_bit_depth		32
 				out_valid_bit_depth	24
-				dma_buffer_size "$[$obs * 2]"
 			}
 			# 32-bit 48KHz 2ch
 			Object.Base.audio_format.3 {
@@ -70,7 +68,6 @@ Class.Pipeline."passthrough-capture" {
 				in_valid_bit_depth	32
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$obs * 2]"
 			}
 			# 16-bit output format 48KHz 4ch. Input sample format is always 32-bit for capture
 			Object.Base.audio_format.4 {
@@ -78,7 +75,6 @@ Class.Pipeline."passthrough-capture" {
 				in_bit_depth		32
 				in_valid_bit_depth	32
 				out_channels		4
-				dma_buffer_size "$[$obs * 2]"
 				in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
 				in_ch_map	$CHANNEL_MAP_3_POINT_1
 				out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
@@ -92,7 +88,6 @@ Class.Pipeline."passthrough-capture" {
 				out_bit_depth		32
 				out_valid_bit_depth	24
 				out_channels		4
-				dma_buffer_size "$[$obs * 2]"
 				in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
 				in_ch_map	$CHANNEL_MAP_3_POINT_1
 				out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
@@ -106,7 +101,6 @@ Class.Pipeline."passthrough-capture" {
 				out_bit_depth		32
 				out_valid_bit_depth	32
 				out_channels		4
-				dma_buffer_size "$[$obs * 2]"
 				in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
 				in_ch_map	$CHANNEL_MAP_3_POINT_1
 				out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1

--- a/tools/topology/topology2/include/pipelines/cavs/passthrough-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/passthrough-playback.conf
@@ -54,7 +54,6 @@ Class.Pipeline."passthrough-playback" {
 			Object.Base.audio_format.1 {
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$ibs * 2]"
 			}
 			# 24-bit 48KHz 2ch
 			Object.Base.audio_format.2 {
@@ -62,7 +61,6 @@ Class.Pipeline."passthrough-playback" {
 				in_valid_bit_depth	24
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$obs * 2]"
 			}
 			# 32-bit 48KHz 2ch
 			Object.Base.audio_format.3 {
@@ -70,7 +68,6 @@ Class.Pipeline."passthrough-playback" {
 				in_valid_bit_depth	32
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$ibs * 2]"
 			}
 		}
 

--- a/tools/topology/topology2/platform/intel/bt-generic.conf
+++ b/tools/topology/topology2/platform/intel/bt-generic.conf
@@ -32,7 +32,6 @@ Object.Pipeline {
 					out_valid_bit_depth	16
 					in_channels		2
 					out_channels		2
-					dma_buffer_size "$[$obs * 2]"
 				}
 				Object.Base.audio_format.2 {
 					in_bit_depth		16
@@ -43,7 +42,6 @@ Object.Pipeline {
 					out_channels		1
 					in_rate		8000
 					out_rate		8000
-					dma_buffer_size "$[$obs * 2]"
 				}
 				Object.Base.audio_format.3 {
 					in_bit_depth		16
@@ -54,7 +52,6 @@ Object.Pipeline {
 					out_channels		1
 					in_rate		16000
 					out_rate		16000
-					dma_buffer_size "$[$obs * 2]"
 				}
 			}
 		}
@@ -78,7 +75,6 @@ Object.Pipeline {
 					out_valid_bit_depth	16
 					in_channels		2
 					out_channels		2
-					dma_buffer_size "$[$obs * 2]"
 				}
 				Object.Base.audio_format.2 {
 					in_bit_depth		16
@@ -89,7 +85,6 @@ Object.Pipeline {
 					out_channels		1
 					in_rate		8000
 					out_rate		8000
-					dma_buffer_size "$[$obs * 2]"
 				}
 				Object.Base.audio_format.3 {
 					in_bit_depth		16
@@ -100,7 +95,6 @@ Object.Pipeline {
 					out_channels		1
 					in_rate		16000
 					out_rate		16000
-					dma_buffer_size "$[$obs * 2]"
 				}
 			}
 		}
@@ -125,7 +119,6 @@ Object.Pipeline {
 					out_valid_bit_depth	16
 					in_channels		2
 					out_channels		2
-					dma_buffer_size "$[$obs * 2]"
 				}
 				Object.Base.audio_format.2 {
 					in_bit_depth		16
@@ -136,7 +129,6 @@ Object.Pipeline {
 					out_channels		1
 					in_rate		8000
 					out_rate		8000
-					dma_buffer_size "$[$obs * 2]"
 				}
 				Object.Base.audio_format.3 {
 					in_bit_depth		16
@@ -147,7 +139,6 @@ Object.Pipeline {
 					out_channels		1
 					in_rate		16000
 					out_rate		16000
-					dma_buffer_size "$[$obs * 2]"
 				}
 			}
 		}
@@ -178,7 +169,6 @@ Object.Pipeline {
 					out_valid_bit_depth	16
 					in_channels		2
 					out_channels		2
-					dma_buffer_size "$[$obs * 2]"
 				}
 				Object.Base.audio_format.1 {
 					in_bit_depth		16
@@ -189,7 +179,6 @@ Object.Pipeline {
 					out_channels		1
 					in_rate		8000
 					out_rate		8000
-					dma_buffer_size "$[$obs * 2]"
 				}
 				Object.Base.audio_format.2 {
 					in_bit_depth		16
@@ -200,7 +189,6 @@ Object.Pipeline {
 					out_channels		1
 					in_rate		16000
 					out_rate		16000
-					dma_buffer_size "$[$obs * 2]"
 				}
 			}
 		}

--- a/tools/topology/topology2/platform/intel/dmic-generic.conf
+++ b/tools/topology/topology2/platform/intel/dmic-generic.conf
@@ -81,7 +81,6 @@ Object.Pipeline.gain-capture [
 				in_valid_bit_depth	32
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$ibs * 2]"
 			}
 			Object.Base.audio_format.2 {
 				in_channels		4
@@ -90,7 +89,6 @@ Object.Pipeline.gain-capture [
 				out_channels		4
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$ibs * 2]"
 				in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
 				in_ch_map	$CHANNEL_MAP_3_POINT_1
 				out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
@@ -106,7 +104,6 @@ Object.Pipeline.gain-capture [
 				in_valid_bit_depth	32
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$ibs * 2]"
 			}
 			Object.Base.audio_format.2 {
 				in_channels		4
@@ -115,7 +112,6 @@ Object.Pipeline.gain-capture [
 				out_channels		4
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$ibs * 2]"
 				in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
 				in_ch_map	$CHANNEL_MAP_3_POINT_1
 				out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
@@ -135,7 +131,6 @@ Object.Pipeline.gain-capture [
 				in_valid_bit_depth	32
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$ibs * 2]"
 			}
 			Object.Base.audio_format.2 {
 				in_channels		4
@@ -144,7 +139,6 @@ Object.Pipeline.gain-capture [
 				out_channels		4
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$ibs * 2]"
 				in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
 				in_ch_map	$CHANNEL_MAP_3_POINT_1
 				out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
@@ -173,7 +167,6 @@ Object.Pipeline.dai-copier-eqiir-module-copier-capture [
 				in_valid_bit_depth	32
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$ibs * 2]"
 			}
 			Object.Base.audio_format.2 {
 				in_channels		4
@@ -182,7 +175,6 @@ Object.Pipeline.dai-copier-eqiir-module-copier-capture [
 				out_channels		4
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$ibs * 2]"
 				in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
 				in_ch_map	$CHANNEL_MAP_3_POINT_1
 				out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
@@ -200,7 +192,6 @@ Object.Pipeline.dai-copier-eqiir-module-copier-capture [
 				in_valid_bit_depth	32
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$ibs * 2]"
 			}
 			Object.Base.audio_format.2 {
 				in_channels		4
@@ -209,7 +200,6 @@ Object.Pipeline.dai-copier-eqiir-module-copier-capture [
 				out_channels		4
 				out_bit_depth		32
 				out_valid_bit_depth	32
-				dma_buffer_size "$[$ibs * 2]"
 				in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
 				in_ch_map	$CHANNEL_MAP_3_POINT_1
 				out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1

--- a/tools/topology/topology2/platform/intel/dmic-wov.conf
+++ b/tools/topology/topology2/platform/intel/dmic-wov.conf
@@ -16,7 +16,6 @@ Object.Pipeline {
 					out_rate		16000
 					out_bit_depth		32
 					out_valid_bit_depth	32
-					dma_buffer_size "$[$ibs * 2]"
 				}
 				Object.Base.audio_format.2 {
 					in_rate			16000
@@ -27,7 +26,6 @@ Object.Pipeline {
 					out_channels		4
 					out_bit_depth		32
 					out_valid_bit_depth	32
-					dma_buffer_size "$[$ibs * 2]"
 					in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
 					in_ch_map	$CHANNEL_MAP_3_POINT_1
 					out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
@@ -64,7 +62,6 @@ Object.Pipeline {
 					out_rate		16000
 					out_bit_depth		32
 					out_valid_bit_depth	32
-					dma_buffer_size "$[$ibs * 2]"
 				}
 				Object.Base.audio_format.2 {
 					in_rate			16000
@@ -75,7 +72,6 @@ Object.Pipeline {
 					out_channels		4
 					out_bit_depth		32
 					out_valid_bit_depth	32
-					dma_buffer_size "$[$ibs * 2]"
 					in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
 					in_ch_map	$CHANNEL_MAP_3_POINT_1
 					out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1

--- a/tools/topology/topology2/platform/intel/speaker-echo-ref.conf
+++ b/tools/topology/topology2/platform/intel/speaker-echo-ref.conf
@@ -29,7 +29,6 @@ Object.Pipeline {
 					in_valid_bit_depth	32
 					out_bit_depth		32
 					out_valid_bit_depth	32
-					dma_buffer_size "$[$ibs * 2]"
 				}
 			}
 		}


### PR DESCRIPTION
There's been a recent kernel change to compute the DMA buffer size using the ibs/obs. So this attribute no longer needs to be set in the topology.