### PR TITLE
Some more topology cleanups

### DIFF
--- a/tools/topology/topology2/cavs-mixin-mixout-efx-hda.conf
+++ b/tools/topology/topology2/cavs-mixin-mixout-efx-hda.conf
@@ -80,7 +80,7 @@ Object.Pipeline {
 		}
 	]
 
-	passthrough-be [
+	io-gateway [
 		{
 			index		4
 			direction	capture

--- a/tools/topology/topology2/cavs-mixin-mixout-efx-hda.conf
+++ b/tools/topology/topology2/cavs-mixin-mixout-efx-hda.conf
@@ -33,6 +33,7 @@ Object.Pipeline {
 			index 2
 
 			Object.Widget.copier.1 {
+				node_type $HDA_LINK_OUTPUT_CLASS
 				stream_name $HDA_ANALOG_DAI_NAME
 				dai_type "HDA"
 				copier_type "HDA"

--- a/tools/topology/topology2/cavs-mixin-mixout-hda.conf
+++ b/tools/topology/topology2/cavs-mixin-mixout-hda.conf
@@ -33,6 +33,7 @@ Object.Pipeline {
 			index 2
 
 			Object.Widget.copier.1 {
+				node_type $HDA_LINK_OUTPUT_CLASS
 				stream_name $HDA_ANALOG_DAI_NAME
 				dai_type "HDA"
 				copier_type "HDA"

--- a/tools/topology/topology2/cavs-nocodec-bt.conf
+++ b/tools/topology/topology2/cavs-nocodec-bt.conf
@@ -12,7 +12,7 @@
 <virtual.conf>
 <passthrough-playback.conf>
 <passthrough-capture.conf>
-<passthrough-be.conf>
+<io-gateway.conf>
 <passthrough-capture-be.conf>
 <data.conf>
 <pcm.conf>
@@ -113,7 +113,7 @@ Object.Dai.SSP [
 # Pipeline ID:1 PCM ID: 0
 Object.Pipeline {
 	# playback pipelines
-	passthrough-be [
+	io-gateway [
 		{
 			index	2
 			direction	playback

--- a/tools/topology/topology2/cavs-rt5682.conf
+++ b/tools/topology/topology2/cavs-rt5682.conf
@@ -12,7 +12,7 @@
 <virtual.conf>
 <passthrough-playback.conf>
 <passthrough-capture.conf>
-<passthrough-be.conf>
+<io-gateway.conf>
 <passthrough-capture-be.conf>
 <host-copier-gain-mixin-playback.conf>
 <mixout-gain-dai-copier-playback.conf>

--- a/tools/topology/topology2/cavs-sdw.conf
+++ b/tools/topology/topology2/cavs-sdw.conf
@@ -17,7 +17,7 @@
 <deepbuffer-playback.conf>
 <passthrough-playback.conf>
 <passthrough-capture.conf>
-<passthrough-be.conf>
+<io-gateway.conf>
 <passthrough-capture-be.conf>
 <highpass-capture-be.conf>
 <data.conf>

--- a/tools/topology/topology2/cavs-src-mixin-mixout-hda.conf
+++ b/tools/topology/topology2/cavs-src-mixin-mixout-hda.conf
@@ -33,6 +33,7 @@ Object.Pipeline {
 			index 2
 
 			Object.Widget.copier.1 {
+				node_type $HDA_LINK_OUTPUT_CLASS
 				stream_name $HDA_ANALOG_DAI_NAME
 				dai_type "HDA"
 				copier_type "HDA"

--- a/tools/topology/topology2/cavs-src-mixin-mixout-hda.conf
+++ b/tools/topology/topology2/cavs-src-mixin-mixout-hda.conf
@@ -73,7 +73,7 @@ Object.Pipeline {
 		}
 	]
 
-	passthrough-be [
+	io-gateway [
 		{
 			index		4
 			direction	capture

--- a/tools/topology/topology2/include/pipelines/cavs/dai-copier-be.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/dai-copier-be.conf
@@ -37,7 +37,6 @@ Class.Pipeline."dai-copier-be" {
 	Object.Widget {
 		copier."1" {
 			type		dai_in
-			node_type	$HDA_LINK_OUTPUT_CLASS
 			num_audio_formats	3
 			num_input_audio_formats 3
 			num_output_audio_formats 3

--- a/tools/topology/topology2/include/pipelines/cavs/io-gateway.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/io-gateway.conf
@@ -1,12 +1,12 @@
 #
-# BE DAI passthrough pipeline
+# Just a Backend DAI
 #
 # All attributes defined herein are namespaced by alsatplg to
-# "Object.Pipeline.passthrough-be.N.attribute_name"
+# "Object.Pipeline.io-gateway.N.attribute_name"
 #
 # Usage: mixin-playback pipeline object can be instantiated as:
 #
-# Object.Pipeline.dai-pipeline."N" {
+# Object.Pipeline.io-gateway."N" {
 #	direction	"playback"
 # 	period		1000
 # 	time_domain	"timer"
@@ -21,7 +21,7 @@
 <include/components/copier.conf>
 <include/components/pipeline.conf>
 
-Class.Pipeline."passthrough-be" {
+Class.Pipeline."io-gateway" {
 
 	DefineAttribute."index" {}
 
@@ -33,8 +33,8 @@ Class.Pipeline."passthrough-be" {
 		]
 
 		#
-		# mixin-playback objects instantiated within the same alsaconf node must have
-		# unique pipeline_id attribute
+		# io-gateway objects instantiated within the same alsaconf node must have
+		# unique instance attribute
 		#
 		unique	"instance"
 	}

--- a/tools/topology/topology2/include/pipelines/cavs/io-gateway.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/io-gateway.conf
@@ -42,7 +42,6 @@ Class.Pipeline."io-gateway" {
 	Object.Widget {
 		copier."1" {
 			type dai_in
-			node_type $HDA_LINK_OUTPUT_CLASS
 			num_audio_formats 3
 			num_input_audio_formats 3
 			num_output_audio_formats 3

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-gain-dai-copier-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-gain-dai-copier-playback.conf
@@ -48,7 +48,6 @@ Class.Pipeline."mixout-gain-dai-copier-playback" {
 		mixout."1" {}
 		copier."1" {
 			type dai_in
-			node_type $HDA_LINK_OUTPUT_CLASS
 			period_sink_count 0
 			period_source_count 2
 			num_audio_formats 2

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-gain-efx-dai-copier-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-gain-efx-dai-copier-playback.conf
@@ -52,7 +52,6 @@ Class.Pipeline."mixout-gain-efx-dai-copier-playback" {
 		mixout."1" {}
 		copier."1" {
 			type dai_in
-			node_type $HDA_LINK_OUTPUT_CLASS
 			period_sink_count 0
 			period_source_count 2
 			num_audio_formats 2

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-gain-smart-amp-dai-copier-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-gain-smart-amp-dai-copier-playback.conf
@@ -47,7 +47,6 @@ Class.Pipeline."mixout-gain-smart-amp-dai-copier-playback" {
 		mixout."1" {}
 		copier."1" {
 			type dai_in
-			node_type $HDA_LINK_OUTPUT_CLASS
 			num_audio_formats 2
 			num_input_audio_formats 2
 			num_output_audio_formats 2

--- a/tools/topology/topology2/platform/intel/bt-generic.conf
+++ b/tools/topology/topology2/platform/intel/bt-generic.conf
@@ -8,7 +8,7 @@ IncludeByKey.BT_LOOPBACK_MODE {
 
 Object.Pipeline {
 	# playback pipelines
-	passthrough-be [
+	io-gateway [
 		{
 			index		$BT_PB_DAI_PIPELINE_ID
 			direction	playback

--- a/tools/topology/topology2/platform/intel/hdmi-generic.conf
+++ b/tools/topology/topology2/platform/intel/hdmi-generic.conf
@@ -58,7 +58,7 @@ Object.Pipeline {
 			use_chain_dma	$USE_CHAIN_DMA
 		}
 	]
-	passthrough-be [
+	io-gateway	 [
 		{
 			direction	"playback"
 			index $HDMI1_DAI_PIPELINE_ID
@@ -167,7 +167,7 @@ IncludeByKey.NUM_HDMIS {
 				direction playback
 			}
 		]
-		Object.Pipeline.passthrough-be [
+		Object.Pipeline.io-gateway [
 			{
 				direction	"playback"
 				index $HDMI4_DAI_PIPELINE_ID

--- a/tools/topology/topology2/platform/intel/hdmi-generic.conf
+++ b/tools/topology/topology2/platform/intel/hdmi-generic.conf
@@ -64,6 +64,7 @@ Object.Pipeline {
 			index $HDMI1_DAI_PIPELINE_ID
 
 			Object.Widget.copier.1 {
+				node_type $HDA_LINK_OUTPUT_CLASS
 				stream_name "iDisp1"
 				dai_type "HDA"
 				copier_type "HDA"
@@ -75,6 +76,7 @@ Object.Pipeline {
 			index $HDMI2_DAI_PIPELINE_ID
 
 			Object.Widget.copier.1 {
+				node_type $HDA_LINK_OUTPUT_CLASS
 				stream_name 'iDisp2'
 				dai_type "HDA"
 				copier_type "HDA"
@@ -85,6 +87,7 @@ Object.Pipeline {
 			direction	"playback"
 			index $HDMI3_DAI_PIPELINE_ID
 			Object.Widget.copier.1 {
+				node_type $HDA_LINK_OUTPUT_CLASS
 				stream_name 'iDisp3'
 				dai_type "HDA"
 				copier_type "HDA"
@@ -173,6 +176,7 @@ IncludeByKey.NUM_HDMIS {
 				index $HDMI4_DAI_PIPELINE_ID
 
 				Object.Widget.copier.1 {
+					node_type $HDA_LINK_OUTPUT_CLASS
 					stream_name 'iDisp4'
 					dai_type "HDA"
 					copier_type "HDA"

--- a/tools/topology/topology2/platform/intel/sdw-amp-generic.conf
+++ b/tools/topology/topology2/platform/intel/sdw-amp-generic.conf
@@ -71,7 +71,7 @@ IncludeByKey.NUM_SDW_AMPS {
 		}
 
 		Object.Pipeline {
-			passthrough-be [
+			io-gateway [
 				{
 					direction	"playback"
 					index $ALH_2ND_SPK_ID
@@ -163,7 +163,7 @@ IncludeByKey.SDW_AMP_FEEDBACK {
 				}
 			]
 
-			passthrough-be [
+			io-gateway [
 				{
 					direction	"capture"
 					index 31

--- a/tools/topology/topology2/sof-hda-generic.conf
+++ b/tools/topology/topology2/sof-hda-generic.conf
@@ -19,7 +19,7 @@
 <dai-copier-eqiir-module-copier-capture.conf>
 <gain-capture.conf>
 <deepbuffer-playback.conf>
-<passthrough-be.conf>
+<io-gateway.conf>
 <passthrough-capture-be.conf>
 <highpass-capture-be.conf>
 <data.conf>

--- a/tools/topology/topology2/sof-hda-generic.conf
+++ b/tools/topology/topology2/sof-hda-generic.conf
@@ -14,7 +14,6 @@
 <host-copier-gain-src-mixin-playback.conf>
 <mixout-gain-dai-copier-playback.conf>
 <mixout-gain-efx-dai-copier-playback.conf>
-<dai-copier-gain-mixin-capture.conf>
 <mixout-gain-host-copier-capture.conf>
 <dai-copier-eqiir-module-copier-capture.conf>
 <gain-capture.conf>


### PR DESCRIPTION
Rename passthrough-capture.conf to be-dai.conf
And remove setting the default node_type in the BE DAI pipeline class definitions and set them during pipeline object instantiation based on the DAI type.