### PR TITLE
Compile DMA domain by default for i.MX with Zephyr & enable tracing on i.MX platforms

### DIFF
--- a/src/include/sof/schedule/ll_schedule.h
+++ b/src/include/sof/schedule/ll_schedule.h
@@ -34,7 +34,7 @@ struct ll_task_pdata {
 	uint16_t skip_cnt;	/**< how many times the task was skipped for execution */
 };
 
-#if !defined(__ZEPHYR__) || (defined(CONFIG_IMX) && !CONFIG_DMA_DOMAIN)
+#if !defined(__ZEPHYR__)
 int scheduler_init_ll(struct ll_schedule_domain *domain);
 
 int schedule_task_init_ll(struct task *task,

--- a/src/platform/imx8/platform.c
+++ b/src/platform/imx8/platform.c
@@ -203,7 +203,6 @@ int platform_init(struct sof *sof)
 	if (ret < 0)
 		return -ENODEV;
 
-#ifndef __ZEPHYR__
 #if CONFIG_TRACE
 	/* Initialize DMA for Trace*/
 	trace_point(TRACE_BOOT_PLATFORM_DMA_TRACE);
@@ -212,7 +211,6 @@ int platform_init(struct sof *sof)
 
 	/* show heap status */
 	heap_trace_all(1);
-#endif /* __ZEPHYR__ */
 
 	return 0;
 }

--- a/src/platform/imx8m/platform.c
+++ b/src/platform/imx8m/platform.c
@@ -203,7 +203,6 @@ int platform_init(struct sof *sof)
 	if (ret < 0)
 		return -ENODEV;
 
-#ifndef __ZEPHYR__
 #if CONFIG_TRACE
 	/* Initialize DMA for Trace*/
 	trace_point(TRACE_BOOT_PLATFORM_DMA_TRACE);
@@ -212,7 +211,6 @@ int platform_init(struct sof *sof)
 
 	/* show heap status */
 	heap_trace_all(1);
-#endif /* __ZEPHYR__ */
 
 	return 0;
 }

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -276,12 +276,7 @@ if (CONFIG_SOC_SERIES_NXP_IMX8)
 		${SOF_SRC_PATH}/drivers/interrupt.c
 	)
 
-	# Zephyr DMA domain should only be used with zephyr_ll
-	if (NOT(CONFIG_DMA_DOMAIN))
-		zephyr_library_sources(${SOF_SRC_PATH}/schedule/ll_schedule.c)
-	else()
-		zephyr_library_sources(${SOF_SRC_PATH}/schedule/zephyr_ll.c)
-	endif()
+	zephyr_library_sources(${SOF_SRC_PATH}/schedule/zephyr_ll.c)
 
 	set(PLATFORM "imx8")
 endif()
@@ -309,12 +304,7 @@ if (CONFIG_SOC_SERIES_NXP_IMX8M)
 		${SOF_SRC_PATH}/drivers/interrupt.c
 	)
 
-	# Zephyr DMA domain should only be used with zephyr_ll
-	if (NOT(CONFIG_DMA_DOMAIN))
-		zephyr_library_sources(${SOF_SRC_PATH}/schedule/ll_schedule.c)
-	else()
-		zephyr_library_sources(${SOF_SRC_PATH}/schedule/zephyr_ll.c)
-	endif()
+	zephyr_library_sources(${SOF_SRC_PATH}/schedule/zephyr_ll.c)
 
 	set(PLATFORM "imx8m")
 endif()

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -29,13 +29,10 @@ config SOF_ZEPHYR_STRICT_HEADERS
 	  If unsure, say n.
 
 config DMA_DOMAIN
-	bool "Experimental: Enable the usage of DMA domain."
-	default n
+	bool "Enable the usage of DMA domain."
+	default y if IMX
 	help
 	  This enables the usage of the DMA domain in scheduling.
-	  This will most likely come to replace dma_multi_chan
-	  and dma_single_chan in Zephyr once it becomes more
-	  stable.
 
 config ZEPHYR_DP_SCHEDULER
 	bool "use Zephyr thread based DP scheduler"


### PR DESCRIPTION
DMA domain with Zephyr works fine for i.MX platforms. So, remove "experimental" from description and enable it by default for i.MX platforms.

Second patch enables tracing for i.MX platforms with zephyr.