### PR TITLE
xtensa-build-zephyr.py: log ALL "evil" environment differences

### DIFF
--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -270,7 +270,15 @@ def execute_command(*run_args, **run_kwargs):
 		cwd = run_kwargs.get('cwd')
 		print_cwd = f"In dir: {cwd}" if cwd else f"in current dir: {os.getcwd()}"
 		print_args = shlex.join(command_args)
-		print(f"{print_cwd}; running command: {print_args}", flush=True)
+		output = f"{print_cwd}; running command:\n    {print_args}"
+		env_arg = run_kwargs.get('env')
+		env_change = set(env_arg.items()) - set(os.environ.items()) if env_arg else None
+		if env_change:
+			output += "\n... with extra/modified environment:"
+			for k_v in env_change:
+				output += f"\n{k_v[0]}={k_v[1]}"
+		print(output, flush=True)
+
 
 	if run_kwargs.get('check') is None:
 		run_kwargs['check'] = True
@@ -568,8 +576,6 @@ def build_platforms():
 			TOOLCHAIN_VER = platform_dict["XTENSA_TOOLS_VERSION"]
 			XTENSA_CORE = platform_dict["XTENSA_CORE"]
 			platf_build_environ["TOOLCHAIN_VER"] = TOOLCHAIN_VER
-			print(f"XTENSA_TOOLCHAIN_PATH={XTENSA_TOOLCHAIN_PATH}")
-			print(f"TOOLCHAIN_VER={TOOLCHAIN_VER}")
 
 			# Set variables expected by xcc toolchain. CMake cannot set (evil) build-time
 			# environment variables at configure time:
@@ -578,7 +584,6 @@ def build_platforms():
 				TOOLCHAIN_VER).absolute())
 			XTENSA_SYSTEM = str(pathlib.Path(XTENSA_BUILDS_DIR, XTENSA_CORE, "config").absolute())
 			platf_build_environ["XTENSA_SYSTEM"] = XTENSA_SYSTEM
-			print(f"XTENSA_SYSTEM={XTENSA_SYSTEM}")
 
 		platform_build_dir_name = f"build-{platform}"
 


### PR DESCRIPTION
This is a typical example of why environment variables are (a sometimes necessary) evil: imagine you're trying to reproduce exactly the `west build` command run by xtensa-build-zephyr.py when building with the `xt-xcc` toolchain. So you would typically look at the logs, feel lucky that it shows the extra environment variables used and copy them:

```
XTENSA_TOOLCHAIN_PATH=/srv/home/jenkins/xcc/install/tools
TOOLCHAIN_VER=RG-2017.8-linux
XTENSA_SYSTEM=/home/jenkins/xcc/install/builds/RG-2017.8-linux/cavs...
In dir: workspace/sof; running: west build ...
```

Except this won't work because there's one variable currently missing: `ZEPHYR_TOOLCHAIN_VARIANT`!

Of course there could be more in the future.

Fix this by leveraging the recent os.environ.copy() added by commit 8aab18351fd6 ("xtensa-build-zephyr: fix DEFAULT_TOOLCHAIN_VARIANT spill on next platf") compare it to the current os.environ and show the difference in a totally generic, non-hardcoded way.