### PR TITLE
[IGNORE for now] xtensa-build-zephyr.py: forbid overlays in incremental builds

### DIFF
--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -582,16 +582,6 @@ def build_platforms():
 
 		platform_build_dir_name = f"build-{platform}"
 
-		# https://docs.zephyrproject.org/latest/guides/west/build-flash-debug.html#one-time-cmake-arguments
-		# https://github.com/zephyrproject-rtos/zephyr/pull/40431#issuecomment-975992951
-		abs_build_dir = pathlib.Path(west_top, platform_build_dir_name)
-		if (pathlib.Path(abs_build_dir, "build.ninja").is_file()
-		    or pathlib.Path(abs_build_dir, "Makefile").is_file()):
-			if args.cmake_args and not args.pristine:
-				print(args.cmake_args)
-				raise RuntimeError("Some CMake arguments are ignored in incremental builds, "
-						   + f"you must delete {abs_build_dir} first")
-
 		PLAT_CONFIG = platform_dict["PLAT_CONFIG"]
 		build_cmd = ["west"]
 		build_cmd += ["-v"] * args.verbose
@@ -624,6 +614,16 @@ def build_platforms():
 		if overlays:
 			overlays = ";".join(overlays)
 			build_cmd.append(f"-DOVERLAY_CONFIG={overlays}")
+
+		# https://docs.zephyrproject.org/latest/guides/west/build-flash-debug.html#one-time-cmake-arguments
+		# https://github.com/zephyrproject-rtos/zephyr/pull/40431#issuecomment-975992951
+		abs_build_dir = pathlib.Path(west_top, platform_build_dir_name)
+		if (pathlib.Path(abs_build_dir, "build.ninja").is_file()
+		    or pathlib.Path(abs_build_dir, "Makefile").is_file()):
+			if args.cmake_args and not args.pristine:
+				print(args.cmake_args)
+				raise RuntimeError("Some CMake arguments are ignored in incremental builds, "
+						   + f"you must delete {abs_build_dir} first")
 
 		# Build
 		try:

--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -618,10 +618,16 @@ def build_platforms():
 		# https://docs.zephyrproject.org/latest/guides/west/build-flash-debug.html#one-time-cmake-arguments
 		# https://github.com/zephyrproject-rtos/zephyr/pull/40431#issuecomment-975992951
 		abs_build_dir = pathlib.Path(west_top, platform_build_dir_name)
-		if (pathlib.Path(abs_build_dir, "build.ninja").is_file()
-		    or pathlib.Path(abs_build_dir, "Makefile").is_file()):
-			if args.cmake_args and not args.pristine:
-				print(args.cmake_args)
+		if not args.pristine and (
+			pathlib.Path(abs_build_dir, "build.ninja").is_file()
+			or pathlib.Path(abs_build_dir, "Makefile").is_file()
+		):
+			# Catch issues like https://github.com/zephyrproject-rtos/zephyr/issues/56501
+			if args.cmake_args or overlays:
+				print(f"ERROR: {args.cmake_args or overlays}")
+				print(
+		"Check https://docs.zephyrproject.org/latest/guides/west/build-flash-debug.html#one-time-cmake-arguments"
+				)
 				raise RuntimeError("Some CMake arguments are ignored in incremental builds, "
 						   + f"you must delete {abs_build_dir} first")
 


### PR DESCRIPTION
According to
https://docs.zephyrproject.org/latest/develop/west/build-flash-debug.html#one-time-cmake-arguments,
using overlays in incremental builds was never supposed to work. However
it seemed to work most of the time.

Since recent Zephyr issue
https://github.com/zephyrproject-rtos/zephyr/issues/56501 overlays can
now cause incremental builds to fail in extremely confusing ways. So nip
them in the bud with a much clearer error message.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>