### PR TITLE
schedule: zephyr_dma_domain: Make thread priority higher

### DIFF
--- a/src/schedule/zephyr_dma_domain.c
+++ b/src/schedule/zephyr_dma_domain.c
@@ -34,6 +34,7 @@ LOG_MODULE_DECLARE(ll_schedule, CONFIG_SOF_LOG_LEVEL);
 
 #define SEM_LIMIT 1
 #define ZEPHYR_PDOMAIN_STACK_SIZE 8192
+#define ZEPHYR_DMA_DOMAIN_THREAD_PRIO (CONFIG_NUM_PREEMPT_PRIORITIES - 1)
 
 K_KERNEL_STACK_ARRAY_DEFINE(zephyr_dma_domain_stack,
 			    CONFIG_CORE_COUNT,
@@ -305,7 +306,7 @@ static int zephyr_dma_domain_register(struct ll_schedule_domain *domain,
 				 dt,
 				 NULL,
 				 NULL,
-				 CONFIG_NUM_PREEMPT_PRIORITIES - 1,
+				 ZEPHYR_DMA_DOMAIN_THREAD_PRIO,
 				 0,
 				 K_FOREVER);
 


### PR DESCRIPTION
We need to make the Zephyr DMA domain thread's priorty higher than the logging thread priority. If this is not done we may have some issues such as some buzzing noises appearing after resuming a paused stream. This was the case for i.MX93. Presumably this is because the SAI FIFO is underrun (please correct me if I'm wrong).

This fixes the issue on i.MX93 but will require some more tests to make sure that it doesn't break anything on the other i.MX boards which will use Zephyr DMA domain. This is why I added the [DNM] tag.