### PR TITLE
common.h: Prevent error when compiling with Clang

### DIFF
--- a/src/include/sof/common.h
+++ b/src/include/sof/common.h
@@ -43,7 +43,7 @@
 	(compile_check(is_power_of_2(alignment)) ?				\
 	 ALIGN_UP_INTERNAL(size, alignment) : 0xBADCAFE)
 
-#ifdef __XCC__
+#if defined(__XCC__) || defined(__clang__)
 
 /*
  * xcc doesn't support __builtin_constant_p() so we can only do run-time
@@ -62,7 +62,7 @@
 	(size) & ~((alignment) - 1);						\
 })
 
-#else /* not __XCC__ */
+#else /* not __XCC__ or __clang__ */
 
 /* If we can't tell at compile time, assume it's OK and defer to run-time */
 #define COMPILE_TIME_ALIGNED(align) (!__builtin_constant_p(align) ||		\
@@ -82,7 +82,7 @@
 	(size) & ~((alignment) - 1);						\
 })
 
-#endif /* not __XCC__ */
+#endif /* not __XCC__ or __clang__ */
 
 #else /* not VERIFY_ALIGN */
 


### PR DESCRIPTION
Clang requires fields to have a constant size and does not support variable length array in structure causing build to to fail at compile_check()

```
error: fields must have a constant size: 'variable length array in structure' extension will never be supported
```

This change selects the compatible version of ALIGN_UP and ALIGN_DOWN macro when compiling with Clang.

While there's no official support for LLVM toolchain right now, this change should help in that direction.