### PR TITLE
app: remove old cavs platforms

### DIFF
--- a/app/sample.yaml
+++ b/app/sample.yaml
@@ -9,13 +9,9 @@ tests:
   sample.audio.sof:
     tags: sof
     build_only: true
-    platform_allow: intel_adsp_cavs15 intel_adsp_cavs18 intel_adsp_cavs20
-                    intel_adsp_cavs25 nxp_adsp_imx8 nxp_adsp_imx8x nxp_adsp_imx8m
+    platform_allow: intel_adsp_cavs25 nxp_adsp_imx8 nxp_adsp_imx8x nxp_adsp_imx8m
 
     integration_platforms:
-      - intel_adsp_cavs15
-      - intel_adsp_cavs18
-      - intel_adsp_cavs20
       - intel_adsp_cavs25
       - nxp_adsp_imx8
       - nxp_adsp_imx8x


### PR DESCRIPTION
Remove old platforms from zephyr testcase file:

- intel_adsp_cavs15
- intel_adsp_cavs18
- intel_adsp_cavs20

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
