### PR TITLE
rimage: Update rimage revision

### DIFF
--- a/src/include/sof/lib_manager.h
+++ b/src/include/sof/lib_manager.h
@@ -63,7 +63,7 @@
 #define __SOF_LIB_MANAGER_H__
 
 #include <stdint.h>
-#include <rimage/manifest.h>
+#include <rimage/sof/user/manifest.h>
 
 #define LIB_MANAGER_MAX_LIBS				16
 #define LIB_MANAGER_LIB_ID_SHIFT			12

--- a/west.yml
+++ b/west.yml
@@ -34,7 +34,7 @@ manifest:
     - name: rimage
       repo-path: rimage
       path: sof/rimage
-      revision: 9643a986dda97c6cb339d5c75c0eaa178d8317da
+      revision: ab0429fdbe563ef6abe499c69b2483e96c4762d0
 
     - name: tomlc99
       repo-path: tomlc99


### PR DESCRIPTION
Changed rimage submodule revision to 25804e7dc8ee37f3cb87b0a96b58300478cd3cff

lib_manager: Use correct manifest header from rimage

By mistake, the lib_manager module used a private manifest header from the rimage project. It included other private headers. Switched to the public header.
