### PR TITLE
audio: mixer: Fix inactive streams handling

### DIFF
--- a/src/audio/mixer/mixer.c
+++ b/src/audio/mixer/mixer.c
@@ -82,6 +82,7 @@ static int mixer_process(struct processing_module *mod,
 	struct mixer_data *md = module_get_private_data(mod);
 	struct comp_dev *dev = mod->dev;
 	const struct audio_stream __sparse_cache *sources_stream[PLATFORM_MAX_STREAMS];
+	int sources_indices[PLATFORM_MAX_STREAMS];
 	int32_t i = 0, j = 0;
 	uint32_t frames = INT32_MAX;
 	/* Redundant, but helps the compiler */
@@ -143,6 +144,7 @@ static int mixer_process(struct processing_module *mod,
 		if (avail_frames == 0)
 			continue;
 
+		sources_indices[j] = i;
 		sources_stream[j++] = mod->input_buffers[i].data;
 	}
 
@@ -152,7 +154,7 @@ static int mixer_process(struct processing_module *mod,
 
 	/* update source buffer consumed bytes */
 	for (i = 0; i < j; i++)
-		mod->input_buffers[i].consumed = source_bytes;
+		mod->input_buffers[sources_indices[i]].consumed = source_bytes;
 
 	return 0;
 }


### PR DESCRIPTION
The previous patch 908876cc5f introduced a bug where the wrong input buffer had the "consumed" field updated. This affected playing from _only_ the second input stream in weird ways (specifically, sound was slower and every other period I'd get a "no bytes to copy" message from the active host component).

This patch fixes the indexing for that update.

Fixes: 908876cc5f "audio: mixer: Improve handling of inactive input streams"