### PR TITLE
module_adapter: Propagate error from module specific callback

### DIFF
--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -170,13 +170,10 @@ int module_adapter_prepare(struct comp_dev *dev)
 	/* Prepare module */
 	ret = module_prepare(mod);
 	if (ret) {
-		if (ret == PPL_STATUS_PATH_STOP)
-			return ret;
-
-		comp_err(dev, "module_adapter_prepare() error %x: module prepare failed",
-			 ret);
-
-		return -EIO;
+		if (ret != PPL_STATUS_PATH_STOP)
+			comp_err(dev, "module_adapter_prepare() error %x: module prepare failed",
+				 ret);
+		return ret;
 	}
 
 	/* Get period_bytes first on prepare(). At this point it is guaranteed that the stream


### PR DESCRIPTION
When module_prepare() fails we need to return to calling module the exact specific error not just -EIO.

There is no real use for Host AP to receive an error code that doesn't reflect the actual error.