### PR TITLE
Introduce i.MX93 platform support

### DIFF
--- a/src/platform/Kconfig
+++ b/src/platform/Kconfig
@@ -125,6 +125,15 @@ config IMX8ULP
 	 Select if your target platform is imx8ulp-compatible.
 	 imx.8ulp support dsp.
 
+config IMX93_A55
+	bool "Build for NXP i.MX93 arm64 architecture (Zephyr-only)"
+	select BUILD_OUTPUT_BIN
+	select ZEPHYR_LOG
+	select HOST_PTABLE
+	select DMA_DOMAIN
+	help
+	 Select if your target platform is imx93-compatible.
+
 config RENOIR
 	bool "Build for Renoir"
 	select XT_INTERRUPT_LEVEL_5

--- a/src/platform/imx93_a55/CMakeLists.txt
+++ b/src/platform/imx93_a55/CMakeLists.txt
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+add_subdirectory(lib)
+
+add_local_sources(sof platform.c)

--- a/src/platform/imx93_a55/include/platform/drivers/idc.h
+++ b/src/platform/imx93_a55/include/platform/drivers/idc.h
@@ -1,0 +1,28 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright 2023 NXP
+ */
+
+#ifdef __ZEPHYR_RTOS_IDC_H__
+
+#ifndef __PLATFORM_DRIVERS_IDC_H__
+#define __PLATFORM_DRIVERS_IDC_H__
+
+#include <stdint.h>
+
+/* TODO: remove me if possible */
+
+struct idc_msg;
+
+static inline int idc_send_msg(struct idc_msg *msg, uint32_t mode)
+{
+	return 0;
+}
+
+#endif /* __PLATFORM_DRIVERS_IDC_H__ */
+
+#else
+
+#error "This file shouldn't be included from outside of Zephyr's rtos/idc.h"
+
+#endif /* __ZEPHYR_RTOS_IDC_H__ */

--- a/src/platform/imx93_a55/include/platform/drivers/interrupt.h
+++ b/src/platform/imx93_a55/include/platform/drivers/interrupt.h
@@ -1,0 +1,19 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright 2023 NXP
+ */
+
+#ifdef __SOF_DRIVERS_INTERRUPT_H__
+
+#ifndef __PLATFORM_DRIVERS_INTERRUPT_H__
+#define __PLATFORM_DRIVERS_INTERRUPT_H__
+
+/* TODO: remove me if possible */
+
+#endif /* __PLATFORM_DRIVERS_INTERRUPT_H__ */
+
+#else
+
+#error "This file shouldn't be included from outside of sof/drivers/interrupt.h"
+
+#endif /* __SOF_DRIVERS_INTERRUPT_H__ */

--- a/src/platform/imx93_a55/include/platform/lib/clk.h
+++ b/src/platform/imx93_a55/include/platform/lib/clk.h
@@ -1,0 +1,26 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright 2023 NXP
+ */
+
+#ifdef __SOF_LIB_CLK_H__
+
+#ifndef __PLATFORM_LIB_CLK_H__
+#define __PLATFORM_LIB_CLK_H___
+
+#define CLK_CPU(x) (x)
+#define CPU_DEFAULT_IDX 0
+#define NUM_CLOCKS 1
+#define NUM_CPU_FREQ 1
+
+struct sof;
+
+void platform_clock_init(struct sof *sof);
+
+#endif /* __PLATFORM_LIB_CLK_H__ */
+
+#else
+
+#error "This file shouldn't be included from outside of sof/lib/clk.h"
+
+#endif /* __SOF_LIB_CLK_H__ */

--- a/src/platform/imx93_a55/include/platform/lib/cpu.h
+++ b/src/platform/imx93_a55/include/platform/lib/cpu.h
@@ -1,0 +1,23 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright 2023 NXP
+ */
+
+#ifdef __SOF_LIB_CPU_H__
+
+#ifndef __PLATFORM_LIB_CPU_H__
+#define __PLATFORM_LIB_CPU_H__
+
+/* note: although the core assigned to the inmate
+ * might not have the ID = 0 according to Linux,
+ * Zephyr will still index its cores starting from 0.
+ */
+#define PLATFORM_PRIMARY_CORE_ID 0
+
+#endif /* __PLATFORM_LIB_CPU_H__ */
+
+#else
+
+#error "This file shouldn't be included from outside of sof/lib/cpu.h"
+
+#endif /* __SOF_LIB_CPU_H__ */

--- a/src/platform/imx93_a55/include/platform/lib/dai.h
+++ b/src/platform/imx93_a55/include/platform/lib/dai.h
@@ -1,0 +1,19 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright 2023 NXP
+ */
+
+#ifdef __SOF_LIB_DAI_H__
+
+#ifndef __PLATFORM_LIB_DAI_H__
+#define __PLATFORM_LIB_DAI_H__
+
+/* TODO: remove me whenever possible */
+
+#endif /* __PLATFORM_LIB_DAI_H__ */
+
+#else
+
+#error "This file shouldn't be included from outside of sof/lib/dai.h"
+
+#endif /* __SOF_LIB_DAI_H__ */

--- a/src/platform/imx93_a55/include/platform/lib/dma.h
+++ b/src/platform/imx93_a55/include/platform/lib/dma.h
@@ -1,0 +1,30 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright 2023 NXP
+ */
+
+#ifdef __SOF_LIB_DMA_H__
+
+#ifndef __PLATFORM_LIB_DMA_H__
+#define __PLATFORM_LIB_DMA_H__
+
+/* i.MX93 uses dummy DMA and EDMA */
+#define PLATFORM_NUM_DMACS 2
+
+#define DMA_ID_EDMA2 0
+#define DMA_ID_HOST 1
+
+/* TODO: this is already defined with EDMA2_CHAN_MAX */
+#define PLATFORM_MAX_DMA_CHAN 64
+
+/* TODO: required by Zephyr DMA domain to work */
+#define dma_chan_irq_name(dma, chan) dma_irq_name(dma)
+#define dma_chan_irq(dma, chan) ((int *)(dma)->plat_data.drv_plat_data)[chan]
+
+#endif /* __PLATFORM_LIB_DMA_H__ */
+
+#else
+
+#error "This file shouldn't be included from outside of sof/lib/dma.h"
+
+#endif /* __SOF_LIB_DMA_H__ */

--- a/src/platform/imx93_a55/include/platform/lib/mailbox.h
+++ b/src/platform/imx93_a55/include/platform/lib/mailbox.h
@@ -1,0 +1,67 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright 2023 NXP
+ */
+
+#ifdef __SOF_LIB_MAILBOX_H__
+
+#ifndef __PLATFORM_LIB_MAILBOX_H__
+#define __PLATFORM_LIB_MAILBOX_H__
+
+/* i.MX93's mailbox is organized as follows:
+ *
+ * +---------------+----------------------+------------------------+-----------+
+ * | Region name   | Base address  | Offset |  Size   |      Permissions       |
+ * +---------------+---------------+--------+---------+------------------------+
+ * | Inbox region  |   0xce100000  |   0    | 0x1000  | ROOT: R/W, INMATE: R/W |
+ * +---------------+---------------+--------+---------+------------------------+
+ * | Outbox region |   0xce101000  | 0x1000 | 0x1000  | ROOT: R/W, INMATE: R/W |
+ * +---------------+---------------+--------+---------+------------+-----------+
+ * | Stream region |   0xce102000  | 0x2000 | 0x1000  | ROOT: R/W, INMATE: R/W |
+ * +---------------+---------------+--------+---------+------------------------+
+ *
+ *
+ * RESTRICTIONS:
+ *	* the inbox region always needs to be placed at offset 0
+ *	relative to the mailbox memory region used by the Linux host
+ *	driver. Other than that, there's no restrictions regarding the
+ *	placement of these mailbox regions.
+ *
+ * Notes:
+ *	* if there's a need to add new regions, simply append the
+ *	new regions to the above table and create memory regions
+ *	inside the Jailhouse configurations for root/inmate cells.
+ *	Also, please make sure that the Linux host driver is also
+ *	aware of these new regions.
+ *
+ *	* although these regions are placed one after the other please
+ *	note that this isn't a restriction. If there's a need to place
+ *	these regions elsewhere please not that the offset is relative
+ *	to the mailbox memory region used by the Linux host driver.
+ *
+ *	* TODO: root and inmate shouldn't have the same permissions, fix
+ *	it.
+ */
+
+/* inbox */
+#define MAILBOX_HOSTBOX_SIZE 0x1000
+#define MAILBOX_HOSTBOX_BASE 0xce100000
+#define MAILBOX_HOSTBOX_OFFSET 0
+
+/* outbox */
+#define MAILBOX_DSPBOX_SIZE 0x1000
+#define MAILBOX_DSPBOX_BASE 0xce101000
+#define MAILBOX_DSPBOX_OFFSET (MAILBOX_HOSTBOX_OFFSET + MAILBOX_HOSTBOX_SIZE)
+
+/* stream */
+#define MAILBOX_STREAM_SIZE 0x1000
+#define MAILBOX_STREAM_BASE 0xce102000
+#define MAILBOX_STREAM_OFFSET (MAILBOX_DSPBOX_OFFSET + MAILBOX_DSPBOX_SIZE)
+
+#endif /* __PLATFORM_LIB_MAILBOX_H__ */
+
+#else
+
+#error "This file shouldn't be included from outside of sof/lib/mailbox.h"
+
+#endif /* __SOF_LIB_MAILBOX_H__ */

--- a/src/platform/imx93_a55/include/platform/lib/memory.h
+++ b/src/platform/imx93_a55/include/platform/lib/memory.h
@@ -1,0 +1,72 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright 2023 NXP
+ */
+
+#ifdef __SOF_LIB_MEMORY_H__
+
+#ifndef __PLATFORM_LIB_MEMORY_H__
+#define __PLATFORM_LIB_MEMORY_H__
+
+#include <rtos/cache.h>
+
+#define PLATFORM_DCACHE_ALIGN DCACHE_LINE_SIZE
+
+/* seems like in xtensa architecture cached data
+ * may be placed at some special addresses in the
+ * SRAM?
+ *
+ * since we're running on A55 cores, there's no such
+ * thing so all the below cache/shared data "management"
+ * functions aren't necessary.
+ */
+#define SHARED_DATA
+
+#define uncache_to_cache(address) address
+#define cache_to_uncache(address) address
+#define cache_to_uncache_init(address) address
+#define is_uncached(address) 0
+
+/* number of heaps to be used.
+ *
+ * i.MX93 is non-SMP so we're only going to use 1 heap.
+ */
+#define PLATFORM_HEAP_SYSTEM 1
+#define PLATFORM_HEAP_SYSTEM_RUNTIME 1
+#define PLATFORM_HEAP_RUNTIME 1
+#define PLATFORM_HEAP_BUFFER 1
+
+/* host and firmware use shared memory */
+#define host_to_local(addr) (addr)
+#define local_to_host(addr) (addr)
+
+/* if this gets too big then it will be
+ * necessary to increase the SRAM size from
+ * the Zephyr DTS. This should be fine as
+ * we're going to reserve 800MB for Jailhouse
+ * usage.
+ */
+#define HEAPMEM_SIZE 0x00010000
+
+/* SOF uses A side of the WAKEUPMIX MU */
+#define MU_BASE 0x42430000
+
+/* SOF uses EDMA2 (a.k.a EDMA4 in the TRM) */
+#define EDMA2_BASE 0x42010000
+#define EDMA2_CHAN_SIZE 0x8000
+
+/* WM8962 is connected to SAI3 */
+#define SAI3_BASE 0x42660000
+
+static inline void *platform_shared_get(void *ptr, int bytes)
+{
+	return ptr;
+}
+
+#endif /* __PLATFORM_LIB_MEMORY_H__ */
+
+#else
+
+#error "This file shouldn't be included from outside of sof/lib/memory.h"
+
+#endif /* __SOF_LIB_MEMORY_H__*/

--- a/src/platform/imx93_a55/include/platform/lib/pm_runtime.h
+++ b/src/platform/imx93_a55/include/platform/lib/pm_runtime.h
@@ -1,0 +1,56 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright 2023 NXP
+ */
+
+#ifdef __SOF_LIB_PM_RUNTIME_H__
+
+#ifndef __PLATFORM_LIB_PM_RUNTIME_H__
+#define __PLATFORM_LIB_PM_RUNTIME_H__
+
+/* TODO: is this required? Should this be implemented using Zephyr PM
+ * API?
+ */
+#include <stdint.h>
+
+struct pm_runtime_data;
+
+static inline void platform_pm_runtime_init(struct pm_runtime_data *prd)
+{
+}
+
+static inline void platform_pm_runtime_get(uint32_t context,
+					   uint32_t index,
+					   uint32_t flags)
+{
+}
+
+static inline void platform_pm_runtime_put(uint32_t context,
+					   uint32_t index,
+					   uint32_t flags)
+{
+}
+
+static inline void platform_pm_runtime_enable(uint32_t context,
+					      uint32_t index)
+{
+}
+
+static inline void platform_pm_runtime_disable(uint32_t context,
+					       uint32_t index)
+{
+}
+
+static inline bool platform_pm_runtime_is_active(uint32_t context,
+						 uint32_t index)
+{
+	return false;
+}
+
+#endif /* __PLATFORM_LIB_PM_RUNTIME_H__ */
+
+#else
+
+#error "This file shouldn't be included from outside of sof/lib/pm_runtime.h"
+
+#endif /* __SOF_LIB_PM_RUNTIME_H__ */

--- a/src/platform/imx93_a55/include/platform/platform.h
+++ b/src/platform/imx93_a55/include/platform/platform.h
@@ -1,0 +1,35 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright 2023 NXP
+ */
+
+#ifdef __SOF_PLATFORM_H__
+
+#ifndef __PLATFORM_PLATFORM_H__
+#define __PLATFORM_PLATFORM_H__
+
+#define PLATFORM_DEFAULT_CLOCK CLK_CPU(0)
+
+/* host uses 4KB page granularity */
+#define HOST_PAGE_SIZE 4096
+
+#define PLATFORM_PAGE_TABLE_SIZE 256
+
+/* TODO: these values are taken from i.MX8 platform */
+#define PLATFORM_MAX_CHANNELS 4
+#define PLATFORM_MAX_STREAMS 5
+
+/* SOF uses A side of the WAKEUPMIX MU.
+ * We need to add 32 (SPI_BASE) to the
+ * INTID found in the TRM since all the
+ * interrupt IDs here are SPIs.
+ */
+#define PLATFORM_IPC_INTERRUPT (23 + 32)
+
+#endif /* __PLATFORM_PLATFORM_H__ */
+
+#else
+
+#error "This file shouldn't be included from outside of sof/platform.h"
+
+#endif /* __SOF_PLATFORM_H__ */

--- a/src/platform/imx93_a55/include/platform/trace/trace.h
+++ b/src/platform/imx93_a55/include/platform/trace/trace.h
@@ -1,0 +1,19 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright 2023 NXP
+ */
+
+#ifdef __SOF_TRACE_TRACE_H__
+
+#ifndef __PLATFORM_TRACE_TRACE_H__
+#define __PLATFORM_TRACE_TRACE_H__
+
+/* TODO: remove me whenever possible */
+
+#endif /* __PLATFORM_TRACE_TRACE_H__ */
+
+#else
+
+#error "This file shouldn't be included from outside of sof/trace/trace.h"
+
+#endif /* __SOF_TRACE_TRACE_H__ */

--- a/src/platform/imx93_a55/lib/clk.c
+++ b/src/platform/imx93_a55/lib/clk.c
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright 2023 NXP
+ */
+
+#include <rtos/clk.h>
+#include <sof/lib/notifier.h>
+
+static const struct freq_table platform_cpu_freq[] = {
+	{ CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC,
+		CONFIG_SYS_CLOCK_TICKS_PER_SEC * 1000 },
+};
+
+static struct clock_info platform_clocks_info[NUM_CLOCKS];
+
+void platform_clock_init(struct sof *sof)
+{
+	int i;
+
+	sof->clocks = platform_clocks_info;
+
+	/* The CCM doesn't seem to allow setting a core's
+	 * frequency. It probably sets the whole cluster's
+	 * frequency to some value (not relevant). Since
+	 * we're running on top of Jailhouse we don't want
+	 * to allow SOF to change the cluster's frequency
+	 * since that would also affect Linux.
+	 *
+	 * Also, as a consequence to this, on SMP systems,
+	 * NUM_CLOCKS and CONFIG_CORE_COUNT will probably
+	 * differ so watch out for this when using the below
+	 * code. In the case of i.MX93 this is fince since
+	 * SOF runs on a single core.
+	 */
+	for (i = 0; i < CONFIG_CORE_COUNT; i++) {
+		sof->clocks[i] = (struct clock_info) {
+			.freqs_num = NUM_CPU_FREQ,
+			.freqs = platform_cpu_freq,
+			.default_freq_idx = CPU_DEFAULT_IDX,
+			.current_freq_idx = CPU_DEFAULT_IDX,
+			.notification_id = NOTIFIER_ID_CPU_FREQ,
+			.notification_mask = NOTIFIER_TARGET_CORE_MASK(i),
+			.set_freq = NULL,
+		};
+	}
+}

--- a/src/platform/imx93_a55/lib/dai.c
+++ b/src/platform/imx93_a55/lib/dai.c
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright 2023 NXP
+ */
+
+#include <rtos/sof.h>
+#include <sof/drivers/sai.h>
+#include <sof/drivers/edma.h>
+#include <sof/lib/memory.h>
+
+static struct dai sai[] = {
+	{
+		.index = 3, /* SOF uses SAI3 */
+		.plat_data = {
+			.base = SAI3_BASE,
+			.fifo[SOF_IPC_STREAM_PLAYBACK] = {
+				.offset = SAI3_BASE + REG_SAI_TDR0,
+				.depth = 128, /* number of 32-bit words */
+				.watermark = 64, /* needs to be half the depth */
+				.handshake = EDMA_HANDSHAKE(EDMA2_SAI3_CHAN_TX_IRQ,
+							    EDMA2_SAI3_CHAN_TX,
+							    EDMA2_SAI3_TX_MUX),
+			},
+			.fifo[SOF_IPC_STREAM_CAPTURE] = {
+				.offset = SAI3_BASE + REG_SAI_RDR0,
+				.depth = 128,
+				.watermark = 64,
+				.handshake = EDMA_HANDSHAKE(EDMA2_SAI3_CHAN_RX_IRQ,
+							    EDMA2_SAI3_CHAN_RX,
+							    EDMA2_SAI3_RX_MUX),
+			},
+		},
+		.drv = &sai_driver,
+	},
+};
+
+static const struct dai_type_info dti[] = {
+	{
+		.type = SOF_DAI_IMX_SAI,
+		.dai_array = sai,
+		.num_dais = ARRAY_SIZE(sai),
+	},
+};
+
+static const struct dai_info lib_dai = {
+	.dai_type_array = dti,
+	.num_dai_types = ARRAY_SIZE(dti)
+};
+
+int dai_init(struct sof *sof)
+{
+	int i;
+
+	for (i = 0; i < ARRAY_SIZE(sai); i++)
+		k_spinlock_init(&dti[0].dai_array[i].lock);
+
+	sof->dai_info = &lib_dai;
+
+	return 0;
+}

--- a/src/platform/imx93_a55/lib/dma.c
+++ b/src/platform/imx93_a55/lib/dma.c
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright 2023 NXP
+ */
+
+#include <rtos/sof.h>
+#include <sof/lib/dma.h>
+#include <sof/drivers/edma.h>
+
+extern struct dma_ops dummy_dma_ops;
+extern struct dma_ops edma_ops;
+
+static const int edma2_ints[EDMA2_CHAN_MAX] = {
+	[EDMA2_SAI3_CHAN_RX] = EDMA2_SAI3_CHAN_RX_IRQ,
+	[EDMA2_SAI3_CHAN_TX] = EDMA2_SAI3_CHAN_TX_IRQ,
+};
+
+static struct dma dma[PLATFORM_NUM_DMACS] = {
+	{
+		.plat_data = {
+			.id = DMA_ID_EDMA2,
+			.dir = DMA_DIR_MEM_TO_DEV | DMA_DIR_DEV_TO_MEM,
+			.devs = DMA_DEV_SAI,
+			.base = EDMA2_BASE,
+			.chan_size = EDMA2_CHAN_SIZE,
+			.channels = EDMA2_CHAN_MAX,
+			.drv_plat_data = edma2_ints,
+		},
+		.ops = &edma_ops,
+	},
+	{
+		.plat_data = {
+			.id = DMA_ID_HOST,
+			.dir = DMA_DIR_HMEM_TO_LMEM | DMA_DIR_LMEM_TO_HMEM,
+			.devs = DMA_DEV_HOST,
+			.channels = 16
+		},
+		.ops = &dummy_dma_ops,
+	},
+};
+
+static const struct dma_info lib_dma = {
+	.dma_array = dma,
+	.num_dmas = ARRAY_SIZE(dma)
+};
+
+int dmac_init(struct sof *sof)
+{
+	int i;
+
+	/* early lock initialization for ref counting */
+	for (i = 0; i < ARRAY_SIZE(dma); i++)
+		k_spinlock_init(&dma[i].lock);
+
+	sof->dma_info = &lib_dma;
+
+	return 0;
+}

--- a/src/platform/imx93_a55/platform.c
+++ b/src/platform/imx93_a55/platform.c
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright 2023 NXP
+ */
+
+#include <rtos/sof.h>
+#include <rtos/clk.h>
+#include <sof/lib/dma.h>
+#include <sof/lib/dai.h>
+#include <sof/schedule/edf_schedule.h>
+#include <sof/schedule/ll_schedule.h>
+#include <sof/schedule/ll_schedule_domain.h>
+#include <sof/lib/mailbox.h>
+#include <sof/drivers/mu.h>
+#include <sof/fw-ready-metadata.h>
+#include <sof_versions.h>
+#include <kernel/abi.h>
+#include <sof/debug/debug.h>
+
+static const struct sof_ipc_fw_ready ready = {
+	.hdr = {
+		.cmd = SOF_IPC_FW_READY,
+		.size = sizeof(struct sof_ipc_fw_ready),
+	},
+	.version = {
+		.hdr.size = sizeof(struct sof_ipc_fw_version),
+		.micro = SOF_MICRO,
+		.minor = SOF_MINOR,
+		.major = SOF_MAJOR,
+		.build = -1,
+		.date = "dtermin.\0",
+		.time = "fwready.\0",
+		.tag = SOF_TAG,
+		.abi_version = SOF_ABI_VERSION,
+		.src_hash = SOF_SRC_HASH,
+	},
+	.flags = DEBUG_SET_FW_READY_FLAGS,
+};
+
+static const struct sof_ipc_window windows = {
+	.ext_hdr = {
+		.hdr.cmd = SOF_IPC_FW_READY,
+		.hdr.size = sizeof(struct sof_ipc_window),
+		.type = SOF_IPC_EXT_WINDOW,
+	},
+	.num_windows = 3,
+	.window = {
+		{
+			.type = SOF_IPC_REGION_DOWNBOX,
+			.flags = 0,
+			.size = MAILBOX_HOSTBOX_SIZE,
+			.offset = MAILBOX_HOSTBOX_OFFSET,
+		},
+		{
+			.type = SOF_IPC_REGION_UPBOX,
+			.id = 0,
+			.flags = 0,
+			.size = MAILBOX_DSPBOX_SIZE,
+			.offset = MAILBOX_DSPBOX_OFFSET,
+		},
+		{
+			.type = SOF_IPC_REGION_STREAM,
+			.id = 0,
+			.flags = 0,
+			.size = MAILBOX_STREAM_SIZE,
+			.offset = MAILBOX_STREAM_OFFSET,
+		},
+	},
+};
+
+int platform_boot_complete(uint32_t boot_message)
+{
+	struct sof_ipc_reply reply;
+
+	/* prepare reply header */
+	reply.error = 0;
+	reply.hdr.cmd = SOF_IPC_FW_READY;
+	reply.hdr.size = sizeof(reply);
+
+	/* copy reply header to hostbox */
+	mailbox_hostbox_write(0, &reply, sizeof(reply));
+
+	/* copy firmware ready data to hostbox */
+	mailbox_hostbox_write(sizeof(reply), &ready, sizeof(ready));
+
+	/* write manifest data after firmware ready */
+	mailbox_hostbox_write(sizeof(reply) + sizeof(ready),
+			      &windows,
+			      sizeof(windows));
+
+	/* we can return, the IPC handler will take care of the doorbell */
+	return 1;
+}
+
+int platform_context_save(struct sof *sof)
+{
+	/* TODO: nothing to do here, remove me if possible */
+	return 0;
+}
+
+int platform_init(struct sof *sof)
+{
+	int ret;
+
+	/* Initialize clock data */
+	/* TODO: is this really required? */
+	platform_clock_init(sof);
+
+	/* Initialize EDF scheduler */
+	scheduler_init_edf();
+
+	/* Initialize Zephyr domain and timer-based scheduler */
+	sof->platform_timer_domain = zephyr_domain_init(PLATFORM_DEFAULT_CLOCK);
+	zephyr_ll_scheduler_init(sof->platform_timer_domain);
+
+	/* Initialize DMAC data */
+	ret = dmac_init(sof);
+	if (ret < 0)
+		return -ENODEV;
+
+	/* Initialize DMA domain */
+	sof->platform_dma_domain = zephyr_dma_domain_init(&sof->dma_info->dma_array[0],
+							  1,
+							  PLATFORM_DEFAULT_CLOCK);
+	zephyr_ll_scheduler_init(sof->platform_dma_domain);
+
+	/* Initialize IPC */
+	ipc_init(sof);
+
+	/* Initialize DAI */
+	dai_init(sof);
+
+	/* We're all set */
+	return 0;
+}


### PR DESCRIPTION
This PR introduces all the necessary changes for running SOF using Zephyr and Jailhouse on i.MX93's A55 core.

Will update  https://github.com/thesofproject/sof/issues/7192 to contain a short description of our solution and all of its quirks. (**EDIT**: this is now up)

**EDIT**: Depends on Zephyr PR: https://github.com/zephyrproject-rtos/zephyr/pull/56713