### PR TITLE
imx: sai: enable transmitter to output MCLK

### DIFF
--- a/src/drivers/imx/sai.c
+++ b/src/drivers/imx/sai.c
@@ -89,10 +89,6 @@ static void sai_start(struct dai *dai, int direction)
 	/* enable DMA requests */
 	dai_update_bits(dai, REG_SAI_XCSR(direction),
 			REG_SAI_CSR_FRDE, REG_SAI_CSR_FRDE);
-#ifdef CONFIG_IMX8M
-	dai_update_bits(dai, REG_SAI_MCTL, REG_SAI_MCTL_MCLK_EN,
-			REG_SAI_MCTL_MCLK_EN);
-#endif
 
 	chan_idx = BIT(0);
 	/* RX3 supports capture on imx8ulp */
@@ -363,6 +359,17 @@ static inline int sai_set_config(struct dai *dai, struct ipc_config_dai *common_
 	/* turn on (set to zero) stereo slot */
 	dai_update_bits(dai, REG_SAI_XMR(REG_RX_DIR), REG_SAI_XMR_MASK,
 			twm);
+
+#ifdef CONFIG_IMX8M
+	/*
+	 * For i.MX8MP, MCLK is bound with TX enable bit.
+	 * Therefore, enable transmitter to output MCLK
+	 */
+	dai_update_bits(dai, REG_SAI_XCSR(DAI_DIR_PLAYBACK),
+			REG_SAI_CSR_TERE, REG_SAI_CSR_TERE);
+	dai_update_bits(dai, REG_SAI_MCTL, REG_SAI_MCTL_MCLK_EN,
+			REG_SAI_MCTL_MCLK_EN);
+#endif
 
 	return 0;
 }


### PR DESCRIPTION
On i.MX8MP, the SAI MCLK is bound with TX enable bit. Therefore, in order to enable MCLK, we need to enable the transmitter.

This fixes a "wm8962 2-001a: DC servo timed out" - a Linux Kernel error with wm8962 codec.

Signed-off-by: Laurentiu Mihalcea <laurentiu.mihalcea@nxp.com>
Signed-off-by: Iuliana Prodan <iuliana.prodan@nxp.com>
(cherry picked from commit 1754bf97ec1fea02668629cfe916a7f2474c5d72)