### PR TITLE
xtensa-build-zephyr.py: downgrade --cmake-args restriction to a warning

### DIFF
--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -587,16 +587,6 @@ def build_platforms():
 
 		platform_build_dir_name = f"build-{platform}"
 
-		# https://docs.zephyrproject.org/latest/guides/west/build-flash-debug.html#one-time-cmake-arguments
-		# https://github.com/zephyrproject-rtos/zephyr/pull/40431#issuecomment-975992951
-		abs_build_dir = pathlib.Path(west_top, platform_build_dir_name)
-		if (pathlib.Path(abs_build_dir, "build.ninja").is_file()
-		    or pathlib.Path(abs_build_dir, "Makefile").is_file()):
-			if args.cmake_args and not args.pristine:
-				print(args.cmake_args)
-				raise RuntimeError("Some CMake arguments are ignored in incremental builds, "
-						   + f"you must delete {abs_build_dir} first")
-
 		PLAT_CONFIG = platform_dict["PLAT_CONFIG"]
 		build_cmd = ["west"]
 		build_cmd += ["-v"] * args.verbose
@@ -629,6 +619,16 @@ def build_platforms():
 		if overlays:
 			overlays = ";".join(overlays)
 			build_cmd.append(f"-DOVERLAY_CONFIG={overlays}")
+
+		# https://docs.zephyrproject.org/latest/guides/west/build-flash-debug.html#one-time-cmake-arguments
+		# https://github.com/zephyrproject-rtos/zephyr/pull/40431#issuecomment-975992951
+		abs_build_dir = pathlib.Path(west_top, platform_build_dir_name)
+		if (pathlib.Path(abs_build_dir, "build.ninja").is_file()
+		    or pathlib.Path(abs_build_dir, "Makefile").is_file()):
+			if args.cmake_args and not args.pristine:
+				print(args.cmake_args)
+				raise RuntimeError("Some CMake arguments are ignored in incremental builds, "
+						   + f"you must delete {abs_build_dir} first")
 
 		# Build
 		try:


### PR DESCRIPTION
--cmake-args is actually safe, just a bit slower. See explanation in
https://github.com/zephyrproject-rtos/zephyr/pull/56671

Fixes unnecessary restriction added by commit https://github.com/thesofproject/sof/commit/9fb7a607ebdaf2049aaa89dd1a2ab1c9758a310b
("xtensa-build-zephyr.py: fix -C option so it can support whitespace")

Also warn for overlays because they act the same.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>
