### PR TITLE
Audio: SRC: Audio: SRC: Use only module API and fix IPC4 capture direction

### DIFF
--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -89,6 +89,14 @@ struct comp_dev *module_adapter_new(const struct comp_driver *drv,
 		data = spec;
 		break;
 	}
+	case SOF_COMP_SRC:
+	{
+		const struct ipc_config_src *ipc_src = spec;
+
+		size = sizeof(*ipc_src);
+		data = spec;
+		break;
+	}
 	default:
 	{
 		const struct ipc_config_process *ipc_module_adapter = spec;

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -712,7 +712,6 @@ void sys_comp_host_init(void);
 void sys_comp_kpb_init(void);
 void sys_comp_multiband_drc_init(void);
 void sys_comp_selector_init(void);
-void sys_comp_src_init(void);
 
 void sys_comp_module_demux_interface_init(void);
 void sys_comp_module_eq_fir_interface_init(void);
@@ -720,6 +719,7 @@ void sys_comp_module_eq_iir_interface_init(void);
 void sys_comp_module_mfcc_interface_init(void);
 void sys_comp_module_mixer_interface_init(void);
 void sys_comp_module_mux_interface_init(void);
+void sys_comp_module_src_interface_init(void);
 void sys_comp_module_tdfb_interface_init(void);
 void sys_comp_module_volume_interface_init(void);
 

--- a/tools/testbench/common_test.c
+++ b/tools/testbench/common_test.c
@@ -50,13 +50,13 @@ int tb_setup(struct sof *sof, struct testbench_prm *tp)
 	sys_comp_drc_init();
 	sys_comp_multiband_drc_init();
 	sys_comp_selector_init();
-	sys_comp_src_init();
 
 	/* Module adapter components */
 	sys_comp_module_demux_interface_init();
 	sys_comp_module_eq_fir_interface_init();
 	sys_comp_module_eq_iir_interface_init();
 	sys_comp_module_mux_interface_init();
+	sys_comp_module_src_interface_init();
 	sys_comp_module_tdfb_interface_init();
 	sys_comp_module_volume_interface_init();
 


### PR DESCRIPTION
    This patch cleans up SRC component. There is no need to keep
    IPC3 version build with legacy component interface. The patch
    mainly removes code under CONFIG_IPC_MAJOR_3 and makes some
    functions available for all builds from CONFIG_IPC_MAJOR_4.
    
    The IPC4 capture issue is fixed by using the src_init()
    IPC rates for source and sink rate initialize. It needs a
    similar kernel update to always set those values. In practical
    topologies in prepare the buffers may not contain the correct
    stream information because the order of host copier and
    dai copier pipeline prepare can be host first where capture
    SRC is usually placed.
