### PR TITLE
Use accessors to read all struct audio_stream members

### DIFF
--- a/src/audio/aria/aria.c
+++ b/src/audio/aria/aria.c
@@ -218,6 +218,7 @@ static void aria_free(struct comp_dev *dev)
 static void aria_set_stream_params(struct comp_buffer *buffer, struct aria_data *cd)
 {
 	struct comp_buffer __sparse_cache *buffer_c;
+	enum sof_ipc_frame valid_fmt, frame_fmt;
 
 	buffer_c = buffer_acquire(buffer);
 	buffer_c->stream.channels = cd->chan_cnt;
@@ -225,9 +226,12 @@ static void aria_set_stream_params(struct comp_buffer *buffer, struct aria_data 
 	buffer_c->buffer_fmt = cd->base.audio_fmt.interleaving_style;
 	audio_stream_fmt_conversion(cd->base.audio_fmt.depth,
 				    cd->base.audio_fmt.valid_bit_depth,
-				    &buffer_c->stream.frame_fmt,
-				    &buffer_c->stream.valid_sample_fmt,
+				    &frame_fmt, &valid_fmt,
 				    cd->base.audio_fmt.s_type);
+
+	buffer_c->stream.frame_fmt = frame_fmt;
+	buffer_c->stream.valid_sample_fmt = valid_fmt;
+
 	buffer_release(buffer_c);
 }
 

--- a/src/audio/aria/aria.c
+++ b/src/audio/aria/aria.c
@@ -330,7 +330,7 @@ static int aria_copy(struct comp_dev *dev)
 	buffer_stream_invalidate(source_c, source_bytes);
 
 	for (i = 0; i < c.frames; i++) {
-		for (channel = 0; channel < sink_c->stream.channels; channel++) {
+		for (channel = 0; channel < audio_stream_get_channels(&sink_c->stream); channel++) {
 			cd->buf_in[frag] = *(int32_t *)audio_stream_read_frag_s32(&source_c->stream,
 										  frag);
 
@@ -338,16 +338,18 @@ static int aria_copy(struct comp_dev *dev)
 		}
 	}
 	dcache_writeback_region((__sparse_force void __sparse_cache *)cd->buf_in,
-				c.frames * sink_c->stream.channels * sizeof(int32_t));
+				c.frames * audio_stream_get_channels(&sink_c->stream) *
+				sizeof(int32_t));
 
 	aria_process_data(dev, cd->buf_out, sink_bytes / sizeof(uint32_t),
 			  cd->buf_in, source_bytes / sizeof(uint32_t));
 
 	dcache_writeback_region((__sparse_force void __sparse_cache *)cd->buf_out,
-				c.frames * sink_c->stream.channels * sizeof(int32_t));
+				c.frames * audio_stream_get_channels(&sink_c->stream) *
+				sizeof(int32_t));
 	frag = 0;
 	for (i = 0; i < c.frames; i++) {
-		for (channel = 0; channel < sink_c->stream.channels; channel++) {
+		for (channel = 0; channel < audio_stream_get_channels(&sink_c->stream); channel++) {
 			destp = audio_stream_write_frag_s32(&sink_c->stream, frag);
 			*destp = cd->buf_out[frag];
 

--- a/src/audio/asrc/asrc.c
+++ b/src/audio/asrc/asrc.c
@@ -128,7 +128,7 @@ static void src_copy_s32(struct comp_dev *dev,
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 	int32_t *buf;
-	int32_t *src = (int32_t *)source->r_ptr;
+	int32_t *src = audio_stream_get_rptr(source);
 	int32_t *snk = (int32_t *)sink->w_ptr;
 	int n_wrap_src;
 	int n_wrap_snk;
@@ -197,7 +197,7 @@ static void src_copy_s16(struct comp_dev *dev,
 			 int *n_read, int *n_written)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
-	int16_t *src = (int16_t *)source->r_ptr;
+	int16_t *src = audio_stream_get_rptr(source);
 	int16_t *snk = (int16_t *)sink->w_ptr;
 	int16_t *buf;
 	int n_wrap_src;

--- a/src/audio/asrc/asrc.c
+++ b/src/audio/asrc/asrc.c
@@ -147,14 +147,14 @@ static void src_copy_s32(struct comp_dev *dev,
 	buf = (int32_t *)cd->ibuf[0];
 	n = cd->source_frames * source->channels;
 	while (n > 0) {
-		n_wrap_src = (int32_t *)source->end_addr - src;
+		n_wrap_src = (int32_t *)audio_stream_get_end_addr(source) - src;
 		n_copy = (n < n_wrap_src) ? n : n_wrap_src;
 		for (i = 0; i < n_copy; i++)
 			*buf++ = (*src++) << cd->data_shift;
 
 		/* Update and check both source and destination for wrap */
 		n -= n_copy;
-		src_inc_wrap(&src, source->end_addr, source->size);
+		src_inc_wrap(&src, audio_stream_get_end_addr(source), source->size);
 	}
 
 	/* Run ASRC */
@@ -177,14 +177,14 @@ static void src_copy_s32(struct comp_dev *dev,
 	buf = (int32_t *)cd->obuf[0];
 	n = out_frames * sink->channels;
 	while (n > 0) {
-		n_wrap_snk = (int32_t *)sink->end_addr - snk;
+		n_wrap_snk = (int32_t *)audio_stream_get_end_addr(sink) - snk;
 		n_copy = (n < n_wrap_snk) ? n : n_wrap_snk;
 		for (i = 0; i < n_copy; i++)
 			*snk++ = (*buf++) >> cd->data_shift;
 
 		/* Update and check both source and destination for wrap */
 		n -= n_copy;
-		src_inc_wrap(&snk, sink->end_addr, sink->size);
+		src_inc_wrap(&snk, audio_stream_get_end_addr(sink), sink->size);
 	}
 
 	*n_read = in_frames;
@@ -216,7 +216,7 @@ static void src_copy_s16(struct comp_dev *dev,
 	buf = (int16_t *)cd->ibuf[0];
 	n = cd->source_frames * source->channels;
 	while (n > 0) {
-		n_wrap_src = (int16_t *)source->end_addr - src;
+		n_wrap_src = (int16_t *)audio_stream_get_end_addr(source) - src;
 		n_copy = (n < n_wrap_src) ? n : n_wrap_src;
 		s_copy = n_copy * sizeof(int16_t);
 		ret = memcpy_s(buf, s_copy, src, s_copy);
@@ -226,7 +226,7 @@ static void src_copy_s16(struct comp_dev *dev,
 		n -= n_copy;
 		src += n_copy;
 		buf += n_copy;
-		src_inc_wrap_s16(&src, source->end_addr, source->size);
+		src_inc_wrap_s16(&src, audio_stream_get_end_addr(source), source->size);
 	}
 
 	/* Run ASRC */
@@ -250,7 +250,7 @@ static void src_copy_s16(struct comp_dev *dev,
 	buf = (int16_t *)cd->obuf[0];
 	n = out_frames * sink->channels;
 	while (n > 0) {
-		n_wrap_snk = (int16_t *)sink->end_addr - snk;
+		n_wrap_snk = (int16_t *)audio_stream_get_end_addr(sink) - snk;
 		n_copy = (n < n_wrap_snk) ? n : n_wrap_snk;
 		s_copy = n_copy * sizeof(int16_t);
 		ret = memcpy_s(snk, s_copy, buf, s_copy);
@@ -260,7 +260,7 @@ static void src_copy_s16(struct comp_dev *dev,
 		n -= n_copy;
 		snk += n_copy;
 		buf += n_copy;
-		src_inc_wrap_s16(&snk, sink->end_addr, sink->size);
+		src_inc_wrap_s16(&snk, audio_stream_get_end_addr(sink), sink->size);
 	}
 
 	*n_read = in_frames;

--- a/src/audio/asrc/asrc.c
+++ b/src/audio/asrc/asrc.c
@@ -754,12 +754,12 @@ static int asrc_prepare(struct comp_dev *dev)
 	sink_c = buffer_acquire(sinkb);
 
 	/* get source data format and period bytes */
-	cd->source_format = source_c->stream.frame_fmt;
+	cd->source_format = audio_stream_get_frm_fmt(&source_c->stream);
 	source_period_bytes = audio_stream_period_bytes(&source_c->stream,
 							cd->source_frames);
 
 	/* get sink data format and period bytes */
-	cd->sink_format = sink_c->stream.frame_fmt;
+	cd->sink_format = audio_stream_get_frm_fmt(&sink_c->stream);
 	sink_period_bytes = audio_stream_period_bytes(&sink_c->stream,
 						      cd->sink_frames);
 
@@ -785,7 +785,7 @@ static int asrc_prepare(struct comp_dev *dev)
 	}
 
 	/* ASRC supports S16_LE, S24_4LE and S32_LE formats */
-	switch (source_c->stream.frame_fmt) {
+	switch (audio_stream_get_frm_fmt(&source_c->stream)) {
 	case SOF_IPC_FRAME_S16_LE:
 		cd->asrc_func = src_copy_s16;
 		break;

--- a/src/audio/asrc/asrc.c
+++ b/src/audio/asrc/asrc.c
@@ -129,7 +129,7 @@ static void src_copy_s32(struct comp_dev *dev,
 	struct comp_data *cd = comp_get_drvdata(dev);
 	int32_t *buf;
 	int32_t *src = audio_stream_get_rptr(source);
-	int32_t *snk = (int32_t *)sink->w_ptr;
+	int32_t *snk = audio_stream_get_wptr(sink);
 	int n_wrap_src;
 	int n_wrap_snk;
 	int n_copy;
@@ -198,7 +198,7 @@ static void src_copy_s16(struct comp_dev *dev,
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 	int16_t *src = audio_stream_get_rptr(source);
-	int16_t *snk = (int16_t *)sink->w_ptr;
+	int16_t *snk = audio_stream_get_wptr(sink);
 	int16_t *buf;
 	int n_wrap_src;
 	int n_wrap_snk;

--- a/src/audio/asrc/asrc.c
+++ b/src/audio/asrc/asrc.c
@@ -558,8 +558,8 @@ static int asrc_params(struct comp_dev *dev,
 		sink_c->stream.rate = asrc_get_sink_rate(&cd->ipc_config);
 
 	/* set source/sink_frames/rate */
-	cd->source_rate = source_c->stream.rate;
-	cd->sink_rate = sink_c->stream.rate;
+	cd->source_rate = audio_stream_get_rate(&source_c->stream);
+	cd->sink_rate = audio_stream_get_rate(&sink_c->stream);
 
 	buffer_release(sink_c);
 	buffer_release(source_c);

--- a/src/audio/asrc/asrc.c
+++ b/src/audio/asrc/asrc.c
@@ -145,7 +145,7 @@ static void src_copy_s32(struct comp_dev *dev,
 
 	/* Copy input data from source */
 	buf = (int32_t *)cd->ibuf[0];
-	n = cd->source_frames * source->channels;
+	n = cd->source_frames * audio_stream_get_channels(source);
 	while (n > 0) {
 		n_wrap_src = (int32_t *)audio_stream_get_end_addr(source) - src;
 		n_copy = (n < n_wrap_src) ? n : n_wrap_src;
@@ -176,7 +176,7 @@ static void src_copy_s32(struct comp_dev *dev,
 		comp_err(dev, "src_copy_s32(), error %d", ret);
 
 	buf = (int32_t *)cd->obuf[0];
-	n = out_frames * sink->channels;
+	n = out_frames * audio_stream_get_channels(sink);
 	while (n > 0) {
 		n_wrap_snk = (int32_t *)audio_stream_get_end_addr(sink) - snk;
 		n_copy = (n < n_wrap_snk) ? n : n_wrap_snk;
@@ -216,7 +216,7 @@ static void src_copy_s16(struct comp_dev *dev,
 
 	/* Copy input data from source */
 	buf = (int16_t *)cd->ibuf[0];
-	n = cd->source_frames * source->channels;
+	n = cd->source_frames * audio_stream_get_channels(source);
 	while (n > 0) {
 		n_wrap_src = (int16_t *)audio_stream_get_end_addr(source) - src;
 		n_copy = (n < n_wrap_src) ? n : n_wrap_src;
@@ -251,7 +251,7 @@ static void src_copy_s16(struct comp_dev *dev,
 		comp_err(dev, "src_copy_s16(), error %d", ret);
 
 	buf = (int16_t *)cd->obuf[0];
-	n = out_frames * sink->channels;
+	n = out_frames * audio_stream_get_channels(sink);
 	while (n > 0) {
 		n_wrap_snk = (int16_t *)audio_stream_get_end_addr(sink) - snk;
 		n_copy = (n < n_wrap_snk) ? n : n_wrap_snk;
@@ -817,8 +817,8 @@ static int asrc_prepare(struct comp_dev *dev)
 		goto err;
 	}
 
-	sample_bytes = frame_bytes / source_c->stream.channels;
-	for (i = 0; i < sourceb->stream.channels; i++) {
+	sample_bytes = frame_bytes / audio_stream_get_channels(&source_c->stream);
+	for (i = 0; i < audio_stream_get_channels(&source_c->stream); i++) {
 		cd->ibuf[i] = cd->buf + i * sample_bytes;
 		cd->obuf[i] = cd->ibuf[i] + cd->source_frames_max * frame_bytes;
 	}
@@ -826,7 +826,7 @@ static int asrc_prepare(struct comp_dev *dev)
 	/* Get required size and allocate memory for ASRC */
 	sample_bits = sample_bytes * 8;
 	ret = asrc_get_required_size(dev, &cd->asrc_size,
-				     source_c->stream.channels,
+				     audio_stream_get_channels(&source_c->stream),
 				     sample_bits);
 	if (ret) {
 		comp_err(dev, "asrc_prepare(), get_required_size_bytes failed");
@@ -852,7 +852,7 @@ static int asrc_prepare(struct comp_dev *dev)
 		fs_sec = cd->source_rate;
 	}
 
-	ret = asrc_initialise(dev, cd->asrc_obj, source_c->stream.channels,
+	ret = asrc_initialise(dev, cd->asrc_obj, audio_stream_get_channels(&source_c->stream),
 			      fs_prim, fs_sec,
 			      ASRC_IOF_INTERLEAVED, ASRC_IOF_INTERLEAVED,
 			      ASRC_BM_LINEAR, cd->frames, sample_bits,

--- a/src/audio/buffer.c
+++ b/src/audio/buffer.c
@@ -236,7 +236,7 @@ void comp_update_buffer_produce(struct comp_buffer __sparse_cache *buffer, uint3
 		 audio_stream_get_free_bytes(&buffer->stream),
 		(buffer->id << 16) | buffer->stream.size);
 	buf_dbg(buffer, "comp_update_buffer_produce(), ((buffer->r_ptr - buffer->addr) << 16 | (buffer->w_ptr - buffer->addr)) = %08x",
-		((char *)buffer->stream.r_ptr - (char *)buffer->stream.addr) << 16 |
+		((char *)audio_stream_get_rptr(&buffer->stream) - (char *)buffer->stream.addr) << 16 |
 		((char *)buffer->stream.w_ptr - (char *)buffer->stream.addr));
 }
 
@@ -245,7 +245,7 @@ void comp_update_buffer_consume(struct comp_buffer __sparse_cache *buffer, uint3
 	struct buffer_cb_transact cb_data = {
 		.buffer = buffer,
 		.transaction_amount = bytes,
-		.transaction_begin_address = buffer->stream.r_ptr,
+		.transaction_begin_address = audio_stream_get_rptr(&buffer->stream),
 	};
 
 	/* return if no bytes */
@@ -267,7 +267,7 @@ void comp_update_buffer_consume(struct comp_buffer __sparse_cache *buffer, uint3
 		(audio_stream_get_avail_bytes(&buffer->stream) << 16) |
 		 audio_stream_get_free_bytes(&buffer->stream),
 		(buffer->id << 16) | buffer->stream.size,
-		((char *)buffer->stream.r_ptr - (char *)buffer->stream.addr) << 16 |
+		((char *)audio_stream_get_rptr(&buffer->stream) - (char *)buffer->stream.addr) << 16 |
 		((char *)buffer->stream.w_ptr - (char *)buffer->stream.addr));
 }
 

--- a/src/audio/buffer.c
+++ b/src/audio/buffer.c
@@ -86,9 +86,10 @@ void buffer_zero(struct comp_buffer __sparse_cache *buffer)
 {
 	buf_dbg(buffer, "stream_zero()");
 
-	bzero(buffer->stream.addr, buffer->stream.size);
+	bzero(audio_stream_get_addr(&buffer->stream), buffer->stream.size);
 	if (buffer->caps & SOF_MEM_CAPS_DMA)
-		dcache_writeback_region((__sparse_force void __sparse_cache *)buffer->stream.addr,
+		dcache_writeback_region((__sparse_force void __sparse_cache *)
+					audio_stream_get_addr(&buffer->stream),
 					buffer->stream.size);
 }
 
@@ -105,7 +106,7 @@ int buffer_set_size(struct comp_buffer __sparse_cache *buffer, uint32_t size)
 	if (size == buffer->stream.size)
 		return 0;
 
-	new_ptr = rbrealloc(buffer->stream.addr, SOF_MEM_FLAG_NO_COPY,
+	new_ptr = rbrealloc(audio_stream_get_addr(&buffer->stream), SOF_MEM_FLAG_NO_COPY,
 			    buffer->caps, size, buffer->stream.size);
 
 	/* we couldn't allocate bigger chunk */
@@ -236,8 +237,10 @@ void comp_update_buffer_produce(struct comp_buffer __sparse_cache *buffer, uint3
 		 audio_stream_get_free_bytes(&buffer->stream),
 		(buffer->id << 16) | buffer->stream.size);
 	buf_dbg(buffer, "comp_update_buffer_produce(), ((buffer->r_ptr - buffer->addr) << 16 | (buffer->w_ptr - buffer->addr)) = %08x",
-		((char *)audio_stream_get_rptr(&buffer->stream) - (char *)buffer->stream.addr) << 16 |
-		((char *)audio_stream_get_wptr(&buffer->stream) - (char *)buffer->stream.addr));
+		((char *)audio_stream_get_rptr(&buffer->stream) -
+		 (char *)audio_stream_get_addr(&buffer->stream)) << 16 |
+		((char *)audio_stream_get_wptr(&buffer->stream) -
+		 (char *)audio_stream_get_addr(&buffer->stream)));
 }
 
 void comp_update_buffer_consume(struct comp_buffer __sparse_cache *buffer, uint32_t bytes)
@@ -267,8 +270,10 @@ void comp_update_buffer_consume(struct comp_buffer __sparse_cache *buffer, uint3
 		(audio_stream_get_avail_bytes(&buffer->stream) << 16) |
 		 audio_stream_get_free_bytes(&buffer->stream),
 		(buffer->id << 16) | buffer->stream.size,
-		((char *)audio_stream_get_rptr(&buffer->stream) - (char *)buffer->stream.addr) << 16 |
-		((char *)audio_stream_get_wptr(&buffer->stream) - (char *)buffer->stream.addr));
+		((char *)audio_stream_get_rptr(&buffer->stream) -
+		 (char *)audio_stream_get_addr(&buffer->stream)) << 16 |
+		((char *)audio_stream_get_wptr(&buffer->stream) -
+		 (char *)audio_stream_get_addr(&buffer->stream)));
 }
 
 void buffer_attach(struct comp_buffer *buffer, struct list_item *head, int dir)

--- a/src/audio/buffer.c
+++ b/src/audio/buffer.c
@@ -212,7 +212,7 @@ void comp_update_buffer_produce(struct comp_buffer __sparse_cache *buffer, uint3
 	struct buffer_cb_transact cb_data = {
 		.buffer = buffer,
 		.transaction_amount = bytes,
-		.transaction_begin_address = buffer->stream.w_ptr,
+		.transaction_begin_address = audio_stream_get_wptr(&buffer->stream),
 	};
 
 	/* return if no bytes */
@@ -237,7 +237,7 @@ void comp_update_buffer_produce(struct comp_buffer __sparse_cache *buffer, uint3
 		(buffer->id << 16) | buffer->stream.size);
 	buf_dbg(buffer, "comp_update_buffer_produce(), ((buffer->r_ptr - buffer->addr) << 16 | (buffer->w_ptr - buffer->addr)) = %08x",
 		((char *)audio_stream_get_rptr(&buffer->stream) - (char *)buffer->stream.addr) << 16 |
-		((char *)buffer->stream.w_ptr - (char *)buffer->stream.addr));
+		((char *)audio_stream_get_wptr(&buffer->stream) - (char *)buffer->stream.addr));
 }
 
 void comp_update_buffer_consume(struct comp_buffer __sparse_cache *buffer, uint32_t bytes)
@@ -268,7 +268,7 @@ void comp_update_buffer_consume(struct comp_buffer __sparse_cache *buffer, uint3
 		 audio_stream_get_free_bytes(&buffer->stream),
 		(buffer->id << 16) | buffer->stream.size,
 		((char *)audio_stream_get_rptr(&buffer->stream) - (char *)buffer->stream.addr) << 16 |
-		((char *)buffer->stream.w_ptr - (char *)buffer->stream.addr));
+		((char *)audio_stream_get_wptr(&buffer->stream) - (char *)buffer->stream.addr));
 }
 
 void buffer_attach(struct comp_buffer *buffer, struct list_item *head, int dir)

--- a/src/audio/chain_dma.c
+++ b/src/audio/chain_dma.c
@@ -239,7 +239,7 @@ static enum task_state chain_task_run(void *data)
 		 * overwriting valid data and write position by half buffer size.
 		 */
 		struct comp_buffer __sparse_cache *buffer_c = buffer_acquire(cd->dma_buffer);
-		const size_t buff_size = buffer_c->stream.size;
+		const size_t buff_size = audio_stream_get_size(&buffer_c->stream);
 		const size_t half_buff_size = buff_size / 2;
 
 		buffer_release(buffer_c);
@@ -601,7 +601,7 @@ static int chain_task_init(struct comp_dev *dev, uint8_t host_dma_id, uint8_t li
 	buffer_c = buffer_acquire(cd->dma_buffer);
 	buffer_zero(buffer_c);
 	buff_addr = audio_stream_get_addr(&buffer_c->stream);
-	buff_size = buffer_c->stream.size;
+	buff_size = audio_stream_get_size(&buffer_c->stream);
 	buffer_release(buffer_c);
 
 	ret = chain_init(dev, buff_addr, buff_size);

--- a/src/audio/chain_dma.c
+++ b/src/audio/chain_dma.c
@@ -600,7 +600,7 @@ static int chain_task_init(struct comp_dev *dev, uint8_t host_dma_id, uint8_t li
 	/* clear dma buffer */
 	buffer_c = buffer_acquire(cd->dma_buffer);
 	buffer_zero(buffer_c);
-	buff_addr = buffer_c->stream.addr;
+	buff_addr = audio_stream_get_addr(&buffer_c->stream);
 	buff_size = buffer_c->stream.size;
 	buffer_release(buffer_c);
 

--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -187,7 +187,7 @@ int audio_stream_copy(const struct audio_stream __sparse_cache *source, uint32_t
 {
 	int ssize = audio_stream_sample_bytes(source); /* src fmt == sink fmt */
 	ae_int16x4 *src = (ae_int16x4 *)((int8_t *)audio_stream_get_rptr(source) + ioffset * ssize);
-	ae_int16x4 *dst = (ae_int16x4 *)((int8_t *)sink->w_ptr + ooffset * ssize);
+	ae_int16x4 *dst = (ae_int16x4 *)((int8_t *)audio_stream_get_wptr(sink) + ooffset * ssize);
 	int shorts = samples * ssize >> 1;
 	int shorts_src;
 	int shorts_dst;
@@ -233,7 +233,8 @@ int audio_stream_copy(const struct audio_stream __sparse_cache *source, uint32_t
 	int ssize = audio_stream_sample_bytes(source); /* src fmt == sink fmt */
 	uint8_t *src = audio_stream_wrap(source, (uint8_t *)audio_stream_get_rptr(source) +
 					 ioffset * ssize);
-	uint8_t *snk = audio_stream_wrap(sink, (uint8_t *)sink->w_ptr + ooffset * ssize);
+	uint8_t *snk = audio_stream_wrap(sink, (uint8_t *)audio_stream_get_wptr(sink) +
+					 ooffset * ssize);
 	size_t bytes = samples * ssize;
 	size_t bytes_src;
 	size_t bytes_snk;
@@ -261,7 +262,8 @@ void audio_stream_copy_from_linear(const void *linear_source, int ioffset,
 {
 	int ssize = audio_stream_sample_bytes(sink); /* src fmt == sink fmt */
 	uint8_t *src = (uint8_t *)linear_source + ioffset * ssize;
-	uint8_t *snk = audio_stream_wrap(sink, (uint8_t *)sink->w_ptr + ooffset * ssize);
+	uint8_t *snk = audio_stream_wrap(sink, (uint8_t *)audio_stream_get_wptr(sink) +
+					 ooffset * ssize);
 	size_t bytes = samples * ssize;
 	size_t bytes_snk;
 	size_t bytes_copied;

--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -186,7 +186,7 @@ int audio_stream_copy(const struct audio_stream __sparse_cache *source, uint32_t
 		      struct audio_stream __sparse_cache *sink, uint32_t ooffset, uint32_t samples)
 {
 	int ssize = audio_stream_sample_bytes(source); /* src fmt == sink fmt */
-	ae_int16x4 *src = (ae_int16x4 *)((int8_t *)source->r_ptr + ioffset * ssize);
+	ae_int16x4 *src = (ae_int16x4 *)((int8_t *)audio_stream_get_rptr(source) + ioffset * ssize);
 	ae_int16x4 *dst = (ae_int16x4 *)((int8_t *)sink->w_ptr + ooffset * ssize);
 	int shorts = samples * ssize >> 1;
 	int shorts_src;
@@ -231,7 +231,8 @@ int audio_stream_copy(const struct audio_stream __sparse_cache *source, uint32_t
 		      struct audio_stream __sparse_cache *sink, uint32_t ooffset, uint32_t samples)
 {
 	int ssize = audio_stream_sample_bytes(source); /* src fmt == sink fmt */
-	uint8_t *src = audio_stream_wrap(source, (uint8_t *)source->r_ptr + ioffset * ssize);
+	uint8_t *src = audio_stream_wrap(source, (uint8_t *)audio_stream_get_rptr(source) +
+					 ioffset * ssize);
 	uint8_t *snk = audio_stream_wrap(sink, (uint8_t *)sink->w_ptr + ooffset * ssize);
 	size_t bytes = samples * ssize;
 	size_t bytes_src;
@@ -279,7 +280,8 @@ void audio_stream_copy_to_linear(const struct audio_stream __sparse_cache *sourc
 				 void *linear_sink, int ooffset, unsigned int samples)
 {
 	int ssize = audio_stream_sample_bytes(source); /* src fmt == sink fmt */
-	uint8_t *src = audio_stream_wrap(source, (uint8_t *)source->r_ptr + ioffset * ssize);
+	uint8_t *src = audio_stream_wrap(source, (uint8_t *)audio_stream_get_rptr(source) +
+					 ioffset * ssize);
 	uint8_t *snk = (uint8_t *)linear_sink + ooffset * ssize;
 	size_t bytes = samples * ssize;
 	size_t bytes_src;

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -1407,7 +1407,7 @@ static void copier_dma_cb(void *arg, enum notify_id type, void *data)
 		else
 			sink = buffer_acquire(cd->hd->dma_buffer);
 
-		frames = bytes / get_sample_bytes(sink->stream.frame_fmt);
+		frames = bytes / get_sample_bytes(audio_stream_get_frm_fmt(&sink->stream));
 		frames = frames / sink->stream.channels;
 
 		ret = apply_attenuation(dev, cd, sink, frames);

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -1056,7 +1056,8 @@ static int copier_comp_trigger(struct comp_dev *dev, int cmd)
 
 		buffer = list_first_item(&dai_copier->bsource_list, struct comp_buffer, sink_list);
 		buffer_c = buffer_acquire(buffer);
-		pipe_reg.stream_start_offset = posn.dai_posn + latency * buffer_c->stream.size;
+		pipe_reg.stream_start_offset = posn.dai_posn +
+			latency * audio_stream_get_size(&buffer_c->stream);
 		buffer_release(buffer_c);
 		pipe_reg.stream_end_offset = 0;
 		mailbox_sw_regs_write(cd->pipeline_reg_offset, &pipe_reg, sizeof(pipe_reg));
@@ -1081,7 +1082,7 @@ static int copier_comp_trigger(struct comp_dev *dev, int cmd)
 
 		buffer = list_first_item(&dai_copier->bsource_list, struct comp_buffer, sink_list);
 		buffer_c = buffer_acquire(buffer);
-		pipe_reg.stream_start_offset += latency * buffer_c->stream.size;
+		pipe_reg.stream_start_offset += latency * audio_stream_get_size(&buffer_c->stream);
 		buffer_release(buffer_c);
 		mailbox_sw_regs_write(cd->pipeline_reg_offset, &pipe_reg.stream_start_offset,
 				      sizeof(pipe_reg.stream_start_offset));

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -791,7 +791,7 @@ static void copy_single_channel_c16(struct audio_stream __sparse_cache *dst,
 
 		src_samples_without_wrap = audio_stream_samples_without_wrap_s16(src, r_ptr);
 		r_end_ptr = src_stream_sample_count < src_samples_without_wrap ?
-			r_ptr + src_stream_sample_count : (int16_t *)src->end_addr;
+			r_ptr + src_stream_sample_count : (int16_t *)audio_stream_get_end_addr(src);
 
 		r_ptr_before_loop = r_ptr;
 
@@ -799,7 +799,7 @@ static void copy_single_channel_c16(struct audio_stream __sparse_cache *dst,
 			*w_ptr = *r_ptr;
 			r_ptr += src->channels;
 			w_ptr += dst->channels;
-		} while (r_ptr < r_end_ptr && w_ptr < (int16_t *)dst->end_addr);
+		} while (r_ptr < r_end_ptr && w_ptr < (int16_t *)audio_stream_get_end_addr(dst));
 
 		src_stream_sample_count -= r_ptr - r_ptr_before_loop;
 	}
@@ -830,7 +830,7 @@ static void copy_single_channel_c32(struct audio_stream __sparse_cache *dst,
 
 		src_samples_without_wrap = audio_stream_samples_without_wrap_s32(src, r_ptr);
 		r_end_ptr = src_stream_sample_count < src_samples_without_wrap ?
-			r_ptr + src_stream_sample_count : (int32_t *)src->end_addr;
+			r_ptr + src_stream_sample_count : (int32_t *)audio_stream_get_end_addr(src);
 
 		r_ptr_before_loop = r_ptr;
 
@@ -838,7 +838,7 @@ static void copy_single_channel_c32(struct audio_stream __sparse_cache *dst,
 			*w_ptr = *r_ptr;
 			r_ptr += src->channels;
 			w_ptr += dst->channels;
-		} while (r_ptr < r_end_ptr && w_ptr < (int32_t *)dst->end_addr);
+		} while (r_ptr < r_end_ptr && w_ptr < (int32_t *)audio_stream_get_end_addr(dst));
 
 		src_stream_sample_count -= r_ptr - r_ptr_before_loop;
 	}

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -80,8 +80,8 @@ static int create_endpoint_buffer(struct comp_dev *parent_dev,
 				  bool create_multi_endpoint_buffer,
 				  int index)
 {
-	enum sof_ipc_frame __sparse_cache in_frame_fmt, out_frame_fmt;
-	enum sof_ipc_frame __sparse_cache in_valid_fmt, out_valid_fmt;
+	enum sof_ipc_frame in_frame_fmt, out_frame_fmt;
+	enum sof_ipc_frame in_valid_fmt, out_valid_fmt;
 	enum sof_ipc_frame valid_fmt;
 	struct sof_ipc_buffer ipc_buf;
 	struct comp_buffer *buffer;
@@ -91,14 +91,12 @@ static int create_endpoint_buffer(struct comp_dev *parent_dev,
 
 	audio_stream_fmt_conversion(copier_cfg->base.audio_fmt.depth,
 				    copier_cfg->base.audio_fmt.valid_bit_depth,
-				    &in_frame_fmt,
-				    &in_valid_fmt,
+				    &in_frame_fmt, &in_valid_fmt,
 				    copier_cfg->base.audio_fmt.s_type);
 
 	audio_stream_fmt_conversion(copier_cfg->out_fmt.depth,
 				    copier_cfg->out_fmt.valid_bit_depth,
-				    &out_frame_fmt,
-				    &out_valid_fmt,
+				    &out_frame_fmt, &out_valid_fmt,
 				    copier_cfg->out_fmt.s_type);
 
 	/* playback case:
@@ -211,21 +209,19 @@ static int create_host(struct comp_dev *parent_dev, struct copier_data *cd,
 	struct ipc_config_host ipc_host;
 	struct host_data *hd;
 	int ret;
-	enum sof_ipc_frame __sparse_cache in_frame_fmt, out_frame_fmt;
-	enum sof_ipc_frame __sparse_cache in_valid_fmt, out_valid_fmt;
+	enum sof_ipc_frame in_frame_fmt, out_frame_fmt;
+	enum sof_ipc_frame in_valid_fmt, out_valid_fmt;
 
 	config->type = SOF_COMP_HOST;
 
 	audio_stream_fmt_conversion(copier_cfg->base.audio_fmt.depth,
 				    copier_cfg->base.audio_fmt.valid_bit_depth,
-				    &in_frame_fmt,
-				    &in_valid_fmt,
+				    &in_frame_fmt, &in_valid_fmt,
 				    copier_cfg->base.audio_fmt.s_type);
 
 	audio_stream_fmt_conversion(copier_cfg->out_fmt.depth,
 				    copier_cfg->out_fmt.valid_bit_depth,
-				    &out_frame_fmt,
-				    &out_valid_fmt,
+				    &out_frame_fmt, &out_valid_fmt,
 				    copier_cfg->out_fmt.s_type);
 
 	if (cd->direction == SOF_IPC_STREAM_PLAYBACK)
@@ -752,7 +748,7 @@ static pcm_converter_func get_converter_func(const struct ipc4_audio_format *in_
 					     enum ipc4_gateway_type type,
 					     enum ipc4_direction_type dir)
 {
-	enum sof_ipc_frame __sparse_cache in, in_valid, out, out_valid;
+	enum sof_ipc_frame in, in_valid, out, out_valid;
 
 	audio_stream_fmt_conversion(in_fmt->depth, in_fmt->valid_bit_depth, &in, &in_valid,
 				    in_fmt->s_type);
@@ -1362,15 +1358,18 @@ static void update_internal_comp(struct comp_dev *parent, struct comp_dev *child
 static void update_buffer_format(struct comp_buffer __sparse_cache *buf_c,
 				 const struct ipc4_audio_format *fmt)
 {
+	enum sof_ipc_frame valid_fmt, frame_fmt;
 	int i;
 
 	buf_c->stream.channels = fmt->channels_count;
 	buf_c->stream.rate = fmt->sampling_frequency;
 	audio_stream_fmt_conversion(fmt->depth,
 				    fmt->valid_bit_depth,
-				    &buf_c->stream.frame_fmt,
-				    &buf_c->stream.valid_sample_fmt,
+				    &frame_fmt, &valid_fmt,
 				    fmt->s_type);
+
+	buf_c->stream.frame_fmt = frame_fmt;
+	buf_c->stream.valid_sample_fmt = valid_fmt;
 
 	buf_c->buffer_fmt = fmt->interleaving_style;
 
@@ -1583,7 +1582,7 @@ static int set_attenuation(struct comp_dev *dev, uint32_t data_offset, const cha
 {
 	struct copier_data *cd = comp_get_drvdata(dev);
 	uint32_t attenuation;
-	uint32_t __sparse_cache valid_fmt, frame_fmt;
+	enum sof_ipc_frame valid_fmt, frame_fmt;
 
 	/* only support attenuation in format of 32bit */
 	if (data_offset > sizeof(uint32_t)) {
@@ -1599,8 +1598,7 @@ static int set_attenuation(struct comp_dev *dev, uint32_t data_offset, const cha
 
 	audio_stream_fmt_conversion(cd->config.base.audio_fmt.depth,
 				    cd->config.base.audio_fmt.valid_bit_depth,
-				    &frame_fmt,
-				    &valid_fmt,
+				    &frame_fmt, &valid_fmt,
 				    cd->config.base.audio_fmt.s_type);
 
 	if (frame_fmt < SOF_IPC_FRAME_S24_4LE) {

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -771,7 +771,7 @@ static void copy_single_channel_c16(struct audio_stream __sparse_cache *dst,
 				    const struct audio_stream __sparse_cache *src,
 				    int src_channel, int frame_count)
 {
-	int16_t *r_ptr = (int16_t *)src->r_ptr + src_channel;
+	int16_t *r_ptr = (int16_t *)audio_stream_get_rptr(src) + src_channel;
 	int16_t *w_ptr = (int16_t *)dst->w_ptr + dst_channel;
 
 	/* We have to iterate over frames here. However, tracking frames requires using
@@ -810,7 +810,7 @@ static void copy_single_channel_c32(struct audio_stream __sparse_cache *dst,
 				    const struct audio_stream __sparse_cache *src,
 				    int src_channel, int frame_count)
 {
-	int32_t *r_ptr = (int32_t *)src->r_ptr + src_channel;
+	int32_t *r_ptr = (int32_t *)audio_stream_get_rptr(src) + src_channel;
 	int32_t *w_ptr = (int32_t *)dst->w_ptr + dst_channel;
 
 	/* We have to iterate over frames here. However, tracking frames requires using

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -772,7 +772,7 @@ static void copy_single_channel_c16(struct audio_stream __sparse_cache *dst,
 				    int src_channel, int frame_count)
 {
 	int16_t *r_ptr = (int16_t *)audio_stream_get_rptr(src) + src_channel;
-	int16_t *w_ptr = (int16_t *)dst->w_ptr + dst_channel;
+	int16_t *w_ptr = (int16_t *)audio_stream_get_wptr(dst) + dst_channel;
 
 	/* We have to iterate over frames here. However, tracking frames requires using
 	 * of expensive division operations (e.g., inside audio_stream_frames_without_wrap()).
@@ -811,7 +811,7 @@ static void copy_single_channel_c32(struct audio_stream __sparse_cache *dst,
 				    int src_channel, int frame_count)
 {
 	int32_t *r_ptr = (int32_t *)audio_stream_get_rptr(src) + src_channel;
-	int32_t *w_ptr = (int32_t *)dst->w_ptr + dst_channel;
+	int32_t *w_ptr = (int32_t *)audio_stream_get_wptr(dst) + dst_channel;
 
 	/* We have to iterate over frames here. However, tracking frames requires using
 	 * of expensive division operations (e.g., inside audio_stream_frames_without_wrap()).

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -776,7 +776,7 @@ static void copy_single_channel_c16(struct audio_stream __sparse_cache *dst,
 	 * is NOT number of samples we need to copy but total samples for all channels. We just
 	 * track them to know when to stop.
 	 */
-	int src_stream_sample_count = frame_count * src->channels;
+	int src_stream_sample_count = frame_count * audio_stream_get_channels(src);
 
 	while (src_stream_sample_count) {
 		int src_samples_without_wrap;
@@ -793,8 +793,8 @@ static void copy_single_channel_c16(struct audio_stream __sparse_cache *dst,
 
 		do {
 			*w_ptr = *r_ptr;
-			r_ptr += src->channels;
-			w_ptr += dst->channels;
+			r_ptr += audio_stream_get_channels(src);
+			w_ptr += audio_stream_get_channels(dst);
 		} while (r_ptr < r_end_ptr && w_ptr < (int16_t *)audio_stream_get_end_addr(dst));
 
 		src_stream_sample_count -= r_ptr - r_ptr_before_loop;
@@ -815,7 +815,7 @@ static void copy_single_channel_c32(struct audio_stream __sparse_cache *dst,
 	 * is NOT number of samples we need to copy but total samples for all channels. We just
 	 * track them to know when to stop.
 	 */
-	int src_stream_sample_count = frame_count * src->channels;
+	int src_stream_sample_count = frame_count * audio_stream_get_channels(src);
 
 	while (src_stream_sample_count) {
 		int src_samples_without_wrap;
@@ -832,8 +832,8 @@ static void copy_single_channel_c32(struct audio_stream __sparse_cache *dst,
 
 		do {
 			*w_ptr = *r_ptr;
-			r_ptr += src->channels;
-			w_ptr += dst->channels;
+			r_ptr += audio_stream_get_channels(src);
+			w_ptr += audio_stream_get_channels(dst);
 		} while (r_ptr < r_end_ptr && w_ptr < (int32_t *)audio_stream_get_end_addr(dst));
 
 		src_stream_sample_count -= r_ptr - r_ptr_before_loop;
@@ -1117,8 +1117,8 @@ static int demux_from_multi_endpoint_buffer(struct copier_data *cd)
 
 		endp_buf_c = buffer_acquire(cd->endpoint_buffer[endp_idx]);
 
-		for (endp_channel = 0; endp_channel < endp_buf_c->stream.channels;
-				endp_channel++) {
+		for (endp_channel = 0; endp_channel <
+		     audio_stream_get_channels(&endp_buf_c->stream); endp_channel++) {
 			int multi_buf_channel = endp_buf_c->chmap[endp_channel];
 
 			cd->copy_single_channel(&endp_buf_c->stream, endp_channel,
@@ -1163,8 +1163,8 @@ static int mux_into_multi_endpoint_buffer(struct copier_data *cd)
 		endp_buf_byte_count = frame_count * audio_stream_frame_bytes(&endp_buf_c->stream);
 		buffer_stream_invalidate(endp_buf_c, endp_buf_byte_count);
 
-		for (endp_channel = 0; endp_channel < endp_buf_c->stream.channels;
-				endp_channel++) {
+		for (endp_channel = 0; endp_channel <
+		     audio_stream_get_channels(&endp_buf_c->stream); endp_channel++) {
 			int multi_buf_channel = endp_buf_c->chmap[endp_channel];
 
 			cd->copy_single_channel(&multi_buf_c->stream, multi_buf_channel,
@@ -1239,7 +1239,7 @@ static int do_conversion_copy(struct comp_dev *dev,
 	buffer_stream_invalidate(src, processed_data->source_bytes);
 
 	cd->converter[i](&src->stream, 0, &sink->stream, 0,
-			 processed_data->frames * sink->stream.channels);
+			 processed_data->frames * audio_stream_get_channels(&sink->stream));
 
 	if (cd->attenuation) {
 		ret = apply_attenuation(dev, cd, sink, processed_data->frames);
@@ -1408,7 +1408,7 @@ static void copier_dma_cb(void *arg, enum notify_id type, void *data)
 			sink = buffer_acquire(cd->hd->dma_buffer);
 
 		frames = bytes / get_sample_bytes(audio_stream_get_frm_fmt(&sink->stream));
-		frames = frames / sink->stream.channels;
+		frames = frames / audio_stream_get_channels(&sink->stream);
 
 		ret = apply_attenuation(dev, cd, sink, frames);
 		if (ret < 0)
@@ -1487,7 +1487,7 @@ static int copier_params(struct comp_dev *dev, struct sof_ipc_stream_params *par
 			struct sof_ipc_stream_params demuxed_params = *params;
 
 			buf_c = buffer_acquire(cd->endpoint_buffer[i]);
-			demuxed_params.channels = buf_c->stream.channels;
+			demuxed_params.channels = audio_stream_get_channels(&buf_c->stream);
 			buffer_release(buf_c);
 
 			ret = cd->endpoint[i]->drv->ops.params(cd->endpoint[i],

--- a/src/audio/copier/copier_generic.c
+++ b/src/audio/copier/copier_generic.c
@@ -27,7 +27,7 @@ int apply_attenuation(struct comp_dev *dev, struct copier_data *cd,
 	int n;
 	int nmax;
 	int remaining_samples = frame * sink->stream.channels;
-	int32_t *dst = sink->stream.r_ptr;
+	int32_t *dst = audio_stream_get_rptr(&sink->stream);
 
 	/* only support attenuation in format of 32bit */
 	switch (sink->stream.frame_fmt) {

--- a/src/audio/copier/copier_generic.c
+++ b/src/audio/copier/copier_generic.c
@@ -30,7 +30,7 @@ int apply_attenuation(struct comp_dev *dev, struct copier_data *cd,
 	int32_t *dst = audio_stream_get_rptr(&sink->stream);
 
 	/* only support attenuation in format of 32bit */
-	switch (sink->stream.frame_fmt) {
+	switch (audio_stream_get_frm_fmt(&sink->stream)) {
 	case SOF_IPC_FRAME_S16_LE:
 		comp_err(dev, "16bit sample isn't supported by attenuation");
 		return -EINVAL;
@@ -49,7 +49,8 @@ int apply_attenuation(struct comp_dev *dev, struct copier_data *cd,
 
 		return 0;
 	default:
-		comp_err(dev, "unsupported format %d for attenuation", sink->stream.frame_fmt);
+		comp_err(dev, "unsupported format %d for attenuation",
+			 audio_stream_get_frm_fmt(&sink->stream));
 		return -EINVAL;
 	}
 }

--- a/src/audio/copier/copier_generic.c
+++ b/src/audio/copier/copier_generic.c
@@ -26,7 +26,7 @@ int apply_attenuation(struct comp_dev *dev, struct copier_data *cd,
 	int i;
 	int n;
 	int nmax;
-	int remaining_samples = frame * sink->stream.channels;
+	int remaining_samples = frame * audio_stream_get_channels(&sink->stream);
 	int32_t *dst = audio_stream_get_rptr(&sink->stream);
 
 	/* only support attenuation in format of 32bit */

--- a/src/audio/copier/copier_hifi.c
+++ b/src/audio/copier/copier_hifi.c
@@ -31,7 +31,7 @@ int apply_attenuation(struct comp_dev *dev, struct copier_data *cd,
 	ae_valign uu = AE_ZALIGN64();
 	ae_valign su = AE_ZALIGN64();
 	int remaining_samples = frame * sink->stream.channels;
-	uint32_t *dst = sink->stream.r_ptr;
+	uint32_t *dst = audio_stream_get_rptr(&sink->stream);
 	ae_int32x2 *in = (ae_int32x2 *)dst;
 	ae_int32x2 *out = (ae_int32x2 *)dst;
 

--- a/src/audio/copier/copier_hifi.c
+++ b/src/audio/copier/copier_hifi.c
@@ -36,7 +36,7 @@ int apply_attenuation(struct comp_dev *dev, struct copier_data *cd,
 	ae_int32x2 *out = (ae_int32x2 *)dst;
 
 	/* only support attenuation in format of 32bit */
-	switch (sink->stream.frame_fmt) {
+	switch (audio_stream_get_frm_fmt(&sink->stream)) {
 	case SOF_IPC_FRAME_S16_LE:
 		comp_err(dev, "16bit sample isn't supported by attenuation");
 		return -EINVAL;
@@ -66,7 +66,8 @@ int apply_attenuation(struct comp_dev *dev, struct copier_data *cd,
 
 		return 0;
 	default:
-		comp_err(dev, "unsupported format %d for attenuation", sink->stream.frame_fmt);
+		comp_err(dev, "unsupported format %d for attenuation",
+			 audio_stream_get_frm_fmt(&sink->stream));
 		return -EINVAL;
 	}
 }

--- a/src/audio/copier/copier_hifi.c
+++ b/src/audio/copier/copier_hifi.c
@@ -30,7 +30,7 @@ int apply_attenuation(struct comp_dev *dev, struct copier_data *cd,
 	ae_int32x2 sample;
 	ae_valign uu = AE_ZALIGN64();
 	ae_valign su = AE_ZALIGN64();
-	int remaining_samples = frame * sink->stream.channels;
+	int remaining_samples = frame * audio_stream_get_channels(&sink->stream);
 	uint32_t *dst = audio_stream_get_rptr(&sink->stream);
 	ae_int32x2 *in = (ae_int32x2 *)dst;
 	ae_int32x2 *out = (ae_int32x2 *)dst;

--- a/src/audio/crossover/crossover.c
+++ b/src/audio/crossover/crossover.c
@@ -731,10 +731,10 @@ static int crossover_prepare(struct comp_dev *dev)
 		} else {
 			sink_period_bytes = audio_stream_period_bytes(&sink_c->stream,
 								      dev->frames);
-			if (sink_c->stream.size < sink_period_bytes) {
+			if (audio_stream_get_size(&sink_c->stream) < sink_period_bytes) {
 				comp_err(dev,
 					 "crossover_prepare(), sink %d buffer size %d is insufficient",
-					 sink_c->pipeline_id, sink_c->stream.size);
+					 sink_c->pipeline_id, audio_stream_get_size(&sink_c->stream));
 				ret = -ENOMEM;
 			}
 		}

--- a/src/audio/crossover/crossover.c
+++ b/src/audio/crossover/crossover.c
@@ -716,16 +716,16 @@ static int crossover_prepare(struct comp_dev *dev)
 	source_c = buffer_acquire(source);
 
 	/* Get source data format */
-	cd->source_format = source_c->stream.frame_fmt;
+	cd->source_format = audio_stream_get_frm_fmt(&source_c->stream);
 
 	/* Validate frame format and buffer size of sinks */
 	list_for_item(sink_list, &dev->bsink_list) {
 		sink = container_of(sink_list, struct comp_buffer, source_list);
 		sink_c = buffer_acquire(sink);
 
-		if (cd->source_format != sink_c->stream.frame_fmt) {
+		if (cd->source_format != audio_stream_get_frm_fmt(&sink_c->stream)) {
 			comp_err(dev, "crossover_prepare(): Source fmt %d and sink fmt %d are different for sink %d.",
-				 cd->source_format, sink_c->stream.frame_fmt,
+				 cd->source_format, audio_stream_get_frm_fmt(&sink_c->stream),
 				 sink_c->pipeline_id);
 			ret = -EINVAL;
 		} else {

--- a/src/audio/crossover/crossover.c
+++ b/src/audio/crossover/crossover.c
@@ -610,7 +610,7 @@ static int crossover_copy(struct comp_dev *dev)
 	/* Check for changed configuration */
 	if (comp_is_new_data_blob_available(cd->model_handler)) {
 		cd->config = comp_get_data_blob(cd->model_handler, NULL, NULL);
-		ret = crossover_setup(cd, source_c->stream.channels);
+		ret = crossover_setup(cd, audio_stream_get_channels(&source_c->stream));
 		if (ret < 0) {
 			comp_err(dev, "crossover_copy(), failed Crossover setup");
 			goto out;
@@ -747,7 +747,7 @@ static int crossover_prepare(struct comp_dev *dev)
 
 	comp_info(dev, "crossover_prepare(), source_format=%d, sink_formats=%d, nch=%d",
 		  cd->source_format, cd->source_format,
-		  source_c->stream.channels);
+		  audio_stream_get_channels(&source_c->stream));
 
 	cd->config = comp_get_data_blob(cd->model_handler, NULL, NULL);
 
@@ -759,7 +759,7 @@ static int crossover_prepare(struct comp_dev *dev)
 	}
 
 	if (cd->config) {
-		ret = crossover_setup(cd, source_c->stream.channels);
+		ret = crossover_setup(cd, audio_stream_get_channels(&source_c->stream));
 		if (ret < 0) {
 			comp_err(dev, "crossover_prepare(), setup failed");
 			goto out;

--- a/src/audio/crossover/crossover_generic.c
+++ b/src/audio/crossover/crossover_generic.c
@@ -96,7 +96,7 @@ static void crossover_s16_default_pass(const struct comp_dev *dev,
 	int16_t *x;
 	int32_t *y;
 	int i, j;
-	int n = source_stream->channels * frames;
+	int n = audio_stream_get_channels(source_stream) * frames;
 
 	for (i = 0; i < n; i++) {
 		x = audio_stream_read_frag_s16(source_stream, i);
@@ -120,7 +120,7 @@ static void crossover_s32_default_pass(const struct comp_dev *dev,
 	const struct audio_stream __sparse_cache *source_stream = &source->stream;
 	int32_t *x, *y;
 	int i, j;
-	int n = source_stream->channels * frames;
+	int n = audio_stream_get_channels(source_stream) * frames;
 
 	for (i = 0; i < n; i++) {
 		x = audio_stream_read_frag_s32(source_stream, i);
@@ -148,7 +148,7 @@ static void crossover_s16_default(const struct comp_dev *dev,
 	int16_t *x, *y;
 	int ch, i, j;
 	int idx;
-	int nch = source_stream->channels;
+	int nch = audio_stream_get_channels(source_stream);
 	int32_t out[num_sinks];
 
 	for (ch = 0; ch < nch; ch++) {
@@ -187,7 +187,7 @@ static void crossover_s24_default(const struct comp_dev *dev,
 	int32_t *x, *y;
 	int ch, i, j;
 	int idx;
-	int nch = source_stream->channels;
+	int nch = audio_stream_get_channels(source_stream);
 	int32_t out[num_sinks];
 
 	for (ch = 0; ch < nch; ch++) {
@@ -226,7 +226,7 @@ static void crossover_s32_default(const struct comp_dev *dev,
 	int32_t *x, *y;
 	int ch, i, j;
 	int idx;
-	int nch = source_stream->channels;
+	int nch = audio_stream_get_channels(source_stream);
 	int32_t out[num_sinks];
 
 	for (ch = 0; ch < nch; ch++) {

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -332,8 +332,8 @@ static int dai_playback_params(struct comp_dev *dev, uint32_t period_bytes,
 	struct dma_sg_config *config = &dd->config;
 	struct comp_buffer __sparse_cache *dma_buf = buffer_acquire(dd->dma_buffer),
 		*local_buf = buffer_acquire(dd->local_buffer);
-	uint32_t local_fmt = local_buf->stream.frame_fmt;
-	uint32_t dma_fmt = dma_buf->stream.frame_fmt;
+	uint32_t local_fmt = audio_stream_get_frm_fmt(&local_buf->stream);
+	uint32_t dma_fmt = audio_stream_get_frm_fmt(&dma_buf->stream);
 	uint32_t fifo;
 	int err = 0;
 
@@ -394,8 +394,8 @@ static int dai_capture_params(struct comp_dev *dev, uint32_t period_bytes,
 	struct dma_sg_config *config = &dd->config;
 	struct comp_buffer __sparse_cache *dma_buf = buffer_acquire(dd->dma_buffer),
 		*local_buf = buffer_acquire(dd->local_buffer);
-	uint32_t local_fmt = local_buf->stream.frame_fmt;
-	uint32_t dma_fmt = dma_buf->stream.frame_fmt;
+	uint32_t local_fmt = audio_stream_get_frm_fmt(&local_buf->stream);
+	uint32_t dma_fmt = audio_stream_get_frm_fmt(&dma_buf->stream);
 	uint32_t fifo;
 	int err = 0;
 
@@ -941,7 +941,7 @@ static int dai_copy(struct comp_dev *dev)
 
 	buf_c = buffer_acquire(dd->dma_buffer);
 
-	dma_fmt = buf_c->stream.frame_fmt;
+	dma_fmt = audio_stream_get_frm_fmt(&buf_c->stream);
 	sampling = get_sample_bytes(dma_fmt);
 
 	buffer_release(buf_c);

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -374,7 +374,7 @@ static int dai_playback_params(struct comp_dev *dev, uint32_t period_bytes,
 				   config->direction,
 				   period_count,
 				   period_bytes,
-				   (uintptr_t)(dma_buf->stream.addr),
+				   (uintptr_t)(audio_stream_get_addr(&dma_buf->stream)),
 				   fifo);
 		if (err < 0)
 			comp_err(dev, "dai_playback_params(): dma_sg_alloc() for period_count %d period_bytes %d failed with err = %d",
@@ -447,7 +447,7 @@ static int dai_capture_params(struct comp_dev *dev, uint32_t period_bytes,
 				   config->direction,
 				   period_count,
 				   period_bytes,
-				   (uintptr_t)(dma_buf->stream.addr),
+				   (uintptr_t)(audio_stream_get_addr(&dma_buf->stream)),
 				   fifo);
 		if (err < 0)
 			comp_err(dev, "dai_capture_params(): dma_sg_alloc() for period_count %d period_bytes %d failed with err = %d",

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -543,7 +543,7 @@ static int dai_params(struct comp_dev *dev,
 
 	/* calculate frame size */
 	frame_size = get_frame_bytes(dev->ipc_config.frame_fmt,
-				     buffer_c->stream.channels);
+				     audio_stream_get_channels(&buffer_c->stream));
 
 	buffer_release(buffer_c);
 
@@ -968,7 +968,7 @@ static int dai_copy(struct comp_dev *dev)
 
 	comp_dbg(dev, "dai_copy(), dir: %d copy_bytes= 0x%x, frames= %d",
 		 dev->direction, copy_bytes,
-		 samples / buf_c->stream.channels);
+		 samples / audio_stream_get_channels(&buf_c->stream));
 
 	buffer_release(buf_c);
 

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -441,8 +441,8 @@ static int dai_playback_params(struct comp_dev *dev, uint32_t period_bytes,
 	struct dma_block_config *prev = NULL;
 	struct comp_buffer __sparse_cache *dma_buf = buffer_acquire(dd->dma_buffer),
 		*local_buf = buffer_acquire(dd->local_buffer);
-	uint32_t local_fmt = local_buf->stream.frame_fmt;
-	uint32_t dma_fmt = dma_buf->stream.frame_fmt;
+	uint32_t local_fmt = audio_stream_get_frm_fmt(&local_buf->stream);
+	uint32_t dma_fmt = audio_stream_get_frm_fmt(&dma_buf->stream);
 	uint32_t fifo, max_block_count, buf_size;
 	int i, err = 0;
 
@@ -579,8 +579,8 @@ static int dai_capture_params(struct comp_dev *dev, uint32_t period_bytes,
 	struct dma_block_config *prev = NULL;
 	struct comp_buffer __sparse_cache *dma_buf = buffer_acquire(dd->dma_buffer),
 		*local_buf = buffer_acquire(dd->local_buffer);
-	uint32_t local_fmt = local_buf->stream.frame_fmt;
-	uint32_t dma_fmt = dma_buf->stream.frame_fmt;
+	uint32_t local_fmt = audio_stream_get_frm_fmt(&local_buf->stream);
+	uint32_t dma_fmt = audio_stream_get_frm_fmt(&dma_buf->stream);
 	uint32_t fifo, max_block_count, buf_size;
 	int i, err = 0;
 
@@ -1241,7 +1241,7 @@ static int dai_copy(struct comp_dev *dev)
 
 	buf_c = buffer_acquire(dd->dma_buffer);
 
-	dma_fmt = buf_c->stream.frame_fmt;
+	dma_fmt = audio_stream_get_frm_fmt(&buf_c->stream);
 	sampling = get_sample_bytes(dma_fmt);
 
 	buffer_release(buf_c);

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -503,7 +503,7 @@ static int dai_playback_params(struct comp_dev *dev, uint32_t period_bytes,
 				   config->direction,
 				   period_count,
 				   period_bytes,
-				   (uintptr_t)(dma_buf->stream.addr),
+				   (uintptr_t)audio_stream_get_addr(&dma_buf->stream),
 				   fifo);
 		if (err < 0) {
 			comp_err(dev, "dai_playback_params(): dma_sg_alloc() for period_count %d period_bytes %d failed with err = %d",
@@ -658,7 +658,7 @@ static int dai_capture_params(struct comp_dev *dev, uint32_t period_bytes,
 				   config->direction,
 				   period_count,
 				   period_bytes,
-				   (uintptr_t)(dma_buf->stream.addr),
+				   (uintptr_t)audio_stream_get_addr(&dma_buf->stream),
 				   fifo);
 		if (err < 0) {
 			comp_err(dev, "dai_capture_params(): dma_sg_alloc() for period_count %d period_bytes %d failed with err = %d",

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -797,7 +797,7 @@ static int dai_params(struct comp_dev *dev, struct sof_ipc_stream_params *params
 
 	/* calculate frame size */
 	frame_size = get_frame_bytes(dev->ipc_config.frame_fmt,
-				     buffer_c->stream.channels);
+				     audio_stream_get_channels(&buffer_c->stream));
 
 	buffer_release(buffer_c);
 
@@ -1270,7 +1270,7 @@ static int dai_copy(struct comp_dev *dev)
 
 	comp_dbg(dev, "dai_copy(), dir: %d copy_bytes= 0x%x, frames= %d",
 		 dev->direction, copy_bytes,
-		 samples / buf_c->stream.channels);
+		 samples / audio_stream_get_channels(&buf_c->stream));
 
 	buffer_release(buf_c);
 

--- a/src/audio/dcblock/dcblock.c
+++ b/src/audio/dcblock/dcblock.c
@@ -365,9 +365,9 @@ static int dcblock_prepare(struct comp_dev *dev)
 	cd->sink_format = sink_c->stream.frame_fmt;
 	sink_period_bytes = audio_stream_period_bytes(&sink_c->stream, dev->frames);
 
-	if (sink_c->stream.size < sink_period_bytes) {
+	if (audio_stream_get_size(&sink_c->stream) < sink_period_bytes) {
 		comp_err(dev, "dcblock_prepare(): sink buffer size %d is insufficient < %d",
-			 sink_c->stream.size, sink_period_bytes);
+			 audio_stream_get_size(&sink_c->stream), sink_period_bytes);
 		ret = -ENOMEM;
 		goto out;
 	}

--- a/src/audio/dcblock/dcblock.c
+++ b/src/audio/dcblock/dcblock.c
@@ -359,10 +359,10 @@ static int dcblock_prepare(struct comp_dev *dev)
 	sink_c = buffer_acquire(sinkb);
 
 	/* get source data format */
-	cd->source_format = source_c->stream.frame_fmt;
+	cd->source_format = audio_stream_get_frm_fmt(&source_c->stream);
 
 	/* get sink data format and period bytes */
-	cd->sink_format = sink_c->stream.frame_fmt;
+	cd->sink_format = audio_stream_get_frm_fmt(&sink_c->stream);
 	sink_period_bytes = audio_stream_period_bytes(&sink_c->stream, dev->frames);
 
 	if (audio_stream_get_size(&sink_c->stream) < sink_period_bytes) {

--- a/src/audio/dcblock/dcblock_generic.c
+++ b/src/audio/dcblock/dcblock_generic.c
@@ -43,7 +43,7 @@ static void dcblock_s16_default(const struct comp_dev *dev,
 	struct comp_data *cd = comp_get_drvdata(dev);
 	struct dcblock_state *state;
 	int16_t *x = audio_stream_get_rptr(source);
-	int16_t *y = sink->w_ptr;
+	int16_t *y = audio_stream_get_wptr(sink);
 	int32_t R;
 	int32_t tmp;
 	int idx;
@@ -84,7 +84,7 @@ static void dcblock_s24_default(const struct comp_dev *dev,
 	struct comp_data *cd = comp_get_drvdata(dev);
 	struct dcblock_state *state;
 	int32_t *x = audio_stream_get_rptr(source);
-	int32_t *y = sink->w_ptr;
+	int32_t *y = audio_stream_get_wptr(sink);
 	int32_t R;
 	int32_t tmp;
 	int idx;
@@ -125,7 +125,7 @@ static void dcblock_s32_default(const struct comp_dev *dev,
 	struct comp_data *cd = comp_get_drvdata(dev);
 	struct dcblock_state *state;
 	int32_t *x = audio_stream_get_rptr(source);
-	int32_t *y = sink->w_ptr;
+	int32_t *y = audio_stream_get_wptr(sink);
 	int32_t R;
 	int idx;
 	int ch;

--- a/src/audio/dcblock/dcblock_generic.c
+++ b/src/audio/dcblock/dcblock_generic.c
@@ -42,7 +42,7 @@ static void dcblock_s16_default(const struct comp_dev *dev,
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 	struct dcblock_state *state;
-	int16_t *x = source->r_ptr;
+	int16_t *x = audio_stream_get_rptr(source);
 	int16_t *y = sink->w_ptr;
 	int32_t R;
 	int32_t tmp;
@@ -83,7 +83,7 @@ static void dcblock_s24_default(const struct comp_dev *dev,
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 	struct dcblock_state *state;
-	int32_t *x = source->r_ptr;
+	int32_t *x = audio_stream_get_rptr(source);
 	int32_t *y = sink->w_ptr;
 	int32_t R;
 	int32_t tmp;
@@ -124,7 +124,7 @@ static void dcblock_s32_default(const struct comp_dev *dev,
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 	struct dcblock_state *state;
-	int32_t *x = source->r_ptr;
+	int32_t *x = audio_stream_get_rptr(source);
 	int32_t *y = sink->w_ptr;
 	int32_t R;
 	int idx;

--- a/src/audio/dcblock/dcblock_generic.c
+++ b/src/audio/dcblock/dcblock_generic.c
@@ -49,7 +49,7 @@ static void dcblock_s16_default(const struct comp_dev *dev,
 	int idx;
 	int ch;
 	int i, n, nmax;
-	int nch = source->channels;
+	int nch = audio_stream_get_channels(source);
 	int samples = nch * frames;
 
 	while (samples) {
@@ -90,7 +90,7 @@ static void dcblock_s24_default(const struct comp_dev *dev,
 	int idx;
 	int ch;
 	int i, n, nmax;
-	int nch = source->channels;
+	int nch = audio_stream_get_channels(source);
 	int samples = nch * frames;
 
 	while (samples) {
@@ -130,7 +130,7 @@ static void dcblock_s32_default(const struct comp_dev *dev,
 	int idx;
 	int ch;
 	int i, n, nmax;
-	int nch = source->channels;
+	int nch = audio_stream_get_channels(source);
 	int samples = nch * frames;
 
 	while (samples) {

--- a/src/audio/dcblock/dcblock_hifi3.c
+++ b/src/audio/dcblock/dcblock_hifi3.c
@@ -32,7 +32,7 @@ static inline ae_int32x2  dcblock_cal(ae_int32x2 R, ae_int32x2 state_x, ae_int32
 static inline void dcblock_set_circular(const struct audio_stream __sparse_cache *source)
 {
 	/* Set source as circular buffer 0 */
-	AE_SETCBEGIN0(source->addr);
+	AE_SETCBEGIN0(audio_stream_get_addr(source));
 	AE_SETCEND0(audio_stream_get_end_addr(source));
 }
 

--- a/src/audio/dcblock/dcblock_hifi3.c
+++ b/src/audio/dcblock/dcblock_hifi3.c
@@ -43,7 +43,7 @@ static void dcblock_s16_default(const struct comp_dev *dev,
 				uint32_t frames)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
-	ae_int16 *src = (ae_int16 *)source->r_ptr;
+	ae_int16 *src = audio_stream_get_rptr(source);
 	ae_int16 *dst = (ae_int16 *)sink->w_ptr;
 	ae_int16 *in;
 	ae_int16 *out;
@@ -91,7 +91,7 @@ static void dcblock_s24_default(const struct comp_dev *dev,
 				uint32_t frames)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
-	ae_int32 *src = (ae_int32 *)source->r_ptr;
+	ae_int32 *src = audio_stream_get_rptr(source);
 	ae_int32 *dst = (ae_int32 *)sink->w_ptr;
 	ae_int32 *in;
 	ae_int32 *out;
@@ -139,7 +139,7 @@ static void dcblock_s32_default(const struct comp_dev *dev,
 				uint32_t frames)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
-	ae_int32 *src = (ae_int32 *)source->r_ptr;
+	ae_int32 *src = audio_stream_get_rptr(source);
 	ae_int32 *dst = (ae_int32 *)sink->w_ptr;
 	ae_int32 *in;
 	ae_int32 *out;

--- a/src/audio/dcblock/dcblock_hifi3.c
+++ b/src/audio/dcblock/dcblock_hifi3.c
@@ -44,7 +44,7 @@ static void dcblock_s16_default(const struct comp_dev *dev,
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 	ae_int16 *src = audio_stream_get_rptr(source);
-	ae_int16 *dst = (ae_int16 *)sink->w_ptr;
+	ae_int16 *dst = audio_stream_get_wptr(sink);
 	ae_int16 *in;
 	ae_int16 *out;
 	ae_int32x2 R, state_x, state_y, sample;
@@ -92,7 +92,7 @@ static void dcblock_s24_default(const struct comp_dev *dev,
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 	ae_int32 *src = audio_stream_get_rptr(source);
-	ae_int32 *dst = (ae_int32 *)sink->w_ptr;
+	ae_int32 *dst = audio_stream_get_wptr(sink);
 	ae_int32 *in;
 	ae_int32 *out;
 	ae_int32x2 R, state_x, state_y;
@@ -140,7 +140,7 @@ static void dcblock_s32_default(const struct comp_dev *dev,
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 	ae_int32 *src = audio_stream_get_rptr(source);
-	ae_int32 *dst = (ae_int32 *)sink->w_ptr;
+	ae_int32 *dst = audio_stream_get_wptr(sink);
 	ae_int32 *in;
 	ae_int32 *out;
 	ae_int32x2 R, state_x, state_y;

--- a/src/audio/dcblock/dcblock_hifi3.c
+++ b/src/audio/dcblock/dcblock_hifi3.c
@@ -33,7 +33,7 @@ static inline void dcblock_set_circular(const struct audio_stream __sparse_cache
 {
 	/* Set source as circular buffer 0 */
 	AE_SETCBEGIN0(source->addr);
-	AE_SETCEND0(source->end_addr);
+	AE_SETCEND0(audio_stream_get_end_addr(source));
 }
 
 #if CONFIG_FORMAT_S16LE

--- a/src/audio/dcblock/dcblock_hifi3.c
+++ b/src/audio/dcblock/dcblock_hifi3.c
@@ -50,7 +50,7 @@ static void dcblock_s16_default(const struct comp_dev *dev,
 	ae_int32x2 R, state_x, state_y, sample;
 	ae_int16x4 in_sample, out_sample;
 	int ch, i, n;
-	int nch = source->channels;
+	int nch = audio_stream_get_channels(source);
 	const int inc = nch * sizeof(ae_int16);
 	int samples = nch * frames;
 
@@ -98,7 +98,7 @@ static void dcblock_s24_default(const struct comp_dev *dev,
 	ae_int32x2 R, state_x, state_y;
 	ae_int32x2 in_sample, out_sample;
 	int ch, i, n;
-	int nch = source->channels;
+	int nch = audio_stream_get_channels(source);
 	const int inc = nch * sizeof(ae_int32);
 	int samples = nch * frames;
 
@@ -146,7 +146,7 @@ static void dcblock_s32_default(const struct comp_dev *dev,
 	ae_int32x2 R, state_x, state_y;
 	ae_int32x2 in_sample;
 	int ch, i, n;
-	int nch = source->channels;
+	int nch = audio_stream_get_channels(source);
 	const int inc = nch * sizeof(ae_int32);
 	int samples = nch * frames;
 

--- a/src/audio/dcblock/dcblock_hifi4.c
+++ b/src/audio/dcblock/dcblock_hifi4.c
@@ -33,11 +33,11 @@ static inline void dcblock_set_circular(const struct audio_stream __sparse_cache
 					const struct audio_stream __sparse_cache *sink)
 {
 	/* Set source as circular buffer 0 */
-	AE_SETCBEGIN0(source->addr);
+	AE_SETCBEGIN0(audio_stream_get_addr(source));
 	AE_SETCEND0(audio_stream_get_end_addr(source));
 
 	/* Set sink as circular buffer 1 */
-	AE_SETCBEGIN1(sink->addr);
+	AE_SETCBEGIN1(audio_stream_get_addr(sink));
 	AE_SETCEND1(audio_stream_get_end_addr(sink));
 }
 

--- a/src/audio/dcblock/dcblock_hifi4.c
+++ b/src/audio/dcblock/dcblock_hifi4.c
@@ -58,7 +58,7 @@ static void dcblock_s16_default(const struct comp_dev *dev,
 
 	dcblock_set_circular(source, sink);
 	for (ch = 0; ch < nch; ch++) {
-		in = (ae_int16 *)source->r_ptr + ch;
+		in = (ae_int16 *)audio_stream_get_rptr(source) + ch;
 		out = (ae_int16 *)sink->w_ptr + ch;
 		state_x = cd->state[ch].x_prev;
 		state_y = cd->state[ch].y_prev;
@@ -96,7 +96,7 @@ static void dcblock_s24_default(const struct comp_dev *dev,
 
 	dcblock_set_circular(source, sink);
 	for (ch = 0; ch < nch; ch++) {
-		in = (ae_int32 *)source->r_ptr + ch;
+		in = (ae_int32 *)audio_stream_get_rptr(source) + ch;
 		out = (ae_int32 *)sink->w_ptr + ch;
 
 		state_x = cd->state[ch].x_prev;
@@ -135,7 +135,7 @@ static void dcblock_s32_default(const struct comp_dev *dev,
 
 	dcblock_set_circular(source, sink);
 	for (ch = 0; ch < nch; ch++) {
-		in = (ae_int32 *)source->r_ptr + ch;
+		in = (ae_int32 *)audio_stream_get_rptr(source) + ch;
 		out = (ae_int32 *)sink->w_ptr + ch;
 
 		state_x = cd->state[ch].x_prev;

--- a/src/audio/dcblock/dcblock_hifi4.c
+++ b/src/audio/dcblock/dcblock_hifi4.c
@@ -34,11 +34,11 @@ static inline void dcblock_set_circular(const struct audio_stream __sparse_cache
 {
 	/* Set source as circular buffer 0 */
 	AE_SETCBEGIN0(source->addr);
-	AE_SETCEND0(source->end_addr);
+	AE_SETCEND0(audio_stream_get_end_addr(source));
 
 	/* Set sink as circular buffer 1 */
 	AE_SETCBEGIN1(sink->addr);
-	AE_SETCEND1(sink->end_addr);
+	AE_SETCEND1(audio_stream_get_end_addr(sink));
 }
 
 #if CONFIG_FORMAT_S16LE

--- a/src/audio/dcblock/dcblock_hifi4.c
+++ b/src/audio/dcblock/dcblock_hifi4.c
@@ -59,7 +59,7 @@ static void dcblock_s16_default(const struct comp_dev *dev,
 	dcblock_set_circular(source, sink);
 	for (ch = 0; ch < nch; ch++) {
 		in = (ae_int16 *)audio_stream_get_rptr(source) + ch;
-		out = (ae_int16 *)sink->w_ptr + ch;
+		out = (ae_int16 *)audio_stream_get_wptr(sink) + ch;
 		state_x = cd->state[ch].x_prev;
 		state_y = cd->state[ch].y_prev;
 		R = cd->R_coeffs[ch];
@@ -97,7 +97,7 @@ static void dcblock_s24_default(const struct comp_dev *dev,
 	dcblock_set_circular(source, sink);
 	for (ch = 0; ch < nch; ch++) {
 		in = (ae_int32 *)audio_stream_get_rptr(source) + ch;
-		out = (ae_int32 *)sink->w_ptr + ch;
+		out = (ae_int32 *)audio_stream_get_wptr(sink) + ch;
 
 		state_x = cd->state[ch].x_prev;
 		state_y = cd->state[ch].y_prev;
@@ -136,7 +136,7 @@ static void dcblock_s32_default(const struct comp_dev *dev,
 	dcblock_set_circular(source, sink);
 	for (ch = 0; ch < nch; ch++) {
 		in = (ae_int32 *)audio_stream_get_rptr(source) + ch;
-		out = (ae_int32 *)sink->w_ptr + ch;
+		out = (ae_int32 *)audio_stream_get_wptr(sink) + ch;
 
 		state_x = cd->state[ch].x_prev;
 		state_y = cd->state[ch].y_prev;

--- a/src/audio/dcblock/dcblock_hifi4.c
+++ b/src/audio/dcblock/dcblock_hifi4.c
@@ -53,7 +53,7 @@ static void dcblock_s16_default(const struct comp_dev *dev,
 	ae_int32x2 R, state_x, state_y, sample;
 	ae_int16x4 in_sample, out_sample;
 	int ch, i;
-	int nch = source->channels;
+	int nch = audio_stream_get_channels(source);
 	const int inc = nch * sizeof(ae_int16);
 
 	dcblock_set_circular(source, sink);
@@ -91,7 +91,7 @@ static void dcblock_s24_default(const struct comp_dev *dev,
 	ae_int32x2 R, state_x, state_y;
 	ae_int32x2 in_sample, out_sample;
 	int ch, i;
-	int nch = source->channels;
+	int nch = audio_stream_get_channels(source);
 	const int inc = nch * sizeof(ae_int32);
 
 	dcblock_set_circular(source, sink);
@@ -130,7 +130,7 @@ static void dcblock_s32_default(const struct comp_dev *dev,
 	ae_int32x2 R, state_x, state_y;
 	ae_int32x2 in_sample;
 	int ch, i;
-	int nch = source->channels;
+	int nch = audio_stream_get_channels(source);
 	const int inc = nch * sizeof(ae_int32);
 
 	dcblock_set_circular(source, sink);

--- a/src/audio/drc/drc.c
+++ b/src/audio/drc/drc.c
@@ -391,7 +391,7 @@ static int drc_prepare(struct comp_dev *dev)
 	source_c = buffer_acquire(sourceb);
 
 	/* get source data format */
-	cd->source_format = source_c->stream.frame_fmt;
+	cd->source_format = audio_stream_get_frm_fmt(&source_c->stream);
 
 	/* Initialize DRC */
 	comp_info(dev, "drc_prepare(), source_format=%d, sink_format=%d",
@@ -419,9 +419,9 @@ static int drc_prepare(struct comp_dev *dev)
 	sink_c = buffer_acquire(sinkb);
 
 	/* validate sink data format and period bytes */
-	if (cd->source_format != sink_c->stream.frame_fmt) {
+	if (cd->source_format != audio_stream_get_frm_fmt(&sink_c->stream)) {
 		comp_err(dev, "drc_prepare(): Source fmt %d and sink fmt %d are different.",
-			 cd->source_format, sink_c->stream.frame_fmt);
+			 cd->source_format, audio_stream_get_frm_fmt(&sink_c->stream));
 		ret = -EINVAL;
 		goto out_sink;
 	}

--- a/src/audio/drc/drc.c
+++ b/src/audio/drc/drc.c
@@ -429,9 +429,9 @@ static int drc_prepare(struct comp_dev *dev)
 	sink_period_bytes = audio_stream_period_bytes(&sink_c->stream,
 						      dev->frames);
 
-	if (sink_c->stream.size < sink_period_bytes) {
+	if (audio_stream_get_size(&sink_c->stream) < sink_period_bytes) {
 		comp_err(dev, "drc_prepare(), sink buffer size %d is insufficient",
-			 sink_c->stream.size);
+			 audio_stream_get_size(&sink_c->stream));
 		ret = -ENOMEM;
 	}
 

--- a/src/audio/drc/drc.c
+++ b/src/audio/drc/drc.c
@@ -344,7 +344,8 @@ static int drc_copy(struct comp_dev *dev)
 	/* Check for changed configuration */
 	if (comp_is_new_data_blob_available(cd->model_handler)) {
 		cd->config = comp_get_data_blob(cd->model_handler, NULL, NULL);
-		ret = drc_setup(cd, source_c->stream.channels, source_c->stream.rate);
+		ret = drc_setup(cd, source_c->stream.channels,
+				audio_stream_get_rate(&source_c->stream));
 		if (ret < 0) {
 			comp_err(dev, "drc_copy(), failed DRC setup");
 			goto out;
@@ -398,7 +399,8 @@ static int drc_prepare(struct comp_dev *dev)
 		  cd->source_format, cd->source_format);
 	cd->config = comp_get_data_blob(cd->model_handler, NULL, NULL);
 	if (cd->config) {
-		ret = drc_setup(cd, source_c->stream.channels, source_c->stream.rate);
+		ret = drc_setup(cd, source_c->stream.channels,
+				audio_stream_get_rate(&source_c->stream));
 		if (ret < 0) {
 			comp_err(dev, "drc_prepare() error: drc_setup failed.");
 			goto out_source;

--- a/src/audio/drc/drc.c
+++ b/src/audio/drc/drc.c
@@ -344,7 +344,7 @@ static int drc_copy(struct comp_dev *dev)
 	/* Check for changed configuration */
 	if (comp_is_new_data_blob_available(cd->model_handler)) {
 		cd->config = comp_get_data_blob(cd->model_handler, NULL, NULL);
-		ret = drc_setup(cd, source_c->stream.channels,
+		ret = drc_setup(cd, audio_stream_get_channels(&source_c->stream),
 				audio_stream_get_rate(&source_c->stream));
 		if (ret < 0) {
 			comp_err(dev, "drc_copy(), failed DRC setup");
@@ -399,7 +399,7 @@ static int drc_prepare(struct comp_dev *dev)
 		  cd->source_format, cd->source_format);
 	cd->config = comp_get_data_blob(cd->model_handler, NULL, NULL);
 	if (cd->config) {
-		ret = drc_setup(cd, source_c->stream.channels,
+		ret = drc_setup(cd, audio_stream_get_channels(&source_c->stream),
 				audio_stream_get_rate(&source_c->stream));
 		if (ret < 0) {
 			comp_err(dev, "drc_prepare() error: drc_setup failed.");

--- a/src/audio/drc/drc_generic.c
+++ b/src/audio/drc/drc_generic.c
@@ -532,7 +532,7 @@ static void drc_s16_default(const struct comp_dev *dev,
 			    uint32_t frames)
 {
 	int16_t *x = audio_stream_get_rptr(source);
-	int16_t *y = sink->w_ptr;
+	int16_t *y = audio_stream_get_wptr(sink);
 	int nch = source->channels;
 	int samples = frames * nch;
 	struct drc_comp_data *cd = comp_get_drvdata(dev);
@@ -678,7 +678,7 @@ static void drc_s24_default(const struct comp_dev *dev,
 			    uint32_t frames)
 {
 	int32_t *x = audio_stream_get_rptr(source);
-	int32_t *y = sink->w_ptr;
+	int32_t *y = audio_stream_get_wptr(sink);
 	int nch = source->channels;
 	int samples = frames * nch;
 	struct drc_comp_data *cd = comp_get_drvdata(dev);
@@ -726,7 +726,7 @@ static void drc_s32_default(const struct comp_dev *dev,
 			    uint32_t frames)
 {
 	int32_t *x = audio_stream_get_rptr(source);
-	int32_t *y = sink->w_ptr;
+	int32_t *y = audio_stream_get_wptr(sink);
 	int nch = source->channels;
 	int samples = frames * nch;
 	struct drc_comp_data *cd = comp_get_drvdata(dev);

--- a/src/audio/drc/drc_generic.c
+++ b/src/audio/drc/drc_generic.c
@@ -531,7 +531,7 @@ static void drc_s16_default(const struct comp_dev *dev,
 			    struct audio_stream __sparse_cache *sink,
 			    uint32_t frames)
 {
-	int16_t *x = source->r_ptr;
+	int16_t *x = audio_stream_get_rptr(source);
 	int16_t *y = sink->w_ptr;
 	int nch = source->channels;
 	int samples = frames * nch;
@@ -677,7 +677,7 @@ static void drc_s24_default(const struct comp_dev *dev,
 			    struct audio_stream __sparse_cache *sink,
 			    uint32_t frames)
 {
-	int32_t *x = source->r_ptr;
+	int32_t *x = audio_stream_get_rptr(source);
 	int32_t *y = sink->w_ptr;
 	int nch = source->channels;
 	int samples = frames * nch;
@@ -725,7 +725,7 @@ static void drc_s32_default(const struct comp_dev *dev,
 			    struct audio_stream __sparse_cache *sink,
 			    uint32_t frames)
 {
-	int32_t *x = source->r_ptr;
+	int32_t *x = audio_stream_get_rptr(source);
 	int32_t *y = sink->w_ptr;
 	int nch = source->channels;
 	int samples = frames * nch;

--- a/src/audio/drc/drc_generic.c
+++ b/src/audio/drc/drc_generic.c
@@ -468,7 +468,7 @@ static void drc_process_one_division(struct drc_state *state,
 void drc_default_pass(const struct comp_dev *dev, const struct audio_stream __sparse_cache *source,
 		      struct audio_stream __sparse_cache *sink, uint32_t frames)
 {
-	audio_stream_copy(source, 0, sink, 0, frames * source->channels);
+	audio_stream_copy(source, 0, sink, 0, frames * audio_stream_get_channels(source));
 }
 
 static inline void drc_pre_delay_index_inc(int *idx, int increment)
@@ -492,7 +492,7 @@ static void drc_delay_input_sample_s16(struct drc_state *state,
 	int16_t *x0 = *x;
 	int16_t *y0 = *y;
 	int remaining_samples = samples;
-	int nch = source->channels;
+	int nch = audio_stream_get_channels(source);
 
 	while (remaining_samples) {
 		nbuf = audio_stream_samples_without_wrap_s16(source, x0);
@@ -533,7 +533,7 @@ static void drc_s16_default(const struct comp_dev *dev,
 {
 	int16_t *x = audio_stream_get_rptr(source);
 	int16_t *y = audio_stream_get_wptr(sink);
-	int nch = source->channels;
+	int nch = audio_stream_get_channels(source);
 	int samples = frames * nch;
 	struct drc_comp_data *cd = comp_get_drvdata(dev);
 	struct drc_state *state = &cd->state;
@@ -587,7 +587,7 @@ static void drc_delay_input_sample_s32(struct drc_state *state,
 	int32_t *x0 = *x;
 	int32_t *y0 = *y;
 	int remaining_samples = samples;
-	int nch = source->channels;
+	int nch = audio_stream_get_channels(source);
 
 	while (remaining_samples) {
 		nbuf = audio_stream_samples_without_wrap_s32(source, x0);
@@ -638,7 +638,7 @@ static void drc_delay_input_sample_s24(struct drc_state *state,
 	int32_t *x0 = *x;
 	int32_t *y0 = *y;
 	int remaining_samples = samples;
-	int nch = source->channels;
+	int nch = audio_stream_get_channels(source);
 
 	while (remaining_samples) {
 		nbuf = audio_stream_samples_without_wrap_s24(source, x0);
@@ -679,7 +679,7 @@ static void drc_s24_default(const struct comp_dev *dev,
 {
 	int32_t *x = audio_stream_get_rptr(source);
 	int32_t *y = audio_stream_get_wptr(sink);
-	int nch = source->channels;
+	int nch = audio_stream_get_channels(source);
 	int samples = frames * nch;
 	struct drc_comp_data *cd = comp_get_drvdata(dev);
 	struct drc_state *state = &cd->state;
@@ -727,7 +727,7 @@ static void drc_s32_default(const struct comp_dev *dev,
 {
 	int32_t *x = audio_stream_get_rptr(source);
 	int32_t *y = audio_stream_get_wptr(sink);
-	int nch = source->channels;
+	int nch = audio_stream_get_channels(source);
 	int samples = frames * nch;
 	struct drc_comp_data *cd = comp_get_drvdata(dev);
 	struct drc_state *state = &cd->state;

--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -529,7 +529,7 @@ static int eq_fir_process(struct processing_module *mod,
 			return ret;
 		} else if (cd->fir_delay_size) {
 			comp_dbg(mod->dev, "eq_fir_process(), active");
-			ret = set_fir_func(mod, source->frame_fmt);
+			ret = set_fir_func(mod, audio_stream_get_frm_fmt(source));
 			if (ret < 0)
 				return ret;
 		} else {
@@ -593,7 +593,7 @@ static int eq_fir_prepare(struct processing_module *mod)
 	sink_c = buffer_acquire(sinkb);
 	eq_fir_set_alignment(&source_c->stream, &sink_c->stream);
 	channels = sink_c->stream.channels;
-	frame_fmt = source_c->stream.frame_fmt;
+	frame_fmt = audio_stream_get_frm_fmt(&source_c->stream);
 	buffer_release(sink_c);
 	buffer_release(source_c);
 

--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -175,7 +175,7 @@ static int eq_fir_params(struct processing_module *mod)
 	struct comp_dev *dev = mod->dev;
 	struct comp_buffer *sinkb;
 	struct comp_buffer __sparse_cache *sink_c;
-	uint32_t __sparse_cache valid_fmt, frame_fmt;
+	enum sof_ipc_frame valid_fmt, frame_fmt;
 	int i, ret;
 
 	comp_dbg(dev, "eq_fir_params()");

--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -216,7 +216,7 @@ static void eq_fir_passthrough(struct fir_state_32x16 fir[],
 	struct audio_stream __sparse_cache *source = bsource->data;
 	struct audio_stream __sparse_cache *sink = bsink->data;
 
-	audio_stream_copy(source, 0, sink, 0, frames * source->channels);
+	audio_stream_copy(source, 0, sink, 0, frames * audio_stream_get_channels(source));
 }
 
 static void eq_fir_free_delaylines(struct comp_data *cd)
@@ -523,7 +523,7 @@ static int eq_fir_process(struct processing_module *mod,
 	/* Check for changed configuration */
 	if (comp_is_new_data_blob_available(cd->model_handler)) {
 		cd->config = comp_get_data_blob(cd->model_handler, NULL, NULL);
-		ret = eq_fir_setup(mod->dev, cd, source->channels);
+		ret = eq_fir_setup(mod->dev, cd, audio_stream_get_channels(source));
 		if (ret < 0) {
 			comp_err(mod->dev, "eq_fir_process(), failed FIR setup");
 			return ret;
@@ -592,7 +592,7 @@ static int eq_fir_prepare(struct processing_module *mod)
 	source_c = buffer_acquire(sourceb);
 	sink_c = buffer_acquire(sinkb);
 	eq_fir_set_alignment(&source_c->stream, &sink_c->stream);
-	channels = sink_c->stream.channels;
+	channels = audio_stream_get_channels(&sink_c->stream);
 	frame_fmt = audio_stream_get_frm_fmt(&source_c->stream);
 	buffer_release(sink_c);
 	buffer_release(source_c);

--- a/src/audio/eq_fir/eq_fir_generic.c
+++ b/src/audio/eq_fir/eq_fir_generic.c
@@ -28,7 +28,7 @@ void eq_fir_s16(struct fir_state_32x16 fir[], struct input_stream_buffer *bsourc
 	struct fir_state_32x16 *filter;
 	int32_t z;
 	int16_t *x0, *y0;
-	int16_t *x = source->r_ptr;
+	int16_t *x = audio_stream_get_rptr(source);
 	int16_t *y = sink->w_ptr;
 	int nmax, n, i, j;
 	int nch = source->channels;
@@ -66,7 +66,7 @@ void eq_fir_s24(struct fir_state_32x16 fir[], struct input_stream_buffer *bsourc
 	struct fir_state_32x16 *filter;
 	int32_t z;
 	int32_t *x0, *y0;
-	int32_t *x = source->r_ptr;
+	int32_t *x = audio_stream_get_rptr(source);
 	int32_t *y = sink->w_ptr;
 	int nmax, n, i, j;
 	int nch = source->channels;
@@ -103,7 +103,7 @@ void eq_fir_s32(struct fir_state_32x16 fir[], struct input_stream_buffer *bsourc
 	struct audio_stream __sparse_cache *sink = bsink->data;
 	struct fir_state_32x16 *filter;
 	int32_t *x0, *y0;
-	int32_t *x = source->r_ptr;
+	int32_t *x = audio_stream_get_rptr(source);
 	int32_t *y = sink->w_ptr;
 	int nmax, n, i, j;
 	int nch = source->channels;

--- a/src/audio/eq_fir/eq_fir_generic.c
+++ b/src/audio/eq_fir/eq_fir_generic.c
@@ -29,7 +29,7 @@ void eq_fir_s16(struct fir_state_32x16 fir[], struct input_stream_buffer *bsourc
 	int32_t z;
 	int16_t *x0, *y0;
 	int16_t *x = audio_stream_get_rptr(source);
-	int16_t *y = sink->w_ptr;
+	int16_t *y = audio_stream_get_wptr(sink);
 	int nmax, n, i, j;
 	int nch = source->channels;
 	int remaining_samples = frames * nch;
@@ -67,7 +67,7 @@ void eq_fir_s24(struct fir_state_32x16 fir[], struct input_stream_buffer *bsourc
 	int32_t z;
 	int32_t *x0, *y0;
 	int32_t *x = audio_stream_get_rptr(source);
-	int32_t *y = sink->w_ptr;
+	int32_t *y = audio_stream_get_wptr(sink);
 	int nmax, n, i, j;
 	int nch = source->channels;
 	int remaining_samples = frames * nch;
@@ -104,7 +104,7 @@ void eq_fir_s32(struct fir_state_32x16 fir[], struct input_stream_buffer *bsourc
 	struct fir_state_32x16 *filter;
 	int32_t *x0, *y0;
 	int32_t *x = audio_stream_get_rptr(source);
-	int32_t *y = sink->w_ptr;
+	int32_t *y = audio_stream_get_wptr(sink);
 	int nmax, n, i, j;
 	int nch = source->channels;
 	int remaining_samples = frames * nch;

--- a/src/audio/eq_fir/eq_fir_generic.c
+++ b/src/audio/eq_fir/eq_fir_generic.c
@@ -31,7 +31,7 @@ void eq_fir_s16(struct fir_state_32x16 fir[], struct input_stream_buffer *bsourc
 	int16_t *x = audio_stream_get_rptr(source);
 	int16_t *y = audio_stream_get_wptr(sink);
 	int nmax, n, i, j;
-	int nch = source->channels;
+	int nch = audio_stream_get_channels(source);
 	int remaining_samples = frames * nch;
 
 	while (remaining_samples) {
@@ -69,7 +69,7 @@ void eq_fir_s24(struct fir_state_32x16 fir[], struct input_stream_buffer *bsourc
 	int32_t *x = audio_stream_get_rptr(source);
 	int32_t *y = audio_stream_get_wptr(sink);
 	int nmax, n, i, j;
-	int nch = source->channels;
+	int nch = audio_stream_get_channels(source);
 	int remaining_samples = frames * nch;
 
 	while (remaining_samples) {
@@ -106,7 +106,7 @@ void eq_fir_s32(struct fir_state_32x16 fir[], struct input_stream_buffer *bsourc
 	int32_t *x = audio_stream_get_rptr(source);
 	int32_t *y = audio_stream_get_wptr(sink);
 	int nmax, n, i, j;
-	int nch = source->channels;
+	int nch = audio_stream_get_channels(source);
 	int remaining_samples = frames * nch;
 
 	while (remaining_samples) {

--- a/src/audio/eq_fir/eq_fir_hifi2ep.c
+++ b/src/audio/eq_fir/eq_fir_hifi2ep.c
@@ -31,7 +31,7 @@ void eq_fir_2x_s32(struct fir_state_32x16 fir[], struct input_stream_buffer *bso
 	struct audio_stream __sparse_cache *source = bsource->data;
 	struct audio_stream __sparse_cache *sink = bsink->data;
 	struct fir_state_32x16 *f;
-	int32_t *src = (int32_t *)source->r_ptr;
+	int32_t *src = audio_stream_get_rptr(source);
 	int32_t *snk = (int32_t *)sink->w_ptr;
 	int32_t *x0;
 	int32_t *y0;
@@ -75,7 +75,7 @@ void eq_fir_2x_s24(struct fir_state_32x16 fir[], struct input_stream_buffer *bso
 	struct audio_stream __sparse_cache *source = bsource->data;
 	struct audio_stream __sparse_cache *sink = bsink->data;
 	struct fir_state_32x16 *f;
-	int32_t *src = (int32_t *)source->r_ptr;
+	int32_t *src = audio_stream_get_rptr(source);
 	int32_t *snk = (int32_t *)sink->w_ptr;
 	int32_t *x0;
 	int32_t *y0;
@@ -123,7 +123,7 @@ void eq_fir_2x_s16(struct fir_state_32x16 fir[], struct input_stream_buffer *bso
 	struct audio_stream __sparse_cache *source = bsource->data;
 	struct audio_stream __sparse_cache *sink = bsink->data;
 	struct fir_state_32x16 *f;
-	int16_t *src = (int16_t *)source->r_ptr;
+	int16_t *src = audio_stream_get_rptr(source);
 	int16_t *snk = (int16_t *)sink->w_ptr;
 	int16_t *x0;
 	int16_t *y0;

--- a/src/audio/eq_fir/eq_fir_hifi2ep.c
+++ b/src/audio/eq_fir/eq_fir_hifi2ep.c
@@ -32,7 +32,7 @@ void eq_fir_2x_s32(struct fir_state_32x16 fir[], struct input_stream_buffer *bso
 	struct audio_stream __sparse_cache *sink = bsink->data;
 	struct fir_state_32x16 *f;
 	int32_t *src = audio_stream_get_rptr(source);
-	int32_t *snk = (int32_t *)sink->w_ptr;
+	int32_t *snk = audio_stream_get_wptr(sink);
 	int32_t *x0;
 	int32_t *y0;
 	int32_t *x1;
@@ -76,7 +76,7 @@ void eq_fir_2x_s24(struct fir_state_32x16 fir[], struct input_stream_buffer *bso
 	struct audio_stream __sparse_cache *sink = bsink->data;
 	struct fir_state_32x16 *f;
 	int32_t *src = audio_stream_get_rptr(source);
-	int32_t *snk = (int32_t *)sink->w_ptr;
+	int32_t *snk = audio_stream_get_wptr(sink);
 	int32_t *x0;
 	int32_t *y0;
 	int32_t *x1;
@@ -124,7 +124,7 @@ void eq_fir_2x_s16(struct fir_state_32x16 fir[], struct input_stream_buffer *bso
 	struct audio_stream __sparse_cache *sink = bsink->data;
 	struct fir_state_32x16 *f;
 	int16_t *src = audio_stream_get_rptr(source);
-	int16_t *snk = (int16_t *)sink->w_ptr;
+	int16_t *snk = audio_stream_get_wptr(sink);
 	int16_t *x0;
 	int16_t *y0;
 	int16_t *x1;

--- a/src/audio/eq_fir/eq_fir_hifi2ep.c
+++ b/src/audio/eq_fir/eq_fir_hifi2ep.c
@@ -41,7 +41,7 @@ void eq_fir_2x_s32(struct fir_state_32x16 fir[], struct input_stream_buffer *bso
 	int i;
 	int rshift;
 	int lshift;
-	int nch = source->channels;
+	int nch = audio_stream_get_channels(source);
 	int inc = nch << 1;
 
 	for (ch = 0; ch < nch; ch++) {
@@ -87,7 +87,7 @@ void eq_fir_2x_s24(struct fir_state_32x16 fir[], struct input_stream_buffer *bso
 	int i;
 	int rshift;
 	int lshift;
-	int nch = source->channels;
+	int nch = audio_stream_get_channels(source);
 	int inc = nch << 1;
 
 	for (ch = 0; ch < nch; ch++) {
@@ -135,7 +135,7 @@ void eq_fir_2x_s16(struct fir_state_32x16 fir[], struct input_stream_buffer *bso
 	int i;
 	int rshift;
 	int lshift;
-	int nch = source->channels;
+	int nch = audio_stream_get_channels(source);
 	int inc = nch << 1;
 
 	for (ch = 0; ch < nch; ch++) {

--- a/src/audio/eq_fir/eq_fir_hifi3.c
+++ b/src/audio/eq_fir/eq_fir_hifi3.c
@@ -33,7 +33,7 @@ void eq_fir_2x_s32(struct fir_state_32x16 fir[], struct input_stream_buffer *bso
 	ae_int32x2 d0 = 0;
 	ae_int32x2 d1 = 0;
 	ae_int32 *src = audio_stream_get_rptr(source);
-	ae_int32 *snk = (ae_int32 *)sink->w_ptr;
+	ae_int32 *snk = audio_stream_get_wptr(sink);
 	ae_int32 *x;
 	ae_int32 *y0;
 	ae_int32 *y1;
@@ -98,7 +98,7 @@ void eq_fir_2x_s24(struct fir_state_32x16 fir[], struct input_stream_buffer *bso
 	ae_int32 z0;
 	ae_int32 z1;
 	ae_int32 *src = audio_stream_get_rptr(source);
-	ae_int32 *snk = (ae_int32 *)sink->w_ptr;
+	ae_int32 *snk = audio_stream_get_wptr(sink);
 	ae_int32 *x;
 	ae_int32 *y;
 	int ch;
@@ -174,7 +174,7 @@ void eq_fir_2x_s16(struct fir_state_32x16 fir[], struct input_stream_buffer *bso
 	ae_int32 x0;
 	ae_int32 x1;
 	ae_int16 *src = audio_stream_get_rptr(source);
-	ae_int16 *snk = (ae_int16 *)sink->w_ptr;
+	ae_int16 *snk = audio_stream_get_wptr(sink);
 	ae_int16 *x;
 	ae_int16 *y;
 	int ch;

--- a/src/audio/eq_fir/eq_fir_hifi3.c
+++ b/src/audio/eq_fir/eq_fir_hifi3.c
@@ -32,7 +32,7 @@ void eq_fir_2x_s32(struct fir_state_32x16 fir[], struct input_stream_buffer *bso
 	struct fir_state_32x16 *f;
 	ae_int32x2 d0 = 0;
 	ae_int32x2 d1 = 0;
-	ae_int32 *src = (ae_int32 *)source->r_ptr;
+	ae_int32 *src = audio_stream_get_rptr(source);
 	ae_int32 *snk = (ae_int32 *)sink->w_ptr;
 	ae_int32 *x;
 	ae_int32 *y0;
@@ -97,7 +97,7 @@ void eq_fir_2x_s24(struct fir_state_32x16 fir[], struct input_stream_buffer *bso
 	ae_int32x2 d1 = 0;
 	ae_int32 z0;
 	ae_int32 z1;
-	ae_int32 *src = (ae_int32 *)source->r_ptr;
+	ae_int32 *src = audio_stream_get_rptr(source);
 	ae_int32 *snk = (ae_int32 *)sink->w_ptr;
 	ae_int32 *x;
 	ae_int32 *y;
@@ -173,7 +173,7 @@ void eq_fir_2x_s16(struct fir_state_32x16 fir[], struct input_stream_buffer *bso
 	ae_int32 z1;
 	ae_int32 x0;
 	ae_int32 x1;
-	ae_int16 *src = (ae_int16 *)source->r_ptr;
+	ae_int16 *src = audio_stream_get_rptr(source);
 	ae_int16 *snk = (ae_int16 *)sink->w_ptr;
 	ae_int16 *x;
 	ae_int16 *y;

--- a/src/audio/eq_fir/eq_fir_hifi3.c
+++ b/src/audio/eq_fir/eq_fir_hifi3.c
@@ -42,7 +42,7 @@ void eq_fir_2x_s32(struct fir_state_32x16 fir[], struct input_stream_buffer *bso
 	int rshift;
 	int lshift;
 	int shift;
-	int nch = source->channels;
+	int nch = audio_stream_get_channels(source);
 	int inc_nch_s = nch * sizeof(int32_t);
 	int inc_2nch_s = 2 * inc_nch_s;
 
@@ -106,7 +106,7 @@ void eq_fir_2x_s24(struct fir_state_32x16 fir[], struct input_stream_buffer *bso
 	int rshift;
 	int lshift;
 	int shift;
-	int nch = source->channels;
+	int nch = audio_stream_get_channels(source);
 	int inc_nch_s = nch * sizeof(int32_t);
 
 	for (ch = 0; ch < nch; ch++) {
@@ -182,7 +182,7 @@ void eq_fir_2x_s16(struct fir_state_32x16 fir[], struct input_stream_buffer *bso
 	int rshift;
 	int lshift;
 	int shift;
-	int nch = source->channels;
+	int nch = audio_stream_get_channels(source);
 	int inc_nch_s = nch * sizeof(int16_t);
 
 	for (ch = 0; ch < nch; ch++) {

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -82,7 +82,7 @@ static void eq_iir_s16_default(struct processing_module *mod, struct input_strea
 	int processed = 0;
 
 	x = audio_stream_get_rptr(source);
-	y = sink->w_ptr;
+	y = audio_stream_get_wptr(sink);
 	while (processed < samples) {
 		nmax = samples - processed;
 		n1 = audio_stream_bytes_without_wrap(source, x) >> 1;
@@ -130,7 +130,7 @@ static void eq_iir_s24_default(struct processing_module *mod, struct input_strea
 	int processed = 0;
 
 	x = audio_stream_get_rptr(source);
-	y = sink->w_ptr;
+	y = audio_stream_get_wptr(sink);
 	while (processed < samples) {
 		nmax = samples - processed;
 		n1 = audio_stream_bytes_without_wrap(source, x) >> 2;
@@ -178,7 +178,7 @@ static void eq_iir_s32_default(struct processing_module *mod, struct input_strea
 	int processed = 0;
 
 	x = audio_stream_get_rptr(source);
-	y = sink->w_ptr;
+	y = audio_stream_get_wptr(sink);
 	while (processed < samples) {
 		nmax = samples - processed;
 		n1 = audio_stream_bytes_without_wrap(source, x) >> 2;
@@ -227,7 +227,7 @@ static void eq_iir_s32_16_default(struct processing_module *mod,
 	int processed = 0;
 
 	x = audio_stream_get_rptr(source);
-	y = sink->w_ptr;
+	y = audio_stream_get_wptr(sink);
 	while (processed < samples) {
 		nmax = samples - processed;
 		n1 = audio_stream_bytes_without_wrap(source, x) >> 2; /* divide 4 */
@@ -275,7 +275,7 @@ static void eq_iir_s32_24_default(struct processing_module *mod,
 	int processed = 0;
 
 	x = audio_stream_get_rptr(source);
-	y = sink->w_ptr;
+	y = audio_stream_get_wptr(sink);
 	while (processed < samples) {
 		nmax = samples - processed;
 		n1 = audio_stream_bytes_without_wrap(source, x) >> 2;
@@ -317,7 +317,7 @@ static void eq_iir_s32_s16_pass(struct processing_module *mod, struct input_stre
 	struct audio_stream __sparse_cache *source = bsource->data;
 	struct audio_stream __sparse_cache *sink = bsink->data;
 	int32_t *x = audio_stream_get_rptr(source);
-	int16_t *y = sink->w_ptr;
+	int16_t *y = audio_stream_get_wptr(sink);
 	int nmax;
 	int n;
 	int i;
@@ -347,7 +347,7 @@ static void eq_iir_s32_s24_pass(struct processing_module *mod, struct input_stre
 	struct audio_stream __sparse_cache *source = bsource->data;
 	struct audio_stream __sparse_cache *sink = bsink->data;
 	int32_t *x = audio_stream_get_rptr(source);
-	int32_t *y = sink->w_ptr;
+	int32_t *y = audio_stream_get_wptr(sink);
 	int nmax;
 	int n;
 	int i;

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -720,8 +720,8 @@ static int eq_iir_verify_params(struct comp_dev *dev,
 	 * pcm frame_fmt and will not make any conversion (sink and source
 	 * frame_fmt will be equal).
 	 */
-	buffer_flag = eq_iir_find_func(source_c->stream.frame_fmt,
-				       sink_c->stream.frame_fmt, fm_configured,
+	buffer_flag = eq_iir_find_func(audio_stream_get_frm_fmt(&source_c->stream),
+				       audio_stream_get_frm_fmt(&sink_c->stream), fm_configured,
 				       ARRAY_SIZE(fm_configured)) ?
 				       BUFF_PARAMS_FRAME_FMT : 0;
 
@@ -808,8 +808,8 @@ static int eq_iir_process(struct processing_module *mod,
 	/* Check for changed configuration */
 	if (comp_is_new_data_blob_available(cd->model_handler)) {
 		cd->config = comp_get_data_blob(cd->model_handler, NULL, NULL);
-		ret = eq_iir_new_blob(mod, cd, source->frame_fmt,
-				      sink->frame_fmt, source->channels);
+		ret = eq_iir_new_blob(mod, cd, audio_stream_get_frm_fmt(source),
+				      audio_stream_get_frm_fmt(sink), source->channels);
 		if (ret)
 			return ret;
 	}
@@ -919,8 +919,8 @@ static int eq_iir_prepare(struct processing_module *mod)
 
 	/* get source and sink data format */
 	channels = sink_c->stream.channels;
-	source_format = source_c->stream.frame_fmt;
-	sink_format = sink_c->stream.frame_fmt;
+	source_format = audio_stream_get_frm_fmt(&source_c->stream);
+	sink_format = audio_stream_get_frm_fmt(&sink_c->stream);
 	buffer_release(sink_c);
 	buffer_release(source_c);
 

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -81,7 +81,7 @@ static void eq_iir_s16_default(struct processing_module *mod, struct input_strea
 	const int samples = frames * nch;
 	int processed = 0;
 
-	x = source->r_ptr;
+	x = audio_stream_get_rptr(source);
 	y = sink->w_ptr;
 	while (processed < samples) {
 		nmax = samples - processed;
@@ -129,7 +129,7 @@ static void eq_iir_s24_default(struct processing_module *mod, struct input_strea
 	const int samples = frames * nch;
 	int processed = 0;
 
-	x = source->r_ptr;
+	x = audio_stream_get_rptr(source);
 	y = sink->w_ptr;
 	while (processed < samples) {
 		nmax = samples - processed;
@@ -177,7 +177,7 @@ static void eq_iir_s32_default(struct processing_module *mod, struct input_strea
 	const int samples = frames * nch;
 	int processed = 0;
 
-	x = source->r_ptr;
+	x = audio_stream_get_rptr(source);
 	y = sink->w_ptr;
 	while (processed < samples) {
 		nmax = samples - processed;
@@ -226,7 +226,7 @@ static void eq_iir_s32_16_default(struct processing_module *mod,
 	const int samples = frames * nch;
 	int processed = 0;
 
-	x = source->r_ptr;
+	x = audio_stream_get_rptr(source);
 	y = sink->w_ptr;
 	while (processed < samples) {
 		nmax = samples - processed;
@@ -274,7 +274,7 @@ static void eq_iir_s32_24_default(struct processing_module *mod,
 	const int samples = frames * nch;
 	int processed = 0;
 
-	x = source->r_ptr;
+	x = audio_stream_get_rptr(source);
 	y = sink->w_ptr;
 	while (processed < samples) {
 		nmax = samples - processed;
@@ -316,7 +316,7 @@ static void eq_iir_s32_s16_pass(struct processing_module *mod, struct input_stre
 {
 	struct audio_stream __sparse_cache *source = bsource->data;
 	struct audio_stream __sparse_cache *sink = bsink->data;
-	int32_t *x = source->r_ptr;
+	int32_t *x = audio_stream_get_rptr(source);
 	int16_t *y = sink->w_ptr;
 	int nmax;
 	int n;
@@ -346,7 +346,7 @@ static void eq_iir_s32_s24_pass(struct processing_module *mod, struct input_stre
 {
 	struct audio_stream __sparse_cache *source = bsource->data;
 	struct audio_stream __sparse_cache *sink = bsink->data;
-	int32_t *x = source->r_ptr;
+	int32_t *x = audio_stream_get_rptr(source);
 	int32_t *y = sink->w_ptr;
 	int nmax;
 	int n;

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -844,7 +844,7 @@ static int eq_iir_params(struct processing_module *mod)
 	struct comp_dev *dev = mod->dev;
 	struct comp_buffer *sinkb;
 	struct comp_buffer __sparse_cache *sink_c;
-	uint32_t __sparse_cache valid_fmt, frame_fmt;
+	enum sof_ipc_frame valid_fmt, frame_fmt;
 	int i, ret;
 
 	comp_dbg(dev, "eq_iir_params()");

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -77,7 +77,7 @@ static void eq_iir_s16_default(struct processing_module *mod, struct input_strea
 	int i;
 	int j;
 	int n;
-	const int nch = source->channels;
+	const int nch = audio_stream_get_channels(source);
 	const int samples = frames * nch;
 	int processed = 0;
 
@@ -125,7 +125,7 @@ static void eq_iir_s24_default(struct processing_module *mod, struct input_strea
 	int i;
 	int j;
 	int n;
-	const int nch = source->channels;
+	const int nch = audio_stream_get_channels(source);
 	const int samples = frames * nch;
 	int processed = 0;
 
@@ -173,7 +173,7 @@ static void eq_iir_s32_default(struct processing_module *mod, struct input_strea
 	int i;
 	int j;
 	int n;
-	const int nch = source->channels;
+	const int nch = audio_stream_get_channels(source);
 	const int samples = frames * nch;
 	int processed = 0;
 
@@ -222,7 +222,7 @@ static void eq_iir_s32_16_default(struct processing_module *mod,
 	int i;
 	int j;
 	int n;
-	const int nch = source->channels;
+	const int nch = audio_stream_get_channels(source);
 	const int samples = frames * nch;
 	int processed = 0;
 
@@ -270,7 +270,7 @@ static void eq_iir_s32_24_default(struct processing_module *mod,
 	int i;
 	int j;
 	int n;
-	const int nch = source->channels;
+	const int nch = audio_stream_get_channels(source);
 	const int samples = frames * nch;
 	int processed = 0;
 
@@ -306,7 +306,7 @@ static void eq_iir_pass(struct processing_module *mod, struct input_stream_buffe
 	struct audio_stream __sparse_cache *source = bsource->data;
 	struct audio_stream __sparse_cache *sink = bsink->data;
 
-	audio_stream_copy(source, 0, sink, 0, frames * source->channels);
+	audio_stream_copy(source, 0, sink, 0, frames * audio_stream_get_channels(source));
 }
 
 #if CONFIG_IPC_MAJOR_3
@@ -321,7 +321,7 @@ static void eq_iir_s32_s16_pass(struct processing_module *mod, struct input_stre
 	int nmax;
 	int n;
 	int i;
-	int remaining_samples = frames * source->channels;
+	int remaining_samples = frames * audio_stream_get_channels(source);
 
 	while (remaining_samples) {
 		nmax = EQ_IIR_BYTES_TO_S32_SAMPLES(audio_stream_bytes_without_wrap(source, x));
@@ -351,7 +351,7 @@ static void eq_iir_s32_s24_pass(struct processing_module *mod, struct input_stre
 	int nmax;
 	int n;
 	int i;
-	int remaining_samples = frames * source->channels;
+	int remaining_samples = frames * audio_stream_get_channels(source);
 
 	while (remaining_samples) {
 		nmax = EQ_IIR_BYTES_TO_S32_SAMPLES(audio_stream_bytes_without_wrap(source, x));
@@ -809,7 +809,8 @@ static int eq_iir_process(struct processing_module *mod,
 	if (comp_is_new_data_blob_available(cd->model_handler)) {
 		cd->config = comp_get_data_blob(cd->model_handler, NULL, NULL);
 		ret = eq_iir_new_blob(mod, cd, audio_stream_get_frm_fmt(source),
-				      audio_stream_get_frm_fmt(sink), source->channels);
+				      audio_stream_get_frm_fmt(sink),
+				      audio_stream_get_channels(source));
 		if (ret)
 			return ret;
 	}
@@ -918,7 +919,7 @@ static int eq_iir_prepare(struct processing_module *mod)
 	eq_iir_set_alignment(&source_c->stream, &sink_c->stream);
 
 	/* get source and sink data format */
-	channels = sink_c->stream.channels;
+	channels = audio_stream_get_channels(&sink_c->stream);
 	source_format = audio_stream_get_frm_fmt(&source_c->stream);
 	sink_format = audio_stream_get_frm_fmt(&sink_c->stream);
 	buffer_release(sink_c);

--- a/src/audio/google/google_hotword_detect.c
+++ b/src/audio/google/google_hotword_detect.c
@@ -408,12 +408,13 @@ static int ghd_copy(struct comp_dev *dev)
 	comp_dbg(dev, "buffer begin/r_ptr/end [0x%x 0x%x 0x%x]",
 		 (uint32_t)stream->addr,
 		 (uint32_t)audio_stream_get_rptr(stream),
-		 (uint32_t)stream->end_addr);
+		 (uint32_t)audio_stream_get_end_addr(stream));
 
 	/* copy and perform detection */
 	buffer_stream_invalidate(source_c, bytes);
 
-	tail_bytes = (char *)stream->end_addr - (char *)audio_stream_get_rptr(stream);
+	tail_bytes = (char *)audio_stream_get_end_addr(stream) -
+		(char *)audio_stream_get_rptr(stream);
 	if (bytes <= tail_bytes)
 		tail_bytes = bytes;
 	else

--- a/src/audio/google/google_hotword_detect.c
+++ b/src/audio/google/google_hotword_detect.c
@@ -406,7 +406,7 @@ static int ghd_copy(struct comp_dev *dev)
 
 	comp_dbg(dev, "ghd_copy() avail_bytes %u", bytes);
 	comp_dbg(dev, "buffer begin/r_ptr/end [0x%x 0x%x 0x%x]",
-		 (uint32_t)stream->addr,
+		 (uint32_t)audio_stream_get_addr(stream),
 		 (uint32_t)audio_stream_get_rptr(stream),
 		 (uint32_t)audio_stream_get_end_addr(stream));
 
@@ -423,7 +423,7 @@ static int ghd_copy(struct comp_dev *dev)
 	if (tail_bytes)
 		ghd_detect(dev, stream, audio_stream_get_rptr(stream), tail_bytes);
 	if (head_bytes)
-		ghd_detect(dev, stream, stream->addr, head_bytes);
+		ghd_detect(dev, stream, audio_stream_get_addr(stream), head_bytes);
 
 	/* calc new available */
 	comp_update_buffer_consume(source_c, bytes);

--- a/src/audio/google/google_hotword_detect.c
+++ b/src/audio/google/google_hotword_detect.c
@@ -181,7 +181,7 @@ static int ghd_params(struct comp_dev *dev,
 	if (source_c->stream.channels != 1) {
 		comp_err(dev, "ghd_params(): Only single-channel supported");
 		ret = -EINVAL;
-	} else if (source_c->stream.frame_fmt != SOF_IPC_FRAME_S16_LE) {
+	} else if (audio_stream_get_frm_fmt(&source_c->stream) != SOF_IPC_FRAME_S16_LE) {
 		comp_err(dev, "ghd_params(): Only S16_LE supported");
 		ret = -EINVAL;
 	} else if (source_c->stream.rate != KPB_SAMPLNG_FREQUENCY) {

--- a/src/audio/google/google_hotword_detect.c
+++ b/src/audio/google/google_hotword_detect.c
@@ -407,20 +407,20 @@ static int ghd_copy(struct comp_dev *dev)
 	comp_dbg(dev, "ghd_copy() avail_bytes %u", bytes);
 	comp_dbg(dev, "buffer begin/r_ptr/end [0x%x 0x%x 0x%x]",
 		 (uint32_t)stream->addr,
-		 (uint32_t)stream->r_ptr,
+		 (uint32_t)audio_stream_get_rptr(stream),
 		 (uint32_t)stream->end_addr);
 
 	/* copy and perform detection */
 	buffer_stream_invalidate(source_c, bytes);
 
-	tail_bytes = (char *)stream->end_addr - (char *)stream->r_ptr;
+	tail_bytes = (char *)stream->end_addr - (char *)audio_stream_get_rptr(stream);
 	if (bytes <= tail_bytes)
 		tail_bytes = bytes;
 	else
 		head_bytes = bytes - tail_bytes;
 
 	if (tail_bytes)
-		ghd_detect(dev, stream, stream->r_ptr, tail_bytes);
+		ghd_detect(dev, stream, audio_stream_get_rptr(stream), tail_bytes);
 	if (head_bytes)
 		ghd_detect(dev, stream, stream->addr, head_bytes);
 

--- a/src/audio/google/google_rtc_audio_processing.c
+++ b/src/audio/google/google_rtc_audio_processing.c
@@ -624,7 +624,7 @@ static int google_rtc_audio_processing_copy(struct comp_dev *dev)
 
 	buffer_c = buffer_acquire(cd->aec_reference);
 
-	ref = buffer_c->stream.r_ptr;
+	ref = audio_stream_get_rptr(&buffer_c->stream);
 
 	num_aec_reference_frames = audio_stream_get_avail_frames(&buffer_c->stream);
 	num_aec_reference_bytes = audio_stream_get_avail_bytes(&buffer_c->stream);
@@ -659,7 +659,7 @@ static int google_rtc_audio_processing_copy(struct comp_dev *dev)
 	mic_buf = buffer_acquire(cd->raw_microphone);
 	output_buf = buffer_acquire(cd->output);
 
-	src = mic_buf->stream.r_ptr;
+	src = audio_stream_get_rptr(&mic_buf->stream);
 	dst = output_buf->stream.w_ptr;
 
 	comp_get_copy_limits(mic_buf, output_buf, &cl);

--- a/src/audio/google/google_rtc_audio_processing.c
+++ b/src/audio/google/google_rtc_audio_processing.c
@@ -555,7 +555,7 @@ static int google_rtc_audio_processing_prepare(struct comp_dev *dev)
 	}
 
 	output_c = buffer_acquire(cd->output);
-	frame_fmt = output_c->stream.frame_fmt;
+	frame_fmt = audio_stream_get_frm_fmt(&output_c->stream);
 	rate = output_c->stream.rate;
 	buffer_release(output_c);
 

--- a/src/audio/google/google_rtc_audio_processing.c
+++ b/src/audio/google/google_rtc_audio_processing.c
@@ -660,7 +660,7 @@ static int google_rtc_audio_processing_copy(struct comp_dev *dev)
 	output_buf = buffer_acquire(cd->output);
 
 	src = audio_stream_get_rptr(&mic_buf->stream);
-	dst = output_buf->stream.w_ptr;
+	dst = audio_stream_get_wptr(&output_buf->stream);
 
 	comp_get_copy_limits(mic_buf, output_buf, &cl);
 	buffer_stream_invalidate(mic_buf, cl.source_bytes);

--- a/src/audio/google/google_rtc_audio_processing.c
+++ b/src/audio/google/google_rtc_audio_processing.c
@@ -105,6 +105,7 @@ static int google_rtc_audio_processing_params(
 	/* update sink format */
 	if (!list_is_empty(&dev->bsink_list)) {
 		struct ipc4_audio_format *out_fmt = &cd->config.output_fmt;
+		enum sof_ipc_frame valid_fmt, frame_fmt;
 
 		sink = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
 		sink_c = buffer_acquire(sink);
@@ -113,12 +114,14 @@ static int google_rtc_audio_processing_params(
 
 		audio_stream_fmt_conversion(out_fmt->depth,
 					    out_fmt->valid_bit_depth,
-					    &sink_c->stream.frame_fmt,
-					    &sink_c->stream.valid_sample_fmt,
+					    &frame_fmt, &valid_fmt,
 					    out_fmt->s_type);
 
+		sink_c->stream.frame_fmt = frame_fmt;
+		sink_c->stream.valid_sample_fmt = valid_fmt;
+
 		sink_c->buffer_fmt = out_fmt->interleaving_style;
-		params->frame_fmt = sink_c->stream.frame_fmt;
+		params->frame_fmt = frame_fmt;
 
 		sink_c->hw_params_configured = true;
 

--- a/src/audio/google/google_rtc_audio_processing.c
+++ b/src/audio/google/google_rtc_audio_processing.c
@@ -556,7 +556,7 @@ static int google_rtc_audio_processing_prepare(struct comp_dev *dev)
 
 	output_c = buffer_acquire(cd->output);
 	frame_fmt = audio_stream_get_frm_fmt(&output_c->stream);
-	rate = output_c->stream.rate;
+	rate = audio_stream_get_rate(&output_c->stream);
 	buffer_release(output_c);
 
 

--- a/src/audio/host-legacy.c
+++ b/src/audio/host-legacy.c
@@ -851,8 +851,8 @@ int host_zephyr_params(struct host_data *hd, struct comp_dev *dev,
 		host_copy_normal;
 
 	/* set processing function */
-	hd->process = pcm_get_conversion_function(host_buf_c->stream.frame_fmt,
-						  host_buf_c->stream.frame_fmt);
+	hd->process = pcm_get_conversion_function(audio_stream_get_frm_fmt(&host_buf_c->stream),
+						  audio_stream_get_frm_fmt(&host_buf_c->stream));
 
 out:
 	buffer_release(host_buf_c);

--- a/src/audio/host-legacy.c
+++ b/src/audio/host-legacy.c
@@ -472,7 +472,7 @@ static int create_local_elems(struct host_data *hd, struct comp_dev *dev, uint32
 	dma_buf_c = buffer_acquire(hd->dma_buffer);
 	err = dma_sg_alloc(elem_array, SOF_MEM_ZONE_RUNTIME, dir, buffer_count,
 			   buffer_bytes,
-			   (uintptr_t)(dma_buf_c->stream.addr), 0);
+			   (uintptr_t)(audio_stream_get_addr(&dma_buf_c->stream)), 0);
 	buffer_release(dma_buf_c);
 	if (err < 0) {
 		comp_err(dev, "create_local_elems(): dma_sg_alloc() failed");

--- a/src/audio/host-zephyr.c
+++ b/src/audio/host-zephyr.c
@@ -860,11 +860,13 @@ int host_zephyr_params(struct host_data *hd, struct comp_dev *dev,
 
 		/* set processing function */
 		if (params->direction == SOF_IPC_STREAM_CAPTURE)
-			hd->process = pcm_get_conversion_function(host_buf_c->stream.frame_fmt,
-								  dma_buf_c->stream.frame_fmt);
+			hd->process = pcm_get_conversion_function(
+				audio_stream_get_frm_fmt(&host_buf_c->stream),
+				audio_stream_get_frm_fmt(&dma_buf_c->stream));
 		else
-			hd->process = pcm_get_conversion_function(dma_buf_c->stream.frame_fmt,
-								  host_buf_c->stream.frame_fmt);
+			hd->process = pcm_get_conversion_function(
+				audio_stream_get_frm_fmt(&dma_buf_c->stream),
+				audio_stream_get_frm_fmt(&host_buf_c->stream));
 
 		config->src_width = audio_stream_sample_bytes(&dma_buf_c->stream);
 		config->dest_width = config->src_width;

--- a/src/audio/host-zephyr.c
+++ b/src/audio/host-zephyr.c
@@ -484,8 +484,9 @@ static int host_copy_normal(struct host_data *hd, struct comp_dev *dev)
 	 * also adding a 2ms safety margin.
 	 */
 	if (!IS_ENABLED(CONFIG_HOST_DMA_RELOAD_DELAY_ENABLE) ||
-	    buffer_c->stream.size < hd->period_bytes << 3 ||
-	    buffer_c->stream.size - hd->partial_size <= (2 + threshold) * hd->period_bytes) {
+	    audio_stream_get_size(&buffer_c->stream) < hd->period_bytes << 3 ||
+	    audio_stream_get_size(&buffer_c->stream) - hd->partial_size <=
+	    (2 + threshold) * hd->period_bytes) {
 		ret = dma_reload(hd->chan->dma->z_dev, hd->chan->index, 0, 0, hd->partial_size);
 		if (ret < 0)
 			comp_err(dev, "host_copy_normal(): dma_copy() failed, ret = %u", ret);

--- a/src/audio/host-zephyr.c
+++ b/src/audio/host-zephyr.c
@@ -527,7 +527,7 @@ static int create_local_elems(struct host_data *hd, struct comp_dev *dev, uint32
 	dma_buf_c = buffer_acquire(hd->dma_buffer);
 	err = dma_sg_alloc(elem_array, SOF_MEM_ZONE_RUNTIME, dir, buffer_count,
 			   buffer_bytes,
-			   (uintptr_t)(dma_buf_c->stream.addr), 0);
+			   (uintptr_t)audio_stream_get_addr(&dma_buf_c->stream), 0);
 	buffer_release(dma_buf_c);
 	if (err < 0) {
 		comp_err(dev, "create_local_elems(): dma_sg_alloc() failed");

--- a/src/audio/igo_nr/igo_nr.c
+++ b/src/audio/igo_nr/igo_nr.c
@@ -249,7 +249,7 @@ static inline int32_t set_capture_func(struct comp_dev *dev)
 				  sink_list);
 
 	/* The igo_nr supports S16_LE data. Format converter is needed. */
-	switch (sourceb->stream.frame_fmt) {
+	switch (audio_stream_get_frm_fmt(&sourceb->stream)) {
 #if CONFIG_FORMAT_S16LE
 	case SOF_IPC_FRAME_S16_LE:
 		comp_info(dev, "set_capture_func(), SOF_IPC_FRAME_S16_LE");

--- a/src/audio/igo_nr/igo_nr.c
+++ b/src/audio/igo_nr/igo_nr.c
@@ -70,7 +70,7 @@ static void igo_nr_capture_s16(struct comp_data *cd,
 			       struct audio_stream __sparse_cache *sink,
 			       int32_t frames)
 {
-	int32_t nch = source->channels;
+	int32_t nch = audio_stream_get_channels(source);
 	int32_t i;
 	int32_t j;
 	int32_t idx_in = 0;
@@ -129,7 +129,7 @@ static void igo_nr_capture_s24(struct comp_data *cd,
 			       struct audio_stream __sparse_cache *sink,
 			       int32_t frames)
 {
-	int32_t nch = source->channels;
+	int32_t nch = audio_stream_get_channels(source);
 	int32_t i;
 	int32_t j;
 	int32_t idx_in = 0;
@@ -188,7 +188,7 @@ static void igo_nr_capture_s32(struct comp_data *cd,
 			       struct audio_stream __sparse_cache *sink,
 			       int32_t frames)
 {
-	int32_t nch = source->channels;
+	int32_t nch = audio_stream_get_channels(source);
 	int32_t i;
 	int32_t j;
 	int32_t idx_in = 0;
@@ -402,7 +402,7 @@ static int32_t igo_nr_params(struct comp_dev *dev,
 	cd->source_rate = audio_stream_get_rate(&source_c->stream);
 	cd->sink_rate = audio_stream_get_rate(&sink_c->stream);
 
-	if (source_c->stream.channels != sink_c->stream.channels) {
+	if (source_c->stream.channels != audio_stream_get_channels(&sink_c->stream)) {
 		comp_err(dev, "igo_nr_params(), mismatch source/sink stream channels");
 		cd->invalid_param = true;
 	}

--- a/src/audio/igo_nr/igo_nr.c
+++ b/src/audio/igo_nr/igo_nr.c
@@ -399,8 +399,8 @@ static int32_t igo_nr_params(struct comp_dev *dev,
 	sink_c = buffer_acquire(sinkb);
 
 	/* set source/sink_frames/rate */
-	cd->source_rate = source_c->stream.rate;
-	cd->sink_rate = sink_c->stream.rate;
+	cd->source_rate = audio_stream_get_rate(&source_c->stream);
+	cd->sink_rate = audio_stream_get_rate(&sink_c->stream);
 
 	if (source_c->stream.channels != sink_c->stream.channels) {
 		comp_err(dev, "igo_nr_params(), mismatch source/sink stream channels");

--- a/src/audio/ipcgtw.c
+++ b/src/audio/ipcgtw.c
@@ -132,7 +132,7 @@ static inline
 void audio_stream_copy_bytes_to_linear(const struct audio_stream __sparse_cache *source,
 				       void *linear_sink, unsigned int bytes)
 {
-	uint8_t *src = audio_stream_wrap(source, (uint8_t *)source->r_ptr);
+	uint8_t *src = audio_stream_wrap(source, audio_stream_get_rptr(source));
 	uint8_t *snk = (uint8_t *)linear_sink;
 	size_t bytes_src, bytes_copied;
 

--- a/src/audio/ipcgtw.c
+++ b/src/audio/ipcgtw.c
@@ -115,7 +115,7 @@ static inline void audio_stream_copy_bytes_from_linear(const void *linear_source
 						       unsigned int bytes)
 {
 	const uint8_t *src = (const uint8_t *)linear_source;
-	uint8_t *snk = audio_stream_wrap(sink, (uint8_t *)sink->w_ptr);
+	uint8_t *snk = audio_stream_wrap(sink, audio_stream_get_wptr(sink));
 	size_t bytes_snk, bytes_copied;
 
 	while (bytes) {

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -940,7 +940,7 @@ static void kpb_micselect_copy16(struct comp_buffer __sparse_cache *sink,
 	uint16_t ch;
 	size_t i;
 
-	AE_SETCBEGIN0(ostream->addr);
+	AE_SETCBEGIN0(audio_stream_get_addr(ostream));
 	AE_SETCEND0(audio_stream_get_end_addr(ostream));
 
 	buffer_stream_invalidate(source, size);
@@ -973,7 +973,7 @@ static void kpb_micselect_copy32(struct comp_buffer __sparse_cache *sink,
 	uint16_t ch;
 	size_t i;
 
-	AE_SETCBEGIN0(ostream->addr);
+	AE_SETCBEGIN0(audio_stream_get_addr(ostream));
 	AE_SETCEND0(audio_stream_get_end_addr(ostream));
 
 	buffer_stream_invalidate(source, size);
@@ -1021,7 +1021,7 @@ static void kpb_micselect_copy16(struct comp_buffer __sparse_cache *sink,
 		for (size_t i = 0; i < samples_per_chan * in_channels; i += in_channels) {
 			if (&out_data[out_samples + ch]
 					>= (int16_t *)audio_stream_get_end_addr(ostream)) {
-				out_data = (int16_t *)ostream->addr;
+				out_data = (int16_t *)audio_stream_get_addr(ostream);
 				out_samples = 0;
 			}
 			out_data[out_samples + ch] = in_data[i + offsets[ch]];
@@ -1052,7 +1052,7 @@ static void kpb_micselect_copy32(struct comp_buffer __sparse_cache *sink,
 		for (size_t i = 0; i < samples_per_chan * in_channels; i += in_channels) {
 			if (&out_data[out_samples + ch]
 					>= (int32_t *)audio_stream_get_end_addr(ostream)) {
-				out_data = (int32_t *)ostream->addr;
+				out_data = (int32_t *)audio_stream_get_addr(ostream);
 				out_samples = 0;
 			}
 			out_data[out_samples + ch] = in_data[i + offsets[ch]];
@@ -1828,7 +1828,7 @@ static void kpb_convert_24b_to_32b(const void *linear_source, int ioffset,
 	ae_int32x2 *buf_end;
 	ae_int32x2 *buf;
 
-	buf = (ae_int32x2 *)(sink->addr);
+	buf = (ae_int32x2 *)(audio_stream_get_addr(sink));
 	buf_end = audio_stream_get_end_addr(sink);
 	ae_int32x2 *out_ptr = (ae_int32x2 *)buf;
 

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -222,7 +222,7 @@ static void kpb_set_params(struct comp_dev *dev,
 			   struct sof_ipc_stream_params *params)
 {
 	struct comp_data *kpb = comp_get_drvdata(dev);
-	uint32_t __sparse_cache valid_fmt, frame_fmt;
+	enum sof_ipc_frame frame_fmt, valid_fmt;
 
 	comp_dbg(dev, "kpb_set_params()");
 

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -941,7 +941,7 @@ static void kpb_micselect_copy16(struct comp_buffer __sparse_cache *sink,
 	size_t i;
 
 	AE_SETCBEGIN0(ostream->addr);
-	AE_SETCEND0(ostream->end_addr);
+	AE_SETCEND0(audio_stream_get_end_addr(ostream));
 
 	buffer_stream_invalidate(source, size);
 	const ae_int16 *in_ptr = audio_stream_get_rptr(istream);
@@ -974,7 +974,7 @@ static void kpb_micselect_copy32(struct comp_buffer __sparse_cache *sink,
 	size_t i;
 
 	AE_SETCBEGIN0(ostream->addr);
-	AE_SETCEND0(ostream->end_addr);
+	AE_SETCEND0(audio_stream_get_end_addr(ostream));
 
 	buffer_stream_invalidate(source, size);
 
@@ -1020,7 +1020,7 @@ static void kpb_micselect_copy16(struct comp_buffer __sparse_cache *sink,
 
 		for (size_t i = 0; i < samples_per_chan * in_channels; i += in_channels) {
 			if (&out_data[out_samples + ch]
-					>= (int16_t *)ostream->end_addr) {
+					>= (int16_t *)audio_stream_get_end_addr(ostream)) {
 				out_data = (int16_t *)ostream->addr;
 				out_samples = 0;
 			}
@@ -1051,7 +1051,7 @@ static void kpb_micselect_copy32(struct comp_buffer __sparse_cache *sink,
 
 		for (size_t i = 0; i < samples_per_chan * in_channels; i += in_channels) {
 			if (&out_data[out_samples + ch]
-					>= (int32_t *)ostream->end_addr) {
+					>= (int32_t *)audio_stream_get_end_addr(ostream)) {
 				out_data = (int32_t *)ostream->addr;
 				out_samples = 0;
 			}
@@ -1829,7 +1829,7 @@ static void kpb_convert_24b_to_32b(const void *linear_source, int ioffset,
 	ae_int32x2 *buf;
 
 	buf = (ae_int32x2 *)(sink->addr);
-	buf_end = (ae_int32x2 *)(sink->end_addr);
+	buf_end = audio_stream_get_end_addr(sink);
 	ae_int32x2 *out_ptr = (ae_int32x2 *)buf;
 
 	AE_SETCBEGIN0(buf);

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -1912,7 +1912,7 @@ static void kpb_drain_samples(void *source, struct audio_stream __sparse_cache *
 #endif /* CONFIG_FORMAT_S16LE */
 #if CONFIG_FORMAT_S24LE || CONFIG_FORMAT_S32LE
 	case 24:
-		samples = size / ((sample_width >> 3) * sink->channels);
+		samples = size / ((sample_width >> 3) * audio_stream_get_channels(sink));
 		kpb_convert_24b_to_32b(source, 0, sink, 0, samples);
 		break;
 	case 32:
@@ -2016,8 +2016,8 @@ static void kpb_buffer_samples(const struct audio_stream __sparse_cache *source,
 #endif
 #if CONFIG_FORMAT_S24LE || CONFIG_FORMAT_S32LE
 	case 24:
-		samples_count =  size / ((sample_width >> 3) * source->channels);
-		samples_offset = offset / ((sample_width >> 3) * source->channels);
+		samples_count =  size / ((sample_width >> 3) * audio_stream_get_channels(source));
+		samples_offset = offset / ((sample_width >> 3) * audio_stream_get_channels(source));
 		kpb_convert_32b_to_24b(source, samples_offset,
 				       sink, 0, samples_count);
 		break;

--- a/src/audio/mfcc/mfcc.c
+++ b/src/audio/mfcc/mfcc.c
@@ -209,13 +209,13 @@ static int mfcc_prepare(struct processing_module *mod)
 	sink_c = buffer_acquire(sinkb);
 
 	/* get source data format */
-	source_format = source_c->stream.frame_fmt;
+	source_format = audio_stream_get_frm_fmt(&source_c->stream);
 
 	/* set align requirements */
 	mfcc_set_alignment(&source_c->stream, &sink_c->stream);
 
 	/* get sink data format and period bytes */
-	sink_format = sink_c->stream.frame_fmt;
+	sink_format = audio_stream_get_frm_fmt(&sink_c->stream);
 	sink_period_bytes = audio_stream_period_bytes(&sink_c->stream, dev->frames);
 	comp_info(dev, "mfcc_prepare(), source_format = %d, sink_format = %d",
 		  source_format, sink_format);

--- a/src/audio/mfcc/mfcc.c
+++ b/src/audio/mfcc/mfcc.c
@@ -219,9 +219,9 @@ static int mfcc_prepare(struct processing_module *mod)
 	sink_period_bytes = audio_stream_period_bytes(&sink_c->stream, dev->frames);
 	comp_info(dev, "mfcc_prepare(), source_format = %d, sink_format = %d",
 		  source_format, sink_format);
-	if (sink_c->stream.size < sink_period_bytes) {
+	if (audio_stream_get_size(&sink_c->stream) < sink_period_bytes) {
 		comp_err(dev, "mfcc_prepare(): sink buffer size %d is insufficient < %d",
-			 sink_c->stream.size, sink_period_bytes);
+			 audio_stream_get_size(&sink_c->stream), sink_period_bytes);
 		ret = -ENOMEM;
 		goto err;
 	}

--- a/src/audio/mfcc/mfcc.c
+++ b/src/audio/mfcc/mfcc.c
@@ -231,7 +231,7 @@ static int mfcc_prepare(struct processing_module *mod)
 	/* Initialize MFCC, max_frames is set to dev->frames + 4 */
 	if (cd->config) {
 		ret = mfcc_setup(mod, dev->frames + 4, audio_stream_get_rate(&source_c->stream),
-				 source_c->stream.channels);
+				 audio_stream_get_channels(&source_c->stream));
 		if (ret < 0) {
 			comp_err(dev, "mfcc_prepare(), setup failed.");
 			goto err;

--- a/src/audio/mfcc/mfcc.c
+++ b/src/audio/mfcc/mfcc.c
@@ -230,7 +230,7 @@ static int mfcc_prepare(struct processing_module *mod)
 
 	/* Initialize MFCC, max_frames is set to dev->frames + 4 */
 	if (cd->config) {
-		ret = mfcc_setup(mod, dev->frames + 4, source_c->stream.rate,
+		ret = mfcc_setup(mod, dev->frames + 4, audio_stream_get_rate(&source_c->stream),
 				 source_c->stream.channels);
 		if (ret < 0) {
 			comp_err(dev, "mfcc_prepare(), setup failed.");

--- a/src/audio/mfcc/mfcc_generic.c
+++ b/src/audio/mfcc/mfcc_generic.c
@@ -462,7 +462,7 @@ void mfcc_s16_default(struct processing_module *mod, struct input_stream_buffer 
 	struct mfcc_state *state = &cd->state;
 	struct mfcc_buffer *buf = &cd->state.buf;
 	uint32_t magic = MFCC_MAGIC;
-	int16_t *w_ptr = sink->w_ptr;
+	int16_t *w_ptr = audio_stream_get_wptr(sink);
 	int num_magic = sizeof(magic) / sizeof(int16_t);
 	int num_ceps;
 	int zero_samples;

--- a/src/audio/mfcc/mfcc_generic.c
+++ b/src/audio/mfcc/mfcc_generic.c
@@ -93,7 +93,7 @@ static void mfcc_source_copy_s16(struct input_stream_buffer *bsource, struct mfc
 	struct audio_stream __sparse_cache *source = bsource->data;
 	int32_t s;
 	int16_t *x0;
-	int16_t *x = source->r_ptr;
+	int16_t *x = audio_stream_get_rptr(source);
 	int16_t *w = buf->w_ptr;
 	int copied;
 	int nmax;

--- a/src/audio/mfcc/mfcc_generic.c
+++ b/src/audio/mfcc/mfcc_generic.c
@@ -101,7 +101,7 @@ static void mfcc_source_copy_s16(struct input_stream_buffer *bsource, struct mfc
 	int n2;
 	int n;
 	int i;
-	int num_channels = source->channels;
+	int num_channels = audio_stream_get_channels(source);
 
 	/* Copy from source to pre-buffer for FFT.
 	 * The pre-emphasis filter is done in this step.
@@ -126,7 +126,7 @@ static void mfcc_source_copy_s16(struct input_stream_buffer *bsource, struct mfc
 			w++;
 		}
 
-		x = audio_stream_wrap(source, x + n * source->channels);
+		x = audio_stream_wrap(source, x + n * audio_stream_get_channels(source));
 		w = mfcc_buffer_wrap(buf, w);
 	}
 	buf->s_avail += copied;
@@ -478,7 +478,7 @@ void mfcc_s16_default(struct processing_module *mod, struct input_stream_buffer 
 	/* Done, copy data to sink. This works only if the period has room for magic (2)
 	 * plus num_ceps int16_t samples. TODO: split ceps over multiple periods.
 	 */
-	zero_samples = frames * sink->channels;
+	zero_samples = frames * audio_stream_get_channels(sink);
 	if (num_ceps > 0) {
 		zero_samples -= num_ceps + num_magic;
 		w_ptr = mfcc_sink_copy_data_s16(sink, w_ptr, num_magic, (int16_t *)&magic);

--- a/src/audio/mixer/mixer_generic.c
+++ b/src/audio/mixer/mixer_generic.c
@@ -24,7 +24,7 @@ static void mix_n_s16(struct comp_dev *dev, struct audio_stream __sparse_cache *
 	int nch = sink->channels;
 	int samples = frames * nch;
 
-	dest = sink->w_ptr;
+	dest = audio_stream_get_wptr(sink);
 	for (j = 0; j < num_sources; j++)
 		src[j] = audio_stream_get_rptr(sources[j]);
 
@@ -71,7 +71,7 @@ static void mix_n_s24(struct comp_dev *dev, struct audio_stream __sparse_cache *
 	int nch = sink->channels;
 	int samples = frames * nch;
 
-	dest = sink->w_ptr;
+	dest = audio_stream_get_wptr(sink);
 	for (j = 0; j < num_sources; j++)
 		src[j] = audio_stream_get_rptr(sources[j]);
 
@@ -118,7 +118,7 @@ static void mix_n_s32(struct comp_dev *dev, struct audio_stream __sparse_cache *
 	int nch = sink->channels;
 	int samples = frames * nch;
 
-	dest = sink->w_ptr;
+	dest = audio_stream_get_wptr(sink);
 	for (j = 0; j < num_sources; j++)
 		src[j] = audio_stream_get_rptr(sources[j]);
 

--- a/src/audio/mixer/mixer_generic.c
+++ b/src/audio/mixer/mixer_generic.c
@@ -26,7 +26,7 @@ static void mix_n_s16(struct comp_dev *dev, struct audio_stream __sparse_cache *
 
 	dest = sink->w_ptr;
 	for (j = 0; j < num_sources; j++)
-		src[j] = sources[j]->r_ptr;
+		src[j] = audio_stream_get_rptr(sources[j]);
 
 	while (processed < samples) {
 		nmax = samples - processed;
@@ -73,7 +73,7 @@ static void mix_n_s24(struct comp_dev *dev, struct audio_stream __sparse_cache *
 
 	dest = sink->w_ptr;
 	for (j = 0; j < num_sources; j++)
-		src[j] = sources[j]->r_ptr;
+		src[j] = audio_stream_get_rptr(sources[j]);
 
 	while (processed < samples) {
 		nmax = samples - processed;
@@ -120,7 +120,7 @@ static void mix_n_s32(struct comp_dev *dev, struct audio_stream __sparse_cache *
 
 	dest = sink->w_ptr;
 	for (j = 0; j < num_sources; j++)
-		src[j] = sources[j]->r_ptr;
+		src[j] = audio_stream_get_rptr(sources[j]);
 
 	while (processed < samples) {
 		nmax = samples - processed;

--- a/src/audio/mixer/mixer_generic.c
+++ b/src/audio/mixer/mixer_generic.c
@@ -21,7 +21,7 @@ static void mix_n_s16(struct comp_dev *dev, struct audio_stream __sparse_cache *
 	int nmax;
 	int i, j, n, ns;
 	int processed = 0;
-	int nch = sink->channels;
+	int nch = audio_stream_get_channels(sink);
 	int samples = frames * nch;
 
 	dest = audio_stream_get_wptr(sink);
@@ -68,7 +68,7 @@ static void mix_n_s24(struct comp_dev *dev, struct audio_stream __sparse_cache *
 	int nmax;
 	int i, j, n, ns;
 	int processed = 0;
-	int nch = sink->channels;
+	int nch = audio_stream_get_channels(sink);
 	int samples = frames * nch;
 
 	dest = audio_stream_get_wptr(sink);
@@ -115,7 +115,7 @@ static void mix_n_s32(struct comp_dev *dev, struct audio_stream __sparse_cache *
 	int nmax;
 	int i, j, n, ns;
 	int processed = 0;
-	int nch = sink->channels;
+	int nch = audio_stream_get_channels(sink);
 	int samples = frames * nch;
 
 	dest = audio_stream_get_wptr(sink);

--- a/src/audio/mixer/mixer_hifi3.c
+++ b/src/audio/mixer/mixer_hifi3.c
@@ -28,9 +28,9 @@ static void mix_n_s16(struct comp_dev *dev, struct audio_stream __sparse_cache *
 	unsigned int n, m, nmax, i, j, left_samples;
 	unsigned int samples = frames * sink->channels;
 
-	for (j = 0; j < num_sources; j++) {
-		in[j] = sources[j]->r_ptr;
-	}
+	for (j = 0; j < num_sources; j++)
+		in[j] = audio_stream_get_rptr(sources[j]);
+
 	for (left_samples = samples; left_samples; left_samples -= n) {
 		out = audio_stream_wrap(sink,  out);
 		nmax = audio_stream_samples_without_wrap_s16(sink, out);
@@ -80,9 +80,9 @@ static void mix_n_s24(struct comp_dev *dev, struct audio_stream __sparse_cache *
 	unsigned int n, m, nmax, i, j, left_samples;
 	unsigned int samples = frames * sink->channels;
 
-	for (j = 0; j < num_sources; j++) {
-		in[j] = sources[j]->r_ptr;
-	}
+	for (j = 0; j < num_sources; j++)
+		in[j] = audio_stream_get_rptr(sources[j]);
+
 	for (left_samples = samples; left_samples; left_samples -= n) {
 		out = audio_stream_wrap(sink,  out);
 		nmax = audio_stream_samples_without_wrap_s32(sink, out);
@@ -128,7 +128,7 @@ static void mix_n_s32(struct comp_dev *dev, struct audio_stream __sparse_cache *
 	unsigned int samples = frames * sink->channels;
 
 	for (j = 0; j < num_sources; j++)
-		in[j] = sources[j]->r_ptr;
+		in[j] = audio_stream_get_rptr(sources[j]);
 
 	for (left_samples = samples; left_samples; left_samples -= n) {
 		out = audio_stream_wrap(sink,  out);

--- a/src/audio/mixer/mixer_hifi3.c
+++ b/src/audio/mixer/mixer_hifi3.c
@@ -18,7 +18,7 @@ static void mix_n_s16(struct comp_dev *dev, struct audio_stream __sparse_cache *
 		      uint32_t frames)
 {
 	ae_int16x4 * in[PLATFORM_MAX_CHANNELS];
-	ae_int16x4 *out = sink->w_ptr;
+	ae_int16x4 *out = audio_stream_get_wptr(sink);
 	ae_int16x4 sample = AE_ZERO16();
 	ae_int16x4 res = AE_ZERO16();
 	ae_int32x2 val1;
@@ -74,7 +74,7 @@ static void mix_n_s24(struct comp_dev *dev, struct audio_stream __sparse_cache *
 		      uint32_t frames)
 {
 	ae_int32x2 *in[PLATFORM_MAX_CHANNELS];
-	ae_int32x2 *out = sink->w_ptr;
+	ae_int32x2 *out = audio_stream_get_wptr(sink);
 	ae_int32x2 val;
 	ae_int32x2 sample = AE_ZERO32();
 	unsigned int n, m, nmax, i, j, left_samples;
@@ -119,7 +119,7 @@ static void mix_n_s32(struct comp_dev *dev, struct audio_stream __sparse_cache *
 		      uint32_t frames)
 {
 	ae_q32s * in[PLATFORM_MAX_CHANNELS];
-	ae_int32 *out = sink->w_ptr;
+	ae_int32 *out = audio_stream_get_wptr(sink);
 	ae_int64 sample;
 	ae_int64 val;
 	ae_int32x2 res;

--- a/src/audio/mixer/mixer_hifi3.c
+++ b/src/audio/mixer/mixer_hifi3.c
@@ -26,7 +26,7 @@ static void mix_n_s16(struct comp_dev *dev, struct audio_stream __sparse_cache *
 	ae_int32x2 sample_1;
 	ae_int32x2 sample_2;
 	unsigned int n, m, nmax, i, j, left_samples;
-	unsigned int samples = frames * sink->channels;
+	unsigned int samples = frames * audio_stream_get_channels(sink);
 
 	for (j = 0; j < num_sources; j++)
 		in[j] = audio_stream_get_rptr(sources[j]);
@@ -78,7 +78,7 @@ static void mix_n_s24(struct comp_dev *dev, struct audio_stream __sparse_cache *
 	ae_int32x2 val;
 	ae_int32x2 sample = AE_ZERO32();
 	unsigned int n, m, nmax, i, j, left_samples;
-	unsigned int samples = frames * sink->channels;
+	unsigned int samples = frames * audio_stream_get_channels(sink);
 
 	for (j = 0; j < num_sources; j++)
 		in[j] = audio_stream_get_rptr(sources[j]);
@@ -125,7 +125,7 @@ static void mix_n_s32(struct comp_dev *dev, struct audio_stream __sparse_cache *
 	ae_int32x2 res;
 	unsigned int n, nmax, i, j, left_samples;
 	unsigned int m = 0;
-	unsigned int samples = frames * sink->channels;
+	unsigned int samples = frames * audio_stream_get_channels(sink);
 
 	for (j = 0; j < num_sources; j++)
 		in[j] = audio_stream_get_rptr(sources[j]);

--- a/src/audio/mixin_mixout/mixin_mixout.c
+++ b/src/audio/mixin_mixout/mixin_mixout.c
@@ -252,7 +252,8 @@ static void silence(struct audio_stream __sparse_cache *stream, uint32_t start_f
 		return;
 
 	size = audio_stream_period_bytes(stream, frame_count - skip_mixed_frames);
-	ptr = (uint8_t *)stream->w_ptr + audio_stream_period_bytes(stream, mixed_frames);
+	ptr = (uint8_t *)audio_stream_get_wptr(stream) +
+		audio_stream_period_bytes(stream, mixed_frames);
 
 	while (size) {
 		ptr = audio_stream_wrap(stream, ptr);

--- a/src/audio/mixin_mixout/mixin_mixout.c
+++ b/src/audio/mixin_mixout/mixin_mixout.c
@@ -699,7 +699,7 @@ static int mixin_prepare(struct processing_module *mod)
 
 	sink = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
 	sink_c = buffer_acquire(sink);
-	fmt = sink_c->stream.valid_sample_fmt;
+	fmt = audio_stream_get_valid_fmt(&sink_c->stream);
 	buffer_release(sink_c);
 
 	/* currently inactive so setup mixer */

--- a/src/audio/mixin_mixout/mixin_mixout.c
+++ b/src/audio/mixin_mixout/mixin_mixout.c
@@ -774,7 +774,7 @@ static int mixout_params(struct processing_module *mod)
 				    &dummy, &sink_c->stream.valid_sample_fmt,
 				    mod->priv.cfg.base_cfg.audio_fmt.s_type);
 
-	sink_stream_size = sink_c->stream.size;
+	sink_stream_size = audio_stream_get_size(&sink_c->stream);
 
 	/* calculate period size based on config */
 	sink_period_bytes = audio_stream_period_bytes(&sink_c->stream,

--- a/src/audio/mixin_mixout/mixin_mixout_generic.c
+++ b/src/audio/mixin_mixout/mixin_mixout_generic.c
@@ -26,7 +26,7 @@ static void normal_mix_channel_s16(struct audio_stream __sparse_cache *sink, int
 	int32_t n, nmax, i;
 
 	/* audio_stream_wrap() is required and is done below in a loop */
-	int16_t *dst = (int16_t *)sink->w_ptr + start_frame;
+	int16_t *dst = (int16_t *)audio_stream_get_wptr(sink) + start_frame;
 	int16_t *src = audio_stream_get_rptr(source);
 
 	assert(mixed_frames >= start_frame);
@@ -71,7 +71,8 @@ static void remap_mix_channel_s16(struct audio_stream __sparse_cache *sink,
 	int32_t n, nmax, frames, i, samples;
 
 	/* audio_stream_wrap() is required and is done below in a loop */
-	dst = (int16_t *)sink->w_ptr + start_frame * sink_channel_count + sink_channel_index;
+	dst = (int16_t *)audio_stream_get_wptr(sink) + start_frame * sink_channel_count +
+		sink_channel_index;
 	src = (int16_t *)audio_stream_get_rptr(source) + source_channel_index;
 
 	assert(mixed_frames >= start_frame);
@@ -131,7 +132,8 @@ static void mute_channel_s16(struct audio_stream __sparse_cache *stream, int32_t
 	frame_count -= skip_mixed_frames;
 	channel_count = stream->channels;
 	/* audio_stream_wrap() is needed here and it is just below in a loop */
-	ptr = (int16_t *)stream->w_ptr + mixed_frames * stream->channels + channel_index;
+	ptr = (int16_t *)audio_stream_get_wptr(stream) + mixed_frames * stream->channels +
+		channel_index;
 
 	for (left_frames = frame_count; left_frames; left_frames -= frames) {
 		ptr = audio_stream_wrap(stream, ptr);
@@ -163,7 +165,7 @@ static void normal_mix_channel_s24(struct audio_stream __sparse_cache *sink, int
 	int32_t frames_to_mix, frames_to_copy, left_frames;
 	int32_t n, nmax, i;
 	/* audio_stream_wrap() is required and is done below in a loop */
-	int32_t *dst = (int32_t *)sink->w_ptr + start_frame;
+	int32_t *dst = (int32_t *)audio_stream_get_wptr(sink) + start_frame;
 	int32_t *src = audio_stream_get_rptr(source);
 
 	assert(mixed_frames >= start_frame);
@@ -208,7 +210,8 @@ static void remap_mix_channel_s24(struct audio_stream __sparse_cache *sink,
 	int32_t n, nmax, i, frames, samples;
 
 	/* audio_stream_wrap() is required and is done below in a loop */
-	dst = (int32_t *)sink->w_ptr + start_frame * sink_channel_count + sink_channel_index;
+	dst = (int32_t *)audio_stream_get_wptr(sink) + start_frame * sink_channel_count +
+		sink_channel_index;
 	src = (int32_t *)audio_stream_get_rptr(source) + source_channel_index;
 
 	assert(mixed_frames >= start_frame);
@@ -272,7 +275,7 @@ static void normal_mix_channel_s32(struct audio_stream __sparse_cache *sink, int
 {
 	int32_t frames_to_mix, frames_to_copy, left_frames;
 	int32_t n, nmax, i;
-	int32_t *dst = (int32_t *)sink->w_ptr + start_frame;
+	int32_t *dst = (int32_t *)audio_stream_get_wptr(sink) + start_frame;
 	int32_t *src = audio_stream_get_rptr(source);
 
 	assert(mixed_frames >= start_frame);
@@ -317,7 +320,8 @@ static void remap_mix_channel_s32(struct audio_stream __sparse_cache *sink,
 	int32_t *dst, *src;
 
 	/* audio_stream_wrap() is required and is done below in a loop */
-	dst = (int32_t *)sink->w_ptr + start_frame * sink_channel_count + sink_channel_index;
+	dst = (int32_t *)audio_stream_get_wptr(sink) + start_frame * sink_channel_count +
+		sink_channel_index;
 	src = (int32_t *)audio_stream_get_rptr(source) + source_channel_index;
 
 	assert(mixed_frames >= start_frame);
@@ -380,7 +384,8 @@ static void mute_channel_s32(struct audio_stream __sparse_cache *stream, int32_t
 	frame_count -= skip_mixed_frames;
 	channel_count = stream->channels;
 
-	ptr = (int32_t *)stream->w_ptr + mixed_frames * stream->channels + channel_index;
+	ptr = (int32_t *)audio_stream_get_wptr(stream) + mixed_frames * stream->channels +
+		channel_index;
 
 	for (left_frames = frame_count; left_frames > 0; left_frames -= frames) {
 		ptr = audio_stream_wrap(stream, ptr);

--- a/src/audio/mixin_mixout/mixin_mixout_generic.c
+++ b/src/audio/mixin_mixout/mixin_mixout_generic.c
@@ -27,7 +27,7 @@ static void normal_mix_channel_s16(struct audio_stream __sparse_cache *sink, int
 
 	/* audio_stream_wrap() is required and is done below in a loop */
 	int16_t *dst = (int16_t *)sink->w_ptr + start_frame;
-	int16_t *src = (int16_t *)source->r_ptr;
+	int16_t *src = audio_stream_get_rptr(source);
 
 	assert(mixed_frames >= start_frame);
 	frames_to_mix = mixed_frames - start_frame;
@@ -72,7 +72,7 @@ static void remap_mix_channel_s16(struct audio_stream __sparse_cache *sink,
 
 	/* audio_stream_wrap() is required and is done below in a loop */
 	dst = (int16_t *)sink->w_ptr + start_frame * sink_channel_count + sink_channel_index;
-	src = (int16_t *)source->r_ptr + source_channel_index;
+	src = (int16_t *)audio_stream_get_rptr(source) + source_channel_index;
 
 	assert(mixed_frames >= start_frame);
 	frames_to_mix = mixed_frames - start_frame;
@@ -164,7 +164,7 @@ static void normal_mix_channel_s24(struct audio_stream __sparse_cache *sink, int
 	int32_t n, nmax, i;
 	/* audio_stream_wrap() is required and is done below in a loop */
 	int32_t *dst = (int32_t *)sink->w_ptr + start_frame;
-	int32_t *src = (int32_t *)source->r_ptr;
+	int32_t *src = audio_stream_get_rptr(source);
 
 	assert(mixed_frames >= start_frame);
 	frames_to_mix = mixed_frames - start_frame;
@@ -209,7 +209,7 @@ static void remap_mix_channel_s24(struct audio_stream __sparse_cache *sink,
 
 	/* audio_stream_wrap() is required and is done below in a loop */
 	dst = (int32_t *)sink->w_ptr + start_frame * sink_channel_count + sink_channel_index;
-	src = (int32_t *)source->r_ptr + source_channel_index;
+	src = (int32_t *)audio_stream_get_rptr(source) + source_channel_index;
 
 	assert(mixed_frames >= start_frame);
 	frames_to_mix = mixed_frames - start_frame;
@@ -273,7 +273,7 @@ static void normal_mix_channel_s32(struct audio_stream __sparse_cache *sink, int
 	int32_t frames_to_mix, frames_to_copy, left_frames;
 	int32_t n, nmax, i;
 	int32_t *dst = (int32_t *)sink->w_ptr + start_frame;
-	int32_t *src = (int32_t *)source->r_ptr;
+	int32_t *src = audio_stream_get_rptr(source);
 
 	assert(mixed_frames >= start_frame);
 	frames_to_mix = mixed_frames - start_frame;
@@ -318,7 +318,7 @@ static void remap_mix_channel_s32(struct audio_stream __sparse_cache *sink,
 
 	/* audio_stream_wrap() is required and is done below in a loop */
 	dst = (int32_t *)sink->w_ptr + start_frame * sink_channel_count + sink_channel_index;
-	src = (int32_t *)source->r_ptr + source_channel_index;
+	src = (int32_t *)audio_stream_get_rptr(source) + source_channel_index;
 
 	assert(mixed_frames >= start_frame);
 	frames_to_mix = mixed_frames - start_frame;

--- a/src/audio/mixin_mixout/mixin_mixout_generic.c
+++ b/src/audio/mixin_mixout/mixin_mixout_generic.c
@@ -11,9 +11,9 @@
 #ifdef MIXIN_MIXOUT_GENERIC
 
 #if CONFIG_FORMAT_S16LE
-/* Instead of using sink->channels and source->channels, sink_channel_count and
- * source_channel_count are supplied as parameters. This is done to reuse the function
- * to also mix an entire stream. In this case the function is called with fake stream
+/* Instead of using audio_stream_get_channels(sink) and audio_stream_get_channels(source),
+ * sink_channel_count and source_channel_count are supplied as parameters. This is done to reuse
+ * the function to also mix an entire stream. In this case the function is called with fake stream
  * parameters: multichannel stream is treated as single channel and so the entire stream
  * contents is mixed.
  */
@@ -130,9 +130,10 @@ static void mute_channel_s16(struct audio_stream __sparse_cache *stream, int32_t
 	if (frame_count <= skip_mixed_frames)
 		return;
 	frame_count -= skip_mixed_frames;
-	channel_count = stream->channels;
+	channel_count = audio_stream_get_channels(stream);
 	/* audio_stream_wrap() is needed here and it is just below in a loop */
-	ptr = (int16_t *)audio_stream_get_wptr(stream) + mixed_frames * stream->channels +
+	ptr = (int16_t *)audio_stream_get_wptr(stream) +
+		mixed_frames * audio_stream_get_channels(stream) +
 		channel_index;
 
 	for (left_frames = frame_count; left_frames; left_frames -= frames) {
@@ -151,9 +152,9 @@ static void mute_channel_s16(struct audio_stream __sparse_cache *stream, int32_t
 #endif	/* CONFIG_FORMAT_S16LE */
 
 #if CONFIG_FORMAT_S24LE
-/* Instead of using sink->channels and source->channels, sink_channel_count and
- * source_channel_count are supplied as parameters. This is done to reuse the function
- * to also mix an entire stream. In this case the function is called with fake stream
+/* Instead of using audio_stream_get_channels(sink) and audio_stream_get_channels(source),
+ * sink_channel_count and source_channel_count are supplied as parameters. This is done to reuse
+ * the function to also mix an entire stream. In this case the function is called with fake stream
  * parameters: multichannel stream is treated as single channel and so the entire stream
  * contents is mixed.
  */
@@ -262,9 +263,9 @@ static void remap_mix_channel_s24(struct audio_stream __sparse_cache *sink,
 #endif	/* CONFIG_FORMAT_S24LE */
 
 #if CONFIG_FORMAT_S32LE
-/* Instead of using sink->channels and source->channels, sink_channel_count and
- * source_channel_count are supplied as parameters. This is done to reuse the function
- * to also mix an entire stream. In this case the function is called with fake stream
+/* Instead of using audio_stream_get_channels(sink) and audio_stream_get_channels(source),
+ * sink_channel_count and source_channel_count are supplied as parameters. This is done to reuse
+ * the function to also mix an entire stream. In this case the function is called with fake stream
  * parameters: multichannel stream is treated as single channel and so the entire stream
  * contents is mixed.
  */
@@ -382,9 +383,10 @@ static void mute_channel_s32(struct audio_stream __sparse_cache *stream, int32_t
 	if (frame_count <= skip_mixed_frames)
 		return;
 	frame_count -= skip_mixed_frames;
-	channel_count = stream->channels;
+	channel_count = audio_stream_get_channels(stream);
 
-	ptr = (int32_t *)audio_stream_get_wptr(stream) + mixed_frames * stream->channels +
+	ptr = (int32_t *)audio_stream_get_wptr(stream) +
+		mixed_frames * audio_stream_get_channels(stream) +
 		channel_index;
 
 	for (left_frames = frame_count; left_frames > 0; left_frames -= frames) {

--- a/src/audio/mixin_mixout/mixin_mixout_hifi3.c
+++ b/src/audio/mixin_mixout/mixin_mixout_hifi3.c
@@ -136,7 +136,7 @@ static void remap_mix_channel_s16(struct audio_stream __sparse_cache *sink,
 
 	/* set source as circular buffer, hifi3 only have 1 circular buffer*/
 	AE_SETCBEGIN0(source->addr);
-	AE_SETCEND0(source->end_addr);
+	AE_SETCEND0(audio_stream_get_end_addr(source));
 
 	for (left_frames = frames_to_mix; left_frames > 0; left_frames -= frames) {
 		/* audio_stream_wrap() is required and is done below in a loop */
@@ -198,7 +198,7 @@ static void mute_channel_s16(struct audio_stream __sparse_cache *stream, int32_t
 	frame_count -= skip_mixed_frames;
 
 	AE_SETCBEGIN0(stream->addr);
-	AE_SETCEND0(stream->end_addr);
+	AE_SETCEND0(audio_stream_get_end_addr(stream));
 
 	/* audio_stream_wrap() is needed here and it is just below in a loop */
 	ptr = (ae_int16 *)audio_stream_get_wptr(stream) + mixed_frames * stream->channels +
@@ -328,7 +328,7 @@ static void remap_mix_channel_s24(struct audio_stream __sparse_cache *sink,
 	AE_L16_IP(gain_v, pgain, 0);
 	/* set source as circular buffer, hifi3 only have 1 circular buffer*/
 	AE_SETCBEGIN0(source->addr);
-	AE_SETCEND0(source->end_addr);
+	AE_SETCEND0(audio_stream_get_end_addr(source));
 
 	for (left_frames = frames_to_mix; left_frames > 0; left_frames -= frames) {
 		dst = audio_stream_wrap(sink, dst);
@@ -500,7 +500,7 @@ static void remap_mix_channel_s32(struct audio_stream __sparse_cache *sink,
 	AE_L16_IP(gain_v, pgain, 0);
 	/* set source as circular buffer, hifi3 only have 1 circular buffer*/
 	AE_SETCBEGIN0(source->addr);
-	AE_SETCEND0(source->end_addr);
+	AE_SETCEND0(audio_stream_get_end_addr(source));
 	src = audio_stream_wrap(source, src);
 
 	for (left_frames = frames_to_mix; left_frames > 0; left_frames -= frames) {
@@ -564,7 +564,7 @@ static void mute_channel_s32(struct audio_stream __sparse_cache *stream, int32_t
 	frame_count -= skip_mixed_frames;
 
 	AE_SETCBEGIN0(stream->addr);
-	AE_SETCEND0(stream->end_addr);
+	AE_SETCEND0(audio_stream_get_end_addr(stream));
 
 	/* audio_stream_wrap() is needed here and it is just below in a loop */
 	ptr = (ae_int32 *)audio_stream_get_wptr(stream) + mixed_frames * stream->channels +

--- a/src/audio/mixin_mixout/mixin_mixout_hifi3.c
+++ b/src/audio/mixin_mixout/mixin_mixout_hifi3.c
@@ -135,7 +135,7 @@ static void remap_mix_channel_s16(struct audio_stream __sparse_cache *sink,
 	AE_L16_IP(gain_v, pgain, 0);
 
 	/* set source as circular buffer, hifi3 only have 1 circular buffer*/
-	AE_SETCBEGIN0(source->addr);
+	AE_SETCBEGIN0(audio_stream_get_addr(source));
 	AE_SETCEND0(audio_stream_get_end_addr(source));
 
 	for (left_frames = frames_to_mix; left_frames > 0; left_frames -= frames) {
@@ -197,7 +197,7 @@ static void mute_channel_s16(struct audio_stream __sparse_cache *stream, int32_t
 		return;
 	frame_count -= skip_mixed_frames;
 
-	AE_SETCBEGIN0(stream->addr);
+	AE_SETCBEGIN0(audio_stream_get_addr(stream));
 	AE_SETCEND0(audio_stream_get_end_addr(stream));
 
 	/* audio_stream_wrap() is needed here and it is just below in a loop */
@@ -327,7 +327,7 @@ static void remap_mix_channel_s24(struct audio_stream __sparse_cache *sink,
 	/* store gain to a AE_DR register gain_v*/
 	AE_L16_IP(gain_v, pgain, 0);
 	/* set source as circular buffer, hifi3 only have 1 circular buffer*/
-	AE_SETCBEGIN0(source->addr);
+	AE_SETCBEGIN0(audio_stream_get_addr(source));
 	AE_SETCEND0(audio_stream_get_end_addr(source));
 
 	for (left_frames = frames_to_mix; left_frames > 0; left_frames -= frames) {
@@ -499,7 +499,7 @@ static void remap_mix_channel_s32(struct audio_stream __sparse_cache *sink,
 	/* store gain to a AE_DR register gain_v*/
 	AE_L16_IP(gain_v, pgain, 0);
 	/* set source as circular buffer, hifi3 only have 1 circular buffer*/
-	AE_SETCBEGIN0(source->addr);
+	AE_SETCBEGIN0(audio_stream_get_addr(source));
 	AE_SETCEND0(audio_stream_get_end_addr(source));
 	src = audio_stream_wrap(source, src);
 
@@ -563,7 +563,7 @@ static void mute_channel_s32(struct audio_stream __sparse_cache *stream, int32_t
 		return;
 	frame_count -= skip_mixed_frames;
 
-	AE_SETCBEGIN0(stream->addr);
+	AE_SETCBEGIN0(audio_stream_get_addr(stream));
 	AE_SETCEND0(audio_stream_get_end_addr(stream));
 
 	/* audio_stream_wrap() is needed here and it is just below in a loop */

--- a/src/audio/mixin_mixout/mixin_mixout_hifi3.c
+++ b/src/audio/mixin_mixout/mixin_mixout_hifi3.c
@@ -31,7 +31,7 @@ static void normal_mix_channel_s16(struct audio_stream __sparse_cache *sink, int
 	ae_valign outu1 = AE_ZALIGN64();
 	ae_valign outu2 = AE_ZALIGN64();
 	/* audio_stream_wrap() is required and is done below in a loop */
-	ae_int16 *dst = (ae_int16 *)sink->w_ptr + start_frame;
+	ae_int16 *dst = (ae_int16 *)audio_stream_get_wptr(sink) + start_frame;
 	ae_int16 *src = audio_stream_get_rptr(source);
 
 	assert(mixed_frames >= start_frame);
@@ -122,7 +122,8 @@ static void remap_mix_channel_s16(struct audio_stream __sparse_cache *sink,
 	ae_int16x4 gain_v;
 	ae_int32x2 temp, out1;
 
-	dst = (ae_int16 *)sink->w_ptr + start_frame * sink_channel_count + sink_channel_index;
+	dst = (ae_int16 *)audio_stream_get_wptr(sink) + start_frame * sink_channel_count +
+		sink_channel_index;
 	src = (ae_int16 *)audio_stream_get_rptr(source) + source_channel_index;
 	src = audio_stream_wrap(source, src);
 
@@ -200,7 +201,8 @@ static void mute_channel_s16(struct audio_stream __sparse_cache *stream, int32_t
 	AE_SETCEND0(stream->end_addr);
 
 	/* audio_stream_wrap() is needed here and it is just below in a loop */
-	ptr = (ae_int16 *)stream->w_ptr + mixed_frames * stream->channels + channel_index;
+	ptr = (ae_int16 *)audio_stream_get_wptr(stream) + mixed_frames * stream->channels +
+		channel_index;
 	ptr = audio_stream_wrap(stream, ptr);
 
 	for (left_frames = frame_count ; left_frames; left_frames--)
@@ -230,7 +232,7 @@ static void normal_mix_channel_s24(struct audio_stream __sparse_cache *sink, int
 	ae_valign outu1 = AE_ZALIGN64();
 	ae_valign outu2 = AE_ZALIGN64();
 	/* audio_stream_wrap() is required and is done below in a loop */
-	int32_t *dst = (int32_t *)sink->w_ptr + start_frame;
+	int32_t *dst = (int32_t *)audio_stream_get_wptr(sink) + start_frame;
 	int32_t *src = audio_stream_get_rptr(source);
 
 	assert(mixed_frames >= start_frame);
@@ -314,7 +316,8 @@ static void remap_mix_channel_s24(struct audio_stream __sparse_cache *sink,
 	ae_int16x4 gain_v;
 	ae_int32 *dst, *src;
 
-	dst = (ae_int32 *)sink->w_ptr + start_frame * sink_channel_count + sink_channel_index;
+	dst = (ae_int32 *)audio_stream_get_wptr(sink) + start_frame * sink_channel_count +
+		sink_channel_index;
 	src = (ae_int32 *)audio_stream_get_rptr(source) + source_channel_index;
 	src = audio_stream_wrap(source, src);
 	assert(mixed_frames >= start_frame);
@@ -400,7 +403,7 @@ static void normal_mix_channel_s32(struct audio_stream __sparse_cache *sink, int
 	ae_valign outu1 = AE_ZALIGN64();
 	ae_valign outu2 = AE_ZALIGN64();
 	/* audio_stream_wrap() is required and is done below in a loop */
-	int32_t *dst = (int32_t *)sink->w_ptr + start_frame;
+	int32_t *dst = (int32_t *)audio_stream_get_wptr(sink) + start_frame;
 	int32_t *src = audio_stream_get_rptr(source);
 
 	assert(mixed_frames >= start_frame);
@@ -486,7 +489,8 @@ static void remap_mix_channel_s32(struct audio_stream __sparse_cache *sink,
 	ae_int32 *dst, *src;
 
 	/* audio_stream_wrap() is required and is done below in a loop */
-	dst = (ae_int32 *)sink->w_ptr + start_frame * sink_channel_count + sink_channel_index;
+	dst = (ae_int32 *)audio_stream_get_wptr(sink) + start_frame * sink_channel_count +
+		sink_channel_index;
 	src = (ae_int32 *)audio_stream_get_rptr(source) + source_channel_index;
 
 	assert(mixed_frames >= start_frame);
@@ -563,7 +567,8 @@ static void mute_channel_s32(struct audio_stream __sparse_cache *stream, int32_t
 	AE_SETCEND0(stream->end_addr);
 
 	/* audio_stream_wrap() is needed here and it is just below in a loop */
-	ptr = (ae_int32 *)stream->w_ptr + mixed_frames * stream->channels + channel_index;
+	ptr = (ae_int32 *)audio_stream_get_wptr(stream) + mixed_frames * stream->channels +
+		channel_index;
 	ptr = audio_stream_wrap(stream, ptr);
 
 	for (left_frames = frame_count ; left_frames > 0; left_frames--)

--- a/src/audio/mixin_mixout/mixin_mixout_hifi3.c
+++ b/src/audio/mixin_mixout/mixin_mixout_hifi3.c
@@ -32,7 +32,7 @@ static void normal_mix_channel_s16(struct audio_stream __sparse_cache *sink, int
 	ae_valign outu2 = AE_ZALIGN64();
 	/* audio_stream_wrap() is required and is done below in a loop */
 	ae_int16 *dst = (ae_int16 *)sink->w_ptr + start_frame;
-	ae_int16 *src = (ae_int16 *)source->r_ptr;
+	ae_int16 *src = audio_stream_get_rptr(source);
 
 	assert(mixed_frames >= start_frame);
 	frames_to_mix = AE_MIN_32_signed(mixed_frames - start_frame, frame_count);
@@ -123,7 +123,7 @@ static void remap_mix_channel_s16(struct audio_stream __sparse_cache *sink,
 	ae_int32x2 temp, out1;
 
 	dst = (ae_int16 *)sink->w_ptr + start_frame * sink_channel_count + sink_channel_index;
-	src = (ae_int16 *)source->r_ptr + source_channel_index;
+	src = (ae_int16 *)audio_stream_get_rptr(source) + source_channel_index;
 	src = audio_stream_wrap(source, src);
 
 	assert(mixed_frames >= start_frame);
@@ -231,7 +231,7 @@ static void normal_mix_channel_s24(struct audio_stream __sparse_cache *sink, int
 	ae_valign outu2 = AE_ZALIGN64();
 	/* audio_stream_wrap() is required and is done below in a loop */
 	int32_t *dst = (int32_t *)sink->w_ptr + start_frame;
-	int32_t *src = (int32_t *)source->r_ptr;
+	int32_t *src = audio_stream_get_rptr(source);
 
 	assert(mixed_frames >= start_frame);
 	frames_to_mix = AE_MIN_32_signed(mixed_frames - start_frame, frame_count);
@@ -315,7 +315,7 @@ static void remap_mix_channel_s24(struct audio_stream __sparse_cache *sink,
 	ae_int32 *dst, *src;
 
 	dst = (ae_int32 *)sink->w_ptr + start_frame * sink_channel_count + sink_channel_index;
-	src = (ae_int32 *)source->r_ptr + source_channel_index;
+	src = (ae_int32 *)audio_stream_get_rptr(source) + source_channel_index;
 	src = audio_stream_wrap(source, src);
 	assert(mixed_frames >= start_frame);
 	frames_to_mix = AE_MIN_32_signed(mixed_frames - start_frame, frame_count);
@@ -401,7 +401,7 @@ static void normal_mix_channel_s32(struct audio_stream __sparse_cache *sink, int
 	ae_valign outu2 = AE_ZALIGN64();
 	/* audio_stream_wrap() is required and is done below in a loop */
 	int32_t *dst = (int32_t *)sink->w_ptr + start_frame;
-	int32_t *src = (int32_t *)source->r_ptr;
+	int32_t *src = audio_stream_get_rptr(source);
 
 	assert(mixed_frames >= start_frame);
 	frames_to_mix = AE_MIN_32_signed(mixed_frames - start_frame, frame_count);
@@ -487,7 +487,7 @@ static void remap_mix_channel_s32(struct audio_stream __sparse_cache *sink,
 
 	/* audio_stream_wrap() is required and is done below in a loop */
 	dst = (ae_int32 *)sink->w_ptr + start_frame * sink_channel_count + sink_channel_index;
-	src = (ae_int32 *)source->r_ptr + source_channel_index;
+	src = (ae_int32 *)audio_stream_get_rptr(source) + source_channel_index;
 
 	assert(mixed_frames >= start_frame);
 	frames_to_mix = AE_MIN_32_signed(mixed_frames - start_frame, frame_count);

--- a/src/audio/mixin_mixout/mixin_mixout_hifi3.c
+++ b/src/audio/mixin_mixout/mixin_mixout_hifi3.c
@@ -10,9 +10,9 @@
 #ifdef MIXIN_MIXOUT_HIFI3
 
 #if CONFIG_FORMAT_S16LE
-/* Instead of using sink->channels and source->channels, sink_channel_count and
- * source_channel_count are supplied as parameters. This is done to reuse the function
- * to also mix an entire stream. In this case the function is called with fake stream
+/* Instead of using audio_stream_get_channels(sink) and audio_stream_get_channels(source),
+ * sink_channel_count and source_channel_count are supplied as parameters. This is done to reuse
+ * the function to also mix an entire stream. In this case the function is called with fake stream
  * parameters: multichannel stream is treated as single channel and so the entire stream
  * contents is mixed.
  */
@@ -186,7 +186,7 @@ static void mute_channel_s16(struct audio_stream __sparse_cache *stream, int32_t
 			     int32_t start_frame, int32_t mixed_frames, int32_t frame_count)
 {
 	int skip_mixed_frames, left_frames;
-	int off = stream->channels * sizeof(ae_int16);
+	int off = audio_stream_get_channels(stream) * sizeof(ae_int16);
 	ae_int16 *ptr;
 	ae_int16x4 zero = AE_ZERO16();
 
@@ -201,7 +201,8 @@ static void mute_channel_s16(struct audio_stream __sparse_cache *stream, int32_t
 	AE_SETCEND0(audio_stream_get_end_addr(stream));
 
 	/* audio_stream_wrap() is needed here and it is just below in a loop */
-	ptr = (ae_int16 *)audio_stream_get_wptr(stream) + mixed_frames * stream->channels +
+	ptr = (ae_int16 *)audio_stream_get_wptr(stream) +
+		mixed_frames * audio_stream_get_channels(stream) +
 		channel_index;
 	ptr = audio_stream_wrap(stream, ptr);
 
@@ -211,9 +212,9 @@ static void mute_channel_s16(struct audio_stream __sparse_cache *stream, int32_t
 #endif	/* CONFIG_FORMAT_S16LE */
 
 #if CONFIG_FORMAT_S24LE
-/* Instead of using sink->channels and source->channels, sink_channel_count and
- * source_channel_count are supplied as parameters. This is done to reuse the function
- * to also mix an entire stream. In this case the function is called with fake stream
+/* Instead of using audio_stream_get_channels(sink) and audio_stream_get_channels(source),
+ * sink_channel_count and source_channel_count are supplied as parameters. This is done to reuse
+ * the function to also mix an entire stream. In this case the function is called with fake stream
  * parameters: multichannel stream is treated as single channel and so the entire stream
  * contents is mixed.
  */
@@ -382,9 +383,9 @@ static void remap_mix_channel_s24(struct audio_stream __sparse_cache *sink,
 #endif	/* CONFIG_FORMAT_S24LE */
 
 #if CONFIG_FORMAT_S32LE
-/* Instead of using sink->channels and source->channels, sink_channel_count and
- * source_channel_count are supplied as parameters. This is done to reuse the function
- * to also mix an entire stream. In this case the function is called with fake stream
+/* Instead of using audio_stream_get_channels(sink) and audio_stream_get_channels(source),
+ * sink_channel_count and source_channel_count are supplied as parameters. This is done to reuse
+ * the function to also mix an entire stream. In this case the function is called with fake stream
  * parameters: multichannel stream is treated as single channel and so the entire stream
  * contents is mixed.
  */
@@ -553,7 +554,7 @@ static void mute_channel_s32(struct audio_stream __sparse_cache *stream, int32_t
 {
 	int skip_mixed_frames, left_frames;
 	ae_int32 *ptr;
-	int off = stream->channels * sizeof(ae_int32);
+	int off = audio_stream_get_channels(stream) * sizeof(ae_int32);
 	ae_int32x2 zero = AE_ZERO32();
 
 	assert(mixed_frames >= start_frame);
@@ -567,7 +568,8 @@ static void mute_channel_s32(struct audio_stream __sparse_cache *stream, int32_t
 	AE_SETCEND0(audio_stream_get_end_addr(stream));
 
 	/* audio_stream_wrap() is needed here and it is just below in a loop */
-	ptr = (ae_int32 *)audio_stream_get_wptr(stream) + mixed_frames * stream->channels +
+	ptr = (ae_int32 *)audio_stream_get_wptr(stream) +
+		mixed_frames * audio_stream_get_channels(stream) +
 		channel_index;
 	ptr = audio_stream_wrap(stream, ptr);
 

--- a/src/audio/module_adapter/module/dts.c
+++ b/src/audio/module_adapter/module/dts.c
@@ -93,7 +93,7 @@ static int dts_effect_populate_buffer_configuration(struct comp_dev *dev,
 
 	buffer_fmt = source_c->buffer_fmt;
 	stream = &source_c->stream;
-	frame_fmt = stream->frame_fmt;
+	frame_fmt = audio_stream_get_frm_fmt(stream);
 	rate = stream->rate;
 	channels = stream->channels;
 

--- a/src/audio/module_adapter/module/dts.c
+++ b/src/audio/module_adapter/module/dts.c
@@ -95,7 +95,7 @@ static int dts_effect_populate_buffer_configuration(struct comp_dev *dev,
 	stream = &source_c->stream;
 	frame_fmt = audio_stream_get_frm_fmt(stream);
 	rate = audio_stream_get_rate(stream);
-	channels = stream->channels;
+	channels = audio_stream_get_channels(stream);
 
 	buffer_release(source_c);
 

--- a/src/audio/module_adapter/module/dts.c
+++ b/src/audio/module_adapter/module/dts.c
@@ -94,7 +94,7 @@ static int dts_effect_populate_buffer_configuration(struct comp_dev *dev,
 	buffer_fmt = source_c->buffer_fmt;
 	stream = &source_c->stream;
 	frame_fmt = audio_stream_get_frm_fmt(stream);
-	rate = stream->rate;
+	rate = audio_stream_get_rate(stream);
 	channels = stream->channels;
 
 	buffer_release(source_c);

--- a/src/audio/module_adapter/module/volume/volume.c
+++ b/src/audio/module_adapter/module/volume/volume.c
@@ -1276,9 +1276,9 @@ static int volume_prepare(struct processing_module *mod)
 	sink_period_bytes = audio_stream_period_bytes(&sink_c->stream,
 						      dev->frames);
 
-	if (sink_c->stream.size < sink_period_bytes) {
+	if (audio_stream_get_size(&sink_c->stream) < sink_period_bytes) {
 		comp_err(dev, "volume_prepare(): sink buffer size %d is insufficient < %d",
-			 sink_c->stream.size, sink_period_bytes);
+			 audio_stream_get_size(&sink_c->stream), sink_period_bytes);
 		ret = -ENOMEM;
 		goto err;
 	}

--- a/src/audio/module_adapter/module/volume/volume.c
+++ b/src/audio/module_adapter/module/volume/volume.c
@@ -1190,7 +1190,7 @@ static vol_zc_func vol_get_zc_function(struct comp_dev *dev,
 
 	/* map the zc function to frame format */
 	for (i = 0; i < ARRAY_SIZE(zc_func_map); i++) {
-		if (sinkb->stream.valid_sample_fmt == zc_func_map[i].frame_fmt)
+		if (audio_stream_get_valid_fmt(&sinkb->stream) == zc_func_map[i].frame_fmt)
 			return zc_func_map[i].func;
 	}
 

--- a/src/audio/module_adapter/module/volume/volume.c
+++ b/src/audio/module_adapter/module/volume/volume.c
@@ -985,10 +985,9 @@ static int volume_set_attenuation(struct processing_module *mod, const uint8_t *
 				  int data_size)
 {
 	struct vol_data *cd = module_get_private_data(mod);
+	enum sof_ipc_frame frame_fmt, valid_fmt;
 	struct comp_dev *dev = mod->dev;
 	uint32_t attenuation;
-	uint32_t __sparse_cache valid_fmt, frame_fmt;
-
 
 	/* only support attenuation in format of 32bit */
 	if (data_size > sizeof(uint32_t)) {
@@ -1088,10 +1087,10 @@ static int volume_params(struct processing_module *mod)
 {
 	struct sof_ipc_stream_params *params = mod->stream_params;
 	struct sof_ipc_stream_params vol_params;
+	enum sof_ipc_frame frame_fmt, valid_fmt;
 	struct comp_dev *dev = mod->dev;
 	struct comp_buffer *sinkb;
 	struct comp_buffer __sparse_cache *sink_c;
-	uint32_t __sparse_cache valid_fmt, frame_fmt;
 	int i, ret;
 
 	comp_dbg(dev, "volume_params()");

--- a/src/audio/module_adapter/module/volume/volume.c
+++ b/src/audio/module_adapter/module/volume/volume.c
@@ -80,7 +80,7 @@ static uint32_t vol_zc_get_s16(const struct audio_stream __sparse_cache *source,
 {
 	uint32_t curr_frames = frames;
 	int32_t sum;
-	int16_t *x = source->r_ptr;
+	int16_t *x = audio_stream_get_rptr(source);
 	int bytes;
 	int nmax;
 	int i, j, n;
@@ -128,7 +128,7 @@ static uint32_t vol_zc_get_s24(const struct audio_stream __sparse_cache *source,
 {
 	int64_t sum;
 	uint32_t curr_frames = frames;
-	int32_t *x = source->r_ptr;
+	int32_t *x = audio_stream_get_rptr(source);
 	int bytes;
 	int nmax;
 	int i, j, n;
@@ -176,7 +176,7 @@ static uint32_t vol_zc_get_s32(const struct audio_stream __sparse_cache *source,
 {
 	int64_t sum;
 	uint32_t curr_frames = frames;
-	int32_t *x = source->r_ptr;
+	int32_t *x = audio_stream_get_rptr(source);
 	int bytes;
 	int nmax;
 	int i, j, n;

--- a/src/audio/module_adapter/module/volume/volume.c
+++ b/src/audio/module_adapter/module/volume/volume.c
@@ -1311,7 +1311,8 @@ static int volume_prepare(struct processing_module *mod)
 		goto err;
 	}
 
-	cd->sample_rate_inv = (int32_t)(1000LL * INT32_MAX / sink_c->stream.rate);
+	cd->sample_rate_inv = (int32_t)(1000LL * INT32_MAX /
+					audio_stream_get_rate(&sink_c->stream));
 
 	buffer_release(sink_c);
 

--- a/src/audio/module_adapter/module/volume/volume.c
+++ b/src/audio/module_adapter/module/volume/volume.c
@@ -84,7 +84,7 @@ static uint32_t vol_zc_get_s16(const struct audio_stream __sparse_cache *source,
 	int bytes;
 	int nmax;
 	int i, j, n;
-	const int nch = source->channels;
+	const int nch = audio_stream_get_channels(source);
 	int remaining_samples = frames * nch;
 
 	x = audio_stream_wrap(source, x + remaining_samples - 1); /* Go to last channel */
@@ -132,7 +132,7 @@ static uint32_t vol_zc_get_s24(const struct audio_stream __sparse_cache *source,
 	int bytes;
 	int nmax;
 	int i, j, n;
-	const int nch = source->channels;
+	const int nch = audio_stream_get_channels(source);
 	int remaining_samples = frames * nch;
 
 	x = audio_stream_wrap(source, x + remaining_samples - 1); /* Go to last channel */
@@ -180,7 +180,7 @@ static uint32_t vol_zc_get_s32(const struct audio_stream __sparse_cache *source,
 	int bytes;
 	int nmax;
 	int i, j, n;
-	const int nch = source->channels;
+	const int nch = audio_stream_get_channels(source);
 	int remaining_samples = frames * nch;
 
 	x = audio_stream_wrap(source, x + remaining_samples - 1); /* Go to last channel */
@@ -1305,7 +1305,7 @@ static int volume_prepare(struct processing_module *mod)
 	 */
 	cd->ramp_finished = false;
 
-	cd->channels = sink_c->stream.channels;
+	cd->channels = audio_stream_get_channels(&sink_c->stream);
 	if (cd->channels > SOF_IPC_MAX_CHANNELS) {
 		ret = -EINVAL;
 		goto err;

--- a/src/audio/module_adapter/module/volume/volume_generic.c
+++ b/src/audio/module_adapter/module/volume/volume_generic.c
@@ -70,7 +70,7 @@ static void vol_s24_to_s24(struct processing_module *mod, struct input_stream_bu
 	const int nch = source->channels;
 	int remaining_samples = frames * nch;
 
-	x = audio_stream_wrap(source, (char *)source->r_ptr + bsource->consumed);
+	x = audio_stream_wrap(source, (char *)audio_stream_get_rptr(source) + bsource->consumed);
 	y = audio_stream_wrap(sink, (char *)sink->w_ptr + bsink->size);
 
 	bsource->consumed += VOL_S32_SAMPLES_TO_BYTES(remaining_samples);
@@ -121,7 +121,7 @@ static void vol_s32_to_s32(struct processing_module *mod, struct input_stream_bu
 	const int nch = source->channels;
 	int remaining_samples = frames * nch;
 
-	x = audio_stream_wrap(source, (char *)source->r_ptr + bsource->consumed);
+	x = audio_stream_wrap(source, (char *)audio_stream_get_rptr(source) + bsource->consumed);
 	y = audio_stream_wrap(sink, (char *)sink->w_ptr + bsink->size);
 	bsource->consumed += VOL_S32_SAMPLES_TO_BYTES(remaining_samples);
 	bsink->size += VOL_S32_SAMPLES_TO_BYTES(remaining_samples);
@@ -175,7 +175,7 @@ static void vol_s16_to_s16(struct processing_module *mod, struct input_stream_bu
 	const int nch = source->channels;
 	int remaining_samples = frames * nch;
 
-	x = audio_stream_wrap(source, (char *)source->r_ptr + bsource->consumed);
+	x = audio_stream_wrap(source, (char *)audio_stream_get_rptr(source) + bsource->consumed);
 	y = audio_stream_wrap(sink, (char *)sink->w_ptr + bsink->size);
 	bsource->consumed += VOL_S16_SAMPLES_TO_BYTES(remaining_samples);
 	bsink->size += VOL_S16_SAMPLES_TO_BYTES(remaining_samples);

--- a/src/audio/module_adapter/module/volume/volume_generic.c
+++ b/src/audio/module_adapter/module/volume/volume_generic.c
@@ -71,7 +71,7 @@ static void vol_s24_to_s24(struct processing_module *mod, struct input_stream_bu
 	int remaining_samples = frames * nch;
 
 	x = audio_stream_wrap(source, (char *)audio_stream_get_rptr(source) + bsource->consumed);
-	y = audio_stream_wrap(sink, (char *)sink->w_ptr + bsink->size);
+	y = audio_stream_wrap(sink, (char *)audio_stream_get_wptr(sink) + bsink->size);
 
 	bsource->consumed += VOL_S32_SAMPLES_TO_BYTES(remaining_samples);
 	bsink->size += VOL_S32_SAMPLES_TO_BYTES(remaining_samples);
@@ -122,7 +122,7 @@ static void vol_s32_to_s32(struct processing_module *mod, struct input_stream_bu
 	int remaining_samples = frames * nch;
 
 	x = audio_stream_wrap(source, (char *)audio_stream_get_rptr(source) + bsource->consumed);
-	y = audio_stream_wrap(sink, (char *)sink->w_ptr + bsink->size);
+	y = audio_stream_wrap(sink, (char *)audio_stream_get_wptr(sink) + bsink->size);
 	bsource->consumed += VOL_S32_SAMPLES_TO_BYTES(remaining_samples);
 	bsink->size += VOL_S32_SAMPLES_TO_BYTES(remaining_samples);
 	while (remaining_samples) {
@@ -176,7 +176,7 @@ static void vol_s16_to_s16(struct processing_module *mod, struct input_stream_bu
 	int remaining_samples = frames * nch;
 
 	x = audio_stream_wrap(source, (char *)audio_stream_get_rptr(source) + bsource->consumed);
-	y = audio_stream_wrap(sink, (char *)sink->w_ptr + bsink->size);
+	y = audio_stream_wrap(sink, (char *)audio_stream_get_wptr(sink) + bsink->size);
 	bsource->consumed += VOL_S16_SAMPLES_TO_BYTES(remaining_samples);
 	bsink->size += VOL_S16_SAMPLES_TO_BYTES(remaining_samples);
 	while (remaining_samples) {

--- a/src/audio/module_adapter/module/volume/volume_generic.c
+++ b/src/audio/module_adapter/module/volume/volume_generic.c
@@ -67,7 +67,7 @@ static void vol_s24_to_s24(struct processing_module *mod, struct input_stream_bu
 	int32_t *x, *x0;
 	int32_t *y, *y0;
 	int nmax, n, i, j;
-	const int nch = source->channels;
+	const int nch = audio_stream_get_channels(source);
 	int remaining_samples = frames * nch;
 
 	x = audio_stream_wrap(source, (char *)audio_stream_get_rptr(source) + bsource->consumed);
@@ -118,7 +118,7 @@ static void vol_s32_to_s32(struct processing_module *mod, struct input_stream_bu
 	int32_t *x, *x0;
 	int32_t *y, *y0;
 	int nmax, n, i, j;
-	const int nch = source->channels;
+	const int nch = audio_stream_get_channels(source);
 	int remaining_samples = frames * nch;
 
 	x = audio_stream_wrap(source, (char *)audio_stream_get_rptr(source) + bsource->consumed);
@@ -172,7 +172,7 @@ static void vol_s16_to_s16(struct processing_module *mod, struct input_stream_bu
 	int16_t *x, *x0;
 	int16_t *y, *y0;
 	int nmax, n, i, j;
-	const int nch = source->channels;
+	const int nch = audio_stream_get_channels(source);
 	int remaining_samples = frames * nch;
 
 	x = audio_stream_wrap(source, (char *)audio_stream_get_rptr(source) + bsource->consumed);

--- a/src/audio/module_adapter/module/volume/volume_generic_with_peakvol.c
+++ b/src/audio/module_adapter/module/volume/volume_generic_with_peakvol.c
@@ -69,7 +69,7 @@ static void vol_s24_to_s24(struct processing_module *mod, struct input_stream_bu
 
 	memset(cd->peak_regs.peak_meter, 0, sizeof(uint32_t) * cd->channels);
 	x = audio_stream_wrap(source, (char *)audio_stream_get_rptr(source) + bsource->consumed);
-	y = audio_stream_wrap(sink, (char *)sink->w_ptr + bsink->size);
+	y = audio_stream_wrap(sink, (char *)audio_stream_get_wptr(sink) + bsink->size);
 
 	bsource->consumed += VOL_S32_SAMPLES_TO_BYTES(remaining_samples);
 	bsink->size += VOL_S32_SAMPLES_TO_BYTES(remaining_samples);
@@ -128,7 +128,7 @@ static void vol_s32_to_s32(struct processing_module *mod, struct input_stream_bu
 
 	memset(cd->peak_regs.peak_meter, 0, sizeof(uint32_t) * cd->channels);
 	x = audio_stream_wrap(source, (char *)audio_stream_get_rptr(source) + bsource->consumed);
-	y = audio_stream_wrap(sink, (char *)sink->w_ptr + bsink->size);
+	y = audio_stream_wrap(sink, (char *)audio_stream_get_wptr(sink) + bsink->size);
 	bsource->consumed += VOL_S32_SAMPLES_TO_BYTES(remaining_samples);
 	bsink->size += VOL_S32_SAMPLES_TO_BYTES(remaining_samples);
 	while (remaining_samples) {
@@ -191,7 +191,7 @@ static void vol_s16_to_s16(struct processing_module *mod, struct input_stream_bu
 
 	memset(cd->peak_regs.peak_meter, 0, sizeof(uint32_t) * cd->channels);
 	x = audio_stream_wrap(source, (char *)audio_stream_get_rptr(source) + bsource->consumed);
-	y = audio_stream_wrap(sink, (char *)sink->w_ptr + bsink->size);
+	y = audio_stream_wrap(sink, (char *)audio_stream_get_wptr(sink) + bsink->size);
 
 	bsource->consumed += VOL_S16_SAMPLES_TO_BYTES(remaining_samples);
 	bsink->size += VOL_S16_SAMPLES_TO_BYTES(remaining_samples);

--- a/src/audio/module_adapter/module/volume/volume_generic_with_peakvol.c
+++ b/src/audio/module_adapter/module/volume/volume_generic_with_peakvol.c
@@ -68,7 +68,7 @@ static void vol_s24_to_s24(struct processing_module *mod, struct input_stream_bu
 	int32_t tmp;
 
 	memset(cd->peak_regs.peak_meter, 0, sizeof(uint32_t) * cd->channels);
-	x = audio_stream_wrap(source, (char *)source->r_ptr + bsource->consumed);
+	x = audio_stream_wrap(source, (char *)audio_stream_get_rptr(source) + bsource->consumed);
 	y = audio_stream_wrap(sink, (char *)sink->w_ptr + bsink->size);
 
 	bsource->consumed += VOL_S32_SAMPLES_TO_BYTES(remaining_samples);
@@ -127,7 +127,7 @@ static void vol_s32_to_s32(struct processing_module *mod, struct input_stream_bu
 	int32_t tmp;
 
 	memset(cd->peak_regs.peak_meter, 0, sizeof(uint32_t) * cd->channels);
-	x = audio_stream_wrap(source, (char *)source->r_ptr + bsource->consumed);
+	x = audio_stream_wrap(source, (char *)audio_stream_get_rptr(source) + bsource->consumed);
 	y = audio_stream_wrap(sink, (char *)sink->w_ptr + bsink->size);
 	bsource->consumed += VOL_S32_SAMPLES_TO_BYTES(remaining_samples);
 	bsink->size += VOL_S32_SAMPLES_TO_BYTES(remaining_samples);
@@ -190,7 +190,7 @@ static void vol_s16_to_s16(struct processing_module *mod, struct input_stream_bu
 	int32_t tmp;
 
 	memset(cd->peak_regs.peak_meter, 0, sizeof(uint32_t) * cd->channels);
-	x = audio_stream_wrap(source, (char *)source->r_ptr + bsource->consumed);
+	x = audio_stream_wrap(source, (char *)audio_stream_get_rptr(source) + bsource->consumed);
 	y = audio_stream_wrap(sink, (char *)sink->w_ptr + bsink->size);
 
 	bsource->consumed += VOL_S16_SAMPLES_TO_BYTES(remaining_samples);

--- a/src/audio/module_adapter/module/volume/volume_generic_with_peakvol.c
+++ b/src/audio/module_adapter/module/volume/volume_generic_with_peakvol.c
@@ -63,7 +63,7 @@ static void vol_s24_to_s24(struct processing_module *mod, struct input_stream_bu
 	int32_t *x, *x0;
 	int32_t *y, *y0;
 	int nmax, n, i, j;
-	const int nch = source->channels;
+	const int nch = audio_stream_get_channels(source);
 	int remaining_samples = frames * nch;
 	int32_t tmp;
 
@@ -122,7 +122,7 @@ static void vol_s32_to_s32(struct processing_module *mod, struct input_stream_bu
 	int32_t *x, *x0;
 	int32_t *y, *y0;
 	int nmax, n, i, j;
-	const int nch = source->channels;
+	const int nch = audio_stream_get_channels(source);
 	int remaining_samples = frames * nch;
 	int32_t tmp;
 
@@ -185,7 +185,7 @@ static void vol_s16_to_s16(struct processing_module *mod, struct input_stream_bu
 	int16_t *x, *x0;
 	int16_t *y, *y0;
 	int nmax, n, i, j;
-	const int nch = source->channels;
+	const int nch = audio_stream_get_channels(source);
 	int remaining_samples = frames * nch;
 	int32_t tmp;
 

--- a/src/audio/module_adapter/module/volume/volume_hifi3.c
+++ b/src/audio/module_adapter/module/volume/volume_hifi3.c
@@ -72,7 +72,8 @@ static void vol_s24_to_s24_s32(struct processing_module *mod, struct input_strea
 	ae_valign outu = AE_ZALIGN64();
 	ae_f32x2 *in = (ae_f32x2 *)audio_stream_wrap(source, (char *)audio_stream_get_rptr(source)
 						     + bsource->consumed);
-	ae_f32x2 *out = (ae_f32x2 *)audio_stream_wrap(sink, (char *)sink->w_ptr + bsink->size);
+	ae_f32x2 *out = (ae_f32x2 *)audio_stream_wrap(sink, (char *)audio_stream_get_wptr(sink)
+						      + bsink->size);
 	const int channels_count = sink->channels;
 	const int inc = sizeof(ae_f32x2);
 	int samples = channels_count * frames;
@@ -164,7 +165,8 @@ static void vol_s32_to_s24_s32(struct processing_module *mod, struct input_strea
 	int samples = channels_count * frames;
 	ae_f32x2 *in = (ae_f32x2 *)audio_stream_wrap(source, (char *)audio_stream_get_rptr(source)
 						     + bsource->consumed);
-	ae_f32x2 *out = (ae_f32x2 *)audio_stream_wrap(sink, (char *)sink->w_ptr + bsink->size);
+	ae_f32x2 *out = (ae_f32x2 *)audio_stream_wrap(sink, (char *)audio_stream_get_wptr(sink)
+						      + bsink->size);
 
 	/** to ensure the address is 8-byte aligned and avoid risk of
 	 * error loading of volume gain while the cd->vol would be set
@@ -254,7 +256,8 @@ static void vol_s16_to_s16(struct processing_module *mod, struct input_stream_bu
 	ae_valign outu = AE_ZALIGN64();
 	ae_f16x4 *in = (ae_f16x4 *)audio_stream_wrap(source, (char *)audio_stream_get_rptr(source)
 						     + bsource->consumed);
-	ae_f16x4 *out = (ae_f16x4 *)audio_stream_wrap(sink, (char *)sink->w_ptr + bsink->size);
+	ae_f16x4 *out = (ae_f16x4 *)audio_stream_wrap(sink, (char *)audio_stream_get_wptr(sink)
+						      + bsink->size);
 	const int channels_count = sink->channels;
 	const int inc = sizeof(ae_f32x2);
 	int samples = channels_count * frames;

--- a/src/audio/module_adapter/module/volume/volume_hifi3.c
+++ b/src/audio/module_adapter/module/volume/volume_hifi3.c
@@ -70,7 +70,7 @@ static void vol_s24_to_s24_s32(struct processing_module *mod, struct input_strea
 	ae_f32x2 *vol;
 	ae_valign inu = AE_ZALIGN64();
 	ae_valign outu = AE_ZALIGN64();
-	ae_f32x2 *in = (ae_f32x2 *)audio_stream_wrap(source, (char *)source->r_ptr
+	ae_f32x2 *in = (ae_f32x2 *)audio_stream_wrap(source, (char *)audio_stream_get_rptr(source)
 						     + bsource->consumed);
 	ae_f32x2 *out = (ae_f32x2 *)audio_stream_wrap(sink, (char *)sink->w_ptr + bsink->size);
 	const int channels_count = sink->channels;
@@ -162,7 +162,7 @@ static void vol_s32_to_s24_s32(struct processing_module *mod, struct input_strea
 	const int channels_count = sink->channels;
 	const int inc = sizeof(ae_f32x2);
 	int samples = channels_count * frames;
-	ae_f32x2 *in = (ae_f32x2 *)audio_stream_wrap(source, (char *)source->r_ptr
+	ae_f32x2 *in = (ae_f32x2 *)audio_stream_wrap(source, (char *)audio_stream_get_rptr(source)
 						     + bsource->consumed);
 	ae_f32x2 *out = (ae_f32x2 *)audio_stream_wrap(sink, (char *)sink->w_ptr + bsink->size);
 
@@ -252,7 +252,7 @@ static void vol_s16_to_s16(struct processing_module *mod, struct input_stream_bu
 	ae_f32x2 *vol;
 	ae_valign inu = AE_ZALIGN64();
 	ae_valign outu = AE_ZALIGN64();
-	ae_f16x4 *in = (ae_f16x4 *)audio_stream_wrap(source, (char *)source->r_ptr
+	ae_f16x4 *in = (ae_f16x4 *)audio_stream_wrap(source, (char *)audio_stream_get_rptr(source)
 						     + bsource->consumed);
 	ae_f16x4 *out = (ae_f16x4 *)audio_stream_wrap(sink, (char *)sink->w_ptr + bsink->size);
 	const int channels_count = sink->channels;

--- a/src/audio/module_adapter/module/volume/volume_hifi3.c
+++ b/src/audio/module_adapter/module/volume/volume_hifi3.c
@@ -74,7 +74,7 @@ static void vol_s24_to_s24_s32(struct processing_module *mod, struct input_strea
 						     + bsource->consumed);
 	ae_f32x2 *out = (ae_f32x2 *)audio_stream_wrap(sink, (char *)audio_stream_get_wptr(sink)
 						      + bsink->size);
-	const int channels_count = sink->channels;
+	const int channels_count = audio_stream_get_channels(sink);
 	const int inc = sizeof(ae_f32x2);
 	int samples = channels_count * frames;
 
@@ -160,7 +160,7 @@ static void vol_s32_to_s24_s32(struct processing_module *mod, struct input_strea
 	ae_f32x2 *vol;
 	ae_valign inu = AE_ZALIGN64();
 	ae_valign outu = AE_ZALIGN64();
-	const int channels_count = sink->channels;
+	const int channels_count = audio_stream_get_channels(sink);
 	const int inc = sizeof(ae_f32x2);
 	int samples = channels_count * frames;
 	ae_f32x2 *in = (ae_f32x2 *)audio_stream_wrap(source, (char *)audio_stream_get_rptr(source)
@@ -258,7 +258,7 @@ static void vol_s16_to_s16(struct processing_module *mod, struct input_stream_bu
 						     + bsource->consumed);
 	ae_f16x4 *out = (ae_f16x4 *)audio_stream_wrap(sink, (char *)audio_stream_get_wptr(sink)
 						      + bsink->size);
-	const int channels_count = sink->channels;
+	const int channels_count = audio_stream_get_channels(sink);
 	const int inc = sizeof(ae_f32x2);
 	int samples = channels_count * frames;
 

--- a/src/audio/module_adapter/module/volume/volume_hifi3_with_peakvol.c
+++ b/src/audio/module_adapter/module/volume/volume_hifi3_with_peakvol.c
@@ -63,7 +63,7 @@ static void vol_s24_to_s24_s32(struct processing_module *mod, struct input_strea
 	ae_f32x2 *vol;
 	ae_valign inu = AE_ZALIGN64();
 	ae_valign outu = AE_ZALIGN64();
-	ae_f32x2 *in = (ae_f32x2 *)audio_stream_wrap(source, (char *)source->r_ptr
+	ae_f32x2 *in = (ae_f32x2 *)audio_stream_wrap(source, (char *)audio_stream_get_rptr(source)
 						     + bsource->consumed);
 	ae_f32x2 *out = (ae_f32x2 *)audio_stream_wrap(sink, (char *)sink->w_ptr + bsink->size);
 	const int channels_count = sink->channels;
@@ -168,7 +168,7 @@ static void vol_s32_to_s24_s32(struct processing_module *mod, struct input_strea
 	const int channels_count = sink->channels;
 	const int inc = sizeof(ae_f32x2);
 	int samples = channels_count * frames;
-	ae_f32x2 *in = (ae_f32x2 *)audio_stream_wrap(source, (char *)source->r_ptr
+	ae_f32x2 *in = (ae_f32x2 *)audio_stream_wrap(source, (char *)audio_stream_get_rptr(source)
 						     + bsource->consumed);
 	ae_f32x2 *out = (ae_f32x2 *)audio_stream_wrap(sink, (char *)sink->w_ptr + bsink->size);
 	ae_f32x2 temp;
@@ -274,7 +274,7 @@ static void vol_s16_to_s16(struct processing_module *mod, struct input_stream_bu
 	ae_f32x2 *vol;
 	ae_valign inu = AE_ZALIGN64();
 	ae_valign outu = AE_ZALIGN64();
-	ae_f16x4 *in = (ae_f16x4 *)audio_stream_wrap(source, (char *)source->r_ptr
+	ae_f16x4 *in = (ae_f16x4 *)audio_stream_wrap(source, (char *)audio_stream_get_rptr(source)
 						     + bsource->consumed);
 	ae_f16x4 *out = (ae_f16x4 *)audio_stream_wrap(sink, (char *)sink->w_ptr + bsink->size);
 	const int channels_count = sink->channels;
@@ -389,7 +389,7 @@ static void vol_s24_to_s24_s32(struct processing_module *mod, struct input_strea
 	ae_f32x2 out_sample = AE_ZERO32();
 	ae_f32x2 volume = AE_ZERO32();
 	int channel, n, i, m;
-	ae_f32 *in0 = (ae_f32 *)audio_stream_wrap(source, (char *)source->r_ptr
+	ae_f32 *in0 = (ae_f32 *)audio_stream_wrap(source, (char *)audio_stream_get_rptr(source)
 						  + bsource->consumed);
 	ae_f32 *out0 = (ae_f32 *)audio_stream_wrap(sink, (char *)sink->w_ptr + bsink->size);
 	ae_f32 *in, *out;
@@ -472,7 +472,7 @@ static void vol_s32_to_s24_s32(struct processing_module *mod, struct input_strea
 	const int channels_count = sink->channels;
 	const int inc = sizeof(ae_f32) * channels_count;
 	int samples = channels_count * frames;
-	ae_f32 *in0 = (ae_f32 *)audio_stream_wrap(source, (char *)source->r_ptr
+	ae_f32 *in0 = (ae_f32 *)audio_stream_wrap(source, (char *)audio_stream_get_rptr(source)
 						  + bsource->consumed);
 	ae_f32 *out0 = (ae_f32 *)audio_stream_wrap(sink, (char *)sink->w_ptr + bsink->size);
 	ae_f32 *in, *out;
@@ -550,7 +550,7 @@ static void vol_s16_to_s16(struct processing_module *mod, struct input_stream_bu
 	int i, n, channel, m;
 	ae_f16 *in;
 	ae_f16 *out;
-	ae_f16 *in0 = (ae_f16 *)audio_stream_wrap(source, (char *)source->r_ptr
+	ae_f16 *in0 = (ae_f16 *)audio_stream_wrap(source, (char *)audio_stream_get_rptr(source)
 						  + bsource->consumed);
 	ae_f16 *out0 = (ae_f16 *)audio_stream_wrap(sink, (char *)sink->w_ptr + bsink->size);
 	const int channels_count = sink->channels;

--- a/src/audio/module_adapter/module/volume/volume_hifi3_with_peakvol.c
+++ b/src/audio/module_adapter/module/volume/volume_hifi3_with_peakvol.c
@@ -65,7 +65,8 @@ static void vol_s24_to_s24_s32(struct processing_module *mod, struct input_strea
 	ae_valign outu = AE_ZALIGN64();
 	ae_f32x2 *in = (ae_f32x2 *)audio_stream_wrap(source, (char *)audio_stream_get_rptr(source)
 						     + bsource->consumed);
-	ae_f32x2 *out = (ae_f32x2 *)audio_stream_wrap(sink, (char *)sink->w_ptr + bsink->size);
+	ae_f32x2 *out = (ae_f32x2 *)audio_stream_wrap(sink, (char *)audio_stream_get_wptr(sink)
+						      + bsink->size);
 	const int channels_count = sink->channels;
 	const int inc = sizeof(ae_f32x2);
 	int samples = channels_count * frames;
@@ -170,7 +171,8 @@ static void vol_s32_to_s24_s32(struct processing_module *mod, struct input_strea
 	int samples = channels_count * frames;
 	ae_f32x2 *in = (ae_f32x2 *)audio_stream_wrap(source, (char *)audio_stream_get_rptr(source)
 						     + bsource->consumed);
-	ae_f32x2 *out = (ae_f32x2 *)audio_stream_wrap(sink, (char *)sink->w_ptr + bsink->size);
+	ae_f32x2 *out = (ae_f32x2 *)audio_stream_wrap(sink, (char *)audio_stream_get_wptr(sink)
+						      + bsink->size);
 	ae_f32x2 temp;
 	ae_f32x2 *peakvol = (ae_f32x2 *)cd->peak_vol;
 
@@ -276,7 +278,8 @@ static void vol_s16_to_s16(struct processing_module *mod, struct input_stream_bu
 	ae_valign outu = AE_ZALIGN64();
 	ae_f16x4 *in = (ae_f16x4 *)audio_stream_wrap(source, (char *)audio_stream_get_rptr(source)
 						     + bsource->consumed);
-	ae_f16x4 *out = (ae_f16x4 *)audio_stream_wrap(sink, (char *)sink->w_ptr + bsink->size);
+	ae_f16x4 *out = (ae_f16x4 *)audio_stream_wrap(sink, (char *)audio_stream_get_wptr(sink)
+						      + bsink->size);
 	const int channels_count = sink->channels;
 	const int inc = sizeof(ae_f32x2);
 	int samples = channels_count * frames;
@@ -391,7 +394,8 @@ static void vol_s24_to_s24_s32(struct processing_module *mod, struct input_strea
 	int channel, n, i, m;
 	ae_f32 *in0 = (ae_f32 *)audio_stream_wrap(source, (char *)audio_stream_get_rptr(source)
 						  + bsource->consumed);
-	ae_f32 *out0 = (ae_f32 *)audio_stream_wrap(sink, (char *)sink->w_ptr + bsink->size);
+	ae_f32 *out0 = (ae_f32 *)audio_stream_wrap(sink, (char *)audio_stream_get_wptr(sink)
+						   + bsink->size);
 	ae_f32 *in, *out;
 	const int channels_count = sink->channels;
 	const int inc = sizeof(ae_f32) * channels_count;
@@ -474,7 +478,8 @@ static void vol_s32_to_s24_s32(struct processing_module *mod, struct input_strea
 	int samples = channels_count * frames;
 	ae_f32 *in0 = (ae_f32 *)audio_stream_wrap(source, (char *)audio_stream_get_rptr(source)
 						  + bsource->consumed);
-	ae_f32 *out0 = (ae_f32 *)audio_stream_wrap(sink, (char *)sink->w_ptr + bsink->size);
+	ae_f32 *out0 = (ae_f32 *)audio_stream_wrap(sink, (char *)audio_stream_get_wptr(sink)
+						   + bsink->size);
 	ae_f32 *in, *out;
 	ae_f32x2 peak_vol;
 	uint32_t *peak_meter = cd->peak_regs.peak_meter;
@@ -552,7 +557,8 @@ static void vol_s16_to_s16(struct processing_module *mod, struct input_stream_bu
 	ae_f16 *out;
 	ae_f16 *in0 = (ae_f16 *)audio_stream_wrap(source, (char *)audio_stream_get_rptr(source)
 						  + bsource->consumed);
-	ae_f16 *out0 = (ae_f16 *)audio_stream_wrap(sink, (char *)sink->w_ptr + bsink->size);
+	ae_f16 *out0 = (ae_f16 *)audio_stream_wrap(sink, (char *)audio_stream_get_wptr(sink)
+						   + bsink->size);
 	const int channels_count = sink->channels;
 	const int inc = sizeof(ae_f16) * channels_count;
 	int samples = channels_count * frames;

--- a/src/audio/module_adapter/module/volume/volume_hifi3_with_peakvol.c
+++ b/src/audio/module_adapter/module/volume/volume_hifi3_with_peakvol.c
@@ -67,7 +67,7 @@ static void vol_s24_to_s24_s32(struct processing_module *mod, struct input_strea
 						     + bsource->consumed);
 	ae_f32x2 *out = (ae_f32x2 *)audio_stream_wrap(sink, (char *)audio_stream_get_wptr(sink)
 						      + bsink->size);
-	const int channels_count = sink->channels;
+	const int channels_count = audio_stream_get_channels(sink);
 	const int inc = sizeof(ae_f32x2);
 	int samples = channels_count * frames;
 	ae_f32x2 temp;
@@ -166,7 +166,7 @@ static void vol_s32_to_s24_s32(struct processing_module *mod, struct input_strea
 	ae_f32x2 *vol;
 	ae_valign inu = AE_ZALIGN64();
 	ae_valign outu = AE_ZALIGN64();
-	const int channels_count = sink->channels;
+	const int channels_count = audio_stream_get_channels(sink);
 	const int inc = sizeof(ae_f32x2);
 	int samples = channels_count * frames;
 	ae_f32x2 *in = (ae_f32x2 *)audio_stream_wrap(source, (char *)audio_stream_get_rptr(source)
@@ -280,7 +280,7 @@ static void vol_s16_to_s16(struct processing_module *mod, struct input_stream_bu
 						     + bsource->consumed);
 	ae_f16x4 *out = (ae_f16x4 *)audio_stream_wrap(sink, (char *)audio_stream_get_wptr(sink)
 						      + bsink->size);
-	const int channels_count = sink->channels;
+	const int channels_count = audio_stream_get_channels(sink);
 	const int inc = sizeof(ae_f32x2);
 	int samples = channels_count * frames;
 	ae_f32x2 temp;
@@ -397,7 +397,7 @@ static void vol_s24_to_s24_s32(struct processing_module *mod, struct input_strea
 	ae_f32 *out0 = (ae_f32 *)audio_stream_wrap(sink, (char *)audio_stream_get_wptr(sink)
 						   + bsink->size);
 	ae_f32 *in, *out;
-	const int channels_count = sink->channels;
+	const int channels_count = audio_stream_get_channels(sink);
 	const int inc = sizeof(ae_f32) * channels_count;
 	int samples = channels_count * frames;
 	ae_f32x2 peak_vol;
@@ -473,7 +473,7 @@ static void vol_s32_to_s24_s32(struct processing_module *mod, struct input_strea
 	ae_f32x2 volume = AE_ZERO32();
 	int i, n, channel, m;
 	ae_f64 mult0;
-	const int channels_count = sink->channels;
+	const int channels_count = audio_stream_get_channels(sink);
 	const int inc = sizeof(ae_f32) * channels_count;
 	int samples = channels_count * frames;
 	ae_f32 *in0 = (ae_f32 *)audio_stream_wrap(source, (char *)audio_stream_get_rptr(source)
@@ -559,7 +559,7 @@ static void vol_s16_to_s16(struct processing_module *mod, struct input_stream_bu
 						  + bsource->consumed);
 	ae_f16 *out0 = (ae_f16 *)audio_stream_wrap(sink, (char *)audio_stream_get_wptr(sink)
 						   + bsink->size);
-	const int channels_count = sink->channels;
+	const int channels_count = audio_stream_get_channels(sink);
 	const int inc = sizeof(ae_f16) * channels_count;
 	int samples = channels_count * frames;
 	ae_f32x2 peak_vol;

--- a/src/audio/module_adapter/module/waves.c
+++ b/src/audio/module_adapter/module/waves.c
@@ -251,9 +251,9 @@ static int waves_effect_check(struct comp_dev *dev)
 	}
 
 	/* different frame format not supported */
-	if (src_fmt->frame_fmt != snk_fmt->frame_fmt) {
+	if (src_fmt->frame_fmt != audio_stream_get_frm_fmt(snk_fmt)) {
 		comp_err(dev, "waves_effect_check() source %d sink %d sample format mismatch",
-			 src_fmt->frame_fmt, snk_fmt->frame_fmt);
+			 audio_stream_get_frm_fmt(src_fmt), audio_stream_get_frm_fmt(snk_fmt));
 		ret = -EINVAL;
 		goto out;
 	}
@@ -265,7 +265,7 @@ static int waves_effect_check(struct comp_dev *dev)
 		goto out;
 	}
 
-	if (!format_is_supported(src_fmt->frame_fmt)) {
+	if (!format_is_supported(audio_stream_get_frm_fmt(src_fmt))) {
 		comp_err(dev, "waves_effect_check() float samples not supported");
 		ret = -EINVAL;
 		goto out;
@@ -318,10 +318,10 @@ static int waves_effect_init(struct processing_module *mod)
 
 	comp_dbg(dev, "waves_effect_init() start");
 
-	sample_format = format_convert_sof_to_me(src_fmt->frame_fmt);
+	sample_format = format_convert_sof_to_me(audio_stream_get_frm_fmt(src_fmt));
 	if (sample_format < 0) {
 		comp_err(dev, "waves_effect_init() sof sample format %d not supported",
-			 src_fmt->frame_fmt);
+			 audio_stream_get_frm_fmt(src_fmt));
 		ret = -EINVAL;
 		goto out;
 	}

--- a/src/audio/module_adapter/module/waves.c
+++ b/src/audio/module_adapter/module/waves.c
@@ -243,9 +243,9 @@ static int waves_effect_check(struct comp_dev *dev)
 	}
 
 	/* upmix/downmix not supported */
-	if (src_fmt->channels != snk_fmt->channels) {
+	if (src_fmt->channels != audio_stream_get_channels(snk_fmt)) {
 		comp_err(dev, "waves_effect_check() source %d sink %d channels mismatch",
-			 src_fmt->channels, snk_fmt->channels);
+			 audio_stream_get_channels(src_fmt), audio_stream_get_channels(snk_fmt));
 		ret = -EINVAL;
 		goto out;
 	}
@@ -285,7 +285,8 @@ static int waves_effect_check(struct comp_dev *dev)
 	}
 
 	if (src_fmt->channels != 2) {
-		comp_err(dev, "waves_effect_check() channels %d not supported", src_fmt->channels);
+		comp_err(dev, "waves_effect_check() channels %d not supported",
+			 audio_stream_get_channels(src_fmt));
 		ret = -EINVAL;
 		goto out;
 	}
@@ -348,7 +349,7 @@ static int waves_effect_init(struct processing_module *mod)
 	waves_codec->o_buffer = 0;
 
 	waves_codec->i_format.sampleRate = audio_stream_get_rate(src_fmt);
-	waves_codec->i_format.numChannels = src_fmt->channels;
+	waves_codec->i_format.numChannels = audio_stream_get_channels(src_fmt);
 	waves_codec->i_format.samplesFormat = sample_format;
 	waves_codec->i_format.samplesLayout = buffer_format;
 	waves_codec->o_format = waves_codec->i_format;
@@ -359,8 +360,8 @@ static int waves_effect_init(struct processing_module *mod)
 	 */
 	waves_codec->buffer_samples = audio_stream_get_rate(src_fmt) * dev->pipeline->period /
 		1000000;
-	waves_codec->buffer_bytes = waves_codec->buffer_samples * src_fmt->channels *
-		waves_codec->sample_size_in_bytes;
+	waves_codec->buffer_bytes = waves_codec->buffer_samples *
+		audio_stream_get_channels(src_fmt) * waves_codec->sample_size_in_bytes;
 
 	// trace allows printing only up-to 4 words at a time
 	// logging all the information in two calls

--- a/src/audio/module_adapter/module/waves.c
+++ b/src/audio/module_adapter/module/waves.c
@@ -235,9 +235,9 @@ static int waves_effect_check(struct comp_dev *dev)
 	/* todo use fallback to comp_verify_params when ready */
 
 	/* resampling not supported */
-	if (src_fmt->rate != snk_fmt->rate) {
+	if (src_fmt->rate != audio_stream_get_rate(snk_fmt)) {
 		comp_err(dev, "waves_effect_check() source %d sink %d rate mismatch",
-			 src_fmt->rate, snk_fmt->rate);
+			 audio_stream_get_rate(src_fmt), audio_stream_get_rate(snk_fmt));
 		ret = -EINVAL;
 		goto out;
 	}
@@ -277,8 +277,9 @@ static int waves_effect_check(struct comp_dev *dev)
 		goto out;
 	}
 
-	if (!rate_is_supported(src_fmt->rate)) {
-		comp_err(dev, "waves_effect_check() rate %d not supported", src_fmt->rate);
+	if (!rate_is_supported(audio_stream_get_rate(src_fmt))) {
+		comp_err(dev, "waves_effect_check() rate %d not supported",
+			 audio_stream_get_rate(src_fmt));
 		ret = -EINVAL;
 		goto out;
 	}
@@ -346,7 +347,7 @@ static int waves_effect_init(struct processing_module *mod)
 	waves_codec->i_buffer = 0;
 	waves_codec->o_buffer = 0;
 
-	waves_codec->i_format.sampleRate = src_fmt->rate;
+	waves_codec->i_format.sampleRate = audio_stream_get_rate(src_fmt);
 	waves_codec->i_format.numChannels = src_fmt->channels;
 	waves_codec->i_format.samplesFormat = sample_format;
 	waves_codec->i_format.samplesLayout = buffer_format;
@@ -356,7 +357,8 @@ static int waves_effect_init(struct processing_module *mod)
 	/* Prepare a buffer for 1 period worth of data
 	 * dev->pipeline->period stands for the scheduling period in us
 	 */
-	waves_codec->buffer_samples = src_fmt->rate * dev->pipeline->period / 1000000;
+	waves_codec->buffer_samples = audio_stream_get_rate(src_fmt) * dev->pipeline->period /
+		1000000;
 	waves_codec->buffer_bytes = waves_codec->buffer_samples * src_fmt->channels *
 		waves_codec->sample_size_in_bytes;
 

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -458,18 +458,20 @@ ca_copy_from_source_to_module(const struct audio_stream __sparse_cache *source,
 			      void __sparse_cache *buff, uint32_t buff_size, size_t bytes)
 {
 	/* head_size - available data until end of source buffer */
-	const int without_wrap = audio_stream_bytes_without_wrap(source, source->r_ptr);
+	const int without_wrap = audio_stream_bytes_without_wrap(source,
+								 audio_stream_get_rptr(source));
 	uint32_t head_size = MIN(bytes, without_wrap);
 	/* tail_size - residual data to be copied starting from the beginning of the buffer */
 	uint32_t tail_size = bytes - head_size;
 
 	/* copy head_size to module buffer */
-	memcpy((__sparse_force void *)buff, source->r_ptr, MIN(buff_size, head_size));
+	memcpy((__sparse_force void *)buff, audio_stream_get_rptr(source),
+	       MIN(buff_size, head_size));
 
 	/* copy residual samples after wrap */
 	if (tail_size)
 		memcpy((__sparse_force char *)buff + head_size,
-		       audio_stream_wrap(source, (char *)source->r_ptr + head_size),
+		       audio_stream_wrap(source, (char *)audio_stream_get_rptr(source) + head_size),
 					 MIN(buff_size, tail_size));
 }
 

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -494,12 +494,14 @@ ca_copy_from_module_to_sink(const struct audio_stream __sparse_cache *sink,
 	uint32_t tail_size = bytes - head_size;
 
 	/* copy "head_size" samples to sink buffer */
-	memcpy(audio_stream_get_wptr(sink), (__sparse_force void *)buff, MIN(sink->size, head_size));
+	memcpy(audio_stream_get_wptr(sink), (__sparse_force void *)buff,
+	       MIN(audio_stream_get_size(sink), head_size));
 
 	/* copy rest of the samples after buffer wrap */
 	if (tail_size)
 		memcpy(audio_stream_wrap(sink, (char *)audio_stream_get_wptr(sink) + head_size),
-		       (__sparse_force char *)buff + head_size, MIN(sink->size, tail_size));
+		       (__sparse_force char *)buff + head_size,
+		       MIN(audio_stream_get_size(sink), tail_size));
 }
 
 /**

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -486,7 +486,7 @@ ca_copy_from_module_to_sink(const struct audio_stream __sparse_cache *sink,
 			    void __sparse_cache *buff, size_t bytes)
 {
 	/* head_size - free space until end of sink buffer */
-	const int without_wrap = audio_stream_bytes_without_wrap(sink, sink->w_ptr);
+	const int without_wrap = audio_stream_bytes_without_wrap(sink, audio_stream_get_wptr(sink));
 	uint32_t head_size = MIN(bytes, without_wrap);
 	/* tail_size - rest of the bytes that needs to be written
 	 * starting from the beginning of the buffer
@@ -494,11 +494,11 @@ ca_copy_from_module_to_sink(const struct audio_stream __sparse_cache *sink,
 	uint32_t tail_size = bytes - head_size;
 
 	/* copy "head_size" samples to sink buffer */
-	memcpy(sink->w_ptr, (__sparse_force void *)buff, MIN(sink->size, head_size));
+	memcpy(audio_stream_get_wptr(sink), (__sparse_force void *)buff, MIN(sink->size, head_size));
 
 	/* copy rest of the samples after buffer wrap */
 	if (tail_size)
-		memcpy(audio_stream_wrap(sink, (char *)sink->w_ptr + head_size),
+		memcpy(audio_stream_wrap(sink, (char *)audio_stream_get_wptr(sink) + head_size),
 		       (__sparse_force char *)buff + head_size, MIN(sink->size, tail_size));
 }
 
@@ -515,7 +515,7 @@ static void generate_zeroes(struct comp_buffer __sparse_cache *sink, uint32_t by
 	void *ptr;
 
 	while (copy_bytes) {
-		ptr = audio_stream_wrap(&sink->stream, sink->stream.w_ptr);
+		ptr = audio_stream_wrap(&sink->stream, audio_stream_get_wptr(&sink->stream));
 		tmp = audio_stream_bytes_without_wrap(&sink->stream, ptr);
 		tmp = MIN(tmp, copy_bytes);
 		ptr = (char *)ptr + tmp;

--- a/src/audio/multiband_drc/multiband_drc.c
+++ b/src/audio/multiband_drc/multiband_drc.c
@@ -534,7 +534,7 @@ static int multiband_drc_prepare(struct comp_dev *dev)
 	source_c = buffer_acquire(sourceb);
 
 	/* get source data format */
-	cd->source_format = source_c->stream.frame_fmt;
+	cd->source_format = audio_stream_get_frm_fmt(&source_c->stream);
 
 	/* Initialize DRC */
 	comp_dbg(dev, "multiband_drc_prepare(), source_format=%d, sink_format=%d",
@@ -574,10 +574,10 @@ static int multiband_drc_prepare(struct comp_dev *dev)
 	sink_c = buffer_acquire(sinkb);
 
 	/* validate sink data format and period bytes */
-	if (cd->source_format != sink_c->stream.frame_fmt) {
+	if (cd->source_format != audio_stream_get_frm_fmt(&sink_c->stream)) {
 		comp_err(dev,
 			 "multiband_drc_prepare(): Source fmt %d and sink fmt %d are different.",
-			 cd->source_format, sink_c->stream.frame_fmt);
+			 cd->source_format, audio_stream_get_frm_fmt(&sink_c->stream));
 		ret = -EINVAL;
 		goto out_sink;
 	}

--- a/src/audio/multiband_drc/multiband_drc.c
+++ b/src/audio/multiband_drc/multiband_drc.c
@@ -585,9 +585,9 @@ static int multiband_drc_prepare(struct comp_dev *dev)
 	sink_period_bytes = audio_stream_period_bytes(&sink_c->stream,
 						      dev->frames);
 
-	if (sink_c->stream.size < sink_period_bytes) {
+	if (audio_stream_get_size(&sink_c->stream) < sink_period_bytes) {
 		comp_err(dev, "multiband_drc_prepare(), sink buffer size %d is insufficient",
-			 sink_c->stream.size);
+			 audio_stream_get_size(&sink_c->stream));
 		ret = -ENOMEM;
 	}
 

--- a/src/audio/multiband_drc/multiband_drc.c
+++ b/src/audio/multiband_drc/multiband_drc.c
@@ -488,7 +488,7 @@ static int multiband_drc_copy(struct comp_dev *dev)
 	if (comp_is_new_data_blob_available(cd->model_handler)) {
 		cd->config = comp_get_data_blob(cd->model_handler, NULL, NULL);
 		ret = multiband_drc_setup(cd, (int16_t)source_c->stream.channels,
-					  source_c->stream.rate);
+					  audio_stream_get_rate(&source_c->stream));
 		if (ret < 0) {
 			comp_err(dev, "multiband_drc_copy(), failed DRC setup");
 			goto out;
@@ -541,7 +541,8 @@ static int multiband_drc_prepare(struct comp_dev *dev)
 		 cd->source_format, cd->source_format);
 	cd->config = comp_get_data_blob(cd->model_handler, NULL, NULL);
 	if (cd->config && cd->process_enabled) {
-		ret = multiband_drc_setup(cd, source_c->stream.channels, source_c->stream.rate);
+		ret = multiband_drc_setup(cd, source_c->stream.channels,
+					  audio_stream_get_rate(&source_c->stream));
 		if (ret < 0) {
 			comp_err(dev, "multiband_drc_prepare() error: multiband_drc_setup failed.");
 			goto out_source;

--- a/src/audio/multiband_drc/multiband_drc.c
+++ b/src/audio/multiband_drc/multiband_drc.c
@@ -487,7 +487,7 @@ static int multiband_drc_copy(struct comp_dev *dev)
 	/* Check for changed configuration */
 	if (comp_is_new_data_blob_available(cd->model_handler)) {
 		cd->config = comp_get_data_blob(cd->model_handler, NULL, NULL);
-		ret = multiband_drc_setup(cd, (int16_t)source_c->stream.channels,
+		ret = multiband_drc_setup(cd, (int16_t)audio_stream_get_channels(&source_c->stream),
 					  audio_stream_get_rate(&source_c->stream));
 		if (ret < 0) {
 			comp_err(dev, "multiband_drc_copy(), failed DRC setup");
@@ -541,7 +541,7 @@ static int multiband_drc_prepare(struct comp_dev *dev)
 		 cd->source_format, cd->source_format);
 	cd->config = comp_get_data_blob(cd->model_handler, NULL, NULL);
 	if (cd->config && cd->process_enabled) {
-		ret = multiband_drc_setup(cd, source_c->stream.channels,
+		ret = multiband_drc_setup(cd, audio_stream_get_channels(&source_c->stream),
 					  audio_stream_get_rate(&source_c->stream));
 		if (ret < 0) {
 			comp_err(dev, "multiband_drc_prepare() error: multiband_drc_setup failed.");

--- a/src/audio/multiband_drc/multiband_drc_generic.c
+++ b/src/audio/multiband_drc/multiband_drc_generic.c
@@ -215,7 +215,7 @@ static void multiband_drc_s16_default(const struct comp_dev *dev,
 	int32_t buf_drc_sink[PLATFORM_MAX_CHANNELS * SOF_MULTIBAND_DRC_MAX_BANDS];
 	int32_t *band_buf_drc_src;
 	int32_t *band_buf_drc_sink;
-	int16_t *x = source->r_ptr;
+	int16_t *x = audio_stream_get_rptr(source);
 	int16_t *y = sink->w_ptr;
 	int band;
 	int nbuf;
@@ -282,7 +282,7 @@ static void multiband_drc_s24_default(const struct comp_dev *dev,
 	int32_t buf_drc_sink[PLATFORM_MAX_CHANNELS * SOF_MULTIBAND_DRC_MAX_BANDS];
 	int32_t *band_buf_drc_src;
 	int32_t *band_buf_drc_sink;
-	int32_t *x = source->r_ptr;
+	int32_t *x = audio_stream_get_rptr(source);
 	int32_t *y = sink->w_ptr;
 	int band;
 	int nbuf;
@@ -349,7 +349,7 @@ static void multiband_drc_s32_default(const struct comp_dev *dev,
 	int32_t buf_drc_sink[PLATFORM_MAX_CHANNELS * SOF_MULTIBAND_DRC_MAX_BANDS];
 	int32_t *band_buf_drc_src;
 	int32_t *band_buf_drc_sink;
-	int32_t *x = source->r_ptr;
+	int32_t *x = audio_stream_get_rptr(source);
 	int32_t *y = sink->w_ptr;
 	int band;
 	int nbuf;

--- a/src/audio/multiband_drc/multiband_drc_generic.c
+++ b/src/audio/multiband_drc/multiband_drc_generic.c
@@ -216,7 +216,7 @@ static void multiband_drc_s16_default(const struct comp_dev *dev,
 	int32_t *band_buf_drc_src;
 	int32_t *band_buf_drc_sink;
 	int16_t *x = audio_stream_get_rptr(source);
-	int16_t *y = sink->w_ptr;
+	int16_t *y = audio_stream_get_wptr(sink);
 	int band;
 	int nbuf;
 	int npcm;
@@ -283,7 +283,7 @@ static void multiband_drc_s24_default(const struct comp_dev *dev,
 	int32_t *band_buf_drc_src;
 	int32_t *band_buf_drc_sink;
 	int32_t *x = audio_stream_get_rptr(source);
-	int32_t *y = sink->w_ptr;
+	int32_t *y = audio_stream_get_wptr(sink);
 	int band;
 	int nbuf;
 	int npcm;
@@ -350,7 +350,7 @@ static void multiband_drc_s32_default(const struct comp_dev *dev,
 	int32_t *band_buf_drc_src;
 	int32_t *band_buf_drc_sink;
 	int32_t *x = audio_stream_get_rptr(source);
-	int32_t *y = sink->w_ptr;
+	int32_t *y = audio_stream_get_wptr(sink);
 	int band;
 	int nbuf;
 	int npcm;

--- a/src/audio/multiband_drc/multiband_drc_generic.c
+++ b/src/audio/multiband_drc/multiband_drc_generic.c
@@ -15,7 +15,7 @@ static void multiband_drc_default_pass(const struct comp_dev *dev,
 				       struct audio_stream __sparse_cache *sink,
 				       uint32_t frames)
 {
-	audio_stream_copy(source, 0, sink, 0, source->channels * frames);
+	audio_stream_copy(source, 0, sink, 0, audio_stream_get_channels(source) * frames);
 }
 
 static void multiband_drc_process_emp_crossover(struct multiband_drc_state *state,
@@ -222,7 +222,7 @@ static void multiband_drc_s16_default(const struct comp_dev *dev,
 	int npcm;
 	int ch;
 	int i;
-	int nch = source->channels;
+	int nch = audio_stream_get_channels(source);
 	int nband = cd->config->num_bands;
 	int enable_emp_deemp = cd->config->enable_emp_deemp;
 	int samples = frames * nch;
@@ -289,7 +289,7 @@ static void multiband_drc_s24_default(const struct comp_dev *dev,
 	int npcm;
 	int ch;
 	int i;
-	int nch = source->channels;
+	int nch = audio_stream_get_channels(source);
 	int nband = cd->config->num_bands;
 	int enable_emp_deemp = cd->config->enable_emp_deemp;
 	int samples = frames * nch;
@@ -356,7 +356,7 @@ static void multiband_drc_s32_default(const struct comp_dev *dev,
 	int npcm;
 	int ch;
 	int i;
-	int nch = source->channels;
+	int nch = audio_stream_get_channels(source);
 	int nband = cd->config->num_bands;
 	int enable_emp_deemp = cd->config->enable_emp_deemp;
 	int samples = frames * nch;

--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -306,7 +306,7 @@ static void set_mux_params(struct processing_module *mod)
 			sink_c->stream.valid_sample_fmt = valid_fmt;
 
 			sink_c->buffer_fmt = out_fmt.interleaving_style;
-			params->frame_fmt = sink_c->stream.frame_fmt;
+			params->frame_fmt = audio_stream_get_frm_fmt(&sink_c->stream);
 
 			for (i = 0; i < SOF_IPC_MAX_CHANNELS; i++)
 				sink_c->chmap[i] = (out_fmt.ch_map >> i * 4) & 0xf;

--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -263,6 +263,7 @@ static void set_mux_params(struct processing_module *mod)
 	struct comp_dev *dev = mod->dev;
 	struct comp_buffer *sink, *source;
 	struct comp_buffer __sparse_cache *sink_c, *source_c;
+	enum sof_ipc_frame frame_fmt, valid_fmt;
 	struct list_item *source_list;
 	int i, j, valid_bit_depth;
 	const uint32_t byte_align = 1;
@@ -298,9 +299,11 @@ static void set_mux_params(struct processing_module *mod)
 			sink_c->stream.rate = out_fmt.sampling_frequency;
 			audio_stream_fmt_conversion(out_fmt.depth,
 						    out_fmt.valid_bit_depth,
-						    &sink_c->stream.frame_fmt,
-						    &sink_c->stream.valid_sample_fmt,
+						    &frame_fmt, &valid_fmt,
 						    out_fmt.s_type);
+
+			sink_c->stream.frame_fmt = frame_fmt;
+			sink_c->stream.valid_sample_fmt = valid_fmt;
 
 			sink_c->buffer_fmt = out_fmt.interleaving_style;
 			params->frame_fmt = sink_c->stream.frame_fmt;
@@ -331,8 +334,7 @@ static void set_mux_params(struct processing_module *mod)
 						cd->md.base_cfg.audio_fmt.sampling_frequency;
 				audio_stream_fmt_conversion(cd->md.base_cfg.audio_fmt.depth,
 							    valid_bit_depth,
-							    &source_c->stream.frame_fmt,
-							    &source_c->stream.valid_sample_fmt,
+							    &frame_fmt, &valid_fmt,
 							    cd->md.base_cfg.audio_fmt.s_type);
 
 				source_c->buffer_fmt = cd->md.base_cfg.audio_fmt.interleaving_style;
@@ -347,15 +349,19 @@ static void set_mux_params(struct processing_module *mod)
 				source_c->stream.rate = cd->md.reference_format.sampling_frequency;
 				audio_stream_fmt_conversion(cd->md.reference_format.depth,
 							    cd->md.reference_format.valid_bit_depth,
-							    &source_c->stream.frame_fmt,
-							    &source_c->stream.valid_sample_fmt,
+							    &frame_fmt, &valid_fmt,
 							    cd->md.reference_format.s_type);
+
 				source_c->buffer_fmt = cd->md.reference_format.interleaving_style;
 
 				for (i = 0; i < SOF_IPC_MAX_CHANNELS; i++)
 					source_c->chmap[i] =
 						(cd->md.reference_format.ch_map >> i * 4) & 0xf;
 			}
+
+			source_c->stream.frame_fmt = frame_fmt;
+			source_c->stream.valid_sample_fmt = valid_fmt;
+
 			source_c->hw_params_configured = true;
 			buffer_release(source_c);
 		}

--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -424,8 +424,8 @@ static void mux_prepare_active_look_up(struct comp_data *cd,
 		if (!source)
 			continue;
 
-		if (cd->lookup[0].copy_elem[elem].in_ch >= source->channels ||
-		    cd->lookup[0].copy_elem[elem].out_ch >= sink->channels)
+		if (cd->lookup[0].copy_elem[elem].in_ch >= audio_stream_get_channels(source) ||
+		    cd->lookup[0].copy_elem[elem].out_ch >= audio_stream_get_channels(sink))
 			continue;
 
 		cd->active_lookup.copy_elem[active_elem] = cd->lookup[0].copy_elem[elem];
@@ -445,8 +445,8 @@ static void demux_prepare_active_look_up(struct comp_data *cd,
 
 	/* init pointers */
 	for (elem = 0; elem < look_up->num_elems; elem++) {
-		if (look_up->copy_elem[elem].in_ch >= source->channels ||
-		    look_up->copy_elem[elem].out_ch >= sink->channels)
+		if (look_up->copy_elem[elem].in_ch >= audio_stream_get_channels(source) ||
+		    look_up->copy_elem[elem].out_ch >= audio_stream_get_channels(sink))
 			continue;
 
 		cd->active_lookup.copy_elem[active_elem] = look_up->copy_elem[elem];

--- a/src/audio/mux/mux_generic.c
+++ b/src/audio/mux/mux_generic.c
@@ -535,7 +535,7 @@ mux_func mux_get_processing_function(struct processing_module *mod)
 
 	for (i = 0; i < ARRAY_SIZE(mux_func_map); i++) {
 		struct comp_buffer __sparse_cache *sink_c = buffer_acquire(sinkb);
-		enum sof_ipc_frame fmt = sink_c->stream.frame_fmt;
+		enum sof_ipc_frame fmt = audio_stream_get_frm_fmt(&sink_c->stream);
 
 
 		if (fmt == mux_func_map[i].frame_format)
@@ -559,7 +559,7 @@ demux_func demux_get_processing_function(struct processing_module *mod)
 
 	for (i = 0; i < ARRAY_SIZE(mux_func_map); i++) {
 		struct comp_buffer __sparse_cache *source_c = buffer_acquire(sourceb);
-		enum sof_ipc_frame fmt = source_c->stream.frame_fmt;
+		enum sof_ipc_frame fmt = audio_stream_get_frm_fmt(&source_c->stream);
 
 		buffer_release(source_c);
 

--- a/src/audio/mux/mux_generic.c
+++ b/src/audio/mux/mux_generic.c
@@ -122,7 +122,7 @@ static void mux_init_look_up_pointers_s16(struct audio_stream __sparse_cache *si
 	for (elem = 0; elem < lookup->num_elems; elem++) {
 		source = sources[lookup->copy_elem[elem].stream_id];
 
-		lookup->copy_elem[elem].src = (int16_t *)source->r_ptr +
+		lookup->copy_elem[elem].src = (int16_t *)audio_stream_get_rptr(source) +
 			lookup->copy_elem[elem].in_ch;
 		lookup->copy_elem[elem].src_inc = source->channels;
 
@@ -140,7 +140,7 @@ static void demux_init_look_up_pointers_s16(struct audio_stream __sparse_cache *
 
 	/* init pointers */
 	for (elem = 0; elem < lookup->num_elems; elem++) {
-		lookup->copy_elem[elem].src = (int16_t *)source->r_ptr +
+		lookup->copy_elem[elem].src = (int16_t *)audio_stream_get_rptr(source) +
 			lookup->copy_elem[elem].in_ch;
 		lookup->copy_elem[elem].src_inc = source->channels;
 
@@ -324,7 +324,7 @@ static void mux_init_look_up_pointers_s32(struct audio_stream __sparse_cache *si
 	for (elem = 0; elem < lookup->num_elems; elem++) {
 		source = sources[lookup->copy_elem[elem].stream_id];
 
-		lookup->copy_elem[elem].src = (int32_t *)source->r_ptr +
+		lookup->copy_elem[elem].src = (int32_t *)audio_stream_get_rptr(source) +
 			lookup->copy_elem[elem].in_ch;
 		lookup->copy_elem[elem].src_inc = source->channels;
 
@@ -342,7 +342,7 @@ static void demux_init_look_up_pointers_s32(struct audio_stream __sparse_cache *
 
 	/* init pointers */
 	for (elem = 0; elem < lookup->num_elems; elem++) {
-		lookup->copy_elem[elem].src = (int32_t *)source->r_ptr +
+		lookup->copy_elem[elem].src = (int32_t *)audio_stream_get_rptr(source) +
 			lookup->copy_elem[elem].in_ch;
 		lookup->copy_elem[elem].src_inc = source->channels;
 

--- a/src/audio/mux/mux_generic.c
+++ b/src/audio/mux/mux_generic.c
@@ -126,7 +126,7 @@ static void mux_init_look_up_pointers_s16(struct audio_stream __sparse_cache *si
 			lookup->copy_elem[elem].in_ch;
 		lookup->copy_elem[elem].src_inc = source->channels;
 
-		lookup->copy_elem[elem].dest = (int16_t *)sink->w_ptr +
+		lookup->copy_elem[elem].dest = (int16_t *)audio_stream_get_wptr(sink) +
 			lookup->copy_elem[elem].out_ch;
 		lookup->copy_elem[elem].dest_inc = sink->channels;
 	}
@@ -144,7 +144,7 @@ static void demux_init_look_up_pointers_s16(struct audio_stream __sparse_cache *
 			lookup->copy_elem[elem].in_ch;
 		lookup->copy_elem[elem].src_inc = source->channels;
 
-		lookup->copy_elem[elem].dest = (int16_t *)sink->w_ptr +
+		lookup->copy_elem[elem].dest = (int16_t *)audio_stream_get_wptr(sink) +
 			lookup->copy_elem[elem].out_ch;
 		lookup->copy_elem[elem].dest_inc = sink->channels;
 	}
@@ -328,7 +328,7 @@ static void mux_init_look_up_pointers_s32(struct audio_stream __sparse_cache *si
 			lookup->copy_elem[elem].in_ch;
 		lookup->copy_elem[elem].src_inc = source->channels;
 
-		lookup->copy_elem[elem].dest = (int32_t *)sink->w_ptr +
+		lookup->copy_elem[elem].dest = (int32_t *)audio_stream_get_wptr(sink) +
 			lookup->copy_elem[elem].out_ch;
 		lookup->copy_elem[elem].dest_inc = sink->channels;
 	}
@@ -346,7 +346,7 @@ static void demux_init_look_up_pointers_s32(struct audio_stream __sparse_cache *
 			lookup->copy_elem[elem].in_ch;
 		lookup->copy_elem[elem].src_inc = source->channels;
 
-		lookup->copy_elem[elem].dest = (int32_t *)sink->w_ptr +
+		lookup->copy_elem[elem].dest = (int32_t *)audio_stream_get_wptr(sink) +
 			lookup->copy_elem[elem].out_ch;
 		lookup->copy_elem[elem].dest_inc = sink->channels;
 	}

--- a/src/audio/mux/mux_generic.c
+++ b/src/audio/mux/mux_generic.c
@@ -124,11 +124,11 @@ static void mux_init_look_up_pointers_s16(struct audio_stream __sparse_cache *si
 
 		lookup->copy_elem[elem].src = (int16_t *)audio_stream_get_rptr(source) +
 			lookup->copy_elem[elem].in_ch;
-		lookup->copy_elem[elem].src_inc = source->channels;
+		lookup->copy_elem[elem].src_inc = audio_stream_get_channels(source);
 
 		lookup->copy_elem[elem].dest = (int16_t *)audio_stream_get_wptr(sink) +
 			lookup->copy_elem[elem].out_ch;
-		lookup->copy_elem[elem].dest_inc = sink->channels;
+		lookup->copy_elem[elem].dest_inc = audio_stream_get_channels(sink);
 	}
 }
 
@@ -142,11 +142,11 @@ static void demux_init_look_up_pointers_s16(struct audio_stream __sparse_cache *
 	for (elem = 0; elem < lookup->num_elems; elem++) {
 		lookup->copy_elem[elem].src = (int16_t *)audio_stream_get_rptr(source) +
 			lookup->copy_elem[elem].in_ch;
-		lookup->copy_elem[elem].src_inc = source->channels;
+		lookup->copy_elem[elem].src_inc = audio_stream_get_channels(source);
 
 		lookup->copy_elem[elem].dest = (int16_t *)audio_stream_get_wptr(sink) +
 			lookup->copy_elem[elem].out_ch;
-		lookup->copy_elem[elem].dest_inc = sink->channels;
+		lookup->copy_elem[elem].dest_inc = audio_stream_get_channels(sink);
 	}
 }
 
@@ -326,11 +326,11 @@ static void mux_init_look_up_pointers_s32(struct audio_stream __sparse_cache *si
 
 		lookup->copy_elem[elem].src = (int32_t *)audio_stream_get_rptr(source) +
 			lookup->copy_elem[elem].in_ch;
-		lookup->copy_elem[elem].src_inc = source->channels;
+		lookup->copy_elem[elem].src_inc = audio_stream_get_channels(source);
 
 		lookup->copy_elem[elem].dest = (int32_t *)audio_stream_get_wptr(sink) +
 			lookup->copy_elem[elem].out_ch;
-		lookup->copy_elem[elem].dest_inc = sink->channels;
+		lookup->copy_elem[elem].dest_inc = audio_stream_get_channels(sink);
 	}
 }
 
@@ -344,11 +344,11 @@ static void demux_init_look_up_pointers_s32(struct audio_stream __sparse_cache *
 	for (elem = 0; elem < lookup->num_elems; elem++) {
 		lookup->copy_elem[elem].src = (int32_t *)audio_stream_get_rptr(source) +
 			lookup->copy_elem[elem].in_ch;
-		lookup->copy_elem[elem].src_inc = source->channels;
+		lookup->copy_elem[elem].src_inc = audio_stream_get_channels(source);
 
 		lookup->copy_elem[elem].dest = (int32_t *)audio_stream_get_wptr(sink) +
 			lookup->copy_elem[elem].out_ch;
-		lookup->copy_elem[elem].dest_inc = sink->channels;
+		lookup->copy_elem[elem].dest_inc = audio_stream_get_channels(sink);
 	}
 }
 

--- a/src/audio/pcm_converter/pcm_converter.c
+++ b/src/audio/pcm_converter/pcm_converter.c
@@ -23,7 +23,7 @@ int pcm_convert_as_linear(const struct audio_stream __sparse_cache *source, uint
 	const int s_size_out = audio_stream_sample_bytes(sink);
 	const int log2_s_size_in = ffs(s_size_in) - 1;
 	const int log2_s_size_out = ffs(s_size_out) - 1;
-	char *r_ptr = audio_stream_get_frag(source, source->r_ptr, ioffset,
+	char *r_ptr = audio_stream_get_frag(source, audio_stream_get_rptr(source), ioffset,
 					    s_size_in);
 	char *w_ptr = audio_stream_get_frag(sink, sink->w_ptr, ooffset,
 					    s_size_out);

--- a/src/audio/pcm_converter/pcm_converter.c
+++ b/src/audio/pcm_converter/pcm_converter.c
@@ -25,7 +25,7 @@ int pcm_convert_as_linear(const struct audio_stream __sparse_cache *source, uint
 	const int log2_s_size_out = ffs(s_size_out) - 1;
 	char *r_ptr = audio_stream_get_frag(source, audio_stream_get_rptr(source), ioffset,
 					    s_size_in);
-	char *w_ptr = audio_stream_get_frag(sink, sink->w_ptr, ooffset,
+	char *w_ptr = audio_stream_get_frag(sink, audio_stream_get_wptr(sink), ooffset,
 					    s_size_out);
 	int i = 0;
 	int chunk;

--- a/src/audio/pcm_converter/pcm_converter_generic.c
+++ b/src/audio/pcm_converter/pcm_converter_generic.c
@@ -36,7 +36,7 @@ static int pcm_convert_s16_to_s24(const struct audio_stream __sparse_cache *sour
 				  uint32_t ooffset, uint32_t samples)
 {
 	int16_t *src = audio_stream_get_rptr(source);
-	int32_t *dst = sink->w_ptr;
+	int32_t *dst = audio_stream_get_wptr(sink);
 	int processed;
 	int nmax, i, n;
 
@@ -65,7 +65,7 @@ static int pcm_convert_s24_to_s16(const struct audio_stream __sparse_cache *sour
 				  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
-	int16_t *dst = sink->w_ptr;
+	int16_t *dst = audio_stream_get_wptr(sink);
 	int processed;
 	int nmax, i, n;
 
@@ -98,7 +98,7 @@ static int pcm_convert_s16_to_s32(const struct audio_stream __sparse_cache *sour
 				  uint32_t ooffset, uint32_t samples)
 {
 	int16_t *src = audio_stream_get_rptr(source);
-	int32_t *dst = sink->w_ptr;
+	int32_t *dst = audio_stream_get_wptr(sink);
 	int processed;
 	int nmax, i, n;
 
@@ -127,7 +127,7 @@ static int pcm_convert_s32_to_s16(const struct audio_stream __sparse_cache *sour
 				  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
-	int16_t *dst = sink->w_ptr;
+	int16_t *dst = audio_stream_get_wptr(sink);
 	int processed;
 	int nmax, i, n;
 
@@ -160,7 +160,7 @@ static int pcm_convert_s24_to_s32(const struct audio_stream __sparse_cache *sour
 				  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
-	int32_t *dst = sink->w_ptr;
+	int32_t *dst = audio_stream_get_wptr(sink);
 	int processed;
 	int nmax, i, n;
 
@@ -189,7 +189,7 @@ static int pcm_convert_s32_to_s24(const struct audio_stream __sparse_cache *sour
 				  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
-	int32_t *dst = sink->w_ptr;
+	int32_t *dst = audio_stream_get_wptr(sink);
 	int processed;
 	int nmax, i, n;
 
@@ -218,7 +218,7 @@ static int pcm_convert_s32_to_s24_be(const struct audio_stream __sparse_cache *s
 				     uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
-	int32_t *dst = sink->w_ptr;
+	int32_t *dst = audio_stream_get_wptr(sink);
 	int processed;
 	int nmax, i, n;
 
@@ -533,7 +533,7 @@ static int pcm_convert_s16_c16_to_s16_c32(const struct audio_stream __sparse_cac
 					  uint32_t ooffset, uint32_t samples)
 {
 	int16_t *src = audio_stream_get_rptr(source);
-	int32_t *dst = sink->w_ptr;
+	int32_t *dst = audio_stream_get_wptr(sink);
 	int processed;
 	int nmax, i, n;
 
@@ -562,7 +562,7 @@ static int pcm_convert_s16_c32_to_s16_c16(const struct audio_stream __sparse_cac
 					  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
-	int16_t *dst = sink->w_ptr;
+	int16_t *dst = audio_stream_get_wptr(sink);
 	int processed;
 	int nmax, i, n;
 
@@ -592,7 +592,7 @@ static int pcm_convert_s16_c32_to_s32_c32(const struct audio_stream __sparse_cac
 					  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
-	int32_t *dst = sink->w_ptr;
+	int32_t *dst = audio_stream_get_wptr(sink);
 	int processed;
 	int nmax, i, n;
 
@@ -621,7 +621,7 @@ static int pcm_convert_s32_c32_to_s16_c32(const struct audio_stream __sparse_cac
 					  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
-	int32_t *dst = sink->w_ptr;
+	int32_t *dst = audio_stream_get_wptr(sink);
 	int processed;
 	int nmax, i, n;
 
@@ -651,7 +651,7 @@ static int pcm_convert_s16_c32_to_s24_c32(const struct audio_stream __sparse_cac
 					  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
-	int32_t *dst = sink->w_ptr;
+	int32_t *dst = audio_stream_get_wptr(sink);
 	int processed;
 	int nmax, i, n;
 
@@ -680,7 +680,7 @@ static int pcm_convert_s24_c32_to_s16_c32(const struct audio_stream __sparse_cac
 					  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
-	int32_t *dst = sink->w_ptr;
+	int32_t *dst = audio_stream_get_wptr(sink);
 	int processed;
 	int nmax, i, n;
 
@@ -711,7 +711,7 @@ static int pcm_convert_s24_c24_to_s24_c32(const struct audio_stream __sparse_cac
 					  uint32_t ooffset, uint32_t samples)
 {
 	uint8_t *src = audio_stream_get_rptr(source);
-	int32_t *dst = sink->w_ptr;
+	int32_t *dst = audio_stream_get_wptr(sink);
 	int processed;
 	int nmax, i, n;
 
@@ -741,7 +741,7 @@ static int pcm_convert_s24_c32_to_s24_c24(const struct audio_stream __sparse_cac
 					  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
-	uint8_t *dst = sink->w_ptr;
+	uint8_t *dst = audio_stream_get_wptr(sink);
 	int processed;
 	int nmax, i, n;
 
@@ -775,7 +775,7 @@ static int pcm_convert_s24_c32_to_s24_c24_link_gtw(const struct audio_stream __s
 						   uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
-	uint16_t *dst = sink->w_ptr;
+	uint16_t *dst = audio_stream_get_wptr(sink);
 	int processed;
 	int nmax, i = 0, n = 0;
 

--- a/src/audio/pcm_converter/pcm_converter_generic.c
+++ b/src/audio/pcm_converter/pcm_converter_generic.c
@@ -35,7 +35,7 @@ static int pcm_convert_s16_to_s24(const struct audio_stream __sparse_cache *sour
 				  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
 				  uint32_t ooffset, uint32_t samples)
 {
-	int16_t *src = source->r_ptr;
+	int16_t *src = audio_stream_get_rptr(source);
 	int32_t *dst = sink->w_ptr;
 	int processed;
 	int nmax, i, n;
@@ -64,7 +64,7 @@ static int pcm_convert_s24_to_s16(const struct audio_stream __sparse_cache *sour
 				  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
 				  uint32_t ooffset, uint32_t samples)
 {
-	int32_t *src = source->r_ptr;
+	int32_t *src = audio_stream_get_rptr(source);
 	int16_t *dst = sink->w_ptr;
 	int processed;
 	int nmax, i, n;
@@ -97,7 +97,7 @@ static int pcm_convert_s16_to_s32(const struct audio_stream __sparse_cache *sour
 				  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
 				  uint32_t ooffset, uint32_t samples)
 {
-	int16_t *src = source->r_ptr;
+	int16_t *src = audio_stream_get_rptr(source);
 	int32_t *dst = sink->w_ptr;
 	int processed;
 	int nmax, i, n;
@@ -126,7 +126,7 @@ static int pcm_convert_s32_to_s16(const struct audio_stream __sparse_cache *sour
 				  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
 				  uint32_t ooffset, uint32_t samples)
 {
-	int32_t *src = source->r_ptr;
+	int32_t *src = audio_stream_get_rptr(source);
 	int16_t *dst = sink->w_ptr;
 	int processed;
 	int nmax, i, n;
@@ -159,7 +159,7 @@ static int pcm_convert_s24_to_s32(const struct audio_stream __sparse_cache *sour
 				  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
 				  uint32_t ooffset, uint32_t samples)
 {
-	int32_t *src = source->r_ptr;
+	int32_t *src = audio_stream_get_rptr(source);
 	int32_t *dst = sink->w_ptr;
 	int processed;
 	int nmax, i, n;
@@ -188,7 +188,7 @@ static int pcm_convert_s32_to_s24(const struct audio_stream __sparse_cache *sour
 				  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
 				  uint32_t ooffset, uint32_t samples)
 {
-	int32_t *src = source->r_ptr;
+	int32_t *src = audio_stream_get_rptr(source);
 	int32_t *dst = sink->w_ptr;
 	int processed;
 	int nmax, i, n;
@@ -217,7 +217,7 @@ static int pcm_convert_s32_to_s24_be(const struct audio_stream __sparse_cache *s
 				     uint32_t ioffset, struct audio_stream __sparse_cache *sink,
 				     uint32_t ooffset, uint32_t samples)
 {
-	int32_t *src = source->r_ptr;
+	int32_t *src = audio_stream_get_rptr(source);
 	int32_t *dst = sink->w_ptr;
 	int processed;
 	int nmax, i, n;
@@ -532,7 +532,7 @@ static int pcm_convert_s16_c16_to_s16_c32(const struct audio_stream __sparse_cac
 					  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
 					  uint32_t ooffset, uint32_t samples)
 {
-	int16_t *src = source->r_ptr;
+	int16_t *src = audio_stream_get_rptr(source);
 	int32_t *dst = sink->w_ptr;
 	int processed;
 	int nmax, i, n;
@@ -561,7 +561,7 @@ static int pcm_convert_s16_c32_to_s16_c16(const struct audio_stream __sparse_cac
 					  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
 					  uint32_t ooffset, uint32_t samples)
 {
-	int32_t *src = source->r_ptr;
+	int32_t *src = audio_stream_get_rptr(source);
 	int16_t *dst = sink->w_ptr;
 	int processed;
 	int nmax, i, n;
@@ -591,7 +591,7 @@ static int pcm_convert_s16_c32_to_s32_c32(const struct audio_stream __sparse_cac
 					  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
 					  uint32_t ooffset, uint32_t samples)
 {
-	int32_t *src = source->r_ptr;
+	int32_t *src = audio_stream_get_rptr(source);
 	int32_t *dst = sink->w_ptr;
 	int processed;
 	int nmax, i, n;
@@ -620,7 +620,7 @@ static int pcm_convert_s32_c32_to_s16_c32(const struct audio_stream __sparse_cac
 					  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
 					  uint32_t ooffset, uint32_t samples)
 {
-	int32_t *src = source->r_ptr;
+	int32_t *src = audio_stream_get_rptr(source);
 	int32_t *dst = sink->w_ptr;
 	int processed;
 	int nmax, i, n;
@@ -650,7 +650,7 @@ static int pcm_convert_s16_c32_to_s24_c32(const struct audio_stream __sparse_cac
 					  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
 					  uint32_t ooffset, uint32_t samples)
 {
-	int32_t *src = source->r_ptr;
+	int32_t *src = audio_stream_get_rptr(source);
 	int32_t *dst = sink->w_ptr;
 	int processed;
 	int nmax, i, n;
@@ -679,7 +679,7 @@ static int pcm_convert_s24_c32_to_s16_c32(const struct audio_stream __sparse_cac
 					  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
 					  uint32_t ooffset, uint32_t samples)
 {
-	int32_t *src = source->r_ptr;
+	int32_t *src = audio_stream_get_rptr(source);
 	int32_t *dst = sink->w_ptr;
 	int processed;
 	int nmax, i, n;
@@ -710,7 +710,7 @@ static int pcm_convert_s24_c24_to_s24_c32(const struct audio_stream __sparse_cac
 					  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
 					  uint32_t ooffset, uint32_t samples)
 {
-	uint8_t *src = source->r_ptr;
+	uint8_t *src = audio_stream_get_rptr(source);
 	int32_t *dst = sink->w_ptr;
 	int processed;
 	int nmax, i, n;
@@ -740,7 +740,7 @@ static int pcm_convert_s24_c32_to_s24_c24(const struct audio_stream __sparse_cac
 					  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
 					  uint32_t ooffset, uint32_t samples)
 {
-	int32_t *src = source->r_ptr;
+	int32_t *src = audio_stream_get_rptr(source);
 	uint8_t *dst = sink->w_ptr;
 	int processed;
 	int nmax, i, n;
@@ -774,7 +774,7 @@ static int pcm_convert_s24_c32_to_s24_c24_link_gtw(const struct audio_stream __s
 						   uint32_t ioffset, struct audio_stream __sparse_cache *sink,
 						   uint32_t ooffset, uint32_t samples)
 {
-	int32_t *src = source->r_ptr;
+	int32_t *src = audio_stream_get_rptr(source);
 	uint16_t *dst = sink->w_ptr;
 	int processed;
 	int nmax, i = 0, n = 0;

--- a/src/audio/pcm_converter/pcm_converter_hifi3.c
+++ b/src/audio/pcm_converter/pcm_converter_hifi3.c
@@ -45,7 +45,7 @@ static int pcm_convert_s16_to_s24(const struct audio_stream __sparse_cache *sour
 	ae_valign inu = AE_ZALIGN64();
 	ae_valign outu = AE_ZALIGN64();
 	int16_t *src = audio_stream_get_rptr(source);
-	int32_t *dst = sink->w_ptr;
+	int32_t *dst = audio_stream_get_wptr(sink);
 
 	ae_int16x4 *in = audio_stream_wrap(source, src + ioffset);
 	ae_int32x2 *out = audio_stream_wrap(sink, dst + ooffset);
@@ -121,7 +121,7 @@ static int pcm_convert_s24_to_s16(const struct audio_stream __sparse_cache *sour
 	ae_valign inu = AE_ZALIGN64();
 	ae_valign outu = AE_ZALIGN64();
 	ae_int32 *src = audio_stream_get_rptr(source);
-	ae_int16 *dst = sink->w_ptr;
+	ae_int16 *dst = audio_stream_get_wptr(sink);
 
 	ae_int32x2 *in = audio_stream_wrap(source, src + ioffset);
 	ae_int16x4 *out = audio_stream_wrap(sink, dst + ooffset);
@@ -186,7 +186,7 @@ static int pcm_convert_s16_to_s32(const struct audio_stream __sparse_cache *sour
 				  uint32_t ooffset, uint32_t samples)
 {
 	int16_t *src = audio_stream_get_rptr(source);
-	int32_t *dst = sink->w_ptr;
+	int32_t *dst = audio_stream_get_wptr(sink);
 	ae_int16x4 sample = AE_ZERO16();
 	uint32_t nmax, i, n, m, left, left_samples;
 	ae_valign inu = AE_ZALIGN64();
@@ -242,7 +242,7 @@ static int pcm_convert_s32_to_s16(const struct audio_stream __sparse_cache *sour
 				  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
-	int16_t *dst = sink->w_ptr;
+	int16_t *dst = audio_stream_get_wptr(sink);
 	ae_int16x4 sample = AE_ZERO16();
 	ae_int32x2 sample_1 = AE_ZERO32();
 	ae_int32x2 sample_2 = AE_ZERO32();
@@ -308,7 +308,7 @@ static int pcm_convert_s24_to_s32(const struct audio_stream __sparse_cache *sour
 				  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
-	int32_t *dst = sink->w_ptr;
+	int32_t *dst = audio_stream_get_wptr(sink);
 	ae_int32x2 sample = AE_ZERO32();
 	uint32_t nmax, i, n, m, left_samples;
 	ae_valign outu = AE_ZALIGN64();
@@ -373,7 +373,7 @@ static int pcm_convert_s32_to_s24(const struct audio_stream __sparse_cache *sour
 				  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
-	int32_t *dst = sink->w_ptr;
+	int32_t *dst = audio_stream_get_wptr(sink);
 	ae_int32x2 sample = AE_ZERO32();
 	uint32_t nmax, i, n, m, left_samples;
 	ae_valign outu = AE_ZALIGN64();
@@ -418,7 +418,7 @@ static int pcm_convert_s32_to_s24_be(const struct audio_stream __sparse_cache *s
 				     uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
-	int32_t *dst = sink->w_ptr;
+	int32_t *dst = audio_stream_get_wptr(sink);
 	ae_int32x2 sample = AE_ZERO32();
 	uint32_t nmax, i, n, m, left_samples;
 	ae_valign outu = AE_ZALIGN64();
@@ -816,7 +816,7 @@ static int pcm_convert_s16_c16_to_s16_c32(const struct audio_stream __sparse_cac
 					  uint32_t ooffset, uint32_t samples)
 {
 	int16_t *src = audio_stream_get_rptr(source);
-	int32_t *dst = sink->w_ptr;
+	int32_t *dst = audio_stream_get_wptr(sink);
 	ae_int16x4 sample = AE_ZERO16();
 	uint32_t nmax, i, n, m, left, left_samples;
 	ae_valign inu = AE_ZALIGN64();
@@ -866,7 +866,7 @@ static int pcm_convert_s16_c32_to_s16_c16(const struct audio_stream __sparse_cac
 					  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
-	int16_t *dst = sink->w_ptr;
+	int16_t *dst = audio_stream_get_wptr(sink);
 	ae_int16x4 sample = AE_ZERO16();
 	ae_int32x2 sample_1 = AE_ZERO32();
 	ae_int32x2 sample_2 = AE_ZERO32();
@@ -925,7 +925,7 @@ static int pcm_convert_s16_c32_to_s32_c32(const struct audio_stream __sparse_cac
 					  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
-	int32_t *dst = sink->w_ptr;
+	int32_t *dst = audio_stream_get_wptr(sink);
 	ae_int32x2 sample = AE_ZERO32();
 	uint32_t nmax, i, n, m, left_samples;
 	ae_valign outu = AE_ZALIGN64();
@@ -968,7 +968,7 @@ static int pcm_convert_s32_c32_to_s16_c32(const struct audio_stream __sparse_cac
 					  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
-	int32_t *dst = sink->w_ptr;
+	int32_t *dst = audio_stream_get_wptr(sink);
 	ae_int32x2 sample = AE_ZERO32();
 	uint32_t nmax, i, n, m, left_samples;
 	ae_valign outu = AE_ZALIGN64();
@@ -1013,7 +1013,7 @@ static int pcm_convert_s16_c32_to_s24_c32(const struct audio_stream __sparse_cac
 					  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
-	int32_t *dst = sink->w_ptr;
+	int32_t *dst = audio_stream_get_wptr(sink);
 	ae_int32x2 sample = AE_ZERO32();
 	uint32_t nmax, i, n, m, left_samples;
 	ae_valign outu = AE_ZALIGN64();
@@ -1068,7 +1068,7 @@ static int pcm_convert_s24_c32_to_s16_c32(const struct audio_stream __sparse_cac
 					  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
-	int32_t *dst = sink->w_ptr;
+	int32_t *dst = audio_stream_get_wptr(sink);
 	ae_int32x2 sample = AE_ZERO32();
 	uint32_t nmax, i, n, m, left_samples;
 	ae_valign outu = AE_ZALIGN64();
@@ -1115,7 +1115,7 @@ static int pcm_convert_s24_c24_to_s24_c32(const struct audio_stream __sparse_cac
 					  uint32_t ooffset, uint32_t samples)
 {
 	uint8_t *src = audio_stream_get_rptr(source);
-	int32_t *dst = sink->w_ptr;
+	int32_t *dst = audio_stream_get_wptr(sink);
 	ae_int24x2 sample24 =  AE_ZERO24();
 	ae_int32x2 sample = AE_ZERO32();
 	uint32_t nmax, i, n, m, left_samples;
@@ -1162,7 +1162,7 @@ static int pcm_convert_s24_c32_to_s24_c24(const struct audio_stream __sparse_cac
 					  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
-	uint8_t *dst = sink->w_ptr;
+	uint8_t *dst = audio_stream_get_wptr(sink);
 	ae_int32x2 sample = AE_ZERO32();
 	ae_int24x2 sample24 =  AE_ZERO24();
 	uint32_t nmax, i, n, m, left_samples;

--- a/src/audio/pcm_converter/pcm_converter_hifi3.c
+++ b/src/audio/pcm_converter/pcm_converter_hifi3.c
@@ -44,7 +44,7 @@ static int pcm_convert_s16_to_s24(const struct audio_stream __sparse_cache *sour
 	uint32_t nmax, i, n, m, left, left_samples;
 	ae_valign inu = AE_ZALIGN64();
 	ae_valign outu = AE_ZALIGN64();
-	int16_t *src = source->r_ptr;
+	int16_t *src = audio_stream_get_rptr(source);
 	int32_t *dst = sink->w_ptr;
 
 	ae_int16x4 *in = audio_stream_wrap(source, src + ioffset);
@@ -120,7 +120,7 @@ static int pcm_convert_s24_to_s16(const struct audio_stream __sparse_cache *sour
 	uint32_t nmax, i, n, m, left, left_samples;
 	ae_valign inu = AE_ZALIGN64();
 	ae_valign outu = AE_ZALIGN64();
-	ae_int32 *src = source->r_ptr;
+	ae_int32 *src = audio_stream_get_rptr(source);
 	ae_int16 *dst = sink->w_ptr;
 
 	ae_int32x2 *in = audio_stream_wrap(source, src + ioffset);
@@ -185,7 +185,7 @@ static int pcm_convert_s16_to_s32(const struct audio_stream __sparse_cache *sour
 				  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
 				  uint32_t ooffset, uint32_t samples)
 {
-	int16_t *src = source->r_ptr;
+	int16_t *src = audio_stream_get_rptr(source);
 	int32_t *dst = sink->w_ptr;
 	ae_int16x4 sample = AE_ZERO16();
 	uint32_t nmax, i, n, m, left, left_samples;
@@ -241,7 +241,7 @@ static int pcm_convert_s32_to_s16(const struct audio_stream __sparse_cache *sour
 				  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
 				  uint32_t ooffset, uint32_t samples)
 {
-	int32_t *src = source->r_ptr;
+	int32_t *src = audio_stream_get_rptr(source);
 	int16_t *dst = sink->w_ptr;
 	ae_int16x4 sample = AE_ZERO16();
 	ae_int32x2 sample_1 = AE_ZERO32();
@@ -307,7 +307,7 @@ static int pcm_convert_s24_to_s32(const struct audio_stream __sparse_cache *sour
 				  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
 				  uint32_t ooffset, uint32_t samples)
 {
-	int32_t *src = source->r_ptr;
+	int32_t *src = audio_stream_get_rptr(source);
 	int32_t *dst = sink->w_ptr;
 	ae_int32x2 sample = AE_ZERO32();
 	uint32_t nmax, i, n, m, left_samples;
@@ -372,7 +372,7 @@ static int pcm_convert_s32_to_s24(const struct audio_stream __sparse_cache *sour
 				  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
 				  uint32_t ooffset, uint32_t samples)
 {
-	int32_t *src = source->r_ptr;
+	int32_t *src = audio_stream_get_rptr(source);
 	int32_t *dst = sink->w_ptr;
 	ae_int32x2 sample = AE_ZERO32();
 	uint32_t nmax, i, n, m, left_samples;
@@ -417,7 +417,7 @@ static int pcm_convert_s32_to_s24_be(const struct audio_stream __sparse_cache *s
 				     uint32_t ioffset, struct audio_stream __sparse_cache *sink,
 				     uint32_t ooffset, uint32_t samples)
 {
-	int32_t *src = source->r_ptr;
+	int32_t *src = audio_stream_get_rptr(source);
 	int32_t *dst = sink->w_ptr;
 	ae_int32x2 sample = AE_ZERO32();
 	uint32_t nmax, i, n, m, left_samples;
@@ -815,7 +815,7 @@ static int pcm_convert_s16_c16_to_s16_c32(const struct audio_stream __sparse_cac
 					  struct audio_stream __sparse_cache *sink,
 					  uint32_t ooffset, uint32_t samples)
 {
-	int16_t *src = source->r_ptr;
+	int16_t *src = audio_stream_get_rptr(source);
 	int32_t *dst = sink->w_ptr;
 	ae_int16x4 sample = AE_ZERO16();
 	uint32_t nmax, i, n, m, left, left_samples;
@@ -865,7 +865,7 @@ static int pcm_convert_s16_c32_to_s16_c16(const struct audio_stream __sparse_cac
 					  struct audio_stream __sparse_cache *sink,
 					  uint32_t ooffset, uint32_t samples)
 {
-	int32_t *src = source->r_ptr;
+	int32_t *src = audio_stream_get_rptr(source);
 	int16_t *dst = sink->w_ptr;
 	ae_int16x4 sample = AE_ZERO16();
 	ae_int32x2 sample_1 = AE_ZERO32();
@@ -924,7 +924,7 @@ static int pcm_convert_s16_c32_to_s32_c32(const struct audio_stream __sparse_cac
 					  struct audio_stream __sparse_cache *sink,
 					  uint32_t ooffset, uint32_t samples)
 {
-	int32_t *src = source->r_ptr;
+	int32_t *src = audio_stream_get_rptr(source);
 	int32_t *dst = sink->w_ptr;
 	ae_int32x2 sample = AE_ZERO32();
 	uint32_t nmax, i, n, m, left_samples;
@@ -967,7 +967,7 @@ static int pcm_convert_s32_c32_to_s16_c32(const struct audio_stream __sparse_cac
 					  struct audio_stream __sparse_cache *sink,
 					  uint32_t ooffset, uint32_t samples)
 {
-	int32_t *src = source->r_ptr;
+	int32_t *src = audio_stream_get_rptr(source);
 	int32_t *dst = sink->w_ptr;
 	ae_int32x2 sample = AE_ZERO32();
 	uint32_t nmax, i, n, m, left_samples;
@@ -1012,7 +1012,7 @@ static int pcm_convert_s16_c32_to_s24_c32(const struct audio_stream __sparse_cac
 					  struct audio_stream __sparse_cache *sink,
 					  uint32_t ooffset, uint32_t samples)
 {
-	int32_t *src = source->r_ptr;
+	int32_t *src = audio_stream_get_rptr(source);
 	int32_t *dst = sink->w_ptr;
 	ae_int32x2 sample = AE_ZERO32();
 	uint32_t nmax, i, n, m, left_samples;
@@ -1067,7 +1067,7 @@ static int pcm_convert_s24_c32_to_s16_c32(const struct audio_stream __sparse_cac
 					  struct audio_stream __sparse_cache *sink,
 					  uint32_t ooffset, uint32_t samples)
 {
-	int32_t *src = source->r_ptr;
+	int32_t *src = audio_stream_get_rptr(source);
 	int32_t *dst = sink->w_ptr;
 	ae_int32x2 sample = AE_ZERO32();
 	uint32_t nmax, i, n, m, left_samples;
@@ -1114,7 +1114,7 @@ static int pcm_convert_s24_c24_to_s24_c32(const struct audio_stream __sparse_cac
 					  struct audio_stream __sparse_cache *sink,
 					  uint32_t ooffset, uint32_t samples)
 {
-	uint8_t *src = source->r_ptr;
+	uint8_t *src = audio_stream_get_rptr(source);
 	int32_t *dst = sink->w_ptr;
 	ae_int24x2 sample24 =  AE_ZERO24();
 	ae_int32x2 sample = AE_ZERO32();
@@ -1161,7 +1161,7 @@ static int pcm_convert_s24_c32_to_s24_c24(const struct audio_stream __sparse_cac
 					  struct audio_stream __sparse_cache *sink,
 					  uint32_t ooffset, uint32_t samples)
 {
-	int32_t *src = source->r_ptr;
+	int32_t *src = audio_stream_get_rptr(source);
 	uint8_t *dst = sink->w_ptr;
 	ae_int32x2 sample = AE_ZERO32();
 	ae_int24x2 sample24 =  AE_ZERO24();

--- a/src/audio/pipeline/pipeline-params.c
+++ b/src/audio/pipeline/pipeline-params.c
@@ -138,7 +138,7 @@ static void pipeline_update_buffer_pcm_params(struct comp_buffer __sparse_cache 
 	int i;
 
 	params->buffer_fmt = buffer->buffer_fmt;
-	params->frame_fmt = buffer->stream.frame_fmt;
+	params->frame_fmt = audio_stream_get_frm_fmt(&buffer->stream);
 	params->rate = buffer->stream.rate;
 	params->channels = buffer->stream.channels;
 	for (i = 0; i < SOF_IPC_MAX_CHANNELS; i++)

--- a/src/audio/pipeline/pipeline-params.c
+++ b/src/audio/pipeline/pipeline-params.c
@@ -139,7 +139,7 @@ static void pipeline_update_buffer_pcm_params(struct comp_buffer __sparse_cache 
 
 	params->buffer_fmt = buffer->buffer_fmt;
 	params->frame_fmt = audio_stream_get_frm_fmt(&buffer->stream);
-	params->rate = buffer->stream.rate;
+	params->rate = audio_stream_get_rate(&buffer->stream);
 	params->channels = buffer->stream.channels;
 	for (i = 0; i < SOF_IPC_MAX_CHANNELS; i++)
 		params->chmap[i] = buffer->chmap[i];

--- a/src/audio/pipeline/pipeline-params.c
+++ b/src/audio/pipeline/pipeline-params.c
@@ -140,7 +140,7 @@ static void pipeline_update_buffer_pcm_params(struct comp_buffer __sparse_cache 
 	params->buffer_fmt = buffer->buffer_fmt;
 	params->frame_fmt = audio_stream_get_frm_fmt(&buffer->stream);
 	params->rate = audio_stream_get_rate(&buffer->stream);
-	params->channels = buffer->stream.channels;
+	params->channels = audio_stream_get_channels(&buffer->stream);
 	for (i = 0; i < SOF_IPC_MAX_CHANNELS; i++)
 		params->chmap[i] = buffer->chmap[i];
 }

--- a/src/audio/rtnr/rtnr.c
+++ b/src/audio/rtnr/rtnr.c
@@ -734,7 +734,7 @@ static void rtnr_copy_from_sof_stream(struct audio_stream_rtnr *dst,
 	dst->free = src->free;
 	dst->w_ptr = audio_stream_get_wptr(src);
 	dst->r_ptr = audio_stream_get_rptr(src);
-	dst->addr = src->addr;
+	dst->addr = audio_stream_get_addr(src);
 	dst->end_addr = audio_stream_get_end_addr(src);
 }
 
@@ -746,7 +746,7 @@ static void rtnr_copy_to_sof_stream(struct audio_stream __sparse_cache *dst,
 	dst->free = src->free;
 	dst->w_ptr = audio_stream_get_wptr(src);
 	dst->r_ptr = audio_stream_get_rptr(src);
-	dst->addr = src->addr;
+	dst->addr = audio_stream_get_addr(src);
 	dst->end_addr = audio_stream_get_end_addr(src);
 }
 

--- a/src/audio/rtnr/rtnr.c
+++ b/src/audio/rtnr/rtnr.c
@@ -733,7 +733,7 @@ static void rtnr_copy_from_sof_stream(struct audio_stream_rtnr *dst,
 	dst->avail = src->avail;
 	dst->free = src->free;
 	dst->w_ptr = src->w_ptr;
-	dst->r_ptr = src->r_ptr;
+	dst->r_ptr = audio_stream_get_rptr(src);
 	dst->addr = src->addr;
 	dst->end_addr = src->end_addr;
 }
@@ -745,7 +745,7 @@ static void rtnr_copy_to_sof_stream(struct audio_stream __sparse_cache *dst,
 	dst->avail = src->avail;
 	dst->free = src->free;
 	dst->w_ptr = src->w_ptr;
-	dst->r_ptr = src->r_ptr;
+	dst->r_ptr = audio_stream_get_rptr(src);
 	dst->addr = src->addr;
 	dst->end_addr = src->end_addr;
 }

--- a/src/audio/rtnr/rtnr.c
+++ b/src/audio/rtnr/rtnr.c
@@ -729,7 +729,7 @@ static void rtnr_copy_from_sof_stream(struct audio_stream_rtnr *dst,
 				      struct audio_stream __sparse_cache *src)
 {
 
-	dst->size = src->size;
+	dst->size = audio_stream_get_size(src);
 	dst->avail = src->avail;
 	dst->free = src->free;
 	dst->w_ptr = audio_stream_get_wptr(src);
@@ -741,7 +741,7 @@ static void rtnr_copy_from_sof_stream(struct audio_stream_rtnr *dst,
 static void rtnr_copy_to_sof_stream(struct audio_stream __sparse_cache *dst,
 				    struct audio_stream_rtnr *src)
 {
-	dst->size = src->size;
+	dst->size = audio_stream_get_size(src);
 	dst->avail = src->avail;
 	dst->free = src->free;
 	dst->w_ptr = audio_stream_get_wptr(src);

--- a/src/audio/rtnr/rtnr.c
+++ b/src/audio/rtnr/rtnr.c
@@ -730,7 +730,7 @@ static void rtnr_copy_from_sof_stream(struct audio_stream_rtnr *dst,
 {
 
 	dst->size = audio_stream_get_size(src);
-	dst->avail = src->avail;
+	dst->avail = audio_stream_get_avail(src);
 	dst->free = src->free;
 	dst->w_ptr = audio_stream_get_wptr(src);
 	dst->r_ptr = audio_stream_get_rptr(src);
@@ -742,7 +742,7 @@ static void rtnr_copy_to_sof_stream(struct audio_stream __sparse_cache *dst,
 				    struct audio_stream_rtnr *src)
 {
 	dst->size = audio_stream_get_size(src);
-	dst->avail = src->avail;
+	dst->avail = audio_stream_get_avail(src);
 	dst->free = src->free;
 	dst->w_ptr = audio_stream_get_wptr(src);
 	dst->r_ptr = audio_stream_get_rptr(src);

--- a/src/audio/rtnr/rtnr.c
+++ b/src/audio/rtnr/rtnr.c
@@ -732,7 +732,7 @@ static void rtnr_copy_from_sof_stream(struct audio_stream_rtnr *dst,
 	dst->size = src->size;
 	dst->avail = src->avail;
 	dst->free = src->free;
-	dst->w_ptr = src->w_ptr;
+	dst->w_ptr = audio_stream_get_wptr(src);
 	dst->r_ptr = audio_stream_get_rptr(src);
 	dst->addr = src->addr;
 	dst->end_addr = src->end_addr;
@@ -744,7 +744,7 @@ static void rtnr_copy_to_sof_stream(struct audio_stream __sparse_cache *dst,
 	dst->size = src->size;
 	dst->avail = src->avail;
 	dst->free = src->free;
-	dst->w_ptr = src->w_ptr;
+	dst->w_ptr = audio_stream_get_wptr(src);
 	dst->r_ptr = audio_stream_get_rptr(src);
 	dst->addr = src->addr;
 	dst->end_addr = src->end_addr;

--- a/src/audio/rtnr/rtnr.c
+++ b/src/audio/rtnr/rtnr.c
@@ -873,8 +873,8 @@ static int rtnr_prepare(struct comp_dev *dev)
 	/* Get sink data format */
 	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
 	sink_c = buffer_acquire(sinkb);
-	cd->sink_format = sink_c->stream.frame_fmt;
-	cd->sink_stream.frame_fmt = sink_c->stream.frame_fmt;
+	cd->sink_format = audio_stream_get_frm_fmt(&sink_c->stream);
+	cd->sink_stream.frame_fmt = audio_stream_get_frm_fmt(&sink_c->stream);
 	buffer_release(sink_c);
 
 	/* Check source and sink PCM format and get processing function */

--- a/src/audio/rtnr/rtnr.c
+++ b/src/audio/rtnr/rtnr.c
@@ -735,7 +735,7 @@ static void rtnr_copy_from_sof_stream(struct audio_stream_rtnr *dst,
 	dst->w_ptr = audio_stream_get_wptr(src);
 	dst->r_ptr = audio_stream_get_rptr(src);
 	dst->addr = src->addr;
-	dst->end_addr = src->end_addr;
+	dst->end_addr = audio_stream_get_end_addr(src);
 }
 
 static void rtnr_copy_to_sof_stream(struct audio_stream __sparse_cache *dst,
@@ -747,7 +747,7 @@ static void rtnr_copy_to_sof_stream(struct audio_stream __sparse_cache *dst,
 	dst->w_ptr = audio_stream_get_wptr(src);
 	dst->r_ptr = audio_stream_get_rptr(src);
 	dst->addr = src->addr;
-	dst->end_addr = src->end_addr;
+	dst->end_addr = audio_stream_get_end_addr(src);
 }
 
 /* copy and process stream data from source to sink buffers */

--- a/src/audio/rtnr/rtnr.c
+++ b/src/audio/rtnr/rtnr.c
@@ -731,7 +731,7 @@ static void rtnr_copy_from_sof_stream(struct audio_stream_rtnr *dst,
 
 	dst->size = audio_stream_get_size(src);
 	dst->avail = audio_stream_get_avail(src);
-	dst->free = src->free;
+	dst->free = audio_stream_get_free(src);
 	dst->w_ptr = audio_stream_get_wptr(src);
 	dst->r_ptr = audio_stream_get_rptr(src);
 	dst->addr = audio_stream_get_addr(src);
@@ -743,7 +743,7 @@ static void rtnr_copy_to_sof_stream(struct audio_stream __sparse_cache *dst,
 {
 	dst->size = audio_stream_get_size(src);
 	dst->avail = audio_stream_get_avail(src);
-	dst->free = src->free;
+	dst->free = audio_stream_get_free(src);
 	dst->w_ptr = audio_stream_get_wptr(src);
 	dst->r_ptr = audio_stream_get_rptr(src);
 	dst->addr = audio_stream_get_addr(src);

--- a/src/audio/rtnr/rtnr.c
+++ b/src/audio/rtnr/rtnr.c
@@ -345,10 +345,10 @@ static int rtnr_params(struct comp_dev *dev, struct sof_ipc_stream_params *param
 	sink_c = buffer_acquire(sinkb);
 
 	/* set source/sink_frames/rate */
-	cd->source_rate = source_c->stream.rate;
-	cd->sink_rate = sink_c->stream.rate;
-	cd->sources_stream[0].rate = source_c->stream.rate;
-	cd->sink_stream.rate = sink_c->stream.rate;
+	cd->source_rate = audio_stream_get_rate(&source_c->stream);
+	cd->sink_rate = audio_stream_get_rate(&sink_c->stream);
+	cd->sources_stream[0].rate = audio_stream_get_rate(&source_c->stream);
+	cd->sink_stream.rate = audio_stream_get_rate(&sink_c->stream);
 	channels_valid = source_c->stream.channels == sink_c->stream.channels;
 
 	if (!cd->sink_rate) {

--- a/src/audio/rtnr/rtnr.c
+++ b/src/audio/rtnr/rtnr.c
@@ -349,7 +349,7 @@ static int rtnr_params(struct comp_dev *dev, struct sof_ipc_stream_params *param
 	cd->sink_rate = audio_stream_get_rate(&sink_c->stream);
 	cd->sources_stream[0].rate = audio_stream_get_rate(&source_c->stream);
 	cd->sink_stream.rate = audio_stream_get_rate(&sink_c->stream);
-	channels_valid = source_c->stream.channels == sink_c->stream.channels;
+	channels_valid = source_c->stream.channels == audio_stream_get_channels(&sink_c->stream);
 
 	if (!cd->sink_rate) {
 		comp_err(dev, "rtnr_nr_params(), zero sink rate");
@@ -379,8 +379,8 @@ static int rtnr_params(struct comp_dev *dev, struct sof_ipc_stream_params *param
 	}
 
 	/* set source/sink stream channels */
-	cd->sources_stream[0].channels = source_c->stream.channels;
-	cd->sink_stream.channels = sink_c->stream.channels;
+	cd->sources_stream[0].channels = audio_stream_get_channels(&source_c->stream);
+	cd->sink_stream.channels = audio_stream_get_channels(&sink_c->stream);
 
 	/* set source/sink stream overrun/underrun permitted */
 	cd->sources_stream[0].overrun_permitted = source_c->stream.overrun_permitted;
@@ -779,7 +779,8 @@ static int rtnr_copy(struct comp_dev *dev)
 	source = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
 
 	/* put empty data into output queue*/
-	RTKMA_API_First_Copy(cd->rtk_agl, cd->source_rate, source->stream.channels);
+	RTKMA_API_First_Copy(cd->rtk_agl, cd->source_rate,
+			     audio_stream_get_channels(&source->stream));
 
 	sink = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
 
@@ -835,7 +836,7 @@ static int rtnr_copy(struct comp_dev *dev)
 		buffer_stream_invalidate(source, cl.source_bytes);
 
 		audio_stream_copy(&source->stream, 0, &sink->stream, 0,
-				source->stream.channels * cl.frames);
+				audio_stream_get_channels(&source->stream) * cl.frames);
 
 		buffer_stream_writeback(sink, cl.sink_bytes);
 		comp_update_buffer_consume(source, cl.source_bytes);

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -576,7 +576,7 @@ SOF_MODULE_INIT(selector, sys_comp_selector_init);
 #else
 static void build_config(struct comp_data *cd, struct module_config *cfg)
 {
-	enum sof_ipc_frame __sparse_cache frame_fmt, valid_fmt;
+	enum sof_ipc_frame frame_fmt, valid_fmt;
 	const struct sof_selector_ipc4_config *sel_cfg = &cd->sel_ipc4_cfg;
 	const struct ipc4_audio_format *out_fmt;
 	int i;
@@ -697,14 +697,17 @@ static void set_selector_params(struct processing_module *mod,
 		struct comp_buffer *sink_buf =
 			container_of(sink_list, struct comp_buffer, source_list);
 		struct comp_buffer __sparse_cache *sink = buffer_acquire(sink_buf);
+		enum sof_ipc_frame frame_fmt, valid_fmt;
 
 		sink->stream.channels = params->channels;
 		sink->stream.rate = params->rate;
 		audio_stream_fmt_conversion(out_fmt->depth,
 					    out_fmt->valid_bit_depth,
-					    &sink->stream.frame_fmt,
-					    &sink->stream.valid_sample_fmt,
+					    &frame_fmt, &valid_fmt,
 					    out_fmt->s_type);
+
+		sink->stream.frame_fmt = frame_fmt;
+		sink->stream.valid_sample_fmt = valid_fmt;
 
 		sink->buffer_fmt = out_fmt->interleaving_style;
 
@@ -725,15 +728,18 @@ static void set_selector_params(struct processing_module *mod,
 	source = buffer_acquire(src_buf);
 	if (!source->hw_params_configured) {
 		struct ipc4_audio_format *in_fmt;
+		enum sof_ipc_frame frame_fmt, valid_fmt;
 
 		in_fmt = &mod->priv.cfg.base_cfg.audio_fmt;
 		source->stream.channels = in_fmt->channels_count;
 		source->stream.rate = in_fmt->sampling_frequency;
 		audio_stream_fmt_conversion(in_fmt->depth,
 					    in_fmt->valid_bit_depth,
-					    &source->stream.frame_fmt,
-					    &source->stream.valid_sample_fmt,
+					    &frame_fmt, &valid_fmt,
 					    in_fmt->s_type);
+
+		source->stream.frame_fmt = frame_fmt;
+		source->stream.valid_sample_fmt = valid_fmt;
 
 		source->buffer_fmt = in_fmt->interleaving_style;
 

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -463,11 +463,11 @@ static int selector_prepare(struct comp_dev *dev)
 	sink_c = buffer_acquire(sinkb);
 
 	/* get source data format and period bytes */
-	cd->source_format = source_c->stream.frame_fmt;
+	cd->source_format = audio_stream_get_frm_fmt(&source_c->stream);
 	cd->source_period_bytes = audio_stream_period_bytes(&source_c->stream, dev->frames);
 
 	/* get sink data format and period bytes */
-	cd->sink_format = sink_c->stream.frame_fmt;
+	cd->sink_format = audio_stream_get_frm_fmt(&sink_c->stream);
 	cd->sink_period_bytes = audio_stream_period_bytes(&sink_c->stream, dev->frames);
 
 	/* There is an assumption that sink component will report out
@@ -920,11 +920,11 @@ static int selector_prepare(struct processing_module *mod)
 	audio_stream_init_alignment_constants(4, 1, &sink_c->stream);
 
 	/* get source data format and period bytes */
-	cd->source_format = source_c->stream.frame_fmt;
+	cd->source_format = audio_stream_get_frm_fmt(&source_c->stream);
 	cd->source_period_bytes = audio_stream_period_bytes(&source_c->stream, dev->frames);
 
 	/* get sink data format and period bytes */
-	cd->sink_format = sink_c->stream.frame_fmt;
+	cd->sink_format = audio_stream_get_frm_fmt(&sink_c->stream);
 	cd->sink_period_bytes = audio_stream_period_bytes(&sink_c->stream, dev->frames);
 
 	/* There is an assumption that sink component will report out

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -479,7 +479,7 @@ static int selector_prepare(struct comp_dev *dev)
 	comp_dbg(dev, "selector_prepare(): sinkb->channels = %u",
 		 sink_c->stream.channels);
 
-	sink_size = sink_c->stream.size;
+	sink_size = audio_stream_get_size(&sink_c->stream);
 
 	buffer_release(sink_c);
 	buffer_release(source_c);
@@ -928,7 +928,7 @@ static int selector_prepare(struct processing_module *mod)
 	comp_info(dev, "selector_prepare(): source sink channel = %u %u",
 		  source_c->stream.channels, sink_c->stream.channels);
 
-	sink_size = sink_c->stream.size;
+	sink_size = audio_stream_get_size(&sink_c->stream);
 
 	md->mpd.in_buff_size = cd->source_period_bytes;
 	md->mpd.out_buff_size = cd->sink_period_bytes;

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -402,7 +402,7 @@ static int selector_copy(struct comp_dev *dev)
 
 	source_c = buffer_acquire(source);
 
-	if (!source_c->stream.avail) {
+	if (!audio_stream_get_avail(&source_c->stream)) {
 		buffer_release(source_c);
 		return PPL_STATUS_PATH_STOP;
 	}

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -94,7 +94,7 @@ static int selector_verify_params(struct comp_dev *dev,
 		 * pipeline_comp_hw_params()
 		 */
 		out_channels = cd->config.out_channels_count ?
-			cd->config.out_channels_count : buffer_c->stream.channels;
+			cd->config.out_channels_count : audio_stream_get_channels(&buffer_c->stream);
 		params->channels = out_channels;
 	} else {
 		/* fetch source buffer for capture */
@@ -115,7 +115,7 @@ static int selector_verify_params(struct comp_dev *dev,
 		 * pipeline_comp_hw_params()
 		 */
 		in_channels = cd->config.in_channels_count ?
-			cd->config.in_channels_count : buffer_c->stream.channels;
+			cd->config.in_channels_count : audio_stream_get_channels(&buffer_c->stream);
 		params->channels = in_channels;
 	}
 
@@ -475,9 +475,9 @@ static int selector_prepare(struct comp_dev *dev)
 	 * reduce channel count between source and sink
 	 */
 	comp_dbg(dev, "selector_prepare(): sourceb->schannels = %u",
-		 source_c->stream.channels);
+		 audio_stream_get_channels(&source_c->stream));
 	comp_dbg(dev, "selector_prepare(): sinkb->channels = %u",
-		 sink_c->stream.channels);
+		 audio_stream_get_channels(&sink_c->stream));
 
 	sink_size = audio_stream_get_size(&sink_c->stream);
 
@@ -932,7 +932,7 @@ static int selector_prepare(struct processing_module *mod)
 	 * reduce channel count between source and sink
 	 */
 	comp_info(dev, "selector_prepare(): source sink channel = %u %u",
-		  source_c->stream.channels, sink_c->stream.channels);
+		  audio_stream_get_channels(&source_c->stream), sink_c->stream.channels);
 
 	sink_size = audio_stream_get_size(&sink_c->stream);
 

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -126,7 +126,7 @@ static int selector_verify_params(struct comp_dev *dev,
 
 	/* set component period frames */
 	sink_c = buffer_acquire(sinkb);
-	component_set_nearest_period_frames(dev, sink_c->stream.rate);
+	component_set_nearest_period_frames(dev, audio_stream_get_rate(&sink_c->stream));
 	buffer_release(sink_c);
 
 	/* verify input channels */
@@ -791,7 +791,7 @@ static int selector_verify_params(struct processing_module *mod,
 	/* set component period frames */
 	buffer = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
 	buffer_c = buffer_acquire(buffer);
-	component_set_nearest_period_frames(dev, buffer_c->stream.rate);
+	component_set_nearest_period_frames(dev, audio_stream_get_rate(&buffer_c->stream));
 	buffer_release(buffer_c);
 
 	return 0;

--- a/src/audio/selector/selector_generic.c
+++ b/src/audio/selector/selector_generic.c
@@ -36,7 +36,7 @@ static void sel_s16le_1ch(struct comp_dev *dev, struct audio_stream __sparse_cac
 			  const struct audio_stream __sparse_cache *source, uint32_t frames)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
-	int16_t *src = source->r_ptr;
+	int16_t *src = audio_stream_get_rptr(source);
 	int16_t *dest = sink->w_ptr;
 	int16_t *src_ch;
 	int nmax;
@@ -75,7 +75,7 @@ static void sel_s16le_1ch(struct comp_dev *dev, struct audio_stream __sparse_cac
 static void sel_s16le_nch(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
 			  const struct audio_stream __sparse_cache *source, uint32_t frames)
 {
-	int8_t *src = (int8_t *)source->r_ptr;
+	int8_t *src = audio_stream_get_rptr(source);
 	int8_t *dst = (int8_t *)sink->w_ptr;
 	int bmax;
 	int b;
@@ -108,7 +108,7 @@ static void sel_s32le_1ch(struct comp_dev *dev, struct audio_stream __sparse_cac
 			  const struct audio_stream __sparse_cache *source, uint32_t frames)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
-	int32_t *src = source->r_ptr;
+	int32_t *src = audio_stream_get_rptr(source);
 	int32_t *dest = sink->w_ptr;
 	int32_t *src_ch;
 	int nmax;
@@ -147,7 +147,7 @@ static void sel_s32le_1ch(struct comp_dev *dev, struct audio_stream __sparse_cac
 static void sel_s32le_nch(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
 			  const struct audio_stream __sparse_cache *source, uint32_t frames)
 {
-	int8_t *src = (int8_t *)source->r_ptr;
+	int8_t *src = audio_stream_get_rptr(source);
 	int8_t *dst = (int8_t *)sink->w_ptr;
 	int bmax;
 	int b;
@@ -208,7 +208,7 @@ static void sel_s16le(struct processing_module *mod, struct input_stream_buffer 
 	struct comp_data *cd = module_get_private_data(mod);
 	struct audio_stream __sparse_cache *source = bsource->data;
 	struct audio_stream __sparse_cache *sink = bsink->data;
-	int16_t *src = source->r_ptr;
+	int16_t *src = audio_stream_get_rptr(source);
 	int16_t *dest = sink->w_ptr;
 	int nmax;
 	int i;
@@ -279,7 +279,7 @@ static void sel_s32le(struct processing_module *mod, struct input_stream_buffer 
 	struct comp_data *cd = module_get_private_data(mod);
 	struct audio_stream __sparse_cache *source = bsource->data;
 	struct audio_stream __sparse_cache *sink = bsink->data;
-	int32_t *src = source->r_ptr;
+	int32_t *src = audio_stream_get_rptr(source);
 	int32_t *dest = sink->w_ptr;
 	int nmax;
 	int i;

--- a/src/audio/selector/selector_generic.c
+++ b/src/audio/selector/selector_generic.c
@@ -37,7 +37,7 @@ static void sel_s16le_1ch(struct comp_dev *dev, struct audio_stream __sparse_cac
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 	int16_t *src = audio_stream_get_rptr(source);
-	int16_t *dest = sink->w_ptr;
+	int16_t *dest = audio_stream_get_wptr(sink);
 	int16_t *src_ch;
 	int nmax;
 	int i;
@@ -76,7 +76,7 @@ static void sel_s16le_nch(struct comp_dev *dev, struct audio_stream __sparse_cac
 			  const struct audio_stream __sparse_cache *source, uint32_t frames)
 {
 	int8_t *src = audio_stream_get_rptr(source);
-	int8_t *dst = (int8_t *)sink->w_ptr;
+	int8_t *dst = audio_stream_get_wptr(sink);
 	int bmax;
 	int b;
 	int bytes_copied = 0;
@@ -109,7 +109,7 @@ static void sel_s32le_1ch(struct comp_dev *dev, struct audio_stream __sparse_cac
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 	int32_t *src = audio_stream_get_rptr(source);
-	int32_t *dest = sink->w_ptr;
+	int32_t *dest = audio_stream_get_wptr(sink);
 	int32_t *src_ch;
 	int nmax;
 	int i;
@@ -148,7 +148,7 @@ static void sel_s32le_nch(struct comp_dev *dev, struct audio_stream __sparse_cac
 			  const struct audio_stream __sparse_cache *source, uint32_t frames)
 {
 	int8_t *src = audio_stream_get_rptr(source);
-	int8_t *dst = (int8_t *)sink->w_ptr;
+	int8_t *dst = audio_stream_get_wptr(sink);
 	int bmax;
 	int b;
 	int bytes_copied = 0;
@@ -209,7 +209,7 @@ static void sel_s16le(struct processing_module *mod, struct input_stream_buffer 
 	struct audio_stream __sparse_cache *source = bsource->data;
 	struct audio_stream __sparse_cache *sink = bsink->data;
 	int16_t *src = audio_stream_get_rptr(source);
-	int16_t *dest = sink->w_ptr;
+	int16_t *dest = audio_stream_get_wptr(sink);
 	int nmax;
 	int i;
 	int n;
@@ -280,7 +280,7 @@ static void sel_s32le(struct processing_module *mod, struct input_stream_buffer 
 	struct audio_stream __sparse_cache *source = bsource->data;
 	struct audio_stream __sparse_cache *sink = bsink->data;
 	int32_t *src = audio_stream_get_rptr(source);
-	int32_t *dest = sink->w_ptr;
+	int32_t *dest = audio_stream_get_wptr(sink);
 	int nmax;
 	int i;
 	int n;

--- a/src/audio/selector/selector_generic.c
+++ b/src/audio/selector/selector_generic.c
@@ -44,7 +44,7 @@ static void sel_s16le_1ch(struct comp_dev *dev, struct audio_stream __sparse_cac
 	int n;
 	int processed = 0;
 	const int source_frame_bytes = audio_stream_frame_bytes(source);
-	const unsigned int nch = source->channels;
+	const unsigned int nch = audio_stream_get_channels(source);
 	const unsigned int sel_channel = cd->config.sel_channel; /* 0 to nch - 1 */
 
 	while (processed < frames) {
@@ -116,7 +116,7 @@ static void sel_s32le_1ch(struct comp_dev *dev, struct audio_stream __sparse_cac
 	int n;
 	int processed = 0;
 	const int source_frame_bytes = audio_stream_frame_bytes(source);
-	const unsigned int nch = source->channels;
+	const unsigned int nch = audio_stream_get_channels(source);
 	const unsigned int sel_channel = cd->config.sel_channel; /* 0 to nch - 1 */
 
 	while (processed < frames) {
@@ -216,8 +216,8 @@ static void sel_s16le(struct processing_module *mod, struct input_stream_buffer 
 	int processed = 0;
 	int source_frame_bytes = audio_stream_frame_bytes(source);
 	int sink_frame_bytes = audio_stream_frame_bytes(sink);
-	int n_chan_source = MIN(SEL_SOURCE_CHANNELS_MAX, source->channels);
-	int n_chan_sink = MIN(SEL_SINK_CHANNELS_MAX, sink->channels);
+	int n_chan_source = MIN(SEL_SOURCE_CHANNELS_MAX, audio_stream_get_channels(source));
+	int n_chan_sink = MIN(SEL_SINK_CHANNELS_MAX, audio_stream_get_channels(sink));
 
 	while (processed < frames) {
 		n = frames - processed;
@@ -228,8 +228,8 @@ static void sel_s16le(struct processing_module *mod, struct input_stream_buffer 
 		for (i = 0; i < n; i++) {
 			process_frame_s16le(dest, n_chan_sink, src, n_chan_source,
 					    &cd->coeffs_config);
-			src += source->channels;
-			dest += sink->channels;
+			src += audio_stream_get_channels(source);
+			dest += audio_stream_get_channels(sink);
 		}
 		src = audio_stream_wrap(source, src);
 		dest = audio_stream_wrap(sink, dest);
@@ -287,8 +287,8 @@ static void sel_s32le(struct processing_module *mod, struct input_stream_buffer 
 	int processed = 0;
 	int source_frame_bytes = audio_stream_frame_bytes(source);
 	int sink_frame_bytes = audio_stream_frame_bytes(sink);
-	int n_chan_source = MIN(SEL_SOURCE_CHANNELS_MAX, source->channels);
-	int n_chan_sink = MIN(SEL_SINK_CHANNELS_MAX, sink->channels);
+	int n_chan_source = MIN(SEL_SOURCE_CHANNELS_MAX, audio_stream_get_channels(source));
+	int n_chan_sink = MIN(SEL_SINK_CHANNELS_MAX, audio_stream_get_channels(sink));
 
 	while (processed < frames) {
 		n = frames - processed;
@@ -299,8 +299,8 @@ static void sel_s32le(struct processing_module *mod, struct input_stream_buffer 
 		for (i = 0; i < n; i++) {
 			process_frame_s32le(dest, n_chan_sink, src, n_chan_source,
 					    &cd->coeffs_config);
-			src += source->channels;
-			dest += sink->channels;
+			src += audio_stream_get_channels(source);
+			dest += audio_stream_get_channels(sink);
 		}
 		src = audio_stream_wrap(source, src);
 		dest = audio_stream_wrap(sink, dest);

--- a/src/audio/smart_amp/smart_amp.c
+++ b/src/audio/smart_amp/smart_amp.c
@@ -558,8 +558,12 @@ static int smart_amp_process(struct comp_dev *dev,
 static smart_amp_proc get_smart_amp_process(struct comp_dev *dev)
 {
 	struct smart_amp_data *sad = comp_get_drvdata(dev);
+	struct comp_buffer __sparse_cache *source_buf = buffer_acquire(sad->source_buf);
+	enum sof_ipc_frame fmt = audio_stream_get_frm_fmt(&source_buf->stream);
 
-	switch (sad->source_buf->stream.frame_fmt) {
+	buffer_release(source_buf);
+
+	switch (fmt) {
 	case SOF_IPC_FRAME_S16_LE:
 	case SOF_IPC_FRAME_S24_4LE:
 	case SOF_IPC_FRAME_S32_LE:
@@ -710,7 +714,7 @@ static int smart_amp_prepare(struct comp_dev *dev)
 		}
 	}
 
-	switch (source_c->stream.frame_fmt) {
+	switch (audio_stream_get_frm_fmt(&source_c->stream)) {
 	case SOF_IPC_FRAME_S16_LE:
 		bitwidth = 16;
 		break;
@@ -722,7 +726,7 @@ static int smart_amp_prepare(struct comp_dev *dev)
 		break;
 	default:
 		comp_err(dev, "[DSM] smart_amp_process() error: not supported frame format %d",
-			 source_c->stream.frame_fmt);
+			 audio_stream_get_frm_fmt(&source_c->stream));
 		goto error;
 	}
 

--- a/src/audio/smart_amp/smart_amp.c
+++ b/src/audio/smart_amp/smart_amp.c
@@ -701,14 +701,14 @@ static int smart_amp_prepare(struct comp_dev *dev)
 		buf_c = buffer_acquire(sad->feedback_buf);
 
 		buf_c->stream.channels = sad->config.feedback_channels;
-		buf_c->stream.rate = source_c->stream.rate;
+		buf_c->stream.rate = audio_stream_get_rate(&source_c->stream);
 		buffer_release(buf_c);
 
-		ret = smart_amp_check_audio_fmt(source_c->stream.rate,
+		ret = smart_amp_check_audio_fmt(audio_stream_get_rate(&source_c->stream),
 						source_c->stream.channels);
 		if (ret) {
 			comp_err(dev, "[DSM] Format not supported, sample rate: %d, ch: %d",
-				 source_c->stream.rate,
+				 audio_stream_get_rate(&source_c->stream),
 				 source_c->stream.channels);
 			goto error;
 		}

--- a/src/audio/smart_amp/smart_amp.c
+++ b/src/audio/smart_amp/smart_amp.c
@@ -551,7 +551,7 @@ static int smart_amp_process(struct comp_dev *dev,
 		ret = smart_amp_fb_copy(dev, frames,
 					source, sink,
 					chan_map, sad->mod_handle,
-					source->channels);
+					audio_stream_get_channels(source));
 	return ret;
 }
 
@@ -682,7 +682,7 @@ static int smart_amp_prepare(struct comp_dev *dev)
 			sad->feedback_buf = source_buffer;
 		} else {
 			sad->source_buf = source_buffer;
-			sad->in_channels = source_c->stream.channels;
+			sad->in_channels = audio_stream_get_channels(&source_c->stream);
 		}
 
 		buffer_release(source_c);
@@ -692,7 +692,7 @@ static int smart_amp_prepare(struct comp_dev *dev)
 					source_list);
 
 	buf_c = buffer_acquire(sad->sink_buf);
-	sad->out_channels = buf_c->stream.channels;
+	sad->out_channels = audio_stream_get_channels(&buf_c->stream);
 	buffer_release(buf_c);
 
 	source_c = buffer_acquire(sad->source_buf);
@@ -705,11 +705,11 @@ static int smart_amp_prepare(struct comp_dev *dev)
 		buffer_release(buf_c);
 
 		ret = smart_amp_check_audio_fmt(audio_stream_get_rate(&source_c->stream),
-						source_c->stream.channels);
+						audio_stream_get_channels(&source_c->stream));
 		if (ret) {
 			comp_err(dev, "[DSM] Format not supported, sample rate: %d, ch: %d",
 				 audio_stream_get_rate(&source_c->stream),
-				 source_c->stream.channels);
+				 audio_stream_get_channels(&source_c->stream));
 			goto error;
 		}
 	}

--- a/src/audio/smart_amp/smart_amp_generic.c
+++ b/src/audio/smart_amp/smart_amp_generic.c
@@ -35,7 +35,7 @@ static void smart_amp_s16_ff_default(const struct comp_dev *dev,
 	int idx;
 	int ch;
 	int i;
-	int nch = source->channels;
+	int nch = audio_stream_get_channels(source);
 
 	for (ch = 0; ch < nch; ch++) {
 		idx = ch;
@@ -63,7 +63,7 @@ static void smart_amp_s24_ff_default(const struct comp_dev *dev,
 	int idx;
 	int ch;
 	int i;
-	int nch = source->channels;
+	int nch = audio_stream_get_channels(source);
 
 	for (ch = 0; ch < nch; ch++) {
 		idx = ch;
@@ -90,7 +90,7 @@ static void smart_amp_s32_ff_default(const struct comp_dev *dev,
 	int idx;
 	int ch;
 	int i;
-	int nch = source->channels;
+	int nch = audio_stream_get_channels(source);
 
 	for (ch = 0; ch < nch; ch++) {
 		idx = ch;
@@ -115,7 +115,7 @@ static void smart_amp_s16_fb_default(const struct comp_dev *dev,
 	int idx;
 	int ch;
 	int i;
-	int nch = source->channels;
+	int nch = audio_stream_get_channels(source);
 
 	for (ch = 0; ch < nch; ch++) {
 		idx = ch;
@@ -139,7 +139,7 @@ static void smart_amp_s24_fb_default(const struct comp_dev *dev,
 	int idx;
 	int ch;
 	int i;
-	int nch = source->channels;
+	int nch = audio_stream_get_channels(source);
 
 	for (ch = 0; ch < nch; ch++) {
 		idx = ch;
@@ -163,7 +163,7 @@ static void smart_amp_s32_fb_default(const struct comp_dev *dev,
 	int idx;
 	int ch;
 	int i;
-	int nch = source->channels;
+	int nch = audio_stream_get_channels(source);
 
 	for (ch = 0; ch < nch; ch++) {
 		idx = ch;

--- a/src/audio/smart_amp/smart_amp_maxim_dsm.c
+++ b/src/audio/smart_amp/smart_amp_maxim_dsm.c
@@ -592,7 +592,7 @@ static int smart_amp_get_buffer(int32_t *buf, uint32_t frames,
 	output.buf16 = (int16_t *)buf;
 	output.buf32 = (int32_t *)buf;
 
-	switch (stream->frame_fmt) {
+	switch (audio_stream_get_frm_fmt(stream)) {
 	case SOF_IPC_FRAME_S16_LE:
 		for (idx = 0 ; idx < frames ; idx++) {
 			for (ch = 0 ; ch < num_ch; ch++) {
@@ -642,7 +642,7 @@ static int smart_amp_put_buffer(int32_t *buf, uint32_t frames,
 	output.buf16 = audio_stream_get_wptr(stream);
 	output.buf32 = audio_stream_get_wptr(stream);
 
-	switch (stream->frame_fmt) {
+	switch (audio_stream_get_frm_fmt(stream)) {
 	case SOF_IPC_FRAME_S16_LE:
 		for (idx = 0 ; idx < frames ; idx++) {
 			for (ch = 0 ; ch < num_ch_out; ch++) {
@@ -708,7 +708,7 @@ int smart_amp_ff_copy(struct comp_dev *dev, uint32_t frames,
 	if (ret)
 		goto err;
 
-	switch (source->frame_fmt) {
+	switch (audio_stream_get_frm_fmt(source)) {
 	case SOF_IPC_FRAME_S16_LE:
 		maxim_dsm_ff_proc(hspk, dev,
 				  hspk->buf.frame_in,
@@ -767,7 +767,7 @@ int smart_amp_fb_copy(struct comp_dev *dev, uint32_t frames,
 	if (ret)
 		goto err;
 
-	switch (source->frame_fmt) {
+	switch (audio_stream_get_frm_fmt(source)) {
 	case SOF_IPC_FRAME_S16_LE:
 		maxim_dsm_fb_proc(hspk, dev, hspk->buf.frame_iv,
 				  frames * num_ch, sizeof(int16_t));
@@ -784,6 +784,6 @@ int smart_amp_fb_copy(struct comp_dev *dev, uint32_t frames,
 	return 0;
 err:
 	comp_err(dev, "[DSM] Not supported frame format : %d",
-		 source->frame_fmt);
+		 audio_stream_get_frm_fmt(source));
 	return ret;
 }

--- a/src/audio/smart_amp/smart_amp_maxim_dsm.c
+++ b/src/audio/smart_amp/smart_amp_maxim_dsm.c
@@ -639,8 +639,8 @@ static int smart_amp_put_buffer(int32_t *buf, uint32_t frames,
 
 	input.buf16 = (int16_t *)buf;
 	input.buf32 = (int32_t *)buf;
-	output.buf16 = (int16_t *)stream->w_ptr;
-	output.buf32 = (int32_t *)stream->w_ptr;
+	output.buf16 = audio_stream_get_wptr(stream);
+	output.buf32 = audio_stream_get_wptr(stream);
 
 	switch (stream->frame_fmt) {
 	case SOF_IPC_FRAME_S16_LE:

--- a/src/audio/smart_amp/smart_amp_maxim_dsm.c
+++ b/src/audio/smart_amp/smart_amp_maxim_dsm.c
@@ -587,8 +587,8 @@ static int smart_amp_get_buffer(int32_t *buf, uint32_t frames,
 	union smart_amp_buf input, output;
 	int index;
 
-	input.buf16 = (int16_t *)stream->r_ptr;
-	input.buf32 = (int32_t *)stream->r_ptr;
+	input.buf16 = audio_stream_get_rptr(stream);
+	input.buf32 = audio_stream_get_rptr(stream);
 	output.buf16 = (int16_t *)buf;
 	output.buf32 = (int32_t *)buf;
 

--- a/src/audio/smart_amp/smart_amp_maxim_dsm.c
+++ b/src/audio/smart_amp/smart_amp_maxim_dsm.c
@@ -604,7 +604,7 @@ static int smart_amp_get_buffer(int32_t *buf, uint32_t frames,
 								   index);
 				output.buf16[num_ch * idx + ch] = *input.buf16;
 			}
-			in_frag += stream->channels;
+			in_frag += audio_stream_get_channels(stream);
 		}
 		break;
 	case SOF_IPC_FRAME_S24_4LE:
@@ -619,7 +619,7 @@ static int smart_amp_get_buffer(int32_t *buf, uint32_t frames,
 								   index);
 				output.buf32[num_ch * idx + ch] = *input.buf32;
 			}
-			in_frag += stream->channels;
+			in_frag += audio_stream_get_channels(stream);
 		}
 		break;
 	default:

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -380,7 +380,7 @@ static void src_2s(struct comp_dev *dev, struct comp_data *cd,
 
 	s2.x_end_addr = sbuf_end_addr;
 	s2.x_size = sbuf_size;
-	s2.y_addr = sink->addr;
+	s2.y_addr = audio_stream_get_addr(sink);
 	s2.y_end_addr = audio_stream_get_end_addr(sink);
 	s2.y_size = sink->size;
 	s2.state = &cd->src.state2;

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -366,7 +366,7 @@ static void src_2s(struct comp_dev *dev, struct comp_data *cd,
 
 	*n_read = 0;
 	*n_written = 0;
-	s1.x_end_addr = source->end_addr;
+	s1.x_end_addr = audio_stream_get_end_addr(source);
 	s1.x_size = source->size;
 	s1.y_addr = sbuf_addr;
 	s1.y_end_addr = sbuf_end_addr;
@@ -381,7 +381,7 @@ static void src_2s(struct comp_dev *dev, struct comp_data *cd,
 	s2.x_end_addr = sbuf_end_addr;
 	s2.x_size = sbuf_size;
 	s2.y_addr = sink->addr;
-	s2.y_end_addr = sink->end_addr;
+	s2.y_end_addr = audio_stream_get_end_addr(sink);
 	s2.y_size = sink->size;
 	s2.state = &cd->src.state2;
 	s2.stage = cd->src.stage2;
@@ -443,10 +443,10 @@ static void src_1s(struct comp_dev *dev, struct comp_data *cd,
 
 	s1.times = cd->param.stage1_times;
 	s1.x_rptr = audio_stream_get_rptr(source);
-	s1.x_end_addr = source->end_addr;
+	s1.x_end_addr = audio_stream_get_end_addr(source);
 	s1.x_size = source->size;
 	s1.y_wptr = audio_stream_get_wptr(sink);
-	s1.y_end_addr = sink->end_addr;
+	s1.y_end_addr = audio_stream_get_end_addr(sink);
 	s1.y_size = sink->size;
 	s1.state = &cd->src.state1;
 	s1.stage = cd->src.stage1;

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -373,7 +373,7 @@ static void src_2s(struct comp_dev *dev, struct comp_data *cd,
 	s1.y_size = sbuf_size;
 	s1.state = &cd->src.state1;
 	s1.stage = cd->src.stage1;
-	s1.x_rptr = source->r_ptr;
+	s1.x_rptr = audio_stream_get_rptr(source);
 	s1.y_wptr = cd->sbuf_w_ptr;
 	s1.nch = nch;
 	s1.shift = cd->data_shift;
@@ -442,7 +442,7 @@ static void src_1s(struct comp_dev *dev, struct comp_data *cd,
 	struct src_stage_prm s1;
 
 	s1.times = cd->param.stage1_times;
-	s1.x_rptr = source->r_ptr;
+	s1.x_rptr = audio_stream_get_rptr(source);
 	s1.x_end_addr = source->end_addr;
 	s1.x_size = source->size;
 	s1.y_wptr = sink->w_ptr;

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -467,7 +467,7 @@ static void src_copy_sxx(struct comp_dev *dev, struct comp_data *cd,
 {
 	int frames = cd->param.blk_in;
 
-	switch (sink->frame_fmt) {
+	switch (audio_stream_get_frm_fmt(sink)) {
 	case SOF_IPC_FRAME_S16_LE:
 	case SOF_IPC_FRAME_S24_4LE:
 	case SOF_IPC_FRAME_S32_LE:
@@ -766,7 +766,7 @@ static int src_params_general(struct comp_dev *dev, struct comp_data *cd,
 
 	/* Allocate needed memory for delay lines */
 	comp_info(dev, "src_params(), source_rate = %u, sink_rate = %u, format = %d",
-		  cd->source_rate, cd->sink_rate, source_c->stream.frame_fmt);
+		  cd->source_rate, cd->sink_rate, audio_stream_get_frm_fmt(&source_c->stream));
 	comp_info(dev, "src_params(), sourceb->channels = %u, sinkb->channels = %u, dev->frames = %u",
 		  source_c->stream.channels, sink_c->stream.channels, dev->frames);
 	err = src_buffer_lengths(dev, cd, source_c->stream.channels);
@@ -861,8 +861,8 @@ static int src_prepare_general(struct comp_dev *dev, struct comp_data *cd)
 #endif
 
 	/* get source/sink data format */
-	source_format = source_c->stream.frame_fmt;
-	sink_format = sink_c->stream.frame_fmt;
+	source_format = audio_stream_get_frm_fmt(&source_c->stream);
+	sink_format = audio_stream_get_frm_fmt(&sink_c->stream);
 
 	ret = src_check_buffer_sizes(dev, cd, &source_c->stream, &sink_c->stream);
 	if (ret < 0)

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -533,13 +533,17 @@ static void src_set_sink_params(struct comp_dev *dev, struct comp_buffer __spars
 {
 	struct processing_module *mod = comp_get_drvdata(dev);
 	struct comp_data *cd = module_get_private_data(mod);
+	enum sof_ipc_frame frame_fmt, valid_fmt;
 
 	/* convert IPC4 config to format used by the module */
 	audio_stream_fmt_conversion(cd->ipc_config.base.audio_fmt.depth,
 				    cd->ipc_config.base.audio_fmt.valid_bit_depth,
-				    &sinkb->stream.frame_fmt,
-				    &sinkb->stream.valid_sample_fmt,
+				    &frame_fmt, &valid_fmt,
 				    cd->ipc_config.base.audio_fmt.s_type);
+
+	sinkb->stream.frame_fmt = frame_fmt;
+	sinkb->stream.valid_sample_fmt = valid_fmt;
+
 	sinkb->stream.channels = cd->ipc_config.base.audio_fmt.channels_count;
 	sinkb->buffer_fmt = cd->ipc_config.base.audio_fmt.interleaving_style;
 }

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -367,7 +367,7 @@ static void src_2s(struct comp_dev *dev, struct comp_data *cd,
 	*n_read = 0;
 	*n_written = 0;
 	s1.x_end_addr = audio_stream_get_end_addr(source);
-	s1.x_size = source->size;
+	s1.x_size = audio_stream_get_size(source);
 	s1.y_addr = sbuf_addr;
 	s1.y_end_addr = sbuf_end_addr;
 	s1.y_size = sbuf_size;
@@ -382,7 +382,7 @@ static void src_2s(struct comp_dev *dev, struct comp_data *cd,
 	s2.x_size = sbuf_size;
 	s2.y_addr = audio_stream_get_addr(sink);
 	s2.y_end_addr = audio_stream_get_end_addr(sink);
-	s2.y_size = sink->size;
+	s2.y_size = audio_stream_get_size(sink);
 	s2.state = &cd->src.state2;
 	s2.stage = cd->src.stage2;
 	s2.x_rptr = cd->sbuf_r_ptr;
@@ -444,10 +444,10 @@ static void src_1s(struct comp_dev *dev, struct comp_data *cd,
 	s1.times = cd->param.stage1_times;
 	s1.x_rptr = audio_stream_get_rptr(source);
 	s1.x_end_addr = audio_stream_get_end_addr(source);
-	s1.x_size = source->size;
+	s1.x_size = audio_stream_get_size(source);
 	s1.y_wptr = audio_stream_get_wptr(sink);
 	s1.y_end_addr = audio_stream_get_end_addr(sink);
-	s1.y_size = sink->size;
+	s1.y_size = audio_stream_get_size(sink);
 	s1.state = &cd->src.state1;
 	s1.stage = cd->src.stage1;
 	s1.nch = source->channels;
@@ -701,15 +701,15 @@ static int src_check_buffer_sizes(struct comp_dev *dev, struct comp_data *cd,
 	}
 
 	n = audio_stream_frame_bytes(source_stream) * (blk_in + cd->source_frames);
-	if (source_stream->size < n) {
+	if (audio_stream_get_size(source_stream) < n) {
 		comp_warn(dev, "Source size %d is less than required %d",
-			  source_stream->size, n);
+			  audio_stream_get_size(source_stream), n);
 	}
 
 	n = audio_stream_frame_bytes(sink_stream) * (blk_out + cd->sink_frames);
-	if (sink_stream->size < n) {
+	if (audio_stream_get_size(sink_stream) < n) {
 		comp_warn(dev, "Sink size %d is less than required %d",
-			  sink_stream->size, n);
+			  audio_stream_get_size(sink_stream), n);
 	}
 
 	return 0;
@@ -1145,7 +1145,7 @@ static void src_process(struct comp_dev *dev, struct comp_buffer __sparse_cache 
 	int produced = 0;
 
 	/* consumed bytes are not known at this point */
-	buffer_stream_invalidate(source, source->stream.size);
+	buffer_stream_invalidate(source, audio_stream_get_size(&source->stream));
 	cd->src_func(dev, cd, &source->stream, &sink->stream, &consumed, &produced);
 	buffer_stream_writeback(sink, produced * audio_stream_frame_bytes(&sink->stream));
 

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -386,7 +386,7 @@ static void src_2s(struct comp_dev *dev, struct comp_data *cd,
 	s2.state = &cd->src.state2;
 	s2.stage = cd->src.stage2;
 	s2.x_rptr = cd->sbuf_r_ptr;
-	s2.y_wptr = sink->w_ptr;
+	s2.y_wptr = audio_stream_get_wptr(sink);
 	s2.nch = nch;
 	s2.shift = cd->data_shift;
 
@@ -445,7 +445,7 @@ static void src_1s(struct comp_dev *dev, struct comp_data *cd,
 	s1.x_rptr = audio_stream_get_rptr(source);
 	s1.x_end_addr = source->end_addr;
 	s1.x_size = source->size;
-	s1.y_wptr = sink->w_ptr;
+	s1.y_wptr = audio_stream_get_wptr(sink);
 	s1.y_end_addr = sink->end_addr;
 	s1.y_size = sink->size;
 	s1.state = &cd->src.state1;

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -752,8 +752,8 @@ static int src_params_general(struct comp_dev *dev, struct comp_data *cd,
 	src_set_sink_params(dev, sink_c);
 
 	/* Set source/sink_rate/frames */
-	cd->source_rate = source_c->stream.rate;
-	cd->sink_rate = sink_c->stream.rate;
+	cd->source_rate = audio_stream_get_rate(&source_c->stream);
+	cd->sink_rate = audio_stream_get_rate(&sink_c->stream);
 	if (!cd->sink_rate) {
 		comp_err(dev, "src_params(), zero sink rate");
 

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -358,7 +358,7 @@ static void src_2s(struct comp_dev *dev, struct comp_data *cd,
 	void *sbuf_addr = cd->delay_lines;
 	void *sbuf_end_addr = &cd->delay_lines[cd->param.sbuf_length];
 	size_t sbuf_size = cd->param.sbuf_length * sizeof(int32_t);
-	int nch = source->channels;
+	int nch = audio_stream_get_channels(source);
 	int sbuf_free = cd->param.sbuf_length - cd->sbuf_avail;
 	int avail_b = audio_stream_get_avail_bytes(source);
 	int free_b = audio_stream_get_free_bytes(sink);
@@ -450,7 +450,7 @@ static void src_1s(struct comp_dev *dev, struct comp_data *cd,
 	s1.y_size = audio_stream_get_size(sink);
 	s1.state = &cd->src.state1;
 	s1.stage = cd->src.stage1;
-	s1.nch = source->channels;
+	s1.nch = audio_stream_get_channels(source);
 	s1.shift = cd->data_shift;
 
 	cd->polyphase_func(&s1);
@@ -472,7 +472,7 @@ static void src_copy_sxx(struct comp_dev *dev, struct comp_data *cd,
 	case SOF_IPC_FRAME_S24_4LE:
 	case SOF_IPC_FRAME_S32_LE:
 		audio_stream_copy(source, 0, sink, 0,
-				  frames * source->channels);
+				  frames * audio_stream_get_channels(source));
 		*n_read = frames;
 		*n_written = frames;
 		break;
@@ -767,9 +767,11 @@ static int src_params_general(struct comp_dev *dev, struct comp_data *cd,
 	/* Allocate needed memory for delay lines */
 	comp_info(dev, "src_params(), source_rate = %u, sink_rate = %u, format = %d",
 		  cd->source_rate, cd->sink_rate, audio_stream_get_frm_fmt(&source_c->stream));
-	comp_info(dev, "src_params(), sourceb->channels = %u, sinkb->channels = %u, dev->frames = %u",
-		  source_c->stream.channels, sink_c->stream.channels, dev->frames);
-	err = src_buffer_lengths(dev, cd, source_c->stream.channels);
+	comp_info(dev,
+		  "src_params(), sourceb->channels = %u, sinkb->channels = %u, dev->frames = %u",
+		  audio_stream_get_channels(&source_c->stream), sink_c->stream.channels,
+		  dev->frames);
+	err = src_buffer_lengths(dev, cd, audio_stream_get_channels(&source_c->stream));
 	if (err < 0) {
 		comp_err(dev, "src_params(): src_buffer_lengths() failed");
 		goto out;

--- a/src/audio/tdfb/tdfb.c
+++ b/src/audio/tdfb/tdfb.c
@@ -745,7 +745,7 @@ static int tdfb_prepare(struct processing_module *mod)
 	sink_c = buffer_acquire(sinkb);
 	tdfb_set_alignment(&source_c->stream, &sink_c->stream);
 
-	frame_fmt = source_c->stream.frame_fmt;
+	frame_fmt = audio_stream_get_frm_fmt(&source_c->stream);
 	source_channels = source_c->stream.channels;
 	sink_channels = sink_c->stream.channels;
 	rate = source_c->stream.rate;

--- a/src/audio/tdfb/tdfb.c
+++ b/src/audio/tdfb/tdfb.c
@@ -671,7 +671,8 @@ static int tdfb_process(struct processing_module *mod,
 	/* Check for changed configuration */
 	if (comp_is_new_data_blob_available(cd->model_handler)) {
 		cd->config = comp_get_data_blob(cd->model_handler, NULL, NULL);
-		ret = tdfb_setup(mod, source->channels, sink->channels);
+		ret = tdfb_setup(mod, audio_stream_get_channels(source),
+				 audio_stream_get_channels(sink));
 		if (ret < 0) {
 			comp_err(dev, "tdfb_process(), failed FIR setup");
 			return ret;
@@ -681,7 +682,8 @@ static int tdfb_process(struct processing_module *mod,
 	/* Handle enum controls */
 	if (cd->update) {
 		cd->update = false;
-		ret = tdfb_setup(mod, source->channels, sink->channels);
+		ret = tdfb_setup(mod, audio_stream_get_channels(source),
+				 audio_stream_get_channels(sink));
 		if (ret < 0) {
 			comp_err(dev, "tdfb_process(), failed FIR setup");
 			return ret;
@@ -699,7 +701,7 @@ static int tdfb_process(struct processing_module *mod,
 		module_update_buffer_position(input_buffers, output_buffers, frame_count);
 
 		/* Update sound direction estimate */
-		tdfb_direction_estimate(cd, frame_count, source->channels);
+		tdfb_direction_estimate(cd, frame_count, audio_stream_get_channels(source));
 		comp_dbg(dev, "tdfb_dint %u %d %d %d", cd->direction.trigger, cd->direction.level,
 			 (int32_t)(cd->direction.level_ambient >> 32), cd->direction.az_slow);
 
@@ -746,8 +748,8 @@ static int tdfb_prepare(struct processing_module *mod)
 	tdfb_set_alignment(&source_c->stream, &sink_c->stream);
 
 	frame_fmt = audio_stream_get_frm_fmt(&source_c->stream);
-	source_channels = source_c->stream.channels;
-	sink_channels = sink_c->stream.channels;
+	source_channels = audio_stream_get_channels(&source_c->stream);
+	sink_channels = audio_stream_get_channels(&sink_c->stream);
 	rate = audio_stream_get_rate(&source_c->stream);
 	buffer_release(sink_c);
 	buffer_release(source_c);

--- a/src/audio/tdfb/tdfb.c
+++ b/src/audio/tdfb/tdfb.c
@@ -748,7 +748,7 @@ static int tdfb_prepare(struct processing_module *mod)
 	frame_fmt = audio_stream_get_frm_fmt(&source_c->stream);
 	source_channels = source_c->stream.channels;
 	sink_channels = sink_c->stream.channels;
-	rate = source_c->stream.rate;
+	rate = audio_stream_get_rate(&source_c->stream);
 	buffer_release(sink_c);
 	buffer_release(source_c);
 

--- a/src/audio/tdfb/tdfb_generic.c
+++ b/src/audio/tdfb/tdfb_generic.c
@@ -61,7 +61,7 @@ void tdfb_fir_s16(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource
 	struct audio_stream __sparse_cache *source = bsource->data;
 	struct audio_stream __sparse_cache *sink = bsink->data;
 	int16_t *x = audio_stream_get_rptr(source);
-	int16_t *y = sink->w_ptr;
+	int16_t *y = audio_stream_get_wptr(sink);
 	int fmax;
 	int i;
 	int j;
@@ -107,7 +107,7 @@ void tdfb_fir_s24(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource
 	struct audio_stream __sparse_cache *source = bsource->data;
 	struct audio_stream __sparse_cache *sink = bsink->data;
 	int32_t *x = audio_stream_get_rptr(source);
-	int32_t *y = sink->w_ptr;
+	int32_t *y = audio_stream_get_wptr(sink);
 	int fmax;
 	int i;
 	int j;
@@ -153,7 +153,7 @@ void tdfb_fir_s32(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource
 	struct audio_stream __sparse_cache *source = bsource->data;
 	struct audio_stream __sparse_cache *sink = bsink->data;
 	int32_t *x = audio_stream_get_rptr(source);
-	int32_t *y = sink->w_ptr;
+	int32_t *y = audio_stream_get_wptr(sink);
 	int fmax;
 	int i;
 	int j;

--- a/src/audio/tdfb/tdfb_generic.c
+++ b/src/audio/tdfb/tdfb_generic.c
@@ -60,7 +60,7 @@ void tdfb_fir_s16(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource
 {
 	struct audio_stream __sparse_cache *source = bsource->data;
 	struct audio_stream __sparse_cache *sink = bsink->data;
-	int16_t *x = source->r_ptr;
+	int16_t *x = audio_stream_get_rptr(source);
 	int16_t *y = sink->w_ptr;
 	int fmax;
 	int i;
@@ -106,7 +106,7 @@ void tdfb_fir_s24(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource
 {
 	struct audio_stream __sparse_cache *source = bsource->data;
 	struct audio_stream __sparse_cache *sink = bsink->data;
-	int32_t *x = source->r_ptr;
+	int32_t *x = audio_stream_get_rptr(source);
 	int32_t *y = sink->w_ptr;
 	int fmax;
 	int i;
@@ -152,7 +152,7 @@ void tdfb_fir_s32(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource
 {
 	struct audio_stream __sparse_cache *source = bsource->data;
 	struct audio_stream __sparse_cache *sink = bsink->data;
-	int32_t *x = source->r_ptr;
+	int32_t *x = audio_stream_get_rptr(source);
 	int32_t *y = sink->w_ptr;
 	int fmax;
 	int i;

--- a/src/audio/tdfb/tdfb_generic.c
+++ b/src/audio/tdfb/tdfb_generic.c
@@ -66,8 +66,8 @@ void tdfb_fir_s16(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource
 	int i;
 	int j;
 	int f;
-	const int in_nch = source->channels;
-	const int out_nch = sink->channels;
+	const int in_nch = audio_stream_get_channels(source);
+	const int out_nch = audio_stream_get_channels(sink);
 	int remaining_frames = frames;
 	int emp_ch = 0;
 
@@ -112,8 +112,8 @@ void tdfb_fir_s24(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource
 	int i;
 	int j;
 	int f;
-	const int in_nch = source->channels;
-	const int out_nch = sink->channels;
+	const int in_nch = audio_stream_get_channels(source);
+	const int out_nch = audio_stream_get_channels(sink);
 	int remaining_frames = frames;
 	int emp_ch = 0;
 
@@ -158,8 +158,8 @@ void tdfb_fir_s32(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource
 	int i;
 	int j;
 	int f;
-	const int in_nch = source->channels;
-	const int out_nch = sink->channels;
+	const int in_nch = audio_stream_get_channels(source);
+	const int out_nch = audio_stream_get_channels(sink);
 	int remaining_frames = frames;
 	int emp_ch = 0;
 

--- a/src/audio/tdfb/tdfb_hifi3.c
+++ b/src/audio/tdfb/tdfb_hifi3.c
@@ -26,7 +26,7 @@ void tdfb_fir_s16(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource
 	ae_int16x4 d;
 	ae_int32 y0;
 	ae_int32 y1;
-	ae_int16 *x = (ae_int16 *)source->r_ptr;
+	ae_int16 *x = audio_stream_get_rptr(source);
 	ae_int16 *y = (ae_int16 *)sink->w_ptr;
 	int shift;
 	int is2;
@@ -101,7 +101,7 @@ void tdfb_fir_s24(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource
 	ae_int32x2 d;
 	ae_int32 y0;
 	ae_int32 y1;
-	ae_int32 *x = (ae_int32 *)source->r_ptr;
+	ae_int32 *x = audio_stream_get_rptr(source);
 	ae_int32 *y = (ae_int32 *)sink->w_ptr;
 	int shift;
 	int is2;
@@ -175,7 +175,7 @@ void tdfb_fir_s32(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource
 	ae_int32x2 d;
 	ae_int32 y0;
 	ae_int32 y1;
-	ae_int32 *x = (ae_int32 *)source->r_ptr;
+	ae_int32 *x = audio_stream_get_rptr(source);
 	ae_int32 *y = (ae_int32 *)sink->w_ptr;
 	int shift;
 	int is2;

--- a/src/audio/tdfb/tdfb_hifi3.c
+++ b/src/audio/tdfb/tdfb_hifi3.c
@@ -27,7 +27,7 @@ void tdfb_fir_s16(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource
 	ae_int32 y0;
 	ae_int32 y1;
 	ae_int16 *x = audio_stream_get_rptr(source);
-	ae_int16 *y = (ae_int16 *)sink->w_ptr;
+	ae_int16 *y = audio_stream_get_wptr(sink);
 	int shift;
 	int is2;
 	int is;
@@ -102,7 +102,7 @@ void tdfb_fir_s24(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource
 	ae_int32 y0;
 	ae_int32 y1;
 	ae_int32 *x = audio_stream_get_rptr(source);
-	ae_int32 *y = (ae_int32 *)sink->w_ptr;
+	ae_int32 *y = audio_stream_get_wptr(sink);
 	int shift;
 	int is2;
 	int is;
@@ -176,7 +176,7 @@ void tdfb_fir_s32(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource
 	ae_int32 y0;
 	ae_int32 y1;
 	ae_int32 *x = audio_stream_get_rptr(source);
-	ae_int32 *y = (ae_int32 *)sink->w_ptr;
+	ae_int32 *y = audio_stream_get_wptr(sink);
 	int shift;
 	int is2;
 	int is;

--- a/src/audio/tdfb/tdfb_hifi3.c
+++ b/src/audio/tdfb/tdfb_hifi3.c
@@ -35,8 +35,8 @@ void tdfb_fir_s16(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource
 	int i;
 	int j;
 	int k;
-	int in_nch = source->channels;
-	int out_nch = sink->channels;
+	int in_nch = audio_stream_get_channels(source);
+	int out_nch = audio_stream_get_channels(sink);
 	int emp_ch = 0;
 
 	for (j = 0; j < (frames >> 1); j++) {
@@ -110,8 +110,8 @@ void tdfb_fir_s24(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource
 	int i;
 	int j;
 	int k;
-	int in_nch = source->channels;
-	int out_nch = sink->channels;
+	int in_nch = audio_stream_get_channels(source);
+	int out_nch = audio_stream_get_channels(sink);
 	int emp_ch = 0;
 
 	for (j = 0; j < (frames >> 1); j++) {
@@ -184,8 +184,8 @@ void tdfb_fir_s32(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource
 	int i;
 	int j;
 	int k;
-	int in_nch = source->channels;
-	int out_nch = sink->channels;
+	int in_nch = audio_stream_get_channels(source);
+	int out_nch = audio_stream_get_channels(sink);
 	int emp_ch = 0;
 
 	for (j = 0; j < (frames >> 1); j++) {

--- a/src/audio/tdfb/tdfb_hifiep.c
+++ b/src/audio/tdfb/tdfb_hifiep.c
@@ -61,7 +61,7 @@ void tdfb_fir_s16(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource
 	struct audio_stream __sparse_cache *source = bsource->data;
 	struct audio_stream __sparse_cache *sink = bsink->data;
 	int16_t *x = audio_stream_get_rptr(source);
-	int16_t *y = sink->w_ptr;
+	int16_t *y = audio_stream_get_wptr(sink);
 	int fmax;
 	int i;
 	int j;
@@ -107,7 +107,7 @@ void tdfb_fir_s24(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource
 	struct audio_stream __sparse_cache *source = bsource->data;
 	struct audio_stream __sparse_cache *sink = bsink->data;
 	int32_t *x = audio_stream_get_rptr(source);
-	int32_t *y = sink->w_ptr;
+	int32_t *y = audio_stream_get_wptr(sink);
 	int fmax;
 	int i;
 	int j;
@@ -153,7 +153,7 @@ void tdfb_fir_s32(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource
 	struct audio_stream __sparse_cache *source = bsource->data;
 	struct audio_stream __sparse_cache *sink = bsink->data;
 	int32_t *x = audio_stream_get_rptr(source);
-	int32_t *y = sink->w_ptr;
+	int32_t *y = audio_stream_get_wptr(sink);
 	int fmax;
 	int i;
 	int j;

--- a/src/audio/tdfb/tdfb_hifiep.c
+++ b/src/audio/tdfb/tdfb_hifiep.c
@@ -60,7 +60,7 @@ void tdfb_fir_s16(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource
 {
 	struct audio_stream __sparse_cache *source = bsource->data;
 	struct audio_stream __sparse_cache *sink = bsink->data;
-	int16_t *x = source->r_ptr;
+	int16_t *x = audio_stream_get_rptr(source);
 	int16_t *y = sink->w_ptr;
 	int fmax;
 	int i;
@@ -106,7 +106,7 @@ void tdfb_fir_s24(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource
 {
 	struct audio_stream __sparse_cache *source = bsource->data;
 	struct audio_stream __sparse_cache *sink = bsink->data;
-	int32_t *x = source->r_ptr;
+	int32_t *x = audio_stream_get_rptr(source);
 	int32_t *y = sink->w_ptr;
 	int fmax;
 	int i;
@@ -152,7 +152,7 @@ void tdfb_fir_s32(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource
 {
 	struct audio_stream __sparse_cache *source = bsource->data;
 	struct audio_stream __sparse_cache *sink = bsink->data;
-	int32_t *x = source->r_ptr;
+	int32_t *x = audio_stream_get_rptr(source);
 	int32_t *y = sink->w_ptr;
 	int fmax;
 	int i;

--- a/src/audio/tdfb/tdfb_hifiep.c
+++ b/src/audio/tdfb/tdfb_hifiep.c
@@ -66,8 +66,8 @@ void tdfb_fir_s16(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource
 	int i;
 	int j;
 	int f;
-	const int in_nch = source->channels;
-	const int out_nch = sink->channels;
+	const int in_nch = audio_stream_get_channels(source);
+	const int out_nch = audio_stream_get_channels(sink);
 	int remaining_frames = frames;
 	int emp_ch = 0;
 
@@ -112,8 +112,8 @@ void tdfb_fir_s24(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource
 	int i;
 	int j;
 	int f;
-	const int in_nch = source->channels;
-	const int out_nch = sink->channels;
+	const int in_nch = audio_stream_get_channels(source);
+	const int out_nch = audio_stream_get_channels(sink);
 	int remaining_frames = frames;
 	int emp_ch = 0;
 
@@ -158,8 +158,8 @@ void tdfb_fir_s32(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource
 	int i;
 	int j;
 	int f;
-	const int in_nch = source->channels;
-	const int out_nch = sink->channels;
+	const int in_nch = audio_stream_get_channels(source);
+	const int out_nch = audio_stream_get_channels(sink);
 	int remaining_frames = frames;
 	int emp_ch = 0;
 

--- a/src/audio/tone.c
+++ b/src/audio/tone.c
@@ -117,7 +117,7 @@ static void tone_s32_default(struct comp_dev *dev, struct audio_stream __sparse_
 			     uint32_t frames)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
-	int32_t *dest = (int32_t *)sink->w_ptr;
+	int32_t *dest = audio_stream_get_wptr(sink);
 	int i;
 	int n;
 	int n_wrap_dest;

--- a/src/audio/tone.c
+++ b/src/audio/tone.c
@@ -138,7 +138,8 @@ static void tone_s32_default(struct comp_dev *dev, struct audio_stream __sparse_
 				dest++;
 			}
 		}
-		tone_circ_inc_wrap(&dest, audio_stream_get_end_addr(sink), sink->size);
+		tone_circ_inc_wrap(&dest, audio_stream_get_end_addr(sink),
+				   audio_stream_get_size(sink));
 	}
 }
 

--- a/src/audio/tone.c
+++ b/src/audio/tone.c
@@ -126,7 +126,7 @@ static void tone_s32_default(struct comp_dev *dev, struct audio_stream __sparse_
 
 	n = frames * nch;
 	while (n > 0) {
-		n_wrap_dest = (int32_t *)sink->end_addr - dest;
+		n_wrap_dest = (int32_t *)audio_stream_get_end_addr(sink) - dest;
 		n_min = (n < n_wrap_dest) ? n : n_wrap_dest;
 		/* Process until wrap or completed n */
 		while (n_min > 0) {
@@ -138,7 +138,7 @@ static void tone_s32_default(struct comp_dev *dev, struct audio_stream __sparse_
 				dest++;
 			}
 		}
-		tone_circ_inc_wrap(&dest, sink->end_addr, sink->size);
+		tone_circ_inc_wrap(&dest, audio_stream_get_end_addr(sink), sink->size);
 	}
 }
 

--- a/src/audio/tone.c
+++ b/src/audio/tone.c
@@ -688,7 +688,7 @@ static int tone_prepare(struct comp_dev *dev)
 	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer,
 				  sink_list);
 
-	cd->channels = sourceb->stream.channels;
+	cd->channels = audio_stream_get_channels(&sourceb->stream);
 	comp_info(dev, "tone_prepare(), cd->channels = %u, cd->rate = %u",
 		  cd->channels, cd->rate);
 

--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -112,6 +112,12 @@ static inline uint32_t audio_stream_get_free(const struct audio_stream __sparse_
 	return buf->free;
 }
 
+static inline enum sof_ipc_frame audio_stream_get_frm_fmt(
+	const struct audio_stream __sparse_cache *buf)
+{
+	return buf->frame_fmt;
+}
+
 /**
  * Retrieves readable address of a sample at specified index (see versions of
  * this macro specialized for various sample types).

--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -118,6 +118,12 @@ static inline enum sof_ipc_frame audio_stream_get_frm_fmt(
 	return buf->frame_fmt;
 }
 
+static inline enum sof_ipc_frame audio_stream_get_valid_fmt(
+	const struct audio_stream __sparse_cache *buf)
+{
+	return buf->valid_sample_fmt;
+}
+
 /**
  * Retrieves readable address of a sample at specified index (see versions of
  * this macro specialized for various sample types).

--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -77,6 +77,11 @@ struct audio_stream {
 	bool underrun_permitted; /**< indicates whether underrun is permitted */
 };
 
+static inline void *audio_stream_get_rptr(const struct audio_stream __sparse_cache *buf)
+{
+	return buf->r_ptr;
+}
+
 /**
  * Retrieves readable address of a sample at specified index (see versions of
  * this macro specialized for various sample types).

--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -107,6 +107,11 @@ static inline uint32_t audio_stream_get_avail(const struct audio_stream __sparse
 	return buf->avail;
 }
 
+static inline uint32_t audio_stream_get_free(const struct audio_stream __sparse_cache *buf)
+{
+	return buf->free;
+}
+
 /**
  * Retrieves readable address of a sample at specified index (see versions of
  * this macro specialized for various sample types).

--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -82,6 +82,11 @@ static inline void *audio_stream_get_rptr(const struct audio_stream __sparse_cac
 	return buf->r_ptr;
 }
 
+static inline void *audio_stream_get_wptr(const struct audio_stream __sparse_cache *buf)
+{
+	return buf->w_ptr;
+}
+
 /**
  * Retrieves readable address of a sample at specified index (see versions of
  * this macro specialized for various sample types).

--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -97,6 +97,11 @@ static inline void *audio_stream_get_addr(const struct audio_stream __sparse_cac
 	return buf->addr;
 }
 
+static inline uint32_t audio_stream_get_size(const struct audio_stream __sparse_cache *buf)
+{
+	return buf->size;
+}
+
 /**
  * Retrieves readable address of a sample at specified index (see versions of
  * this macro specialized for various sample types).

--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -102,6 +102,11 @@ static inline uint32_t audio_stream_get_size(const struct audio_stream __sparse_
 	return buf->size;
 }
 
+static inline uint32_t audio_stream_get_avail(const struct audio_stream __sparse_cache *buf)
+{
+	return buf->avail;
+}
+
 /**
  * Retrieves readable address of a sample at specified index (see versions of
  * this macro specialized for various sample types).

--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -819,8 +819,8 @@ static inline int audio_stream_set_zero(struct audio_stream __sparse_cache *buff
 
 static inline void audio_stream_fmt_conversion(enum ipc4_bit_depth depth,
 					       enum ipc4_bit_depth valid,
-					       enum sof_ipc_frame __sparse_cache *frame_fmt,
-					       enum sof_ipc_frame __sparse_cache *valid_fmt,
+					       enum sof_ipc_frame *frame_fmt,
+					       enum sof_ipc_frame *valid_fmt,
 					       enum ipc4_sample_type type)
 {
 	/* IPC4_DEPTH_16BIT (16) <---> SOF_IPC_FRAME_S16_LE (0)

--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -92,6 +92,11 @@ static inline void *audio_stream_get_end_addr(const struct audio_stream __sparse
 	return buf->end_addr;
 }
 
+static inline void *audio_stream_get_addr(const struct audio_stream __sparse_cache *buf)
+{
+	return buf->addr;
+}
+
 /**
  * Retrieves readable address of a sample at specified index (see versions of
  * this macro specialized for various sample types).

--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -87,6 +87,11 @@ static inline void *audio_stream_get_wptr(const struct audio_stream __sparse_cac
 	return buf->w_ptr;
 }
 
+static inline void *audio_stream_get_end_addr(const struct audio_stream __sparse_cache *buf)
+{
+	return buf->end_addr;
+}
+
 /**
  * Retrieves readable address of a sample at specified index (see versions of
  * this macro specialized for various sample types).

--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -129,6 +129,11 @@ static inline uint32_t audio_stream_get_rate(const struct audio_stream __sparse_
 	return buf->rate;
 }
 
+static inline uint32_t audio_stream_get_channels(const struct audio_stream __sparse_cache *buf)
+{
+	return buf->channels;
+}
+
 /**
  * Retrieves readable address of a sample at specified index (see versions of
  * this macro specialized for various sample types).

--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -124,6 +124,11 @@ static inline enum sof_ipc_frame audio_stream_get_valid_fmt(
 	return buf->valid_sample_fmt;
 }
 
+static inline uint32_t audio_stream_get_rate(const struct audio_stream __sparse_cache *buf)
+{
+	return buf->rate;
+}
+
 /**
  * Retrieves readable address of a sample at specified index (see versions of
  * this macro specialized for various sample types).

--- a/src/include/sof/audio/mixer.h
+++ b/src/include/sof/audio/mixer.h
@@ -68,7 +68,7 @@ static inline mixer_func mixer_get_processing_function(struct comp_dev *dev,
 
 	/* map the volume function for source and sink buffers */
 	for (i = 0; i < mixer_func_count; i++) {
-		if (sinkb->stream.frame_fmt != mixer_func_map[i].frame_fmt)
+		if (audio_stream_get_frm_fmt(&sinkb->stream) != mixer_func_map[i].frame_fmt)
 			continue;
 
 		return mixer_func_map[i].func;

--- a/src/include/sof/audio/volume.h
+++ b/src/include/sof/audio/volume.h
@@ -190,7 +190,7 @@ static inline vol_scale_func vol_get_processing_function(struct comp_dev *dev,
 
 	/* map the volume function for source and sink buffers */
 	for (i = 0; i < volume_func_count; i++) {
-		if (sinkb->stream.frame_fmt != volume_func_map[i].frame_fmt)
+		if (audio_stream_get_frm_fmt(&sinkb->stream) != volume_func_map[i].frame_fmt)
 			continue;
 
 		return volume_func_map[i].func;

--- a/src/include/sof/math/fir_hifi3.h
+++ b/src/include/sof/math/fir_hifi3.h
@@ -48,10 +48,10 @@ static inline void fir_core_setup_circular(struct fir_state_32x16 *fir)
 }
 
 /* Setup circular for component buffer */
-static inline void fir_comp_setup_circular(const struct audio_stream *buffer)
+static inline void fir_comp_setup_circular(const struct audio_stream __sparse_cache *buffer)
 {
 	AE_SETCBEGIN0(buffer->addr);
-	AE_SETCEND0(buffer->end_addr);
+	AE_SETCEND0(audio_stream_get_end_addr(buffer));
 }
 
 void fir_get_lrshifts(struct fir_state_32x16 *fir, int *lshift,

--- a/src/include/sof/math/fir_hifi3.h
+++ b/src/include/sof/math/fir_hifi3.h
@@ -50,7 +50,7 @@ static inline void fir_core_setup_circular(struct fir_state_32x16 *fir)
 /* Setup circular for component buffer */
 static inline void fir_comp_setup_circular(const struct audio_stream __sparse_cache *buffer)
 {
-	AE_SETCBEGIN0(buffer->addr);
+	AE_SETCBEGIN0(audio_stream_get_addr(buffer));
 	AE_SETCEND0(audio_stream_get_end_addr(buffer));
 }
 

--- a/src/ipc/ipc-helper.c
+++ b/src/ipc/ipc-helper.c
@@ -87,7 +87,7 @@ static void comp_update_params(uint32_t flag,
 			       struct comp_buffer __sparse_cache *buffer)
 {
 	if (flag & BUFF_PARAMS_FRAME_FMT)
-		params->frame_fmt = buffer->stream.frame_fmt;
+		params->frame_fmt = audio_stream_get_frm_fmt(&buffer->stream);
 
 	if (flag & BUFF_PARAMS_BUFFER_FMT)
 		params->buffer_fmt = buffer->buffer_fmt;

--- a/src/ipc/ipc-helper.c
+++ b/src/ipc/ipc-helper.c
@@ -93,7 +93,7 @@ static void comp_update_params(uint32_t flag,
 		params->buffer_fmt = buffer->buffer_fmt;
 
 	if (flag & BUFF_PARAMS_CHANNELS)
-		params->channels = buffer->stream.channels;
+		params->channels = audio_stream_get_channels(&buffer->stream);
 
 	if (flag & BUFF_PARAMS_RATE)
 		params->rate = audio_stream_get_rate(&buffer->stream);

--- a/src/ipc/ipc-helper.c
+++ b/src/ipc/ipc-helper.c
@@ -96,7 +96,7 @@ static void comp_update_params(uint32_t flag,
 		params->channels = buffer->stream.channels;
 
 	if (flag & BUFF_PARAMS_RATE)
-		params->rate = buffer->stream.rate;
+		params->rate = audio_stream_get_rate(&buffer->stream);
 }
 
 int comp_verify_params(struct comp_dev *dev, uint32_t flag,
@@ -145,7 +145,7 @@ int comp_verify_params(struct comp_dev *dev, uint32_t flag,
 		buffer_set_params(buf_c, params, BUFFER_UPDATE_FORCE);
 
 		/* set component period frames */
-		component_set_nearest_period_frames(dev, buf_c->stream.rate);
+		component_set_nearest_period_frames(dev, audio_stream_get_rate(&buf_c->stream));
 
 		buffer_release(buf_c);
 	} else {
@@ -167,7 +167,7 @@ int comp_verify_params(struct comp_dev *dev, uint32_t flag,
 					source_list);
 
 		buf_c = buffer_acquire(sinkb);
-		component_set_nearest_period_frames(dev, buf_c->stream.rate);
+		component_set_nearest_period_frames(dev, audio_stream_get_rate(&buf_c->stream));
 		buffer_release(buf_c);
 	}
 

--- a/src/library_manager/lib_manager.c
+++ b/src/library_manager/lib_manager.c
@@ -411,7 +411,7 @@ static int lib_manager_dma_buffer_init(struct lib_manager_dma_buf *buffer, uint3
 	dcache_writeback_region((__sparse_force void __sparse_cache *)buffer->addr, size);
 
 	tr_dbg(&lib_manager_tr, "lib_manager_dma_buffer_init(): %#lx, %#lx",
-	       buffer->addr, buffer->end_addr);
+	       buffer->addr, audio_stream_get_end_addr(buffer));
 
 	return 0;
 }

--- a/src/probe/probe.c
+++ b/src/probe/probe.c
@@ -829,7 +829,7 @@ static void probe_cb_produce(void *arg, enum notify_id type, void *data)
 	}
 
 	if (_probe->probe_points[i].purpose == PROBE_PURPOSE_EXTRACTION) {
-		format = probe_gen_format(buffer->stream.frame_fmt,
+		format = probe_gen_format(audio_stream_get_frm_fmt(&buffer->stream),
 					  buffer->stream.rate,
 					  buffer->stream.channels);
 		ret = probe_gen_header(buffer_id,

--- a/src/probe/probe.c
+++ b/src/probe/probe.c
@@ -840,9 +840,9 @@ static void probe_cb_produce(void *arg, enum notify_id type, void *data)
 
 		/* check if transaction amount exceeds component buffer end addr */
 		/* if yes: divide copying into two stages, head and tail */
-		if ((char *)cb_data->transaction_begin_address +
-		    cb_data->transaction_amount > (char *)buffer->stream.end_addr) {
-			head = (uintptr_t)buffer->stream.end_addr -
+		if ((char *)cb_data->transaction_begin_address + cb_data->transaction_amount >
+		    (char *)audio_stream_get_end_addr(&buffer->stream)) {
+			head = (uintptr_t)audio_stream_get_end_addr(&buffer->stream) -
 			       (uintptr_t)cb_data->transaction_begin_address;
 			tail = (uintptr_t)cb_data->transaction_amount - head;
 			ret = copy_to_pbuffer(&_probe->ext_dma.dmapb,
@@ -896,9 +896,9 @@ static void probe_cb_produce(void *arg, enum notify_id type, void *data)
 
 		/* check if transaction amount exceeds component buffer end addr */
 		/* if yes: divide copying into two stages, head and tail */
-		if ((char *)cb_data->transaction_begin_address +
-			cb_data->transaction_amount > (char *)buffer->stream.end_addr) {
-			head = (char *)buffer->stream.end_addr -
+		if ((char *)cb_data->transaction_begin_address + cb_data->transaction_amount >
+		    (char *)audio_stream_get_end_addr(&buffer->stream)) {
+			head = (char *)audio_stream_get_end_addr(&buffer->stream) -
 				(char *)cb_data->transaction_begin_address;
 			tail = cb_data->transaction_amount - head;
 

--- a/src/probe/probe.c
+++ b/src/probe/probe.c
@@ -852,7 +852,7 @@ static void probe_cb_produce(void *arg, enum notify_id type, void *data)
 				goto err;
 
 			ret = copy_to_pbuffer(&_probe->ext_dma.dmapb,
-					      buffer->stream.addr, tail);
+					      audio_stream_get_addr(&buffer->stream), tail);
 			if (ret < 0)
 				goto err;
 		} else {
@@ -908,7 +908,7 @@ static void probe_cb_produce(void *arg, enum notify_id type, void *data)
 				goto err;
 
 			ret = copy_from_pbuffer(&dma->dmapb,
-						buffer->stream.addr, tail);
+						audio_stream_get_addr(&buffer->stream), tail);
 			if (ret < 0)
 				goto err;
 		} else {

--- a/src/probe/probe.c
+++ b/src/probe/probe.c
@@ -831,7 +831,7 @@ static void probe_cb_produce(void *arg, enum notify_id type, void *data)
 	if (_probe->probe_points[i].purpose == PROBE_PURPOSE_EXTRACTION) {
 		format = probe_gen_format(audio_stream_get_frm_fmt(&buffer->stream),
 					  audio_stream_get_rate(&buffer->stream),
-					  buffer->stream.channels);
+					  audio_stream_get_channels(&buffer->stream));
 		ret = probe_gen_header(buffer_id,
 				       cb_data->transaction_amount,
 				       format, &checksum);

--- a/src/probe/probe.c
+++ b/src/probe/probe.c
@@ -830,7 +830,7 @@ static void probe_cb_produce(void *arg, enum notify_id type, void *data)
 
 	if (_probe->probe_points[i].purpose == PROBE_PURPOSE_EXTRACTION) {
 		format = probe_gen_format(audio_stream_get_frm_fmt(&buffer->stream),
-					  buffer->stream.rate,
+					  audio_stream_get_rate(&buffer->stream),
 					  buffer->stream.channels);
 		ret = probe_gen_header(buffer_id,
 				       cb_data->transaction_amount,

--- a/src/samples/audio/detect_test.c
+++ b/src/samples/audio/detect_test.c
@@ -284,7 +284,7 @@ static void test_keyword_set_params(struct comp_dev *dev,
 				    struct sof_ipc_stream_params *params)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
-	uint32_t __sparse_cache valid_fmt, frame_fmt;
+	enum sof_ipc_frame valid_fmt, frame_fmt;
 
 	comp_info(dev, "test_keyword_set_params()");
 

--- a/src/samples/audio/detect_test.c
+++ b/src/samples/audio/detect_test.c
@@ -837,7 +837,7 @@ static int test_keyword_copy(struct comp_dev *dev)
 				 struct comp_buffer, sink_list);
 	source_c = buffer_acquire(source);
 
-	if (!source_c->stream.avail) {
+	if (!audio_stream_get_avail(&source_c->stream)) {
 		buffer_release(source_c);
 		return PPL_STATUS_PATH_STOP;
 	}

--- a/src/samples/audio/detect_test.c
+++ b/src/samples/audio/detect_test.c
@@ -767,7 +767,7 @@ static int test_keyword_params(struct comp_dev *dev,
 				  sink_list);
 	source_c = buffer_acquire(sourceb);
 	channels = source_c->stream.channels;
-	frame_fmt = source_c->stream.frame_fmt;
+	frame_fmt = audio_stream_get_frm_fmt(&source_c->stream);
 	rate = source_c->stream.rate;
 	buffer_release(source_c);
 

--- a/src/samples/audio/detect_test.c
+++ b/src/samples/audio/detect_test.c
@@ -768,7 +768,7 @@ static int test_keyword_params(struct comp_dev *dev,
 	source_c = buffer_acquire(sourceb);
 	channels = source_c->stream.channels;
 	frame_fmt = audio_stream_get_frm_fmt(&source_c->stream);
-	rate = source_c->stream.rate;
+	rate = audio_stream_get_rate(&source_c->stream);
 	buffer_release(source_c);
 
 	if (channels != 1) {

--- a/src/samples/audio/detect_test.c
+++ b/src/samples/audio/detect_test.c
@@ -766,7 +766,7 @@ static int test_keyword_params(struct comp_dev *dev,
 	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer,
 				  sink_list);
 	source_c = buffer_acquire(sourceb);
-	channels = source_c->stream.channels;
+	channels = audio_stream_get_channels(&source_c->stream);
 	frame_fmt = audio_stream_get_frm_fmt(&source_c->stream);
 	rate = audio_stream_get_rate(&source_c->stream);
 	buffer_release(source_c);

--- a/src/samples/audio/smart_amp_test.c
+++ b/src/samples/audio/smart_amp_test.c
@@ -146,6 +146,7 @@ static void smart_amp_set_params(struct comp_dev *dev,
 	if (!list_is_empty(&dev->bsink_list)) {
 		struct ipc4_output_pin_format *sink_fmt = &sad->ipc4_cfg.output_pin;
 		struct ipc4_audio_format out_fmt = sink_fmt->audio_fmt;
+		enum sof_ipc_frame frame_fmt, valid_fmt;
 
 		sink = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
 		sink_c = buffer_acquire(sink);
@@ -154,9 +155,11 @@ static void smart_amp_set_params(struct comp_dev *dev,
 
 		audio_stream_fmt_conversion(out_fmt.depth,
 					    out_fmt.valid_bit_depth,
-					    &sink_c->stream.frame_fmt,
-					    &sink_c->stream.valid_sample_fmt,
+					    &frame_fmt, &valid_fmt,
 					    out_fmt.s_type);
+
+		sink_c->stream.frame_fmt = frame_fmt;
+		sink_c->stream.valid_sample_fmt = valid_fmt;
 
 		sink_c->buffer_fmt = out_fmt.interleaving_style;
 		params->frame_fmt = sink_c->stream.frame_fmt;

--- a/src/samples/audio/smart_amp_test.c
+++ b/src/samples/audio/smart_amp_test.c
@@ -162,7 +162,7 @@ static void smart_amp_set_params(struct comp_dev *dev,
 		sink_c->stream.valid_sample_fmt = valid_fmt;
 
 		sink_c->buffer_fmt = out_fmt.interleaving_style;
-		params->frame_fmt = sink_c->stream.frame_fmt;
+		params->frame_fmt = audio_stream_get_frm_fmt(&sink_c->stream);
 
 		sink_c->hw_params_configured = true;
 
@@ -636,7 +636,7 @@ static int smart_amp_process_s32(struct comp_dev *dev,
 static smart_amp_proc get_smart_amp_process(struct comp_dev *dev,
 					    struct comp_buffer __sparse_cache *buf)
 {
-	switch (buf->stream.frame_fmt) {
+	switch (audio_stream_get_frm_fmt(&buf->stream)) {
 	case SOF_IPC_FRAME_S16_LE:
 		return smart_amp_process_s16;
 	case SOF_IPC_FRAME_S24_4LE:

--- a/src/samples/audio/smart_amp_test.c
+++ b/src/samples/audio/smart_amp_test.c
@@ -595,7 +595,7 @@ static int smart_amp_process_s16(struct comp_dev *dev,
 			}
 			out_frag++;
 		}
-		in_frag += source->channels;
+		in_frag += audio_stream_get_channels(source);
 	}
 	return 0;
 }
@@ -627,7 +627,7 @@ static int smart_amp_process_s32(struct comp_dev *dev,
 			}
 			out_frag++;
 		}
-		in_frag += source->channels;
+		in_frag += audio_stream_get_channels(source);
 	}
 
 	return 0;
@@ -769,11 +769,11 @@ static int smart_amp_prepare(struct comp_dev *dev)
 					source_list);
 
 	buffer_c = buffer_acquire(sad->sink_buf);
-	sad->out_channels = buffer_c->stream.channels;
+	sad->out_channels = audio_stream_get_channels(&buffer_c->stream);
 	buffer_release(buffer_c);
 
 	buffer_c = buffer_acquire(sad->source_buf);
-	sad->in_channels = buffer_c->stream.channels;
+	sad->in_channels = audio_stream_get_channels(&buffer_c->stream);
 
 	k_mutex_lock(&sad->lock, K_FOREVER);
 	if (sad->feedback_buf) {

--- a/src/samples/audio/smart_amp_test.c
+++ b/src/samples/audio/smart_amp_test.c
@@ -780,7 +780,7 @@ static int smart_amp_prepare(struct comp_dev *dev)
 		struct comp_buffer __sparse_cache *buf = buffer_acquire(sad->feedback_buf);
 
 		buf->stream.channels = sad->config.feedback_channels;
-		buf->stream.rate = buffer_c->stream.rate;
+		buf->stream.rate = audio_stream_get_rate(&buffer_c->stream);
 		buffer_release(buf);
 	}
 	k_mutex_unlock(&sad->lock);


### PR DESCRIPTION
users shouldn't access `struct audio_stream` internals directly, add accessors for that. This is part 1 - adding read accessors. We keep direct access in the header itself and in buffer.c - for those it's logical to have direct knowledge about internal structure of the buffer class. After part 1 we will add write accessors too.