### PR TITLE
west: test rimage with only ssl 3 support

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -36,7 +36,7 @@ manifest:
     - name: rimage
       repo-path: rimage
       path: sof/rimage
-      revision: 48777207f5fdc49314dd4709d660e891c48d5ba9
+      revision: pull/157/head
 
     - name: tomlc99
       repo-path: tomlc99


### PR DESCRIPTION
Test rimage version that supports only ssl 3 upwards.