### PR TITLE
numbers.sh: do not (re)define ROUND_DOWN() if __ZEPHYR__

### DIFF
--- a/src/include/sof/math/numbers.h
+++ b/src/include/sof/math/numbers.h
@@ -18,6 +18,12 @@
  */
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
 #define MAX(a, b) ((a) < (b) ? (b) : (a))
+
+#define ROUND_DOWN(size, alignment) ({			\
+	typeof(size) __size = (size);			\
+	typeof(alignment) __alignment = (alignment);	\
+	__size - (__size % __alignment);		\
+})
 #endif /* ! __ZEPHYR__ */
 
 #define ABS(a) ({		\
@@ -29,13 +35,7 @@
 	__a < 0 ? -1 :		\
 	__a > 0 ? 1 : 0;	\
 })
-#ifndef ROUND_DOWN
-#define ROUND_DOWN(size, alignment) ({			\
-	typeof(size) __size = (size);			\
-	typeof(alignment) __alignment = (alignment);	\
-	__size - (__size % __alignment);		\
-})
-#endif /* !ROUND_DOWN */
+
 int gcd(int a, int b); /* Calculate greatest common divisor for a and b */
 
 /* This is a divide function that returns ceil of the quotient.


### PR DESCRIPTION
Move the ROUND_DOWN() definition to the nearby #ifndef __ZEPHYR__ block.

The previous `#ifndef ROUND_DOWN` logic depends on the #include order, so it fails sometimes.

Fixes commit a6f8daec2acb ("kpb: add micselection function")

Fixes XCC compilation failure with
```
./scripts/xtensa-build-zephyr.py  mtl --cmake-args='-DEXTRA_CFLAGS=-Werror'

 - In file included from sof/src/audio/src/src_hifi4.c:22:
zephyr/include/zephyr/sys/util.h:238:9: warning:
         'ROUND_DOWN' macro redefined [-Wmacro-redefined]
        ^
sof/zephyr/../src/include/sof/math/numbers.h:33:9:
         note: previous definition is here
```