### PR TITLE
DSP panic during playback with suspend/resume

### DIFF
--- a/src/audio/pipeline/pipeline-graph.c
+++ b/src/audio/pipeline/pipeline-graph.c
@@ -359,6 +359,17 @@ static int pipeline_comp_reset(struct comp_dev *current,
 		}
 	}
 
+	/* two cases for a component still being active here:
+	 * 1. trigger function failed to handle stop event
+	 * 2. trigger functon skipped due to error of other component's trigger function
+	 */
+	if (current->state == COMP_STATE_ACTIVE) {
+		pipe_warn(current->pipeline, "pipeline_comp_reset(): component is in active state, try to stop it");
+		err = comp_trigger(current, COMP_TRIGGER_STOP);
+		if (err)
+			pipe_err(current->pipeline, "pipeline_comp_reset(): failed to recover");
+	}
+
 	err = comp_reset(current);
 	if (err < 0 || err == PPL_STATUS_PATH_STOP)
 		return err;


### PR DESCRIPTION
DSP panic during playback with suspend/resume test.

[  649.505750] sof-audio-pci-intel-tgl 0000:00:1f.3: ------------[ DSP dump start ]------------
[  649.505756] sof-audio-pci-intel-tgl 0000:00:1f.3: DSP panic!
[  649.505757] sof-audio-pci-intel-tgl 0000:00:1f.3: fw_state: SOF_FW_BOOT_COMPLETE (6)
[  649.505776] sof-audio-pci-intel-tgl 0000:00:1f.3: status: fw entered - code 00000005
[  649.505863] sof-audio-pci-intel-tgl 0000:00:1f.3: reason: runtime exception (0x6)
[  649.505864] sof-audio-pci-intel-tgl 0000:00:1f.3: trace point: 0x00004000
[  649.505865] sof-audio-pci-intel-tgl 0000:00:1f.3: panic at :0
[  649.505867] sof-audio-pci-intel-tgl 0000:00:1f.3: error: DSP Firmware Oops
[  649.505868] sof-audio-pci-intel-tgl 0000:00:1f.3: error: Exception Cause: LoadStorePIFDataErrorCause, Synchronous PIF data error during LoadStore access
[  649.505869] sof-audio-pci-intel-tgl 0000:00:1f.3: EXCCAUSE 0x0000000d EXCVADDR 0x0000005c PS       0x00060725 SAR     0x00000000
[  649.505871] sof-audio-pci-intel-tgl 0000:00:1f.3: EPC1     0xbe02e4f7 EPC2     0xbe05112b EPC3     0x00000000 EPC4    0x00000000
[  649.505872] sof-audio-pci-intel-tgl 0000:00:1f.3: EPC5     0x00000000 EPC6     0x00000000 EPC7     0x00000000 DEPC    0x00000000
[  649.505873] sof-audio-pci-intel-tgl 0000:00:1f.3: EPS2     0x00060320 EPS3     0x00000000 EPS4     0x00000000 EPS5    0x00000000
[  649.505874] sof-audio-pci-intel-tgl 0000:00:1f.3: EPS6     0x00000000 EPS7     0x00000000 INTENABL 0x00000000 INTERRU 0x00000222
[  649.505876] sof-audio-pci-intel-tgl 0000:00:1f.3: stack dump from 0xbe1a0d70
[  649.505878] sof-audio-pci-intel-tgl 0000:00:1f.3: 0xbe1a0d70: 03000000 00000000 00000000 00000000
[  649.505879] sof-audio-pci-intel-tgl 0000:00:1f.3: 0xbe1a0d80: fe05d468 be1a0dc0 be1a0df0 0000000d
[  649.505880] sof-audio-pci-intel-tgl 0000:00:1f.3: 0xbe1a0d90: be1a0d70 01001001 c8c29dda 00000003
[  649.505881] sof-audio-pci-intel-tgl 0000:00:1f.3: 0xbe1a0da0: 20015b40 be1a0e10 00000001 20015ce8
[  649.505883] sof-audio-pci-intel-tgl 0000:00:1f.3: 0xbe1a0db0: 7e044d65 be1a0df0 000000c0 be1e0800
[  649.505884] sof-audio-pci-intel-tgl 0000:00:1f.3: 0xbe1a0dc0: be02e4f7 01001001 c8c29c74 00000003
[  649.505885] sof-audio-pci-intel-tgl 0000:00:1f.3: 0xbe1a0dd0: 0000037f be25cf00 be25db00 00000002
[  649.505886] sof-audio-pci-intel-tgl 0000:00:1f.3: 0xbe1a0de0: be04b119 be1a0ff0 00000001 fe044d65
[  649.505888] sof-audio-pci-intel-tgl 0000:00:1f.3: ------------[ DSP dump end ]------------
[  650.008885] sof-audio-pci-intel-tgl 0000:00:1f.3: ipc tx timed out for 0x60030000 (msg/reply size: 12/12)
[  650.008914] sof-audio-pci-intel-tgl 0000:00:1f.3: preventing DSP entering D3 state to preserve context
[  650.008928] sof-audio-pci-intel-tgl 0000:00:1f.3: ------------[ IPC dump start ]------------
[  650.008966] sof-audio-pci-intel-tgl 0000:00:1f.3: hda irq intsts 0x00000000 intlctl 0xc0000081 rirb 00
[  650.008980] sof-audio-pci-intel-tgl 0000:00:1f.3: dsp irq ppsts 0x00000000 adspis 0x00000000
[  650.009012] sof-audio-pci-intel-tgl 0000:00:1f.3: error: host status 0x00000000 dsp status 0x00000000 mask 0x00000003
[  650.009023] sof-audio-pci-intel-tgl 0000:00:1f.3: ------------[ IPC dump end ]------------
[  650.009034] sof-audio-pci-intel-tgl 0000:00:1f.3: Firmware exception
[  650.009052] sof-audio-pci-intel-tgl 0000:00:1f.3: ASoC: error at soc_component_trigger on 0000:00:1f.3: -110
[  650.009069]  smart373-spk: ASoC: trigger FE cmd: 0 failed: -110
[  650.009355] sof-audio-pci-intel-tgl 0000:00:1f.3: ASoC: error at snd_soc_pcm_component_hw_free on 0000:00:1f.3: -19
[  650.009495] sof-audio-pci-intel-tgl 0000:00:1f.3: error: failed resetting DAI config for SSP1.IN
[  650.090000] sof-audio-pci-intel-tgl 0000:00:1f.3: ASoC: error at soc_component_trigger on 0000:00:1f.3: -19
[  650.090005]  smart373-spk: ASoC: trigger FE cmd: 0 failed: -19
[  650.090054] sof-audio-pci-intel-tgl 0000:00:1f.3: ASoC: error at snd_soc_pcm_component_hw_free on 0000:00:1f.3: -19
[  650.090059] sof-audio-pci-intel-tgl 0000:00:1f.3: error: failed resetting DAI config for SSP1.OUT

I'm not able to get a valid coredump but from the sof log we can learn that DMA is still running when dai_reset() is called. We need to stop it first before releasing the buffer.

[    90627511.711286] (      517712.531250) c0 ipc                  src/ipc/ipc3/handler.c:1605 INFO ipc: new cmd 0x60050000
=> STOP trigger received
[    90627546.555035] (          34.843750) c1 idc                ......./intel/cavs/idc.c:58   INFO idc_irq_handler(), IPC_IDCTFC_BUSY
[    90627572.961284] (          26.406248) c1 idc                ......./intel/cavs/idc.c:186  INFO idc_do_cmd()
[    90627598.065449] (          25.104166) c1 ipc                  src/ipc/ipc3/handler.c:449  INFO ipc: comp 47 -> trigger cmd 0x50000
[    90627617.596699] (          19.531250) c1 pipe         11.52 ....../pipeline-stream.c:270  INFO pipe trigger cmd 0
[    90628181.242510] (         563.645813) c1 demux        11.48      src/audio/mux/mux.c:811  INFO mux_trigger(), command = 0
[    90628206.711259] (          25.468748) c1 demux        11.48      src/audio/mux/mux.c:824  INFO mux_trigger(), sink_n_active = 1, sink_n_paused = 0
=> there is active sink so mux_trigger aborts entire pipeline walk. dai's trigger funcion is skipped.

[    90629183.013303] (         976.302063) c0 ipc                  src/ipc/ipc3/handler.c:1605 INFO ipc: new cmd 0x60030000
=> hw_free received
[    90629219.107052] (          36.093750) c1 idc                ......./intel/cavs/idc.c:58   INFO idc_irq_handler(), IPC_IDCTFC_BUSY
[    90629245.461217] (          26.354166) c1 idc                ......./intel/cavs/idc.c:186  INFO idc_do_cmd()
[    90629271.242466] (          25.781248) c1 pipe         11.52 ......./pipeline-graph.c:346  INFO pipe reset
[    90629364.419546] (          93.177078) c1 demux        11.48      src/audio/mux/mux.c:629  INFO mux_reset()
[    90629392.804961] (          28.385416) c1 demux        11.48    src/audio/component.c:105  ERROR comp_set_state(): wrong state = 5, COMP_TRIGGER_RESET
[    90629414.940377] (          22.135416) c1 dai          11.51          src/audio/dai.c:673  INFO dai_reset()
[    90629433.377877] (          18.437500) c1 dai          11.51       src/ipc/ipc3/dai.c:252  INFO dai_dma_release(): Component is in active state. Ignore resetting
[    90629503.742457] (          70.364578) c1 dai          11.51    src/audio/component.c:105  ERROR comp_set_state(): wrong state = 5, COMP_TRIGGER_RESET
=> dai is still in active state but dma resources are going to release.
