### PR TITLE
cadence: register module logs in Zephyr

### DIFF
--- a/src/audio/module_adapter/module/cadence.c
+++ b/src/audio/module_adapter/module/cadence.c
@@ -16,6 +16,8 @@
 #include <ipc/compress_params.h>
 #include <rtos/init.h>
 
+LOG_MODULE_REGISTER(cadence, CONFIG_SOF_LOG_LEVEL);
+
 /* d8218443-5ff3-4a4c-b388-6cfe07b956aa */
 DECLARE_SOF_RT_UUID("cadence_codec", cadence_uuid, 0xd8218443, 0x5ff3, 0x4a4c,
 		    0xb3, 0x88, 0x6c, 0xfe, 0x07, 0xb9, 0x56, 0xaa);


### PR DESCRIPTION
Use LOG_MODULE_REGISTER() to register cadence in the Zephyr logger framework.