### PR TITLE
modAPI: modules should use provided buf pointers

### DIFF
--- a/src/audio/mixer/mixer.c
+++ b/src/audio/mixer/mixer.c
@@ -100,8 +100,8 @@ static int mixer_process(struct processing_module *mod,
 	for (i = 0; i < num_input_buffers; i++) {
 		uint32_t avail_frames;
 
-		avail_frames = audio_stream_avail_frames_aligned(mod->input_buffers[i].data,
-								 mod->output_buffers[0].data);
+		avail_frames = audio_stream_avail_frames_aligned(input_buffers[i].data,
+								 output_buffers[0].data);
 
 		/* if one source is inactive, skip it */
 		if (avail_frames == 0)
@@ -118,17 +118,17 @@ static int mixer_process(struct processing_module *mod,
 		 * generating silence until at least one of the
 		 * sources start to have data available (frames!=0).
 		 */
-		sink_bytes = dev->frames * audio_stream_frame_bytes(mod->output_buffers[0].data);
-		if (!audio_stream_set_zero(mod->output_buffers[0].data, sink_bytes))
-			mod->output_buffers[0].size = sink_bytes;
+		sink_bytes = dev->frames * audio_stream_frame_bytes(output_buffers[0].data);
+		if (!audio_stream_set_zero(output_buffers[0].data, sink_bytes))
+			output_buffers[0].size = sink_bytes;
 
 		return 0;
 	}
 
 	/* Every source has the same format, so calculate bytes based on the first one */
-	source_bytes = frames * audio_stream_frame_bytes(mod->input_buffers[0].data);
+	source_bytes = frames * audio_stream_frame_bytes(input_buffers[0].data);
 
-	sink_bytes = frames * audio_stream_frame_bytes(mod->output_buffers[0].data);
+	sink_bytes = frames * audio_stream_frame_bytes(output_buffers[0].data);
 
 	comp_dbg(dev, "mixer_process(), source_bytes = 0x%x, sink_bytes = 0x%x",
 		 source_bytes, sink_bytes);
@@ -137,24 +137,24 @@ static int mixer_process(struct processing_module *mod,
 	for (i = 0; i < num_input_buffers; i++) {
 		uint32_t avail_frames;
 
-		avail_frames = audio_stream_avail_frames_aligned(mod->input_buffers[i].data,
-								 mod->output_buffers[0].data);
+		avail_frames = audio_stream_avail_frames_aligned(input_buffers[i].data,
+								 output_buffers[0].data);
 
 		/* if one source is inactive, skip it */
 		if (avail_frames == 0)
 			continue;
 
 		sources_indices[j] = i;
-		sources_stream[j++] = mod->input_buffers[i].data;
+		sources_stream[j++] = input_buffers[i].data;
 	}
 
 	if (j)
-		md->mix_func(dev, mod->output_buffers[0].data, sources_stream, j, frames);
-	mod->output_buffers[0].size = sink_bytes;
+		md->mix_func(dev, output_buffers[0].data, sources_stream, j, frames);
+	output_buffers[0].size = sink_bytes;
 
 	/* update source buffer consumed bytes */
 	for (i = 0; i < j; i++)
-		mod->input_buffers[sources_indices[i]].consumed = source_bytes;
+		input_buffers[sources_indices[i]].consumed = source_bytes;
 
 	return 0;
 }

--- a/src/audio/module_adapter/module/iadk_modules.c
+++ b/src/audio/module_adapter/module/iadk_modules.c
@@ -167,7 +167,7 @@ static int iadk_modules_process(struct processing_module *mod,
 
 	/* IADK modules require output buffer size to set to its real size. */
 	list_for_item(blist, &dev->bsource_list) {
-		mod->output_buffers[i].size = md->mpd.out_buff_size;
+		output_buffers[i].size = md->mpd.out_buff_size;
 		i++;
 	}
 	/* Call module specific process function. */

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -159,6 +159,8 @@ int module_adapter_prepare(struct comp_dev *dev)
 	struct module_data *md = &mod->priv;
 	struct comp_buffer __sparse_cache *buffer_c;
 	struct comp_buffer __sparse_cache *sink_c;
+	uint32_t num_input_buffers = 0;
+	uint32_t num_output_buffers = 0;
 	struct comp_buffer *sink;
 	struct list_item *blist, *_blist;
 	uint32_t buff_periods;
@@ -220,48 +222,21 @@ int module_adapter_prepare(struct comp_dev *dev)
 		if (source->pipeline && source->pipeline->core != dev->pipeline->core)
 			coherent_shared_thread(mod->source_info, c);
 
-		mod->num_input_buffers++;
+		num_input_buffers++;
 	}
 
 	/* compute number of output buffers */
 	list_for_item(blist, &dev->bsink_list)
-		mod->num_output_buffers++;
+		num_output_buffers++;
 
-	if (!mod->num_input_buffers && !mod->num_output_buffers) {
+	if (!num_input_buffers && !num_output_buffers) {
 		comp_err(dev, "module_adapter_prepare(): no source and sink buffers connected!");
 		return -EINVAL;
 	}
 
-	if (mod->simple_copy && mod->num_input_buffers > 1 && mod->num_output_buffers > 1) {
+	if (mod->simple_copy && num_input_buffers > 1 && num_output_buffers > 1) {
 		comp_err(dev, "module_adapter_prepare(): Invalid use of simple_copy");
 		return -EINVAL;
-	}
-
-	/* allocate memory for input buffers */
-	if (mod->num_input_buffers) {
-		mod->input_buffers =
-			rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM,
-				sizeof(*mod->input_buffers) * mod->num_input_buffers);
-		if (!mod->input_buffers) {
-			comp_err(dev, "module_adapter_prepare(): failed to allocate input buffers");
-			return -ENOMEM;
-		}
-	} else {
-		mod->input_buffers = NULL;
-	}
-
-	/* allocate memory for output buffers */
-	if (mod->num_output_buffers) {
-		mod->output_buffers =
-			rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM,
-				sizeof(*mod->output_buffers) * mod->num_output_buffers);
-		if (!mod->output_buffers) {
-			comp_err(dev, "module_adapter_prepare(): failed to allocate output buffers");
-			ret = -ENOMEM;
-			goto in_out_free;
-		}
-	} else {
-		mod->output_buffers = NULL;
 	}
 
 	/*
@@ -320,12 +295,12 @@ int module_adapter_prepare(struct comp_dev *dev)
 	list_for_item(blist, &dev->bsource_list) {
 		size_t size = MAX(mod->deep_buff_bytes, mod->period_bytes);
 
-		mod->input_buffers[i].data =
+		mod->local_input_buffer[i] =
 			(__sparse_force void __sparse_cache *)rballoc(0, SOF_MEM_CAPS_RAM, size);
-		if (!mod->input_buffers[i].data) {
+		if (!mod->local_input_buffer[i]) {
 			comp_err(mod->dev, "module_adapter_prepare(): Failed to alloc input buffer data");
 			ret = -ENOMEM;
-			goto in_data_free;
+			goto buffers_free;
 		}
 		i++;
 	}
@@ -333,20 +308,20 @@ int module_adapter_prepare(struct comp_dev *dev)
 	/* allocate memory for output buffer data */
 	i = 0;
 	list_for_item(blist, &dev->bsink_list) {
-		mod->output_buffers[i].data =
+		mod->local_output_buffer[i] =
 			(__sparse_force void __sparse_cache *)rballoc(0, SOF_MEM_CAPS_RAM,
 								      md->mpd.out_buff_size);
-		if (!mod->output_buffers[i].data) {
+		if (!mod->local_output_buffer[i]) {
 			comp_err(mod->dev, "module_adapter_prepare(): Failed to alloc output buffer data");
 			ret = -ENOMEM;
-			goto out_data_free;
+			goto buffers_free;
 		}
 		i++;
 	}
 
 	/* allocate buffer for all sinks */
 	if (list_is_empty(&mod->sink_buffer_list)) {
-		for (i = 0; i < mod->num_output_buffers; i++) {
+		for (i = 0; i < num_output_buffers; i++) {
 			struct comp_buffer *buffer = buffer_alloc(buff_size, SOF_MEM_CAPS_RAM,
 								  PLATFORM_DCACHE_ALIGN);
 			if (!buffer) {
@@ -395,17 +370,11 @@ free:
 		buffer_free(buffer);
 	}
 
-out_data_free:
-	for (i = 0; i < mod->num_output_buffers; i++)
-		rfree((__sparse_force void *)mod->output_buffers[i].data);
-
-in_data_free:
-	for (i = 0; i < mod->num_input_buffers; i++)
-		rfree((__sparse_force void *)mod->input_buffers[i].data);
-
-in_out_free:
-	rfree(mod->output_buffers);
-	rfree(mod->input_buffers);
+buffers_free:
+	for (i = 0; i < PLATFORM_MAX_STREAMS; i++) {
+		rfree((__sparse_force void *)mod->local_input_buffer[i]);
+		rfree((__sparse_force void *)mod->local_output_buffer[i]);
+	}
 	return ret;
 }
 
@@ -560,7 +529,9 @@ static void module_copy_samples(struct comp_dev *dev, struct comp_buffer __spars
 	comp_update_buffer_consume(src_buffer, copy_bytes);
 }
 
-static void module_adapter_process_output(struct comp_dev *dev)
+static void module_adapter_process_output(struct comp_dev *dev,
+					  struct input_stream_buffer *input_buffers,
+					  struct output_stream_buffer *output_buffers)
 {
 	struct processing_module *mod = comp_get_drvdata(dev);
 	struct comp_buffer *sink;
@@ -573,16 +544,16 @@ static void module_adapter_process_output(struct comp_dev *dev)
 	 * there are no samples produced.
 	 */
 	list_for_item(blist, &mod->sink_buffer_list) {
-		if (mod->output_buffers[i].size > 0) {
+		if (output_buffers[i].size > 0) {
 			struct comp_buffer *buffer;
 			struct comp_buffer __sparse_cache *buffer_c;
 
 			buffer = container_of(blist, struct comp_buffer, sink_list);
 			buffer_c = buffer_acquire(buffer);
 
-			ca_copy_from_module_to_sink(&buffer_c->stream, mod->output_buffers[i].data,
-						    mod->output_buffers[i].size);
-			audio_stream_produce(&buffer_c->stream, mod->output_buffers[i].size);
+			ca_copy_from_module_to_sink(&buffer_c->stream, output_buffers[i].data,
+						    output_buffers[i].size);
+			audio_stream_produce(&buffer_c->stream, output_buffers[i].size);
 			buffer_release(buffer_c);
 		}
 		i++;
@@ -605,11 +576,11 @@ static void module_adapter_process_output(struct comp_dev *dev)
 				sink_c = buffer_acquire(sink);
 				source_c = buffer_acquire(source);
 				module_copy_samples(dev, source_c, sink_c,
-						    mod->output_buffers[i].size);
+						    output_buffers[i].size);
 				buffer_release(source_c);
 				buffer_release(sink_c);
 
-				mod->output_buffers[i].size = 0;
+				output_buffers[i].size = 0;
 				break;
 			}
 			j++;
@@ -621,7 +592,9 @@ static void module_adapter_process_output(struct comp_dev *dev)
 static uint32_t
 module_single_sink_setup(struct comp_dev *dev,
 			 struct comp_buffer __sparse_cache **source_c,
-			 struct comp_buffer __sparse_cache **sinks_c)
+			 struct comp_buffer __sparse_cache **sinks_c,
+			 struct input_stream_buffer *input_buffers,
+			 struct output_stream_buffer *output_buffers)
 {
 	struct processing_module *mod = comp_get_drvdata(dev);
 	struct comp_copy_limits c;
@@ -639,17 +612,17 @@ module_single_sink_setup(struct comp_dev *dev,
 		 * note that the size is in number of frames not the number of
 		 * bytes
 		 */
-		mod->input_buffers[i].size = c.frames;
-		mod->input_buffers[i].consumed = 0;
+		input_buffers[i].size = c.frames;
+		input_buffers[i].consumed = 0;
 
-		mod->input_buffers[i].data = &source_c[i]->stream;
+		input_buffers[i].data = &source_c[i]->stream;
 		i++;
 	}
 
 	num_input_buffers = i;
 
-	mod->output_buffers[0].size = 0;
-	mod->output_buffers[0].data = &sinks_c[0]->stream;
+	output_buffers[0].size = 0;
+	output_buffers[0].data = &sinks_c[0]->stream;
 
 	return num_input_buffers;
 }
@@ -657,7 +630,10 @@ module_single_sink_setup(struct comp_dev *dev,
 static uint32_t
 module_single_source_setup(struct comp_dev *dev,
 			   struct comp_buffer __sparse_cache **source_c,
-			   struct comp_buffer __sparse_cache **sinks_c)
+			   struct comp_buffer __sparse_cache **sinks_c,
+			   struct input_stream_buffer *input_buffers,
+			   struct output_stream_buffer *output_buffers)
+
 {
 	struct processing_module *mod = comp_get_drvdata(dev);
 	struct comp_copy_limits c;
@@ -677,8 +653,8 @@ module_single_source_setup(struct comp_dev *dev,
 			min_frames = MIN(min_frames, c.frames);
 			source_frame_bytes = c.source_frame_bytes;
 
-			mod->output_buffers[i].size = 0;
-			mod->output_buffers[i].data = &sinks_c[i]->stream;
+			output_buffers[i].size = 0;
+			output_buffers[i].data = &sinks_c[i]->stream;
 			i++;
 		}
 	}
@@ -689,9 +665,9 @@ module_single_source_setup(struct comp_dev *dev,
 		buffer_stream_invalidate(source_c[0], min_frames * source_frame_bytes);
 
 	/* note that the size is in number of frames not the number of bytes */
-	mod->input_buffers[0].size = min_frames;
-	mod->input_buffers[0].consumed = 0;
-	mod->input_buffers[0].data = &source_c[0]->stream;
+	input_buffers[0].size = min_frames;
+	input_buffers[0].consumed = 0;
+	input_buffers[0].data = &source_c[0]->stream;
 
 	return num_output_buffers;
 }
@@ -700,6 +676,8 @@ static int module_adapter_simple_copy(struct comp_dev *dev)
 {
 	struct comp_buffer __sparse_cache *source_c[PLATFORM_MAX_STREAMS];
 	struct comp_buffer __sparse_cache *sinks_c[PLATFORM_MAX_STREAMS];
+	struct input_stream_buffer input_buffers[PLATFORM_MAX_STREAMS];
+	struct output_stream_buffer output_buffers[PLATFORM_MAX_STREAMS];
 	struct processing_module *mod = comp_get_drvdata(dev);
 	struct list_item *blist;
 	uint32_t num_input_buffers = 0;
@@ -712,28 +690,39 @@ static int module_adapter_simple_copy(struct comp_dev *dev)
 
 		sink = container_of(blist, struct comp_buffer, source_list);
 		sinks_c[i++] = buffer_acquire(sink);
+		num_output_buffers++;
 	}
+
 	i = 0;
 	list_for_item(blist, &dev->bsource_list) {
 		struct comp_buffer *source;
 
 		source = container_of(blist, struct comp_buffer, sink_list);
 		source_c[i++] = buffer_acquire(source);
+		num_input_buffers++;
 	}
 
 	/* setup active input/output buffers for processing */
-	if (mod->num_output_buffers == 1) {
-		num_input_buffers = module_single_sink_setup(dev, source_c, sinks_c);
+	if (num_output_buffers == 1) {
+		num_input_buffers = module_single_sink_setup(
+				dev, source_c, sinks_c, input_buffers, output_buffers);
 		if (sinks_c[0]->sink->state == dev->state)
 			num_output_buffers = 1;
-	} else {
-		num_output_buffers = module_single_source_setup(dev, source_c, sinks_c);
+	} else if (num_output_buffers > 1) {
+		/* num_output_buffers > 1 has been checked before,
+		 * but compiler shows "unint" warning
+		 */
+		num_output_buffers = module_single_source_setup(
+				dev, source_c, sinks_c, input_buffers, output_buffers);
 		if (source_c[0]->source->state == dev->state)
 			num_input_buffers = 1;
+	} else {
+		ret = -EINVAL;
+		goto out;
 	}
 
-	ret = module_process(mod, mod->input_buffers, num_input_buffers,
-			     mod->output_buffers, num_output_buffers);
+	ret = module_process(mod, input_buffers, num_input_buffers,
+			     output_buffers, num_output_buffers);
 	if (ret) {
 		if (ret != -ENOSPC && ret != -ENODATA) {
 			comp_err(dev, "module_adapter_simple_copy() process failed with error: %x",
@@ -748,18 +737,16 @@ static int module_adapter_simple_copy(struct comp_dev *dev)
 	for (i = 0; i < num_input_buffers; i++) {
 		struct comp_buffer __sparse_cache *src_c;
 
-		src_c = attr_container_of(mod->input_buffers[i].data,
+		src_c = attr_container_of(input_buffers[i].data,
 					  struct comp_buffer __sparse_cache,
 					  stream, __sparse_cache);
-		comp_update_buffer_consume(src_c, mod->input_buffers[i].consumed);
+		comp_update_buffer_consume(src_c, input_buffers[i].consumed);
 	}
 
 	/* release all source buffers */
 	i = 0;
 	list_for_item(blist, &dev->bsource_list) {
 		buffer_release(source_c[i]);
-		mod->input_buffers[i].size = 0;
-		mod->input_buffers[i].consumed = 0;
 		i++;
 	}
 
@@ -767,20 +754,19 @@ static int module_adapter_simple_copy(struct comp_dev *dev)
 	for (i = 0; i < num_output_buffers; i++) {
 		struct comp_buffer __sparse_cache *sink_c;
 
-		sink_c = attr_container_of(mod->output_buffers[i].data,
+		sink_c = attr_container_of(output_buffers[i].data,
 					   struct comp_buffer __sparse_cache,
 					   stream, __sparse_cache);
 
 		if (!mod->skip_sink_buffer_writeback)
-			buffer_stream_writeback(sink_c, mod->output_buffers[i].size);
-		comp_update_buffer_produce(sink_c, mod->output_buffers[i].size);
+			buffer_stream_writeback(sink_c, output_buffers[i].size);
+		comp_update_buffer_produce(sink_c, output_buffers[i].size);
 	}
 
 	/* release all sink buffers */
 	i = 0;
 	list_for_item(blist, &dev->bsink_list) {
 		buffer_release(sinks_c[i]);
-		mod->output_buffers[i++].size = 0;
 	}
 
 	return 0;
@@ -792,19 +778,15 @@ out:
 	list_for_item(blist, &dev->bsource_list)
 		buffer_release(source_c[i++]);
 
-	for (i = 0; i < mod->num_output_buffers; i++)
-		mod->output_buffers[i].size = 0;
-
-	for (i = 0; i < mod->num_input_buffers; i++) {
-		mod->input_buffers[i].size = 0;
-		mod->input_buffers[i].consumed = 0;
-	}
-
 	return ret;
 }
 
 int module_adapter_copy(struct comp_dev *dev)
 {
+	struct input_stream_buffer input_buffers[PLATFORM_MAX_STREAMS];
+	struct output_stream_buffer output_buffers[PLATFORM_MAX_STREAMS];
+	uint32_t num_input_buffers = 0;
+	uint32_t num_output_buffers = 0;
 	struct processing_module *mod = comp_get_drvdata(dev);
 	struct module_data *md = &mod->priv;
 	struct comp_buffer *source, *sink;
@@ -826,8 +808,13 @@ int module_adapter_copy(struct comp_dev *dev)
 		min_free_frames = MIN(min_free_frames,
 				      audio_stream_get_free_frames(&sink_c->stream));
 		buffer_release(sink_c);
+		output_buffers[i].data = mod->local_output_buffer[i];
+		output_buffers[i].size = 0;
+		i++;
 	}
+	num_output_buffers = i;
 
+	i = 0;
 	/* copy source samples into input buffer */
 	list_for_item(blist, &dev->bsource_list) {
 		struct comp_buffer __sparse_cache *src_c;
@@ -850,26 +837,24 @@ int module_adapter_copy(struct comp_dev *dev)
 		bytes_to_process = MIN(frames * source_frame_bytes, md->mpd.in_buff_size);
 
 		buffer_stream_invalidate(src_c, bytes_to_process);
-		mod->input_buffers[i].size = bytes_to_process;
-		mod->input_buffers[i].consumed = 0;
+		input_buffers[i].size = bytes_to_process;
+		input_buffers[i].consumed = 0;
+		input_buffers[i].data = mod->local_input_buffer[i];
 
-		ca_copy_from_source_to_module(&src_c->stream, mod->input_buffers[i].data,
+		ca_copy_from_source_to_module(&src_c->stream, input_buffers[i].data,
 					      md->mpd.in_buff_size, bytes_to_process);
 		buffer_release(src_c);
-
 		i++;
 	}
+	num_input_buffers = i;
 
-	ret = module_process(mod, mod->input_buffers, mod->num_input_buffers,
-			     mod->output_buffers, mod->num_output_buffers);
-	if (ret) {
-		if (ret != -ENOSPC && ret != -ENODATA) {
-			comp_err(dev, "module_adapter_copy() error %x: module processing failed",
-				 ret);
-			goto out;
-		}
+	ret = module_process(mod, input_buffers, num_input_buffers,
+			     output_buffers, num_output_buffers);
 
-		ret = 0;
+	if (ret && ret != -ENOSPC && ret != -ENODATA) {
+		comp_err(dev, "module_adapter_copy() error %d: module processing failed",
+			 ret);
+		return ret;
 	}
 
 	i = 0;
@@ -880,29 +865,15 @@ int module_adapter_copy(struct comp_dev *dev)
 		source = container_of(blist, struct comp_buffer, sink_list);
 		src_c = buffer_acquire(source);
 
-		comp_update_buffer_consume(src_c, mod->input_buffers[i].consumed);
+		comp_update_buffer_consume(src_c, input_buffers[i].consumed);
 		buffer_release(src_c);
 
-		bzero((__sparse_force void *)mod->input_buffers[i].data, size);
-		mod->input_buffers[i].size = 0;
-		mod->input_buffers[i].consumed = 0;
+		bzero((__sparse_force void *)input_buffers[i].data, size);
 		i++;
 	}
-	module_adapter_process_output(dev);
+	module_adapter_process_output(dev, input_buffers, output_buffers);
 
 	return 0;
-
-out:
-	for (i = 0; i < mod->num_output_buffers; i++)
-		mod->output_buffers[i].size = 0;
-
-	for (i = 0; i < mod->num_input_buffers; i++) {
-		bzero((__sparse_force void *)mod->input_buffers[i].data, size);
-		mod->input_buffers[i].size = 0;
-		mod->input_buffers[i].consumed = 0;
-	}
-
-	return ret;
 }
 
 static int module_adapter_get_set_params(struct comp_dev *dev, struct sof_ipc_ctrl_data *cdata,
@@ -1072,7 +1043,8 @@ int module_adapter_trigger(struct comp_dev *dev, int cmd)
 	}
 
 #if CONFIG_IPC_MAJOR_3
-	if (mod->num_input_buffers > 1) {
+	/* check if we do have more than 1 input buffer */
+	if (!list_item_is_last(dev->bsource_list.next, &dev->bsource_list)) {
 		bool sources_active;
 		int ret;
 
@@ -1111,19 +1083,10 @@ int module_adapter_reset(struct comp_dev *dev)
 	}
 
 	if (!mod->simple_copy)
-		for (i = 0; i < mod->num_output_buffers; i++)
-			rfree((__sparse_force void *)mod->output_buffers[i].data);
-
-	rfree(mod->output_buffers);
-
-	if (!mod->simple_copy)
-		for (i = 0; i < mod->num_input_buffers; i++)
-			rfree((__sparse_force void *)mod->input_buffers[i].data);
-
-	rfree(mod->input_buffers);
-
-	mod->num_input_buffers = 0;
-	mod->num_output_buffers = 0;
+		for (i = 0; i < PLATFORM_MAX_STREAMS; i++) {
+			rfree((__sparse_force void *)mod->local_input_buffer[i]);
+			rfree((__sparse_force void *)mod->local_output_buffer[i]);
+		}
 
 	list_for_item(blist, &mod->sink_buffer_list) {
 		struct comp_buffer *buffer = container_of(blist, struct comp_buffer,

--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -493,19 +493,19 @@ static int demux_process(struct processing_module *mod,
 		return 0;
 
 	frames = input_buffers[0].size;
-	source_bytes = frames * audio_stream_frame_bytes(mod->input_buffers[0].data);
-	sink_bytes = frames * audio_stream_frame_bytes(mod->output_buffers[0].data);
+	source_bytes = frames * audio_stream_frame_bytes(input_buffers[0].data);
+	sink_bytes = frames * audio_stream_frame_bytes(output_buffers[0].data);
 
 	/* produce output, one sink at a time */
 	for (i = 0; i < num_output_buffers; i++) {
 		demux_prepare_active_look_up(cd, sinks_stream[i],
 					     input_buffers[0].data, look_ups[i]);
 		cd->demux(dev, sinks_stream[i], input_buffers[0].data, frames, &cd->active_lookup);
-		mod->output_buffers[i].size = sink_bytes;
+		output_buffers[i].size = sink_bytes;
 	}
 
 	/* Update consumed */
-	mod->input_buffers[0].consumed = source_bytes;
+	input_buffers[0].consumed = source_bytes;
 	return 0;
 }
 
@@ -549,16 +549,16 @@ static int mux_process(struct processing_module *mod,
 		return 0;
 
 	frames = input_buffers[0].size;
-	source_bytes = frames * audio_stream_frame_bytes(mod->input_buffers[0].data);
-	sink_bytes = frames * audio_stream_frame_bytes(mod->output_buffers[0].data);
+	source_bytes = frames * audio_stream_frame_bytes(input_buffers[0].data);
+	sink_bytes = frames * audio_stream_frame_bytes(output_buffers[0].data);
 	mux_prepare_active_look_up(cd, output_buffers[0].data, &sources_stream[0]);
 
 	/* produce output */
 	cd->mux(dev, output_buffers[0].data, &sources_stream[0], frames, &cd->active_lookup);
 
 	/* Update consumed and produced */
-	mod->input_buffers[0].consumed = source_bytes;
-	mod->output_buffers[0].size = sink_bytes;
+	input_buffers[0].consumed = source_bytes;
+	output_buffers[0].size = sink_bytes;
 	return 0;
 }
 

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -974,8 +974,8 @@ static int src_process(struct processing_module *mod,
 	comp_dbg(dev, "src_process()");
 
 	/* src component needs 1 source and 1 sink buffer */
-	source_c = (struct audio_stream *)input_buffers[0].data;
-	sink_c = (struct audio_stream *)output_buffers[0].data;
+	source_c = (struct audio_stream __sparse_cache *)input_buffers[0].data;
+	sink_c = (struct audio_stream __sparse_cache *)output_buffers[0].data;
 
 	ret = src_get_copy_limits(cd, source_c, sink_c);
 	if (ret) {

--- a/src/audio/up_down_mixer/up_down_mixer.c
+++ b/src/audio/up_down_mixer/up_down_mixer.c
@@ -430,26 +430,26 @@ up_down_mixer_process(struct processing_module *mod,
 
 	comp_dbg(dev, "up_down_mixer_process()");
 
-	mix_frames = audio_stream_avail_frames(mod->input_buffers[0].data,
-					       mod->output_buffers[0].data);
+	mix_frames = audio_stream_avail_frames(input_buffers[0].data,
+					       output_buffers[0].data);
 
-	source_bytes = mix_frames * audio_stream_frame_bytes(mod->input_buffers[0].data);
-	sink_bytes = mix_frames * audio_stream_frame_bytes(mod->output_buffers[0].data);
+	source_bytes = mix_frames * audio_stream_frame_bytes(input_buffers[0].data);
+	sink_bytes = mix_frames * audio_stream_frame_bytes(output_buffers[0].data);
 
 	if (source_bytes) {
 		uint32_t sink_sample_bytes;
 
-		audio_stream_copy_to_linear(mod->input_buffers[0].data, 0, cd->buf_in, 0,
+		audio_stream_copy_to_linear(input_buffers[0].data, 0, cd->buf_in, 0,
 					    source_bytes /
-					    audio_stream_sample_bytes(mod->input_buffers[0].data));
+					    audio_stream_sample_bytes(input_buffers[0].data));
 
 		cd->mix_routine(cd, (uint8_t *)cd->buf_in, source_bytes, (uint8_t *)cd->buf_out);
 
-		sink_sample_bytes = audio_stream_sample_bytes(mod->output_buffers[0].data);
-		audio_stream_copy_from_linear(cd->buf_out, 0, mod->output_buffers[0].data, 0,
+		sink_sample_bytes = audio_stream_sample_bytes(output_buffers[0].data);
+		audio_stream_copy_from_linear(cd->buf_out, 0, output_buffers[0].data, 0,
 					      sink_bytes / sink_sample_bytes);
-		mod->output_buffers[0].size = sink_bytes;
-		mod->input_buffers[0].consumed = source_bytes;
+		output_buffers[0].size = sink_bytes;
+		input_buffers[0].consumed = source_bytes;
 	}
 
 	return 0;

--- a/src/include/sof/audio/module_adapter/module/generic.h
+++ b/src/include/sof/audio/module_adapter/module/generic.h
@@ -179,13 +179,19 @@ struct processing_module {
 	uint32_t period_bytes; /** pipeline period bytes */
 	uint32_t deep_buff_bytes; /**< copy start threshold */
 	uint32_t output_buffer_size; /**< size of local buffer to save produced samples */
-	struct input_stream_buffer *input_buffers;
-	struct output_stream_buffer *output_buffers;
-	uint32_t num_input_buffers; /**< number of input buffers */
-	uint32_t num_output_buffers; /**< number of output buffers */
+		/**< pointers local input buffers in case of raw data mode */
+	void __sparse_cache *local_input_buffer[PLATFORM_MAX_STREAMS];
+		/**< pointers local output buffer in case of raw data mode */
+	void __sparse_cache *local_output_buffer[PLATFORM_MAX_STREAMS];
 	/*
 	 * flag set by a module that produces period_bytes every copy. It can be used by modules
 	 * that support 1:1, 1:N, N:1 sources:sinks configuration.
+	 *
+	 * in module_process: input_buffers->data and output_buffers->data point to
+	 *   audio_stream structures
+	 *
+	 * in case simple_copy==0 (a.k.a "raw data mode") double buffering will occur
+	 *    input_buffers->data and output_buffers->data point to raw linear data buffers
 	 */
 	bool simple_copy;
 


### PR DESCRIPTION
Module process API provides pointers to data sources and data destinations.
Modules should always use it instead of going directly to internal structures