### PR TITLE
smart_amp_test: fix unbind implementation

### DIFF
--- a/src/samples/audio/smart_amp_test.c
+++ b/src/samples/audio/smart_amp_test.c
@@ -298,7 +298,7 @@ static int smart_amp_unbind(struct comp_dev *dev, void *data)
 
 	comp_dbg(dev, "smart_amp_unbind()");
 
-	if (bu->extension.r.dst_instance_id == SOF_SMART_AMP_FEEDBACK_QUEUE_ID) {
+	if (bu->extension.r.dst_queue == SOF_SMART_AMP_FEEDBACK_QUEUE_ID) {
 		k_mutex_lock(&sad->lock, K_FOREVER);
 		sad->feedback_buf = NULL;
 		k_mutex_unlock(&sad->lock);


### PR DESCRIPTION
Code in unbind is looking at wrong field for queue-id. This works some of the time, but in some cases leads to access to freed heap data and later to heap corruption.

Link: https://github.com/thesofproject/sof/issues/7191