### PR TITLE
ipc4: raise error when DP cannot be created

### DIFF
--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -98,10 +98,18 @@ struct comp_dev *comp_new_ipc4(struct ipc4_module_init_instance *module_init)
 	ipc_config.pipeline_id = module_init->extension.r.ppl_instance_id;
 	ipc_config.core = module_init->extension.r.core_id;
 
+#if CONFIG_ZEPHYR_DP_SCHEDULER
 	if (module_init->extension.r.proc_domain)
 		ipc_config.proc_domain = COMP_PROCESSING_DOMAIN_DP;
 	else
 		ipc_config.proc_domain = COMP_PROCESSING_DOMAIN_LL;
+#else /* CONFIG_ZEPHYR_DP_SCHEDULER */
+	if (module_init->extension.r.proc_domain) {
+		tr_err(&ipc_tr, "ipc: DP scheduling is disabled, cannot create comp %d", comp_id);
+		return NULL;
+	}
+	ipc_config.proc_domain = COMP_PROCESSING_DOMAIN_LL;
+#endif /* CONFIG_ZEPHYR_DP_SCHEDULER */
 
 	dcache_invalidate_region((__sparse_force void __sparse_cache *)MAILBOX_HOSTBOX_BASE,
 				 MAILBOX_HOSTBOX_SIZE);

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -40,6 +40,7 @@ config ZEPHYR_DP_SCHEDULER
 	default n
 	depends on IPC_MAJOR_4
 	depends on ZEPHYR_SOF_MODULE
+	depends on ACE
 	help
 	  Enable Data Processing preemptive scheduler based on
 	  Zephyr preemptive threads.


### PR DESCRIPTION
DP scheduler is intended to work on MTL and
future platforms only - has not been tested on
any legacy.
1) dependency on ACE to compile DP is introduced
2) when a DP module is to be created when DP
is disabled, module creation is rejected