### PR TITLE
zephyr: include: rtos: Use native Zephyr cache management functions o…

### DIFF
--- a/zephyr/include/rtos/cache.h
+++ b/zephyr/include/rtos/cache.h
@@ -24,12 +24,6 @@
 
 #endif /* defined(CONFIG_XTENSA) && defined(CONFIG_INTEL) */
 
-/* writeback and invalidate data */
-#define CACHE_WRITEBACK_INV	0
-
-/* invalidate data */
-#define CACHE_INVALIDATE	1
-
 /* sanity check - make sure CONFIG_DCACHE_LINE_SIZE is valid */
 #if !defined(CONFIG_DCACHE_LINE_SIZE_DETECT) && (CONFIG_DCACHE_LINE_SIZE > 0)
 #define DCACHE_LINE_SIZE CONFIG_DCACHE_LINE_SIZE

--- a/zephyr/include/rtos/cache.h
+++ b/zephyr/include/rtos/cache.h
@@ -6,14 +6,65 @@
 #ifndef __ZEPHYR_RTOS_CACHE_H__
 #define __ZEPHYR_RTOS_CACHE_H__
 
-/* TODO: align with Zephyr generic cache API when ready */
 #define __SOF_LIB_CACHE_H__
-#include <arch/lib/cache.h>
+
+#if !defined(__ASSEMBLER__) && !defined(LINKER)
+
+#include <zephyr/cache.h>
+#include <zephyr/debug/sparse.h>
+
+#if defined(CONFIG_XTENSA) && defined(CONFIG_INTEL)
+
+/* definitions required by xtensa-based Intel platforms.
+ *
+ * TODO: if possible, move these to Zephyr.
+ */
+#define SRAM_UNCACHED_ALIAS 0x20000000
+#define is_cached(address) (!!((uintptr_t)(address) & SRAM_UNCACHED_ALIAS))
+
+#endif /* defined(CONFIG_XTENSA) && defined(CONFIG_INTEL) */
 
 /* writeback and invalidate data */
 #define CACHE_WRITEBACK_INV	0
 
 /* invalidate data */
 #define CACHE_INVALIDATE	1
+
+/* sanity check - make sure CONFIG_DCACHE_LINE_SIZE is valid */
+#if !defined(CONFIG_DCACHE_LINE_SIZE_DETECT) && (CONFIG_DCACHE_LINE_SIZE > 0)
+#define DCACHE_LINE_SIZE CONFIG_DCACHE_LINE_SIZE
+#else
+#if defined(CONFIG_LIBRARY) || defined(CONFIG_ZEPHYR_POSIX)
+#define DCACHE_LINE_SIZE 64
+#else
+#error "Invalid cache configuration."
+#endif /* defined(CONFIG_LIBRARY) || defined(CONFIG_ZEPHYR_POSIX) */
+#endif /* !defined(CONFIG_DCACHE_LINE_SIZE_DETECT) && (CONFIG_DCACHE_LINE_SIZE > 0) */
+
+static inline void dcache_writeback_region(void __sparse_cache *addr, size_t size)
+{
+	/* TODO: return value should probably be checked here */
+	sys_cache_data_flush_range((__sparse_force void *)addr, size);
+}
+
+static inline void dcache_invalidate_region(void __sparse_cache *addr, size_t size)
+{
+	/* TODO: return value should probably be checked here */
+	sys_cache_data_invd_range((__sparse_force void *)addr, size);
+}
+
+static inline void icache_invalidate_region(void __sparse_cache *addr, size_t size)
+{
+	/* TODO: return value should probably be checked here */
+	sys_cache_instr_invd_range((__sparse_force void *)addr, size);
+}
+
+static inline void dcache_writeback_invalidate_region(void __sparse_cache *addr, size_t size)
+{
+	/* TODO: return value should probably be checked here */
+	sys_cache_data_flush_and_invd_range((__sparse_force void *)addr, size);
+}
+
+#endif /* !defined(__ASSEMBLER__) && !defined(LINKER) */
 
 #endif /* __ZEPHYR_RTOS_CACHE_H__ */


### PR DESCRIPTION
Since Zephyr offers cache-management operations for the arm64 architecture we can make use of them on all ARM64-based platforms. In time, if the architecture supports it, more platforms could end up using them instead of using the ones in arch/lib/cache.h.

**Please see https://github.com/thesofproject/sof/issues/7192 for PR dependency graph.**