### PR TITLE
include: sof: debug: gdb: gdb.h: Add ifdef guard for symbol definition

### DIFF
--- a/src/include/sof/debug/gdb/gdb.h
+++ b/src/include/sof/debug/gdb/gdb.h
@@ -8,6 +8,16 @@
 #ifndef __SOF_DEBUG_GDB_GDB_H__
 #define __SOF_DEBUG_GDB_GDB_H__
 
+/* unconditionally including this header will cause
+ * problems on architectures such as ARM64 with Zephyr
+ * since they don't have an entry in arch/.
+ *
+ * since GDB debug is only to be used when CONFIG_GDB_DEBUG=y
+ * we can safely avoid this problem with the below conditional
+ * definition of the symbols.
+ */
+#ifdef CONFIG_GDB_DEBUG
+
 #include <arch/debug/gdb/init.h>
 #include <arch/debug/gdb/utilities.h>
 
@@ -29,5 +39,7 @@ void gdb_handle_exception(void);
 void gdb_debug_info(unsigned char *str);
 void gdb_init_debug_exception(void);
 void gdb_init(void);
+
+#endif /* CONFIG_GDB_DEBUG */
 
 #endif /* __SOF_DEBUG_GDB_GDB_H__ */


### PR DESCRIPTION
GDB debug should only be used when CONFIG_DBG_DEBUG=y. On ARM64 platforms with Zephyr, including this header will cause compilation errors due to the fact that they don't have an arch/ entry. This commit fixes this issue by conditionally defining all symbols based on CONFIG_GDB_DEBUG.

**Please see https://github.com/thesofproject/sof/issues/7192 for PR dependency graph.**