### PR TITLE
Add support for SOF_IPC_FW_READY message initiated by host

### DIFF
--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -198,6 +198,20 @@ int task_main_start(struct sof *sof)
 	return 0;
 }
 
+static int boot_complete(void)
+{
+#ifdef CONFIG_IMX93_A55
+	/* in the case of i.MX93, SOF_IPC_FW_READY
+	 * sequence will be initiated by the host
+	 * so we shouldn't do anything here.
+	 */
+	return 0;
+#else
+	/* let host know DSP boot is complete */
+	return platform_boot_complete(0);
+#endif /* CONFIG_IMX93_A55 */
+}
+
 int start_complete(void)
 {
 #if defined(CONFIG_IMX)
@@ -215,9 +229,7 @@ int start_complete(void)
 	pm_policy_state_lock_get(PM_STATE_RUNTIME_IDLE, PM_ALL_SUBSTATES);
 	pm_policy_state_lock_get(PM_STATE_SOFT_OFF, PM_ALL_SUBSTATES);
 #endif
-
-	/* let host know DSP boot is complete */
-	return platform_boot_complete(0);
+	return boot_complete();
 }
 
 /*


### PR DESCRIPTION
In the case of i.MX93 Linux will send an IPC_FW_READY message to SOF and will expect to receive the following information in the hostbox:
	1) reply structure
	2) sof_ipc_fw_ready structure
	3) sof_ipc_window structure

This flow is required because Jailhouse is currently controlled from user space. This means that SOF will be up before the platform driver from Linux so the IPC_FW_READY sequence can't be initiated by SOF.

**Please see https://github.com/thesofproject/sof/issues/7192 for PR dependency graph.**