### PR TITLE
Remove unused soc.h header inclusions

### DIFF
--- a/zephyr/lib/alloc.c
+++ b/zephyr/lib/alloc.c
@@ -25,7 +25,6 @@
 #include <zephyr/pm/policy.h>
 #include <version.h>
 #include <zephyr/sys/__assert.h>
-#include <soc.h>
 
 #if defined(CONFIG_ARCH_XTENSA) && !defined(CONFIG_KERNEL_COHERENCE)
 #include <zephyr/arch/xtensa/cache.h>

--- a/zephyr/lib/cpu.c
+++ b/zephyr/lib/cpu.c
@@ -15,7 +15,6 @@
 #include <sof/lib/pm_runtime.h>
 
 /* Zephyr includes */
-#include <soc.h>
 #include <version.h>
 #include <zephyr/kernel.h>
 

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -28,7 +28,6 @@
 #include <zephyr/pm/policy.h>
 #include <version.h>
 #include <zephyr/sys/__assert.h>
-#include <soc.h>
 
 LOG_MODULE_REGISTER(zephyr, CONFIG_SOF_LOG_LEVEL);
 


### PR DESCRIPTION
Since i.MX93 doesn't have a soc.h file in Zephyr nor does it need one right now, instead of adding an empty soc.h to Zephyr just encase the '#include <soc.h>' statement in an ifdef block.

**Please see https://github.com/thesofproject/sof/issues/7192 for PR dependency graph.**