### PR TITLE
src: init: init.c: Remove unused sof_init parameter

### DIFF
--- a/src/init/init.c
+++ b/src/init/init.c
@@ -340,10 +340,8 @@ int sof_main(int argc, char *argv[])
 
 struct device;
 
-static int sof_init(const struct device *dev)
+static int sof_init(void)
 {
-	ARG_UNUSED(dev);
-
 	return primary_core_init(0, NULL, &sof);
 }
 


### PR DESCRIPTION
This commit fixes compilation error:

"error: initialization of 'int (*)(void)' from incompatible pointer type 'int (*)(const struct device *)' [-Werror=incompatible-pointer-types]"

from SOF CI Zephyr builds.