### PR TITLE
schedule: zephyr_dma_domain: Conditionally call interrupt_clear_mask()

### DIFF
--- a/src/schedule/zephyr_dma_domain.c
+++ b/src/schedule/zephyr_dma_domain.c
@@ -32,6 +32,10 @@ LOG_MODULE_DECLARE(ll_schedule, CONFIG_SOF_LOG_LEVEL);
 #define interrupt_disable mux_interrupt_disable
 #endif
 
+#ifdef CONFIG_ARM64
+#define interrupt_clear_mask(irq, bit)
+#endif /* CONFIG_ARM64 */
+
 #define SEM_LIMIT 1
 #define ZEPHYR_PDOMAIN_STACK_SIZE 8192
 


### PR DESCRIPTION
There's no need to clear IRQ mask on ARM64 architecture as there's currently no way to mask them. This commit aims to fix the compilation issues that would be caused by calling interrupt_clear_mask() on ARM64-based platforms.