### PR TITLE
topology2: cavs-rt5682: remove 24-bit override in mixout-gain-dai-cop…

### DIFF
--- a/tools/topology/topology2/cavs-rt5682.conf
+++ b/tools/topology/topology2/cavs-rt5682.conf
@@ -221,14 +221,6 @@ Object.Pipeline {
 				copier_type	"SSP"
 				stream_name	"$HEADSET_CODEC_NAME"
 				node_type $I2S_LINK_OUTPUT_CLASS
-
-				# override for 24-bit
-				Object.Base.audio_format.1 {
-					in_bit_depth		32
-					in_valid_bit_depth	24
-					out_bit_depth		32
-					out_valid_bit_depth	32
-				}
 			}
 
 			Object.Widget.gain.1 {


### PR DESCRIPTION
…ier-playback

With 208c2049f ("topology2: deep buffer: use 32 bits to align with other pipeline"), we can remove this override now.