### PR TITLE
topology2: tokens: Split the tokens for input/output pin index

### DIFF
--- a/tools/topology/topology2/include/common/input_audio_format.conf
+++ b/tools/topology/topology2/include/common/input_audio_format.conf
@@ -15,7 +15,7 @@ Class.Base."input_audio_format" {
 	DefineAttribute."instance" {
 	}
 
-	DefineAttribute."pin_index" {
+	DefineAttribute."input_pin_index" {
 		# Token set reference name
 		token_ref	"sof_tkn_cavs_audio_format.word"
 	}

--- a/tools/topology/topology2/include/common/output_audio_format.conf
+++ b/tools/topology/topology2/include/common/output_audio_format.conf
@@ -15,7 +15,7 @@ Class.Base."output_audio_format" {
 	DefineAttribute."instance" {
 	}
 
-	DefineAttribute."pin_index" {
+	DefineAttribute."output_pin_index" {
 		# Token set reference name
 		token_ref	"sof_tkn_cavs_audio_format.word"
 	}

--- a/tools/topology/topology2/include/common/tokens.conf
+++ b/tools/topology/topology2/include/common/tokens.conf
@@ -156,7 +156,7 @@ Object.Base.VendorToken {
 		in_interleaving_style	1906
 		in_fmt_cfg		1907
 		in_sample_type		1908
-		pin_index		1909
+		input_pin_index		1909
 		# tokens up to 1929 reserved for future use
 		out_rate		1930
 		out_bit_depth		1931
@@ -167,6 +167,7 @@ Object.Base.VendorToken {
 		out_interleaving_style	1936
 		out_fmt_cfg		1937
 		out_sample_type		1938
+		output_pin_index	1939
 		# tokens up to 1969 reserved for future use
 		ibs			1970
 		obs			1971

--- a/tools/topology/topology2/include/pipelines/cavs/io-gateway.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/io-gateway.conf
@@ -46,32 +46,33 @@ Class.Pipeline."io-gateway" {
 			num_input_audio_formats 3
 			num_output_audio_formats 3
 			# 32-bit 48KHz 2ch
-			Object.Base.audio_format.3 {
-				in_bit_depth            32
-				in_valid_bit_depth      24
-				out_bit_depth           32
-				out_valid_bit_depth     24
-			}
-
-			Object.Base.audio_format.1 {
-				in_bit_depth		32
-				in_valid_bit_depth	32
-				out_bit_depth		32
-				out_valid_bit_depth	32
-			}
-			# 32-bit 48KHz 4ch
-			Object.Base.audio_format.2 {
-				in_channels		4
-				in_bit_depth		32
-				in_valid_bit_depth	32
-				out_channels		4
-				out_bit_depth		32
-				out_valid_bit_depth	32
-				in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-				in_ch_map	$CHANNEL_MAP_3_POINT_1
-				out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-				out_ch_map	$CHANNEL_MAP_3_POINT_1
-			}
+			Object.Base.audio_format [
+				{
+					in_bit_depth            32
+					in_valid_bit_depth      24
+					out_bit_depth           32
+					out_valid_bit_depth     24
+				}
+				{
+					in_bit_depth		32
+					in_valid_bit_depth	32
+					out_bit_depth		32
+					out_valid_bit_depth	32
+				}
+				# 32-bit 48KHz 4ch
+				{
+					in_channels		4
+					in_bit_depth		32
+					in_valid_bit_depth	32
+					out_channels		4
+					out_bit_depth		32
+					out_valid_bit_depth	32
+					in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+					in_ch_map	$CHANNEL_MAP_3_POINT_1
+					out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+					out_ch_map	$CHANNEL_MAP_3_POINT_1
+				}
+			]
 		}
 
 		pipeline."1" {

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-gain-smart-amp-dai-copier-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-gain-smart-amp-dai-copier-playback.conf
@@ -93,18 +93,18 @@ Class.Pipeline."mixout-gain-smart-amp-dai-copier-playback" {
 			# 32-bit 48KHz 2ch
 			Object.Base.input_audio_format {
 				1 {
-					pin_index		0
+					input_pin_index	0
 					in_bit_depth		32
 					in_valid_bit_depth	32
 				}
 				2 {
-					pin_index		1
+					input_pin_index	1
 					in_bit_depth		32
 					in_valid_bit_depth	32
 				}
 			}
 			Object.Base.output_audio_format.1 {
-				pin_index 0
+				output_pin_index 0
 				out_bit_depth		32
 				out_valid_bit_depth	32
 			}


### PR DESCRIPTION
Separate the pin index token ID for input/output pin index to avoid collisions between the two and incorrect pin index parsing in the kernel.

Corresponding kernel PR: https://github.com/thesofproject/linux/pull/4311

There is no dependency between the two in terms of merging.