### PR TITLE
topology2: Remove unnecessary audio formats 

### DIFF
--- a/tools/topology/topology2/include/components/mixin.conf
+++ b/tools/topology/topology2/include/components/mixin.conf
@@ -100,21 +100,18 @@ Class.Widget."mixin" {
 	}
 
 	# Only 32-bit depth format is supported by mixin
-	num_audio_formats 2
+	num_audio_formats 1
+	num_input_audio_formats 1
+	num_output_audio_formats 1
 	# 32-bit 48KHz 2ch
-	Object.Base.audio_format.1 {
-		in_bit_depth		32
-		in_valid_bit_depth	24
-		out_bit_depth		32
-		out_valid_bit_depth	24
-	}
-
-	Object.Base.audio_format.2 {
-		in_bit_depth            32
-		in_valid_bit_depth      32
-		out_bit_depth           32
-		out_valid_bit_depth     32
-	}
+	Object.Base.audio_format [
+		{
+			in_bit_depth            32
+			in_valid_bit_depth      32
+			out_bit_depth           32
+			out_valid_bit_depth     32
+		}
+	]
 
 	#
 	# Default attributes for mixin
@@ -129,6 +126,5 @@ Class.Widget."mixin" {
 	cpc 910
 	num_input_pins	1
 	num_output_pins	3
-	num_input_audio_formats 2
-	num_output_audio_formats 2
+
 }

--- a/tools/topology/topology2/include/components/mixout.conf
+++ b/tools/topology/topology2/include/components/mixout.conf
@@ -100,23 +100,18 @@ Class.Widget."mixout" {
 	}
 
 	# Only 32-bit depth format is supported by mixout
-	num_audio_formats 2
-	num_input_audio_formats 2
-	num_output_audio_formats 2
+	num_audio_formats 1
+	num_input_audio_formats 1
+	num_output_audio_formats 1
 	# 32-bit 48KHz 2ch
-	Object.Base.audio_format.1 {
-		in_bit_depth		32
-		in_valid_bit_depth	24
-		out_bit_depth		32
-		out_valid_bit_depth	24
-	}
-
-	Object.Base.audio_format.2 {
-		in_bit_depth            32
-		in_valid_bit_depth      32
-		out_bit_depth           32
-		out_valid_bit_depth     32
-	}
+	Object.Base.audio_format [
+		{
+			in_bit_depth            32
+			in_valid_bit_depth      32
+			out_bit_depth           32
+			out_valid_bit_depth     32
+		}
+	]
 
 	#
 	# Default attributes for mixout

--- a/tools/topology/topology2/include/pipelines/cavs/deepbuffer-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/deepbuffer-playback.conf
@@ -75,24 +75,19 @@ Class.Pipeline."deepbuffer-playback" {
 		}
 
 		gain."1" {
-			num_audio_formats 2
-			num_input_audio_formats 2
-			num_output_audio_formats 2
+			num_audio_formats 1
+			num_input_audio_formats 1
+			num_output_audio_formats 1
 
 			# 32-bit 48KHz 2ch
-			Object.Base.audio_format.1 {
-				in_bit_depth		32
-				in_valid_bit_depth	24
-				out_bit_depth		32
-				out_valid_bit_depth	24
-			}
-
-			Object.Base.audio_format.2 {
-				in_bit_depth		32
-				in_valid_bit_depth	32
-				out_bit_depth		32
-				out_valid_bit_depth	32
-			}
+			Object.Base.audio_format [
+				{
+					in_bit_depth		32
+					in_valid_bit_depth	32
+					out_bit_depth		32
+					out_valid_bit_depth	32
+				}
+			]
 		}
 
 		mixin."1" {}

--- a/tools/topology/topology2/include/pipelines/cavs/host-copier-gain-mixin-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/host-copier-gain-mixin-playback.conf
@@ -74,24 +74,19 @@ Class.Pipeline."host-copier-gain-mixin-playback" {
 		}
 
 		gain."1" {
-			num_audio_formats 2
-			num_input_audio_formats 2
-			num_output_audio_formats 2
+			num_audio_formats 1
+			num_input_audio_formats 1
+			num_output_audio_formats 1
 
 			# 32-bit 48KHz 2ch
-			Object.Base.audio_format.1 {
-				in_bit_depth		32
-				in_valid_bit_depth	24
-				out_bit_depth		32
-				out_valid_bit_depth	24
-			}
-
-			Object.Base.audio_format.2 {
-				in_bit_depth		32
-				in_valid_bit_depth	32
-				out_bit_depth		32
-				out_valid_bit_depth	32
-			}
+			Object.Base.audio_format [
+				{
+					in_bit_depth		32
+					in_valid_bit_depth	32
+					out_bit_depth		32
+					out_valid_bit_depth	32
+				}
+			]
 		}
 
 		mixin."1" {}

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-gain-dai-copier-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-gain-dai-copier-playback.conf
@@ -50,44 +50,34 @@ Class.Pipeline."mixout-gain-dai-copier-playback" {
 			type dai_in
 			period_sink_count 0
 			period_source_count 2
-			num_audio_formats 2
-			num_input_audio_formats 2
-			num_output_audio_formats 2
+			num_audio_formats 1
+			num_input_audio_formats 1
+			num_output_audio_formats 1
 
 			# copier only supports one format based on mixin/mixout requirements: 32-bit 48KHz 2ch
-			Object.Base.audio_format.1 {
-				in_bit_depth		32
-				in_valid_bit_depth	24
-				out_bit_depth		32
-				out_valid_bit_depth	24
-			}
-
-			Object.Base.audio_format.2 {
-				in_bit_depth		32
-				in_valid_bit_depth	32
-				out_bit_depth		32
-				out_valid_bit_depth	32
-			}
+			Object.Base.audio_format [
+				{
+					in_bit_depth		32
+					in_valid_bit_depth	32
+					out_bit_depth		32
+					out_valid_bit_depth	32
+				}
+			]
 		}
 		gain."1" {
-			num_audio_formats 2
-			num_input_audio_formats 2
-			num_output_audio_formats 2
+			num_audio_formats 1
+			num_input_audio_formats 1
+			num_output_audio_formats 1
 
 			# 32-bit 48KHz 2ch
-			Object.Base.audio_format.1 {
-				in_bit_depth		32
-				in_valid_bit_depth	24
-				out_bit_depth		32
-				out_valid_bit_depth	24
-			}
-
-			Object.Base.audio_format.2 {
-				in_bit_depth		32
-				in_valid_bit_depth	32
-				out_bit_depth		32
-				out_valid_bit_depth	32
-			}
+			Object.Base.audio_format [
+				{
+					in_bit_depth		32
+					in_valid_bit_depth	32
+					out_bit_depth		32
+					out_valid_bit_depth	32
+				}
+			]
 		}
 
 		pipeline."1" {

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-gain-smart-amp-dai-copier-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-gain-smart-amp-dai-copier-playback.conf
@@ -47,44 +47,34 @@ Class.Pipeline."mixout-gain-smart-amp-dai-copier-playback" {
 		mixout."1" {}
 		copier."1" {
 			type dai_in
-			num_audio_formats 2
-			num_input_audio_formats 2
-			num_output_audio_formats 2
+			num_audio_formats 1
+			num_input_audio_formats 1
+			num_output_audio_formats 1
 
 			# copier only supports one format based on mixin/mixout requirements: 32-bit 48KHz 2ch
-			Object.Base.audio_format.1 {
-				in_bit_depth		32
-				in_valid_bit_depth	24
-				out_bit_depth		32
-				out_valid_bit_depth	24
-			}
-
-			Object.Base.audio_format.2 {
-				in_bit_depth		32
-				in_valid_bit_depth	32
-				out_bit_depth		32
-				out_valid_bit_depth	32
-			}
+			Object.Base.audio_format [
+				{
+					in_bit_depth		32
+					in_valid_bit_depth	32
+					out_bit_depth		32
+					out_valid_bit_depth	32
+				}
+			]
 		}
 		gain."1" {
-			num_audio_formats 2
-			num_input_audio_formats 2
-			num_output_audio_formats 2
+			num_audio_formats 1
+			num_input_audio_formats 1
+			num_output_audio_formats 1
 
 			# 32-bit 48KHz 2ch
-			Object.Base.audio_format.1 {
-				in_bit_depth		32
-				in_valid_bit_depth	24
-				out_bit_depth		32
-				out_valid_bit_depth	24
-			}
-
-			Object.Base.audio_format.2 {
-				in_bit_depth		32
-				in_valid_bit_depth	32
-				out_bit_depth		32
-				out_valid_bit_depth	32
-			}
+			Object.Base.audio_format [
+				{
+					in_bit_depth		32
+					in_valid_bit_depth	32
+					out_bit_depth		32
+					out_valid_bit_depth	32
+				}
+			]
 		}
 
 		smart_amp."1" {

--- a/tools/topology/topology2/platform/intel/hdmi-generic.conf
+++ b/tools/topology/topology2/platform/intel/hdmi-generic.conf
@@ -68,6 +68,19 @@ Object.Pipeline {
 				stream_name "iDisp1"
 				dai_type "HDA"
 				copier_type "HDA"
+				num_audio_formats 1
+				num_input_audio_formats 1
+				num_output_audio_formats 1
+
+				# copier only supports 32-bit 48KHz 2ch
+				Object.Base.audio_format [
+					{
+						in_bit_depth		32
+						in_valid_bit_depth	32
+						out_bit_depth		32
+						out_valid_bit_depth	32
+					}
+				]
 			}
 			use_chain_dma	$USE_CHAIN_DMA
 		}
@@ -80,6 +93,19 @@ Object.Pipeline {
 				stream_name 'iDisp2'
 				dai_type "HDA"
 				copier_type "HDA"
+				num_audio_formats 1
+				num_input_audio_formats 1
+				num_output_audio_formats 1
+
+				# copier only supports 32-bit 48KHz 2ch
+				Object.Base.audio_format [
+					{
+						in_bit_depth		32
+						in_valid_bit_depth	32
+						out_bit_depth		32
+						out_valid_bit_depth	32
+					}
+				]
 			}
 			use_chain_dma	$USE_CHAIN_DMA
 		}
@@ -91,6 +117,19 @@ Object.Pipeline {
 				stream_name 'iDisp3'
 				dai_type "HDA"
 				copier_type "HDA"
+				num_audio_formats 1
+				num_input_audio_formats 1
+				num_output_audio_formats 1
+
+				# copier only supports 32-bit 48KHz 2ch
+				Object.Base.audio_format [
+					{
+						in_bit_depth		32
+						in_valid_bit_depth	32
+						out_bit_depth		32
+						out_valid_bit_depth	32
+					}
+				]
 			}
 			use_chain_dma	$USE_CHAIN_DMA
 		}
@@ -180,6 +219,19 @@ IncludeByKey.NUM_HDMIS {
 					stream_name 'iDisp4'
 					dai_type "HDA"
 					copier_type "HDA"
+					num_audio_formats 1
+					num_input_audio_formats 1
+					num_output_audio_formats 1
+
+					# copier only supports 32-bit 48KHz 2ch
+					Object.Base.audio_format [
+						{
+							in_bit_depth		32
+							in_valid_bit_depth	32
+							out_bit_depth		32
+							out_valid_bit_depth	32
+						}
+					]
 				}
 				use_chain_dma	$USE_CHAIN_DMA
 			}


### PR DESCRIPTION
The 24-bit formats defined in topologies will never be used because the mixin/mixout only support 32-bit format. So remove these audio formats from the component and pipelines audio format definitions.

Depends on https://github.com/thesofproject/linux/pull/4313 (merged)