### PR TITLE
topology1: fix buffer size calculation if period-size >44ms

### DIFF
--- a/tools/topology/topology1/m4/buffer.m4
+++ b/tools/topology/topology1/m4/buffer.m4
@@ -44,6 +44,8 @@ dnl COMP_BUFFER_SIZE( num_periods, sample_size, channels, fmames)
 define(`COMP_BUFFER_SIZE', `eval(`$1 * $2 * $3 * $4')')
 
 dnl COMP_PERIOD_FRAMES( sample_rate, period_us)
-define(`COMP_PERIOD_FRAMES', `eval(`($1 * $2) / 1000000')')
+dnl note: m4 eval arithmetic is 32bit signed, so split the 10^6
+dnl       division to avoid overflow.
+define(`COMP_PERIOD_FRAMES', `eval(`$1 / 100 * $2 / 10000')')
 
 divert(0)dnl


### PR DESCRIPTION
Calculation of SOF_TKN_BUF_SIZE in COMP_PERIOD_FRAMES() macro led to incorrect results with large period size values. For example at 48000Hz sampling rate, period size larger than 44739us would be incorrectly calculated.

This happens as m4 eval does arithmetic in 32bit signed values and multiplication of period size and sampling rate can easily exceed 2^31.

Fix the issue by splitting the arithmetic in steps that fit available value range.

Link: https://github.com/thesofproject/sof/issues/7476