### PR TITLE
zephyr: de-static-ify memcpy_s()

### DIFF
--- a/zephyr/include/rtos/string.h
+++ b/zephyr/include/rtos/string.h
@@ -34,24 +34,10 @@ static inline int rstrcmp(const char *s1, const char *s2)
 }
 
 /* C library does not have the "_s" versions used by Windows */
-static inline int memcpy_s(void *dest, size_t dest_size,
-			   const void *src, size_t count)
-{
-	if (!dest || !src)
-		return -EINVAL;
+int memcpy_s(void *dest, size_t dest_size,
+	     const void *src, size_t count);
 
-	if ((dest >= src && (char *)dest < ((char *)src + count)) ||
-	    (src >= dest && (char *)src < ((char *)dest + dest_size)))
-		return -EINVAL;
-
-	if (count > dest_size)
-		return -EINVAL;
-
-	memcpy(dest, src, count);
-
-	return 0;
-}
-
+// TODO
 static inline int memset_s(void *dest, size_t dest_size, int data, size_t count)
 {
 	if (!dest)

--- a/zephyr/lib.c
+++ b/zephyr/lib.c
@@ -9,6 +9,25 @@
 #include <stddef.h>
 #include <stdint.h>
 
+/* Duplicate of src/arch/xtensa/include/arch/string.h */
+int memcpy_s(void *dest, size_t dest_size,
+	     const void *src, size_t count)
+{
+	if (!dest || !src)
+		return -EINVAL;
+
+	if ((dest >= src && (char *)dest < ((char *)src + count)) ||
+	    (src >= dest && (char *)src < ((char *)dest + dest_size)))
+		return -EINVAL;
+
+	if (count > dest_size)
+		return -EINVAL;
+
+	memcpy(dest, src, count);
+
+	return 0;
+}
+
 void *__vec_memcpy(void *dst, const void *src, size_t len)
 {
 	return memcpy(dst, src, len);


### PR DESCRIPTION
TODO: memset_s(). Others?

memcpy_s() used to be `static` since the dawn of SOF+Zephyr in commit c90055f2f51e ("header: rtos: use rtos specific version of string.h")

This is unlike pre-Zephyr XTOS SOF; I don't know why.

So far it's been working fine but it's now causing problems when trying to link with external .a libraries that assume `memcpy_s` is not static.

Note Zephyr rejected the `memcpy_s()` annex K due to security concerns like https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1969.htm

So this problem may seem superficially related to Zephyr but it's actually not, it is a pure SOF issue.