### PR TITLE
[DNM] zephyr: use system cache API

### DIFF
--- a/zephyr/lib/alloc.c
+++ b/zephyr/lib/alloc.c
@@ -25,11 +25,8 @@
 #include <zephyr/pm/policy.h>
 #include <version.h>
 #include <zephyr/sys/__assert.h>
+#include <zephyr/cache.h>
 #include <soc.h>
-
-#if defined(CONFIG_ARCH_XTENSA) && !defined(CONFIG_KERNEL_COHERENCE)
-#include <zephyr/arch/xtensa/cache.h>
-#endif
 
 #if CONFIG_SYS_HEAP_RUNTIME_STATS && CONFIG_IPC_MAJOR_4
 #include <zephyr/sys/sys_heap.h>
@@ -216,7 +213,8 @@ static void heap_free(struct k_heap *h, void *mem)
 
 	if (is_cached(mem)) {
 		mem_uncached = z_soc_uncached_ptr((__sparse_force void __sparse_cache *)mem);
-		z_xtensa_cache_flush_inv(mem, sys_heap_usable_size(&h->heap, mem_uncached));
+		sys_cache_data_flush_and_invd_range(mem,
+				sys_heap_usable_size(&h->heap, mem_uncached));
 
 		mem = mem_uncached;
 	}


### PR DESCRIPTION
Use zephyr cache APIs instead of xtensa specific ones.

We need https://github.com/zephyrproject-rtos/zephyr/pull/50136 first.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
