### PR TITLE
topology2: rename NUM_SDW_AMPS to NUM_SDW_AMP_LINKS

### DIFF
--- a/tools/topology/topology2/avs-tplg/tplg-targets.cmake
+++ b/tools/topology/topology2/avs-tplg/tplg-targets.cmake
@@ -19,19 +19,19 @@ PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-hda-generic-4ch.bin,USE_CHAIN_DMA=true
 PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-cavs-sdw.bin"
 
 # IPC4 topology for TGL rt711 Headset + rt1316 Amplifier + rt714 DMIC
-"cavs-sdw\;sof-tgl-rt711-rt1316-rt714\;NUM_SDW_AMPS=2,SDW_DMIC=1,\
+"cavs-sdw\;sof-tgl-rt711-rt1316-rt714\;NUM_SDW_AMP_LINKS=2,SDW_DMIC=1,\
 PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-tgl-rt711-rt1316-rt714.bin"
 
-"cavs-sdw\;sof-adl-rt711-l0-rt1316-l12-rt714-l3\;NUM_SDW_AMPS=2,SDW_DMIC=1"
+"cavs-sdw\;sof-adl-rt711-l0-rt1316-l12-rt714-l3\;NUM_SDW_AMP_LINKS=2,SDW_DMIC=1"
 
 # IPC4 topology for TGL rt711 Headset + rt1308 Amplifier + rt715 DMIC
-"cavs-sdw\;sof-tgl-rt715-rt711-rt1308-mono\;NUM_SDW_AMPS=1,SDW_DMIC=1,\
+"cavs-sdw\;sof-tgl-rt715-rt711-rt1308-mono\;NUM_SDW_AMP_LINKS=1,SDW_DMIC=1,\
 SDW_JACK_OUT_STREAM=SDW1-Playback,SDW_JACK_IN_STREAM=SDW1-Capture,\
 SDW_SPK_STREAM=SDW2-Playback,SDW_DMIC_STREAM=SDW0-Capture,SDW_AMP_FEEDBACK=false,\
 PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-tgl-rt715-rt711-rt1308-mono.bin"
 
 # IPC4 topology for TGL rt711 Headset + rt1308 Amplifier + PCH DMIC
-"cavs-sdw\;sof-tgl-rt711-rt1308-4ch\;NUM_SDW_AMPS=1,NUM_DMICS=4,DMIC0_ID=3,\
+"cavs-sdw\;sof-tgl-rt711-rt1308-4ch\;NUM_SDW_AMP_LINKS=1,NUM_DMICS=4,DMIC0_ID=3,\
 DMIC1_ID=4,PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,SDW_AMP_FEEDBACK=false,\
 PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-tgl-rt711-rt1308-4ch.bin"
 

--- a/tools/topology/topology2/cavs-sdw.conf
+++ b/tools/topology/topology2/cavs-sdw.conf
@@ -67,7 +67,7 @@ Define {
 	SDW_JACK_IN_STREAM	'SDW0-Capture'
 	SDW_JACK_OUT_BE_ID	0
 	SDW_JACK_IN_BE_ID	1
-	NUM_SDW_AMPS 0
+	NUM_SDW_AMP_LINKS 0
 	SDW_DMIC 0
 }
 
@@ -95,7 +95,7 @@ IncludeByKey.DEEPBUFFER_FW_DMA_MS{
         "[1-1000]" "platform/intel/deep-buffer.conf"
 }
 
-IncludeByKey.NUM_SDW_AMPS {
+IncludeByKey.NUM_SDW_AMP_LINKS {
 "[1-2]" "platform/intel/sdw-amp-generic.conf"
 }
 

--- a/tools/topology/topology2/platform/intel/sdw-amp-generic.conf
+++ b/tools/topology/topology2/platform/intel/sdw-amp-generic.conf
@@ -64,7 +64,7 @@ Object.Pipeline {
 
 }
 
-IncludeByKey.NUM_SDW_AMPS {
+IncludeByKey.NUM_SDW_AMP_LINKS {
 "2"	{
 		Define {
 			AMP_FEEDBACK_CH 4


### PR DESCRIPTION
NUM_SDW_AMPS refers to how many sdw links are used by the amp pcm. Rename to NUM_SDW_AMP_LINKS for less confusing.