### PR TITLE
[SKIP CI] parse_sparse_output.sh: add "removes address space" and "too many"

### DIFF
--- a/scripts/parse_sparse_output.sh
+++ b/scripts/parse_sparse_output.sh
@@ -27,7 +27,11 @@ main()
 
     sparse_errors+=(-e '[[:space:]]error:[[:space:]]')
 
+    sparse_errors+=(-e '[[:space:]]warning:[[:space:]].*too many warnings')
+
     sparse_errors+=(-e '[[:space:]]warning:[[:space:]].*different address space')
+
+    sparse_errors+=(-e '[[:space:]]warning:[[:space:]].*cast removes address space')
 
     ! grep -v 'alsatplg.*topology2.*skip' | grep -i  "${sparse_errors[@]}"
 


### PR DESCRIPTION
Catch the additional two warnings below:
```
warning: too many warnings
warning: cast removes address space
```