### PR TITLE
[DNM][TEST] zephyr: update SYS_INIT calls

### DIFF
--- a/src/init/init.c
+++ b/src/init/init.c
@@ -338,12 +338,8 @@ int sof_main(int argc, char *argv[])
 	return start_complete();
 }
 
-struct device;
-
-static int sof_init(const struct device *dev)
+static int sof_init(void)
 {
-	ARG_UNUSED(dev);
-
 	return primary_core_init(0, NULL, &sof);
 }
 

--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 1851950977d5c89d8727e1058a5732f71ce4cd2a
+      revision: pull/57127/head
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision

--- a/zephyr/include/rtos/init.h
+++ b/zephyr/include/rtos/init.h
@@ -9,9 +9,8 @@
 #include <zephyr/init.h>
 
 #define SOF_MODULE_INIT(name, init) \
-static int zephyr_##name##_init(const struct device *dev) \
+static int zephyr_##name##_init(void) \
 { \
-	ARG_UNUSED(dev); \
 	init(); \
 	return 0; \
 } \

--- a/zephyr/lib/alloc.c
+++ b/zephyr/lib/alloc.c
@@ -359,10 +359,8 @@ void rfree(void *ptr)
 	heap_free(&sof_heap, ptr);
 }
 
-static int heap_init(const struct device *unused)
+static int heap_init(void)
 {
-	ARG_UNUSED(unused);
-
 	sys_heap_init(&sof_heap.heap, heapmem, HEAPMEM_SIZE);
 
 #if CONFIG_L3_HEAP

--- a/zephyr/lib/regions_mm.c
+++ b/zephyr/lib/regions_mm.c
@@ -20,10 +20,8 @@ struct virtual_memory_heap
  * virtual first heaps.
  * Has to be initialized after calculations for regions is done in zephyr.
  */
-static int virtual_heaps_init(const struct device *unused)
+static int virtual_heaps_init(void)
 {
-	ARG_UNUSED(unused);
-
 	struct sys_mm_drv_region *virtual_memory_regions =
 		(struct sys_mm_drv_region *)sys_mm_drv_query_memory_regions();
 


### PR DESCRIPTION
Update Zephyr head, and use the new call signature: int (*init_fn)(void);


[updated Zephyr commit-id]

Testing for https://github.com/zephyrproject-rtos/zephyr/pull/57127