### PR TITLE
asrc: fix buffer acquisition

### DIFF
--- a/src/audio/asrc/asrc.c
+++ b/src/audio/asrc/asrc.c
@@ -882,6 +882,9 @@ static int asrc_prepare(struct comp_dev *dev)
 		goto err_free_asrc;
 	}
 
+	buffer_release(sink_c);
+	buffer_release(source_c);
+
 	return 0;
 
 err_free_asrc:


### PR DESCRIPTION
Add missing buffer release calls in asrc_prepare().