### PR TITLE
platform: move tgl tgl-h to supported platforms

### DIFF
--- a/scripts/xtensa-build-all.sh
+++ b/scripts/xtensa-build-all.sh
@@ -8,7 +8,6 @@ set -e
 # Platforms built and tested by default in CI using the `-a` option.
 # They must have a toolchain available in the latest Docker image.
 DEFAULT_PLATFORMS=(
-    tgl tgl-h
     imx8 imx8x imx8m imx8ulp
     rn rmb
     mt8186 mt8195
@@ -16,7 +15,7 @@ DEFAULT_PLATFORMS=(
 
 # Work in progress can be added to this "staging area" without breaking
 # the -a option for everyone.
-SUPPORTED_PLATFORMS=( "${DEFAULT_PLATFORMS[@]}" )
+SUPPORTED_PLATFORMS=( tgl tgl-h "${DEFAULT_PLATFORMS[@]}" )
 
 # Waiting for container work in progress
 SUPPORTED_PLATFORMS+=( mt8188 )


### PR DESCRIPTION
scripts/xtensa-build-all.sh -a throws error when tgl tgl-h are built with gcc tool chain. New SOF docker image don't have xtensa-cnl-elf-gcc any more. Related change is dc9ba281d76519dbed3670fe3691d0a9aedee85a.

Move tgl tgl-h from DEFAULT_PLATFORMS to SUPPORTED_PLATFORMS. Those platforms can be built if xcc/gcc toolchains are available.