### PR TITLE
[SKIP CI] .github/zephyr: build with the debug overlay and CONFIG_ASSERT

### DIFF
--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -80,6 +80,14 @@ jobs:
           # Temporary testbed for Zephyr development.
           -i IPC4 tgl tgl-h,
         ]
+        build_opts: [""]
+        # Sparse matrices are complicated, you must read this page slowly:
+        # https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs
+        include:
+          # specify one extra -d combination without affecting the main matrix
+          - build_opts: -d
+            zephyr_revision: mnfst
+            IPC_platforms: mtl
 
     steps:
       - uses: actions/checkout@v3
@@ -123,13 +131,14 @@ jobs:
         run: cd workspace && ./sof/zephyr/docker-run.sh
              ./sof/zephyr/docker-build.sh --cmake-args=-DEXTRA_CFLAGS=-Werror
              --cmake-args=-DEXTRA_AFLAGS='-Werror -Wa,--fatal-warnings'
-             --cmake-args=--warn-uninitialized ${{ matrix.IPC_platforms }}
+             --cmake-args=--warn-uninitialized
+             ${{ matrix.build_opts }} ${{ matrix.IPC_platforms }}
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v3
         if: ${{ matrix.zephyr_revision == 'mnfst' }}
         with:
-          name: linux-build ${{ matrix.IPC_platforms }}
+          name: linux-build ${{ matrix.build_opts }} ${{ matrix.IPC_platforms }}
           path: |
             ${{ github.workspace }}/workspace/build-sof-staging
             ${{ github.workspace }}/workspace/**/compile_commands.json
@@ -138,7 +147,6 @@ jobs:
     runs-on: windows-latest
     strategy:
       fail-fast: false
-      # FIXME: Create common matrix for build-linux and build-windows
       matrix:
         # Using groups to avoid spamming the small results box with too
         # many lines. Pay attention to COMMAS.
@@ -151,6 +159,13 @@ jobs:
           # Very few IPC3 platforms support IPC4 too.
           -i IPC4 tgl tgl-h,
         ]
+        build_opts: [""]
+        # Sparse matrices are complicated, see comments on Linux matrix above.
+        include:
+          - build_opts: -d
+            zephyr_revsion: mnfst
+            platforms: mtl
+
 
     steps:
       - uses: actions/checkout@v3
@@ -267,12 +282,12 @@ jobs:
           --no-interactive
           --cmake-args=-DEXTRA_CFLAGS=-Werror
           --cmake-args=-DEXTRA_AFLAGS='-Werror -Wa,--fatal-warnings'
-          --cmake-args=--warn-uninitialized ${{ matrix.platforms }}
+          --cmake-args=--warn-uninitialized ${{ matrix.build_opts }} ${{ matrix.platforms }}
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: windows-build ${{ matrix.platforms}}
+          name: windows-build ${{ matrix.build_opts }} ${{ matrix.platforms }}
           path: |
             ${{ github.workspace }}/workspace/build-sof-staging
             ${{ github.workspace }}/workspace/**/compile_commands.json
@@ -313,7 +328,18 @@ jobs:
 
       - name: Compare Linux vs Windows builds
         run: |
-          diffs=0
+          diffs=0; ls -l
+
+          # Check not too much is missing (it happened!)
+          # http://mywiki.wooledge.org/ParsingLs
+          for regdir in 'linux-build *mtl' \
+                        'windows-build *mtl' \
+                        'windows-build *-i IPC4 tgl tgl-h'; do
+            find . -maxdepth 1 | grep -q "\./${regdir}\$" ||
+              { >&2 printf 'Missing %s\n' "${regdir}"; exit 1; }
+          done
+
+          set -x
           for windir in windows-build*; do
             lindir=linux-"${windir#windows-}"
             diff -qr "$lindir" "$windir" || : $((diffs++))

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -90,27 +90,11 @@ jobs:
           fetch-depth: 0
           path: ./workspace/sof
 
-      # As of December 2022 `--shallow-exclude=v3.2.0-rc3` fixes `git
-      # describe`, Zephyr's version.h and build reproducibility while
-      # downloading about 200MB less compared to a full clone.
-      #
-      # Ideally, the --shallow-exclude= argument should be regularly
-      # bumped whenever SOF upgrades Zephyr to keep this as fast as
-      # possible.
-      # In a bigger Zephyr future maybe we could move to a more permanent
-      # git fetch --shallow-since='5 months ago' because Zephyr follows
-      # a "roughly 4-month release" but for now that saves only 100MB
-      # https://docs.zephyrproject.org/latest/project/release_process.html
-      #
-      # TODO: try replacing --narrow and --depth with some
-      # --fetch-opt=--filter=?
-      # https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/
       - name: west clones
 
         # Get some git tags in Zephyr. keep in sync with build-windows below
         run: pip3 install west && cd workspace/sof/ && west init -l &&
-               west update --narrow --fetch-opt=--depth=5 &&
-               git -C ../zephyr fetch --shallow-exclude=v3.2.0-rc3
+               west update --narrow --fetch-opt=--filter=tree:0
 
       - name: select zephyr revision
         run: |
@@ -252,8 +236,7 @@ jobs:
         working-directory: ${{ github.workspace }}/workspace
         # Keep in sync with build-linux above
         run: west init -l sof &&
-             west update --narrow --fetch-opt=--depth=5 &&
-             git -C zephyr fetch --shallow-exclude=v3.2.0-rc3
+             west update --narrow --fetch-opt=--filter=tree:0
 
       # Call Setup Python again to save the PIP packages in cache
       - name: Setup Python
@@ -330,7 +313,6 @@ jobs:
 
       - name: Compare Linux vs Windows builds
         run: |
-          # FIXME: for windows the Z_SDK version is hardcoded above, for Linux it's not.
           diffs=0
           for windir in windows-build*; do
             lindir=linux-"${windir#windows-}"


### PR DESCRIPTION
This makes sure Zephyr's -fmacro-prefix-map is working and keeps the
builds reproducible when using a recent enough toolchain.

As found in the CONFIG_ASSERT PR
https://github.com/thesofproject/sof/pull/6530#issuecomment-1482330214
this is not true for old Xtensa toolchains.