### PR TITLE
topology2: enable multicore in nocodec topology for CI test

### DIFF
--- a/tools/topology/topology2/cavs-nocodec-multicore.conf
+++ b/tools/topology/topology2/cavs-nocodec-multicore.conf
@@ -1,0 +1,473 @@
+<searchdir:include>
+<searchdir:include/common>
+<searchdir:include/components>
+<searchdir:include/dais>
+<searchdir:include/pipelines/cavs>
+<searchdir:platform>
+<searchdir:platform/intel>
+
+<vendor-token.conf>
+<manifest.conf>
+<pdm_config.conf>
+<tokens.conf>
+<virtual.conf>
+<host-gateway-capture.conf>
+<io-gateway-capture.conf>
+<host-copier-gain-mixin-playback.conf>
+<mixout-gain-dai-copier-playback.conf>
+<gain-module-copier.conf>
+<gain-capture.conf>
+<gain-copier-capture.conf>
+<mixout-mixin.conf>
+<data.conf>
+<pcm.conf>
+<pcm_caps.conf>
+<fe_dai.conf>
+<ssp.conf>
+<dmic.conf>
+<intel/hw_config_cardinal_clk.conf>
+<manifest.conf>
+<route.conf>
+<intel/common_definitions.conf>
+<copier.conf>
+<module-copier.conf>
+<pipeline.conf>
+<dai.conf>
+<host.conf>
+<kpb.conf>
+<input_pin_binding.conf>
+<output_pin_binding.conf>
+<input_audio_format.conf>
+<output_audio_format.conf>
+<dmic-default.conf>
+
+Define {
+	MCLK 		24576000
+	PLATFORM 	"none"
+	SSP0_CORE_ID	0
+	SSP1_CORE_ID	1
+	SSP2_CORE_ID	2
+}
+
+# override defaults with platform-specific config
+IncludeByKey.PLATFORM {
+	"tgl"	"platform/intel/tgl.conf"
+	"adl"	"platform/intel/tgl.conf"
+	"mtl"	"platform/intel/mtl.conf"
+}
+
+#
+# List of all DAIs
+#
+Object.Dai.SSP [
+	{
+		id 			0
+		dai_index		0
+		direction		"duplex"
+		name			NoCodec-0
+		default_hw_conf_id	0
+		sample_bits		32
+		quirks			"lbm_mode"
+		io_clk			$MCLK
+
+		Object.Base.hw_config.1 {
+			name	"SSP0"
+			id	0
+			bclk_freq	3072000
+			tdm_slot_width	32
+			# TODO: remove this. Needs alsaptlg change.
+			Object.Base.link_config.1 {
+				clock_source	1
+			}
+		}
+	}
+	{
+		id 			2
+		dai_index		2
+		direction		"duplex"
+		name			NoCodec-2
+		default_hw_conf_id	0
+		sample_bits		32
+		quirks			"lbm_mode"
+		io_clk			$MCLK
+
+		Object.Base.hw_config.1 {
+			name	"SSP2"
+			id	0
+			bclk_freq	3072000
+			tdm_slot_width	32
+			# TODO: remove this. Needs alsaptlg change.
+			Object.Base.link_config.1 {
+				clock_source	1
+			}
+		}
+	}
+]
+
+#
+# Pipeline definitions
+#
+# PCM0 ---> gain ---> Mixin ---> Mixout ---> gain ---> SSP0 (core SSP0_CORE_ID)
+# PCM1 ---> gain ---> Mixin ---> Mixout ---> gain ---> SSP1 (core SSP1_CORE_ID)
+# PCM2 ---> gain ---> Mixin ---> Mixout ---> gain ---> SSP2 (core SSP2_CORE_ID)
+# SSP0 ---> PCM0
+# SSP1 ---> PCM1
+# SSP2 ---> PCM2
+
+# Pipeline ID:1 PCM ID: 0
+Object.Pipeline.host-copier-gain-mixin-playback [
+	{
+		index 1
+
+		core $SSP0_CORE_ID
+		Object.Widget.copier.1 {
+			core_id $SSP0_CORE_ID
+			stream_name 'SSP0 Playback'
+		}
+		Object.Widget.gain.1 {
+			core_id $SSP0_CORE_ID
+			Object.Control.mixer.1 {
+				name 'Playback Volume 1'
+			}
+		}
+	}
+	{
+		index 5
+
+		core $SSP2_CORE_ID
+		Object.Widget.copier.1 {
+			core_id $SSP2_CORE_ID
+			stream_name 'SSP2 Playback'
+		}
+		Object.Widget.gain.1 {
+			core_id $SSP2_CORE_ID
+			Object.Control.mixer.1 {
+				name 'Playback Volume 5'
+			}
+		}
+		Object.Widget.mixin.1 {
+			core_id $SSP2_CORE_ID
+		}
+	}
+]
+
+Object.Pipeline.mixout-gain-dai-copier-playback [
+	{
+		index 14
+
+		core $SSP0_CORE_ID
+		Object.Widget.copier.1 {
+			core_id $SSP0_CORE_ID
+			dai_index	0
+			dai_type "SSP"
+			copier_type "SSP"
+			stream_name "NoCodec-0"
+			node_type $I2S_LINK_OUTPUT_CLASS
+		}
+
+		Object.Widget.gain.1 {
+			core_id $SSP0_CORE_ID
+			Object.Control.mixer.1 {
+				name 'Main Playback Volume 14'
+			}
+		}
+	}
+	{
+		index 6
+
+		core $SSP2_CORE_ID
+		Object.Widget.copier.1 {
+			core_id $SSP2_CORE_ID
+			dai_index	2
+			dai_type "SSP"
+			copier_type "SSP"
+			stream_name "NoCodec-2"
+			node_type $I2S_LINK_OUTPUT_CLASS
+		}
+
+		Object.Widget.gain.1 {
+			core_id $SSP2_CORE_ID
+			Object.Control.mixer.1 {
+				name 'Main Playback Volume 6'
+			}
+		}
+		Object.Widget.mixout.1 {
+			core_id $SSP2_CORE_ID
+		}
+	}
+]
+
+Object.Pipeline.host-gateway-capture [
+	{
+		index 7
+
+		Object.Widget.copier.1 {
+			stream_name 'SSP0 Capture'
+		}
+	}
+	{
+		index 11
+
+		Object.Widget.copier.1 {
+			stream_name 'SSP2 Capture'
+		}
+	}
+]
+
+Object.Pipeline.io-gateway-capture [
+	{
+		index 8
+		direction capture
+
+		Object.Widget.copier."1" {
+			dai_index	1
+			dai_type	"SSP"
+			type		dai_out
+			copier_type	"SSP"
+			stream_name	"NoCodec-0"
+			node_type	$I2S_LINK_INPUT_CLASS
+			Object.Base.audio_format.1 {
+				in_bit_depth		32
+				in_valid_bit_depth	32
+				out_bit_depth		32
+				out_valid_bit_depth	32
+			}
+		}
+	}
+	{
+		index 12
+		direction capture
+
+		Object.Widget.copier."1" {
+			dai_index	2
+			dai_type	"SSP"
+			type		dai_out
+			copier_type	"SSP"
+			stream_name	"NoCodec-2"
+			node_type	$I2S_LINK_INPUT_CLASS
+			Object.Base.audio_format.1 {
+				in_bit_depth		32
+				in_valid_bit_depth	32
+				out_bit_depth		32
+				out_valid_bit_depth	32
+			}
+		}
+	}
+]
+
+Object.PCM.pcm [
+	{
+		name	"Port0"
+		id 0
+		direction	"duplex"
+		Object.Base.fe_dai.1 {
+			name	"Port0"
+		}
+
+		Object.PCM.pcm_caps.1 {
+			direction	"playback"
+			name "SSP0 Playback"
+			formats 'S16_LE,S24_LE,S32_LE'
+		}
+
+		Object.PCM.pcm_caps.2 {
+			direction	"capture"
+			name "SSP0 Capture"
+			formats 'S16_LE,S24_LE,S32_LE'
+		}
+	}
+	{
+		name	"Port2"
+		id 2
+		direction	"duplex"
+		Object.Base.fe_dai.1 {
+			name	"Port2"
+		}
+
+		Object.PCM.pcm_caps.1 {
+			direction	"playback"
+			name "SSP2 Playback"
+			formats 'S16_LE,S24_LE,S32_LE'
+		}
+
+		Object.PCM.pcm_caps.2 {
+			direction	"capture"
+			name "SSP2 Capture"
+			formats 'S16_LE,S24_LE,S32_LE'
+		}
+	}
+]
+
+Object.Base.route [
+	{
+		source	"gain.14.1"
+		sink	"copier.SSP.14.1"
+	}
+	{
+		source	"mixin.1.1"
+		sink	"mixout.14.1"
+	}
+	{
+		source	"gain.6.1"
+		sink	"copier.SSP.6.1"
+	}
+	{
+		source	"mixin.5.1"
+		sink	"mixout.6.1"
+	}
+	{
+		source	"copier.SSP.8.1"
+		sink	"copier.host.7.1"
+	}
+	{
+		source	"copier.SSP.12.1"
+		sink	"copier.host.11.1"
+	}
+]
+
+# There is pinmux conflict between SSP1 and DMIC on MTL RVP,
+# so include SSP1 pipelines conditionally.
+IncludeByKey.SSP1_ENABLED {
+	"true" {
+		Object.Dai.SSP [
+			{
+				id 			1
+				dai_index		1
+				direction		"duplex"
+				name			NoCodec-1
+				default_hw_conf_id	0
+				sample_bits		32
+				quirks			"lbm_mode"
+				io_clk			$MCLK
+
+				Object.Base.hw_config.1 {
+					name	"SSP1"
+					id	0
+					bclk_freq	3072000
+					tdm_slot_width	32
+					# TODO: remove this. Needs alsaptlg change.
+					Object.Base.link_config.1 {
+						clock_source	1
+					}
+				}
+			}
+		]
+
+		Object.Pipeline.host-copier-gain-mixin-playback [
+			{
+				index 3
+
+				core $SSP1_CORE_ID
+				Object.Widget.copier.1 {
+					core_id $SSP1_CORE_ID
+					stream_name 'SSP1 Playback'
+				}
+				Object.Widget.gain.1 {
+					core_id $SSP1_CORE_ID
+					Object.Control.mixer.1 {
+						name 'Playback Volume 3'
+					}
+				}
+				Object.Widget.mixin.1 {
+					core_id $SSP1_CORE_ID
+				}
+			}
+		]
+
+		Object.Pipeline.mixout-gain-dai-copier-playback [
+			{
+				index 4
+
+				core $SSP1_CORE_ID
+				Object.Widget.copier.1 {
+					core_id $SSP1_CORE_ID
+					dai_index	1
+					dai_type "SSP"
+					copier_type "SSP"
+					stream_name "NoCodec-1"
+					node_type $I2S_LINK_OUTPUT_CLASS
+				}
+
+				Object.Widget.gain.1 {
+					core_id $SSP1_CORE_ID
+					Object.Control.mixer.1 {
+						name 'Main Playback Volume 4'
+					}
+				}
+				Object.Widget.mixout.1 {
+					core_id $SSP1_CORE_ID
+				}
+			}
+		]
+
+		Object.Pipeline.host-gateway-capture [
+			{
+				index 9
+
+				Object.Widget.copier.1 {
+					stream_name 'SSP1 Capture'
+				}
+			}
+		]
+
+		Object.Pipeline.io-gateway-capture [
+			{
+				index 10
+				direction capture
+
+				Object.Widget.copier."1" {
+					dai_index	1
+					dai_type	"SSP"
+					type		dai_out
+					copier_type	"SSP"
+					stream_name	"NoCodec-1"
+					node_type	$I2S_LINK_INPUT_CLASS
+					Object.Base.audio_format.1 {
+						in_bit_depth		32
+						in_valid_bit_depth	32
+						out_bit_depth		32
+						out_valid_bit_depth	32
+					}
+				}
+			}
+		]
+
+		Object.PCM.pcm [
+			{
+				name	"Port1"
+				id 1
+				direction	"duplex"
+				Object.Base.fe_dai.1 {
+					name	"Port1"
+				}
+
+				Object.PCM.pcm_caps.1 {
+					direction	"playback"
+					name "SSP1 Playback"
+					formats 'S16_LE,S24_LE,S32_LE'
+				}
+
+				Object.PCM.pcm_caps.2 {
+					direction	"capture"
+					name "SSP1 Capture"
+					formats 'S16_LE,S24_LE,S32_LE'
+				}
+			}
+		]
+
+		Object.Base.route [
+			{
+				source	"mixin.3.1"
+				sink	"mixout.4.1"
+			}
+			{
+				source	"gain.4.1"
+				sink	"copier.SSP.4.1"
+			}
+			{
+				source	"copier.SSP.10.1"
+				sink	"copier.host.9.1"
+			}
+		]
+	}
+}

--- a/tools/topology/topology2/development/tplg-targets.cmake
+++ b/tools/topology/topology2/development/tplg-targets.cmake
@@ -34,6 +34,9 @@ DEEPBUFFER_D0I3_COMPATIBLE=true"
 PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-mtl-nocodec.bin,DEEPBUFFER_FW_DMA_MS=100,\
 DEEPBUFFER_D0I3_COMPATIBLE=true"
 
+"cavs-nocodec-multicore\;sof-mtl-nocodec-multicore\;PLATFORM=mtl,SSP1_ENABLED=true,SSP0_CORE_ID=0,\
+SSP1_CORE_ID=1,SSP2_CORE_ID=2,PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-mtl-nocodec.bin"
+
 # CAVS HDA topology with mixer-based efx eq pipelines for HDA and passthrough pipelines for HDMI
 "sof-hda-generic\;sof-hda-efx-generic\;HDA_CONFIG=efx,USE_CHAIN_DMA=true,DEEPBUFFER_FW_DMA_MS=100,\
 EFX_FIR_PARAMS=passthrough,EFX_IIR_PARAMS=passthrough"


### PR DESCRIPTION
create another topology to test multicore since Currently we have done too much work in cavs-nocodec and CI test will be failed for FW main branch is not ready for multicore feature.

Discussed with @mengdonglin that we need a separate topology to enable multicore feature to help this feature development in FW. This topology is not very complex since it is for test only