### PR TITLE
[TEST ONLY][DNM] modAPI: modules should use provided buf pointers

### DIFF
--- a/src/audio/mixer/mixer.c
+++ b/src/audio/mixer/mixer.c
@@ -100,8 +100,8 @@ static int mixer_process(struct processing_module *mod,
 	for (i = 0; i < num_input_buffers; i++) {
 		uint32_t avail_frames;
 
-		avail_frames = audio_stream_avail_frames_aligned(mod->input_buffers[i].data,
-								 mod->output_buffers[0].data);
+		avail_frames = audio_stream_avail_frames_aligned(input_buffers[i].data,
+								 output_buffers[0].data);
 
 		/* if one source is inactive, skip it */
 		if (avail_frames == 0)
@@ -118,17 +118,17 @@ static int mixer_process(struct processing_module *mod,
 		 * generating silence until at least one of the
 		 * sources start to have data available (frames!=0).
 		 */
-		sink_bytes = dev->frames * audio_stream_frame_bytes(mod->output_buffers[0].data);
-		if (!audio_stream_set_zero(mod->output_buffers[0].data, sink_bytes))
-			mod->output_buffers[0].size = sink_bytes;
+		sink_bytes = dev->frames * audio_stream_frame_bytes(output_buffers[0].data);
+		if (!audio_stream_set_zero(output_buffers[0].data, sink_bytes))
+			output_buffers[0].size = sink_bytes;
 
 		return 0;
 	}
 
 	/* Every source has the same format, so calculate bytes based on the first one */
-	source_bytes = frames * audio_stream_frame_bytes(mod->input_buffers[0].data);
+	source_bytes = frames * audio_stream_frame_bytes(input_buffers[0].data);
 
-	sink_bytes = frames * audio_stream_frame_bytes(mod->output_buffers[0].data);
+	sink_bytes = frames * audio_stream_frame_bytes(output_buffers[0].data);
 
 	comp_dbg(dev, "mixer_process(), source_bytes = 0x%x, sink_bytes = 0x%x",
 		 source_bytes, sink_bytes);
@@ -137,24 +137,24 @@ static int mixer_process(struct processing_module *mod,
 	for (i = 0; i < num_input_buffers; i++) {
 		uint32_t avail_frames;
 
-		avail_frames = audio_stream_avail_frames_aligned(mod->input_buffers[i].data,
-								 mod->output_buffers[0].data);
+		avail_frames = audio_stream_avail_frames_aligned(input_buffers[i].data,
+								 output_buffers[0].data);
 
 		/* if one source is inactive, skip it */
 		if (avail_frames == 0)
 			continue;
 
 		sources_indices[j] = i;
-		sources_stream[j++] = mod->input_buffers[i].data;
+		sources_stream[j++] = input_buffers[i].data;
 	}
 
 	if (j)
-		md->mix_func(dev, mod->output_buffers[0].data, sources_stream, j, frames);
-	mod->output_buffers[0].size = sink_bytes;
+		md->mix_func(dev, output_buffers[0].data, sources_stream, j, frames);
+	output_buffers[0].size = sink_bytes;
 
 	/* update source buffer consumed bytes */
 	for (i = 0; i < j; i++)
-		mod->input_buffers[sources_indices[i]].consumed = source_bytes;
+		input_buffers[sources_indices[i]].consumed = source_bytes;
 
 	return 0;
 }

--- a/src/audio/module_adapter/module/iadk_modules.c
+++ b/src/audio/module_adapter/module/iadk_modules.c
@@ -167,7 +167,7 @@ static int iadk_modules_process(struct processing_module *mod,
 
 	/* IADK modules require output buffer size to set to its real size. */
 	list_for_item(blist, &dev->bsource_list) {
-		mod->output_buffers[i].size = md->mpd.out_buff_size;
+		output_buffers[i].size = md->mpd.out_buff_size;
 		i++;
 	}
 	/* Call module specific process function. */

--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -493,19 +493,19 @@ static int demux_process(struct processing_module *mod,
 		return 0;
 
 	frames = input_buffers[0].size;
-	source_bytes = frames * audio_stream_frame_bytes(mod->input_buffers[0].data);
-	sink_bytes = frames * audio_stream_frame_bytes(mod->output_buffers[0].data);
+	source_bytes = frames * audio_stream_frame_bytes(input_buffers[0].data);
+	sink_bytes = frames * audio_stream_frame_bytes(output_buffers[0].data);
 
 	/* produce output, one sink at a time */
 	for (i = 0; i < num_output_buffers; i++) {
 		demux_prepare_active_look_up(cd, sinks_stream[i],
 					     input_buffers[0].data, look_ups[i]);
 		cd->demux(dev, sinks_stream[i], input_buffers[0].data, frames, &cd->active_lookup);
-		mod->output_buffers[i].size = sink_bytes;
+		output_buffers[i].size = sink_bytes;
 	}
 
 	/* Update consumed */
-	mod->input_buffers[0].consumed = source_bytes;
+	input_buffers[0].consumed = source_bytes;
 	return 0;
 }
 
@@ -549,16 +549,16 @@ static int mux_process(struct processing_module *mod,
 		return 0;
 
 	frames = input_buffers[0].size;
-	source_bytes = frames * audio_stream_frame_bytes(mod->input_buffers[0].data);
-	sink_bytes = frames * audio_stream_frame_bytes(mod->output_buffers[0].data);
+	source_bytes = frames * audio_stream_frame_bytes(input_buffers[0].data);
+	sink_bytes = frames * audio_stream_frame_bytes(output_buffers[0].data);
 	mux_prepare_active_look_up(cd, output_buffers[0].data, &sources_stream[0]);
 
 	/* produce output */
 	cd->mux(dev, output_buffers[0].data, &sources_stream[0], frames, &cd->active_lookup);
 
 	/* Update consumed and produced */
-	mod->input_buffers[0].consumed = source_bytes;
-	mod->output_buffers[0].size = sink_bytes;
+	input_buffers[0].consumed = source_bytes;
+	output_buffers[0].size = sink_bytes;
 	return 0;
 }
 

--- a/src/audio/up_down_mixer/up_down_mixer.c
+++ b/src/audio/up_down_mixer/up_down_mixer.c
@@ -430,26 +430,26 @@ up_down_mixer_process(struct processing_module *mod,
 
 	comp_dbg(dev, "up_down_mixer_process()");
 
-	mix_frames = audio_stream_avail_frames(mod->input_buffers[0].data,
-					       mod->output_buffers[0].data);
+	mix_frames = audio_stream_avail_frames(input_buffers[0].data,
+					       output_buffers[0].data);
 
-	source_bytes = mix_frames * audio_stream_frame_bytes(mod->input_buffers[0].data);
-	sink_bytes = mix_frames * audio_stream_frame_bytes(mod->output_buffers[0].data);
+	source_bytes = mix_frames * audio_stream_frame_bytes(input_buffers[0].data);
+	sink_bytes = mix_frames * audio_stream_frame_bytes(output_buffers[0].data);
 
 	if (source_bytes) {
 		uint32_t sink_sample_bytes;
 
-		audio_stream_copy_to_linear(mod->input_buffers[0].data, 0, cd->buf_in, 0,
+		audio_stream_copy_to_linear(input_buffers[0].data, 0, cd->buf_in, 0,
 					    source_bytes /
-					    audio_stream_sample_bytes(mod->input_buffers[0].data));
+					    audio_stream_sample_bytes(input_buffers[0].data));
 
 		cd->mix_routine(cd, (uint8_t *)cd->buf_in, source_bytes, (uint8_t *)cd->buf_out);
 
-		sink_sample_bytes = audio_stream_sample_bytes(mod->output_buffers[0].data);
-		audio_stream_copy_from_linear(cd->buf_out, 0, mod->output_buffers[0].data, 0,
+		sink_sample_bytes = audio_stream_sample_bytes(output_buffers[0].data);
+		audio_stream_copy_from_linear(cd->buf_out, 0, output_buffers[0].data, 0,
 					      sink_bytes / sink_sample_bytes);
-		mod->output_buffers[0].size = sink_bytes;
-		mod->input_buffers[0].consumed = source_bytes;
+		output_buffers[0].size = sink_bytes;
+		input_buffers[0].consumed = source_bytes;
 	}
 
 	return 0;


### PR DESCRIPTION
Module process API provides pointers to data sources and data destinations.
Modules should always use it instead of going directly to internal structures