### PR TITLE
Revert "scripts/docker-run.sh: run with sudo-cwd.sh"

### DIFF
--- a/scripts/docker-run.sh
+++ b/scripts/docker-run.sh
@@ -33,8 +33,6 @@ test "$(id -u)" = 1000 ||
   >&2 printf "Warning: this script should be run as user ID 1000 to match the container's account\n"
 
 set -x
-# FIXME: During the transition to sudo-cwd.sh, the tag will be "latest_ubuntu22.04".
-#       Later it will be back to latest
 docker run -i -v "${SOF_TOP}":/home/sof/work/sof.git \
 	-v "${SOF_TOP}":/home/sof/work/sof-bind-mount-DO-NOT-DELETE \
 	--env CMAKE_BUILD_TYPE \
@@ -44,5 +42,6 @@ docker run -i -v "${SOF_TOP}":/home/sof/work/sof.git \
 	--env VERBOSE \
 	--env http_proxy="$http_proxy" \
 	--env https_proxy="$https_proxy" \
+	--user "$(id -u)" \
 	$SOF_DOCKER_RUN \
-	thesofproject/sof:latest_ubuntu22.04 ./scripts/sudo-cwd.sh "$@"
+	thesofproject/sof "$@"


### PR DESCRIPTION
This reverts commit 80e9c3454a0a048704f863a52443b536a27a2410.

This was merged too early, there are still build issues and failures to solve first, notably issues caused by the now missing xtensa-cnl-elf-gcc (for TGL)

https://github.com/thesofproject/sof/actions/runs/4789961860/jobs/8518459642 https://github.com/thesofproject/sof/actions/runs/4789961859/jobs/8518459155 etc.