### PR TITLE
[SKIP CI] scripts: Dockerfile: re-add TGL toolchain removed by accident

### DIFF
--- a/scripts/docker_build/sof_builder/Dockerfile
+++ b/scripts/docker_build/sof_builder/Dockerfile
@@ -93,7 +93,7 @@ RUN cd "$HOME" && \
 	git clone $CLONE_DEFAULTS --branch sof-gcc10x $CT_NG_REPO && \
 	cd crosstool-ng && \
 	./bootstrap && ./configure --prefix=`pwd` && make && make install && \
-	for arch in imx imx8m imx8ulp rn rmb mt8186 mt8195; do \
+	for arch in cnl imx imx8m imx8ulp rn rmb mt8186 mt8195; do \
 		echo "$arch: ct-ng build start..." && \
 		cp config-${arch}-gcc10.2-gdb9 .config && \
 		# replace the build dist to save space
@@ -104,6 +104,7 @@ RUN cd "$HOME" && \
 	done && \
 	echo "Stage2: xtensa-overlay, crosstool-ng are done!"
 
+ENV PATH="/home/sof/work/xtensa-cnl-elf/bin:${PATH}"
 ENV PATH="/home/sof/work/xtensa-rn-elf/bin:${PATH}"
 ENV PATH="/home/sof/work/xtensa-rmb-elf/bin:${PATH}"
 ENV PATH="/home/sof/work/xtensa-imx-elf/bin:${PATH}"
@@ -116,7 +117,7 @@ ARG NEWLIB_REPO=https://github.com/jcmvbkbc/newlib-xtensa.git
 RUN cd "$HOME" && \
 	git clone $CLONE_DEFAULTS --branch xtensa $NEWLIB_REPO && \
 	cd newlib-xtensa && \
-	for arch in imx imx8m imx8ulp rn rmb mt8186 mt8195; do \
+	for arch in cnl imx imx8m imx8ulp rn rmb mt8186 mt8195; do \
 		./configure --target=xtensa-${arch}-elf \
 		--prefix=/home/sof/work/xtensa-root && \
 		make && make install && \


### PR DESCRIPTION
_[SKIP CI because there is ZERO CI using that file, it's used manually only. See #5073]_

TGL has always been using the `xtensa-cnl-elf` toolchain. That toolchain was removed by accident when cavs 1.8 support (including CNL) was removed by massive search/replace commit dc9ba281d76519 ("platform: remove support for cAVS 1.8 platforms")