### PR TITLE
audio: mixin_mixout_generic: normal_mix: Update src/dst after each copy

### DIFF
--- a/src/audio/mixin_mixout/mixin_mixout_generic.c
+++ b/src/audio/mixin_mixout/mixin_mixout_generic.c
@@ -56,6 +56,8 @@ static void normal_mix_channel_s16(struct audio_stream __sparse_cache *sink, int
 		nmax = audio_stream_samples_without_wrap_s16(sink, dst);
 		n = MIN(n, nmax);
 		memcpy_s(dst, n * sizeof(int16_t), src, n * sizeof(int16_t));
+		dst += n;
+		src += n;
 	}
 }
 
@@ -196,6 +198,8 @@ static void normal_mix_channel_s24(struct audio_stream __sparse_cache *sink, int
 		nmax = audio_stream_samples_without_wrap_s24(sink, dst);
 		n = MIN(n, nmax);
 		memcpy_s(dst, n * sizeof(int32_t), src, n * sizeof(int32_t));
+		dst += n;
+		src += n;
 	}
 }
 
@@ -306,6 +310,8 @@ static void normal_mix_channel_s32(struct audio_stream __sparse_cache *sink, int
 		nmax = audio_stream_samples_without_wrap_s32(sink, dst);
 		n = MIN(n, nmax);
 		memcpy_s(dst, n * sizeof(int32_t), src, n * sizeof(int32_t));
+		dst += n;
+		src += n;
 	}
 }
 


### PR DESCRIPTION
The copying part of the functions need to update the src/dst buffer pointers after each iteration to correctly account for the possible wrap of the buffer.

This was discovered while doing pause - 1sec_wait - resume - 3sec_wait cycles and around the 10th iteration audio became 'metallic' sounding.

Fixes: #7478 

Thanks @ranj063 to test with XCC which is not affected and pointing me to the correct path.