### PR TITLE
rtnr: fix regression

### DIFF
--- a/src/audio/rtnr/rtnr.c
+++ b/src/audio/rtnr/rtnr.c
@@ -741,13 +741,13 @@ static void rtnr_copy_from_sof_stream(struct audio_stream_rtnr *dst,
 static void rtnr_copy_to_sof_stream(struct audio_stream __sparse_cache *dst,
 				    struct audio_stream_rtnr *src)
 {
-	dst->size = audio_stream_get_size(src);
-	dst->avail = audio_stream_get_avail(src);
-	dst->free = audio_stream_get_free(src);
-	dst->w_ptr = audio_stream_get_wptr(src);
-	dst->r_ptr = audio_stream_get_rptr(src);
-	dst->addr = audio_stream_get_addr(src);
-	dst->end_addr = audio_stream_get_end_addr(src);
+	dst->size = src->size;
+	dst->avail = src->avail;
+	dst->free = src->free;
+	dst->w_ptr = src->w_ptr;
+	dst->r_ptr = src->r_ptr;
+	dst->addr = src->addr;
+	dst->end_addr = src->end_addr;
 }
 
 /* copy and process stream data from source to sink buffers */


### PR DESCRIPTION
Earlier commits wrongly used struct audio_stream accessors to read members of struct audio_stream_rtnr in rtnr_copy_to_sof_stream(). Revert those changes.