### PR TITLE
Add XCC build support for Zephyr i.MX8 platforms

### DIFF
--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -107,7 +107,8 @@ platform_configs = {
 	#  NXP platforms
 	"imx8" : PlatformConfig(
 		"imx8", "nxp_adsp_imx8",
-		None, None,
+		f"RI-2023.11{xtensa_tools_version_postfix}",
+		"hifi4_nxp_v5_3_1_prod",
 		RIMAGE_KEY = "key param ignored by imx8",
 	),
 	"imx8x" : PlatformConfig(

--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -119,7 +119,8 @@ platform_configs = {
 	),
 	"imx8m" : PlatformConfig(
 		"imx8m", "nxp_adsp_imx8m",
-		None, None,
+		f"RI-2023.11{xtensa_tools_version_postfix}",
+		"hifi4_mscale_v2_0_2_prod",
 		RIMAGE_KEY = "key param ignored by imx8m"
 	),
 }

--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -113,7 +113,8 @@ platform_configs = {
 	),
 	"imx8x" : PlatformConfig(
 		"imx8x", "nxp_adsp_imx8x",
-		None, None,
+		f"RI-2023.11{xtensa_tools_version_postfix}",
+		"hifi4_nxp_v5_3_1_prod",
 		RIMAGE_KEY = "key param ignored by imx8x"
 	),
 	"imx8m" : PlatformConfig(


### PR DESCRIPTION
Here I add the configuration options for building SOF on Zephyr for i.MX8, i.MX8X and i.MX8M platforms. No further changes on top of this are required for the builds to succeed, however I did not do any runtime testing of any of these.