### PR TITLE
zephyr: use system cache API

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 9028ad5d713baaf7c44c699e515e40eb6ccdf475
+      revision: 3e02d48e4ead9978d10ee760c640bf55873f6e95
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision

--- a/zephyr/lib/alloc.c
+++ b/zephyr/lib/alloc.c
@@ -25,10 +25,7 @@
 #include <zephyr/pm/policy.h>
 #include <version.h>
 #include <zephyr/sys/__assert.h>
-
-#if defined(CONFIG_ARCH_XTENSA) && !defined(CONFIG_KERNEL_COHERENCE)
-#include <zephyr/arch/xtensa/cache.h>
-#endif
+#include <zephyr/cache.h>
 
 #if CONFIG_SYS_HEAP_RUNTIME_STATS && CONFIG_IPC_MAJOR_4
 #include <zephyr/sys/sys_heap.h>
@@ -215,7 +212,8 @@ static void heap_free(struct k_heap *h, void *mem)
 
 	if (is_cached(mem)) {
 		mem_uncached = z_soc_uncached_ptr((__sparse_force void __sparse_cache *)mem);
-		z_xtensa_cache_flush_inv(mem, sys_heap_usable_size(&h->heap, mem_uncached));
+		sys_cache_data_flush_and_invd_range(mem,
+				sys_heap_usable_size(&h->heap, mem_uncached));
 
 		mem = mem_uncached;
 	}


### PR DESCRIPTION
Use zephyr cache APIs instead of xtensa specific ones.