### PR TITLE
xtensa-build-zephyr.py: drop intermediate build-$platf/sof-$platf.ri 

### DIFF
--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -733,16 +733,13 @@ def install_platform(platform, sof_platform_output_dir, platf_build_environ):
 		# Regular name
 		output_fwname = "".join(["sof-", platform, ".ri"])
 
-	shutil.copy2(abs_build_dir / "zephyr.ri", abs_build_dir / output_fwname)
-	fw_file_to_copy = abs_build_dir / output_fwname
-
 	install_key_dir = sof_platform_output_dir
 	if args.key_type_subdir != "none":
 		install_key_dir = install_key_dir / args.key_type_subdir
 
 	os.makedirs(install_key_dir, exist_ok=True)
 	# looses file owner and group - file is commonly accessible
-	shutil.copy2(fw_file_to_copy, install_key_dir)
+	shutil.copy2(abs_build_dir / "zephyr.ri", install_key_dir / output_fwname)
 
 
 	# sof-info/ directory


### PR DESCRIPTION
Remove one intermediate and unnecessary .ri file. Simplify the code and the build directory. Example below with `sof-mtl.ri` for better
readability but this applies the same to `sof-imx8.ri` and every other
`sof-$platf.ri` file.


There were 3 .ri copies before this commit:

```
                build-mtl/zephyr/zephyr.ri
copied to  ->   build-mtl/zephyr/sof-mtl.ri
copied to  ->   build-sof-staging/___/sof-mtl.ri
```

Only 2 left after dropping the second and pointless copy:

```
                build-mtl/zephyr/zephyr.ri
copied to  ->   build-sof-staging/___/sof-mtl.ri
```

Fewer copies means less wondering about what is what, two identical files in the same directory is at best pointless and at worst misleading.

The `build-mtl/` directory belongs to the zephyr build system exclusively, this wrapper script has no business interfering with `build-mtl`. `build-mtl/zephyr/sof-mtl.ri can even be dangerous because it does not get cleaned. Demonstration:

```
 # Compile successfully
 $ ./scripts/xtensa-build-zephyr.py mtl

 # Write some code and make a mistake.
 # Fail to compile.
 $ echo BROKEN >> ../zephyr/kernel/sched.c
 $ ./scripts/xtensa-build-zephyr.py mtl

 # Obsolete .ri files are still there
 $ find ../build-mtl/ -name *.ri
  ../build-mtl/zephyr/zephyr.ri
  ../build-mtl/zephyr/sof-mtl.ri

 $ ninja -C ../build-mtl clean

 # Obsolete sof-mtl.ri is still there!
 $ find ../build-mtl/ -name *.ri
  ../build-mtl/zephyr/sof-mtl.ri

```