### PR TITLE
[TEST PATCH] DON'T REVIEW

### DIFF
--- a/src/audio/asrc/asrc.c
+++ b/src/audio/asrc/asrc.c
@@ -33,6 +33,12 @@
 #if CONFIG_IPC_MAJOR_4
 #include <ipc4/base-config.h>
 #include <ipc4/asrc.h>
+#include <ipc4/copier.h>
+#include <ipc/dai.h>
+#if CONFIG_ZEPHYR_NATIVE_DRIVERS
+#include <zephyr/device.h>
+#include <zephyr/drivers/dai.h>
+#endif
 #endif
 
 /* Simple count value to prevent first delta timestamp
@@ -78,6 +84,7 @@ struct comp_data {
 #endif
 	struct asrc_farrow *asrc_obj;	/* ASRC core data */
 	struct comp_dev *dai_dev;	/* Associated DAI component */
+	struct copier_data *cd;		/* Associated copier component */
 	enum asrc_operation_mode mode;  /* Control for push or pull mode */
 	uint64_t ts;
 	uint32_t sink_rate;	/* Sample rate in Hz */
@@ -591,6 +598,197 @@ static int asrc_params(struct comp_dev *dev,
 	return 0;
 }
 
+#ifdef CONFIG_IPC_MAJOR_4
+
+#if CONFIG_ZEPHYR_NATIVE_DRIVERS
+/**
+ * \brief Get DAI parameters and configure timestamping
+ * \param[in, out] dev DAI device.
+ * \return Error code.
+ *
+ * This function retrieves various DAI parameters such as type, direction, index, and DMA
+ * controller information those are needed when configuring HW timestamping. Note that
+ * DAI must be prepared before this function is used (for DMA information). If not, an error
+ * is returned.
+ */
+static int dai_ts_config_op(struct comp_dev *dev)
+{
+	struct comp_data *cd = comp_get_drvdata(dev);
+	struct dai_data *dd = cd->cd->dd[0];
+	struct ipc_config_dai *dai = &dd->ipc_config;
+	struct dai_ts_cfg cfg;
+
+	comp_dbg(dev, "dai_ts_config()");
+	if (!dd->chan) {
+		comp_err(dev, "dai_ts_config(), No DMA channel information");
+		return -EINVAL;
+	}
+
+	switch (dai->type) {
+	case SOF_DAI_INTEL_SSP:
+		cfg.type = DAI_INTEL_SSP;
+		break;
+	case SOF_DAI_INTEL_ALH:
+		cfg.type = DAI_INTEL_ALH;
+		break;
+	case SOF_DAI_INTEL_DMIC:
+		cfg.type = DAI_INTEL_DMIC;
+		break;
+	default:
+		comp_err(dev, "dai_ts_config(), not supported dai type");
+		return -EINVAL;
+	}
+
+	cfg.direction = dai->direction;
+	cfg.index = dd->dai->index;
+	cfg.dma_id = dd->dma->plat_data.id;
+	cfg.dma_chan_index = dd->chan->index;
+	cfg.dma_chan_count = dd->dma->plat_data.channels;
+
+	return dai_ts_config(dd->dai->dev, &cfg);
+}
+
+static int dai_ts_start_op(struct comp_dev *dev)
+{
+	struct comp_data *cd = comp_get_drvdata(dev);
+	struct dai_data *dd = cd->cd->dd[0];
+	struct dai_ts_cfg cfg;
+
+	comp_dbg(dev, "dai_ts_start()");
+
+	return dai_ts_start(dd->dai->dev, &cfg);
+}
+
+static int dai_ts_get_op(struct comp_dev *dev, struct timestamp_data *tsd)
+{
+	struct comp_data *cd = comp_get_drvdata(dev);
+	struct dai_data *dd = cd->cd->dd[0];
+	struct dai_ts_data tsdata;
+	struct dai_ts_cfg cfg;
+	int ret;
+
+	comp_dbg(dev, "dai_ts_get()");
+
+	ret = dai_ts_get(dd->dai->dev, &cfg, &tsdata);
+
+	if (ret < 0)
+		return ret;
+
+	/* todo convert to timestamp_data */
+
+	return ret;
+}
+
+static int dai_ts_stop_op(struct comp_dev *dev)
+{
+	struct comp_data *cd = comp_get_drvdata(dev);
+	struct dai_data *dd = cd->cd->dd[0];
+	struct dai_ts_cfg cfg;
+
+	comp_dbg(dev, "dai_ts_stop()");
+
+	return dai_ts_stop(dd->dai->dev, &cfg);
+}
+#else
+static inline int dai_ts_config_op(struct comp_dev *dev)
+{
+	return 0;
+}
+
+static inline int dai_ts_start_op(struct comp_dev *dev)
+{
+	return 0;
+}
+
+static inline int dai_ts_get_op(struct comp_dev *dev, struct timestamp_data *tsd)
+{
+	return 0;
+}
+
+static inline int dai_ts_stop_op(struct comp_dev *dev)
+{
+	return 0;
+}
+
+#endif
+static int asrc_dai_find(struct comp_dev *dev, struct comp_data *cd)
+{
+	struct comp_buffer *sourceb, *sinkb;
+	struct comp_buffer __sparse_cache *source_c, *sink_c;
+	int pid;
+
+	/* Get current pipeline ID and walk to find the DAI */
+	pid = dev_comp_pipe_id(dev);
+	cd->cd = NULL;
+	if (cd->mode == ASRC_OM_PUSH) {
+		/* In push mode check if sink component is DAI */
+		do {
+			sinkb = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
+
+			sink_c = buffer_acquire(sinkb);
+			dev = sink_c->sink;
+			buffer_release(sink_c);
+
+			if (!dev) {
+				comp_cl_err(&comp_asrc, "At end, no DAI found.");
+				return -EINVAL;
+			}
+
+			if (dev_comp_pipe_id(dev) != pid) {
+				comp_cl_err(&comp_asrc, "No DAI sink in pipeline.");
+				return -EINVAL;
+			}
+
+		} while (dev_comp_type(dev) != SOF_COMP_DAI);
+	} else {
+		/* In pull mode check if source component is DAI */
+		do {
+			sourceb = list_first_item(&dev->bsource_list, struct comp_buffer,
+						  sink_list);
+
+			source_c = buffer_acquire(sourceb);
+			dev = source_c->source;
+			buffer_release(source_c);
+
+			if (!dev) {
+				comp_cl_err(&comp_asrc, "At beginning, no DAI found.");
+				return -EINVAL;
+			}
+
+			if (dev_comp_pipe_id(dev) != pid) {
+				comp_cl_err(&comp_asrc, "No DAI source in pipeline.");
+				return -EINVAL;
+			}
+		} while (dev_comp_type(dev) != SOF_COMP_DAI);
+	}
+
+	/* Point cd to copier data, dev here is copier dev */
+	cd->cd = comp_get_drvdata(dev);
+
+	return 0;
+}
+
+static int asrc_dai_configure_timestamp(struct comp_dev *dev)
+{
+	return dai_ts_config_op(dev);
+}
+
+static int asrc_dai_start_timestamp(struct comp_dev *dev)
+{
+	return dai_ts_start_op(dev);
+}
+
+static int asrc_dai_stop_timestamp(struct comp_dev *dev)
+{
+	return dai_ts_stop_op(dev);
+}
+
+static int asrc_dai_get_timestamp(struct comp_dev *dev,
+				  struct timestamp_data *tsd)
+{
+	return dai_ts_get_op(dev, tsd);
+}
+#else
 static int asrc_dai_find(struct comp_dev *dev, struct comp_data *cd)
 {
 	struct comp_buffer *sourceb, *sinkb;
@@ -647,8 +845,9 @@ static int asrc_dai_find(struct comp_dev *dev, struct comp_data *cd)
 	return 0;
 }
 
-static int asrc_dai_configure_timestamp(struct comp_data *cd)
+static int asrc_dai_configure_timestamp(struct comp_dev *dev)
 {
+	struct comp_data *cd = comp_get_drvdata(dev);
 	int ret;
 
 	if (cd->dai_dev)
@@ -659,8 +858,9 @@ static int asrc_dai_configure_timestamp(struct comp_data *cd)
 	return ret;
 }
 
-static int asrc_dai_start_timestamp(struct comp_data *cd)
+static int asrc_dai_start_timestamp(struct comp_dev *dev)
 {
+	struct comp_data *cd = comp_get_drvdata(dev);
 	int ret;
 
 	if (cd->dai_dev)
@@ -671,8 +871,9 @@ static int asrc_dai_start_timestamp(struct comp_data *cd)
 	return ret;
 }
 
-static int asrc_dai_stop_timestamp(struct comp_data *cd)
+static int asrc_dai_stop_timestamp(struct comp_dev *dev)
 {
+	struct comp_data *cd = comp_get_drvdata(dev);
 	int ret;
 
 	if (cd->dai_dev)
@@ -683,14 +884,17 @@ static int asrc_dai_stop_timestamp(struct comp_data *cd)
 	return ret;
 }
 
-static int asrc_dai_get_timestamp(struct comp_data *cd,
+static int asrc_dai_get_timestamp(struct comp_dev *dev,
 				  struct timestamp_data *tsd)
 {
+	struct comp_data *cd = comp_get_drvdata(dev);
+
 	if (!cd->dai_dev)
 		return -EINVAL;
 
 	return cd->dai_dev->drv->ops.dai_ts_get(cd->dai_dev, tsd);
 }
+#endif
 
 static int asrc_trigger(struct comp_dev *dev, int cmd)
 {
@@ -709,7 +913,7 @@ static int asrc_trigger(struct comp_dev *dev, int cmd)
 		}
 
 		cd->ts_count = 0;
-		ret = asrc_dai_configure_timestamp(cd);
+		ret = asrc_dai_configure_timestamp(dev);
 		if (ret) {
 			comp_err(dev, "No timestamp capability in DAI");
 			cd->track_drift = false;
@@ -927,12 +1131,13 @@ static int asrc_control_loop(struct comp_dev *dev, struct comp_data *cd)
 
 	if (!cd->ts_count) {
 		cd->ts_count++;
-		asrc_dai_start_timestamp(cd);
+		asrc_dai_start_timestamp(dev);
 		return 0;
 	}
 
-	ts_ret = asrc_dai_get_timestamp(cd, &tsd);
-	asrc_dai_start_timestamp(cd);
+	memset((void *)&tsd, 0, sizeof(tsd));
+	ts_ret = asrc_dai_get_timestamp(dev, &tsd);
+	asrc_dai_start_timestamp(dev);
 	if (ts_ret)
 		return ts_ret;
 
@@ -1073,7 +1278,7 @@ static int asrc_reset(struct comp_dev *dev)
 
 	/* If any resources feasible to stop */
 	if (cd->track_drift)
-		asrc_dai_stop_timestamp(cd);
+		asrc_dai_stop_timestamp(dev);
 
 	/* Free the allocations those were done in prepare() */
 	asrc_release_buffers(cd->asrc_obj);

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -1054,27 +1054,46 @@ static int copier_reset(struct comp_dev *dev)
 {
 	struct copier_data *cd = comp_get_drvdata(dev);
 	struct ipc4_pipeline_registers pipe_reg;
-	int ret = 0;
-	int i;
+	int i, ret = 0;
 
 	comp_dbg(dev, "copier_reset()");
 
 	cd->input_total_data_processed = 0;
 	cd->output_total_data_processed = 0;
 
-	if (dev->ipc_config.type == SOF_COMP_HOST && !cd->ipc_gtw) {
-		if (cd->hd->chan)
-			notifier_unregister(dev,
-					    cd->hd->chan, NOTIFIER_ID_DMA_COPY);
-		host_zephyr_reset(cd->hd, dev->state);
-	}
-
-	for (i = 0; i < cd->endpoint_num; i++) {
-		if (dev->ipc_config.type != SOF_COMP_HOST || cd->ipc_gtw) {
-			ret = cd->endpoint[i]->drv->ops.reset(cd->endpoint[i]);
-			if (ret < 0)
-				break;
+	switch (dev->ipc_config.type) {
+	case SOF_COMP_HOST:
+		if (!cd->ipc_gtw) {
+			if (cd->hd->chan)
+				notifier_unregister(dev,
+						    cd->hd->chan, NOTIFIER_ID_DMA_COPY);
+			host_zephyr_reset(cd->hd, dev->state);
+		} else {
+			/* handle gtw case */
+			for (i = 0; i < cd->endpoint_num; i++) {
+				ret = cd->endpoint[i]->drv->ops.reset(cd->endpoint[i]);
+				if (ret < 0)
+					return ret;
+			}
 		}
+		break;
+	case SOF_COMP_DAI:
+		if (cd->endpoint_num == 1) {
+			dai_zephyr_reset(cd->dd[0], cd->endpoint[0]);
+			comp_set_state(cd->endpoint[0], COMP_TRIGGER_RESET);
+		} else {
+			/* multi endpoint case */
+			for (i = 0; i < cd->endpoint_num; i++) {
+				ret = cd->endpoint[i]->drv->ops.reset(cd->endpoint[i]);
+				if (ret < 0)
+					break;
+			}
+		}
+		break;
+	default:
+		comp_err(dev, "Unexpected copier device type to reset %d",
+			 dev->ipc_config.type);
+		break;
 	}
 
 	if (cd->pipeline_reg_offset) {

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -1898,6 +1898,7 @@ static uint64_t copier_get_processed_data(struct comp_dev *dev, uint32_t stream_
 {
 	struct copier_data *cd = comp_get_drvdata(dev);
 	uint64_t ret = 0;
+	bool source = dev->direction == SOF_IPC_STREAM_PLAYBACK;
 
 	/*
 	 * total data processed is calculated as: accumulate all input data in bytes
@@ -1910,14 +1911,32 @@ static uint64_t copier_get_processed_data(struct comp_dev *dev, uint32_t stream_
 	 */
 	if (cd->endpoint_num) {
 		if (stream_no < cd->endpoint_num) {
-			if (dev->ipc_config.type == SOF_COMP_HOST && !cd->ipc_gtw) {
-				bool source = dev->direction == SOF_IPC_STREAM_PLAYBACK;
+			switch (dev->ipc_config.type) {
+			case  SOF_COMP_HOST:
+				/* need handle gtw case separately,
+				 *since cd->hd not assigned in this case.
+				 */
+				if (cd->ipc_gtw) {
+					struct comp_dev *host_dev;
 
-				if (source == input)
+					host_dev = cd->endpoint[stream_no];
+					ret = comp_get_total_data_processed(host_dev,
+									    0, input);
+				} else if (source == input) {
 					ret = cd->hd->total_data_processed;
-			} else {
+				}
+				break;
+
+			case  SOF_COMP_DAI:
+				if (source == input)
+					ret = cd->dd[0]->total_data_processed;
+				break;
+
+			default:
 				ret = comp_get_total_data_processed(cd->endpoint[stream_no],
-								    0, input);
+							    0, input);
+				break;
+
 			}
 		}
 	} else {
@@ -1950,17 +1969,29 @@ static int copier_get_attribute(struct comp_dev *dev, uint32_t type, void *value
 static int copier_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn)
 {
 	struct copier_data *cd = comp_get_drvdata(dev);
-	int ret;
+	int ret = 0;
 
 	/* Exit if no endpoints */
 	if (!cd->endpoint_num)
 		return -EINVAL;
 
-	if (dev->ipc_config.type == SOF_COMP_HOST && !cd->ipc_gtw) {
-		posn->host_posn = cd->hd->local_pos;
-		ret = posn->host_posn;
-	} else {
-		ret = comp_position(cd->endpoint[IPC4_COPIER_GATEWAY_PIN], posn);
+	switch (dev->ipc_config.type) {
+	case SOF_COMP_HOST:
+		if (!cd->ipc_gtw) {
+			posn->host_posn = cd->hd->local_pos;
+			ret = posn->host_posn;
+		} else {
+			/* handle gtw case */
+			ret = comp_position(cd->endpoint[IPC4_COPIER_GATEWAY_PIN], posn);
+		}
+		break;
+	case SOF_COMP_DAI:
+		ret = dai_zephyr_position(cd->dd[0], cd->endpoint[IPC4_COPIER_GATEWAY_PIN], posn);
+		break;
+	default:
+		comp_err(dev, "Unexpected copier device type to position! %d",
+			 dev->ipc_config.type);
+		break;
 	}
 	/* Return position from the default gateway pin */
 	return ret;

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -1127,18 +1127,36 @@ static int copier_comp_trigger(struct comp_dev *dev, int cmd)
 	if (ret == COMP_STATUS_STATE_ALREADY_SET)
 		return PPL_STATUS_PATH_STOP;
 
-	if (dev->ipc_config.type == SOF_COMP_HOST && !cd->ipc_gtw) {
-		ret = host_zephyr_trigger(cd->hd, dev, cmd);
-		if (ret < 0)
-			return ret;
-	}
-
-	for (i = 0; i < cd->endpoint_num; i++) {
-		if (dev->ipc_config.type != SOF_COMP_HOST || cd->ipc_gtw) {
-			ret = cd->endpoint[i]->drv->ops.trigger(cd->endpoint[i], cmd);
+	switch (dev->ipc_config.type) {
+	case SOF_COMP_HOST:
+		if (!cd->ipc_gtw) {
+			ret = host_zephyr_trigger(cd->hd, dev, cmd);
 			if (ret < 0)
-				break;
+				return ret;
+		} else {
+			/* handle gtw case */
+			for (i = 0; i < cd->endpoint_num; i++) {
+				ret = cd->endpoint[i]->drv->ops.trigger(cd->endpoint[i], cmd);
+				if (ret < 0)
+					return ret;
+			}
 		}
+		break;
+	case SOF_COMP_DAI:
+		if (cd->endpoint_num == 1) {
+			ret = dai_zephyr_trigger(cd->dd[0], cd->endpoint[0], cmd);
+			if (ret < 0)
+				return ret;
+		} else {
+			for (i = 0; i < cd->endpoint_num; i++) {
+				ret = cd->endpoint[i]->drv->ops.trigger(cd->endpoint[i], cmd);
+				if (ret < 0)
+					break;
+			}
+		}
+		break;
+	default:
+		break;
 	}
 
 	/* For capture cd->pipeline_reg_offset == 0 */

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -1387,6 +1387,8 @@ static int do_endpoint_copy(struct comp_dev *dev)
 	} else {
 		if (dev->ipc_config.type == SOF_COMP_HOST && !cd->ipc_gtw)
 			return host_zephyr_copy(cd->hd, dev);
+		else if (dev->ipc_config.type == SOF_COMP_DAI)
+			return dai_zephyr_copy(cd->dd[0], dev);
 
 		return cd->endpoint[0]->drv->ops.copy(cd->endpoint[0]);
 	}

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -235,7 +235,7 @@ static void dai_free(struct comp_dev *dev)
 
 	dma_put(dd->dma);
 
-	dai_release_llp_slot(dev);
+	dai_release_llp_slot(dd);
 
 	dai_put(dd->dai);
 

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -59,10 +59,8 @@ static void dai_atomic_trigger(void *arg, enum notify_id type, void *data)
 }
 
 /* Assign DAI to a group */
-int dai_assign_group(struct comp_dev *dev, uint32_t group_id)
+int dai_assign_group(struct dai_data *dd, struct comp_dev *dev, uint32_t group_id)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
-
 	if (dd->group) {
 		if (dd->group->group_id != group_id) {
 			comp_err(dev, "dai_assign_group(), DAI already in group %d, requested %d",

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -477,7 +477,7 @@ static int dai_params(struct comp_dev *dev,
 	comp_dbg(dev, "dai_params()");
 
 	/* configure dai_data first */
-	err = ipc_dai_data_config(dev);
+	err = ipc_dai_data_config(dd, dev, &dev->ipc_config.frame_fmt);
 	if (err < 0)
 		return err;
 

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -997,7 +997,7 @@ static int dai_copy(struct comp_dev *dev)
 		return ret;
 	}
 
-	dai_dma_position_update(dev);
+	dai_dma_position_update(dd, dev);
 
 	return ret;
 }

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -713,7 +713,7 @@ static int dai_reset(struct comp_dev *dev)
 	 * It will be done when the host sends the DAI_CONFIG IPC during hw_free.
 	 */
 	if (!dd->delayed_dma_stop)
-		dai_dma_release(dev);
+		dai_dma_release(dd, dev);
 
 	dma_sg_free(&config->elem_array);
 

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -620,7 +620,7 @@ static int dai_config_prepare(struct comp_dev *dev)
 		return 0;
 	}
 
-	channel = dai_config_dma_channel(dev, dd->dai_spec_config);
+	channel = dai_config_dma_channel(dd, dev, dd->dai_spec_config);
 	comp_info(dev, "dai_config_prepare(), channel = %d", channel);
 
 	/* do nothing for asking for channel free, for compatibility. */

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -416,46 +416,10 @@ static int dai_comp_get_hw_params(struct comp_dev *dev,
 	return ret;
 }
 
-static int dai_verify_params(struct comp_dev *dev, struct sof_ipc_stream_params *params)
-{
-	struct sof_ipc_stream_params hw_params;
-	int ret;
-
-	ret = dai_comp_get_hw_params(dev, &hw_params, params->direction);
-	if (ret < 0) {
-		comp_err(dev, "dai_verify_params(): dai_verify_params failed ret %d", ret);
-		return ret;
-	}
-
-	/* checks whether pcm parameters match hardware DAI parameter set
-	 * during dai_set_config(). If hardware parameter is equal to 0, it
-	 * means that it can vary, so any value is acceptable. We do not check
-	 * format parameter, because DAI is able to change format using
-	 * pcm_converter functions.
-	 */
-	if (hw_params.rate && hw_params.rate != params->rate) {
-		comp_err(dev, "dai_verify_params(): pcm rate parameter %d does not match hardware rate %d",
-			 params->rate, hw_params.rate);
-		return -EINVAL;
-	}
-
-	if (hw_params.channels && hw_params.channels != params->channels) {
-		comp_err(dev, "dai_verify_params(): pcm channels parameter %d does not match hardware channels %d",
-			 params->channels, hw_params.channels);
-		return -EINVAL;
-	}
-
-	/* set component period frames */
-	component_set_nearest_period_frames(dev, params->rate);
-
-	return 0;
-}
-
 /* set component audio SSP and DMA configuration */
-static int dai_playback_params(struct comp_dev *dev, uint32_t period_bytes,
-			       uint32_t period_count)
+int dai_playback_params(struct dai_data *dd, struct comp_dev *dev, uint32_t period_bytes,
+			uint32_t period_count)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
 	struct dma_sg_config *config = &dd->config;
 	struct dma_config *dma_cfg;
 	struct dma_block_config *dma_block_cfg;
@@ -590,10 +554,9 @@ out:
 	return err;
 }
 
-static int dai_capture_params(struct comp_dev *dev, uint32_t period_bytes,
-			      uint32_t period_count)
+int dai_capture_params(struct dai_data *dd, struct comp_dev *dev, uint32_t period_bytes,
+		       uint32_t period_count)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
 	struct dma_sg_config *config = &dd->config;
 	struct dma_config *dma_cfg;
 	struct dma_block_config *dma_block_cfg;
@@ -745,10 +708,14 @@ out:
 	return err;
 }
 
-static int dai_params(struct comp_dev *dev, struct sof_ipc_stream_params *params)
+int dai_zephyr_params(struct dai_data *dd, struct comp_dev *dev,
+		      struct sof_ipc_stream_params *params,
+		      uint32_t *count,
+		      uint32_t *bytes,
+		      struct list_item *bsource_list,
+		      struct list_item *bsink_list)
 {
 	struct sof_ipc_stream_params hw_params = *params;
-	struct dai_data *dd = comp_get_drvdata(dev);
 	struct comp_buffer __sparse_cache *buffer_c;
 	uint32_t frame_size;
 	uint32_t period_count;
@@ -758,32 +725,26 @@ static int dai_params(struct comp_dev *dev, struct sof_ipc_stream_params *params
 	uint32_t align;
 	int err;
 
-	comp_dbg(dev, "dai_params()");
-
 	/* configure dai_data first */
-	err = ipc_dai_data_config(dev);
+	err = ipc_dai_data_config(dd, dev, &dev->ipc_config.frame_fmt);
 	if (err < 0)
 		return err;
 
-	err = dai_verify_params(dev, params);
-	if (err < 0) {
-		comp_err(dev, "dai_params(): pcm params verification failed.");
-		return -EINVAL;
-	}
+	component_set_nearest_period_frames(dev, params->rate);
 
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK)
-		dd->local_buffer = list_first_item(&dev->bsource_list,
+		dd->local_buffer = list_first_item(bsource_list,
 						   struct comp_buffer,
 						   sink_list);
 	else
-		dd->local_buffer = list_first_item(&dev->bsink_list,
+		dd->local_buffer = list_first_item(bsink_list,
 						   struct comp_buffer,
 						   source_list);
 
 	/* check if already configured */
 	if (dev->state == COMP_STATE_PREPARE) {
 		comp_info(dev, "dai_params() component has been already configured.");
-		return 0;
+		return -EINVAL;
 	}
 
 	/* can set params on only init state */
@@ -868,9 +829,28 @@ static int dai_params(struct comp_dev *dev, struct sof_ipc_stream_params *params
 		buffer_release(buffer_c);
 	}
 
+	*count = period_count;
+	*bytes = period_bytes;
+	return 0;
+}
+
+static int dai_params(struct comp_dev *dev, struct sof_ipc_stream_params *params)
+{
+	struct dai_data *dd = comp_get_drvdata(dev);
+	uint32_t period_count = 0;
+	uint32_t period_bytes = 0;
+	int ret;
+
+	comp_dbg(dev, "dai_params()");
+
+	ret = dai_zephyr_params(dd, dev, params, &period_count, &period_bytes,
+				&dev->bsource_list, &dev->bsink_list);
+	if (ret < 0)
+		return ret;
+
 	return dev->direction == SOF_IPC_STREAM_PLAYBACK ?
-		dai_playback_params(dev, period_bytes, period_count) :
-		dai_capture_params(dev, period_bytes, period_count);
+		dai_playback_params(dd, dev, period_bytes, period_count) :
+		dai_capture_params(dd, dev, period_bytes, period_count);
 }
 
 int dai_config_prepare(struct dai_data *dd, struct comp_dev *dev)

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -284,34 +284,18 @@ static enum dma_cb_status dai_dma_cb(struct comp_dev *dev, uint32_t bytes)
 	return dma_status;
 }
 
-static struct comp_dev *dai_new(const struct comp_driver *drv,
-				const struct comp_ipc_config *config,
-				const void *spec)
+/*
+ * when copier call this function, dev will be passed with copier dev
+ */
+int dai_zephyr_new(struct dai_data *dd, struct comp_dev *dev,
+		   const struct ipc_config_dai *dai_cfg)
 {
-	struct comp_dev *dev;
-	const struct ipc_config_dai *dai_cfg = spec;
-	struct dai_data *dd;
 	uint32_t dir;
-
-	comp_cl_dbg(&comp_dai, "dai_new()");
-
-	dev = comp_alloc(drv, sizeof(*dev));
-	if (!dev)
-		return NULL;
-	dev->ipc_config = *config;
-
-	dd = rzalloc(SOF_MEM_ZONE_RUNTIME_SHARED, 0, SOF_MEM_CAPS_RAM, sizeof(*dd));
-	if (!dd) {
-		rfree(dev);
-		return NULL;
-	}
-
-	comp_set_drvdata(dev, dd);
 
 	dd->dai = dai_get(dai_cfg->type, dai_cfg->dai_index, DAI_CREAT);
 	if (!dd->dai) {
-		comp_cl_err(&comp_dai, "dai_new(): dai_get() failed to create DAI.");
-		goto error;
+		comp_err(dev, "dai_new(): dai_get() failed to create DAI.");
+		return -ENODEV;
 	}
 
 	dd->ipc_config = *dai_cfg;
@@ -322,8 +306,9 @@ static struct comp_dev *dai_new(const struct comp_driver *drv,
 
 	dd->dma = dma_get(dir, dd->dai->dma_caps, dd->dai->dma_dev, DMA_ACCESS_SHARED);
 	if (!dd->dma) {
-		comp_cl_err(&comp_dai, "dai_new(): dma_get() failed to get shared access to DMA.");
-		goto error;
+		dai_put(dd->dai);
+		comp_err(dev, "dai_new(): dma_get() failed to get shared access to DMA.");
+		return -ENODEV;
 	}
 
 	k_spinlock_init(&dd->dai->lock);
@@ -332,24 +317,52 @@ static struct comp_dev *dai_new(const struct comp_driver *drv,
 	dd->xrun = 0;
 	dd->chan = NULL;
 
+	return 0;
+}
+
+static struct comp_dev *dai_new(const struct comp_driver *drv,
+				const struct comp_ipc_config *config,
+				const void *spec)
+{
+	struct comp_dev *dev;
+	const struct ipc_config_dai *dai_cfg = spec;
+	struct dai_data *dd;
+	int ret;
+
+	comp_cl_dbg(&comp_dai, "dai_new()");
+
+	dev = comp_alloc(drv, sizeof(*dev));
+	if (!dev)
+		return NULL;
+	dev->ipc_config = *config;
+
+	dd = rzalloc(SOF_MEM_ZONE_RUNTIME_SHARED, 0, SOF_MEM_CAPS_RAM, sizeof(*dd));
+	if (!dd)
+		goto e_data;
+
+	comp_set_drvdata(dev, dd);
+
+	ret = dai_zephyr_new(dd, dev, dai_cfg);
+	if (ret < 0)
+		goto error;
+
 	dev->state = COMP_STATE_READY;
+
 	return dev;
 
 error:
 	rfree(dd);
+e_data:
 	rfree(dev);
 	return NULL;
 }
 
-static void dai_free(struct comp_dev *dev)
+void dai_zephyr_free(struct dai_data *dd, struct comp_dev *dev)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
-
 	if (dd->group) {
 		notifier_unregister(dev, dd->group, NOTIFIER_ID_DAI_TRIGGER);
 		dai_group_put(dd->group);
 	}
-
 	if (dd->chan) {
 		dma_release_channel(dd->dma->z_dev, dd->chan->index);
 		dd->chan->dev_data = NULL;
@@ -357,12 +370,20 @@ static void dai_free(struct comp_dev *dev)
 
 	dma_put(dd->dma);
 
-	dai_release_llp_slot(dev);
+	dai_release_llp_slot(dd);
 
 	dai_put(dd->dai);
 
 	rfree(dd->dai_spec_config);
 	rfree(dd);
+}
+
+static void dai_free(struct comp_dev *dev)
+{
+	struct dai_data *dd = comp_get_drvdata(dev);
+
+	dai_zephyr_free(dd, dev);
+
 	rfree(dev);
 }
 

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -979,19 +979,16 @@ static int dai_prepare(struct comp_dev *dev)
 	return dai_zephyr_prepare(dd, dev);
 }
 
-static int dai_reset(struct comp_dev *dev)
+void dai_zephyr_reset(struct dai_data *dd, struct comp_dev *dev)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
 	struct dma_sg_config *config = &dd->config;
-
-	comp_dbg(dev, "dai_reset()");
 
 	/*
 	 * DMA channel release should be skipped now for DAI's that support the two-step stop
 	 * option. It will be done when the host sends the DAI_CONFIG IPC during hw_free.
 	 */
 	if (!dd->delayed_dma_stop)
-		dai_dma_release(dev);
+		dai_dma_release(dd, dev);
 
 	dma_sg_free(&config->elem_array);
 	if (dd->z_config) {
@@ -1008,6 +1005,16 @@ static int dai_reset(struct comp_dev *dev)
 	dd->wallclock = 0;
 	dd->total_data_processed = 0;
 	dd->xrun = 0;
+}
+
+static int dai_reset(struct comp_dev *dev)
+{
+	struct dai_data *dd = comp_get_drvdata(dev);
+
+	comp_dbg(dev, "dai_reset()");
+
+	dai_zephyr_reset(dd, dev);
+
 	comp_set_state(dev, COMP_TRIGGER_RESET);
 
 	return 0;

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -219,9 +219,8 @@ static int dai_get_fifo(struct dai *dai, int direction, int stream_id)
 }
 
 /* this is called by DMA driver every time descriptor has completed */
-static enum dma_cb_status dai_dma_cb(struct comp_dev *dev, uint32_t bytes)
+static enum dma_cb_status dai_dma_cb(struct dai_data *dd, struct comp_dev *dev, uint32_t bytes)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
 	struct comp_buffer __sparse_cache *local_buf, *dma_buf;
 	enum dma_cb_status dma_status = DMA_CB_STATUS_RELOAD;
 	int ret;
@@ -1195,9 +1194,8 @@ static int dai_comp_trigger(struct comp_dev *dev, int cmd)
 }
 
 /* report xrun occurrence */
-static void dai_report_xrun(struct comp_dev *dev, uint32_t bytes)
+static void dai_report_xrun(struct dai_data *dd, struct comp_dev *dev, uint32_t bytes)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
 	struct comp_buffer __sparse_cache *buf_c = buffer_acquire(dd->local_buffer);
 
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK) {
@@ -1211,10 +1209,8 @@ static void dai_report_xrun(struct comp_dev *dev, uint32_t bytes)
 	buffer_release(buf_c);
 }
 
-/* copy and process stream data from source to sink buffers */
-static int dai_copy(struct comp_dev *dev)
+int dai_zephyr_copy(struct dai_data *dd, struct comp_dev *dev)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
 	uint32_t dma_fmt;
 	uint32_t sampling;
 	struct comp_buffer __sparse_cache *buf_c;
@@ -1226,8 +1222,6 @@ static int dai_copy(struct comp_dev *dev)
 	uint32_t sink_samples;
 	uint32_t samples;
 	int ret;
-
-	comp_dbg(dev, "dai_copy()");
 
 	/* get data sizes from DMA */
 	ret = dma_get_status(dd->chan->dma->z_dev, dd->chan->index, &stat);
@@ -1306,18 +1300,26 @@ static int dai_copy(struct comp_dev *dev)
 	if (ret < 0)
 		comp_warn(dev, "dai_copy(): dai trigger copy failed");
 
-	if (dai_dma_cb(dev, copy_bytes) == DMA_CB_STATUS_END)
+	if (dai_dma_cb(dd, dev, copy_bytes) == DMA_CB_STATUS_END)
 		dma_stop(dd->chan->dma->z_dev, dd->chan->index);
 
 	ret = dma_reload(dd->chan->dma->z_dev, dd->chan->index, 0, 0, copy_bytes);
 	if (ret < 0) {
-		dai_report_xrun(dev, copy_bytes);
+		dai_report_xrun(dd, dev, copy_bytes);
 		return ret;
 	}
 
-	dai_dma_position_update(dev);
+	dai_dma_position_update(dd, dev);
 
 	return ret;
+}
+
+/* copy and process stream data from source to sink buffers */
+static int dai_copy(struct comp_dev *dev)
+{
+	struct dai_data *dd = comp_get_drvdata(dev);
+
+	return dai_zephyr_copy(dd, dev);
 }
 
 /**

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -873,9 +873,8 @@ static int dai_params(struct comp_dev *dev, struct sof_ipc_stream_params *params
 		dai_capture_params(dev, period_bytes, period_count);
 }
 
-static int dai_config_prepare(struct comp_dev *dev)
+int dai_config_prepare(struct dai_data *dd, struct comp_dev *dev)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
 	int channel;
 
 	/* cannot configure DAI while active */
@@ -895,7 +894,7 @@ static int dai_config_prepare(struct comp_dev *dev)
 		return 0;
 	}
 
-	channel = dai_config_dma_channel(dev, dd->dai_spec_config);
+	channel = dai_config_dma_channel(dd, dev, dd->dai_spec_config);
 	comp_dbg(dev, "dai_config_prepare(), channel = %d", channel);
 
 	/* do nothing for asking for channel free, for compatibility. */
@@ -921,17 +920,10 @@ static int dai_config_prepare(struct comp_dev *dev)
 	return 0;
 }
 
-static int dai_prepare(struct comp_dev *dev)
+int dai_zephyr_prepare(struct dai_data *dd, struct comp_dev *dev)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
 	struct comp_buffer __sparse_cache *buffer_c;
 	int ret;
-
-	comp_dbg(dev, "dai_prepare()");
-
-	ret = dai_config_prepare(dev);
-	if (ret < 0)
-		return ret;
 
 	ret = comp_set_state(dev, COMP_TRIGGER_PREPARE);
 	if (ret < 0)
@@ -971,6 +963,20 @@ static int dai_prepare(struct comp_dev *dev)
 		comp_set_state(dev, COMP_TRIGGER_RESET);
 
 	return ret;
+}
+
+static int dai_prepare(struct comp_dev *dev)
+{
+	struct dai_data *dd = comp_get_drvdata(dev);
+	int ret;
+
+	comp_dbg(dev, "dai_prepare()");
+
+	ret = dai_config_prepare(dd, dev);
+	if (ret < 0)
+		return ret;
+
+	return dai_zephyr_prepare(dd, dev);
 }
 
 static int dai_reset(struct comp_dev *dev)

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -64,10 +64,8 @@ static void dai_atomic_trigger(void *arg, enum notify_id type, void *data)
 }
 
 /* Assign DAI to a group */
-int dai_assign_group(struct comp_dev *dev, uint32_t group_id)
+int dai_assign_group(struct dai_data *dd, struct comp_dev *dev, uint32_t group_id)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
-
 	if (dd->group) {
 		if (dd->group->group_id != group_id) {
 			comp_err(dev, "dai_assign_group(), DAI already in group %d, requested %d",
@@ -359,7 +357,6 @@ e_data:
 void dai_zephyr_free(struct dai_data *dd, struct comp_dev *dev)
 {
 	if (dd->group) {
-		notifier_unregister(dev, dd->group, NOTIFIER_ID_DAI_TRIGGER);
 		dai_group_put(dd->group);
 	}
 	if (dd->chan) {
@@ -380,6 +377,9 @@ void dai_zephyr_free(struct dai_data *dd, struct comp_dev *dev)
 static void dai_free(struct comp_dev *dev)
 {
 	struct dai_data *dd = comp_get_drvdata(dev);
+
+	if (dd->group)
+		notifier_unregister(dev, dd->group, NOTIFIER_ID_DAI_TRIGGER);
 
 	dai_zephyr_free(dd, dev);
 
@@ -1338,7 +1338,6 @@ static const struct comp_driver comp_dai = {
 		.prepare			= dai_prepare,
 		.reset				= dai_reset,
 		.position			= dai_position,
-		.dai_config			= dai_config,
 		.get_total_data_processed	= dai_get_processed_data,
 },
 };

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -386,35 +386,6 @@ static void dai_free(struct comp_dev *dev)
 	rfree(dev);
 }
 
-static int dai_comp_get_hw_params(struct comp_dev *dev,
-				  struct sof_ipc_stream_params *params,
-				  int dir)
-{
-	struct dai_data *dd = comp_get_drvdata(dev);
-	struct dai_config cfg;
-	int ret;
-
-	comp_dbg(dev, "dai_hw_params()");
-
-	ret = dai_config_get(dd->dai->dev, &cfg, dir);
-	if (ret)
-		return ret;
-
-	params->rate = cfg.rate;
-	params->buffer_fmt = 0;
-	params->channels = cfg.channels;
-
-	/* dai_comp_get_hw_params() function fetches hardware dai parameters,
-	 * which then are propagating back through the pipeline, so that any
-	 * component can convert specific stream parameter. Here, we overwrite
-	 * frame_fmt hardware parameter as DAI component is able to convert
-	 * stream with different frame_fmt's (using pcm converter)
-	 */
-	params->frame_fmt = dev->ipc_config.frame_fmt;
-
-	return ret;
-}
-
 /* set component audio SSP and DMA configuration */
 int dai_playback_params(struct dai_data *dd, struct comp_dev *dev, uint32_t period_bytes,
 			uint32_t period_count)
@@ -1447,7 +1418,6 @@ static const struct comp_driver comp_dai = {
 		.create				= dai_new,
 		.free				= dai_free,
 		.params				= dai_params,
-		.dai_get_hw_params		= dai_comp_get_hw_params,
 		.trigger			= dai_comp_trigger,
 		.copy				= dai_copy,
 		.prepare			= dai_prepare,

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -51,7 +51,7 @@ DECLARE_TR_CTX(dai_comp_tr, SOF_UUID(dai_comp_uuid), LOG_LEVEL_INFO);
 
 #if CONFIG_COMP_DAI_GROUP
 
-static int dai_comp_trigger_internal(struct comp_dev *dev, int cmd);
+static int dai_comp_trigger_internal(struct dai_data *dd, struct comp_dev *dev, int cmd);
 
 static void dai_atomic_trigger(void *arg, enum notify_id type, void *data)
 {
@@ -60,7 +60,7 @@ static void dai_atomic_trigger(void *arg, enum notify_id type, void *data)
 	struct dai_group *group = dd->group;
 
 	/* Atomic context set by the last DAI to receive trigger command */
-	group->trigger_ret = dai_comp_trigger_internal(dev, group->trigger_cmd);
+	group->trigger_ret = dai_comp_trigger_internal(dd, dev, group->trigger_cmd);
 }
 
 /* Assign DAI to a group */
@@ -1020,20 +1020,11 @@ static int dai_reset(struct comp_dev *dev)
 	return 0;
 }
 
-static void dai_update_start_position(struct comp_dev *dev)
-{
-	struct dai_data *dd = comp_get_drvdata(dev);
-
-	/* update starting wallclock */
-	platform_dai_wallclock(dev, &dd->wallclock);
-}
-
 /* used to pass standard and bespoke command (with data) to component */
-static int dai_comp_trigger_internal(struct comp_dev *dev, int cmd)
+static int dai_comp_trigger_internal(struct dai_data *dd, struct comp_dev *dev, int cmd)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
 	int prev_state = dev->state;
-	int ret;
+	int ret = 0;
 
 	comp_dbg(dev, "dai_comp_trigger_internal(), command = %u", cmd);
 
@@ -1060,7 +1051,7 @@ static int dai_comp_trigger_internal(struct comp_dev *dev, int cmd)
 			dd->xrun = 0;
 		}
 
-		dai_update_start_position(dev);
+		platform_dai_wallclock(dev, &dd->wallclock);
 		break;
 	case COMP_TRIGGER_RELEASE:
 		/* before release, we clear the buffer data to 0s,
@@ -1099,7 +1090,7 @@ static int dai_comp_trigger_internal(struct comp_dev *dev, int cmd)
 			dd->xrun = 0;
 		}
 
-		dai_update_start_position(dev);
+		platform_dai_wallclock(dev, &dd->wallclock);
 		break;
 	case COMP_TRIGGER_XRUN:
 		comp_info(dev, "dai_comp_trigger_internal(), XRUN");
@@ -1161,17 +1152,16 @@ static int dai_comp_trigger_internal(struct comp_dev *dev, int cmd)
 	return ret;
 }
 
-static int dai_comp_trigger(struct comp_dev *dev, int cmd)
+int dai_zephyr_trigger(struct dai_data *dd, struct comp_dev *dev, int cmd)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
 	struct dai_group *group = dd->group;
 	uint32_t irq_flags;
 	int ret = 0;
 
 	/* DAI not in a group, use normal trigger */
 	if (!group) {
-		comp_dbg(dev, "dai_comp_trigger(), non-atomic trigger");
-		return dai_comp_trigger_internal(dev, cmd);
+		comp_dbg(dev, "dai_zephyr_trigger(), non-atomic trigger");
+		return dai_comp_trigger_internal(dd, dev, cmd);
 	}
 
 	/* DAI is grouped, so only trigger when the entire group is ready */
@@ -1180,13 +1170,13 @@ static int dai_comp_trigger(struct comp_dev *dev, int cmd)
 		/* First DAI to receive the trigger command,
 		 * prepare for atomic trigger
 		 */
-		comp_dbg(dev, "dai_comp_trigger(), begin atomic trigger for group %d",
+		comp_dbg(dev, "dai_zephyr_trigger(), begin atomic trigger for group %d",
 			 group->group_id);
 		group->trigger_cmd = cmd;
 		group->trigger_counter = group->num_dais - 1;
 	} else if (group->trigger_cmd != cmd) {
 		/* Already processing a different trigger command */
-		comp_err(dev, "dai_comp_trigger(), already processing atomic trigger");
+		comp_err(dev, "dai_zephyr_trigger(), already processing atomic trigger");
 		ret = -EAGAIN;
 	} else {
 		/* Count down the number of remaining DAIs required
@@ -1194,7 +1184,7 @@ static int dai_comp_trigger(struct comp_dev *dev, int cmd)
 		 * takes place
 		 */
 		group->trigger_counter--;
-		comp_dbg(dev, "dai_comp_trigger(), trigger counter %d, group %d",
+		comp_dbg(dev, "dai_zephyr_trigger(), trigger counter %d, group %d",
 			 group->trigger_counter, group->group_id);
 
 		if (!group->trigger_counter) {
@@ -1215,6 +1205,13 @@ static int dai_comp_trigger(struct comp_dev *dev, int cmd)
 	}
 
 	return ret;
+}
+
+static int dai_comp_trigger(struct comp_dev *dev, int cmd)
+{
+	struct dai_data *dd = comp_get_drvdata(dev);
+
+	return dai_zephyr_trigger(dd, dev, cmd);
 }
 
 /* report xrun occurrence */

--- a/src/audio/pipeline/pipeline-stream.c
+++ b/src/audio/pipeline/pipeline-stream.c
@@ -325,11 +325,22 @@ static int pipeline_comp_trigger(struct comp_dev *current,
 			 * Initialization delay is only used with SSP, where we
 			 * don't use more than one DAI per copier
 			 */
+#if CONFIG_IPC_MAJOR_4
+			/* ipc4 case, dd get from cd->dd */
+			struct copier_data *cd = comp_get_drvdata(current);
+
+			if (cd) {
+				struct dai_data *dd = cd->dd[0];
+
+#elif CONFIG_IPC_MAJOR_3
 			struct comp_dev *dai = comp_get_dai(current, 0);
 
 			if (dai) {
 				struct dai_data *dd = comp_get_drvdata(dai);
 
+#else
+#error Unknown IPC major version
+#endif
 				ppl_data->delay_ms = dai_get_init_delay_ms(dd->dai);
 			} else {
 				/* Chain DMA case */

--- a/src/include/ipc4/copier.h
+++ b/src/include/ipc4/copier.h
@@ -27,6 +27,7 @@
 #include <stdint.h>
 #include <ipc4/base-config.h>
 #include <ipc4/gateway.h>
+#include <ipc4/alh.h>
 
 #include <sof/compiler_attributes.h>
 #include <sof/audio/buffer.h>
@@ -263,6 +264,7 @@ struct copier_data {
 	uint64_t output_total_data_processed;
 	struct host_data *hd;
 	bool ipc_gtw;
+	struct dai_data *dd[IPC4_ALH_MAX_NUMBER_OF_GTW];
 };
 
 int apply_attenuation(struct comp_dev *dev, struct copier_data *cd,

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -347,8 +347,8 @@ struct comp_ops {
 	 *
 	 * Mandatory for components that allocate DAI.
 	 */
-	int (*dai_config)(struct comp_dev *dev, struct ipc_config_dai *dai_config,
-			  const void *dai_spec_config);
+	int (*dai_config)(struct dai_data *dd, struct comp_dev *dev,
+			  struct ipc_config_dai *dai_config, const void *dai_spec_config);
 
 	/**
 	 * Used to pass standard and bespoke commands (with optional data).

--- a/src/include/sof/audio/component_ext.h
+++ b/src/include/sof/audio/component_ext.h
@@ -252,16 +252,27 @@ static inline int comp_reset(struct comp_dev *dev)
 	return 0;
 }
 
+#if CONFIG_IPC_MAJOR_3
 /** See comp_ops::dai_config */
 static inline int comp_dai_config(struct comp_dev *dev, struct ipc_config_dai *config,
 				  const void *spec_config)
 {
+	struct dai_data *dd = comp_get_drvdata(dev);
+
 	if (dev->drv->ops.dai_config)
-		return dev->drv->ops.dai_config(dev, config, spec_config);
+		return dev->drv->ops.dai_config(dd, dev, config, spec_config);
 
 	return 0;
 }
-
+#elif CONFIG_IPC_MAJOR_4
+static inline int comp_dai_config(struct dai_data *dd, struct comp_dev *dev,
+				  struct ipc_config_dai *config, const void *spec_config)
+{
+	return dai_config(dd, dev, config, spec_config);
+}
+#else
+#error Unknown IPC major version
+#endif
 /** See comp_ops::position */
 static inline int comp_position(struct comp_dev *dev,
 				struct sof_ipc_stream_posn *posn)

--- a/src/include/sof/audio/dai_copier.h
+++ b/src/include/sof/audio/dai_copier.h
@@ -1,0 +1,32 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2023 Intel Corporation. All rights reserved.
+ *
+ * Author: Baofeng Tian <baofeng.tian@intel.com>
+ */
+
+/**
+ * \file audio/dai_copier.h
+ * \brief dai copier shared header file
+ * \authors Baofeng Tian <baofeng.tian@intel.com>
+ */
+
+#ifndef __SOF_LIB_DAI_COPIER_H__
+#define __SOF_LIB_DAI_COPIER_H__
+
+#if CONFIG_ZEPHYR_NATIVE_DRIVERS
+int dai_zephyr_new(struct dai_data *dd, struct comp_dev *dev,
+		   const struct ipc_config_dai *dai_cfg);
+
+void dai_zephyr_free(struct dai_data *dd, struct comp_dev *dev);
+#else
+static inline int dai_zephyr_new(struct dai_data *dd, struct comp_dev *dev,
+				 const struct ipc_config_dai *dai_cfg)
+{
+	return 0;
+}
+
+static inline void dai_zephyr_free(struct dai_data *dd, struct comp_dev *dev) {}
+
+#endif
+#endif /* __SOF_LIB_DAI_COPIER_H__ */

--- a/src/include/sof/audio/dai_copier.h
+++ b/src/include/sof/audio/dai_copier.h
@@ -19,6 +19,10 @@ int dai_zephyr_new(struct dai_data *dd, struct comp_dev *dev,
 		   const struct ipc_config_dai *dai_cfg);
 
 void dai_zephyr_free(struct dai_data *dd, struct comp_dev *dev);
+
+int dai_config_prepare(struct dai_data *dd, struct comp_dev *dev);
+
+int dai_zephyr_prepare(struct dai_data *dd, struct comp_dev *dev);
 #else
 static inline int dai_zephyr_new(struct dai_data *dd, struct comp_dev *dev,
 				 const struct ipc_config_dai *dai_cfg)
@@ -27,6 +31,16 @@ static inline int dai_zephyr_new(struct dai_data *dd, struct comp_dev *dev,
 }
 
 static inline void dai_zephyr_free(struct dai_data *dd, struct comp_dev *dev) {}
+
+static inline int dai_config_prepare(struct dai_data *dd, struct comp_dev *dev)
+{
+	return 0;
+}
+
+static inline int dai_zephyr_prepare(struct dai_data *dd, struct comp_dev *dev)
+{
+	return 0;
+}
 
 #endif
 #endif /* __SOF_LIB_DAI_COPIER_H__ */

--- a/src/include/sof/audio/dai_copier.h
+++ b/src/include/sof/audio/dai_copier.h
@@ -40,6 +40,8 @@ int dai_zephyr_params(struct dai_data *dd, struct comp_dev *dev,
 		      uint32_t *period_bytes,
 		      struct list_item *bsource_list,
 		      struct list_item *bsink_list);
+
+int dai_zephyr_copy(struct dai_data *dd, struct comp_dev *dev);
 #else
 static inline int dai_zephyr_new(struct dai_data *dd, struct comp_dev *dev,
 				 const struct ipc_config_dai *dai_cfg)
@@ -84,6 +86,11 @@ static inline int dai_zephyr_params(struct dai_data *dd, struct comp_dev *dev,
 				    uint32_t *period_bytes,
 				    struct list_item *bsource_list,
 				    struct list_item *bsink_list)
+{
+	return 0;
+}
+
+static inline int dai_zephyr_copy(struct dai_data *dd, struct comp_dev *dev)
 {
 	return 0;
 }

--- a/src/include/sof/audio/dai_copier.h
+++ b/src/include/sof/audio/dai_copier.h
@@ -23,6 +23,8 @@ void dai_zephyr_free(struct dai_data *dd, struct comp_dev *dev);
 int dai_config_prepare(struct dai_data *dd, struct comp_dev *dev);
 
 int dai_zephyr_prepare(struct dai_data *dd, struct comp_dev *dev);
+
+void dai_zephyr_reset(struct dai_data *dd, struct comp_dev *dev);
 #else
 static inline int dai_zephyr_new(struct dai_data *dd, struct comp_dev *dev,
 				 const struct ipc_config_dai *dai_cfg)
@@ -41,6 +43,8 @@ static inline int dai_zephyr_prepare(struct dai_data *dd, struct comp_dev *dev)
 {
 	return 0;
 }
+
+static inline void dai_zephyr_reset(struct dai_data *dd, struct comp_dev *dev) {}
 
 #endif
 #endif /* __SOF_LIB_DAI_COPIER_H__ */

--- a/src/include/sof/audio/dai_copier.h
+++ b/src/include/sof/audio/dai_copier.h
@@ -27,6 +27,19 @@ int dai_zephyr_prepare(struct dai_data *dd, struct comp_dev *dev);
 void dai_zephyr_reset(struct dai_data *dd, struct comp_dev *dev);
 
 int dai_zephyr_trigger(struct dai_data *dd, struct comp_dev *dev, int cmd);
+
+int dai_playback_params(struct dai_data *dd, struct comp_dev *dev, uint32_t period_bytes,
+			uint32_t period_count);
+
+int dai_capture_params(struct dai_data *dd, struct comp_dev *dev, uint32_t period_bytes,
+		       uint32_t period_count);
+
+int dai_zephyr_params(struct dai_data *dd, struct comp_dev *dev,
+		      struct sof_ipc_stream_params *params,
+		      uint32_t *period_count,
+		      uint32_t *period_bytes,
+		      struct list_item *bsource_list,
+		      struct list_item *bsink_list);
 #else
 static inline int dai_zephyr_new(struct dai_data *dd, struct comp_dev *dev,
 				 const struct ipc_config_dai *dai_cfg)
@@ -49,6 +62,28 @@ static inline int dai_zephyr_prepare(struct dai_data *dd, struct comp_dev *dev)
 static inline void dai_zephyr_reset(struct dai_data *dd, struct comp_dev *dev) {}
 
 static inline int dai_zephyr_trigger(struct dai_data *dd, struct comp_dev *dev, int cmd)
+{
+	return 0;
+}
+
+static inline int dai_playback_params(struct dai_data *dd, struct comp_dev *dev,
+				      uint32_t period_bytes, uint32_t period_count)
+{
+	return 0;
+}
+
+static inline int dai_capture_params(struct dai_data *dd, struct comp_dev *dev,
+				     uint32_t period_bytes, uint32_t period_count)
+{
+	return 0;
+}
+
+static inline int dai_zephyr_params(struct dai_data *dd, struct comp_dev *dev,
+				    struct sof_ipc_stream_params *params,
+				    uint32_t *period_count,
+				    uint32_t *period_bytes,
+				    struct list_item *bsource_list,
+				    struct list_item *bsink_list)
 {
 	return 0;
 }

--- a/src/include/sof/audio/dai_copier.h
+++ b/src/include/sof/audio/dai_copier.h
@@ -18,7 +18,7 @@
 int dai_zephyr_new(struct dai_data *dd, struct comp_dev *dev,
 		   const struct ipc_config_dai *dai_cfg);
 
-void dai_zephyr_free(struct dai_data *dd, struct comp_dev *dev);
+void dai_zephyr_free(struct dai_data *dd);
 
 int dai_config_prepare(struct dai_data *dd, struct comp_dev *dev);
 
@@ -37,9 +37,7 @@ int dai_capture_params(struct dai_data *dd, struct comp_dev *dev, uint32_t perio
 int dai_zephyr_params(struct dai_data *dd, struct comp_dev *dev,
 		      struct sof_ipc_stream_params *params,
 		      uint32_t *period_count,
-		      uint32_t *period_bytes,
-		      struct list_item *bsource_list,
-		      struct list_item *bsink_list);
+		      uint32_t *period_bytes);
 
 int dai_zephyr_copy(struct dai_data *dd, struct comp_dev *dev);
 #else
@@ -49,7 +47,7 @@ static inline int dai_zephyr_new(struct dai_data *dd, struct comp_dev *dev,
 	return 0;
 }
 
-static inline void dai_zephyr_free(struct dai_data *dd, struct comp_dev *dev) {}
+static inline void dai_zephyr_free(struct dai_data *dd) {}
 
 static inline int dai_config_prepare(struct dai_data *dd, struct comp_dev *dev)
 {
@@ -83,9 +81,7 @@ static inline int dai_capture_params(struct dai_data *dd, struct comp_dev *dev,
 static inline int dai_zephyr_params(struct dai_data *dd, struct comp_dev *dev,
 				    struct sof_ipc_stream_params *params,
 				    uint32_t *period_count,
-				    uint32_t *period_bytes,
-				    struct list_item *bsource_list,
-				    struct list_item *bsink_list)
+				    uint32_t *period_bytes)
 {
 	return 0;
 }

--- a/src/include/sof/audio/dai_copier.h
+++ b/src/include/sof/audio/dai_copier.h
@@ -25,6 +25,8 @@ int dai_config_prepare(struct dai_data *dd, struct comp_dev *dev);
 int dai_zephyr_prepare(struct dai_data *dd, struct comp_dev *dev);
 
 void dai_zephyr_reset(struct dai_data *dd, struct comp_dev *dev);
+
+int dai_zephyr_trigger(struct dai_data *dd, struct comp_dev *dev, int cmd);
 #else
 static inline int dai_zephyr_new(struct dai_data *dd, struct comp_dev *dev,
 				 const struct ipc_config_dai *dai_cfg)
@@ -45,6 +47,11 @@ static inline int dai_zephyr_prepare(struct dai_data *dd, struct comp_dev *dev)
 }
 
 static inline void dai_zephyr_reset(struct dai_data *dd, struct comp_dev *dev) {}
+
+static inline int dai_zephyr_trigger(struct dai_data *dd, struct comp_dev *dev, int cmd)
+{
+	return 0;
+}
 
 #endif
 #endif /* __SOF_LIB_DAI_COPIER_H__ */

--- a/src/include/sof/ipc/common.h
+++ b/src/include/sof/ipc/common.h
@@ -145,7 +145,8 @@ void ipc_send_buffer_status_notify(void);
  * \brief Configure DAI.
  * @return 0 on success.
  */
-int ipc_dai_data_config(struct comp_dev *dev);
+struct dai_data;
+int ipc_dai_data_config(struct dai_data *dd, struct comp_dev *dev, uint32_t *frame_fmt);
 
 /**
  * \brief create a IPC boot complete message.

--- a/src/include/sof/lib/dai-legacy.h
+++ b/src/include/sof/lib/dai-legacy.h
@@ -548,7 +548,7 @@ int dai_config_dma_channel(struct dai_data *dd, struct comp_dev *dev, const void
 /**
  * \brief Reset DAI DMA config
  */
-void dai_dma_release(struct comp_dev *dev);
+void dai_dma_release(struct dai_data *dd, struct comp_dev *dev);
 
 /**
  * \brief Configure DAI physical interface.

--- a/src/include/sof/lib/dai-legacy.h
+++ b/src/include/sof/lib/dai-legacy.h
@@ -575,7 +575,7 @@ int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn);
 /**
  * \brief update dai dma position for host driver.
  */
-void dai_dma_position_update(struct comp_dev *dev);
+void dai_dma_position_update(struct dai_data *dd, struct comp_dev *dev);
 
 /**
  * \brief release llp slot

--- a/src/include/sof/lib/dai-legacy.h
+++ b/src/include/sof/lib/dai-legacy.h
@@ -543,7 +543,7 @@ static inline const struct dai_info *dai_info_get(void)
 /**
  * \brief Configure DMA channel for DAI
  */
-int dai_config_dma_channel(struct comp_dev *dev, const void *config);
+int dai_config_dma_channel(struct dai_data *dd, struct comp_dev *dev, const void *config);
 
 /**
  * \brief Reset DAI DMA config

--- a/src/include/sof/lib/dai-legacy.h
+++ b/src/include/sof/lib/dai-legacy.h
@@ -562,6 +562,12 @@ int dai_config(struct comp_dev *dev,  struct ipc_config_dai *common_config,
 int dai_assign_group(struct comp_dev *dev, uint32_t group_id);
 
 /**
+ * \brief dai zephyr position
+ */
+int dai_zephyr_position(struct dai_data *dd, struct comp_dev *dev,
+			struct sof_ipc_stream_posn *posn);
+
+/**
  * \brief dai position for host driver.
  */
 int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn);

--- a/src/include/sof/lib/dai-legacy.h
+++ b/src/include/sof/lib/dai-legacy.h
@@ -574,7 +574,7 @@ void dai_dma_position_update(struct comp_dev *dev);
 /**
  * \brief release llp slot
  */
-void dai_release_llp_slot(struct comp_dev *dev);
+void dai_release_llp_slot(struct dai_data *dd);
 /** @}*/
 
 #endif /* __SOF_LIB_DAI_LEGACY_H__ */

--- a/src/include/sof/lib/dai-legacy.h
+++ b/src/include/sof/lib/dai-legacy.h
@@ -553,13 +553,13 @@ void dai_dma_release(struct dai_data *dd, struct comp_dev *dev);
 /**
  * \brief Configure DAI physical interface.
  */
-int dai_config(struct comp_dev *dev,  struct ipc_config_dai *common_config,
+int dai_config(struct dai_data *dd, struct comp_dev *dev,  struct ipc_config_dai *common_config,
 	       const void *spec_config);
 
 /**
  * \brief Assign DAI to a group for simultaneous triggering.
  */
-int dai_assign_group(struct comp_dev *dev, uint32_t group_id);
+int dai_assign_group(struct dai_data *dd, struct comp_dev *dev, uint32_t group_id);
 
 /**
  * \brief dai zephyr position

--- a/src/include/sof/lib/dai-zephyr.h
+++ b/src/include/sof/lib/dai-zephyr.h
@@ -286,7 +286,7 @@ int dai_zephyr_position(struct dai_data *dd, struct comp_dev *dev,
 /**
  * \brief update dai dma position for host driver.
  */
-void dai_dma_position_update(struct comp_dev *dev);
+void dai_dma_position_update(struct dai_data *dd, struct comp_dev *dev);
 
 /**
  * \brief release llp slot

--- a/src/include/sof/lib/dai-zephyr.h
+++ b/src/include/sof/lib/dai-zephyr.h
@@ -265,12 +265,13 @@ void dai_dma_release(struct dai_data *dd, struct comp_dev *dev);
 /**
  * \brief Configure DAI physical interface.
  */
-int dai_config(struct comp_dev *dev,  struct ipc_config_dai *common_cfg, const void *spec_cfg);
+int dai_config(struct dai_data *dd, struct comp_dev *dev,
+	       struct ipc_config_dai *common_cfg, const void *spec_cfg);
 
 /**
  * \brief Assign DAI to a group for simultaneous triggering.
  */
-int dai_assign_group(struct comp_dev *dev, uint32_t group_id);
+int dai_assign_group(struct dai_data *dd, struct comp_dev *dev, uint32_t group_id);
 
 /**
  * \brief dai position for host driver.

--- a/src/include/sof/lib/dai-zephyr.h
+++ b/src/include/sof/lib/dai-zephyr.h
@@ -278,6 +278,12 @@ int dai_assign_group(struct comp_dev *dev, uint32_t group_id);
 int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn);
 
 /**
+ * \brief dai zephyr position
+ */
+int dai_zephyr_position(struct dai_data *dd, struct comp_dev *dev,
+			struct sof_ipc_stream_posn *posn);
+
+/**
  * \brief update dai dma position for host driver.
  */
 void dai_dma_position_update(struct comp_dev *dev);

--- a/src/include/sof/lib/dai-zephyr.h
+++ b/src/include/sof/lib/dai-zephyr.h
@@ -283,7 +283,7 @@ void dai_dma_position_update(struct comp_dev *dev);
 /**
  * \brief release llp slot
  */
-void dai_release_llp_slot(struct comp_dev *dev);
+void dai_release_llp_slot(struct dai_data *dd);
 /** @}*/
 
 #endif /* __SOF_LIB_DAI_ZEPHYR_H__ */

--- a/src/include/sof/lib/dai-zephyr.h
+++ b/src/include/sof/lib/dai-zephyr.h
@@ -32,7 +32,9 @@
 #include <errno.h>
 #include <stddef.h>
 #include <stdint.h>
+#ifdef __ZEPHYR__
 #include <zephyr/device.h>
+#endif
 
 /** \addtogroup sof_dai_drivers DAI Drivers
  *  DAI Drivers API specification.
@@ -258,7 +260,7 @@ int dai_config_dma_channel(struct dai_data *dd, struct comp_dev *dev, const void
 /**
  * \brief Reset DAI DMA config
  */
-void dai_dma_release(struct comp_dev *dev);
+void dai_dma_release(struct dai_data *dd, struct comp_dev *dev);
 
 /**
  * \brief Configure DAI physical interface.

--- a/src/include/sof/lib/dai-zephyr.h
+++ b/src/include/sof/lib/dai-zephyr.h
@@ -253,7 +253,7 @@ int dai_get_stream_id(struct dai *dai, int direction);
 /**
  * \brief Configure DMA channel for DAI
  */
-int dai_config_dma_channel(struct comp_dev *dev, const void *config);
+int dai_config_dma_channel(struct dai_data *dd, struct comp_dev *dev, const void *config);
 
 /**
  * \brief Reset DAI DMA config

--- a/src/ipc/ipc3/dai.c
+++ b/src/ipc/ipc3/dai.c
@@ -94,9 +94,8 @@ int dai_config_dma_channel(struct dai_data *dd, struct comp_dev *dev, const void
 	return channel;
 }
 
-int ipc_dai_data_config(struct comp_dev *dev)
+int ipc_dai_data_config(struct dai_data *dd, struct comp_dev *dev, uint32_t *frame_fmt)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
 	struct ipc_config_dai *dai = &dd->ipc_config;
 	struct sof_ipc_dai_config *config = ipc_from_dai_config(dd->dai_spec_config);
 	struct comp_buffer __sparse_cache *buffer_c;
@@ -140,10 +139,10 @@ int ipc_dai_data_config(struct comp_dev *dev)
 		/* SDW HW FIFO always requires 32bit MSB aligned sample data for
 		 * all formats, such as 8/16/24/32 bits.
 		 */
-		dev->ipc_config.frame_fmt = SOF_IPC_FRAME_S32_LE;
+		*frame_fmt = SOF_IPC_FRAME_S32_LE;
 		if (dd->dma_buffer) {
 			buffer_c = buffer_acquire(dd->dma_buffer);
-			buffer_c->stream.frame_fmt = dev->ipc_config.frame_fmt;
+			buffer_c->stream.frame_fmt = *frame_fmt;
 			buffer_release(buffer_c);
 		}
 		dd->config.burst_elems = dai_get_fifo_depth(dd->dai, dai->direction);
@@ -158,23 +157,23 @@ int ipc_dai_data_config(struct comp_dev *dev)
 		dd->config.burst_elems = dai_get_fifo_depth(dd->dai, dai->direction);
 		break;
 	case SOF_DAI_AMD_BT:
-		dev->ipc_config.frame_fmt = SOF_IPC_FRAME_S16_LE;
+		*frame_fmt = SOF_IPC_FRAME_S16_LE;
 		break;
 	case SOF_DAI_AMD_SP:
 	case SOF_DAI_AMD_SP_VIRTUAL:
-		dev->ipc_config.frame_fmt = SOF_IPC_FRAME_S16_LE;
+		*frame_fmt = SOF_IPC_FRAME_S16_LE;
 		break;
 	case SOF_DAI_AMD_DMIC:
-		dev->ipc_config.frame_fmt = SOF_IPC_FRAME_S32_LE;
+		*frame_fmt = SOF_IPC_FRAME_S32_LE;
 		if (dd->dma_buffer) {
 			buffer_c = buffer_acquire(dd->dma_buffer);
-			buffer_c->stream.frame_fmt = dev->ipc_config.frame_fmt;
+			buffer_c->stream.frame_fmt = *frame_fmt;
 			buffer_release(buffer_c);
 		}
 		break;
 	case SOF_DAI_AMD_HS:
 	case SOF_DAI_AMD_HS_VIRTUAL:
-		dev->ipc_config.frame_fmt = SOF_IPC_FRAME_S16_LE;
+		*frame_fmt = SOF_IPC_FRAME_S16_LE;
 		break;
 	case SOF_DAI_MEDIATEK_AFE:
 		break;

--- a/src/ipc/ipc3/dai.c
+++ b/src/ipc/ipc3/dai.c
@@ -262,10 +262,8 @@ int ipc_comp_dai_config(struct ipc *ipc, struct ipc_config_dai *common_config,
 	return ret;
 }
 
-void dai_dma_release(struct comp_dev *dev)
+void dai_dma_release(struct dai_data *dd, struct comp_dev *dev)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
-
 	/* cannot configure DAI while active */
 	if (dev->state == COMP_STATE_ACTIVE) {
 		comp_info(dev, "dai_config(): Component is in active state. Ignore resetting");
@@ -335,7 +333,7 @@ int dai_config(struct comp_dev *dev, struct ipc_config_dai *common_config,
 			if (ret < 0)
 				return ret;
 
-			dai_dma_release(dev);
+			dai_dma_release(dd, dev);
 		}
 
 		return 0;

--- a/src/ipc/ipc3/dai.c
+++ b/src/ipc/ipc3/dai.c
@@ -392,6 +392,6 @@ int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn)
 	return 0;
 }
 
-void dai_dma_position_update(struct comp_dev *dev) { }
+void dai_dma_position_update(struct dai_data *dd, struct comp_dev *dev) { }
 
 void dai_release_llp_slot(struct dai_data *dd) { }

--- a/src/ipc/ipc3/dai.c
+++ b/src/ipc/ipc3/dai.c
@@ -29,9 +29,8 @@
 
 LOG_MODULE_DECLARE(ipc, CONFIG_SOF_LOG_LEVEL);
 
-int dai_config_dma_channel(struct comp_dev *dev, const void *spec_config)
+int dai_config_dma_channel(struct dai_data *dd, struct comp_dev *dev, const void *spec_config)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
 	const struct sof_ipc_dai_config *config = spec_config;
 	struct ipc_config_dai *dai = &dd->ipc_config;
 	int channel;
@@ -360,7 +359,7 @@ int dai_config(struct comp_dev *dev, struct ipc_config_dai *common_config,
 	}
 #endif
 	/* do nothing for asking for channel free, for compatibility. */
-	if (dai_config_dma_channel(dev, spec_config) == DMA_CHAN_INVALID)
+	if (dai_config_dma_channel(dd, dev, spec_config) == DMA_CHAN_INVALID)
 		return 0;
 
 	/* allocated dai_config if not yet */

--- a/src/ipc/ipc3/dai.c
+++ b/src/ipc/ipc3/dai.c
@@ -398,4 +398,4 @@ int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn)
 
 void dai_dma_position_update(struct comp_dev *dev) { }
 
-void dai_release_llp_slot(struct comp_dev *dev) { }
+void dai_release_llp_slot(struct dai_data *dd) { }

--- a/src/ipc/ipc3/dai.c
+++ b/src/ipc/ipc3/dai.c
@@ -283,11 +283,10 @@ void dai_dma_release(struct dai_data *dd, struct comp_dev *dev)
 	}
 }
 
-int dai_config(struct comp_dev *dev, struct ipc_config_dai *common_config,
+int dai_config(struct dai_data *dd, struct comp_dev *dev, struct ipc_config_dai *common_config,
 	       const void *spec_config)
 {
 	const struct sof_ipc_dai_config *config = spec_config;
-	struct dai_data *dd = comp_get_drvdata(dev);
 	int ret;
 
 	/* ignore if message not for this DAI id/type */
@@ -349,7 +348,7 @@ int dai_config(struct comp_dev *dev, struct ipc_config_dai *common_config,
 	}
 #if CONFIG_COMP_DAI_GROUP
 	if (config->group_id) {
-		ret = dai_assign_group(dev, config->group_id);
+		ret = dai_assign_group(dd, dev, config->group_id);
 
 		if (ret)
 			return ret;

--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -248,9 +248,8 @@ static int dai_get_unused_llp_slot(struct comp_dev *dev,
 	return offset;
 }
 
-static int dai_init_llp_info(struct comp_dev *dev)
+static int dai_init_llp_info(struct dai_data *dd, struct comp_dev *dev)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
 	struct ipc4_copier_module_cfg *copier_cfg;
 	union ipc4_connector_node_id node;
 	int ret;
@@ -278,11 +277,10 @@ static int dai_init_llp_info(struct comp_dev *dev)
 	return 0;
 }
 
-int dai_config(struct comp_dev *dev, struct ipc_config_dai *common_config,
+int dai_config(struct dai_data *dd, struct comp_dev *dev, struct ipc_config_dai *common_config,
 	       const void *spec_config)
 {
 	const struct ipc4_copier_module_cfg *copier_cfg = spec_config;
-	struct dai_data *dd = comp_get_drvdata(dev);
 	int size;
 	int ret;
 
@@ -308,7 +306,7 @@ int dai_config(struct comp_dev *dev, struct ipc_config_dai *common_config,
 
 #if CONFIG_COMP_DAI_GROUP
 	if (common_config->group_id) {
-		ret = dai_assign_group(dev, common_config->group_id);
+		ret = dai_assign_group(dd, dev, common_config->group_id);
 
 		if (ret)
 			return ret;
@@ -317,7 +315,7 @@ int dai_config(struct comp_dev *dev, struct ipc_config_dai *common_config,
 	/* do nothing for asking for channel free, for compatibility. */
 	if (dai_config_dma_channel(dd, dev, spec_config) == DMA_CHAN_INVALID)
 		return 0;
-
+	/* only period was used, so copier and dai are same */
 	dd->dai_dev = dev;
 
 	/* allocated dai_config if not yet */
@@ -337,7 +335,7 @@ int dai_config(struct comp_dev *dev, struct ipc_config_dai *common_config,
 		}
 	}
 
-	ret = dai_init_llp_info(dev);
+	ret = dai_init_llp_info(dd, dev);
 	if (ret < 0)
 		return ret;
 

--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -373,9 +373,8 @@ int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn)
 	return dai_zephyr_position(dd, dev, posn);
 }
 
-void dai_dma_position_update(struct comp_dev *dev)
+void dai_dma_position_update(struct dai_data *dd, struct comp_dev *dev)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
 	struct ipc4_llp_reading_slot slot;
 	struct dma_status status;
 	int ret;
@@ -422,9 +421,8 @@ int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn)
 	return dai_zephyr_position(dd, dev, posn);
 }
 
-void dai_dma_position_update(struct comp_dev *dev)
+void dai_dma_position_update(struct dai_data *dd, struct comp_dev *dev)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
 	struct ipc4_llp_reading_slot slot;
 	struct dma_chan_status status;
 	uint32_t llp_data[2];

--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -189,9 +189,8 @@ void dai_dma_release(struct comp_dev *dev)
 	}
 }
 
-void dai_release_llp_slot(struct comp_dev *dev)
+void dai_release_llp_slot(struct dai_data *dd)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
 	struct ipc4_llp_reading_slot slot;
 	k_spinlock_key_t key;
 

--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -346,9 +346,9 @@ int dai_config(struct comp_dev *dev, struct ipc_config_dai *common_config,
 }
 
 #if CONFIG_ZEPHYR_NATIVE_DRIVERS
-int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn)
+int dai_zephyr_position(struct dai_data *dd, struct comp_dev *dev,
+			struct sof_ipc_stream_posn *posn)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
 	struct dma_status status;
 	int ret;
 
@@ -365,6 +365,13 @@ int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn)
 	posn->comp_posn = status.total_copied;
 
 	return 0;
+}
+
+int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn)
+{
+	struct dai_data *dd = comp_get_drvdata(dev);
+
+	return dai_zephyr_position(dd, dev, posn);
 }
 
 void dai_dma_position_update(struct comp_dev *dev)
@@ -392,9 +399,9 @@ void dai_dma_position_update(struct comp_dev *dev)
 	mailbox_sw_regs_write(dd->slot_info.reg_offset, &slot, sizeof(slot));
 }
 #else
-int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn)
+int dai_zephyr_position(struct dai_data *dd, struct comp_dev *dev,
+			struct sof_ipc_stream_posn *posn)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
 	struct dma_chan_status status;
 
 	/* total processed bytes count */
@@ -407,6 +414,13 @@ int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn)
 	dma_status_legacy(dd->chan, &status, dev->direction);
 
 	return 0;
+}
+
+int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn)
+{
+	struct dai_data *dd = comp_get_drvdata(dev);
+
+	return dai_zephyr_position(dd, dev, posn);
 }
 
 void dai_dma_position_update(struct comp_dev *dev)

--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -30,10 +30,9 @@
 
 LOG_MODULE_DECLARE(ipc, CONFIG_SOF_LOG_LEVEL);
 
-int dai_config_dma_channel(struct comp_dev *dev, const void *spec_config)
+int dai_config_dma_channel(struct dai_data *dd, struct comp_dev *dev, const void *spec_config)
 {
 	const struct ipc4_copier_module_cfg *copier_cfg = spec_config;
-	struct dai_data *dd = comp_get_drvdata(dev);
 	struct ipc_config_dai *dai = &dd->ipc_config;
 	int channel;
 
@@ -319,7 +318,7 @@ int dai_config(struct comp_dev *dev, struct ipc_config_dai *common_config,
 	}
 #endif
 	/* do nothing for asking for channel free, for compatibility. */
-	if (dai_config_dma_channel(dev, spec_config) == DMA_CHAN_INVALID)
+	if (dai_config_dma_channel(dd, dev, spec_config) == DMA_CHAN_INVALID)
 		return 0;
 
 	dd->dai_dev = dev;

--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -170,14 +170,9 @@ void dai_dma_release(struct dai_data *dd, struct comp_dev *dev)
 		if (dev->state != COMP_STATE_PAUSED)
 			dma_stop(dd->chan->dma->z_dev, dd->chan->index);
 
-		/* remove callback */
-		notifier_unregister(dev, dd->chan, NOTIFIER_ID_DMA_COPY);
 		dma_release_channel(dd->chan->dma->z_dev, dd->chan->index);
 #else
 		dma_stop_legacy(dd->chan);
-
-		/* remove callback */
-		notifier_unregister(dev, dd->chan, NOTIFIER_ID_DMA_COPY);
 		dma_channel_put_legacy(dd->chan);
 #endif
 		dd->chan->dev_data = NULL;

--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -61,9 +61,8 @@ int dai_config_dma_channel(struct dai_data *dd, struct comp_dev *dev, const void
 	return channel;
 }
 
-int ipc_dai_data_config(struct comp_dev *dev)
+int ipc_dai_data_config(struct dai_data *dd, struct comp_dev *dev, uint32_t *frame_fmt)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
 	struct ipc_config_dai *dai = &dd->ipc_config;
 	struct ipc4_copier_module_cfg *copier_cfg = dd->dai_spec_config;
 	struct dai *dai_p = dd->dai;
@@ -110,12 +109,12 @@ int ipc_dai_data_config(struct comp_dev *dev)
 		/* SDW HW FIFO always requires 32bit MSB aligned sample data for
 		 * all formats, such as 8/16/24/32 bits.
 		 */
-		dev->ipc_config.frame_fmt = SOF_IPC_FRAME_S32_LE;
+		*frame_fmt = SOF_IPC_FRAME_S32_LE;
 
 		dd->config.burst_elems = dai_get_fifo_depth(dd->dai, dai->direction);
 
 		comp_dbg(dev, "dai_data_config() SOF_DAI_INTEL_ALH dev->ipc_config.frame_fmt: %d, stream_id: %d",
-			 dev->ipc_config.frame_fmt, dd->stream_id);
+			 *frame_fmt, dd->stream_id);
 
 		break;
 	default:

--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -137,10 +137,8 @@ int ipc_comp_dai_config(struct ipc *ipc, struct ipc_config_dai *common_config,
 	return 0;
 }
 
-void dai_dma_release(struct comp_dev *dev)
+void dai_dma_release(struct dai_data *dd, struct comp_dev *dev)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
-
 	/* cannot configure DAI while active */
 	if (dev->state == COMP_STATE_ACTIVE) {
 		comp_info(dev, "dai_config(): Component is in active state. Ignore resetting");


### PR DESCRIPTION
Create and expose two functions for dai allocation and free along with struct dai_data,these functions will be shared by both dai and copier components.
This is in preparation to remove the creation of dai component and endpoint buffer in init_dai().

Below is the preparation work:
Add dai data structure to copier data structure
Currently, copier call dai interface need through ops driver. However, with dedicated work, all dai interface can be called through dai_data, this commit add dai data into copier data.