### PR TITLE
buffer: add and switch to final read and write accessors for struct audio_stream

### DIFF
--- a/src/audio/aria/aria.c
+++ b/src/audio/aria/aria.c
@@ -221,16 +221,16 @@ static void aria_set_stream_params(struct comp_buffer *buffer, struct aria_data 
 	enum sof_ipc_frame valid_fmt, frame_fmt;
 
 	buffer_c = buffer_acquire(buffer);
-	buffer_c->stream.channels = cd->chan_cnt;
-	buffer_c->stream.rate = cd->base.audio_fmt.sampling_frequency;
 	buffer_c->buffer_fmt = cd->base.audio_fmt.interleaving_style;
 	audio_stream_fmt_conversion(cd->base.audio_fmt.depth,
 				    cd->base.audio_fmt.valid_bit_depth,
 				    &frame_fmt, &valid_fmt,
 				    cd->base.audio_fmt.s_type);
 
-	buffer_c->stream.frame_fmt = frame_fmt;
-	buffer_c->stream.valid_sample_fmt = valid_fmt;
+	audio_stream_set_frm_fmt(&buffer_c->stream, frame_fmt);
+	audio_stream_set_valid_fmt(&buffer_c->stream, valid_fmt);
+	audio_stream_set_channels(&buffer_c->stream, cd->chan_cnt);
+	audio_stream_set_rate(&buffer_c->stream, cd->base.audio_fmt.sampling_frequency);
 
 	buffer_release(buffer_c);
 }

--- a/src/audio/buffer.c
+++ b/src/audio/buffer.c
@@ -27,7 +27,7 @@ DECLARE_SOF_RT_UUID("buffer", buffer_uuid, 0x42544c92, 0x8e92, 0x4e41,
 		 0xb6, 0x79, 0x34, 0x51, 0x9f, 0x1c, 0x1d, 0x28);
 DECLARE_TR_CTX(buffer_tr, SOF_UUID(buffer_uuid), LOG_LEVEL_INFO);
 
-struct comp_buffer *buffer_alloc(uint32_t size, uint32_t caps, uint32_t align)
+struct comp_buffer *buffer_alloc(uint32_t size, uint32_t caps, uint32_t flags, uint32_t align)
 {
 	struct comp_buffer *buffer;
 	struct comp_buffer __sparse_cache *buffer_c;
@@ -58,6 +58,9 @@ struct comp_buffer *buffer_alloc(uint32_t size, uint32_t caps, uint32_t align)
 		       size, caps);
 		return NULL;
 	}
+
+	buffer->stream.underrun_permitted = !!(flags & SOF_BUF_UNDERRUN_PERMITTED);
+	buffer->stream.overrun_permitted = !!(flags & SOF_BUF_OVERRUN_PERMITTED);
 
 	list_init(&buffer->source_list);
 	list_init(&buffer->sink_list);

--- a/src/audio/chain_dma.c
+++ b/src/audio/chain_dma.c
@@ -589,7 +589,7 @@ static int chain_task_init(struct comp_dev *dev, uint8_t host_dma_id, uint8_t li
 
 	fifo_size = ALIGN_UP_INTERNAL(fifo_size, addr_align);
 
-	cd->dma_buffer = buffer_alloc(fifo_size, SOF_MEM_CAPS_DMA, addr_align);
+	cd->dma_buffer = buffer_alloc(fifo_size, SOF_MEM_CAPS_DMA, 0, addr_align);
 
 	if (!cd->dma_buffer) {
 		comp_err(dev, "chain_task_init(): failed to alloc dma buffer");

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -573,7 +573,7 @@ static int dai_params(struct comp_dev *dev,
 			return err;
 		}
 	} else {
-		dd->dma_buffer = buffer_alloc(buffer_size, SOF_MEM_CAPS_DMA,
+		dd->dma_buffer = buffer_alloc(buffer_size, SOF_MEM_CAPS_DMA, 0,
 					      addr_align);
 		if (!dd->dma_buffer) {
 			comp_err(dev, "dai_params(): failed to alloc dma buffer");

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -827,7 +827,7 @@ static int dai_params(struct comp_dev *dev, struct sof_ipc_stream_params *params
 			return err;
 		}
 	} else {
-		dd->dma_buffer = buffer_alloc(buffer_size, SOF_MEM_CAPS_DMA,
+		dd->dma_buffer = buffer_alloc(buffer_size, SOF_MEM_CAPS_DMA, 0,
 					      addr_align);
 		if (!dd->dma_buffer) {
 			comp_err(dev, "dai_params(): failed to alloc dma buffer");

--- a/src/audio/google/google_rtc_audio_processing.c
+++ b/src/audio/google/google_rtc_audio_processing.c
@@ -109,16 +109,16 @@ static int google_rtc_audio_processing_params(
 
 		sink = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
 		sink_c = buffer_acquire(sink);
-		sink_c->stream.channels = cd->config.output_fmt.channels_count;
-		sink_c->stream.rate = cd->config.output_fmt.sampling_frequency;
 
 		audio_stream_fmt_conversion(out_fmt->depth,
 					    out_fmt->valid_bit_depth,
 					    &frame_fmt, &valid_fmt,
 					    out_fmt->s_type);
 
-		sink_c->stream.frame_fmt = frame_fmt;
-		sink_c->stream.valid_sample_fmt = valid_fmt;
+		audio_stream_set_frm_fmt(&sink_c->stream, frame_fmt);
+		audio_stream_set_valid_fmt(&sink_c->stream, valid_fmt);
+		audio_stream_set_channels(&sink_c->stream, cd->config.output_fmt.channels_count);
+		audio_stream_set_rate(&sink_c->stream, cd->config.output_fmt.sampling_frequency);
 
 		sink_c->buffer_fmt = out_fmt->interleaving_style;
 		params->frame_fmt = frame_fmt;

--- a/src/audio/host-legacy.c
+++ b/src/audio/host-legacy.c
@@ -787,7 +787,7 @@ int host_zephyr_params(struct host_data *hd, struct comp_dev *dev,
 			goto out;
 		}
 	} else {
-		hd->dma_buffer = buffer_alloc(buffer_size, SOF_MEM_CAPS_DMA,
+		hd->dma_buffer = buffer_alloc(buffer_size, SOF_MEM_CAPS_DMA, 0,
 					      addr_align);
 		if (!hd->dma_buffer) {
 			comp_err(dev, "host_params(): failed to alloc dma buffer");

--- a/src/audio/host-zephyr.c
+++ b/src/audio/host-zephyr.c
@@ -847,7 +847,7 @@ int host_zephyr_params(struct host_data *hd, struct comp_dev *dev,
 			goto out;
 		}
 	} else {
-		hd->dma_buffer = buffer_alloc(buffer_size, SOF_MEM_CAPS_DMA,
+		hd->dma_buffer = buffer_alloc(buffer_size, SOF_MEM_CAPS_DMA, 0,
 					      addr_align);
 		if (!hd->dma_buffer) {
 			comp_err(dev, "host_params(): failed to alloc dma buffer");

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -835,9 +835,9 @@ static int kpb_prepare(struct comp_dev *dev)
 			sink_id = sink_c->id;
 
 			if (sink_id == 0)
-				sink_c->stream.channels = kpb->num_of_sel_mic;
+				audio_stream_set_channels(&sink_c->stream, kpb->num_of_sel_mic);
 			else
-				sink_c->stream.channels = kpb->config.channels;
+				audio_stream_set_channels(&sink_c->stream, kpb->config.channels);
 
 			buffer_release(sink_c);
 		}

--- a/src/audio/mixin_mixout/mixin_mixout.c
+++ b/src/audio/mixin_mixout/mixin_mixout.c
@@ -639,7 +639,8 @@ static int mixin_params(struct processing_module *mod)
 		sink = buffer_from_list(blist, PPL_DIR_DOWNSTREAM);
 		sink_c = buffer_acquire(sink);
 
-		sink_c->stream.channels = mod->priv.cfg.base_cfg.audio_fmt.channels_count;
+		audio_stream_set_channels(&sink_c->stream,
+					  mod->priv.cfg.base_cfg.audio_fmt.channels_count);
 
 		/* Applying channel remapping may produce sink stream with channel count
 		 * different from source channel count.
@@ -652,7 +653,8 @@ static int mixin_params(struct processing_module *mod)
 			return -EINVAL;
 		}
 		if (md->sink_config[sink_id].mixer_mode == IPC4_MIXER_CHANNEL_REMAPPING_MODE)
-			sink_c->stream.channels = md->sink_config[sink_id].output_channel_count;
+			audio_stream_set_channels(&sink_c->stream,
+						  md->sink_config[sink_id].output_channel_count);
 
 		/* comp_verify_params() does not modify valid_sample_fmt (a BUG?),
 		 * let's do this here
@@ -662,8 +664,8 @@ static int mixin_params(struct processing_module *mod)
 					    &frame_fmt, &valid_fmt,
 					    mod->priv.cfg.base_cfg.audio_fmt.s_type);
 
-		sink_c->stream.frame_fmt = frame_fmt;
-		sink_c->stream.valid_sample_fmt = valid_fmt;
+		audio_stream_set_frm_fmt(&sink_c->stream, frame_fmt);
+		audio_stream_set_valid_fmt(&sink_c->stream, valid_fmt);
 
 		buffer_release(sink_c);
 	}
@@ -781,7 +783,7 @@ static int mixout_params(struct processing_module *mod)
 				    &frame_fmt, &valid_fmt,
 				    mod->priv.cfg.base_cfg.audio_fmt.s_type);
 
-	sink_c->stream.valid_sample_fmt = valid_fmt;
+	audio_stream_set_valid_fmt(&sink_c->stream, valid_fmt);
 
 	sink_stream_size = audio_stream_get_size(&sink_c->stream);
 

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -348,7 +348,7 @@ int module_adapter_prepare(struct comp_dev *dev)
 	if (list_is_empty(&mod->sink_buffer_list)) {
 		for (i = 0; i < mod->num_output_buffers; i++) {
 			struct comp_buffer *buffer = buffer_alloc(buff_size, SOF_MEM_CAPS_RAM,
-								  PLATFORM_DCACHE_ALIGN);
+								  0, PLATFORM_DCACHE_ALIGN);
 			if (!buffer) {
 				comp_err(dev, "module_adapter_prepare(): failed to allocate local buffer");
 				ret = -ENOMEM;

--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -295,15 +295,15 @@ static void set_mux_params(struct processing_module *mod)
 			struct ipc4_audio_format out_fmt;
 
 			out_fmt = cd->md.output_format;
-			sink_c->stream.channels = out_fmt.channels_count;
-			sink_c->stream.rate = out_fmt.sampling_frequency;
 			audio_stream_fmt_conversion(out_fmt.depth,
 						    out_fmt.valid_bit_depth,
 						    &frame_fmt, &valid_fmt,
 						    out_fmt.s_type);
 
-			sink_c->stream.frame_fmt = frame_fmt;
-			sink_c->stream.valid_sample_fmt = valid_fmt;
+			audio_stream_set_frm_fmt(&sink_c->stream, frame_fmt);
+			audio_stream_set_valid_fmt(&sink_c->stream, valid_fmt);
+			audio_stream_set_channels(&sink_c->stream, out_fmt.channels_count);
+			audio_stream_set_rate(&sink_c->stream, out_fmt.sampling_frequency);
 
 			sink_c->buffer_fmt = out_fmt.interleaving_style;
 			params->frame_fmt = audio_stream_get_frm_fmt(&sink_c->stream);
@@ -328,10 +328,10 @@ static void set_mux_params(struct processing_module *mod)
 			cd->config.streams[j].pipeline_id = source_c->pipeline_id;
 			valid_bit_depth = cd->md.base_cfg.audio_fmt.valid_bit_depth;
 			if (j == BASE_CFG_QUEUED_ID) {
-				source_c->stream.channels =
-						cd->md.base_cfg.audio_fmt.channels_count;
-				source_c->stream.rate =
-						cd->md.base_cfg.audio_fmt.sampling_frequency;
+				audio_stream_set_channels(&source_c->stream,
+							  cd->md.base_cfg.audio_fmt.channels_count);
+				audio_stream_set_rate(&source_c->stream,
+						      cd->md.base_cfg.audio_fmt.sampling_frequency);
 				audio_stream_fmt_conversion(cd->md.base_cfg.audio_fmt.depth,
 							    valid_bit_depth,
 							    &frame_fmt, &valid_fmt,
@@ -344,9 +344,10 @@ static void set_mux_params(struct processing_module *mod)
 						(cd->md.base_cfg.audio_fmt.ch_map >> i * 4) & 0xf;
 			} else {
 				/* set parameters for reference input channels */
-				source_c->stream.channels =
-						cd->md.reference_format.channels_count;
-				source_c->stream.rate = cd->md.reference_format.sampling_frequency;
+				audio_stream_set_channels(&source_c->stream,
+							  cd->md.reference_format.channels_count);
+				audio_stream_set_rate(&source_c->stream,
+						      cd->md.reference_format.sampling_frequency);
 				audio_stream_fmt_conversion(cd->md.reference_format.depth,
 							    cd->md.reference_format.valid_bit_depth,
 							    &frame_fmt, &valid_fmt,
@@ -359,8 +360,8 @@ static void set_mux_params(struct processing_module *mod)
 						(cd->md.reference_format.ch_map >> i * 4) & 0xf;
 			}
 
-			source_c->stream.frame_fmt = frame_fmt;
-			source_c->stream.valid_sample_fmt = valid_fmt;
+			audio_stream_set_frm_fmt(&source_c->stream, frame_fmt);
+			audio_stream_set_valid_fmt(&source_c->stream, valid_fmt);
 
 			source_c->hw_params_configured = true;
 			buffer_release(source_c);

--- a/src/audio/rtnr/rtnr.c
+++ b/src/audio/rtnr/rtnr.c
@@ -384,10 +384,10 @@ static int rtnr_params(struct comp_dev *dev, struct sof_ipc_stream_params *param
 	cd->sink_stream.channels = audio_stream_get_channels(&sink_c->stream);
 
 	/* set source/sink stream overrun/underrun permitted */
-	cd->sources_stream[0].overrun_permitted = source_c->stream.overrun_permitted;
-	cd->sink_stream.overrun_permitted = sink_c->stream.overrun_permitted;
-	cd->sources_stream[0].underrun_permitted = source_c->stream.underrun_permitted;
-	cd->sink_stream.underrun_permitted = sink_c->stream.underrun_permitted;
+	cd->sources_stream[0].overrun_permitted = audio_stream_get_overrun(&source_c->stream);
+	cd->sink_stream.overrun_permitted = audio_stream_get_overrun(&sink_c->stream);
+	cd->sources_stream[0].underrun_permitted = audio_stream_get_underrun(&source_c->stream);
+	cd->sink_stream.underrun_permitted = audio_stream_get_underrun(&sink_c->stream);
 
 out:
 	buffer_release(sink_c);

--- a/src/audio/rtnr/rtnr.c
+++ b/src/audio/rtnr/rtnr.c
@@ -741,13 +741,13 @@ static void rtnr_copy_from_sof_stream(struct audio_stream_rtnr *dst,
 static void rtnr_copy_to_sof_stream(struct audio_stream __sparse_cache *dst,
 				    struct audio_stream_rtnr *src)
 {
-	dst->size = src->size;
-	dst->avail = src->avail;
-	dst->free = src->free;
-	dst->w_ptr = src->w_ptr;
-	dst->r_ptr = src->r_ptr;
-	dst->addr = src->addr;
-	dst->end_addr = src->end_addr;
+	audio_stream_set_size(dst, src->size);
+	audio_stream_set_avail(dst, src->avail);
+	audio_stream_set_free(dst, src->free);
+	audio_stream_set_wptr(dst, src->w_ptr);
+	audio_stream_set_rptr(dst, src->r_ptr);
+	audio_stream_set_addr(dst, src->addr);
+	audio_stream_set_end_addr(dst, src->end_addr);
 }
 
 /* copy and process stream data from source to sink buffers */

--- a/src/audio/rtnr/rtnr.c
+++ b/src/audio/rtnr/rtnr.c
@@ -349,7 +349,8 @@ static int rtnr_params(struct comp_dev *dev, struct sof_ipc_stream_params *param
 	cd->sink_rate = audio_stream_get_rate(&sink_c->stream);
 	cd->sources_stream[0].rate = audio_stream_get_rate(&source_c->stream);
 	cd->sink_stream.rate = audio_stream_get_rate(&sink_c->stream);
-	channels_valid = source_c->stream.channels == audio_stream_get_channels(&sink_c->stream);
+	channels_valid = audio_stream_get_channels(&source_c->stream) ==
+		audio_stream_get_channels(&sink_c->stream);
 
 	if (!cd->sink_rate) {
 		comp_err(dev, "rtnr_nr_params(), zero sink rate");

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -699,15 +699,15 @@ static void set_selector_params(struct processing_module *mod,
 		struct comp_buffer __sparse_cache *sink = buffer_acquire(sink_buf);
 		enum sof_ipc_frame frame_fmt, valid_fmt;
 
-		sink->stream.channels = params->channels;
-		sink->stream.rate = params->rate;
 		audio_stream_fmt_conversion(out_fmt->depth,
 					    out_fmt->valid_bit_depth,
 					    &frame_fmt, &valid_fmt,
 					    out_fmt->s_type);
 
-		sink->stream.frame_fmt = frame_fmt;
-		sink->stream.valid_sample_fmt = valid_fmt;
+		audio_stream_set_frm_fmt(&sink->stream, frame_fmt);
+		audio_stream_set_valid_fmt(&sink->stream, valid_fmt);
+		audio_stream_set_channels(&sink->stream, params->channels);
+		audio_stream_set_rate(&sink->stream, params->rate);
 
 		sink->buffer_fmt = out_fmt->interleaving_style;
 
@@ -731,15 +731,15 @@ static void set_selector_params(struct processing_module *mod,
 		enum sof_ipc_frame frame_fmt, valid_fmt;
 
 		in_fmt = &mod->priv.cfg.base_cfg.audio_fmt;
-		source->stream.channels = in_fmt->channels_count;
-		source->stream.rate = in_fmt->sampling_frequency;
 		audio_stream_fmt_conversion(in_fmt->depth,
 					    in_fmt->valid_bit_depth,
 					    &frame_fmt, &valid_fmt,
 					    in_fmt->s_type);
 
-		source->stream.frame_fmt = frame_fmt;
-		source->stream.valid_sample_fmt = valid_fmt;
+		audio_stream_set_frm_fmt(&source->stream, frame_fmt);
+		audio_stream_set_valid_fmt(&source->stream, valid_fmt);
+		audio_stream_set_channels(&source->stream, in_fmt->channels_count);
+		audio_stream_set_rate(&source->stream, in_fmt->sampling_frequency);
 
 		source->buffer_fmt = in_fmt->interleaving_style;
 

--- a/src/audio/smart_amp/smart_amp.c
+++ b/src/audio/smart_amp/smart_amp.c
@@ -700,8 +700,8 @@ static int smart_amp_prepare(struct comp_dev *dev)
 	if (sad->feedback_buf) {
 		buf_c = buffer_acquire(sad->feedback_buf);
 
-		buf_c->stream.channels = sad->config.feedback_channels;
-		buf_c->stream.rate = audio_stream_get_rate(&source_c->stream);
+		audio_stream_set_channels(&buf_c->stream, sad->config.feedback_channels);
+		audio_stream_set_rate(&buf_c->stream, audio_stream_get_rate(&source_c->stream));
 		buffer_release(buf_c);
 
 		ret = smart_amp_check_audio_fmt(audio_stream_get_rate(&source_c->stream),

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -541,10 +541,10 @@ static void src_set_sink_params(struct comp_dev *dev, struct comp_buffer __spars
 				    &frame_fmt, &valid_fmt,
 				    cd->ipc_config.base.audio_fmt.s_type);
 
-	sinkb->stream.frame_fmt = frame_fmt;
-	sinkb->stream.valid_sample_fmt = valid_fmt;
+	audio_stream_set_frm_fmt(&sinkb->stream, frame_fmt);
+	audio_stream_set_valid_fmt(&sinkb->stream, valid_fmt);
+	audio_stream_set_channels(&sinkb->stream, cd->ipc_config.base.audio_fmt.channels_count);
 
-	sinkb->stream.channels = cd->ipc_config.base.audio_fmt.channels_count;
 	sinkb->buffer_fmt = cd->ipc_config.base.audio_fmt.interleaving_style;
 }
 

--- a/src/audio/tone.c
+++ b/src/audio/tone.c
@@ -447,8 +447,8 @@ static int tone_params(struct comp_dev *dev,
 	source_c = buffer_acquire(sourceb);
 	sink_c = buffer_acquire(sinkb);
 
-	source_c->stream.frame_fmt = dev->ipc_config.frame_fmt;
-	sink_c->stream.frame_fmt = dev->ipc_config.frame_fmt;
+	audio_stream_set_frm_fmt(&source_c->stream, dev->ipc_config.frame_fmt);
+	audio_stream_set_frm_fmt(&sink_c->stream, dev->ipc_config.frame_fmt);
 
 	/* calculate period size based on config */
 	cd->period_bytes = dev->frames *

--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -134,6 +134,16 @@ static inline uint32_t audio_stream_get_channels(const struct audio_stream __spa
 	return buf->channels;
 }
 
+static inline bool audio_stream_get_underrun(const struct audio_stream __sparse_cache *buf)
+{
+	return buf->underrun_permitted;
+}
+
+static inline bool audio_stream_get_overrun(const struct audio_stream __sparse_cache *buf)
+{
+	return buf->overrun_permitted;
+}
+
 static inline void audio_stream_set_rptr(struct audio_stream __sparse_cache *buf, void *val)
 {
 	buf->r_ptr = val;

--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -169,6 +169,28 @@ static inline void audio_stream_set_free(struct audio_stream __sparse_cache *buf
 	buf->free = val;
 }
 
+static inline void audio_stream_set_frm_fmt(struct audio_stream __sparse_cache *buf,
+					    enum sof_ipc_frame val)
+{
+	buf->frame_fmt = val;
+}
+
+static inline void audio_stream_set_valid_fmt(struct audio_stream __sparse_cache *buf,
+					      enum sof_ipc_frame val)
+{
+	buf->valid_sample_fmt = val;
+}
+
+static inline void audio_stream_set_rate(struct audio_stream __sparse_cache *buf, uint32_t val)
+{
+	buf->rate = val;
+}
+
+static inline void audio_stream_set_channels(struct audio_stream __sparse_cache *buf, uint16_t val)
+{
+	buf->channels = val;
+}
+
 /**
  * Retrieves readable address of a sample at specified index (see versions of
  * this macro specialized for various sample types).

--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -134,6 +134,41 @@ static inline uint32_t audio_stream_get_channels(const struct audio_stream __spa
 	return buf->channels;
 }
 
+static inline void audio_stream_set_rptr(struct audio_stream __sparse_cache *buf, void *val)
+{
+	buf->r_ptr = val;
+}
+
+static inline void audio_stream_set_wptr(struct audio_stream __sparse_cache *buf, void *val)
+{
+	buf->w_ptr = val;
+}
+
+static inline void audio_stream_set_end_addr(struct audio_stream __sparse_cache *buf, void *val)
+{
+	buf->end_addr = val;
+}
+
+static inline void audio_stream_set_addr(struct audio_stream __sparse_cache *buf, void *val)
+{
+	buf->addr = val;
+}
+
+static inline void audio_stream_set_size(struct audio_stream __sparse_cache *buf, uint32_t val)
+{
+	buf->size = val;
+}
+
+static inline void audio_stream_set_avail(struct audio_stream __sparse_cache *buf, uint32_t val)
+{
+	buf->avail = val;
+}
+
+static inline void audio_stream_set_free(struct audio_stream __sparse_cache *buf, uint32_t val)
+{
+	buf->free = val;
+}
+
 /**
  * Retrieves readable address of a sample at specified index (see versions of
  * this macro specialized for various sample types).

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -189,7 +189,7 @@ struct buffer_cb_free {
 	} while (0)
 
 /* pipeline buffer creation and destruction */
-struct comp_buffer *buffer_alloc(uint32_t size, uint32_t caps, uint32_t align);
+struct comp_buffer *buffer_alloc(uint32_t size, uint32_t caps, uint32_t flags, uint32_t align);
 struct comp_buffer *buffer_new(const struct sof_ipc_buffer *desc);
 int buffer_set_size(struct comp_buffer __sparse_cache *buffer, uint32_t size);
 void buffer_free(struct comp_buffer *buffer);

--- a/src/ipc/ipc-helper.c
+++ b/src/ipc/ipc-helper.c
@@ -44,16 +44,11 @@ struct comp_buffer *buffer_new(const struct sof_ipc_buffer *desc)
 		desc->size, desc->comp.pipeline_id, desc->comp.id, desc->flags);
 
 	/* allocate buffer */
-	buffer = buffer_alloc(desc->size, desc->caps, PLATFORM_DCACHE_ALIGN);
+	buffer = buffer_alloc(desc->size, desc->caps, desc->flags, PLATFORM_DCACHE_ALIGN);
 	if (buffer) {
 		buffer->id = desc->comp.id;
 		buffer->pipeline_id = desc->comp.pipeline_id;
 		buffer->core = desc->comp.core;
-
-		buffer->stream.underrun_permitted = desc->flags &
-						    SOF_BUF_UNDERRUN_PERMITTED;
-		buffer->stream.overrun_permitted = desc->flags &
-						   SOF_BUF_OVERRUN_PERMITTED;
 
 		memcpy_s(&buffer->tctx, sizeof(struct tr_ctx),
 			 &buffer_tr, sizeof(struct tr_ctx));

--- a/src/ipc/ipc3/dai.c
+++ b/src/ipc/ipc3/dai.c
@@ -144,7 +144,7 @@ int ipc_dai_data_config(struct comp_dev *dev)
 		dev->ipc_config.frame_fmt = SOF_IPC_FRAME_S32_LE;
 		if (dd->dma_buffer) {
 			buffer_c = buffer_acquire(dd->dma_buffer);
-			buffer_c->stream.frame_fmt = dev->ipc_config.frame_fmt;
+			audio_stream_set_frm_fmt(&buffer_c->stream, dev->ipc_config.frame_fmt);
 			buffer_release(buffer_c);
 		}
 		dd->config.burst_elems = dai_get_fifo_depth(dd->dai, dai->direction);
@@ -169,7 +169,7 @@ int ipc_dai_data_config(struct comp_dev *dev)
 		dev->ipc_config.frame_fmt = SOF_IPC_FRAME_S32_LE;
 		if (dd->dma_buffer) {
 			buffer_c = buffer_acquire(dd->dma_buffer);
-			buffer_c->stream.frame_fmt = dev->ipc_config.frame_fmt;
+			audio_stream_set_frm_fmt(&buffer_c->stream, dev->ipc_config.frame_fmt);
 			buffer_release(buffer_c);
 		}
 		break;

--- a/src/samples/audio/smart_amp_test.c
+++ b/src/samples/audio/smart_amp_test.c
@@ -150,16 +150,16 @@ static void smart_amp_set_params(struct comp_dev *dev,
 
 		sink = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
 		sink_c = buffer_acquire(sink);
-		sink_c->stream.channels = out_fmt.channels_count;
-		sink_c->stream.rate = out_fmt.sampling_frequency;
 
 		audio_stream_fmt_conversion(out_fmt.depth,
 					    out_fmt.valid_bit_depth,
 					    &frame_fmt, &valid_fmt,
 					    out_fmt.s_type);
 
-		sink_c->stream.frame_fmt = frame_fmt;
-		sink_c->stream.valid_sample_fmt = valid_fmt;
+		audio_stream_set_frm_fmt(&sink_c->stream, frame_fmt);
+		audio_stream_set_valid_fmt(&sink_c->stream, valid_fmt);
+		audio_stream_set_channels(&sink_c->stream, out_fmt.channels_count);
+		audio_stream_set_rate(&sink_c->stream, out_fmt.sampling_frequency);
 
 		sink_c->buffer_fmt = out_fmt.interleaving_style;
 		params->frame_fmt = audio_stream_get_frm_fmt(&sink_c->stream);


### PR DESCRIPTION
This makes `struct audio_stream` completely opaque to users, no direct access outside of audio_stream.h and buffer.c should happen to its fields after this.