### PR TITLE
Tools: Topology2: SRC format fixes

### DIFF
--- a/tools/topology/topology2/include/components/src_format.conf
+++ b/tools/topology/topology2/include/components/src_format.conf
@@ -1,369 +1,238 @@
 #src format array
 			num_input_audio_formats 42
-			num_output_audio_formats 42
 
-			# 8khz input
-			Object.Base.audio_format.1 {
-				in_rate                 8000
-				in_bit_depth            16
-				in_valid_bit_depth      16
-				out_bit_depth           32
-				out_valid_bit_depth     24
+			Object.Base.input_audio_format [
+				# 8khz input
+				{
+					in_rate                 8000
+					in_bit_depth            16
+					in_valid_bit_depth      16
 				}
+				{
+					in_rate                 8000
+					in_bit_depth            32
+					in_valid_bit_depth      24
+				}
+				{
+					in_bit_depth            32
+					in_valid_bit_depth      32
+				}
+				# 11.025 khz input
+				{
+					in_rate                 11025
+					in_bit_depth            16
+					in_valid_bit_depth      16
+				}
+				{
+					in_rate                 11025
+					in_bit_depth            32
+					in_valid_bit_depth      24
+				}
+				{
+					in_rate                 11025
+					in_bit_depth            32
+					in_valid_bit_depth      32
+				}
+				# 12khz input
+				{
+					in_rate                 12000
+					in_bit_depth            16
+					in_valid_bit_depth      16
+				}
+				{
+					in_rate                 12000
+					in_bit_depth            32
+					in_valid_bit_depth      24
+				}
+				{
+					in_rate                 12000
+					in_bit_depth            32
+					in_valid_bit_depth      32
+				}
+				# 16khz input
+				{
+					in_rate                 16000
+					in_bit_depth            16
+					in_valid_bit_depth      16
+				}
+				{
+					in_rate                 16000
+					in_bit_depth            32
+					in_valid_bit_depth      24
+				}
+				{
+					in_rate                 16000
+					in_bit_depth            32
+					in_valid_bit_depth      32
+				}
+				# 22.05khz input
+				{
+					in_rate                 22050
+					in_bit_depth            16
+					in_valid_bit_depth      16
+				}
+				{
+					in_rate                 22050
+					in_bit_depth            32
+					in_valid_bit_depth      24
+				}
+				{
+					in_rate                 22050
+					in_bit_depth            32
+					in_valid_bit_depth      32
+				}
+				# 24khz input
+				{
+					in_rate                 24000
+					in_bit_depth            16
+					in_valid_bit_depth      16
+				}
+				{
+					in_rate                 24000
+					in_bit_depth            32
+					in_valid_bit_depth      24
+				}
+				{
+					in_rate                 24000
+					in_bit_depth            32
+					in_valid_bit_depth      32
+				}
+				# 32khz input
+				{
+					in_rate                 32000
+					in_bit_depth            16
+					in_valid_bit_depth      16
+				}
+				{
+					in_rate                 32000
+					in_bit_depth            32
+					in_valid_bit_depth      24
+				}
+				{
+					in_rate                 32000
+					in_bit_depth            32
+					in_valid_bit_depth      32
+				}
+				# 44.1khz input
+				{
+					in_rate                 44100
+					in_bit_depth            16
+					in_valid_bit_depth      16
+				}
+				{
+					in_rate                 44100
+					in_bit_depth            32
+					in_valid_bit_depth      24
+				}
+				{
+					in_rate                 44100
+					in_bit_depth            32
+					in_valid_bit_depth      32
+				}
+				# 48khz input
+				{
+					in_rate                 48000
+					in_bit_depth            16
+					in_valid_bit_depth      16
+				}
+				{
+					in_rate                 48000
+					in_bit_depth            32
+					in_valid_bit_depth      24
+				}
+				{
+					in_rate                 48000
+					in_bit_depth            32
+					in_valid_bit_depth      32
+				}
+				# 64khz input
+				{
+					in_rate                 64000
+					in_bit_depth            16
+					in_valid_bit_depth      16
+				}
+				{
+					in_rate                 64000
+					in_bit_depth            32
+					in_valid_bit_depth      24
+				}
+				{
+					in_rate                 64000
+					in_bit_depth            32
+					in_valid_bit_depth      32
+				}
+				# 88.2khz input
+				{
+					in_rate                 88200
+					in_bit_depth            16
+					in_valid_bit_depth      16
+				}
+				{
+					in_rate                 88200
+					in_bit_depth            32
+					in_valid_bit_depth      24
+				}
+				{
+					in_rate                 88200
+					in_bit_depth            32
+					in_valid_bit_depth      32
+				}
+				# 96khz input
+				{
+					in_rate                 96000
+					in_bit_depth            16
+					in_valid_bit_depth      16
+				}
+				{
+					in_rate                 96000
+					in_bit_depth            32
+					in_valid_bit_depth      24
+				}
+				{
+					in_rate                 96000
+					in_bit_depth            32
+					in_valid_bit_depth      32
+				}
+				# 176.4khz input
+				{
+					in_rate                 176400
+					in_bit_depth            16
+					in_valid_bit_depth      16
+				}
+				{
+					in_rate                 176400
+					in_bit_depth            32
+					in_valid_bit_depth      24
+				}
+				{
+					in_rate                 176400
+					in_bit_depth            32
+					in_valid_bit_depth      32
+				}
+				# 192khz input
+				{
+					in_rate                 192000
+					in_bit_depth            16
+					in_valid_bit_depth      16
+				}
+				{
+					in_rate                 192000
+					in_bit_depth            32
+					in_valid_bit_depth      24
+				}
+				{
+					in_rate                 192000
+					in_bit_depth            32
+					in_valid_bit_depth      32
+				}
+			]
 
-			Object.Base.audio_format.2 {
-				in_rate                 8000
-				in_bit_depth            32
-				in_valid_bit_depth      24
-				out_bit_depth           32
-				out_valid_bit_depth     24
-				}
+			num_output_audio_formats 1
 
-			Object.Base.audio_format.3{
-				in_rate                 8000
-				in_bit_depth            32
-				in_valid_bit_depth      32
-				out_bit_depth           32
-				out_valid_bit_depth     32
+			Object.Base.output_audio_format [
+				{
+					out_rate                 48000
+					out_bit_depth            32
+					out_valid_bit_depth      32
 				}
-
-			# 11.025 khz input
-			Object.Base.audio_format.4 {
-				in_rate                 11025
-				in_bit_depth            16
-				in_valid_bit_depth      16
-				out_bit_depth           32
-				out_valid_bit_depth     24
-				# for 11.025k, 22.05k, 44.1k, 88.2k and 176.4k, extra 4 sample size is needed
-				obs "$[($out_channels * (($[($out_rate + 999)] / 1000) + 4)) * ($out_bit_depth / 8)]"
-				}
-
-			Object.Base.audio_format.5 {
-				in_rate                 11025
-				in_bit_depth            32
-				in_valid_bit_depth      24
-				out_bit_depth           32
-				out_valid_bit_depth     24
-				obs "$[($out_channels * (($[($out_rate + 999)] / 1000) + 4)) * ($out_bit_depth / 8)]"
-				}
-
-			Object.Base.audio_format.6{
-				in_rate                 11025
-				in_bit_depth            32
-				in_valid_bit_depth      32
-				out_bit_depth           32
-				out_valid_bit_depth     32
-				obs "$[($out_channels * (($[($out_rate + 999)] / 1000) + 4)) * ($out_bit_depth / 8)]"
-				}
-
-			# 12khz input
-			Object.Base.audio_format.7 {
-				in_rate                 12000
-				in_bit_depth            16
-				in_valid_bit_depth      16
-				out_bit_depth           32
-				out_valid_bit_depth     24
-				}
-
-			Object.Base.audio_format.8 {
-				in_rate                 12000
-				in_bit_depth            32
-				in_valid_bit_depth      24
-				out_bit_depth           32
-				out_valid_bit_depth     24
-				}
-
-			Object.Base.audio_format.9{
-				in_rate                 12000
-				in_bit_depth            32
-				in_valid_bit_depth      32
-				out_bit_depth           32
-				out_valid_bit_depth     32
-				}
-
-			# 16khz input
-			Object.Base.audio_format.10 {
-				in_rate                 16000
-				in_bit_depth            16
-				in_valid_bit_depth      16
-				out_bit_depth           32
-				out_valid_bit_depth     24
-				}
-
-			Object.Base.audio_format.11 {
-				in_rate                 16000
-				in_bit_depth            32
-				in_valid_bit_depth      24
-				out_bit_depth           32
-				out_valid_bit_depth     24
-				}
-
-			Object.Base.audio_format.12{
-				in_rate                 16000
-				in_bit_depth            32
-				in_valid_bit_depth      32
-				out_bit_depth           32
-				out_valid_bit_depth     32
-				}
-
-			# 22.05khz input
-			Object.Base.audio_format.13 {
-				in_rate                 22050
-				in_bit_depth            16
-				in_valid_bit_depth      16
-				out_bit_depth           32
-				out_valid_bit_depth     24
-				obs "$[($out_channels * (($[($out_rate + 999)] / 1000) + 4)) * ($out_bit_depth / 8)]"
-				}
-
-			Object.Base.audio_format.14 {
-				in_rate                 22050
-				in_bit_depth            32
-				in_valid_bit_depth      24
-				out_bit_depth           32
-				out_valid_bit_depth     24
-				obs "$[($out_channels * (($[($out_rate + 999)] / 1000) + 4)) * ($out_bit_depth / 8)]"
-				}
-
-			Object.Base.audio_format.15{
-				in_rate                 22050
-				in_bit_depth            32
-				in_valid_bit_depth      32
-				out_bit_depth           32
-				out_valid_bit_depth     32
-				obs "$[($out_channels * (($[($out_rate + 999)] / 1000) + 4)) * ($out_bit_depth / 8)]"
-				}
-
-
-			# 24khz input
-			Object.Base.audio_format.16 {
-				in_rate                 24000
-				in_bit_depth            16
-				in_valid_bit_depth      16
-				out_bit_depth           32
-				out_valid_bit_depth     24
-				}
-
-			Object.Base.audio_format.17 {
-				in_rate                 24000
-				in_bit_depth            32
-				in_valid_bit_depth      24
-				out_bit_depth           32
-				out_valid_bit_depth     24
-				}
-
-			Object.Base.audio_format.18{
-				in_rate                 24000
-				in_bit_depth            32
-				in_valid_bit_depth      32
-				out_bit_depth           32
-				out_valid_bit_depth     32
-				}
-
-			# 32khz input
-			Object.Base.audio_format.19 {
-				in_rate                 32000
-				in_bit_depth            16
-				in_valid_bit_depth      16
-				out_bit_depth           32
-				out_valid_bit_depth     24
-				}
-
-			Object.Base.audio_format.20 {
-				in_rate                 32000
-				in_bit_depth            32
-				in_valid_bit_depth      24
-				out_bit_depth           32
-				out_valid_bit_depth     24
-				}
-
-			Object.Base.audio_format.21 {
-				in_rate                 32000
-				in_bit_depth            32
-				in_valid_bit_depth      32
-				out_bit_depth           32
-				out_valid_bit_depth     32
-				}
-
-			# 44.1khz input
-			Object.Base.audio_format.22 {
-				in_rate                 44100
-				in_bit_depth            16
-				in_valid_bit_depth      16
-				out_bit_depth           32
-				out_valid_bit_depth     24
-				obs "$[($out_channels * (($[($out_rate + 999)] / 1000) + 4)) * ($out_bit_depth / 8)]"
-				}
-
-			Object.Base.audio_format.23 {
-				in_rate                 44100
-				in_bit_depth            32
-				in_valid_bit_depth      24
-				out_bit_depth           32
-				out_valid_bit_depth     24
-				obs "$[($out_channels * (($[($out_rate + 999)] / 1000) + 4)) * ($out_bit_depth / 8)]"
-				}
-
-			Object.Base.audio_format.24{
-				in_rate                 44100
-				in_bit_depth            32
-				in_valid_bit_depth      32
-				out_bit_depth           32
-				out_valid_bit_depth     32
-				obs "$[($out_channels * (($[($out_rate + 999)] / 1000) + 4)) * ($out_bit_depth / 8)]"
-				}
-
-			# 48khz input
-			Object.Base.audio_format.25 {
-				in_rate                 48000
-				in_bit_depth            16
-				in_valid_bit_depth      16
-				out_bit_depth           32
-				out_valid_bit_depth     24
-				}
-
-			Object.Base.audio_format.26 {
-				in_rate                 48000
-				in_bit_depth            32
-				in_valid_bit_depth      24
-				out_bit_depth           32
-				out_valid_bit_depth     24
-				}
-
-			Object.Base.audio_format.27 {
-				in_rate                 48000
-				in_bit_depth            32
-				in_valid_bit_depth      32
-				out_bit_depth           32
-				out_valid_bit_depth     32
-				}
-
-			# 64khz input
-			Object.Base.audio_format.28 {
-				in_rate                 64000
-				in_bit_depth            16
-				in_valid_bit_depth      16
-				out_bit_depth           32
-				out_valid_bit_depth     24
-				}
-
-			Object.Base.audio_format.29 {
-				in_rate                 64000
-				in_bit_depth            32
-				in_valid_bit_depth      24
-				out_bit_depth           32
-				out_valid_bit_depth     24
-				}
-
-			Object.Base.audio_format.30 {
-				in_rate                 64000
-				in_bit_depth            32
-				in_valid_bit_depth      32
-				out_bit_depth           32
-				out_valid_bit_depth     32
-				}
-			# 88.2khz input
-			Object.Base.audio_format.31 {
-				in_rate                 88200
-				in_bit_depth            16
-				in_valid_bit_depth      16
-				out_bit_depth           32
-				out_valid_bit_depth     24
-				obs "$[($out_channels * (($[($out_rate + 999)] / 1000) + 4)) * ($out_bit_depth / 8)]"
-				}
-
-			Object.Base.audio_format.32 {
-				in_rate                 88200
-				in_bit_depth            32
-				in_valid_bit_depth      24
-				out_bit_depth           32
-				out_valid_bit_depth     24
-				obs "$[($out_channels * (($[($out_rate + 999)] / 1000) + 4)) * ($out_bit_depth / 8)]"
-				}
-
-			Object.Base.audio_format.33 {
-				in_rate                 88200
-				in_bit_depth            32
-				in_valid_bit_depth      32
-				out_bit_depth           32
-				out_valid_bit_depth     32
-				obs "$[($out_channels * (($[($out_rate + 999)] / 1000) + 4)) * ($out_bit_depth / 8)]"
-				}
-
-			# 96khz input
-			Object.Base.audio_format.34 {
-				in_rate                 96000
-				in_bit_depth            16
-				in_valid_bit_depth      16
-				out_bit_depth           32
-				out_valid_bit_depth     24
-				}
-
-			Object.Base.audio_format.35 {
-				in_rate                 96000
-				in_bit_depth            32
-				in_valid_bit_depth      24
-				out_bit_depth           32
-				out_valid_bit_depth     24
-				}
-
-			Object.Base.audio_format.36 {
-				in_rate                 96000
-				in_bit_depth            32
-				in_valid_bit_depth      32
-				out_bit_depth           32
-				out_valid_bit_depth     32
-				}
-
-			# 176.4khz input
-			Object.Base.audio_format.37 {
-				in_rate                 176400
-				in_bit_depth            16
-				in_valid_bit_depth      16
-				out_bit_depth           32
-				out_valid_bit_depth     24
-				obs "$[($out_channels * (($[($out_rate + 999)] / 1000) + 4)) * ($out_bit_depth / 8)]"
-				}
-
-			Object.Base.audio_format.38 {
-				in_rate                 176400
-				in_bit_depth            32
-				in_valid_bit_depth      24
-				out_bit_depth           32
-				out_valid_bit_depth     24
-				obs "$[($out_channels * (($[($out_rate + 999)] / 1000) + 4)) * ($out_bit_depth / 8)]"
-				}
-
-			Object.Base.audio_format.39 {
-				in_rate                 176400
-				in_bit_depth            32
-				in_valid_bit_depth      32
-				out_bit_depth           32
-				out_valid_bit_depth     32
-				obs "$[($out_channels * (($[($out_rate + 999)] / 1000) + 4)) * ($out_bit_depth / 8)]"
-				}
-
-			# 192khz input
-			Object.Base.audio_format.40 {
-				in_rate                 192000
-				in_bit_depth            16
-				in_valid_bit_depth      16
-				out_bit_depth           32
-				out_valid_bit_depth     24
-				}
-
-			Object.Base.audio_format.41 {
-				in_rate                 192000
-				in_bit_depth            32
-				in_valid_bit_depth      24
-				out_bit_depth           32
-				out_valid_bit_depth     24
-				}
-
-			Object.Base.audio_format.42 {
-				in_rate                 192000
-				in_bit_depth            32
-				in_valid_bit_depth      32
-				out_bit_depth           32
-				out_valid_bit_depth     32
-				}
+			]

--- a/tools/topology/topology2/include/pipelines/cavs/host-copier-gain-src-mixin-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/host-copier-gain-src-mixin-playback.conf
@@ -16,7 +16,8 @@
 # Where N is the unique pipeline ID within the same alsaconf node.
 #
 
-<include/common/audio_format.conf>
+<include/common/input_audio_format.conf>
+<include/common/output_audio_format.conf>
 <include/components/copier.conf>
 <include/components/mixin.conf>
 <include/components/pipeline.conf>

--- a/tools/topology/topology2/include/pipelines/cavs/src-gain-mixin-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/src-gain-mixin-playback.conf
@@ -15,6 +15,8 @@
 #
 # Where N is the unique pipeline ID within the same alsaconf node.
 #
+<include/common/input_audio_format.conf>
+<include/common/output_audio_format.conf>
 <include/common/audio_format.conf>
 <include/components/copier.conf>
 <include/components/gain.conf>


### PR DESCRIPTION
This patch avoids with development topology sof-hda-src-generic.tplg the playback start failure and error seen in trace "buffer: buffer_alloc(): new size = 0 is invalid".

The kernel selects in case of multiple output formats defined the format that matches the input. It then caused the obs to become zero. When the SRC is used in the mixin-based playback pipeline, its output format is limited to 32-bits format only. So replace the multiple output formats with a single 48K, 2ch 32-bit format.