### PR TITLE
DAI copier optimization

### DIFF
--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -1344,9 +1344,18 @@ static int do_endpoint_copy(struct comp_dev *dev)
 
 		return ret;
 	} else {
-		if (dev->ipc_config.type == SOF_COMP_HOST && !cd->ipc_gtw)
-			return host_zephyr_copy(cd->hd, dev, copier_dma_cb);
-
+		switch (dev->ipc_config.type) {
+		case SOF_COMP_HOST:
+			if (!cd->ipc_gtw)
+				return host_zephyr_copy(cd->hd, dev, copier_dma_cb);
+			break;
+		case SOF_COMP_DAI:
+			if (cd->endpoint_num == 1)
+				return dai_zephyr_copy(cd->dd[0], cd->endpoint[0]);
+			break;
+		default:
+			break;
+		}
 		return cd->endpoint[0]->drv->ops.copy(cd->endpoint[0]);
 	}
 }

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -369,7 +369,8 @@ static int init_dai(struct comp_dev *parent_dev,
 	list_init(&dev->bsource_list);
 	list_init(&dev->bsink_list);
 
-	ret = comp_dai_config(dev, dai, copier);
+	cd->dd[index] = comp_get_drvdata(dev);
+	ret = comp_dai_config(cd->dd[index], dev, dai, copier);
 	if (ret < 0)
 		goto free_dev;
 
@@ -394,7 +395,6 @@ static int init_dai(struct comp_dev *parent_dev,
 	}
 
 	cd->endpoint[cd->endpoint_num++] = dev;
-	cd->dd[index] = comp_get_drvdata(dev);
 
 	return 0;
 free_dev:

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -2021,6 +2021,18 @@ static int copier_dai_ts_stop_op(struct comp_dev *dev)
 	return dai_zephyr_ts_stop(dd, dev);
 }
 
+static int copier_get_hw_params(struct comp_dev *dev, struct sof_ipc_stream_params *params,
+				int dir)
+{
+	struct copier_data *cd = comp_get_drvdata(dev);
+	struct dai_data *dd = cd->dd[0];
+
+	if (dev->ipc_config.type != SOF_COMP_DAI)
+		return -EINVAL;
+
+	return dai_zephyr_get_hw_params(dd, dev, params, dir);
+}
+
 static const struct comp_driver comp_copier = {
 	.uid	= SOF_RT_UUID(copier_comp_uuid),
 	.tctx	= &copier_comp_tr,
@@ -2041,6 +2053,7 @@ static const struct comp_driver comp_copier = {
 		.dai_ts_start			= copier_dai_ts_start_op,
 		.dai_ts_stop			= copier_dai_ts_stop_op,
 		.dai_ts_get			= copier_dai_ts_get_op,
+		.dai_get_hw_params		= copier_get_hw_params,
 	},
 };
 

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -38,6 +38,10 @@
 #include <sof/audio/host_copier.h>
 #include <sof/audio/dai_copier.h>
 
+#if CONFIG_ZEPHYR_NATIVE_DRIVERS
+#include <zephyr/drivers/dai.h>
+#endif
+
 static const struct comp_driver comp_copier;
 
 LOG_MODULE_REGISTER(copier, CONFIG_SOF_LOG_LEVEL);
@@ -1979,6 +1983,44 @@ static int copier_position(struct comp_dev *dev, struct sof_ipc_stream_posn *pos
 	return ret;
 }
 
+static int copier_dai_ts_config_op(struct comp_dev *dev)
+{
+	struct copier_data *cd = comp_get_drvdata(dev);
+	struct dai_data *dd = cd->dd[0];
+
+	return dai_zephyr_ts_config_op(dd, dev);
+}
+
+static int copier_dai_ts_start_op(struct comp_dev *dev)
+{
+	struct copier_data *cd = comp_get_drvdata(dev);
+	struct dai_data *dd = cd->dd[0];
+
+	comp_dbg(dev, "dai_ts_start()");
+
+	return dai_zephyr_ts_start(dd, dev);
+}
+
+static int copier_dai_ts_get_op(struct comp_dev *dev, struct timestamp_data *tsd)
+{
+	struct copier_data *cd = comp_get_drvdata(dev);
+	struct dai_data *dd = cd->dd[0];
+
+	comp_dbg(dev, "dai_ts_get()");
+
+	return dai_zephyr_ts_get(dd, dev, tsd);
+}
+
+static int copier_dai_ts_stop_op(struct comp_dev *dev)
+{
+	struct copier_data *cd = comp_get_drvdata(dev);
+	struct dai_data *dd = cd->dd[0];
+
+	comp_dbg(dev, "dai_ts_stop()");
+
+	return dai_zephyr_ts_stop(dd, dev);
+}
+
 static const struct comp_driver comp_copier = {
 	.uid	= SOF_RT_UUID(copier_comp_uuid),
 	.tctx	= &copier_comp_tr,
@@ -1995,6 +2037,10 @@ static const struct comp_driver comp_copier = {
 		.get_total_data_processed	= copier_get_processed_data,
 		.get_attribute			= copier_get_attribute,
 		.position			= copier_position,
+		.dai_ts_config			= copier_dai_ts_config_op,
+		.dai_ts_start			= copier_dai_ts_start_op,
+		.dai_ts_stop			= copier_dai_ts_stop_op,
+		.dai_ts_get			= copier_dai_ts_get_op,
 	},
 };
 

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -1925,17 +1925,27 @@ static int copier_get_attribute(struct comp_dev *dev, uint32_t type, void *value
 static int copier_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn)
 {
 	struct copier_data *cd = comp_get_drvdata(dev);
-	int ret;
+	int ret = 0;
 
 	/* Exit if no endpoints */
 	if (!cd->endpoint_num)
 		return -EINVAL;
 
-	if (dev->ipc_config.type == SOF_COMP_HOST && !cd->ipc_gtw) {
-		posn->host_posn = cd->hd->local_pos;
-		ret = posn->host_posn;
-	} else {
-		ret = comp_position(cd->endpoint[IPC4_COPIER_GATEWAY_PIN], posn);
+	switch (dev->ipc_config.type) {
+	case SOF_COMP_HOST:
+		if (!cd->ipc_gtw) {
+			posn->host_posn = cd->hd->local_pos;
+			ret = posn->host_posn;
+		} else {
+			/* handle gtw case */
+			ret = comp_position(cd->endpoint[IPC4_COPIER_GATEWAY_PIN], posn);
+		}
+		break;
+	case SOF_COMP_DAI:
+		ret = dai_zephyr_position(cd->dd[0], cd->endpoint[IPC4_COPIER_GATEWAY_PIN], posn);
+		break;
+	default:
+		break;
 	}
 	/* Return position from the default gateway pin */
 	return ret;

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -1564,8 +1564,7 @@ static int copier_params(struct comp_dev *dev, struct sof_ipc_stream_params *par
 	struct comp_buffer *sink, *source;
 	struct comp_buffer __sparse_cache *sink_c, *source_c;
 	struct list_item *sink_list;
-	int ret = 0;
-	int i;
+	int i, ret = 0;
 
 	comp_dbg(dev, "copier_params()");
 
@@ -1631,21 +1630,41 @@ static int copier_params(struct comp_dev *dev, struct sof_ipc_stream_params *par
 			ret = cd->endpoint[i]->drv->ops.params(cd->endpoint[i],
 							       &demuxed_params);
 		} else {
-			if (dev->ipc_config.type == SOF_COMP_HOST && !cd->ipc_gtw) {
-				component_set_nearest_period_frames(dev, params->rate);
-				if (params->direction == SOF_IPC_STREAM_CAPTURE) {
-					params->buffer.size = cd->config.base.obs;
-					params->sample_container_bytes = cd->out_fmt->depth / 8;
-					params->sample_valid_bytes =
-						cd->out_fmt->valid_bit_depth / 8;
+			switch (dev->ipc_config.type) {
+			case SOF_COMP_HOST:
+				if (!cd->ipc_gtw) {
+					component_set_nearest_period_frames(dev, params->rate);
+					if (params->direction == SOF_IPC_STREAM_CAPTURE) {
+						params->buffer.size = cd->config.base.obs;
+						params->sample_container_bytes =
+							cd->out_fmt->depth / 8;
+						params->sample_valid_bytes =
+							cd->out_fmt->valid_bit_depth / 8;
+					}
+
+					ret = host_zephyr_params(cd->hd, dev, params,
+								 copier_notifier_cb);
+
+					cd->hd->process = cd->converter[IPC4_COPIER_GATEWAY_PIN];
+				} else {
+					/* handle gtw case */
+					ret = cd->endpoint[i]->drv->ops.params(cd->endpoint[i],
+									       params);
 				}
-
-				ret = host_zephyr_params(cd->hd, dev, params, copier_notifier_cb);
-
-				cd->hd->process = cd->converter[IPC4_COPIER_GATEWAY_PIN];
-			} else {
-				ret = cd->endpoint[i]->drv->ops.params(cd->endpoint[i],
-								       params);
+				break;
+			case SOF_COMP_DAI:
+				if (cd->endpoint_num == 1) {
+					ret = dai_zephyr_params(cd->dd[0], cd->endpoint[0],
+								params);
+					if (ret < 0)
+						return ret;
+				} else {
+					ret = cd->endpoint[i]->drv->ops.params(cd->endpoint[i],
+									       params);
+				}
+				break;
+			default:
+				break;
 			}
 		}
 		if (ret < 0)

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -300,39 +300,77 @@ static enum sof_ipc_stream_direction
 	}
 }
 
-static struct comp_dev *init_dai_single(struct comp_dev *parent_dev,
-					const struct comp_driver *drv,
-					struct comp_ipc_config *config,
-					struct ipc_config_dai *dai)
+static int init_dai_single(struct comp_dev *parent_dev,
+			   const struct comp_driver *drv,
+			   struct comp_ipc_config *config,
+			   const struct ipc4_copier_module_cfg *copier,
+			   struct pipeline *pipeline,
+			   struct ipc_config_dai *dai,
+			   enum ipc4_gateway_type type)
 {
-	struct comp_dev *dev;
+	struct copier_data *cd;
 	struct dai_data *dd;
 	int ret;
 
-	dev = comp_alloc(drv, sizeof(*dev));
-	if (!dev)
-		return NULL;
+	cd = comp_get_drvdata(parent_dev);
 
-	dev->ipc_config = *config;
+	if (cd->direction == SOF_IPC_STREAM_PLAYBACK) {
+		enum sof_ipc_frame out_frame_fmt, out_valid_fmt;
+
+		audio_stream_fmt_conversion(copier->out_fmt.depth,
+					    copier->out_fmt.valid_bit_depth,
+					    &out_frame_fmt,
+					    &out_valid_fmt,
+					    copier->out_fmt.s_type);
+		config->frame_fmt = out_frame_fmt;
+		pipeline->sink_comp = parent_dev;
+	} else {
+		enum sof_ipc_frame in_frame_fmt, in_valid_fmt;
+
+		audio_stream_fmt_conversion(copier->base.audio_fmt.depth,
+					    copier->base.audio_fmt.valid_bit_depth,
+					    &in_frame_fmt, &in_valid_fmt,
+					    copier->base.audio_fmt.s_type);
+		config->frame_fmt = in_frame_fmt;
+		pipeline->source_comp = parent_dev;
+	}
+
+	parent_dev->ipc_config.frame_fmt = config->frame_fmt;
 
 	dd = rzalloc(SOF_MEM_ZONE_RUNTIME_SHARED, 0, SOF_MEM_CAPS_RAM, sizeof(*dd));
 	if (!dd)
-		goto free_dev;
-
-	comp_set_drvdata(dev, dd);
+		return -ENOMEM;
 
 	ret = dai_zephyr_new(dd, parent_dev, dai);
 	if (ret < 0)
-		goto free_dd;
+		goto e_dd;
 
-	dev->state = COMP_STATE_READY;
+	pipeline->sched_id = config->id;
 
-	return dev;
-free_dd:
+	ret = comp_dai_config(dd, parent_dev, dai, copier);
+	if (ret < 0)
+		goto e_zephyr;
+
+	cd->converter[IPC4_COPIER_GATEWAY_PIN] =
+			get_converter_func(&copier->base.audio_fmt, &copier->out_fmt, type,
+					   IPC4_DIRECTION(dai->direction));
+	if (!cd->converter[IPC4_COPIER_GATEWAY_PIN]) {
+		comp_err(parent_dev, "failed to get converter type %d, dir %d",
+			 type, dai->direction);
+		ret = -EINVAL;
+		goto e_zephyr;
+	}
+
+	cd->endpoint_num++;
+	cd->dd[0] = dd;
+
+	return 0;
+
+e_zephyr:
+	dai_zephyr_free(dd);
+e_dd:
 	rfree(dd);
-free_dev:
-	rfree(dev);
-	return NULL;
+	return ret;
 }
 
 static int init_dai(struct comp_dev *parent_dev,
@@ -348,16 +386,15 @@ static int init_dai(struct comp_dev *parent_dev,
 	struct copier_data *cd;
 	int ret;
 
+	if (dai_count == 1)
+		return init_dai_single(parent_dev, drv, config, copier, pipeline, dai, type);
+
 	cd = comp_get_drvdata(parent_dev);
 	ret = create_endpoint_buffer(parent_dev, cd, config, copier, type, false, index);
 	if (ret < 0)
 		return ret;
 
-	if (dai_count == 1)
-		dev = init_dai_single(parent_dev, drv, config, dai);
-	else
-		dev = drv->ops.create(drv, config, dai);
-
+	dev = drv->ops.create(drv, config, dai);
 	if (!dev) {
 		ret = -ENOMEM;
 		goto e_buf;
@@ -777,8 +814,6 @@ static void copier_free(struct comp_dev *dev)
 		if (cd->endpoint_num == 1) {
 			dai_zephyr_free(cd->dd[0]);
 			rfree(cd->dd[0]);
-			rfree(cd->endpoint[0]);
-			buffer_free(cd->endpoint_buffer[0]);
 		} else {
 			for (i = 0; i < cd->endpoint_num; i++) {
 				cd->endpoint[i]->drv->ops.free(cd->endpoint[i]);
@@ -928,6 +963,12 @@ static int copier_prepare(struct comp_dev *dev)
 		return 0;
 	}
 
+	if (dev->ipc_config.type == SOF_COMP_DAI && cd->endpoint_num == 1) {
+		ret = dai_zephyr_config_prepare(cd->dd[0], dev);
+		if (ret < 0)
+			return ret;
+	}
+
 	ret = comp_set_state(dev, COMP_TRIGGER_PREPARE);
 	if (ret < 0)
 		return ret;
@@ -952,18 +993,7 @@ static int copier_prepare(struct comp_dev *dev)
 		break;
 	case SOF_COMP_DAI:
 		if (cd->endpoint_num == 1) {
-			ret = dai_zephyr_config_prepare(cd->dd[0], cd->endpoint[0]);
-			if (ret < 0)
-				return ret;
-
-			ret = comp_set_state(cd->endpoint[0], COMP_TRIGGER_PREPARE);
-			if (ret < 0)
-				return ret;
-
-			if (ret == COMP_STATUS_STATE_ALREADY_SET)
-				return PPL_STATUS_PATH_STOP;
-
-			ret = dai_zephyr_prepare(cd->dd[0], cd->endpoint[0]);
+			ret = dai_zephyr_prepare(cd->dd[0], dev);
 			if (ret < 0)
 				return ret;
 		} else {
@@ -1042,8 +1072,7 @@ static int copier_reset(struct comp_dev *dev)
 		break;
 	case SOF_COMP_DAI:
 		if (cd->endpoint_num == 1) {
-			dai_zephyr_reset(cd->dd[0], cd->endpoint[0]);
-			comp_set_state(cd->endpoint[0], COMP_TRIGGER_RESET);
+			dai_zephyr_reset(cd->dd[0], dev);
 		} else {
 			for (i = 0; i < cd->endpoint_num; i++) {
 				ret = cd->endpoint[i]->drv->ops.reset(cd->endpoint[i]);
@@ -1072,7 +1101,6 @@ static int copier_comp_trigger(struct comp_dev *dev, int cmd)
 	struct copier_data *cd = comp_get_drvdata(dev);
 	struct sof_ipc_stream_posn posn;
 	struct comp_dev *dai_copier;
-	struct copier_data *dai_cd;
 	struct comp_buffer *buffer;
 	struct comp_buffer __sparse_cache *buffer_c;
 	uint32_t latency;
@@ -1080,12 +1108,18 @@ static int copier_comp_trigger(struct comp_dev *dev, int cmd)
 
 	comp_dbg(dev, "copier_comp_trigger()");
 
-	ret = comp_set_state(dev, cmd);
-	if (ret < 0)
-		return ret;
+	/*
+	 * do not modify the comp state in case of single endpoint DAI, it will be done in
+	 * dai_zephyr_trigger()
+	 */
+	if (!(dev->ipc_config.type == SOF_COMP_DAI && cd->endpoint_num == 1)) {
+		ret = comp_set_state(dev, cmd);
+		if (ret < 0)
+			return ret;
 
-	if (ret == COMP_STATUS_STATE_ALREADY_SET)
-		return PPL_STATUS_PATH_STOP;
+		if (ret == COMP_STATUS_STATE_ALREADY_SET)
+			return PPL_STATUS_PATH_STOP;
+	}
 
 	switch (dev->ipc_config.type) {
 	case SOF_COMP_HOST:
@@ -1104,7 +1138,7 @@ static int copier_comp_trigger(struct comp_dev *dev, int cmd)
 		break;
 	case SOF_COMP_DAI:
 		if (cd->endpoint_num == 1) {
-			ret = dai_zephyr_trigger(cd->dd[0], cd->endpoint[0], cmd);
+			ret = dai_zephyr_trigger(cd->dd[0], dev, cmd);
 			if (ret < 0)
 				return ret;
 		} else {
@@ -1134,10 +1168,8 @@ static int copier_comp_trigger(struct comp_dev *dev, int cmd)
 		return 0;
 	}
 
-	dai_cd = comp_get_drvdata(dai_copier);
 	/* dai is in another pipeline and it is not prepared or active */
-	if (dai_copier->state <= COMP_STATE_READY ||
-	    dai_cd->endpoint[IPC4_COPIER_GATEWAY_PIN]->state <= COMP_STATE_READY) {
+	if (dai_copier->state <= COMP_STATE_READY) {
 		struct ipc4_pipeline_registers pipe_reg;
 
 		comp_warn(dev, "dai is not ready");
@@ -1355,7 +1387,7 @@ static int do_endpoint_copy(struct comp_dev *dev)
 			break;
 		case SOF_COMP_DAI:
 			if (cd->endpoint_num == 1)
-				return dai_zephyr_copy(cd->dd[0], cd->endpoint[0]);
+				return dai_zephyr_copy(cd->dd[0], dev);
 			break;
 		default:
 			break;
@@ -1421,8 +1453,18 @@ static int copier_copy(struct comp_dev *dev)
 
 	comp_dbg(dev, "copier_copy()");
 
-	if (dev->ipc_config.type == SOF_COMP_HOST && !cd->ipc_gtw)
-		return do_endpoint_copy(dev);
+	switch (dev->ipc_config.type) {
+	case SOF_COMP_HOST:
+		if (!cd->ipc_gtw)
+			return do_endpoint_copy(dev);
+		break;
+	case SOF_COMP_DAI:
+		if (cd->endpoint_num == 1)
+			return do_endpoint_copy(dev);
+		break;
+	default:
+		break;
+	}
 
 	processed_data.source_bytes = 0;
 
@@ -1574,9 +1616,12 @@ static void copier_notifier_cb(void *arg, enum notify_id type, void *data)
 static int copier_params(struct comp_dev *dev, struct sof_ipc_stream_params *params)
 {
 	struct copier_data *cd = comp_get_drvdata(dev);
+	const struct ipc4_audio_format *in_fmt = &cd->config.base.audio_fmt;
+	const struct ipc4_audio_format *out_fmt = &cd->config.out_fmt;
 	struct comp_buffer *sink, *source;
 	struct comp_buffer __sparse_cache *sink_c, *source_c;
 	struct list_item *sink_list;
+	enum sof_ipc_frame in_bits, in_valid_bits, out_bits, out_valid_bits;
 	int i, ret = 0;
 
 	comp_dbg(dev, "copier_params()");
@@ -1625,8 +1670,27 @@ static int copier_params(struct comp_dev *dev, struct sof_ipc_stream_params *par
 		buffer_release(source_c);
 	}
 
+	/* update params for the DMA buffer */
+	switch (dev->ipc_config.type) {
+	case SOF_COMP_HOST:
+		if (cd->ipc_gtw || params->direction == SOF_IPC_STREAM_PLAYBACK)
+			break;
+		COMPILER_FALLTHROUGH;
+	case SOF_COMP_DAI:
+		if (dev->ipc_config.type == SOF_COMP_DAI &&
+		    (cd->endpoint_num > 1 || params->direction == SOF_IPC_STREAM_CAPTURE))
+			break;
+		params->buffer.size = cd->config.base.obs;
+		params->sample_container_bytes = cd->out_fmt->depth / 8;
+		params->sample_valid_bytes = cd->out_fmt->valid_bit_depth / 8;
+		break;
+	default:
+		break;
+	}
+
 	for (i = 0; i < cd->endpoint_num; i++) {
-		update_internal_comp(dev, cd->endpoint[i]);
+		if (cd->endpoint[i])
+			update_internal_comp(dev, cd->endpoint[i]);
 
 		/* For ALH multi-gateway case, params->channels is a total multiplexed
 		 * number of channels. Demultiplexed number of channels for each individual
@@ -1647,14 +1711,6 @@ static int copier_params(struct comp_dev *dev, struct sof_ipc_stream_params *par
 			case SOF_COMP_HOST:
 				if (!cd->ipc_gtw) {
 					component_set_nearest_period_frames(dev, params->rate);
-					if (params->direction == SOF_IPC_STREAM_CAPTURE) {
-						params->buffer.size = cd->config.base.obs;
-						params->sample_container_bytes =
-							cd->out_fmt->depth / 8;
-						params->sample_valid_bytes =
-							cd->out_fmt->valid_bit_depth / 8;
-					}
-
 					ret = host_zephyr_params(cd->hd, dev, params,
 								 copier_notifier_cb);
 
@@ -1667,10 +1723,27 @@ static int copier_params(struct comp_dev *dev, struct sof_ipc_stream_params *par
 				break;
 			case SOF_COMP_DAI:
 				if (cd->endpoint_num == 1) {
-					ret = dai_zephyr_params(cd->dd[0], cd->endpoint[0],
-								params);
-					if (ret < 0)
-						return ret;
+					ret = dai_zephyr_params(cd->dd[0], dev, params);
+
+					/*
+					 * dai_zephyr_params assigns the conversion function
+					 * based on the input/output formats but does not take
+					 * the valid bits into account. So change the conversion
+					 * function if the valid bits are different from the
+					 * container size.
+					 */
+					audio_stream_fmt_conversion(in_fmt->depth,
+								    in_fmt->valid_bit_depth,
+								    &in_bits, &in_valid_bits,
+								    in_fmt->s_type);
+					audio_stream_fmt_conversion(out_fmt->depth,
+								    out_fmt->valid_bit_depth,
+								    &out_bits, &out_valid_bits,
+								    out_fmt->s_type);
+
+					if (in_bits != in_valid_bits || out_bits != out_valid_bits)
+						cd->dd[0]->process =
+							cd->converter[IPC4_COPIER_GATEWAY_PIN];
 				} else {
 					ret = cd->endpoint[i]->drv->ops.params(cd->endpoint[i],
 									       params);
@@ -1812,11 +1885,17 @@ static int copier_get_large_config(struct comp_dev *dev, uint32_t param_id,
 	struct sof_ipc_stream_posn posn;
 	struct ipc4_llp_reading_extended llp_ext;
 	struct ipc4_llp_reading llp;
+	struct comp_dev *temp_dev;
+
+	if (dev->ipc_config.type == SOF_COMP_DAI && cd->endpoint_num == 1)
+		temp_dev = dev;
+	else
+		temp_dev = cd->endpoint[IPC4_COPIER_GATEWAY_PIN];
 
 	switch (param_id) {
 	case IPC4_COPIER_MODULE_CFG_PARAM_LLP_READING:
 		if (!cd->endpoint_num ||
-		    comp_get_endpoint_type(cd->endpoint[IPC4_COPIER_GATEWAY_PIN]) !=
+		    comp_get_endpoint_type(temp_dev) !=
 		    COMP_ENDPOINT_DAI) {
 			comp_err(dev, "Invalid component type");
 			return -EINVAL;
@@ -1830,13 +1909,13 @@ static int copier_get_large_config(struct comp_dev *dev, uint32_t param_id,
 		*data_offset = sizeof(struct ipc4_llp_reading);
 		memset(&llp, 0, sizeof(llp));
 
-		if (cd->endpoint[IPC4_COPIER_GATEWAY_PIN]->state != COMP_STATE_ACTIVE) {
+		if (temp_dev->state != COMP_STATE_ACTIVE) {
 			memcpy_s(data, sizeof(llp), &llp, sizeof(llp));
 			return 0;
 		}
 
 		/* get llp from dai */
-		comp_position(cd->endpoint[IPC4_COPIER_GATEWAY_PIN], &posn);
+		comp_position(temp_dev, &posn);
 
 		convert_u64_to_u32s(posn.comp_posn, &llp.llp_l, &llp.llp_u);
 		convert_u64_to_u32s(posn.wallclock, &llp.wclk_l, &llp.wclk_u);
@@ -1846,7 +1925,7 @@ static int copier_get_large_config(struct comp_dev *dev, uint32_t param_id,
 
 	case IPC4_COPIER_MODULE_CFG_PARAM_LLP_READING_EXTENDED:
 		if (!cd->endpoint_num ||
-		    comp_get_endpoint_type(cd->endpoint[IPC4_COPIER_GATEWAY_PIN]) !=
+		    comp_get_endpoint_type(temp_dev) !=
 		    COMP_ENDPOINT_DAI) {
 			comp_err(dev, "Invalid component type");
 			return -EINVAL;
@@ -1860,13 +1939,13 @@ static int copier_get_large_config(struct comp_dev *dev, uint32_t param_id,
 		*data_offset = sizeof(struct ipc4_llp_reading_extended);
 		memset(&llp_ext, 0, sizeof(llp_ext));
 
-		if (cd->endpoint[IPC4_COPIER_GATEWAY_PIN]->state != COMP_STATE_ACTIVE) {
+		if (temp_dev->state != COMP_STATE_ACTIVE) {
 			memcpy_s(data, sizeof(llp_ext), &llp_ext, sizeof(llp_ext));
 			return 0;
 		}
 
 		/* get llp from dai */
-		comp_position(cd->endpoint[IPC4_COPIER_GATEWAY_PIN], &posn);
+		comp_position(temp_dev, &posn);
 
 		convert_u64_to_u32s(posn.comp_posn, &llp_ext.llp_reading.llp_l,
 				    &llp_ext.llp_reading.llp_u);
@@ -1974,7 +2053,11 @@ static int copier_position(struct comp_dev *dev, struct sof_ipc_stream_posn *pos
 		}
 		break;
 	case SOF_COMP_DAI:
-		ret = dai_zephyr_position(cd->dd[0], cd->endpoint[IPC4_COPIER_GATEWAY_PIN], posn);
+		if (cd->endpoint_num == 1)
+			ret = dai_zephyr_position(cd->dd[0], dev, posn);
+		else
+			ret = dai_zephyr_position(cd->dd[0], cd->endpoint[IPC4_COPIER_GATEWAY_PIN],
+						  posn);
 		break;
 	default:
 		break;

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -480,8 +480,8 @@ out:
 	return err;
 }
 
-static int dai_zephyr_params(struct dai_data *dd, struct comp_dev *dev,
-			     struct sof_ipc_stream_params *params)
+int dai_zephyr_params(struct dai_data *dd, struct comp_dev *dev,
+		      struct sof_ipc_stream_params *params)
 {
 	struct sof_ipc_stream_params hw_params = *params;
 	struct comp_buffer __sparse_cache *buffer_c;

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -235,7 +235,7 @@ static void dai_free(struct comp_dev *dev)
 
 	dma_put(dd->dma);
 
-	dai_release_llp_slot(dev);
+	dai_release_llp_slot(dd);
 
 	dai_put(dd->dai);
 

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -480,11 +480,10 @@ out:
 	return err;
 }
 
-static int dai_params(struct comp_dev *dev,
-		      struct sof_ipc_stream_params *params)
+static int dai_zephyr_params(struct dai_data *dd, struct comp_dev *dev,
+			     struct sof_ipc_stream_params *params)
 {
 	struct sof_ipc_stream_params hw_params = *params;
-	struct dai_data *dd = comp_get_drvdata(dev);
 	struct comp_buffer __sparse_cache *buffer_c;
 	uint32_t frame_size;
 	uint32_t period_count;
@@ -616,6 +615,15 @@ static int dai_params(struct comp_dev *dev,
 	return dev->direction == SOF_IPC_STREAM_PLAYBACK ?
 		dai_playback_params(dev, period_bytes, period_count) :
 		dai_capture_params(dev, period_bytes, period_count);
+}
+
+static int dai_params(struct comp_dev *dev, struct sof_ipc_stream_params *params)
+{
+	struct dai_data *dd = comp_get_drvdata(dev);
+
+	comp_dbg(dev, "dai_params()");
+
+	return dai_zephyr_params(dd, dev, params);
 }
 
 int dai_zephyr_config_prepare(struct dai_data *dd, struct comp_dev *dev)

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -618,13 +618,13 @@ static int dai_params(struct comp_dev *dev,
 		dai_capture_params(dev, period_bytes, period_count);
 }
 
-static int dai_config_prepare(struct dai_data *dd, struct comp_dev *dev)
+int dai_zephyr_config_prepare(struct dai_data *dd, struct comp_dev *dev)
 {
 	int channel = 0;
 
 	/* cannot configure DAI while active */
 	if (dev->state == COMP_STATE_ACTIVE) {
-		comp_info(dev, "dai_config_prepare(): Component is in active state.");
+		comp_info(dev, "dai_zephyr_config_prepare(): Component is in active state.");
 		return 0;
 	}
 
@@ -634,13 +634,13 @@ static int dai_config_prepare(struct dai_data *dd, struct comp_dev *dev)
 	}
 
 	if (dd->chan) {
-		comp_info(dev, "dai_config_prepare(): dma channel index %d already configured",
+		comp_info(dev, "dai_zephyr_config_prepare(): dma channel index %d already configured",
 			  dd->chan->index);
 		return 0;
 	}
 
 	channel = dai_config_dma_channel(dd, dev, dd->dai_spec_config);
-	comp_info(dev, "dai_config_prepare(), channel = %d", channel);
+	comp_info(dev, "dai_zephyr_config_prepare(), channel = %d", channel);
 
 	/* do nothing for asking for channel free, for compatibility. */
 	if (channel == DMA_CHAN_INVALID) {
@@ -651,14 +651,14 @@ static int dai_config_prepare(struct dai_data *dd, struct comp_dev *dev)
 	/* allocate DMA channel */
 	dd->chan = dma_channel_get_legacy(dd->dma, channel);
 	if (!dd->chan) {
-		comp_err(dev, "dai_config_prepare(): dma_channel_get() failed");
+		comp_err(dev, "dai_zephyr_config_prepare(): dma_channel_get() failed");
 		dd->chan = NULL;
 		return -EIO;
 	}
 
 	dd->chan->dev_data = dd;
 
-	comp_info(dev, "dai_config_prepare(): new configured dma channel index %d",
+	comp_info(dev, "dai_zephyr_config_prepare(): new configured dma channel index %d",
 		  dd->chan->index);
 
 	/* setup callback */
@@ -668,7 +668,7 @@ static int dai_config_prepare(struct dai_data *dd, struct comp_dev *dev)
 	return 0;
 }
 
-static int dai_zephyr_prepare(struct dai_data *dd, struct comp_dev *dev)
+int dai_zephyr_prepare(struct dai_data *dd, struct comp_dev *dev)
 {
 	struct comp_buffer __sparse_cache *buffer_c;
 	int ret;
@@ -713,7 +713,7 @@ static int dai_prepare(struct comp_dev *dev)
 
 	comp_info(dev, "dai_prepare()");
 
-	ret = dai_config_prepare(dd, dev);
+	ret = dai_zephyr_config_prepare(dd, dev);
 	if (ret < 0)
 		return ret;
 

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -640,7 +640,7 @@ static int dai_config_prepare(struct comp_dev *dev)
 		return 0;
 	}
 
-	channel = dai_config_dma_channel(dev, dd->dai_spec_config);
+	channel = dai_config_dma_channel(dd, dev, dd->dai_spec_config);
 	comp_info(dev, "dai_config_prepare(), channel = %d", channel);
 
 	/* do nothing for asking for channel free, for compatibility. */

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -230,17 +230,12 @@ error:
 	return NULL;
 }
 
-static void dai_free(struct comp_dev *dev)
+static void dai_zephyr_free(struct dai_data *dd)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
-
-	if (dd->group) {
-		notifier_unregister(dev, dd->group, NOTIFIER_ID_DAI_TRIGGER);
+	if (dd->group)
 		dai_group_put(dd->group);
-	}
 
 	if (dd->chan) {
-		notifier_unregister(dev, dd->chan, NOTIFIER_ID_DMA_COPY);
 		dd->chan->dev_data = NULL;
 		dma_channel_put_legacy(dd->chan);
 	}
@@ -253,6 +248,19 @@ static void dai_free(struct comp_dev *dev)
 
 	if (dd->dai_spec_config)
 		rfree(dd->dai_spec_config);
+}
+
+static void dai_free(struct comp_dev *dev)
+{
+	struct dai_data *dd = comp_get_drvdata(dev);
+
+	if (dd->group)
+		notifier_unregister(dev, dd->group, NOTIFIER_ID_DAI_TRIGGER);
+
+	if (dd->chan)
+		notifier_unregister(dev, dd->chan, NOTIFIER_ID_DMA_COPY);
+
+	dai_zephyr_free(dd);
 
 	rfree(dd);
 	rfree(dev);

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -954,9 +954,8 @@ static void dai_report_xrun(struct comp_dev *dev, uint32_t bytes)
 }
 
 /* copy and process stream data from source to sink buffers */
-static int dai_copy(struct comp_dev *dev)
+static int dai_zephyr_copy(struct dai_data *dd, struct comp_dev *dev)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
 	uint32_t dma_fmt;
 	uint32_t sampling;
 	struct comp_buffer __sparse_cache *buf_c;
@@ -967,8 +966,6 @@ static int dai_copy(struct comp_dev *dev)
 	uint32_t sink_samples;
 	uint32_t samples;
 	int ret;
-
-	comp_dbg(dev, "dai_copy()");
 
 	/* get data sizes from DMA */
 	ret = dma_get_data_size_legacy(dd->chan, &avail_bytes, &free_bytes);
@@ -1004,7 +1001,7 @@ static int dai_copy(struct comp_dev *dev)
 
 	copy_bytes = samples * sampling;
 
-	comp_dbg(dev, "dai_copy(), dir: %d copy_bytes= 0x%x, frames= %d",
+	comp_dbg(dev, "dai_zephyr_copy(), dir: %d copy_bytes= 0x%x, frames= %d",
 		 dev->direction, copy_bytes,
 		 samples / audio_stream_get_channels(&buf_c->stream));
 
@@ -1013,16 +1010,16 @@ static int dai_copy(struct comp_dev *dev)
 	/* Check possibility of glitch occurrence */
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK &&
 	    copy_bytes + avail_bytes < dd->period_bytes)
-		comp_warn(dev, "dai_copy(): Copy_bytes %d + avail bytes %d < period bytes %d, possible glitch",
+		comp_warn(dev, "dai_zephyr_copy(): Copy_bytes %d + avail bytes %d < period bytes %d, possible glitch",
 			  copy_bytes, avail_bytes, dd->period_bytes);
 	else if (dev->direction == SOF_IPC_STREAM_CAPTURE &&
 		 copy_bytes + free_bytes < dd->period_bytes)
-		comp_warn(dev, "dai_copy(): Copy_bytes %d + free bytes %d < period bytes %d, possible glitch",
+		comp_warn(dev, "dai_zephyr_copy(): Copy_bytes %d + free bytes %d < period bytes %d, possible glitch",
 			  copy_bytes, free_bytes, dd->period_bytes);
 
 	/* return if nothing to copy */
 	if (!copy_bytes) {
-		comp_warn(dev, "dai_copy(): nothing to copy");
+		comp_warn(dev, "dai_zephyr_copy(): nothing to copy");
 		return 0;
 	}
 
@@ -1038,6 +1035,15 @@ static int dai_copy(struct comp_dev *dev)
 	dai_dma_position_update(dd, dev);
 
 	return ret;
+}
+
+static int dai_copy(struct comp_dev *dev)
+{
+	struct dai_data *dd = comp_get_drvdata(dev);
+
+	comp_dbg(dev, "dai_copy()");
+
+	return dai_zephyr_copy(dd, dev);
 }
 
 /**

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -60,10 +60,8 @@ static void dai_atomic_trigger(void *arg, enum notify_id type, void *data)
 }
 
 /* Assign DAI to a group */
-int dai_assign_group(struct comp_dev *dev, uint32_t group_id)
+int dai_assign_group(struct dai_data *dd, struct comp_dev *dev, uint32_t group_id)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
-
 	if (dd->group) {
 		if (dd->group->group_id != group_id) {
 			comp_err(dev, "dai_assign_group(), DAI already in group %d, requested %d",

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -1035,7 +1035,7 @@ static int dai_copy(struct comp_dev *dev)
 		return ret;
 	}
 
-	dai_dma_position_update(dev);
+	dai_dma_position_update(dd, dev);
 
 	return ret;
 }

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -739,7 +739,7 @@ static int dai_reset(struct comp_dev *dev)
 	 * It will be done when the host sends the DAI_CONFIG IPC during hw_free.
 	 */
 	if (!dd->delayed_dma_stop)
-		dai_dma_release(dev);
+		dai_dma_release(dd, dev);
 
 	dma_sg_free(&config->elem_array);
 

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -727,7 +727,7 @@ static int dai_prepare(struct comp_dev *dev)
 	return dai_zephyr_prepare(dd, dev);
 }
 
-static void dai_zephyr_reset(struct dai_data *dd, struct comp_dev *dev)
+void dai_zephyr_reset(struct dai_data *dd, struct comp_dev *dev)
 {
 	struct dma_sg_config *config = &dd->config;
 

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -866,7 +866,7 @@ static int dai_comp_trigger_internal(struct dai_data *dd, struct comp_dev *dev, 
 	return ret;
 }
 
-static int dai_zephyr_trigger(struct dai_data *dd, struct comp_dev *dev, int cmd)
+int dai_zephyr_trigger(struct dai_data *dd, struct comp_dev *dev, int cmd)
 {
 	struct dai_group *group = dd->group;
 	uint32_t irq_flags;

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -322,7 +322,7 @@ static int dai_verify_params(struct comp_dev *dev,
 {
 	struct sof_ipc_stream_params hw_params;
 
-	dai_comp_get_hw_params(dev, &hw_params, params->direction);
+	comp_dai_get_hw_params(dev, &hw_params, params->direction);
 
 	/* checks whether pcm parameters match hardware DAI parameter set
 	 * during dai_set_config(). If hardware parameter is equal to 0, it

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -264,12 +264,10 @@ static void dai_free(struct comp_dev *dev)
 	rfree(dev);
 }
 
-static int dai_comp_get_hw_params(struct comp_dev *dev,
-				  struct sof_ipc_stream_params *params,
-				  int dir)
+int dai_zephyr_get_hw_params(struct dai_data *dd, struct comp_dev *dev,
+			     struct sof_ipc_stream_params *params, int dir)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
-	int ret = 0;
+	int ret;
 
 	comp_dbg(dev, "dai_hw_params()");
 
@@ -290,6 +288,14 @@ static int dai_comp_get_hw_params(struct comp_dev *dev,
 	params->frame_fmt = dev->ipc_config.frame_fmt;
 
 	return 0;
+}
+
+static int dai_comp_get_hw_params(struct comp_dev *dev,
+				  struct sof_ipc_stream_params *params, int dir)
+{
+	struct dai_data *dd = comp_get_drvdata(dev);
+
+	return dai_zephyr_get_hw_params(dd, dev, params, dir);
 }
 
 static int dai_comp_hw_params(struct comp_dev *dev,

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -497,7 +497,7 @@ static int dai_params(struct comp_dev *dev,
 	comp_dbg(dev, "dai_params()");
 
 	/* configure dai_data first */
-	err = ipc_dai_data_config(dev);
+	err = ipc_dai_data_config(dd, dev);
 	if (err < 0)
 		return err;
 

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -47,7 +47,7 @@ DECLARE_TR_CTX(dai_comp_tr, SOF_UUID(dai_comp_uuid), LOG_LEVEL_INFO);
 
 #if CONFIG_COMP_DAI_GROUP
 
-static int dai_comp_trigger_internal(struct comp_dev *dev, int cmd);
+static int dai_comp_trigger_internal(struct dai_data *dd, struct comp_dev *dev, int cmd);
 
 static void dai_atomic_trigger(void *arg, enum notify_id type, void *data)
 {
@@ -56,7 +56,7 @@ static void dai_atomic_trigger(void *arg, enum notify_id type, void *data)
 	struct dai_group *group = dd->group;
 
 	/* Atomic context set by the last DAI to receive trigger command */
-	group->trigger_ret = dai_comp_trigger_internal(dev, group->trigger_cmd);
+	group->trigger_ret = dai_comp_trigger_internal(dd, dev, group->trigger_cmd);
 }
 
 /* Assign DAI to a group */
@@ -763,18 +763,9 @@ static int dai_reset(struct comp_dev *dev)
 	return 0;
 }
 
-static void dai_update_start_position(struct comp_dev *dev)
-{
-	struct dai_data *dd = comp_get_drvdata(dev);
-
-	/* update starting wallclock */
-	platform_dai_wallclock(dev, &dd->wallclock);
-}
-
 /* used to pass standard and bespoke command (with data) to component */
-static int dai_comp_trigger_internal(struct comp_dev *dev, int cmd)
+static int dai_comp_trigger_internal(struct dai_data *dd, struct comp_dev *dev, int cmd)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
 	int ret;
 
 	comp_dbg(dev, "dai_comp_trigger_internal(), command = %u", cmd);
@@ -801,7 +792,7 @@ static int dai_comp_trigger_internal(struct comp_dev *dev, int cmd)
 			dd->xrun = 0;
 		}
 
-		dai_update_start_position(dev);
+		platform_dai_wallclock(dev, &dd->wallclock);
 		break;
 	case COMP_TRIGGER_RELEASE:
 		/* before release, we clear the buffer data to 0s,
@@ -832,7 +823,7 @@ static int dai_comp_trigger_internal(struct comp_dev *dev, int cmd)
 			dd->xrun = 0;
 		}
 
-		dai_update_start_position(dev);
+		platform_dai_wallclock(dev, &dd->wallclock);
 		break;
 	case COMP_TRIGGER_XRUN:
 		comp_info(dev, "dai_comp_trigger_internal(), XRUN");
@@ -875,17 +866,16 @@ static int dai_comp_trigger_internal(struct comp_dev *dev, int cmd)
 	return ret;
 }
 
-static int dai_comp_trigger(struct comp_dev *dev, int cmd)
+static int dai_zephyr_trigger(struct dai_data *dd, struct comp_dev *dev, int cmd)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
 	struct dai_group *group = dd->group;
 	uint32_t irq_flags;
 	int ret = 0;
 
 	/* DAI not in a group, use normal trigger */
 	if (!group) {
-		comp_dbg(dev, "dai_comp_trigger(), non-atomic trigger");
-		return dai_comp_trigger_internal(dev, cmd);
+		comp_dbg(dev, "dai_zephyr_trigger(), non-atomic trigger");
+		return dai_comp_trigger_internal(dd, dev, cmd);
 	}
 
 	/* DAI is grouped, so only trigger when the entire group is ready */
@@ -894,13 +884,13 @@ static int dai_comp_trigger(struct comp_dev *dev, int cmd)
 		/* First DAI to receive the trigger command,
 		 * prepare for atomic trigger
 		 */
-		comp_dbg(dev, "dai_comp_trigger(), begin atomic trigger for group %d",
+		comp_dbg(dev, "dai_zephyr_trigger(), begin atomic trigger for group %d",
 			 group->group_id);
 		group->trigger_cmd = cmd;
 		group->trigger_counter = group->num_dais - 1;
 	} else if (group->trigger_cmd != cmd) {
 		/* Already processing a different trigger command */
-		comp_err(dev, "dai_comp_trigger(), already processing atomic trigger");
+		comp_err(dev, "dai_zephyr_trigger(), already processing atomic trigger");
 		ret = -EAGAIN;
 	} else {
 		/* Count down the number of remaining DAIs required
@@ -908,7 +898,7 @@ static int dai_comp_trigger(struct comp_dev *dev, int cmd)
 		 * takes place
 		 */
 		group->trigger_counter--;
-		comp_dbg(dev, "dai_comp_trigger(), trigger counter %d, group %d",
+		comp_dbg(dev, "dai_zephyr_trigger(), trigger counter %d, group %d",
 			 group->trigger_counter, group->group_id);
 
 		if (!group->trigger_counter) {
@@ -929,6 +919,13 @@ static int dai_comp_trigger(struct comp_dev *dev, int cmd)
 	}
 
 	return ret;
+}
+
+static int dai_comp_trigger(struct comp_dev *dev, int cmd)
+{
+	struct dai_data *dd = comp_get_drvdata(dev);
+
+	return dai_zephyr_trigger(dd, dev, cmd);
 }
 
 /* report xrun occurrence */

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -7,6 +7,7 @@
 
 #include <sof/audio/buffer.h>
 #include <sof/audio/component_ext.h>
+#include <sof/audio/dai_copier.h>
 #include <sof/audio/format.h>
 #include <sof/audio/pipeline.h>
 #include <sof/common.h>
@@ -160,8 +161,7 @@ static void dai_dma_cb(void *arg, enum notify_id type, void *data)
 	buffer_release(dma_buf);
 }
 
-static int dai_zephyr_new(struct dai_data *dd, struct comp_dev *dev,
-			  const struct ipc_config_dai *dai)
+int dai_zephyr_new(struct dai_data *dd, struct comp_dev *dev, const struct ipc_config_dai *dai)
 {
 	uint32_t dir, caps, dma_dev;
 
@@ -230,7 +230,7 @@ error:
 	return NULL;
 }
 
-static void dai_zephyr_free(struct dai_data *dd)
+void dai_zephyr_free(struct dai_data *dd)
 {
 	if (dd->group)
 		dai_group_put(dd->group);

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -727,12 +727,9 @@ static int dai_prepare(struct comp_dev *dev)
 	return dai_zephyr_prepare(dd, dev);
 }
 
-static int dai_reset(struct comp_dev *dev)
+static void dai_zephyr_reset(struct dai_data *dd, struct comp_dev *dev)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
 	struct dma_sg_config *config = &dd->config;
-
-	comp_info(dev, "dai_reset()");
 
 	/*
 	 * DMA channel release should be skipped now for DAI's that support the two-step stop option.
@@ -751,6 +748,16 @@ static int dai_reset(struct comp_dev *dev)
 	dd->wallclock = 0;
 	dd->total_data_processed = 0;
 	dd->xrun = 0;
+}
+
+static int dai_reset(struct comp_dev *dev)
+{
+	struct dai_data *dd = comp_get_drvdata(dev);
+
+	comp_info(dev, "dai_reset()");
+
+	dai_zephyr_reset(dd, dev);
+
 	comp_set_state(dev, COMP_TRIGGER_RESET);
 
 	return 0;

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -954,7 +954,7 @@ static void dai_report_xrun(struct comp_dev *dev, uint32_t bytes)
 }
 
 /* copy and process stream data from source to sink buffers */
-static int dai_zephyr_copy(struct dai_data *dd, struct comp_dev *dev)
+int dai_zephyr_copy(struct dai_data *dd, struct comp_dev *dev)
 {
 	uint32_t dma_fmt;
 	uint32_t sampling;

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -1341,7 +1341,7 @@ static int dai_copy(struct comp_dev *dev)
 		return ret;
 	}
 
-	dai_dma_position_update(dev);
+	dai_dma_position_update(dd, dev);
 
 	return ret;
 }

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -874,13 +874,13 @@ static int dai_params(struct comp_dev *dev, struct sof_ipc_stream_params *params
 		dai_capture_params(dev, period_bytes, period_count);
 }
 
-static int dai_config_prepare(struct dai_data *dd, struct comp_dev *dev)
+int dai_zephyr_config_prepare(struct dai_data *dd, struct comp_dev *dev)
 {
 	int channel;
 
 	/* cannot configure DAI while active */
 	if (dev->state == COMP_STATE_ACTIVE) {
-		comp_info(dev, "dai_config_prepare(): Component is in active state.");
+		comp_info(dev, "dai_zephyr_config_prepare(): Component is in active state.");
 		return 0;
 	}
 
@@ -890,13 +890,13 @@ static int dai_config_prepare(struct dai_data *dd, struct comp_dev *dev)
 	}
 
 	if (dd->chan) {
-		comp_info(dev, "dai_config_prepare(): dma channel index %d already configured",
+		comp_info(dev, "dai_zephyr_config_prepare(): dma channel index %d already configured",
 			  dd->chan->index);
 		return 0;
 	}
 
 	channel = dai_config_dma_channel(dd, dev, dd->dai_spec_config);
-	comp_dbg(dev, "dai_config_prepare(), channel = %d", channel);
+	comp_dbg(dev, "dai_zephyr_config_prepare(), channel = %d", channel);
 
 	/* do nothing for asking for channel free, for compatibility. */
 	if (channel == DMA_CHAN_INVALID) {
@@ -907,7 +907,7 @@ static int dai_config_prepare(struct dai_data *dd, struct comp_dev *dev)
 	/* get DMA channel */
 	channel = dma_request_channel(dd->dma->z_dev, &channel);
 	if (channel < 0) {
-		comp_err(dev, "dai_config_prepare(): dma_request_channel() failed");
+		comp_err(dev, "dai_zephyr_config_prepare(): dma_request_channel() failed");
 		dd->chan = NULL;
 		return -EIO;
 	}
@@ -915,13 +915,13 @@ static int dai_config_prepare(struct dai_data *dd, struct comp_dev *dev)
 	dd->chan = &dd->dma->chan[channel];
 	dd->chan->dev_data = dd;
 
-	comp_dbg(dev, "dai_config_prepare(): new configured dma channel index %d",
+	comp_dbg(dev, "dai_zephyr_config_prepare(): new configured dma channel index %d",
 		 dd->chan->index);
 
 	return 0;
 }
 
-static int dai_zephyr_prepare(struct dai_data *dd, struct comp_dev *dev)
+int dai_zephyr_prepare(struct dai_data *dd, struct comp_dev *dev)
 {
 	struct comp_buffer __sparse_cache *buffer_c;
 	int ret;
@@ -966,7 +966,7 @@ static int dai_prepare(struct comp_dev *dev)
 
 	comp_dbg(dev, "dai_prepare()");
 
-	ret = dai_config_prepare(dd, dev);
+	ret = dai_zephyr_config_prepare(dd, dev);
 	if (ret < 0)
 		return ret;
 

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -7,6 +7,7 @@
 
 #include <sof/audio/buffer.h>
 #include <sof/audio/component_ext.h>
+#include <sof/audio/dai_copier.h>
 #include <sof/audio/format.h>
 #include <sof/audio/pipeline.h>
 #include <sof/common.h>
@@ -284,8 +285,8 @@ static enum dma_cb_status dai_dma_cb(struct comp_dev *dev, uint32_t bytes)
 	return dma_status;
 }
 
-static int dai_zephyr_new(struct dai_data *dd, struct comp_dev *dev,
-			  const struct ipc_config_dai *dai_cfg)
+int dai_zephyr_new(struct dai_data *dd, struct comp_dev *dev,
+		   const struct ipc_config_dai *dai_cfg)
 {
 	uint32_t dir;
 
@@ -355,7 +356,7 @@ e_data:
 	return NULL;
 }
 
-static void dai_zephyr_free(struct dai_data *dd)
+void dai_zephyr_free(struct dai_data *dd)
 {
 	if (dd->group)
 		dai_group_put(dd->group);

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -980,12 +980,9 @@ static int dai_prepare(struct comp_dev *dev)
 	return dai_zephyr_prepare(dd, dev);
 }
 
-static int dai_reset(struct comp_dev *dev)
+static void dai_zephyr_reset(struct dai_data *dd, struct comp_dev *dev)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
 	struct dma_sg_config *config = &dd->config;
-
-	comp_dbg(dev, "dai_reset()");
 
 	/*
 	 * DMA channel release should be skipped now for DAI's that support the two-step stop
@@ -1009,6 +1006,16 @@ static int dai_reset(struct comp_dev *dev)
 	dd->wallclock = 0;
 	dd->total_data_processed = 0;
 	dd->xrun = 0;
+}
+
+static int dai_reset(struct comp_dev *dev)
+{
+	struct dai_data *dd = comp_get_drvdata(dev);
+
+	comp_dbg(dev, "dai_reset()");
+
+	dai_zephyr_reset(dd, dev);
+
 	comp_set_state(dev, COMP_TRIGGER_RESET);
 
 	return 0;

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -65,10 +65,8 @@ static void dai_atomic_trigger(void *arg, enum notify_id type, void *data)
 }
 
 /* Assign DAI to a group */
-int dai_assign_group(struct comp_dev *dev, uint32_t group_id)
+int dai_assign_group(struct dai_data *dd, struct comp_dev *dev, uint32_t group_id)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
-
 	if (dd->group) {
 		if (dd->group->group_id != group_id) {
 			comp_err(dev, "dai_assign_group(), DAI already in group %d, requested %d",

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -355,14 +355,10 @@ e_data:
 	return NULL;
 }
 
-static void dai_free(struct comp_dev *dev)
+static void dai_zephyr_free(struct dai_data *dd)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
-
-	if (dd->group) {
-		notifier_unregister(dev, dd->group, NOTIFIER_ID_DAI_TRIGGER);
+	if (dd->group)
 		dai_group_put(dd->group);
-	}
 
 	if (dd->chan) {
 		dma_release_channel(dd->dma->z_dev, dd->chan->index);
@@ -376,6 +372,17 @@ static void dai_free(struct comp_dev *dev)
 	dai_put(dd->dai);
 
 	rfree(dd->dai_spec_config);
+}
+
+static void dai_free(struct comp_dev *dev)
+{
+	struct dai_data *dd = comp_get_drvdata(dev);
+
+	if (dd->group)
+		notifier_unregister(dev, dd->group, NOTIFIER_ID_DAI_TRIGGER);
+
+	dai_zephyr_free(dd);
+
 	rfree(dd);
 	rfree(dev);
 }

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -426,7 +426,7 @@ static int dai_verify_params(struct comp_dev *dev, struct sof_ipc_stream_params 
 	struct sof_ipc_stream_params hw_params;
 	int ret;
 
-	ret = dai_comp_get_hw_params(dev, &hw_params, params->direction);
+	ret = comp_dai_get_hw_params(dev, &hw_params, params->direction);
 	if (ret < 0) {
 		comp_err(dev, "dai_verify_params(): dai_verify_params failed ret %d", ret);
 		return ret;

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -1153,7 +1153,7 @@ static int dai_comp_trigger_internal(struct dai_data *dd, struct comp_dev *dev, 
 	return ret;
 }
 
-static int dai_zephyr_trigger(struct dai_data *dd, struct comp_dev *dev, int cmd)
+int dai_zephyr_trigger(struct dai_data *dd, struct comp_dev *dev, int cmd)
 {
 	struct dai_group *group = dd->group;
 	uint32_t irq_flags;

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -1236,7 +1236,7 @@ static void dai_report_xrun(struct dai_data *dd, struct comp_dev *dev, uint32_t 
 }
 
 /* copy and process stream data from source to sink buffers */
-static int dai_zephyr_copy(struct dai_data *dd, struct comp_dev *dev)
+int dai_zephyr_copy(struct dai_data *dd, struct comp_dev *dev)
 {
 	uint32_t dma_fmt;
 	uint32_t sampling;

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -357,7 +357,7 @@ static void dai_free(struct comp_dev *dev)
 
 	dma_put(dd->dma);
 
-	dai_release_llp_slot(dev);
+	dai_release_llp_slot(dd);
 
 	dai_put(dd->dai);
 

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -744,8 +744,8 @@ out:
 	return err;
 }
 
-static int dai_zephyr_params(struct dai_data *dd, struct comp_dev *dev,
-			     struct sof_ipc_stream_params *params)
+int dai_zephyr_params(struct dai_data *dd, struct comp_dev *dev,
+		      struct sof_ipc_stream_params *params)
 {
 	struct sof_ipc_stream_params hw_params = *params;
 	struct comp_buffer __sparse_cache *buffer_c;

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -895,7 +895,7 @@ static int dai_config_prepare(struct comp_dev *dev)
 		return 0;
 	}
 
-	channel = dai_config_dma_channel(dev, dd->dai_spec_config);
+	channel = dai_config_dma_channel(dd, dev, dd->dai_spec_config);
 	comp_dbg(dev, "dai_config_prepare(), channel = %d", channel);
 
 	/* do nothing for asking for channel free, for compatibility. */

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -980,7 +980,7 @@ static int dai_prepare(struct comp_dev *dev)
 	return dai_zephyr_prepare(dd, dev);
 }
 
-static void dai_zephyr_reset(struct dai_data *dd, struct comp_dev *dev)
+void dai_zephyr_reset(struct dai_data *dd, struct comp_dev *dev)
 {
 	struct dma_sg_config *config = &dd->config;
 

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -992,7 +992,7 @@ static int dai_reset(struct comp_dev *dev)
 	 * option. It will be done when the host sends the DAI_CONFIG IPC during hw_free.
 	 */
 	if (!dd->delayed_dma_stop)
-		dai_dma_release(dev);
+		dai_dma_release(dd, dev);
 
 	dma_sg_free(&config->elem_array);
 	if (dd->z_config) {

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -762,7 +762,7 @@ static int dai_params(struct comp_dev *dev, struct sof_ipc_stream_params *params
 	comp_dbg(dev, "dai_params()");
 
 	/* configure dai_data first */
-	err = ipc_dai_data_config(dev);
+	err = ipc_dai_data_config(dd, dev);
 	if (err < 0)
 		return err;
 

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -385,15 +385,13 @@ static void dai_free(struct comp_dev *dev)
 	rfree(dev);
 }
 
-static int dai_comp_get_hw_params(struct comp_dev *dev,
-				  struct sof_ipc_stream_params *params,
-				  int dir)
+int dai_zephyr_get_hw_params(struct dai_data *dd, struct comp_dev *dev,
+			     struct sof_ipc_stream_params *params, int dir)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
 	struct dai_config cfg;
 	int ret;
 
-	comp_dbg(dev, "dai_hw_params()");
+	comp_dbg(dev, "dai_zephyr_get_hw_params()");
 
 	ret = dai_config_get(dd->dai->dev, &cfg, dir);
 	if (ret)
@@ -412,6 +410,15 @@ static int dai_comp_get_hw_params(struct comp_dev *dev,
 	params->frame_fmt = dev->ipc_config.frame_fmt;
 
 	return ret;
+}
+
+static int dai_comp_get_hw_params(struct comp_dev *dev,
+				  struct sof_ipc_stream_params *params,
+				  int dir)
+{
+	struct dai_data *dd = comp_get_drvdata(dev);
+
+	return dai_zephyr_get_hw_params(dd, dev, params, dir);
 }
 
 static int dai_verify_params(struct comp_dev *dev, struct sof_ipc_stream_params *params)

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -1356,9 +1356,8 @@ static int dai_copy(struct comp_dev *dev)
  * DAI must be prepared before this function is used (for DMA information). If not, an error
  * is returned.
  */
-static int dai_ts_config_op(struct comp_dev *dev)
+int dai_zephyr_ts_config_op(struct dai_data *dd, struct comp_dev *dev)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
 	struct ipc_config_dai *dai = &dd->ipc_config;
 	struct dai_ts_cfg cfg;
 
@@ -1392,43 +1391,60 @@ static int dai_ts_config_op(struct comp_dev *dev)
 	return dai_ts_config(dd->dai->dev, &cfg);
 }
 
+static int dai_ts_config_op(struct comp_dev *dev)
+{
+	struct dai_data *dd = comp_get_drvdata(dev);
+
+	return dai_zephyr_ts_config_op(dd, dev);
+}
+
+int dai_zephyr_ts_start(struct dai_data *dd, struct comp_dev *dev)
+{
+	struct dai_ts_cfg cfg;
+
+	return dai_ts_start(dd->dai->dev, &cfg);
+}
+
 static int dai_ts_start_op(struct comp_dev *dev)
 {
 	struct dai_data *dd = comp_get_drvdata(dev);
-	struct dai_ts_cfg cfg;
 
 	comp_dbg(dev, "dai_ts_start()");
+	return dai_zephyr_ts_start(dd, dev);
+}
 
-	return dai_ts_start(dd->dai->dev, &cfg);
+int dai_zephyr_ts_get(struct dai_data *dd, struct comp_dev *dev, struct timestamp_data *tsd)
+{
+	struct dai_ts_data tsdata;
+	struct dai_ts_cfg cfg;
+
+	/* TODO: convert to timestamp_data */
+	return dai_ts_get(dd->dai->dev, &cfg, &tsdata);
 }
 
 static int dai_ts_get_op(struct comp_dev *dev, struct timestamp_data *tsd)
 {
 	struct dai_data *dd = comp_get_drvdata(dev);
-	struct dai_ts_data tsdata;
-	struct dai_ts_cfg cfg;
-	int ret;
 
 	comp_dbg(dev, "dai_ts_get()");
 
-	ret = dai_ts_get(dd->dai->dev, &cfg, &tsdata);
+	return dai_zephyr_ts_get(dd, dev, tsd);
+}
 
-	if (ret < 0)
-		return ret;
+int dai_zephyr_ts_stop(struct dai_data *dd, struct comp_dev *dev)
+{
+	struct dai_ts_cfg cfg;
 
-	/* todo convert to timestamp_data */
-
-	return ret;
+	return dai_ts_stop(dd->dai->dev, &cfg);
 }
 
 static int dai_ts_stop_op(struct comp_dev *dev)
 {
 	struct dai_data *dd = comp_get_drvdata(dev);
-	struct dai_ts_cfg cfg;
 
 	comp_dbg(dev, "dai_ts_stop()");
 
-	return dai_ts_stop(dd->dai->dev, &cfg);
+	return dai_zephyr_ts_stop(dd, dev);
 }
 
 uint32_t dai_get_init_delay_ms(struct dai *dai)

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -453,10 +453,9 @@ static int dai_verify_params(struct comp_dev *dev, struct sof_ipc_stream_params 
 }
 
 /* set component audio SSP and DMA configuration */
-static int dai_playback_params(struct comp_dev *dev, uint32_t period_bytes,
-			       uint32_t period_count)
+static int dai_playback_params(struct dai_data *dd, struct comp_dev *dev, uint32_t period_bytes,
+			       int32_t period_count)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
 	struct dma_sg_config *config = &dd->config;
 	struct dma_config *dma_cfg;
 	struct dma_block_config *dma_block_cfg;
@@ -591,10 +590,9 @@ out:
 	return err;
 }
 
-static int dai_capture_params(struct comp_dev *dev, uint32_t period_bytes,
+static int dai_capture_params(struct dai_data *dd, struct comp_dev *dev, uint32_t period_bytes,
 			      uint32_t period_count)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
 	struct dma_sg_config *config = &dd->config;
 	struct dma_config *dma_cfg;
 	struct dma_block_config *dma_block_cfg;
@@ -746,10 +744,10 @@ out:
 	return err;
 }
 
-static int dai_params(struct comp_dev *dev, struct sof_ipc_stream_params *params)
+static int dai_zephyr_params(struct dai_data *dd, struct comp_dev *dev,
+			     struct sof_ipc_stream_params *params)
 {
 	struct sof_ipc_stream_params hw_params = *params;
-	struct dai_data *dd = comp_get_drvdata(dev);
 	struct comp_buffer __sparse_cache *buffer_c;
 	uint32_t frame_size;
 	uint32_t period_count;
@@ -759,8 +757,6 @@ static int dai_params(struct comp_dev *dev, struct sof_ipc_stream_params *params
 	uint32_t align;
 	int err;
 
-	comp_dbg(dev, "dai_params()");
-
 	/* configure dai_data first */
 	err = ipc_dai_data_config(dd, dev);
 	if (err < 0)
@@ -768,7 +764,7 @@ static int dai_params(struct comp_dev *dev, struct sof_ipc_stream_params *params
 
 	err = dai_verify_params(dev, params);
 	if (err < 0) {
-		comp_err(dev, "dai_params(): pcm params verification failed.");
+		comp_err(dev, "dai_zephyr_params(): pcm params verification failed.");
 		return -EINVAL;
 	}
 
@@ -783,13 +779,13 @@ static int dai_params(struct comp_dev *dev, struct sof_ipc_stream_params *params
 
 	/* check if already configured */
 	if (dev->state == COMP_STATE_PREPARE) {
-		comp_info(dev, "dai_params() component has been already configured.");
+		comp_info(dev, "dai_zephyr_params() component has been already configured.");
 		return 0;
 	}
 
 	/* can set params on only init state */
 	if (dev->state != COMP_STATE_READY) {
-		comp_err(dev, "dai_params(): Component is in state %d, expected COMP_STATE_READY.",
+		comp_err(dev, "dai_zephyr_params(): Component is in state %d, expected COMP_STATE_READY.",
 			 dev->state);
 		return -EINVAL;
 	}
@@ -797,21 +793,21 @@ static int dai_params(struct comp_dev *dev, struct sof_ipc_stream_params *params
 	err = dma_get_attribute(dd->dma->z_dev, DMA_ATTR_BUFFER_ADDRESS_ALIGNMENT,
 				&addr_align);
 	if (err < 0) {
-		comp_err(dev, "dai_params(): could not get dma buffer address alignment, err = %d",
+		comp_err(dev, "dai_zephyr_params(): could not get dma buffer address alignment, err = %d",
 			 err);
 		return err;
 	}
 
 	err = dma_get_attribute(dd->dma->z_dev, DMA_ATTR_BUFFER_SIZE_ALIGNMENT, &align);
 	if (err < 0 || !align) {
-		comp_err(dev, "dai_params(): no valid dma buffer alignment, err = %d, align = %u",
+		comp_err(dev, "dai_zephyr_params(): no valid dma buffer alignment, err = %d, align = %u",
 			 err, align);
 		return -EINVAL;
 	}
 
 	period_count = dd->dma->plat_data.period_count;
 	if (!period_count) {
-		comp_err(dev, "dai_params(): no valid dma buffer period count");
+		comp_err(dev, "dai_zephyr_params(): no valid dma buffer period count");
 		return -EINVAL;
 	}
 
@@ -826,7 +822,7 @@ static int dai_params(struct comp_dev *dev, struct sof_ipc_stream_params *params
 	/* calculate period size */
 	period_bytes = dev->frames * frame_size;
 	if (!period_bytes) {
-		comp_err(dev, "dai_params(): invalid period_bytes.");
+		comp_err(dev, "dai_zephyr_params(): invalid period_bytes.");
 		return -EINVAL;
 	}
 
@@ -844,7 +840,7 @@ static int dai_params(struct comp_dev *dev, struct sof_ipc_stream_params *params
 		buffer_release(buffer_c);
 
 		if (err < 0) {
-			comp_err(dev, "dai_params(): buffer_set_size() failed, buffer_size = %u",
+			comp_err(dev, "dai_zephyr_params(): buffer_set_size() failed, buffer_size = %u",
 				 buffer_size);
 			return err;
 		}
@@ -852,7 +848,7 @@ static int dai_params(struct comp_dev *dev, struct sof_ipc_stream_params *params
 		dd->dma_buffer = buffer_alloc(buffer_size, SOF_MEM_CAPS_DMA, 0,
 					      addr_align);
 		if (!dd->dma_buffer) {
-			comp_err(dev, "dai_params(): failed to alloc dma buffer");
+			comp_err(dev, "dai_zephyr_params(): failed to alloc dma buffer");
 			return -ENOMEM;
 		}
 
@@ -870,8 +866,17 @@ static int dai_params(struct comp_dev *dev, struct sof_ipc_stream_params *params
 	}
 
 	return dev->direction == SOF_IPC_STREAM_PLAYBACK ?
-		dai_playback_params(dev, period_bytes, period_count) :
-		dai_capture_params(dev, period_bytes, period_count);
+		dai_playback_params(dd, dev, period_bytes, period_count) :
+		dai_capture_params(dd, dev, period_bytes, period_count);
+}
+
+static int dai_params(struct comp_dev *dev, struct sof_ipc_stream_params *params)
+{
+	struct dai_data *dd = comp_get_drvdata(dev);
+
+	comp_dbg(dev, "dai_params()");
+
+	return dai_zephyr_params(dd, dev, params);
 }
 
 int dai_zephyr_config_prepare(struct dai_data *dd, struct comp_dev *dev)

--- a/src/include/ipc4/alh.h
+++ b/src/include/ipc4/alh.h
@@ -25,6 +25,7 @@
 #define __SOF_IPC4_ALH_H__
 
 #include <stdint.h>
+#include <stdbool.h>
 #include <ipc4/gateway.h>
 
 #define IPC4_ALH_MAX_NUMBER_OF_GTW 16

--- a/src/include/ipc4/copier.h
+++ b/src/include/ipc4/copier.h
@@ -27,6 +27,7 @@
 #include <stdint.h>
 #include <ipc4/base-config.h>
 #include <ipc4/gateway.h>
+#include <ipc4/alh.h>
 
 #include <sof/compiler_attributes.h>
 #include <sof/audio/buffer.h>
@@ -263,6 +264,7 @@ struct copier_data {
 	uint64_t output_total_data_processed;
 	struct host_data *hd;
 	bool ipc_gtw;
+	struct dai_data *dd[IPC4_ALH_MAX_NUMBER_OF_GTW];
 };
 
 int apply_attenuation(struct comp_dev *dev, struct copier_data *cd,

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -347,8 +347,8 @@ struct comp_ops {
 	 *
 	 * Mandatory for components that allocate DAI.
 	 */
-	int (*dai_config)(struct comp_dev *dev, struct ipc_config_dai *dai_config,
-			  const void *dai_spec_config);
+	int (*dai_config)(struct dai_data *dd, struct comp_dev *dev,
+			  struct ipc_config_dai *dai_config, const void *dai_spec_config);
 
 	/**
 	 * Used to pass standard and bespoke commands (with optional data).

--- a/src/include/sof/audio/component_ext.h
+++ b/src/include/sof/audio/component_ext.h
@@ -252,16 +252,27 @@ static inline int comp_reset(struct comp_dev *dev)
 	return 0;
 }
 
+#if CONFIG_IPC_MAJOR_3
 /** See comp_ops::dai_config */
 static inline int comp_dai_config(struct comp_dev *dev, struct ipc_config_dai *config,
 				  const void *spec_config)
 {
+	struct dai_data *dd = comp_get_drvdata(dev);
+
 	if (dev->drv->ops.dai_config)
-		return dev->drv->ops.dai_config(dev, config, spec_config);
+		return dev->drv->ops.dai_config(dd, dev, config, spec_config);
 
 	return 0;
 }
-
+#elif CONFIG_IPC_MAJOR_4
+static inline int comp_dai_config(struct dai_data *dd, struct comp_dev *dev,
+				  struct ipc_config_dai *config, const void *spec_config)
+{
+	return dai_config(dd, dev, config, spec_config);
+}
+#else
+#error Unknown IPC major version
+#endif
 /** See comp_ops::position */
 static inline int comp_position(struct comp_dev *dev,
 				struct sof_ipc_stream_posn *posn)

--- a/src/include/sof/audio/component_ext.h
+++ b/src/include/sof/audio/component_ext.h
@@ -362,26 +362,6 @@ static inline int comp_get_endpoint_type(struct comp_dev *dev)
 	}
 }
 
-#if CONFIG_IPC_MAJOR_4
-#include <ipc4/copier.h>
-static inline struct comp_dev *comp_get_dai(struct comp_dev *parent, int index)
-{
-	struct copier_data *cd = comp_get_drvdata(parent);
-
-	if (index >= ARRAY_SIZE(cd->endpoint))
-		return NULL;
-
-	return cd->endpoint[index];
-}
-#elif CONFIG_IPC_MAJOR_3
-static inline struct comp_dev *comp_get_dai(struct comp_dev *parent, int index)
-{
-	return parent;
-}
-#else
-#error Unknown IPC major version
-#endif
-
 /**
  * Called to check whether component schedules its pipeline.
  * @param dev Component device.

--- a/src/include/sof/audio/dai_copier.h
+++ b/src/include/sof/audio/dai_copier.h
@@ -45,4 +45,7 @@ int dai_zephyr_ts_start(struct dai_data *dd, struct comp_dev *dev);
 int dai_zephyr_ts_stop(struct dai_data *dd, struct comp_dev *dev);
 
 int dai_zephyr_ts_get(struct dai_data *dd, struct comp_dev *dev, struct timestamp_data *tsd);
+
+int dai_zephyr_get_hw_params(struct dai_data *dd, struct comp_dev *dev,
+			     struct sof_ipc_stream_params *params, int dir);
 #endif /* __SOF_LIB_DAI_COPIER_H__ */

--- a/src/include/sof/audio/dai_copier.h
+++ b/src/include/sof/audio/dai_copier.h
@@ -35,4 +35,6 @@ int dai_zephyr_position(struct dai_data *dd, struct comp_dev *dev,
 
 int dai_zephyr_params(struct dai_data *dd, struct comp_dev *dev,
 		      struct sof_ipc_stream_params *params);
+
+int dai_zephyr_copy(struct dai_data *dd, struct comp_dev *dev);
 #endif /* __SOF_LIB_DAI_COPIER_H__ */

--- a/src/include/sof/audio/dai_copier.h
+++ b/src/include/sof/audio/dai_copier.h
@@ -22,4 +22,7 @@ int dai_zephyr_new(struct dai_data *dd, struct comp_dev *dev,
 
 void dai_zephyr_free(struct dai_data *dd);
 
+int dai_zephyr_config_prepare(struct dai_data *dd, struct comp_dev *dev);
+
+int dai_zephyr_prepare(struct dai_data *dd, struct comp_dev *dev);
 #endif /* __SOF_LIB_DAI_COPIER_H__ */

--- a/src/include/sof/audio/dai_copier.h
+++ b/src/include/sof/audio/dai_copier.h
@@ -27,4 +27,6 @@ int dai_zephyr_config_prepare(struct dai_data *dd, struct comp_dev *dev);
 int dai_zephyr_prepare(struct dai_data *dd, struct comp_dev *dev);
 
 void dai_zephyr_reset(struct dai_data *dd, struct comp_dev *dev);
+
+int dai_zephyr_trigger(struct dai_data *dd, struct comp_dev *dev, int cmd);
 #endif /* __SOF_LIB_DAI_COPIER_H__ */

--- a/src/include/sof/audio/dai_copier.h
+++ b/src/include/sof/audio/dai_copier.h
@@ -37,4 +37,12 @@ int dai_zephyr_params(struct dai_data *dd, struct comp_dev *dev,
 		      struct sof_ipc_stream_params *params);
 
 int dai_zephyr_copy(struct dai_data *dd, struct comp_dev *dev);
+
+int dai_zephyr_ts_config_op(struct dai_data *dd, struct comp_dev *dev);
+
+int dai_zephyr_ts_start(struct dai_data *dd, struct comp_dev *dev);
+
+int dai_zephyr_ts_stop(struct dai_data *dd, struct comp_dev *dev);
+
+int dai_zephyr_ts_get(struct dai_data *dd, struct comp_dev *dev, struct timestamp_data *tsd);
 #endif /* __SOF_LIB_DAI_COPIER_H__ */

--- a/src/include/sof/audio/dai_copier.h
+++ b/src/include/sof/audio/dai_copier.h
@@ -29,4 +29,7 @@ int dai_zephyr_prepare(struct dai_data *dd, struct comp_dev *dev);
 void dai_zephyr_reset(struct dai_data *dd, struct comp_dev *dev);
 
 int dai_zephyr_trigger(struct dai_data *dd, struct comp_dev *dev, int cmd);
+
+int dai_zephyr_position(struct dai_data *dd, struct comp_dev *dev,
+			struct sof_ipc_stream_posn *posn);
 #endif /* __SOF_LIB_DAI_COPIER_H__ */

--- a/src/include/sof/audio/dai_copier.h
+++ b/src/include/sof/audio/dai_copier.h
@@ -32,4 +32,7 @@ int dai_zephyr_trigger(struct dai_data *dd, struct comp_dev *dev, int cmd);
 
 int dai_zephyr_position(struct dai_data *dd, struct comp_dev *dev,
 			struct sof_ipc_stream_posn *posn);
+
+int dai_zephyr_params(struct dai_data *dd, struct comp_dev *dev,
+		      struct sof_ipc_stream_params *params);
 #endif /* __SOF_LIB_DAI_COPIER_H__ */

--- a/src/include/sof/audio/dai_copier.h
+++ b/src/include/sof/audio/dai_copier.h
@@ -1,0 +1,25 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2023 Intel Corporation. All rights reserved.
+ *
+ * Author: Baofeng Tian <baofeng.tian@intel.com>
+ */
+
+/**
+ * \file audio/dai_copier.h
+ * \brief dai copier shared header file
+ * \authors Baofeng Tian <baofeng.tian@intel.com>
+ */
+
+#ifndef __SOF_LIB_DAI_COPIER_H__
+#define __SOF_LIB_DAI_COPIER_H__
+
+struct ipc_config_dai;
+struct comp_dev;
+struct dai_data;
+int dai_zephyr_new(struct dai_data *dd, struct comp_dev *dev,
+		   const struct ipc_config_dai *dai_cfg);
+
+void dai_zephyr_free(struct dai_data *dd);
+
+#endif /* __SOF_LIB_DAI_COPIER_H__ */

--- a/src/include/sof/audio/dai_copier.h
+++ b/src/include/sof/audio/dai_copier.h
@@ -25,4 +25,6 @@ void dai_zephyr_free(struct dai_data *dd);
 int dai_zephyr_config_prepare(struct dai_data *dd, struct comp_dev *dev);
 
 int dai_zephyr_prepare(struct dai_data *dd, struct comp_dev *dev);
+
+void dai_zephyr_reset(struct dai_data *dd, struct comp_dev *dev);
 #endif /* __SOF_LIB_DAI_COPIER_H__ */

--- a/src/include/sof/ipc/common.h
+++ b/src/include/sof/ipc/common.h
@@ -141,11 +141,12 @@ int ipc_dma_trace_send_position(void);
  */
 void ipc_send_buffer_status_notify(void);
 
+struct dai_data;
 /**
  * \brief Configure DAI.
  * @return 0 on success.
  */
-int ipc_dai_data_config(struct comp_dev *dev);
+int ipc_dai_data_config(struct dai_data *dd, struct comp_dev *dev);
 
 /**
  * \brief create a IPC boot complete message.

--- a/src/include/sof/lib/dai-legacy.h
+++ b/src/include/sof/lib/dai-legacy.h
@@ -553,13 +553,13 @@ void dai_dma_release(struct dai_data *dd, struct comp_dev *dev);
 /**
  * \brief Configure DAI physical interface.
  */
-int dai_config(struct comp_dev *dev,  struct ipc_config_dai *common_config,
+int dai_config(struct dai_data *dd, struct comp_dev *dev,  struct ipc_config_dai *common_config,
 	       const void *spec_config);
 
 /**
  * \brief Assign DAI to a group for simultaneous triggering.
  */
-int dai_assign_group(struct comp_dev *dev, uint32_t group_id);
+int dai_assign_group(struct dai_data *dd, struct comp_dev *dev, uint32_t group_id);
 
 /**
  * \brief dai position for host driver.

--- a/src/include/sof/lib/dai-legacy.h
+++ b/src/include/sof/lib/dai-legacy.h
@@ -548,7 +548,7 @@ int dai_config_dma_channel(struct dai_data *dd, struct comp_dev *dev, const void
 /**
  * \brief Reset DAI DMA config
  */
-void dai_dma_release(struct comp_dev *dev);
+void dai_dma_release(struct dai_data *dd, struct comp_dev *dev);
 
 /**
  * \brief Configure DAI physical interface.

--- a/src/include/sof/lib/dai-legacy.h
+++ b/src/include/sof/lib/dai-legacy.h
@@ -543,7 +543,7 @@ static inline const struct dai_info *dai_info_get(void)
 /**
  * \brief Configure DMA channel for DAI
  */
-int dai_config_dma_channel(struct comp_dev *dev, const void *config);
+int dai_config_dma_channel(struct dai_data *dd, struct comp_dev *dev, const void *config);
 
 /**
  * \brief Reset DAI DMA config

--- a/src/include/sof/lib/dai-legacy.h
+++ b/src/include/sof/lib/dai-legacy.h
@@ -574,7 +574,7 @@ void dai_dma_position_update(struct comp_dev *dev);
 /**
  * \brief release llp slot
  */
-void dai_release_llp_slot(struct comp_dev *dev);
+void dai_release_llp_slot(struct dai_data *dd);
 /** @}*/
 
 #endif /* __SOF_LIB_DAI_LEGACY_H__ */

--- a/src/include/sof/lib/dai-legacy.h
+++ b/src/include/sof/lib/dai-legacy.h
@@ -569,7 +569,7 @@ int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn);
 /**
  * \brief update dai dma position for host driver.
  */
-void dai_dma_position_update(struct comp_dev *dev);
+void dai_dma_position_update(struct dai_data *dd, struct comp_dev *dev);
 
 /**
  * \brief release llp slot

--- a/src/include/sof/lib/dai-zephyr.h
+++ b/src/include/sof/lib/dai-zephyr.h
@@ -278,7 +278,7 @@ int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn);
 /**
  * \brief update dai dma position for host driver.
  */
-void dai_dma_position_update(struct comp_dev *dev);
+void dai_dma_position_update(struct dai_data *dd, struct comp_dev *dev);
 
 /**
  * \brief release llp slot

--- a/src/include/sof/lib/dai-zephyr.h
+++ b/src/include/sof/lib/dai-zephyr.h
@@ -258,7 +258,7 @@ int dai_config_dma_channel(struct dai_data *dd, struct comp_dev *dev, const void
 /**
  * \brief Reset DAI DMA config
  */
-void dai_dma_release(struct comp_dev *dev);
+void dai_dma_release(struct dai_data *dd, struct comp_dev *dev);
 
 /**
  * \brief Configure DAI physical interface.

--- a/src/include/sof/lib/dai-zephyr.h
+++ b/src/include/sof/lib/dai-zephyr.h
@@ -283,7 +283,7 @@ void dai_dma_position_update(struct comp_dev *dev);
 /**
  * \brief release llp slot
  */
-void dai_release_llp_slot(struct comp_dev *dev);
+void dai_release_llp_slot(struct dai_data *dd);
 /** @}*/
 
 #endif /* __SOF_LIB_DAI_ZEPHYR_H__ */

--- a/src/include/sof/lib/dai-zephyr.h
+++ b/src/include/sof/lib/dai-zephyr.h
@@ -263,12 +263,13 @@ void dai_dma_release(struct dai_data *dd, struct comp_dev *dev);
 /**
  * \brief Configure DAI physical interface.
  */
-int dai_config(struct comp_dev *dev,  struct ipc_config_dai *common_cfg, const void *spec_cfg);
+int dai_config(struct dai_data *dd, struct comp_dev *dev,
+	       struct ipc_config_dai *common_cfg, const void *spec_cfg);
 
 /**
  * \brief Assign DAI to a group for simultaneous triggering.
  */
-int dai_assign_group(struct comp_dev *dev, uint32_t group_id);
+int dai_assign_group(struct dai_data *dd, struct comp_dev *dev, uint32_t group_id);
 
 /**
  * \brief dai position for host driver.

--- a/src/include/sof/lib/dai-zephyr.h
+++ b/src/include/sof/lib/dai-zephyr.h
@@ -253,7 +253,7 @@ int dai_get_stream_id(struct dai *dai, int direction);
 /**
  * \brief Configure DMA channel for DAI
  */
-int dai_config_dma_channel(struct comp_dev *dev, const void *config);
+int dai_config_dma_channel(struct dai_data *dd, struct comp_dev *dev, const void *config);
 
 /**
  * \brief Reset DAI DMA config

--- a/src/ipc/ipc3/dai.c
+++ b/src/ipc/ipc3/dai.c
@@ -94,9 +94,8 @@ int dai_config_dma_channel(struct dai_data *dd, struct comp_dev *dev, const void
 	return channel;
 }
 
-int ipc_dai_data_config(struct comp_dev *dev)
+int ipc_dai_data_config(struct dai_data *dd, struct comp_dev *dev)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
 	struct ipc_config_dai *dai = &dd->ipc_config;
 	struct sof_ipc_dai_config *config = ipc_from_dai_config(dd->dai_spec_config);
 	struct comp_buffer __sparse_cache *buffer_c;

--- a/src/ipc/ipc3/dai.c
+++ b/src/ipc/ipc3/dai.c
@@ -262,10 +262,8 @@ int ipc_comp_dai_config(struct ipc *ipc, struct ipc_config_dai *common_config,
 	return ret;
 }
 
-void dai_dma_release(struct comp_dev *dev)
+void dai_dma_release(struct dai_data *dd, struct comp_dev *dev)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
-
 	/* cannot configure DAI while active */
 	if (dev->state == COMP_STATE_ACTIVE) {
 		comp_info(dev, "dai_config(): Component is in active state. Ignore resetting");
@@ -335,7 +333,7 @@ int dai_config(struct comp_dev *dev, struct ipc_config_dai *common_config,
 			if (ret < 0)
 				return ret;
 
-			dai_dma_release(dev);
+			dai_dma_release(dd, dev);
 		}
 
 		return 0;

--- a/src/ipc/ipc3/dai.c
+++ b/src/ipc/ipc3/dai.c
@@ -392,6 +392,6 @@ int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn)
 	return 0;
 }
 
-void dai_dma_position_update(struct comp_dev *dev) { }
+void dai_dma_position_update(struct dai_data *dd, struct comp_dev *dev) { }
 
 void dai_release_llp_slot(struct dai_data *dd) { }

--- a/src/ipc/ipc3/dai.c
+++ b/src/ipc/ipc3/dai.c
@@ -29,9 +29,8 @@
 
 LOG_MODULE_DECLARE(ipc, CONFIG_SOF_LOG_LEVEL);
 
-int dai_config_dma_channel(struct comp_dev *dev, const void *spec_config)
+int dai_config_dma_channel(struct dai_data *dd, struct comp_dev *dev, const void *spec_config)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
 	const struct sof_ipc_dai_config *config = spec_config;
 	struct ipc_config_dai *dai = &dd->ipc_config;
 	int channel;
@@ -360,7 +359,7 @@ int dai_config(struct comp_dev *dev, struct ipc_config_dai *common_config,
 	}
 #endif
 	/* do nothing for asking for channel free, for compatibility. */
-	if (dai_config_dma_channel(dev, spec_config) == DMA_CHAN_INVALID)
+	if (dai_config_dma_channel(dd, dev, spec_config) == DMA_CHAN_INVALID)
 		return 0;
 
 	/* allocated dai_config if not yet */

--- a/src/ipc/ipc3/dai.c
+++ b/src/ipc/ipc3/dai.c
@@ -398,4 +398,4 @@ int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn)
 
 void dai_dma_position_update(struct comp_dev *dev) { }
 
-void dai_release_llp_slot(struct comp_dev *dev) { }
+void dai_release_llp_slot(struct dai_data *dd) { }

--- a/src/ipc/ipc3/dai.c
+++ b/src/ipc/ipc3/dai.c
@@ -283,11 +283,10 @@ void dai_dma_release(struct dai_data *dd, struct comp_dev *dev)
 	}
 }
 
-int dai_config(struct comp_dev *dev, struct ipc_config_dai *common_config,
+int dai_config(struct dai_data *dd, struct comp_dev *dev, struct ipc_config_dai *common_config,
 	       const void *spec_config)
 {
 	const struct sof_ipc_dai_config *config = spec_config;
-	struct dai_data *dd = comp_get_drvdata(dev);
 	int ret;
 
 	/* ignore if message not for this DAI id/type */
@@ -349,7 +348,7 @@ int dai_config(struct comp_dev *dev, struct ipc_config_dai *common_config,
 	}
 #if CONFIG_COMP_DAI_GROUP
 	if (config->group_id) {
-		ret = dai_assign_group(dev, config->group_id);
+		ret = dai_assign_group(dd, dev, config->group_id);
 
 		if (ret)
 			return ret;

--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -249,9 +249,8 @@ static int dai_get_unused_llp_slot(struct comp_dev *dev,
 	return offset;
 }
 
-static int dai_init_llp_info(struct comp_dev *dev)
+static int dai_init_llp_info(struct dai_data *dd, struct comp_dev *dev)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
 	struct ipc4_copier_module_cfg *copier_cfg;
 	union ipc4_connector_node_id node;
 	int ret;
@@ -279,11 +278,10 @@ static int dai_init_llp_info(struct comp_dev *dev)
 	return 0;
 }
 
-int dai_config(struct comp_dev *dev, struct ipc_config_dai *common_config,
+int dai_config(struct dai_data *dd, struct comp_dev *dev, struct ipc_config_dai *common_config,
 	       const void *spec_config)
 {
 	const struct ipc4_copier_module_cfg *copier_cfg = spec_config;
-	struct dai_data *dd = comp_get_drvdata(dev);
 	int size;
 	int ret;
 
@@ -309,7 +307,7 @@ int dai_config(struct comp_dev *dev, struct ipc_config_dai *common_config,
 
 #if CONFIG_COMP_DAI_GROUP
 	if (common_config->group_id) {
-		ret = dai_assign_group(dev, common_config->group_id);
+		ret = dai_assign_group(dd, dev, common_config->group_id);
 
 		if (ret)
 			return ret;
@@ -338,7 +336,7 @@ int dai_config(struct comp_dev *dev, struct ipc_config_dai *common_config,
 		}
 	}
 
-	ret = dai_init_llp_info(dev);
+	ret = dai_init_llp_info(dd, dev);
 	if (ret < 0)
 		return ret;
 

--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -189,9 +189,8 @@ void dai_dma_release(struct comp_dev *dev)
 	}
 }
 
-void dai_release_llp_slot(struct comp_dev *dev)
+void dai_release_llp_slot(struct dai_data *dd)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
 	struct ipc4_llp_reading_slot slot;
 	k_spinlock_key_t key;
 

--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -30,10 +30,9 @@
 
 LOG_MODULE_DECLARE(ipc, CONFIG_SOF_LOG_LEVEL);
 
-int dai_config_dma_channel(struct comp_dev *dev, const void *spec_config)
+int dai_config_dma_channel(struct dai_data *dd, struct comp_dev *dev, const void *spec_config)
 {
 	const struct ipc4_copier_module_cfg *copier_cfg = spec_config;
-	struct dai_data *dd = comp_get_drvdata(dev);
 	struct ipc_config_dai *dai = &dd->ipc_config;
 	int channel;
 
@@ -319,7 +318,7 @@ int dai_config(struct comp_dev *dev, struct ipc_config_dai *common_config,
 	}
 #endif
 	/* do nothing for asking for channel free, for compatibility. */
-	if (dai_config_dma_channel(dev, spec_config) == DMA_CHAN_INVALID)
+	if (dai_config_dma_channel(dd, dev, spec_config) == DMA_CHAN_INVALID)
 		return 0;
 
 	dd->dai_dev = dev;

--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -7,6 +7,7 @@
 
 #include <sof/audio/buffer.h>
 #include <sof/audio/component_ext.h>
+#include <sof/audio/dai_copier.h>
 #include <sof/audio/ipc-config.h>
 #include <sof/common.h>
 #include <sof/drivers/alh.h>
@@ -346,8 +347,8 @@ int dai_config(struct comp_dev *dev, struct ipc_config_dai *common_config,
 }
 
 #if CONFIG_ZEPHYR_NATIVE_DRIVERS
-static int dai_zephyr_position(struct dai_data *dd, struct comp_dev *dev,
-			       struct sof_ipc_stream_posn *posn)
+int dai_zephyr_position(struct dai_data *dd, struct comp_dev *dev,
+			struct sof_ipc_stream_posn *posn)
 {
 	struct dma_status status;
 	int ret;
@@ -399,8 +400,8 @@ void dai_dma_position_update(struct comp_dev *dev)
 	mailbox_sw_regs_write(dd->slot_info.reg_offset, &slot, sizeof(slot));
 }
 #else
-static int dai_zephyr_position(struct dai_data *dd, struct comp_dev *dev,
-			       struct sof_ipc_stream_posn *posn)
+int dai_zephyr_position(struct dai_data *dd, struct comp_dev *dev,
+			struct sof_ipc_stream_posn *posn)
 {
 	struct dma_chan_status status;
 

--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -62,9 +62,8 @@ int dai_config_dma_channel(struct dai_data *dd, struct comp_dev *dev, const void
 	return channel;
 }
 
-int ipc_dai_data_config(struct comp_dev *dev)
+int ipc_dai_data_config(struct dai_data *dd, struct comp_dev *dev)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
 	struct ipc_config_dai *dai = &dd->ipc_config;
 	struct ipc4_copier_module_cfg *copier_cfg = dd->dai_spec_config;
 	struct dai *dai_p = dd->dai;

--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -346,9 +346,9 @@ int dai_config(struct comp_dev *dev, struct ipc_config_dai *common_config,
 }
 
 #if CONFIG_ZEPHYR_NATIVE_DRIVERS
-int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn)
+static int dai_zephyr_position(struct dai_data *dd, struct comp_dev *dev,
+			       struct sof_ipc_stream_posn *posn)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
 	struct dma_status status;
 	int ret;
 
@@ -365,6 +365,13 @@ int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn)
 	posn->comp_posn = status.total_copied;
 
 	return 0;
+}
+
+int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn)
+{
+	struct dai_data *dd = comp_get_drvdata(dev);
+
+	return dai_zephyr_position(dd, dev, posn);
 }
 
 void dai_dma_position_update(struct comp_dev *dev)
@@ -392,9 +399,9 @@ void dai_dma_position_update(struct comp_dev *dev)
 	mailbox_sw_regs_write(dd->slot_info.reg_offset, &slot, sizeof(slot));
 }
 #else
-int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn)
+static int dai_zephyr_position(struct dai_data *dd, struct comp_dev *dev,
+			       struct sof_ipc_stream_posn *posn)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
 	struct dma_chan_status status;
 
 	/* total processed bytes count */
@@ -407,6 +414,13 @@ int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn)
 	dma_status_legacy(dd->chan, &status, dev->direction);
 
 	return 0;
+}
+
+int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn)
+{
+	struct dai_data *dd = comp_get_drvdata(dev);
+
+	return dai_zephyr_position(dd, dev, posn);
 }
 
 void dai_dma_position_update(struct comp_dev *dev)

--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -374,9 +374,8 @@ int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn)
 	return dai_zephyr_position(dd, dev, posn);
 }
 
-void dai_dma_position_update(struct comp_dev *dev)
+void dai_dma_position_update(struct dai_data *dd, struct comp_dev *dev)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
 	struct ipc4_llp_reading_slot slot;
 	struct dma_status status;
 	int ret;
@@ -423,9 +422,8 @@ int dai_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn)
 	return dai_zephyr_position(dd, dev, posn);
 }
 
-void dai_dma_position_update(struct comp_dev *dev)
+void dai_dma_position_update(struct dai_data *dd, struct comp_dev *dev)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
 	struct ipc4_llp_reading_slot slot;
 	struct dma_chan_status status;
 	uint32_t llp_data[2];

--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -137,10 +137,8 @@ int ipc_comp_dai_config(struct ipc *ipc, struct ipc_config_dai *common_config,
 	return 0;
 }
 
-void dai_dma_release(struct comp_dev *dev)
+void dai_dma_release(struct dai_data *dd, struct comp_dev *dev)
 {
-	struct dai_data *dd = comp_get_drvdata(dev);
-
 	/* cannot configure DAI while active */
 	if (dev->state == COMP_STATE_ACTIVE) {
 		comp_info(dev, "dai_config(): Component is in active state. Ignore resetting");

--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -171,14 +171,9 @@ void dai_dma_release(struct dai_data *dd, struct comp_dev *dev)
 		if (dev->state != COMP_STATE_PAUSED)
 			dma_stop(dd->chan->dma->z_dev, dd->chan->index);
 
-		/* remove callback */
-		notifier_unregister(dev, dd->chan, NOTIFIER_ID_DMA_COPY);
 		dma_release_channel(dd->chan->dma->z_dev, dd->chan->index);
 #else
 		dma_stop_legacy(dd->chan);
-
-		/* remove callback */
-		notifier_unregister(dev, dd->chan, NOTIFIER_ID_DMA_COPY);
 		dma_channel_put_legacy(dd->chan);
 #endif
 		dd->chan->dev_data = NULL;

--- a/tools/topology/topology2/cavs-nocodec.conf
+++ b/tools/topology/topology2/cavs-nocodec.conf
@@ -213,7 +213,7 @@ Object.Pipeline.mixout-gain-smart-amp-dai-copier-playback [
 			}
 
 			Object.Base.input_pin_binding.2 {
-				input_pin_binding_name	"copier.SSP.8.1"
+				input_pin_binding_name	"module-copier.8.1"
 			}
 
 			Object.Control.bytes."1" {
@@ -345,7 +345,9 @@ Object.Pipeline.dai-copier-gain-module-copier-capture [
 				out_bit_depth		32
 				out_valid_bit_depth	32
 			}
+		}
 
+		Object.Widget.module-copier.1 {
 			Object.Base.output_pin_binding.1 {
 				output_pin_binding_name "gain.8.1"
 			}
@@ -634,7 +636,7 @@ Object.Base.route [
 	}
 	{
 		source	"copier.SSP.8.1"
-		sink	"gain.8.1"
+		sink	"module-copier.8.1"
 	}
 	{
 		source	"copier.SSP.12.1"
@@ -661,7 +663,7 @@ Object.Base.route [
 		sink    gain.20.1
 	}
 	{
-		source	"copier.SSP.8.1"
+		source	"module-copier.8.1"
 		sink	"smart_amp.2.1"
 	}
 ]

--- a/tools/topology/topology2/include/pipelines/cavs/dai-copier-gain-module-copier-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/dai-copier-gain-module-copier-capture.conf
@@ -57,6 +57,16 @@ Class.Pipeline."dai-copier-gain-module-copier-capture" {
 				out_valid_bit_depth	32
 			}
 		}
+		module-copier."1" {
+			num_input_audio_formats 1
+			num_output_audio_formats 1
+			Object.Base.audio_format.1 {
+				in_bit_depth		32
+				in_valid_bit_depth	32
+				out_bit_depth		32
+				out_valid_bit_depth	32
+			}
+		}
 
 		module-copier."2" {
 			num_input_audio_formats 1
@@ -91,6 +101,10 @@ Class.Pipeline."dai-copier-gain-module-copier-capture" {
 		route.1 {
 			source gain.$index.1
 			sink	module-copier.$index.2
+		}
+		route.2 {
+			source	module-copier.$index.1
+			sink gain.$index.1
 		}
 	}
 


### PR DESCRIPTION
This is a replacement for #7229 

It optimizes the DAI copier performance to bring its MCPS down to 3.8 and also saves memory by not creating an extra DAI device for every DAI copier. 

The limitation with this PR is that it restricts the DAI copier to have only a single sink for now (single sink != single endpoint. Multiple endpoints for SDW aggregation is still supported). Support for multiple sinks with both host and DAI copiers will be added in a follow up PR. (#7554 is a preview for multi-sink support in DAIs) 