### PR TITLE
IPC4 fuzzing support

### DIFF
--- a/src/audio/base_fw.c
+++ b/src/audio/base_fw.c
@@ -11,6 +11,7 @@
 #include <sof/lib/cpu-clk-manager.h>
 #include <sof/lib/cpu.h>
 #include <rtos/init.h>
+#include <platform/lib/clk.h>
 
 #if CONFIG_ACE_V1X_ART_COUNTER || CONFIG_ACE_V1X_RTC_COUNTER
 #include <zephyr/device.h>

--- a/src/include/ipc4/notification.h
+++ b/src/include/ipc4/notification.h
@@ -25,6 +25,7 @@
 
 #include <stdint.h>
 #include <ipc/header.h>
+#include <sof/compiler_attributes.h>
 
 /* ipc4 notification msg */
 enum sof_ipc4_notification_type {

--- a/src/init/init.c
+++ b/src/init/init.c
@@ -32,6 +32,7 @@
 #include <ipc/trace.h>
 #if CONFIG_IPC_MAJOR_4
 #include <ipc4/fw_reg.h>
+#include <platform/lib/mailbox.h>
 #endif
 #ifdef CONFIG_ZEPHYR_LOG
 #include <zephyr/logging/log_ctrl.h>

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -20,8 +20,14 @@
 #include <sof/platform.h>
 #include <sof/schedule/ll_schedule_domain.h>
 #include <rtos/wait.h>
-#ifdef __ZEPHYR__
-#include <adsp_memory.h> /* for IMR_BOOT_LDR_MANIFEST_BASE */
+
+/* TODO: Remove platform-specific code, see https://github.com/thesofproject/sof/issues/7549 */
+#if defined(CONFIG_SOC_SERIES_INTEL_ACE) || defined(CONFIG_INTEL_ADSP_CAVS)
+#define RIMAGE_MANIFEST 1
+#endif
+
+#ifdef RIMAGE_MANIFEST
+#include <adsp_memory.h>
 #endif
 
 #include <rtos/sof.h>
@@ -685,10 +691,19 @@ out:
 
 const struct comp_driver *ipc4_get_comp_drv(int module_id)
 {
-	struct sof_man_fw_desc *desc = (struct sof_man_fw_desc *)IMR_BOOT_LDR_MANIFEST_BASE;
+	struct sof_man_fw_desc *desc = NULL;
 	const struct comp_driver *drv;
 	struct sof_man_module *mod;
 	int entry_index;
+
+#ifdef RIMAGE_MANIFEST
+	desc = (struct sof_man_fw_desc *)IMR_BOOT_LDR_MANIFEST_BASE;
+#else
+	/* Non-rimage platforms have no component facility yet.  This
+	 * needs to move to the platform layer.
+	 */
+	return NULL;
+#endif
 
 	uint32_t lib_idx = LIB_MANAGER_GET_LIB_ID(module_id);
 

--- a/src/platform/posix/include/platform/drivers/alh.h
+++ b/src/platform/posix/include/platform/drivers/alh.h
@@ -1,0 +1,6 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2023 Google LLC.  All rights reserved.
+ * Author: Andy Ross <andyross@google.com>
+ */
+/* empty file, must be included but defines no needed APIs */
+

--- a/src/platform/posix/include/platform/lib/clk.h
+++ b/src/platform/posix/include/platform/lib/clk.h
@@ -2,3 +2,12 @@
  * Copyright(c) 2022 Google LLC.  All rights reserved.
  * Author: Andy Ross <andyross@google.com>
  */
+
+#define CLK_MAX_CPU_HZ CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC
+#define CPU_LPRO_FREQ_IDX 1
+
+/* This is not a platform function, it's defined in src/lib/clk.c.
+ * But the declaration has historically been in the platform layer, so
+ * it's repeated here.
+ */
+uint32_t clock_get_freq(int clock);

--- a/src/platform/posix/include/platform/lib/dai.h
+++ b/src/platform/posix/include/platform/lib/dai.h
@@ -2,3 +2,10 @@
  * Copyright(c) 2022 Google LLC.  All rights reserved.
  * Author: Andy Ross <andyross@google.com>
  */
+
+#define DAI_NUM_ALH_BI_DIR_LINKS_GROUP 4
+#define DAI_NUM_HDA_IN 10
+#define DAI_NUM_HDA_OUT 9
+#define DAI_NUM_SSP_BASE 6
+#define DAI_NUM_ALH_BI_DIR_LINKS 16
+

--- a/src/platform/posix/include/platform/lib/mailbox.h
+++ b/src/platform/posix/include/platform/lib/mailbox.h
@@ -7,4 +7,22 @@
 
 #include <platform/lib/memory.h>
 
+static inline uint32_t mailbox_sw_reg_read(size_t offset)
+{
+	return 0;
+}
+
+static inline uint64_t mailbox_sw_reg_read64(size_t offset)
+{
+	return 0;
+}
+
+static inline void mailbox_sw_reg_write(size_t offset, uint32_t src)
+{
+}
+
+static inline void mailbox_sw_regs_write(size_t offset, const void *src, size_t bytes)
+{
+}
+
 #endif /* PLATFORM_POSIX_LIB_MAILBOX_H */

--- a/src/platform/posix/include/platform/lib/memory.h
+++ b/src/platform/posix/include/platform/lib/memory.h
@@ -39,6 +39,11 @@ static inline void *platform_shared_get(void *ptr, int bytes)
 	return ptr;
 }
 
+#define SRAM_BANK_SIZE 0x10000
+#define EBB_BANKS_IN_SEGMENT 32
+#define PLATFORM_HPSRAM_EBB_COUNT 32
+#define PLATFORM_LPSRAM_EBB_COUNT 1
+
 #define SHARED_DATA /**/
 
 #endif /* PLATFORM_HOST_PLATFORM_MEMORY_H */

--- a/src/platform/posix/include/platform/platform.h
+++ b/src/platform/posix/include/platform/platform.h
@@ -24,6 +24,8 @@
 
 #define PLATFORM_DEFAULT_DELAY 12
 
+#define HW_CFG_VERSION 0x010000
+
 struct sof;
 
 void posix_dma_init(struct sof *sof);

--- a/src/platform/posix/ipc.c
+++ b/src/platform/posix/ipc.c
@@ -184,3 +184,20 @@ int platform_ipc_init(struct ipc *ipc)
 
 	return 0;
 }
+
+/* Quirky handling of 8 byte messages due to the Intel IPC mechanism
+ * that has two out-of-band words on the controller hardware that
+ * avoid the need for shared memory.
+ */
+int ipc_platform_compact_read_msg(struct ipc_cmd_hdr *hdr, int words)
+{
+	uint32_t *chdr = (uint32_t *)hdr;
+
+	if (words != 2)
+		return 0;
+
+	chdr[0] = ((uint32_t *)posix_hostbox)[0];
+	chdr[1] = ((uint32_t *)posix_hostbox)[1];
+
+	return 2; /* number of words read */
+}

--- a/xtos/include/sof/compiler_attributes.h
+++ b/xtos/include/sof/compiler_attributes.h
@@ -7,6 +7,8 @@
 
 #ifdef __ZEPHYR__
 
+#include <zephyr/toolchain.h>
+
 /* Get __sparse_cache and __sparse_force definitions if __CHECKER__ is defined */
 #include <zephyr/debug/sparse.h>
 


### PR DESCRIPTION
Support for IPC4 protocol fuzzing with the existing rig.  Just select CONFIG_IPC_MAJOR_4=y and it will adjust as needed.  It seems to have pretty decent coverage as far as I've been able to check manually, has run on my system for about two hours now (running 64 instances in parallel), and has uncovered one bug (in #7528 -- that will obviously want to merge before this does).

@marc-hb I didn't adjust the existing fuzz.sh script in this PR, it's still doing IPC3 by default.  There are lots of ways to handle this: you could run the fuzzer twice in CI for each protocol, we could add new "posix" platform variants for each, etc...  Let me know what you'd prefer.