### PR TITLE
Fixes for i.MX xt-clang build

### DIFF
--- a/src/arch/xtensa/include/xtensa/config/core.h
+++ b/src/arch/xtensa/include/xtensa/config/core.h
@@ -36,6 +36,24 @@
 #ifndef XTENSA_CONFIG_CORE_H
 #define XTENSA_CONFIG_CORE_H
 
+/*
+ * This define is used by the new 2023 xt-clang toolchain and, while there are a few definitions
+ * (identical to this one) in various implementations such as newlib, none of them is in use when
+ * building SOF with Zephyr and XtensaTools.
+ */
+
+#if defined(__ZEPHYR__)
+
+#ifndef __UINT32_C
+#define __UINT32_C(x) x ## U
+#endif
+
+#ifndef UINT32_C
+#define UINT32_C(x) __UINT32_C(x)
+#endif
+
+#endif
+
 /*  CONFIGURATION INDEPENDENT DEFINITIONS:  */
 #ifdef __XTENSA__
 #include <xtensa/hal.h>

--- a/src/drivers/imx/interrupt-generic.c
+++ b/src/drivers/imx/interrupt-generic.c
@@ -36,6 +36,7 @@ int irqstr_get_sof_int(int irqstr_int)
 
 void platform_interrupt_init(void) {}
 
+#ifndef __ZEPHYR__
 void platform_interrupt_set(uint32_t irq)
 {
 	arch_interrupt_set(irq);
@@ -45,6 +46,7 @@ void platform_interrupt_clear(uint32_t irq, uint32_t mask)
 {
 	arch_interrupt_clear(irq);
 }
+#endif /* __ZEPHYR__ */
 
 uint32_t platform_interrupt_get_enabled(void)
 {

--- a/src/drivers/imx/interrupt-irqsteer.c
+++ b/src/drivers/imx/interrupt-irqsteer.c
@@ -451,6 +451,7 @@ void platform_interrupt_init(void)
 		interrupt_cascade_register(dsp_irq + i);
 }
 
+#ifndef __ZEPHYR__
 void platform_interrupt_set(uint32_t irq)
 {
 	if (interrupt_is_dsp_direct(irq))
@@ -462,6 +463,7 @@ void platform_interrupt_clear(uint32_t irq, uint32_t mask)
 	if (interrupt_is_dsp_direct(irq))
 		arch_interrupt_clear(irq);
 }
+#endif /* __ZEPHYR */
 
 uint32_t platform_interrupt_get_enabled(void)
 {

--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: aba3b12e311b4779338406fe3e7c4c54f655d0cd
+      revision: fa5117225af9c2167449d79cccd5f0e81bb10696
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -107,6 +107,7 @@ void interrupt_unmask(uint32_t irq, unsigned int cpu)
 {
 	/* TODO: how do we unmask on other cores with Zephyr APIs */
 }
+#endif
 
 void platform_interrupt_set(uint32_t irq)
 {
@@ -117,7 +118,6 @@ void platform_interrupt_clear(uint32_t irq, uint32_t mask)
 {
 	/* handled by zephyr - needed for linkage */
 }
-#endif
 
 /*
  * Asynchronous Messaging Service


### PR DESCRIPTION
These two commits, together with upstream patch https://github.com/zephyrproject-rtos/zephyr/pull/57374 fix the build of SOF for i.MX platforms with the new xt-clang Cadence 2023 toolchain.

Keeping as draft until the Zephyr patch is merged. (edit: Zephyr patch merged, west manifest updated)