### PR TITLE
scripts/docker-run.sh: run with sudo-cwd.sh (Ubuntu upgrade of the Docker image)

### DIFF
--- a/scripts/docker-run.sh
+++ b/scripts/docker-run.sh
@@ -33,6 +33,8 @@ test "$(id -u)" = 1000 ||
   >&2 printf "Warning: this script should be run as user ID 1000 to match the container's account\n"
 
 set -x
+# FIXME: During the transition to sudo-cwd.sh, the tag will be "latest_ubuntu22.04".
+#       Later it will be back to latest
 docker run -i -v "${SOF_TOP}":/home/sof/work/sof.git \
 	-v "${SOF_TOP}":/home/sof/work/sof-bind-mount-DO-NOT-DELETE \
 	--env CMAKE_BUILD_TYPE \
@@ -42,6 +44,5 @@ docker run -i -v "${SOF_TOP}":/home/sof/work/sof.git \
 	--env VERBOSE \
 	--env http_proxy="$http_proxy" \
 	--env https_proxy="$https_proxy" \
-	--user "$(id -u)" \
 	$SOF_DOCKER_RUN \
-	thesofproject/sof "$@"
+	thesofproject/sof:latest_ubuntu22.04 ./scripts/sudo-cwd.sh "$@"


### PR DESCRIPTION
There is a UID mistmatch and file permission problem. sudo-cwd.sh will switch id every docker run command.

80e9c3454a0a048704f863a52443b536a27a2410 was reverted due to missing a toolchain.