### PR TITLE
module_adapter: Don't print an error if reset path stops

### DIFF
--- a/src/audio/module_adapter/module/generic.c
+++ b/src/audio/module_adapter/module/generic.c
@@ -271,8 +271,10 @@ int module_reset(struct processing_module *mod)
 
 	ret = md->ops->reset(mod);
 	if (ret) {
-		comp_err(mod->dev, "module_reset() error %d: module specific reset() failed for comp %d",
-			 ret, dev_comp_id(mod->dev));
+		if (ret != PPL_STATUS_PATH_STOP)
+			comp_err(mod->dev,
+				 "module_reset() error %d: module specific reset() failed for comp %d",
+				 ret, dev_comp_id(mod->dev));
 		return ret;
 	}
 


### PR DESCRIPTION
When md->ops->reset() returns PPL_STATUS_PATH_STOP this means that reset is not propagated along the pipeline. This is a normal condition.

So do not print an error.