### PR TITLE
TEST IGNORE app: Switch main return type to 'int'

### DIFF
--- a/app/src/main.c
+++ b/app/src/main.c
@@ -20,7 +20,7 @@ int sof_main(int argc, char *argv[]);
  * TODO: Here comes SOF initialization
  */
 
-void main(void)
+int main(void)
 {
 	int ret;
 
@@ -47,4 +47,5 @@ void main(void)
 	 */
 	k_thread_suspend(k_current_get());
 #endif
+	return 0;
 }


### PR DESCRIPTION
With Zephyr adopting a different type for 'main', adapt this application to match.

- https://github.com/zephyrproject-rtos/zephyr/pull/54628
- https://github.com/zephyrproject-rtos/sof/pull/28

Signed-off-by: Keith Packard <keithp@keithp.com>
(cherry picked from commit 43526aed1b422e4bbe7f61c7f9a3dbe93f37e18a)