### PR TITLE
app: Switch main return type to 'int'

### DIFF
--- a/app/src/main.c
+++ b/app/src/main.c
@@ -20,7 +20,7 @@ int sof_main(int argc, char *argv[]);
  * TODO: Here comes SOF initialization
  */
 
-void main(void)
+int main(void)
 {
 	int ret;
 
@@ -47,4 +47,5 @@ void main(void)
 	 */
 	k_thread_suspend(k_current_get());
 #endif
+	return 0;
 }


### PR DESCRIPTION
With Zephyr adopting a different type for 'main', adapt this application to match.

This is required when building without the `-ffreestanding` compiler flag as the C standard for "hosted" applications requires one of a small set of specific signatures for the `main` function.