### PR TITLE
topology2: cavs-sdw: make jack optional

### DIFF
--- a/tools/topology/topology2/cavs-sdw.conf
+++ b/tools/topology/topology2/cavs-sdw.conf
@@ -69,6 +69,7 @@ Define {
 	SDW_JACK_IN_BE_ID	1
 	NUM_SDW_AMP_LINKS 0
 	SDW_DMIC 0
+	SDW_JACK true
 }
 
 # override defaults with platform-specific config
@@ -90,11 +91,6 @@ IncludeByKey.NUM_HDMIS {
 "[3-4]" "platform/intel/hdmi-generic.conf"
 }
 
-# include deep buffer config if buffer size is in 1 - 1000 ms.
-IncludeByKey.DEEPBUFFER_FW_DMA_MS{
-        "[1-1000]" "platform/intel/deep-buffer.conf"
-}
-
 IncludeByKey.NUM_SDW_AMP_LINKS {
 "[1-2]" "platform/intel/sdw-amp-generic.conf"
 }
@@ -103,159 +99,7 @@ IncludeByKey.SDW_DMIC {
 "1" "platform/intel/sdw-dmic-generic.conf"
 }
 
-#
-# List of all DAIs
-#
-#ALH Index: 0, Direction: duplex
-Object.Dai.ALH [
-	{
-		dai_index 0
-		id 		$SDW_JACK_OUT_BE_ID
-		direction	"playback"
-		name		$SDW_JACK_OUT_STREAM
-		default_hw_conf_id	0
-		rate			48000
-		channels		2
-
-		Object.Base.hw_config.1 {
-			id	0
-			name	"ALH2"
-		}
-	}
-	{
-		dai_index 10
-		id 		$SDW_JACK_IN_BE_ID
-		direction	"capture"
-		name		$SDW_JACK_IN_STREAM
-		default_hw_conf_id	1
-		rate			48000
-		channels		2
-
-		Object.Base.hw_config.1 {
-			id	1
-			name	"ALH3"
-		}
-	}
-]
-
-#
-# Pipeline definitions
-#
-
-# Pipeline ID:1 PCM ID: 0
-Object.Pipeline {
-	host-copier-gain-mixin-playback [
-		{
-			index 0
-
-		Object.Widget.copier.1 {
-			stream_name "volume playback 0"
-		}
-		Object.Widget.gain.1 {
-			Object.Control.mixer.1 {
-				name '1 Playback Volume 0'
-				}
-			}
-		}
-	]
-
-	mixout-gain-dai-copier-playback [
-		{
-			index 1
-
-			Object.Widget.copier.1 {
-				stream_name $SDW_JACK_OUT_STREAM
-				dai_type "ALH"
-				copier_type "ALH"
-				node_type $ALH_LINK_OUTPUT_CLASS
-			}
-			Object.Widget.gain.1 {
-				Object.Control.mixer.1 {
-					name '2 Main Playback Volume'
-				}
-			}
-		}
-	]
-
-	host-gateway-capture [
-		{
-			index 10
-
-			Object.Widget.copier.1.stream_name	"Passthrough Capture 0"
-			Object.Widget.copier.1.Object.Base.audio_format.1 {
-				# 32/32 -> 16/16 bits conversion is done here
-				in_bit_depth	32
-				in_valid_bit_depth	32
-			}
-		}
-	]
-
-	highpass-capture-be [
-		{
-			direction	"capture"
-			index 11
-			copier_type "ALH"
-
-			Object.Widget.copier.1 {
-				stream_name	$SDW_JACK_IN_STREAM
-				dai_type	"ALH"
-				copier_type	"ALH"
-				type		"dai_out"
-				node_type $ALH_LINK_INPUT_CLASS
-			}
-			Object.Widget.eqiir.1 {
-				Object.Control.bytes."1" {
-					name '4 Main capture Iir Eq'
-				}
-			}
-		}
-	]
+IncludeByKey.SDW_JACK {
+"true" "platform/intel/sdw-jack-generic.conf"
 }
 
-Object.PCM.pcm [
-	{
-		name	"Jack out"
-		id 0
-		direction	"playback"
-		Object.Base.fe_dai.1 {
-			name	"Jack out"
-		}
-
-		Object.PCM.pcm_caps.1 {
-			name "volume playback 0"
-			formats 'S16_LE,S32_LE'
-		}
-	}
-	{
-		name	"Jack in"
-		id 1
-		direction	"capture"
-		Object.Base.fe_dai.1 {
-			name	"Jack in"
-		}
-
-		Object.PCM.pcm_caps.1 {
-			name "Passthrough Capture 0"
-			formats 'S16_LE,S32_LE'
-		}
-	}
-]
-
-Object.Base.route [
-	{
-		source	"gain.1.1"
-		sink	"copier.ALH.1.1"
-	}
-	{
-		source "mixin.0.1"
-		sink "mixout.1.1"
-	}
-	{
-		source	"copier.ALH.11.1"
-		sink	"eqiir.11.1"
-	}
-	{
-		source	"eqiir.11.1"
-		sink	"copier.host.10.1"
-	}
-]

--- a/tools/topology/topology2/platform/intel/sdw-jack-generic.conf
+++ b/tools/topology/topology2/platform/intel/sdw-jack-generic.conf
@@ -1,0 +1,159 @@
+# include deep buffer config if buffer size is in 1 - 1000 ms.
+IncludeByKey.DEEPBUFFER_FW_DMA_MS{
+        "[1-1000]" "platform/intel/deep-buffer.conf"
+}
+
+#
+# List of all DAIs
+#
+Object.Dai.ALH [
+	{
+		dai_index 0
+		id 		$SDW_JACK_OUT_BE_ID
+		direction	"playback"
+		name		$SDW_JACK_OUT_STREAM
+		default_hw_conf_id	0
+		rate			48000
+		channels		2
+
+		Object.Base.hw_config.1 {
+			id	0
+			name	"ALH2"
+		}
+	}
+	{
+		dai_index 10
+		id 		$SDW_JACK_IN_BE_ID
+		direction	"capture"
+		name		$SDW_JACK_IN_STREAM
+		default_hw_conf_id	0
+		rate			48000
+		channels		2
+
+		Object.Base.hw_config.1 {
+			id	0
+			name	"ALH3"
+		}
+	}
+]
+
+#
+# Pipeline definitions
+#
+
+Object.Pipeline {
+	host-copier-gain-mixin-playback [
+		{
+			index 0
+
+		Object.Widget.copier.1 {
+			stream_name "volume playback 0"
+		}
+		Object.Widget.gain.1 {
+			Object.Control.mixer.1 {
+				name '1 Playback Volume 0'
+				}
+			}
+		}
+	]
+
+	mixout-gain-dai-copier-playback [
+		{
+			index 1
+
+			Object.Widget.copier.1 {
+				stream_name $SDW_JACK_OUT_STREAM
+				dai_type "ALH"
+				copier_type "ALH"
+				node_type $ALH_LINK_OUTPUT_CLASS
+			}
+			Object.Widget.gain.1 {
+				Object.Control.mixer.1 {
+					name '2 Main Playback Volume'
+				}
+			}
+		}
+	]
+
+	host-gateway-capture [
+		{
+			index 10
+
+			Object.Widget.copier.1.stream_name	"Passthrough Capture 0"
+			Object.Widget.copier.1.Object.Base.audio_format.1 {
+				# 32/32 -> 16/16 bits conversion is done here
+				in_bit_depth	32
+				in_valid_bit_depth	32
+			}
+		}
+	]
+
+	highpass-capture-be [
+		{
+			direction	"capture"
+			index 11
+			copier_type "ALH"
+
+			Object.Widget.copier.1 {
+				stream_name	$SDW_JACK_IN_STREAM
+				dai_type	"ALH"
+				copier_type	"ALH"
+				type		"dai_out"
+				node_type $ALH_LINK_INPUT_CLASS
+			}
+			Object.Widget.eqiir.1 {
+				Object.Control.bytes."1" {
+					name '4 Main capture Iir Eq'
+				}
+			}
+		}
+	]
+}
+
+Object.PCM.pcm [
+	{
+		name	"Jack out"
+		id 0
+		direction	"playback"
+		Object.Base.fe_dai.1 {
+			name	"Jack out"
+		}
+
+		Object.PCM.pcm_caps.1 {
+			name "volume playback 0"
+			formats 'S16_LE,S32_LE'
+		}
+	}
+	{
+		name	"Jack in"
+		id 1
+		direction	"capture"
+		Object.Base.fe_dai.1 {
+			name	"Jack in"
+		}
+
+		Object.PCM.pcm_caps.1 {
+			name "Passthrough Capture 0"
+			formats 'S16_LE,S32_LE'
+		}
+	}
+]
+
+Object.Base.route [
+	{
+		source	"gain.1.1"
+		sink	"copier.ALH.1.1"
+	}
+	{
+		source "mixin.0.1"
+		sink "mixout.1.1"
+	}
+	{
+		source	"copier.ALH.11.1"
+		sink	"eqiir.11.1"
+	}
+	{
+		source	"eqiir.11.1"
+		sink	"copier.host.10.1"
+	}
+]


### PR DESCRIPTION
We assume sdw jack is always there in a sdw topology. 
This commit make it be optional to deal with the sdw amp only case.