### PR TITLE
xtensa-build-zephyr.py: don't extract SOF_BUILD from generated .h file

### DIFF
--- a/scripts/cmake/version-build-counter.cmake
+++ b/scripts/cmake/version-build-counter.cmake
@@ -8,6 +8,10 @@ set(VERSION_BUILD_COUNTER_CMAKE_PATH ${CMAKE_CURRENT_LIST_DIR}/version-build-cou
 
 set(BUILD_COUNTER_PATH "${SOF_ROOT_BINARY_DIRECTORY}/.build")
 
+# Among many other differences, the Zephyr build does not invoke
+# sof_add_build_counter_rule() at build time. In other words, Zephyr has
+# never supported incrementing the BLD_COUNTERS: SOF_BUILD is always
+# equal to the starting value below when building with Zephyr.
 if(NOT EXISTS "${BUILD_COUNTER_PATH}")
 	file(WRITE "${BUILD_COUNTER_PATH}" "1")
 endif()


### PR DESCRIPTION
This replaces and simplifies commit a823958a8d2d3 ("xtensa-build-zephyr: pass sof build version to rimage") with a constant.

EDIT: That commit was submitted to avoid a test failure in a broken, internal
test looking for an SOF_BUILD value... hardcoded to 1! (internal FW issue
257, test TestLoadFwExtended::()::test_00_01_load_fw_and_check_version")

The final goal is for this script to stop extracting anything from `generated/sof_versions.h` so rimage can be configured _before_ the build has started. Other commits will deal with other parts of sof_versions.h

SOF_BUILD can be replaced by a constant because it has always been one when building with Zephyr. The optional BLD_COUNTERS feature - disabled by default in XTOS since commit 9f8cce152240 ("Disable __TIME__ and the non-reproducible build counter by default") for build reproducibility reasons - has never worked with Zephyr for the following reasons:

- The sof_add_build_counter_rule() invocation is located in the top-level sof/CMakeLists.txt file which has never been used by the Zephyr build.

- sof_add_build_counter_rule() registers a POST_BUILD command for the top-level "sof" CMake target but there is no "sof" build target in the Zephyr build.

- Variables like VERSION_BUILD_COUNTER_CMAKE_PATH are not defined in the Zephyr build for some unknown reason.

- Probably others.