### PR TITLE
[SKIP CI] .github: upgrade all checkout actions to v3

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -33,7 +33,7 @@ jobs:
       # depth 2 so:
       # ^1. we can show the Subject of the current target branch tip
       # ^2. we reconnect/graft to the later fetch pull/1234/head,
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with: {fetch-depth: 2}
 
       - name: install codespell
@@ -56,7 +56,7 @@ jobs:
   yamllint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: run yamllint
         # Quoting to please all parsers is hard. This indirection helps.

--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -28,7 +28,7 @@ jobs:
         ]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         # From time to time this will catch a git tag and change SOF_VERSION
         with: {fetch-depth: 50, submodules: recursive}
 

--- a/.github/workflows/repro-build.yml
+++ b/.github/workflows/repro-build.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with: {fetch-depth: 5, submodules: recursive}
 
       - name: docker pull

--- a/.github/workflows/testbench.yml
+++ b/.github/workflows/testbench.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with: {fetch-depth: 5}
 
       - name: apt get

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -12,7 +12,7 @@ jobs:
   top-level_default_CMake_target_ALL:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # The ALSA version in Ubuntu 20.04 is buggy
       # (https://github.com/thesofproject/sof/issues/2543) and likely

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,7 +14,7 @@ jobs:
   cmocka_utests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with: {fetch-depth: 2}
 
       - name: build and run all defconfigs


### PR DESCRIPTION
Search and replace checkout@v2 with checkout@v3.

This finally gets rid of all warnings "Node.js 12 actions are deprecated".

We've been using v3 in a few other places and never met any backwards compatibility issue.