### PR TITLE
[SKIP CI] sof_builder/Dockerfile: restore deleted toolchains

### DIFF
--- a/scripts/docker_build/sof_builder/Dockerfile
+++ b/scripts/docker_build/sof_builder/Dockerfile
@@ -93,7 +93,7 @@ RUN cd "$HOME" && \
 	git clone $CLONE_DEFAULTS --branch sof-gcc10x $CT_NG_REPO && \
 	cd crosstool-ng && \
 	./bootstrap && ./configure --prefix=`pwd` && make && make install && \
-	for arch in cnl imx imx8m imx8ulp rn rmb mt8186 mt8195; do \
+	for arch in byt hsw apl cnl imx imx8m imx8ulp rn rmb mt8186 mt8195; do \
 		echo "$arch: ct-ng build start..." && \
 		cp config-${arch}-gcc10.2-gdb9 .config && \
 		# replace the build dist to save space
@@ -104,6 +104,9 @@ RUN cd "$HOME" && \
 	done && \
 	echo "Stage2: xtensa-overlay, crosstool-ng are done!"
 
+ENV PATH="/home/sof/work/xtensa-byt-elf/bin:${PATH}"
+ENV PATH="/home/sof/work/xtensa-hsw-elf/bin:${PATH}"
+ENV PATH="/home/sof/work/xtensa-apl-elf/bin:${PATH}"
 ENV PATH="/home/sof/work/xtensa-cnl-elf/bin:${PATH}"
 ENV PATH="/home/sof/work/xtensa-rn-elf/bin:${PATH}"
 ENV PATH="/home/sof/work/xtensa-rmb-elf/bin:${PATH}"
@@ -117,7 +120,7 @@ ARG NEWLIB_REPO=https://github.com/jcmvbkbc/newlib-xtensa.git
 RUN cd "$HOME" && \
 	git clone $CLONE_DEFAULTS --branch xtensa $NEWLIB_REPO && \
 	cd newlib-xtensa && \
-	for arch in cnl imx imx8m imx8ulp rn rmb mt8186 mt8195; do \
+	for arch in byt hsw apl cnl imx imx8m imx8ulp rn rmb mt8186 mt8195; do \
 		./configure --target=xtensa-${arch}-elf \
 		--prefix=/home/sof/work/xtensa-root && \
 		make && make install && \


### PR DESCRIPTION
Building a Docker image takes several hours. To reduce costs and save time we don't want to maintain a different Docker image for the stable-v2.2 branch. Restore toolchains that were accidentally removed from the Dockerfile because this will unnecessarily paint red every PR submitted to the stable-v2.2 branch, example:

https://github.com/thesofproject/sof/actions/runs/4867162042/jobs/8679468096

If we want to stop supporting something then let's keep things simple and remove it only where it actually gets in the way and where it actually becomes a problem. No need to search and scrub every reference to it from the face of the planet and accidentally make our life harder on release branches, create pointless git conflicts and _increase_ maintenance costs when trying to reduce them!