### PR TITLE
[SKIP SOF-TEST] .github: upgrade most runners to latest Ubuntu 22.04

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -16,7 +16,7 @@ on: [pull_request]
 
 jobs:
   checkpatch:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -17,7 +17,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   checktree:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -118,7 +118,7 @@ jobs:
 
 
   gcc-build-only:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false
@@ -154,7 +154,7 @@ jobs:
   # duplication.
 
   qemu-boot-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/repro-build.yml
+++ b/.github/workflows/repro-build.yml
@@ -16,7 +16,7 @@ on: [pull_request]
 
 jobs:
   main:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Let's not fall behind.

Ubuntu 22.04 is the latest runner offered by Github: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners