### PR TITLE
Preparation for multi-endpoint copier optimization

### DIFF
--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -1077,9 +1077,8 @@ static int copier_reset(struct comp_dev *dev)
 			dai_zephyr_reset(cd->dd[0], dev);
 		} else {
 			for (i = 0; i < cd->endpoint_num; i++) {
-				ret = cd->endpoint[i]->drv->ops.reset(cd->endpoint[i]);
-				if (ret < 0)
-					break;
+				dai_zephyr_reset(cd->dd[i], cd->endpoint[i]);
+				comp_set_state(cd->endpoint[i], COMP_TRIGGER_RESET);
 			}
 		}
 		break;

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -1727,7 +1727,7 @@ static int copier_params(struct comp_dev *dev, struct sof_ipc_stream_params *par
 			demuxed_params.channels = audio_stream_get_channels(&buf_c->stream);
 			buffer_release(buf_c);
 
-			ret = cd->endpoint[i]->drv->ops.params(cd->endpoint[i], &demuxed_params);
+			ret = dai_zephyr_params(cd->dd[i], cd->endpoint[i], &demuxed_params);
 			break;
 		}
 		default:

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -819,7 +819,9 @@ static void copier_free(struct comp_dev *dev)
 			rfree(cd->dd[0]);
 		} else {
 			for (i = 0; i < cd->endpoint_num; i++) {
-				cd->endpoint[i]->drv->ops.free(cd->endpoint[i]);
+				dai_zephyr_free(cd->dd[i]);
+				rfree(cd->dd[i]);
+				rfree(cd->endpoint[i]);
 				buffer_free(cd->endpoint_buffer[i]);
 			}
 		}

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -966,12 +966,6 @@ static int copier_prepare(struct comp_dev *dev)
 		return 0;
 	}
 
-	if (dev->ipc_config.type == SOF_COMP_DAI && cd->endpoint_num == 1) {
-		ret = dai_zephyr_config_prepare(cd->dd[0], dev);
-		if (ret < 0)
-			return ret;
-	}
-
 	ret = comp_set_state(dev, COMP_TRIGGER_PREPARE);
 	if (ret < 0)
 		return ret;
@@ -989,6 +983,10 @@ static int copier_prepare(struct comp_dev *dev)
 		break;
 	case SOF_COMP_DAI:
 		if (cd->endpoint_num == 1) {
+			ret = dai_zephyr_config_prepare(cd->dd[0], dev);
+			if (ret < 0)
+				return ret;
+
 			ret = dai_zephyr_prepare(cd->dd[0], dev);
 			if (ret < 0)
 				return ret;

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -992,7 +992,18 @@ static int copier_prepare(struct comp_dev *dev)
 				return ret;
 		} else {
 			for (i = 0; i < cd->endpoint_num; i++) {
-				ret = cd->endpoint[i]->drv->ops.prepare(cd->endpoint[i]);
+				ret = comp_set_state(cd->endpoint[i], COMP_TRIGGER_PREPARE);
+				if (ret < 0)
+					return ret;
+
+				if (ret == COMP_STATUS_STATE_ALREADY_SET)
+					return PPL_STATUS_PATH_STOP;
+
+				ret = dai_zephyr_config_prepare(cd->dd[i], cd->endpoint[i]);
+				if (ret < 0)
+					return ret;
+
+				ret = dai_zephyr_prepare(cd->dd[i], cd->endpoint[i]);
 				if (ret < 0)
 					return ret;
 			}


### PR DESCRIPTION
No change in functionality, just preparatory patches to remove the creation of DAI devices and endpoint buffers for the multi-endpoint DAI copier.