### PR TITLE
host-zephyr: No need to call dma_sg_free() twice

### DIFF
--- a/src/audio/host-zephyr.c
+++ b/src/audio/host-zephyr.c
@@ -666,7 +666,6 @@ void host_zephyr_free(struct host_data *hd)
 	dma_put(hd->dma);
 
 	ipc_msg_free(hd->msg);
-	dma_sg_free(&hd->config.elem_array);
 }
 
 static void host_free(struct comp_dev *dev)


### PR DESCRIPTION
It is called during reset already. No need to invoke it again during free.