### PR TITLE
Remove ipcgtw device to align with host and dai usage

### DIFF
--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -1090,11 +1090,8 @@ static int copier_reset(struct comp_dev *dev)
 		if (!cd->ipc_gtw) {
 			host_zephyr_reset(cd->hd, dev->state);
 		} else {
-			for (i = 0; i < cd->endpoint_num; i++) {
-				ret = cd->endpoint[i]->drv->ops.reset(cd->endpoint[i]);
-				if (ret < 0)
-					break;
-			}
+			ipcgtw_zephyr_reset(cd->endpoint[0]);
+			comp_set_state(cd->endpoint[0], COMP_TRIGGER_RESET);
 		}
 		break;
 	case SOF_COMP_DAI:
@@ -1745,8 +1742,9 @@ static int copier_params(struct comp_dev *dev, struct sof_ipc_stream_params *par
 					cd->hd->process = cd->converter[IPC4_COPIER_GATEWAY_PIN];
 				} else {
 					/* handle gtw case */
-					ret = cd->endpoint[i]->drv->ops.params(cd->endpoint[i],
-									       params);
+					ret = ipcgtw_zephyr_params(cd->ipcgtw_data,
+								   cd->endpoint[i],
+								   params);
 				}
 				break;
 			case SOF_COMP_DAI:

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -1009,12 +1009,13 @@ static int copier_prepare(struct comp_dev *dev)
 			if (ret < 0)
 				return ret;
 		} else {
-			/* handle gtw case */
-			for (i = 0; i < cd->endpoint_num; i++) {
-				ret = cd->endpoint[i]->drv->ops.prepare(cd->endpoint[i]);
-				if (ret < 0)
-					return ret;
-			}
+			/* nothing to do for ipcgtw case, except for set state */
+			ret = comp_set_state(cd->endpoint[0], COMP_TRIGGER_PREPARE);
+			if (ret < 0)
+				return ret;
+
+			if (ret == COMP_STATUS_STATE_ALREADY_SET)
+				return PPL_STATUS_PATH_STOP;
 		}
 		break;
 	case SOF_COMP_DAI:
@@ -1154,12 +1155,13 @@ static int copier_comp_trigger(struct comp_dev *dev, int cmd)
 			if (ret < 0)
 				return ret;
 		} else {
-			/* handle gtw case */
-			for (i = 0; i < cd->endpoint_num; i++) {
-				ret = cd->endpoint[i]->drv->ops.trigger(cd->endpoint[i], cmd);
-				if (ret < 0)
-					return ret;
-			}
+			/* nothing to do for ipcgtw case, except for set state */
+			ret = comp_set_state(cd->endpoint[0], cmd);
+			if (ret < 0)
+				return ret;
+
+			if (ret == COMP_STATUS_STATE_ALREADY_SET)
+				return PPL_STATUS_PATH_STOP;
 		}
 		break;
 	case SOF_COMP_DAI:

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -1417,7 +1417,7 @@ static int do_endpoint_copy(struct comp_dev *dev)
 		default:
 			break;
 		}
-		return cd->endpoint[0]->drv->ops.copy(cd->endpoint[0]);
+		return 0;
 	}
 }
 

--- a/src/audio/ipcgtw.c
+++ b/src/audio/ipcgtw.c
@@ -260,12 +260,12 @@ static int ipcgtw_copy(struct comp_dev *dev)
 	return 0;
 }
 
-static int ipcgtw_params(struct comp_dev *dev, struct sof_ipc_stream_params *params)
+static int ipcgtw_zephyr_params(struct ipcgtw_data *ipcgtw_data, struct comp_dev *dev,
+				struct sof_ipc_stream_params *params)
 {
 	struct comp_buffer *buf;
 	struct comp_buffer __sparse_cache *buf_c;
 	int err;
-	struct ipcgtw_data *ipcgtw_data = comp_get_drvdata(dev);
 
 	comp_cl_dbg(&comp_ipcgtw, "ipcgtw_params()");
 
@@ -287,6 +287,13 @@ static int ipcgtw_params(struct comp_dev *dev, struct sof_ipc_stream_params *par
 	}
 
 	return 0;
+}
+
+static int ipcgtw_params(struct comp_dev *dev, struct sof_ipc_stream_params *params)
+{
+	struct ipcgtw_data *ipcgtw_data = comp_get_drvdata(dev);
+
+	return ipcgtw_zephyr_params(ipcgtw_data, dev, params);
 }
 
 static int ipcgtw_trigger(struct comp_dev *dev, int cmd)

--- a/src/audio/ipcgtw.c
+++ b/src/audio/ipcgtw.c
@@ -321,7 +321,7 @@ static int ipcgtw_prepare(struct comp_dev *dev)
 	return 0;
 }
 
-static int ipcgtw_reset(struct comp_dev *dev)
+static void ipcgtw_zephyr_reset(struct comp_dev *dev)
 {
 	struct comp_buffer *buf = get_buffer(dev);
 
@@ -333,6 +333,11 @@ static int ipcgtw_reset(struct comp_dev *dev)
 	} else {
 		comp_cl_warn(&comp_ipcgtw, "ipcgtw_reset(): no buffer found");
 	}
+}
+
+static int ipcgtw_reset(struct comp_dev *dev)
+{
+	ipcgtw_zephyr_reset(dev);
 
 	comp_set_state(dev, COMP_TRIGGER_RESET);
 

--- a/src/audio/ipcgtw.c
+++ b/src/audio/ipcgtw.c
@@ -10,6 +10,7 @@
 #include <rtos/init.h>
 #include <ipc4/ipcgtw.h>
 #include <ipc4/copier.h>
+#include <sof/audio/ipcgtw_copier.h>
 
 static const struct comp_driver comp_ipcgtw;
 
@@ -21,27 +22,12 @@ DECLARE_SOF_RT_UUID("ipcgw", ipcgtw_comp_uuid, 0xa814a1ca, 0x0b83, 0x466c,
 
 DECLARE_TR_CTX(ipcgtw_comp_tr, SOF_UUID(ipcgtw_comp_uuid), LOG_LEVEL_INFO);
 
-/* Host communicates with IPC gateways via global IPC messages. To address a particular
- * IPC gateway, its node_id is sent in message payload. Hence we need to keep a list of existing
- * IPC gateways and their node_ids to search for a gateway host wants to address.
- */
-struct ipcgtw_data {
-	union ipc4_connector_node_id node_id;
-	struct comp_dev *dev;
-	struct list_item item;
-
-	/* IPC gateway buffer size comes in blob at creation time, we keep size here
-	 * to resize buffer later at ipcgtw_params().
-	 */
-	uint32_t buf_size;
-};
-
 /* List of existing IPC gateways */
 static struct list_item ipcgtw_list_head = LIST_INIT(ipcgtw_list_head);
 
-static void ipcgtw_zephyr_new(struct ipcgtw_data *ipcgtw_data,
-			      const struct ipc4_copier_gateway_cfg *gtw_cfg,
-			      struct comp_dev *dev)
+void ipcgtw_zephyr_new(struct ipcgtw_data *ipcgtw_data,
+		       const struct ipc4_copier_gateway_cfg *gtw_cfg,
+		       struct comp_dev *dev)
 {
 	const struct ipc4_ipc_gateway_config_blob *blob;
 
@@ -94,7 +80,7 @@ static struct comp_dev *ipcgtw_new(const struct comp_driver *drv,
 	return dev;
 }
 
-static void ipcgtw_zephyr_free(struct ipcgtw_data *ipcgtw_data)
+void ipcgtw_zephyr_free(struct ipcgtw_data *ipcgtw_data)
 {
 	list_item_del(&ipcgtw_data->item);
 	rfree(ipcgtw_data);

--- a/src/audio/ipcgtw.c
+++ b/src/audio/ipcgtw.c
@@ -94,13 +94,17 @@ static struct comp_dev *ipcgtw_new(const struct comp_driver *drv,
 	return dev;
 }
 
+static void ipcgtw_zephyr_free(struct ipcgtw_data *ipcgtw_data)
+{
+	list_item_del(&ipcgtw_data->item);
+	rfree(ipcgtw_data);
+}
+
 static void ipcgtw_free(struct comp_dev *dev)
 {
 	struct ipcgtw_data *ipcgtw_data = comp_get_drvdata(dev);
 
-	list_item_del(&ipcgtw_data->item);
-
-	rfree(ipcgtw_data);
+	ipcgtw_zephyr_free(ipcgtw_data);
 	rfree(dev);
 }
 

--- a/src/audio/ipcgtw.c
+++ b/src/audio/ipcgtw.c
@@ -260,8 +260,8 @@ static int ipcgtw_copy(struct comp_dev *dev)
 	return 0;
 }
 
-static int ipcgtw_zephyr_params(struct ipcgtw_data *ipcgtw_data, struct comp_dev *dev,
-				struct sof_ipc_stream_params *params)
+int ipcgtw_zephyr_params(struct ipcgtw_data *ipcgtw_data, struct comp_dev *dev,
+			 struct sof_ipc_stream_params *params)
 {
 	struct comp_buffer *buf;
 	struct comp_buffer __sparse_cache *buf_c;
@@ -328,7 +328,7 @@ static int ipcgtw_prepare(struct comp_dev *dev)
 	return 0;
 }
 
-static void ipcgtw_zephyr_reset(struct comp_dev *dev)
+void ipcgtw_zephyr_reset(struct comp_dev *dev)
 {
 	struct comp_buffer *buf = get_buffer(dev);
 

--- a/src/include/ipc4/copier.h
+++ b/src/include/ipc4/copier.h
@@ -265,6 +265,7 @@ struct copier_data {
 	struct host_data *hd;
 	bool ipc_gtw;
 	struct dai_data *dd[IPC4_ALH_MAX_NUMBER_OF_GTW];
+	struct ipcgtw_data *ipcgtw_data;
 };
 
 int apply_attenuation(struct comp_dev *dev, struct copier_data *cd,

--- a/src/include/sof/audio/ipcgtw_copier.h
+++ b/src/include/sof/audio/ipcgtw_copier.h
@@ -41,4 +41,9 @@ void ipcgtw_zephyr_new(struct ipcgtw_data *ipcgtw_data,
 
 void ipcgtw_zephyr_free(struct ipcgtw_data *ipcgtw_data);
 
+int ipcgtw_zephyr_params(struct ipcgtw_data *ipcgtw_data, struct comp_dev *dev,
+			 struct sof_ipc_stream_params *params);
+
+void ipcgtw_zephyr_reset(struct comp_dev *dev);
+
 #endif /* __SOF_IPCGTW_COPIER_H__ */

--- a/src/include/sof/audio/ipcgtw_copier.h
+++ b/src/include/sof/audio/ipcgtw_copier.h
@@ -1,0 +1,44 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2023 Intel Corporation. All rights reserved.
+ *
+ * Author: Baofeng Tian <baofeng.tian@intel.com>
+ */
+
+/**
+ * \file audio/ipcgtw_copier.h
+ * \brief ipcgtw copier shared header file
+ * \authors Baofeng Tian <baofeng.tian@intel.com>
+ */
+
+#ifndef __SOF_IPCGTW_COPIER_H__
+#define __SOF_IPCGTW_COPIER_H__
+
+#include <sof/audio/component_ext.h>
+#include <ipc4/gateway.h>
+#include <sof/list.h>
+#include <ipc/stream.h>
+
+/* Host communicates with IPC gateways via global IPC messages. To address a particular
+ * IPC gateway, its node_id is sent in message payload. Hence we need to keep a list of existing
+ * IPC gateways and their node_ids to search for a gateway host wants to address.
+ */
+struct ipcgtw_data {
+	union ipc4_connector_node_id node_id;
+	struct comp_dev *dev;
+	struct list_item item;
+
+	/* IPC gateway buffer size comes in blob at creation time, we keep size here
+	 * to resize buffer later at ipcgtw_params().
+	 */
+	uint32_t buf_size;
+};
+
+struct ipc4_copier_gateway_cfg;
+void ipcgtw_zephyr_new(struct ipcgtw_data *ipcgtw_data,
+		       const struct ipc4_copier_gateway_cfg *gtw_cfg,
+		       struct comp_dev *dev);
+
+void ipcgtw_zephyr_free(struct ipcgtw_data *ipcgtw_data);
+
+#endif /* __SOF_IPCGTW_COPIER_H__ */


### PR DESCRIPTION
With #6951, #7530, #7554 merged, host and dai device and endpoint buffer got removed from copier, this can save memory and mcps.

For ipc gateway, due to there is no extra copy, only copy from input to endpoint buffer, so buffer can't be removed, only device got removed.

With this patch, below purpose are met:
1. ipcgtw device removed, 112 bytes saved for each ipcgtw.
2. aligned usage model with host and dai.
3. prepare for upcoming copier modulization work.