### PR TITLE
peakvol: correct volume processing function

### DIFF
--- a/src/audio/module_adapter/module/volume/volume_hifi3_with_peakvol.c
+++ b/src/audio/module_adapter/module/volume/volume_hifi3_with_peakvol.c
@@ -114,7 +114,7 @@ static void vol_s24_to_s24_s32(struct processing_module *mod, struct input_strea
 #if COMP_VOLUME_Q8_16
 			out_sample = AE_MULFP32X2RS(AE_SLAI32S(volume, 7), AE_SLAI32(in_sample, 8));
 #elif COMP_VOLUME_Q1_23
-			out_sample = AE_MULFP32X2RS(volume, AE_SLAI32S(in_sample, 8));
+			out_sample = AE_MULFP32X2RS(volume, AE_SLAI32(in_sample, 8));
 #else
 #error "Need CONFIG_COMP_VOLUME_Qx_y"
 #endif


### PR DESCRIPTION
When calculating the out_sample value,
the AE_SLAI32S function is used,
which rounds the result to the value 1/(-1),
resulting in a rectangular signal.