### PR TITLE
cpc: make CPC data "opt-in" with fallback

### DIFF
--- a/src/audio/pipeline/pipeline-stream.c
+++ b/src/audio/pipeline/pipeline-stream.c
@@ -296,13 +296,15 @@ static int add_pipeline_cps_consumption(struct comp_dev *current,
 		cd = &md->cfg.base_cfg;
 	}
 
-	int kcps = cd->cpc * 1000 / ppl_data->p->period;
-	if (kcps == 0) {
-		tr_warn(pipe, "0 KCPS for module: %#x, core: %d", current->ipc_config.id, ppl_data->p->core);
-	} else {
-		core_kcps_adjust(ppl_data->p->core, kcps);
-		tr_info(pipe, "Registering KCPS consumption: %d, core: %d", kcps, ppl_data->p->core);
+	if (cd->cpc == 0) {
+		cd->cpc = PLATFORM_IPC4_MAX_CPC;
+		tr_warn(pipe, "0 CPS requested for module: %#x, core: %d using safe max CPC: %d",
+			current->ipc_config.id, ppl_data->p->core, cd->cpc);
 	}
+	int kcps = cd->cpc * 1000 / ppl_data->p->period;
+
+	core_kcps_adjust(ppl_data->p->core, kcps);
+	tr_info(pipe, "Registering KCPS consumption: %d, core: %d", kcps, ppl_data->p->core);
 
 	int summary_cps = core_kcps_get(ppl_data->p->core);
 	tr_info(pipe, "Sum of KCPS consumption: %d, core: %d", summary_cps, ppl_data->p->core);

--- a/src/platform/intel/ace/include/ace/lib/cpu.h
+++ b/src/platform/intel/ace/include/ace/lib/cpu.h
@@ -16,6 +16,9 @@
 /** \brief Id of primary DSP core */
 #define PLATFORM_PRIMARY_CORE_ID	0
 
+/** \brief Maximum CPC used y this platform with IPC4 module */
+#define PLATFORM_IPC4_MAX_CPC	400000	/* based on max 400M clk and 1ms period */
+
 #endif /* __ACE_LIB_CPU_H__ */
 
 #else


### PR DESCRIPTION
CPC is used to select the correct clock for the desired pipeline workload.

In the case where the CPC data is not available from the manifest and the kernel driver sends a CPC of 0 then SOF should pick a platform safe level to ensure operational glitch free audio at the expense of power consumption. i.e. it's better to prioritize and preserve audio quality over audio power when CPC data is missing.