### PR TITLE
cadence: enable processing with ipc4 protocol

### DIFF
--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -115,6 +115,7 @@ struct comp_dev *module_adapter_new(const struct comp_driver *drv,
 
 		dst->init_data = ipc_module_adapter->data;
 		dst->size = ipc_module_adapter->size;
+		dst->avail = true;
 
 		memcpy(&dst->base_cfg, ipc_module_adapter->data, sizeof(dst->base_cfg));
 	} else {

--- a/src/include/sof/audio/module_adapter/module/cadence.h
+++ b/src/include/sof/audio/module_adapter/module/cadence.h
@@ -48,4 +48,12 @@ struct cadence_codec_data {
 	struct module_config setup_cfg;
 };
 
+#if CONFIG_IPC_MAJOR_4
+struct ipc4_cadence_module_cfg {
+	struct ipc4_base_module_cfg base_cfg;
+	uint32_t param_size;
+	struct module_param param[];
+} __packed __aligned(4);
+#endif
+
 #endif /* __SOF_AUDIO_CADENCE_CODEC__ */


### PR DESCRIPTION
Maintain codec configuration initialization for ipc4 protocol in cadence
module by separation critical functions into ipc3/ipc4 versions

Changes affect:
- different size of init/runtime config allocation
- resolving codec id from configuration from configuration params for ipc4