### PR TITLE
fix: zephyr logging macro comp_cl_err accesses const struct member

### DIFF
--- a/src/audio/ipcgtw.c
+++ b/src/audio/ipcgtw.c
@@ -180,8 +180,9 @@ int ipcgtw_process_cmd(const struct ipc4_ipcgtw_cmd *cmd,
 
 	dev = find_ipcgtw_by_node_id(in->node_id);
 	if (!dev) {
+		uint32_t nodeid_connector_val = in->node_id.dw;
 		comp_cl_err(&comp_ipcgtw, "ipcgtw_process_cmd(): node_id not found: %x",
-			    in->node_id.dw);
+			    nodeid_connector_val);
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
Zephyr logging macro comp_cl_err expands to many different logging frameworks depending on log configuration selected (possible z_log_minimal_printk, z_log_printf_arg_checker, cbprintf_package or even syscalls). There is no warranty that a format specifier passed as argument to %x will not be modified. Constant struct members should not be passed to this logging macro. Fixed by provoding macro with value copy.