### PR TITLE
topology2: cavs-nocodec-multicore: run DMIC pipelines on core1

### DIFF
--- a/tools/topology/topology2/cavs-nocodec-multicore.conf
+++ b/tools/topology/topology2/cavs-nocodec-multicore.conf
@@ -18,6 +18,7 @@
 <gain-module-copier.conf>
 <gain-capture.conf>
 <gain-copier-capture.conf>
+<dai-copier-eqiir-module-copier-capture.conf>
 <mixout-mixin.conf>
 <data.conf>
 <pcm.conf>
@@ -47,6 +48,19 @@ Define {
 	SSP0_CORE_ID	0
 	SSP1_CORE_ID	1
 	SSP2_CORE_ID	2
+
+	NUM_DMICS			0
+	# override DMIC default definitions
+	DMIC0_HOST_PIPELINE_ID		20
+	DMIC0_DAI_PIPELINE_ID		21
+	DMIC0_HOST_PIPELINE_SINK	'gain.20.1'
+	DMIC0_DAI_PIPELINE_SRC		'module-copier.21.2'
+	DMIC0_DAI_COPIER		'dai-copier.DMIC.NoCodec-6.capture'
+	DMIC0_DAI_GAIN			'eqiir.21.1'
+	DMIC0_PCM_CAPS			'Gain Capture 20'
+	DMIC1_PCM_CAPS			'DMIC1 WOV Capture'
+	DMIC0_NAME			'NoCodec-6'
+	DMIC1_NAME			'NoCodec-7'
 }
 
 # override defaults with platform-specific config
@@ -54,6 +68,11 @@ IncludeByKey.PLATFORM {
 	"tgl"	"platform/intel/tgl.conf"
 	"adl"	"platform/intel/tgl.conf"
 	"mtl"	"platform/intel/mtl.conf"
+}
+
+# include DMIC config if needed.
+IncludeByKey.NUM_DMICS {
+	"[1-4]"	"platform/intel/dmic-generic.conf"
 }
 
 #

--- a/tools/topology/topology2/development/tplg-targets.cmake
+++ b/tools/topology/topology2/development/tplg-targets.cmake
@@ -46,6 +46,10 @@ SSP1_CORE_ID=1,SSP2_CORE_ID=2,PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-mtl-noco
 "cavs-nocodec-multicore\;sof-mtl-nocodec-multicore-ssp0-ssp2\;PLATFORM=mtl,SSP1_ENABLED=false,\
 SSP2_CORE_ID=1,PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-mtl-nocodec.bin"
 
+"cavs-nocodec-multicore\;sof-mtl-nocodec-multicore-4ch\;PLATFORM=mtl,SSP1_ENABLED=false,\
+SSP0_CORE_ID=0,DMIC_CORE_ID=1,SSP2_CORE_ID=2,NUM_DMICS=4,PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,\
+PASSTHROUGH=true,PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-mtl-nocodec.bin"
+
 # SSP topology for LNL FPGA with lower DMIC IO clock of 19.2MHz, 2ch PDM1 enabled
 "cavs-nocodec\;sof-lnl-nocodec-fpga-2ch-pdm1\;PLATFORM=lnl,NUM_DMICS=2,PDM1_MIC_A_ENABLE=1,\
 PDM1_MIC_B_ENABLE=1,PDM0_MIC_A_ENABLE=0,PDM0_MIC_B_ENABLE=0,PREPROCESS_PLUGINS=nhlt,\


### PR DESCRIPTION
For MTL platform, config DMIC pipeline on coreX for CI test.