### PR TITLE
audio: buffer: Realloc buffer with alignment

### DIFF
--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -587,7 +587,7 @@ int dai_zephyr_params(struct dai_data *dd, struct comp_dev *dev,
 	/* alloc DMA buffer or change its size if exists */
 	if (dd->dma_buffer) {
 		buffer_c = buffer_acquire(dd->dma_buffer);
-		err = buffer_set_size(buffer_c, buffer_size);
+		err = buffer_set_size(buffer_c, buffer_size, addr_align);
 		buffer_release(buffer_c);
 
 		if (err < 0) {

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -840,7 +840,7 @@ int dai_zephyr_params(struct dai_data *dd, struct comp_dev *dev,
 	/* alloc DMA buffer or change its size if exists */
 	if (dd->dma_buffer) {
 		buffer_c = buffer_acquire(dd->dma_buffer);
-		err = buffer_set_size(buffer_c, buffer_size);
+		err = buffer_set_size(buffer_c, buffer_size, addr_align);
 		buffer_release(buffer_c);
 
 		if (err < 0) {

--- a/src/audio/host-legacy.c
+++ b/src/audio/host-legacy.c
@@ -779,7 +779,7 @@ int host_zephyr_params(struct host_data *hd, struct comp_dev *dev,
 	 */
 	if (hd->dma_buffer) {
 		dma_buf_c = buffer_acquire(hd->dma_buffer);
-		err = buffer_set_size(dma_buf_c, buffer_size);
+		err = buffer_set_size(dma_buf_c, buffer_size, addr_align);
 		buffer_release(dma_buf_c);
 		if (err < 0) {
 			comp_err(dev, "host_params(): buffer_set_size() failed, buffer_size = %u",

--- a/src/audio/host-zephyr.c
+++ b/src/audio/host-zephyr.c
@@ -823,7 +823,7 @@ int host_zephyr_params(struct host_data *hd, struct comp_dev *dev,
 	 */
 	if (hd->dma_buffer) {
 		dma_buf_c = buffer_acquire(hd->dma_buffer);
-		err = buffer_set_size(dma_buf_c, buffer_size);
+		err = buffer_set_size(dma_buf_c, buffer_size, addr_align);
 		buffer_release(dma_buf_c);
 		if (err < 0) {
 			comp_err(dev, "host_params(): buffer_set_size() failed, buffer_size = %u",

--- a/src/audio/ipcgtw.c
+++ b/src/audio/ipcgtw.c
@@ -279,7 +279,7 @@ static int ipcgtw_params(struct comp_dev *dev, struct sof_ipc_stream_params *par
 
 	/* resize buffer to size specified in IPC gateway config blob */
 	buf_c = buffer_acquire(buf);
-	err = buffer_set_size(buf_c, ipcgtw_data->buf_size);
+	err = buffer_set_size(buf_c, ipcgtw_data->buf_size, 0);
 	buffer_release(buf_c);
 
 	if (err < 0) {

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -376,7 +376,7 @@ int module_adapter_prepare(struct comp_dev *dev)
 								  sink_list);
 
 			buffer_c = buffer_acquire(buffer);
-			ret = buffer_set_size(buffer_c, buff_size);
+			ret = buffer_set_size(buffer_c, buff_size, 0);
 			if (ret < 0) {
 				buffer_release(buffer_c);
 				comp_err(dev, "module_adapter_prepare(): buffer_set_size() failed, buff_size = %u",

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -191,7 +191,7 @@ struct buffer_cb_free {
 /* pipeline buffer creation and destruction */
 struct comp_buffer *buffer_alloc(uint32_t size, uint32_t caps, uint32_t flags, uint32_t align);
 struct comp_buffer *buffer_new(const struct sof_ipc_buffer *desc);
-int buffer_set_size(struct comp_buffer __sparse_cache *buffer, uint32_t size);
+int buffer_set_size(struct comp_buffer __sparse_cache *buffer, uint32_t size, uint32_t alignment);
 void buffer_free(struct comp_buffer *buffer);
 void buffer_zero(struct comp_buffer __sparse_cache *buffer);
 

--- a/tools/testbench/file.c
+++ b/tools/testbench/file.c
@@ -722,7 +722,7 @@ static int file_params(struct comp_dev *dev,
 	samples = periods * dev->frames * stream->channels;
 	switch (stream->frame_fmt) {
 	case SOF_IPC_FRAME_S16_LE:
-		ret = buffer_set_size(buffer, samples * sizeof(int16_t));
+		ret = buffer_set_size(buffer, samples * sizeof(int16_t), 0);
 		if (ret < 0) {
 			fprintf(stderr, "error: file buffer size set\n");
 			return ret;
@@ -732,7 +732,7 @@ static int file_params(struct comp_dev *dev,
 		cd->file_func = file_s16;
 		break;
 	case SOF_IPC_FRAME_S24_4LE:
-		ret = buffer_set_size(buffer, samples * sizeof(int32_t));
+		ret = buffer_set_size(buffer, samples * sizeof(int32_t), 0);
 		if (ret < 0) {
 			fprintf(stderr, "error: file buffer size set\n");
 			return ret;
@@ -742,7 +742,7 @@ static int file_params(struct comp_dev *dev,
 		cd->file_func = file_s24;
 		break;
 	case SOF_IPC_FRAME_S32_LE:
-		ret = buffer_set_size(buffer, samples * sizeof(int32_t));
+		ret = buffer_set_size(buffer, samples * sizeof(int32_t), 0);
 		if (ret < 0) {
 			fprintf(stderr, "error: file buffer size set\n");
 			return ret;


### PR DESCRIPTION
When the DMA buffer is reallocated pass the alignment argument to honor the buffer address alignment that was used originally. Update the buffer_set_size() to pass the requested alignment and all its users. This is particularly needed in the case of host and DAI DMA buffers that query the buffer address alignment from the DMA driver while allocating the DMA buffers.