### PR TITLE
Dummy smart_amp: copy input_pins and output_pin separately

### DIFF
--- a/src/samples/audio/smart_amp_test_ipc4.c
+++ b/src/samples/audio/smart_amp_test_ipc4.c
@@ -44,7 +44,8 @@ static int smart_amp_init(struct processing_module *mod)
 	struct smart_amp_data *sad;
 	struct comp_dev *dev = mod->dev;
 	struct module_data *mod_data = &mod->priv;
-	int bs;
+	const size_t in_size = sizeof(struct ipc4_input_pin_format) * SMART_AMP_NUM_IN_PINS;
+	const size_t out_size = sizeof(struct ipc4_output_pin_format) * SMART_AMP_NUM_OUT_PINS;
 	int ret;
 	const struct ipc4_base_module_extended_cfg *base_cfg = mod_data->cfg.init_data;
 
@@ -70,9 +71,10 @@ static int smart_amp_init(struct processing_module *mod)
 	}
 
 	/* Copy the pin formats */
-	bs = sizeof(sad->ipc4_cfg.input_pins) + sizeof(sad->ipc4_cfg.output_pin);
-	memcpy_s(sad->ipc4_cfg.input_pins, bs,
-		 base_cfg->base_cfg_ext.pin_formats, bs);
+	memcpy_s(sad->ipc4_cfg.input_pins, in_size,
+		 base_cfg->base_cfg_ext.pin_formats, in_size);
+	memcpy_s(&sad->ipc4_cfg.output_pin, out_size,
+		 &base_cfg->base_cfg_ext.pin_formats[in_size], out_size);
 
 	mod->simple_copy = true;
 


### PR DESCRIPTION
The original code confuses static code analyzers since it was
relying on the fact that we have the 2x input and 1x output pin
config in adjacent position in smart_amp_data struct similarly
to the extended module configuration.

While it works, it is not a good practice.

Split the copy of input and output pin formats to make the code
obvious and less error prone.

Fixes: https://github.com/andrula-song/sof/commit/bcc14074cd2b80d2e2a4803932daf6a961b3cb0a ("smart_amp_test: Split the module config and blob receiving for IPC4")

Signed-off-by: Andrula Song <andrula.song@intel.com>