### PR TITLE
[SKIP SOF-TEST] rebuild-testbench.sh: add -j jobs option

### DIFF
--- a/scripts/rebuild-testbench.sh
+++ b/scripts/rebuild-testbench.sh
@@ -107,6 +107,8 @@ source $export_script
 \$XTENSA_PATH/xt-run $xtbench -h
 
 EOFUSAGE
+            ;;
+        *) >&2 printf 'testbench_usage: unknown/missing BUILD_TYPE=%s\n' "$BUILD_TYPE" ;;
     esac
 }
 

--- a/scripts/rebuild-testbench.sh
+++ b/scripts/rebuild-testbench.sh
@@ -17,6 +17,8 @@ usage: $0 [-f] [-p <platform>]
        -p Build testbench binary for xt-run for selected platform, e.g. -p tgl
        -f Build testbench with compiler provided by fuzzer
           (default path: $HOME/sof/work/AFL/afl-gcc)
+       -j number of parallel make/ninja jobs. Defaults to /usr/bin/nproc.
+          You MUST re-run with -j1 when something is failing!
 EOFUSAGE
 }
 
@@ -40,7 +42,7 @@ rebuild_testbench()
 
     cmake -DCMAKE_INSTALL_PREFIX=install  ..
 
-    cmake --build .  --  -j"$(nproc)" $BUILD_TARGET
+    cmake --build .  --  -j"${jobs}" $BUILD_TARGET
 }
 
 export_CC_with_afl()
@@ -122,13 +124,15 @@ main()
     BUILD_TESTBENCH_DIR="$SOF_REPO"/tools/testbench
     : "${SOF_AFL:=$HOME/sof/work/AFL/afl-gcc}"
 
-    while getopts "fhp:" OPTION; do
+    jobs=$(nproc)
+    while getopts "fhj:p:" OPTION; do
         case "$OPTION" in
             p)
                 BUILD_PLATFORM="$OPTARG"
                 setup_xtensa_tools_build
                 ;;
             f) export_CC_with_afl;;
+            j) jobs=$(printf '%d' "$OPTARG") ;;
             h) print_usage; exit 1;;
             *) print_usage; exit 1;;
         esac

--- a/scripts/rebuild-testbench.sh
+++ b/scripts/rebuild-testbench.sh
@@ -59,6 +59,9 @@ setup_xtensa_tools_build()
     test -n "${XTENSA_TOOLS_ROOT}" || die "XTENSA_TOOLS_ROOT need to be set.\n"
 
     # Get compiler version for platform
+
+    # 'shellcheck -x ...' works only from the top directory
+    # shellcheck source=scripts/set_xtensa_params.sh
     source "$SCRIPT_DIR/set_xtensa_params.sh" "$BUILD_PLATFORM"
 
     test -n "${XTENSA_TOOLS_VERSION}" ||


### PR DESCRIPTION
3 commits. Main one:

rebuild-testbench.sh: add -j jobs option

This is required to investigate build failures. Because of the way the
build is split, a failure in one component can become totally drown in
the long build logs of another component.

Example: with -j2 the `parser_ep` build failure below is completely
drown by the long (and successful!) build logs of `sof_ep`:

```
./scripts/rebuild-testbench.sh -j 1 -p tgl

sof/tools/testbench/build_xt_testbench/sof_parser/build/include/alsa/
sound/asoc.h:196: error: expected specifier-qualifier-list before ‘__le32’
```

Signed-off-by: Marc Herbert <marc.herbert@intel.com>