### PR TITLE
copier: preparation for copier module adapter interface

### DIFF
--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -1801,7 +1801,7 @@ static int copier_get_hw_params(struct comp_dev *dev, struct sof_ipc_stream_para
 	if (dev->ipc_config.type != SOF_COMP_DAI)
 		return -EINVAL;
 
-	return dai_zephyr_get_hw_params(dd, dev, params, dir);
+	return dai_common_get_hw_params(dd, dev, params, dir);
 }
 
 static int copier_unbind(struct comp_dev *dev, void *data)

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -522,12 +522,8 @@ static int init_pipeline_reg(struct comp_dev *dev)
 	struct copier_data *cd = comp_get_drvdata(dev);
 	struct ipc4_pipeline_registers pipe_reg;
 	uint32_t gateway_id;
-	int ret;
 
-	ret = comp_get_attribute(dev, COMP_ATTR_VDMA_INDEX, &gateway_id);
-	if (ret)
-		return ret;
-
+	gateway_id = cd->config.gtw_cfg.node_id.f.v_index;
 	if (gateway_id >= IPC4_MAX_PIPELINE_REG_SLOTS) {
 		comp_cl_err(&comp_copier, "gateway_id %u out of array bounds.", gateway_id);
 		return -EINVAL;
@@ -1721,9 +1717,6 @@ static int copier_get_attribute(struct comp_dev *dev, uint32_t type, void *value
 	struct copier_data *cd = comp_get_drvdata(dev);
 
 	switch (type) {
-	case COMP_ATTR_VDMA_INDEX:
-		*(uint32_t *)value = cd->config.gtw_cfg.node_id.f.v_index;
-		break;
 	case COMP_ATTR_BASE_CONFIG:
 		*(struct ipc4_base_module_cfg *)value = cd->config.base;
 		break;

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -264,7 +264,7 @@ static void dai_free(struct comp_dev *dev)
 	rfree(dev);
 }
 
-int dai_zephyr_get_hw_params(struct dai_data *dd, struct comp_dev *dev,
+int dai_common_get_hw_params(struct dai_data *dd, struct comp_dev *dev,
 			     struct sof_ipc_stream_params *params, int dir)
 {
 	int ret;
@@ -295,7 +295,7 @@ static int dai_comp_get_hw_params(struct comp_dev *dev,
 {
 	struct dai_data *dd = comp_get_drvdata(dev);
 
-	return dai_zephyr_get_hw_params(dd, dev, params, dir);
+	return dai_common_get_hw_params(dd, dev, params, dir);
 }
 
 static int dai_comp_hw_params(struct comp_dev *dev,
@@ -323,7 +323,7 @@ static int dai_verify_params(struct dai_data *dd, struct comp_dev *dev,
 	struct sof_ipc_stream_params hw_params;
 	int ret;
 
-	ret = dai_zephyr_get_hw_params(dd, dev, &hw_params, params->direction);
+	ret = dai_common_get_hw_params(dd, dev, &hw_params, params->direction);
 	if (ret < 0)
 		return ret;
 

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -317,12 +317,15 @@ static int dai_comp_hw_params(struct comp_dev *dev,
 	return 0;
 }
 
-static int dai_verify_params(struct comp_dev *dev,
+static int dai_verify_params(struct dai_data *dd, struct comp_dev *dev,
 			     struct sof_ipc_stream_params *params)
 {
 	struct sof_ipc_stream_params hw_params;
+	int ret;
 
-	comp_dai_get_hw_params(dev, &hw_params, params->direction);
+	ret = dai_zephyr_get_hw_params(dd, dev, &hw_params, params->direction);
+	if (ret < 0)
+		return ret;
 
 	/* checks whether pcm parameters match hardware DAI parameter set
 	 * during dai_set_config(). If hardware parameter is equal to 0, it
@@ -504,7 +507,7 @@ int dai_zephyr_params(struct dai_data *dd, struct comp_dev *dev,
 	if (err < 0)
 		return err;
 
-	err = dai_verify_params(dev, params);
+	err = dai_verify_params(dd, dev, params);
 	if (err < 0) {
 		comp_err(dev, "dai_params(): pcm params verification failed.");
 		return -EINVAL;

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -513,13 +513,13 @@ static void dai_free(struct comp_dev *dev)
 	rfree(dev);
 }
 
-int dai_zephyr_get_hw_params(struct dai_data *dd, struct comp_dev *dev,
+int dai_common_get_hw_params(struct dai_data *dd, struct comp_dev *dev,
 			     struct sof_ipc_stream_params *params, int dir)
 {
 	struct dai_config cfg;
 	int ret;
 
-	comp_dbg(dev, "dai_zephyr_get_hw_params()");
+	comp_dbg(dev, "dai_common_get_hw_params()");
 
 	ret = dai_config_get(dd->dai->dev, &cfg, dir);
 	if (ret)
@@ -546,7 +546,7 @@ static int dai_comp_get_hw_params(struct comp_dev *dev,
 {
 	struct dai_data *dd = comp_get_drvdata(dev);
 
-	return dai_zephyr_get_hw_params(dd, dev, params, dir);
+	return dai_common_get_hw_params(dd, dev, params, dir);
 }
 
 static int dai_verify_params(struct dai_data *dd, struct comp_dev *dev,
@@ -555,7 +555,7 @@ static int dai_verify_params(struct dai_data *dd, struct comp_dev *dev,
 	struct sof_ipc_stream_params hw_params;
 	int ret;
 
-	ret = dai_zephyr_get_hw_params(dd, dev, &hw_params, params->direction);
+	ret = dai_common_get_hw_params(dd, dev, &hw_params, params->direction);
 	if (ret < 0) {
 		comp_err(dev, "dai_verify_params(): dai_verify_params failed ret %d", ret);
 		return ret;

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -549,12 +549,13 @@ static int dai_comp_get_hw_params(struct comp_dev *dev,
 	return dai_zephyr_get_hw_params(dd, dev, params, dir);
 }
 
-static int dai_verify_params(struct comp_dev *dev, struct sof_ipc_stream_params *params)
+static int dai_verify_params(struct dai_data *dd, struct comp_dev *dev,
+			     struct sof_ipc_stream_params *params)
 {
 	struct sof_ipc_stream_params hw_params;
 	int ret;
 
-	ret = comp_dai_get_hw_params(dev, &hw_params, params->direction);
+	ret = dai_zephyr_get_hw_params(dd, dev, &hw_params, params->direction);
 	if (ret < 0) {
 		comp_err(dev, "dai_verify_params(): dai_verify_params failed ret %d", ret);
 		return ret;
@@ -894,7 +895,7 @@ int dai_zephyr_params(struct dai_data *dd, struct comp_dev *dev,
 	if (err < 0)
 		return err;
 
-	err = dai_verify_params(dev, params);
+	err = dai_verify_params(dd, dev, params);
 	if (err < 0) {
 		comp_err(dev, "dai_zephyr_params(): pcm params verification failed.");
 		return -EINVAL;

--- a/src/include/sof/audio/dai_copier.h
+++ b/src/include/sof/audio/dai_copier.h
@@ -46,7 +46,7 @@ int dai_zephyr_ts_stop(struct dai_data *dd, struct comp_dev *dev);
 
 int dai_zephyr_ts_get(struct dai_data *dd, struct comp_dev *dev, struct timestamp_data *tsd);
 
-int dai_zephyr_get_hw_params(struct dai_data *dd, struct comp_dev *dev,
+int dai_common_get_hw_params(struct dai_data *dd, struct comp_dev *dev,
 			     struct sof_ipc_stream_params *params, int dir);
 
 int dai_zephyr_multi_endpoint_copy(struct dai_data **dd, struct comp_dev *dev,


### PR DESCRIPTION
no change for functionality, changes list below:

1. Removed dependency in dai-zephyr.c and dai-legacy.c for comp_dai_get_hw_params with direct calling.
2. Removed one case for COMP_ATTR_VDMA_INDEX in function: copier_get_attribute, since it only used inside copier.
3. Renamed function name with better aligned with name convention.
4. Removed copier get hw parameters function.

This is for preparation of copier module interface.