### PR TITLE
Tools: Tplg_parser: Add include of <linux/types.h>

### DIFF
--- a/tools/tplg_parser/include/tplg_parser/tokens.h
+++ b/tools/tplg_parser/include/tplg_parser/tokens.h
@@ -18,6 +18,7 @@
 #define SNDRV_CTL_ELEM_ID_NAME_MAXLEN	44
 #endif
 
+#include <linux/types.h>
 #include <alsa/sound/asoc.h>
 
 struct sof_topology_token {

--- a/tools/tplg_parser/include/tplg_parser/topology.h
+++ b/tools/tplg_parser/include/tplg_parser/topology.h
@@ -22,6 +22,7 @@
 #define SNDRV_CTL_ELEM_ID_NAME_MAXLEN	44
 #endif
 
+#include <linux/types.h>
 #include <alsa/sound/asoc.h>
 
 #define TPLG_PARSER_SOF_DEV 1


### PR DESCRIPTION
These headers include alsa/sound/asoc.h and some versions of the headers have this conditional include of types.h:

	#if defined(__linux__)
	#include <linux/types.h>
	#endif

To ensure types __le64, __le32, __le16, __u8 are defined explicitly include types.h becore including asoc.h.