### PR TITLE
Multiple endpoint DAI copier optimization

### DIFF
--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -363,16 +363,6 @@ static int init_dai(struct comp_dev *parent_dev,
 	if (ret < 0)
 		goto e_zephyr_free;
 
-	cd->converter[IPC4_COPIER_GATEWAY_PIN] =
-			get_converter_func(&copier->base.audio_fmt, &copier->out_fmt, type,
-					   IPC4_DIRECTION(dai->direction));
-	if (!cd->converter[IPC4_COPIER_GATEWAY_PIN]) {
-		comp_err(parent_dev, "failed to get converter type %d, dir %d",
-			 type, dai->direction);
-		ret = -EINVAL;
-		goto e_zephyr_free;
-	}
-
 	cd->endpoint_num++;
 
 	return 0;
@@ -497,6 +487,15 @@ static int create_dai(struct comp_dev *parent_dev, struct copier_data *cd,
 			comp_err(parent_dev, "failed to create dai");
 			return ret;
 		}
+	}
+
+	cd->converter[IPC4_COPIER_GATEWAY_PIN] =
+			get_converter_func(&copier->base.audio_fmt, &copier->out_fmt, type,
+					   IPC4_DIRECTION(dai.direction));
+	if (!cd->converter[IPC4_COPIER_GATEWAY_PIN]) {
+		comp_err(parent_dev, "failed to get converter type %d, dir %d",
+			 type, dai.direction);
+		return -EINVAL;
 	}
 
 	/* create multi_endpoint_buffer for ALH multi-gateway case */

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -873,13 +873,8 @@ int dai_zephyr_params(struct dai_data *dd, struct comp_dev *dev,
 		return -EINVAL;
 	}
 
-	buffer_c = buffer_acquire(dd->local_buffer);
-
 	/* calculate frame size */
-	frame_size = get_frame_bytes(dev->ipc_config.frame_fmt,
-				     audio_stream_get_channels(&buffer_c->stream));
-
-	buffer_release(buffer_c);
+	frame_size = get_frame_bytes(dev->ipc_config.frame_fmt, params->channels);
 
 	/* calculate period size */
 	period_bytes = dev->frames * frame_size;

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -1152,16 +1152,9 @@ static int dai_reset(struct comp_dev *dev)
 /* used to pass standard and bespoke command (with data) to component */
 static int dai_comp_trigger_internal(struct dai_data *dd, struct comp_dev *dev, int cmd)
 {
-	int ret;
+	int ret = 0;
 
 	comp_dbg(dev, "dai_comp_trigger_internal(), command = %u", cmd);
-
-	ret = comp_set_state(dev, cmd);
-	if (ret < 0)
-		return ret;
-
-	if (ret == COMP_STATUS_STATE_ALREADY_SET)
-		return PPL_STATUS_PATH_STOP;
 
 	switch (cmd) {
 	case COMP_TRIGGER_START:

--- a/src/include/ipc4/copier.h
+++ b/src/include/ipc4/copier.h
@@ -227,12 +227,6 @@ struct ipc4_data_segment_enabled {
 	uint32_t data_seg_size;
 } __attribute__((packed, aligned(4)));
 
-/* One of copy_single_channel_cXX() to mux/demux channels into/from copier multi_endpoint_buffer */
-typedef int (*channel_copy_func)(struct audio_stream __sparse_cache *src,
-				   int src_channel,
-				   const struct audio_stream __sparse_cache *dst,
-				   int dst_channel, int frame_count);
-
 struct copier_data {
 	/*
 	 * struct ipc4_copier_module_cfg actually has variable size, but we
@@ -246,7 +240,6 @@ struct copier_data {
 
 	/* buffer to mux/demux data from/to multiple endpoint buffers for ALH multi-gateway case */
 	struct comp_buffer *multi_endpoint_buffer;
-	channel_copy_func copy_single_channel;
 
 	bool bsource_buffer;
 
@@ -265,6 +258,8 @@ struct copier_data {
 	struct host_data *hd;
 	bool ipc_gtw;
 	struct dai_data *dd[IPC4_ALH_MAX_NUMBER_OF_GTW];
+	uint32_t channels[IPC4_ALH_MAX_NUMBER_OF_GTW];
+	uint32_t chan_map[IPC4_ALH_MAX_NUMBER_OF_GTW];
 	struct ipcgtw_data *ipcgtw_data;
 };
 

--- a/src/include/ipc4/copier.h
+++ b/src/include/ipc4/copier.h
@@ -228,10 +228,10 @@ struct ipc4_data_segment_enabled {
 } __attribute__((packed, aligned(4)));
 
 /* One of copy_single_channel_cXX() to mux/demux channels into/from copier multi_endpoint_buffer */
-typedef void (* channel_copy_func)(struct audio_stream __sparse_cache *dst,
-				   int dst_channel,
-				   const struct audio_stream __sparse_cache *src,
-				   int src_channel, int frame_count);
+typedef int (*channel_copy_func)(struct audio_stream __sparse_cache *src,
+				   int src_channel,
+				   const struct audio_stream __sparse_cache *dst,
+				   int dst_channel, int frame_count);
 
 struct copier_data {
 	/*

--- a/src/include/sof/audio/dai_copier.h
+++ b/src/include/sof/audio/dai_copier.h
@@ -48,4 +48,8 @@ int dai_zephyr_ts_get(struct dai_data *dd, struct comp_dev *dev, struct timestam
 
 int dai_zephyr_get_hw_params(struct dai_data *dd, struct comp_dev *dev,
 			     struct sof_ipc_stream_params *params, int dir);
+
+int dai_zephyr_multi_endpoint_copy(struct dai_data **dd, struct comp_dev *dev,
+				   struct comp_buffer *multi_endpoint_buffer,
+				   int num_endpoints);
 #endif /* __SOF_LIB_DAI_COPIER_H__ */


### PR DESCRIPTION
Removes the endpoint DAI devices and endpoint buffers for multiple endpoint DAI copiers and saves an extra copy. 