### PR TITLE
schedule: zephyr_dma_domain: Fix multiple issues

### DIFF
--- a/src/include/sof/schedule/ll_schedule_domain.h
+++ b/src/include/sof/schedule/ll_schedule_domain.h
@@ -48,7 +48,7 @@ struct ll_schedule_domain_ops {
 	void (*domain_clear)(struct ll_schedule_domain *domain);
 	bool (*domain_is_pending)(struct ll_schedule_domain *domain,
 				  struct task *task, struct comp_dev **comp);
-	void (*domain_task_cancel)(struct ll_schedule_domain *domain, uint32_t num_tasks);
+	void (*domain_task_cancel)(struct ll_schedule_domain *domain, struct task *task);
 };
 
 struct ll_schedule_domain {
@@ -130,10 +130,10 @@ static inline void domain_clear(struct ll_schedule_domain *domain)
 
 /* let the domain know that a task has been cancelled */
 static inline void domain_task_cancel(struct ll_schedule_domain *domain,
-				      uint32_t num_tasks)
+				      struct task *task)
 {
 	if (domain->ops->domain_task_cancel)
-		domain->ops->domain_task_cancel(domain, num_tasks);
+		domain->ops->domain_task_cancel(domain, task);
 }
 
 static inline int domain_register(struct ll_schedule_domain *domain,

--- a/src/schedule/zephyr_dma_domain.c
+++ b/src/schedule/zephyr_dma_domain.c
@@ -297,6 +297,16 @@ static int zephyr_dma_domain_register(struct ll_schedule_domain *domain,
 
 	tr_info(&ll_tr, "zephyr_dma_domain_register()");
 
+	/* don't even bother trying to register DMA IRQ for
+	 * non-registrable tasks.
+	 *
+	 * this is needed because zephyr_dma_domain_register() will
+	 * return -EINVAL for non-registrable tasks because of
+	 * register_dma_irq() which is not right.
+	 */
+	if (!pipe_task->registrable)
+		return 0;
+
 	/* the DMA IRQ has to be registered before the Zephyr thread is
 	 * started.
 	 *

--- a/src/schedule/zephyr_ll.c
+++ b/src/schedule/zephyr_ll.c
@@ -439,7 +439,7 @@ static int zephyr_ll_task_cancel(void *data, struct task *task)
 	if (task->state != SOF_TASK_STATE_FREE) {
 		task->state = SOF_TASK_STATE_CANCEL;
 		/* let domain know that a task has been cancelled */
-		domain_task_cancel(sch->ll_domain, sch->n_tasks - 1);
+		domain_task_cancel(sch->ll_domain, task);
 	}
 	zephyr_ll_unlock(sch, &flags);
 

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -34,6 +34,15 @@ config DMA_DOMAIN
 	help
 	  This enables the usage of the DMA domain in scheduling.
 
+config DMA_DOMAIN_SEM_LIMIT
+	int "Number of resources the Zephyr's DMA domain can accumulate"
+	depends on DMA_DOMAIN
+	default 10
+	help
+	  Set this value according to the load of the system. Please make sure
+	  that SEM_LIMIT covers the maximum number of tasks your system will be
+	  executing at some point (worst case).
+
 config ZEPHYR_DP_SCHEDULER
 	bool "use Zephyr thread based DP scheduler"
 	default y if ACE


### PR DESCRIPTION
Please see the description of each commit for the problem and the solution they offer. Also, please note that, theoretically, in the case of last commit the following issue can happen: (not sure how this would affect the flow especially during a TRIGGER STOP which will stop the stream)

1) TRIGGER stop comes and does a pipeline graph traversal marking some buffer->walking = true.
2) DMA interrupt comes and the DMA domain thread is scheduled since its priority is in the COOP range.
3) pipeline_copy() will see that some buffers have the walking flag marked as true and will stop.

Theoretically, this should also happen in the case of timer domain. Please do correct me if I'm wrong.

This PR will be marked as [DNM] until NXP internal CI is run.