### PR TITLE
[SKIP SOF-TEST] .github/fuzzer: apt-get install i386 dependencies explicitly 

### DIFF
--- a/.github/workflows/ipc_fuzzer.yml
+++ b/.github/workflows/ipc_fuzzer.yml
@@ -57,10 +57,27 @@ jobs:
           sudo dpkg --add-architecture i386
           sudo apt-get update
 
-      - name: apt-get install
-        run: sudo apt-get update && sudo apt-get -y install
-          clang llvm libc6-dev-i386 libstdc++-12-dev:i386
-          ninja-build device-tree-compiler python3-pyelftools
+      - name: apt-get install i386 packages
+        run: |
+
+          # We don't know why Github requires us to explicit all these i386
+          # dependencies. On a vanilla Ubuntu 22.04 the last apt-get is
+          # enough.
+          # Also, it does not seem possible to download Github images for
+          # local testing which means trial and error for this requires a
+          # force-push every time: excruciatingly slow!
+          sudo apt-get -y install       \
+            libgcc-s1:i386 libc6-dev:i386 libstdc++6:i386         \
+            libgomp1:i386  libitm1:i386   libatomic1:i386         \
+            libasan8:i386  libubsan1:i386 libquadmath0:i386       \
+
+          sudo apt-get -y install \
+            libc6-dev-i386 libstdc++-12-dev:i386
+
+      - name: apt-get install build tools
+        run:
+          sudo apt-get -y install
+            clang llvm ninja-build device-tree-compiler python3-pyelftools
 
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Let's try to fix the error below spotted in
https://github.com/thesofproject/sof/actions/runs/4981366388

I have no idea why this worked before and not anymore but if it makes apt happy then we're happy.

```
libstdc++-12-dev:i386 :
  Depends: libstdc++6:i386 (>= 12.1.0-2ubuntu1~22.04) but it is not
           going to be installed
  Depends: libc6-dev:i386 (>= 2.13-0ubuntu6) but it is not installable
```