### PR TITLE
[SKIP SOF-TEST] .github/sparse-zephyr.yml: delete obsolete REAL_CC magic

### DIFF
--- a/.github/workflows/sparse-zephyr.yml
+++ b/.github/workflows/sparse-zephyr.yml
@@ -62,6 +62,8 @@ jobs:
         run: |
              ./sof/zephyr/docker-run.sh                          \
              ./sof/zephyr/docker-build.sh ${{ matrix.platform }}          \
-             --cmake-args=-DSPARSE=y --cmake-args=-DCONFIG_LOG_USE_VLA=n --pristine 2>&1 | tee _.log
+             --cmake-args=-DZEPHYR_SCA_VARIANT=sparse --cmake-args=-DCONFIG_LOG_USE_VLA=n  \
+             --pristine 2>&1 | tee _.log
+
              printf '\n\n\t\t\t  ---- Messages below are treated as sparse errors --- \n\n\n'
              (set -x; ./sof/scripts/parse_sparse_output.sh ${{ matrix.platforms.platform }} <_.log)

--- a/.github/workflows/sparse-zephyr.yml
+++ b/.github/workflows/sparse-zephyr.yml
@@ -22,20 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platforms: [
-          {platform: tgl,
-           real_cc: xtensa-intel_s1000_zephyr-elf/bin/xtensa-intel_s1000_zephyr-elf-gcc},
-          # This is the WRONG compiler for MTL but for now this is the
-          # one and only one expected by the Zephyr build system so it
-          # must be set to this value to sparse MTL.
-          # Sparse needs a REAL_CC but it does not matter which one, it
-          # does not affect sparse results.
-          # As soon as sof/west.yml is updated to a fixed Zephyr version
-          # this will fail with an error message that will show the
-          # exact value that must replace this one.
-          {platform: mtl,
-           real_cc: xtensa-intel_s1000_zephyr-elf/bin/xtensa-intel_s1000_zephyr-elf-gcc},
-        ]
+        platform: [tgl, mtl]
 
     steps:
       - name: git clone sparse analyzer
@@ -67,22 +54,14 @@ jobs:
       - name: Download docker image && ls /opt/toolchains/
         run: cd workspace && ./sof/zephyr/docker-run.sh ls -l /opt/toolchains/
 
-      # We have to painfully extract REAL_CC from the docker image to
-      # tell the Zephyr build what it... already knows and wants!! Zephyr
-      # commit 3ebb18b8826 explains this sparse problem.
-      #
       # --pristine is important to reproduce _warnings_. It makes no
       # difference for github but it's useful for anyone trying to
       # reproduce and copying the command from the logs.
       - name: analyze zephyr
         working-directory: ./workspace
         run: |
-          ./sof/zephyr/docker-run.sh /bin/sh -c               \
-            'cmake -P ./sof/zephyr/FindZephyr-sdk.cmake > zsdk_location'
-          cat zsdk_location
-          ZSDK=$(cat zsdk_location); _RCC=${{ matrix.platforms.real_cc }}
-          REAL_CC="$ZSDK/$_RCC" ./sof/zephyr/docker-run.sh                          \
-             ./sof/zephyr/docker-build.sh ${{ matrix.platforms.platform }}          \
+             ./sof/zephyr/docker-run.sh                          \
+             ./sof/zephyr/docker-build.sh ${{ matrix.platform }}          \
              --cmake-args=-DSPARSE=y --cmake-args=-DCONFIG_LOG_USE_VLA=n --pristine 2>&1 | tee _.log
              printf '\n\n\t\t\t  ---- Messages below are treated as sparse errors --- \n\n\n'
              (set -x; ./sof/scripts/parse_sparse_output.sh ${{ matrix.platforms.platform }} <_.log)


### PR DESCRIPTION
This hasn't been required since Zephyr commit 91902c5fd4db ("cmake: add sparse support to the new SCA infrastructure")