### PR TITLE
topology2: sdw-amp-generic: use fixed format on amp feedback io

### DIFF
--- a/tools/topology/topology2/cavs-sdw.conf
+++ b/tools/topology/topology2/cavs-sdw.conf
@@ -37,6 +37,8 @@
 <pipeline.conf>
 <dai.conf>
 <host.conf>
+<input_audio_format.conf>
+<output_audio_format.conf>
 <dmic-default.conf>
 <hdmi-default.conf>
 

--- a/tools/topology/topology2/platform/intel/sdw-amp-generic.conf
+++ b/tools/topology/topology2/platform/intel/sdw-amp-generic.conf
@@ -163,9 +163,8 @@ IncludeByKey.SDW_AMP_FEEDBACK {
 				}
 			]
 
-			io-gateway [
+			io-gateway-capture [
 				{
-					direction	"capture"
 					index 31
 					copier_type "ALH"
 
@@ -175,6 +174,29 @@ IncludeByKey.SDW_AMP_FEEDBACK {
 						copier_type	"ALH"
 						type		"dai_out"
 						node_type $ALH_LINK_INPUT_CLASS
+						#Use 4 channel format if there are 2 amps on different sdw links
+						IncludeByKey.NUM_SDW_AMP_LINKS {
+						"2"	{
+								Object.Base.input_audio_format [
+									{
+										in_channels		4
+										in_bit_depth		32
+										in_valid_bit_depth	32
+										in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+										in_ch_map	$CHANNEL_MAP_3_POINT_1
+									}
+								]
+								Object.Base.output_audio_format [
+									{
+										out_channels		4
+										out_bit_depth		32
+										out_valid_bit_depth	32
+										out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+										out_ch_map	$CHANNEL_MAP_3_POINT_1
+									}
+								]
+							}
+						}
 					}
 				}
 			]


### PR DESCRIPTION
Use fixed 32 bit format on io-gateway and let host-gateway do the conversion.