### PR TITLE
copier: pipeline period recalculation

### DIFF
--- a/src/audio/pipeline/pipeline-graph.c
+++ b/src/audio/pipeline/pipeline-graph.c
@@ -14,6 +14,7 @@
 #include <sof/lib/uuid.h>
 #include <sof/compiler_attributes.h>
 #include <sof/list.h>
+#include <sof/schedule/ll_schedule_domain.h>
 #include <rtos/spinlock.h>
 #include <rtos/string.h>
 #include <rtos/clk.h>
@@ -301,6 +302,14 @@ int pipeline_complete(struct pipeline *p, struct comp_dev *source,
 
 	data.start = source;
 	data.p = p;
+
+	/* If a component has been added to the pipeline that cannot run on longer periods
+	 * we need to set pipe period to one ms.
+	 */
+	if (!p->deep_buffering) {
+		p->period = LL_TIMER_PERIOD_US;
+		pipe_info(p, "setting pipe period to %llu us", LL_TIMER_PERIOD_US);
+	}
 
 	/* now walk downstream from source component and
 	 * complete component task and pipeline initialization

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -591,6 +591,9 @@ struct comp_dev {
 	bool is_shared;		/**< indicates whether component is shared
 				  *  across cores
 				  */
+	bool deep_buffering;	/**< indicates whether component is able to work
+				  *  deep buffering
+				  */
 	struct comp_ipc_config ipc_config;	/**< Component IPC configuration */
 	struct tr_ctx tctx;	/**< trace settings */
 

--- a/src/include/sof/audio/pipeline.h
+++ b/src/include/sof/audio/pipeline.h
@@ -94,6 +94,8 @@ struct pipeline {
 		bool aborted;		/* STOP or PAUSE failed, stay active */
 		bool pending;		/* trigger scheduled but not executed yet */
 	} trigger;
+	/* pipe can use long periods for scheduling in case of a deep buffering */
+	bool deep_buffering;
 };
 
 struct pipeline_walk_context {


### PR DESCRIPTION
In case of a deep buffering pipelines don't require scheduling on every millisecond. We can calculate period based on the gateway buffer size.

At pipeline creation we assume that it can work on longer periods, period value is set to zero to be later adjust base on the pipeline components.