### PR TITLE
ipc4: mixin/mixout multi-core support

### DIFF
--- a/src/audio/mixin_mixout/mixin_mixout.c
+++ b/src/audio/mixin_mixout/mixin_mixout.c
@@ -46,24 +46,6 @@ DECLARE_TR_CTX(mixout_tr, SOF_UUID(mixout_uuid), LOG_LEVEL_INFO);
 #define MIXIN_MAX_SINKS IPC4_MIXIN_MODULE_MAX_OUTPUT_QUEUES
 #define MIXOUT_MAX_SOURCES IPC4_MIXOUT_MODULE_MAX_INPUT_QUEUES
 
-/*
- * Unfortunately, if we have to support a topology with a single mixin
- * connected to multiple mixouts, we cannot use simple implementation as in
- * mixer component. We either need to use intermediate buffer between mixin and
- * mixout, or use a more complex implementation as described below.
- *
- * This implementation does not use buffer between mixin and mixout. Mixed
- * data is written directly to mixout sink buffer. Most of the mixing is done
- * by mixins in mixin_process(). Simply speaking, if no data present in mixout
- * sink -- mixin just copies its source data to mixout sink. If mixout sink
- * has some data (written there previously by some other mixin) -- mixin reads
- * data from mixout sink, mixes it with its source data and writes back to
- * mixout sink.
- *
- * Such implementation has less buffer reads/writes than simple implementation
- * using intermediate buffer between mixin and mixout.
- */
-
 struct mixin_sink_config {
 	enum ipc4_mixer_mode mixer_mode;
 	uint32_t output_channel_count;
@@ -74,24 +56,16 @@ struct mixin_sink_config {
 
 /* mixin component private data */
 struct mixin_data {
-	normal_mix_func normal_mix_channel;
-	remap_mix_func remap_mix_channel;
-	mute_func mute_channel;
 	struct mixin_sink_config sink_config[MIXIN_MAX_SINKS];
+
+	void (*gain_func)(struct audio_stream *stream, uint32_t sample_count,
+		       uint16_t gain_mul, uint8_t gain_shift);
 };
 
-/* mixout component private data. This can be accessed from different cores. */
+/* mixout component private data */
 struct mixout_data {
-	/* number of currently mixed frames in mixout sink buffer */
-	uint32_t mixed_frames;
-	/*
-	 * Source data is consumed by mixins in mixin_process() but sink data cannot be
-	 * immediately produced. Sink data is produced by mixout in mixout_process() after
-	 * ensuring all connected mixins have mixed their data into mixout sink buffer.
-	 * So for each connected mixin, mixout keeps knowledge of data already consumed
-	 * by mixin but not yet produced in mixout.
-	 */
-	uint32_t pending_frames[MIXOUT_MAX_SOURCES];
+	void (* mix_func)(const struct audio_stream *source, struct audio_stream *sink,
+		      uint32_t sample_count);
 };
 
 static int mixin_init(struct processing_module *mod)
@@ -122,15 +96,14 @@ static int mixin_init(struct processing_module *mod)
 
 	dev->ipc_config.frame_fmt = frame_fmt;
 	mod->simple_copy = true;
-	mod->skip_src_buffer_invalidate = true;
 
 	return 0;
 }
 
 static int mixout_init(struct processing_module *mod)
 {
-	struct module_source_info __sparse_cache *mod_source_info;
 	struct comp_dev *dev = mod->dev;
+	struct module_data *mod_data = &mod->priv;
 	struct mixout_data *mo_data;
 	enum sof_ipc_frame __sparse_cache frame_fmt, valid_fmt;
 
@@ -140,9 +113,7 @@ static int mixout_init(struct processing_module *mod)
 	if (!mo_data)
 		return -ENOMEM;
 
-	mod_source_info = module_source_info_acquire(mod->source_info);
-	mod_source_info->private = mo_data;
-	module_source_info_release(mod_source_info);
+	mod_data->private = mo_data;
 
 	audio_stream_fmt_conversion(mod->priv.cfg.base_cfg.audio_fmt.depth,
 				    mod->priv.cfg.base_cfg.audio_fmt.valid_bit_depth,
@@ -151,7 +122,6 @@ static int mixout_init(struct processing_module *mod)
 
 	dev->ipc_config.frame_fmt = frame_fmt;
 	mod->simple_copy = true;
-	mod->skip_sink_buffer_writeback = true;
 
 	return 0;
 }
@@ -169,21 +139,17 @@ static int mixin_free(struct processing_module *mod)
 
 static int mixout_free(struct processing_module *mod)
 {
-	struct module_source_info __sparse_cache *mod_source_info;
+	struct mixout_data *md = module_get_private_data(mod);
 
 	comp_dbg(mod->dev, "mixout_free()");
-
-	mod_source_info = module_source_info_acquire(mod->source_info);
-	rfree(mod_source_info->private);
-	mod_source_info->private = NULL;
-	module_source_info_release(mod_source_info);
+	rfree(md);
 
 	return 0;
 }
 
-static int mix_and_remap(struct comp_dev *dev, const struct mixin_data *mixin_data,
+/* Currently only does copy with gain. Remapping is not implemented. */
+static int copy_and_remap(struct comp_dev *dev, const struct mixin_data *mixin_data,
 			 uint16_t sink_index, struct audio_stream __sparse_cache *sink,
-			 uint32_t start_frame, uint32_t mixed_frames,
 			 const struct audio_stream __sparse_cache *source, uint32_t frame_count)
 {
 	const struct mixin_sink_config *sink_config;
@@ -197,37 +163,14 @@ static int mix_and_remap(struct comp_dev *dev, const struct mixin_data *mixin_da
 	sink_config = &mixin_data->sink_config[sink_index];
 
 	if (sink_config->mixer_mode == IPC4_MIXER_NORMAL_MODE) {
-		/* Mix streams. mix_channel() is reused here to mix streams, not individual
-		 * channels. To do so, (multichannel) stream is treated as single channel:
-		 * channel count is passed as 1, channel index is 0, frame indices (start_frame
-		 * and mixed_frame) and frame count are multiplied by real stream channel count.
-		 */
-		mixin_data->normal_mix_channel(sink, start_frame * sink->channels,
-					mixed_frames * sink->channels, source,
-					frame_count * sink->channels, sink_config->gain);
+		audio_stream_copy(source, 0, sink, 0, frame_count * sink->channels);
+
+		if (sink_config->gain != IPC4_MIXIN_UNITY_GAIN)
+			mixin_data->gain_func(sink, frame_count * sink->channels,
+					      sink_config->gain, IPC4_MIXIN_GAIN_SHIFT);
 	} else if (sink_config->mixer_mode == IPC4_MIXER_CHANNEL_REMAPPING_MODE) {
-		int i;
-
-		for (i = 0; i < sink->channels; i++) {
-			uint8_t source_channel =
-				(sink_config->output_channel_map >> (i * 4)) & 0xf;
-
-			if (source_channel == 0xf) {
-				mixin_data->mute_channel(sink, i, start_frame, mixed_frames,
-							 frame_count);
-			} else {
-				if (source_channel >= source->channels) {
-					comp_err(dev, "Out of range chmap: 0x%x, src channels: %u",
-						 sink_config->output_channel_map,
-						 source->channels);
-					return -EINVAL;
-				}
-				mixin_data->remap_mix_channel(sink, i, sink->channels, start_frame,
-							mixed_frames, source, source_channel,
-							source->channels, frame_count,
-							sink_config->gain);
-			}
-		}
+		comp_err(dev, "Remapping mode is not implemented!");
+		return -EINVAL;
 	} else {
 		comp_err(dev, "Unexpected mixer mode: %d", sink_config->mixer_mode);
 		return -EINVAL;
@@ -236,49 +179,6 @@ static int mix_and_remap(struct comp_dev *dev, const struct mixin_data *mixin_da
 	return 0;
 }
 
-/* mix silence into stream, i.e. set not yet mixed data in stream to zero */
-static void silence(struct audio_stream __sparse_cache *stream, uint32_t start_frame,
-		    uint32_t mixed_frames, uint32_t frame_count)
-{
-	uint32_t skip_mixed_frames;
-	uint8_t *ptr;
-	uint32_t size;
-	int n;
-
-	assert(mixed_frames >= start_frame);
-	skip_mixed_frames = mixed_frames - start_frame;
-
-	if (frame_count <= skip_mixed_frames)
-		return;
-
-	size = audio_stream_period_bytes(stream, frame_count - skip_mixed_frames);
-	ptr = (uint8_t *)stream->w_ptr + audio_stream_period_bytes(stream, mixed_frames);
-
-	while (size) {
-		ptr = audio_stream_wrap(stream, ptr);
-		n = MIN(audio_stream_bytes_without_wrap(stream, ptr), size);
-		memset(ptr, 0, n);
-		size -= n;
-		ptr += n;
-	}
-}
-
-/* Most of the mixing is done here on mixin side. mixin mixes its source data
- * into each connected mixout sink buffer. Basically, if mixout sink buffer has
- * no data, mixin copies its source data into mixout sink buffer. If mixout sink
- * buffer has some data (written there by other mixin), mixin reads mixout sink
- * buffer data, mixes it with its source data and writes back to mixout sink
- * buffer. So after all mixin mixin_process() calls, mixout sink buffer contains
- * mixed data. Every mixin calls xxx_consume() on its processed source data, but
- * they do not call xxx_produce(). That is done on mixout side in mixout_process().
- *
- * Since there is no garantie that mixout processing is done in time we have
- * to account for a possibility having not yet produced data in mixout sink
- * buffer that was written there on previous run(s) of mixin_process(). So for each
- * mixin <--> mixout pair we track consumed_yet_not_produced data amount.
- * That value is also used in mixout_process() to calculate how many data was
- * actually mixed and so xxx_produce() is called for that amount.
- */
 static int mixin_process(struct processing_module *mod,
 			 struct input_stream_buffer *input_buffers, int num_input_buffers,
 			 struct output_stream_buffer *output_buffers, int num_output_buffers)
@@ -286,11 +186,9 @@ static int mixin_process(struct processing_module *mod,
 	struct mixin_data *mixin_data = module_get_private_data(mod);
 	struct comp_dev *dev = mod->dev;
 	uint32_t source_avail_frames, sinks_free_frames;
-	struct comp_dev *active_mixouts[MIXIN_MAX_SINKS];
 	uint16_t sinks_ids[MIXIN_MAX_SINKS];
 	uint32_t bytes_to_consume_from_source_buf;
 	uint32_t frames_to_copy;
-	int source_index;
 	int i, ret;
 
 	comp_dbg(dev, "mixin_process()");
@@ -310,254 +208,223 @@ static int mixin_process(struct processing_module *mod,
 
 	/* first, let's find out how many frames can be now processed --
 	 * it is a nimimal value among frames available in source buffer
-	 * and frames free in each connected mixout sink buffer.
+	 * and frames free in each connected mixin sink buffer.
 	 */
 	for (i = 0; i < num_output_buffers; i++) {
-		struct comp_buffer __sparse_cache *unused_in_between_buf_c;
-		struct comp_dev *mixout;
-		uint16_t sink_id;
-		struct comp_buffer *sink;
-		struct mixout_data *mixout_data;
-		struct processing_module *mixout_mod;
-		struct module_source_info __sparse_cache *mod_source_info;
 		struct comp_buffer __sparse_cache *sink_c;
-		uint32_t free_frames, pending_frames;
 
-		/* unused buffer between mixin and mixout */
-		unused_in_between_buf_c = attr_container_of(output_buffers[i].data,
+		sink_c = attr_container_of(output_buffers[i].data,
 							    struct comp_buffer __sparse_cache,
 							    stream, __sparse_cache);
-		mixout = unused_in_between_buf_c->sink;
-		sink_id = IPC4_SRC_QUEUE_ID(unused_in_between_buf_c->id);
-
-		active_mixouts[i] = mixout;
-		sinks_ids[i] = sink_id;
-
-		sink = list_first_item(&mixout->bsink_list, struct comp_buffer, source_list);
-
-		mixout_mod = comp_get_drvdata(mixout);
-		mod_source_info = module_source_info_acquire(mixout_mod->source_info);
-		mixout_data = mod_source_info->private;
-		source_index = find_module_source_index(mod_source_info, dev);
-		if (source_index < 0) {
-			comp_err(dev, "No source info");
-			module_source_info_release(mod_source_info);
-			return -EINVAL;
-		}
-
-		sink_c = buffer_acquire(sink);
+		sinks_ids[i] = IPC4_SRC_QUEUE_ID(sink_c->id);
 
 		/* Normally this should never happen as we checked above
-		 * that mixout is in active state and so its sink buffer
-		 * should be already initialized in mixout .params().
+		 * that mixin is in active state and so its sink buffer
+		 * should be already initialized in mixin .params().
 		 */
 		if (!sink_c->hw_params_configured) {
-			comp_err(dev, "Uninitialized mixout sink buffer!");
-			buffer_release(sink_c);
-			module_source_info_release(mod_source_info);
+			comp_err(dev, "Uninitialized mixin sink buffer!");
 			return -EINVAL;
 		}
 
-		free_frames = audio_stream_get_free_frames(&sink_c->stream);
-
-		/* mixout sink buffer may still have not yet produced data -- data
-		 * consumed and written there by mixin on previous mixin_process() run.
-		 * We do NOT want to overwrite that data.
-		 */
-		pending_frames = mixout_data->pending_frames[source_index];
-		assert(free_frames >= pending_frames);
-		sinks_free_frames = MIN(sinks_free_frames, free_frames - pending_frames);
-
-		buffer_release(sink_c);
-		module_source_info_release(mod_source_info);
+		sinks_free_frames = MIN(audio_stream_get_free_frames(output_buffers[i].data),
+								     sinks_free_frames);
 	}
 
 	if (source_avail_frames > 0) {
-		struct comp_buffer __sparse_cache *source_c;
-
 		frames_to_copy = MIN(source_avail_frames, sinks_free_frames);
 		bytes_to_consume_from_source_buf =
 			audio_stream_period_bytes(input_buffers[0].data, frames_to_copy);
-		if (bytes_to_consume_from_source_buf > 0) {
-			input_buffers[0].consumed = bytes_to_consume_from_source_buf;
-			source_c = attr_container_of(input_buffers[0].data,
-						     struct comp_buffer __sparse_cache,
-						     stream, __sparse_cache);
-			buffer_stream_invalidate(source_c, bytes_to_consume_from_source_buf);
-		}
+		input_buffers[0].consumed = bytes_to_consume_from_source_buf;
 	} else {
 		/* if source does not produce any data -- do NOT block mixing but generate
 		 * silence as that source output.
 		 *
 		 * here frames_to_copy is silence size.
 		 */
+		/* FIXME: This will not work with 44.1 kHz !!! */
 		frames_to_copy = MIN(dev->frames, sinks_free_frames);
 	}
 
-	/* iterate over all connected mixouts and mix source data into each mixout sink buffer */
 	for (i = 0; i < num_output_buffers; i++) {
-		struct comp_dev *mixout;
-		struct comp_buffer *sink;
-		struct mixout_data *mixout_data;
-		struct module_source_info __sparse_cache *mod_source_info;
-		struct processing_module *mixout_mod;
-		uint32_t start_frame;
-		struct comp_buffer __sparse_cache *sink_c;
-		uint32_t writeback_size;
-
-		mixout = active_mixouts[i];
-		sink = list_first_item(&mixout->bsink_list, struct comp_buffer, source_list);
-
-		mixout_mod = comp_get_drvdata(mixout);
-		mod_source_info = module_source_info_acquire(mixout_mod->source_info);
-		mixout_data = mod_source_info->private;
-		source_index = find_module_source_index(mod_source_info, dev);
-		if (source_index < 0) {
-			comp_err(dev, "No source info");
-			module_source_info_release(mod_source_info);
-			return -EINVAL;
-		}
-
-		/* Skip data from previous run(s) not yet produced in mixout_process().
-		 * Normally start_frame would be 0 unless mixout pipeline has serious
-		 * performance problems with processing data on time in mixout.
-		 */
-		start_frame = mixout_data->pending_frames[source_index];
-
-		sink_c = buffer_acquire(sink);
-
 		/* if source does not produce any data but mixin is in active state -- generate
 		 * silence instead of that source data
 		 */
 		if (source_avail_frames == 0) {
 			/* generate silence */
-			silence(&sink_c->stream, start_frame, mixout_data->mixed_frames,
-				frames_to_copy);
+			audio_stream_set_zero(output_buffers[i].data,
+					      audio_stream_period_bytes(output_buffers[i].data,
+										frames_to_copy));
 		} else {
-			/* basically, if sink buffer has no data -- copy source data there, if
-			 * sink buffer has some data (written by another mixin) mix that data
-			 * with source data.
-			 */
-			ret = mix_and_remap(dev, mixin_data, sinks_ids[i], &sink_c->stream,
-					    start_frame, mixout_data->mixed_frames,
+			ret = copy_and_remap(dev, mixin_data, sinks_ids[i], output_buffers[i].data,
 					    input_buffers[0].data, frames_to_copy);
 			if (ret < 0) {
-				buffer_release(sink_c);
-				module_source_info_release(mod_source_info);
 				return ret;
 			}
 		}
 
-		/* it would be better to writeback memory region starting from start_frame and
-		 * of frames_to_copy size (converted to bytes, of course). However, seems
-		 * there is no appropreate API. Anyway, start_frame would be 0 most of the time.
-		 */
-		writeback_size = audio_stream_period_bytes(&sink_c->stream,
-							   frames_to_copy + start_frame);
-		if (writeback_size > 0)
-			buffer_stream_writeback(sink_c, writeback_size);
-		buffer_release(sink_c);
-
-		mixout_data->pending_frames[source_index] += frames_to_copy;
-
-		if (frames_to_copy + start_frame > mixout_data->mixed_frames)
-			mixout_data->mixed_frames = frames_to_copy + start_frame;
-
-		module_source_info_release(mod_source_info);
+		output_buffers[i].size = audio_stream_period_bytes(output_buffers[i].data,
+								   frames_to_copy);
 	}
 
 	return 0;
 }
 
-/* mixout just calls xxx_produce() on data mixed into its sink buffer by
- * mixins.
- */
+static void apply_gain_s16(struct audio_stream *stream, uint32_t sample_count,
+			   uint16_t gain_mul, uint8_t gain_shift)
+{
+	int16_t *ptr = stream->w_ptr;
+
+	while (sample_count > 0) {
+		uint32_t i, n;
+
+		ptr = audio_stream_wrap(stream, ptr);
+		n = MIN(audio_stream_samples_without_wrap_s16(stream, ptr), sample_count);
+
+		for (i = 0; i < n; i++) {
+			*ptr = ((int32_t)*ptr * gain_mul) >> gain_shift;
+			ptr++;
+		}
+
+		sample_count -= n;
+	}
+}
+
+static void apply_gain_s32(struct audio_stream *stream, uint32_t sample_count,
+			   uint16_t gain_mul, uint8_t gain_shift)
+{
+	int32_t *ptr = stream->w_ptr;
+
+	while (sample_count > 0) {
+		uint32_t i, n;
+
+		ptr = audio_stream_wrap(stream, ptr);
+		n = MIN(audio_stream_samples_without_wrap_s32(stream, ptr), sample_count);
+
+		for (i = 0; i < n; i++) {
+			*ptr = ((int64_t)*ptr * gain_mul) >> gain_shift;
+			ptr++;
+		}
+
+		sample_count -= n;
+	}
+}
+
+static void mix_s16(const struct audio_stream *source, struct audio_stream *sink,
+		    uint32_t sample_count)
+{
+	int16_t *src = source->r_ptr;
+	int16_t *dst = sink->w_ptr;
+
+	while (sample_count > 0) {
+		uint32_t i, n;
+
+		src = audio_stream_wrap(source, src);
+		dst = audio_stream_wrap(sink, dst);
+
+		n = MIN(audio_stream_samples_without_wrap_s16(source, src),
+		audio_stream_samples_without_wrap_s16(sink, dst));
+		n = MIN(n, sample_count);
+
+		for (i = 0; i < n; i++) {
+			*dst = sat_int16((int32_t)*src + (int32_t)*dst);
+			src++;
+			dst++;
+		}
+
+		sample_count -= n;
+	}
+}
+
+static void mix_s24(const struct audio_stream *source, struct audio_stream *sink,
+		    uint32_t sample_count)
+{
+	int32_t *src = source->r_ptr;
+	int32_t *dst = sink->w_ptr;
+
+	while (sample_count > 0) {
+		uint32_t i, n;
+
+		src = audio_stream_wrap(source, src);
+		dst = audio_stream_wrap(sink, dst);
+
+		n = MIN(audio_stream_samples_without_wrap_s32(source, src),
+		audio_stream_samples_without_wrap_s32(sink, dst));
+		n = MIN(n, sample_count);
+
+		for (i = 0; i < n; i++) {
+			*dst = sat_int24(*src + *dst);
+			src++;
+			dst++;
+		}
+
+		sample_count -= n;
+	}
+}
+
+static void mix_s32(const struct audio_stream *source, struct audio_stream *sink,
+		    uint32_t sample_count)
+{
+	int32_t *src = source->r_ptr;
+	int32_t *dst = sink->w_ptr;
+
+	while (sample_count > 0) {
+		uint32_t i, n;
+
+		src = audio_stream_wrap(source, src);
+		dst = audio_stream_wrap(sink, dst);
+
+		n = MIN(audio_stream_samples_without_wrap_s32(source, src),
+		audio_stream_samples_without_wrap_s32(sink, dst));
+		n = MIN(n, sample_count);
+
+		for (i = 0; i < n; i++) {
+			*dst = sat_int32((int64_t)*src + (int64_t)*dst);
+			src++;
+			dst++;
+		}
+
+		sample_count -= n;
+	}
+}
+
 static int mixout_process(struct processing_module *mod,
 			  struct input_stream_buffer *input_buffers, int num_input_buffers,
 			  struct output_stream_buffer *output_buffers, int num_output_buffers)
 {
-	struct module_source_info __sparse_cache *mod_source_info;
 	struct comp_dev *dev = mod->dev;
-	struct mixout_data *md;
-	uint32_t frames_to_produce = INT32_MAX;
-	uint32_t pending_frames;
-	uint32_t sink_bytes;
+	struct mixout_data *md = module_get_private_data(mod);
+	uint32_t avail_samples = INT32_MAX;
 	int i;
 
 	comp_dbg(dev, "mixout_process()");
 
-	mod_source_info = module_source_info_acquire(mod->source_info);
-	md = mod_source_info->private;
-
-	/* iterate over all connected mixins to find minimal value of frames they consumed
-	 * (i.e., mixed into mixout sink buffer). That is the amount that can/should be
-	 * produced now.
-	 */
 	for (i = 0; i < num_input_buffers; i++) {
-		const struct audio_stream __sparse_cache *source_stream;
-		struct comp_buffer __sparse_cache *unused_in_between_buf;
-		struct comp_dev *source;
-		int source_index;
-
-		source_stream = input_buffers[i].data;
-		unused_in_between_buf = attr_container_of(source_stream,
-							  struct comp_buffer __sparse_cache,
-							  stream, __sparse_cache);
-
-		source = unused_in_between_buf->source;
-
-		source_index = find_module_source_index(mod_source_info, source);
-		/* this shouldn't happen but skip even if it does and move to the next source */
-		if (source_index < 0)
-			continue;
-
-		pending_frames = md->pending_frames[source_index];
-
-		if (source->state == COMP_STATE_ACTIVE || pending_frames)
-			frames_to_produce = MIN(frames_to_produce, pending_frames);
+		avail_samples = MIN(audio_stream_get_avail_samples(input_buffers[i].data),
+				    avail_samples);
 	}
 
-	if (frames_to_produce > 0 && frames_to_produce < INT32_MAX) {
-		for (i = 0; i < num_input_buffers; i++) {
-			const struct audio_stream __sparse_cache *source_stream;
-			struct comp_buffer __sparse_cache *unused_in_between_buf;
-			struct comp_dev *source;
-			int source_index;
-			uint32_t pending_frames;
+	if (avail_samples > 0 && avail_samples < INT32_MAX) {
+		uint32_t samples_to_mix = MIN(audio_stream_get_free_samples(output_buffers[0].data), avail_samples);
+		uint32_t bytes_to_mix = samples_to_mix * audio_stream_sample_bytes(output_buffers[0].data);
 
-			source_stream = input_buffers[i].data;
-			unused_in_between_buf = attr_container_of(source_stream,
-								  struct comp_buffer __sparse_cache,
-								  stream, __sparse_cache);
+		audio_stream_copy(input_buffers[0].data, 0, output_buffers[0].data, 0, samples_to_mix);
+		input_buffers[0].consumed = bytes_to_mix;
 
-			source = unused_in_between_buf->source;
-
-			source_index = find_module_source_index(mod_source_info, source);
-			if (source_index < 0)
-				continue;
-
-			pending_frames = md->pending_frames[source_index];
-			if (pending_frames >= frames_to_produce)
-				md->pending_frames[source_index] -= frames_to_produce;
-			else
-				md->pending_frames[source_index] = 0;
+		for (i = 1; i < num_input_buffers; i++) {
+			md->mix_func(input_buffers[i].data, output_buffers[0].data, samples_to_mix);
+			input_buffers[i].consumed = bytes_to_mix;
 		}
 
-		assert(md->mixed_frames >= frames_to_produce);
-		md->mixed_frames -= frames_to_produce;
-
-		sink_bytes = frames_to_produce *
-				audio_stream_frame_bytes(output_buffers[0].data);
-		output_buffers[0].size = sink_bytes;
+		output_buffers[0].size = bytes_to_mix;
 	} else {
-		sink_bytes = dev->frames * audio_stream_frame_bytes(output_buffers[0].data);
+		/* FIXME: That will not work with 44.1 kHz !!! */
+		uint32_t sink_bytes = MIN(audio_stream_get_free_frames(output_buffers[0].data), dev->frames) * audio_stream_frame_bytes(output_buffers[0].data);
 		if (!audio_stream_set_zero(output_buffers[0].data, sink_bytes))
 			output_buffers[0].size = sink_bytes;
 		else
 			output_buffers[0].size = 0;
 	}
-
-	module_source_info_release(mod_source_info);
 
 	return 0;
 }
@@ -569,19 +436,20 @@ static int mixin_reset(struct processing_module *mod)
 
 	comp_dbg(dev, "mixin_reset()");
 
-	mixin_data->normal_mix_channel = NULL;
-	mixin_data->remap_mix_channel = NULL;
-	mixin_data->mute_channel = NULL;
+	mixin_data->gain_func = NULL;
 
 	return 0;
 }
 
 static int mixout_reset(struct processing_module *mod)
 {
+	struct mixout_data *mixout_data = module_get_private_data(mod);
 	struct comp_dev *dev = mod->dev;
 	struct list_item *blist;
 
 	comp_dbg(dev, "mixout_reset()");
+
+	mixout_data->mix_func = NULL;
 
 	/* FIXME: move this to module_adapter_reset() */
 	if (dev->pipeline->source_comp->direction == SOF_IPC_STREAM_PLAYBACK) {
@@ -622,9 +490,6 @@ static int mixin_params(struct processing_module *mod)
 
 	base_module_cfg_to_stream_params(&mod->priv.cfg.base_cfg, params);
 
-	/* Buffers between mixins and mixouts are not used (mixin writes data directly to mixout
-	 * sink). But, anyway, let's setup these buffers properly just in case.
-	 */
 	list_for_item(blist, &dev->bsink_list) {
 		struct comp_buffer *sink;
 		struct comp_buffer __sparse_cache *sink_c;
@@ -701,19 +566,14 @@ static int mixin_prepare(struct processing_module *mod)
 	/* currently inactive so setup mixer */
 	switch (fmt) {
 	case SOF_IPC_FRAME_S16_LE:
+		md->gain_func = apply_gain_s16;
+		break;
 	case SOF_IPC_FRAME_S24_4LE:
 	case SOF_IPC_FRAME_S32_LE:
-		md->normal_mix_channel = normal_mix_get_processing_function(fmt);
-		md->remap_mix_channel = remap_mix_get_processing_function(fmt);
-		md->mute_channel = mute_mix_get_processing_function(fmt);
+		md->gain_func = apply_gain_s32;
 		break;
 	default:
 		comp_err(dev, "unsupported data format %d", fmt);
-		return -EINVAL;
-	}
-
-	if (!md->normal_mix_channel || !md->remap_mix_channel || !md->mute_channel) {
-		comp_err(dev, "have not found the suitable processing function");
 		return -EINVAL;
 	}
 
@@ -796,10 +656,12 @@ static int mixout_params(struct processing_module *mod)
 
 static int mixout_prepare(struct processing_module *mod)
 {
-	struct module_source_info __sparse_cache *mod_source_info;
 	struct comp_dev *dev = mod->dev;
-	struct mixout_data *md;
-	int ret, i;
+	struct mixout_data *md = module_get_private_data(mod);
+	struct comp_buffer *sink;
+	struct comp_buffer __sparse_cache *sink_c;
+	enum sof_ipc_frame fmt;
+	int ret;
 
 	ret = mixout_params(mod);
 	if (ret < 0)
@@ -807,17 +669,26 @@ static int mixout_prepare(struct processing_module *mod)
 
 	comp_dbg(dev, "mixout_prepare()");
 
-	/*
-	 * Since mixout sink buffer stream is reset on .prepare(), let's
-	 * reset counters for not yet produced frames in that buffer.
-	 */
-	mod_source_info = module_source_info_acquire(mod->source_info);
-	md = mod_source_info->private;
-	md->mixed_frames = 0;
+	sink = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
+	sink_c = buffer_acquire(sink);
+	fmt = sink_c->stream.valid_sample_fmt;
+	buffer_release(sink_c);
 
-	for (i = 0; i < MIXOUT_MAX_SOURCES; i++)
-		md->pending_frames[i] = 0;
-	module_source_info_release(mod_source_info);
+	/* currently inactive so setup mixout */
+	switch (fmt) {
+	case SOF_IPC_FRAME_S16_LE:
+		md->mix_func = mix_s16;
+		break;
+	case SOF_IPC_FRAME_S24_4LE:
+		md->mix_func = mix_s24;
+		break;
+	case SOF_IPC_FRAME_S32_LE:
+		md->mix_func = mix_s32;
+		break;
+	default:
+		comp_err(dev, "unsupported data format %d", fmt);
+		return -EINVAL;
+	}
 
 	return 0;
 }


### PR DESCRIPTION
Reimplementation of mixin/mixout to support multi-core case when connected mixin and mixout are running on different cores.
Previous implementation had dead lock problem.