### PR TITLE
[SKIP SOF-TEST] .github/codestyle: drop spurious *.yml pattern

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -64,4 +64,4 @@ jobs:
           yamllint_config: '{extends: default, rules: {line-length: {max: 100}}}'
         run: yamllint -f parsable
           -d "$yamllint_config"
-          --strict .github/workflows/*.yml *.yml
+          --strict .github/workflows/*.yml


### PR DESCRIPTION
This suddenly failed in for PR #7551 in
https://github.com/thesofproject/sof/actions/runs/4998109337/jobs/8953192254

I have no idea why it never failed earlier (new yamllint version maybe?) but it's always been wrong and should have never been there anyway.

Fixes commit 3d69a7f69eb63e (".github: extend yamllint line-length to 100")