### PR TITLE
topology2: cavs-nocodec-bt: fix bclk for loopback A2DP case

### DIFF
--- a/tools/topology/topology2/platform/intel/bt-ssp-config-lbm.conf
+++ b/tools/topology/topology2/platform/intel/bt-ssp-config-lbm.conf
@@ -48,7 +48,7 @@ Object.Dai.SSP [
 			id		2
 			name		"BT-A2DP"
 			mclk_freq	$BT_MCLK
-			bclk_freq	3072000
+			bclk_freq	1536000
 			tdm_slot_width	16
 			format		"DSP_A"
 			bclk		"codec_consumer"


### PR DESCRIPTION
The BCLK was incorrect for the loopback (LBM) configuration for BT A2DP (48kHz 2ch 16bit), leading to incorrect playback/capture speed.