### PR TITLE
CODEOWNERS: Add NXP people as owners for scheduler

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -65,7 +65,7 @@ src/math/*				@singalsu
 src/ipc/*				@bardliao @marcinszkudlinski @pblaszko @aborisovich
 src/lib/*				@libinyang
 src/debug/gdb/*				@abonislawski
-src/schedule				@pblaszko @marcinszkudlinski
+src/schedule				@pblaszko @marcinszkudlinski @dbaluta @LaurentiuM1234
 
 # samples
 samples/audio/detect_test.c		@iganakov


### PR DESCRIPTION
With the work done for zephyr DMA domain we got a lot of insights about how scheduler works.

So add myself and Laurentiu as codeowners.