### PR TITLE
topology2: cavs-nocodec-bt: Remove duplicate route

### DIFF
--- a/tools/topology/topology2/cavs-nocodec-bt.conf
+++ b/tools/topology/topology2/cavs-nocodec-bt.conf
@@ -306,8 +306,4 @@ Object.Base.route [
 		source	"copier.SSP.10.1"
 		sink	"copier.host.9.1"
 	}
-	{
-		source	"copier.SSP.12.1"
-		sink	"copier.host.11.1"
-	}
 ]


### PR DESCRIPTION
This has already been added in bt-generic.conf.

The old topology looks like
![sof-nocodec-bt-mtl](https://github.com/thesofproject/sof/assets/7766921/4baa7cff-1f10-4ce4-9995-6322e69cfc0f)
and the new one looks like
![sof-nocodec-bt-mtl-1](https://github.com/thesofproject/sof/assets/7766921/398f9eb7-1513-455b-9123-20f303df7196)
