### PR TITLE
Change the naming convention for the ALH DAI copiers in topology

### DIFF
--- a/tools/topology/topology2/cavs-sdw-src-gain-mixin.conf
+++ b/tools/topology/topology2/cavs-sdw-src-gain-mixin.conf
@@ -11,7 +11,7 @@
 <tokens.conf>
 <virtual.conf>
 <src-gain-mixin-playback.conf>
-<mixout-gain-dai-copier-playback.conf>
+<mixout-gain-alh-dai-copier-playback.conf>
 <host-gateway-capture.conf>
 <io-gateway-capture.conf>
 <data.conf>
@@ -93,14 +93,12 @@ Object.Pipeline {
 		}
 	]
 
-	mixout-gain-dai-copier-playback [
+	mixout-gain-alh-dai-copier-playback [
 			{
 			index 2
 
-			Object.Widget.copier.1 {
+			Object.Widget.alh-copier.1 {
 				stream_name	$SDW_PLAYBACK_PCM
-				dai_type	"ALH"
-				copier_type	"ALH"
 				type		"dai_in"
 				node_type $ALH_LINK_OUTPUT_CLASS
 			}
@@ -128,19 +126,42 @@ Object.Pipeline {
 			}
 		}
 	]
+}
 
-	io-gateway-capture [
+# Capture pipeline widgets
+Object.Widget {
+	alh-copier [
 		{
+			stream_name	$SDW_CAPTURE_PCM
 			direction	"capture"
-			index 3
-			copier_type "ALH"
-			Object.Widget.copier.1 {
-				stream_name	$SDW_CAPTURE_PCM
-				dai_type	"ALH"
-				copier_type	"ALH"
-				type		"dai_out"
-				node_type $ALH_LINK_INPUT_CLASS
-			}
+			type		"dai_out"
+			index		3
+			node_type $ALH_LINK_INPUT_CLASS
+			num_input_audio_formats 1
+			num_output_audio_formats 1
+			num_output_pins 1
+
+			Object.Base.input_audio_format [
+				{
+					in_bit_depth		32
+					in_valid_bit_depth	32
+				}
+			]
+			Object.Base.output_audio_format [
+				{
+					out_bit_depth		32
+					out_valid_bit_depth	32
+				}
+			]
+		}
+	]
+
+	pipeline [
+		{
+			index		3
+			priority	0
+			lp_mode		0
+			dynamic_pipeline 1
 		}
 	]
 }
@@ -183,14 +204,14 @@ Object.Base.route [
 	}
         {
                 source 'gain.2.1'
-                sink 'copier.ALH.2.1'
+                sink 'alh-copier.$SDW_PLAYBACK_PCM.0'
         }
 	{
-		source	"copier.ALH.3.1"
+		source	"alh-copier.$SDW_CAPTURE_PCM.0"
 		sink	"host-copier.1.capture"
 	}
 	{
 		source 'host-copier.0.playback'
-		sink 'gain.1.1'
+		sink 'src.1.1'
 	}
 ]

--- a/tools/topology/topology2/cavs-sdw.conf
+++ b/tools/topology/topology2/cavs-sdw.conf
@@ -11,7 +11,7 @@
 <tokens.conf>
 <virtual.conf>
 <host-copier-gain-mixin-playback.conf>
-<mixout-gain-dai-copier-playback.conf>
+<mixout-gain-alh-dai-copier-playback.conf>
 <dai-copier-eqiir-module-copier-capture.conf>
 <gain-capture.conf>
 <gain-copier-capture.conf>
@@ -33,6 +33,7 @@
 <route.conf>
 <intel/common_definitions.conf>
 <copier.conf>
+<alh-dai-copier.conf>
 <module-copier.conf>
 <pipeline.conf>
 <dai.conf>

--- a/tools/topology/topology2/include/components/alh-dai-copier.conf
+++ b/tools/topology/topology2/include/components/alh-dai-copier.conf
@@ -1,0 +1,143 @@
+#
+# ALH DAI gateway copier
+#
+# ALH DAI copier widget. All attributes defined herein are namespaced
+# by alsatplg to "Object.Widget.alh-copier.N.attribute_name"
+#
+# Usage: this component can be used by instantiating it in the parent object. i.e.
+#
+# 	Object.Widget.alh-copier."N" {
+#		dai_index 0
+#		stream_name	"SDW1-Playback"
+#	}
+#
+# Where N is the unique instance number for the alh-copier object within the same alsaconf node.
+
+Class.Widget."alh-copier" {
+	#
+	# Pipeline ID for the alh-copier object
+	#
+	DefineAttribute."index" {}
+
+	# DAI index: this is always 0 when there is no aggregation.
+	DefineAttribute."dai_index" {
+		token_ref	"sof_tkn_dai.word"
+	}
+
+	#
+	# alh-copier object instance
+	#
+	DefineAttribute."instance" {}
+
+	#include common component definition
+	<include/components/widget-common.conf>
+
+	#
+	# alh-copier component UUID
+	#
+	DefineAttribute."uuid" {
+		type "string"
+		# Token set reference name and type
+		token_ref	"sof_tkn_comp.uuid"
+	}
+
+	#
+	# Bespoke Attribute Definitions for alh-copier
+	#
+
+        DefineAttribute."dai_type" {
+                type    "string"
+                token_ref       "sof_tkn_dai.string"
+        }
+
+	DefineAttribute."direction" {
+		type "string"
+		token_ref	"sof_tkn_dai.word"
+		constraints {
+			!valid_values [
+				"playback"
+				"capture"
+			]
+			!tuple_values [
+				0
+				1
+			]
+		}
+	}
+
+	#
+	# cycles per chunk processed
+	#
+	DefineAttribute."cpc" {
+		# Token set reference name and type
+		token_ref	"sof_tkn_comp.word"
+	}
+
+	DefineAttribute."bss_size" {}
+
+	DefineAttribute."is_pages" {
+		# Token set reference name and type
+		token_ref	"sof_tkn_comp.word"
+	}
+
+	DefineAttribute."node_type" {
+		# Token set reference name and type
+		token_ref	"sof_tkn_copier.word"
+		constraints {
+			!valid_values [
+				$ALH_LINK_OUTPUT_CLASS # ALH link output, legacy for SNDW (DSP ->)
+				$ALH_LINK_INPUT_CLASS # ALH link input, legacy for SNDW (DSP <-)
+			]
+		}
+	}
+
+	attributes {
+		#
+		# The alh-copier widget name would be constructed using the stream_name,
+		# direction and dai_index attributes. For ex: "alh-copier.SDW1-Playback.0".
+		#
+		!constructor [
+			"stream_name"
+			"dai_index"
+		]
+
+		#
+		# mandatory attributes that must be provided when the alh-copier class is
+		# instantiated
+		#
+		!mandatory [
+			"no_pm"
+			"num_input_audio_formats"
+			"num_output_audio_formats"
+			"node_type"
+		]
+
+		#
+		# immutable attributes cannot be modified in the object instance
+		# num_input_audio_formats for capture and num_output_formats for playback are
+		# mandatory even though the num_input_pins/num_output_pins are 0 because
+		# these are used to set the DMA buffer format.
+		#
+		!immutable [
+			"uuid"
+			"dai_type"
+		]
+
+		unique	"instance"
+	}
+
+	#
+	# Default attributes for alh-copier
+	#
+	#UUID: 9BA00C83-CA12-4A83-943C-1FA2E82F9DDA
+	uuid 		"83:0c:a0:9b:12:CA:83:4a:94:3c:1f:a2:e8:2f:9d:da"
+	no_pm 		"true"
+	core_id	0
+	cpc		1647
+	bss_size	280
+	dai_type	"ALH"
+	dai_index	0
+
+	# math expression for computing is_pages
+	is_pages "$[(($bss_size + 4095) & -4095) / 4096]"
+}

--- a/tools/topology/topology2/include/components/copier.conf
+++ b/tools/topology/topology2/include/components/copier.conf
@@ -52,7 +52,6 @@ Class.Widget."copier" {
 			!valid_values [
 				"HDA"
 				"SSP"
-				"ALH"
 				"DMIC"
 			]
 		}
@@ -66,7 +65,6 @@ Class.Widget."copier" {
                                 "SSP"
                                 "DMIC"
                                 "HDA"
-                                "ALH"
                         ]
                 }
         }
@@ -112,12 +110,6 @@ Class.Widget."copier" {
 				$DMIC_LINK_INPUT_CLASS # DMIC link input (DSP <-)
 				$I2S_LINK_OUTPUT_CLASS # I2S link output (DSP ->)
 				$I2S_LINK_INPUT_CLASS # I2S link input (DSP <-)
-				$ALH_LINK_OUTPUT_CLASS # ALH link output, legacy for SNDW (DSP ->)
-				$ALH_LINK_INPUT_CLASS # ALH link input, legacy for SNDW (DSP <-)
-				$ALH_SNDWIRE_STREAM_LINK_OUTPUT_CLASS # SNDW link output (DSP ->)
-				$ALH_SNDWIRE_STREAM_LINK_INPUT_CLASS # SNDW link input (DSP <-)
-				$ALH_UAOL_STREAM_LINK_OUTPUT_CLASS # UAOL link output (DSP ->)
-				$ALH_UAOL_STREAM_LINK_INPUT_CLASS # UAOL link input (DSP <-)
 				$IPC_OUTPUT_CLASS # IPC output (DSP ->)
 				$IPC_INPUT_CLASS # IPC input (DSP <-)
 				$I2S_MULTILINK_OUTPUT_CLASS # I2S Multi gtw output (DSP ->)

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-gain-alh-dai-copier-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-gain-alh-dai-copier-playback.conf
@@ -1,0 +1,109 @@
+#
+# BE playback pipeline: mixout-gain-alh-dai-copier.
+#
+# All attributes defined herein are namespaced
+# by alsatplg to "Object.Pipeline.mixout-gain-alh-dai-copier-playback.N.attribute_name"
+#
+# Usage: mixout-gain-alh-dai-copier-playback pipeline object can be instantiated as:
+#
+# Object.Pipeline.mixout-gain-alh-dai-copier-playback."N" {
+# 	time_domain	"timer"
+# 	rate		48000
+# }
+#
+# Where N is the unique pipeline ID within the same alsaconf node.
+#
+
+<include/common/audio_format.conf>
+<include/components/alh-dai-copier.conf>
+<include/components/gain.conf>
+<include/components/mixout.conf>
+<include/components/pipeline.conf>
+
+Class.Pipeline."mixout-gain-alh-dai-copier-playback" {
+
+	DefineAttribute."index" {}
+
+	<include/pipelines/pipeline-common.conf>
+
+	attributes {
+		!constructor [
+			"index"
+		]
+
+		!immutable [
+			"direction"
+		]
+
+		#
+		# mixout-gain-alh-dai-copier-playback objects instantiated within the same alsaconf
+		#  node must have unique instance attribute
+		#
+		unique	"instance"
+	}
+
+	Object.Widget {
+		mixout."1" {}
+		alh-copier."1" {
+			type dai_in
+			num_input_audio_formats 1
+			num_output_audio_formats 1
+			num_input_pins 1
+
+			# copier only supports one format based on mixin/mixout requirements:
+			# 32-bit 48KHz 2ch
+			Object.Base.input_audio_format [
+				{
+					in_bit_depth		32
+					in_valid_bit_depth	32
+				}
+			]
+			Object.Base.output_audio_format [
+				{
+					out_bit_depth		32
+					out_valid_bit_depth	32
+				}
+			]
+		}
+		gain."1" {
+			num_input_audio_formats 1
+			num_output_audio_formats 1
+
+			# 32-bit 48KHz 2ch
+			Object.Base.input_audio_format [
+				{
+					in_bit_depth		32
+					in_valid_bit_depth	32
+				}
+			]
+			Object.Base.output_audio_format [
+				{
+					out_bit_depth		32
+					out_valid_bit_depth	32
+				}
+			]
+		}
+
+		pipeline."1" {
+			priority		0
+			lp_mode		0
+		}
+	}
+
+	Object.Base {
+		route.1 {
+			source mixout.$index.1
+			sink	gain.$index.1
+		}
+	}
+
+	direction	"playback"
+	dynamic_pipeline 1
+	time_domain	"timer"
+	channels	2
+	channels_min	2
+	channels_max	2
+	rate		48000
+	rate_min	48000
+	rate_max	48000
+}

--- a/tools/topology/topology2/platform/intel/sdw-amp-generic.conf
+++ b/tools/topology/topology2/platform/intel/sdw-amp-generic.conf
@@ -138,7 +138,30 @@ IncludeByKey.NUM_SDW_AMP_LINKS {
 					dynamic_pipeline 1
 				}
 			]
+			# Add a virtual widget to connect the aggregated 2nd DAI copier
+			virtual [
+				{
+					name 'virtual.sdw-amp'
+					type input
+					index $ALH_2ND_SPK_ID
+				}
+			]
 		}
+
+		# Add the connection from the gain module to the aggregated 2nd DAI copier
+		# via the virtual widget. The virtual widget ensures that the routes between
+		# the gain and copier do not get established in the firmware. These are purely
+		# to show the existence of aggregation in the topology graph.
+		Object.Base.route [
+			{
+				source  "gain.21.1"
+				sink    "virtual.sdw-amp"
+			}
+			{
+				source  "virtual.sdw-amp"
+				sink    "alh-copier.$SDW_SPK_STREAM.1"
+			}
+		]
 	}
 }
 

--- a/tools/topology/topology2/platform/intel/sdw-amp-generic.conf
+++ b/tools/topology/topology2/platform/intel/sdw-amp-generic.conf
@@ -45,14 +45,12 @@ Object.Pipeline {
 		}
 	]
 
-	mixout-gain-dai-copier-playback [
+	mixout-gain-alh-dai-copier-playback [
 		{
 			index 21
 
-			Object.Widget.copier.1 {
+			Object.Widget.alh-copier.1 {
 				stream_name $SDW_SPK_STREAM
-				dai_type "ALH"
-				copier_type "ALH"
 				node_type $ALH_LINK_OUTPUT_CLASS
 			}
 			Object.Widget.gain.1 {
@@ -71,34 +69,73 @@ IncludeByKey.NUM_SDW_AMP_LINKS {
 			AMP_FEEDBACK_CH 4
 		}
 
-		Object.Pipeline {
-			io-gateway [
+		Object.Widget {
+			alh-copier [
 				{
-					direction	"playback"
 					index $ALH_2ND_SPK_ID
-					copier_type "ALH"
-					Object.Widget.copier.1 {
-						stream_name	$SDW_SPK_STREAM
-						dai_type	"ALH"
-						copier_type	"ALH"
-						type		"dai_in"
-						node_type $ALH_LINK_OUTPUT_CLASS
-					}
+					type dai_in
+					stream_name	$SDW_SPK_STREAM
+					dai_index	1
+					type		"dai_in"
+					direction	"playback"
+					node_type $ALH_LINK_OUTPUT_CLASS
+					num_input_audio_formats 1
+					num_output_audio_formats 1
+					num_input_pins 1
+
+					# 32-bit 48KHz 2ch
+					Object.Base.input_audio_format [
+						{
+							in_bit_depth            32
+							in_valid_bit_depth      32
+						}
+					]
+					Object.Base.output_audio_format [
+						{
+							out_bit_depth            32
+							out_valid_bit_depth      32
+						}
+					]
+				}
+				{
+					index $ALH_2ND_SPK_IN_ID
+					type dai_out
+					stream_name	$SDW_SPK_IN_STREAM
+					dai_index	1
+					type		"dai_out"
+					direction	"capture"
+					node_type $ALH_LINK_INPUT_CLASS
+					num_input_audio_formats 1
+					num_output_audio_formats 1
+					num_output_pins 1
+
+					# 32-bit 48KHz 2ch
+					Object.Base.input_audio_format [
+						{
+							in_bit_depth            32
+							in_valid_bit_depth      32
+						}
+					]
+					Object.Base.output_audio_format [
+						{
+							out_bit_depth            32
+							out_valid_bit_depth      32
+						}
+					]
 				}
 			]
-			io-gateway-capture	[
+			pipeline [
 				{
-					direction	"capture"
-					index $ALH_2ND_SPK_IN_ID
-					copier_type "ALH"
-
-					Object.Widget.copier.1 {
-						stream_name	$SDW_SPK_IN_STREAM
-						dai_type	"ALH"
-						copier_type	"ALH"
-						type		"dai_out"
-						node_type $ALH_LINK_INPUT_CLASS
-					}
+					index		$ALH_2ND_SPK_ID
+					priority	0
+					lp_mode	0
+					dynamic_pipeline 1
+				}
+				{
+					index		$ALH_2ND_SPK_IN_ID
+					priority	0
+					lp_mode	0
+					dynamic_pipeline 1
 				}
 			]
 		}
@@ -124,7 +161,7 @@ Object.PCM.pcm [
 Object.Base.route [
 	{
 		source	"gain.21.1"
-		sink	"copier.ALH.21.1"
+		sink	"alh-copier.$SDW_SPK_STREAM.0"
 	}
 	{
 		source 'mixin.20.1'
@@ -170,42 +207,65 @@ IncludeByKey.SDW_AMP_FEEDBACK {
 					}
 				}
 			]
-
-			io-gateway-capture [
+		}
+		Object.Widget {
+			alh-copier [
 				{
 					index 31
-					copier_type "ALH"
+					type dai_out
+					stream_name	$SDW_SPK_IN_STREAM
+					type		"dai_out"
+					direction	"capture"
+					node_type $ALH_LINK_INPUT_CLASS
+					num_input_audio_formats 1
+					num_output_audio_formats 1
+					num_output_pins 1
 
-					Object.Widget.copier.1 {
-						stream_name	$SDW_SPK_IN_STREAM
-						dai_type	"ALH"
-						copier_type	"ALH"
-						type		"dai_out"
-						node_type $ALH_LINK_INPUT_CLASS
-						#Use 4 channel format if there are 2 amps on different sdw links
-						IncludeByKey.NUM_SDW_AMP_LINKS {
-						"2"	{
-								Object.Base.input_audio_format [
-									{
-										in_channels		4
-										in_bit_depth		32
-										in_valid_bit_depth	32
-										in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-										in_ch_map	$CHANNEL_MAP_3_POINT_1
-									}
-								]
-								Object.Base.output_audio_format [
-									{
-										out_channels		4
-										out_bit_depth		32
-										out_valid_bit_depth	32
-										out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-										out_ch_map	$CHANNEL_MAP_3_POINT_1
-									}
-								]
-							}
+					IncludeByKey.NUM_SDW_AMP_LINKS {
+					"2"	{
+							Object.Base.input_audio_format [
+								{
+									in_channels		4
+									in_bit_depth		32
+									in_valid_bit_depth	32
+									in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+									in_ch_map	$CHANNEL_MAP_3_POINT_1
+								}
+							]
+							Object.Base.output_audio_format [
+								{
+									out_channels		4
+									out_bit_depth		32
+									out_valid_bit_depth	32
+									out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+									out_ch_map	$CHANNEL_MAP_3_POINT_1
+								}
+							]
 						}
+					"1"	{
+						# 32-bit 48KHz 2ch
+						Object.Base.input_audio_format [
+							{
+								in_bit_depth            32
+								in_valid_bit_depth      32
+							}
+						]
+						Object.Base.output_audio_format [
+							{
+								out_bit_depth            32
+								out_valid_bit_depth      32
+							}
+						]
 					}
+					}
+				}
+			]
+			pipeline [
+				{
+					index		31
+					priority	0
+					lp_mode	0
+					dynamic_pipeline 1
 				}
 			]
 		}
@@ -228,7 +288,7 @@ IncludeByKey.SDW_AMP_FEEDBACK {
 		]
 		Object.Base.route [
 			{
-				source	"copier.ALH.31.1"
+				source	"alh-copier.$SDW_SPK_IN_STREAM.0"
 				sink	"host-copier.3.capture"
 			}
 		]

--- a/tools/topology/topology2/platform/intel/sdw-dmic-generic.conf
+++ b/tools/topology/topology2/platform/intel/sdw-dmic-generic.conf
@@ -38,18 +38,42 @@ Object.Pipeline {
 			}
 		}
 	]
-	io-gateway-capture [
+}
+
+Object.Widget {
+	alh-copier [
 		{
-			direction	"capture"
 			index 41
-			copier_type "ALH"
-			Object.Widget.copier.1 {
-				stream_name	$SDW_DMIC_STREAM
-				dai_type	"ALH"
-				copier_type	"ALH"
-				type		"dai_out"
-				node_type $ALH_LINK_INPUT_CLASS
-			}
+			type dai_out
+			stream_name	$SDW_DMIC_STREAM
+			type		"dai_out"
+			direction	"capture"
+			node_type $ALH_LINK_INPUT_CLASS
+			num_input_audio_formats 1
+			num_output_audio_formats 1
+			num_output_pins 1
+
+			# 32-bit 48KHz 2ch
+			Object.Base.input_audio_format [
+				{
+					in_bit_depth            32
+					in_valid_bit_depth      32
+				}
+			]
+			Object.Base.output_audio_format [
+				{
+					out_bit_depth            32
+					out_valid_bit_depth      32
+				}
+			]
+		}
+	]
+	pipeline [
+		{
+			index		41
+			priority	0
+			lp_mode	0
+			dynamic_pipeline 1
 		}
 	]
 }
@@ -72,7 +96,7 @@ Object.PCM.pcm [
 
 Object.Base.route [
 	{
-		source	"copier.ALH.41.1"
+		source	"alh-copier.$SDW_DMIC_STREAM.0"
 		sink	"host-copier.4.capture"
 	}
 ]

--- a/tools/topology/topology2/platform/intel/sdw-jack-generic.conf
+++ b/tools/topology/topology2/platform/intel/sdw-jack-generic.conf
@@ -58,14 +58,12 @@ Object.Pipeline {
 		}
 	]
 
-	mixout-gain-dai-copier-playback [
+	mixout-gain-alh-dai-copier-playback [
 		{
 			index 1
 
-			Object.Widget.copier.1 {
+			Object.Widget.alh-copier.1 {
 				stream_name $SDW_JACK_OUT_STREAM
-				dai_type "ALH"
-				copier_type "ALH"
 				node_type $ALH_LINK_OUTPUT_CLASS
 			}
 			Object.Widget.gain.1 {
@@ -91,25 +89,55 @@ Object.Pipeline {
 			}
 		}
 	]
+}
 
-	highpass-capture-be [
+# Jack capture pipeline widgets
+Object.Widget {
+	alh-copier [
 		{
+			stream_name	$SDW_JACK_IN_STREAM
 			direction	"capture"
-			index 11
-			copier_type "ALH"
+			type		"dai_out"
+			index		11
+			node_type $ALH_LINK_INPUT_CLASS
+			num_input_audio_formats 1
+			num_output_audio_formats 1
+			num_output_pins 1
 
-			Object.Widget.copier.1 {
-				stream_name	$SDW_JACK_IN_STREAM
-				dai_type	"ALH"
-				copier_type	"ALH"
-				type		"dai_out"
-				node_type $ALH_LINK_INPUT_CLASS
+			Object.Base.audio_format.1 {
+				in_bit_depth		32
+				in_valid_bit_depth	32
+				out_bit_depth		32
+				out_valid_bit_depth	32
 			}
-			Object.Widget.eqiir.1 {
-				Object.Control.bytes."1" {
-					name '4 Main capture Iir Eq'
-				}
+		}
+	]
+
+	eqiir [
+		{
+			num_input_audio_formats 1
+			num_output_audio_formats 1
+			index		11
+			Object.Base.audio_format.1 {
+				in_bit_depth		32
+				in_valid_bit_depth	32
+				out_bit_depth		32
+				out_valid_bit_depth	32
 			}
+
+			Object.Control.bytes."1" {
+				<include/components/eqiir/highpass_40hz_0db_48khz.conf>
+				name '4 Main capture Iir Eq'
+			}
+		}
+	]
+
+	pipeline [
+		{
+			index		11
+			priority		0
+			lp_mode		0
+			dynamic_pipeline	1
 		}
 	]
 }
@@ -146,18 +174,18 @@ Object.PCM.pcm [
 Object.Base.route [
 	{
 		source	"gain.1.1"
-		sink	"copier.ALH.1.1"
+		sink	"alh-copier.$SDW_JACK_OUT_STREAM.0"
 	}
 	{
 		source "mixin.0.1"
 		sink "mixout.1.1"
 	}
 	{
-		source	"copier.ALH.11.1"
-		sink	"eqiir.11.1"
+		source	"alh-copier.$SDW_JACK_IN_STREAM.0"
+		sink	"eqiir.11.0"
 	}
 	{
-		source	"eqiir.11.1"
+		source	"eqiir.11.0"
 		sink	"host-copier.1.capture"
 	}
 	{


### PR DESCRIPTION
For ALH DAI, the new name is changed to reflect the link ID and index in an aggregated group like: dai-copier-ALH.SDW1-Playback.0 or alh-copier.SDW1-Playback.1

Also, today we do  not show the aggregated DAI copiers in the topology graph. So add a route via a virtual widget to show its existence as below
![sof-mtl-rt711-l0-rt1316-l23-rt714-l1](https://github.com/thesofproject/sof/assets/7766921/be2628ee-9c28-4769-b4a8-54ea0f4d3507)

