### PR TITLE
topology2: cavs-mixin-mixout-hda: Rename mixin-mixout mixers

### DIFF
--- a/tools/topology/topology2/cavs-mixin-mixout-hda.conf
+++ b/tools/topology/topology2/cavs-mixin-mixout-hda.conf
@@ -40,7 +40,7 @@ Object.Pipeline {
 			}
 			Object.Widget.gain.1 {
 				Object.Control.mixer.1 {
-					name '2 Main Playback Volume'
+					name 'Post Mixer $ANALOG_PLAYBACK_PCM Volume'
 				}
 			}
 		}
@@ -56,7 +56,7 @@ Object.Pipeline {
 
 			Object.Widget.gain.1 {
 				Object.Control.mixer.1 {
-					name '1 2nd Playback Volume'
+					name 'Pre Mixer $ANALOG_PLAYBACK_PCM Volume'
 				}
 			}
 		}


### PR DESCRIPTION
Rename mixin and mixout Analog Playback volumes. Rewrite the names of the mixers to better reflect their position in the topology.

As a result of this commit mixers are renamed in sof-hda-generic.tplg.

'gain.1.1 1 2nd Playback Volume' becomes
'gain.1.1 Pre Mixer Analog Playback Volume'

and

'gain.2.1 2 Main Playback Volume' becomes
'gain.2.1 Post Mixer Analog Playback Volume'