### PR TITLE
workflows: Zephyr workflow uses new 0.16.1 Zephyr SDK

### DIFF
--- a/.github/workflows/sparse-zephyr.yml
+++ b/.github/workflows/sparse-zephyr.yml
@@ -15,9 +15,9 @@ jobs:
   # sof/scripts/parse_sparse_output.sh
   warnings-subset:
 
-    # We're sharing binaries with the zephyr-build container so keep
+    # We're sharing the sparse binary with the zephyr-build container so keep
     # this in sync with it.
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -211,13 +211,6 @@ jobs:
           path: zephyr-sdk-0.16.1_windows-x86_64.7z
           key: ${{ runner.os }}-cache-zephyr-sdk-0-16-1
 
-      # Unzip is needed by Zephyr SDK setup.cmd installation script
-      - name: Download unzip
-        if: ${{ steps.cache-unzip.outputs.cache-hit != 'true' }}
-        run: |
-          curl -L -o unzip-5.51-1-bin.zip `
-          https://gnuwin32.sourceforge.net/downlinks/unzip-bin-zip.php
-
       # Wget is needed by Zephyr SDK setup.cmd installation script
       - name: Download wget
         if: ${{ steps.cache-wget.outputs.cache-hit != 'true' }}

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -59,7 +59,7 @@ jobs:
           fi
 
   build-linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -204,12 +204,12 @@ jobs:
 
       # Keep this SDK version identical to the one in
       # sof/zephyr/docker-run.sh
-      - name: Cache Zephyr SDK 0.15.2
+      - name: Cache Zephyr SDK 0.16.1
         id: cache-zephyr-sdk
         uses: actions/cache@v3.0.11
         with:
-          path: zephyr-sdk-0.15.2_windows-x86_64.zip
-          key: ${{ runner.os }}-cache-zephyr-sdk-0-15-2
+          path: zephyr-sdk-0.16.1_windows-x86_64.7z
+          key: ${{ runner.os }}-cache-zephyr-sdk-0-16-1
 
       # Unzip is needed by Zephyr SDK setup.cmd installation script
       - name: Download unzip
@@ -224,15 +224,17 @@ jobs:
         run: |
           curl -L -O http://downloads.sourceforge.net/gnuwin32/wget-1.11.4-1-bin.zip
 
-      - name: Download Zephyr SDK 0.15.2
+      - name: Download Zephyr SDK 0.16.1
         if: ${{ steps.cache-zephyr-sdk.outputs.cache-hit != 'true' }}
         run: |  # yamllint disable-line rule:line-length
           curl -L -O `
-          https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.2/zephyr-sdk-0.15.2_windows-x86_64.zip
+          https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.1/zephyr-sdk-0.16.1_windows-x86_64.7z
 
       # Unzips every .zip package to directory matching its name without extension
       - name: Unzip downloaded packages
-        run: 7z x *.zip -o*
+        run: |
+          7z x *.zip -o*
+          7z x *.7z -o*
 
       - name: Add unzip to system PATH
         run: |
@@ -249,7 +251,7 @@ jobs:
       # setup.cmd may not be called in from msys shell as it does not parse
       # forward slash script input arguments correctly.
       - name: Install Zephyr SDK
-        run: zephyr-sdk-0.15.2_windows-x86_64/zephyr-sdk-0.15.2/setup.cmd /t all /h /c
+        run: zephyr-sdk-0.16.1_windows-x86_64/zephyr-sdk-0.16.1/setup.cmd /t all /h /c
 
       - name: Setup Python
         uses: actions/setup-python@v4

--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: fa5117225af9c2167449d79cccd5f0e81bb10696
+      revision: 9fc99928caf04c3ae78871f803ce8cee83541ae0
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision

--- a/zephyr/docker-run.sh
+++ b/zephyr/docker-run.sh
@@ -18,10 +18,10 @@
 # use this script with a image other than the one officially tagged
 # "latest", simply overwrite the official tag. Example:
 #
-#   docker tag ghcr.io/zephyrproject-rtos/zephyr-build:v0.24.1
+#   docker tag ghcr.io/zephyrproject-rtos/zephyr-build:v0.26.4
 #              ghcr.io/zephyrproject-rtos/zephyr-build:latest
 #
-# "latest" is just a regular tag like "v0.24.1", it may or many not name
+# "latest" is just a regular tag like "v0.26.4", it may or many not name
 # the most recent image.
 #
 # To automatically restore the official "latest" tag, just delete it:
@@ -54,7 +54,7 @@ main()
 
 run_command()
 {
-    # zephyr-build:v0.24.13 has /opt/toolchains/zephyr-sdk-0.15.2
+    # zephyr-build:v0.26.4 has /opt/toolchains/zephyr-sdk-0.16.1
     # https://hub.docker.com/r/zephyrprojectrtos/zephyr-build/tags
     #
     # Keep this SDK version identical to the one in
@@ -63,7 +63,7 @@ run_command()
            --workdir /zep_workspace \
            $SOF_DOCKER_RUN \
            --env REAL_CC --env http_proxy --env https_proxy \
-           ghcr.io/zephyrproject-rtos/zephyr-build:v0.24.13 \
+           ghcr.io/zephyrproject-rtos/zephyr-build:v0.26.4 \
            ./sof/scripts/sudo-cwd.sh "$@"
 }
 


### PR DESCRIPTION
Updated Zephyr workflow - installed new Zephyr SDK v0.16.1 that is required by Zephyr main branch.
New Zephyr SDK is **NOT** backward compatible to older Zephyr revisions so the upgrade in `west.yml` is done to the commit: https://github.com/zephyrproject-rtos/zephyr/commit/9fc99928caf0 that requires this toolchain.
Build-windows job changes:
* new Zephyr SDK had changed extension and now is compressed using 7z format.
* from build-windows workflow removed unzip package that is no longer required by the setup.cmd Zephyr SDK installation script

Build-linux job changes:
* updated script `zephyr\docker-run.sh` that clones Zephyr Docker container to clone latest tag versioned v0.26.4.
* new container contains Zephyr SDK v0.16.1
* upgraded runner OS to Ubuntu 22.04 to match OS from Docker container

Sparse-Zephyr workflow:
* upgraded runner OS to Ubuntu 22.04 to match OS from the Zephyr workflow.

Signed-off-by: Andrey Borisovich <andrey.borisovich@intel.com>