### PR TITLE
smex/cmake: move -Wl,EL option to target_linker_options() for clang

### DIFF
--- a/smex/CMakeLists.txt
+++ b/smex/CMakeLists.txt
@@ -19,7 +19,11 @@ add_executable(smex
 
 # In addition to the usual flags from CMAKE_BUILD_TYPE
 target_compile_options(smex PRIVATE
-	-Wall -Werror -Wl,-EL -Wmissing-prototypes -Wimplicit-fallthrough=3
+	-Wall -Werror -Wmissing-prototypes -Wimplicit-fallthrough
+)
+
+target_link_options(smex PRIVATE
+	-Wall -Werror -Wl,-EL
 )
 
 target_include_directories(smex PRIVATE


### PR DESCRIPTION
-Wl,EL is a linker option, not a compiler option and clang does not like it at compilation time; it fails like this:
```
cd smex
cmake -B build -DCMAKE_C_COMPILER=clang
make -C build

clang-15: error: -Wl,-EL: 'linker' input unused
          [-Werror,-Wunused-command-line-argument]
```

Reported by @andyross in https://github.com/google/oss-fuzz/pull/10342

oss-fuzz does not need smex at all but this one-line fix is just faster and simpler than a bigger CMake re-architecture just for oss-fuzz.

Also simplify this for clang compatibility:
```
error: unknown warning option '-Wimplicit-fallthrough=3'; did you mean
     '-Wimplicit-fallthrough'? [-Werror,-Wunknown-warning-option]
```