### PR TITLE
dai: always reload dma ll chain

### DIFF
--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -1577,6 +1577,7 @@ int dai_zephyr_copy(struct dai_data *dd, struct comp_dev *dev, pcm_converter_fun
 	/* return if nothing to copy */
 	if (!copy_bytes) {
 		comp_warn(dev, "dai_zephyr_copy(): nothing to copy");
+		dma_reload(dd->chan->dma->z_dev, dd->chan->index, 0, 0, 0);
 		return 0;
 	}
 


### PR DESCRIPTION
A problem was observed with launching capture with dmic. Sometimes the host starts reading data too late, so that the capture buffer becomes full. In this case, the dma descriptors are not reloaded. This leads to stopping the dma. When the host starts reading and reads the accumulated data the stream is already stopped. With this patch, the descriptors are always reloaded and the stream will not be stopped. A glitch may occur but it is better than no data at all.