### PR TITLE
Tools: Test: Audio: Add test for level dependent gain

### DIFF
--- a/tools/test/audio/std_utils/ldlg_test_input.m
+++ b/tools/test/audio/std_utils/ldlg_test_input.m
@@ -1,0 +1,72 @@
+function test = ldlg_test_input(test)
+
+%% t = ldlg_test_input(t)
+%
+% Create tone data file for playback & record on real device or
+% for algorithm simulation.
+%
+% Input parameters
+% t.fs        - sample rate
+% t.bits_in   - signal word length
+% t.ch        - mix test signal to channel ch
+% t.nch       - total number of channels in data
+%
+% Output parameters
+% t.fn_in     - created input file name
+% t.fn_out    - proposed output file name for captured output
+% t.f         - test signal frequency
+% t.tl        - tone length in seconds
+% t.ts        - tone start time
+% t.tr        - tone gain ramp length in seconds
+% t.ti        - ignore time from tone start and end, must be ti > tr
+% t.a         - tone amplitude (lin)
+% t.a_db      - tone amplitude (dB)
+% t.mark_t    - length of marker tone in seconds
+% t.mark_a    - amplitude max of marker tone (lin)
+% t.mark_a_db - amplitude max of marker tone (dB)
+%
+
+% SPDX-License-Identifier: BSD-3-Clause
+% Copyright(c) 2017 Intel Corporation. All rights reserved.
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+
+%% Reference: AES17 8.1 Level-dependent logarithmic gain
+%  http://www.aes.org/publications/standards/
+
+if nargin < 1
+        fprintf('Warning, using default parameters!\n');
+        test.fs = 48e3; test.bits=32; test.ch=1; test.nch=1;
+end
+
+if test.ch == 0
+        test.ch = 1+round(rand(1,1)*(test.nch-1)); % Test random channel 1..Nch
+end
+
+for ch = test.ch
+    fprintf('Using parameters Fs=%.1f, bits_in=%d, ch=%d, Nch=%d\n', ...
+        test.fs/1e3, test.bits_in, ch, test.nch);
+end
+
+id = floor(rand(1,1) * 1e6);
+test.fn_in = sprintf('ldlg_test_in_%d.%s', id, test.fmt);
+test.fn_out = sprintf('ldlg_test_out_%d.%s', id, test.fmt);
+test.f = 997;
+
+
+%% Tone sweep parameters
+test.is = 30e-3; % Ignore signal from tone start
+test.ie = 20e-3; % Ignore signal from tone end
+test.tr = 10e-3; % Gain ramp time for tones
+test.sm = 3; % Seek start marker from 3s from start
+test.em = 3; % Seek end marker from 3s from end
+test.mt = 0.3; % Error if marker positions delta is greater than 0.3s
+test.tc = 25; % Min. 20 cycles of sine wave for a frequency
+test.a_db = 0:-1:-60; % 0 to -60 dBFS
+test.a = 10.^(test.a_db/20);
+% 250ms seconds tone, this will be adjusted to be integer number of samples
+test.tl = 250e-3;
+
+%% Mix the input file for test and write output
+test = mix_sweep(test);
+
+end

--- a/tools/test/audio/std_utils/ldlg_test_measure.m
+++ b/tools/test/audio/std_utils/ldlg_test_measure.m
@@ -1,0 +1,80 @@
+function test = ldlg_test_measure(test)
+
+% SPDX-License-Identifier: BSD-3-Clause
+% Copyright(c) 2017 Intel Corporation. All rights reserved.
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+
+%% Reference: AES17 8.1 Level dependent logarithmic gain
+%  http://www.aes.org/publications/standards/
+
+default_result = NaN * ones(test.na, length(test.ch));
+test.gain_db = default_result;
+
+%% Load output file
+[x, nx] = load_test_output(test);
+
+if nx == 0
+	test.fail = 1;
+	return
+end
+
+%% 1/3 octave filter
+fc = test.f;
+bw = 1/3;
+fmin = fc / sqrt(2^bw);
+fmax = fmin * 2^bw;
+wn = 2 * [fmin fmax] / test.fs;
+[b, a] = butter(4, wn);
+y0 = filter(b, a, x);
+
+%% Find sync
+[d, nt, nt_use, nt_skip] = find_test_signal(x, test);
+if isempty(d)
+	test.fail = 1;
+	return
+end
+
+%% Measure gains for sweep
+level_in = test.a_db(:);
+for n=1:test.na
+	i1 = d + (n-1) * nt + nt_skip;
+	i2 = i1 + nt_use - 1;
+	level_out(n,:) = level_dbfs(y0(i1:i2,:));
+end
+
+test.gain_db = level_out - level_in + test.att_rec_db;
+test.level_in_db = level_in;
+test.level_out_db = level_out + test.att_rec_db;
+test.fail = 0;
+
+test.fh(1) = figure('visible', test.plot_visible);
+test.ph(1) = subplot(1, 1, 1);
+if test.plot_channels_combine
+	plot(level_in, level_out);
+	hold on
+	p1 = min(level_in);
+	p2 = max(level_in);
+	plot([p1 p2], [p1 p2], 'k--');
+	hold off
+	grid on
+	xlabel('Input level (dBFS)');
+	ylabel('Output level (dBFS)');
+	if test.nch == 2
+		legend('ch1', 'ch2', 'Location', 'NorthWest');
+	end
+end
+
+test.fh(2) = figure('visible', test.plot_visible);
+test.ph(2) = subplot(1, 1, 1);
+if test.plot_channels_combine
+	plot(level_in, test.gain_db);
+	hold on
+	plot([p1 p2], [0 0], 'k--');
+	hold off
+	grid on
+	xlabel('Input level (dBFS)');
+	ylabel('Gain (dB)');
+	if test.nch == 2
+		legend('ch1', 'ch2');
+	end
+end


### PR DESCRIPTION
This patch adds to process_test.m test with amplitude sweep to determine level dependent logarithmic gain.

Currently there is no test pass/fail criteria. But the test result plot can be examined from directory plots. E.g. first full test for DRC with "process_test('drc', 32, 32, 48000, 1);".

The view the plots from shell with "eog plots/ldlg_drc_*.png". Or examine the plots directory with a file maneger GUI.