### PR TITLE
[DNM][DRAFT] ipc4: base_fw: set PG policy implementation

### DIFF
--- a/src/lib/pm_runtime.c
+++ b/src/lib/pm_runtime.c
@@ -144,6 +144,13 @@ bool pm_runtime_is_active(enum pm_runtime_context context, uint32_t index)
 #endif
 }
 
+#if defined(CONFIG_PM_POLICY_CUSTOM)
+void pm_runtime_pg_policy_set(uint32_t ticks)
+{
+	platform_pm_runtime_pg_policy_set(ticks);
+}
+#endif
+
 #if CONFIG_DSP_RESIDENCY_COUNTERS
 void init_dsp_r_state(enum dsp_r_state r_state)
 {

--- a/xtos/include/sof/lib/pm_runtime.h
+++ b/xtos/include/sof/lib/pm_runtime.h
@@ -148,6 +148,9 @@ static inline struct pm_runtime_data *pm_runtime_data_get(void)
 	return sof_get()->prd;
 }
 
+#if defined(CONFIG_PM_POLICY_CUSTOM)
+void pm_runtime_pg_policy_set(uint32_t ticks);
+#endif
 #if CONFIG_DSP_RESIDENCY_COUNTERS
 /**
  * \brief Initializes DSP residency counters.


### PR DESCRIPTION
Implementation of IPC4_POWER_GATING_POLICY.

Message allows SW on host to dynamically adjust of DSP power gating policy. According to the needs, SW can change number of minimal clock cycles during which the core will enter the d0i3 state.