### PR TITLE
xtensa-build-zephyr: parse SOF versions from new versions.json instead of generated sof_versions.h

### DIFF
--- a/scripts/cmake/version.cmake
+++ b/scripts/cmake/version.cmake
@@ -87,6 +87,7 @@ string(JSON SOF_MICRO ERROR_VARIABLE micro_error
 if(NOT "${micro_error}" STREQUAL "NOTFOUND")
 	message(STATUS "versions.json: ${micro_error}, defaulting to 0")
 	# TODO: default this to .99 on the main, never released branch like zephyr does
+	# Keep this default SOF_MICRO the same as the one in xtensa-build-zephyr.py
 	set(SOF_MICRO 0)
 endif()
 

--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -670,6 +670,11 @@ def build_platforms():
 	see https://docs.zephyrproject.org/latest/guides/west/build-flash-debug.html#one-time-cmake-arguments
 	Try "west config build.cmake-args -- ..." instead.""")
 
+		sign_cmd = ["west"]
+		sign_cmd += ["-v"] * args.verbose
+		sign_cmd += ["sign", "--build-dir", platform_build_dir_name, "--tool", "rimage"]
+		sign_cmd += rimage_configuration(platform_dict)
+
 		# Make sure the build logs don't leave anything hidden
 		execute_command(['west', 'config', '-l'], cwd=west_top)
 
@@ -691,11 +696,6 @@ def build_platforms():
 		execute_command([str(smex_executable), "-l", str(fw_ldc_file), str(input_elf_file)])
 
 		# Sign firmware
-		sign_cmd = ["west"]
-		sign_cmd += ["-v"] * args.verbose
-		sign_cmd += ["sign", "--build-dir", platform_build_dir_name, "--tool", "rimage"]
-		sign_cmd += rimage_configuration(platform_dict)
-
 		execute_command(sign_cmd, cwd=west_top)
 
 		if platform not in RI_INFO_UNSUPPORTED:

--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -525,7 +525,6 @@ def rimage_configuration(platform_dict):
 	sign_cmd = []
 
 	rimage_executable = shutil.which("rimage", path=RIMAGE_BUILD_DIR)
-	rimage_config = RIMAGE_SOURCE_DIR / "config"
 
 	sign_cmd += ["--tool-path", rimage_executable]
 	signing_key = ""
@@ -536,7 +535,7 @@ def rimage_configuration(platform_dict):
 	else:
 		signing_key = default_rimage_key
 
-	sign_cmd += ["--tool-data", str(rimage_config), "--", "-k", str(signing_key)]
+	sign_cmd += ["--", "-k", str(signing_key)]
 
 	sof_fw_vers = get_sof_version()
 
@@ -551,8 +550,11 @@ def rimage_configuration(platform_dict):
 	sign_cmd += ["-b", "1"]
 
 	if args.ipc == "IPC4":
-		rimage_desc = pathlib.Path(SOF_TOP, "rimage", "config", platform_dict["IPC4_RIMAGE_DESC"])
-		sign_cmd += ["-c", str(rimage_desc)]
+		rimage_desc = platform_dict["IPC4_RIMAGE_DESC"]
+	else:
+		rimage_desc = platform_dict["name"] + ".toml"
+
+	sign_cmd += ["-c", str(RIMAGE_SOURCE_DIR / "config" / rimage_desc)]
 
 	return sign_cmd
 

--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -528,13 +528,19 @@ def rimage_configuration(platform_dict):
 
 	sign_cmd += ["--tool-path", rimage_executable, "--"]
 
-	sign_cmd += rimage_options(platform_dict)
+	# Flatten the list of [ ( "-o", "value" ), ...] tuples
+	for t in rimage_options(platform_dict):
+		sign_cmd += t
+
 	return sign_cmd
 
 
 def rimage_options(platform_dict):
+	"""Return a list of default rimage options as a list of tuples,
+	example: [ (-f, 2.5.0), (-b, 1), (-k, key.pem),... ]
 
-	sign_cmd = []
+	"""
+	opts = []
 
 	signing_key = ""
 	if args.key:
@@ -544,11 +550,11 @@ def rimage_options(platform_dict):
 	else:
 		signing_key = default_rimage_key
 
-	sign_cmd += ["-k", str(signing_key)]
+	opts.append(("-k", str(signing_key)))
 
 	sof_fw_vers = get_sof_version()
 
-	sign_cmd += ["-f", sof_fw_vers]
+	opts.append(("-f", sof_fw_vers))
 
 	# Default value is 0 in rimage but for Zephyr the "build counter" has always
 	# been hardcoded to 1 in CMake and there is even a (broken) test that fails
@@ -556,16 +562,16 @@ def rimage_options(platform_dict):
 	# FIXME: drop this line once the following test is fixed
 	# tests/avs/fw_00_basic/test_01_load_fw_extended.py::TestLoadFwExtended::()::
 	#                         test_00_01_load_fw_and_check_version
-	sign_cmd += ["-b", "1"]
+	opts.append(("-b", "1"))
 
 	if args.ipc == "IPC4":
 		rimage_desc = platform_dict["IPC4_RIMAGE_DESC"]
 	else:
 		rimage_desc = platform_dict["name"] + ".toml"
 
-	sign_cmd += ["-c", str(RIMAGE_SOURCE_DIR / "config" / rimage_desc)]
+	opts.append(("-c", str(RIMAGE_SOURCE_DIR / "config" / rimage_desc)))
 
-	return sign_cmd
+	return opts
 
 
 STAGING_DIR = None

--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -526,7 +526,16 @@ def rimage_configuration(platform_dict):
 
 	rimage_executable = shutil.which("rimage", path=RIMAGE_BUILD_DIR)
 
-	sign_cmd += ["--tool-path", rimage_executable]
+	sign_cmd += ["--tool-path", rimage_executable, "--"]
+
+	sign_cmd += rimage_options(platform_dict)
+	return sign_cmd
+
+
+def rimage_options(platform_dict):
+
+	sign_cmd = []
+
 	signing_key = ""
 	if args.key:
 		signing_key = args.key
@@ -535,7 +544,7 @@ def rimage_configuration(platform_dict):
 	else:
 		signing_key = default_rimage_key
 
-	sign_cmd += ["--", "-k", str(signing_key)]
+	sign_cmd += ["-k", str(signing_key)]
 
 	sof_fw_vers = get_sof_version()
 

--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -277,9 +277,9 @@ def execute_command(*run_args, **run_kwargs):
 		env_arg = run_kwargs.get('env')
 		env_change = set(env_arg.items()) - set(os.environ.items()) if env_arg else None
 		if env_change and (run_kwargs.get('sof_log_env') or args.verbose >= 1):
-			output += "\n... with extra/modified environment:"
+			output += "\n... with extra/modified environment:\n"
 			for k_v in env_change:
-				output += f"\n{k_v[0]}={k_v[1]}"
+				output += f"{k_v[0]}={k_v[1]}\n"
 		print(output, flush=True)
 
 	run_kwargs = {k: run_kwargs[k] for k in run_kwargs if not k.startswith("sof_")}


### PR DESCRIPTION
\+ move some rimage-related code around to prepare for the switch to `west build` (1st part of successfully tested  draft TEST PR #7595)

No functional change.

One of the last parts for this v2.6 requirement:
- #6917