### PR TITLE
dts: handle the zero config size in apply_config instead of set_configuration

### DIFF
--- a/src/audio/module_adapter/module/dts.c
+++ b/src/audio/module_adapter/module/dts.c
@@ -316,10 +316,10 @@ static int dts_codec_apply_config(struct processing_module *mod)
 	config_header_size = sizeof(config->size) + sizeof(config->avail);
 	if (config->size < config_header_size) {
 		comp_err(dev, "dts_codec_apply_config() config->data is invalid");
-		return -EINVAL;
+		return 0;
 	} else if (config->size == config_header_size) {
 		comp_err(dev, "dts_codec_apply_config() size of config->data is 0");
-		return -EINVAL;
+		return 0;
 	}
 
 	/* Calculate size of config->data */
@@ -434,10 +434,6 @@ dts_codec_set_configuration(struct processing_module *mod, uint32_t config_id,
 	/* return if more fragments are expected or if the module is not prepared */
 	if ((pos != MODULE_CFG_FRAGMENT_LAST && pos != MODULE_CFG_FRAGMENT_SINGLE) ||
 	    md->state < MODULE_INITIALIZED)
-		return 0;
-
-	/* return if configuration size is 0 */
-	if (!md->new_cfg_size)
 		return 0;
 
 	/* whole configuration received, apply it now */

--- a/tools/topology/topology2/cavs-sdw.conf
+++ b/tools/topology/topology2/cavs-sdw.conf
@@ -37,6 +37,8 @@
 <pipeline.conf>
 <dai.conf>
 <host.conf>
+<input_audio_format.conf>
+<output_audio_format.conf>
 <dmic-default.conf>
 <hdmi-default.conf>
 

--- a/tools/topology/topology2/platform/intel/sdw-amp-generic.conf
+++ b/tools/topology/topology2/platform/intel/sdw-amp-generic.conf
@@ -163,9 +163,8 @@ IncludeByKey.SDW_AMP_FEEDBACK {
 				}
 			]
 
-			io-gateway [
+			io-gateway-capture [
 				{
-					direction	"capture"
 					index 31
 					copier_type "ALH"
 
@@ -175,6 +174,29 @@ IncludeByKey.SDW_AMP_FEEDBACK {
 						copier_type	"ALH"
 						type		"dai_out"
 						node_type $ALH_LINK_INPUT_CLASS
+						#Use 4 channel format if there are 2 amps on different sdw links
+						IncludeByKey.NUM_SDW_AMP_LINKS {
+						"2"	{
+								Object.Base.input_audio_format [
+									{
+										in_channels		4
+										in_bit_depth		32
+										in_valid_bit_depth	32
+										in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+										in_ch_map	$CHANNEL_MAP_3_POINT_1
+									}
+								]
+								Object.Base.output_audio_format [
+									{
+										out_channels		4
+										out_bit_depth		32
+										out_valid_bit_depth	32
+										out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+										out_ch_map	$CHANNEL_MAP_3_POINT_1
+									}
+								]
+							}
+						}
 					}
 				}
 			]


### PR DESCRIPTION
To handle zero config size case in set_configuration would let dts_codec_apply_config() never be called due to early return when checking if md->new_config_size is zero. This causes the problem that DTS tuning parameter would never be set. We've found this issue on the latest Chrome OS version on RPL. So, instead, check the config size in dts_codec_apply_config() could resolve the zero config case and let the tuning parameter could be set successfully. 