### PR TITLE
dts: handle zero config size case in apply_config instead of set_configuration

### DIFF
--- a/src/audio/module_adapter/module/dts.c
+++ b/src/audio/module_adapter/module/dts.c
@@ -315,11 +315,11 @@ static int dts_codec_apply_config(struct processing_module *mod)
 	/* Check that config->data isn't invalid and has size greater than 0 */
 	config_header_size = sizeof(config->size) + sizeof(config->avail);
 	if (config->size < config_header_size) {
-		comp_err(dev, "dts_codec_apply_config() config->data is invalid");
-		return -EINVAL;
+		comp_warn(dev, "dts_codec_apply_config() config->data is invalid");
+		return 0;
 	} else if (config->size == config_header_size) {
-		comp_err(dev, "dts_codec_apply_config() size of config->data is 0");
-		return -EINVAL;
+		comp_warn(dev, "dts_codec_apply_config() size of config->data is 0");
+		return 0;
 	}
 
 	/* Calculate size of config->data */
@@ -434,10 +434,6 @@ dts_codec_set_configuration(struct processing_module *mod, uint32_t config_id,
 	/* return if more fragments are expected or if the module is not prepared */
 	if ((pos != MODULE_CFG_FRAGMENT_LAST && pos != MODULE_CFG_FRAGMENT_SINGLE) ||
 	    md->state < MODULE_INITIALIZED)
-		return 0;
-
-	/* return if configuration size is 0 */
-	if (!md->new_cfg_size)
 		return 0;
 
 	/* whole configuration received, apply it now */


### PR DESCRIPTION
To handle zero config size case in set_configuration would let dts_codec_apply_config never be called due to early return when checking if md->new_config_size is zero. This causes the problem that DTS tuning parameter would never be set. We've found the issue on the latest Chrome OS version on RPL. So, instead, check the config size in dts_codec_apply_config() could resolve the zero config case and let the tuning parameter could be set successfully.