### PR TITLE
[BACKPORT imx-stable-v2.5] drivers: imx: sdma: Invalidate cache when reading info from BDs

### DIFF
--- a/src/drivers/imx/sdma.c
+++ b/src/drivers/imx/sdma.c
@@ -887,6 +887,8 @@ static int sdma_get_data_size(struct dma_chan_data *channel, uint32_t *avail,
 		return -EINVAL;
 	}
 
+	dcache_invalidate_region(pdata->desc, sizeof(pdata->desc[0]) * SDMA_MAX_BDS);
+
 	for (i = 0; i < pdata->desc_count && i < SDMA_MAX_BDS; i++) {
 		if (pdata->desc[i].config & SDMA_BD_DONE)
 			continue; /* These belong to SDMA controller */


### PR DESCRIPTION
This invalidation is required in order for the driver to correctly report the available/free bytes on a given DMA channel.

Fixes: 87d79c48dd ("drivers: imx: sdma: Add SDMA support to SOF")