### PR TITLE
Audio: Fix the 24/32 bits format peak volume calculation

### DIFF
--- a/src/audio/module_adapter/module/volume/volume_generic_with_peakvol.c
+++ b/src/audio/module_adapter/module/volume/volume_generic_with_peakvol.c
@@ -87,7 +87,7 @@ static void vol_s24_to_s24(struct processing_module *mod, struct input_stream_bu
 				y0[i] = vol_mult_s24_to_s24(x0[i], vol);
 				tmp = MAX(abs(x0[i]), tmp);
 			}
-			tmp = tmp << attenuation;
+			tmp = tmp << (attenuation + PEAK_24S_32C_ADJUST);
 			cd->peak_regs.peak_meter[j] = MAX(tmp, cd->peak_regs.peak_meter[j]);
 		}
 		remaining_samples -= n;

--- a/src/audio/module_adapter/module/volume/volume_hifi3_with_peakvol.c
+++ b/src/audio/module_adapter/module/volume/volume_hifi3_with_peakvol.c
@@ -133,7 +133,8 @@ static void vol_s24_to_s24_s32(struct processing_module *mod, struct input_strea
 	}
 	for (i = 0; i < channels_count; i++)
 		cd->peak_regs.peak_meter[i] = MAX(cd->peak_vol[i],
-						  cd->peak_vol[i + channels_count]) << attenuation;
+						  cd->peak_vol[i + channels_count])
+						  << (attenuation + PEAK_24S_32C_ADJUST);
 	/* update peak vol */
 	peak_vol_update(cd);
 }
@@ -440,7 +441,7 @@ static void vol_s24_to_s24_s32(struct processing_module *mod, struct input_strea
 				/* Store the output sample */
 				AE_S32_L_XP(out_sample, out, inc);
 			}
-			peak_vol = AE_SLAA32S(peak_vol, attenuation);
+			peak_vol = AE_SLAA32S(peak_vol, attenuation + PEAK_24S_32C_ADJUST);
 			peak_meter[channel] = AE_MAX32(peak_vol, peak_meter[channel]);
 		}
 		samples -= n;

--- a/src/include/sof/audio/volume.h
+++ b/src/include/sof/audio/volume.h
@@ -90,6 +90,12 @@ struct sof_ipc_ctrl_value_chan;
 #define VOL_RAMP_UPDATE_THRESHOLD_FASTEST_MS	32
 
 /**
+ * \brief left shift 8 bits to put the valid 24 bits into
+ * higher part of 32 bits container.
+ */
+#define PEAK_24S_32C_ADJUST 8
+
+/**
  * \brief Volume maximum value.
  * TODO: This should be 1 << (VOL_QX_BITS + VOL_QY_BITS - 1) - 1 but
  * the current volume code cannot handle the full Q1.16 range correctly.


### PR DESCRIPTION
Left shift 8 bits the max value to put the valid 24 bits into high 24 bits in 32 bits container.