### PR TITLE
schedule: zephyr_dma_domain: Fix various issues

### DIFF
--- a/src/include/sof/audio/pipeline.h
+++ b/src/include/sof/audio/pipeline.h
@@ -129,6 +129,10 @@ struct pipeline_task {
 	struct task task;		/**< parent structure */
 	bool registrable;		/**< should task be registered on irq */
 	struct comp_dev *sched_comp;	/**< pipeline scheduling component */
+	/* private data used by Zephyr DMA domain for internal
+	 * housekeeping - don't touch.
+	 */
+	void *priv;
 };
 
 #define pipeline_task_get(t) container_of(t, struct pipeline_task, task)

--- a/src/include/sof/schedule/ll_schedule_domain.h
+++ b/src/include/sof/schedule/ll_schedule_domain.h
@@ -195,13 +195,10 @@ static inline void domain_disable(struct ll_schedule_domain *domain, int core)
 static inline bool domain_is_pending(struct ll_schedule_domain *domain,
 				     struct task *task, struct comp_dev **comp)
 {
-	bool ret;
-
-	assert(domain->ops->domain_is_pending);
-
-	ret = domain->ops->domain_is_pending(domain, task, comp);
-
-	return ret;
+	if (domain->ops->domain_is_pending)
+		return domain->ops->domain_is_pending(domain, task, comp);
+	else
+		return true;
 }
 
 

--- a/src/schedule/zephyr_dma_domain.c
+++ b/src/schedule/zephyr_dma_domain.c
@@ -143,13 +143,16 @@ static void dma_irq_handler(void *data)
 	irq = zephyr_dma_domain_data->irq;
 	dt = zephyr_dma_domain_data->dt;
 
-	/* clear IRQ */
-	dma_interrupt_legacy(channel, DMA_IRQ_CLEAR);
-	interrupt_clear_mask(irq, BIT(channel_index));
+	/* was the IRQ triggered by this channel? */
+	if (dma_interrupt_legacy(channel, DMA_IRQ_STATUS_GET)) {
+		/* clear IRQ */
+		dma_interrupt_legacy(channel, DMA_IRQ_CLEAR);
+		interrupt_clear_mask(irq, BIT(channel_index));
 
-	/* give resources to thread semaphore */
-	if (dt->handler)
-		k_sem_give(sem);
+		/* give resources to thread semaphore */
+		if (dt->handler)
+			k_sem_give(sem);
+	}
 }
 
 static int enable_dma_irq(struct zephyr_dma_domain_data *data)

--- a/src/schedule/zephyr_ll.c
+++ b/src/schedule/zephyr_ll.c
@@ -195,6 +195,10 @@ static void zephyr_ll_run(void *data)
 		list_item_del(list);
 		list_item_append(list, &task_head);
 
+		/* check if the task can be scheduled */
+		if (!domain_is_pending(sch->ll_domain, task, NULL))
+			continue;
+
 		zephyr_ll_unlock(sch, &flags);
 
 		/*


### PR DESCRIPTION
Issues fixed by this series of patches:

1. Zephyr DMA domain doesn't support DMACs with aggregated IRQs. This lead to the DMA IRQ handler giving multiple semaphore resources (since the handler is registered multiple times for the same IRQ but with different data)
2. Each time a DMA IRQ was triggered all pipeline tasks were executed which, in the case of i.MX8MP, would lead to warnings such as "no bytes to copy". To fix this, a pipeline task is now executed only if a DMA IRQ was triggered for the channel used by said task.