### PR TITLE
[SKIP SOF-TEST] .github: ipc_fuzzer: just a stable-v2.2 test

### DIFF
--- a/.github/workflows/ipc_fuzzer.yml
+++ b/.github/workflows/ipc_fuzzer.yml
@@ -1,6 +1,7 @@
 ---
 
 # For the actual fuzzer see tools/oss-fuzz/README.
+# TEST ME now
 # also see
 # https://google.github.io/oss-fuzz/getting-started/continuous-integration/
 #


### PR DESCRIPTION
Just a stable-v2.2 test.

Sample failure on the main branch:
https://github.com/thesofproject/sof/actions/runs/5053499443/

Probably since https://github.com/google/oss-fuzz/pull/10342 ?