### PR TITLE
Topology2: sdw-jack-generic: add 24 bit format support for sdw jack

### DIFF
--- a/tools/topology/topology2/platform/intel/sdw-jack-generic.conf
+++ b/tools/topology/topology2/platform/intel/sdw-jack-generic.conf
@@ -301,7 +301,7 @@ Object.PCM.pcm [
 
 		Object.PCM.pcm_caps.1 {
 			name "volume playback 0"
-			formats 'S16_LE,S32_LE'
+			formats 'S16_LE,S24_LE,S32_LE'
 		}
 	}
 	{
@@ -314,7 +314,7 @@ Object.PCM.pcm [
 
 		Object.PCM.pcm_caps.1 {
 			name "Passthrough Capture 0"
-			formats 'S16_LE,S32_LE'
+			formats 'S16_LE,S24_LE,S32_LE'
 			channels_min	$SDW_JACK_CAPTURE_CH
 			channels_max	$SDW_JACK_CAPTURE_CH
 		}


### PR DESCRIPTION
Somehow s24_le format is missed.