### PR TITLE
topology2: add sdw format

### DIFF
--- a/tools/topology/topology2/cavs-sdw.conf
+++ b/tools/topology/topology2/cavs-sdw.conf
@@ -73,6 +73,8 @@ Define {
 	NUM_SDW_AMP_LINKS 0
 	SDW_DMIC 0
 	SDW_JACK true
+	SDW_JACK_FORMAT	''
+	SDW_AMP_FORMAT	''
 }
 
 # override defaults with platform-specific config

--- a/tools/topology/topology2/platform/intel/sdw-amp-generic.conf
+++ b/tools/topology/topology2/platform/intel/sdw-amp-generic.conf
@@ -82,6 +82,11 @@ IncludeByKey.NUM_SDW_AMP_LINKS {
 					num_input_audio_formats 1
 					num_output_audio_formats 1
 					num_input_pins 1
+IncludeByKey.SDW_AMP_FORMAT {
+"[s*le]"	{
+					format		$SDW_AMP_FORMAT
+	}
+}
 
 					# 32-bit 48KHz 2ch
 					Object.Base.input_audio_format [
@@ -108,6 +113,11 @@ IncludeByKey.NUM_SDW_AMP_LINKS {
 					num_input_audio_formats 1
 					num_output_audio_formats 1
 					num_output_pins 1
+IncludeByKey.SDW_AMP_FORMAT {
+"[s*le]"	{
+					format		$SDW_AMP_FORMAT
+	}
+}
 
 					# 32-bit 48KHz 2ch
 					Object.Base.input_audio_format [
@@ -243,6 +253,11 @@ IncludeByKey.SDW_AMP_FEEDBACK {
 					num_input_audio_formats 1
 					num_output_audio_formats 1
 					num_output_pins 1
+IncludeByKey.SDW_AMP_FORMAT {
+"[s*le]"	{
+					format		$SDW_AMP_FORMAT
+	}
+}
 
 					IncludeByKey.NUM_SDW_AMP_LINKS {
 					"2"	{

--- a/tools/topology/topology2/platform/intel/sdw-jack-generic.conf
+++ b/tools/topology/topology2/platform/intel/sdw-jack-generic.conf
@@ -65,6 +65,11 @@ Object.Pipeline {
 			Object.Widget.alh-copier.1 {
 				stream_name $SDW_JACK_OUT_STREAM
 				node_type $ALH_LINK_OUTPUT_CLASS
+IncludeByKey.SDW_JACK_FORMAT {
+"[s*le]"	{
+				format		$SDW_JACK_FORMAT
+	}
+}
 			}
 			Object.Widget.gain.1 {
 				Object.Control.mixer.1 {
@@ -103,6 +108,11 @@ Object.Widget {
 			num_input_audio_formats 1
 			num_output_audio_formats 1
 			num_output_pins 1
+IncludeByKey.SDW_JACK_FORMAT {
+"[s*le]"	{
+					format		$SDW_JACK_FORMAT
+	}
+}
 
 			Object.Base.audio_format.1 {
 				in_bit_depth		32


### PR DESCRIPTION
Some sdw codecs may not support all formats. We can use 'format' to inform to use the specified format.