### PR TITLE
Rename cavs nocodec mixers

### DIFF
--- a/tools/topology/topology2/cavs-nocodec.conf
+++ b/tools/topology/topology2/cavs-nocodec.conf
@@ -82,6 +82,9 @@ Define {
 	SSP0_MIXER_SOURCE_3		'mixin.21.1'
 	SSP1_ENABLED			"true"
 	PASSTHROUGH			"false"
+	SSP0_PCM_NAME			"Port0"
+	SSP1_PCM_NAME			"Port1"
+	SSP2_PCM_NAME			"Port2"
 }
 
 # override defaults with platform-specific config
@@ -180,7 +183,7 @@ IncludeByKey.PASSTHROUGH {
 				}
 				Object.Widget.gain.1 {
 					Object.Control.mixer.1 {
-						name 'Playback Volume 1'
+						name 'Pre Mixer $SSP0_PCM_NAME Playback Volume'
 					}
 				}
 			}
@@ -193,7 +196,7 @@ IncludeByKey.PASSTHROUGH {
 				}
 				Object.Widget.gain.1 {
 					Object.Control.mixer.1 {
-						name 'Playback Volume 5'
+						name 'Pre Mixer $SSP2_PCM_NAME Playback Volume'
 					}
 				}
 			}
@@ -213,7 +216,7 @@ IncludeByKey.PASSTHROUGH {
 
 				Object.Widget.gain.1 {
 					Object.Control.mixer.1 {
-						name 'Main Playback Volume 2'
+						name 'Post Mixer $SSP0_PCM_NAME Playback Volume'
 					}
 				}
 
@@ -248,7 +251,7 @@ IncludeByKey.PASSTHROUGH {
 
 				Object.Widget.gain.1 {
 					Object.Control.mixer.1 {
-						name 'Main Playback Volume 6'
+						name 'Post Mixer $SSP2_PCM_NAME Playback Volume'
 					}
 				}
 			}
@@ -747,11 +750,11 @@ IncludeByKey.PASSTHROUGH {
 
 Object.PCM.pcm [
 	{
-		name	"Port0"
+		name	"$SSP0_PCM_NAME"
 		id 0
 		direction	"duplex"
 		Object.Base.fe_dai.1 {
-			name	"Port0"
+			name	"$SSP0_PCM_NAME"
 		}
 
 		Object.PCM.pcm_caps.1 {
@@ -767,11 +770,11 @@ Object.PCM.pcm [
 		}
 	}
 	{
-		name	"Port2"
+		name	"$SSP2_PCM_NAME"
 		id 2
 		direction	"duplex"
 		Object.Base.fe_dai.1 {
-			name	"Port2"
+			name	"$SSP2_PCM_NAME"
 		}
 
 		Object.PCM.pcm_caps.1 {
@@ -1018,7 +1021,7 @@ IncludeByKey.SSP1_ENABLED {
 						}
 						Object.Widget.gain.1 {
 							Object.Control.mixer.1 {
-								name 'Playback Volume 3'
+								name 'Pre Mixer $SSP1_PCM_NAME Playback Volume'
 							}
 						}
 					}
@@ -1038,7 +1041,7 @@ IncludeByKey.SSP1_ENABLED {
 
 						Object.Widget.gain.1 {
 							Object.Control.mixer.1 {
-								name 'Main Playback Volume 4'
+								name 'Post Mixer $SSP1_PCM_NAME Playback Volume'
 							}
 						}
 					}
@@ -1133,11 +1136,11 @@ IncludeByKey.SSP1_ENABLED {
 
 		Object.PCM.pcm [
 			{
-				name	"Port1"
+				name	"$SSP1_PCM_NAME"
 				id 1
 				direction	"duplex"
 				Object.Base.fe_dai.1 {
-					name	"Port1"
+					name	"$SSP1_PCM_NAME"
 				}
 
 				Object.PCM.pcm_caps.1 {

--- a/tools/topology/topology2/cavs-nocodec.conf
+++ b/tools/topology/topology2/cavs-nocodec.conf
@@ -86,6 +86,8 @@ Define {
 	SSP0_CAPTURE_PCM		"ssp-capture"
 	SSP1_PCM_NAME			"Port1"
 	SSP2_PCM_NAME			"Port2"
+	DMIC0_PCM_0_NAME		"DMIC0 Raw"
+	DMIC0_PCM_1_NAME		"DMIC0 Raw 2"
 }
 
 # override defaults with platform-specific config
@@ -340,7 +342,7 @@ IncludeByKey.PASSTHROUGH {
 						out_ch_map	$CHANNEL_MAP_3_POINT_1
 					}
 					Object.Control.mixer.1 {
-						name 'Main Capture Volume 3'
+						name 'Pre Demux $DMIC0_PCM_0_NAME Capture Volume'
 					}
 				}
 			}
@@ -637,7 +639,7 @@ IncludeByKey.PASSTHROUGH {
 				format		$FORMAT
 				index		18
 				Object.Widget.pipeline.1 {
-					stream_name "DMIC0 Raw"
+					stream_name "$DMIC0_PCM_0_NAME"
 				}
 				Object.Widget.host-copier.1 {
 					stream_name "Gain Capture 18"
@@ -685,7 +687,7 @@ IncludeByKey.PASSTHROUGH {
 						out_ch_map	$CHANNEL_MAP_3_POINT_1
 					}
 					Object.Control.mixer.1 {
-						name 'Capture Raw Volume 1'
+						name 'Post Demux $DMIC0_PCM_0_NAME Capture Volume'
 					}
 				}
 			}
@@ -693,7 +695,7 @@ IncludeByKey.PASSTHROUGH {
 				format		$FORMAT
 				index		20
 				Object.Widget.pipeline.1 {
-					stream_name "DMIC0 Raw 2"
+					stream_name "$DMIC0_PCM_1_NAME"
 				}
 				Object.Widget.host-copier.1 {
 					stream_name "Gain Capture 20"
@@ -741,7 +743,7 @@ IncludeByKey.PASSTHROUGH {
 						out_ch_map	$CHANNEL_MAP_3_POINT_1
 					}
 					Object.Control.mixer.1 {
-						name 'Capture Raw Volume 2'
+						name 'Post Demux $DMIC0_PCM_1_NAME Capture Volume'
 					}
 				}
 			}
@@ -808,10 +810,10 @@ IncludeByKey.PASSTHROUGH {
 				}
 			}
 			{
-				name	"DMIC0 Raw"
+				name	"$DMIC0_PCM_0_NAME"
 				id 27
 				direction	"capture"
-				Object.Base.fe_dai."DMIC0 Raw" {}
+				Object.Base.fe_dai."$DMIC0_PCM_0_NAME" {}
 
 				Object.PCM.pcm_caps."capture" {
 					name "Gain Capture 18"
@@ -822,10 +824,10 @@ IncludeByKey.PASSTHROUGH {
 				}
 			}
 			{
-				name	"DMIC0 Raw 2"
+				name	"$DMIC0_PCM_1_NAME"
 				id 28
 				direction	"capture"
-				Object.Base.fe_dai."DMIC0 Raw 2" {}
+				Object.Base.fe_dai."$DMIC0_PCM_1_NAME" {}
 
 				Object.PCM.pcm_caps."capture" {
 					name "Gain Capture 20"

--- a/tools/topology/topology2/cavs-nocodec.conf
+++ b/tools/topology/topology2/cavs-nocodec.conf
@@ -83,6 +83,7 @@ Define {
 	SSP1_ENABLED			"true"
 	PASSTHROUGH			"false"
 	SSP0_PCM_NAME			"Port0"
+	SSP0_CAPTURE_PCM		"ssp-capture"
 	SSP1_PCM_NAME			"Port1"
 	SSP2_PCM_NAME			"Port2"
 }
@@ -267,7 +268,7 @@ IncludeByKey.PASSTHROUGH {
 				}
 				Object.Widget.gain.1 {
 					Object.Control.mixer.1 {
-						name 'Main Capture Volume 1'
+						name 'Post Demux $SSP0_PCM_NAME Capture Volume'
 					}
 				}
 			}
@@ -281,7 +282,7 @@ IncludeByKey.PASSTHROUGH {
 				}
 				Object.Widget.gain.1 {
 					Object.Control.mixer.1 {
-						name 'Main Capture Volume 2'
+						name 'Post Demux $SSP0_CAPTURE_PCM Capture Volume'
 					}
 				}
 			}
@@ -382,7 +383,7 @@ IncludeByKey.PASSTHROUGH {
 				}
 				Object.Widget.gain.1 {
 					Object.Control.mixer.1 {
-						name 'Host Capture Volume'
+						name 'Pre Demux $SSP0_PCM_NAME Capture Volume'
 					}
 				}
 			}
@@ -795,11 +796,11 @@ IncludeByKey.PASSTHROUGH {
 "false" {
 		Object.PCM.pcm [
 			{
-				name	"ssp-capture"
+				name	"$SSP0_CAPTURE_PCM"
 				id 12
 				direction	"capture"
 				Object.Base.fe_dai.1 {
-					name	"ssp-capture"
+					name	"$SSP0_CAPTURE_PCM"
 				}
 				Object.PCM.pcm_caps.1 {
 					name "SSP0-1 Capture"

--- a/tools/topology/topology2/platform/intel/dmic-generic.conf
+++ b/tools/topology/topology2/platform/intel/dmic-generic.conf
@@ -1,3 +1,7 @@
+Define {
+       DMIC0_PCM_NAME	"DMIC"
+}
+
 Object.Dai.DMIC [
 	{
 		dai_index 0
@@ -121,7 +125,7 @@ IncludeByKey.PASSTHROUGH {
 						out_ch_map	$CHANNEL_MAP_3_POINT_1
 					}
 					Object.Control.mixer.1 {
-						name 'DMIC0 Capture Volume 1'
+						name '$DMIC0_PCM_NAME Capture Volume'
 					}
 				}
 
@@ -345,11 +349,11 @@ IncludeByKey.PASSTHROUGH {
 
 Object.PCM.pcm [
 	{
-		name	"DMIC"
+		name	"$DMIC0_PCM_NAME"
 		id $DMIC0_PCM_ID
 		direction	"capture"
 		Object.Base.fe_dai.1 {
-			name "DMIC"
+			name "$DMIC0_PCM_NAME"
 		}
 
 		Object.PCM.pcm_caps.1 {

--- a/tools/topology/topology2/platform/intel/nocodec-ssp0-2level.conf
+++ b/tools/topology/topology2/platform/intel/nocodec-ssp0-2level.conf
@@ -1,3 +1,7 @@
+Define {
+	SSP0_AUX_PCM_NAME	"Port0 Aux Playback"
+}
+
 Object.Pipeline.host-copier-gain-mixin-playback [
 	{
 		index $SSP0_MIXER_PIPELINE_ID_2
@@ -11,7 +15,7 @@ Object.Pipeline.host-copier-gain-mixin-playback [
 		}
 		Object.Widget.gain.1 {
 			Object.Control.mixer.1 {
-				name 'Playback Volume 8'
+				name 'Pre Mixer $SSP0_AUX_PCM_NAME Volume'
 			}
 		}
 	}
@@ -29,7 +33,7 @@ Object.Pipeline.mixout-mixin [
 
 Object.PCM.pcm [
 	{
-		name "Port0 Aux Playback"
+		name "$SSP0_AUX_PCM_NAME"
 		id $SSP0_MIXER_PCM_ID_1
 		direction "playback"
 		Object.Base.fe_dai."Port0 aux" {}


### PR DESCRIPTION
This tries to fix the first tap in https://github.com/thesofproject/sof/issues/6576 for cavs-nocodec topology.