### PR TITLE
topology2: sdw-amp-generic: set virtual widget type output

### DIFF
--- a/tools/topology/topology2/platform/intel/sdw-amp-generic.conf
+++ b/tools/topology/topology2/platform/intel/sdw-amp-generic.conf
@@ -142,7 +142,7 @@ IncludeByKey.NUM_SDW_AMP_LINKS {
 			virtual [
 				{
 					name 'virtual.sdw-amp'
-					type input
+					type output
 					index $ALH_2ND_SPK_ID
 				}
 			]


### PR DESCRIPTION
Widget type snd_soc_dapm_out_drv and snd_soc_dapm_output will be treat as virtual widget and be ignored in sof topology in kernel. We need to set type = output or out_drv in topology when it is a virtual widget.

Fixes: 3835846836d4 ("topology2: sdw-amp-generic: Show all aggregated DAIs on the graph")

Fixes: #7677 