### PR TITLE
src: mixin_mixout: Set channels during mixout_params

### DIFF
--- a/src/audio/mixin_mixout/mixin_mixout.c
+++ b/src/audio/mixin_mixout/mixin_mixout.c
@@ -784,6 +784,7 @@ static int mixout_params(struct processing_module *mod)
 				    mod->priv.cfg.base_cfg.audio_fmt.s_type);
 
 	audio_stream_set_valid_fmt(&sink_c->stream, valid_fmt);
+	audio_stream_set_channels(&sink_c->stream, params->channels);
 
 	sink_stream_size = audio_stream_get_size(&sink_c->stream);
 


### PR DESCRIPTION
comp_verify_params() doesn't set the channels. So set it explicitly during params.