### PR TITLE
[SKIP SOF-TEST] .github: ipc_fuzzer: upload stdout logs

### DIFF
--- a/.github/workflows/ipc_fuzzer.yml
+++ b/.github/workflows/ipc_fuzzer.yml
@@ -66,4 +66,12 @@ jobs:
             IPC3) cmake_arg='-DCONFIG_IPC_MAJOR_3=y' ;;
             IPC4) cmake_arg='-DCONFIG_IPC_MAJOR_4=y' ;;
           esac
-          sof/scripts/fuzz.sh -o _.log -t 300 -- "$cmake_arg"
+          sof/scripts/fuzz.sh -o fuzz-stdout.txt -t 300 -- "$cmake_arg"
+
+      - name: Upload stdout
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: ${{ matrix.IPC }} logs
+          path: |
+            workspace/fuzz-stdout.txt


### PR DESCRIPTION
Quoting @andyross in
https://github.com/thesofproject/sof/pull/7668#issuecomment-1561587959

> OK, as it turns out when running native_posix+fuzzing, the fuzzer
> output goes to stderr (and appears here) where the console output goes
> to stdout, and is currently being discarded. For a sanitizer-detected
> failure, that's actually fine as the stack trace will show up in the
> CI logs. But this was just a call to posix_exit(), which is an "error"
> to the fuzzer but not very informative to us without knowing the
> software state that led to it. Most likely this is a Zephyr
> panic (e.g. an assertion failure -- not a trap like SIGSEGV/SIGILL
> that would be caught by the host OS and thus libfuzzer), because the
> default fatal error handler is to tell the arch layer to do a system
> halt, and native_posix implements this by exiting. And it's certainly
> not unlikely to have been triggered by the fuzzing.

> Basically: @marc-hb if we could arrange to save the stdout of the
> offending fuzz process on failure that would be great. Alas this
> particular incident may have been lost, but there will surely be more.