### PR TITLE
platform: cavs: do not program GPDMA/ALH ownership in Zephyr builds [MANIFEST UDPATE!]

### DIFF
--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -336,6 +336,7 @@ static void platform_init_hw(void)
 	io_reg_write(DSP_INIT_IOPO,
 		IOPO_DMIC_FLAG | IOPO_I2S_FLAG);
 
+#ifndef __ZEPHYR__
 	io_reg_write(DSP_INIT_ALHO,
 		ALHO_ASO_FLAG | ALHO_CSO_FLAG);
 
@@ -343,6 +344,7 @@ static void platform_init_hw(void)
 		LPGPDMA_CHOSEL_FLAG | LPGPDMA_CTLOSEL_FLAG);
 	io_reg_write(DSP_INIT_LPGPDMA(1),
 		LPGPDMA_CHOSEL_FLAG | LPGPDMA_CTLOSEL_FLAG);
+#endif
 }
 
 /* Runs on the primary core only */

--- a/west.yml
+++ b/west.yml
@@ -45,7 +45,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 7d54586751cfe405d2cdcfd850f8100bc9844f63
+      revision: 2ad1a24fd60d0df8cb45fb6ed6acf7b0d3820754
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
If SOF is built with Zephyr, the GPDMA/ALH ownership programming should happen in Zephyr platform code, not on SOF side.

Link: https://github.com/zephyrproject-rtos/zephyr/pull/55738
Closes: https://github.com/thesofproject/sof/issues/7249