### PR TITLE
Topo2 more mixer name fixes

### DIFF
--- a/tools/topology/topology2/cavs-mixin-mixout-efx-hda.conf
+++ b/tools/topology/topology2/cavs-mixin-mixout-efx-hda.conf
@@ -45,12 +45,12 @@ Object.Pipeline {
 			}
 			Object.Widget.eqiir.1 {
 				Object.Control.bytes."1" {
-					name '2 Main playback Iir Eq'
+					name 'Post Mixer $ANALOG_PLAYBACK_PCM Iir Eq'
 				}
 			}
 			Object.Widget.eqfir.1 {
 				Object.Control.bytes."1" {
-					name '2 Main playback Fir Eq'
+					name 'Post Mixer $ANALOG_PLAYBACK_PCM Fir Eq'
 				}
 			}
 		}

--- a/tools/topology/topology2/cavs-mixin-mixout-efx-hda.conf
+++ b/tools/topology/topology2/cavs-mixin-mixout-efx-hda.conf
@@ -40,7 +40,7 @@ Object.Pipeline {
 			}
 			Object.Widget.gain.1 {
 				Object.Control.mixer.1 {
-					name '2 Main Playback Volume'
+					name 'Post Mixer $ANALOG_PLAYBACK_PCM Volume'
 				}
 			}
 			Object.Widget.eqiir.1 {
@@ -67,7 +67,7 @@ Object.Pipeline {
 
 			Object.Widget.gain.1 {
 				Object.Control.mixer.1 {
-					name '1 2nd Playback Volume'
+					name 'Pre Mixer $ANALOG_PLAYBACK_PCM Volume'
 				}
 			}
 		}

--- a/tools/topology/topology2/cavs-nocodec-multicore.conf
+++ b/tools/topology/topology2/cavs-nocodec-multicore.conf
@@ -61,6 +61,10 @@ Define {
 	DMIC1_PCM_CAPS			'DMIC1 WOV Capture'
 	DMIC0_NAME			'NoCodec-6'
 	DMIC1_NAME			'NoCodec-7'
+
+	SSP0_PCM_NAME	"Port0"
+	SSP1_PCM_NAME	"Port1"
+	SSP2_PCM_NAME	"Port2"
 }
 
 # override defaults with platform-specific config
@@ -147,7 +151,7 @@ Object.Pipeline.host-copier-gain-mixin-playback [
 		Object.Widget.gain.1 {
 			core_id $SSP0_CORE_ID
 			Object.Control.mixer.1 {
-				name 'Playback Volume 1'
+				name 'Pre Mixer $SSP0_PCM_NAME Playback Volume'
 			}
 		}
 	}
@@ -163,7 +167,7 @@ Object.Pipeline.host-copier-gain-mixin-playback [
 		Object.Widget.gain.1 {
 			core_id $SSP2_CORE_ID
 			Object.Control.mixer.1 {
-				name 'Playback Volume 5'
+				name 'Pre Mixer $SSP2_PCM_NAME Playback Volume'
 			}
 		}
 		Object.Widget.mixin.1 {
@@ -189,7 +193,7 @@ Object.Pipeline.mixout-gain-dai-copier-playback [
 		Object.Widget.gain.1 {
 			core_id $SSP0_CORE_ID
 			Object.Control.mixer.1 {
-				name 'Main Playback Volume 14'
+				name 'Post Mixer $SSP0_PCM_NAME Playback Volume'
 			}
 		}
 	}
@@ -209,7 +213,7 @@ Object.Pipeline.mixout-gain-dai-copier-playback [
 		Object.Widget.gain.1 {
 			core_id $SSP2_CORE_ID
 			Object.Control.mixer.1 {
-				name 'Main Playback Volume 6'
+				name 'Post Mixer $SSP2_PCM_NAME Playback Volume'
 			}
 		}
 		Object.Widget.mixout.1 {
@@ -292,11 +296,11 @@ Object.Pipeline.io-gateway-capture [
 
 Object.PCM.pcm [
 	{
-		name	"Port0"
+		name	"$SSP0_PCM_NAME"
 		id 0
 		direction	"duplex"
 		Object.Base.fe_dai.1 {
-			name	"Port0"
+			name	"$SSP0_PCM_NAME"
 		}
 
 		Object.PCM.pcm_caps.1 {
@@ -312,11 +316,11 @@ Object.PCM.pcm [
 		}
 	}
 	{
-		name	"Port2"
+		name	"$SSP2_PCM_NAME"
 		id 2
 		direction	"duplex"
 		Object.Base.fe_dai.1 {
-			name	"Port2"
+			name	"$SSP2_PCM_NAME"
 		}
 
 		Object.PCM.pcm_caps.1 {
@@ -409,7 +413,7 @@ IncludeByKey.SSP1_ENABLED {
 				Object.Widget.gain.1 {
 					core_id $SSP1_CORE_ID
 					Object.Control.mixer.1 {
-						name 'Playback Volume 3'
+						name 'Pre Mixer $SSP1_PCM_NAME Playback Volume'
 					}
 				}
 				Object.Widget.mixin.1 {
@@ -435,7 +439,7 @@ IncludeByKey.SSP1_ENABLED {
 				Object.Widget.gain.1 {
 					core_id $SSP1_CORE_ID
 					Object.Control.mixer.1 {
-						name 'Main Playback Volume 4'
+						name 'Post Mixer $SSP1_PCM_NAME Playback Volume'
 					}
 				}
 				Object.Widget.mixout.1 {
@@ -485,11 +489,11 @@ IncludeByKey.SSP1_ENABLED {
 
 		Object.PCM.pcm [
 			{
-				name	"Port1"
+				name	"$SSP1_PCM_NAME"
 				id 1
 				direction	"duplex"
 				Object.Base.fe_dai.1 {
-					name	"Port1"
+					name	"$SSP1_PCM_NAME"
 				}
 
 				Object.PCM.pcm_caps.1 {


### PR DESCRIPTION
After this the only topology source files that do not have their mixer names fixed are cavs-rt5682.conf and cavs-sdw-src-gain-mixin.conf.  One of the PRs to fix https://github.com/thesofproject/sof/issues/6576