### PR TITLE
host: zephyr: Subtract partial_size from dma avail/free size.

### DIFF
--- a/src/audio/host-zephyr.c
+++ b/src/audio/host-zephyr.c
@@ -405,11 +405,11 @@ static uint32_t host_get_copy_bytes_normal(struct host_data *hd, struct comp_dev
 
 	/* calculate minimum size to copy */
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK) {
-		avail_samples = dma_stat.pending_length / dma_sample_bytes;
+		avail_samples = (dma_stat.pending_length - hd->partial_size) / dma_sample_bytes;
 		free_samples = audio_stream_get_free_samples(&buffer_c->stream);
 	} else {
 		avail_samples = audio_stream_get_avail_samples(&buffer_c->stream);
-		free_samples = dma_stat.free / dma_sample_bytes;
+		free_samples = (dma_stat.free - hd->partial_size) / dma_sample_bytes;
 	}
 
 	dma_copy_bytes = MIN(avail_samples, free_samples) * dma_sample_bytes;


### PR DESCRIPTION
When the host component detects use of deep buffering it decreases frequency of dma reloading. The number of processed data is summed up in the partial_size variable and they are acknowledged in larger packets. However, the size of processed data was not subtracted from the number of available data, which could lead to a buffer underrun/overrun.