### PR TITLE
topology2: intel: dmic-generic: Simplify the core ID setting

### DIFF
--- a/tools/topology/topology2/include/components/alh-dai-copier.conf
+++ b/tools/topology/topology2/include/components/alh-dai-copier.conf
@@ -123,7 +123,6 @@ Class.Widget."alh-copier" {
 	#UUID: 9BA00C83-CA12-4A83-943C-1FA2E82F9DDA
 	uuid 		"83:0c:a0:9b:12:CA:83:4a:94:3c:1f:a2:e8:2f:9d:da"
 	no_pm 		"true"
-	core_id	0
 	cpc		1647
 	bss_size	280
 	dai_type	"ALH"

--- a/tools/topology/topology2/include/components/dai-copier.conf
+++ b/tools/topology/topology2/include/components/dai-copier.conf
@@ -161,7 +161,6 @@ Class.Widget."dai-copier" {
 	#UUID: 9BA00C83-CA12-4A83-943C-1FA2E82F9DDA
 	uuid 		"83:0c:a0:9b:12:CA:83:4a:94:3c:1f:a2:e8:2f:9d:da"
 	no_pm 		"true"
-	core_id	0
 	cpc		1647
 	bss_size	280
 

--- a/tools/topology/topology2/include/components/dai.conf
+++ b/tools/topology/topology2/include/components/dai.conf
@@ -121,5 +121,4 @@ Class.Widget."dai" {
 	# Default attribute values for DAI widget
 	uuid "27:0d:b0:c2:bc:ff:50:41:a5:1a:24:5c:79:c5:e5:4b"
 	no_pm		"true"
-	core_id 	0
 }

--- a/tools/topology/topology2/include/components/eqfir.conf
+++ b/tools/topology/topology2/include/components/eqfir.conf
@@ -59,7 +59,6 @@ Class.Widget."eqfir" {
 	uuid 			"e7:0c:a9:43:a5:f3:df:41:ac:06:ba:98:65:1a:e6:a3"
 	type			"effect"
 	no_pm			"true"
-	core_id			0
 	num_input_pins		1
 	num_output_pins		1
 }

--- a/tools/topology/topology2/include/components/eqiir.conf
+++ b/tools/topology/topology2/include/components/eqiir.conf
@@ -59,7 +59,6 @@ Class.Widget."eqiir" {
 	uuid 			"e6:c0:50:51:f9:27:c8:4e:83:51:c7:05:b6:42:d1:2f"
 	type			"effect"
 	no_pm			"true"
-	core_id			0
 	num_input_pins		1
 	num_output_pins		1
 }

--- a/tools/topology/topology2/include/components/google-rtc-aec.conf
+++ b/tools/topology/topology2/include/components/google-rtc-aec.conf
@@ -122,7 +122,6 @@ Class.Widget."google-rtc-aec" {
 	uuid			$AEC_UUID
 	type			"effect"
 	no_pm 			"true"
-	core_id			0
 	cpc 			5000
 	is_pages		1
         num_input_pins          2

--- a/tools/topology/topology2/include/components/host-copier.conf
+++ b/tools/topology/topology2/include/components/host-copier.conf
@@ -120,7 +120,6 @@ Class.Widget."host-copier" {
 	#UUID: 9BA00C83-CA12-4A83-943C-1FA2E82F9DDA
 	uuid 		"83:0c:a0:9b:12:CA:83:4a:94:3c:1f:a2:e8:2f:9d:da"
 	no_pm 		"true"
-	core_id	0
 	cpc		1647
 	bss_size	280
 

--- a/tools/topology/topology2/include/components/kpb.conf
+++ b/tools/topology/topology2/include/components/kpb.conf
@@ -70,7 +70,6 @@ Class.Widget."kpb" {
 	#UUID: D8218443-5FF3-4A4C-B388-6CFE07B9562E
 	uuid		"43:84:21:d8:f3:5f:4c:4a:b3:88:6c:fe:07:b9:56:2e"
 	no_pm 		"true"
-	core_id	0
 	cpc 720000
 	num_input_pins		1
 	num_output_pins		2

--- a/tools/topology/topology2/include/components/micsel.conf
+++ b/tools/topology/topology2/include/components/micsel.conf
@@ -69,7 +69,6 @@ Class.Widget."micsel" {
 	#UUID: 32FE92C1-1E17-4FC2-9758-C7F3542E980A
 	uuid 		"c1:92:fe:32:17:1e:c2:4f:97:58:c7:f3:54:2e:98:0a"
 	no_pm 		"true"
-	core_id	0
 	cpc 29000
 	num_input_pins		1
 	num_output_pins		1

--- a/tools/topology/topology2/include/components/mixin.conf
+++ b/tools/topology/topology2/include/components/mixin.conf
@@ -107,7 +107,6 @@ Class.Widget."mixin" {
 	#UUID: 39656EB2-3B71-4049-8D3F-F92CD5C43C09
 	uuid 		"b2:6e:65:39:71:3b:49:40:8d:3f:f9:2c:d5:c4:3c:09"
 	no_pm 		"true"
-	core_id	0
 	cpc 910
 	num_input_pins	1
 	num_output_pins	3

--- a/tools/topology/topology2/include/components/mixout.conf
+++ b/tools/topology/topology2/include/components/mixout.conf
@@ -107,7 +107,6 @@ Class.Widget."mixout" {
 	#UUID: 3C56505A-24D7-418F-BDDC-C1F5A3AC2AE0
 	uuid 		"5a:50:56:3c:d7:24:8f:41:bd:dc:c1:f5:a3:ac:2a:e0"
 	no_pm 		"true"
-	core_id	0
 	cpc 		5000
 	num_input_pins	8
 	num_output_pins	1

--- a/tools/topology/topology2/include/components/module-copier.conf
+++ b/tools/topology/topology2/include/components/module-copier.conf
@@ -85,7 +85,6 @@ Class.Widget."module-copier" {
 	uuid 		"83:0c:a0:9b:12:CA:83:4a:94:3c:1f:a2:e8:2f:9d:da"
 	type		"buffer"
 	no_pm 		"true"
-	core_id	0
 	cpc		1647
 	bss_size	280
 	num_input_pins	1

--- a/tools/topology/topology2/include/components/muxdemux.conf
+++ b/tools/topology/topology2/include/components/muxdemux.conf
@@ -65,5 +65,4 @@ Class.Widget."muxdemux" {
 	process_type	"DEMUX"
 	widget_type	"effect"
 	no_pm		"true"
-	core_id	0
 }

--- a/tools/topology/topology2/include/components/smart_amp.conf
+++ b/tools/topology/topology2/include/components/smart_amp.conf
@@ -113,7 +113,6 @@ Class.Widget."smart_amp" {
 	uuid			$SMART_AMP_UUID
 	type			"effect"
 	no_pm 			"true"
-	core_id			0
 	cpc 			5000
 	is_pages		1
 	num_input_pins		2

--- a/tools/topology/topology2/include/components/src.conf
+++ b/tools/topology/topology2/include/components/src.conf
@@ -85,7 +85,6 @@ Class.Widget."src" {
 	type			"src"
 	uuid			"8d:b2:1b:e6:9a:14:1f:4c:b7:09:46:82:3e:f5:f5:ae"
 	no_pm			"true"
-	core_id			0
 	num_input_pins		1
 	num_output_pins		1
 }

--- a/tools/topology/topology2/include/components/wov.conf
+++ b/tools/topology/topology2/include/components/wov.conf
@@ -99,7 +99,6 @@ Class.Widget."wov" {
 	#
 	type		"effect"
 	no_pm 		"true"
-	core_id	0
 	num_input_pins		1
 	num_output_pins		0
 }

--- a/tools/topology/topology2/include/pipelines/pipeline-common.conf
+++ b/tools/topology/topology2/include/pipelines/pipeline-common.conf
@@ -90,3 +90,5 @@ DefineAttribute."use_chain_dma" {
 		]
 	}
 }
+
+DefineAttribute."core_id" {}

--- a/tools/topology/topology2/platform/intel/dmic-generic.conf
+++ b/tools/topology/topology2/platform/intel/dmic-generic.conf
@@ -76,10 +76,9 @@ IncludeByKey.PASSTHROUGH {
 			{
 				format		$FORMAT
 				index 		$DMIC0_HOST_PIPELINE_ID
-
+				core_id		$DMIC_CORE_ID
 				Object.Widget.host-copier.1 {
 					stream_name $DMIC0_PCM_CAPS
-					core_id $DMIC_CORE_ID
 					pcm_id	$DMIC0_PCM_ID
 					num_input_audio_formats 2
 					num_output_audio_formats 2
@@ -103,7 +102,6 @@ IncludeByKey.PASSTHROUGH {
 					}
 				}
 				Object.Widget.gain.1 {
-					core_id $DMIC_CORE_ID
 					num_input_audio_formats 2
 					num_output_audio_formats 2
 					Object.Base.audio_format.1 {
@@ -130,7 +128,6 @@ IncludeByKey.PASSTHROUGH {
 				}
 
 				Object.Widget.module-copier."2" {
-					core_id $DMIC_CORE_ID
 					num_input_audio_formats 2
 					num_output_audio_formats 2
 					Object.Base.audio_format.1 {
@@ -161,9 +158,9 @@ IncludeByKey.PASSTHROUGH {
 		Object.Pipeline.dai-copier-eqiir-module-copier-capture [
 			{
 				index		$DMIC0_DAI_PIPELINE_ID
+				core_id		$DMIC_CORE_ID
 
 				Object.Widget.dai-copier.1 {
-					core_id		$DMIC_CORE_ID
 					dai_index	0
 					dai_type	"DMIC"
 					copier_type	"DMIC"
@@ -193,7 +190,6 @@ IncludeByKey.PASSTHROUGH {
 				}
 
 				Object.Widget.module-copier."2" {
-					core_id		$DMIC_CORE_ID
 					stream_name $DMIC0_NAME
 					num_input_audio_formats 2
 					num_output_audio_formats 2
@@ -218,7 +214,6 @@ IncludeByKey.PASSTHROUGH {
 				}
 
 				Object.Widget.eqiir.1 {
-					core_id		$DMIC_CORE_ID
 					num_input_audio_formats 2
 					num_output_audio_formats 2
 					Object.Base.audio_format.1 {


### PR DESCRIPTION
When all components of a pipeline are scheduled on the same core, use the pipeline's core_id attribute to set the core_id for all the components in it. Also, remove the default core_id in the module-copier and eqiir class definitions so that it doesn't take priority over the value passed from the pipeline object.