### PR TITLE
topology2: deepbuffer-playback: increase default buffer_size_max

### DIFF
--- a/tools/topology/topology2/platform/intel/deep-buffer.conf
+++ b/tools/topology/topology2/platform/intel/deep-buffer.conf
@@ -29,6 +29,9 @@ Object.PCM.pcm [
 		Object.PCM.pcm_caps.1 {
 			name $DEEP_BUFFER_PCM_NAME
 			formats 'S16_LE,S24_LE,S32_LE'
+			# align with $DEEPBUFFER_FW_DMA_MS
+			period_size_max		65535
+			buffer_size_max		262144
 		}
 	}
 ]


### PR DESCRIPTION
Increase the buffer_size/period_size range for user space snd_pcm_hw_params_get_* to extract, this will allow aplay to run with --period-size=8192 --buffer-size=32768 for deepbuf.