### PR TITLE
Audio: Peak volume: Add Kconfig to select the period of reporting peak meter value.

### DIFF
--- a/src/audio/module_adapter/Kconfig
+++ b/src/audio/module_adapter/Kconfig
@@ -184,6 +184,42 @@ config COMP_PEAK_VOL
          This option enables reporting to host peak vol regs.
          See: struct ipc4_peak_volume_regs
 
+choice "PEAK_METER_UPDATE_PERIOD_CHOICE"
+	prompt "The periods(ms) of updating peak meter value"
+	default PEAK_METER_UPDATE_10MS
+	depends on COMP_PEAK_VOL
+
+	config PEAK_METER_UPDATE_1MS
+		bool "1ms"
+		help
+		  Update the peak meter value every 1ms
+
+	config PEAK_METER_UPDATE_10MS
+		bool "10ms"
+		help
+		  Update the peak meter value every 10ms
+
+	config PEAK_METER_UPDATE_100MS
+		bool "100ms"
+		help
+		  Update the peak meter value every 100ms
+
+	config PEAK_METER_UPDATE_1000MS
+		bool "1000ms"
+		help
+		  Update the peak meter value every 1000ms
+	endchoice
+
+config PEAK_METER_UPDATE_PERIOD
+	int
+	depends on COMP_PEAK_VOL
+	default 1 if PEAK_METER_UPDATE_1MS
+	default 10 if PEAK_METER_UPDATE_10MS
+	default 100 if PEAK_METER_UPDATE_100MS
+	default 1000 if PEAK_METER_UPDATE_1000MS
+	help
+	  Decide which period of update the peak volume meter value
+
 config COMP_GAIN
 	bool "GAIN component"
 	default y

--- a/src/audio/module_adapter/module/volume/volume_generic_with_peakvol.c
+++ b/src/audio/module_adapter/module/volume/volume_generic_with_peakvol.c
@@ -67,7 +67,6 @@ static void vol_s24_to_s24(struct processing_module *mod, struct input_stream_bu
 	int remaining_samples = frames * nch;
 	int32_t tmp;
 
-	memset(cd->peak_regs.peak_meter, 0, sizeof(uint32_t) * cd->channels);
 	x = audio_stream_wrap(source, (char *)audio_stream_get_rptr(source) + bsource->consumed);
 	y = audio_stream_wrap(sink, (char *)audio_stream_get_wptr(sink) + bsink->size);
 
@@ -94,8 +93,6 @@ static void vol_s24_to_s24(struct processing_module *mod, struct input_stream_bu
 		x = audio_stream_wrap(source, x + n);
 		y = audio_stream_wrap(sink, y + n);
 	}
-	/* update peak vol */
-	peak_vol_update(cd);
 }
 #endif /* CONFIG_FORMAT_S24LE */
 
@@ -126,7 +123,6 @@ static void vol_s32_to_s32(struct processing_module *mod, struct input_stream_bu
 	int remaining_samples = frames * nch;
 	int32_t tmp;
 
-	memset(cd->peak_regs.peak_meter, 0, sizeof(uint32_t) * cd->channels);
 	x = audio_stream_wrap(source, (char *)audio_stream_get_rptr(source) + bsource->consumed);
 	y = audio_stream_wrap(sink, (char *)audio_stream_get_wptr(sink) + bsink->size);
 	bsource->consumed += VOL_S32_SAMPLES_TO_BYTES(remaining_samples);
@@ -156,9 +152,6 @@ static void vol_s32_to_s32(struct processing_module *mod, struct input_stream_bu
 		x = audio_stream_wrap(source, x + n);
 		y = audio_stream_wrap(sink, y + n);
 	}
-
-	/* update peak vol */
-	peak_vol_update(cd);
 }
 #endif /* CONFIG_FORMAT_S32LE */
 
@@ -189,7 +182,6 @@ static void vol_s16_to_s16(struct processing_module *mod, struct input_stream_bu
 	int remaining_samples = frames * nch;
 	int32_t tmp;
 
-	memset(cd->peak_regs.peak_meter, 0, sizeof(uint32_t) * cd->channels);
 	x = audio_stream_wrap(source, (char *)audio_stream_get_rptr(source) + bsource->consumed);
 	y = audio_stream_wrap(sink, (char *)audio_stream_get_wptr(sink) + bsink->size);
 
@@ -216,9 +208,6 @@ static void vol_s16_to_s16(struct processing_module *mod, struct input_stream_bu
 		x = audio_stream_wrap(source, x + n);
 		y = audio_stream_wrap(sink, y + n);
 	}
-
-	/* update peak vol */
-	peak_vol_update(cd);
 }
 #endif
 

--- a/src/audio/module_adapter/module/volume/volume_hifi3_with_peakvol.c
+++ b/src/audio/module_adapter/module/volume/volume_hifi3_with_peakvol.c
@@ -135,8 +135,6 @@ static void vol_s24_to_s24_s32(struct processing_module *mod, struct input_strea
 		cd->peak_regs.peak_meter[i] = MAX(cd->peak_vol[i],
 						  cd->peak_vol[i + channels_count])
 						  << (attenuation + PEAK_24S_32C_ADJUST);
-	/* update peak vol */
-	peak_vol_update(cd);
 }
 #endif /* CONFIG_FORMAT_S24LE */
 
@@ -243,9 +241,6 @@ static void vol_s32_to_s24_s32(struct processing_module *mod, struct input_strea
 	for (i = 0; i < channels_count; i++)
 		cd->peak_regs.peak_meter[i] = MAX(cd->peak_vol[i],
 						  cd->peak_vol[i + channels_count]) << attenuation;
-
-	/* update peak vol */
-	peak_vol_update(cd);
 }
 #endif /* CONFIG_FORMAT_S32LE */
 
@@ -364,8 +359,6 @@ static void vol_s16_to_s16(struct processing_module *mod, struct input_stream_bu
 		m = MAX(m, cd->peak_vol[i + channels_count * 3]);
 		cd->peak_regs.peak_meter[i] = m;
 	}
-	/* update peak vol */
-	peak_vol_update(cd);
 }
 #endif /* CONFIG_FORMAT_S16LE */
 
@@ -403,8 +396,6 @@ static void vol_s24_to_s24_s32(struct processing_module *mod, struct input_strea
 	int samples = channels_count * frames;
 	ae_f32x2 peak_vol;
 	uint32_t *peak_meter = cd->peak_regs.peak_meter;
-
-	memset(peak_meter, 0, sizeof(int32_t) * cd->channels);
 
 	bsource->consumed += VOL_S32_SAMPLES_TO_BYTES(samples);
 	bsink->size += VOL_S32_SAMPLES_TO_BYTES(samples);
@@ -448,8 +439,6 @@ static void vol_s24_to_s24_s32(struct processing_module *mod, struct input_strea
 		out0 = audio_stream_wrap(sink, out0 + n);
 		in0 = audio_stream_wrap(source, in0 + n);
 	}
-	/* update peak vol */
-	peak_vol_update(cd);
 }
 #endif /* CONFIG_FORMAT_S24LE */
 
@@ -485,7 +474,6 @@ static void vol_s32_to_s24_s32(struct processing_module *mod, struct input_strea
 	ae_f32x2 peak_vol;
 	uint32_t *peak_meter = cd->peak_regs.peak_meter;
 
-	memset(peak_meter, 0, sizeof(uint32_t) * cd->channels);
 	bsource->consumed += VOL_S32_SAMPLES_TO_BYTES(samples);
 	bsink->size += VOL_S32_SAMPLES_TO_BYTES(samples);
 	while (samples) {
@@ -528,8 +516,6 @@ static void vol_s32_to_s24_s32(struct processing_module *mod, struct input_strea
 		out0 = audio_stream_wrap(sink, out0 + n);
 		in0 = audio_stream_wrap(source, in0 + n);
 	}
-	/* update peak vol */
-	peak_vol_update(cd);
 }
 #endif /* CONFIG_FORMAT_S32LE */
 
@@ -565,8 +551,6 @@ static void vol_s16_to_s16(struct processing_module *mod, struct input_stream_bu
 	int samples = channels_count * frames;
 	ae_f32x2 peak_vol;
 	uint32_t *peak_meter = cd->peak_regs.peak_meter;
-
-	memset(peak_meter, 0, sizeof(int32_t) * cd->channels);
 
 	while (samples) {
 		m = audio_stream_samples_without_wrap_s16(source, in0);
@@ -614,8 +598,6 @@ static void vol_s16_to_s16(struct processing_module *mod, struct input_stream_bu
 		bsource->consumed += VOL_S16_SAMPLES_TO_BYTES(n);
 		bsink->size += VOL_S16_SAMPLES_TO_BYTES(n);
 	}
-	/* update peak vol */
-	peak_vol_update(cd);
 }
 #endif /* CONFIG_FORMAT_S16LE */
 #endif /* HIFI3 VERSION */

--- a/src/include/sof/audio/volume.h
+++ b/src/include/sof/audio/volume.h
@@ -141,6 +141,8 @@ struct vol_data {
 	struct ipc4_peak_volume_regs peak_regs;
 	/**< store temp peak volume 4 times for scale_vol function */
 	int32_t *peak_vol;
+	uint32_t peak_cnt;		/**< accumulated period of volume processing*/
+	uint32_t peak_report_cnt;		/**< the period number to update peak meter*/
 #endif
 	int32_t volume[SOF_IPC_MAX_CHANNELS];	/**< current volume */
 	int32_t tvolume[SOF_IPC_MAX_CHANNELS];	/**< target volume */


### PR DESCRIPTION
Add kconfig to select the period of reporting peak meter value. The default value is reporting peak meter every 10 ms.