### PR TITLE
Tools: Test: Audio: Valgrind run related fixes

### DIFF
--- a/tools/test/audio/process_test.m
+++ b/tools/test/audio/process_test.m
@@ -409,6 +409,9 @@ function test = test_defaults(t)
 	test.thdnf_max = [];            % Set per component
 	test.dr_db_min = 80;            % Min. DR
 	test.fr_rp_max_db = 0.5;        % Allow 0.5 dB frequency response ripple
+
+	% No need to collect trace
+	test.trace = '';
 end
 
 function test = test_run_process(test)

--- a/tools/test/audio/test_utils/test_run.m
+++ b/tools/test/audio/test_utils/test_run.m
@@ -92,14 +92,16 @@ else
 	fprintf(fh, 'XTRUN=\n');
 end
 
-% Override defaults in comp_run.sh
-fprintf(fh, 'VALGRIND=false\n');
 fclose(fh);
 
 arg = sprintf('-t %s', fn_config);
 rcmd = sprintf('%s %s', ex, arg);
 fprintf('Running ''%s''...\n', rcmd);
-system(rcmd);
+ret = system(rcmd);
+if ret
+	error('''%s'' returned status %d\n', rcmd, ret);
+end
+
 delete(fn_config);
 
 end

--- a/tools/test/audio/test_utils/test_run.m
+++ b/tools/test/audio/test_utils/test_run.m
@@ -55,7 +55,7 @@ if isfield(test, 'nch_in') == 0
 	test.nch_in = test.nch;
 end
 
-fprintf(fh, '#!/bin/sh\n', test.comp);
+fprintf(fh, '#!/bin/sh\n');
 fprintf(fh, 'COMP=\"%s\"\n', test.comp);
 fprintf(fh, 'DIRECTION=playback\n');
 fprintf(fh, 'BITS_IN=%d\n', test.bits_in);


### PR DESCRIPTION
The changes to scripts/host-testbench.sh have unintentionally dropped valgrind run from test.

This patch enables valgrind for process_test.m runs and fixes issue in test run octave side function to silently ignore error about failed shell command. Normally test fail when there is no data or incorrect data, but a valgrind failure with correct test output was passed.

Valgrind output becomes visible if testbench run trace stderr redirection to file is disabled. If not done valgrind error would stop the test but the analysis would not be printed to console.