### PR TITLE
Extend the module interface ops

### DIFF
--- a/src/audio/module_adapter/module/generic.c
+++ b/src/audio/module_adapter/module/generic.c
@@ -436,3 +436,21 @@ int module_set_configuration(struct processing_module *mod,
 
 	return ret;
 }
+
+int module_bind(struct processing_module *mod, void *data)
+{
+	struct module_data *md = &mod->priv;
+
+	if (md->ops->bind)
+		return md->ops->bind(mod, data);
+	return 0;
+}
+
+int module_unbind(struct processing_module *mod, void *data)
+{
+	struct module_data *md = &mod->priv;
+
+	if (md->ops->unbind)
+		return md->ops->unbind(mod, data);
+	return 0;
+}

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -1283,6 +1283,11 @@ int module_adapter_bind(struct comp_dev *dev, void *data)
 	struct comp_dev *source_dev;
 	int source_index;
 	int src_id;
+	int ret;
+
+	ret = module_bind(mod, data);
+	if (ret < 0)
+		return ret;
 
 	bu = (struct ipc4_module_bind_unbind *)data;
 	src_id = IPC4_COMP_ID(bu->primary.r.module_id, bu->primary.r.instance_id);
@@ -1332,6 +1337,11 @@ int module_adapter_unbind(struct comp_dev *dev, void *data)
 	struct comp_dev *source_dev;
 	int source_index;
 	int src_id;
+	int ret;
+
+	ret = module_unbind(mod, data);
+	if (ret < 0)
+		return ret;
 
 	bu = (struct ipc4_module_bind_unbind *)data;
 	src_id = IPC4_COMP_ID(bu->primary.r.module_id, bu->primary.r.instance_id);

--- a/src/include/sof/audio/module_adapter/module/generic.h
+++ b/src/include/sof/audio/module_adapter/module/generic.h
@@ -235,6 +235,8 @@ int module_set_configuration(struct processing_module *mod,
 			     enum module_cfg_fragment_position pos, size_t data_offset_size,
 			     const uint8_t *fragment, size_t fragment_size, uint8_t *response,
 			     size_t response_size);
+int module_bind(struct processing_module *mod, void *data);
+int module_unbind(struct processing_module *mod, void *data);
 
 struct comp_dev *module_adapter_new(const struct comp_driver *drv,
 				    const struct comp_ipc_config *config,

--- a/src/include/sof/audio/module_adapter/module/module_interface.h
+++ b/src/include/sof/audio/module_adapter/module/module_interface.h
@@ -143,6 +143,14 @@ struct module_interface {
 	 * free in .free(). This should free all memory allocated during module initialization.
 	 */
 	int (*free)(struct processing_module *mod);
+	/**
+	 * Module specific bind procedure, called when modules are bound with each other
+	 */
+	int (*bind)(struct processing_module *mod, void *data);
+	/**
+	 * Module specific unbind procedure, called when modules are disconnected from one another
+	 */
+	int (*unbind)(struct processing_module *mod, void *data);
 };
 
 /* Convert first_block/last_block indicator to fragment position */

--- a/src/include/sof/audio/module_adapter/module/module_interface.h
+++ b/src/include/sof/audio/module_adapter/module/module_interface.h
@@ -65,6 +65,72 @@ struct output_stream_buffer {
 	uint32_t size; /* size of data in the buffer */
 };
 
+/**
+ * \struct module_endpoint_ops
+ * \brief Ops relevant only for the endpoint devices such as the host copier or DAI copier.
+ *	  Other modules should not implement these.
+ */
+struct module_endpoint_ops {
+	/**
+	 * Returns total data processed in number bytes.
+	 * @param dev Component device
+	 * @param stream_no Index of input/output stream
+	 * @param input Selects between input (true) or output (false) stream direction
+	 * @return total data processed if succeeded, 0 otherwise.
+	 */
+	uint64_t (*get_total_data_processed)(struct comp_dev *dev, uint32_t stream_no, bool input);
+	/**
+	 * Retrieves component rendering position.
+	 * @param dev Component device.
+	 * @param posn Receives reported position.
+	 */
+	int (*position)(struct comp_dev *dev, struct sof_ipc_stream_posn *posn);
+	/**
+	 * Configures timestamping in attached DAI.
+	 * @param dev Component device.
+	 *
+	 * Mandatory for components that allocate DAI.
+	 */
+	int (*dai_ts_config)(struct comp_dev *dev);
+
+	/**
+	 * Starts timestamping.
+	 * @param dev Component device.
+	 *
+	 * Mandatory for components that allocate DAI.
+	 */
+	int (*dai_ts_start)(struct comp_dev *dev);
+
+	/**
+	 * Stops timestamping.
+	 * @param dev Component device.
+	 *
+	 * Mandatory for components that allocate DAI.
+	 */
+	int (*dai_ts_stop)(struct comp_dev *dev);
+
+	/**
+	 * Gets timestamp.
+	 * @param dev Component device.
+	 * @param tsd Receives timestamp data.
+	 *
+	 * Mandatory for components that allocate DAI.
+	 */
+	int (*dai_ts_get)(struct comp_dev *dev, struct timestamp_data *tsd);
+
+	/**
+	 * Fetches hardware stream parameters.
+	 * @param dev Component device.
+	 * @param params Receives copy of stream parameters retrieved from
+	 *	DAI hw settings.
+	 * @param dir Stream direction (see enum sof_ipc_stream_direction).
+	 *
+	 * Mandatory for components that allocate DAI.
+	 */
+	int (*dai_get_hw_params)(struct comp_dev *dev,
+				 struct sof_ipc_stream_params *params, int dir);
+};
+
 struct processing_module;
 /**
  * \struct module_interface
@@ -151,6 +217,8 @@ struct module_interface {
 	 * Module specific unbind procedure, called when modules are disconnected from one another
 	 */
 	int (*unbind)(struct processing_module *mod, void *data);
+
+	const struct module_endpoint_ops *endpoint_ops;
 };
 
 /* Convert first_block/last_block indicator to fragment position */


### PR DESCRIPTION
Extend the module interface to add the bind/unbind ops and also make it easier to convert the copier to use the module adapter