### PR TITLE
xtensa-build-zephyr.py: resolve relative --key arguments

### DIFF
--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -589,7 +589,9 @@ def rimage_options(platform_dict):
 
 	signing_key = ""
 	if args.key:
-		signing_key = args.key
+		key_path = pathlib.Path(args.key)
+		assert key_path.exists(), f"{key_path} not found"
+		signing_key = key_path.resolve()
 	elif "RIMAGE_KEY" in platform_dict:
 		signing_key = platform_dict["RIMAGE_KEY"]
 	else:

--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -60,7 +60,6 @@ VERSION = version.Version("2.0.0")
 # Constant value resolves SOF_TOP directory as: "this script directory/.."
 SOF_TOP = pathlib.Path(__file__).parents[1].resolve()
 west_top = pathlib.Path(SOF_TOP, "..").resolve()
-default_rimage_key = pathlib.Path(SOF_TOP, "keys", "otc_private_key.pem")
 
 sof_fw_version = None
 
@@ -587,17 +586,16 @@ def rimage_options(platform_dict):
 	if args.verbose > 0:
 		opts.append(("-v",) * args.verbose)
 
-	signing_key = ""
+	signing_key = None
 	if args.key:
 		key_path = pathlib.Path(args.key)
 		assert key_path.exists(), f"{key_path} not found"
 		signing_key = key_path.resolve()
 	elif "RIMAGE_KEY" in platform_dict:
 		signing_key = platform_dict["RIMAGE_KEY"]
-	else:
-		signing_key = default_rimage_key
 
-	opts.append(("-k", str(signing_key)))
+	if signing_key is not None:
+		opts.append(("-k", str(signing_key)))
 
 	sof_fw_vers = get_sof_version()
 


### PR DESCRIPTION
2 commits, please review separately. Main commit:

`xtensa-build-zephyr.py: resolve relative --key arguments`

Fixes commit https://github.com/thesofproject/sof/commit/a769d3941d81f6d487e1a2bb6c3f99a193ebdcae ("xtensa-build-zephyr.py: stop calling west
sign, rely on west build")

Before that commit, `xtensa-build-zephyr.py` used to invoke `west sign`
directly and in the same current directory. This allowed relative key
paths to just work. Now that `west sign` is indirectly invoked by `west
build`, there is no possible way to make relative key paths work. So we
must resolve them before using them.

Fixes https://github.com/thesofproject/sof/issues/7718