### PR TITLE
app/prj.conf: restore the CONFIG_CLEANUP_INTERMEDIATE_FILES=n default

### DIFF
--- a/app/prj.conf
+++ b/app/prj.conf
@@ -9,6 +9,14 @@ CONFIG_BUILD_OUTPUT_BIN=n
 # and usage in xtensa-build-zephyr.py
 CONFIG_BUILD_OUTPUT_STRIPPED=y
 
+# Zephyr has hardcoded this to 'y' because it saves CI some disk space
+# when compiling hundreds of different zephyr/tests/, each in a separate
+# build directory. But when compiling just one "sof/app" it saves
+# practically no space, breaks the incremental build and can make it
+# more difficult to troubleshoot some build issues. So, reset it to the
+# default value.
+CONFIG_CLEANUP_INTERMEDIATE_FILES=n
+
 CONFIG_HAVE_AGENT=n
 
 CONFIG_LOG=y


### PR DESCRIPTION
Zephyr has hardcoded this to 'y' because it saves CI some disk space when compiling hundreds of different zephyr/tests/, each in a separate build directory. But when compiling just one "sof/app" it saves practically no space, breaks the incremental build and can make it more difficult to troubleshoot some build issues. So, reset it to the default value.