### PR TITLE
audio: avoid division when calculating samples and frames

### DIFF
--- a/src/audio/asrc/asrc.c
+++ b/src/audio/asrc/asrc.c
@@ -555,7 +555,7 @@ static int asrc_params(struct comp_dev *dev,
 
 	/* Don't change sink rate if value from IPC is 0 (auto detect) */
 	if (asrc_get_sink_rate(&cd->ipc_config))
-		sink_c->stream.rate = asrc_get_sink_rate(&cd->ipc_config);
+		audio_stream_set_rate(&sink_c->stream, asrc_get_sink_rate(&cd->ipc_config));
 
 	/* set source/sink_frames/rate */
 	cd->source_rate = audio_stream_get_rate(&source_c->stream);

--- a/src/audio/buffer.c
+++ b/src/audio/buffer.c
@@ -65,8 +65,8 @@ struct comp_buffer *buffer_alloc(uint32_t size, uint32_t caps, uint32_t flags, u
 	buffer_c->stream.addr = stream_addr;
 	buffer_init(buffer_c, size, caps);
 
-	buffer_c->stream.underrun_permitted = !!(flags & SOF_BUF_UNDERRUN_PERMITTED);
-	buffer_c->stream.overrun_permitted = !!(flags & SOF_BUF_OVERRUN_PERMITTED);
+	audio_stream_set_underrun(&buffer_c->stream, !!(flags & SOF_BUF_UNDERRUN_PERMITTED));
+	audio_stream_set_overrun(&buffer_c->stream, !!(flags & SOF_BUF_OVERRUN_PERMITTED));
 
 	buffer_release(buffer_c);
 
@@ -170,15 +170,15 @@ bool buffer_params_match(struct comp_buffer __sparse_cache *buffer,
 	assert(params);
 
 	if ((flag & BUFF_PARAMS_FRAME_FMT) &&
-	    buffer->stream.frame_fmt != params->frame_fmt)
+	     audio_stream_get_frm_fmt(&buffer->stream) != params->frame_fmt)
 		return false;
 
 	if ((flag & BUFF_PARAMS_RATE) &&
-	    buffer->stream.rate != params->rate)
+	     audio_stream_get_rate(&buffer->stream) != params->rate)
 		return false;
 
 	if ((flag & BUFF_PARAMS_CHANNELS) &&
-	    buffer->stream.channels != params->channels)
+	     audio_stream_get_channels(&buffer->stream) != params->channels)
 		return false;
 
 	return true;

--- a/src/audio/copier/copier_generic.c
+++ b/src/audio/copier/copier_generic.c
@@ -62,15 +62,15 @@ void update_buffer_format(struct comp_buffer __sparse_cache *buf_c,
 	enum sof_ipc_frame valid_fmt, frame_fmt;
 	int i;
 
-	buf_c->stream.channels = fmt->channels_count;
-	buf_c->stream.rate = fmt->sampling_frequency;
+	audio_stream_set_channels(&buf_c->stream, fmt->channels_count);
+	audio_stream_set_rate(&buf_c->stream, fmt->sampling_frequency);
 	audio_stream_fmt_conversion(fmt->depth,
 				    fmt->valid_bit_depth,
 				    &frame_fmt, &valid_fmt,
 				    fmt->s_type);
 
-	buf_c->stream.frame_fmt = frame_fmt;
-	buf_c->stream.valid_sample_fmt = valid_fmt;
+	audio_stream_set_frm_fmt(&buf_c->stream, frame_fmt);
+	audio_stream_set_valid_fmt(&buf_c->stream, valid_fmt);
 
 	buf_c->buffer_fmt = fmt->interleaving_style;
 

--- a/src/audio/copier/copier_host.c
+++ b/src/audio/copier/copier_host.c
@@ -145,7 +145,7 @@ void copier_host_dma_cb(struct comp_dev *dev, size_t bytes)
 	if (cd->attenuation && dev->direction == SOF_IPC_STREAM_PLAYBACK) {
 		source = buffer_acquire(cd->hd->dma_buffer);
 		sink = buffer_acquire(cd->hd->local_buffer);
-		frames = bytes / audio_stream_frame_bytes(&source->stream);
+		frames = audio_stream_bytes_to_frames(&sink->stream, bytes);
 
 		ret = apply_attenuation(dev, cd, sink, frames);
 		if (ret < 0)

--- a/src/audio/google/google_hotword_detect.c
+++ b/src/audio/google/google_hotword_detect.c
@@ -178,7 +178,7 @@ static int ghd_params(struct comp_dev *dev,
 				  sink_list);
 	source_c = buffer_acquire(sourceb);
 
-	if (source_c->stream.channels != 1) {
+	if (audio_stream_get_channels(source_c->stream) != 1) {
 		comp_err(dev, "ghd_params(): Only single-channel supported");
 		ret = -EINVAL;
 	} else if (audio_stream_get_frm_fmt(&source_c->stream) != SOF_IPC_FRAME_S16_LE) {

--- a/src/audio/host-zephyr.c
+++ b/src/audio/host-zephyr.c
@@ -398,7 +398,7 @@ static uint32_t host_get_copy_bytes_normal(struct host_data *hd, struct comp_dev
 	}
 
 	dma_buf_c = buffer_acquire(hd->dma_buffer);
-	dma_sample_bytes = get_sample_bytes(dma_buf_c->stream.frame_fmt);
+	dma_sample_bytes = get_sample_bytes(audio_stream_get_frm_fmt(&dma_buf_c->stream));
 	buffer_release(dma_buf_c);
 
 	buffer_c = buffer_acquire(buffer);

--- a/src/audio/igo_nr/igo_nr.c
+++ b/src/audio/igo_nr/igo_nr.c
@@ -402,7 +402,8 @@ static int32_t igo_nr_params(struct comp_dev *dev,
 	cd->source_rate = audio_stream_get_rate(&source_c->stream);
 	cd->sink_rate = audio_stream_get_rate(&sink_c->stream);
 
-	if (source_c->stream.channels != audio_stream_get_channels(&sink_c->stream)) {
+	if (audio_stream_get_channels(source_c->stream) !=
+	    audio_stream_get_channels(&sink_c->stream)) {
 		comp_err(dev, "igo_nr_params(), mismatch source/sink stream channels");
 		cd->invalid_param = true;
 	}

--- a/src/audio/mixer/mixer.c
+++ b/src/audio/mixer/mixer.c
@@ -200,7 +200,7 @@ static inline void mixer_set_frame_alignment(struct audio_stream __sparse_cache 
 	/* Xtensa intrinsics ask for 8-byte aligned. 5.1 format SSE audio
 	 * requires 16-byte aligned.
 	 */
-	const uint32_t byte_align = source->channels == 6 ? 16 : 8;
+	const uint32_t byte_align = audio_stream_get_channels(source) == 6 ? 16 : 8;
 
 	/*There is no limit for frame number, so set it as 1*/
 	const uint32_t frame_align_req = 1;

--- a/src/audio/module_adapter/module/volume/volume.c
+++ b/src/audio/module_adapter/module/volume/volume.c
@@ -1214,7 +1214,7 @@ static void volume_set_alignment(struct audio_stream __sparse_cache *source,
 	 * xtensa intrinsics ask for 8-byte aligned. 5.1 format SSE audio
 	 * requires 16-byte aligned.
 	 */
-	const uint32_t byte_align = source->channels == 6 ? 16 : 8;
+	const uint32_t byte_align = audio_stream_get_channels(source) == 6 ? 16 : 8;
 
 	/*There is no limit for frame number, so both source and sink set it to be 1*/
 	const uint32_t frame_align_req = 1;

--- a/src/audio/rtnr/rtnr.c
+++ b/src/audio/rtnr/rtnr.c
@@ -381,7 +381,7 @@ static int rtnr_params(struct comp_dev *dev, struct sof_ipc_stream_params *param
 
 	/* set source/sink stream channels */
 	cd->sources_stream[0].channels = audio_stream_get_channels(&source_c->stream);
-	cd->sink_stream.channels = audio_stream_get_channels(&sink_c->stream);
+	audio_stream_set_channels(&cd->sink_stream, audio_stream_get_channels(&sink_c->stream));
 
 	/* set source/sink stream overrun/underrun permitted */
 	cd->sources_stream[0].overrun_permitted = audio_stream_get_overrun(&source_c->stream);

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -932,7 +932,8 @@ static int selector_prepare(struct processing_module *mod)
 	 * reduce channel count between source and sink
 	 */
 	comp_info(dev, "selector_prepare(): source sink channel = %u %u",
-		  audio_stream_get_channels(&source_c->stream), sink_c->stream.channels);
+		  audio_stream_get_channels(&source_c->stream),
+		  audio_stream_get_channels(&sink_c->stream));
 
 	sink_size = audio_stream_get_size(&sink_c->stream);
 

--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -201,6 +201,18 @@ static inline void audio_stream_set_channels(struct audio_stream __sparse_cache 
 	buf->channels = val;
 }
 
+static inline void audio_stream_set_underrun(struct audio_stream __sparse_cache *buf,
+					     bool underrun_permitted)
+{
+	buf->underrun_permitted = underrun_permitted;
+}
+
+static inline void audio_stream_set_overrun(struct audio_stream __sparse_cache *buf,
+					    bool overrun_permitted)
+{
+	buf->overrun_permitted = overrun_permitted;
+}
+
 /**
  * Retrieves readable address of a sample at specified index (see versions of
  * this macro specialized for various sample types).

--- a/src/samples/audio/detect_test.c
+++ b/src/samples/audio/detect_test.c
@@ -225,7 +225,7 @@ static void default_detect_test(struct comp_dev *dev,
 	if (cd->config.load_mips) {
 		/* assuming count is a processing frame size in samples */
 		cycles_per_frame = (cd->config.load_mips * 1000000 * count)
-				   / source->rate;
+				   / audio_stream_get_rate(source);
 		idelay(cycles_per_frame);
 	}
 

--- a/src/samples/audio/smart_amp_test_ipc3.c
+++ b/src/samples/audio/smart_amp_test_ipc3.c
@@ -537,8 +537,8 @@ static int smart_amp_prepare(struct comp_dev *dev)
 	if (sad->feedback_buf) {
 		struct comp_buffer __sparse_cache *buf = buffer_acquire(sad->feedback_buf);
 
-		buf->stream.channels = sad->config.feedback_channels;
-		buf->stream.rate = audio_stream_get_rate(&buffer_c->stream);
+		audio_stream_set_channels(&buf->stream, sad->config.feedback_channels);
+		audio_stream_set_rate(&buf->stream, audio_stream_get_rate(&buffer_c->stream));
 		buffer_release(buf);
 	}
 

--- a/src/samples/audio/smart_amp_test_ipc4.c
+++ b/src/samples/audio/smart_amp_test_ipc4.c
@@ -227,7 +227,7 @@ static int smart_amp_process_s16(struct processing_module *mod,
 	int i;
 	int j;
 
-	bsource->consumed += frames * source->channels * sizeof(int16_t);
+	bsource->consumed += frames * audio_stream_get_channels(source) * sizeof(int16_t);
 	for (i = 0; i < frames; i++) {
 		for (j = 0 ; j < sad->out_channels; j++) {
 			if (chan_map[j] != -1) {
@@ -260,7 +260,7 @@ static int smart_amp_process_s32(struct processing_module *mod,
 	int i;
 	int j;
 
-	bsource->consumed += frames * source->channels * sizeof(int32_t);
+	bsource->consumed += frames * audio_stream_get_channels(source) * sizeof(int32_t);
 	for (i = 0; i < frames; i++) {
 		for (j = 0 ; j < sad->out_channels; j++) {
 			if (chan_map[j] != -1) {
@@ -388,8 +388,9 @@ static int smart_amp_prepare(struct processing_module *mod)
 		buffer_c = buffer_acquire(source_buffer);
 		audio_stream_init_alignment_constants(1, 1, &buffer_c->stream);
 		if (IPC4_SINK_QUEUE_ID(buffer_c->id) == SOF_SMART_AMP_FEEDBACK_QUEUE_ID) {
-			buffer_c->stream.channels = sad->config.feedback_channels;
-			buffer_c->stream.rate = mod->priv.cfg.base_cfg.audio_fmt.sampling_frequency;
+			audio_stream_set_channels(&buffer_c->stream, sad->config.feedback_channels);
+			audio_stream_set_rate(&buffer_c->stream,
+					      mod->priv.cfg.base_cfg.audio_fmt.sampling_frequency);
 		}
 		buffer_release(buffer_c);
 	}

--- a/test/cmocka/src/audio/eq_fir/eq_fir_process.c
+++ b/test/cmocka/src/audio/eq_fir/eq_fir_process.c
@@ -214,7 +214,7 @@ static void fill_source_s16(struct test_data *td, int frames_max)
 	sb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
 	ss = &sb->stream;
 	frames = MIN(audio_stream_get_free_frames(ss), frames_max);
-	samples = frames * ss->channels;
+	samples = frames * audio_stream_get_channels(ss);
 	for (i = 0; i < samples; i++) {
 		x = audio_stream_write_frag_s16(ss, i);
 		*x = sat_int16(Q_SHIFT_RND(chirp_2ch[buffer_fill_data.idx++], 31, 15));
@@ -230,7 +230,7 @@ static void fill_source_s16(struct test_data *td, int frames_max)
 		comp_update_buffer_produce(sb, bytes_total);
 	}
 
-	mod->input_buffers[0].size = samples_processed / ss->channels;
+	mod->input_buffers[0].size = samples_processed / audio_stream_get_channels(ss);
 }
 
 static void verify_sink_s16(struct test_data *td)
@@ -280,7 +280,7 @@ static void fill_source_s24(struct test_data *td, int frames_max)
 	sb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
 	ss = &sb->stream;
 	frames = MIN(audio_stream_get_free_frames(ss), frames_max);
-	samples = frames * ss->channels;
+	samples = frames * audio_stream_get_channels(ss);
 	for (i = 0; i < samples; i++) {
 		x = audio_stream_write_frag_s32(ss, i);
 		*x = sat_int24(Q_SHIFT_RND(chirp_2ch[buffer_fill_data.idx++], 31, 23));
@@ -296,7 +296,7 @@ static void fill_source_s24(struct test_data *td, int frames_max)
 		comp_update_buffer_produce(sb, bytes_total);
 	}
 
-	mod->input_buffers[0].size = samples_processed / ss->channels;
+	mod->input_buffers[0].size = samples_processed / audio_stream_get_channels(ss);
 }
 
 static void verify_sink_s24(struct test_data *td)
@@ -346,7 +346,7 @@ static void fill_source_s32(struct test_data *td, int frames_max)
 	sb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
 	ss = &sb->stream;
 	frames = MIN(audio_stream_get_free_frames(ss), frames_max);
-	samples = frames * ss->channels;
+	samples = frames * audio_stream_get_channels(ss);
 	for (i = 0; i < samples; i++) {
 		x = audio_stream_write_frag_s32(ss, i);
 		*x = chirp_2ch[buffer_fill_data.idx++];
@@ -362,7 +362,7 @@ static void fill_source_s32(struct test_data *td, int frames_max)
 		comp_update_buffer_produce(sb, bytes_total);
 	}
 
-	mod->input_buffers[0].size = samples_processed / ss->channels;
+	mod->input_buffers[0].size = samples_processed / audio_stream_get_channels(ss);
 }
 
 static void verify_sink_s32(struct test_data *td)
@@ -419,7 +419,7 @@ static void test_audio_eq_fir(void **state)
 
 	while (td->continue_loop) {
 		frames = frames_jitter(td->params->frames);
-		switch (source->stream.frame_fmt) {
+		switch (audio_stream_get_frm_fmt(&source->stream)) {
 		case SOF_IPC_FRAME_S16_LE:
 			fill_source_s16(td, frames);
 			break;
@@ -445,7 +445,7 @@ static void test_audio_eq_fir(void **state)
 		comp_update_buffer_consume(source, mod->input_buffers[0].consumed);
 		comp_update_buffer_produce(sink, mod->output_buffers[0].size);
 
-		switch (sink->stream.frame_fmt) {
+		switch (audio_stream_get_frm_fmt(&sink->stream)) {
 		case SOF_IPC_FRAME_S16_LE:
 			verify_sink_s16(td);
 			break;

--- a/test/cmocka/src/audio/eq_iir/eq_iir_process.c
+++ b/test/cmocka/src/audio/eq_iir/eq_iir_process.c
@@ -213,7 +213,7 @@ static void fill_source_s16(struct test_data *td, int frames_max)
 	sb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
 	ss = &sb->stream;
 	frames = MIN(audio_stream_get_free_frames(ss), frames_max);
-	samples = frames * ss->channels;
+	samples = frames * audio_stream_get_channels(ss);
 	for (i = 0; i < samples; i++) {
 		x = audio_stream_write_frag_s16(ss, i);
 		*x = sat_int16(Q_SHIFT_RND(chirp_2ch[buffer_fill_data.idx++], 31, 15));
@@ -229,7 +229,7 @@ static void fill_source_s16(struct test_data *td, int frames_max)
 		comp_update_buffer_produce(sb, bytes_total);
 	}
 
-	mod->input_buffers[0].size = samples_processed / ss->channels;
+	mod->input_buffers[0].size = samples_processed / audio_stream_get_channels(ss);
 }
 
 static void verify_sink_s16(struct test_data *td)
@@ -276,7 +276,7 @@ static void fill_source_s24(struct test_data *td, int frames_max)
 	sb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
 	ss = &sb->stream;
 	frames = MIN(audio_stream_get_free_frames(ss), frames_max);
-	samples = frames * ss->channels;
+	samples = frames * audio_stream_get_channels(ss);
 	for (i = 0; i < samples; i++) {
 		x = audio_stream_write_frag_s32(ss, i);
 		*x = sat_int24(Q_SHIFT_RND(chirp_2ch[buffer_fill_data.idx++], 31, 23));
@@ -292,7 +292,7 @@ static void fill_source_s24(struct test_data *td, int frames_max)
 		comp_update_buffer_produce(sb, bytes_total);
 	}
 
-	mod->input_buffers[0].size = samples_processed / ss->channels;
+	mod->input_buffers[0].size = samples_processed / audio_stream_get_channels(ss);
 }
 
 static void verify_sink_s24(struct test_data *td)
@@ -339,7 +339,7 @@ static void fill_source_s32(struct test_data *td, int frames_max)
 	sb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
 	ss = &sb->stream;
 	frames = MIN(audio_stream_get_free_frames(ss), frames_max);
-	samples = frames * ss->channels;
+	samples = frames * audio_stream_get_channels(ss);
 	for (i = 0; i < samples; i++) {
 		x = audio_stream_write_frag_s32(ss, i);
 		*x = chirp_2ch[buffer_fill_data.idx++];
@@ -355,7 +355,7 @@ static void fill_source_s32(struct test_data *td, int frames_max)
 		comp_update_buffer_produce(sb, bytes_total);
 	}
 
-	mod->input_buffers[0].size = samples_processed / ss->channels;
+	mod->input_buffers[0].size = samples_processed / audio_stream_get_channels(ss);
 }
 
 static void verify_sink_s32(struct test_data *td)
@@ -409,7 +409,7 @@ static void test_audio_eq_iir(void **state)
 
 	while (td->continue_loop) {
 		frames = frames_jitter(td->params->frames);
-		switch (source->stream.frame_fmt) {
+		switch (audio_stream_get_frm_fmt(&source->stream)) {
 		case SOF_IPC_FRAME_S16_LE:
 			fill_source_s16(td, frames);
 			break;
@@ -434,7 +434,7 @@ static void test_audio_eq_iir(void **state)
 		comp_update_buffer_consume(source, mod->input_buffers[0].consumed);
 		comp_update_buffer_produce(sink, mod->output_buffers[0].size);
 
-		switch (sink->stream.frame_fmt) {
+		switch (audio_stream_get_frm_fmt(&sink->stream)) {
 		case SOF_IPC_FRAME_S16_LE:
 			verify_sink_s16(td);
 			break;

--- a/test/cmocka/src/audio/mux/mux_get_processing_function.c
+++ b/test/cmocka/src/audio/mux/mux_get_processing_function.c
@@ -111,7 +111,7 @@ static void test_mux_get_processing_function_invalid_float(void **state)
 	mux_func func = NULL;
 
 	/* set frame format value to unsupported value */
-	td->sink->stream.frame_fmt = SOF_IPC_FRAME_FLOAT;
+	audio_stream_set_frm_fmt(&td->sink->stream, SOF_IPC_FRAME_FLOAT);
 
 	func = mux_get_processing_function(td->mod);
 
@@ -125,7 +125,7 @@ static void test_mux_get_processing_function_valid_s16le(void **state)
 	struct test_data *td = *state;
 	mux_func func = NULL;
 
-	td->sink->stream.frame_fmt = SOF_IPC_FRAME_S16_LE;
+	audio_stream_set_frm_fmt(&td->sink->stream, SOF_IPC_FRAME_S16_LE);
 
 	func = mux_get_processing_function(td->mod);
 
@@ -139,7 +139,7 @@ static void test_mux_get_processing_function_valid_s24_4le(void **state)
 	struct test_data *td = *state;
 	mux_func func = NULL;
 
-	td->sink->stream.frame_fmt = SOF_IPC_FRAME_S24_4LE;
+	audio_stream_set_frm_fmt(&td->sink->stream, SOF_IPC_FRAME_S24_4LE);
 
 	func = mux_get_processing_function(td->mod);
 
@@ -153,7 +153,7 @@ static void test_mux_get_processing_function_valid_s32le(void **state)
 	struct test_data *td = *state;
 	mux_func func = NULL;
 
-	td->sink->stream.frame_fmt = SOF_IPC_FRAME_S32_LE;
+	audio_stream_set_frm_fmt(&td->sink->stream, SOF_IPC_FRAME_S32_LE);
 
 	func = mux_get_processing_function(td->mod);
 

--- a/test/cmocka/src/audio/selector/selector_test.c
+++ b/test/cmocka/src/audio/selector/selector_test.c
@@ -275,7 +275,7 @@ static void verify_s16le_2ch_to_2ch(struct processing_module *mod,
 {
 	const uint16_t *src = (uint16_t *)source->r_ptr;
 	const uint16_t *dst = (uint16_t *)sink->w_ptr;
-	uint32_t channels = source->channels;
+	uint32_t channels = audio_stream_get_channels(source);
 	uint32_t channel;
 	uint32_t i;
 	double processed;
@@ -300,7 +300,7 @@ static void verify_s16le_4ch_to_4ch(struct processing_module *mod,
 {
 	const uint16_t *src = (uint16_t *)source->r_ptr;
 	const uint16_t *dst = (uint16_t *)sink->w_ptr;
-	uint32_t channels = source->channels;
+	uint32_t channels = audio_stream_get_channels(source);
 	uint32_t channel;
 	uint32_t i;
 	double processed;
@@ -376,7 +376,7 @@ static void verify_s32le_2ch_to_2ch(struct processing_module *mod,
 {
 	const uint32_t *src = (uint32_t *)source->r_ptr;
 	const uint32_t *dst = (uint32_t *)sink->w_ptr;
-	uint32_t channels = source->channels;
+	uint32_t channels = audio_stream_get_channels(source);
 	uint32_t channel;
 	uint32_t i;
 	uint32_t processed;
@@ -401,7 +401,7 @@ static void verify_s32le_4ch_to_4ch(struct processing_module *mod,
 {
 	const uint32_t *src = (uint32_t *)source->r_ptr;
 	const uint32_t *dst = (uint32_t *)sink->w_ptr;
-	uint32_t channels = source->channels;
+	uint32_t channels = audio_stream_get_channels(source);
 	uint32_t channel;
 	uint32_t i;
 	uint32_t processed;

--- a/test/cmocka/src/audio/volume/volume_process.c
+++ b/test/cmocka/src/audio/volume/volume_process.c
@@ -116,7 +116,7 @@ static void verify_s16_to_s16(struct processing_module *mod, struct comp_buffer 
 	const int16_t *src = (int16_t *)source->stream.r_ptr;
 	const int16_t *dst = (int16_t *)sink->stream.w_ptr;
 	double processed;
-	int channels = sink->stream.channels;
+	int channels = audio_stream_get_channels(&sink->stream);
 	int channel;
 	int delta;
 	int i;
@@ -168,7 +168,7 @@ static void verify_s24_to_s24_s32(struct processing_module *mod,
 	double processed;
 	int32_t dst_sample;
 	int32_t sample;
-	int channels = sink->stream.channels;
+	int channels = audio_stream_get_channels(&sink->stream);
 	int channel;
 	int delta;
 	int i;
@@ -225,7 +225,7 @@ static void verify_s32_to_s24_s32(struct processing_module *mod,
 	const int32_t *dst = (int32_t *)sink->stream.w_ptr;
 	int32_t dst_sample;
 	int32_t sample;
-	int channels = sink->stream.channels;
+	int channels = audio_stream_get_channels(&sink->stream);
 	int channel;
 	int delta;
 	int i;
@@ -262,7 +262,7 @@ static void test_audio_vol(void **state)
 	struct processing_module *mod = vol_state->mod;
 	struct vol_data *cd = module_get_private_data(mod);
 
-	switch (vol_state->sinks[0]->stream.frame_fmt) {
+	switch (audio_stream_get_frm_fmt(&vol_state->sinks[0]->stream)) {
 	case SOF_IPC_FRAME_S16_LE:
 		fill_source_s16(vol_state);
 		break;

--- a/test/cmocka/src/math/fft/fft.c
+++ b/test/cmocka/src/math/fft/fft.c
@@ -52,7 +52,7 @@ static void fft_real(struct comp_buffer *src, struct comp_buffer *dst, uint32_t 
 	struct fft_plan *plan;
 	int i;
 
-	if (src->stream.channels != 1)
+	if (audio_stream_get_channels(&src->stream) != 1)
 		return;
 
 	if (src->stream.size < size * sizeof(int32_t) ||
@@ -106,7 +106,7 @@ static void ifft_complex(struct comp_buffer *src, struct comp_buffer *dst, uint3
 	struct fft_plan *plan;
 	int i;
 
-	if (src->stream.channels != 1)
+	if (audio_stream_get_channels(&src->stream) != 1)
 		return;
 
 	if (src->stream.size < size * sizeof(struct icomplex32) ||
@@ -163,7 +163,7 @@ static void fft_real_2(struct comp_buffer *src, struct comp_buffer *dst1,
 	struct fft_plan *plan;
 	int i;
 
-	if (src->stream.channels != 2)
+	if (audio_stream_get_channels(&src->stream) != 2)
 		return;
 
 	if (src->stream.size < size * sizeof(int32_t) * 2 ||
@@ -280,7 +280,7 @@ static void test_math_fft_256(void **state)
 
 	/* create sine wave */
 	get_sine_32(in, SINE_FREQ, SINE_FS, fft_size);
-	source->stream.channels = 1;
+	audio_stream_set_channels(&source->stream, 1);
 
 	/* do fft transform */
 	fft_real(source, sink, fft_size);
@@ -322,7 +322,7 @@ static void test_math_fft_512(void **state)
 
 	/* create sine wave */
 	get_sine_32(in, SINE_FREQ, SINE_FS, fft_size);
-	source->stream.channels = 1;
+	audio_stream_set_channels(&source->stream, 1);
 
 	/* do fft transform */
 	fft_real(source, sink, fft_size);
@@ -364,7 +364,7 @@ static void test_math_fft_1024(void **state)
 
 	/* create sine wave */
 	get_sine_32(in, SINE_FREQ, SINE_FS, fft_size);
-	source->stream.channels = 1;
+	audio_stream_set_channels(&source->stream, 1);
 
 	/* do fft transform */
 	fft_real(source, sink, fft_size);
@@ -405,12 +405,12 @@ static void test_math_fft_1024_ifft(void **state)
 	(void)state;
 
 	get_sine_32(in, SINE_FREQ, SINE_FS, fft_size);
-	source->stream.channels = 1;
+	audio_stream_set_channels(&source->stream, 1);
 
 	/* do fft transform */
 	fft_real(source, intm, fft_size);
 
-	intm->stream.channels = 1;
+	audio_stream_set_channels(&intm->stream, 1);
 	/* do ifft transform */
 	ifft_complex(intm, sink, fft_size);
 
@@ -448,7 +448,7 @@ static void test_math_fft_512_2ch(void **state)
 		*((int32_t *)source->stream.addr + 2 * i + 1) = input_samples[fft_size + i];
 	}
 
-	source->stream.channels = 2;
+	audio_stream_set_channels(&source->stream, 2);
 	/* do fft transform */
 	fft_real_2(source, sink1, sink2, fft_size);
 
@@ -482,7 +482,7 @@ static void fft_real_16(struct comp_buffer *src, struct comp_buffer *dst, uint32
 	struct fft_plan *plan;
 	int i;
 
-	if (src->stream.channels != 1)
+	if (audio_stream_get_channels(&src->stream) != 1)
 		return;
 
 	if (src->stream.size < size * sizeof(int16_t) ||
@@ -536,7 +536,7 @@ static void ifft_complex_16(struct comp_buffer *src, struct comp_buffer *dst, ui
 	struct fft_plan *plan;
 	int i;
 
-	if (src->stream.channels != 1)
+	if (audio_stream_get_channels(&src->stream) != 1)
 		return;
 
 	if (src->stream.size < size * sizeof(struct icomplex16) ||
@@ -640,7 +640,7 @@ static void test_math_fft_256_16(void **state)
 
 	/* create sine wave */
 	get_sine_16(in, SINE_FREQ, SINE_FS, fft_size);
-	source->stream.channels = 1;
+	audio_stream_set_channels(&source->stream, 1);
 
 	/* do fft transform */
 	fft_real_16(source, sink, fft_size);
@@ -682,7 +682,7 @@ static void test_math_fft_512_16(void **state)
 
 	/* create sine wave */
 	get_sine_16(in, SINE_FREQ, SINE_FS, fft_size);
-	source->stream.channels = 1;
+	audio_stream_set_channels(&source->stream, 1);
 
 	/* do fft transform */
 	fft_real_16(source, sink, fft_size);
@@ -724,7 +724,7 @@ static void test_math_fft_1024_16(void **state)
 
 	/* create sine wave */
 	get_sine_16(in, SINE_FREQ, SINE_FS, fft_size);
-	source->stream.channels = 1;
+	audio_stream_set_channels(&source->stream, 1);
 
 	/* do fft transform */
 	fft_real_16(source, sink, fft_size);
@@ -765,12 +765,12 @@ static void test_math_fft_1024_ifft_16(void **state)
 	(void)state;
 
 	get_sine_16(in, SINE_FREQ, SINE_FS, fft_size);
-	source->stream.channels = 1;
+	audio_stream_set_channels(&source->stream, 1);
 
 	/* do fft transform */
 	fft_real_16(source, intm, fft_size);
 
-	intm->stream.channels = 1;
+	audio_stream_set_channels(&intm->stream, 1);
 	/* do ifft transform */
 	ifft_complex_16(intm, sink, fft_size);
 

--- a/test/cmocka/src/util.h
+++ b/test/cmocka/src/util.h
@@ -34,8 +34,8 @@ static inline struct comp_buffer *create_test_sink(struct comp_dev *dev,
 	/* alloc sink and set default parameters */
 	buffer->sink = calloc(1, sizeof(struct comp_dev));
 	buffer->sink->state = COMP_STATE_PREPARE;
-	buffer->stream.frame_fmt = frame_fmt;
-	buffer->stream.channels = channels;
+	audio_stream_set_frm_fmt(&buffer->stream, frame_fmt);
+	audio_stream_set_channels(&buffer->stream, channels);
 
 	return buffer;
 }
@@ -69,8 +69,8 @@ static inline struct comp_buffer *create_test_source(struct comp_dev *dev,
 	/* alloc source and set default parameters */
 	buffer->source = calloc(1, sizeof(struct comp_dev));
 	buffer->source->state = COMP_STATE_PREPARE;
-	buffer->stream.frame_fmt = frame_fmt;
-	buffer->stream.channels = channels;
+	audio_stream_set_frm_fmt(&buffer->stream, frame_fmt);
+	audio_stream_set_channels(&buffer->stream, channels);
 
 	return buffer;
 }

--- a/tools/testbench/file.c
+++ b/tools/testbench/file.c
@@ -429,12 +429,12 @@ static int file_s32(struct comp_dev *dev, struct audio_stream *sink,
 	switch (cd->fs.mode) {
 	case FILE_READ:
 		/* read samples */
-		nch = sink->channels;
+		nch = audio_stream_get_channels(sink);
 		n_samples = read_samples_s32(cd, sink, frames * nch, SOF_IPC_FRAME_S32_LE);
 		break;
 	case FILE_WRITE:
 		/* write samples */
-		nch = source->channels;
+		nch = audio_stream_get_channels(source);
 		n_samples = write_samples_s32(cd, source, frames * nch, SOF_IPC_FRAME_S32_LE);
 		break;
 	default:
@@ -463,12 +463,12 @@ static int file_s16(struct comp_dev *dev, struct audio_stream *sink,
 	switch (cd->fs.mode) {
 	case FILE_READ:
 		/* read samples */
-		nch = sink->channels;
+		nch = audio_stream_get_channels(sink);
 		n_samples = read_samples_s16(cd, sink, frames * nch);
 		break;
 	case FILE_WRITE:
 		/* write samples */
-		nch = source->channels;
+		nch = audio_stream_get_channels(source);
 		n_samples = write_samples_s16(cd, source, frames * nch);
 		break;
 	default:
@@ -497,12 +497,12 @@ static int file_s24(struct comp_dev *dev, struct audio_stream *sink,
 	switch (cd->fs.mode) {
 	case FILE_READ:
 		/* read samples */
-		nch = sink->channels;
+		nch = audio_stream_get_channels(sink);
 		n_samples = read_samples_s32(cd, sink, frames * nch, SOF_IPC_FRAME_S24_4LE);
 		break;
 	case FILE_WRITE:
 		/* write samples */
-		nch = source->channels;
+		nch = audio_stream_get_channels(source);
 		n_samples = write_samples_s32(cd, source, frames * nch, SOF_IPC_FRAME_S24_4LE);
 		break;
 	default:
@@ -719,8 +719,8 @@ static int file_params(struct comp_dev *dev,
 
 	/* set downstream buffer size */
 	stream = &buffer->stream;
-	samples = periods * dev->frames * stream->channels;
-	switch (stream->frame_fmt) {
+	samples = periods * dev->frames * audio_stream_get_channels(stream);
+	switch (audio_stream_get_frm_fmt(stream)) {
 	case SOF_IPC_FRAME_S16_LE:
 		ret = buffer_set_size(buffer, samples * sizeof(int16_t), 0);
 		if (ret < 0) {
@@ -757,7 +757,7 @@ static int file_params(struct comp_dev *dev,
 		return -EINVAL;
 	}
 
-	cd->sample_container_bytes = get_sample_bytes(stream->frame_fmt);
+	cd->sample_container_bytes = audio_stream_sample_bytes(stream);
 	buffer_reset_pos(buffer, NULL);
 
 	return 0;


### PR DESCRIPTION
Bytes per sample and bytes per frame are usually powers of 2, so it bitshift can be used instead of division to calculate frame and sample counts. Note, that this doesn't necessarily improve performance, our measurements haven't showed any significant difference to the original code, but rather this is a clean up, achieved by replacing open-coded divisions spread around the code by calls to one of `audio_stream_bytes_to_samples()` and `audio_stream_bytes_to_frames()`