### PR TITLE
module_adapter: optimize simple copy

### DIFF
--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -772,7 +772,7 @@ static int module_adapter_simple_copy(struct comp_dev *dev)
 					  struct comp_buffer __sparse_cache,
 					  stream, __sparse_cache);
 
-		comp_update_buffer_consume(src_c, mod->input_buffers[i].consumed);
+		audio_stream_consume(&src_c->stream, mod->input_buffers[i].consumed);
 	}
 
 	/* compute data consumed based on pin 0 since it is processed with base config
@@ -799,7 +799,7 @@ static int module_adapter_simple_copy(struct comp_dev *dev)
 
 		if (!mod->skip_sink_buffer_writeback)
 			buffer_stream_writeback(sink_c, mod->output_buffers[i].size);
-		comp_update_buffer_produce(sink_c, mod->output_buffers[i].size);
+		audio_stream_produce(&sink_c->stream, mod->output_buffers[i].size);
 	}
 
 	mod->total_data_produced += mod->output_buffers[0].size;

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -73,6 +73,10 @@ struct comp_dev *module_adapter_new(const struct comp_driver *drv,
 	dst = &mod->priv.cfg;
 	mod->dev = dev;
 
+	/* by default we are single core unless otherwise stated */
+	mod->skip_sink_buffer_writeback = true;
+	mod->skip_src_buffer_invalidate = true;
+
 	comp_set_drvdata(dev, mod);
 	list_init(&mod->sink_buffer_list);
 

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -638,22 +638,27 @@ module_single_sink_setup(struct comp_dev *dev,
 			 struct comp_buffer __sparse_cache **sinks_c)
 {
 	struct processing_module *mod = comp_get_drvdata(dev);
-	struct comp_copy_limits c;
 	struct list_item *blist;
 	uint32_t num_input_buffers;
+	uint32_t frames;
 	int i = 0;
 
 	list_for_item(blist, &dev->bsource_list) {
-		comp_get_copy_limits_frame_aligned(source_c[i], sinks_c[0], &c);
+		frames = audio_stream_avail_frames_aligned(&source_c[i]->stream,
+							   &sinks_c[0]->stream);
 
-		if (!mod->skip_src_buffer_invalidate)
-			buffer_stream_invalidate(source_c[i], c.frames * c.source_frame_bytes);
+		if (!mod->skip_src_buffer_invalidate) {
+			uint32_t source_frame_bytes;
+
+			source_frame_bytes = audio_stream_frame_bytes(&source_c[i]->stream);
+			buffer_stream_invalidate(source_c[i], frames * source_frame_bytes);
+		}
 
 		/*
 		 * note that the size is in number of frames not the number of
 		 * bytes
 		 */
-		mod->input_buffers[i].size = c.frames;
+		mod->input_buffers[i].size = frames;
 		mod->input_buffers[i].consumed = 0;
 
 		mod->input_buffers[i].data = &source_c[i]->stream;
@@ -674,7 +679,6 @@ module_single_source_setup(struct comp_dev *dev,
 			   struct comp_buffer __sparse_cache **sinks_c)
 {
 	struct processing_module *mod = comp_get_drvdata(dev);
-	struct comp_copy_limits c;
 	struct list_item *blist;
 	uint32_t min_frames = UINT32_MAX;
 	uint32_t num_output_buffers;
@@ -685,11 +689,13 @@ module_single_source_setup(struct comp_dev *dev,
 		min_frames = audio_stream_get_avail_frames(&source_c[0]->stream);
 		source_frame_bytes = audio_stream_frame_bytes(&source_c[0]->stream);
 	} else {
+		uint32_t frames;
 		list_for_item(blist, &dev->bsink_list) {
-			comp_get_copy_limits_frame_aligned(source_c[0], sinks_c[i], &c);
+			frames = audio_stream_avail_frames_aligned(&source_c[0]->stream,
+								   &sinks_c[1]->stream);
 
-			min_frames = MIN(min_frames, c.frames);
-			source_frame_bytes = c.source_frame_bytes;
+			min_frames = MIN(min_frames, frames);
+			source_frame_bytes =  audio_stream_frame_bytes(&source_c[0]->stream);
 
 			mod->output_buffers[i].size = 0;
 			mod->output_buffers[i].data = &sinks_c[i]->stream;


### PR DESCRIPTION
Simple copy does not need full buffer info for every iteration. Only calculate what we need.