### PR TITLE
Improve logs on xruns

### DIFF
--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -1597,6 +1597,13 @@ int dai_zephyr_copy(struct dai_data *dd, struct comp_dev *dev, pcm_converter_fun
 		samples = MIN(samples, src_samples);
 	}
 
+	/* return if nothing to copy */
+	if (!samples) {
+		comp_warn(dev, "dai_zephyr_copy(): nothing to copy");
+		dma_reload(dd->chan->dma->z_dev, dd->chan->index, 0, 0, 0);
+		return 0;
+	}
+
 	/* limit bytes per copy to one period for the whole pipeline
 	 * in order to avoid high load spike
 	 * if FAST_MODE is enabled, then one period limitation is omitted
@@ -1618,13 +1625,6 @@ int dai_zephyr_copy(struct dai_data *dd, struct comp_dev *dev, pcm_converter_fun
 		 copy_bytes + free_bytes < dd->period_bytes)
 		comp_warn(dev, "dai_zephyr_copy(): Copy_bytes %d + free bytes %d < period bytes %d, possible glitch",
 			  copy_bytes, free_bytes, dd->period_bytes);
-
-	/* return if nothing to copy */
-	if (!copy_bytes) {
-		comp_warn(dev, "dai_zephyr_copy(): nothing to copy");
-		dma_reload(dd->chan->dma->z_dev, dd->chan->index, 0, 0, 0);
-		return 0;
-	}
 
 	/* trigger optional DAI_TRIGGER_COPY which prepares dai to copy */
 	ret = dai_trigger(dd->dai->dev, dev->direction, DAI_TRIGGER_COPY);

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -1599,7 +1599,7 @@ int dai_zephyr_copy(struct dai_data *dd, struct comp_dev *dev, pcm_converter_fun
 
 	/* return if nothing to copy */
 	if (!samples) {
-		comp_warn(dev, "dai_zephyr_copy(): nothing to copy");
+		comp_warn(dev, "dai_zephyr_copy(): nothing to copy, dd->total_data_processed %llu", dd->total_data_processed);
 		dma_reload(dd->chan->dma->z_dev, dd->chan->index, 0, 0, 0);
 		return 0;
 	}

--- a/src/audio/host-zephyr.c
+++ b/src/audio/host-zephyr.c
@@ -422,8 +422,8 @@ static uint32_t host_get_copy_bytes_normal(struct host_data *hd, struct comp_dev
 		dma_copy_bytes = MIN(hd->period_bytes, dma_copy_bytes);
 
 	if (!dma_copy_bytes)
-		comp_info(dev, "no bytes to copy, available samples: %d, free_samples: %d",
-			  avail_samples, free_samples);
+		comp_info(dev, "no bytes to copy, hd->total_data_processed %llu available samples: %d, free_samples: %d",
+			  hd->total_data_processed, avail_samples, free_samples);
 
 	buffer_release(buffer_c);
 


### PR DESCRIPTION
Add the 'total_data_processed' to the logs to get a better sense of when xruns happen with no space to copy to/from dma buffers, e.g.

````
[00:01:10.379,758] <inf> host_comp: host_get_copy_bytes_normal: comp:1 0x40002 no bytes to copy, hd->total_data_processed 0 available samples: 0, free_samples: 768
````
````
[00:01:10.446,761] <inf> host_comp: host_get_copy_bytes_normal: comp:1 0x40002 no bytes to copy, hd->total_data_processed 49664 available samples: 192, free_samples: 0
[00:01:10.447,761] <inf> host_comp: host_get_copy_bytes_normal: comp:1 0x40002 no bytes to copy, hd->total_data_processed 49664 available samples: 384, free_samples: 0
[00:01:10.448,756] <inf> host_comp: host_get_copy_bytes_normal: comp:1 0x40002 no bytes to copy, hd->total_data_processed 49664 available samples: 384, free_samples: 0
[00:01:10.449,756] <inf> host_comp: host_get_copy_bytes_normal: comp:1 0x40002 no bytes to copy, hd->total_data_processed 49664 available samples: 384, free_samples: 0
[00:01:10.450,756] <inf> host_comp: host_get_copy_bytes_normal: comp:1 0x40002 no bytes to copy, hd->total_data_processed 49664 available samples: 384, free_samples: 0
[00:01:10.451,756] <inf> host_comp: host_get_copy_bytes_normal: comp:1 0x40002 no bytes to copy, hd->total_data_processed 49664 available samples: 384, free_samples: 0
[00:01:10.452,843] <inf> host_comp: host_get_copy_bytes_normal: comp:1 0x40002 no bytes to copy, hd->total_data_processed 49664 available samples: 384, free_samples: 0
[00:01:10.453,756] <inf> host_comp: host_get_copy_bytes_normal: comp:1 0x40002 no bytes to copy, hd->total_data_processed 49664 available samples: 384, free_samples: 0
[00:01:10.453,788] <wrn> dai_comp: comp:0 0x40000 dai_zephyr_copy(): nothing to copy, dd->total_data_processed 55808
````

The first log is probably ok, this means the DMA has not started yet, but the second one shows the flows are broken with the DMA stuck for a while