### PR TITLE
versions.json: bump to 2.6.99

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -1,6 +1,7 @@
 {
   "SOF": {
     "MAJOR": "2",
-    "MINOR": "5"
+    "MINOR": "6",
+    "MICRO": "99"
   }
 }


### PR DESCRIPTION
Adopt Zephyr's (and others) .99 convention to indicate a development branch.