### PR TITLE
[stable-v2.2] intel: ssp: DMA request management and TX stop simplification

### DIFF
--- a/src/drivers/intel/ssp/ssp.c
+++ b/src/drivers/intel/ssp/ssp.c
@@ -835,18 +835,19 @@ static int ssp_set_config_blob(struct dai *dai, struct ipc_config_dai *common_co
 {
 	struct ipc4_ssp_configuration_blob *blob = spec_config;
 	struct ssp_pdata *ssp = dai_get_drvdata(dai);
-	uint32_t ssc0, sstsa, ssrsa;
+	uint32_t ssc0, sstsa, ssrsa, sscr1;
 
 	/* set config only once for playback or capture */
 	if (dai->sref > 1)
 		return 0;
 
 	ssc0 = blob->i2s_driver_config.i2s_config.ssc0;
-	sstsa = blob->i2s_driver_config.i2s_config.sstsa;
-	ssrsa = blob->i2s_driver_config.i2s_config.ssrsa;
+	sstsa =  SSTSA_GET(blob->i2s_driver_config.i2s_config.sstsa);
+	ssrsa = SSRSA_GET(blob->i2s_driver_config.i2s_config.ssrsa);
+	sscr1 = blob->i2s_driver_config.i2s_config.ssc1 & ~(SSCR1_RSRE | SSCR1_TSRE);
 
 	ssp_write(dai, SSCR0, ssc0);
-	ssp_write(dai, SSCR1, blob->i2s_driver_config.i2s_config.ssc1);
+	ssp_write(dai, SSCR1, sscr1);
 	ssp_write(dai, SSCR2, blob->i2s_driver_config.i2s_config.ssc2);
 	ssp_write(dai, SSCR3, blob->i2s_driver_config.i2s_config.ssc3);
 	ssp_write(dai, SSPSP, blob->i2s_driver_config.i2s_config.sspsp);
@@ -857,8 +858,7 @@ static int ssp_set_config_blob(struct dai *dai, struct ipc_config_dai *common_co
 	ssp_write(dai, SSRSA, ssrsa);
 
 	dai_info(dai, "ssp_set_config(), sscr0 = 0x%08x, sscr1 = 0x%08x, ssto = 0x%08x, sspsp = 0x%0x",
-		 ssc0, blob->i2s_driver_config.i2s_config.ssc1,
-		 blob->i2s_driver_config.i2s_config.sscto,
+		 ssc0, sscr1, blob->i2s_driver_config.i2s_config.sscto,
 		 blob->i2s_driver_config.i2s_config.sspsp);
 	dai_info(dai, "ssp_set_config(), sscr2 = 0x%08x, sspsp2 = 0x%08x, sscr3 = 0x%08x",
 		 blob->i2s_driver_config.i2s_config.ssc2, blob->i2s_driver_config.i2s_config.sspsp2,

--- a/src/drivers/intel/ssp/ssp.c
+++ b/src/drivers/intel/ssp/ssp.c
@@ -773,12 +773,6 @@ clk:
 			ssp->clk_active |= SSP_CLK_BCLK_ES_REQ;
 
 			if (enable_sse) {
-
-				/* enable TRSE/RSRE before SSE */
-				ssp_update_bits(dai, SSCR1,
-						SSCR1_TSRE | SSCR1_RSRE,
-						SSCR1_TSRE | SSCR1_RSRE);
-
 				/* enable port */
 				ssp_update_bits(dai, SSCR0, SSCR0_SSE, SSCR0_SSE);
 
@@ -802,11 +796,6 @@ clk:
 			dai_info(dai, "ssp_set_config(): hw_free stage: releasing BCLK clocks for SSP%d...",
 				 dai->index);
 			if (ssp->clk_active & SSP_CLK_BCLK_ACTIVE) {
-				/* clear TRSE/RSRE before SSE */
-				ssp_update_bits(dai, SSCR1,
-						SSCR1_TSRE | SSCR1_RSRE,
-						0);
-
 				ssp_update_bits(dai, SSCR0, SSCR0_SSE, 0);
 				dai_info(dai, "ssp_set_config(): SSE clear for SSP%d", dai->index);
 			}
@@ -885,9 +874,6 @@ static int ssp_set_config_blob(struct dai *dai, struct ipc_config_dai *common_co
 	mn_set_mclk_blob(blob->i2s_driver_config.mclk_config.mdivc,
 			 blob->i2s_driver_config.mclk_config.mdivr);
 	ssp->clk_active |= SSP_CLK_MCLK_ES_REQ;
-
-	/* enable TRSE/RSRE before SSE */
-	ssp_update_bits(dai, SSCR1, SSCR1_TSRE | SSCR1_RSRE, SSCR1_TSRE | SSCR1_RSRE);
 
 	/* enable port */
 	ssp_update_bits(dai, SSCR0, SSCR0_SSE, SSCR0_SSE);
@@ -1008,11 +994,6 @@ static void ssp_early_start(struct dai *dai, int direction)
 	ssp_pre_start(dai);
 
 	if (!(ssp->clk_active & SSP_CLK_BCLK_ES_REQ)) {
-		/* enable TRSE/RSRE before SSE */
-		ssp_update_bits(dai, SSCR1,
-				SSCR1_TSRE | SSCR1_RSRE,
-				SSCR1_TSRE | SSCR1_RSRE);
-
 		/* enable port */
 		ssp_update_bits(dai, SSCR0, SSCR0_SSE, SSCR0_SSE);
 		dai_info(dai, "ssp_early_start(): SSE set for SSP%d", dai->index);
@@ -1033,10 +1014,13 @@ static void ssp_start(struct dai *dai, int direction)
 	dai_info(dai, "ssp_start()");
 
 	/* enable DMA */
-	if (direction == DAI_DIR_PLAYBACK)
+	if (direction == DAI_DIR_PLAYBACK) {
+		ssp_update_bits(dai, SSCR1, SSCR1_TSRE, SSCR1_TSRE);
 		ssp_update_bits(dai, SSTSA, SSTSA_TXEN, SSTSA_TXEN);
-	else
+	} else {
+		ssp_update_bits(dai, SSCR1, SSCR1_RSRE, SSCR1_RSRE);
 		ssp_update_bits(dai, SSRSA, SSRSA_RXEN, SSRSA_RXEN);
+	}
 
 	ssp->state[direction] = COMP_STATE_ACTIVE;
 
@@ -1083,6 +1067,7 @@ static void ssp_stop(struct dai *dai, int direction)
 	if (direction == DAI_DIR_CAPTURE &&
 	    ssp->state[SOF_IPC_STREAM_CAPTURE] != COMP_STATE_PREPARE) {
 		ssp_update_bits(dai, SSRSA, SSRSA_RXEN, 0);
+		ssp_update_bits(dai, SSCR1, SSCR1_RSRE, 0);
 		ssp_empty_rx_fifo_on_stop(dai);
 		ssp->state[SOF_IPC_STREAM_CAPTURE] = COMP_STATE_PREPARE;
 		dai_info(dai, "ssp_stop(), RX stop");
@@ -1091,6 +1076,7 @@ static void ssp_stop(struct dai *dai, int direction)
 	/* stop Tx if needed */
 	if (direction == DAI_DIR_PLAYBACK &&
 	    ssp->state[SOF_IPC_STREAM_PLAYBACK] != COMP_STATE_PREPARE) {
+		ssp_update_bits(dai, SSCR1, SSCR1_TSRE, 0);
 		ssp_empty_tx_fifo(dai);
 		ssp_update_bits(dai, SSTSA, SSTSA_TXEN, 0);
 		ssp->state[SOF_IPC_STREAM_PLAYBACK] = COMP_STATE_PREPARE;
@@ -1099,16 +1085,10 @@ static void ssp_stop(struct dai *dai, int direction)
 
 	/* disable SSP port if no users */
 	if (ssp->state[SOF_IPC_STREAM_CAPTURE] == COMP_STATE_PREPARE &&
-	    ssp->state[SOF_IPC_STREAM_PLAYBACK] == COMP_STATE_PREPARE) {
-		if (!(ssp->clk_active & SSP_CLK_BCLK_ES_REQ)) {
-			/* clear TRSE/RSRE before SSE */
-			ssp_update_bits(dai, SSCR1,
-					SSCR1_TSRE | SSCR1_RSRE,
-					0);
-
-			ssp_update_bits(dai, SSCR0, SSCR0_SSE, 0);
-			dai_info(dai, "ssp_stop(): SSE clear SSP%d", dai->index);
-		}
+	    ssp->state[SOF_IPC_STREAM_PLAYBACK] == COMP_STATE_PREPARE &&
+	    !(ssp->clk_active & SSP_CLK_BCLK_ES_REQ)) {
+		ssp_update_bits(dai, SSCR0, SSCR0_SSE, 0);
+		dai_info(dai, "ssp_stop(): SSE clear for SSP%d", dai->index);
 	}
 
 	ssp_post_stop(dai);

--- a/src/drivers/intel/ssp/ssp.c
+++ b/src/drivers/intel/ssp/ssp.c
@@ -41,30 +41,37 @@ DECLARE_SOF_UUID("ssp-dai", ssp_uuid, 0x31458125, 0x95c4, 0x4085,
 
 DECLARE_TR_CTX(ssp_tr, SOF_UUID(ssp_uuid), LOG_LEVEL_INFO);
 
-/* empty SSP transmit FIFO */
-static void ssp_empty_tx_fifo(struct dai *dai)
+static void ssp_wait_tx_dma_idle(struct dai *dai)
 {
-	int ret;
-	uint32_t sssr;
+	struct ssp_pdata *ssp = dai_get_drvdata(dai);
+	uint64_t sample_ticks = clock_ticks_per_sample(PLATFORM_DEFAULT_CLOCK,
+						       ssp->params.fsync_rate);
+	uint32_t retry = SSP_RX_FLUSH_RETRY_MAX;
+	uint32_t entries[2];
 
-	/*
-	 * SSSR_TNF is cleared when TX FIFO is empty or full,
-	 * so wait for set TNF then for TFL zero - order matter.
-	 */
-	ret = poll_for_register_delay(dai_base(dai) + SSSR, SSSR_TNF, SSSR_TNF,
-				      SSP_MAX_SEND_TIME_PER_SAMPLE);
-	ret |= poll_for_register_delay(dai_base(dai) + SSCR3, SSCR3_TFL_MASK, 0,
-				       SSP_MAX_SEND_TIME_PER_SAMPLE *
-				       (SSP_FIFO_DEPTH - 1) / 2);
+	entries[0] = SSCR3_TFL_VAL(ssp_read(dai, SSCR3));
 
-	if (ret)
-		dai_warn(dai, "ssp_empty_tx_fifo() warning: timeout");
+	/* Unlikely: the TX FIFO is empty */
+	if (!entries[0] && (ssp_read(dai, SSSR) & SSSR_TNF))
+		return;
 
-	sssr = ssp_read(dai, SSSR);
+	while (retry--) {
+		/* Wait one sample time */
+		wait_delay(sample_ticks);
 
-	/* clear interrupt */
-	if (sssr & SSSR_TUR)
-		ssp_write(dai, SSSR, sssr);
+		entries[1] = SSCR3_TFL_VAL(ssp_read(dai, SSCR3));
+
+		/*
+		 * If the TX FIFO has less entries or equal entries after one
+		 * sample time then DMA is not running to fill the FIFO and we
+		 * can break out from the loop
+		 */
+		if (entries[0] >= entries[1])
+			break;
+	}
+
+	/* Just in case clear the underflow status */
+	ssp_update_bits(dai, SSSR, SSSR_TUR, SSSR_TUR);
 }
 
 static void ssp_empty_rx_fifo_on_start(struct dai *dai)
@@ -1032,6 +1039,7 @@ static void ssp_start(struct dai *dai, int direction)
 
 	/* enable DMA */
 	if (direction == DAI_DIR_PLAYBACK) {
+		ssp_update_bits(dai, SSSR, SSSR_TUR, SSSR_TUR);
 		ssp_update_bits(dai, SSCR1, SSCR1_TSRE, SSCR1_TSRE);
 		ssp_update_bits(dai, SSTSA, SSTSA_TXEN, SSTSA_TXEN);
 	} else {
@@ -1094,7 +1102,7 @@ static void ssp_stop(struct dai *dai, int direction)
 	if (direction == DAI_DIR_PLAYBACK &&
 	    ssp->state[SOF_IPC_STREAM_PLAYBACK] != COMP_STATE_PREPARE) {
 		ssp_update_bits(dai, SSCR1, SSCR1_TSRE, 0);
-		ssp_empty_tx_fifo(dai);
+		ssp_wait_tx_dma_idle(dai);
 		ssp_update_bits(dai, SSTSA, SSTSA_TXEN, 0);
 		ssp->state[SOF_IPC_STREAM_PLAYBACK] = COMP_STATE_PREPARE;
 		dai_info(dai, "ssp_stop(), TX stop");

--- a/src/include/sof/drivers/ssp.h
+++ b/src/include/sof/drivers/ssp.h
@@ -228,11 +228,13 @@ extern const struct dai_driver ssp_driver;
 #define ssp_irq(ssp) \
 	ssp->plat_data.irq
 
-#define SSP_CLK_MCLK_ES_REQ	BIT(0)
-#define SSP_CLK_MCLK_ACTIVE	BIT(1)
-#define SSP_CLK_BCLK_ES_REQ	BIT(2)
-#define SSP_CLK_BCLK_ACTIVE	BIT(3)
+#define SSP_CLK_MCLK_IS_NEEDED	BIT(1)
+#define SSP_CLK_MCLK_ES_REQ	BIT(2)
+#define SSP_CLK_MCLK_ACTIVE	BIT(3)
 #define SSP_CLK_MCLK_AON_REQ	BIT(4)
+#define SSP_CLK_BCLK_IS_NEEDED	BIT(5)
+#define SSP_CLK_BCLK_ES_REQ	BIT(6)
+#define SSP_CLK_BCLK_ACTIVE	BIT(7)
 
 /* SSP private data */
 struct ssp_pdata {


### PR DESCRIPTION
Hi,

This PR contains two patches:

This first one (verified on product: #7732) changes how the DMA request is managed (or not managed currently):
instead of keeping both TX and RX DMA request active, only keep the one enabled which is in use.

The second one is an improved version of #7735 to make sure that the DMA is not running to fill the TX FIFO when we disable the SSP (in case of playback only stop).
#7735 has been verified on production, this change just makes it a bit safer.

Replaces #7732 and #7735
