### PR TITLE
module_adapter: optimize simple copy

### DIFF
--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -750,7 +750,7 @@ module_single_source_setup(struct comp_dev *dev,
 	struct list_item *blist;
 	uint32_t min_frames = UINT32_MAX;
 	uint32_t num_output_buffers;
-	uint32_t source_frame_bytes = 0;
+	uint32_t source_frame_bytes;
 	int i = 0;
 
 	source_frame_bytes = audio_stream_frame_bytes(&source_c[0]->stream);
@@ -840,8 +840,8 @@ static int module_adapter_audio_stream_type_copy(struct comp_dev *dev)
 		src_c = attr_container_of(mod->input_buffers[i].data,
 					  struct comp_buffer __sparse_cache,
 					  stream, __sparse_cache);
-
-		comp_update_buffer_consume(src_c, mod->input_buffers[i].consumed);
+		if (mod->input_buffers[i].consumed)
+			audio_stream_consume(&src_c->stream, mod->input_buffers[i].consumed);
 	}
 
 	/* compute data consumed based on pin 0 since it is processed with base config
@@ -868,7 +868,8 @@ static int module_adapter_audio_stream_type_copy(struct comp_dev *dev)
 
 		if (!mod->skip_sink_buffer_writeback)
 			buffer_stream_writeback(sink_c, mod->output_buffers[i].size);
-		comp_update_buffer_produce(sink_c, mod->output_buffers[i].size);
+		if (mod->output_buffers[i].size)
+			audio_stream_produce(&sink_c->stream, mod->output_buffers[i].size);
 	}
 
 	mod->total_data_produced += mod->output_buffers[0].size;


### PR DESCRIPTION
Simple copy does not need full buffer info for every iteration. Only calculate what we need.