### PR TITLE
copier: fix attenuation stream frames calculation

### DIFF
--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -439,7 +439,6 @@ static int do_conversion_copy(struct comp_dev *dev,
 			      struct comp_copy_limits *processed_data)
 {
 	int i;
-	int ret;
 
 	/* buffer params might be not yet configured by component on another pipeline */
 	if (!src->hw_params_configured || !sink->hw_params_configured)
@@ -454,12 +453,6 @@ static int do_conversion_copy(struct comp_dev *dev,
 
 	cd->converter[i](&src->stream, 0, &sink->stream, 0,
 			 processed_data->frames * audio_stream_get_channels(&sink->stream));
-
-	if (cd->attenuation) {
-		ret = apply_attenuation(dev, cd, sink, processed_data->frames);
-		if (ret < 0)
-			return ret;
-	}
 
 	buffer_stream_writeback(sink, processed_data->sink_bytes);
 	comp_update_buffer_produce(sink, processed_data->sink_bytes);


### PR DESCRIPTION
When calculating number of frames to be attenuated in HOST copier source stream frame bytes should be used instead of sink frame bytes.

E.g. in case of 24/24 bit to 24/32 bit PCM conversion using sink container size will reduce frames number by 1/4 which will lead to multiple glitches.

Also attenuation has to be applied in HOST copier in playback scenario only, thus remove from do_conversion_copy()