### PR TITLE
[NOT FOR MAIN] module_adapter: skip invalidate/writeback with single_core

### DIFF
--- a/src/audio/mixin_mixout/mixin_mixout.c
+++ b/src/audio/mixin_mixout/mixin_mixout.c
@@ -388,7 +388,9 @@ static int mixin_process(struct processing_module *mod,
 			source_c = attr_container_of(input_buffers[0].data,
 						     struct comp_buffer __sparse_cache,
 						     stream, __sparse_cache);
-			buffer_stream_invalidate(source_c, bytes_to_consume_from_source_buf);
+			if (mod->is_multi_core)
+				buffer_stream_invalidate(source_c,
+							 bytes_to_consume_from_source_buf);
 		}
 	} else {
 		/* if source does not produce any data -- do NOT block mixing but generate
@@ -459,7 +461,7 @@ static int mixin_process(struct processing_module *mod,
 		 */
 		writeback_size = audio_stream_period_bytes(&sink_c->stream,
 							   frames_to_copy + start_frame);
-		if (writeback_size > 0)
+		if (writeback_size > 0 && mod->is_multi_core)
 			buffer_stream_writeback(sink_c, writeback_size);
 		buffer_release(sink_c);
 

--- a/src/include/sof/audio/module_adapter/module/generic.h
+++ b/src/include/sof/audio/module_adapter/module/generic.h
@@ -208,6 +208,11 @@ struct processing_module {
 	 */
 	bool skip_src_buffer_invalidate;
 
+	/* flag to indicate if the module is connected to modules that are scheduled to run
+	 * on a core that's different from the module's core
+	 */
+	bool is_multi_core;
+
 	/* table containing the list of connected sources */
 	struct module_source_info *source_info;
 


### PR DESCRIPTION
Add a new flag, is_multi_core, and set it if a module to connected to another module on a different core.