### PR TITLE
Kconfig: don't fall back on CONFIG_TIGERLAKE

### DIFF
--- a/scripts/fuzz.sh
+++ b/scripts/fuzz.sh
@@ -67,13 +67,17 @@ main()
   : "${TEST_DURATION:=3}"
   : "${FUZZER_STDOUT:=/dev/stdout}" # bashism
 
-  west build -d build-fuzz -b native_posix "$SOF_TOP"/app/ -- \
-    -DCONFIG_ASSERT=y \
-    -DCONFIG_SYS_HEAP_BIG_ONLY=y \
-    -DCONFIG_ZEPHYR_NATIVE_DRIVERS=y \
-    -DCONFIG_ARCH_POSIX_LIBFUZZER=y \
-    -DCONFIG_ARCH_POSIX_FUZZ_TICKS=100 \
-    -DCONFIG_ASAN=y "$@"
+  # Move this to a new fuzz.conf overlay file if it grows bigger
+  local fuzz_configs=(
+    -DCONFIG_ASSERT=y
+    -DCONFIG_SYS_HEAP_BIG_ONLY=y
+    -DCONFIG_ZEPHYR_NATIVE_DRIVERS=y
+    -DCONFIG_ARCH_POSIX_LIBFUZZER=y
+    -DCONFIG_ARCH_POSIX_FUZZ_TICKS=100
+    -DCONFIG_ASAN=y
+  )
+
+  west build -d build-fuzz -b native_posix "$SOF_TOP"/app/ -- "${fuzz_configs[@]}" "$@"
 
   mkdir -p ./fuzz_corpus
 

--- a/scripts/fuzz.sh
+++ b/scripts/fuzz.sh
@@ -69,6 +69,7 @@ main()
 
   # Move this to a new fuzz.conf overlay file if it grows bigger
   local fuzz_configs=(
+    -DCONFIG_ZEPHYR_POSIX=y
     -DCONFIG_ASSERT=y
     -DCONFIG_SYS_HEAP_BIG_ONLY=y
     -DCONFIG_ZEPHYR_NATIVE_DRIVERS=y

--- a/src/arch/xtensa/CMakeLists.txt
+++ b/src/arch/xtensa/CMakeLists.txt
@@ -22,6 +22,8 @@ elseif(CONFIG_MT8188)
         set(platform_folder mt8188)
 elseif(CONFIG_MT8195)
 	set(platform_folder mt8195)
+else()
+	message(FATAL_ERROR "Platform not defined, check your Kconfiguration?")
 endif()
 
 set(fw_name ${CONFIG_RIMAGE_SIGNING_SCHEMA})

--- a/src/arch/xtensa/CMakeLists.txt
+++ b/src/arch/xtensa/CMakeLists.txt
@@ -12,6 +12,10 @@ elseif(CONFIG_IMX8M)
 	set(platform_folder imx8m)
 elseif(CONFIG_IMX8ULP)
 	set(platform_folder imx8ulp)
+elseif(CONFIG_RENOIR)
+	set(platform_folder amd/renoir)
+elseif(CONFIG_REMBRANDT)
+	set(platform_folder amd/rembrandt)
 elseif(CONFIG_MT8186)
         set(platform_folder mt8186)
 elseif(CONFIG_MT8188)
@@ -22,18 +26,11 @@ endif()
 
 set(fw_name ${CONFIG_RIMAGE_SIGNING_SCHEMA})
 
-set(platform_ld_script ${platform_folder}.x)
+# File name without directory
+get_filename_component(_plf_ld_script ${platform_folder} NAME)
+set(platform_ld_script ${_plf_ld_script}.x)
 set(platform_rom_ld_script rom.x)
 
-if(CONFIG_RENOIR)
-	set(platform_folder amd/renoir)
-	set(platform_ld_script renoir.x)
-endif()
-
-if(CONFIG_REMBRANDT)
-	set(platform_folder amd/rembrandt)
-	set(platform_ld_script rembrandt.x)
-endif()
 # includes
 
 # None of these should be included if Zephyr strict headers are used.

--- a/src/platform/Kconfig
+++ b/src/platform/Kconfig
@@ -5,7 +5,9 @@ menu "Platform"
 choice
 	prompt "Platform"
 	default ZEPHYR_POSIX if ARCH_POSIX
-	default TIGERLAKE
+	# It's not really 'optional' but no value is much less confusing
+	# than falling back on a totally random value.
+	optional
 
 config TIGERLAKE
 	bool "Build for Tigerlake"

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -363,6 +363,9 @@ zephyr_library_sources_ifdef(CONFIG_LIBRARY
 	${SOF_DRIVERS_PATH}/host/ipc.c
 )
 
+if(NOT DEFINED PLATFORM)
+	message(FATAL_ERROR "PLATFORM is not defined, check your Kconfiguration?")
+endif()
 zephyr_include_directories(${SOF_PLATFORM_PATH}/${PLATFORM}/include)
 
 # Mandatory Files used on all platforms.


### PR DESCRIPTION
There's really no reason to fall back on a default "platform" and pick up a bunch of other, totally random settings.

Now the following command fails immediately with a useful `platform not defined` error message instead of stopping with a cryptic `platform/trace/trace.h: No such file or directory` after successfully compiling half the .c files in a Frankenstein CONFIG_uration.

```
  west build -p --board mimx8mm_evk_a53 modules/audio/sof/app
```

More context in #7192.