### PR TITLE
Topology2: Remove usage of audio_format class

### DIFF
--- a/tools/topology/topology2/cavs-mixin-mixout-efx-hda.conf
+++ b/tools/topology/topology2/cavs-mixin-mixout-efx-hda.conf
@@ -95,12 +95,20 @@ Object.Pipeline {
 				stream_name	$HDA_ANALOG_DAI_NAME
 				node_type	$HDA_LINK_INPUT_CLASS
 				num_output_pins 1
-				Object.Base.audio_format.1 {
-					in_bit_depth		32
-					in_valid_bit_depth	32
-					out_bit_depth		32
-					out_valid_bit_depth	32
-				}
+				num_input_audio_formats 1
+				num_output_audio_formats 1
+				Object.Base.input_audio_format [
+					{
+						in_bit_depth		32
+						in_valid_bit_depth	32
+					}
+				]
+				Object.Base.output_audio_format [
+					{
+						out_bit_depth		32
+						out_valid_bit_depth	32
+					}
+				]
 			}
 		}
 	]

--- a/tools/topology/topology2/cavs-mixin-mixout-hda.conf
+++ b/tools/topology/topology2/cavs-mixin-mixout-hda.conf
@@ -84,12 +84,21 @@ Object.Pipeline {
 				copier_type	"HDA"
 				stream_name	$HDA_ANALOG_DAI_NAME
 				node_type	$HDA_LINK_INPUT_CLASS
-				Object.Base.audio_format.1 {
-					in_bit_depth		32
-					in_valid_bit_depth	32
-					out_bit_depth		32
-					out_valid_bit_depth	32
-				}
+				num_output_pins 1
+				num_input_audio_formats 1
+				num_output_audio_formats 1
+				Object.Base.input_audio_format [
+					{
+						in_bit_depth		32
+						in_valid_bit_depth	32
+					}
+				]
+				Object.Base.output_audio_format [
+					{
+						out_bit_depth		32
+						out_valid_bit_depth	32
+					}
+				]
 			}
 			Object.Widget.eqiir.1 {
 				Object.Control.bytes."1" {

--- a/tools/topology/topology2/cavs-src-mixin-mixout-hda.conf
+++ b/tools/topology/topology2/cavs-src-mixin-mixout-hda.conf
@@ -88,12 +88,20 @@ Object.Pipeline {
 				stream_name	$HDA_ANALOG_DAI_NAME
 				node_type	$HDA_LINK_INPUT_CLASS
 				num_output_pins 1
-				Object.Base.audio_format.1 {
-					in_bit_depth		32
-					in_valid_bit_depth	32
-					out_bit_depth		32
-					out_valid_bit_depth	32
-				}
+				num_input_audio_formats 1
+				num_output_audio_formats 1
+				Object.Base.input_audio_format [
+					{
+						in_bit_depth		32
+						in_valid_bit_depth	32
+					}
+				]
+				Object.Base.output_audio_format [
+					{
+						out_bit_depth		32
+						out_valid_bit_depth	32
+					}
+				]
 			}
 		}
 	]

--- a/tools/topology/topology2/platform/intel/hdmi-generic.conf
+++ b/tools/topology/topology2/platform/intel/hdmi-generic.conf
@@ -76,10 +76,14 @@ Object.Pipeline {
 				num_input_pins 1
 
 				# copier only supports 32-bit 48KHz 2ch
-				Object.Base.audio_format [
+				Object.Base.input_audio_format [
 					{
 						in_bit_depth		32
 						in_valid_bit_depth	32
+					}
+				]
+				Object.Base.output_audio_format [
+					{
 						out_bit_depth		32
 						out_valid_bit_depth	32
 					}
@@ -101,10 +105,14 @@ Object.Pipeline {
 				num_input_pins 1
 
 				# copier only supports 32-bit 48KHz 2ch
-				Object.Base.audio_format [
+				Object.Base.input_audio_format [
 					{
 						in_bit_depth		32
 						in_valid_bit_depth	32
+					}
+				]
+				Object.Base.output_audio_format [
+					{
 						out_bit_depth		32
 						out_valid_bit_depth	32
 					}
@@ -125,10 +133,14 @@ Object.Pipeline {
 				num_input_pins 1
 
 				# copier only supports 32-bit 48KHz 2ch
-				Object.Base.audio_format [
+				Object.Base.input_audio_format [
 					{
 						in_bit_depth		32
 						in_valid_bit_depth	32
+					}
+				]
+				Object.Base.output_audio_format [
+					{
 						out_bit_depth		32
 						out_valid_bit_depth	32
 					}
@@ -227,10 +239,14 @@ IncludeByKey.NUM_HDMIS {
 					num_input_pins 1
 
 					# copier only supports 32-bit 48KHz 2ch
-					Object.Base.audio_format [
+					Object.Base.input_audio_format [
 						{
 							in_bit_depth		32
 							in_valid_bit_depth	32
+						}
+					]
+					Object.Base.output_audio_format [
+						{
 							out_bit_depth		32
 							out_valid_bit_depth	32
 						}


### PR DESCRIPTION
First PR to remove it from HDA and HDMI definitions. This will be followed up with several others to do the same thing until the audio_format class is deprecated