### PR TITLE
mixin_out: optimize mixin and mixout module

### DIFF
--- a/src/audio/mixin_mixout/mixin_mixout.c
+++ b/src/audio/mixin_mixout/mixin_mixout.c
@@ -75,7 +75,6 @@ struct mixin_sink_config {
 /* mixin component private data */
 struct mixin_data {
 	normal_mix_func normal_mix_channel;
-	remap_mix_func remap_mix_channel;
 	mute_func mute_channel;
 	struct mixin_sink_config sink_config[MIXIN_MAX_SINKS];
 };
@@ -546,7 +545,6 @@ static int mixin_reset(struct processing_module *mod)
 	comp_dbg(dev, "mixin_reset()");
 
 	mixin_data->normal_mix_channel = NULL;
-	mixin_data->remap_mix_channel = NULL;
 	mixin_data->mute_channel = NULL;
 
 	return 0;
@@ -685,7 +683,6 @@ static int mixin_prepare(struct processing_module *mod)
 	case SOF_IPC_FRAME_S24_4LE:
 	case SOF_IPC_FRAME_S32_LE:
 		md->normal_mix_channel = normal_mix_get_processing_function(fmt);
-		md->remap_mix_channel = remap_mix_get_processing_function(fmt);
 		md->mute_channel = mute_mix_get_processing_function(fmt);
 		break;
 	default:
@@ -693,7 +690,7 @@ static int mixin_prepare(struct processing_module *mod)
 		return -EINVAL;
 	}
 
-	if (!md->normal_mix_channel || !md->remap_mix_channel || !md->mute_channel) {
+	if (!md->normal_mix_channel || !md->mute_channel) {
 		comp_err(dev, "have not found the suitable processing function");
 		return -EINVAL;
 	}

--- a/src/audio/mixin_mixout/mixin_mixout.c
+++ b/src/audio/mixin_mixout/mixin_mixout.c
@@ -433,6 +433,7 @@ static int mixout_process(struct processing_module *mod,
 	struct module_source_info __sparse_cache *mod_source_info;
 	struct comp_dev *dev = mod->dev;
 	struct mixout_data *md;
+	int active_index[MIXOUT_MAX_SOURCES];
 	uint32_t frames_to_produce = INT32_MAX;
 	uint32_t pending_frames;
 	uint32_t sink_bytes;
@@ -461,10 +462,10 @@ static int mixout_process(struct processing_module *mod,
 		source = unused_in_between_buf->source;
 
 		source_index = find_module_source_index(mod_source_info, source);
+		active_index[i] = source_index;
 		/* this shouldn't happen but skip even if it does and move to the next source */
 		if (source_index < 0)
 			continue;
-
 		pending_frames = md->pending_frames[source_index];
 
 		if (source->state == COMP_STATE_ACTIVE || pending_frames)
@@ -474,19 +475,11 @@ static int mixout_process(struct processing_module *mod,
 	if (frames_to_produce > 0 && frames_to_produce < INT32_MAX) {
 		for (i = 0; i < num_input_buffers; i++) {
 			const struct audio_stream __sparse_cache *source_stream;
-			struct comp_buffer __sparse_cache *unused_in_between_buf;
-			struct comp_dev *source;
 			int source_index;
 			uint32_t pending_frames;
 
 			source_stream = input_buffers[i].data;
-			unused_in_between_buf = attr_container_of(source_stream,
-								  struct comp_buffer __sparse_cache,
-								  stream, __sparse_cache);
-
-			source = unused_in_between_buf->source;
-
-			source_index = find_module_source_index(mod_source_info, source);
+			source_index = active_index[i];
 			if (source_index < 0)
 				continue;
 

--- a/src/audio/mixin_mixout/mixin_mixout_generic.c
+++ b/src/audio/mixin_mixout/mixin_mixout_generic.c
@@ -61,65 +61,6 @@ static void normal_mix_channel_s16(struct audio_stream __sparse_cache *sink, int
 	}
 }
 
-static void remap_mix_channel_s16(struct audio_stream __sparse_cache *sink,
-				  int32_t sink_channel_index,  int32_t sink_channel_count,
-				  int32_t start_frame, int32_t mixed_frames,
-				  const struct audio_stream __sparse_cache *source,
-				  int32_t source_channel_index, int32_t source_channel_count,
-				  int32_t frame_count, uint16_t gain)
-{
-	int16_t *dst, *src;
-	int32_t frames_to_mix, frames_to_copy, left_frames;
-	int32_t n, nmax, frames, i, samples;
-
-	/* audio_stream_wrap() is required and is done below in a loop */
-	dst = (int16_t *)audio_stream_get_wptr(sink) + start_frame * sink_channel_count +
-		sink_channel_index;
-	src = (int16_t *)audio_stream_get_rptr(source) + source_channel_index;
-
-	assert(mixed_frames >= start_frame);
-	frames_to_mix = mixed_frames - start_frame;
-	frames_to_mix = MIN(frames_to_mix, frame_count);
-	frames_to_copy = frame_count - frames_to_mix;
-
-	for (left_frames = frames_to_mix; left_frames > 0; left_frames -= frames) {
-		src = audio_stream_wrap(source, src);
-		dst = audio_stream_wrap(sink, dst);
-		/* calculate the remaining samples*/
-		nmax = audio_stream_samples_without_wrap_s16(source, src);
-		samples = left_frames * source_channel_count;
-		n = MIN(samples, nmax);
-		nmax = audio_stream_samples_without_wrap_s16(sink, dst);
-		n = MIN(n, nmax);
-		/* frames is the processed frame count in this loop*/
-		frames = 0;
-		for (i = 0; i < n; i += source_channel_count) {
-			*dst = sat_int16((int32_t)*dst +
-			       q_mults_16x16(*src, gain, IPC4_MIXIN_GAIN_SHIFT));
-			src += source_channel_count;
-			dst += sink_channel_count;
-			frames++;
-		}
-	}
-
-	for (left_frames = frames_to_copy; left_frames > 0; left_frames -= frames) {
-		src = audio_stream_wrap(source, src);
-		dst = audio_stream_wrap(sink, dst);
-		nmax = audio_stream_samples_without_wrap_s16(source, src);
-		samples = left_frames * source_channel_count;
-		n = MIN(samples, nmax);
-		nmax = audio_stream_samples_without_wrap_s16(sink, dst);
-		n = MIN(n, nmax);
-		frames = 0;
-		for (i = 0; i < n; i += source_channel_count) {
-			*dst = (int16_t)q_mults_16x16(*src, gain, IPC4_MIXIN_GAIN_SHIFT);
-			src += source_channel_count;
-			dst += sink_channel_count;
-			frames++;
-		}
-	}
-}
-
 static void mute_channel_s16(struct audio_stream __sparse_cache *stream, int32_t channel_index,
 			     int32_t start_frame, int32_t mixed_frames, int32_t frame_count)
 {
@@ -203,67 +144,6 @@ static void normal_mix_channel_s24(struct audio_stream __sparse_cache *sink, int
 	}
 }
 
-static void remap_mix_channel_s24(struct audio_stream __sparse_cache *sink,
-				  int32_t sink_channel_index,  int32_t sink_channel_count,
-				  int32_t start_frame, int32_t mixed_frames,
-				  const struct audio_stream __sparse_cache *source,
-				  int32_t source_channel_index, int32_t source_channel_count,
-				  int32_t frame_count, uint16_t gain)
-{
-	int32_t *dst, *src;
-	int32_t frames_to_mix, frames_to_copy, left_frames;
-	int32_t n, nmax, i, frames, samples;
-
-	/* audio_stream_wrap() is required and is done below in a loop */
-	dst = (int32_t *)audio_stream_get_wptr(sink) + start_frame * sink_channel_count +
-		sink_channel_index;
-	src = (int32_t *)audio_stream_get_rptr(source) + source_channel_index;
-
-	assert(mixed_frames >= start_frame);
-	frames_to_mix = mixed_frames - start_frame;
-	frames_to_mix = MIN(frames_to_mix, frame_count);
-	frames_to_copy = frame_count - frames_to_mix;
-
-	for (left_frames = frames_to_mix; left_frames > 0; left_frames -= frames) {
-		src = audio_stream_wrap(source, src);
-		dst = audio_stream_wrap(sink, dst);
-		/* calculate the remaining samples*/
-		nmax = audio_stream_samples_without_wrap_s24(source, src);
-		samples = left_frames * source_channel_count;
-		n = MIN(samples, nmax);
-		nmax = audio_stream_samples_without_wrap_s24(sink, dst);
-		n = MIN(n, nmax);
-		/* frames is the processed frame count in this loop*/
-		frames = 0;
-		for (i = 0; i < n; i += source_channel_count) {
-			*dst = sat_int24(sign_extend_s24(*dst) +
-					  (int32_t)q_mults_32x32(sign_extend_s24(*src),
-					  gain, IPC4_MIXIN_GAIN_SHIFT));
-			src += source_channel_count;
-			dst += sink_channel_count;
-			frames++;
-		}
-	}
-
-	for (left_frames = frames_to_copy; left_frames > 0; left_frames -= frames) {
-		src = audio_stream_wrap(source, src);
-		dst = audio_stream_wrap(sink, dst);
-		nmax = audio_stream_samples_without_wrap_s24(source, src);
-		samples = left_frames * source_channel_count;
-		n = MIN(samples, nmax);
-		nmax = audio_stream_samples_without_wrap_s24(sink, dst);
-		n = MIN(n, nmax);
-		frames = 0;
-		for (i = 0; i < n; i += source_channel_count) {
-			*dst = (int32_t)q_mults_32x32(sign_extend_s24(*src),
-							   gain, IPC4_MIXIN_GAIN_SHIFT);
-			src += source_channel_count;
-			dst += sink_channel_count;
-			frames++;
-		}
-	}
-}
-
 #endif	/* CONFIG_FORMAT_S24LE */
 
 #if CONFIG_FORMAT_S32LE
@@ -315,65 +195,6 @@ static void normal_mix_channel_s32(struct audio_stream __sparse_cache *sink, int
 	}
 }
 
-static void remap_mix_channel_s32(struct audio_stream __sparse_cache *sink,
-				  int32_t sink_channel_index,  int32_t sink_channel_count,
-				  int32_t start_frame, int32_t mixed_frames,
-				  const struct audio_stream __sparse_cache *source,
-				  int32_t source_channel_index, int32_t source_channel_count,
-				  int32_t frame_count, uint16_t gain)
-{
-	int32_t frames_to_mix, frames_to_copy, left_frames;
-	int32_t n, nmax, frames, i, samples;
-	int32_t *dst, *src;
-
-	/* audio_stream_wrap() is required and is done below in a loop */
-	dst = (int32_t *)audio_stream_get_wptr(sink) + start_frame * sink_channel_count +
-		sink_channel_index;
-	src = (int32_t *)audio_stream_get_rptr(source) + source_channel_index;
-
-	assert(mixed_frames >= start_frame);
-	frames_to_mix = mixed_frames - start_frame;
-	frames_to_mix = MIN(frames_to_mix, frame_count);
-	frames_to_copy = frame_count - frames_to_mix;
-
-	for (left_frames = frames_to_mix; left_frames > 0; left_frames -= frames) {
-		src = audio_stream_wrap(source, src);
-		dst = audio_stream_wrap(sink, dst);
-		/* calculate the remaining samples*/
-		nmax = audio_stream_samples_without_wrap_s32(source, src);
-		samples = left_frames * source_channel_count;
-		n = MIN(samples, nmax);
-		nmax = audio_stream_samples_without_wrap_s32(sink, dst);
-		n = MIN(n, nmax);
-		/* frames is the processed frame count in this loop*/
-		frames = 0;
-		for (i = 0; i < n; i += source_channel_count) {
-			*dst = sat_int32((int64_t)*dst +
-					  q_mults_32x32(*src, gain, IPC4_MIXIN_GAIN_SHIFT));
-			src += source_channel_count;
-			dst += sink_channel_count;
-			frames++;
-		}
-	}
-
-	for (left_frames = frames_to_copy; left_frames > 0; left_frames -= frames) {
-		src = audio_stream_wrap(source, src);
-		dst = audio_stream_wrap(sink, dst);
-		nmax = audio_stream_samples_without_wrap_s32(source, src);
-		samples = left_frames * source_channel_count;
-		n = MIN(samples, nmax);
-		nmax = audio_stream_samples_without_wrap_s32(sink, dst);
-		n = MIN(n, nmax);
-		frames = 0;
-		for (i = 0; i < n; i += source_channel_count) {
-			*dst = (int32_t)q_mults_32x32(*src, gain, IPC4_MIXIN_GAIN_SHIFT);
-			src += source_channel_count;
-			dst += sink_channel_count;
-			frames++;
-		}
-	}
-}
-
 #endif	/* CONFIG_FORMAT_S32LE */
 
 #if CONFIG_FORMAT_S32LE || CONFIG_FORMAT_S24LE
@@ -413,13 +234,13 @@ static void mute_channel_s32(struct audio_stream __sparse_cache *stream, int32_t
 
 const struct mix_func_map mix_func_map[] = {
 #if CONFIG_FORMAT_S16LE
-	{ SOF_IPC_FRAME_S16_LE, normal_mix_channel_s16, remap_mix_channel_s16, mute_channel_s16},
+	{ SOF_IPC_FRAME_S16_LE, normal_mix_channel_s16, mute_channel_s16},
 #endif
 #if CONFIG_FORMAT_S24LE
-	{ SOF_IPC_FRAME_S24_4LE, normal_mix_channel_s24, remap_mix_channel_s24, mute_channel_s32},
+	{ SOF_IPC_FRAME_S24_4LE, normal_mix_channel_s24, mute_channel_s32},
 #endif
 #if CONFIG_FORMAT_S32LE
-	{ SOF_IPC_FRAME_S32_LE, normal_mix_channel_s32, remap_mix_channel_s32, mute_channel_s32}
+	{ SOF_IPC_FRAME_S32_LE, normal_mix_channel_s32, mute_channel_s32}
 #endif
 };
 

--- a/src/audio/mixin_mixout/mixin_mixout_hifi3.c
+++ b/src/audio/mixin_mixout/mixin_mixout_hifi3.c
@@ -104,84 +104,6 @@ static void normal_mix_channel_s16(struct audio_stream __sparse_cache *sink, int
 	}
 }
 
-static void remap_mix_channel_s16(struct audio_stream __sparse_cache *sink,
-				  int32_t sink_channel_index,  int32_t sink_channel_count,
-				  int32_t start_frame, int32_t mixed_frames,
-				  const struct audio_stream __sparse_cache *source,
-				  int32_t source_channel_index, int32_t source_channel_count,
-				  int32_t frame_count, uint16_t gain)
-{
-	ae_int16 *dst, *src;
-	int frames_to_mix, frames_to_copy, left_frames;
-	int n, nmax, frames, i;
-	int inoff = source_channel_count * sizeof(ae_int16);
-	int outoff = sink_channel_count * sizeof(ae_int16);
-	ae_int16x4 in;
-	ae_int16x4 out;
-	ae_int16 *pgain = (ae_int16 *)&gain;
-	ae_int16x4 gain_v;
-	ae_int32x2 temp, out1;
-
-	dst = (ae_int16 *)audio_stream_get_wptr(sink) + start_frame * sink_channel_count +
-		sink_channel_index;
-	src = (ae_int16 *)audio_stream_get_rptr(source) + source_channel_index;
-	src = audio_stream_wrap(source, src);
-
-	assert(mixed_frames >= start_frame);
-	frames_to_mix = AE_MIN_32_signed(mixed_frames - start_frame, frame_count);
-	frames_to_copy = frame_count - frames_to_mix;
-
-	/* store gain to a AE_DR register gain_v*/
-	AE_L16_IP(gain_v, pgain, 0);
-
-	/* set source as circular buffer, hifi3 only have 1 circular buffer*/
-	AE_SETCBEGIN0(audio_stream_get_addr(source));
-	AE_SETCEND0(audio_stream_get_end_addr(source));
-
-	for (left_frames = frames_to_mix; left_frames > 0; left_frames -= frames) {
-		/* audio_stream_wrap() is required and is done below in a loop */
-		dst = audio_stream_wrap(sink, dst);
-
-		/* calculate the remaining samples of sink*/
-		nmax = audio_stream_samples_without_wrap_s16(sink, dst);
-		n = AE_MIN_32_signed(left_frames * sink_channel_count, nmax);
-
-		/* frames is the processed frame count in this loop*/
-		frames = 0;
-		for (i = 0; i < n; i += source_channel_count) {
-			AE_L16_XC(in, src, inoff);
-			AE_L16_XP(out, dst, 0);
-			/* Q1.15 * Q1.15 to Q2.30*/
-			temp = AE_MULF16SS_00(in, gain_v);
-			temp = AE_SRAI32R(temp, IPC4_MIXIN_GAIN_SHIFT + 1);
-			out1 = AE_SEXT32X2D16_10(out);
-			temp = AE_ADD32S(temp, out1);
-			temp = AE_SLAI32S(temp, 16);
-			out = AE_ROUND16X4F32SSYM(temp, temp);
-			AE_S16_0_XP(out, dst, outoff);
-			frames++;
-		}
-	}
-
-	for (left_frames = frames_to_copy; left_frames > 0; left_frames -= frames) {
-		dst = audio_stream_wrap(sink, dst);
-		nmax = audio_stream_samples_without_wrap_s16(sink, dst);
-		n = AE_MIN_32_signed(left_frames * sink_channel_count, nmax);
-		frames = 0;
-
-		for (i = 0; i < n; i += source_channel_count) {
-			AE_L16_XC(in, src, inoff);
-			AE_L16_XP(out, dst, 0);
-			temp = AE_MULF16SS_00(in, gain_v);
-			temp = AE_SRAI32R(temp, IPC4_MIXIN_GAIN_SHIFT + 1);
-			temp = AE_SLAI32S(temp, 16);
-			out = AE_ROUND16X4F32SSYM(temp, temp);
-			AE_S16_0_XP(out, dst, outoff);
-			frames++;
-		}
-	}
-}
-
 static void mute_channel_s16(struct audio_stream __sparse_cache *stream, int32_t channel_index,
 			     int32_t start_frame, int32_t mixed_frames, int32_t frame_count)
 {
@@ -299,87 +221,6 @@ static void normal_mix_channel_s24(struct audio_stream __sparse_cache *sink, int
 	}
 }
 
-static void remap_mix_channel_s24(struct audio_stream __sparse_cache *sink,
-				  int32_t sink_channel_index,  int32_t sink_channel_count,
-				  int32_t start_frame, int32_t mixed_frames,
-				  const struct audio_stream __sparse_cache *source,
-				  int32_t source_channel_index, int32_t source_channel_count,
-				  int32_t frame_count, uint16_t gain)
-{
-	int frames_to_mix, frames_to_copy, left_frames;
-	int n, nmax, i, frames;
-	int inoff = source_channel_count * sizeof(ae_int32);
-	int outoff = sink_channel_count * sizeof(ae_int32);
-	ae_int32x2 in;
-	ae_int32x2 out;
-	ae_int64 tmp;
-	ae_int16 *pgain = (ae_int16 *)&gain;
-	ae_int16x4 gain_v;
-	ae_int32 *dst, *src;
-
-	dst = (ae_int32 *)audio_stream_get_wptr(sink) + start_frame * sink_channel_count +
-		sink_channel_index;
-	src = (ae_int32 *)audio_stream_get_rptr(source) + source_channel_index;
-	src = audio_stream_wrap(source, src);
-	assert(mixed_frames >= start_frame);
-	frames_to_mix = AE_MIN_32_signed(mixed_frames - start_frame, frame_count);
-	frames_to_copy = frame_count - frames_to_mix;
-
-	/* store gain to a AE_DR register gain_v*/
-	AE_L16_IP(gain_v, pgain, 0);
-	/* set source as circular buffer, hifi3 only have 1 circular buffer*/
-	AE_SETCBEGIN0(audio_stream_get_addr(source));
-	AE_SETCEND0(audio_stream_get_end_addr(source));
-
-	for (left_frames = frames_to_mix; left_frames > 0; left_frames -= frames) {
-		dst = audio_stream_wrap(sink, dst);
-		/* calculate the remaining samples*/
-		nmax = audio_stream_samples_without_wrap_s24(sink, dst);
-		n = AE_MIN_32_signed(left_frames * sink_channel_count, nmax);
-		/* frames is the processed frame count in this loop*/
-		frames = 0;
-
-		for (i = 0; i < n; i += source_channel_count) {
-			AE_L32_XC(in, src, inoff);
-			/*shift the significant 8 bits to the left*/
-			in = AE_SLAI32(in, 8);
-			AE_L32_XP(out, dst, 0);
-			out = AE_SLAI32(out, 8);
-			out = AE_SRAI32(out, 8);
-			tmp = AE_MUL32X16_H0(in, gain_v);
-
-			/* shift should be IPC4_MIXIN_GAIN_SHIFT + 8(shift right for in)
-			 * - 16(to keep the valid LSB bits of ae_int64)
-			 */
-			in = AE_ROUND32F48SSYM(AE_SRAI64(tmp, IPC4_MIXIN_GAIN_SHIFT - 8));
-			out = AE_ADD32S(out, in);
-			out = AE_SLAI32S(out, 8);
-			out = AE_SRAI32(out, 8);
-			AE_S32_L_XP(out, dst, outoff);
-			frames++;
-		}
-	}
-
-	for (left_frames = frames_to_copy; left_frames > 0; left_frames -= frames) {
-		dst = audio_stream_wrap(sink, dst);
-		nmax = audio_stream_samples_without_wrap_s24(sink, dst);
-		n = AE_MIN_32_signed(left_frames * sink_channel_count, nmax);
-		frames = 0;
-
-		for (i = 0; i < n; i += source_channel_count) {
-			AE_L32_XC(in, src, inoff);
-			/*shift the significant bit to the left*/
-			in = AE_SLAI32(in, 8);
-			tmp = AE_MUL32X16_H0(in, gain_v);
-			out = AE_ROUND32F48SSYM(AE_SRAI64(tmp, IPC4_MIXIN_GAIN_SHIFT - 8));
-			out = AE_SLAI32S(out, 8);
-			out = AE_SRAI32(out, 8);
-			AE_S32_L_XP(out, dst, outoff);
-			frames++;
-		}
-	}
-}
-
 #endif	/* CONFIG_FORMAT_S24LE */
 
 #if CONFIG_FORMAT_S32LE
@@ -471,81 +312,6 @@ static void normal_mix_channel_s32(struct audio_stream __sparse_cache *sink, int
 	}
 }
 
-static void remap_mix_channel_s32(struct audio_stream __sparse_cache *sink,
-				  int32_t sink_channel_index,  int32_t sink_channel_count,
-				  int32_t start_frame, int32_t mixed_frames,
-				  const struct audio_stream __sparse_cache *source,
-				  int32_t source_channel_index, int32_t source_channel_count,
-				  int32_t frame_count, uint16_t gain)
-{
-	int inoff = source_channel_count * sizeof(ae_int32);
-	int outoff = sink_channel_count * sizeof(ae_int32);
-	ae_int32x2 in;
-	ae_int32x2 out;
-	ae_int64 tmp, tmp1;
-	ae_int16 *pgain = (ae_int16 *)&gain;
-	ae_int16x4 gain_v;
-	int32_t frames_to_mix, frames_to_copy, left_frames;
-	int32_t n, nmax, frames, i;
-	ae_int32 *dst, *src;
-
-	/* audio_stream_wrap() is required and is done below in a loop */
-	dst = (ae_int32 *)audio_stream_get_wptr(sink) + start_frame * sink_channel_count +
-		sink_channel_index;
-	src = (ae_int32 *)audio_stream_get_rptr(source) + source_channel_index;
-
-	assert(mixed_frames >= start_frame);
-	frames_to_mix = AE_MIN_32_signed(mixed_frames - start_frame, frame_count);
-	frames_to_copy = frame_count - frames_to_mix;
-	/* store gain to a AE_DR register gain_v*/
-	AE_L16_IP(gain_v, pgain, 0);
-	/* set source as circular buffer, hifi3 only have 1 circular buffer*/
-	AE_SETCBEGIN0(audio_stream_get_addr(source));
-	AE_SETCEND0(audio_stream_get_end_addr(source));
-	src = audio_stream_wrap(source, src);
-
-	for (left_frames = frames_to_mix; left_frames > 0; left_frames -= frames) {
-		dst = audio_stream_wrap(sink, dst);
-		nmax = audio_stream_samples_without_wrap_s32(sink, dst);
-		n = AE_MIN_32_signed(left_frames * sink_channel_count, nmax);
-		/* frames is the processed frame count in this loop*/
-		frames = 0;
-
-		for (i = 0; i < n; i += source_channel_count) {
-			AE_L32_XC(in, src, inoff);
-			AE_L32_XP(out, dst, 0);
-			tmp = AE_MUL32X16_H0(in, gain_v);
-
-			/* shift should be -(IPC4_MIXIN_GAIN_SHIFT
-			 * - 16(to keep the valid LSB bits of ae_int64))
-			 */
-			tmp = AE_SLAI64S(tmp, 16 - IPC4_MIXIN_GAIN_SHIFT);
-			tmp1 = AE_CVT48A32(out);
-			tmp = AE_ADD64S(tmp, tmp1);
-			out = AE_ROUND32F48SSYM(tmp);
-			AE_S32_L_XP(out, dst, outoff);
-			frames++;
-		}
-	}
-
-	for (left_frames = frames_to_copy; left_frames > 0; left_frames -= frames) {
-		dst = audio_stream_wrap(sink, dst);
-		nmax = audio_stream_samples_without_wrap_s32(sink, dst);
-		n = AE_MIN_32_signed(left_frames * sink_channel_count, nmax);
-		/* frames is the processed frame count in this loop*/
-		frames = 0;
-
-		for (i = 0; i < n; i += source_channel_count) {
-			AE_L32_XC(in, src, inoff);
-			tmp = AE_MUL32X16_H0(in, gain_v);
-			tmp = AE_SLAI64S(tmp, 16 - IPC4_MIXIN_GAIN_SHIFT);
-			out = AE_ROUND32F48SSYM(tmp);
-			AE_S32_L_XP(out, dst, outoff);
-			frames++;
-		}
-	}
-}
-
 #endif	/* CONFIG_FORMAT_S32LE */
 
 #if CONFIG_FORMAT_S32LE || CONFIG_FORMAT_S24LE
@@ -581,13 +347,13 @@ static void mute_channel_s32(struct audio_stream __sparse_cache *stream, int32_t
 
 const struct mix_func_map mix_func_map[] = {
 #if CONFIG_FORMAT_S16LE
-	{ SOF_IPC_FRAME_S16_LE, normal_mix_channel_s16, remap_mix_channel_s16, mute_channel_s16},
+	{ SOF_IPC_FRAME_S16_LE, normal_mix_channel_s16, mute_channel_s16},
 #endif
 #if CONFIG_FORMAT_S24LE
-	{ SOF_IPC_FRAME_S24_4LE, normal_mix_channel_s24, remap_mix_channel_s24, mute_channel_s32},
+	{ SOF_IPC_FRAME_S24_4LE, normal_mix_channel_s24, mute_channel_s32},
 #endif
 #if CONFIG_FORMAT_S32LE
-	{ SOF_IPC_FRAME_S32_LE, normal_mix_channel_s32, remap_mix_channel_s32, mute_channel_s32}
+	{ SOF_IPC_FRAME_S32_LE, normal_mix_channel_s32, mute_channel_s32}
 #endif
 };
 

--- a/src/include/ipc4/mixin_mixout.h
+++ b/src/include/ipc4/mixin_mixout.h
@@ -133,7 +133,6 @@ typedef void (*mute_func) (struct audio_stream __sparse_cache *stream, int32_t c
 struct mix_func_map {
 	uint16_t frame_fmt;				/* frame format */
 	normal_mix_func normal_func;	/* normal mode mixin_mixout processing function */
-	remap_mix_func remap_func;	/* remap mode mixin_mixout processing function */
 	mute_func mute_func;			/* mute processing function */
 };
 
@@ -151,23 +150,6 @@ static inline normal_mix_func normal_mix_get_processing_function(int fmt)
 	for (i = 0; i < mix_count; i++) {
 		if (fmt == mix_func_map[i].frame_fmt)
 			return mix_func_map[i].normal_func;
-	}
-
-	return NULL;
-}
-
-/**
- * \brief Retrievies normal mode mixer processing function.
- * \param[in] fmt  stream PCM frame format
- */
-static inline remap_mix_func remap_mix_get_processing_function(int fmt)
-{
-	int i;
-
-	/* map the remap mode mixin_mixout function for source and sink buffers */
-	for (i = 0; i < mix_count; i++) {
-		if (fmt == mix_func_map[i].frame_fmt)
-			return mix_func_map[i].remap_func;
 	}
 
 	return NULL;


### PR DESCRIPTION
1. remove remap feature and its code since it is only used in close source.
2. remove duplicated calculation by pre-store it into memory.